### PR TITLE
Prefer enabled sets when loading images

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -92,7 +92,7 @@ void CardSet::setIsKnown(bool _isknown)
     settings.setValue("isknown", isknown);
 }
 
-class SetList::CompareFunctor {
+class SetList::KeyCompareFunctor {
 public:
     inline bool operator()(CardSet *a, CardSet *b) const
     {
@@ -102,7 +102,39 @@ public:
 
 void SetList::sortByKey()
 {
-    qSort(begin(), end(), CompareFunctor());
+    qSort(begin(), end(), KeyCompareFunctor());
+}
+
+class SetList::EnabledAndKeyCompareFunctor {
+public:
+    inline bool operator()(CardSet *a, CardSet *b) const
+    {
+        if(a->getEnabled())
+        {
+            if(b->getEnabled())
+            {
+                // both enabled: sort by key
+                return a->getSortKey() < b->getSortKey();
+            } else {
+                // only a enabled
+                return true;
+            }
+        } else {
+            if(b->getEnabled())
+            {
+                // only b enabled
+                return false;
+            } else {
+                // both disabled: sort by key
+                return a->getSortKey() < b->getSortKey();
+            }
+        }
+    }
+};
+
+void SetList::sortByEnabledAndKey()
+{
+    qSort(begin(), end(), EnabledAndKeyCompareFunctor());
 }
 
 int SetList::getEnabledSetsNum()
@@ -185,7 +217,7 @@ PictureToLoad::PictureToLoad(CardInfo *_card, bool _hq)
 {
     if (card) {
         sortedSets = card->getSets();
-        sortedSets.sortByKey();
+        sortedSets.sortByEnabledAndKey();
     }
 }
 

--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -889,6 +889,8 @@ void CardDatabase::clearPixmapCache()
     }
     if (noCard)
         noCard->clearPixmapCache();
+
+    QPixmapCache::clear();
 }
 
 void CardDatabase::loadSetsFromXml(QXmlStreamReader &xml)

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -54,8 +54,10 @@ public:
 
 class SetList : public QList<CardSet *> {
 private:
-    class CompareFunctor;
+    class KeyCompareFunctor;
+    class EnabledAndKeyCompareFunctor;
 public:
+    void sortByEnabledAndKey();
     void sortByKey();
     void guessSortKeys();
     void enableAllUnknown();

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -123,6 +123,7 @@ WndSets::~WndSets()
 void WndSets::actSave()
 {
     model->save(db);
+    db->clearPixmapCache();
     QMessageBox::information(this, tr("Success"), tr("The sets database has been saved successfully."));
     close();
 }

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -92,7 +92,7 @@ WndSets::WndSets(QWidget *parent)
 
 
     QLabel *labNotes = new QLabel;
-    labNotes->setText("<b>" + tr("hints:") + "</b>" + "<ul><li>" + tr("Enable the sets that you want to have available in the deck editor") + "</li><li>" + tr("Move sets around to change their order, or click on a column header to sort sets on that field") + "</li><li>" + tr("Sets order decides the source that will be used when loading images for a specific card") + "</li><li>" + tr("Disabled sets will still be used for loading images") + "</li></ul>");
+    labNotes->setText("<b>" + tr("hints:") + "</b>" + "<ul><li>" + tr("Enable the sets that you want to have available in the deck editor") + "</li><li>" + tr("Move sets around to change their order, or click on a column header to sort sets on that field") + "</li><li>" + tr("Sets order decides the source that will be used when loading images for a specific card") + "</li><li>" + tr("Disabled sets will be used for loading images only if all the enabled sets failed") + "</li></ul>");
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actSave()));


### PR DESCRIPTION
fix #1235

This PR changes the behavior used to determine the order sets will be used to load/download card images.
 * before: we used set order, making no distinction if sets were enabled or disabled;
 * after: we first use only enabled sets following their order, and then disabled sets following their order.
