### PR TITLE
Specify the player when triggering a move on a revealed card

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1900,12 +1900,16 @@ void Player::cardMenuAction()
             default: ;
         }
     }
-    game->sendGameCommand(prepareGameCommand(commandList), getId());
+    if(local)
+        sendGameCommand(prepareGameCommand(commandList));
+    else
+        game->sendGameCommand(prepareGameCommand(commandList));
 }
 
 void Player::actIncPT(int deltaP, int deltaT)
 {
     QString ptString = "+" + QString::number(deltaP) + "/+" + QString::number(deltaT);
+    int playerid = id;
     
     QList< const ::google::protobuf::Message * > commandList;
     QListIterator<QGraphicsItem *> j(scene()->selectedItems());
@@ -1917,13 +1921,19 @@ void Player::actIncPT(int deltaP, int deltaT)
         cmd->set_attribute(AttrPT);
         cmd->set_attr_value(ptString.toStdString());
         commandList.append(cmd);
+
+        if(local)
+            playerid=card->getZone()->getPlayer()->getId();
     }
-    sendGameCommand(prepareGameCommand(commandList));
+
+    game->sendGameCommand(prepareGameCommand(commandList), playerid);
 }
 
 void Player::actSetPT()
 {
     QString oldPT;
+    int playerid = id;
+
     QListIterator<QGraphicsItem *> i(scene()->selectedItems());
     while (i.hasNext()) {
         CardItem *card = static_cast<CardItem *>(i.next());
@@ -1949,8 +1959,12 @@ void Player::actSetPT()
         cmd->set_attribute(AttrPT);
         cmd->set_attr_value(pt.toStdString());
         commandList.append(cmd);
+
+        if(local)
+            playerid=card->getZone()->getPlayer()->getId();
     }
-    sendGameCommand(prepareGameCommand(commandList));
+
+    game->sendGameCommand(prepareGameCommand(commandList), playerid);
 }
 
 void Player::actDrawArrow()

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1900,7 +1900,7 @@ void Player::cardMenuAction()
             default: ;
         }
     }
-    game->sendGameCommand(prepareGameCommand(commandList));
+    game->sendGameCommand(prepareGameCommand(commandList), getId());
 }
 
 void Player::actIncPT(int deltaP, int deltaT)


### PR DESCRIPTION
Fixes #72, #493 
Please have a look at https://github.com/Cockatrice/Cockatrice/issues/72#issuecomment-68182612 for the full discussion.
I'm not so confident with this part of the code, so i'm unsure wether this patch could break something else.
Please hard-review this before committing.
