### PR TITLE
Change cards from sb<->mb with double-click

### DIFF
--- a/cockatrice/src/deckview.cpp
+++ b/cockatrice/src/deckview.cpp
@@ -1,5 +1,6 @@
 #include <QApplication>
 #include <QGraphicsSceneMouseEvent>
+#include <QMouseEvent>
 #include <math.h>
 #include "deckview.h"
 #include "decklist.h"
@@ -114,6 +115,39 @@ void DeckViewCard::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
         scene()->addItem(drag);
     }
     setCursor(Qt::OpenHandCursor);
+}
+
+void DeckView::mouseDoubleClickEvent(QMouseEvent *event)
+{
+    if (static_cast<DeckViewScene *>(scene())->getLocked())
+        return;
+
+    if (event->button() == Qt::LeftButton)
+    {
+        QList<MoveCard_ToZone> result;
+        QList<QGraphicsItem *> sel = scene()->selectedItems();
+
+        for (int i = 0; i < sel.size(); i++) {
+            DeckViewCard *c = static_cast<DeckViewCard *>(sel.at(i));
+            DeckViewCardContainer *zone = static_cast<DeckViewCardContainer *>(c->parentItem());
+            MoveCard_ToZone m;
+            m.set_card_name(c->getName().toStdString());
+            m.set_start_zone(zone->getName().toStdString());
+
+            if (zone->getName() == "main")
+                m.set_target_zone("side");
+            else if (zone->getName() == "side")
+                m.set_target_zone("main");
+            else // Trying to move from another zone
+                m.set_target_zone(zone->getName().toStdString());
+
+            result.append(m);
+        }
+
+        deckViewScene->applySideboardPlan(result);
+        deckViewScene->rearrangeItems();
+        emit deckViewScene->sideboardPlanChanged();
+    }
 }
 
 void DeckViewCard::hoverEnterEvent(QGraphicsSceneHoverEvent *event)

--- a/cockatrice/src/deckview.h
+++ b/cockatrice/src/deckview.h
@@ -83,7 +83,6 @@ private:
     qreal optimalAspectRatio;
     void clearContents();
     void rebuildTree();
-    void applySideboardPlan(const QList<MoveCard_ToZone> &plan);
 public:
     DeckViewScene(QObject *parent = 0);
     ~DeckViewScene();
@@ -95,6 +94,7 @@ public:
     void updateContents();
     QList<MoveCard_ToZone> getSideboardPlan() const;
     void resetSideboardPlan();
+    void applySideboardPlan(const QList<MoveCard_ToZone> &plan);
 };
 
 class DeckView : public QGraphicsView {
@@ -113,6 +113,7 @@ public:
     void setDeck(const DeckList &_deck);
     void setLocked(bool _locked) { deckViewScene->setLocked(_locked); }
     QList<MoveCard_ToZone> getSideboardPlan() const { return deckViewScene->getSideboardPlan(); }
+    void mouseDoubleClickEvent(QMouseEvent *event);
     void resetSideboardPlan();
 };
 

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -277,7 +277,7 @@ void DeckViewContainer::sideboardPlanChanged()
     Command_SetSideboardPlan cmd;
     const QList<MoveCard_ToZone> &newPlan = deckView->getSideboardPlan();
     for (int i = 0; i < newPlan.size(); ++i)
-        cmd.add_move_list()->CopyFrom(newPlan[i]);
+        cmd.add_move_list()->CopyFrom(newPlan.at(i));
     parentGame->sendGameCommand(cmd, playerId);
 }
 


### PR DESCRIPTION
## Related Ticket(s)
Fix #2594

This PR allows a person to double click on a card to change it from sideboard to mainboard and vice versa. This will not impact tokens (if you imported them to the deck) and will work in the exact same context as the drag/drop method.