### PR TITLE
show buddyOnly on filter clear

### DIFF
--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -283,6 +283,7 @@ void GamesProxyModel::resetFilterParameters()
 {
     unavailableGamesVisible = false;
     showPasswordProtectedGames = true;
+    showBuddiesOnlyGames = true;
     gameNameFilter = QString();
     creatorNameFilter = QString();
     gameTypeFilter.clear();


### PR DESCRIPTION
Fix #2079

Will set show buddy games to "true" when the clear filter button is reset.