### PR TITLE
#1351 Fix

### DIFF
--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -111,7 +111,7 @@ SettingsCache::SettingsCache()
     maxPlayers = settings->value("game/maxplayers", 2).toInt();
     gameTypes = settings->value("game/gametypes","").toString();
     onlyBuddies = settings->value("game/onlybuddies", false).toBool();
-    onlyRegistered = settings->value("game/onlyregistered", true).toBool();
+    onlyRegistered = settings->value("game/onlyregistered", false).toBool();
     spectatorsAllowed = settings->value("game/spectatorsallowed", true).toBool();
     spectatorsNeedPassword = settings->value("game/spectatorsneedpassword", false).toBool();
     spectatorsCanTalk = settings->value("game/spectatorscantalk", false).toBool();


### PR DESCRIPTION
This update address's the issue were a server with no db has only non-registered users but when creating a game will cause the dialogue to only allow the check box of "registered users only" resulting in a game that no user will ever be able to join.