### PR TITLE
Log inconsistent session / session table situation

### DIFF
--- a/common/server.cpp
+++ b/common/server.cpp
@@ -133,6 +133,8 @@ AuthenticationResult Server::loginUser(Server_ProtocolHandler *session, QString 
                 delete se;
 
                 users.value(name)->prepareDestroy();
+            } else {
+                qDebug() << "Active session and sessions table inconsistent, please validate session table information for user " << name;
             }
         }
 


### PR DESCRIPTION
If a user session is not successfully cleared from the db a condition can occur that the session does not exist at login to log out but the db table for session information still shows the old session data.  This adds a log entry when the condition occurs. 