### PR TITLE
Only use local db if no pt is provided

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1003,7 +1003,8 @@ void Player::actCreateToken()
     lastTokenPT = dlg.getPT();
     if (CardInfo *correctedCard = db->getCardBySimpleName(lastTokenName, false)) {
         lastTokenName = correctedCard->getName();
-        lastTokenPT = correctedCard->getPowTough();
+        if (lastTokenPT.isEmpty())
+            lastTokenPT = correctedCard->getPowTough();
     }
     lastTokenColor = dlg.getColor();
     lastTokenAnnotation = dlg.getAnnotation();


### PR DESCRIPTION
Addresses Issue #1032

If a token is created with no p/t then the local db value will be passed
instead. If a value is provided then that will be used instead.

Fix #1032 