### PR TITLE
auto admin

### DIFF
--- a/cockatrice/src/tab_admin.cpp
+++ b/cockatrice/src/tab_admin.cpp
@@ -87,6 +87,8 @@ TabAdmin::TabAdmin(TabSupervisor *_tabSupervisor, AbstractClient *_client, bool 
     QWidget * mainWidget = new QWidget(this);
     mainWidget->setLayout(mainLayout);
     setCentralWidget(mainWidget);
+
+    actUnlock();
 }
 
 void TabAdmin::retranslateUi()
@@ -125,14 +127,12 @@ void TabAdmin::actReloadConfig()
 
 void TabAdmin::actUnlock()
 {
-    if (QMessageBox::question(this, tr("Unlock administration functions"), tr("Do you really want to unlock the administration functions?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) {
         if (fullAdmin)
             adminGroupBox->setEnabled(true);
         lockButton->setEnabled(true);
         unlockButton->setEnabled(false);
         locked = false;
         emit adminLockChanged(false);
-    }
 }
 
 void TabAdmin::actLock()


### PR DESCRIPTION
Something I have in a personal build.

When I log in as an admin I want to automatically be able to use the features.
From a usability standpoint, it is frustrating if you want to deal with a situation but first have to navigate to the admin window. It also means when the server kicks you, or if you close your laptop for a while, you need to re-enable it.

This makes my life a little easier.

+ Auto unlocks admin features when log in
+ Removed popup to ask if you are sure.