### PR TITLE
Create token dialog: show tokens from all sets; fix #2044

### DIFF
--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -3,8 +3,8 @@
 
 #define CARDDBMODEL_COLUMNS 6
 
-CardDatabaseModel::CardDatabaseModel(CardDatabase *_db, QObject *parent)
-    : QAbstractListModel(parent), db(_db)
+CardDatabaseModel::CardDatabaseModel(CardDatabase *_db, bool _showOnlyCardsFromEnabledSets, QObject *parent)
+    : QAbstractListModel(parent), db(_db), showOnlyCardsFromEnabledSets(_showOnlyCardsFromEnabledSets)
 {
     connect(db, SIGNAL(cardAdded(CardInfo *)), this, SLOT(cardAdded(CardInfo *)));
     connect(db, SIGNAL(cardRemoved(CardInfo *)), this, SLOT(cardRemoved(CardInfo *)));
@@ -77,6 +77,9 @@ void CardDatabaseModel::cardInfoChanged(CardInfo *card)
 
 bool CardDatabaseModel::checkCardHasAtLeastOneEnabledSet(CardInfo *card)
 {
+    if(!showOnlyCardsFromEnabledSets)
+        return true;
+
     foreach(CardSet * set, card->getSets())
     {
         if(set->getEnabled())

--- a/cockatrice/src/carddatabasemodel.h
+++ b/cockatrice/src/carddatabasemodel.h
@@ -14,7 +14,7 @@ class CardDatabaseModel : public QAbstractListModel {
 public:
     enum Columns { NameColumn, SetListColumn, ManaCostColumn, PTColumn, CardTypeColumn, ColorColumn };
     enum Role { SortRole=Qt::UserRole };
-    CardDatabaseModel(CardDatabase *_db, QObject *parent = 0);
+    CardDatabaseModel(CardDatabase *_db, bool _showOnlyCardsFromEnabledSets, QObject *parent = 0);
     ~CardDatabaseModel();
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
     int columnCount(const QModelIndex &parent = QModelIndex()) const;
@@ -25,6 +25,7 @@ public:
 private:
     QList<CardInfo *> cardList;
     CardDatabase *db;
+    bool showOnlyCardsFromEnabledSets;
 
     inline bool checkCardHasAtLeastOneEnabledSet(CardInfo *card);
 private slots:

--- a/cockatrice/src/dlg_create_token.cpp
+++ b/cockatrice/src/dlg_create_token.cpp
@@ -67,7 +67,7 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
     QGroupBox *tokenDataGroupBox = new QGroupBox(tr("Token data"));
     tokenDataGroupBox->setLayout(grid);
     
-    cardDatabaseModel = new CardDatabaseModel(db, this);
+    cardDatabaseModel = new CardDatabaseModel(db, false, this);
     cardDatabaseDisplayModel = new TokenDisplayModel(this);
     cardDatabaseDisplayModel->setSourceModel(cardDatabaseModel);
     

--- a/cockatrice/src/dlg_edit_tokens.cpp
+++ b/cockatrice/src/dlg_edit_tokens.cpp
@@ -60,7 +60,7 @@ DlgEditTokens::DlgEditTokens(QWidget *parent)
     QGroupBox *tokenDataGroupBox = new QGroupBox(tr("Token data"));
     tokenDataGroupBox->setLayout(grid);
 
-    databaseModel = new CardDatabaseModel(db, this);
+    databaseModel = new CardDatabaseModel(db, false, this);
     databaseModel->setObjectName("databaseModel");
     cardDatabaseDisplayModel = new TokenDisplayModel(this);
     cardDatabaseDisplayModel->setSourceModel(databaseModel);

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -324,7 +324,7 @@ void TabDeckEditor::createCentralFrame()
     connect(&searchKeySignals, SIGNAL(onCtrlAltEnter()), this, SLOT(actAddCardToSideboard()));
     connect(&searchKeySignals, SIGNAL(onCtrlEnter()), this, SLOT(actAddCardToSideboard()));    
 
-    databaseModel = new CardDatabaseModel(db, this);
+    databaseModel = new CardDatabaseModel(db, true, this);
     databaseModel->setObjectName("databaseModel");
     databaseDisplayModel = new CardDatabaseDisplayModel(this);
     databaseDisplayModel->setSourceModel(databaseModel);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2044

## Short roundup of the initial problem
The "create token" and "edit token" dialogs were only showing cards from enabled sets.
Only the deck editor is supposed to be filtered by enabled sets.

## What will change with this Pull Request?
- CardDatabaseModel not accepts a `showOnlyCardsFromEnabledSets` param, default false, true only for the deck editor.
- The "create token" and "edit token" dialogs will always show all tokens.
- When in the "create token" dialog the "show tokens from this deck" is checked, tokens from disabled sets won't be hidden.
