### PR TITLE
[WIP] Fix idle client disabling

### DIFF
--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -387,14 +387,14 @@ void Server_ProtocolHandler::pingClockTimeout()
     if (timeRunning - lastDataReceived > server->getMaxPlayerInactivityTime())
         prepareDestroy();
 
-    if (!userInfo || QString::fromStdString(userInfo->privlevel()).toLower() == "none") {
-        if ((server->getIdleClientTimeout() > 0) && (idleClientWarningSent)) {
+    if ((!userInfo || QString::fromStdString(userInfo->privlevel()).toLower() == "none") && (server->getIdleClientTimeout() > 0)) {
+        if (idleClientWarningSent) {
             if (timeRunning - lastActionReceived > server->getIdleClientTimeout()) {
                 prepareDestroy();
             }
         }
 
-        if (((timeRunning - lastActionReceived) >= ceil(server->getIdleClientTimeout() *.9)) && (!idleClientWarningSent) && (server->getIdleClientTimeout() > 0)) {
+        if (((timeRunning - lastActionReceived) >= ceil(server->getIdleClientTimeout() *.9)) && (!idleClientWarningSent)) {
             Event_NotifyUser event;
             event.set_type(Event_NotifyUser::IDLEWARNING);
             SessionEvent *se = prepareSessionEvent(event);


### PR DESCRIPTION
Updated the idle client timeout value check to properly disable the  idle client checking routines during ping interval timeouts.  

## Short roundup of the initial problem
Prior to this the code inside the loops were always entered and inner loops checked if time out value was set to 0.  This results in delayed server ping responses at higher user loads.

