### PR TITLE
Servatrice rooms table respect Server ID

### DIFF
--- a/servatrice/migrations/servatrice_0014_to_0015.sql
+++ b/servatrice/migrations/servatrice_0014_to_0015.sql
@@ -1,0 +1,6 @@
+-- Servatrice db migration from version 14 to version 15
+
+alter table cockatrice_rooms add `id_server` tinyint(3) not null default 0;
+alter table cockatrice_rooms_gametypes add `id_server` tinyint(3) not null default 0;
+
+UPDATE cockatrice_schema_version SET version=15 WHERE version=14;

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_schema_version` (
   PRIMARY KEY  (`version`)
 ) ENGINE=INNODB DEFAULT CHARSET=utf8;
 
-INSERT INTO cockatrice_schema_version VALUES(14);
+INSERT INTO cockatrice_schema_version VALUES(15);
 
 -- users and user data tables
 CREATE TABLE IF NOT EXISTS `cockatrice_users` (

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -276,10 +276,12 @@ bool Servatrice::initServer()
 
     const QString roomMethod = settingsCache->value("rooms/method").toString();
     if (roomMethod == "sql") {
-        QSqlQuery *query = servatriceDatabaseInterface->prepareQuery("select id, name, descr, permissionlevel, auto_join, join_message, chat_history_size from {prefix}_rooms order by id asc");
+        QSqlQuery *query = servatriceDatabaseInterface->prepareQuery("select id, name, descr, permissionlevel, auto_join, join_message, chat_history_size from {prefix}_rooms where id_server = :id_server order by id asc");
+        query->bindValue(":id_server", serverId);
         servatriceDatabaseInterface->execSqlQuery(query);
         while (query->next()) {
-            QSqlQuery *query2 = servatriceDatabaseInterface->prepareQuery("select name from {prefix}_rooms_gametypes where id_room = :id_room");
+            QSqlQuery *query2 = servatriceDatabaseInterface->prepareQuery("select name from {prefix}_rooms_gametypes where id_room = :id_room AND id_server = :id_server");
+            query2->bindValue(":id_server", serverId);
             query2->bindValue(":id_room", query->value(0).toInt());
             servatriceDatabaseInterface->execSqlQuery(query2);
             QStringList gameTypes;

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -9,7 +9,7 @@
 #include "server.h"
 #include "server_database_interface.h"
 
-#define DATABASE_SCHEMA_VERSION 14
+#define DATABASE_SCHEMA_VERSION 15
 
 class Servatrice;
 


### PR DESCRIPTION
Fix #1123
This change add's the db column "id_server" to the rooms and rooms_gametypes table and updates servatrices queries to respect room/room information per server based on the server id.  This is the only portion of the database that I could find that doesn't respect a server id when the DB is queried for information and with the change will allow multiple servers to use the same DB.

Using the same DB will not of course allow for active game information to be shared but what it will allow for is geographically dispersed servers to replicate there DB information and keep a consistent copy amongst sites.