### PR TITLE
Colorless for color filter

### DIFF
--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -178,7 +178,7 @@ bool FilterItem::acceptColor(const CardInfo *info) const
     converted_term.replace(QString("wht"), QString("w"), Qt::CaseInsensitive);
     converted_term.replace(QString(" "), QString(""), Qt::CaseInsensitive);
     
-    if (converted_term.toLower() == "none" || converted_term.toLower() == "colorless") {
+    if (converted_term.toLower() == "none" || converted_term.toLower() == "colorless" || converted_term.toLower() == "c") {
         if (info->getColors().length() < 1) {
             return true;
         }

--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -177,9 +177,16 @@ bool FilterItem::acceptColor(const CardInfo *info) const
     converted_term.replace(QString("white"), QString("w"), Qt::CaseInsensitive);
     converted_term.replace(QString("wht"), QString("w"), Qt::CaseInsensitive);
     converted_term.replace(QString(" "), QString(""), Qt::CaseInsensitive);
+    
+    if (converted_term == "" || converted_term.toLower() == "colorless") {
+        if (info->getColors().length() < 1) {
+            return true;
+        }
+    }
 
     /* This is a tricky part, if the filter has multiple colors in it, like UGW,
        then we should match all of them to the card's colors */
+    
     match_count = 0;
     for (it = converted_term.begin(); it != converted_term.end(); it++) {
         for (i = info->getColors().constBegin(); i != info->getColors().constEnd(); i++)

--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -178,7 +178,7 @@ bool FilterItem::acceptColor(const CardInfo *info) const
     converted_term.replace(QString("wht"), QString("w"), Qt::CaseInsensitive);
     converted_term.replace(QString(" "), QString(""), Qt::CaseInsensitive);
     
-    if (converted_term == "" || converted_term.toLower() == "colorless") {
+    if (converted_term.toLower() == "none" || converted_term.toLower() == "colorless") {
         if (info->getColors().length() < 1) {
             return true;
         }


### PR DESCRIPTION
Add 'colorless' as an option for color filter in deck editor / card list.

## Related Ticket(s)
- Fixes #2736

## Short roundup of the initial problem
Only way to search for colorless cards is to do a 5 way 'not' filter.

## What will change with this Pull Request?
You can now filter for `colorless` or `none` as a color and get all cards that do not have color defined in cards.xml
