### PR TITLE
Fix #674

### DIFF
--- a/servatrice/src/server_logger.cpp
+++ b/servatrice/src/server_logger.cpp
@@ -2,6 +2,8 @@
 #include "settingscache.h"
 #include <QSocketNotifier>
 #include <QFile>
+#include <QFileInfo>
+#include <QDir>
 #include <QTextStream>
 #include <QDateTime>
 #include <iostream>
@@ -26,8 +28,23 @@ ServerLogger::~ServerLogger()
 void ServerLogger::startLog(const QString &logFileName)
 {
     if (!logFileName.isEmpty()) {
+        QFileInfo fi(logFileName);
+        QDir fileDir(fi.path());
+        if (!fileDir.exists() && !fileDir.mkpath(fileDir.absolutePath())) {
+            std::cerr << "ERROR: logfile folder doesn't exist and i can't create it." << std::endl;
+            logFile = 0;
+            return;
+        }
+
+
         logFile = new QFile(logFileName, this);
-        logFile->open(QIODevice::Append);
+        if(!logFile->open(QIODevice::Append)) {
+            std::cerr << "ERROR: can't open() logfile." << std::endl;
+            delete logFile;
+            logFile = 0;
+            return;
+        }
+
 #ifdef Q_OS_UNIX
         ::socketpair(AF_UNIX, SOCK_STREAM, 0, sigHupFD);
 


### PR DESCRIPTION
 * try to create logfile folder if it doesn't exists yet
 * spit an error if the log doesn't exist and can't be created
 * spit an error if the folder exists, but servatrice has no permission to open() the logfile
 * set logFile to 0 to avoid "QIODevice::write: device not open" messages in terminal