### PR TITLE
Add rarity filter to Deck Editor

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -162,6 +162,7 @@ CardInfo::CardInfo(const QString &_name,
                    const QString &_cmc,
                    const QString &_cardtype,
                    const QString &_powtough,
+                   const QString &_rarity,
                    const QString &_text,
                    const QStringList &_colors,
                    const QStringList &_relatedCards,
@@ -182,6 +183,7 @@ CardInfo::CardInfo(const QString &_name,
       cmc(_cmc),
       cardtype(_cardtype),
       powtough(_powtough),
+      rarity(_rarity),
       text(_text),
       colors(_colors),
       relatedCards(_relatedCards),
@@ -308,6 +310,7 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfo *info)
 {
     xml.writeStartElement("card");
     xml.writeTextElement("name", info->getName());
+    xml.writeTextElement("rarity", info->getRarity());
 
     const SetList &sets = info->getSets();
     QString tmpString;
@@ -489,7 +492,7 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml)
         if (xml.readNext() == QXmlStreamReader::EndElement)
             break;
         if (xml.name() == "card") {
-            QString name, manacost, cmc, type, pt, text;
+            QString name, manacost, cmc, type, pt, rarity, text;
             QStringList colors, relatedCards, reverseRelatedCards;
             QStringMap customPicURLs;
             MuidMap muids;
@@ -513,6 +516,8 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml)
                     type = xml.readElementText();
                 else if (xml.name() == "pt")
                     pt = xml.readElementText();
+                else if (xml.name() == "rarity")
+                    rarity = xml.readElementText();
                 else if (xml.name() == "text")
                     text = xml.readElementText();
                 else if (xml.name() == "set") {
@@ -550,7 +555,7 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml)
                 }
             }
 
-            addCard(new CardInfo(name, isToken, manacost, cmc, type, pt, text, colors, relatedCards, reverseRelatedCards, upsideDown, loyalty, cipt, tableRow, sets, customPicURLs, muids, setNumbers));
+            addCard(new CardInfo(name, isToken, manacost, cmc, type, pt, rarity, text, colors, relatedCards, reverseRelatedCards, upsideDown, loyalty, cipt, tableRow, sets, customPicURLs, muids, setNumbers));
         }
     }
 }

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -74,6 +74,7 @@ private:
     QString cmc;
     QString cardtype;
     QString powtough;
+    QString rarity;
     QString text;
     QStringList colors;
     // the cards i'm related to
@@ -98,6 +99,7 @@ public:
         const QString &_cmc = QString(),
         const QString &_cardtype = QString(),
         const QString &_powtough = QString(),
+        const QString &_rarity = QString(),
         const QString &_text = QString(),
         const QStringList &_colors = QStringList(),
         const QStringList &_relatedCards = QStringList(),
@@ -121,6 +123,7 @@ public:
     inline const QString &getCmc() const { return cmc; }
     inline const QString &getCardType() const { return cardtype; }
     inline const QString &getPowTough() const { return powtough; }
+    inline const QString &getRarity() const { return rarity; }
     const QString &getText() const { return text; }
     const QString &getPixmapCacheKey() const { return pixmapCacheKey; }
     const int &getLoyalty() const { return loyalty; }
@@ -129,6 +132,7 @@ public:
     void setCmc(const QString &_cmc) { cmc = _cmc; emit cardInfoChanged(this); }
     void setCardType(const QString &_cardType) { cardtype = _cardType; emit cardInfoChanged(this); }
     void setPowTough(const QString &_powTough) { powtough = _powTough; emit cardInfoChanged(this); }
+    void setRarity(const QString &_rarity) { rarity = _rarity; emit cardInfoChanged(this); }
     void setText(const QString &_text) { text = _text; emit cardInfoChanged(this); }
     void setColors(const QStringList &_colors) { colors = _colors; emit cardInfoChanged(this); }
     const QChar getColorChar() const;

--- a/cockatrice/src/cardfilter.cpp
+++ b/cockatrice/src/cardfilter.cpp
@@ -33,6 +33,8 @@ const char *CardFilter::attrName(Attr a)
             return "mana cost";
         case AttrCmc:
             return "cmc";
+        case AttrRarity:
+            return "rarity";
         default:
             return "";
     }

--- a/cockatrice/src/cardfilter.h
+++ b/cockatrice/src/cardfilter.h
@@ -23,6 +23,7 @@ public:
         AttrSet,
         AttrManaCost,
         AttrCmc,
+        AttrRarity,
         AttrEnd
     };
 

--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -224,6 +224,14 @@ bool FilterItem::acceptCmc(const CardInfo *info) const
     return (info->getCmc() == term);
 }
 
+bool FilterItem::acceptRarity(const CardInfo *info) const
+{
+    if (info->getRarity().compare(term, Qt::CaseInsensitive) == 0)
+        return true;
+    
+    return false;
+}
+
 bool FilterItem::acceptCardAttr(const CardInfo *info, CardFilter::Attr attr) const
 {
     switch (attr) {
@@ -241,6 +249,8 @@ bool FilterItem::acceptCardAttr(const CardInfo *info, CardFilter::Attr attr) con
             return acceptManaCost(info);
         case CardFilter::AttrCmc:
             return acceptCmc(info);
+        case CardFilter::AttrRarity:
+            return acceptRarity(info);
         default:
             return true; /* ignore this attribute */
     }

--- a/cockatrice/src/filtertree.h
+++ b/cockatrice/src/filtertree.h
@@ -118,6 +118,7 @@ public:
     bool acceptSet(const CardInfo *info) const;
     bool acceptManaCost(const CardInfo *info) const;
     bool acceptCmc(const CardInfo *info) const;
+    bool acceptRarity(const CardInfo *info) const;
     bool acceptCardAttr(const CardInfo *info, CardFilter::Attr attr) const;
 };
 

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -61,6 +61,7 @@ CardInfo *OracleImporter::addCard(const QString &setName,
                                   QString &cmc,
                                   const QString &cardType,
                                   const QString &cardPT,
+                                  const QString &rarity,
                                   int cardLoyalty,
                                   const QString &cardText,
                                   const QStringList & colors,
@@ -94,7 +95,7 @@ CardInfo *OracleImporter::addCard(const QString &setName,
         bool cipt = cardText.contains("Hideaway") || (cardText.contains(cardName + " enters the battlefield tapped") && !cardText.contains(cardName + " enters the battlefield tapped unless"));
         
         // insert the card and its properties
-        card = new CardInfo(cardName, isToken, cardCost, cmc, cardType, cardPT, cardText, colors, relatedCards, reverseRelatedCards, upsideDown, cardLoyalty, cipt);
+        card = new CardInfo(cardName, isToken, cardCost, cmc, cardType, cardPT, rarity, cardText, colors, relatedCards, reverseRelatedCards, upsideDown, cardLoyalty, cipt);
         int tableRow = 1;
         QString mainCardType = card->getMainCardType();
         if ((mainCardType == "Land") || mArtifact)
@@ -143,6 +144,7 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
     QString cmc;
     QString cardType;
     QString cardPT;
+    QString rarity;
     QString cardText;
     QStringList colors;
     QStringList relatedCards;
@@ -177,6 +179,7 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
         cmc = map.contains("cmc") ? map.value("cmc").toString() : QString("0");
         cardType = map.contains("type") ? map.value("type").toString() : QString("");
         cardPT = map.contains("power") || map.contains("toughness") ? map.value("power").toString() + QString('/') + map.value("toughness").toString() : QString("");
+        rarity = map.contains("rarity") ? map.value("rarity").toString() : QString("");
         cardText = map.contains("text") ? map.value("text").toString() : QString("");
         cardId = map.contains("multiverseid") ? map.value("multiverseid").toInt() : 0;
         setNumber = map.contains("number") ? map.value("number").toString() : QString("");
@@ -195,7 +198,7 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
         colors.clear();
         extractColors(map.value("colors").toStringList(), colors);
 
-        CardInfo *card = addCard(set->getShortName(), cardName, false, cardId, setNumber, cardCost, cmc, cardType, cardPT, cardLoyalty, cardText, colors, relatedCards, reverseRelatedCards, upsideDown);
+        CardInfo *card = addCard(set->getShortName(), cardName, false, cardId, setNumber, cardCost, cmc, cardType, cardPT, rarity, cardLoyalty, cardText, colors, relatedCards, reverseRelatedCards, upsideDown);
 
         if (!set->contains(card)) {
             card->addToSet(set);
@@ -227,6 +230,7 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
         cmc = "";
         cardType = "";
         cardPT = "";
+        rarity = "";
         cardText = "";
         setNumber = ""; 
         colors.clear();
@@ -236,47 +240,47 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
         // loop cards and merge their contents
         QString prefix = QString(" // ");
         QString prefix2 = QString("\n\n---\n\n");
-        foreach(QVariantMap map, orderedMaps.values())
+        foreach (QVariantMap map, orderedMaps.values())
         {
-            if(map.contains("name"))
+            if (map.contains("name"))
             {
-                if(!cardName.isEmpty())
+                if (!cardName.isEmpty())
                     cardName += prefix;
                 cardName += map.value("name").toString();
             }
-            if(map.contains("manaCost"))
+            if (map.contains("manaCost"))
             {
-                if(!cardCost.isEmpty())
+                if (!cardCost.isEmpty())
                     cardCost += prefix;
                 cardCost += map.value("manaCost").toString();
             }
-            if(map.contains("cmc"))
+            if (map.contains("cmc"))
             {
-                if(!cmc.isEmpty())
+                if (!cmc.isEmpty())
                     cmc += prefix;
                 cmc += map.value("cmc").toString();
             }
-            if(map.contains("type"))
+            if (map.contains("type"))
             {
-                if(!cardType.isEmpty())
+                if (!cardType.isEmpty())
                     cardType += prefix;
                 cardType += map.value("type").toString();
             }
-            if(map.contains("power") || map.contains("toughness"))
+            if (map.contains("power") || map.contains("toughness"))
             {
-                if(!cardPT.isEmpty())
+                if (!cardPT.isEmpty())
                     cardPT += prefix;
                 cardPT += map.value("power").toString() + QString('/') + map.value("toughness").toString();
             }
-            if(map.contains("text"))
+            if (map.contains("text"))
             {
                 if(!cardText.isEmpty())
                     cardText += prefix2;
                 cardText += map.value("text").toString();
             }
-            if(map.contains("number"))
+            if (map.contains("number"))
             {
-                if(setNumber.isEmpty())
+                if (setNumber.isEmpty())
                     setNumber = map.value("number").toString();
             }
 
@@ -289,7 +293,7 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
         upsideDown = false;
 
         // add the card
-        CardInfo *card = addCard(set->getShortName(), cardName, false, muid, setNumber, cardCost, cmc, cardType, cardPT, cardLoyalty, cardText, colors, relatedCards, reverseRelatedCards, upsideDown);
+        CardInfo *card = addCard(set->getShortName(), cardName, false, muid, setNumber, cardCost, cmc, cardType, cardPT, rarity, cardLoyalty, cardText, colors, relatedCards, reverseRelatedCards, upsideDown);
 
         if (!set->contains(card)) {
             card->addToSet(set);

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -40,6 +40,7 @@ private:
         QString &cmc,
         const QString &cardType,
         const QString &cardPT,
+        const QString &rarity,
         int cardLoyalty,
         const QString &cardText,
         const QStringList & colors,


### PR DESCRIPTION
Fix #492

This change implements a rarity filter into the deck editor. It also has an updated oracle to incorporate the rarity within the cards.xml generated file. You can search for the following rarities, as defined by MTGJSON:

- Common
- Uncommon
- Rare
- Mythic Rare
- Special

