### PR TITLE
Update Custom PIcture URL to match wiki

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -30,7 +30,7 @@
 #include "soundengine.h"
 #include "sequenceEdit/shortcutstab.h"
 
-#define WIKI_CUSTOM_PIC_URL "https://github.com/Cockatrice/Cockatrice/wiki/Custom-Download-URLs"
+#define WIKI_CUSTOM_PIC_URL "https://github.com/Cockatrice/Cockatrice/wiki/Custom-Picture-Download-URLs"
 
 GeneralSettingsPage::GeneralSettingsPage()
 {


### PR DESCRIPTION
Wiki page was moved, link in settings points to old page.