### PR TITLE
Import spoiler.xml as spoiler.xml and overwrite existing

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -1043,25 +1043,35 @@ void MainWindow::actAddCustomSet()
     int nextPrefix = getNextCustomSetPrefix(dir);
 
     bool res = false;
-    if (fileName.indexOf("spoiler.xml") != -1) {
+    if (fileName.compare("spoiler.xml", Qt::CaseInsensitive) == 0)
+    {
+        /*
+         * If the file being added is "spoiler.xml"
+         * then we'll want to overwrite the old version
+         * and replace it with the new one
+         */
         if (QFile::exists(dir.absolutePath() + "/spoiler.xml"))
         {
             QFile::remove(dir.absolutePath() + "/spoiler.xml");
         }
+
+        res = QFile::copy(fileName, dir.absolutePath() + "/spoiler.xml");
+    }
+    else
+    {
         res = QFile::copy(
-            fileName, dir.absolutePath() + "/spoiler.xml"
+                fileName,
+                dir.absolutePath() + "/" + (nextPrefix > 9 ? "" : "0") + QString::number(nextPrefix) + "." + QFileInfo(fileName).fileName()
         );
     }
-    else {
-        res = QFile::copy(
-            fileName, dir.absolutePath() + "/" + (nextPrefix > 9 ? "" : "0") +
-            QString::number(nextPrefix) + "." + QFileInfo(fileName).fileName()
-        );
-    }
-    if (res) {
+
+    if (res)
+    {
         QMessageBox::information(this, tr("Load sets/cards"), tr("The new sets/cards have been added successfully.\nCockatrice will now reload the card database."));
         QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
-    } else {
+    }
+    else
+    {
         QMessageBox::warning(this, tr("Load sets/cards"), tr("Sets/cards failed to import."));
     }
 }

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -1042,11 +1042,22 @@ void MainWindow::actAddCustomSet()
     QDir dir = settingsCache->getCustomCardDatabasePath();
     int nextPrefix = getNextCustomSetPrefix(dir);
 
-    bool res = QFile::copy(
-        fileName, dir.absolutePath() + "/" + (nextPrefix > 9 ? "" : "0") +
-        QString::number(nextPrefix) + "." + QFileInfo(fileName).fileName()
-    );
-
+    bool res = false;
+    if (fileName.indexOf("spoiler.xml") != -1) {
+        if (QFile::exists(dir.absolutePath() + "/spoiler.xml"))
+        {
+            QFile::remove(dir.absolutePath() + "/spoiler.xml");
+        }
+        res = QFile::copy(
+            fileName, dir.absolutePath() + "/spoiler.xml"
+        );
+    }
+    else {
+        res = QFile::copy(
+            fileName, dir.absolutePath() + "/" + (nextPrefix > 9 ? "" : "0") +
+            QString::number(nextPrefix) + "." + QFileInfo(fileName).fileName()
+        );
+    }
     if (res) {
         QMessageBox::information(this, tr("Load sets/cards"), tr("The new sets/cards have been added successfully.\nCockatrice will now reload the card database."));
         QtConcurrent::run(db, &CardDatabase::loadCardDatabases);

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -1027,14 +1027,14 @@ void MainWindow::actAddCustomSet()
     if (!dialog.exec())
         return;
 
-    QString fileName = dialog.selectedFiles().at(0);
+    QString fullFilePath = dialog.selectedFiles().at(0);
 
-    if (!QFile::exists(fileName)) {
+    if (!QFile::exists(fullFilePath)) {
         QMessageBox::warning(this, tr("Load sets/cards"), tr("Selected file cannot be found."));
         return;
     }
 
-    if (QFileInfo(fileName).suffix() != "xml") { // fileName = *.xml
+    if (QFileInfo(fullFilePath).suffix() != "xml") { // fileName = *.xml
         QMessageBox::warning(this, tr("Load sets/cards"), tr("You can only import XML databases at this time."));
         return;
     }
@@ -1043,6 +1043,8 @@ void MainWindow::actAddCustomSet()
     int nextPrefix = getNextCustomSetPrefix(dir);
 
     bool res = false;
+
+    QString fileName = QFileInfo(fullFilePath).fileName();
     if (fileName.compare("spoiler.xml", Qt::CaseInsensitive) == 0)
     {
         /*
@@ -1055,13 +1057,13 @@ void MainWindow::actAddCustomSet()
             QFile::remove(dir.absolutePath() + "/spoiler.xml");
         }
 
-        res = QFile::copy(fileName, dir.absolutePath() + "/spoiler.xml");
+        res = QFile::copy(fullFilePath, dir.absolutePath() + "/spoiler.xml");
     }
     else
     {
         res = QFile::copy(
-                fileName,
-                dir.absolutePath() + "/" + (nextPrefix > 9 ? "" : "0") + QString::number(nextPrefix) + "." + QFileInfo(fileName).fileName()
+                fullFilePath,
+                dir.absolutePath() + "/" + (nextPrefix > 9 ? "" : "0") + QString::number(nextPrefix) + "." + fileName
         );
     }
 


### PR DESCRIPTION
When using Add Sets, spoiler.xml should be imported as spoiler.xml and overwrite existing file if it exists.

## Related Ticket(s)
- Assists with #2764

## Short roundup of the initial problem
When attempting to overwrite a spoiler with a newer version of the spoiler file, using `Add custom set/cards` caused a new, duplicate file to be created.

## What will change with this Pull Request?
- Importing a file named `spoiler.xml` will delete an existing `spoiler.xml` and copy the new one in.
