### PR TITLE
Crash Fix: Removed mod notification code that causes crashes

### DIFF
--- a/common/server.cpp
+++ b/common/server.cpp
@@ -262,18 +262,6 @@ void Server::removeClient(Server_ProtocolHandler *client)
     qDebug() << "Server::removeClient: removed" << (void *) client << ";" << clients.size() << "clients; " << users.size() << "users left";
 }
 
-QList<QString> Server::getOnlineModeratorList()
-{
-    QList<QString> results;
-    QReadLocker clientsLocker(&clientsLock);
-    for (int i = 0; i < clients.size(); ++i) {
-        ServerInfo_User *data = clients[i]->getUserInfo();
-        if (data->user_level() & ServerInfo_User::IsModerator || data->user_level() & ServerInfo_User::IsAdmin) //TODO: this line should be updated in the event there is any type of new user level created
-            results << QString::fromStdString(data->name()).simplified();
-    }
-    return results;
-}
-
 void Server::externalUserJoined(const ServerInfo_User &userInfo)
 {
     // This function is always called from the main thread via signal/slot.

--- a/common/server.h
+++ b/common/server.h
@@ -57,7 +57,6 @@ public:
     virtual QMap<QString, bool> getServerRequiredFeatureList() const { return QMap<QString, bool>(); }
     void addClient(Server_ProtocolHandler *player);
     void removeClient(Server_ProtocolHandler *player);
-    QList<QString> getOnlineModeratorList();
     virtual QString getLoginMessage() const { return QString(); }
     virtual bool permitUnregisteredUsers() const { return true; }
     virtual bool getGameShouldPing() const { return false; }

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -868,14 +868,6 @@ Response::ResponseCode ServerSocketInterface::cmdWarnUser(const Command_WarnUser
             delete se;
         }
 
-        QList<QString> moderatorList = server->getOnlineModeratorList();
-        QListIterator<QString> modIterator(moderatorList);
-        foreach(QString moderator, moderatorList) {
-            QString notificationMessage = sendingModerator + " has sent a warning with the following information";
-            notificationMessage.append("\n    Username: " + userName);
-            notificationMessage.append("\n    Reason: " + warningReason);
-            sendServerMessage(moderator.simplified(), notificationMessage);
-        }
 
         return Response::RespOk;
     } else {
@@ -950,23 +942,6 @@ Response::ResponseCode ServerSocketInterface::cmdBanFromServer(const Command_Ban
         }
     }
     servatrice->clientsLock.unlock();
-
-    QList<QString> moderatorList = server->getOnlineModeratorList();
-    QListIterator<QString> modIterator(moderatorList);
-    foreach(QString moderator, moderatorList) {
-        QString notificationMessage = QString::fromStdString(userInfo->name()).simplified() + " has placed a ban with the following information";
-        if (!userName.isEmpty())
-            notificationMessage.append("\n    Username: " + userName);
-        if (!address.isEmpty())
-            notificationMessage.append("\n    IP Address: " + address);
-        if (!clientID.isEmpty())
-            notificationMessage.append("\n    Client ID: " + clientID);
-
-        notificationMessage.append("\n    Length: " + QString::number(minutes) + " minute(s)");
-        notificationMessage.append("\n    Internal Reason: " + QString::fromStdString(cmd.reason()));
-        notificationMessage.append("\n    Visible Reason: " + QString::fromStdString(cmd.visible_reason()));
-        sendServerMessage(moderator.simplified(), notificationMessage);
-    }
 
     return Response::RespOk;
 }


### PR DESCRIPTION
This PR removes the mod notification when warnings and bans occur.  The function to get the online moderators list causes the server to crash.  The functionality will be worked back in at a later date but for now it should be removed to prevent crashing.