### PR TITLE
Fix store replays

### DIFF
--- a/common/server.h
+++ b/common/server.h
@@ -65,6 +65,7 @@ public:
     virtual bool getRegOnlyServerEnabled() const { return false; }
     virtual bool getMaxUserLimitEnabled() const { return false; }
     virtual bool getEnableLogQuery() const { return false; }
+    virtual bool getStoreReplaysEnabled() const { return true; }
     virtual int getIdleClientTimeout() const { return 0; }
     virtual int getClientKeepAlive() const { return 0; }
     virtual int getMaxGameInactivityTime() const { return 9999999; }

--- a/common/server_game.cpp
+++ b/common/server_game.cpp
@@ -153,8 +153,7 @@ void Server_Game::storeGameInformation()
     server->clientsLock.lockForRead();
     while (allUsersIterator.hasNext()) {
         Server_AbstractUserInterface *userHandler = server->findUser(allUsersIterator.next());
-        if (userHandler)
-            if (server->getStoreReplaysEnabled())
+        if (userHandler && server->getStoreReplaysEnabled())
                 userHandler->sendProtocolItem(*sessionEvent);
     }
     server->clientsLock.unlock();

--- a/common/server_game.cpp
+++ b/common/server_game.cpp
@@ -111,7 +111,9 @@ Server_Game::~Server_Game()
 
     currentReplay->set_duration_seconds(secondsElapsed - startTimeOfThisGame);
     replayList.append(currentReplay);
-    storeGameInformation();
+    Server *server = room->getServer();
+    if (server->getStoreReplaysEnabled())
+        storeGameInformation();
 
     for (int i = 0; i < replayList.size(); ++i)
         delete replayList[i];


### PR DESCRIPTION
Fixed the server side store replay enable/disable functionality.  Not sure when it was broken but we have a variable definition that allows owners to enable/disable the storing of replays but no underlying code that does the actual work.  This fixes that.