### PR TITLE
Specify reason when on game leave; fix #2624

### DIFF
--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -42,10 +42,10 @@ void MessageLogWidget::logJoin(Player *player)
     appendHtmlServerMessage(tr("%1 has joined the game.").arg(sanitizeHtml(player->getName())));
 }
 
-void MessageLogWidget::logLeave(Player *player)
+void MessageLogWidget::logLeave(Player *player, QString reason)
 {
     soundEngine->playSound("player_leave");
-    appendHtmlServerMessage(tr("%1 has left the game.").arg(sanitizeHtml(player->getName())));
+    appendHtmlServerMessage(tr("%1 has left the game (%2).").arg(sanitizeHtml(player->getName()), sanitizeHtml(reason)));
 }
 
 void MessageLogWidget::logGameClosed()
@@ -64,10 +64,10 @@ void MessageLogWidget::logJoinSpectator(QString name)
     appendHtmlServerMessage(tr("%1 is now watching the game.").arg(sanitizeHtml(name)));
 }
 
-void MessageLogWidget::logLeaveSpectator(QString name)
+void MessageLogWidget::logLeaveSpectator(QString name, QString reason)
 {
     soundEngine->playSound("spectator_leave");
-    appendHtmlServerMessage(tr("%1 is not watching the game any more.").arg(sanitizeHtml(name)));
+    appendHtmlServerMessage(tr("%1 is not watching the game any more (%2).").arg(sanitizeHtml(name), sanitizeHtml(reason)));
 }
 
 void MessageLogWidget::logDeckSelect(Player *player, QString deckHash, int sideboardSize)

--- a/cockatrice/src/messagelogwidget.h
+++ b/cockatrice/src/messagelogwidget.h
@@ -40,11 +40,11 @@ public slots:
     void logGameJoined(int gameId);
     void logReplayStarted(int gameId);
     void logJoin(Player *player);
-    void logLeave(Player *player);
+    void logLeave(Player *player, QString reason);
     void logGameClosed();
     void logKicked();
     void logJoinSpectator(QString name);
-    void logLeaveSpectator(QString name);
+    void logLeaveSpectator(QString name, QString reason);
     void logDeckSelect(Player *player, QString deckHash, int sideboardSize);
     void logReadyStart(Player *player);
     void logNotReadyStart(Player *player);

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -1047,13 +1047,13 @@ QString TabGame::getLeaveReason(Event_Leave::LeaveReason reason)
     switch(reason)
     {
         case Event_Leave::USER_KICKED:
-            return tr("kicked");
+            return tr("kicked by game host or moderator");
             break;
-        case Event_Leave::USER_LEAVED:
-            return tr("player leaved the game");
+        case Event_Leave::USER_LEFT:
+            return tr("player left the game");
             break;
         case Event_Leave::USER_DISCONNECTED:
-            return tr("disconnected");
+            return tr("player disconnected from server");
             break;
         case Event_Leave::OTHER:
         default:

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -891,12 +891,12 @@ void TabGame::eventSpectatorSay(const Event_GameSay &event, int eventPlayerId, c
     messageLog->logSpectatorSay(QString::fromStdString(userInfo.name()), UserLevelFlags(userInfo.user_level()), QString::fromStdString(userInfo.privlevel()), QString::fromStdString(event.message()));
 }
 
-void TabGame::eventSpectatorLeave(const Event_Leave & /*event*/, int eventPlayerId, const GameEventContext & /*context*/)
+void TabGame::eventSpectatorLeave(const Event_Leave & event, int eventPlayerId, const GameEventContext & /*context*/)
 {
     QString playerName = "@" + QString::fromStdString(spectators.value(eventPlayerId).name());
     if (sayEdit && autocompleteUserList.removeOne(playerName))
         sayEdit->setCompletionList(autocompleteUserList);
-    messageLog->logLeaveSpectator(QString::fromStdString(spectators.value(eventPlayerId).name()));
+    messageLog->logLeaveSpectator(QString::fromStdString(spectators.value(eventPlayerId).name()), getLeaveReason(event.reason()));
     playerListWidget->removePlayer(eventPlayerId);
     spectators.remove(eventPlayerId);
 
@@ -1042,7 +1042,26 @@ void TabGame::eventJoin(const Event_Join &event, int /*eventPlayerId*/, const Ga
     emitUserEvent();
 }
 
-void TabGame::eventLeave(const Event_Leave & /*event*/, int eventPlayerId, const GameEventContext & /*context*/)
+QString TabGame::getLeaveReason(Event_Leave::LeaveReason reason)
+{
+    switch(reason)
+    {
+        case Event_Leave::USER_KICKED:
+            return tr("kicked");
+            break;
+        case Event_Leave::USER_LEAVED:
+            return tr("player leaved the game");
+            break;
+        case Event_Leave::USER_DISCONNECTED:
+            return tr("disconnected");
+            break;
+        case Event_Leave::OTHER:
+        default:
+            return tr("reason unknown");
+            break;
+    }
+}
+void TabGame::eventLeave(const Event_Leave & event, int eventPlayerId, const GameEventContext & /*context*/)
 {
     Player *player = players.value(eventPlayerId, 0);
     if (!player)
@@ -1052,7 +1071,7 @@ void TabGame::eventLeave(const Event_Leave & /*event*/, int eventPlayerId, const
     if(sayEdit && autocompleteUserList.removeOne(playerName))
         sayEdit->setCompletionList(autocompleteUserList);
 
-    messageLog->logLeave(player);
+    messageLog->logLeave(player, getLeaveReason(event.reason()));
     playerListWidget->removePlayer(eventPlayerId);
     players.remove(eventPlayerId);
     emit playerRemoved(player);

--- a/cockatrice/src/tab_game.h
+++ b/cockatrice/src/tab_game.h
@@ -6,6 +6,7 @@
 #include <QCompleter>
 #include "tab.h"
 #include "pb/serverinfo_game.pb.h"
+#include "pb/event_leave.pb.h"
 
 class AbstractClient;
 class CardDatabase;
@@ -186,6 +187,7 @@ private:
     void createPlayAreaWidget(bool bReplay=false);
     void createDeckViewContainerWidget(bool bReplay=false);
     void createReplayDock();
+    QString getLeaveReason(Event_Leave::LeaveReason reason);
 signals:
     void gameClosing(TabGame *tab);
     void playerAdded(Player *player);

--- a/common/pb/event_leave.proto
+++ b/common/pb/event_leave.proto
@@ -8,7 +8,7 @@ message Event_Leave {
     enum LeaveReason {
         OTHER = 1;
         USER_KICKED = 2;
-        USER_LEAVED = 3;
+        USER_LEFT = 3;
         USER_DISCONNECTED = 4;
     }
     optional LeaveReason reason = 1;

--- a/common/pb/event_leave.proto
+++ b/common/pb/event_leave.proto
@@ -5,4 +5,11 @@ message Event_Leave {
     extend GameEvent {
         optional Event_Leave ext = 1001;
     }
+    enum LeaveReason {
+        OTHER = 1;
+        USER_KICKED = 2;
+        USER_LEAVED = 3;
+        USER_DISCONNECTED = 4;
+    }
+    optional LeaveReason reason = 1;
 }

--- a/common/server_game.cpp
+++ b/common/server_game.cpp
@@ -471,7 +471,7 @@ void Server_Game::addPlayer(Server_AbstractUserInterface *userInterface, Respons
     createGameJoinedEvent(newPlayer, rc, false);
 }
 
-void Server_Game::removePlayer(Server_Player *player)
+void Server_Game::removePlayer(Server_Player *player, Event_Leave::LeaveReason reason)
 {
     room->getServer()->removePersistentPlayer(QString::fromStdString(player->getUserInfo()->name()), room->getId(), gameId, player->getPlayerId());
     players.remove(player->getPlayerId());
@@ -479,7 +479,10 @@ void Server_Game::removePlayer(Server_Player *player)
     GameEventStorage ges;
     removeArrowsRelatedToPlayer(ges, player);
     unattachCards(ges, player);
-    ges.enqueueGameEvent(Event_Leave(), player->getPlayerId());
+
+    Event_Leave event;
+    event.set_reason(reason);
+    ges.enqueueGameEvent(event, player->getPlayerId());
     ges.sendToGame(this);
 
     bool playerActive = activePlayer == player->getPlayerId();
@@ -585,7 +588,7 @@ bool Server_Game::kickPlayer(int playerId)
     playerToKick->sendGameEvent(*gec);
     delete gec;
 
-    removePlayer(playerToKick);
+    removePlayer(playerToKick, Event_Leave::USER_KICKED);
 
     return true;
 }

--- a/common/server_game.h
+++ b/common/server_game.h
@@ -29,6 +29,7 @@
 #include "server_response_containers.h"
 #include "pb/response.pb.h"
 #include "pb/serverinfo_game.pb.h"
+#include "pb/event_leave.pb.h"
 
 class QTimer;
 class GameEventContainer;
@@ -103,7 +104,7 @@ public:
     Response::ResponseCode checkJoin(ServerInfo_User *user, const QString &_password, bool spectator, bool overrideRestrictions);
     bool containsUser(const QString &userName) const;
     void addPlayer(Server_AbstractUserInterface *userInterface, ResponseContainer &rc, bool spectator, bool broadcastUpdate = true);
-    void removePlayer(Server_Player *player);
+    void removePlayer(Server_Player *player, Event_Leave::LeaveReason reason);
     void removeArrowsRelatedToPlayer(GameEventStorage &ges, Server_Player *player);
     void unattachCards(GameEventStorage &ges, Server_Player *player);
     bool kickPlayer(int playerId);

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -616,7 +616,7 @@ Response::ResponseCode Server_Player::setCardAttrHelper(GameEventStorage &ges, c
 
 Response::ResponseCode Server_Player::cmdLeaveGame(const Command_LeaveGame & /*cmd*/, ResponseContainer & /*rc*/, GameEventStorage & /*ges*/)
 {
-    game->removePlayer(this);
+    game->removePlayer(this, Event_Leave::USER_LEAVED);
     return Response::RespOk;
 }
 
@@ -1715,7 +1715,7 @@ void Server_Player::setUserInterface(Server_AbstractUserInterface *_userInterfac
 void Server_Player::disconnectClient()
 {
     if (!(userInfo->user_level() & ServerInfo_User::IsRegistered) || spectator)
-        game->removePlayer(this);
+        game->removePlayer(this, Event_Leave::USER_DISCONNECTED);
     else
         setUserInterface(0);
 }

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -616,7 +616,7 @@ Response::ResponseCode Server_Player::setCardAttrHelper(GameEventStorage &ges, c
 
 Response::ResponseCode Server_Player::cmdLeaveGame(const Command_LeaveGame & /*cmd*/, ResponseContainer & /*rc*/, GameEventStorage & /*ges*/)
 {
-    game->removePlayer(this, Event_Leave::USER_LEAVED);
+    game->removePlayer(this, Event_Leave::USER_LEFT);
     return Response::RespOk;
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2624

## Short roundup of the initial problem
When an user leaves a game the reason is not stated, leading to misinterpretations:
 * the game host can quietly kick an user saying that he leaved by himself;
 * a user disconnected because of a temporary internet connection problem will seems to have leaved the game.

## What will change with this Pull Request?
The reason why a user leaved the game is passed by the server to clients following @Daenyth's suggestion of keeping the protocol backwards compatible:
https://github.com/Cockatrice/Cockatrice/issues/2624#issuecomment-296640397

Please check the reason strings i chose, they need to be short but correct english.
