### PR TITLE
remove invalid connect

### DIFF
--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -383,7 +383,6 @@ void TabSupervisor::addRoomTab(const ServerInfo_Room &info, bool setCurrent)
     connect(tab, SIGNAL(maximizeClient()), this, SLOT(maximizeMainWindow()));   
     connect(tab, SIGNAL(roomClosing(TabRoom *)), this, SLOT(roomLeft(TabRoom *)));
     connect(tab, SIGNAL(openMessageDialog(const QString &, bool)), this, SLOT(addMessageTab(const QString &, bool)));
-    connect(tab, SIGNAL(notIdle()), this, SLOT(resetIdleTimer()));
     int tabIndex = myAddTab(tab);
     addCloseButtonToTab(tab, tabIndex);
     roomTabs.insert(info.room_id(), tab);


### PR DESCRIPTION
When running the client, `QObject::connect: No such slot TabSupervisor::resetIdleTimer() in /Users/USER/Desktop/Stuff/Cockatrice/cockatrice/cockatrice/src/tab_supervisor.cpp:386` would appear.

I swear i fixed this in the past...