### PR TITLE
prevent focus unnecessarily

### DIFF
--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -754,7 +754,10 @@ void TabGame::processGameEventContainer(const GameEventContainer &cont, Abstract
                 case GameEvent::GAME_HOST_CHANGED: eventGameHostChanged(event.GetExtension(Event_GameHostChanged::ext), playerId, context); break;
                 case GameEvent::GAME_CLOSED: eventGameClosed(event.GetExtension(Event_GameClosed::ext), playerId, context); break;
                 case GameEvent::SET_ACTIVE_PLAYER: eventSetActivePlayer(event.GetExtension(Event_SetActivePlayer::ext), playerId, context); break;
-                case GameEvent::SET_ACTIVE_PHASE: eventSetActivePhase(event.GetExtension(Event_SetActivePhase::ext), playerId, context); break;
+                case GameEvent::SET_ACTIVE_PHASE:
+                    sayEdit->clearFocus();
+                    eventSetActivePhase(event.GetExtension(Event_SetActivePhase::ext), playerId, context);
+                    break;
 
                 default: {
                     Player *player = players.value(playerId, 0);
@@ -790,8 +793,6 @@ void TabGame::sendGameCommand(PendingCommand *pend, int playerId)
     if (!client)
         return;
 
-    sayEdit->clearFocus();
-
     connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(commandFinished(const Response &)));
     client->sendCommand(pend);
 }
@@ -801,8 +802,6 @@ void TabGame::sendGameCommand(const google::protobuf::Message &command, int play
     AbstractClient *client = getClientForPlayer(playerId);
     if (!client)
         return;
-
-    sayEdit->clearFocus();
 
     PendingCommand *pend = prepareGameCommand(command);
     connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(commandFinished(const Response &)));

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -790,6 +790,8 @@ void TabGame::sendGameCommand(PendingCommand *pend, int playerId)
     if (!client)
         return;
 
+    sayEdit->clearFocus();
+
     connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(commandFinished(const Response &)));
     client->sendCommand(pend);
 }
@@ -799,6 +801,8 @@ void TabGame::sendGameCommand(const google::protobuf::Message &command, int play
     AbstractClient *client = getClientForPlayer(playerId);
     if (!client)
         return;
+
+    sayEdit->clearFocus();
 
     PendingCommand *pend = prepareGameCommand(command);
     connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(commandFinished(const Response &)));


### PR DESCRIPTION
## Related Ticket(s)
Attempts to fix #2490


## What will change with this Pull Request?
I was playing with this annoying bug and by clearing the focus whenever a game action is sent it should work better
