### PR TITLE
Fix one to many zero's

### DIFF
--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -162,7 +162,7 @@ SettingsCache::SettingsCache()
     notifyAboutUpdates = settings->value("personal/updatenotification", true).toBool();
     lang = settings->value("personal/lang").toString();
     keepalive = settings->value("personal/keepalive", 5).toInt();
-    idlekeepalive = settings->value("personal/idlekeepalive", 36000).toInt();
+    idlekeepalive = settings->value("personal/idlekeepalive", 3600).toInt();
 
     deckPath = getSafeConfigPath("paths/decks", dataPath + "/decks/");
     replaysPath = getSafeConfigPath("paths/replays", dataPath + "/replays/");


### PR DESCRIPTION
Looks like I typo'd the default value for the number of seconds in 1 hour for the default client side idle time out.  This fixes it.