### PR TITLE
Fixed card search

### DIFF
--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -148,47 +148,12 @@ bool CardDatabaseDisplayModel::filterAcceptsRow(int sourceRow, const QModelIndex
     
     bool show = false;
     if (!cardName.isEmpty()) {
-        if (info->getName().contains(cardName, Qt::CaseInsensitive)) {
+        if (info->getName().contains(cardName, Qt::CaseInsensitive))
             show = true;
-        }
     } else
         return true;// search is empty, show all
 
-    return show; // term was not found
-
-        
-
-    //if (((isToken == ShowTrue) && !info->getIsToken()) || ((isToken == ShowFalse) && info->getIsToken()))
-    //    return false;
-    //
-    //if (!cardNameBeginning.isEmpty())
-    //    if (!info->getName().startsWith(cardNameBeginning, Qt::CaseInsensitive))
-    //        return false;
-    //
-    //if (!cardName.isEmpty())
-    //    if (!info->getName().contains(cardName, Qt::CaseInsensitive))
-    //        return false;
-    //
-    //if (!cardNameSet.isEmpty())
-    //    if (!cardNameSet.contains(info->getName()))
-    //        return false;
-    //
-    //if (!cardText.isEmpty())
-    //    if (!info->getText().contains(cardText, Qt::CaseInsensitive))
-    //        return false;
-    //
-    //if (!cardColors.isEmpty())
-    //    if (QSet<QString>::fromList(info->getColors()).intersect(cardColors).isEmpty() && !(info->getColors().isEmpty() && cardColors.contains("X")))
-    //        return false;
-    //
-    //if (!cardTypes.isEmpty())
-    //    if (!cardTypes.contains(info->getMainCardType()))
-    //        return false;
-
-    //if (filterTree != NULL)
-    //    return filterTree->acceptsCard(info);
-
-    //return true;
+    return show;
 }
 
 void CardDatabaseDisplayModel::clearSearch()

--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -117,40 +117,78 @@ CardDatabaseDisplayModel::CardDatabaseDisplayModel(QObject *parent)
     setSortCaseSensitivity(Qt::CaseInsensitive);
 }
 
+
+bool CardDatabaseDisplayModel::lessThan(const QModelIndex &left, const QModelIndex &right) const {
+
+    QString leftString = sourceModel()->data(left).toString();
+    QString rightString = sourceModel()->data(right).toString();
+
+    if (leftString.compare(cardName, Qt::CaseInsensitive) == 0) {// exact match should be at top
+        return true;
+    }
+
+    if (rightString.compare(cardName, Qt::CaseInsensitive) == 0) {// exact match should be at top
+        return false;
+    }
+
+    bool isLeftType2 = leftString.startsWith(cardName, Qt::CaseInsensitive);
+    bool isRightType2 = rightString.startsWith(cardName, Qt::CaseInsensitive);
+    if (isLeftType2 && !isRightType2)
+        return true;
+    if (isRightType2 && !isLeftType2)
+        return false;
+
+    return QString::localeAwareCompare(leftString, rightString) < 0;
+
+}
+
 bool CardDatabaseDisplayModel::filterAcceptsRow(int sourceRow, const QModelIndex & /*sourceParent*/) const
 {
     CardInfo const *info = static_cast<CardDatabaseModel *>(sourceModel())->getCard(sourceRow);
-    if (((isToken == ShowTrue) && !info->getIsToken()) || ((isToken == ShowFalse) && info->getIsToken()))
-        return false;
     
-    if (!cardNameBeginning.isEmpty())
-        if (!info->getName().startsWith(cardNameBeginning, Qt::CaseInsensitive))
-            return false;
-    
-    if (!cardName.isEmpty())
-        if (!info->getName().contains(cardName, Qt::CaseInsensitive))
-            return false;
-    
-    if (!cardNameSet.isEmpty())
-        if (!cardNameSet.contains(info->getName()))
-            return false;
-    
-    if (!cardText.isEmpty())
-        if (!info->getText().contains(cardText, Qt::CaseInsensitive))
-            return false;
-    
-    if (!cardColors.isEmpty())
-        if (QSet<QString>::fromList(info->getColors()).intersect(cardColors).isEmpty() && !(info->getColors().isEmpty() && cardColors.contains("X")))
-            return false;
-    
-    if (!cardTypes.isEmpty())
-        if (!cardTypes.contains(info->getMainCardType()))
-            return false;
+    bool show = false;
+    if (!cardName.isEmpty()) {
+        if (info->getName().contains(cardName, Qt::CaseInsensitive)) {
+            show = true;
+        }
+    } else
+        return true;// search is empty, show all
 
-    if (filterTree != NULL)
-        return filterTree->acceptsCard(info);
+    return show; // term was not found
 
-    return true;
+        
+
+    //if (((isToken == ShowTrue) && !info->getIsToken()) || ((isToken == ShowFalse) && info->getIsToken()))
+    //    return false;
+    //
+    //if (!cardNameBeginning.isEmpty())
+    //    if (!info->getName().startsWith(cardNameBeginning, Qt::CaseInsensitive))
+    //        return false;
+    //
+    //if (!cardName.isEmpty())
+    //    if (!info->getName().contains(cardName, Qt::CaseInsensitive))
+    //        return false;
+    //
+    //if (!cardNameSet.isEmpty())
+    //    if (!cardNameSet.contains(info->getName()))
+    //        return false;
+    //
+    //if (!cardText.isEmpty())
+    //    if (!info->getText().contains(cardText, Qt::CaseInsensitive))
+    //        return false;
+    //
+    //if (!cardColors.isEmpty())
+    //    if (QSet<QString>::fromList(info->getColors()).intersect(cardColors).isEmpty() && !(info->getColors().isEmpty() && cardColors.contains("X")))
+    //        return false;
+    //
+    //if (!cardTypes.isEmpty())
+    //    if (!cardTypes.contains(info->getMainCardType()))
+    //        return false;
+
+    //if (filterTree != NULL)
+    //    return filterTree->acceptsCard(info);
+
+    //return true;
 }
 
 void CardDatabaseDisplayModel::clearSearch()

--- a/cockatrice/src/carddatabasemodel.h
+++ b/cockatrice/src/carddatabasemodel.h
@@ -37,6 +37,7 @@ public:
 private:
     FilterBool isToken;
     QString cardNameBeginning, cardName, cardText;
+    QString searchTerm;
     QSet<QString> cardNameSet, cardTypes, cardColors;
     FilterTree *filterTree;
 public:
@@ -46,11 +47,13 @@ public:
     void setCardNameBeginning(const QString &_beginning) { cardNameBeginning = _beginning; invalidate(); }
     void setCardName(const QString &_cardName) { cardName = _cardName; invalidate(); }
     void setCardNameSet(const QSet<QString> &_cardNameSet) { cardNameSet = _cardNameSet; invalidate(); }
+    void setSearchTerm(const QString &_searchTerm) { searchTerm = _searchTerm; }
     void setCardText(const QString &_cardText) { cardText = _cardText; invalidate(); }
     void setCardTypes(const QSet<QString> &_cardTypes) { cardTypes = _cardTypes; invalidate(); }
     void setCardColors(const QSet<QString> &_cardColors) { cardColors = _cardColors; invalidate(); }
     void clearSearch();
 protected:
+    bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
     bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
 private slots:
     void filterTreeChanged();


### PR DESCRIPTION
Addresses issues mentioned in #442 

Card search will now order the following way:

1. Exact match at top
2. Exact match with preceding values sorted lexically.
3. Match contained in word sorted lexically

![fixed](https://cloud.githubusercontent.com/assets/2134793/6462488/e54e7352-c1a9-11e4-850c-5a9dd5368c82.png)
