### PR TITLE
Disable SB button when ready

### DIFF
--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -217,6 +217,7 @@ void DeckViewContainer::setReadyStart(bool ready)
 {
     readyStartButton->setState(ready);
     deckView->setLocked(ready || !sideboardLockButton->getState());
+    sideboardLockButton->setEnabled(!readyStartButton->getState());
 }
 
 void DeckViewContainer::setSideboardLocked(bool locked)


### PR DESCRIPTION
Reduces confusion, cant click the button when ready anyway.

![untitled](https://cloud.githubusercontent.com/assets/2134793/7662046/197379b0-fb58-11e4-8804-a9a9945c7116.png)