### PR TITLE
Game events do not notify taskbar while spectating.

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -449,6 +449,7 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     connect(&notificationsEnabledCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setSpecNotificationEnabled(int)));
 
     specNotificationsEnabledCheckBox.setChecked(settingsCache->getSpectatorNotificationsEnabled());
+    specNotificationsEnabledCheckBox.setEnabled(settingsCache->getNotificationsEnabled());
     connect(&specNotificationsEnabledCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setSpectatorNotificationsEnabled(int)));
 
     doubleClickToPlayCheckBox.setChecked(settingsCache->getDoubleClickToPlay());

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -446,6 +446,10 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
 
     notificationsEnabledCheckBox.setChecked(settingsCache->getNotificationsEnabled());
     connect(&notificationsEnabledCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setNotificationsEnabled(int)));
+    connect(&notificationsEnabledCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setSpecNotificationEnabled(int)));
+
+    specNotificationsEnabledCheckBox.setChecked(settingsCache->getSpectatorNotificationsEnabled());
+    connect(&specNotificationsEnabledCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setSpectatorNotificationsEnabled(int)));
 
     doubleClickToPlayCheckBox.setChecked(settingsCache->getDoubleClickToPlay());
     connect(&doubleClickToPlayCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setDoubleClickToPlay(int)));
@@ -455,8 +459,9 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     
     QGridLayout *generalGrid = new QGridLayout;
     generalGrid->addWidget(&notificationsEnabledCheckBox, 0, 0);
-    generalGrid->addWidget(&doubleClickToPlayCheckBox, 1, 0);
-    generalGrid->addWidget(&playToStackCheckBox, 2, 0);
+    generalGrid->addWidget(&specNotificationsEnabledCheckBox, 1, 0);
+    generalGrid->addWidget(&doubleClickToPlayCheckBox, 2, 0);
+    generalGrid->addWidget(&playToStackCheckBox, 3, 0);
     
     generalGroupBox = new QGroupBox;
     generalGroupBox->setLayout(generalGrid);
@@ -500,10 +505,15 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     setLayout(mainLayout);
 }
 
+void UserInterfaceSettingsPage::setSpecNotificationEnabled(int i) {
+    specNotificationsEnabledCheckBox.setEnabled(i != 0);
+}
+
 void UserInterfaceSettingsPage::retranslateUi()
 {
     generalGroupBox->setTitle(tr("General interface settings"));
     notificationsEnabledCheckBox.setText(tr("Enable notifications in taskbar"));
+    specNotificationsEnabledCheckBox.setText(tr("Notify in the taskbar for game events while you are spectating"));
     doubleClickToPlayCheckBox.setText(tr("&Double-click cards to play them (instead of single-click)"));
     playToStackCheckBox.setText(tr("&Play all nonlands onto the stack (not the battlefield) by default"));
     animationGroupBox->setTitle(tr("Animation settings"));

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -115,10 +115,12 @@ class UserInterfaceSettingsPage : public AbstractSettingsPage {
 private slots:
     void soundPathClearButtonClicked();
     void soundPathButtonClicked();
+    void setSpecNotificationEnabled(int);
 signals:
     void soundPathChanged();
 private:
     QCheckBox notificationsEnabledCheckBox;
+    QCheckBox specNotificationsEnabledCheckBox;
     QCheckBox doubleClickToPlayCheckBox;
     QCheckBox playToStackCheckBox;
     QCheckBox tapAnimationCheckBox;

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -35,6 +35,7 @@ SettingsCache::SettingsCache()
 
     mainWindowGeometry = settings->value("interface/main_window_geometry").toByteArray();
     notificationsEnabled = settings->value("interface/notificationsenabled", true).toBool();
+    spectatorNotificationsEnabled = settings->value("interface/specnotificationsenabled", false).toBool();
     doubleClickToPlay = settings->value("interface/doubleclicktoplay", true).toBool();
     playToStack = settings->value("interface/playtostack", false).toBool();
     cardInfoMinimized = settings->value("interface/cardinfominimized", 0).toInt();
@@ -181,6 +182,11 @@ void SettingsCache::setNotificationsEnabled(int _notificationsEnabled)
 {
     notificationsEnabled = _notificationsEnabled;
     settings->setValue("interface/notificationsenabled", notificationsEnabled);
+}
+
+void SettingsCache::setSpectatorNotificationsEnabled(int _spectatorNotificationsEnabled) {
+    spectatorNotificationsEnabled = _spectatorNotificationsEnabled;
+    settings->setValue("interface/specnotificationsenabled", spectatorNotificationsEnabled);
 }
 
 void SettingsCache::setDoubleClickToPlay(int _doubleClickToPlay)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -48,6 +48,7 @@ private:
     bool picDownload;
     bool picDownloadHq;
     bool notificationsEnabled;
+    bool spectatorNotificationsEnabled;
     bool doubleClickToPlay;
     bool playToStack;
     int cardInfoMinimized;
@@ -91,6 +92,8 @@ public:
     bool getPicDownload() const { return picDownload; }
     bool getPicDownloadHq() const { return picDownloadHq; }
     bool getNotificationsEnabled() const { return notificationsEnabled; }
+    bool getSpectatorNotificationsEnabled() const { return spectatorNotificationsEnabled; }
+
     bool getDoubleClickToPlay() const { return doubleClickToPlay; }
     bool getPlayToStack() const { return playToStack; }
     int  getCardInfoMinimized() const { return cardInfoMinimized; }
@@ -139,6 +142,7 @@ public slots:
     void setPicDownload(int _picDownload);
     void setPicDownloadHq(int _picDownloadHq);
     void setNotificationsEnabled(int _notificationsEnabled);
+    void setSpectatorNotificationsEnabled(int _spectatorNotificationsEnabled);
     void setDoubleClickToPlay(int _doubleClickToPlay);
     void setPlayToStack(int _playToStack);
     void setCardInfoMinimized(int _cardInfoMinimized);

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -514,6 +514,11 @@ void TabGame::addMentionTag(QString value) {
     sayEdit->setFocus();
 }
 
+void TabGame::emitUserEvent() {
+    bool globalEvent = !spectator || settingsCache->getSpectatorNotificationsEnabled();
+    emit userEvent(globalEvent);
+}
+
 TabGame::~TabGame()
 {
     delete replay;
@@ -806,7 +811,7 @@ void TabGame::processGameEventContainer(const GameEventContainer &cont, Abstract
                         break;
                     }
                     player->processGameEvent(eventType, event, context);
-                    emit userEvent();
+                    emitUserEvent();
                 }
             }
         }
@@ -929,7 +934,7 @@ void TabGame::eventSpectatorLeave(const Event_Leave & /*event*/, int eventPlayer
     playerListWidget->removePlayer(eventPlayerId);
     spectators.remove(eventPlayerId);
     
-    emit userEvent();
+    emitUserEvent();
 }
 
 void TabGame::eventGameStateChanged(const Event_GameStateChanged &event, int /*eventPlayerId*/, const GameEventContext & /*context*/)
@@ -988,7 +993,7 @@ void TabGame::eventGameStateChanged(const Event_GameStateChanged &event, int /*e
         scene->clearViews();
     }
     gameStateKnown = true;
-    emit userEvent();
+    emitUserEvent();
 }
 
 void TabGame::eventPlayerPropertiesChanged(const Event_PlayerPropertiesChanged &event, int eventPlayerId, const GameEventContext &context)
@@ -1056,7 +1061,7 @@ void TabGame::eventJoin(const Event_Join &event, int /*eventPlayerId*/, const Ga
         messageLog->logJoin(newPlayer);
     }
     playerListWidget->addPlayer(playerInfo);
-    emit userEvent();
+    emitUserEvent();
 }
 
 void TabGame::eventLeave(const Event_Leave & /*event*/, int eventPlayerId, const GameEventContext & /*context*/)
@@ -1077,7 +1082,7 @@ void TabGame::eventLeave(const Event_Leave & /*event*/, int eventPlayerId, const
     while (playerIterator.hasNext())
         playerIterator.next().value()->updateZones();
     
-    emit userEvent();
+    emitUserEvent();
 }
 
 void TabGame::eventKicked(const Event_Kicked & /*event*/, int /*eventPlayerId*/, const GameEventContext & /*context*/)
@@ -1092,7 +1097,7 @@ void TabGame::eventKicked(const Event_Kicked & /*event*/, int /*eventPlayerId*/,
     msgBox.setIcon(QMessageBox::Information);
     msgBox.exec();
 
-    emit userEvent();
+    emitUserEvent();
 }
 
 void TabGame::eventGameHostChanged(const Event_GameHostChanged & /*event*/, int eventPlayerId, const GameEventContext & /*context*/)
@@ -1104,7 +1109,7 @@ void TabGame::eventGameClosed(const Event_GameClosed & /*event*/, int /*eventPla
 {
     closeGame();
     messageLog->logGameClosed();
-    emit userEvent();
+    emitUserEvent();
 }
 
 Player *TabGame::setActivePlayer(int id)
@@ -1128,7 +1133,7 @@ Player *TabGame::setActivePlayer(int id)
         }
     }
     currentPhase = -1;
-    emit userEvent();
+    emitUserEvent();
     return player;
 }
 
@@ -1138,7 +1143,7 @@ void TabGame::eventSetActivePlayer(const Event_SetActivePlayer &event, int /*eve
     if (!player)
         return;
     messageLog->logSetActivePlayer(player);
-    emit userEvent();
+    emitUserEvent();
 }
 
 void TabGame::setActivePhase(int phase)
@@ -1155,7 +1160,7 @@ void TabGame::eventSetActivePhase(const Event_SetActivePhase &event, int /*event
     if (currentPhase != phase)
         messageLog->logSetActivePhase(phase);
     setActivePhase(phase);
-    emit userEvent();
+    emitUserEvent();
 }
 
 void TabGame::newCardAdded(AbstractCardItem *card)

--- a/cockatrice/src/tab_game.h
+++ b/cockatrice/src/tab_game.h
@@ -164,6 +164,7 @@ private:
     void setActivePhase(int phase);
     void eventSetActivePhase(const Event_SetActivePhase &event, int eventPlayerId, const GameEventContext &context);
     void eventPing(const Event_Ping &event, int eventPlayerId, const GameEventContext &context);
+    void emitUserEvent();
 signals:
     void gameClosing(TabGame *tab);
     void playerAdded(Player *player);


### PR DESCRIPTION
The behavior is configurable.

This fixes #649 

![screen shot 2015-02-20 at 8 57 52 pm](https://cloud.githubusercontent.com/assets/14644/6312348/4c3b2eee-b943-11e4-94e8-170903aec73a.png)

![screen shot 2015-02-20 at 8 58 01 pm](https://cloud.githubusercontent.com/assets/14644/6312349/4f1e6ce8-b943-11e4-9261-d2e2887ced8b.png)
