### PR TITLE
Show card sets

### DIFF
--- a/cockatrice/src/cardinfotext.cpp
+++ b/cockatrice/src/cardinfotext.cpp
@@ -31,6 +31,8 @@ CardInfoText::CardInfoText(QWidget *parent)
     powtoughLabel2->setTextInteractionFlags(Qt::TextBrowserInteraction);
     loyaltyLabel1 = new QLabel;
     loyaltyLabel2 = new QLabel;
+    setLabel1 = new QLabel;
+    setLabel2 = new QLabel;
     loyaltyLabel1->setTextInteractionFlags(Qt::TextBrowserInteraction);
 
     textLabel = new QTextEdit();
@@ -40,6 +42,8 @@ CardInfoText::CardInfoText(QWidget *parent)
     int row = 0;
     grid->addWidget(nameLabel1, row, 0);
     grid->addWidget(nameLabel2, row++, 1);
+    grid->addWidget(setLabel1, row, 0);
+    grid->addWidget(setLabel2, row++, 1);
     grid->addWidget(manacostLabel1, row, 0);
     grid->addWidget(manacostLabel2, row++, 1);
     grid->addWidget(colorLabel1, row, 0);
@@ -68,6 +72,8 @@ void CardInfoText::setCard(CardInfo *card)
         powtoughLabel2->setText(card->getPowTough());
         loyaltyLabel2->setText(card->getLoyalty() > 0 ? QString::number(card->getLoyalty()) : QString());
         textLabel->setText(card->getText());
+        setLabel2->setText(card->getSetsNames());
+        setLabel2->setWordWrap(true);
     } else {
         nameLabel2->setText("");
         manacostLabel2->setText("");
@@ -76,6 +82,7 @@ void CardInfoText::setCard(CardInfo *card)
         powtoughLabel2->setText("");
         loyaltyLabel2->setText("");
         textLabel->setText("");
+        setLabel2->setText("");
     }
 }
 
@@ -87,4 +94,5 @@ void CardInfoText::retranslateUi()
     cardtypeLabel1->setText(tr("Card type:"));
     powtoughLabel1->setText(tr("P / T:"));
     loyaltyLabel1->setText(tr("Loyalty:"));
+    setLabel1->setText(tr("Sets:"));
 }

--- a/cockatrice/src/cardinfotext.h
+++ b/cockatrice/src/cardinfotext.h
@@ -13,6 +13,7 @@ class CardInfoText : public QFrame {
 private:
     QLabel *nameLabel1, *nameLabel2;
     QLabel *manacostLabel1, *manacostLabel2;
+    QLabel *setLabel1, *setLabel2;
     QLabel *colorLabel1, *colorLabel2;
     QLabel *cardtypeLabel1, *cardtypeLabel2;
     QLabel *powtoughLabel1, *powtoughLabel2;


### PR DESCRIPTION
Fix #2210. 

This PR will show the sets each card is in, according to the import rules from Oracle.

This change appears when you're using the deck editor, when a card is linked in chat via the [[ cardName ]] tag, and in game on the side.

It does slightly cut off some of the cards that have been in tons of sets, but I don't see much of an issue with that (ex: Basic Lands)


<img width="292" alt="screen shot 2016-10-11 at 5 47 33 pm" src="https://cloud.githubusercontent.com/assets/7460172/19289900/f4852126-8fda-11e6-902b-e97d72da67cf.png">
<img width="299" alt="screen shot 2016-10-11 at 5 47 43 pm" src="https://cloud.githubusercontent.com/assets/7460172/19289901/f48c22b4-8fda-11e6-9744-276cd5693611.png">
<img width="710" alt="screen shot 2016-10-11 at 5 47 48 pm" src="https://cloud.githubusercontent.com/assets/7460172/19289902/f48f859e-8fda-11e6-9955-cd9800ca372c.png">
<img width="273" alt="screen shot 2016-10-11 at 5 48 09 pm" src="https://cloud.githubusercontent.com/assets/7460172/19289903/f4929e32-8fda-11e6-8cca-5bca1c53bb49.png">







