### PR TITLE
Autoadmin

### DIFF
--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -80,7 +80,7 @@ void ChatView::appendHtmlServerMessage(const QString &html, bool optionalIsBold,
 {
     bool atBottom = verticalScrollBar()->value() >= verticalScrollBar()->maximum();
 
-    QString htmlText = "<font color=" + ((optionalFontColor.size() > 0) ? optionalFontColor : SERVER_MESSAGE_COLOR) + ">" + html + "</font>";
+    QString htmlText = "<font color=" + ((optionalFontColor.size() > 0) ? optionalFontColor : SERVER_MESSAGE_COLOR) + ">" + QDateTime::currentDateTime().toString("[hh:mm:ss] ")+ html + "</font>";
 
     if (optionalIsBold)
         htmlText = "<b>" + htmlText + "</b>";

--- a/cockatrice/src/tab_admin.cpp
+++ b/cockatrice/src/tab_admin.cpp
@@ -14,8 +14,7 @@
 #include "pb/admin_commands.pb.h"
 
 ShutdownDialog::ShutdownDialog(QWidget *parent)
-    : QDialog(parent)
-{
+        : QDialog(parent) {
     QLabel *reasonLabel = new QLabel(tr("&Reason for shutdown:"));
     reasonEdit = new QLineEdit;
     reasonLabel->setBuddy(reasonEdit);
@@ -25,118 +24,109 @@ ShutdownDialog::ShutdownDialog(QWidget *parent)
     minutesEdit->setMinimum(0);
     minutesEdit->setValue(5);
     minutesEdit->setMaximum(999);
-    
+
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
     connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
-    
+
     QGridLayout *mainLayout = new QGridLayout;
     mainLayout->addWidget(reasonLabel, 0, 0);
     mainLayout->addWidget(reasonEdit, 0, 1);
     mainLayout->addWidget(minutesLabel, 1, 0);
     mainLayout->addWidget(minutesEdit, 1, 1);
     mainLayout->addWidget(buttonBox, 2, 0, 1, 2);
-    
+
     setLayout(mainLayout);
     setWindowTitle(tr("Shut down server"));
 }
 
-QString ShutdownDialog::getReason() const
-{
+QString ShutdownDialog::getReason() const {
     return reasonEdit->text();
 }
 
-int ShutdownDialog::getMinutes() const
-{
+int ShutdownDialog::getMinutes() const {
     return minutesEdit->value();
 }
 
 TabAdmin::TabAdmin(TabSupervisor *_tabSupervisor, AbstractClient *_client, bool _fullAdmin, QWidget *parent)
-    : Tab(_tabSupervisor, parent), locked(true), client(_client), fullAdmin(_fullAdmin)
-{
+        : Tab(_tabSupervisor, parent), locked(true), client(_client), fullAdmin(_fullAdmin) {
     updateServerMessageButton = new QPushButton;
     connect(updateServerMessageButton, SIGNAL(clicked()), this, SLOT(actUpdateServerMessage()));
     shutdownServerButton = new QPushButton;
     connect(shutdownServerButton, SIGNAL(clicked()), this, SLOT(actShutdownServer()));
     reloadConfigButton = new QPushButton;
     connect(reloadConfigButton, SIGNAL(clicked()), this, SLOT(actReloadConfig()));
-    
+
     QVBoxLayout *vbox = new QVBoxLayout;
     vbox->addWidget(updateServerMessageButton);
     vbox->addWidget(shutdownServerButton);
     vbox->addWidget(reloadConfigButton);
     vbox->addStretch();
-    
+
     adminGroupBox = new QGroupBox;
     adminGroupBox->setLayout(vbox);
     adminGroupBox->setEnabled(false);
-    
+
     unlockButton = new QPushButton;
     connect(unlockButton, SIGNAL(clicked()), this, SLOT(actUnlock()));
     lockButton = new QPushButton;
     lockButton->setEnabled(false);
     connect(lockButton, SIGNAL(clicked()), this, SLOT(actLock()));
-    
+
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(adminGroupBox);
     mainLayout->addWidget(unlockButton);
     mainLayout->addWidget(lockButton);
-    
+
     retranslateUi();
 
-    QWidget * mainWidget = new QWidget(this);
+    QWidget *mainWidget = new QWidget(this);
     mainWidget->setLayout(mainLayout);
     setCentralWidget(mainWidget);
+
+    actUnlock();
 }
 
-void TabAdmin::retranslateUi()
-{
+void TabAdmin::retranslateUi() {
     updateServerMessageButton->setText(tr("Update server &message"));
     shutdownServerButton->setText(tr("&Shut down server"));
     reloadConfigButton->setText(tr("&Reload configuration"));
     adminGroupBox->setTitle(tr("Server administration functions"));
-    
+
     unlockButton->setText(tr("&Unlock functions"));
     lockButton->setText(tr("&Lock functions"));
 }
 
-void TabAdmin::actUpdateServerMessage()
-{
+void TabAdmin::actUpdateServerMessage() {
     client->sendCommand(client->prepareAdminCommand(Command_UpdateServerMessage()));
 }
 
-void TabAdmin::actShutdownServer()
-{
+void TabAdmin::actShutdownServer() {
     ShutdownDialog dlg;
     if (dlg.exec()) {
         Command_ShutdownServer cmd;
         cmd.set_reason(dlg.getReason().toStdString());
         cmd.set_minutes(dlg.getMinutes());
-        
+
         client->sendCommand(client->prepareAdminCommand(cmd));
     }
 }
 
-void TabAdmin::actReloadConfig()
-{
+void TabAdmin::actReloadConfig() {
     Command_ReloadConfig cmd;
     client->sendCommand(client->prepareAdminCommand(cmd));
 }
 
-void TabAdmin::actUnlock()
-{
-    if (QMessageBox::question(this, tr("Unlock administration functions"), tr("Do you really want to unlock the administration functions?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) {
-        if (fullAdmin)
-            adminGroupBox->setEnabled(true);
-        lockButton->setEnabled(true);
-        unlockButton->setEnabled(false);
-        locked = false;
-        emit adminLockChanged(false);
-    }
+void TabAdmin::actUnlock() {
+    if (fullAdmin)
+        adminGroupBox->setEnabled(true);
+    lockButton->setEnabled(true);
+    unlockButton->setEnabled(false);
+    locked = false;
+    emit adminLockChanged(false);
 }
 
-void TabAdmin::actLock()
-{
+void TabAdmin::actLock() {
     if (fullAdmin)
         adminGroupBox->setEnabled(false);
     lockButton->setEnabled(false);


### PR DESCRIPTION
Something I have in a personal build.

When I log in as an admin I want to automatically be able to use the features.
From a usability standpoint, it is frustrating if you want to deal with a situation but first have to navigate to the admin window. It also means when the server kicks you, or if you close your laptop for a while, you need to re-enable it.

This makes my life a little easier.

+ Auto admin features when log in
+ Removed popup to ask if you are sure.