### PR TITLE
fix settings icon spacing

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -917,5 +917,7 @@ void DlgSettings::retranslateUi()
     
     for (int i = 0; i < pagesWidget->count(); i++)
         dynamic_cast<AbstractSettingsPage *>(pagesWidget->widget(i))->retranslateUi();
+
+    contentsWidget->reset();
 }
 


### PR DESCRIPTION
Tell the list widget to recalculate items size after we set the items’ labels; fix #663