### PR TITLE
Correct VS2017 Compile Issue

### DIFF
--- a/servatrice/CMakeLists.txt
+++ b/servatrice/CMakeLists.txt
@@ -109,7 +109,11 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 # Build servatrice binary and link it
 ADD_EXECUTABLE(servatrice MACOSX_BUNDLE ${servatrice_SOURCES} ${servatrice_RESOURCES_RCC} ${servatrice_MOC_SRCS})
 
-TARGET_LINK_LIBRARIES(servatrice cockatrice_common ${CMAKE_THREAD_LIBS_INIT})
+if(MSVC)
+    TARGET_LINK_LIBRARIES(servatrice cockatrice_common ${CMAKE_THREAD_LIBS_INIT} Qt5::WinMain)
+else()
+    TARGET_LINK_LIBRARIES(servatrice cockatrice_common ${CMAKE_THREAD_LIBS_INIT})
+endif()
 qt5_use_modules(servatrice ${SERVATRICE_LIBS})
 
 # install rules


### PR DESCRIPTION
Fix #2877 

This PR adds back the removed CMAKE lines during cleanup of the previous commit that appears to have broken VS2017 compiling of the servatrice application.

@ctrlaltca  
You see any reason why this shouldn't be added back ?  Maybe you know a better way of doing what it does.