### PR TITLE
Apply filters at start

### DIFF
--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -1,5 +1,4 @@
 #include "dlg_filter_games.h"
-#include <QDebug>
 #include <QCheckBox>
 #include <QPushButton>
 #include <QLabel>
@@ -22,7 +21,6 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes, const Ga
     settings.beginGroup("filter_games");
 
     unavailableGamesVisibleCheckBox = new QCheckBox(tr("Show &unavailable games"));
-    qDebug() << "getUnavailableGamesVisible() == " << gamesProxyModel->getUnavailableGamesVisible();
     unavailableGamesVisibleCheckBox->setChecked(gamesProxyModel->getUnavailableGamesVisible());
 
     passwordProtectedGamesVisibleCheckBox = new QCheckBox(tr("Show &password protected games"));

--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -13,7 +13,7 @@
 #include <QSettings>
 #include <QCryptographicHash>
 
-DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes, GamesProxyModel *_gamesProxyModel, QWidget *parent)
+DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes, const GamesProxyModel *_gamesProxyModel, QWidget *parent)
     : QDialog(parent),
       allGameTypes(_allGameTypes),
       gamesProxyModel(_gamesProxyModel)

--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -112,34 +112,6 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes, GamesPro
 }
 
 void DlgFilterGames::actOk() {
-    QSettings settings;
-    settings.beginGroup("filter_games");
-    settings.setValue(
-        "unavailable_games_visible",
-	unavailableGamesVisibleCheckBox->isChecked()
-    );
-    settings.setValue(
-        "password_protected_games_visible",
-        passwordProtectedGamesVisibleCheckBox->isChecked()
-    );
-    settings.setValue("game_name_filter", gameNameFilterEdit->text());
-    settings.setValue("creator_name_filter", creatorNameFilterEdit->text());
-
-    QMapIterator<int, QString> gameTypeIterator(allGameTypes);
-    QMapIterator<int, QCheckBox *> checkboxIterator(gameTypeFilterCheckBoxes);
-    while (gameTypeIterator.hasNext()) {
-        gameTypeIterator.next();
-        checkboxIterator.next();
-
-        settings.setValue(
-            "game_type/" + hashGameType(gameTypeIterator.value()),
-            checkboxIterator.value()->isChecked()
-        );
-    }
-
-    settings.setValue("min_players", maxPlayersFilterMinSpinBox->value());
-    settings.setValue("max_players", maxPlayersFilterMaxSpinBox->value());
-
     accept();
 }
 

--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -113,10 +113,6 @@ void DlgFilterGames::actOk() {
     accept();
 }
 
-QString DlgFilterGames::hashGameType(const QString &gameType) const {
-    return QCryptographicHash::hash(gameType.toUtf8(), QCryptographicHash::Md5).toHex();
-}
-
 bool DlgFilterGames::getUnavailableGamesVisible() const
 {
     return unavailableGamesVisibleCheckBox->isChecked();

--- a/cockatrice/src/dlg_filter_games.h
+++ b/cockatrice/src/dlg_filter_games.h
@@ -22,7 +22,6 @@ private:
     QSpinBox *maxPlayersFilterMaxSpinBox;
 
     const QMap<int, QString> &allGameTypes;
-    // This needs a const someplace
     const GamesProxyModel *gamesProxyModel;
 
 private slots:

--- a/cockatrice/src/dlg_filter_games.h
+++ b/cockatrice/src/dlg_filter_games.h
@@ -25,11 +25,6 @@ private:
     // This needs a const someplace
     const GamesProxyModel *gamesProxyModel;
 
-    /*
-     * The game type might contain special characters, so to use it in
-     * QSettings we just hash it.
-     */
-    QString hashGameType(const QString &gameType) const;
 private slots:
     void actOk();
 public:

--- a/cockatrice/src/dlg_filter_games.h
+++ b/cockatrice/src/dlg_filter_games.h
@@ -23,7 +23,7 @@ private:
 
     const QMap<int, QString> &allGameTypes;
     // This needs a const someplace
-    GamesProxyModel *gamesProxyModel;
+    const GamesProxyModel *gamesProxyModel;
 
     /*
      * The game type might contain special characters, so to use it in
@@ -33,7 +33,7 @@ private:
 private slots:
     void actOk();
 public:
-    DlgFilterGames(const QMap<int, QString> &_allGameTypes, GamesProxyModel *_gamesProxyModel, QWidget *parent = 0);
+    DlgFilterGames(const QMap<int, QString> &_allGameTypes, const GamesProxyModel *_gamesProxyModel, QWidget *parent = 0);
 
     bool getUnavailableGamesVisible() const;
     void setUnavailableGamesVisible(bool _unavailableGamesVisible);

--- a/cockatrice/src/dlg_filter_games.h
+++ b/cockatrice/src/dlg_filter_games.h
@@ -4,6 +4,7 @@
 #include <QDialog>
 #include <QSet>
 #include <QMap>
+#include "gamesmodel.h"
 
 class QCheckBox;
 class QLineEdit;
@@ -21,6 +22,8 @@ private:
     QSpinBox *maxPlayersFilterMaxSpinBox;
 
     const QMap<int, QString> &allGameTypes;
+    // This needs a const someplace
+    GamesProxyModel *gamesProxyModel;
 
     /*
      * The game type might contain special characters, so to use it in
@@ -30,8 +33,8 @@ private:
 private slots:
     void actOk();
 public:
-    DlgFilterGames(const QMap<int, QString> &allGameTypes, QWidget *parent = 0);
-    
+    DlgFilterGames(const QMap<int, QString> &_allGameTypes, GamesProxyModel *_gamesProxyModel, QWidget *parent = 0);
+
     bool getUnavailableGamesVisible() const;
     void setUnavailableGamesVisible(bool _unavailableGamesVisible);
     bool getPasswordProtectedGamesVisible() const;

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -109,6 +109,7 @@ void GameSelector::actSetFilter()
     gameListProxyModel->setCreatorNameFilter(dlg.getCreatorNameFilter());
     gameListProxyModel->setGameTypeFilter(dlg.getGameTypeFilter());
     gameListProxyModel->setMaxPlayersFilter(dlg.getMaxPlayersFilterMin(), dlg.getMaxPlayersFilterMax());
+    gameListProxyModel->saveFilterParameters(gameTypeMap);
 }
 
 void GameSelector::actClearFilter()

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -39,8 +39,6 @@ GameSelector::GameSelector(AbstractClient *_client, const TabSupervisor *_tabSup
 
     gameListProxyModel->loadFilterParameters(gameTypeMap);
 
-    // set the reset filter button enabled
-
 #if QT_VERSION < 0x050000
     gameListView->header()->setResizeMode(0, QHeaderView::ResizeToContents);
 #else
@@ -51,7 +49,7 @@ GameSelector::GameSelector(AbstractClient *_client, const TabSupervisor *_tabSup
     connect(filterButton, SIGNAL(clicked()), this, SLOT(actSetFilter()));
     clearFilterButton = new QPushButton;
     clearFilterButton->setIcon(QIcon(":/resources/icon_clearsearch.svg"));
-    clearFilterButton->setEnabled(false);
+    clearFilterButton->setEnabled(true);
     connect(clearFilterButton, SIGNAL(clicked()), this, SLOT(actClearFilter()));
 
     if (room) {

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -1,4 +1,3 @@
-#include <QDebug>
 #include <QTreeView>
 #include <QCheckBox>
 #include <QPushButton>
@@ -39,8 +38,6 @@ GameSelector::GameSelector(AbstractClient *_client, const TabSupervisor *_tabSup
         gameTypeMap = gameListModel->getGameTypes().value(room->getRoomId());
 
     gameListProxyModel->loadFilterParameters(gameTypeMap);
-
-    qDebug() << "Check unavailable" << gameListProxyModel->getUnavailableGamesVisible();
 
     // set the reset filter button enabled
 
@@ -95,7 +92,6 @@ void GameSelector::actSetFilter()
 	GameTypeMap gameTypeMap;
 	if (room)
 	    gameTypeMap = gameListModel->getGameTypes().value(room->getRoomId());
-	qDebug() << "Check unavailable" << gameListProxyModel->getUnavailableGamesVisible();
     DlgFilterGames dlg(gameTypeMap, gameListProxyModel, this);
 
     if (!dlg.exec())

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -33,7 +33,6 @@ GameSelector::GameSelector(AbstractClient *_client, const TabSupervisor *_tabSup
     if (_room)
         gameListView->header()->hideSection(gameListModel->roomColIndex());
 
-    GameTypeMap gameTypeMap;
     if (room)
         gameTypeMap = gameListModel->getGameTypes().value(room->getRoomId());
 
@@ -87,9 +86,6 @@ GameSelector::GameSelector(AbstractClient *_client, const TabSupervisor *_tabSup
 
 void GameSelector::actSetFilter()
 {
-	GameTypeMap gameTypeMap;
-	if (room)
-	    gameTypeMap = gameListModel->getGameTypes().value(room->getRoomId());
     DlgFilterGames dlg(gameTypeMap, gameListProxyModel, this);
 
     if (!dlg.exec())
@@ -111,6 +107,7 @@ void GameSelector::actClearFilter()
     clearFilterButton->setEnabled(false);
 
     gameListProxyModel->resetFilterParameters();
+    gameListProxyModel->saveFilterParameters(gameTypeMap);
 }
 
 void GameSelector::actCreate()

--- a/cockatrice/src/gameselector.h
+++ b/cockatrice/src/gameselector.h
@@ -34,6 +34,7 @@ private:
     GamesModel *gameListModel;
     GamesProxyModel *gameListProxyModel;
     QPushButton *filterButton, *clearFilterButton, *createButton, *joinButton, *spectateButton;
+    GameTypeMap gameTypeMap;
 public:
     GameSelector(AbstractClient *_client, const TabSupervisor *_tabSupervisor, TabRoom *_room, const QMap<int, QString> &_rooms, const QMap<int, GameTypeMap> &_gameTypes, QWidget *parent = 0);
     void retranslateUi();

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -235,7 +235,6 @@ void GamesProxyModel::loadFilterParameters(const QMap<int, QString> &allGameType
     settings.beginGroup("filter_games");
 
     unavailableGamesVisible = settings.value("unavailable_games_visible", false).toBool();
-    qDebug() << "Load unavailable = " << unavailableGamesVisible;
     passwordProtectedGamesVisible = settings.value("password_protected_games_visible", false).toBool();
     gameNameFilter = settings.value("game_name_filter", "").toString();
     creatorNameFilter = settings.value("creator_name_filter", "").toString();

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -224,7 +224,7 @@ void GamesProxyModel::resetFilterParameters()
     creatorNameFilter = QString();
     gameTypeFilter.clear();
     maxPlayersFilterMin = 1;
-    maxPlayersFilterMax = 99;
+    maxPlayersFilterMax = DEFAULT_MAX_PLAYERS_MAX;
 
     invalidateFilter();
 }
@@ -239,7 +239,7 @@ void GamesProxyModel::loadFilterParameters(const QMap<int, QString> &allGameType
     gameNameFilter = settings.value("game_name_filter", "").toString();
     creatorNameFilter = settings.value("creator_name_filter", "").toString();
     maxPlayersFilterMin = settings.value("min_players", 1).toInt();
-    maxPlayersFilterMax = settings.value("max_players", 99).toInt();
+    maxPlayersFilterMax = settings.value("max_players", DEFAULT_MAX_PLAYERS_MAX).toInt();
 
     QMapIterator<int, QString> gameTypesIterator(allGameTypes);
     while (gameTypesIterator.hasNext()) {

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -253,6 +253,33 @@ void GamesProxyModel::loadFilterParameters(const QMap<int, QString> &allGameType
     invalidateFilter();
 }
 
+void GamesProxyModel::saveFilterParameters(const QMap<int, QString> &allGameTypes)
+{
+    QSettings settings;
+    settings.beginGroup("filter_games");
+
+    settings.setValue("unavailable_games_visible", unavailableGamesVisible);
+    settings.setValue(
+        "password_protected_games_visible",
+        passwordProtectedGamesVisible
+    );
+    settings.setValue("game_name_filter", gameNameFilter);
+    settings.setValue("creator_name_filter", creatorNameFilter);
+
+    QMapIterator<int, QString> gameTypeIterator(allGameTypes);
+    while (gameTypeIterator.hasNext()) {
+        gameTypeIterator.next();
+
+        settings.setValue(
+            "game_type/" + hashGameType(gameTypeIterator.value()),
+            gameTypeFilter.contains(gameTypeIterator.key())
+        );
+    }
+
+    settings.setValue("min_players", maxPlayersFilterMin);
+    settings.setValue("max_players", maxPlayersFilterMax);
+}
+
 bool GamesProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &/*sourceParent*/) const
 {
     GamesModel *model = qobject_cast<GamesModel *>(sourceModel());

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -50,6 +50,8 @@ private:
     QSet<int> gameTypeFilter;
     int maxPlayersFilterMin, maxPlayersFilterMax;
 
+    static const int DEFAULT_MAX_PLAYERS_MAX = 99;
+
     /*
      * The game type might contain special characters, so to use it in
      * QSettings we just hash it.

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -49,6 +49,12 @@ private:
     QString gameNameFilter, creatorNameFilter;
     QSet<int> gameTypeFilter;
     int maxPlayersFilterMin, maxPlayersFilterMax;
+
+    /*
+     * The game type might contain special characters, so to use it in
+     * QSettings we just hash it.
+     */
+    QString hashGameType(const QString &gameType) const;
 public:
     GamesProxyModel(QObject *parent = 0, ServerInfo_User *_ownUser = 0);
 
@@ -66,6 +72,8 @@ public:
     int getMaxPlayersFilterMax() const { return maxPlayersFilterMax; }
     void setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlayersFilterMax);
     void resetFilterParameters();
+    void loadFilterParameters(const QMap<int, QString> &allGameTypes);
+    void saveFilterParameters();
 protected:
     bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
 };

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -73,7 +73,7 @@ public:
     void setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlayersFilterMax);
     void resetFilterParameters();
     void loadFilterParameters(const QMap<int, QString> &allGameTypes);
-    void saveFilterParameters();
+    void saveFilterParameters(const QMap<int, QString> &allGameTypes);
 protected:
     bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
 };


### PR DESCRIPTION
Fixes #509 

Basically, this patch refactors the filter code such that persistence of the filters is not done by the dialog class, but the model instead.  Then the dialog uses the model to set the state of the dialog properly, then save the data back to the model, then on to the qsettings.

I added a load filters function that is called at the time the games window is created that sets the filters up initially from the saved settings.