### PR TITLE
Left hand justification

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -309,9 +309,13 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     
     horizontalHandCheckBox.setChecked(settingsCache->getHorizontalHand());
     connect(&horizontalHandCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setHorizontalHand(int)));
+
+    leftJustifiedHandCheckBox.setChecked(settingsCache->getLeftJustified());
+    connect(&leftJustifiedHandCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setLeftJustified(int)));
     
     QGridLayout *handGrid = new QGridLayout;
     handGrid->addWidget(&horizontalHandCheckBox, 0, 0, 1, 2);
+    handGrid->addWidget(&leftJustifiedHandCheckBox, 1, 0, 1, 2);
     
     handGroupBox = new QGroupBox;
     handGroupBox->setLayout(handGrid);
@@ -356,6 +360,7 @@ void AppearanceSettingsPage::retranslateUi()
     
     handGroupBox->setTitle(tr("Hand layout"));
     horizontalHandCheckBox.setText(tr("Display hand horizontally (wastes space)"));
+    leftJustifiedHandCheckBox.setText(tr("Enable left justification"));
     
     tableGroupBox->setTitle(tr("Table grid layout"));
     invertVerticalCoordinateCheckBox.setText(tr("Invert vertical coordinate"));

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -100,6 +100,7 @@ private:
     QCheckBox displayCardNamesCheckBox;
     QCheckBox cardScalingCheckBox;
     QCheckBox horizontalHandCheckBox;
+    QCheckBox leftJustifiedHandCheckBox;
     QCheckBox invertVerticalCoordinateCheckBox;
     QGroupBox *zoneBgGroupBox;
     QGroupBox *cardsGroupBox;

--- a/cockatrice/src/handzone.cpp
+++ b/cockatrice/src/handzone.cpp
@@ -88,19 +88,22 @@ void HandZone::reorganizeCards()
     if (!cards.isEmpty()) {
         const int cardCount = cards.size();
         if (settingsCache->getHorizontalHand()) {
-            const int xPadding = 5;
-            qreal totalWidth = boundingRect().width() - 2 * xPadding;
+            bool leftJustified = settingsCache->getLeftJustified();
             qreal cardWidth = cards.at(0)->boundingRect().width();
+            const int xPadding = leftJustified ? cardWidth * 1.4 : 5;
+            qreal totalWidth = leftJustified? boundingRect().width() - (1 * xPadding) - 5 : boundingRect().width() - 2 * xPadding;
             
             for (int i = 0; i < cardCount; i++) {
                 CardItem *c = cards.at(i);
-    
                 // If the total width of the cards is smaller than the available width,
                 // the cards do not need to overlap and are displayed in the center of the area.
                 if (cardWidth * cardCount > totalWidth)
                     c->setPos(xPadding + ((qreal) i) * (totalWidth - cardWidth) / (cardCount - 1), 5);
-                else
-                    c->setPos(xPadding + ((qreal) i) * cardWidth + (totalWidth - cardCount * cardWidth) / 2, 5);
+                else {
+                    qreal xPosition = leftJustified ? xPadding + ((qreal) i) * cardWidth : 
+                        xPadding + ((qreal) i) * cardWidth + (totalWidth - cardCount * cardWidth) / 2;
+                    c->setPos(xPosition, 5);
+                }
                 c->setRealZValue(i);
             }
         } else {

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -115,6 +115,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
     userInfo->CopyFrom(info);
     
     connect(settingsCache, SIGNAL(horizontalHandChanged()), this, SLOT(rearrangeZones()));
+    connect(settingsCache, SIGNAL(handJustificationChanged()), this, SLOT(rearrangeZones()));
     
     playerArea = new PlayerArea(this);
     

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -77,6 +77,14 @@ SettingsCache::SettingsCache()
     scaleCards = settings->value("cards/scaleCards", true).toBool();
     showMessagePopups = settings->value("chat/showmessagepopups", true).toBool();
     showMentionPopups = settings->value("chat/showmentionpopups", true).toBool();
+
+    leftJustified = settings->value("interface/leftjustified", false).toBool();
+}
+
+void SettingsCache::setLeftJustified(const int _leftJustified) {
+    leftJustified = _leftJustified;
+    settings->setValue("interface/leftjustified", leftJustified);
+    emit handJustificationChanged();
 }
 
 void SettingsCache::setCardScaling(const int _scaleCards) {

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -30,6 +30,7 @@ signals:
     void picDownloadHqChanged();
     void displayCardNamesChanged();
     void horizontalHandChanged();
+    void handJustificationChanged();
     void invertVerticalCoordinateChanged();
     void minPlayersForMultiColumnLayoutChanged();
     void soundEnabledChanged();
@@ -77,6 +78,7 @@ private:
     bool scaleCards;
     bool showMessagePopups;
     bool showMentionPopups;
+    bool leftJustified;
 public:
     SettingsCache();
     const QByteArray &getMainWindowGeometry() const { return mainWindowGeometry; }
@@ -131,6 +133,7 @@ public:
     bool getScaleCards() const {  return scaleCards; }
     bool getShowMessagePopup() const { return showMessagePopups; }
     bool getShowMentionPopup() const { return showMentionPopups; }
+    bool getLeftJustified() const { return leftJustified; }
 public slots:
     void setMainWindowGeometry(const QByteArray &_mainWindowGeometry);
     void setLang(const QString &_lang);
@@ -178,6 +181,7 @@ public slots:
     void setCardScaling(const int _scaleCards);
     void setShowMessagePopups(const int _showMessagePopups);
     void setShowMentionPopups(const int _showMentionPopups);
+    void setLeftJustified( const int _leftJustified);
 };
 
 extern SettingsCache *settingsCache;


### PR DESCRIPTION
As all cards are played to the left of the screen by default this feels more
comfortable to use as you dont need to keep looking at different areas
of the screen.

+ Set to false by default, let me know if you think it should be true.
+ can be toggled in the settings.
+ Will auto rearrange when changed during game-play.
+ allows users to use clients with less width, without downscaling play area(depending on hand size)

![left](https://cloud.githubusercontent.com/assets/2134793/6962754/daf334ba-d937-11e4-93b1-13747f5d2c63.png)



