### PR TITLE
Tokens use PT levels from cards.xml if available

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1092,13 +1092,12 @@ void Player::eventCreateToken(const Event_CreateToken &event)
         return;
 
     CardItem *card = new CardItem(this, QString::fromStdString(event.card_name()), event.card_id());
-    card->setColor(QString::fromStdString(event.color()));
-	
-	// use db p/t if not provided in event
-    if (QString::fromStdString(event.pt()).isEmpty())
-		card->setPT(db->getCard(QString::fromStdString(event.card_name()))->getPowTough());
-	else
+    // use db PT if not provided in event
+    if (!QString::fromStdString(event.pt()).isEmpty())
         card->setPT(QString::fromStdString(event.pt()));
+    else
+        card->setPT(db->getCard(QString::fromStdString(event.card_name()))->getPowTough());
+    card->setColor(QString::fromStdString(event.color()));
     card->setAnnotation(QString::fromStdString(event.annotation()));
     card->setDestroyOnZoneChange(event.destroy_on_zone_change());
 


### PR DESCRIPTION
I added a check to see if the event PT is empty, if it is, we try and
use the PT from the cards.xml. In resp to issue #330.
