### PR TITLE
improve provided info in "edit sets"

### DIFF
--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -94,8 +94,8 @@ WndSets::WndSets(QWidget *parent)
             this, SLOT(actToggleButtons(const QItemSelection &, const QItemSelection &)));
 
     labNotes = new QLabel;
-    labNotes->setText("<b>" + tr("Enable the sets that you want to have available in the deck editor") + "</b><br><br>" 
-                      + "<b>" + tr("Card Art") + ": " + "</b>" + tr("Set image priority is decided by enabled sets first (top to bottom), then disabled sets (top to bottom)") + "<br>"
+    labNotes->setText("<br><b>" + tr("Enable all sets that you want to have available in the deck editor") + "</b><br><br>" 
+                      + "<b>" + tr("Card Art") + ": " + "</b>" + tr("Image priority is decided by enabled sets first (top to bottom), then disabled sets (top to bottom)") + "<br>"
                      );
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -95,11 +95,11 @@ WndSets::WndSets(QWidget *parent)
 
     labNotes = new QLabel;
     labNotes->setText("<b>" + tr("Enable the sets that you want to have available in the deck editor") + "</b><br><br>" 
-                      + "<b>" + tr("Card Art") + ":" + "</b>" 
+                      + "<b>" + tr("Card Art") + ": " + "</b>" + tr("Set image priority is decided by enabled sets (top to bottom), then disabled sets (top to bottom)") + "<br><br>"
+                  //  + "<b>" + tr("Card Art") + ":" + "</b>" 
                   //  + "<ul><li>" + tr("Sets order decides the source that will be used when loading images for a specific card")
-                      + "<ul><li>" + tr("Sets on top are priotized over others on the bottom when loading images for a specific card")
-                      + "</li><li>" + tr("Disabled sets will only be used for loading images if all the enabled sets failed") 
-                      + "</li></ul>"
+                  //  + "</li><li>" + tr("Disabled sets will only be used for loading images if all the enabled sets failed") 
+                  //  + "</li></ul>"
                       + "<b>" + tr("Hint") + ": " + "</b>" + tr("Move sets around to change their order, or click on a column header to sort sets on that field")
                      );
 

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -96,9 +96,10 @@ WndSets::WndSets(QWidget *parent)
     labNotes = new QLabel;
     labNotes->setText("<b>" + tr("Enable the sets that you want to have available in the deck editor") + "</b><br><br>" 
                       + "<b>" + tr("Card Art") + ":" + "</b>" 
-                      + "<ul><li>" + tr("Sets order decides the source that will be used when loading images for a specific card") 
+                  //  + "<ul><li>" + tr("Sets order decides the source that will be used when loading images for a specific card")
+                      + "<ul><li>" + tr("Sets on top are priotized over others on the bottom when loading images for a specific card")
                       + "</li><li>" + tr("Disabled sets will only be used for loading images if all the enabled sets failed") 
-                      + "</li></ul><br>"
+                      + "</li></ul>"
                       + "<b>" + tr("Hint") + ": " + "</b>" + tr("Move sets around to change their order, or click on a column header to sort sets on that field")
                      );
 

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -98,8 +98,9 @@ WndSets::WndSets(QWidget *parent)
                       + "<br><b>" + tr("Card Art") + ":" + "</b>" 
                       + "<ul><li>" + tr("Sets order decides the source that will be used when loading images for a specific card") 
                       + "</li><li>" + tr("Disabled sets will only be used for loading images if all the enabled sets failed") 
-                      + "</li></ul><br>"
-                      + "<b>" + tr("Hint") + ":" + tr("Move sets around to change their order, or click on a column header to sort sets on that field") + "</b>");
+                      + "</li></ul><br><br>"
+                      + "<b>" + tr("Hint") + "</b>" + ": " + tr("Move sets around to change their order, or click on a column header to sort sets on that field")
+                     );
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actSave()));

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -95,12 +95,7 @@ WndSets::WndSets(QWidget *parent)
 
     labNotes = new QLabel;
     labNotes->setText("<b>" + tr("Enable the sets that you want to have available in the deck editor") + "</b><br><br>" 
-                      + "<b>" + tr("Card Art") + ": " + "</b>" + tr("Set image priority is decided by enabled sets (top to bottom), then disabled sets (top to bottom)") + "<br><br>"
-                  //  + "<b>" + tr("Card Art") + ":" + "</b>" 
-                  //  + "<ul><li>" + tr("Sets order decides the source that will be used when loading images for a specific card")
-                  //  + "</li><li>" + tr("Disabled sets will only be used for loading images if all the enabled sets failed") 
-                  //  + "</li></ul>"
-                      + "<b>" + tr("Hint") + ": " + "</b>" + tr("Move sets around to change their order, or click on a column header to sort sets on that field")
+                      + "<b>" + tr("Card Art") + ": " + "</b>" + tr("Set image priority is decided by enabled sets first (top to bottom), then disabled sets (top to bottom)") + "<br>"
                      );
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -94,7 +94,12 @@ WndSets::WndSets(QWidget *parent)
             this, SLOT(actToggleButtons(const QItemSelection &, const QItemSelection &)));
 
     labNotes = new QLabel;
-    labNotes->setText("<b>" + tr("hints:") + "</b>" + "<ul><li>" + tr("Enable the sets that you want to have available in the deck editor") + "</li><li>" + tr("Move sets around to change their order, or click on a column header to sort sets on that field") + "</li><li>" + tr("Sets order decides the source that will be used when loading images for a specific card") + "</li><li>" + tr("Disabled sets will be used for loading images only if all the enabled sets failed") + "</li></ul>");
+    labNotes->setText("<b>" + tr("Enable the sets that you want to have available in the deck editor") + "</b>" 
+                      + "<br><b>" + tr("Card Art") + ":" + "</b>" 
+                      + "<ul><li>" + tr("Sets order decides the source that will be used when loading images for a specific card") 
+                      + "</li><li>" + tr("Disabled sets will only be used for loading images if all the enabled sets failed") 
+                      + "</li></ul><br>"
+                      + "<b>" + tr("Hint") + ":" + tr("Move sets around to change their order, or click on a column header to sort sets on that field") + "</b>");
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actSave()));

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -94,12 +94,12 @@ WndSets::WndSets(QWidget *parent)
             this, SLOT(actToggleButtons(const QItemSelection &, const QItemSelection &)));
 
     labNotes = new QLabel;
-    labNotes->setText("<b>" + tr("Enable the sets that you want to have available in the deck editor") + "</b>" 
-                      + "<br><b>" + tr("Card Art") + ":" + "</b>" 
+    labNotes->setText("<b>" + tr("Enable the sets that you want to have available in the deck editor") + "</b><br><br>" 
+                      + "<b>" + tr("Card Art") + ":" + "</b>" 
                       + "<ul><li>" + tr("Sets order decides the source that will be used when loading images for a specific card") 
                       + "</li><li>" + tr("Disabled sets will only be used for loading images if all the enabled sets failed") 
-                      + "</li></ul><br><br>"
-                      + "<b>" + tr("Hint") + "</b>" + ": " + tr("Move sets around to change their order, or click on a column header to sort sets on that field")
+                      + "</li></ul><br>"
+                      + "<b>" + tr("Hint") + ": " + "</b>" + tr("Move sets around to change their order, or click on a column header to sort sets on that field")
                      );
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -94,9 +94,16 @@ WndSets::WndSets(QWidget *parent)
             this, SLOT(actToggleButtons(const QItemSelection &, const QItemSelection &)));
 
     labNotes = new QLabel;
-    labNotes->setText("<br><b>" + tr("Enable all sets that you want to have available in the deck editor") + "</b><br><br>" 
-                      + "<b>" + tr("Card Art") + ": " + "</b>" + tr("Image priority is decided by enabled sets first (top to bottom), then disabled sets (top to bottom)") + "<br>"
-                     );
+    labNotes->setWordWrap(true);
+    labNotes->setTextInteractionFlags(Qt::TextBrowserInteraction);
+    labNotes->setOpenExternalLinks(true);
+    labNotes->setText(
+    "<b>" + tr("Deck Editor") + ":</b> "
+    + tr("Only cards in enabled sets will appear in the deck editor card list")
+    + "<br><b>" + tr("Card Art") + ":</b> " + tr("Image priority is decided in the following order")
+    + "<ol><li>" + tr("The") + "<a href='https://github.com/Cockatrice/Cockatrice/wiki/Custom-Cards-%26-Sets#to-add-custom-art-for-cards-the-easiest-way-is-to-use-the-custom-folder'> "
+    + tr("CUSTOM Folder") + "</a></li><li>" + tr("Enabled Sets (Top to Bottom)") + "</li><li>" + tr("Disabled Sets (Top to Bottom)") + "</li></ol>"
+    );
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actSave()));


### PR DESCRIPTION
## Short roundup of the initial problem
 - Info text was just too much and not very well highlighted

## What will change with this Pull Request?
- Short phrasing
- Highlighted info about card art handling

## Screenshots
- before
![editssets_before](https://cloud.githubusercontent.com/assets/9874850/25354162/3b9da272-2932-11e7-84d0-722239481f07.png)

- after
![editsets_after](https://cloud.githubusercontent.com/assets/9874850/25354642/09edeb54-2934-11e7-87e0-33b0701b0121.png)
