### PR TITLE
AppVeyor: prevent unnecessary builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,9 +3,9 @@ version: 2.3.18-branch-{branch}-build-{build}
 # Skipping commits affecting specific files (GitHub only). More details here: /docs/appveyor-yml
 skip_commits:
   files:
-    - .github/*
-    - .travis/*
-    - .tx/*
+    - '.github/*'
+    - '.travis/*'
+    - '.tx/*'
     - webclient/*
     - .*ignore
     - .gitlab-ci.yml

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -69,9 +69,9 @@ build_script:
     - msbuild PACKAGE.vcxproj /p:Configuration=Release
     - ps: |
         $exe = dir -name *.exe
-        $new_name = $exe.Replace(".exe", "-${env:target_arch}.exe")
+        $new_name = $exe.Replace(".exe", "-${env:target_arch}_qt5.exe")
         Push-AppveyorArtifact $exe -FileName $new_name
-        $cmake_name = $exe.Replace(".exe", "-${env:target_arch}.cmake.txt")
+        $cmake_name = $exe.Replace(".exe", "-${env:target_arch}_qt5.cmake.txt")
         Push-AppveyorArtifact CMakeCache.txt -FileName $cmake_name
         $json = New-Object PSObject
         (New-Object PSObject | Add-Member -PassThru NoteProperty bin $new_name | Add-Member -PassThru NoteProperty cmake $cmake_name | Add-Member -PassThru NoteProperty commit $env:APPVEYOR_REPO_COMMIT) | ConvertTo-JSON | Out-File -FilePath "latest-$env:target_arch" -Encoding ASCII

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,23 @@
 version: 2.3.18-branch-{branch}-build-{build}
+
+# Skipping commits affecting specific files (GitHub only). More details here: /docs/appveyor-yml
+skip_commits:
+  files:
+    - .github/*
+    - .travis/*
+    - .tx/*
+    - webclient/*
+    - .*ignore
+    - .gitlab-ci.yml
+    - .travis.yml
+    - *.md
+    
 image: Visual Studio 2015
+
 cache:
     - c:\protobuf-release
     - c:\zlib-release
+    
 environment:
     matrix:
         - qt_ver: 5.9\msvc2015_64
@@ -17,6 +32,7 @@ environment:
           cmake_generator: Visual Studio 14 2015
           cmake_toolset: v140_xp # use the windows XP compatible toolset
           target_arch: x86
+          
 install:
     - ps: |
         if (Test-Path c:\protobuf-release) {
@@ -37,8 +53,10 @@ install:
             cmake . -G "$env:cmake_generator" -T "$env:cmake_toolset" -DCMAKE_INSTALL_PREFIX=c:/zlib-release
             msbuild INSTALL.vcxproj /p:Configuration=Release
         }
+        
 services:
     - mysql
+    
 build_script:
     - ps: |
         New-Item -ItemType directory -Path $env:APPVEYOR_BUILD_FOLDER\build
@@ -51,20 +69,22 @@ build_script:
     - msbuild PACKAGE.vcxproj /p:Configuration=Release
     - ps: |
         $exe = dir -name *.exe
-        $new_name = $exe.Replace(".exe", "-${env:target_arch}_qt5.exe")
+        $new_name = $exe.Replace(".exe", "-${env:target_arch}.exe")
         Push-AppveyorArtifact $exe -FileName $new_name
-        $cmake_name = $exe.Replace(".exe", "-${env:target_arch}_qt5.cmake.txt")
+        $cmake_name = $exe.Replace(".exe", "-${env:target_arch}.cmake.txt")
         Push-AppveyorArtifact CMakeCache.txt -FileName $cmake_name
         $json = New-Object PSObject
         (New-Object PSObject | Add-Member -PassThru NoteProperty bin $new_name | Add-Member -PassThru NoteProperty cmake $cmake_name | Add-Member -PassThru NoteProperty commit $env:APPVEYOR_REPO_COMMIT) | ConvertTo-JSON | Out-File -FilePath "latest-$env:target_arch" -Encoding ASCII
         Push-AppveyorArtifact "latest-$env:target_arch"
         $version = $matches['content']
+        
 test: off
+
 deploy:
-  description: "Dev build of Cockatrice"
   provider: GitHub
   auth_token:
     secure: p+7wPVry2XEa6TBm9XH8IaQZbBmXQ/J2ldbGmcIxUZD3NkkPrSRRlmE7Of1CBBIO
+  description: "Dev build of Cockatrice"
   artifact: /.*\.exe/
   draft: false
   prerelease: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 version: 2.3.18-branch-{branch}-build-{build}
 
-# Skipping commits affecting specific files (GitHub only). More details here: /docs/appveyor-yml
+# Skipping commits affecting specific files (GitHub only). More details here: https://www.appveyor.com/docs/appveyor-yml
 skip_commits:
   files:
     - .github/*

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,14 +3,14 @@ version: 2.3.18-branch-{branch}-build-{build}
 # Skipping commits affecting specific files (GitHub only). More details here: /docs/appveyor-yml
 skip_commits:
   files:
-    - '.github/*'
-    - '.travis/*'
-    - '.tx/*'
+    - .github/*
+    - .travis/*
+    - .tx/*
     - webclient/*
     - .*ignore
     - .gitlab-ci.yml
     - .travis.yml
-    - *.md
+    - '*.md'
     
 image: Visual Studio 2015
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,9 @@
 .git/
-CONTRIBUTING.md
-Dockerfile
-TODO.md
 build/
+.github/
+.travis/
+.tx/
 cockatrice/
 doc/
 oracle/
-sounds/
-travis-compile.sh
-travis-dependencies.sh
+Dockerfile

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 ### Compatibility ###
 
-Cockatrice is compiled on all platform using C++11, even if the majority of the
-code is written in C++03.
+Cockatrice is compiled on all platform using <kbd>C++11</kbd>, even if the majority of the
+code is written in <kbd>C++03</kbd>.
 
 For consistency, use Qt data structures where possible, such as `QString` over
 `std::string` or `QList` over `std::vector`.

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,3 +56,5 @@ notifications:
     on_failure: change
     on_start: never
     
+# official validator for travis.yml config files: https://yaml.travis-ci.org
+# travis documentation: https://docs.travis-ci.com/user/customizing-the-build

--- a/.tx/config
+++ b/.tx/config
@@ -10,4 +10,3 @@ source_lang = en
 file_filter = oracle/translations/oracle_<lang>.ts
 source_file = oracle/translations/oracle_en.ts
 source_lang = en
-

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We offer downloads for all full releases (recommended) and the latest developmen
 
 - Latest full release (**recommended**): [![Download from GitHub Releases](https://img.shields.io/github/release/cockatrice/cockatrice.svg)](https://github.com/cockatrice/cockatrice/releases/latest) [![Download Count on Latest Release](https://img.shields.io/github/downloads/cockatrice/cockatrice/latest/total.svg)](https://tooomm.github.io/github-release-stats/?username=Cockatrice&repository=Cockatrice)<br>
 
-- Latest development version: [![Download from GitHub Pre-Releases](https://img.shields.io/github/release/cockatrice/cockatrice/all.svg)](https://github.com/cockatrice/cockatrice/releases)
+- Latest development version: [![Download from GitHub Pre-Releases](https://img.shields.io/github/release/cockatrice/cockatrice/all.svg)](https://github.com/cockatrice/cockatrice/releases) 
    - Development builds may not be stable and/or contain several bugs.
    - If you'd like to be a Cockatrice Beta Tester, use this version.
    - More information can be [found here](https://github.com/Cockatrice/Cockatrice/wiki/Release-Channels)


### PR DESCRIPTION
## Short roundup of the initial problem
AppVeyor CI always started builds, also on completely unrelated changes.

## What will change with this Pull Request?
- prevent builds on .md changes, like a README.md update
- prevent builds on config changes for other services, like travis, transifex, gitlab or github

Results in faster check marks for quicker merging. Also, important builds don't queue up and have to wait for such unrelated build to finish.
For example, travis is building this change to a appveyor config file, a total waste and delay!

Am I correct, that we don't want AppVeyor to build changes made in the webclient as well?
Did I miss anything?

---

~~This also removes the `qt5` extension for the windows builds. We don't use such a tag for our macOS and Linux builds.~~
Sadly this is needed as of now:
https://github.com/Cockatrice/Cockatrice/blob/ff6b0f86ec6d3bf76d6667003b82ce24479c0d15/cockatrice/src/releasechannel.cpp#L59-L68
We need a workaround for this to finally remove it in future versions. At best **before** releasing a new version. Just add an additional check for `-x86_64` and `-x86` without `qt5` for the transition period?