### PR TITLE
Having token set to not null breaks the use of requireemail=false

### DIFF
--- a/servatrice/migrations/servatrice_0011_to_0012.sql
+++ b/servatrice/migrations/servatrice_0011_to_0012.sql
@@ -1,0 +1,5 @@
+-- Servatrice db migration from version 11 to version 12
+
+alter table cockatrice_users modify token binary(16) NULL;
+
+UPDATE cockatrice_schema_version SET version=12 WHERE version=11;

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -82,7 +82,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_users` (
   `avatar_bmp` blob NOT NULL,
   `registrationDate` datetime NOT NULL,
   `active` tinyint(1) NOT NULL,
-  `token` binary(16) NOT NULL,
+  `token` binary(16),
   `clientid` varchar(15) NOT NULL,
   PRIMARY KEY  (`id`),
   UNIQUE KEY `name` (`name`),

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_schema_version` (
   PRIMARY KEY  (`version`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
-INSERT INTO cockatrice_schema_version VALUES(11);
+INSERT INTO cockatrice_schema_version VALUES(12);
 
 CREATE TABLE IF NOT EXISTS `cockatrice_decklist_files` (
   `id` int(7) unsigned zerofill NOT NULL auto_increment,


### PR DESCRIPTION
Having token set to not null breaks the use of requireemail=false in the servatrice.ini as token will be null in this use case.