### PR TITLE
Load additional xml sets from $userprofile/customsets/

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -1053,6 +1053,18 @@ void CardDatabase::loadTokenDatabase()
     loadCardDatabase(settingsCache->getTokenDatabasePath(), true);
 }
 
+void CardDatabase::loadCustomCardDatabases(const QString &path)
+{
+    QDir dir(path);
+    if(!dir.exists())
+        return;
+
+    foreach(QString fileName, dir.entryList(QStringList("*.xml"), QDir::Files | QDir::Readable, QDir::Name))
+    {
+        loadCardDatabase(dir.absoluteFilePath(fileName), false);
+    }
+}
+
 QStringList CardDatabase::getAllColors() const
 {
     QSet<QString> colors;

--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -1059,7 +1059,7 @@ void CardDatabase::loadCustomCardDatabases(const QString &path)
     if(!dir.exists())
         return;
 
-    foreach(QString fileName, dir.entryList(QStringList("*.xml"), QDir::Files | QDir::Readable, QDir::Name))
+    foreach(QString fileName, dir.entryList(QStringList("*.xml"), QDir::Files | QDir::Readable, QDir::Name | QDir::IgnoreCase))
     {
         loadCardDatabase(dir.absoluteFilePath(fileName), false);
     }

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -271,6 +271,7 @@ public:
 public slots:
     void clearPixmapCache();
     LoadStatus loadCardDatabase(const QString &path, bool tokens = false);
+    void loadCustomCardDatabases(const QString &path);
     void emitCardListChanged();
 private slots:
     void imageLoaded(CardInfo *card, QImage image);

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -164,6 +164,13 @@ int main(int argc, char *argv[])
     }
     if (!QDir().mkpath(settingsCache->getPicsPath() + "/CUSTOM"))
         qDebug() << "Could not create " + settingsCache->getPicsPath().toUtf8() + "/CUSTOM. Will fall back on default card images.";
+    if (QDir().mkpath(dataDir + "/customsets"))
+    {
+        // if the dir exists (or has just been created)
+        db->loadCustomCardDatabases(dataDir + "/customsets");
+    } else {
+        qDebug() << "Could not create " + dataDir + "/customsets folder.";
+    }
 
     if(settingsCache->getSoundPath().isEmpty() || !QDir(settingsCache->getSoundPath()).exists())
     {


### PR DESCRIPTION
as requested by @doombringer777:
```
Been thinking a minor change I wouldn't mind would be if Cockatrice loaded all .xml card files in a directory on startup
so that custom set creators could have their cards load without having to constantly go to the settings -> card database path
```