### PR TITLE
Fix old_session logout race condition

### DIFF
--- a/common/server.cpp
+++ b/common/server.cpp
@@ -138,6 +138,7 @@ AuthenticationResult Server::loginUser(Server_ProtocolHandler *session, QString 
             users.value(name)->sendProtocolItem(*se);
             delete se;
 
+            QMetaObject::invokeMethod(users.value(name), "prepareDestroy", Qt::QueuedConnection);
         }
     } else if (authState == UnknownUser) {
         // Change user name so that no two users have the same names,


### PR DESCRIPTION
Fix #1437 

During a user log in, if the user has an old session an event is sent to the old sessions connection and relies on the event to remove the connection.  If a user's session has crashed and the event never logs the user out , the event for logout is sent and processing continues causing the new session to attempt to be created resulting in a problem. This change forces the old session to be destroyed on the server side along with the information event for log out making sure the new session doesn't create problems at login.
