### PR TITLE
auto_connect toggle fix

### DIFF
--- a/cockatrice/src/settings/serverssettings.cpp
+++ b/cockatrice/src/settings/serverssettings.cpp
@@ -109,11 +109,11 @@ void ServersSettings::setSavePassword(int save)
     setValue(save, "save_password", "server");
 }
 
-int ServersSettings::getSavePassword()
+bool ServersSettings::getSavePassword()
 {
     int index = getPrevioushostindex(getPrevioushostName());
-    QVariant save = getValue(QString("savePassword%1").arg(index), "server", "server_details");
-    return save == QVariant() ? 1 : save.toInt();
+    bool save = getValue(QString("savePassword%1").arg(index), "server", "server_details").toBool();
+    return save;
 }
 
 void ServersSettings::setAutoConnect(int autoconnect)

--- a/cockatrice/src/settings/serverssettings.h
+++ b/cockatrice/src/settings/serverssettings.h
@@ -22,7 +22,7 @@ public:
     QString getFPPlayerName(QString defaultName = "");
     QString getPassword();
     QString getSaveName(QString defaultname = "");
-    int getSavePassword();
+    bool getSavePassword();
     int getAutoConnect();
 
     void setPreviousHostLogin(int previous);


### PR DESCRIPTION
Auto connect seemed to have an issue with the multi-server configurations that was rolled in a few days ago. This fixes that issue (this should have always returned a boolean, no idea why it returned int ever...)