### PR TITLE
version number bump to next patch

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.3.18-branch-{branch}-build-{build}
+version: 2.4.1-branch-{branch}-build-{build}
 
 # Skipping commits affecting specific files (GitHub only). More details here: https://www.appveyor.com/docs/appveyor-yml
 skip_commits:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ ENDIF()
 
 # A project name is needed for CPack
 # Version can be overriden by git tags, see cmake/getversion.cmake
-PROJECT("Cockatrice" VERSION 2.3.18)
+PROJECT("Cockatrice" VERSION 2.4.1)
 
 # Use c++11 for all targets
 set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ ISO Standard")


### PR DESCRIPTION
new release version in the tag is going to be: `2.4.0`
therefore bumping this to the followup `2.4.1`
