### PR TITLE
fix deckstats.net regex

### DIFF
--- a/cockatrice/src/deckstats_interface.cpp
+++ b/cockatrice/src/deckstats_interface.cpp
@@ -28,8 +28,8 @@ void DeckStatsInterface::queryFinished(QNetworkReply *reply)
         
     QString data(reply->readAll());
     reply->deleteLater();
-    
-    QRegExp rx("<meta property=\"og:url\" content=\"([^\"]+)\"/>");
+
+    QRegExp rx("<meta property=\"og:url\" content=\"([^\"]+)\"");
     if (-1 == rx.indexIn(data)) {
         QMessageBox::critical(0, tr("Error"), tr("The reply from the server could not be parsed."));
         deleteLater();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2853 

## Short roundup of the initial problem
Deckstats would not open the URL even though the 3rd party client was receiving our data. It seems that when they sent us the data back, there was a change in spacing. 

Here's the change:
Old: <kbd>\<meta property="og:url" content="..."/></kbd>
New: <kbd>\<meta property="og:url" content="..." /></kbd>
(Notice the added space at the end!)

## What will change with this Pull Request?
This PR will remove the check for `/>` and just parse out the URL. We have enough information from the regex that we can leave this small portion off.