### PR TITLE
How Many Cards

### DIFF
--- a/cockatrice/src/deckview.cpp
+++ b/cockatrice/src/deckview.cpp
@@ -180,9 +180,11 @@ void DeckViewCardContainer::paint(QPainter *painter, const QStyleOptionGraphicsI
         qreal thisRowHeight = CARD_HEIGHT * currentRowsAndCols[i].first;
         QRectF textRect(0, yUntilNow, totalTextWidth, thisRowHeight);
         yUntilNow += thisRowHeight + paddingY;
-        
+
+        QString displayString = QString("%1\n(%2)").arg(cardTypeList[i]).arg(cardsByType.count(cardTypeList[i]));
+
         painter->setPen(Qt::white);
-        painter->drawText(textRect, Qt::AlignHCenter | Qt::AlignVCenter | Qt::TextSingleLine, cardTypeList[i]);
+        painter->drawText(textRect, Qt::AlignHCenter | Qt::AlignVCenter, displayString);
     }
 }
 


### PR DESCRIPTION
This PR addresses #482 and adds a way to see how many of each card of each type there is.

Example (Blurry b/c retina screen and QT doesn't have support yet):
![http://grab.by/CTHo](http://grab.by/CTHo)
