### PR TITLE
Prevent login error handler being incorrectly called

### DIFF
--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -152,7 +152,7 @@ void RemoteClient::loginResponse(const Response &response)
         if (resp.missing_features_size() > 0 && settingsCache->getNotifyAboutUpdates())
                 emit notifyUserAboutUpdate();
 
-    } else {
+    } else if (response.response_code() != Response::RespNotConnected) {
         QList<QString> missingFeatures;
         if (resp.missing_features_size() > 0) {
             for (int i = 0; i < resp.missing_features_size(); ++i)


### PR DESCRIPTION
Fix #2176.

In some situations, when the server disconnects the client during a login,
multiple dialogs will be shown. This is undesirable behavior, and hence
`loginError` should only be called when the client is actually connected
(`response.response_code() != Response::RespNotConnected`).