### PR TITLE
Removed server tab icons

### DIFF
--- a/cockatrice/src/tab.h
+++ b/cockatrice/src/tab.h
@@ -33,6 +33,7 @@ public:
     virtual void retranslateUi() = 0;
     virtual void closeRequest() { }
     virtual void tabActivated() { }
+    virtual bool updateIcon() { return true; }
 };
 
 #endif

--- a/cockatrice/src/tab_server.h
+++ b/cockatrice/src/tab_server.h
@@ -51,6 +51,7 @@ public:
     TabServer(TabSupervisor *_tabSupervisor, AbstractClient *_client, QWidget *parent = 0);
     void retranslateUi();
     QString getTabText() const { return tr("Server"); }
+    bool updateIcon() { return false; }
 };
 
 #endif

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -91,7 +91,6 @@ TabSupervisor::TabSupervisor(AbstractClient *_client, QWidget *parent)
     connect(client, SIGNAL(gameEventContainerReceived(const GameEventContainer &)), this, SLOT(processGameEventContainer(const GameEventContainer &)));
     connect(client, SIGNAL(gameJoinedEventReceived(const Event_GameJoined &)), this, SLOT(gameJoined(const Event_GameJoined &)));
     connect(client, SIGNAL(userMessageEventReceived(const Event_UserMessage &)), this, SLOT(processUserMessageEvent(const Event_UserMessage &)));
-    connect(client, SIGNAL(maxPingTime(int, int)), this, SLOT(updatePingTime(int, int)));
     connect(client, SIGNAL(notifyUserEventReceived(const Event_NotifyUser &)), this, SLOT(processNotifyUserEvent(const Event_NotifyUser &)));
     
     retranslateUi();
@@ -205,8 +204,6 @@ void TabSupervisor::start(const ServerInfo_User &_userInfo) {
                                                                                const QString &)));
     myAddTab(tabUserLists);
 
-    updatePingTime(0, -1);
-
     if (userInfo->user_level() & ServerInfo_User::IsRegistered) {
         tabDeckStorage = new TabDeckStorage(this, client);
         connect(tabDeckStorage, SIGNAL(openDeckEditor(
@@ -301,16 +298,6 @@ void TabSupervisor::stop()
 
     delete userInfo;
     userInfo = 0;
-}
-
-void TabSupervisor::updatePingTime(int value, int max)
-{
-    if (!tabServer)
-        return;
-    if (tabServer->getContentsChanged())
-        return;
-    
-    setTabIcon(indexOf(tabServer), QIcon(PingPixmapGenerator::generatePixmap(15, value, max)));
 }
 
 void TabSupervisor::closeButtonPressed()
@@ -489,7 +476,9 @@ void TabSupervisor::tabUserEvent(bool globalEvent)
     Tab *tab = static_cast<Tab *>(sender());
     if (tab != currentWidget()) {
         tab->setContentsChanged(true);
-        setTabIcon(indexOf(tab), QPixmap("theme:icons/tab_changed"));
+        if (tab->updateIcon()) {
+            setTabIcon(indexOf(tab), QPixmap("theme:icons/tab_changed"));
+        }
     }
     if (globalEvent && settingsCache->getNotificationsEnabled())
         QApplication::alert(this);

--- a/cockatrice/src/tab_supervisor.h
+++ b/cockatrice/src/tab_supervisor.h
@@ -96,7 +96,6 @@ public slots:
 private slots:
     void closeButtonPressed();
     void updateCurrent(int index);
-    void updatePingTime(int value, int max);
     void gameJoined(const Event_GameJoined &event);
     void localGameJoined(const Event_GameJoined &event);
     void gameLeft(TabGame *tab);


### PR DESCRIPTION
## Short roundup of the initial problem
The `Server` tab Icon has 2 potential icons. A green dot that is ping/server status(?), and a blue info icon.
From my use, and I assume a large majority of others, I rarely click on the server tab, so it will remain as the info icon.
This PR removes the clutter. Its annoying to constantly have an alert icon when its not needed.

Extra note: When you remove _only_ the info icon, the ping will be a black dot (`updatePingTime(0, -1);`).
It will _only_ change to green if you click on the tab, making me this if this is even working at all.
Further reason I feel that this is not needed.

## What will change with this Pull Request?
- Adds a `virtual` function to the `Tab` class to determine if is should update the tab icon
- Remove the green ping dot and info icon from the server tab
