### PR TITLE
Prevent no games from showing

### DIFF
--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -93,7 +93,11 @@ void SettingsCache::translateLegacySettings()
     gameFilters().setShowPasswordProtectedGames(legacySetting.value("show_password_protected_games").toBool());
     gameFilters().setGameNameFilter(legacySetting.value("game_name_filter").toString());
     gameFilters().setMinPlayers(legacySetting.value("min_players").toInt());
-    gameFilters().setMaxPlayers(legacySetting.value("max_players").toInt());
+
+    if (legacySetting.value("max_players").toInt() > 1)
+        gameFilters().setMaxPlayers(legacySetting.value("max_players").toInt());
+    else
+        gameFilters().setMaxPlayers(99); // This prevents a bug where no games will show if max was not set before
 
     QStringList allFilters = legacySetting.allKeys();
     for (int i = 0; i < allFilters.size(); ++i) {


### PR DESCRIPTION
Fix #1476 

When you first launch the client (the very first time) it will try to convert "legacy settings" you may have saved within the application in the past to the preferences file. If it didn't detect a value, -1 was inserted. This will prevent -1 from being inserted for max players and instead insert 99. By doing this, the game will show all games of all types once the client is launched for the first time.