### PR TITLE
allow max font size to be defined by user

### DIFF
--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -68,7 +68,7 @@ QSizeF AbstractCardItem::getTranslatedSize(QPainter *painter) const
 void AbstractCardItem::transformPainter(QPainter *painter, const QSizeF &translatedSize, int angle)
 {
     const int MAX_FONT_SIZE = settingsCache->getMaxFontSize();
-    const int fontSize = std::max(9, std::min<int>(MAX_FONT_SIZE, round(translatedSize.height() / 8)));
+    const int fontSize = std::max(9, MAX_FONT_SIZE);
 
     QRectF totalBoundingRect = painter->combinedTransform().mapRect(boundingRect());
     

--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -3,6 +3,7 @@
 #include <QCursor>
 #include <QGraphicsSceneMouseEvent>
 #include <cmath>
+#include <algorithm>
 #ifdef _WIN32
 #include "round.h"
 #endif /* _WIN32 */
@@ -66,7 +67,8 @@ QSizeF AbstractCardItem::getTranslatedSize(QPainter *painter) const
 
 void AbstractCardItem::transformPainter(QPainter *painter, const QSizeF &translatedSize, int angle)
 {
-    int MAX_FONT_SIZE = settingsCache->getMaxFontSize();
+    const int MAX_FONT_SIZE = settingsCache->getMaxFontSize();
+    const int fontSize = std::max(9, std::min<int>(MAX_FONT_SIZE, round(translatedSize.height() / 8)));
 
     QRectF totalBoundingRect = painter->combinedTransform().mapRect(boundingRect());
     
@@ -79,12 +81,6 @@ void AbstractCardItem::transformPainter(QPainter *painter, const QSizeF &transla
     painter->setTransform(pixmapTransform);
 
     QFont f;
-    int fontSize = round(translatedSize.height() / 8);
-    if (fontSize < 9)
-        fontSize = 9;
-    if (fontSize > MAX_FONT_SIZE)
-        fontSize = MAX_FONT_SIZE;
-
     f.setPixelSize(fontSize);
 
     painter->setFont(f);

--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -66,6 +66,8 @@ QSizeF AbstractCardItem::getTranslatedSize(QPainter *painter) const
 
 void AbstractCardItem::transformPainter(QPainter *painter, const QSizeF &translatedSize, int angle)
 {
+    int MAX_FONT_SIZE = settingsCache->getMaxFontSize();
+
     QRectF totalBoundingRect = painter->combinedTransform().mapRect(boundingRect());
     
     painter->resetTransform();
@@ -80,6 +82,9 @@ void AbstractCardItem::transformPainter(QPainter *painter, const QSizeF &transla
     int fontSize = round(translatedSize.height() / 8);
     if (fontSize < 9)
         fontSize = 9;
+    if (fontSize > MAX_FONT_SIZE)
+        fontSize = MAX_FONT_SIZE;
+
     f.setPixelSize(fontSize);
 
     painter->setFont(f);

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -352,7 +352,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     connect(&minPlayersForMultiColumnLayoutEdit, SIGNAL(valueChanged(int)), settingsCache, SLOT(setMinPlayersForMultiColumnLayout(int)));
     minPlayersForMultiColumnLayoutLabel.setBuddy(&minPlayersForMultiColumnLayoutEdit);
 
-    maxFontSizeForCardsEdit.setMinimum(10);
+    maxFontSizeForCardsEdit.setMinimum(9);
     maxFontSizeForCardsEdit.setMaximum(100);
     maxFontSizeForCardsEdit.setValue(settingsCache->getMaxFontSize());
     connect(&maxFontSizeForCardsEdit, SIGNAL(valueChanged(int)), settingsCache, SLOT(setMaxFontSize(int)));

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -353,6 +353,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     minPlayersForMultiColumnLayoutLabel.setBuddy(&minPlayersForMultiColumnLayoutEdit);
 
     maxFontSizeForCardsEdit.setMinimum(10);
+    maxFontSizeForCardsEdit.setMaximum(100);
     maxFontSizeForCardsEdit.setValue(settingsCache->getMaxFontSize());
     connect(&maxFontSizeForCardsEdit, SIGNAL(valueChanged(int)), settingsCache, SLOT(setMaxFontSize(int)));
     maxFontSizeForCardsLabel.setBuddy(&maxFontSizeForCardsEdit);
@@ -399,7 +400,7 @@ void AppearanceSettingsPage::retranslateUi()
     tableGroupBox->setTitle(tr("Table grid layout"));
     invertVerticalCoordinateCheckBox.setText(tr("Invert vertical coordinate"));
     minPlayersForMultiColumnLayoutLabel.setText(tr("Minimum player count for multi-column layout:"));
-    maxFontSizeForCardsLabel.setText(tr("Maximum size font for displaying card attributes"));
+    maxFontSizeForCardsLabel.setText(tr("Maximum font size for information displayed on cards"));
 }
 
 UserInterfaceSettingsPage::UserInterfaceSettingsPage()

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -351,11 +351,18 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     minPlayersForMultiColumnLayoutEdit.setValue(settingsCache->getMinPlayersForMultiColumnLayout());
     connect(&minPlayersForMultiColumnLayoutEdit, SIGNAL(valueChanged(int)), settingsCache, SLOT(setMinPlayersForMultiColumnLayout(int)));
     minPlayersForMultiColumnLayoutLabel.setBuddy(&minPlayersForMultiColumnLayoutEdit);
-    
+
+    maxFontSizeForCardsEdit.setMinimum(10);
+    maxFontSizeForCardsEdit.setValue(settingsCache->getMaxFontSize());
+    connect(&maxFontSizeForCardsEdit, SIGNAL(valueChanged(int)), settingsCache, SLOT(setMaxFontSize(int)));
+    maxFontSizeForCardsLabel.setBuddy(&maxFontSizeForCardsEdit);
+
     QGridLayout *tableGrid = new QGridLayout;
     tableGrid->addWidget(&invertVerticalCoordinateCheckBox, 0, 0, 1, 2);
     tableGrid->addWidget(&minPlayersForMultiColumnLayoutLabel, 1, 0, 1, 1);
     tableGrid->addWidget(&minPlayersForMultiColumnLayoutEdit, 1, 1, 1, 1);
+    tableGrid->addWidget(&maxFontSizeForCardsLabel, 2, 0, 1, 1);
+    tableGrid->addWidget(&maxFontSizeForCardsEdit, 2, 1, 1, 1);
     
     tableGroupBox = new QGroupBox;
     tableGroupBox->setLayout(tableGrid);
@@ -392,6 +399,7 @@ void AppearanceSettingsPage::retranslateUi()
     tableGroupBox->setTitle(tr("Table grid layout"));
     invertVerticalCoordinateCheckBox.setText(tr("Invert vertical coordinate"));
     minPlayersForMultiColumnLayoutLabel.setText(tr("Minimum player count for multi-column layout:"));
+    maxFontSizeForCardsLabel.setText(tr("Maximum size font for displaying card attributes"));
 }
 
 UserInterfaceSettingsPage::UserInterfaceSettingsPage()

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -88,6 +88,7 @@ private:
     QLabel themeLabel;
     QComboBox themeBox;
     QLabel minPlayersForMultiColumnLayoutLabel;
+    QLabel maxFontSizeForCardsLabel;
     QCheckBox displayCardNamesCheckBox;
     QCheckBox cardScalingCheckBox;
     QCheckBox horizontalHandCheckBox;
@@ -98,6 +99,7 @@ private:
     QGroupBox *handGroupBox;
     QGroupBox *tableGroupBox;
     QSpinBox minPlayersForMultiColumnLayoutEdit;
+    QSpinBox maxFontSizeForCardsEdit;
 public:
     AppearanceSettingsPage();
     void retranslateUi();

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -658,3 +658,9 @@ void SettingsCache::setUpdateReleaseChannel(int _updateReleaseChannel)
     updateReleaseChannel = _updateReleaseChannel;
     settings->setValue("personal/updatereleasechannel", updateReleaseChannel);
 }
+
+void SettingsCache::setMaxFontSize(int _max)
+{
+    maxFontSize = _max;
+    settings->setValue("game/maxfontsize", maxFontSize);
+}

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -188,7 +188,7 @@ public:
     bool getSpectatorsCanSeeEverything() const { return spectatorsCanSeeEverything; }
     bool getRememberGameSettings() const { return rememberGameSettings; }
     int getKeepAlive() const { return keepalive; }
-    int getMaxFontSize() const { return maxFontSize; }
+    int getMaxFontSize() const { return (maxFontSize > 1) ? maxFontSize : 9; }
     void setClientID(QString clientID);
     void setKnownMissingFeatures(QString _knownMissingFeatures);
     QString getClientID() { return clientID; }

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -61,6 +61,7 @@ private:
     QString deckPath, replaysPath, picsPath, customPicsPath, cardDatabasePath, customCardDatabasePath, tokenDatabasePath, themeName;
     bool notifyAboutUpdates;
     int updateReleaseChannel;
+    int maxFontSize;
     bool picDownload;
     bool notificationsEnabled;
     bool spectatorNotificationsEnabled;
@@ -187,6 +188,7 @@ public:
     bool getSpectatorsCanSeeEverything() const { return spectatorsCanSeeEverything; }
     bool getRememberGameSettings() const { return rememberGameSettings; }
     int getKeepAlive() const { return keepalive; }
+    int getMaxFontSize() const { return maxFontSize; }
     void setClientID(QString clientID);
     void setKnownMissingFeatures(QString _knownMissingFeatures);
     QString getClientID() { return clientID; }
@@ -256,6 +258,7 @@ public slots:
     void setRememberGameSettings(const bool _rememberGameSettings);
     void setNotifyAboutUpdate(int _notifyaboutupdate);
     void setUpdateReleaseChannel(int _updateReleaseChannel);
+    void setMaxFontSize(int _max);
 };
 
 extern SettingsCache *settingsCache;


### PR DESCRIPTION
## Related Ticket(s)
Reverts #2427 to make it better

## Short roundup of the initial problem
Font size had a cap in the past, but then we removed it. Some users had fonts WAY too large. 

## What will change with this Pull Request?
Users can now define their own font size caps. This will allow users who want smaller fonts to have such an option

## Screenshots
<img width="134" alt="screenshot 2017-03-16 22 06 19" src="https://cloud.githubusercontent.com/assets/7460172/24026050/dde04920-0a94-11e7-98f8-dda0119d1970.png">
<img width="172" alt="screenshot 2017-03-16 22 06 31" src="https://cloud.githubusercontent.com/assets/7460172/24026049/dddffe70-0a94-11e7-9031-1e4eaea52a7b.png">
<img width="929" alt="screenshot 2017-03-16 22 06 39" src="https://cloud.githubusercontent.com/assets/7460172/24026051/dde23668-0a94-11e7-963a-0212343a136a.png">
