### PR TITLE
Block private messages from unregistered users

### DIFF
--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -454,13 +454,10 @@ void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)
 
     if (twi)
         sendingUser = twi->getUserInfo();
+        if (settingsCache->getIgnoreUnregisteredUsers())
+            return;
     else
         sendingUser.set_name(senderName.toStdString());
-
-    UserLevelFlags sendingUserLevel = UserLevelFlags(sendingUser.user_level());
-
-    if (settingsCache->getIgnoreUnregisteredUsers() && (!sendingUserLevel.testFlag(ServerInfo_User::IsUser) || !sendingUserLevel.testFlag(ServerInfo_User::IsRegistered) || !sendingUserLevel.testFlag(ServerInfo_User::IsModerator) || !sendingUserLevel.testFlag(ServerInfo_User::IsAdmin)))
-        return;
 
 TabMessage *tab = messageTabs.value(senderName);
     if (!tab)

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -446,11 +446,27 @@ void TabSupervisor::processGameEventContainer(const GameEventContainer &cont)
 
 void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)
 {
-    TabMessage *tab = messageTabs.value(QString::fromStdString(event.sender_name()));
+    QString senderName = QString::fromStdString(event.sender_name());
+
+    UserListTWI *twi = tabUserLists->getAllUsersList()->getUsers().value(senderName);
+
+    ServerInfo_User sendingUser;
+
+    if (twi)
+        sendingUser = twi->getUserInfo();
+    else
+        sendingUser.set_name(senderName.toStdString());
+
+    UserLevelFlags sendingUserLevel = UserLevelFlags(sendingUser.user_level());
+
+    if (settingsCache->getIgnoreUnregisteredUsers() && (!sendingUserLevel.testFlag(ServerInfo_User::IsUser) || !sendingUserLevel.testFlag(ServerInfo_User::IsRegistered) || !sendingUserLevel.testFlag(ServerInfo_User::IsModerator) || !sendingUserLevel.testFlag(ServerInfo_User::IsAdmin)))
+        return;
+
+TabMessage *tab = messageTabs.value(senderName);
     if (!tab)
         tab = messageTabs.value(QString::fromStdString(event.receiver_name()));
     if (!tab)
-        tab = addMessageTab(QString::fromStdString(event.sender_name()), false);
+        tab = addMessageTab(senderName, false);
     if (!tab)
         return;
     tab->processUserMessageEvent(event);


### PR DESCRIPTION
Variables have been changed to be more clear. Tested on Moderator level, Registered level, and Unregistered accounts, and it works for all three.