### PR TITLE
Fixed issue with non creature perms set to 0/0

### DIFF
--- a/common/server_card.cpp
+++ b/common/server_card.cpp
@@ -23,7 +23,7 @@
 #include "pb/serverinfo_card.pb.h"
 
 Server_Card::Server_Card(QString _name, int _id, int _coord_x, int _coord_y, Server_CardZone *_zone)
-    : zone(_zone), id(_id), coord_x(_coord_x), coord_y(_coord_y), name(_name), tapped(false), attacking(false), facedown(false), color(QString()), power(0), toughness(0), annotation(QString()), destroyOnZoneChange(false), doesntUntap(false), parentCard(0)
+    : zone(_zone), id(_id), coord_x(_coord_x), coord_y(_coord_y), name(_name), tapped(false), attacking(false), facedown(false), color(QString()), power(-1), toughness(-1), annotation(QString()), destroyOnZoneChange(false), doesntUntap(false), parentCard(0)
 {
 }
 
@@ -42,8 +42,8 @@ void Server_Card::resetState()
     counters.clear();
     setTapped(false);
     setAttacking(false);
-    power = 0;
-    toughness = 0;
+    power = -1;
+    toughness = -1;
     setAnnotation(QString());
     setDoesntUntap(false);
 }
@@ -90,7 +90,6 @@ void Server_Card::setPT(const QString &_pt)
         if ((p1[0] == '+') || (p2[0] == '+'))
             if (toughness < 0)
                 toughness = 0;
-
         if (p1[0] == '+')
             power += p1.mid(1).toInt();
         else


### PR DESCRIPTION
The issue was that I had set the ctor to set the p/t to 0/0 rather than
-1/-1. This meant that when you join a game in progress (spec or
reconnect) the server would send the card value to the client as 0/0,
instead of -1/-1. The client has been coded so that if the toughness is
<0 then dont show it. 0/0 is instead shown.

We still need to look into cards with no p/t being set to a 0/1 as
@tooomm mentioned in anther issue. As it stands, this is more important
than that.

Related to #1007 and #1009 