### PR TITLE
Updated message limit from 10 -> 15

### DIFF
--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -256,7 +256,7 @@ bool Servatrice::initServer()
 
     maxUsersPerAddress = settingsCache->value("security/max_users_per_address", 4).toInt();
     messageCountingInterval = settingsCache->value("security/message_counting_interval", 10).toInt();
-    maxMessageCountPerInterval = settingsCache->value("security/max_message_count_per_interval", 10).toInt();
+    maxMessageCountPerInterval = settingsCache->value("security/max_message_count_per_interval", 15).toInt();
     maxMessageSizePerInterval = settingsCache->value("security/max_message_size_per_interval", 1000).toInt();
     maxGamesPerUser = settingsCache->value("security/max_games_per_user", 5).toInt();
     commandCountingInterval = settingsCache->value("game/command_counting_interval", 10).toInt();


### PR DESCRIPTION
I have updated the `maxMessageCountPerInterval` from 10 to 15. This will
allow some faster play from exp users.

NOTE:
If you have an existing server and update to this version, you will need
to manually change the value in the ini file, or have no ini file to
begin with. Otherwise the old ini will load in 10.