### PR TITLE
Travis/Appveyor publish to github pre-release using tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,40 @@
 language: cpp
+sudo: required
 matrix:
   fast_finish: true
   include:
-    # linux debug build, trusty + gcc + qt5
-    - os: linux
-      dist: trusty
-      env: BUILDTYPE=Debug DIST=trusty
-    # osx debug build, osx + clang + qt5
-    - os: osx
-      osx_image: xcode6.4
-      env: BUILDTYPE=Debug
-    # linux trusty release build, precise + gcc + qt5
-    - os: linux
-      dist: trusty
-      env: BUILDTYPE=Release DIST=trusty
-    # osx release build, osx + gcc + qt5
-    - os: osx
-      osx_image: xcode6.4
-      env: BUILDTYPE=Release
-script: ./travis-compile.sh
-install: ./travis-dependencies.sh
+  - os: linux
+    dist: trusty
+    env: BUILDTYPE=Debug DIST=trusty
+  - os: linux
+    dist: trusty
+    env: BUILDTYPE=Release DIST=trusty
+  - os: osx
+    osx_image: xcode6.4
+    env: BUILDTYPE=Debug
+  - os: osx
+    osx_image: xcode6.4
+    env: BUILDTYPE=Release
+script: "./travis-compile.sh"
+install: "./travis-dependencies.sh"
 cache: apt
 notifications:
-  slack: cockatrice:dNA81maCU8SAHB7pYrCWiQg9
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/d94969c3b01b22cbdcb7
+    - https://webhooks.gitter.im/e/d94969c3b01b22cbdcb7
     on_success: change
     on_failure: change
     on_start: never
+deploy:
+  provider: releases
+  api_key:
+    secure: "mLMF41q7xgOR1sjczsilEy7HQis2PkZCzhfOGbn/8FoOQnmmPOZjrsdhn06ZSl3SFsbfCLuClDYXAbFscQmdgjcGN5AmHV+JYfW650QEuQa/f4/lQFsVRtEqUA1O3FQ0OuRxdpCfJubZBdFVH8SbZ93GLC5zXJbkWQNq+xCX1fU="
+  file_glob: true
+  file: "build/Cockatrice-*"
+  prerelease: true
+  skip_cleanup: true
+  overwrite: true
+  on:
+    tags: true
+    repo: Cockatrice/Cockatrice
+    condition: $BUILDTYPE = Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,3 +86,14 @@ build_script:
         Push-AppveyorArtifact "latest-$env:target_arch"
         $version = $matches['content']
 test: off
+deploy:
+  description: "Dev build of Cockatrice"
+  provider: GitHub
+  auth_token:
+    secure: JHNaVdd4Hdig2aF8q268OM33TbyHtoya0Pui9IBMAVZigwL4PHhTr921ZpSxlqlt
+  artifact: /.*\.exe/
+  draft: false
+  prerelease: true
+  force_update: true
+  on:
+    appveyor_repo_tag: true


### PR DESCRIPTION
This PR allows Travis and Appveyor to publish dev builds with tags to github pre-release. If we set a standard tag to the master branch with a number (i.e. 2.3.14 :wink:) we can then publish constantly. The programs will both overwrite old files if we publish to the same tag.