### PR TITLE
Update mention-bot config to remove comments

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,6 +1,5 @@
 {
   "message": "@pullRequester, thanks for contributing! @reviewers are the best people to review the changes.",
-             // custom message using @pullRequester and @reviewers
-  "fileBlacklist": ["*.md"], // mention-bot will ignore any files that match these file globs
-  "userBlacklist": ["mbruker"], // users in this list will never be mentioned by mention-bot
+  "fileBlacklist": ["*.md"],
+  "userBlacklist": ["mbruker"],
 }


### PR DESCRIPTION
It doesn't seem to be respecting the `userBlacklist` field, judging by https://github.com/Cockatrice/Cockatrice/pull/1981#issuecomment-218639352

Ref https://github.com/facebook/mention-bot/issues/117