### PR TITLE
Token PT shown in create related dialog

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -660,7 +660,12 @@ void CardDatabase::refreshCachedReverseRelatedCards()
         if(card->getReverseRelatedCards().isEmpty())
             continue;
 
-        QString relatedCardName = card->getName();
+        QString relatedCardName;
+        if (card->getPowTough().size() > 0)
+            relatedCardName = card->getPowTough() + " " + card->getName(); // "n/n name"
+        else
+            relatedCardName = card->getName(); // "name"
+
         foreach(QString targetCard, card->getReverseRelatedCards())
         {
             if (!cards.contains(targetCard))

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1135,7 +1135,14 @@ void Player::actCreateRelatedCard()
 
     // get the target card name
     QAction *action = static_cast<QAction *>(sender());
-    CardInfo *cardInfo = db->getCard(action->text());
+
+    // removes p/t from tokens (and leading space))
+    QStringList spaces = action->text().split(" ");
+
+    if (spaces.at(0).indexOf("/") != -1) // Strip space from creatures
+        spaces.removeFirst();
+
+    CardInfo *cardInfo = db->getCard(spaces.join(" "));
 
     // create the token for the related card
     Command_CreateToken cmd;


### PR DESCRIPTION
This addresses a concern I had before (in #1722) about tokens not showing their P/T in the dialog.

<img width="460" alt="screenshot 2015-12-29 18 29 44" src="https://cloud.githubusercontent.com/assets/7460172/12044116/41c064b8-ae5a-11e5-8f43-42765ad4364e.png">
<img width="599" alt="screenshot 2015-12-29 18 29 52" src="https://cloud.githubusercontent.com/assets/7460172/12044113/41bc139a-ae5a-11e5-9a11-fbadc1d6b7ff.png">
<img width="366" alt="screenshot 2015-12-29 18 29 56" src="https://cloud.githubusercontent.com/assets/7460172/12044114/41bcfca6-ae5a-11e5-9343-3765f4add4e0.png">
<img width="321" alt="screenshot 2015-12-29 18 30 21" src="https://cloud.githubusercontent.com/assets/7460172/12044115/41c01080-ae5a-11e5-8183-718b387d2ae7.png">
<img width="841" alt="screenshot 2015-12-29 18 30 32" src="https://cloud.githubusercontent.com/assets/7460172/12044117/41c1ce52-ae5a-11e5-9ec2-932f8b276cf6.png">