### PR TITLE
Added 2 shortcuts to game deck screen

### DIFF
--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -124,8 +124,10 @@ DeckViewContainer::DeckViewContainer(int _playerId, TabGame *parent)
 
 void DeckViewContainer::retranslateUi()
 {
-    loadLocalButton->setText(tr("Load &local deck"));
-    loadRemoteButton->setText(tr("Load d&eck from server"));
+    loadLocalButton->setText(tr("Load local deck"));
+    loadLocalButton->setShortcut(QKeySequence("Ctrl+O"));
+    loadRemoteButton->setText(tr("Load deck from server"));
+    loadRemoteButton->setShortcut(QKeySequence("Ctrl+Alt+O"));
     readyStartButton->setText(tr("Ready to s&tart"));
     updateSideboardLockButtonText();
 }


### PR DESCRIPTION
Fix #740 
- Ctrl+O (Load Deck, formally Alt+L)
- Ctrl+Alt+O (Load Remote Deck, formally Alt+E)

If you feel there should be shortcuts for Locking/Unlocking the sideboard (currently Alt+I) and Ready to Start (currently Alt+T) throw some ideas as to what they should be.