### PR TITLE
Updated server shutdown timer logic

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -86,7 +86,13 @@ void MainWindow::processConnectionClosedEvent(const Event_ConnectionClosed &even
 
 void MainWindow::processServerShutdownEvent(const Event_ServerShutdown &event)
 {
-    QMessageBox::information(this, tr("Scheduled server shutdown"), tr("The server is going to be restarted in %n minute(s).\nAll running games will be lost.\nReason for shutdown: %1", "", event.minutes()).arg(QString::fromStdString(event.reason())));
+    if (serverShutdownMessageBox)
+        serverShutdownMessageBox->close();
+    serverShutdownMessageBox = new QMessageBox(this);
+    serverShutdownMessageBox->setAttribute(Qt::WA_DeleteOnClose);
+    serverShutdownMessageBox->setInformativeText(tr("The server is going to be restarted in %n minute(s).\nAll running games will be lost.\nReason for shutdown: %1", "", event.minutes()).arg(QString::fromStdString(event.reason())));
+    serverShutdownMessageBox->setText(tr("Scheduled server shutdown"));
+    serverShutdownMessageBox->exec();
 }
 
 void MainWindow::statusChanged(ClientStatus _status)

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -31,6 +31,7 @@ class LocalClient;
 class LocalServer;
 class ServerInfo_User;
 class QThread;
+class QMessageBox;
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -86,6 +87,8 @@ private:
     
     LocalServer *localServer;
     bool bHasActivated;
+
+    QMessageBox *serverShutdownMessageBox;
 public:
     MainWindow(QWidget *parent = 0);
     ~MainWindow();

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -126,7 +126,7 @@ void Servatrice_IslServer::incomingConnection(qintptr socketDescriptor)
 }
 
 Servatrice::Servatrice(QObject *parent)
-    : Server(true, parent), uptime(0), shutdownTimer(0)
+    : Server(true, parent), uptime(0), shutdownTimer(0), isFirstShutdownMessage(true)
 {
     qRegisterMetaType<QSqlDatabase>("QSqlDatabase");
 }
@@ -485,26 +485,29 @@ void Servatrice::shutdownTimeout()
 {
     --shutdownMinutes;
 
-    SessionEvent *se;
-    if (shutdownMinutes) {
-        Event_ServerShutdown event;
-        event.set_reason(shutdownReason.toStdString());
-        event.set_minutes(shutdownMinutes);
-        se = Server_ProtocolHandler::prepareSessionEvent(event);
-    } else {
-        Event_ConnectionClosed event;
-        event.set_reason(Event_ConnectionClosed::SERVER_SHUTDOWN);
-        se = Server_ProtocolHandler::prepareSessionEvent(event);
+    if (shutdownMinutes <= 5 || isFirstShutdownMessage || shutdownMinutes % 20 == 0) {
+        isFirstShutdownMessage = false;
+        SessionEvent *se;
+        if (shutdownMinutes) {
+            Event_ServerShutdown event;
+            event.set_reason(shutdownReason.toStdString());
+            event.set_minutes(shutdownMinutes);
+            se = Server_ProtocolHandler::prepareSessionEvent(event);
+        } else {
+            Event_ConnectionClosed event;
+            event.set_reason(Event_ConnectionClosed::SERVER_SHUTDOWN);
+            se = Server_ProtocolHandler::prepareSessionEvent(event);
+        }
+
+        clientsLock.lockForRead();
+        for (int i = 0; i < clients.size(); ++i)
+            clients[i]->sendProtocolItem(*se);
+        clientsLock.unlock();
+        delete se;
+    
+        if (!shutdownMinutes)
+            deleteLater();
     }
-
-    clientsLock.lockForRead();
-    for (int i = 0; i < clients.size(); ++i)
-        clients[i]->sendProtocolItem(*se);
-    clientsLock.unlock();
-    delete se;
-
-    if (!shutdownMinutes)
-        deleteLater();
 }
 
 bool Servatrice::islConnectionExists(int serverId) const

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -485,7 +485,7 @@ void Servatrice::shutdownTimeout()
 {
     --shutdownMinutes;
 
-    if (shutdownMinutes <= 5 || isFirstShutdownMessage || shutdownMinutes % 20 == 0) {
+    if (shutdownMinutes <= 5 || isFirstShutdownMessage || shutdownMinutes % 10 == 0) {
         isFirstShutdownMessage = false;
         SessionEvent *se;
         if (shutdownMinutes) {

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -120,6 +120,7 @@ private:
 	QString shutdownReason;
 	int shutdownMinutes;
 	QTimer *shutdownTimer;
+    bool isFirstShutdownMessage;
 	
 	mutable QMutex serverListMutex;
 	QList<ServerProperties> serverList;


### PR DESCRIPTION
Will follow the following rules

+ send a message initially
+ send a message every 20 mins
+ send a message every min when time <= 5

Popup messages will close previous popups.