### PR TITLE
Fix windows size growing out of screen; fix #1144

### DIFF
--- a/cockatrice/src/playerlistwidget.cpp
+++ b/cockatrice/src/playerlistwidget.cpp
@@ -67,7 +67,7 @@ PlayerListWidget::PlayerListWidget(TabSupervisor *_tabSupervisor, AbstractClient
     } else
         userContextMenu = 0;
     
-    setMinimumHeight(60);
+    setMinimumHeight(40);
     setIconSize(QSize(20, 15));
     setColumnCount(6);
     setColumnWidth(0, 20);

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -358,7 +358,8 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, GameReplay *_replay)
     setLayout(superMainLayout);
 
     splitter->restoreState(settingsCache->getTabGameSplitterSizes());
-    
+    splitter->setChildrenCollapsible(false);
+
     messageLog->logReplayStarted(gameInfo.game_id());
 }
 
@@ -490,6 +491,7 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, QList<AbstractClient *> &_client
     setLayout(mainLayout);
 
     splitter->restoreState(settingsCache->getTabGameSplitterSizes());
+    splitter->setChildrenCollapsible(false);
     
     messageLog->logGameJoined(gameInfo.game_id());
 

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -293,6 +293,7 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, GameReplay *_replay)
     deckViewContainerLayout = new QVBoxLayout;
 
     QVBoxLayout *messageLogLayout = new QVBoxLayout;
+    messageLogLayout->setContentsMargins(0, 0, 0, 0);
     messageLogLayout->addWidget(messageLog);
     
     QWidget *messageLogLayoutWidget = new QWidget;
@@ -414,6 +415,7 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, QList<AbstractClient *> &_client
     deckViewContainerLayout = new QVBoxLayout;
 
     QVBoxLayout *messageLogLayout = new QVBoxLayout;
+    messageLogLayout->setContentsMargins(0, 0, 0, 0);
     messageLogLayout->addWidget(timeElapsedLabel);
     messageLogLayout->addWidget(messageLog);
     messageLogLayout->addLayout(hLayout);

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -12,7 +12,7 @@
 #include "dlg_creategame.h"
 #include "tab_game.h"
 #include "tab_supervisor.h"
-#include "cardinfowidget.h"
+#include "cardframe.h"
 #include "playerlistwidget.h"
 #include "messagelogwidget.h"
 #include "phasestoolbar.h"
@@ -280,7 +280,7 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, GameReplay *_replay)
     gameView = new GameView(scene);
     gameView->hide();
     
-    cardInfo = new CardInfoWidget(CardInfoWidget::ModeGameTab);
+    cardInfo = new CardFrame(250, 372);
     playerListWidget = new PlayerListWidget(0, 0, this);
     playerListWidget->setFocusPolicy(Qt::NoFocus);
     
@@ -391,7 +391,7 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, QList<AbstractClient *> &_client
     gameView = new GameView(scene);
     gameView->hide();
     
-    cardInfo = new CardInfoWidget(CardInfoWidget::ModeGameTab);
+    cardInfo = new CardFrame(250, 372);
     playerListWidget = new PlayerListWidget(tabSupervisor, clients.first(), this);
     playerListWidget->setFocusPolicy(Qt::NoFocus);
     connect(playerListWidget, SIGNAL(openMessageDialog(QString, bool)), this, SIGNAL(openMessageDialog(QString, bool)));

--- a/cockatrice/src/tab_game.h
+++ b/cockatrice/src/tab_game.h
@@ -11,7 +11,7 @@ class CardDatabase;
 class GameView;
 class DeckView;
 class GameScene;
-class CardInfoWidget;
+class CardFrame;
 class MessageLogWidget;
 class QTimer;
 class QSplitter;
@@ -125,7 +125,7 @@ private:
     QToolButton *replayStartButton, *replayPauseButton, *replayFastForwardButton;
     
     QSplitter *splitter;
-    CardInfoWidget *cardInfo;
+    CardFrame *cardInfo;
     PlayerListWidget *playerListWidget;
     QLabel *timeElapsedLabel;
     MessageLogWidget *messageLog;

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -21,6 +21,9 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _fullInfo, QWidget *paren
     nameFont.setBold(true);
     nameFont.setPointSize(nameFont.pointSize() * 1.5);
     nameLabel.setFont(nameFont);
+
+    avatarLabel.setMaximumWidth(400);
+    avatarLabel.setMaximumHeight(200);
     
     QGridLayout *mainLayout = new QGridLayout;
     mainLayout->addWidget(&avatarLabel, 0, 0, 1, 3, Qt::AlignCenter);
@@ -61,7 +64,7 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
     const std::string bmp = user.avatar_bmp();
     if (!avatarPixmap.loadFromData((const uchar *) bmp.data(), bmp.size()))
         avatarPixmap = UserLevelPixmapGenerator::generatePixmap(64, userLevel, false);
-    avatarLabel.setPixmap(avatarPixmap);
+    avatarLabel.setPixmap(avatarPixmap.scaled(avatarLabel.size(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
     
     nameLabel.setText(QString::fromStdString(user.name()));
     realNameLabel2.setText(QString::fromStdString(user.real_name()));


### PR DESCRIPTION
We had two different problems here:
 1. in the accounts tab, the avatar image had no limits in size; it's now constrained to 400x200 to avoid the image making the windows grow out of screen. The same code is used in the "user" popup.
 2. in the game tab, the card preview on the right could cause the splitters size to grow out of the screen. The old widget has been replaces by the new cardframe introduced in #1137, that fixes the issue.

How to replicate the problem in game with the old card preview widget:
 * switch the widget to "image only" mode
 * move the splitter up, and make the players/chat boxes as wide as possible
 * switch the widget to "image and text" mode: the card preview hioght will grow, pushing the other two widgets out of the screen.

Note: this PR avoids the splitter from getting a wrong value, but if it already has a wrong value as described in #1144, you probably need to reset the splitter size to a sane value manually.