### PR TITLE
exclude translation files from codacy

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,7 @@ skip_commits:
     - .tx/*
     - webclient/*
     - .*ignore
+    - .codacy.yml
     - .gitlab-ci.yml
     - .travis.yml
     - '*.md'

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,5 @@
+---
+exclude_paths:
+  - '**/translations/*.ts'
+  
+  # see https://support.codacy.com/hc/en-us/articles/115002130625-Codacy-Configuration-File


### PR DESCRIPTION
## Related Ticket(s)
- recent translation strings update: https://github.com/Cockatrice/Cockatrice/pull/2890

## Short roundup of the initial problem
Codacy needs ages to analyze code-unrelated changes that alter a lot of lines

## What will change with this Pull Request?
- introduce codacy config file
- ignore changes on translation files for codacy