### PR TITLE
Cmake: build Windows Xp compatible packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,8 @@ endif()
 # Define proper compilation flags
 IF(MSVC)
 	# Visual Studio:
+    # Support from Windows XP
+    SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:WINDOWS,5.01")
 	# Maximum optimization
     set(CMAKE_CXX_FLAGS_RELEASE "/Ox /MD")
 	# Generate complete debugging information


### PR DESCRIPTION
Without this simple fix, cockatrice on windows xp fails to run and report a “is not a valid win32 application” error.