### PR TITLE
Corrected miss-matched schema versions

### DIFF
--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_schema_version` (
   PRIMARY KEY  (`version`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
-INSERT INTO cockatrice_schema_version VALUES(6);
+INSERT INTO cockatrice_schema_version VALUES(7);
 
 CREATE TABLE IF NOT EXISTS `cockatrice_decklist_files` (
   `id` int(7) unsigned zerofill NOT NULL auto_increment,


### PR DESCRIPTION
Servatrice schema version should be 7 (not 6) for current commit level.  Not sure exactly why it wasn't updated.