### PR TITLE
Added clear chat fix

### DIFF
--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -305,6 +305,7 @@ QString ChatView::getNameFromUserList(QMap<QString, UserListTWI *> &userList, QS
 
 void ChatView::clearChat() {
     document()->clear();
+    lastSender = "";
 }
 
 void ChatView::enterEvent(QEvent * /*event*/)


### PR DESCRIPTION
When clearing the chat, we now clear the last sender.

This fixes the issue where you clear the chat and a user continues to
talk, you get no indication of who is talking. Now it will show the
users name.