### PR TITLE
Chat has focus when starting game

### DIFF
--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -885,6 +885,7 @@ void TabGame::startGame(bool resuming)
     gameInfo.set_started(true);
     static_cast<GameScene *>(gameView->scene())->rearrange();
     gameView->show();
+    sayEdit->setFocus();
 }
 
 void TabGame::stopGame()


### PR DESCRIPTION
When the game starts the line edit now has focus immediately.