### PR TITLE
context menu fix

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -1,7 +1,6 @@
 #include <QApplication>
 #include <QPainter>
 #include <QMenu>
-#include <QAction>
 #include <QGraphicsSceneMouseEvent>
 #include "gamescene.h"
 #include "carditem.h"

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2079,7 +2079,7 @@ void Player::cardMenuAction()
                 }
                 case cmClone: {
                     Command_CreateToken *cmd = new Command_CreateToken;
-                    cmd->set_zone(card->getZone()->getName().toStdString());
+                    cmd->set_zone("table");
                     cmd->set_card_name(card->getName().toStdString());
                     cmd->set_color(card->getColor().toStdString());
                     cmd->set_pt(card->getPT().toStdString());
@@ -2519,6 +2519,13 @@ void Player::updateCardMenu(const CardItem *card)
             }
         } else
             cardMenu->addMenu(moveMenu);
+    } else {
+        if (card->getZone()
+            && card->getZone()->getName() != "hand") {
+            cardMenu->addAction(aDrawArrow);
+            cardMenu->addSeparator();
+            cardMenu->addAction(aClone);
+        }
     }
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2714
- Support for #2702

## Short roundup of the initial problem
#2714 introduced the issue of not being able to open a context menu on your opponents cards.

## What will change with this Pull Request?
- Able to clone from zones apart from table #2702
- Removed unused import
- Context menu has been re-added for opponents cards
- Context menu for opponents cards has only 2 options:
    - draw arrow
    - clone

## Screenshots

<img width="238" alt="screen shot 2017-05-14 at 11 11 28" src="https://cloud.githubusercontent.com/assets/26419373/26032559/aeca4e58-3896-11e7-9cae-0830fa90b975.png">
