### PR TITLE
Update replay maintenance script

### DIFF
--- a/servatrice/scripts/linux/maint_replays
+++ b/servatrice/scripts/linux/maint_replays
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-# SCHEDULE WITH CRONTAB BASED ON TIME PERIOD REPLAYS SHOULD BE SAVED UNTIL (EX: SCHEDULE ONCE A WEEK TO KEEP A WEEKS WORTH OF REPLAYS IN THE DB)
-
+# SCHEDULE WITH CRONTAB DAILY
 DBNAME="servatrice"					#set this to the database name used
 TABLEPREFIX="cockatrice"			#set this to the prefix used for the table names in the database (do not inclue the _)
 SQLCONFFILE="./mysql.cnf" 			#set this to the path that contains the mysql.cnf file
-mysql --defaults-file=$SQLCONFFILE -h localhost -e 'truncate table ""$DBNAME"".""$TABLEPREFIX""_replays;truncate table ""$DBNAME"".""$TABLEPREFIX""_replays_access'
+mysql --defaults-file=$SQLCONFFILE -h localhost -e 'delete from servatrice.cockatrice_games where time_finished < DATE_SUB(now(), INTERVAL 8 DAY)'
+mysql --defaults-file=$SQLCONFFILE -h localhost -e 'delete from servatrice.cockatrice_replays where id_game NOT IN (select id from servatrice.cockatrice_games)'
+mysql --defaults-file=$SQLCONFFILE -h localhost -e 'delete from servatrice.cockatrice_replays_access where id_game NOT IN (select id from servatrice.cockatrice_games)'


### PR DESCRIPTION
Update the replay maintenance script to allow for rolling replay maintenance along with cleanup of the two associated db tables (replay access and games).  This updated script will now allow players to see the past X days (8 by default) of replays rather than loosing all replays from the point in the the script gets run.