### PR TITLE
Avoid loading the same card's picture twice; Fix #745

### DIFF
--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -74,6 +74,7 @@ private:
     QMutex mutex;
     QNetworkAccessManager *networkManager;
     QList<PictureToLoad> cardsToDownload;
+    PictureToLoad cardBeingLoaded;
     PictureToLoad cardBeingDownloaded;
     bool picDownload, picDownloadHq, downloadRunning, loadQueueRunning;
     void startNextPicDownload();


### PR DESCRIPTION
If the picture for a card that is not currently cached is requested more than once, each request will be queued creating duplicates in the queue and thus making the cache inefficient.
This PR addresses this issue tracking the card currently being loaded and avoiding duplicates in the queue.