### PR TITLE
allow osx build that troubles to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,7 @@ notifications:
     on_start: false
 matrix:
   fast_finish: true
+  allow_failures:
+    - compiler: gcc
+      os: osx
+      env: QT4=0


### PR DESCRIPTION
Travis has been failing recently with GCC OSX QT4=0 which just holds us back.
This allow it to fail and continue with a positive build, provided everything else works.