### PR TITLE
Model col widths off deck editor & disable button if no tokens in deck

### DIFF
--- a/cockatrice/src/dlg_create_token.cpp
+++ b/cockatrice/src/dlg_create_token.cpp
@@ -75,7 +75,9 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
     connect(chooseTokenFromAllRadioButton, SIGNAL(toggled(bool)), this, SLOT(actChooseTokenFromAll(bool)));
     chooseTokenFromDeckRadioButton = new QRadioButton(tr("Show tokens from this &deck"));
     connect(chooseTokenFromDeckRadioButton, SIGNAL(toggled(bool)), this, SLOT(actChooseTokenFromDeck(bool)));
-    QTreeView *chooseTokenView = new QTreeView;
+
+    QByteArray deckHeaderState = settingsCache->layouts().getDeckEditorDbHeaderState();
+    chooseTokenView = new QTreeView;
     chooseTokenView->setModel(cardDatabaseDisplayModel);
     chooseTokenView->setUniformRowHeights(true);
     chooseTokenView->setRootIsDecorated(false);
@@ -83,19 +85,24 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
     chooseTokenView->setSortingEnabled(true);
     chooseTokenView->sortByColumn(0, Qt::AscendingOrder);
     chooseTokenView->resizeColumnToContents(0);
-    chooseTokenView->header()->setStretchLastSection(false);
-    chooseTokenView->header()->hideSection(1);
-    chooseTokenView->header()->hideSection(2);
     chooseTokenView->setWordWrap(true);
-    chooseTokenView->setColumnWidth(0, 130);
-    chooseTokenView->setColumnWidth(3, 178);
-    chooseTokenView->header()->setSectionResizeMode(4, QHeaderView::ResizeToContents);
 
+    if (!deckHeaderState.isNull())
+        chooseTokenView->header()->restoreState(deckHeaderState);
+
+    chooseTokenView->header()->setStretchLastSection(false);
+    chooseTokenView->header()->hideSection(1); // Sets
+    chooseTokenView->header()->hideSection(2); // Mana Cost
+    chooseTokenView->header()->setSectionResizeMode(5, QHeaderView::ResizeToContents); // Color(s)
     connect(chooseTokenView->selectionModel(), SIGNAL(currentRowChanged(QModelIndex, QModelIndex)), this, SLOT(tokenSelectionChanged(QModelIndex, QModelIndex)));
     
     if (predefinedTokens.isEmpty())
+    {
         chooseTokenFromAllRadioButton->setChecked(true);
-    else {
+        chooseTokenFromDeckRadioButton->setDisabled(true); // No tokens in deck = no need for option
+    }
+    else
+    {
         chooseTokenFromDeckRadioButton->setChecked(true);
         cardDatabaseDisplayModel->setCardNameSet(QSet<QString>::fromList(predefinedTokens));
     }

--- a/cockatrice/src/dlg_create_token.h
+++ b/cockatrice/src/dlg_create_token.h
@@ -11,6 +11,7 @@ class QCheckBox;
 class QPushButton;
 class QRadioButton;
 class QCloseEvent;
+class QTreeView;
 class DeckList;
 class CardDatabaseModel;
 class TokenDisplayModel;
@@ -44,6 +45,7 @@ private:
     QCheckBox *destroyCheckBox;
     QRadioButton *chooseTokenFromAllRadioButton, *chooseTokenFromDeckRadioButton;
     CardInfoPicture *pic;
+    QTreeView *chooseTokenView;
 
     void updateSearchFieldWithoutUpdatingFilter(const QString &newValue) const;
 };

--- a/cockatrice/src/settings/layoutssettings.h
+++ b/cockatrice/src/settings/layoutssettings.h
@@ -8,8 +8,7 @@ class LayoutsSettings : public SettingsManager
 {
     Q_OBJECT
     friend class SettingsCache;
-public:    
-
+public:
     void setDeckEditorLayoutState(const QByteArray &value);
     void setDeckEditorGeometry(const QByteArray &value);
     void setDeckEditorCardSize(const QSize &value);

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -345,11 +345,13 @@ void TabDeckEditor::createCentralFrame()
     connect(databaseView, SIGNAL(doubleClicked(const QModelIndex &)), this, SLOT(actAddCard()));
 
     QByteArray dbHeaderState = settingsCache->layouts().getDeckEditorDbHeaderState();
-    if(dbHeaderState.isNull())
+    if (dbHeaderState.isNull())
     {
         // first run
         databaseView->setColumnWidth(0, 200);
-    } else {
+    }
+    else
+    {
         databaseView->header()->restoreState(dbHeaderState);
     }
     connect(databaseView->header(), SIGNAL(geometriesChanged()), this, SLOT(saveDbHeaderState()));


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2646 

## Short roundup of the initial problem
- The widths of the token editor were random at best.
- Tokens in deck would show everything if no tokens were added to deck.

## What will change with this Pull Request?
- Will now model exactly after the deck editor's layout (So if you set col1.width=100, tokensCol1.width will be 100 too). It's an exact copy, but you do not have the ability to edit the sizes in the token editor. (_If you make a change to deck editor width, token editor width will change, but not vice versa._)
- Button for tokens in deck will disable if no tokens were added to deck.


## Screenshots
<img width="900" alt="screenshot 2017-06-03 22 56 05" src="https://cloud.githubusercontent.com/assets/7460172/26758568/effcdcaa-48af-11e7-8438-3b08248ca90e.png">

