### PR TITLE
use list over vector

### DIFF
--- a/cockatrice/src/dlg_viewlog.cpp
+++ b/cockatrice/src/dlg_viewlog.cpp
@@ -24,7 +24,7 @@ DlgViewLog::DlgViewLog(QWidget *parent)
 
 void DlgViewLog::loadInitialLogBuffer()
 {
-    QVector<QString> logBuffer = Logger::getInstance().getLogBuffer();
+    QList<QString> logBuffer = Logger::getInstance().getLogBuffer();
     foreach(QString message, logBuffer)
         logEntryAdded(message);
 }

--- a/cockatrice/src/logger.h
+++ b/cockatrice/src/logger.h
@@ -25,11 +25,11 @@ private:
     QTextStream fileStream;
     QFile fileHandle;
 
-    QVector<QString> logBuffer;
+    QList<QString> logBuffer;
 public:
 	void logToFile(bool enabled);
     void log(QtMsgType type, const QMessageLogContext &ctx, const QString &message);
-    QVector<QString> getLogBuffer() { return logBuffer; }
+    QList<QString> getLogBuffer() { return logBuffer; }
 protected:
     void openLogfileSession();
     void closeLogfileSession();


### PR DESCRIPTION
I went to Stackoverflow's guide and checked around to see why QVector caused SIGABRT so frequently. It looks like it was common issue and a workaround seems to be to use QList instead. Similar functionality and we don't use this elsewhere, so lets throw it up!