### PR TITLE
Reworked deck editor

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -587,7 +587,7 @@ void CardInfo::imageLoaded(const QImage &image)
 
 void CardInfo::getPixmap(QSize size, QPixmap &pixmap)
 {
-    QString key = QLatin1String("card_") + name + QLatin1Char('_') + QString::number(size.width());
+    QString key = QLatin1String("card_") + name + QLatin1Char('_') + QString::number(size.width()) + QString::number(size.height());
     if(QPixmapCache::find(key, &pixmap))
         return;
 
@@ -598,15 +598,15 @@ void CardInfo::getPixmap(QSize size, QPixmap &pixmap)
             pixmap = QPixmap(); // null
             return;
         } else {
-            pixmap = QPixmap(size);
-            pixmap.fill(Qt::transparent);
             QSvgRenderer svg(QString(":/back.svg"));
-            QPainter painter(&pixmap);
-            svg.render(&painter, QRectF(0, 0, size.width(), size.height()));
+            bigPixmap = QPixmap(svg.defaultSize());
+            bigPixmap.fill(Qt::transparent);
+            QPainter painter(&bigPixmap);
+            svg.render(&painter);
         }
-    } else {
-        pixmap = bigPixmap.scaled(size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
     }
+
+    pixmap = bigPixmap.scaled(size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
     QPixmapCache::insert(key, pixmap);
 }
 

--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -183,7 +183,7 @@ bool CardDatabaseDisplayModel::filterAcceptsRow(int sourceRow, const QModelIndex
     return true;
 }
 
-void CardDatabaseDisplayModel::clearSearch()
+void CardDatabaseDisplayModel::clearFilterAll()
 {
     cardName.clear();
     cardText.clear();

--- a/cockatrice/src/carddatabasemodel.h
+++ b/cockatrice/src/carddatabasemodel.h
@@ -53,7 +53,7 @@ public:
     void setCardText(const QString &_cardText) { cardText = _cardText; invalidate(); }
     void setCardTypes(const QSet<QString> &_cardTypes) { cardTypes = _cardTypes; invalidate(); }
     void setCardColors(const QSet<QString> &_cardColors) { cardColors = _cardColors; invalidate(); }
-    void clearSearch();
+    void clearFilterAll();
 protected:
     bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
     bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;

--- a/cockatrice/src/cardframe.cpp
+++ b/cockatrice/src/cardframe.cpp
@@ -8,15 +8,13 @@
 #include "settingscache.h"
 
 #include <QVBoxLayout>
-#include <QTabBar>
 
 CardFrame::CardFrame(int width, int height,
                         const QString &cardName, QWidget *parent)
-    : QFrame(parent)
+    : QTabWidget(parent)
     , info(0)
     , cardTextOnly(false)
 {
-    setFrameStyle(QFrame::Panel | QFrame::Raised);
     setMaximumWidth(width);
     setMinimumWidth(width);
     setMinimumHeight(height);
@@ -24,20 +22,28 @@ CardFrame::CardFrame(int width, int height,
     pic = new CardInfoPicture(width);
     text = new CardInfoText();
 
-    tabBar = new QTabBar(this);
-    tabBar->setDrawBase(false);
-    tabBar->insertTab(ImageOnlyView, QString());
-    tabBar->insertTab(TextOnlyView, QString());
-    tabBar->insertTab(ImageAndTextView, QString());
-    connect(tabBar, SIGNAL(currentChanged(int)), this, SLOT(setViewMode(int)));
+    tab1 = new QWidget(this);
+    tab2 = new QWidget(this);
+    tab3 = new QWidget(this);
+    insertTab(ImageOnlyView, tab1, QString());
+    insertTab(TextOnlyView, tab2, QString());
+    insertTab(ImageAndTextView, tab3, QString());
+    connect(this, SIGNAL(currentChanged(int)), this, SLOT(setViewMode(int)));
 
-    QVBoxLayout * layout = new QVBoxLayout();
-    layout->addWidget(tabBar);
-    layout->addWidget(pic);
-    layout->addWidget(text);
-    layout->setContentsMargins(0, 0, 0, 0);
-    layout->setSpacing(0);
-    setLayout(layout);
+    tab1Layout = new QVBoxLayout();
+    tab1Layout->setContentsMargins(0, 0, 0, 0);
+    tab1Layout->setSpacing(0);
+    tab1->setLayout(tab1Layout);
+
+    tab2Layout = new QVBoxLayout();
+    tab2Layout->setContentsMargins(0, 0, 0, 0);
+    tab2Layout->setSpacing(0);
+    tab2->setLayout(tab2Layout);
+
+    tab3Layout = new QVBoxLayout();
+    tab3Layout->setContentsMargins(0, 0, 0, 0);
+    tab3Layout->setSpacing(0);
+    tab3->setLayout(tab3Layout);
 
     setViewMode(settingsCache->getCardInfoViewMode());
 
@@ -46,29 +52,26 @@ CardFrame::CardFrame(int width, int height,
 
 void CardFrame::retranslateUi()
 {
-    tabBar->setTabText(ImageOnlyView, tr("Image"));
-    tabBar->setTabText(TextOnlyView, tr("Description"));
-    tabBar->setTabText(ImageAndTextView, tr("Both"));
+    setTabText(ImageOnlyView, tr("Image"));
+    setTabText(TextOnlyView, tr("Description"));
+    setTabText(ImageAndTextView, tr("Both"));
 }
 
 void CardFrame::setViewMode(int mode)
 {
-    if(tabBar->currentIndex() != mode)
-        tabBar->setCurrentIndex(mode);
+    if(currentIndex() != mode)
+        setCurrentIndex(mode);
 
     switch(mode)
     {
         case ImageOnlyView:
-            pic->setVisible(true);
-            text->setVisible(false);
-            break;
         case TextOnlyView:
-            pic->setVisible(false);
-            text->setVisible(true);
+            tab1Layout->addWidget(pic);
+            tab2Layout->addWidget(text);
             break;
         case ImageAndTextView:
-            pic->setVisible(true);
-            text->setVisible(true);
+            tab3Layout->addWidget(pic);
+            tab3Layout->addWidget(text);
             break;
     }
 

--- a/cockatrice/src/cardframe.h
+++ b/cockatrice/src/cardframe.h
@@ -1,23 +1,24 @@
 #ifndef CARDFRAME_H
 #define CARDFRAME_H
 
-#include <QFrame>
+#include <QTabWidget>
 
 class AbstractCardItem;
 class CardInfo;
 class CardInfoPicture;
 class CardInfoText;
-class QTabBar;
+class QVBoxLayout;
 
-class CardFrame : public QFrame {
+class CardFrame : public QTabWidget {
     Q_OBJECT
 
 private:
-    QTabBar * tabBar;
     CardInfo *info;
     CardInfoPicture *pic;
     CardInfoText *text;
     bool cardTextOnly;
+    QWidget *tab1, *tab2, *tab3;
+    QVBoxLayout *tab1Layout, *tab2Layout, *tab3Layout;
 
 public:
     enum ViewMode { ImageOnlyView, TextOnlyView, ImageAndTextView };
@@ -25,7 +26,6 @@ public:
     CardFrame(int width, int height, const QString &cardName = QString(),
                 QWidget *parent = 0);
     void retranslateUi();
-
 public slots:
     void setCard(CardInfo *card);
     void setCard(const QString &cardName);

--- a/cockatrice/src/cardframe.h
+++ b/cockatrice/src/cardframe.h
@@ -1,36 +1,37 @@
 #ifndef CARDFRAME_H
 #define CARDFRAME_H
 
-#include <QStackedWidget>
+#include <QFrame>
 
 class AbstractCardItem;
 class CardInfo;
 class CardInfoPicture;
 class CardInfoText;
+class QTabBar;
 
-class CardFrame : public QStackedWidget {
+class CardFrame : public QFrame {
     Q_OBJECT
 
 private:
+    QTabBar * tabBar;
     CardInfo *info;
     CardInfoPicture *pic;
     CardInfoText *text;
     bool cardTextOnly;
 
 public:
+    enum ViewMode { ImageOnlyView, TextOnlyView, ImageAndTextView };
+
     CardFrame(int width, int height, const QString &cardName = QString(),
                 QWidget *parent = 0);
-    void setCardTextOnly(bool status) { cardTextOnly = status; hasPictureChanged(); }
+    void retranslateUi();
 
 public slots:
     void setCard(CardInfo *card);
     void setCard(const QString &cardName);
     void setCard(AbstractCardItem *card);
     void clear();
-
-private slots:
-    void hasPictureChanged();
-    void toggleCardTextOnly() { setCardTextOnly(!cardTextOnly); }
+    void setViewMode(int mode);
 };
 
 #endif

--- a/cockatrice/src/cardinfopicture.cpp
+++ b/cockatrice/src/cardinfopicture.cpp
@@ -10,6 +10,7 @@ CardInfoPicture::CardInfoPicture(int maximumWidth, QWidget *parent)
     , info(0)
     , noPicture(true)
 {
+    setAlignment(Qt::AlignCenter);
     setMaximumWidth(maximumWidth);
 }
 
@@ -31,22 +32,24 @@ void CardInfoPicture::setCard(CardInfo *card)
     updatePixmap();
 }
 
+void CardInfoPicture::resizeEvent(QResizeEvent * /* e */)
+{
+    updatePixmap();
+}
+
 void CardInfoPicture::updatePixmap()
 {
-    qreal aspectRatio = (qreal) CARD_HEIGHT / (qreal) CARD_WIDTH;
-    qreal pixmapWidth = this->width();
-
-    if (pixmapWidth == 0) {
+    if (info == 0 || width() == 0 || height() == 0) {
         setNoPicture(true);
         return;
     }
 
     QPixmap resizedPixmap;
-    info->getPixmap(QSize(pixmapWidth, pixmapWidth * aspectRatio), resizedPixmap);
+    info->getPixmap(size(), resizedPixmap);
 
     if (resizedPixmap.isNull()) {
         setNoPicture(true);
-        db->getCard()->getPixmap(QSize(pixmapWidth, pixmapWidth * aspectRatio), resizedPixmap);
+        db->getCard()->getPixmap(size(), resizedPixmap);
     } else {
         setNoPicture(false);
     }

--- a/cockatrice/src/cardinfopicture.h
+++ b/cockatrice/src/cardinfopicture.h
@@ -19,16 +19,14 @@ private:
 public:
     CardInfoPicture(int maximumWidth, QWidget *parent = 0);
     bool hasPicture() const { return !noPicture; }
-
 private:
     void setNoPicture(bool status);
+protected:
+    void resizeEvent(QResizeEvent *event);
 
 public slots:
     void setCard(CardInfo *card);
-
-private slots:
     void updatePixmap();
-
 };
 
 #endif

--- a/cockatrice/src/filterbuilder.cpp
+++ b/cockatrice/src/filterbuilder.cpp
@@ -1,6 +1,6 @@
 #include "filterbuilder.h"
 
-#include <QHBoxLayout>
+#include <QGridLayout>
 #include <QComboBox>
 #include <QPushButton>
 #include <QLineEdit>
@@ -8,41 +8,36 @@
 #include "cardfilter.h"
 
 FilterBuilder::FilterBuilder(QWidget *parent)
-    : QFrame(parent)
+    : QWidget(parent)
 {
-    int i;
-
-    QVBoxLayout *layout = new QVBoxLayout;
-    QHBoxLayout *addFilter = new QHBoxLayout;
-
     filterCombo = new QComboBox;
-    for (i = 0; i < CardFilter::AttrEnd; i++)
+    for (int i = 0; i < CardFilter::AttrEnd; i++)
         filterCombo->addItem(
             tr(CardFilter::attrName(static_cast<CardFilter::Attr>(i))),
             QVariant(i)
         );
 
     typeCombo = new QComboBox;
-    for (i = 0; i < CardFilter::TypeEnd; i++)
+    for (int i = 0; i < CardFilter::TypeEnd; i++)
         typeCombo->addItem(
             tr(CardFilter::typeName(static_cast<CardFilter::Type>(i))),
             QVariant(i)
         );
 
-    QPushButton *ok = new QPushButton("+");
+    QPushButton *ok = new QPushButton(QIcon(":/resources/increment.svg"), QString());
     ok->setMaximumSize(20, 20);
-
-    addFilter->addWidget(ok);
-    addFilter->addWidget(typeCombo);
-    addFilter->addWidget(filterCombo, Qt::AlignLeft);
 
     edit = new QLineEdit;
     edit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-    layout->addLayout(addFilter);
-    layout->addWidget(edit);
 
-    setFrameStyle(QFrame::Panel | QFrame::Raised);
-    layout->setAlignment(Qt::AlignTop);
+    QGridLayout *layout = new QGridLayout;
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    layout->addWidget(typeCombo, 0, 0, 1, 2);
+    layout->addWidget(filterCombo, 0, 2, 1, 2);
+    layout->addWidget(edit, 1, 0, 1, 3);
+    layout->addWidget(ok, 1, 3);
+
     setLayout(layout);
 
     connect(edit, SIGNAL(returnPressed()), this, SLOT(emit_add()));

--- a/cockatrice/src/filterbuilder.h
+++ b/cockatrice/src/filterbuilder.h
@@ -1,14 +1,14 @@
 #ifndef FILTERBUILDER_H
 #define FILTERBUILDER_H
 
-#include <QFrame>
+#include <QWidget>
 
 class QCheckBox;
 class QComboBox;
 class QLineEdit;
 class CardFilter;
 
-class FilterBuilder : public QFrame {
+class FilterBuilder : public QWidget {
     Q_OBJECT
 
 private:

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -79,6 +79,13 @@ SettingsCache::SettingsCache()
     leftJustified = settings->value("interface/leftjustified", false).toBool();
 
     masterVolume = settings->value("sound/mastervolume", 100).toInt();
+
+    cardInfoViewMode = settings->value("cards/cardinfoviewmode", 0).toInt();
+}
+
+void SettingsCache::setCardInfoViewMode(const int _viewMode) {
+    cardInfoViewMode = _viewMode;
+    settings->setValue("cards/cardinfoviewmode", cardInfoViewMode);
 }
 
 void SettingsCache::setMasterVolume(int _masterVolume) {

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -81,6 +81,7 @@ private:
     bool showMentionPopups;
     bool leftJustified;
     int masterVolume;
+    int cardInfoViewMode;
 public:
     SettingsCache();
     const QByteArray &getMainWindowGeometry() const { return mainWindowGeometry; }
@@ -136,6 +137,7 @@ public:
     bool getShowMentionPopup() const { return showMentionPopups; }
     bool getLeftJustified() const { return leftJustified; }
     int getMasterVolume() const { return masterVolume; }
+    int getCardInfoViewMode() const { return cardInfoViewMode; }
 public slots:
     void setMainWindowGeometry(const QByteArray &_mainWindowGeometry);
     void setLang(const QString &_lang);
@@ -184,7 +186,8 @@ public slots:
     void setShowMessagePopups(const int _showMessagePopups);
     void setShowMentionPopups(const int _showMentionPopups);
     void setLeftJustified( const int _leftJustified);
-    void setMasterVolume(const int _masterVolume); 
+    void setMasterVolume(const int _masterVolume);
+    void setCardInfoViewMode(const int _viewMode);
 };
 
 extern SettingsCache *settingsCache;

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -9,6 +9,7 @@
 #include <QAction>
 #include <QCloseEvent>
 #include <QFileDialog>
+#include <QGroupBox>
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QPrintPreviewDialog>
@@ -49,9 +50,14 @@ void SearchLineEdit::keyPressEvent(QKeyEvent *event)
 TabDeckEditor::TabDeckEditor(TabSupervisor *_tabSupervisor, QWidget *parent)
     : Tab(_tabSupervisor, parent), modified(false)
 {
-    aClearSearch = new QAction(QString(), this);
-    aClearSearch->setIcon(QIcon(":/resources/icon_clearsearch.svg"));
-    connect(aClearSearch, SIGNAL(triggered()), this, SLOT(actClearSearch()));
+    aClearFilterAll = new QAction(QString(), this);
+    aClearFilterAll->setIcon(QIcon(":/resources/icon_clearsearch.svg"));
+    connect(aClearFilterAll, SIGNAL(triggered()), this, SLOT(actClearFilterAll()));
+
+    aClearFilterOne = new QAction(QString(), this);
+    aClearFilterOne->setIcon(QIcon(":/resources/decrement.svg"));
+    connect(aClearFilterOne, SIGNAL(triggered()), this, SLOT(actClearFilterOne()));
+
     searchEdit = new SearchLineEdit;
 #if QT_VERSION >= 0x050300
     searchEdit->addAction(QIcon(":/resources/icon_search_black.svg"), QLineEdit::LeadingPosition);
@@ -103,9 +109,6 @@ TabDeckEditor::TabDeckEditor(TabSupervisor *_tabSupervisor, QWidget *parent)
     leftFrame->addWidget(databaseView);
 
     cardInfo = new CardFrame(250, 356);
-    aCardTextOnly = new QAction(QString(), this);
-    aCardTextOnly->setCheckable(true);
-    connect(aCardTextOnly, SIGNAL(triggered()), cardInfo, SLOT(toggleCardTextOnly()));
 
     filterModel = new FilterTreeModel();
     databaseDisplayModel->setFilterTree(filterModel->filterTree());
@@ -119,16 +122,29 @@ TabDeckEditor::TabDeckEditor(TabSupervisor *_tabSupervisor, QWidget *parent)
     connect(filterView, SIGNAL(customContextMenuRequested(const QPoint &)),
             this, SLOT(filterViewCustomContextMenu(const QPoint &)));
     FilterBuilder *filterBuilder = new FilterBuilder;
-    filterBuilder->setMaximumWidth(250);
     connect(filterBuilder, SIGNAL(add(const CardFilter *)), filterModel, SLOT(addFilter(const CardFilter *)));
 
-    QVBoxLayout *filter = new QVBoxLayout;
-    filter->addWidget(filterBuilder, 0, Qt::AlignTop);
-    filter->addWidget(filterView, 10);
+    QToolButton *filterDelOne = new QToolButton();
+    filterDelOne->setDefaultAction(aClearFilterOne);
+    filterDelOne->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+
+    QToolButton *filterDelAll = new QToolButton();
+    filterDelAll->setDefaultAction(aClearFilterAll);
+    filterDelAll->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+
+    QGridLayout *filterLayout = new QGridLayout;
+    filterLayout->addWidget(filterBuilder, 0, 0, 1, 2);
+    filterLayout->addWidget(filterView, 1, 0, 1, 2);
+    filterLayout->addWidget(filterDelOne, 2, 0);
+    filterLayout->addWidget(filterDelAll, 2, 1);
+
+    filterBox = new QGroupBox();
+    filterBox->setMaximumWidth(250);
+    filterBox->setLayout(filterLayout);
 
     QVBoxLayout *middleFrame = new QVBoxLayout;
     middleFrame->addWidget(cardInfo, 0, Qt::AlignTop);
-    middleFrame->addLayout(filter, 10);
+    middleFrame->addWidget(filterBox, 0);
 
     deckModel = new DeckListModel(this);
     connect(deckModel, SIGNAL(deckHashChanged()), this, SLOT(updateHash()));
@@ -258,8 +274,7 @@ TabDeckEditor::TabDeckEditor(TabSupervisor *_tabSupervisor, QWidget *parent)
     dbMenu->addAction(aEditSets);
     dbMenu->addAction(aEditTokens);
     dbMenu->addSeparator();
-    dbMenu->addAction(aClearSearch);
-    dbMenu->addAction(aCardTextOnly);
+    dbMenu->addAction(aClearFilterAll);
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     dbMenu->addSeparator();
     dbMenu->addAction(aOpenCustomFolder);
@@ -303,8 +318,11 @@ TabDeckEditor::~TabDeckEditor()
 
 void TabDeckEditor::retranslateUi()
 {
-    aCardTextOnly->setText(tr("Show card text only"));
-    aClearSearch->setText(tr("&Clear search"));
+    cardInfo->retranslateUi();
+
+    filterBox->setTitle(tr("Filters"));
+    aClearFilterAll->setText(tr("&Clear all filters"));
+    aClearFilterOne->setText(tr("Delete selected"));
     
     nameLabel->setText(tr("Deck &name:"));
     commentsLabel->setText(tr("&Comments:"));
@@ -570,9 +588,16 @@ void TabDeckEditor::actEditTokens()
     db->saveToFile(settingsCache->getTokenDatabasePath(), true);
 }
 
-void TabDeckEditor::actClearSearch()
+void TabDeckEditor::actClearFilterAll()
 {
-    databaseDisplayModel->clearSearch();
+    databaseDisplayModel->clearFilterAll();
+}
+
+void TabDeckEditor::actClearFilterOne()
+{
+    QModelIndexList selIndexes = filterView->selectionModel()->selectedIndexes();
+    foreach(QModelIndex idx, selIndexes)
+        filterModel->removeRow(idx.row(), idx.parent());
 }
 
 void TabDeckEditor::recursiveExpand(const QModelIndex &index)

--- a/cockatrice/src/tab_deck_editor.h
+++ b/cockatrice/src/tab_deck_editor.h
@@ -17,7 +17,9 @@ class QLabel;
 class DeckLoader;
 class Response;
 class FilterTreeModel;
+class FilterBuilder;
 class CardInfo;
+class QGroupBox;
 
 class SearchLineEdit : public QLineEdit {
 private:
@@ -52,7 +54,8 @@ class TabDeckEditor : public Tab {
             void actEditSets();
             void actEditTokens();
 
-            void actClearSearch();
+            void actClearFilterAll();
+            void actClearFilterOne();
 
             void actSwapCard();
             void actAddCard();
@@ -96,10 +99,11 @@ private:
     QLabel *hashLabel;
     FilterTreeModel *filterModel;
     QTreeView *filterView;
+    QGroupBox *filterBox;
 
     QMenu *deckMenu, *dbMenu;
     QAction *aNewDeck, *aLoadDeck, *aSaveDeck, *aSaveDeckAs, *aLoadDeckFromClipboard, *aSaveDeckToClipboard, *aPrintDeck, *aAnalyzeDeck, *aClose, *aOpenCustomFolder;
-    QAction *aEditSets, *aEditTokens, *aClearSearch, *aCardTextOnly;
+    QAction *aEditSets, *aEditTokens, *aClearFilterAll, *aClearFilterOne;
     QAction *aAddCard, *aAddCardToSideboard, *aRemoveCard, *aIncrement, *aDecrement;// *aUpdatePrices;
 
     bool modified;


### PR DESCRIPTION
Reworked the filters area, added proper buttons to remove filters and grouped it in a box.
Reworked the card preview, added back the ability to see both the card image and text.
Idea from #97 

![middle](https://cloud.githubusercontent.com/assets/1631111/8145541/70f806d6-120c-11e5-9fb5-1685f39db232.png)
