### PR TITLE
Show password games by default

### DIFF
--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -23,8 +23,8 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes, const Ga
     unavailableGamesVisibleCheckBox = new QCheckBox(tr("Show &unavailable games"));
     unavailableGamesVisibleCheckBox->setChecked(gamesProxyModel->getUnavailableGamesVisible());
 
-    passwordProtectedGamesVisibleCheckBox = new QCheckBox(tr("Show &password protected games"));
-    passwordProtectedGamesVisibleCheckBox->setChecked(gamesProxyModel->getPasswordProtectedGamesVisible());
+    passwordProtectedGamesHiddenCheckBox = new QCheckBox(tr("Hide &password protected games"));
+    passwordProtectedGamesHiddenCheckBox->setChecked(gamesProxyModel->getPasswordProtectedGamesHidden());
 
     gameNameFilterEdit = new QLineEdit;
     gameNameFilterEdit->setText(gamesProxyModel->getGameNameFilter());
@@ -84,7 +84,7 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes, const Ga
     leftGrid->addWidget(creatorNameFilterEdit, 1, 1);
     leftGrid->addWidget(maxPlayersGroupBox, 2, 0, 1, 2);
     leftGrid->addWidget(unavailableGamesVisibleCheckBox, 3, 0, 1, 2);
-    leftGrid->addWidget(passwordProtectedGamesVisibleCheckBox, 4, 0, 1, 2);
+    leftGrid->addWidget(passwordProtectedGamesHiddenCheckBox, 4, 0, 1, 2);
 
     QVBoxLayout *leftColumn = new QVBoxLayout;
     leftColumn->addLayout(leftGrid);
@@ -123,14 +123,14 @@ void DlgFilterGames::setUnavailableGamesVisible(bool _unavailableGamesVisible)
     unavailableGamesVisibleCheckBox->setChecked(_unavailableGamesVisible);
 }
 
-bool DlgFilterGames::getPasswordProtectedGamesVisible() const
+bool DlgFilterGames::getPasswordProtectedGamesHidden() const
 {
-    return passwordProtectedGamesVisibleCheckBox->isChecked();
+    return passwordProtectedGamesHiddenCheckBox->isChecked();
 }
 
-void DlgFilterGames::setPasswordProtectedGamesVisible(bool _passwordProtectedGamesVisible)
+void DlgFilterGames::setPasswordProtectedGamesHidden(bool _passwordProtectedGamesHidden)
 {
-    passwordProtectedGamesVisibleCheckBox->setChecked(_passwordProtectedGamesVisible);
+    passwordProtectedGamesHiddenCheckBox->setChecked(_passwordProtectedGamesHidden);
 }
 
 QString DlgFilterGames::getGameNameFilter() const

--- a/cockatrice/src/dlg_filter_games.h
+++ b/cockatrice/src/dlg_filter_games.h
@@ -14,7 +14,7 @@ class DlgFilterGames : public QDialog {
     Q_OBJECT
 private:
     QCheckBox *unavailableGamesVisibleCheckBox;
-    QCheckBox *passwordProtectedGamesVisibleCheckBox;
+    QCheckBox *passwordProtectedGamesHiddenCheckBox;
     QLineEdit *gameNameFilterEdit;
     QLineEdit *creatorNameFilterEdit;
     QMap<int, QCheckBox *> gameTypeFilterCheckBoxes;
@@ -31,8 +31,8 @@ public:
 
     bool getUnavailableGamesVisible() const;
     void setUnavailableGamesVisible(bool _unavailableGamesVisible);
-    bool getPasswordProtectedGamesVisible() const;
-    void setPasswordProtectedGamesVisible(bool _passwordProtectedGamesVisible);
+    bool getPasswordProtectedGamesHidden() const;
+    void setPasswordProtectedGamesHidden(bool _passwordProtectedGamesHidden);
     QString getGameNameFilter() const;
     void setGameNameFilter(const QString &_gameNameFilter);
     QString getCreatorNameFilter() const;

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -94,7 +94,7 @@ void GameSelector::actSetFilter()
     clearFilterButton->setEnabled(true);
 
     gameListProxyModel->setUnavailableGamesVisible(dlg.getUnavailableGamesVisible());
-    gameListProxyModel->setPasswordProtectedGamesVisible(dlg.getPasswordProtectedGamesVisible());
+    gameListProxyModel->setPasswordProtectedGamesHidden(dlg.getPasswordProtectedGamesHidden());
     gameListProxyModel->setGameNameFilter(dlg.getGameNameFilter());
     gameListProxyModel->setCreatorNameFilter(dlg.getCreatorNameFilter());
     gameListProxyModel->setGameTypeFilter(dlg.getGameTypeFilter());

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -232,7 +232,7 @@ GamesProxyModel::GamesProxyModel(QObject *parent, ServerInfo_User *_ownUser)
     : QSortFilterProxyModel(parent),
     ownUser(_ownUser),
     unavailableGamesVisible(false),
-    passwordProtectedGamesVisible(false),
+    passwordProtectedGamesHidden(false),
     maxPlayersFilterMin(-1),
     maxPlayersFilterMax(-1)
 {
@@ -246,9 +246,9 @@ void GamesProxyModel::setUnavailableGamesVisible(bool _unavailableGamesVisible)
     invalidateFilter();
 }
 
-void GamesProxyModel::setPasswordProtectedGamesVisible(bool _passwordProtectedGamesVisible)
+void GamesProxyModel::setPasswordProtectedGamesHidden(bool _passwordProtectedGamesHidden)
 {
-    passwordProtectedGamesVisible = _passwordProtectedGamesVisible;
+    passwordProtectedGamesHidden = _passwordProtectedGamesHidden;
     invalidateFilter();
 }
 
@@ -280,7 +280,7 @@ void GamesProxyModel::setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlay
 void GamesProxyModel::resetFilterParameters()
 {
     unavailableGamesVisible = false;
-    passwordProtectedGamesVisible = false;
+    passwordProtectedGamesHidden = false;
     gameNameFilter = QString();
     creatorNameFilter = QString();
     gameTypeFilter.clear();
@@ -296,7 +296,7 @@ void GamesProxyModel::loadFilterParameters(const QMap<int, QString> &allGameType
     settings.beginGroup("filter_games");
 
     unavailableGamesVisible = settings.value("unavailable_games_visible", false).toBool();
-    passwordProtectedGamesVisible = settings.value("password_protected_games_visible", false).toBool();
+    passwordProtectedGamesHidden = settings.value("password_protected_games_hidden", false).toBool();
     gameNameFilter = settings.value("game_name_filter", "").toString();
     creatorNameFilter = settings.value("creator_name_filter", "").toString();
     maxPlayersFilterMin = settings.value("min_players", 1).toInt();
@@ -320,8 +320,8 @@ void GamesProxyModel::saveFilterParameters(const QMap<int, QString> &allGameType
 
     settings.setValue("unavailable_games_visible", unavailableGamesVisible);
     settings.setValue(
-        "password_protected_games_visible",
-        passwordProtectedGamesVisible
+        "password_protected_games_hidden",
+        passwordProtectedGamesHidden
         );
     settings.setValue("game_name_filter", gameNameFilter);
     settings.setValue("creator_name_filter", creatorNameFilter);
@@ -356,7 +356,7 @@ bool GamesProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &/*sourc
             if (game.only_registered())
                 return false;
     }
-    if (!passwordProtectedGamesVisible && game.with_password())
+    if (passwordProtectedGamesHidden && game.with_password())
         return false;
     if (!gameNameFilter.isEmpty())
         if (!QString::fromStdString(game.description()).contains(gameNameFilter, Qt::CaseInsensitive))

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -45,7 +45,7 @@ class GamesProxyModel : public QSortFilterProxyModel {
 private:
     ServerInfo_User *ownUser;
     bool unavailableGamesVisible;
-    bool passwordProtectedGamesVisible;
+    bool passwordProtectedGamesHidden;
     QString gameNameFilter, creatorNameFilter;
     QSet<int> gameTypeFilter;
     int maxPlayersFilterMin, maxPlayersFilterMax;
@@ -62,8 +62,8 @@ public:
 
     bool getUnavailableGamesVisible() const { return unavailableGamesVisible; }
     void setUnavailableGamesVisible(bool _unavailableGamesVisible);
-    bool getPasswordProtectedGamesVisible() const { return passwordProtectedGamesVisible; }
-    void setPasswordProtectedGamesVisible(bool _passwordProtectedGamesVisible);
+    bool getPasswordProtectedGamesHidden() const { return passwordProtectedGamesHidden; }
+    void setPasswordProtectedGamesHidden(bool _passwordProtectedGamesHidden);
     QString getGameNameFilter() const { return gameNameFilter; }
     void setGameNameFilter(const QString &_gameNameFilter);
     QString getCreatorNameFilter() const { return creatorNameFilter; }


### PR DESCRIPTION
New users find this really confusing. Old users can use the fact that we remember filter settings to still hide them.

This PR toggles the "show password protected games", unchecked by default to be "Hide password protected games" unchecked by default.