### PR TITLE
Colored PT

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -105,13 +105,19 @@ void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
     
     if (!pt.isEmpty()) {
         painter->save();
-        
         transformPainter(painter, translatedSize, tapAngle);
+
+        QStringList ptDbSplit = db->getCard(name)->getPowTough().split("/");
+        QStringList ptSplit = pt.split("/");
+        
+        if (ptDbSplit.at(0) != ptSplit.at(0) || ptDbSplit.at(1) != ptSplit.at(1))
+            painter->setPen(QColor(0, 195, 255));
+        else
+            painter->setPen(Qt::white);
         painter->setBackground(Qt::black);
         painter->setBackgroundMode(Qt::OpaqueMode);
-        painter->setPen(Qt::white);
         
-        painter->drawText(QRectF(4 * scaleFactor, 4 * scaleFactor, translatedSize.width() - 8 * scaleFactor, translatedSize.height() - 8 * scaleFactor), Qt::AlignRight | Qt::AlignBottom, pt);
+        painter->drawText(QRectF(4 * scaleFactor, 4 * scaleFactor, translatedSize.width() - 10 * scaleFactor, translatedSize.height() - 8 * scaleFactor), Qt::AlignRight | Qt::AlignBottom, pt);
         painter->restore();
     }
     if (!annotation.isEmpty()) {


### PR DESCRIPTION
I compare the card pt, to the card with the same name in the db. if the
card is found, we compare the pt, of the db item and the item in play.
If there is not a match then we change the color of the PT. This is
pretty much the same as mtgo does it.

I looked into having only the P, or the T colored, though this is not
posible, when you set a pen color you can not change it partway through
painting a string. That would require 3 strings painted, one for p, /
and t. Which is more effort than its worth. This does the job pretty
well.

I have also moved the pt slightly to the left so it lines up better. I
have some images to compate.

BEFORE
![before](https://cloud.githubusercontent.com/assets/2134793/7274889/e5eb3d08-e900-11e4-91b7-010462d55cf7.png)

AFTER
![after](https://cloud.githubusercontent.com/assets/2134793/7274897/e933deca-e900-11e4-8389-9280df2912dc.png)
