### PR TITLE
Fixed Oracle save bug

### DIFF
--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -433,6 +433,8 @@ bool SaveSetsPage::validatePage()
             QMessageBox::information(this, tr("Success"), tr("The card database has been saved successfully."));
         } else {
             QMessageBox::critical(this, tr("Error"), tr("The file could not be saved to the desired location."));
+            if (defaultPathCheckBox->isChecked())
+                defaultPathCheckBox->setChecked(false);
         }
     } while (!ok);
 


### PR DESCRIPTION
Fixes #284
Fixed a bug that caused Oracle to be stuck in an infinite loop if the default path checkbox was checked but failed to write.
