### PR TITLE
Fixed pile view bug

### DIFF
--- a/cockatrice/src/zoneviewzone.cpp
+++ b/cockatrice/src/zoneviewzone.cpp
@@ -118,7 +118,6 @@ void ZoneViewZone::reorganizeCards()
                     typeRow++; // add below current card
                 else { // if no match then move card to next column
                     typeColumn++;
-                    longestRow = qMax(typeRow, longestRow);
                     typeRow = 0;
                 }
             }
@@ -128,6 +127,7 @@ void ZoneViewZone::reorganizeCards()
             qreal y = typeRow * CARD_HEIGHT / 3;
             c->setPos(x + 5, y + 5);
             c->setRealZValue(i);
+            longestRow = qMax(typeRow, longestRow);
         }
     } else {
         for (int i = 0; i < cardCount; i++) {


### PR DESCRIPTION
When sorting a view which has the last column the longest an error happens where the view is squashed.
**BEFORE**
![cramped](https://cloud.githubusercontent.com/assets/2134793/5990280/c9c47c20-a9a9-11e4-9981-cf7eb85e4f7b.png)

**AFTER**
![fixed](https://cloud.githubusercontent.com/assets/2134793/5990288/02216d1c-a9aa-11e4-9316-c3cfd4d6eb66.png)
