### PR TITLE
Fix idle timeout warning on registration / login

### DIFF
--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -394,7 +394,7 @@ void Server_ProtocolHandler::pingClockTimeout()
             }
         }
 
-        if (((timeRunning - lastActionReceived) >= ceil(server->getIdleClientTimeout() *.9)) && (!idleClientWarningSent)) {
+        if (((timeRunning - lastActionReceived) >= ceil(server->getIdleClientTimeout() *.9)) && (!idleClientWarningSent) && (server->getIdleClientTimeout() > 0)) {
             Event_NotifyUser event;
             event.set_type(Event_NotifyUser::IDLEWARNING);
             SessionEvent *se = prepareSessionEvent(event);


### PR DESCRIPTION
Fix #2319
This should resolve the issue of users getting the popup immediately when logging in and the time out value is set to 0.
This needs tested, its a quick fix put in with the web editor.