### PR TITLE
Fix server crash on banning

### DIFF
--- a/cockatrice/src/user_context_menu.cpp
+++ b/cockatrice/src/user_context_menu.cpp
@@ -210,7 +210,7 @@ void UserContextMenu::showContextMenu(const QPoint &pos, const QString &userName
         }
     }
     bool anotherUser = userName != QString::fromStdString(tabSupervisor->getUserInfo()->name());
-    aDetails->setEnabled(online);
+    aDetails->setEnabled(true);
     aChat->setEnabled(anotherUser && online);
     aShowGames->setEnabled(anotherUser);
     aAddToBuddyList->setEnabled(anotherUser);

--- a/cockatrice/src/userlist.cpp
+++ b/cockatrice/src/userlist.cpp
@@ -124,19 +124,19 @@ void BanDialog::okClicked()
     }
 
     if (nameBanCheckBox->isChecked())
-        if (nameBanEdit->text() == ""){
+        if (nameBanEdit->text().simplified() == ""){
             QMessageBox::critical(this, tr("Error"), tr("You must have a value in the name ban when selecting the name ban checkbox."));
             return;
         }
 
     if (ipBanCheckBox->isChecked())
-        if (ipBanEdit->text() == ""){
+        if (ipBanEdit->text().simplified() == ""){
             QMessageBox::critical(this, tr("Error"), tr("You must have a value in the ip ban when selecting the ip ban checkbox."));
             return;
         }
 
     if (idBanCheckBox->isChecked())
-        if (idBanCheckBox->text() == ""){
+        if (idBanEdit->text().simplified() == ""){
             QMessageBox::critical(this, tr("Error"), tr("You must have a value in the clientid ban when selecting the clientid ban checkbox."));
             return;
         }

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -18,6 +18,7 @@
 #include "pb/event_user_message.pb.h"
 #include "pb/event_game_joined.pb.h"
 #include "pb/event_room_say.pb.h"
+#include "pb/serverinfo_user.pb.h"
 #include <google/protobuf/descriptor.h>
 #include "featureset.h"
 
@@ -536,11 +537,13 @@ Response::ResponseCode Server_ProtocolHandler::cmdGetUserInfo(const Command_GetU
         QReadLocker locker(&server->clientsLock);
 
         ServerInfo_User_Container *infoSource = server->findUser(userName);
-        if (!infoSource)
-            return Response::RespNameNotFound;
-
-        re->mutable_user_info()->CopyFrom(infoSource->copyUserInfo(true, false, userInfo->user_level() & ServerInfo_User::IsModerator));
+        if (!infoSource) {
+            re->mutable_user_info()->CopyFrom(databaseInterface->getUserData(userName,true));
+        } else {
+            re->mutable_user_info()->CopyFrom(infoSource->copyUserInfo(true, false, userInfo->user_level() & ServerInfo_User::IsModerator));
+        }
     }
+
 
     rc.setResponseExtension(re);
     return Response::RespOk;


### PR DESCRIPTION
Fix #107 

This PR also fixes the crash that can occur if the username field is passed as empty spaces for the name. There is a change to trim all the variables that could be used to place a ban and adds a check that if all 3 variables end up blank to not put an invalid ban table row.

This should fix the issue reported by JineteDV .
Was able to reproduce the issue on the testing server.

This also address's the issue reported that when an offline user data is queried no user information is returned.  The cmdGetUserInfo function is updated to query the users data from the user table and return it.  Information such as ip_address for an offline user is not returned but other details should be.