### PR TITLE
Large decks (up to 8000-ish cards) no longer make client crash; Fix #67

### DIFF
--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -91,7 +91,10 @@ void AbstractCardItem::paintPicture(QPainter *painter, const QSizeF &translatedS
     
     CardInfo *imageSource = facedown ? db->getCard() : info;
     QPixmap translatedPixmap;
-    imageSource->getPixmap(translatedSize.toSize(), translatedPixmap);
+    // don't even spend time trying to load the picture if our size is too small
+    if(translatedSize.width() > 10)
+        imageSource->getPixmap(translatedSize.toSize(), translatedPixmap);        
+
     painter->save();
     QColor bgColor = Qt::transparent;
     if (translatedPixmap.isNull()) {

--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -970,7 +970,9 @@ QStringList CardDatabase::getAllMainCardTypes() const
 void CardDatabase::cacheCardPixmaps(const QStringList &cardNames)
 {
     QPixmap tmp;
-    for (int i = 0; i < cardNames.size(); ++i)
+    // never cache more than 300 cards at once for a single deck
+    int max = qMin(cardNames.size(), 300);
+    for (int i = 0; i < max; ++i)
         getCard(cardNames[i])->loadPixmap(tmp);
 }
 


### PR DESCRIPTION
Workaround the two remaining issues, mostly fixing the “load deck” screen in tab_game:
 * Only preload up to the first 300 cards of a deck;
 * don’t even bother trying to load card images if they’ll be shown with width <= 10;

Trying a 17k cards deck like the one proposed in #67 is still a no go, mostly due to the cpu time used by trice to create all the card objects. Anyway, i tested decks up to 8k cards and they works fine now (if you like to wait while trice is loading them).