### PR TITLE
Clean up a small pile of compiler warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,9 +79,9 @@ ELSEIF (CMAKE_COMPILER_IS_GNUCXX)
     include(CheckCXXCompilerFlag)
 
     set(CMAKE_CXX_FLAGS_RELEASE "-s -O2")
-    set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -O0 -Wall -Wextra -pedantic -Werror")
+    set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -O0 -Wall -Wextra -Werror")
 
-    set(ADDITIONAL_DEBUG_FLAGS -Wcast-align -Wmissing-declarations -Winline -Wno-long-long -Wno-error=extra -Wno-error=unused-parameter -Wno-inline -Wno-error=delete-non-virtual-dtor -Wno-error=sign-compare -Wno-error=reorder -Wno-error=missing-declarations)
+    set(ADDITIONAL_DEBUG_FLAGS -Wcast-align -Wmissing-declarations -Wno-long-long -Wno-error=extra -Wno-error=delete-non-virtual-dtor -Wno-error=sign-compare -Wno-error=missing-declarations)
 
     FOREACH(FLAG ${ADDITIONAL_DEBUG_FLAGS})
         CHECK_CXX_COMPILER_FLAG("${FLAG}" CXX_HAS_WARNING_${FLAG})

--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -31,7 +31,7 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardSet *set)
 }
 
 CardSet::CardSet(const QString &_shortName, const QString &_longName, const QString &_setType, const QDate &_releaseDate)
-    : shortName(_shortName), longName(_longName), setType(_setType), releaseDate(_releaseDate)
+    : shortName(_shortName), longName(_longName), releaseDate(_releaseDate), setType(_setType)
 {
     updateSortKey();
 }

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -75,6 +75,7 @@ DlgConnect::DlgConnect(QWidget *parent)
 
 void DlgConnect::passwordSaved(int state)
 {
+    Q_UNUSED(state);
     if(savePasswordCheckBox->isChecked()) {
        autoConnectCheckBox->setEnabled(true);
     } else {

--- a/cockatrice/src/filtertree.h
+++ b/cockatrice/src/filtertree.h
@@ -154,7 +154,7 @@ public:
     FilterTreeNode *termNode(const CardFilter *f);
     FilterTreeNode *attrTypeNode(CardFilter::Attr attr,
                                 CardFilter::Type type);
-    const char *textCStr() { return "root"; }
+    const char *textCStr() const { return "root"; }
     int index() const { return 0; }
 
     bool acceptsCard(const CardInfo *info) const;

--- a/cockatrice/src/setsmodel.h
+++ b/cockatrice/src/setsmodel.h
@@ -29,7 +29,7 @@ public:
     SetsModel(CardDatabase *_db, QObject *parent = 0);
     ~SetsModel();
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
-    int columnCount(const QModelIndex &parent = QModelIndex()) const { return NUM_COLS; }
+    int columnCount(const QModelIndex &parent = QModelIndex()) const { Q_UNUSED(parent); return NUM_COLS; }
     QVariant data(const QModelIndex &index, int role) const;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
     Qt::ItemFlags flags(const QModelIndex &index) const;

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -21,7 +21,7 @@ public:
     bool getImport() const { return import; }
     void setImport(bool _import) { import = _import; }
     SetToDownload(const QString &_shortName, const QString &_longName, const QVariant &_cards, bool _import, const QString &_setType = QString(), const QDate &_releaseDate = QDate())
-        : shortName(_shortName), longName(_longName), import(_import), cards(_cards), setType(_setType), releaseDate(_releaseDate)  { }
+        : shortName(_shortName), longName(_longName), import(_import), cards(_cards), releaseDate(_releaseDate), setType(_setType)  { }
     bool operator<(const SetToDownload &set) const { return longName.compare(set.longName, Qt::CaseInsensitive) < 0; }
 };
 

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -108,7 +108,11 @@ void Servatrice_GameServer::incomingConnection(qintptr socketDescriptor)
     QMetaObject::invokeMethod(ssi, "initConnection", Qt::QueuedConnection, Q_ARG(int, socketDescriptor));
 }
 
+#if QT_VERSION < 0x050000
 void Servatrice_IslServer::incomingConnection(int socketDescriptor)
+#else
+void Servatrice_IslServer::incomingConnection(qintptr socketDescriptor)
+#endif
 {
     QThread *thread = new QThread;
     connect(thread, SIGNAL(finished()), thread, SLOT(deleteLater()));

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -68,7 +68,11 @@ public:
 	Servatrice_IslServer(Servatrice *_server, const QSslCertificate &_cert, const QSslKey &_privateKey, QObject *parent = 0)
 		: QTcpServer(parent), server(_server), cert(_cert), privateKey(_privateKey) { }
 protected:
+#if QT_VERSION < 0x050000
 	void incomingConnection(int socketDescriptor);
+#else
+	void incomingConnection(qintptr socketDescriptor);
+#endif
 };
 
 class ServerProperties {


### PR DESCRIPTION
Clean up the following compiler warnings:

1) Don't specifiy both -Winline and -Wno-inline in the debug warnings.

2) Yank -pendantic from the debug flags.  QT5 is not pre c++98 pendantic.  Optionally cockatrice could specify -std=c++98 and -pedantic.

3) Fix all of the -Wreorder warnings.

4) Fix the Wunused-parameter warnings with Q_UNUSED.

5) Fix servatrice qt5 prototypes for incomingConnection
