### PR TITLE
Run oracle from inside cockatrice and improve sets handling; 

### DIFF
--- a/cockatrice/cockatrice.qrc
+++ b/cockatrice/cockatrice.qrc
@@ -38,6 +38,11 @@
     <file>resources/remove_row.svg</file>
     <file>resources/arrow_left_green.svg</file>
     <file>resources/arrow_right_green.svg</file>
+
+    <file>resources/arrow_top_green.svg</file>
+    <file>resources/arrow_up_green.svg</file>
+    <file>resources/arrow_down_green.svg</file>
+    <file>resources/arrow_bottom_green.svg</file>
     
     <file>resources/icon_ready_start.svg</file>
     <file>resources/icon_not_ready_start.svg</file>

--- a/cockatrice/resources/arrow_bottom_green.svg
+++ b/cockatrice/resources/arrow_bottom_green.svg
@@ -1,0 +1,793 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   id="svg2646"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.4 r9943 custom"
+   version="1.0"
+   sodipodi:docname="arrow_down_green.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <defs
+     id="defs2648">
+    <linearGradient
+       id="linearGradient3169">
+      <stop
+         style="stop-color:#0000ff;stop-opacity:1;"
+         offset="0"
+         id="stop3171" />
+      <stop
+         style="stop-color:#000067;stop-opacity:1;"
+         offset="1"
+         id="stop3173" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient3175"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4766">
+      <stop
+         style="stop-color:#784421;stop-opacity:1;"
+         offset="0"
+         id="stop4768" />
+      <stop
+         style="stop-color:#3d2210;stop-opacity:0;"
+         offset="1"
+         id="stop4770" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2396"
+       gradientUnits="userSpaceOnUse"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)" />
+    <linearGradient
+       id="linearGradient4758">
+      <stop
+         style="stop-color:#a05a2c;stop-opacity:1;"
+         offset="0"
+         id="stop4760" />
+      <stop
+         style="stop-color:#3d2210;stop-opacity:1;"
+         offset="1"
+         id="stop4762" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2399"
+       gradientUnits="userSpaceOnUse"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective2654" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2691"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2693"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2695"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2707"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2709"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2711"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient3508"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient3510"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient3512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient3514"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient3516"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient3518"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient3520"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient3522"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient3524"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2444"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2446"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2448"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2450"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2452"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2454"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2456"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2458"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2460"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2478"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2480"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2482"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2484"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2486"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2488"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2490"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2494"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2527"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2529"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2531"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2533"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2535"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2537"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2539"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2541"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2543"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2545"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2547"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2549"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2561"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2563"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2565"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2594"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2596"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2598"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2602"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2606"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2608"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2610"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2612"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2614"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2616"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2620"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.625"
+     inkscape:cx="8.25663"
+     inkscape:cy="31.788561"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     inkscape:window-width="1272"
+     inkscape:window-height="723"
+     inkscape:window-x="0"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata2651">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Pfeil"
+     style="display:inline">
+    <path
+       style="fill:#96ff96;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 52.71118,29.086208 -12.351931,0 12.852459,-18.346676 -42.685714,0 12.327869,18.346676 -12.351929,0 21.104622,25.485735 z"
+       id="rect2714"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/cockatrice/resources/arrow_down_green.svg
+++ b/cockatrice/resources/arrow_down_green.svg
@@ -1,0 +1,793 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   id="svg2646"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.4 r9943 custom"
+   version="1.0"
+   sodipodi:docname="arrow_up_green.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <defs
+     id="defs2648">
+    <linearGradient
+       id="linearGradient3169">
+      <stop
+         style="stop-color:#0000ff;stop-opacity:1;"
+         offset="0"
+         id="stop3171" />
+      <stop
+         style="stop-color:#000067;stop-opacity:1;"
+         offset="1"
+         id="stop3173" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient3175"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4766">
+      <stop
+         style="stop-color:#784421;stop-opacity:1;"
+         offset="0"
+         id="stop4768" />
+      <stop
+         style="stop-color:#3d2210;stop-opacity:0;"
+         offset="1"
+         id="stop4770" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2396"
+       gradientUnits="userSpaceOnUse"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)" />
+    <linearGradient
+       id="linearGradient4758">
+      <stop
+         style="stop-color:#a05a2c;stop-opacity:1;"
+         offset="0"
+         id="stop4760" />
+      <stop
+         style="stop-color:#3d2210;stop-opacity:1;"
+         offset="1"
+         id="stop4762" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2399"
+       gradientUnits="userSpaceOnUse"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective2654" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2691"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2693"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2695"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2707"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2709"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2711"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient3508"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient3510"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient3512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient3514"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient3516"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient3518"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient3520"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient3522"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient3524"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2444"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2446"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2448"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2450"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2452"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2454"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2456"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2458"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2460"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2478"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2480"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2482"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2484"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2486"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2488"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2490"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2494"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2527"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2529"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2531"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2533"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2535"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2537"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2539"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2541"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2543"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2545"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2547"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2549"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2561"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2563"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2565"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2594"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2596"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2598"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2602"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2606"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2608"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2610"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2612"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2614"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2616"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2620"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.625"
+     inkscape:cx="8.25663"
+     inkscape:cy="31.788561"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     inkscape:window-width="1272"
+     inkscape:window-height="723"
+     inkscape:window-x="0"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata2651">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Pfeil"
+     style="display:inline">
+    <path
+       style="fill:#96ff96;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 53.104623,35.38129 -12.351931,0 0,-32.248315 -17.505386,0 0,32.248315 -12.351929,0 21.104622,25.485735 21.104624,-25.485735 z"
+       id="rect2714"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/cockatrice/resources/arrow_top_green.svg
+++ b/cockatrice/resources/arrow_top_green.svg
@@ -1,0 +1,793 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   id="svg2646"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.4 r9943 custom"
+   version="1.0"
+   sodipodi:docname="arrow_bottom_green.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <defs
+     id="defs2648">
+    <linearGradient
+       id="linearGradient3169">
+      <stop
+         style="stop-color:#0000ff;stop-opacity:1;"
+         offset="0"
+         id="stop3171" />
+      <stop
+         style="stop-color:#000067;stop-opacity:1;"
+         offset="1"
+         id="stop3173" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient3175"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4766">
+      <stop
+         style="stop-color:#784421;stop-opacity:1;"
+         offset="0"
+         id="stop4768" />
+      <stop
+         style="stop-color:#3d2210;stop-opacity:0;"
+         offset="1"
+         id="stop4770" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2396"
+       gradientUnits="userSpaceOnUse"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)" />
+    <linearGradient
+       id="linearGradient4758">
+      <stop
+         style="stop-color:#a05a2c;stop-opacity:1;"
+         offset="0"
+         id="stop4760" />
+      <stop
+         style="stop-color:#3d2210;stop-opacity:1;"
+         offset="1"
+         id="stop4762" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2399"
+       gradientUnits="userSpaceOnUse"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective2654" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2691"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2693"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2695"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2707"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2709"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2711"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient3508"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient3510"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient3512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient3514"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient3516"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient3518"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient3520"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient3522"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient3524"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2444"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2446"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2448"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2450"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2452"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2454"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2456"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2458"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2460"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2478"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2480"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2482"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2484"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2486"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2488"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2490"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2494"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2527"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2529"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2531"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2533"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2535"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2537"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2539"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2541"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2543"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2545"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2547"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2549"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2561"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2563"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2565"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2594"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2596"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2598"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2602"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2606"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2608"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2610"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2612"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2614"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2616"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2620"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.625"
+     inkscape:cx="8.25663"
+     inkscape:cy="31.788561"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     inkscape:window-width="1272"
+     inkscape:window-height="723"
+     inkscape:window-x="0"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata2651">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Pfeil"
+     style="display:inline">
+    <path
+       style="fill:#96ff96;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 11.002462,36.225266 12.351931,0 -12.852459,18.346676 42.685714,0 -12.327869,-18.346676 12.351929,0 -21.104622,-25.485734 z"
+       id="rect2714"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/cockatrice/resources/arrow_up_green.svg
+++ b/cockatrice/resources/arrow_up_green.svg
@@ -1,0 +1,792 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   id="svg2646"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.4 r9943 custom"
+   version="1.0"
+   sodipodi:docname="arrow_up_green.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <defs
+     id="defs2648">
+    <linearGradient
+       id="linearGradient3169">
+      <stop
+         style="stop-color:#0000ff;stop-opacity:1;"
+         offset="0"
+         id="stop3171" />
+      <stop
+         style="stop-color:#000067;stop-opacity:1;"
+         offset="1"
+         id="stop3173" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient3175"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4766">
+      <stop
+         style="stop-color:#784421;stop-opacity:1;"
+         offset="0"
+         id="stop4768" />
+      <stop
+         style="stop-color:#3d2210;stop-opacity:0;"
+         offset="1"
+         id="stop4770" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2396"
+       gradientUnits="userSpaceOnUse"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)" />
+    <linearGradient
+       id="linearGradient4758">
+      <stop
+         style="stop-color:#a05a2c;stop-opacity:1;"
+         offset="0"
+         id="stop4760" />
+      <stop
+         style="stop-color:#3d2210;stop-opacity:1;"
+         offset="1"
+         id="stop4762" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2399"
+       gradientUnits="userSpaceOnUse"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective2654" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2691"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2693"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2695"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2707"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2709"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2711"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient3508"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient3510"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient3512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient3514"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient3516"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient3518"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient3520"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient3522"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient3524"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2444"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2446"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2448"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2450"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2452"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2454"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2456"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2458"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2460"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2478"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2480"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2482"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2484"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2486"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2488"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2490"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2494"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2527"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2529"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2531"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2533"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2535"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2537"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2539"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2541"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2543"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2545"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2547"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2549"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2561"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2563"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2565"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2594"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2596"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2598"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2602"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2606"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2608"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2610"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2612"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2614"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2616"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4758"
+       id="linearGradient2618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="590.62201"
+       y1="434.7522"
+       x2="698.54004"
+       y2="517.79218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient2620"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9650128,0,0,0.9948433,-449.70565,-312.80927)"
+       x1="661.24402"
+       y1="602.90814"
+       x2="431.5"
+       y2="201.5482" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="radialGradient2622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.2116376,0,44.257186)"
+       cx="120.07376"
+       cy="56.138123"
+       fx="120.07376"
+       fy="56.138123"
+       r="82.790039" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.625"
+     inkscape:cx="8.25663"
+     inkscape:cy="31.788561"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     inkscape:window-width="1272"
+     inkscape:window-height="723"
+     inkscape:window-x="0"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata2651">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Pfeil"
+     style="display:inline">
+    <path
+       style="fill:#96ff96;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 10.895377,28.61871 12.351931,0 0,32.248315 17.505386,0 0,-32.248315 12.351929,0 L 32.000001,3.132975 10.895377,28.61871 z"
+       id="rect2714"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -232,12 +232,14 @@ protected:
     QThread *pictureLoaderThread;
     PictureLoader *pictureLoader;
     LoadStatus loadStatus;
+    bool detectedFirstRun;
 private:
     static const int versionNeeded;
     void loadCardsFromXml(QXmlStreamReader &xml, bool tokens);
     void loadSetsFromXml(QXmlStreamReader &xml);
 
     CardInfo *getCardFromMap(CardNameMap &cardMap, const QString &cardName, bool createIfNotFound);
+    void checkUnknownSets();
 public:
     static const char* TOKENS_SETNAME;
 
@@ -265,6 +267,7 @@ public:
     bool getLoadSuccess() const { return loadStatus == Ok; }
     void cacheCardPixmaps(const QStringList &cardNames);
     void loadImage(CardInfo *card);
+    bool hasDetectedFirstRun();
 public slots:
     void clearPixmapCache();
     LoadStatus loadCardDatabase(const QString &path, bool tokens = false);

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -293,8 +293,7 @@ TabDeckEditor::TabDeckEditor(TabSupervisor *_tabSupervisor, QWidget *parent)
     
     resize(950, 700);
 
-    connect(this, SIGNAL(setListChanged()), db, SIGNAL(cardListChanged()));
-    QTimer::singleShot(0, this, SLOT(checkUnknownSets()));
+    QTimer::singleShot(0, this, SLOT(checkFirstRunDetected()));
 }
 
 TabDeckEditor::~TabDeckEditor()
@@ -786,39 +785,11 @@ void TabDeckEditor::filterRemove(QAction *action) {
     filterModel->removeRow(idx.row(), idx.parent());
 }
 
-void TabDeckEditor::checkUnknownSets()
+void TabDeckEditor::checkFirstRunDetected()
 {
-    SetList sets = db->getSetList();
-
-    // no set is enabled. Probably this is the first time running trice
-    if(!sets.getEnabledSetsNum())
+    if(db->hasDetectedFirstRun())
     {
-        sets.guessSortKeys();
-        sets.sortByKey();
-        sets.enableAll();
-        db->emitCardListChanged();
-
+        QMessageBox::information(this, tr("Welcome"), tr("Hi! Its seems like it's the first time you run this version of Cockatrice.<br/>All the sets in the card database have been enabled; if you want to hide a set from the deck editor, disable it in the \"Edit Sets\" window."));
         actEditSets();
-        return;
-    }
-
-    int numUnknownSets = sets.getUnknownSetsNum();
-    // no unkown sets. 
-    if(!numUnknownSets)
-        return;
-
-    int ret = QMessageBox::question(this, tr("New sets found"), tr("%1 new set(s) have been found in the card database. Do you want to enable them?").arg(numUnknownSets), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel, QMessageBox::Yes);
-
-    switch(ret)
-    {
-        case QMessageBox::No:
-            sets.markAllAsKnown();
-            break;
-        case QMessageBox::Yes:
-            sets.enableAllUnknown();
-            db->emitCardListChanged();
-            break;
-        default:
-            break;
     }
 }

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -789,7 +789,7 @@ void TabDeckEditor::checkFirstRunDetected()
 {
     if(db->hasDetectedFirstRun())
     {
-        QMessageBox::information(this, tr("Welcome"), tr("Hi! Its seems like it's the first time you run this version of Cockatrice.<br/>All the sets in the card database have been enabled; if you want to hide a set from the deck editor, disable it in the \"Edit Sets\" window."));
+        QMessageBox::information(this, tr("Welcome"), tr("Hi! Its seems like it's the first time you run this version of Cockatrice.\nAll the sets in the card database have been enabled.\nRead more about changing the set order or disabling specific sets in the the \"Edit Sets\" window."));
         actEditSets();
     }
 }

--- a/cockatrice/src/tab_deck_editor.h
+++ b/cockatrice/src/tab_deck_editor.h
@@ -113,10 +113,9 @@ public:
     bool confirmClose();
 public slots:
     void closeRequest();
-    void checkUnknownSets();
+    void checkFirstRunDetected();
 signals:
     void deckEditorClosing(TabDeckEditor *tab);
-    void setListChanged();
 };
 
 #endif

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -325,6 +325,7 @@ void MainWindow::retranslateUi()
 #endif
     aAbout->setText(tr("&About Cockatrice"));
     helpMenu->setTitle(tr("&Help"));
+    aCheckCardUpdates->setText(tr("Check card updates..."));
     
     tabSupervisor->retranslateUi();
 }
@@ -352,6 +353,9 @@ void MainWindow::createActions()
     
     aAbout = new QAction(this);
     connect(aAbout, SIGNAL(triggered()), this, SLOT(actAbout()));
+
+    aCheckCardUpdates = new QAction(this);
+    connect(aCheckCardUpdates, SIGNAL(triggered()), this, SLOT(actCheckCardUpdates()));
 
 #if defined(__APPLE__)  /* For OSX */
     aSettings->setMenuRole(QAction::PreferencesRole);
@@ -383,6 +387,7 @@ void MainWindow::createMenus()
     cockatriceMenu->addAction(aFullScreen);
     cockatriceMenu->addSeparator();
     cockatriceMenu->addAction(aSettings);
+    cockatriceMenu->addAction(aCheckCardUpdates);
     cockatriceMenu->addSeparator();
     cockatriceMenu->addAction(aExit);
     
@@ -391,7 +396,7 @@ void MainWindow::createMenus()
 }
 
 MainWindow::MainWindow(QWidget *parent)
-    : QMainWindow(parent), localServer(0), bHasActivated(false)
+    : QMainWindow(parent), localServer(0), bHasActivated(false), cardUpdateProcess(0)
 {
     connect(settingsCache, SIGNAL(pixmapCacheSizeChanged(int)), this, SLOT(pixmapCacheSizeChanged(int)));
     pixmapCacheSizeChanged(settingsCache->getPixmapCacheSize());
@@ -521,4 +526,94 @@ void MainWindow::pixmapCacheSizeChanged(int newSizeInMBs)
 
 void MainWindow::maximize() {
     showNormal();
+}
+
+/* CARD UPDATER */
+
+void MainWindow::actCheckCardUpdates()
+{
+    if(cardUpdateProcess)
+    {
+        QMessageBox::information(this, tr("Information"), tr("A card update is already ongoing."));
+        return;
+    }
+
+    cardUpdateProcess = new QProcess(this);
+    connect(cardUpdateProcess, SIGNAL(error(QProcess::ProcessError)), this, SLOT(cardUpdateError(QProcess::ProcessError)));
+    connect(cardUpdateProcess, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(cardUpdateFinished(int, QProcess::ExitStatus)));
+
+    // full "run the update" command; leave empty if not present
+    QString updaterCmd;
+    QString binaryName;
+    QDir dir = QDir(QApplication::applicationDirPath());
+
+#if defined(Q_OS_MAC)
+    binaryName = getCardUpdaterBinaryName();
+
+    // exit from the application bundle
+    dir.cdUp();
+    dir.cdUp();
+    dir.cdUp();
+    dir.cd(binaryName + ".app");
+    dir.cd("Contents");
+    dir.cd("MacOS");
+#elif defined(Q_OS_WIN)
+    binaryName = getCardUpdaterBinaryName() + ".exe";
+#else
+    binaryName = getCardUpdaterBinaryName();
+#endif    
+
+    if(dir.exists(binaryName))
+        updaterCmd = dir.absoluteFilePath(binaryName);
+
+    if(updaterCmd.isEmpty())
+    {
+        QMessageBox::warning(this, tr("Error"), tr("Unable to run the card updater: ") + dir.absoluteFilePath(binaryName));
+        return;
+    }
+
+    cardUpdateProcess->start(updaterCmd);
+}
+
+void MainWindow::cardUpdateError(QProcess::ProcessError err)
+{
+    QString error;
+    switch(err)
+    {
+        case QProcess::FailedToStart:
+            error = tr("failed to start.");
+            break;
+        case QProcess::Crashed:
+            error = tr("crashed.");
+            break;
+        case QProcess::Timedout:
+            error = tr("timed out.");
+            break;
+        case QProcess::WriteError:
+            error = tr("write error.");
+            break;
+        case QProcess::ReadError:
+            error = tr("read error.");
+            break;
+        case QProcess::UnknownError:
+        default:
+            error = tr("unknown error.");
+            break;
+    }
+
+    cardUpdateProcess->deleteLater();
+    cardUpdateProcess = 0;
+
+    QMessageBox::warning(this, tr("Error"), tr("The card updater exited with an error: %1").arg(error));
+}
+
+void MainWindow::cardUpdateFinished(int, QProcess::ExitStatus)
+{
+    cardUpdateProcess->deleteLater();
+    cardUpdateProcess = 0;
+
+    QMessageBox::information(this, tr("Information"), tr("Card update completed successfully. Will now reload card database."));
+
+    // this will force a database reload
+    settingsCache->setCardDatabasePath(settingsCache->getCardDatabasePath());
 }

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -22,6 +22,7 @@
 
 #include <QMainWindow>
 #include <QSystemTrayIcon>
+#include <QProcess>
 #include "abstractclient.h"
 #include "pb/response.pb.h"
 
@@ -62,6 +63,10 @@ private slots:
     void iconActivated(QSystemTrayIcon::ActivationReason reason);
 
     void maximize();
+
+    void actCheckCardUpdates();
+    void cardUpdateError(QProcess::ProcessError err);
+    void cardUpdateFinished(int exitCode, QProcess::ExitStatus exitStatus);
 private:
     static const QString appName;
     void setClientStatusTitle();
@@ -71,11 +76,13 @@ private:
 
     void createTrayIcon();
     void createTrayActions();
+    // TODO: add a preference item to choose updater name for other games
+    inline QString getCardUpdaterBinaryName() { return "oracle"; };
 
     QList<QMenu *> tabMenus;
     QMenu *cockatriceMenu, *helpMenu;
     QAction *aConnect, *aDisconnect, *aSinglePlayer, *aWatchReplay, *aDeckEditor, *aFullScreen, *aSettings, *aExit,
-        *aAbout;
+        *aAbout, *aCheckCardUpdates;
     TabSupervisor *tabSupervisor;
 
     QMenu *trayIconMenu;
@@ -89,6 +96,7 @@ private:
     bool bHasActivated;
 
     QMessageBox *serverShutdownMessageBox;
+    QProcess * cardUpdateProcess;
 public:
     MainWindow(QWidget *parent = 0);
     ~MainWindow();

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -10,10 +10,48 @@
 #include <QGroupBox>
 #include <QDialogButtonBox>
 #include <QVBoxLayout>
+#include <QToolBar>
+#include <QAction>
+#include <QLabel>
 
 WndSets::WndSets(QWidget *parent)
     : QMainWindow(parent)
 {
+    // left toolbar
+    QToolBar *setsEditToolBar = new QToolBar;
+    setsEditToolBar->setOrientation(Qt::Vertical);
+    setsEditToolBar->setIconSize(QSize(24, 24));
+    setsEditToolBar->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
+
+    aTop = new QAction(QString(), this);
+    aTop->setIcon(QIcon(":/resources/arrow_top_green.svg"));
+    aTop->setToolTip(tr("Move selected set to top"));
+    aTop->setEnabled(false);
+    connect(aTop, SIGNAL(triggered()), this, SLOT(actTop()));
+    setsEditToolBar->addAction(aTop);
+
+    aUp = new QAction(QString(), this);
+    aUp->setIcon(QIcon(":/resources/arrow_up_green.svg"));
+    aUp->setToolTip(tr("Move selected set up"));
+    aUp->setEnabled(false);
+    connect(aUp, SIGNAL(triggered()), this, SLOT(actUp()));
+    setsEditToolBar->addAction(aUp);
+
+    aDown = new QAction(QString(), this);
+    aDown->setIcon(QIcon(":/resources/arrow_down_green.svg"));
+    aDown->setToolTip(tr("Move selected set down"));
+    aDown->setEnabled(false);
+    connect(aDown, SIGNAL(triggered()), this, SLOT(actDown()));
+    setsEditToolBar->addAction(aDown);
+
+    aBottom = new QAction(QString(), this);
+    aBottom->setIcon(QIcon(":/resources/arrow_bottom_green.svg"));
+    aBottom->setToolTip(tr("Move selected set to bottom"));
+    aBottom->setEnabled(false);
+    connect(aBottom, SIGNAL(triggered()), this, SLOT(actBottom()));
+    setsEditToolBar->addAction(aBottom);
+
+    // view 
     model = new SetsModel(db, this);
     view = new QTreeView;
     view->setModel(model);
@@ -43,59 +81,32 @@ WndSets::WndSets(QWidget *parent)
     view->setColumnHidden(SetsModel::IsKnownCol, true);
     view->setRootIsDecorated(false);
 
-    enableButton = new QPushButton(tr("Enable set"));
-    connect(enableButton, SIGNAL(clicked()), this, SLOT(actEnable()));
-    disableButton = new QPushButton(tr("Disable set"));
-    connect(disableButton, SIGNAL(clicked()), this, SLOT(actDisable()));
+    connect(view->selectionModel(), SIGNAL(selectionChanged(const QItemSelection &, const QItemSelection &)),
+        this, SLOT(actToggleButtons(const QItemSelection &, const QItemSelection &)));
+
+    // bottom buttons
     enableAllButton = new QPushButton(tr("Enable all sets"));
     connect(enableAllButton, SIGNAL(clicked()), this, SLOT(actEnableAll()));
     disableAllButton = new QPushButton(tr("Disable all sets"));
     connect(disableAllButton, SIGNAL(clicked()), this, SLOT(actDisableAll()));
 
-    upButton = new QPushButton(tr("Move selected set up"));
-    connect(upButton, SIGNAL(clicked()), this, SLOT(actUp()));
-    downButton = new QPushButton(tr("Move selected set down"));
-    connect(downButton, SIGNAL(clicked()), this, SLOT(actDown()));
-    topButton = new QPushButton(tr("Move selected set to top"));
-    connect(topButton, SIGNAL(clicked()), this, SLOT(actTop()));
-    bottomButton = new QPushButton(tr("Move selected set to bottom"));
-    connect(bottomButton, SIGNAL(clicked()), this, SLOT(actBottom()));
 
-    enableButton->setDisabled(true);
-    disableButton->setDisabled(true);
-    upButton->setDisabled(true);
-    downButton->setDisabled(true);
-    topButton->setDisabled(true);
-    bottomButton->setDisabled(true);
-
-    connect(view->selectionModel(), SIGNAL(selectionChanged(const QItemSelection &, const QItemSelection &)),
-        this, SLOT(actToggleButtons(const QItemSelection &, const QItemSelection &)));
-
-    QGroupBox *toggleFrame = new QGroupBox(tr("Enable sets"));
-    QVBoxLayout *toggleVBox = new QVBoxLayout;
-    toggleVBox->addWidget(enableButton);
-    toggleVBox->addWidget(disableButton);
-    toggleVBox->addWidget(enableAllButton);
-    toggleVBox->addWidget(disableAllButton);
-    toggleFrame->setLayout(toggleVBox);
-
-    QGroupBox *sortFrame = new QGroupBox(tr("Sort sets"));
-    QVBoxLayout *sortVBox = new QVBoxLayout;
-    sortVBox->addWidget(upButton);
-    sortVBox->addWidget(downButton);
-    sortVBox->addWidget(topButton);
-    sortVBox->addWidget(bottomButton);
-    sortFrame->setLayout(sortVBox);
+    QLabel *labNotes = new QLabel;
+    labNotes->setText("Enable the sets that you want to have available in the deck editor.\nMove sets around to change their order, or click on a column header to sort sets on that field.\nSets order decides the source that will be used when loading images for a specific card.\nDisabled sets will still be used for loading images.");
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actSave()));
     connect(buttonBox, SIGNAL(rejected()), this, SLOT(actRestore()));
 
     QGridLayout *mainLayout = new QGridLayout;
-    mainLayout->addWidget(view, 0, 0, 1, 2);
-    mainLayout->addWidget(toggleFrame, 1, 0, 1, 1);
-    mainLayout->addWidget(sortFrame, 1, 1, 1, 1);
-    mainLayout->addWidget(buttonBox, 2, 0, 1, 2);
+    mainLayout->addWidget(setsEditToolBar, 0, 0, 1, 1);
+    mainLayout->addWidget(view, 0, 1, 1, 2);
+    mainLayout->addWidget(enableAllButton, 1, 1, 1, 1);
+    mainLayout->addWidget(disableAllButton, 1, 2, 1, 1);
+    mainLayout->addWidget(labNotes, 2, 1, 1, 2);
+    mainLayout->addWidget(buttonBox, 3, 1, 1, 2);
+    mainLayout->setColumnStretch(1, 1);
+    mainLayout->setColumnStretch(2, 1);
 
     QWidget *centralWidget = new QWidget;
     centralWidget->setLayout(mainLayout);
@@ -125,12 +136,10 @@ void WndSets::actRestore()
 void WndSets::actToggleButtons(const QItemSelection & selected, const QItemSelection &)
 {
     bool disabled = selected.empty();
-    upButton->setDisabled(disabled);
-    downButton->setDisabled(disabled);
-    topButton->setDisabled(disabled);
-    bottomButton->setDisabled(disabled);
-    enableButton->setDisabled(disabled);
-    disableButton->setDisabled(disabled);
+    aTop->setDisabled(disabled);
+    aUp->setDisabled(disabled);
+    aDown->setDisabled(disabled);
+    aBottom->setDisabled(disabled);
 }
 
 void WndSets::selectRow(int row)

--- a/cockatrice/src/window_sets.h
+++ b/cockatrice/src/window_sets.h
@@ -15,8 +15,8 @@ class WndSets : public QMainWindow {
 private:
     SetsModel *model;
     QTreeView *view;
-    QPushButton *enableButton, *disableButton, *enableAllButton, *disableAllButton,
-                *upButton, *downButton, *bottomButton, *topButton;
+    QPushButton *enableAllButton, *disableAllButton;
+    QAction *aUp, *aDown, *aBottom, *aTop;
 public:
     WndSets(QWidget *parent = 0);
     ~WndSets();


### PR DESCRIPTION
This is a continuation of #891.
It adds the ability to run oracle from inside cockatrice and update the card database. Cockatrice will detect when oracle has finished its job, reload the card database and check if new sets have been found.
I also added a quick informative popup for users running cockatrice for the first time/updating from an older version, hoping it will be helpful; improvements to the message are welcome.
This possibly fixes parts of #135, #210, #641

Fix #135 
Fix #641 
Fix #1072 