### PR TITLE
Updated cockatrice_warnings table to use id column as primary key

### DIFF
--- a/servatrice/migrations/servatrice_0010_to_0011.sql
+++ b/servatrice/migrations/servatrice_0010_to_0011.sql
@@ -1,0 +1,6 @@
+-- Servatrice db migration from version 10 to version 11
+
+alter table cockatrice_warnings change id user_id int(7) unsigned NOT NULL;
+alter table cockatrice_warnings drop primary key, add primary key(user_id,time_of);
+
+UPDATE cockatrice_schema_version SET version=11 WHERE version=10;

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_schema_version` (
   PRIMARY KEY  (`version`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
-INSERT INTO cockatrice_schema_version VALUES(10);
+INSERT INTO cockatrice_schema_version VALUES(11);
 
 CREATE TABLE IF NOT EXISTS `cockatrice_decklist_files` (
   `id` int(7) unsigned zerofill NOT NULL auto_increment,
@@ -139,13 +139,13 @@ CREATE TABLE IF NOT EXISTS `cockatrice_bans` (
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `cockatrice_warnings` (
-  `id` int(7) unsigned NOT NULL,
+  `user_id` int(7) unsigned NOT NULL,
   `user_name` varchar(255) NOT NULL,
   `mod_name` varchar(255) NOT NULL
   `reason` text NOT NULL,
   `time_of` datetime NOT NULL,
   `clientid` varchar(15) NOT NULL,
-  PRIMARY KEY (`user_name`,`time_of`)
+  PRIMARY KEY (`user_id`,`time_of`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `cockatrice_sessions` (

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -959,7 +959,7 @@ bool Servatrice_DatabaseInterface::addWarning(const QString userName, const QStr
         return false;
 
     int userID = getUserIdInDB(userName);
-    QSqlQuery *query = prepareQuery("insert into {prefix}_warnings (id,user_name,mod_name,reason,time_of,clientid) values (:user_id,:user_name,:mod_name,:warn_reason,NOW(),:client_id)");
+    QSqlQuery *query = prepareQuery("insert into {prefix}_warnings (user_id,user_name,mod_name,reason,time_of,clientid) values (:user_id,:user_name,:mod_name,:warn_reason,NOW(),:client_id)");
     query->bindValue(":user_id", userID);
     query->bindValue(":user_name", userName);
     query->bindValue(":mod_name", adminName);
@@ -982,7 +982,7 @@ QList<ServerInfo_Warning> Servatrice_DatabaseInterface::getUserWarnHistory(const
         return results;
 
     int userID = getUserIdInDB(userName);
-    QSqlQuery *query = prepareQuery("SELECT user_name, mod_name, reason, time_of FROM {prefix}_warnings WHERE id = :user_id");
+    QSqlQuery *query = prepareQuery("SELECT user_name, mod_name, reason, time_of FROM {prefix}_warnings WHERE user_id = :user_id");
     query->bindValue(":user_id", userID);
 
     if (!execSqlQuery(query)) {

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -9,7 +9,7 @@
 #include "server.h"
 #include "server_database_interface.h"
 
-#define DATABASE_SCHEMA_VERSION 10
+#define DATABASE_SCHEMA_VERSION 11
 
 class Servatrice;
 


### PR DESCRIPTION
Per @Daenyth request, the cockatrice_warnings table has the primary keys set to user_name,time_of.  With this PR the schema is updated to use the user's id column and time_of.