### PR TITLE
Cmake support for openssl 1.1 on windows; fix #2424

### DIFF
--- a/cmake/FindWin32SslRuntime.cmake
+++ b/cmake/FindWin32SslRuntime.cmake
@@ -48,9 +48,10 @@ set(_OPENSSL_ROOT_HINTS_AND_PATHS
     PATHS ${_OPENSSL_ROOT_PATHS}
     )
 
-# Even if the dll is 64bit, it's still suffixed as *32.dll
-FIND_FILE(WIN32SSLRUNTIME_LIBEAY NAMES libeay32.dll ${_OPENSSL_ROOT_HINTS_AND_PATHS})
-FIND_FILE(WIN32SSLRUNTIME_SSLEAY NAMES ssleay32.dll ${_OPENSSL_ROOT_HINTS_AND_PATHS})
+# For OpenSSL < 1.1, they are named libeay32 and ssleay32 and even if the dll is 64bit, it's still suffixed as *32.dll
+# For OpenSSL >= 1.1, they are named libcrypto and libssl with no suffix
+FIND_FILE(WIN32SSLRUNTIME_LIBEAY NAMES libeay32.dll libcrypto.dll ${_OPENSSL_ROOT_HINTS_AND_PATHS})
+FIND_FILE(WIN32SSLRUNTIME_SSLEAY NAMES ssleay32.dll libssl.dll ${_OPENSSL_ROOT_HINTS_AND_PATHS})
 
 
 IF(WIN32SSLRUNTIME_LIBEAY AND WIN32SSLRUNTIME_SSLEAY)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2424

## Short roundup of the initial problem
See #2424; In openssl 1.1 the library names changed, so our custom cmake script used to find and bundle them in the installer is not able to find them anymore.

## What will change with this Pull Request?
Support for the new library names has been added.
Please note that Qt still doesn't support openssl 1.1 yet, so it's not usable anyway.

## Screenshots
N/a
