### PR TITLE
Fixes issue #1330 : Card description textedit copy shortcut

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -238,7 +238,7 @@ TabDeckEditor::TabDeckEditor(TabSupervisor *_tabSupervisor, QWidget *parent)
     aLoadDeckFromClipboard->setShortcuts(QKeySequence::Paste);
     aSaveDeckToClipboard = new QAction(QString(), this);
     connect(aSaveDeckToClipboard, SIGNAL(triggered()), this, SLOT(actSaveDeckToClipboard()));
-    aSaveDeckToClipboard->setShortcuts(QKeySequence::Copy);
+    aSaveDeckToClipboard->setShortcuts(QKeySequence::Cut);
     aPrintDeck = new QAction(QString(), this);
     aPrintDeck->setShortcuts(QKeySequence::Print);
     connect(aPrintDeck, SIGNAL(triggered()), this, SLOT(actPrintDeck()));


### PR DESCRIPTION
Fixes issue #1330 : Changed "Save deck to clipboard" shorcut to cut secuence because it shadows text edit copy shortcut