### PR TITLE
Repeatly download text spoiler until a valid XML document is received

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -296,7 +296,8 @@ void OracleImporter::httpRequestFinished(int requestId, bool error)
 	buffer->seek(0);
 	buffer->close();
 	int cards = importTextSpoiler(set, buffer->data());
-	++setIndex;
+        if (cards > 0)
+            ++setIndex;
 	
 	if (setIndex == setsToDownload.size()) {
 		emit setIndexChanged(cards, setIndex, QString());


### PR DESCRIPTION
This is a workaround to prevent fails on importing set information in Oracle downloader. Sometimes the website give the downloader invalid XML documents so it fails to extract set information from those documents. I think it is OK to repeatedly download them until the downloader get the valid XML documents or we may need to use a better HTML parser there.
