### PR TITLE
Support images without .full suffix

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -76,8 +76,8 @@ void SetList::sortByKey()
     qSort(begin(), end(), CompareFunctor());
 }
 
-PictureToLoad::PictureToLoad(CardInfo *_card, bool _stripped, bool _hq)
-    : card(_card), stripped(_stripped), setIndex(0), hq(_hq)
+PictureToLoad::PictureToLoad(CardInfo *_card, bool _hq)
+    : card(_card), setIndex(0), hq(_hq)
 {
     if (card) {
         sortedSets = card->getSets();
@@ -308,11 +308,11 @@ void PictureLoader::picDownloadFinished(QNetworkReply *reply)
     startNextPicDownload();
 }
 
-void PictureLoader::loadImage(CardInfo *card, bool stripped)
+void PictureLoader::loadImage(CardInfo *card)
 {
     QMutexLocker locker(&mutex);
 
-    loadQueue.append(PictureToLoad(card, stripped));
+    loadQueue.append(PictureToLoad(card));
     emit startLoadQueue();
 }
 
@@ -938,7 +938,7 @@ void CardDatabase::cacheCardPixmaps(const QStringList &cardNames)
 
 void CardDatabase::loadImage(CardInfo *card)
 {
-    pictureLoader->loadImage(card, false);
+    pictureLoader->loadImage(card);
 }
 
 void CardDatabase::imageLoaded(CardInfo *card, QImage image)

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -47,14 +47,12 @@ public:
 class PictureToLoad {
 private:
     CardInfo *card;
-    bool stripped;
     SetList sortedSets;
     int setIndex;
     bool hq;
 public:
-    PictureToLoad(CardInfo *_card = 0, bool _stripped = false, bool _hq = true);
+    PictureToLoad(CardInfo *_card = 0, bool _hq = true);
     CardInfo *getCard() const { return card; }
-    bool getStripped() const { return stripped; }
     QString getSetName() const;
     bool nextSet();
     bool getHq() const { return hq; }
@@ -79,7 +77,7 @@ public:
     void setPicsPath(const QString &path);
     void setPicDownload(bool _picDownload);
     void setPicDownloadHq(bool _picDownloadHq);
-    void loadImage(CardInfo *card, bool stripped);
+    void loadImage(CardInfo *card);
 private slots:
     void picDownloadFinished(QNetworkReply *reply);
 public slots:


### PR DESCRIPTION
Fixes #276
Still need to know what you guys want to do regarding existing .full handling in the code base. There are still classes and functions that store/take bool stripped (a variable used for determining whether or not to append the .full suffix), for example, that no longer need to process the variable since this PR now stores images as "card name"."file extension" without a ".full" suffix independently of bool stripped.
