### PR TITLE
Disallow usernames that contain certain words and RegExp

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -404,7 +404,7 @@ QString MainWindow::extractInvalidUsernameMessage(QString & in)
 {
     QString out = tr("Invalid username.") + "<br/>";
     QStringList rules = in.split(QChar('|'));
-    if (rules.size() == 9)
+    if (rules.size() == 7 || rules.size() == 9)
     {
         out += tr("Your username must respect these rules:") + "<ul>";
 
@@ -418,11 +418,14 @@ QString MainWindow::extractInvalidUsernameMessage(QString & in)
 
         out += "<li>" + tr("first character can %1 be a punctuation mark").arg((rules.at(5).toInt() > 0) ? "" : tr("NOT")) + "</li>";
 
-        if (rules.at(7).size() > 0)
-            out += "<li>" + tr("can not contain any of the following words: %1").arg(rules.at(7).toHtmlEscaped()) + "</li>";
+        if (rules.size() == 9)
+        {
+            if (rules.at(7).size() > 0)
+                out += "<li>" + tr("can not contain any of the following words: %1").arg(rules.at(7).toHtmlEscaped()) + "</li>";
 
-        if (rules.at(8).size() > 0)
-            out += "<li>" + tr("can not match any of the following expressions: %1").arg(rules.at(8).toHtmlEscaped()) + "</li>";
+            if (rules.at(8).size() > 0)
+                out += "<li>" + tr("can not match any of the following expressions: %1").arg(rules.at(8).toHtmlEscaped()) + "</li>";
+        }
 
         out += "</ul>";
     }

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -407,11 +407,11 @@ QString MainWindow::extractInvalidUsernameMessage(QString & in)
 
         out += "<li>" + tr("first character can %1 be a punctuation mark").arg((rules.at(5).toInt() > 0) ? "" : tr("NOT")) + "</li>";
 
-		if (rules.at(7).size() > 0)
-			out += "<li>" + tr("can not contain any of the following words: %1").arg(rules.at(7).toHtmlEscaped()) + "</li>";
+        if (rules.at(7).size() > 0)
+            out += "<li>" + tr("can not contain any of the following words: %1").arg(rules.at(7).toHtmlEscaped()) + "</li>";
 
-		if (rules.at(8).size() > 0)
-			out += "<li>" + tr("can not match any of the following expressions: %1").arg(rules.at(8).toHtmlEscaped()) + "</li>";
+        if (rules.at(8).size() > 0)
+            out += "<li>" + tr("can not match any of the following expressions: %1").arg(rules.at(8).toHtmlEscaped()) + "</li>";
 
         out += "</ul>";
     }

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -393,7 +393,7 @@ QString MainWindow::extractInvalidUsernameMessage(QString & in)
 {
     QString out = tr("Invalid username.") + "<br/>";
     QStringList rules = in.split(QChar('|'));
-    if (rules.size() == 8)
+    if (rules.size() == 9)
     {
         out += tr("Your username must respect these rules:") + "<ul>";
 
@@ -409,6 +409,9 @@ QString MainWindow::extractInvalidUsernameMessage(QString & in)
 
 		if (rules.at(7).size() > 0)
 			out += "<li>" + tr("can not contain any of the following words: %1").arg(rules.at(7).toHtmlEscaped()) + "</li>";
+
+		if (rules.at(8).size() > 0)
+			out += "<li>" + tr("can not match any of the following expressions: %1").arg(rules.at(8).toHtmlEscaped()) + "</li>";
 
         out += "</ul>";
     }

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -393,9 +393,9 @@ QString MainWindow::extractInvalidUsernameMessage(QString & in)
 {
     QString out = tr("Invalid username.") + "<br/>";
     QStringList rules = in.split(QChar('|'));
-    if (rules.size() == 7)
+    if (rules.size() == 8)
     {
-        out += tr("Your username must respect these rules:") + "<br><ul>";
+        out += tr("Your username must respect these rules:") + "<ul>";
 
         out += "<li>" + tr("is %1 - %2 characters long").arg(rules.at(0)).arg(rules.at(1)) + "</li>";
         out += "<li>" + tr("can %1 contain lowercase characters").arg((rules.at(2).toInt() > 0) ? "" : tr("NOT")) + "</li>";
@@ -406,6 +406,10 @@ QString MainWindow::extractInvalidUsernameMessage(QString & in)
             out += "<li>" + tr("can contain the following punctuation: %1").arg(rules.at(6).toHtmlEscaped()) + "</li>";
 
         out += "<li>" + tr("first character can %1 be a punctuation mark").arg((rules.at(5).toInt() > 0) ? "" : tr("NOT")) + "</li>";
+
+		if (rules.at(7).size() > 0)
+			out += "<li>" + tr("can not contain any of the following words: %1").arg(rules.at(7).toHtmlEscaped()) + "</li>";
+
         out += "</ul>";
     }
     else
@@ -516,7 +520,7 @@ void MainWindow::retranslateUi()
     dbMenu->setTitle(tr("C&ard Database"));
     aOpenCustomFolder->setText(tr("Open custom image folder"));
     aOpenCustomsetsFolder->setText(tr("Open custom sets folder"));
-    aAddCustomSet->setText(tr("Add custom sets/cards"));    
+    aAddCustomSet->setText(tr("Add custom sets/cards"));
     aEditSets->setText(tr("&Edit sets..."));
     aEditTokens->setText(tr("Edit &tokens..."));
 

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -107,6 +107,9 @@ allowedpunctuation=_.-
 ; If a username can begin with punctuation defined in allowedpunctuation
 allowpunctuationprefix=false
 
+; Disallow usernames containing these words
+disallowedwords="admin,administrator"
+
 [registration]
 
 ; Servatrice can process registration requests to add new users on the fly.

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -107,8 +107,8 @@ allowedpunctuation=_.-
 ; If a username can begin with punctuation defined in allowedpunctuation
 allowpunctuationprefix=false
 
-; Disallow usernames containing these words
-disallowedwords="admin,administrator"
+; Disallow usernames containing these words. This list is comma seperated
+disallowedwords="admin"
 
 [registration]
 

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -110,6 +110,11 @@ allowpunctuationprefix=false
 ; Disallow usernames containing these words. This list is comma seperated
 disallowedwords="admin"
 
+; Disallow usernames matching these regular expressions. This list is comma
+; separated, hence you cannot use commas in your expressions. Backslashes must
+; be escaped, so `\w+\d+` becomes `\\w+\\d+`
+disallowedregexp=""
+
 [registration]
 
 ; Servatrice can process registration requests to add new users on the fly.

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -107,12 +107,16 @@ allowedpunctuation=_.-
 ; If a username can begin with punctuation defined in allowedpunctuation
 allowpunctuationprefix=false
 
-; Disallow usernames containing these words. This list is comma seperated
+; Disallow usernames containing these words. This list is comma seperated, e.g.
+; "admin,user,name"
 disallowedwords="admin"
 
 ; Disallow usernames matching these regular expressions. This list is comma
-; separated, hence you cannot use commas in your expressions. Backslashes must
-; be escaped, so `\w+\d+` becomes `\\w+\\d+`
+; separated, e.g. "\\w+\\d+,\\d{2}user", hence you cannot use commas in your
+; expressions. Backslashes must be escaped, so `\w+\d+` becomes `\\w+\\d+`.
+; WARNING: Complex expressions can be harmful to performance. Please make sure
+;          your expressions are considered well formed. See this page for info:
+;          http://www.regular-expressions.info/catastrophic.html
 disallowedregexp=""
 
 [registration]

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -132,6 +132,9 @@ bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user, QString 
     bool allowNumerics = settingsCache->value("users/allownumerics", true).toBool();
     bool allowPunctuationPrefix = settingsCache->value("users/allowpunctuationprefix", false).toBool();
     QString allowedPunctuation = settingsCache->value("users/allowedpunctuation", "_").toString();
+    QStringList disallowedWords = settingsCache->value("users/disallowedwords", "").toString().split(",", QString::SkipEmptyParts);
+    disallowedWords.removeDuplicates();
+
     error = QString("%1|%2|%3|%4|%5|%6|%7").arg(minNameLength).arg(maxNameLength).arg(allowLowercase).arg(allowUppercase).arg(allowNumerics).arg(allowPunctuationPrefix).arg(allowedPunctuation);
 
     if (user.length() < minNameLength || user.length() > maxNameLength)
@@ -139,6 +142,10 @@ bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user, QString 
 
     if (!allowPunctuationPrefix && allowedPunctuation.contains(user.at(0)))
         return false;
+
+    for (const QString &word : disallowedWords) {
+        if (user.contains(word, Qt::CaseInsensitive)) return false;
+    }
 
     QString regEx("[");
     if (allowLowercase)

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -132,10 +132,12 @@ bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user, QString 
     bool allowNumerics = settingsCache->value("users/allownumerics", true).toBool();
     bool allowPunctuationPrefix = settingsCache->value("users/allowpunctuationprefix", false).toBool();
     QString allowedPunctuation = settingsCache->value("users/allowedpunctuation", "_").toString();
-    QStringList disallowedWords = settingsCache->value("users/disallowedwords", "").toString().split(",", QString::SkipEmptyParts);
+	QString disallowedWordsStr = settingsCache->value("users/disallowedwords", "").toString();
+    QStringList disallowedWords = disallowedWordsStr.split(",", QString::SkipEmptyParts);
     disallowedWords.removeDuplicates();
+	QString disallowedRegExpStr = settingsCache->value("users/disallowedregexp", "").toString();
 
-    error = QString("%1|%2|%3|%4|%5|%6|%7|%8|%9").arg(minNameLength).arg(maxNameLength).arg(allowLowercase).arg(allowUppercase).arg(allowNumerics).arg(allowPunctuationPrefix).arg(allowedPunctuation).arg(settingsCache->value("users/disallowedwords", "").toString()).arg(settingsCache->value("users/disallowedregexp", "").toString());
+    error = QString("%1|%2|%3|%4|%5|%6|%7|%8|%9").arg(minNameLength).arg(maxNameLength).arg(allowLowercase).arg(allowUppercase).arg(allowNumerics).arg(allowPunctuationPrefix).arg(allowedPunctuation).arg(disallowedWordsStr).arg(disallowedRegExpStr);
 
     if (user.length() < minNameLength || user.length() > maxNameLength)
         return false;

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -132,10 +132,10 @@ bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user, QString 
     bool allowNumerics = settingsCache->value("users/allownumerics", true).toBool();
     bool allowPunctuationPrefix = settingsCache->value("users/allowpunctuationprefix", false).toBool();
     QString allowedPunctuation = settingsCache->value("users/allowedpunctuation", "_").toString();
-	QString disallowedWordsStr = settingsCache->value("users/disallowedwords", "").toString();
+    QString disallowedWordsStr = settingsCache->value("users/disallowedwords", "").toString();
     QStringList disallowedWords = disallowedWordsStr.split(",", QString::SkipEmptyParts);
     disallowedWords.removeDuplicates();
-	QString disallowedRegExpStr = settingsCache->value("users/disallowedregexp", "").toString();
+    QString disallowedRegExpStr = settingsCache->value("users/disallowedregexp", "").toString();
 
     error = QString("%1|%2|%3|%4|%5|%6|%7|%8|%9").arg(minNameLength).arg(maxNameLength).arg(allowLowercase).arg(allowUppercase).arg(allowNumerics).arg(allowPunctuationPrefix).arg(allowedPunctuation).arg(disallowedWordsStr).arg(disallowedRegExpStr);
 

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -137,7 +137,7 @@ bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user, QString 
     QStringList disallowedRegExp = settingsCache->value("users/disallowedregexp", "").toString().split(",", QString::SkipEmptyParts);
     disallowedRegExp.removeDuplicates();
 
-    error = QString("%1|%2|%3|%4|%5|%6|%7|%8").arg(minNameLength).arg(maxNameLength).arg(allowLowercase).arg(allowUppercase).arg(allowNumerics).arg(allowPunctuationPrefix).arg(allowedPunctuation).arg(disallowedWords.join(","));
+    error = QString("%1|%2|%3|%4|%5|%6|%7|%8|%9").arg(minNameLength).arg(maxNameLength).arg(allowLowercase).arg(allowUppercase).arg(allowNumerics).arg(allowPunctuationPrefix).arg(allowedPunctuation).arg(disallowedWords.join(",")).arg(disallowedRegExp.join(","));
 
     if (user.length() < minNameLength || user.length() > maxNameLength)
         return false;

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -134,6 +134,8 @@ bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user, QString 
     QString allowedPunctuation = settingsCache->value("users/allowedpunctuation", "_").toString();
     QStringList disallowedWords = settingsCache->value("users/disallowedwords", "").toString().split(",", QString::SkipEmptyParts);
     disallowedWords.removeDuplicates();
+    QStringList disallowedRegExp = settingsCache->value("users/disallowedregexp", "").toString().split(",", QString::SkipEmptyParts);
+    disallowedRegExp.removeDuplicates();
 
     error = QString("%1|%2|%3|%4|%5|%6|%7|%8").arg(minNameLength).arg(maxNameLength).arg(allowLowercase).arg(allowUppercase).arg(allowNumerics).arg(allowPunctuationPrefix).arg(allowedPunctuation).arg(disallowedWords.join(","));
 
@@ -145,6 +147,10 @@ bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user, QString 
 
     for (const QString &word : disallowedWords) {
         if (user.contains(word, Qt::CaseInsensitive)) return false;
+    }
+
+    for (const QString &regExp : disallowedRegExp) {
+        if (QRegExp(regExp).exactMatch(user)) return false;
     }
 
     QString regEx("[");

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -134,10 +134,8 @@ bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user, QString 
     QString allowedPunctuation = settingsCache->value("users/allowedpunctuation", "_").toString();
     QStringList disallowedWords = settingsCache->value("users/disallowedwords", "").toString().split(",", QString::SkipEmptyParts);
     disallowedWords.removeDuplicates();
-    QStringList disallowedRegExp = settingsCache->value("users/disallowedregexp", "").toString().split(",", QString::SkipEmptyParts);
-    disallowedRegExp.removeDuplicates();
 
-    error = QString("%1|%2|%3|%4|%5|%6|%7|%8|%9").arg(minNameLength).arg(maxNameLength).arg(allowLowercase).arg(allowUppercase).arg(allowNumerics).arg(allowPunctuationPrefix).arg(allowedPunctuation).arg(disallowedWords.join(",")).arg(disallowedRegExp.join(","));
+    error = QString("%1|%2|%3|%4|%5|%6|%7|%8|%9").arg(minNameLength).arg(maxNameLength).arg(allowLowercase).arg(allowUppercase).arg(allowNumerics).arg(allowPunctuationPrefix).arg(allowedPunctuation).arg(settingsCache->value("users/disallowedwords", "").toString()).arg(settingsCache->value("users/disallowedregexp", "").toString());
 
     if (user.length() < minNameLength || user.length() > maxNameLength)
         return false;
@@ -149,8 +147,8 @@ bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user, QString 
         if (user.contains(word, Qt::CaseInsensitive)) return false;
     }
 
-    for (const QString &regExp : disallowedRegExp) {
-        if (QRegExp(regExp).exactMatch(user)) return false;
+    for (const QRegExp &regExp : settingsCache->disallowedRegExp) {
+        if (regExp.exactMatch(user)) return false;
     }
 
     QString regEx("[");

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -135,7 +135,7 @@ bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user, QString 
     QStringList disallowedWords = settingsCache->value("users/disallowedwords", "").toString().split(",", QString::SkipEmptyParts);
     disallowedWords.removeDuplicates();
 
-    error = QString("%1|%2|%3|%4|%5|%6|%7").arg(minNameLength).arg(maxNameLength).arg(allowLowercase).arg(allowUppercase).arg(allowNumerics).arg(allowPunctuationPrefix).arg(allowedPunctuation);
+    error = QString("%1|%2|%3|%4|%5|%6|%7|%8").arg(minNameLength).arg(maxNameLength).arg(allowLowercase).arg(allowUppercase).arg(allowNumerics).arg(allowPunctuationPrefix).arg(allowedPunctuation).arg(disallowedWords.join(","));
 
     if (user.length() < minNameLength || user.length() > maxNameLength)
         return false;

--- a/servatrice/src/settingscache.cpp
+++ b/servatrice/src/settingscache.cpp
@@ -4,14 +4,18 @@
 #include <QStandardPaths>
 
 SettingsCache::SettingsCache(const QString & fileName, QSettings::Format format, QObject * parent)
-:QSettings(fileName, format, parent)
+    :QSettings(fileName, format, parent)
 {
-
+    QStringList disallowedRegExpStr = value("users/disallowedregexp", "").toString().split(",", QString::SkipEmptyParts);
+    disallowedRegExpStr.removeDuplicates();
+    for (const QString &regExpStr : disallowedRegExpStr) {
+        disallowedRegExp.append(QRegExp(regExpStr));
+    }
 }
 
 QString SettingsCache::guessConfigurationPath(QString & specificPath)
 {
-    const QString fileName="servatrice.ini";    
+    const QString fileName="servatrice.ini";
     #ifdef PORTABLE_BUILD
     return fileName;
     #endif

--- a/servatrice/src/settingscache.h
+++ b/servatrice/src/settingscache.h
@@ -3,6 +3,8 @@
 
 #include <QSettings>
 #include <QString>
+#include <QList>
+#include <QRegExp>
 
 class SettingsCache : public QSettings {
     Q_OBJECT
@@ -11,6 +13,7 @@ private:
 public:
     SettingsCache(const QString & fileName="servatrice.ini", QSettings::Format format=QSettings::IniFormat, QObject * parent = 0);
     static QString guessConfigurationPath(QString & specificPath);
+    QList<QRegExp> disallowedRegExp;
 };
 
 extern SettingsCache *settingsCache;


### PR DESCRIPTION
Fix #2135.

Check if any of the words in `disallowedwords` are contained in the username. If
so, return false like other checks.

NOTE: Needs testing.