### PR TITLE
Ignore All PMs

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -576,7 +576,10 @@ MessagesSettingsPage::MessagesSettingsPage()
     ignoreUnregUserMessages.setChecked(settingsCache->getIgnoreUnregisteredUserMessages());
     connect(&ignoreUnregUsersMainChat, SIGNAL(stateChanged(int)), settingsCache, SLOT(setIgnoreUnregisteredUsers(int)));
     connect(&ignoreUnregUserMessages, SIGNAL(stateChanged(int)), settingsCache, SLOT(setIgnoreUnregisteredUserMessages(int)));
-    
+
+    ignoreAllUserMessages.setChecked(settingsCache->getIgnoreAllUserMessages());
+    connect(&ignoreAllUserMessages, SIGNAL(stateChanged(int)), settingsCache, SLOT(setIgnoreAllUserMessages(int)));
+
     invertMentionForeground.setChecked(settingsCache->getChatMentionForeground());
     connect(&invertMentionForeground, SIGNAL(stateChanged(int)), this, SLOT(updateTextColor(int)));
 
@@ -597,9 +600,10 @@ MessagesSettingsPage::MessagesSettingsPage()
     chatGrid->addWidget(mentionColor, 0, 2);
     chatGrid->addWidget(&ignoreUnregUsersMainChat, 1, 0);
     chatGrid->addWidget(&hexLabel, 1, 2);
-    chatGrid->addWidget(&ignoreUnregUserMessages, 2, 0);
-    chatGrid->addWidget(&messagePopups, 3, 0);
-    chatGrid->addWidget(&mentionPopups, 4, 0);
+    chatGrid->addWidget(&ignoreAllUserMessages, 2, 0);
+    chatGrid->addWidget(&ignoreUnregUserMessages, 3, 0);
+    chatGrid->addWidget(&messagePopups, 4, 0);
+    chatGrid->addWidget(&mentionPopups, 5, 0);
     chatGroupBox = new QGroupBox;
     chatGroupBox->setLayout(chatGrid);
 
@@ -693,6 +697,7 @@ void MessagesSettingsPage::retranslateUi()
     ignoreUnregUsersMainChat.setText(tr("Ignore unregistered users in main chat"));
     ignoreUnregUsersMainChat.setText(tr("Ignore chat room messages sent by unregistered users."));
     ignoreUnregUserMessages.setText(tr("Ignore private messages sent by unregistered users."));
+    ignoreAllUserMessages.setText(tr("Ignore all private messages"));
     invertMentionForeground.setText(tr("Invert text color"));
     messagePopups.setText(tr("Enable desktop notifications for private messages."));
     mentionPopups.setText(tr("Enable desktop notification for mentions."));

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -169,6 +169,7 @@ private:
     QCheckBox invertMentionForeground;
     QCheckBox ignoreUnregUsersMainChat;
     QCheckBox ignoreUnregUserMessages;
+    QCheckBox ignoreAllUserMessages;
     QCheckBox messagePopups;
     QCheckBox mentionPopups;
     QGroupBox *chatGroupBox;

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -70,6 +70,7 @@ SettingsCache::SettingsCache()
 
     ignoreUnregisteredUsers = settings->value("chat/ignore_unregistered", false).toBool();
     ignoreUnregisteredUserMessages = settings->value("chat/ignore_unregistered_messages", false).toBool();
+    ignoreAllUserMessages = settings->value("chat/ignore_all_messages", false).toBool();
 
     attemptAutoConnect = settings->value("server/auto_connect", 0).toBool();
 
@@ -373,6 +374,12 @@ void SettingsCache::setIgnoreUnregisteredUserMessages(int _ignoreUnregisteredUse
 {
     ignoreUnregisteredUserMessages = _ignoreUnregisteredUserMessages;
     settings->setValue("chat/ignore_unregistered_messages", ignoreUnregisteredUserMessages);
+}
+
+void SettingsCache::setIgnoreAllUserMessages(int _ignoreAllUserMessages)
+{
+    ignoreAllUserMessages = _ignoreAllUserMessages;
+    settings->setValue("chat/ignore_all_messages", ignoreAllUserMessages);
 }
 
 void SettingsCache::setMainWindowGeometry(const QByteArray &_mainWindowGeometry)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -73,6 +73,7 @@ private:
     int priceTagSource;
     bool ignoreUnregisteredUsers;
     bool ignoreUnregisteredUserMessages;
+    bool ignoreAllUserMessages;
     QString picUrl;
     QString picUrlHq;
     QString picUrlFallback;
@@ -130,6 +131,7 @@ public:
     int getPriceTagSource() const { return priceTagSource; }
     bool getIgnoreUnregisteredUsers() const { return ignoreUnregisteredUsers; }
     bool getIgnoreUnregisteredUserMessages() const { return ignoreUnregisteredUserMessages; }
+    bool getIgnoreAllUserMessages() const { return ignoreAllUserMessages; }
     QString getPicUrl() const { return picUrl; }
     QString getPicUrlHq() const { return picUrlHq; }
     QString getPicUrlFallback() const { return picUrlFallback; }
@@ -182,6 +184,7 @@ public slots:
     void setPriceTagSource(int _priceTagSource);
     void setIgnoreUnregisteredUsers(int _ignoreUnregisteredUsers);
     void setIgnoreUnregisteredUserMessages(int _ignoreUnregisteredUserMessages);
+    void setIgnoreAllUserMessages(int _ignoreAllUserMessages);
     void setPicUrl(const QString &_picUrl);
     void setPicUrlHq(const QString &_picUrlHq);
     void setPicUrlFallback(const QString &_picUrlFallback);


### PR DESCRIPTION
Fix #1250 

This follows the same logic of "Ignore All Unregistered PMs" and applies it to all users, less server staff. The reason server staff are allowed to bypass this check is because the user is blocking PMs in general and it's not against a specific user, and if a staff member needs to speak with them about something, they should have the ability to. A user still has the option to place a staff on ignore, which would then prevent contact.

Tested and works fully as expected, but further testing is welcomed.

What happens when `foo` attempts to send a PM to `bar`:
```
What foo sees:
[hh:mm:ss] foo: Hey bar, what's up!

What bar sees:
```