### PR TITLE
Removed compile time ssize_t warnings

### DIFF
--- a/servatrice/src/server_logger.cpp
+++ b/servatrice/src/server_logger.cpp
@@ -122,23 +122,27 @@ void ServerLogger::flushBuffer()
 void ServerLogger::hupSignalHandler(int /*unused*/)
 {
 #ifdef Q_OS_UNIX
+    ssize_t writeValue = NULL;
+
     if (!logFile)
         return;
     
     char a = 1;
-    ::write(sigHupFD[0], &a, sizeof(a));
+    writeValue = ::write(sigHupFD[0], &a, sizeof(a));
 #endif
 }
 
 void ServerLogger::handleSigHup()
 {
 #ifdef Q_OS_UNIX
+    ssize_t readValue = NULL;
+
     if (!logFile)
         return;
     
     snHup->setEnabled(false);
     char tmp;
-    ::read(sigHupFD[1], &tmp, sizeof(tmp));
+    readValue = ::read(sigHupFD[1], &tmp, sizeof(tmp));
     
     logFile->close();
     logFile->open(QIODevice::Append);


### PR DESCRIPTION
On Linux (and maybe OSX though OSX is not tested), when compiling I get a warning:

"ignoring return value of ‘ssize_t write(int, const void*, size_t)’, declared with attribute warn_unused_result"

and

"warning: ignoring return value of ‘ssize_t read(int, void*, size_t)’, declared with attribute warn_unused_result"

I fixed it by adding variables.