### PR TITLE
Append last commit date to version string; fix #1036

### DIFF
--- a/cmake/getversion.cmake
+++ b/cmake/getversion.cmake
@@ -1,7 +1,7 @@
 find_package(Git)
 if(GIT_FOUND)
 	execute_process(
-		COMMAND ${GIT_EXECUTABLE} describe --long --always
+		COMMAND ${GIT_EXECUTABLE} log -1 --date=short "--pretty=%h (%cd)"
 		WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 		RESULT_VARIABLE res_var
 		OUTPUT_VARIABLE GIT_COM_ID


### PR DESCRIPTION
Shown in “about” dialog and used in windows packages name.
![schermata 2015-05-02 alle 19 11 53](https://cloud.githubusercontent.com/assets/1631111/7441968/7c0e35fa-f0ff-11e4-9f65-0ca780c5ccac.png)