### PR TITLE
Do not close message tabs on disconnect

### DIFF
--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -281,11 +281,6 @@ void TabSupervisor::stop()
     while (replayIterator.hasNext())
         replayIterator.next()->deleteLater();
     replayTabs.clear();
-
-    QMapIterator<QString, TabMessage *> messageIterator(messageTabs);
-    while (messageIterator.hasNext())
-        messageIterator.next().value()->deleteLater();
-    messageTabs.clear();
     
     delete userInfo;
     userInfo = 0;


### PR DESCRIPTION
This PR is to prevent the tab supervisor from closing private message tabs on disconnect from the server.  This will allow users with less stable connections to not loose there conversations.  

I thought there was an issue / request for this but I couldnt find it in the searching I did.