### PR TITLE
make sure xml file is uploaded

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -1030,7 +1030,8 @@ void MainWindow::actAddCustomSet()
         QMessageBox::warning(this, tr("Load sets/cards"), tr("Selected file cannot be found."));
         return;
     }
-    else if (QFileInfo(fileName).suffix() != "xml") { // fileName = *.xml
+
+    if (QFileInfo(fileName).suffix() != "xml") { // fileName = *.xml
         QMessageBox::warning(this, tr("Load sets/cards"), tr("You can only import XML databases at this time."));
         return;
     }

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -1030,6 +1030,10 @@ void MainWindow::actAddCustomSet()
         QMessageBox::warning(this, tr("Load sets/cards"), tr("Selected file cannot be found."));
         return;
     }
+    else if (QFileInfo(fileName).suffix() != "xml") { // fileName = *.xml
+        QMessageBox::warning(this, tr("Load sets/cards"), tr("You can only import XML databases at this time."));
+        return;
+    }
 
     QDir dir = settingsCache->getCustomCardDatabasePath();
     int nextPrefix = getNextCustomSetPrefix(dir);


### PR DESCRIPTION
Addresses bulletpoint 1 of #2065 

This will now require an XML file to be uploaded. We _dont_ check for well formatted XML files, which I find to be a problem. That would probably fix some other tickets I saw earlier (That @tooomm will link shortly haha).

We should incorporate a well-formated check for all XML files in Cockatrice on initial load(). Just something for another PR later.