### PR TITLE
fix Decks, Pics replays & sounds paths on Portable build

### DIFF
--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -26,7 +26,13 @@ QString SettingsCache::getSettingsPath()
 
 void SettingsCache::translateLegacySettings()
 {
-    //NOTE Please remove this legacy setting translation after 2016-9-1 (+1 year after creation)
+#ifdef PORTABLE_BUILD
+    setDeckPath("data/decks");
+    setReplaysPath("data/replays");
+    setPicsPath("data/pics");
+    setSoundPath("data/sounds");
+    return;
+#endif
 
     //Layouts
     QFile layoutFile(getSettingsPath()+"layouts/deckLayout.ini");

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -1,6 +1,7 @@
 #include "settingscache.h"
 #include <QSettings>
 #include <QFile>
+#include <QApplication>
 
 #if QT_VERSION >= 0x050000
     #include <QStandardPaths>
@@ -10,7 +11,7 @@
 
 QString SettingsCache::getSettingsPath()
 {
-    QString file = "settings/";
+    QString file = qApp->applicationDirPath() + "settings/";
 
 #ifndef PORTABLE_BUILD
     #if QT_VERSION >= 0x050000
@@ -27,10 +28,6 @@ QString SettingsCache::getSettingsPath()
 void SettingsCache::translateLegacySettings()
 {
 #ifdef PORTABLE_BUILD
-    setDeckPath("data/decks");
-    setReplaysPath("data/replays");
-    setPicsPath("data/pics");
-    setSoundPath("data/sounds");
     return;
 #endif
 
@@ -135,6 +132,13 @@ SettingsCache::SettingsCache()
 
     if(!QFile(settingsPath+"global.ini").exists())
         translateLegacySettings();
+
+#ifdef PORTABLE_BUILD
+    setDeckPath(qApp->applicationDirPath() + "data/decks");
+    setReplaysPath(qApp->applicationDirPath() +"data/replays");
+    setPicsPath(qApp->applicationDirPath() +  "data/pics");
+    setSoundPath(qApp->applicationDirPath() +"data/sounds");
+#endif
 
     notifyAboutUpdates = settings->value("personal/updatenotification", true).toBool();
     lang = settings->value("personal/lang").toString();

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -516,7 +516,7 @@ bool SaveSetsPage::validatePage()
         dataDir = QStandardPaths::standardLocations(QStandardPaths::DataLocation).first();
 #endif
 #else
-    dataDir = "data";
+    dataDir =  qApp->applicationDirPath() + "/data";
 #endif
 
 #ifdef PORTABLE_BUILD
@@ -731,7 +731,7 @@ bool SaveTokensPage::validatePage()
         dataDir = QStandardPaths::standardLocations(QStandardPaths::DataLocation).first();
 #endif
 #else
-    dataDir = "data";
+    dataDir = qApp->applicationDirPath() + "/data";
 #endif
 
 #ifdef PORTABLE_BUILD


### PR DESCRIPTION
fix Decks, Pics replays & sounds paths on Portable build
adding relative paths to the default values and stoping conckatrice to copy non-portable settings