### PR TITLE
Moderator ban notifications + Server PM functionality

### DIFF
--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -130,7 +130,7 @@ void ChatView::appendMessage(QString message, RoomMessageTypeFlags messageType, 
     lastSender = sender;
     
     // timestamp
-    if (showTimestamps && !sameSender && !sender.isEmpty()) {
+    if (showTimestamps && (!sameSender || sender.toLower() == "servatrice") && !sender.isEmpty()) {
         QTextCharFormat timeFormat;
         timeFormat.setForeground(QColor(SERVER_MESSAGE_COLOR));
         if (sender.isEmpty())
@@ -139,31 +139,35 @@ void ChatView::appendMessage(QString message, RoomMessageTypeFlags messageType, 
         cursor.insertText(QDateTime::currentDateTime().toString("[hh:mm:ss] "));
     }
 
-    // nickname    
-    QTextCharFormat senderFormat;
-    if (tabSupervisor && tabSupervisor->getUserInfo() && (sender == QString::fromStdString(tabSupervisor->getUserInfo()->name()))) {
-        senderFormat.setForeground(QBrush(getCustomMentionColor()));
-        senderFormat.setFontWeight(QFont::Bold);
-    } else {
-        senderFormat.setForeground(QBrush(OTHER_USER_COLOR));
-        if (playerBold)
+    // nickname
+    if (sender.toLower() != "servatrice") {
+        QTextCharFormat senderFormat;
+        if (tabSupervisor && tabSupervisor->getUserInfo() &&
+            (sender == QString::fromStdString(tabSupervisor->getUserInfo()->name()))) {
+            senderFormat.setForeground(QBrush(getCustomMentionColor()));
             senderFormat.setFontWeight(QFont::Bold);
-    }
-    senderFormat.setAnchor(true);
-    senderFormat.setAnchorHref("user://" + QString::number(userLevel) + "_" + sender);
-    if (sameSender) {
-        cursor.insertText("    ");
-    } else {
-        if (!sender.isEmpty() && tabSupervisor->getUserListsTab()) {
-            const int pixelSize = QFontInfo(cursor.charFormat().font()).pixelSize();
-            QMap<QString, UserListTWI *> buddyList = tabSupervisor->getUserListsTab()->getBuddyList()->getUsers();
-            cursor.insertImage(UserLevelPixmapGenerator::generatePixmap(pixelSize, userLevel, buddyList.contains(sender)).toImage());
-            cursor.insertText(" ");
+        } else {
+            senderFormat.setForeground(QBrush(OTHER_USER_COLOR));
+            if (playerBold)
+                senderFormat.setFontWeight(QFont::Bold);
         }
-        cursor.setCharFormat(senderFormat);
-        if (!sender.isEmpty())
-            sender.append(": ");
-        cursor.insertText(sender);
+        senderFormat.setAnchor(true);
+        senderFormat.setAnchorHref("user://" + QString::number(userLevel) + "_" + sender);
+        if (sameSender) {
+            cursor.insertText("    ");
+        } else {
+            if (!sender.isEmpty() && tabSupervisor->getUserListsTab()) {
+                const int pixelSize = QFontInfo(cursor.charFormat().font()).pixelSize();
+                QMap<QString, UserListTWI *> buddyList = tabSupervisor->getUserListsTab()->getBuddyList()->getUsers();
+                cursor.insertImage(UserLevelPixmapGenerator::generatePixmap(pixelSize, userLevel,
+                                                                            buddyList.contains(sender)).toImage());
+                cursor.insertText(" ");
+            }
+            cursor.setCharFormat(senderFormat);
+            if (!sender.isEmpty())
+                sender.append(": ");
+            cursor.insertText(sender);
+        }
     }
 
     // use different color for server messages 
@@ -180,6 +184,9 @@ void ChatView::appendMessage(QString message, RoomMessageTypeFlags messageType, 
                 defaultFormat.setFontItalic(true);
                 break;
         }
+    } else if (sender.toLower() == "servatrice") {
+        defaultFormat.setForeground(Qt::darkGreen);
+        defaultFormat.setFontWeight(QFont::Bold);
     }
     cursor.setCharFormat(defaultFormat);
 

--- a/cockatrice/src/tab_message.cpp
+++ b/cockatrice/src/tab_message.cpp
@@ -116,6 +116,8 @@ void TabMessage::processUserMessageEvent(const Event_UserMessage &event)
         soundEngine->playSound("private_message");
     if (settingsCache->getShowMessagePopup() && shouldShowSystemPopup(event))
         showSystemPopup(event);
+    if (QString::fromStdString(event.sender_name()).simplified() == "Servatrice")
+        sayEdit->setDisabled(true);
 
     emit userEvent();
 }

--- a/common/server.cpp
+++ b/common/server.cpp
@@ -262,6 +262,18 @@ void Server::removeClient(Server_ProtocolHandler *client)
     qDebug() << "Server::removeClient: removed" << (void *) client << ";" << clients.size() << "clients; " << users.size() << "users left";
 }
 
+QList<QString> Server::getOnlineModeratorList()
+{
+    QList<QString> results;
+    QReadLocker clientsLocker(&clientsLock);
+    for (int i = 0; i < clients.size(); ++i) {
+        ServerInfo_User *data = clients[i]->getUserInfo();
+        if (data->user_level() & ServerInfo_User::IsModerator || data->user_level() & ServerInfo_User::IsAdmin) //TODO: this line should be updated in the event there is any type of new user level created
+            results << QString::fromStdString(data->name()).simplified();
+    }
+    return results;
+}
+
 void Server::externalUserJoined(const ServerInfo_User &userInfo)
 {
     // This function is always called from the main thread via signal/slot.

--- a/common/server.h
+++ b/common/server.h
@@ -55,6 +55,7 @@ public:
     virtual QMap<QString, bool> getServerRequiredFeatureList() const { return QMap<QString, bool>(); }
     void addClient(Server_ProtocolHandler *player);
     void removeClient(Server_ProtocolHandler *player);
+    QList<QString> getOnlineModeratorList();
     virtual QString getLoginMessage() const { return QString(); }
     virtual bool permitUnregisteredUsers() const { return true; }
     virtual bool getGameShouldPing() const { return false; }

--- a/servatrice/src/serversocketinterface.h
+++ b/servatrice/src/serversocketinterface.h
@@ -86,6 +86,7 @@ private:
 	Response::ResponseCode cmdDeckList(const Command_DeckList &cmd, ResponseContainer &rc);
 	Response::ResponseCode cmdDeckNewDir(const Command_DeckNewDir &cmd, ResponseContainer &rc);
 	void deckDelDirHelper(int basePathId);
+	void sendServerMessage(const QString userName, const QString message);
 	Response::ResponseCode cmdDeckDelDir(const Command_DeckDelDir &cmd, ResponseContainer &rc);
 	Response::ResponseCode cmdDeckDel(const Command_DeckDel &cmd, ResponseContainer &rc);
 	Response::ResponseCode cmdDeckUpload(const Command_DeckUpload &cmd, ResponseContainer &rc);


### PR DESCRIPTION
Fix #668 

Added server private message functionality to allow server based PM notifications.
Ban based notification to other online moderators is the first form implemented by this PR.

* The server now includes a public function to return a QList of online mod's/admins
* The servers socket interface has been extended to now allow PM's by the server (username Servatrice)
* The registration system restricts the registration of the Servatrice / servatrice username.
* When a private message is sent by the server, the response box is disabled to prevent user responding.

![image](https://cloud.githubusercontent.com/assets/1361287/9947837/70dd6d26-5d6b-11e5-8c7d-9eea1bfee878.png)



