### PR TITLE
Cards Scale with mouse over action

### DIFF
--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -190,6 +190,8 @@ void AbstractCardItem::setHovered(bool _hovered)
         processHoverEvent();
     isHovered = _hovered;
     setZValue(_hovered ? 2000000004 : realZValue);
+    setScale(_hovered ? 1.1 : 1);
+    setTransformOriginPoint(_hovered ? CARD_WIDTH / 2 : 0, _hovered ? CARD_HEIGHT / 2 : 0);
     update();
 }
 


### PR DESCRIPTION
Cards now scale up by 10% when mouse over.

Preview: http://imgur.com/a/sE39Y
Webm: http://webmup.com/wFXdg/
