### PR TITLE
Add full and short name for card color filters.

### DIFF
--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -161,11 +161,30 @@ bool FilterItem::acceptType(const CardInfo *info) const
 bool FilterItem::acceptColor(const CardInfo *info) const
 {
     QStringList::const_iterator i;
+    QString converted_term;
     bool status;
 
     status = false;
+    if (term.contains("green", Qt::CaseInsensitive) || term.contains("grn", Qt::CaseInsensitive)) {
+        converted_term = 'g';
+    }
+    else if (term.contains("blue", Qt::CaseInsensitive) || term.contains("blu", Qt::CaseInsensitive)) {
+        converted_term = 'u';
+    }
+    else if (term.contains("black", Qt::CaseInsensitive) || term.contains("blk", Qt::CaseInsensitive)) {
+        converted_term = 'b';
+    }
+    else if (term.contains("red", Qt::CaseInsensitive)) {
+        converted_term = 'r';
+    }
+    else if (term.contains("white", Qt::CaseInsensitive) || term.contains("wht", Qt::CaseInsensitive)) {
+        converted_term = 'w';
+    }
+    else {
+        converted_term = term;
+    }
     for (i = info->getColors().constBegin(); i != info->getColors().constEnd(); i++)
-        if ((*i).contains(term, Qt::CaseInsensitive)) {
+        if ((*i).contains(converted_term, Qt::CaseInsensitive)) {
             status = true;
             break;
         }

--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -162,34 +162,32 @@ bool FilterItem::acceptColor(const CardInfo *info) const
 {
     QStringList::const_iterator i;
     QString converted_term;
-    bool status;
+    QString::const_iterator it;
+    int match_count;
 
-    status = false;
-    if (term.contains("green", Qt::CaseInsensitive) || term.contains("grn", Qt::CaseInsensitive)) {
-        converted_term = 'g';
-    }
-    else if (term.contains("blue", Qt::CaseInsensitive) || term.contains("blu", Qt::CaseInsensitive)) {
-        converted_term = 'u';
-    }
-    else if (term.contains("black", Qt::CaseInsensitive) || term.contains("blk", Qt::CaseInsensitive)) {
-        converted_term = 'b';
-    }
-    else if (term.contains("red", Qt::CaseInsensitive)) {
-        converted_term = 'r';
-    }
-    else if (term.contains("white", Qt::CaseInsensitive) || term.contains("wht", Qt::CaseInsensitive)) {
-        converted_term = 'w';
-    }
-    else {
-        converted_term = term;
-    }
-    for (i = info->getColors().constBegin(); i != info->getColors().constEnd(); i++)
-        if ((*i).contains(converted_term, Qt::CaseInsensitive)) {
-            status = true;
-            break;
-        }
+    converted_term = term;
+    converted_term.replace(QString("green"), QString("g"), Qt::CaseInsensitive);
+    converted_term.replace(QString("grn"), QString("g"), Qt::CaseInsensitive);
+    converted_term.replace(QString("blue"), QString("u"), Qt::CaseInsensitive);
+    converted_term.replace(QString("blu"), QString("u"), Qt::CaseInsensitive);
+    converted_term.replace(QString("black"), QString("b"), Qt::CaseInsensitive);
+    converted_term.replace(QString("blk"), QString("b"), Qt::CaseInsensitive);
+    converted_term.replace(QString("red"), QString("r"), Qt::CaseInsensitive);
+    converted_term.replace(QString("white"), QString("w"), Qt::CaseInsensitive);
+    converted_term.replace(QString("wht"), QString("w"), Qt::CaseInsensitive);
+    converted_term.replace(QString(" "), QString(""), Qt::CaseInsensitive);
 
-    return status;
+    /* This is a tricky part, if the filter has multiple colors in it, like UGW,
+       then we should match all of them to the card's colors */
+    match_count = 0;
+    for (it = converted_term.begin(); it != converted_term.end(); it++) {
+        for (i = info->getColors().constBegin(); i != info->getColors().constEnd(); i++)
+            if ((*i).contains((*it), Qt::CaseInsensitive)) {
+                match_count++;
+            }
+    }
+
+    return match_count == converted_term.length();
 }
 
 bool FilterItem::acceptText(const CardInfo *info) const


### PR DESCRIPTION
This addresses one of the parts in #97.  Basically you can enter "green" into the card filter tree and get all of the green cards.

This feels a bit klunky though.  Maybe someone with more familiarity could suggest a place to put a color conversion function like this.