### PR TITLE
update notification: show published date

### DIFF
--- a/cockatrice/src/releasechannel.cpp
+++ b/cockatrice/src/releasechannel.cpp
@@ -250,7 +250,7 @@ void DevReleaseChannel::releaseListFinished()
         !resultMap.contains("tag_name") ||
         !resultMap.contains("target_commitish") ||
         !resultMap.contains("assets_url") ||
-        !resultMap.contains("created_at"))
+        !resultMap.contains("published_at"))
     {
         qWarning() << "Invalid received from the release update server:" << resultMap;
         emit error(tr("Invalid reply received from the release update server."));
@@ -261,7 +261,7 @@ void DevReleaseChannel::releaseListFinished()
         lastRelease = new Release;
 
     lastRelease->setCommitHash(resultMap["target_commitish"].toString());
-    lastRelease->setPublishDate(resultMap["created_at"].toDate());
+    lastRelease->setPublishDate(resultMap["published_at"].toDate());
 
     QString shortHash = lastRelease->getCommitHash().left(GIT_SHORT_HASH_LEN);
     lastRelease->setName(QString("%1 (%2)").arg(resultMap["tag_name"].toString()).arg(shortHash));


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2722 

## Short roundup of the initial problem
- date missmatch in update notification because we use create over publish from github api

## What will change with this Pull Request?
- `setPublishDate` now is finally published date, and not created date any longer

## Screenshots
- before:
![before](https://cloud.githubusercontent.com/assets/9874850/26258775/70b5fb1a-3cc6-11e7-883b-11d475d727fd.png)

- after:
![after](https://cloud.githubusercontent.com/assets/9874850/26276657/b47befac-3d7b-11e7-858e-7d095821595d.png)
