### PR TITLE
Revert "Condensed Card Counter Context Menu"

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -26,9 +26,6 @@ CardItem::CardItem(Player *_owner, const QString &_name, int _cardid, bool _reve
     cardMenu = new QMenu;
     ptMenu = new QMenu;
     moveMenu = new QMenu;
-    addCounterMenu = new QMenu;
-    removeCounterMenu = new QMenu;
-    setCounterMenu = new QMenu;
     
     retranslateUi();
     emit updateCardMenu(this);
@@ -44,9 +41,6 @@ CardItem::~CardItem()
     delete cardMenu;
     delete ptMenu;
     delete moveMenu;
-    delete addCounterMenu;
-    delete removeCounterMenu;
-    delete setCounterMenu;
     
     deleteDragItem();
 }
@@ -88,9 +82,6 @@ void CardItem::retranslateUi()
 {
     moveMenu->setTitle(tr("&Move to"));
     ptMenu->setTitle(tr("&Power / toughness"));
-    addCounterMenu->setTitle(tr("Add Counter"));
-    removeCounterMenu->setTitle(tr("Remove Counter"));
-    setCounterMenu->setTitle(tr("Set Counters"));
 }
 
 void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)

--- a/cockatrice/src/carditem.h
+++ b/cockatrice/src/carditem.h
@@ -32,7 +32,7 @@ private:
     CardItem *attachedTo;
     QList<CardItem *> attachedCards;
     
-    QMenu *cardMenu, *ptMenu, *moveMenu, *addCounterMenu, *removeCounterMenu, *setCounterMenu;
+    QMenu *cardMenu, *ptMenu, *moveMenu;
 
     void prepareDelete();
 public slots:
@@ -75,9 +75,6 @@ public:
     QMenu *getCardMenu() const { return cardMenu; }
     QMenu *getPTMenu() const { return ptMenu; }
     QMenu *getMoveMenu() const { return moveMenu; }
-    QMenu *getAddCounterMenu() const { return addCounterMenu; }
-    QMenu *getRemoveCounterMenu() const { return removeCounterMenu; }
-    QMenu *getSetCounterMenu() const { return setCounterMenu; }
     
     bool animationEvent();
     CardDragItem *createDragItem(int _id, const QPointF &_pos, const QPointF &_scenePos, bool faceDown);

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -699,13 +699,13 @@ void Player::retranslateUi()
     counterColors.append(tr("Green"));
 
     for (int i = 0; i < aAddCounter.size(); ++i){
-        aAddCounter[i]->setText(tr("%1").arg(counterColors[i]));
+        aAddCounter[i]->setText(tr("&Add counter (%1)").arg(counterColors[i]));
     }
     for (int i = 0; i < aRemoveCounter.size(); ++i){
-        aRemoveCounter[i]->setText(tr("%1").arg(counterColors[i]));
+        aRemoveCounter[i]->setText(tr("&Remove counter (%1)").arg(counterColors[i]));
     }
     for (int i = 0; i < aSetCounter.size(); ++i){
-        aSetCounter[i]->setText(tr("%1...").arg(counterColors[i]));
+        aSetCounter[i]->setText(tr("&Set counters (%1)...").arg(counterColors[i]));
     }
 
     aMoveToTopLibrary->setText(tr("&Top of library"));
@@ -2330,9 +2330,6 @@ void Player::updateCardMenu(const CardItem *card)
     QMenu *cardMenu = card->getCardMenu();
     QMenu *ptMenu = card->getPTMenu();
     QMenu *moveMenu = card->getMoveMenu();
-    QMenu *addCounterMenu = card->getAddCounterMenu();
-    QMenu *removeCounterMenu = card->getRemoveCounterMenu();
-    QMenu *setCountersMenu = card->getSetCounterMenu();
 
     cardMenu->clear();
 
@@ -2399,15 +2396,11 @@ void Player::updateCardMenu(const CardItem *card)
                 cardMenu->addMenu(moveMenu);
 
                 for (int i = 0; i < aAddCounter.size(); ++i) {
-                    addCounterMenu->addAction(aAddCounter[i]);
-                    removeCounterMenu->addAction(aRemoveCounter[i]);
-                    setCountersMenu->addAction(aSetCounter[i]);
+                    cardMenu->addSeparator();
+                    cardMenu->addAction(aAddCounter[i]);
+                    cardMenu->addAction(aRemoveCounter[i]);
+                    cardMenu->addAction(aSetCounter[i]);
                 }
-
-                cardMenu->addSeparator();
-                cardMenu->addMenu(addCounterMenu);
-                cardMenu->addMenu(removeCounterMenu);
-                cardMenu->addMenu(setCountersMenu);
                 cardMenu->addSeparator();
             } else if (card->getZone()->getName() == "stack") {
                 cardMenu->addAction(aDrawArrow);


### PR DESCRIPTION
Reverts Cockatrice/Cockatrice#2348
Fix #2402

Based on initial feedback, this feature was not well received. As such, we are reverting back. May consider adding an option to "condense menus" at some point, but it won't be today unfortunately :( 