### PR TITLE
Fix #248: the token dialog generates cards irrespective of their case and punctuation

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -959,6 +959,10 @@ void Player::actCreateToken()
         return;
     
     lastTokenName = dlg.getName();
+    if (CardInfo *correctedCard = db->getCardBySimpleName(lastTokenName, false)) {
+        lastTokenName = correctedCard->getName();
+    }
+
     lastTokenColor = dlg.getColor();
     lastTokenPT = dlg.getPT();
     lastTokenAnnotation = dlg.getAnnotation();


### PR DESCRIPTION
So now `Emrakul, the Aeons Torn` and `emrakul the aeons torn` both work.
