### PR TITLE
Add rarity filter to deck editor

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -173,7 +173,8 @@ CardInfo::CardInfo(const QString &_name,
                    const SetList &_sets,
                    const QStringMap &_customPicURLs,
                    MuidMap _muIds,
-                   QStringMap _setNumbers
+                   QStringMap _setNumbers,
+                   QStringMap _rarities
                    )
     : name(_name),
       isToken(_isToken),
@@ -192,6 +193,7 @@ CardInfo::CardInfo(const QString &_name,
       customPicURLs(_customPicURLs),
       muIds(_muIds),
       setNumbers(_setNumbers),
+      rarities(_rarities),
       cipt(_cipt),
       tableRow(_tableRow)
 {
@@ -316,6 +318,7 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfo *info)
         xml.writeStartElement("set");
 
         tmpSet=sets[i]->getShortName();
+        xml.writeAttribute("rarity", info->getRarity(tmpSet));
         xml.writeAttribute("muId", QString::number(info->getMuId(tmpSet)));
 
         tmpString = info->getSetNumber(tmpSet);
@@ -493,7 +496,7 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml)
             QStringList colors, relatedCards, reverseRelatedCards;
             QStringMap customPicURLs;
             MuidMap muids;
-            QStringMap setNumbers;
+            QStringMap setNumbers, rarities;
             SetList sets;
             int tableRow = 0;
             int loyalty = 0;
@@ -528,6 +531,9 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml)
                     if (attrs.hasAttribute("num")) {
                         setNumbers[setName] = attrs.value("num").toString();
                     }
+                    if (attrs.hasAttribute("rarity")) {
+                        rarities[setName] = attrs.value("rarity").toString();
+                    }
                 } else if (xml.name() == "color")
                     colors << xml.readElementText();
                 else if (xml.name() == "related")
@@ -550,7 +556,7 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml)
                 }
             }
 
-            addCard(new CardInfo(name, isToken, manacost, cmc, type, pt, text, colors, relatedCards, reverseRelatedCards, upsideDown, loyalty, cipt, tableRow, sets, customPicURLs, muids, setNumbers));
+            addCard(new CardInfo(name, isToken, manacost, cmc, type, pt, text, colors, relatedCards, reverseRelatedCards, upsideDown, loyalty, cipt, tableRow, sets, customPicURLs, muids, setNumbers, rarities));
         }
     }
 }

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -88,6 +88,7 @@ private:
     QStringMap customPicURLs;
     MuidMap muIds;
     QStringMap setNumbers;
+    QStringMap rarities;
     bool cipt;
     int tableRow;
     QString pixmapCacheKey;
@@ -109,7 +110,8 @@ public:
         const SetList &_sets = SetList(),
         const QStringMap &_customPicURLs = QStringMap(),
         MuidMap muids = MuidMap(),
-        QStringMap _setNumbers = QStringMap()
+        QStringMap _setNumbers = QStringMap(),
+        QStringMap _rarities = QStringMap()
         );
     ~CardInfo();
     inline const QString &getName() const { return name; }
@@ -142,6 +144,8 @@ public:
     QString getCustomPicURL(const QString &set) const { return customPicURLs.value(set); }
     int getMuId(const QString &set) const { return muIds.value(set); }
     QString getSetNumber(const QString &set) const { return setNumbers.value(set); }
+    QString getRarity(const QString &set) const { return rarities.value(set); }
+    QStringMap getRarities() const { return rarities; }
     QString getMainCardType() const;
     QString getCorrectedName() const;
     int getTableRow() const { return tableRow; }
@@ -150,6 +154,7 @@ public:
     void setCustomPicURL(const QString &_set, const QString &_customPicURL) { customPicURLs.insert(_set, _customPicURL); }
     void setMuId(const QString &_set, const int &_muId) { muIds.insert(_set, _muId); }
     void setSetNumber(const QString &_set, const QString &_setNumber) { setNumbers.insert(_set, _setNumber); }
+    void setRarity(const QString &_set, const QString &_setNumber) { rarities.insert(_set, _setNumber); }
     void addToSet(CardSet *set);
     void emitPixmapUpdated() { emit pixmapUpdated(); }
     void refreshCachedSetNames();

--- a/cockatrice/src/cardfilter.cpp
+++ b/cockatrice/src/cardfilter.cpp
@@ -33,6 +33,8 @@ const char *CardFilter::attrName(Attr a)
             return "mana cost";
         case AttrCmc:
             return "cmc";
+        case AttrRarity:
+            return "rarity";
         default:
             return "";
     }

--- a/cockatrice/src/cardfilter.h
+++ b/cockatrice/src/cardfilter.h
@@ -23,6 +23,7 @@ public:
         AttrSet,
         AttrManaCost,
         AttrCmc,
+        AttrRarity,
         AttrEnd
     };
 

--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -224,6 +224,17 @@ bool FilterItem::acceptCmc(const CardInfo *info) const
     return (info->getCmc() == term);
 }
 
+bool FilterItem::acceptRarity(const CardInfo *info) const
+{
+    foreach (QString rareLevel, info->getRarities())
+    {
+        if (rareLevel.compare(term, Qt::CaseInsensitive) == 0)
+            return true;
+    }
+
+    return false;
+}
+
 bool FilterItem::acceptCardAttr(const CardInfo *info, CardFilter::Attr attr) const
 {
     switch (attr) {
@@ -241,6 +252,8 @@ bool FilterItem::acceptCardAttr(const CardInfo *info, CardFilter::Attr attr) con
             return acceptManaCost(info);
         case CardFilter::AttrCmc:
             return acceptCmc(info);
+        case CardFilter::AttrRarity:
+            return acceptRarity(info);
         default:
             return true; /* ignore this attribute */
     }

--- a/cockatrice/src/filtertree.h
+++ b/cockatrice/src/filtertree.h
@@ -118,6 +118,7 @@ public:
     bool acceptSet(const CardInfo *info) const;
     bool acceptManaCost(const CardInfo *info) const;
     bool acceptCmc(const CardInfo *info) const;
+    bool acceptRarity(const CardInfo *info) const;
     bool acceptCardAttr(const CardInfo *info, CardFilter::Attr attr) const;
 };
 

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -66,7 +66,8 @@ CardInfo *OracleImporter::addCard(const QString &setName,
                                   const QStringList & colors,
                                   const QStringList & relatedCards,
                                   const QStringList & reverseRelatedCards,
-                                  bool upsideDown
+                                  bool upsideDown,
+                                  QString &rarity
                                   )
 {
     QStringList cardTextRows = cardText.split("\n");
@@ -109,6 +110,7 @@ CardInfo *OracleImporter::addCard(const QString &setName,
     }
     card->setMuId(setName, cardId);
     card->setSetNumber(setName, setNumber);
+    card->setRarity(setName, rarity);
 
     return card;
 }
@@ -149,6 +151,7 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
     QStringList reverseRelatedCards; // dummy
     int cardId;
     QString setNumber;
+    QString rarity;
     int cardLoyalty;
     bool upsideDown = false;
     QMap<int, QVariantMap> splitCards;
@@ -180,6 +183,7 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
         cardText = map.contains("text") ? map.value("text").toString() : QString("");
         cardId = map.contains("multiverseid") ? map.value("multiverseid").toInt() : 0;
         setNumber = map.contains("number") ? map.value("number").toString() : QString("");
+        rarity = map.contains("rarity") ? map.value("rarity").toString() : QString("");
         cardLoyalty = map.contains("loyalty") ? map.value("loyalty").toInt() : 0;
         relatedCards = map.contains("names") ? map.value("names").toStringList() : QStringList();
         relatedCards.removeAll(cardName);
@@ -195,7 +199,7 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
         colors.clear();
         extractColors(map.value("colors").toStringList(), colors);
 
-        CardInfo *card = addCard(set->getShortName(), cardName, false, cardId, setNumber, cardCost, cmc, cardType, cardPT, cardLoyalty, cardText, colors, relatedCards, reverseRelatedCards, upsideDown);
+        CardInfo *card = addCard(set->getShortName(), cardName, false, cardId, setNumber, cardCost, cmc, cardType, cardPT, cardLoyalty, cardText, colors, relatedCards, reverseRelatedCards, upsideDown, rarity);
 
         if (!set->contains(card)) {
             card->addToSet(set);
@@ -229,6 +233,7 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
         cardPT = "";
         cardText = "";
         setNumber = ""; 
+        rarity = "";
         colors.clear();
         // this is currently an integer; can't accept 2 values
         cardLoyalty = 0;
@@ -289,7 +294,7 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
         upsideDown = false;
 
         // add the card
-        CardInfo *card = addCard(set->getShortName(), cardName, false, muid, setNumber, cardCost, cmc, cardType, cardPT, cardLoyalty, cardText, colors, relatedCards, reverseRelatedCards, upsideDown);
+        CardInfo *card = addCard(set->getShortName(), cardName, false, muid, setNumber, cardCost, cmc, cardType, cardPT, cardLoyalty, cardText, colors, relatedCards, reverseRelatedCards, upsideDown, rarity);
 
         if (!set->contains(card)) {
             card->addToSet(set);

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -45,7 +45,8 @@ private:
         const QStringList & colors,
         const QStringList & relatedCards,
         const QStringList & reverseRelatedCards,
-        bool upsideDown
+        bool upsideDown,
+        QString &rarity
     );
 signals:
     void setIndexChanged(int cardsImported, int setIndex, const QString &setName);


### PR DESCRIPTION
Fix #492

This change implements a rarity filter into the deck editor. It also has an updated oracle to incorporate the rarity within the cards.xml generated file. You can search for the following rarities, as defined by MTGJSON:

- Common
- Uncommon
- Rare
- Mythic Rare
- Special

An example of how this works:
```
<card>
    <name>Kird Ape</name>
    <set rarity="Common" muId="962">ARN</set>
    <set rarity="Common" muId="26605" num="39">BTD</set>
    <set rarity="Uncommon" muId="249382" num="2">DDH</set>
    <set rarity="Special" muId="0" num="64">pFNM</set>
    <set rarity="Mythic Rare" muId="194974" num="6">V09</set>
    <set rarity="Uncommon" muId="83346" num="199">9ED</set>
    <set rarity="Common" muId="1302">3ED</set>
    <color>R</color>
    <manacost>R</manacost>
    <cmc>1</cmc>
    <type>Creature — Ape</type>
    <pt>1/1</pt>
    <tablerow>2</tablerow>
    <text>Kird Ape gets +1/+2 as long as you control a Forest.</text>
</card>
```

If you use the filter to search for a common, uncommon, special, or mythic rare, Kird Ape will be in the list of cards. This is how I feel it should be as once a card is printed as common, it is then legal in pauper and while it may be reprinted, it should still show under the common rarity filter.