### PR TITLE
Fix infinite loop on local game close

### DIFF
--- a/cockatrice/src/localserver.cpp
+++ b/cockatrice/src/localserver.cpp
@@ -11,6 +11,10 @@ LocalServer::LocalServer(QObject *parent)
 
 LocalServer::~LocalServer()
 {
+    // LocalServer is single threaded so it doesn't need locks on this
+    while (!clients.isEmpty())
+        clients.first()->prepareDestroy();
+
     prepareDestroy();
 }
 

--- a/common/server.cpp
+++ b/common/server.cpp
@@ -59,28 +59,6 @@ Server::~Server()
 
 void Server::prepareDestroy()
 {
-    // dirty :(
-    clientsLock.lockForRead();
-    for (int i = 0; i < clients.size(); ++i)
-        QMetaObject::invokeMethod(clients.at(i), "prepareDestroy", Qt::QueuedConnection);
-    clientsLock.unlock();
-
-    bool done = false;
-
-    class SleeperThread : public QThread
-    {
-    public:
-        static void msleep(unsigned long msecs) { QThread::usleep(msecs); }
-    };
-
-    do {
-        SleeperThread::msleep(10);
-        clientsLock.lockForRead();
-        if (clients.isEmpty())
-            done = true;
-        clientsLock.unlock();
-    } while (!done);
-
     roomsLock.lockForWrite();
     QMapIterator<int, Server_Room *> roomIterator(rooms);
     while (roomIterator.hasNext())


### PR DESCRIPTION
Since #1991 servatrice only works in multithread mode, so in`Server::prepareDestroy()` the code  dealing with client destruction was using proper locking.
Since the "local game" server in cockatrice is not multithreaded, while closing a game it will hang indefinitely waiting for the lock to be removed.
This PR removes locking when destroying a local game server, the same way it was implemented before #1991.

fix #2091 