### PR TITLE
Fixed revealing top card bug

### DIFF
--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -369,12 +369,15 @@ Response::ResponseCode Server_Player::moveCard(GameEventStorage &ges, Server_Car
     if (cardsToMove.isEmpty())
         return Response::RespContextError;
     
-    MoveCardCompareFunctor cmp(startzone == targetzone ? -1 : x);
+    // 0 performs no sorting
+    // 1 reverses the sorting 
+    MoveCardCompareFunctor cmp(0);
     qSort(cardsToMove.begin(), cardsToMove.end(), cmp);
     
     bool secondHalf = false;
     int xIndex = -1;
-    for (int cardIndex = 0; cardIndex < cardsToMove.size(); ++cardIndex) {
+
+    for (int cardIndex = cardsToMove.size() - 1; cardIndex > -1; --cardIndex) {
         Server_Card *card = cardsToMove[cardIndex].first;
         const CardToMove *thisCardProperties = cardProperties.value(card);
         bool faceDown = thisCardProperties->has_face_down() ? thisCardProperties->face_down() : card->getFaceDown();


### PR DESCRIPTION
Previously if you were to reveal the top card, then look at the top x (x > 1) cards, then move them to another zone, the top card would stop being revealed.

The issue was that when moving the cards the first card was being
revealed, then being moved.

I have also fixed an issue where:
+ reveal top card
+ scry 4
+ grab all cards and move to the first column of available space at the
left most of the screen (column 0). Everything is fine.
+ now try with another column (> 0), you will see that the card order
has flipped.

This no longer happens.

This needs some testing before being merged. I will run the build for a
while, right now it feels good though.

REVEAL TOP CARD AND SCRY
![s0](https://cloud.githubusercontent.com/assets/2134793/7441624/56b84318-f0f0-11e4-9e07-43dc985bae2e.png)

DRAG SCRY CARDS TO BF. TOP CARD IS STILL REVEALED!
![s1](https://cloud.githubusercontent.com/assets/2134793/7441625/59dc2bb8-f0f0-11e4-858d-231730728f25.png)
