### PR TITLE
Add correct encrypted api key to deploy to bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,6 @@ deploy:
   file: "build/bintray_deploy.json"
   user: "ctrlaltca"
   key:
-    secure: b9Nv8FeYJGaTs1bZD8z0a7VksmEDkgVSDu8Os1ldYVaE6AwgYTt++RAbX60eu6jRb0G1bUCTWNF5wh3vhjYNl2xrj7N89O5FQAIgQcyWveAU91pn2I92pMcRfhHMIUVLwgzHoSy9JQPFG3ecE6CtWAi9+rbqcRwQRg+A2jfd7yI=
+    secure: DtVeeLoi5fZG/RvLTecRnRQGW9fVNS4Oa5iut2vJa14PdKBAJiXACQ0EzcRJFsbtby7MyMc2IVtT5skpvsaSqkpaxoBaL1YtKwJ4CTkYcm2MDWHS7UlijuxxTjI6BnaL3lcCCIeG+NHBZa3dV2YNJ1sWv6Xmiiix1ujPPW8VtnM=
   on:
     condition: $BUILDTYPE = Release

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ such as Magic: The Gathering, over a network. It is fully client-server based
 to prevent any kind of cheating, though it supports single-player games without
 a network interface as well. Both client and server are written in Qt, supporting both Qt4 and Qt5.<br>
 
+# Downloads
+We offer a download for both the last stable version (recommended for users) and the last development version. The development version contains the last implemented features, but can be unstable and unsuitable for gaming.
+Downloads are hosted on [BinTray](https://bintray.com/).
+
+- Latest stable version download: [ ![Download](https://api.bintray.com/packages/cockatrice/Cockatrice/Cockatrice/images/download.svg) ](https://bintray.com/cockatrice/Cockatrice/Cockatrice/_latestVersion)
+- Latest development (unstable) version download: [ ![Download](https://api.bintray.com/packages/cockatrice/Cockatrice/Cockatrice-git/images/download.svg) ](https://bintray.com/cockatrice/Cockatrice/Cockatrice-git/_latestVersion)
 
 # Get Involved [![Gitter chat](https://badges.gitter.im/Cockatrice/Cockatrice.png)](https://gitter.im/Cockatrice/Cockatrice)
 


### PR DESCRIPTION
With this key Travis should be authorized to deploy packages built from the Cockatrice/Cockatrice repo, master branch only, to bintray.

fix #1703