### PR TITLE
Add colors to popup

### DIFF
--- a/cockatrice/src/cardinfowidget.cpp
+++ b/cockatrice/src/cardinfowidget.cpp
@@ -39,6 +39,9 @@ CardInfoWidget::CardInfoWidget(ResizeMode _mode, const QString &cardName, QWidge
     manacostLabel1 = new QLabel;
     manacostLabel2 = new QLabel;
     manacostLabel2->setWordWrap(true);
+    colorLabel1 = new QLabel;
+    colorLabel2 = new QLabel;
+    colorLabel2->setWordWrap(true);
     cardtypeLabel1 = new QLabel;
     cardtypeLabel2 = new QLabel;
     cardtypeLabel2->setWordWrap(true);
@@ -59,6 +62,8 @@ CardInfoWidget::CardInfoWidget(ResizeMode _mode, const QString &cardName, QWidge
     grid->addWidget(nameLabel2, row++, 1);
     grid->addWidget(manacostLabel1, row, 0);
     grid->addWidget(manacostLabel2, row++, 1);
+    grid->addWidget(colorLabel1, row, 0);
+    grid->addWidget(colorLabel2, row++, 1);
     grid->addWidget(cardtypeLabel1, row, 0);
     grid->addWidget(cardtypeLabel2, row++, 1);
     grid->addWidget(powtoughLabel1, row, 0);
@@ -117,6 +122,8 @@ void CardInfoWidget::setMinimized(int _minimized)
         nameLabel2->setVisible(showAll);
         manacostLabel1->setVisible(showAll);
         manacostLabel2->setVisible(showAll);
+        colorLabel1->setVisible(showAll);
+        colorLabel2->setVisible(showAll);
         cardtypeLabel1->setVisible(showAll);
         cardtypeLabel2->setVisible(showAll);
         powtoughLabel1->setVisible(showPowTough);
@@ -153,6 +160,7 @@ void CardInfoWidget::setCard(CardInfo *card)
     updatePixmap();
     nameLabel2->setText(card->getName());
     manacostLabel2->setText(card->getManaCost());
+    colorLabel2->setText(card->getColors().join(""));
     cardtypeLabel2->setText(card->getCardType());
     powtoughLabel2->setText(card->getPowTough());
     loyaltyLabel2->setText(card->getLoyalty() > 0 ? QString::number(card->getLoyalty()) : QString());
@@ -200,6 +208,7 @@ void CardInfoWidget::retranslateUi()
 {
     nameLabel1->setText(tr("Name:"));
     manacostLabel1->setText(tr("Mana cost:"));
+    colorLabel1->setText(tr("Color(s):"));
     cardtypeLabel1->setText(tr("Card type:"));
     powtoughLabel1->setText(tr("P / T:"));
     loyaltyLabel1->setText(tr("Loyalty:"));

--- a/cockatrice/src/cardinfowidget.h
+++ b/cockatrice/src/cardinfowidget.h
@@ -31,6 +31,7 @@ private:
     QLabel *cardPicture;
     QLabel *nameLabel1, *nameLabel2;
     QLabel *manacostLabel1, *manacostLabel2;
+    QLabel *colorLabel1, *colorLabel2;
     QLabel *cardtypeLabel1, *cardtypeLabel2;
     QLabel *powtoughLabel1, *powtoughLabel2;
     QLabel *loyaltyLabel1, *loyaltyLabel2;


### PR DESCRIPTION
This adds the color field to popups when you call the `[card]` or `[[` tag.

Old:
<img width="367" alt="screenshot 2015-07-15 16 39 26" src="https://cloud.githubusercontent.com/assets/7460172/8709453/3de090c0-2b10-11e5-9ff6-5675af93e22b.png">

New:


<img width="361" alt="screenshot 2015-07-15 16 36 31" src="https://cloud.githubusercontent.com/assets/7460172/8709429/064e5a02-2b10-11e5-9203-9c26334f75e6.png">
