### PR TITLE
Cast to target from hand

### DIFF
--- a/cockatrice/src/arrowitem.cpp
+++ b/cockatrice/src/arrowitem.cpp
@@ -6,6 +6,7 @@
 #include "carditem.h"
 #include "cardzone.h"
 #include "player.h"
+#include "settingscache.h"
 #include <QPainter>
 #include <QGraphicsSceneMouseEvent>
 #include <QGraphicsScene>
@@ -17,16 +18,16 @@
 #include "pb/command_delete_arrow.pb.h"
 
 ArrowItem::ArrowItem(Player *_player, int _id, ArrowTarget *_startItem, ArrowTarget *_targetItem, const QColor &_color)
-        : QGraphicsItem(), player(_player), id(_id), startItem(_startItem), targetItem(_targetItem), color(_color), fullColor(true)
+    : QGraphicsItem(), player(_player), id(_id), startItem(_startItem), targetItem(_targetItem), color(_color), fullColor(true)
 {
     qDebug() << "ArrowItem constructor: startItem=" << static_cast<QGraphicsItem *>(startItem);
     setZValue(2000000005);
-    
+
     if (startItem)
         startItem->addArrowFrom(this);
     if (targetItem)
         targetItem->addArrowTo(this);
-    
+
     if (startItem && targetItem)
         updatePath();
 }
@@ -42,13 +43,13 @@ void ArrowItem::delArrow()
         startItem->removeArrowFrom(this);
         startItem = 0;
     }
-    
+
     if (targetItem) {
         targetItem->setBeingPointedAt(false);
         targetItem->removeArrowTo(this);
         targetItem = 0;
     }
-    
+
     player->removeArrow(this);
     deleteLater();
 }
@@ -57,7 +58,7 @@ void ArrowItem::updatePath()
 {
     if (!targetItem)
         return;
-    
+
     QPointF endPoint = targetItem->mapToScene(QPointF(targetItem->boundingRect().width() / 2, targetItem->boundingRect().height() / 2));
     updatePath(endPoint);
 }
@@ -68,24 +69,24 @@ void ArrowItem::updatePath(const QPointF &endPoint)
     const double headWidth = 40.0;
     const double headLength = headWidth / pow(2, 0.5); // aka headWidth / sqrt (2) but this produces a compile error with MSVC++
     const double phi = 15;
-    
+
     if (!startItem)
         return;
-    
+
     QPointF startPoint = startItem->mapToScene(QPointF(startItem->boundingRect().width() / 2, startItem->boundingRect().height() / 2));
     QLineF line(startPoint, endPoint);
     qreal lineLength = line.length();
-    
+
     prepareGeometryChange();
     if (lineLength < 30)
         path = QPainterPath();
     else {
         QPointF c(lineLength / 2, tan(phi * M_PI / 180) * lineLength);
-        
+
         QPainterPath centerLine;
         centerLine.moveTo(0, 0);
         centerLine.quadTo(c, QPointF(lineLength, 0));
-        
+
         double percentage = 1 - headLength / lineLength;
         QPointF arrowBodyEndPoint = centerLine.pointAtPercent(percentage);
         QLineF testLine(arrowBodyEndPoint, centerLine.pointAtPercent(percentage + 0.001));
@@ -94,7 +95,7 @@ void ArrowItem::updatePath(const QPointF &endPoint)
         QPointF endPoint2 = arrowBodyEndPoint + arrowWidth / 2 * QPointF(-cos(alpha * M_PI / 180), sin(alpha * M_PI / 180));
         QPointF point1 = endPoint1 + (headWidth - arrowWidth) / 2 * QPointF(cos(alpha * M_PI / 180), -sin(alpha * M_PI / 180));
         QPointF point2 = endPoint2 + (headWidth - arrowWidth) / 2 * QPointF(-cos(alpha * M_PI / 180), sin(alpha * M_PI / 180));
-        
+
         path = QPainterPath(-arrowWidth / 2 * QPointF(cos((phi - 90) * M_PI / 180), sin((phi - 90) * M_PI / 180)));
         path.quadTo(c, endPoint1);
         path.lineTo(point1);
@@ -104,7 +105,7 @@ void ArrowItem::updatePath(const QPointF &endPoint)
         path.quadTo(c, arrowWidth / 2 * QPointF(cos((phi - 90) * M_PI / 180), sin((phi - 90) * M_PI / 180)));
         path.lineTo(-arrowWidth / 2 * QPointF(cos((phi - 90) * M_PI / 180), sin((phi - 90) * M_PI / 180)));
     }
-    
+
     setPos(startPoint);
     setTransform(QTransform().rotate(-line.angle()));
 }
@@ -126,24 +127,24 @@ void ArrowItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
         event->ignore();
         return;
     }
-    
+
     QList<QGraphicsItem *> colliding = scene()->items(event->scenePos());
     for (int i = 0; i < colliding.size(); ++i)
         if (qgraphicsitem_cast<CardItem *>(colliding[i])) {
             event->ignore();
             return;
         }
-    
-    event->accept();
-    if (event->button() == Qt::RightButton) {
-        Command_DeleteArrow cmd;
-        cmd.set_arrow_id(id);
-        player->sendGameCommand(cmd);
-    }
+
+        event->accept();
+        if (event->button() == Qt::RightButton) {
+            Command_DeleteArrow cmd;
+            cmd.set_arrow_id(id);
+            player->sendGameCommand(cmd);
+        }
 }
 
 ArrowDragItem::ArrowDragItem(Player *_owner, ArrowTarget *_startItem, const QColor &_color)
-        : ArrowItem(_owner, -1, _startItem, 0, _color)
+    : ArrowItem(_owner, -1, _startItem, 0, _color)
 {
 }
 
@@ -158,9 +159,9 @@ void ArrowDragItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
     // the event will be discarded as it would create some stray pointers.
     if (!startItem)
         return;
-    
+
     QPointF endPos = event->scenePos();
-    
+
     QList<QGraphicsItem *> colliding = scene()->items(endPos);
     ArrowTarget *cursorItem = 0;
     qreal cursorItemZ = -1;
@@ -170,36 +171,36 @@ void ArrowDragItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
                 cursorItem = static_cast<ArrowTarget *>(colliding.at(i));
                 cursorItemZ = cursorItem->zValue();
             }
-    if ((cursorItem != targetItem) && targetItem) {
-        targetItem->setBeingPointedAt(false);
-        targetItem->removeArrowTo(this);
-    }
-        if (!cursorItem) {
-        fullColor = false;
-        targetItem = 0;
-        updatePath(endPos);
-    } else {
-        if (cursorItem != targetItem) {
-            fullColor = true;
-            if (cursorItem != startItem) {
-                cursorItem->setBeingPointedAt(true);
-                cursorItem->addArrowTo(this);
+            if ((cursorItem != targetItem) && targetItem) {
+                targetItem->setBeingPointedAt(false);
+                targetItem->removeArrowTo(this);
             }
-            targetItem = cursorItem;
-        }
-        updatePath();
-    }
-    update();
-    
-    for (int i = 0; i < childArrows.size(); ++i)
-        childArrows[i]->mouseMoveEvent(event);
+            if (!cursorItem) {
+                fullColor = false;
+                targetItem = 0;
+                updatePath(endPos);
+            } else {
+                if (cursorItem != targetItem) {
+                    fullColor = true;
+                    if (cursorItem != startItem) {
+                        cursorItem->setBeingPointedAt(true);
+                        cursorItem->addArrowTo(this);
+                    }
+                    targetItem = cursorItem;
+                }
+                updatePath();
+            }
+            update();
+
+            for (int i = 0; i < childArrows.size(); ++i)
+                childArrows[i]->mouseMoveEvent(event);
 }
 
 void ArrowDragItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     if (!startItem)
         return;
-    
+
     if (targetItem && (targetItem != startItem)) {
         CardZone *startZone = static_cast<CardItem *>(startItem)->getZone();
         // For now, we can safely assume that the start item is always a card.
@@ -214,6 +215,8 @@ void ArrowDragItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
         cmd.set_start_card_id(startCard->getId());
 
         if (targetCard) {
+            CardZone *startZone = startCard->getZone();
+            
             CardZone *targetZone = targetCard->getZone();
             cmd.set_target_player_id(targetZone->getPlayer()->getId());
             cmd.set_target_zone(targetZone->getName().toStdString());
@@ -221,6 +224,10 @@ void ArrowDragItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
         } else {
             PlayerTarget *targetPlayer = qgraphicsitem_cast<PlayerTarget *>(targetItem);
             cmd.set_target_player_id(targetPlayer->getOwner()->getId());
+        }
+        if (startZone->getName().compare("hand") == 0)  {
+            startCard->playCard(false);
+            cmd.set_start_zone(settingsCache->getPlayToStack() ? "stack" :"table");
         }
         player->sendGameCommand(cmd);
     }
@@ -231,7 +238,7 @@ void ArrowDragItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 }
 
 ArrowAttachItem::ArrowAttachItem(ArrowTarget *_startItem)
-        : ArrowItem(_startItem->getOwner(), -1, _startItem, 0, Qt::green)
+    : ArrowItem(_startItem->getOwner(), -1, _startItem, 0, Qt::green)
 {
 }
 
@@ -241,31 +248,31 @@ void ArrowAttachItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
         return;
 
     QPointF endPos = event->scenePos();
-    
+
     QList<QGraphicsItem *> colliding = scene()->items(endPos);
-        ArrowTarget *cursorItem = 0;
+    ArrowTarget *cursorItem = 0;
     qreal cursorItemZ = -1;
-        for (int i = colliding.size() - 1; i >= 0; i--)
-                if (qgraphicsitem_cast<CardItem *>(colliding.at(i)))
+    for (int i = colliding.size() - 1; i >= 0; i--)
+        if (qgraphicsitem_cast<CardItem *>(colliding.at(i)))
             if (colliding.at(i)->zValue() > cursorItemZ) {
                 cursorItem = static_cast<ArrowTarget *>(colliding.at(i));
                 cursorItemZ = cursorItem->zValue();
             }
-            
-    if ((cursorItem != targetItem) && targetItem)
-        targetItem->setBeingPointedAt(false);
-        if (!cursorItem) {
-        fullColor = false;
-        targetItem = 0;
-        updatePath(endPos);
-    } else {
-        fullColor = true;
-        if (cursorItem != startItem)
-            cursorItem->setBeingPointedAt(true);
-        targetItem = cursorItem;
-        updatePath();
-    }
-    update();
+
+            if ((cursorItem != targetItem) && targetItem)
+                targetItem->setBeingPointedAt(false);
+            if (!cursorItem) {
+                fullColor = false;
+                targetItem = 0;
+                updatePath(endPos);
+            } else {
+                fullColor = true;
+                if (cursorItem != startItem)
+                    cursorItem->setBeingPointedAt(true);
+                targetItem = cursorItem;
+                updatePath();
+            }
+            update();
 }
 
 void ArrowAttachItem::mouseReleaseEvent(QGraphicsSceneMouseEvent * /*event*/)
@@ -278,7 +285,7 @@ void ArrowAttachItem::mouseReleaseEvent(QGraphicsSceneMouseEvent * /*event*/)
         CardZone *startZone = startCard->getZone();
         CardItem *targetCard = qgraphicsitem_cast<CardItem *>(targetItem);
         CardZone *targetZone = targetCard->getZone();
-        
+
         Command_AttachCard cmd;
         cmd.set_start_zone(startZone->getName().toStdString());
         cmd.set_card_id(startCard->getId());
@@ -288,6 +295,6 @@ void ArrowAttachItem::mouseReleaseEvent(QGraphicsSceneMouseEvent * /*event*/)
 
         player->sendGameCommand(cmd);
     }
-    
+
     delArrow();
 }


### PR DESCRIPTION
Users can now target from their hand. This will cast the card and point
to the target.

This will also work for users who cast to the table (an option in the settings).

Cast like this:

![before](https://cloud.githubusercontent.com/assets/2134793/6857455/22d1785e-d407-11e4-8512-b4def446706b.png)


Results in this:

![after](https://cloud.githubusercontent.com/assets/2134793/6857460/2aa5cfee-d407-11e4-91bc-819bb9c7e37d.png)
