### PR TITLE
updated badges (gitter+licence)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We offer downloads for all full releases (recommended) and the latest developmen
 
 
 
-# Get Involved [![Gitter chat](https://badges.gitter.im/Cockatrice/Cockatrice.png)](https://gitter.im/Cockatrice/Cockatrice)
+# Get Involved [![Gitter Chat](https://img.shields.io/gitter/room/Cockatrice/Cockatrice.svg)](https://gitter.im/Cockatrice/Cockatrice)
 
 [Chat](https://gitter.im/Cockatrice/Cockatrice) with the Cockatrice developers on Gitter. Come here to talk about the application, features, or just to hang out. For support regarding specific servers, please contact that server's admin or forum for support rather than asking here.<br>
 
@@ -41,6 +41,7 @@ We try to be very responsive to new issues. We'll try to give you advice on how 
 
 
 # Community Resources
+
 - [Cockatrice Official Site](https://cockatrice.github.io)
 - [Cockatrice Official Wiki](https://github.com/Cockatrice/Cockatrice/wiki)
 - [reddit r/Cockatrice](https://reddit.com/r/cockatrice)
@@ -117,7 +118,7 @@ Please note that running this command will expose the TCP port 4747 of the docke
 More infos on how to use Servatrice with Docker can be found in our [wiki](https://github.com/Cockatrice/Cockatrice/wiki/Setting-up-Servatrice#using-docker).
 
 
-# License [![GPLv2 License](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://github.com/Cockatrice/Cockatrice/blob/master/COPYING)
+# License [![GPLv2 License](https://img.shields.io/github/license/Cockatrice/Cockatrice.svg)](https://github.com/Cockatrice/Cockatrice/blob/master/COPYING)
 
 Cockatrice is free software, licensed under the [GPLv2](https://github.com/Cockatrice/Cockatrice/blob/master/COPYING).
 


### PR DESCRIPTION
## What will change with this Pull Request?
- new high-quality svg badge for gitter
- official licence badge, no custom made one
<br>

See live in action [here](https://github.com/Cockatrice/Cockatrice/tree/tooomm-hq_badges#get-involved-)!
<br>

Just found out that gitter also offers their own old badge as svg.
Which one do we prefer?
- old: [![](https://badges.gitter.im/Cockatrice/Cockatrice.png)]()
- old as svg: [![](https://badges.gitter.im/Cockatrice/Cockatrice.svg)]()
- new version: [![](https://img.shields.io/gitter/room/Cockatrice/Cockatrice.svg)]()