### PR TITLE
Fixed order of the counters

### DIFF
--- a/cockatrice/src/abstractcounter.cpp
+++ b/cockatrice/src/abstractcounter.cpp
@@ -23,7 +23,7 @@ AbstractCounter::AbstractCounter(Player *_player, int _id, const QString &_name,
         connect(aSet, SIGNAL(triggered()), this, SLOT(setCounter()));
         menu->addAction(aSet);
         menu->addSeparator();
-        for (int i = -10; i <= 10; ++i)
+        for (int i = 10; i >= -10; --i)
             if (i == 0)
                 menu->addSeparator();
             else {


### PR DESCRIPTION
Previously had - numbers at the top and + at the bottom.
This feels like it makes more sense.

![counters](https://cloud.githubusercontent.com/assets/2134793/6928331/813c4eec-d7f3-11e4-9875-a441b98b5a0f.png)
