### PR TITLE
More descriptive reason for "to many requests" when registering

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -455,7 +455,7 @@ void MainWindow::registerError(Response::ResponseCode r, QString reasonStr, quin
             QMessageBox::critical(this, tr("Registration denied"), tr("The email address provider used during registration has been blacklisted for use on this server."));
             break;
         case Response::RespTooManyRequests:
-            QMessageBox::critical(this, tr("Registration denied"), tr("It appears you are attempting to register a new account on this server yet you already have an account registered and the server restricts the number of accounts a user can register.  Please contact the server operator for further assistance or to obtain your credential information."));
+            QMessageBox::critical(this, tr("Registration denied"), tr("It appears you are attempting to register a new account on this server yet you already have an account registered with the email provided. This server restricts the number of accounts a user can register per address.  Please contact the server operator for further assistance or to obtain your credential information."));
             break;
         case Response::RespPasswordTooShort:
             QMessageBox::critical(this, tr("Registration denied"), tr("Password too short."));

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -455,7 +455,7 @@ void MainWindow::registerError(Response::ResponseCode r, QString reasonStr, quin
             QMessageBox::critical(this, tr("Registration denied"), tr("The email address provider used during registration has been blacklisted for use on this server."));
             break;
         case Response::RespTooManyRequests:
-            QMessageBox::critical(this, tr("Registration denied"), tr("Too many registration attempts, please try again later or contact the server operator for further details."));
+            QMessageBox::critical(this, tr("Registration denied"), tr("It appears you are attempting to register a new account on this server yet you already have an account registered and the server restricts the number of accounts a user can register.  Please contact the server operator for further assistance or to obtain your credential information."));
             break;
         case Response::RespPasswordTooShort:
             QMessageBox::critical(this, tr("Registration denied"), tr("Password too short."));


### PR DESCRIPTION
Currently the only way for a user to get a response of "to many registration attempts"  is by the servers configuration to restrict the number of registration attempts but the error message presented to the user is very vague as to why they have been denied.  This PR updates the reasoning.  I'm open for suggestions on any clarity recommendations.

## Related Ticket(s)
I don't believe there is any.

## Short roundup of the initial problem
I would say well over 95% of messages I receive from users comes from the vagueness of this message.  Just looking to clarify it a bit more.

## What will change with this Pull Request?
The user dialogue wording that is presented if they attempt to register to many times.


