### PR TITLE
Failed logins reopen login dlg

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -268,6 +268,7 @@ void MainWindow::loginError(Response::ResponseCode r, QString reasonStr, quint32
         default:
             QMessageBox::critical(this, tr("Error"), tr("Unknown login error: %1").arg(static_cast<int>(r)));
     }
+    actConnect();
 }
 
 void MainWindow::socketError(const QString &errorStr)


### PR DESCRIPTION
If you fail a login you are returned to the login dialog. 
#875 