### PR TITLE
exchange tr() for QString()

### DIFF
--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -112,7 +112,7 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
         userLevelText = tr("Unregistered user");
 
     if (user.has_privlevel() && user.privlevel() != "NONE") {
-        userLevelText += " | " + tr("%1").arg(user.privlevel().c_str());
+        userLevelText += " | " + QString("%1").arg(user.privlevel().c_str());
     }
 
     userLevelLabel3.setText(userLevelText);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2544

## Short roundup of the initial problem
The string just contained an argument `%1`. This lead to confusions and potential mistakes in our tanslations on transifex.

## What will change with this Pull Request?
- exchange tr() for QString(), to make it disappear from translations/transifex
It's of no use to have it translatable!

cc: @ZeldaZach correct?
