### PR TITLE
update msg rework

### DIFF
--- a/cockatrice/src/dlg_update.cpp
+++ b/cockatrice/src/dlg_update.cpp
@@ -115,10 +115,10 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
         //If there's no need to update, tell them that. However we still allow them to run the
         //downloader themselves if there's a compatible build
         QMessageBox::information(this, tr("Cockatrice Update"),
-                 tr("Cockatrice is up to date!") + QString ("<br><br>")
-                 + tr("You are already running the latest version available in the chosen release channel.") + QString("<br>")
-                 + tr("Current version") + QString(": %2<br>")
-                 + tr("Current release channel") + QString(": %1").arg(settingsCache->getUpdateReleaseChannel()->getName().toUtf8()).arg(VERSION_STRING));
+                 tr("Cockatrice is up to date!") + "<br><br>"
+                 + tr("You are already running the latest version available in the chosen release channel.") + "<br>"
+                 + tr("Current version") + ": %2<br>"
+                 + tr("Current release channel") + ": %1").arg(settingsCache->getUpdateReleaseChannel()->getName().toUtf8()).arg(VERSION_STRING);
         return;
     }
 
@@ -129,21 +129,21 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
 
         int reply;
         reply = QMessageBox::question(this, tr("Update Available"),
-            tr("A new version of Cockatrice is available!") + QString("<br><br>")
-            + tr("New version") + QString(": %1<br>")
-            + tr("Publishing date") + QString(": %2 <a href=\"%3\">(") + tr("Changelog") + QString(")</a><br><br>") 
-            + tr("Do you want to update now?").arg(release->getName(), publishDate, release->getDescriptionUrl()),
+            tr("A new version of Cockatrice is available!") + "<br><br>"
+            + tr("New version") + ": %1<br>"
+            + tr("Publishing date") + ": %2 <a href=\"%3\">(" + tr("Changelog") + ")</a><br><br>"
+            + tr("Do you want to update now?")).arg(release->getName(), publishDate, release->getDescriptionUrl(),
             QMessageBox::Yes | QMessageBox::No);
 
         if (reply == QMessageBox::Yes)
             downloadUpdate();
     } else {
         QMessageBox::information(this, tr("Cockatrice Update"),
-            tr("A new version of Cockatrice is available!") + Qstring("<br><br>")
-            + tr("New version") + QString(": %1<br>")
-            + tr("Publishing date") + QString(": %2 <a href=\"%3\">(") + tr("Changelog") + QString(")</a><br><br>")
-            + tr("Unfortunately there are no download packages available for your operating system. \nYou may have to build from source yourself.") + QString("<br><br>")
-            + tr("Please check the download page manually and visit the wiki for instructions on compiling.").arg(release->getName(), publishDate, release->getDescriptionUrl()));
+            tr("A new version of Cockatrice is available!") + "<br><br>"
+            + tr("New version") + ": %1<br>"
+            + tr("Publishing date") + ": %2 <a href=\"%3\">(" + tr("Changelog") + ")</a><br><br>"
+            + tr("Unfortunately there are no download packages available for your operating system. \nYou may have to build from source yourself.") + "<br><br>"
+            + tr("Please check the download page manually and visit the wiki for instructions on compiling.")).arg(release->getName(), publishDate, release->getDescriptionUrl());
     }
 }
 
@@ -194,7 +194,7 @@ void DlgUpdate::downloadSuccessful(QUrl filepath) {
     } else {
         setLabel(tr("Error"));
         QMessageBox::critical(this, tr("Update Error"),
-            tr("Unable to open the installer.") + QString("<br><br>")
+            tr("Unable to open the installer.") + "<br><br>"
             + tr("You might be able to manually update by closing Cockatrice and running the installer downloaded to \n%1.").arg(filepath.toLocalFile()));
     }
 }

--- a/cockatrice/src/dlg_update.cpp
+++ b/cockatrice/src/dlg_update.cpp
@@ -117,8 +117,8 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
         QMessageBox::information(this, tr("Cockatrice Update"),
                  tr("Cockatrice is up to date!") + "<br><br>"
                  + tr("You are already running the latest version available in the chosen release channel.") + "<br>"
-                 + tr("Current version") + QString(": %1<br>").arg(settingsCache->getUpdateReleaseChannel()->getName().toUtf8())
-                 + tr("Current release channel") + QString(": %1").arg(VERSION_STRING));
+                 + tr("Current version") + QString(": %1<br>").arg(VERSION_STRING)
+                 + tr("Current release channel") + QString(": %1").arg(settingsCache->getUpdateReleaseChannel()->getName().toUtf8()));
         return;
     }
 
@@ -131,7 +131,7 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
         reply = QMessageBox::question(this, tr("Update Available"),
             tr("A new version of Cockatrice is available!") + "<br><br>"
             + tr("New version") + QString(": %1<br>").arg(release->getName())
-            + tr("Publishing date") + QString(": %2 <a href=\"%3\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") + ")</a><br><br>"
+            + tr("Publishing date") + QString(": %1 <a href=\"%2\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") + ")</a><br><br>"
             + tr("Do you want to update now?"),
             QMessageBox::Yes | QMessageBox::No);
 
@@ -140,10 +140,10 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
     } else {
         QMessageBox::information(this, tr("Cockatrice Update"),
             tr("A new version of Cockatrice is available!") + "<br><br>"
-            + tr("New version") + ": %1<br>"
-            + tr("Publishing date") + ": %2 <a href=\"%3\">(" + tr("Changelog") + ")</a><br><br>"
+            + tr("New version") + QString(": %1<br>").arg(release->getName())
+            + tr("Publishing date") + QString(": %1 <a href=\"%2\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") + ")</a><br><br>"
             + tr("Unfortunately there are no download packages available for your operating system. \nYou may have to build from source yourself.") + "<br><br>"
-            + tr("Please check the download page manually and visit the wiki for instructions on compiling.")).arg(release->getName(), publishDate, release->getDescriptionUrl());
+            + tr("Please check the download page manually and visit the wiki for instructions on compiling."));
     }
 }
 

--- a/cockatrice/src/dlg_update.cpp
+++ b/cockatrice/src/dlg_update.cpp
@@ -117,8 +117,8 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
         QMessageBox::information(this, tr("Cockatrice Update"),
                  tr("Cockatrice is up to date!") + "<br><br>"
                  + tr("You are already running the latest version available in the chosen release channel.") + "<br>"
-                 + tr("Current version") + ": %2<br>"
-                 + tr("Current release channel") + ": %1").arg(settingsCache->getUpdateReleaseChannel()->getName().toUtf8()).arg(VERSION_STRING);
+                 + tr("Current version") + QString(": %1<br>").arg(settingsCache->getUpdateReleaseChannel()->getName().toUtf8())
+                 + tr("Current release channel") + QString(": %1").arg(VERSION_STRING));
         return;
     }
 
@@ -130,9 +130,9 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
         int reply;
         reply = QMessageBox::question(this, tr("Update Available"),
             tr("A new version of Cockatrice is available!") + "<br><br>"
-            + tr("New version") + ": %1<br>"
-            + tr("Publishing date") + ": %2 <a href=\"%3\">(" + tr("Changelog") + ")</a><br><br>"
-            + tr("Do you want to update now?")).arg(release->getName(), publishDate, release->getDescriptionUrl(),
+            + tr("New version") + QString(": %1<br>").arg(release->getName())
+            + tr("Publishing date") + QString(": %2 <a href=\"%3\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") + ")</a><br><br>"
+            + tr("Do you want to update now?"),
             QMessageBox::Yes | QMessageBox::No);
 
         if (reply == QMessageBox::Yes)

--- a/cockatrice/src/dlg_update.cpp
+++ b/cockatrice/src/dlg_update.cpp
@@ -131,7 +131,7 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
         reply = QMessageBox::question(this, tr("Update Available"),
             tr("A new version of Cockatrice is available!") + "<br><br>"
             + "<b>" + tr("New version") + QString(":</b> %1<br>").arg(release->getName())
-            + "<b>" + tr("Publishing date") + QString(":</b> %1 <a href=\"%2\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") + ")</a><br><br>"
+            + "<b>" + tr("Published") + QString(":</b> %1 <a href=\"%2\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") + ")</a><br><br>"
             + tr("Do you want to update now?"),
             QMessageBox::Yes | QMessageBox::No);
 
@@ -141,7 +141,7 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
         QMessageBox::information(this, tr("Update Available"),
             tr("A new version of Cockatrice is available!") + "<br><br>"
             + "<b>" + tr("New version") + QString(":</b> %1<br>").arg(release->getName())
-            + "<b>" + tr("Publishing date") + QString(":</b> %1 <a href=\"%2\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") + ")</a><br><br>"
+            + "<b>" + tr("Published") + QString(":</b> %1 <a href=\"%2\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") + ")</a><br><br>"
             + tr("Unfortunately there are no download packages available for your operating system. \nYou may have to build from source yourself.") + "<br><br>"
             + tr("Please check the download page manually and visit the wiki for instructions on compiling."));
     }
@@ -173,14 +173,16 @@ void DlgUpdate::setLabel(QString newText) {
 }
 
 void DlgUpdate::updateCheckError(QString errorString) {
-    setLabel("Error");
-    QMessageBox::critical(this, tr("Update Error"), tr("An error occurred while checking for updates: ") + errorString);
+    setLabel(tr("Error"));
+    QMessageBox::critical(this, tr("Update Error"),
+        tr("An error occurred while checking for updates:") + QString(" ") + errorString);
 }
 
 void DlgUpdate::downloadError(QString errorString) {
     setLabel(tr("Error"));
     enableUpdateButton(true);
-    QMessageBox::critical(this, tr("Update Error"), tr("An error occurred while downloading an update: ") + errorString);
+    QMessageBox::critical(this, tr("Update Error"),
+        tr("An error occurred while downloading an update:") + QString(" ") + errorString);
 }
 
 void DlgUpdate::downloadSuccessful(QUrl filepath) {

--- a/cockatrice/src/dlg_update.cpp
+++ b/cockatrice/src/dlg_update.cpp
@@ -118,7 +118,7 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
                  tr("Cockatrice is up to date!") + "<br><br>"
                  + tr("You are already running the latest version available in the chosen release channel.") + "<br>"
                  + tr("Current version") + QString(": %1<br>").arg(VERSION_STRING)
-                 + tr("Current release channel") + QString(": %1").arg(settingsCache->getUpdateReleaseChannel()->getName().toUtf8()));
+                 + tr("Current release channel") + QString(": %1").arg(tr(settingsCache->getUpdateReleaseChannel()->getName().toUtf8())));
         return;
     }
 

--- a/cockatrice/src/dlg_update.cpp
+++ b/cockatrice/src/dlg_update.cpp
@@ -131,7 +131,7 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
         reply = QMessageBox::question(this, tr("Update Available"),
             tr("A new version of Cockatrice is available!") + "<br><br>"
             + "<b>" + tr("New version") + QString(":</b> %1<br>").arg(release->getName())
-            + "<b>" + tr("Published") + QString(":</b> %1 <a href=\"%2\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") + ")</a><br><br>"
+            + "<b>" + tr("Released") + QString(":</b> %1 <a href=\"%2\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") + ")</a><br><br>"
             + tr("Do you want to update now?"),
             QMessageBox::Yes | QMessageBox::No);
 
@@ -141,7 +141,7 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
         QMessageBox::information(this, tr("Update Available"),
             tr("A new version of Cockatrice is available!") + "<br><br>"
             + "<b>" + tr("New version") + QString(":</b> %1<br>").arg(release->getName())
-            + "<b>" + tr("Published") + QString(":</b> %1 <a href=\"%2\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") + ")</a><br><br>"
+            + "<b>" + tr("Released") + QString(":</b> %1 <a href=\"%2\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") + ")</a><br><br>"
             + tr("Unfortunately there are no download packages available for your operating system. \nYou may have to build from source yourself.") + "<br><br>"
             + tr("Please check the download page manually and visit the wiki for instructions on compiling."));
     }

--- a/cockatrice/src/dlg_update.cpp
+++ b/cockatrice/src/dlg_update.cpp
@@ -21,7 +21,7 @@ DlgUpdate::DlgUpdate(QWidget *parent) : QDialog(parent) {
     statusLabel = new QLabel(this);
     statusLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
     statusLabel->setWordWrap(true);
-    descriptionLabel = new QLabel(tr("Current release channel:") + " " + tr(settingsCache->getUpdateReleaseChannel()->getName().toUtf8()), this);
+    descriptionLabel = new QLabel(tr("Current release channel") + QString(": %1").arg(settingsCache->getUpdateReleaseChannel()->getName().toUtf8()), this);
     progress = new QProgressBar(this);
 
     buttonBox = new QDialogButtonBox(this);
@@ -87,7 +87,7 @@ void DlgUpdate::downloadUpdate() {
 
 void DlgUpdate::cancelDownload() {
     emit uDownloader->stopDownload();
-    setLabel("Download Canceled");
+    setLabel("Download canceled");
     addStopDownloadAndRemoveOthers(false);
     downloadProgressMade(0, 1);
 }
@@ -105,7 +105,7 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
 
     //Update the UI to say we've finished
     progress->setMaximum(100);
-    setLabel(tr("Finished checking for updates."));
+    setLabel(tr("Finished checking for updates"));
 
     //If there are no available builds, then they can't auto update.
     enableUpdateButton(isCompatible);
@@ -114,11 +114,11 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
     if (!needToUpdate) {
         //If there's no need to update, tell them that. However we still allow them to run the
         //downloader themselves if there's a compatible build
-        QMessageBox::information(this, tr("Cockatrice Update"),
+        QMessageBox::information(this, tr("No Update Available"),
                  tr("Cockatrice is up to date!") + "<br><br>"
                  + tr("You are already running the latest version available in the chosen release channel.") + "<br>"
-                 + tr("Current version") + QString(": %1<br>").arg(VERSION_STRING)
-                 + tr("Current release channel") + QString(": %1").arg(tr(settingsCache->getUpdateReleaseChannel()->getName().toUtf8())));
+                 + "<b>" + tr("Current version") + QString(":</b> %1<br>").arg(VERSION_STRING)
+                 + "<b>" + tr("Selected release channel") + QString(":</b> %1").arg(tr(settingsCache->getUpdateReleaseChannel()->getName().toUtf8())));
         return;
     }
 
@@ -130,18 +130,18 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
         int reply;
         reply = QMessageBox::question(this, tr("Update Available"),
             tr("A new version of Cockatrice is available!") + "<br><br>"
-            + tr("New version") + QString(": %1<br>").arg(release->getName())
-            + tr("Publishing date") + QString(": %1 <a href=\"%2\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") + ")</a><br><br>"
+            + "<b>" + tr("New version") + QString(":</b> %1<br>").arg(release->getName())
+            + "<b>" + tr("Publishing date") + QString(":</b> %1 <a href=\"%2\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") + ")</a><br><br>"
             + tr("Do you want to update now?"),
             QMessageBox::Yes | QMessageBox::No);
 
         if (reply == QMessageBox::Yes)
             downloadUpdate();
     } else {
-        QMessageBox::information(this, tr("Cockatrice Update"),
+        QMessageBox::information(this, tr("Update Available"),
             tr("A new version of Cockatrice is available!") + "<br><br>"
-            + tr("New version") + QString(": %1<br>").arg(release->getName())
-            + tr("Publishing date") + QString(": %1 <a href=\"%2\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") + ")</a><br><br>"
+            + "<b>" + tr("New version") + QString(":</b> %1<br>").arg(release->getName())
+            + "<b>" + tr("Publishing date") + QString(":</b> %1 <a href=\"%2\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") + ")</a><br><br>"
             + tr("Unfortunately there are no download packages available for your operating system. \nYou may have to build from source yourself.") + "<br><br>"
             + tr("Please check the download page manually and visit the wiki for instructions on compiling."));
     }
@@ -194,8 +194,9 @@ void DlgUpdate::downloadSuccessful(QUrl filepath) {
     } else {
         setLabel(tr("Error"));
         QMessageBox::critical(this, tr("Update Error"),
-            tr("Unable to open the installer.") + "<br><br>"
-            + tr("You might be able to manually update by closing Cockatrice and running the installer downloaded to \n%1.").arg(filepath.toLocalFile()));
+            tr("Cockatrice is unable to open the installer.") + "<br><br>"
+            + tr("Try to update manually by closing Cockatrice and running the installer.") + "<br>"
+            + tr("Download location") + QString(": %1").arg(filepath.toLocalFile()));
     }
 }
 

--- a/cockatrice/src/dlg_update.cpp
+++ b/cockatrice/src/dlg_update.cpp
@@ -21,7 +21,7 @@ DlgUpdate::DlgUpdate(QWidget *parent) : QDialog(parent) {
     statusLabel = new QLabel(this);
     statusLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
     statusLabel->setWordWrap(true);
-    descriptionLabel = new QLabel(tr("Current release channel") + QString(": %1").arg(settingsCache->getUpdateReleaseChannel()->getName().toUtf8()), this);
+    descriptionLabel = new QLabel(tr("Current release channel") + QString(": %1").arg(tr(settingsCache->getUpdateReleaseChannel()->getName().toUtf8())), this);
     progress = new QProgressBar(this);
 
     buttonBox = new QDialogButtonBox(this);

--- a/cockatrice/src/dlg_update.cpp
+++ b/cockatrice/src/dlg_update.cpp
@@ -53,8 +53,7 @@ DlgUpdate::DlgUpdate(QWidget *parent) : QDialog(parent) {
     if (!QSslSocket::supportsSsl()) {
         enableUpdateButton(false);
         QMessageBox::critical(this, tr("Error"),
-            tr("Cockatrice was not built with SSL support, so you cannot download updates automatically! "
-            "Please visit the download page to update manually."));
+            tr("Cockatrice was not built with SSL support, therefore you cannot download updates automatically! \nPlease visit the download page to update manually."));
     }
 
     //Initialize the checker and downloader class
@@ -115,8 +114,11 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
     if (!needToUpdate) {
         //If there's no need to update, tell them that. However we still allow them to run the
         //downloader themselves if there's a compatible build
-        QMessageBox::information(this, tr("Cockatrice Update"), tr("Your version of Cockatrice is up to date."));
-        setLabel(tr("You are already running the latest %1 release - %2").arg(tr(settingsCache->getUpdateReleaseChannel()->getName().toUtf8())).arg(VERSION_STRING));
+        QMessageBox::information(this, tr("Cockatrice Update"),
+                 tr("Cockatrice is up to date!") + QString ("<br><br>")
+                 + tr("You are already running the latest version available in the chosen release channel.") + QString("<br>")
+                 + tr("Current version") + QString(": %2<br>")
+                 + tr("Current release channel") + QString(": %1").arg(settingsCache->getUpdateReleaseChannel()->getName().toUtf8()).arg(VERSION_STRING));
         return;
     }
 
@@ -126,20 +128,22 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
         updateUrl = release->getDownloadUrl();
 
         int reply;
-        reply = QMessageBox::question(this, "Update Available",
-            tr("A new version is available:<br/>%1<br/>published on %2 ."
-            "<br/>More informations are available on the <a href=\"%3\">release changelog</a>"
-            "<br/>Do you want to update now?").arg(release->getName(), publishDate, release->getDescriptionUrl()),
+        reply = QMessageBox::question(this, tr("Update Available"),
+            tr("A new version of Cockatrice is available!") + QString("<br><br>")
+            + tr("New version") + QString(": %1<br>")
+            + tr("Publishing date") + QString(": %2 <a href=\"%3\">(") + tr("Changelog") + QString(")</a><br><br>") 
+            + tr("Do you want to update now?").arg(release->getName(), publishDate, release->getDescriptionUrl()),
             QMessageBox::Yes | QMessageBox::No);
 
         if (reply == QMessageBox::Yes)
             downloadUpdate();
     } else {
         QMessageBox::information(this, tr("Cockatrice Update"),
-            tr("A new version is available:<br/>%1<br/>published on %2 ."
-            "<br/>More informations are available on the <a href=\"%3\">release changelog</a>"
-            "<br/>Unfortunately there are no packages available for your operating system. "
-            "You may have to use a developer build or build from source yourself. Please visit the download page.").arg(release->getName(), publishDate, release->getDescriptionUrl()));
+            tr("A new version of Cockatrice is available!") + Qstring("<br><br>")
+            + tr("New version") + QString(": %1<br>")
+            + tr("Publishing date") + QString(": %2 <a href=\"%3\">(") + tr("Changelog") + QString(")</a><br><br>")
+            + tr("Unfortunately there are no download packages available for your operating system. \nYou may have to build from source yourself.") + QString("<br><br>")
+            + tr("Please check the download page manually and visit the wiki for instructions on compiling.").arg(release->getName(), publishDate, release->getDescriptionUrl()));
     }
 }
 
@@ -190,7 +194,8 @@ void DlgUpdate::downloadSuccessful(QUrl filepath) {
     } else {
         setLabel(tr("Error"));
         QMessageBox::critical(this, tr("Update Error"),
-            tr("Unable to open the installer. You might be able to manually update by closing Cockatrice and running the installer at %1.").arg(filepath.toLocalFile()));
+            tr("Unable to open the installer.") + QString("<br><br>")
+            + tr("You might be able to manually update by closing Cockatrice and running the installer downloaded to \n%1.").arg(filepath.toLocalFile()));
     }
 }
 


### PR DESCRIPTION
## Short round-up of the initial problem
- some strings used to be messed up in transifex:
![tx strings](https://cloud.githubusercontent.com/assets/9874850/25558030/bd6d85d4-2d1e-11e7-890f-3e7922173d21.png)
- https://github.com/Cockatrice/Cockatrice/pull/2504/files#diff-68c33782ee685fda6ebc3cc66405a16aR114 was not displayed (Label inside QMessageBox)

## What will change with this Pull Request?
- added missing tr() string
- split content and formatting (get rid of translation strings with html tags, formatting and arguments),
modularized the strings into smaller parts as a result
- rephrased messages for better visibility and readability,
tried to uniform messages and still stress the important parts for the user

`\n` is no problem and gets actually recognized as linebreak by transifex. It also tells users to use `Return` in this spot.

## Screenshots
Some example screenshots:
- before:
![old-available](https://cloud.githubusercontent.com/assets/9874850/25565238/d94dc6e2-2dc3-11e7-97be-d60323932e57.png)
after (development snapshots):
![new-version](https://cloud.githubusercontent.com/assets/9874850/25565257/2c88e814-2dc4-11e7-9358-b17718456653.png)
after (stable releases):
![new-available](https://cloud.githubusercontent.com/assets/9874850/25565232/b6fec438-2dc3-11e7-9890-d54576caa819.png)
