### PR TITLE
[WIP] Add donator recognition

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -382,6 +382,9 @@ void MainWindow::loginError(Response::ResponseCode r, QString reasonStr, quint32
         case Response::RespContextError:
             QMessageBox::critical(this, tr("Error"), tr("An internal error has occurred, please try closing and reopening your client and try again. If the error persists try updating your client to the most recent build and if need be contact your software provider."));
             break;
+        case Response::RespUserLimitReached:
+            QMessageBox::critical(this, tr("Server Full"), tr("The server has reached its maximum user capacity, please check back later."));
+            break;
         case Response::RespAccountNotActivated: {
             bool ok = false;
             QString token = QInputDialog::getText(this, tr("Account activation"), tr("Your account has not been activated yet.\nYou need to provide the activation token received in the activation email"), QLineEdit::Normal, QString(), &ok);

--- a/common/featureset.cpp
+++ b/common/featureset.cpp
@@ -21,6 +21,7 @@ void FeatureSet::initalizeFeatureList(QMap<QString, bool> &featureList) {
     featureList.insert("client_warnings", false);
     featureList.insert("mod_log_lookup", false);
     featureList.insert("client_inactivetimeout", false);
+    featureList.insert("donator_recognition", false);
 }
 
 void FeatureSet::enableRequiredFeature(QMap<QString, bool> &featureList, QString featureName){

--- a/common/pb/response.proto
+++ b/common/pb/response.proto
@@ -37,6 +37,7 @@ message Response {
         RespRegistrationAcceptedNeedsActivation = 33; // Server accepted cient registration, but it will need token activation
         RespClientIdRequired = 34; // Server requires client to generate and send its client id before allowing access
         RespClientUpdateRequired = 35; // Client is missing features that the server is requiring
+        RespUserLimitReached = 36; // Server has a user limit and it has been reached
     }
     enum ResponseType {
         JOIN_ROOM = 1000;

--- a/common/server.h
+++ b/common/server.h
@@ -31,7 +31,7 @@ class GameEventContainer;
 class CommandContainer;
 class Command_JoinGame;
 
-enum AuthenticationResult { NotLoggedIn, PasswordRight, UnknownUser, WouldOverwriteOldSession, UserIsBanned, UsernameInvalid, RegistrationRequired, UserIsInactive, ClientIdRequired };
+enum AuthenticationResult { NotLoggedIn, PasswordRight, UnknownUser, WouldOverwriteOldSession, UserIsBanned, UsernameInvalid, RegistrationRequired, UserIsInactive, ClientIdRequired, UserLimitReached };
 
 class Server : public QObject
 {
@@ -62,6 +62,8 @@ public:
     virtual bool getGameShouldPing() const { return false; }
     virtual bool getClientIdRequired() const { return false; }
     virtual bool getRegOnlyServer() const { return false; }
+    virtual bool getMaxUserLimitEnabled() const { return false; }
+    virtual int getMaxUsers() const { return 0; }
     virtual int getPingClockInterval() const { return 0; }
     virtual int getMaxGameInactivityTime() const { return 9999999; }
     virtual int getMaxPlayerInactivityTime() const { return 9999999; }

--- a/common/server_database_interface.h
+++ b/common/server_database_interface.h
@@ -9,7 +9,7 @@ class Server_DatabaseInterface : public QObject {
 public:
     Server_DatabaseInterface(QObject *parent = 0)
         : QObject(parent) { }
-    
+
     virtual AuthenticationResult checkUserPassword(Server_ProtocolHandler *handler, const QString &user, const QString &password, const QString &clientId, QString &reasonStr, int &secondsLeft) = 0;
     virtual bool checkUserIsBanned(const QString & /* ipAddress */, const QString & /* userName */, const QString & /* clientId */, QString & /* banReason */, int & /* banSecondsRemaining */) { return false; }
     virtual bool activeUserExists(const QString & /* user */) { return false; }
@@ -21,9 +21,10 @@ public:
     virtual ServerInfo_User getUserData(const QString &name, bool withId = false) = 0;
     virtual void storeGameInformation(const QString & /* roomName */, const QStringList & /* roomGameTypes */, const ServerInfo_Game & /* gameInfo */, const QSet<QString> & /* allPlayersEver */, const QSet<QString> & /* allSpectatorsEver */, const QList<GameReplay *> & /* replayList */) { }
     virtual DeckList *getDeckFromDatabase(int /* deckId */, int /* userId */) { return 0; }
-    
+
     virtual qint64 startSession(const QString & /* userName */, const QString & /* address */, const QString & /* clientId */, const QString & /* connectionType */) { return 0; }
     virtual bool usernameIsValid(const QString & /*userName */, QString & /* error */) { return true; };
+    virtual bool isUserADonator(const QString & /* user */) { return false; };
 public slots:
     virtual void endSession(qint64 /* sessionId */ ) { }
 public:

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -436,6 +436,7 @@ Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd
         case RegistrationRequired: return Response::RespRegistrationRequired;
         case ClientIdRequired: return Response::RespClientIdRequired;
         case UserIsInactive: return Response::RespAccountNotActivated;
+        case UserLimitReached: return Response::RespUserLimitReached;
         default: authState = res;
     }
 

--- a/servatrice/migrations/servatrice_0017_to_0018.sql
+++ b/servatrice/migrations/servatrice_0017_to_0018.sql
@@ -1,0 +1,5 @@
+-- Servatrice db migration from version 17 to version 18
+
+alter table cockatrice_users add `donator` tinyint(1) not null default 0;
+
+UPDATE cockatrice_schema_version SET version=18 WHERE version=17;

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_schema_version` (
   PRIMARY KEY  (`version`)
 ) ENGINE=INNODB DEFAULT CHARSET=utf8;
 
-INSERT INTO cockatrice_schema_version VALUES(17);
+INSERT INTO cockatrice_schema_version VALUES(18);
 
 -- users and user data tables
 CREATE TABLE IF NOT EXISTS `cockatrice_users` (
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_users` (
   `active` tinyint(1) NOT NULL,
   `token` binary(16),
   `clientid` varchar(15) NOT NULL,
+  `donator` tinyint(1) NOT NULL default 0,
   PRIMARY KEY  (`id`),
   UNIQUE KEY `name` (`name`),
   KEY `token` (`token`),

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -234,11 +234,11 @@ bool Servatrice::initServer()
 
     qDebug() << "Store Replays: " << settingsCache->value("game/store_replays", true).toBool();
     qDebug() << "Client ID Required: " << clientIdRequired;
-    bool maxUserLimitEnabled = settingsCache->value("security/enable_max_user_limit", false).toBool();
+    maxUserLimitEnabled = settingsCache->value("security/enable_max_user_limit", false).toBool();
     qDebug() << "Maximum user limit enabled: " << maxUserLimitEnabled;
 
     if (maxUserLimitEnabled){
-        int maxUserLimit = settingsCache->value("security/max_users_total", 500).toInt();
+        maxUserLimit = settingsCache->value("security/max_users_total", 500).toInt();
         qDebug() << "Maximum total user limit: " << maxUserLimit;
         int maxTcpUserLimit = settingsCache->value("security/max_users_tcp", 500).toInt();
         qDebug() << "Maximum tcp user limit: " << maxTcpUserLimit;

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -135,13 +135,13 @@ private:
     QMutex txBytesMutex, rxBytesMutex;
     quint64 txBytes, rxBytes;
     int maxGameInactivityTime, maxPlayerInactivityTime;
-    int maxUsersPerAddress, messageCountingInterval, maxMessageCountPerInterval, maxMessageSizePerInterval, maxGamesPerUser, commandCountingInterval, maxCommandCountPerInterval, pingClockInterval;
+    int maxUserLimit, maxUsersPerAddress, messageCountingInterval, maxMessageCountPerInterval, maxMessageSizePerInterval, maxGamesPerUser, commandCountingInterval, maxCommandCountPerInterval, pingClockInterval;
 
     QString shutdownReason;
     int shutdownMinutes;
     int nextShutdownMessageMinutes;
     QTimer *shutdownTimer;
-    bool isFirstShutdownMessage, clientIdRequired, regServerOnly;
+    bool isFirstShutdownMessage, clientIdRequired, regServerOnly, maxUserLimitEnabled;
 
     mutable QMutex serverListMutex;
     QList<ServerProperties> serverList;
@@ -164,10 +164,12 @@ public:
     bool getGameShouldPing() const { return true; }
     bool getClientIdRequired() const { return clientIdRequired; }
     bool getRegOnlyServer() const { return regServerOnly; }
+    bool getMaxUserLimitEnabled() const { return maxUserLimitEnabled; }
     int getPingClockInterval() const { return pingClockInterval; }
     int getMaxGameInactivityTime() const { return maxGameInactivityTime; }
     int getMaxPlayerInactivityTime() const { return maxPlayerInactivityTime; }
     int getMaxUsersPerAddress() const { return maxUsersPerAddress; }
+    int getMaxUsers() const { return maxUserLimit; }
     int getMessageCountingInterval() const { return messageCountingInterval; }
     int getMaxMessageCountPerInterval() const { return maxMessageCountPerInterval; }
     int getMaxMessageSizePerInterval() const { return maxMessageSizePerInterval; }

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -1091,3 +1091,23 @@ QList<ServerInfo_ChatMessage> Servatrice_DatabaseInterface::getMessageLogHistory
 
     return results;
 }
+
+bool Servatrice_DatabaseInterface::isUserADonator(const QString &user)
+{
+    if (!checkSql())
+        return false;
+    
+    QSqlQuery *query = prepareQuery("SELECT donator from {prefix}_users WHERE name = :user_name");
+    query->bindValue(":user_name", user);
+
+    if (!execSqlQuery(query)) {
+        qDebug("Failed to collect donator information: SQL Error");
+        return false;
+    }
+
+    if (query->next()) {
+        if (query->value(0).toInt() > 0)
+            return true;
+    }
+    return false;
+}

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -9,7 +9,7 @@
 #include "server.h"
 #include "server_database_interface.h"
 
-#define DATABASE_SCHEMA_VERSION 17
+#define DATABASE_SCHEMA_VERSION 18
 
 class Servatrice;
 
@@ -69,7 +69,7 @@ public:
     bool userSessionExists(const QString &userName);
     bool usernameIsValid(const QString &user, QString & error);
     bool checkUserIsBanned(const QString &ipAddress, const QString &userName, const QString &clientId, QString &banReason, int &banSecondsRemaining);
-
+    bool isUserADonator(const QString &user);
     bool registerUser(const QString &userName, const QString &realName, ServerInfo_User_Gender const &gender,
         const QString &password, const QString &emailAddress, const QString &country, QString &token, bool active = false);
     bool activateUser(const QString &userName, const QString &token);

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -93,24 +93,7 @@ bool AbstractServerSocketInterface::initSession()
     SessionEvent *identSe = prepareSessionEvent(identEvent);
     sendProtocolItem(*identSe);
     delete identSe;
-
-    //limit the number of total users based on configuration settings
-    bool enforceUserLimit = settingsCache->value("security/enable_max_user_limit", false).toBool();
-    if (enforceUserLimit){
-        int userLimit = settingsCache->value("security/max_users_total", 500).toInt();
-        int playerCount = (databaseInterface->getActiveUserCount() + 1);
-        if (playerCount > userLimit){
-            std::cerr << "Max Users Total Limit Reached, please increase the max_users_total setting." << std::endl;
-            logger->logMessage(QString("Max Users Total Limit Reached, please increase the max_users_total setting."), this);
-            Event_ConnectionClosed event;
-            event.set_reason(Event_ConnectionClosed::USER_LIMIT_REACHED);
-            SessionEvent *se = prepareSessionEvent(event);
-            sendProtocolItem(*se);
-            delete se;
-            return false;
-        }
-    }
-
+    
     //allow unlimited number of connections from the trusted sources
     QString trustedSources = settingsCache->value("security/trusted_sources","127.0.0.1,::1").toString();
     if (trustedSources.contains(getAddress(),Qt::CaseInsensitive))


### PR DESCRIPTION
Added server side functionality to allow recognition of user accounts
that have donated. If the user is marked as a donator they are granted
server access regardless of maximum user settings.  In doing so I have
moved the max user check out of the server socket interface and moved it
into the protocol handler (were it should live honestly) and also
created a response to the server login request instead of triggering an
event for the server capacity being reached.