### PR TITLE
Bold kick msg

### DIFF
--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -73,10 +73,16 @@ void ChatView::appendHtml(const QString &html)
         verticalScrollBar()->setValue(verticalScrollBar()->maximum());
 }
 
-void ChatView::appendHtmlServerMessage(const QString &html)
+void ChatView::appendHtmlServerMessage(const QString &html, bool optionalIsBold, QString optionalFontColor)
 {
     bool atBottom = verticalScrollBar()->value() >= verticalScrollBar()->maximum();
-    prepareBlock().insertHtml("<font color=" + SERVER_MESSAGE_COLOR + ">" + html + "</font>");
+
+    QString htmlText = "<font color=" + ((optionalFontColor.size() > 0) ? optionalFontColor : SERVER_MESSAGE_COLOR) + ">" + html + "</font>";
+
+    if (optionalIsBold)
+        htmlText = "<b>" + htmlText + "</b>";
+
+    prepareBlock().insertHtml(htmlText);
     if (atBottom)
         verticalScrollBar()->setValue(verticalScrollBar()->maximum());
 }

--- a/cockatrice/src/chatview.h
+++ b/cockatrice/src/chatview.h
@@ -51,7 +51,7 @@ public:
     ChatView(const TabSupervisor *_tabSupervisor, TabGame *_game, bool _showTimestamps, QWidget *parent = 0);
     void retranslateUi();
     void appendHtml(const QString &html);
-    void appendHtmlServerMessage(const QString &html);
+    void appendHtmlServerMessage(const QString &html, bool optionalIsBold = false, QString optionalFontColor = QString());
     void appendMessage(QString message, QString sender = QString(), UserLevelFlags userLevel = UserLevelFlags(), bool playerBold = false);
     void clearChat();
 protected:

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -76,7 +76,7 @@ void MessageLogWidget::logGameClosed()
 
 void MessageLogWidget::logKicked()
 {
-    appendHtmlServerMessage(tr("You have been kicked out of the game."));
+    appendHtmlServerMessage(tr("You have been kicked out of the game."), true);
 }
 
 void MessageLogWidget::logJoinSpectator(QString name)


### PR DESCRIPTION
Fix #719

This makes the kick message in games bold and green, so it's more noticeable to the player.

I overloaded the `appendHtmlServerMessage` function so it can be re-used again in the future if we want to change the defaults of any server colors / boldness.

Old:
<img width="268" alt="screenshot 2015-07-11 18 33 26" src="https://cloud.githubusercontent.com/assets/7460172/8635638/54902d2a-27fb-11e5-8f94-cd0e81c318b5.png">

New:
<img width="270" alt="screenshot 2015-07-11 18 28 12" src="https://cloud.githubusercontent.com/assets/7460172/8635637/34423fe0-27fb-11e5-9b8d-d9e41b551ba8.png">
