### PR TITLE
Remember last created game options

### DIFF
--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -47,8 +47,8 @@ void DlgCreateGame::sharedCtor()
         QCheckBox *gameTypeCheckBox = new QCheckBox(gameTypeIterator.value());
         gameTypeLayout->addWidget(gameTypeCheckBox);
         gameTypeCheckBoxes.insert(gameTypeIterator.key(), gameTypeCheckBox);
-        keyText = gameTypeIterator.key();
-        if (settingsCache->getGameTypes().contains(keyText + ",1"))
+        keyText = gameTypeIterator.value();
+        if (settingsCache->getGameTypes().contains(keyText + ",1~"))
             gameTypeCheckBoxes[gameTypeIterator.key()]->setChecked(true);
     }
     QGroupBox *gameTypeGroupBox = new QGroupBox(tr("Game type"));
@@ -110,7 +110,7 @@ void DlgCreateGame::sharedCtor()
 }
 
 DlgCreateGame::DlgCreateGame(TabRoom *_room, const QMap<int, QString> &_gameTypes, QWidget *parent)
-: QDialog(parent), room(_room), gameTypes(_gameTypes)
+    : QDialog(parent), room(_room), gameTypes(_gameTypes)
 {
     sharedCtor();
 
@@ -197,17 +197,15 @@ void DlgCreateGame::actOK()
     cmd.set_spectators_can_talk(spectatorsCanTalkCheckBox->isChecked());
     cmd.set_spectators_see_everything(spectatorsSeeEverythingCheckBox->isChecked());
 
-    static QString gameTypes = QString();
-    QString keyText;
-
+    static QString gameTypes;
+    settingsCache->setGameTypes(gameTypes);
     QMapIterator<int, QCheckBox *> gameTypeCheckBoxIterator(gameTypeCheckBoxes);
     while (gameTypeCheckBoxIterator.hasNext()) {
         gameTypeCheckBoxIterator.next();
         if (gameTypeCheckBoxIterator.value()->isChecked())
         {
             cmd.add_game_type_ids(gameTypeCheckBoxIterator.key());
-            keyText = gameTypeCheckBoxIterator.key();
-            gameTypes += keyText + ",1;";
+            gameTypes += gameTypeCheckBoxIterator.value()->text() + ",1~";
         }
     }
     

--- a/cockatrice/src/dlg_creategame.h
+++ b/cockatrice/src/dlg_creategame.h
@@ -23,6 +23,7 @@ public:
     DlgCreateGame(const ServerInfo_Game &game, const QMap<int, QString> &_gameTypes, QWidget *parent = 0);
 private slots:
     void actOK();
+    void actReset();
     void checkResponse(const Response &response);
     void spectatorsAllowedChanged(int state);
 private:
@@ -37,7 +38,8 @@ private:
     QCheckBox *onlyBuddiesCheckBox, *onlyRegisteredCheckBox;
     QCheckBox *spectatorsAllowedCheckBox, *spectatorsNeedPasswordCheckBox, *spectatorsCanTalkCheckBox, *spectatorsSeeEverythingCheckBox;
     QDialogButtonBox *buttonBox;
-    
+    QPushButton *resetButton;
+
     void sharedCtor();
 };
 

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -46,6 +46,7 @@ SettingsCache::SettingsCache()
     spectatorNotificationsEnabled = settings->value("interface/specnotificationsenabled", false).toBool();
     doubleClickToPlay = settings->value("interface/doubleclicktoplay", true).toBool();
     playToStack = settings->value("interface/playtostack", false).toBool();
+    annotateTokens = settings->value("interface/annotatetokens", false).toBool();
     cardInfoMinimized = settings->value("interface/cardinfominimized", 0).toInt();
     tabGameSplitterSizes = settings->value("interface/tabgame_splittersizes").toByteArray();
     displayCardNames = settings->value("cards/displaycardnames", true).toBool();
@@ -81,6 +82,17 @@ SettingsCache::SettingsCache()
     masterVolume = settings->value("sound/mastervolume", 100).toInt();
 
     cardInfoViewMode = settings->value("cards/cardinfoviewmode", 0).toInt();
+
+    gameDescription = settings->value("game/gamedescription","").toString();
+    maxPlayers = settings->value("game/maxplayers", 2).toInt();
+    gameTypes = settings->value("game/gametypes","").toString();
+    gamePassword = settings->value("game/gamepassword", "").toString();
+    onlyBuddies = settings->value("game/onlybuddies", false).toBool();
+    onlyRegistered = settings->value("game/onlyregistered", true).toBool();
+    spectatorsAllowed = settings->value("game/spectatorsallowed", true).toBool();
+    spectatorsNeedPassword = settings->value("game/spectatorsneedpassword", false).toBool();
+    spectatorsCanTalk = settings->value("game/spectatorscantalk", false).toBool();
+    spectatorsCanSeeEverything = settings->value("game/spectatorscanseeeverything", false).toBool();
 }
 
 void SettingsCache::setCardInfoViewMode(const int _viewMode) {
@@ -251,6 +263,12 @@ void SettingsCache::setPlayToStack(int _playToStack)
     settings->setValue("interface/playtostack", playToStack);
 }
 
+void SettingsCache::setAnnotateTokens(int _annotateTokens)
+{
+    annotateTokens = _annotateTokens;
+    settings->setValue("interface/annotatetokens", annotateTokens);
+}
+
 void SettingsCache::setCardInfoMinimized(int _cardInfoMinimized)
 {
         cardInfoMinimized = _cardInfoMinimized;
@@ -385,4 +403,96 @@ void SettingsCache::setPixmapCacheSize(const int _pixmapCacheSize)
     pixmapCacheSize = _pixmapCacheSize;
     settings->setValue("personal/pixmapCacheSize", pixmapCacheSize);
     emit pixmapCacheSizeChanged(pixmapCacheSize);
+}
+
+QStringList SettingsCache::getCountries() const
+{
+    static QStringList countries = QStringList()
+    << "ad" << "ae" << "af" << "ag" << "ai" << "al" << "am" << "ao" << "aq" << "ar"
+    << "as" << "at" << "au" << "aw" << "ax" << "az" << "ba" << "bb" << "bd" << "be"
+    << "bf" << "bg" << "bh" << "bi" << "bj" << "bl" << "bm" << "bn" << "bo" << "bq"
+    << "br" << "bs" << "bt" << "bv" << "bw" << "by" << "bz" << "ca" << "cc" << "cd" 
+    << "cf" << "cg" << "ch" << "ci" << "ck" << "cl" << "cm" << "cn" << "co" << "cr"
+    << "cu" << "cv" << "cw" << "cx" << "cy" << "cz" << "de" << "dj" << "dk" << "dm"
+    << "do" << "dz" << "ec" << "ee" << "eg" << "eh" << "er" << "es" << "et" << "fi"
+    << "fj" << "fk" << "fm" << "fo" << "fr" << "ga" << "gb" << "gd" << "ge" << "gf"
+    << "gg" << "gh" << "gi" << "gl" << "gm" << "gn" << "gp" << "gq" << "gr" << "gs"
+    << "gt" << "gu" << "gw" << "gy" << "hk" << "hm" << "hn" << "hr" << "ht" << "hu"
+    << "id" << "ie" << "il" << "im" << "in" << "io" << "iq" << "ir" << "is" << "it"
+    << "je" << "jm" << "jo" << "jp" << "ke" << "kg" << "kh" << "ki" << "km" << "kn"
+    << "kp" << "kr" << "kw" << "ky" << "kz" << "la" << "lb" << "lc" << "li" << "lk"
+    << "lr" << "ls" << "lt" << "lu" << "lv" << "ly" << "ma" << "mc" << "md" << "me"
+    << "mf" << "mg" << "mh" << "mk" << "ml" << "mm" << "mn" << "mo" << "mp" << "mq" 
+    << "mr" << "ms" << "mt" << "mu" << "mv" << "mw" << "mx" << "my" << "mz" << "na"
+    << "nc" << "ne" << "nf" << "ng" << "ni" << "nl" << "no" << "np" << "nr" << "nu"
+    << "nz" << "om" << "pa" << "pe" << "pf" << "pg" << "ph" << "pk" << "pl" << "pm" 
+    << "pn" << "pr" << "ps" << "pt" << "pw" << "py" << "qa" << "re" << "ro" << "rs"
+    << "ru" << "rw" << "sa" << "sb" << "sc" << "sd" << "se" << "sg" << "sh" << "si"
+    << "sj" << "sk" << "sl" << "sm" << "sn" << "so" << "sr" << "ss" << "st" << "sv"
+    << "sx" << "sy" << "sz" << "tc" << "td" << "tf" << "tg" << "th" << "tj" << "tk"
+    << "tl" << "tm" << "tn" << "to" << "tr" << "tt" << "tv" << "tw" << "tz" << "ua"
+    << "ug" << "um" << "us" << "uy" << "uz" << "va" << "vc" << "ve" << "vg" << "vi"
+    << "vn" << "vu" << "wf" << "ws" << "ye" << "yt" << "za" << "zm" << "zw";
+
+    return countries;
+}
+
+void SettingsCache::setGameDescription(const QString _gameDescription)
+{
+    gameDescription = _gameDescription;
+    settings->setValue("game/gamedescription", gameDescription);
+}
+
+void SettingsCache::setMaxPlayers(const int _maxPlayers)
+{
+    maxPlayers = _maxPlayers;
+    settings->setValue("game/maxplayers", maxPlayers);
+}
+
+void SettingsCache::setGameTypes(const QString _gameTypes)
+{
+    gameTypes = _gameTypes;
+    settings->setValue("game/gametypes", gameTypes);
+}
+
+void SettingsCache::setGamePassword(const QString _gamePassword)
+{
+    gamePassword = _gamePassword;
+    settings->setValue("game/gamepassword", gamePassword);
+}
+
+void SettingsCache::setOnlyBuddies(const bool _onlyBuddies)
+{
+    onlyBuddies = _onlyBuddies;
+    settings->setValue("game/onlybuddies", onlyBuddies);
+}
+
+void SettingsCache::setOnlyRegistered(const bool _onlyRegistered)
+{
+    onlyRegistered = _onlyRegistered;
+    settings->setValue("game/onlyregistered", onlyRegistered);
+}
+
+void SettingsCache::setSpectatorsAllowed(const bool _spectatorsAllowed)
+{
+    spectatorsAllowed = _spectatorsAllowed;
+    settings->setValue("game/spectatorsallowed", spectatorsAllowed);
+}
+
+void SettingsCache::setSpectatorsNeedPassword(const bool _spectatorsNeedPassword)
+{
+    spectatorsNeedPassword = _spectatorsNeedPassword;
+    settings->setValue("game/spectatorsneedpassword", spectatorsNeedPassword);
+}
+
+void SettingsCache::setSpectatorsCanTalk(const bool _spectatorsCanTalk)
+{
+    spectatorsCanTalk = _spectatorsCanTalk;
+    settings->setValue("game/spectatorscantalk", spectatorsCanTalk);
+}
+
+void SettingsCache::setSpectatorsCanSeeEverything(const bool _spectatorsCanSeeEverything)
+{
+    spectatorsCanSeeEverything = _spectatorsCanSeeEverything;
+    settings->setValue("game/spectatorscanseeeverything", spectatorsCanSeeEverything);
 }

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -2,6 +2,7 @@
 #define SETTINGSCACHE_H
 
 #include <QObject>
+#include <QStringList>
 
 // the falbacks are used for cards without a muid
 #define PIC_URL_DEFAULT "http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!cardid!&type=card"
@@ -54,6 +55,7 @@ private:
     bool spectatorNotificationsEnabled;
     bool doubleClickToPlay;
     bool playToStack;
+    bool annotateTokens;
     int cardInfoMinimized;
     QByteArray tabGameSplitterSizes;
     bool displayCardNames;
@@ -83,6 +85,16 @@ private:
     bool leftJustified;
     int masterVolume;
     int cardInfoViewMode;
+    QString gameDescription;
+    int maxPlayers;
+    QString gameTypes;
+    QString gamePassword;
+    bool onlyBuddies;
+    bool onlyRegistered;
+    bool spectatorsAllowed;
+    bool spectatorsNeedPassword;
+    bool spectatorsCanTalk;
+    bool spectatorsCanSeeEverything;
 public:
     SettingsCache();
     const QByteArray &getMainWindowGeometry() const { return mainWindowGeometry; }
@@ -105,6 +117,7 @@ public:
 
     bool getDoubleClickToPlay() const { return doubleClickToPlay; }
     bool getPlayToStack() const { return playToStack; }
+    bool getAnnotateTokens() const { return annotateTokens; }
     int  getCardInfoMinimized() const { return cardInfoMinimized; }
     QByteArray getTabGameSplitterSizes() const { return tabGameSplitterSizes; }
     bool getDisplayCardNames() const { return displayCardNames; }
@@ -139,6 +152,17 @@ public:
     bool getLeftJustified() const { return leftJustified; }
     int getMasterVolume() const { return masterVolume; }
     int getCardInfoViewMode() const { return cardInfoViewMode; }
+    QStringList getCountries() const;
+    QString getGameDescription() const { return gameDescription; }
+    int getMaxPlayers() const { return maxPlayers; }
+    QString getGameTypes() const { return gameTypes; }
+    QString getGamePassword() const { return gamePassword; }
+    bool getOnlyBuddies() const { return onlyBuddies; }
+    bool getOnlyRegistered() const { return onlyRegistered; }
+    bool getSpectatorsAllowed() const { return spectatorsAllowed; }
+    bool getSpectatorsNeedPassword() const { return spectatorsNeedPassword; }
+    bool getSpectatorsCanTalk() const { return spectatorsCanTalk; }
+    bool getSpectatorsCanSeeEverything() const { return spectatorsCanSeeEverything; }
 public slots:
     void setMainWindowGeometry(const QByteArray &_mainWindowGeometry);
     void setLang(const QString &_lang);
@@ -159,6 +183,7 @@ public slots:
     void setSpectatorNotificationsEnabled(int _spectatorNotificationsEnabled);
     void setDoubleClickToPlay(int _doubleClickToPlay);
     void setPlayToStack(int _playToStack);
+    void setAnnotateTokens(int _annotateTokens);
     void setCardInfoMinimized(int _cardInfoMinimized);
     void setTabGameSplitterSizes(const QByteArray &_tabGameSplitterSizes);
     void setDisplayCardNames(int _displayCardNames);
@@ -189,6 +214,16 @@ public slots:
     void setLeftJustified( const int _leftJustified);
     void setMasterVolume(const int _masterVolume);
     void setCardInfoViewMode(const int _viewMode);
+    void setGameDescription(const QString _gameDescription);
+    void setMaxPlayers(const int _maxPlayers);
+    void setGameTypes(const QString _gameTypes);
+    void setGamePassword(const QString _gamePassword);
+    void setOnlyBuddies(const bool _onlyBuddies);
+    void setOnlyRegistered(const bool _onlyRegistered);
+    void setSpectatorsAllowed(const bool _spectatorsAllowed);
+    void setSpectatorsNeedPassword(const bool _spectatorsNeedPassword);
+    void setSpectatorsCanTalk(const bool _spectatorsCanTalk);
+    void setSpectatorsCanSeeEverything(const bool _spectatorsCanSeeEverything);
 };
 
 extern SettingsCache *settingsCache;


### PR DESCRIPTION
Fix #1069 

- Added a reset button to the create game dialog.
- Saves the settings used for the last created game.