### PR TITLE
Some work on the tokens dialog

### DIFF
--- a/cockatrice/src/dlg_create_token.cpp
+++ b/cockatrice/src/dlg_create_token.cpp
@@ -125,7 +125,7 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
 
     setWindowTitle(tr("Create token"));
 
-    resize(450, 500);
+    resize(600, 500);
     restoreGeometry(settingsCache->getTokenDialogGeometry());
 }
 

--- a/cockatrice/src/dlg_create_token.h
+++ b/cockatrice/src/dlg_create_token.h
@@ -10,9 +10,11 @@ class QComboBox;
 class QCheckBox;
 class QPushButton;
 class QRadioButton;
+class QCloseEvent;
 class DeckList;
 class CardDatabaseModel;
 class TokenDisplayModel;
+class CardInfoPicture;
 
 class DlgCreateToken : public QDialog {
     Q_OBJECT
@@ -23,12 +25,15 @@ public:
     QString getPT() const;
     QString getAnnotation() const;
     bool getDestroy() const;
+protected:
+    void closeEvent(QCloseEvent *event);
 private slots:
     void tokenSelectionChanged(const QModelIndex &current, const QModelIndex &previous);
     void updateSearch(const QString &search);
     void actChooseTokenFromAll(bool checked);
     void actChooseTokenFromDeck(bool checked);
     void actOk();
+    void actReject();
 private:
     CardDatabaseModel *cardDatabaseModel;
     TokenDisplayModel *cardDatabaseDisplayModel;
@@ -38,6 +43,7 @@ private:
     QLineEdit *nameEdit, *ptEdit, *annotationEdit;
     QCheckBox *destroyCheckBox;
     QRadioButton *chooseTokenFromAllRadioButton, *chooseTokenFromDeckRadioButton;
+    CardInfoPicture *pic;
 
     void updateSearchFieldWithoutUpdatingFilter(const QString &newValue) const;
 };

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -208,6 +208,7 @@ SettingsCache::SettingsCache()
     picUrlFallback = settings->value("personal/picUrlFallback", PIC_URL_FALLBACK).toString();
 
     mainWindowGeometry = settings->value("interface/main_window_geometry").toByteArray();
+    tokenDialogGeometry = settings->value("interface/token_dialog_geometry").toByteArray();
     notificationsEnabled = settings->value("interface/notificationsenabled", true).toBool();
     spectatorNotificationsEnabled = settings->value("interface/specnotificationsenabled", false).toBool();
     doubleClickToPlay = settings->value("interface/doubleclicktoplay", true).toBool();
@@ -542,6 +543,12 @@ void SettingsCache::setMainWindowGeometry(const QByteArray &_mainWindowGeometry)
 {
     mainWindowGeometry = _mainWindowGeometry;
     settings->setValue("interface/main_window_geometry", mainWindowGeometry);
+}
+
+void SettingsCache::setTokenDialogGeometry(const QByteArray &_tokenDialogGeometry)
+{
+    tokenDialogGeometry = _tokenDialogGeometry;
+    settings->setValue("interface/token_dialog_geometry", tokenDialogGeometry);
 }
 
 void SettingsCache::setPixmapCacheSize(const int _pixmapCacheSize)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -59,6 +59,7 @@ private:
     LayoutsSettings *layoutsSettings;
 
     QByteArray mainWindowGeometry;
+    QByteArray tokenDialogGeometry;
     QString lang;
     QString deckPath, replaysPath, picsPath, customPicsPath, cardDatabasePath, customCardDatabasePath, tokenDatabasePath, themeName;
     bool notifyAboutUpdates;
@@ -123,6 +124,7 @@ public:
     QString getDataPath();
     QString getSettingsPath();
     const QByteArray &getMainWindowGeometry() const { return mainWindowGeometry; }
+    const QByteArray &getTokenDialogGeometry() const { return tokenDialogGeometry; }
     QString getLang() const { return lang; }
     QString getDeckPath() const { return deckPath; }
     QString getReplaysPath() const { return replaysPath; }
@@ -203,6 +205,7 @@ public:
     LayoutsSettings& layouts() const { return *layoutsSettings; }
 public slots:
     void setMainWindowGeometry(const QByteArray &_mainWindowGeometry);
+    void setTokenDialogGeometry(const QByteArray &_tokenDialog);
     void setLang(const QString &_lang);
     void setDeckPath(const QString &_deckPath);
     void setReplaysPath(const QString &_replaysPath);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1623 
- Fixes #1665
- Fixes #2591

## Short roundup of the initial problem
It was hard to get informations from the dialog and to discriminate between different tokens with the same name

## What will change with this Pull Request?
 * card image preview in token dialog
 * token dialog is resizable
 * token dialog saves its size and position on close, restores on reopen

## Screenshots
![schermata 2017-04-24 alle 18 45 05](https://cloud.githubusercontent.com/assets/1631111/25348312/2aa79ea0-291e-11e7-9975-71219c466259.png)

