### PR TITLE
Added logic to server shutdown warnings

### DIFF
--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -126,7 +126,7 @@ void Servatrice_IslServer::incomingConnection(qintptr socketDescriptor)
 }
 
 Servatrice::Servatrice(QObject *parent)
-    : Server(true, parent), uptime(0), shutdownTimer(0)
+    : Server(true, parent), uptime(0), shutdownTimer(0), isFirstShutdownMessage(true)
 {
     qRegisterMetaType<QSqlDatabase>("QSqlDatabase");
 }
@@ -462,7 +462,12 @@ void Servatrice::scheduleShutdown(const QString &reason, int minutes)
     if (minutes > 0) {
         shutdownTimer = new QTimer;
         connect(shutdownTimer, SIGNAL(timeout()), this, SLOT(shutdownTimeout()));
-        shutdownTimer->start(60000);
+        if (minutes <= 5 || isFirstShutdownMessage) {
+            shutdownTimer->start(60000);
+            isFirstShutdownMessage = false;
+        }
+        else
+            shutdownTimer->start((shutdownMinutes / 2) * 60 * 1000);
     }
     shutdownTimeout();
 }

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -120,6 +120,7 @@ private:
 	QString shutdownReason;
 	int shutdownMinutes;
 	QTimer *shutdownTimer;
+    bool isFirstShutdownMessage;
 	
 	mutable QMutex serverListMutex;
 	QList<ServerProperties> serverList;


### PR DESCRIPTION
Follow these rules:

The following example uses a 60 min shutdown
+ First message gets sent straight away (t minus 60m)
+ Each message is then send every t/2m (30m, 15m, 7m)
+ For each message <= 5m we send one a min.  (3m, 2m, 1m)

Fixes #979