### PR TITLE
Ensure sounds are working at startup; Fix 1070

### DIFF
--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -56,7 +56,7 @@ Section "Update configuration" SecUpdateConfig
 	WriteRegStr HKCU "Software\Cockatrice\Cockatrice\paths" "carddatabase" "$LOCALAPPDATA\Cockatrice\cards.xml"
 	WriteRegStr HKCU "Software\Cockatrice\Cockatrice\paths" "decks" "$LOCALAPPDATA\Cockatrice\decks"
 	WriteRegStr HKCU "Software\Cockatrice\Cockatrice\paths" "pics" "$LOCALAPPDATA\Cockatrice\pics"
-	WriteRegStr HKCU "Software\Cockatrice\Cockatrice\sound" "path" "$LOCALAPPDATA\Cockatrice\sounds"
+	WriteRegStr HKCU "Software\Cockatrice\Cockatrice\sound" "path" "$INSTDIR\sounds"
 SectionEnd
 
 Section "Start menu item" SecStartMenu

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -164,42 +164,6 @@ int main(int argc, char *argv[])
     }
     if (!QDir().mkpath(settingsCache->getPicsPath() + "/CUSTOM"))
         qDebug() << "Could not create " + settingsCache->getPicsPath().toUtf8() + "/CUSTOM. Will fall back on default card images.";
-        
-#ifdef Q_OS_MAC
-    if(settingsCache->getHandBgPath().isEmpty() &&
-        settingsCache->getStackBgPath().isEmpty() &&
-        settingsCache->getTableBgPath().isEmpty() &&
-        settingsCache->getPlayerBgPath().isEmpty())
-    {
-        QString srcDir = QLibraryInfo::location(QLibraryInfo::DataPath);
-        QString destDir = dataDir + "/zonebg";
-        QDir tmpDir(destDir);
-        if(!tmpDir.exists())
-        {
-            // try to install the default images for the current user and set the settigs value
-            settingsCache->copyPath(srcDir + "/zonebg", destDir);
-
-            settingsCache->setHandBgPath(destDir + "/fabric_green.png");
-            settingsCache->setStackBgPath(destDir + "/fabric_red.png");
-            settingsCache->setTableBgPath(destDir + "/fabric_blue.png");
-            settingsCache->setPlayerBgPath(destDir + "/fabric_gray.png");
-        }
-    }
-
-    if(settingsCache->getSoundPath().isEmpty())
-    {
-        QString srcDir = QLibraryInfo::location(QLibraryInfo::DataPath);
-        QString destDir = dataDir + "/sounds";
-        QDir tmpDir(destDir);
-        if(!tmpDir.exists())
-        {
-            // try to install the default sounds for the current user and set the settigs value
-            settingsCache->copyPath(srcDir + "/sounds", destDir);
-
-            settingsCache->setSoundPath(destDir);
-        }
-    }
-#endif
 
     if (!settingsValid() || db->getLoadStatus() != Ok) {
         qDebug("main(): invalid settings or load status");

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -165,6 +165,20 @@ int main(int argc, char *argv[])
     if (!QDir().mkpath(settingsCache->getPicsPath() + "/CUSTOM"))
         qDebug() << "Could not create " + settingsCache->getPicsPath().toUtf8() + "/CUSTOM. Will fall back on default card images.";
 
+    if(settingsCache->getSoundPath().isEmpty() || !QDir(settingsCache->getSoundPath()).exists())
+    {
+        QDir tmpDir;
+        
+#ifdef Q_OS_MAC
+        tmpDir = app.applicationDirPath() + "/../Resources/sounds";
+#elif defined(Q_OS_WIN)
+         tmpDir = app.applicationDirPath() + "/sounds";
+#else // linux
+        tmpDir = app.applicationDirPath() + "/../share/cockatrice/sounds/";
+#endif
+        settingsCache->setSoundPath(tmpDir.canonicalPath());
+    }
+
     if (!settingsValid() || db->getLoadStatus() != Ok) {
         qDebug("main(): invalid settings or load status");
         DlgSettings dlgSettings;

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -1,7 +1,5 @@
 #include "settingscache.h"
 #include <QSettings>
-#include <QDebug>
-#include <QDir>
 
 SettingsCache::SettingsCache()
 {
@@ -380,32 +378,4 @@ void SettingsCache::setPixmapCacheSize(const int _pixmapCacheSize)
     pixmapCacheSize = _pixmapCacheSize;
     settings->setValue("personal/pixmapCacheSize", pixmapCacheSize);
     emit pixmapCacheSizeChanged(pixmapCacheSize);
-}
-
-void SettingsCache::copyPath(const QString &src, const QString &dst)
-{
-    // test source && return if inexistent
-    QDir dir(src);
-    if (! dir.exists())
-        return;
-    // test destination && create if inexistent
-    QDir tmpDir(dst);
-    if (!tmpDir.exists())
-    {
-        tmpDir.setPath(QDir::rootPath());
-        if (!tmpDir.mkdir(dst) && !tmpDir.exists()) {
-            // TODO: this is probably not good.
-            qDebug() << "copyPath(): Failed to create dir: " << dst;
-        }
-    }
-
-    foreach (QString d, dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot)) {
-        QString dst_path = dst + QDir::separator() + d;
-        dir.mkpath(dst_path);
-        copyPath(src+ QDir::separator() + d, dst_path);
-    }
-
-    foreach (QString f, dir.entryList(QDir::Files)) {
-        QFile::copy(src + QDir::separator() + f, dst + QDir::separator() + f);
-    }
 }

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -129,7 +129,6 @@ public:
     QString getPicUrlHq() const { return picUrlHq; }
     QString getPicUrlFallback() const { return picUrlFallback; }
     QString getPicUrlHqFallback() const { return picUrlHqFallback; }
-    void copyPath(const QString &src, const QString &dst);
     bool getAutoConnect() const { return attemptAutoConnect; }
     int getPixmapCacheSize() const { return pixmapCacheSize; }
     bool getScaleCards() const {  return scaleCards; }


### PR DESCRIPTION
In #1070 some issues with the current handling of sounds emerged. The first issues was fixed in #1071, this commit should fix the remaining ones. This PR implements https://github.com/Cockatrice/Cockatrice/issues/1070#issuecomment-102035472 :

 * fix windows's nsis setup script to use "$INSTDIR\sounds" instead of "$LOCALAPPDATA\sounds". This reverts a single line of commit f1e6aeb that had a specific meaning (taking cards.xml and pictures out of c:\program files, where users can't write anymore since windows vista), but it's currently breaking sounds under windows
 * make sounds under osx works the same, pointing them to the plication bundle's Resources/sounds directory
