### PR TITLE
Fix #225: Multiples of cards are now sent to deckstats.

### DIFF
--- a/cockatrice/src/deckstats_interface.cpp
+++ b/cockatrice/src/deckstats_interface.cpp
@@ -88,7 +88,11 @@ struct CopyIfNotAToken {
         const DecklistCardNode *card
     ) const {
         if (!cardDatabase.getCard(card->getName())->getIsToken()) {
-            destination.addCard(card->getName(), node->getName());
+            DecklistCardNode *addedCard = destination.addCard(
+                card->getName(),
+                node->getName()
+            );
+            addedCard->setNumber(card->getNumber());
         }
     }
 };


### PR DESCRIPTION
Sorry! I didn't copy enough information when filtering the cards based on whether or not they're tokens. The name and number are the only relevant fields in `DecklistCardNode`, so all of it should be copied now.

In action:

![screen shot 2014-07-23 at 3 20 49 pm](https://cloud.githubusercontent.com/assets/454057/3678867/c12ccee8-129e-11e4-8e4e-29ec66f8187f.png)

![screen shot 2014-07-23 at 3 20 57 pm](https://cloud.githubusercontent.com/assets/454057/3678869/c2faff06-129e-11e4-93e7-74721cfaa8be.png)

Thanks for the heads up @ZeldaZach, you're a great QA tester :heart:.
