### PR TITLE
Changed pt to orange

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -111,7 +111,7 @@ void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
         QStringList ptSplit = pt.split("/");
         
         if (ptDbSplit.at(0) != ptSplit.at(0) || ptDbSplit.at(1) != ptSplit.at(1))
-            painter->setPen(QColor(0, 195, 255));
+            painter->setPen(QColor(255, 150, 0));
         else
             painter->setPen(Qt::white);
         painter->setBackground(Qt::black);


### PR DESCRIPTION
After feedback, and also noticing myself, the blue requires a little
more focus than should be nessesarry. I have updated to be orange, which
feels more comfortable. I have polled the community and they also agree
orange > blue.

![small orange](https://cloud.githubusercontent.com/assets/2134793/7334833/dc6be2cc-eb9f-11e4-890a-62e6ffe60000.png)

![orange](https://cloud.githubusercontent.com/assets/2134793/7334834/dff2ea80-eb9f-11e4-8d55-1a0beb0500d7.png)


You can look at #1005 for comparison.