### PR TITLE
Trim deck name on save file dialog; fix #2623

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -719,7 +719,7 @@ bool TabDeckEditor::actSaveDeckAs()
     dialog.setConfirmOverwrite(true);
     dialog.setDefaultSuffix("cod");
     dialog.setNameFilters(DeckLoader::fileNameFilters);
-    dialog.selectFile(deckModel->getDeckList()->getName());
+    dialog.selectFile(deckModel->getDeckList()->getName().trimmed());
     if (!dialog.exec())
         return false;
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2623

## Short roundup of the initial problem
When creating a new deck, if the name has a leading or trailing space, it will end up in the file name when the decks gets saved 

## What will change with this Pull Request?
The save file name will be trimmed.