### PR TITLE
Block Unregistered Users Private Messages

### DIFF
--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -450,18 +450,27 @@ void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)
     
     UserListTWI *twi = tabUserLists->getAllUsersList()->getUsers().value(senderName);
 
-    ServerInfo_User otherUser;
+    ServerInfo_User Self;
 
     if (twi)
-        otherUser = twi->getUserInfo();
+        Self = twi->getUserInfo();
     else
-        otherUser.set_name(senderName.toStdString());
+        Self.set_name(senderName.toStdString());
 
     UserLevelFlags SelfLevel = UserLevelFlags(Self.user_level());
 
-    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsUser)) || !SelfLevel.testFlag(ServerInfo_User::IsRegistered)) || !SelfLevel.testFlag(ServerInfo_User::IsModerator)) || !SelfLevel.testFlag(ServerInfo_User::IsAdmin))
+    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsUser))
         return;
         
+    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsRegistered))
+        return;
+        
+    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsModerator))
+        return;
+        
+    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsAdmin))
+        return;
+    
 TabMessage *tab = messageTabs.value(senderName);
     if (!tab)
         tab = messageTabs.value(QString::fromStdString(event.receiver_name()));

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -459,18 +459,9 @@ void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)
 
     UserLevelFlags SelfLevel = UserLevelFlags(Self.user_level());
 
-    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsNormal))
-        return;
-    
-    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsRegistered))
+    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsUser)) || !SelfLevel.testFlag(ServerInfo_User::IsRegistered)) || !SelfLevel.testFlag(ServerInfo_User::IsModerator)) || !SelfLevel.testFlag(ServerInfo_User::IsAdmin))
         return;
         
-    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsModerator))
-        return;
-        
-    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsAdmin))
-        return;
-
 TabMessage *tab = messageTabs.value(senderName);
     if (!tab)
         tab = messageTabs.value(QString::fromStdString(event.receiver_name()));

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -450,12 +450,12 @@ void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)
     
     UserListTWI *twi = tabUserLists->getAllUsersList()->getUsers().value(senderName);
 
-    ServerInfo_User Self;
+    ServerInfo_User otherUser;
 
     if (twi)
-        Self = twi->getUserInfo();
+        otherUser = twi->getUserInfo();
     else
-        Self.set_name(senderName.toStdString());
+        otherUser.set_name(senderName.toStdString());
 
     UserLevelFlags SelfLevel = UserLevelFlags(Self.user_level());
 

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -459,7 +459,7 @@ void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)
 
     UserLevelFlags SelfLevel = UserLevelFlags(Self.user_level());
 
-    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsUnegistered))
+    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsNormal))
         return;
     
     if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsRegistered))
@@ -468,7 +468,7 @@ void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)
     if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsModerator))
         return;
         
-    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsAdministrator))
+    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsAdmin))
         return;
 
 TabMessage *tab = messageTabs.value(senderName);

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -459,17 +459,8 @@ void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)
 
     UserLevelFlags SelfLevel = UserLevelFlags(Self.user_level());
 
-    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsUser))
-        return;
-        
-    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsRegistered))
-        return;
-        
-    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsModerator))
-        return;
-        
-    if (settingsCache->getIgnoreUnregisteredUsers() && !SelfLevel.testFlag(ServerInfo_User::IsAdmin))
-        return;
+     if (settingsCache->getIgnoreUnregisteredUsers() && (!SelfLevel.testFlag(ServerInfo_User::IsUser) || !SelfLevel.testFlag(ServerInfo_User::IsRegistered) || !SelfLevel.testFlag(ServerInfo_User::IsModerator) || !SelfLevel.testFlag(ServerInfo_User::IsAdmin)))
+        return; 
     
 TabMessage *tab = messageTabs.value(senderName);
     if (!tab)

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -365,13 +365,13 @@ TabMessage *TabSupervisor::addMessageTab(const QString &receiverName, bool focus
     if (receiverName == QString::fromStdString(userInfo->name()))
         return 0;
     
-    ServerInfo_User Self;
+    ServerInfo_User otherUser;
     UserListTWI *twi = tabUserLists->getAllUsersList()->getUsers().value(receiverName);
     if (twi)
-        Self = twi->getUserInfo();
+        otherUser = twi->getUserInfo();
     else
-        Self.set_name(receiverName.toStdString());
-    TabMessage *tab = new TabMessage(this, client, *userInfo, Self);
+        otherUser.set_name(receiverName.toStdString());
+    TabMessage *tab = new TabMessage(this, client, *userInfo, otherUser);
     connect(tab, SIGNAL(talkClosing(TabMessage *)), this, SLOT(talkLeft(TabMessage *)));
     int tabIndex = myAddTab(tab);
     addCloseButtonToTab(tab, tabIndex);


### PR DESCRIPTION
#575 with the ability to ignore at all user levels (Admin, Moderator, Registered, and Unregistered), instead of just Registered. Also, the variable has been changed to be more clear (that is, that you are blocking them).