### PR TITLE
Added ability to rotate player positions in the local game view.

### DIFF
--- a/cockatrice/src/gamescene.cpp
+++ b/cockatrice/src/gamescene.cpp
@@ -11,9 +11,13 @@
 #include <QSet>
 #include <QBasicTimer>
 #include <QGraphicsView>
+#include <QDebug>
 
 GameScene::GameScene(PhasesToolbar *_phasesToolbar, QObject *parent)
-    : QGraphicsScene(parent), phasesToolbar(_phasesToolbar), viewSize(QSize())
+    : QGraphicsScene(parent),
+      phasesToolbar(_phasesToolbar),
+      viewSize(QSize()),
+      playerRotation(0)
 {
     animationTimer = new QBasicTimer;
     addItem(phasesToolbar);
@@ -35,7 +39,7 @@ void GameScene::retranslateUi()
 
 void GameScene::addPlayer(Player *player)
 {
-    qDebug("GameScene::addPlayer");
+    qDebug() << "GameScene::addPlayer name=" << player->getName();
     players << player;
     addItem(player);
     connect(player, SIGNAL(sizeChanged()), this, SLOT(rearrange()));
@@ -44,9 +48,15 @@ void GameScene::addPlayer(Player *player)
 
 void GameScene::removePlayer(Player *player)
 {
-    qDebug("GameScene::removePlayer");
+    qDebug() << "GameScene::removePlayer name=" << player->getName();
     players.removeAt(players.indexOf(player));
     removeItem(player);
+    rearrange();
+}
+
+void GameScene::adjustPlayerRotation(int rotationAdjustment)
+{
+    playerRotation += rotationAdjustment;
     rearrange();
 }
 
@@ -54,29 +64,47 @@ void GameScene::rearrange()
 {
     playersByColumn.clear();
 
+    // Create the list of players playing, noting the first player's index.
     QList<Player *> playersPlaying;
-    int firstPlayer = -1;
-    for (int i = 0; i < players.size(); ++i)
-        if (!players[i]->getConceded()) {
-            playersPlaying.append(players[i]);
-            if ((firstPlayer == -1) && (players[i]->getLocal()))
-                firstPlayer = playersPlaying.size() - 1;
+    int firstPlayerIndex = 0;
+    bool firstPlayerFound = false;
+    QListIterator<Player *> playersIter(players);
+    while (playersIter.hasNext()) {
+        Player *p = playersIter.next();
+        if (!p->getConceded()) {
+            playersPlaying.append(p);
+            if (!firstPlayerFound && (p->getLocal())) {
+                firstPlayerIndex = playersPlaying.size() - 1;
+                firstPlayerFound = true;
+            }
         }
-    if (firstPlayer == -1)
-        firstPlayer = 0;
+    }
+
+    // Rotate the players playing list so that first player is first, then
+    // adjust by the additional rotation setting.
+    if (!playersPlaying.isEmpty()) {
+        int totalRotation = firstPlayerIndex + playerRotation;
+        while (totalRotation < 0)
+            totalRotation += playersPlaying.size();
+        for (int i = 0; i < totalRotation; ++i) {
+            playersPlaying.append(playersPlaying.takeFirst());
+        }
+    }
+
     const int playersCount = playersPlaying.size();
     const int columns = playersCount < settingsCache->getMinPlayersForMultiColumnLayout() ? 1 : 2;
     const int rows = ceil((qreal) playersCount / columns);
     qreal sceneHeight = 0, sceneWidth = -playerAreaSpacing;
     QList<int> columnWidth;
-    int firstPlayerOfColumn = firstPlayer;
+
+    QListIterator<Player *> playersPlayingIter(playersPlaying);
     for (int col = 0; col < columns; ++col) {
         playersByColumn.append(QList<Player *>());
         columnWidth.append(0);
         qreal thisColumnHeight = -playerAreaSpacing;
         const int rowsInColumn = rows - (playersCount % columns) * col; // only correct for max. 2 cols
         for (int j = 0; j < rowsInColumn; ++j) {
-            Player *player = playersPlaying[(firstPlayerOfColumn + j) % playersCount];
+            Player *player = playersPlayingIter.next();
             if (col == 0)
                 playersByColumn[col].prepend(player);
             else
@@ -88,8 +116,6 @@ void GameScene::rearrange()
         if (thisColumnHeight > sceneHeight)
             sceneHeight = thisColumnHeight;
         sceneWidth += columnWidth[col] + playerAreaSpacing;
-
-        firstPlayerOfColumn += rowsInColumn;
     }
 
     phasesToolbar->setHeight(sceneHeight);

--- a/cockatrice/src/gamescene.h
+++ b/cockatrice/src/gamescene.h
@@ -28,6 +28,7 @@ private:
     QPointer<CardItem> hoveredCard;
     QBasicTimer *animationTimer;
     QSet<CardItem *> cardsToAnimate;
+    int playerRotation;
     void updateHover(const QPointF &scenePos);
 public:
     GameScene(PhasesToolbar *_phasesToolbar, QObject *parent = 0);
@@ -51,6 +52,7 @@ public slots:
     void removePlayer(Player *player);
     void clearViews();
     void closeMostRecentZoneView();
+    void adjustPlayerRotation(int rotationAdjustment);
     void rearrange();
 protected:
     bool event(QEvent *event);

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -345,6 +345,8 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, GameReplay *_replay)
     aNextPhase = 0;
     aNextTurn = 0;
     aRemoveLocalArrows = 0;
+    aRotateViewCW = 0;
+    aRotateViewCCW = 0;
     aGameInfo = 0;
     aConcede = 0;
     aLeaveGame = 0;
@@ -450,6 +452,10 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, QList<AbstractClient *> &_client
     connect(aNextTurn, SIGNAL(triggered()), this, SLOT(actNextTurn()));
     aRemoveLocalArrows = new QAction(this);
     connect(aRemoveLocalArrows, SIGNAL(triggered()), this, SLOT(actRemoveLocalArrows()));
+    aRotateViewCW = new QAction(this);
+    connect(aRotateViewCW, SIGNAL(triggered()), this, SLOT(actRotateViewCW()));
+    aRotateViewCCW = new QAction(this);
+    connect(aRotateViewCCW, SIGNAL(triggered()), this, SLOT(actRotateViewCCW()));
     aGameInfo = new QAction(this);
     connect(aGameInfo, SIGNAL(triggered()), this, SLOT(actGameInfo()));
     aConcede = new QAction(this);
@@ -483,6 +489,8 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, QList<AbstractClient *> &_client
     gameMenu->addAction(aNextTurn);
     gameMenu->addSeparator();
     gameMenu->addAction(aRemoveLocalArrows);
+    gameMenu->addAction(aRotateViewCW);
+    gameMenu->addAction(aRotateViewCCW);
     gameMenu->addSeparator();
     gameMenu->addAction(aGameInfo);
     gameMenu->addAction(aConcede);
@@ -546,6 +554,14 @@ void TabGame::retranslateUi()
     if (aRemoveLocalArrows) {
         aRemoveLocalArrows->setText(tr("&Remove all local arrows"));
         aRemoveLocalArrows->setShortcut(QKeySequence("Ctrl+R"));
+    }
+    if (aRotateViewCW) {
+        aRotateViewCW->setText(tr("Rotate View Cl&ockwise"));
+        aRotateViewCW->setShortcut(QKeySequence("Ctrl+]"));
+    }
+    if (aRotateViewCCW) {
+        aRotateViewCCW->setText(tr("Rotate View Co&unterclockwise"));
+        aRotateViewCCW->setShortcut(QKeySequence("Ctrl+["));
     }
     if (aGameInfo)
         aGameInfo->setText(tr("Game &information"));
@@ -711,6 +727,16 @@ void TabGame::actRemoveLocalArrows()
             sendGameCommand(cmd);
         }
     }
+}
+
+void TabGame::actRotateViewCW()
+{
+    scene->adjustPlayerRotation(-1);
+}
+
+void TabGame::actRotateViewCCW()
+{
+    scene->adjustPlayerRotation(1);
 }
 
 Player *TabGame::addPlayer(int playerId, const ServerInfo_User &info)

--- a/cockatrice/src/tab_game.h
+++ b/cockatrice/src/tab_game.h
@@ -141,7 +141,7 @@ private:
     QAction *playersSeparator;
     QMenu *gameMenu;
     QMenu *phasesMenu;
-    QAction *aGameInfo, *aConcede, *aLeaveGame, *aCloseReplay, *aNextPhase, *aNextTurn, *aRemoveLocalArrows;
+    QAction *aGameInfo, *aConcede, *aLeaveGame, *aCloseReplay, *aNextPhase, *aNextTurn, *aRemoveLocalArrows, *aRotateViewCW, *aRotateViewCCW;
     QList<QAction *> phaseActions;
 
     Player *addPlayer(int playerId, const ServerInfo_User &info);
@@ -190,6 +190,8 @@ private slots:
     void actConcede();
     void actLeaveGame();
     void actRemoveLocalArrows();
+    void actRotateViewCW();
+    void actRotateViewCCW();
     void actSay();
     void actPhaseAction();
     void actNextPhase();


### PR DESCRIPTION
Added menu items (and keyboard shortcuts) to the game menu to rotate the local game view.  This is the proposed replacement for PR #1175.

I added this for multiplayer games - in the two-column view the local player always ended up in the bottom left corner. In 2v2 multiplayer this setting allows players to adjust their "seat at the table".