### PR TITLE
Fix crash on logger; make log window modalless

### DIFF
--- a/cockatrice/src/dlg_viewlog.cpp
+++ b/cockatrice/src/dlg_viewlog.cpp
@@ -33,3 +33,8 @@ void DlgViewLog::logEntryAdded(QString message)
 {
     logArea->appendPlainText(message);
 }
+
+void DlgViewLog::closeEvent(QCloseEvent *event)
+{
+    logArea->clear();
+}

--- a/cockatrice/src/dlg_viewlog.cpp
+++ b/cockatrice/src/dlg_viewlog.cpp
@@ -34,7 +34,7 @@ void DlgViewLog::logEntryAdded(QString message)
     logArea->appendPlainText(message);
 }
 
-void DlgViewLog::closeEvent(QCloseEvent *event)
+void DlgViewLog::closeEvent(QCloseEvent * /* event */)
 {
     logArea->clear();
 }

--- a/cockatrice/src/dlg_viewlog.h
+++ b/cockatrice/src/dlg_viewlog.h
@@ -4,11 +4,14 @@
 #include <QDialog>
 
 class QPlainTextEdit;
+class QCloseEvent;
 
 class DlgViewLog : public QDialog {
 Q_OBJECT
 public:
     DlgViewLog(QWidget *parent);
+protected:
+    void closeEvent(QCloseEvent *event);
 private:
 	QPlainTextEdit *logArea;
 

--- a/cockatrice/src/logger.h
+++ b/cockatrice/src/logger.h
@@ -5,6 +5,7 @@
 #include <QFile>
 #include <QVector>
 #include <QString>
+#include <QMutex>
 
 class Logger : public QObject {
 Q_OBJECT
@@ -24,15 +25,17 @@ private:
     bool logToFileEnabled;
     QTextStream fileStream;
     QFile fileHandle;
-
     QList<QString> logBuffer;
+    QMutex mutex;
 public:
 	void logToFile(bool enabled);
-    void log(QtMsgType type, const QMessageLogContext &ctx, const QString &message);
+    void log(QtMsgType type, const QMessageLogContext &ctx, const QString message);
     QList<QString> getLogBuffer() { return logBuffer; }
 protected:
     void openLogfileSession();
     void closeLogfileSession();
+protected slots:
+    void internalLog(const QString message);
 signals:
     void logEntryAdded(QString message);
 };

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -314,8 +314,13 @@ void MainWindow::actUpdate()
 
 void MainWindow::actViewLog()
 {
-    DlgViewLog dlg(this);
-    dlg.exec();
+    if (logviewDialog == nullptr) {
+        logviewDialog = new DlgViewLog(this);
+    }
+
+    logviewDialog->show();
+    logviewDialog->raise();
+    logviewDialog->activateWindow();
 }
 
 void MainWindow::serverTimeout()
@@ -652,7 +657,7 @@ void MainWindow::createMenus()
 }
 
 MainWindow::MainWindow(QWidget *parent)
-    : QMainWindow(parent), localServer(0), bHasActivated(false), cardUpdateProcess(0)
+    : QMainWindow(parent), localServer(0), bHasActivated(false), cardUpdateProcess(0), logviewDialog(0)
 {
     connect(settingsCache, SIGNAL(pixmapCacheSizeChanged(int)), this, SLOT(pixmapCacheSizeChanged(int)));
     pixmapCacheSizeChanged(settingsCache->getPixmapCacheSize());

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -36,6 +36,7 @@ class LocalClient;
 class LocalServer;
 class ServerInfo_User;
 class QThread;
+class DlgViewLog;
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -125,6 +126,7 @@ private:
     QMessageBox serverShutdownMessageBox;
     QProcess * cardUpdateProcess;
 
+    DlgViewLog * logviewDialog;
 public:
     MainWindow(QWidget *parent = 0);
     ~MainWindow();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2297
- Fixes #2581

## Short roundup of the initial problem
Cockatrice's logger was not thread safe, while qDebug() messages were being printed from both the UI thread and worker threads. This caused random crashes on the logger's `QList<QString>` structure holding messages history.
Also, it was impossible to keep the debug log window open and move around in trice.

## What will change with this Pull Request?
 * Cockatrice should no more crash because of the logger.
 * The debug log window is no more modal, so you can open it and make you way inside trice while seeing realtime logs.
