### PR TITLE
Updated card borders

### DIFF
--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -120,14 +120,21 @@ void AbstractCardItem::paintPicture(QPainter *painter, const QSizeF &translatedS
     } else {
         painter->save();
         transformPainter(painter, translatedSize, angle);
-        painter->drawPixmap(QPointF(0, 0), translatedPixmap);
+        painter->drawPixmap(QPointF(0, angle ? -1 : 0), translatedPixmap);
         painter->restore();
     }
     painter->setBrush(bgColor);
+
     QPen pen(Qt::black);
-    pen.setWidth(2);
+    pen.setJoinStyle(Qt::MiterJoin);
+    const int penWidth = 2;
+    pen.setWidth(penWidth);
     painter->setPen(pen);
-    painter->drawRect(QRectF(1, 1, CARD_WIDTH - 2, CARD_HEIGHT - 2));
+
+    if (!angle)
+        painter->drawRect(QRectF(0, 0, CARD_WIDTH - 1, CARD_HEIGHT - penWidth));
+    else
+        painter->drawRect(QRectF(1, 1, CARD_WIDTH - 2, CARD_HEIGHT - 1.5));
     
     if (translatedPixmap.isNull() || settingsCache->getDisplayCardNames() || facedown) {
         painter->save();
@@ -157,13 +164,19 @@ void AbstractCardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *
     painter->save();
     painter->setRenderHint(QPainter::Antialiasing, false);
     transformPainter(painter, translatedSize, tapAngle);
-    if (isSelected()) {
-        painter->setPen(Qt::red);
-        painter->drawRect(QRectF(0.5, 0.5, translatedSize.width() - 1, translatedSize.height() - 1));
-    } else if (isHovered) {
-        painter->setPen(Qt::yellow);
-        painter->drawRect(QRectF(0.5, 0.5, translatedSize.width() - 1, translatedSize.height() - 1));
+
+    if (isSelected() || isHovered) {
+        QPen pen;
+        if (isHovered)
+            pen.setColor(Qt::yellow);
+        if (isSelected())
+            pen.setColor(Qt::red);
+        const int penWidth = 1;
+        pen.setWidth(penWidth);
+        painter->setPen(pen);
+        painter->drawRect(QRectF(0, 0, translatedSize.width() + penWidth, translatedSize.height() - penWidth));
     }
+
     painter->restore();
 
     painter->restore();


### PR DESCRIPTION
+ refactored code
+ improved card border lines (black)
+ cards no longer have curved edges, this prevents card image corners
showing behind. (Compare the lands on the stack)
+ tapped cards now have better border lines
+ Prevents cards having a strange faint shadow effect.

You will need to look very closely to notice the difference. :)

BEFORE:
![before](https://cloud.githubusercontent.com/assets/2134793/6708486/24f7d746-cd71-11e4-94f8-51150e32981b.png)

AFTER:
![after](https://cloud.githubusercontent.com/assets/2134793/6708488/27946afa-cd71-11e4-8747-78928f0a645f.png)
