### PR TITLE
Prevent Hash Collision

### DIFF
--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -726,12 +726,25 @@ bool DeckList::deleteNode(AbstractDecklistNode *node, InnerDecklistNode *rootNod
 void DeckList::updateDeckHash()
 {
     QStringList cardList;
-    for (int i = 0; i < root->size(); i++) {
+    bool isValidDeckList = true;
+    for (int i = 0; i < root->size(); i++)
+    {
         InnerDecklistNode *node = dynamic_cast<InnerDecklistNode *>(root->at(i));
-        for (int j = 0; j < node->size(); j++) {
+        for (int j = 0; j < node->size(); j++)
+        {
             DecklistCardNode *card = dynamic_cast<DecklistCardNode *>(node->at(j));
             for (int k = 0; k < card->getNumber(); ++k)
-                cardList.append((node->getName() == "side" ? "SB:" : "") + card->getName().toLower());
+            {
+                if (node->getName() == "main" || node->getName() == "side") // Mainboard or Sideboard
+                {
+                    cardList.append((node->getName() == "side" ? "SB:" : "") + card->getName().toLower());
+                }
+                else if (node->getName() != "tokens") // Neither Mainboard, Sideboard, or Tokens... cheater?
+                {
+                    isValidDeckList = false;
+                    break; break; break; // Deck is invalid, end the entire check
+                }
+            }
         }
     }
     cardList.sort();
@@ -741,7 +754,7 @@ void DeckList::updateDeckHash()
                     + (((quint64) (unsigned char) deckHashArray[2] << 16))
                     + (((quint64) (unsigned char) deckHashArray[3]) << 8)
                     + (quint64) (unsigned char) deckHashArray[4];
-    deckHash = QString::number(number, 32).rightJustified(8, '0');
+    deckHash = (isValidDeckList) ? QString::number(number, 32).rightJustified(8, '0') : "INVALID";
     
     emit deckHashChanged();
 }

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -741,8 +741,7 @@ void DeckList::updateDeckHash()
                 }
                 else if (node->getName() != "tokens") // Neither Mainboard, Sideboard, or Tokens... cheater?
                 {
-                    isValidDeckList = false;
-                    break; break; break; // Deck is invalid, end the entire check
+                    isValidDeckList = false; // Deck is invalid
                 }
             }
         }

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -727,6 +727,11 @@ void DeckList::updateDeckHash()
 {
     QStringList cardList;
     bool isValidDeckList = true;
+    static QSet<QString> hashZones, optionalZones;
+
+    hashZones << "main" << "side"; // Zones in deck to be included in hashing process
+    optionalZones << "tokens"; // Optional zones in deck not included in hashing process
+
     for (int i = 0; i < root->size(); i++)
     {
         InnerDecklistNode *node = dynamic_cast<InnerDecklistNode *>(root->at(i));
@@ -735,11 +740,11 @@ void DeckList::updateDeckHash()
             DecklistCardNode *card = dynamic_cast<DecklistCardNode *>(node->at(j));
             for (int k = 0; k < card->getNumber(); ++k)
             {
-                if (node->getName() == "main" || node->getName() == "side") // Mainboard or Sideboard
+                if (hashZones.contains(node->getName())) // Mainboard or Sideboard
                 {
                     cardList.append((node->getName() == "side" ? "SB:" : "") + card->getName().toLower());
                 }
-                else if (node->getName() != "tokens") // Neither Mainboard, Sideboard, or Tokens... cheater?
+                else if (!optionalZones.contains(node->getName())) // Not a valid zone -> cheater?
                 {
                     isValidDeckList = false; // Deck is invalid
                 }

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -727,7 +727,7 @@ void DeckList::updateDeckHash()
 {
     QStringList cardList;
     bool isValidDeckList = true;
-    static QSet<QString> hashZones, optionalZones;
+    QSet<QString> hashZones, optionalZones;
 
     hashZones << "main" << "side"; // Zones in deck to be included in hashing process
     optionalZones << "tokens"; // Optional zones in deck not included in hashing process
@@ -737,17 +737,15 @@ void DeckList::updateDeckHash()
         InnerDecklistNode *node = dynamic_cast<InnerDecklistNode *>(root->at(i));
         for (int j = 0; j < node->size(); j++)
         {
-            DecklistCardNode *card = dynamic_cast<DecklistCardNode *>(node->at(j));
-            for (int k = 0; k < card->getNumber(); ++k)
+            if (hashZones.contains(node->getName())) // Mainboard or Sideboard
             {
-                if (hashZones.contains(node->getName())) // Mainboard or Sideboard
-                {
+                DecklistCardNode *card = dynamic_cast<DecklistCardNode *>(node->at(j));
+                for (int k = 0; k < card->getNumber(); ++k)
                     cardList.append((node->getName() == "side" ? "SB:" : "") + card->getName().toLower());
-                }
-                else if (!optionalZones.contains(node->getName())) // Not a valid zone -> cheater?
-                {
-                    isValidDeckList = false; // Deck is invalid
-                }
+            }
+            else if (!optionalZones.contains(node->getName())) // Not a valid zone -> cheater?
+            {
+                isValidDeckList = false; // Deck is invalid
             }
         }
     }


### PR DESCRIPTION
This is a server-sided & client-sided fix for deck hashes.

It seems that if you add a custom `<zone>` tag, you can eventually create a hash collision.
For example, lets say you want to play 5 extra copies of a card. You can use a new zone with a specific card name (that would have to be bruteforced) to force the hash of the modified deck to be the same as the one with only 4 copies, while actually playing 9.

In addition, this changes how hashing works slightly as tokens are no longer apart of the hashing process. They were in the past, which doesn't really make sense as tokens are added as a convenience and don't change the deck's build.

In the future, we should potentially look into simply rejecting decks that attempt to cause collisions by adding zones not per-approved by the server.

Credit to @Fizztastic for pointing out the exploit to me.