### PR TITLE
2 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@ such as Magic: The Gathering, over a network. It is fully client-server based
 to prevent any kind of cheating, though it supports single-player games without
 a network interface as well. Both client and server are written in Qt, supporting both Qt4 and Qt5.
 
-# Get Involved
+# Get Involved [![Gitter chat](https://badges.gitter.im/Cockatrice/Cockatrice.png)](https://gitter.im/Cockatrice/Cockatrice)
 
 Chat with the Cockatrice developers on Gitter. Come here to talk about the application, features, or just to hang out. For support regarding specific servers, please contact that server's admin or forum for support rather than asking here.
 
-[![Gitter chat](https://badges.gitter.im/Cockatrice/Cockatrice.png)](https://gitter.im/Cockatrice/Cockatrice)
+# Community Resources
+- [reddit r/Cockatrice](http://reddit.com/r/cockatrice)
+- [Woogerworks Server & Forums](http://www.woogerworks.com)
+- [Cockatrice Official Wiki](https://github.com/Cockatrice/Cockatrice/wiki)
 
-# Building
-
-[![Build Status](https://travis-ci.org/Cockatrice/Cockatrice.svg?branch=master)](https://travis-ci.org/Cockatrice/Cockatrice)
+# Building [![Build Status](https://travis-ci.org/Cockatrice/Cockatrice.svg?branch=master)](https://travis-ci.org/Cockatrice/Cockatrice)
 
 **Detailed installation instructions are on the Cockatrice wiki under [Installing Cockatrice](https://github.com/Cockatrice/Cockatrice/wiki/Installing-Cockatrice)**
 
@@ -49,11 +50,6 @@ The following flags can be passed to `cmake`:
 `oracle` fetches card data  
 `cockatrice` is the game client  
 `servatrice` is the server
-
-# Community Resources
-- [reddit r/Cockatrice](http://reddit.com/r/cockatrice)
-- [Woogerworks Server & Forums](http://www.woogerworks.com)
-- [Cockatrice Official Wiki](https://github.com/Cockatrice/Cockatrice/wiki)
 
 # License
 


### PR DESCRIPTION
Messed title up. This is about README.md file

2nd try

- moved "Community Resources" up as talked about here 7e92b4e7df027164b8c4f5521a0978d59e770fa3
- moved Gitter and Travis buttons for cleaner and nicer look