### PR TITLE
Game Viewer Update

### DIFF
--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -36,7 +36,7 @@ GameSelector::GameSelector(AbstractClient *_client, const TabSupervisor *_tabSup
     gameListView->setAlternatingRowColors(true);
     gameListView->setRootIsDecorated(true);
     // game created width
-    gameListView->resizeColumnToContents(1);
+    gameListView->setColumnWidth(1, gameListView->columnWidth(2) * 0.7);
     // players width
     gameListView->resizeColumnToContents(6);
     // description width

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -13,30 +13,21 @@ enum GameListColumn {ROOM, CREATED, DESCRIPTION, CREATOR, GAME_TYPE, RESTRICTION
 const QString GamesModel::getGameCreatedString(const int secs) const {
 
     QString ret;
-    if (secs < SECS_PER_MIN)
-        ret = tr("<1m ago");
-    else if (secs < SECS_PER_MIN * 5)
-        ret = tr("<5m ago");
-    else if (secs < SECS_PER_HOUR)
-        ret = tr("%1m ago").arg(QString::number(secs / SECS_PER_MIN));
-    else if (secs < SECS_PER_MIN * 90) {
-        ret = tr("1hr %1m ago").arg(QString::number((secs / SECS_PER_MIN) - 60));
-    } else if (secs < SECS_PER_HOUR * 4) {
-        unsigned int hours = secs / SECS_PER_HOUR;
-        if (secs % SECS_PER_HOUR >= SECS_PER_MIN * 30)
+    if (secs < SECS_PER_MIN * 2) // for first min we display "New"
+        ret = tr("New");
+    else if (secs < SECS_PER_MIN * 10) // from 2 - 10 mins we show the mins
+        ret = QString("%1 min").arg(QString::number(secs / SECS_PER_MIN));
+    else if (secs < SECS_PER_MIN * 60) { // from 10 mins to 1h we aggregate every 10 mins
+        int unitOfTen = secs / SECS_PER_TEN_MIN;
+        QString str = "%1%2";
+        ret = str.arg(QString::number(unitOfTen), "0+ min");
+    } else { // from 1 hr onward we show hrs
+        int hours = secs / SECS_PER_HOUR;
+        if (secs % SECS_PER_HOUR >= SECS_PER_MIN * 30) // if the room is open for 1hr 30 mins, we round to 2hrs
             hours++;
-        ret = tr("%1hr ago").arg(QString::number(hours));
-    } else
-        ret = tr("5+ hrs ago");
-
+        ret = QString("%1+ h").arg(QString::number(hours));
+    }
     return ret;
-
-    /*
-    todo
-    . would like less if()
-    . would like less code repition 
-    */
-
 }
 
 GamesModel::GamesModel(const QMap<int, QString> &_rooms, const QMap<int, GameTypeMap> &_gameTypes, QObject *parent)
@@ -67,6 +58,7 @@ QVariant GamesModel::data(const QModelIndex &index, int role) const
             switch (role) {
                 case Qt::DisplayRole: return getGameCreatedString(secs);
                 case SORT_ROLE: return QVariant(secs);
+                case Qt::TextAlignmentRole: return Qt::AlignCenter;
                 default: return QVariant();
             }
         }
@@ -135,7 +127,7 @@ QVariant GamesModel::data(const QModelIndex &index, int role) const
             case Qt::DisplayRole: 
                 return QString("%1/%2").arg(g.player_count()).arg(g.max_players());
             case Qt::TextAlignmentRole:
-                return Qt::AlignLeft;
+                return Qt::AlignCenter;
             default:
                 return QVariant();
             }
@@ -174,18 +166,32 @@ QVariant GamesModel::data(const QModelIndex &index, int role) const
     }
 }
 
-QVariant GamesModel::headerData(int section, Qt::Orientation orientation, int role) const
+QVariant GamesModel::headerData(int section, Qt::Orientation /*orientation*/, int role) const
 {
-    if ((role != Qt::DisplayRole) || (orientation != Qt::Horizontal))
+    if ((role != Qt::DisplayRole) && (role != Qt::TextAlignmentRole))
         return QVariant();
     switch (section) {
     case ROOM: return tr("Room");
-    case CREATED: return tr("Game Created");
+    case CREATED: {
+        switch(role) {
+            case Qt::DisplayRole:
+                return tr("Age");
+            case Qt::TextAlignmentRole:
+                return Qt::AlignCenter;
+        }
+    }
     case DESCRIPTION: return tr("Description");
     case CREATOR: return tr("Creator");
-    case GAME_TYPE: return tr("Game Type");
+    case GAME_TYPE: return tr("Type");
     case RESTRICTIONS: return tr("Restrictions");
-    case PLAYERS: return tr("Players");
+    case PLAYERS: {
+        switch(role) {
+            case Qt::DisplayRole:
+                return tr("Players");
+            case Qt::TextAlignmentRole:
+                return Qt::AlignCenter;
+        }
+    }
     case SPECTATORS: return tr("Spectators");
     default: return QVariant();
     }

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -8,10 +8,8 @@
 #include "gametypemap.h"
 #include "pb/serverinfo_game.pb.h"
 
-class ServerInfo_User;
-
 class GamesModel : public QAbstractTableModel {
-    Q_OBJECT
+Q_OBJECT
 private:
     QList<ServerInfo_Game> gameList;
     QMap<int, QString> rooms;
@@ -19,6 +17,7 @@ private:
 
     static const int NUM_COLS = 8;
     static const int SECS_PER_MIN  = 60;
+    static const int SECS_PER_TEN_MIN = 600;
     static const int SECS_PER_HOUR = 3600;
 public:
     static const int SORT_ROLE = Qt::UserRole+1;
@@ -41,6 +40,8 @@ public:
 
     const QMap<int, GameTypeMap> &getGameTypes() { return gameTypes; }
 };
+
+class ServerInfo_User;
 
 class GamesProxyModel : public QSortFilterProxyModel {
     Q_OBJECT


### PR DESCRIPTION
## Description
Updated the `Game Created` column to be more accurate when a game a newer.
The overall appearance is less clutter, cleaner and more central.
 
+ New games (<2 mins) will be defined as `New`
+ Games <10 mins will show the time in mins.
+ Games over 10 mins will show `10+ min`, `20+ min` . . . all the way up to `50+ min`
+ Games over 1 hour will show the time in hours: `1+ h`, `2+ h` . . .

This makes 3 areas of games and precision:
+ High precision : Newest games
+ Medium precision : Game may be getting stagnant
+ Low precision: Game has high chance of being stagnant.

## Changelist

+ Changed `Game Created` to `Age`.  `Game` is not needed as all entries in the list fall under the category `Game` that is defined in the upper left of the table.

+ Changed `Game Type` to just `Type` for the same reason as above.

+ Removed `ago` from each timestamp. This is just clutter and is not needed.

+ Changed the units from `m` and `hr` to `min` and `h` as defined [here](https://en.wikipedia.org/wiki/Non-SI_units_mentioned_in_the_SI).

+ The timestamps are now centred to help draw the eye. 

+ `Players` is now centred.

## Old
<img width="420" alt="screen shot 2016-07-10 at 15 16 09" src="https://cloud.githubusercontent.com/assets/2134793/16713741/4a1c203a-46b1-11e6-9882-b92be534ea85.png">

## New
<img width="501" alt="screen shot 2016-07-11 at 10 23 35" src="https://cloud.githubusercontent.com/assets/2134793/16724150/8ac9c376-4751-11e6-9fec-738759ee3866.png">



