### PR TITLE
Mod Global Messaging

### DIFF
--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -171,7 +171,7 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
     {
         // search for the first [ or @
         bracketFirstIndex = message.indexOf('[');
-        mentionFirstIndex = mentionEnabled ? message.indexOf('@') : -1;
+        mentionFirstIndex = message.indexOf('@');
         urlFirstIndex = message.indexOf(urlStarter);
 
         bool startsWithBracket = (bracketFirstIndex != -1);
@@ -298,19 +298,18 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
         }
         else if (index == mentionFirstIndex)
         {
-            if (tabSupervisor->getIsLocalGame())
+            int firstSpace = message.indexOf(" ");
+            QString fullMentionUpToSpaceOrEnd = (firstSpace == -1) ? message.mid(1) : message.mid(1, firstSpace - 1);
+            QString mentionIntact = fullMentionUpToSpaceOrEnd;
+
+            if ((!mentionEnabled && !isModeratorSendingGlobal(userLevel, fullMentionUpToSpaceOrEnd)) || tabSupervisor->getIsLocalGame())
             {
                 cursor.insertText("@");
                 message = message.mid(1);
             }
             else
             {
-
                 QMap<QString, UserListTWI *> userList = tabSupervisor->getUserListsTab()->getAllUsersList()->getUsers();
-
-                int firstSpace = message.indexOf(" ");
-                QString fullMentionUpToSpaceOrEnd = (firstSpace == -1) ? message.mid(1) : message.mid(1, firstSpace - 1);
-                QString mentionIntact = fullMentionUpToSpaceOrEnd;
 
                 do
                 {

--- a/cockatrice/src/chatview.h
+++ b/cockatrice/src/chatview.h
@@ -43,6 +43,7 @@ private:
     QColor getCustomMentionColor();
     bool shouldShowSystemPopup();
     void showSystemPopup(QString &sender);
+    bool isModeratorSendingGlobal(QFlags<ServerInfo_User::UserLevelFlag> userLevelFlag, QString message);
 private slots:
     void openLink(const QUrl &link);
     void actMessageClicked();

--- a/common/pb/serverinfo_user.proto
+++ b/common/pb/serverinfo_user.proto
@@ -1,25 +1,25 @@
 message ServerInfo_User {
-	enum UserLevelFlag {
-        	IsNothing = 0;
-	        IsUser = 1;
-		IsRegistered = 2;
-		IsModerator = 4;
-		IsAdmin = 8;
-	};
-	enum Gender {
-		GenderUnknown = -1;
-		Male = 0;
-		Female = 1;
-	};
-	optional string name = 1;
-	optional uint32 user_level = 2;
-	optional string address = 3;
-	optional string real_name = 4;
-	optional Gender gender = 5 [default = GenderUnknown];
-	optional string country = 6;
-	optional bytes avatar_bmp = 7;
-	optional sint32 id = 8 [default = -1];
-	optional sint32 server_id = 9 [default = -1];
-	optional uint64 session_id = 10;
+    enum UserLevelFlag {
+        IsNothing = 0;
+        IsUser = 1;
+        IsRegistered = 2;
+        IsModerator = 4;
+        IsAdmin = 8;
+    };
+    enum Gender {
+        GenderUnknown = -1;
+        Male = 0;
+        Female = 1;
+    };
+    optional string name = 1;
+    optional uint32 user_level = 2;
+    optional string address = 3;
+    optional string real_name = 4;
+    optional Gender gender = 5 [default = GenderUnknown];
+    optional string country = 6;
+    optional bytes avatar_bmp = 7;
+    optional sint32 id = 8 [default = -1];
+    optional sint32 server_id = 9 [default = -1];
+    optional uint64 session_id = 10;
     optional uint64 accountage_secs = 11;
 }


### PR DESCRIPTION
Fix #1208.

This allows moderators/admins to send a global message to all users on the server by typing `@/all`.
This could be useful to alert all users of something important.

The list is a `QStringList` so we can add more mention phrases in the future, such as `@/unregistered`, for example.

I'm considering overriding the user preferences here and forcing the word to be highlighted & a popup on the desktop to be shown, but I'd like feedback on the idea as a whole and the idea of the override.

<img width="369" alt="screenshot 2015-07-05 22 14 51" src="https://cloud.githubusercontent.com/assets/7460172/8514706/573863fe-2363-11e5-8a22-6a4fb238d0b2.png">
(The `@/all` would highlight for every user on the server, provided a mod/admin sent the msg)