### PR TITLE
Inform users about server's username rules on invalid username error

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -307,9 +307,7 @@ void MainWindow::loginError(Response::ResponseCode r, QString reasonStr, quint32
             break;
         }
         case Response::RespUsernameInvalid: {
-            QString errorStr;
-            extractInvalidUsernameMessage(reasonStr, errorStr);
-            QMessageBox::critical(this, tr("Error"), errorStr);
+            QMessageBox::critical(this, tr("Error"), extractInvalidUsernameMessage(reasonStr));
             break;
         }
         case Response::RespRegistrationRequired:
@@ -335,9 +333,9 @@ void MainWindow::loginError(Response::ResponseCode r, QString reasonStr, quint32
     actConnect();
 }
 
-void MainWindow::extractInvalidUsernameMessage(QString & in, QString & out)
+QString MainWindow::extractInvalidUsernameMessage(QString & in)
 {
-    out = tr("Invalid username.") + "<br/>";
+    QString out = tr("Invalid username.") + "<br/>";
     QStringList rules = in.split(QChar('|'));
     if (rules.size() == 7)
     {
@@ -357,12 +355,14 @@ void MainWindow::extractInvalidUsernameMessage(QString & in, QString & out)
     rules.at(6).toHtmlEscaped()
 #endif
         ) + "</li>";
-        if(rules.at(5).toInt() > 0)
+        if(rules.at(5).toInt() == 0)
             out += "<li>" + tr("the first character can't be a punctuation") + "</li>";
         out += "</ul>";
     } else {
         out += tr("You may only use A-Z, a-z, 0-9, _, ., and - in your username.");
     }
+
+    return out;
 }
 
 void MainWindow::registerError(Response::ResponseCode r, QString reasonStr, quint32 endTime)
@@ -396,9 +396,7 @@ void MainWindow::registerError(Response::ResponseCode r, QString reasonStr, quin
             break;
         }
         case Response::RespUsernameInvalid: {
-            QString errorStr;
-            extractInvalidUsernameMessage(reasonStr, errorStr);
-            QMessageBox::critical(this, tr("Error"), errorStr);
+            QMessageBox::critical(this, tr("Error"), extractInvalidUsernameMessage(reasonStr));
             break;
         }
         case Response::RespRegistrationFailed:

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -109,7 +109,7 @@ public:
 protected:
     void closeEvent(QCloseEvent *event);
     void changeEvent(QEvent *event);
-    void extractInvalidUsernameMessage(QString & in, QString & out);
+    QString extractInvalidUsernameMessage(QString & in);
 };
 
 #endif

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -109,6 +109,7 @@ public:
 protected:
     void closeEvent(QCloseEvent *event);
     void changeEvent(QEvent *event);
+    void extractInvalidUsernameMessage(QString & in, QString & out);
 };
 
 #endif

--- a/common/server_database_interface.h
+++ b/common/server_database_interface.h
@@ -25,7 +25,7 @@ public:
     virtual DeckList *getDeckFromDatabase(int /* deckId */, int /* userId */) { return 0; }
     
     virtual qint64 startSession(const QString & /* userName */, const QString & /* address */) { return 0; }
-    virtual bool usernameIsValid(const QString & /*userName */) { return true; };
+    virtual bool usernameIsValid(const QString & /*userName */, QString & /* error */) { return true; };
 public slots:
     virtual void endSession(qint64 /* sessionId */ ) { }
 public:

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -388,7 +388,12 @@ Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd
         }
         case NotLoggedIn: return Response::RespWrongPassword;
         case WouldOverwriteOldSession: return Response::RespWouldOverwriteOldSession;
-        case UsernameInvalid: return Response::RespUsernameInvalid;
+        case UsernameInvalid: {
+            Response_Login *re = new Response_Login;
+            re->set_denied_reason_str(reasonStr.toStdString());
+            rc.setResponseExtension(re);
+            return Response::RespUsernameInvalid;
+        }
         case RegistrationRequired: return Response::RespRegistrationRequired;
         case UserIsInactive: return Response::RespAccountNotActivated;
         default: authState = res;

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -247,8 +247,7 @@ AuthenticationResult Servatrice_DatabaseInterface::checkUserPassword(Server_Prot
         if (!checkSql())
             return UnknownUser;
 
-        QString error;
-        if (!usernameIsValid(user, error))
+        if (!usernameIsValid(user, reasonStr))
             return UsernameInvalid;
         
         if (checkUserIsBanned(handler->getAddress(), user, reasonStr, banSecondsLeft))

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -118,24 +118,29 @@ bool Servatrice_DatabaseInterface::execSqlQuery(QSqlQuery *query)
     return false;
 }
 
-bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user)
+bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user, QString & error)
 {
-    int maxNameLength = settingsCache->value("users/maxnamelength", 12).toInt();
     int minNameLength = settingsCache->value("users/minnamelength", 6).toInt();
+    int maxNameLength = settingsCache->value("users/maxnamelength", 12).toInt();
+    bool allowLowercase = settingsCache->value("users/allowlowercase", true).toBool();
+    bool allowUppercase = settingsCache->value("users/allowuppercase", true).toBool();
+    bool allowNumerics = settingsCache->value("users/allownumerics", true).toBool();
+    bool allowPunctuationPrefix = settingsCache->value("users/allowpunctuationprefix", false).toBool();
+    QString allowedPunctuation = settingsCache->value("users/allowedpunctuation", "_").toString();
+    error = QString("%1|%2|%3|%4|%5|%6|%7").arg(minNameLength).arg(maxNameLength).arg(allowLowercase).arg(allowUppercase).arg(allowNumerics).arg(allowPunctuationPrefix).arg(allowedPunctuation);
+
     if (user.length() < minNameLength || user.length() > maxNameLength)
         return false;
 
-    bool allowPunctuationPrefix = settingsCache->value("users/allowpunctuationprefix", false).toBool();
-    QString allowedPunctuation = settingsCache->value("users/allowedpunctuation", "_").toString();
     if (!allowPunctuationPrefix && allowedPunctuation.contains(user.at(0)))
         return false;
 
     QString regEx("[");
-    if (settingsCache->value("users/allowlowercase", true).toBool())
+    if (allowLowercase)
         regEx.append("a-z");
-    if (settingsCache->value("users/allowuppercase", true).toBool())
+    if (allowUppercase)
         regEx.append("A-Z");
-    if(settingsCache->value("users/allownumerics", true).toBool())
+    if(allowNumerics)
         regEx.append("0-9");
     regEx.append(QRegExp::escape(allowedPunctuation));
     regEx.append("]+");
@@ -242,7 +247,8 @@ AuthenticationResult Servatrice_DatabaseInterface::checkUserPassword(Server_Prot
         if (!checkSql())
             return UnknownUser;
 
-        if (!usernameIsValid(user))
+        QString error;
+        if (!usernameIsValid(user, error))
             return UsernameInvalid;
         
         if (checkUserIsBanned(handler->getAddress(), user, reasonStr, banSecondsLeft))

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -62,7 +62,7 @@ public:
 	void lockSessionTables();
 	void unlockSessionTables();
 	bool userSessionExists(const QString &userName);
-	bool usernameIsValid(const QString &user);
+	bool usernameIsValid(const QString &user, QString & error);
 	bool checkUserIsBanned(const QString &ipAddress, const QString &userName, QString &banReason, int &banSecondsRemaining);
 
 	bool getRequireRegistration();

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -788,8 +788,14 @@ Response::ResponseCode ServerSocketInterface::cmdRegisterAccount(const Command_R
     }
 
     // TODO: Move this method outside of the db interface
-    if (!sqlInterface->usernameIsValid(userName))
+    QString errorString;
+    if (!sqlInterface->usernameIsValid(userName, errorString))
+    {
+        Response_Register *re = new Response_Register;
+        re->set_denied_reason_str(errorString.toStdString());
+        rc.setResponseExtension(re);
         return Response::RespUsernameInvalid;
+    }
 
     if(sqlInterface->userExists(userName))
         return Response::RespUserAlreadyExists;


### PR DESCRIPTION
This PR aims at resolving #1173.
When a register or login command fails because the username is not accepted as valid, the server will include in the error response the rules it's actually using to validate the username.
The client will unpack these rules and try to explain them to the user:
![popup](https://cloud.githubusercontent.com/assets/1631111/8436466/d1bfaba0-1f58-11e5-9234-aec1d2580c10.png)

The proposed examples in #1173 were more specific about the error, but unfortunately we're parsing the username using a regexp, so we can't really tell the user why the username failed.
This change is fully backwards compatible on the client; if the server is not updated, the old "hardcoded" message will be shown to the user.

