### PR TITLE
Fixed shuffle issue

### DIFF
--- a/cockatrice/src/zoneviewwidget.cpp
+++ b/cockatrice/src/zoneviewwidget.cpp
@@ -57,7 +57,7 @@ void TitleLabel::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 }
 
 ZoneViewWidget::ZoneViewWidget(Player *_player, CardZone *_origZone, int numberCards, bool _revealZone, bool _writeableRevealZone, const QList<const ServerInfo_Card *> &cardList)
-    : QGraphicsWidget(0, Qt::Tool | Qt::FramelessWindowHint), player(_player)
+    : QGraphicsWidget(0, Qt::Tool | Qt::FramelessWindowHint), player(_player), canBeShuffled(_origZone->getIsShufflable())
 {
     setAcceptHoverEvents(true);
     setAttribute(Qt::WA_DeleteOnClose);
@@ -227,7 +227,8 @@ void ZoneViewWidget::closeEvent(QCloseEvent *event)
     }
     if (shuffleCheckBox.isChecked()) 
         player->sendGameCommand(Command_Shuffle());
-    settingsCache->setZoneViewShuffle(shuffleCheckBox.isChecked());
+    if (canBeShuffled)
+        settingsCache->setZoneViewShuffle(shuffleCheckBox.isChecked());
     emit closePressed(this);
     deleteLater();
     event->accept();

--- a/cockatrice/src/zoneviewwidget.h
+++ b/cockatrice/src/zoneviewwidget.h
@@ -48,6 +48,7 @@ private:
     QCheckBox shuffleCheckBox;
     QCheckBox pileViewCheckBox;
     
+    bool canBeShuffled;
     int extraHeight;
     Player *player;
 signals:


### PR DESCRIPTION
when closing a view we save the current settings. I added a check to
only update the shuffle settings if the zone we are closing can be
shuffled. #591 