### PR TITLE
Added game type to tab title

### DIFF
--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -359,6 +359,9 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, GameReplay *_replay)
     splitter->restoreState(settingsCache->getTabGameSplitterSizes());
     
     messageLog->logReplayStarted(gameInfo.game_id());
+
+    for (int i = gameInfo.game_types_size() - 1; i >= 0; i--)
+        gameTypes.append(roomGameTypes.find(gameInfo.game_types(i)).value());
 }
 
 TabGame::TabGame(TabSupervisor *_tabSupervisor, QList<AbstractClient *> &_clients, const Event_GameJoined &event, const QMap<int, QString> &_roomGameTypes)
@@ -490,6 +493,9 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, QList<AbstractClient *> &_client
     splitter->restoreState(settingsCache->getTabGameSplitterSizes());
     
     messageLog->logGameJoined(gameInfo.game_id());
+
+    for (int i = gameInfo.game_types_size() - 1; i >= 0; i--)
+        gameTypes.append(roomGameTypes.find(gameInfo.game_types(i)).value());
 }
 
 void TabGame::addMentionTag(QString value) {
@@ -1159,10 +1165,32 @@ CardItem *TabGame::getCard(int playerId, const QString &zoneName, int cardId) co
 
 QString TabGame::getTabText() const
 {
+    QString gameTypeInfo;
+    if (gameTypes.size() != 0) {
+        gameTypeInfo = gameTypes.at(0);
+        if (gameTypes.size() > 1) 
+            gameTypeInfo.append("...");
+    }
+
+    QString gameDesc(gameInfo.description().c_str());
+    QString gameId(QString::number(gameInfo.game_id()));
+
+    QString tabText;
     if (replay)
-        return tr("Replay %1: %2").arg(gameInfo.game_id()).arg(QString::fromStdString(gameInfo.description()));
-    else
-        return tr("Game %1: %2").arg(gameInfo.game_id()).arg(QString::fromStdString(gameInfo.description()));
+        tabText.append(tr("REPLAY "));
+    if (!gameTypeInfo.isEmpty())
+        tabText.append(gameTypeInfo + " ");
+    if (!gameDesc.isEmpty()) {
+        if (gameDesc.length() >= 15)
+            tabText.append("| " + gameDesc.left(15) + "... ");
+        else
+            tabText.append("| " + gameDesc + " ");
+    }
+    if (!tabText.isEmpty())
+        tabText.append("| ");
+    tabText.append("#" + gameId);
+
+    return tabText;
 }
 
 Player *TabGame::getActiveLocalPlayer() const

--- a/cockatrice/src/tab_game.h
+++ b/cockatrice/src/tab_game.h
@@ -115,6 +115,7 @@ private:
     int activePlayer;
     CardItem *activeCard;
     bool gameClosed;
+    QStringList gameTypes;
     
     // Replay related members
     GameReplay *replay;


### PR DESCRIPTION
+ The game type is now displayed in the tab
+ >1 game type will use (...)
+ Removed titles for sections

![untitled](https://cloud.githubusercontent.com/assets/2134793/7712912/7ef0db7e-fe74-11e4-8b0a-114859a20ff9.png)

In the above:
 + tab 1 is 1 type with desc
 + tab 2 is >1 type with desc
 + tab 3 is only type.

If you have nothing set then you just see the game #.
