### PR TITLE
Prevent PTColumn from being the last column shown.

### DIFF
--- a/cockatrice/src/carddatabasemodel.h
+++ b/cockatrice/src/carddatabasemodel.h
@@ -12,7 +12,7 @@ class FilterTree;
 class CardDatabaseModel : public QAbstractListModel {
     Q_OBJECT
 public:
-    enum Columns { NameColumn, SetListColumn, ManaCostColumn, CardTypeColumn, PTColumn, CMCColumn };
+    enum Columns { NameColumn, SetListColumn, ManaCostColumn, PTColumn, CardTypeColumn, CMCColumn };
     enum Role { SortRole=Qt::UserRole };
     CardDatabaseModel(CardDatabase *_db, QObject *parent = 0);
     ~CardDatabaseModel();


### PR DESCRIPTION
P/T column is really narrow. It should go before Card Type, so Card Type can expand into the remaining space.

Improves #1671, assuming I got this correct.

Untested!