### PR TITLE
User suspicion

### DIFF
--- a/cockatrice/src/userlist.cpp
+++ b/cockatrice/src/userlist.cpp
@@ -352,10 +352,10 @@ void UserList::processUserInfo(const ServerInfo_User &user, bool online)
         item = new UserListTWI(user);
         users.insert(userName, item);
 
-		if (user.user_level() > 3) {  //NEED TO CORRECT THIS TO EITHER LOCATE IF YOUR ARE ADMIN/MOD AND SHOW OR BLOCK SUSPICION LEVEL FROM BEING RETURNED IF A REG USER REQUESTS USER DATA
+		if (!tabSupervisor->getAdminLocked()) {
 			if (user.suspicion() > 10) { // apply warning level due to user suspicion level being elevated
 				item->setBackground(0, *(new QBrush(Qt::yellow, Qt::Dense6Pattern)));
-				item->setBackground(1, *(new QBrush(Qt::yellow , Qt::Dense6Pattern)));
+				item->setBackground(1, *(new QBrush(Qt::yellow, Qt::Dense6Pattern)));
 				item->setBackground(2, *(new QBrush(Qt::yellow, Qt::Dense6Pattern)));
 			}
 
@@ -365,7 +365,6 @@ void UserList::processUserInfo(const ServerInfo_User &user, bool online)
 				item->setBackground(2, *(new QBrush(Qt::red, Qt::Dense6Pattern)));
 			}
 		}
-
         userTree->addTopLevelItem(item);
         if (online)
             ++onlineCount;

--- a/cockatrice/src/userlist.cpp
+++ b/cockatrice/src/userlist.cpp
@@ -320,7 +320,6 @@ UserList::UserList(TabSupervisor *_tabSupervisor, AbstractClient *_client, UserL
     userTree->setRootIsDecorated(false);
     userTree->setIconSize(QSize(20, 12));
     userTree->setItemDelegate(itemDelegate);
-    userTree->setAlternatingRowColors(true);
     connect(userTree, SIGNAL(itemActivated(QTreeWidgetItem *, int)), this, SLOT(userClicked(QTreeWidgetItem *, int)));
     
     QVBoxLayout *vbox = new QVBoxLayout;
@@ -352,6 +351,21 @@ void UserList::processUserInfo(const ServerInfo_User &user, bool online)
     else {
         item = new UserListTWI(user);
         users.insert(userName, item);
+
+		if (user.user_level() > 3) {  //NEED TO CORRECT THIS TO EITHER LOCATE IF YOUR ARE ADMIN/MOD AND SHOW OR BLOCK SUSPICION LEVEL FROM BEING RETURNED IF A REG USER REQUESTS USER DATA
+			if (user.suspicion() > 50) { // apply warning level due to user suspicion level being elevated
+				item->setBackground(0, *(new QBrush(Qt::yellow, Qt::Dense6Pattern)));
+				item->setBackground(1, *(new QBrush(Qt::yellow , Qt::Dense6Pattern)));
+				item->setBackground(2, *(new QBrush(Qt::yellow, Qt::Dense6Pattern)));
+			}
+
+			if (user.suspicion() > 80) { // apply alert level due to user suspicion level being elevated
+				item->setBackground(0, *(new QBrush(Qt::red, Qt::Dense6Pattern)));
+				item->setBackground(1, *(new QBrush(Qt::red, Qt::Dense6Pattern)));
+				item->setBackground(2, *(new QBrush(Qt::red, Qt::Dense6Pattern)));
+			}
+		}
+
         userTree->addTopLevelItem(item);
         if (online)
             ++onlineCount;

--- a/cockatrice/src/userlist.cpp
+++ b/cockatrice/src/userlist.cpp
@@ -353,13 +353,13 @@ void UserList::processUserInfo(const ServerInfo_User &user, bool online)
         users.insert(userName, item);
 
 		if (user.user_level() > 3) {  //NEED TO CORRECT THIS TO EITHER LOCATE IF YOUR ARE ADMIN/MOD AND SHOW OR BLOCK SUSPICION LEVEL FROM BEING RETURNED IF A REG USER REQUESTS USER DATA
-			if (user.suspicion() > 50) { // apply warning level due to user suspicion level being elevated
+			if (user.suspicion() > 10) { // apply warning level due to user suspicion level being elevated
 				item->setBackground(0, *(new QBrush(Qt::yellow, Qt::Dense6Pattern)));
 				item->setBackground(1, *(new QBrush(Qt::yellow , Qt::Dense6Pattern)));
 				item->setBackground(2, *(new QBrush(Qt::yellow, Qt::Dense6Pattern)));
 			}
 
-			if (user.suspicion() > 80) { // apply alert level due to user suspicion level being elevated
+			if (user.suspicion() > 25) { // apply alert level due to user suspicion level being elevated
 				item->setBackground(0, *(new QBrush(Qt::red, Qt::Dense6Pattern)));
 				item->setBackground(1, *(new QBrush(Qt::red, Qt::Dense6Pattern)));
 				item->setBackground(2, *(new QBrush(Qt::red, Qt::Dense6Pattern)));

--- a/common/featureset.cpp
+++ b/common/featureset.cpp
@@ -20,6 +20,7 @@ void FeatureSet::initalizeFeatureList(QMap<QString, bool> &featureList) {
     featureList.insert("room_chat_history", false);
     featureList.insert("client_warnings", false);
     featureList.insert("mod_log_lookup", false);
+	featureList.insert("suspicion_levels", false);
 }
 
 void FeatureSet::enableRequiredFeature(QMap<QString, bool> &featureList, QString featureName){

--- a/common/pb/serverinfo_user.proto
+++ b/common/pb/serverinfo_user.proto
@@ -24,4 +24,5 @@ message ServerInfo_User {
     optional uint64 accountage_secs = 11;
     optional string email = 12;
     optional string clientid = 13;
+	optional sint32 suspicion = 14;
 }

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -528,7 +528,74 @@ ServerInfo_User Servatrice_DatabaseInterface::evalUserQueryResult(const QSqlQuer
 
 int Servatrice_DatabaseInterface::LocateUserSuspicion(const QString &userName)
 {
-	return 0;
+	
+	if (!checkSql()) 
+		return 0;
+
+	QString clientID;
+	int admin;
+	int calculatedSuspicion = 0;
+	int userID = getUserIdInDB(userName);
+
+	//determin if user is mod/admin
+	QSqlQuery *adminQuery = prepareQuery("select admin from cockatrice_users where id = :userID");
+	adminQuery->bindValue(":userID", userID);
+	if (!execSqlQuery(adminQuery))
+		return 0;
+
+	if (adminQuery->next())
+		admin = adminQuery->value(0).toInt();
+	
+	if (admin)
+		return 0;
+	
+	QSqlQuery *clientidQuery = prepareQuery("select clientid from cockatrice_users where id = :userID");
+	clientidQuery->bindValue(":userID", userID);
+	if (!execSqlQuery(clientidQuery)) 
+		return 0;
+
+	if (clientidQuery->next())
+		clientID = clientidQuery->value(0).toString();
+
+	//count number of accounts
+	QSqlQuery *accountsQuery = prepareQuery("select count(name) from cockatrice_users where clientid = :clientID");
+	accountsQuery->bindValue(":clientID", clientID);
+	if (!execSqlQuery(accountsQuery))
+		return 0;
+
+	if (accountsQuery->next())
+		calculatedSuspicion = calculatedSuspicion + accountsQuery->value(0).toInt();
+
+	//calculate bans
+	QSqlQuery *banQuery = prepareQuery("select count(*) from cockatrice_bans where user_name = :userName");
+	banQuery->bindValue(":userName", userName);
+	if (!execSqlQuery(banQuery))
+		return 0;
+
+	if (banQuery->next())
+		calculatedSuspicion = calculatedSuspicion + banQuery->value(0).toInt();
+
+	//count buddies
+	QSqlQuery *buddyQuery = prepareQuery("select count(*) from cockatrice_buddylist where id_user2 = :userID");
+	buddyQuery->bindValue(":userID", userID);
+	if (!execSqlQuery(buddyQuery))
+		return 0;
+
+	if (buddyQuery->next())
+		calculatedSuspicion = calculatedSuspicion - buddyQuery->value(0).toInt();
+
+	//count ignores
+	QSqlQuery *ignoreQuery = prepareQuery("select count(*) from cockatrice_ignorelist where id_user2 = :userID");
+	ignoreQuery->bindValue(":userID", userID);
+	if (!execSqlQuery(ignoreQuery))
+		return 0;
+
+	if (ignoreQuery->next())
+		calculatedSuspicion = calculatedSuspicion - ignoreQuery->value(0).toInt();
+
+	qDebug() << userName << " suspicion leven calculated to be: " << calculatedSuspicion;
+	return calculatedSuspicion;
+	
 }
 
 ServerInfo_User Servatrice_DatabaseInterface::getUserData(const QString &name, bool withId)

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -520,8 +520,15 @@ ServerInfo_User Servatrice_DatabaseInterface::evalUserQueryResult(const QSqlQuer
         const QString clientid = query->value(9).toString();
         if (!clientid.isEmpty())
             result.set_clientid(clientid.toStdString());
+
+		result.set_suspicion(LocateUserSuspicion(QString::fromStdString(query->value(1).toString().toStdString())));
     }
     return result;
+}
+
+int Servatrice_DatabaseInterface::LocateUserSuspicion(const QString &userName)
+{
+	return 0;
 }
 
 ServerInfo_User Servatrice_DatabaseInterface::getUserData(const QString &name, bool withId)

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -27,6 +27,7 @@ private:
     bool checkUserIsIpBanned(const QString &ipAddress, QString &banReason, int &banSecondsRemaining);
     /** Must be called after checkSql and server is known to be in auth mode. */
     bool checkUserIsNameBanned(QString const &userName, QString &banReason, int &banSecondsRemaining);
+	int LocateUserSuspicion(const QString &userName);
 
 protected:
     AuthenticationResult checkUserPassword(Server_ProtocolHandler *handler, const QString &user, const QString &password, const QString &clientId, QString &reasonStr, int &secondsLeft);


### PR DESCRIPTION
So *hopefully* this is the beginning / partial implementation of issue #170 

First things first.  What this PR currently does.  The server now calculates a user suspicion level upon login and sends the information in the user_info pb container which in turn will change the background color of the userlist row if the suspicion level ever exceed's pre-defined values.  This functionality is turned on and off by lock/unlocking the admin tools in client.

Now as for what it doesn't do that I would like to see:
- When the admin/moderator hits the lock/unlock I would like to see the user list in rooms refreshed
- Better calculations for suspicion level (just threw a few in to start with)
- Fine tune ranges for background color adjustments

What thoughts do others have?  Keep in mind this is very very very rough.  I really had intended on implementing the basic's for the functionality to work and then later fine tune the calculations part.

Attached are a couple of pics showing the background color changes.
![blob2](https://cloud.githubusercontent.com/assets/1361287/13903119/25329c7a-ee43-11e5-92e9-482375372ab9.png)
![blob1](https://cloud.githubusercontent.com/assets/1361287/13903120/27caf64e-ee43-11e5-955a-7a05b1ad4157.png)
