### PR TITLE
Fix room chat history

### DIFF
--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -297,7 +297,7 @@ bool Servatrice::initServer()
             while (query2->next())
                 gameTypes.append(query2->value(0).toString());
                 addRoom(new Server_Room(query->value(0).toInt(),
-                                    query->value(6).toInt(),
+                                    query->value(7).toInt(),
                                     query->value(1).toString(),
                                     query->value(2).toString(),
                                     query->value(3).toString().toLower(),


### PR DESCRIPTION
Looks like an addition to the table shifted things.  We probably  should look into some how use the actual column names (if it can be done).  But for now this should fix the server room chat history.

## Related Ticket(s)
- Fixes broken chat history in rooms (not sure if there is a ticket number)

## Short roundup of the initial problem
When users would join rooms previous chat was presented, this was broke by a change in the table / room layout.

