### PR TITLE
Fix Store Replays Functionality

### DIFF
--- a/common/server.h
+++ b/common/server.h
@@ -65,6 +65,7 @@ public:
     virtual bool getRegOnlyServerEnabled() const { return false; }
     virtual bool getMaxUserLimitEnabled() const { return false; }
     virtual bool getEnableLogQuery() const { return false; }
+    virtual bool getStoreReplaysEnabled() const { return true; }
     virtual int getIdleClientTimeout() const { return 0; }
     virtual int getClientKeepAlive() const { return 0; }
     virtual int getMaxGameInactivityTime() const { return 9999999; }

--- a/common/server_game.cpp
+++ b/common/server_game.cpp
@@ -111,7 +111,9 @@ Server_Game::~Server_Game()
 
     currentReplay->set_duration_seconds(secondsElapsed - startTimeOfThisGame);
     replayList.append(currentReplay);
-    storeGameInformation();
+    Server *server = room->getServer();
+    if (server->getStoreReplaysEnabled())
+        storeGameInformation();
 
     for (int i = 0; i < replayList.size(); ++i)
         delete replayList[i];


### PR DESCRIPTION
For whatever reason we have a variable in the servers ini to
enable/disable the storing of replays but there is no code that uses
that variable.  At one time there was but in light of it being removed
some were along the line, this change add's the ability back in for server
owners to disable the storing of game replay data.