### PR TITLE
Add set names to dialog

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -105,6 +105,18 @@ int SetList::getUnknownSetsNum()
     return num;
 }
 
+QStringList SetList::getUnknownSetsNames()
+{
+    QStringList sets = QStringList();
+    for (int i = 0; i < size(); ++i)
+    {
+        CardSet *set = at(i);
+        if(!set->getIsKnown())
+            sets << set->getShortName();
+    }
+    return sets;
+}
+
 void SetList::enableAllUnknown()
 {
     for (int i = 0; i < size(); ++i)
@@ -755,8 +767,9 @@ void CardDatabase::checkUnknownSets()
     {
         // if some sets are first found on thus run, ask the user
         int numUnknownSets = sets.getUnknownSetsNum();
+        QStringList unknownSetNames = sets.getUnknownSetsNames();
         if(numUnknownSets > 0)
-            emit cardDatabaseNewSetsFound(numUnknownSets);
+            emit cardDatabaseNewSetsFound(numUnknownSets, unknownSetNames);
     } else {
         // No set enabled. Probably this is the first time running trice
         sets.guessSortKeys();

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -55,6 +55,7 @@ public:
     void markAllAsKnown();
     int getEnabledSetsNum();
     int getUnknownSetsNum();
+    QStringList getUnknownSetsNames();
 };
 
 class CardInfo : public QObject {
@@ -237,7 +238,7 @@ private slots:
     LoadStatus loadCardDatabase(const QString &path);
 signals:
     void cardDatabaseLoadingFailed();
-    void cardDatabaseNewSetsFound(int numUnknownSets);
+    void cardDatabaseNewSetsFound(int numUnknownSets, QStringList unknownSetsNames);
     void cardDatabaseAllNewSetsEnabled();
     void cardDatabaseEnabledSetsChanged();
     void cardAdded(CardInfo *card);

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -664,7 +664,7 @@ MainWindow::MainWindow(QWidget *parent)
     refreshShortcuts();
 
     connect(db, SIGNAL(cardDatabaseLoadingFailed()), this, SLOT(cardDatabaseLoadingFailed()));
-    connect(db, SIGNAL(cardDatabaseNewSetsFound(int)), this, SLOT(cardDatabaseNewSetsFound(int)));
+    connect(db, SIGNAL(cardDatabaseNewSetsFound(int, QStringList)), this, SLOT(cardDatabaseNewSetsFound(int, QStringList)));
     connect(db, SIGNAL(cardDatabaseAllNewSetsEnabled()), this, SLOT(cardDatabaseAllNewSetsEnabled()));
     QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
 }
@@ -782,13 +782,16 @@ void MainWindow::cardDatabaseLoadingFailed()
     }
 }
 
-void MainWindow::cardDatabaseNewSetsFound(int numUnknownSets)
+void MainWindow::cardDatabaseNewSetsFound(int numUnknownSets, QStringList unknownSetsNames)
 {
     QMessageBox msgBox;
     msgBox.setWindowTitle(tr("New sets found"));
     msgBox.setIcon(QMessageBox::Question);
-    msgBox.setText(tr("%1 new set(s) have been found in the card database.\n"
-        "Do you want to enable them?").arg(numUnknownSets));
+    msgBox.setText(
+        tr("%1 new sets found in the card database\n"
+        "Set codes: %2\n"
+        "Do you want to enable them?"
+        ).arg(numUnknownSets).arg(unknownSetsNames.join(", ")));
 
     QPushButton *yesButton = msgBox.addButton(tr("Yes"), QMessageBox::YesRole);
     QPushButton *noButton = msgBox.addButton(tr("No"), QMessageBox::NoRole);

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -80,7 +80,7 @@ private slots:
     void cardUpdateFinished(int exitCode, QProcess::ExitStatus exitStatus);
     void refreshShortcuts();
     void cardDatabaseLoadingFailed();
-    void cardDatabaseNewSetsFound(int numUnknownSets);
+    void cardDatabaseNewSetsFound(int numUnknownSets, QStringList unknownSetsNames);
     void cardDatabaseAllNewSetsEnabled();
 
     void actOpenCustomFolder();


### PR DESCRIPTION
Fix #1946 

When you have new sets in the card database, you will now also be informed of their set codes in the popup message.

<img width="411" alt="screenshot 2016-05-31 20 26 59" src="https://cloud.githubusercontent.com/assets/7460172/15694743/5c50c4b6-276e-11e6-808c-fc281490d9ed.png">
