### PR TITLE
Added custom registration success/failure append messages

### DIFF
--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -187,7 +187,7 @@ void RemoteClient::registerResponse(const Response &response)
             doLogin();
             break;
         default:
-            emit registerError(response.response_code(), QString::fromStdString(resp.denied_reason_str()), resp.denied_end_time());
+            emit registerError(response.response_code(), QString::fromStdString(resp.denied_reason_str()), resp.denied_end_time(), QString::fromStdString(resp.custom_reason_str()));
             setStatus(StatusDisconnecting);
             doDisconnectFromServer();
             break;

--- a/cockatrice/src/remoteclient.h
+++ b/cockatrice/src/remoteclient.h
@@ -12,7 +12,7 @@ signals:
     void maxPingTime(int seconds, int maxSeconds);
     void serverTimeout();
     void loginError(Response::ResponseCode resp, QString reasonStr, quint32 endTime, QList<QString> missingFeatures);
-    void registerError(Response::ResponseCode resp, QString reasonStr, quint32 endTime);
+    void registerError(Response::ResponseCode resp, QString reasonStr, quint32 endTime, QString customStr);
     void activateError();
     void socketError(const QString &errorString);
     void protocolVersionMismatch(int clientVersion, int serverVersion);

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -433,32 +433,31 @@ QString MainWindow::extractInvalidUsernameMessage(QString & in)
 
 void MainWindow::registerError(Response::ResponseCode r, QString reasonStr, quint32 endTime, QString customStr)
 {
-    qDebug() << "RECEIVED RESPONSE!";
-    QString titleStr = "Registration";
+    QString titleStr = "";
     QString explinationStr = "";
     switch (r) {
         case Response::RespRegistrationDisabled:
-            titleStr = titleStr + " denied";
-            explinationStr = "Registration is currently disabled on this server";
+            titleStr = tr("Registration denied");
+            explinationStr = tr("Registration is currently disabled on this server");
             break;
         case Response::RespUserAlreadyExists:
-            titleStr = titleStr + " denied";
-            explinationStr = "There is already an existing account with the same user name.";
+            titleStr = tr("Registration denied");
+            explinationStr = tr("There is already an existing account with the same user name.");
             break;
         case Response::RespEmailRequiredToRegister:
-            titleStr = titleStr + " denied";
-            explinationStr = "It's mandatory to specify a valid email address when registering.";
+            titleStr = tr("Registration denied");
+            explinationStr = tr("It's mandatory to specify a valid email address when registering.");
             break;
         case Response::RespTooManyRequests:
-            titleStr = titleStr + " denied";
-            explinationStr = "Too many registration attempts, please try again later or contact the server operator for further details.";
+            titleStr = tr("Registration denied");
+            explinationStr = tr("Too many registration attempts, please try again later or contact the server operator for further details.");
             break;
         case Response::RespPasswordTooShort:
-            titleStr = titleStr + " denied";
+            titleStr = tr("Registration denied");
             QMessageBox::critical(this, tr("Registration denied"), tr("Password too short."));
             break;
         case Response::RespUserIsBanned: {
-            titleStr = titleStr + " error";
+            titleStr = tr("Registration error");
             if (endTime)
                 explinationStr = tr("You are banned until %1.").arg(QDateTime::fromTime_t(endTime).toString());
             else
@@ -468,22 +467,23 @@ void MainWindow::registerError(Response::ResponseCode r, QString reasonStr, quin
             break;
         }
         case Response::RespUsernameInvalid: {
-            titleStr = titleStr + " error";
+            titleStr = tr("Registration error");
             explinationStr = extractInvalidUsernameMessage(reasonStr);
             break;
         }
         case Response::RespRegistrationFailed:
-            titleStr = titleStr + " error";
-            explinationStr = "Registration failed for a technical problem on the server.";
+            titleStr = tr("Registration error");
+            explinationStr = tr("Registration failed for a technical problem on the server.");
             break;
         default:
-            titleStr = titleStr + " error";
-            explinationStr = "Unknown registration error.\nThis usually means that your client version is out of date, and the server sent a reply your client doesn't understand." ;
+            titleStr = tr("Registration error");
+            explinationStr = tr("Unknown registration error.\nThis usually means that your client version is out of date, and the server sent a reply your client doesn't understand.");
     }
-    if (!customStr.isEmpty())
-        explinationStr = explinationStr + "\n\n" + customStr;
 
-    QMessageBox::critical(this, tr("%1").arg(titleStr), tr("%1").arg(explinationStr));
+    if (!customStr.isEmpty())
+		explinationStr += "\n\n" + tr("Note from server: ") + customStr;
+
+    QMessageBox::critical(this, titleStr, explinationStr);
     actRegister();
 }
 

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -433,57 +433,57 @@ QString MainWindow::extractInvalidUsernameMessage(QString & in)
 
 void MainWindow::registerError(Response::ResponseCode r, QString reasonStr, quint32 endTime, QString customStr)
 {
-	qDebug() << "RECEIVED RESPONSE!";
-	QString titleStr = "Registration";
-	QString explinationStr = "";
+    qDebug() << "RECEIVED RESPONSE!";
+    QString titleStr = "Registration";
+    QString explinationStr = "";
     switch (r) {
         case Response::RespRegistrationDisabled:
-			titleStr = titleStr + " denied";
-			explinationStr = "Registration is currently disabled on this server";
+            titleStr = titleStr + " denied";
+            explinationStr = "Registration is currently disabled on this server";
             break;
         case Response::RespUserAlreadyExists:
-			titleStr = titleStr + " denied";
-			explinationStr = "There is already an existing account with the same user name.";
+            titleStr = titleStr + " denied";
+            explinationStr = "There is already an existing account with the same user name.";
             break;
         case Response::RespEmailRequiredToRegister:
-			titleStr = titleStr + " denied";
-			explinationStr = "It's mandatory to specify a valid email address when registering.";
+            titleStr = titleStr + " denied";
+            explinationStr = "It's mandatory to specify a valid email address when registering.";
             break;
         case Response::RespTooManyRequests:
-			titleStr = titleStr + " denied";
-			explinationStr = "Too many registration attempts, please try again later or contact the server operator for further details.";
+            titleStr = titleStr + " denied";
+            explinationStr = "Too many registration attempts, please try again later or contact the server operator for further details.";
             break;
         case Response::RespPasswordTooShort:
-			titleStr = titleStr + " denied";
-			QMessageBox::critical(this, tr("Registration denied"), tr("Password too short."));
+            titleStr = titleStr + " denied";
+            QMessageBox::critical(this, tr("Registration denied"), tr("Password too short."));
             break;
         case Response::RespUserIsBanned: {
-			titleStr = titleStr + " error";
+            titleStr = titleStr + " error";
             if (endTime)
-				explinationStr = tr("You are banned until %1.").arg(QDateTime::fromTime_t(endTime).toString());
+                explinationStr = tr("You are banned until %1.").arg(QDateTime::fromTime_t(endTime).toString());
             else
-				explinationStr = tr("You are banned indefinitely.");
+                explinationStr = tr("You are banned indefinitely.");
             if (!reasonStr.isEmpty())
-				explinationStr.append("\n\n" + reasonStr);
+                explinationStr.append("\n\n" + reasonStr);
             break;
         }
         case Response::RespUsernameInvalid: {
-			titleStr = titleStr + " error";
-			explinationStr = extractInvalidUsernameMessage(reasonStr);
+            titleStr = titleStr + " error";
+            explinationStr = extractInvalidUsernameMessage(reasonStr);
             break;
         }
         case Response::RespRegistrationFailed:
-			titleStr = titleStr + " error";
-			explinationStr = "Registration failed for a technical problem on the server.";
+            titleStr = titleStr + " error";
+            explinationStr = "Registration failed for a technical problem on the server.";
             break;
         default:
-			titleStr = titleStr + " error";
-			explinationStr = "Unknown registration error.\nThis usually means that your client version is out of date, and the server sent a reply your client doesn't understand." ;
+            titleStr = titleStr + " error";
+            explinationStr = "Unknown registration error.\nThis usually means that your client version is out of date, and the server sent a reply your client doesn't understand." ;
     }
-	if (!customStr.isEmpty())
-		explinationStr = explinationStr + "\n\n" + customStr;
+    if (!customStr.isEmpty())
+        explinationStr = explinationStr + "\n\n" + customStr;
 
-	QMessageBox::critical(this, tr("%1").arg(titleStr), tr("%1").arg(explinationStr));
+    QMessageBox::critical(this, tr("%1").arg(titleStr), tr("%1").arg(explinationStr));
     actRegister();
 }
 
@@ -680,7 +680,6 @@ MainWindow::MainWindow(QWidget *parent)
     clientThread = new QThread(this);
     client->moveToThread(clientThread);
     clientThread->start();
-
     createActions();
     createMenus();
 

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -431,46 +431,59 @@ QString MainWindow::extractInvalidUsernameMessage(QString & in)
     return out;
 }
 
-void MainWindow::registerError(Response::ResponseCode r, QString reasonStr, quint32 endTime)
+void MainWindow::registerError(Response::ResponseCode r, QString reasonStr, quint32 endTime, QString customStr)
 {
+	qDebug() << "RECEIVED RESPONSE!";
+	QString titleStr = "Registration";
+	QString explinationStr = "";
     switch (r) {
         case Response::RespRegistrationDisabled:
-            QMessageBox::critical(this, tr("Registration denied"), tr("Registration is currently disabled on this server"));
+			titleStr = titleStr + " denied";
+			explinationStr = "Registration is currently disabled on this server";
             break;
         case Response::RespUserAlreadyExists:
-            QMessageBox::critical(this, tr("Registration denied"), tr("There is already an existing account with the same user name."));
+			titleStr = titleStr + " denied";
+			explinationStr = "There is already an existing account with the same user name.";
             break;
         case Response::RespEmailRequiredToRegister:
-            QMessageBox::critical(this, tr("Registration denied"), tr("It's mandatory to specify a valid email address when registering."));
+			titleStr = titleStr + " denied";
+			explinationStr = "It's mandatory to specify a valid email address when registering.";
             break;
         case Response::RespTooManyRequests:
-            QMessageBox::critical(this, tr("Registration denied"), tr("Too many registration attempts, please try again later or contact the server operator for further details."));
+			titleStr = titleStr + " denied";
+			explinationStr = "Too many registration attempts, please try again later or contact the server operator for further details.";
             break;
         case Response::RespPasswordTooShort:
-            QMessageBox::critical(this, tr("Registration denied"), tr("Password too short."));
+			titleStr = titleStr + " denied";
+			QMessageBox::critical(this, tr("Registration denied"), tr("Password too short."));
             break;
         case Response::RespUserIsBanned: {
-            QString bannedStr;
+			titleStr = titleStr + " error";
             if (endTime)
-                bannedStr = tr("You are banned until %1.").arg(QDateTime::fromTime_t(endTime).toString());
+				explinationStr = tr("You are banned until %1.").arg(QDateTime::fromTime_t(endTime).toString());
             else
-                bannedStr = tr("You are banned indefinitely.");
+				explinationStr = tr("You are banned indefinitely.");
             if (!reasonStr.isEmpty())
-                bannedStr.append("\n\n" + reasonStr);
-
-            QMessageBox::critical(this, tr("Error"), bannedStr);
+				explinationStr.append("\n\n" + reasonStr);
             break;
         }
         case Response::RespUsernameInvalid: {
-            QMessageBox::critical(this, tr("Error"), extractInvalidUsernameMessage(reasonStr));
+			titleStr = titleStr + " error";
+			explinationStr = extractInvalidUsernameMessage(reasonStr);
             break;
         }
         case Response::RespRegistrationFailed:
-            QMessageBox::critical(this, tr("Error"), tr("Registration failed for a technical problem on the server."));
+			titleStr = titleStr + " error";
+			explinationStr = "Registration failed for a technical problem on the server.";
             break;
         default:
-            QMessageBox::critical(this, tr("Error"), tr("Unknown registration error: %1").arg(static_cast<int>(r)) + tr("\nThis usually means that your client version is out of date, and the server sent a reply your client doesn't understand."));
+			titleStr = titleStr + " error";
+			explinationStr = "Unknown registration error.\nThis usually means that your client version is out of date, and the server sent a reply your client doesn't understand." ;
     }
+	if (!customStr.isEmpty())
+		explinationStr = explinationStr + "\n\n" + customStr;
+
+	QMessageBox::critical(this, tr("%1").arg(titleStr), tr("%1").arg(explinationStr));
     actRegister();
 }
 
@@ -660,7 +673,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(client, SIGNAL(notifyUserAboutUpdate()), this, SLOT(notifyUserAboutUpdate()));
     connect(client, SIGNAL(registerAccepted()), this, SLOT(registerAccepted()));
     connect(client, SIGNAL(registerAcceptedNeedsActivate()), this, SLOT(registerAcceptedNeedsActivate()));
-    connect(client, SIGNAL(registerError(Response::ResponseCode, QString, quint32)), this, SLOT(registerError(Response::ResponseCode, QString, quint32)));
+    connect(client, SIGNAL(registerError(Response::ResponseCode, QString, quint32, QString)), this, SLOT(registerError(Response::ResponseCode, QString, quint32, QString)));
     connect(client, SIGNAL(activateAccepted()), this, SLOT(activateAccepted()));
     connect(client, SIGNAL(activateError()), this, SLOT(activateError()));
 

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -47,7 +47,7 @@ private slots:
     void processServerShutdownEvent(const Event_ServerShutdown &event);
     void serverTimeout();
     void loginError(Response::ResponseCode r, QString reasonStr, quint32 endTime, QList<QString> missingFeatures);
-    void registerError(Response::ResponseCode r, QString reasonStr, quint32 endTime);
+    void registerError(Response::ResponseCode r, QString reasonStr, quint32 endTime, QString customStr);
     void activateError();
     void socketError(const QString &errorStr);
     void protocolVersionMismatch(int localVersion, int remoteVersion);

--- a/common/pb/response_register.proto
+++ b/common/pb/response_register.proto
@@ -6,6 +6,6 @@ message Response_Register {
         optional Response_Register ext = 1009;
     }
     optional string denied_reason_str = 1;
-    optional uint64 denied_end_time = 2;
+	optional uint64 denied_end_time = 2;
 	optional string custom_reason_str = 3;
 }

--- a/common/pb/response_register.proto
+++ b/common/pb/response_register.proto
@@ -7,4 +7,5 @@ message Response_Register {
     }
     optional string denied_reason_str = 1;
     optional uint64 denied_end_time = 2;
+	optional string custom_reason_str = 3;
 }

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -144,6 +144,16 @@ disallowedregexp=""
 ; using the same email address. 0 = Unlimited number of accounts (default).
 ;maxaccountsperemail=0 
 
+; Populate this value with a custom message you would like appended to the response that is given
+; to clients that fail the registration process.  Leaving the value empty will not append anything
+; to the default messages presented to the client.  Default = "" 
+;customerrormessage=""
+
+; Populate this value with a custom message you would like appended to the response that is given
+; to clients that succeed the registration process.  Leaving the value empty will not append anything
+; to the default messages presented to the client.  Default = ""
+;customsuccessmessage=""
+
 [smtp]
 
 ; Enable the internal smtp client to send registration emails.  If you would like to

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -844,3 +844,11 @@ int Servatrice::getMaxAccountsPerEmail() const {
 bool Servatrice::getEnableInternalSMTPClient() const {
     return settingsCache->value("smtp/enableinternalsmtpclient", true).toBool();
 }
+
+QString Servatrice::getCustomRegErrorMessage() const {
+	return settingsCache->value("registration/customerrormessage", "").toString();
+}
+
+QString Servatrice::getCustomRegSuccessMessage() const {
+	return settingsCache->value("registration/customsuccessmessage", "").toString();
+}

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -179,6 +179,8 @@ public:
     QString getRequiredFeatures() const;
     QString getAuthenticationMethodString() const;
     QString getDBTypeString() const;
+	QString getCustomRegErrorMessage() const;
+	QString getCustomRegSuccessMessage() const;
     QString getDbPrefix() const { return dbPrefix; }
     AuthenticationMethod getAuthenticationMethod() const { return authenticationMethod; }
     bool permitUnregisteredUsers() const { return authenticationMethod != AuthenticationNone; }

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -178,7 +178,7 @@ public:
     QString getLoginMessage() const { QMutexLocker locker(&loginMessageMutex); return loginMessage; }
     QString getRequiredFeatures() const;
     QString getAuthenticationMethodString() const;
-    QString getDBTypeString() const;
+	QString getDBTypeString() const;
 	QString getCustomRegErrorMessage() const;
 	QString getCustomRegSuccessMessage() const;
     QString getDbPrefix() const { return dbPrefix; }

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -877,24 +877,24 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
     QString clientId = QString::fromStdString(cmd.clientid());
     qDebug() << "Got register command: " << userName;
 
-	Response_Register *re = new Response_Register;
-	re->set_custom_reason_str(servatrice->getCustomRegErrorMessage().toStdString());
+    Response_Register *re = new Response_Register;
+    re->set_custom_reason_str(servatrice->getCustomRegErrorMessage().toStdString());
 
     bool registrationEnabled = settingsCache->value("registration/enabled", false).toBool();
-	if (!registrationEnabled) {
-		rc.setResponseExtension(re);
-		return Response::RespRegistrationDisabled;
-	}
+    if (!registrationEnabled) {
+        rc.setResponseExtension(re);
+        return Response::RespRegistrationDisabled;
+    }
 
     QString emailAddress = QString::fromStdString(cmd.email());
     bool requireEmailForRegistration = settingsCache->value("registration/requireemail", true).toBool();
     if (requireEmailForRegistration)
     {
         QRegExp rx("\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}\\b");
-		if (emailAddress.isEmpty() || !rx.exactMatch(emailAddress)) {
-			rc.setResponseExtension(re);
-			return Response::RespEmailRequiredToRegister;
-		}
+        if (emailAddress.isEmpty() || !rx.exactMatch(emailAddress)) {
+            rc.setResponseExtension(re);
+            return Response::RespEmailRequiredToRegister;
+        }
     }
 
     // TODO: Move this method outside of the db interface
@@ -902,23 +902,23 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
     if (!sqlInterface->usernameIsValid(userName, errorString))
     {
         re->set_denied_reason_str(errorString.toStdString());
-		rc.setResponseExtension(re);
+        rc.setResponseExtension(re);
         return Response::RespUsernameInvalid;
     }
 
-	if (userName.toLower().simplified() == "servatrice") {
-		rc.setResponseExtension(re);
-		return Response::RespUsernameInvalid;
-	}
+    if (userName.toLower().simplified() == "servatrice") {
+        rc.setResponseExtension(re);
+        return Response::RespUsernameInvalid;
+    }
 
-	if (sqlInterface->userExists(userName)) {
-		rc.setResponseExtension(re);
-		return Response::RespUserAlreadyExists;
-	}
+    if (sqlInterface->userExists(userName)) {
+        rc.setResponseExtension(re);
+        return Response::RespUserAlreadyExists;
+    }
 
     if (servatrice->getMaxAccountsPerEmail() && !(sqlInterface->checkNumberOfUserAccounts(emailAddress) < servatrice->getMaxAccountsPerEmail()))
     {
-		rc.setResponseExtension(re);
+        rc.setResponseExtension(re);
         return Response::RespTooManyRequests;
     }
 
@@ -929,14 +929,14 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
         re->set_denied_reason_str(banReason.toStdString());
         if (banSecondsRemaining != 0)
             re->set_denied_end_time(QDateTime::currentDateTime().addSecs(banSecondsRemaining).toTime_t());
-		rc.setResponseExtension(re);
+        rc.setResponseExtension(re);
         return Response::RespUserIsBanned;
     }
 
-	if (tooManyRegistrationAttempts(this->getAddress())) {
-		rc.setResponseExtension(re);
-		return Response::RespTooManyRequests;
-	}
+    if (tooManyRegistrationAttempts(this->getAddress())) {
+        rc.setResponseExtension(re);
+        return Response::RespTooManyRequests;
+    }
 
     QString realName = QString::fromStdString(cmd.real_name());
     ServerInfo_User_Gender gender = cmd.gender();
@@ -944,10 +944,10 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
     QString password = QString::fromStdString(cmd.password());
 
     // TODO make this configurable?
-	if (password.length() < 6) {
-		rc.setResponseExtension(re);
-		return Response::RespPasswordTooShort;
-	}
+    if (password.length() < 6) {
+        rc.setResponseExtension(re);
+        return Response::RespPasswordTooShort;
+    }
 
     QString token;
     bool requireEmailActivation = settingsCache->value("registration/requireemailactivation", true).toBool();
@@ -960,21 +960,21 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
         {
             QSqlQuery *query = sqlInterface->prepareQuery("insert into {prefix}_activation_emails (name) values(:name)");
             query->bindValue(":name", userName);
-			if (!sqlInterface->execSqlQuery(query)) {
-				rc.setResponseExtension(re);
-				return Response::RespRegistrationFailed;
-			}
+            if (!sqlInterface->execSqlQuery(query)) {
+                rc.setResponseExtension(re);
+                return Response::RespRegistrationFailed;
+            }
 
-			re->set_custom_reason_str(servatrice->getCustomRegSuccessMessage().toStdString());
-			rc.setResponseExtension(re);
+            re->set_custom_reason_str(servatrice->getCustomRegSuccessMessage().toStdString());
+            rc.setResponseExtension(re);
             return Response::RespRegistrationAcceptedNeedsActivation;
         } else {
-			re->set_custom_reason_str(servatrice->getCustomRegSuccessMessage().toStdString());
-			rc.setResponseExtension(re);
+            re->set_custom_reason_str(servatrice->getCustomRegSuccessMessage().toStdString());
+            rc.setResponseExtension(re);
             return Response::RespRegistrationAccepted;
         }
     } else {
-		rc.setResponseExtension(re);
+        rc.setResponseExtension(re);
         return Response::RespRegistrationFailed;
     }
 }

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -877,37 +877,48 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
     QString clientId = QString::fromStdString(cmd.clientid());
     qDebug() << "Got register command: " << userName;
 
+	Response_Register *re = new Response_Register;
+	re->set_custom_reason_str(servatrice->getCustomRegErrorMessage().toStdString());
+
     bool registrationEnabled = settingsCache->value("registration/enabled", false).toBool();
-    if (!registrationEnabled)
-        return Response::RespRegistrationDisabled;
+	if (!registrationEnabled) {
+		rc.setResponseExtension(re);
+		return Response::RespRegistrationDisabled;
+	}
 
     QString emailAddress = QString::fromStdString(cmd.email());
     bool requireEmailForRegistration = settingsCache->value("registration/requireemail", true).toBool();
     if (requireEmailForRegistration)
     {
         QRegExp rx("\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}\\b");
-        if(emailAddress.isEmpty() || !rx.exactMatch(emailAddress))
-            return Response::RespEmailRequiredToRegister;
+		if (emailAddress.isEmpty() || !rx.exactMatch(emailAddress)) {
+			rc.setResponseExtension(re);
+			return Response::RespEmailRequiredToRegister;
+		}
     }
 
     // TODO: Move this method outside of the db interface
     QString errorString;
     if (!sqlInterface->usernameIsValid(userName, errorString))
     {
-        Response_Register *re = new Response_Register;
         re->set_denied_reason_str(errorString.toStdString());
-        rc.setResponseExtension(re);
+		rc.setResponseExtension(re);
         return Response::RespUsernameInvalid;
     }
 
-    if (userName.toLower().simplified() == "servatrice")
-        return Response::RespUsernameInvalid;
+	if (userName.toLower().simplified() == "servatrice") {
+		rc.setResponseExtension(re);
+		return Response::RespUsernameInvalid;
+	}
 
-    if(sqlInterface->userExists(userName))
-        return Response::RespUserAlreadyExists;
+	if (sqlInterface->userExists(userName)) {
+		rc.setResponseExtension(re);
+		return Response::RespUserAlreadyExists;
+	}
 
     if (servatrice->getMaxAccountsPerEmail() && !(sqlInterface->checkNumberOfUserAccounts(emailAddress) < servatrice->getMaxAccountsPerEmail()))
     {
+		rc.setResponseExtension(re);
         return Response::RespTooManyRequests;
     }
 
@@ -915,16 +926,17 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
     int banSecondsRemaining;
     if (sqlInterface->checkUserIsBanned(this->getAddress(), userName, clientId, banReason, banSecondsRemaining))
     {
-        Response_Register *re = new Response_Register;
         re->set_denied_reason_str(banReason.toStdString());
         if (banSecondsRemaining != 0)
             re->set_denied_end_time(QDateTime::currentDateTime().addSecs(banSecondsRemaining).toTime_t());
-        rc.setResponseExtension(re);
+		rc.setResponseExtension(re);
         return Response::RespUserIsBanned;
     }
 
-    if (tooManyRegistrationAttempts(this->getAddress()))
-        return Response::RespTooManyRequests;
+	if (tooManyRegistrationAttempts(this->getAddress())) {
+		rc.setResponseExtension(re);
+		return Response::RespTooManyRequests;
+	}
 
     QString realName = QString::fromStdString(cmd.real_name());
     ServerInfo_User_Gender gender = cmd.gender();
@@ -932,8 +944,10 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
     QString password = QString::fromStdString(cmd.password());
 
     // TODO make this configurable?
-    if(password.length() < 6)
-        return Response::RespPasswordTooShort;
+	if (password.length() < 6) {
+		rc.setResponseExtension(re);
+		return Response::RespPasswordTooShort;
+	}
 
     QString token;
     bool requireEmailActivation = settingsCache->value("registration/requireemailactivation", true).toBool();
@@ -946,14 +960,21 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
         {
             QSqlQuery *query = sqlInterface->prepareQuery("insert into {prefix}_activation_emails (name) values(:name)");
             query->bindValue(":name", userName);
-            if (!sqlInterface->execSqlQuery(query))
-                return Response::RespRegistrationFailed;
+			if (!sqlInterface->execSqlQuery(query)) {
+				rc.setResponseExtension(re);
+				return Response::RespRegistrationFailed;
+			}
 
+			re->set_custom_reason_str(servatrice->getCustomRegSuccessMessage().toStdString());
+			rc.setResponseExtension(re);
             return Response::RespRegistrationAcceptedNeedsActivation;
         } else {
+			re->set_custom_reason_str(servatrice->getCustomRegSuccessMessage().toStdString());
+			rc.setResponseExtension(re);
             return Response::RespRegistrationAccepted;
         }
     } else {
+		rc.setResponseExtension(re);
         return Response::RespRegistrationFailed;
     }
 }


### PR DESCRIPTION
Fix #1863 

So this is my first attempt to implement the custom response message idea I was wanting to add a while back to allow server operators to add a more custom/descriptive reason as to why the server they operate may be denying registration or even an addition to the success message.

The original reasoning behind the idea was when registration emails do not immediately get sent to the end user they tend to nag operators.  And depending on the method an operator wishes to choose to activate an account an activation email may not be sent immediately upon registration request.  By allowing a more custom registration response message an operator may be able to explain a bit more in detail as to an acceptable waiting time for registration activation tokens.

The only thing I am questioning with the way its written in the PR is I am not certain how well translations would work mainly due to my lack of understanding how translations really work period.  I understand the that custom string read into the server will not translate but will the pre-appended "hard coded" words translate? Originally in the issue @Daenyth mentioned a custom response.  But that really isn't the goal of adding this functionality.  I didn't want to have to require the server operators to write updated code in order to send a custom message but more append a custom message to the already defined responses.

What are others thoughts in something like this?  To me the code seems a bit "dirty", but I couldn't think of a better way to implement it.  Maybe the solution should go more towards us creating custom responses and expecting operators to write code?

Thoughts?