### PR TITLE
Script to add the first admin account

### DIFF
--- a/servatrice/scripts/setup_addfirstadmin
+++ b/servatrice/scripts/setup_addfirstadmin
@@ -1,0 +1,3 @@
+#!/bin/bash
+# SCRIPT TO ADD THE FIRST ADMIN USER NAMED SERVATRICE WITH THE PASSWORD OF PASSWORD
+mysql --defaults-file=./mysql.cnf -h localhost -e "insert into servatrice.cockatrice_users (admin,name,password_sha512,active) values (1,'servatrice','jbB4kSWDmjaVzMNdU13n73SpdBCJTCJ/JYm5ZBZvfxlzbISbXir+e/aSvMz86KzOoaBfidxO0s6GVd8t00qC0TNPl+udHfECaF7MsA==',1);"


### PR DESCRIPTION
Script to add the first admin account to the servatrice database.  Running this script after setting up a servatrice server will add the user account "servatrice" with the password of "password" with admin level access.