### PR TITLE
Detect if a use is trying to place an invalid ban

### DIFF
--- a/cockatrice/src/userlist.cpp
+++ b/cockatrice/src/userlist.cpp
@@ -122,6 +122,25 @@ void BanDialog::okClicked()
         QMessageBox::critical(this, tr("Error"), tr("You have to select a name-based, IP-based, clientId based, or some combination of the three to place a ban."));
         return;
     }
+
+    if (nameBanCheckBox->isChecked())
+        if (nameBanEdit->text() == ""){
+            QMessageBox::critical(this, tr("Error"), tr("You must have at value in the name ban when selecting the name ban checkbox."));
+            return;
+        }
+
+    if (ipBanCheckBox->isChecked())
+        if (ipBanEdit->text() == ""){
+            QMessageBox::critical(this, tr("Error"), tr("You must have at value in the ip ban when selecting the ip ban checkbox."));
+            return;
+        }
+
+    if (idBanCheckBox->isChecked())
+        if (idBanCheckBox->text() == ""){
+            QMessageBox::critical(this, tr("Error"), tr("You must have at value in the clientid ban when selecting the clientid ban checkbox."));
+            return;
+        }
+
     accept();
 }
 


### PR DESCRIPTION
If a user selects the boxes next to the type of ban to place yet clears the box value's and clicks ok a ban is created that has no username, no ip and no client id in the db table.  This PR will prevent the user from creating the ban by checking the value(s) if the check boxes are selected.