### PR TITLE
remove mention-bot config file

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,5 +1,0 @@
-{
-  "message": "@pullRequester, thanks for contributing! @reviewers are the best people to review the changes.",
-  "fileBlacklist": ["*.md"],
-  "userBlacklist": ["@mbruker", "@Psithief"],
-}


### PR DESCRIPTION
## What will change with this Pull Request?
- we don't use mention bot any longer, therefore removing config file