### PR TITLE
Moved load buttons

### DIFF
--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -125,8 +125,8 @@ DeckViewContainer::DeckViewContainer(int _playerId, TabGame *parent)
     connect(deckView, SIGNAL(sideboardPlanChanged()), this, SLOT(sideboardPlanChanged()));
 
     QVBoxLayout *deckViewLayout = new QVBoxLayout;
-    deckViewLayout->addLayout(buttonHBox);
     deckViewLayout->addWidget(deckView);
+    deckViewLayout->addLayout(buttonHBox);
     deckViewLayout->setContentsMargins(0, 0, 0, 0);
     setLayout(deckViewLayout);
 


### PR DESCRIPTION
## Description of feature
I have some custom branches with some tweaks that I like.
This is a simple one, it moves the load deck buttons to the bottom of the screen.
Lifts the deck viewer up. Can be argued its more comfortable to look at.

## What will change with this Pull Request?
- Screen layout for deck view

## Screenshots
<img width="1147" alt="screen shot 2017-05-06 at 09 36 48" src="https://cloud.githubusercontent.com/assets/26419373/25770801/91697940-323f-11e7-8ed1-31760a8839ff.png">
