### PR TITLE
add colourless keyword to filter

### DIFF
--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -178,7 +178,7 @@ bool FilterItem::acceptColor(const CardInfo *info) const
     converted_term.replace(QString("wht"), QString("w"), Qt::CaseInsensitive);
     converted_term.replace(QString(" "), QString(""), Qt::CaseInsensitive);
     
-    if (converted_term.toLower() == "none" || converted_term.toLower() == "c" || converted_term.toLower() == "colorless" || converted_term.toLower() == "colourless") {
+    if (converted_term.toLower() == "none" || converted_term.toLower() == "colorless" || converted_term.toLower() == "c" || converted_term.toLower() == "colourless") {    
         if (info->getColors().length() < 1) {
             return true;
         }

--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -178,7 +178,7 @@ bool FilterItem::acceptColor(const CardInfo *info) const
     converted_term.replace(QString("wht"), QString("w"), Qt::CaseInsensitive);
     converted_term.replace(QString(" "), QString(""), Qt::CaseInsensitive);
     
-    if (converted_term.toLower() == "none" || converted_term.toLower() == "colorless" || converted_term.toLower() == "c") {
+    if (converted_term.toLower() == "none" || converted_term.toLower() == "c" || converted_term.toLower() == "colorless" || converted_term.toLower() == "colourless") {
         if (info->getColors().length() < 1) {
             return true;
         }


### PR DESCRIPTION
## Related Ticket(s)
- extends #2737 for missing term

## Short roundup of the initial problem
british english was missing

## What will change with this Pull Request?
- add `colourless` as option

<br>

Can somebody have a look at the AppVeyor builds, please?
There are some cmake errors due to deprecation and cmake_policy.