### PR TITLE
Webtrice set targets

### DIFF
--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -25,7 +25,6 @@ DlgConnect::DlgConnect(QWidget *parent)
     QStringList previousHostList = settingsCache->servers().getPreviousHostList();
     if (previousHostList.isEmpty()) {
         previousHostList << "cockatrice.woogerworks.com";
-        previousHostList << "vps.poixen.com";
         previousHostList << "chickatrice.net";
         previousHostList << "mtg.tetrarch.co";
         previousHostList << "cockatric.es";

--- a/webclient/index.html
+++ b/webclient/index.html
@@ -141,8 +141,13 @@ Loading cockatrice web client...
       $(div).find("[href]").each(function() {
         var attributeValue = $(this).attr('href');
         for(var protocol in hrefWhitelist)
-          if(attributeValue.indexOf(hrefWhitelist[protocol]) == 0)
-            return;
+        {
+            if(attributeValue.indexOf(hrefWhitelist[protocol]) == 0)
+            {
+                $(this).setAttribute('target', '_blank');
+                return;
+            }
+        }
 
         $(this).removeAttr('href');        
       });

--- a/webclient/index.html
+++ b/webclient/index.html
@@ -92,7 +92,6 @@ Loading cockatrice web client...
     source: [
       // add custom servers here
       "cockatrice.woogerworks.com",
-      "vps.poixen.com",
       "chickatrice.net",
       "127.0.0.1"
     ]


### PR DESCRIPTION
Fix #2309 

This should set the blank target, thus opening a new page when a link is clicked on.