### PR TITLE
Fixes #34

### DIFF
--- a/cockatrice/src/deck_loader.cpp
+++ b/cockatrice/src/deck_loader.cpp
@@ -4,7 +4,6 @@
 #include "decklist.h"
 
 const QStringList DeckLoader::fileNameFilters = QStringList()
-	<< QObject::tr("All files (*.*)")
 	<< QObject::tr("Cockatrice decks (*.cod)")
 	<< QObject::tr("Plain text decks (*.dec *.mwDeck)");
 
@@ -94,8 +93,8 @@ bool DeckLoader::saveToFile(const QString &fileName, FileFormat fmt)
 DeckLoader::FileFormat DeckLoader::getFormatFromNameFilter(const QString &selectedNameFilter)
 {
 	switch (fileNameFilters.indexOf(selectedNameFilter)) {
-		case 1: return CockatriceFormat;
-		case 2: return PlainTextFormat;
+		case 0: return CockatriceFormat;
+		case 1: return PlainTextFormat;
 	}
 	return PlainTextFormat;
 }


### PR DESCRIPTION
This issue is actually present in my stable version of Cockatrice. The
problem is that Cockatrice identifies the file type by the file type
dialog, which is one of "All files", "Cockatrice decks", or "Plain text
decks". However, it can't figure out what to do with "All files", since
by definition that oughtn't have a structure associated with it. When
using "all files" as the deck type, Cockatrice fails in the listed
manner.

Nothing broke in commit 67c4d08, but "all files" was moved to the top
(presumably cosmetically), so now people are hitting it accidentally.
To fix this, I just removed "all files". This is the right thing to do
because 1) people didn't seem to be having this issue before,
indicating nobody used "all files", so removing it won't affect
anybody, and 2) Cockatrice can't know what to do with the file anyway,
so there's no simple way to keep it.
