### PR TITLE
[WIP] Strap decklist creation into the test harness

### DIFF
--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -173,11 +173,11 @@ float InnerDecklistNode::recursivePrice(bool countTotalCards) const
 bool InnerDecklistNode::compare(AbstractDecklistNode *other) const
 {
     switch (sortMethod) {
-        case 0:
+        case ByNumber:
             return compareNumber(other);
-        case 1:
+        case ByName:
             return compareName(other);
-        case 2:
+        case ByPrice:
             return comparePrice(other);
     }
     return 0;

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -13,7 +13,7 @@
 #include <QtCore/QXmlStreamReader>
 #include <QtCore/QXmlStreamWriter>
 
-#include "pb/move_card_to_zone.pb.h"
+#include <common/pb/move_card_to_zone.pb.h>
 
 class CardDatabase;
 class QIODevice;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,3 +38,4 @@ include_directories(${GTEST_INCLUDE_DIRS})
 target_link_libraries(dummy_test ${GTEST_BOTH_LIBRARIES})
 
 add_subdirectory(carddatabase)
+add_subdirectory(loading_from_clipboard)

--- a/tests/loading_from_clipboard/CMakeLists.txt
+++ b/tests/loading_from_clipboard/CMakeLists.txt
@@ -1,0 +1,39 @@
+ADD_DEFINITIONS("-DCARDDB_DATADIR=\"${CMAKE_CURRENT_SOURCE_DIR}/data/\"")
+add_executable(loading_from_clipboard_test
+        loading_from_clipboard_test.cpp
+        ../../common/decklist.cpp
+        )
+
+if(NOT GTEST_FOUND)
+    add_dependencies(loading_from_clipboard_test gtest)
+endif()
+
+target_link_libraries(loading_from_clipboard_test ${GTEST_BOTH_LIBRARIES})
+target_link_libraries(loading_from_clipboard_test cockatrice_common)
+
+add_test(NAME loading_from_clipboard_test COMMAND loading_from_clipboard_test)
+
+#### I feel like the rest of this file should not be necessary and
+#### is (effective) cargo culting of tests/carddatabase/CMakeLists.txt.
+#### Ideally we would only need to say "hey this test is against something from cockatrice_common",
+#### and cockatrice_common would declare all of it's dependencies. I need to learn more about CMake.
+
+# qt5 stuff
+include_directories(${Qt5Widgets_INCLUDE_DIRS})
+list(APPEND COCKATRICE_LIBS Widgets)
+
+# QtConcurrent
+find_package(Qt5Concurrent)
+if(Qt5Concurrent_FOUND)
+    include_directories(${Qt5Concurrent_INCLUDE_DIRS})
+    list(APPEND ORACLE_LIBS Concurrent)
+endif()
+
+# QtNetwork
+find_package(Qt5Network)
+if(Qt5Network_FOUND)
+    include_directories(${Qt5Network_INCLUDE_DIRS})
+    list(APPEND COCKATRICE_LIBS Network)
+endif()
+
+qt5_use_modules(loading_from_clipboard_test ${COCKATRICE_LIBS})

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -101,6 +101,21 @@ namespace {
         ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
         ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
     }
+
+    TEST(LoadingFromClipboardTest, UnknownCardsAreNotDiscarded) {
+        QString *clipboard = new QString("");
+        clipboard->append("1 CardThatDoesNotExistInCardsXml\n");
+        DeckList *deckList = fromClipboard(clipboard);
+
+        DecklistBuilder decklistBuilder = DecklistBuilder();
+        deckList->forEachCard(decklistBuilder);
+
+        CardRows expectedMainboard = CardRows({{"CardThatDoesNotExistInCardsXml", 1}});
+        CardRows expectedSideboard = CardRows({});
+
+        ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
+        ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
+    }
 }
 
 int main(int argc, char **argv) {

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -55,14 +55,15 @@ namespace {
         clipboard->append("2x Island\n");
         DeckList *deckList = fromClipboard(clipboard);
 
-        CardRows expectedMainboard = CardRows({{"Mountain", 1},
-                                               {"Island",   2}});
         DecklistBuilder decklistBuilder = DecklistBuilder();
-
         deckList->forEachCard(decklistBuilder);
 
+        CardRows expectedMainboard = CardRows({{"Mountain", 1},
+                                               {"Island",   2}});
+        CardRows expectedSideboard = CardRows({});
+
         ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
-        ASSERT_EQ(CardRows({}), decklistBuilder.sideboard());
+        ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
     }
 
     TEST(LoadingFromClipboardTest, CommentsAreIgnoed) {
@@ -72,13 +73,14 @@ namespace {
         // TODO: Sideboard comments are ignored
         DeckList *deckList = fromClipboard(clipboard);
 
-        CardRows expectedMainboard = CardRows({});
         DecklistBuilder decklistBuilder = DecklistBuilder();
-
         deckList->forEachCard(decklistBuilder);
 
+        CardRows expectedMainboard = CardRows({});
+        CardRows expectedSideboard = CardRows({});
+
         ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
-        ASSERT_EQ(CardRows({}), decklistBuilder.sideboard());
+        ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
     }
 
     TEST(LoadingFromClipboardTest, SideboardPrefix) {
@@ -88,13 +90,12 @@ namespace {
         clipboard->append("SB: 2x Island\n");
         DeckList *deckList = fromClipboard(clipboard);
 
+        DecklistBuilder decklistBuilder = DecklistBuilder();
+        deckList->forEachCard(decklistBuilder);
+
         CardRows expectedMainboard = CardRows({{"Mountain", 1}});
         CardRows expectedSideboard = CardRows({{"Mountain", 1},
                                                {"Island",   2}});
-
-        DecklistBuilder decklistBuilder = DecklistBuilder();
-
-        deckList->forEachCard(decklistBuilder);
 
         ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
         ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -17,7 +17,7 @@ struct DecklistBuilder {
     CardRows actualMainboard;
     CardRows actualSideboard;
 
-    DecklistBuilder() : actualMainboard({}), actualSideboard({}) {}
+    explicit DecklistBuilder() : actualMainboard({}), actualSideboard({}) {}
 
     void operator()(const InnerDecklistNode *innerDecklistNode, const DecklistCardNode *card) {
         if (innerDecklistNode->getName() == "main") {

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -66,11 +66,12 @@ namespace {
         ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
     }
 
-    TEST(LoadingFromClipboardTest, CommentsAreIgnoed) {
+    TEST(LoadingFromClipboardTest, CommentsAreIgnored) {
         QString *clipboard = new QString("");
-        clipboard->append("// 1 Mountain\n");
-        clipboard->append("// 2x Island\n");
-        // TODO: Sideboard comments are ignored
+        clipboard->append("//1 Mountain\n");
+        clipboard->append("//2x Island\n");
+        clipboard->append("//SB:2x Island\n");
+
         DeckList *deckList = fromClipboard(clipboard);
 
         DecklistBuilder decklistBuilder = DecklistBuilder();

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -50,9 +50,10 @@ namespace {
     }
 
     TEST(LoadingFromClipboardTest, QuantityPrefixed) {
-        QString *clipboard = new QString("");
-        clipboard->append("1 Mountain\n");
-        clipboard->append("2x Island\n");
+        QString *clipboard = new QString(
+                "1 Mountain\n"
+                "2x Island\n"
+        );
         DeckList *deckList = fromClipboard(clipboard);
 
         DecklistBuilder decklistBuilder = DecklistBuilder();
@@ -67,10 +68,11 @@ namespace {
     }
 
     TEST(LoadingFromClipboardTest, CommentsAreIgnored) {
-        QString *clipboard = new QString("");
-        clipboard->append("//1 Mountain\n");
-        clipboard->append("//2x Island\n");
-        clipboard->append("//SB:2x Island\n");
+        QString *clipboard = new QString(
+                "//1 Mountain\n"
+                "//2x Island\n"
+                "//SB:2x Island\n"
+        );
 
         DeckList *deckList = fromClipboard(clipboard);
 
@@ -85,10 +87,11 @@ namespace {
     }
 
     TEST(LoadingFromClipboardTest, SideboardPrefix) {
-        QString *clipboard = new QString("");
-        clipboard->append("1 Mountain\n");
-        clipboard->append("SB: 1 Mountain\n");
-        clipboard->append("SB: 2x Island\n");
+        QString *clipboard = new QString(
+                "1 Mountain\n"
+                "SB: 1 Mountain\n"
+                "SB: 2x Island\n"
+        );
         DeckList *deckList = fromClipboard(clipboard);
 
         DecklistBuilder decklistBuilder = DecklistBuilder();
@@ -103,8 +106,9 @@ namespace {
     }
 
     TEST(LoadingFromClipboardTest, UnknownCardsAreNotDiscarded) {
-        QString *clipboard = new QString("");
-        clipboard->append("1 CardThatDoesNotExistInCardsXml\n");
+        QString *clipboard = new QString(
+                "1 CardThatDoesNotExistInCardsXml\n"
+        );
         DeckList *deckList = fromClipboard(clipboard);
 
         DecklistBuilder decklistBuilder = DecklistBuilder();

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -1,0 +1,63 @@
+#include "gtest/gtest.h"
+#include "loading_from_clipboard_test.h"
+#include <QTextStream>
+#include "../../common/decklist.h"
+
+DeckList *fromClipboard(QString *clipboard);
+
+DeckList *fromClipboard(QString *clipboard) {
+    DeckList *deckList = new DeckList;
+    QTextStream *stream = new QTextStream(clipboard);
+    deckList->loadFromStream_Plain(*stream);
+    return deckList;
+}
+
+struct AssertDeckList {
+    QList<QString> expectedCards;
+    int actualDecklistSize = 0;
+
+    AssertDeckList(QList<QString> _expectedCards) : expectedCards(_expectedCards) {}
+
+    void operator()(const InnerDecklistNode *node, const DecklistCardNode *card) {
+        actualDecklistSize += card->getNumber();
+    }
+
+    void assertSizeIsCorrect() {
+        ASSERT_EQ(expectedCards.size(), actualDecklistSize);
+    }
+};
+
+namespace {
+    TEST(LoadingFromClipboardTest, EmptyDeck) {
+        DeckList *deckList = fromClipboard(new QString(""));
+
+        QStringList cardsInDeck = deckList->getCardList();
+        ASSERT_TRUE(cardsInDeck.isEmpty()) << "Deck should be empty";
+    }
+
+    TEST(LoadingFromClipboardTest, EmptySideboard) {
+        DeckList *deckList = fromClipboard(new QString("Sideboard"));
+
+        QStringList cardsInDeck = deckList->getCardList();
+        ASSERT_TRUE(cardsInDeck.isEmpty()) << "Deck should be empty";
+    }
+
+    TEST(LoadingFromClipboardTest, QuantityPrefixed) {
+        QString * clipboard = new QString("");
+        clipboard->append("1 Mountain\n");
+        clipboard->append("2x Island\n");
+        DeckList *deckList = fromClipboard(clipboard);
+
+        QList<QString> expectedDeck = QList<QString>() << "Mountain" << "Island" << "Island";
+        AssertDeckList assertDeckList(expectedDeck);
+
+        deckList->forEachCard(assertDeckList);
+
+        assertDeckList.assertSizeIsCorrect();
+    }
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -18,13 +18,13 @@ struct AssertDeckList {
 
     AssertDeckList(QList<QString> _expectedCards) : expectedCards(_expectedCards) {}
 
-    void operator()(const InnerDecklistNode * _, const DecklistCardNode *card) {
+    void operator()(const InnerDecklistNode *, const DecklistCardNode *card) {
         for (int i = 0; i < card->getNumber(); i++) {
             actualCards.append(card->getName());
         }
     }
 
-    void assertSizeIsCorrect() {
+    void makeAssertions() {
         ASSERT_EQ(expectedCards.size(), actualCards.size());
         ASSERT_EQ(expectedCards, actualCards);
     }
@@ -56,7 +56,7 @@ namespace {
 
         deckList->forEachCard(assertDeckList);
 
-        assertDeckList.assertSizeIsCorrect();
+        assertDeckList.makeAssertions();
     }
 }
 

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -14,16 +14,19 @@ DeckList *fromClipboard(QString *clipboard) {
 
 struct AssertDeckList {
     QList<QString> expectedCards;
-    int actualDecklistSize = 0;
+    QList<QString> actualCards;
 
     AssertDeckList(QList<QString> _expectedCards) : expectedCards(_expectedCards) {}
 
-    void operator()(const InnerDecklistNode *node, const DecklistCardNode *card) {
-        actualDecklistSize += card->getNumber();
+    void operator()(const InnerDecklistNode * _, const DecklistCardNode *card) {
+        for (int i = 0; i < card->getNumber(); i++) {
+            actualCards.append(card->getName());
+        }
     }
 
     void assertSizeIsCorrect() {
-        ASSERT_EQ(expectedCards.size(), actualDecklistSize);
+        ASSERT_EQ(expectedCards.size(), actualCards.size());
+        ASSERT_EQ(expectedCards, actualCards);
     }
 };
 

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -59,7 +59,6 @@ namespace {
                                                {"Island",   2}});
         DecklistBuilder decklistBuilder = DecklistBuilder();
 
-        SCOPED_TRACE("");
         deckList->forEachCard(decklistBuilder);
 
         ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
@@ -76,7 +75,6 @@ namespace {
         CardRows expectedMainboard = CardRows({});
         DecklistBuilder decklistBuilder = DecklistBuilder();
 
-        SCOPED_TRACE("");
         deckList->forEachCard(decklistBuilder);
 
         ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
@@ -96,7 +94,6 @@ namespace {
 
         DecklistBuilder decklistBuilder = DecklistBuilder();
 
-        SCOPED_TRACE("");
         deckList->forEachCard(decklistBuilder);
 
         ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -12,48 +12,93 @@ DeckList *fromClipboard(QString *clipboard) {
     return deckList;
 }
 
+using Cardrows = QMap<QString, int>;
+
 struct AssertDeckList {
-    QList<QString> expectedCards;
-    QList<QString> actualCards;
+    Cardrows expectedMainboard;
+    Cardrows expectedSideboard;
 
-    AssertDeckList(QList<QString> _expectedCards) : expectedCards(_expectedCards) {}
+    Cardrows actualMainboard;
+    Cardrows actualSideboard;
 
-    void operator()(const InnerDecklistNode *, const DecklistCardNode *card) {
-        for (int i = 0; i < card->getNumber(); i++) {
-            actualCards.append(card->getName());
+    AssertDeckList(Cardrows _expectedMainboardMap, Cardrows _expectedSideboard) :
+            expectedMainboard(_expectedMainboardMap), expectedSideboard(_expectedSideboard) {}
+
+    AssertDeckList(Cardrows _expectedMainboardMap) : AssertDeckList(_expectedMainboardMap, Cardrows({})) {}
+
+    void operator()(const InnerDecklistNode *innerDecklistNode, const DecklistCardNode *card) {
+        if (innerDecklistNode->getName() == "main") {
+            actualMainboard[card->getName()] += card->getNumber();
+        } else if (innerDecklistNode->getName() == "side") {
+            actualSideboard[card->getName()] += card->getNumber();
+        } else {
+            FAIL();
         }
     }
 
     void makeAssertions() {
-        ASSERT_EQ(expectedCards.size(), actualCards.size());
-        ASSERT_EQ(expectedCards, actualCards);
+        ASSERT_EQ(expectedSideboard, actualSideboard);
+        ASSERT_EQ(expectedMainboard, actualMainboard);
     }
 };
 
 namespace {
     TEST(LoadingFromClipboardTest, EmptyDeck) {
         DeckList *deckList = fromClipboard(new QString(""));
-
-        QStringList cardsInDeck = deckList->getCardList();
-        ASSERT_TRUE(cardsInDeck.isEmpty()) << "Deck should be empty";
+        ASSERT_TRUE(deckList->getCardList().isEmpty()) << "Deck should be empty";
     }
 
     TEST(LoadingFromClipboardTest, EmptySideboard) {
         DeckList *deckList = fromClipboard(new QString("Sideboard"));
-
-        QStringList cardsInDeck = deckList->getCardList();
-        ASSERT_TRUE(cardsInDeck.isEmpty()) << "Deck should be empty";
+        ASSERT_TRUE(deckList->getCardList().isEmpty()) << "Deck should be empty";
     }
 
     TEST(LoadingFromClipboardTest, QuantityPrefixed) {
-        QString * clipboard = new QString("");
+        QString *clipboard = new QString("");
         clipboard->append("1 Mountain\n");
         clipboard->append("2x Island\n");
         DeckList *deckList = fromClipboard(clipboard);
 
-        QList<QString> expectedDeck = QList<QString>() << "Mountain" << "Island" << "Island";
-        AssertDeckList assertDeckList(expectedDeck);
+        Cardrows expectedMainboard = Cardrows({{"Mountain", 1},
+                                               {"Island",   2}});
+        AssertDeckList assertDeckList(expectedMainboard);
 
+        SCOPED_TRACE("");
+        deckList->forEachCard(assertDeckList);
+
+        assertDeckList.makeAssertions();
+    }
+
+    TEST(LoadingFromClipboardTest, CommentsAreIgnoed) {
+        QString *clipboard = new QString("");
+        clipboard->append("// 1 Mountain\n");
+        clipboard->append("// 2x Island\n");
+        // TODO: Sideboard comments are ignored
+        DeckList *deckList = fromClipboard(clipboard);
+
+        Cardrows expectedMainboard = Cardrows({});
+        AssertDeckList assertDeckList(expectedMainboard);
+
+        SCOPED_TRACE("");
+        deckList->forEachCard(assertDeckList);
+
+        assertDeckList.makeAssertions();
+    }
+
+    TEST(LoadingFromClipboardTest, SideboardPrefix) {
+        QString *clipboard = new QString("");
+        clipboard->append("1 Mountain\n");
+        clipboard->append("SB: 1 Mountain\n");
+        clipboard->append("SB: 2x Island\n");
+        DeckList *deckList = fromClipboard(clipboard);
+
+        Cardrows expectedMainboard = Cardrows({{"Mountain", 1}});
+        Cardrows expectedSideboard = Cardrows({{"Mountain", 1},
+                                               {"Island",   2}});
+
+        AssertDeckList assertDeckList(expectedMainboard, expectedSideboard);
+
+        SCOPED_TRACE("");
         deckList->forEachCard(assertDeckList);
 
         assertDeckList.makeAssertions();


### PR DESCRIPTION
Here's a first pass at getting some test coverage on the decklist creation 
before refactoring it and making it awesome.

I feel we shouldn't have to list out all of the qt dependencies common requires 
in our test's makefiles, but I don't know enough about cmake to make it better.