### PR TITLE
Moved zone loactions

### DIFF
--- a/cockatrice/src/gamescene.cpp
+++ b/cockatrice/src/gamescene.cpp
@@ -127,7 +127,12 @@ void GameScene::toggleZoneView(Player *player, const QString &zoneName, int numb
         zoneViews.append(item);
         connect(item, SIGNAL(closePressed(ZoneViewWidget *)), this, SLOT(removeZoneView(ZoneViewWidget *)));
     addItem(item);
-    item->setPos(50, 50);
+    if (zoneName=="grave")
+        item->setPos(360, 100);
+    else if (zoneName=="rfg")
+        item->setPos(380, 120);
+    else
+        item->setPos(340, 80);
 }
 
 void GameScene::addRevealedZoneView(Player *player, CardZone *zone, const QList<const ServerInfo_Card *> &cardList, bool withWritePermission)
@@ -136,7 +141,7 @@ void GameScene::addRevealedZoneView(Player *player, CardZone *zone, const QList<
     zoneViews.append(item);
         connect(item, SIGNAL(closePressed(ZoneViewWidget *)), this, SLOT(removeZoneView(ZoneViewWidget *)));
     addItem(item);
-    item->setPos(50, 50);
+    item->setPos(600, 80);
 }
 
 void GameScene::removeZoneView(ZoneViewWidget *item)


### PR DESCRIPTION
I have moved the default opening positions of some of the reveal zones.

Example:
![zonelocations](https://cloud.githubusercontent.com/assets/2134793/7441696/18500c42-f0f4-11e4-8ce8-733cf98578fb.png)


The sideboard will be in the same position as the scry and the random
card from hand will be the same as the hand view.