### PR TITLE
Rework #838 commenting out c++11 usage

### DIFF
--- a/common/rng_sfmt.cpp
+++ b/common/rng_sfmt.cpp
@@ -13,8 +13,9 @@
 RNG_SFMT::RNG_SFMT(QObject *parent)
     : RNG_Abstract(parent)
 {
-    // initialize the random number generator with a 32bit integer seed (timestamp)
-    sfmt_init_gen_rand(&sfmt, QDateTime::currentDateTime().toTime_t());
+  // seed the random number generator using <random>, C++11
+  sfmt_init_gen_rand(&sfmt, rd()); 
+
 }
 
 /**
@@ -56,81 +57,30 @@ unsigned int RNG_SFMT::rand(int min, int max) {
 }
 
 /**
- * Much thought went into this, please read this comment before you modify the code.
- * Let SFMT() be an alias for sfmt_genrand_uint64() aka SFMT's rand() function.
- *
- * SMFT() returns a uniformly distributed pseudorandom number from 0 to UINT64_MAX.
- * As SFMT() operates on a limited integer range, it is a _discrete_ function.
- *
- * We want a random number from a given interval [min, max] though, so we need to
- * implement the (discrete) cumulative distribution function SFMT(min, max), which
- * returns a random number X from [min, max].
- *
- * This CDF is by formal definition:
- * SFMT(X; min, max) = (floor(X) - min + 1) / (max - min + 1)
- *
- * To get out the random variable, solve for X:
- * floor(X) = SFMT(X; min, max) * (max - min + 1) + min - 1
- * So this is, what rand(min, max) should look like.
- * Problem: SFMT(X; min, max) * (max - min + 1) could produce an integer overflow,
- * so it is not safe.
- *
- * One solution is to divide the universe into buckets of equal size depending on the
- * range [min, max] and assign X to the bucket that contains the number generated
- * by SFMT(). This equals to modulo computation and is not satisfying:
- * If the buckets don't divide the universe equally, because the bucket size is not
- * a divisor of 2, there will be a range in the universe that is biased because one
- * bucket is too small thus will be chosen less equally!
- *
- * This is solved by rejection sampling:
- * As SFMT() is assumed to be unbiased, we are allowed to ignore those random numbers
- * from SFMT() that would force us to have an unequal bucket and generate new random
- * numbers until one number fits into one of the other buckets.
- * This can be compared to an ideal six sided die that is rolled until only sides
- * 1-5 show up, while 6 represents something that you don't want. So you basically roll
- * a five sided die.
- * 
- * Note: If you replace the SFMT RNG with some other rand() function in the future,
- * then you _need_ to change the UINT64_MAX constant to the largest possible random 
- * number which can be created by the new rand() function. This value is often defined
- * in a RAND_MAX constant.
- * Otherwise you will probably skew the outcome of the rand() method or worsen the
- * performance of the application.
+ Using SMFT random number generator on an interval from [0,1], then maping to [min,max].
  */
 unsigned int RNG_SFMT::cdf(unsigned int min, unsigned int max)
 {
-    // This all makes no sense if min > max, which should never happen.
-    if(min > max) {
-        throw std::invalid_argument(
-          QString("Invalid bounds for RNG: min > max! Values were: min = " +
-          QString::number(min) + ", max = " +
-          QString::number(max)).toStdString());
-        // at this point, the method exits. No return value is needed, because
-        // basically the exception itself is returned.
-    }
+  // This all makes no sense if min > max, which should never happen.
+  if(min > max) {
+    throw std::invalid_argument(
+				QString("Invalid bounds for RNG: min > max! Values were: min = " +
+					QString::number(min) + ", max = " +
+					QString::number(max)).toStdString());
+    // at this point, the method exits. No return value is needed, because
+    // basically the exception itself is returned.
+  }
 
-    // First compute the diameter (aka size, length) of the [min, max] interval
-    const unsigned int diameter = max - min + 1;
 
-    // Compute how many buckets (each in size of the diameter) will fit into the
-    // universe.
-    // If the division has a remainder, the result is floored automatically.
-    const uint64_t buckets = UINT64_MAX / diameter;
+  // generate a random number uniformly from 0 to 1
+  // exclude the case when rn = 1, ( min + (max-min+1) * 1 = max + 1 )
+  // numbers are generated uniformly so this should not effect the cdf
+  
+  double rn; 
+  do {
+    rn = sfmt_genrand_real1(&sfmt);
+  } while ( rn == 1 ) ;
 
-    // Compute the last valid random number. All numbers beyond have to be ignored.
-    // If there was no remainder in the previous step, limit is equal to UINT64_MAX.
-    const uint64_t limit = diameter * buckets;
-
-    uint64_t rand;
-    // To make the random number generation thread-safe, a mutex is created around
-    // the generation. Outside of the loop of course, to avoid lock/unlock overhead.
-    mutex.lock();
-    do {
-        rand = sfmt_genrand_uint64(&sfmt);
-    } while (rand >= limit);
-    mutex.unlock();
-
-    // Now determine the bucket containing the SFMT() random number and after adding
-    // the lower bound, a random number from [min, max] can be returned.
-    return (unsigned int) (rand / buckets + min);
+  // return the number scaled to the interval [min,max]
+  return  ( min + (int) (( max -  min + 1 ) * rn));
 }

--- a/common/rng_sfmt.cpp
+++ b/common/rng_sfmt.cpp
@@ -13,9 +13,11 @@
 RNG_SFMT::RNG_SFMT(QObject *parent)
     : RNG_Abstract(parent)
 {
-  // seed the random number generator using <random>, C++11
-  sfmt_init_gen_rand(&sfmt, rd()); 
-
+    // initialize the random number generator with a 32bit integer seed (timestamp)
+    sfmt_init_gen_rand(&sfmt, QDateTime::currentDateTime().toTime_t());
+    // TODO: when c++11 support will be enabled, use <random> instead 
+    // seed the random number generator using <random>, C++11
+    // sfmt_init_gen_rand(&sfmt, rd()); 
 }
 
 /**

--- a/common/rng_sfmt.h
+++ b/common/rng_sfmt.h
@@ -3,6 +3,7 @@
 
 #include <climits>
 #include <QMutex>
+#include <random>
 #include "sfmt/SFMT.h"
 #include "rng_abstract.h"
 
@@ -30,6 +31,7 @@ class RNG_SFMT : public RNG_Abstract {
 private:
     QMutex mutex;
     sfmt_t sfmt;
+    std::random_device rd;
     // The discrete cumulative distribution function for the RNG
     unsigned int cdf(unsigned int min, unsigned int max);
 public:

--- a/common/rng_sfmt.h
+++ b/common/rng_sfmt.h
@@ -3,7 +3,8 @@
 
 #include <climits>
 #include <QMutex>
-#include <random>
+// TODO: when c++11 support will be enabled, use <random> to seed the RNG 
+// #include <random>
 #include "sfmt/SFMT.h"
 #include "rng_abstract.h"
 
@@ -31,7 +32,8 @@ class RNG_SFMT : public RNG_Abstract {
 private:
     QMutex mutex;
     sfmt_t sfmt;
-    std::random_device rd;
+    // TODO: when c++11 support will be enabled, use <random> to seed the RNG 
+    // std::random_device rd;
     // The discrete cumulative distribution function for the RNG
     unsigned int cdf(unsigned int min, unsigned int max);
 public:


### PR DESCRIPTION
Keeping the other two useful changes:
 * removal of a mutex
 * use of float instead of uint64.