### PR TITLE
Removed clientid requirements from the protocol handler.

### DIFF
--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -385,8 +385,6 @@ Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd
     
     if (userName.isEmpty() || (userInfo != 0))
         return Response::RespContextError;
-    if (clientId.isEmpty())
-        return Response::RespContextError;
 
     QString reasonStr;
     int banSecondsLeft = 0;


### PR DESCRIPTION
Remove the check for clientid with in the protocol handler since servatrice has the option to check if the clientid is required.