### PR TITLE
Fix #259

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -236,6 +236,8 @@ void PictureLoader::startNextPicDownload()
     QString picUrl = getPicUrl(cardBeingDownloaded.getCard());
     if (picUrl.isEmpty()) {
         qDebug() << "No url for" << cardBeingDownloaded.getCard()->getName();
+        cardBeingDownloaded = 0;
+        downloadRunning = false;
         return;
     }
 


### PR DESCRIPTION
I just cherry-picked the relevant commits from @Daenyth 's better-picurl-error-handling branch to avoid downloading the picture for a card if we're missing the relevant info. 
