### PR TITLE
Fix #110: Price column is removed when the setting is disabled.

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -646,6 +646,7 @@ void TabDeckEditor::actDecrement()
 void TabDeckEditor::setPriceTagFeatureEnabled(int enabled)
 {
     aUpdatePrices->setVisible(enabled);
+    deckModel->pricesUpdated();
 }
 
 void TabDeckEditor::actUpdatePrices()


### PR DESCRIPTION
Enable deck pricing and get the prices for a deck.

![begin](https://cloud.githubusercontent.com/assets/454057/3712702/dca5c262-152b-11e4-9f6d-400d70458714.png)

Disable deck pricing. Under the old version, the last column would remain:

![broken](https://cloud.githubusercontent.com/assets/454057/3712703/e966e152-152b-11e4-87ea-3df3e0f065bd.png)

Now it doesn't:

![fixed](https://cloud.githubusercontent.com/assets/454057/3712704/ee83e75c-152b-11e4-8f25-731c46b8d2e7.png)
