### PR TITLE
Prevent bad flags

### DIFF
--- a/cockatrice/src/dlg_register.h
+++ b/cockatrice/src/dlg_register.h
@@ -19,7 +19,7 @@ public:
     QString getPassword() const { return passwordEdit->text(); }
     QString getEmail() const { return emailEdit->text(); }
     int getGender() const { return genderEdit->currentIndex() - 1; }
-    QString getCountry() const { return genderEdit->currentIndex() == 0 ? "" : countryEdit->currentText(); }
+    QString getCountry() const { return countryEdit->currentIndex() == 0 ? "" : countryEdit->currentText(); }
     QString getRealName() const { return realnameEdit->text(); }
 private slots:
     void actOk();


### PR DESCRIPTION
Fix #1412 

This prevents the translation & invalid args being sent when registering for invalid flags.