### PR TITLE
Fixed deck tokens showing in token dlg

### DIFF
--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -156,6 +156,10 @@ bool CardDatabaseDisplayModel::filterAcceptsRow(int sourceRow, const QModelIndex
             if (!CardInfo::simplifyName(info->getName()).contains(cardName, Qt::CaseInsensitive))
                 return false;
 
+    if (!cardNameSet.isEmpty())
+            if (!cardNameSet.contains(info->getName()))
+                return false;
+
     if (filterTree != NULL)
         return filterTree->acceptsCard(info);
 


### PR DESCRIPTION
Tokens from decks will now show in the token dlg window:

![fix](https://cloud.githubusercontent.com/assets/2134793/7078631/2c4b6b0a-df1b-11e4-8078-35eed0a35b54.png)
