### PR TITLE
Stop P/T Color of Morphs

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -110,7 +110,7 @@ void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
         QStringList ptDbSplit = db->getCard(name)->getPowTough().split("/");
         QStringList ptSplit = pt.split("/");
         
-        if (ptDbSplit.at(0) != ptSplit.at(0) || ptDbSplit.at(1) != ptSplit.at(1))
+        if ((ptDbSplit.at(0) != ptSplit.at(0) || ptDbSplit.at(1) != ptSplit.at(1)) && !getFaceDown())
             painter->setPen(QColor(255, 150, 0));
         else
             painter->setPen(Qt::white);

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -110,7 +110,7 @@ void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
         QStringList ptDbSplit = db->getCard(name)->getPowTough().split("/");
         QStringList ptSplit = pt.split("/");
         
-        if ((ptDbSplit.at(0) != ptSplit.at(0) || ptDbSplit.at(1) != ptSplit.at(1)) && !getFaceDown())
+        if (getFaceDown() || ptDbSplit.at(0) != ptSplit.at(0) || ptDbSplit.at(1) != ptSplit.at(1))
             painter->setPen(QColor(255, 150, 0));
         else
             painter->setPen(Qt::white);


### PR DESCRIPTION
This fixes #1126.

By including the `getFaceDown()` function from the `abstractcarditem.h` header, we can determine if the card that's about to have it's P/T changed is face up or face down. If the card is face down, we will write the text in white (the default color) no matter what the P/T of the creature/card really is. This is to prevent information from being leaked, such as, in the past, if you have a 2/2 that you morphed, the text would be white as the system would see it matching the database.