### PR TITLE
Updated connect dlg

### DIFF
--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -53,7 +53,9 @@ DlgConnect::DlgConnect(QWidget *parent)
     savePasswordCheckBox = new QCheckBox(tr("&Save password"));
     savePasswordCheckBox->setChecked(settingsCache->servers().getSavePassword());
 
-    autoConnectCheckBox = new QCheckBox(tr("A&uto connect at start"));
+    autoConnectCheckBox = new QCheckBox(tr("A&uto connect"));
+    autoConnectCheckBox->setToolTip(tr("Automatically connect to the most recent login when Cockatrice opens"));
+
     if(savePasswordCheckBox->isChecked())
     {
         autoConnectCheckBox->setChecked(settingsCache->servers().getAutoConnect());
@@ -74,6 +76,7 @@ DlgConnect::DlgConnect(QWidget *parent)
     connectionLayout->addWidget(hostEdit, 3, 1);
     connectionLayout->addWidget(portLabel, 4, 0);
     connectionLayout->addWidget(portEdit, 4, 1);
+    connectionLayout->addWidget(autoConnectCheckBox, 5, 1);
 
     QGroupBox *restrictionsGroupBox = new QGroupBox(tr("Server"));
     restrictionsGroupBox->setLayout(connectionLayout);
@@ -83,6 +86,7 @@ DlgConnect::DlgConnect(QWidget *parent)
     loginLayout->addWidget(playernameEdit, 0, 1);
     loginLayout->addWidget(passwordLabel, 1, 0);
     loginLayout->addWidget(passwordEdit, 1, 1);
+    loginLayout->addWidget(savePasswordCheckBox, 2, 1);
 
     QGroupBox *loginGroupBox = new QGroupBox(tr("Login"));
     loginGroupBox->setLayout(loginLayout);
@@ -90,9 +94,7 @@ DlgConnect::DlgConnect(QWidget *parent)
     QGridLayout *grid = new QGridLayout;
     grid->addWidget(restrictionsGroupBox, 0, 0);
     grid->addWidget(loginGroupBox, 1, 0);
-    grid->addWidget(savePasswordCheckBox, 3, 0);
-    grid->addWidget(autoConnectCheckBox, 4, 0);
-    
+
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
     connect(buttonBox, SIGNAL(rejected()), this, SLOT(actCancel()));

--- a/cockatrice/src/shortcutssettings.cpp
+++ b/cockatrice/src/shortcutssettings.cpp
@@ -140,7 +140,7 @@ void ShortcutsSettings::clearAllShortcuts()
 void ShortcutsSettings::fillDefaultShorcuts()
 {
     defaultShortCuts["MainWindow/aCheckCardUpdates"] = parseSequenceString("");
-    defaultShortCuts["MainWindow/aConnect"] = parseSequenceString("");
+    defaultShortCuts["MainWindow/aConnect"] = parseSequenceString("Ctrl+L");
     defaultShortCuts["MainWindow/aDeckEditor"] = parseSequenceString("");
     defaultShortCuts["MainWindow/aDisconnect"] = parseSequenceString("");
     defaultShortCuts["MainWindow/aExit"] = parseSequenceString("");


### PR DESCRIPTION
## Description
Moved the check boxes into their relative sections to keep the dialog tidy, added a shortcut to open the connection dialog.

## Changelist

+ `Save password` has been moved into the `Login` group
+ `Auto connect` has been moved into the `Server` group
+ Renamed `Auto connect at start` to `Auto connect`.
+ Added tool tip to `Auto connect`: `Automatically connect to the most recent login when Cockatrice opens`
+ Added a default key binding of `Ctrl/Cmd + L` to open the connection dialog (L for Login).

## Old
<img width="462" alt="screen shot 2016-07-21 at 11 49 48" src="https://cloud.githubusercontent.com/assets/2134793/17018708/5389bc5a-4f39-11e6-83ca-5f724e3c2efd.png">


## New
<img width="451" alt="screen shot 2016-07-21 at 11 49 09" src="https://cloud.githubusercontent.com/assets/2134793/17018712/57de638c-4f39-11e6-957b-a743b13562bd.png">
