### PR TITLE
Added privileged level only room

### DIFF
--- a/cockatrice/src/localserver.cpp
+++ b/cockatrice/src/localserver.cpp
@@ -6,7 +6,7 @@ LocalServer::LocalServer(QObject *parent)
     : Server(parent)
 {
     setDatabaseInterface(new LocalServer_DatabaseInterface(this));
-    addRoom(new Server_Room(0, 0, QString(), QString(), QString(), false, QString(), QStringList(), this));
+    addRoom(new Server_Room(0, 0, QString(), QString(), QString(), QString(), false, QString(), QStringList(), this));
 }
 
 LocalServer::~LocalServer()

--- a/cockatrice/src/tab_server.cpp
+++ b/cockatrice/src/tab_server.cpp
@@ -71,11 +71,18 @@ void RoomSelector::processListRoomsEvent(const Event_ListRooms &event)
     const int roomListSize = event.room_list_size();
     for (int i = 0; i < roomListSize; ++i) {
         const ServerInfo_Room &room = event.room_list(i);
+
+        /*
+        * A room can have a permission level and a privilege level. How ever we want to display only the necessary information 
+        * on the server tab needed to inform users of required permissions to enter a room. If the room has a privilege level
+        * the server tab will display the privilege level in the "permissions" column in the row however if the room contains
+        * a permissions level for the room the permissions level defined for the room will be displayed.
+        */
+
         QString roomPermissionDisplay = QString::fromStdString(room.privilegelevel()).toLower();
-        if (QString::fromStdString(room.permissionlevel()).toLower() != "none" && QString::fromStdString(room.privilegelevel()).toLower() == "none")
+        if (QString::fromStdString(room.permissionlevel()).toLower() != "none" || roomPermissionDisplay == "")
             roomPermissionDisplay = QString::fromStdString(room.permissionlevel()).toLower();
-        if (roomPermissionDisplay == "")
-            roomPermissionDisplay = QString::fromStdString(room.permissionlevel()).toLower();
+
         for (int j = 0; j < roomList->topLevelItemCount(); ++j) {
               QTreeWidgetItem *twi = roomList->topLevelItem(j);
             if (twi->data(0, Qt::UserRole).toInt() == room.room_id()) {

--- a/cockatrice/src/tab_server.cpp
+++ b/cockatrice/src/tab_server.cpp
@@ -74,7 +74,8 @@ void RoomSelector::processListRoomsEvent(const Event_ListRooms &event)
         QString roomPermissionDisplay = QString::fromStdString(room.privilegelevel()).toLower();
         if (QString::fromStdString(room.permissionlevel()).toLower() != "none" && QString::fromStdString(room.privilegelevel()).toLower() == "none")
             roomPermissionDisplay = QString::fromStdString(room.permissionlevel()).toLower();
-       
+        if (roomPermissionDisplay == "")
+            roomPermissionDisplay = QString::fromStdString(room.permissionlevel()).toLower();
         for (int j = 0; j < roomList->topLevelItemCount(); ++j) {
               QTreeWidgetItem *twi = roomList->topLevelItem(j);
             if (twi->data(0, Qt::UserRole).toInt() == room.room_id()) {

--- a/cockatrice/src/tab_server.cpp
+++ b/cockatrice/src/tab_server.cpp
@@ -80,8 +80,10 @@ void RoomSelector::processListRoomsEvent(const Event_ListRooms &event)
         */
 
         QString roomPermissionDisplay = QString::fromStdString(room.privilegelevel()).toLower();
-        if (QString::fromStdString(room.permissionlevel()).toLower() != "none" || roomPermissionDisplay == "")
+        if (QString::fromStdString(room.permissionlevel()).toLower() != "none")
             roomPermissionDisplay = QString::fromStdString(room.permissionlevel()).toLower();
+        if (roomPermissionDisplay == "")    // catch all for misconfigured .ini room definitions 
+            roomPermissionDisplay = "none";
 
         for (int j = 0; j < roomList->topLevelItemCount(); ++j) {
               QTreeWidgetItem *twi = roomList->topLevelItem(j);

--- a/cockatrice/src/tab_server.cpp
+++ b/cockatrice/src/tab_server.cpp
@@ -71,7 +71,10 @@ void RoomSelector::processListRoomsEvent(const Event_ListRooms &event)
     const int roomListSize = event.room_list_size();
     for (int i = 0; i < roomListSize; ++i) {
         const ServerInfo_Room &room = event.room_list(i);
-        
+        QString roomPermissionDisplay = QString::fromStdString(room.privilegelevel()).toLower();
+        if (QString::fromStdString(room.permissionlevel()).toLower() != "none" && QString::fromStdString(room.privilegelevel()).toLower() == "none")
+            roomPermissionDisplay = QString::fromStdString(room.permissionlevel()).toLower();
+       
         for (int j = 0; j < roomList->topLevelItemCount(); ++j) {
               QTreeWidgetItem *twi = roomList->topLevelItem(j);
             if (twi->data(0, Qt::UserRole).toInt() == room.room_id()) {
@@ -80,7 +83,7 @@ void RoomSelector::processListRoomsEvent(const Event_ListRooms &event)
                 if (room.has_description())
                     twi->setData(1, Qt::DisplayRole, QString::fromStdString(room.description()));
                 if (room.has_permissionlevel())
-                    twi->setData(2, Qt::DisplayRole, QString::fromStdString(room.permissionlevel()).toLower());
+                    twi->setData(2, Qt::DisplayRole, roomPermissionDisplay);
                 if (room.has_player_count())
                     twi->setData(3, Qt::DisplayRole, room.player_count());
                 if (room.has_game_count())
@@ -95,7 +98,7 @@ void RoomSelector::processListRoomsEvent(const Event_ListRooms &event)
         if (room.has_description())
             twi->setData(1, Qt::DisplayRole, QString::fromStdString(room.description()));
         if (room.has_permissionlevel())
-            twi->setData(2, Qt::DisplayRole, QString::fromStdString(room.permissionlevel()).toLower());
+            twi->setData(2, Qt::DisplayRole, roomPermissionDisplay);
         twi->setData(3, Qt::DisplayRole, room.player_count());
         twi->setData(4, Qt::DisplayRole, room.game_count());
         twi->setTextAlignment(2, Qt::AlignRight);

--- a/common/pb/serverinfo_room.proto
+++ b/common/pb/serverinfo_room.proto
@@ -14,4 +14,5 @@ message ServerInfo_Room {
     repeated ServerInfo_User user_list = 8;
     repeated ServerInfo_GameType gametype_list = 9;
     optional string permissionlevel = 10;
+    optional string privilegelevel = 11;
 }

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -637,6 +637,8 @@ Response::ResponseCode Server_ProtocolHandler::cmdJoinRoom(const Command_JoinRoo
                 return Response::RespUserLevelTooLow;
         }
 
+        // TODO: POSSIBLY EXTEND THE ROOM OBJECT TO HAVE PRIV LEVEL SETTINGS AND COMPARE TO USER PRIVLEVEL ?
+
         if (roomPermission == "vip") {
             if (!(userInfo->user_level() & ServerInfo_User::IsRegistered))
                 return Response::RespUserLevelTooLow;

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -645,6 +645,15 @@ Response::ResponseCode Server_ProtocolHandler::cmdJoinRoom(const Command_JoinRoo
                 if (QString::fromStdString(userInfo->privlevel()).toLower() != "vip")
                     return Response::RespUserLevelTooLow;
         }
+
+        if (roomPermission == "donator") {
+            if (!(userInfo->user_level() & ServerInfo_User::IsRegistered))
+                return Response::RespUserLevelTooLow;
+
+            if (!((userInfo->user_level() & ServerInfo_User::IsAdmin) && (userInfo->user_level() & ServerInfo_User::IsModerator)))
+                if (QString::fromStdString(userInfo->privlevel()).toLower() != "donator")
+                    return Response::RespUserLevelTooLow;
+        }
 }
 
     r->addClient(this);

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -766,9 +766,12 @@ bool Server_ProtocolHandler::isUserPermittedToJoinRoom(const QString roomPermiss
         {
             if (QString::fromStdString(userInfo->privlevel()).toLower() == "none")
                 return false;
-        } else
+        } 
+        else
+        {
             if (roomPrivilegeLevel.toLower() != QString::fromStdString(userInfo->privlevel()).toLower())
                 return false;
+        }
     }
     return true;
 }

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -639,11 +639,20 @@ Response::ResponseCode Server_ProtocolHandler::cmdJoinRoom(const Command_JoinRoo
 
         // TODO: POSSIBLY EXTEND THE ROOM OBJECT TO HAVE PRIV LEVEL SETTINGS AND COMPARE TO USER PRIVLEVEL ?
 
+        if (roomPermission == "privileged") {
+            if (!(userInfo->user_level() & ServerInfo_User::IsRegistered))
+                return Response::RespUserLevelTooLow;
+
+            if (!((userInfo->user_level() & ServerInfo_User::IsAdmin) || (userInfo->user_level() & ServerInfo_User::IsModerator)))
+                if (QString::fromStdString(userInfo->privlevel()).toLower() == "none")
+                    return Response::RespUserLevelTooLow;
+        }
+
         if (roomPermission == "vip") {
             if (!(userInfo->user_level() & ServerInfo_User::IsRegistered))
                 return Response::RespUserLevelTooLow;
             
-            if (!((userInfo->user_level() & ServerInfo_User::IsAdmin) && (userInfo->user_level() & ServerInfo_User::IsModerator)))
+            if (!((userInfo->user_level() & ServerInfo_User::IsAdmin) || (userInfo->user_level() & ServerInfo_User::IsModerator)))
                 if (QString::fromStdString(userInfo->privlevel()).toLower() != "vip")
                     return Response::RespUserLevelTooLow;
         }
@@ -652,7 +661,7 @@ Response::ResponseCode Server_ProtocolHandler::cmdJoinRoom(const Command_JoinRoo
             if (!(userInfo->user_level() & ServerInfo_User::IsRegistered))
                 return Response::RespUserLevelTooLow;
 
-            if (!((userInfo->user_level() & ServerInfo_User::IsAdmin) && (userInfo->user_level() & ServerInfo_User::IsModerator)))
+            if (!((userInfo->user_level() & ServerInfo_User::IsAdmin) || (userInfo->user_level() & ServerInfo_User::IsModerator)))
                 if (QString::fromStdString(userInfo->privlevel()).toLower() != "donator")
                     return Response::RespUserLevelTooLow;
         }

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -620,7 +620,7 @@ Response::ResponseCode Server_ProtocolHandler::cmdJoinRoom(const Command_JoinRoo
     if (!r)
         return Response::RespNameNotFound;
 
-    if (!(userInfo->user_level() & ServerInfo_User::IsModerator || userInfo->user_level() & ServerInfo_User::IsModerator))
+    if (!(userInfo->user_level() & ServerInfo_User::IsModerator))
         if (!(isUserPermittedToJoinRoom(r->getRoomPermission(), r->getRoomPrivilege())))
             return Response::RespUserLevelTooLow;
 

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -627,16 +627,25 @@ Response::ResponseCode Server_ProtocolHandler::cmdJoinRoom(const Command_JoinRoo
                 return Response::RespUserLevelTooLow;
         }
 
-        if (roomPermission == "moderator"){
+        if (roomPermission == "moderator") {
             if (!(userInfo->user_level() & ServerInfo_User::IsModerator))
                 return Response::RespUserLevelTooLow;
         }
 
-        if (roomPermission == "administrator"){
+        if (roomPermission == "administrator") {
             if (!(userInfo->user_level() & ServerInfo_User::IsAdmin))
                 return Response::RespUserLevelTooLow;
         }
-    }
+
+        if (roomPermission == "vip") {
+            if (!(userInfo->user_level() & ServerInfo_User::IsRegistered))
+                return Response::RespUserLevelTooLow;
+            
+            if (!((userInfo->user_level() & ServerInfo_User::IsAdmin) && (userInfo->user_level() & ServerInfo_User::IsModerator)))
+                if (QString::fromStdString(userInfo->privlevel()).toLower() != "vip")
+                    return Response::RespUserLevelTooLow;
+        }
+}
 
     r->addClient(this);
     rooms.insert(r->getId(), r);

--- a/common/server_protocolhandler.h
+++ b/common/server_protocolhandler.h
@@ -84,6 +84,7 @@ private:
     virtual Response::ResponseCode processExtendedAdminCommand(int /* cmdType */, const AdminCommand & /* cmd */, ResponseContainer & /* rc */) { return Response::RespFunctionNotAllowed; }
 
     void resetIdleTimer();
+    bool isUserPermittedToJoinRoom(const QString roomPermission, const QString roomPrivilegeLevel);
 private slots:
     void pingClockTimeout();
 public slots:

--- a/common/server_room.cpp
+++ b/common/server_room.cpp
@@ -14,8 +14,8 @@
 #include "pb/serverinfo_chat_message.pb.h"
 #include <google/protobuf/descriptor.h>
 
-Server_Room::Server_Room(int _id, int _chatHistorySize, const QString &_name, const QString &_description, const QString &_permissionLevel, bool _autoJoin, const QString &_joinMessage, const QStringList &_gameTypes, Server *parent)
-    : QObject(parent), id(_id), chatHistorySize(_chatHistorySize), name(_name), description(_description), permissionLevel(_permissionLevel), autoJoin(_autoJoin), joinMessage(_joinMessage), gameTypes(_gameTypes), gamesLock(QReadWriteLock::Recursive)
+Server_Room::Server_Room(int _id, int _chatHistorySize, const QString &_name, const QString &_description, const QString &_permissionLevel, const QString &_privilegeLevel, bool _autoJoin, const QString &_joinMessage, const QStringList &_gameTypes, Server *parent)
+    : QObject(parent), id(_id), chatHistorySize(_chatHistorySize), name(_name), description(_description), permissionLevel(_permissionLevel), privilegeLevel(_privilegeLevel), autoJoin(_autoJoin), joinMessage(_joinMessage), gameTypes(_gameTypes), gamesLock(QReadWriteLock::Recursive)
 {
     connect(this, SIGNAL(gameListChanged(ServerInfo_Game)), this, SLOT(broadcastGameListUpdate(ServerInfo_Game)), Qt::QueuedConnection);
 }
@@ -44,11 +44,11 @@ Server *Server_Room::getServer() const
 const ServerInfo_Room &Server_Room::getInfo(ServerInfo_Room &result, bool complete, bool showGameTypes, bool includeExternalData) const
 {
     result.set_room_id(id);
-    
     result.set_name(name.toStdString());
     result.set_description(description.toStdString());
     result.set_auto_join(autoJoin);
     result.set_permissionlevel(permissionLevel.toStdString());
+    result.set_privilegelevel(privilegeLevel.toStdString());
     
     gamesLock.lockForRead();
     result.set_game_count(games.size() + externalGames.size());

--- a/common/server_room.h
+++ b/common/server_room.h
@@ -56,6 +56,7 @@ public:
     QString getName() const { return name; }
     QString getDescription() const { return description; }
     QString getRoomPermission() const { return permissionLevel; }
+    QString getRoomPrivilege() const { return privilegeLevel; }
     bool getAutoJoin() const { return autoJoin; }
     QString getJoinMessage() const { return joinMessage; }
     const QStringList &getGameTypes() const { return gameTypes; }

--- a/common/server_room.h
+++ b/common/server_room.h
@@ -35,6 +35,7 @@ private:
     QString name;
     QString description;
     QString permissionLevel;
+    QString privilegeLevel;
     bool autoJoin;
     QString joinMessage;
     QStringList gameTypes;
@@ -49,7 +50,7 @@ public:
     mutable QReadWriteLock usersLock;
     mutable QReadWriteLock gamesLock;
     mutable QReadWriteLock historyLock;
-    Server_Room(int _id, int _chatHistorySize, const QString &_name, const QString &_description, const QString &_permissionLevel, bool _autoJoin, const QString &_joinMessage, const QStringList &_gameTypes, Server *parent );
+    Server_Room(int _id, int _chatHistorySize, const QString &_name, const QString &_description, const QString &_permissionLevel, const QString &_privilegeLevel, bool _autoJoin, const QString &_joinMessage, const QStringList &_gameTypes, Server *parent );
     ~Server_Room();
     int getId() const { return id; }
     QString getName() const { return name; }

--- a/servatrice/migrations/servatrice_0022_to_0023.sql
+++ b/servatrice/migrations/servatrice_0022_to_0023.sql
@@ -1,0 +1,5 @@
+-- Servatrice db migration from version 22 to version 23
+
+alter table cockatrice_rooms add column privlevel enum("NONE","VIP","DONATOR") NOT NULL;
+
+UPDATE cockatrice_schema_version SET version=23 WHERE version=22;

--- a/servatrice/migrations/servatrice_0022_to_0023.sql
+++ b/servatrice/migrations/servatrice_0022_to_0023.sql
@@ -1,5 +1,5 @@
 -- Servatrice db migration from version 22 to version 23
 
-alter table cockatrice_rooms add column privlevel enum("NONE","VIP","DONATOR") NOT NULL;
+alter table cockatrice_rooms add column privlevel enum("NONE","PRIVILEGED","VIP","DONATOR") NOT NULL;
 
 UPDATE cockatrice_schema_version SET version=23 WHERE version=22;

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -261,6 +261,10 @@ roomlist\1\description="Play anything here."
 ; Default is none.
 roomlist\1\permissionlevel=none
 
+; Rooms can restrict the permission level of users that can join, Currnetly supported options are none, privileged, vip, and donator.
+; Default is none.
+roomlist\1\privilegelevel=none
+
 ; Wether to make users autojoin this room when connected to the server
 roomlist\1\autojoin=true
 

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -90,7 +90,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_rooms` (
   `name` varchar(50) NOT NULL,
   `descr` varchar(255) NOT NULL,
   `permissionlevel` varchar(20) NOT NULL,
-  `privlevel` enum("NONE","VIP","DONATOR") NOT NULL,
+  `privlevel` enum("NONE","PRIVILEGED","VIP","DONATOR") NOT NULL,
   `auto_join` tinyint(1) default 0,
   `join_message` varchar(255) NOT NULL,
   `chat_history_size` int(4) NOT NULL,

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_schema_version` (
   PRIMARY KEY  (`version`)
 ) ENGINE=INNODB DEFAULT CHARSET=utf8;
 
-INSERT INTO cockatrice_schema_version VALUES(22);
+INSERT INTO cockatrice_schema_version VALUES(23);
 
 -- users and user data tables
 CREATE TABLE IF NOT EXISTS `cockatrice_users` (
@@ -90,6 +90,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_rooms` (
   `name` varchar(50) NOT NULL,
   `descr` varchar(255) NOT NULL,
   `permissionlevel` varchar(20) NOT NULL,
+  `privlevel` enum("NONE","VIP","DONATOR") NOT NULL,
   `auto_join` tinyint(1) default 0,
   `join_message` varchar(255) NOT NULL,
   `chat_history_size` int(4) NOT NULL,

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -285,7 +285,7 @@ bool Servatrice::initServer()
     }
 
     if (getRoomsMethodString() == "sql") {
-        QSqlQuery *query = servatriceDatabaseInterface->prepareQuery("select id, name, descr, permissionlevel, auto_join, join_message, chat_history_size from {prefix}_rooms where id_server = :id_server order by id asc");
+        QSqlQuery *query = servatriceDatabaseInterface->prepareQuery("select id, name, descr, permissionlevel, privlevel, auto_join, join_message, chat_history_size from {prefix}_rooms where id_server = :id_server order by id asc");
         query->bindValue(":id_server", serverId);
         servatriceDatabaseInterface->execSqlQuery(query);
         while (query->next()) {
@@ -301,8 +301,9 @@ bool Servatrice::initServer()
                                     query->value(1).toString(),
                                     query->value(2).toString(),
                                     query->value(3).toString().toLower(),
-                                    query->value(4).toInt(),
-                                    query->value(5).toString(),
+                                    query->value(4).toString().toLower(),
+                                    query->value(5).toInt(),
+                                    query->value(6).toString(),
                                     gameTypes,
                                     this));
         }
@@ -317,13 +318,13 @@ bool Servatrice::initServer()
                 gameTypes.append(settingsCache->value("name").toString());
             }
             settingsCache->endArray();
-            Server_Room *newRoom = new Server_Room(i,settingsCache->value("chathistorysize").toInt(),settingsCache->value("name").toString(),settingsCache->value("description").toString(),settingsCache->value("permissionlevel").toString().toLower(),settingsCache->value("autojoin").toBool(),settingsCache->value("joinmessage").toString(),gameTypes,this);
+            Server_Room *newRoom = new Server_Room(i,settingsCache->value("chathistorysize").toInt(),settingsCache->value("name").toString(),settingsCache->value("description").toString(),settingsCache->value("permissionlevel").toString().toLower(),settingsCache->value("privilegelevel").toString().toLower(),settingsCache->value("autojoin").toBool(),settingsCache->value("joinmessage").toString(),gameTypes,this);
             addRoom(newRoom);
         }
 
         if(size==0) {
             // no room defined in config, add a dummy one
-            Server_Room *newRoom = new Server_Room(0,100,"General room","Play anything here.","none",true,"",QStringList("Standard"),this);
+            Server_Room *newRoom = new Server_Room(0,100,"General room","Play anything here.","none","none",true,"",QStringList("Standard"),this);
             addRoom(newRoom);
         }
 

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -9,7 +9,7 @@
 #include "server.h"
 #include "server_database_interface.h"
 
-#define DATABASE_SCHEMA_VERSION 22
+#define DATABASE_SCHEMA_VERSION 23
 
 class Servatrice;
 


### PR DESCRIPTION
Fix #2463 

Added the ability for registered user - VIP/DONATOR/PRIVILEGED room.

Since the users privilege level does not have any type of tier concept to it, we can only compare the actual literal string value of the privilege level and check to see if a user is a part of the given privilege level to allow or deny them into a given room.   

As explained when the privilege level concept was being introduced, we have admin level which is a bit comparison to allow the concept of admin > mod > reg > non-reg, but privilege level doesn't work like that.  Its a sub category.   So something like VIP !> DONATOR and vice versa.

With the logic in this PR a DONATOR for example can not enter a VIP room, nor can a VIP enter a DONATOR room, but we do compare admin level value(s) so regardless of admin/mod privilege levels they can enter the rooms. How ever an unregistered user is not allowed to enter the room if defined with the "vip" , "donator" or "privileged"  database table privlevel"column value.

Clear as mud?  

This PR now adds a "privlevel" to the room so we can do easy comparisons between a rooms definition of "privilege" to a users definition of "privilege" and allow/deny access based on the combinations of definitions rather than a hard written code block for every single privlevel added to the db table.  This way new privilege levels can be added into the database columns for the enum value(s) in the users/rooms table columns and their should be no additional coding required to restrict room access based on the new enum definitions.