### PR TITLE
Prevent trayIcon Null Crash

### DIFF
--- a/cockatrice/src/tab_message.cpp
+++ b/cockatrice/src/tab_message.cpp
@@ -5,6 +5,7 @@
 #include <QAction>
 #include <QSystemTrayIcon>
 #include <QApplication>
+#include <QDebug>
 #include "tab_message.h"
 #include "abstractclient.h"
 #include "chatview.h"
@@ -131,9 +132,15 @@ bool TabMessage::shouldShowSystemPopup(const Event_UserMessage &event) {
 }
 
 void TabMessage::showSystemPopup(const Event_UserMessage &event) {
-    disconnect(trayIcon, SIGNAL(messageClicked()), 0, 0);
-    trayIcon->showMessage(tr("Private message from ") + otherUserInfo->name().c_str(), event.message().c_str());
-    connect(trayIcon, SIGNAL(messageClicked()), this, SLOT(messageClicked()));
+    if (trayIcon) {
+        disconnect(trayIcon, SIGNAL(messageClicked()), 0, 0);
+        trayIcon->showMessage(tr("Private message from ") + otherUserInfo->name().c_str(), event.message().c_str());
+        connect(trayIcon, SIGNAL(messageClicked()), this, SLOT(messageClicked()));
+    }
+    else
+    {
+        qDebug() << "Error: trayIcon is NULL. TabMessage::showSystemPopup failed";
+    }
 }
 
 void TabMessage::messageClicked() {

--- a/cockatrice/src/tab_room.cpp
+++ b/cockatrice/src/tab_room.cpp
@@ -160,8 +160,8 @@ void TabRoom::focusTab() {
 }
 
 void TabRoom::actShowMentionPopup(QString &sender) {
-    if (tabSupervisor->currentIndex() != tabSupervisor->indexOf(this) 
-        || QApplication::activeWindow() == 0 || QApplication::focusWidget() == 0) {
+    if (trayIcon && (tabSupervisor->currentIndex() != tabSupervisor->indexOf(this) || QApplication::activeWindow() == 0
+        || QApplication::focusWidget() == 0)) {
         disconnect(trayIcon, SIGNAL(messageClicked()), 0, 0);
         trayIcon->showMessage(sender + tr(" mentioned you."), tr("Click to view"));
         connect(trayIcon, SIGNAL(messageClicked()), chatView, SLOT(actMessageClicked()));


### PR DESCRIPTION
Fix #1860 

Adds `trayIcon != NULL` to the checks prior to attempting to alter the trayIcon to prevent a crash.