### PR TITLE
Added logs tab to allow moderators the ability to review log history

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -75,6 +75,7 @@ SET(cockatrice_SOURCES
     src/tab_admin.cpp 
     src/tab_userlists.cpp 
     src/tab_deck_editor.cpp
+    src/tab_logs.cpp
     src/replay_timeline_widget.cpp
     src/deckstats_interface.cpp
     src/chatview.cpp 

--- a/cockatrice/src/tab_logs.cpp
+++ b/cockatrice/src/tab_logs.cpp
@@ -1,0 +1,336 @@
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QGroupBox>
+#include <QMessageBox>
+#include <QDialogButtonBox>
+#include <QSpinBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QCheckBox>
+#include <QRadioButton>
+#include "tab_logs.h"
+#include "abstractclient.h"
+#include "window_sets.h"
+#include "pending_command.h"
+#include "pb/moderator_commands.pb.h"
+#include "pb/response_viewlog_history.pb.h"
+
+#include <QtGui>
+#if QT_VERSION >= 0x050000
+#include <QtWidgets>
+#endif
+
+TabLog::TabLog(TabSupervisor *_tabSupervisor, AbstractClient *_client, QWidget *parent)
+    : Tab(_tabSupervisor, parent), client(_client)
+{
+    MainWindow = new QMainWindow;
+    createDock();
+    restartLayout();
+    clearClicked();
+    retranslateUi();
+}
+
+TabLog::~TabLog()
+{
+
+}
+
+void TabLog::retranslateUi()
+{
+
+}
+
+void TabLog::getClicked()
+{
+    if (findUsername->text().isEmpty() && findIPAddress->text().isEmpty() && findGameName->text().isEmpty() && findGameID->text().isEmpty() && findMessage->text().isEmpty()) {
+        QMessageBox::critical(this, tr("Error"), tr("You must select at least one filter."));
+        return;
+    }
+
+    if (!lastHour->isChecked() && !today->isChecked() && !pastDays->isChecked()){
+        pastDays->setChecked(true);
+        pastXDays->setValue(20);
+    }
+
+    if (pastDays->isChecked() && pastXDays->value() == 0) {
+        QMessageBox::critical(this, tr("Error"), tr("You have to select a valid number of days to locate."));
+        return;
+    }
+
+    if (!mainRoom->isChecked() && !gameRoom->isChecked() && !privateChat->isChecked()) {
+        mainRoom->setChecked(true);
+        gameRoom->setChecked(true);
+        privateChat->setChecked(true);
+    }
+
+    if (maximumResults->value() == 0)
+        maximumResults->setValue(1000);
+
+    int dateRange;
+    if (lastHour->isChecked())
+        dateRange = 1;
+
+    if (today->isChecked())
+        dateRange = 24;
+
+    if (pastDays->isChecked())
+        dateRange = pastXDays->value() * 24;
+
+    Command_ViewLogHistory cmd;
+    cmd.set_user_name(findUsername->text().toStdString());
+    cmd.set_ip_address(findIPAddress->text().toStdString());
+    cmd.set_game_name(findGameName->text().toStdString());
+    cmd.set_game_id(findGameID->text().toStdString());
+    cmd.set_message(findMessage->text().toStdString());
+    if (mainRoom->isChecked()) { cmd.add_log_location("room"); };
+    if (gameRoom->isChecked()) { cmd.add_log_location("game"); };
+    if (privateChat->isChecked()) { cmd.add_log_location("chat"); };
+    cmd.set_date_range(dateRange);
+    cmd.set_maximum_results(maximumResults->value());
+    PendingCommand *pend = client->prepareModeratorCommand(cmd);
+    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(viewLogHistory_processResponse(Response)));
+    client->sendCommand(pend);
+}
+
+void TabLog::clearClicked()
+{
+    findUsername->clear();
+    findIPAddress->clear();
+    findGameName->clear();
+    findGameID->clear();
+    findMessage->clear();
+    pastXDays->clear();
+    maximumResults->clear();
+    mainRoom->setChecked(false);
+    gameRoom->setChecked(false);
+    privateChat->setChecked(false);
+    pastDays->setAutoExclusive(false);
+    pastDays->setChecked(false);
+    today->setAutoExclusive(false);
+    today->setChecked(false);
+    lastHour->setAutoExclusive(false);
+    lastHour->setChecked(false);
+    pastDays->setAutoExclusive(true);
+    today->setAutoExclusive(true);
+    lastHour->setAutoExclusive(true);
+}
+
+void TabLog::createDock()
+{
+
+    labelFindUserName = new QLabel(tr("Username: "));
+    findUsername = new QLineEdit("");
+    findUsername->setAlignment(Qt::AlignCenter);
+    labelFindIPAddress = new QLabel(tr("IP Address: "));
+    findIPAddress = new QLineEdit("");
+    findIPAddress->setAlignment(Qt::AlignCenter);
+    labelFindGameName = new QLabel(tr("Game Name: "));
+    findGameName = new QLineEdit("");
+    findGameName->setAlignment(Qt::AlignCenter);
+    labelFindGameID = new QLabel(tr("GameID: "));
+    findGameID = new QLineEdit("");
+    findGameID->setAlignment(Qt::AlignCenter);
+    labelMessage = new QLabel(tr("Message: "));
+    findMessage = new QLineEdit("");
+    findMessage->setAlignment(Qt::AlignCenter);
+
+    mainRoom = new QCheckBox(tr("Main Room"));
+    gameRoom = new QCheckBox(tr("Game Room"));
+    privateChat = new QCheckBox(tr("Private Chat"));
+
+    pastDays = new QRadioButton(tr("Past X Days: "));
+    today = new QRadioButton(tr("Today"));
+    lastHour = new QRadioButton(tr("Last Hour"));
+    pastXDays = new QSpinBox;
+    pastXDays->setMaximum(20);
+
+
+    labelMaximum = new QLabel(tr("Maximum Results: "));
+    maximumResults = new QSpinBox;
+    maximumResults->setMaximum(1000);
+
+    labelDescription = new QLabel(tr("At least one filter is required.\nThe more information you put in, the more specific your results will be."));
+
+    getButton = new QPushButton(tr("Get User Logs"));
+    getButton->setAutoDefault(true);
+    connect(getButton, SIGNAL(clicked()), this, SLOT(getClicked()));
+
+    clearButton = new QPushButton(tr("Clear Filters"));
+    clearButton->setAutoDefault(true);
+    connect(clearButton, SIGNAL(clicked()), this, SLOT(clearClicked()));
+
+    criteriaGrid = new QGridLayout;
+    criteriaGrid->addWidget(labelFindUserName, 0, 0);
+    criteriaGrid->addWidget(findUsername, 0, 1);
+    criteriaGrid->addWidget(labelFindIPAddress, 1, 0);
+    criteriaGrid->addWidget(findIPAddress, 1, 1);
+    criteriaGrid->addWidget(labelFindGameName, 2, 0);
+    criteriaGrid->addWidget(findGameName, 2, 1);
+    criteriaGrid->addWidget(labelFindGameID, 3, 0);
+    criteriaGrid->addWidget(findGameID, 3, 1);
+    criteriaGrid->addWidget(labelMessage, 4, 0);
+    criteriaGrid->addWidget(findMessage, 4, 1);
+
+    criteriaGroupBox = new QGroupBox(tr("Filters"));
+    criteriaGroupBox->setLayout(criteriaGrid);
+    criteriaGroupBox->setFixedSize(500,300);
+
+    locationGrid = new QGridLayout;
+    locationGrid->addWidget(mainRoom, 0, 0);
+    locationGrid->addWidget(gameRoom, 0, 1);
+    locationGrid->addWidget(privateChat, 0, 2);
+
+    locationGroupBox = new QGroupBox(tr("Log Locations"));
+    locationGroupBox->setLayout(locationGrid);
+
+    rangeGrid = new QGridLayout;
+    rangeGrid->addWidget(pastDays, 0, 0);
+    rangeGrid->addWidget(pastXDays, 0, 1);
+    rangeGrid->addWidget(today, 0, 2);
+    rangeGrid->addWidget(lastHour, 0, 3);
+
+    rangeGroupBox = new QGroupBox(tr("Date Range"));
+    rangeGroupBox->setLayout(rangeGrid);
+
+    maxResultsGrid = new QGridLayout;
+    maxResultsGrid->addWidget(labelMaximum, 0, 0);
+    maxResultsGrid->addWidget(maximumResults, 0, 1);
+
+    maxResultsGroupBox = new QGroupBox(tr("Maximum Results"));
+    maxResultsGroupBox->setLayout(maxResultsGrid);
+
+    descriptionGrid = new QGridLayout;
+    descriptionGrid->addWidget(labelDescription, 0, 0);
+
+    descriptionGroupBox = new QGroupBox(tr(""));
+    descriptionGroupBox->setLayout(descriptionGrid);
+
+    buttonGrid = new QGridLayout;
+    buttonGrid->addWidget(getButton, 0, 0);
+    buttonGrid->addWidget(clearButton, 0, 1);
+
+    buttonGroupBox = new QGroupBox(tr(""));
+    buttonGroupBox->setLayout(buttonGrid);
+
+    mainLayout = new QVBoxLayout(MainWindow);
+    mainLayout->addWidget(criteriaGroupBox);
+    mainLayout->addWidget(locationGroupBox);
+    mainLayout->addWidget(rangeGroupBox);
+    mainLayout->addWidget(maxResultsGroupBox);
+    mainLayout->addWidget(descriptionGroupBox);
+    mainLayout->addWidget(buttonGroupBox);
+    mainLayout->setAlignment(Qt::AlignCenter);
+
+    searchDockContents = new QWidget(MainWindow);
+    searchDockContents->setLayout(mainLayout);
+
+    searchDock = new QDockWidget(MainWindow);
+    searchDock->setFeatures(QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable);
+    searchDock->setWidget(searchDockContents);
+
+    QVBoxLayout *mainVLayoutContent = new QVBoxLayout;
+    QHBoxLayout *mainHLayoutContent = new QHBoxLayout;
+    mainHLayoutContent->addWidget(MainWindow);
+    mainHLayoutContent->addLayout(mainVLayoutContent);
+    setLayout(mainHLayoutContent);
+}
+
+void TabLog::viewLogHistory_processResponse(const Response &resp)
+{
+    const Response_ViewLogHistory &response = resp.GetExtension(Response_ViewLogHistory::ext);
+    if (resp.response_code() == Response::RespOk) {
+
+        if (response.log_message_size() > 0) {
+
+            int j = 0;
+            QTableWidget *roomTable = new QTableWidget();
+            roomTable->setWindowTitle(tr("Room Logs"));
+            roomTable->setRowCount(response.log_message_size());
+            roomTable->setColumnCount(6);
+            roomTable->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+            roomTable->setHorizontalHeaderLabels(QString(tr("Time;SenderName;SenderIP;Message;TargetID;TargetName")).split(";"));
+
+            int k = 0;
+            QTableWidget *gameTable = new QTableWidget();
+            gameTable->setWindowTitle(tr("Game Logs"));
+            gameTable->setRowCount(response.log_message_size());
+            gameTable->setColumnCount(6);
+            gameTable->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+            gameTable->setHorizontalHeaderLabels(QString(tr("Time;SenderName;SenderIP;Message;TargetID;TargetName")).split(";"));
+
+            int l = 0;
+            QTableWidget *chatTable = new QTableWidget();
+            chatTable->setWindowTitle(tr("Chat Logs"));
+            chatTable->setRowCount(response.log_message_size());
+            chatTable->setColumnCount(6);
+            chatTable->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+            chatTable->setHorizontalHeaderLabels(QString(tr("Time;SenderName;SenderIP;Message;TargetID;TargetName")).split(";"));
+
+            ServerInfo_ChatMessage message; for (int i = 0; i < response.log_message_size(); ++i) {
+                message = response.log_message(i);
+                if (QString::fromStdString(message.target_type()) == "room") {
+                    roomTable->setItem(j, 0, new QTableWidgetItem(QString::fromStdString(message.time())));
+                    roomTable->setItem(j, 1, new QTableWidgetItem(QString::fromStdString(message.sender_name())));
+                    roomTable->setItem(j, 2, new QTableWidgetItem(QString::fromStdString(message.sender_ip())));
+                    roomTable->setItem(j, 3, new QTableWidgetItem(QString::fromStdString(message.message())));
+                    roomTable->setItem(j, 4, new QTableWidgetItem(QString::fromStdString(message.target_id())));
+                    roomTable->setItem(j, 5, new QTableWidgetItem(QString::fromStdString(message.target_name())));
+                    ++j;
+                }
+
+                if (QString::fromStdString(message.target_type()) == "game") {
+                    gameTable->setItem(k, 0, new QTableWidgetItem(QString::fromStdString(message.time())));
+                    gameTable->setItem(k, 1, new QTableWidgetItem(QString::fromStdString(message.sender_name())));
+                    gameTable->setItem(k, 2, new QTableWidgetItem(QString::fromStdString(message.sender_ip())));
+                    gameTable->setItem(k, 3, new QTableWidgetItem(QString::fromStdString(message.message())));
+                    gameTable->setItem(k, 4, new QTableWidgetItem(QString::fromStdString(message.target_id())));
+                    gameTable->setItem(k, 5, new QTableWidgetItem(QString::fromStdString(message.target_name())));
+                    ++k;
+                }
+
+                if (QString::fromStdString(message.target_type()) == "chat") {
+                    chatTable->setItem(l, 0, new QTableWidgetItem(QString::fromStdString(message.time())));
+                    chatTable->setItem(l, 1, new QTableWidgetItem(QString::fromStdString(message.sender_name())));
+                    chatTable->setItem(l, 2, new QTableWidgetItem(QString::fromStdString(message.sender_ip())));
+                    chatTable->setItem(l, 3, new QTableWidgetItem(QString::fromStdString(message.message())));
+                    chatTable->setItem(l, 4, new QTableWidgetItem(QString::fromStdString(message.target_id())));
+                    chatTable->setItem(l, 5, new QTableWidgetItem(QString::fromStdString(message.target_name())));
+                    ++l;
+                }
+            }
+
+            roomTable->setRowCount(j);
+            roomTable->resizeColumnsToContents();
+            gameTable->setRowCount(k);
+            gameTable->resizeColumnsToContents();
+            chatTable->setRowCount(l);
+            chatTable->resizeColumnsToContents();
+
+            if (mainRoom->isChecked()) {
+                roomTable->resize(600, 200);
+                roomTable->show();
+            }
+
+            if (gameRoom->isChecked()) {
+                gameTable->resize(600, 200);
+                gameTable->show();
+            }
+
+            if (privateChat->isChecked()) {
+                chatTable->resize(600, 200);
+                chatTable->show();
+            }
+
+        } else
+            QMessageBox::information(static_cast<QWidget *>(parent()), tr("Message History"), tr("There is no messages for the selected iilters."));
+
+    } else
+        QMessageBox::critical(static_cast<QWidget *>(parent()), tr("Message History"), tr("Failed to collecting message history information."));
+}
+
+void TabLog::restartLayout()
+{
+    searchDock->setFloating(false);
+    MainWindow->addDockWidget(Qt::TopDockWidgetArea, searchDock);
+    searchDock->setVisible(true);
+}

--- a/cockatrice/src/tab_logs.h
+++ b/cockatrice/src/tab_logs.h
@@ -1,0 +1,57 @@
+#ifndef TAB_LOG_H
+#define TAB_LOG_H
+
+#include "tab.h"
+#include <QDialog>
+
+class AbstractClient;
+
+class QGroupBox;
+class QPushButton;
+class QSpinBox;
+class QLineEdit;
+class QCheckBox;
+class QRadioButton;
+class QLabel;
+class QDockWidget;
+class QWidget;
+class QGridLayout;
+class CommandContainer;
+class Response;
+class AbstractClient;
+class QMainWindow;
+
+class TabLog : public Tab {
+    Q_OBJECT
+private:
+    AbstractClient *client;
+    QLabel *labelFindUserName, *labelFindIPAddress, *labelFindGameName, *labelFindGameID, *labelMessage, *labelMaximum, *labelDescription;
+    QLineEdit *findUsername, *findIPAddress, *findGameName, *findGameID, *findMessage;
+    QCheckBox *mainRoom, *gameRoom, *privateChat;
+    QRadioButton *pastDays, *today, *lastHour;
+    QSpinBox *maximumResults, *pastXDays;
+    QDockWidget *searchDock;
+    QWidget *searchDockContents;
+    QPushButton *getButton, *clearButton;
+    QGridLayout *criteriaGrid, *locationGrid, *rangeGrid, *maxResultsGrid, *descriptionGrid, *buttonGrid;
+    QGroupBox *criteriaGroupBox, *locationGroupBox, *rangeGroupBox, *maxResultsGroupBox, *descriptionGroupBox, *buttonGroupBox;
+    QVBoxLayout *mainLayout;
+    QMainWindow *MainWindow;
+
+    void createDock();
+signals:
+
+private slots:
+    void getClicked();
+    void clearClicked();
+    void viewLogHistory_processResponse(const Response &resp);
+    void restartLayout();
+
+public:
+    TabLog(TabSupervisor *_tabSupervisor, AbstractClient *_client, QWidget *parent = 0);
+    ~TabLog();
+    void retranslateUi();
+    QString getTabText() const { return tr("Logs"); }
+};
+
+#endif

--- a/cockatrice/src/tab_supervisor.h
+++ b/cockatrice/src/tab_supervisor.h
@@ -18,6 +18,7 @@ class TabAdmin;
 class TabMessage;
 class TabUserLists;
 class TabDeckEditor;
+class TabLog;
 class RoomEvent;
 class GameEventContainer;
 class Event_GameJoined;
@@ -51,6 +52,7 @@ private:
     TabDeckStorage *tabDeckStorage;
     TabReplays *tabReplays;
     TabAdmin *tabAdmin;
+    TabLog *tabLog;
     QMap<int, TabRoom *> roomTabs;
     QMap<int, TabGame *> gameTabs;
     QList<TabGame *> replayTabs;

--- a/common/featureset.cpp
+++ b/common/featureset.cpp
@@ -19,6 +19,7 @@ void FeatureSet::initalizeFeatureList(QMap<QString, bool> &featureList) {
     featureList.insert("user_ban_history", false);
     featureList.insert("room_chat_history", false);
     featureList.insert("client_warnings", false);
+    featureList.insert("mod_log_lookup", false);
 }
 
 void FeatureSet::enableRequiredFeature(QMap<QString, bool> &featureList, QString featureName){

--- a/common/pb/CMakeLists.txt
+++ b/common/pb/CMakeLists.txt
@@ -132,6 +132,7 @@ SET(PROTO_FILES
     response_adjust_mod.proto
     response_warn_history.proto
     response_warn_list.proto
+    response_viewlog_history.proto
     response.proto
     room_commands.proto
     room_event.proto

--- a/common/pb/moderator_commands.proto
+++ b/common/pb/moderator_commands.proto
@@ -6,6 +6,7 @@ message ModeratorCommand {
         WARN_USER = 1002;
         WARN_HISTORY = 1003;
         WARN_LIST = 1004;
+        VIEWLOG_HISTORY = 1005;
     }
     extensions 100 to max;
 }
@@ -53,4 +54,19 @@ message Command_GetWarnList {
     optional string mod_name = 1;
     optional string user_name = 2;
     optional string user_clientid = 3;
+}
+
+message Command_ViewLogHistory {
+    extend ModeratorCommand {
+        optional Command_ViewLogHistory ext = 1005;
+    }
+    optional string user_name = 1;  // user that created message
+    optional string ip_address = 2; // ip address of user that created message
+    optional string game_name = 3; // client id of user that created the message
+    optional string game_id = 4; // game number the message was sent to
+    optional string message = 5; // raw message that was sent
+    repeated string log_location = 6; // destination of message (ex: main room, game room, private chat)
+    required uint32 date_range = 7; // the length of time (in minutes) to look back for
+    optional uint32 maximum_results = 8; // the maximum number of query results
+
 }

--- a/common/pb/response.proto
+++ b/common/pb/response.proto
@@ -55,6 +55,7 @@ message Response {
         BAN_HISTORY = 1012;
         WARN_HISTORY = 1013;
         WARN_LIST = 1014;
+        VIEW_LOG = 1015;
         REPLAY_LIST = 1100;
         REPLAY_DOWNLOAD = 1101;
     }

--- a/common/pb/response_viewlog_history.proto
+++ b/common/pb/response_viewlog_history.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+import "response.proto";
+import "serverinfo_chat_message.proto";
+
+message Response_ViewLogHistory{
+    extend Response {
+        optional Response_ViewLogHistory ext = 1015;
+    }
+    repeated ServerInfo_ChatMessage log_message = 1;
+}

--- a/common/server.h
+++ b/common/server.h
@@ -11,6 +11,7 @@
 #include "pb/serverinfo_user.pb.h"
 #include "pb/serverinfo_ban.pb.h"
 #include "pb/serverinfo_warning.pb.h"
+#include "pb/serverinfo_chat_message.pb.h"
 #include "server_player_reference.h"
 
 class Server_DatabaseInterface;

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -81,6 +81,7 @@ public:
     QList<ServerInfo_Ban> getUserBanHistory(const QString userName);
     bool addWarning(const QString userName, const QString adminName, const QString warningReason, const QString clientID);
     QList<ServerInfo_Warning> getUserWarnHistory(const QString userName);
+    QList<ServerInfo_ChatMessage> getMessageLogHistory(const QString &user, const QString &ipaddress, const QString &gamename, const QString &gameid, const QString &message, bool &chat, bool &game, bool &room, int &range, int &maxresults);
 };
 
 #endif

--- a/servatrice/src/serversocketinterface.h
+++ b/servatrice/src/serversocketinterface.h
@@ -98,6 +98,7 @@ private:
 	Response::ResponseCode cmdReplayDeleteMatch(const Command_ReplayDeleteMatch &cmd, ResponseContainer &rc);
 	Response::ResponseCode cmdBanFromServer(const Command_BanFromServer &cmd, ResponseContainer &rc);
 	Response::ResponseCode cmdWarnUser(const Command_WarnUser &cmd, ResponseContainer &rc);
+	Response::ResponseCode cmdGetLogHistory(const Command_ViewLogHistory &cmd, ResponseContainer &rc);
 	Response::ResponseCode cmdGetBanHistory(const Command_GetBanHistory &cmd, ResponseContainer &rc);
 	Response::ResponseCode cmdGetWarnList(const Command_GetWarnList &cmd, ResponseContainer &rc);
 	Response::ResponseCode cmdGetWarnHistory(const Command_GetWarnHistory &cmd, ResponseContainer &rc);


### PR DESCRIPTION
Fix #1397 
(Also address's one point in #1306)

This PR adds a new tab that the moderators/admins can use to lookup log history similar to what is in the external PHP based page currently used on the woogerworks server.

Things to note:
* This will have merge conflicts with PR #1522
* Extends the protocol
* Log tab content is dockable
* Log results are shown in plain table format
* There are 3 separate tables that are shown that break the chat history down to room/game/private (only 1 image is given as an example below)

The results displayed are nothing really special and has no special abilities such as clickable names to re-query based on result content.  It's not paginated in any way.  Im not that great of a UI guy and figured this should lay the ground work and a new issue/pr could be opened if some one wants to work on getting the results content prettied up in some fashion.

![image](https://cloud.githubusercontent.com/assets/1361287/9981843/c4cbdefe-5f96-11e5-8aea-683b169c266b.png)

![image](https://cloud.githubusercontent.com/assets/1361287/9981851/040b50e0-5f97-11e5-9802-53ed9abd99a1.png)