### PR TITLE
Fixed horizontal positioning in multicolumn layout.

### DIFF
--- a/cockatrice/src/gamescene.cpp
+++ b/cockatrice/src/gamescene.cpp
@@ -202,14 +202,14 @@ void GameScene::processViewSizeChange(const QSize &newSize)
     setSceneRect(0, 0, newWidth, sceneRect().height());
 
     qreal extraWidthPerColumn = (newWidth - minWidth) / playersByColumn.size();
-    for (int col = 0; col < playersByColumn.size(); ++col)
+    qreal newx = phasesToolbar->getWidth();
+    for (int col = 0; col < playersByColumn.size(); ++col) {
         for (int row = 0; row < playersByColumn[col].size(); ++row){
             playersByColumn[col][row]->processSceneSizeChange(minWidthByColumn[col] + extraWidthPerColumn);
-            if (col == 0)
-                playersByColumn[col][row]->setPos(phasesToolbar->getWidth(), playersByColumn[col][row]->y());
-            else
-                playersByColumn[col][row]->setPos(phasesToolbar->getWidth() + (newWidth - phasesToolbar->getWidth()) / 2, playersByColumn[col][row]->y());
+            playersByColumn[col][row]->setPos(newx, playersByColumn[col][row]->y());
         }
+        newx += minWidthByColumn[col] + extraWidthPerColumn;
+    }
 }
 
 void GameScene::updateHover(const QPointF &scenePos)


### PR DESCRIPTION
Multicolumn horizontal layout positioning was not being properly handled.  This issue can be seen often when using 2-columns during games - you can see strange spacing between the columns.  The behavior can be pretty easily reproduced by starting a 3-player local game and dragging a card to the rightmost portion of the table in the first column:

![screenshot - 06302015 - 01 09 53 pm](https://cloud.githubusercontent.com/assets/13039044/8471002/3294c2ae-2048-11e5-8c1f-8e210c61add9.png)

This PR corrects the x-coordinate adjustment for players laid out in multicolumn.  Same test after the fix:

![screenshot - 07012015 - 11 25 43 pm](https://cloud.githubusercontent.com/assets/13039044/8471032/9be1dad0-2048-11e5-98dd-c6764a81dc2f.png)

(This issue was noted in comments for #1179.)