### PR TITLE
Fix index issues on windows temporarily

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -71,7 +71,7 @@ GeneralSettingsPage::GeneralSettingsPage()
     connect(&languageBox, SIGNAL(currentIndexChanged(int)), this, SLOT(languageBoxChanged(int)));
     connect(&picDownloadCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setPicDownload(int)));
     connect(&pixmapCacheEdit, SIGNAL(valueChanged(int)), settingsCache, SLOT(setPixmapCacheSize(int)));
-    connect(&updateReleaseChannelBox, SIGNAL(currentIndexChanged(int)), settingsCache, SLOT(setUpdateReleaseChannel(int)));
+    connect(&updateReleaseChannelBox, SIGNAL(currentIndexChanged(const QString &)), settingsCache, SLOT(setUpdateReleaseChannel(const QString &)));
     connect(&updateNotificationCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setNotifyAboutUpdate(int)));
     connect(&picDownloadCheckBox, SIGNAL(clicked(bool)), this, SLOT(setEnabledStatus(bool)));
     connect(defaultUrlEdit, SIGNAL(textChanged(QString)), settingsCache, SLOT(setPicUrl(QString)));

--- a/cockatrice/src/dlg_update.cpp
+++ b/cockatrice/src/dlg_update.cpp
@@ -108,6 +108,7 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
         //If there's no need to update, tell them that. However we still allow them to run the
         //downloader themselves if there's a compatible build
         QMessageBox::information(this, tr("Cockatrice Update"), tr("Your version of Cockatrice is up to date."));
+        return;
     }
 
     if (isCompatible) {

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -653,8 +653,22 @@ void SettingsCache::setNotifyAboutUpdate(int _notifyaboutupdate)
     settings->setValue("personal/updatenotification", notifyAboutUpdates);
 }
 
-void SettingsCache::setUpdateReleaseChannel(int _updateReleaseChannel)
+void SettingsCache::setUpdateReleaseChannel(const QString &_updateReleaseChannel)
 {
-    updateReleaseChannel = _updateReleaseChannel;
+    /*
+     * This fixes an issue on windows with out of order indexes
+     * To be re-addressed before the next major release
+     * along with all settings in the dialogs so they update
+     * only when you close dialog
+     */
+    if (_updateReleaseChannel == tr("Stable releases"))
+        updateReleaseChannel = 0;
+    else if (_updateReleaseChannel == tr("Development snapshots"))
+        updateReleaseChannel = 1;
+    else
+        updateReleaseChannel = 2;
+    
+    qDebug() << "setUpdateReleaseChannel changed to = " << _updateReleaseChannel;
+
     settings->setValue("personal/updatereleasechannel", updateReleaseChannel);
 }

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -255,7 +255,7 @@ public slots:
     void setSpectatorsCanSeeEverything(const bool _spectatorsCanSeeEverything);
     void setRememberGameSettings(const bool _rememberGameSettings);
     void setNotifyAboutUpdate(int _notifyaboutupdate);
-    void setUpdateReleaseChannel(int _updateReleaseChannel);
+    void setUpdateReleaseChannel(const QString &_updateReleaseChannel);
 };
 
 extern SettingsCache *settingsCache;


### PR DESCRIPTION
## Related Ticket(s)
Fixes issue 1 of #2465 

## Short roundup of the initial problem
Windows seems to have an issue with the indexes, so I changed it over to alert by string so we can decypher it. This is a temporary fix for the release, but we will be making sure all dialogs have constant interactions (Do not do anything until Save/close is pressed) by the next release.
