### PR TITLE
clean transifex translations up

### DIFF
--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -54,7 +54,7 @@ DlgConnect::DlgConnect(QWidget *parent)
     autoConnectCheckBox = new QCheckBox(tr("A&uto connect"));
     autoConnectCheckBox->setToolTip(tr("Automatically connect to the most recent login when Cockatrice opens"));
 
-    publicServersLabel = new QLabel(QString("(<a href=\"%1\">")+tr("Public Servers")+QString("</a>)").arg(PUBLIC_SERVERS_URL));
+    publicServersLabel = new QLabel(QString("(<a href=\"%1\">").arg(PUBLIC_SERVERS_URL)+tr("Public Servers")+QString("</a>)"));
     publicServersLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
     publicServersLabel->setWordWrap(true);
     publicServersLabel->setTextFormat(Qt::RichText);

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -54,7 +54,7 @@ DlgConnect::DlgConnect(QWidget *parent)
     autoConnectCheckBox = new QCheckBox(tr("A&uto connect"));
     autoConnectCheckBox->setToolTip(tr("Automatically connect to the most recent login when Cockatrice opens"));
 
-    publicServersLabel = new QLabel(tr("(<a href=\"%1\">Public Servers</a>)").arg(PUBLIC_SERVERS_URL));
+    publicServersLabel = new QLabel(QString("(<a href=\"%1\">")+tr("Public Servers")+QString("</a>)").arg(PUBLIC_SERVERS_URL));
     publicServersLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
     publicServersLabel->setWordWrap(true);
     publicServersLabel->setTextFormat(Qt::RichText);


### PR DESCRIPTION
## Related Ticket(s)
- cleans up #2503

## Short roundup of the initial problem
- string shows up on transifex like this:
![tx](https://cloud.githubusercontent.com/assets/9874850/24600727/2f1b7110-1856-11e7-8c24-663f74fc7580.png)


## What will change with this Pull Request?
- separate the html code and formatting from actual translation string
