### PR TITLE
cmake - bump version number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(PROJECT_NAME "Cockatrice")
 # Can be overriden by git tags, see cmake/getversion.cmake
 set(PROJECT_VERSION_MAJOR "2")
 set(PROJECT_VERSION_MINOR "3")
-set(PROJECT_VERSION_PATCH "17")
+set(PROJECT_VERSION_PATCH "18")
 
 # Default to "Release" build type
 # User-provided value for CMAKE_BUILD_TYPE must be checked before the PROJECT() call


### PR DESCRIPTION
## Related Ticket(s)
- related #2613

## Short roundup of the initial problem
After Zach released new main version (2.3.17) and all files had been uploaded he forgot to bump the `PROJECT VERSION` in cmake to 2.3.18

## What will change with this Pull Request?
- `PROJECT_VERSION_PATCH "17"` --> 18
now all pr's or local development correctly build with the right new version prefix again