### PR TITLE
Server Connect Remade

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -115,6 +115,7 @@ SET(cockatrice_SOURCES
     src/update_downloader.cpp
     src/logger.cpp
     src/releasechannel.cpp
+    src/userconnection_information.cpp
     ${VERSION_STRING_CPP}
 )
 

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -190,7 +190,7 @@ void DlgConnect::updateDisplayInfo(const QString &saveName)
     UserConnection_Information uci;
     QStringList data = uci.getServerInfo(saveName);
 
-    if (saveEdit == NULL)
+    if (saveEdit == nullptr)
         return;
     
     saveEdit->setText(data.at(0));
@@ -232,7 +232,9 @@ void DlgConnect::actOk()
         settingsCache->servers().addNewServer(saveEdit->text(), hostEdit->text(), portEdit->text(), playernameEdit->text(), passwordEdit->text(), savePasswordCheckBox->isChecked());
     else
         settingsCache->servers().updateExistingServer(saveEdit->text(), hostEdit->text(), portEdit->text(), playernameEdit->text(), passwordEdit->text(), savePasswordCheckBox->isChecked());
+
     settingsCache->servers().setPrevioushostName(saveEdit->text());
+    settingsCache->servers().setAutoConnect(autoConnectCheckBox->isChecked() ? 1 : 0);
 
     if (playernameEdit->text().isEmpty())
     {

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -27,7 +27,7 @@ DlgConnect::DlgConnect(QWidget *parent)
 
     newHostButton = new QRadioButton(tr("New Host"), this);
     
-    saveLabel = new QLabel(tr("Menu Name:"));
+    saveLabel = new QLabel(tr("Name:"));
     saveEdit = new QLineEdit(settingsCache->servers().getSaveName());
     saveLabel->setBuddy(saveEdit);
 

--- a/cockatrice/src/dlg_connect.h
+++ b/cockatrice/src/dlg_connect.h
@@ -1,6 +1,7 @@
 #ifndef DLG_CONNECT_H
 #define DLG_CONNECT_H
 
+#include "userconnection_information.h"
 #include <QDialog>
 #include <QLineEdit>
 
@@ -31,17 +32,21 @@ public:
 private slots:
     void actOk();
     void actCancel();
+    void actSaveConfig();
     void passwordSaved(int state);
     void previousHostSelected(bool state);
     void newHostSelected(bool state);
     void actForgotPassword();
+    void updateDisplayInfo(const QString &saveName);
+    void rebuildComboBoxList();
 private:
-    QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel;
-    QLineEdit *hostEdit, *portEdit, *playernameEdit, *passwordEdit;
+    QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *saveLabel;
+    QLineEdit *hostEdit, *portEdit, *playernameEdit, *passwordEdit, *saveEdit;
     QCheckBox *savePasswordCheckBox, *autoConnectCheckBox;
     QComboBox *previousHosts;
     QRadioButton *newHostButton, *previousHostButton;
     QPushButton *btnOk, *btnCancel, *btnForgotPassword;
+    QMap<QString, UserConnection_Information> savedHostList;
 };
 
 #endif

--- a/cockatrice/src/settings/serverssettings.cpp
+++ b/cockatrice/src/settings/serverssettings.cpp
@@ -1,4 +1,5 @@
 #include "serverssettings.h"
+#include <QDebug>
 
 ServersSettings::ServersSettings(QString settingPath, QObject *parent)
     : SettingsManager(settingPath+"servers.ini", parent)
@@ -26,14 +27,32 @@ QStringList ServersSettings::getPreviousHostList()
     return getValue("previoushosts", "server").toStringList();
 }
 
-void ServersSettings::setPrevioushostindex(int index)
+void ServersSettings::setPrevioushostName(const QString &name)
 {
-    setValue(index, "previoushostindex", "server");
+    setValue(name, "previoushostName", "server");
 }
 
-int ServersSettings::getPrevioushostindex()
+QString ServersSettings::getSaveName(QString defaultname)
 {
-    return getValue("previoushostindex", "server").toInt();
+    int index = getPrevioushostindex(getPrevioushostName());
+    QVariant saveName = getValue(QString("saveName%1").arg(index), "server", "server_details");
+    return saveName == QVariant() ? defaultname : saveName.toString();
+}
+
+QString ServersSettings::getPrevioushostName()
+{
+    return getValue("previoushostName", "server").toString();
+}
+
+int ServersSettings::getPrevioushostindex(const QString &saveName)
+{
+    int size = getValue("totalServers", "server", "server_details").toInt() + 1;
+
+    for (int i = 0; i < size; i++)
+        if (saveName == getValue(QString("saveName%1").arg(i), "server", "server_details").toString())
+            return i;
+
+    return -1;
 }
 
 void ServersSettings::setHostName(QString hostname)
@@ -43,7 +62,8 @@ void ServersSettings::setHostName(QString hostname)
 
 QString ServersSettings::getHostname(QString defaultHost)
 {
-    QVariant hostname = getValue("hostname","server");
+    int index = getPrevioushostindex(getPrevioushostName());
+    QVariant hostname = getValue(QString("server%1").arg(index), "server", "server_details");
     return hostname == QVariant() ? defaultHost : hostname.toString();
 }
 
@@ -54,7 +74,9 @@ void ServersSettings::setPort(QString port)
 
 QString ServersSettings::getPort(QString defaultPort)
 {
-    QVariant port = getValue("port","server");
+    int index = getPrevioushostindex(getPrevioushostName());
+    QVariant port = getValue(QString("port%1").arg(index), "server", "server_details");
+    qDebug() << "getPort() index = " << index << " port.val = " << port.toString();
     return port == QVariant() ? defaultPort : port.toString();
 }
 
@@ -65,7 +87,9 @@ void ServersSettings::setPlayerName(QString playerName)
 
 QString ServersSettings::getPlayerName(QString defaultName)
 {
-    QVariant name = getValue("playername", "server");
+    int index = getPrevioushostindex(getPrevioushostName());
+    QVariant name = getValue(QString("username%1").arg(index), "server", "server_details");
+    qDebug() << "getPlayerName() index = " << index << " name.val = " << name.toString();
     return name == QVariant() ? defaultName : name.toString();
 }
 
@@ -76,7 +100,8 @@ void ServersSettings::setPassword(QString password)
 
 QString ServersSettings::getPassword()
 {
-    return getValue("password", "server").toString();
+    int index = getPrevioushostindex(getPrevioushostName());
+    return getValue(QString("password%1").arg(index), "server", "server_details").toString();
 }
 
 void ServersSettings::setSavePassword(int save)
@@ -86,7 +111,8 @@ void ServersSettings::setSavePassword(int save)
 
 int ServersSettings::getSavePassword()
 {
-    QVariant save = getValue("save_password", "server");
+    int index = getPrevioushostindex(getPrevioushostName());
+    QVariant save = getValue(QString("savePassword%1").arg(index), "server", "server_details");
     return save == QVariant() ? 1 : save.toInt();
 }
 
@@ -132,4 +158,40 @@ QString ServersSettings::getFPPlayerName(QString defaultName)
 {
     QVariant name = getValue("fpplayername", "server");
     return name == QVariant() ? defaultName : name.toString();
+}
+
+void ServersSettings::addNewServer(QString saveName, QString serv, QString port, QString username, QString password, bool savePassword)
+{
+    if (updateExistingServer(saveName, serv, port, username, password, savePassword))
+        return;
+
+    int index = getValue("totalServers", "server", "server_details").toInt() + 1;
+
+    setValue(saveName, QString("saveName%1").arg(index), "server", "server_details");
+    setValue(serv, QString("server%1").arg(index), "server", "server_details");
+    setValue(port, QString("port%1").arg(index), "server", "server_details");
+    setValue(username, QString("username%1").arg(index), "server", "server_details");
+    setValue(password, QString("password%1").arg(index), "server", "server_details");
+    setValue(savePassword, QString("savePassword%1").arg(index), "server", "server_details");
+    setValue(index, "totalServers", "server", "server_details");
+    
+}
+
+bool ServersSettings::updateExistingServer(QString saveName, QString serv, QString port, QString username, QString password, bool savePassword)
+{
+    int size = getValue("totalServers", "server", "server_details").toInt() + 1;
+
+    for (int i = 0; i < size; i++)
+    {
+        if (saveName == getValue(QString("saveName%1").arg(i), "server", "server_details").toString())
+        {
+            setValue(serv, QString("server%1").arg(i), "server", "server_details");
+            setValue(port, QString("port%1").arg(i), "server", "server_details");
+            setValue(username, QString("username%1").arg(i), "server", "server_details");
+            setValue(password, QString("password%1").arg(i), "server", "server_details");
+            setValue(savePassword, QString("savePassword%1").arg(i), "server", "server_details");
+            return true;
+        }
+    }
+    return false;
 }

--- a/cockatrice/src/settings/serverssettings.h
+++ b/cockatrice/src/settings/serverssettings.h
@@ -11,8 +11,9 @@ class ServersSettings : public SettingsManager
 
 public:    
     int getPreviousHostLogin();
+    int getPrevioushostindex(const QString &);
     QStringList getPreviousHostList();
-    int getPrevioushostindex();
+    QString getPrevioushostName();
     QString getHostname(QString defaultHost = "");
     QString getPort(QString defaultPort = "");
     QString getPlayerName(QString defaultName = "");
@@ -20,10 +21,12 @@ public:
     QString getFPPort(QString defaultPort = "");
     QString getFPPlayerName(QString defaultName = "");
     QString getPassword();
+    QString getSaveName(QString defaultname = "");
     int getSavePassword();
     int getAutoConnect();
 
     void setPreviousHostLogin(int previous);
+    void setPrevioushostName(const QString &);
     void setPreviousHostList(QStringList list);
     void setPrevioushostindex(int index);
     void setHostName(QString hostname);
@@ -35,6 +38,8 @@ public:
     void setFPHostName(QString hostname);
     void setFPPort(QString port);
     void setFPPlayerName(QString playerName);
+    void addNewServer(QString saveName, QString serv, QString port, QString username, QString password, bool savePassword);
+    bool updateExistingServer(QString saveName, QString serv, QString port, QString username, QString password, bool savePassword);
 signals:
 
 public slots:

--- a/cockatrice/src/settings/settingsmanager.h
+++ b/cockatrice/src/settings/settingsmanager.h
@@ -11,6 +11,7 @@ class SettingsManager : public QObject
     Q_OBJECT
 public:
     SettingsManager(QString settingPath, QObject *parent = 0);
+    QVariant getValue(QString name, QString group = "", QString subGroup = "");
 
 signals:
 
@@ -18,8 +19,7 @@ public slots:
 
 protected:
     QSettings settings;
-    QVariant getValue(QString name, QString group = "", QString subGroup = "" );
-    void setValue(QVariant value, QString name, QString group = "", QString subGroup = "" );
+    void setValue(QVariant value, QString name, QString group = "", QString subGroup = "");
 };
 
 #endif // SETTINGSMANAGER_H

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -58,7 +58,6 @@ void SettingsCache::translateLegacySettings()
     legacySetting.beginGroup("server");
     servers().setPreviousHostLogin(legacySetting.value("previoushostlogin").toInt());
     servers().setPreviousHostList(legacySetting.value("previoushosts").toStringList());
-    servers().setPrevioushostindex(legacySetting.value("previoushostindex").toInt());
     servers().setHostName(legacySetting.value("hostname").toString());
     servers().setPort(legacySetting.value("port").toString());
     servers().setPlayerName(legacySetting.value("playername").toString());

--- a/cockatrice/src/userconnection_information.cpp
+++ b/cockatrice/src/userconnection_information.cpp
@@ -1,0 +1,68 @@
+#include "userconnection_information.h"
+#include "settingscache.h"
+#include <QDebug>
+
+UserConnection_Information::UserConnection_Information()
+{
+}
+
+UserConnection_Information::UserConnection_Information(QString _saveName, QString _serverName, QString _portNum, QString _userName, QString _pass, bool _savePass)
+    : saveName(_saveName), server(_serverName), port(_portNum), username(_userName), password(_pass), savePassword(_savePass)
+{
+
+}
+
+QMap<QString, UserConnection_Information> UserConnection_Information::getServerInfo()
+{
+    QMap<QString, UserConnection_Information> serverList;
+    
+    int size = settingsCache->servers().getValue("totalServers", "server", "server_details").toInt() + 1;
+
+    for (int i = 0; i < size; i++)
+    {        
+        QString saveName = settingsCache->servers().getValue(QString("saveName%1").arg(i), "server", "server_details").toString();
+        QString serverName = settingsCache->servers().getValue(QString("server%1").arg(i), "server", "server_details").toString();
+        QString portNum = settingsCache->servers().getValue(QString("port%1").arg(i), "server", "server_details").toString();
+        QString userName = settingsCache->servers().getValue(QString("username%1").arg(i), "server", "server_details").toString();
+        QString pass = settingsCache->servers().getValue(QString("password%1").arg(i), "server", "server_details").toString();
+        bool savePass =settingsCache->servers().getValue(QString("savePassword%1").arg(i), "server", "server_details").toBool();
+
+        UserConnection_Information userInfo(saveName, serverName, portNum, userName, pass, savePass);
+        serverList.insert(saveName, userInfo);  
+    }
+
+    return serverList;
+}
+
+QStringList UserConnection_Information::getServerInfo(const QString &find)
+{
+    QStringList server;
+ 
+    int size = settingsCache->servers().getValue("totalServers", "server", "server_details").toInt() + 1;
+    for (int i = 0; i < size; i++)
+    {
+        QString saveName = settingsCache->servers().getValue(QString("saveName%1").arg(i), "server", "server_details").toString();
+
+        if (find != saveName)
+            continue;
+
+        QString serverName = settingsCache->servers().getValue(QString("server%1").arg(i), "server", "server_details").toString();
+        QString portNum = settingsCache->servers().getValue(QString("port%1").arg(i), "server", "server_details").toString();
+        QString userName = settingsCache->servers().getValue(QString("username%1").arg(i), "server", "server_details").toString();
+        QString pass = settingsCache->servers().getValue(QString("password%1").arg(i), "server", "server_details").toString();
+        bool savePass =settingsCache->servers().getValue(QString("savePassword%1").arg(i), "server", "server_details").toBool();
+        
+        server.append(saveName);
+        server.append(serverName);
+        server.append(portNum);
+        server.append(userName);
+        server.append(pass);
+        server.append(savePass ? "1" : "0");
+        break;
+    }
+    
+    if (!server.size())
+        qDebug() << "There was a problem!";
+
+    return server;
+}

--- a/cockatrice/src/userconnection_information.h
+++ b/cockatrice/src/userconnection_information.h
@@ -1,0 +1,31 @@
+#ifndef USERCONNECTION_INFORMATION_H
+#define USERCONNECTION_INFORMATION_H
+
+#include <QSettings>
+#include <QFile>
+#include <QDir>
+#include <QApplication>
+#include <QStandardPaths>
+
+class UserConnection_Information {
+    private:
+        QString saveName;
+        QString server;
+        QString port;
+        QString username;
+        QString password;
+        bool savePassword;
+    
+    public:
+        UserConnection_Information();
+        UserConnection_Information(QString, QString, QString, QString, QString, bool);
+        QString getSaveName() { return saveName; }
+        QString getServer() { return server; }
+        QString getPort() { return port; }
+        QString getUsername() { return username; }
+        QString getPassword() { return password; }
+        bool getSavePassword() { return savePassword; }
+        QMap<QString, UserConnection_Information> getServerInfo();
+        QStringList getServerInfo(const QString &find);
+};
+#endif


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2070
(If you can find others please update this list)

## Short roundup of the initial problem
The dropdown menu had only one set of configurations when we had multiple servers, leading users to want to have same passwords across numerous servatrices.

## What will change with this Pull Request?
This changes the behavior of the connection dialog to only save one set of settings for all servers to have multiple configurations that are changed when the dropdown menu is changed. You can either save the server settings by pressing the button OR when you connect the settings are automatically updated. Everything is based around Menu Name as a key, so if you try to add an element that's the same name, it will instead update the old key values.

## Screenshots
<img width="470" alt="screenshot 2017-03-14 17 32 02" src="https://cloud.githubusercontent.com/assets/7460172/23923215/2ba10b6e-08dc-11e7-8189-34250910e456.png">
<img width="427" alt="screenshot 2017-03-14 17 32 06" src="https://cloud.githubusercontent.com/assets/7460172/23923216/2ba31134-08dc-11e7-9565-427a60d1a6d0.png">
<img width="429" alt="screenshot 2017-03-14 17 32 40" src="https://cloud.githubusercontent.com/assets/7460172/23923237/3c9234e8-08dc-11e7-998b-02f4840b5851.png">

