### PR TITLE
fix errors in new connect dialog

### DIFF
--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -14,6 +14,8 @@
 #include "settingscache.h"
 #include "userconnection_information.h"
 
+#define PUBLIC_SERVERS_URL "https://github.com/Cockatrice/Cockatrice/wiki/Public-Servers"
+
 DlgConnect::DlgConnect(QWidget *parent)
     : QDialog(parent)
 {
@@ -52,6 +54,14 @@ DlgConnect::DlgConnect(QWidget *parent)
     autoConnectCheckBox = new QCheckBox(tr("A&uto connect"));
     autoConnectCheckBox->setToolTip(tr("Automatically connect to the most recent login when Cockatrice opens"));
 
+    publicServersLabel = new QLabel(tr("Looking for a list of public servers? <a href=\"%1\">Click here</a>!").arg(PUBLIC_SERVERS_URL));
+    publicServersLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+    publicServersLabel->setWordWrap(true);
+    publicServersLabel->setTextFormat(Qt::RichText);
+    publicServersLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
+    publicServersLabel->setOpenExternalLinks(true);
+    publicServersLabel->setAlignment(Qt::AlignCenter);
+
     if (savePasswordCheckBox->isChecked())
     {
         autoConnectCheckBox->setChecked(settingsCache->servers().getAutoConnect());
@@ -78,16 +88,18 @@ DlgConnect::DlgConnect(QWidget *parent)
     connect(btnCancel, SIGNAL(released()), this, SLOT(actCancel()));
 
     QGridLayout *connectionLayout = new QGridLayout;
-    connectionLayout->addWidget(previousHostButton, 0, 1);
-    connectionLayout->addWidget(previousHosts, 1, 1);
-    connectionLayout->addWidget(newHostButton, 2, 1);
-    connectionLayout->addWidget(saveLabel, 3, 0);
-    connectionLayout->addWidget(saveEdit, 3, 1);
-    connectionLayout->addWidget(hostLabel, 4, 0);
-    connectionLayout->addWidget(hostEdit, 4, 1);
-    connectionLayout->addWidget(portLabel, 5, 0);
-    connectionLayout->addWidget(portEdit, 5, 1);
-    connectionLayout->addWidget(autoConnectCheckBox, 6, 1);
+    connectionLayout->addWidget(publicServersLabel, 0, 0, 1, 2);
+    connectionLayout->addWidget(previousHostButton, 1, 1);
+    connectionLayout->addWidget(previousHosts, 2, 1);
+    connectionLayout->addWidget(newHostButton, 3, 1);
+    connectionLayout->addWidget(saveLabel, 4, 0);
+    connectionLayout->addWidget(saveEdit, 4, 1);
+    connectionLayout->addWidget(hostLabel, 5, 0);
+    connectionLayout->addWidget(hostEdit, 5, 1);
+    connectionLayout->addWidget(portLabel, 6, 0);
+    connectionLayout->addWidget(portEdit, 6, 1);
+    connectionLayout->addWidget(autoConnectCheckBox, 7, 1);
+
 
     QGridLayout *buttons = new QGridLayout;
     buttons->addWidget(btnOk, 0, 0);
@@ -155,7 +167,7 @@ void DlgConnect::rebuildComboBoxList()
     {
         settingsCache->servers().addNewServer("Woogerworks", "cockatrice.woogerworks.com", "4747", "", "", false);
         settingsCache->servers().addNewServer("Chickatrice", "chickatrice.net", "4747", "", "", false);
-        settingsCache->servers().addNewServer("Cockatric.es", "cockatric.es", "4747", "", "", false);
+        settingsCache->servers().addNewServer("cockatric.es", "cockatric.es", "4747", "", "", false);
         settingsCache->servers().addNewServer("Tetrarch", "mtg.tetrarch.co", "4747", "", "", false);
     }
     savedHostList = uci.getServerInfo();
@@ -208,6 +220,11 @@ void DlgConnect::newHostSelected(bool state) {
     if (state)
     {
         previousHosts->setDisabled(true);
+        hostEdit->clear();
+        portEdit->clear();
+        playernameEdit->clear();
+        passwordEdit->clear();
+        savePasswordCheckBox->setChecked(false);
         saveEdit->clear();
         saveEdit->setPlaceholderText("New Menu Name");
         saveEdit->setDisabled(false);

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -19,7 +19,7 @@
 DlgConnect::DlgConnect(QWidget *parent)
     : QDialog(parent)
 {
-    previousHostButton = new QRadioButton(tr("Previous Host"), this);
+    previousHostButton = new QRadioButton(tr("Known Hosts"), this);
     previousHosts = new QComboBox(this);
     previousHosts->installEventFilter(new DeleteHighlightedItemWhenShiftDelPressedEventFilter);
 
@@ -54,7 +54,7 @@ DlgConnect::DlgConnect(QWidget *parent)
     autoConnectCheckBox = new QCheckBox(tr("A&uto connect"));
     autoConnectCheckBox->setToolTip(tr("Automatically connect to the most recent login when Cockatrice opens"));
 
-    publicServersLabel = new QLabel(tr("Looking for a list of public servers? <a href=\"%1\">Click here</a>!").arg(PUBLIC_SERVERS_URL));
+    publicServersLabel = new QLabel(tr("(<a href=\"%1\">Public Servers</a>)").arg(PUBLIC_SERVERS_URL));
     publicServersLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
     publicServersLabel->setWordWrap(true);
     publicServersLabel->setTextFormat(Qt::RichText);
@@ -87,19 +87,21 @@ DlgConnect::DlgConnect(QWidget *parent)
     btnCancel->setFixedWidth(100);
     connect(btnCancel, SIGNAL(released()), this, SLOT(actCancel()));
 
-    QGridLayout *connectionLayout = new QGridLayout;
-    connectionLayout->addWidget(publicServersLabel, 0, 0, 1, 2);
-    connectionLayout->addWidget(previousHostButton, 1, 1);
-    connectionLayout->addWidget(previousHosts, 2, 1);
-    connectionLayout->addWidget(newHostButton, 3, 1);
-    connectionLayout->addWidget(saveLabel, 4, 0);
-    connectionLayout->addWidget(saveEdit, 4, 1);
-    connectionLayout->addWidget(hostLabel, 5, 0);
-    connectionLayout->addWidget(hostEdit, 5, 1);
-    connectionLayout->addWidget(portLabel, 6, 0);
-    connectionLayout->addWidget(portEdit, 6, 1);
-    connectionLayout->addWidget(autoConnectCheckBox, 7, 1);
+    QGridLayout *newHostLayout = new QGridLayout;
+    newHostLayout->addWidget(newHostButton, 0, 1);
+    newHostLayout->addWidget(publicServersLabel, 0, 2);
 
+    QGridLayout *connectionLayout = new QGridLayout;
+    connectionLayout->addWidget(previousHostButton, 0, 1);
+    connectionLayout->addWidget(previousHosts, 1, 1);
+    connectionLayout->addLayout(newHostLayout, 2, 1, 1, 2);
+    connectionLayout->addWidget(saveLabel, 3, 0);
+    connectionLayout->addWidget(saveEdit, 3, 1);
+    connectionLayout->addWidget(hostLabel, 4, 0);
+    connectionLayout->addWidget(hostEdit, 4, 1);
+    connectionLayout->addWidget(portLabel, 5, 0);
+    connectionLayout->addWidget(portEdit, 5, 1);
+    connectionLayout->addWidget(autoConnectCheckBox, 6, 1);
 
     QGridLayout *buttons = new QGridLayout;
     buttons->addWidget(btnOk, 0, 0);

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -3,13 +3,11 @@
 #include <QComboBox>
 #include <QRadioButton>
 #include <QGridLayout>
-#include <QHBoxLayout>
 #include <QDialogButtonBox>
 #include <QDebug>
 #include <QEvent>
 #include <QKeyEvent>
 #include <QMessageBox>
-#include <iostream>
 #include <QGroupBox>
 #include <QPushButton>
 #include "dlg_connect.h"
@@ -155,10 +153,10 @@ void DlgConnect::rebuildComboBoxList()
 
     if (savedHostList.size() == 1)
     {
-        settingsCache->servers().addNewServer("Woogerworks Cockatrice", "cockatrice.woogerworks.com", "4747", "", "", false);
-        settingsCache->servers().addNewServer("Chickatrice Cockatrice", "chickatrice.net", "4747", "", "", false);
-        settingsCache->servers().addNewServer("Cockatric.es Cockatrice", "cockatric.es", "4747", "", "", false);
-        settingsCache->servers().addNewServer("Tetrarch Cockatrice", "mtg.tetrarch.co", "4747", "", "", false);
+        settingsCache->servers().addNewServer("Woogerworks", "cockatrice.woogerworks.com", "4747", "", "", false);
+        settingsCache->servers().addNewServer("Chickatrice", "chickatrice.net", "4747", "", "", false);
+        settingsCache->servers().addNewServer("Cockatric.es", "cockatric.es", "4747", "", "", false);
+        settingsCache->servers().addNewServer("Tetrarch", "mtg.tetrarch.co", "4747", "", "", false);
     }
     savedHostList = uci.getServerInfo();
 
@@ -181,6 +179,7 @@ void DlgConnect::rebuildComboBoxList()
 
 void DlgConnect::previousHostSelected(bool state) {
     if (state) {
+        saveEdit->setDisabled(true);
         previousHosts->setDisabled(false);
     }
 }
@@ -192,13 +191,17 @@ void DlgConnect::updateDisplayInfo(const QString &saveName)
 
     if (saveEdit == nullptr)
         return;
+
+    bool savePasswordStatus = data.at(5) == "1";
     
     saveEdit->setText(data.at(0));
     hostEdit->setText(data.at(1));
     portEdit->setText(data.at(2));
     playernameEdit->setText(data.at(3));
-    passwordEdit->setText(data.at(4));
-    savePasswordCheckBox->setChecked(data.at(5) == "1" ? true : false);
+    savePasswordCheckBox->setChecked(savePasswordStatus);
+
+    if (savePasswordStatus)
+        passwordEdit->setText(data.at(4));
 }
 
 void DlgConnect::newHostSelected(bool state) {
@@ -207,6 +210,7 @@ void DlgConnect::newHostSelected(bool state) {
         previousHosts->setDisabled(true);
         saveEdit->clear();
         saveEdit->setPlaceholderText("New Menu Name");
+        saveEdit->setDisabled(false);
     }
     else
     {
@@ -229,7 +233,15 @@ void DlgConnect::passwordSaved(int state)
 void DlgConnect::actOk()
 {
     if (newHostButton->isChecked())
+    {
+        if (saveEdit->text().isEmpty())
+        {
+            QMessageBox::critical(this, tr("Connection Warning"), tr("You need to name your new connection profile."));
+            return;
+        }
+
         settingsCache->servers().addNewServer(saveEdit->text(), hostEdit->text(), portEdit->text(), playernameEdit->text(), passwordEdit->text(), savePasswordCheckBox->isChecked());
+    }
     else
         settingsCache->servers().updateExistingServer(saveEdit->text(), hostEdit->text(), portEdit->text(), playernameEdit->text(), passwordEdit->text(), savePasswordCheckBox->isChecked());
 
@@ -257,7 +269,6 @@ void DlgConnect::actCancel()
     reject();
 }
 
-
 bool DeleteHighlightedItemWhenShiftDelPressedEventFilter::eventFilter(QObject *obj, QEvent *event)
 {
     if (event->type() == QEvent::KeyPress) {
@@ -276,4 +287,3 @@ void DlgConnect::actForgotPassword()
     emit sigStartForgotPasswordRequest();
     reject();
 }
-

--- a/cockatrice/src/dlg_connect.h
+++ b/cockatrice/src/dlg_connect.h
@@ -40,7 +40,7 @@ private slots:
     void updateDisplayInfo(const QString &saveName);
     void rebuildComboBoxList();
 private:
-    QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *saveLabel;
+    QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *saveLabel, *publicServersLabel;
     QLineEdit *hostEdit, *portEdit, *playernameEdit, *passwordEdit, *saveEdit;
     QCheckBox *savePasswordCheckBox, *autoConnectCheckBox;
     QComboBox *previousHosts;

--- a/cockatrice/src/dlg_connect.h
+++ b/cockatrice/src/dlg_connect.h
@@ -48,5 +48,4 @@ private:
     QPushButton *btnOk, *btnCancel, *btnForgotPassword;
     QMap<QString, UserConnection_Information> savedHostList;
 };
-
 #endif

--- a/cockatrice/src/settings/serverssettings.cpp
+++ b/cockatrice/src/settings/serverssettings.cpp
@@ -110,6 +110,16 @@ bool ServersSettings::getSavePassword()
     return save;
 }
 
+void ServersSettings::setPassword(QString password)
+{
+    setValue(password, "password", "server");
+}
+
+void ServersSettings::setSavePassword(int save)
+{
+    setValue(save, "save_password", "server");
+}
+
 void ServersSettings::setAutoConnect(int autoconnect)
 {
     setValue(autoconnect, "auto_connect", "server");

--- a/cockatrice/src/settings/serverssettings.cpp
+++ b/cockatrice/src/settings/serverssettings.cpp
@@ -93,11 +93,6 @@ QString ServersSettings::getPlayerName(QString defaultName)
     return name == QVariant() ? defaultName : name.toString();
 }
 
-void ServersSettings::setPassword(QString password)
-{
-
-}
-
 QString ServersSettings::getPassword()
 {
     int index = getPrevioushostindex(getPrevioushostName());
@@ -106,11 +101,6 @@ QString ServersSettings::getPassword()
         return getValue(QString("password%1").arg(index), "server", "server_details").toString();
 
     return QString();
-}
-
-void ServersSettings::setSavePassword(int save)
-{
-
 }
 
 bool ServersSettings::getSavePassword()

--- a/cockatrice/src/settings/serverssettings.cpp
+++ b/cockatrice/src/settings/serverssettings.cpp
@@ -95,18 +95,22 @@ QString ServersSettings::getPlayerName(QString defaultName)
 
 void ServersSettings::setPassword(QString password)
 {
-    setValue(password, "password", "server");
+
 }
 
 QString ServersSettings::getPassword()
 {
     int index = getPrevioushostindex(getPrevioushostName());
-    return getValue(QString("password%1").arg(index), "server", "server_details").toString();
+
+    if (getSavePassword())
+        return getValue(QString("password%1").arg(index), "server", "server_details").toString();
+
+    return QString();
 }
 
 void ServersSettings::setSavePassword(int save)
 {
-    setValue(save, "save_password", "server");
+
 }
 
 bool ServersSettings::getSavePassword()
@@ -171,9 +175,9 @@ void ServersSettings::addNewServer(QString saveName, QString serv, QString port,
     setValue(serv, QString("server%1").arg(index), "server", "server_details");
     setValue(port, QString("port%1").arg(index), "server", "server_details");
     setValue(username, QString("username%1").arg(index), "server", "server_details");
-    setValue(password, QString("password%1").arg(index), "server", "server_details");
     setValue(savePassword, QString("savePassword%1").arg(index), "server", "server_details");
     setValue(index, "totalServers", "server", "server_details");
+    setValue(password, QString("password%1").arg(index), "server", "server_details");
     
 }
 
@@ -188,8 +192,8 @@ bool ServersSettings::updateExistingServer(QString saveName, QString serv, QStri
             setValue(serv, QString("server%1").arg(i), "server", "server_details");
             setValue(port, QString("port%1").arg(i), "server", "server_details");
             setValue(username, QString("username%1").arg(i), "server", "server_details");
-            setValue(password, QString("password%1").arg(i), "server", "server_details");
             setValue(savePassword, QString("savePassword%1").arg(i), "server", "server_details");
+            setValue(password, QString("password%1").arg(i), "server", "server_details");
             return true;
         }
     }

--- a/cockatrice/src/settings/serverssettings.h
+++ b/cockatrice/src/settings/serverssettings.h
@@ -33,7 +33,9 @@ public:
     void setPlayerName(QString playerName);
     void setAutoConnect(int autoconnect);
     void setFPHostName(QString hostname);
+    void setPassword(QString password);
     void setFPPort(QString port);
+    void setSavePassword(int save);
     void setFPPlayerName(QString playerName);
     void addNewServer(QString saveName, QString serv, QString port, QString username, QString password, bool savePassword);
     bool updateExistingServer(QString saveName, QString serv, QString port, QString username, QString password, bool savePassword);

--- a/cockatrice/src/settings/serverssettings.h
+++ b/cockatrice/src/settings/serverssettings.h
@@ -28,12 +28,9 @@ public:
     void setPreviousHostLogin(int previous);
     void setPrevioushostName(const QString &);
     void setPreviousHostList(QStringList list);
-    void setPrevioushostindex(int index);
     void setHostName(QString hostname);
     void setPort(QString port);
     void setPlayerName(QString playerName);
-    void setPassword(QString password);
-    void setSavePassword(int save);
     void setAutoConnect(int autoconnect);
     void setFPHostName(QString hostname);
     void setFPPort(QString port);


### PR DESCRIPTION
## Related Ticket(s)
Fixes mostly #2492 
> Passwords are always saved, even if you don't check the corresponding option

Fixed

> You can't change the name of a server profile

They are a key, so I can't really do that right now. Maybe in the future

> Grey out the Name field if previous host is selected

Done