### PR TITLE
Deck editor: force default file extension on file save; fix #2829

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -720,7 +720,7 @@ bool TabDeckEditor::actSaveDeckAs()
     dialog.setConfirmOverwrite(true);
     dialog.setDefaultSuffix("cod");
     dialog.setNameFilters(DeckLoader::fileNameFilters);
-    dialog.selectFile(deckModel->getDeckList()->getName().trimmed());
+    dialog.selectFile(deckModel->getDeckList()->getName().trimmed() + ".cod");
     if (!dialog.exec())
         return false;
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2869

## Short roundup of the initial problem
The "save file as" file dialog in deck editor was defining a "default suffix" for the file but not explicitly adding the `cod` file extension to the proposed file name.
It looks like not all native "save file" dialogs works the same way, so the one in Ubuntu (Unity) was causing files to be saved with no extension at all by default.

## What will change with this Pull Request?
The extension is explicitly adde to the proposed file name.

