### PR TITLE
Changed app title when logged in

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -440,7 +440,7 @@ void MainWindow::setClientStatusTitle()
         case StatusRegistering: setWindowTitle(appName + " - " + tr("Registering to %1 as %2...").arg(client->peerName()).arg(client->getUserName())); break;
         case StatusDisconnected: setWindowTitle(appName + " - " + tr("Disconnected")); break;
         case StatusLoggingIn: setWindowTitle(appName + " - " + tr("Connected, logging in at %1").arg(client->peerName())); break;
-        case StatusLoggedIn: setWindowTitle(appName + " - " + tr("Logged in as %1 at %2").arg(client->getUserName()).arg(client->peerName())); break;
+        case StatusLoggedIn: setWindowTitle(client->getUserName() + "@" + client->peerName()); break;
         default: setWindowTitle(appName);
     }
 }


### PR DESCRIPTION
As seen in this image, you cant see where you are logged in:

![before](https://cloud.githubusercontent.com/assets/2134793/8908246/5411afa4-347b-11e5-9088-d33369c009d5.png)


How it looks now:

![after](https://cloud.githubusercontent.com/assets/2134793/8908248/56c6dd78-347b-11e5-9d02-149a096e569a.png)

