### PR TITLE
Format insensitive cards for loader & Blank Delim for sideboard

### DIFF
--- a/cockatrice/src/chatview/chatview.cpp
+++ b/cockatrice/src/chatview/chatview.cpp
@@ -93,7 +93,7 @@ void ChatView::appendCardTag(QTextCursor &cursor, const QString &cardName)
     anchorFormat.setAnchor(true);
     anchorFormat.setAnchorHref("card://" + cardName);
     anchorFormat.setFontItalic(true);
-    
+
     cursor.setCharFormat(anchorFormat);
     cursor.insertText(cardName);
     cursor.setCharFormat(oldFormat);

--- a/cockatrice/src/deck_loader.cpp
+++ b/cockatrice/src/deck_loader.cpp
@@ -200,9 +200,19 @@ void DeckLoader::saveToStream_DeckZoneCards(QTextStream &out, const InnerDecklis
 QString DeckLoader::getCardZoneFromName(QString cardName, QString currentZoneName)
 {
     CardInfo *card = db->getCard(cardName);
-    if(card && card->getIsToken())
+    if (card && card->getIsToken())
         return DECK_ZONE_TOKENS;
 
     return currentZoneName;
 }
 
+QString DeckLoader::getCompleteCardName(const QString cardName) const
+{
+    if (db) {
+        CardInfo *temp = db->getCardBySimpleName(cardName);
+        if (temp)
+            return temp->getName();
+    }
+
+    return cardName;
+}

--- a/cockatrice/src/deck_loader.h
+++ b/cockatrice/src/deck_loader.h
@@ -37,6 +37,7 @@ protected:
     void saveToStream_DeckZone(QTextStream &out, const InnerDecklistNode *zoneNode);
     void saveToStream_DeckZoneCards(QTextStream &out, const InnerDecklistNode *zoneNode, QList <DecklistCardNode*> cards);
     virtual QString getCardZoneFromName(QString cardName, QString currentZoneName);
+    virtual QString getCompleteCardName(const QString cardName) const;
 };
 
 #endif

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -498,18 +498,18 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
     }
 
     /*
-     * Removes all blank lines at end of inputs
-     * Ex: ("Card1", "Card2", "", "", "") => ("Card1", "Card2")
+     * Removes  blank line at end of inputs (if applicable)
+     * Ex: ("Card1", "Card2", "") => ("Card1", "Card2")
+     * NOTE: Any duplicates were taken care of above, so there can be
+     * at most one blank line at the very end
      */
-     for (auto iter = inputs.end()-1; iter > inputs.begin(); iter--)
-     {
-         if (*iter == QString())
-             inputs.erase(iter);
-         else
-             break;
-     }
+    if (inputs.last() == QString())
+    {
+        blankLines--;
+        inputs.erase(inputs.end() - 1);
+    }
 
-    // If "Sideboard" line appears, then blank lines mean nothing
+    // If "Sideboard" line appears in inputs, then blank lines mean nothing
     if (inputs.contains("sideboard"))
         blankLines = 2;
 
@@ -537,7 +537,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
         // also indicate the start of the sideboard.
         if ((line.isEmpty() && blankLines == 1) || line.startsWith("sideboard")) {
             inSideboard = true;
-            continue;
+            continue; // The line isn't actually a card
         }
 
         isSideboard = inSideboard;
@@ -569,7 +569,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
         bool ok;
         int number = line.left(i).toInt(&ok);
         if (!ok)
-            continue;
+            number = 1; // If input is "cardName" assume it's "1x cardName"
 
         QString cardName = line.mid(cardNameStart);
 

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -503,7 +503,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
      * NOTE: Any duplicates were taken care of above, so there can be
      * at most one blank line at the very end
      */
-    if (inputs.last() == QString())
+    if (inputs.size() && inputs.last() == QString())
     {
         blankLines--;
         inputs.erase(inputs.end() - 1);
@@ -546,6 +546,9 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
             line = line.mid(3).trimmed();
             isSideboard = true;
         }
+
+        if (line.trimmed().isEmpty())
+            continue; // The line was "    " instead of "\n"
 
         // Filter out MWS edition symbols and basic land extras
         QRegExp rx("\\[.*\\]");

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -483,7 +483,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
          * This will also concise multiple blank lines in a row to just one blank
          * Ex: ("Card1", "Card2", "", "", "", "Card3") => ("Card1", "Card2", "", "Card3")
          */
-        if (line == QString()) {
+        if (line.isEmpty()) {
             if (priorEntryIsBlank || isAtBeginning)
                 continue;
 
@@ -503,7 +503,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
      * NOTE: Any duplicates were taken care of above, so there can be
      * at most one blank line at the very end
      */
-    if (inputs.size() && inputs.last() == QString())
+    if (inputs.size() && inputs.last().isEmpty())
     {
         blankLines--;
         inputs.erase(inputs.end() - 1);
@@ -515,10 +515,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
 
     bool inSideboard = false, titleFound = false, isSideboard;
     int okRows = 0;
-    for (auto iter = inputs.begin(); iter != inputs.end(); iter++)
-    {
-        QString line = *iter;
-
+    foreach(QString line, inputs) {
         // This is a comment line, ignore it
         if (line.startsWith("//"))
         {
@@ -542,7 +539,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
 
         isSideboard = inSideboard;
 
-        if (line.startsWith("SB:", Qt::CaseInsensitive)) {
+        if (line.startsWith("sb:")) {
             line = line.mid(3).trimmed();
             isSideboard = true;
         }
@@ -559,7 +556,6 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
         // Filter out post card name editions
         rx.setPattern("\\|.*$");
         line.remove(rx);
-        line = line.simplified().toLower();
 
         int i = line.indexOf(' ');
         int cardNameStart = i + 1;

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -3,8 +3,6 @@
 #include <QVariant>
 #include <QCryptographicHash>
 #include <QDebug>
-#include <QVector>
-#include <algorithm>
 #include "decklist.h"
 
 SideboardPlan::SideboardPlan(const QString &_name, const QList<MoveCard_ToZone> &_moveList)

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -123,8 +123,10 @@ private:
     InnerDecklistNode *root;
     void getCardListHelper(InnerDecklistNode *node, QSet<QString> &result) const;
     InnerDecklistNode *getZoneObjFromName(const QString  zoneName);
+    void removeEmptyLinesFromStart(QVector<QString> &inputs);
 protected:
     virtual QString getCardZoneFromName(QString /* cardName */, QString currentZoneName) { return currentZoneName; };
+    virtual QString getCompleteCardName(const QString cardName) const { return cardName; };
 signals:
     void deckHashChanged();
 public slots:

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -123,7 +123,6 @@ private:
     InnerDecklistNode *root;
     void getCardListHelper(InnerDecklistNode *node, QSet<QString> &result) const;
     InnerDecklistNode *getZoneObjFromName(const QString  zoneName);
-    void removeEmptyLinesFromStart(QVector<QString> &inputs);
 protected:
     virtual QString getCardZoneFromName(QString /* cardName */, QString currentZoneName) { return currentZoneName; };
     virtual QString getCompleteCardName(const QString cardName) const { return cardName; };

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -41,12 +41,12 @@ struct DecklistBuilder {
 namespace {
     TEST(LoadingFromClipboardTest, EmptyDeck) {
         DeckList *deckList = fromClipboard(new QString(""));
-        ASSERT_TRUE(deckList->getCardList().isEmpty()) << "Deck should be empty";
+        ASSERT_TRUE(deckList->getCardList().isEmpty());
     }
 
     TEST(LoadingFromClipboardTest, EmptySideboard) {
         DeckList *deckList = fromClipboard(new QString("Sideboard"));
-        ASSERT_TRUE(deckList->getCardList().isEmpty()) << "Deck should be empty";
+        ASSERT_TRUE(deckList->getCardList().isEmpty());
     }
 
     TEST(LoadingFromClipboardTest, QuantityPrefixed) {

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -210,6 +210,54 @@ namespace {
         ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
         ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
     }
+
+    TEST(LoadingFromClipboardTest, LotsOfStuffInBulkTesting) {
+        QString *clipboard = new QString(
+                "\n"
+                        "\n"
+                        "\n"
+                        "1x test1"
+                        "testNoValueMB"
+                        "2x test2"
+                        "SB: 10 testSB"
+                        "3 test3"
+                        "4X test4"
+                        "\n"
+                        "\n"
+                        "\n"
+                        "\n"
+                        "5x test5"
+                        "6X test6"
+                        "testNoValueSB"
+                        "\n"
+                        "\n"
+                        "\n"
+                        "\n"
+        );
+
+        DeckList *deckList = fromClipboard(clipboard);
+
+        DecklistBuilder decklistBuilder = DecklistBuilder();
+        deckList->forEachCard(decklistBuilder);
+
+        CardRows expectedMainboard = CardRows({
+                                                      {"test1", 1},
+                                                      {"testnovaluemb", 1},
+                                                      {"test2", 2},
+                                                      {"test3", 3},
+                                                      {"test4", 4}
+
+                                      });
+        CardRows expectedSideboard = CardRows({
+                                                      {"testsb", 10},
+                                                      {"test5", 5},
+                                                      {"test6", 6},
+                                                      {"testnovaluesb", 1}
+                                              });
+
+        ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
+        ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
+    }
 }
 
 int main(int argc, char **argv) {

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -39,7 +39,8 @@ struct DecklistBuilder {
 };
 
 namespace {
-    TEST(LoadingFromClipboardTest, EmptyDeck) {
+    TEST(LoadingFromClipboardTest, EmptyDeck)
+    {
         DeckList *deckList = fromClipboard(new QString(""));
         ASSERT_TRUE(deckList->getCardList().isEmpty());
     }
@@ -216,19 +217,19 @@ namespace {
                 "\n"
                         "\n"
                         "\n"
-                        "1x test1"
-                        "testNoValueMB"
-                        "2x test2"
-                        "SB: 10 testSB"
-                        "3 test3"
-                        "4X test4"
+                        "1x test1\n"
+                        "testNoValueMB\n"
+                        "2x test2\n"
+                        "SB: 10 testSB\n"
+                        "3 test3\n"
+                        "4X test4\n"
                         "\n"
                         "\n"
                         "\n"
                         "\n"
-                        "5x test5"
-                        "6X test6"
-                        "testNoValueSB"
+                        "5x test5\n"
+                        "6X test6\n"
+                        "testNoValueSB\n"
                         "\n"
                         "\n"
                         "\n"
@@ -242,10 +243,10 @@ namespace {
 
         CardRows expectedMainboard = CardRows({
                                                       {"test1", 1},
-                                                      {"testnovaluemb", 1},
                                                       {"test2", 2},
                                                       {"test3", 3},
-                                                      {"test4", 4}
+                                                      {"test4", 4},
+                                                      {"testnovaluemb", 1}
 
                                       });
         CardRows expectedSideboard = CardRows({
@@ -253,8 +254,8 @@ namespace {
                                                       {"test5", 5},
                                                       {"test6", 6},
                                                       {"testnovaluesb", 1}
-                                              });
 
+                                              });
         ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
         ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
     }

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -52,15 +52,19 @@ namespace {
     TEST(LoadingFromClipboardTest, QuantityPrefixed) {
         QString *clipboard = new QString(
                 "1 Mountain\n"
-                "2x Island\n"
+                        "2x Island\n"
+                        "3X FOREST\n"
         );
         DeckList *deckList = fromClipboard(clipboard);
 
         DecklistBuilder decklistBuilder = DecklistBuilder();
         deckList->forEachCard(decklistBuilder);
 
-        CardRows expectedMainboard = CardRows({{"Mountain", 1},
-                                               {"Island",   2}});
+        CardRows expectedMainboard = CardRows({
+                                                      {"mountain", 1},
+                                                      {"island", 2},
+                                                      {"forest", 3}
+                                              });
         CardRows expectedSideboard = CardRows({});
 
         ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
@@ -70,8 +74,8 @@ namespace {
     TEST(LoadingFromClipboardTest, CommentsAreIgnored) {
         QString *clipboard = new QString(
                 "//1 Mountain\n"
-                "//2x Island\n"
-                "//SB:2x Island\n"
+                        "//2x Island\n"
+                        "//SB:2x Island\n"
         );
 
         DeckList *deckList = fromClipboard(clipboard);
@@ -89,17 +93,21 @@ namespace {
     TEST(LoadingFromClipboardTest, SideboardPrefix) {
         QString *clipboard = new QString(
                 "1 Mountain\n"
-                "SB: 1 Mountain\n"
-                "SB: 2x Island\n"
+                        "SB: 1 Mountain\n"
+                        "SB: 2x Island\n"
         );
         DeckList *deckList = fromClipboard(clipboard);
 
         DecklistBuilder decklistBuilder = DecklistBuilder();
         deckList->forEachCard(decklistBuilder);
 
-        CardRows expectedMainboard = CardRows({{"Mountain", 1}});
-        CardRows expectedSideboard = CardRows({{"Mountain", 1},
-                                               {"Island",   2}});
+        CardRows expectedMainboard = CardRows({
+                                                      {"mountain", 1}
+                                              });
+        CardRows expectedSideboard = CardRows({
+                                                      {"mountain", 1},
+                                                      {"island",   2}
+                                              });
 
         ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
         ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
@@ -114,7 +122,89 @@ namespace {
         DecklistBuilder decklistBuilder = DecklistBuilder();
         deckList->forEachCard(decklistBuilder);
 
-        CardRows expectedMainboard = CardRows({{"CardThatDoesNotExistInCardsXml", 1}});
+        CardRows expectedMainboard = CardRows({
+                                                      {"cardthatdoesnotexistincardsxml", 1}
+                                              });
+        CardRows expectedSideboard = CardRows({});
+
+        ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
+        ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
+    }
+
+    TEST(LoadingFromClipboardTest, RemoveBlankEntriesFromBeginningAndEnd) {
+        QString *clipboard = new QString(
+                "\n"
+                        "\n"
+                        "\n"
+                        "1x Algae Gharial\n"
+                        "3x CardThatDoesNotExistInCardsXml\n"
+                        "2x Phelddagrif\n"
+                        "\n"
+                        "\n"
+        );
+
+        DeckList *deckList = fromClipboard(clipboard);
+
+        DecklistBuilder decklistBuilder = DecklistBuilder();
+        deckList->forEachCard(decklistBuilder);
+
+        CardRows expectedMainboard = CardRows({
+                                                      {"algae gharial", 1},
+                                                      {"cardthatdoesnotexistincardsxml", 3},
+                                                      {"phelddagrif", 2}
+                                              });
+        CardRows expectedSideboard = CardRows({});
+
+        ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
+        ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
+    }
+
+    TEST(LoadingFromClipboardTest, UseFirstBlankIfOnlyOneBlankToSplitSideboard) {
+        QString *clipboard = new QString(
+                "1x Algae Gharial\n"
+                        "3x CardThatDoesNotExistInCardsXml\n"
+                        "\n"
+                        "2x Phelddagrif\n"
+        );
+
+        DeckList *deckList = fromClipboard(clipboard);
+
+        DecklistBuilder decklistBuilder = DecklistBuilder();
+        deckList->forEachCard(decklistBuilder);
+
+        CardRows expectedMainboard = CardRows({
+                                                      {"algae gharial",                  1},
+                                                      {"cardthatdoesnotexistincardsxml", 3}
+                                              });
+        CardRows expectedSideboard = CardRows({
+                                                      {"phelddagrif", 2}
+                                              });
+
+        ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
+        ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
+    }
+
+    TEST(LoadingFromClipboardTest, IfMultipleScatteredBlanksAllMainBoard) {
+        QString *clipboard = new QString(
+                "1x Algae Gharial\n"
+                        "3x CardThatDoesNotExistInCardsXml\n"
+                        "\n"
+                        "2x Phelddagrif\n"
+                        "\n"
+                        "3 Giant Growth\n"
+        );
+
+        DeckList *deckList = fromClipboard(clipboard);
+
+        DecklistBuilder decklistBuilder = DecklistBuilder();
+        deckList->forEachCard(decklistBuilder);
+
+        CardRows expectedMainboard = CardRows({
+                                                      {"algae gharial",                  1},
+                                                      {"cardthatdoesnotexistincardsxml", 3},
+                                                      {"phelddagrif", 2},
+                                                      {"giant growth", 3}
+                                              });
         CardRows expectedSideboard = CardRows({});
 
         ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2701 

## Short roundup of the initial problem
Cards input to the deck editor weren't validated correctly and, if not typed _exactly_ as they are defined in an XML file, would be added to the "unknown" section.

The sideboard wouldn't begin if there was a line break in a file and insisted on a "Sideboard" word or "SB:" in front of cards.

## What will change with this Pull Request?
This PR adds a validation against the installed databases to find which card the inputs match up to and gives them the correct name attribute before loading them to the deck editor, effectively allowing case insensitivity and grammatical insensitivity. 

This PR also addresses an issue when importing decks from MTGGoldFish where they would have the sideboard split up with one blank line. This is now an added feature to check for a blank line and then start the sideboard.

~~It is possible (in the future?) that we should re-address how the loader works and make it "smarter" to check if there is the word "Sideboard" in the file, and if it is there then treat blank lines like nothing.~~

I added some new parts to the parser to make it "smarter," per say. It will now cut out all blank lines at the start of the paste and see how many blank lines there are. If there's only 1, assume it's the sideboard split point. If not, just assume the old logic was correct.
