### PR TITLE
Small improvements to card image downloading

### DIFF
--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -94,6 +94,7 @@ private:
     bool picDownload, picDownloadHq, downloadRunning, loadQueueRunning;
     void startNextPicDownload();
     QString getPicUrl();
+    static QStringList md5Blacklist;
 public:
     PictureLoader(const QString &__picsPath, bool _picDownload, bool _picDownloadHq, QObject *parent = 0);
     ~PictureLoader();

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -3,10 +3,11 @@
 
 #include <QObject>
 
+// the falbacks are used for cards without a muid
 #define PIC_URL_DEFAULT "http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!cardid!&type=card"
-#define PIC_URL_FALLBACK "http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!cardid!&type=card"
+#define PIC_URL_FALLBACK "http://gatherer.wizards.com/Handlers/Image.ashx?name=!name!&type=card"
 #define PIC_URL_HQ_DEFAULT "http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!cardid!&type=card"
-#define PIC_URL_HQ_FALLBACK "http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!cardid!&type=card"
+#define PIC_URL_HQ_FALLBACK "http://gatherer.wizards.com/Handlers/Image.ashx?name=!name!&type=card"
 // size should be a multiple of 64
 #define PIXMAPCACHE_SIZE_DEFAULT 2047
 #define PIXMAPCACHE_SIZE_MIN 64


### PR DESCRIPTION
This PR addresses two things:
1) it adds a blacklist for card images; when a card image is downloaded, its md5 will be calculated and if it's in the blacklist, we'll consider the download as failed; this should avoid the problem where gatherer is returning MTG's card back image for cards it doesn't know:
```
Trying to load picture (set:  "S99"  card:  "TestCard" )
Picture NOT found, trying to download (set:  "S99"  card:  "TestCard" )
starting picture download: "TestCard" Url:  QUrl( "http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=2020300000&type=card" ) 
Picture downloaded, but blacklisted ( "db0c48db407a907c16ade38de048a441" ), will consider it as not found
Picture NOT found, download failed, moving to next set (newset:  "USG"  card:  "TestCard" )
```

2) the fallback urls for card downloads was initially implemented to solve the issue of cards with muId=0. When mtgimage got shut down the fallback urls has been pointed to gatherer, but they were still using !muid!, so image downloading could not work, creating the previous issue. This PR modifies the fallbacks urls making them use the card name instead.

This should fix #1158.