### PR TITLE
Remove additional minute in server shutdown

### DIFF
--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -598,7 +598,7 @@ void Servatrice::statusUpdate()
 void Servatrice::scheduleShutdown(const QString &reason, int minutes)
 {
     shutdownReason = reason;
-    shutdownMinutes = minutes + 1;
+    shutdownMinutes = minutes;
     nextShutdownMessageMinutes = shutdownMinutes;
     if (minutes > 0) {
         shutdownTimer = new QTimer;


### PR DESCRIPTION
With #2084 the server shutdown timer calculation has changed, and w don't need anymore to add one minute to the timer.