### PR TITLE
add link to project roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ We offer downloads for all full releases (recommended) and the latest developmen
 If you'd like to contribute code to the project, please review [the guidelines](https://github.com/Cockatrice/Cockatrice/blob/master/.github/CONTRIBUTING.md).
 We maintain a tag for "easy" changes on our issue tracker: issues tagged in this way provide a simple way to get started. [Issues tagged as Easy Changes](https://github.com/Cockatrice/Cockatrice/issues?q=is%3Aopen+is%3Aissue+label%3A%22Easy+Change%22)
 
+Check our long-term project **roadmap** with some visions [here](https://docs.google.com/document/d/1Ewe5uSaRE2nR2pNPMaGmP6gVZdqgFbBgwSscGqIr4W0/edit).
+
 We try to be very responsive to new issues. We'll try to give you advice on how a feature should be implemented / advice on places the codebase is doing something similar before you get too far along with a PR.
 
 


### PR DESCRIPTION
## Short roundup of the initial problem
no way to find roadmap

## What will change with this Pull Request?
- easy link in readme


Is there some kind of linking we can do without writing permissions?
Just realized that like this, everybody should be able to make suggestions to the file, I think we don't want to mess it up that easily.
If we can have a view-only link i would prefer to put that here instead @Daenyth.