### PR TITLE
Rework the way sets selection/importing works; fix #539 (rebased)

### DIFF
--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -31,6 +31,7 @@ private:
     unsigned int sortKey;
     QDate releaseDate;
     QString setType;
+    bool enabled, isknown;
 public:
     CardSet(const QString &_shortName = QString(), const QString &_longName = QString(), const QString &_setType = QString(), const QDate &_releaseDate = QDate());
     QString getCorrectedShortName() const;
@@ -38,9 +39,17 @@ public:
     QString getLongName() const { return longName; }
     QString getSetType() const { return setType; }
     QDate getReleaseDate() const { return releaseDate; }
+    void setLongName(QString & _longName) { longName = _longName; }
+    void setSetType(QString & _setType) { setType = _setType; }
+    void setReleaseDate(QDate & _releaseDate) { releaseDate = _releaseDate; }
+
+    void loadSetOptions();
     int getSortKey() const { return sortKey; }
     void setSortKey(unsigned int _sortKey);
-    void updateSortKey();
+    bool getEnabled() const { return enabled; }
+    void setEnabled(bool _enabled);
+    bool getIsKnown() const { return isknown; }
+    void setIsKnown(bool _isknown);
 };
 
 class SetList : public QList<CardSet *> {
@@ -48,6 +57,12 @@ private:
     class CompareFunctor;
 public:
     void sortByKey();
+    void guessSortKeys();
+    void enableAllUnknown();
+    void enableAll();
+    void markAllAsKnown();
+    int getEnabledSetsNum();
+    int getUnknownSetsNum();
 };
 
 class PictureToLoad {
@@ -253,6 +268,7 @@ public:
 public slots:
     void clearPixmapCache();
     LoadStatus loadCardDatabase(const QString &path, bool tokens = false);
+    void emitCardListChanged();
 private slots:
     void imageLoaded(CardInfo *card, QImage image);
     void picDownloadChanged();

--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -42,7 +42,10 @@ QVariant CardDatabaseModel::data(const QModelIndex &index, int role) const
             QStringList setList;
             const QList<CardSet *> &sets = card->getSets();
             for (int i = 0; i < sets.size(); i++)
-                setList << sets[i]->getShortName();
+            {
+                if(sets[i]->getEnabled())
+                    setList << sets[i]->getShortName();
+            }
             return setList.join(", ");
         }
         case ManaCostColumn: return role == SortRole ?
@@ -77,9 +80,26 @@ void CardDatabaseModel::updateCardList()
     for (int i = 0; i < cardList.size(); ++i)
         disconnect(cardList[i], 0, this, 0);
     
-    cardList = db->getCardList();
-    for (int i = 0; i < cardList.size(); ++i)
-        connect(cardList[i], SIGNAL(cardInfoChanged(CardInfo *)), this, SLOT(cardInfoChanged(CardInfo *)));
+    cardList.clear();
+
+    foreach(CardInfo * card, db->getCardList())
+    {
+        bool hasSet = false;
+        foreach(CardSet * set, card->getSets())
+        {
+            if(set->getEnabled())
+            {
+                hasSet = true;
+                break;
+            }
+        }
+
+        if(hasSet)
+        {
+            cardList.append(card);
+            connect(card, SIGNAL(cardInfoChanged(CardInfo *)), this, SLOT(cardInfoChanged(CardInfo *)));
+        }
+    }
     
     endResetModel();
 }

--- a/cockatrice/src/setsmodel.cpp
+++ b/cockatrice/src/setsmodel.cpp
@@ -4,6 +4,11 @@ SetsModel::SetsModel(CardDatabase *_db, QObject *parent)
     : QAbstractTableModel(parent), sets(_db->getSetList())
 {
     sets.sortByKey();
+    foreach(CardSet *set, sets)
+    {
+        if(set->getEnabled())
+            enabledSets.insert(set);
+    }
 }
 
 SetsModel::~SetsModel()
@@ -20,12 +25,20 @@ int SetsModel::rowCount(const QModelIndex &parent) const
 
 QVariant SetsModel::data(const QModelIndex &index, int role) const
 {
-    if (!index.isValid() || (index.column() >= NUM_COLS) || (index.row() >= rowCount()) || (role != Qt::DisplayRole))
+    if (!index.isValid() || (index.column() >= NUM_COLS) || (index.row() >= rowCount()))
         return QVariant();
 
     CardSet *set = sets[index.row()];
+
+    if ( role == Qt::CheckStateRole && index.column() == EnabledCol )
+        return static_cast< int >( enabledSets.contains(set) ? Qt::Checked : Qt::Unchecked );
+
+    if (role != Qt::DisplayRole)
+        return QVariant();
+
     switch (index.column()) {
-        case SortKeyCol: return QString("%1").arg(set->getSortKey(), 4, 10, QChar('0'));
+        case SortKeyCol: return QString("%1").arg(set->getSortKey(), 8, 10, QChar('0'));
+        case IsKnownCol: return set->getIsKnown();
         case SetTypeCol: return set->getSetType();
         case ShortNameCol: return set->getShortName();
         case LongNameCol: return set->getLongName();
@@ -34,12 +47,24 @@ QVariant SetsModel::data(const QModelIndex &index, int role) const
     }
 }
 
+bool SetsModel::setData(const QModelIndex & index, const QVariant & value, int role)
+{
+    if (role == Qt::CheckStateRole && index.column () == EnabledCol)
+    {
+        toggleRow(index.row(), value == Qt::Checked);
+        return true;
+    }
+    return false;
+}
+
 QVariant SetsModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
     if ((role != Qt::DisplayRole) || (orientation != Qt::Horizontal))
         return QVariant();
     switch (section) {
         case SortKeyCol: return tr("Key");
+        case IsKnownCol: return tr("Is known");
+        case EnabledCol: return tr("Enabled");
         case SetTypeCol: return tr("Set type");
         case ShortNameCol: return tr("Set code");
         case LongNameCol: return tr("Long name");
@@ -50,8 +75,17 @@ QVariant SetsModel::headerData(int section, Qt::Orientation orientation, int rol
 
 Qt::ItemFlags SetsModel::flags(const QModelIndex &index) const
 {
-    Qt::ItemFlags result = QAbstractTableModel::flags(index);
-    return result | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled;
+    if (!index.isValid())
+        return 0;
+
+    Qt::ItemFlags flags = QAbstractTableModel::flags(index) |
+        Qt::ItemIsDragEnabled |
+        Qt::ItemIsDropEnabled;
+
+    if ( index.column() == EnabledCol)
+        flags |= Qt::ItemIsUserCheckable;
+
+    return flags;
 }
 
 Qt::DropActions SetsModel::supportedDropActions() const
@@ -84,6 +118,30 @@ bool SetsModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int r
     swapRows(oldRow, row);
 
     return true;
+}
+
+void SetsModel::toggleRow(int row, bool enable)
+{
+    CardSet *temp = sets.at(row);
+
+    if(enable)
+        enabledSets.insert(temp);
+    else
+        enabledSets.remove(temp);
+
+    emit dataChanged(index(row, EnabledCol), index(row, EnabledCol));
+}
+
+void SetsModel::toggleAll(bool enable)
+{
+    enabledSets.clear();
+    if(enable)
+    {
+        foreach(CardSet *set, sets)
+            enabledSets.insert(set);
+    }
+
+    emit dataChanged(index(0, 0), index(rowCount() - 1, columnCount() - 1));
 }
 
 void SetsModel::swapRows(int oldRow, int newRow)
@@ -124,18 +182,34 @@ void SetsModel::sort(int column, Qt::SortOrder order)
     emit dataChanged(index(0, 0), index(numRows - 1, columnCount() - 1));
 }
 
-void SetsModel::save()
+void SetsModel::save(CardDatabase *db)
 {
+    // order
     for (int i = 0; i < sets.size(); i++)
-        sets[i]->setSortKey(i);
+        sets[i]->setSortKey(i+1);
+
+    // enabled sets
+    foreach(CardSet *set, sets)
+        set->setEnabled(enabledSets.contains(set));
 
     sets.sortByKey();
+
+    db->emitCardListChanged();
 }
 
 void SetsModel::restore(CardDatabase *db)
 {
+    // order
     sets = db->getSetList();
     sets.sortByKey();
+
+    // enabled sets
+    enabledSets.clear();
+    foreach(CardSet *set, sets)
+    {
+        if(set->getEnabled())
+            enabledSets.insert(set);
+    }
 
     emit dataChanged(index(0, 0), index(rowCount() - 1, columnCount() - 1));
 }

--- a/cockatrice/src/setsmodel.h
+++ b/cockatrice/src/setsmodel.h
@@ -3,6 +3,7 @@
 
 #include <QAbstractTableModel>
 #include <QMimeData>
+#include <QSet>
 #include "carddatabase.h"
 
 class SetsProxyModel;
@@ -21,16 +22,18 @@ class SetsModel : public QAbstractTableModel {
     Q_OBJECT
     friend class SetsProxyModel;
 private:
-    static const int NUM_COLS = 5;
+    static const int NUM_COLS = 7;
     SetList sets;
+    QSet<CardSet *> enabledSets;
 public:
-    enum SetsColumns { SortKeyCol, LongNameCol, ShortNameCol, SetTypeCol, ReleaseDateCol };
+    enum SetsColumns { SortKeyCol, IsKnownCol, EnabledCol, LongNameCol, ShortNameCol, SetTypeCol, ReleaseDateCol };
 
     SetsModel(CardDatabase *_db, QObject *parent = 0);
     ~SetsModel();
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
     int columnCount(const QModelIndex &parent = QModelIndex()) const { Q_UNUSED(parent); return NUM_COLS; }
     QVariant data(const QModelIndex &index, int role) const;
+    bool setData(const QModelIndex & index, const QVariant & value, int role);
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
     Qt::ItemFlags flags(const QModelIndex &index) const;
     Qt::DropActions supportedDropActions() const;
@@ -39,8 +42,10 @@ public:
     bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent);
     QStringList mimeTypes() const;
     void swapRows(int oldRow, int newRow);
+    void toggleRow(int row, bool enable);
+    void toggleAll(bool enable);
     void sort(int column, Qt::SortOrder order = Qt::AscendingOrder);
-    void save();
+    void save(CardDatabase *db);
     void restore(CardDatabase *db);
 };
 

--- a/cockatrice/src/tab_deck_editor.h
+++ b/cockatrice/src/tab_deck_editor.h
@@ -111,10 +111,12 @@ public:
     void setDeck(DeckLoader *_deckLoader);
     void setModified(bool _windowModified);
     bool confirmClose();
-    public slots:
-        void closeRequest();
+public slots:
+    void closeRequest();
+    void checkUnknownSets();
 signals:
-        void deckEditorClosing(TabDeckEditor *tab);
+    void deckEditorClosing(TabDeckEditor *tab);
+    void setListChanged();
 };
 
 #endif

--- a/cockatrice/src/window_sets.h
+++ b/cockatrice/src/window_sets.h
@@ -15,13 +15,18 @@ class WndSets : public QMainWindow {
 private:
     SetsModel *model;
     QTreeView *view;
-    QPushButton *saveButton, *restoreButton, *upButton, *downButton, *bottomButton, *topButton;
+    QPushButton *enableButton, *disableButton, *enableAllButton, *disableAllButton,
+                *upButton, *downButton, *bottomButton, *topButton;
 public:
     WndSets(QWidget *parent = 0);
     ~WndSets();
 protected:
     void selectRow(int row);
 private slots:
+    void actEnable();
+    void actDisable();
+    void actEnableAll();
+    void actDisableAll();
     void actSave();
     void actRestore();
     void actUp();

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -32,7 +32,6 @@ bool OracleImporter::readSetsFromByteArray(const QByteArray &data)
     QVariant editionCards;
     QString setType;
     QDate releaseDate;
-    bool import;
 
     while (it.hasNext()) {
         map = it.next().toMap();
@@ -45,11 +44,7 @@ bool OracleImporter::readSetsFromByteArray(const QByteArray &data)
             setType[0] = setType[0].toUpper();
         releaseDate = map.value("releaseDate").toDate();
 
-        // core and expansion sets are marked to be imported by default
-        import = (0 == QString::compare(setType, QString("core"), Qt::CaseInsensitive) ||
-            0 == QString::compare(setType, QString("expansion"), Qt::CaseInsensitive));
-
-        newSetList.append(SetToDownload(edition, editionLong, editionCards, import, setType, releaseDate));
+        newSetList.append(SetToDownload(edition, editionLong, editionCards, setType, releaseDate));
     }
 
     qSort(newSetList);
@@ -265,10 +260,7 @@ int OracleImporter::startImport()
 
     while (it.hasNext())
     {
-        curSet = & it.next();
-        if(!curSet->getImport())
-            continue;
-            
+        curSet = & it.next();            
         CardSet *set = new CardSet(curSet->getShortName(), curSet->getLongName(), curSet->getSetType(), curSet->getReleaseDate());
         if (!sets.contains(set->getShortName()))
             sets.insert(set->getShortName(), set);

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -8,7 +8,6 @@
 class SetToDownload {
 private:
     QString shortName, longName;
-    bool import;
     QVariant cards;
     QDate releaseDate;
     QString setType;
@@ -18,10 +17,8 @@ public:
     const QVariant &getCards() const { return cards; }
     const QString &getSetType() const { return setType; }
     const QDate &getReleaseDate() const { return releaseDate; }
-    bool getImport() const { return import; }
-    void setImport(bool _import) { import = _import; }
-    SetToDownload(const QString &_shortName, const QString &_longName, const QVariant &_cards, bool _import, const QString &_setType = QString(), const QDate &_releaseDate = QDate())
-        : shortName(_shortName), longName(_longName), import(_import), cards(_cards), releaseDate(_releaseDate), setType(_setType)  { }
+    SetToDownload(const QString &_shortName, const QString &_longName, const QVariant &_cards, const QString &_setType = QString(), const QDate &_releaseDate = QDate())
+        : shortName(_shortName), longName(_longName), cards(_cards), releaseDate(_releaseDate), setType(_setType)  { }
     bool operator<(const SetToDownload &set) const { return longName.compare(set.longName, Qt::CaseInsensitive) < 0; }
 };
 

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -56,7 +56,6 @@ OracleWizard::OracleWizard(QWidget *parent)
 
     addPage(new IntroPage);
     addPage(new LoadSetsPage);
-    addPage(new ChooseSetsPage);
     addPage(new SaveSetsPage);
 
     retranslateUi();
@@ -425,94 +424,6 @@ void LoadSetsPage::importFinished()
     } else {
         QMessageBox::critical(this, tr("Error"), tr("The file was retrieved successfully, but it does not contain any sets data."));
     }
-}
-
-ChooseSetsPage::ChooseSetsPage(QWidget *parent)
-    : OracleWizardPage(parent)
-{
-    checkBoxLayout = new QVBoxLayout;
-    
-    QWidget *checkboxFrame = new QWidget(this);
-    checkboxFrame->setLayout(checkBoxLayout);
-    
-    QScrollArea *checkboxArea = new QScrollArea(this);
-    checkboxArea->setWidget(checkboxFrame);
-    checkboxArea->setWidgetResizable(true);
-    
-    checkAllButton = new QPushButton(this);
-    connect(checkAllButton, SIGNAL(clicked()), this, SLOT(actCheckAll()));
-    uncheckAllButton = new QPushButton(this);
-    connect(uncheckAllButton, SIGNAL(clicked()), this, SLOT(actUncheckAll()));
-
-    QGridLayout *layout = new QGridLayout(this);
-    layout->addWidget(checkboxArea, 0, 0, 1, 2);
-    layout->addWidget(checkAllButton, 1, 0);
-    layout->addWidget(uncheckAllButton, 1, 1);
-
-    setLayout(layout);
-}
-
-void ChooseSetsPage::initializePage()
-{
-    // populate checkbox list
-    for (int i = 0; i < checkBoxList.size(); ++i)
-        delete checkBoxList[i];
-    checkBoxList.clear();
-    
-    QList<SetToDownload> &sets = wizard()->importer->getSets();
-    for (int i = 0; i < sets.size(); ++i) {
-        QCheckBox *checkBox = new QCheckBox(sets[i].getLongName());
-        checkBox->setChecked(sets[i].getImport());
-        connect(checkBox, SIGNAL(stateChanged(int)), this, SLOT(checkBoxChanged(int)));
-        checkBoxLayout->addWidget(checkBox);
-        checkBoxList << checkBox;
-    }
-}
-
-void ChooseSetsPage::retranslateUi()
-{
-    setTitle(tr("Sets selection"));
-    setSubTitle(tr("The following sets has been found in the source file. "
-                   "Please mark the sets that will be imported.\n"
-                   "All core and expansion sets are selected by default."));
-
-    checkAllButton->setText(tr("&Check all"));
-    uncheckAllButton->setText(tr("&Uncheck all"));
-}
-
-void ChooseSetsPage::checkBoxChanged(int state)
-{
-    QCheckBox *checkBox = qobject_cast<QCheckBox *>(sender());
-    QList<SetToDownload> &sets = wizard()->importer->getSets();
-    for (int i = 0; i < sets.size(); ++i)
-        if (sets[i].getLongName() == checkBox->text()) {
-            sets[i].setImport(state);
-            break;
-        }
-}
-
-void ChooseSetsPage::actCheckAll()
-{
-    for (int i = 0; i < checkBoxList.size(); ++i)
-        checkBoxList[i]->setChecked(true);
-}
-
-void ChooseSetsPage::actUncheckAll()
-{
-    for (int i = 0; i < checkBoxList.size(); ++i)
-        checkBoxList[i]->setChecked(false);
-}
-
-bool ChooseSetsPage::validatePage()
-{
-    for (int i = 0; i < checkBoxList.size(); ++i)
-    {
-        if(checkBoxList[i]->isChecked())
-            return true;
-    }
-
-    QMessageBox::critical(this, tr("Error"), tr("Please mark at least one set."));
-    return false;        
 }
 
 SaveSetsPage::SaveSetsPage(QWidget *parent)

--- a/oracle/src/oraclewizard.h
+++ b/oracle/src/oraclewizard.h
@@ -98,25 +98,6 @@ private slots:
      void zipDownloadFailed(const QString &message);
 };
 
-class ChooseSetsPage : public OracleWizardPage
-{
-     Q_OBJECT
-public:
-     ChooseSetsPage(QWidget *parent = 0);
-    void retranslateUi();
-protected:
-     void initializePage();
-     bool validatePage();
-private:
-     QPushButton *checkAllButton, *uncheckAllButton;
-     QVBoxLayout *checkBoxLayout;
-     QList<QCheckBox *> checkBoxList;
-private slots:
-     void actCheckAll();
-     void actUncheckAll();
-     void checkBoxChanged(int state);
-};
-
 class SaveSetsPage : public OracleWizardPage
 {
      Q_OBJECT


### PR DESCRIPTION
This PR modifies the way oracle imports and cockatrice handles sets in order to:

 * ensure every player have the full list of cards (needed eg. when spectating other's games);
 * a player can decide once the sets he want to use, and oracle won't override that at every run;

So, first change is that now oracle always loads all the sets (no more choice screen).
Second change, inside cockatrice, you can enable/disable each set; cards from disabled sets won't be shown in the deck editor, but cockatrice will still knows that they exists and show them if needed (eg. when another player use that card).

![Sets window](https://cloud.githubusercontent.com/assets/1631111/7216365/d15df7c4-e5fc-11e4-80b0-2be6e0b11ca6.png)

The third change is that the "edit sets" window has been rationalized a bit. Buttons have been grouped by function, and the window now have two common "ok" and "cancel" buttons, instead of the old ones that sounded strange.

The fourth change is that cockatrice will remember the existing sets from its previous runs, so it will be able to understand if a new set has been added to the card database. If this is the case, when a new "deck editor" tab gets open, the user will be presented a popup with 3 options:
![popup](https://cloud.githubusercontent.com/assets/1631111/7216349/863f7c18-e5fc-11e4-9585-2478c2d0c01f.jpg)

 * Yes enables the new sets;
 * No keeps the new sets disabled;
 * Cancel postpones the question.

If cockatrice is run for the first time by a new user, this popup would confuse him (her). So, if cockatrice finds no previously known and enabled sets, all of them will get enabled and sorted by release date desc. Instead of the popup, we'll directly bring up the "edit sets" window, so that the user can make its first decisions (disabling unwanted sets, reordering them).

The fifth and last change is a fix for how cockatrice's card database creates sets. Before, if a set was found both in cards.xml and tokens.xml, it would be created twice, leak memory and cause its settings to be lost, causing strange sets reordering. This behavior has been fixed.

Note: this PR is a single commit rebased version of #891. Fore reference, most of the discussion have been done there.