### PR TITLE
[WIP] Use QCommandLineParser instead of by-hand parsing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ MESSAGE("UPDATE TRANSLATIONS: ${UPDATE_TRANSLATIONS}")
 
 IF(NOT WITH_QT4)
     # First known not-broken Qt5 version (5.0.2 available on old ubuntus is buggy).
-    FIND_PACKAGE(Qt5Widgets 5.0.3)
+    FIND_PACKAGE(Qt5Widgets 5.0.3 REQUIRED)
 ENDIF()
 
 IF(Qt5Widgets_FOUND)

--- a/servatrice/src/main.cpp
+++ b/servatrice/src/main.cpp
@@ -33,6 +33,9 @@
 #include "rng_sfmt.h"
 #include "version_string.h"
 #include <google/protobuf/stubs/common.h>
+#if QT_VERSION_CHECK(5, 2, 0)
+#include <qcommandlineparser.h>
+#endif
 
 RNG_Abstract *rng;
 ServerLogger *logger;
@@ -129,15 +132,45 @@ int main(int argc, char *argv[])
 	QCoreApplication app(argc, argv);
 	app.setOrganizationName("Cockatrice");
 	app.setApplicationName("Servatrice");
-	
-	QStringList args = app.arguments();
-	bool testRandom = args.contains("--test-random");
-	bool testHashFunction = args.contains("--test-hash");
-	bool logToConsole = args.contains("--log-to-console");
+	app.setApplicationVersion(VERSION_STRING);
+
+	bool testRandom = false;
+	bool testHashFunction = false;
+	bool logToConsole = false;
 	QString configPath;
-	int hasConfigPath=args.indexOf("--config");
-	if(hasConfigPath > -1 && args.count() > hasConfigPath + 1)
-		configPath = args.at(hasConfigPath + 1);
+
+#if QT_VERSION_CHECK(5, 2, 0)
+	QCommandLineParser parser;
+	parser.addHelpOption();
+	parser.addVersionOption();
+
+	QCommandLineOption testRandomOpt("test-random", "Test PRNG (chi^2)");
+	parser.addOption(testRandomOpt);
+
+	QCommandLineOption testHashFunctionOpt("test-hash", "Test password hash function");
+	parser.addOption(testHashFunctionOpt);
+
+	QCommandLineOption logToConsoleOpt("log-to-console", "Write server logs to console");
+	parser.addOption(logToConsoleOpt);
+
+	QCommandLineOption configPathOpt("config", "Read server configuration from <file>", "file", "");
+	parser.addOption(configPathOpt);
+
+	parser.process(app);
+
+	testRandom = parser.isSet(testRandomOpt);
+	testHashFunction = parser.isSet(testHashFunctionOpt);
+	logToConsole = parser.isSet(logToConsoleOpt);
+	configPath = parser.value(configPathOpt);
+#else
+	QStringList args = app.arguments();
+	testRandom = args.contains("--test-random");
+	testHashFunction = args.contains("--test-hash");
+ 	logToConsole = args.contains("--log-to-console");
+ 	int hasConfigPath = args.indexOf("--config");
+ 	if (hasConfigPath > -1 && args.count() > hasConfigPath + 1)
+ 		configPath = args.at(hasConfigPath + 1);
+#endif // QT_VERSION_CHECK
 	
 	qRegisterMetaType<QList<int> >("QList<int>");
 

--- a/servatrice/src/passwordhasher.cpp
+++ b/servatrice/src/passwordhasher.cpp
@@ -1,44 +1,12 @@
 #include "passwordhasher.h"
 
-#if QT_VERSION < 0x050000
-    #include <stdio.h>
-    #include <string.h>
-    #include <gcrypt.h>
-#endif
-
 #include <QCryptographicHash>
 #include "rng_sfmt.h"
 
 void PasswordHasher::initialize()
 {
-#if QT_VERSION < 0x050000
-    // These calls are required by libgcrypt before we use any of its functions.
-    gcry_check_version(0);
-    gcry_control(GCRYCTL_DISABLE_SECMEM, 0);
-    gcry_control(GCRYCTL_INITIALIZATION_FINISHED, 0);
-#endif
 }
 
-#if QT_VERSION < 0x050000
-QString PasswordHasher::computeHash(const QString &password, const QString &salt)
-{
-    const int algo = GCRY_MD_SHA512;
-    const int rounds = 1000;
-
-    QByteArray passwordBuffer = (salt + password).toUtf8();
-    int hashLen = gcry_md_get_algo_dlen(algo);
-    char *hash = new char[hashLen], *tmp = new char[hashLen];
-    gcry_md_hash_buffer(algo, hash, passwordBuffer.data(), passwordBuffer.size());
-    for (int i = 1; i < rounds; ++i) {
-        memcpy(tmp, hash, hashLen);
-        gcry_md_hash_buffer(algo, hash, tmp, hashLen);
-    }
-    QString hashedPass = salt + QString(QByteArray(hash, hashLen).toBase64());
-    delete[] tmp;
-    delete[] hash;
-    return hashedPass;
-}
-#else
 QString PasswordHasher::computeHash(const QString &password, const QString &salt)
 {
     QCryptographicHash::Algorithm algo = QCryptographicHash::Sha512;
@@ -51,7 +19,6 @@ QString PasswordHasher::computeHash(const QString &password, const QString &salt
     QString hashedPass = salt + QString(hash.toBase64());
     return hashedPass;
 }
-#endif
 
 QString PasswordHasher::generateRandomSalt(const int len)
 {

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -80,11 +80,7 @@ Servatrice_GameServer::~Servatrice_GameServer()
     }
 }
 
-#if QT_VERSION < 0x050000
-void Servatrice_GameServer::incomingConnection(int socketDescriptor)
-#else
 void Servatrice_GameServer::incomingConnection(qintptr socketDescriptor)
-#endif
 {
     // Determine connection pool with smallest client count
     int minClientCount = -1;
@@ -109,11 +105,7 @@ void Servatrice_GameServer::incomingConnection(qintptr socketDescriptor)
     QMetaObject::invokeMethod(ssi, "initConnection", Qt::QueuedConnection, Q_ARG(int, socketDescriptor));
 }
 
-#if QT_VERSION < 0x050000
-void Servatrice_IslServer::incomingConnection(int socketDescriptor)
-#else
 void Servatrice_IslServer::incomingConnection(qintptr socketDescriptor)
-#endif
 {
     QThread *thread = new QThread;
     connect(thread, SIGNAL(finished()), thread, SLOT(deleteLater()));
@@ -298,16 +290,11 @@ bool Servatrice::initServer()
         if (!certFile.open(QIODevice::ReadOnly))
             throw QString("Error opening certificate file: %1").arg(certFileName);
         QSslCertificate cert(&certFile);
-#if QT_VERSION < 0x050000
-        if (!cert.isValid())
-            throw(QString("Invalid certificate."));
-#else
         const QDateTime currentTime = QDateTime::currentDateTime();
         if(currentTime < cert.effectiveDate() ||
             currentTime > cert.expiryDate() ||
             cert.isBlacklisted())
             throw(QString("Invalid certificate."));
-#endif
         qDebug() << "Loading private key...";
         QFile keyFile(keyFileName);
         if (!keyFile.open(QIODevice::ReadOnly))

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -51,11 +51,7 @@ public:
     Servatrice_GameServer(Servatrice *_server, int _numberPools, const QSqlDatabase &_sqlDatabase, QObject *parent = 0);
     ~Servatrice_GameServer();
 protected:
-#if QT_VERSION < 0x050000
-    void incomingConnection(int socketDescriptor);
-#else
     void incomingConnection(qintptr socketDescriptor);
-#endif
 };
 
 class Servatrice_IslServer : public QTcpServer {
@@ -68,11 +64,7 @@ public:
     Servatrice_IslServer(Servatrice *_server, const QSslCertificate &_cert, const QSslKey &_privateKey, QObject *parent = 0)
         : QTcpServer(parent), server(_server), cert(_cert), privateKey(_privateKey) { }
 protected:
-#if QT_VERSION < 0x050000
-    void incomingConnection(int socketDescriptor);
-#else
     void incomingConnection(qintptr socketDescriptor);
-#endif
 };
 
 class ServerProperties {

--- a/servatrice/src/settingscache.cpp
+++ b/servatrice/src/settingscache.cpp
@@ -1,11 +1,7 @@
 #include "settingscache.h"
 #include <QCoreApplication>
 #include <QFile>
-#if QT_VERSION >= 0x050000
-    #include <QStandardPaths>
-#else
-    #include <QDesktopServices>
-#endif
+#include <QStandardPaths>
 
 SettingsCache::SettingsCache(const QString & fileName, QSettings::Format format, QObject * parent)
 :QSettings(fileName, format, parent)
@@ -34,10 +30,6 @@ QString SettingsCache::guessConfigurationPath(QString & specificPath)
         return guessFileName;
 #endif
 
-#if QT_VERSION >= 0x050000
-    guessFileName =  QStandardPaths::writableLocation(QStandardPaths::DataLocation) + "/" + fileName;
-#else
-    guessFileName =  QDesktopServices::storageLocation(QDesktopServices::DataLocation) + "/" + fileName;
-#endif
+    guessFileName = QStandardPaths::writableLocation(QStandardPaths::DataLocation) + "/" + fileName;
     return guessFileName;
 }

--- a/servatrice/src/smtp/qxthmac.h
+++ b/servatrice/src/smtp/qxthmac.h
@@ -28,10 +28,6 @@
 
 #include <QtGlobal>
 
-#if QT_VERSION < 0x040300
-#   warning QxtHmac requires Qt 4.3.0 or greater
-#else
-
 #include <QCryptographicHash>
 #include "qxtglobal.h"
 
@@ -60,5 +56,4 @@ private:
     QXT_DECLARE_PRIVATE(QxtHmac)
 };
 
-#endif
 #endif


### PR DESCRIPTION
This will be more flexible for future CLI options

```
arg-parsing!Cockatrice/build *> ./servatrice/servatrice.app/Contents/MacOS/servatrice --help
Usage: ./servatrice/servatrice.app/Contents/MacOS/servatrice [options]

Options:
  -h, --help        Displays this help.
  -v, --version     Displays version information.
  --test-random     Test PRNG
  --test-hash       Test hash function
  --log-to-console  Write server logs to console
  --config <file>   Read server configuration from <file>
```