### PR TITLE
Confirmation dialog on close

### DIFF
--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -136,17 +136,20 @@ void TabSupervisor::retranslateUi()
 
 bool TabSupervisor::closeRequest()
 {
-    if (getGameCount()) {
-        if (QMessageBox::question(this, tr("Are you sure?"), tr("There are still open games. Are you sure you want to quit?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::No) {
+    if (getGameCount())
+    {
+        if (QMessageBox::question(this, tr("Are you sure?"), tr("There are still open games. Are you sure you want to quit?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::No)
             return false;
-        }
+    }
+    else
+    {
+        if (QMessageBox::question(this, tr("Close Cockatrice"), tr("Are you sure you want to close Cockatrice?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::No)
+            return false;
     }
 
     foreach(TabDeckEditor *tab,  deckEditorTabs)
-    {
-        if(!tab->confirmClose())
+        if (!tab->confirmClose())
             return false;
-    }
 
     return true;
 }

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -71,7 +71,7 @@ void MainWindow::processConnectionClosedEvent(const Event_ConnectionClosed &even
     client->disconnectFromServer();
     QString reasonStr;
     switch (event.reason()) {
-	case Event_ConnectionClosed::USER_LIMIT_REACHED: reasonStr = tr("The server has reached its maximum user capacity, please check back later."); break;
+        case Event_ConnectionClosed::USER_LIMIT_REACHED: reasonStr = tr("The server has reached its maximum user capacity, please check back later."); break;
         case Event_ConnectionClosed::TOO_MANY_CONNECTIONS: reasonStr = tr("There are too many concurrent connections from your address."); break;
         case Event_ConnectionClosed::BANNED: {
             reasonStr = tr("Banned by moderator");
@@ -632,7 +632,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
 {
     // workaround Qt bug where closeEvent gets called twice
     static bool bClosingDown=false;
-    if(bClosingDown)
+    if (bClosingDown)
         return;
     bClosingDown=true;
 


### PR DESCRIPTION
Fix #982 

This adds a confirmation dialog when you attempt to close the client, either through the red "X" or by `Cockatrice -> Quit`

This works as expected on OS X but needs testing on Linux & Windows.