### PR TITLE
Fix regression #180

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -90,6 +90,7 @@ SET(cockatrice_SOURCES
     src/qt-json/json.cpp
     src/soundengine.cpp
     src/pending_command.cpp
+    src/lineinput.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/version_string.cpp
 )
 

--- a/cockatrice/src/lineinput.cpp
+++ b/cockatrice/src/lineinput.cpp
@@ -1,0 +1,29 @@
+#include <QKeyEvent>
+#include <QKeySequence>
+#include <QDebug>
+#include "lineinput.h"
+
+LineInput::LineInput(QWidget *parent)
+    : QLineEdit(parent)
+{
+}
+
+bool LineInput::eventFilter(QObject *obj, QEvent *event)
+{
+    // intercept keyborad events from chatView
+    if (event->type() == QEvent::KeyPress) {
+        QKeyEvent *keyEvent = (QKeyEvent*)event;
+
+        // ensure "copy" and "select all" shortcuts works on the chatView
+        if(!(keyEvent->key() == Qt::Key_Control) &&
+            !keyEvent->matches(QKeySequence::Copy) &&
+          !keyEvent->matches(QKeySequence::SelectAll))
+        {
+            setFocus();
+            keyPressEvent(keyEvent);
+            return true;
+        }
+    }
+
+    return QLineEdit::eventFilter(obj, event);
+}

--- a/cockatrice/src/lineinput.h
+++ b/cockatrice/src/lineinput.h
@@ -1,0 +1,16 @@
+#ifndef LINEINPUT_H
+#define LINEINPUT_H
+
+#include <QLineEdit>
+
+class QEvent;
+
+class LineInput : public QLineEdit {
+    Q_OBJECT
+public:
+    LineInput(QWidget *parent=0);
+protected:
+    bool eventFilter(QObject *obj, QEvent *event);
+};
+
+#endif

--- a/cockatrice/src/tab_message.cpp
+++ b/cockatrice/src/tab_message.cpp
@@ -1,4 +1,3 @@
-#include <QLineEdit>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QMenu>
@@ -6,6 +5,7 @@
 #include "tab_message.h"
 #include "abstractclient.h"
 #include "chatview.h"
+#include "lineinput.h"
 
 #include "pending_command.h"
 #include "pb/session_commands.pb.h"
@@ -18,7 +18,7 @@ TabMessage::TabMessage(TabSupervisor *_tabSupervisor, AbstractClient *_client, c
     chatView = new ChatView(tabSupervisor, 0, true);
     connect(chatView, SIGNAL(showCardInfoPopup(QPoint, QString)), this, SLOT(showCardInfoPopup(QPoint, QString)));
     connect(chatView, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));
-    sayEdit = new QLineEdit;
+    sayEdit = new LineInput;
     connect(sayEdit, SIGNAL(returnPressed()), this, SLOT(sendMessage()));
     
     QVBoxLayout *vbox = new QVBoxLayout;
@@ -36,7 +36,7 @@ TabMessage::TabMessage(TabSupervisor *_tabSupervisor, AbstractClient *_client, c
     setLayout(vbox);
     
     setFocusProxy(sayEdit);
-    chatView->setFocusProxy(sayEdit);
+    chatView->installEventFilter(sayEdit);
     sayEdit->setFocus();
 }
 

--- a/cockatrice/src/tab_message.h
+++ b/cockatrice/src/tab_message.h
@@ -5,7 +5,7 @@
 
 class AbstractClient;
 class ChatView;
-class QLineEdit;
+class LineInput;
 class Event_UserMessage;
 class Response;
 class ServerInfo_User;
@@ -20,7 +20,7 @@ private:
     bool userOnline;
     
     ChatView *chatView;
-    QLineEdit *sayEdit;
+    LineInput *sayEdit;
 
     QAction *aLeave;
 signals:

--- a/cockatrice/src/tab_room.cpp
+++ b/cockatrice/src/tab_room.cpp
@@ -1,4 +1,3 @@
-#include <QLineEdit>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QMenu>
@@ -16,6 +15,7 @@
 #include "userlist.h"
 #include "abstractclient.h"
 #include "chatview.h"
+#include "lineinput.h"
 #include "gameselector.h"
 #include "settingscache.h"
 
@@ -46,7 +46,7 @@ TabRoom::TabRoom(TabSupervisor *_tabSupervisor, AbstractClient *_client, ServerI
     connect(chatView, SIGNAL(showCardInfoPopup(QPoint, QString)), this, SLOT(showCardInfoPopup(QPoint, QString)));
     connect(chatView, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));
     sayLabel = new QLabel;
-    sayEdit = new QLineEdit;
+    sayEdit = new LineInput;
     sayLabel->setBuddy(sayEdit);
     connect(sayEdit, SIGNAL(returnPressed()), this, SLOT(sendMessage()));
     
@@ -100,7 +100,7 @@ TabRoom::TabRoom(TabSupervisor *_tabSupervisor, AbstractClient *_client, ServerI
         gameSelector->processGameInfo(info.game_list(i));
 
     setFocusProxy(sayEdit);
-    chatView->setFocusProxy(sayEdit);
+    chatView->installEventFilter(sayEdit);
     QTimer::singleShot(0, sayEdit, SLOT(setFocus()));
 }
 

--- a/cockatrice/src/tab_room.h
+++ b/cockatrice/src/tab_room.h
@@ -10,7 +10,7 @@ class AbstractClient;
 class UserList;
 class QLabel;
 class ChatView;
-class QLineEdit;
+class LineInput;
 class QPushButton;
 class QTextTable;
 class RoomEvent;
@@ -38,7 +38,7 @@ private:
     UserList *userList;
     ChatView *chatView;
     QLabel *sayLabel;
-    QLineEdit *sayEdit;
+    LineInput *sayEdit;
     QGroupBox *chatGroupBox;
     
     QMenu *roomMenu;


### PR DESCRIPTION
This is a different approach at solving #113 that fixes the problem introduced by #151 and reported in  #180.
Instead of blindly grabbing the focus from the chatView, we filter its events and steal keyboard events when convenient. The context menu and shortcut keys (copy/select all) works on the chatView.
