### PR TITLE
Add option to servatrice to disable replay storage.

### DIFF
--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -193,6 +193,11 @@ roomlist\1\game_types\3\name="GameType3"
 ; default is 120
 max_game_inactivity_time=120
 
+; All actions during a game are recorded and stored in the database as a replay that all participants of
+; the game can go back to and review after the game is closed.  This can require a fairly large amount of
+; storage to save all the information.  Disable this option to prevent the storing of replay data in
+; the database.  Default value is true.
+store_replays=true
 
 [security]
 ; You may want to restrict the number of users that can connect to your server at any given time.

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -162,6 +162,7 @@ bool Servatrice::initServer()
         authenticationMethod = AuthenticationNone;
     }
 
+    qDebug() << "Store Replays: " << settingsCache->value("game/store_replays", true).toBool();
     qDebug() << "Client ID Required: " << clientIdRequired;
     bool maxUserLimitEnabled = settingsCache->value("security/enable_max_user_limit", false).toBool();
     qDebug() << "Maximum user limit enabled: " << maxUserLimitEnabled;

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -642,6 +642,9 @@ void Servatrice_DatabaseInterface::storeGameInformation(const QString &roomName,
     if (!checkSql())
         return;
 
+    if (!settingsCache->value("game/store_replays", 1).toBool() )
+        return;
+
     QVariantList gameIds1, playerNames, gameIds2, userIds, replayNames;
     QSetIterator<QString> playerIterator(allPlayersEver);
     while (playerIterator.hasNext()) {


### PR DESCRIPTION
Fix #380
(i believe, but if not more can be added).
This allows the server operator to set servatrice to not store the replay data into the database.  This option would be useful for operators with small amounts of storage on their server.  With this setting the behavior is that a game is created by a user and recorded allowing for the client to review the game after a game is complete. But when the value is set on the server side to not store the data, the data never gets stored into the database allowing for review of the game up till the client closes. 