### PR TITLE
Updated reveal zone

### DIFF
--- a/cockatrice/src/zoneviewwidget.cpp
+++ b/cockatrice/src/zoneviewwidget.cpp
@@ -7,6 +7,8 @@
 #include <QPainter>
 #include <QPalette>
 #include <QScrollBar>
+#include <QStyleOption>
+#include <QStyleOptionTitleBar>
 #include "zoneviewwidget.h"
 #include "carditem.h"
 #include "zoneviewzone.h"
@@ -57,28 +59,14 @@ void TitleLabel::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 }
 
 ZoneViewWidget::ZoneViewWidget(Player *_player, CardZone *_origZone, int numberCards, bool _revealZone, bool _writeableRevealZone, const QList<const ServerInfo_Card *> &cardList)
-    : QGraphicsWidget(0, Qt::Tool | Qt::FramelessWindowHint), canBeShuffled(_origZone->getIsShufflable()), player(_player)
+    : QGraphicsWidget(0, Qt::Window), canBeShuffled(_origZone->getIsShufflable()), player(_player)
 {
     setAcceptHoverEvents(true);
     setAttribute(Qt::WA_DeleteOnClose);
     setZValue(2000000006);
     setFlag(ItemIgnoresTransformations);
 
-    QGraphicsLinearLayout *hbox = new QGraphicsLinearLayout(Qt::Horizontal);
-    titleLabel = new TitleLabel;
-    connect(titleLabel, SIGNAL(mouseMoved(QPointF)), this, SLOT(moveWidget(QPointF)));
-    closeButton = new QPushButton("X");
-    connect(closeButton, SIGNAL(clicked()), this, SLOT(close()));
-    closeButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-    QGraphicsProxyWidget *closeButtonProxy = new QGraphicsProxyWidget;
-    closeButtonProxy->setWidget(closeButton);
-
-    hbox->addItem(titleLabel);
-    hbox->addItem(closeButtonProxy);
     QGraphicsLinearLayout *vbox = new QGraphicsLinearLayout(Qt::Vertical);
-
-    vbox->addItem(hbox);
-
     QGraphicsLinearLayout *hPilebox = 0;
 
     if (numberCards < 0) {
@@ -179,17 +167,11 @@ void ZoneViewWidget::processSetPileView(int value) {
 
 void ZoneViewWidget::retranslateUi()
 {
-    titleLabel->setText(zone->getTranslatedName(false, CaseNominative));
+    setWindowTitle(zone->getTranslatedName(false, CaseNominative));
     sortByNameCheckBox.setText(tr("sort by name"));
     sortByTypeCheckBox.setText(tr("sort by type"));
     shuffleCheckBox.setText(tr("shuffle when closing"));
     pileViewCheckBox.setText(tr("pile view"));
-}
-
-void ZoneViewWidget::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
-{
-    painter->fillRect(boundingRect(), palette().color(QPalette::Window));
-    QGraphicsWidget::paint(painter, option, widget);
 }
 
 void ZoneViewWidget::moveWidget(QPointF scenePos)
@@ -263,4 +245,10 @@ void ZoneViewWidget::zoneDeleted()
 {
     emit closePressed(this);
     deleteLater();
+}
+
+void ZoneViewWidget::initStyleOption(QStyleOption *option) const {
+    QStyleOptionTitleBar *titleBar = qstyleoption_cast<QStyleOptionTitleBar *>(option);
+    if (titleBar)
+        titleBar->icon = QIcon(":/resources/appicon.svg");
 }

--- a/cockatrice/src/zoneviewwidget.h
+++ b/cockatrice/src/zoneviewwidget.h
@@ -16,6 +16,7 @@ class GameScene;
 class ServerInfo_Card;
 class QGraphicsSceneMouseEvent;
 class QGraphicsSceneWheelEvent;
+class QStyleOption;
 
 class TitleLabel : public QGraphicsWidget {
     Q_OBJECT
@@ -68,7 +69,7 @@ public:
     void retranslateUi();
 protected:
     void closeEvent(QCloseEvent *event);
-    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+    void initStyleOption(QStyleOption *option) const;
 };
 
 #endif

--- a/cockatrice/src/zoneviewzone.cpp
+++ b/cockatrice/src/zoneviewzone.cpp
@@ -1,6 +1,8 @@
 #include <math.h>
 #include <QDebug>
 #include <QGraphicsSceneWheelEvent>
+#include <QBrush>
+#include <QPainter>
 #include "zoneviewzone.h"
 #include "player.h"
 #include "carddragitem.h"
@@ -32,8 +34,11 @@ QRectF ZoneViewZone::boundingRect() const
     return bRect;
 }
 
-void ZoneViewZone::paint(QPainter * /*painter*/, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
+void ZoneViewZone::paint(QPainter * painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
 {
+    QBrush windowBrush(QColor(240,240,240));
+    windowBrush.setColor(windowBrush.color().darker(150));
+    painter->fillRect(boundingRect(), windowBrush);
 }
 
 void ZoneViewZone::initializeCards(const QList<const ServerInfo_Card *> &cardList)
@@ -123,7 +128,7 @@ void ZoneViewZone::reorganizeCards()
             }
 
             lastCardType = cardType;
-            qreal x = typeColumn * CARD_WIDTH;
+            qreal x = 7 + (typeColumn * CARD_WIDTH);
             qreal y = typeRow * CARD_HEIGHT / 3;
             c->setPos(x + 5, y + 5);
             c->setRealZValue(i);
@@ -132,7 +137,7 @@ void ZoneViewZone::reorganizeCards()
     } else {
         for (int i = 0; i < cardCount; i++) {
             CardItem *c = cardsToDisplay.at(i);
-            qreal x = (i / rows) * CARD_WIDTH;
+            qreal x = 7 + ((i / rows) * CARD_WIDTH);
             qreal y = (i % rows) * CARD_HEIGHT / 3;
             c->setPos(x + 5, y + 5);
             c->setRealZValue(i);


### PR DESCRIPTION
+ darkened card area to easily see selection boundaries
+ reverted back to using a window
+ **window can be re-sized**
+ removed fake title bar and "X"
+ moved all cards revealed slightly to the right, makes it easier to
drag-select from the left

![woop](https://cloud.githubusercontent.com/assets/2134793/7457853/e207f15c-f28f-11e4-91c9-8960eedb0b49.png)
