### PR TITLE
Change only own counters

### DIFF
--- a/cockatrice/src/abstractcounter.cpp
+++ b/cockatrice/src/abstractcounter.cpp
@@ -65,6 +65,9 @@ void AbstractCounter::retranslateUi()
 
 void AbstractCounter::setShortcutsActive()
 {
+    if (!player->getLocal()) {
+        return;
+    }
     if (name == "life") {
         shortcutActive = true;
         aSet->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aSet"));
@@ -97,7 +100,7 @@ void AbstractCounter::setValue(int _value)
 
 void AbstractCounter::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-    if (isUnderMouse()) {
+    if (isUnderMouse() && player->getLocal()) {
         if (event->button() == Qt::LeftButton) {
             Command_IncCounter cmd;
             cmd.set_counter_id(id);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2027

## Short roundup of the initial problem
 In an online game, clicking on your opponent's life or mana counters would update your own

## What will change with this Pull Request?
- if playing online, clicking on your opponent's life or mana counters will now do nothing
- local games are unaffected

