### PR TITLE
temp fix to downloading folders

### DIFF
--- a/cockatrice/src/tab_replays.cpp
+++ b/cockatrice/src/tab_replays.cpp
@@ -190,8 +190,13 @@ void TabReplays::actDownload()
     }
 
     ServerInfo_Replay const *curRight = serverDirView->getCurrentReplay();
+
     if (!curRight)
+    {
+        QMessageBox::information(this, tr("Downloading Replays"), tr("You cannot download replay folders at this time"));
         return;
+    }
+
     filePath += QString("/replay_%1.cor").arg(curRight->replay_id());
     
     Command_ReplayDownload cmd;


### PR DESCRIPTION
Fix #2374 

I will be looking into downloading multiple replays at once / downloading folders with their same structures in the near future. Will probably add to this PR after, just thought I'd throw this up for now