### PR TITLE
Æ now actually works with the case-insensitive tags.

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -437,6 +437,11 @@ int CardInfo::getPreferredMuId()
 QString CardInfo::simplifyName(const QString &name) {
     QString simpleName(name);
 
+    // So Aetherling would work, but not Ætherling since 'Æ' would get replaced
+    // with nothing.
+    simpleName.replace("æ", "ae");
+    simpleName.replace("Æ", "AE");
+
     // Replace Jötun Grunt with Jotun Grunt.
     simpleName = simpleName.normalized(QString::NormalizationForm_KD);
 


### PR DESCRIPTION
So previously `[[Aetherling]]` would work but not `[[Ætherling]]` because the 'Æ' would be stripped out, but this fixes that. Although it's probably unlikely that people will type `[[Ætherling]]`.
