### PR TITLE
Zone crash fix

### DIFF
--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -649,6 +649,7 @@ void TabGame::actLeaveGame()
         if (!replay)
             sendGameCommand(Command_LeaveGame());
     }
+    scene->clearViews();
     deleteLater();
 }
 


### PR DESCRIPTION
Related to #808

When closing the app/game tab with a zone revealed the client will
crash. This was due to the zones not being deleted.