### PR TITLE
Allow placement below top X cards

### DIFF
--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -277,8 +277,10 @@ void MessageLogWidget::doMoveCard(LogMoveCard &attributes)
             finalStr = tr("%1 puts %2%3 on bottom of their library.");
         else if (attributes.newX == 0)
             finalStr = tr("%1 puts %2%3 on top of their library.");
-        else
-            finalStr = tr("%1 puts %2%3 into their library at position %4.");
+        else {
+            attributes.newX++;
+            finalStr = tr("%1 puts %2%3 into their library %4 cards from the top.");
+        }
     } else if (targetName == "sb")
         finalStr = tr("%1 moves %2%3 to sideboard.");
     else if (targetName == "stack") {

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -95,6 +95,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
       game(_parent),
       shortcutsActive(false),
       defaultNumberTopCards(1),
+      defaultNumberTopCardsToPlaceBelow(1),
       lastTokenDestroy(true),
       lastTokenTableRow(0),
       id(_id),
@@ -417,6 +418,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
     aMoveToTopLibrary->setData(cmMoveToTopLibrary);
     aMoveToBottomLibrary = new QAction(this);
     aMoveToBottomLibrary->setData(cmMoveToBottomLibrary);
+    aMoveToXfromTopOfLibrary = new QAction(this);
     aMoveToGraveyard = new QAction(this);
     aMoveToHand = new QAction(this);
     aMoveToHand->setData(cmMoveToHand);
@@ -425,6 +427,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
     aMoveToExile->setData(cmMoveToExile);
     connect(aMoveToTopLibrary, SIGNAL(triggered()), this, SLOT(cardMenuAction()));
     connect(aMoveToBottomLibrary, SIGNAL(triggered()), this, SLOT(cardMenuAction()));
+    connect(aMoveToXfromTopOfLibrary, SIGNAL(triggered()), this, SLOT(actMoveCardXCardsFromTop()));
     connect(aMoveToHand, SIGNAL(triggered()), this, SLOT(cardMenuAction()));
     connect(aMoveToGraveyard, SIGNAL(triggered()), this, SLOT(cardMenuAction()));
     connect(aMoveToExile, SIGNAL(triggered()), this, SLOT(cardMenuAction()));
@@ -723,6 +726,7 @@ void Player::retranslateUi()
     }
 
     aMoveToTopLibrary->setText(tr("&Top of library"));
+    aMoveToXfromTopOfLibrary->setText(tr("X cards from the top..."));
     aMoveToBottomLibrary->setText(tr("&Bottom of library"));
     aMoveToHand->setText(tr("&Hand"));
     aMoveToGraveyard->setText(tr("&Graveyard"));
@@ -1972,6 +1976,49 @@ bool Player::clearCardsToDelete()
     return true;
 }
 
+void Player::actMoveCardXCardsFromTop()
+{
+    bool ok;
+    int number = QInputDialog::getInt(0, tr("Place card X cards from top library"), tr("How many cards from the top of the deck should this card be placed:"), defaultNumberTopCardsToPlaceBelow, 1, 2000000000, 1, &ok);
+    number--;
+
+    if (!ok)
+        return;
+
+    defaultNumberTopCardsToPlaceBelow = number;
+
+    QList<QGraphicsItem *> sel = scene()->selectedItems();
+    QList<CardItem *> cardList;
+    while (!sel.isEmpty())
+        cardList.append(qgraphicsitem_cast<CardItem *>(sel.takeFirst()));
+
+    QList< const ::google::protobuf::Message * > commandList;
+    ListOfCardsToMove idList;
+    for (int i = 0; i < cardList.size(); ++i)
+        idList.add_card()->set_card_id(cardList[i]->getId());
+
+    if (cardList.isEmpty())
+        return;
+
+    int startPlayerId = cardList[0]->getZone()->getPlayer()->getId();
+    QString startZone = cardList[0]->getZone()->getName();
+
+    Command_MoveCard *cmd = new Command_MoveCard;
+    cmd->set_start_player_id(startPlayerId);
+    cmd->set_start_zone(startZone.toStdString());
+    cmd->mutable_cards_to_move()->CopyFrom(idList);
+    cmd->set_target_player_id(getId());
+    cmd->set_target_zone("deck");
+    cmd->set_x(number);
+    cmd->set_y(0);
+    commandList.append(cmd);
+
+    if (local)
+        sendGameCommand(prepareGameCommand(commandList));
+    else
+        game->sendGameCommand(prepareGameCommand(commandList));
+}
+
 void Player::cardMenuAction()
 {
     QAction *a = static_cast<QAction *>(sender());
@@ -2406,6 +2453,7 @@ void Player::updateCardMenu(const CardItem *card)
     else if (writeableCard) {
         if (moveMenu->isEmpty()) {
             moveMenu->addAction(aMoveToTopLibrary);
+            moveMenu->addAction(aMoveToXfromTopOfLibrary);
             moveMenu->addAction(aMoveToBottomLibrary);
             moveMenu->addSeparator();
             moveMenu->addAction(aMoveToHand);

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -145,6 +145,7 @@ private slots:
     void actCreateRelatedCard();
     void actCreateAllRelatedCards();
     void cardMenuAction();
+    void actMoveCardXCardsFromTop();
     void actCardCounterTrigger();
     void actAttach();
     void actUnattach();
@@ -182,10 +183,11 @@ private:
     QAction *aPlay, *aPlayFacedown,
         *aHide,
         *aTap, *aUntap, *aDoesntUntap, *aAttach, *aUnattach, *aDrawArrow, *aSetPT, *aIncP, *aDecP, *aIncT, *aDecT, *aIncPT, *aDecPT, *aSetAnnotation, *aFlip, *aPeek, *aClone,
-        *aMoveToTopLibrary, *aMoveToBottomLibrary, *aMoveToHand, *aMoveToGraveyard, *aMoveToExile;
+        *aMoveToTopLibrary, *aMoveToBottomLibrary, *aMoveToHand, *aMoveToGraveyard, *aMoveToExile, *aMoveToXfromTopOfLibrary;
 
     bool shortcutsActive;
     int defaultNumberTopCards;
+    int defaultNumberTopCardsToPlaceBelow;
     QString lastTokenName, lastTokenColor, lastTokenPT, lastTokenAnnotation;
     bool lastTokenDestroy;
     int lastTokenTableRow;

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -341,7 +341,7 @@ Response::ResponseCode Server_Player::moveCard(GameEventStorage &ges, Server_Car
     if (((targetzone->getType() != ServerInfo_Zone::PublicZone) || !targetzone->hasCoords()) && (startzone->getPlayer() != targetzone->getPlayer()))
         return Response::RespContextError;
     
-    if (!targetzone->hasCoords() && (x == -1))
+    if (!targetzone->hasCoords() && (x <= -1))
         x = targetzone->getCards().size();
     
     QList<QPair<Server_Card *, int> > cardsToMove;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2665 
**NOTE:** This PR also addresses an option in the server that if we sent it (-inf, -2] as X, it would crash the user. This just prevents a crash and is backwards compatible with prior client/servers.

## Short roundup of the initial problem
Couldn't place a card X cards from top easily into the deck.

## Screenshots
<img width="421" alt="screenshot 2017-04-27 20 27 07" src="https://cloud.githubusercontent.com/assets/7460172/25509566/f502571a-2b87-11e7-9812-4da2514230ed.png">
<img width="469" alt="screenshot 2017-04-27 20 27 17" src="https://cloud.githubusercontent.com/assets/7460172/25509567/f502e8d8-2b87-11e7-988b-cc7f42724831.png">
<img width="275" alt="screenshot 2017-04-27 20 27 23" src="https://cloud.githubusercontent.com/assets/7460172/25509565/f501ee24-2b87-11e7-90ec-0e5bce8bb8f1.png">
