### PR TITLE
Updated ClientID Functionality

### DIFF
--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -364,8 +364,8 @@ void RemoteClient::disconnectFromServer()
 
 QString RemoteClient::getSrvClientID(const QString _hostname)
 {
-	QString srvClientID = settingsCache->getClientID();
-	srvClientID += _hostname;
-	QString uniqueServerClientID = QCryptographicHash::hash(srvClientID.toUtf8(), QCryptographicHash::Sha1).toHex().right(15);
-	return uniqueServerClientID;
+    QString srvClientID = settingsCache->getClientID();
+    srvClientID += _hostname;
+    QString uniqueServerClientID = QCryptographicHash::hash(srvClientID.toUtf8(), QCryptographicHash::Sha1).toHex().right(15);
+    return uniqueServerClientID;
 }

--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -81,7 +81,7 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
         cmdRegister.set_gender((ServerInfo_User_Gender) gender);
         cmdRegister.set_country(country.toStdString());
         cmdRegister.set_real_name(realName.toStdString());
-        cmdRegister.set_clientid(settingsCache->getClientID().toStdString());
+        cmdRegister.set_clientid(settingsCache->getSrvClientID(lastHostname).toStdString());
         PendingCommand *pend = prepareSessionCommand(cmdRegister);
         connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(registerResponse(Response)));
         sendCommand(pend);
@@ -111,7 +111,7 @@ void RemoteClient::doLogin() {
     Command_Login cmdLogin;
     cmdLogin.set_user_name(userName.toStdString());
     cmdLogin.set_password(password.toStdString());
-    cmdLogin.set_clientid(settingsCache->getClientID().toStdString());
+    cmdLogin.set_clientid(settingsCache->getSrvClientID(lastHostname).toStdString());
     cmdLogin.set_clientver(VERSION_STRING);
 
     if (!clientFeatures.isEmpty()) {
@@ -119,7 +119,6 @@ void RemoteClient::doLogin() {
         for (i = clientFeatures.begin(); i != clientFeatures.end(); ++i)
             cmdLogin.add_clientfeatures(i.key().toStdString().c_str());
     }
-
     PendingCommand *pend = prepareSessionCommand(cmdLogin);
     connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(loginResponse(Response)));
     sendCommand(pend);
@@ -263,7 +262,6 @@ void RemoteClient::doConnectToServer(const QString &hostname, unsigned int port,
 
     userName = _userName;
     password = _password;
-    QString clientid = settingsCache->getClientID();
     lastHostname = hostname;
     lastPort = port;
 

--- a/cockatrice/src/remoteclient.h
+++ b/cockatrice/src/remoteclient.h
@@ -51,6 +51,7 @@ private:
     QTcpSocket *socket;
     QString lastHostname;
     int lastPort;
+	QString getSrvClientID(const QString _hostname);
 protected slots:    
     void sendCommandContainer(const CommandContainer &cont);
 public:

--- a/cockatrice/src/remoteclient.h
+++ b/cockatrice/src/remoteclient.h
@@ -51,7 +51,7 @@ private:
     QTcpSocket *socket;
     QString lastHostname;
     int lastPort;
-	QString getSrvClientID(const QString _hostname);
+    QString getSrvClientID(const QString _hostname);
 protected slots:    
     void sendCommandContainer(const CommandContainer &cont);
 public:

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -2,6 +2,7 @@
 #include <QSettings>
 #include <QFile>
 #include <QApplication>
+#include <QCryptographicHash>
 
 #if QT_VERSION >= 0x050000
     #include <QStandardPaths>
@@ -612,4 +613,12 @@ void SettingsCache::setNotifyAboutUpdate(int _notifyaboutupdate)
 {
     notifyAboutUpdates = _notifyaboutupdate;
     settings->setValue("personal/updatenotification", notifyAboutUpdates);
+}
+
+QString SettingsCache::getSrvClientID(const QString _hostname)
+{
+    QString srvClientID = getClientID();
+    srvClientID += _hostname;
+    QString uniqueServerClientID = QCryptographicHash::hash(srvClientID.toUtf8(), QCryptographicHash::Sha1).toHex().right(15);
+    return uniqueServerClientID;
 }

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -2,7 +2,6 @@
 #include <QSettings>
 #include <QFile>
 #include <QApplication>
-#include <QCryptographicHash>
 
 #if QT_VERSION >= 0x050000
     #include <QStandardPaths>
@@ -613,12 +612,4 @@ void SettingsCache::setNotifyAboutUpdate(int _notifyaboutupdate)
 {
     notifyAboutUpdates = _notifyaboutupdate;
     settings->setValue("personal/updatenotification", notifyAboutUpdates);
-}
-
-QString SettingsCache::getSrvClientID(const QString _hostname)
-{
-    QString srvClientID = getClientID();
-    srvClientID += _hostname;
-    QString uniqueServerClientID = QCryptographicHash::hash(srvClientID.toUtf8(), QCryptographicHash::Sha1).toHex().right(15);
-    return uniqueServerClientID;
 }

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -176,7 +176,8 @@ public:
     bool getRememberGameSettings() const { return rememberGameSettings; }
     int getKeepAlive() const { return keepalive; }
     void setClientID(QString clientID);
-    QString getClientID() { return clientID; }    
+    QString getClientID() { return clientID; }   
+    QString getSrvClientID(const QString _hostname);
     ShortcutsSettings& shortcuts() const { return *shortcutsSettings; }
     CardDatabaseSettings& cardDatabase() const { return *cardDatabaseSettings; }
     ServersSettings& servers() const { return *serversSettings; }

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -176,8 +176,7 @@ public:
     bool getRememberGameSettings() const { return rememberGameSettings; }
     int getKeepAlive() const { return keepalive; }
     void setClientID(QString clientID);
-    QString getClientID() { return clientID; }   
-    QString getSrvClientID(const QString _hostname);
+    QString getClientID() { return clientID; }
     ShortcutsSettings& shortcuts() const { return *shortcutsSettings; }
     CardDatabaseSettings& cardDatabase() const { return *cardDatabaseSettings; }
     ServersSettings& servers() const { return *serversSettings; }


### PR DESCRIPTION
ClientID is now generated on startup and stored in settings cache.  Then upon connect there is a new SrvClientID generated from the ClientID + servername being connected to.  This will allow for unique ID's to be generated per client and per server being connected to but not the same across all servers preventing a malicious server from collecting users client id's.