### PR TITLE
Added custom notify user event

### DIFF
--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -587,6 +587,20 @@ void TabSupervisor::processNotifyUserEvent(const Event_NotifyUser &event)
                 QMessageBox::warning(this, tr("Warned"), tr("You have received a warning due to %1.\nPlease refrain from engaging in this activity or further actions may be taken against you. If you have any questions, please private message a moderator.").arg(QString::fromStdString(event.warning_reason()).simplified()));
             break;
         }
+		case Event_NotifyUser::CUSTOM: {
+			if (!QString::fromStdString(event.custom_title()).simplified().isEmpty() && !QString::fromStdString(event.custom_content()).simplified().isEmpty()) {
+				QMessageBox msgBox;
+				msgBox.setParent(this);
+				msgBox.setWindowFlags(Qt::Dialog);
+				msgBox.setIcon(QMessageBox::Information);
+				msgBox.setWindowTitle(QString::fromStdString(event.custom_title()).simplified());
+				msgBox.setText(tr("You have received the following message from the server.\n(custom messages like these could be untranslated)"));
+				msgBox.setDetailedText(QString::fromStdString(event.custom_content()).simplified());
+				msgBox.setMinimumWidth(200);
+				msgBox.exec();
+			}
+			break;
+		}
         default: ;
     }
 

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -587,20 +587,20 @@ void TabSupervisor::processNotifyUserEvent(const Event_NotifyUser &event)
                 QMessageBox::warning(this, tr("Warned"), tr("You have received a warning due to %1.\nPlease refrain from engaging in this activity or further actions may be taken against you. If you have any questions, please private message a moderator.").arg(QString::fromStdString(event.warning_reason()).simplified()));
             break;
         }
-		case Event_NotifyUser::CUSTOM: {
-			if (!QString::fromStdString(event.custom_title()).simplified().isEmpty() && !QString::fromStdString(event.custom_content()).simplified().isEmpty()) {
-				QMessageBox msgBox;
-				msgBox.setParent(this);
-				msgBox.setWindowFlags(Qt::Dialog);
-				msgBox.setIcon(QMessageBox::Information);
-				msgBox.setWindowTitle(QString::fromStdString(event.custom_title()).simplified());
-				msgBox.setText(tr("You have received the following message from the server.\n(custom messages like these could be untranslated)"));
-				msgBox.setDetailedText(QString::fromStdString(event.custom_content()).simplified());
-				msgBox.setMinimumWidth(200);
-				msgBox.exec();
-			}
-			break;
-		}
+        case Event_NotifyUser::CUSTOM: {
+            if (!QString::fromStdString(event.custom_title()).simplified().isEmpty() && !QString::fromStdString(event.custom_content()).simplified().isEmpty()) {
+                QMessageBox msgBox;
+                msgBox.setParent(this);
+                msgBox.setWindowFlags(Qt::Dialog);
+                msgBox.setIcon(QMessageBox::Information);
+                msgBox.setWindowTitle(QString::fromStdString(event.custom_title()).simplified());
+                msgBox.setText(tr("You have received the following message from the server.\n(custom messages like these could be untranslated)"));
+                msgBox.setDetailedText(QString::fromStdString(event.custom_content()).simplified());
+                msgBox.setMinimumWidth(200);
+                msgBox.exec();
+            }
+            break;
+        }
         default: ;
     }
 

--- a/common/pb/event_notify_user.proto
+++ b/common/pb/event_notify_user.proto
@@ -8,7 +8,7 @@ message Event_NotifyUser {
         PROMOTED = 1;
         WARNING = 2;
         IDLEWARNING = 3;
-		CUSTOM = 4;
+        CUSTOM = 4;
     }
 
     extend SessionEvent {
@@ -16,7 +16,7 @@ message Event_NotifyUser {
     }
     optional NotificationType type = 1;
     optional string warning_reason = 2;
-	optional string custom_title = 3;
-	optional string custom_content = 4;
+    optional string custom_title = 3;
+    optional string custom_content = 4;
 
 }

--- a/common/pb/event_notify_user.proto
+++ b/common/pb/event_notify_user.proto
@@ -8,6 +8,7 @@ message Event_NotifyUser {
         PROMOTED = 1;
         WARNING = 2;
         IDLEWARNING = 3;
+		CUSTOM = 4;
     }
 
     extend SessionEvent {
@@ -15,5 +16,7 @@ message Event_NotifyUser {
     }
     optional NotificationType type = 1;
     optional string warning_reason = 2;
+	optional string custom_title = 3;
+	optional string custom_content = 4;
 
 }


### PR DESCRIPTION
This PR adds a custom notify user event.  I am closing an existing PR and implementing this as a first step towards completing #1863 .  Adding a custom notification event such as this allows for a larger scope of use inside the server/client.

Here is a sceen shot of the custom message.  There is one translated line in the dialog (that can be reworded upon suggestion) but with the layout as it is now it should enable the user to copy/paste the custom message out into a translation type software such as google translate in the event they do need the message translated.

![image](https://cloud.githubusercontent.com/assets/1361287/22484409/4c9ba7da-e7cf-11e6-8dc7-0a5630eb5a5a.png)
