### PR TITLE
protobuf warnings

### DIFF
--- a/common/pb/admin_commands.proto
+++ b/common/pb/admin_commands.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 message AdminCommand {
     enum AdminCommandType {
         UPDATE_SERVER_MESSAGE = 1000;

--- a/common/pb/card_attributes.proto
+++ b/common/pb/card_attributes.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 enum CardAttribute {
     AttrTapped = 1;
     AttrAttacking = 2;

--- a/common/pb/color.proto
+++ b/common/pb/color.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 message color {
     optional uint32 r = 1;
     optional uint32 g = 2;

--- a/common/pb/command_attach_card.proto
+++ b/common/pb/command_attach_card.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_AttachCard {
     extend GameCommand {

--- a/common/pb/command_change_zone_properties.proto
+++ b/common/pb/command_change_zone_properties.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 
 message Command_ChangeZoneProperties {

--- a/common/pb/command_concede.proto
+++ b/common/pb/command_concede.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_Concede {
     extend GameCommand {

--- a/common/pb/command_create_arrow.proto
+++ b/common/pb/command_create_arrow.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 import "color.proto";
 

--- a/common/pb/command_create_counter.proto
+++ b/common/pb/command_create_counter.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 import "color.proto";
 

--- a/common/pb/command_create_token.proto
+++ b/common/pb/command_create_token.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_CreateToken {
     extend GameCommand {

--- a/common/pb/command_deck_del.proto
+++ b/common/pb/command_deck_del.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_commands.proto";
 
 message Command_DeckDel {

--- a/common/pb/command_deck_del_dir.proto
+++ b/common/pb/command_deck_del_dir.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_commands.proto";
 
 message Command_DeckDelDir {

--- a/common/pb/command_deck_download.proto
+++ b/common/pb/command_deck_download.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_commands.proto";
 
 message Command_DeckDownload {

--- a/common/pb/command_deck_list.proto
+++ b/common/pb/command_deck_list.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_commands.proto";
 
 message Command_DeckList {

--- a/common/pb/command_deck_new_dir.proto
+++ b/common/pb/command_deck_new_dir.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_commands.proto";
 
 message Command_DeckNewDir {

--- a/common/pb/command_deck_select.proto
+++ b/common/pb/command_deck_select.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_DeckSelect {
     extend GameCommand {

--- a/common/pb/command_deck_upload.proto
+++ b/common/pb/command_deck_upload.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_commands.proto";
 
 message Command_DeckUpload {

--- a/common/pb/command_del_counter.proto
+++ b/common/pb/command_del_counter.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_DelCounter {
     extend GameCommand {

--- a/common/pb/command_delete_arrow.proto
+++ b/common/pb/command_delete_arrow.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_DeleteArrow {
     extend GameCommand {

--- a/common/pb/command_draw_cards.proto
+++ b/common/pb/command_draw_cards.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_DrawCards {
     extend GameCommand {

--- a/common/pb/command_dump_zone.proto
+++ b/common/pb/command_dump_zone.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_DumpZone {
     extend GameCommand {

--- a/common/pb/command_flip_card.proto
+++ b/common/pb/command_flip_card.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_FlipCard {
     extend GameCommand {

--- a/common/pb/command_game_say.proto
+++ b/common/pb/command_game_say.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_GameSay {
     extend GameCommand {

--- a/common/pb/command_inc_card_counter.proto
+++ b/common/pb/command_inc_card_counter.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_IncCardCounter {
     extend GameCommand {

--- a/common/pb/command_inc_counter.proto
+++ b/common/pb/command_inc_counter.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_IncCounter {
     extend GameCommand {

--- a/common/pb/command_kick_from_game.proto
+++ b/common/pb/command_kick_from_game.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_KickFromGame {
     extend GameCommand {

--- a/common/pb/command_leave_game.proto
+++ b/common/pb/command_leave_game.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_LeaveGame {
     extend GameCommand {

--- a/common/pb/command_move_card.proto
+++ b/common/pb/command_move_card.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message CardToMove {
     optional sint32 card_id = 1 [default = -1];

--- a/common/pb/command_mulligan.proto
+++ b/common/pb/command_mulligan.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_Mulligan {
     extend GameCommand {

--- a/common/pb/command_next_turn.proto
+++ b/common/pb/command_next_turn.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_NextTurn {
     extend GameCommand {

--- a/common/pb/command_ready_start.proto
+++ b/common/pb/command_ready_start.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_ReadyStart {
     extend GameCommand {

--- a/common/pb/command_replay_delete_match.proto
+++ b/common/pb/command_replay_delete_match.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_commands.proto";
 
 message Command_ReplayDeleteMatch {

--- a/common/pb/command_replay_download.proto
+++ b/common/pb/command_replay_download.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_commands.proto";
 
 message Command_ReplayDownload {

--- a/common/pb/command_replay_list.proto
+++ b/common/pb/command_replay_list.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_commands.proto";
 
 message Command_ReplayList {

--- a/common/pb/command_replay_modify_match.proto
+++ b/common/pb/command_replay_modify_match.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_commands.proto";
 
 message Command_ReplayModifyMatch {

--- a/common/pb/command_reveal_cards.proto
+++ b/common/pb/command_reveal_cards.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_RevealCards {
     extend GameCommand {

--- a/common/pb/command_roll_die.proto
+++ b/common/pb/command_roll_die.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_RollDie {
     extend GameCommand {

--- a/common/pb/command_set_active_phase.proto
+++ b/common/pb/command_set_active_phase.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_SetActivePhase {
     extend GameCommand {

--- a/common/pb/command_set_card_attr.proto
+++ b/common/pb/command_set_card_attr.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 import "card_attributes.proto";
 

--- a/common/pb/command_set_card_counter.proto
+++ b/common/pb/command_set_card_counter.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_SetCardCounter {
     extend GameCommand {

--- a/common/pb/command_set_counter.proto
+++ b/common/pb/command_set_counter.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_SetCounter {
     extend GameCommand {

--- a/common/pb/command_set_sideboard_lock.proto
+++ b/common/pb/command_set_sideboard_lock.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_SetSideboardLock {
     extend GameCommand {

--- a/common/pb/command_set_sideboard_plan.proto
+++ b/common/pb/command_set_sideboard_plan.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 import "move_card_to_zone.proto";
 

--- a/common/pb/command_shuffle.proto
+++ b/common/pb/command_shuffle.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_Shuffle {
     extend GameCommand {

--- a/common/pb/command_stop_dump_zone.proto
+++ b/common/pb/command_stop_dump_zone.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_StopDumpZone {
     extend GameCommand {

--- a/common/pb/command_undo_draw.proto
+++ b/common/pb/command_undo_draw.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_commands.proto";
 message Command_UndoDraw {
     extend GameCommand {

--- a/common/pb/commands.proto
+++ b/common/pb/commands.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_commands.proto";
 import "game_commands.proto";
 import "room_commands.proto";

--- a/common/pb/context_concede.proto
+++ b/common/pb/context_concede.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event_context.proto";
 
 message Context_Concede {

--- a/common/pb/context_connection_state_changed.proto
+++ b/common/pb/context_connection_state_changed.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event_context.proto";
 
 message Context_ConnectionStateChanged {

--- a/common/pb/context_deck_select.proto
+++ b/common/pb/context_deck_select.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event_context.proto";
 
 message Context_DeckSelect {

--- a/common/pb/context_move_card.proto
+++ b/common/pb/context_move_card.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event_context.proto";
 
 message Context_MoveCard {

--- a/common/pb/context_mulligan.proto
+++ b/common/pb/context_mulligan.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event_context.proto";
 
 message Context_Mulligan {

--- a/common/pb/context_ping_changed.proto
+++ b/common/pb/context_ping_changed.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event_context.proto";
 
 message Context_PingChanged {

--- a/common/pb/context_ready_start.proto
+++ b/common/pb/context_ready_start.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event_context.proto";
 
 message Context_ReadyStart {

--- a/common/pb/context_set_sideboard_lock.proto
+++ b/common/pb/context_set_sideboard_lock.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event_context.proto";
 
 message Context_SetSideboardLock {

--- a/common/pb/context_undo_draw.proto
+++ b/common/pb/context_undo_draw.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event_context.proto";
 
 message Context_UndoDraw {

--- a/common/pb/event_add_to_list.proto
+++ b/common/pb/event_add_to_list.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_event.proto";
 import "serverinfo_user.proto";
 

--- a/common/pb/event_attach_card.proto
+++ b/common/pb/event_attach_card.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_AttachCard {

--- a/common/pb/event_change_zone_properties.proto
+++ b/common/pb/event_change_zone_properties.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_ChangeZoneProperties {

--- a/common/pb/event_connection_closed.proto
+++ b/common/pb/event_connection_closed.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_event.proto";
 
 message Event_ConnectionClosed {

--- a/common/pb/event_create_arrow.proto
+++ b/common/pb/event_create_arrow.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 import "serverinfo_arrow.proto";
 

--- a/common/pb/event_create_counter.proto
+++ b/common/pb/event_create_counter.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 import "serverinfo_counter.proto";
 

--- a/common/pb/event_create_token.proto
+++ b/common/pb/event_create_token.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_CreateToken {

--- a/common/pb/event_del_counter.proto
+++ b/common/pb/event_del_counter.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_DelCounter {

--- a/common/pb/event_delete_arrow.proto
+++ b/common/pb/event_delete_arrow.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_DeleteArrow {

--- a/common/pb/event_destroy_card.proto
+++ b/common/pb/event_destroy_card.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_DestroyCard {

--- a/common/pb/event_draw_cards.proto
+++ b/common/pb/event_draw_cards.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 import "serverinfo_card.proto";
 

--- a/common/pb/event_dump_zone.proto
+++ b/common/pb/event_dump_zone.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_DumpZone {

--- a/common/pb/event_flip_card.proto
+++ b/common/pb/event_flip_card.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_FlipCard {

--- a/common/pb/event_game_closed.proto
+++ b/common/pb/event_game_closed.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_GameClosed {

--- a/common/pb/event_game_host_changed.proto
+++ b/common/pb/event_game_host_changed.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_GameHostChanged {

--- a/common/pb/event_game_joined.proto
+++ b/common/pb/event_game_joined.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_event.proto";
 import "serverinfo_game.proto";
 import "serverinfo_gametype.proto";

--- a/common/pb/event_game_say.proto
+++ b/common/pb/event_game_say.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_GameSay {

--- a/common/pb/event_game_state_changed.proto
+++ b/common/pb/event_game_state_changed.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 import "serverinfo_player.proto";
 

--- a/common/pb/event_join.proto
+++ b/common/pb/event_join.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 import "serverinfo_playerproperties.proto";
 

--- a/common/pb/event_join_room.proto
+++ b/common/pb/event_join_room.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "room_event.proto";
 import "serverinfo_user.proto";
 

--- a/common/pb/event_kicked.proto
+++ b/common/pb/event_kicked.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_Kicked {
@@ -5,3 +6,4 @@ message Event_Kicked {
         optional Event_Kicked ext = 1004;
     }
 }
+

--- a/common/pb/event_leave.proto
+++ b/common/pb/event_leave.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_Leave {

--- a/common/pb/event_leave_room.proto
+++ b/common/pb/event_leave_room.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "room_event.proto";
 
 message Event_LeaveRoom {

--- a/common/pb/event_list_games.proto
+++ b/common/pb/event_list_games.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "room_event.proto";
 import "serverinfo_game.proto";
 

--- a/common/pb/event_list_rooms.proto
+++ b/common/pb/event_list_rooms.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_event.proto";
 import "serverinfo_room.proto";
 

--- a/common/pb/event_move_card.proto
+++ b/common/pb/event_move_card.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_MoveCard {

--- a/common/pb/event_notify_user.proto
+++ b/common/pb/event_notify_user.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_event.proto";
 
 message Event_NotifyUser {

--- a/common/pb/event_player_properties_changed.proto
+++ b/common/pb/event_player_properties_changed.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 import "serverinfo_playerproperties.proto";
 

--- a/common/pb/event_remove_from_list.proto
+++ b/common/pb/event_remove_from_list.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_event.proto";
 
 message Event_RemoveFromList {

--- a/common/pb/event_replay_added.proto
+++ b/common/pb/event_replay_added.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_event.proto";
 import "serverinfo_replay_match.proto";
 

--- a/common/pb/event_reveal_cards.proto
+++ b/common/pb/event_reveal_cards.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 import "serverinfo_card.proto";
 

--- a/common/pb/event_roll_die.proto
+++ b/common/pb/event_roll_die.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_RollDie {

--- a/common/pb/event_room_say.proto
+++ b/common/pb/event_room_say.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "room_event.proto";
 
 message Event_RoomSay {

--- a/common/pb/event_server_complete_list.proto
+++ b/common/pb/event_server_complete_list.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_event.proto";
 import "serverinfo_user.proto";
 import "serverinfo_room.proto";

--- a/common/pb/event_server_identification.proto
+++ b/common/pb/event_server_identification.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_event.proto";
 
 message Event_ServerIdentification {

--- a/common/pb/event_server_message.proto
+++ b/common/pb/event_server_message.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_event.proto";
 
 message Event_ServerMessage {

--- a/common/pb/event_server_shutdown.proto
+++ b/common/pb/event_server_shutdown.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_event.proto";
 
 message Event_ServerShutdown {

--- a/common/pb/event_set_active_phase.proto
+++ b/common/pb/event_set_active_phase.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_SetActivePhase {

--- a/common/pb/event_set_active_player.proto
+++ b/common/pb/event_set_active_player.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_SetActivePlayer {

--- a/common/pb/event_set_card_attr.proto
+++ b/common/pb/event_set_card_attr.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 import "card_attributes.proto";
 

--- a/common/pb/event_set_card_counter.proto
+++ b/common/pb/event_set_card_counter.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_SetCardCounter {

--- a/common/pb/event_set_counter.proto
+++ b/common/pb/event_set_counter.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_SetCounter {

--- a/common/pb/event_shuffle.proto
+++ b/common/pb/event_shuffle.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_Shuffle {

--- a/common/pb/event_stop_dump_zone.proto
+++ b/common/pb/event_stop_dump_zone.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 
 message Event_StopDumpZone {

--- a/common/pb/event_user_joined.proto
+++ b/common/pb/event_user_joined.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_event.proto";
 import "serverinfo_user.proto";
 

--- a/common/pb/event_user_left.proto
+++ b/common/pb/event_user_left.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_event.proto";
 
 message Event_UserLeft {

--- a/common/pb/event_user_message.proto
+++ b/common/pb/event_user_message.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "session_event.proto";
 
 message Event_UserMessage {

--- a/common/pb/game_commands.proto
+++ b/common/pb/game_commands.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 message GameCommand {
     enum GameCommandType {
         KICK_FROM_GAME = 1000;

--- a/common/pb/game_event.proto
+++ b/common/pb/game_event.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 message GameEvent {
     enum GameEventType {
         JOIN = 1000;

--- a/common/pb/game_event_container.proto
+++ b/common/pb/game_event_container.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "game_event.proto";
 import "game_event_context.proto";
 

--- a/common/pb/game_event_context.proto
+++ b/common/pb/game_event_context.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 message GameEventContext {
     enum ContextType {
         READY_START = 1000;

--- a/common/pb/game_replay.proto
+++ b/common/pb/game_replay.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "serverinfo_game.proto";
 import "game_event_container.proto";
 

--- a/common/pb/isl_message.proto
+++ b/common/pb/isl_message.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 import "session_event.proto";
 import "commands.proto";

--- a/common/pb/moderator_commands.proto
+++ b/common/pb/moderator_commands.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 message ModeratorCommand {
     enum ModeratorCommandType {
         BAN_FROM_SERVER = 1000;

--- a/common/pb/move_card_to_zone.proto
+++ b/common/pb/move_card_to_zone.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 message MoveCard_ToZone {
     optional string card_name = 1;
     optional string start_zone = 2;

--- a/common/pb/response.proto
+++ b/common/pb/response.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 message Response {
     enum ResponseCode {
         RespNotConnected = -1;

--- a/common/pb/response_activate.proto
+++ b/common/pb/response_activate.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 
 message Response_Activate {

--- a/common/pb/response_adjust_mod.proto
+++ b/common/pb/response_adjust_mod.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 
 message Response_AdjustMod{

--- a/common/pb/response_ban_history.proto
+++ b/common/pb/response_ban_history.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 import "serverinfo_ban.proto";
 

--- a/common/pb/response_deck_download.proto
+++ b/common/pb/response_deck_download.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 
 message Response_DeckDownload {

--- a/common/pb/response_deck_list.proto
+++ b/common/pb/response_deck_list.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 import "serverinfo_deckstorage.proto";
 

--- a/common/pb/response_deck_upload.proto
+++ b/common/pb/response_deck_upload.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 import "serverinfo_deckstorage.proto";
 

--- a/common/pb/response_dump_zone.proto
+++ b/common/pb/response_dump_zone.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 import "serverinfo_zone.proto";
 

--- a/common/pb/response_get_games_of_user.proto
+++ b/common/pb/response_get_games_of_user.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 import "serverinfo_game.proto";
 import "serverinfo_room.proto";

--- a/common/pb/response_get_user_info.proto
+++ b/common/pb/response_get_user_info.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 import "serverinfo_user.proto";
 

--- a/common/pb/response_join_room.proto
+++ b/common/pb/response_join_room.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 import "serverinfo_room.proto";
 

--- a/common/pb/response_list_users.proto
+++ b/common/pb/response_list_users.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 import "serverinfo_user.proto";
 

--- a/common/pb/response_login.proto
+++ b/common/pb/response_login.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 import "serverinfo_user.proto";
 

--- a/common/pb/response_register.proto
+++ b/common/pb/response_register.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 
 message Response_Register {

--- a/common/pb/response_replay_download.proto
+++ b/common/pb/response_replay_download.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 
 message Response_ReplayDownload {

--- a/common/pb/response_replay_list.proto
+++ b/common/pb/response_replay_list.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 import "serverinfo_replay_match.proto";
 

--- a/common/pb/response_viewlog_history.proto
+++ b/common/pb/response_viewlog_history.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 import "serverinfo_chat_message.proto";
 

--- a/common/pb/response_warn_history.proto
+++ b/common/pb/response_warn_history.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 import "serverinfo_warning.proto";
 

--- a/common/pb/response_warn_list.proto
+++ b/common/pb/response_warn_list.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 
 message Response_WarnList{

--- a/common/pb/room_commands.proto
+++ b/common/pb/room_commands.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 message RoomCommand {
     enum RoomCommandType {
         LEAVE_ROOM = 1000;

--- a/common/pb/room_event.proto
+++ b/common/pb/room_event.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 message RoomEvent {
     enum RoomEventType {
         LEAVE_ROOM = 1000;

--- a/common/pb/server_message.proto
+++ b/common/pb/server_message.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "response.proto";
 import "session_event.proto";
 import "game_event_container.proto";

--- a/common/pb/serverinfo_arrow.proto
+++ b/common/pb/serverinfo_arrow.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "color.proto";
 
 message ServerInfo_Arrow {

--- a/common/pb/serverinfo_ban.proto
+++ b/common/pb/serverinfo_ban.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /*
  * Historical ban information stored in the ban table
  */

--- a/common/pb/serverinfo_card.proto
+++ b/common/pb/serverinfo_card.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "serverinfo_cardcounter.proto";
 
 message ServerInfo_Card {

--- a/common/pb/serverinfo_cardcounter.proto
+++ b/common/pb/serverinfo_cardcounter.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 message ServerInfo_CardCounter {
     optional sint32 id = 1;
     optional sint32 value = 2;

--- a/common/pb/serverinfo_chat_message.proto
+++ b/common/pb/serverinfo_chat_message.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /*
  * Chat communication of a user to a target.
  * Targets can be users or rooms.

--- a/common/pb/serverinfo_counter.proto
+++ b/common/pb/serverinfo_counter.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "color.proto";
 
 message ServerInfo_Counter {

--- a/common/pb/serverinfo_deckstorage.proto
+++ b/common/pb/serverinfo_deckstorage.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 message ServerInfo_DeckStorage_File {
     optional uint32 creation_time = 1;
 }

--- a/common/pb/serverinfo_game.proto
+++ b/common/pb/serverinfo_game.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "serverinfo_user.proto";
 
 message ServerInfo_Game {

--- a/common/pb/serverinfo_gametype.proto
+++ b/common/pb/serverinfo_gametype.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 message ServerInfo_GameType {
     optional sint32 game_type_id = 1;
     optional string description = 2;

--- a/common/pb/serverinfo_player.proto
+++ b/common/pb/serverinfo_player.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "serverinfo_zone.proto";
 import "serverinfo_counter.proto";
 import "serverinfo_arrow.proto";

--- a/common/pb/serverinfo_playerping.proto
+++ b/common/pb/serverinfo_playerping.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 message ServerInfo_PlayerPing {
     optional sint32 player_id = 1;
     optional sint32 ping_time = 2;

--- a/common/pb/serverinfo_playerproperties.proto
+++ b/common/pb/serverinfo_playerproperties.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "serverinfo_user.proto";
 
 message ServerInfo_PlayerProperties {

--- a/common/pb/serverinfo_replay.proto
+++ b/common/pb/serverinfo_replay.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 message ServerInfo_Replay {
     optional sint32 replay_id = 1 [default = -1];
     optional string replay_name = 2;

--- a/common/pb/serverinfo_replay_match.proto
+++ b/common/pb/serverinfo_replay_match.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "serverinfo_replay.proto";
 
 message ServerInfo_ReplayMatch {

--- a/common/pb/serverinfo_room.proto
+++ b/common/pb/serverinfo_room.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "serverinfo_game.proto";
 import "serverinfo_user.proto";
 import "serverinfo_gametype.proto";

--- a/common/pb/serverinfo_user.proto
+++ b/common/pb/serverinfo_user.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 message ServerInfo_User {
     enum UserLevelFlag {
         IsNothing = 0;

--- a/common/pb/serverinfo_warning.proto
+++ b/common/pb/serverinfo_warning.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /*
  * Historical warning information stored in the warnings table
  */

--- a/common/pb/serverinfo_zone.proto
+++ b/common/pb/serverinfo_zone.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "serverinfo_card.proto";
 
 message ServerInfo_Zone {

--- a/common/pb/session_commands.proto
+++ b/common/pb/session_commands.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "serverinfo_user.proto";
 
 message SessionCommand {

--- a/common/pb/session_event.proto
+++ b/common/pb/session_event.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 message SessionEvent {
     enum SessionEventType {
         SERVER_IDENTIFICATION = 500;


### PR DESCRIPTION
When compiling, protobuf has been throwing warnings that look similar to 
`
libprotobuf WARNING google/protobuf/compiler/parser.cc:546] No syntax specified for the proto file: serverinfo_gametype.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
`

This fixes those warnings. Small change.