### PR TITLE
updated login

### DIFF
--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -10,6 +10,7 @@
 #include <QKeyEvent>
 #include <QMessageBox>
 #include <iostream>
+#include <QGroupBox>
 #include "dlg_connect.h"
 #include "settingscache.h"
 
@@ -65,20 +66,32 @@ DlgConnect::DlgConnect(QWidget *parent)
 
     connect(savePasswordCheckBox, SIGNAL(stateChanged(int)), this, SLOT(passwordSaved(int)));
 
+    QGridLayout *connectionLayout = new QGridLayout;
+    connectionLayout->addWidget(previousHostButton, 0, 1);
+    connectionLayout->addWidget(previousHosts, 1, 1);
+    connectionLayout->addWidget(newHostButton, 2, 1);
+    connectionLayout->addWidget(hostLabel, 3, 0);
+    connectionLayout->addWidget(hostEdit, 3, 1);
+    connectionLayout->addWidget(portLabel, 4, 0);
+    connectionLayout->addWidget(portEdit, 4, 1);
+
+    QGroupBox *restrictionsGroupBox = new QGroupBox(tr("Server"));
+    restrictionsGroupBox->setLayout(connectionLayout);
+
+    QGridLayout *loginLayout = new QGridLayout;
+    loginLayout->addWidget(playernameLabel, 0, 0);
+    loginLayout->addWidget(playernameEdit, 0, 1);
+    loginLayout->addWidget(passwordLabel, 1, 0);
+    loginLayout->addWidget(passwordEdit, 1, 1);
+
+    QGroupBox *loginGroupBox = new QGroupBox(tr("Login"));
+    loginGroupBox->setLayout(loginLayout);
+
     QGridLayout *grid = new QGridLayout;
-    grid->addWidget(previousHostButton, 0, 1);
-    grid->addWidget(previousHosts, 1, 1);
-    grid->addWidget(newHostButton, 2, 1);
-    grid->addWidget(hostLabel, 3, 0);
-    grid->addWidget(hostEdit, 3, 1);
-    grid->addWidget(portLabel, 4, 0);
-    grid->addWidget(portEdit, 4, 1);
-    grid->addWidget(playernameLabel, 5, 0);
-    grid->addWidget(playernameEdit, 5, 1);
-    grid->addWidget(passwordLabel, 6, 0);
-    grid->addWidget(passwordEdit, 6, 1);
-    grid->addWidget(savePasswordCheckBox, 7, 0, 1, 2);
-    grid->addWidget(autoConnectCheckBox, 8, 0, 1, 2);
+    grid->addWidget(restrictionsGroupBox, 0, 0);
+    grid->addWidget(loginGroupBox, 1, 0);
+    grid->addWidget(savePasswordCheckBox, 3, 0);
+    grid->addWidget(autoConnectCheckBox, 4, 0);
     
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
@@ -100,11 +113,14 @@ DlgConnect::DlgConnect(QWidget *parent)
         previousHostButton->setChecked(true);
     else
         newHostButton->setChecked(true);
+
+    playernameEdit->setFocus();
 }
 
 
 void DlgConnect::previousHostSelected(bool state) {
     if (state) {
+        hostLabel->setDisabled(true);
         hostEdit->setDisabled(true);
         previousHosts->setDisabled(false);
     }
@@ -113,6 +129,7 @@ void DlgConnect::previousHostSelected(bool state) {
 void DlgConnect::newHostSelected(bool state) {
     if (state) {
         hostEdit->setDisabled(false);
+        hostLabel->setDisabled(false);
         previousHosts->setDisabled(true);
     }
 }


### PR DESCRIPTION
## Description
Updated login screen. Previously the dlg would auto highlight the `port` number. Its more useful to have the username the first highlight item. I have also grouped the 2 different parts of the dlg.

## Changelist
 + `Username` is now the auto selected item.
 + Separation of Server and Login.
 + `New Host` label is faded when s`Previous Host` is selected.


## Old
<img width="477" alt="screen shot 2016-07-15 at 15 33 22" src="https://cloud.githubusercontent.com/assets/2134793/16875792/86b0214c-4aa1-11e6-9b74-9ee55f72460f.png">

## New
<img width="462" alt="screen shot 2016-07-15 at 15 41 20" src="https://cloud.githubusercontent.com/assets/2134793/16876049/ba4393e4-4aa2-11e6-92e7-037006dce6b2.png">



