### PR TITLE
Fixed duplicate case compile error

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -258,7 +258,7 @@ void MainWindow::loginError(Response::ResponseCode r, QString reasonStr, quint32
 			QMessageBox::critical(this, tr("Error"), bannedStr);
 			break;
 		}
-		case Response::RespUserIsBanned:
+		case Response::RespUsernameInvalid:
 			QMessageBox::critical(this, tr("Error"), tr("Invalid username."));
 			break;
 		default:


### PR DESCRIPTION
I tried to compile Cockatrice and found the following error:

Cockatrice/cockatrice/src/window_main.cpp: In member function 'void MainWindow::loginError(Response::ResponseCode, QString, quint32)':
Cockatrice/cockatrice/src/window_main.cpp:261:3: error: duplicate case value
Cockatrice/cockatrice/src/window_main.cpp:249:3: error: previously used here

I looked at the source and I deduced from the "Invalid username" codeline and the file common/pb/response.proto that the second "case Response::RespUserIsBanned" should actually be a "case Response::RespUsernameInvalid" case.
If this is correct, please apply my fix.
