### PR TITLE
fix google tests

### DIFF
--- a/cmake/gtest-CMakeLists.txt.in
+++ b/cmake/gtest-CMakeLists.txt.in
@@ -4,8 +4,8 @@ project(gtest-download LANGUAGES NONE)
 
 include(ExternalProject)
 ExternalProject_Add(googletest
-  URL https://googletest.googlecode.com/files/gtest-1.7.0.zip
-  URL_HASH SHA1=f85f6d2481e2c6c4a18539e391aa4ea8ab0394af
+  URL https://github.com/google/googletest/archive/release-1.7.0.zip
+  URL_HASH SHA1=f89bc9f55477df2fde082481e2d709bfafdb057b
   SOURCE_DIR "${CMAKE_BINARY_DIR}/gtest-src"
   BINARY_DIR "${CMAKE_BINARY_DIR}/gtest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Google test moved from googlecode to github, and we're hardlinking to the zip file on the old location. This causes travis failures.
Fix linking to the same archive on the new location.

