### PR TITLE
Fixed life points not showing (#2868), fixes #2868

### DIFF
--- a/cockatrice/src/playertarget.cpp
+++ b/cockatrice/src/playertarget.cpp
@@ -11,7 +11,7 @@
 #endif /* _WIN32 */
 
 PlayerCounter::PlayerCounter(Player *_player, int _id, const QString &_name, int _value, QGraphicsItem *parent)
-    : AbstractCounter(_player, _id, _name, false, _value, parent)
+    : AbstractCounter(_player, _id, _name, false, _value, false, parent)
 {
 }
 


### PR DESCRIPTION
Added a missing parameter on an AbstractCounter inheritance (fixes #2868 and fixes #2846)