### PR TITLE
docker - tweaks and link to wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,19 +95,21 @@ The following flags can be passed to `cmake`:
 
 #### Servatrice Docker container
 
-A Dockerfile is provided to run Servatrice (the Cockatrice server) using [Docker](https://www.docker.com/what-docker).
-You just need to create an image from the Dockerfile
-`docker build -t servatrice .`
-And then run it
-`docker run -i -p 4747:4747/tcp -t servatrice:latest`
-Please note that running this command will expose the TCP port 4747 of the docker container to permit connections to the server.
-<br>
+A Dockerfile is provided to run Servatrice (the Cockatrice server) using [Docker](https://www.docker.com/what-docker).<br>
+
+You just need to create an image from the Dockerfile<br>
+`docker build -t servatrice .`<br>
+And then run it<br>
+`docker run -i -p 4747:4747/tcp -t servatrice:latest`<br>
+
+Please note that running this command will expose the TCP port 4747 of the docker container to permit connections to the server.<br>
+More infos on how to use Servatrice with Docker can be found in our [wiki](https://github.com/Cockatrice/Cockatrice/wiki/Setting-up-Servatrice#using-docker).
 
 
 # Running
 
-`oracle` fetches card data  
-`cockatrice` is the game client  
+`cockatrice` is the game client    
+`oracle` fetches card data    
 `servatrice` is the server<br>
 
 


### PR DESCRIPTION
added paragraphs and linebreaks for better readability
link to wiki on how to use docker

![docker](https://cloud.githubusercontent.com/assets/9874850/14436507/505710ca-001d-11e6-8f50-15b82e3c2513.png)


(also reordered the running part, call it alphabetically or most important part on top... both apply :P )