### PR TITLE
Server Name Rules Information

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -357,7 +357,7 @@ QString MainWindow::extractInvalidUsernameMessage(QString & in)
             ) + "</li>";
         }
         
-        out += "<li>" + tr("first character can %1 be a punctuation mark").arg((rules.at(5).toInt() == 0) ? "" : tr("NOT")) + "</li>";
+        out += "<li>" + tr("first character can %1 be a punctuation mark").arg((rules.at(5).toInt() > 0) ? "" : tr("NOT")) + "</li>";
         out += "</ul>";
     }
     else

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -339,26 +339,29 @@ QString MainWindow::extractInvalidUsernameMessage(QString & in)
     QStringList rules = in.split(QChar('|'));
     if (rules.size() == 7)
     {
-        out += tr("The username must respect these rules:") + "<br/><ul>"
-            + "<li>" + tr("length between %1 and %2 characters").arg(rules.at(0)).arg(rules.at(1)) + "</li>";
-        if(rules.at(2).toInt() > 0)
-            out += "<li>" + tr("it can contain lowercase characters") + "</li>";
-        if(rules.at(3).toInt() > 0)
-            out += "<li>" + tr("it can contain uppercase characters") + "</li>";
-        if(rules.at(4).toInt() > 0)
-            out += "<li>" + tr("it can contain numeric characters") + "</li>";
-        if(rules.at(6).size() > 0)
-            out += "<li>" + tr("it can contain the following punctuation: %1").arg(
-#if QT_VERSION < 0x050000
-    Qt::escape(rules.at(6))
-#else
-    rules.at(6).toHtmlEscaped()
-#endif
-        ) + "</li>";
-        if(rules.at(5).toInt() == 0)
-            out += "<li>" + tr("the first character can't be a punctuation") + "</li>";
+        out += tr("Your username must respect these rules:") + "<br><ul>";
+
+        out += "<li>" + tr("is %1 - %2 characters long").arg(rules.at(0)).arg(rules.at(1)) + "</li>";
+        out += "<li>" + tr("can %1 contain lowercase characters").arg((rules.at(2).toInt() > 0) ? "" : tr("NOT")) + "</li>";
+        out += "<li>" + tr("can %1 contain uppercase characters").arg((rules.at(3).toInt() > 0) ? "" : tr("NOT")) + "</li>";
+        out += "<li>" + tr("can %1 contain numeric characters").arg((rules.at(4).toInt() > 0) ? "" : tr("NOT")) + "</li>";
+
+        if (rules.at(6).size() > 0)
+        {   
+            out += "<li>" + tr("can contain the following punctuation: %1").arg(
+                #if QT_VERSION < 0x050000
+                    Qt::escape(rules.at(6))
+                #else
+                    rules.at(6).toHtmlEscaped()
+                #endif
+            ) + "</li>";
+        }
+        
+        out += "<li>" + tr("first character can %1 be a punctuation mark").arg((rules.at(5).toInt() == 0) ? "" : tr("NOT")) + "</li>";
         out += "</ul>";
-    } else {
+    }
+    else
+    {
         out += tr("You may only use A-Z, a-z, 0-9, _, ., and - in your username.");
     }
 

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -307,9 +307,7 @@ void MainWindow::loginError(Response::ResponseCode r, QString reasonStr, quint32
             break;
         }
         case Response::RespUsernameInvalid: {
-            QString errorStr;
-            extractInvalidUsernameMessage(reasonStr, errorStr);
-            QMessageBox::critical(this, tr("Error"), errorStr);
+            QMessageBox::critical(this, tr("Error"), extractInvalidUsernameMessage(reasonStr));
             break;
         }
         case Response::RespRegistrationRequired:
@@ -335,9 +333,9 @@ void MainWindow::loginError(Response::ResponseCode r, QString reasonStr, quint32
     actConnect();
 }
 
-void MainWindow::extractInvalidUsernameMessage(QString & in, QString & out)
+QString MainWindow::extractInvalidUsernameMessage(QString & in)
 {
-    out = tr("Invalid username.") + "<br/>";
+    QString out = tr("Invalid username.") + "<br/>";
     QStringList rules = in.split(QChar('|'));
     if (rules.size() == 7)
     {
@@ -357,12 +355,14 @@ void MainWindow::extractInvalidUsernameMessage(QString & in, QString & out)
     rules.at(6).toHtmlEscaped()
 #endif
         ) + "</li>";
-        if(rules.at(5).toInt() > 0)
+        if(rules.at(5).toInt() == 0)
             out += "<li>" + tr("the first character can't be a punctuation") + "</li>";
         out += "</ul>";
     } else {
         out += tr("You may only use A-Z, a-z, 0-9, _, ., and - in your username.");
     }
+
+    return out;
 }
 
 void MainWindow::registerError(Response::ResponseCode r, QString reasonStr, quint32 endTime)
@@ -396,9 +396,7 @@ void MainWindow::registerError(Response::ResponseCode r, QString reasonStr, quin
             break;
         }
         case Response::RespUsernameInvalid: {
-            QString errorStr;
-            extractInvalidUsernameMessage(reasonStr, errorStr);
-            QMessageBox::critical(this, tr("Error"), errorStr);
+            QMessageBox::critical(this, tr("Error"), extractInvalidUsernameMessage(reasonStr));
             break;
         }
         case Response::RespRegistrationFailed:

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -109,7 +109,7 @@ public:
 protected:
     void closeEvent(QCloseEvent *event);
     void changeEvent(QEvent *event);
-    void extractInvalidUsernameMessage(QString & in, QString & out);
+    QString extractInvalidUsernameMessage(QString & in);
 };
 
 #endif

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -109,6 +109,7 @@ public:
 protected:
     void closeEvent(QCloseEvent *event);
     void changeEvent(QEvent *event);
+    void extractInvalidUsernameMessage(QString & in, QString & out);
 };
 
 #endif

--- a/common/server_database_interface.h
+++ b/common/server_database_interface.h
@@ -25,7 +25,7 @@ public:
     virtual DeckList *getDeckFromDatabase(int /* deckId */, int /* userId */) { return 0; }
     
     virtual qint64 startSession(const QString & /* userName */, const QString & /* address */) { return 0; }
-    virtual bool usernameIsValid(const QString & /*userName */) { return true; };
+    virtual bool usernameIsValid(const QString & /*userName */, QString & /* error */) { return true; };
 public slots:
     virtual void endSession(qint64 /* sessionId */ ) { }
 public:

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -388,7 +388,12 @@ Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd
         }
         case NotLoggedIn: return Response::RespWrongPassword;
         case WouldOverwriteOldSession: return Response::RespWouldOverwriteOldSession;
-        case UsernameInvalid: return Response::RespUsernameInvalid;
+        case UsernameInvalid: {
+            Response_Login *re = new Response_Login;
+            re->set_denied_reason_str(reasonStr.toStdString());
+            rc.setResponseExtension(re);
+            return Response::RespUsernameInvalid;
+        }
         case RegistrationRequired: return Response::RespRegistrationRequired;
         case UserIsInactive: return Response::RespAccountNotActivated;
         default: authState = res;

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -247,8 +247,7 @@ AuthenticationResult Servatrice_DatabaseInterface::checkUserPassword(Server_Prot
         if (!checkSql())
             return UnknownUser;
 
-        QString error;
-        if (!usernameIsValid(user, error))
+        if (!usernameIsValid(user, reasonStr))
             return UsernameInvalid;
         
         if (checkUserIsBanned(handler->getAddress(), user, reasonStr, banSecondsLeft))

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -118,24 +118,29 @@ bool Servatrice_DatabaseInterface::execSqlQuery(QSqlQuery *query)
     return false;
 }
 
-bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user)
+bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user, QString & error)
 {
-    int maxNameLength = settingsCache->value("users/maxnamelength", 12).toInt();
     int minNameLength = settingsCache->value("users/minnamelength", 6).toInt();
+    int maxNameLength = settingsCache->value("users/maxnamelength", 12).toInt();
+    bool allowLowercase = settingsCache->value("users/allowlowercase", true).toBool();
+    bool allowUppercase = settingsCache->value("users/allowuppercase", true).toBool();
+    bool allowNumerics = settingsCache->value("users/allownumerics", true).toBool();
+    bool allowPunctuationPrefix = settingsCache->value("users/allowpunctuationprefix", false).toBool();
+    QString allowedPunctuation = settingsCache->value("users/allowedpunctuation", "_").toString();
+    error = QString("%1|%2|%3|%4|%5|%6|%7").arg(minNameLength).arg(maxNameLength).arg(allowLowercase).arg(allowUppercase).arg(allowNumerics).arg(allowPunctuationPrefix).arg(allowedPunctuation);
+
     if (user.length() < minNameLength || user.length() > maxNameLength)
         return false;
 
-    bool allowPunctuationPrefix = settingsCache->value("users/allowpunctuationprefix", false).toBool();
-    QString allowedPunctuation = settingsCache->value("users/allowedpunctuation", "_").toString();
     if (!allowPunctuationPrefix && allowedPunctuation.contains(user.at(0)))
         return false;
 
     QString regEx("[");
-    if (settingsCache->value("users/allowlowercase", true).toBool())
+    if (allowLowercase)
         regEx.append("a-z");
-    if (settingsCache->value("users/allowuppercase", true).toBool())
+    if (allowUppercase)
         regEx.append("A-Z");
-    if(settingsCache->value("users/allownumerics", true).toBool())
+    if(allowNumerics)
         regEx.append("0-9");
     regEx.append(QRegExp::escape(allowedPunctuation));
     regEx.append("]+");
@@ -242,7 +247,8 @@ AuthenticationResult Servatrice_DatabaseInterface::checkUserPassword(Server_Prot
         if (!checkSql())
             return UnknownUser;
 
-        if (!usernameIsValid(user))
+        QString error;
+        if (!usernameIsValid(user, error))
             return UsernameInvalid;
         
         if (checkUserIsBanned(handler->getAddress(), user, reasonStr, banSecondsLeft))

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -62,7 +62,7 @@ public:
 	void lockSessionTables();
 	void unlockSessionTables();
 	bool userSessionExists(const QString &userName);
-	bool usernameIsValid(const QString &user);
+	bool usernameIsValid(const QString &user, QString & error);
 	bool checkUserIsBanned(const QString &ipAddress, const QString &userName, QString &banReason, int &banSecondsRemaining);
 
 	bool getRequireRegistration();

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -788,8 +788,14 @@ Response::ResponseCode ServerSocketInterface::cmdRegisterAccount(const Command_R
     }
 
     // TODO: Move this method outside of the db interface
-    if (!sqlInterface->usernameIsValid(userName))
+    QString errorString;
+    if (!sqlInterface->usernameIsValid(userName, errorString))
+    {
+        Response_Register *re = new Response_Register;
+        re->set_denied_reason_str(errorString.toStdString());
+        rc.setResponseExtension(re);
         return Response::RespUsernameInvalid;
+    }
 
     if(sqlInterface->userExists(userName))
         return Response::RespUserAlreadyExists;


### PR DESCRIPTION
Addition to #1180.
Fix #1173.

This makes all messages show and appends the word "NOT" if the rule is not allowed.
(i.e. if you can't use numbers it will say "can NOT contain numeric characters")
<img width="428" alt="screenshot 2015-07-03 23 55 46" src="https://cloud.githubusercontent.com/assets/7460172/8506381/1bffa9ee-21df-11e5-9473-c995b727869c.png">

