### PR TITLE
log ui window: title change

### DIFF
--- a/cockatrice/src/dlg_viewlog.cpp
+++ b/cockatrice/src/dlg_viewlog.cpp
@@ -15,7 +15,7 @@ DlgViewLog::DlgViewLog(QWidget *parent)
 
     setLayout(mainLayout);
 
-    setWindowTitle(tr("View debug log"));
+    setWindowTitle(tr("Debug Log"));
     resize(800, 500);
 
     loadInitialLogBuffer();


### PR DESCRIPTION
While translating I realized that `View Debug Log` for the menu is perfectly fine, the dialog window should just say `Debug Log` though...