### PR TITLE
Fix #408

### DIFF
--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -56,7 +56,12 @@ void DlgCreateGame::sharedCtor()
     onlyBuddiesCheckBox = new QCheckBox(tr("Only &buddies can join"));
     onlyRegisteredCheckBox = new QCheckBox(tr("Only &registered users can join"));
     if (room && room->getUserInfo()->user_level() & ServerInfo_User::IsRegistered)
+    {
         onlyRegisteredCheckBox->setChecked(true);
+    } else {
+        onlyBuddiesCheckBox->setEnabled(false);
+        onlyRegisteredCheckBox->setEnabled(false);        
+    }
     
     QGridLayout *joinRestrictionsLayout = new QGridLayout;
     joinRestrictionsLayout->addWidget(passwordLabel, 0, 0);


### PR DESCRIPTION
Gray out "only buddies/only reg users" in the “create game” dialog if
the user is unregistered
