### PR TITLE
No need for [url][/url]

### DIFF
--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -168,7 +168,7 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
         // search for the first [ or @
         bracketFirstIndex = message.indexOf('[');
         mentionFirstIndex = mentionEnabled ? message.indexOf('@') : -1;
-        urlFirstIndex = message.indexOf("https://");
+        urlFirstIndex = message.indexOf(QRegExp("https?://|www."));
         if(bracketFirstIndex == -1) {
             if(mentionFirstIndex == -1) {
                 if (urlFirstIndex == -1) {


### PR DESCRIPTION
No longer need to use the [url] tags to add **HTTPS** links. I want to
only link to "secure" site by default, hence only https.

Users can still use [url] tags if they want to.

The ENTIRE chat  code needs to be rewitten, as it is just packing more
code upon code. It can be done in another PR though. This just gets the
base working feature in place.

This example was produced without the use of [url] tags

![exampleofurl](https://cloud.githubusercontent.com/assets/2134793/7665295/f1759b06-fbb0-11e4-95d7-cbc5622cf62c.png)
