### PR TITLE
Make deck list appear if deck loaded

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -937,6 +937,10 @@ void TabDeckEditor::setDeck(DeckLoader *_deck)
     PictureLoader::cacheCardPixmaps(db->getCards(deckModel->getDeckList()->getCardList()));
     deckView->expandAll();
     setModified(false);
+
+    // If they load a deck, make the deck list appear
+    aDeckDockVisible->setChecked(true);
+    deckDock->setVisible(aDeckDockVisible->isChecked());
 }
 
 void TabDeckEditor::setModified(bool _modified)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2713 

## Short roundup of the initial problem
If deck window was closed, then when you loaded a deck nothing really happened visually...

## What will change with this Pull Request?
- On load of deck, deck list will become visible
