### PR TITLE
Added appveyor script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 IF(MSVC)
 	# Visual Studio:
 	# Maximum optimization
-    set(CMAKE_CXX_FLAGS_RELEASE "/Ox")
+    set(CMAKE_CXX_FLAGS_RELEASE "/Ox /MD")
 	# Generate complete debugging information
     #set(CMAKE_CXX_FLAGS_DEBUG "/Zi")
 ELSEIF (CMAKE_COMPILER_IS_GNUCXX)
@@ -104,7 +104,7 @@ ENDIF()
 # Default is Qt5 unless WITH_QT4 option is enabled
 option(WITH_QT4 "Force the use of Qt4 libraries" OFF)
 OPTION(UPDATE_TRANSLATIONS "Update translations on compile" OFF)
-MESSAGE("UPDATE TRANSLATIONS: ${UPDATE_TRANSLATIONS}")
+MESSAGE(STATUS "UPDATE TRANSLATIONS: ${UPDATE_TRANSLATIONS}")
 
 IF(NOT WITH_QT4)
     # First known not-broken Qt5 version (5.0.2 available on old ubuntus is buggy).
@@ -197,7 +197,7 @@ if(UNIX)
     endif()
 elseif(WIN32)
     set(CPACK_GENERATOR NSIS ${CPACK_GENERATOR})
-    set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}_win32_git-${PROJECT_VERSION_SAFE}")
+    set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}_git-${PROJECT_VERSION_SAFE}")
 
     # Configure file with custom definitions for NSIS.
     configure_file(

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,78 @@
+version: 0.0.0.0.1-branch-{branch}-build-{build}
+cache:
+    - c:\protobuf
+    - c:\protoc
+    - c:\zlib
+environment:
+    matrix:
+        - vc_arch: amd64
+          choco_arch:
+          nuget_arch: x64
+          target_arch: x86_64
+          qt_ver: 5.5\msvc2013_64
+        - vc_arch: amd64_x86  # cross-compile from amd64 to x86
+          choco_arch: --x86
+          nuget_arch: Win32
+          target_arch: x86
+          qt_ver: 5.5\msvc2013
+install:
+    - systeminfo
+    # upgrade cmake in order to have c++11 support
+    - choco install cmake -y
+    - choco install nsis -y
+    - choco install jom -y
+    - ps: |
+        if (Test-Path c:\protoc) {
+            echo "using protoc from cache"
+        } else {
+            Invoke-WebRequest "https://github.com/google/protobuf/releases/download/v2.6.1/protoc-2.6.1-win32.zip" -OutFile c:\protoc-2.6.1-win32.zip
+            c:\cygwin\bin\bash -lc "cd /cygdrive/c; 7z x -y protoc-2.6.1-win32.zip -oc:\protoc"
+        }
+    - ps: |
+        if (Test-Path c:\protobuf) {
+            echo "using protobuf from cache"
+        } else {
+           nuget install protobuf-v120 -OutputDirectory c:\protobuf
+        }
+    - ps: |
+        if (Test-Path c:\zlib) {
+            echo "using zlib from cache"
+        } else {
+           nuget install zlib -OutputDirectory c:\zlib
+        }
+build_script:
+    - mkdir build
+    - cd build
+    - '"c:/Program Files (x86)/Microsoft Visual Studio 12.0/VC/vcvarsall" %vc_arch%'
+    - path
+    - ps: |
+        $zlibinc = c:\cygwin\bin\find /cygdrive/c/zlib/ -path '*v120*/zlib.h'
+        $zlibinc = c:\cygwin\bin\dirname $zlibinc
+        $zlibinc = c:\cygwin\bin\cygpath -m $zlibinc
+        $zliblib = c:\cygwin\bin\find /cygdrive/c/zlib/ -path "*v120*/$env:nuget_arch/Release/zlib.lib"
+        $zliblib = c:\cygwin\bin\cygpath -m $zliblib
+        $protoinc = c:\cygwin\bin\find /cygdrive/c/protobuf/ -name 'google'
+        $protoinc = c:\cygwin\bin\dirname $protoinc
+        $protoinc = c:\cygwin\bin\cygpath -m $protoinc
+        $protolib = c:\cygwin\bin\find /cygdrive/c/protobuf/ -path "*/lib/$env:nuget_arch/v120/Release/libprotobuf.lib"
+        $protolib = c:\cygwin\bin\cygpath -m $protolib
+        $protoc = c:\cygwin\bin\find /cygdrive/c/protoc/ -name "protoc.exe"
+        $protoc = c:\cygwin\bin\cygpath -m $protoc
+        Write-Output "ZLIBINC  = $zlibinc"
+        Write-Output "ZLIBLIB  = $zliblib"
+        Write-Output "PROTOINC = $protoinc"
+        Write-Output "PROTOLIB = $protolib"
+        Write-Output "PROTOC   = $protoc"
+        cmake .. "-GNMake Makefiles JOM" "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_PREFIX_PATH=c:/Qt/$env:qt_ver" "-DWITH_SERVER=1" "-DZLIB_INCLUDE_DIR=$zlibinc" "-DZLIB_LIBRARY=$zliblib" "-DPROTOBUF_INCLUDE_DIR=$protoinc" "-DPROTOBUF_LIBRARIES=$protolib" "-DPROTOBUF_LIBRARIES=$protolib" "-DPROTOBUF_LIBRARY=$protolib" "-DPROTOBUF_PROTOC_EXECUTABLE=$protoc"
+    - jom package
+    - c:\cygwin\bin\ls -l
+    - ps: |
+        $exe = dir -name *.exe
+        $new_name = $exe.Replace(".exe", "-$env:target_arch_qt5.exe")
+        Push-AppveyorArtifact $exe -FileName $new_name
+        $cmake_name = $exe.Replace(".exe", "-$env:target_arch_qt5.cmake.txt")
+        Push-AppveyorArtifact CMakeCache.txt -FileName $cmake_name
+        $json = New-Object PSObject
+        (New-Object PSObject | Add-Member -PassThru NoteProperty bin $new_name | Add-Member -PassThru NoteProperty cmake $cmake_name | Add-Member -PassThru NoteProperty commit $env:APPVEYOR_REPO_COMMIT) | ConvertTo-JSON | Out-File -FilePath "latest-$env:target_arch" -Encoding ASCII
+        Push-AppveyorArtifact "latest-$env:target_arch"
+test: off

--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -214,10 +214,13 @@ IF(WIN32)
     set(qtconf_dest_dir .)
     list(APPEND libSearchDirs ${QT_LIBRARY_DIR})
     IF(ZLIB_FOUND)
+        # look for dll in the bin/ directory (gnuwin32 package)
         get_filename_component(ZLIB_DLL_DIR "${ZLIB_INCLUDE_DIRS}/../bin/" REALPATH)
         list(APPEND libSearchDirs ${ZLIB_DLL_DIR})
+        # look for dll in the lib/ directory (nuget package)
+        get_filename_component(ZLIB_DLL_DIR "${ZLIB_LIBRARY}" DIRECTORY)
+        list(APPEND libSearchDirs ${ZLIB_DLL_DIR})
     ENDIF()
-    MESSAGE(STATUS "Oracle: ZLIB dll found at ${ZLIB_DLL_DIR}")
 
     # qt4: codecs, iconengines, imageformats
     # qt5: iconengines, imageformats, platforms


### PR DESCRIPTION
It will test msvc builds and create windows packages for both 32 and 64 bits. Fix #1218.
If you're compiling windows packages (@woogerboy21), you could need to review these changes:
 * Forced /MD flag to the visual studio compiler (fixes linking)
 * removed the hardcoded "win32" text in the package name
