### PR TITLE
Client ID Generation

### DIFF
--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
  *   Copyright (C) 2008 by Max-Wilhelm Bruker   *
  *   brukie@gmx.net   *
  *                                                                         *
@@ -32,6 +32,9 @@
 #include <QDesktopServices>
 #include <QDebug>
 #include <QSystemTrayIcon>
+#include "QtNetwork/QNetworkInterface"
+#include <QCryptographicHash>
+
 
 #include "main.h"
 #include "window_main.h"
@@ -95,6 +98,19 @@ bool settingsValid()
         !settingsCache->getDeckPath().isEmpty() &&
         QDir(settingsCache->getPicsPath()).exists() &&
         !settingsCache->getPicsPath().isEmpty();
+}
+
+void generateClientID()
+{
+    QString macList;
+    foreach(QNetworkInterface interface, QNetworkInterface::allInterfaces())
+    {
+        if (interface.hardwareAddress() != "")
+            if (interface.hardwareAddress() != "00:00:00:00:00:00:00:E0")
+                macList += interface.hardwareAddress() + ".";
+    }
+    QString strClientID = QCryptographicHash::hash(macList.toUtf8(), QCryptographicHash::Sha1).toHex().right(15);
+    settingsCache->setClientID(strClientID);
 }
 
 int main(int argc, char *argv[])
@@ -203,6 +219,9 @@ int main(int argc, char *argv[])
 
         QIcon icon(":/resources/appicon.svg");
         ui.setWindowIcon(icon);
+        
+        generateClientID();    //generate the users client id
+        qDebug() << "ClientID In Cache: " << settingsCache->getClientID();
 
         ui.show();
         qDebug("main(): ui.show() finished");

--- a/cockatrice/src/main.h
+++ b/cockatrice/src/main.h
@@ -14,6 +14,7 @@ extern const QString translationPrefix;
 extern QString translationPath;
 
 void installNewTranslator();
+void generateClientID();
 
 bool settingsValid();
 

--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -10,6 +10,7 @@
 #include "pb/response_activate.pb.h"
 #include "pb/server_message.pb.h"
 #include "pb/event_server_identification.pb.h"
+#include "settingscache.h"
 
 static const unsigned int protocolVersion = 14;
 
@@ -108,7 +109,7 @@ void RemoteClient::doLogin()
     Command_Login cmdLogin;
     cmdLogin.set_user_name(userName.toStdString());
     cmdLogin.set_password(password.toStdString());
-
+    cmdLogin.set_clientid(settingsCache->getClientID().toStdString());
     PendingCommand *pend = prepareSessionCommand(cmdLogin);
     connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(loginResponse(Response)));
     sendCommand(pend);
@@ -243,6 +244,7 @@ void RemoteClient::doConnectToServer(const QString &hostname, unsigned int port,
 
     userName = _userName;
     password = _password;
+    QString clientid = settingsCache->getClientID();
     lastHostname = hostname;
     lastPort = port;
 

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -85,9 +85,7 @@ SettingsCache::SettingsCache()
     masterVolume = settings->value("sound/mastervolume", 100).toInt();
 
     cardInfoViewMode = settings->value("cards/cardinfoviewmode", 0).toInt();
-
     highlightWords = settings->value("personal/highlightWords", QString()).toString();
-
     gameDescription = settings->value("game/gamedescription","").toString();
     maxPlayers = settings->value("game/maxplayers", 2).toInt();
     gameTypes = settings->value("game/gametypes","").toString();
@@ -97,6 +95,8 @@ SettingsCache::SettingsCache()
     spectatorsNeedPassword = settings->value("game/spectatorsneedpassword", false).toBool();
     spectatorsCanTalk = settings->value("game/spectatorscantalk", false).toBool();
     spectatorsCanSeeEverything = settings->value("game/spectatorscanseeeverything", false).toBool();
+    clientID = settings->value("personal/clientid", "notset").toString();
+
 }
 
 void SettingsCache::setCardInfoViewMode(const int _viewMode) {
@@ -422,6 +422,12 @@ void SettingsCache::setPixmapCacheSize(const int _pixmapCacheSize)
     pixmapCacheSize = _pixmapCacheSize;
     settings->setValue("personal/pixmapCacheSize", pixmapCacheSize);
     emit pixmapCacheSizeChanged(pixmapCacheSize);
+}
+
+void SettingsCache::setClientID(QString _clientID)
+{
+    clientID = _clientID;
+    settings->setValue("personal/clientid", clientID);
 }
 
 QStringList SettingsCache::getCountries() const

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -79,6 +79,7 @@ private:
     QString picUrlHq;
     QString picUrlFallback;
     QString picUrlHqFallback;
+    QString clientID;
     bool attemptAutoConnect;
     int pixmapCacheSize;
     bool scaleCards;
@@ -169,6 +170,8 @@ public:
     bool getSpectatorsCanTalk() const { return spectatorsCanTalk; }
     bool getSpectatorsCanSeeEverything() const { return spectatorsCanSeeEverything; }
     int getKeepAlive() const { return keepalive; }
+    void setClientID(QString clientID);
+    QString getClientID() { return clientID; }
 public slots:
     void setMainWindowGeometry(const QByteArray &_mainWindowGeometry);
     void setLang(const QString &_lang);

--- a/common/pb/response.proto
+++ b/common/pb/response.proto
@@ -1,58 +1,59 @@
 message Response {
-	enum ResponseCode {
-		RespNotConnected = -1;
-		RespNothing = 0;
-		RespOk = 1;
-		RespNotInRoom = 2;
-		RespInternalError = 3;
-		RespInvalidCommand = 4;
-		RespInvalidData = 5;
-		RespNameNotFound = 6;
-		RespLoginNeeded = 7;
-		RespFunctionNotAllowed = 8;
-		RespGameNotStarted = 9;
-		RespGameFull = 10;
-		RespContextError = 11;
-		RespWrongPassword = 12;
-		RespSpectatorsNotAllowed = 13;
-		RespOnlyBuddies = 14;
-		RespUserLevelTooLow = 15;
-		RespInIgnoreList = 16;
-		RespWouldOverwriteOldSession = 17;
-		RespChatFlood = 18;
-		RespUserIsBanned = 19;
-		RespAccessDenied = 20;
-		RespUsernameInvalid = 21;
-		RespRegistrationRequired = 22;
-		RespRegistrationAccepted = 23; // Server agrees to process client's registration request
-		RespUserAlreadyExists = 24; // Client attempted to register a name which is already registered
-		RespEmailRequiredToRegister = 25; // Server requires email to register accounts but client did not provide one
-		RespTooManyRequests = 26; // Server refused to complete command because client has sent too many too quickly
-		RespPasswordTooShort = 27; // Server requires a decent password
-		RespAccountNotActivated = 28; // Client attempted to log into a registered username but the account hasn't been activated
-		RespRegistrationDisabled = 29; // Server does not allow clients to register
-		RespRegistrationFailed = 30; // Server accepted a reg request but failed to perform the registration
-		RespActivationAccepted = 31; // Server accepted a reg user activation token
-		RespActivationFailed = 32; // Server didn't accept a reg user activation token
-		RespRegistrationAcceptedNeedsActivation = 33; // Server accepted cient registration, but it will need token activation
-	}
-	enum ResponseType {
-		JOIN_ROOM = 1000;
-		LIST_USERS = 1001;
-		GET_GAMES_OF_USER = 1002;
-		GET_USER_INFO = 1003;
-		DUMP_ZONE = 1004;
-		LOGIN = 1005;
-		DECK_LIST = 1006;
-		DECK_DOWNLOAD = 1007;
-		DECK_UPLOAD = 1008;
-		REGISTER = 1009;
-		ACTIVATE = 1010;
-		REPLAY_LIST = 1100;
-		REPLAY_DOWNLOAD = 1101;
-	}
-	required uint64 cmd_id = 1;
-	optional ResponseCode response_code = 2;
-	
-	extensions 100 to max;
+    enum ResponseCode {
+        RespNotConnected = -1;
+        RespNothing = 0;
+        RespOk = 1;
+        RespNotInRoom = 2;
+        RespInternalError = 3;
+        RespInvalidCommand = 4;
+        RespInvalidData = 5;
+        RespNameNotFound = 6;
+        RespLoginNeeded = 7;
+        RespFunctionNotAllowed = 8;
+        RespGameNotStarted = 9;
+        RespGameFull = 10;
+        RespContextError = 11;
+        RespWrongPassword = 12;
+        RespSpectatorsNotAllowed = 13;
+        RespOnlyBuddies = 14;
+        RespUserLevelTooLow = 15;
+        RespInIgnoreList = 16;
+        RespWouldOverwriteOldSession = 17;
+        RespChatFlood = 18;
+        RespUserIsBanned = 19;
+        RespAccessDenied = 20;
+        RespUsernameInvalid = 21;
+        RespRegistrationRequired = 22;
+        RespRegistrationAccepted = 23; // Server agrees to process client's registration request
+        RespUserAlreadyExists = 24; // Client attempted to register a name which is already registered
+        RespEmailRequiredToRegister = 25; // Server requires email to register accounts but client did not provide one
+        RespTooManyRequests = 26; // Server refused to complete command because client has sent too many too quickly
+        RespPasswordTooShort = 27; // Server requires a decent password
+        RespAccountNotActivated = 28; // Client attempted to log into a registered username but the account hasn't been activated
+        RespRegistrationDisabled = 29; // Server does not allow clients to register
+        RespRegistrationFailed = 30; // Server accepted a reg request but failed to perform the registration
+        RespActivationAccepted = 31; // Server accepted a reg user activation token
+        RespActivationFailed = 32; // Server didn't accept a reg user activation token
+        RespRegistrationAcceptedNeedsActivation = 33; // Server accepted cient registration, but it will need token activation
+        RespClientIDRequired = 34; // Server require's client to generate and send its client id before allowing access
+    }
+    enum ResponseType {
+        JOIN_ROOM = 1000;
+        LIST_USERS = 1001;
+        GET_GAMES_OF_USER = 1002;
+        GET_USER_INFO = 1003;
+        DUMP_ZONE = 1004;
+        LOGIN = 1005;
+        DECK_LIST = 1006;
+        DECK_DOWNLOAD = 1007;
+        DECK_UPLOAD = 1008;
+        REGISTER = 1009;
+        ACTIVATE = 1010;
+        REPLAY_LIST = 1100;
+        REPLAY_DOWNLOAD = 1101;
+    }
+    required uint64 cmd_id = 1;
+    optional ResponseCode response_code = 2;
+    
+    extensions 100 to max;
 }

--- a/common/pb/session_commands.proto
+++ b/common/pb/session_commands.proto
@@ -1,157 +1,158 @@
 import "serverinfo_user.proto";
 
 message SessionCommand {
-	enum SessionCommandType {
-		PING = 1000;
-		LOGIN = 1001;
-		MESSAGE = 1002;
-		LIST_USERS = 1003;
-		GET_GAMES_OF_USER = 1004;
-		GET_USER_INFO = 1005;
-		ADD_TO_LIST = 1006;
-		REMOVE_FROM_LIST = 1007;
-		DECK_LIST = 1008;
-		DECK_NEW_DIR = 1009;
-		DECK_DEL_DIR = 1010;
-		DECK_DEL = 1011;
-		DECK_DOWNLOAD = 1012;
-		DECK_UPLOAD = 1013;
-		LIST_ROOMS = 1014;
-		JOIN_ROOM = 1015;
-		REGISTER = 1016;
-		ACTIVATE = 1017;
-		ACCOUNT_EDIT = 1018;
-		ACCOUNT_IMAGE = 1019;
-		ACCOUNT_PASSWORD = 1020;
-		REPLAY_LIST = 1100;
-		REPLAY_DOWNLOAD = 1101;
-		REPLAY_MODIFY_MATCH = 1102;
-		REPLAY_DELETE_MATCH = 1103;
-	}
-	extensions 100 to max;
+    enum SessionCommandType {
+        PING = 1000;
+        LOGIN = 1001;
+        MESSAGE = 1002;
+        LIST_USERS = 1003;
+        GET_GAMES_OF_USER = 1004;
+        GET_USER_INFO = 1005;
+        ADD_TO_LIST = 1006;
+        REMOVE_FROM_LIST = 1007;
+        DECK_LIST = 1008;
+        DECK_NEW_DIR = 1009;
+        DECK_DEL_DIR = 1010;
+        DECK_DEL = 1011;
+        DECK_DOWNLOAD = 1012;
+        DECK_UPLOAD = 1013;
+        LIST_ROOMS = 1014;
+        JOIN_ROOM = 1015;
+        REGISTER = 1016;
+        ACTIVATE = 1017;
+        ACCOUNT_EDIT = 1018;
+        ACCOUNT_IMAGE = 1019;
+        ACCOUNT_PASSWORD = 1020;
+        REPLAY_LIST = 1100;
+        REPLAY_DOWNLOAD = 1101;
+        REPLAY_MODIFY_MATCH = 1102;
+        REPLAY_DELETE_MATCH = 1103;
+    }
+    extensions 100 to max;
 }
 
 message Command_Ping {
-	extend SessionCommand {
-		optional Command_Ping ext = 1000;
-	}
+    extend SessionCommand {
+        optional Command_Ping ext = 1000;
+    }
 }
 
 message Command_Login {
-	extend SessionCommand {
-		optional Command_Login ext = 1001;
-	}
-	optional string user_name = 1;
-	optional string password = 2;
+    extend SessionCommand {
+        optional Command_Login ext = 1001;
+    }
+    optional string user_name = 1;
+    optional string password = 2;
+    optional string clientid = 3;
 }
 
 message Command_Message {
-	extend SessionCommand {
-		optional Command_Message ext = 1002;
-	}
-	optional string user_name = 1;
-	optional string message = 2;
+    extend SessionCommand {
+        optional Command_Message ext = 1002;
+    }
+    optional string user_name = 1;
+    optional string message = 2;
 }
 
 message Command_ListUsers {
-	extend SessionCommand {
-		optional Command_ListUsers ext = 1003;
-	}
+    extend SessionCommand {
+        optional Command_ListUsers ext = 1003;
+    }
 }
 
 message Command_GetGamesOfUser {
-	extend SessionCommand {
-		optional Command_GetGamesOfUser ext = 1004;
-	}
-	optional string user_name = 1;
+    extend SessionCommand {
+        optional Command_GetGamesOfUser ext = 1004;
+    }
+    optional string user_name = 1;
 }
 
 message Command_GetUserInfo {
-	extend SessionCommand {
-		optional Command_GetUserInfo ext = 1005;
-	}
-	optional string user_name = 1;
+    extend SessionCommand {
+        optional Command_GetUserInfo ext = 1005;
+    }
+    optional string user_name = 1;
 }
 
 message Command_AddToList {
-	extend SessionCommand {
-		optional Command_AddToList ext = 1006;
-	}
-	optional string list = 1;
-	optional string user_name = 2;
+    extend SessionCommand {
+        optional Command_AddToList ext = 1006;
+    }
+    optional string list = 1;
+    optional string user_name = 2;
 }
 
 message Command_RemoveFromList {
-	extend SessionCommand {
-		optional Command_RemoveFromList ext = 1007;
-	}
-	optional string list = 1;
-	optional string user_name = 2;
+    extend SessionCommand {
+        optional Command_RemoveFromList ext = 1007;
+    }
+    optional string list = 1;
+    optional string user_name = 2;
 }
 
 message Command_ListRooms {
-	extend SessionCommand {
-		optional Command_ListRooms ext = 1014;
-	}
+    extend SessionCommand {
+        optional Command_ListRooms ext = 1014;
+    }
 }
 
 message Command_JoinRoom {
-	extend SessionCommand {
-		optional Command_JoinRoom ext = 1015;
-	}
-	optional uint32 room_id = 1;
+    extend SessionCommand {
+        optional Command_JoinRoom ext = 1015;
+    }
+    optional uint32 room_id = 1;
 }
 
 // User wants to register a new account
 message Command_Register {
-	extend SessionCommand {
-		optional Command_Register ext = 1016;
-	}
-	// User name client wants to register
-	required string user_name = 1;
-	// Hashed password to be inserted into database
-	required string password = 2;
-	// Email address of the client for user validation
-	optional string email = 3;
-	// Gender of the user
-	optional ServerInfo_User.Gender gender = 4;
-	// Country code of the user. 2 letter ISO format
-	optional string country = 5;
-	optional string real_name = 6;
+    extend SessionCommand {
+        optional Command_Register ext = 1016;
+    }
+    // User name client wants to register
+    required string user_name = 1;
+    // Hashed password to be inserted into database
+    required string password = 2;
+    // Email address of the client for user validation
+    optional string email = 3;
+    // Gender of the user
+    optional ServerInfo_User.Gender gender = 4;
+    // Country code of the user. 2 letter ISO format
+    optional string country = 5;
+    optional string real_name = 6;
 }
 
 // User wants to activate an account
 message Command_Activate {
-	extend SessionCommand {
-		optional Command_Activate ext = 1017;
-	}
-	// User name client wants to activate
-	required string user_name = 1;
-	// Activation token
-	required string token = 2;
+    extend SessionCommand {
+        optional Command_Activate ext = 1017;
+    }
+    // User name client wants to activate
+    required string user_name = 1;
+    // Activation token
+    required string token = 2;
 }
 
 message Command_AccountEdit {
-	extend SessionCommand {
-		optional Command_AccountEdit ext = 1018;
-	}
-	optional string real_name = 1;
-	optional string email = 2;
-	optional ServerInfo_User.Gender gender = 3;
-	optional string country = 4;
+    extend SessionCommand {
+        optional Command_AccountEdit ext = 1018;
+    }
+    optional string real_name = 1;
+    optional string email = 2;
+    optional ServerInfo_User.Gender gender = 3;
+    optional string country = 4;
 }
 
 message Command_AccountImage {
-	extend SessionCommand {
-		optional Command_AccountImage ext = 1019;
-	}
-	optional bytes image = 1;
+    extend SessionCommand {
+        optional Command_AccountImage ext = 1019;
+    }
+    optional bytes image = 1;
 }
 
 message Command_AccountPassword {
-	extend SessionCommand {
-		optional Command_AccountPassword ext = 1020;
-	}
-	optional string old_password = 1;
-	optional string new_password = 2;
+    extend SessionCommand {
+        optional Command_AccountPassword ext = 1020;
+    }
+    optional string old_password = 1;
+    optional string new_password = 2;
 }

--- a/common/server.cpp
+++ b/common/server.cpp
@@ -103,7 +103,7 @@ Server_DatabaseInterface *Server::getDatabaseInterface() const
     return databaseInterfaces.value(QThread::currentThread());
 }
 
-AuthenticationResult Server::loginUser(Server_ProtocolHandler *session, QString &name, const QString &password, QString &reasonStr, int &secondsLeft)
+AuthenticationResult Server::loginUser(Server_ProtocolHandler *session, QString &name, const QString &password, QString &reasonStr, int &secondsLeft, QString &clientid)
 {
     if (name.size() > 35)
         name = name.left(35);
@@ -123,6 +123,8 @@ AuthenticationResult Server::loginUser(Server_ProtocolHandler *session, QString 
     databaseInterface->lockSessionTables();
     
     if (authState == PasswordRight) {
+
+        // verify that new session would not cause problems with older existing session
         if (users.contains(name) || databaseInterface->userSessionExists(name)) {
             qDebug("Login denied: would overwrite old session");
             databaseInterface->unlockSessionTables();
@@ -168,6 +170,15 @@ AuthenticationResult Server::loginUser(Server_ProtocolHandler *session, QString 
     event.mutable_user_info()->CopyFrom(session->copyUserInfo(true, true, true));
     locker.unlock();
     
+    // check if client id exists (older client compatibility)
+    if (clientid.isEmpty()){
+        // client id is empty, either out dated client or client has been modified
+    }
+    else {
+        // update users database table with client id
+        databaseInterface->updateUsersClientID(name, clientid);
+    }
+
     se = Server_ProtocolHandler::prepareSessionEvent(event);
     sendIsl_SessionEvent(*se);
     delete se;

--- a/common/server.h
+++ b/common/server.h
@@ -44,7 +44,7 @@ public:
     Server(bool _threaded, QObject *parent = 0);
     ~Server();
     void setThreaded(bool _threaded) { threaded = _threaded; }
-    AuthenticationResult loginUser(Server_ProtocolHandler *session, QString &name, const QString &password, QString &reason, int &secondsLeft);
+    AuthenticationResult loginUser(Server_ProtocolHandler *session, QString &name, const QString &password, QString &reason, int &secondsLeft, QString &clientid);
 
     const QMap<int, Server_Room *> &getRooms() { return rooms; }
 

--- a/common/server_database_interface.h
+++ b/common/server_database_interface.h
@@ -41,6 +41,7 @@ public:
     virtual bool getRequireRegistration() { return false; }
     virtual bool registerUser(const QString & /* userName */, const QString & /* realName */, ServerInfo_User_Gender const & /* gender */, const QString & /* password */, const QString & /* emailAddress */, const QString & /* country */, bool /* active = false */) { return false; }
     virtual bool activateUser(const QString & /* userName */, const QString & /* token */) { return false; }
+    virtual void updateUsersClientID(const QString & /* userName */, const QString & /* userClientID */) { }
 
     enum LogMessage_TargetType { MessageTargetRoom, MessageTargetGame, MessageTargetChat, MessageTargetIslRoom };
     virtual void logMessage(const int /* senderId */, const QString & /* senderName */, const QString & /* senderIp */, const QString & /* logMessage */, LogMessage_TargetType /* targetType */, const int /* targetId */, const QString & /* targetName */) { };

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -381,11 +381,12 @@ Response::ResponseCode Server_ProtocolHandler::cmdPing(const Command_Ping & /*cm
 Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd, ResponseContainer &rc)
 {
     QString userName = QString::fromStdString(cmd.user_name()).simplified();
+    QString clientid = QString::fromStdString(cmd.clientid()).simplified();
     if (userName.isEmpty() || (userInfo != 0))
         return Response::RespContextError;
     QString reasonStr;
     int banSecondsLeft = 0;
-    AuthenticationResult res = server->loginUser(this, userName, QString::fromStdString(cmd.password()), reasonStr, banSecondsLeft);
+    AuthenticationResult res = server->loginUser(this, userName, QString::fromStdString(cmd.password()), reasonStr, banSecondsLeft, clientid);
     switch (res) {
         case UserIsBanned: {
             Response_Login *re = new Response_Login;

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_schema_version` (
   PRIMARY KEY  (`version`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
-INSERT INTO cockatrice_schema_version VALUES(1);
+INSERT INTO cockatrice_schema_version VALUES(3);
 
 CREATE TABLE IF NOT EXISTS `cockatrice_decklist_files` (
   `id` int(7) unsigned zerofill NOT NULL auto_increment,
@@ -83,6 +83,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_users` (
   `registrationDate` datetime NOT NULL,
   `active` tinyint(1) NOT NULL,
   `token` binary(16) NOT NULL,
+  `clientid` varchar(15) NOT NULL,
   PRIMARY KEY  (`id`),
   UNIQUE KEY `name` (`name`),
   KEY `token` (`token`),

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -811,20 +811,33 @@ bool Servatrice_DatabaseInterface::changeUserPassword(const QString &user, const
 
 int Servatrice_DatabaseInterface::getActiveUserCount()
 {
-	int userCount = 0;
+    int userCount = 0;
 
-	if (!checkSql())
-		return userCount;
+    if (!checkSql())
+        return userCount;
 
-	QSqlQuery *query = prepareQuery("select count(*) from {prefix}_sessions where id_server = :serverid AND end_time is NULL");
-	query->bindValue(":serverid", server->getServerId());
-	if (!execSqlQuery(query)){
-		return userCount;
-	}
+    QSqlQuery *query = prepareQuery("select count(*) from {prefix}_sessions where id_server = :serverid AND end_time is NULL");
+    query->bindValue(":serverid", server->getServerId());
+    if (!execSqlQuery(query)){
+        return userCount;
+    }
 
-	if (query->next()){
-		userCount = query->value(0).toInt();
-	}
+    if (query->next()){
+        userCount = query->value(0).toInt();
+    }
 
-	return userCount;
+    return userCount;
+}
+
+void Servatrice_DatabaseInterface::updateUsersClientID(const QString &userName, const QString &userClientID)
+{
+    
+    if (!checkSql())
+        return;
+
+    QSqlQuery *query = prepareQuery("update {prefix}_users set clientid = :clientid where name = :username");
+    query->bindValue(":clientid", userClientID);
+    query->bindValue(":username", userName);
+    execSqlQuery(query);
+    
 }

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -9,7 +9,7 @@
 #include "server.h"
 #include "server_database_interface.h"
 
-#define DATABASE_SCHEMA_VERSION 2
+#define DATABASE_SCHEMA_VERSION 3
 
 class Servatrice;
 
@@ -72,7 +72,7 @@ public:
     bool registerUser(const QString &userName, const QString &realName, ServerInfo_User_Gender const &gender, 
         const QString &password, const QString &emailAddress, const QString &country, QString &token, bool active = false);
     bool activateUser(const QString &userName, const QString &token);
-
+    void updateUsersClientID(const QString &userName, const QString &userClientID);
     void logMessage(const int senderId, const QString &senderName, const QString &senderIp, const QString &logMessage, 
         LogMessage_TargetType targetType, const int targetId, const QString &targetName);
     bool changeUserPassword(const QString &user, const QString &oldPassword, const QString &newPassword);


### PR DESCRIPTION
Re-roll of the PR for client side ID generation.  Currently the id is based on a hash of all the valid mac address's from across all the adapters in a PC.  We can add / change the logic for the client ID generation as it is just a function being called.  The client ID is then passed to the server and stored in the user database table with the account during login.

Right now the server does nothing with the ID other than store it.  This PR is designed to simply add design space into the management and tracking of users with the thought of adding additional banning functionality at a later date as well as possibly assist in the creation of things like suspicion level indication (https://github.com/Cockatrice/Cockatrice/issues/170)  or statistical data analysis. 