### PR TITLE
Mention popup fix

### DIFF
--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -5,13 +5,11 @@
 #include <QDesktopServices>
 #include <QApplication>
 #include <QDebug>
-#include <QSystemTrayIcon>
 #include "chatview.h"
 #include "user_level.h"
 #include "user_context_menu.h"
 #include "pixmapgenerator.h"
 #include "settingscache.h"
-#include "main.h"
 #include "tab_userlists.h"
 
 const QColor DEFAULT_MENTION_COLOR = QColor(194, 31, 47);
@@ -282,9 +280,7 @@ bool ChatView::shouldShowSystemPopup() {
 }
 
 void ChatView::showSystemPopup(QString &sender) {
-    disconnect(trayIcon, SIGNAL(messageClicked()), 0, 0);
-    trayIcon->showMessage(sender + tr(" mentioned you."), tr("Click to view"));
-    connect(trayIcon, SIGNAL(messageClicked()), this, SLOT(actMessageClicked()));
+    emit showMentionPopup(sender);
 }
 
 

--- a/cockatrice/src/chatview.h
+++ b/cockatrice/src/chatview.h
@@ -65,6 +65,7 @@ signals:
     void deleteCardInfoPopup(QString cardName);
     void addMentionTag(QString mentionTag);
     void messageClickedSignal();
+    void showMentionPopup(QString &sender);
 };
 
 #endif

--- a/cockatrice/src/tab_room.cpp
+++ b/cockatrice/src/tab_room.cpp
@@ -10,6 +10,7 @@
 #include <QToolButton>
 #include <QSplitter>
 #include <QApplication>
+#include <QSystemTrayIcon>
 #include "tab_supervisor.h"
 #include "tab_room.h"
 #include "tab_userlists.h"
@@ -18,6 +19,7 @@
 #include "chatview.h"
 #include "gameselector.h"
 #include "settingscache.h"
+#include "main.h"
 
 #include "get_pb_extension.h"
 #include "pb/room_commands.pb.h"
@@ -43,6 +45,7 @@ TabRoom::TabRoom(TabSupervisor *_tabSupervisor, AbstractClient *_client, ServerI
     connect(userList, SIGNAL(openMessageDialog(const QString &, bool)), this, SIGNAL(openMessageDialog(const QString &, bool)));
 
     chatView = new ChatView(tabSupervisor, 0, true);
+    connect(chatView, SIGNAL(showMentionPopup(QString&)), this, SLOT(actShowMentionPopup(QString&)));
     connect(chatView, SIGNAL(messageClickedSignal()), this, SLOT(focusTab()));
     connect(chatView, SIGNAL(openMessageDialog(QString, bool)), this, SIGNAL(openMessageDialog(QString, bool)));
     connect(chatView, SIGNAL(showCardInfoPopup(QPoint, QString)), this, SLOT(showCardInfoPopup(QPoint, QString)));
@@ -130,6 +133,15 @@ void TabRoom::retranslateUi()
 void TabRoom::focusTab() {
     QApplication::setActiveWindow(this);
     tabSupervisor->setCurrentIndex(tabSupervisor->indexOf(this));
+}
+
+void TabRoom::actShowMentionPopup(QString &sender) {
+    if (tabSupervisor->currentIndex() != tabSupervisor->indexOf(this) 
+        || QApplication::activeWindow() == 0 || QApplication::focusWidget() == 0) {
+        disconnect(trayIcon, SIGNAL(messageClicked()), 0, 0);
+        trayIcon->showMessage(sender + tr(" mentioned you."), tr("Click to view"));
+        connect(trayIcon, SIGNAL(messageClicked()), chatView, SLOT(actMessageClicked()));
+    }
 }
 
 void TabRoom::closeRequest()

--- a/cockatrice/src/tab_room.h
+++ b/cockatrice/src/tab_room.h
@@ -57,6 +57,7 @@ private slots:
     void actOpenChatSettings();
     void addMentionTag(QString mentionTag);
     void focusTab();
+    void actShowMentionPopup(QString &sender);
     
     void processListGamesEvent(const Event_ListGames &event);
     void processJoinRoomEvent(const Event_JoinRoom &event);


### PR DESCRIPTION
+ will now only popup with a mention alert when you are not on the same
tab/window.
+ will also no longer popup by mentioning yourself