### PR TITLE
Log old session out of server if logging in from a second location

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -85,6 +85,7 @@ void MainWindow::processConnectionClosedEvent(const Event_ConnectionClosed &even
         }
         case Event_ConnectionClosed::SERVER_SHUTDOWN: reasonStr = tr("Scheduled server shutdown."); break;
         case Event_ConnectionClosed::USERNAMEINVALID: reasonStr = tr("Invalid username."); break;
+        case Event_ConnectionClosed::LOGGEDINELSEWERE: reasonStr = tr("You have been logged out due to logging in at another location."); break;
         default: reasonStr = QString::fromStdString(event.reason_str());
     }
     QMessageBox::critical(this, tr("Connection closed"), tr("The server has terminated your connection.\nReason: %1").arg(reasonStr));

--- a/common/pb/event_connection_closed.proto
+++ b/common/pb/event_connection_closed.proto
@@ -12,6 +12,7 @@ message Event_ConnectionClosed {
 		USERNAMEINVALID = 5;
 		USER_LIMIT_REACHED = 6;
 		DEMOTED = 7;
+		LOGGEDINELSEWERE = 8;
 	}
 	optional CloseReason reason = 1;
 	optional string reason_str = 2;


### PR DESCRIPTION
Fix #1393 

This doesnt extend the session information, its just a change to the way the server handles the previous logged in session.  With no update to the protocol there is no need for a client side change.

![image](https://cloud.githubusercontent.com/assets/1361287/9422694/b4111b00-486d-11e5-85d0-629435e960bf.png)
