### PR TITLE
Username Completer in server room

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -573,6 +573,9 @@ MessagesSettingsPage::MessagesSettingsPage()
 {
     chatMentionCheckBox.setChecked(settingsCache->getChatMention());
     connect(&chatMentionCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setChatMention(int)));
+
+    chatMentionCompleterCheckbox.setChecked(settingsCache->getChatMentionCompleter());
+    connect(&chatMentionCompleterCheckbox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setChatMentionCompleter(int)));
     
     ignoreUnregUsersMainChat.setChecked(settingsCache->getIgnoreUnregisteredUsers());
     ignoreUnregUserMessages.setChecked(settingsCache->getIgnoreUnregisteredUserMessages());
@@ -605,11 +608,12 @@ MessagesSettingsPage::MessagesSettingsPage()
     chatGrid->addWidget(&chatMentionCheckBox, 0, 0);
     chatGrid->addWidget(&invertMentionForeground, 0, 1);
     chatGrid->addWidget(mentionColor, 0, 2);
-    chatGrid->addWidget(&ignoreUnregUsersMainChat, 1, 0);
+    chatGrid->addWidget(&chatMentionCompleterCheckbox, 1, 0);
+    chatGrid->addWidget(&ignoreUnregUsersMainChat, 2, 0);
     chatGrid->addWidget(&hexLabel, 1, 2);
-    chatGrid->addWidget(&ignoreUnregUserMessages, 2, 0);
-    chatGrid->addWidget(&messagePopups, 3, 0);
-    chatGrid->addWidget(&mentionPopups, 4, 0);
+    chatGrid->addWidget(&ignoreUnregUserMessages, 3, 0);
+    chatGrid->addWidget(&messagePopups, 4, 0);
+    chatGrid->addWidget(&mentionPopups, 5, 0);
     chatGroupBox = new QGroupBox;
     chatGroupBox->setLayout(chatGrid);
     
@@ -734,6 +738,7 @@ void MessagesSettingsPage::retranslateUi()
     chatGroupBox->setTitle(tr("Chat settings"));
     highlightGroupBox->setTitle(tr("Custom alert words"));
     chatMentionCheckBox.setText(tr("Enable chat mentions"));
+    chatMentionCompleterCheckbox.setText(tr("Enable mention completer"));
     messageShortcuts->setTitle(tr("In-game message macros"));
     ignoreUnregUsersMainChat.setText(tr("Ignore chat room messages sent by unregistered users"));
     ignoreUnregUserMessages.setText(tr("Ignore private messages sent by unregistered users"));

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -168,6 +168,7 @@ private:
     QAction *aAdd;
     QAction *aRemove;
     QCheckBox chatMentionCheckBox;
+    QCheckBox chatMentionCompleterCheckbox;
     QCheckBox invertMentionForeground;
     QCheckBox invertHighlightForeground;
     QCheckBox ignoreUnregUsersMainChat;

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -77,6 +77,7 @@ SettingsCache::SettingsCache()
     minPlayersForMultiColumnLayout = settings->value("interface/min_players_multicolumn", 5).toInt();
     tapAnimation = settings->value("cards/tapanimation", true).toBool();
     chatMention = settings->value("chat/mention", true).toBool();
+    chatMentionCompleter = settings->value("chat/mentioncompleter", true).toBool();
     chatMentionForeground = settings->value("chat/mentionforeground", true).toBool();
     chatHighlightForeground = settings->value("chat/highlightforeground", true).toBool();
     chatMentionColor = settings->value("chat/mentioncolor", "A6120D").toString();
@@ -358,6 +359,13 @@ void SettingsCache::setTapAnimation(int _tapAnimation)
 void SettingsCache::setChatMention(int _chatMention) {
     chatMention = _chatMention;
     settings->setValue("chat/mention", chatMention);
+}
+
+void SettingsCache::setChatMentionCompleter(const int _enableMentionCompleter)
+{
+    chatMentionCompleter = _enableMentionCompleter;
+    settings->setValue("chat/mentioncompleter", chatMentionCompleter);
+    emit chatMentionCompleterChanged();
 }
 
 void SettingsCache::setChatMentionForeground(int _chatMentionForeground) {

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -43,6 +43,7 @@ signals:
     void ignoreUnregisteredUserMessagesChanged();
     void pixmapCacheSizeChanged(int newSizeInMBs);
     void masterVolumeChanged(int value);
+    void chatMentionCompleterChanged();
 private:
     QSettings *settings;
 
@@ -65,6 +66,7 @@ private:
     int minPlayersForMultiColumnLayout;
     bool tapAnimation;
     bool chatMention;
+    bool chatMentionCompleter;
     QString chatMentionColor;
     QString chatHighlightColor;
     bool chatMentionForeground;
@@ -136,6 +138,7 @@ public:
     int getMinPlayersForMultiColumnLayout() const { return minPlayersForMultiColumnLayout; }
     bool getTapAnimation() const { return tapAnimation; }
     bool getChatMention()  const { return chatMention; }
+    bool getChatMentionCompleter() const { return chatMentionCompleter; }
     bool getChatMentionForeground() const { return chatMentionForeground; }
     bool getChatHighlightForeground() const { return chatHighlightForeground; }
     bool getZoneViewSortByName() const { return zoneViewSortByName; }
@@ -218,6 +221,7 @@ public slots:
     void setMinPlayersForMultiColumnLayout(int _minPlayersForMultiColumnLayout);
     void setTapAnimation(int _tapAnimation);
     void setChatMention(int _chatMention);
+    void setChatMentionCompleter(int _chatMentionCompleter);
     void setChatMentionForeground(int _chatMentionForeground);
     void setChatHighlightForeground(int _chatHighlightForeground);
     void setZoneViewSortByName(int _zoneViewSortByName);

--- a/cockatrice/src/tab_room.h
+++ b/cockatrice/src/tab_room.h
@@ -4,6 +4,9 @@
 #include "tab.h"
 #include <QGroupBox>
 #include <QMap>
+#include <QLineEdit>
+#include <QKeyEvent>
+#include <QFocusEvent>
 
 namespace google { namespace protobuf { class Message; } }
 class AbstractClient;
@@ -13,6 +16,7 @@ class ChatView;
 class QLineEdit;
 class QPushButton;
 class QTextTable;
+class QCompleter;
 class RoomEvent;
 class ServerInfo_Room;
 class ServerInfo_Game;
@@ -24,6 +28,7 @@ class GameSelector;
 class Response;
 class PendingCommand;
 class ServerInfo_User;
+class CustomLineEdit;
 
 class TabRoom : public Tab {
     Q_OBJECT
@@ -38,14 +43,17 @@ private:
     UserList *userList;
     ChatView *chatView;
     QLabel *sayLabel;
-    QLineEdit *sayEdit;
+    CustomLineEdit *sayEdit;
     QGroupBox *chatGroupBox;
     
     QMenu *roomMenu;
     QAction *aLeaveRoom;
     QAction *aOpenChatSettings;
-    QAction * aClearChat;
+    QAction *aClearChat;
     QString sanitizeHtml(QString dirty) const;
+
+    QStringList autocompleteUserList;
+    QCompleter *completer;
 signals:
     void roomClosing(TabRoom *tab);
     void openMessageDialog(const QString &userName, bool focus);
@@ -59,7 +67,8 @@ private slots:
     void addMentionTag(QString mentionTag);
     void focusTab();
     void actShowMentionPopup(QString &sender);
-    
+    void actCompleterChanged();
+
     void processListGamesEvent(const Event_ListGames &event);
     void processJoinRoomEvent(const Event_JoinRoom &event);
     void processLeaveRoomEvent(const Event_LeaveRoom &event);
@@ -79,6 +88,23 @@ public:
 
     PendingCommand *prepareRoomCommand(const ::google::protobuf::Message &cmd);
     void sendRoomCommand(PendingCommand *pend);
+};
+
+class CustomLineEdit : public QLineEdit
+{
+    Q_OBJECT
+private:
+    QString cursorWord(const QString& line) const;
+    QCompleter* c;
+private slots:
+    void insertCompletion(QString);
+protected:
+    void keyPressEvent(QKeyEvent * event);
+    void focusOutEvent(QFocusEvent * e);
+public:
+    explicit CustomLineEdit(QWidget *parent = 0);
+    void setCompleter(QCompleter*);
+    void updateCompleterModel(QStringList);
 };
 
 #endif


### PR DESCRIPTION
Fix #457
- Adds QCompleter in server room chat to assist in typing usernames.
- Adds a setting to enable/disable it under Settings > Chat.
- Implicit Shortcuts: Escape (cancel current completion), Enter/Tab/Space (insert current completion)

![settings](https://cloud.githubusercontent.com/assets/11285250/9159651/de2e963c-3efa-11e5-8189-19769d58a6d5.jpg)
![chat](https://cloud.githubusercontent.com/assets/11285250/9159644/b08f108a-3efa-11e5-8603-0edd0c4d6528.jpg)

