### PR TITLE
fix card not showing correctly in games

### DIFF
--- a/cockatrice/src/cardframe.cpp
+++ b/cockatrice/src/cardframe.cpp
@@ -102,7 +102,7 @@ void CardFrame::setCard(CardInfo *card)
 
 void CardFrame::setCard(const QString &cardName)
 {
-    setCard(db->getCard(cardName));
+    setCard(db->getCardBySimpleName(cardName));
 }
 
 void CardFrame::setCard(AbstractCardItem *card)


### PR DESCRIPTION
Quick fix that i don't think is related to a ticket. If you hot-linked a card in chat (i.e. `[[CardName]]`) but didn't have the _correct_ punctuation and caps and such, the big card in games wouldn't show the correct figure. This fixes it