### PR TITLE
Fix local mention crash

### DIFF
--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -298,7 +298,7 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
         }
         else if (index == mentionFirstIndex)
         {
-            if (tabSupervisor->isALocalGame())
+            if (tabSupervisor->getIsLocalGame())
             {
                 cursor.insertText("@");
                 message = message.mid(1);

--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -298,59 +298,68 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
         }
         else if (index == mentionFirstIndex)
         {
-            QMap<QString, UserListTWI *> userList = tabSupervisor->getUserListsTab()->getAllUsersList()->getUsers();
-
-            int firstSpace = message.indexOf(" ");
-            QString fullMentionUpToSpaceOrEnd = (firstSpace == -1) ? message.mid(1) : message.mid(1, firstSpace - 1);
-            QString mentionIntact = fullMentionUpToSpaceOrEnd;
-
-            while (fullMentionUpToSpaceOrEnd.size())
+            if (tabSupervisor->isALocalGame())
             {
-                if (isFullMentionAValidUser(userList, fullMentionUpToSpaceOrEnd)) // Is there a user online named this?
+                cursor.insertText("@");
+                message = message.mid(1);
+            }
+            else
+            {
+
+                QMap<QString, UserListTWI *> userList = tabSupervisor->getUserListsTab()->getAllUsersList()->getUsers();
+
+                int firstSpace = message.indexOf(" ");
+                QString fullMentionUpToSpaceOrEnd = (firstSpace == -1) ? message.mid(1) : message.mid(1, firstSpace - 1);
+                QString mentionIntact = fullMentionUpToSpaceOrEnd;
+
+                while (fullMentionUpToSpaceOrEnd.size())
                 {
-                    if (userName.toLower() == fullMentionUpToSpaceOrEnd.toLower()) // Is this user you?
+                    if (isFullMentionAValidUser(userList, fullMentionUpToSpaceOrEnd)) // Is there a user online named this?
                     {
-                        // You have received a valid mention!!
-                        mentionFormat.setBackground(QBrush(getCustomMentionColor()));
-                        mentionFormat.setForeground(settingsCache->getChatMentionForeground() ? QBrush(Qt::white) : QBrush(Qt::black));
-                        cursor.insertText(mention, mentionFormat);
-                        message = message.mid(mention.size());
-                        QApplication::alert(this);
-                        if (settingsCache->getShowMentionPopup() && shouldShowSystemPopup())
+                        if (userName.toLower() == fullMentionUpToSpaceOrEnd.toLower()) // Is this user you?
                         {
-                            QString ref = sender.left(sender.length() - 2);
-                            showSystemPopup(ref);
+                            // You have received a valid mention!!
+                            mentionFormat.setBackground(QBrush(getCustomMentionColor()));
+                            mentionFormat.setForeground(settingsCache->getChatMentionForeground() ? QBrush(Qt::white) : QBrush(Qt::black));
+                            cursor.insertText(mention, mentionFormat);
+                            message = message.mid(mention.size());
+                            QApplication::alert(this);
+                            if (settingsCache->getShowMentionPopup() && shouldShowSystemPopup())
+                            {
+                                QString ref = sender.left(sender.length() - 2);
+                                showSystemPopup(ref);
+                            }
                         }
+                        else
+                        {
+                            QString correctUserName = getNameFromUserList(userList, fullMentionUpToSpaceOrEnd);
+                            UserListTWI *vlu = userList.value(correctUserName);
+                            mentionFormatOtherUser.setAnchorHref("user://" + QString::number(vlu->getUserInfo().user_level()) + "_" + correctUserName);
+                            cursor.insertText("@" + correctUserName, mentionFormatOtherUser);
+
+                            message = message.mid(correctUserName.size() + 1);
+                        }
+
+                        cursor.setCharFormat(defaultFormat);
+                        break;
+                    }
+                    else if (fullMentionUpToSpaceOrEnd.right(1).indexOf(notALetterOrNumber) == -1)
+                    {               
+                        cursor.insertText("@" + mentionIntact, defaultFormat);
+                        message = message.mid(mentionIntact.size() + 1);
+                        cursor.setCharFormat(defaultFormat);
+                        break;
                     }
                     else
                     {
-                        QString correctUserName = getNameFromUserList(userList, fullMentionUpToSpaceOrEnd);
-                        UserListTWI *vlu = userList.value(correctUserName);
-                        mentionFormatOtherUser.setAnchorHref("user://" + QString::number(vlu->getUserInfo().user_level()) + "_" + correctUserName);
-                        cursor.insertText("@" + correctUserName, mentionFormatOtherUser);
-
-                        message = message.mid(correctUserName.size() + 1);
+                        fullMentionUpToSpaceOrEnd = fullMentionUpToSpaceOrEnd.left(fullMentionUpToSpaceOrEnd.size() - 1);
                     }
-
-                    cursor.setCharFormat(defaultFormat);
-                    break;
-                }
-                else if (fullMentionUpToSpaceOrEnd.right(1).indexOf(notALetterOrNumber) == -1)
-                {               
-                    cursor.insertText("@" + mentionIntact, defaultFormat);
-                    message = message.mid(mentionIntact.size() + 1);
-                    cursor.setCharFormat(defaultFormat);
-                    break;
-                }
-                else
-                {
-                    fullMentionUpToSpaceOrEnd = fullMentionUpToSpaceOrEnd.left(fullMentionUpToSpaceOrEnd.size() - 1);
                 }
             }
         }
         else
         {
-            message = message.mid(1); // Not certain when this would ever be reached, but just incase
+            message = message.mid(1); // Not certain when this would ever be reached, but just incase lets skip the character
         }
     }
 

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -184,6 +184,7 @@ int TabSupervisor::myAddTab(Tab *tab)
 
 void TabSupervisor::start(const ServerInfo_User &_userInfo)
 {
+    isLocalGame = false;
     userInfo = new ServerInfo_User(_userInfo);
     
     tabServer = new TabServer(this, client);
@@ -227,6 +228,7 @@ void TabSupervisor::startLocal(const QList<AbstractClient *> &_clients)
     tabDeckStorage = 0;
     tabReplays = 0;
     tabAdmin = 0;
+    isLocalGame = true;
     userInfo = new ServerInfo_User;
     localClients = _clients;
     for (int i = 0; i < localClients.size(); ++i)

--- a/cockatrice/src/tab_supervisor.h
+++ b/cockatrice/src/tab_supervisor.h
@@ -68,7 +68,7 @@ public:
     void start(const ServerInfo_User &userInfo);
     void startLocal(const QList<AbstractClient *> &_clients);
     void stop();
-    bool isALocalGame() const { return isLocalGame; }
+    bool getIsLocalGame() const { return isLocalGame; }
     int getGameCount() const { return gameTabs.size(); }
     TabUserLists *getUserListsTab() const { return tabUserLists; }
     ServerInfo_User *getUserInfo() const { return userInfo; }

--- a/cockatrice/src/tab_supervisor.h
+++ b/cockatrice/src/tab_supervisor.h
@@ -60,6 +60,7 @@ private:
     void addCloseButtonToTab(Tab *tab, int tabIndex);
     QString sanitizeTabName(QString dirty) const;
     QString sanitizeHtml(QString dirty) const;
+    bool isLocalGame;
 public:
     TabSupervisor(AbstractClient *_client, QWidget *parent = 0);
     ~TabSupervisor();
@@ -67,6 +68,7 @@ public:
     void start(const ServerInfo_User &userInfo);
     void startLocal(const QList<AbstractClient *> &_clients);
     void stop();
+    bool isALocalGame() const { return isLocalGame; }
     int getGameCount() const { return gameTabs.size(); }
     TabUserLists *getUserListsTab() const { return tabUserLists; }
     ServerInfo_User *getUserInfo() const { return userInfo; }


### PR DESCRIPTION
Fix #1192.

This addresses the issue where if you `@foo` in a local game the client would crash. This came about from calling the `getUserListsTab()` function from the `tabSupervisor` which would return an exception when calling in a local match.