### PR TITLE
require pass & email confirmation

### DIFF
--- a/cockatrice/src/dlg_register.cpp
+++ b/cockatrice/src/dlg_register.cpp
@@ -4,6 +4,7 @@
 #include <QGridLayout>
 #include <QHBoxLayout>
 #include <QDialogButtonBox>
+#include <QMessageBox>
 #include <QDebug>
 
 #include "dlg_register.h"
@@ -33,9 +34,18 @@ DlgRegister::DlgRegister(QWidget *parent)
     passwordLabel->setBuddy(passwordEdit);
     passwordEdit->setEchoMode(QLineEdit::Password);
 
+    passwordConfirmationLabel = new QLabel(tr("Password (again):"));
+    passwordConfirmationEdit = new QLineEdit();
+    passwordConfirmationLabel->setBuddy(passwordConfirmationEdit);
+    passwordConfirmationEdit->setEchoMode(QLineEdit::Password);
+
     emailLabel = new QLabel(tr("Email:"));
     emailEdit = new QLineEdit();
     emailLabel->setBuddy(emailEdit);
+
+    emailConfirmationLabel = new QLabel(tr("Email (again):"));
+    emailConfirmationEdit = new QLineEdit();
+    emailConfirmationLabel->setBuddy(emailConfirmationEdit);
 
     genderLabel = new QLabel(tr("Pronouns:"));
     genderEdit = new QComboBox();
@@ -69,14 +79,18 @@ DlgRegister::DlgRegister(QWidget *parent)
     grid->addWidget(playernameEdit, 2, 1);
     grid->addWidget(passwordLabel, 3, 0);
     grid->addWidget(passwordEdit, 3, 1);
-    grid->addWidget(emailLabel, 4, 0);
-    grid->addWidget(emailEdit, 4, 1);
-    grid->addWidget(genderLabel, 5, 0);
-    grid->addWidget(genderEdit, 5, 1);
-    grid->addWidget(countryLabel, 6, 0);
-    grid->addWidget(countryEdit, 6, 1);
-    grid->addWidget(realnameLabel, 7, 0);
-    grid->addWidget(realnameEdit, 7, 1);
+    grid->addWidget(passwordConfirmationLabel, 4, 0);
+    grid->addWidget(passwordConfirmationEdit, 4, 1);
+    grid->addWidget(emailLabel, 5, 0);
+    grid->addWidget(emailEdit, 5, 1);
+    grid->addWidget(emailConfirmationLabel, 6, 0);
+    grid->addWidget(emailConfirmationEdit, 6, 1);
+    grid->addWidget(genderLabel, 7, 0);
+    grid->addWidget(genderEdit, 7, 1);
+    grid->addWidget(countryLabel, 8, 0);
+    grid->addWidget(countryEdit, 8, 1);
+    grid->addWidget(realnameLabel, 9, 0);
+    grid->addWidget(realnameEdit, 9, 1);
     
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
@@ -94,6 +108,17 @@ DlgRegister::DlgRegister(QWidget *parent)
 
 void DlgRegister::actOk()
 {
+    if (passwordEdit->text() != passwordConfirmationEdit->text())
+    {
+         QMessageBox::critical(this, tr("Registration Warning"), tr("Your passwords do not match, please try again."));
+         return;
+    }
+    else if (emailConfirmationEdit->text() != emailEdit->text())
+    {
+        QMessageBox::critical(this, tr("Registration Warning"), tr("Your email addresses do not match, please try again."));
+        return;
+    }
+
     QSettings settings;
     settings.beginGroup("server");
     settings.setValue("hostname", hostEdit->text());

--- a/cockatrice/src/dlg_register.h
+++ b/cockatrice/src/dlg_register.h
@@ -25,8 +25,8 @@ private slots:
     void actOk();
     void actCancel();
 private:
-    QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *emailLabel, *genderLabel, *countryLabel, *realnameLabel;
-    QLineEdit *hostEdit, *portEdit, *playernameEdit, *passwordEdit, *emailEdit, *realnameEdit;
+    QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *passwordConfirmationLabel, *emailLabel, *emailConfirmationLabel, *genderLabel, *countryLabel, *realnameLabel;
+    QLineEdit *hostEdit, *portEdit, *playernameEdit, *passwordEdit, *passwordConfirmationEdit, *emailEdit, *emailConfirmationEdit, *realnameEdit;
     QComboBox *genderEdit, *countryEdit;
 };
 


### PR DESCRIPTION
Fix #1248 

This adds the requirement for a password/email confirmation, to prevent people from entering the wrong information by accident.

<img width="334" alt="screenshot 2015-07-13 20 31 16" src="https://cloud.githubusercontent.com/assets/7460172/8663873/26cdcd12-299e-11e5-8765-b485e28a0d66.png">
<img width="424" alt="screenshot 2015-07-13 20 30 54" src="https://cloud.githubusercontent.com/assets/7460172/8663872/26cb39c6-299e-11e5-904b-b4ff2f6b8c07.png">
<img width="397" alt="screenshot 2015-07-13 20 30 59" src="https://cloud.githubusercontent.com/assets/7460172/8663874/26ce21b8-299e-11e5-851a-36dad9874dfa.png">
