### PR TITLE
Local chat focus

### DIFF
--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -886,7 +886,7 @@ void TabGame::startGame(bool resuming)
     gameInfo.set_started(true);
     static_cast<GameScene *>(gameView->scene())->rearrange();
     gameView->show();
-    if(sayEdit)
+    if(sayEdit && players.size() > 1)
         sayEdit->setFocus();
 }
 


### PR DESCRIPTION
Games with only 1 player will now not focus on the chat when starting
the game. This helps with goldfishing.