### PR TITLE
Added Mull to the server whitelist

### DIFF
--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -194,7 +194,9 @@ Response::ResponseCode Server_ProtocolHandler::processGameCommandContainer(const
         // set card attributes (eg: tapping 10 cards at once)
         << GameCommand::SET_CARD_ATTR
         // increment / decrement counter (eg: -10 lifepoints one by one)
-        << GameCommand::INC_COUNTER;
+        << GameCommand::INC_COUNTER
+        // mulling lots of hands in a row
+        << GameCommand::MULLIGAN;
 
     if (authState == NotLoggedIn)
         return Response::RespLoginNeeded;


### PR DESCRIPTION
Mullling through 2 hands will give a flood warning, a user thought this
should not happen. It is very similar to drawing cards, which is in the
white list.