### PR TITLE
Remove Blank Flag Notation

### DIFF
--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -68,16 +68,16 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
     genderLabel2.setPixmap(GenderPixmapGenerator::generatePixmap(15, user.gender()));
     QString country = QString::fromStdString(user.country());
 
-	if (country.length() != 0)
-	{
-		countryLabel2.setPixmap(CountryPixmapGenerator::generatePixmap(15, country));
-		countryLabel3.setText(QString("(%1)").arg(country.toUpper()));
-	}
-	else
-	{
-		countryLabel2.setText("");
-		countryLabel3.setText("");
-	}
+    if (country.length() != 0)
+    {
+        countryLabel2.setPixmap(CountryPixmapGenerator::generatePixmap(15, country));
+        countryLabel3.setText(QString("(%1)").arg(country.toUpper()));
+    }
+    else
+    {
+        countryLabel2.setText("");
+        countryLabel3.setText("");
+    }
 	
     userLevelLabel2.setPixmap(UserLevelPixmapGenerator::generatePixmap(15, userLevel, false));
     QString userLevelText;

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -67,8 +67,18 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
     realNameLabel2.setText(QString::fromStdString(user.real_name()));
     genderLabel2.setPixmap(GenderPixmapGenerator::generatePixmap(15, user.gender()));
     QString country = QString::fromStdString(user.country());
-    countryLabel2.setPixmap(CountryPixmapGenerator::generatePixmap(15, country));
-    countryLabel3.setText(QString("(%1)").arg(country.toUpper()));
+
+	if (country.length() != 0)
+	{
+		countryLabel2.setPixmap(CountryPixmapGenerator::generatePixmap(15, country));
+		countryLabel3.setText(QString("(%1)").arg(country.toUpper()));
+	}
+	else
+	{
+		countryLabel2.setText("");
+		countryLabel3.setText("");
+	}
+	
     userLevelLabel2.setPixmap(UserLevelPixmapGenerator::generatePixmap(15, userLevel, false));
     QString userLevelText;
     if (userLevel.testFlag(ServerInfo_User::IsAdmin))


### PR DESCRIPTION
Fixes #692

This will stop accounts that have no flag from showing a blank `()` if no country is set

![screenshot 2015-02-05 17 26 05](https://cloud.githubusercontent.com/assets/7460172/6070620/197bce20-ad5c-11e4-9f70-9eb4b9edf305.png)


![screenshot 2015-02-05 17 26 10](https://cloud.githubusercontent.com/assets/7460172/6070619/19785d80-ad5c-11e4-8b47-3ec2493def72.png)

