### PR TITLE
Edit sets: sort by enabled; fix #2580

### DIFF
--- a/cockatrice/src/setsmodel.cpp
+++ b/cockatrice/src/setsmodel.cpp
@@ -30,10 +30,21 @@ QVariant SetsModel::data(const QModelIndex &index, int role) const
 
     CardSet *set = sets[index.row()];
 
-    if ( role == Qt::CheckStateRole && index.column() == EnabledCol )
-        return static_cast< int >( enabledSets.contains(set) ? Qt::Checked : Qt::Unchecked );
+    if (index.column() == EnabledCol)
+    {
+        switch(role)
+        {
+            case SortRole:
+               return enabledSets.contains(set) ? "1" : "0";
+            case Qt::CheckStateRole:
+                return static_cast< int >( enabledSets.contains(set) ? Qt::Checked : Qt::Unchecked );
+            case Qt::DisplayRole:
+            default:
+               return QVariant();
+        }
+    }
 
-    if (role != Qt::DisplayRole)
+    if (role != Qt::DisplayRole && role != SortRole)
         return QVariant();
 
     switch (index.column()) {
@@ -178,7 +189,7 @@ void SetsModel::sort(int column, Qt::SortOrder order)
     int row;
 
     for(row = 0; row < numRows; ++row)
-        setMap.insertMulti(index(row, column).data().toString(), sets.at(row));
+        setMap.insertMulti(index(row, column).data(SetsModel::SortRole).toString(), sets.at(row));
     
     QList<CardSet *> tmp = setMap.values();
     sets.clear();

--- a/cockatrice/src/setsmodel.h
+++ b/cockatrice/src/setsmodel.h
@@ -27,6 +27,7 @@ private:
     QSet<CardSet *> enabledSets;
 public:
     enum SetsColumns { SortKeyCol, IsKnownCol, EnabledCol, LongNameCol, ShortNameCol, SetTypeCol, ReleaseDateCol };
+    enum Role { SortRole=Qt::UserRole };
 
     SetsModel(CardDatabase *_db, QObject *parent = 0);
     ~SetsModel();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2580

## Short roundup of the initial problem
Sort be "enabled" was not working in the "edit sets" dialog

## What will change with this Pull Request?
Sort be "enabled" works in the "edit sets" dialog
