### PR TITLE
removed tr() for URLs

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -546,8 +546,8 @@ void TabDeckEditor::retranslateUi()
     aPrintDeck->setText(tr("&Print deck..."));
 
     analyzeDeckMenu->setTitle(tr("&Analyze deck online"));
-    aAnalyzeDeckDeckstats->setText(tr("deckstats.net"));
-    aAnalyzeDeckTappedout->setText(tr("tappedout.net"));
+    aAnalyzeDeckDeckstats->setText("deckstats.net");
+    aAnalyzeDeckTappedout->setText("tappedout.net");
 
     aClose->setText(tr("&Close"));
     


### PR DESCRIPTION
No translation needed for URL names.
Less strings for translators and less chance for errors. 👍 