### PR TITLE
Added click mentions to PMs

### DIFF
--- a/cockatrice/src/tab_message.cpp
+++ b/cockatrice/src/tab_message.cpp
@@ -18,6 +18,7 @@ TabMessage::TabMessage(TabSupervisor *_tabSupervisor, AbstractClient *_client, c
     chatView = new ChatView(tabSupervisor, 0, true);
     connect(chatView, SIGNAL(showCardInfoPopup(QPoint, QString)), this, SLOT(showCardInfoPopup(QPoint, QString)));
     connect(chatView, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));
+    connect(chatView, SIGNAL(addMentionTag(QString)), this, SLOT(addMentionTag(QString)));
     sayEdit = new QLineEdit;
     connect(sayEdit, SIGNAL(returnPressed()), this, SLOT(sendMessage()));
     
@@ -41,6 +42,11 @@ TabMessage::~TabMessage()
     emit talkClosing(this);
     delete ownUserInfo;
     delete otherUserInfo;
+}
+
+void TabMessage::addMentionTag(QString mentionTag) {
+    sayEdit->insert(mentionTag + " ");
+    sayEdit->setFocus();
 }
 
 void TabMessage::retranslateUi()

--- a/cockatrice/src/tab_message.h
+++ b/cockatrice/src/tab_message.h
@@ -29,6 +29,7 @@ private slots:
     void sendMessage();
     void actLeave();
     void messageSent(const Response &response);
+    void addMentionTag(QString mentionTag);
 public:
     TabMessage(TabSupervisor *_tabSupervisor, AbstractClient *_client, const ServerInfo_User &_ownUserInfo, const ServerInfo_User &_otherUserInfo);
     ~TabMessage();


### PR DESCRIPTION
Adds the ability to click on a user to add a mention to the line edit.
+ Adds client wide continuity
+ One day we might have multi-user PMs
+ I use it when greeting users who PM me: "hello @username!"