### PR TITLE
Add Tab shortcut for next phase

### DIFF
--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -532,7 +532,7 @@ void TabGame::retranslateUi()
     gameMenu->setTitle(tr("&Game"));
     if (aNextPhase) {
         aNextPhase->setText(tr("Next &phase"));
-        aNextPhase->setShortcut(tr("Ctrl+Space"));
+        aNextPhase->setShortcuts(QList<QKeySequence>() << QKeySequence(tr("Ctrl+Space")) << QKeySequence(tr("Tab")));
     }
     if (aNextTurn) {
         aNextTurn->setText(tr("Next &turn"));


### PR DESCRIPTION
The existing keyboard shortcut for moving to the next phase is Ctrl+Space. This becomes Cmd+Space on Macs. Unfortunately, Cmd+Space is the default shortcut for opening Spotlight. This means that there essentially is no next phase shortcut on a Mac unless the Spotlight shortcut is disabled, which I'm sure most people are unwilling to do.

This keeps Ctrl+Space but also adds Tab. I chose tab because it currently does nothing useful in Cockatrice. Hitting tab just switches between the "Show card only" dropdown, the chat window itself, and the "Say" box. This is just the default behavior.

I've been testing this and I really like tab as the shortcut since it's so quick and natural. However, if anyone sees a problem with this, we can always change it to something else. The important thing is that we have an alternative to Ctrl+Space.
