### PR TITLE
Related cards

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -482,13 +482,15 @@ CardInfo::CardInfo(CardDatabase *_db,
                    const QString &_powtough,
                    const QString &_text,
                    const QStringList &_colors,
+                   const QStringList &_relatedCards,
                    int _loyalty,
                    bool _cipt,
                    int _tableRow,
                    const SetList &_sets,
                    const QStringMap &_customPicURLs,
                    const QStringMap &_customPicURLsHq,
-                   MuidMap _muIds)
+                   MuidMap _muIds
+                   )
     : db(_db),
       name(_name),
       isToken(_isToken),
@@ -499,6 +501,7 @@ CardInfo::CardInfo(CardDatabase *_db,
       powtough(_powtough),
       text(_text),
       colors(_colors),
+      relatedCards(_relatedCards),
       loyalty(_loyalty),
       customPicURLs(_customPicURLs),
       customPicURLsHq(_customPicURLsHq),
@@ -685,6 +688,10 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfo *info)
     for (int i = 0; i < colors.size(); i++)
         xml.writeTextElement("color", colors[i]);
 
+    const QStringList &related = info->getRelatedCards();
+    for (int i = 0; i < related.size(); i++)
+        xml.writeTextElement("related", related[i]);
+
     xml.writeTextElement("manacost", info->getManaCost());
     xml.writeTextElement("cmc", info->getCmc());
     xml.writeTextElement("type", info->getCardType());
@@ -852,7 +859,7 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml, bool tokens)
             break;
         if (xml.name() == "card") {
             QString name, manacost, cmc, type, pt, text;
-            QStringList colors;
+            QStringList colors, relatedCards;
             QStringMap customPicURLs, customPicURLsHq;
             MuidMap muids;
             SetList sets;
@@ -890,6 +897,8 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml, bool tokens)
                     }
                 } else if (xml.name() == "color")
                     colors << xml.readElementText();
+                else if (xml.name() == "related")
+                    relatedCards << xml.readElementText();
                 else if (xml.name() == "tablerow")
                     tableRow = xml.readElementText().toInt();
                 else if (xml.name() == "cipt")
@@ -901,7 +910,7 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml, bool tokens)
             }
 
             if (isToken == tokens) {
-                addCard(new CardInfo(this, name, isToken, manacost, cmc, type, pt, text, colors, loyalty, cipt, tableRow, sets, customPicURLs, customPicURLsHq, muids));
+                addCard(new CardInfo(this, name, isToken, manacost, cmc, type, pt, text, colors, relatedCards, loyalty, cipt, tableRow, sets, customPicURLs, customPicURLsHq, muids));
             }
         }
     }

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -132,13 +132,13 @@ private:
     QString powtough;
     QString text;
     QStringList colors;
+    QStringList relatedCards;
     int loyalty;
     QStringMap customPicURLs, customPicURLsHq;
     MuidMap muIds;
     bool cipt;
     int tableRow;
     QString pixmapCacheKey;
-    QStringList relatedCards;
 public:
     CardInfo(CardDatabase *_db,
         const QString &_name = QString(),

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -133,6 +133,7 @@ private:
     QString text;
     QStringList colors;
     QStringList relatedCards;
+    bool upsideDownArt;
     int loyalty;
     QStringMap customPicURLs, customPicURLsHq;
     MuidMap muIds;
@@ -150,6 +151,7 @@ public:
         const QString &_text = QString(),
         const QStringList &_colors = QStringList(),
         const QStringList &_relatedCards = QStringList(),
+        bool _upsideDownArt = false,
         int _loyalty = 0,
         bool _cipt = false,
         int _tableRow = 0,
@@ -178,6 +180,7 @@ public:
     void setColors(const QStringList &_colors) { colors = _colors; emit cardInfoChanged(this); }
     const QStringList &getColors() const { return colors; }
     const QStringList &getRelatedCards() const { return relatedCards; }
+    bool getUpsideDownArt() const { return upsideDownArt; }
     QString getCustomPicURL(const QString &set) const { return customPicURLs.value(set); }
     QString getCustomPicURLHq(const QString &set) const { return customPicURLsHq.value(set); }
     int getMuId(const QString &set) const { return muIds.value(set); }

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -138,6 +138,7 @@ private:
     bool cipt;
     int tableRow;
     QString pixmapCacheKey;
+    QStringList relatedCards;
 public:
     CardInfo(CardDatabase *_db,
         const QString &_name = QString(),
@@ -148,13 +149,15 @@ public:
         const QString &_powtough = QString(),
         const QString &_text = QString(),
         const QStringList &_colors = QStringList(),
+        const QStringList &_relatedCards = QStringList(),
         int _loyalty = 0,
         bool _cipt = false,
         int _tableRow = 0,
         const SetList &_sets = SetList(),
         const QStringMap &_customPicURLs = QStringMap(),
         const QStringMap &_customPicURLsHq = QStringMap(),
-        MuidMap muids = MuidMap());
+        MuidMap muids = MuidMap()
+        );
     ~CardInfo();
     const QString &getName() const { return name; }
     const QString &getSimpleName() const { return simpleName; }
@@ -174,6 +177,7 @@ public:
     void setText(const QString &_text) { text = _text; emit cardInfoChanged(this); }
     void setColors(const QStringList &_colors) { colors = _colors; emit cardInfoChanged(this); }
     const QStringList &getColors() const { return colors; }
+    const QStringList &getRelatedCards() const { return relatedCards; }
     QString getCustomPicURL(const QString &set) const { return customPicURLs.value(set); }
     QString getCustomPicURLHq(const QString &set) const { return customPicURLsHq.value(set); }
     int getMuId(const QString &set) const { return muIds.value(set); }

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1078,7 +1078,12 @@ void Player::actCreatePredefinedToken()
 
 void Player::actCreateRelatedCard()
 {
-    // get he target card name
+    // get the clicked card
+    CardItem * sourceCard = game->getActiveCard();
+    if(!sourceCard)
+        return;
+
+    // get the target card name
     QAction *action = static_cast<QAction *>(sender());
     CardInfo *cardInfo = db->getCard(action->text());
 
@@ -1089,8 +1094,8 @@ void Player::actCreateRelatedCard()
     cmd.set_color(cardInfo->getColors().isEmpty() ? QString().toStdString() : cardInfo->getColors().first().toLower().toStdString());
     cmd.set_pt(cardInfo->getPowTough().toStdString());
     cmd.set_destroy_on_zone_change(true);
-    cmd.set_x(-1);
-    cmd.set_y(0);
+    cmd.set_target_zone(sourceCard->getZone()->getName().toStdString());
+    cmd.set_target_card_id(sourceCard->getId());
 
     sendGameCommand(cmd);
 }

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -676,7 +676,7 @@ void Player::retranslateUi()
         for (int i = 0; i < allPlayersActions.size(); ++i)
             allPlayersActions[i]->setText(tr("&All players"));
     }
-    
+
     aPlay->setText(tr("&Play"));
     aHide->setText(tr("&Hide"));
     aPlayFacedown->setText(tr("Play &Face Down"));
@@ -1074,6 +1074,25 @@ void Player::actCreatePredefinedToken()
     aCreateAnotherToken->setEnabled(true);
     
     actCreateAnotherToken();
+}
+
+void Player::actCreateRelatedCard()
+{
+    // get he target card name
+    QAction *action = static_cast<QAction *>(sender());
+    CardInfo *cardInfo = db->getCard(action->text());
+
+    // create the token for the related card
+    Command_CreateToken cmd;
+    cmd.set_zone("table");
+    cmd.set_card_name(cardInfo->getName().toStdString());
+    cmd.set_color(cardInfo->getColors().isEmpty() ? QString().toStdString() : cardInfo->getColors().first().toLower().toStdString());
+    cmd.set_pt(cardInfo->getPowTough().toStdString());
+    cmd.set_destroy_on_zone_change(true);
+    cmd.set_x(-1);
+    cmd.set_y(0);
+
+    sendGameCommand(cmd);
 }
 
 void Player::actSayMessage()
@@ -2247,6 +2266,17 @@ void Player::updateCardMenu(CardItem *card)
                 cardMenu->addAction(aFlip);
                 if (card->getFaceDown())
                     cardMenu->addAction(aPeek);
+
+                QStringList relatedCards = card->getInfo()->getRelatedCards();
+                if(relatedCards.size())
+                {
+                    QMenu * createRelatedCardMenu = cardMenu->addMenu(tr("Cr&eate related card"));
+
+                    for (int i = 0; i < relatedCards.size(); ++i) {
+                        QAction *a = createRelatedCardMenu->addAction(relatedCards.at(i));
+                        connect(a, SIGNAL(triggered()), this, SLOT(actCreateRelatedCard()));
+                    }
+                }
                 cardMenu->addSeparator();
                 cardMenu->addAction(aAttach);
                 if (card->getAttachedTo())

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -141,6 +141,7 @@ private slots:
     
     void actOpenDeckInDeckEditor();
     void actCreatePredefinedToken();
+    void actCreateRelatedCard();
     void cardMenuAction();
     void actCardCounterTrigger();
     void actAttach();

--- a/common/pb/command_create_token.proto
+++ b/common/pb/command_create_token.proto
@@ -11,6 +11,8 @@ message Command_CreateToken {
 	optional bool destroy_on_zone_change = 6;
 	optional sint32 x = 7;
 	optional sint32 y = 8;
+	optional string target_zone = 9;
+	optional sint32 target_card_id = 10 [default = -1];
 }
 
 

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -1065,7 +1065,7 @@ Response::ResponseCode Server_Player::cmdAttachCard(const Command_AttachCard &cm
     return Response::RespOk;
 }
 
-Response::ResponseCode Server_Player::cmdCreateToken(const Command_CreateToken &cmd, ResponseContainer & /*rc*/, GameEventStorage &ges)
+Response::ResponseCode Server_Player::cmdCreateToken(const Command_CreateToken &cmd, ResponseContainer & rc, GameEventStorage &ges)
 {
     if (spectator)
         return Response::RespFunctionNotAllowed;
@@ -1109,8 +1109,20 @@ Response::ResponseCode Server_Player::cmdCreateToken(const Command_CreateToken &
     event.set_x(x);
     event.set_y(y);
     ges.enqueueGameEvent(event, playerId);
-    
-    return Response::RespOk;
+   
+    // chck if the token is a replacement for an existing card
+    if(cmd.target_card_id() < 0)
+        return Response::RespOk;
+
+    Command_AttachCard cmd2;
+    cmd2.set_start_zone(cmd.target_zone());
+    cmd2.set_card_id(cmd.target_card_id());
+
+    cmd2.set_target_player_id(zone->getPlayer()->getPlayerId());
+    cmd2.set_target_zone(cmd.zone());
+    cmd2.set_target_card_id(card->getId());
+
+    return cmdAttachCard(cmd2, rc, ges);
 }
 
 Response::ResponseCode Server_Player::cmdCreateArrow(const Command_CreateArrow &cmd, ResponseContainer & /*rc*/, GameEventStorage &ges)

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -29,7 +29,7 @@ private:
     QVariantMap setsMap;
     QString dataDir;
     
-    CardInfo *addCard(const QString &setName, QString cardName, bool isToken, int cardId, QString &cardCost, QString &cmc, const QString &cardType, const QString &cardPT, int cardLoyalty, const QString &cardText, const QStringList & colors);
+    CardInfo *addCard(const QString &setName, QString cardName, bool isToken, int cardId, QString &cardCost, QString &cmc, const QString &cardType, const QString &cardPT, int cardLoyalty, const QString &cardText, const QStringList & colors, const QStringList & relatedCards);
 signals:
     void setIndexChanged(int cardsImported, int setIndex, const QString &setName);
     void dataReadProgress(int bytesRead, int totalBytes);

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -29,7 +29,7 @@ private:
     QVariantMap setsMap;
     QString dataDir;
     
-    CardInfo *addCard(const QString &setName, QString cardName, bool isToken, int cardId, QString &cardCost, QString &cmc, const QString &cardType, const QString &cardPT, int cardLoyalty, const QString &cardText, const QStringList & colors, const QStringList & relatedCards);
+    CardInfo *addCard(const QString &setName, QString cardName, bool isToken, int cardId, QString &cardCost, QString &cmc, const QString &cardType, const QString &cardPT, int cardLoyalty, const QString &cardText, const QStringList & colors, const QStringList & relatedCards, bool upsideDown);
 signals:
     void setIndexChanged(int cardsImported, int setIndex, const QString &setName);
     void dataReadProgress(int bytesRead, int totalBytes);


### PR DESCRIPTION
Hopefully fixes the following: Fix #804 and Fix #77
Oracle is now able to parse a list of related cards for each card (double faced, flip, ..) and save them to cards.xml.
You can then have cockatrice create a token for the related cards directly in-game, without the need to add them to the deck.

![related](https://cloud.githubusercontent.com/assets/1631111/8105315/5e9dc24e-1038-11e5-82c3-7b635affac8b.jpg)

This is mostly based on the solution proposed by @Daenyth in #77.

What's next? I thought about flipping the original card facedown and attach it to the just-created token, but i quickly abandoned the idea since it's too game-specific and it would require a new command to be implemented (backwards compatibility, etc).