### PR TITLE
Implement migrations; fix #153

### DIFF
--- a/servatrice/migrations/servatrice_0000_to_0001.sql
+++ b/servatrice/migrations/servatrice_0000_to_0001.sql
@@ -1,0 +1,13 @@
+-- Servatrice db migration from version 0 to version 1
+
+-- FIX #153
+CREATE TABLE IF NOT EXISTS `cockatrice_schema_version` (
+  `version` int(7) unsigned NOT NULL,
+  PRIMARY KEY  (`version`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+INSERT INTO cockatrice_schema_version VALUES(1);
+
+-- FIX #1119
+ALTER TABLE `cockatrice_rooms_gametypes` DROP PRIMARY KEY;
+ALTER TABLE `cockatrice_rooms_gametypes` ADD KEY (`id_room`);

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -11,6 +11,17 @@ SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
 /*!40101 SET NAMES utf8 */;
 
+-- Every time the database schema changes, the schema version number
+-- must be incremented. Also remember to update the corresponding
+-- number in servatrice/src/servatrice_database_interface.h
+
+CREATE TABLE IF NOT EXISTS `cockatrice_schema_version` (
+  `version` int(7) unsigned NOT NULL,
+  PRIMARY KEY  (`version`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+INSERT INTO cockatrice_schema_version VALUES(1);
+
 CREATE TABLE IF NOT EXISTS `cockatrice_decklist_files` (
   `id` int(7) unsigned zerofill NOT NULL auto_increment,
   `id_folder` int(7) unsigned zerofill NOT NULL,

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -89,7 +89,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_users` (
   KEY `email` (`email`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8;
 
-CREATE TABLE `cockatrice_uptime` (
+CREATE TABLE IF NOT EXISTS `cockatrice_uptime` (
   `id_server` tinyint(3) NOT NULL,
   `timest` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `uptime` int(11) NOT NULL,
@@ -100,14 +100,14 @@ CREATE TABLE `cockatrice_uptime` (
   PRIMARY KEY (`timest`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
-CREATE TABLE `cockatrice_servermessages` (
+CREATE TABLE IF NOT EXISTS `cockatrice_servermessages` (
   `id_server` tinyint(3) not null default 0,
   `timest` datetime NOT NULL default '0000-00-00 00:00:00',
   `message` text,
   PRIMARY KEY  (`timest`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
-CREATE TABLE `cockatrice_ignorelist` (
+CREATE TABLE IF NOT EXISTS `cockatrice_ignorelist` (
   `id_user1` int(7) unsigned NOT NULL,
   `id_user2` int(7) unsigned NOT NULL,
   UNIQUE KEY `key` (`id_user1`, `id_user2`),
@@ -115,7 +115,7 @@ CREATE TABLE `cockatrice_ignorelist` (
   KEY `id_user2` (`id_user2`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
-CREATE TABLE `cockatrice_buddylist` (
+CREATE TABLE IF NOT EXISTS `cockatrice_buddylist` (
   `id_user1` int(7) unsigned NOT NULL,
   `id_user2` int(7) unsigned NOT NULL,
   UNIQUE KEY `key` (`id_user1`, `id_user2`),
@@ -123,7 +123,7 @@ CREATE TABLE `cockatrice_buddylist` (
   KEY `id_user2` (`id_user2`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
-CREATE TABLE `cockatrice_bans` (
+CREATE TABLE IF NOT EXISTS `cockatrice_bans` (
  `user_name` varchar(255) NOT NULL,
  `ip_address` varchar(255) NOT NULL,
  `id_admin` int(7) unsigned zerofill NOT NULL,
@@ -136,7 +136,7 @@ CREATE TABLE `cockatrice_bans` (
   KEY `ip_address` (`ip_address`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
-CREATE TABLE `cockatrice_sessions` (
+CREATE TABLE IF NOT EXISTS `cockatrice_sessions` (
   `id` int(9) NOT NULL AUTO_INCREMENT,
   `user_name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `id_server` tinyint(3) NOT NULL,
@@ -147,7 +147,7 @@ CREATE TABLE `cockatrice_sessions` (
   KEY `username` (`user_name`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
-CREATE TABLE `cockatrice_servers` (
+CREATE TABLE IF NOT EXISTS `cockatrice_servers` (
   `id` mediumint(8) unsigned NOT NULL,
   `ssl_cert` text COLLATE utf8_unicode_ci NOT NULL,
   `hostname` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
@@ -157,7 +157,7 @@ CREATE TABLE `cockatrice_servers` (
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
-CREATE TABLE `cockatrice_replays` (
+CREATE TABLE IF NOT EXISTS `cockatrice_replays` (
   `id` int(7) NOT NULL AUTO_INCREMENT,
   `id_game` int(7) NOT NULL,
   `duration` int(7) NOT NULL,
@@ -166,7 +166,7 @@ CREATE TABLE `cockatrice_replays` (
   KEY `id_game` (`id_game`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
-CREATE TABLE `cockatrice_replays_access` (
+CREATE TABLE IF NOT EXISTS `cockatrice_replays_access` (
   `id_game` int(7) NOT NULL,
   `id_player` int(7) NOT NULL,
   `replay_name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -60,6 +60,25 @@ bool Servatrice_DatabaseInterface::openDatabase()
         return false;
     }
 
+    QSqlQuery *versionQuery = prepareQuery("select version from {prefix}_schema_version limit 1");
+    if (!execSqlQuery(versionQuery)) {
+        qCritical() << QString("[%1] Error opening database: unable to load database schema version (hint: ensure the cockatrice_schema_version exists)").arg(poolStr);
+        return false;
+    }
+
+    if (versionQuery->next()) {
+        const int dbversion = versionQuery->value(0).toInt();
+        const int expectedversion = DATABASE_SCHEMA_VERSION;
+        if(dbversion != expectedversion)
+        {
+            qCritical() << QString("[%1] Error opening database: the database schema version is too old, yum need to run the migrations to update it from version %2 to version %3").arg(poolStr).arg(dbversion).arg(expectedversion);
+            return false;
+        }
+    } else {
+        qCritical() << QString("[%1] Error opening database: unable to load database schema version (hint: ensure the cockatrice_schema_version contains a single record)").arg(poolStr);
+        return false;
+    }
+
     // reset all prepared statements
     qDeleteAll(preparedStatements);
     preparedStatements.clear();

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -71,7 +71,7 @@ bool Servatrice_DatabaseInterface::openDatabase()
         const int expectedversion = DATABASE_SCHEMA_VERSION;
         if(dbversion != expectedversion)
         {
-            qCritical() << QString("[%1] Error opening database: the database schema version is too old, yum need to run the migrations to update it from version %2 to version %3").arg(poolStr).arg(dbversion).arg(expectedversion);
+            qCritical() << QString("[%1] Error opening database: the database schema version is too old, you need to run the migrations to update it from version %2 to version %3").arg(poolStr).arg(dbversion).arg(expectedversion);
             return false;
         }
     } else {

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -9,6 +9,8 @@
 #include "server.h"
 #include "server_database_interface.h"
 
+#define DATABASE_SCHEMA_VERSION 1
+
 class Servatrice;
 
 class Servatrice_DatabaseInterface : public Server_DatabaseInterface {


### PR DESCRIPTION
Well, #153 also included implementing a script that automatically detect the version, snapshots and update the database schema.
I'm unsure wether making this automatic is a good idea, and we should probably make it support all the three major OSes..