### PR TITLE
[WIP] Add ability to place cards at bottom of library randomly

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -418,6 +418,8 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
     aMoveToTopLibrary->setData(cmMoveToTopLibrary);
     aMoveToBottomLibrary = new QAction(this);
     aMoveToBottomLibrary->setData(cmMoveToBottomLibrary);
+    aMoveToBottomLibraryRandomly = new QAction(this);
+    aMoveToBottomLibraryRandomly->setData(cmMoveToBottomLibraryRandomly);
     aMoveToXfromTopOfLibrary = new QAction(this);
     aMoveToGraveyard = new QAction(this);
     aMoveToHand = new QAction(this);
@@ -427,6 +429,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
     aMoveToExile->setData(cmMoveToExile);
     connect(aMoveToTopLibrary, SIGNAL(triggered()), this, SLOT(cardMenuAction()));
     connect(aMoveToBottomLibrary, SIGNAL(triggered()), this, SLOT(cardMenuAction()));
+    connect(aMoveToBottomLibraryRandomly, SIGNAL(triggered()), this, SLOT(cardMenuAction()));
     connect(aMoveToXfromTopOfLibrary, SIGNAL(triggered()), this, SLOT(actMoveCardXCardsFromTop()));
     connect(aMoveToHand, SIGNAL(triggered()), this, SLOT(cardMenuAction()));
     connect(aMoveToGraveyard, SIGNAL(triggered()), this, SLOT(cardMenuAction()));
@@ -728,6 +731,7 @@ void Player::retranslateUi()
     aMoveToTopLibrary->setText(tr("&Top of library"));
     aMoveToXfromTopOfLibrary->setText(tr("X cards from the top of library..."));
     aMoveToBottomLibrary->setText(tr("&Bottom of library"));
+    aMoveToBottomLibraryRandomly->setText(tr("Bottom of library randomly"));
     aMoveToHand->setText(tr("&Hand"));
     aMoveToGraveyard->setText(tr("&Graveyard"));
     aMoveToExile->setText(tr("&Exile"));
@@ -2125,6 +2129,24 @@ void Player::cardMenuAction()
                 commandList.append(cmd);
                 break;
             }
+            case cmMoveToBottomLibraryRandomly: {
+                Command_MoveCard *cmd = new Command_MoveCard;
+                cmd->set_start_player_id(startPlayerId);
+                cmd->set_start_zone(startZone.toStdString());
+
+                idList.clear_card();
+                std::random_shuffle(cardList.begin(), cardList.end());
+                for (int i = 0; i < cardList.size(); ++i)
+                    idList.add_card()->set_card_id(cardList[i]->getId());
+
+                cmd->mutable_cards_to_move()->CopyFrom(idList);
+                cmd->set_target_player_id(getId());
+                cmd->set_target_zone("deck");
+                cmd->set_x(-1);
+                cmd->set_y(0);
+                commandList.append(cmd);
+                break;
+            }
             case cmMoveToHand: {
                 Command_MoveCard *cmd = new Command_MoveCard;
                 cmd->set_start_player_id(startPlayerId);
@@ -2455,6 +2477,7 @@ void Player::updateCardMenu(const CardItem *card)
             moveMenu->addAction(aMoveToTopLibrary);
             moveMenu->addAction(aMoveToXfromTopOfLibrary);
             moveMenu->addAction(aMoveToBottomLibrary);
+            moveMenu->addAction(aMoveToBottomLibraryRandomly);
             moveMenu->addSeparator();
             moveMenu->addAction(aMoveToHand);
             moveMenu->addSeparator();

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -183,7 +183,7 @@ private:
     QAction *aPlay, *aPlayFacedown,
         *aHide,
         *aTap, *aUntap, *aDoesntUntap, *aAttach, *aUnattach, *aDrawArrow, *aSetPT, *aIncP, *aDecP, *aIncT, *aDecT, *aIncPT, *aDecPT, *aSetAnnotation, *aFlip, *aPeek, *aClone,
-        *aMoveToTopLibrary, *aMoveToBottomLibrary, *aMoveToHand, *aMoveToGraveyard, *aMoveToExile, *aMoveToXfromTopOfLibrary;
+        *aMoveToTopLibrary, *aMoveToBottomLibrary, *aMoveToBottomLibraryRandomly, *aMoveToHand, *aMoveToGraveyard, *aMoveToExile, *aMoveToXfromTopOfLibrary;
 
     bool shortcutsActive;
     int defaultNumberTopCards;
@@ -249,7 +249,7 @@ private:
     void eventChangeZoneProperties(const Event_ChangeZoneProperties &event);
 public:
     static const int counterAreaWidth = 55;
-    enum CardMenuActionType { cmTap, cmUntap, cmDoesntUntap, cmFlip, cmPeek, cmClone, cmMoveToTopLibrary, cmMoveToBottomLibrary, cmMoveToHand, cmMoveToGraveyard, cmMoveToExile };
+    enum CardMenuActionType { cmTap, cmUntap, cmDoesntUntap, cmFlip, cmPeek, cmClone, cmMoveToTopLibrary, cmMoveToBottomLibrary, cmMoveToBottomLibraryRandomly, cmMoveToHand, cmMoveToGraveyard, cmMoveToExile };
     enum CardsToReveal {RANDOM_CARD_FROM_ZONE = -2};
 
     enum { Type = typeOther };


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #673 

## Short roundup of the initial problem
Cascade wouldn't work as it should as you cannot randomly set to bottom.

## What will change with this Pull Request?
Allow cards to be randomized before being placed back into the deck.
*NOTE:* Currently the log will tell you the order the cards were placed in, even though it is randomized. I couldn't figure out how to tell the server to "forget" the names of the cards before they get placed back into the deck.


## Screenshots
<img width="468" alt="screenshot 2017-05-05 23 53 37" src="https://cloud.githubusercontent.com/assets/7460172/25769679/18d48002-31ee-11e7-9e4f-11e0bcfba962.png">
<img width="292" alt="screenshot 2017-05-05 23 53 45" src="https://cloud.githubusercontent.com/assets/7460172/25769680/18d5afc2-31ee-11e7-891b-91855759face.png">

