### PR TITLE
Fix mysql plugin deploy on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,12 +11,18 @@ environment:
           target_arch: x86_64
           qt_ver: 5.5\msvc2013_64
           bintray_path: Win64
+          MYSQL_DRIVER_URL: https://dev.mysql.com/get/Downloads/Connector-C/mysql-connector-c-6.1.6-winx64.zip
+          MYSQL_DRIVER_ARCHIVE: mysql-connector-c-6.1.6-winx64.zip
+          MYSQL_DRIVER_NAME: mysql-connector-c-6.1.6-winx64
         - vc_arch: amd64_x86  # cross-compile from amd64 to x86
           choco_arch: --x86
           nuget_arch: Win32
           target_arch: x86
           qt_ver: 5.5\msvc2013
           bintray_path: Win32
+          MYSQL_DRIVER_URL: https://dev.mysql.com/get/Downloads/Connector-C/mysql-connector-c-6.1.6-win32.zip
+          MYSQL_DRIVER_ARCHIVE: mysql-connector-c-6.1.6-win32.zip
+          MYSQL_DRIVER_NAME: mysql-connector-c-6.1.6-win32
 install:
     - systeminfo
     # upgrade cmake in order to have c++11 support
@@ -41,6 +47,9 @@ install:
         } else {
            nuget install zlib -OutputDirectory c:\zlib
         }
+    # install mysql connector
+    - curl -kLO %MYSQL_DRIVER_URL%
+    - 7z x %MYSQL_DRIVER_ARCHIVE% -oc:\ >nul
 build_script:
     - mkdir build
     - cd build
@@ -59,12 +68,15 @@ build_script:
         $protolib = c:\cygwin\bin\cygpath -m $protolib
         $protoc = c:\cygwin\bin\find /cygdrive/c/protoc/ -name "protoc.exe"
         $protoc = c:\cygwin\bin\cygpath -m $protoc
+        $mysqldll = c:\cygwin\bin\find /cygdrive/c/$env:MYSQL_DRIVER_NAME -name "libmysql.dll"
+        $mysqldll = c:\cygwin\bin\cygpath -m $mysqldll
         Write-Output "ZLIBINC  = $zlibinc"
         Write-Output "ZLIBLIB  = $zliblib"
         Write-Output "PROTOINC = $protoinc"
         Write-Output "PROTOLIB = $protolib"
         Write-Output "PROTOC   = $protoc"
-        cmake .. "-GNMake Makefiles" "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_PREFIX_PATH=c:/Qt/$env:qt_ver" "-DWITH_SERVER=1" "-DZLIB_INCLUDE_DIR=$zlibinc" "-DZLIB_LIBRARY=$zliblib" "-DPROTOBUF_INCLUDE_DIR=$protoinc" "-DPROTOBUF_LIBRARIES=$protolib" "-DPROTOBUF_LIBRARIES=$protolib" "-DPROTOBUF_LIBRARY=$protolib" "-DPROTOBUF_PROTOC_EXECUTABLE=$protoc"
+        Write-Output "MYSQLDLL   = $mysqldll"
+        cmake .. "-GNMake Makefiles" "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_PREFIX_PATH=c:/Qt/$env:qt_ver" "-DWITH_SERVER=1" "-DZLIB_INCLUDE_DIR=$zlibinc" "-DZLIB_LIBRARY=$zliblib" "-DPROTOBUF_INCLUDE_DIR=$protoinc" "-DPROTOBUF_LIBRARIES=$protolib" "-DPROTOBUF_LIBRARIES=$protolib" "-DPROTOBUF_LIBRARY=$protolib" "-DPROTOBUF_PROTOC_EXECUTABLE=$protoc" "-DMYSQLCLIENT_LIBRARIES=$mysqldll"
     - nmake package
     - c:\cygwin\bin\ls -l
     - ps: |

--- a/servatrice/CMakeLists.txt
+++ b/servatrice/CMakeLists.txt
@@ -201,7 +201,7 @@ if(WIN32)
     # qt5: platforms, sqldrivers
 
     install(DIRECTORY "${QT_PLUGINS_DIR}/" DESTINATION ${plugin_dest_dir} COMPONENT Runtime
-        FILES_MATCHING REGEX "(codecs/.*|platforms/.*|sqldrivers/libqsqlmysql)\\.dll"
+        FILES_MATCHING REGEX "(codecs/.*|platforms/.*|sqldrivers/qsqlmysql)\\.dll"
         REGEX ".*d\\.dll" EXCLUDE)
 
     install(CODE "


### PR DESCRIPTION
Aka: make servatrice able to work with mysql under windows.

Fixes two separate issues:
 * qt’s mysql plugin was not being bundled in the package
 * appveyor builds were always bundling the 64-bit version of libmysql.dll. Now the x86 package correctly contains a 32-bit version of the library.

Note: servatrice+mysql will work only on OS >= Windows Vista. This is due to mysql not supporting anymore Windows Xp since mysql connector 6.1.2 (https://dev.mysql.com/doc/relnotes/connector-c/en/news-6-1-2.html)