### PR TITLE
Oracle version during importer

### DIFF
--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -24,6 +24,7 @@
 #include "oracleimporter.h"
 #include "main.h"
 #include "settingscache.h"
+#include "version_string.h"
 
 #define ZIP_SIGNATURE "PK"
 #define ALLSETS_URL_FALLBACK "https://mtgjson.com/json/AllSets.json"
@@ -118,6 +119,7 @@ IntroPage::IntroPage(QWidget *parent)
     label->setWordWrap(true);
 
     languageLabel = new QLabel(this);
+    versionLabel = new QLabel(this);
     languageBox = new QComboBox(this);
     QString setLanguage = settingsCache->getLang();
     QStringList qmFiles = findQmFiles();
@@ -133,6 +135,7 @@ IntroPage::IntroPage(QWidget *parent)
     layout->addWidget(label, 0, 0, 1, 2);
     layout->addWidget(languageLabel, 1, 0);
     layout->addWidget(languageBox, 1, 1);
+    layout->addWidget(versionLabel, 4, 0);
 
     setLayout(layout);
 }
@@ -169,6 +172,7 @@ void IntroPage::retranslateUi()
                       "\nYou will need to specify a URL or a filename that "
                       "will be used as a source."));
     languageLabel->setText(tr("Language:"));
+    versionLabel->setText(tr("Version: %1").arg(VERSION_STRING));
 }
 
 LoadSetsPage::LoadSetsPage(QWidget *parent)

--- a/oracle/src/oraclewizard.h
+++ b/oracle/src/oraclewizard.h
@@ -64,7 +64,7 @@ private:
     QStringList findQmFiles();
     QString languageName(const QString &qmFile);
 private:
-     QLabel *label, *languageLabel;
+     QLabel *label, *languageLabel, *versionLabel;
      QComboBox *languageBox;
 private slots:
     void languageBoxChanged(int index);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2693

## Short roundup of the initial problem
- according to ticket, having the version will help with debugging

## What will change with this Pull Request?
- adds version label to Oracle Importer

## Screenshots
![oracleimportversionafter](https://user-images.githubusercontent.com/1735228/28993404-7f81a37a-796a-11e7-9ca5-5b1e9aa83a50.png)

