### PR TITLE
Chat mention color

### DIFF
--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -116,9 +116,7 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
     
     QTextCharFormat senderFormat;
     if (tabSupervisor && tabSupervisor->getUserInfo() && (sender == QString::fromStdString(tabSupervisor->getUserInfo()->name()))) {
-        QColor customColor;
-        customColor.setNamedColor("#" + settingsCache->getChatMentionColor());
-        senderFormat.setForeground(customColor.isValid() ? QBrush(customColor) : QBrush(DEFAULT_MENTION_COLOR));
+        senderFormat.setForeground(QBrush(getCustomMentionColor()));
         senderFormat.setFontWeight(QFont::Bold);
     } else {
         senderFormat.setForeground(QBrush(OTHER_USER_COLOR));
@@ -195,9 +193,7 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
                 break;
             // you have been mentioned
             if (message.toLower().startsWith(mention)) {
-                QColor customColor;
-                customColor.setNamedColor("#" + settingsCache->getChatMentionColor());
-                mentionFormat.setBackground(customColor.isValid() ? QBrush(customColor) : QBrush(DEFAULT_MENTION_COLOR));
+                mentionFormat.setBackground(QBrush(getCustomMentionColor()));
                 mentionFormat.setForeground(settingsCache->getChatMentionForeground() ? QBrush(Qt::white):QBrush(Qt::black));
                 cursor.insertText("@" + userName, mentionFormat);
                 message = message.mid(mention.size());
@@ -229,6 +225,12 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
 
     if (atBottom)
         verticalScrollBar()->setValue(verticalScrollBar()->maximum());
+}
+
+QColor ChatView::getCustomMentionColor() {
+    QColor customColor;
+    customColor.setNamedColor("#" + settingsCache->getChatMentionColor());
+    return customColor.isValid() ? customColor : DEFAULT_MENTION_COLOR;
 }
 
 /**

--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -12,7 +12,7 @@
 #include "main.h"
 #include "tab_userlists.h"
 
-const QColor MENTION_COLOR = QColor(190, 25, 85); // maroon
+const QColor DEFAULT_MENTION_COLOR = QColor(194, 31, 47);
 const QColor OTHER_USER_COLOR = QColor(0, 65, 255); // dark blue
 
 ChatView::ChatView(const TabSupervisor *_tabSupervisor, TabGame *_game, bool _showTimestamps, QWidget *parent)
@@ -26,8 +26,6 @@ ChatView::ChatView(const TabSupervisor *_tabSupervisor, TabGame *_game, bool _sh
     mention = "@" + userName.toLower();
 
     mentionFormat.setFontWeight(QFont::Bold);
-    mentionFormat.setForeground(QBrush(Qt::white));
-    mentionFormat.setBackground(QBrush(MENTION_COLOR));
 
     mentionFormatOtherUser.setFontWeight(QFont::Bold);
     mentionFormatOtherUser.setForeground(Qt::blue);
@@ -118,8 +116,10 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
     
     QTextCharFormat senderFormat;
     if (tabSupervisor && tabSupervisor->getUserInfo() && (sender == QString::fromStdString(tabSupervisor->getUserInfo()->name()))) {
+        QColor customColor;
+        customColor.setNamedColor("#" + settingsCache->getChatMentionColor());
+        senderFormat.setForeground(customColor.isValid() ? QBrush(customColor) : QBrush(DEFAULT_MENTION_COLOR));
         senderFormat.setFontWeight(QFont::Bold);
-        senderFormat.setForeground(QBrush(MENTION_COLOR));
     } else {
         senderFormat.setForeground(QBrush(OTHER_USER_COLOR));
         if (playerBold)
@@ -195,6 +195,10 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
                 break;
             // you have been mentioned
             if (message.toLower().startsWith(mention)) {
+                QColor customColor;
+                customColor.setNamedColor("#" + settingsCache->getChatMentionColor());
+                mentionFormat.setBackground(customColor.isValid() ? QBrush(customColor) : QBrush(DEFAULT_MENTION_COLOR));
+                mentionFormat.setForeground(settingsCache->getChatMentionForeground() ? QBrush(Qt::white):QBrush(Qt::black));
                 cursor.insertText("@" + userName, mentionFormat);
                 message = message.mid(mention.size());
                 QApplication::alert(this);

--- a/cockatrice/src/chatview.h
+++ b/cockatrice/src/chatview.h
@@ -37,6 +37,7 @@ private:
     void appendCardTag(QTextCursor &cursor, const QString &cardName);
     void appendUrlTag(QTextCursor &cursor, QString url);
     QString getNameFromUserList(QMap<QString, UserListTWI *> &userList, QString &userName);
+    QColor getCustomMentionColor();
 private slots:
     void openLink(const QUrl &link);
 public:

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -566,7 +566,6 @@ void DeckEditorSettingsPage::radioPriceTagSourceClicked(bool checked)
 
 MessagesSettingsPage::MessagesSettingsPage()
 {
-
     chatMentionCheckBox.setChecked(settingsCache->getChatMention());
     connect(&chatMentionCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setChatMention(int)));
     
@@ -574,18 +573,18 @@ MessagesSettingsPage::MessagesSettingsPage()
     connect(&ignoreUnregUsersMainChat, SIGNAL(stateChanged(int)), settingsCache, SLOT(setIgnoreUnregisteredUsers(int)));
     
     invertMentionForeground.setChecked(settingsCache->getChatMentionForeground());
-    connect(&invertMentionForeground, SIGNAL(stateChanged(int)), settingsCache, SLOT(setChatMentionForeground(int)));
+    connect(&invertMentionForeground, SIGNAL(stateChanged(int)), this, SLOT(updateTextColor(int)));
 
     mentionColor = new QLineEdit();
     mentionColor->setText(settingsCache->getChatMentionColor());
-    connect(mentionColor, SIGNAL(textChanged(QString)), settingsCache, SLOT(setChatMentionColor(QString)));
+    updateMentionPreview();
+    connect(mentionColor, SIGNAL(textChanged(QString)), this, SLOT(updateColor(QString)));
 
     QGridLayout *chatGrid = new QGridLayout;
     chatGrid->addWidget(&chatMentionCheckBox, 0, 0);
-    chatGrid->addWidget(&mentionColorLabel, 1, 0);
-    chatGrid->addWidget(mentionColor, 1, 1);
-    chatGrid->addWidget(&invertMentionForeground, 2, 0);
-    chatGrid->addWidget(&ignoreUnregUsersMainChat, 3, 0);
+    chatGrid->addWidget(&invertMentionForeground, 0, 1);
+    chatGrid->addWidget(mentionColor, 0, 2);
+    chatGrid->addWidget(&ignoreUnregUsersMainChat, 1, 0);
     
     chatGroupBox = new QGroupBox;
     chatGroupBox->setLayout(chatGrid);
@@ -624,6 +623,25 @@ MessagesSettingsPage::MessagesSettingsPage()
     retranslateUi();
 }
 
+void MessagesSettingsPage::updateColor(const QString &value) {
+    QColor colorToSet;
+    colorToSet.setNamedColor("#" + value);
+    if (colorToSet.isValid()) {
+        settingsCache->setChatMentionColor(value);
+        updateMentionPreview();
+    }
+}
+
+void MessagesSettingsPage::updateTextColor(int value) {
+    settingsCache->setChatMentionForeground(value);
+    updateMentionPreview();
+}
+
+void MessagesSettingsPage::updateMentionPreview() {
+    mentionColor->setStyleSheet("QLineEdit{background:#" + settingsCache->getChatMentionColor() + 
+        ";color: " + (settingsCache->getChatMentionForeground() ? "white" : "black") + ";}");
+}
+
 void MessagesSettingsPage::storeSettings()
 {
     QSettings settings;
@@ -656,11 +674,10 @@ void MessagesSettingsPage::retranslateUi()
     aAdd->setText(tr("&Add"));
     aRemove->setText(tr("&Remove"));
     chatGroupBox->setTitle(tr("Chat settings"));
-    chatMentionCheckBox.setText(tr("Enable chat mentions ('@yourusername' in chat log will be highlighted)"));
+    chatMentionCheckBox.setText(tr("Enable chat mentions"));
     messageShortcuts->setTitle(tr("In-game message macros"));
     ignoreUnregUsersMainChat.setText(tr("Ignore unregistered users in main chat"));
-    mentionColorLabel.setText(tr("Username/Mention color:"));
-    invertMentionForeground.setText(tr("Invert mention text color (white)"));
+    invertMentionForeground.setText(tr("Invert text color"));
 }
 
 DlgSettings::DlgSettings(QWidget *parent)

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -573,9 +573,20 @@ MessagesSettingsPage::MessagesSettingsPage()
     ignoreUnregUsersMainChat.setChecked(settingsCache->getIgnoreUnregisteredUsers());
     connect(&ignoreUnregUsersMainChat, SIGNAL(stateChanged(int)), settingsCache, SLOT(setIgnoreUnregisteredUsers(int)));
     
+    invertMentionForeground.setChecked(settingsCache->getChatMentionForeground());
+    connect(&invertMentionForeground, SIGNAL(stateChanged(int)), settingsCache, SLOT(setChatMentionForeground(int)));
+
+    mentionColor = new QLineEdit();
+    mentionColor->setText(settingsCache->getChatMentionColor());
+    connect(mentionColor, SIGNAL(textChanged(QString)), settingsCache, SLOT(setChatMentionColor(QString)));
+
     QGridLayout *chatGrid = new QGridLayout;
     chatGrid->addWidget(&chatMentionCheckBox, 0, 0);
-    chatGrid->addWidget(&ignoreUnregUsersMainChat, 1, 0);
+    chatGrid->addWidget(&mentionColorLabel, 1, 0);
+    chatGrid->addWidget(mentionColor, 1, 1);
+    chatGrid->addWidget(&invertMentionForeground, 2, 0);
+    chatGrid->addWidget(&ignoreUnregUsersMainChat, 3, 0);
+    
     chatGroupBox = new QGroupBox;
     chatGroupBox->setLayout(chatGrid);
 
@@ -648,6 +659,8 @@ void MessagesSettingsPage::retranslateUi()
     chatMentionCheckBox.setText(tr("Enable chat mentions ('@yourusername' in chat log will be highlighted)"));
     messageShortcuts->setTitle(tr("In-game message macros"));
     ignoreUnregUsersMainChat.setText(tr("Ignore unregistered users in main chat"));
+    mentionColorLabel.setText(tr("Username/Mention color:"));
+    invertMentionForeground.setText(tr("Invert mention text color (white)"));
 }
 
 DlgSettings::DlgSettings(QWidget *parent)

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -585,6 +585,7 @@ MessagesSettingsPage::MessagesSettingsPage()
     chatGrid->addWidget(&invertMentionForeground, 0, 1);
     chatGrid->addWidget(mentionColor, 0, 2);
     chatGrid->addWidget(&ignoreUnregUsersMainChat, 1, 0);
+    chatGrid->addWidget(&hexLabel, 1, 2);
     
     chatGroupBox = new QGroupBox;
     chatGroupBox->setLayout(chatGrid);
@@ -678,6 +679,7 @@ void MessagesSettingsPage::retranslateUi()
     messageShortcuts->setTitle(tr("In-game message macros"));
     ignoreUnregUsersMainChat.setText(tr("Ignore unregistered users in main chat"));
     invertMentionForeground.setText(tr("Invert text color"));
+    hexLabel.setText(tr("(Color is hexadecimal)"));
 }
 
 DlgSettings::DlgSettings(QWidget *parent)

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -156,6 +156,8 @@ public:
 private slots:
     void actAdd();
     void actRemove();
+    void updateColor(const QString &value);
+    void updateTextColor(int value);
 private:
     QListWidget *messageList;
     QAction *aAdd;
@@ -166,9 +168,9 @@ private:
     QGroupBox *chatGroupBox;
     QGroupBox *messageShortcuts;
     QLineEdit *mentionColor;
-    QLabel mentionColorLabel;
 
     void storeSettings();
+    void updateMentionPreview();
 };
 
 class DlgSettings : public QDialog {

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -168,6 +168,7 @@ private:
     QGroupBox *chatGroupBox;
     QGroupBox *messageShortcuts;
     QLineEdit *mentionColor;
+    QLabel hexLabel;
 
     void storeSettings();
     void updateMentionPreview();

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -162,8 +162,11 @@ private:
     QAction *aRemove;
     QCheckBox chatMentionCheckBox;
     QCheckBox ignoreUnregUsersMainChat;
+    QCheckBox invertMentionForeground;
     QGroupBox *chatGroupBox;
     QGroupBox *messageShortcuts;
+    QLineEdit *mentionColor;
+    QLabel mentionColorLabel;
 
     void storeSettings();
 };

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -45,6 +45,8 @@ SettingsCache::SettingsCache()
     minPlayersForMultiColumnLayout = settings->value("interface/min_players_multicolumn", 5).toInt();
     tapAnimation = settings->value("cards/tapanimation", true).toBool();
     chatMention = settings->value("chat/mention", true).toBool();
+    chatMentionForeground = settings->value("chat/mentionforeground", true).toBool();
+    chatMentionColor = settings->value("chat/mentioncolor", "C21F2F").toString();
 
     zoneViewSortByName = settings->value("zoneview/sortbyname", true).toBool();
     zoneViewSortByType = settings->value("zoneview/sortbytype", true).toBool();
@@ -242,6 +244,16 @@ void SettingsCache::setTapAnimation(int _tapAnimation)
 void SettingsCache::setChatMention(int _chatMention) {
     chatMention = _chatMention;
     settings->setValue("chat/mention", chatMention);
+}
+
+void SettingsCache::setChatMentionForeground(int _chatMentionForeground) {
+    chatMentionForeground = _chatMentionForeground;
+    settings->setValue("chat/mentionforeground", chatMentionForeground);
+}
+
+void SettingsCache::setChatMentionColor(const QString &_chatMentionColor) {
+    chatMentionColor = _chatMentionColor;
+    settings->setValue("chat/mentioncolor", chatMentionColor);
 }
 
 void SettingsCache::setZoneViewSortByName(int _zoneViewSortByName)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -57,6 +57,8 @@ private:
     int minPlayersForMultiColumnLayout;
     bool tapAnimation;
     bool chatMention;
+    QString chatMentionColor;
+    bool chatMentionForeground;
     bool zoneViewSortByName, zoneViewSortByType, zoneViewPileView, zoneViewShuffle;
     bool soundEnabled;
     QString soundPath;
@@ -83,6 +85,7 @@ public:
     QString getTableBgPath() const { return tableBgPath; }
     QString getPlayerBgPath() const { return playerBgPath; }
     QString getCardBackPicturePath() const { return cardBackPicturePath; }
+    QString getChatMentionColor() const { return chatMentionColor; }
     bool getPicDownload() const { return picDownload; }
     bool getPicDownloadHq() const { return picDownloadHq; }
     bool getNotificationsEnabled() const { return notificationsEnabled; }
@@ -96,6 +99,7 @@ public:
     int getMinPlayersForMultiColumnLayout() const { return minPlayersForMultiColumnLayout; }
     bool getTapAnimation() const { return tapAnimation; }
     bool getChatMention()  const { return chatMention; }
+    bool getChatMentionForeground() const { return chatMentionForeground; }
     bool getZoneViewSortByName() const { return zoneViewSortByName; }
     bool getZoneViewSortByType() const { return zoneViewSortByType; }
     /**
@@ -133,6 +137,7 @@ public slots:
     void setTableBgPath(const QString &_tableBgPath);
     void setPlayerBgPath(const QString &_playerBgPath);
     void setCardBackPicturePath(const QString &_cardBackPicturePath);
+    void setChatMentionColor(const QString &_chatMentionColor);
     void setPicDownload(int _picDownload);
     void setPicDownloadHq(int _picDownloadHq);
     void setNotificationsEnabled(int _notificationsEnabled);
@@ -146,6 +151,7 @@ public slots:
     void setMinPlayersForMultiColumnLayout(int _minPlayersForMultiColumnLayout);
     void setTapAnimation(int _tapAnimation);
     void setChatMention(int _chatMention);
+    void setChatMentionForeground(int _chatMentionForeground);
     void setZoneViewSortByName(int _zoneViewSortByName);
     void setZoneViewSortByType(int _zoneViewSortByType);
     void setZoneViewPileView(int _zoneViewPileView);


### PR DESCRIPTION
+ Chat mention / username color can now be set via hex in the settings
+ Users can invert the color of the mention text black/white
+ if an invalid color is provided, the default will be used

![color](https://cloud.githubusercontent.com/assets/2134793/5968620/fd0173ae-a819-11e4-80a5-fcff3d2101fd.png)