### PR TITLE
Reduced min table width

### DIFF
--- a/cockatrice/src/tablezone.h
+++ b/cockatrice/src/tablezone.h
@@ -24,7 +24,7 @@ private:
     static const int PADDING_X  = 35;
     static const int PADDING_Y = 10;
     static const int MARGIN_X = 20;
-    static const int MIN_WIDTH = 15 * CARD_WIDTH / 2;
+    static const int MIN_WIDTH = 10 * CARD_WIDTH / 2;
     
     /*
     Default background color, inactive mask and boarder gradient 


### PR DESCRIPTION
The initial table width is too high. The table starts to scale down far
too soon, meaning you have to play in a letterbox ratio.

Before
![a](https://cloud.githubusercontent.com/assets/2134793/8263679/8bb5f49e-16dd-11e5-9fa4-9d2736acaca6.png)

After
![b](https://cloud.githubusercontent.com/assets/2134793/8263662/423502c4-16dd-11e5-91c8-a4a96afc7f05.png)
