### PR TITLE
Condensed Card Counter Context Menu

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -26,6 +26,9 @@ CardItem::CardItem(Player *_owner, const QString &_name, int _cardid, bool _reve
     cardMenu = new QMenu;
     ptMenu = new QMenu;
     moveMenu = new QMenu;
+    addCounterMenu = new QMenu;
+    removeCounterMenu = new QMenu;
+    setCounterMenu = new QMenu;
     
     retranslateUi();
     emit updateCardMenu(this);
@@ -41,6 +44,9 @@ CardItem::~CardItem()
     delete cardMenu;
     delete ptMenu;
     delete moveMenu;
+    delete addCounterMenu;
+    delete removeCounterMenu;
+    delete setCounterMenu;
     
     deleteDragItem();
 }
@@ -82,6 +88,9 @@ void CardItem::retranslateUi()
 {
     moveMenu->setTitle(tr("&Move to"));
     ptMenu->setTitle(tr("&Power / toughness"));
+    addCounterMenu->setTitle(tr("Add Counter"));
+    removeCounterMenu->setTitle(tr("Remove Counter"));
+    setCounterMenu->setTitle(tr("Set Counters"));
 }
 
 void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)

--- a/cockatrice/src/carditem.h
+++ b/cockatrice/src/carditem.h
@@ -32,7 +32,7 @@ private:
     CardItem *attachedTo;
     QList<CardItem *> attachedCards;
     
-    QMenu *cardMenu, *ptMenu, *moveMenu;
+    QMenu *cardMenu, *ptMenu, *moveMenu, *addCounterMenu, *removeCounterMenu, *setCounterMenu;
 
     void prepareDelete();
 public slots:
@@ -75,6 +75,9 @@ public:
     QMenu *getCardMenu() const { return cardMenu; }
     QMenu *getPTMenu() const { return ptMenu; }
     QMenu *getMoveMenu() const { return moveMenu; }
+    QMenu *getAddCounterMenu() const { return addCounterMenu; }
+    QMenu *getRemoveCounterMenu() const { return removeCounterMenu; }
+    QMenu *getSetCounterMenu() const { return setCounterMenu; }
     
     bool animationEvent();
     CardDragItem *createDragItem(int _id, const QPointF &_pos, const QPointF &_scenePos, bool faceDown);

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -698,13 +698,13 @@ void Player::retranslateUi()
     counterColors.append(tr("Green"));
 
     for (int i = 0; i < aAddCounter.size(); ++i){
-        aAddCounter[i]->setText(tr("&Add counter (%1)").arg(counterColors[i]));
+        aAddCounter[i]->setText(tr("%1").arg(counterColors[i]));
     }
     for (int i = 0; i < aRemoveCounter.size(); ++i){
-        aRemoveCounter[i]->setText(tr("&Remove counter (%1)").arg(counterColors[i]));
+        aRemoveCounter[i]->setText(tr("%1").arg(counterColors[i]));
     }
     for (int i = 0; i < aSetCounter.size(); ++i){
-        aSetCounter[i]->setText(tr("&Set counters (%1)...").arg(counterColors[i]));
+        aSetCounter[i]->setText(tr("%1...").arg(counterColors[i]));
     }
 
     aMoveToTopLibrary->setText(tr("&Top of library"));
@@ -2294,6 +2294,9 @@ void Player::updateCardMenu(CardItem *card)
     QMenu *cardMenu = card->getCardMenu();
     QMenu *ptMenu = card->getPTMenu();
     QMenu *moveMenu = card->getMoveMenu();
+    QMenu *addCounterMenu = card->getAddCounterMenu();
+    QMenu *removeCounterMenu = card->getRemoveCounterMenu();
+    QMenu *setCountersMenu = card->getSetCounterMenu();
 
     cardMenu->clear();
 
@@ -2378,11 +2381,15 @@ void Player::updateCardMenu(CardItem *card)
                 cardMenu->addMenu(moveMenu);
 
                 for (int i = 0; i < aAddCounter.size(); ++i) {
-                    cardMenu->addSeparator();
-                    cardMenu->addAction(aAddCounter[i]);
-                    cardMenu->addAction(aRemoveCounter[i]);
-                    cardMenu->addAction(aSetCounter[i]);
+                    addCounterMenu->addAction(aAddCounter[i]);
+                    removeCounterMenu->addAction(aRemoveCounter[i]);
+                    setCountersMenu->addAction(aSetCounter[i]);
                 }
+
+                cardMenu->addSeparator();
+                cardMenu->addMenu(addCounterMenu);
+                cardMenu->addMenu(removeCounterMenu);
+                cardMenu->addMenu(setCountersMenu);
                 cardMenu->addSeparator();
             } else if (card->getZone()->getName() == "stack") {
                 cardMenu->addAction(aDrawArrow);


### PR DESCRIPTION
## Description
Context menu is used extensively, so should be as tight as possible. Currently _half_ of the menu is dedicated to the same 3 command for adding counters:
<img width="237" alt="screen shot 2017-01-06 at 19 02 15" src="https://cloud.githubusercontent.com/assets/2134793/21727947/0482be5a-d444-11e6-89a9-f4de0697d0eb.png">
My solution condenses these colors into their own menus:
<img width="303" alt="screen shot 2017-01-06 at 19 08 55" src="https://cloud.githubusercontent.com/assets/2134793/21727986/3b66515c-d444-11e6-9837-47c6f331d223.png">
<img width="303" alt="screen shot 2017-01-06 at 19 09 04" src="https://cloud.githubusercontent.com/assets/2134793/21727988/3d4c15ec-d444-11e6-996b-3b80dae6401c.png">
<img width="312" alt="screen shot 2017-01-06 at 19 09 11" src="https://cloud.githubusercontent.com/assets/2134793/21727991/3f931242-d444-11e6-9c92-84cdb549fd8f.png">

## Changelist

+ Cosmetic overhaul of the card counter context menu