### PR TITLE
Cleanup script to delete unactivated user accounts

### DIFF
--- a/servatrice/scripts/maint_removeinactiveplayeraccounts
+++ b/servatrice/scripts/maint_removeinactiveplayeraccounts
@@ -1,0 +1,3 @@
+#!/bin/bash
+# SCHEDULE WITH CRONTAB BASED ON TIME PERIOD UNACTIVE ACCOUNT SHOULD BE REMOVED. UPDATE INTERVAL DATE TO BE NUMBER OF DAYS OLD (OR OLDER) TO REMOVE.
+mysql --defaults-file=./mysql.cnf -h localhost -e 'delete from servatrice.cockatrice_users where registrationDate < DATE_SUB(now(), INTERVAL 5 DAY) AND active = 0';


### PR DESCRIPTION
Fix #782
The script will remove any registered user accounts that are not active that are 5 days old or older (by default). You can change the time frame to whatever liking you desire.