### PR TITLE
Fixing Shortcuts; Fix #476

### DIFF
--- a/cockatrice/src/abstractcounter.cpp
+++ b/cockatrice/src/abstractcounter.cpp
@@ -65,9 +65,9 @@ void AbstractCounter::retranslateUi()
 void AbstractCounter::setShortcutsActive()
 {
     if (name == "life") {
-        aSet->setShortcut(tr("Ctrl+L"));
-        aDec->setShortcut(tr("F11"));
-        aInc->setShortcut(tr("F12"));
+        aSet->setShortcut(QKeySequence("Ctrl+L"));
+        aDec->setShortcut(QKeySequence("F11"));
+        aInc->setShortcut(QKeySequence("F12"));
     }
 }
 

--- a/cockatrice/src/gameview.cpp
+++ b/cockatrice/src/gameview.cpp
@@ -19,7 +19,7 @@ GameView::GameView(QGraphicsScene *scene, QWidget *parent)
     connect(scene, SIGNAL(sigStopRubberBand()), this, SLOT(stopRubberBand()));
 
     aCloseMostRecentZoneView = new QAction(this);
-    aCloseMostRecentZoneView->setShortcut(tr("Esc"));
+    aCloseMostRecentZoneView->setShortcut(QKeySequence("Esc"));
     connect(aCloseMostRecentZoneView, SIGNAL(triggered()), scene, SLOT(closeMostRecentZoneView()));
     addAction(aCloseMostRecentZoneView);
 

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -670,25 +670,25 @@ void Player::retranslateUi()
     aFlip->setText(tr("&Flip"));
     aPeek->setText(tr("&Peek at card face"));
     aClone->setText(tr("&Clone"));
-    aClone->setShortcut(tr("Ctrl+J"));
+    aClone->setShortcut(QKeySequence("Ctrl+J"));
     aAttach->setText(tr("Attac&h to card..."));
-    aAttach->setShortcut(tr("Ctrl+A"));
+    aAttach->setShortcut(QKeySequence("Ctrl+A"));
     aUnattach->setText(tr("Unattac&h"));
     aDrawArrow->setText(tr("&Draw arrow..."));
     aIncP->setText(tr("&Increase power"));
-    aIncP->setShortcut(tr("Ctrl++"));
+    aIncP->setShortcut(QKeySequence("Ctrl++"));
     aDecP->setText(tr("&Decrease power"));
-    aDecP->setShortcut(tr("Ctrl+-"));
+    aDecP->setShortcut(QKeySequence("Ctrl+-"));
     aIncT->setText(tr("I&ncrease toughness"));
-    aIncT->setShortcut(tr("Alt++"));
+    aIncT->setShortcut(QKeySequence("Alt++"));
     aDecT->setText(tr("D&ecrease toughness"));
-    aDecT->setShortcut(tr("Alt+-"));
+    aDecT->setShortcut(QKeySequence("Alt+-"));
     aIncPT->setText(tr("In&crease power and toughness"));
-    aIncPT->setShortcut(tr("Ctrl+Alt++"));
+    aIncPT->setShortcut(QKeySequence("Ctrl+Alt++"));
     aDecPT->setText(tr("Dec&rease power and toughness"));
-    aDecPT->setShortcut(tr("Ctrl+Alt+-"));
+    aDecPT->setShortcut(QKeySequence("Ctrl+Alt+-"));
     aSetPT->setText(tr("Set &power and toughness..."));
-    aSetPT->setShortcut(tr("Ctrl+P"));
+    aSetPT->setShortcut(QKeySequence("Ctrl+P"));
     aSetAnnotation->setText(tr("&Set annotation..."));
     QStringList counterColors;
     counterColors.append(tr("Red"));
@@ -703,7 +703,7 @@ void Player::retranslateUi()
     aMoveToTopLibrary->setText(tr("&Top of library"));
     aMoveToBottomLibrary->setText(tr("&Bottom of library"));
     aMoveToGraveyard->setText(tr("&Graveyard"));
-    aMoveToGraveyard->setShortcut(tr("Ctrl+Del"));
+    aMoveToGraveyard->setShortcut(QKeySequence("Ctrl+Del"));
     aMoveToExile->setText(tr("&Exile"));
     
     QMapIterator<QString, CardZone *> zoneIterator(zones);
@@ -715,20 +715,20 @@ void Player::setShortcutsActive()
 {
     shortcutsActive = true;
     
-    aViewSideboard->setShortcut(tr("Ctrl+F3"));
-    aViewLibrary->setShortcut(tr("F3"));
-    aViewTopCards->setShortcut(tr("Ctrl+W"));
-    aViewGraveyard->setShortcut(tr("F4"));
-    aDrawCard->setShortcut(tr("Ctrl+D"));
-    aDrawCards->setShortcut(tr("Ctrl+E"));
-    aUndoDraw->setShortcut(tr("Ctrl+Shift+D"));
-    aMulligan->setShortcut(tr("Ctrl+M"));
-    aShuffle->setShortcut(tr("Ctrl+S"));
-    aUntapAll->setShortcut(tr("Ctrl+U"));
-    aRollDie->setShortcut(tr("Ctrl+I"));
-    aCreateToken->setShortcut(tr("Ctrl+T"));
-    aCreateAnotherToken->setShortcut(tr("Ctrl+G"));
-    aAlwaysRevealTopCard->setShortcut(tr("Ctrl+N"));
+    aViewSideboard->setShortcut(QKeySequence("Ctrl+F3"));
+    aViewLibrary->setShortcut(QKeySequence("F3"));
+    aViewTopCards->setShortcut(QKeySequence("Ctrl+W"));
+    aViewGraveyard->setShortcut(QKeySequence("F4"));
+    aDrawCard->setShortcut(QKeySequence("Ctrl+D"));
+    aDrawCards->setShortcut(QKeySequence("Ctrl+E"));
+    aUndoDraw->setShortcut(QKeySequence("Ctrl+Shift+D"));
+    aMulligan->setShortcut(QKeySequence("Ctrl+M"));
+    aShuffle->setShortcut(QKeySequence("Ctrl+S"));
+    aUntapAll->setShortcut(QKeySequence("Ctrl+U"));
+    aRollDie->setShortcut(QKeySequence("Ctrl+I"));
+    aCreateToken->setShortcut(QKeySequence("Ctrl+T"));
+    aCreateAnotherToken->setShortcut(QKeySequence("Ctrl+G"));
+    aAlwaysRevealTopCard->setShortcut(QKeySequence("Ctrl+N"));
 
     QMapIterator<int, AbstractCounter *> counterIterator(counters);
     while (counterIterator.hasNext())
@@ -769,7 +769,7 @@ void Player::initSayMenu()
     for (int i = 0; i < count; i++) {
         QAction *newAction = new QAction(settings.value(QString("msg%1").arg(i)).toString(), this);
         if (i <= 10)
-            newAction->setShortcut(QString("Ctrl+%1").arg((i + 1) % 10));
+            newAction->setShortcut(QKeySequence(QString("Ctrl+%1").arg((i + 1) % 10)));
         connect(newAction, SIGNAL(triggered()), this, SLOT(actSayMessage()));
         sayMenu->addAction(newAction);
     }
@@ -789,7 +789,7 @@ void Player::setDeck(const DeckLoader &_deck)
             predefinedTokens.append(tokenName);
             QAction *a = createPredefinedTokenMenu->addAction(tokenName);
             if (i < 10)
-                a->setShortcut("Alt+" + QString::number((i + 1) % 10));
+                a->setShortcut(QKeySequence("Alt+" + QString::number((i + 1) % 10)));
             connect(a, SIGNAL(triggered()), this, SLOT(actCreatePredefinedToken()));
         }
 }

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -301,7 +301,7 @@ void TabDeckEditor::retranslateUi()
     hashLabel1->setText(tr("Hash:"));
     
     //aUpdatePrices->setText(tr("&Update prices"));
-    //aUpdatePrices->setShortcut(tr("Ctrl+U"));
+    //aUpdatePrices->setShortcut(QKeySequence("Ctrl+U"));
 
     aNewDeck->setText(tr("&New deck"));
     aLoadDeck->setText(tr("&Load deck..."));
@@ -312,17 +312,17 @@ void TabDeckEditor::retranslateUi()
     aPrintDeck->setText(tr("&Print deck..."));
     aAnalyzeDeck->setText(tr("&Analyze deck on deckstats.net"));
     aClose->setText(tr("&Close"));
-    aClose->setShortcut(tr("Ctrl+Q"));
+    aClose->setShortcut(QKeySequence("Ctrl+Q"));
     
     aAddCard->setText(tr("Add card to &maindeck"));
     aAddCardToSideboard->setText(tr("Add card to &sideboard"));
 
     aRemoveCard->setText(tr("&Remove row"));
-    aRemoveCard->setShortcut(tr("Del"));
+    aRemoveCard->setShortcut(QKeySequence("Del"));
     aIncrement->setText(tr("&Increment number"));
-    aIncrement->setShortcut(tr("+"));
+    aIncrement->setShortcut(QKeySequence("+"));
     aDecrement->setText(tr("&Decrement number"));
-    aDecrement->setShortcut(tr("-"));
+    aDecrement->setShortcut(QKeySequence("-"));
     
     deckMenu->setTitle(tr("&Deck Editor"));
     dbMenu->setTitle(tr("C&ard Database"));

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -457,12 +457,12 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, QList<AbstractClient *> &_client
         QAction *temp = new QAction(QString(), this);
         connect(temp, SIGNAL(triggered()), this, SLOT(actPhaseAction()));
         switch (i) {
-            case 0: temp->setShortcut(tr("F5")); break;
-            case 2: temp->setShortcut(tr("F6")); break;
-            case 3: temp->setShortcut(tr("F7")); break;
-            case 4: temp->setShortcut(tr("F8")); break;
-            case 9: temp->setShortcut(tr("F9")); break;
-            case 10: temp->setShortcut(tr("F10")); break;
+            case 0: temp->setShortcut(QKeySequence("F5")); break;
+            case 2: temp->setShortcut(QKeySequence("F6")); break;
+            case 3: temp->setShortcut(QKeySequence("F7")); break;
+            case 4: temp->setShortcut(QKeySequence("F8")); break;
+            case 9: temp->setShortcut(QKeySequence("F9")); break;
+            case 10: temp->setShortcut(QKeySequence("F10")); break;
             default: ;
         }
         phasesMenu->addAction(temp);
@@ -527,29 +527,29 @@ void TabGame::retranslateUi()
     gameMenu->setTitle(tr("&Game"));
     if (aNextPhase) {
         aNextPhase->setText(tr("Next &phase"));
-        aNextPhase->setShortcuts(QList<QKeySequence>() << QKeySequence(tr("Ctrl+Space")) << QKeySequence(tr("Tab")));
+        aNextPhase->setShortcuts(QList<QKeySequence>() << QKeySequence("Ctrl+Space") << QKeySequence("Tab"));
     }
     if (aNextTurn) {
         aNextTurn->setText(tr("Next &turn"));
-        aNextTurn->setShortcuts(QList<QKeySequence>() << QKeySequence(tr("Ctrl+Return")) << QKeySequence(tr("Ctrl+Enter")));
+        aNextTurn->setShortcuts(QList<QKeySequence>() << QKeySequence("Ctrl+Return") << QKeySequence("Ctrl+Enter"));
     }
     if (aRemoveLocalArrows) {
         aRemoveLocalArrows->setText(tr("&Remove all local arrows"));
-        aRemoveLocalArrows->setShortcut(tr("Ctrl+R"));
+        aRemoveLocalArrows->setShortcut(QKeySequence("Ctrl+R"));
     }
     if (aGameInfo)
         aGameInfo->setText(tr("Game &information"));
     if (aConcede) {
         aConcede->setText(tr("&Concede"));
-        aConcede->setShortcut(tr("F2"));
+        aConcede->setShortcut(QKeySequence("F2"));
     }
     if (aLeaveGame) {
         aLeaveGame->setText(tr("&Leave game"));
-        aLeaveGame->setShortcut(tr("Ctrl+Q"));
+        aLeaveGame->setShortcut(QKeySequence("Ctrl+Q"));
     }
     if (aCloseReplay) {
         aCloseReplay->setText(tr("C&lose replay"));
-        aCloseReplay->setShortcut(tr("Ctrl+Q"));
+        aCloseReplay->setShortcut(QKeySequence("Ctrl+Q"));
     }
     
     if (sayLabel)

--- a/cockatrice/src/tab_room.cpp
+++ b/cockatrice/src/tab_room.cpp
@@ -59,7 +59,7 @@ TabRoom::TabRoom(TabSupervisor *_tabSupervisor, AbstractClient *_client, ServerI
     QMenu *chatSettingsMenu = new QMenu(this);
 
     aClearChat = chatSettingsMenu->addAction(QString());
-    aClearChat->setShortcut(tr("F12"));
+    aClearChat->setShortcut(QKeySequence("F12"));
     connect(aClearChat, SIGNAL(triggered()), this, SLOT(actClearChat()));
 
     chatSettingsMenu->addSeparator();

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -307,7 +307,7 @@ void MainWindow::retranslateUi()
     aWatchReplay->setText(tr("&Watch replay..."));
     aDeckEditor->setText(tr("&Deck editor"));
     aFullScreen->setText(tr("&Full screen"));
-    aFullScreen->setShortcut(tr("Ctrl+F"));
+    aFullScreen->setShortcut(QKeySequence("Ctrl+F"));
     aSettings->setText(tr("&Settings..."));
     aExit->setText(tr("&Exit"));
     


### PR DESCRIPTION
You can't translate keyboard shortcuts, so I'm removing the `tr()` tags from them.
I've also replaced them over with the necessary `QKeySequence()` method to allow them to properly function. Fixing #476 

I used `grep -ir "setshortcut(tr" .` to determine all of the strings that violated this rule, but if there's anything else you'd like to see changed, feel free to comment.