### PR TITLE
Implemented !setnumber!

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -172,7 +172,8 @@ CardInfo::CardInfo(const QString &_name,
                    int _tableRow,
                    const SetList &_sets,
                    const QStringMap &_customPicURLs,
-                   MuidMap _muIds
+                   MuidMap _muIds,
+                   QStringMap _setNumbers
                    )
     : name(_name),
       isToken(_isToken),
@@ -190,6 +191,7 @@ CardInfo::CardInfo(const QString &_name,
       loyalty(_loyalty),
       customPicURLs(_customPicURLs),
       muIds(_muIds),
+      setNumbers(_setNumbers),
       cipt(_cipt),
       tableRow(_tableRow)
 {
@@ -315,6 +317,10 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfo *info)
 
         tmpSet=sets[i]->getShortName();
         xml.writeAttribute("muId", QString::number(info->getMuId(tmpSet)));
+
+        tmpString = info->getSetNumber(tmpSet);
+        if(!tmpString.isEmpty())
+            xml.writeAttribute("num", info->getSetNumber(tmpSet));
 
         tmpString = info->getCustomPicURL(tmpSet);
         if(!tmpString.isEmpty())
@@ -487,6 +493,7 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml)
             QStringList colors, relatedCards, reverseRelatedCards;
             QStringMap customPicURLs;
             MuidMap muids;
+            QStringMap setNumbers;
             SetList sets;
             int tableRow = 0;
             int loyalty = 0;
@@ -518,6 +525,9 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml)
                     if (attrs.hasAttribute("picURL")) {
                         customPicURLs[setName] = attrs.value("picURL").toString();
                     }
+                    if (attrs.hasAttribute("num")) {
+                        setNumbers[setName] = attrs.value("num").toString();
+                    }
                 } else if (xml.name() == "color")
                     colors << xml.readElementText();
                 else if (xml.name() == "related")
@@ -540,7 +550,7 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml)
                 }
             }
 
-            addCard(new CardInfo(name, isToken, manacost, cmc, type, pt, text, colors, relatedCards, reverseRelatedCards, upsideDown, loyalty, cipt, tableRow, sets, customPicURLs, muids));
+            addCard(new CardInfo(name, isToken, manacost, cmc, type, pt, text, colors, relatedCards, reverseRelatedCards, upsideDown, loyalty, cipt, tableRow, sets, customPicURLs, muids, setNumbers));
         }
     }
 }

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -87,6 +87,7 @@ private:
     int loyalty;
     QStringMap customPicURLs;
     MuidMap muIds;
+    QStringMap setNumbers;
     bool cipt;
     int tableRow;
     QString pixmapCacheKey;
@@ -107,7 +108,8 @@ public:
         int _tableRow = 0,
         const SetList &_sets = SetList(),
         const QStringMap &_customPicURLs = QStringMap(),
-        MuidMap muids = MuidMap()
+        MuidMap muids = MuidMap(),
+        QStringMap _setNumbers = QStringMap()
         );
     ~CardInfo();
     inline const QString &getName() const { return name; }
@@ -139,6 +141,7 @@ public:
     bool getUpsideDownArt() const { return upsideDownArt; }
     QString getCustomPicURL(const QString &set) const { return customPicURLs.value(set); }
     int getMuId(const QString &set) const { return muIds.value(set); }
+    QString getSetNumber(const QString &set) const { return setNumbers.value(set); }
     QString getMainCardType() const;
     QString getCorrectedName() const;
     int getTableRow() const { return tableRow; }
@@ -146,6 +149,7 @@ public:
     void setLoyalty(int _loyalty) { loyalty = _loyalty; emit cardInfoChanged(this); }
     void setCustomPicURL(const QString &_set, const QString &_customPicURL) { customPicURLs.insert(_set, _customPicURL); }
     void setMuId(const QString &_set, const int &_muId) { muIds.insert(_set, _muId); }
+    void setSetNumber(const QString &_set, const QString &_setNumber) { setNumbers.insert(_set, _setNumber); }
     void addToSet(CardSet *set);
     void emitPixmapUpdated() { emit pixmapUpdated(); }
     void refreshCachedSetNames();

--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -220,6 +220,7 @@ QString PictureLoaderWorker::getPicUrl()
     picUrl.replace("!cardid!", QUrl::toPercentEncoding(QString::number(muid)));
     if (set)
     {
+        picUrl.replace("!setnumber!", QUrl::toPercentEncoding(card->getSetNumber(set->getShortName())));
         picUrl.replace("!setcode!", QUrl::toPercentEncoding(set->getShortName()));
         picUrl.replace("!setcode_lower!", QUrl::toPercentEncoding(set->getShortName().toLower()));
         picUrl.replace("!setname!", QUrl::toPercentEncoding(set->getLongName()));
@@ -229,6 +230,7 @@ QString PictureLoaderWorker::getPicUrl()
     if (
         picUrl.contains("!name!") ||
         picUrl.contains("!name_lower!") ||
+        picUrl.contains("!setnumber!") ||
         picUrl.contains("!setcode!") ||
         picUrl.contains("!setcode_lower!") ||
         picUrl.contains("!setname!") ||

--- a/doc/cards.xsd
+++ b/doc/cards.xsd
@@ -29,6 +29,7 @@
                           <xs:extension base="xs:string">
                             <xs:attribute type="xs:int" name="muId" use="optional"/>
                             <xs:attribute type="xs:anyURI" name="picUrl" use="optional"/>
+                            <xs:attribute type="xs:string" name="num" use="optional"/>
                           </xs:extension>
                         </xs:simpleContent>
                       </xs:complexType>

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -59,6 +59,7 @@ CardInfo *OracleImporter::addCard(const QString &setName,
                                   QString cardName,
                                   bool isToken,
                                   int cardId,
+                                  QString &setNumber,
                                   QString &cardCost,
                                   QString &cmc,
                                   const QString &cardType,
@@ -110,6 +111,7 @@ CardInfo *OracleImporter::addCard(const QString &setName,
         cards.insert(cardName, card);
     }
     card->setMuId(setName, cardId);
+    card->setSetNumber(setName, setNumber);
 
     return card;
 }
@@ -149,6 +151,7 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
     QStringList relatedCards;
     QStringList reverseRelatedCards; // dummy
     int cardId;
+    QString setNumber;
     int cardLoyalty;
     bool upsideDown = false;
     QMap<int, QVariantMap> splitCards;
@@ -179,6 +182,7 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
         cardPT = map.contains("power") || map.contains("toughness") ? map.value("power").toString() + QString('/') + map.value("toughness").toString() : QString("");
         cardText = map.contains("text") ? map.value("text").toString() : QString("");
         cardId = map.contains("multiverseid") ? map.value("multiverseid").toInt() : 0;
+        setNumber = map.contains("number") ? map.value("number").toString() : QString("");
         cardLoyalty = map.contains("loyalty") ? map.value("loyalty").toInt() : 0;
         relatedCards = map.contains("names") ? map.value("names").toStringList() : QStringList();
         relatedCards.removeAll(cardName);
@@ -194,7 +198,7 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
         colors.clear();
         extractColors(map.value("colors").toStringList(), colors);
 
-        CardInfo *card = addCard(set->getShortName(), cardName, false, cardId, cardCost, cmc, cardType, cardPT, cardLoyalty, cardText, colors, relatedCards, reverseRelatedCards, upsideDown);
+        CardInfo *card = addCard(set->getShortName(), cardName, false, cardId, setNumber, cardCost, cmc, cardType, cardPT, cardLoyalty, cardText, colors, relatedCards, reverseRelatedCards, upsideDown);
 
         if (!set->contains(card)) {
             card->addToSet(set);
@@ -227,6 +231,7 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
         cardType = "";
         cardPT = "";
         cardText = "";
+        setNumber = ""; 
         colors.clear();
         // this is currently an integer; can't accept 2 values
         cardLoyalty = 0;
@@ -272,6 +277,11 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
                     cardText += prefix2;
                 cardText += map.value("text").toString();
             }
+            if(map.contains("number"))
+            {
+                if(setNumber.isEmpty())
+                    setNumber = map.value("number").toString();
+            }
 
             extractColors(map.value("colors").toStringList(), colors);
         }
@@ -282,7 +292,7 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
         upsideDown = false;
 
         // add the card
-        CardInfo *card = addCard(set->getShortName(), cardName, false, muid, cardCost, cmc, cardType, cardPT, cardLoyalty, cardText, colors, relatedCards, reverseRelatedCards, upsideDown);
+        CardInfo *card = addCard(set->getShortName(), cardName, false, muid, setNumber, cardCost, cmc, cardType, cardPT, cardLoyalty, cardText, colors, relatedCards, reverseRelatedCards, upsideDown);
 
         if (!set->contains(card)) {
             card->addToSet(set);

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -30,7 +30,23 @@ private:
     QVariantMap setsMap;
     QString dataDir;
     
-    CardInfo *addCard(const QString &setName, QString cardName, bool isToken, int cardId, QString &cardCost, QString &cmc, const QString &cardType, const QString &cardPT, int cardLoyalty, const QString &cardText, const QStringList & colors, const QStringList & relatedCards, const QStringList & reverseRelatedCards, bool upsideDown);
+    CardInfo *addCard(
+        const QString &setName,
+        QString cardName,
+        bool isToken,
+        int cardId,
+        QString &setNumber,
+        QString &cardCost,
+        QString &cmc,
+        const QString &cardType,
+        const QString &cardPT,
+        int cardLoyalty,
+        const QString &cardText,
+        const QStringList & colors,
+        const QStringList & relatedCards,
+        const QStringList & reverseRelatedCards,
+        bool upsideDown
+    );
 signals:
     void setIndexChanged(int cardsImported, int setIndex, const QString &setName);
     void dataReadProgress(int bytesRead, int totalBytes);


### PR DESCRIPTION
With this PR, the new !setnumber! code can be used in picture urls.

Tested using ```http://magiccards.info/scans/en/!setcode_lower!/!setnumber!.jpg```

fix #1741