### PR TITLE
Fix #688. Reuse chat tabs when user opens more chat with same user

### DIFF
--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -371,7 +371,16 @@ TabMessage *TabSupervisor::addMessageTab(const QString &receiverName, bool focus
         otherUser = twi->getUserInfo();
     else
         otherUser.set_name(receiverName.toStdString());
-    TabMessage *tab = new TabMessage(this, client, *userInfo, otherUser);
+
+    TabMessage *tab;
+    tab = messageTabs.value(QString::fromStdString(otherUser.name()));
+    if (tab) {
+        if (focus)
+          setCurrentWidget(tab);
+        return tab;
+    }
+
+    tab = new TabMessage(this, client, *userInfo, otherUser);
     connect(tab, SIGNAL(talkClosing(TabMessage *)), this, SLOT(talkLeft(TabMessage *)));
     int tabIndex = myAddTab(tab);
     addCloseButtonToTab(tab, tabIndex);


### PR DESCRIPTION
Before:

- Right click user, direct chat
- go back to user list, right click direct chat again
- Two chat tabs get opened

Now:

- Direct chat twice
- Same tab is reused instead of opening another one.