### PR TITLE
Allows admins to promote users to mod and demote mod to user

### DIFF
--- a/cockatrice/src/abstractclient.cpp
+++ b/cockatrice/src/abstractclient.cpp
@@ -8,6 +8,7 @@
 #include "pb/event_server_shutdown.pb.h"
 #include "pb/event_connection_closed.pb.h"
 #include "pb/event_user_message.pb.h"
+#include "pb/event_notify_user.pb.h"
 #include "pb/event_list_rooms.pb.h"
 #include "pb/event_add_to_list.pb.h"
 #include "pb/event_remove_from_list.pb.h"
@@ -40,6 +41,7 @@ AbstractClient::AbstractClient(QObject *parent)
     qRegisterMetaType<Event_ListRooms>("Event_ListRooms");
     qRegisterMetaType<Event_GameJoined>("Event_GameJoined");
     qRegisterMetaType<Event_UserMessage>("Event_UserMessage");
+    qRegisterMetaType<Event_NotifyUser>("Event_NotifyUser");
     qRegisterMetaType<ServerInfo_User>("ServerInfo_User");
     qRegisterMetaType<QList<ServerInfo_User> >("QList<ServerInfo_User>");
     qRegisterMetaType<Event_ReplayAdded>("Event_ReplayAdded");
@@ -75,6 +77,7 @@ void AbstractClient::processProtocolItem(const ServerMessage &item)
                 case SessionEvent::SERVER_SHUTDOWN: emit serverShutdownEventReceived(event.GetExtension(Event_ServerShutdown::ext)); break;
                 case SessionEvent::CONNECTION_CLOSED: emit connectionClosedEventReceived(event.GetExtension(Event_ConnectionClosed::ext)); break;
                 case SessionEvent::USER_MESSAGE: emit userMessageEventReceived(event.GetExtension(Event_UserMessage::ext)); break;
+                case SessionEvent::NOTIFY_USER: emit notifyUserEventReceived(event.GetExtension(Event_NotifyUser::ext)); break;
                 case SessionEvent::LIST_ROOMS: emit listRoomsEventReceived(event.GetExtension(Event_ListRooms::ext)); break;
                 case SessionEvent::ADD_TO_LIST: emit addToListEventReceived(event.GetExtension(Event_AddToList::ext)); break;
                 case SessionEvent::REMOVE_FROM_LIST: emit removeFromListEventReceived(event.GetExtension(Event_RemoveFromList::ext)); break;

--- a/cockatrice/src/abstractclient.h
+++ b/cockatrice/src/abstractclient.h
@@ -21,6 +21,7 @@ class Event_ServerMessage;
 class Event_ListRooms;
 class Event_GameJoined;
 class Event_UserMessage;
+class Event_NotifyUser;
 class Event_ConnectionClosed;
 class Event_ServerShutdown;
 class Event_ReplayAdded;
@@ -56,6 +57,7 @@ signals:
     void listRoomsEventReceived(const Event_ListRooms &event);
     void gameJoinedEventReceived(const Event_GameJoined &event);
     void userMessageEventReceived(const Event_UserMessage &event);
+    void notifyUserEventReceived(const Event_NotifyUser &event);
     void userInfoChanged(const ServerInfo_User &userInfo);
     void buddyListReceived(const QList<ServerInfo_User> &buddyList);
     void ignoreListReceived(const QList<ServerInfo_User> &ignoreList);

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -1,3 +1,6 @@
+#include <QDebug>
+#include <QPainter>
+#include <QMessageBox>
 #include <QApplication>
 #include "tab_supervisor.h"
 #include "abstractclient.h"
@@ -13,14 +16,12 @@
 #include "pixmapgenerator.h"
 #include "userlist.h"
 #include "settingscache.h"
-#include <QDebug>
-#include <QPainter>
-#include <QMessageBox>
 
 #include "pb/room_commands.pb.h"
 #include "pb/room_event.pb.h"
 #include "pb/game_event_container.pb.h"
 #include "pb/event_user_message.pb.h"
+#include "pb/event_notify_user.pb.h"
 #include "pb/event_game_joined.pb.h"
 #include "pb/serverinfo_user.pb.h"
 #include "pb/serverinfo_room.pb.h"
@@ -90,6 +91,7 @@ TabSupervisor::TabSupervisor(AbstractClient *_client, QWidget *parent)
     connect(client, SIGNAL(gameJoinedEventReceived(const Event_GameJoined &)), this, SLOT(gameJoined(const Event_GameJoined &)));
     connect(client, SIGNAL(userMessageEventReceived(const Event_UserMessage &)), this, SLOT(processUserMessageEvent(const Event_UserMessage &)));
     connect(client, SIGNAL(maxPingTime(int, int)), this, SLOT(updatePingTime(int, int)));
+    connect(client, SIGNAL(notifyUserEventReceived(const Event_NotifyUser &)), this, SLOT(processNotifyUserEvent(const Event_NotifyUser &)));
     
     retranslateUi();
 }
@@ -559,3 +561,13 @@ bool TabSupervisor::getAdminLocked() const
         return true;
     return tabAdmin->getLocked();
 }
+
+void TabSupervisor::processNotifyUserEvent(const Event_NotifyUser &event)
+{
+    switch ((Event_NotifyUser::NotificationType) event.type()) {
+        case Event_NotifyUser::PROMOTED: QMessageBox::information(this, tr("Promotion"), tr("You have been promoted to moderator. Please log out and back in for changes to take effect.")); break;
+        default: ;
+    }
+
+}
+

--- a/cockatrice/src/tab_supervisor.h
+++ b/cockatrice/src/tab_supervisor.h
@@ -22,6 +22,7 @@ class RoomEvent;
 class GameEventContainer;
 class Event_GameJoined;
 class Event_UserMessage;
+class Event_NotifyUser;
 class ServerInfo_Room;
 class ServerInfo_User;
 class GameReplay;
@@ -105,6 +106,7 @@ private slots:
     void processRoomEvent(const RoomEvent &event);
     void processGameEventContainer(const GameEventContainer &cont);
     void processUserMessageEvent(const Event_UserMessage &event);
+    void processNotifyUserEvent(const Event_NotifyUser &event);
 };
 
 #endif

--- a/cockatrice/src/user_context_menu.h
+++ b/cockatrice/src/user_context_menu.h
@@ -27,10 +27,12 @@ private:
     QAction *aAddToIgnoreList, *aRemoveFromIgnoreList;
     QAction *aKick;
     QAction *aBan;
+    QAction *aPromoteToMod, *aDemoteFromMod;
 signals:
     void openMessageDialog(const QString &userName, bool focus);
 private slots:
     void banUser_processUserInfoResponse(const Response &resp);
+    void adjustMod_processUserResponse(const Response &resp, const CommandContainer &commandContainer);
     void banUser_dialogFinished();
     void gamesOfUserReceived(const Response &resp, const CommandContainer &commandContainer);
 public:

--- a/common/pb/CMakeLists.txt
+++ b/common/pb/CMakeLists.txt
@@ -106,6 +106,7 @@ SET(PROTO_FILES
     event_user_joined.proto
     event_user_left.proto
     event_user_message.proto
+    event_notify_user.proto
     game_commands.proto
     game_event_container.proto
     game_event_context.proto
@@ -127,6 +128,7 @@ SET(PROTO_FILES
     response_register.proto
     response_replay_download.proto
     response_replay_list.proto
+    response_adjust_mod.proto
     response.proto
     room_commands.proto
     room_event.proto

--- a/common/pb/admin_commands.proto
+++ b/common/pb/admin_commands.proto
@@ -3,6 +3,7 @@ message AdminCommand {
 		UPDATE_SERVER_MESSAGE = 1000;
 		SHUTDOWN_SERVER = 1001;
 		RELOAD_CONFIG = 1002;
+		ADJUST_MOD = 1003;
 	}
 	extensions 100 to max;
 }
@@ -26,3 +27,12 @@ message Command_ReloadConfig {
 		optional Command_ReloadConfig ext = 1002;
 	}
 }
+
+message Command_AdjustMod {
+	extend AdminCommand {
+		optional Command_AdjustMod ext = 1003;
+	}
+	required string user_name = 1;
+	required bool should_be_mod = 2;
+}
+

--- a/common/pb/event_connection_closed.proto
+++ b/common/pb/event_connection_closed.proto
@@ -11,6 +11,7 @@ message Event_ConnectionClosed {
 		BANNED = 4;
 		USERNAMEINVALID = 5;
 		USER_LIMIT_REACHED = 6;
+		DEMOTED = 7;
 	}
 	optional CloseReason reason = 1;
 	optional string reason_str = 2;

--- a/common/pb/event_notify_user.proto
+++ b/common/pb/event_notify_user.proto
@@ -1,0 +1,14 @@
+import "session_event.proto";
+
+message Event_NotifyUser {
+
+	enum NotificationType {
+        PROMOTED = 1;
+    }
+
+	extend SessionEvent {
+		optional Event_NotifyUser ext = 1010;
+	}
+	optional NotificationType type = 1;
+
+}

--- a/common/pb/response.proto
+++ b/common/pb/response.proto
@@ -49,6 +49,7 @@ message Response {
         DECK_UPLOAD = 1008;
         REGISTER = 1009;
         ACTIVATE = 1010;
+        ADJUST_MOD = 1011;
         REPLAY_LIST = 1100;
         REPLAY_DOWNLOAD = 1101;
     }

--- a/common/pb/response_adjust_mod.proto
+++ b/common/pb/response_adjust_mod.proto
@@ -1,0 +1,7 @@
+import "response.proto";
+
+message Response_AdjustMod{
+	extend Response {
+		optional Response_AdjustMod ext = 1011;
+	}
+}

--- a/common/pb/session_event.proto
+++ b/common/pb/session_event.proto
@@ -12,6 +12,7 @@ message SessionEvent {
 		USER_JOINED = 1007;
 		USER_LEFT = 1008;
 		GAME_JOINED = 1009;
+		NOTIFY_USER = 1010;
 		REPLAY_ADDED = 1100;
 	}
 	extensions 100 to max;

--- a/servatrice/src/serversocketinterface.h
+++ b/servatrice/src/serversocketinterface.h
@@ -100,6 +100,7 @@ private:
     Response::ResponseCode cmdRegisterAccount(const Command_Register &cmd, ResponseContainer &rc);
     Response::ResponseCode cmdActivateAccount(const Command_Activate &cmd, ResponseContainer & /* rc */);
     Response::ResponseCode cmdReloadConfig(const Command_ReloadConfig &/* cmd */, ResponseContainer & /*rc*/);
+	Response::ResponseCode cmdAdjustMod(const Command_AdjustMod &cmd, ResponseContainer & /*rc*/);
 	
 	Response::ResponseCode processExtendedSessionCommand(int cmdType, const SessionCommand &cmd, ResponseContainer &rc);
 	Response::ResponseCode processExtendedModeratorCommand(int cmdType, const ModeratorCommand &cmd, ResponseContainer &rc);


### PR DESCRIPTION
Fix #1377 

This PR adds the ability for administrators to promote a user to moderator status, or demote a moderator to user status.  A new right click context menu item has been added when a moderator right clicks on the username from the user list (as long as the admin tools are  unlocked).

Things to point out about this change.
* A extension to the session event protocol has been put in place.
* Right click menu option evaluates users current position and only adds promote or demote
* When a user is promoted, the user is sent a notification about so mentioning they need to log out / in
* When a mod is demoted, the moderator is immediately removed from the server.
* Admin performing the command always gets notified of the commands results (success/fail)
* The new event notifications logic has been put in place to also accommodate #190.

(Items not pictured are the context menu items and failure popup boxes if the commands fail.)

Edit:
Please ignore the commit message, it mis-states "moderators to promote".  It should read "Admins to promote".  Moderators do not get the menu options and the new menu items are located in the processExtendedAdminCommands function.