### PR TITLE
Servatrice: Split requireemail into requireemail and requireemailaction

### DIFF
--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -105,10 +105,13 @@ allowpunctuationprefix=false
 ; Enable this feature? Default false.
 ;enabled=false
 
-; Require users to provide an email address in order to register. Newly registered users will receive an
-; activation token by email, and will be required to input back this token on cockatrice at the first login
-; to get their account activated. Default true.
+; Require users to provide an email address in order to register. Default true.
 ;requireemail=true
+
+; Require email activation. Newly registered users will receive an activation token by email,
+; and will be required to input back this token on cockatrice at the first login to get their
+; account activated. Default true.
+;requireemailactivation=true
 
 [smtp]
 

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -175,11 +175,15 @@ bool Servatrice::initServer()
 
     bool registrationEnabled = settingsCache->value("registration/enabled", false).toBool();
     bool requireEmailForRegistration = settingsCache->value("registration/requireemail", true).toBool();
+    bool requireEmailActivation = settingsCache->value("registration/requireemailactivation", true).toBool();
 
     qDebug() << "Accept registered users only: " << regServerOnly;
     qDebug() << "Registration enabled: " << registrationEnabled;
     if (registrationEnabled)
+    {
         qDebug() << "Require email address to register: " << requireEmailForRegistration;
+        qDebug() << "Require email activation via token: " << requireEmailActivation;
+    }
 
     FeatureSet features;
     features.initalizeFeatureList(serverRequiredFeatureList);
@@ -498,8 +502,8 @@ void Servatrice::statusUpdate()
 
     // send activation emails
     bool registrationEnabled = settingsCache->value("registration/enabled", false).toBool();
-    bool requireEmailForRegistration = settingsCache->value("registration/requireemail", true).toBool();
-    if (registrationEnabled && requireEmailForRegistration)
+    bool requireEmailActivation = settingsCache->value("registration/requireemailactivation", true).toBool();
+    if (registrationEnabled && requireEmailActivation)
     {
         QSqlQuery *query = servatriceDatabaseInterface->prepareQuery("select a.name, b.email, b.token from {prefix}_activation_emails a left join {prefix}_users b on a.name = b.name");
         if (!servatriceDatabaseInterface->execSqlQuery(query))

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -1034,12 +1034,13 @@ Response::ResponseCode ServerSocketInterface::cmdRegisterAccount(const Command_R
         return Response::RespPasswordTooShort;
 
     QString token;
-    bool regSucceeded = sqlInterface->registerUser(userName, realName, gender, password, emailAddress, country, token, !requireEmailForRegistration);
+    bool requireEmailActivation = settingsCache->value("registration/requireemailactivation", true).toBool();
+    bool regSucceeded = sqlInterface->registerUser(userName, realName, gender, password, emailAddress, country, token, !requireEmailActivation);
 
     if(regSucceeded)
     {
         qDebug() << "Accepted register command for user: " << userName;
-        if(requireEmailForRegistration)
+        if(requireEmailActivation)
         {
             QSqlQuery *query = sqlInterface->prepareQuery("insert into {prefix}_activation_emails (name) values(:name)");
             query->bindValue(":name", userName);


### PR DESCRIPTION
> @woogerboy21:
 i see a potential need for having the ability to require registration + email but not send activation tokens (simply just activate the account) is it adds one more criteria that could be used for validating a users account really is that user when they "forget" there password and request a reset.
I am always hesitant to reset some one's password that sends me an email saying they forgot on an account that does not have an email address with it since it could be just some one randomly trying to hijack another users account
its really not that difficult to run a DB query to activate the accounts on a timed bases. the problem with using that method is the users are prompted to enter a token that never comes and most users end up sending a message to the server operator rather than simply retrying there login

This PR splits the "requireemail" servatrice setting into:
 * "requireemail": simple regexp validation on the email
 * requireemailactivation: send token email, require users to input their activation token