### PR TITLE
Spectator viewing options

### DIFF
--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -172,8 +172,18 @@ QVariant GamesModel::data(const QModelIndex &index, int role) const
         case SPECTATORS: 
             switch(role) {
             case SORT_ROLE:
-            case Qt::DisplayRole: 
-                return g.spectators_allowed() ? QVariant(g.spectators_count()) : QVariant(tr("not allowed"));
+            case Qt::DisplayRole: {
+                if (g.spectators_allowed()) {
+                    QString result;
+                    result.append(QString::number(g.spectators_count()));
+                    if (g.spectators_can_chat()) 
+                        result.append(", ").append(tr("chat"));
+                    if (g.spectators_omniscient())
+                        result.append(", ").append(tr("see hands"));
+                    return result;
+                }
+                return QVariant(tr("not allowed"));
+            }
             case Qt::TextAlignmentRole:
                 return Qt::AlignLeft;
             default:

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -179,7 +179,7 @@ QVariant GamesModel::data(const QModelIndex &index, int role) const
                     if (g.spectators_can_chat()) 
                         result.append(", ").append(tr("chat"));
                     if (g.spectators_omniscient())
-                        result.append(", ").append(tr("see hands"));
+                        result.append(", ").append(tr("see everything"));
                     return result;
                 }
                 return QVariant(tr("not allowed"));


### PR DESCRIPTION
Its now easy to see which games you can chat/see hands in.
+ Added "chat" - If spectators can chat
+ Added "See everything" - If spectators can see hands

![untitled](https://cloud.githubusercontent.com/assets/2134793/6114152/8496de78-b09c-11e4-8af4-87432a148e28.png)

