### PR TITLE
Reverse wording on logfilters description

### DIFF
--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -44,7 +44,7 @@ writelog=1
 ; [ex: C:\\Temp\\server.log ]
 logfile=server.log
 
-; You may want to log only certain messages the logfile. The default log level is extremely verbose. 
+; You may want to log only certain messages in the logfile. The default log level is extremely verbose. 
 ; This setting should contain a comma-separated list of strings that will be selectively logged.
 ; All other lines will be excluded from the log. Default is empty; example: "Registration,_Login,foobar"
 logfilters=""

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -44,9 +44,9 @@ writelog=1
 ; [ex: C:\\Temp\\server.log ]
 logfile=server.log
 
-; You may want to silence some commonly recurring messages in the logfile. This setting can contain a
-; comma-separed list of words; if any message that is about to be logged contains at least one of these words,
-; it won't be logged. Default is empty; example: "kittens,ponies,faires"
+; You may want to log only certain messages the logfile. The default log level is extremely verbose. 
+; This setting should contain a comma-separated list of strings that will be selectively logged.
+; All other lines will be excluded from the log. Default is empty; example: "Registration,_Login,foobar"
 logfilters=""
 
 ; Set the time interval in seconds that servatrice will use to communicate with each connected client


### PR DESCRIPTION
The `logfilters` setting was inverted.  Previously said it logged everything *except* listed strings, actually logs *only* listed strings.