### PR TITLE
Adds !corrected_name! and !corrected_name_lower! to customURL

### DIFF
--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -218,6 +218,8 @@ QString PictureLoaderWorker::getPicUrl()
 
     picUrl.replace("!name!", QUrl::toPercentEncoding(card->getName()));
     picUrl.replace("!name_lower!", QUrl::toPercentEncoding(card->getName().toLower()));
+    picUrl.replace("!corrected_name!", QUrl::toPercentEncoding(card->getCorrectedName()));
+    picUrl.replace("!corrected_name_lower!", QUrl::toPercentEncoding(card->getCorrectedName().toLower()));
     picUrl.replace("!cardid!", QUrl::toPercentEncoding(QString::number(muid)));
     if (set)
     {
@@ -234,6 +236,8 @@ QString PictureLoaderWorker::getPicUrl()
     if (
         picUrl.contains("!name!") ||
         picUrl.contains("!name_lower!") ||
+        picUrl.contains("!corrected_name!") ||
+        picUrl.contains("!corrected_name_lower!") ||
         picUrl.contains("!setnumber!") ||
         picUrl.contains("!setcode!") ||
         picUrl.contains("!setcode_lower!") ||


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/Cockatrice/Cockatrice/pull/2164 where split cards can no longer be downloaded using !name! in a customURL.
