### PR TITLE
Custom default zone colors

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -234,6 +234,34 @@ void GeneralSettingsPage::retranslateUi()
 
 AppearanceSettingsPage::AppearanceSettingsPage()
 {
+
+    handZoneColor = new QLineEdit;
+    handZoneColor->setText(settingsCache->getHandZoneColor());
+    updateZonePreview(handZoneColor);
+    connect(handZoneColor, SIGNAL(textChanged(QString)), this, SLOT(updateZoneColor(QString)));
+
+    tableZoneColor = new QLineEdit;
+    tableZoneColor->setText(settingsCache->getTableZoneColor());
+    updateZonePreview(tableZoneColor);
+    connect(tableZoneColor, SIGNAL(textChanged(QString)), this, SLOT(updateZoneColor(QString)));
+
+    stackZoneColor = new QLineEdit;
+    stackZoneColor->setText(settingsCache->getStackZoneColor());
+    updateZonePreview(stackZoneColor);
+    connect(stackZoneColor, SIGNAL(textChanged(QString)), this, SLOT(updateZoneColor(QString)));
+
+
+    QGridLayout *zoneDefaultColorGrid = new QGridLayout;
+    zoneDefaultColorGrid->addWidget(&handZoneLabel, 0, 0);
+    zoneDefaultColorGrid->addWidget(handZoneColor, 0, 1);
+    zoneDefaultColorGrid->addWidget(&tableZoneLabel, 1, 0);
+    zoneDefaultColorGrid->addWidget(tableZoneColor, 1, 1);
+    zoneDefaultColorGrid->addWidget(&stackZoneLabel, 2, 0);
+    zoneDefaultColorGrid->addWidget(stackZoneColor, 2, 1);
+
+    zoneDefaultColorGroupBox = new QGroupBox;
+    zoneDefaultColorGroupBox->setLayout(zoneDefaultColorGrid);
+
     QIcon deleteIcon(":/resources/icon_delete.svg");
     
     handBgEdit = new QLineEdit(settingsCache->getHandBgPath());
@@ -339,6 +367,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     tableGroupBox->setLayout(tableGrid);
     
     QVBoxLayout *mainLayout = new QVBoxLayout;
+    mainLayout->addWidget(zoneDefaultColorGroupBox);
     mainLayout->addWidget(zoneBgGroupBox);
     mainLayout->addWidget(cardsGroupBox);
     mainLayout->addWidget(handGroupBox);
@@ -349,6 +378,10 @@ AppearanceSettingsPage::AppearanceSettingsPage()
 
 void AppearanceSettingsPage::retranslateUi()
 {
+    zoneDefaultColorGroupBox->setTitle(tr("Default Game-play Colors"));
+    handZoneLabel.setText(tr("Hand Zone"));
+    tableZoneLabel.setText(tr("Table Zone"));
+    stackZoneLabel.setText(tr("Stack Zone"));
     zoneBgGroupBox->setTitle(tr("Zone background pictures"));
     handBgLabel.setText(tr("Hand background:"));
     stackBgLabel.setText(tr("Stack background:"));
@@ -367,6 +400,36 @@ void AppearanceSettingsPage::retranslateUi()
     tableGroupBox->setTitle(tr("Table grid layout"));
     invertVerticalCoordinateCheckBox.setText(tr("Invert vertical coordinate"));
     minPlayersForMultiColumnLayoutLabel.setText(tr("Minimum player count for multi-column layout:"));
+}
+
+void AppearanceSettingsPage::updateZonePreview(QLineEdit* zone) {
+    QString colorString;
+    if (zone == handZoneColor)
+        colorString = settingsCache->getHandZoneColor();
+    else if (zone == tableZoneColor)
+        colorString = settingsCache->getTableZoneColor();
+    else if (zone == stackZoneColor)
+        colorString = settingsCache->getStackZoneColor();
+    QColor colorToSet;
+    colorToSet.setNamedColor("#" + colorString);
+    if (colorToSet.isValid())
+        zone->setStyleSheet("QLineEdit{background:#" + colorString + ";color: " +  (colorToSet.black() > 100 ? "white" : "black") + "}");
+}
+
+void AppearanceSettingsPage::updateZoneColor(QString value) {
+    QColor colorToSet;
+    colorToSet.setNamedColor("#" + value);
+    if (colorToSet.isValid()) {
+        QLineEdit* zone = qobject_cast<QLineEdit*>(sender());
+        if (zone == handZoneColor)
+            settingsCache->setHandZoneColor(value);
+        else if (zone == tableZoneColor)
+            settingsCache->setTableZoneColor(value);
+        else if (zone == stackZoneColor)
+            settingsCache->setStackZoneColor(value);
+        
+        updateZonePreview(zone);
+    }
 }
 
 void AppearanceSettingsPage::handBgClearButtonClicked()

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -378,10 +378,10 @@ AppearanceSettingsPage::AppearanceSettingsPage()
 
 void AppearanceSettingsPage::retranslateUi()
 {
-    zoneDefaultColorGroupBox->setTitle(tr("Default Game-play Colors"));
-    handZoneLabel.setText(tr("Hand Zone"));
-    tableZoneLabel.setText(tr("Table Zone"));
-    stackZoneLabel.setText(tr("Stack Zone"));
+    zoneDefaultColorGroupBox->setTitle(tr("Default Game-play Colors (Hexadecimal)"));
+    handZoneLabel.setText(tr("Hand Zone:"));
+    tableZoneLabel.setText(tr("Table Zone:"));
+    stackZoneLabel.setText(tr("Stack Zone:"));
     zoneBgGroupBox->setTitle(tr("Zone background pictures"));
     handBgLabel.setText(tr("Hand background:"));
     stackBgLabel.setText(tr("Stack background:"));

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -81,6 +81,7 @@ private slots:
     void playerAreaBgButtonClicked();
     void cardBackPicturePathClearButtonClicked();
     void cardBackPicturePathButtonClicked();
+    void updateZoneColor(QString);
 signals:
     void handBgChanged(const QString &path);
     void stackBgChanged(const QString &path);
@@ -105,13 +106,22 @@ private:
     QCheckBox leftJustifiedHandCheckBox;
     QCheckBox invertVerticalCoordinateCheckBox;
     QGroupBox *zoneBgGroupBox;
+    QGroupBox *zoneDefaultColorGroupBox;
     QGroupBox *cardsGroupBox;
     QGroupBox *handGroupBox;
     QGroupBox *tableGroupBox;
     QSpinBox minPlayersForMultiColumnLayoutEdit;
+    QLineEdit *handZoneColor;
+    QLineEdit *tableZoneColor;
+    QLineEdit *stackZoneColor;
+    QLabel handZoneLabel;
+    QLabel tableZoneLabel;
+    QLabel stackZoneLabel;
 public:
     AppearanceSettingsPage();
     void retranslateUi();
+private:
+    void updateZonePreview(QLineEdit* zone);
 };
 
 class UserInterfaceSettingsPage : public AbstractSettingsPage {

--- a/cockatrice/src/handzone.cpp
+++ b/cockatrice/src/handzone.cpp
@@ -77,8 +77,14 @@ QRectF HandZone::boundingRect() const
 
 void HandZone::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
 {
-    if (bgPixmap.isNull())
-        painter->fillRect(boundingRect(), QColor(30, 30, 30));
+    if (bgPixmap.isNull()) {
+        QColor colorToSet;
+        colorToSet.setNamedColor("#" + settingsCache->getHandZoneColor());
+        if (colorToSet.isValid())
+            painter->fillRect(boundingRect(), colorToSet);
+        else
+            painter->fillRect(boundingRect(), QColor(30, 30, 30));
+    }
     else
         painter->fillRect(boundingRect(), QBrush(bgPixmap));
 }

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -81,6 +81,25 @@ SettingsCache::SettingsCache()
     leftJustified = settings->value("interface/leftjustified", false).toBool();
 
     masterVolume = settings->value("sound/mastervolume", 100).toInt();
+
+    handZoneColor = settings->value("personal/handzonecolor", "1E1E1E").toString();
+    tableZoneColor = settings->value("personal/tablezonecolor", "646464").toString();
+    stackZoneColor = settings->value("personal/stackzonecolor", "712B2B").toString();
+}
+
+void SettingsCache::setHandZoneColor(const QString &_color) {
+    handZoneColor = _color;
+    settings->setValue("personal/handzonecolor", handZoneColor);
+}
+
+void SettingsCache::setTableZoneColor(const QString &_color) {
+    tableZoneColor = _color;
+    settings->setValue("personal/tablezonecolor", tableZoneColor);
+}
+
+void SettingsCache::setStackZoneColor(const QString &_color) {
+    stackZoneColor = _color;
+    settings->setValue("personal/stackzonecolor", stackZoneColor);
 }
 
 void SettingsCache::setMasterVolume(int _masterVolume) {

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -81,6 +81,9 @@ private:
     bool showMentionPopups;
     bool leftJustified;
     int masterVolume;
+    QString handZoneColor;
+    QString tableZoneColor;
+    QString stackZoneColor;
 public:
     SettingsCache();
     const QByteArray &getMainWindowGeometry() const { return mainWindowGeometry; }
@@ -96,6 +99,9 @@ public:
     QString getPlayerBgPath() const { return playerBgPath; }
     QString getCardBackPicturePath() const { return cardBackPicturePath; }
     QString getChatMentionColor() const { return chatMentionColor; }
+    QString getHandZoneColor() const { return handZoneColor; }
+    QString getTableZoneColor() const { return tableZoneColor; }
+    QString getStackZoneColor() const { return stackZoneColor; }
     bool getPicDownload() const { return picDownload; }
     bool getPicDownloadHq() const { return picDownloadHq; }
     bool getNotificationsEnabled() const { return notificationsEnabled; }
@@ -186,6 +192,9 @@ public slots:
     void setShowMentionPopups(const int _showMentionPopups);
     void setLeftJustified( const int _leftJustified);
     void setMasterVolume(const int _masterVolume); 
+    void setHandZoneColor(const QString& _color);
+    void setTableZoneColor(const QString& _color);
+    void setStackZoneColor(const QString& _color);
 };
 
 extern SettingsCache *settingsCache;

--- a/cockatrice/src/stackzone.cpp
+++ b/cockatrice/src/stackzone.cpp
@@ -48,9 +48,14 @@ QRectF StackZone::boundingRect() const
 
 void StackZone::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
 {
-    if (bgPixmap.isNull())
-        painter->fillRect(boundingRect(), QColor(113, 43, 43));
-    else
+    if (bgPixmap.isNull()) {
+        QColor colorToSet;
+        colorToSet.setNamedColor("#" + settingsCache->getStackZoneColor());
+            if (colorToSet.isValid())
+                painter->fillRect(boundingRect(), colorToSet);
+            else
+                painter->fillRect(boundingRect(), QColor(113, 43, 43));
+    }
         painter->fillRect(boundingRect(), QBrush(bgPixmap));
 }
 

--- a/cockatrice/src/tablezone.cpp
+++ b/cockatrice/src/tablezone.cpp
@@ -68,8 +68,14 @@ bool TableZone::isInverted() const
 void TableZone::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
 {
     // if no custom background is provided then use the default color
-    if (backgroundPixelMap.isNull())
-        painter->fillRect(boundingRect(), BACKGROUND_COLOR);
+    if (backgroundPixelMap.isNull()) {
+        QColor colorToSet;
+        colorToSet.setNamedColor("#" + settingsCache->getTableZoneColor());
+            if (colorToSet.isValid())
+                painter->fillRect(boundingRect(), colorToSet);
+            else
+                painter->fillRect(boundingRect(), BACKGROUND_COLOR);
+    }
     else
         painter->fillRect(boundingRect(), QBrush(backgroundPixelMap));
 


### PR DESCRIPTION
Users can now set the default color of zones

+ Preview of the colors, like with the mention preview
+ Will set the text to white if preview color is too dark

Horrible example below, just a PoC

![1](https://cloud.githubusercontent.com/assets/2134793/7629946/6b6189e2-fa31-11e4-8526-3975c9b3b628.png)

![2](https://cloud.githubusercontent.com/assets/2134793/7629950/74a47500-fa31-11e4-96ef-5a08f5959dcb.png)

