### PR TITLE
Log UI

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -17,6 +17,7 @@ SET(cockatrice_SOURCES
     src/dlg_edit_user.cpp
     src/dlg_register.cpp 
     src/dlg_update.cpp
+    src/dlg_viewlog.cpp
     src/abstractclient.cpp
     src/remoteclient.cpp 
     src/main.cpp 
@@ -110,6 +111,7 @@ SET(cockatrice_SOURCES
     src/settings/layoutssettings.cpp
     src/update_checker.cpp
     src/update_downloader.cpp
+    src/logger.cpp
     ${VERSION_STRING_CPP}
 )
 

--- a/cockatrice/src/dlg_viewlog.cpp
+++ b/cockatrice/src/dlg_viewlog.cpp
@@ -1,0 +1,35 @@
+#include "dlg_viewlog.h"
+#include "logger.h"
+
+#include <QVBoxLayout>
+#include <QPlainTextEdit>
+
+DlgViewLog::DlgViewLog(QWidget *parent)
+: QDialog(parent)
+{
+    logArea = new QPlainTextEdit;
+    logArea->setReadOnly(true);
+    
+    QVBoxLayout *mainLayout = new QVBoxLayout;
+    mainLayout->addWidget(logArea);
+
+    setLayout(mainLayout);
+
+    setWindowTitle(tr("View debug log"));
+    resize(800, 500);
+
+    loadInitialLogBuffer();
+    connect(&Logger::getInstance(), SIGNAL(logEntryAdded(QString)), this, SLOT(logEntryAdded(QString)));    
+}
+
+void DlgViewLog::loadInitialLogBuffer()
+{
+    QVector<QString> logBuffer = Logger::getInstance().getLogBuffer();
+    foreach(QString message, logBuffer)
+        logEntryAdded(message);
+}
+
+void DlgViewLog::logEntryAdded(QString message)
+{
+    logArea->appendPlainText(message);
+}

--- a/cockatrice/src/dlg_viewlog.h
+++ b/cockatrice/src/dlg_viewlog.h
@@ -1,0 +1,20 @@
+#ifndef DLG_VIEWLOG_H
+#define DLG_VIEWLOG_H
+
+#include <QDialog>
+
+class QPlainTextEdit;
+
+class DlgViewLog : public QDialog {
+Q_OBJECT
+public:
+    DlgViewLog(QWidget *parent);
+private:
+	QPlainTextEdit *logArea;
+
+	void loadInitialLogBuffer();
+private slots:
+	void logEntryAdded(QString message);
+};
+
+#endif

--- a/cockatrice/src/logger.cpp
+++ b/cockatrice/src/logger.cpp
@@ -1,0 +1,62 @@
+#include "logger.h"
+
+#include <QDateTime>
+
+#define LOGGER_MAX_ENTRIES 128
+#define LOGGER_FILENAME "qdebug.txt"
+
+Logger::Logger()
+: logToFileEnabled(false)
+{
+}
+
+Logger::~Logger()
+{
+    closeLogfileSession();
+    logBuffer.clear();
+}
+
+void Logger::logToFile(bool enabled)
+{
+    if(enabled)
+        openLogfileSession();
+    else
+        closeLogfileSession();
+}
+
+void Logger::openLogfileSession()
+{
+    if(logToFileEnabled)
+        return;
+
+    fileHandle.setFileName(LOGGER_FILENAME);
+    fileHandle.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text);
+    fileStream.setDevice(&fileHandle);
+    fileStream << "Log session started at " << QDateTime::currentDateTime().toString() << endl;
+    logToFileEnabled = true;
+}
+
+void Logger::closeLogfileSession()
+{
+    if(!logToFileEnabled)
+        return;
+
+    logToFileEnabled = false;
+    fileStream << "Log session closed at " << QDateTime::currentDateTime().toString() << endl;
+    fileHandle.close();
+}
+
+
+void Logger::log(QtMsgType /* type */, const QMessageLogContext & /* ctx */, const QString &message)
+{
+    logBuffer.append(message);
+    if(logBuffer.size() > LOGGER_MAX_ENTRIES)
+        logBuffer.removeFirst();
+
+    emit logEntryAdded(message);
+
+    if(logToFileEnabled)
+    {
+        fileStream << message << endl;
+    }
+}

--- a/cockatrice/src/logger.h
+++ b/cockatrice/src/logger.h
@@ -1,0 +1,40 @@
+#ifndef LOGGER_H
+#define LOGGER_H
+
+#include <QTextStream>
+#include <QFile>
+#include <QVector>
+#include <QString>
+
+class Logger : public QObject {
+Q_OBJECT
+public:
+    static Logger& getInstance()
+    {
+        static Logger instance;
+        return instance;
+    }
+private:
+    Logger();
+    ~Logger();
+    // Singleton - Don't implement copy constructor and assign operator
+    Logger(Logger const&);
+    void operator=(Logger const&); 
+
+    bool logToFileEnabled;
+    QTextStream fileStream;
+    QFile fileHandle;
+
+    QVector<QString> logBuffer;
+public:
+	void logToFile(bool enabled);
+    void log(QtMsgType type, const QMessageLogContext &ctx, const QString &message);
+    QVector<QString> getLogBuffer() { return logBuffer; }
+protected:
+    void openLogfileSession();
+    void closeLogfileSession();
+signals:
+    void logEntryAdded(QString message);
+};
+
+#endif

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -41,8 +41,7 @@
 #include "rng_sfmt.h"
 #include "soundengine.h"
 #include "featureset.h"
-
-//Q_IMPORT_PLUGIN(qjpeg)
+#include "logger.h"
 
 CardDatabase *db;
 QTranslator *translator, *qtTranslator;
@@ -55,13 +54,8 @@ ThemeManager *themeManager;
 const QString translationPrefix = "cockatrice";
 QString translationPath;
 
-static void myMessageOutput(QtMsgType /*type*/, const QMessageLogContext &, const QString &msg)
-{
-    QFile file("qdebug.txt");
-    file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text);
-    QTextStream out(&file);
-    out << msg << endl;
-    file.close();
+static void CockatriceLogger(QtMsgType type, const QMessageLogContext &ctx, const QString &message) {
+    Logger::getInstance().log(type, ctx, message);
 }
 
 void installNewTranslator()
@@ -91,8 +85,9 @@ int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
 
+    qInstallMessageHandler(CockatriceLogger);
     if (app.arguments().contains("--debug-output"))
-        qInstallMessageHandler(myMessageOutput);
+        Logger::getInstance().logToFile(true);
 
 #ifdef Q_OS_WIN
     app.addLibraryPath(app.applicationDirPath() + "/plugins");

--- a/cockatrice/src/pictureloader.h
+++ b/cockatrice/src/pictureloader.h
@@ -75,7 +75,7 @@ public:
 private:
     PictureLoader();
     ~PictureLoader();
-    // Don't implement
+    // Singleton - Don't implement copy constructor and assign operator
     PictureLoader(PictureLoader const&);
     void operator=(PictureLoader const&); 
 

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -39,6 +39,7 @@
 #include "dlg_register.h"
 #include "dlg_settings.h"
 #include "dlg_update.h"
+#include "dlg_viewlog.h"
 #include "tab_supervisor.h"
 #include "remoteclient.h"
 #include "localserver.h"
@@ -304,6 +305,12 @@ void MainWindow::actUpdate()
     dlg.exec();
 }
 
+void MainWindow::actViewLog()
+{
+    DlgViewLog dlg(this);
+    dlg.exec();
+}
+
 void MainWindow::serverTimeout()
 {
     QMessageBox::critical(this, tr("Error"), tr("Server timeout"));
@@ -511,6 +518,7 @@ void MainWindow::retranslateUi()
 
     aAbout->setText(tr("&About Cockatrice"));
     aUpdate->setText(tr("&Update Cockatrice"));
+    aViewLog->setText(tr("View &debug log"));
     helpMenu->setTitle(tr("&Help"));
     aCheckCardUpdates->setText(tr("Check for card updates..."));
     tabSupervisor->retranslateUi();
@@ -543,6 +551,8 @@ void MainWindow::createActions()
     connect(aAbout, SIGNAL(triggered()), this, SLOT(actAbout()));
     aUpdate = new QAction(this);
     connect(aUpdate, SIGNAL(triggered()), this, SLOT(actUpdate()));
+    aViewLog = new QAction(this);
+    connect(aViewLog, SIGNAL(triggered()), this, SLOT(actViewLog()));
 
     aCheckCardUpdates = new QAction(this);
     connect(aCheckCardUpdates, SIGNAL(triggered()), this, SLOT(actCheckCardUpdates()));
@@ -610,6 +620,7 @@ void MainWindow::createMenus()
     helpMenu = menuBar()->addMenu(QString());
     helpMenu->addAction(aAbout);
     helpMenu->addAction(aUpdate);
+    helpMenu->addAction(aViewLog);
 }
 
 MainWindow::MainWindow(QWidget *parent)

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -70,6 +70,7 @@ private slots:
     
     void actAbout();
     void actUpdate();
+    void actViewLog();
 
     void iconActivated(QSystemTrayIcon::ActivationReason reason);
 
@@ -106,7 +107,7 @@ private:
     QList<QMenu *> tabMenus;
     QMenu *cockatriceMenu, *dbMenu, *helpMenu;
     QAction *aConnect, *aDisconnect, *aSinglePlayer, *aWatchReplay, *aDeckEditor, *aFullScreen, *aSettings, *aExit,
-        *aAbout, *aCheckCardUpdates, *aRegister, *aUpdate;
+        *aAbout, *aCheckCardUpdates, *aRegister, *aUpdate, *aViewLog;
     QAction *aEditSets, *aEditTokens, *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet;
     TabSupervisor *tabSupervisor;
 


### PR DESCRIPTION
This PR adds a specialized class for logging of debug messages in cockatrice, and a dialog where the last log messages are shown.
It should help users without a decent terminal (= windows users) to report problems with card database loading, picture downloading, etc..

![dat menu](https://cloud.githubusercontent.com/assets/1631111/16332845/83e62830-39f8-11e6-9f11-7518b6a5e778.png)

![dat dialog](https://cloud.githubusercontent.com/assets/1631111/16332849/878ad6ac-39f8-11e6-8bd5-815e1f922f8a.png)

fix #1867