### PR TITLE
temporarly remove dev build downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ Downloads are hosted on [BinTray](https://bintray.com/cockatrice/Cockatrice).
 
 - Latest full release (**recommended**): [ ![Download](https://api.bintray.com/packages/cockatrice/Cockatrice/Cockatrice/images/download.svg) ](https://bintray.com/cockatrice/Cockatrice/Cockatrice/_latestVersion#files)<br>
 
-- Latest development version: [ ![Download](https://api.bintray.com/packages/cockatrice/Cockatrice/Cockatrice-git/images/download.svg) ](https://bintray.com/cockatrice/Cockatrice/Cockatrice-git/_latestVersion#files)<br>
-*Development builds may not be stable or contain several bugs. Especially if from a branch other than `master`!*
-
-
 
 # Get Involved [![Gitter chat](https://badges.gitter.im/Cockatrice/Cockatrice.png)](https://gitter.im/Cockatrice/Cockatrice)
 


### PR DESCRIPTION
## Short roundup of the initial problem
no more hosted dev builds on bintray due to agb problems

## What will change with this Pull Request?
- remove link

