### PR TITLE
Better scrolling in reveal zones

### DIFF
--- a/cockatrice/src/zoneviewwidget.cpp
+++ b/cockatrice/src/zoneviewwidget.cpp
@@ -3,9 +3,7 @@
 #include <QGraphicsSceneMouseEvent>
 #include <QCheckBox>
 #include <QLabel>
-#include <QPushButton>
 #include <QPainter>
-#include <QPalette>
 #include <QScrollBar>
 #include <QStyleOption>
 #include <QStyleOptionTitleBar>
@@ -15,7 +13,6 @@
 #include "player.h"
 #include "gamescene.h"
 #include "settingscache.h"
-#include "gamescene.h"
 
 #include "pb/command_stop_dump_zone.pb.h"
 #include "pb/command_shuffle.pb.h"
@@ -78,7 +75,8 @@ ZoneViewWidget::ZoneViewWidget(Player *_player, CardZone *_origZone, int numberC
 
     scrollBar = new QScrollBar(Qt::Vertical);
     scrollBar->setMinimum(0);
-    scrollBar->setSingleStep(50);
+    scrollBar->setSingleStep(20);
+    scrollBar->setPageStep(200);
     connect(scrollBar, SIGNAL(valueChanged(int)), this, SLOT(handleScrollBarChange(int)));
     QGraphicsProxyWidget *scrollBarProxy = new QGraphicsProxyWidget;
     scrollBarProxy->setWidget(scrollBar);


### PR DESCRIPTION
## Short roundup of the initial problem
Scrolling in a "zone" has always been painfully slow.

## What will change with this Pull Request?
- Removed unused imports
- Better scroll bar height and stepping
    - Faster and less scrolling

## Screenshots

<img width="562" alt="screen shot 2017-05-13 at 22 33 30" src="https://cloud.githubusercontent.com/assets/26419373/26029044/6e85709e-382c-11e7-882a-de9907045954.png">
