### PR TITLE
Handle 'aftermath' cards like 'split' cards

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -165,7 +165,7 @@ int OracleImporter::importTextSpoiler(CardSet *set, const QVariant &data)
         if(layout == "token")
             continue;
 
-        if(layout == "split")
+        if(layout == "split" || layout == "aftermath")
         {
             // Enqueue split card for later handling
             cardId = map.contains("multiverseid") ? map.value("multiverseid").toInt() : 0;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2625 

## Short roundup of the initial problem
New card type in new set called 'aftermath' should be handled like old card type 'split'.  

## What will change with this Pull Request?
- Aftermath cards will show as `TopCard // BottomCard` in Cockatrice card database like split cards.
