### PR TITLE
Sortable card views can now be split into pile types

### DIFF
--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -44,6 +44,8 @@ SettingsCache::SettingsCache()
 
     zoneViewSortByName = settings->value("zoneview/sortbyname", true).toBool();
     zoneViewSortByType = settings->value("zoneview/sortbytype", true).toBool();
+    zoneViewPileView = settings->value("zoneview/pileview", true).toBool();
+    zoneViewShuffle = settings->value("zoneview/shuffle", true).toBool();
 
     soundEnabled = settings->value("sound/enabled", false).toBool();
     soundPath = settings->value("sound/path").toString();
@@ -248,6 +250,16 @@ void SettingsCache::setZoneViewSortByType(int _zoneViewSortByType)
 {
     zoneViewSortByType = _zoneViewSortByType;
     settings->setValue("zoneview/sortbytype", zoneViewSortByType);
+}
+
+void SettingsCache::setZoneViewPileView(int _zoneViewPileView){
+    zoneViewPileView = _zoneViewPileView;
+    settings->setValue("zoneview/pileview", zoneViewPileView);
+}
+
+void SettingsCache::setZoneViewShuffle(int _zoneViewShuffle) {
+    zoneViewShuffle = _zoneViewShuffle;
+    settings->setValue("zoneview/shuffle", zoneViewShuffle);
 }
 
 void SettingsCache::setSoundEnabled(int _soundEnabled)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -55,7 +55,7 @@ private:
     int minPlayersForMultiColumnLayout;
     bool tapAnimation;
     bool chatMention;
-    bool zoneViewSortByName, zoneViewSortByType;
+    bool zoneViewSortByName, zoneViewSortByType, zoneViewPileView, zoneViewShuffle;
     bool soundEnabled;
     QString soundPath;
     bool priceTagFeature;
@@ -96,6 +96,8 @@ public:
     bool getChatMention()  const { return chatMention; }
     bool getZoneViewSortByName() const { return zoneViewSortByName; }
     bool getZoneViewSortByType() const { return zoneViewSortByType; }
+    bool getZoneViewPileView() const { return zoneViewPileView; }
+    bool getZoneViewShuffle() const { return zoneViewShuffle; }
     bool getSoundEnabled() const { return soundEnabled; }
     QString getSoundPath() const { return soundPath; }
     bool getPriceTagFeature() const { return priceTagFeature; }
@@ -136,6 +138,8 @@ public slots:
     void setChatMention(int _chatMention);
     void setZoneViewSortByName(int _zoneViewSortByName);
     void setZoneViewSortByType(int _zoneViewSortByType);
+    void setZoneViewPileView(int _zoneViewPileView);
+    void setZoneViewShuffle(int _zoneViewShuffle);
     void setSoundEnabled(int _soundEnabled);
     void setSoundPath(const QString &_soundPath);
     void setPriceTagFeature(int _priceTagFeature);

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -96,7 +96,15 @@ public:
     bool getChatMention()  const { return chatMention; }
     bool getZoneViewSortByName() const { return zoneViewSortByName; }
     bool getZoneViewSortByType() const { return zoneViewSortByType; }
+    /**
+       Returns if the view should be sorted into pile view.
+       @return zoneViewPileView if the view should be sorted into pile view.
+     */
     bool getZoneViewPileView() const { return zoneViewPileView; }
+    /**
+       Returns if the view should be shuffled on closing.
+       @return zoneViewShuffle if the view should be shuffled on closing.
+     */
     bool getZoneViewShuffle() const { return zoneViewShuffle; }
     bool getSoundEnabled() const { return soundEnabled; }
     QString getSoundPath() const { return soundPath; }

--- a/cockatrice/src/zoneviewwidget.cpp
+++ b/cockatrice/src/zoneviewwidget.cpp
@@ -123,6 +123,8 @@ ZoneViewWidget::ZoneViewWidget(Player *_player, CardZone *_origZone, int numberC
     zone = new ZoneViewZone(player, _origZone, numberCards, _revealZone, _writeableRevealZone, zoneContainer);
     connect(zone, SIGNAL(wheelEventReceived(QGraphicsSceneWheelEvent *)), this, SLOT(handleWheelEvent(QGraphicsSceneWheelEvent *)));
 
+    // numberCard is the num of cards we want to reveal from an area. Ex: scry the top 3 cards.
+    // If the number is < 0 then it means that we can make the area sorted and we dont care about the order.
     if (numberCards < 0) {
         connect(&sortByNameCheckBox, SIGNAL(stateChanged(int)), this, SLOT(processSortByName(int)));
         connect(&sortByTypeCheckBox, SIGNAL(stateChanged(int)), this, SLOT(processSortByType(int)));

--- a/cockatrice/src/zoneviewwidget.cpp
+++ b/cockatrice/src/zoneviewwidget.cpp
@@ -88,6 +88,13 @@ ZoneViewWidget::ZoneViewWidget(Player *_player, CardZone *_origZone, int numberC
         sortByTypeProxy->setWidget(&sortByTypeCheckBox);
         vbox->addItem(sortByTypeProxy);
 
+        QGraphicsProxyWidget *lineProxy = new QGraphicsProxyWidget;
+        QFrame *line = new QFrame;
+        line->setFrameShape(QFrame::HLine);
+        line->setFrameShadow(QFrame::Sunken);
+        lineProxy->setWidget(line);
+        vbox->addItem(lineProxy);
+
         QGraphicsProxyWidget *pileViewProxy = new QGraphicsProxyWidget;
         pileViewProxy->setWidget(&pileViewCheckBox);
         vbox->addItem(pileViewProxy);

--- a/cockatrice/src/zoneviewwidget.cpp
+++ b/cockatrice/src/zoneviewwidget.cpp
@@ -63,7 +63,7 @@ ZoneViewWidget::ZoneViewWidget(Player *_player, CardZone *_origZone, int numberC
     setAttribute(Qt::WA_DeleteOnClose);
     setZValue(2000000006);
     setFlag(ItemIgnoresTransformations);
-    
+
     QGraphicsLinearLayout *hbox = new QGraphicsLinearLayout(Qt::Horizontal);
     titleLabel = new TitleLabel;
     connect(titleLabel, SIGNAL(mouseMoved(QPointF)), this, SLOT(moveWidget(QPointF)));
@@ -72,47 +72,44 @@ ZoneViewWidget::ZoneViewWidget(Player *_player, CardZone *_origZone, int numberC
     closeButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     QGraphicsProxyWidget *closeButtonProxy = new QGraphicsProxyWidget;
     closeButtonProxy->setWidget(closeButton);
-    
+
     hbox->addItem(titleLabel);
     hbox->addItem(closeButtonProxy);
     QGraphicsLinearLayout *vbox = new QGraphicsLinearLayout(Qt::Vertical);
-    
+
     vbox->addItem(hbox);
-    
+
     if (numberCards < 0) {
-        sortByNameCheckBox = new QCheckBox;
         QGraphicsProxyWidget *sortByNameProxy = new QGraphicsProxyWidget;
-        sortByNameProxy->setWidget(sortByNameCheckBox);
+        sortByNameProxy->setWidget(&sortByNameCheckBox);
         vbox->addItem(sortByNameProxy);
 
-        sortByTypeCheckBox = new QCheckBox;
         QGraphicsProxyWidget *sortByTypeProxy = new QGraphicsProxyWidget;
-        sortByTypeProxy->setWidget(sortByTypeCheckBox);
+        sortByTypeProxy->setWidget(&sortByTypeCheckBox);
         vbox->addItem(sortByTypeProxy);
-    } else {
-        sortByNameCheckBox = 0;
-        sortByTypeCheckBox = 0;
+
+        QGraphicsProxyWidget *pileViewProxy = new QGraphicsProxyWidget;
+        pileViewProxy->setWidget(&pileViewCheckBox);
+        vbox->addItem(pileViewProxy);
     }
-    
+
     if (_origZone->getIsShufflable() && (numberCards == -1)) {
-        shuffleCheckBox = new QCheckBox;
-        shuffleCheckBox->setChecked(true);
+        shuffleCheckBox.setChecked(settingsCache->getZoneViewShuffle());
         QGraphicsProxyWidget *shuffleProxy = new QGraphicsProxyWidget;
-        shuffleProxy->setWidget(shuffleCheckBox);
+        shuffleProxy->setWidget(&shuffleCheckBox);
         vbox->addItem(shuffleProxy);
-    } else
-        shuffleCheckBox = 0;
-    
+    }
+
     extraHeight = vbox->sizeHint(Qt::PreferredSize).height();
     resize(150, 150);
-    
+
     QGraphicsLinearLayout *zoneHBox = new QGraphicsLinearLayout(Qt::Horizontal);
-    
+
     zoneContainer = new QGraphicsWidget(this);
     zoneContainer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     zoneContainer->setFlag(QGraphicsItem::ItemClipsChildrenToShape);
     zoneHBox->addItem(zoneContainer);
-    
+
     scrollBar = new QScrollBar(Qt::Vertical);
     scrollBar->setMinimum(0);
     scrollBar->setSingleStep(50);
@@ -120,36 +117,55 @@ ZoneViewWidget::ZoneViewWidget(Player *_player, CardZone *_origZone, int numberC
     QGraphicsProxyWidget *scrollBarProxy = new QGraphicsProxyWidget;
     scrollBarProxy->setWidget(scrollBar);
     zoneHBox->addItem(scrollBarProxy);
-    
+
     vbox->addItem(zoneHBox);
-    
+
     zone = new ZoneViewZone(player, _origZone, numberCards, _revealZone, _writeableRevealZone, zoneContainer);
     connect(zone, SIGNAL(wheelEventReceived(QGraphicsSceneWheelEvent *)), this, SLOT(handleWheelEvent(QGraphicsSceneWheelEvent *)));
-    
-    if (sortByNameCheckBox) {
-        connect(sortByNameCheckBox, SIGNAL(stateChanged(int)), zone, SLOT(setSortByName(int)));
-        connect(sortByTypeCheckBox, SIGNAL(stateChanged(int)), zone, SLOT(setSortByType(int)));
-        sortByNameCheckBox->setChecked(settingsCache->getZoneViewSortByName());
-        sortByTypeCheckBox->setChecked(settingsCache->getZoneViewSortByType());
+
+    if (numberCards < 0) {
+        connect(&sortByNameCheckBox, SIGNAL(stateChanged(int)), this, SLOT(processSortByName(int)));
+        connect(&sortByTypeCheckBox, SIGNAL(stateChanged(int)), this, SLOT(processSortByType(int)));
+        connect(&pileViewCheckBox, SIGNAL(stateChanged(int)), this, SLOT(processSetPileView(int)));
+        sortByNameCheckBox.setChecked(settingsCache->getZoneViewSortByName());
+        sortByTypeCheckBox.setChecked(settingsCache->getZoneViewSortByType());
+        pileViewCheckBox.setChecked(settingsCache->getZoneViewPileView());
+        if (!settingsCache->getZoneViewSortByType())
+            pileViewCheckBox.setEnabled(false);
     }
 
     retranslateUi();
     setLayout(vbox);
-    
+
     connect(zone, SIGNAL(optimumRectChanged()), this, SLOT(resizeToZoneContents()));
     connect(zone, SIGNAL(beingDeleted()), this, SLOT(zoneDeleted()));
     zone->initializeCards(cardList);
 }
 
+void ZoneViewWidget::processSortByType(int value) {
+    pileViewCheckBox.setEnabled(value);
+    settingsCache->setZoneViewSortByType(value);
+    zone->setPileView(pileViewCheckBox.isChecked());
+    zone->setSortByType(value);
+}
+
+void ZoneViewWidget::processSortByName(int value) {
+    settingsCache->setZoneViewSortByName(value);
+    zone->setSortByName(value);
+}
+
+void ZoneViewWidget::processSetPileView(int value) {
+    settingsCache->setZoneViewPileView(value);
+    zone->setPileView(value);
+}
+
 void ZoneViewWidget::retranslateUi()
 {
     titleLabel->setText(zone->getTranslatedName(false, CaseNominative));
-    if (sortByNameCheckBox)
-        sortByNameCheckBox->setText(tr("sort by name"));
-    if (sortByTypeCheckBox)
-        sortByTypeCheckBox->setText(tr("sort by type"));
-    if (shuffleCheckBox)
-        shuffleCheckBox->setText(tr("shuffle when closing"));
+    sortByNameCheckBox.setText(tr("sort by name"));
+    sortByTypeCheckBox.setText(tr("sort by type"));
+    shuffleCheckBox.setText(tr("shuffle when closing"));
+    pileViewCheckBox.setText(tr("pile view"));
 }
 
 void ZoneViewWidget::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
@@ -172,10 +188,10 @@ void ZoneViewWidget::resizeToZoneContents()
     QSizeF newSize(qMax(QGraphicsWidget::layout()->effectiveSizeHint(Qt::MinimumSize, QSizeF()).width(), zoneRect.width() + scrollBar->width() + 10), zoneRect.height() + extraHeight + 10);
     setMaximumSize(newSize);
     resize(newSize);
-    
+
     zone->setGeometry(QRectF(0, -scrollBar->value(), zoneContainer->size().width(), totalZoneHeight));
     scrollBar->setMaximum(totalZoneHeight - zoneRect.height());
-    
+
     if (layout())
         layout()->invalidate();
 }
@@ -200,9 +216,9 @@ void ZoneViewWidget::closeEvent(QCloseEvent *event)
         cmd.set_zone_name(zone->getName().toStdString());
         player->sendGameCommand(cmd);
     }
-    if (shuffleCheckBox)
-        if (shuffleCheckBox->isChecked())
-            player->sendGameCommand(Command_Shuffle());
+    if (shuffleCheckBox.isChecked()) 
+        player->sendGameCommand(Command_Shuffle());
+    settingsCache->setZoneViewShuffle(shuffleCheckBox.isChecked());
     emit closePressed(this);
     deleteLater();
     event->accept();

--- a/cockatrice/src/zoneviewwidget.h
+++ b/cockatrice/src/zoneviewwidget.h
@@ -2,6 +2,7 @@
 #define ZONEVIEWWIDGET_H
 
 #include <QGraphicsWidget>
+#include <QCheckBox>
 
 class QLabel;
 class QPushButton;
@@ -42,13 +43,19 @@ private:
     TitleLabel *titleLabel;
     QPushButton *closeButton;
     QScrollBar *scrollBar;
-    QCheckBox *sortByNameCheckBox, *sortByTypeCheckBox, *shuffleCheckBox;
+    QCheckBox sortByNameCheckBox;
+    QCheckBox sortByTypeCheckBox;
+    QCheckBox shuffleCheckBox;
+    QCheckBox pileViewCheckBox;
     
     int extraHeight;
     Player *player;
 signals:
     void closePressed(ZoneViewWidget *zv);
 private slots:
+    void processSortByType(int value);
+    void processSortByName(int value);
+    void processSetPileView(int value);
     void resizeToZoneContents();
     void handleWheelEvent(QGraphicsSceneWheelEvent *event);
     void handleScrollBarChange(int value);

--- a/cockatrice/src/zoneviewzone.cpp
+++ b/cockatrice/src/zoneviewzone.cpp
@@ -120,8 +120,8 @@ void ZoneViewZone::reorganizeCards()
     
     qreal aleft = 0;
     qreal atop = 0;
-    qreal awidth = (pileView && sortByType) ? qMax(typeColumn + 1, 3) * CARD_WIDTH + 20 : qMax(cols, 1) * CARD_WIDTH + 20;
-    qreal aheight = (pileView && sortByType) ? ((longestRow - 1) * CARD_HEIGHT) / 3 + CARD_HEIGHT + 60 : ((rows - 1) * CARD_HEIGHT) / 3 + CARD_HEIGHT + 20;
+    qreal awidth = (pileView && sortByType) ? qMax(typeColumn + 1, 3) * CARD_WIDTH + (CARD_WIDTH/2) : qMax(cols, 1) * CARD_WIDTH + (CARD_WIDTH/2);
+    qreal aheight = (pileView && sortByType) ? (longestRow * CARD_HEIGHT) / 3 + CARD_HEIGHT * 1.3 : (rows * CARD_HEIGHT) / 3 + CARD_HEIGHT * 1.3;
     optimumRect = QRectF(aleft, atop, awidth, aheight);
 
     updateGeometry();

--- a/cockatrice/src/zoneviewzone.cpp
+++ b/cockatrice/src/zoneviewzone.cpp
@@ -118,10 +118,12 @@ void ZoneViewZone::reorganizeCards()
         }
     }
     
-    if (pileView && sortByType)
-        optimumRect = QRectF(0, 0, qMax(typeColumn + 1, 3) * CARD_WIDTH + 20, ((longestRow - 1) * CARD_HEIGHT) / 3 + CARD_HEIGHT + 60);
-    else 
-        optimumRect = QRectF(0, 0, qMax(cols, 1) * CARD_WIDTH + 20, ((rows - 1) * CARD_HEIGHT) / 3 + CARD_HEIGHT + 20);
+    qreal aleft = 0;
+    qreal atop = 0;
+    qreal awidth = (pileView && sortByType) ? qMax(typeColumn + 1, 3) * CARD_WIDTH + 20 : qMax(cols, 1) * CARD_WIDTH + 20;
+    qreal aheight = (pileView && sortByType) ? ((longestRow - 1) * CARD_HEIGHT) / 3 + CARD_HEIGHT + 60 : ((rows - 1) * CARD_HEIGHT) / 3 + CARD_HEIGHT + 20;
+    optimumRect = QRectF(aleft, atop, awidth, aheight);
+
     updateGeometry();
     emit optimumRectChanged();
 }
@@ -134,7 +136,7 @@ void ZoneViewZone::setPileViewPositions(int cardCount, CardList &cardsToDisplay,
         QString cardType = c->getInfo()->getMainCardType();
 
         if (i){
-            // last card and this card have a matching main type?
+            // if not the first card. Last card and this card have a matching main type?
             cardTypeMatch = cardType.compare(cardsToDisplay.at(i-1)->getInfo()->getMainCardType()) == 0 ? true : false;
             if (!cardTypeMatch) { // if no match then move card to next column
                 typeColumn++;

--- a/cockatrice/src/zoneviewzone.h
+++ b/cockatrice/src/zoneviewzone.h
@@ -19,12 +19,17 @@ private:
     CardZone *origZone;
     bool revealZone, writeableRevealZone;
     bool sortByName, sortByType;
+    bool pileView;
 public:
     ZoneViewZone(Player *_p, CardZone *_origZone, int _numberCards = -1, bool _revealZone = false, bool _writeableRevealZone = false, QGraphicsItem *parent = 0);
     ~ZoneViewZone();
     QRectF boundingRect() const;
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
     void reorganizeCards();
+
+    void setPileViewPositions(int cardCount, CardList &cardsToDisplay, int &typeColumn, int &longestRow);
+    
+
     void initializeCards(const QList<const ServerInfo_Card *> &cardList = QList<const ServerInfo_Card *>());
     void removeCard(int position);
     int getNumberCards() const { return numberCards; }
@@ -36,6 +41,7 @@ public:
 public slots:
     void setSortByName(int _sortByName);
     void setSortByType(int _sortByType);
+    void setPileView(int _pileView);
 private slots:
     void zoneDumpReceived(const Response &r);
 signals:


### PR DESCRIPTION
+ When viewing a sorted card view (like revealing hand, or looking at library), the cards will now be sorted in columns based on the main card type.
+ check box added to enable/disable
+ users **can not** have "pile view" without "sort-by-type" enabled. For this reason the "pile view" becomes disabled when "sort-by-type" is not checked.
+ **BONUS:** check box states are now stored and will be the same when reopeing zone.
Welcome to the future boys!

**Before:**
![before sorting](https://cloud.githubusercontent.com/assets/2134793/5722786/7370770c-9b3f-11e4-8f9c-2dab7edd90cf.png)


**After:**
![after sorting](https://cloud.githubusercontent.com/assets/2134793/5722782/6ee0a9fa-9b3f-11e4-8822-0ee47bde0ebc.png)
