### PR TITLE
Client id nametoip fix

### DIFF
--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -1,7 +1,10 @@
+#include <QDebug>
 #include <QList>
 #include <QTimer>
 #include <QThread>
 #include <QCryptographicHash>
+#include <QHostInfo>
+#include <QHostAddress>
 #include "remoteclient.h"
 #include "settingscache.h"
 #include "pending_command.h"
@@ -365,7 +368,15 @@ void RemoteClient::disconnectFromServer()
 QString RemoteClient::getSrvClientID(const QString _hostname)
 {
     QString srvClientID = settingsCache->getClientID();
-    srvClientID += _hostname;
+    QHostInfo hostInfo = QHostInfo::fromName(_hostname);
+    if (!hostInfo.error()) {
+        QHostAddress hostAddress = hostInfo.addresses().first();
+        srvClientID += hostAddress.toString();
+    }
+    else {
+        qDebug() << "Warning: ClientID generation host lookup failure [" << hostInfo.errorString() << "]";
+        srvClientID += _hostname;
+    }
     QString uniqueServerClientID = QCryptographicHash::hash(srvClientID.toUtf8(), QCryptographicHash::Sha1).toHex().right(15);
     return uniqueServerClientID;
 }


### PR DESCRIPTION
The way the clientid functionality works is it takes the name of the
host and combines it with the portion of the mac address to generate a
client id.  Using the name can allow for easy circumvention of the
clientid generation process by a user if they simply use a hostname file
to constantly change the name to ip resolution.  With this change the
name will no longer be used and the looked up ip address of the server
being connected to will be used.