### PR TITLE
fix incorrect pawn icons

### DIFF
--- a/cockatrice/src/tab_message.cpp
+++ b/cockatrice/src/tab_message.cpp
@@ -114,8 +114,10 @@ void TabMessage::actLeave()
 
 void TabMessage::processUserMessageEvent(const Event_UserMessage &event)
 {
-    const UserLevelFlags userLevel(event.sender_name() == otherUserInfo->name() ? otherUserInfo->user_level() : ownUserInfo->user_level());
-    const QString userPriv(event.sender_name() == otherUserInfo->name() ? QString::fromStdString(otherUserInfo->privlevel()) : QString::fromStdString(ownUserInfo->privlevel()));
+    auto userInfo = event.sender_name() == otherUserInfo->name() ? otherUserInfo : ownUserInfo;
+    const UserLevelFlags userLevel(userInfo->user_level());
+    const QString userPriv = QString::fromStdString(userInfo->privlevel());
+
     chatView->appendMessage(QString::fromStdString(event.message()), 0,QString::fromStdString(event.sender_name()), userLevel, userPriv, true);
     if (tabSupervisor->currentIndex() != tabSupervisor->indexOf(this))
         soundEngine->playSound("private_message");

--- a/cockatrice/src/tab_message.cpp
+++ b/cockatrice/src/tab_message.cpp
@@ -115,7 +115,8 @@ void TabMessage::actLeave()
 void TabMessage::processUserMessageEvent(const Event_UserMessage &event)
 {
     const UserLevelFlags userLevel(event.sender_name() == otherUserInfo->name() ? otherUserInfo->user_level() : ownUserInfo->user_level());
-    chatView->appendMessage(QString::fromStdString(event.message()), 0,QString::fromStdString(event.sender_name()), userLevel, QString::fromStdString(otherUserInfo->privlevel()), true);
+    const QString userPriv(event.sender_name() == otherUserInfo->name() ? QString::fromStdString(otherUserInfo->privlevel()) : QString::fromStdString(ownUserInfo->privlevel()));
+    chatView->appendMessage(QString::fromStdString(event.message()), 0,QString::fromStdString(event.sender_name()), userLevel, userPriv, true);
     if (tabSupervisor->currentIndex() != tabSupervisor->indexOf(this))
         soundEngine->playSound("private_message");
     if (settingsCache->getShowMessagePopup() && shouldShowSystemPopup(event))


### PR DESCRIPTION
Fix #2386 

The issue came about because we always showed the pawn of "other user's pawn rank" instead of doing a tertiary case (like we do for flags).

This fixes the issue.