### PR TITLE
Save deck editor's database view columns state

### DIFF
--- a/cockatrice/src/settings/layoutssettings.cpp
+++ b/cockatrice/src/settings/layoutssettings.cpp
@@ -58,6 +58,16 @@ void LayoutsSettings::setDeckEditorFilterSize(const QSize &value)
     setValue(value,"layouts/deckEditor_FilterSize");
 }
 
+const QByteArray LayoutsSettings::getDeckEditorDbHeaderState()
+{
+    return getValue("layouts/deckEditorDbHeader_state").toByteArray();
+}
+
+void LayoutsSettings::setDeckEditorDbHeaderState(const QByteArray &value)
+{
+    setValue(value,"layouts/deckEditorDbHeader_state");
+}
+
 void LayoutsSettings::setGamePlayAreaGeometry(const QByteArray &value)
 {
     setValue(value,"layouts/gameplayarea_geometry");

--- a/cockatrice/src/settings/layoutssettings.h
+++ b/cockatrice/src/settings/layoutssettings.h
@@ -15,6 +15,7 @@ public:
     void setDeckEditorCardSize(const QSize &value);
     void setDeckEditorDeckSize(const QSize &value);
     void setDeckEditorFilterSize(const QSize &value);
+    void setDeckEditorDbHeaderState(const QByteArray &value);
 
     void setGamePlayAreaGeometry(const QByteArray &value);
     void setGamePlayAreaState(const QByteArray &value);
@@ -34,6 +35,7 @@ public:
     const QSize getDeckEditorCardSize();
     const QSize getDeckEditorDeckSize();
     const QSize getDeckEditorFilterSize();
+    const QByteArray getDeckEditorDbHeaderState();
 
     const QByteArray getGamePlayAreaLayoutState();
     const QByteArray getGamePlayAreaGeometry();

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -335,14 +335,19 @@ void TabDeckEditor::createCentralFrame()
     databaseView->setSortingEnabled(true);
     databaseView->sortByColumn(0, Qt::AscendingOrder);
     databaseView->setModel(databaseDisplayModel);
-    databaseView->header()->setStretchLastSection(false);
-#if QT_VERSION >= 0x050000
-    databaseView->header()->setSectionResizeMode(0, QHeaderView::Stretch);
-#else
-    databaseView->header()->setResizeMode(0, QHeaderView::Stretch);
-#endif
     connect(databaseView->selectionModel(), SIGNAL(currentRowChanged(const QModelIndex &, const QModelIndex &)), this, SLOT(updateCardInfoLeft(const QModelIndex &, const QModelIndex &)));
     connect(databaseView, SIGNAL(doubleClicked(const QModelIndex &)), this, SLOT(actAddCard()));
+
+    QByteArray dbHeaderState = settingsCache->layouts().getDeckEditorDbHeaderState();
+    if(dbHeaderState.isNull())
+    {
+        // first run
+        databaseView->setColumnWidth(0, 200);
+    } else {
+        databaseView->header()->restoreState(dbHeaderState);
+    }
+    connect(databaseView->header(), SIGNAL(geometriesChanged()), this, SLOT(saveDbHeaderState()));
+
     searchEdit->setTreeView(databaseView);
 
     aAddCard = new QAction(QString(), this);
@@ -1078,4 +1083,9 @@ void TabDeckEditor::dockTopLevelChanged(bool topLevel)
         aFilterDockFloating->setChecked(topLevel);
         return;
     }
+}
+
+void TabDeckEditor::saveDbHeaderState()
+{
+    settingsCache->layouts().setDeckEditorDbHeaderState(databaseView->header()->saveState());
 }

--- a/cockatrice/src/tab_deck_editor.h
+++ b/cockatrice/src/tab_deck_editor.h
@@ -83,6 +83,7 @@ class TabDeckEditor : public Tab {
             void dockVisibleTriggered();
             void dockFloatingTriggered();
             void dockTopLevelChanged(bool topLevel);
+            void saveDbHeaderState();
 private:
     CardInfo *currentCardInfo() const;
     void addCardHelper(QString zoneName);


### PR DESCRIPTION
This PR add the save/restore of the state of the database views's columns in the deck editor.
You can resize the column, reorder them and choose which column is used for sorting the view.
These choices will be saved to ```layouts.ini``` and restored to the deck editor.

Hopefully fixes #1897