### PR TITLE
expanded error msg for name conflicts (tokens)

### DIFF
--- a/cockatrice/src/dlg_edit_tokens.cpp
+++ b/cockatrice/src/dlg_edit_tokens.cpp
@@ -136,7 +136,7 @@ void DlgEditTokens::actAddToken()
     do {
         name = QInputDialog::getText(this, tr("Add token"), tr("Please enter the name of the token:"));
         if (!name.isEmpty() && cardDatabaseModel->getDatabase()->getCard(name, false)) {
-            QMessageBox::critical(this, tr("Error"), tr("The chosen name conflicts with an existing card or token."));
+            QMessageBox::critical(this, tr("Error"), tr("The chosen name conflicts with an existing card or token.\n Make sure to enable the 'token set' in 'Edit sets...' dialog to display them correctly."));
             askAgain = true;
         } else
             askAgain = false;


### PR DESCRIPTION
added "Make sure to enable the 'token set' in 'Edit sets...' dialog to display them correctly."

This error message shows when you try to create a token with the same name of a card or a existent token. The problem is that if  they have the dummy token set disabled they don't see any tokens in the list, but still cockatrice recognizes the conflict, that's very confusing.

- enable dummy token set
- create a token named `abc` in `edit tokens`
- it shows in the list
- disable dummy token set
- `edit tokens` doesn't show `abc` token anymore
- try to create a new token named `abc`
- error

Right now the user gets no hint about how to fix it or what he made wrong...

---
Better to use `\"Edit Sets\"`?