### PR TITLE
make "not set to untap normally" normally more distinct

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -90,7 +90,8 @@ void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
     
     int i = 0;
     QMapIterator<int, int> counterIterator(counters);
-    while (counterIterator.hasNext()) {
+    while (counterIterator.hasNext())
+    {
         counterIterator.next();
         QColor color;
         color.setHsv(counterIterator.key() * 60, 150, 255);
@@ -102,7 +103,8 @@ void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
     QSizeF translatedSize = getTranslatedSize(painter);
     qreal scaleFactor = translatedSize.width() / boundingRect().width();
     
-    if (!pt.isEmpty()) {
+    if (!pt.isEmpty())
+    {
         painter->save();
         transformPainter(painter, translatedSize, tapAngle);
 
@@ -115,7 +117,9 @@ void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
                 painter->setPen(QColor(255, 150, 0));
             else
                 painter->setPen(Qt::white);
-        } else {
+        }
+        else
+        {
             painter->setPen(Qt::white);
         }
         painter->setBackground(Qt::black);
@@ -124,7 +128,9 @@ void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
         painter->drawText(QRectF(4 * scaleFactor, 4 * scaleFactor, translatedSize.width() - 10 * scaleFactor, translatedSize.height() - 8 * scaleFactor), Qt::AlignRight | Qt::AlignBottom, pt);
         painter->restore();
     }
-    if (!annotation.isEmpty()) {
+
+    if (!annotation.isEmpty())
+    {
         painter->save();
 
         transformPainter(painter, translatedSize, tapAngle);
@@ -135,9 +141,29 @@ void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
         painter->drawText(QRectF(4 * scaleFactor, 4 * scaleFactor, translatedSize.width() - 8 * scaleFactor, translatedSize.height() - 8 * scaleFactor), Qt::AlignCenter | Qt::TextWrapAnywhere, annotation);
         painter->restore();
     }
+
     if (getBeingPointedAt())
+    {
         painter->fillRect(boundingRect(), QBrush(QColor(255, 0, 0, 100)));
-    painter->restore();
+        painter->restore();
+    }
+
+    if (doesntUntap)
+    {
+        painter->save();
+
+        painter->setRenderHint(QPainter::Antialiasing, false);
+        transformPainter(painter, translatedSize, tapAngle);
+
+        QPen pen;
+        pen.setColor(Qt::magenta);
+        const int penWidth = 1;
+        pen.setWidth(penWidth);
+        painter->setPen(pen);
+        painter->drawRect(QRectF(0, 0, translatedSize.width() + penWidth, translatedSize.height() - penWidth));
+
+        painter->restore();
+    }
 }
 
 void CardItem::setAttacking(bool _attacking)
@@ -164,6 +190,7 @@ void CardItem::setAnnotation(const QString &_annotation)
 void CardItem::setDoesntUntap(bool _doesntUntap)
 {
     doesntUntap = _doesntUntap;
+    update();
 }
 
 void CardItem::setPT(const QString &_pt)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2728 

## Short roundup of the initial problem
Looked like a popular issue and it's something I feel should have been addressed a long time ago. This will add a magenta border to all cards that are set not to untap normally.

Also some cleanup with brackets to make it easier to understand.

<img width="456" alt="screenshot 2017-06-01 00 27 09" src="https://cloud.githubusercontent.com/assets/7460172/26664648/1f3f0aca-4661-11e7-9fc1-1dd8b133d9c0.png">

