### PR TITLE
Mod Clear Chat Globally

### DIFF
--- a/cockatrice/src/tab_room.h
+++ b/cockatrice/src/tab_room.h
@@ -20,6 +20,7 @@ class Event_ListGames;
 class Event_JoinRoom;
 class Event_LeaveRoom;
 class Event_RoomSay;
+class Event_RoomClear;
 class GameSelector;
 class Response;
 class PendingCommand;
@@ -45,6 +46,7 @@ private:
     QAction *aLeaveRoom;
     QAction *aOpenChatSettings;
     QAction * aClearChat;
+    QAction * aClearChatMod;
     QString sanitizeHtml(QString dirty) const;
 signals:
     void roomClosing(TabRoom *tab);
@@ -55,6 +57,7 @@ private slots:
     void sayFinished(const Response &response);
     void actLeaveRoom();
     void actClearChat();
+    void actClearChatMod();
     void actOpenChatSettings();
     void addMentionTag(QString mentionTag);
     void focusTab();
@@ -64,6 +67,7 @@ private slots:
     void processJoinRoomEvent(const Event_JoinRoom &event);
     void processLeaveRoomEvent(const Event_LeaveRoom &event);
     void processRoomSayEvent(const Event_RoomSay &event);
+    void processRoomClearEvent(const Event_RoomClear &event);
 public:
     TabRoom(TabSupervisor *_tabSupervisor, AbstractClient *_client, ServerInfo_User *_ownUser, const ServerInfo_Room &info);
     ~TabRoom();

--- a/common/pb/CMakeLists.txt
+++ b/common/pb/CMakeLists.txt
@@ -92,6 +92,7 @@ SET(PROTO_FILES
     event_reveal_cards.proto
     event_roll_die.proto
     event_room_say.proto
+    event_room_clear.proto
     event_server_complete_list.proto
     event_server_identification.proto
     event_server_message.proto

--- a/common/pb/event_room_clear.proto
+++ b/common/pb/event_room_clear.proto
@@ -1,0 +1,8 @@
+import "room_event.proto";
+
+message Event_RoomClear {
+    extend RoomEvent {
+        optional Event_RoomClear ext = 1004;
+    }
+    optional string message = 1;
+}

--- a/common/pb/room_commands.proto
+++ b/common/pb/room_commands.proto
@@ -1,48 +1,56 @@
 message RoomCommand {
-	enum RoomCommandType {
-		LEAVE_ROOM = 1000;
-		ROOM_SAY = 1001;
-		CREATE_GAME = 1002;
-		JOIN_GAME = 1003;
-	}
-	extensions 100 to max;
+    enum RoomCommandType {
+        LEAVE_ROOM = 1000;
+        ROOM_SAY = 1001;
+        CREATE_GAME = 1002;
+        JOIN_GAME = 1003;
+        ROOM_CLEAR = 1004;
+    }
+    extensions 100 to max;
 }
 
 message Command_LeaveRoom {
-	extend RoomCommand {
-		optional Command_LeaveRoom ext = 1000;
-	}
+    extend RoomCommand {
+        optional Command_LeaveRoom ext = 1000;
+    }
 }
 
 message Command_RoomSay {
-	extend RoomCommand {
-		optional Command_RoomSay ext = 1001;
-	}
-	optional string message = 1;
+    extend RoomCommand {
+        optional Command_RoomSay ext = 1001;
+    }
+    optional string message = 1;
 }
 
 message Command_CreateGame {
-	extend RoomCommand {
-		optional Command_CreateGame ext = 1002;
-	}
-	optional string description = 1;
-	optional string password = 2;
-	optional uint32 max_players = 3;
-	optional bool only_buddies = 4;
-	optional bool only_registered = 5;
-	optional bool spectators_allowed = 6;
-	optional bool spectators_need_password = 7;
-	optional bool spectators_can_talk = 8;
-	optional bool spectators_see_everything = 9;
-	repeated uint32 game_type_ids = 10;
+    extend RoomCommand {
+        optional Command_CreateGame ext = 1002;
+    }
+    optional string description = 1;
+    optional string password = 2;
+    optional uint32 max_players = 3;
+    optional bool only_buddies = 4;
+    optional bool only_registered = 5;
+    optional bool spectators_allowed = 6;
+    optional bool spectators_need_password = 7;
+    optional bool spectators_can_talk = 8;
+    optional bool spectators_see_everything = 9;
+    repeated uint32 game_type_ids = 10;
 }
 
 message Command_JoinGame {
-	extend RoomCommand {
-		optional Command_JoinGame ext = 1003;
-	}
-	optional sint32 game_id = 1 [default = -1];
-	optional string password = 2;
-	optional bool spectator = 3;
-	optional bool override_restrictions = 4;
+    extend RoomCommand {
+        optional Command_JoinGame ext = 1003;
+    }
+    optional sint32 game_id = 1 [default = -1];
+    optional string password = 2;
+    optional bool spectator = 3;
+    optional bool override_restrictions = 4;
+}
+
+message Command_RoomClear {
+    extend RoomCommand {
+        optional Command_RoomClear ext = 1004;
+    }
+    optional string message = 1;
 }

--- a/common/pb/room_event.proto
+++ b/common/pb/room_event.proto
@@ -1,10 +1,11 @@
 message RoomEvent {
-	enum RoomEventType {
-		LEAVE_ROOM = 1000;
-		JOIN_ROOM = 1001;
-		ROOM_SAY = 1002;
-		LIST_GAMES = 1003;
-	}
-	optional sint32 room_id = 1;
-	extensions 100 to max;
+    enum RoomEventType {
+        LEAVE_ROOM = 1000;
+        JOIN_ROOM = 1001;
+        ROOM_SAY = 1002;
+        LIST_GAMES = 1003;
+        ROOM_CLEAR = 1004;
+    }
+    optional sint32 room_id = 1;
+    extensions 100 to max;
 }

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -18,6 +18,7 @@
 #include "pb/event_user_message.pb.h"
 #include "pb/event_game_joined.pb.h"
 #include "pb/event_room_say.pb.h"
+#include "pb/event_room_clear.pb.h"
 #include <google/protobuf/descriptor.h>
 
 Server_ProtocolHandler::Server_ProtocolHandler(Server *_server, Server_DatabaseInterface *_databaseInterface, QObject *parent)
@@ -179,6 +180,7 @@ Response::ResponseCode Server_ProtocolHandler::processRoomCommandContainer(const
             case RoomCommand::ROOM_SAY: resp = cmdRoomSay(sc.GetExtension(Command_RoomSay::ext), room, rc); break;
             case RoomCommand::CREATE_GAME: resp = cmdCreateGame(sc.GetExtension(Command_CreateGame::ext), room, rc); break;
             case RoomCommand::JOIN_GAME: resp = cmdJoinGame(sc.GetExtension(Command_JoinGame::ext), room, rc); break;
+            case RoomCommand::ROOM_CLEAR: resp = cmdRoomClear(sc.GetExtension(Command_RoomClear::ext), room, rc); break;
         }
         if (resp != Response::RespOk)
             finalResponseCode = resp;
@@ -597,6 +599,14 @@ Response::ResponseCode Server_ProtocolHandler::cmdRoomSay(const Command_RoomSay 
     room->say(QString::fromStdString(userInfo->name()), msg);
 
     databaseInterface->logMessage(userInfo->id(), QString::fromStdString(userInfo->name()), QString::fromStdString(userInfo->address()), msg, Server_DatabaseInterface::MessageTargetRoom, room->getId(), room->getName());
+
+    return Response::RespOk;
+}
+
+Response::ResponseCode Server_ProtocolHandler::cmdRoomClear(const Command_RoomClear &cmd, Server_Room *room, ResponseContainer & /*rc*/)
+{
+    room->clear();
+    room->say("", "Room Cleared by Moderator");
 
     return Response::RespOk;
 }

--- a/common/server_protocolhandler.h
+++ b/common/server_protocolhandler.h
@@ -37,6 +37,7 @@ class Command_ListRooms;
 class Command_JoinRoom;
 class Command_LeaveRoom;
 class Command_RoomSay;
+class Command_RoomClear;
 class Command_CreateGame;
 class Command_JoinGame;
 
@@ -68,6 +69,7 @@ private:
     Response::ResponseCode cmdListUsers(const Command_ListUsers &cmd, ResponseContainer &rc);
     Response::ResponseCode cmdLeaveRoom(const Command_LeaveRoom &cmd, Server_Room *room, ResponseContainer &rc);
     Response::ResponseCode cmdRoomSay(const Command_RoomSay &cmd, Server_Room *room, ResponseContainer &rc);
+    Response::ResponseCode cmdRoomClear(const Command_RoomClear &cmd, Server_Room *room, ResponseContainer &rc);
     Response::ResponseCode cmdCreateGame(const Command_CreateGame &cmd, Server_Room *room, ResponseContainer &rc);
     Response::ResponseCode cmdJoinGame(const Command_JoinGame &cmd, Server_Room *room, ResponseContainer &rc);
     

--- a/common/server_room.cpp
+++ b/common/server_room.cpp
@@ -9,6 +9,7 @@
 #include "pb/event_leave_room.pb.h"
 #include "pb/event_list_games.pb.h"
 #include "pb/event_room_say.pb.h"
+#include "pb/event_room_clear.pb.h"
 #include "pb/serverinfo_room.pb.h"
 #include <google/protobuf/descriptor.h>
 
@@ -224,12 +225,17 @@ Response::ResponseCode Server_Room::processJoinGameCommand(const Command_JoinGam
     return result;
 }
 
-
 void Server_Room::say(const QString &userName, const QString &s, bool sendToIsl)
 {
     Event_RoomSay event;
     event.set_name(userName.toStdString());
     event.set_message(s.toStdString());
+    sendRoomEvent(prepareRoomEvent(event), sendToIsl);
+}
+
+void Server_Room::clear(bool sendToIsl)
+{
+    Event_RoomClear event;
     sendRoomEvent(prepareRoomEvent(event), sendToIsl);
 }
 

--- a/common/server_room.h
+++ b/common/server_room.h
@@ -70,6 +70,7 @@ public:
     Response::ResponseCode processJoinGameCommand(const Command_JoinGame &cmd, ResponseContainer &rc, Server_AbstractUserInterface *userInterface);
     
     void say(const QString &userName, const QString &s, bool sendToIsl = true);
+    void clear(bool sendToIsl = true);
     
     void addGame(Server_Game *game);
     void removeGame(Server_Game *game);


### PR DESCRIPTION
Fix #506.

This PR allows mods to clear the room's chat for all users in the room.
Server needs to be rebuilt in order for this change to work, as well as new clients.

<img width="440" alt="screenshot 2015-08-02 21 42 15" src="https://cloud.githubusercontent.com/assets/7460172/9029305/609af63e-395f-11e5-98a5-a941a63b9190.png">
<img width="218" alt="screenshot 2015-08-02 21 42 17" src="https://cloud.githubusercontent.com/assets/7460172/9029306/60a01268-395f-11e5-849e-96429d6fe6f9.png">
<img width="406" alt="screenshot 2015-08-02 21 42 20" src="https://cloud.githubusercontent.com/assets/7460172/9029307/60b6acd0-395f-11e5-856c-7a89dac84a2a.png">

I mainly did this as a learning experience, but I figured I'd throw it up here to see others' opinions