### PR TITLE
clear focus only if needed

### DIFF
--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -755,7 +755,7 @@ void TabGame::processGameEventContainer(const GameEventContainer &cont, Abstract
                 case GameEvent::GAME_CLOSED: eventGameClosed(event.GetExtension(Event_GameClosed::ext), playerId, context); break;
                 case GameEvent::SET_ACTIVE_PLAYER: eventSetActivePlayer(event.GetExtension(Event_SetActivePlayer::ext), playerId, context); break;
                 case GameEvent::SET_ACTIVE_PHASE:
-                    if (sayEdit && sayEdit->text().size() == 0)
+                    if (sayEdit && sayEdit->text().isEmpty())
                         sayEdit->clearFocus();
                     eventSetActivePhase(event.GetExtension(Event_SetActivePhase::ext), playerId, context);
                     break;

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -755,7 +755,8 @@ void TabGame::processGameEventContainer(const GameEventContainer &cont, Abstract
                 case GameEvent::GAME_CLOSED: eventGameClosed(event.GetExtension(Event_GameClosed::ext), playerId, context); break;
                 case GameEvent::SET_ACTIVE_PLAYER: eventSetActivePlayer(event.GetExtension(Event_SetActivePlayer::ext), playerId, context); break;
                 case GameEvent::SET_ACTIVE_PHASE:
-                    sayEdit->clearFocus();
+                    if (sayEdit && sayEdit->text().size() == 0)
+                        sayEdit->clearFocus();
                     eventSetActivePhase(event.GetExtension(Event_SetActivePhase::ext), playerId, context);
                     break;
 


### PR DESCRIPTION
## Related Ticket(s)
Fix #2593 
Fix #2602

This will fix the replay problem as sayEdit might not be defined. Also, we will now only clear the focus if the user's text field is empty (they're not actively typing anything, if they were, we should keep focus no matter what).