### PR TITLE
Double click room fix

### DIFF
--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -77,7 +77,6 @@ GameSelector::GameSelector(AbstractClient *_client, const TabSupervisor *_tabSup
 
     connect(joinButton, SIGNAL(clicked()), this, SLOT(actJoin()));
     connect(spectateButton, SIGNAL(clicked()), this, SLOT(actJoin()));
-    connect(gameListView, SIGNAL(doubleClicked(const QModelIndex &)), this, SLOT(actJoin()));
     connect(gameListView, SIGNAL(activated(const QModelIndex &)), this, SLOT(actJoin()));
 }
 

--- a/cockatrice/src/tab_server.cpp
+++ b/cockatrice/src/tab_server.cpp
@@ -52,7 +52,6 @@ RoomSelector::RoomSelector(AbstractClient *_client, QWidget *parent)
     setLayout(vbox);
     
     connect(client, SIGNAL(listRoomsEventReceived(const Event_ListRooms &)), this, SLOT(processListRoomsEvent(const Event_ListRooms &)));
-    connect(roomList, SIGNAL(doubleClicked(const QModelIndex &)), this, SLOT(joinClicked()));
     connect(roomList, SIGNAL(activated(const QModelIndex &)), this, SLOT(joinClicked()));
     client->sendCommand(client->prepareSessionCommand(Command_ListRooms()));
 }


### PR DESCRIPTION
doubleclick is not needed. Both ENTER and double click will activate the item.
Having both means both were being called when double clicking. Fix for #460 
