### PR TITLE
fix folder names

### DIFF
--- a/cockatrice/src/tab_deck_storage.cpp
+++ b/cockatrice/src/tab_deck_storage.cpp
@@ -271,7 +271,7 @@ void TabDeckStorage::actNewFolder()
     if (folderName.isEmpty())
         return;
 
-	// '/' isn't a valid filename character on *nix so we're choosing to replace it with a different arbitrary character.
+    // '/' isn't a valid filename character on *nix so we're choosing to replace it with a different arbitrary character.
     std::string folder = folderName.toStdString();
     std::replace(folder.begin(), folder.end(), '/', '-');
 

--- a/cockatrice/src/tab_deck_storage.cpp
+++ b/cockatrice/src/tab_deck_storage.cpp
@@ -270,6 +270,8 @@ void TabDeckStorage::actNewFolder()
     QString folderName = QInputDialog::getText(this, tr("New folder"), tr("Name of new folder:"));
     if (folderName.isEmpty())
         return;
+    std::string folder = folderName.toStdString();
+    std::replace(folder.begin(), folder.end(), '/', '\\'); // Fix #2429
 
     QString targetPath;
     RemoteDeckList_TreeModel::Node *curRight = serverDirView->getCurrentItem();
@@ -282,8 +284,8 @@ void TabDeckStorage::actNewFolder()
     
     Command_DeckNewDir cmd;
     cmd.set_path(targetPath.toStdString());
-    cmd.set_dir_name(folderName.toStdString());
-    
+    cmd.set_dir_name(folder);
+
     PendingCommand *pend = client->prepareSessionCommand(cmd);
     connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(newFolderFinished(Response, CommandContainer)));
     client->sendCommand(pend);

--- a/cockatrice/src/tab_deck_storage.cpp
+++ b/cockatrice/src/tab_deck_storage.cpp
@@ -270,8 +270,10 @@ void TabDeckStorage::actNewFolder()
     QString folderName = QInputDialog::getText(this, tr("New folder"), tr("Name of new folder:"));
     if (folderName.isEmpty())
         return;
+
+	// '/' isn't a valid filename character on *nix so we're choosing to replace it with a different arbitrary character.
     std::string folder = folderName.toStdString();
-    std::replace(folder.begin(), folder.end(), '/', '\\'); // Fix #2429
+    std::replace(folder.begin(), folder.end(), '/', '-');
 
     QString targetPath;
     RemoteDeckList_TreeModel::Node *curRight = serverDirView->getCurrentItem();


### PR DESCRIPTION
Fix #2429 

This should prevent folders from getting a troubling "/" character. Will replace with a backslash, which my testing showed worked fine.