### PR TITLE
Clear chat

### DIFF
--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -175,6 +175,10 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
         verticalScrollBar()->setValue(verticalScrollBar()->maximum());
 }
 
+void ChatView::clearChat() {
+    document()->clear();
+}
+
 void ChatView::enterEvent(QEvent * /*event*/)
 {
     setMouseTracking(true);

--- a/cockatrice/src/chatview.h
+++ b/cockatrice/src/chatview.h
@@ -37,6 +37,7 @@ public:
     void retranslateUi();
     void appendHtml(const QString &html);
     void appendMessage(QString message, QString sender = QString(), UserLevelFlags userLevel = UserLevelFlags(), bool playerBold = false);
+    void clearChat();
 protected:
     void enterEvent(QEvent *event);
     void leaveEvent(QEvent *event);

--- a/cockatrice/src/tab_room.cpp
+++ b/cockatrice/src/tab_room.cpp
@@ -53,6 +53,9 @@ TabRoom::TabRoom(TabSupervisor *_tabSupervisor, AbstractClient *_client, ServerI
     aIgnoreUnregisteredUsers = chatSettingsMenu->addAction(QString());
     aIgnoreUnregisteredUsers->setCheckable(true);
     connect(aIgnoreUnregisteredUsers, SIGNAL(triggered()), this, SLOT(actIgnoreUnregisteredUsers()));
+    chatSettingsMenu->addSeparator();
+    aClearChat = chatSettingsMenu->addAction(QString());
+    connect(aClearChat, SIGNAL(triggered()), this, SLOT(actClearChat()));
     connect(settingsCache, SIGNAL(ignoreUnregisteredUsersChanged()), this, SLOT(ignoreUnregisteredUsersChanged()));    
     QToolButton *chatSettingsButton = new QToolButton;
     chatSettingsButton->setIcon(QIcon(":/resources/icon_settings.svg"));
@@ -114,6 +117,7 @@ void TabRoom::retranslateUi()
     roomMenu->setTitle(tr("&Room"));
     aLeaveRoom->setText(tr("&Leave room"));
     aIgnoreUnregisteredUsers->setText(tr("&Ignore unregistered users in chat"));
+    aClearChat->setText(tr("&Clear chat"));
 }
 
 void TabRoom::closeRequest()
@@ -170,6 +174,10 @@ void TabRoom::actIgnoreUnregisteredUsers()
 void TabRoom::ignoreUnregisteredUsersChanged()
 {
     aIgnoreUnregisteredUsers->setChecked(settingsCache->getIgnoreUnregisteredUsers());
+}
+
+void TabRoom::actClearChat() {
+    chatView->clearChat();
 }
 
 void TabRoom::processRoomEvent(const RoomEvent &event)

--- a/cockatrice/src/tab_room.h
+++ b/cockatrice/src/tab_room.h
@@ -44,6 +44,7 @@ private:
     QMenu *roomMenu;
     QAction *aLeaveRoom;
     QAction *aIgnoreUnregisteredUsers;
+    QAction * aClearChat;
     QString sanitizeHtml(QString dirty) const;
 signals:
     void roomClosing(TabRoom *tab);
@@ -53,6 +54,7 @@ private slots:
     void sayFinished(const Response &response);
     void actLeaveRoom();
     void actIgnoreUnregisteredUsers();
+    void actClearChat();
     void ignoreUnregisteredUsersChanged();
     
     void processListGamesEvent(const Event_ListGames &event);


### PR DESCRIPTION
Users can now clear the chat in the main lobby. This removes unwanted
text and clears up memory when the client has been open a long time.
![clear chat](https://cloud.githubusercontent.com/assets/2134793/5713377/dbc40be0-9abb-11e4-80c0-54b2d9a59749.png)