### PR TITLE
extend updater description in menu

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -550,7 +550,7 @@ void MainWindow::retranslateUi()
     aEditTokens->setText(tr("Edit &tokens..."));
 
     aAbout->setText(tr("&About Cockatrice"));
-    aUpdate->setText(tr("Check for Updates"));
+    aUpdate->setText(tr("Check for Client Updates"));
     aViewLog->setText(tr("View &debug log"));
     helpMenu->setTitle(tr("&Help"));
     aCheckCardUpdates->setText(tr("Check for card updates..."));


### PR DESCRIPTION
## Short roundup of the initial problem
The menu label was unclear. If people read they need to update to get new cards they might think this is the way to go instead running the card updater (Oracle)
https://www.reddit.com/r/Cockatrice/comments/684yeo/i_do_not_get_most_ahmonket_cards_but_it_says_i_am/

@tritoch mentioned it in gitter and I never thought about that potential confusion, but he is right.

## What will change with this Pull Request?
- Clearer label: `Check for Client Updates` (uniform to "check for card updates")