### PR TITLE
keep client version persistent in logs

### DIFF
--- a/cockatrice/src/dlg_viewlog.cpp
+++ b/cockatrice/src/dlg_viewlog.cpp
@@ -37,4 +37,5 @@ void DlgViewLog::logEntryAdded(QString message)
 void DlgViewLog::closeEvent(QCloseEvent * /* event */)
 {
     logArea->clear();
+    logArea->appendPlainText(Logger::getInstance().getClientVersion());
 }

--- a/cockatrice/src/logger.h
+++ b/cockatrice/src/logger.h
@@ -30,6 +30,7 @@ private:
 public:
 	void logToFile(bool enabled);
     void log(QtMsgType type, const QMessageLogContext &ctx, const QString message);
+    QString getClientVersion();
     QList<QString> getLogBuffer() { return logBuffer; }
 protected:
     void openLogfileSession();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2747 

## Short roundup of the initial problem
Client version was never logged in debug, harder to debug without it

## What will change with this Pull Request?
Keeps client version persistent on the in client popup log and std output logs
