### PR TITLE
Fixed accidental +/- of counters when using middle click menu

### DIFF
--- a/cockatrice/src/abstractcounter.cpp
+++ b/cockatrice/src/abstractcounter.cpp
@@ -88,23 +88,25 @@ void AbstractCounter::setValue(int _value)
 
 void AbstractCounter::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-    if (event->button() == Qt::LeftButton) {
-        Command_IncCounter cmd;
-        cmd.set_counter_id(id);
-        cmd.set_delta(1);
-        player->sendGameCommand(cmd);
-        event->accept();
-    } else if (event->button() == Qt::RightButton) {
-        Command_IncCounter cmd;
-        cmd.set_counter_id(id);
-        cmd.set_delta(-1);
-        player->sendGameCommand(cmd);
-        event->accept();
-    } else if (event->button() == Qt::MidButton) {
-        if (menu)
-            menu->exec(event->screenPos());
-        event->accept();
-    } else
+    if (isUnderMouse()) {
+        if (event->button() == Qt::LeftButton && isUnderMouse()) {
+            Command_IncCounter cmd;
+            cmd.set_counter_id(id);
+            cmd.set_delta(1);
+            player->sendGameCommand(cmd);
+            event->accept();
+        } else if (event->button() == Qt::RightButton && isUnderMouse()) {
+            Command_IncCounter cmd;
+            cmd.set_counter_id(id);
+            cmd.set_delta(-1);
+            player->sendGameCommand(cmd);
+            event->accept();
+        } else if (event->button() == Qt::MidButton && isUnderMouse()) {
+            if (menu)
+                menu->exec(event->screenPos());
+            event->accept();
+        } 
+    }else
         event->ignore();
 }
 

--- a/cockatrice/src/abstractcounter.cpp
+++ b/cockatrice/src/abstractcounter.cpp
@@ -89,19 +89,19 @@ void AbstractCounter::setValue(int _value)
 void AbstractCounter::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
     if (isUnderMouse()) {
-        if (event->button() == Qt::LeftButton && isUnderMouse()) {
+        if (event->button() == Qt::LeftButton) {
             Command_IncCounter cmd;
             cmd.set_counter_id(id);
             cmd.set_delta(1);
             player->sendGameCommand(cmd);
             event->accept();
-        } else if (event->button() == Qt::RightButton && isUnderMouse()) {
+        } else if (event->button() == Qt::RightButton) {
             Command_IncCounter cmd;
             cmd.set_counter_id(id);
             cmd.set_delta(-1);
             player->sendGameCommand(cmd);
             event->accept();
-        } else if (event->button() == Qt::MidButton && isUnderMouse()) {
+        } else if (event->button() == Qt::MidButton) {
             if (menu)
                 menu->exec(event->screenPos());
             event->accept();


### PR DESCRIPTION
Previously if you middle click on a counter (life/mana) and then click
away, depending on the button clicked, the counter would +/-.

I have added a fix to make sure the mouse is over the counter to change
it.