### PR TITLE
Added privilege level start/end columns

### DIFF
--- a/servatrice/migrations/servatrice_0019_to_0020.sql
+++ b/servatrice/migrations/servatrice_0019_to_0020.sql
@@ -1,0 +1,8 @@
+-- Servatrice db migration from version 19 to version 20
+
+alter table cockatrice_users add column privlevelStartDate datetime NOT NULL;
+alter table cockatrice_users add column privlevelEndDate datetime NOT NULL;
+update cockatrice_users set privlevelStartDate = NOW() where privlevel != 'NONE';
+update cockatrice_users set privlevelEndDate = DATE_ADD(NOW() , INTERVAL 30 DAY) where privlevel != 'NONE';
+
+UPDATE cockatrice_schema_version SET version=20 WHERE version=19;

--- a/servatrice/migrations/servatrice_0019_to_0020.sql
+++ b/servatrice/migrations/servatrice_0019_to_0020.sql
@@ -5,4 +5,16 @@ alter table cockatrice_users add column privlevelEndDate datetime NOT NULL;
 update cockatrice_users set privlevelStartDate = NOW() where privlevel != 'NONE';
 update cockatrice_users set privlevelEndDate = DATE_ADD(NOW() , INTERVAL 30 DAY) where privlevel != 'NONE';
 
+CREATE TABLE IF NOT EXISTS `cockatrice_donations` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `username` varchar(255) DEFAULT NULL,
+  `email` varchar(255) DEFAULT NULL,
+  `payment_pre_fee` double DEFAULT NULL,
+  `payment_post_fee` double DEFAULT NULL,
+  `term_length` int(11) DEFAULT NULL,
+  `date` varchar(255) DEFAULT NULL,
+  `pp_type` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
 UPDATE cockatrice_schema_version SET version=20 WHERE version=19;

--- a/servatrice/scripts/linux/maint_privlevel
+++ b/servatrice/scripts/linux/maint_privlevel
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# SCHEDULE WITH CRONTAB TO RUN ON A REGULAR BASIS
+
+DBNAME="servatrice"					#set this to the database name used
+TABLEPREFIX="cockatrice"			#set this to the prefix used for the table names in the database (do not inclue the _)
+SQLCONFFILE="./mysql.cnf" 			#set this to the path that contains the mysql.cnf file
+mysql --defaults-file=$SQLCONFFILE -h localhost -e "update ""$DBNAME"".""$TABLEPREFIX""_users set privlevel = 'NONE' where privelevel != 'NONE" AND privlevelEndDate < NOW()"

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_schema_version` (
   PRIMARY KEY  (`version`)
 ) ENGINE=INNODB DEFAULT CHARSET=utf8;
 
-INSERT INTO cockatrice_schema_version VALUES(19);
+INSERT INTO cockatrice_schema_version VALUES(20);
 
 -- users and user data tables
 CREATE TABLE IF NOT EXISTS `cockatrice_users` (
@@ -38,6 +38,8 @@ CREATE TABLE IF NOT EXISTS `cockatrice_users` (
   `token` binary(16),
   `clientid` varchar(15) NOT NULL,
   `privlevel` enum("NONE","VIP","DONATOR") NOT NULL,
+  `privlevelStartDate` datetime NOT NULL,
+  `privlevelEndDate` datetime NOT NULL,
   PRIMARY KEY  (`id`),
   UNIQUE KEY `name` (`name`),
   KEY `token` (`token`),

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -246,3 +246,15 @@ CREATE TABLE IF NOT EXISTS `cockatrice_user_analytics` (
   PRIMARY KEY  (`id`),
   FOREIGN KEY(`id`) REFERENCES `cockatrice_users`(`id`)  ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=INNODB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS `cockatrice_donations` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `username` varchar(255) DEFAULT NULL,
+  `email` varchar(255) DEFAULT NULL,
+  `payment_pre_fee` double DEFAULT NULL,
+  `payment_post_fee` double DEFAULT NULL,
+  `term_length` int(11) DEFAULT NULL,
+  `date` varchar(255) DEFAULT NULL,
+  `pp_type` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -9,7 +9,7 @@
 #include "server.h"
 #include "server_database_interface.h"
 
-#define DATABASE_SCHEMA_VERSION 19
+#define DATABASE_SCHEMA_VERSION 20
 
 class Servatrice;
 


### PR DESCRIPTION
Added 2 new columns to the users table to indicate when a users privilege level date / time was recognized and when the privilege level should end.  After some discussions with users in client I realized there was going to need to be a way to understand when a user first recognized and the ability to set a time frame on recognition. 

There currently is no code base changes that does anything with the information.  A maintenance script for checking for expired priv-leveled users and resetting the privlevel's to ```NONE``` has been added.

The current DB upgrade script sets any existing priv-leveled users to expire in 30 days from date of when the db upgrade script is executed.