### PR TITLE
Add last_login column to user table and populate upon login

### DIFF
--- a/common/server.cpp
+++ b/common/server.cpp
@@ -179,6 +179,7 @@ AuthenticationResult Server::loginUser(Server_ProtocolHandler *session, QString 
         databaseInterface->updateUsersClientID(name, clientid);
     }
 
+    databaseInterface->updateUsersLastLoginTime(name);
     se = Server_ProtocolHandler::prepareSessionEvent(event);
     sendIsl_SessionEvent(*se);
     delete se;

--- a/common/server_database_interface.h
+++ b/common/server_database_interface.h
@@ -42,6 +42,7 @@ public:
     virtual bool registerUser(const QString & /* userName */, const QString & /* realName */, ServerInfo_User_Gender const & /* gender */, const QString & /* password */, const QString & /* emailAddress */, const QString & /* country */, bool /* active = false */) { return false; }
     virtual bool activateUser(const QString & /* userName */, const QString & /* token */) { return false; }
     virtual void updateUsersClientID(const QString & /* userName */, const QString & /* userClientID */) { }
+    virtual void updateUsersLastLoginTime(const QString & /* userName */) { }
 
     enum LogMessage_TargetType { MessageTargetRoom, MessageTargetGame, MessageTargetChat, MessageTargetIslRoom };
     virtual void logMessage(const int /* senderId */, const QString & /* senderName */, const QString & /* senderIp */, const QString & /* logMessage */, LogMessage_TargetType /* targetType */, const int /* targetId */, const QString & /* targetName */) { };

--- a/servatrice/migrations/servatrice_0005_to_0006.sql
+++ b/servatrice/migrations/servatrice_0005_to_0006.sql
@@ -1,0 +1,5 @@
+-- Servatrice db migration from version 5 to version 6
+
+alter table cockatrice_users add last_login datetime not null;
+
+UPDATE cockatrice_schema_version SET version=6 WHERE version=5;

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_schema_version` (
   PRIMARY KEY  (`version`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
-INSERT INTO cockatrice_schema_version VALUES(5);
+INSERT INTO cockatrice_schema_version VALUES(6);
 
 CREATE TABLE IF NOT EXISTS `cockatrice_decklist_files` (
   `id` int(7) unsigned zerofill NOT NULL auto_increment,
@@ -84,6 +84,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_users` (
   `active` tinyint(1) NOT NULL,
   `token` binary(16) NOT NULL,
   `clientid` varchar(15) NOT NULL,
+  `last_login` datetime NOT NULL,
   PRIMARY KEY  (`id`),
   UNIQUE KEY `name` (`name`),
   KEY `token` (`token`),

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -880,3 +880,14 @@ void Servatrice_DatabaseInterface::updateUsersClientID(const QString &userName, 
     execSqlQuery(query);
 
 }
+
+void Servatrice_DatabaseInterface::updateUsersLastLoginTime(const QString &userName)
+{
+    if (!checkSql())
+        return;
+
+    QSqlQuery *query = prepareQuery("update {prefix}_users set last_login = NOW() where name = :user_name");
+    query->bindValue(":user_name", userName);
+    execSqlQuery(query);
+
+}

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -9,7 +9,7 @@
 #include "server.h"
 #include "server_database_interface.h"
 
-#define DATABASE_SCHEMA_VERSION 5
+#define DATABASE_SCHEMA_VERSION 6
 
 class Servatrice;
 
@@ -73,6 +73,7 @@ public:
         const QString &password, const QString &emailAddress, const QString &country, QString &token, bool active = false);
     bool activateUser(const QString &userName, const QString &token);
     void updateUsersClientID(const QString &userName, const QString &userClientID);
+    void updateUsersLastLoginTime(const QString &userName);
     void logMessage(const int senderId, const QString &senderName, const QString &senderIp, const QString &logMessage,
         LogMessage_TargetType targetType, const int targetId, const QString &targetName);
     bool changeUserPassword(const QString &user, const QString &oldPassword, const QString &newPassword);


### PR DESCRIPTION
This will allow operators to keep a cleaner user base.  Even though the sessions table contains the users login/logout time the sessions table is commonly removed / cleared and should be considered volatile causing the loss of important last login information.  This resolves that issue.

This change is strictly a server side functionality addition and wont require any type of client side update.