### PR TITLE
Added chat history to a room that is displayed on join

### DIFF
--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -12,6 +12,7 @@
 #include "settingscache.h"
 #include "tab_userlists.h"
 #include "soundengine.h"
+#include "room_message_type.h"
 
 const QColor DEFAULT_MENTION_COLOR = QColor(194, 31, 47);
 const QColor OTHER_USER_COLOR = QColor(0, 65, 255); // dark blue
@@ -121,7 +122,7 @@ void ChatView::appendUrlTag(QTextCursor &cursor, QString url)
     cursor.setCharFormat(oldFormat);
 }
 
-void ChatView::appendMessage(QString message, QString sender, UserLevelFlags userLevel, bool playerBold)
+void ChatView::appendMessage(QString message, RoomMessageTypeFlags messageType, QString sender, UserLevelFlags userLevel, bool playerBold)
 {
     bool atBottom = verticalScrollBar()->value() >= verticalScrollBar()->maximum();
     bool sameSender = (sender == lastSender) && !lastSender.isEmpty();
@@ -129,7 +130,7 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
     lastSender = sender;
     
     // timestamp
-    if (showTimestamps && !sameSender) {
+    if (showTimestamps && !sameSender && !sender.isEmpty()) {
         QTextCharFormat timeFormat;
         timeFormat.setForeground(QColor(SERVER_MESSAGE_COLOR));
         if (sender.isEmpty())
@@ -168,8 +169,17 @@ void ChatView::appendMessage(QString message, QString sender, UserLevelFlags use
     // use different color for server messages 
     defaultFormat = QTextCharFormat();
     if (sender.isEmpty()) {
-        defaultFormat.setForeground(Qt::darkGreen);
-        defaultFormat.setFontWeight(QFont::Bold);
+        switch (messageType) {
+            case Event_RoomSay::Welcome:
+                defaultFormat.setForeground(Qt::darkGreen);
+                defaultFormat.setFontWeight(QFont::Bold);
+                break;
+            case Event_RoomSay::ChatHistory:
+                defaultFormat.setForeground(Qt::gray);
+                defaultFormat.setFontWeight(QFont::Light);
+                defaultFormat.setFontItalic(true);
+                break;
+        }
     }
     cursor.setCharFormat(defaultFormat);
 

--- a/cockatrice/src/chatview.h
+++ b/cockatrice/src/chatview.h
@@ -8,6 +8,7 @@
 #include <QAction>
 #include "userlist.h"
 #include "user_level.h"
+#include "room_message_type.h"
 #include "tab_supervisor.h"
 
 class QTextTable;
@@ -59,7 +60,7 @@ public:
     void retranslateUi();
     void appendHtml(const QString &html);
     void appendHtmlServerMessage(const QString &html, bool optionalIsBold = false, QString optionalFontColor = QString());
-    void appendMessage(QString message, QString sender = QString(), UserLevelFlags userLevel = UserLevelFlags(), bool playerBold = false);
+    void appendMessage(QString message, RoomMessageTypeFlags messageType = 0, QString sender = QString(), UserLevelFlags userLevel = UserLevelFlags(), bool playerBold = false);
     void clearChat();
 protected:
     void enterEvent(QEvent *event);

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -483,6 +483,9 @@ MessagesSettingsPage::MessagesSettingsPage()
     mentionPopups.setChecked(settingsCache->getShowMentionPopup());
     connect(&mentionPopups, SIGNAL(stateChanged(int)), settingsCache, SLOT(setShowMentionPopups(int)));
 
+    roomHistory.setChecked(settingsCache->getRoomHistory());
+    connect(&roomHistory, SIGNAL(stateChanged(int)), settingsCache, SLOT(setRoomHistory(int)));
+
     customAlertString = new QLineEdit();
     customAlertString->setPlaceholderText("Word1 Word2 Word3");
     customAlertString->setText(settingsCache->getHighlightWords());
@@ -498,6 +501,7 @@ MessagesSettingsPage::MessagesSettingsPage()
     chatGrid->addWidget(&ignoreUnregUserMessages, 3, 0);
     chatGrid->addWidget(&messagePopups, 4, 0);
     chatGrid->addWidget(&mentionPopups, 5, 0);
+    chatGrid->addWidget(&roomHistory, 6, 0);
     chatGroupBox = new QGroupBox;
     chatGroupBox->setLayout(chatGrid);
     
@@ -626,7 +630,8 @@ void MessagesSettingsPage::retranslateUi()
     invertMentionForeground.setText(tr("Invert text color"));
     invertHighlightForeground.setText(tr("Invert text color"));
     messagePopups.setText(tr("Enable desktop notifications for private messages"));
-    mentionPopups.setText(tr("Enable desktop notification for mentions."));
+    mentionPopups.setText(tr("Enable desktop notification for mentions"));
+    roomHistory.setText(tr("Enable room message history on join"));
     hexLabel.setText(tr("(Color is hexadecimal)"));
     hexHighlightLabel.setText(tr("(Color is hexadecimal)"));
     customAlertStringLabel.setText(tr("Separate words with a space, alphanumeric characters only"));

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -153,6 +153,7 @@ private:
     QCheckBox ignoreUnregUserMessages;
     QCheckBox messagePopups;
     QCheckBox mentionPopups;
+    QCheckBox roomHistory;
     QGroupBox *chatGroupBox;
     QGroupBox *highlightGroupBox;
     QGroupBox *messageShortcuts;

--- a/cockatrice/src/localserver.cpp
+++ b/cockatrice/src/localserver.cpp
@@ -6,7 +6,7 @@ LocalServer::LocalServer(QObject *parent)
     : Server(false, parent)
 {
     setDatabaseInterface(new LocalServer_DatabaseInterface(this));
-    addRoom(new Server_Room(0, QString(), QString(), QString(), false, QString(), QStringList(), this));
+    addRoom(new Server_Room(0, 0, QString(), QString(), QString(), false, QString(), QStringList(), this));
 }
 
 LocalServer::~LocalServer()

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -168,12 +168,12 @@ void MessageLogWidget::logConnectionStateChanged(Player *player, bool connection
 
 void MessageLogWidget::logSay(Player *player, QString message)
 {
-    appendMessage(message, player->getName(), UserLevelFlags(player->getUserInfo()->user_level()), true);
+    appendMessage(message, 0, player->getName(), UserLevelFlags(player->getUserInfo()->user_level()), true);
 }
 
 void MessageLogWidget::logSpectatorSay(QString spectatorName, UserLevelFlags spectatorUserLevel, QString message)
 {
-    appendMessage(message, spectatorName, spectatorUserLevel, false);
+    appendMessage(message, 0, spectatorName, spectatorUserLevel, false);
 }
 
 void MessageLogWidget::logShuffle(Player *player, CardZone *zone)

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -208,6 +208,7 @@ SettingsCache::SettingsCache()
     scaleCards = settings->value("cards/scaleCards", true).toBool();
     showMessagePopups = settings->value("chat/showmessagepopups", true).toBool();
     showMentionPopups = settings->value("chat/showmentionpopups", true).toBool();
+    roomHistory = settings->value("chat/roomhistory", true).toBool();
 
     leftJustified = settings->value("interface/leftjustified", false).toBool();
 
@@ -263,6 +264,11 @@ void SettingsCache::setShowMessagePopups(const int _showMessagePopups) {
 void SettingsCache::setShowMentionPopups(const int _showMentionPopus) {
     showMentionPopups = _showMentionPopus;
     settings->setValue("chat/showmentionpopups", showMentionPopups);
+}
+
+void SettingsCache::setRoomHistory(const int _roomHistory) {
+    roomHistory = _roomHistory;
+    settings->setValue("chat/roomhistory", roomHistory);
 }
 
 void SettingsCache::setLang(const QString &_lang)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -95,6 +95,7 @@ private:
     bool scaleCards;
     bool showMessagePopups;
     bool showMentionPopups;
+    bool roomHistory;
     bool leftJustified;
     int masterVolume;
     int cardInfoViewMode;
@@ -166,6 +167,7 @@ public:
     bool getScaleCards() const {  return scaleCards; }
     bool getShowMessagePopup() const { return showMessagePopups; }
     bool getShowMentionPopup() const { return showMentionPopups; }
+    bool getRoomHistory() const { return roomHistory; }
     bool getLeftJustified() const { return leftJustified; }
     int getMasterVolume() const { return masterVolume; }
     int getCardInfoViewMode() const { return cardInfoViewMode; }
@@ -236,6 +238,7 @@ public slots:
     void setCardScaling(const int _scaleCards);
     void setShowMessagePopups(const int _showMessagePopups);
     void setShowMentionPopups(const int _showMentionPopups);
+    void setRoomHistory(const int _roomHistory);
     void setLeftJustified( const int _leftJustified);
     void setMasterVolume(const int _masterVolume);
     void setCardInfoViewMode(const int _viewMode);

--- a/cockatrice/src/tab_message.cpp
+++ b/cockatrice/src/tab_message.cpp
@@ -111,7 +111,7 @@ void TabMessage::actLeave()
 void TabMessage::processUserMessageEvent(const Event_UserMessage &event)
 {
     const UserLevelFlags userLevel(event.sender_name() == otherUserInfo->name() ? otherUserInfo->user_level() : ownUserInfo->user_level());
-    chatView->appendMessage(QString::fromStdString(event.message()), QString::fromStdString(event.sender_name()), userLevel, true);
+    chatView->appendMessage(QString::fromStdString(event.message()), 0,QString::fromStdString(event.sender_name()), userLevel, true);
     if (tabSupervisor->currentIndex() != tabSupervisor->indexOf(this))
         soundEngine->playSound("private_message");
     if (settingsCache->getShowMessagePopup() && shouldShowSystemPopup(event))

--- a/common/featureset.cpp
+++ b/common/featureset.cpp
@@ -17,6 +17,7 @@ void FeatureSet::initalizeFeatureList(QMap<QString, bool> &featureList){
     featureList.insert("client_ver", false);
     featureList.insert("feature_set", false);
     featureList.insert("user_ban_history", false);
+    featureList.insert("room_chat_history", false);
 }
 
 void FeatureSet::enableRequiredFeature(QMap<QString, bool> &featureList, QString featureName){

--- a/common/pb/CMakeLists.txt
+++ b/common/pb/CMakeLists.txt
@@ -137,6 +137,7 @@ SET(PROTO_FILES
     serverinfo_ban.proto
     serverinfo_cardcounter.proto
     serverinfo_card.proto
+    serverinfo_chat_message.proto
     serverinfo_counter.proto
     serverinfo_deckstorage.proto
     serverinfo_game.proto

--- a/common/pb/event_room_say.proto
+++ b/common/pb/event_room_say.proto
@@ -5,6 +5,13 @@ message Event_RoomSay {
     extend RoomEvent {
         optional Event_RoomSay ext = 1002;
     }
+    enum RoomMessageType {
+        Welcome = 1;    // rooms welcome message
+        ChatHistory = 2;    // rooms chat history message
+    }
     optional string name = 1;
     optional string message = 2;
+    optional RoomMessageType message_type = 3;
+    optional uint64 time_of = 4;
+
 }

--- a/common/pb/serverinfo_chat_message.proto
+++ b/common/pb/serverinfo_chat_message.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+/*
+ * Chat communication of a user to a target.
+ * Targets can be users or rooms.
+ * These communications are also stored in the DB log table.
+ */
+message ServerInfo_ChatMessage {
+    optional string time = 1; // time chat was sent
+    optional string sender_id = 2; // id of sender
+    optional string sender_name = 3; // name of sender
+    optional string sender_ip = 4; // ip of sender
+    optional string message = 5;  // message
+    optional string target_type = 6; // target type (room,game,chat)
+    optional string target_id = 7; // id of target
+    optional string target_name = 8; // name of target
+}

--- a/common/room_message_type.h
+++ b/common/room_message_type.h
@@ -1,0 +1,15 @@
+#ifndef ROOM_MESSAGE_TYPE_H
+#define ROOM_MESSAGE_TYPE_H
+
+#ifdef Q_OS_OSX
+// avoid collision from Mac OS X's ConditionalMacros.h
+// https://code.google.com/p/protobuf/issues/detail?id=119
+#undef TYPE_BOOL
+#endif
+#include "pb/event_room_say.pb.h"
+#include <QFlags>
+
+Q_DECLARE_FLAGS(RoomMessageTypeFlags, Event_RoomSay::RoomMessageType)
+Q_DECLARE_OPERATORS_FOR_FLAGS(RoomMessageTypeFlags)
+
+#endif

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -600,7 +600,18 @@ Response::ResponseCode Server_ProtocolHandler::cmdJoinRoom(const Command_JoinRoo
 
     Event_RoomSay joinMessageEvent;
     joinMessageEvent.set_message(r->getJoinMessage().toStdString());
+    joinMessageEvent.set_message_type(Event_RoomSay::Welcome);
     rc.enqueuePostResponseItem(ServerMessage::ROOM_EVENT, r->prepareRoomEvent(joinMessageEvent));
+
+    ServerInfo_ChatMessage chatMessage; for (int i = 0; i < r->chatHistory.size(); ++i) {
+        chatMessage = r->chatHistory.at(i);
+        qDebug() << QString::fromStdString(chatMessage.message()).simplified();
+        Event_RoomSay roomChatHistory;
+        roomChatHistory.set_message(chatMessage.sender_name() + ": " + chatMessage.message());
+        roomChatHistory.set_message_type(Event_RoomSay::ChatHistory);
+        roomChatHistory.set_time_of(QDateTime::fromString(QString::fromStdString(chatMessage.time())).toMSecsSinceEpoch());
+        rc.enqueuePostResponseItem(ServerMessage::ROOM_EVENT, r->prepareRoomEvent(roomChatHistory));
+    }
 
     Response_JoinRoom *re = new Response_JoinRoom;
     r->getInfo(*re->mutable_room_info(), true);

--- a/common/server_room.h
+++ b/common/server_room.h
@@ -9,6 +9,7 @@
 #include <QReadWriteLock>
 #include "serverinfo_user_container.h"
 #include "pb/response.pb.h"
+#include "pb/serverinfo_chat_message.pb.h"
 
 class Server_DatabaseInterface;
 class Server_ProtocolHandler;
@@ -30,6 +31,7 @@ signals:
     void gameListChanged(const ServerInfo_Game &gameInfo);
 private:
     int id;
+    int chatHistorySize;
     QString name;
     QString description;
     QString permissionLevel;
@@ -45,7 +47,8 @@ private slots:
 public:
     mutable QReadWriteLock usersLock;
     mutable QReadWriteLock gamesLock;
-    Server_Room(int _id, const QString &_name, const QString &_description, const QString &_permissionLevel, bool _autoJoin, const QString &_joinMessage, const QStringList &_gameTypes, Server *parent);
+    QList<ServerInfo_ChatMessage> chatHistory;
+    Server_Room(int _id, int _chatHistorySize, const QString &_name, const QString &_description, const QString &_permissionLevel, bool _autoJoin, const QString &_joinMessage, const QStringList &_gameTypes, Server *parent );
     ~Server_Room();
     int getId() const { return id; }
     QString getName() const { return name; }
@@ -60,6 +63,7 @@ public:
     const ServerInfo_Room &getInfo(ServerInfo_Room &result, bool complete, bool showGameTypes = false, bool includeExternalData = true) const;
     int getGamesCreatedByUser(const QString &name) const;
     QList<ServerInfo_Game> getGamesOfUser(const QString &name) const;
+    QList<ServerInfo_ChatMessage> getChatHistory() { return chatHistory; }
     
     void addClient(Server_ProtocolHandler *client);
     void removeClient(Server_ProtocolHandler *client);

--- a/servatrice/migrations/servatrice_0008_to_0009.sql
+++ b/servatrice/migrations/servatrice_0008_to_0009.sql
@@ -1,0 +1,6 @@
+-- Servatrice db migration from version 8 to version 9
+
+alter table cockatrice_rooms add chat_history_size int(4) not null after join_message;
+update cockatrice_rooms set chat_history_size = 100;
+
+UPDATE cockatrice_schema_version SET version=9 WHERE version=8;

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -188,6 +188,9 @@ roomlist\1\autojoin=true
 ; Message displayed to each user when he joins room  number 1
 roomlist\1\joinmessage="This message is only here to show that rooms can have a join message."
 
+; The number of chat history messages to save that gets presented to a user joining the room
+roomlist\1\chathistorysize=100
+
 ; Number of game types allowed (defined) in the room number 1
 roomlist\1\game_types\size=3
 

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -185,6 +185,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_rooms` (
   `permissionlevel` varchar(20) NOT NULL,
   `auto_join` tinyint(1) default 0,
   `join_message` varchar(255) NOT NULL,
+  `chat_history_size` int(4) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -222,7 +222,7 @@ bool Servatrice::initServer()
 
     const QString roomMethod = settingsCache->value("rooms/method").toString();
     if (roomMethod == "sql") {
-        QSqlQuery *query = servatriceDatabaseInterface->prepareQuery("select id, name, descr, permissionlevel, auto_join, join_message from {prefix}_rooms order by id asc");
+        QSqlQuery *query = servatriceDatabaseInterface->prepareQuery("select id, name, descr, permissionlevel, auto_join, join_message, chat_history_size from {prefix}_rooms order by id asc");
         servatriceDatabaseInterface->execSqlQuery(query);
         while (query->next()) {
             QSqlQuery *query2 = servatriceDatabaseInterface->prepareQuery("select name from {prefix}_rooms_gametypes where id_room = :id_room");
@@ -233,6 +233,7 @@ bool Servatrice::initServer()
                 gameTypes.append(query2->value(0).toString());
 
             addRoom(new Server_Room(query->value(0).toInt(),
+                                    query->value(6).toInt(),
                                     query->value(1).toString(),
                                     query->value(2).toString(),
                                     query->value(3).toString().toLower(),
@@ -257,6 +258,7 @@ bool Servatrice::initServer()
 
             Server_Room *newRoom = new Server_Room(
                 i,
+                settingsCache->value("chathistorysize").toInt(),
                 settingsCache->value("name").toString(),
                 settingsCache->value("description").toString(),
                 settingsCache->value("permissionlevel").toString().toLower(),
@@ -273,6 +275,7 @@ bool Servatrice::initServer()
             // no room defined in config, add a dummy one
             Server_Room *newRoom = new Server_Room(
                 0,
+                100,
                 "General room",
                 "Play anything here.",
                 "none",

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -9,7 +9,7 @@
 #include "server.h"
 #include "server_database_interface.h"
 
-#define DATABASE_SCHEMA_VERSION 8
+#define DATABASE_SCHEMA_VERSION 9
 
 class Servatrice;
 


### PR DESCRIPTION
This PR adds room chat history that is presented on join. A new server info message type has been added to the protocol which is used for retaining room chat history that is now presented to users on join and will be used to also allow the moderator tool for looking up chat history to be developed later.

Currently the server only retains 100 messages on a per room basis.
Note:  Older clients will not have the historic messages formatting in place and the historic messages will be presented in the same text/color as the default room join message till they upgrade there clients.

This should be the last thing need to fix #169 but it may be mentioned some were else as something nice to have (chat room history).

One feature added to the room history is the ability for each room to have its own amount of history defined to it.  See the sample servatrice.ini to see how to define the number of rooms historic chat information to store.  A column in the database rooms table has also been added for those using a database to store room information.

![image](https://cloud.githubusercontent.com/assets/1361287/9837487/74b1f9a4-5a0e-11e5-935b-ba1866fa6a8c.png)


