### PR TITLE
Fix user registration query on mysql strict mode; fix #1200

### DIFF
--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -161,7 +161,7 @@ bool Servatrice_DatabaseInterface::registerUser(const QString &userName, const Q
         return false;
 
     QString passwordSha512 = PasswordHasher::computeHash(password, PasswordHasher::generateRandomSalt());
-    token = active ? QString() : PasswordHasher::generateActivationToken();
+    token = active ? QString("") : PasswordHasher::generateActivationToken();
 
     QSqlQuery *query = prepareQuery("insert into {prefix}_users "
             "(name, realname, gender, password_sha512, email, country, registrationDate, active, token) "


### PR DESCRIPTION
Trying to register on a server where user activation is disabled, we could end up trying to insert NULL on the 'token' field of the 'cockatrice_users' table. That field is declared as NOT NULL.
This PR introduces a quick workaround: we'll insert an empty string instead of null.