### PR TITLE
Oracle cards.xml path

### DIFF
--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -412,17 +412,17 @@ bool SaveSetsPage::validatePage()
     do {
         QString fileName;
         if (savePath.isEmpty()) {
-            if (!defaultPathCheckBox->isChecked())
-                fileName = QFileDialog::getSaveFileName(this, windowName, dataDir + "/cards.xml", fileType);
+            if (defaultPathCheckBox->isChecked())
+                fileName = dataDir + "/cards.xml";
             else
-                fileName = dataDir + "/cards.xml";;
+                fileName = QFileDialog::getSaveFileName(this, windowName, dataDir + "/cards.xml", fileType);
             settings->setValue("paths/carddatabase", fileName);
         }
         else {
-            if (!defaultPathCheckBox->isChecked())
-                fileName = QFileDialog::getSaveFileName(this, windowName, savePath, fileType);
-            else
+            if (defaultPathCheckBox->isChecked())
                 fileName = savePath;
+            else
+                fileName = QFileDialog::getSaveFileName(this, windowName, savePath, fileType);
         }
         if (fileName.isEmpty()) {
             return false;


### PR DESCRIPTION
Fixes #240 
Before:
If default is checked, Oracle will always save to the AppData path.
Now:
If a path to cards.xml is set, Oracle will update that cards.xml.
If Oracle is run before a path to cards.xml is set, if default is checked, cards.xml will be saved on the AppData path. Furthermore, this path will be set as the cards.xml path for both Oracle and Cockatrice.
If Oracle is run before a path to cards.xml is set, if default is NOT checked, cards.xml will be saved at the selected path and this path will be set as the cards.xml path for both Oracle and Cockatrice.
If a path to cards.xml is set, if default is NOT checked, cards.xml will be saved at the selected path but this path will NOT be set as the cards.xml path for either Oracle or Cockatrice. This allows people who already have a cards.xml (which may be customized), to still obtain clean copies of cards.xml through Oracle without overwriting their own
