### PR TITLE
Simple name searching on by default

### DIFF
--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -152,9 +152,8 @@ bool CardDatabaseDisplayModel::filterAcceptsRow(int sourceRow, const QModelIndex
         return false;
 
     if (!cardName.isEmpty())
-        if (!info->getName().contains(cardName, Qt::CaseInsensitive)) 
-            if (!CardInfo::simplifyName(info->getName()).contains(cardName, Qt::CaseInsensitive))
-                return false;
+        if (!CardInfo::simplifyName(info->getName()).contains(cardName, Qt::CaseInsensitive))
+            return false;
 
     if (!cardNameSet.isEmpty())
             if (!cardNameSet.contains(info->getName()))


### PR DESCRIPTION
Previously would try to match the card name, if nothing is found, then
we would try again with the simple name.

I have now made it only the simple name version. We do not need to
perform the first check. Should help a little with performance.