### PR TITLE
Slightly more accurate XSD.

### DIFF
--- a/doc/cards.xsd
+++ b/doc/cards.xsd
@@ -1,4 +1,13 @@
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="relatedType">
+    <xs:simpleContent>
+        <xs:extension base="xs:string">
+            <xs:attribute type="xs:string" name="count" use="optional"/>
+            <xs:attribute type="xs:string" name="exclude" use="optional"/>
+            <xs:attribute type="xs:string" name="attach" use="optional"/>
+        </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
   <xs:element name="cockatrice_carddatabase">
     <xs:complexType>
       <xs:all>
@@ -7,12 +16,12 @@
                 <xs:sequence>
                     <xs:element name="set" maxOccurs="unbounded" minOccurs="0">
                         <xs:complexType>
-                            <xs:choice maxOccurs="unbounded">
+                            <xs:all>
                                 <xs:element type="xs:string" name="name" minOccurs="1" maxOccurs="1"/>
-                                <xs:element type="xs:string" name="longname" maxOccurs="1" />
-                                <xs:element type="xs:string" name="settype" maxOccurs="1"/>
-                                <xs:element type="xs:string" name="releasedate" maxOccurs="1"/>
-                            </xs:choice>
+                                <xs:element type="xs:string" name="longname" minOccurs="0" maxOccurs="1" />
+                                <xs:element type="xs:string" name="settype" minOccurs="0" maxOccurs="1"/>
+                                <xs:element type="xs:string" name="releasedate" minOccurs="0" maxOccurs="1"/>
+                            </xs:all>
                         </xs:complexType>
                     </xs:element>
                 </xs:sequence>
@@ -23,54 +32,37 @@
                 <xs:sequence>
                     <xs:element name="card" maxOccurs="unbounded" minOccurs="0">
                         <xs:complexType>
-                            <xs:choice maxOccurs="unbounded">
-                                <xs:element type="xs:string" name="name" />
-                                <xs:element name="set" maxOccurs="unbounded" minOccurs="1">
-                                    <xs:complexType>
-                                        <xs:simpleContent>
-                                            <xs:extension base="xs:string">
-                                                <xs:attribute type="xs:int" name="muId" use="optional" />
-                                                <xs:attribute type="xs:anyURI" name="picURL" use="optional" />
-                                                <xs:attribute type="xs:string" name="num"  use="optional" />
-                                                <xs:attribute type="xs:string" name="rarity" use="optional" />
-                                            </xs:extension>
-                                        </xs:simpleContent>
-                                    </xs:complexType>
-                                </xs:element>
-                                <xs:element type="xs:string" name="color" minOccurs="0" maxOccurs="5" />
-                                <xs:element type="xs:string" name="manacost" maxOccurs="1" />
-                                <xs:element type="xs:string" name="type" minOccurs="1" maxOccurs="1" />
-                                <xs:element type="xs:string" name="pt" minOccurs="0" maxOccurs="1" />
-                                <xs:element type="xs:integer" name="tablerow" maxOccurs="1" />
-                                <xs:element type="xs:string" name="text" maxOccurs="1" />
-                                <xs:element type="xs:boolean" name="cipt" minOccurs="0" maxOccurs="1" />
-                                <xs:element type="xs:string" name="loyalty" minOccurs="0"  maxOccurs="1" />
-                                <xs:element type="xs:string" name="cmc" minOccurs="1" maxOccurs="1" />
-                                <xs:element type="xs:boolean" name="upsidedown" minOccurs="0" maxOccurs="1" />
-                                <xs:element type="xs:boolean" name="token" minOccurs="0" maxOccurs="1" />
-                                <xs:element  name="related" minOccurs="0" maxOccurs="unbounded">
-                                    <xs:complexType>
-                                        <xs:simpleContent>
-                                            <xs:extension base="xs:string">
-                                                <xs:attribute type="xs:string" name="count" use="optional"/>
-                                                <xs:attribute type="xs:string" name="exclude" use="optional"/>
-                                                <xs:attribute type="xs:string" name="attach" use="optional"/>
-                                            </xs:extension>
-                                        </xs:simpleContent>
-                                    </xs:complexType>
-                                </xs:element>
-                                <xs:element  name="reverse-related" minOccurs="0" maxOccurs="unbounded">
-                                    <xs:complexType>
-                                        <xs:simpleContent>
-                                            <xs:extension base="xs:string">
-                                                <xs:attribute type="xs:string" name="count" use="optional"/>
-                                                <xs:attribute type="xs:string" name="exclude" use="optional"/>
-                                                <xs:attribute type="xs:string" name="attach" use="optional"/>
-                                            </xs:extension>
-                                        </xs:simpleContent>
-                                    </xs:complexType>
-                                </xs:element>
-                            </xs:choice>
+                            <xs:sequence>
+                                    <xs:element type="xs:string" name="name" />
+                                    <xs:element name="set" maxOccurs="unbounded" minOccurs="1">
+                                        <xs:complexType>
+                                            <xs:simpleContent>
+                                                <xs:extension base="xs:string">
+                                                    <xs:attribute type="xs:int" name="muId" use="optional" />
+                                                    <xs:attribute type="xs:anyURI" name="picURL" use="optional" />
+                                                    <xs:attribute type="xs:string" name="num"  use="optional" />
+                                                    <xs:attribute type="xs:string" name="rarity" use="optional" />
+                                                </xs:extension>
+                                            </xs:simpleContent>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element type="xs:string" name="color" minOccurs="0" maxOccurs="5" />
+                                    <xs:element type="relatedType" name="related" minOccurs="0" maxOccurs="unbounded" />
+                                    <xs:element type="xs:string" name="manacost" minOccurs="0" maxOccurs="1" />
+                                    <xs:element type="xs:string" name="cmc" minOccurs="0" maxOccurs="1" default="0" />
+                                    <xs:element type="xs:string" name="type" minOccurs="1" maxOccurs="1" />
+                                    <xs:element type="xs:string" name="pt" minOccurs="0" maxOccurs="1" />
+                                    <xs:element type="xs:integer" name="tablerow" maxOccurs="1" />
+                                    <xs:element type="xs:string" name="text" minOccurs="0" maxOccurs="1" />
+                                    <xs:element type="xs:boolean" name="cipt" minOccurs="0" maxOccurs="1" />
+                                    <xs:element type="xs:string" name="loyalty" minOccurs="0"  maxOccurs="1" />
+                                    <xs:element type="xs:boolean" name="upsidedown" minOccurs="0" maxOccurs="1" />
+                                    <xs:element type="xs:boolean" name="token" minOccurs="0" maxOccurs="1" />
+                                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                        <xs:element type="relatedType" name="related" />
+                                        <xs:element type="relatedType" name="reverse-related" />
+                                    </xs:choice>
+                            </xs:sequence>
                         </xs:complexType>
                     </xs:element>
                 </xs:sequence>


### PR DESCRIPTION
## Short roundup of the initial problem
The previously pushed XSD does not enforce at least one appearance any element that was required. It's not practical to implement this without a sequence with XML1.0 for this many elements.

### On an unimportant note
Also, cockatrice is writing `<related>` tags after the `<color>` tags in `cards.xml`. That seems like an odd place for the output.