### PR TITLE
Simple stack trace for signal handler (unix only)

### DIFF
--- a/servatrice/src/main.cpp
+++ b/servatrice/src/main.cpp
@@ -33,7 +33,11 @@
 #include <google/protobuf/stubs/common.h>
 #ifdef Q_OS_UNIX
 #include <signal.h>
+#include <execinfo.h>
+#include <unistd.h>
 #endif
+
+#define SIGSEGV_TRACE_LINES 40
 
 RNG_Abstract *rng;
 ServerLogger *logger;
@@ -129,6 +133,16 @@ void myMessageOutput2(QtMsgType /*type*/, const QMessageLogContext &, const QStr
 #ifdef Q_OS_UNIX
 void sigSegvHandler(int sig)
 {
+    void *array[SIGSEGV_TRACE_LINES];
+    size_t size;
+
+    // get void*'s for all entries on the stack
+    size = backtrace(array, SIGSEGV_TRACE_LINES);
+
+    // print out all the frames to stderr
+    fprintf(stderr, "Error: signal %d:\n", sig);
+    backtrace_symbols_fd(array, size, STDERR_FILENO);
+
 	if (sig == SIGSEGV)
 		logger->logMessage("CRASH: SIGSEGV");
 	else if (sig == SIGABRT)


### PR DESCRIPTION
When servatrice crashes for a SIGSEGV or a SIGABRT, it will print a stack trace that hopefully will help in debugging the issue:
```
Lapidus:build fab$ ./servatrice 
Servatrice 881cea2 starting.
...
Server listening.
-------------------------
Server initialized.
Error: signal 6:
0   servatrice                          0x000000010ae27403 _Z14sigSegvHandleri + 51
1   libsystem_platform.dylib            0x00007fff94c41f1a _sigtramp + 26
2   ???                                 0x00007fff54ddbd20 0x0 + 140734617206048
3   QtCore                              0x000000010c5ddcc8 _Z14qt_safe_selectiP6fd_setS0_S0_PK8timespec + 104
4   QtCore                              0x000000010c5ded80 _ZN27QEventDispatcherUNIXPrivate8doSelectE6QFlagsIN10QEventLoop17ProcessEventsFlagEEP8timespec + 672
5   QtCore                              0x000000010c5dfe4a _ZN20QEventDispatcherUNIX13processEventsE6QFlagsIN10QEventLoop17ProcessEventsFlagEE + 234
6   QtCore                              0x000000010c58a37d _ZN10QEventLoop4execE6QFlagsINS_17ProcessEventsFlagEE + 381
7   QtCore                              0x000000010c58d35a _ZN16QCoreApplication4execEv + 346
8   servatrice                          0x000000010ae28555 main + 3909
9   libdyld.dylib                       0x00007fff8b8b55c9 start + 1
10  ???                                 0x0000000000000001 0x0 + 1
Abort trap: 6
```