### PR TITLE
Highlight text after adding card

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -606,6 +606,7 @@ void TabDeckEditor::addCardHelper(QString zoneName)
     recursiveExpand(newCardIndex);
     deckView->setCurrentIndex(newCardIndex);
     setModified(true);
+    searchEdit->setSelection(0, searchEdit->text().length());
 }
 
 void TabDeckEditor::actSwapCard()


### PR DESCRIPTION
After adding a card to the main or side, the search text will become
selected to easily start the next search