### PR TITLE
Ban by client ID

### DIFF
--- a/cockatrice/src/localserver.cpp
+++ b/cockatrice/src/localserver.cpp
@@ -33,7 +33,7 @@ ServerInfo_User LocalServer_DatabaseInterface::getUserData(const QString &name, 
     return result;
 }
 
-AuthenticationResult LocalServer_DatabaseInterface::checkUserPassword(Server_ProtocolHandler * /* handler */, const QString & /* user */, const QString & /* password */, QString & /* reasonStr */, int & /* secondsLeft */)
+AuthenticationResult LocalServer_DatabaseInterface::checkUserPassword(Server_ProtocolHandler * /* handler */, const QString & /* user */, const QString & /* password */, const QString & /* clientId */, QString & /* reasonStr */, int & /* secondsLeft */)
 {
     return UnknownUser;
 }

--- a/cockatrice/src/localserver.h
+++ b/cockatrice/src/localserver.h
@@ -24,7 +24,7 @@ protected:
     ServerInfo_User getUserData(const QString &name, bool withId = false);
 public:
     LocalServer_DatabaseInterface(LocalServer *_localServer);
-    AuthenticationResult checkUserPassword(Server_ProtocolHandler *handler, const QString &user, const QString &password, QString &reasonStr, int &secondsLeft);
+    AuthenticationResult checkUserPassword(Server_ProtocolHandler *handler, const QString &user, const QString &password, const QString &clientId, QString &reasonStr, int &secondsLeft);
     int getNextGameId() { return localServer->getNextLocalGameId(); }
     int getNextReplayId() { return -1; }
     int getActiveUserCount() { return 0; }

--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -11,6 +11,7 @@
 #include "pb/server_message.pb.h"
 #include "pb/event_server_identification.pb.h"
 #include "settingscache.h"
+#include "main.h"
 
 static const unsigned int protocolVersion = 14;
 
@@ -78,6 +79,7 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
         cmdRegister.set_gender((ServerInfo_User_Gender) gender);
         cmdRegister.set_country(country.toStdString());
         cmdRegister.set_real_name(realName.toStdString());
+        cmdRegister.set_clientid(settingsCache->getClientID().toStdString());
 
         PendingCommand *pend = prepareSessionCommand(cmdRegister);
         connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(registerResponse(Response)));

--- a/cockatrice/src/user_context_menu.cpp
+++ b/cockatrice/src/user_context_menu.cpp
@@ -99,6 +99,7 @@ void UserContextMenu::banUser_dialogFinished()
     cmd.set_minutes(dlg->getMinutes());
     cmd.set_reason(dlg->getReason().toStdString());
     cmd.set_visible_reason(dlg->getVisibleReason().toStdString());
+    cmd.set_clientid(dlg->getBanId().toStdString());
 
     client->sendCommand(client->prepareModeratorCommand(cmd));
 }

--- a/cockatrice/src/userlist.cpp
+++ b/cockatrice/src/userlist.cpp
@@ -36,11 +36,19 @@ BanDialog::BanDialog(const ServerInfo_User &info, QWidget *parent)
     ipBanCheckBox = new QCheckBox(tr("ban &IP address"));
     ipBanCheckBox->setChecked(true);
     ipBanEdit = new QLineEdit(QString::fromStdString(info.address()));
+    idBanCheckBox = new QCheckBox(tr("ban client I&D"));
+    idBanCheckBox->setChecked(true);
+    idBanEdit = new QLineEdit(QString::fromStdString(info.clientid()));
+    if (QString::fromStdString(info.clientid()).isEmpty())
+        idBanCheckBox->setChecked(false);
+
     QGridLayout *banTypeGrid = new QGridLayout;
     banTypeGrid->addWidget(nameBanCheckBox, 0, 0);
     banTypeGrid->addWidget(nameBanEdit, 0, 1);
     banTypeGrid->addWidget(ipBanCheckBox, 1, 0);
     banTypeGrid->addWidget(ipBanEdit, 1, 1);
+    banTypeGrid->addWidget(idBanCheckBox, 2, 0);
+    banTypeGrid->addWidget(idBanEdit, 2, 1);
     QGroupBox *banTypeGroupBox = new QGroupBox(tr("Ban type"));
     banTypeGroupBox->setLayout(banTypeGrid);
     
@@ -110,8 +118,8 @@ BanDialog::BanDialog(const ServerInfo_User &info, QWidget *parent)
 
 void BanDialog::okClicked()
 {
-    if (!nameBanCheckBox->isChecked() && !ipBanCheckBox->isChecked()) {
-        QMessageBox::critical(this, tr("Error"), tr("You have to select a name-based or IP-based ban, or both."));
+    if (!nameBanCheckBox->isChecked() && !ipBanCheckBox->isChecked() && !idBanCheckBox->isChecked()) {
+        QMessageBox::critical(this, tr("Error"), tr("You have to select a name-based, IP-based, clientId based, or some combination of the three to place a ban."));
         return;
     }
     accept();
@@ -125,6 +133,11 @@ void BanDialog::enableTemporaryEdits(bool enabled)
     hoursEdit->setEnabled(enabled);
     minutesLabel->setEnabled(enabled);
     minutesEdit->setEnabled(enabled);
+}
+
+QString BanDialog::getBanId() const
+{
+    return idBanCheckBox->isChecked() ? idBanEdit->text() : QString();
 }
 
 QString BanDialog::getBanName() const

--- a/cockatrice/src/userlist.h
+++ b/cockatrice/src/userlist.h
@@ -24,8 +24,8 @@ class BanDialog : public QDialog {
     Q_OBJECT
 private:
     QLabel *daysLabel, *hoursLabel, *minutesLabel;
-    QCheckBox *nameBanCheckBox, *ipBanCheckBox;
-    QLineEdit *nameBanEdit, *ipBanEdit;
+    QCheckBox *nameBanCheckBox, *ipBanCheckBox, *idBanCheckBox;
+    QLineEdit *nameBanEdit, *ipBanEdit, *idBanEdit;
     QSpinBox *daysEdit, *hoursEdit, *minutesEdit;
     QRadioButton *permanentRadio, *temporaryRadio;
     QPlainTextEdit *reasonEdit, *visibleReasonEdit;
@@ -36,6 +36,7 @@ public:
     BanDialog(const ServerInfo_User &info, QWidget *parent = 0);
     QString getBanName() const;
     QString getBanIP() const;
+    QString getBanId() const;
     int getMinutes() const;
     QString getReason() const;
     QString getVisibleReason() const;

--- a/common/pb/moderator_commands.proto
+++ b/common/pb/moderator_commands.proto
@@ -14,4 +14,5 @@ message Command_BanFromServer {
 	optional uint32 minutes = 3;
 	optional string reason = 4;
 	optional string visible_reason = 5;
+	optional string clientid = 6;
 }

--- a/common/pb/serverinfo_user.proto
+++ b/common/pb/serverinfo_user.proto
@@ -23,4 +23,5 @@ message ServerInfo_User {
     optional uint64 session_id = 10;
     optional uint64 accountage_secs = 11;
     optional string email = 12;
+    optional string clientid = 13;
 }

--- a/common/pb/session_commands.proto
+++ b/common/pb/session_commands.proto
@@ -119,6 +119,7 @@ message Command_Register {
     // Country code of the user. 2 letter ISO format
     optional string country = 5;
     optional string real_name = 6;
+    optional string clientid = 7;
 }
 
 // User wants to activate an account

--- a/common/server.cpp
+++ b/common/server.cpp
@@ -112,7 +112,7 @@ AuthenticationResult Server::loginUser(Server_ProtocolHandler *session, QString 
 
     QWriteLocker locker(&clientsLock);
 
-    AuthenticationResult authState = databaseInterface->checkUserPassword(session, name, password, reasonStr, secondsLeft);
+    AuthenticationResult authState = databaseInterface->checkUserPassword(session, name, password, clientid, reasonStr, secondsLeft);
     if (authState == NotLoggedIn || authState == UserIsBanned || authState == UsernameInvalid || authState == UserIsInactive)
         return authState;
 

--- a/common/server_database_interface.h
+++ b/common/server_database_interface.h
@@ -12,8 +12,8 @@ public:
     Server_DatabaseInterface(QObject *parent = 0)
         : QObject(parent) { }
     
-    virtual AuthenticationResult checkUserPassword(Server_ProtocolHandler *handler, const QString &user, const QString &password, QString &reasonStr, int &secondsLeft) = 0;
-    virtual bool checkUserIsBanned(const QString & /* ipAddress */, const QString & /* userName */, QString & /* banReason */, int & /* banSecondsRemaining */) { return false; }
+    virtual AuthenticationResult checkUserPassword(Server_ProtocolHandler *handler, const QString &user, const QString &password, const QString &clientId, QString &reasonStr, int &secondsLeft) = 0;
+    virtual bool checkUserIsBanned(const QString & /* ipAddress */, const QString & /* userName */, const QString & /* clientId */, QString & /* banReason */, int & /* banSecondsRemaining */) { return false; }
     virtual bool activeUserExists(const QString & /* user */) { return false; }
     virtual bool userExists(const QString & /* user */) { return false; }
     virtual QMap<QString, ServerInfo_User> getBuddyList(const QString & /* name */) { return QMap<QString, ServerInfo_User>(); }

--- a/common/serverinfo_user_container.cpp
+++ b/common/serverinfo_user_container.cpp
@@ -36,6 +36,7 @@ ServerInfo_User &ServerInfo_User_Container::copyUserInfo(ServerInfo_User &result
         if (!sessionInfo) {
             result.clear_session_id();
             result.clear_address();
+            result.clear_clientid();
         }
         if (!internalInfo)
         {

--- a/servatrice/migrations/servatrice_0004_to_0005.sql
+++ b/servatrice/migrations/servatrice_0004_to_0005.sql
@@ -1,0 +1,5 @@
+-- Servatrice db migration from version 4 to version 5
+
+alter table cockatrice_bans add clientid varchar(15) not null;
+
+UPDATE cockatrice_schema_version SET version=5 WHERE version=4;

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_schema_version` (
   PRIMARY KEY  (`version`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
-INSERT INTO cockatrice_schema_version VALUES(4);
+INSERT INTO cockatrice_schema_version VALUES(5);
 
 CREATE TABLE IF NOT EXISTS `cockatrice_decklist_files` (
   `id` int(7) unsigned zerofill NOT NULL auto_increment,
@@ -132,6 +132,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_bans` (
  `minutes` int(6) NOT NULL,
  `reason` text NOT NULL,
  `visible_reason` text NOT NULL,
+ `clientid` varchar(15) NOT NULL,
   PRIMARY KEY (`user_name`,`time_from`),
   KEY `time_from` (`time_from`,`ip_address`),
   KEY `ip_address` (`ip_address`)

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -9,7 +9,7 @@
 #include "server.h"
 #include "server_database_interface.h"
 
-#define DATABASE_SCHEMA_VERSION 4
+#define DATABASE_SCHEMA_VERSION 5
 
 class Servatrice;
 
@@ -22,13 +22,14 @@ private:
     Servatrice *server;
     ServerInfo_User evalUserQueryResult(const QSqlQuery *query, bool complete, bool withId = false);
     /** Must be called after checkSql and server is known to be in auth mode. */
+    bool checkUserIsIdBanned(const QString &clientId, QString &banReason, int &banSecondsRemaining);
+    /** Must be called after checkSql and server is known to be in auth mode. */
     bool checkUserIsIpBanned(const QString &ipAddress, QString &banReason, int &banSecondsRemaining);
     /** Must be called after checkSql and server is known to be in auth mode. */
     bool checkUserIsNameBanned(QString const &userName, QString &banReason, int &banSecondsRemaining);
 
 protected:
-    AuthenticationResult checkUserPassword(Server_ProtocolHandler *handler, const QString &user,
-        const QString &password, QString &reasonStr, int &secondsLeft);
+    AuthenticationResult checkUserPassword(Server_ProtocolHandler *handler, const QString &user, const QString &password, const QString &clientId, QString &reasonStr, int &secondsLeft);
 
 public slots:
     void initDatabase(const QSqlDatabase &_sqlDatabase);
@@ -66,7 +67,7 @@ public:
     void unlockSessionTables();
     bool userSessionExists(const QString &userName);
     bool usernameIsValid(const QString &user, QString & error);
-    bool checkUserIsBanned(const QString &ipAddress, const QString &userName, QString &banReason, int &banSecondsRemaining);
+    bool checkUserIsBanned(const QString &ipAddress, const QString &userName, const QString &clientId, QString &banReason, int &banSecondsRemaining);
 
     bool registerUser(const QString &userName, const QString &realName, ServerInfo_User_Gender const &gender,
         const QString &password, const QString &emailAddress, const QString &country, QString &token, bool active = false);


### PR DESCRIPTION
Fix #42 

This adds the ability to ban users by there generated client id's.  This PR also includes the updated ban checking for client registration to check for a clientid in the ban table of the client trying to register a new account but has been banned under a different username.

The client id ban check function has been written to allow backwards compatibility for users that may have registered / used an older client to connect that does not pass the client id and thus not have the id stored in the database.