### PR TITLE
Country to lower (fix win bug)

### DIFF
--- a/cockatrice/src/dlg_edit_user.cpp
+++ b/cockatrice/src/dlg_edit_user.cpp
@@ -35,7 +35,7 @@ DlgEditUser::DlgEditUser(QWidget *parent, QString email, int gender, QString cou
     foreach(QString c, countries)
     {
         countryEdit->addItem(QPixmap(":/resources/countries/" + c + ".svg"), c);
-        if(c == country)
+        if (c == country)
             countryEdit->setCurrentIndex(i);
 
         ++i;

--- a/cockatrice/src/dlg_register.cpp
+++ b/cockatrice/src/dlg_register.cpp
@@ -62,9 +62,7 @@ DlgRegister::DlgRegister(QWidget *parent)
     countryEdit->setCurrentIndex(0);
     QStringList countries = settingsCache->getCountries();
     foreach(QString c, countries)
-    {
         countryEdit->addItem(QPixmap(":/resources/countries/" + c + ".svg"), c);
-    }
 
     realnameLabel = new QLabel(tr("Real name:"));
     realnameEdit = new QLineEdit();

--- a/cockatrice/src/pixmapgenerator.cpp
+++ b/cockatrice/src/pixmapgenerator.cpp
@@ -119,7 +119,7 @@ QPixmap CountryPixmapGenerator::generatePixmap(int height, const QString &countr
     if (pmCache.contains(key))
         return pmCache.value(key);
     
-    QSvgRenderer svg(QString(":/resources/countries/" + countryCode + ".svg"));
+    QSvgRenderer svg(QString(":/resources/countries/" + countryCode.toLower() + ".svg"));
     int width = (int) round(height * (double) svg.defaultSize().width() / (double) svg.defaultSize().height());
     QPixmap pixmap(width, height);
     pixmap.fill(Qt::transparent);


### PR DESCRIPTION
Bug reported by @tooomm and @woogerboy21.

User country flag was sometimes set with the wrong case. This PR makes sure the country code is always lower case (except when you see it on somebody's profile, then it's upper).