### PR TITLE
Improved login error message

### DIFF
--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -8,6 +8,7 @@
 #include <QDebug>
 #include <QEvent>
 #include <QKeyEvent>
+#include <QMessageBox>
 #include <iostream>
 #include "dlg_connect.h"
 #include "settingscache.h"
@@ -148,6 +149,12 @@ void DlgConnect::actOk()
     
     settingsCache->servers().setPreviousHostList(hostList);
     settingsCache->servers().setPrevioushostindex(previousHosts->currentIndex());
+
+    if(playernameEdit->text().isEmpty())
+    {
+        QMessageBox::critical(this, tr("Connect Warning"), tr("The player name can't be empty."));
+        return;
+    }
 
     accept();
 }

--- a/cockatrice/src/dlg_register.cpp
+++ b/cockatrice/src/dlg_register.cpp
@@ -361,6 +361,11 @@ void DlgRegister::actOk()
         QMessageBox::critical(this, tr("Registration Warning"), tr("Your email addresses do not match, please try again."));
         return;
     }
+    if(playernameEdit->text().isEmpty())
+    {
+        QMessageBox::critical(this, tr("Registration Warning"), tr("The player name can't be empty."));
+        return;
+    }
 
     settingsCache->servers().setHostName(hostEdit->text());
     settingsCache->servers().setPort(portEdit->text());

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -387,7 +387,7 @@ Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd
     QString clientId = QString::fromStdString(cmd.clientid()).simplified();
     QString clientVersion = QString::fromStdString(cmd.clientver()).simplified();
 
-    if (userName.isEmpty() || (userInfo != 0))
+    if (userInfo != 0)
         return Response::RespContextError;
 
     // check client feature set against server feature set

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -176,7 +176,8 @@ bool Servatrice::initServer()
     bool registrationEnabled = settingsCache->value("registration/enabled", false).toBool();
     bool requireEmailForRegistration = settingsCache->value("registration/requireemail", true).toBool();
 
-    qDebug() << "Registration enabled: " << regServerOnly;
+    qDebug() << "Accept registered users only: " << regServerOnly;
+    qDebug() << "Registration enabled: " << registrationEnabled;
     if (registrationEnabled)
         qDebug() << "Require email address to register: " << requireEmailForRegistration;
 

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -124,6 +124,8 @@ bool Servatrice_DatabaseInterface::execSqlQuery(QSqlQuery *query)
 bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user, QString & error)
 {
     int minNameLength = settingsCache->value("users/minnamelength", 6).toInt();
+    if(minNameLength < 1)
+        minNameLength = 1;
     int maxNameLength = settingsCache->value("users/maxnamelength", 12).toInt();
     bool allowLowercase = settingsCache->value("users/allowlowercase", true).toBool();
     bool allowUppercase = settingsCache->value("users/allowuppercase", true).toBool();


### PR DESCRIPTION
If the server is reg-only and an user tries to login with an empty username, he receives a generic error that’s really hard to interpret.

Behavior after this change:

Accepy registered users only:  true

 * Empty username : "Invalid username" popup
 * Inexistant username: "This server requires registration. Do you want to register now?" popup
 * Existant username, wrong or empry password: "Incorrect username or password" popup
 * Correct username and password : login

Accepy registered users only:  false 

* Empty username : "Invalid username" popup
* Inexistant username: login as unregistered user
* Existant username, wrong or empry password: "Incorrect username or password" popup
* Correct username and password : login

Fix #1694  and related ticket #1693