### PR TITLE
Fix issue mentioned in #152: price updater loads all cards now.

### DIFF
--- a/cockatrice/src/priceupdater.cpp
+++ b/cockatrice/src/priceupdater.cpp
@@ -136,6 +136,11 @@ void DBPriceUpdater::updatePrices()
         for(int j = 0; j < sets.size(); ++j)
         {
             muid=card->getMuId(sets[j]->getShortName());
+
+            if (!muid) {
+                continue;
+            }
+
             //qDebug() << "muid " << muid << " card: " << cards[i] << endl;
             if(bNotFirst)
             {


### PR DESCRIPTION
This seems to have fixed some issues on my system. @ZeldaZach Can you try this version and see if it fixes your issues as well?

Before:

![broken](https://cloud.githubusercontent.com/assets/454057/3696412/18777140-138e-11e4-93f3-4ba313df5a43.png)

After:

![fixed](https://cloud.githubusercontent.com/assets/454057/3696414/1d57cc96-138e-11e4-866e-a8ecf07e4a5c.png)
