### PR TITLE
Prevent emitting initial server message event

### DIFF
--- a/cockatrice/src/tab_server.cpp
+++ b/cockatrice/src/tab_server.cpp
@@ -168,7 +168,12 @@ void TabServer::retranslateUi()
 void TabServer::processServerMessageEvent(const Event_ServerMessage &event)
 {
     serverInfoBox->setHtml(QString::fromStdString(event.message()));
-    emit userEvent();
+    if (shouldEmitUpdate) {
+        // prevent the initial server message from taking attention from ping icon
+        emit userEvent();
+    } else {
+        shouldEmitUpdate = true;
+    }
 }
 
 void TabServer::joinRoom(int id, bool setCurrent)

--- a/cockatrice/src/tab_server.h
+++ b/cockatrice/src/tab_server.h
@@ -47,6 +47,7 @@ private:
     AbstractClient *client;
     RoomSelector *roomSelector;
     QTextBrowser *serverInfoBox;
+    bool shouldEmitUpdate = false;
 public:
     TabServer(TabSupervisor *_tabSupervisor, AbstractClient *_client, QWidget *parent = 0);
     void retranslateUi();


### PR DESCRIPTION
## Related Ticket(s)
- #2687

## Short roundup of the initial problem
When connecting to the server, the `i` will always show and cover the ping status.
To see the ping status, you have to click on the tab to remove the `i`.
The reason the `i` shows is because the client receives the server tab message.

## What will change with this Pull Request?
- Initial message will not emit the `i`
