### PR TITLE
Updated server side user name check

### DIFF
--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -113,7 +113,7 @@ bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user)
         }
     }
     result = result.trimmed();
-    return (result.size() > 0);
+    return (result.size() == user.size());
 }
 
 bool Servatrice_DatabaseInterface::getRequireRegistration()


### PR DESCRIPTION
Rather than checking if the filtered string is more than 0, we check if the filtered string is the same length as the original. 

If they are the same, no filtering has happened and you can log in. If they are different, then filtration wins and you have an invalid username.