### PR TITLE
Fix column widths in rooms list

### DIFF
--- a/cockatrice/src/tab_server.cpp
+++ b/cockatrice/src/tab_server.cpp
@@ -36,7 +36,6 @@ RoomSelector::RoomSelector(AbstractClient *_client, QWidget *parent)
 #else
     roomList->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
     roomList->header()->setSectionResizeMode(1, QHeaderView::Stretch);
-    roomList->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
     roomList->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
     roomList->header()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
 #endif    


### PR DESCRIPTION
While porting to Qt5, a wrong copy/paste lead to the introduction of a duplicated line that broke autoresizing of the room description column.

Fix #1687