### PR TITLE
Add gear icon to settings menu entry

### DIFF
--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -133,6 +133,10 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationName("Cockatrice");
 
 #ifdef Q_OS_MAC
+    qApp->setAttribute(Qt::AA_DontShowIconsInMenus, true);
+#endif
+
+#ifdef Q_OS_MAC
     translationPath = qApp->applicationDirPath() + "/../Resources/translations";
 #elif defined(Q_OS_WIN)
     translationPath = qApp->applicationDirPath() + "/translations";

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -485,6 +485,7 @@ void MainWindow::retranslateUi()
     aFullScreen->setText(tr("&Full screen"));
     aRegister->setText(tr("&Register to server..."));
     aSettings->setText(tr("&Settings..."));
+    aSettings->setIcon(QPixmap("theme:icons/settings"));
     aExit->setText(tr("&Exit"));
 
 #if defined(__APPLE__)  /* For OSX */


### PR DESCRIPTION
Fix #1108
Replaces #1668
Takes care of not showing menu icons on OSX