### PR TITLE
Reset Always reveal top card when starting a new game.

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2225,6 +2225,13 @@ qreal Player::getMinimumWidth() const
     return result;
 }
 
+void Player::setGameStarted()
+{
+    if (local)
+        aAlwaysRevealTopCard->setChecked(false);
+    setConceded(false);
+}
+
 void Player::setConceded(bool _conceded)
 {
     conceded = _conceded;

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -286,6 +286,8 @@ public:
     
     void setConceded(bool _conceded);
     bool getConceded() const { return conceded; }
+
+    void setGameStarted();
     
     qreal getMinimumWidth() const;
     void setMirrored(bool _mirrored);

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -872,7 +872,7 @@ void TabGame::startGame(bool resuming)
     if (!resuming) {
         QMapIterator<int, Player *> playerIterator(players);
         while (playerIterator.hasNext())
-            playerIterator.next().value()->setConceded(false);
+            playerIterator.next().value()->setGameStarted();
     }
 
     playerListWidget->setGameStarted(true, resuming);


### PR DESCRIPTION
Reset the 'Always reveal top card' library menu item checkbox between games.  It currently phantomly sticks in the checked position when a new game starts even though the cards are not visible.

