### PR TITLE
show colors of cards

### DIFF
--- a/cockatrice/src/cardframe.cpp
+++ b/cockatrice/src/cardframe.cpp
@@ -9,11 +9,8 @@
 
 #include <QVBoxLayout>
 
-CardFrame::CardFrame(int width, int height,
-                        const QString &cardName, QWidget *parent)
-    : QTabWidget(parent)
-    , info(0)
-    , cardTextOnly(false)
+CardFrame::CardFrame(int width, int height, const QString &cardName, QWidget *parent)
+    : QTabWidget(parent), info(0), cardTextOnly(false)
 {
     setFixedWidth(width);
     setMinimumHeight(height);

--- a/cockatrice/src/cardinfotext.cpp
+++ b/cockatrice/src/cardinfotext.cpp
@@ -8,8 +8,7 @@
 #include "main.h"
 
 CardInfoText::CardInfoText(QWidget *parent)
-    : QFrame(parent)
-    , info(0)
+    : QFrame(parent), info(0)
 {
     nameLabel1 = new QLabel;
     nameLabel2 = new QLabel;
@@ -17,6 +16,9 @@ CardInfoText::CardInfoText(QWidget *parent)
     manacostLabel1 = new QLabel;
     manacostLabel2 = new QLabel;
     manacostLabel2->setWordWrap(true);
+    colorLabel1 = new QLabel;
+    colorLabel2 = new QLabel;
+    colorLabel2->setWordWrap(true);
     cardtypeLabel1 = new QLabel;
     cardtypeLabel2 = new QLabel;
     cardtypeLabel2->setWordWrap(true);
@@ -34,6 +36,8 @@ CardInfoText::CardInfoText(QWidget *parent)
     grid->addWidget(nameLabel2, row++, 1);
     grid->addWidget(manacostLabel1, row, 0);
     grid->addWidget(manacostLabel2, row++, 1);
+    grid->addWidget(colorLabel1, row, 0);
+    grid->addWidget(colorLabel2, row++, 1);
     grid->addWidget(cardtypeLabel1, row, 0);
     grid->addWidget(cardtypeLabel2, row++, 1);
     grid->addWidget(powtoughLabel1, row, 0);
@@ -51,6 +55,7 @@ void CardInfoText::setCard(CardInfo *card)
 {
     nameLabel2->setText(card->getName());
     manacostLabel2->setText(card->getManaCost());
+    colorLabel2->setText(card->getColors().join(""));
     cardtypeLabel2->setText(card->getCardType());
     powtoughLabel2->setText(card->getPowTough());
     loyaltyLabel2->setText(card->getLoyalty() > 0 ? QString::number(card->getLoyalty()) : QString());
@@ -61,6 +66,7 @@ void CardInfoText::retranslateUi()
 {
     nameLabel1->setText(tr("Name:"));
     manacostLabel1->setText(tr("Mana cost:"));
+    colorLabel1->setText(tr("Color(s):"));
     cardtypeLabel1->setText(tr("Card type:"));
     powtoughLabel1->setText(tr("P / T:"));
     loyaltyLabel1->setText(tr("Loyalty:"));

--- a/cockatrice/src/cardinfotext.h
+++ b/cockatrice/src/cardinfotext.h
@@ -13,6 +13,7 @@ class CardInfoText : public QFrame {
 private:
     QLabel *nameLabel1, *nameLabel2;
     QLabel *manacostLabel1, *manacostLabel2;
+    QLabel *colorLabel1, *colorLabel2;
     QLabel *cardtypeLabel1, *cardtypeLabel2;
     QLabel *powtoughLabel1, *powtoughLabel2;
     QLabel *loyaltyLabel1, *loyaltyLabel2;


### PR DESCRIPTION
Fix #242.

This adds the "color" field to all cards in the `Description` and `Both` tabs in game.
<img width="257" alt="screenshot 2015-07-07 23 53 39" src="https://cloud.githubusercontent.com/assets/7460172/8562720/6f431bf0-2503-11e5-9a9f-e704fc6ce171.png">
<img width="257" alt="screenshot 2015-07-07 23 53 46" src="https://cloud.githubusercontent.com/assets/7460172/8562719/6f414848-2503-11e5-845c-3c6b139762b4.png">
