### PR TITLE
Add fallback urls for cards without a muId set

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -224,16 +224,18 @@ QString PictureLoader::getPicUrl()
             return picUrl;
     }
 
-    // otherwise, fallback to the default url
-    picUrl = picDownloadHq ? settingsCache->getPicUrlHq() : settingsCache->getPicUrl();
-    picUrl.replace("!name!", QUrl::toPercentEncoding(card->getCorrectedName()));
+    // if a card has a muid, use the default url; if not, use the fallback
+    int muid = set ? muid = card->getMuId(set->getShortName()) : 0;
+    if(muid)
+        picUrl = picDownloadHq ? settingsCache->getPicUrlHq() : settingsCache->getPicUrl();
+    else
+        picUrl = picDownloadHq ? settingsCache->getPicUrlHqFallback() : settingsCache->getPicUrlFallback();
 
+    picUrl.replace("!name!", QUrl::toPercentEncoding(card->getCorrectedName()));
+    picUrl.replace("!cardid!", QUrl::toPercentEncoding(QString::number(muid)));
     if (set) {
         picUrl.replace("!setcode!", QUrl::toPercentEncoding(set->getShortName()));
         picUrl.replace("!setname!", QUrl::toPercentEncoding(set->getLongName()));
-        int muid = card->getMuId(set->getShortName());
-        if (muid)
-            picUrl.replace("!cardid!", QUrl::toPercentEncoding(QString::number(muid)));
     }
 
     if (picUrl.contains("!name!") ||

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -25,6 +25,8 @@ SettingsCache::SettingsCache()
     picDownloadHq = settings->value("personal/picturedownloadhq", false).toBool();
     picUrl = settings->value("personal/picUrl", PIC_URL_DEFAULT).toString();
     picUrlHq = settings->value("personal/picUrlHq", PIC_URL_HQ_DEFAULT).toString();
+    picUrlFallback = settings->value("personal/picUrlFallback", PIC_URL_FALLBACK).toString();
+    picUrlHqFallback = settings->value("personal/picUrlHqFallback", PIC_URL_HQ_FALLBACK).toString();
 
     mainWindowGeometry = settings->value("interface/main_window_geometry").toByteArray();
     notificationsEnabled = settings->value("interface/notificationsenabled", true).toBool();
@@ -151,6 +153,18 @@ void SettingsCache::setPicUrlHq(const QString &_picUrlHq)
 {
     picUrlHq = _picUrlHq;
     settings->setValue("personal/picUrlHq", picUrlHq);
+}
+
+void SettingsCache::setPicUrlFallback(const QString &_picUrlFallback)
+{
+    picUrlFallback = _picUrlFallback;
+    settings->setValue("personal/picUrlFallback", picUrlFallback);
+}
+
+void SettingsCache::setPicUrlHqFallback(const QString &_picUrlHqFallback)
+{
+    picUrlHqFallback = _picUrlHqFallback;
+    settings->setValue("personal/picUrlHqFallback", picUrlHqFallback);
 }
 
 void SettingsCache::setNotificationsEnabled(int _notificationsEnabled)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -4,7 +4,9 @@
 #include <QObject>
 
 #define PIC_URL_DEFAULT "http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!cardid!&type=card"
+#define PIC_URL_FALLBACK "http://mtgimage.com/set/!setcode!/!name!.jpg"
 #define PIC_URL_HQ_DEFAULT "http://mtgimage.com/multiverseid/!cardid!.jpg"
+#define PIC_URL_HQ_FALLBACK "http://mtgimage.com/set/!setcode!/!name!.jpg"
 
 class QSettings;
 
@@ -57,6 +59,8 @@ private:
     bool ignoreUnregisteredUsers;
     QString picUrl;
     QString picUrlHq;
+    QString picUrlFallback;
+    QString picUrlHqFallback;
     bool attemptAutoConnect;
 public:
     SettingsCache();
@@ -93,6 +97,8 @@ public:
     bool getIgnoreUnregisteredUsers() const { return ignoreUnregisteredUsers; }
     QString getPicUrl() const { return picUrl; }
     QString getPicUrlHq() const { return picUrlHq; }
+    QString getPicUrlFallback() const { return picUrlFallback; }
+    QString getPicUrlHqFallback() const { return picUrlHqFallback; }
     void copyPath(const QString &src, const QString &dst);
     bool getAutoConnect() const { return attemptAutoConnect; }
 public slots:
@@ -129,6 +135,8 @@ public slots:
     void setIgnoreUnregisteredUsers(bool _ignoreUnregisteredUsers);
     void setPicUrl(const QString &_picUrl);
     void setPicUrlHq(const QString &_picUrlHq);
+    void setPicUrlFallback(const QString &_picUrlFallback);
+    void setPicUrlHqFallback(const QString &_picUrlHqFallback);
     void setAutoConnect(const bool &_autoConnect);
 };
 


### PR DESCRIPTION
This is still a proposal that could need discussion.
A lot of cards have no multiverse id, so we are not able to download these card's pictures. This results in pictures of the same card from other sets being displayed, or no picture at all.
This commit adds a fallback url using set+name instead of muid to retrieve the card image, used automatically on crds with muid=0.
I only know a good HQ source for the pictures using set+name; any idea on a low-quality source?
