### PR TITLE
Misc speedups in card database

### DIFF
--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -60,8 +60,6 @@ public:
 class CardInfo : public QObject {
     Q_OBJECT
 private:
-    CardDatabase *db;
-
     QString name;
 
     /*
@@ -84,6 +82,7 @@ private:
     QStringList reverseRelatedCards;
     // the cards thare are reverse-related to me
     QStringList reverseRelatedCardsToMe;
+    QString setsNames;
     bool upsideDownArt;
     int loyalty;
     QStringMap customPicURLs;
@@ -92,9 +91,9 @@ private:
     int tableRow;
     QString pixmapCacheKey;
 
+    void refreshCachedSetNames();
 public:
-    CardInfo(CardDatabase *_db,
-        const QString &_name = QString(),
+    CardInfo(const QString &_name = QString(),
         bool _isToken = false,
         const QString &_manacost = QString(),
         const QString &_cmc = QString(),
@@ -113,14 +112,15 @@ public:
         MuidMap muids = MuidMap()
         );
     ~CardInfo();
-    const QString &getName() const { return name; }
+    inline const QString &getName() const { return name; }
+    inline const QString &getSetsNames() const { return setsNames; }
     const QString &getSimpleName() const { return simpleName; }
     bool getIsToken() const { return isToken; }
     const SetList &getSets() const { return sets; }
-    const QString &getManaCost() const { return manacost; }
-    const QString &getCmc() const { return cmc; }
-    const QString &getCardType() const { return cardtype; }
-    const QString &getPowTough() const { return powtough; }
+    inline const QString &getManaCost() const { return manacost; }
+    inline const QString &getCmc() const { return cmc; }
+    inline const QString &getCardType() const { return cardtype; }
+    inline const QString &getPowTough() const { return powtough; }
     const QString &getText() const { return text; }
     const QString &getPixmapCacheKey() const { return pixmapCacheKey; }
     const int &getLoyalty() const { return loyalty; }
@@ -229,12 +229,12 @@ public:
     bool hasDetectedFirstRun();
     void refreshCachedReverseRelatedCards();
 public slots:
-    LoadStatus loadCardDatabase(const QString &path, bool tokens = false);
+    LoadStatus loadCardDatabase();
+    LoadStatus loadTokenDatabase();
     void loadCustomCardDatabases(const QString &path);
     void emitCardListChanged();
 private slots:
-    void loadCardDatabase();
-    void loadTokenDatabase();
+    LoadStatus loadCardDatabase(const QString &path, bool tokens = false);
 signals:
     void cardListChanged();
     void cardAdded(CardInfo *card);

--- a/cockatrice/src/carddatabasemodel.h
+++ b/cockatrice/src/carddatabasemodel.h
@@ -42,6 +42,7 @@ private:
     QString searchTerm;
     QSet<QString> cardNameSet, cardTypes, cardColors;
     FilterTree *filterTree;
+    int loadedRowCount;
 public:
     CardDatabaseDisplayModel(QObject *parent = 0);
     void setFilterTree(FilterTree *filterTree);
@@ -54,9 +55,13 @@ public:
     void setCardTypes(const QSet<QString> &_cardTypes) { cardTypes = _cardTypes; invalidate(); }
     void setCardColors(const QSet<QString> &_cardColors) { cardColors = _cardColors; invalidate(); }
     void clearFilterAll();
+    int rowCount(const QModelIndex &parent = QModelIndex()) const;
 protected:
     bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
     bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
+
+    bool canFetchMore(const QModelIndex &parent) const;
+    void fetchMore(const QModelIndex &parent);
 private slots:
     void filterTreeChanged();
 };

--- a/cockatrice/src/dlg_edit_tokens.cpp
+++ b/cockatrice/src/dlg_edit_tokens.cpp
@@ -145,7 +145,7 @@ void DlgEditTokens::actAddToken()
     if (name.isEmpty())
         return;
     
-    CardInfo *card = new CardInfo(cardDatabaseModel->getDatabase(), name, true);
+    CardInfo *card = new CardInfo(name, true);
     card->addToSet(cardDatabaseModel->getDatabase()->getSet(CardDatabase::TOKENS_SETNAME));
     card->setCardType("Token");
     cardDatabaseModel->getDatabase()->addCard(card);

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -163,12 +163,15 @@ int main(int argc, char *argv[])
 #else
     const QString dataDir = QStandardPaths::standardLocations(QStandardPaths::DataLocation).first();
 #endif
-    
-    if (!db->getLoadSuccess())
-        if (!db->loadCardDatabase(dataDir + "/cards.xml"))
-            settingsCache->setCardDatabasePath(dataDir + "/cards.xml");
-    if (settingsCache->getTokenDatabasePath().isEmpty())
+
+    if (settingsCache->getCardDatabasePath().isEmpty() ||
+        db->loadCardDatabase() != Ok)
+        settingsCache->setCardDatabasePath(dataDir + "/cards.xml");
+
+    if (settingsCache->getTokenDatabasePath().isEmpty() ||
+        db->loadTokenDatabase() != Ok)
         settingsCache->setTokenDatabasePath(dataDir + "/tokens.xml");
+
     if (!QDir(settingsCache->getDeckPath()).exists() || settingsCache->getDeckPath().isEmpty()) {
         QDir().mkpath(dataDir + "/decks");
         settingsCache->setDeckPath(dataDir + "/decks");

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -367,17 +367,16 @@ void TabDeckEditor::createCentralFrame()
     databaseDisplayModel = new CardDatabaseDisplayModel(this);
     databaseDisplayModel->setSourceModel(databaseModel);
     databaseDisplayModel->setFilterKeyColumn(0);
-    databaseDisplayModel->sort(0, Qt::AscendingOrder);
 
     databaseView = new QTreeView();
     databaseView->setObjectName("databaseView");
     databaseView->setFocusProxy(searchEdit);
-    databaseView->setModel(databaseDisplayModel);
     databaseView->setUniformRowHeights(true);
     databaseView->setRootIsDecorated(false);
     databaseView->setAlternatingRowColors(true);
     databaseView->setSortingEnabled(true);
     databaseView->sortByColumn(0, Qt::AscendingOrder);
+    databaseView->setModel(databaseDisplayModel);
     databaseView->resizeColumnToContents(0);
     connect(databaseView->selectionModel(), SIGNAL(currentRowChanged(const QModelIndex &, const QModelIndex &)), this, SLOT(updateCardInfoLeft(const QModelIndex &, const QModelIndex &)));
     connect(databaseView, SIGNAL(doubleClicked(const QModelIndex &)), this, SLOT(actAddCard()));

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -96,7 +96,7 @@ CardInfo *OracleImporter::addCard(const QString &setName,
         bool cipt = cardText.contains("Hideaway") || (cardText.contains(cardName + " enters the battlefield tapped") && !cardText.contains(cardName + " enters the battlefield tapped unless"));
         
         // insert the card and its properties
-        card = new CardInfo(this, cardName, isToken, cardCost, cmc, cardType, cardPT, cardText, colors, relatedCards, reverseRelatedCards, upsideDown, cardLoyalty, cipt);
+        card = new CardInfo(cardName, isToken, cardCost, cmc, cardType, cardPT, cardText, colors, relatedCards, reverseRelatedCards, upsideDown, cardLoyalty, cipt);
         int tableRow = 1;
         QString mainCardType = card->getMainCardType();
         if ((mainCardType == "Land") || mArtifact)


### PR DESCRIPTION
Misc speedup patches for card database. Nothing really impressive.
 * Lazy loading of items in card database view 
 * cache each card’s set list instead of re-joining its sets names at every reload
 * remove unused pointer to card database on each card object
 * avoid double loading of card database on error