### PR TITLE
Remove direct usages of TabSupervisor from Chatview

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -83,7 +83,8 @@ SET(cockatrice_SOURCES
     src/replay_timeline_widget.cpp
     src/deckstats_interface.cpp
     src/tappedout_interface.cpp
-    src/chatview.cpp 
+    src/chatview/chatview.cpp
+    src/chatview/userlistProxy.h
     src/userlist.cpp 
     src/userinfobox.cpp 
     src/user_context_menu.cpp

--- a/cockatrice/src/chatview/chatview.cpp
+++ b/cockatrice/src/chatview/chatview.cpp
@@ -17,7 +17,7 @@ const QColor OTHER_USER_COLOR = QColor(0, 65, 255); // dark blue
 const QString SERVER_MESSAGE_COLOR = "#851515";
 
 ChatView::ChatView(const TabSupervisor *_tabSupervisor, const UserlistProxy *_userlistProxy, TabGame *_game, bool _showTimestamps, QWidget *parent)
-    : QTextBrowser(parent), tabSupervisor(_tabSupervisor), userlistProxy(_userlistProxy), game(_game), evenNumber(true), showTimestamps(_showTimestamps), hoveredItemType(HoveredNothing)
+    : QTextBrowser(parent), tabSupervisor(_tabSupervisor), game(_game), userlistProxy(_userlistProxy), evenNumber(true), showTimestamps(_showTimestamps), hoveredItemType(HoveredNothing)
 {
     document()->setDefaultStyleSheet("a { text-decoration: none; color: blue; }");
     userContextMenu = new UserContextMenu(tabSupervisor, this, game);

--- a/cockatrice/src/chatview/chatview.h
+++ b/cockatrice/src/chatview/chatview.h
@@ -6,10 +6,11 @@
 #include <QTextCursor>
 #include <QColor>
 #include <QAction>
-#include "userlist.h"
+#include "../userlist.h"
 #include "user_level.h"
 #include "room_message_type.h"
-#include "tab_supervisor.h"
+#include "../tab_supervisor.h"
+#include "userlistProxy.h"
 
 class QTextTable;
 class QMouseEvent;
@@ -23,6 +24,7 @@ protected:
     TabGame * const game;
 private:
     enum HoveredItemType { HoveredNothing, HoveredUrl, HoveredCard, HoveredUser };
+    const UserlistProxy * const userlistProxy;
     UserContextMenu *userContextMenu;
     QString lastSender;
     QString userName;
@@ -41,11 +43,8 @@ private:
     QTextCursor prepareBlock(bool same = false);
     void appendCardTag(QTextCursor &cursor, const QString &cardName);
     void appendUrlTag(QTextCursor &cursor, QString url);
-    QString getNameFromUserList(QMap<QString, UserListTWI *> &userList, QString &userName);
-    bool isFullMentionAValidUser(QMap<QString, UserListTWI *> &userList, QString userNameToMatch);
     QColor getCustomMentionColor();
     QColor getCustomHighlightColor();
-    bool shouldShowSystemPopup();
     void showSystemPopup(QString &sender);
     bool isModeratorSendingGlobal(QFlags<ServerInfo_User::UserLevelFlag> userLevelFlag, QString message);
     void checkTag(QTextCursor &cursor, QString &message);
@@ -56,7 +55,7 @@ private slots:
     void openLink(const QUrl &link);
     void actMessageClicked();
 public:
-    ChatView(const TabSupervisor *_tabSupervisor, TabGame *_game, bool _showTimestamps, QWidget *parent = 0);
+    ChatView(const TabSupervisor *_tabSupervisor, const UserlistProxy *_userlistProxy, TabGame *_game, bool _showTimestamps, QWidget *parent = 0);
     void retranslateUi();
     void appendHtml(const QString &html);
     void appendHtmlServerMessage(const QString &html, bool optionalIsBold = false, QString optionalFontColor = QString());

--- a/cockatrice/src/chatview/userlistProxy.h
+++ b/cockatrice/src/chatview/userlistProxy.h
@@ -9,8 +9,10 @@ class ServerInfo_User;
  */
 class UserlistProxy {
 public:
+    virtual const bool isOwnUserRegistered() const = 0;
     virtual const QString getOwnUsername() const = 0;
     virtual bool isUserBuddy(const QString &userName) const = 0;
+    virtual bool isUserIgnored(const QString &userName) const = 0;
     virtual const ServerInfo_User* getOnlineUser(const QString &userName) const = 0; // Can return nullptr
 };
 

--- a/cockatrice/src/chatview/userlistProxy.h
+++ b/cockatrice/src/chatview/userlistProxy.h
@@ -1,0 +1,17 @@
+#ifndef COCKATRICE_USERLISTPROXY_H
+#define COCKATRICE_USERLISTPROXY_H
+
+class ServerInfo_User;
+
+/**
+ * Responsible for providing a bare-bones minimal interface into userlist information,
+ * including your current connection to the server as well as buddy/ignore/alluser lists.
+ */
+class UserlistProxy {
+public:
+    virtual const QString getOwnUsername() const = 0;
+    virtual bool isUserBuddy(const QString &userName) const = 0;
+    virtual const ServerInfo_User* getOnlineUser(const QString &userName) const = 0; // Can return nullptr
+};
+
+#endif //COCKATRICE_USERLISTPROXY_H

--- a/cockatrice/src/chatview/userlistProxy.h
+++ b/cockatrice/src/chatview/userlistProxy.h
@@ -9,8 +9,8 @@ class ServerInfo_User;
  */
 class UserlistProxy {
 public:
-    virtual const bool isOwnUserRegistered() const = 0;
-    virtual const QString getOwnUsername() const = 0;
+    virtual bool isOwnUserRegistered() const = 0;
+    virtual QString getOwnUsername() const = 0;
     virtual bool isUserBuddy(const QString &userName) const = 0;
     virtual bool isUserIgnored(const QString &userName) const = 0;
     virtual const ServerInfo_User* getOnlineUser(const QString &userName) const = 0; // Can return nullptr

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -25,7 +25,8 @@ GameSelector::GameSelector(AbstractClient *_client, const TabSupervisor *_tabSup
     gameListModel = new GamesModel(_rooms, _gameTypes, this);
     if(showfilters)
     {
-        gameListProxyModel = new GamesProxyModel(this, tabSupervisor->getUserInfo());
+        bool ownUserIsRegistered = (bool)(tabSupervisor->getUserInfo()->user_level() & ServerInfo_User::IsRegistered);
+        gameListProxyModel = new GamesProxyModel(this, ownUserIsRegistered);
         gameListProxyModel->setSourceModel(gameListModel);
         gameListProxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
         gameListView->setModel(gameListProxyModel);

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -25,8 +25,7 @@ GameSelector::GameSelector(AbstractClient *_client, const TabSupervisor *_tabSup
     gameListModel = new GamesModel(_rooms, _gameTypes, this);
     if(showfilters)
     {
-        bool ownUserIsRegistered = (bool)(tabSupervisor->getUserInfo()->user_level() & ServerInfo_User::IsRegistered);
-        gameListProxyModel = new GamesProxyModel(this, ownUserIsRegistered);
+        gameListProxyModel = new GamesProxyModel(this, tabSupervisor->isOwnUserRegistered());
         gameListProxyModel->setSourceModel(gameListModel);
         gameListProxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
         gameListView->setModel(gameListProxyModel);

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -225,9 +225,9 @@ void GamesModel::updateGameList(const ServerInfo_Game &game)
     endInsertRows();
 }
 
-GamesProxyModel::GamesProxyModel(QObject *parent, ServerInfo_User *_ownUser)
+GamesProxyModel::GamesProxyModel(QObject *parent, bool _ownUserIsRegistered)
     : QSortFilterProxyModel(parent),
-    ownUser(_ownUser),
+    ownUserIsRegistered(_ownUserIsRegistered),
     showBuddiesOnlyGames(false),
     unavailableGamesVisible(false),
     showPasswordProtectedGames(true),
@@ -348,7 +348,7 @@ bool GamesProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &/*sourc
             return false;
         if (game.started())
             return false;
-        if (!(ownUser->user_level() & ServerInfo_User::IsRegistered))
+        if (!ownUserIsRegistered)
             if (game.only_registered())
                 return false;
     }

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -46,7 +46,7 @@ class ServerInfo_User;
 class GamesProxyModel : public QSortFilterProxyModel {
     Q_OBJECT
 private:
-    ServerInfo_User *ownUser;
+    bool ownUserIsRegistered;
     bool showBuddiesOnlyGames;
     bool unavailableGamesVisible;
     bool showPasswordProtectedGames;
@@ -56,7 +56,7 @@ private:
 
     static const int DEFAULT_MAX_PLAYERS_MAX = 99;   
 public:
-    GamesProxyModel(QObject *parent = 0, ServerInfo_User *_ownUser = 0);
+    GamesProxyModel(QObject *parent = 0, bool _ownUserIsRegistered = false);
 
     bool getShowBuddiesOnlyGames() const {return showBuddiesOnlyGames; }
     void setShowBuddiesOnlyGames(bool _showBuddiesOnlyGames);

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -636,7 +636,7 @@ void MessageLogWidget::connectToPlayer(Player *player)
     connect(player, SIGNAL(logAlwaysRevealTopCard(Player *, CardZone *, bool)), this, SLOT(logAlwaysRevealTopCard(Player *, CardZone *, bool)));
 }
 
-MessageLogWidget::MessageLogWidget(const TabSupervisor *_tabSupervisor, TabGame *_game, QWidget *parent)
-    : ChatView(_tabSupervisor, _game, true, parent), currentContext(MessageContext_None)
+MessageLogWidget::MessageLogWidget(const TabSupervisor *_tabSupervisor, const UserlistProxy *_userlistProxy, TabGame *_game, QWidget *parent)
+    : ChatView(_tabSupervisor, _userlistProxy, _game, true, parent), currentContext(MessageContext_None)
 {
 }

--- a/cockatrice/src/messagelogwidget.h
+++ b/cockatrice/src/messagelogwidget.h
@@ -1,7 +1,7 @@
 #ifndef MESSAGELOGWIDGET_H
 #define MESSAGELOGWIDGET_H
 
-#include "chatview.h"
+#include "chatview/chatview.h"
 #include "translation.h"
 #include "user_level.h"
 
@@ -83,7 +83,7 @@ public slots:
     void containerProcessingDone();
 public:
     void connectToPlayer(Player *player);
-    MessageLogWidget(const TabSupervisor *_tabSupervisor, TabGame *_game, QWidget *parent = 0);
+    MessageLogWidget(const TabSupervisor *_tabSupervisor, const UserlistProxy *_userlistProxy, TabGame *_game, QWidget *parent = 0);
 };
 
 #endif

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -1574,7 +1574,7 @@ void TabGame::createPlayerListDock(bool bReplay)
 
 void TabGame::createMessageDock(bool bReplay)
 {
-    messageLog = new MessageLogWidget(tabSupervisor, this);
+    messageLog = new MessageLogWidget(tabSupervisor, tabSupervisor, this);
     connect(messageLog, SIGNAL(cardNameHovered(QString)), cardInfo, SLOT(setCard(QString)));
     connect(messageLog, SIGNAL(showCardInfoPopup(QPoint, QString)), this, SLOT(showCardInfoPopup(QPoint, QString)));
     connect(messageLog, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));

--- a/cockatrice/src/tab_message.cpp
+++ b/cockatrice/src/tab_message.cpp
@@ -1,14 +1,12 @@
 #include <QLineEdit>
 #include <QVBoxLayout>
-#include <QHBoxLayout>
 #include <QMenu>
-#include <QAction>
 #include <QSystemTrayIcon>
 #include <QApplication>
 #include <QDebug>
 #include "tab_message.h"
 #include "abstractclient.h"
-#include "chatview.h"
+#include "chatview/chatview.h"
 #include "main.h"
 #include "settingscache.h"
 #include "soundengine.h"
@@ -21,7 +19,7 @@
 TabMessage::TabMessage(TabSupervisor *_tabSupervisor, AbstractClient *_client, const ServerInfo_User &_ownUserInfo, const ServerInfo_User &_otherUserInfo)
     : Tab(_tabSupervisor), client(_client), ownUserInfo(new ServerInfo_User(_ownUserInfo)), otherUserInfo(new ServerInfo_User(_otherUserInfo)), userOnline(true)
 {
-    chatView = new ChatView(tabSupervisor, 0, true);
+    chatView = new ChatView(tabSupervisor, tabSupervisor, 0, true);
     connect(chatView, SIGNAL(showCardInfoPopup(QPoint, QString)), this, SLOT(showCardInfoPopup(QPoint, QString)));
     connect(chatView, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));
     connect(chatView, SIGNAL(addMentionTag(QString)), this, SLOT(addMentionTag(QString)));

--- a/cockatrice/src/tab_room.cpp
+++ b/cockatrice/src/tab_room.cpp
@@ -1,29 +1,24 @@
 #include <QLineEdit>
 #include <QVBoxLayout>
-#include <QHBoxLayout>
 #include <QMenu>
-#include <QAction>
 #include <QPushButton>
 #include <QMessageBox>
-#include <QCheckBox>
 #include <QLabel>
 #include <QToolButton>
 #include <QSplitter>
 #include <QApplication>
 #include <QSystemTrayIcon>
 #include <QCompleter>
-#include <QWidget>
 #include <QtCore/qdatetime.h>
 #include "tab_supervisor.h"
 #include "tab_room.h"
 #include "tab_userlists.h"
 #include "userlist.h"
 #include "abstractclient.h"
-#include "chatview.h"
+#include "chatview/chatview.h"
 #include "gameselector.h"
 #include "settingscache.h"
 #include "main.h"
-#include "lineeditcompleter.h"
 #include "get_pb_extension.h"
 #include "pb/room_commands.pb.h"
 #include "pb/serverinfo_room.pb.h"
@@ -48,7 +43,7 @@ TabRoom::TabRoom(TabSupervisor *_tabSupervisor, AbstractClient *_client, ServerI
     userList = new UserList(tabSupervisor, client, UserList::RoomList);
     connect(userList, SIGNAL(openMessageDialog(const QString &, bool)), this, SIGNAL(openMessageDialog(const QString &, bool)));
 
-    chatView = new ChatView(tabSupervisor, 0, true);
+    chatView = new ChatView(tabSupervisor, tabSupervisor, 0, true);
     connect(chatView, SIGNAL(showMentionPopup(QString&)), this, SLOT(actShowMentionPopup(QString&)));
     connect(chatView, SIGNAL(messageClickedSignal()), this, SLOT(focusTab()));
     connect(chatView, SIGNAL(openMessageDialog(QString, bool)), this, SIGNAL(openMessageDialog(QString, bool)));
@@ -156,8 +151,11 @@ void TabRoom::focusTab() {
 }
 
 void TabRoom::actShowMentionPopup(QString &sender) {
-    if (trayIcon && (tabSupervisor->currentIndex() != tabSupervisor->indexOf(this) || QApplication::activeWindow() == 0
-        || QApplication::focusWidget() == 0)) {
+    if (trayIcon
+        && (tabSupervisor->currentIndex() != tabSupervisor->indexOf(this)
+            || QApplication::activeWindow() == 0
+            || QApplication::focusWidget() == 0)
+            ) {
         disconnect(trayIcon, SIGNAL(messageClicked()), 0, 0);
         trayIcon->showMessage(sender + tr(" mentioned you."), tr("Click to view"));
         connect(trayIcon, SIGNAL(messageClicked()), chatView, SLOT(actMessageClicked()));

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -605,3 +605,33 @@ void TabSupervisor::processNotifyUserEvent(const Event_NotifyUser &event)
     }
 
 }
+const QString TabSupervisor::getOwnUsername() const
+{
+    return QString::fromStdString(userInfo->name());
+}
+
+bool TabSupervisor::isUserBuddy(const QString &userName) const
+{
+    if (!getUserListsTab()) return false;
+    if (!getUserListsTab()->getBuddyList()) return false;
+    QMap<QString, UserListTWI *> buddyList = getUserListsTab()->getBuddyList()->getUsers();
+    bool senderIsBuddy = buddyList.contains(userName);
+    return senderIsBuddy;
+}
+
+const ServerInfo_User * TabSupervisor::getOnlineUser(const QString &userName) const
+{
+    if (!getUserListsTab()) return nullptr;
+    if (!getUserListsTab()->getAllUsersList()) return nullptr;
+    QMap<QString, UserListTWI *> userList = getUserListsTab()->getAllUsersList()->getUsers();
+    const QString &userNameToMatchLower = userName.toLower();
+    QMap<QString, UserListTWI *>::iterator i;
+
+    for (i = userList.begin(); i != userList.end(); ++i)
+        if (i.key().toLower() == userNameToMatchLower) {
+            const ServerInfo_User &userInfo = i.value()->getUserInfo();
+            return &userInfo;
+        }
+
+    return nullptr;
+};

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -605,6 +605,12 @@ void TabSupervisor::processNotifyUserEvent(const Event_NotifyUser &event)
     }
 
 }
+
+const bool TabSupervisor::isOwnUserRegistered() const
+{
+    return (bool) getUserInfo()->user_level() & ServerInfo_User::IsRegistered;
+}
+
 const QString TabSupervisor::getOwnUsername() const
 {
     return QString::fromStdString(userInfo->name());
@@ -615,6 +621,15 @@ bool TabSupervisor::isUserBuddy(const QString &userName) const
     if (!getUserListsTab()) return false;
     if (!getUserListsTab()->getBuddyList()) return false;
     QMap<QString, UserListTWI *> buddyList = getUserListsTab()->getBuddyList()->getUsers();
+    bool senderIsBuddy = buddyList.contains(userName);
+    return senderIsBuddy;
+}
+
+bool TabSupervisor::isUserIgnored(const QString &userName) const
+{
+    if (!getUserListsTab()) return false;
+    if (!getUserListsTab()->getIgnoreList()) return false;
+    QMap<QString, UserListTWI *> buddyList = getUserListsTab()->getIgnoreList()->getUsers();
     bool senderIsBuddy = buddyList.contains(userName);
     return senderIsBuddy;
 }

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -606,12 +606,12 @@ void TabSupervisor::processNotifyUserEvent(const Event_NotifyUser &event)
 
 }
 
-const bool TabSupervisor::isOwnUserRegistered() const
+bool TabSupervisor::isOwnUserRegistered() const
 {
     return (bool) getUserInfo()->user_level() & ServerInfo_User::IsRegistered;
 }
 
-const QString TabSupervisor::getOwnUsername() const
+QString TabSupervisor::getOwnUsername() const
 {
     return QString::fromStdString(userInfo->name());
 }

--- a/cockatrice/src/tab_supervisor.h
+++ b/cockatrice/src/tab_supervisor.h
@@ -5,6 +5,7 @@
 #include <QMap>
 #include <QAbstractButton>
 #include "deck_loader.h"
+#include "chatview/userlistProxy.h"
 
 class QMenu;
 class AbstractClient;
@@ -41,7 +42,7 @@ protected:
     void paintEvent(QPaintEvent *event);
 };
 
-class TabSupervisor : public QTabWidget {
+class TabSupervisor : public QTabWidget, public UserlistProxy {
     Q_OBJECT
 private:
     ServerInfo_User *userInfo;
@@ -78,6 +79,9 @@ public:
     const QMap<int, TabRoom *> &getRoomTabs() const { return roomTabs; }
     bool getAdminLocked() const;
     bool closeRequest();
+    const QString getOwnUsername() const;
+    bool isUserBuddy(const QString &userName) const;
+    const ServerInfo_User* getOnlineUser(const QString &userName) const;
 signals:
     void setMenu(const QList<QMenu *> &newMenuList = QList<QMenu *>());
     void localGameEnded();

--- a/cockatrice/src/tab_supervisor.h
+++ b/cockatrice/src/tab_supervisor.h
@@ -79,8 +79,10 @@ public:
     const QMap<int, TabRoom *> &getRoomTabs() const { return roomTabs; }
     bool getAdminLocked() const;
     bool closeRequest();
+    const bool isOwnUserRegistered() const;
     const QString getOwnUsername() const;
     bool isUserBuddy(const QString &userName) const;
+    bool isUserIgnored(const QString &userName) const;
     const ServerInfo_User* getOnlineUser(const QString &userName) const;
 signals:
     void setMenu(const QList<QMenu *> &newMenuList = QList<QMenu *>());

--- a/cockatrice/src/tab_supervisor.h
+++ b/cockatrice/src/tab_supervisor.h
@@ -79,8 +79,8 @@ public:
     const QMap<int, TabRoom *> &getRoomTabs() const { return roomTabs; }
     bool getAdminLocked() const;
     bool closeRequest();
-    const bool isOwnUserRegistered() const;
-    const QString getOwnUsername() const;
+    bool isOwnUserRegistered() const;
+    QString getOwnUsername() const;
     bool isUserBuddy(const QString &userName) const;
     bool isUserIgnored(const QString &userName) const;
     const ServerInfo_User* getOnlineUser(const QString &userName) const;

--- a/cockatrice/src/user_context_menu.cpp
+++ b/cockatrice/src/user_context_menu.cpp
@@ -245,7 +245,7 @@ void UserContextMenu::warnUser_dialogFinished()
 {
     WarningDialog *dlg = static_cast<WarningDialog *>(sender());
 
-    if (dlg->getName().isEmpty() || QString::fromStdString(tabSupervisor->getUserInfo()->name()).simplified().isEmpty())
+    if (dlg->getName().isEmpty() || tabSupervisor->getOwnUsername().simplified().isEmpty())
         return;
 
     Command_WarnUser cmd;
@@ -267,13 +267,13 @@ void UserContextMenu::showContextMenu(const QPoint &pos, const QString &userName
     menu->addAction(aDetails);
     menu->addAction(aShowGames);
     menu->addAction(aChat);
-    if (userLevel.testFlag(ServerInfo_User::IsRegistered) && (tabSupervisor->getUserInfo()->user_level() & ServerInfo_User::IsRegistered)) {
+    if (userLevel.testFlag(ServerInfo_User::IsRegistered) && tabSupervisor->isOwnUserRegistered()) {
         menu->addSeparator();
-        if (tabSupervisor->getUserListsTab()->getBuddyList()->getUsers().contains(userName))
+        if (tabSupervisor->isUserBuddy(userName))
             menu->addAction(aRemoveFromBuddyList);
         else
             menu->addAction(aAddToBuddyList);
-        if (tabSupervisor->getUserListsTab()->getIgnoreList()->getUsers().contains(userName))
+        if (tabSupervisor->isUserIgnored(userName))
             menu->addAction(aRemoveFromIgnoreList);
         else
             menu->addAction(aAddToIgnoreList);
@@ -298,7 +298,7 @@ void UserContextMenu::showContextMenu(const QPoint &pos, const QString &userName
             menu->addAction(aPromoteToMod);
         }
     }
-    bool anotherUser = userName != QString::fromStdString(tabSupervisor->getUserInfo()->name());
+    bool anotherUser = userName != tabSupervisor->getOwnUsername();
     aDetails->setEnabled(true);
     aChat->setEnabled(anotherUser && online);
     aShowGames->setEnabled(online);


### PR DESCRIPTION
- There still might be inherited usages
- It's still used in the ctor

Areas to test
- Mentions
- Chat notifications
- Username clickable links
