### PR TITLE
fix travis build

### DIFF
--- a/travis-compile.sh
+++ b/travis-compile.sh
@@ -8,7 +8,7 @@ mkdir -p build
 cd build
 prefix=""
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-  prefix="-DCMAKE_PREFIX_PATH=$(echo /usr/local/Cellar/qt5/5.*/)"
+  prefix="-DCMAKE_PREFIX_PATH=$(echo /usr/local/Cellar/qt/5.*/)"
 fi
 if [[ $TRAVIS_OS_NAME == "linux" ]]; then
   prefix="-DCMAKE_PREFIX_PATH=$(echo /opt/qt5*/lib/cmake/)"

--- a/travis-compile.sh
+++ b/travis-compile.sh
@@ -4,7 +4,7 @@ set -e
 
 ./servatrice/check_schema_version.sh
 
-mkdir build
+mkdir -p build
 cd build
 prefix=""
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then

--- a/travis-dependencies.sh
+++ b/travis-dependencies.sh
@@ -2,7 +2,8 @@
 
 if [[ $TRAVIS_OS_NAME == "osx" ]] ; then
   brew update > /dev/null
-  brew install qt5 protobuf > /dev/null
+  brew install --force qt
+  brew install protobuf
 else
   # common prerequisites
   sudo add-apt-repository -y ppa:smspillaz/cmake-master


### PR DESCRIPTION
Travis builds for OSX have been failing and upon running the script I figured out why. Homebrew made some changes to the QT package recently to just qt from qt5, for one.
```
$ brew install qt
Warning: qt is a keg-only and another version is linked to opt.
Use `brew install --force` if you want to install this version
```

As such, I now force it to install and overwrite. This should work to compile.