### PR TITLE
Fixed double click sys icon

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -447,7 +447,7 @@ void MainWindow::createTrayIcon() {
 
 void MainWindow::iconActivated(QSystemTrayIcon::ActivationReason reason) {
     if (reason == QSystemTrayIcon::DoubleClick) {
-        if (windowState() != Qt::WindowMinimized)
+        if (windowState() != Qt::WindowMinimized && windowState() != Qt::WindowMinimized + Qt::WindowMaximized)
             showMinimized();
         else {
             showNormal();


### PR DESCRIPTION
Was an issue with double clicking the icon when the app was full screen/
fullscreen + minimized.

Now works as expected.