### PR TITLE
Removed Player Count Debug Line

### DIFF
--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -137,9 +137,6 @@ bool ServerSocketInterface::initSession()
 			delete se;
 			return false;
 		}
-		else {
-			std::cerr << "Player Count: " << playerCount << " / " << userLimit << std::endl;
-		}
 	}
 
     //allow unlimited number of connections from the trusted sources


### PR DESCRIPTION
Removed the output put to console for every logged in user.  It just cluttered things up.