### PR TITLE
Add keybaord shortcut for creating related cards

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1103,9 +1103,14 @@ void Player::actCreateRelatedCard()
     // get the target card name
     QAction *action = static_cast<QAction *>(sender());
 
+    const QString &cardName = action->text();
+    createCard(sourceCard, cardName);
+}
+
+void Player::createCard(const CardItem *sourceCard, const QString &cardName) {
     // removes p/t from tokens (and leading space))
     // Added split for "Token:" due to change in PR fixing #2317
-    QStringList spaces = action->text().split(tr("Token: "))[1].split(" ");
+    QStringList spaces = cardName.split(tr("Token: "))[1].split(" ");;
     if (spaces.at(0).indexOf("/") != -1) // Strip space from creatures
         spaces.removeFirst();
     CardInfo *cardInfo = db->getCard(spaces.join(" "));

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2355,9 +2355,11 @@ void Player::updateCardMenu(CardItem *card)
 
                 if(card->getInfo())
                 {
-                    QStringList relatedCards = card->getInfo()->getRelatedCards();
-                    QStringList reverserelatedCards2Me = card->getInfo()->getReverseRelatedCards2Me();
-                    if(relatedCards.size() || reverserelatedCards2Me.size())
+                    QStringList relatedCards = * new QStringList();
+                    relatedCards.append(card->getInfo()->getRelatedCards());
+                    relatedCards.append(card->getInfo()->getReverseRelatedCards2Me());
+
+                    if(!relatedCards.empty())
                     {
                         cardMenu->addSeparator();
                         for (int i = 0; i < relatedCards.size(); ++i) {
@@ -2366,11 +2368,6 @@ void Player::updateCardMenu(CardItem *card)
                             cardMenu->addAction(a);
                         }
 
-                        for (int i = 0; i < reverserelatedCards2Me.size(); ++i) {
-                            QAction *a = new QAction(tr("Token: ") + reverserelatedCards2Me.at(i), this);
-                            connect(a, SIGNAL(triggered()), this, SLOT(actCreateRelatedCard()));
-                            cardMenu->addAction(a);
-                        }
                     }
                 }
                 cardMenu->addSeparator();

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1114,9 +1114,8 @@ void Player::actCreateAllRelatedCards()
     relatedCards.append(sourceCard->getInfo()->getRelatedCards());
     relatedCards.append(sourceCard->getInfo()->getReverseRelatedCards2Me());
 
-    for (int i = 0; i < relatedCards.size(); i++)
+    foreach (const QString &tokenName, relatedCards)
     {
-        const QString &tokenName = relatedCards.at(i);
         createCard(sourceCard, dbNameFromTokenDisplayName(tokenName));
     }
 }
@@ -2318,14 +2317,14 @@ void Player::refreshShortcuts()
     {
         setShortcutsActive();
 
-        for (int i = 0; i < table->getCards().size(); ++i) {
-            CardItem *const &card = table->getCards().at(i);
-            updateCardMenu(card);
+        foreach (const CardItem *cardItem, table->getCards())
+        {
+            updateCardMenu(cardItem);
         }
     }
 }
 
-void Player::updateCardMenu(CardItem *card)
+void Player::updateCardMenu(const CardItem *card)
 {
     QMenu *cardMenu = card->getCardMenu();
     QMenu *ptMenu = card->getPTMenu();

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2384,46 +2384,8 @@ void Player::updateCardMenu(CardItem *card)
                 if (card->getFaceDown())
                     cardMenu->addAction(aPeek);
 
-                if(card->getInfo())
-                {
-                    QStringList relatedCards = * new QStringList();
-                    relatedCards.append(card->getInfo()->getRelatedCards());
-                    relatedCards.append(card->getInfo()->getReverseRelatedCards2Me());
+                addRelatedCardActions(card, cardMenu);
 
-                    switch (relatedCards.length())
-                    {
-                        case 0:
-                            break;
-                        case 1:
-                        {
-                            cardMenu->addSeparator();
-                            QAction * createRelatedCards = new QAction(tr("Token: ") + relatedCards.at(0), this);
-                            connect(createRelatedCards, SIGNAL(triggered()), this, SLOT(actCreateAllRelatedCards()));
-                            if (shortcutsActive)
-                            {
-                                createRelatedCards->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aCreateRelatedTokens"));
-                            }
-                            cardMenu->addAction(createRelatedCards);
-                            break;
-                        }
-                        default:
-                        {
-                            cardMenu->addSeparator();
-                            for (int i = 0; i < relatedCards.size(); ++i) {
-                                QAction *createRelated = new QAction(tr("Token: ") + relatedCards.at(i), this);
-                                connect(createRelated, SIGNAL(triggered()), this, SLOT(actCreateRelatedCard()));
-                                cardMenu->addAction(createRelated);
-                            }
-                            QAction * createRelatedCards = new QAction(tr("All tokens"), this);
-                            connect(createRelatedCards, SIGNAL(triggered()), this, SLOT(actCreateAllRelatedCards()));
-                            if (shortcutsActive) {
-                                createRelatedCards->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aCreateRelatedTokens"));
-                            }
-                            cardMenu->addAction(createRelatedCards);
-                            break;
-                        }
-                    }
-                }
                 cardMenu->addSeparator();
                 cardMenu->addAction(aAttach);
                 if (card->getAttachedTo())
@@ -2451,46 +2413,7 @@ void Player::updateCardMenu(CardItem *card)
                 cardMenu->addAction(aDrawArrow);
                 cardMenu->addMenu(moveMenu);
 
-                if(card->getInfo())
-                {
-                    QStringList relatedCards = * new QStringList();
-                    relatedCards.append(card->getInfo()->getRelatedCards());
-                    relatedCards.append(card->getInfo()->getReverseRelatedCards2Me());
-
-                    switch (relatedCards.length())
-                    {
-                        case 0:
-                            break;
-                        case 1:
-                        {
-                            cardMenu->addSeparator();
-                            QAction * createRelatedCards = new QAction(tr("Token: ") + relatedCards.at(0), this);
-                            connect(createRelatedCards, SIGNAL(triggered()), this, SLOT(actCreateAllRelatedCards()));
-                            if (shortcutsActive)
-                            {
-                                createRelatedCards->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aCreateRelatedTokens"));
-                            }
-                            cardMenu->addAction(createRelatedCards);
-                            break;
-                        }
-                        default:
-                        {
-                            cardMenu->addSeparator();
-                            for (int i = 0; i < relatedCards.size(); ++i) {
-                                QAction *createRelated = new QAction(tr("Token: ") + relatedCards.at(i), this);
-                                connect(createRelated, SIGNAL(triggered()), this, SLOT(actCreateRelatedCard()));
-                                cardMenu->addAction(createRelated);
-                            }
-                            QAction * createRelatedCards = new QAction(tr("All tokens"), this);
-                            connect(createRelatedCards, SIGNAL(triggered()), this, SLOT(actCreateAllRelatedCards()));
-                            if (shortcutsActive) {
-                                createRelatedCards->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aCreateRelatedTokens"));
-                            }
-                            cardMenu->addAction(createRelatedCards);
-                            break;
-                        }
-                    }
-                }
+                addRelatedCardActions(card, cardMenu);
             } else {
                 cardMenu->addAction(aPlay);
                 cardMenu->addAction(aPlayFacedown);
@@ -2498,6 +2421,44 @@ void Player::updateCardMenu(CardItem *card)
             }
         } else
             cardMenu->addMenu(moveMenu);
+    }
+}
+
+void Player::addRelatedCardActions(const CardItem *card, QMenu *cardMenu) {
+    if(card->getInfo()) {
+        QStringList relatedCards = *new QStringList();
+        relatedCards.append(card->getInfo()->getRelatedCards());
+        relatedCards.append(card->getInfo()->getReverseRelatedCards2Me());
+
+        switch (relatedCards.length()) {
+            case 0:
+                break;
+            case 1: {
+                cardMenu->addSeparator();
+                QAction *createRelatedCards = new QAction(tr("Token: ") + relatedCards.at(0), this);
+                connect(createRelatedCards, SIGNAL(triggered()), this, SLOT(actCreateAllRelatedCards()));
+                if (shortcutsActive) {
+                    createRelatedCards->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aCreateRelatedTokens"));
+                }
+                cardMenu->addAction(createRelatedCards);
+                break;
+            }
+            default: {
+                cardMenu->addSeparator();
+                for (int i = 0; i < relatedCards.size(); ++i) {
+                    QAction *createRelated = new QAction(tr("Token: ") + relatedCards.at(i), this);
+                    connect(createRelated, SIGNAL(triggered()), this, SLOT(actCreateRelatedCard()));
+                    cardMenu->addAction(createRelated);
+                }
+                QAction *createRelatedCards = new QAction(tr("All tokens"), this);
+                connect(createRelatedCards, SIGNAL(triggered()), this, SLOT(actCreateAllRelatedCards()));
+                if (shortcutsActive) {
+                    createRelatedCards->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aCreateRelatedTokens"));
+                }
+                cardMenu->addAction(createRelatedCards);
+                break;
+            }
+        }
     }
 }
 

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -24,6 +24,7 @@
 #include <QPainter>
 #include <QMenu>
 #include <QDebug>
+#include <QRegExp>
 
 #include "pb/command_change_zone_properties.pb.h"
 #include "pb/command_reveal_cards.pb.h"

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2424,41 +2424,46 @@ void Player::updateCardMenu(const CardItem *card)
 }
 
 void Player::addRelatedCardActions(const CardItem *card, QMenu *cardMenu) {
-    if(card->getInfo()) {
-        QStringList relatedCards = *new QStringList();
-        relatedCards.append(card->getInfo()->getRelatedCards());
-        relatedCards.append(card->getInfo()->getReverseRelatedCards2Me());
+    if (!card || !cardMenu || !card->getInfo())
+    {
+        return;
+    }
 
-        switch (relatedCards.length()) {
-            case 0:
-                break;
-            case 1: {
-                cardMenu->addSeparator();
-                QAction *createRelatedCards = new QAction(tr("Token: ") + relatedCards.at(0), this);
-                connect(createRelatedCards, SIGNAL(triggered()), this, SLOT(actCreateAllRelatedCards()));
-                if (shortcutsActive) {
-                    createRelatedCards->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aCreateRelatedTokens"));
-                }
-                cardMenu->addAction(createRelatedCards);
-                break;
+    QStringList relatedCards = *new QStringList();
+    relatedCards.append(card->getInfo()->getRelatedCards());
+    relatedCards.append(card->getInfo()->getReverseRelatedCards2Me());
+
+    switch (relatedCards.length()) {
+        case 0:
+            break;
+        case 1: {
+            cardMenu->addSeparator();
+            QAction *createRelatedCards = new QAction(tr("Token: ") + relatedCards.at(0), this);
+            connect(createRelatedCards, SIGNAL(triggered()), this, SLOT(actCreateAllRelatedCards()));
+            if (shortcutsActive) {
+                createRelatedCards->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aCreateRelatedTokens"));
             }
-            default: {
-                cardMenu->addSeparator();
-                for (int i = 0; i < relatedCards.size(); ++i) {
-                    QAction *createRelated = new QAction(tr("Token: ") + relatedCards.at(i), this);
-                    connect(createRelated, SIGNAL(triggered()), this, SLOT(actCreateRelatedCard()));
-                    cardMenu->addAction(createRelated);
-                }
-                QAction *createRelatedCards = new QAction(tr("All tokens"), this);
-                connect(createRelatedCards, SIGNAL(triggered()), this, SLOT(actCreateAllRelatedCards()));
-                if (shortcutsActive) {
-                    createRelatedCards->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aCreateRelatedTokens"));
-                }
-                cardMenu->addAction(createRelatedCards);
-                break;
+            cardMenu->addAction(createRelatedCards);
+            break;
+        }
+        default: {
+            cardMenu->addSeparator();
+            foreach (QString cardName, relatedCards)
+            {
+                QAction *createRelated = new QAction(tr("Token: ") + cardName, this);
+                connect(createRelated, SIGNAL(triggered()), this, SLOT(actCreateRelatedCard()));
+                cardMenu->addAction(createRelated);
             }
+            QAction *createRelatedCards = new QAction(tr("All tokens"), this);
+            connect(createRelatedCards, SIGNAL(triggered()), this, SLOT(actCreateAllRelatedCards()));
+            if (shortcutsActive) {
+                createRelatedCards->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aCreateRelatedTokens"));
+            }
+            cardMenu->addAction(createRelatedCards);
+            break;
         }
     }
+
 }
 
 void Player::setCardMenu(QMenu *menu)

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2392,9 +2392,12 @@ void Player::updateCardMenu(CardItem *card)
                             cardMenu->addAction(a);
                         }
 
-                        QAction *a = new QAction(tr("Create all related tokens"), this);
-                        connect(a, SIGNAL(triggered()), this, SLOT(actCreateAllRelatedCards()));
-                        cardMenu->addAction(a);
+                        if (relatedCards.length() > 1)
+                        {
+                            QAction *a = new QAction(tr("Create all related tokens"), this);
+                            connect(a, SIGNAL(triggered()), this, SLOT(actCreateAllRelatedCards()));
+                            cardMenu->addAction(a);
+                        }
                     }
                 }
                 cardMenu->addSeparator();

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -212,7 +212,7 @@ private:
     
     void setCardAttrHelper(const GameEventContext &context, CardItem *card, CardAttribute attribute, const QString &avalue, bool allCards);
     void createCard(const CardItem *sourceCard, const QString &dbCardName);
-    const QString dbNameFromTokenDisplayName(const QString &tokenName) const;
+    QString dbNameFromTokenDisplayName(const QString &tokenName);
 
     QRectF bRect;
 

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -211,6 +211,7 @@ private:
     PlayerTarget *playerTarget;
     
     void setCardAttrHelper(const GameEventContext &context, CardItem *card, CardAttribute attribute, const QString &avalue, bool allCards);
+    void addRelatedCardActions(const CardItem *card, QMenu *cardMenu);
     void createCard(const CardItem *sourceCard, const QString &dbCardName);
     QString dbNameFromTokenDisplayName(const QString &tokenName);
 

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -4,6 +4,7 @@
 #include <QInputDialog>
 #include <QPoint>
 #include <QMap>
+#include <QRegExp>
 #include "abstractgraphicsitem.h"
 #include "pb/game_event.pb.h"
 #include "pb/card_attributes.pb.h"
@@ -141,6 +142,7 @@ private slots:
     void actOpenDeckInDeckEditor();
     void actCreatePredefinedToken();
     void actCreateRelatedCard();
+    void actCreateAllRelatedCards();
     void cardMenuAction();
     void actCardCounterTrigger();
     void actAttach();
@@ -209,6 +211,8 @@ private:
     PlayerTarget *playerTarget;
     
     void setCardAttrHelper(const GameEventContext &context, CardItem *card, CardAttribute attribute, const QString &avalue, bool allCards);
+    void createCard(const CardItem *sourceCard, const QString &dbCardName);
+    const QString dbNameFromTokenDisplayName(const QString &tokenName) const;
 
     QRectF bRect;
 
@@ -307,7 +311,6 @@ public:
     void sendGameCommand(PendingCommand *pend);
     void sendGameCommand(const google::protobuf::Message &command);
 
-    void createCard(const CardItem *sourceCard, const QString &cardName);
 };
 
 #endif

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -4,7 +4,6 @@
 #include <QInputDialog>
 #include <QPoint>
 #include <QMap>
-#include <QRegExp>
 #include "abstractgraphicsitem.h"
 #include "pb/game_event.pb.h"
 #include "pb/card_attributes.pb.h"

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -306,6 +306,8 @@ public:
     PendingCommand *prepareGameCommand(const QList< const ::google::protobuf::Message * > &cmdList);
     void sendGameCommand(PendingCommand *pend);
     void sendGameCommand(const google::protobuf::Message &command);
+
+    void createCard(const CardItem *sourceCard, const QString &cardName);
 };
 
 #endif

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -286,7 +286,7 @@ public:
     const QMap<int, ArrowItem *> &getArrows() const { return arrows; }
     void setCardMenu(QMenu *menu);
     QMenu *getCardMenu() const;
-    void updateCardMenu(CardItem *card);
+    void updateCardMenu(const CardItem *card);
     bool getActive() const { return active; }
     void setActive(bool _active);
     void setShortcutsActive();

--- a/cockatrice/src/sequenceEdit/ui_shortcutstab.h
+++ b/cockatrice/src/sequenceEdit/ui_shortcutstab.h
@@ -199,6 +199,8 @@ public:
     SequenceEdit *Player_aClone;
     QLabel *lbl_Player_aCreateToken;
     SequenceEdit *Player_aCreateToken;
+    QLabel *lbl_Player_aCreateRelatedTokens;
+    SequenceEdit *Player_aCreateRelatedTokens;
     QLabel *lbl_Player_aCreateAnotherToken;
     SequenceEdit *Player_aCreateAnotherToken;
     QLabel *lbl_Player_aSetAnnotation;
@@ -1080,25 +1082,35 @@ public:
 
         gridLayout_13->addWidget(Player_aCreateToken, 10, 1, 1, 1);
 
+        lbl_Player_aCreateRelatedTokens = new QLabel(groupBox_13);
+        lbl_Player_aCreateRelatedTokens->setObjectName("lbl_Player_aCreateRelatedTokens");
+
+        gridLayout_13->addWidget(lbl_Player_aCreateRelatedTokens, 11, 0, 1, 1);
+
+        Player_aCreateRelatedTokens = new SequenceEdit("Player/aCreateRelatedTokens",groupBox_13);
+        Player_aCreateRelatedTokens->setObjectName("Player_aCreateRelatedTokens");
+
+        gridLayout_13->addWidget(Player_aCreateRelatedTokens, 11, 1, 1, 1);
+
         lbl_Player_aCreateAnotherToken = new QLabel(groupBox_13);
         lbl_Player_aCreateAnotherToken->setObjectName("lbl_Player_aCreateAnotherToken");
 
-        gridLayout_13->addWidget(lbl_Player_aCreateAnotherToken, 11, 0, 1, 1);
+        gridLayout_13->addWidget(lbl_Player_aCreateAnotherToken, 12, 0, 1, 1);
 
         Player_aCreateAnotherToken = new SequenceEdit("Player/aCreateAnotherToken",groupBox_13);
         Player_aCreateAnotherToken->setObjectName("Player_aCreateAnotherToken");
 
-        gridLayout_13->addWidget(Player_aCreateAnotherToken, 11, 1, 1, 1);
+        gridLayout_13->addWidget(Player_aCreateAnotherToken, 12, 1, 1, 1);
 
         lbl_Player_aSetAnnotation = new QLabel(groupBox_13);
         lbl_Player_aSetAnnotation->setObjectName("lbl_Player_aSetAnnotation");
 
-        gridLayout_13->addWidget(lbl_Player_aSetAnnotation, 12, 0, 1, 1);
+        gridLayout_13->addWidget(lbl_Player_aSetAnnotation, 13, 0, 1, 1);
 
         Player_aSetAnnotation = new SequenceEdit("Player/aSetAnnotation",groupBox_13);
         Player_aSetAnnotation->setObjectName("Player_aSetAnnotation");
 
-        gridLayout_13->addWidget(Player_aSetAnnotation, 12, 1, 1, 1);
+        gridLayout_13->addWidget(Player_aSetAnnotation, 13, 1, 1, 1);
 
         gridLayout_17->addWidget(groupBox_13, 0, 2, 1, 1);
 
@@ -1543,6 +1555,7 @@ public:
         lbl_Player_aUnattach->setText(QApplication::translate("shortcutsTab", "Unattach card", 0));
         lbl_Player_aClone->setText(QApplication::translate("shortcutsTab", "Clone card", 0));
         lbl_Player_aCreateToken->setText(QApplication::translate("shortcutsTab", "Create token", 0));
+        lbl_Player_aCreateRelatedTokens->setText(QApplication::translate("shortcutsTab", "Create all related tokens", 0));
         lbl_Player_aCreateAnotherToken->setText(QApplication::translate("shortcutsTab", "Create another token", 0));
         lbl_Player_aSetAnnotation->setText(QApplication::translate("shortcutsTab", "Set annotation", 0));
         tabWidget->setTabText(tabWidget->indexOf(tab_2), QApplication::translate("shortcutsTab", "Phases | P/T | Playing Area", 0));

--- a/cockatrice/src/shortcutssettings.cpp
+++ b/cockatrice/src/shortcutssettings.cpp
@@ -185,6 +185,7 @@ void ShortcutsSettings::fillDefaultShorcuts()
     defaultShortCuts["Player/aClone"] = parseSequenceString("Ctrl+J");
     defaultShortCuts["Player/aCreateAnotherToken"] = parseSequenceString("Ctrl+G");
     defaultShortCuts["Player/aCreateToken"] = parseSequenceString("Ctrl+T");
+    defaultShortCuts["Player/aCreateRelatedTokens"] = parseSequenceString("Ctrl+Shift+T");
     defaultShortCuts["Player/aDecP"] = parseSequenceString("Ctrl+-");
     defaultShortCuts["Player/aDecPT"] = parseSequenceString("Ctrl+Alt+-");
     defaultShortCuts["Player/aDecT"] = parseSequenceString("Alt+-");


### PR DESCRIPTION
Finishes #2425.

![create all related cards example](https://cloud.githubusercontent.com/assets/2127384/23336942/532f3bca-fbac-11e6-83fc-3119612ff9aa.gif)

Once again, c++ isn't my forte, so let me know if I can clean anything up.