### PR TITLE
file filenames so window updater works

### DIFF
--- a/cockatrice/src/releasechannel.cpp
+++ b/cockatrice/src/releasechannel.cpp
@@ -55,14 +55,14 @@ bool ReleaseChannel::downloadMatchesCurrentOS(QVariantMap build)
 {
     QString wordSize = QSysInfo::buildAbi().split('-')[2];
     QString arch;
-    QString debugEnd;
+    QString devSnapshotEnd;
 
     if (wordSize == "llp64") {
         arch = "win64";
-        debugEnd = "-x86_64_qt5";
+        devSnapshotEnd = "-x86_64_qt5";
     } else if (wordSize == "ilp32") {
         arch = "win32";
-        debugEnd = "-x86_qt5";
+        devSnapshotEnd = "-x86_qt5";
     } else {
         qWarning() << "Error checking for upgrade version: wordSize is" << wordSize;
         return false;
@@ -72,8 +72,8 @@ bool ReleaseChannel::downloadMatchesCurrentOS(QVariantMap build)
     // Checking for .zip is a workaround for the May 6th 2016 release
     auto zipName = arch + ".zip";
     auto exeName = arch + ".exe";
-    auto zipDebugName = debugEnd + ".zip";
-    auto exeDebugName = debugEnd + ".exe";
+    auto zipDebugName = devSnapshotEnd + ".zip";
+    auto exeDebugName = devSnapshotEnd + ".exe";
     return (fileName.endsWith(exeName) || fileName.endsWith(zipName) ||
         fileName.endsWith(exeDebugName) || fileName.endsWith(zipDebugName));
 }

--- a/cockatrice/src/releasechannel.cpp
+++ b/cockatrice/src/releasechannel.cpp
@@ -59,7 +59,7 @@ bool ReleaseChannel::downloadMatchesCurrentOS(QVariantMap build)
 
     if (wordSize == "llp64") {
         arch = "win64";
-        debugEnd = "-x86_64_qt5"
+        debugEnd = "-x86_64_qt5";
     } else if (wordSize == "ilp32") {
         arch = "win32";
         debugEnd = "-x86_qt5";

--- a/cockatrice/src/releasechannel.cpp
+++ b/cockatrice/src/releasechannel.cpp
@@ -55,10 +55,14 @@ bool ReleaseChannel::downloadMatchesCurrentOS(QVariantMap build)
 {
     QString wordSize = QSysInfo::buildAbi().split('-')[2];
     QString arch;
+    QString debugEnd;
+
     if (wordSize == "llp64") {
         arch = "win64";
+        debugEnd = "-x86_64_qt5"
     } else if (wordSize == "ilp32") {
         arch = "win32";
+        debugEnd = "-x86_qt5";
     } else {
         qWarning() << "Error checking for upgrade version: wordSize is" << wordSize;
         return false;
@@ -68,7 +72,10 @@ bool ReleaseChannel::downloadMatchesCurrentOS(QVariantMap build)
     // Checking for .zip is a workaround for the May 6th 2016 release
     auto zipName = arch + ".zip";
     auto exeName = arch + ".exe";
-    return fileName.endsWith(exeName) || fileName.endsWith(zipName);
+    auto zipDebugName = debugEnd + ".zip";
+    auto exeDebugName = debugEnd + ".exe";
+    return (fileName.endsWith(exeName) || fileName.endsWith(zipName) ||
+        fileName.endsWith(exeDebugName) || fileName.endsWith(zipDebugName));
 }
 #else
 


### PR DESCRIPTION
Full release files end in arch name (win64.exe or win32.exe) while debug builds end in a QT string (-x86_64_qt5.exe or -x86_qt5.exe)

This fixes the auto-updater on windows for development builds