### PR TITLE
Appveyor: fix artifact names

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,9 +68,9 @@ build_script:
     - c:\cygwin\bin\ls -l
     - ps: |
         $exe = dir -name *.exe
-        $new_name = $exe.Replace(".exe", "-$env:target_arch_qt5.exe")
+        $new_name = $exe.Replace(".exe", "-${env:target_arch}_qt5.exe")
         Push-AppveyorArtifact $exe -FileName $new_name
-        $cmake_name = $exe.Replace(".exe", "-$env:target_arch_qt5.cmake.txt")
+        $cmake_name = $exe.Replace(".exe", "-${env:target_arch}_qt5.cmake.txt")
         Push-AppveyorArtifact CMakeCache.txt -FileName $cmake_name
         $json = New-Object PSObject
         (New-Object PSObject | Add-Member -PassThru NoteProperty bin $new_name | Add-Member -PassThru NoteProperty cmake $cmake_name | Add-Member -PassThru NoteProperty commit $env:APPVEYOR_REPO_COMMIT) | ConvertTo-JSON | Out-File -FilePath "latest-$env:target_arch" -Encoding ASCII


### PR DESCRIPTION
They were missing the arch name at the end of the file.
```
Old: Cockatrice_git-3e9610a_2015-10-01-.exe
New: Cockatrice_git-3e9610a_2015-10-01-x86_qt5.exe
```