### PR TITLE
Possibly fix crash leaving game

### DIFF
--- a/cockatrice/src/gamescene.cpp
+++ b/cockatrice/src/gamescene.cpp
@@ -269,7 +269,8 @@ void GameScene::unregisterAnimationItem(AbstractCardItem *card)
 {
     cardsToAnimate.remove(static_cast<CardItem *>(card));
     if (cardsToAnimate.isEmpty())
-        animationTimer->stop();
+        if (animationTimer)
+            animationTimer->stop();
 }
 
 void GameScene::startRubberBand(const QPointF &selectionOrigin)

--- a/cockatrice/src/gamescene.cpp
+++ b/cockatrice/src/gamescene.cpp
@@ -267,7 +267,8 @@ void GameScene::registerAnimationItem(AbstractCardItem *card)
 
 void GameScene::unregisterAnimationItem(AbstractCardItem *card)
 {
-    cardsToAnimate.remove(static_cast<CardItem *>(card));
+    if (cardsToAnimate)
+        cardsToAnimate.remove(static_cast<CardItem *>(card));
     if (cardsToAnimate.isEmpty())
         if (animationTimer)
             animationTimer->stop();

--- a/cockatrice/src/gamescene.cpp
+++ b/cockatrice/src/gamescene.cpp
@@ -267,8 +267,7 @@ void GameScene::registerAnimationItem(AbstractCardItem *card)
 
 void GameScene::unregisterAnimationItem(AbstractCardItem *card)
 {
-    if (cardsToAnimate != NULL)
-        cardsToAnimate.remove(static_cast<CardItem *>(card));
+    cardsToAnimate.remove(static_cast<CardItem *>(card));
     if (cardsToAnimate.isEmpty())
         if (animationTimer)
             animationTimer->stop();

--- a/cockatrice/src/gamescene.cpp
+++ b/cockatrice/src/gamescene.cpp
@@ -267,7 +267,7 @@ void GameScene::registerAnimationItem(AbstractCardItem *card)
 
 void GameScene::unregisterAnimationItem(AbstractCardItem *card)
 {
-    if (cardsToAnimate)
+    if (cardsToAnimate != NULL)
         cardsToAnimate.remove(static_cast<CardItem *>(card));
     if (cardsToAnimate.isEmpty())
         if (animationTimer)


### PR DESCRIPTION
I got this crash: https://gist.github.com/Daenyth/3b28b7fcca5308e003ba

```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   org.qt-project.QtCore         	0x000000010f2ae3d0 QHashData::detach_helper(void (*)(QHashData::Node*, void*), void (*)(QHashData::Node*), int, int) + 704
1   com.cockatrice.cockatrice     	0x000000010d5ed35f QHash<CardItem*, QHashDummyValue>::detach_helper() + 63 (qhash.h:593)
2   com.cockatrice.cockatrice     	0x000000010d5ed06b QHash<CardItem*, QHashDummyValue>::detach() + 59 (qhash.h:323)
3   com.cockatrice.cockatrice     	0x000000010d5ecf32 QHash<CardItem*, QHashDummyValue>::remove(CardItem* const&) + 66 (qhash.h:797)
4   com.cockatrice.cockatrice     	0x000000010d5ececd QSet<CardItem*>::remove(CardItem* const&) + 29 (qset.h:92)
5   com.cockatrice.cockatrice     	0x000000010d5eb886 GameScene::unregisterAnimationItem(AbstractCardItem*) + 54 (gamescene.cpp:271)
```

@ctrlaltca you're better than I am with this, does this make sense?

Given that
```
GameScene::~GameScene()
{
    delete animationTimer;
}
```