### PR TITLE
Default to one player

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -135,7 +135,7 @@ void MainWindow::actDisconnect()
 void MainWindow::actSinglePlayer()
 {
     bool ok;
-    int numberPlayers = QInputDialog::getInt(this, tr("Number of players"), tr("Please enter the number of players."), 2, 1, 8, 1, &ok);
+    int numberPlayers = QInputDialog::getInt(this, tr("Number of players"), tr("Please enter the number of players."), 1, 1, 8, 1, &ok);
     if (!ok)
         return;
     


### PR DESCRIPTION
I think the majority of players use this feature for
goldfishing/practicing. Defaulting to one player for convenience.

![oneplayer](https://cloud.githubusercontent.com/assets/2134793/6963120/8d4583a4-d93b-11e4-81ae-34a23dcd0916.png)
