### PR TITLE
Username block highlighting

### DIFF
--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -183,7 +183,7 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
             int mentionIndex;
             while ((mentionIndex = message.toLower().indexOf(mention)) != -1) {
                 cursor.insertText(message.left(mentionIndex), defaultFormat);
-                cursor.insertText(userName, mentionFormat);
+                cursor.insertText("@" + userName, mentionFormat);
                 message = message.mid(mentionIndex + mention.size());
             }
         } 

--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -18,6 +18,13 @@ ChatView::ChatView(const TabSupervisor *_tabSupervisor, TabGame *_game, bool _sh
     userContextMenu = new UserContextMenu(tabSupervisor, this, game);
     connect(userContextMenu, SIGNAL(openMessageDialog(QString, bool)), this, SIGNAL(openMessageDialog(QString, bool)));
     
+    userName = QString::fromStdString(tabSupervisor->getUserInfo()->name());
+    mention = "@" + userName.toLower();
+
+    mentionFormat.setFontWeight(QFont::Bold);
+    mentionFormat.setForeground(QBrush(Qt::white));
+    mentionFormat.setBackground(QBrush(QColor(190, 25, 85)));
+
     viewport()->setCursor(Qt::IBeamCursor);
     setReadOnly(true);
     setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::LinksAccessibleByMouse);
@@ -104,7 +111,7 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
     QTextCharFormat senderFormat;
     if (tabSupervisor && tabSupervisor->getUserInfo() && (sender == QString::fromStdString(tabSupervisor->getUserInfo()->name()))) {
         senderFormat.setFontWeight(QFont::Bold);
-        senderFormat.setForeground(QBrush(QColor(255, 120, 0)));
+        senderFormat.setForeground(QBrush(QColor(190, 25, 85)));
     } else {
         senderFormat.setForeground(Qt::blue);
         if (playerBold)
@@ -172,15 +179,19 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
     }
 
     if (settingsCache->getChatMention()) {
-        if (message.toLower().contains("@" + QString::fromStdString(tabSupervisor->getUserInfo()->name()).toLower())) {
-            messageFormat.setFontWeight(QFont::Bold);
-            messageFormat.setForeground(QBrush(QColor(255, 120, 0)));
+        if (message.toLower().contains(mention)) {
+            int mentionIndex;
+            while ((mentionIndex = message.toLower().indexOf(mention)) != -1) {
+                cursor.insertText(message.left(mentionIndex), defaultFormat);
+                cursor.insertText(userName, mentionFormat);
+                message = message.mid(mentionIndex + mention.size());
+            }
         } 
     }
 
     if (!message.isEmpty())
-        cursor.insertText(message, messageFormat);
-    
+        cursor.insertText(message, defaultFormat);
+
     if (atBottom)
         verticalScrollBar()->setValue(verticalScrollBar()->maximum());
 }

--- a/cockatrice/src/chatview.h
+++ b/cockatrice/src/chatview.h
@@ -22,6 +22,10 @@ private:
     enum HoveredItemType { HoveredNothing, HoveredUrl, HoveredCard, HoveredUser };
     UserContextMenu *userContextMenu;
     QString lastSender;
+    QString userName;
+    QString mention;
+    QTextCharFormat mentionFormat;
+    QTextCharFormat defaultFormat;
     bool evenNumber;
     bool showTimestamps;
     HoveredItemType hoveredItemType;


### PR DESCRIPTION
I was able to find a simple way to achive the block highlighting.
You will see that only some of the **test**s are highlighted. The ones that are have been used with the @
 symbol which as been parsed out.
![username block](https://cloud.githubusercontent.com/assets/2134793/5788806/1a8fa42c-9e4c-11e4-81db-bb82fa75784a.png)
Also, a lot of users found the orange hard to see, so i have make it a dark pink instead. This will be the default color, but will be configurable in an upcoming update.