### PR TITLE
Fix ban issue

### DIFF
--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -777,7 +777,7 @@ Response::ResponseCode ServerSocketInterface::cmdBanFromServer(const Command_Ban
         userList.append(user);
     }
 
-    if (userName.isEmpty() && address.isEmpty()) {
+    if (userName.isEmpty() && address.isEmpty() && (!QString::fromStdString(cmd.clientid()).isEmpty())) {
         QSqlQuery *query = sqlInterface->prepareQuery("select name from {prefix}_users where clientid = :client_id");
         query->bindValue(":client_id", QString::fromStdString(cmd.clientid()));
         sqlInterface->execSqlQuery(query);


### PR DESCRIPTION
An issue while banning was identified recently.  If a moderator opens the ban window, clears the name and address and leaves the clientid field either blank or unchecked the server identified all users containing no client id as the target list of people to place the ban for.

This adds a check in to make sure that the clientid is not blank.