### PR TITLE
Activation Email Misspelling

### DIFF
--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -120,7 +120,7 @@ subject="Cockatrice server account activation token"
 ; Email body. You can use these tags here: %username %token
 ; They will be substituted with the actual values in the email
 ; 
-body="Hi %username, thank our for registering on our Cockatrice server\r\nHere's the activation token you need to supply for activatin your account:\r\n\r\n%token\r\n\r\nHappy gaming!"
+body="Hi %username, thank our for registering on our Cockatrice server\r\nHere's the activation token you need to supply for activating your account:\r\n\r\n%token\r\n\r\nHappy gaming!"
 
 [database]
 


### PR DESCRIPTION
Corrected the misspelling of the word "activating' in the servatrice.ini example file.