### PR TITLE
Add token creation for opponent board items

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -339,23 +339,22 @@ void CardItem::playCard(bool faceDown)
 void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     if (event->button() == Qt::RightButton) {
-        if (cardMenu)
-            if (!cardMenu->isEmpty()) {
-                owner->updateCardMenu(this);
-                cardMenu->exec(event->screenPos());
-            }
+        if (cardMenu && !cardMenu->isEmpty() && owner) {
+            owner->updateCardMenu(this);
+            cardMenu->exec(event->screenPos());
+        }
     } else if ((event->button() == Qt::LeftButton) && !settingsCache->getDoubleClickToPlay()) {
-        
         bool hideCard = false;
-        if (zone->getIsView()) {
+        if (zone && zone->getIsView()) {
             ZoneViewZone *view = static_cast<ZoneViewZone *>(zone);
             if (view->getRevealZone() && !view->getWriteableRevealZone())
                 hideCard = true;
         }
-        if (hideCard)
+        if (zone && hideCard) {
             zone->removeCard(this);
-        else
+        } else {
             playCard(event->modifiers().testFlag(Qt::ShiftModifier));
+        }
     }
 
     setCursor(Qt::OpenHandCursor);

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -110,6 +110,8 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
     userInfo = new ServerInfo_User;
     userInfo->CopyFrom(info);
 
+
+
     connect(settingsCache, SIGNAL(horizontalHandChanged()), this, SLOT(rearrangeZones()));
     connect(settingsCache, SIGNAL(handJustificationChanged()), this, SLOT(rearrangeZones()));
 
@@ -2427,8 +2429,11 @@ void Player::refreshShortcuts()
 
 void Player::updateCardMenu(const CardItem *card)
 {
-    if (card == nullptr)
+    // If bad card OR is a spectator (as spectators don't need card menus), return
+    if (card == nullptr || game->isSpectator())
+    {
         return;
+    }
 
     QMenu *cardMenu = card->getCardMenu();
     QMenu *ptMenu = card->getPTMenu();
@@ -2438,20 +2443,30 @@ void Player::updateCardMenu(const CardItem *card)
 
     bool revealedCard = false;
     bool writeableCard = getLocal();
-    if (card->getZone() && card->getZone()->getIsView()) {
+    if (card->getZone() && card->getZone()->getIsView())
+    {
         ZoneViewZone *view = static_cast<ZoneViewZone *>(card->getZone());
-        if (view->getRevealZone()) {
+        if (view->getRevealZone())
+        {
             if (view->getWriteableRevealZone())
+            {
                 writeableCard = true;
+            }
             else
+            {
                 revealedCard = true;
+            }
         }
     }
 
-    if (revealedCard) {
+    if (revealedCard)
+    {
         cardMenu->addAction(aHide);
-    } else if (writeableCard) {
-        if (moveMenu->isEmpty()) {
+    }
+    else if (writeableCard)
+    {
+        if (moveMenu->isEmpty())
+        {
             moveMenu->addAction(aMoveToTopLibrary);
             moveMenu->addAction(aMoveToXfromTopOfLibrary);
             moveMenu->addAction(aMoveToBottomLibrary);
@@ -2463,9 +2478,12 @@ void Player::updateCardMenu(const CardItem *card)
             moveMenu->addAction(aMoveToExile);
         }
 
-        if (card->getZone()){
-            if (card->getZone()->getName() == "table") {
-                if (ptMenu->isEmpty()) {
+        if (card->getZone())
+        {
+            if (card->getZone()->getName() == "table")
+            {
+                if (ptMenu->isEmpty())
+                {
                     ptMenu->addAction(aIncP);
                     ptMenu->addAction(aDecP);
                     ptMenu->addSeparator();
@@ -2483,14 +2501,18 @@ void Player::updateCardMenu(const CardItem *card)
                 cardMenu->addAction(aDoesntUntap);
                 cardMenu->addAction(aFlip);
                 if (card->getFaceDown())
+                {
                     cardMenu->addAction(aPeek);
+                }
 
                 addRelatedCardActions(card, cardMenu);
 
                 cardMenu->addSeparator();
                 cardMenu->addAction(aAttach);
                 if (card->getAttachedTo())
+                {
                     cardMenu->addAction(aUnattach);
+                }
                 cardMenu->addAction(aDrawArrow);
                 cardMenu->addSeparator();
                 cardMenu->addMenu(ptMenu);
@@ -2499,28 +2521,41 @@ void Player::updateCardMenu(const CardItem *card)
                 cardMenu->addAction(aClone);
                 cardMenu->addMenu(moveMenu);
 
-                for (int i = 0; i < aAddCounter.size(); ++i) {
+                for (int i = 0; i < aAddCounter.size(); ++i)
+                {
                     cardMenu->addSeparator();
                     cardMenu->addAction(aAddCounter[i]);
                     if (card->getCounters().contains(i))
+                    {
                         cardMenu->addAction(aRemoveCounter[i]);
+                    }
                     cardMenu->addAction(aSetCounter[i]);
                 }
                 cardMenu->addSeparator();
-            } else if (card->getZone()->getName() == "stack") {
+            }
+            else if (card->getZone()->getName() == "stack")
+            {
                 cardMenu->addAction(aDrawArrow);
                 cardMenu->addMenu(moveMenu);
 
                 addRelatedCardActions(card, cardMenu);
-            } else {
+            }
+            else
+            {
                 cardMenu->addAction(aPlay);
                 cardMenu->addAction(aPlayFacedown);
                 cardMenu->addMenu(moveMenu);
             }
-        } else
+        }
+        else
+        {
             cardMenu->addMenu(moveMenu);
-    } else {
-        if (card->getZone() && card->getZone()->getName() != "hand") {
+        }
+    }
+    else
+    {
+        if (card->getZone() && card->getZone()->getName() != "hand")
+        {
             cardMenu->addAction(aDrawArrow);
             cardMenu->addSeparator();
             addRelatedCardActions(card, cardMenu);

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2448,9 +2448,9 @@ void Player::updateCardMenu(const CardItem *card)
         }
     }
 
-    if (revealedCard)
+    if (revealedCard) {
         cardMenu->addAction(aHide);
-    else if (writeableCard) {
+    } else if (writeableCard) {
         if (moveMenu->isEmpty()) {
             moveMenu->addAction(aMoveToTopLibrary);
             moveMenu->addAction(aMoveToXfromTopOfLibrary);
@@ -2463,7 +2463,7 @@ void Player::updateCardMenu(const CardItem *card)
             moveMenu->addAction(aMoveToExile);
         }
 
-        if (card->getZone()) {
+        if (card->getZone()){
             if (card->getZone()->getName() == "table") {
                 if (ptMenu->isEmpty()) {
                     ptMenu->addAction(aIncP);
@@ -2520,9 +2520,10 @@ void Player::updateCardMenu(const CardItem *card)
         } else
             cardMenu->addMenu(moveMenu);
     } else {
-        if (card->getZone()
-            && card->getZone()->getName() != "hand") {
+        if (card->getZone() && card->getZone()->getName() != "hand") {
             cardMenu->addAction(aDrawArrow);
+            cardMenu->addSeparator();
+            addRelatedCardActions(card, cardMenu);
             cardMenu->addSeparator();
             cardMenu->addAction(aClone);
         }
@@ -2634,7 +2635,7 @@ void Player::processSceneSizeChange(int newPlayerWidth)
 
 void Player::setLastToken(CardInfo *cardInfo)
 {
-    if (cardInfo == nullptr)
+    if (cardInfo == nullptr || aCreateAnotherToken == nullptr)
         return;
 
     lastTokenName = cardInfo->getName();

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1670,7 +1670,7 @@ void Player::processGameEvent(GameEvent::GameEventType type, const GameEvent &ev
         case GameEvent::REVEAL_CARDS: eventRevealCards(event.GetExtension(Event_RevealCards::ext)); break;
         case GameEvent::CHANGE_ZONE_PROPERTIES: eventChangeZoneProperties(event.GetExtension(Event_ChangeZoneProperties::ext)); break;
         default: {
-            qDebug() << "unhandled game event";
+            qDebug() << "unhandled game event" << type;
         }
     }
 }

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -593,6 +593,11 @@ void TabGame::adminLockChanged(bool lock)
     sayEdit->setVisible(v);
 }
 
+bool TabGame::isSpectator()
+{
+    return spectator;
+}
+
 void TabGame::actGameInfo()
 {
     DlgCreateGame dlg(gameInfo, roomGameTypes);

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -735,7 +735,7 @@ void TabGame::processGameEventContainer(const GameEventContainer &cont, Abstract
                 case GameEvent::GAME_SAY: eventSpectatorSay(event.GetExtension(Event_GameSay::ext), playerId, context); break;
                 case GameEvent::LEAVE: eventSpectatorLeave(event.GetExtension(Event_Leave::ext), playerId, context); break;
                 default: {
-                    qDebug() << "unhandled spectator game event";
+                    qDebug() << "unhandled spectator game event" << eventType;
                     break;
                 }
             }

--- a/cockatrice/src/tab_game.h
+++ b/cockatrice/src/tab_game.h
@@ -251,7 +251,7 @@ public:
     bool getSpectatorsSeeEverything() const { return gameInfo.spectators_omniscient(); }
     Player *getActiveLocalPlayer() const;
     AbstractClient *getClientForPlayer(int playerId) const;
-    
+
     void setActiveCard(CardItem *_card) { activeCard = _card; }
     CardItem *getActiveCard() const { return activeCard; }
 

--- a/cockatrice/src/tab_game.h
+++ b/cockatrice/src/tab_game.h
@@ -249,6 +249,7 @@ public:
     QString getTabText() const;
     bool getSpectator() const { return spectator; }
     bool getSpectatorsSeeEverything() const { return gameInfo.spectators_omniscient(); }
+    bool isSpectator();
     Player *getActiveLocalPlayer() const;
     AbstractClient *getClientForPlayer(int playerId) const;
 


### PR DESCRIPTION
## Related Ticket(s)
- Groundwork for #2732

## Short roundup of the initial problem
Couldn't make tokens from opponents stuff with [the new change](https://github.com/Cockatrice/Cockatrice/pull/2719). This adds the "Token: CardName" to the menu. 

## What will change with this Pull Request?
- Allow tokens to be made from opponent's board state
    - If spectator, then clicking it will do nothing (as is the same behavior with the other buttons)
- Code cleanup for some parts in the file just to clarify what's going on.
    - Adds some debugging info for unhandled events (for future use)

## Screenshots
Makes tokens:
<img width="181" alt="screenshot 2017-05-31 22 57 22" src="https://cloud.githubusercontent.com/assets/7460172/26662815/8c50febe-4654-11e7-95cb-a16d7b07b24d.png">

Does not make tokens:
<img width="134" alt="screenshot 2017-05-31 23 02 42" src="https://cloud.githubusercontent.com/assets/7460172/26662907/435511cc-4655-11e7-88f8-49f5d9178af1.png">