### PR TITLE
Deck editor: clear button in search line edit; fix #2632

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -306,6 +306,9 @@ void TabDeckEditor::createCentralFrame()
 {
     searchEdit = new SearchLineEdit;
     searchEdit->setObjectName("searchEdit");
+#if QT_VERSION >= 0x050200
+    searchEdit->setClearButtonEnabled(true);
+#endif
 #if QT_VERSION >= 0x050300
     searchEdit->addAction(QPixmap("theme:icons/search"), QLineEdit::LeadingPosition);
 #endif


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2632

## Short roundup of the initial problem
People are lazy

## What will change with this Pull Request?
In the deck editor, inside the "search" lineedit a "clear" button will appear when there's some text.
Note: this requires Qt5.2