### PR TITLE
Load .cod files from clipboard in deck editor

### DIFF
--- a/cockatrice/src/dlg_load_deck_from_clipboard.cpp
+++ b/cockatrice/src/dlg_load_deck_from_clipboard.cpp
@@ -48,7 +48,20 @@ void DlgLoadDeckFromClipboard::actOK()
     QTextStream stream(&buffer);
     
     DeckLoader *l = new DeckLoader;
-    if (l->loadFromStream_Plain(stream)) {
+    if (buffer.contains("<cockatrice_deck version=\"1\">"))
+    {
+        if (l->loadFromString_Native(buffer))
+        {
+            deckList = l;
+            accept();
+        }
+        else
+        {
+            QMessageBox::critical(this, tr("Error"), tr("Invalid deck list."));
+            delete l;
+        }
+    }
+    else if (l->loadFromStream_Plain(stream)) {
         deckList = l;
         accept();
     } else {


### PR DESCRIPTION
Fix #818

Adds the ability to load .cod (xml) from clipboard.