### PR TITLE
Fix #258: Dashes to spaces.

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -477,6 +477,10 @@ QString CardInfo::simplifyName(const QString &name) {
     // Replace Jötun Grunt with Jotun Grunt.
     simpleName = simpleName.normalized(QString::NormalizationForm_KD);
 
+    // Replace dashes with spaces so that we can say "garruk the veil cursed"
+    // instead of the unintuitive "garruk the veilcursed".
+    simpleName = simpleName.replace("-", " ");
+
     simpleName.remove(QRegExp("[^a-zA-Z0-9 ]"));
     simpleName = simpleName.toLower();
     return simpleName;


### PR DESCRIPTION
So my initial thought was to just remove all the spaces from the name, since that wouldn't cause anything to conflict, but since our tokens are distinguished only by having extra spaces, that turned out to be a bad idea. Also I'm bad at git and `--force` everything.

The current behavior is that `garruk the veil cursed` works but `garruk the veilcursed` doesn't, which seems fine to me.
