### PR TITLE
Switch travis builds to debug mode, since they catch more errors

### DIFF
--- a/travis-compile.sh
+++ b/travis-compile.sh
@@ -11,5 +11,5 @@ fi
 if [[ $TRAVIS_OS_NAME == "linux" && $QT4 == 0 ]]; then
   prefix="-DCMAKE_PREFIX_PATH=/opt/qt52/lib/cmake/"
 fi
-cmake .. -DWITH_SERVER=1 -DWITH_QT4=$QT4 $prefix
+cmake .. -DWITH_SERVER=1 -DCMAKE_BUILD_TYPE=Debug -DWITH_QT4=$QT4 $prefix
 make -j2


### PR DESCRIPTION
In debug mode, warnings are considered as errors.