### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,27 @@
 language: cpp
-env:
-  - QT4=1 BUILDTYPE=Debug
-  - QT4=0 BUILDTYPE=Debug
-  - QT4=0 BUILDTYPE=Release
-os:
-  - linux
-  - osx
+matrix:
+  fast_finish: true
+  include:
+    # linux precise debug build, precise + gcc + qt4
+    - os: linux
+      env: QT4=1 BUILDTYPE=Debug DIST=precise
+    # linux debug build, trusty + gcc + qt5
+    - os: linux
+      dist: trusty
+      env: QT4=0 BUILDTYPE=Debug DIST=trusty
+    # osx debug build, osx + clang + qt5
+    - os: osx
+      env: QT4=0 BUILDTYPE=Debug
+    # linux precise release build, precise + gcc + qt4
+    - os: linux
+      env: QT4=1 BUILDTYPE=Release DIST=precise
+    # linux trusty release build, precise + gcc + qt5
+    - os: linux
+      dist: trusty
+      env: QT4=0 BUILDTYPE=Release DIST=trusty
+    # osx release build, osx + gcc + qt5
+    - os: osx
+      env: QT4=0 BUILDTYPE=Release
 script: ./travis-compile.sh
 install: ./travis-dependencies.sh
 cache: apt
@@ -16,6 +32,12 @@ notifications:
       - https://webhooks.gitter.im/e/d94969c3b01b22cbdcb7
     on_success: change
     on_failure: change
-    on_start: false
-matrix:
-  fast_finish: true
+    on_start: never
+deploy:
+  provider: bintray
+  file: "build/bintray_deploy.json"
+  user: "ctrlaltca"
+  key:
+    secure: b9Nv8FeYJGaTs1bZD8z0a7VksmEDkgVSDu8Os1ldYVaE6AwgYTt++RAbX60eu6jRb0G1bUCTWNF5wh3vhjYNl2xrj7N89O5FQAIgQcyWveAU91pn2I92pMcRfhHMIUVLwgzHoSy9JQPFG3ecE6CtWAi9+rbqcRwQRg+A2jfd7yI=
+  on:
+    condition: $BUILDTYPE = Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,9 +188,11 @@ if(UNIX)
         set(CPACK_GENERATOR DEB ${CPACK_GENERATOR})
         set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}-${PROJECT_VERSION}")
     	set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
-    	set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5multimedia5-plugins")
     	set(CPACK_DEBIAN_PACKAGE_SECTION "games")
     	set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "http://github.com/Cockatrice/Cockatrice")
+        IF(Qt5Widgets_FOUND)
+            set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5multimedia5-plugins")
+        ENDIF()
     endif()
 elseif(WIN32)
     set(CPACK_GENERATOR NSIS ${CPACK_GENERATOR})
@@ -202,6 +204,12 @@ elseif(WIN32)
         ${PROJECT_BINARY_DIR}/NSIS.definitions.nsh
     )
 endif()
+
+# Configure file with build deployment data for travis
+configure_file(
+    ${CMAKE_MODULE_PATH}/bintray_deploy.json.in
+    ${PROJECT_BINARY_DIR}/bintray_deploy.json
+)
 
 include(CPack)
 

--- a/cmake/bintray_deploy.json.in
+++ b/cmake/bintray_deploy.json.in
@@ -1,6 +1,6 @@
 {
     "package": {
-        "name": "Cockatrice-dev",
+        "name": "Cockatrice-git",
         "repo": "Cockatrice",
         "subject": "cockatrice",
         "desc": "Cockatrice master branch automated builds",
@@ -12,7 +12,7 @@
         "licenses": ["GPL-2.0"],
         "labels": ["card", "tabletop", "game"],
         "public_download_numbers": false,
-        "public_stats": false
+        "public_stats": true
     },
     "version": {
         "name": "@PROJECT_VERSION@",

--- a/cmake/bintray_deploy.json.in
+++ b/cmake/bintray_deploy.json.in
@@ -1,0 +1,28 @@
+{
+    "package": {
+        "name": "Cockatrice-dev",
+        "repo": "Cockatrice",
+        "subject": "cockatrice",
+        "desc": "Cockatrice master branch automated builds",
+        "website_url": "https://github.com/Cockatrice/Cockatrice",
+        "issue_tracker_url": "https://github.com/Cockatrice/Cockatrice/issues",
+        "vcs_url": "https://github.com/Cockatrice/Cockatrice.git",
+        "github_use_tag_release_notes": true,
+        "github_release_notes_file": "RELEASE.txt",
+        "licenses": ["GPL-2.0"],
+        "labels": ["card", "tabletop", "game"],
+        "public_download_numbers": false,
+        "public_stats": false
+    },
+    "version": {
+        "name": "@PROJECT_VERSION@",
+        "desc": "Unstable builds from master",
+        "vcs_tag": "@GIT_COMMIT_ID@",
+        "gpgSign": false
+    },
+    "files": [
+        { "includePattern": "build/(Cockatrice.*\\.deb)", "uploadPattern": "Ubuntu/$ENV{DIST}/$1" },
+        { "includePattern": "build/(Cockatrice.*\\.dmg)", "uploadPattern": "MacOSX/$1" }
+    ],
+    "publish": true
+}

--- a/travis-dependencies.sh
+++ b/travis-dependencies.sh
@@ -9,23 +9,41 @@ if [[ $TRAVIS_OS_NAME == "osx" ]] ; then
   fi
   brew unlink cmake
   brew upgrade cmake
+
 else
-  sudo add-apt-repository -y ppa:george-edison55/precise-backports
+
+  # common prerequisites
+  sudo apt-get update -qq
+  sudo apt-get install -y libprotobuf-dev protobuf-compiler cmake
+
   if (( QT4 )); then
-    sudo apt-get update -qq
+    # qt4 prerequisites
     sudo apt-get install -y qtmobility-dev libqt4-dev
   else
-    sudo add-apt-repository -y ppa:beineri/opt-qt542
-    sudo apt-get update -qq
-    sudo apt-get install -y libsqlite3-dev\
-      qt54base qt54webkit qt54tools qt54svg qt54multimedia
+    # qt5 prerequisites
+    sudo apt-get install -y libprotobuf-dev protobuf-compiler \
+      qt5-default qttools5-dev qttools5-dev-tools \
+      qtmultimedia5-dev libqt5multimedia5-plugins libqt5svg5-dev libqt5sql5-mysql
   fi
-  sudo apt-get install -y cmake cmake-data libgtest-dev libprotobuf-dev protobuf-compiler
-  sudo mkdir /usr/src/gtest/build
-  cd /usr/src/gtest/build
-  sudo cmake .. -DBUILD_SHARED_LIBS=1
-  sudo make -j2
-  sudo ln -s /usr/src/gtest/build/libgtest.so /usr/lib/libgtest.so
-  sudo ln -s /usr/src/gtest/build/libgtest_main.so /usr/lib/libgtest_main.so
-  cd -
+
+  # prerequisites for tests
+  if [[ $BUILDTYPE == "Debug" ]]; then
+    if [[ $DIST == "precise" ]]; then
+      sudo add-apt-repository -y ppa:george-edison55/precise-backports
+      sudo apt-get update -qq
+      sudo apt-get install -y cmake cmake-data libgtest-dev
+    else
+      sudo add-apt-repository -y ppa:george-edison55/cmake-3.x
+      sudo apt-get update -qq
+      sudo apt-get install -y cmake cmake-extras libgtest-dev
+    fi
+
+    sudo mkdir /usr/src/gtest/build
+    cd /usr/src/gtest/build
+    sudo cmake .. -DBUILD_SHARED_LIBS=1
+    sudo make -j2
+    sudo ln -s /usr/src/gtest/build/libgtest.so /usr/lib/libgtest.so
+    sudo ln -s /usr/src/gtest/build/libgtest_main.so /usr/lib/libgtest_main.so
+    cd -
+  fi
 fi


### PR DESCRIPTION
This PR makes some modifications to travis builds.
This PR replaces #1648; new targets are:
 * ubuntu precise, debug, qt4 (+tests)
 * ubuntu precise, release, qt4 (+tests)
 * ubuntu trusty, debug, qt5 (+tests)
 * ubuntu trusty, release, qt5 (+package)
 * osx, debug, qt5 (+package)
 * osx, release, qt5 (+package)

The precise+qt5 has been left out because a package built with this combination would force users to manually add PPAs and install packages.
The osx+qt4 and trusty+qt4 have been left out because there is just no need for them.

The second part of this PR adds package deployment to bintray. I've not been able to test this outside of the main repo, let's see if this works on this PR or if we need to create a new branch in the Cockatrice repo.