### PR TITLE
Fix use of uninitalized value

### DIFF
--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -912,7 +912,7 @@ void Servatrice_DatabaseInterface::updateUsersLastLoginData(const QString &userN
     if (!checkSql())
         return;
 
-    int usersID;
+    int usersID=0;
 
     QSqlQuery *query = prepareQuery("select id from {prefix}_users where name = :user_name");
     query->bindValue(":user_name", userName);


### PR DESCRIPTION
Should only happen if the server accepts guest users.
Found using valgrind.