### PR TITLE
Check for .xlhq (CCGHQ naming scheme) files

### DIFF
--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -201,6 +201,12 @@ bool PictureLoaderWorker::cardImageExistsOnDisk(QString & setName, QString & cor
             imageLoaded(cardBeingLoaded.getCard(), image);
             return true;
         }
+        imgReader.setFileName(picsPaths.at(i) + ".xlhq");
+        if (imgReader.read(&image)) {
+            qDebug() << "Picture.xlhq found on disk (set: " << setName << " file: " << correctedCardname << ")";
+            imageLoaded(cardBeingLoaded.getCard(), image);
+            return true;
+        }
     }
 
     return false;


### PR DESCRIPTION
## Short roundup of the initial problem
CCHQ has filenames with the pattern `.full.jpg` for their 200DPI images, but Cockatrice doesn't support the `.xlhq.jpg` pattern for their 300DPI images.

## What will change with this Pull Request?
300DPI image support is added.

Stolen (with credit) from @tritoch (https://github.com/tritoch/Cockatrice/commit/714a85181523578c2f0130a1c23ce8aa00fab3b3)