### PR TITLE
Fix #155: Vanguard card names no longer conflict with regular card names.

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -197,6 +197,11 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
             cardText = map.contains("text") ? map.value("text").toString() : QString("");
             cardId = map.contains("multiverseid") ? map.value("multiverseid").toInt() : 0;
             cardLoyalty = map.contains("loyalty") ? map.value("loyalty").toInt() : 0;
+
+            // Distinguish Vanguard cards from regular cards of the same name.
+            if (map.value("layout") == "vanguard") {
+                cardName += " Avatar";
+            }
         }
 
         CardInfo *card = addCard(set->getShortName(), cardName, false, cardId, cardCost, cardType, cardPT, cardLoyalty, cardText.split("\n"));


### PR DESCRIPTION
This would require a re-run of Oracle, of course.
