### PR TITLE
remove qt5 tag

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,9 +77,9 @@ build_script:
     - c:\cygwin\bin\ls -l
     - ps: |
         $exe = dir -name *.exe
-        $new_name = $exe.Replace(".exe", "-${env:target_arch}_qt5.exe")
+        $new_name = $exe.Replace(".exe", "-${env:target_arch}.exe")
         Push-AppveyorArtifact $exe -FileName $new_name
-        $cmake_name = $exe.Replace(".exe", "-${env:target_arch}_qt5.cmake.txt")
+        $cmake_name = $exe.Replace(".exe", "-${env:target_arch}.cmake.txt")
         Push-AppveyorArtifact CMakeCache.txt -FileName $cmake_name
         $json = New-Object PSObject
         (New-Object PSObject | Add-Member -PassThru NoteProperty bin $new_name | Add-Member -PassThru NoteProperty cmake $cmake_name | Add-Member -PassThru NoteProperty commit $env:APPVEYOR_REPO_COMMIT) | ConvertTo-JSON | Out-File -FilePath "latest-$env:target_arch" -Encoding ASCII


### PR DESCRIPTION
## Short roundup of the initial problem
All autobuild files for windows on appveyor had a `_qt5` tag in the file.

## What will change with this Pull Request?
Since we don't use anything else besides qt5 and don't have this tag on other platforms --> remove.

<br>
Can somebody please double check that this isn't interfering with our updater checking for files?
