### PR TITLE
Don't remove card images from revealed decks

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -493,7 +493,6 @@ void Player::playerListActionTriggered()
     
     if (menu == mRevealLibrary) {
         cmd.set_zone_name("deck");
-        cmd.set_grant_write_access(true);
     } else if (menu == mRevealTopCard) {
         cmd.set_zone_name("deck");
         cmd.set_card_id(0);


### PR DESCRIPTION
Revealed library had write access, which meant that the user would see cards being removed from the zone as the other player drew cards. The cards were not the actual ones drawn, just the ones at the same index, so no information was leaked.

Fix #297
