### PR TITLE
[WIP] Updated client notification

### DIFF
--- a/cockatrice/src/abstractclient.h
+++ b/cockatrice/src/abstractclient.h
@@ -65,6 +65,8 @@ signals:
     void registerAccepted();
     void registerAcceptedNeedsActivate();
     void activateAccepted();
+    void serverUpdateClientCheckReceived();
+    void notifyOfClientUpdate();
     
     void sigQueuePendingCommand(PendingCommand *pend);
 private:

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -54,6 +54,7 @@ GeneralSettingsPage::GeneralSettingsPage()
     pixmapCacheEdit.setSuffix(" MB");
     picDownloadHqCheckBox.setChecked(settingsCache->getPicDownloadHq());
     picDownloadCheckBox.setChecked(settingsCache->getPicDownload());
+    checkForUpdatesCheckBox.setChecked(settingsCache->getEnableClientUpdateCheck());
     
     highQualityURLEdit = new QLineEdit(settingsCache->getPicUrlHq());
     highQualityURLEdit->setEnabled(settingsCache->getPicDownloadHq());
@@ -63,6 +64,7 @@ GeneralSettingsPage::GeneralSettingsPage()
     connect(&picDownloadCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setPicDownload(int)));
     connect(&picDownloadHqCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setPicDownloadHq(int)));
     connect(&pixmapCacheEdit, SIGNAL(valueChanged(int)), settingsCache, SLOT(setPixmapCacheSize(int)));
+    connect(&checkForUpdatesCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setEnableClientUpdateCheck(int)));
     connect(&picDownloadHqCheckBox, SIGNAL(clicked(bool)), this, SLOT(setEnabledStatus(bool)));
     connect(highQualityURLEdit, SIGNAL(textChanged(QString)), settingsCache, SLOT(setPicUrlHq(QString)));
 
@@ -73,7 +75,8 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(&pixmapCacheEdit, 1, 1, 1, 1);
     personalGrid->addWidget(&picDownloadCheckBox, 2, 0, 1, 2);
     personalGrid->addWidget(&picDownloadHqCheckBox, 3, 0, 1, 2);
-    personalGrid->addWidget(&clearDownloadedPicsButton, 4, 0, 1, 1);
+    personalGrid->addWidget(&checkForUpdatesCheckBox, 4, 0);
+    personalGrid->addWidget(&clearDownloadedPicsButton,6, 0, 1, 1);
     personalGrid->addWidget(&highQualityURLLabel, 5, 0, 1, 1);
     personalGrid->addWidget(highQualityURLEdit, 5, 1, 1, 1);
     personalGrid->addWidget(&highQualityURLLinkLabel, 6, 1, 1, 1);
@@ -236,6 +239,7 @@ void GeneralSettingsPage::retranslateUi()
     languageLabel.setText(tr("Language:"));
     picDownloadCheckBox.setText(tr("Download card pictures on the fly"));
     picDownloadHqCheckBox.setText(tr("Download card pictures from a custom URL"));
+    checkForUpdatesCheckBox.setText(tr("Automatically check for client updates"));
     pathsGroupBox->setTitle(tr("Paths"));
     deckPathLabel.setText(tr("Decks directory:"));
     replaysPathLabel.setText(tr("Replays directory:"));

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -60,6 +60,7 @@ private:
     QComboBox languageBox;
     QCheckBox picDownloadCheckBox;
     QCheckBox picDownloadHqCheckBox;
+    QCheckBox checkForUpdatesCheckBox;
     QLabel languageLabel;
     QLabel pixmapCacheLabel;
     QLabel deckPathLabel;

--- a/cockatrice/src/remoteclient.h
+++ b/cockatrice/src/remoteclient.h
@@ -21,6 +21,9 @@ signals:
     void sigRegisterToServer(const QString &hostname, unsigned int port, const QString &_userName, const QString &_password, const QString &_email, const int _gender, const QString &_country, const QString &_realname);
     void sigActivateToServer(const QString &_token);
     void sigDisconnectFromServer();
+    void sendServerUpdateClientCheck();
+
+
 private slots:
     void slotConnected();
     void readData();
@@ -36,6 +39,8 @@ private slots:
     void doLogin();
     void doDisconnectFromServer();
     void doActivateToServer(const QString &_token);
+    void doServerUpdateClientCheck();
+    void processClientUpdateCheck(const Response &response);
 
 private:
     static const int maxTimeout = 10;
@@ -50,6 +55,7 @@ private:
     QTcpSocket *socket;
     QString lastHostname;
     int lastPort;
+
 protected slots:    
     void sendCommandContainer(const CommandContainer &cont);
 public:

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -27,6 +27,7 @@ SettingsCache::SettingsCache()
     settings = new QSettings(this);
     shortcutsSettings = new ShortcutsSettings(getSettingsPath(),this);
 
+    trustedSourceClientUpdateSuccess = settings->value("personal/trustedsourceclientchecksuccess",false).toBool();
     lang = settings->value("personal/lang").toString();
     keepalive = settings->value("personal/keepalive", 5).toInt();
 
@@ -120,6 +121,7 @@ SettingsCache::SettingsCache()
     spectatorsCanSeeEverything = settings->value("game/spectatorscanseeeverything", false).toBool();
     rememberGameSettings = settings->value("game/remembergamesettings", true).toBool();
     clientID = settings->value("personal/clientid", "notset").toString();
+    enableClientUpdateCheck = settings->value("personal/checkforupdates", true).toBool();
 
     QString file = getSettingsPath();
     file.append("layouts/deckLayout.ini");
@@ -607,8 +609,17 @@ void SettingsCache::setSpectatorsCanSeeEverything(const bool _spectatorsCanSeeEv
     settings->setValue("game/spectatorscanseeeverything", spectatorsCanSeeEverything);
 }
 
-void SettingsCache::setRememberGameSettings(const bool _rememberGameSettings)
-{
+void SettingsCache::setRememberGameSettings(const bool _rememberGameSettings) {
     rememberGameSettings = _rememberGameSettings;
     settings->setValue("game/remembergamesettings", rememberGameSettings);
+}
+void SettingsCache::setEnableClientUpdateCheck(int _enableClientUpdateCheck){
+    enableClientUpdateCheck = _enableClientUpdateCheck;
+    settings->setValue("personal/checkforupdates", enableClientUpdateCheck);
+}
+void SettingsCache::setTrustedSourceClientUpdateSuccess(const bool _trustedSourceClientUpdateSuccess)
+{
+    //set this value to true to automatically disable the client update check at login, this value will be used when trusted source client update checks come online
+    trustedSourceClientUpdateSuccess = _trustedSourceClientUpdateSuccess;
+    settings->setValue("personal/trustedsourceclientchecksuccess", trustedSourceClientUpdateSuccess);
 }

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -103,7 +103,9 @@ private:
     bool spectatorsCanTalk;
     bool spectatorsCanSeeEverything;
     bool rememberGameSettings;
+    bool trustedSourceClientUpdateSuccess;
     int keepalive;
+    bool enableClientUpdateCheck;
     QByteArray deckEditorLayoutState, deckEditorGeometry;
     QSize deckEditorFilterSize, deckEditorDeckSize, deckEditorCardSize;
     QString getSettingsPath();
@@ -128,7 +130,7 @@ public:
     bool getPicDownloadHq() const { return picDownloadHq; }
     bool getNotificationsEnabled() const { return notificationsEnabled; }
     bool getSpectatorNotificationsEnabled() const { return spectatorNotificationsEnabled; }
-
+    bool getTrustedSourceClientUpdateSuccess() const { return trustedSourceClientUpdateSuccess;}
     bool getDoubleClickToPlay() const { return doubleClickToPlay; }
     bool getPlayToStack() const { return playToStack; }
     bool getAnnotateTokens() const { return annotateTokens; }
@@ -180,6 +182,7 @@ public:
     bool getSpectatorsCanTalk() const { return spectatorsCanTalk; }
     bool getSpectatorsCanSeeEverything() const { return spectatorsCanSeeEverything; }
     bool getRememberGameSettings() const { return rememberGameSettings; }
+    bool getEnableClientUpdateCheck() const { return enableClientUpdateCheck; }
     int getKeepAlive() const { return keepalive; }
     void setClientID(QString clientID);
     QString getClientID() { return clientID; }
@@ -260,6 +263,8 @@ public slots:
     void setSpectatorsCanTalk(const bool _spectatorsCanTalk);
     void setSpectatorsCanSeeEverything(const bool _spectatorsCanSeeEverything);
     void setRememberGameSettings(const bool _rememberGameSettings);
+    void setEnableClientUpdateCheck(int _enableClientUpdateCheck);
+    void setTrustedSourceClientUpdateSuccess(const bool _trustedSourceClientUpdateSuccess);
 };
 
 extern SettingsCache *settingsCache;

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -567,7 +567,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(client, SIGNAL(statusChanged(ClientStatus)), this, SLOT(statusChanged(ClientStatus)));
     connect(client, SIGNAL(protocolVersionMismatch(int, int)), this, SLOT(protocolVersionMismatch(int, int)));
     connect(client, SIGNAL(userInfoChanged(const ServerInfo_User &)), this, SLOT(userInfoReceived(const ServerInfo_User &)), Qt::BlockingQueuedConnection);
-
+    connect(client, SIGNAL(notifyOfClientUpdate()), this, SLOT(doNotifyOfClientUpdate()));
     connect(client, SIGNAL(registerAccepted()), this, SLOT(registerAccepted()));
     connect(client, SIGNAL(registerAcceptedNeedsActivate()), this, SLOT(registerAcceptedNeedsActivate()));
     connect(client, SIGNAL(registerError(Response::ResponseCode, QString, quint32)), this, SLOT(registerError(Response::ResponseCode, QString, quint32)));
@@ -794,4 +794,9 @@ void MainWindow::refreshShortcuts()
     aSettings->setShortcuts(settingsCache->shortcuts().getShortcut("MainWindow/aSettings"));
     aExit->setShortcuts(settingsCache->shortcuts().getShortcut("MainWindow/aExit"));
     aCheckCardUpdates->setShortcuts(settingsCache->shortcuts().getShortcut("MainWindow/aCheckCardUpdates"));
+}
+
+void MainWindow::doNotifyOfClientUpdate()
+{
+    QMessageBox::information(this, "Client Update Check", "There is a new client available, please update your client.");
 }

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -53,6 +53,7 @@ private slots:
     void activateAccepted();
     void localGameEnded();
     void pixmapCacheSizeChanged(int newSizeInMBs);
+    void doNotifyOfClientUpdate();
 
     void actConnect();
     void actDisconnect();

--- a/common/pb/CMakeLists.txt
+++ b/common/pb/CMakeLists.txt
@@ -128,6 +128,7 @@ SET(PROTO_FILES
     response_register.proto
     response_replay_download.proto
     response_replay_list.proto
+    response_update_check.proto
     response_adjust_mod.proto
     response.proto
     room_commands.proto

--- a/common/pb/response.proto
+++ b/common/pb/response.proto
@@ -50,6 +50,7 @@ message Response {
         REGISTER = 1009;
         ACTIVATE = 1010;
         ADJUST_MOD = 1011;
+        UPDATE_CHECK = 1012;
         REPLAY_LIST = 1100;
         REPLAY_DOWNLOAD = 1101;
     }

--- a/common/pb/response_update_check.proto
+++ b/common/pb/response_update_check.proto
@@ -1,0 +1,15 @@
+syntax = "proto2";
+import "response.proto";
+
+message Response_UpdateCheck {
+	enum ResponseSource {
+  		TRUSTED_SITE = 1;
+   		SERVER = 2;
+   	}
+	extend Response {
+		optional Response_UpdateCheck ext = 1012;
+	}
+	required ResponseSource source = 1;
+	required string server_version = 2;
+	required bool update_available = 3;
+}

--- a/common/pb/session_commands.proto
+++ b/common/pb/session_commands.proto
@@ -23,6 +23,7 @@ message SessionCommand {
         ACCOUNT_EDIT = 1018;
         ACCOUNT_IMAGE = 1019;
         ACCOUNT_PASSWORD = 1020;
+        UPDATE_CHECK = 1021;
         REPLAY_LIST = 1100;
         REPLAY_DOWNLOAD = 1101;
         REPLAY_MODIFY_MATCH = 1102;
@@ -157,4 +158,11 @@ message Command_AccountPassword {
     }
     optional string old_password = 1;
     optional string new_password = 2;
+}
+
+message Command_UpdateCheck {
+    extend SessionCommand {
+        optional Command_UpdateCheck ext = 1021;
+    }
+    required string client_version = 1;
 }

--- a/common/server.h
+++ b/common/server.h
@@ -54,11 +54,12 @@ public:
     void addClient(Server_ProtocolHandler *player);
     void removeClient(Server_ProtocolHandler *player);
     virtual QString getLoginMessage() const { return QString(); }
-
+    virtual QString getServerVersion() const { return QString(); }
     virtual bool permitUnregisteredUsers() const { return true; }
     virtual bool getGameShouldPing() const { return false; }
     virtual bool getClientIdRequired() const { return false; }
     virtual bool getRegOnlyServer() const { return false; }
+    virtual bool getDenyClientUpdateResponses() const { return false; }
     virtual int getPingClockInterval() const { return 0; }
     virtual int getMaxGameInactivityTime() const { return 9999999; }
     virtual int getMaxPlayerInactivityTime() const { return 9999999; }

--- a/common/server_protocolhandler.h
+++ b/common/server_protocolhandler.h
@@ -39,6 +39,7 @@ class Command_LeaveRoom;
 class Command_RoomSay;
 class Command_CreateGame;
 class Command_JoinGame;
+class Command_UpdateCheck;
 
 class Server_ProtocolHandler : public QObject, public Server_AbstractUserInterface {
     Q_OBJECT
@@ -70,6 +71,7 @@ private:
     Response::ResponseCode cmdRoomSay(const Command_RoomSay &cmd, Server_Room *room, ResponseContainer &rc);
     Response::ResponseCode cmdCreateGame(const Command_CreateGame &cmd, Server_Room *room, ResponseContainer &rc);
     Response::ResponseCode cmdJoinGame(const Command_JoinGame &cmd, Server_Room *room, ResponseContainer &rc);
+    Response::ResponseCode cmdUpdateCheck(const Command_UpdateCheck &cmd, ResponseContainer &rc);
     
     Response::ResponseCode processSessionCommandContainer(const CommandContainer &cont, ResponseContainer &rc);
     virtual Response::ResponseCode processExtendedSessionCommand(int /* cmdType */, const SessionCommand & /* cmd */, ResponseContainer & /* rc */) { return Response::RespFunctionNotAllowed; }

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -47,8 +47,13 @@ clientkeepalive=1
 max_player_inactivity_time=15
 
 ; More modern clients generate client IDs based on specific client side information.  Enable this option to
-' require that clients report the client ID in order to log into the server.  Default is false
+; require that clients report the client ID in order to log into the server.  Default is false
 requireclientid=false
+
+; When clients check for updates and the update server is unreachable you can allow users to check for updates
+; against your server by comparing the client version information to the server information.  To disable responses
+; to client update requests set this setting to true.  Default is false
+denyupdatechecking=false
 
 [authentication]
 

--- a/servatrice/src/main.cpp
+++ b/servatrice/src/main.cpp
@@ -173,7 +173,7 @@ int main(int argc, char *argv[])
 	signalhandler = new SignalHandler();
 
 	rng = new RNG_SFMT;
-	
+
 	std::cerr << "Servatrice " << VERSION_STRING << " starting." << std::endl;
 	std::cerr << "-------------------------" << std::endl;
 	

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -140,6 +140,7 @@ Servatrice::~Servatrice()
 
 bool Servatrice::initServer()
 {
+    serverVersion = VERSION_STRING;
     serverName = settingsCache->value("server/name", "My Cockatrice server").toString();
     serverId = settingsCache->value("server/id", 0).toInt();
     clientIdRequired = settingsCache->value("server/requireclientid",0).toBool();
@@ -178,6 +179,9 @@ bool Servatrice::initServer()
     qDebug() << "Registration enabled: " << regServerOnly;
     if (registrationEnabled)
         qDebug() << "Require email address to register: " << requireEmailForRegistration;
+
+    denyClientUpdateResponses = settingsCache->value("server/denyupdatechecking", false).toBool();
+    qDebug() << "Allow client update requests: " << denyClientUpdateResponses;
 
     QString dbTypeStr = settingsCache->value("database/type").toString();
     if (dbTypeStr == "mysql")

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -29,6 +29,7 @@
 #include <QSqlDatabase>
 #include <QMetaType>
 #include "server.h"
+#include "version_string.h"
 
 Q_DECLARE_METATYPE(QSqlDatabase)
 
@@ -106,6 +107,7 @@ private:
     Servatrice_GameServer *gameServer;
     Servatrice_IslServer *islServer;
     QString serverName;
+    QString serverVersion;
     mutable QMutex loginMessageMutex;
     QString loginMessage;
     QString dbPrefix;
@@ -120,7 +122,7 @@ private:
     QString shutdownReason;
     int shutdownMinutes;
     QTimer *shutdownTimer;
-    bool isFirstShutdownMessage, clientIdRequired, regServerOnly;
+    bool isFirstShutdownMessage, clientIdRequired, regServerOnly, denyClientUpdateResponses;
 
     mutable QMutex serverListMutex;
     QList<ServerProperties> serverList;
@@ -135,11 +137,13 @@ public:
     ~Servatrice();
     bool initServer();
     QString getServerName() const { return serverName; }
+    QString getServerVersion() const { return serverVersion; }
     QString getLoginMessage() const { QMutexLocker locker(&loginMessageMutex); return loginMessage; }
     bool permitUnregisteredUsers() const { return authenticationMethod != AuthenticationNone; }
     bool getGameShouldPing() const { return true; }
     bool getClientIdRequired() const { return clientIdRequired; }
     bool getRegOnlyServer() const { return regServerOnly; }
+    bool getDenyClientUpdateResponses() const { return denyClientUpdateResponses; }
     int getPingClockInterval() const { return pingClockInterval; }
     int getMaxGameInactivityTime() const { return maxGameInactivityTime; }
     int getMaxPlayerInactivityTime() const { return maxPlayerInactivityTime; }


### PR DESCRIPTION
This is a fix / partial fix for #1214 

This PR adds the ability for client update checking based against the server that is being connected to.  How this works is, upon successful login a command is sent from the client to the server with the clients version string.  That string is then compared by the server to its own version string information and calculates if the servers version is newer than the clients version and if depending on the results sends a response back to the client containing the servers version string and true/false for a client upgrade.  The client then runs through its own checks to see if the expected result for update matches and if it does , it notifies the user that an updated client is available.

Both parties have the ability to disable the functionality preventing either update checks from occurring from the client or update true / server version string information from being returned to the client from the server.

The reason for this transaction type checking on both client and server parts is the future expectation for signed installers allowing for a trusted version of the code base.  If the client (or server) knows that they are in fact from a trusted source they can guarantee that there side calculations for if a client check is correct.  If that type of solution never comes to fruition the functionality will still operate, it just is doing more work than needed.

Another bit of functionality has been added to allow additional flexibility.  The client side check is designed to be a fall back type solution to update checking.  There is a variable created in the settings cache (TrustedSourceClientUpdateSuccess) that can be flipped to disable the client update check at login portion of the functionality leaving room for another update solution to occur prior to this version string type commit check to be performed.  With this functionality in place when another (non-version) type update solution comes around it can be worked in very easily and become the primary update check solution utilizing this as a fallback method.