### PR TITLE
Optimize card move between main/side in deck editor

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -823,7 +823,7 @@ void TabDeckEditor::actSwapCard()
 
     QModelIndex newCardIndex = deckModel->addCard(cardName, otherZoneName);
     recursiveExpand(newCardIndex);
-    deckView->setCurrentIndex(newCardIndex);
+
     setModified(true);
 }
 


### PR DESCRIPTION
When a card is moved between main and side in the deck editor using the "S" shortcut key, change the currently selected card "following" its movement only if it's the last copy of that card in that zone.

To explain it a bit simpler, if you have 4 copies of the same card in the "main" zone, pressing S will move a card to the "side" but keep the selection on the 3 cards that are still in the "main" zone.
Only when the last card is moved to the "side" zone, the selection will follow the card into the new zone.
 
fix #2129