### PR TITLE
Add configuration to enable/disable internal smtp client

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -374,7 +374,7 @@ void MainWindow::loginError(Response::ResponseCode r, QString reasonStr, quint32
             break;
         case Response::RespAccountNotActivated: {
             bool ok = false;
-            QString token = QInputDialog::getText(this, tr("Account activation"), tr("Your account has not been activated yet.\nYou need to provide the activation token received in the activation email"), QLineEdit::Normal, QString(), &ok);
+            QString token = QInputDialog::getText(this, tr("Account activation"), tr("Your account has not been activated yet.\nYou need to provide the activation token received in the activation email."), QLineEdit::Normal, QString(), &ok);
             if(ok && !token.isEmpty())
             {
                 client->activateToServer(token);

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -142,6 +142,14 @@ disallowedregexp=""
 
 [smtp]
 
+; Enable the internal smtp client to send registration emails.  If you would like to
+; use some other method to send email activation tokens set this value to false. Otherwise
+; setting it to true (default) the server will send canned generated emails containing
+; activation tokens for you during update intervals. Setting this to false will require
+; you to either manually activate user accounts or manually send users the activation token
+; by whatever means.
+enableinternalsmtpclient=true
+
 ; Connectin type: currently supported method are "tcp" and "ssl"; tls is autodetected if available
 connection=tcp
 

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -242,6 +242,11 @@ bool Servatrice::initServer()
     if (getRegistrationEnabled()) {
         qDebug() << "Require email address to register: " << getRequireEmailForRegistrationEnabled();
         qDebug() << "Require email activation via token: " << getRequireEmailActivationEnabled();
+        qDebug() << "Enable Internal SMTP Client: " << getEnableInternalSMTPClient();
+        if (!getEnableInternalSMTPClient())
+        {
+            qDebug() << "WARNING: Registrations are enabled but internal SMTP client is disabled.  Users activation emails will not be automatically mailed to users!";
+        }
     }
 
     if (getDBTypeString() == "mysql") {
@@ -535,7 +540,7 @@ void Servatrice::statusUpdate()
     servatriceDatabaseInterface->execSqlQuery(query);
 
     // send activation emails
-    if (getRegistrationEnabled() && getRequireEmailActivationEnabled())
+    if (getRegistrationEnabled() && getRequireEmailActivationEnabled() && getEnableInternalSMTPClient())
     {
         QSqlQuery *query = servatriceDatabaseInterface->prepareQuery("select a.name, b.email, b.token from {prefix}_activation_emails a left join {prefix}_users b on a.name = b.name");
         if (!servatriceDatabaseInterface->execSqlQuery(query))
@@ -829,4 +834,8 @@ int Servatrice::getIdleClientTimeout() const {
 
 bool Servatrice::getEnableLogQuery() const {
     return settingsCache->value("logging/enablelogquery", false).toBool();
+}
+
+bool Servatrice::getEnableInternalSMTPClient() const {
+    return settingsCache->value("smtp/enableinternalsmtpclient", true).toBool();
 }

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -162,6 +162,7 @@ private:
     int getServerWebSocketPort() const;
     int getISLNetworkPort() const;
     bool getISLNetworkEnabled() const;
+    bool getEnableInternalSMTPClient() const;
 
 public slots:
     void scheduleShutdown(const QString &reason, int minutes);


### PR DESCRIPTION
Fix #1881
This change allows the server operator to enable or disable the internal SMTP client that sends activation emails.  With this new configuration option server operators can choose to require email activation yet use
an external method of account verification and/or account token notification.