### PR TITLE
cockatrice: ask to save modified decks on close; fix #759

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -379,6 +379,7 @@ void TabDeckEditor::updateHash()
 bool TabDeckEditor::confirmClose()
 {
     if (modified) {
+        tabSupervisor->setCurrentWidget(this);
         QMessageBox::StandardButton ret = QMessageBox::warning(this, tr("Are you sure?"),
             tr("The decklist has been modified.\nDo you want to save the changes?"),
             QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);

--- a/cockatrice/src/tab_deck_editor.h
+++ b/cockatrice/src/tab_deck_editor.h
@@ -75,7 +75,6 @@ private:
     void offsetCountAtIndex(const QModelIndex &idx, int offset);
     void decrementCardHelper(QString zoneName);
     void recursiveExpand(const QModelIndex &index);
-    bool confirmClose();
 
     CardDatabaseModel *databaseModel;
     CardDatabaseDisplayModel *databaseDisplayModel;
@@ -110,6 +109,7 @@ public:
     QString getTabText() const;
     void setDeck(DeckLoader *_deckLoader);
     void setModified(bool _windowModified);
+    bool confirmClose();
 public slots:
     void closeRequest();
 signals:

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -15,6 +15,7 @@
 #include "settingscache.h"
 #include <QDebug>
 #include <QPainter>
+#include <QMessageBox>
 
 #include "pb/room_commands.pb.h"
 #include "pb/room_event.pb.h"
@@ -128,6 +129,23 @@ void TabSupervisor::retranslateUi()
             setTabText(indexOf(tabs[i]), tabs[i]->getTabText());
             tabs[i]->retranslateUi();
         }
+}
+
+bool TabSupervisor::closeRequest()
+{
+    if (getGameCount()) {
+        if (QMessageBox::question(this, tr("Are you sure?"), tr("There are still open games. Are you sure you want to quit?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::No) {
+            return false;
+        }
+    }
+
+    foreach(TabDeckEditor *tab,  deckEditorTabs)
+    {
+        if(!tab->confirmClose())
+            return false;
+    }
+
+    return true;
 }
 
 AbstractClient *TabSupervisor::getClient() const

--- a/cockatrice/src/tab_supervisor.h
+++ b/cockatrice/src/tab_supervisor.h
@@ -71,6 +71,7 @@ public:
     AbstractClient *getClient() const;
     const QMap<int, TabRoom *> &getRoomTabs() const { return roomTabs; }
     bool getAdminLocked() const;
+    bool closeRequest();
 signals:
     void setMenu(const QList<QMenu *> &newMenuList = QList<QMenu *>());
     void localGameEnded();

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -423,12 +423,12 @@ MainWindow::~MainWindow()
 
 void MainWindow::closeEvent(QCloseEvent *event)
 {
-    if (tabSupervisor->getGameCount()) {
-        if (QMessageBox::question(this, tr("Are you sure?"), tr("There are still open games. Are you sure you want to quit?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::No) {
-            event->ignore();
-            return;
-        }
+    if (!tabSupervisor->closeRequest())
+    {
+        event->ignore();
+        return;
     }
+
     event->accept();
     settingsCache->setMainWindowGeometry(saveGeometry());
     tabSupervisor->deleteLater();

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -423,9 +423,16 @@ MainWindow::~MainWindow()
 
 void MainWindow::closeEvent(QCloseEvent *event)
 {
+    // workaround Qt bug where closeEvent gets called twice
+    static bool bClosingDown=false;
+    if(bClosingDown)
+        return;
+    bClosingDown=true;
+
     if (!tabSupervisor->closeRequest())
     {
         event->ignore();
+        bClosingDown=false;
         return;
     }
 


### PR DESCRIPTION
If you have more than one deck editor with non-saved changes, you'll get a dialog for each of them.