### PR TITLE
clearly differentiate user lists

### DIFF
--- a/cockatrice/src/userlist.cpp
+++ b/cockatrice/src/userlist.cpp
@@ -240,7 +240,7 @@ void UserList::retranslateUi()
 {
     userContextMenu->retranslateUi();
     switch (type) {
-        case AllUsersList: titleStr = tr("Users online: %1"); break;
+        case AllUsersList: titleStr = tr("Users connected to server: %1"); break;
         case RoomList: titleStr = tr("Users in this room: %1"); break;
         case BuddyList: titleStr = tr("Buddies online: %1 / %2"); break;
         case IgnoreList: titleStr = tr("Ignored users online: %1 / %2"); break;


### PR DESCRIPTION
users in room vs. users on server

Please double check!

---
Alternatives:
`Users (on server):`
`Users (in room):`

Thoughts?