### PR TITLE
logbuffer clear

### DIFF
--- a/cockatrice/src/logger.cpp
+++ b/cockatrice/src/logger.cpp
@@ -51,16 +51,18 @@ void Logger::closeLogfileSession()
 void Logger::log(QtMsgType /* type */, const QMessageLogContext & /* ctx */, const QString &message)
 {
     logBuffer.append(message);
-    if(logBuffer.size() > LOGGER_MAX_ENTRIES)
-        logBuffer.removeFirst();
+    if (logBuffer.size() > LOGGER_MAX_ENTRIES)
+        logBuffer.clear();
 
-    if (message.size() > 0)
+    if (message.size() > 0) {
         emit logEntryAdded(message);
+        std::cerr << message.toStdString() << std::endl; // Print to stdout
 
-    std::cerr << message.toStdString() << std::endl; // Print to stdout
+        if (logToFileEnabled)
+            fileStream << message << endl; // Print to fileStream
+    }
 
-    if (logToFileEnabled)
-        fileStream << message << endl; // Print to fileStream
+
 
 
 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2523 

## Short roundup of the initial problem
Logger tries to clear first entry, but it's seen as a double free and crashes the program. This bug seemed to occur only while in spectator mode of games and happened within ~10 minutes of each connection instance.

## What will change with this Pull Request?
flushes the entire log buffer instead of just the first element to avoid a potential double clear. I ran this for over an hour spectating and saw no crash.
