### PR TITLE
Extend the login protocol to send the client version (as optional)

### DIFF
--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -12,6 +12,7 @@
 #include "pb/event_server_identification.pb.h"
 #include "settingscache.h"
 #include "main.h"
+#include "version_string.h"
 
 static const unsigned int protocolVersion = 14;
 
@@ -112,6 +113,7 @@ void RemoteClient::doLogin()
     cmdLogin.set_user_name(userName.toStdString());
     cmdLogin.set_password(password.toStdString());
     cmdLogin.set_clientid(settingsCache->getClientID().toStdString());
+    cmdLogin.set_clientver(VERSION_STRING);
     PendingCommand *pend = prepareSessionCommand(cmdLogin);
     connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(loginResponse(Response)));
     sendCommand(pend);

--- a/common/pb/session_commands.proto
+++ b/common/pb/session_commands.proto
@@ -44,6 +44,7 @@ message Command_Login {
     optional string user_name = 1;
     optional string password = 2;
     optional string clientid = 3;
+    optional string clientver = 4;
 }
 
 message Command_Message {


### PR DESCRIPTION
Added the client version information into the PB item to be sent to the server from the client at login.