### PR TITLE
Clone in exile graveyard

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2555,14 +2555,10 @@ void Player::updateCardMenu(const CardItem *card)
         }
     }
 
-    if (revealedCard)
-    {
+    if (revealedCard) {
         cardMenu->addAction(aHide);
-    }
-    else if (writeableCard)
-    {
-        if (moveMenu->isEmpty())
-        {
+    } else if (writeableCard) {
+        if (moveMenu->isEmpty()) {
             moveMenu->addAction(aMoveToTopLibrary);
             moveMenu->addAction(aMoveToXfromTopOfLibrary);
             moveMenu->addAction(aMoveToBottomLibrary);
@@ -2574,12 +2570,9 @@ void Player::updateCardMenu(const CardItem *card)
             moveMenu->addAction(aMoveToExile);
         }
 
-        if (card->getZone())
-        {
-            if (card->getZone()->getName() == "table")
-            {
-                if (ptMenu->isEmpty())
-                {
+        if (card->getZone()) {
+            if (card->getZone()->getName() == "table") {
+                if (ptMenu->isEmpty()) {
                     ptMenu->addAction(aIncP);
                     ptMenu->addAction(aDecP);
                     ptMenu->addSeparator();
@@ -2596,8 +2589,7 @@ void Player::updateCardMenu(const CardItem *card)
                 cardMenu->addAction(aUntap);
                 cardMenu->addAction(aDoesntUntap);
                 cardMenu->addAction(aFlip);
-                if (card->getFaceDown())
-                {
+                if (card->getFaceDown()) {
                     cardMenu->addAction(aPeek);
                 }
 
@@ -2605,8 +2597,7 @@ void Player::updateCardMenu(const CardItem *card)
 
                 cardMenu->addSeparator();
                 cardMenu->addAction(aAttach);
-                if (card->getAttachedTo())
-                {
+                if (card->getAttachedTo()) {
                     cardMenu->addAction(aUnattach);
                 }
                 cardMenu->addAction(aDrawArrow);
@@ -2617,49 +2608,36 @@ void Player::updateCardMenu(const CardItem *card)
                 cardMenu->addAction(aClone);
                 cardMenu->addMenu(moveMenu);
 
-                for (int i = 0; i < aAddCounter.size(); ++i)
-                {
+                for (int i = 0; i < aAddCounter.size(); ++i) {
                     cardMenu->addSeparator();
                     cardMenu->addAction(aAddCounter[i]);
-                    if (card->getCounters().contains(i))
-                    {
+                    if (card->getCounters().contains(i)) {
                         cardMenu->addAction(aRemoveCounter[i]);
                     }
                     cardMenu->addAction(aSetCounter[i]);
                 }
                 cardMenu->addSeparator();
-            }
-            else if (card->getZone()->getName() == "stack")
-            {
+            } else if (card->getZone()->getName() == "stack") {
                 cardMenu->addAction(aDrawArrow);
                 cardMenu->addMenu(moveMenu);
 
                 addRelatedCardActions(card, cardMenu);
-            }
-			else if (card->getZone()->getName() == "rfg" || card->getZone()->getName() == "grave")
-			{
+            } else if (card->getZone()->getName() == "rfg" || card->getZone()->getName() == "grave") {
 				cardMenu->addAction(aPlay);
 				cardMenu->addAction(aPlayFacedown);
 				cardMenu->addSeparator();
 				cardMenu->addAction(aClone);
 				cardMenu->addMenu(moveMenu);
-			}
-            else
-            {
+			} else {
                 cardMenu->addAction(aPlay);
                 cardMenu->addAction(aPlayFacedown);
                 cardMenu->addMenu(moveMenu);
             }
-        }
-        else
-        {
+        } else {
             cardMenu->addMenu(moveMenu);
         }
-    }
-    else
-    {
-        if (card->getZone() && card->getZone()->getName() != "hand")
-        {
+    } else {
+        if (card->getZone() && card->getZone()->getName() != "hand") {
             cardMenu->addAction(aDrawArrow);
             cardMenu->addSeparator();
             addRelatedCardActions(card, cardMenu);

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2636,6 +2636,14 @@ void Player::updateCardMenu(const CardItem *card)
 
                 addRelatedCardActions(card, cardMenu);
             }
+			else if (card->getZone()->getName() == "rfg" || card->getZone()->getName() == "grave")
+			{
+				cardMenu->addAction(aPlay);
+				cardMenu->addAction(aPlayFacedown);
+				cardMenu->addSeparator();
+				cardMenu->addAction(aClone);
+				cardMenu->addMenu(moveMenu);
+			}
             else
             {
                 cardMenu->addAction(aPlay);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes narrow scope of initial problem in #2702

## Short roundup of the initial problem
 - Playing a game that required cloning a lot of cards from graveyard and exile required pulling them out individually back to the table to clone them.

## What will change with this Pull Request?
- Add ability to clone cards from graveyard and exile
- small formatting enhancement per style guide

## Screenshots
![exileclone](https://user-images.githubusercontent.com/1735228/28758075-c5bc875c-7545-11e7-983b-89a178c096fa.png)
![graveyardclone](https://user-images.githubusercontent.com/1735228/28758076-c5bd48e0-7545-11e7-8ad6-448661cb5c5e.png)

