### PR TITLE
add mtg.tetrarch.co server

### DIFF
--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -26,6 +26,7 @@ DlgConnect::DlgConnect(QWidget *parent)
         previousHostList << "cockatrice.woogerworks.com";
         previousHostList << "vps.poixen.com";
         previousHostList << "chickatrice.net";
+        previousHostList << "mtg.tetrarch.co";
     }
     previousHosts->addItems(previousHostList);
     previousHosts->setCurrentIndex(settingsCache->servers().getPrevioushostindex());


### PR DESCRIPTION
Added `mtg.tetrarch.co` server hosted by @skwerlman to the in-client default list

This deals with Nr.2 in https://github.com/Cockatrice/Cockatrice/issues/2173


I can see this staying around for while to checkout how things develop (and finally don't forget about adding a new stable server to the list). ;)