### PR TITLE
Highlight Custom Words

### DIFF
--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -161,72 +161,116 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
     }
     cursor.setCharFormat(messageFormat);
     
-    int index = -1, bracketFirstIndex = -1, mentionFirstIndex = -1, urlFirstIndex = -1;
+    int index = -1, bracketFirstIndex = -1, mentionFirstIndex = -1, urlFirstIndex = -1, highlightWordFirstIndex = -1, wordFinder = 0;
     bool mentionEnabled = settingsCache->getChatMention();
     const QRegExp urlStarter = QRegExp("https?://|\\bwww\\.");
     const QRegExp phraseEnder = QRegExp("\\s");
     const QRegExp notALetterOrNumber = QRegExp("[^a-zA-Z0-9]");
-    
+    const QStringList highlightedWords = settingsCache->getHighlightWords().trimmed().split(" ");
+    const QStringList fullMessage = message.trimmed().split(" ");
+
     while (message.size())
     {
-        // search for the first [ or @
         bracketFirstIndex = message.indexOf('[');
         mentionFirstIndex = message.indexOf('@');
         urlFirstIndex = message.indexOf(urlStarter);
+        highlightWordFirstIndex = -1;
+
+        for (; wordFinder < fullMessage.size(); ++wordFinder)
+        {
+            if (highlightedWords.contains(removePunctuation(fullMessage.at(wordFinder)), Qt::CaseInsensitive))
+            {
+                highlightWordFirstIndex = message.indexOf(fullMessage.at(wordFinder));
+                ++wordFinder;
+                break;
+            }
+        }
 
         bool startsWithBracket = (bracketFirstIndex != -1);
         bool startsWithAtSymbol = (mentionFirstIndex != -1);
-        bool startsWithUrl = (urlFirstIndex != -1);     
-        
-        if (!startsWithBracket)
+        bool startsWithUrl = (urlFirstIndex != -1);
+        bool startsWithHighlightWord = (highlightWordFirstIndex != -1);
+
+        if (!startsWithBracket && !startsWithAtSymbol && !startsWithUrl && !startsWithHighlightWord)
         {
-            if (!startsWithAtSymbol)
-            {
-                if (!startsWithUrl)
-                {
-                    // No brackets, mentions, or urls. Send message as normal
-                    cursor.insertText(message);
-                    break;
-                }
-                else
-                {
-                    // There's a URL, lets begin!
-                    index = urlFirstIndex;
-                }
-            }
-            else
-            {
-                if (!startsWithUrl)
-                {
-                    // There's an @ symbol, lets begin!
-                    index = mentionFirstIndex;
-                }
-                else
-                {
-                    // There's both an @ symbol and URL, pick the first one... lets begin!
-                    index = std::min(urlFirstIndex, mentionFirstIndex);
-                }
-            }
+            // No functions need to be run. Send message as normal
+            cursor.insertText(message);
+            break;
         }
-        else
+        else if (startsWithBracket && !startsWithAtSymbol && !startsWithUrl && !startsWithHighlightWord)
         {
-            if (!startsWithAtSymbol) 
-            {
-                // There's a [, look down!
-                index = bracketFirstIndex;
-            }
-            else
-            {
-                // There's both a [ and @, pick the first one... look down!
-                index = std::min(bracketFirstIndex, mentionFirstIndex);
-            }
-            
-            if (startsWithUrl)
-            {
-                // If there's a URL, pick the first one... then lets begin!
-                // Otherwise, just "lets begin!"
-                index = std::min(index, urlFirstIndex);
-            }
+            // Contains a bracket
+            index = bracketFirstIndex;
+        }
+        else if (!startsWithBracket && startsWithAtSymbol && !startsWithUrl && !startsWithHighlightWord)
+        {
+            // Contains an @ symbol
+            index = mentionFirstIndex;
+        }
+        else if (!startsWithBracket && !startsWithAtSymbol && startsWithUrl && !startsWithHighlightWord)
+        {
+            // Contains URL stuff (http or www.)
+            index = urlFirstIndex;
+        }
+        else if (!startsWithBracket && !startsWithAtSymbol && !startsWithUrl && startsWithHighlightWord)
+        {
+            // Contains a word the user wants highlighted
+            index = highlightWordFirstIndex;
+        }
+        else if (startsWithBracket && startsWithAtSymbol && !startsWithUrl && !startsWithHighlightWord)
+        {
+            // Contains both a bracket and an @ symbol
+            index = std::min(bracketFirstIndex, mentionFirstIndex);
+        }
+        else if (startsWithBracket && !startsWithAtSymbol && startsWithUrl && !startsWithHighlightWord)
+        {
+            // Contains both a bracket and URL stuff
+            index = std::min(bracketFirstIndex, urlFirstIndex);
+        }
+        else if (startsWithBracket && !startsWithAtSymbol && !startsWithUrl && startsWithHighlightWord)
+        {
+            // Contains both a bracket and a word the user wants highlighted
+            index = std::min(bracketFirstIndex, highlightWordFirstIndex);
+        }
+        else if (!startsWithBracket && startsWithAtSymbol && startsWithUrl && !startsWithHighlightWord)
+        {
+            // Contains both an @ symbol and URL stuff
+            index = std::min(mentionFirstIndex, urlFirstIndex);
+        }
+        else if (!startsWithBracket && startsWithAtSymbol && !startsWithUrl && startsWithHighlightWord)
+        {
+            // Contains both an @ symbol and a word the user wants highlighted
+            index = std::min(mentionFirstIndex, highlightWordFirstIndex);
+        }
+        else if (!startsWithBracket && !startsWithAtSymbol && startsWithUrl && startsWithHighlightWord)
+        {
+            // Contains both URL stuff and a word the user wants highlighted
+            index = std::min(urlFirstIndex, highlightWordFirstIndex);
+        }
+        else if (!startsWithBracket && startsWithAtSymbol && startsWithUrl && startsWithHighlightWord)
+        {
+            // Contains an @ symbol, URL stuff, and a word the user wants highlighted
+            index = std::min(mentionFirstIndex, std::min(urlFirstIndex, highlightWordFirstIndex));
+        }
+        else if (startsWithBracket && !startsWithAtSymbol && startsWithUrl && startsWithHighlightWord)
+        {
+            // Contains a bracket, URL stuff, and a word the user wants highlighted
+            index = std::min(bracketFirstIndex, std::min(urlFirstIndex, highlightWordFirstIndex));
+        }
+        else if (startsWithBracket && startsWithAtSymbol && !startsWithUrl && startsWithHighlightWord)
+        {
+            // Contains a bracket, an @ symbol, and a word the user wants highlighted
+            index = std::min(bracketFirstIndex, std::min(mentionFirstIndex, highlightWordFirstIndex));
+        }
+        else if (startsWithBracket && startsWithAtSymbol && startsWithUrl && !startsWithHighlightWord)
+        {
+            // Contains a bracket, an @ symbol, and URL stuff
+            index = std::min(bracketFirstIndex, std::min(mentionFirstIndex, urlFirstIndex));
+        }
+        else if (startsWithBracket && startsWithAtSymbol && startsWithUrl && startsWithHighlightWord)
+        {
+            // Contains a bracket, an @ symbol, URL stuff, and a word the user wants highlighted
+            index = std::min(highlightWordFirstIndex, std::min(bracketFirstIndex, std::min(mentionFirstIndex, urlFirstIndex)));
         }
 
         if (index > 0)
@@ -279,6 +323,7 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
                 cursor.insertText("[", defaultFormat);
                 message = message.mid(1);
             }
+            wordFinder = 0;
         }
         else if (index == urlFirstIndex) // The message now starts with either: www. , http:// , or https://
         {
@@ -295,6 +340,7 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
                 message.clear();
             else
                 message = message.mid(urlEndIndex);
+            wordFinder = 0;
         }
         else if (index == mentionFirstIndex)
         {
@@ -335,11 +381,11 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
                             UserListTWI *vlu = userList.value(correctUserName);
                             mentionFormatOtherUser.setAnchorHref("user://" + QString::number(vlu->getUserInfo().user_level()) + "_" + correctUserName);
                             cursor.insertText("@" + correctUserName, mentionFormatOtherUser);
-
                             message = message.mid(correctUserName.size() + 1);
                         }
 
                         cursor.setCharFormat(defaultFormat);
+                        wordFinder = 0;
                         break;
                     }
                     else if (isModeratorSendingGlobal(userLevel, fullMentionUpToSpaceOrEnd))
@@ -357,6 +403,7 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
                         }
 
                         cursor.setCharFormat(defaultFormat);
+                        wordFinder = 0;
                         break;
                     }
                     else if (fullMentionUpToSpaceOrEnd.right(1).indexOf(notALetterOrNumber) == -1 || fullMentionUpToSpaceOrEnd.size() < 2)
@@ -364,6 +411,7 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
                         cursor.insertText("@" + mentionIntact, defaultFormat);
                         message = message.mid(mentionIntact.size() + 1);
                         cursor.setCharFormat(defaultFormat);
+                        wordFinder = 0;
                         break;
                     }
                     else
@@ -374,14 +422,43 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
                 while (fullMentionUpToSpaceOrEnd.size());
             }
         }
+        else if (index == highlightWordFirstIndex)
+        {
+            // You have received a valid mention of custom word!!
+            int firstSpace = (message.indexOf(" ") == -1 ? message.size() : message.indexOf(" "));
+            highlightFormat.setBackground(QBrush(getCustomHighlightColor()));
+            highlightFormat.setForeground(settingsCache->getChatHighlightForeground() ? QBrush(Qt::white) : QBrush(Qt::black));
+            cursor.insertText(message.mid(0, firstSpace), highlightFormat);
+            cursor.setCharFormat(defaultFormat);
+            message = message.mid(firstSpace);
+            wordFinder = 0;
+            QApplication::alert(this);
+        }
         else
         {
-            message = message.mid(1); // Not certain when this would ever be reached, but just incase lets skip the character
+            // Not certain when this would ever be reached, but just incase lets skip the character
+            cursor.insertText(message.at(0), defaultFormat);
+            cursor.setCharFormat(defaultFormat);
+            wordFinder = 0;
+            message = message.mid(1);
         }
     }
 
     if (atBottom)
         verticalScrollBar()->setValue(verticalScrollBar()->maximum());
+}
+
+QString ChatView::removePunctuation(QString wordToParse)
+{
+    QString tmp = QString();
+    QStringList acceptablePunctuation;
+    acceptablePunctuation << "." << "_" << "-";
+
+    for (int i = 0; i < wordToParse.size(); i++)
+        if (wordToParse.at(i).isLetterOrNumber() || acceptablePunctuation.contains(wordToParse.at(i)))
+            tmp += wordToParse.at(i);
+
+    return (tmp.size() ? tmp : "");
 }
 
 bool ChatView::isModeratorSendingGlobal(QFlags<ServerInfo_User::UserLevelFlag> userLevelFlag, QString message)
@@ -413,6 +490,12 @@ void ChatView::showSystemPopup(QString &sender) {
 QColor ChatView::getCustomMentionColor() {
     QColor customColor;
     customColor.setNamedColor("#" + settingsCache->getChatMentionColor());
+    return customColor.isValid() ? customColor : DEFAULT_MENTION_COLOR;
+}
+
+QColor ChatView::getCustomHighlightColor() {
+    QColor customColor;
+    customColor.setNamedColor("#" + settingsCache->getChatHighlightColor());
     return customColor.isValid() ? customColor : DEFAULT_MENTION_COLOR;
 }
 

--- a/cockatrice/src/chatview.h
+++ b/cockatrice/src/chatview.h
@@ -27,6 +27,7 @@ private:
     QString userName;
     QString mention;
     QTextCharFormat mentionFormat;
+    QTextCharFormat highlightFormat;
     QTextCharFormat mentionFormatOtherUser;
     QTextCharFormat defaultFormat;
     bool evenNumber;
@@ -41,9 +42,11 @@ private:
     QString getNameFromUserList(QMap<QString, UserListTWI *> &userList, QString &userName);
     bool isFullMentionAValidUser(QMap<QString, UserListTWI *> &userList, QString userNameToMatch);
     QColor getCustomMentionColor();
+    QColor getCustomHighlightColor();
     bool shouldShowSystemPopup();
     void showSystemPopup(QString &sender);
     bool isModeratorSendingGlobal(QFlags<ServerInfo_User::UserLevelFlag> userLevelFlag, QString message);
+    QString removePunctuation(QString wordToParse);
 private slots:
     void openLink(const QUrl &link);
     void actMessageClicked();

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -580,6 +580,9 @@ MessagesSettingsPage::MessagesSettingsPage()
     invertMentionForeground.setChecked(settingsCache->getChatMentionForeground());
     connect(&invertMentionForeground, SIGNAL(stateChanged(int)), this, SLOT(updateTextColor(int)));
 
+    invertHighlightForeground.setChecked(settingsCache->getChatHighlightForeground());
+    connect(&invertHighlightForeground, SIGNAL(stateChanged(int)), this, SLOT(updateTextHighlightColor(int)));
+
     mentionColor = new QLineEdit();
     mentionColor->setText(settingsCache->getChatMentionColor());
     updateMentionPreview();
@@ -590,6 +593,11 @@ MessagesSettingsPage::MessagesSettingsPage()
 
     mentionPopups.setChecked(settingsCache->getShowMentionPopup());
     connect(&mentionPopups, SIGNAL(stateChanged(int)), settingsCache, SLOT(setShowMentionPopups(int)));
+
+    customAlertString = new QLineEdit();
+    customAlertString->setPlaceholderText("Word1 Word2 Word3");
+    customAlertString->setText(settingsCache->getHighlightWords());
+    connect(customAlertString, SIGNAL(textChanged(QString)), settingsCache, SLOT(setHighlightWords(QString)));
 
     QGridLayout *chatGrid = new QGridLayout;
     chatGrid->addWidget(&chatMentionCheckBox, 0, 0);
@@ -602,6 +610,20 @@ MessagesSettingsPage::MessagesSettingsPage()
     chatGrid->addWidget(&mentionPopups, 4, 0);
     chatGroupBox = new QGroupBox;
     chatGroupBox->setLayout(chatGrid);
+    
+    highlightColor = new QLineEdit();
+    highlightColor->setText(settingsCache->getChatHighlightColor());
+    updateHighlightPreview();
+    connect(highlightColor, SIGNAL(textChanged(QString)), this, SLOT(updateHighlightColor(QString)));
+
+    QGridLayout *highlightNotice = new QGridLayout;
+    highlightNotice->addWidget(highlightColor, 0, 2);
+    highlightNotice->addWidget(&invertHighlightForeground, 0, 1);
+    highlightNotice->addWidget(&hexHighlightLabel, 1, 2);
+    highlightNotice->addWidget(customAlertString, 0, 0);
+    highlightNotice->addWidget(&customAlertStringLabel, 1, 0);
+    highlightGroupBox = new QGroupBox;
+    highlightGroupBox->setLayout(highlightNotice);
 
     QSettings settings;
     messageList = new QListWidget;
@@ -628,11 +650,12 @@ MessagesSettingsPage::MessagesSettingsPage()
 
     messageShortcuts = new QGroupBox;
     messageShortcuts->setLayout(messageListLayout);
-    
+
     QVBoxLayout *mainLayout = new QVBoxLayout;
-     
+
     mainLayout->addWidget(messageShortcuts);
     mainLayout->addWidget(chatGroupBox);
+    mainLayout->addWidget(highlightGroupBox);
 
     setLayout(mainLayout);
     
@@ -648,14 +671,33 @@ void MessagesSettingsPage::updateColor(const QString &value) {
     }
 }
 
+void MessagesSettingsPage::updateHighlightColor(const QString &value) {
+    QColor colorToSet;
+    colorToSet.setNamedColor("#" + value);
+    if (colorToSet.isValid()) {
+        settingsCache->setChatHighlightColor(value);
+        updateHighlightPreview();
+    }
+}
+
 void MessagesSettingsPage::updateTextColor(int value) {
     settingsCache->setChatMentionForeground(value);
     updateMentionPreview();
 }
 
+void MessagesSettingsPage::updateTextHighlightColor(int value) {
+    settingsCache->setChatHighlightForeground(value);
+    updateHighlightPreview();
+}
+
 void MessagesSettingsPage::updateMentionPreview() {
-    mentionColor->setStyleSheet("QLineEdit{background:#" + settingsCache->getChatMentionColor() + 
+    mentionColor->setStyleSheet("QLineEdit{background:#" + settingsCache->getChatMentionColor() +
         ";color: " + (settingsCache->getChatMentionForeground() ? "white" : "black") + ";}");
+}
+
+void MessagesSettingsPage::updateHighlightPreview() {
+    highlightColor->setStyleSheet("QLineEdit{background:#" + settingsCache->getChatHighlightColor() +
+        ";color: " + (settingsCache->getChatHighlightForeground() ? "white" : "black") + ";}");
 }
 
 void MessagesSettingsPage::storeSettings()
@@ -688,15 +730,19 @@ void MessagesSettingsPage::actRemove()
 void MessagesSettingsPage::retranslateUi()
 {
     chatGroupBox->setTitle(tr("Chat settings"));
+    highlightGroupBox->setTitle(tr("Custom alert words"));
     chatMentionCheckBox.setText(tr("Enable chat mentions"));
     messageShortcuts->setTitle(tr("In-game message macros"));
     ignoreUnregUsersMainChat.setText(tr("Ignore unregistered users in main chat"));
-    ignoreUnregUsersMainChat.setText(tr("Ignore chat room messages sent by unregistered users."));
-    ignoreUnregUserMessages.setText(tr("Ignore private messages sent by unregistered users."));
+    ignoreUnregUsersMainChat.setText(tr("Ignore chat room messages sent by unregistered users"));
+    ignoreUnregUserMessages.setText(tr("Ignore private messages sent by unregistered users"));
     invertMentionForeground.setText(tr("Invert text color"));
-    messagePopups.setText(tr("Enable desktop notifications for private messages."));
-    mentionPopups.setText(tr("Enable desktop notification for mentions."));
+    invertHighlightForeground.setText(tr("Invert text color"));
+    messagePopups.setText(tr("Enable desktop notifications for private messages"));
+    mentionPopups.setText(tr("Enable desktop notification for mentions"));
     hexLabel.setText(tr("(Color is hexadecimal)"));
+    hexHighlightLabel.setText(tr("(Color is hexadecimal)"));
+    customAlertStringLabel.setText(tr("(Separate each word with a space, words are case insensitive)"));
 }
 
 

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -160,24 +160,33 @@ private slots:
     void actAdd();
     void actRemove();
     void updateColor(const QString &value);
+    void updateHighlightColor(const QString &value);
     void updateTextColor(int value);
+    void updateTextHighlightColor(int value);
 private:
     QListWidget *messageList;
     QAction *aAdd;
     QAction *aRemove;
     QCheckBox chatMentionCheckBox;
     QCheckBox invertMentionForeground;
+    QCheckBox invertHighlightForeground;
     QCheckBox ignoreUnregUsersMainChat;
     QCheckBox ignoreUnregUserMessages;
     QCheckBox messagePopups;
     QCheckBox mentionPopups;
     QGroupBox *chatGroupBox;
+    QGroupBox *highlightGroupBox;
     QGroupBox *messageShortcuts;
     QLineEdit *mentionColor;
+    QLineEdit *customAlertString;
+    QLineEdit *highlightColor;
     QLabel hexLabel;
+    QLabel hexHighlightLabel;
+    QLabel customAlertStringLabel;
 
     void storeSettings();
     void updateMentionPreview();
+    void updateHighlightPreview();
 };
 
 class SoundSettingsPage : public AbstractSettingsPage {

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -56,7 +56,9 @@ SettingsCache::SettingsCache()
     tapAnimation = settings->value("cards/tapanimation", true).toBool();
     chatMention = settings->value("chat/mention", true).toBool();
     chatMentionForeground = settings->value("chat/mentionforeground", true).toBool();
+    chatHighlightForeground = settings->value("chat/highlightforeground", true).toBool();
     chatMentionColor = settings->value("chat/mentioncolor", "A6120D").toString();
+    chatHighlightColor = settings->value("chat/highlightcolor", "A6120D").toString();
 
     zoneViewSortByName = settings->value("zoneview/sortbyname", true).toBool();
     zoneViewSortByType = settings->value("zoneview/sortbytype", true).toBool();
@@ -82,11 +84,18 @@ SettingsCache::SettingsCache()
     masterVolume = settings->value("sound/mastervolume", 100).toInt();
 
     cardInfoViewMode = settings->value("cards/cardinfoviewmode", 0).toInt();
+
+    highlightWords = settings->value("personal/highlightWords", QString()).toString();
 }
 
 void SettingsCache::setCardInfoViewMode(const int _viewMode) {
     cardInfoViewMode = _viewMode;
     settings->setValue("cards/cardinfoviewmode", cardInfoViewMode);
+}
+
+void SettingsCache::setHighlightWords(const QString &_highlightWords) {
+    highlightWords = _highlightWords;
+    settings->setValue("personal/highlightWords", highlightWords);
 }
 
 void SettingsCache::setMasterVolume(int _masterVolume) {
@@ -314,9 +323,19 @@ void SettingsCache::setChatMentionForeground(int _chatMentionForeground) {
     settings->setValue("chat/mentionforeground", chatMentionForeground);
 }
 
+void SettingsCache::setChatHighlightForeground(int _chatHighlightForeground) {
+    chatHighlightForeground = _chatHighlightForeground;
+    settings->setValue("chat/highlightforeground", chatHighlightForeground);
+}
+
 void SettingsCache::setChatMentionColor(const QString &_chatMentionColor) {
     chatMentionColor = _chatMentionColor;
     settings->setValue("chat/mentioncolor", chatMentionColor);
+}
+
+void SettingsCache::setChatHighlightColor(const QString &_chatHighlightColor) {
+    chatHighlightColor = _chatHighlightColor;
+    settings->setValue("chat/highlightcolor", chatHighlightColor);
 }
 
 void SettingsCache::setZoneViewSortByName(int _zoneViewSortByName)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -65,7 +65,9 @@ private:
     bool tapAnimation;
     bool chatMention;
     QString chatMentionColor;
+    QString chatHighlightColor;
     bool chatMentionForeground;
+    bool chatHighlightForeground;
     bool zoneViewSortByName, zoneViewSortByType, zoneViewPileView;
     bool soundEnabled;
     QString soundPath;
@@ -85,6 +87,7 @@ private:
     bool leftJustified;
     int masterVolume;
     int cardInfoViewMode;
+    QString highlightWords;
 public:
     SettingsCache();
     const QByteArray &getMainWindowGeometry() const { return mainWindowGeometry; }
@@ -100,6 +103,7 @@ public:
     QString getPlayerBgPath() const { return playerBgPath; }
     QString getCardBackPicturePath() const { return cardBackPicturePath; }
     QString getChatMentionColor() const { return chatMentionColor; }
+    QString getChatHighlightColor() const { return chatHighlightColor; }
     bool getPicDownload() const { return picDownload; }
     bool getPicDownloadHq() const { return picDownloadHq; }
     bool getNotificationsEnabled() const { return notificationsEnabled; }
@@ -117,6 +121,7 @@ public:
     bool getTapAnimation() const { return tapAnimation; }
     bool getChatMention()  const { return chatMention; }
     bool getChatMentionForeground() const { return chatMentionForeground; }
+    bool getChatHighlightForeground() const { return chatHighlightForeground; }
     bool getZoneViewSortByName() const { return zoneViewSortByName; }
     bool getZoneViewSortByType() const { return zoneViewSortByType; }
     /**
@@ -143,6 +148,7 @@ public:
     int getMasterVolume() const { return masterVolume; }
     int getCardInfoViewMode() const { return cardInfoViewMode; }
     QStringList getCountries() const;
+    QString getHighlightWords() const { return highlightWords; }
 public slots:
     void setMainWindowGeometry(const QByteArray &_mainWindowGeometry);
     void setLang(const QString &_lang);
@@ -157,6 +163,7 @@ public slots:
     void setPlayerBgPath(const QString &_playerBgPath);
     void setCardBackPicturePath(const QString &_cardBackPicturePath);
     void setChatMentionColor(const QString &_chatMentionColor);
+    void setChatHighlightColor(const QString &_chatHighlightColor);
     void setPicDownload(int _picDownload);
     void setPicDownloadHq(int _picDownloadHq);
     void setNotificationsEnabled(int _notificationsEnabled);
@@ -173,6 +180,7 @@ public slots:
     void setTapAnimation(int _tapAnimation);
     void setChatMention(int _chatMention);
     void setChatMentionForeground(int _chatMentionForeground);
+    void setChatHighlightForeground(int _chatHighlightForeground);
     void setZoneViewSortByName(int _zoneViewSortByName);
     void setZoneViewSortByType(int _zoneViewSortByType);
     void setZoneViewPileView(int _zoneViewPileView);
@@ -194,6 +202,7 @@ public slots:
     void setLeftJustified( const int _leftJustified);
     void setMasterVolume(const int _masterVolume);
     void setCardInfoViewMode(const int _viewMode);
+    void setHighlightWords(const QString &_highlightWords);
 };
 
 extern SettingsCache *settingsCache;


### PR DESCRIPTION
Fix #458 

This allows users the option to set words they'd like highlighted to be highlighted, via settings.
<img width="730" alt="screenshot 2015-07-11 22 40 33" src="https://cloud.githubusercontent.com/assets/7460172/8636105/d92f3f72-281d-11e5-808e-826a0d7c207c.png">

The only rules are that words can not contain spaces (duh, as words usually don't have spaces...) & you separate words by a comma. There is a placeHolder if the field is blank, so the user can see an example.

Example in action:
<img width="719" alt="screenshot 2015-07-11 22 40 57" src="https://cloud.githubusercontent.com/assets/7460172/8636108/efc7eb1c-281d-11e5-8a45-7b1ae777fab0.png">
<img width="597" alt="screenshot 2015-07-11 22 41 10" src="https://cloud.githubusercontent.com/assets/7460172/8636107/efc781cc-281d-11e5-8214-d55fd1ba5d9d.png">

___

A concern I have is with the iterations of the `appendMessage` and how they are growing exponentially. We really need to find a new way to do this in the near future, but not in this PR necessarily.

**EDIT:** I fixed the spell of `insensitive` that you see in the pictures. Was rushing a bit.