### PR TITLE
Move related card creation out of sub menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ mysql.cnf
 .DS_Store
 .idea/
 *.aps
+cmake-build-debug/

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -107,12 +107,12 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
 {
     userInfo = new ServerInfo_User;
     userInfo->CopyFrom(info);
-    
+
     connect(settingsCache, SIGNAL(horizontalHandChanged()), this, SLOT(rearrangeZones()));
     connect(settingsCache, SIGNAL(handJustificationChanged()), this, SLOT(rearrangeZones()));
-    
+
     playerArea = new PlayerArea(this);
-    
+
     playerTarget = new PlayerTarget(this, playerArea);
     qreal avatarMargin = (counterAreaWidth + CARD_HEIGHT + 15 - playerTarget->boundingRect().width()) / 2.0;
     playerTarget->setPos(QPointF(avatarMargin, avatarMargin));
@@ -126,7 +126,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
     HandCounter *handCounter = new HandCounter(playerArea);
     handCounter->setPos(base + QPointF(0, h + 10));
     qreal h2 = handCounter->boundingRect().height();
-    
+
     PileZone *grave = new PileZone(this, "grave", false, true, playerArea);
     grave->setPos(base + QPointF(0, h + h2 + 10));
 
@@ -138,19 +138,19 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
 
     table = new TableZone(this, this);
     connect(table, SIGNAL(sizeChanged()), this, SLOT(updateBoundingRect()));
-    
+
     stack = new StackZone(this, (int) table->boundingRect().height(), this);
-    
+
     hand = new HandZone(this, _local || (_parent->getSpectator() && _parent->getSpectatorsSeeEverything()), (int) table->boundingRect().height(), this);
     connect(hand, SIGNAL(cardCountChanged()), handCounter, SLOT(updateNumber()));
     connect(handCounter, SIGNAL(showContextMenu(const QPoint &)), hand, SLOT(showContextMenu(const QPoint &)));
-    
+
     updateBoundingRect();
 
     if (local) {
         connect(_parent, SIGNAL(playerAdded(Player *)), this, SLOT(addPlayer(Player *)));
         connect(_parent, SIGNAL(playerRemoved(Player *)), this, SLOT(removePlayer(Player *)));
-        
+
         aMoveHandToTopLibrary = new QAction(this);
         aMoveHandToTopLibrary->setData(QList<QVariant>() << "deck" << 0);
         aMoveHandToBottomLibrary = new QAction(this);
@@ -159,7 +159,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
         aMoveHandToGrave->setData(QList<QVariant>() << "grave" << 0);
         aMoveHandToRfg = new QAction(this);
         aMoveHandToRfg->setData(QList<QVariant>() << "rfg" << 0);
-        
+
         connect(aMoveHandToTopLibrary, SIGNAL(triggered()), hand, SLOT(moveAllToZone()));
         connect(aMoveHandToBottomLibrary, SIGNAL(triggered()), hand, SLOT(moveAllToZone()));
         connect(aMoveHandToGrave, SIGNAL(triggered()), hand, SLOT(moveAllToZone()));
@@ -173,7 +173,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
         aMoveGraveToHand->setData(QList<QVariant>() << "hand" << 0);
         aMoveGraveToRfg = new QAction(this);
         aMoveGraveToRfg->setData(QList<QVariant>() << "rfg" << 0);
-        
+
         connect(aMoveGraveToTopLibrary, SIGNAL(triggered()), grave, SLOT(moveAllToZone()));
         connect(aMoveGraveToBottomLibrary, SIGNAL(triggered()), grave, SLOT(moveAllToZone()));
         connect(aMoveGraveToHand, SIGNAL(triggered()), grave, SLOT(moveAllToZone()));
@@ -187,7 +187,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
         aMoveRfgToHand->setData(QList<QVariant>() << "hand" << 0);
         aMoveRfgToGrave = new QAction(this);
         aMoveRfgToGrave->setData(QList<QVariant>() << "grave" << 0);
-        
+
         connect(aMoveRfgToTopLibrary, SIGNAL(triggered()), rfg, SLOT(moveAllToZone()));
         connect(aMoveRfgToBottomLibrary, SIGNAL(triggered()), rfg, SLOT(moveAllToZone()));
         connect(aMoveRfgToHand, SIGNAL(triggered()), rfg, SLOT(moveAllToZone()));
@@ -214,7 +214,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
     if (local) {
         aViewSideboard = new QAction(this);
         connect(aViewSideboard, SIGNAL(triggered()), this, SLOT(actViewSideboard()));
-    
+
         aDrawCard = new QAction(this);
         connect(aDrawCard, SIGNAL(triggered()), this, SLOT(actDrawCard()));
         aDrawCards = new QAction(this);
@@ -320,14 +320,14 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
 
         aRollDie = new QAction(this);
         connect(aRollDie, SIGNAL(triggered()), this, SLOT(actRollDie()));
-    
+
         aCreateToken = new QAction(this);
         connect(aCreateToken, SIGNAL(triggered()), this, SLOT(actCreateToken()));
-        
+
         aCreateAnotherToken = new QAction(this);
         connect(aCreateAnotherToken, SIGNAL(triggered()), this, SLOT(actCreateAnotherToken()));
         aCreateAnotherToken->setEnabled(false);
-        
+
         createPredefinedTokenMenu = new QMenu(QString());
 
         playerMenu->addSeparator();
@@ -343,7 +343,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
         playerMenu->addSeparator();
         sayMenu = playerMenu->addMenu(QString());
         initSayMenu();
-        
+
         aCardMenu = new QAction(this);
         playerMenu->addSeparator();
         playerMenu->addAction(aCardMenu);
@@ -362,7 +362,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
         createPredefinedTokenMenu = 0;
         aCardMenu = 0;
     }
-    
+
     aTap = new QAction(this);
     aTap->setData(cmTap);
     connect(aTap, SIGNAL(triggered()), this, SLOT(cardMenuAction()));
@@ -418,7 +418,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
     connect(aMoveToHand, SIGNAL(triggered()), this, SLOT(cardMenuAction()));
     connect(aMoveToGraveyard, SIGNAL(triggered()), this, SLOT(cardMenuAction()));
     connect(aMoveToExile, SIGNAL(triggered()), this, SLOT(cardMenuAction()));
-    
+
     aPlay = new QAction(this);
     connect(aPlay, SIGNAL(triggered()), this, SLOT(actPlay()));
     aHide = new QAction(this);
@@ -444,7 +444,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
     const QList<Player *> &players = game->getPlayers().values();
     for (int i = 0; i < players.size(); ++i)
         addPlayer(players[i]);
-    
+
     rearrangeZones();
     retranslateUi();
     connect(&settingsCache->shortcuts(), SIGNAL(shortCutchanged()),this,SLOT(refreshShortcuts()));
@@ -456,13 +456,13 @@ Player::~Player()
     qDebug() << "Player destructor:" << getName();
 
     static_cast<GameScene *>(scene())->removePlayer(this);
-    
+
     clear();
     QMapIterator<QString, CardZone *> i(zones);
     while (i.hasNext())
         delete i.next().value();
     zones.clear();
-    
+
     delete playerMenu;
     delete userInfo;
 }
@@ -470,11 +470,11 @@ Player::~Player()
 void Player::clear()
 {
     clearArrows();
-    
+
     QMapIterator<QString, CardZone *> i(zones);
     while (i.hasNext())
         i.next().value()->clearContents();
-    
+
     clearCounters();
 }
 
@@ -505,12 +505,12 @@ void Player::playerListActionTriggered()
 {
     QAction *action = static_cast<QAction *>(sender());
     QMenu *menu = static_cast<QMenu *>(action->parentWidget());
-    
+
     Command_RevealCards cmd;
     const int otherPlayerId = action->data().toInt();
     if (otherPlayerId != -1)
         cmd.set_player_id(otherPlayerId);
-    
+
     if (menu == mRevealLibrary) {
         cmd.set_zone_name("deck");
     } else if (menu == mRevealTopCard) {
@@ -523,7 +523,7 @@ void Player::playerListActionTriggered()
             // backward compatibility: servers before #1051 only permits to reveal the first card
             cmd.set_card_id(0);
         }
-        
+
     } else if (menu == mRevealHand)
         cmd.set_zone_name("hand");
     else if (menu == mRevealRandomHandCard) {
@@ -531,7 +531,7 @@ void Player::playerListActionTriggered()
         cmd.set_card_id(-2);
     } else
         return;
-    
+
     sendGameCommand(cmd);
 }
 
@@ -546,17 +546,17 @@ void Player::rearrangeZones()
                 base += QPointF(0, hand->boundingRect().height());
             } else
                 handVisible = false;
-            
+
             stack->setPos(base);
             base += QPointF(stack->boundingRect().width(), 0);
-            
+
             table->setPos(base);
         } else {
             stack->setPos(base);
-            
+
             table->setPos(base.x() + stack->boundingRect().width(), 0);
             base += QPointF(0, table->boundingRect().height());
-            
+
             if (hand->contentsKnown()) {
                 handVisible = true;
                 hand->setPos(base);
@@ -566,13 +566,13 @@ void Player::rearrangeZones()
         hand->setWidth(table->getWidth() + stack->boundingRect().width());
     } else {
         handVisible = true;
-        
+
         hand->setPos(base);
         base += QPointF(hand->boundingRect().width(), 0);
-        
+
         stack->setPos(base);
         base += QPointF(stack->boundingRect().width(), 0);
-        
+
         table->setPos(base);
     }
     hand->setVisible(handVisible);
@@ -597,7 +597,7 @@ void Player::updateBoundingRect()
     } else
         bRect = QRectF(0, 0, width + hand->boundingRect().width() + table->boundingRect().width(), table->boundingRect().height());
     playerArea->setSize(CARD_HEIGHT + counterAreaWidth + 15, bRect.height());
-    
+
     emit sizeChanged();
 }
 
@@ -609,7 +609,7 @@ void Player::retranslateUi()
     playerMenu->setTitle(tr("Player \"%1\"").arg(QString::fromStdString(userInfo->name())));
     graveMenu->setTitle(tr("&Graveyard"));
     rfgMenu->setTitle(tr("&Exile"));
-    
+
     if (local) {
         moveHandMenu->setTitle(tr("&Move hand to..."));
         aMoveHandToTopLibrary->setText(tr("&Top of library"));
@@ -646,7 +646,7 @@ void Player::retranslateUi()
         aMoveTopCardsToExile->setText(tr("Move top cards to &exile..."));
         aMoveTopCardToBottom->setText(tr("Put top card on &bottom"));
         aMoveBottomCardToGrave->setText(tr("Put bottom card &in graveyard"));
-    
+
         handMenu->setTitle(tr("&Hand"));
         mRevealHand->setTitle(tr("&Reveal hand to..."));
         mRevealRandomHandCard->setTitle(tr("Reveal r&andom card to..."));
@@ -660,13 +660,13 @@ void Player::retranslateUi()
         aCreateAnotherToken->setText(tr("C&reate another token"));
         createPredefinedTokenMenu->setTitle(tr("Cr&eate predefined token"));
         sayMenu->setTitle(tr("S&ay"));
-        
+
         QMapIterator<int, AbstractCounter *> counterIterator(counters);
         while (counterIterator.hasNext())
             counterIterator.next().value()->retranslateUi();
 
         aCardMenu->setText(tr("C&ard"));
-        
+
         for (int i = 0; i < allPlayersActions.size(); ++i)
             allPlayersActions[i]->setText(tr("&All players"));
     }
@@ -721,7 +721,7 @@ void Player::retranslateUi()
 void Player::setShortcutsActive()
 {
     shortcutsActive = true;
-    
+
     aPlay->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aPlay"));
     aTap->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aTap"));
     aUntap->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aUntap"));
@@ -794,7 +794,7 @@ void Player::setShortcutsActive()
 void Player::setShortcutsInactive()
 {
     shortcutsActive = false;
-    
+
     aViewSideboard->setShortcut(QKeySequence());
     aViewLibrary->setShortcut(QKeySequence());
     aViewTopCards->setShortcut(QKeySequence());
@@ -835,7 +835,7 @@ void Player::setDeck(const DeckLoader &_deck)
 {
     deck = new DeckLoader(_deck);
     aOpenDeckInDeckEditor->setEnabled(deck);
-    
+
     createPredefinedTokenMenu->clear();
     predefinedTokens.clear();
     InnerDecklistNode *tokenZone = dynamic_cast<InnerDecklistNode *>(deck->getRoot()->findChild("tokens"));
@@ -873,7 +873,7 @@ void Player::actAlwaysRevealTopCard()
     Command_ChangeZoneProperties cmd;
     cmd.set_zone_name("deck");
     cmd.set_always_reveal_top_card(aAlwaysRevealTopCard->isChecked());
-    
+
     sendGameCommand(cmd);
 }
 
@@ -948,7 +948,7 @@ void Player::actMoveTopCardsToGrave()
 
     for (int i = 0; i < number; ++i)
         cmd.mutable_cards_to_move()->add_card()->set_card_id(i);
-    
+
     sendGameCommand(cmd);
 }
 
@@ -961,7 +961,7 @@ void Player::actMoveTopCardsToExile()
     const int maxCards = zones.value("deck")->getCards().size();
     if (number > maxCards)
         number = maxCards;
-    
+
     Command_MoveCard cmd;
     cmd.set_start_zone("deck");
     cmd.set_target_player_id(getId());
@@ -971,7 +971,7 @@ void Player::actMoveTopCardsToExile()
 
     for (int i = 0; i < number; ++i)
         cmd.mutable_cards_to_move()->add_card()->set_card_id(i);
-    
+
     sendGameCommand(cmd);
 }
 
@@ -984,7 +984,7 @@ void Player::actMoveTopCardToBottom()
     cmd.set_target_zone("deck");
     cmd.set_x(-1);
     cmd.set_y(0);
-    
+
     sendGameCommand(cmd);
 }
 
@@ -999,7 +999,7 @@ void Player::actMoveTopCardToPlayFaceDown()
     cmd.set_target_zone("table");
     cmd.set_x(-1);
     cmd.set_y(0);
-    
+
     sendGameCommand(cmd);
 }
 
@@ -1022,7 +1022,7 @@ void Player::actUntapAll()
     cmd.set_zone("table");
     cmd.set_attribute(AttrTapped);
     cmd.set_attr_value("0");
-    
+
     sendGameCommand(cmd);
 }
 
@@ -1056,7 +1056,7 @@ void Player::actCreateToken()
     lastTokenAnnotation = dlg.getAnnotation();
     lastTokenDestroy = dlg.getDestroy();
     aCreateAnotherToken->setEnabled(true);
-    
+
     actCreateAnotherToken();
 }
 
@@ -1071,7 +1071,7 @@ void Player::actCreateAnotherToken()
     cmd.set_destroy_on_zone_change(lastTokenDestroy);
     cmd.set_x(-1);
     cmd.set_y(lastTokenTableRow);
-    
+
     sendGameCommand(cmd);
 }
 
@@ -1089,7 +1089,7 @@ void Player::actCreatePredefinedToken()
     lastTokenTableRow = table->clampValidTableRow(2 - cardInfo->getTableRow());
     lastTokenDestroy = true;
     aCreateAnotherToken->setEnabled(true);
-    
+
     actCreateAnotherToken();
 }
 
@@ -1104,13 +1104,14 @@ void Player::actCreateRelatedCard()
     QAction *action = static_cast<QAction *>(sender());
 
     // removes p/t from tokens (and leading space))
-    QStringList spaces = action->text().split(" ");
+    // Added split for "Token:" due to change in PR fixing #2317
+    QStringList spaces = action->text().split(tr("Token: "))[1].split(" ");
     if (spaces.at(0).indexOf("/") != -1) // Strip space from creatures
         spaces.removeFirst();
     CardInfo *cardInfo = db->getCard(spaces.join(" "));
     if(!cardInfo)
         return;
-    
+
     // get the target token's location
     // TODO: Define this QPoint into its own function along with the one below
     QPoint gridPoint = QPoint(-1, table->clampValidTableRow(2 - cardInfo->getTableRow()));
@@ -1202,7 +1203,7 @@ void Player::eventCreateArrow(const Event_CreateArrow &event)
     ArrowItem *arrow = addArrow(event.arrow_info());
     if (!arrow)
         return;
-    
+
     CardItem *startCard = static_cast<CardItem *>(arrow->getStartItem());
     CardItem *targetCard = qgraphicsitem_cast<CardItem *>(arrow->getTargetItem());
     if (targetCard)
@@ -1272,7 +1273,7 @@ void Player::eventSetCardCounter(const Event_SetCardCounter &event)
     CardItem *card = zone->getCard(event.card_id(), QString());
     if (!card)
         return;
-    
+
     int oldValue = card->getCounters().value(event.counter_id(), 0);
     card->setCounter(event.counter_id(), event.counter_value());
     emit logSetCardCounter(this, card->getName(), event.counter_id(), event.counter_value(), oldValue);
@@ -1336,7 +1337,7 @@ void Player::eventMoveCard(const Event_MoveCard &event, const GameEventContext &
         targetZone = startZone;
     if (!startZone || !targetZone)
         return;
-    
+
     int position = event.position();
     int x = event.x();
     int y = event.y();
@@ -1352,7 +1353,7 @@ void Player::eventMoveCard(const Event_MoveCard &event, const GameEventContext &
         card->deleteCardInfoPopup();
     if (event.has_card_name())
         card->setName(QString::fromStdString(event.card_name()));
-    
+
     if (card->getAttachedTo() && (startZone != targetZone)) {
         CardItem *parentCard = card->getAttachedTo();
         card->setAttachedTo(0);
@@ -1366,11 +1367,11 @@ void Player::eventMoveCard(const Event_MoveCard &event, const GameEventContext &
     if (startZone != targetZone) {
         card->setBeingPointedAt(false);
         card->setHovered(false);
-        
+
         const QList<CardItem *> &attachedCards = card->getAttachedCards();
         for (int i = 0; i < attachedCards.size(); ++i)
             attachedCards[i]->setParentItem(targetZone);
-        
+
         if (startZone->getPlayer() != targetZone->getPlayer())
             card->setOwner(targetZone->getPlayer());
     }
@@ -1423,16 +1424,16 @@ void Player::eventDestroyCard(const Event_DestroyCard &event)
     CardZone *zone = zones.value(QString::fromStdString(event.zone_name()), 0);
     if (!zone)
         return;
-    
+
     CardItem *card = zone->getCard(event.card_id(), QString());
     if (!card)
         return;
-    
+
     QList<CardItem *> attachedCards = card->getAttachedCards();
     // This list is always empty except for buggy server implementations.
     for (int i = 0; i < attachedCards.size(); ++i)
         attachedCards[i]->setAttachedTo(0);
-    
+
     emit logDestroyCard(this, card->getName());
     zone->takeCard(-1, event.card_id(), true);
     card->deleteLater();
@@ -1452,25 +1453,25 @@ void Player::eventAttachCard(const Event_AttachCard &event)
                 targetCard = targetZone->getCard(event.target_card_id(), QString());
         }
     }
-    
+
     CardZone *startZone = getZones().value(QString::fromStdString(event.start_zone()), 0);
     if (!startZone)
         return;
-    
+
     CardItem *startCard = startZone->getCard(event.card_id(), QString());
     if (!startCard)
         return;
-    
+
     CardItem *oldParent = startCard->getAttachedTo();
-    
+
     startCard->setAttachedTo(targetCard);
-    
+
     startZone->reorganizeCards();
     if ((startZone != targetZone) && targetZone)
         targetZone->reorganizeCards();
     if (oldParent)
         oldParent->getZone()->reorganizeCards();
-    
+
     if (targetCard)
         emit logAttachCard(this, startCard->getName(), targetPlayer, targetCard->getName());
     else
@@ -1481,7 +1482,7 @@ void Player::eventDrawCards(const Event_DrawCards &event)
 {
     CardZone *deck = zones.value("deck");
     CardZone *hand = zones.value("hand");
-    
+
     const int listSize = event.cards_size();
     if (listSize) {
         for (int i = 0; i < listSize; ++i) {
@@ -1495,7 +1496,7 @@ void Player::eventDrawCards(const Event_DrawCards &event)
         for (int i = 0; i < number; ++i)
             hand->addCard(deck->takeCard(0, -1), false, -1);
     }
-    
+
     hand->reorganizeCards();
     deck->reorganizeCards();
     emit logDrawCards(this, event.number());
@@ -1512,7 +1513,7 @@ void Player::eventRevealCards(const Event_RevealCards &event)
         if (!otherPlayer)
             return;
     }
-    
+
     bool peeking = false;
     QList<const ServerInfo_Card *> cardList;
     const int cardListSize = event.cards_size();
@@ -1522,7 +1523,7 @@ void Player::eventRevealCards(const Event_RevealCards &event)
             peeking = true;
         cardList.append(temp);
     }
-    
+
     if (peeking) {
         for (int i = 0; i < cardList.size(); ++i) {
             QString cardName = QString::fromStdString(cardList.at(i)->name());
@@ -1545,7 +1546,7 @@ void Player::eventRevealCards(const Event_RevealCards &event)
         }
         if (showZoneView && !cardList.isEmpty())
             static_cast<GameScene *>(scene())->addRevealedZoneView(this, zone, cardList, event.grant_write_access());
-        
+
         emit logRevealCards(this, zone, event.card_id(), cardName, otherPlayer, false);
     }
 }
@@ -1555,7 +1556,7 @@ void Player::eventChangeZoneProperties(const Event_ChangeZoneProperties &event)
     CardZone *zone = zones.value(QString::fromStdString(event.zone_name()));
     if (!zone)
         return;
-    
+
     if (event.has_always_reveal_top_card()) {
         zone->setAlwaysRevealTopCard(event.always_reveal_top_card());
         emit logAlwaysRevealTopCard(this, zone, event.always_reveal_top_card());
@@ -1611,18 +1612,18 @@ void Player::processPlayerInfo(const ServerInfo_Player &info)
 {
     clearCounters();
     clearArrows();
-    
+
     QMapIterator<QString, CardZone *> zoneIt(zones);
     while (zoneIt.hasNext())
         zoneIt.next().value()->clearContents();
-    
+
     const int zoneListSize = info.zone_list_size();
     for (int i = 0; i < zoneListSize; ++i) {
         const ServerInfo_Zone &zoneInfo = info.zone_list(i);
         CardZone *zone = zones.value(QString::fromStdString(zoneInfo.name()), 0);
         if (!zone)
             continue;
-        
+
         const int cardListSize = zoneInfo.card_list_size();
         if (!cardListSize) {
             for (int j = 0; j < zoneInfo.card_count(); ++j)
@@ -1637,14 +1638,14 @@ void Player::processPlayerInfo(const ServerInfo_Player &info)
         }
         if (zoneInfo.has_always_reveal_top_card())
             zone->setAlwaysRevealTopCard(zoneInfo.always_reveal_top_card());
-        
+
         zone->reorganizeCards();
     }
-    
+
     const int counterListSize = info.counter_list_size();
     for (int i = 0; i < counterListSize; ++i)
         addCounter(info.counter_list(i));
-    
+
     setConceded(info.properties().conceded());
 }
 
@@ -1656,7 +1657,7 @@ void Player::processCardAttachment(const ServerInfo_Player &info)
         CardZone *zone = zones.value(QString::fromStdString(zoneInfo.name()), 0);
         if (!zone)
             continue;
-        
+
         const int cardListSize = zoneInfo.card_list_size();
         for (int j = 0; j < cardListSize; ++j) {
             const ServerInfo_Card &cardInfo = zoneInfo.card_list(j);
@@ -1665,12 +1666,12 @@ void Player::processCardAttachment(const ServerInfo_Player &info)
                 CardItem *targetCard = game->getCard(cardInfo.attach_player_id(), QString::fromStdString(cardInfo.attach_zone()), cardInfo.attach_card_id());
                 if (!targetCard)
                     continue;
-                
+
                 startCard->setAttachedTo(targetCard);
             }
         }
     }
-    
+
     const int arrowListSize = info.arrow_list_size();
     for (int i = 0; i < arrowListSize; ++i)
         addArrow(info.arrow_list(i));
@@ -1684,7 +1685,7 @@ void Player::playCard(CardItem *c, bool faceDown, bool tapped)
     cmd.set_target_player_id(getId());
     CardToMove *cardToMove = cmd.mutable_cards_to_move()->add_card();
     cardToMove->set_card_id(c->getId());
-    
+
     CardInfo *ci = c->getInfo();
     if(!ci)
         return;
@@ -1736,7 +1737,7 @@ AbstractCounter *Player::addCounter(int counterId, const QString &name, QColor c
     qDebug() << "addCounter:" << getName() << counterId << name;
     if (counters.contains(counterId))
         return 0;
-    
+
     AbstractCounter *c;
     if (name == "life")
         c = playerTarget->addCounter(counterId, name, value);
@@ -1756,7 +1757,7 @@ void Player::delCounter(int counterId)
     AbstractCounter *c = counters.value(counterId, 0);
     if (!c)
         return;
-    
+
     c->delCounter();
     counters.remove(counterId);
     rearrangeCounters();
@@ -1777,21 +1778,21 @@ ArrowItem *Player::addArrow(const ServerInfo_Arrow &arrow)
     Player *targetPlayer = playerList.value(arrow.target_player_id(), 0);
     if (!startPlayer || !targetPlayer)
         return 0;
-    
+
     CardZone *startZone = startPlayer->getZones().value(QString::fromStdString(arrow.start_zone()), 0);
     CardZone *targetZone = 0;
     if (arrow.has_target_zone())
         targetZone = targetPlayer->getZones().value(QString::fromStdString(arrow.target_zone()), 0);
     if (!startZone || (!targetZone && arrow.has_target_zone()))
         return 0;
-    
+
     CardItem *startCard = startZone->getCard(arrow.start_card_id(), QString());
     CardItem *targetCard = 0;
     if (targetZone)
         targetCard = targetZone->getCard(arrow.target_card_id(), QString());
     if (!startCard || (!targetCard && arrow.has_target_card_id()))
         return 0;
-    
+
     if (targetCard)
         return addArrow(arrow.id(), startCard, targetCard, convertColorToQColor(arrow.arrow_color()));
     else
@@ -1831,7 +1832,7 @@ void Player::clearArrows()
 void Player::rearrangeCounters()
 {
     qreal marginTop = 80;
-    
+
     // Determine total height of bounding rectangles
     qreal totalHeight = 0;
     QMapIterator<int, AbstractCounter *> counterIterator(counters);
@@ -1840,17 +1841,17 @@ void Player::rearrangeCounters()
         if (counterIterator.value()->getShownInCounterArea())
             totalHeight += counterIterator.value()->boundingRect().height();
     }
-    
+
     const qreal padding = 5;
     qreal y = boundingRect().y() + marginTop;
-    
+
     // Place objects
     for (counterIterator.toFront(); counterIterator.hasNext(); ) {
         AbstractCounter *c = counterIterator.next().value();
 
         if (!c->getShownInCounterArea())
             continue;
-        
+
         QRectF br = c->boundingRect();
         c->setPos((counterAreaWidth - br.width()) / 2, y);
         y += br.height() + padding;
@@ -1881,11 +1882,11 @@ bool Player::clearCardsToDelete()
 {
     if (cardsToDelete.isEmpty())
         return false;
-    
+
     for (int i = 0; i < cardsToDelete.size(); ++i)
         cardsToDelete[i]->deleteLater();
     cardsToDelete.clear();
-    
+
     return true;
 }
 
@@ -1896,7 +1897,7 @@ void Player::cardMenuAction()
     QList<CardItem *> cardList;
     while (!sel.isEmpty())
         cardList.append(qgraphicsitem_cast<CardItem *>(sel.takeFirst()));
-    
+
     QList< const ::google::protobuf::Message * > commandList;
     if (a->data().toInt() <= (int) cmClone)
         for (int i = 0; i < cardList.size(); ++i) {
@@ -1969,7 +1970,7 @@ void Player::cardMenuAction()
             idList.add_card()->set_card_id(cardList[i]->getId());
         int startPlayerId = cardList[0]->getZone()->getPlayer()->getId();
         QString startZone = cardList[0]->getZone()->getName();
-        
+
         switch (static_cast<CardMenuActionType>(a->data().toInt())) {
             case cmMoveToTopLibrary: {
                 Command_MoveCard *cmd = new Command_MoveCard;
@@ -2044,7 +2045,7 @@ void Player::actIncPT(int deltaP, int deltaT)
 {
     QString ptString = "+" + QString::number(deltaP) + "/+" + QString::number(deltaT);
     int playerid = id;
-    
+
     QList< const ::google::protobuf::Message * > commandList;
     QListIterator<QGraphicsItem *> j(scene()->selectedItems());
     while (j.hasNext()) {
@@ -2082,7 +2083,7 @@ void Player::actSetPT()
         return;
     if (!ok)
         return;
-    
+
     QList< const ::google::protobuf::Message * > commandList;
     QListIterator<QGraphicsItem *> j(scene()->selectedItems());
     while (j.hasNext()) {
@@ -2148,7 +2149,7 @@ void Player::actSetAnnotation()
         if (!card->getAnnotation().isEmpty())
             oldAnnotation = card->getAnnotation();
     }
-    
+
     bool ok;
     dialogSemaphore = true;
     QString annotation = QInputDialog::getText(0, tr("Set annotation"), tr("Please enter the new annotation:"), QLineEdit::Normal, oldAnnotation, &ok);
@@ -2157,7 +2158,7 @@ void Player::actSetAnnotation()
         return;
     if (!ok)
         return;
-    
+
     QList< const ::google::protobuf::Message * > commandList;
     i.toFront();
     while (i.hasNext()) {
@@ -2176,7 +2177,7 @@ void Player::actAttach()
 {
     if(!game->getActiveCard())
         return;
-    
+
     ArrowAttachItem *arrow = new ArrowAttachItem(game->getActiveCard());
     scene()->addItem(arrow);
     arrow->grabMouse();
@@ -2239,7 +2240,7 @@ void Player::actCardCounterTrigger()
                 return;
             if (!ok)
                 return;
-        
+
             QListIterator<QGraphicsItem *> i(scene()->selectedItems());
             while (i.hasNext()) {
                 CardItem *card = static_cast<CardItem *>(i.next());
@@ -2293,9 +2294,9 @@ void Player::updateCardMenu(CardItem *card)
     QMenu *cardMenu = card->getCardMenu();
     QMenu *ptMenu = card->getPTMenu();
     QMenu *moveMenu = card->getMoveMenu();
-    
+
     cardMenu->clear();
-    
+
     bool revealedCard = false;
     bool writeableCard = getLocal();
     if (card->getZone() && card->getZone()->getIsView()) {
@@ -2307,7 +2308,7 @@ void Player::updateCardMenu(CardItem *card)
                 revealedCard = true;
         }
     }
-    
+
     if (revealedCard)
         cardMenu->addAction(aHide);
     else if (writeableCard) {
@@ -2321,7 +2322,7 @@ void Player::updateCardMenu(CardItem *card)
             moveMenu->addSeparator();
             moveMenu->addAction(aMoveToExile);
         }
-        
+
         if (card->getZone()) {
             if (card->getZone()->getName() == "table") {
                 if (ptMenu->isEmpty()) {
@@ -2336,7 +2337,7 @@ void Player::updateCardMenu(CardItem *card)
                     ptMenu->addSeparator();
                     ptMenu->addAction(aSetPT);
                 }
-                
+
                 cardMenu->addAction(aTap);
                 cardMenu->addAction(aUntap);
                 cardMenu->addAction(aDoesntUntap);
@@ -2350,16 +2351,17 @@ void Player::updateCardMenu(CardItem *card)
                     QStringList reverserelatedCards2Me = card->getInfo()->getReverseRelatedCards2Me();
                     if(relatedCards.size() || reverserelatedCards2Me.size())
                     {
-                        QMenu * createRelatedCardMenu = cardMenu->addMenu(tr("Cr&eate related card"));
-
+                        cardMenu->addSeparator();
                         for (int i = 0; i < relatedCards.size(); ++i) {
-                            QAction *a = createRelatedCardMenu->addAction(relatedCards.at(i));
+                            QAction *a = new QAction(tr("Token: ") + relatedCards.at(i), this);
                             connect(a, SIGNAL(triggered()), this, SLOT(actCreateRelatedCard()));
+                            cardMenu->addAction(a);
                         }
 
                         for (int i = 0; i < reverserelatedCards2Me.size(); ++i) {
-                            QAction *a = createRelatedCardMenu->addAction(reverserelatedCards2Me.at(i));
+                            QAction *a = new QAction(tr("Token: ") + reverserelatedCards2Me.at(i), this);
                             connect(a, SIGNAL(triggered()), this, SLOT(actCreateRelatedCard()));
+                            cardMenu->addAction(a);
                         }
                     }
                 }
@@ -2374,7 +2376,7 @@ void Player::updateCardMenu(CardItem *card)
                 cardMenu->addSeparator();
                 cardMenu->addAction(aClone);
                 cardMenu->addMenu(moveMenu);
-                
+
                 for (int i = 0; i < aAddCounter.size(); ++i) {
                     cardMenu->addSeparator();
                     cardMenu->addAction(aAddCounter[i]);
@@ -2392,16 +2394,17 @@ void Player::updateCardMenu(CardItem *card)
                     QStringList reverserelatedCards2Me = card->getInfo()->getReverseRelatedCards2Me();
                     if(relatedCards.size() || reverserelatedCards2Me.size())
                     {
-                        QMenu * createRelatedCardMenu = cardMenu->addMenu(tr("Cr&eate related card"));
-
+                        cardMenu->addSeparator();
                         for (int i = 0; i < relatedCards.size(); ++i) {
-                            QAction *a = createRelatedCardMenu->addAction(relatedCards.at(i));
+                            QAction *a = new QAction(tr("Token: ") + relatedCards.at(i), this);
                             connect(a, SIGNAL(triggered()), this, SLOT(actCreateRelatedCard()));
+                            cardMenu->addAction(a);
                         }
 
                         for (int i = 0; i < reverserelatedCards2Me.size(); ++i) {
-                            QAction *a = createRelatedCardMenu->addAction(reverserelatedCards2Me.at(i));
+                            QAction *a = new QAction(tr("Token: ") + reverserelatedCards2Me.at(i), this);
                             connect(a, SIGNAL(triggered()), this, SLOT(actCreateRelatedCard()));
+                            cardMenu->addAction(a);
                         }
                     }
                 }
@@ -2472,7 +2475,7 @@ void Player::processSceneSizeChange(int newPlayerWidth)
     qreal tableWidth = newPlayerWidth - CARD_HEIGHT - 15 - counterAreaWidth - stack->boundingRect().width();
     if (!settingsCache->getHorizontalHand())
         tableWidth -= hand->boundingRect().width();
-    
+
     table->setWidth(tableWidth);
     hand->setWidth(tableWidth + stack->boundingRect().width());
 }


### PR DESCRIPTION
Fix #2317 

This changes how the sub-menu works relating to tokens. Instead of an additional sub-menu, there will now be additional components to the main menu that say "Token: n/n Example".

<img width="315" alt="screenshot 2016-12-16 03 52 05" src="https://cloud.githubusercontent.com/assets/7460172/21256942/38ef0516-c343-11e6-85ee-7123540fa2c1.png">
<img width="416" alt="screenshot 2016-12-16 03 52 15" src="https://cloud.githubusercontent.com/assets/7460172/21256941/38ed9848-c343-11e6-8542-d04c6153d6aa.png">

Works on both the stack and play ground.

PS: CLion 2016.3 started doing auto cmake builds, added that folder to gitignore.