### PR TITLE
tablezone refactor and cleanup

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2389,6 +2389,7 @@ void Player::setMirrored(bool _mirrored)
 
 void Player::processSceneSizeChange(int newPlayerWidth)
 {
+    // Extend table (and hand, if horizontal) to accomodate the new player width.
     qreal tableWidth = newPlayerWidth - CARD_HEIGHT - 15 - counterAreaWidth - stack->boundingRect().width();
     if (!settingsCache->getHorizontalHand())
         tableWidth -= hand->boundingRect().width();

--- a/cockatrice/src/tablezone.h
+++ b/cockatrice/src/tablezone.h
@@ -20,13 +20,34 @@ signals:
     void sizeChanged();
 
 private:
-    static const int BOX_LINE_WIDTH = 10;
-    static const int PADDING_X  = 35;
-    static const int PADDING_Y = 10;
-    static const int MARGIN_X = 20;
-    static const int MIN_WIDTH = 10 * CARD_WIDTH / 2;
     static const int TABLEROWS = 3;
-    
+
+    /*
+    Margins between table edges and cards, paddings between cards
+    */
+    static const int MARGIN_LEFT = 20;
+    static const int MARGIN_RIGHT = 15;
+    static const int MARGIN_TOP = 10;
+    static const int MARGIN_BOTTOM = 30;
+    static const int PADDING_X  = 35;
+    static const int PADDING_Y = 30;
+
+    /*
+    Minimum width of the table zone including margins.
+    */
+    static const int MIN_WIDTH = MARGIN_LEFT + (5 * CARD_WIDTH) + MARGIN_RIGHT;
+
+    /*
+    Offset sizes when cards are stacked on each other in the grid
+    */
+    static const int STACKED_CARD_OFFSET_X = CARD_WIDTH / 3;
+    static const int STACKED_CARD_OFFSET_Y = PADDING_Y / 3;
+
+    /*
+    Width of the box line drawn in the margin around the active player's area
+    */
+    static const int BOX_LINE_WIDTH = 10;
+
     /*
     Default background color, inactive mask and boarder gradient 
     */
@@ -38,10 +59,14 @@ private:
     /*
        Size and shape variables
      */
-    QMap<int, int> gridPointWidth;
     int width;
     int height;
     int currentMinimumWidth;
+
+    /*
+    Internal cache for widths of stacks of cards by row and column.
+    */
+    QMap<int, int> cardStackWidth;
 
     /*
        Holds any custom background image for the TableZone
@@ -114,11 +139,9 @@ public:
      */
     CardItem *getCardFromCoords(const QPointF &point) const;
 
-    QPointF mapFromGrid(QPoint gridPoint) const;
-    QPoint mapToGrid(const QPointF &mapPoint) const;
     QPointF closestGridPoint(const QPointF &point);
 
-    int clampValidTableRow(const int row);
+    static int clampValidTableRow(const int row);
 
     /**
        Removes a card from view.
@@ -137,7 +160,7 @@ public:
     void resizeToContents();
 
     int getMinimumWidth() const { return currentMinimumWidth; }
-    void setWidth(qreal _width){ prepareGeometryChange(); width = _width;};
+    void setWidth(qreal _width) { prepareGeometryChange(); width = _width; }
     qreal getWidth() const { return width; }
     void setActive(bool _active) { active = _active; update(); }
 
@@ -147,6 +170,22 @@ protected:
 private:
     void paintZoneOutline(QPainter *painter);
     void paintLandDivider(QPainter *painter);
+
+    /*
+    Calculates card stack widths so mapping functions work properly
+    */
+    void computeCardStackWidths();
+
+    /*
+    Mapping functions for points to/from gridpoints.
+    */
+    QPointF mapFromGrid(QPoint gridPoint) const;
+    QPoint mapToGrid(const QPointF &mapPoint) const;
+
+    /*
+    Helper function to create a single key from a card stack location.
+    */
+    int getCardStackMapKey (int x, int y) const { return x + (y * 1000); }
 };
 
 #endif


### PR DESCRIPTION
The tablezone code is pretty difficult to follow in its current state.  Looking ahead to features like #453 I think it made sense to tend to it a bit - more comments, more named constants, fewer magic numbers, refactored the large reorganizeCards() method, etc.

*Functionality should be unchanged* with one small exception:  The previous code was a little liberal with the amount of empty space being allocated to the right of the last card, so I reduced that.  That way the table area stays a little more compact and cards will stay just a little bit larger than before after scaling.

Tested by playing local games (Linux qt4) and by giving test builds to friends (Windows qt5) and playing some network games.  No reports of any unusual behavior. 

This code is pretty fundamental; please code review.