### PR TITLE
Changed default server to woogerworks

### DIFF
--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -13,7 +13,7 @@ DlgConnect::DlgConnect(QWidget *parent)
 	settings.beginGroup("server");
 
 	hostLabel = new QLabel(tr("&Host:"));
-	hostEdit = new QLineEdit(settings.value("hostname", "play.cockatrice.de").toString());
+	hostEdit = new QLineEdit(settings.value("hostname", "cockatrice.woogerworks.com").toString());
 	hostLabel->setBuddy(hostEdit);
 
 	portLabel = new QLabel(tr("&Port:"));


### PR DESCRIPTION
As play.cockatrice.de is down, I set the default server to cockatrice.woogerworks.com where >700 players are online right now. Seems to be popular :-)
