### PR TITLE
additional null checks in player.cpp

### DIFF
--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -129,6 +129,11 @@ void GameSelector::actClearFilter()
 
 void GameSelector::actCreate()
 {
+    if (room == nullptr) {
+        qDebug() << "Attempted to create game, error caught!";
+        return;
+    }
+
     DlgCreateGame dlg(room, room->getGameTypes(), this);
     dlg.exec();
 }

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -131,7 +131,7 @@ void GameSelector::actClearFilter()
 void GameSelector::actCreate()
 {
     if (room == nullptr) {
-        qDebug() << "Attempted to create game, error caught!";
+        qWarning() << "Attempted to create game, but the room was null";
         return;
     }
 

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -6,6 +6,7 @@
 #include <QMessageBox>
 #include <QHeaderView>
 #include <QInputDialog>
+#include <QDebug>
 #include "tab_supervisor.h"
 #include "dlg_creategame.h"
 #include "dlg_filter_games.h"

--- a/cockatrice/src/logger.cpp
+++ b/cockatrice/src/logger.cpp
@@ -54,7 +54,8 @@ void Logger::log(QtMsgType /* type */, const QMessageLogContext & /* ctx */, con
     if(logBuffer.size() > LOGGER_MAX_ENTRIES)
         logBuffer.removeFirst();
 
-    emit logEntryAdded(message);
+    if (message.size() > 0)
+        emit logEntryAdded(message);
 
     std::cerr << message.toStdString() << std::endl; // Print to stdout
 

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -481,8 +481,9 @@ void Player::clear()
 
 void Player::addPlayer(Player *player)
 {
-    if (player == this)
+    if (player == nullptr || player == this)
         return;
+
     for (int i = 0; i < playerLists.size(); ++i) {
         QAction *newAction = playerLists[i]->addAction(player->getName());
         newAction->setData(player->getId());
@@ -492,6 +493,9 @@ void Player::addPlayer(Player *player)
 
 void Player::removePlayer(Player *player)
 {
+    if (player == nullptr)
+        return;
+
     for (int i = 0; i < playerLists.size(); ++i) {
         QList<QAction *> actionList = playerLists[i]->actions();
         for (int j = 0; j < actionList.size(); ++j)
@@ -1137,7 +1141,8 @@ void Player::actCreateAllRelatedCards()
 
 void Player::createCard(const CardItem *sourceCard, const QString &dbCardName) {
     CardInfo *cardInfo = db->getCard(dbCardName);
-    if(!cardInfo)
+
+    if (cardInfo == nullptr || sourceCard == nullptr)
         return;
 
     // get the target token's location
@@ -1172,6 +1177,9 @@ void Player::actSayMessage()
 
 void Player::setCardAttrHelper(const GameEventContext &context, CardItem *card, CardAttribute attribute, const QString &avalue, bool allCards)
 {
+    if (card == nullptr)
+        return;
+
     bool moveCardContext = context.HasExtension(Context_MoveCard::ext);
     switch (attribute) {
         case AttrTapped: {
@@ -1728,6 +1736,9 @@ void Player::processCardAttachment(const ServerInfo_Player &info)
 
 void Player::playCard(CardItem *c, bool faceDown, bool tapped)
 {
+    if (c == nullptr)
+        return;
+
     Command_MoveCard cmd;
     cmd.set_start_player_id(c->getZone()->getPlayer()->getId());
     cmd.set_start_zone(c->getZone()->getName().toStdString());
@@ -2347,6 +2358,9 @@ void Player::refreshShortcuts()
 
 void Player::updateCardMenu(const CardItem *card)
 {
+    if (card == nullptr)
+        return;
+
     QMenu *cardMenu = card->getCardMenu();
     QMenu *ptMenu = card->getPTMenu();
     QMenu *moveMenu = card->getMoveMenu();
@@ -2438,10 +2452,8 @@ void Player::updateCardMenu(const CardItem *card)
 }
 
 void Player::addRelatedCardActions(const CardItem *card, QMenu *cardMenu) {
-    if (!card || !cardMenu || !card->getInfo())
-    {
+    if (card == nullptr || cardMenu == nullptr || card->getInfo() == nullptr)
         return;
-    }
 
     QStringList relatedCards = *new QStringList();
     relatedCards.append(card->getInfo()->getRelatedCards());

--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -283,7 +283,9 @@ void RemoteClient::readData()
 #ifdef QT_DEBUG
         qDebug() << "IN" << messageLength << QString::fromStdString(newServerMessage.ShortDebugString());
 #endif
-        inputBuffer.remove(0, messageLength);
+        if (inputBuffer.remove(0, messageLength) == nullptr)
+            return;
+
         messageInProgress = false;
 
         processProtocolItem(newServerMessage);

--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -283,9 +283,7 @@ void RemoteClient::readData()
 #ifdef QT_DEBUG
         qDebug() << "IN" << messageLength << QString::fromStdString(newServerMessage.ShortDebugString());
 #endif
-        if (inputBuffer.remove(0, messageLength) == nullptr)
-            return;
-
+        qDebug() << inputBuffer.remove(0, messageLength);
         messageInProgress = false;
 
         processProtocolItem(newServerMessage);


### PR DESCRIPTION
Crash came from a nullptr in this file, so I added checks where ever pointers were used just in case. Fixed many nullptr issues throughout a few files that led to 3 different types of crashes.

Fix #2489 