### PR TITLE
Fix clipboard behavior in deck editor and game

### DIFF
--- a/cockatrice/src/cardinfotext.cpp
+++ b/cockatrice/src/cardinfotext.cpp
@@ -13,19 +13,25 @@ CardInfoText::CardInfoText(QWidget *parent)
     nameLabel1 = new QLabel;
     nameLabel2 = new QLabel;
     nameLabel2->setWordWrap(true);
+    nameLabel2->setTextInteractionFlags(Qt::TextBrowserInteraction);
     manacostLabel1 = new QLabel;
     manacostLabel2 = new QLabel;
     manacostLabel2->setWordWrap(true);
+    manacostLabel2->setTextInteractionFlags(Qt::TextBrowserInteraction);
     colorLabel1 = new QLabel;
     colorLabel2 = new QLabel;
     colorLabel2->setWordWrap(true);
+    colorLabel2->setTextInteractionFlags(Qt::TextBrowserInteraction);
     cardtypeLabel1 = new QLabel;
     cardtypeLabel2 = new QLabel;
     cardtypeLabel2->setWordWrap(true);
+    cardtypeLabel2->setTextInteractionFlags(Qt::TextBrowserInteraction);
     powtoughLabel1 = new QLabel;
     powtoughLabel2 = new QLabel;
+    powtoughLabel2->setTextInteractionFlags(Qt::TextBrowserInteraction);
     loyaltyLabel1 = new QLabel;
     loyaltyLabel2 = new QLabel;
+    loyaltyLabel1->setTextInteractionFlags(Qt::TextBrowserInteraction);
 
     textLabel = new QTextEdit();
     textLabel->setReadOnly(true);

--- a/cockatrice/src/shortcutssettings.cpp
+++ b/cockatrice/src/shortcutssettings.cpp
@@ -159,7 +159,7 @@ void ShortcutsSettings::fillDefaultShorcuts()
     defaultShortCuts["TabDeckEditor/aEditTokens"] = parseSequenceString("");
     defaultShortCuts["TabDeckEditor/aIncrement"] = parseSequenceString("+");
     defaultShortCuts["TabDeckEditor/aLoadDeck"] = parseSequenceString("Ctrl+O");
-    defaultShortCuts["TabDeckEditor/aLoadDeckFromClipboard"] = parseSequenceString("Ctrl+V");
+    defaultShortCuts["TabDeckEditor/aLoadDeckFromClipboard"] = parseSequenceString("Ctrl+Shift+V");
     defaultShortCuts["TabDeckEditor/aNewDeck"] = parseSequenceString("Ctrl+N");
     defaultShortCuts["TabDeckEditor/aOpenCustomFolder"] = parseSequenceString("");
     defaultShortCuts["TabDeckEditor/aPrintDeck"] = parseSequenceString("Ctrl+P");
@@ -167,7 +167,7 @@ void ShortcutsSettings::fillDefaultShorcuts()
     defaultShortCuts["TabDeckEditor/aResetLayout"] = parseSequenceString("");
     defaultShortCuts["TabDeckEditor/aSaveDeck"] = parseSequenceString("Ctrl+S");
     defaultShortCuts["TabDeckEditor/aSaveDeckAs"] = parseSequenceString("");
-    defaultShortCuts["TabDeckEditor/aSaveDeckToClipboard"] = parseSequenceString("Ctrl+C");
+    defaultShortCuts["TabDeckEditor/aSaveDeckToClipboard"] = parseSequenceString("Ctrl+Shift+C");
 
     defaultShortCuts["DeckViewContainer/loadLocalButton"] = parseSequenceString("Ctrl+O");
     defaultShortCuts["DeckViewContainer/loadRemoteButton"] = parseSequenceString("Ctrl+Alt+O");

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -280,7 +280,7 @@ void MainWindow::actExit()
 
 void MainWindow::actAbout()
 {
-    QMessageBox::about(this, tr("About Cockatrice"), QString(
+    QMessageBox mb(QMessageBox::NoIcon, tr("About Cockatrice"), QString(
         "<font size=\"8\"><b>Cockatrice</b></font><br>"
         + tr("Version %1").arg(VERSION_STRING)
         + "<br><br><b><a href='" + GITHUB_PAGES_URL + "'>" + tr("Cockatrice Webpage") + "</a></b><br>"
@@ -295,8 +295,12 @@ void MainWindow::actAbout()
         + "<b>" + tr("Support:") + "</b><br>"
         + "<a href='" + GITHUB_ISSUES_URL + "'>" + tr("Report an Issue") + "</a><br>"
         + "<a href='" + GITHUB_TROUBLESHOOTING_URL + "'>" + tr("Troubleshooting") + "</a><br>"
-        + "<a href='" + GITHUB_FAQ_URL + "'>" + tr("F.A.Q.") + "</a><br>"
-    ));
+        + "<a href='" + GITHUB_FAQ_URL + "'>" + tr("F.A.Q.") + "</a><br>"),
+        QMessageBox::Ok, this
+    );
+    mb.setIconPixmap(QPixmap("theme:cockatrice").scaled(64, 64));
+    mb.setTextInteractionFlags(Qt::TextBrowserInteraction);
+    mb.exec();
 }
 
 void MainWindow::actUpdate()


### PR DESCRIPTION
1. Change the default shortcut keys for "load/paste deck from clipboard" from `ctrl+c/v` to `ctrl+shift+c/v`, to avoid overriding the common shortcuts for copy/paste text provided by the OS
2. Make text selectable in the "card info" panel in both the deck editor and game
3. Make text form the "about dialog" selectable: people needs this to copypaste the cockatrice version number in reports.

Note: current shortcut keys in use are not automatically overwritten to avoid headaches to existing users.

fix #1762
fix #1330