### PR TITLE
Added account age to user info window

### DIFF
--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -2,43 +2,40 @@
 #include "pixmapgenerator.h"
 #include "abstractclient.h"
 #include <QLabel>
+#include <QDateTime>
 #include <QGridLayout>
+
 
 #include "pending_command.h"
 #include "pb/session_commands.pb.h"
 #include "pb/response_get_user_info.pb.h"
 
+const qint64 SIXTY = 60;
+const qint64 HOURS_IN_A_DAY = 24;
+const qint64 DAYS_IN_A_YEAR = 365;
+
 UserInfoBox::UserInfoBox(AbstractClient *_client, bool _fullInfo, QWidget *parent, Qt::WindowFlags flags)
     : QWidget(parent, flags), client(_client), fullInfo(_fullInfo)
 {
-    avatarLabel = new QLabel;
-    nameLabel = new QLabel;
-    QFont nameFont = nameLabel->font();
+    QFont nameFont = nameLabel.font();
     nameFont.setBold(true);
     nameFont.setPointSize(nameFont.pointSize() * 1.5);
-    nameLabel->setFont(nameFont);
-    realNameLabel1 = new QLabel;
-    realNameLabel2 = new QLabel;
-    genderLabel1 = new QLabel;
-    genderLabel2 = new QLabel;
-    countryLabel1 = new QLabel;
-    countryLabel2 = new QLabel;
-    userLevelLabel1 = new QLabel;
-    userLevelLabel2 = new QLabel;
-    userLevelLabel3 = new QLabel;
+    nameLabel.setFont(nameFont);
     
     QGridLayout *mainLayout = new QGridLayout;
-    mainLayout->addWidget(avatarLabel, 0, 0, 1, 3, Qt::AlignCenter);
-    mainLayout->addWidget(nameLabel, 1, 0, 1, 3);
-    mainLayout->addWidget(realNameLabel1, 2, 0, 1, 1);
-    mainLayout->addWidget(realNameLabel2, 2, 1, 1, 2);
-    mainLayout->addWidget(genderLabel1, 3, 0, 1, 1);
-    mainLayout->addWidget(genderLabel2, 3, 1, 1, 2);
-    mainLayout->addWidget(countryLabel1, 4, 0, 1, 1);
-    mainLayout->addWidget(countryLabel2, 4, 1, 1, 2);
-    mainLayout->addWidget(userLevelLabel1, 5, 0, 1, 1);
-    mainLayout->addWidget(userLevelLabel2, 5, 1, 1, 1);
-    mainLayout->addWidget(userLevelLabel3, 5, 2, 1, 1);
+    mainLayout->addWidget(&avatarLabel, 0, 0, 1, 3, Qt::AlignCenter);
+    mainLayout->addWidget(&nameLabel, 1, 0, 1, 3);
+    mainLayout->addWidget(&realNameLabel1, 2, 0, 1, 1);
+    mainLayout->addWidget(&realNameLabel2, 2, 1, 1, 2);
+    mainLayout->addWidget(&genderLabel1, 3, 0, 1, 1);
+    mainLayout->addWidget(&genderLabel2, 3, 1, 1, 2);
+    mainLayout->addWidget(&countryLabel1, 4, 0, 1, 1);
+    mainLayout->addWidget(&countryLabel2, 4, 1, 1, 2);
+    mainLayout->addWidget(&userLevelLabel1, 5, 0, 1, 1);
+    mainLayout->addWidget(&userLevelLabel2, 5, 1, 1, 1);
+    mainLayout->addWidget(&userLevelLabel3, 5, 2, 1, 1);
+    mainLayout->addWidget(&accountAgeLebel1, 6, 0, 1, 1);
+    mainLayout->addWidget(&accountAgeLabel2, 6, 2, 1, 1);
     mainLayout->setColumnStretch(2, 10);
     
     setWindowTitle(tr("User information"));
@@ -48,10 +45,11 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _fullInfo, QWidget *paren
 
 void UserInfoBox::retranslateUi()
 {
-    realNameLabel1->setText(tr("Real name:"));
-    genderLabel1->setText(tr("Gender:"));
-    countryLabel1->setText(tr("Location:"));
-    userLevelLabel1->setText(tr("User level:"));
+    realNameLabel1.setText(tr("Real name:"));
+    genderLabel1.setText(tr("Gender:"));
+    countryLabel1.setText(tr("Location:"));
+    userLevelLabel1.setText(tr("User level:"));
+    accountAgeLebel1.setText(tr("Account Age:"));
 }
 
 void UserInfoBox::updateInfo(const ServerInfo_User &user)
@@ -62,13 +60,13 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
     const std::string bmp = user.avatar_bmp();
     if (!avatarPixmap.loadFromData((const uchar *) bmp.data(), bmp.size()))
         avatarPixmap = UserLevelPixmapGenerator::generatePixmap(64, userLevel);
-    avatarLabel->setPixmap(avatarPixmap);
+    avatarLabel.setPixmap(avatarPixmap);
     
-    nameLabel->setText(QString::fromStdString(user.name()));
-    realNameLabel2->setText(QString::fromStdString(user.real_name()));
-    genderLabel2->setPixmap(GenderPixmapGenerator::generatePixmap(15, user.gender()));
-    countryLabel2->setPixmap(CountryPixmapGenerator::generatePixmap(15, QString::fromStdString(user.country())));
-    userLevelLabel2->setPixmap(UserLevelPixmapGenerator::generatePixmap(15, userLevel));
+    nameLabel.setText(QString::fromStdString(user.name()));
+    realNameLabel2.setText(QString::fromStdString(user.real_name()));
+    genderLabel2.setPixmap(GenderPixmapGenerator::generatePixmap(15, user.gender()));
+    countryLabel2.setPixmap(CountryPixmapGenerator::generatePixmap(15, QString::fromStdString(user.country())));
+    userLevelLabel2.setPixmap(UserLevelPixmapGenerator::generatePixmap(15, userLevel));
     QString userLevelText;
     if (userLevel.testFlag(ServerInfo_User::IsAdmin))
         userLevelText = tr("Administrator");
@@ -78,7 +76,34 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
         userLevelText = tr("Registered user");
     else
         userLevelText = tr("Unregistered user");
-    userLevelLabel3->setText(userLevelText);
+    userLevelLabel3.setText(userLevelText);
+
+    QString accountAgeString = tr("Unregistered user");
+    if (userLevel.testFlag(ServerInfo_User::IsAdmin) || userLevel.testFlag(ServerInfo_User::IsModerator) || userLevel.testFlag(ServerInfo_User::IsRegistered)) {
+        if (user.accountage_secs() == 0) 
+            accountAgeString = tr("Unknown");
+        else {
+            qint64 seconds = user.accountage_secs();
+            qint64 minutes =  seconds / SIXTY;
+            qint64 hours = minutes / SIXTY;
+            qint64 days = hours / HOURS_IN_A_DAY;
+            qint64 years = days / DAYS_IN_A_YEAR;
+            qint64 daysMinusYears = days - (years * DAYS_IN_A_YEAR);
+
+            accountAgeString = "";
+            if (years >= 1) {
+                accountAgeString = QString::number(years);
+                accountAgeString.append(" ");
+                accountAgeString.append(years == 1 ? tr("Year") : tr("Years"));
+                accountAgeString.append(" ");
+            }
+
+            accountAgeString.append(QString::number(daysMinusYears));
+            accountAgeString.append(" ");
+            accountAgeString.append(days == 1 ? tr("Day") : tr("Days"));
+        }
+    }
+    accountAgeLabel2.setText(accountAgeString);
 }
 
 void UserInfoBox::updateInfo(const QString &userName)

--- a/cockatrice/src/userinfobox.h
+++ b/cockatrice/src/userinfobox.h
@@ -2,6 +2,7 @@
 #define USERINFOBOX_H
 
 #include <QWidget>
+#include <QLabel>
 
 class QLabel;
 class ServerInfo_User;
@@ -13,7 +14,8 @@ class UserInfoBox : public QWidget {
 private:
     AbstractClient *client;
     bool fullInfo;
-    QLabel *avatarLabel, *nameLabel, *realNameLabel1, *realNameLabel2, *genderLabel1, *genderLabel2, *countryLabel1, *countryLabel2, *userLevelLabel1, *userLevelLabel2, *userLevelLabel3;
+    QLabel avatarLabel, nameLabel, realNameLabel1, realNameLabel2, genderLabel1, genderLabel2, countryLabel1, 
+        countryLabel2, userLevelLabel1, userLevelLabel2, userLevelLabel3, accountAgeLebel1, accountAgeLabel2;
 public:
     UserInfoBox(AbstractClient *_client, bool fullInfo, QWidget *parent = 0, Qt::WindowFlags flags = 0);
     void retranslateUi();

--- a/common/pb/serverinfo_user.proto
+++ b/common/pb/serverinfo_user.proto
@@ -21,4 +21,5 @@ message ServerInfo_User {
 	optional sint32 id = 8 [default = -1];
 	optional sint32 server_id = 9 [default = -1];
 	optional uint64 session_id = 10;
+    optional uint64 accountage_secs = 11;
 }

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -8,6 +8,7 @@
 #include <QDebug>
 #include <QSqlError>
 #include <QSqlQuery>
+#include <QDateTime>
 
 Servatrice_DatabaseInterface::Servatrice_DatabaseInterface(int _instanceId, Servatrice *_server)
 	: instanceId(_instanceId),
@@ -283,6 +284,12 @@ ServerInfo_User Servatrice_DatabaseInterface::evalUserQueryResult(const QSqlQuer
 	const QString realName = query.value(3).toString();
 	if (!realName.isEmpty())
 		result.set_real_name(realName.toStdString());
+
+    const QDateTime regDate = query.value(7).toDateTime();
+    if(!regDate.toString(Qt::ISODate).isEmpty()) {
+        qint64 accountAgeInSeconds = regDate.secsTo(QDateTime::currentDateTime());
+        result.set_accountage_secs(accountAgeInSeconds);
+    }
 	
 	return result;
 }
@@ -298,7 +305,7 @@ ServerInfo_User Servatrice_DatabaseInterface::getUserData(const QString &name, b
 			return result;
 		
 		QSqlQuery query(sqlDatabase);
-		query.prepare("select id, name, admin, realname, gender, country, avatar_bmp from " + server->getDbPrefix() + "_users where name = :name and active = 1");
+		query.prepare("select id, name, admin, realname, gender, country, avatar_bmp, registrationDate from " + server->getDbPrefix() + "_users where name = :name and active = 1");
 		query.bindValue(":name", name);
 		if (!execSqlQuery(query))
 			return result;


### PR DESCRIPTION
Added the ability to see the account age of registered users. Changes are both in server and client. The server will now send how long the account has been active in seconds. The client will then use this to calculate the account age and display it in the user details window.

![account age](https://cloud.githubusercontent.com/assets/2134793/5672889/772dcc30-9795-11e4-98f8-e5f3483a7d6e.png)