### PR TITLE
add RPM support to `make package`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,12 +77,12 @@ endif()
 
 # Define proper compilation flags
 IF(MSVC)
-	# Visual Studio:
+    # Visual Studio:
     # Support from Windows XP
     SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:WINDOWS,5.01")
-	# Maximum optimization
+    # Maximum optimization
     set(CMAKE_CXX_FLAGS_RELEASE "/Ox /MD")
-	# Generate complete debugging information
+    # Generate complete debugging information
     #set(CMAKE_CXX_FLAGS_DEBUG "/Zi")
 ELSEIF (CMAKE_COMPILER_IS_GNUCXX)
     # linux/gcc, bsd/gcc, windows/mingw
@@ -174,12 +174,19 @@ if(UNIX)
         set(CPACK_PACKAGE_ICON "${CMAKE_CURRENT_SOURCE_DIR}/cockatrice/resources/appicon.icns")
     else()
         # linux
-        set(CPACK_GENERATOR DEB ${CPACK_GENERATOR})
+        IF(CPACK_GENERATOR STREQUAL "RPM")
+            set(CPACK_RPM_PACKAGE_LICENSE "GPLv2")
+            set(CPACK_RPM_PACKAGE_REQUIRES "protobuf, qt5-qttools, qt5-qtsvg, qt5-qtmultimedia")
+            set(CPACK_RPM_PACKAGE_GROUP "Amusements/Games")
+            set(CPACK_RPM_PACKAGE_URL "http://github.com/Cockatrice/Cockatrice")
+        ELSE()
+            set(CPACK_GENERATOR DEB)
+            set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+            set(CPACK_DEBIAN_PACKAGE_SECTION "games")
+            set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "http://github.com/Cockatrice/Cockatrice")
+            set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5multimedia5-plugins, libqt5svg5")
+        ENDIF()
         set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}-${PROJECT_VERSION}")
-    	set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
-    	set(CPACK_DEBIAN_PACKAGE_SECTION "games")
-    	set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "http://github.com/Cockatrice/Cockatrice")
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5multimedia5-plugins, libqt5svg5")
     endif()
 elseif(WIN32)
     set(CPACK_GENERATOR NSIS ${CPACK_GENERATOR})


### PR DESCRIPTION
Re-submitting #2351

Still works the same as before, but now has the necessary variables for RPM packages.