### PR TITLE
disable join if spec disabled

### DIFF
--- a/cockatrice/src/gameselector.h
+++ b/cockatrice/src/gameselector.h
@@ -23,6 +23,7 @@ private slots:
     void actCreate();
     void actJoin();
     void checkResponse(const Response &response);
+    void updateButtonChoices(const QModelIndex &);
 signals:
     void gameJoined(int gameId);
 private:


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2599 

## Short roundup of the initial problem
Join button should be disabled if the game doesn't allow spectators. This does so.

## Screenshots
<img width="1069" alt="screenshot 2017-04-19 23 31 47" src="https://cloud.githubusercontent.com/assets/7460172/25212458/623360d0-2558-11e7-95e4-30045fb87f5a.png">

