### PR TITLE
Fixed incorrect zone positioning in multi-column layout

### DIFF
--- a/cockatrice/src/gamescene.cpp
+++ b/cockatrice/src/gamescene.cpp
@@ -198,8 +198,14 @@ void GameScene::processViewSizeChange(const QSize &newSize)
 
     qreal extraWidthPerColumn = (newWidth - minWidth) / playersByColumn.size();
     for (int col = 0; col < playersByColumn.size(); ++col)
-        for (int row = 0; row < playersByColumn[col].size(); ++row)
-            playersByColumn[col][row]->processSceneSizeChange(minWidthByColumn[col] + extraWidthPerColumn);
+		for (int row = 0; row < playersByColumn[col].size(); ++row){
+			playersByColumn[col][row]->processSceneSizeChange(minWidthByColumn[col] + extraWidthPerColumn);
+			if (col == 0)
+				playersByColumn[col][row]->setPos(phasesToolbar->getWidth(), playersByColumn[col][row]->y());
+			else
+				playersByColumn[col][row]->setPos(phasesToolbar->getWidth() + (newWidth - phasesToolbar->getWidth()) / 2, playersByColumn[col][row]->y());
+		}
+
 }
 
 void GameScene::updateHover(const QPointF &scenePos)

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2293,7 +2293,7 @@ void Player::processSceneSizeChange(int newPlayerWidth)
     qreal tableWidth = newPlayerWidth - CARD_HEIGHT - 15 - counterAreaWidth - stack->boundingRect().width();
     if (!settingsCache->getHorizontalHand())
         tableWidth -= hand->boundingRect().width();
-    
+	else
+		hand->setWidth(tableWidth + stack->boundingRect().width());
     table->setWidth(tableWidth);
-    hand->setWidth(tableWidth + stack->boundingRect().width());
 }


### PR DESCRIPTION
Bugfix - Hand zone width was being set to table + stack width, both for vertical and horizontal layout. 
--> Now only for horizontal layout.

Bugfix - When in multicolumn layout, with low vertical window size, the columns were not being repositioned, even though they changed size, causing overlapping zones.
--> Now positions correctly