### PR TITLE
Pixmap memory, 2nd attempt

### DIFF
--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -90,15 +90,11 @@ void AbstractCardItem::paintPicture(QPainter *painter, const QSizeF &translatedS
     qreal scaleFactor = translatedSize.width() / boundingRect().width();
     
     CardInfo *imageSource = facedown ? db->getCard() : info;
-    QPixmap *translatedPixmap = imageSource->getPixmap(translatedSize.toSize());
+    QPixmap translatedPixmap;
+    imageSource->getPixmap(translatedSize.toSize(), translatedPixmap);
     painter->save();
     QColor bgColor = Qt::transparent;
-    if (translatedPixmap) {
-        painter->save();
-        transformPainter(painter, translatedSize, angle);
-        painter->drawPixmap(QPointF(0, 0), *translatedPixmap);
-        painter->restore();
-    } else {
+    if (translatedPixmap.isNull()) {
         QString colorStr;
         if (!color.isEmpty())
             colorStr = color;
@@ -121,6 +117,11 @@ void AbstractCardItem::paintPicture(QPainter *painter, const QSizeF &translatedS
             bgColor = QColor(250, 190, 30);
         else
             bgColor = QColor(230, 230, 230);
+    } else {
+        painter->save();
+        transformPainter(painter, translatedSize, angle);
+        painter->drawPixmap(QPointF(0, 0), translatedPixmap);
+        painter->restore();
     }
     painter->setBrush(bgColor);
     QPen pen(Qt::black);
@@ -128,7 +129,7 @@ void AbstractCardItem::paintPicture(QPainter *painter, const QSizeF &translatedS
     painter->setPen(pen);
     painter->drawRect(QRectF(1, 1, CARD_WIDTH - 2, CARD_HEIGHT - 2));
     
-    if (!translatedPixmap || settingsCache->getDisplayCardNames() || facedown) {
+    if (translatedPixmap.isNull() || settingsCache->getDisplayCardNames() || facedown) {
         painter->save();
         transformPainter(painter, translatedSize, angle);
         painter->setPen(Qt::white);

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -12,6 +12,7 @@
 #include <QThread>
 #include <QMutex>
 #include <QWaitCondition>
+#include <QPixmapCache>
 
 class CardDatabase;
 class CardInfo;
@@ -119,8 +120,7 @@ private:
     MuidMap muIds;
     bool cipt;
     int tableRow;
-    QPixmap *pixmap;
-    QMap<int, QPixmap *> scaledPixmapCache;
+    QString pixmapCacheKey;
 public:
     CardInfo(CardDatabase *_db,
         const QString &_name = QString(),
@@ -165,8 +165,8 @@ public:
     void setCustomPicURLHq(const QString &_set, const QString &_customPicURL) { customPicURLsHq.insert(_set, _customPicURL); }
     void setMuId(const QString &_set, const int &_muId) { muIds.insert(_set, _muId); }
     void addToSet(CardSet *set);
-    QPixmap *loadPixmap();
-    QPixmap *getPixmap(QSize size);
+    void loadPixmap(QPixmap &pixmap);
+    void getPixmap(QSize size, QPixmap &pixmap);
     void clearPixmapCache();
     void clearPixmapCacheMiss();
     void imageLoaded(const QImage &image);

--- a/cockatrice/src/cardinfopicture.cpp
+++ b/cockatrice/src/cardinfopicture.cpp
@@ -41,13 +41,14 @@ void CardInfoPicture::updatePixmap()
         return;
     }
 
-    QPixmap *resizedPixmap = info->getPixmap(QSize(pixmapWidth, pixmapWidth * aspectRatio));
-    if (resizedPixmap) {
-        setNoPicture(false);
-        this->setPixmap(*resizedPixmap);
-    }
-    else {
+    QPixmap resizedPixmap;
+    info->getPixmap(QSize(pixmapWidth, pixmapWidth * aspectRatio), resizedPixmap);
+
+    if (resizedPixmap.isNull()) {
         setNoPicture(true);
-        this->setPixmap(*(db->getCard()->getPixmap(QSize(pixmapWidth, pixmapWidth * aspectRatio))));
+        db->getCard()->getPixmap(QSize(pixmapWidth, pixmapWidth * aspectRatio), resizedPixmap);
+    } else {
+        setNoPicture(false);
     }
+    this->setPixmap(resizedPixmap);
 }

--- a/cockatrice/src/cardinfowidget.cpp
+++ b/cockatrice/src/cardinfowidget.cpp
@@ -188,11 +188,12 @@ void CardInfoWidget::updatePixmap()
     if (pixmapWidth == 0)
         return;
     
-    QPixmap *resizedPixmap = info->getPixmap(QSize(pixmapWidth, pixmapWidth * aspectRatio));
-    if (resizedPixmap)
-        cardPicture->setPixmap(*resizedPixmap);
-    else
-        cardPicture->setPixmap(*(getCard()->getPixmap(QSize(pixmapWidth, pixmapWidth * aspectRatio))));
+    QPixmap resizedPixmap;
+    info->getPixmap(QSize(pixmapWidth, pixmapWidth * aspectRatio), resizedPixmap);
+
+    if (resizedPixmap.isNull())
+        getCard()->getPixmap(QSize(pixmapWidth, pixmapWidth * aspectRatio), resizedPixmap);
+    cardPicture->setPixmap(resizedPixmap);
 }
 
 void CardInfoWidget::retranslateUi()

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -50,16 +50,27 @@ GeneralSettingsPage::GeneralSettingsPage()
     picDownloadHqCheckBox = new QCheckBox;
     picDownloadHqCheckBox->setChecked(settingsCache->getPicDownloadHq());
 
+    pixmapCacheLabel = new QLabel;
+    pixmapCacheEdit = new QSpinBox;
+    pixmapCacheEdit->setMinimum(64);
+    pixmapCacheEdit->setMaximum(8192);
+    pixmapCacheEdit->setSingleStep(64);
+    pixmapCacheEdit->setValue(settingsCache->getPixmapCacheSize());
+    pixmapCacheEdit->setSuffix(" MB");
+
     connect(languageBox, SIGNAL(currentIndexChanged(int)), this, SLOT(languageBoxChanged(int)));
     connect(picDownloadCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setPicDownload(int)));
     connect(picDownloadHqCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setPicDownloadHq(int)));
+    connect(pixmapCacheEdit, SIGNAL(valueChanged(int)), settingsCache, SLOT(setPixmapCacheSize(int)));
 
     QGridLayout *personalGrid = new QGridLayout;
     personalGrid->addWidget(languageLabel, 0, 0);
     personalGrid->addWidget(languageBox, 0, 1);
-    personalGrid->addWidget(picDownloadCheckBox, 1, 0, 1, 2);
-    personalGrid->addWidget(picDownloadHqCheckBox, 2, 0, 1, 2);
-    personalGrid->addWidget(clearDownloadedPicsButton, 3, 0, 1, 1);
+    personalGrid->addWidget(pixmapCacheLabel, 1, 0, 1, 1);
+    personalGrid->addWidget(pixmapCacheEdit, 1, 1, 1, 1);
+    personalGrid->addWidget(picDownloadCheckBox, 2, 0, 1, 2);
+    personalGrid->addWidget(picDownloadHqCheckBox, 3, 0, 1, 2);
+    personalGrid->addWidget(clearDownloadedPicsButton, 4, 0, 1, 1);
 
     personalGroupBox = new QGroupBox;
     personalGroupBox->setLayout(personalGrid);
@@ -227,6 +238,7 @@ void GeneralSettingsPage::retranslateUi()
     picsPathLabel->setText(tr("Pictures directory:"));
     cardDatabasePathLabel->setText(tr("Card database:"));
     tokenDatabasePathLabel->setText(tr("Token database:"));
+    pixmapCacheLabel->setText(tr("Picture cache size:"));
 }
 
 AppearanceSettingsPage::AppearanceSettingsPage()

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -16,6 +16,7 @@ class QLabel;
 class QCloseEvent;
 class QSpinBox;
 class QRadioButton;
+class QSpinBox;
 
 class AbstractSettingsPage : public QWidget {
 public:
@@ -39,11 +40,12 @@ private:
     QStringList findQmFiles();
     QString languageName(const QString &qmFile);
     QLineEdit *deckPathEdit, *replaysPathEdit, *picsPathEdit, *cardDatabasePathEdit, *tokenDatabasePathEdit;
+    QSpinBox *pixmapCacheEdit;
     QGroupBox *personalGroupBox, *pathsGroupBox;
     QComboBox *languageBox;
     QCheckBox *picDownloadCheckBox;
     QCheckBox *picDownloadHqCheckBox;
-    QLabel *languageLabel, *deckPathLabel, *replaysPathLabel, *picsPathLabel, *cardDatabasePathLabel, *tokenDatabasePathLabel;
+    QLabel *languageLabel, *deckPathLabel, *replaysPathLabel, *picsPathLabel, *cardDatabasePathLabel, *tokenDatabasePathLabel, *pixmapCacheLabel;
 };
 
 class AppearanceSettingsPage : public AbstractSettingsPage {

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -23,6 +23,7 @@ SettingsCache::SettingsCache()
 
     picDownload = settings->value("personal/picturedownload", true).toBool();
     picDownloadHq = settings->value("personal/picturedownloadhq", false).toBool();
+    pixmapCacheSize = settings->value("personal/pixmapCacheSize", PIXMAPCACHE_SIZE_DEFAULT).toInt();
     picUrl = settings->value("personal/picUrl", PIC_URL_DEFAULT).toString();
     picUrlHq = settings->value("personal/picUrlHq", PIC_URL_HQ_DEFAULT).toString();
     picUrlFallback = settings->value("personal/picUrlFallback", PIC_URL_FALLBACK).toString();
@@ -287,6 +288,13 @@ void SettingsCache::setAutoConnect(const bool &_autoConnect)
 {
     attemptAutoConnect = _autoConnect;
     settings->setValue("server/auto_connect", attemptAutoConnect ? 1 : 0);
+}
+
+void SettingsCache::setPixmapCacheSize(const int _pixmapCacheSize)
+{
+    pixmapCacheSize = _pixmapCacheSize;
+    settings->setValue("personal/pixmapCacheSize", pixmapCacheSize);
+    emit pixmapCacheSizeChanged(pixmapCacheSize);
 }
 
 void SettingsCache::copyPath(const QString &src, const QString &dst)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -34,7 +34,7 @@ signals:
     void soundPathChanged();
     void priceTagFeatureChanged(int enabled);
     void ignoreUnregisteredUsersChanged();
-    void pixmapCacheSizeChanged(int value);
+    void pixmapCacheSizeChanged(int newSizeInMBs);
 private:
     QSettings *settings;
 

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -7,6 +7,8 @@
 #define PIC_URL_FALLBACK "http://mtgimage.com/set/!setcode!/!name!.jpg"
 #define PIC_URL_HQ_DEFAULT "http://mtgimage.com/multiverseid/!cardid!.jpg"
 #define PIC_URL_HQ_FALLBACK "http://mtgimage.com/set/!setcode!/!name!.jpg"
+// size should be a multiple of 64
+#define PIXMAPCACHE_SIZE_DEFAULT 256
 
 class QSettings;
 
@@ -32,6 +34,7 @@ signals:
     void soundPathChanged();
     void priceTagFeatureChanged(int enabled);
     void ignoreUnregisteredUsersChanged();
+    void pixmapCacheSizeChanged(int value);
 private:
     QSettings *settings;
 
@@ -62,6 +65,7 @@ private:
     QString picUrlFallback;
     QString picUrlHqFallback;
     bool attemptAutoConnect;
+    int pixmapCacheSize;
 public:
     SettingsCache();
     const QByteArray &getMainWindowGeometry() const { return mainWindowGeometry; }
@@ -101,6 +105,7 @@ public:
     QString getPicUrlHqFallback() const { return picUrlHqFallback; }
     void copyPath(const QString &src, const QString &dst);
     bool getAutoConnect() const { return attemptAutoConnect; }
+    int getPixmapCacheSize() const { return pixmapCacheSize; }
 public slots:
     void setMainWindowGeometry(const QByteArray &_mainWindowGeometry);
     void setLang(const QString &_lang);
@@ -138,6 +143,7 @@ public slots:
     void setPicUrlFallback(const QString &_picUrlFallback);
     void setPicUrlHqFallback(const QString &_picUrlHqFallback);
     void setAutoConnect(const bool &_autoConnect);
+    void setPixmapCacheSize(const int _pixmapCacheSize);
 };
 
 extern SettingsCache *settingsCache;

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -361,7 +361,8 @@ void MainWindow::createMenus()
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent), localServer(0), bHasActivated(false)
 {
-    QPixmapCache::setCacheLimit(200000);
+    connect(settingsCache, SIGNAL(pixmapCacheSizeChanged(int)), this, SLOT(pixmapCacheSizeChanged(int)));
+    pixmapCacheSizeChanged(settingsCache->getPixmapCacheSize());
 
     client = new RemoteClient;
     connect(client, SIGNAL(connectionClosedEventReceived(const Event_ConnectionClosed &)), this, SLOT(processConnectionClosedEvent(const Event_ConnectionClosed &)));
@@ -429,4 +430,11 @@ void MainWindow::changeEvent(QEvent *event)
     }
 
     QMainWindow::changeEvent(event);
+}
+
+void MainWindow::pixmapCacheSizeChanged(int value)
+{
+    //qDebug() << "Setting pixmap cache size to " << value << " MBs";
+    // translate MBs to KBs
+    QPixmapCache::setCacheLimit(value * 1024);
 }

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -432,9 +432,9 @@ void MainWindow::changeEvent(QEvent *event)
     QMainWindow::changeEvent(event);
 }
 
-void MainWindow::pixmapCacheSizeChanged(int value)
+void MainWindow::pixmapCacheSizeChanged(int newSizeInMBs)
 {
     //qDebug() << "Setting pixmap cache size to " << value << " MBs";
     // translate MBs to KBs
-    QPixmapCache::setCacheLimit(value * 1024);
+    QPixmapCache::setCacheLimit(newSizeInMBs * 1024);
 }

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -44,6 +44,7 @@ private slots:
     void protocolVersionMismatch(int localVersion, int remoteVersion);
     void userInfoReceived(const ServerInfo_User &userInfo);
     void localGameEnded();
+    void pixmapCacheSizeChanged(int value);
 
     void actConnect();
     void actDisconnect();

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -44,7 +44,7 @@ private slots:
     void protocolVersionMismatch(int localVersion, int remoteVersion);
     void userInfoReceived(const ServerInfo_User &userInfo);
     void localGameEnded();
-    void pixmapCacheSizeChanged(int value);
+    void pixmapCacheSizeChanged(int newSizeInMBs);
 
     void actConnect();
     void actDisconnect();


### PR DESCRIPTION
This is my second attempt at resolving the problem of card images eating up all the available memory and thus making cockatrice crash.
Cockatrice was messing up with memory when handling card pictures; in memory you would find:
 1. CardInfo's own "pixmap" copy of the full-res picture, that was never freed.
 2. QPIxmapCache's copy of the very same pictures (limited at 200MB)
 3. CardInfo's own scaledPixmapCache, containing a copy of the same image at different resolutions; never freed, too.

This commit removes CardInfo's internal pixmap (number 1. and 3.) and delegates all the storage of pixmaps to QPixmapCache.
QPixmapCache has be instructed to limit the maximum amount of used memory RAM, freeing the least recently used cached card pixmaps.
The QPixmapCache's limit is exposed as an user preference, defaulting to 256 MB.