### PR TITLE
Ability to rotate player position in game view

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -343,6 +343,10 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     invertVerticalCoordinateCheckBox.setChecked(settingsCache->getInvertVerticalCoordinate());
     connect(&invertVerticalCoordinateCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setInvertVerticalCoordinate(int)));
     
+    playerPositionRotationSpinBox.setValue(settingsCache->getPlayerPositionRotation());
+    connect(&playerPositionRotationSpinBox, SIGNAL(valueChanged(int)), settingsCache, SLOT(setPlayerPositionRotation(int)));
+    playerPositionRotationLabel.setBuddy(&playerPositionRotationSpinBox);
+    
     minPlayersForMultiColumnLayoutEdit.setMinimum(2);
     minPlayersForMultiColumnLayoutEdit.setValue(settingsCache->getMinPlayersForMultiColumnLayout());
     connect(&minPlayersForMultiColumnLayoutEdit, SIGNAL(valueChanged(int)), settingsCache, SLOT(setMinPlayersForMultiColumnLayout(int)));
@@ -350,8 +354,10 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     
     QGridLayout *tableGrid = new QGridLayout;
     tableGrid->addWidget(&invertVerticalCoordinateCheckBox, 0, 0, 1, 2);
-    tableGrid->addWidget(&minPlayersForMultiColumnLayoutLabel, 1, 0, 1, 1);
-    tableGrid->addWidget(&minPlayersForMultiColumnLayoutEdit, 1, 1, 1, 1);
+    tableGrid->addWidget(&playerPositionRotationLabel, 1, 0, 1, 1);
+    tableGrid->addWidget(&playerPositionRotationSpinBox, 1, 1, 1, 1);
+    tableGrid->addWidget(&minPlayersForMultiColumnLayoutLabel, 2, 0, 1, 1);
+    tableGrid->addWidget(&minPlayersForMultiColumnLayoutEdit, 2, 1, 1, 1);
     
     tableGroupBox = new QGroupBox;
     tableGroupBox->setLayout(tableGrid);
@@ -384,6 +390,7 @@ void AppearanceSettingsPage::retranslateUi()
     
     tableGroupBox->setTitle(tr("Table grid layout"));
     invertVerticalCoordinateCheckBox.setText(tr("Invert vertical coordinate"));
+    playerPositionRotationLabel.setText(tr("Player position rotation amount:"));
     minPlayersForMultiColumnLayoutLabel.setText(tr("Minimum player count for multi-column layout:"));
 }
 

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -97,6 +97,7 @@ private:
     QLabel tableBgLabel;
     QLabel playerAreaBgLabel;
     QLabel cardBackPicturePathLabel;
+    QLabel playerPositionRotationLabel;
     QLabel minPlayersForMultiColumnLayoutLabel;
     QLineEdit *handBgEdit;
     QLineEdit *stackBgEdit;
@@ -112,6 +113,7 @@ private:
     QGroupBox *cardsGroupBox;
     QGroupBox *handGroupBox;
     QGroupBox *tableGroupBox;
+    QSpinBox playerPositionRotationSpinBox;
     QSpinBox minPlayersForMultiColumnLayoutEdit;
 public:
     AppearanceSettingsPage();

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -51,6 +51,7 @@ SettingsCache::SettingsCache()
     displayCardNames = settings->value("cards/displaycardnames", true).toBool();
     horizontalHand = settings->value("hand/horizontal", true).toBool();
     invertVerticalCoordinate = settings->value("table/invert_vertical", false).toBool();
+    playerPositionRotation = settings->value("interface/player_position_rotation", 0).toInt();
     minPlayersForMultiColumnLayout = settings->value("interface/min_players_multicolumn", 5).toInt();
     tapAnimation = settings->value("cards/tapanimation", true).toBool();
     chatMention = settings->value("chat/mention", true).toBool();
@@ -282,6 +283,13 @@ void SettingsCache::setInvertVerticalCoordinate(int _invertVerticalCoordinate)
     invertVerticalCoordinate = _invertVerticalCoordinate;
     settings->setValue("table/invert_vertical", invertVerticalCoordinate);
     emit invertVerticalCoordinateChanged();
+}
+
+void SettingsCache::setPlayerPositionRotation(int _playerPositionRotation)
+{
+    playerPositionRotation = _playerPositionRotation;
+    settings->setValue("interface/player_position_rotation", playerPositionRotation);
+    emit playerPositionRotationChanged();
 }
 
 void SettingsCache::setMinPlayersForMultiColumnLayout(int _minPlayersForMultiColumnLayout)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -33,6 +33,7 @@ signals:
     void horizontalHandChanged();
     void handJustificationChanged();
     void invertVerticalCoordinateChanged();
+    void playerPositionRotationChanged();
     void minPlayersForMultiColumnLayoutChanged();
     void soundEnabledChanged();
     void soundPathChanged();
@@ -59,6 +60,7 @@ private:
     bool displayCardNames;
     bool horizontalHand;
     bool invertVerticalCoordinate;
+    int playerPositionRotation;
     int minPlayersForMultiColumnLayout;
     bool tapAnimation;
     bool chatMention;
@@ -110,6 +112,7 @@ public:
     bool getDisplayCardNames() const { return displayCardNames; }
     bool getHorizontalHand() const { return horizontalHand; }
     bool getInvertVerticalCoordinate() const { return invertVerticalCoordinate; }
+    int getPlayerPositionRotation() const { return playerPositionRotation; }
     int getMinPlayersForMultiColumnLayout() const { return minPlayersForMultiColumnLayout; }
     bool getTapAnimation() const { return tapAnimation; }
     bool getChatMention()  const { return chatMention; }
@@ -164,6 +167,7 @@ public slots:
     void setDisplayCardNames(int _displayCardNames);
     void setHorizontalHand(int _horizontalHand);
     void setInvertVerticalCoordinate(int _invertVerticalCoordinate);
+    void setPlayerPositionRotation(int _playerPositionRotation);
     void setMinPlayersForMultiColumnLayout(int _minPlayersForMultiColumnLayout);
     void setTapAnimation(int _tapAnimation);
     void setChatMention(int _chatMention);


### PR DESCRIPTION
With the "Player position rotation amount" setting, players can adjust their position in the local game view.  No effect on actual player ordering.  With the default setting of 0 there should be no change to current behavior.

I added this for multiplayer games - in the two-column view the local player always ended up in the bottom left corner.  In 2v2 multiplayer this setting allows players to adjust their "seat at the table".