### PR TITLE
Reset idle timer when a message is sent.

### DIFF
--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -536,7 +536,7 @@ Response::ResponseCode Server_ProtocolHandler::cmdMessage(const Command_Message 
     rc.enqueuePreResponseItem(ServerMessage::SESSION_EVENT, se);
 
     databaseInterface->logMessage(userInfo->id(), QString::fromStdString(userInfo->name()), QString::fromStdString(userInfo->address()), QString::fromStdString(cmd.message()), Server_DatabaseInterface::MessageTargetChat, userInterface->getUserInfo()->id(), receiver);
-
+    resetIdleTimer();
     return Response::RespOk;
 }
 


### PR DESCRIPTION
Fix #2454 
When a user sends a message to the server this action was not recorded as a valid action to reset the idle timer on a clients session.  This change will now allow the idle timer countdown to get reset if a user sends a message.