### PR TITLE
Fix #2608; fix #2609; fix #2611

### DIFF
--- a/cockatrice/src/gameselector.h
+++ b/cockatrice/src/gameselector.h
@@ -22,8 +22,8 @@ private slots:
     void actClearFilter();
     void actCreate();
     void actJoin();
+    void actSelectedGameChanged(const QModelIndex &current, const QModelIndex &previous);
     void checkResponse(const Response &response);
-    void updateButtonChoices(const QModelIndex &);
 signals:
     void gameJoined(int gameId);
 private:


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2608 
- Fixes #2609 
- Fixes #2611

## Short roundup of the initial problem
The initial PR #2605 was incomplete

## What will change with this Pull Request?
The "join" button will be disabled if the room is full.
The "spectate" button will be disabled/enabled both when the game row gets selected using the mouse, keyboard or any other input method.

