### PR TITLE
Close connection dialog on "forgot password"; fix #2445

### DIFF
--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -224,4 +224,5 @@ bool DeleteHighlightedItemWhenShiftDelPressedEventFilter::eventFilter(QObject *o
 void DlgConnect::actForgotPassword()
 {
     emit sigStartForgotPasswordRequest();
+    reject();
 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2445 

## Short roundup of the initial problem
See #2445

## What will change with this Pull Request?
When pressing the "forgot password" button, the connection dialog will be closed.

## Screenshots
Mhh.. no
