### PR TITLE
Update registration user count check to include clientid

### DIFF
--- a/common/server_database_interface.h
+++ b/common/server_database_interface.h
@@ -45,7 +45,7 @@ public:
     enum LogMessage_TargetType { MessageTargetRoom, MessageTargetGame, MessageTargetChat, MessageTargetIslRoom };
     virtual void logMessage(const int /* senderId */, const QString & /* senderName */, const QString & /* senderIp */, const QString & /* logMessage */, LogMessage_TargetType /* targetType */, const int /* targetId */, const QString & /* targetName */) { };
     bool checkUserIsBanned(Server_ProtocolHandler *session, QString &banReason, int &banSecondsRemaining);
-    virtual int checkNumberOfUserAccounts(const QString & /* email */) { return 0; };
+    virtual int checkNumberOfUserAccounts(const QString & /* email */, const QString /* clientid */) { return 0; };
     virtual bool changeUserPassword(const QString & /* user */, const QString & /* oldPassword */, const QString & /* newPassword */) { return true; };
     virtual QChar getGenderChar(ServerInfo_User_Gender const & /* gender */) { return QChar('u'); };
 };

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -141,8 +141,8 @@ disallowedregexp=""
 ;requireemailactivation=true
 
 ; Set this number to the maximum number of accounts any one user can use to create new accounts
-; using the same email address. 0 = Unlimited number of accounts (default).
-;maxaccountsperemail=0 
+; using the same email address or clientid. 0 = Unlimited number of accounts (default).
+;maxaccountsperuser=0 
 
 [smtp]
 

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -242,7 +242,7 @@ bool Servatrice::initServer()
     if (getRegistrationEnabled()) {
         qDebug() << "Require email address to register: " << getRequireEmailForRegistrationEnabled();
         qDebug() << "Require email activation via token: " << getRequireEmailActivationEnabled();
-        if (getMaxAccountsPerEmail()) { qDebug() << "Maximum number of accounts per email: " << getMaxAccountsPerEmail(); } else { qDebug() << "Maximum number of accounts per email: unlimited"; }
+        if (getMaxAccountsPerUser()) { qDebug() << "Maximum number of accounts per email: " << getMaxAccountsPerUser(); } else { qDebug() << "Maximum number of accounts per email: unlimited"; }
         qDebug() << "Enable Internal SMTP Client: " << getEnableInternalSMTPClient();
         if (!getEnableInternalSMTPClient())
         {
@@ -837,8 +837,8 @@ bool Servatrice::getEnableLogQuery() const {
     return settingsCache->value("logging/enablelogquery", false).toBool();
 }
 
-int Servatrice::getMaxAccountsPerEmail() const {
-    return settingsCache->value("registration/maxaccountsperemail", 0).toInt();
+int Servatrice::getMaxAccountsPerUser() const {
+    return settingsCache->value("registration/maxaccountsperuser", 0).toInt();
 }
 
 bool Servatrice::getEnableInternalSMTPClient() const {

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -207,7 +207,7 @@ public:
     int getMaxTcpUserLimit() const;
     int getMaxWebSocketUserLimit() const;
     int getUsersWithAddress(const QHostAddress &address) const;
-    int getMaxAccountsPerEmail() const;
+    int getMaxAccountsPerUser() const;
     QList<AbstractServerSocketInterface *> getUsersWithAddressAsList(const QHostAddress &address) const;
     void incTxBytes(quint64 num);
     void incRxBytes(quint64 num);

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -1110,21 +1110,45 @@ QList<ServerInfo_ChatMessage> Servatrice_DatabaseInterface::getMessageLogHistory
     return results;
 }
 
-int Servatrice_DatabaseInterface::checkNumberOfUserAccounts(const QString &email)
+int Servatrice_DatabaseInterface::checkNumberOfUserAccounts(const QString &email, const QString &clientid)
 {
     if (!checkSql())
         return 0;
+	
+	int emailAccountCount = 0;
+	int clientIDAccountCount = 0;
 
-    QSqlQuery *query = prepareQuery("SELECT count(email) FROM {prefix}_users WHERE email = :user_email");
-    query->bindValue(":user_email", email);
+	if (email != "") {
+		QSqlQuery *query = prepareQuery("SELECT count(email) FROM {prefix}_users WHERE email = :user_email");
+		query->bindValue(":user_email", email);
 
-    if (!execSqlQuery(query)) {
-        qDebug("Failed to identify the number of users accounts for users email address: SQL Error");
-        return 0;
-    }
+		if (!execSqlQuery(query)) {
+			qDebug("Failed to identify the number of users accounts for users email address: SQL Error");
+			return 0;
+		}
 
-    if (query->next())
-        return query->value(0).toInt();
+		if (query->next())
+			emailAccountCount = query->value(0).toInt();
+	}
+
+	if (clientid != "") {
+		QSqlQuery *query = prepareQuery("SELECT count(clientid) FROM {prefix}_users WHERE clientid = :clientid");
+		query->bindValue(":clientid", clientid);
+
+		if (!execSqlQuery(query)) {
+			qDebug("Failed to identify the number of users accounts for users client id: SQL Error");
+			return 0;
+		}
+
+		if (query->next())
+			clientIDAccountCount = query->value(0).toInt();
+	}
+
+	if (emailAccountCount > clientIDAccountCount) {
+		return emailAccountCount;
+	} else {
+		return clientIDAccountCount;
+	}
 
     return 0;
 }

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -69,7 +69,7 @@ public:
     bool userSessionExists(const QString &userName);
     bool usernameIsValid(const QString &user, QString & error);
     bool checkUserIsBanned(const QString &ipAddress, const QString &userName, const QString &clientId, QString &banReason, int &banSecondsRemaining);
-    int checkNumberOfUserAccounts(const QString &email);
+    int checkNumberOfUserAccounts(const QString &email, const QString &clientid);
     bool registerUser(const QString &userName, const QString &realName, ServerInfo_User_Gender const &gender,
         const QString &password, const QString &emailAddress, const QString &country, QString &token, bool active = false);
     bool activateUser(const QString &userName, const QString &token);

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -906,7 +906,7 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
     if(sqlInterface->userExists(userName))
         return Response::RespUserAlreadyExists;
 
-    if (servatrice->getMaxAccountsPerEmail() && !(sqlInterface->checkNumberOfUserAccounts(emailAddress) < servatrice->getMaxAccountsPerEmail()))
+	if (servatrice->getMaxAccountsPerUser() && !(sqlInterface->checkNumberOfUserAccounts(emailAddress, clientId) < servatrice->getMaxAccountsPerUser()))
     {
         return Response::RespTooManyRequests;
     }


### PR DESCRIPTION

This PR updates the check that is done during registration for the number of accounts a user may have registered.  Originally the check only looked for accounts associated with the same email.  Now the check does email as well as clientid.

With the update in behavior I also updated the function names that get called for better description as well as the example.ini value used to set the limit.