### PR TITLE
Pending mtgjson/gatherer Æ-->Ae conversion

### DIFF
--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -578,7 +578,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
         rx.setPattern("’");
         cardName.replace(rx, "'");
         rx.setPattern("Æ");
-        cardName.replace(rx, "AE");
+        cardName.replace(rx, "Ae");
         rx.setPattern("\\s*[|/]{1,2}\\s*");
         cardName.replace(rx, " // ");
 


### PR DESCRIPTION
This is to prepare for when mtgjson converts all Æ cards to 'Ae'.  Formerly it was 'AE'.

I believe this portion of the code deals with the deck importer.  If a file to be imported and converted (read: not .cod) via clipboard or plaintext file has an Æ symbol in it, currently that is coverted to `AE` when they card is added to your Cockatrice deck editor list.  This will switch it to an `Ae` conversion if mtgjson moves forward with such a revision.

Do not merge until mtgjson updates to use `Ae` instead of `AE`