### PR TITLE
add shortcut for filter delete

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -323,6 +323,7 @@ void TabDeckEditor::retranslateUi()
     filterBox->setTitle(tr("Filters"));
     aClearFilterAll->setText(tr("&Clear all filters"));
     aClearFilterOne->setText(tr("Delete selected"));
+    aClearFilterOne->setShortcut(QKeySequence("Backspace"));
     
     nameLabel->setText(tr("Deck &name:"));
     commentsLabel->setText(tr("&Comments:"));


### PR DESCRIPTION
This is the final bullet of the ticket, so this fixes #97.

Adds shortcut for deleting filters, the backspace/delete key.