### PR TITLE
Catch std exceptions thrown by protobuf and try to pretty print them

### DIFF
--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -160,7 +160,21 @@ void ServerSocketInterface::readClient()
             return;
 
         CommandContainer newCommandContainer;
-        newCommandContainer.ParseFromArray(inputBuffer.data(), messageLength);
+        try {
+            newCommandContainer.ParseFromArray(inputBuffer.data(), messageLength);
+        }
+        catch(std::exception &e) {
+            qDebug() << "Caught std::exception in" << __FILE__ << __LINE__ << __PRETTY_FUNCTION__;
+            qDebug() << "Exception:" << e.what();
+            qDebug() << "Message coming from:" << getAddress();
+            qDebug() << "Message length:" << messageLength;
+            qDebug() << "Message content:" << inputBuffer.toHex();
+        }
+        catch(...) {
+            qDebug() << "Unhandled exception in" << __FILE__ << __LINE__ << __PRETTY_FUNCTION__;
+            qDebug() << "Message coming from:" << getAddress();
+        }
+
         inputBuffer.remove(0, messageLength);
         messageInProgress = false;
 


### PR DESCRIPTION
Recently @woogerboy21's server is experiencing a lot or crashes due to bad memory allocations while protobuf is parsing a message sent from a client (#1043).
This PR should catch the exception and avoid the server from crashing in that same point (but nothing excludes it will crash in a later point); additionally, if such an exception gets caught, it should pretty print the original message that caused the problem and the IP of the user.