### PR TITLE
Mentions will now work with all legal chars

### DIFF
--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -247,7 +247,7 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
                     showSystemPopup(ref);
                 }
             } else {
-                int mentionEndIndex = message.indexOf(QRegExp("\\W"), 1);// from 1 as @ is non-char
+                int mentionEndIndex = message.indexOf(QRegExp("\\s"), 1);// from 1 as @ is non-char
                 if (mentionEndIndex == -1)
                     mentionEndIndex = message.size(); // there is no text after the mention
                 QString userMention = message.left(mentionEndIndex);


### PR DESCRIPTION
As the server has been updated to enforce username rules, we can now
check for the next position of whitespace. This allows ALL users to have
a working mention system. Currently "-" is not available for users, this
will fix that.