### PR TITLE
Refix #558, Fix #631

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -50,11 +50,6 @@ GeneralSettingsPage::GeneralSettingsPage()
     pixmapCacheEdit.setSingleStep(64);
     pixmapCacheEdit.setValue(settingsCache->getPixmapCacheSize());
     pixmapCacheEdit.setSuffix(" MB");
-    pixmapCacheEdit.setMinimum(64);
-    pixmapCacheEdit.setMaximum(8192);
-    pixmapCacheEdit.setSingleStep(64);
-    pixmapCacheEdit.setValue(settingsCache->getPixmapCacheSize());
-    pixmapCacheEdit.setSuffix(" MB");
     picDownloadHqCheckBox.setChecked(settingsCache->getPicDownloadHq());
     picDownloadCheckBox.setChecked(settingsCache->getPicDownload());
 


### PR DESCRIPTION
#558 added limits for pixmap cache size in the settings dialog
Commit 931b4203235da88450ec9ab80a0fdd36a804b933 contained a previous version of the code, and the merge ended up duplicating both the old and the new code
This PR removes the old code, restoring the functionality from #558