### PR TITLE
Loyalty now string, xsd fix

### DIFF
--- a/doc/cards.xsd
+++ b/doc/cards.xsd
@@ -44,7 +44,7 @@
                                 <xs:element type="xs:integer" name="tablerow" maxOccurs="1" />
                                 <xs:element type="xs:string" name="text" maxOccurs="1" />
                                 <xs:element type="xs:boolean" name="cipt" minOccurs="0" maxOccurs="1" />
-                                <xs:element type="xs:integer" name="loyalty" minOccurs="0"  maxOccurs="1" />
+                                <xs:element type="xs:string" name="loyalty" minOccurs="0"  maxOccurs="1" />
                                 <xs:element type="xs:string" name="cmc" minOccurs="1" maxOccurs="1" />
                                 <xs:element type="xs:boolean" name="upsidedown" minOccurs="0" maxOccurs="1" />
                                 <xs:element type="xs:boolean" name="token" minOccurs="0" maxOccurs="1" />


### PR DESCRIPTION
Card with `X` loyalty was printed, loyalty now string

## Short roundup of the initial problem
- xsd didn't pass cards with loyalty non-integer, but a card has been printed with `X` loyalty so mtgjson has switched to string for that field.

## What will change with this Pull Request?
- xsd now passes string for loyalty