### PR TITLE
ctrl-click to add a card to a selection.

### DIFF
--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -227,7 +227,7 @@ void AbstractCardItem::setFaceDown(bool _facedown)
 void AbstractCardItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
     if ((event->modifiers() & Qt::ControlModifier)) {
-        setSelected(isSelected() ? false : true);
+        setSelected(!isSelected());
     }
     else if (!isSelected()) {
         scene()->clearSelection();

--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -226,7 +226,10 @@ void AbstractCardItem::setFaceDown(bool _facedown)
 
 void AbstractCardItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-    if (!isSelected()) {
+    if ((event->modifiers() & Qt::ControlModifier)) {
+        setSelected(isSelected() ? false : true);
+    }
+    else if (!isSelected()) {
         scene()->clearSelection();
         setSelected(true);
     }


### PR DESCRIPTION
This was one of the suggestions in #655.  This change should mimic other applications were ctrl+click would add/remove items to the current selection.

I'm not a Mac guy, so I don't know if this is the proper change for Mac too.  I think QT's modifier for Ctrl is Command on the Mac.