### PR TITLE
limit gitlab builds to master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,15 @@ stages:
     paths:
       - cache/
 
+.branches: &branches
+  only:
+    - master
+
+.tags: &tags
+  tags:
+    - linux
+    - docker
+
 
 #================================ DEBIAN-BASED ================================
 
@@ -53,18 +62,16 @@ stages:
 
 .build_1604: &1604
   image: ubuntu:16.04
-  tags:
-    - linux
-    - docker
+  <<: *tags
+  <<: *branches
   <<: *install_requirements_16xx
   <<: *artifacts_deb
   <<: *cache
 
 .build_1610: &1610
   image: ubuntu:16.10
-  tags:
-    - linux
-    - docker
+  <<: *tags
+  <<: *branches
   <<: *install_requirements_16xx
   <<: *artifacts_deb
   <<: *cache
@@ -103,9 +110,8 @@ build_debug_1610:
 
 .build_stretch: &stretch
   image: debian:stretch
-  tags:
-    - linux
-    - docker
+  <<: *tags
+  <<: *branches
   <<: *install_requirements_stretch
   <<: *artifacts_deb
   <<: *cache
@@ -157,9 +163,8 @@ build_debug_stretch:
 
 .build_fedora22: &fedora22
   image: fedora:22
-  tags:
-    - linux
-    - docker
+  <<: *tags
+  <<: *branches
   <<: *install_requirements_fedora22
   <<: *artifacts_rpm
   <<: *cache


### PR DESCRIPTION
## Related Ticket(s)
- N/A

## Short roundup of the initial problem
Since getting Gitlab CI set up, my instance has built ~400 binaries, many of which were for small changes outside the master branch, which is essentially wasted work.

## What will change with this Pull Request?
- Gitlab CI builds will only trigger for changes on the master branch
- My power bill will go down

## Screenshots
![2017-05-09-171217_1329x281_scrot](https://cloud.githubusercontent.com/assets/6954107/25873000/be30f44c-34da-11e7-94ad-e8690ddf2b1f.png)
