### PR TITLE
Allow URL redirects for card images

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -448,6 +448,15 @@ void PictureLoader::picDownloadFinished(QNetworkReply *reply)
         qDebug() << "Download failed:" << reply->errorString();
     }
 
+    int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    if (statusCode == 301 || statusCode == 302) {
+        QUrl redirectUrl = reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
+        QNetworkRequest req(redirectUrl);
+        qDebug() << "following redirect:" << cardBeingDownloaded.getCard()->getName() << "Url:" << req.url();
+        networkManager->get(req);
+        return;
+    }
+
     const QByteArray &picData = reply->peek(reply->size()); //peek is used to keep the data in the buffer for use by QImageReader
 
     // check if the image is blacklisted


### PR DESCRIPTION
Fix #1301 

```
Trying to load picture (set:  "ORI"  card:  "Chandra's Ignition" )
Picture NOT found, trying to download (set:  "ORI"  card:  "Chandra's Ignition" )
starting picture download: "Chandra's Ignition" Url: QUrl("http://www.example.com?card=Chandra%27s Ignition&set=ORI")
following redirect: "Chandra's Ignition" Url: QUrl("http://www.example.com/c/chandras_ignition.jpg?m=1436902980")
```

Now follows the redirect for the card and loads appropriately.

Thanks @ctrlaltca for the help