### PR TITLE
Add "Random card from graveyard"

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -287,6 +287,15 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
 
     graveMenu = playerMenu->addMenu(QString());
     graveMenu->addAction(aViewGraveyard);
+
+    if (local) {
+        mRevealRandomGraveyardCard = graveMenu->addMenu(QString());
+        QAction *newAction = mRevealRandomGraveyardCard->addAction(QString());
+        newAction->setData(-1);
+        connect(newAction, SIGNAL(triggered()), this, SLOT(actRevealRandomGraveyardCard()));
+        allPlayersActions.append(newAction);
+        mRevealRandomGraveyardCard->addSeparator();
+    }
     grave->setMenu(graveMenu, aViewGraveyard);
 
     rfgMenu = playerMenu->addMenu(QString());
@@ -655,6 +664,7 @@ void Player::retranslateUi()
         handMenu->setTitle(tr("&Hand"));
         mRevealHand->setTitle(tr("&Reveal hand to..."));
         mRevealRandomHandCard->setTitle(tr("Reveal r&andom card to..."));
+        mRevealRandomGraveyardCard->setTitle(tr("Reveal random card to..."));
         sbMenu->setTitle(tr("&Sideboard"));
         libraryMenu->setTitle(tr("&Library"));
         countersMenu->setTitle(tr("&Counters"));
@@ -890,6 +900,18 @@ void Player::actOpenDeckInDeckEditor()
 void Player::actViewGraveyard()
 {
     static_cast<GameScene *>(scene())->toggleZoneView(this, "grave", -1);
+}
+
+void Player::actRevealRandomGraveyardCard()
+{
+    Command_RevealCards cmd;
+    QAction *action = static_cast<QAction *>(sender());
+    const int otherPlayerId = action->data().toInt();
+    if (otherPlayerId != -1)
+        cmd.set_player_id(otherPlayerId);
+    cmd.set_zone_name("grave");
+    cmd.set_card_id(-2);
+    sendGameCommand(cmd);
 }
 
 void Player::actViewRfg()

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -542,7 +542,7 @@ void Player::playerListActionTriggered()
         cmd.set_zone_name("hand");
     else if (menu == mRevealRandomHandCard) {
         cmd.set_zone_name("hand");
-        cmd.set_card_id(-2);
+        cmd.set_card_id(RANDOM_CARD_FROM_ZONE);
     } else
         return;
 
@@ -910,7 +910,7 @@ void Player::actRevealRandomGraveyardCard()
     if (otherPlayerId != -1)
         cmd.set_player_id(otherPlayerId);
     cmd.set_zone_name("grave");
-    cmd.set_card_id(-2);
+    cmd.set_card_id(RANDOM_CARD_FROM_ZONE);
     sendGameCommand(cmd);
 }
 

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -248,7 +248,8 @@ private:
 public:
     static const int counterAreaWidth = 55;
     enum CardMenuActionType { cmTap, cmUntap, cmDoesntUntap, cmFlip, cmPeek, cmClone, cmMoveToTopLibrary, cmMoveToBottomLibrary, cmMoveToHand, cmMoveToGraveyard, cmMoveToExile };
-    
+    enum CardsToReveal {RANDOM_CARD_FROM_ZONE = -2};
+
     enum { Type = typeOther };
     int type() const { return Type; }
     QRectF boundingRect() const;

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -127,6 +127,7 @@ public slots:
     void actViewTopCards();
     void actAlwaysRevealTopCard();
     void actViewGraveyard();
+    void actRevealRandomGraveyardCard();
     void actViewRfg();
     void actViewSideboard();
     
@@ -165,7 +166,7 @@ private slots:
 private:
     TabGame *game;
     QMenu *playerMenu, *handMenu, *moveHandMenu, *graveMenu, *moveGraveMenu, *rfgMenu, *moveRfgMenu, *libraryMenu, *sbMenu, *countersMenu, *sayMenu, *createPredefinedTokenMenu,
-        *mRevealLibrary, *mRevealTopCard, *mRevealHand, *mRevealRandomHandCard;
+        *mRevealLibrary, *mRevealTopCard, *mRevealHand, *mRevealRandomHandCard, *mRevealRandomGraveyardCard;
     QList<QMenu *> playerLists;
     QList<QAction *> allPlayersActions;
     QAction *aMoveHandToTopLibrary, *aMoveHandToBottomLibrary, *aMoveHandToGrave, *aMoveHandToRfg,


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2481 

## Short roundup of the initial problem
Couldn't randomly share a card from the graveyard, is a game issue for some cards in the card game MTG.

## What will change with this Pull Request?
Add ability to randomly share graveyard with others.
<img width="327" alt="screenshot 2017-04-26 00 47 51" src="https://cloud.githubusercontent.com/assets/7460172/25418454/ff91a02e-2a19-11e7-8b9c-29b2084900e5.png">

