### PR TITLE
Added underline to links in chat

### DIFF
--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -77,6 +77,8 @@ void ChatView::appendUrlTag(QTextCursor &cursor, QString url)
     anchorFormat.setForeground(Qt::blue);
     anchorFormat.setAnchor(true);
     anchorFormat.setAnchorHref(url);
+    anchorFormat.setUnderlineColor(Qt::blue);
+    anchorFormat.setFontUnderline(true);
     
     cursor.setCharFormat(anchorFormat);
     cursor.insertText(url);


### PR DESCRIPTION
[REVIEW]
Links now have a blue underline to better indicate they are clickable.

Preview: http://imgur.com/gQZEv4I
