### PR TITLE
fix replay progress bar

### DIFF
--- a/cockatrice/src/replay_timeline_widget.cpp
+++ b/cockatrice/src/replay_timeline_widget.cpp
@@ -58,7 +58,8 @@ void ReplayTimelineWidget::paintEvent(QPaintEvent * /* event */)
     painter.fillPath(path, Qt::black);
     
     const QColor barColor = QColor::fromHsv(120, 255, 255, 100);
-    painter.fillRect(0, 0, (width() - 1) * currentTime / maxTime, height() - 1, barColor);
+    quint64 w = (quint64)(width() - 1) * (quint64) currentTime / maxTime;
+    painter.fillRect(0, 0, w, height() - 1, barColor);
 }
 
 QSize ReplayTimelineWidget::sizeHint() const


### PR DESCRIPTION
The replay timeline draws a green rectangle used as a progress bar.
On very long replays, the rectangle width’s calculation overflowed the integer data type, resulting in a negative width value.
As a result, after a specific time the green rectangle was nor visible anymore.

This fixes #1525, or at least a part of it.