### PR TITLE
Handle PNGs (and other image formats)

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -132,11 +132,12 @@ void PictureLoader::processLoadQueue()
                                                     << _picsPath + "/downloadedPics/" + ptl.getSetName() + "/" + ptl.getCard()->getCorrectedName() + ".full";
 
         QImage image;
+        QImageReader imgReader;
+        imgReader.setDecideFormatFromContent(true);
         bool found = false;
-        
+
         //Iterates through the list of paths, searching for images with the desired name with any QImageReader-supported extension
         for (int i = 0; i < picsPaths.length() && !found; i ++) {
-            QImageReader imgReader;
             imgReader.setFileName(picsPaths.at(i));
             if (imgReader.read(&image)) {
                 emit imageLoaded(ptl.getCard(), image);


### PR DESCRIPTION
Fixes #249.
Before:
Would download image file and save with .jpg extension regardless of actual format of the downloaded image.
Would attempt to load each image as a JPG, including PNGs saved with .jpg extensions, which would cause the load to fail, and Cockatrice to redownload the image.
Fix:
Checks the most significant bytes of the downloaded image file (contains a signature identifying the format) to determine the format and saves the image with the appropriate extension (defaults to .jpg).
Attempts to load each image first as a JPG, then as a PNG ("card name".full.png is now supported).
Can easily add support for more image formats by adding additional format checks for when downloading/saving the image and additional if statements at loading.

P.S.: To be honest, we may not even require checking in picsPath/setName/ (i.e.:

if (!image.load(QString("%1/%2/%3.full.jpg").arg(picsPath).arg(setName).arg(correctedName)))
    if (!image.load(QString("%1/%2/%3.full.png").arg(picsPath).arg(setName).arg(correctedName)))

) since people using custom images can place those images in the CUSTOM folder whereas people using the default images will have all of those images in picsPath/downloadedPics/setName/ instead. I mention this here since it would reduce the number of additional if statements we'd need to add for each additional image format from 3 to 2.
