### PR TITLE
Fix crash in replay 

### DIFF
--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -613,7 +613,7 @@ bool TabSupervisor::isOwnUserRegistered() const
 
 QString TabSupervisor::getOwnUsername() const
 {
-    return QString::fromStdString(userInfo->name());
+    return userInfo ? QString::fromStdString(userInfo->name()) : QString();
 }
 
 bool TabSupervisor::isUserBuddy(const QString &userName) const


### PR DESCRIPTION
## Short roundup of the initial problem
While investigating #2332, cockatrice crashed because of a null ptr deref.

## What will change with this Pull Request?
Cockatrice won't crash anymore when playing replays.