### PR TITLE
Token dialog: disable progressive loading

### DIFF
--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -236,3 +236,9 @@ bool TokenDisplayModel::filterAcceptsRow(int sourceRow, const QModelIndex & /*so
     
     return info->getIsToken();
 }
+
+int TokenDisplayModel::rowCount(const QModelIndex &parent) const
+{
+    // always load all tokens at start
+    return QSortFilterProxyModel::rowCount(parent);
+}

--- a/cockatrice/src/carddatabasemodel.h
+++ b/cockatrice/src/carddatabasemodel.h
@@ -72,6 +72,7 @@ class TokenDisplayModel : public CardDatabaseDisplayModel {
     Q_OBJECT
 public:
     TokenDisplayModel(QObject *parent = 0);
+    int rowCount(const QModelIndex &parent = QModelIndex()) const;
 protected:
     bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
 };

--- a/cockatrice/src/dlg_create_token.cpp
+++ b/cockatrice/src/dlg_create_token.cpp
@@ -62,9 +62,8 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
     tokenDataGroupBox->setLayout(grid);
     
     cardDatabaseModel = new CardDatabaseModel(db, this);
-    cardDatabaseDisplayModel = new CardDatabaseDisplayModel(this);
+    cardDatabaseDisplayModel = new TokenDisplayModel(this);
     cardDatabaseDisplayModel->setSourceModel(cardDatabaseModel);
-    cardDatabaseDisplayModel->setIsToken(CardDatabaseDisplayModel::ShowTrue);
     
     chooseTokenFromAllRadioButton = new QRadioButton(tr("Show &all tokens"));
     connect(chooseTokenFromAllRadioButton, SIGNAL(toggled(bool)), this, SLOT(actChooseTokenFromAll(bool)));

--- a/cockatrice/src/dlg_create_token.h
+++ b/cockatrice/src/dlg_create_token.h
@@ -12,7 +12,7 @@ class QPushButton;
 class QRadioButton;
 class DeckList;
 class CardDatabaseModel;
-class CardDatabaseDisplayModel;
+class TokenDisplayModel;
 
 class DlgCreateToken : public QDialog {
     Q_OBJECT
@@ -30,7 +30,7 @@ private slots:
     void actOk();
 private:
     CardDatabaseModel *cardDatabaseModel;
-    CardDatabaseDisplayModel *cardDatabaseDisplayModel;
+    TokenDisplayModel *cardDatabaseDisplayModel;
     QStringList predefinedTokens;
     QLabel *nameLabel, *colorLabel, *ptLabel, *annotationLabel;
     QComboBox *colorEdit;


### PR DESCRIPTION
The tokens dialog inherited the progressive card loading patch from the deck editor.
Here it causes a major annoyance of not being able to quickly lookup an existing token by its name.

fix #1903