### PR TITLE
[Don't merge] Grey out unused options in player menu; fix #2640

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -330,6 +330,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
         aCreateAnotherToken->setEnabled(false);
 
         createPredefinedTokenMenu = new QMenu(QString());
+        createPredefinedTokenMenu->setEnabled(false);
 
         playerMenu->addSeparator();
         countersMenu = playerMenu->addMenu(QString());
@@ -346,6 +347,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
         initSayMenu();
 
         aCardMenu = new QAction(this);
+        aCardMenu->setEnabled(false);
         playerMenu->addSeparator();
         playerMenu->addAction(aCardMenu);
 
@@ -825,6 +827,7 @@ void Player::initSayMenu()
     sayMenu->clear();
 
     int count = settingsCache->messages().getCount();
+    sayMenu->setEnabled(count > 0);
 
     for (int i = 0; i < count; i++) {
         QAction *newAction = new QAction(settingsCache->messages().getMessageAt(i), this);
@@ -842,10 +845,15 @@ void Player::setDeck(const DeckLoader &_deck)
     aOpenDeckInDeckEditor->setEnabled(deck);
 
     createPredefinedTokenMenu->clear();
+    createPredefinedTokenMenu->setEnabled(false);
     predefinedTokens.clear();
     InnerDecklistNode *tokenZone = dynamic_cast<InnerDecklistNode *>(deck->getRoot()->findChild("tokens"));
 
     if (tokenZone)
+    {
+        if(tokenZone->size() > 0)
+            createPredefinedTokenMenu->setEnabled(true);
+
         for (int i = 0; i < tokenZone->size(); ++i) {
             const QString tokenName = tokenZone->at(i)->getName();
             predefinedTokens.append(tokenName);
@@ -856,6 +864,7 @@ void Player::setDeck(const DeckLoader &_deck)
             }
             connect(a, SIGNAL(triggered()), this, SLOT(actCreatePredefinedToken()));
         }
+    }
 }
 
 void Player::actViewLibrary()
@@ -2495,7 +2504,10 @@ void Player::addRelatedCardActions(const CardItem *card, QMenu *cardMenu) {
 void Player::setCardMenu(QMenu *menu)
 {
     if (aCardMenu)
+    {
+        aCardMenu->setEnabled(menu != nullptr);
         aCardMenu->setMenu(menu);
+    }
 }
 
 QMenu *Player::getCardMenu() const


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2640

## Short roundup of the initial problem
Some player menu options were active even if useless

## What will change with this Pull Request?
The following options will be greyed out:
 * "Say" when no macro has been set;
 * "Create predefined token" when the deck has no predefined token
 * "Card" when no card is currently selected
