### PR TITLE
make settings size vary based on sizeHint()

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -752,6 +752,9 @@ void SoundSettingsPage::retranslateUi() {
 DlgSettings::DlgSettings(QWidget *parent)
     : QDialog(parent)
 {
+    this->setMinimumSize(500,500);
+    this->adjustSize();
+
     connect(settingsCache, SIGNAL(langChanged()), this, SLOT(updateLanguage()));
     
     contentsWidget = new QListWidget;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2471 

## Short roundup of the initial problem
The dialogs can sometimes be too large to handle on a screen

## What will change with this Pull Request?
This adds a size minimum and calls the dialog to adjustSize() in order for it to fit the screen better. The size cannot go above 2/3'rds the size of the screen by default according to the function, so this may be helpful.

Downside is sometimes it's "smushed" and you'll have to manually readjust the size in order for you to see everything correctly... Suggestions can be taken! 

This is an initial test of just the settings dialog as that seems to be the main issue, but it can be expanded to any and all dialogs in the program.

## Screenshots
*(simply drag & drop image files directly into this description!)*
