### PR TITLE
readme adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,19 @@
 Cockatrice is an open-source multiplatform software for playing card games,
 such as Magic: The Gathering, over a network. It is fully client-server based
 to prevent any kind of cheating, though it supports single-player games without
-a network interface as well. Both client and server are written in Qt, supporting both Qt4 and Qt5.<br> [▲](https://github.com/Cockatrice/Cockatrice#readme)
+a network interface as well. Both client and server are written in Qt, supporting both Qt4 and Qt5.<br>
 
 
 # Get Involved [![Gitter chat](https://badges.gitter.im/Cockatrice/Cockatrice.png)](https://gitter.im/Cockatrice/Cockatrice)
 
 Chat with the Cockatrice developers on Gitter. Come here to talk about the application, features, or just to hang out. For support regarding specific servers, please contact that server's admin or forum for support rather than asking here.<br>
-[▲](https://github.com/Cockatrice/Cockatrice#readme)
+
 
 # Community Resources
 - [Cockatrice Official Wiki](https://github.com/Cockatrice/Cockatrice/wiki)
 - [reddit r/Cockatrice](http://reddit.com/r/cockatrice)
 - [Woogerworks](http://www.woogerworks.com) / [Chickatrice] (http://www.chickatrice.net/) / [Poixen](http://www.poixen.com/) (incomplete Serverlist)<br>
 
-[▲](https://github.com/Cockatrice/Cockatrice#readme)
 
 # Translation Status [![Cockatrice on Transiflex](https://ds0k0en9abmn1.cloudfront.net/static/charts/images/tx-logo-micro.646b0065fce6.png)](https://www.transifex.com/projects/p/cockatrice/)
 
@@ -36,7 +35,7 @@ Language statistics for `Cockatrice` *(on the left)* and `Oracle` *(on the right
 [![Cockatrice translations](https://www.transifex.com/projects/p/cockatrice/resource/cockatrice/chart/image_png)](https://www.transifex.com/projects/p/cockatrice/resource/cockatrice/)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[![Oracle translations](https://www.transifex.com/projects/p/cockatrice/resource/oracle/chart/image_png)](https://www.transifex.com/projects/p/cockatrice/resource/oracle/)
 
 Check out our [Translator FAQ](https://github.com/Cockatrice/Cockatrice/wiki/Translation-FAQ) for more information!<br>
-[▲](https://github.com/Cockatrice/Cockatrice#readme)
+
 
 # Building [![Build Status](https://travis-ci.org/Cockatrice/Cockatrice.svg?branch=master)](https://travis-ci.org/Cockatrice/Cockatrice)
 
@@ -73,16 +72,16 @@ The following flags can be passed to `cmake`:
 
 #### Building servatrice Docker container
 `docker build -t servatrice .`<br>
-[▲](https://github.com/Cockatrice/Cockatrice#readme)
+
 
 # Running
 
 `oracle` fetches card data  
 `cockatrice` is the game client  
 `servatrice` is the server<br>
-[▲](https://github.com/Cockatrice/Cockatrice#readme)
+
 
 # License
 
 Cockatrice is free software, licensed under the GPLv2; see COPYING for details.<br>
-[▲](https://github.com/Cockatrice/Cockatrice#readme)
+

--- a/README.md
+++ b/README.md
@@ -1,33 +1,30 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+<p align='center'><img src=https://cloud.githubusercontent.com/assets/9874850/7516775/b00b8e36-f4d1-11e4-8da4-3df294d01f86.png></p>
 
-- [Cockatrice](#cockatrice)
-- [Get Involved [![Gitter chat](https://badges.gitter.im/Cockatrice/Cockatrice.png)](https://gitter.im/Cockatrice/Cockatrice)](#get-involved-)
-- [Community Resources](#community-resources)
-- [Translation Status [![Cockatrice on Transiflex](https://ds0k0en9abmn1.cloudfront.net/static/charts/images/tx-logo-micro.646b0065fce6.png)](https://www.transifex.com/projects/p/cockatrice/)](#translation-status-)
-- [Building [![Build Status](https://travis-ci.org/Cockatrice/Cockatrice.svg?branch=master)](https://travis-ci.org/Cockatrice/Cockatrice)](#building-)
-- [Building servatrice Docker container](#building-servatrice-docker-container)
-- [Running](#running)
-- [License](#license)
+---
 
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+**Table of Contents** &nbsp;&nbsp; [Cockatrice](#cockatrice) | [Get Involved] (#get-involved-) | [Community](#community-resources) | [Translation](#translation-status-) | [Building](#building-) | [Running](#running) | [License](#license)
+
+---
 
 # Cockatrice
 
 Cockatrice is an open-source multiplatform software for playing card games,
 such as Magic: The Gathering, over a network. It is fully client-server based
 to prevent any kind of cheating, though it supports single-player games without
-a network interface as well. Both client and server are written in Qt, supporting both Qt4 and Qt5.
+a network interface as well. Both client and server are written in Qt, supporting both Qt4 and Qt5.<br> [▲](https://github.com/Cockatrice/Cockatrice#readme)
+
 
 # Get Involved [![Gitter chat](https://badges.gitter.im/Cockatrice/Cockatrice.png)](https://gitter.im/Cockatrice/Cockatrice)
 
-Chat with the Cockatrice developers on Gitter. Come here to talk about the application, features, or just to hang out. For support regarding specific servers, please contact that server's admin or forum for support rather than asking here.
+Chat with the Cockatrice developers on Gitter. Come here to talk about the application, features, or just to hang out. For support regarding specific servers, please contact that server's admin or forum for support rather than asking here.<br>
+[▲](https://github.com/Cockatrice/Cockatrice#readme)
 
 # Community Resources
-- [reddit r/Cockatrice](http://reddit.com/r/cockatrice)
-- [Woogerworks Server & Forums](http://www.woogerworks.com)
 - [Cockatrice Official Wiki](https://github.com/Cockatrice/Cockatrice/wiki)
+- [reddit r/Cockatrice](http://reddit.com/r/cockatrice)
+- [Woogerworks](http://www.woogerworks.com) / [Chickatrice] (http://www.chickatrice.net/) / [Poixen](http://www.poixen.com/) (incomplete Serverlist)<br>
+
+[▲](https://github.com/Cockatrice/Cockatrice#readme)
 
 # Translation Status [![Cockatrice on Transiflex](https://ds0k0en9abmn1.cloudfront.net/static/charts/images/tx-logo-micro.646b0065fce6.png)](https://www.transifex.com/projects/p/cockatrice/)
 
@@ -38,25 +35,24 @@ Language statistics for `Cockatrice` *(on the left)* and `Oracle` *(on the right
 
 [![Cockatrice translations](https://www.transifex.com/projects/p/cockatrice/resource/cockatrice/chart/image_png)](https://www.transifex.com/projects/p/cockatrice/resource/cockatrice/)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[![Oracle translations](https://www.transifex.com/projects/p/cockatrice/resource/oracle/chart/image_png)](https://www.transifex.com/projects/p/cockatrice/resource/oracle/)
 
-Check out our [Translator FAQ](https://github.com/Cockatrice/Cockatrice/wiki/Translation-FAQ) for more information!
+Check out our [Translator FAQ](https://github.com/Cockatrice/Cockatrice/wiki/Translation-FAQ) for more information!<br>
+[▲](https://github.com/Cockatrice/Cockatrice#readme)
 
 # Building [![Build Status](https://travis-ci.org/Cockatrice/Cockatrice.svg?branch=master)](https://travis-ci.org/Cockatrice/Cockatrice)
 
 **Detailed compiling instructions are on the Cockatrice wiki under [Compiling Cockatrice](https://github.com/Cockatrice/Cockatrice/wiki/Compiling-Cockatrice)**
 
 Dependencies:
-
 - [Qt](http://qt-project.org/) 
 - [protobuf](http://code.google.com/p/protobuf/)
 - [CMake](http://www.cmake.org/)
 
 Oracle can optionally use zlib to load zipped files:
-
 - [zlib](http://www.zlib.net/)
 
 The server requires an additional dependency when compiled under Qt4:
-
 - [libgcrypt](http://www.gnu.org/software/libgcrypt/)
+
 
 To compile:
 
@@ -75,15 +71,18 @@ The following flags can be passed to `cmake`:
 - `-DCMAKE_BUILD_TYPE=Debug` Compile in debug mode. Enables extra logging output, debug symbols, and much more verbose compiler warnings.
 - `-DUPDATE_TRANSLATIONS=1` Configure `make` to update the translation .ts files for new strings in the source code. Note: Running `make clean` will remove the .ts files.
 
-# Building servatrice Docker container
-`docker build -t servatrice .`
+#### Building servatrice Docker container
+`docker build -t servatrice .`<br>
+[▲](https://github.com/Cockatrice/Cockatrice#readme)
 
 # Running
 
 `oracle` fetches card data  
 `cockatrice` is the game client  
-`servatrice` is the server
+`servatrice` is the server<br>
+[▲](https://github.com/Cockatrice/Cockatrice#readme)
 
 # License
 
-Cockatrice is free software, licensed under the GPLv2; see COPYING for details.
+Cockatrice is free software, licensed under the GPLv2; see COPYING for details.<br>
+[▲](https://github.com/Cockatrice/Cockatrice#readme)


### PR DESCRIPTION
- toc changed (removed DocToc)
- ~~relinks to the toc under every category (▲)~~
- image included on top
- added links to chickatrice and poixen server in community ressources
- resized `building servatrice docker container` category to make it more `build` related

@Daenyth:
What about the Qt4 references? I kept them all for now.
Or should we go with the footnotes and wiki references you mentioned?

to get an idea:
![untitled](https://cloud.githubusercontent.com/assets/9874850/9124514/ba400202-3c97-11e5-891a-021891b94790.png)
