### PR TITLE
Fix double popup on delete pics

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -39,9 +39,6 @@ GeneralSettingsPage::GeneralSettingsPage()
     }
 
     picDownloadCheckBox.setChecked(settingsCache->getPicDownload());
-    
-    connect(&clearDownloadedPicsButton, SIGNAL(clicked()), this, SLOT(clearDownloadedPicsButtonClicked()));
-
     picDownloadHqCheckBox.setChecked(settingsCache->getPicDownloadHq());
 
     pixmapCacheEdit.setMinimum(PIXMAPCACHE_SIZE_MIN);


### PR DESCRIPTION
I noticed when I hit the button to clear my cards that two popups would appear.

It seems as if there were two `connect` options for the same signal, so I simply deleted one of them.

Works as expected and is a minor fix.