### PR TITLE
Fix card update under windows

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -572,7 +572,7 @@ void MainWindow::actCheckCardUpdates()
         return;
     }
 
-    cardUpdateProcess->start(updaterCmd);
+    cardUpdateProcess->start("\"" + updaterCmd + "\"");
 }
 
 void MainWindow::cardUpdateError(QProcess::ProcessError err)


### PR DESCRIPTION
It failed if the path contained spaces.