### PR TITLE
[WIP] better null checks

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -46,6 +46,8 @@ CardItem::~CardItem()
 
 void CardItem::prepareDelete()
 {
+    disconnect(this, 0, 0, 0);
+
     if (owner) {
         if (owner->getCardMenu() == cardMenu) {
             owner->setCardMenu(0);

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2434,6 +2434,9 @@ void Player::updateCardMenu(const CardItem *card)
     QMenu *ptMenu = card->getPTMenu();
     QMenu *moveMenu = card->getMoveMenu();
 
+    if (cardMenu == nullptr || ptMenu == nullptr || moveMenu == nullptr)
+        return;
+
     cardMenu->clear();
 
     bool revealedCard = false;


### PR DESCRIPTION
Saw a crash happen numerous times when trying to exit the game / close games. I think this might be a fix.


<details><summary>Log</summary>

```
Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       EXC_I386_GPFLT
Exception Note:        EXC_CORPSE_NOTIFY

Termination Signal:    Segmentation fault: 11
Termination Reason:    Namespace SIGNAL, Code 0xb
Terminating Process:   exc handler [0]

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   org.qt-project.QtCore         	0x00000001084f4ea8 QObject::disconnect(QObject const*, char const*, QObject const*, char const*) + 776
1   org.qt-project.QtWidgets      	0x00000001078c7829 QMenu::actionEvent(QActionEvent*) + 201
2   org.qt-project.QtWidgets      	0x0000000107783a38 QWidget::event(QEvent*) + 1240
3   org.qt-project.QtWidgets      	0x00000001078c5ce4 QMenu::event(QEvent*) + 1140
4   org.qt-project.QtWidgets      	0x0000000107743a4d QApplicationPrivate::notify_helper(QObject*, QEvent*) + 269
5   org.qt-project.QtWidgets      	0x0000000107746392 QApplication::notify(QObject*, QEvent*) + 5906
6   org.qt-project.QtCore         	0x00000001084c65c4 QCoreApplication::notifyInternal2(QObject*, QEvent*) + 164
7   org.qt-project.QtWidgets      	0x00000001077778d0 QWidget::removeAction(QAction*) + 112
8   org.qt-project.QtWidgets      	0x00000001077776cc QWidget::insertAction(QAction*, QAction*) + 140
9   com.cockatrice.Cockatrice     	0x00000001069e01bd Player::updateCardMenu(CardItem const*) + 157
10  org.qt-project.QtCore         	0x00000001084f7651 QMetaObject::activate(QObject*, int, int, void**) + 913
11  com.cockatrice.Cockatrice     	0x0000000106b24300 AbstractCardItem::updateCardMenu(AbstractCardItem*) + 64
12  com.cockatrice.Cockatrice     	0x00000001069e9d80 CardItem::prepareDelete() + 272
13  com.cockatrice.Cockatrice     	0x00000001069ea05e CardItem::deleteLater() + 14
14  com.cockatrice.Cockatrice     	0x00000001069e58e5 CardZone::clearContents() + 181
15  com.cockatrice.Cockatrice     	0x00000001069e56e2 CardZone::~CardZone() + 274
16  com.cockatrice.Cockatrice     	0x0000000106b40776 non-virtual thunk to TableZone::~TableZone() + 118
17  org.qt-project.QtWidgets      	0x0000000107a4a048 QGraphicsItem::~QGraphicsItem() + 728
18  com.cockatrice.Cockatrice     	0x00000001069c8c58 Player::~Player() + 2808
19  com.cockatrice.Cockatrice     	0x00000001069c8f7e Player::~Player() + 14
20  com.cockatrice.Cockatrice     	0x0000000106a5c70a TabGame::~TabGame() + 234
21  com.cockatrice.Cockatrice     	0x0000000106a5d14e TabGame::~TabGame() + 14
22  org.qt-project.QtCore         	0x00000001084f0997 QObject::event(QEvent*) + 823
23  org.qt-project.QtWidgets      	0x00000001077845fe QWidget::event(QEvent*) + 4254
24  org.qt-project.QtWidgets      	0x000000010789599c QMainWindow::event(QEvent*) + 1660
25  org.qt-project.QtWidgets      	0x0000000107743a4d QApplicationPrivate::notify_helper(QObject*, QEvent*) + 269
26  org.qt-project.QtWidgets      	0x0000000107746392 QApplication::notify(QObject*, QEvent*) + 5906
27  org.qt-project.QtCore         	0x00000001084c65c4 QCoreApplication::notifyInternal2(QObject*, QEvent*) + 164
28  org.qt-project.QtCore         	0x00000001084c71f8 QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) + 600
29  libqcocoa.dylib               	0x000000010a27af4e 0x10a255000 + 155470
30  libqcocoa.dylib               	0x000000010a27b811 0x10a255000 + 157713
31  com.apple.CoreFoundation      	0x00007fffc9559321 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17
32  com.apple.CoreFoundation      	0x00007fffc953a21d __CFRunLoopDoSources0 + 557
33  com.apple.CoreFoundation      	0x00007fffc9539716 __CFRunLoopRun + 934
34  com.apple.CoreFoundation      	0x00007fffc9539114 CFRunLoopRunSpecific + 420
35  com.apple.HIToolbox           	0x00007fffc8a9aebc RunCurrentEventLoopInMode + 240
36  com.apple.HIToolbox           	0x00007fffc8a9abf9 ReceiveNextEventCommon + 184
37  com.apple.HIToolbox           	0x00007fffc8a9ab26 _BlockUntilNextEventMatchingListInModeWithFilter + 71
38  com.apple.AppKit              	0x00007fffc7033a54 _DPSNextEvent + 1120
39  com.apple.AppKit              	0x00007fffc77af7ee -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 2796
40  com.apple.AppKit              	0x00007fffc70283db -[NSApplication run] + 926
41  libqcocoa.dylib               	0x000000010a27a6bf 0x10a255000 + 153279
42  org.qt-project.QtCore         	0x00000001084c29d1 QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) + 401
43  org.qt-project.QtCore         	0x00000001084c6c35 QCoreApplication::exec() + 341
44  com.cockatrice.Cockatrice     	0x00000001069a1c6a main + 1626
45  libdyld.dylib                 	0x00007fffdecb3235 start + 1
```