### PR TITLE
Debug Log Qstring warnings

### DIFF
--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -317,6 +317,7 @@ void MessageLogWidget::logDoMoveCard(LogMoveCard &lmc)
     }
 
     QString finalStr;
+    bool usesNewX = false;
     if (targetZone == tableConstant()) {
         soundEngine->playSound("play_card");
         if (moveCardTapped.value(lmc.card))
@@ -338,6 +339,7 @@ void MessageLogWidget::logDoMoveCard(LogMoveCard &lmc)
             finalStr = tr("%1 puts %2%3 on top of their library.");
         else {
             lmc.newX++;
+            usesNewX = true;
             finalStr = tr("%1 puts %2%3 into their library %4 cards from the top.");
         }
     } else if (targetZone == sideboardConstant())
@@ -347,11 +349,19 @@ void MessageLogWidget::logDoMoveCard(LogMoveCard &lmc)
         finalStr = tr("%1 plays %2%3.");
     }
 
-    appendHtmlServerMessage(
+    if (usesNewX) {
+        appendHtmlServerMessage(
+                finalStr.arg(sanitizeHtml(lmc.player->getName()))
+                        .arg(cardStr)
+                        .arg(nameFrom.second)
+                        .arg(lmc.newX));
+    } else {
+        appendHtmlServerMessage(
             finalStr.arg(sanitizeHtml(lmc.player->getName()))
-                    .arg(cardStr)
-                    .arg(nameFrom.second)
-                    .arg(lmc.newX));
+            .arg(cardStr)
+            .arg(nameFrom.second));
+    }
+
 }
 
 void MessageLogWidget::logDrawCards(Player *player, int number)


### PR DESCRIPTION

## Short roundup of the initial problem
 - Noticed "QString::arg: Argument missing:" warnings in Debug Log

## What will change with this Pull Request?
- In logDoMoveCard method in messagelogwidget.cpp, made it only conditionally add the 4th argument that was making the warning happen.

## Screenshots
- Before
![debugqstringbefore](https://user-images.githubusercontent.com/1735228/28992120-33ee63ce-7949-11e7-8173-4816e086f78c.png)
- After
![debugqstringafter](https://user-images.githubusercontent.com/1735228/28992121-3a8ad74e-7949-11e7-84d7-cf6a23c5a16c.png)
