### PR TITLE
Servatrice: do not disclose user emails to clients

### DIFF
--- a/common/serverinfo_user_container.cpp
+++ b/common/serverinfo_user_container.cpp
@@ -38,7 +38,10 @@ ServerInfo_User &ServerInfo_User_Container::copyUserInfo(ServerInfo_User &result
             result.clear_address();
         }
         if (!internalInfo)
+        {
             result.clear_id();
+            result.clear_email();
+        }
         if (!complete)
             result.clear_avatar_bmp();
     }


### PR DESCRIPTION
Currently servatrice sends the user email to all connected clients on join events.
This PR removes the the email address so that it's not disclosed to users.