### PR TITLE
Allow Custom Download URL

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -337,16 +337,26 @@ QString PictureLoader::getPicUrl()
         picUrl = picDownloadHq ? settingsCache->getPicUrlHqFallback() : settingsCache->getPicUrlFallback();
 
     picUrl.replace("!name!", QUrl::toPercentEncoding(card->getCorrectedName()));
+    picUrl.replace("!name_lower!", QUrl::toPercentEncoding(card->getCorrectedName().toLower()));
     picUrl.replace("!cardid!", QUrl::toPercentEncoding(QString::number(muid)));
-    if (set) {
+    if (set)
+    {
         picUrl.replace("!setcode!", QUrl::toPercentEncoding(set->getShortName()));
+        picUrl.replace("!setcode_lower!", QUrl::toPercentEncoding(set->getShortName().toLower()));
         picUrl.replace("!setname!", QUrl::toPercentEncoding(set->getLongName()));
+        picUrl.replace("!setname_lower!", QUrl::toPercentEncoding(set->getLongName().toLower()));
     }
 
-    if (picUrl.contains("!name!") ||
-            picUrl.contains("!setcode!") ||
-            picUrl.contains("!setname!") ||
-            picUrl.contains("!cardid!")) {
+    if (
+        picUrl.contains("!name!") ||
+        picUrl.contains("!name_lower!") ||
+        picUrl.contains("!setcode!") ||
+        picUrl.contains("!setcode_lower!") ||
+        picUrl.contains("!setname!") ||
+        picUrl.contains("!setname_lower!") ||
+        picUrl.contains("!cardid!")
+        )
+    {
         qDebug() << "Insufficient card data to download" << card->getName() << "Url:" << picUrl;
         return QString("");
     }

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -51,12 +51,17 @@ GeneralSettingsPage::GeneralSettingsPage()
     pixmapCacheEdit.setSuffix(" MB");
     picDownloadHqCheckBox.setChecked(settingsCache->getPicDownloadHq());
     picDownloadCheckBox.setChecked(settingsCache->getPicDownload());
+    
+    highQualityURLEdit = new QLineEdit(settingsCache->getPicUrlHq());
+    highQualityURLEdit->setEnabled(settingsCache->getPicDownloadHq());
 
     connect(&clearDownloadedPicsButton, SIGNAL(clicked()), this, SLOT(clearDownloadedPicsButtonClicked()));
     connect(&languageBox, SIGNAL(currentIndexChanged(int)), this, SLOT(languageBoxChanged(int)));
     connect(&picDownloadCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setPicDownload(int)));
     connect(&picDownloadHqCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setPicDownloadHq(int)));
     connect(&pixmapCacheEdit, SIGNAL(valueChanged(int)), settingsCache, SLOT(setPixmapCacheSize(int)));
+    connect(&picDownloadHqCheckBox, SIGNAL(clicked(bool)), this, SLOT(setEnabledStatus(bool)));
+    connect(highQualityURLEdit, SIGNAL(textChanged(QString)), settingsCache, SLOT(setPicUrlHq(QString)));
 
     QGridLayout *personalGrid = new QGridLayout;
     personalGrid->addWidget(&languageLabel, 0, 0);
@@ -66,6 +71,12 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(&picDownloadCheckBox, 2, 0, 1, 2);
     personalGrid->addWidget(&picDownloadHqCheckBox, 3, 0, 1, 2);
     personalGrid->addWidget(&clearDownloadedPicsButton, 4, 0, 1, 1);
+    personalGrid->addWidget(&highQualityURLLabel, 5, 0, 1, 1);
+    personalGrid->addWidget(highQualityURLEdit, 5, 1, 1, 1);
+    personalGrid->addWidget(&highQualityURLLinkLabel, 6, 1, 1, 1);
+    
+    highQualityURLLinkLabel.setTextInteractionFlags(Qt::LinksAccessibleByMouse);
+    highQualityURLLinkLabel.setOpenExternalLinks(true);
 
     personalGroupBox = new QGroupBox;
     personalGroupBox->setLayout(personalGrid);
@@ -229,7 +240,14 @@ void GeneralSettingsPage::retranslateUi()
     cardDatabasePathLabel.setText(tr("Card database:"));
     tokenDatabasePathLabel.setText(tr("Token database:"));
     pixmapCacheLabel.setText(tr("Picture cache size:"));
+    highQualityURLLabel.setText(tr("High Quality Source URL:"));
+    highQualityURLLinkLabel.setText(QString("<a href='https://github.com/Cockatrice/Cockatrice/wiki/Custom-Download-HQ-URLs'>" + tr("Linking FAQ") + "</a>"));
     clearDownloadedPicsButton.setText(tr("Reset/Clear Downloaded Pictures"));
+}
+
+void GeneralSettingsPage::setEnabledStatus(bool status)
+{
+    highQualityURLEdit->setEnabled(status);
 }
 
 AppearanceSettingsPage::AppearanceSettingsPage()
@@ -511,7 +529,7 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     //priceTagsCheckBox.setChecked(settingsCache->getPriceTagFeature());
     //connect(&priceTagsCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setPriceTagFeature(int)));
 
-    connect(this, SIGNAL(priceTagSourceChanged(int)), settingsCache, SLOT(setPriceTagSource(int)));
+    //connect(this, SIGNAL(priceTagSourceChanged(int)), settingsCache, SLOT(setPriceTagSource(int)));
 
     QGridLayout *generalGrid = new QGridLayout;
     //generalGrid->addWidget(&priceTagsCheckBox, 0, 0);

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -232,7 +232,7 @@ void GeneralSettingsPage::retranslateUi()
     personalGroupBox->setTitle(tr("Personal settings"));
     languageLabel.setText(tr("Language:"));
     picDownloadCheckBox.setText(tr("Download card pictures on the fly"));
-    picDownloadHqCheckBox.setText(tr("Download high-quality card pictures"));
+    picDownloadHqCheckBox.setText(tr("Download card pictures from a custom URL"));
     pathsGroupBox->setTitle(tr("Paths"));
     deckPathLabel.setText(tr("Decks directory:"));
     replaysPathLabel.setText(tr("Replays directory:"));
@@ -240,7 +240,7 @@ void GeneralSettingsPage::retranslateUi()
     cardDatabasePathLabel.setText(tr("Card database:"));
     tokenDatabasePathLabel.setText(tr("Token database:"));
     pixmapCacheLabel.setText(tr("Picture cache size:"));
-    highQualityURLLabel.setText(tr("High Quality Source URL:"));
+    highQualityURLLabel.setText(tr("Custom Card Download URL:"));
     highQualityURLLinkLabel.setText(QString("<a href='https://github.com/Cockatrice/Cockatrice/wiki/Custom-Download-HQ-URLs'>" + tr("Linking FAQ") + "</a>"));
     clearDownloadedPicsButton.setText(tr("Reset/Clear Downloaded Pictures"));
 }

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -44,6 +44,7 @@ private slots:
     void cardDatabasePathButtonClicked();
     void tokenDatabasePathButtonClicked();
     void languageBoxChanged(int index);
+    void setEnabledStatus(bool);
 private:
     QStringList findQmFiles();
     QString languageName(const QString &qmFile);
@@ -52,6 +53,7 @@ private:
     QLineEdit *picsPathEdit;
     QLineEdit *cardDatabasePathEdit;
     QLineEdit *tokenDatabasePathEdit;
+    QLineEdit *highQualityURLEdit;
     QSpinBox pixmapCacheEdit;
     QGroupBox *personalGroupBox; 
     QGroupBox *pathsGroupBox;
@@ -65,6 +67,8 @@ private:
     QLabel picsPathLabel;
     QLabel cardDatabasePathLabel;
     QLabel tokenDatabasePathLabel;
+    QLabel highQualityURLLabel;
+    QLabel highQualityURLLinkLabel;
     QPushButton clearDownloadedPicsButton;
 };
 

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -4,9 +4,9 @@
 #include <QObject>
 
 #define PIC_URL_DEFAULT "http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!cardid!&type=card"
-#define PIC_URL_FALLBACK "http://mtgimage.com/set/!setcode!/!name!.jpg"
-#define PIC_URL_HQ_DEFAULT "http://mtgimage.com/multiverseid/!cardid!.jpg"
-#define PIC_URL_HQ_FALLBACK "http://mtgimage.com/set/!setcode!/!name!.jpg"
+#define PIC_URL_FALLBACK "http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!cardid!&type=card"
+#define PIC_URL_HQ_DEFAULT "http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!cardid!&type=card"
+#define PIC_URL_HQ_FALLBACK "http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!cardid!&type=card"
 // size should be a multiple of 64
 #define PIXMAPCACHE_SIZE_DEFAULT 2047
 #define PIXMAPCACHE_SIZE_MIN 64


### PR DESCRIPTION
This is a rewrite of #1129 to be more efficient & use functions already put into place by prior development.

When the "Download HQ Pics" Checkbox is checked off, the user will have the option of setting a custom download URL to any source they choose. If the checkbox is disabled, the field will be disabled.

I've included a new wiki page on our GitHub repo that explains the special word replacement strings, "Linking FAQ." [This wiki page](https://github.com/Cockatrice/Cockatrice/wiki/Custom-Download-HQ-URLs) is linked to through the settings.

![screenshot 2015-06-15 16 47 30](https://cloud.githubusercontent.com/assets/7460172/8170384/404fd036-137e-11e5-8dfe-03e70e251a81.png)
![screenshot 2015-06-15 16 47 34](https://cloud.githubusercontent.com/assets/7460172/8170385/4053aeea-137e-11e5-890f-4ce9bda81d3a.png)
