### PR TITLE
Added setting to enable/disable notifications

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -431,6 +431,10 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
 {
 	QIcon deleteIcon(":/resources/icon_delete.svg");
 
+	notificationsEnabledCheckBox = new QCheckBox;
+	notificationsEnabledCheckBox->setChecked(settingsCache->getNotificationsEnabled());
+	connect(notificationsEnabledCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setNotificationsEnabled(int)));
+
 	doubleClickToPlayCheckBox = new QCheckBox;
 	doubleClickToPlayCheckBox->setChecked(settingsCache->getDoubleClickToPlay());
 	connect(doubleClickToPlayCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setDoubleClickToPlay(int)));
@@ -440,8 +444,9 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
 	connect(playToStackCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setPlayToStack(int)));
 	
 	QGridLayout *generalGrid = new QGridLayout;
-	generalGrid->addWidget(doubleClickToPlayCheckBox, 0, 0);
-	generalGrid->addWidget(playToStackCheckBox, 1, 0);
+	generalGrid->addWidget(notificationsEnabledCheckBox, 0, 0);
+	generalGrid->addWidget(doubleClickToPlayCheckBox, 1, 0);
+	generalGrid->addWidget(playToStackCheckBox, 2, 0);
 	
 	generalGroupBox = new QGroupBox;
 	generalGroupBox->setLayout(generalGrid);
@@ -489,6 +494,7 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
 void UserInterfaceSettingsPage::retranslateUi()
 {
 	generalGroupBox->setTitle(tr("General interface settings"));
+	notificationsEnabledCheckBox->setText(tr("Enable notifications in taskbar"));
 	doubleClickToPlayCheckBox->setText(tr("&Double-click cards to play them (instead of single-click)"));
 	playToStackCheckBox->setText(tr("&Play all nonlands onto the stack (not the battlefield) by default"));
 	animationGroupBox->setTitle(tr("Animation settings"));

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -81,6 +81,7 @@ private slots:
 signals:
 	void soundPathChanged();
 private:
+	QCheckBox *notificationsEnabledCheckBox;
 	QCheckBox *doubleClickToPlayCheckBox;
 	QCheckBox *playToStackCheckBox;
 	QCheckBox *tapAnimationCheckBox;

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -21,6 +21,7 @@ SettingsCache::SettingsCache()
 	
 	mainWindowGeometry = settings->value("interface/main_window_geometry").toByteArray();
 	picDownload = settings->value("personal/picturedownload", true).toBool();
+	notificationsEnabled = settings->value("interface/notificationsenabled", true).toBool();
 	doubleClickToPlay = settings->value("interface/doubleclicktoplay", true).toBool();
 	playToStack = settings->value("interface/playtostack", false).toBool();
 	cardInfoMinimized = settings->value("interface/cardinfominimized", 0).toInt();
@@ -122,6 +123,12 @@ void SettingsCache::setPicDownload(int _picDownload)
 	picDownload = _picDownload;
 	settings->setValue("personal/picturedownload", picDownload);
 	emit picDownloadChanged();
+}
+
+void SettingsCache::setNotificationsEnabled(int _notificationsEnabled)
+{
+	notificationsEnabled = _notificationsEnabled;
+	settings->setValue("interface/notificationsenabled", notificationsEnabled);
 }
 
 void SettingsCache::setDoubleClickToPlay(int _doubleClickToPlay)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -33,6 +33,7 @@ private:
 	QString deckPath, replaysPath, picsPath, cardDatabasePath, tokenDatabasePath;
 	QString handBgPath, stackBgPath, tableBgPath, playerBgPath, cardBackPicturePath;
 	bool picDownload;
+	bool notificationsEnabled;
 	bool doubleClickToPlay;
 	bool playToStack;
 	int cardInfoMinimized;
@@ -62,6 +63,7 @@ public:
 	QString getPlayerBgPath() const { return playerBgPath; }
 	QString getCardBackPicturePath() const { return cardBackPicturePath; }
 	bool getPicDownload() const { return picDownload; }
+	bool getNotificationsEnabled() const { return notificationsEnabled; }
 	bool getDoubleClickToPlay() const { return doubleClickToPlay; }
 	bool getPlayToStack() const { return playToStack; }
 	int  getCardInfoMinimized() const { return cardInfoMinimized; }
@@ -91,6 +93,7 @@ public slots:
 	void setPlayerBgPath(const QString &_playerBgPath);
 	void setCardBackPicturePath(const QString &_cardBackPicturePath);
 	void setPicDownload(int _picDownload);
+	void setNotificationsEnabled(int _notificationsEnabled);
 	void setDoubleClickToPlay(int _doubleClickToPlay);
 	void setPlayToStack(int _playToStack);
 	void setCardInfoMinimized(int _cardInfoMinimized);

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -12,6 +12,7 @@
 #include "tab_deck_editor.h"
 #include "pixmapgenerator.h"
 #include "userlist.h"
+#include "settingscache.h"
 #include <QDebug>
 #include <QPainter>
 
@@ -417,7 +418,7 @@ void TabSupervisor::tabUserEvent(bool globalEvent)
 		tab->setContentsChanged(true);
 		setTabIcon(indexOf(tab), *tabChangedIcon);
 	}
-	if (globalEvent)
+	if (globalEvent && settingsCache->getNotificationsEnabled())
 		QApplication::alert(this);
 }
 


### PR DESCRIPTION
When something happens, the taskbar icon lights up/the dock icon
bounces. This can be annoying, so here is a setting to disable that.
