### PR TITLE
Minor deck editor fixes

### DIFF
--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -125,7 +125,7 @@ bool CardDatabaseDisplayModel::lessThan(const QModelIndex &left, const QModelInd
     QString leftString = sourceModel()->data(left).toString();
     QString rightString = sourceModel()->data(right).toString();
 
-    if (!cardName.isEmpty())
+    if (!cardName.isEmpty() && left.column() == CardDatabaseModel::NameColumn)
     {
         if (leftString.compare(cardName, Qt::CaseInsensitive) == 0) {// exact match should be at top
             return true;

--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -32,7 +32,7 @@ QVariant CardDatabaseModel::data(const QModelIndex &index, int role) const
         return QVariant();
     if ((index.row() >= cardList.size()) || (index.column() >= CARDDBMODEL_COLUMNS))
         return QVariant();
-    if (role != Qt::DisplayRole)
+    if (role != Qt::DisplayRole && role != SortRole)
         return QVariant();
 
     CardInfo *card = cardList.at(index.row());
@@ -45,7 +45,9 @@ QVariant CardDatabaseModel::data(const QModelIndex &index, int role) const
                 setList << sets[i]->getShortName();
             return setList.join(", ");
         }
-        case ManaCostColumn: return card->getManaCost();
+        case ManaCostColumn: return role == SortRole ?
+            QString("%1%2").arg(card->getCmc(), 4, QChar('0')).arg(card->getManaCost()) :
+            card->getManaCost();
         case CardTypeColumn: return card->getCardType();
         case PTColumn: return card->getPowTough();
         default: return QVariant();
@@ -122,8 +124,8 @@ CardDatabaseDisplayModel::CardDatabaseDisplayModel(QObject *parent)
 
 bool CardDatabaseDisplayModel::lessThan(const QModelIndex &left, const QModelIndex &right) const {
 
-    QString leftString = sourceModel()->data(left).toString();
-    QString rightString = sourceModel()->data(right).toString();
+    QString leftString = sourceModel()->data(left, CardDatabaseModel::SortRole).toString();
+    QString rightString = sourceModel()->data(right, CardDatabaseModel::SortRole).toString();
 
     if (!cardName.isEmpty() && left.column() == CardDatabaseModel::NameColumn)
     {

--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -1,6 +1,8 @@
 #include "carddatabasemodel.h"
 #include "filtertree.h"
 
+#define CARDDBMODEL_COLUMNS 5
+
 CardDatabaseModel::CardDatabaseModel(CardDatabase *_db, QObject *parent)
     : QAbstractListModel(parent), db(_db)
 {
@@ -21,31 +23,31 @@ int CardDatabaseModel::rowCount(const QModelIndex &/*parent*/) const
 
 int CardDatabaseModel::columnCount(const QModelIndex &/*parent*/) const
 {
-    return 5;
+    return CARDDBMODEL_COLUMNS;
 }
 
 QVariant CardDatabaseModel::data(const QModelIndex &index, int role) const
 {
     if (!index.isValid())
         return QVariant();
-    if ((index.row() >= cardList.size()) || (index.column() >= 5))
+    if ((index.row() >= cardList.size()) || (index.column() >= CARDDBMODEL_COLUMNS))
         return QVariant();
     if (role != Qt::DisplayRole)
         return QVariant();
 
     CardInfo *card = cardList.at(index.row());
     switch (index.column()){
-        case 0: return card->getName();
-        case 1: {
+        case NameColumn: return card->getName();
+        case SetListColumn: {
             QStringList setList;
             const QList<CardSet *> &sets = card->getSets();
             for (int i = 0; i < sets.size(); i++)
                 setList << sets[i]->getShortName();
             return setList.join(", ");
         }
-        case 2: return card->getManaCost();
-        case 3: return card->getCardType();
-        case 4: return card->getPowTough();
+        case ManaCostColumn: return card->getManaCost();
+        case CardTypeColumn: return card->getCardType();
+        case PTColumn: return card->getPowTough();
         default: return QVariant();
     }
 }
@@ -57,11 +59,11 @@ QVariant CardDatabaseModel::headerData(int section, Qt::Orientation orientation,
     if (orientation != Qt::Horizontal)
         return QVariant();
     switch (section) {
-        case 0: return QString(tr("Name"));
-        case 1: return QString(tr("Sets"));
-        case 2: return QString(tr("Mana cost"));
-        case 3: return QString(tr("Card type"));
-        case 4: return QString(tr("P/T"));
+        case NameColumn: return QString(tr("Name"));
+        case SetListColumn: return QString(tr("Sets"));
+        case ManaCostColumn: return QString(tr("Mana cost"));
+        case CardTypeColumn: return QString(tr("Card type"));
+        case PTColumn: return QString(tr("P/T"));
         default: return QVariant();
     }
 }
@@ -86,7 +88,7 @@ void CardDatabaseModel::cardInfoChanged(CardInfo *card)
     if (row == -1)
         return;
     
-    emit dataChanged(index(row, 0), index(row, 4));
+    emit dataChanged(index(row, 0), index(row, CARDDBMODEL_COLUMNS - 1));
 }
 
 void CardDatabaseModel::cardAdded(CardInfo *card)

--- a/cockatrice/src/carddatabasemodel.h
+++ b/cockatrice/src/carddatabasemodel.h
@@ -13,6 +13,7 @@ class CardDatabaseModel : public QAbstractListModel {
     Q_OBJECT
 public:
     enum Columns { NameColumn, SetListColumn, ManaCostColumn, CardTypeColumn, PTColumn, CMCColumn };
+    enum Role { SortRole=Qt::UserRole };
     CardDatabaseModel(CardDatabase *_db, QObject *parent = 0);
     ~CardDatabaseModel();
     int rowCount(const QModelIndex &parent = QModelIndex()) const;

--- a/cockatrice/src/carddatabasemodel.h
+++ b/cockatrice/src/carddatabasemodel.h
@@ -12,6 +12,7 @@ class FilterTree;
 class CardDatabaseModel : public QAbstractListModel {
     Q_OBJECT
 public:
+    enum Columns { NameColumn, SetListColumn, ManaCostColumn, CardTypeColumn, PTColumn, CMCColumn };
     CardDatabaseModel(CardDatabase *_db, QObject *parent = 0);
     ~CardDatabaseModel();
     int rowCount(const QModelIndex &parent = QModelIndex()) const;


### PR DESCRIPTION
 1. When the list is not sorted on the "card name" column, don’t compare the searched term with the current sort column values.
 2. when sorting the list on the "Mana cost" column, instead of doing only a string sort, first sort by cmc.
 3. reworked a bit the code to be more understandable
