### PR TITLE
Ignore punctuation in card search

### DIFF
--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -152,8 +152,9 @@ bool CardDatabaseDisplayModel::filterAcceptsRow(int sourceRow, const QModelIndex
         return false;
 
     if (!cardName.isEmpty())
-        if (!info->getName().contains(cardName, Qt::CaseInsensitive))
-            return false;
+        if (!info->getName().contains(cardName, Qt::CaseInsensitive)) 
+            if (!CardInfo::simplifyName(info->getName()).contains(cardName, Qt::CaseInsensitive))
+                return false;
 
     if (filterTree != NULL)
         return filterTree->acceptsCard(info);


### PR DESCRIPTION
It is awkward to have to use precise punctuation when searching for
cards. Planeswalkers and legendary creatures often have "," in the name
and you have to enter it.

This commit means you no longer need to do that.

+ Can use " " in place of "-" (example: Wilt-Leaf Liege)
+ Can use "" in place of non word chars (Example: Hero's Downfall and
Ajani, Caller of the Pride)

![search](https://cloud.githubusercontent.com/assets/2134793/7031579/da77c120-dd6c-11e4-80de-9b403fa72832.png)

EDIT: 
This also works when using [[heros downfall]] and [card]heros downfall[/card] throughout the client :)
