### PR TITLE
Added the ability or moderation staff to request user ban history

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -6,8 +6,8 @@ PROJECT(cockatrice)
 
 SET(cockatrice_SOURCES
     src/abstractcounter.cpp 
-    src/counter_general.cpp 
-    src/dlg_creategame.cpp 
+    src/counter_general.cpp
+    src/dlg_creategame.cpp
     src/dlg_filter_games.cpp
     src/dlg_connect.cpp 
     src/dlg_create_token.cpp 

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -225,7 +225,6 @@ int main(int argc, char *argv[])
         ui.setWindowIcon(icon);
         
         settingsCache->setClientID(generateClientID());
-        qDebug() << "ClientID In Cache: " << settingsCache->getClientID();
 
         ui.show();
         qDebug("main(): ui.show() finished");

--- a/cockatrice/src/user_context_menu.h
+++ b/cockatrice/src/user_context_menu.h
@@ -26,12 +26,13 @@ private:
     QAction *aAddToBuddyList, *aRemoveFromBuddyList;
     QAction *aAddToIgnoreList, *aRemoveFromIgnoreList;
     QAction *aKick;
-    QAction *aBan;
+    QAction *aBan, *aBanHistory;
     QAction *aPromoteToMod, *aDemoteFromMod;
 signals:
     void openMessageDialog(const QString &userName, bool focus);
 private slots:
     void banUser_processUserInfoResponse(const Response &resp);
+    void banUserHistory_processResponse(const Response &resp);
     void adjustMod_processUserResponse(const Response &resp, const CommandContainer &commandContainer);
     void banUser_dialogFinished();
     void gamesOfUserReceived(const Response &resp, const CommandContainer &commandContainer);

--- a/common/featureset.cpp
+++ b/common/featureset.cpp
@@ -16,6 +16,7 @@ void FeatureSet::initalizeFeatureList(QMap<QString, bool> &featureList){
     featureList.insert("client_id", false);
     featureList.insert("client_ver", false);
     featureList.insert("feature_set", false);
+    featureList.insert("user_ban_history", false);
 }
 
 void FeatureSet::enableRequiredFeature(QMap<QString, bool> &featureList, QString featureName){

--- a/common/pb/CMakeLists.txt
+++ b/common/pb/CMakeLists.txt
@@ -116,6 +116,7 @@ SET(PROTO_FILES
     moderator_commands.proto
     move_card_to_zone.proto
     response_activate.proto
+    response_ban_history.proto
     response_deck_download.proto
     response_deck_list.proto
     response_deck_upload.proto
@@ -133,6 +134,7 @@ SET(PROTO_FILES
     room_commands.proto
     room_event.proto
     serverinfo_arrow.proto
+    serverinfo_ban.proto
     serverinfo_cardcounter.proto
     serverinfo_card.proto
     serverinfo_counter.proto

--- a/common/pb/moderator_commands.proto
+++ b/common/pb/moderator_commands.proto
@@ -2,6 +2,7 @@ syntax = "proto2";
 message ModeratorCommand {
     enum ModeratorCommandType {
         BAN_FROM_SERVER = 1000;
+        BAN_HISTORY = 1001;
     }
     extensions 100 to max;
 }
@@ -16,4 +17,11 @@ message Command_BanFromServer {
     optional string reason = 4;
     optional string visible_reason = 5;
     optional string clientid = 6;
+}
+
+message Command_GetBanHistory {
+    extend ModeratorCommand {
+        optional Command_GetBanHistory ext = 1001;
+    }
+    optional string user_name = 1;
 }

--- a/common/pb/response.proto
+++ b/common/pb/response.proto
@@ -52,6 +52,7 @@ message Response {
         REGISTER = 1009;
         ACTIVATE = 1010;
         ADJUST_MOD = 1011;
+        BAN_HISTORY = 1012;
         REPLAY_LIST = 1100;
         REPLAY_DOWNLOAD = 1101;
     }

--- a/common/pb/response_ban_history.proto
+++ b/common/pb/response_ban_history.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+import "response.proto";
+import "serverinfo_ban.proto";
+
+message Response_BanHistory{
+    extend Response {
+        optional Response_BanHistory ext = 1012;
+    }
+    repeated ServerInfo_Ban ban_list = 1;
+}

--- a/common/pb/serverinfo_ban.proto
+++ b/common/pb/serverinfo_ban.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+/*
+ * Historical ban information stored in the ban table
+ */
+message ServerInfo_Ban {
+    required string admin_id = 1; // id of the staff member placing the ban
+    required string admin_name = 2; // name of the staff member placing the ban
+    required string ban_time = 3; // start time of the ban
+    required string ban_length = 4; // amount of time in minutes the ban is for
+    optional string ban_reason = 5;  // reason seen only by moderation staff
+    optional string visible_reason = 6; // reason shown to the user
+}

--- a/common/server.cpp
+++ b/common/server.cpp
@@ -40,6 +40,7 @@
 Server::Server(bool _threaded, QObject *parent)
     : QObject(parent), threaded(_threaded), nextLocalGameId(0)
 {
+    qRegisterMetaType<ServerInfo_Ban>("ServerInfo_Ban");
     qRegisterMetaType<ServerInfo_Game>("ServerInfo_Game");
     qRegisterMetaType<ServerInfo_Room>("ServerInfo_Room");
     qRegisterMetaType<ServerInfo_User>("ServerInfo_User");

--- a/common/server.h
+++ b/common/server.h
@@ -9,6 +9,7 @@
 #include <QReadWriteLock>
 #include "pb/commands.pb.h"
 #include "pb/serverinfo_user.pb.h"
+#include "pb/serverinfo_ban.pb.h"
 #include "server_player_reference.h"
 
 class Server_DatabaseInterface;

--- a/common/server_metatypes.h
+++ b/common/server_metatypes.h
@@ -3,6 +3,7 @@
 
 #include <QMetaType>
 
+#include "pb/serverinfo_ban.pb.h"
 #include "pb/serverinfo_user.pb.h"
 #include "pb/serverinfo_room.pb.h"
 #include "pb/serverinfo_game.pb.h"
@@ -12,6 +13,7 @@
 #include "pb/isl_message.pb.h"
 #include "pb/room_commands.pb.h"
 
+Q_DECLARE_METATYPE(ServerInfo_Ban)
 Q_DECLARE_METATYPE(ServerInfo_User)
 Q_DECLARE_METATYPE(ServerInfo_Room)
 Q_DECLARE_METATYPE(ServerInfo_Game)

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -923,3 +923,33 @@ void Servatrice_DatabaseInterface::updateUsersLastLoginData(const QString &userN
         }
     }
 }
+
+QList<ServerInfo_Ban> Servatrice_DatabaseInterface::getUserBanHistory(const QString userName)
+{
+    QList<ServerInfo_Ban> results;
+    ServerInfo_Ban banDetails;
+
+    if (!checkSql())
+        return results;
+
+    QSqlQuery *query = prepareQuery("SELECT A.id_admin, A.time_from, A.minutes, A.reason, A.visible_reason, B.name AS name_admin FROM {prefix}_bans A LEFT JOIN {prefix}_users B ON A.id_admin=B.id WHERE A.user_name = :user_name");
+    query->bindValue(":user_name", userName);
+
+    if (!execSqlQuery(query)) {
+        qDebug("Failed to collect ban history information: SQL Error");
+        return results;
+    }
+
+    QString adminID,adminName,banTime,banLength,banReason,visibleReason;
+    while (query->next()){
+        banDetails.set_admin_id(QString(query->value(0).toString()).toStdString());
+        banDetails.set_admin_name(QString(query->value(5).toString()).toStdString());
+        banDetails.set_ban_time(QString(query->value(1).toString()).toStdString());
+        banDetails.set_ban_length(QString(query->value(2).toString()).toStdString());
+        banDetails.set_ban_reason(QString(query->value(3).toString()).toStdString());
+        banDetails.set_visible_reason(QString(query->value(4).toString()).toStdString());
+        results << banDetails;
+    }
+
+    return results;
+}

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -78,6 +78,7 @@ public:
         LogMessage_TargetType targetType, const int targetId, const QString &targetName);
     bool changeUserPassword(const QString &user, const QString &oldPassword, const QString &newPassword);
     QChar getGenderChar(ServerInfo_User_Gender const &gender);
+    QList<ServerInfo_Ban> getUserBanHistory(const QString userName);
 };
 
 #endif

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -51,6 +51,7 @@
 #include "pb/event_add_to_list.pb.h"
 #include "pb/event_remove_from_list.pb.h"
 #include "pb/event_notify_user.pb.h"
+#include "pb/response_ban_history.pb.h"
 #include "pb/response_deck_list.pb.h"
 #include "pb/response_deck_download.pb.h"
 #include "pb/response_deck_upload.pb.h"
@@ -60,6 +61,7 @@
 #include "pb/serverinfo_replay.pb.h"
 #include "pb/serverinfo_user.pb.h"
 #include "pb/serverinfo_deckstorage.pb.h"
+#include "pb/serverinfo_ban.pb.h"
 
 #include "version_string.h"
 #include <string>
@@ -301,6 +303,7 @@ Response::ResponseCode ServerSocketInterface::processExtendedModeratorCommand(in
 {
     switch ((ModeratorCommand::ModeratorCommandType) cmdType) {
         case ModeratorCommand::BAN_FROM_SERVER: return cmdBanFromServer(cmd.GetExtension(Command_BanFromServer::ext), rc);
+        case ModeratorCommand::BAN_HISTORY: return cmdGetBanHistory(cmd.GetExtension(Command_GetBanHistory::ext), rc);
         default: return Response::RespFunctionNotAllowed;
     }
 }
@@ -746,6 +749,19 @@ Response::ResponseCode ServerSocketInterface::cmdReplayDeleteMatch(const Command
 
 // MODERATOR FUNCTIONS.
 // May be called by admins and moderators. Permission is checked by the calling function.
+
+Response::ResponseCode ServerSocketInterface::cmdGetBanHistory(const Command_GetBanHistory &cmd, ResponseContainer &rc)
+{
+    QList<ServerInfo_Ban> banList;
+    QString userName = QString::fromStdString(cmd.user_name());
+
+    Response_BanHistory *re = new Response_BanHistory;
+    QListIterator<ServerInfo_Ban> banIterator(sqlInterface->getUserBanHistory(userName));
+    while (banIterator.hasNext())
+        re->add_ban_list()->CopyFrom(banIterator.next());
+    rc.setResponseExtension(re);
+    return Response::RespOk;
+}
 
 Response::ResponseCode ServerSocketInterface::cmdBanFromServer(const Command_BanFromServer &cmd, ResponseContainer & /*rc*/)
 {

--- a/servatrice/src/serversocketinterface.h
+++ b/servatrice/src/serversocketinterface.h
@@ -53,6 +53,7 @@ class Command_AccountEdit;
 class Command_AccountImage;
 class Command_AccountPassword;
 
+
 class ServerSocketInterface : public Server_ProtocolHandler
 {
 	Q_OBJECT
@@ -95,6 +96,7 @@ private:
 	Response::ResponseCode cmdReplayModifyMatch(const Command_ReplayModifyMatch &cmd, ResponseContainer &rc);
 	Response::ResponseCode cmdReplayDeleteMatch(const Command_ReplayDeleteMatch &cmd, ResponseContainer &rc);
 	Response::ResponseCode cmdBanFromServer(const Command_BanFromServer &cmd, ResponseContainer &rc);
+	Response::ResponseCode cmdGetBanHistory(const Command_GetBanHistory &cmd, ResponseContainer &rc);
 	Response::ResponseCode cmdShutdownServer(const Command_ShutdownServer &cmd, ResponseContainer &rc);
 	Response::ResponseCode cmdUpdateServerMessage(const Command_UpdateServerMessage &cmd, ResponseContainer &rc);
     Response::ResponseCode cmdRegisterAccount(const Command_Register &cmd, ResponseContainer &rc);


### PR DESCRIPTION
Fix #174 

This PR adds the right click option under the user context menu to request a user's ban history.

![image](https://cloud.githubusercontent.com/assets/1361287/9702147/a21eb300-541e-11e5-91d2-f9d99d948b6d.png)
