### PR TITLE
Fixes the "Card preview window gets stuck and can't be removed" issue by...

### DIFF
--- a/cockatrice/src/tab.cpp
+++ b/cockatrice/src/tab.cpp
@@ -10,6 +10,10 @@ Tab::Tab(TabSupervisor *_tabSupervisor, QWidget *parent)
 
 void Tab::showCardInfoPopup(const QPoint &pos, const QString &cardName)
 {
+    if (infoPopup) {
+        infoPopup->deleteLater();
+    }
+	currentCardName = cardName;
     infoPopup = new CardInfoWidget(CardInfoWidget::ModePopUp, cardName, 0, Qt::Widget | Qt::FramelessWindowHint | Qt::X11BypassWindowManagerHint | Qt::WindowStaysOnTopHint);
     infoPopup->setAttribute(Qt::WA_TransparentForMouseEvents);
     QRect screenRect = qApp->desktop()->screenGeometry(this);
@@ -23,7 +27,7 @@ void Tab::showCardInfoPopup(const QPoint &pos, const QString &cardName)
 void Tab::deleteCardInfoPopup(const QString &cardName)
 {
     if (infoPopup) {
-        if ((infoPopup->getCardName() == cardName) || (cardName == "_")) {
+        if ((currentCardName == cardName) || (cardName == "_")) {
             infoPopup->deleteLater();
             infoPopup = 0;
         }

--- a/cockatrice/src/tab.h
+++ b/cockatrice/src/tab.h
@@ -19,6 +19,7 @@ protected slots:
     void showCardInfoPopup(const QPoint &pos, const QString &cardName);
     void deleteCardInfoPopup(const QString &cardName);
 private:
+    QString currentCardName;
     bool contentsChanged;
     CardInfoWidget *infoPopup;
     QList<QMenu *> tabMenus;


### PR DESCRIPTION
... saving the cardname, instead of getting it back from the popup (with possible issues with case sensitivity). Also closes an old popup when a new is created.