### PR TITLE
Fix unknown tokens being drawn as card back

### DIFF
--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -95,7 +95,7 @@ void AbstractCardItem::paintPicture(QPainter *painter, const QSizeF &translatedS
     if(facedown)
     {
         // never reveal card color, always paint the card back
-        PictureLoader::getPixmap(translatedPixmap, nullptr, translatedSize.toSize());
+        PictureLoader::getCardBackPixmap(translatedPixmap, translatedSize.toSize());
     } else {
         // don't even spend time trying to load the picture if our size is too small
         if(translatedSize.width() > 10)

--- a/cockatrice/src/cardinfopicture.cpp
+++ b/cockatrice/src/cardinfopicture.cpp
@@ -41,7 +41,10 @@ void CardInfoPicture::updatePixmap()
 
 void CardInfoPicture::loadPixmap()
 {
-    PictureLoader::getPixmap(resizedPixmap, info, size());
+    if(info)
+        PictureLoader::getPixmap(resizedPixmap, info, size());
+    else
+        PictureLoader::getCardBackPixmap(resizedPixmap, size());
 }
 
 void CardInfoPicture::paintEvent(QPaintEvent *)

--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -422,7 +422,7 @@ PictureLoader::~PictureLoader()
     worker->deleteLater();
 }
 
-void PictureLoader::internalGetCardBackPixmap(QPixmap &pixmap, QSize size)
+void PictureLoader::getCardBackPixmap(QPixmap &pixmap, QSize size)
 {
     QString backCacheKey = "_trice_card_back_" + QString::number(size.width()) + QString::number(size.height());
     if(!QPixmapCache::find(backCacheKey, &pixmap))
@@ -435,29 +435,26 @@ void PictureLoader::internalGetCardBackPixmap(QPixmap &pixmap, QSize size)
 
 void PictureLoader::getPixmap(QPixmap &pixmap, CardInfo *card, QSize size)
 {
-    if(card)
-    {    
-        // search for an exact size copy of the picure in cache
-        QString key = card->getPixmapCacheKey();
-        QString sizekey = key + QLatin1Char('_') + QString::number(size.width()) + QString::number(size.height());
-        if(QPixmapCache::find(sizekey, &pixmap))
-            return;
+    if(card == nullptr)
+        return;
 
-        // load the image and create a copy of the correct size
-        QPixmap bigPixmap;
-        if(QPixmapCache::find(key, &bigPixmap))
-        {
-            pixmap = bigPixmap.scaled(size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-            QPixmapCache::insert(sizekey, pixmap);
-            return;
-        }
+    // search for an exact size copy of the picure in cache
+    QString key = card->getPixmapCacheKey();
+    QString sizekey = key + QLatin1Char('_') + QString::number(size.width()) + QString::number(size.height());
+    if(QPixmapCache::find(sizekey, &pixmap))
+        return;
 
-        // add the card to the load queue
-        getInstance().worker->enqueueImageLoad(card);
-    } else {
-        // requesting the image for a null card is a shortcut to get the card background image
-        internalGetCardBackPixmap(pixmap, size);
+    // load the image and create a copy of the correct size
+    QPixmap bigPixmap;
+    if(QPixmapCache::find(key, &bigPixmap))
+    {
+        pixmap = bigPixmap.scaled(size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        QPixmapCache::insert(sizekey, pixmap);
+        return;
     }
+
+    // add the card to the load queue
+    getInstance().worker->enqueueImageLoad(card);
 }
 
 void PictureLoader::imageLoaded(CardInfo *card, const QImage &image)

--- a/cockatrice/src/pictureloader.h
+++ b/cockatrice/src/pictureloader.h
@@ -82,11 +82,10 @@ private:
     PictureLoaderWorker * worker;
 public:
     static void getPixmap(QPixmap &pixmap, CardInfo *card, QSize size);
+    static void getCardBackPixmap(QPixmap &pixmap, QSize size);
     static void clearPixmapCache(CardInfo *card);
     static void clearPixmapCache();
     static void cacheCardPixmaps(QList<CardInfo *> cards);
-protected:
-    static void internalGetCardBackPixmap(QPixmap &pixmap, QSize size);
 private slots:
     void picDownloadChanged();
     void picsPathChanged();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2600

## Short roundup of the initial problem
Unknown tokens now are drawn as card back images.

## What will change with this Pull Request?
Unknown tokens will be drawn as rectangles filled with the chosen color.
The token name will be shown also when the "Display card names on cards having a picture" is disabled.

## Screenshots
![schermata 2017-04-24 alle 18 03 08](https://cloud.githubusercontent.com/assets/1631111/25346611/55402ad4-2918-11e7-8782-db9d9b336d71.png)

