### PR TITLE
Linux pthread fix

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -48,6 +48,7 @@ INCLUDE_DIRECTORIES(${PROTOBUF_INCLUDE_DIR})
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 
 add_library(cockatrice_common ${common_SOURCES} ${common_HEADERS_MOC})
+# Without this check, Linux will put -pthread out of order in link.txt and build will fail
 if (UNIX)
     target_link_libraries(cockatrice_common cockatrice_protocol pthread)
 else (UNIX)


### PR DESCRIPTION
Fixes #41. I've checked this fix on both Linux (Ubuntu 13.10) and OS X. This fixes the Linux build and doesn't break the OS X build. I don't have a Windows box to test on but I don't see why it would break it.
