### PR TITLE
Add missing feature rememberance to client

### DIFF
--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -120,7 +120,6 @@ int main(int argc, char *argv[])
     installNewTranslator();
 
     qsrand(QDateTime::currentDateTime().toTime_t());
-
     qDebug("main(): starting main program");
 
     MainWindow ui;

--- a/cockatrice/src/remoteclient.h
+++ b/cockatrice/src/remoteclient.h
@@ -45,6 +45,8 @@ private:
     QByteArray inputBuffer;
     bool messageInProgress;
     bool handshakeStarted;
+    bool newMissingFeatureFound(QString _serversMissingFeatures);
+    void clearNewClientFeatures();
     int messageLength;
     
     QTimer *timer;

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -249,6 +249,12 @@ SettingsCache::SettingsCache()
     spectatorsCanSeeEverything = settings->value("game/spectatorscanseeeverything", false).toBool();
     rememberGameSettings = settings->value("game/remembergamesettings", true).toBool();
     clientID = settings->value("personal/clientid", "notset").toString();
+    knownMissingFeatures = settings->value("interface/knownmissingfeatures", "").toString();
+}
+
+void SettingsCache::setKnownMissingFeatures(QString _knownMissingFeatures) {
+    knownMissingFeatures = _knownMissingFeatures;
+    settings->setValue("interface/knownmissingfeatures", knownMissingFeatures);
 }
 
 void SettingsCache::setCardInfoViewMode(const int _viewMode) {

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -86,6 +86,7 @@ private:
     QString picUrl;
     QString picUrlFallback;
     QString clientID;
+    QString knownMissingFeatures;
     int pixmapCacheSize;
     bool scaleCards;
     bool showMessagePopups;
@@ -181,7 +182,9 @@ public:
     bool getRememberGameSettings() const { return rememberGameSettings; }
     int getKeepAlive() const { return keepalive; }
     void setClientID(QString clientID);
+    void setKnownMissingFeatures(QString _knownMissingFeatures);
     QString getClientID() { return clientID; }
+    QString getKnownMissingFeatures() { return knownMissingFeatures; }
     ShortcutsSettings& shortcuts() const { return *shortcutsSettings; }
     CardDatabaseSettings& cardDatabase() const { return *cardDatabaseSettings; }
     ServersSettings& servers() const { return *serversSettings; }


### PR DESCRIPTION
Fix #2249

Add the ability for the client to remember the missing features that it received from the server it last connected to and not display the "missing/optional feature" message at every login.  At each startup the client checks the known missing feature list and compares it to its feature set clearing any known features that have been added after a client upgrade.  The client will now only display the missing / optional feature window when a new missing feature is found upon connecting to a server only once.  Afterwords it will not display the message until an even newer feature the client is missing is found.