### PR TITLE
Add client UI setting for idleclientdisconnect

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -398,12 +398,16 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     annotateTokensCheckBox.setChecked(settingsCache->getAnnotateTokens());
     connect(&annotateTokensCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setAnnotateTokens(int)));
 
+    idleClientTimeOutCheckBox.setChecked(settingsCache->getIdleClientTimeOutEnabled());
+    connect(&idleClientTimeOutCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setIdleClientTimeOutEnabled(int)));
+
     QGridLayout *generalGrid = new QGridLayout;
     generalGrid->addWidget(&notificationsEnabledCheckBox, 0, 0);
     generalGrid->addWidget(&specNotificationsEnabledCheckBox, 1, 0);
     generalGrid->addWidget(&doubleClickToPlayCheckBox, 2, 0);
     generalGrid->addWidget(&playToStackCheckBox, 3, 0);
     generalGrid->addWidget(&annotateTokensCheckBox, 4, 0);
+    generalGrid->addWidget(&idleClientTimeOutCheckBox, 5, 0);
     
     generalGroupBox = new QGroupBox;
     generalGroupBox->setLayout(generalGrid);
@@ -438,6 +442,7 @@ void UserInterfaceSettingsPage::retranslateUi()
     annotateTokensCheckBox.setText(tr("Annotate card text on tokens"));
     animationGroupBox->setTitle(tr("Animation settings"));
     tapAnimationCheckBox.setText(tr("&Tap/untap animation"));
+    idleClientTimeOutCheckBox.setText(tr("Disconnect from server if sitting idle for extended periods of time"));
 }
 
 

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -442,7 +442,7 @@ void UserInterfaceSettingsPage::retranslateUi()
     annotateTokensCheckBox.setText(tr("Annotate card text on tokens"));
     animationGroupBox->setTitle(tr("Animation settings"));
     tapAnimationCheckBox.setText(tr("&Tap/untap animation"));
-    idleClientTimeOutCheckBox.setText(tr("Disconnect from server if sitting idle for extended periods of time"));
+    idleClientTimeOutCheckBox.setText(tr("Disconnect from server if sitting idle for an extended periods of time"));
 }
 
 

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -442,7 +442,7 @@ void UserInterfaceSettingsPage::retranslateUi()
     annotateTokensCheckBox.setText(tr("Annotate card text on tokens"));
     animationGroupBox->setTitle(tr("Animation settings"));
     tapAnimationCheckBox.setText(tr("&Tap/untap animation"));
-    idleClientTimeOutCheckBox.setText(tr("Disconnect from server if sitting idle for an extended periods of time"));
+    idleClientTimeOutCheckBox.setText(tr("Disconnect from server if idle for 1 hour"));
 }
 
 

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -112,6 +112,7 @@ private:
     QCheckBox playToStackCheckBox;
     QCheckBox annotateTokensCheckBox;
     QCheckBox tapAnimationCheckBox;
+    QCheckBox idleClientTimeOutCheckBox;
     QGroupBox *generalGroupBox;
     QGroupBox *animationGroupBox;
     

--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -35,7 +35,7 @@ RemoteClient::RemoteClient(QObject *parent)
     idleTimer->setInterval(idlekeepalive * 1000);
     connect(idleTimer, SIGNAL(timeout()), this, SLOT(doIdleTimeOut()));
     connect(this, SIGNAL(resetIdleTimerClock()), idleTimer, SLOT(start()));
-
+   
     socket = new QTcpSocket(this);
     socket->setSocketOption(QAbstractSocket::LowDelayOption, 1);
     connect(socket, SIGNAL(connected()), this, SLOT(slotConnected()));
@@ -390,8 +390,11 @@ QString RemoteClient::getSrvClientID(const QString _hostname)
 
 void RemoteClient::doIdleTimeOut()
 {
-    doDisconnectFromServer();
-    emit idleTimeout();
+    if (settingsCache->getIdleClientTimeOutEnabled()) {
+        doDisconnectFromServer();
+        emit idleTimeout();
+    }
+ 
 }
 
 void RemoteClient::resetIdleTimer()

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -250,6 +250,7 @@ SettingsCache::SettingsCache()
     spectatorsCanSeeEverything = settings->value("game/spectatorscanseeeverything", false).toBool();
     rememberGameSettings = settings->value("game/remembergamesettings", true).toBool();
     clientID = settings->value("personal/clientid", "notset").toString();
+    idleClientTimeOutEnabled = settings->value("interface/idleClientTimeOutEnabled", true).toBool();
 }
 
 void SettingsCache::setCardInfoViewMode(const int _viewMode) {
@@ -389,6 +390,12 @@ void SettingsCache::setAnnotateTokens(int _annotateTokens)
 {
     annotateTokens = _annotateTokens;
     settings->setValue("interface/annotatetokens", annotateTokens);
+}
+
+void SettingsCache::setIdleClientTimeOutEnabled(int _idleClientTimeOutEnabled)
+{
+    idleClientTimeOutEnabled = _idleClientTimeOutEnabled;
+    settings->setValue("interface/idleClientTimeOutEnabled", idleClientTimeOutEnabled);
 }
 
 void SettingsCache::setTabGameSplitterSizes(const QByteArray &_tabGameSplitterSizes)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -64,6 +64,7 @@ private:
     bool doubleClickToPlay;
     bool playToStack;
     bool annotateTokens;
+    bool idleClientTimeOutEnabled;
     QByteArray tabGameSplitterSizes;
     bool displayCardNames;
     bool horizontalHand;
@@ -131,6 +132,7 @@ public:
     bool getNotificationsEnabled() const { return notificationsEnabled; }
     bool getSpectatorNotificationsEnabled() const { return spectatorNotificationsEnabled; }
     bool getNotifyAboutUpdates() const { return notifyAboutUpdates; }
+    bool getIdleClientTimeOutEnabled() const { return idleClientTimeOutEnabled;  }
 
     bool getDoubleClickToPlay() const { return doubleClickToPlay; }
     bool getPlayToStack() const { return playToStack; }
@@ -207,6 +209,7 @@ public slots:
     void setDoubleClickToPlay(int _doubleClickToPlay);
     void setPlayToStack(int _playToStack);
     void setAnnotateTokens(int _annotateTokens);
+    void setIdleClientTimeOutEnabled(int _idleClientTimeOutEnabled);
     void setTabGameSplitterSizes(const QByteArray &_tabGameSplitterSizes);
     void setDisplayCardNames(int _displayCardNames);
     void setHorizontalHand(int _horizontalHand);


### PR DESCRIPTION
Added disabled option in client UI for client disconnect.  With the way the code is configured the user can enable/disable the idle client timeout setting even while logged in on the fly allowing for users to decide if they want to set there client to timeout without requiring a restart of the client.