### PR TITLE
Various Markdown fixes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ The following flags can be passed to `cmake`:
 
 # Running
 
-`oracle` fetches card data
-
-`cockatrice` is the game client
-
+`oracle` fetches card data  
+`cockatrice` is the game client  
 `servatrice` is the server


### PR DESCRIPTION
There was some slightly improper Markdown formatting that caused subtle display issues like one unordered list actually being outputted as several, or like paragraph breaks being placed where line breaks were intended. So I fixed them!
