### PR TITLE
Fixed a cursor bug

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -331,7 +331,6 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 			if (!cardMenu->isEmpty())
 				cardMenu->exec(event->screenPos());
 	} else if ((event->button() == Qt::LeftButton) && !settingsCache->getDoubleClickToPlay()) {
-		setCursor(Qt::OpenHandCursor);
 		
 		bool hideCard = false;
 		if (zone->getIsView()) {
@@ -345,6 +344,7 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 			playCard(event->modifiers().testFlag(Qt::ShiftModifier));
 	}
 
+	setCursor(Qt::OpenHandCursor);
 	AbstractCardItem::mouseReleaseEvent(event);
 }
 


### PR DESCRIPTION
Click-holding on a card then immediately releasing now properly changes the
cursor from a closed hand back to an open hand
