### PR TITLE
Added registration email blacklist

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -443,6 +443,9 @@ void MainWindow::registerError(Response::ResponseCode r, QString reasonStr, quin
         case Response::RespEmailRequiredToRegister:
             QMessageBox::critical(this, tr("Registration denied"), tr("It's mandatory to specify a valid email address when registering."));
             break;
+        case Response::RespEmailBlackListed:
+            QMessageBox::critical(this, tr("Registration denied"), tr("The email address provider used during registration has been blacklisted for use on this server."));
+            break;
         case Response::RespTooManyRequests:
             QMessageBox::critical(this, tr("Registration denied"), tr("Too many registration attempts, please try again later or contact the server operator for further details."));
             break;

--- a/common/pb/response.proto
+++ b/common/pb/response.proto
@@ -39,6 +39,7 @@ message Response {
         RespClientIdRequired = 34; // Server requires client to generate and send its client id before allowing access
         RespClientUpdateRequired = 35; // Client is missing features that the server is requiring
         RespServerFull = 36; // Server user limit reached
+        RespEmailBlackListed = 37; // Server has blacklisted the email address provided for registration
     }
     enum ResponseType {
         JOIN_ROOM = 1000;

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -144,6 +144,11 @@ disallowedregexp=""
 ; using the same email address. 0 = Unlimited number of accounts (default).
 ;maxaccountsperemail=0 
 
+; You can prevent users from using certain mail domains for registration.  This setting contains a
+; comma-seperated list of email provider domains that you would like to prevent users from using
+; during registration.  Example: "10minutemail.com,gmail.com,mail.com"
+emailblacklist=""
+
 [smtp]
 
 ; Enable the internal smtp client to send registration emails.  If you would like to

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -147,7 +147,7 @@ disallowedregexp=""
 ; You can prevent users from using certain mail domains for registration.  This setting contains a
 ; comma-seperated list of email provider domains that you would like to prevent users from using
 ; during registration.  Example: "10minutemail.com,gmail.com,mail.com"
-emailblacklist=""
+;emailproviderblacklist=""
 
 [smtp]
 

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -146,7 +146,9 @@ disallowedregexp=""
 
 ; You can prevent users from using certain mail domains for registration.  This setting contains a
 ; comma-seperated list of email provider domains that you would like to prevent users from using
-; during registration.  Example: "10minutemail.com,gmail.com,mail.com"
+; during registration. Comparison's are implicit, so placing an entry such as mail.com will also
+; prevent users from registering accounts with providers such as gmail.com and hotmail.com  
+; Example: "10minutemail.com,gmail.com"
 ;emailproviderblacklist=""
 
 [smtp]

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -240,6 +240,8 @@ bool Servatrice::initServer()
     qDebug() << "Accept registered users only: " << getRegOnlyServerEnabled();
     qDebug() << "Registration enabled: " << getRegistrationEnabled();
     if (getRegistrationEnabled()) {
+        QStringList emailBlackListFilters = getEmailBlackList().split(",", QString::SkipEmptyParts);
+        qDebug() << "Email blacklist: " << emailBlackListFilters;
         qDebug() << "Require email address to register: " << getRequireEmailForRegistrationEnabled();
         qDebug() << "Require email activation via token: " << getRequireEmailActivationEnabled();
         if (getMaxAccountsPerEmail()) { qDebug() << "Maximum number of accounts per email: " << getMaxAccountsPerEmail(); } else { qDebug() << "Maximum number of accounts per email: unlimited"; }
@@ -843,4 +845,8 @@ int Servatrice::getMaxAccountsPerEmail() const {
 
 bool Servatrice::getEnableInternalSMTPClient() const {
     return settingsCache->value("smtp/enableinternalsmtpclient", true).toBool();
+}
+
+QString Servatrice::getEmailBlackList() const {
+    return settingsCache->value("registration/emailblacklist").toString();
 }

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -848,5 +848,5 @@ bool Servatrice::getEnableInternalSMTPClient() const {
 }
 
 QString Servatrice::getEmailBlackList() const {
-    return settingsCache->value("registration/emailblacklist").toString();
+    return settingsCache->value("registration/emailproviderblacklist").toString();
 }

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -180,6 +180,7 @@ public:
     QString getAuthenticationMethodString() const;
     QString getDBTypeString() const;
     QString getDbPrefix() const { return dbPrefix; }
+    QString getEmailBlackList() const;
     AuthenticationMethod getAuthenticationMethod() const { return authenticationMethod; }
     bool permitUnregisteredUsers() const { return authenticationMethod != AuthenticationNone; }
     bool getGameShouldPing() const { return true; }

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -881,7 +881,19 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
     if (!registrationEnabled)
         return Response::RespRegistrationDisabled;
 
+    QString emailBlackList = servatrice->getEmailBlackList();
     QString emailAddress = QString::fromStdString(cmd.email());
+    QStringList emailBlackListFilters = emailBlackList.split(",", QString::SkipEmptyParts);
+
+    // verify that users email/provider is not blacklisted
+    if (!emailBlackList.trimmed().isEmpty()) {
+        foreach(QString blackListEmailAddress, emailBlackListFilters) {
+            if (emailAddress.contains(blackListEmailAddress, Qt::CaseInsensitive)) {
+                return Response::RespEmailBlackListed;
+            }
+        }
+    }
+
     bool requireEmailForRegistration = settingsCache->value("registration/requireemail", true).toBool();
     if (requireEmailForRegistration)
     {


### PR DESCRIPTION
Fix #1862 
Added the ability to define email blacklist for user registration.  Now server operators can prevent users from registering accounts that contain providers they do not wish users to use.  This also adds a new response protocol item with new client popup response indicating the reason for denied registration.

![image](https://cloud.githubusercontent.com/assets/1361287/21743995/4e2200a6-d4db-11e6-8dc5-42260e1287aa.png)
