### PR TITLE
enable caching for ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
     env: BUILDTYPE=Debug
     cache:
       ccache: true
+      branch: no-md5deep
       directories:
         - $HOME/Library/Caches/Homebrew   # cache Homebrew ressources
   - os: osx
@@ -23,6 +24,7 @@ matrix:
     env: BUILDTYPE=Release
     cache:
       ccache: true
+      branch: no-md5deep
       directories:
         - $HOME/Library/Caches/Homebrew   # cache Homebrew ressources
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
     env: BUILDTYPE=Debug
     cache:
       ccache: true
+      timeout: 360 # 6min timeout for cache uploading instead default 3
       directories:
         - $HOME/Library/Caches/Homebrew   # cache Homebrew ressources
   - os: osx
@@ -23,6 +24,7 @@ matrix:
     env: BUILDTYPE=Release
     cache:
       ccache: true
+      timeout: 360 # 6min timeout for cache uploading instead default 3
       directories:
         - $HOME/Library/Caches/Homebrew   # cache Homebrew ressources
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,17 @@ matrix:
     dist: trusty
     env: BUILDTYPE=Release DIST=trusty
   - os: osx
-    osx_image: xcode6.4
+    osx_image: xcode7.3
     env: BUILDTYPE=Debug
     cache:
       ccache: true
-      branch: no-md5deep
       directories:
         - $HOME/Library/Caches/Homebrew   # cache Homebrew ressources
   - os: osx
-    osx_image: xcode6.4
+    osx_image: xcode7.3
     env: BUILDTYPE=Release
     cache:
       ccache: true
-      branch: no-md5deep
       directories:
         - $HOME/Library/Caches/Homebrew   # cache Homebrew ressources
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
+sudo: required   # forces legacy build infrastructure
+
 language: cpp
-sudo: required
+
 matrix:
   fast_finish: true
   include:
@@ -12,19 +14,22 @@ matrix:
   - os: osx
     osx_image: xcode6.4
     env: BUILDTYPE=Debug
+    cache:
+      directories:
+        - $HOME/Library/Caches/Homebrew   # cache Homebrew ressources
   - os: osx
     osx_image: xcode6.4
     env: BUILDTYPE=Release
-script: "./travis-compile.sh"
-install: "./travis-dependencies.sh"
+    cache:
+      directories:
+        - $HOME/Library/Caches/Homebrew   # cache Homebrew ressources
+
 cache: ccache
-notifications:
-  webhooks:
-    urls:
-    - https://webhooks.gitter.im/e/d94969c3b01b22cbdcb7
-    on_success: change
-    on_failure: change
-    on_start: never
+
+install: "./travis-dependencies.sh"
+
+script: "./travis-compile.sh"
+
 deploy:
   provider: releases
   api_key:
@@ -38,3 +43,12 @@ deploy:
     tags: true
     repo: Cockatrice/Cockatrice
     condition: $BUILDTYPE = Release
+
+notifications:
+  webhooks:
+    urls:
+    - https://webhooks.gitter.im/e/d94969c3b01b22cbdcb7
+    on_success: change
+    on_failure: change
+    on_start: never
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     env: BUILDTYPE=Release
 script: "./travis-compile.sh"
 install: "./travis-dependencies.sh"
-cache: apt
+cache: ccache
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,14 @@ matrix:
     osx_image: xcode6.4
     env: BUILDTYPE=Debug
     cache:
+      ccache: true
       directories:
         - $HOME/Library/Caches/Homebrew   # cache Homebrew ressources
   - os: osx
     osx_image: xcode6.4
     env: BUILDTYPE=Release
     cache:
+      ccache: true
       directories:
         - $HOME/Library/Caches/Homebrew   # cache Homebrew ressources
 

--- a/travis-compile.sh
+++ b/travis-compile.sh
@@ -8,6 +8,7 @@ mkdir -p build
 cd build
 prefix=""
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+  export PATH="/usr/local/opt/ccache/libexec:$PATH"
   prefix="-DCMAKE_PREFIX_PATH=$(echo /usr/local/opt/qt*/)"
 fi
 if [[ $TRAVIS_OS_NAME == "linux" ]]; then

--- a/travis-dependencies.sh
+++ b/travis-dependencies.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 if [[ $TRAVIS_OS_NAME == "osx" ]] ; then
+  brew install ccache                       # enable caching on mac
+  PATH=/usr/local/opt/ccache/libexec:$PATH  # https://docs.travis-ci.com/user/caching/#ccache-on-OS-X
   brew update > /dev/null
   brew install --force qt@5.7
   brew install protobuf

--- a/travis-dependencies.sh
+++ b/travis-dependencies.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 if [[ $TRAVIS_OS_NAME == "osx" ]] ; then
-  brew install ccache                       # enable caching on mac
-  PATH=/usr/local/opt/ccache/libexec:$PATH  # https://docs.travis-ci.com/user/caching/#ccache-on-OS-X
-  brew update > /dev/null
+  brew install ccache                               # enable caching on mac
+  export PATH=/usr/local/opt/ccache/libexec:$PATH   # https://docs.travis-ci.com/user/caching/#ccache-on-OS-X
+  #brew update > /dev/null
   brew install --force qt@5.7
   brew install protobuf
 else

--- a/travis-dependencies.sh
+++ b/travis-dependencies.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [[ $TRAVIS_OS_NAME == "osx" ]] ; then
-  brew install ccache                               # enable caching on mac
-  export PATH=/usr/local/opt/ccache/libexec:$PATH   # https://docs.travis-ci.com/user/caching/#ccache-on-OS-X
+  brew install ccache                                 # enable caching on mac
+  export PATH="/usr/local/opt/ccache/libexec:$PATH"   # https://docs.travis-ci.com/user/caching/#ccache-on-OS-X
   #brew update > /dev/null
   brew install --force qt@5.7
   brew install protobuf

--- a/travis-dependencies.sh
+++ b/travis-dependencies.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 if [[ $TRAVIS_OS_NAME == "osx" ]] ; then
-  brew install ccache                                 # enable caching on mac
-  export PATH="/usr/local/opt/ccache/libexec:$PATH"   # https://docs.travis-ci.com/user/caching/#ccache-on-OS-X
-  #brew update > /dev/null
+  brew install ccache   # enable caching on mac (PATH only set in travis-compile.sh)
   brew install --force qt@5.7
   brew install protobuf
 else


### PR DESCRIPTION
## Short roundup of the initial problem
- apt cache on travis was never working, see https://github.com/travis-ci/travis-ci/issues/5876
- no caching on appveyor used

## What will change with this Pull Request?
- Travis: use ccache over apt (on mac also cache Homebrew)
to check our travis cache go to: https://travis-ci.org/Cockatrice/Cockatrice/caches
- Appveyor: **TODO**

>Hope to speed up thinks considerably!
>**Build time before:** Travis: linux (5-6min), macos (8-11min) / Appveyor: win (6-7min)
>**Build time after:** Travis: linux (1-2min), macos (5-8min) / Appveyor: win (not enabled yet)
>
>Overall improvement: Travis: ~30min --> ~16min (**-50%**) / Appveyor: **tbd**

<br>

---

Travis caching on osx: https://docs.travis-ci.com/user/caching/#ccache-on-OS-X **done**
Homebrew caching: https://stackoverflow.com/questions/39930171/cache-brew-builds-with-travis-ci **done**

Same should be possible on appveyor: https://www.appveyor.com/docs/build-cache/ **TODO**

cc: @ctrlaltca 