### PR TITLE
Fix #1351 - Server ignores only-reg if in "none" auth mode.

### DIFF
--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -114,7 +114,13 @@ DlgCreateGame::DlgCreateGame(TabRoom *_room, const QMap<int, QString> &_gameType
     descriptionEdit->setText(settingsCache->getGameDescription());
     maxPlayersEdit->setValue(settingsCache->getMaxPlayers());
     onlyBuddiesCheckBox->setChecked(settingsCache->getOnlyBuddies());
-    onlyRegisteredCheckBox->setChecked(settingsCache->getOnlyRegistered());
+    if (room && room->getUserInfo()->user_level() & ServerInfo_User::IsRegistered)
+    {
+        onlyRegisteredCheckBox->setChecked(settingsCache->getOnlyRegistered());
+    } else {
+        onlyBuddiesCheckBox->setEnabled(false);
+        onlyRegisteredCheckBox->setEnabled(false);
+    }
     spectatorsAllowedCheckBox->setChecked(settingsCache->getSpectatorsAllowed());
     spectatorsNeedPasswordCheckBox->setChecked(settingsCache->getSpectatorsNeedPassword());
     spectatorsCanTalkCheckBox->setChecked(settingsCache->getSpectatorsCanTalk());

--- a/common/server.h
+++ b/common/server.h
@@ -55,6 +55,7 @@ public:
     void removeClient(Server_ProtocolHandler *player);
     virtual QString getLoginMessage() const { return QString(); }
 
+    virtual bool permitUnregisteredUsers() const { return true; }
     virtual bool getGameShouldPing() const { return false; }
     virtual bool getClientIdRequired() const { return false; }
     virtual bool getRegOnlyServer() const { return false; }

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -636,7 +636,9 @@ Response::ResponseCode Server_ProtocolHandler::cmdCreateGame(const Command_Creat
     if (description.size() > 60)
         description = description.left(60);
 
-    Server_Game *game = new Server_Game(copyUserInfo(false), gameId, description, QString::fromStdString(cmd.password()), cmd.max_players(), gameTypes, cmd.only_buddies(), cmd.only_registered(), cmd.spectators_allowed(), cmd.spectators_need_password(), cmd.spectators_can_talk(), cmd.spectators_see_everything(), room);
+    // When server doesn't permit registered users to exist, do not honor only-reg setting
+    bool onlyRegisteredUsers = cmd.only_registered() && (server->permitUnregisteredUsers());
+    Server_Game *game = new Server_Game(copyUserInfo(false), gameId, description, QString::fromStdString(cmd.password()), cmd.max_players(), gameTypes, cmd.only_buddies(), onlyRegisteredUsers, cmd.spectators_allowed(), cmd.spectators_need_password(), cmd.spectators_can_talk(), cmd.spectators_see_everything(), room);
     game->addPlayer(this, rc, false, false);
     room->addGame(game);
 

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -136,6 +136,7 @@ public:
     bool initServer();
     QString getServerName() const { return serverName; }
     QString getLoginMessage() const { QMutexLocker locker(&loginMessageMutex); return loginMessage; }
+    bool permitUnregisteredUsers() const { return authenticationMethod != AuthenticationNone; }
     bool getGameShouldPing() const { return true; }
     bool getClientIdRequired() const { return clientIdRequired; }
     bool getRegOnlyServer() const { return regServerOnly; }


### PR DESCRIPTION
When in none auth mode, registered users don't exist; hence the setting
makes the game impossible to join.

Normally the setting would be greyed out when the user is unregistered,
but commit 475c54bf introduced a new edge case where the stored setting
would apply to the field even if the user is unregistered, making the
setting possible to apply in no-reg mode. Regardless, any client could
have done this, not just the default cockatrice.

The server side fix should prevent all issues in the future.