### PR TITLE
Added better support for custom card images

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -129,7 +129,7 @@ void PictureLoader::processLoadQueue()
         QString setName = ptl.getSetName();
 
         QImage image;
-        if (!image.load(QString("%1/%2/%3.full.jpg").arg(picsPath).arg("CUSTOM").arg(correctedName)))
+        if (!image.load(QString("%1/%2/%3.full.jpg").arg(picsPath).arg("CUSTOM").arg(correctedName))) {
             if (!image.load(QString("%1/%2/%3.full.jpg").arg(picsPath).arg(setName).arg(correctedName)))
                 //if (!image.load(QString("%1/%2/%3%4.full.jpg").arg(picsPath).arg(setName).arg(correctedName).arg(1)))
                     if (!image.load(QString("%1/%2/%3/%4.full.jpg").arg(picsPath).arg("downloadedPics").arg(setName).arg(correctedName))) {
@@ -143,8 +143,8 @@ void PictureLoader::processLoadQueue()
                             else
                                 emit imageLoaded(ptl.getCard(), QImage());
                         }
-                        continue;
                     }
+        }
 
         emit imageLoaded(ptl.getCard(), image);
     }


### PR DESCRIPTION
This improvement greatly simplifies the use of custom JPEGs instead of the default card images. Benefits include:

1) All custom art can be placed in a single folder, without having to figure out which set it would normally belong to (normally more bothersome for cards in multiple sets as user-defined set priorities also play a role).
2) Allows players to easily share custom JPEGs since they all go into a single, predefined folder whose location is independent of the player-dependent set priorities.

Added an additional check prior to the previous order-of-priority when determining which JPEG file to use for a card.

New order-of-priority:
1) Pictures path/CUSTOM/Card name.full.jpg
2) Pictures path/Set code/Card name.full.jpg
3) Pictures path/downloadedPics/Set code/Card name.full.jpg
4) Download JPEG and place in Pictures path/downloadedPics/Set code/Card name.full.jpg

If a card appears in multiple sets, the highest priority set (a user-defined ranking) is used.

Prior order-of-priority:
1) Pictures path/Set code/Card name.full.jpg
2) Pictures path/downloadedPics/Set code/Card name.full.jpg
3) Download JPEG and place in Pictures path/downloadedPics/Set code/Card name.full.jpg

The old line 133 (new line 134) was commented out as it did not seem to serve any purpose (JPEGS are not named as such).
