### PR TITLE
Disabling in set window moves row to bottom of list

### DIFF
--- a/cockatrice/src/setsmodel.cpp
+++ b/cockatrice/src/setsmodel.cpp
@@ -135,10 +135,17 @@ void SetsModel::toggleRow(int row, bool enable)
 {
     CardSet *temp = sets.at(row);
 
-    if (enable)
+    int numRows = rowCount();
+
+    if (enable) {
         enabledSets.insert(temp);
-    else
+        swapRows(row, 0);
+    } else {
         enabledSets.remove(temp);
+        swapRows(row, numRows);
+    }
+
+
 
     emit dataChanged(index(row, EnabledCol), index(row, EnabledCol));
 }
@@ -147,13 +154,18 @@ void SetsModel::toggleRow(int row)
 {
     CardSet *tmp = sets.at(row);
 
+    int numRows = rowCount();
+
     if (tmp == nullptr)
         return;
 
-    if (enabledSets.contains(tmp))
+    if (enabledSets.contains(tmp)) {
         enabledSets.remove(tmp);
-    else
+        swapRows(row, numRows);
+    } else {
         enabledSets.insert(tmp);
+        swapRows(row, 0);
+    }
 
     emit dataChanged(index(row, EnabledCol), index(row, EnabledCol));
 }
@@ -190,7 +202,7 @@ void SetsModel::sort(int column, Qt::SortOrder order)
 
     for(row = 0; row < numRows; ++row)
         setMap.insertMulti(index(row, column).data(SetsModel::SortRole).toString(), sets.at(row));
-    
+
     QList<CardSet *> tmp = setMap.values();
     sets.clear();
     if(order == Qt::AscendingOrder)

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -214,6 +214,7 @@ void WndSets::actEnableSome()
 
     foreach(QModelIndex i, rows)
         model->toggleRow(i.row(), true);
+
 }
 
 void WndSets::actDisableSome()

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -211,6 +211,7 @@ void WndSets::actDisableAll()
 void WndSets::actEnableSome()
 {
     QModelIndexList rows = view->selectionModel()->selectedRows();
+
     foreach(QModelIndex i, rows)
         model->toggleRow(i.row(), true);
 }
@@ -218,6 +219,7 @@ void WndSets::actEnableSome()
 void WndSets::actDisableSome()
 {
     QModelIndexList rows = view->selectionModel()->selectedRows();
+
     foreach(QModelIndex i, rows)
         model->toggleRow(i.row(), false);
 }

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -211,16 +211,13 @@ void WndSets::actDisableAll()
 void WndSets::actEnableSome()
 {
     QModelIndexList rows = view->selectionModel()->selectedRows();
-
     foreach(QModelIndex i, rows)
         model->toggleRow(i.row(), true);
-
 }
 
 void WndSets::actDisableSome()
 {
     QModelIndexList rows = view->selectionModel()->selectedRows();
-
     foreach(QModelIndex i, rows)
         model->toggleRow(i.row(), false);
 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2806 

## Short roundup of the initial problem
Wasn't user-friendly to leave disabled sets in current location- Makes more sense to move them to bottom automatically.

## What will change with this Pull Request?
- Disabling a set in the set selection window will now also move it to the bottom of the list.
- This applies if the set is disabled in any way, including setting multiple at once.
