### PR TITLE
Added username to window title

### DIFF
--- a/cockatrice/src/abstractclient.h
+++ b/cockatrice/src/abstractclient.h
@@ -82,6 +82,8 @@ public:
     ClientStatus getStatus() const { QMutexLocker locker(&clientMutex); return status; }
     void sendCommand(const CommandContainer &cont);
     void sendCommand(PendingCommand *pend);
+
+    const QString getUserName() {return userName;}
     
     static PendingCommand *prepareSessionCommand(const ::google::protobuf::Message &cmd);
     static PendingCommand *prepareRoomCommand(const ::google::protobuf::Message &cmd, int roomId);

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -287,7 +287,7 @@ void MainWindow::setClientStatusTitle()
         case StatusConnecting: setWindowTitle(appName + " - " + tr("Connecting to %1...").arg(client->peerName())); break;
         case StatusDisconnected: setWindowTitle(appName + " - " + tr("Disconnected")); break;
         case StatusLoggingIn: setWindowTitle(appName + " - " + tr("Connected, logging in at %1").arg(client->peerName())); break;
-        case StatusLoggedIn: setWindowTitle(appName + " - " + tr("Logged in at %1").arg(client->peerName())); break;
+        case StatusLoggedIn: setWindowTitle(appName + " - " + tr("Logged in as %1 at %2").arg(client->getUserName()).arg(client->peerName())); break;
         default: setWindowTitle(appName);
     }
 }

--- a/cockatrice/translations/cockatrice_es.ts
+++ b/cockatrice/translations/cockatrice_es.ts
@@ -1712,7 +1712,7 @@ La versión local es %1, la versión remota es %2.</translation>
     </message>
     <message>
         <location filename="../src/window_main.cpp" line="290"/>
-        <source>Logged in at %1</source>
+        <source>Logged in as %1 at %2</source>
         <translation>Conectado en %1</translation>
     </message>
     <message>


### PR DESCRIPTION
While having more than 1 client open I found it hard to know which user
was which. I have added the user name to the title bar so you know who
you are logged in as.

Old:
![old](https://cloud.githubusercontent.com/assets/2134793/6462120/a1e9f27e-c1a6-11e4-8492-b6e44e1552fe.png)

New
![new](https://cloud.githubusercontent.com/assets/2134793/6462136/c5f61c06-c1a6-11e4-8393-22b7094c07b7.png)
