### PR TITLE
Added user privilege level

### DIFF
--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -133,14 +133,15 @@ void PictureLoaderWorker::processLoadQueue()
         mutex.unlock();
 
         QString setName = cardBeingLoaded.getSetName();
-        QString correctedCardname = cardBeingLoaded.getCard()->getCorrectedName();
-        qDebug() << "Trying to load picture (set: " << setName << " card: " << correctedCardname << ")";
+        QString cardName = cardBeingLoaded.getCard()->getName();
+        QString correctedCardName = cardBeingLoaded.getCard()->getCorrectedName();
+        qDebug() << "Trying to load picture (set: " << setName << " card: " << cardName << ")";
 
-        if(cardImageExistsOnDisk(setName, correctedCardname))
+        if(cardImageExistsOnDisk(setName, correctedCardName))
             continue;
 
         if (picDownload) {
-            qDebug() << "Picture NOT found, trying to download (set: " << setName << " card: " << correctedCardname << ")";
+            qDebug() << "Picture NOT found, trying to download (set: " << setName << " card: " << cardName << ")";
             cardsToDownload.append(cardBeingLoaded);
             cardBeingLoaded=0;
             if (!downloadRunning)
@@ -148,13 +149,13 @@ void PictureLoaderWorker::processLoadQueue()
         } else {
             if (cardBeingLoaded.nextSet())
             {
-                qDebug() << "Picture NOT found and download disabled, moving to next set (newset: " << setName << " card: " << correctedCardname << ")";
+                qDebug() << "Picture NOT found and download disabled, moving to next set (newset: " << setName << " card: " << cardName << ")";
                 mutex.lock();
                 loadQueue.prepend(cardBeingLoaded);
                 cardBeingLoaded=0;
                 mutex.unlock();
             } else {
-                qDebug() << "Picture NOT found, download disabled, no more sets to try: BAILING OUT (oldset: " << setName << " card: " << correctedCardname << ")";
+                qDebug() << "Picture NOT found, download disabled, no more sets to try: BAILING OUT (oldset: " << setName << " card: " << cardName << ")";
                 imageLoaded(cardBeingLoaded.getCard(), QImage());
             }
         }
@@ -180,13 +181,13 @@ bool PictureLoaderWorker::cardImageExistsOnDisk(QString & setName, QString & cor
     for (int i = 0; i < picsPaths.length(); i ++) {
         imgReader.setFileName(picsPaths.at(i));
         if (imgReader.read(&image)) {
-            qDebug() << "Picture found on disk (set: " << setName << " card: " << correctedCardname << ")";
+            qDebug() << "Picture found on disk (set: " << setName << " file: " << correctedCardname << ")";
             imageLoaded(cardBeingLoaded.getCard(), image);
             return true;
         }
         imgReader.setFileName(picsPaths.at(i) + ".full");
         if (imgReader.read(&image)) {
-            qDebug() << "Picture.full found on disk (set: " << setName << " card: " << correctedCardname << ")";
+            qDebug() << "Picture.full found on disk (set: " << setName << " file: " << correctedCardname << ")";
             imageLoaded(cardBeingLoaded.getCard(), image);
             return true;
         }
@@ -215,8 +216,8 @@ QString PictureLoaderWorker::getPicUrl()
     int muid = set ? card->getMuId(set->getShortName()) : 0;
     picUrl = muid ? settingsCache->getPicUrl() : settingsCache->getPicUrlFallback();
 
-    picUrl.replace("!name!", QUrl::toPercentEncoding(card->getCorrectedName()));
-    picUrl.replace("!name_lower!", QUrl::toPercentEncoding(card->getCorrectedName().toLower()));
+    picUrl.replace("!name!", QUrl::toPercentEncoding(card->getName()));
+    picUrl.replace("!name_lower!", QUrl::toPercentEncoding(card->getName().toLower()));
     picUrl.replace("!cardid!", QUrl::toPercentEncoding(QString::number(muid)));
     if (set)
     {
@@ -277,12 +278,12 @@ void PictureLoaderWorker::picDownloadFailed()
 {
     if (cardBeingDownloaded.nextSet())
     {
-        qDebug() << "Picture NOT found, download failed, moving to next set (newset: " << cardBeingDownloaded.getSetName() << " card: " << cardBeingDownloaded.getCard()->getCorrectedName() << ")";
+        qDebug() << "Picture NOT found, download failed, moving to next set (newset: " << cardBeingDownloaded.getSetName() << " card: " << cardBeingDownloaded.getCard()->getName() << ")";
         mutex.lock();
         loadQueue.prepend(cardBeingDownloaded);
         mutex.unlock();
     } else {
-        qDebug() << "Picture NOT found, download failed, no more sets to try: BAILING OUT (oldset: " << cardBeingDownloaded.getSetName() << " card: " << cardBeingDownloaded.getCard()->getCorrectedName() << ")";
+        qDebug() << "Picture NOT found, download failed, no more sets to try: BAILING OUT (oldset: " << cardBeingDownloaded.getSetName() << " card: " << cardBeingDownloaded.getCard()->getName() << ")";
         imageLoaded(cardBeingDownloaded.getCard(), QImage());
         cardBeingDownloaded = 0;
     }

--- a/common/pb/serverinfo_user.proto
+++ b/common/pb/serverinfo_user.proto
@@ -24,4 +24,5 @@ message ServerInfo_User {
     optional uint64 accountage_secs = 11;
     optional string email = 12;
     optional string clientid = 13;
+    optional string privlevel = 14;
 }

--- a/common/server.h
+++ b/common/server.h
@@ -62,7 +62,7 @@ public:
     virtual bool getGameShouldPing() const { return false; }
     virtual bool getClientIdRequired() const { return false; }
     virtual bool getRegOnlyServer() const { return false; }
-    virtual bool getmaxUserLimitEnabled() const { return false; }
+    virtual bool getMaxUserLimitEnabled() const { return false; }
     virtual int getPingClockInterval() const { return 0; }
     virtual int getMaxGameInactivityTime() const { return 9999999; }
     virtual int getMaxPlayerInactivityTime() const { return 9999999; }

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -383,14 +383,7 @@ Response::ResponseCode Server_ProtocolHandler::cmdPing(const Command_Ping & /*cm
 
 Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd, ResponseContainer &rc)
 {
-    // limit the number of users that can connect to the server based on configuration settings
-    if (server->getMaxUserLimitEnabled()) {
-        if (server->getUsersCount() >= server->getMaxUserLimit()) {
-            qDebug() << "Max Users Total Limit Reached, please increase the max_users_total setting.";
-            return Response::RespServerFull;
-        }
-    }
-
+    
     QString userName = QString::fromStdString(cmd.user_name()).simplified();
     QString clientId = QString::fromStdString(cmd.clientid()).simplified();
     QString clientVersion = QString::fromStdString(cmd.clientver()).simplified();
@@ -445,6 +438,16 @@ Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd
         case ClientIdRequired: return Response::RespClientIdRequired;
         case UserIsInactive: return Response::RespAccountNotActivated;
         default: authState = res;
+    }
+
+    // limit the number of non-privileged users that can connect to the server based on configuration settings
+    if (QString::fromStdString(userInfo->privlevel()).toLower() == "none") {
+        if (server->getmaxUserLimitEnabled()) {
+            if (server->getUsersCount() > server->getMaxUserLimit()) {
+                qDebug() << "Max Users Total Limit Reached, please increase the max_users_total setting.";
+                return Response::RespServerFull;
+            }
+        }
     }
 
     userName = QString::fromStdString(userInfo->name());

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -442,7 +442,7 @@ Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd
 
     // limit the number of non-privileged users that can connect to the server based on configuration settings
     if (QString::fromStdString(userInfo->privlevel()).toLower() == "none") {
-        if (server->getMaxUserLimitEnabled()) {
+        if (server->getmaxUserLimitEnabled()) {
             if (server->getUsersCount() > server->getMaxUserLimit()) {
                 qDebug() << "Max Users Total Limit Reached, please increase the max_users_total setting.";
                 return Response::RespServerFull;

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -384,7 +384,7 @@ Response::ResponseCode Server_ProtocolHandler::cmdPing(const Command_Ping & /*cm
 Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd, ResponseContainer &rc)
 {
     // limit the number of users that can connect to the server based on configuration settings
-    if (server->getmaxUserLimitEnabled()) {
+    if (server->getMaxUserLimitEnabled()) {
         if (server->getUsersCount() >= server->getMaxUserLimit()) {
             qDebug() << "Max Users Total Limit Reached, please increase the max_users_total setting.";
             return Response::RespServerFull;

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -442,7 +442,7 @@ Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd
 
     // limit the number of non-privileged users that can connect to the server based on configuration settings
     if (QString::fromStdString(userInfo->privlevel()).toLower() == "none") {
-        if (server->getmaxUserLimitEnabled()) {
+        if (server->getMaxUserLimitEnabled()) {
             if (server->getUsersCount() > server->getMaxUserLimit()) {
                 qDebug() << "Max Users Total Limit Reached, please increase the max_users_total setting.";
                 return Response::RespServerFull;

--- a/servatrice/migrations/servatrice_0017_to_0018.sql
+++ b/servatrice/migrations/servatrice_0017_to_0018.sql
@@ -1,0 +1,5 @@
+-- Servatrice db migration from version 16 to version 18
+
+alter table cockatrice_users add privlevel enum("NONE","VIP","DONATOR") NOT NULL;
+
+UPDATE cockatrice_schema_version SET version=18 WHERE version=17;

--- a/servatrice/migrations/servatrice_0017_to_0018.sql
+++ b/servatrice/migrations/servatrice_0017_to_0018.sql
@@ -1,4 +1,4 @@
--- Servatrice db migration from version 16 to version 18
+-- Servatrice db migration from version 17 to version 18
 
 alter table cockatrice_users add privlevel enum("NONE","VIP","DONATOR") NOT NULL;
 

--- a/servatrice/migrations/servatrice_0017_to_0018.sql
+++ b/servatrice/migrations/servatrice_0017_to_0018.sql
@@ -1,5 +1,5 @@
 -- Servatrice db migration from version 17 to version 18
 
-alter table cockatrice_users add privlevel enum("NONE","VIP","DONATOR") NOT NULL;
+alter table cockatrice_users add column privlevel enum("NONE","VIP","DONATOR") NOT NULL;
 
 UPDATE cockatrice_schema_version SET version=18 WHERE version=17;

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -39,6 +39,8 @@ writelog=1
 
 ; Choose a name for the log file, if enabled; you can specify an absolute path or a path relative to
 ; the servatrice executable; the default file name is server.log (in the same path as servatrice)
+; Note: When running servatrice under windows you will need to use double backslashes between folder locations
+; [ex: C:\\Temp\\server.log ]
 logfile=server.log
 
 ; You may want to silence some commonly recurring messages in the logfile. This setting can contain a

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_schema_version` (
   PRIMARY KEY  (`version`)
 ) ENGINE=INNODB DEFAULT CHARSET=utf8;
 
-INSERT INTO cockatrice_schema_version VALUES(17);
+INSERT INTO cockatrice_schema_version VALUES(18);
 
 -- users and user data tables
 CREATE TABLE IF NOT EXISTS `cockatrice_users` (
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_users` (
   `active` tinyint(1) NOT NULL,
   `token` binary(16),
   `clientid` varchar(15) NOT NULL,
+  `privlevel` enum("NONE","VIP","DONATOR") NOT NULL,
   PRIMARY KEY  (`id`),
   UNIQUE KEY `name` (`name`),
   KEY `token` (`token`),

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -234,11 +234,11 @@ bool Servatrice::initServer()
 
     qDebug() << "Store Replays: " << settingsCache->value("game/store_replays", true).toBool();
     qDebug() << "Client ID Required: " << clientIdRequired;
-    maxUserLimitEnabled = settingsCache->value("security/enable_max_user_limit", false).toBool();
+    bool maxUserLimitEnabled = getMaxUserLimitEnabled();
     qDebug() << "Maximum user limit enabled: " << maxUserLimitEnabled;
 
     if (maxUserLimitEnabled){
-        maxUserLimit = settingsCache->value("security/max_users_total", 500).toInt();
+        int maxUserLimit = getMaxUserLimit();
         qDebug() << "Maximum total user limit: " << maxUserLimit;
         int maxTcpUserLimit = settingsCache->value("security/max_users_tcp", 500).toInt();
         qDebug() << "Maximum tcp user limit: " << maxTcpUserLimit;
@@ -724,4 +724,12 @@ void Servatrice::doSendIslMessage(const IslMessage &msg, int serverId)
         if (interface)
             interface->transmitMessage(msg);
     }
+}
+
+int Servatrice::getMaxUserLimit() const {
+    return settingsCache->value("security/max_users_total", 500).toInt();
+}
+
+bool Servatrice::getMaxUserLimitEnabled() const {
+    return settingsCache->value("security/enable_max_user_limit", false).toBool();
 }

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -134,14 +134,14 @@ private:
     int uptime;
     QMutex txBytesMutex, rxBytesMutex;
     quint64 txBytes, rxBytes;
-    int maxGameInactivityTime, maxPlayerInactivityTime, maxUserLimit;
+    int maxGameInactivityTime, maxPlayerInactivityTime;
     int maxUsersPerAddress, messageCountingInterval, maxMessageCountPerInterval, maxMessageSizePerInterval, maxGamesPerUser, commandCountingInterval, maxCommandCountPerInterval, pingClockInterval;
 
     QString shutdownReason;
     int shutdownMinutes;
     int nextShutdownMessageMinutes;
     QTimer *shutdownTimer;
-    bool isFirstShutdownMessage, clientIdRequired, regServerOnly, maxUserLimitEnabled;
+    bool isFirstShutdownMessage, clientIdRequired, regServerOnly;
 
     mutable QMutex serverListMutex;
     QList<ServerProperties> serverList;
@@ -164,7 +164,7 @@ public:
     bool getGameShouldPing() const { return true; }
     bool getClientIdRequired() const { return clientIdRequired; }
     bool getRegOnlyServer() const { return regServerOnly; }
-    bool getmaxUserLimitEnabled() const {return maxUserLimitEnabled; }
+    bool getMaxUserLimitEnabled() const;
     int getPingClockInterval() const { return pingClockInterval; }
     int getMaxGameInactivityTime() const { return maxGameInactivityTime; }
     int getMaxPlayerInactivityTime() const { return maxPlayerInactivityTime; }
@@ -175,7 +175,7 @@ public:
     int getMaxGamesPerUser() const { return maxGamesPerUser; }
     int getCommandCountingInterval() const { return commandCountingInterval; }
     int getMaxCommandCountPerInterval() const { return maxCommandCountPerInterval; }
-    int getMaxUserLimit() const { return maxUserLimit; }
+    int getMaxUserLimit() const;
     AuthenticationMethod getAuthenticationMethod() const { return authenticationMethod; }
     QString getDbPrefix() const { return dbPrefix; }
     int getServerId() const { return serverId; }

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -533,6 +533,10 @@ ServerInfo_User Servatrice_DatabaseInterface::evalUserQueryResult(const QSqlQuer
         const QString clientid = query->value(9).toString();
         if (!clientid.isEmpty())
             result.set_clientid(clientid.toStdString());
+
+        const QString privlevel = query->value(10).toString();
+        if (!privlevel.isEmpty())
+            result.set_privlevel(privlevel.toStdString());
     }
     return result;
 }
@@ -547,7 +551,7 @@ ServerInfo_User Servatrice_DatabaseInterface::getUserData(const QString &name, b
         if (!checkSql())
             return result;
 
-        QSqlQuery *query = prepareQuery("select id, name, admin, country, gender, realname, avatar_bmp, registrationDate, email, clientid from {prefix}_users where name = :name and active = 1");
+        QSqlQuery *query = prepareQuery("select id, name, admin, country, gender, realname, avatar_bmp, registrationDate, email, clientid, privlevel from {prefix}_users where name = :name and active = 1");
         query->bindValue(":name", name);
         if (!execSqlQuery(query))
             return result;

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -9,7 +9,7 @@
 #include "server.h"
 #include "server_database_interface.h"
 
-#define DATABASE_SCHEMA_VERSION 17
+#define DATABASE_SCHEMA_VERSION 18
 
 class Servatrice;
 


### PR DESCRIPTION
Added a enum column in the users table named "privilevel" with the current values of "none", "vip", and "donator".  Also allowed anyone with a higher privilege level than "none" to log in even if the server
is set to limit the user total and the user limit is reached.  This change add's the new user information into the users container that gets populated and passed between client and server.