### PR TITLE
Remove unneeded debug 

### DIFF
--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -283,7 +283,7 @@ void RemoteClient::readData()
 #ifdef QT_DEBUG
         qDebug() << "IN" << messageLength << QString::fromStdString(newServerMessage.ShortDebugString());
 #endif
-        qDebug() << inputBuffer.remove(0, messageLength);
+        inputBuffer.remove(0, messageLength);
         messageInProgress = false;
 
         processProtocolItem(newServerMessage);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2682

## Short roundup of the initial problem
A debug call was introduced in https://github.com/Cockatrice/Cockatrice/commit/0da2bdd7aab5005efe9a7801fac4e9bd59a0bf75#diff-27cc8777cc84eeab15dc3940b46e569fR286
This causes a lot of noise in the debug log, mainly binary protobuf data receved from the network

## What will change with this Pull Request?
Removed unneeded debug call
