### PR TITLE
Anti flood for game commands; fix #753

### DIFF
--- a/cockatrice/src/tab_game.h
+++ b/cockatrice/src/tab_game.h
@@ -198,6 +198,7 @@ private slots:
     void actNextTurn();
 
     void addMentionTag(QString value);
+    void commandFinished(const Response &response);
 public:
     TabGame(TabSupervisor *_tabSupervisor, QList<AbstractClient *> &_clients, const Event_GameJoined &event, const QMap<int, QString> &_roomGameTypes);
     TabGame(TabSupervisor *_tabSupervisor, GameReplay *replay);

--- a/cockatrice/translations/cockatrice_en.ts
+++ b/cockatrice/translations/cockatrice_en.ts
@@ -1776,16 +1776,6 @@ Local version is %1, remote version is %2.</source>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../src/window_main.cpp" line="427"/>
-        <source>Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/window_main.cpp" line="427"/>
-        <source>There are still open games. Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>MessageLogWidget</name>
@@ -3609,7 +3599,7 @@ Local version is %1, remote version is %2.</source>
         <location filename="../src/player.cpp" line="861"/>
         <location filename="../src/player.cpp" line="882"/>
         <location filename="../src/player.cpp" line="911"/>
-        <location filename="../src/player.cpp" line="2113"/>
+        <location filename="../src/player.cpp" line="2114"/>
         <source>Number:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3634,27 +3624,27 @@ Local version is %1, remote version is %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="1959"/>
+        <location filename="../src/player.cpp" line="1960"/>
         <source>Set power/toughness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="1959"/>
+        <location filename="../src/player.cpp" line="1960"/>
         <source>Please enter the new PT:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="2031"/>
+        <location filename="../src/player.cpp" line="2032"/>
         <source>Set annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="2031"/>
+        <location filename="../src/player.cpp" line="2032"/>
         <source>Please enter the new annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="2113"/>
+        <location filename="../src/player.cpp" line="2114"/>
         <source>Set counters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4074,42 +4064,42 @@ Local version is %1, remote version is %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_deck_editor.cpp" line="382"/>
+        <location filename="../src/tab_deck_editor.cpp" line="383"/>
         <source>Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_deck_editor.cpp" line="383"/>
+        <location filename="../src/tab_deck_editor.cpp" line="384"/>
         <source>The decklist has been modified.
 Do you want to save the changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_deck_editor.cpp" line="416"/>
+        <location filename="../src/tab_deck_editor.cpp" line="417"/>
         <source>Load deck</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_deck_editor.cpp" line="435"/>
-        <location filename="../src/tab_deck_editor.cpp" line="459"/>
-        <location filename="../src/tab_deck_editor.cpp" line="479"/>
+        <location filename="../src/tab_deck_editor.cpp" line="436"/>
+        <location filename="../src/tab_deck_editor.cpp" line="460"/>
+        <location filename="../src/tab_deck_editor.cpp" line="480"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_deck_editor.cpp" line="435"/>
+        <location filename="../src/tab_deck_editor.cpp" line="436"/>
         <source>The deck could not be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_deck_editor.cpp" line="459"/>
-        <location filename="../src/tab_deck_editor.cpp" line="479"/>
+        <location filename="../src/tab_deck_editor.cpp" line="460"/>
+        <location filename="../src/tab_deck_editor.cpp" line="480"/>
         <source>The deck could not be saved.
 Please check that the directory is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_deck_editor.cpp" line="465"/>
+        <location filename="../src/tab_deck_editor.cpp" line="466"/>
         <source>Save deck</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4342,17 +4332,22 @@ Please enter a name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_game.cpp" line="1096"/>
+        <location filename="../src/tab_game.cpp" line="859"/>
+        <source>You are flooding the game. Please wait a couple of seconds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tab_game.cpp" line="1107"/>
         <source>You have been kicked out of the game.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_game.cpp" line="1190"/>
+        <location filename="../src/tab_game.cpp" line="1201"/>
         <source>Replay %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_game.cpp" line="1192"/>
+        <location filename="../src/tab_game.cpp" line="1203"/>
         <source>Game %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4493,6 +4488,19 @@ Please enter a name:</source>
     <message>
         <location filename="../src/tab_server.h" line="53"/>
         <source>Server</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TabSupervisor</name>
+    <message>
+        <location filename="../src/tab_supervisor.cpp" line="137"/>
+        <source>Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tab_supervisor.cpp" line="137"/>
+        <source>There are still open games. Are you sure you want to quit?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/cockatrice/translations/cockatrice_en.ts
+++ b/cockatrice/translations/cockatrice_en.ts
@@ -1776,6 +1776,16 @@ Local version is %1, remote version is %2.</source>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../src/window_main.cpp" line="427"/>
+        <source>Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/window_main.cpp" line="427"/>
+        <source>There are still open games. Are you sure you want to quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MessageLogWidget</name>
@@ -3599,7 +3609,7 @@ Local version is %1, remote version is %2.</source>
         <location filename="../src/player.cpp" line="861"/>
         <location filename="../src/player.cpp" line="882"/>
         <location filename="../src/player.cpp" line="911"/>
-        <location filename="../src/player.cpp" line="2114"/>
+        <location filename="../src/player.cpp" line="2113"/>
         <source>Number:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3624,27 +3634,27 @@ Local version is %1, remote version is %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="1960"/>
+        <location filename="../src/player.cpp" line="1959"/>
         <source>Set power/toughness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="1960"/>
+        <location filename="../src/player.cpp" line="1959"/>
         <source>Please enter the new PT:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="2032"/>
+        <location filename="../src/player.cpp" line="2031"/>
         <source>Set annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="2032"/>
+        <location filename="../src/player.cpp" line="2031"/>
         <source>Please enter the new annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="2114"/>
+        <location filename="../src/player.cpp" line="2113"/>
         <source>Set counters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4064,42 +4074,42 @@ Local version is %1, remote version is %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_deck_editor.cpp" line="383"/>
+        <location filename="../src/tab_deck_editor.cpp" line="382"/>
         <source>Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_deck_editor.cpp" line="384"/>
+        <location filename="../src/tab_deck_editor.cpp" line="383"/>
         <source>The decklist has been modified.
 Do you want to save the changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_deck_editor.cpp" line="417"/>
+        <location filename="../src/tab_deck_editor.cpp" line="416"/>
         <source>Load deck</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_deck_editor.cpp" line="436"/>
-        <location filename="../src/tab_deck_editor.cpp" line="460"/>
-        <location filename="../src/tab_deck_editor.cpp" line="480"/>
+        <location filename="../src/tab_deck_editor.cpp" line="435"/>
+        <location filename="../src/tab_deck_editor.cpp" line="459"/>
+        <location filename="../src/tab_deck_editor.cpp" line="479"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_deck_editor.cpp" line="436"/>
+        <location filename="../src/tab_deck_editor.cpp" line="435"/>
         <source>The deck could not be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_deck_editor.cpp" line="460"/>
-        <location filename="../src/tab_deck_editor.cpp" line="480"/>
+        <location filename="../src/tab_deck_editor.cpp" line="459"/>
+        <location filename="../src/tab_deck_editor.cpp" line="479"/>
         <source>The deck could not be saved.
 Please check that the directory is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_deck_editor.cpp" line="466"/>
+        <location filename="../src/tab_deck_editor.cpp" line="465"/>
         <source>Save deck</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4332,22 +4342,17 @@ Please enter a name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_game.cpp" line="859"/>
-        <source>You are flooding the game. Please wait a couple of seconds.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tab_game.cpp" line="1107"/>
+        <location filename="../src/tab_game.cpp" line="1096"/>
         <source>You have been kicked out of the game.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_game.cpp" line="1201"/>
+        <location filename="../src/tab_game.cpp" line="1190"/>
         <source>Replay %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tab_game.cpp" line="1203"/>
+        <location filename="../src/tab_game.cpp" line="1192"/>
         <source>Game %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4488,19 +4493,6 @@ Please enter a name:</source>
     <message>
         <location filename="../src/tab_server.h" line="53"/>
         <source>Server</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>TabSupervisor</name>
-    <message>
-        <location filename="../src/tab_supervisor.cpp" line="137"/>
-        <source>Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tab_supervisor.cpp" line="137"/>
-        <source>There are still open games. Are you sure you want to quit?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/common/server.h
+++ b/common/server.h
@@ -60,8 +60,11 @@ public:
     virtual int getMaxMessageCountPerInterval() const { return 0; }
     virtual int getMaxMessageSizePerInterval() const { return 0; }
     virtual int getMaxGamesPerUser() const { return 0; }
+    virtual int getCommandCountingInterval() const { return 0; }
+    virtual int getMaxCommandCountPerInterval() const { return 0; }
+
     virtual bool getThreaded() const { return false; }
-    
+
     Server_DatabaseInterface *getDatabaseInterface() const;
     int getNextLocalGameId() { QMutexLocker locker(&nextLocalGameIdMutex); return ++nextLocalGameId; }
     

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -217,12 +217,26 @@ Response::ResponseCode Server_ProtocolHandler::processGameCommandContainer(const
     if (!player)
         return Response::RespNotInRoom;
     
+    int commandCountingInterval = server->getCommandCountingInterval();
+    int maxMessageCountPerInterval = server->getMaxMessageCountPerInterval();
     GameEventStorage ges;
     Response::ResponseCode finalResponseCode = Response::RespOk;
     for (int i = cont.game_command_size() - 1; i >= 0; --i) {
         const GameCommand &sc = cont.game_command(i);
         logDebugMessage(QString("game %1 player %2: ").arg(cont.game_id()).arg(roomIdAndPlayerId.second) + QString::fromStdString(sc.ShortDebugString()));
-        
+
+        if (commandCountingInterval > 0) {
+            int totalCount = 0;
+            if (commandCountOverTime.isEmpty())
+                commandCountOverTime.prepend(0);
+            ++commandCountOverTime[0];
+            for (int i = 0; i < commandCountOverTime.size(); ++i)
+                totalCount += commandCountOverTime[i];
+            
+            if (totalCount > maxMessageCountPerInterval)
+                return Response::RespChatFlood;
+        }
+
         Response::ResponseCode resp = player->processGameCommand(sc, rc, ges);
 
         if (resp != Response::RespOk)
@@ -314,7 +328,14 @@ void Server_ProtocolHandler::pingClockTimeout()
         if (messageCountOverTime.size() > server->getMessageCountingInterval())
             messageCountOverTime.removeLast();
     }
-    
+
+    interval = server->getCommandCountingInterval();
+    if (interval > 0) {
+        commandCountOverTime.prepend(0);
+        if (commandCountOverTime.size() > server->getCommandCountingInterval())
+            commandCountOverTime.removeLast();
+    }
+
     if (timeRunning - lastDataReceived > server->getMaxPlayerInactivityTime())
         prepareDestroy();
     ++timeRunning;

--- a/common/server_protocolhandler.h
+++ b/common/server_protocolhandler.h
@@ -51,7 +51,7 @@ protected:
     bool acceptsRoomListChanges;
     virtual void logDebugMessage(const QString & /* message */) { }
 private:
-    QList<int> messageSizeOverTime, messageCountOverTime;
+    QList<int> messageSizeOverTime, messageCountOverTime, commandCountOverTime;
     int timeRunning, lastDataReceived;
     QTimer *pingClock;
 

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -130,7 +130,7 @@ max_users_per_address=4
 ; IP addresses listed (ignoring the max_users_per_address). Default is "127.0.0.1,::1"; example: "192.73.233.244,81.4.100.74"
 trusted_sources="127.0.0.1,::1"
 
-; Servatrice can avoid users from flooding rooms with large number messages in an interval of time.
+; Servatrice can avoid users from flooding rooms with large number of messages in an interval of time.
 ; This setting defines the length in seconds of the considered interval; default is 10
 message_counting_interval=10
 
@@ -143,6 +143,12 @@ max_message_count_per_interval=10
 ; Maximum number of games a single user can create; default is 5
 max_games_per_user=5
 
+; Servatrice can avoid users from flooding games with large number of game commands in an interval of time.
+; This setting defines the length in seconds of the considered interval; default is 10
+command_counting_interval=10
+
+; Maximum number of game commands in an interval before new commands gets dropped; default is 10
+max_command_count_per_interval=10
 
 [logging]
 

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -259,6 +259,8 @@ bool Servatrice::initServer()
     maxMessageCountPerInterval = settingsCache->value("security/max_message_count_per_interval", 10).toInt();
     maxMessageSizePerInterval = settingsCache->value("security/max_message_size_per_interval", 1000).toInt();
     maxGamesPerUser = settingsCache->value("security/max_games_per_user", 5).toInt();
+    commandCountingInterval = settingsCache->value("game/command_counting_interval", 10).toInt();
+    maxCommandCountPerInterval = settingsCache->value("game/max_command_count_per_interval", 10).toInt();
 
 	try { if (settingsCache->value("servernetwork/active", 0).toInt()) {
 		qDebug() << "Connecting to ISL network.";

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -115,8 +115,8 @@ private:
 	QMutex txBytesMutex, rxBytesMutex;
 	quint64 txBytes, rxBytes;
 	int maxGameInactivityTime, maxPlayerInactivityTime;
-	int maxUsersPerAddress, messageCountingInterval, maxMessageCountPerInterval, maxMessageSizePerInterval, maxGamesPerUser;
-	
+	int maxUsersPerAddress, messageCountingInterval, maxMessageCountPerInterval, maxMessageSizePerInterval, maxGamesPerUser, commandCountingInterval, maxCommandCountPerInterval;
+
 	QString shutdownReason;
 	int shutdownMinutes;
 	QTimer *shutdownTimer;
@@ -143,6 +143,8 @@ public:
 	int getMaxMessageCountPerInterval() const { return maxMessageCountPerInterval; }
 	int getMaxMessageSizePerInterval() const { return maxMessageSizePerInterval; }
 	int getMaxGamesPerUser() const { return maxGamesPerUser; }
+    int getCommandCountingInterval() const { return commandCountingInterval; }
+    int getMaxCommandCountPerInterval() const { return maxCommandCountPerInterval; }
 	AuthenticationMethod getAuthenticationMethod() const { return authenticationMethod; }
 	QString getDbPrefix() const { return dbPrefix; }
 	int getServerId() const { return serverId; }


### PR DESCRIPTION
Mitigates #753 and any similar DOS based on sending a lot of commands from an user inside a game.
We already had an antiflood for messages in rooms, but not for game commands in a game.
No timers have been added, so it should not weight a lot on performance.
The default settings is max 10 commands in (the last) 10 seconds, the same for room messages.
I suppose that after some testing we'll end up with an higher limit, but i'd like to hear other opinions on this.