### PR TITLE
Fixed server shutdown crash

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -430,6 +430,8 @@ MainWindow::MainWindow(QWidget *parent)
         createTrayActions();
         createTrayIcon();
     }
+
+    serverShutdownMessageBox = 0;
 }
 
 MainWindow::~MainWindow()


### PR DESCRIPTION
`serverShutdownMessageBox` was not assigned to 0 in the ctor.

Fixes #1020 