### PR TITLE
Oracle: download tokens

### DIFF
--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -108,9 +108,15 @@ bool OracleWizard::saveTokensToFile(const QString & fileName)
 {
     QFile file(fileName);
     if(!file.open(QIODevice::WriteOnly))
+    {
+        qDebug() << "File open (w) failed for" << fileName;
         return false;
+    }
     if(file.write(tokensData) == -1)
+    {
+        qDebug() << "File write (w) failed for" << fileName;
         return false;
+    }
     file.close();
     return true;
 }
@@ -653,7 +659,7 @@ void LoadTokensPage::actDownloadFinishedTokensFile()
         return;
     }
 
-    // save allsets.json url, but only if the user customized it and download was successfull
+    // save tokens.xml url, but only if the user customized it and download was successfull
     if(urlLineEdit->text() != QString(TOKENS_URL))
         wizard()->settings->setValue("tokensurl", urlLineEdit->text());
     else

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -39,6 +39,8 @@
     #define ALLSETS_URL "http://mtgjson.com/json/AllSets.json"
 #endif
 
+#define TOKENS_URL "https://raw.githubusercontent.com/Psithief/Cockatrice-tokens/master/tokens.xml"
+
 
 OracleWizard::OracleWizard(QWidget *parent)
     : QWizard(parent)
@@ -57,6 +59,8 @@ OracleWizard::OracleWizard(QWidget *parent)
     addPage(new IntroPage);
     addPage(new LoadSetsPage);
     addPage(new SaveSetsPage);
+    addPage(new LoadTokensPage);
+    addPage(new SaveTokensPage);
 
     retranslateUi();
 }
@@ -98,6 +102,17 @@ void OracleWizard::disableButtons()
 {
     button(QWizard::NextButton)->setDisabled(true);
     button(QWizard::BackButton)->setDisabled(true);
+}
+
+bool OracleWizard::saveTokensToFile(const QString & fileName)
+{
+    QFile file(fileName);
+    if(!file.open(QIODevice::WriteOnly))
+        return false;
+    if(file.write(tokensData) == -1)
+        return false;
+    file.close();
+    return true;
 }
 
 IntroPage::IntroPage(QWidget *parent)
@@ -520,6 +535,206 @@ bool SaveSetsPage::validatePage()
             QMessageBox::information(this,
               tr("Success"),
               tr("The card database has been saved successfully to\n%1").arg(fileName));
+        } else {
+            QMessageBox::critical(this, tr("Error"), tr("The file could not be saved to %1").arg(fileName));;
+            if (defaultPathCheckBox->isChecked())
+                defaultPathCheckBox->setChecked(false);
+        }
+    } while (!ok);
+
+    return true;
+}
+
+LoadTokensPage::LoadTokensPage(QWidget *parent)
+    : OracleWizardPage(parent), nam(0)
+{
+    urlLabel = new QLabel(this);
+    urlLineEdit = new QLineEdit(this);
+
+    progressLabel = new QLabel(this);
+    progressBar = new QProgressBar(this);
+
+    urlButton = new QPushButton(this);
+    connect(urlButton, SIGNAL(clicked()), this, SLOT(actRestoreDefaultUrl()));
+
+    QGridLayout *layout = new QGridLayout(this);
+    layout->addWidget(urlLabel, 0, 0);
+    layout->addWidget(urlLineEdit, 0, 1);
+    layout->addWidget(urlButton, 1, 1, Qt::AlignRight);
+    layout->addWidget(progressLabel, 2, 0);
+    layout->addWidget(progressBar, 2, 1);
+
+    setLayout(layout);
+}
+
+void LoadTokensPage::initializePage()
+{
+    urlLineEdit->setText(wizard()->settings->value("tokensurl", TOKENS_URL).toString());
+
+    progressLabel->hide();
+    progressBar->hide();
+}
+
+void LoadTokensPage::retranslateUi()
+{
+    setTitle(tr("Tokens source selection"));
+    setSubTitle(tr("Please specify a source for the list of tokens. "
+                   "You can specify an url address that will be download or "
+                   "use an existing file from your computer."));
+
+    urlLabel->setText(tr("Download url:"));
+    urlButton->setText(tr("Restore default url"));
+}
+
+void LoadTokensPage::actRestoreDefaultUrl()
+{
+    urlLineEdit->setText(TOKENS_URL);
+}
+
+bool LoadTokensPage::validatePage()
+{
+    // once the import is finished, we call next(); skip validation
+    if(wizard()->hasTokensData())
+        return true;
+
+    QUrl url = QUrl::fromUserInput(urlLineEdit->text());
+    if(!url.isValid())
+    {
+        QMessageBox::critical(this, tr("Error"), tr("The provided url is not valid."));
+        return false;
+    }
+
+    progressLabel->setText(tr("Downloading (0MB)"));
+    // show an infinite progressbar
+    progressBar->setMaximum(0);
+    progressBar->setMinimum(0);
+    progressBar->setValue(0);
+    progressLabel->show();
+    progressBar->show();
+
+    wizard()->disableButtons();
+    setEnabled(false);
+
+    if(!nam)
+        nam = new QNetworkAccessManager(this);
+    QNetworkReply *reply = nam->get(QNetworkRequest(url));
+
+    connect(reply, SIGNAL(finished()), this, SLOT(actDownloadFinishedTokensFile()));
+    connect(reply, SIGNAL(downloadProgress(qint64, qint64)), this, SLOT(actDownloadProgressTokensFile(qint64, qint64)));
+
+    return false;
+}
+
+void LoadTokensPage::actDownloadProgressTokensFile(qint64 received, qint64 total)
+{
+    if(total > 0)
+    {
+        progressBar->setMaximum(total);
+        progressBar->setValue(received);
+    }
+    progressLabel->setText(tr("Downloading (%1MB)").arg((int) received / 1048576));
+}
+
+void LoadTokensPage::actDownloadFinishedTokensFile()
+{
+    progressLabel->hide();
+    progressBar->hide();
+
+    // check for a reply
+    QNetworkReply *reply = static_cast<QNetworkReply *>(sender());
+    QNetworkReply::NetworkError errorCode = reply->error();
+    if (errorCode != QNetworkReply::NoError) {
+        QMessageBox::critical(this, tr("Error"), tr("Network error: %1.").arg(reply->errorString()));
+
+        wizard()->enableButtons();
+        setEnabled(true);
+
+        reply->deleteLater();
+        return;
+    }
+
+    // save allsets.json url, but only if the user customized it and download was successfull
+    if(urlLineEdit->text() != QString(TOKENS_URL))
+        wizard()->settings->setValue("tokensurl", urlLineEdit->text());
+    else
+        wizard()->settings->remove("tokensurl");
+
+    wizard()->setTokensData(reply->readAll());
+    reply->deleteLater();
+
+    wizard()->enableButtons();
+    setEnabled(true);
+    progressLabel->hide();
+    progressBar->hide();
+
+    wizard()->next();
+}
+
+SaveTokensPage::SaveTokensPage(QWidget *parent)
+    : OracleWizardPage(parent)
+{
+    defaultPathCheckBox = new QCheckBox(this);
+    defaultPathCheckBox->setChecked(true);
+
+    QGridLayout *layout = new QGridLayout(this);
+    layout->addWidget(defaultPathCheckBox, 0, 0);
+
+    setLayout(layout);
+}
+
+void SaveTokensPage::retranslateUi()
+{
+    setTitle(tr("Tokens imported"));
+    setSubTitle(tr("The tokens has been imported. "
+                   "Press \"Save\" to save the imported tokens to the Cockatrice tokens database."));
+
+    defaultPathCheckBox->setText(tr("Save to the default path (recommended)"));
+}
+
+bool SaveTokensPage::validatePage()
+{
+    bool ok = false;
+    const QString dataDir = 
+#if QT_VERSION < 0x050000
+        QDesktopServices::storageLocation(QDesktopServices::DataLocation);
+#else
+        QStandardPaths::standardLocations(QStandardPaths::DataLocation).first();
+#endif
+    QSettings* settings = new QSettings(this);
+    QString defaultPath = settings->value("paths/tokendatabase").toString();
+    QString windowName = tr("Save token database");
+    QString fileType = tr("XML; token database (*.xml)");
+
+    do {
+        QString fileName;
+        if (defaultPath.isEmpty()) {
+            if (defaultPathCheckBox->isChecked())
+                fileName = dataDir + "/tokens.xml";
+            else
+                fileName = QFileDialog::getSaveFileName(this, windowName, dataDir + "/tokens.xml", fileType);
+            settings->setValue("paths/tokendatabase", fileName);
+        }
+        else {
+            if (defaultPathCheckBox->isChecked())
+                fileName = defaultPath;
+            else
+                fileName = QFileDialog::getSaveFileName(this, windowName, defaultPath, fileType);
+        }
+        if (fileName.isEmpty()) {
+            return false;
+        }
+
+        QFileInfo fi(fileName);
+        QDir fileDir(fi.path());
+        if (!fileDir.exists() && !fileDir.mkpath(fileDir.absolutePath())) {
+            return false;
+        }
+        if (wizard()->saveTokensToFile(fileName))
+        {
+            ok = true;
+            QMessageBox::information(this,
+              tr("Success"),
+              tr("The token database has been saved successfully to\n%1").arg(fileName));
         } else {
             QMessageBox::critical(this, tr("Error"), tr("The file could not be saved to %1").arg(fileName));;
             if (defaultPathCheckBox->isChecked())

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -39,7 +39,7 @@
     #define ALLSETS_URL "http://mtgjson.com/json/AllSets.json"
 #endif
 
-#define TOKENS_URL "https://raw.githubusercontent.com/Psithief/Cockatrice-tokens/master/tokens.xml"
+#define TOKENS_URL "https://raw.githubusercontent.com/Cockatrice/Magic-Token/master/tokens.xml"
 
 
 OracleWizard::OracleWizard(QWidget *parent)
@@ -323,7 +323,7 @@ void LoadSetsPage::actDownloadProgressSetsFile(qint64 received, qint64 total)
         progressBar->setMaximum(total);
         progressBar->setValue(received);
     }
-    progressLabel->setText(tr("Downloading (%1MB)").arg((int) received / 1048576));
+    progressLabel->setText(tr("Downloading (%1MB)").arg((int) received / (1024 * 1024)));
 }
 
 void LoadSetsPage::actDownloadFinishedSetsFile()
@@ -638,7 +638,7 @@ void LoadTokensPage::actDownloadProgressTokensFile(qint64 received, qint64 total
         progressBar->setMaximum(total);
         progressBar->setValue(received);
     }
-    progressLabel->setText(tr("Downloading (%1MB)").arg((int) received / 1048576));
+    progressLabel->setText(tr("Downloading (%1MB)").arg((int) received / (1024 * 1024)));
 }
 
 void LoadTokensPage::actDownloadFinishedTokensFile()

--- a/oracle/src/oraclewizard.h
+++ b/oracle/src/oraclewizard.h
@@ -27,6 +27,9 @@ public:
      void enableButtons();
      void disableButtons();
      void retranslateUi();
+     void setTokensData(QByteArray _tokensData) { tokensData = _tokensData; }
+     bool hasTokensData() { return !tokensData.isEmpty(); }
+     bool saveTokensToFile(const QString & fileName);
 public: 
      OracleImporter *importer;
      QSettings * settings;
@@ -35,6 +38,7 @@ private slots:
 private:
     QStringList findQmFiles();
     QString languageName(const QString &qmFile);
+    QByteArray tokensData;
 protected:
     void changeEvent(QEvent *event);
 };
@@ -115,4 +119,38 @@ private slots:
      void updateTotalProgress(int cardsImported, int setIndex, const QString &setName);
 };
 
+class LoadTokensPage : public OracleWizardPage
+{
+     Q_OBJECT
+public:
+     LoadTokensPage(QWidget *parent = 0);
+    void retranslateUi();
+protected:
+     void initializePage();
+     bool validatePage();
+private:
+     QLabel *urlLabel;
+     QLineEdit *urlLineEdit;
+     QPushButton *urlButton;
+     QLabel *progressLabel;
+     QProgressBar * progressBar;
+
+     QNetworkAccessManager *nam;
+private slots:
+     void actRestoreDefaultUrl();
+     void actDownloadProgressTokensFile(qint64 received, qint64 total);
+     void actDownloadFinishedTokensFile();
+};
+
+class SaveTokensPage : public OracleWizardPage
+{
+     Q_OBJECT
+public:
+     SaveTokensPage(QWidget *parent = 0);
+    void retranslateUi();
+private:
+     QCheckBox * defaultPathCheckBox;
+protected:
+     bool validatePage();
+};
 #endif


### PR DESCRIPTION
Fix #915.

After downloading cards and saving them, oracle will now download @Psithief 's token database and save it, too.
I suggest (if Psithief agrees to this change):
 1. creating a new "tokens" repo inside the cockatrice org;
 2. give Psithief commit access to it;
 3. change the default url from his own repo to cockatrice's repo.