### PR TITLE
Fix appveyor build names

### DIFF
--- a/cmake/getversion.cmake
+++ b/cmake/getversion.cmake
@@ -1,7 +1,7 @@
 find_package(Git)
 if(GIT_FOUND)
 	execute_process(
-		COMMAND ${GIT_EXECUTABLE} log -1 --date=short "--pretty=%h"
+		COMMAND ${GIT_EXECUTABLE} log -1 --abbrev=7 --date=short "--pretty=%h"
 		WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 		RESULT_VARIABLE res_var
 		OUTPUT_VARIABLE GIT_COM_ID


### PR DESCRIPTION
It seems that the `git` binary from Appveyor now defaults to 8 chars for git short commit hash, instead of 7 as currently used by github and travis.
This caused the cockatrice package to have a different name and version, so when uploaded to bintray it ended up in a different folder.
This PR forces the use of 7 chars.

Fix #2358 