### PR TITLE
Fix Morphs from Sharing Information

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -110,7 +110,7 @@ void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
         QStringList ptDbSplit = db->getCard(name)->getPowTough().split("/");
         QStringList ptSplit = pt.split("/");
         
-        if (ptDbSplit.at(0) != ptSplit.at(0) || ptDbSplit.at(1) != ptSplit.at(1))
+        if (getFaceDown() || ptDbSplit.at(0) != ptSplit.at(0) || ptDbSplit.at(1) != ptSplit.at(1))
             painter->setPen(QColor(255, 150, 0));
         else
             painter->setPen(Qt::white);

--- a/common/server_card.cpp
+++ b/common/server_card.cpp
@@ -126,14 +126,17 @@ void Server_Card::getInfo(ServerInfo_Card *info)
     info->set_name(displayedName.toStdString());
     info->set_x(coord_x);
     info->set_y(coord_y);
+    QString ptStr = getPT();
     if (facedown)
+    {
         info->set_face_down(true);
+        ptStr = getPT();
+    }
     info->set_tapped(tapped);
     if (attacking)
         info->set_attacking(true);
     if (!color.isEmpty())
         info->set_color(color.toStdString());
-    const QString ptStr = getPT();
     if (!ptStr.isEmpty())
         info->set_pt(ptStr.toStdString());
     if (!annotation.isEmpty())


### PR DESCRIPTION
Fix #1126.

This fixes morphs from sharing their information to all clients, server sided.

Left = what you would see; Right = what your opponent would see
<img width="330" alt="screenshot 2015-07-05 23 24 26" src="https://cloud.githubusercontent.com/assets/7460172/8515243/fea57d30-236c-11e5-9744-3a67fe2c77cc.png">

The picture you see above is not fully correct as I made one other small modification. I added back the change I initially made in the client so it will appear orange for you as well, for ascetic purposes.
<img width="213" alt="screenshot 2015-07-05 23 27 02" src="https://cloud.githubusercontent.com/assets/7460172/8515258/5a4fa700-236d-11e5-8e10-ed2adbd0d90b.png">

Credit goes to @Fizztastic for helping me work on the server code.

Feedback is greatly appreciated :smile: 
