### PR TITLE
Update .gitlab-ci.yml with new Ubuntu support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
+---
 stages:
   - build
-  - deploy
 
 .artifacts: &artifacts
   artifacts:
@@ -60,6 +60,16 @@ stages:
     - apt-get -o dir::cache::archives="cache" install -y libqt5svg5-dev libqt5sql5-mysql
     - apt-get -o dir::cache::archives="cache" install -y libqt5websockets5-dev
 
+.requirements_17xx: &install_requirements_17xx
+  before_script:
+    - apt-get -o dir::cache::archives="cache" update -qq
+    - apt-get -o dir::cache::archives="cache" install -y build-essential g++ cmake git
+    - apt-get -o dir::cache::archives="cache" install -y libprotobuf-dev protobuf-compiler
+    - apt-get -o dir::cache::archives="cache" install -y qt5-default qttools5-dev qttools5-dev-tools
+    - apt-get -o dir::cache::archives="cache" install -y qtmultimedia5-dev libqt5multimedia5-plugins
+    - apt-get -o dir::cache::archives="cache" install -y libqt5svg5-dev libqt5sql5-mysql
+    - apt-get -o dir::cache::archives="cache" install -y libqt5websockets5-dev
+
 .build_1604: &1604
   image: ubuntu:16.04
   <<: *tags
@@ -73,6 +83,22 @@ stages:
   <<: *tags
   <<: *branches
   <<: *install_requirements_16xx
+  <<: *artifacts_deb
+  <<: *cache
+
+.build_1704: &1704
+  image: ubuntu:17.04
+  <<: *tags
+  <<: *branches
+  <<: *install_requirements_17xx
+  <<: *artifacts_deb
+  <<: *cache
+
+.build_1710: &1710
+  image: ubuntu:17.10
+  <<: *tags
+  <<: *branches
+  <<: *install_requirements_17xx
   <<: *artifacts_deb
   <<: *cache
 
@@ -93,6 +119,28 @@ build_rc_1610:
 
 build_debug_1610:
   <<: *1610
+  <<: *build_debug_package_deb
+  when: always
+  allow_failure: true
+
+build_rc_1704:
+  <<: *1704
+  <<: *build_rc_package_deb
+  when: always
+
+build_debug_1704:
+  <<: *1704
+  <<: *build_debug_package_deb
+  when: always
+  allow_failure: true
+
+build_rc_1710:
+  <<: *1710
+  <<: *build_rc_package_deb
+  when: always
+
+build_debug_1710:
+  <<: *1710
   <<: *build_debug_package_deb
   when: always
   allow_failure: true
@@ -126,66 +174,4 @@ build_debug_stretch:
   <<: *build_debug_package_deb
   when: always
   allow_failure: true
-
-
-#============================== REDHAT-BASED ==================================
-
-.build_rc_package_rpm: &build_rc_package_rpm
-  stage: build
-  script:
-    - mkdir -p build
-    - cd build
-    - cmake .. -DWITH_SERVER=1 -DCMAKE_BUILD_TYPE=Release -DCPACK_GENERATOR=RPM
-    - make package -j2
-
-.build_debug_package_rpm: &build_debug_package_rpm
-  stage: build
-  script:
-    - mkdir -p build
-    - cd build
-    - cmake .. -DWITH_SERVER=1 -DCMAKE_BUILD_TYPE=Debug -DCPACK_GENERATOR=RPM
-    - make package -j2
-
-.rpm-artifacts: &artifacts_rpm
-  artifacts:
-    paths:
-      - build/*.rpm
-      - build/CMakeFiles/*.log
-    when: always
-
-#--------------------------------- FEDORA -------------------------------------
-
-.requirements_fedora22: &install_requirements_fedora22
-  before_script:
-    - /usr/bin/dnf -y groupinstall "development tools"
-    - /usr/bin/dnf -y install wget qt5* cmake libgcrypt-devel dh-autoreconf gcc-c++
-    - /usr/bin/dnf -y install protobuf protobuf-devel rpm-build
-
-.build_fedora22: &fedora22
-  image: fedora:22
-  <<: *tags
-  <<: *branches
-  <<: *install_requirements_fedora22
-  <<: *artifacts_rpm
-  <<: *cache
-
-build_rc_fedora22:
-  <<: *fedora22
-  <<: *build_rc_package_rpm
-  when: always
-
-build_debug_fedora22:
-  <<: *fedora22
-  <<: *build_debug_package_rpm
-  when: always
-
-
-#=================================== DEPLOY ===================================
-
-# deploy_to_s3: # currently unused; requires some config
-#   stage: deploy
-#   script:
-#     # if CI_BUILD_TAG is undefined, use git hash instead of version number
-#     # otherwise, treat git tag as version number
-#     # TODO: add deploy commands
-#   when: on_success
+  


### PR DESCRIPTION
Remove support for Fedora 22 (been EOL for a while)
Add support for Ubuntu 17.04 and 17.10

Note that debug builds for 17.04 and 17.10 are still affected by #2343, and so always fail.

Example pipeline using updated yml: https://gitlab.tetrarch.co/cockatrice/cockatrice/pipelines/389/builds
Job 1560 failed for reasons unrelated to this PR.

## Related Ticket(s)
- awaiting feedback from #2868, #2869, or anyone with an Ubuntu system running 17.04 or 17.10

## Short roundup of the initial problem
- Ubuntu 17.04 and 17.10 do not have supplied builds.
- Fedora 22 has been EOL for a long time and newer Fedora versions have Cocktrice in the repos, so builds for it are unnecessary.

## What will change with this Pull Request?
- The new Ubuntu versions will be built by gitlab.
- Fedora 22 will no longer be built by gitlab.
