### PR TITLE
Fix dynamic user limit settings

### DIFF
--- a/common/server.h
+++ b/common/server.h
@@ -62,7 +62,7 @@ public:
     virtual bool getGameShouldPing() const { return false; }
     virtual bool getClientIdRequired() const { return false; }
     virtual bool getRegOnlyServer() const { return false; }
-    virtual bool getmaxUserLimitEnabled() const { return false; }
+    virtual bool getMaxUserLimitEnabled() const { return false; }
     virtual int getPingClockInterval() const { return 0; }
     virtual int getMaxGameInactivityTime() const { return 9999999; }
     virtual int getMaxPlayerInactivityTime() const { return 9999999; }

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -384,7 +384,7 @@ Response::ResponseCode Server_ProtocolHandler::cmdPing(const Command_Ping & /*cm
 Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd, ResponseContainer &rc)
 {
     // limit the number of users that can connect to the server based on configuration settings
-    if (server->getmaxUserLimitEnabled()) {
+    if (server->getMaxUserLimitEnabled()) {
         if (server->getUsersCount() >= server->getMaxUserLimit()) {
             qDebug() << "Max Users Total Limit Reached, please increase the max_users_total setting.";
             return Response::RespServerFull;

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -234,11 +234,11 @@ bool Servatrice::initServer()
 
     qDebug() << "Store Replays: " << settingsCache->value("game/store_replays", true).toBool();
     qDebug() << "Client ID Required: " << clientIdRequired;
-    maxUserLimitEnabled = settingsCache->value("security/enable_max_user_limit", false).toBool();
+    bool maxUserLimitEnabled = settingsCache->value("security/enable_max_user_limit", false).toBool();
     qDebug() << "Maximum user limit enabled: " << maxUserLimitEnabled;
 
     if (maxUserLimitEnabled){
-        maxUserLimit = settingsCache->value("security/max_users_total", 500).toInt();
+        int maxUserLimit = settingsCache->value("security/max_users_total", 500).toInt();
         qDebug() << "Maximum total user limit: " << maxUserLimit;
         int maxTcpUserLimit = settingsCache->value("security/max_users_tcp", 500).toInt();
         qDebug() << "Maximum tcp user limit: " << maxTcpUserLimit;
@@ -724,4 +724,12 @@ void Servatrice::doSendIslMessage(const IslMessage &msg, int serverId)
         if (interface)
             interface->transmitMessage(msg);
     }
+}
+
+int Servatrice::getMaxUserLimit() const {
+    return settingsCache->value("security/max_users_total", 500).toInt();
+}
+
+bool Servatrice::getMaxUserLimitEnabled() const {
+    return settingsCache->value("security/enable_max_user_limit", false).toBool();
 }

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -234,11 +234,11 @@ bool Servatrice::initServer()
 
     qDebug() << "Store Replays: " << settingsCache->value("game/store_replays", true).toBool();
     qDebug() << "Client ID Required: " << clientIdRequired;
-    bool maxUserLimitEnabled = settingsCache->value("security/enable_max_user_limit", false).toBool();
+    bool maxUserLimitEnabled = getMaxUserLimitEnabled();
     qDebug() << "Maximum user limit enabled: " << maxUserLimitEnabled;
 
     if (maxUserLimitEnabled){
-        int maxUserLimit = settingsCache->value("security/max_users_total", 500).toInt();
+        int maxUserLimit = getMaxUserLimit();
         qDebug() << "Maximum total user limit: " << maxUserLimit;
         int maxTcpUserLimit = settingsCache->value("security/max_users_tcp", 500).toInt();
         qDebug() << "Maximum tcp user limit: " << maxTcpUserLimit;

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -134,14 +134,14 @@ private:
     int uptime;
     QMutex txBytesMutex, rxBytesMutex;
     quint64 txBytes, rxBytes;
-    int maxGameInactivityTime, maxPlayerInactivityTime, maxUserLimit;
+    int maxGameInactivityTime, maxPlayerInactivityTime;
     int maxUsersPerAddress, messageCountingInterval, maxMessageCountPerInterval, maxMessageSizePerInterval, maxGamesPerUser, commandCountingInterval, maxCommandCountPerInterval, pingClockInterval;
 
     QString shutdownReason;
     int shutdownMinutes;
     int nextShutdownMessageMinutes;
     QTimer *shutdownTimer;
-    bool isFirstShutdownMessage, clientIdRequired, regServerOnly, maxUserLimitEnabled;
+    bool isFirstShutdownMessage, clientIdRequired, regServerOnly;
 
     mutable QMutex serverListMutex;
     QList<ServerProperties> serverList;
@@ -164,7 +164,7 @@ public:
     bool getGameShouldPing() const { return true; }
     bool getClientIdRequired() const { return clientIdRequired; }
     bool getRegOnlyServer() const { return regServerOnly; }
-    bool getmaxUserLimitEnabled() const {return maxUserLimitEnabled; }
+    bool getMaxUserLimitEnabled() const;
     int getPingClockInterval() const { return pingClockInterval; }
     int getMaxGameInactivityTime() const { return maxGameInactivityTime; }
     int getMaxPlayerInactivityTime() const { return maxPlayerInactivityTime; }
@@ -175,7 +175,7 @@ public:
     int getMaxGamesPerUser() const { return maxGamesPerUser; }
     int getCommandCountingInterval() const { return commandCountingInterval; }
     int getMaxCommandCountPerInterval() const { return maxCommandCountPerInterval; }
-    int getMaxUserLimit() const { return maxUserLimit; }
+    int getMaxUserLimit() const;
     AuthenticationMethod getAuthenticationMethod() const { return authenticationMethod; }
     QString getDbPrefix() const { return dbPrefix; }
     int getServerId() const { return serverId; }


### PR DESCRIPTION
PR #2220 removed the ability to be able to change the max user limit count while the server is running requiring a restart to make the settings change.  This PR reverts the behavior back to how it operated
prior to the PR.  It also corrects a minor camel hump naming of a function name involved with the setting.