### PR TITLE
Fix revealed card

### DIFF
--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -305,7 +305,10 @@ void MessageLogWidget::doMoveCard(LogMoveCard &attributes)
     else if (targetName == "rfg")
         finalStr = tr("%1 exiles %2%3.");
     else if (targetName == "hand")
-        finalStr = isFemale(attributes.targetZone->getPlayer()) ? tr("%1 moves %2%3 to her hand.") : tr("%1 moves %2%3 to his hand.");
+        if (attributes.player->topCardRevealed())
+            finalStr = isFemale(attributes.targetZone->getPlayer()) ? tr("%1 moves %2%3 to her hand from her library.") : tr("%1 moves %2%3 to his hand from his library.");
+        else
+            finalStr = isFemale(attributes.targetZone->getPlayer()) ? tr("%1 moves a card to her hand from her library.") : tr("%1 moves a card to his hand from his library.");
     else if (targetName == "deck") {
         if (attributes.newX == -1)
             finalStr = isFemale(attributes.targetZone->getPlayer()) ? tr("%1 puts %2%3 into her library.") : tr("%1 puts %2%3 into his library.");

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -837,7 +837,8 @@ void Player::actAlwaysRevealTopCard()
     Command_ChangeZoneProperties cmd;
     cmd.set_zone_name("deck");
     cmd.set_always_reveal_top_card(aAlwaysRevealTopCard->isChecked());
-    
+    isTopCardRevealed = aAlwaysRevealTopCard->isChecked();
+
     sendGameCommand(cmd);
 }
 

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -181,6 +181,7 @@ private:
         *aMoveToTopLibrary, *aMoveToBottomLibrary, *aMoveToGraveyard, *aMoveToExile;
 
     bool shortcutsActive;
+    bool isTopCardRevealed;
     int defaultNumberTopCards;
     QString lastTokenName, lastTokenColor, lastTokenPT, lastTokenAnnotation;
     bool lastTokenDestroy;
@@ -304,6 +305,8 @@ public:
     PendingCommand *prepareGameCommand(const QList< const ::google::protobuf::Message * > &cmdList);
     void sendGameCommand(PendingCommand *pend);
     void sendGameCommand(const google::protobuf::Message &command);
+    
+    bool topCardRevealed() const { return isTopCardRevealed; }
 };
 
 #endif


### PR DESCRIPTION
Fix #1083

I've added a check for the system to see if the top card was revealed, and if false then it would not tell you what card was moved to the hand.

Feedback is welcomed and I'd really like to see this tested further as I was only testing for the issue described in the ticket.