### PR TITLE
Fix misleading error message in servatrice; fix #1275

### DIFF
--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -69,9 +69,12 @@ bool Servatrice_DatabaseInterface::openDatabase()
     if (versionQuery->next()) {
         const int dbversion = versionQuery->value(0).toInt();
         const int expectedversion = DATABASE_SCHEMA_VERSION;
-        if(dbversion != expectedversion)
+        if(dbversion < expectedversion)
         {
             qCritical() << QString("[%1] Error opening database: the database schema version is too old, you need to run the migrations to update it from version %2 to version %3").arg(poolStr).arg(dbversion).arg(expectedversion);
+            return false;
+        } else if(dbversion > expectedversion) {
+            qCritical() << QString("[%1] Error opening database: the database schema version %2 is too new, you need to update servatrice (this servatrice actually uses version %3)").arg(poolStr).arg(dbversion).arg(expectedversion);
             return false;
         }
     } else {


### PR DESCRIPTION
Servatrice will now check if the database version is lower or higher of the expected one and output a more understandable error message.