### PR TITLE
Create token dialog uses name as search

### DIFF
--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -237,8 +237,7 @@ TokenDisplayModel::TokenDisplayModel(QObject *parent)
 bool TokenDisplayModel::filterAcceptsRow(int sourceRow, const QModelIndex & /*sourceParent*/) const
 {
     CardInfo const *info = static_cast<CardDatabaseModel *>(sourceModel())->getCard(sourceRow);
-    
-    return info->getIsToken();
+    return info->getIsToken() && rowMatchesCardName(info);
 }
 
 int TokenDisplayModel::rowCount(const QModelIndex &parent) const

--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -186,6 +186,10 @@ bool CardDatabaseDisplayModel::filterAcceptsRow(int sourceRow, const QModelIndex
     if (((isToken == ShowTrue) && !info->getIsToken()) || ((isToken == ShowFalse) && info->getIsToken()))
         return false;
 
+    return rowMatchesCardName(info);
+}
+
+bool CardDatabaseDisplayModel::rowMatchesCardName(CardInfo const *info) const {
     if (!cardName.isEmpty() && !info->getName().contains(cardName, Qt::CaseInsensitive))
         return false;
 

--- a/cockatrice/src/carddatabasemodel.h
+++ b/cockatrice/src/carddatabasemodel.h
@@ -61,7 +61,7 @@ public:
 protected:
     bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
     bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
-
+    bool rowMatchesCardName(CardInfo const *info) const;
     bool canFetchMore(const QModelIndex &parent) const;
     void fetchMore(const QModelIndex &parent);
 private slots:

--- a/cockatrice/src/dlg_create_token.cpp
+++ b/cockatrice/src/dlg_create_token.cpp
@@ -23,6 +23,7 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
     nameLabel = new QLabel(tr("&Name:"));
     nameEdit = new QLineEdit(tr("Token"));
     nameEdit->selectAll();
+    connect(nameEdit, SIGNAL(textChanged(const QString &)), this, SLOT(updateSearch(const QString &)));
     nameLabel->setBuddy(nameEdit);
 
     colorLabel = new QLabel(tr("C&olor:"));
@@ -135,7 +136,7 @@ void DlgCreateToken::tokenSelectionChanged(const QModelIndex &current, const QMo
     
     if(cardInfo)
     {
-        nameEdit->setText(cardInfo->getName());
+        updateSearchFieldWithoutUpdatingFilter(cardInfo->getName());
         const QChar cardColor = cardInfo->getColorChar();
         colorEdit->setCurrentIndex(colorEdit->findData(cardColor, Qt::UserRole, Qt::MatchFixedString));
         ptEdit->setText(cardInfo->getPowTough());
@@ -147,6 +148,17 @@ void DlgCreateToken::tokenSelectionChanged(const QModelIndex &current, const QMo
         ptEdit->setText("");
         annotationEdit->setText("");
     }
+}
+
+void DlgCreateToken::updateSearchFieldWithoutUpdatingFilter(const QString &newValue) const {
+    nameEdit->blockSignals(true);
+    nameEdit->setText(newValue);
+    nameEdit->blockSignals(false);
+}
+
+void DlgCreateToken::updateSearch(const QString &search)
+{
+    cardDatabaseDisplayModel->setCardName(search);
 }
 
 void DlgCreateToken::actChooseTokenFromAll(bool checked)

--- a/cockatrice/src/dlg_create_token.h
+++ b/cockatrice/src/dlg_create_token.h
@@ -25,6 +25,7 @@ public:
     bool getDestroy() const;
 private slots:
     void tokenSelectionChanged(const QModelIndex &current, const QModelIndex &previous);
+    void updateSearch(const QString &search);
     void actChooseTokenFromAll(bool checked);
     void actChooseTokenFromDeck(bool checked);
     void actOk();
@@ -37,6 +38,8 @@ private:
     QLineEdit *nameEdit, *ptEdit, *annotationEdit;
     QCheckBox *destroyCheckBox;
     QRadioButton *chooseTokenFromAllRadioButton, *chooseTokenFromDeckRadioButton;
+
+    void updateSearchFieldWithoutUpdatingFilter(const QString &newValue) const;
 };
 
 #endif


### PR DESCRIPTION
This pull request reuses the search functionality from the deck editor inside of the "Create token" dialog.

Here's a quick gif demo:

![](http://g.recordit.co/GHKrtMjcoR.gif)

I'm pretty unfamiliar with C++ and Qt, so please be critical of anything I should change.