### PR TITLE
tray icon is now hidden and then removed

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -425,6 +425,8 @@ MainWindow::MainWindow(QWidget *parent)
 
 MainWindow::~MainWindow()
 {
+    trayIcon->hide();
+    trayIcon->deleteLater();
     client->deleteLater();
     clientThread->wait();
 }


### PR DESCRIPTION
I noticed that sometimes I would have lots of icons in the sys tray. I
would have to mouse over them to make then be removed. This also happens
with some other programs too. I have added some code to hide() the sys
icon when the client is close, it seems to be helping with the issue.
Hard to reproduce, might also only be a windows issue.