### PR TITLE
Ignore incomplete unknown sets

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -99,7 +99,7 @@ int SetList::getUnknownSetsNum()
     for (int i = 0; i < size(); ++i)
     {
         CardSet *set = at(i);
-        if(!set->getIsKnown())
+        if(!set->getIsKnown() && !set->getIsKnownIgnored())
             ++num;
     }
     return num;
@@ -111,7 +111,7 @@ QStringList SetList::getUnknownSetsNames()
     for (int i = 0; i < size(); ++i)
     {
         CardSet *set = at(i);
-        if(!set->getIsKnown())
+        if(!set->getIsKnown() && !set->getIsKnownIgnored())
             sets << set->getShortName();
     }
     return sets;
@@ -122,9 +122,13 @@ void SetList::enableAllUnknown()
     for (int i = 0; i < size(); ++i)
     {
         CardSet *set = at(i);
-        if(!set->getIsKnown())
+        if(!set->getIsKnown() && !set->getIsKnownIgnored())
         {
             set->setIsKnown(true);
+            set->setEnabled(true);
+        }
+        else if (set->getIsKnownIgnored() && !set->getEnabled())
+        {
             set->setEnabled(true);
         }
     }
@@ -135,7 +139,8 @@ void SetList::enableAll()
     for (int i = 0; i < size(); ++i)
     {
         CardSet *set = at(i);
-        set->setIsKnown(true);
+        if(!set->getIsKnownIgnored())
+            set->setIsKnown(true);
         set->setEnabled(true);
     }
 }
@@ -145,9 +150,14 @@ void SetList::markAllAsKnown()
     for (int i = 0; i < size(); ++i)
     {
         CardSet *set = at(i);
-        if(!set->getIsKnown())
+        if(!set->getIsKnown() && !set->getIsKnownIgnored())
         {
             set->setIsKnown(true);
+            set->setEnabled(false);
+        }
+        else if (set->getIsKnownIgnored() && !set->getEnabled())
+        {
+            set->setEnabled(true);
         }
     }
 }
@@ -840,6 +850,8 @@ void CardDatabase::checkUnknownSets()
         QStringList unknownSetNames = sets.getUnknownSetsNames();
         if(numUnknownSets > 0)
             emit cardDatabaseNewSetsFound(numUnknownSets, unknownSetNames);
+        else
+            sets.markAllAsKnown();
     } else {
         // No set enabled. Probably this is the first time running trice
         sets.guessSortKeys();

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -43,6 +43,8 @@ public:
     void setEnabled(bool _enabled);
     bool getIsKnown() const { return isknown; }
     void setIsKnown(bool _isknown);
+    //Determine incomplete sets.
+    bool getIsKnownIgnored() const { return longName.length() + setType.length() + releaseDate.toString().length() == 0 ; }
 };
 
 class SetList : public QList<CardSet *> {


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2712

## What will change with this Pull Request?
When checking unknown sets, consider sets with an empty long name, 
set type and release date as 'incomplete'/'partial' sets.

Do not mark partial sets as known, or ask the user to enable them.
Instead, silently enable partial sets.
When a partial set becomes complete, the user is prompted to enable the
set as before. If they choose not to enable, those partial sets are 
disabled, as we can no longer assume they are disabled by default.

### Detail
In practice, a missing `<sets>…<set>…</set>…</sets>` for example set `HOU` will be considered equivalent to a set with 3 zero-length details:
```xml
<set>
    <name>HOU</name>
    <longname></longname>
    <settype></settype>
    <releasedate></releasedate>
</set>
```
