### PR TITLE
Fix compilation warning introduced in #246

### DIFF
--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -30,6 +30,7 @@
 #include <QIcon>
 #include <QDir>
 #include <QDesktopServices>
+#include <QDebug>
 
 #include "main.h"
 #include "window_main.h"
@@ -159,7 +160,7 @@ int main(int argc, char *argv[])
         settingsCache->setPicsPath(dataDir + "/pics");
     }
     if (!QDir().mkpath(settingsCache->getPicsPath() + "/CUSTOM"))
-        qDebug("Could not create " + settingsCache->getPicsPath().toUtf8() + "/CUSTOM. Will fall back on default card images.");
+        qDebug() << "Could not create " + settingsCache->getPicsPath().toUtf8() + "/CUSTOM. Will fall back on default card images.";
         
 #ifdef Q_OS_MAC
     if(settingsCache->getHandBgPath().isEmpty() &&


### PR DESCRIPTION
QDebug include was missing in main.cpp, and the qDebug() call was using a concatenation of variables for the format string, causing a warning:

```
/cockatrice/src/main.cpp:162:16: warning: format string is not a string
literal (potentially insecure) [-Wformat-security]
        qDebug("Could not create " +
settingsCache->getPicsPath().toUtf8() + "/CUSTOM. Will fall back on
default card images.");
```
