### PR TITLE
counter menu context sensitive

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -341,8 +341,10 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     if (event->button() == Qt::RightButton) {
         if (cardMenu)
-            if (!cardMenu->isEmpty())
+            if (!cardMenu->isEmpty()) {
+                owner->updateCardMenu(this);
                 cardMenu->exec(event->screenPos());
+            }
     } else if ((event->button() == Qt::LeftButton) && !settingsCache->getDoubleClickToPlay()) {
         
         bool hideCard = false;

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2502,7 +2502,8 @@ void Player::updateCardMenu(const CardItem *card)
                 for (int i = 0; i < aAddCounter.size(); ++i) {
                     cardMenu->addSeparator();
                     cardMenu->addAction(aAddCounter[i]);
-                    cardMenu->addAction(aRemoveCounter[i]);
+                    if (card->getCounters().contains(i))
+                        cardMenu->addAction(aRemoveCounter[i]);
                     cardMenu->addAction(aSetCounter[i]);
                 }
                 cardMenu->addSeparator();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2677

## Short roundup of the initial problem
When right clicking on a card, the "remove counters" option would show, even when no counters were on the card.

## What will change with this Pull Request?
Context menus for cards are created at the same time the card comes into play. This update will update when the context menu opens.
- Added `updateCardMenu` call when opening context menu on a single card
- Context menu will only add "remove counters" option if a counter of that type is on the card

## Screenshots

<img width="377" alt="screen shot 2017-05-13 at 00 05 53" src="https://cloud.githubusercontent.com/assets/26419373/26018578/fbc4cf26-376f-11e7-88ae-c655c2347a5d.png">
