### PR TITLE
Previous server connection history

### DIFF
--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -1,10 +1,14 @@
 #include <QSettings>
 #include <QLabel>
 #include <QCheckBox>
+#include <QComboBox>
+#include <QRadioButton>
 #include <QGridLayout>
 #include <QHBoxLayout>
 #include <QDialogButtonBox>
 #include <QDebug>
+#include <QEvent>
+#include <QKeyEvent>
 #include <iostream>
 #include "dlg_connect.h"
 
@@ -14,8 +18,24 @@ DlgConnect::DlgConnect(QWidget *parent)
     QSettings settings;
     settings.beginGroup("server");
 
+    previousHostButton = new QRadioButton(tr("Previous Host"), this);
+
+    previousHosts = new QComboBox(this);
+    previousHosts->installEventFilter(new DeleteHighlightedItemWhenShiftDelPressedEventFilter);
+    QStringList previousHostList = settings.value("previoushosts").toStringList();
+    if (previousHostList.isEmpty()) {
+        previousHostList << "cockatrice.woogerworks.com";
+        previousHostList << "vps.poixen.com";
+        previousHostList << "chickatrice.net";
+    }
+    previousHosts->addItems(previousHostList);
+    previousHosts->setCurrentIndex(settings.value("previoushostindex").toInt());
+
+    newHostButton = new QRadioButton(tr("New Host"), this);
+    
     hostLabel = new QLabel(tr("&Host:"));
-    hostEdit = new QLineEdit(settings.value("hostname", "cockatrice.woogerworks.com").toString());
+    hostEdit = new QLineEdit();
+    hostEdit->setPlaceholderText(tr("Enter host name"));
     hostLabel->setBuddy(hostEdit);
 
     portLabel = new QLabel(tr("&Port:"));
@@ -48,16 +68,19 @@ DlgConnect::DlgConnect(QWidget *parent)
     connect(savePasswordCheckBox, SIGNAL(stateChanged(int)), this, SLOT(passwordSaved(int)));
 
     QGridLayout *grid = new QGridLayout;
-    grid->addWidget(hostLabel, 0, 0);
-    grid->addWidget(hostEdit, 0, 1);
-    grid->addWidget(portLabel, 1, 0);
-    grid->addWidget(portEdit, 1, 1);
-    grid->addWidget(playernameLabel, 2, 0);
-    grid->addWidget(playernameEdit, 2, 1);
-    grid->addWidget(passwordLabel, 3, 0);
-    grid->addWidget(passwordEdit, 3, 1);
-    grid->addWidget(savePasswordCheckBox, 4, 0, 1, 2);
-    grid->addWidget(autoConnectCheckBox, 5, 0, 1, 2);
+    grid->addWidget(previousHostButton, 0, 1);
+    grid->addWidget(previousHosts, 1, 1);
+    grid->addWidget(newHostButton, 2, 1);
+    grid->addWidget(hostLabel, 3, 0);
+    grid->addWidget(hostEdit, 3, 1);
+    grid->addWidget(portLabel, 4, 0);
+    grid->addWidget(portEdit, 4, 1);
+    grid->addWidget(playernameLabel, 5, 0);
+    grid->addWidget(playernameEdit, 5, 1);
+    grid->addWidget(passwordLabel, 6, 0);
+    grid->addWidget(passwordEdit, 6, 1);
+    grid->addWidget(savePasswordCheckBox, 7, 0, 1, 2);
+    grid->addWidget(autoConnectCheckBox, 8, 0, 1, 2);
     
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
@@ -71,7 +94,31 @@ DlgConnect::DlgConnect(QWidget *parent)
     setWindowTitle(tr("Connect to server"));
     setFixedHeight(sizeHint().height());
     setMinimumWidth(300);
+
+    connect(previousHostButton, SIGNAL(toggled(bool)), this, SLOT(previousHostSelected(bool)));
+    connect(newHostButton, SIGNAL(toggled(bool)), this, SLOT(newHostSelected(bool)));
+
+    if (settings.value("previoushostlogin", 1).toInt())
+        previousHostButton->setChecked(true);
+    else
+        newHostButton->setChecked(true);
 }
+
+
+void DlgConnect::previousHostSelected(bool state) {
+    if (state) {
+        hostEdit->setDisabled(true);
+        previousHosts->setDisabled(false);
+    }
+}
+
+void DlgConnect::newHostSelected(bool state) {
+    if (state) {
+        hostEdit->setDisabled(false);
+        previousHosts->setDisabled(true);
+    }
+}
+
 
 void DlgConnect::passwordSaved(int state)
 {
@@ -88,15 +135,32 @@ void DlgConnect::actOk()
 {
     QSettings settings;
     settings.beginGroup("server");
-    settings.setValue("hostname", hostEdit->text());
     settings.setValue("port", portEdit->text());
     settings.setValue("playername", playernameEdit->text());
     settings.setValue("password", savePasswordCheckBox->isChecked() ? passwordEdit->text() : QString());
     settings.setValue("save_password", savePasswordCheckBox->isChecked() ? 1 : 0);
     settings.setValue("auto_connect", autoConnectCheckBox->isChecked() ? 1 : 0);
+    settings.setValue("previoushostlogin", previousHostButton->isChecked() ? 1 : 0);
+    
+    QStringList hostList;
+    if (newHostButton->isChecked())
+        if (!hostEdit->text().trimmed().isEmpty())
+            hostList << hostEdit->text();
+    
+    for (int i = 0; i < previousHosts->count(); i++)
+        if(!previousHosts->itemText(i).trimmed().isEmpty())
+            hostList << previousHosts->itemText(i);
+    
+    settings.setValue("previoushosts", hostList);
+    settings.setValue("previoushostindex", previousHosts->currentIndex());
     settings.endGroup();
 
     accept();
+}
+
+
+QString DlgConnect::getHost() const {
+    return previousHostButton->isChecked() ? previousHosts->currentText() : hostEdit->text();
 }
 
 void DlgConnect::actCancel()
@@ -108,4 +172,18 @@ void DlgConnect::actCancel()
     settings.endGroup();
     
     reject();
+}
+
+
+bool DeleteHighlightedItemWhenShiftDelPressedEventFilter::eventFilter(QObject *obj, QEvent *event)
+{
+    if (event->type() == QEvent::KeyPress) {
+        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+        if (keyEvent->key() == Qt::Key_Delete) {
+            QComboBox* combobox = reinterpret_cast<QComboBox *>(obj);
+            combobox->removeItem(combobox->currentIndex());
+            return true;
+        }
+    }
+    return QObject::eventFilter(obj, event);
 }

--- a/cockatrice/src/dlg_connect.h
+++ b/cockatrice/src/dlg_connect.h
@@ -7,12 +7,22 @@
 class QLabel;
 class QPushButton;
 class QCheckBox;
+class QComboBox;
+class QRadioButton;
+
+class DeleteHighlightedItemWhenShiftDelPressedEventFilter : public QObject
+{
+    Q_OBJECT
+protected:
+    bool eventFilter(QObject *obj, QEvent *event);
+};
+
 
 class DlgConnect : public QDialog {
     Q_OBJECT
 public:
     DlgConnect(QWidget *parent = 0);
-    QString getHost() const { return hostEdit->text(); }
+    QString getHost() const;
     int getPort() const { return portEdit->text().toInt(); }
     QString getPlayerName() const { return playernameEdit->text(); }
     QString getPassword() const { return passwordEdit->text(); }
@@ -20,10 +30,14 @@ private slots:
     void actOk();
     void actCancel();
     void passwordSaved(int state);
+    void previousHostSelected(bool state);
+    void newHostSelected(bool state);
 private:
     QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel;
     QLineEdit *hostEdit, *portEdit, *playernameEdit, *passwordEdit;
     QCheckBox *savePasswordCheckBox, *autoConnectCheckBox;
+    QComboBox *previousHosts;
+    QRadioButton *newHostButton, *previousHostButton;
 };
 
 #endif


### PR DESCRIPTION
![newlogin](https://cloud.githubusercontent.com/assets/2134793/8919537/72839822-34c0-11e5-81fb-c91f9b683add.png)


+ able to select previous servers from a list to connect to.
+ remove items from the drop down by selecting them and pressing delete.
+ new hosts will be added to the previous hosts.
+ remembers the last host connected to in the dropdown.
+ default hosts are "cockatrice.woogerworks.com", "vps.poixen.com" and "chickatrice.net"