### PR TITLE
Game list informs better of what spectators can do

### DIFF
--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -77,7 +77,7 @@ void DlgCreateGame::sharedCtor()
     connect(spectatorsAllowedCheckBox, SIGNAL(stateChanged(int)), this, SLOT(spectatorsAllowedChanged(int)));
     spectatorsNeedPasswordCheckBox = new QCheckBox(tr("Spectators &need a password to watch"));
     spectatorsCanTalkCheckBox = new QCheckBox(tr("Spectators can &chat"));
-    spectatorsSeeEverythingCheckBox = new QCheckBox(tr("Spectators can see hands"));
+    spectatorsSeeEverythingCheckBox = new QCheckBox(tr("Spectators can see &hands"));
     QVBoxLayout *spectatorsLayout = new QVBoxLayout;
     spectatorsLayout->addWidget(spectatorsAllowedCheckBox);
     spectatorsLayout->addWidget(spectatorsNeedPasswordCheckBox);

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -72,12 +72,12 @@ void DlgCreateGame::sharedCtor()
     QGroupBox *joinRestrictionsGroupBox = new QGroupBox(tr("Joining restrictions"));
     joinRestrictionsGroupBox->setLayout(joinRestrictionsLayout);
 
-    spectatorsAllowedCheckBox = new QCheckBox(tr("&Spectators allowed"));
+    spectatorsAllowedCheckBox = new QCheckBox(tr("&Spectators can watch"));
     spectatorsAllowedCheckBox->setChecked(true);
     connect(spectatorsAllowedCheckBox, SIGNAL(stateChanged(int)), this, SLOT(spectatorsAllowedChanged(int)));
-    spectatorsNeedPasswordCheckBox = new QCheckBox(tr("Spectators &need a password to join"));
+    spectatorsNeedPasswordCheckBox = new QCheckBox(tr("Spectators &need a password to watch"));
     spectatorsCanTalkCheckBox = new QCheckBox(tr("Spectators can &chat"));
-    spectatorsSeeEverythingCheckBox = new QCheckBox(tr("Spectators see &everything"));
+    spectatorsSeeEverythingCheckBox = new QCheckBox(tr("Spectators can see hands"));
     QVBoxLayout *spectatorsLayout = new QVBoxLayout;
     spectatorsLayout->addWidget(spectatorsAllowedCheckBox);
     spectatorsLayout->addWidget(spectatorsNeedPasswordCheckBox);

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -176,10 +176,20 @@ QVariant GamesModel::data(const QModelIndex &index, int role) const
                 if (g.spectators_allowed()) {
                     QString result;
                     result.append(QString::number(g.spectators_count()));
-                    if (g.spectators_can_chat()) 
-                        result.append(", ").append(tr("chat"));
-                    if (g.spectators_omniscient())
-                        result.append(", ").append(tr("see everything"));
+
+                    if (g.spectators_can_chat() && g.spectators_omniscient())
+                    {
+                        result.append(" (").append(tr("can chat")).append(" & ").append((tr("can see hands")).append(")"));
+                    }
+                    else if (g.spectators_can_chat())
+                    {
+                        result.append(" (").append(tr("can chat")).append(")");
+                    }
+                    else if (g.spectators_omniscient())
+                    {
+                        result.append(" (").append(tr("can see hands")).append(")");
+                    }
+					
                     return result;
                 }
                 return QVariant(tr("not allowed"));

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -179,7 +179,7 @@ QVariant GamesModel::data(const QModelIndex &index, int role) const
 
                     if (g.spectators_can_chat() && g.spectators_omniscient())
                     {
-                        result.append(" (").append(tr("can chat")).append(" & ").append((tr("see hands")).append(")"));
+                        result.append(" (").append(tr("can chat")).append(" & ").append(tr("see hands")).append(")");
                     }
                     else if (g.spectators_can_chat())
                     {

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -179,7 +179,7 @@ QVariant GamesModel::data(const QModelIndex &index, int role) const
 
                     if (g.spectators_can_chat() && g.spectators_omniscient())
                     {
-                        result.append(" (").append(tr("can chat")).append(" & ").append((tr("can see hands")).append(")"));
+                        result.append(" (").append(tr("can chat")).append(" & ").append((tr("see hands")).append(")"));
                     }
                     else if (g.spectators_can_chat())
                     {


### PR DESCRIPTION
Currently people only know if they are able to watch/spectate a game or not.
![screenshot 2015-02-09 15 36 08](https://cloud.githubusercontent.com/assets/7460172/6115162/71f2c00a-b071-11e4-8c9f-0ccb00c63886.png)

Now they know, if they're able to watch a certain game, what rights they will have within the game.
![screenshot 2015-02-09 15 30 24](https://cloud.githubusercontent.com/assets/7460172/6115163/71f714c0-b071-11e4-8545-45aa26952d18.png)

Game dialog menu has also been updated for the spectator section to match the new wording I used.
