### PR TITLE
Link FAQ pages

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -274,8 +274,8 @@ void MainWindow::actAbout()
         + "<a href='https://github.com/Cockatrice/Cockatrice/wiki/Translation-FAQ'>" + tr("Help Translate!") + "</a><br><br>"
         + "<b>" + tr("Support:") + "</b><br>"
         + "<a href='https://github.com/Cockatrice/Cockatrice/issues'>" + tr("Report an Issue") + "</a><br>"
-        + "<a href='https://github.com/Cockatrice/Cockatrice/issues'>" + tr("Suggest an Improvement") + "</a><br>"
-        
+        + "<a href='https://github.com/Cockatrice/Cockatrice/wiki/Troubleshooting'>" + tr("Troubleshooting") + "</a><br>"
+        + "<a href='https://github.com/Cockatrice/Cockatrice/wiki/Frequently-Asked-Questions'>" + tr("F.A.Q.") + "</a><br>"
     ));
 }
 


### PR DESCRIPTION
Fix #1057.

This links up the Troubleshooting and FAQ pages in Cockatrice.

Minor change.

<img width="334" alt="screenshot 2015-07-05 20 34 28" src="https://cloud.githubusercontent.com/assets/7460172/8514144/49c0b8ba-2355-11e5-8283-b504a0277794.png">
