### PR TITLE
Kick message no longer takes you to kicked tab

### DIFF
--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -1081,7 +1081,6 @@ void TabGame::eventLeave(const Event_Leave & /*event*/, int eventPlayerId, const
 void TabGame::eventKicked(const Event_Kicked & /*event*/, int /*eventPlayerId*/, const GameEventContext & /*context*/)
 {
     closeGame();
-    tabSupervisor->setCurrentIndex(tabSupervisor->indexOf(this));
     messageLog->logKicked();
 
     QMessageBox msgBox(this);


### PR DESCRIPTION
After comments about taking you away from your current tab, that feature has been removed.
If you now get kicked you will get the modal kick message, but on the current tab you are on, for easy dismissal.