### PR TITLE
fix header markdown in TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,16 +1,16 @@
-#TODOs
+# TODOs
 
 This is an unordered list of possible todo items for Cockatrice.
 Note that "improve" and "write" always also means: "document and comment"
 
-##Improve packaging:
+## Improve packaging:
 * Improve nsis file git hash extraction, it only works if the build directory is cleared as version_string.cpp does not seem to get updated by git pull/cmake
 * Create script/... for creating Linux packages (deb, rpm, ebuild, ...) or at least an official tarball/git tags; package maintainers dislike using git snapshots so much that they rather ignore software without stable tarballs.
 
-##Scripts
+## Scripts
 * Write example init script for servatrice.
 
-##Create developer documentation:
+## Create developer documentation:
 * Create developer manual
 * Add comments to code
 * Describe which components exist and how they work and interact
@@ -18,7 +18,7 @@ Note that "improve" and "write" always also means: "document and comment"
 * Comment and document servatrice.sql
 * Document everything!1!!
 
-##Else
+## Else
 
 * Update SFMT library (http://www.math.sci.hiroshima-u.ac.jp/~m-mat@math.sci.hiroshima-u.ac.jp/MT/SFMT/) in common/sfmt and adapt common/rng_sfmt.cpp
 


### PR DESCRIPTION
## Related Ticket(s)
- N/A

## Short roundup of the initial problem
The headers in TODO.md didn't render correctly

## What will change with this Pull Request?
- Spaces were inserted between the `#`s and the actual headers.
- The headers in TODO.md will now render correctly.

## Screenshots
N/A
