### PR TITLE
Fix card attributes being set to the wrong card; fix #2332

### DIFF
--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -523,12 +523,12 @@ Response::ResponseCode Server_Player::moveCard(GameEventStorage &ges, Server_Car
             
             ges.enqueueGameEvent(eventPrivate, playerId, GameEventStorageItem::SendToPrivate, playerId);
             ges.enqueueGameEvent(eventOthers, playerId, GameEventStorageItem::SendToOthers);
-            
+
             if (thisCardProperties->tapped())
-                setCardAttrHelper(ges, targetzone->getName(), card->getId(), AttrTapped, "1");
+                setCardAttrHelper(ges, targetzone->getPlayer()->getPlayerId(), targetzone->getName(), card->getId(), AttrTapped, "1");
             QString ptString = QString::fromStdString(thisCardProperties->pt());
             if (!ptString.isEmpty() && !faceDown)
-                setCardAttrHelper(ges, targetzone->getName(), card->getId(), AttrPT, ptString);
+                setCardAttrHelper(ges, targetzone->getPlayer()->getPlayerId(), targetzone->getName(), card->getId(), AttrPT, ptString);
         }
         if (startzone->getAlwaysRevealTopCard() && !startzone->getCards().isEmpty() && (originalPosition == 0)) {
             Event_RevealCards revealEvent;
@@ -578,7 +578,7 @@ void Server_Player::unattachCard(GameEventStorage &ges, Server_Card *card)
         parentCard->getZone()->updateCardCoordinates(parentCard, parentCard->getX(), parentCard->getY());
 }
 
-Response::ResponseCode Server_Player::setCardAttrHelper(GameEventStorage &ges, const QString &zoneName, int cardId, CardAttribute attribute, const QString &attrValue)
+Response::ResponseCode Server_Player::setCardAttrHelper(GameEventStorage &ges, int targetPlayerId, const QString &zoneName, int cardId, CardAttribute attribute, const QString &attrValue)
 {
     Server_CardZone *zone = getZones().value(zoneName);
     if (!zone)
@@ -609,7 +609,7 @@ Response::ResponseCode Server_Player::setCardAttrHelper(GameEventStorage &ges, c
         event.set_card_id(cardId);
     event.set_attribute(attribute);
     event.set_attr_value(result.toStdString());
-    ges.enqueueGameEvent(event, playerId);
+    ges.enqueueGameEvent(event, targetPlayerId);
     
     return Response::RespOk;
 }
@@ -1224,7 +1224,7 @@ Response::ResponseCode Server_Player::cmdSetCardAttr(const Command_SetCardAttr &
     if (conceded)
         return Response::RespContextError;
     
-    return setCardAttrHelper(ges, QString::fromStdString(cmd.zone()), cmd.card_id(), cmd.attribute(), QString::fromStdString(cmd.attr_value()));
+    return setCardAttrHelper(ges, playerId, QString::fromStdString(cmd.zone()), cmd.card_id(), cmd.attribute(), QString::fromStdString(cmd.attr_value()));
 }
 
 Response::ResponseCode Server_Player::cmdSetCardCounter(const Command_SetCardCounter &cmd, ResponseContainer & /*rc*/, GameEventStorage &ges)

--- a/common/server_player.h
+++ b/common/server_player.h
@@ -121,7 +121,7 @@ public:
     Response::ResponseCode drawCards(GameEventStorage &ges, int number);
     Response::ResponseCode moveCard(GameEventStorage &ges, Server_CardZone *startzone, const QList<const CardToMove *> &_cards, Server_CardZone *targetzone, int x, int y, bool fixFreeSpaces = true, bool undoingDraw = false);
     void unattachCard(GameEventStorage &ges, Server_Card *card);
-    Response::ResponseCode setCardAttrHelper(GameEventStorage &ges, const QString &zone, int cardId, CardAttribute attribute, const QString &attrValue);
+    Response::ResponseCode setCardAttrHelper(GameEventStorage &ges, int targetPlayerId, const QString &zone, int cardId, CardAttribute attribute, const QString &attrValue);
 
     Response::ResponseCode cmdLeaveGame(const Command_LeaveGame &cmd, ResponseContainer &rc, GameEventStorage &ges);
     Response::ResponseCode cmdKickFromGame(const Command_KickFromGame &cmd, ResponseContainer &rc, GameEventStorage &ges);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2332

## Short roundup of the initial problem
If a card changed owner while being put on the table, its attributes could be set on the wrong card.

## What will change with this Pull Request?
Fix the problem

I've been able to reproduce a card collision id and check that the attributes are now set to the correct card:

<details>
<summary>game log</summary>

```
"[Event_SetActivePlayer.ext] { active_player_id: 0 }"
"[Event_SetActivePhase.ext] { phase: 0 }"
OUT 10 "cmd_id: 14 game_id: 69 game_command { [Command_Mulligan.ext] { } }"
IN 195 "message_type: GAME_EVENT_CONTAINER game_event_container { game_id: 69 event_list { player_id: 1 [Event_Shuffle.ext] { } } event_list { player_id: 1 [Event_DrawCards.ext] { number: 7 cards { id: 22 name: \"Urborg, Tomb of Yawgmoth\" } cards { id: 45 name: \"Bloodsoaked Champion\" } cards { id: 8 name: \"Bloodstained Mire\" } cards { id: 18 name: \"Swamp\" } cards { id: 7 name: \"Mana Confluence\" } cards { id: 30 name: \"Chief of the Edge\" } cards { id: 46 name: \"Goblin Rabblemaster\" } } } context { [Context_Mulligan.ext] { number: 4294967295 } } }"
"\x00\x00\x00\b\b\x00\x12\x04\b\x0E\x10\x01"
"player_id: 1 [Event_Shuffle.ext] { }"
"player_id: 1 [Event_DrawCards.ext] { number: 7 cards { id: 22 name: \"Urborg, Tomb of Yawgmoth\" } cards { id: 45 name: \"Bloodsoaked Champion\" } cards { id: 8 name: \"Bloodstained Mire\" } cards { id: 18 name: \"Swamp\" } cards { id: 7 name: \"Mana Confluence\" } cards { id: 30 name: \"Chief of the Edge\" } cards { id: 46 name: \"Goblin Rabblemaster\" } }"
IN 33 "message_type: GAME_EVENT_CONTAINER game_event_container { game_id: 69 event_list { player_id: 0 [Event_Shuffle.ext] { } } event_list { player_id: 0 [Event_DrawCards.ext] { number: 7 } } context { [Context_Mulligan.ext] { number: 4294967295 } } }"
"player_id: 0 [Event_Shuffle.ext] { }"
"player_id: 0 [Event_DrawCards.ext] { number: 7 }"
IN 58 "message_type: GAME_EVENT_CONTAINER game_event_container { game_id: 69 event_list { player_id: 0 [Event_CreateToken.ext] { zone_name: \"table\" card_id: 75 card_name: \"Arlinn Kord (emblem)\" color: \"\\000\" pt: \"\" annotation: \"\" destroy_on_zone_change: true x: 0 y: 1 } } }"
"player_id: 0 [Event_CreateToken.ext] { zone_name: \"table\" card_id: 75 card_name: \"Arlinn Kord (emblem)\" color: \"\\000\" pt: \"\" annotation: \"\" destroy_on_zone_change: true x: 0 y: 1 }"
IN 68 "message_type: GAME_EVENT_CONTAINER game_event_container { game_id: 69 event_list { player_id: 0 [Event_MoveCard.ext] { card_id: 6 card_name: \"Goblin Rabblemaster\" start_player_id: 0 start_zone: \"hand\" position: 5 target_player_id: 0 target_zone: \"stack\" x: 0 y: 0 new_card_id: 6 face_down: false } } context { [Context_MoveCard.ext] { } } }"
"player_id: 0 [Event_MoveCard.ext] { card_id: 6 card_name: \"Goblin Rabblemaster\" start_player_id: 0 start_zone: \"hand\" position: 5 target_player_id: 0 target_zone: \"stack\" x: 0 y: 0 new_card_id: 6 face_down: false }"
QString::arg: Argument missing: "gino plays <i><a href=\"card://Goblin Rabblemaster\">Goblin Rabblemaster</a></i> from their hand." , 0
IN 94 "message_type: GAME_EVENT_CONTAINER game_event_container { game_id: 69 event_list { player_id: 0 [Event_MoveCard.ext] { card_id: 6 card_name: \"Goblin Rabblemaster\" start_player_id: 0 start_zone: \"stack\" position: -1 target_player_id: 1 target_zone: \"table\" x: 0 y: 0 new_card_id: 75 face_down: false } } event_list { player_id: 1 [Event_SetCardAttr.ext] { zone_name: \"table\" card_id: 75 attribute: AttrPT attr_value: \"2/2\" } } context { [Context_MoveCard.ext] { } } }"
"player_id: 0 [Event_MoveCard.ext] { card_id: 6 card_name: \"Goblin Rabblemaster\" start_player_id: 0 start_zone: \"stack\" position: -1 target_player_id: 1 target_zone: \"table\" x: 0 y: 0 new_card_id: 75 face_down: false }"
"player_id: 1 [Event_SetCardAttr.ext] { zone_name: \"table\" card_id: 75 attribute: AttrPT attr_value: \"2/2\" }"
```

</details>


I've created a "Arlinn Kord (emblem)" token with card_id = 75
Then, put a "Goblin Rabblemaster" on the stack, card_id = 6
Then moved the goblin from the stack to the opponent's table; the goblin received a new card id of 75, colliding with the token
The 2/2 PT has been assigned correctly to the Goblin (player_id: 1, zone_name: table, card_id: 75) instead of the token (player_id: 0, zone_name: table, card_id: 75) 

Note: this is a _server side_ change