### PR TITLE
Fix issues with new updater; fix #2465

### DIFF
--- a/cockatrice/src/dlg_update.cpp
+++ b/cockatrice/src/dlg_update.cpp
@@ -108,6 +108,7 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
         //If there's no need to update, tell them that. However we still allow them to run the
         //downloader themselves if there's a compatible build
         QMessageBox::information(this, tr("Cockatrice Update"), tr("Your version of Cockatrice is up to date."));
+        return;
     }
 
     if (isCompatible) {

--- a/cockatrice/src/dlg_update.cpp
+++ b/cockatrice/src/dlg_update.cpp
@@ -111,10 +111,10 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
         return;
     }
 
+    publishDate = release->getPublishDate().toString(Qt::DefaultLocaleLongDate);
     if (isCompatible) {
         //If there is an update, save its URL and work out its name
         updateUrl = release->getDownloadUrl();
-        publishDate = release->getPublishDate().toString(Qt::DefaultLocaleLongDate);
 
         QMessageBox::StandardButton reply;
         reply = QMessageBox::question(this, "Update Available",

--- a/cockatrice/src/releasechannel.cpp
+++ b/cockatrice/src/releasechannel.cpp
@@ -16,6 +16,7 @@
 #define DEVFILES_URL "https://api.bintray.com/packages/cockatrice/Cockatrice/Cockatrice-git/files"
 #define DEVDOWNLOAD_URL "https://dl.bintray.com/cockatrice/Cockatrice/"
 #define DEVMANUALDOWNLOAD_URL "https://bintray.com/cockatrice/Cockatrice/Cockatrice-git/_latestVersion#files"
+#define DEVRELEASE_DESCURL "https://github.com/Cockatrice/Cockatrice/compare/%1...%2"
 #define GIT_SHORT_HASH_LEN 7
 
 int ReleaseChannel::sharedIndex = 0;
@@ -253,11 +254,15 @@ void DevReleaseChannel::releaseListFinished()
     if(!lastRelease)
         lastRelease = new Release;
 
-    lastRelease->setName("Commit " + resultMap["sha"].toString());
-    lastRelease->setDescriptionUrl(resultMap["html_url"].toString());
+    
     lastRelease->setCommitHash(resultMap["sha"].toString());
     lastRelease->setPublishDate(resultMap["commit"].toMap()["author"].toMap()["date"].toDate());
 
+    QString shortHash = lastRelease->getCommitHash().left(GIT_SHORT_HASH_LEN);
+    lastRelease->setName("Commit " + shortHash);
+
+    lastRelease->setDescriptionUrl(QString(DEVRELEASE_DESCURL).arg(VERSION_COMMIT, shortHash));
+    
     qDebug() << "Got reply from release server, size=" << tmp.size()
         << "name=" << lastRelease->getName()
         << "desc=" << lastRelease->getDescriptionUrl()

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -166,8 +166,9 @@ SettingsCache::SettingsCache()
         translateLegacySettings();
 
     // updates - don't reorder them or their index in the settings won't match
-    releaseChannels << new StableReleaseChannel()
-        << new DevReleaseChannel();
+    // append channels one by one, or msvc will add them in the wrong order.
+    releaseChannels << new StableReleaseChannel();
+    releaseChannels << new DevReleaseChannel();
 
     notifyAboutUpdates = settings->value("personal/updatenotification", true).toBool();
     updateReleaseChannel = settings->value("personal/updatereleasechannel", 0).toInt();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2465

## Short roundup of the initial problem
 - See #2465

## What will change with this Pull Request?
 - Fixed release channel selector under windows (issue 1): Msvc initialized the items in the wrong order, so their indexes would mix up; fixed by adding items one by one in the list.
 - dev channel: show the short commit hash instead of the long one (issue 2);
 - dev channel: link to the compare between the old hash and the new hash instead of just the last commit (issue 3)
 - properly return when no update is found (thx @ZeldaZach)

## Screenshots
N/a
