### PR TITLE
Fix for filter

### DIFF
--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -202,8 +202,8 @@ bool FilterItem::acceptSet(const CardInfo *info) const
 
     status = false;
     for (i = info->getSets().constBegin(); i != info->getSets().constEnd(); i++)
-        if ((*i)->getShortName() == term
-                || (*i)->getLongName().contains(term, Qt::CaseInsensitive)) {
+        if ((*i)->getShortName().compare(term, Qt::CaseInsensitive) == 0 
+            || (*i)->getLongName().compare(term, Qt::CaseInsensitive) == 0) {
             status = true;
             break;
         }


### PR DESCRIPTION
fix for #749
+ You can now search for sets using lower case: "frf", "dtk", "rtr" and
so on.
+ You now need exact matches on set short and full names. "rtr" and
"return to ravnica" will work. "return" will not work.

![after](https://cloud.githubusercontent.com/assets/2134793/6721906/c39bf6fa-cdd2-11e4-8efd-66511fe413b9.png)
