### PR TITLE
add oracle name at the end of installer

### DIFF
--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -16,7 +16,7 @@ InstallDir "$PROGRAMFILES\Cockatrice"
 !define MUI_HEADERIMAGE_UNBITMAP "${NSIS_SOURCE_PATH}\cmake\headerimage.bmp"
 !define MUI_WELCOMEPAGE_TEXT "This wizard will guide you through the installation of Cockatrice.$\r$\n$\r$\nClick Next to continue."
 !define MUI_FINISHPAGE_RUN "$INSTDIR/oracle.exe"
-!define MUI_FINISHPAGE_RUN_TEXT "Run card database downloader now"
+!define MUI_FINISHPAGE_RUN_TEXT "Run "Oracle" now to update your card database"
 !define MUI_FINISHPAGE_RUN_PARAMETERS "-dlsets"
 
 !insertmacro MUI_PAGE_WELCOME


### PR DESCRIPTION
If you've finished the installation of Cockatrice and are about to close the setup wizard there is this info text about running the "cards.xml building tool".

Run card database downloader now
vs.
Run "Oracle" now to update your card database

This gives people at least some kind of connection and an idea what Oracle is and what we use it for.
They keep asking about Oracle every time a new set comes out. "rerun Oracle" - "hmm? what's that?" ...
That's no solution to this for sure, but it helps a bit and is a valid interface tweak anyway in my opinion. :)

Thought about adding even more information like:
"Oracle is located here xyz and you can run it every time a new set comes out to check for updates. You should run it too, if you think your cards.xml file will need an update or is broken"