### PR TITLE
Fix False Notifications

### DIFF
--- a/cockatrice/src/chatview.h
+++ b/cockatrice/src/chatview.h
@@ -39,6 +39,7 @@ private:
     void appendCardTag(QTextCursor &cursor, const QString &cardName);
     void appendUrlTag(QTextCursor &cursor, QString url);
     QString getNameFromUserList(QMap<QString, UserListTWI *> &userList, QString &userName);
+    bool isFullMentionAValidUser(QMap<QString, UserListTWI *> &userList, QString userNameToMatch);
     QColor getCustomMentionColor();
     bool shouldShowSystemPopup();
     void showSystemPopup(QString &sender);


### PR DESCRIPTION
Fixes #1050.

To start, I've re-written the base to be a little more clear for development. I've also added more comments to the sections to make it more clear what's happening.

Here's how the fix works, based on the ideas of @ctrlaltca:
1) Checks everything from the `@` character to a space or end of line. &rarr; var `fullMsg`
2) Check if `fullMsg` is a valid user. If it is and it's you, it will highlight to your custom settings. If it's not you, it will highlight as another user was mentioned (at this time is bold & dark blue).
3) If `fullMsg` is not a valid user, check what the last character is. If the last character is a non-letter, non-number character, remove it from `fullMsg` and go back to step 2. If it is a letter or number, end the check and move on.

