### PR TITLE
Token coordinates

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1138,6 +1138,7 @@ void Player::actCreateRelatedCard()
     CardInfo *cardInfo = db->getCard(action->text());
     
     // get the target token's location
+    // TODO: Define this QPoint into its own function along with the one below
     QPoint gridPoint = QPoint(-1, table->clampValidTableRow(2 - cardInfo->getTableRow()));
 
     // create the token for the related card

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1136,6 +1136,9 @@ void Player::actCreateRelatedCard()
     // get the target card name
     QAction *action = static_cast<QAction *>(sender());
     CardInfo *cardInfo = db->getCard(action->text());
+    
+    // get the target token's location
+    QPoint gridPoint = QPoint(-1, table->clampValidTableRow(2 - cardInfo->getTableRow()));
 
     // create the token for the related card
     Command_CreateToken cmd;
@@ -1146,6 +1149,9 @@ void Player::actCreateRelatedCard()
     cmd.set_annotation(settingsCache->getAnnotateTokens() ? cardInfo->getText().toStdString() : QString().toStdString());
     cmd.set_destroy_on_zone_change(true);
     cmd.set_target_zone(sourceCard->getZone()->getName().toStdString());
+    cmd.set_x(gridPoint.x());
+    cmd.set_y(gridPoint.y());
+
     if(!cardInfo->getIsToken())
         cmd.set_target_card_id(sourceCard->getId());
 


### PR DESCRIPTION
Fix #1735

This sets the x&y coordinates of the token so they don't bunch up and they take free space only.

Before:
<img width="285" alt="screenshot 2015-12-29 23 41 36" src="https://cloud.githubusercontent.com/assets/7460172/12046365/b98c92d4-ae85-11e5-8ff8-3af7faa6ee85.png">

After:
<img width="346" alt="screenshot 2015-12-29 23 41 19" src="https://cloud.githubusercontent.com/assets/7460172/12046364/b98a9bd2-ae85-11e5-9b3e-915b8ffd296b.png">

