### PR TITLE
Portable mode for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ The following flags can be passed to `cmake`:
 - `-DWITH_SERVER=1` Whether to build the server (default 0 = no).
 - `-DWITH_CLIENT=0` Whether to build the client (default 1 = yes).
 - `-DWITH_ORACLE=0` Whether to build oracle (default 1 = yes).
-- `-DPORTABLE=1` Build portable versions of client & oracle (default 0 = no).
 - `-DCMAKE_BUILD_TYPE=Debug` Compile in debug mode. Enables extra logging output, debug symbols, and much more verbose compiler warnings (default `Release`).
 - `-DUPDATE_TRANSLATIONS=1` Configure `make` to update the translation .ts files for new strings in the source code. Note: Running `make clean` will remove the .ts files (default 0 = no).
 - `-DTEST=1` Enable regression tests (default 0 = no). Note: needs googletest, will be downloaded on the fly if unavailable. To run tests: ```make test```.

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -111,9 +111,9 @@ nsDialogs::Create 1018
 Pop $0
 ${NSD_CreateLabel} 0 10u 100% 24u "Select install mode:"
 Pop $0
-${NSD_CreateRadioButton} 30u 50u -30u 8u "Normal install"
+${NSD_CreateRadioButton} 30u 50u -30u 8u "Normal installation"
 Pop $1
-${NSD_CreateRadioButton} 30u 70u -30u 8u "Portable (all files in a single folder)"
+${NSD_CreateRadioButton} 30u 70u -30u 8u "Portable mode (all files in a single folder)"
 Pop $2
 ${If} $PortableMode = 0
     SendMessage $1 ${BM_SETCHECK} ${BST_CHECKED} 0

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -5,7 +5,7 @@ OutFile "@CPACK_TOPLEVEL_DIRECTORY@/@CPACK_OUTPUT_FILE_NAME@"
 
 !define UNINSTKEY "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice"
 !define DEFAULTNORMALDESTINATON "$ProgramFiles\Cockatrice"
-!define DEFAULTPORTABLEDESTINATON "$Desktop\Cockatrice"
+!define DEFAULTPORTABLEDESTINATON "$Desktop\CockatricePortable"
 !define INST_DIR "@CPACK_TEMPORARY_DIRECTORY@"
 
 RequestExecutionlevel highest

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -1,13 +1,23 @@
 !include ..\..\..\NSIS.definitions.nsh
-!include "MUI2.nsh"
-!include "FileFunc.nsh"
-
 Name "@CPACK_PACKAGE_NAME@"
 BrandingText "@CPACK_PACKAGE_FILE_NAME@"
 OutFile "@CPACK_TOPLEVEL_DIRECTORY@/@CPACK_OUTPUT_FILE_NAME@"
-SetCompressor /SOLID lzma
-InstallDir "$PROGRAMFILES\Cockatrice"
+
+!define UNINSTKEY "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice"
+!define DEFAULTNORMALDESTINATON "$ProgramFiles\Cockatrice"
+!define DEFAULTPORTABLEDESTINATON "$Desktop\Cockatrice"
 !define INST_DIR "@CPACK_TEMPORARY_DIRECTORY@"
+
+RequestExecutionlevel highest
+SetCompressor LZMA
+
+Var NormalDestDir
+Var PortableDestDir
+Var PortableMode
+
+!include LogicLib.nsh
+!include FileFunc.nsh
+!include MUI2.nsh
 
 !define MUI_ABORTWARNING
 !define MUI_WELCOMEFINISHPAGE_BITMAP "${NSIS_SOURCE_PATH}\cmake\leftimage.bmp"
@@ -21,6 +31,8 @@ InstallDir "$PROGRAMFILES\Cockatrice"
 
 !insertmacro MUI_PAGE_WELCOME
 !insertmacro MUI_PAGE_LICENSE "${NSIS_SOURCE_PATH}\COPYING"
+Page Custom PortableModePageCreate PortableModePageLeave
+!define MUI_PAGE_CUSTOMFUNCTION_PRE componentsPagePre
 !insertmacro MUI_PAGE_COMPONENTS
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_INSTFILES
@@ -31,15 +43,126 @@ InstallDir "$PROGRAMFILES\Cockatrice"
 !insertmacro MUI_UNPAGE_INSTFILES
 !insertmacro MUI_UNPAGE_FINISH
 
-!insertmacro MUI_LANGUAGE "English"
+!insertmacro MUI_LANGUAGE English
+
+Function .onInit
+StrCpy $NormalDestDir "${DEFAULTNORMALDESTINATON}"
+StrCpy $PortableDestDir "${DEFAULTPORTABLEDESTINATON}"
+
+${GetParameters} $9
+
+ClearErrors
+${GetOptions} $9 "/?" $8
+${IfNot} ${Errors}
+    MessageBox MB_ICONINFORMATION|MB_SETFOREGROUND "\
+      /PORTABLE : Install in portable mode$\n\
+      /S : Silent install$\n\
+      /D=%directory% : Specify destination directory$\n"
+    Quit
+${EndIf}
+
+ClearErrors
+${GetOptions} $9 "/PORTABLE" $8
+${IfNot} ${Errors}
+    StrCpy $PortableMode 1
+    StrCpy $0 $PortableDestDir
+${Else}
+    StrCpy $PortableMode 0
+    StrCpy $0 $NormalDestDir
+    ${If} ${Silent}
+        Call RequireAdmin
+    ${EndIf}
+${EndIf}
+
+${If} $InstDir == ""
+    ; User did not use /D to specify a directory, 
+    ; we need to set a default based on the install mode
+    StrCpy $InstDir $0
+${EndIf}
+Call SetModeDestinationFromInstdir
+
+FunctionEnd
+
+
+Function RequireAdmin
+UserInfo::GetAccountType
+Pop $8
+${If} $8 != "admin"
+    MessageBox MB_ICONSTOP "You need administrator rights to install Cockatrice"
+    SetErrorLevel 740 ;ERROR_ELEVATION_REQUIRED
+    Abort
+${EndIf}
+FunctionEnd
+
+
+Function SetModeDestinationFromInstdir
+${If} $PortableMode = 0
+    StrCpy $NormalDestDir $InstDir
+${Else}
+    StrCpy $PortableDestDir $InstDir
+${EndIf}
+FunctionEnd
+
+
+Function PortableModePageCreate
+Call SetModeDestinationFromInstdir ; If the user clicks BACK on the directory page we will remember their mode specific directory
+!insertmacro MUI_HEADER_TEXT "Install Mode" "Choose how you want to install Cockatrice."
+nsDialogs::Create 1018
+Pop $0
+${NSD_CreateLabel} 0 10u 100% 24u "Select install mode:"
+Pop $0
+${NSD_CreateRadioButton} 30u 50u -30u 8u "Normal install"
+Pop $1
+${NSD_CreateRadioButton} 30u 70u -30u 8u "Portable (all files in a single folder)"
+Pop $2
+${If} $PortableMode = 0
+    SendMessage $1 ${BM_SETCHECK} ${BST_CHECKED} 0
+${Else}
+    SendMessage $2 ${BM_SETCHECK} ${BST_CHECKED} 0
+${EndIf}
+nsDialogs::Show
+FunctionEnd
+
+Function PortableModePageLeave
+${NSD_GetState} $1 $0
+${If} $0 <> ${BST_UNCHECKED}
+    StrCpy $PortableMode 0
+    StrCpy $InstDir $NormalDestDir
+    Call RequireAdmin
+${Else}
+    StrCpy $PortableMode 1
+    StrCpy $InstDir $PortableDestDir
+${EndIf}
+FunctionEnd
+
+Function componentsPagePre
+${If} $PortableMode = 0
+    SetShellVarContext all
+    ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice" "UninstallString"
+    StrCmp $R0 "" done
+
+    MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "A previous version of Cockatrice must be uninstalled before installing the new one." IDOK uninst
+    Abort
+
+    uninst:
+    ClearErrors
+    ExecWait "$R0"
+
+	done:
+${Else}
+    Abort
+${EndIf}
+FunctionEnd
 
 Section "Application" SecApplication
-	SetShellVarContext all
-	SetOutPath "$INSTDIR"
 
-    @CPACK_NSIS_EXTRA_PREINSTALL_COMMANDS@
-    @CPACK_NSIS_FULL_INSTALL@
+SetShellVarContext all
+SetOutPath "$INSTDIR"
 
+@CPACK_NSIS_EXTRA_PREINSTALL_COMMANDS@
+@CPACK_NSIS_FULL_INSTALL@
+
+${If} $PortableMode = 0
 	WriteUninstaller "$INSTDIR\uninstall.exe"
 	${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
 	IntFmt $0 "0x%08X" $0
@@ -49,16 +172,12 @@ Section "Application" SecApplication
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice" "InstallLocation" "$INSTDIR"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice" "DisplayIcon" "$INSTDIR\cockatrice.exe"
 	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice" "EstimatedSize" "$0"
-SectionEnd
-
-Section "Update configuration" SecUpdateConfig
-	SetShellVarContext current
-	WriteRegStr HKCU "Software\Cockatrice\Cockatrice\paths" "carddatabase" "$LOCALAPPDATA\Cockatrice\cards.xml"
-	WriteRegStr HKCU "Software\Cockatrice\Cockatrice\paths" "tokendatabase" "$LOCALAPPDATA\Cockatrice\tokens.xml"
-	WriteRegStr HKCU "Software\Cockatrice\Cockatrice\paths" "decks" "$LOCALAPPDATA\Cockatrice\decks"
-	WriteRegStr HKCU "Software\Cockatrice\Cockatrice\paths" "pics" "$LOCALAPPDATA\Cockatrice\pics"
-	WriteRegStr HKCU "Software\Cockatrice\Cockatrice\replays" "pics" "$LOCALAPPDATA\Cockatrice\replays"
-	WriteRegStr HKCU "Software\Cockatrice\Cockatrice\sound" "path" "$INSTDIR\sounds"
+${Else}
+    ; Create the file the application uses to detect portable mode
+    FileOpen $0 "$INSTDIR\portable.dat" w
+    FileWrite $0 "PORTABLE"
+    FileClose $0
+${EndIf}
 SectionEnd
 
 Section "Start menu item" SecStartMenu
@@ -105,11 +224,9 @@ Section /o "un.Configurations, decks, cards, pics" UnSecConfiguration
 SectionEnd
 
 LangString DESC_SecApplication ${LANG_ENGLISH} "Cockatrice program files"
-LangString DESC_SecUpdateConfig ${LANG_ENGLISH} "Update the paths in the application settings according to the installation paths."
 LangString DESC_SecStartMenu ${LANG_ENGLISH} "Create start menu items for Cockatrice and Oracle."
 !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
 	!insertmacro MUI_DESCRIPTION_TEXT ${SecApplication} $(DESC_SecApplication)
-	!insertmacro MUI_DESCRIPTION_TEXT ${SecUpdateConfig} $(DESC_SecUpdateConfig)
 	!insertmacro MUI_DESCRIPTION_TEXT ${SecStartMenu} $(DESC_SecStartMenu)
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
@@ -119,20 +236,3 @@ LangString DESC_UnSecConfiguration ${LANG_ENGLISH} "Configurations, decks, card 
 	!insertmacro MUI_DESCRIPTION_TEXT ${UnSecApplication} $(DESC_UnSecApplication)
 	!insertmacro MUI_DESCRIPTION_TEXT ${UnSecConfiguration} $(DESC_UnSecConfiguration)
 !insertmacro MUI_UNFUNCTION_DESCRIPTION_END
-
-
-Function .onInit
-    SetShellVarContext all
-    ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice" "UninstallString"
-    StrCmp $R0 "" done
-
-    MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "A previous version of Cockatrice must be uninstalled before installing the new one." IDOK uninst
-    Abort
-
-uninst:
-    ClearErrors
-    ExecWait "$R0"
-
-done:
-
-FunctionEnd

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -159,6 +159,30 @@ Section "Application" SecApplication
 SetShellVarContext all
 SetOutPath "$INSTDIR"
 
+${If} $PortableMode = 1
+${AndIf} ${FileExists} "$INSTDIR\portable.dat"
+	; upgrade portable mode
+	RMDir /r "$INSTDIR\plugins"
+	RMDir /r "$INSTDIR\sounds"
+	RMDir /r "$INSTDIR\themes"
+	RMDir /r "$INSTDIR\translations"
+	Delete "$INSTDIR\uninstall.exe"
+	Delete "$INSTDIR\cockatrice.exe"
+	Delete "$INSTDIR\oracle.exe"
+	Delete "$INSTDIR\servatrice.exe"
+	Delete "$INSTDIR\Qt*.dll"
+	Delete "$INSTDIR\libmysql.dll"
+	Delete "$INSTDIR\icu*.dll"
+	Delete "$INSTDIR\libeay32.dll"
+	Delete "$INSTDIR\ssleay32.dll"
+	Delete "$INSTDIR\qt.conf"
+	Delete "$INSTDIR\qdebug.txt"
+	Delete "$INSTDIR\servatrice.sql"
+	Delete "$INSTDIR\servatrice.ini.example"
+	Delete "$INSTDIR\zlib*.dll"
+	RMDir "$INSTDIR"
+${EndIf}
+
 @CPACK_NSIS_EXTRA_PREINSTALL_COMMANDS@
 @CPACK_NSIS_FULL_INSTALL@
 

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -181,11 +181,13 @@ ${EndIf}
 SectionEnd
 
 Section "Start menu item" SecStartMenu
+${If} $PortableMode = 0
 	SetShellVarContext all
 	createDirectory "$SMPROGRAMS\Cockatrice"
 	createShortCut "$SMPROGRAMS\Cockatrice\Cockatrice.lnk" "$INSTDIR\cockatrice.exe"
 	createShortCut "$SMPROGRAMS\Cockatrice\Oracle.lnk" "$INSTDIR\oracle.exe"
 	createShortCut "$SMPROGRAMS\Cockatrice\Servatrice.lnk" "$INSTDIR\servatrice.exe"
+${EndIf}
 SectionEnd
 
 Section "un.Application" UnSecApplication

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -308,8 +308,3 @@ Data = Resources\")
         install(FILES ${WIN32SSLRUNTIME_LIBRARIES} DESTINATION ./)
     endif()
 endif()
-#Compile a portable version, default off
-option(PORTABLE "portable build" OFF)
-IF(PORTABLE)
-add_definitions(-DPORTABLE_BUILD)
-endif()

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -130,6 +130,15 @@ GeneralSettingsPage::GeneralSettingsPage()
     QPushButton *tokenDatabasePathButton = new QPushButton("...");
     connect(tokenDatabasePathButton, SIGNAL(clicked()), this, SLOT(tokenDatabasePathButtonClicked()));
     
+    if(settingsCache->getIsPortableBuild())
+    {
+        deckPathButton->setVisible(false);
+        replaysPathButton->setVisible(false);
+        picsPathButton->setVisible(false);
+        cardDatabasePathButton->setVisible(false);
+        tokenDatabasePathButton->setVisible(false);
+    }
+
     QGridLayout *pathsGrid = new QGridLayout;
     pathsGrid->addWidget(&deckPathLabel, 0, 0);
     pathsGrid->addWidget(deckPathEdit, 0, 1);

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -132,6 +132,12 @@ GeneralSettingsPage::GeneralSettingsPage()
     
     if(settingsCache->getIsPortableBuild())
     {
+        deckPathEdit->setEnabled(false);
+        replaysPathEdit->setEnabled(false);
+        picsPathEdit->setEnabled(false);
+        cardDatabasePathEdit->setEnabled(false);
+        tokenDatabasePathEdit->setEnabled(false);
+
         deckPathButton->setVisible(false);
         replaysPathButton->setVisible(false);
         picsPathButton->setVisible(false);
@@ -282,7 +288,14 @@ void GeneralSettingsPage::retranslateUi()
     personalGroupBox->setTitle(tr("Personal settings"));
     languageLabel.setText(tr("Language:"));
     picDownloadCheckBox.setText(tr("Download card pictures on the fly"));
-    pathsGroupBox->setTitle(tr("Paths"));
+
+    if(settingsCache->getIsPortableBuild())
+    {
+        pathsGroupBox->setTitle(tr("Paths (editing disabled in portable mode)"));
+    } else {
+        pathsGroupBox->setTitle(tr("Paths"));
+    }
+
     deckPathLabel.setText(tr("Decks directory:"));
     replaysPathLabel.setText(tr("Replays directory:"));
     picsPathLabel.setText(tr("Pictures directory:"));

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -146,7 +146,8 @@ QString SettingsCache::getSafeConfigFilePath(QString configEntry, QString defaul
 SettingsCache::SettingsCache()
 {
     // first, figure out if we are running in portable mode
-    if(isPortableBuild = QFile::exists(qApp->applicationDirPath() + "/portable.dat"))
+    isPortableBuild = QFile::exists(qApp->applicationDirPath() + "/portable.dat");
+    if(isPortableBuild)
         qDebug() << "Portable mode enabled";
 
     // define a dummy context that will be used where needed

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -10,12 +10,10 @@
 
 QString SettingsCache::getDataPath()
 {
-    return 
-#ifdef PORTABLE_BUILD
-    qApp->applicationDirPath() + "/data/";
-#else
-    QStandardPaths::writableLocation(QStandardPaths::DataLocation);
-#endif
+    if(isPortableBuild)
+        return qApp->applicationDirPath() + "/data/";
+    else
+        return QStandardPaths::writableLocation(QStandardPaths::DataLocation);
 }
 
 QString SettingsCache::getSettingsPath()
@@ -25,9 +23,8 @@ QString SettingsCache::getSettingsPath()
 
 void SettingsCache::translateLegacySettings()
 {
-#ifdef PORTABLE_BUILD
-    return;
-#endif
+    if(isPortableBuild)
+        return;
 
     //Layouts
     QFile layoutFile(getSettingsPath()+"layouts/deckLayout.ini");
@@ -148,6 +145,10 @@ QString SettingsCache::getSafeConfigFilePath(QString configEntry, QString defaul
 }
 SettingsCache::SettingsCache()
 {
+    // first, figure out if we are running in portable mode
+    if(isPortableBuild = QFile::exists(qApp->applicationDirPath() + "/portable.dat"))
+        qDebug() << "Portable mode enabled";
+
     // define a dummy context that will be used where needed
     QString dummy = QT_TRANSLATE_NOOP("i18n", "English");
 

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -115,6 +115,7 @@ private:
     QString getSafeConfigFilePath(QString configEntry, QString defaultPath) const;
     bool rememberGameSettings;
     QList<ReleaseChannel*> releaseChannels;
+    bool isPortableBuild;
 
 public:
     SettingsCache();
@@ -198,6 +199,7 @@ public:
     MessageSettings& messages() const { return *messageSettings; }
     GameFiltersSettings& gameFilters() const { return *gameFiltersSettings; }
     LayoutsSettings& layouts() const { return *layoutsSettings; }
+    bool getIsPortableBuild() const { return isPortableBuild; }
 public slots:
     void setMainWindowGeometry(const QByteArray &_mainWindowGeometry);
     void setTokenDialogGeometry(const QByteArray &_tokenDialog);

--- a/cockatrice/src/soundengine.cpp
+++ b/cockatrice/src/soundengine.cpp
@@ -106,13 +106,8 @@ QStringMap & SoundEngine::getAvailableThemes()
     availableThemes.clear();
 
     // load themes from user profile dir
-    dir =
-#ifdef PORTABLE_BUILD
-        qApp->applicationDirPath() +
-#else
-        QStandardPaths::standardLocations(QStandardPaths::DataLocation).first() +
-#endif
-        "/sounds";
+
+    dir = settingsCache->getDataPath() +  "/sounds";
 
     foreach(QString themeName, dir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot, QDir::Name))
     {

--- a/cockatrice/src/thememanager.cpp
+++ b/cockatrice/src/thememanager.cpp
@@ -38,13 +38,7 @@ QStringMap & ThemeManager::getAvailableThemes()
     availableThemes.clear();
 
     // load themes from user profile dir
-    dir =
-#ifdef PORTABLE_BUILD
-        qApp->applicationDirPath() +
-#else
-        QStandardPaths::standardLocations(QStandardPaths::DataLocation).first() +
-#endif
-        "/themes";
+    dir = settingsCache->getDataPath() + "/themes";
 
     foreach(QString themeName, dir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot, QDir::Name))
     {

--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -207,8 +207,3 @@ Translations = Resources/translations\")
         fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/Oracle.exe\" \"\${QTPLUGINS}\" \"${libSearchDirs}\")
         " COMPONENT Runtime)
 endif() 
-#Compile a portable version, default off
-option(PORTABLE "portable build" OFF)
-IF(PORTABLE)
-add_definitions(-DPORTABLE_BUILD)
-endif()

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -490,9 +490,6 @@ void SaveSetsPage::retranslateUi()
                    "Press \"Save\" to save the imported cards to the Cockatrice database."));
 
     defaultPathCheckBox->setText(tr("Save to the default path (recommended)"));
-    #ifdef PORTABLE_BUILD
-    defaultPathCheckBox->setEnabled(false);
-    #endif
 }
 
 void SaveSetsPage::updateTotalProgress(int cardsImported, int /* setIndex */, const QString &setName)

--- a/servatrice/CMakeLists.txt
+++ b/servatrice/CMakeLists.txt
@@ -195,8 +195,3 @@ Translations = Resources/translations\")
     fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/Servatrice.exe\" \"\${QTPLUGINS}\" \"${QT_LIBRARY_DIR};${MYSQLCLIENT_LIBRARY_DIR}\")
     " COMPONENT Runtime)
 endif()
-#Compile a portable version, default off
-option(PORTABLE "portable build" OFF)
-IF(PORTABLE)
-add_definitions(-DPORTABLE_BUILD)
-endif()

--- a/servatrice/src/settingscache.cpp
+++ b/servatrice/src/settingscache.cpp
@@ -2,10 +2,14 @@
 #include <QCoreApplication>
 #include <QFile>
 #include <QStandardPaths>
+#include <QDebug>
 
 SettingsCache::SettingsCache(const QString & fileName, QSettings::Format format, QObject * parent)
     :QSettings(fileName, format, parent)
 {
+    // first, figure out if we are running in portable mode
+    isPortableBuild = QFile::exists(qApp->applicationDirPath() + "/portable.dat");
+
     QStringList disallowedRegExpStr = value("users/disallowedregexp", "").toString().split(",", QString::SkipEmptyParts);
     disallowedRegExpStr.removeDuplicates();
     for (const QString &regExpStr : disallowedRegExpStr) {
@@ -16,9 +20,12 @@ SettingsCache::SettingsCache(const QString & fileName, QSettings::Format format,
 QString SettingsCache::guessConfigurationPath(QString & specificPath)
 {
     const QString fileName="servatrice.ini";
-    #ifdef PORTABLE_BUILD
-    return fileName;
-    #endif
+    if(QFile::exists(qApp->applicationDirPath() + "/portable.dat"))
+    {
+        qDebug() << "Portable mode enabled";
+        return fileName;
+    }
+
     QString guessFileName;
     // specific path
     if(!specificPath.isEmpty() && QFile::exists(specificPath))

--- a/servatrice/src/settingscache.h
+++ b/servatrice/src/settingscache.h
@@ -10,10 +10,12 @@ class SettingsCache : public QSettings {
     Q_OBJECT
 private:
     QSettings *settings;
+    bool isPortableBuild;
 public:
     SettingsCache(const QString & fileName="servatrice.ini", QSettings::Format format=QSettings::IniFormat, QObject * parent = 0);
     static QString guessConfigurationPath(QString & specificPath);
     QList<QRegExp> disallowedRegExp;
+    bool getIsPortableBuild() const { return isPortableBuild; }
 };
 
 extern SettingsCache *settingsCache;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1616
- Fixes #2789

## Short roundup of the initial problem
Cockatrice already supported portable mode, but had to be compiled with a special flag. Since we didn't provide portable mode builds, this was impossible for users to use.

## What will change with this Pull Request?
Portable mode is now activated when a spacial file named "portable.dat" is present in the same folder of cockatrice.exe.
The NSIS installer offers a choice between normal and portable install; normal installs works as before, while for portable installs there are a few differences:
 * the portable.dat file is created by NSIS during the install;
 * the default install directory is the user's desktop\Cockatrice;
 * no registry keys are touched: no uninstall entry is created, and no check for a previous installation is executed;
 * the "components" dialog is not shown; the "application" is installed and the "start menu" component is not installed.

While running in portable mode, Cockatrice will log "Portable mode enabled" in the debug log and disable the "edit" button for paths selection in the settings dialog.

Additional changes:
 * ask for administrator permissions when installing in "normal" mode;
 * support command line flags (portable mode, silent install, destination dir)
## Screenshots

![schermata 2017-07-03 alle 20 00 34](https://user-images.githubusercontent.com/1631111/27803545-513a0eb6-602a-11e7-887c-423c4f80c3b0.png)

