### PR TITLE
Fix for Aftermath and Split Cards when sending to Tappedout; fix #2942

### DIFF
--- a/cockatrice/src/tappedout_interface.cpp
+++ b/cockatrice/src/tappedout_interface.cpp
@@ -78,8 +78,8 @@ void TappedOutInterface::getAnalyzeRequestData(DeckList *deck, QByteArray *data)
     QUrl params;
     QUrlQuery urlQuery;
     urlQuery.addQueryItem("name", deck->getName());
-    urlQuery.addQueryItem("mainboard", mainboard.writeToString_Plain(false));
-    urlQuery.addQueryItem("sideboard", sideboard.writeToString_Plain(false));
+    urlQuery.addQueryItem("mainboard", mainboard.writeToString_Plain(false, true));
+    urlQuery.addQueryItem("sideboard", sideboard.writeToString_Plain(false, true));
     params.setQuery(urlQuery);
     data->append(params.query(QUrl::EncodeReserved));
 }

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -647,7 +647,7 @@ struct WriteToStream {
 	   stream << QString("%1 %2\n").arg(
 	       card->getNumber()
 	   ).arg(
-               card->getName().replace("//", "/").replace("Who / What / When / Where / Why", "Who/What/When/Where/Why")
+               card->getName().replace("//", "/")
            );
        }
     }

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -647,7 +647,7 @@ struct WriteToStream {
 	   stream << QString("%1 %2\n").arg(
 	       card->getNumber()
 	   ).arg(
-               card->getName().replace("//", "/")
+               card->getName().replace("//", "/").replace("Who / What / When / Where / Why", "Who/What/When/Where/Why")
            );
        }
     }

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -638,18 +638,17 @@ struct WriteToStream {
            stream << "SB: ";
        }
        if (!slashTappedOutSplitCards) {
+           stream << QString("%1 %2\n").arg(
+               card->getNumber()
+           ).arg(
+               card->getName()
+	   );
+       } else {
 	   stream << QString("%1 %2\n").arg(
 	       card->getNumber()
-	     ).arg(
-		   card->getName()
-	   );
-       }
-       else {
-	   stream << QString("%1 %2\n").arg(
-	       card->getNumber()
-	     ).arg(
-		   card->getName().replace("//", "/")
-	   );
+	   ).arg(
+               card->getName().replace("//", "/")
+           );
        }
     }
 };

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -626,8 +626,9 @@ bool DeckList::loadFromFile_Plain(QIODevice *device)
 struct WriteToStream {
     QTextStream &stream;
     bool prefixSideboardCards;
+    bool slashTappedOutSplitCards;
 
-    WriteToStream(QTextStream &_stream, bool _prefixSideboardCards) : stream(_stream), prefixSideboardCards(_prefixSideboardCards) {}
+  WriteToStream(QTextStream &_stream, bool _prefixSideboardCards, bool _slashTappedOutSplitCards):  stream(_stream), prefixSideboardCards(_prefixSideboardCards), slashTappedOutSplitCards(_slashTappedOutSplitCards) {}
 
     void operator()(
         const InnerDecklistNode *node,
@@ -636,32 +637,41 @@ struct WriteToStream {
        if (prefixSideboardCards && node->getName() == DECK_ZONE_SIDE) {
            stream << "SB: ";
        }
-       stream << QString("%1 %2\n").arg(
-           card->getNumber()
-       ).arg(
-           card->getName()
-       );
+       if (!slashTappedOutSplitCards) {
+	   stream << QString("%1 %2\n").arg(
+	       card->getNumber()
+	     ).arg(
+		   card->getName()
+	   );
+       }
+       else {
+	   stream << QString("%1 %2\n").arg(
+	       card->getNumber()
+	     ).arg(
+		   card->getName().replace("//", "/") //kbg
+	   );
+       }
     }
 };
 
-bool DeckList::saveToStream_Plain(QTextStream &out, bool prefixSideboardCards)
+  bool DeckList::saveToStream_Plain(QTextStream &out, bool prefixSideboardCards, bool slashTappedOutSplitCards)
 {
-    WriteToStream writeToStream(out, prefixSideboardCards);
+    WriteToStream writeToStream(out, prefixSideboardCards, slashTappedOutSplitCards);
     forEachCard(writeToStream);
     return true;
 }
 
-bool DeckList::saveToFile_Plain(QIODevice *device, bool prefixSideboardCards)
+bool DeckList::saveToFile_Plain(QIODevice *device, bool prefixSideboardCards, bool slashTappedOutSplitCards)
 {
     QTextStream out(device);
-    return saveToStream_Plain(out, prefixSideboardCards);
+    return saveToStream_Plain(out, prefixSideboardCards, slashTappedOutSplitCards);
 }
 
-QString DeckList::writeToString_Plain(bool prefixSideboardCards)
+QString DeckList::writeToString_Plain(bool prefixSideboardCards, bool slashTappedOutSplitCards)
 {
     QString result;
     QTextStream out(&result);
-    saveToStream_Plain(out, prefixSideboardCards);
+    saveToStream_Plain(out, prefixSideboardCards, slashTappedOutSplitCards);
     return result;
 }
 

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -648,7 +648,7 @@ struct WriteToStream {
 	   stream << QString("%1 %2\n").arg(
 	       card->getNumber()
 	     ).arg(
-		   card->getName().replace("//", "/") //kbg
+		   card->getName().replace("//", "/")
 	   );
        }
     }

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -151,9 +151,9 @@ public:
     bool saveToFile_Native(QIODevice *device);
     bool loadFromStream_Plain(QTextStream &stream);
     bool loadFromFile_Plain(QIODevice *device);
-    bool saveToStream_Plain(QTextStream &stream, bool prefixSideboardCards);
-    bool saveToFile_Plain(QIODevice *device, bool prefixSideboardCards=true);
-    QString writeToString_Plain(bool prefixSideboardCards=true);
+    bool saveToStream_Plain(QTextStream &stream, bool prefixSideboardCards, bool slashTappedOutSplitCards);
+    bool saveToFile_Plain(QIODevice *device, bool prefixSideboardCards=true, bool slashTappedOutSplitCards=false);
+    QString writeToString_Plain(bool prefixSideboardCards=true, bool slashTappedOutSplitCards=false);
 
     void cleanList();
     bool isEmpty() const { return root->isEmpty() && name.isEmpty() && comments.isEmpty() && sideboardPlans.isEmpty(); }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2942 

## Short roundup of the initial problem
Split cards show up as only the first half of the card when a list is uploaded to tappedout due to an inconsistency in card naming. Tappedout uses "Side1 / Side2" instead of "Side1 // Side2".

## What will change with this Pull Request?
- This makes a few changes to how a card list is generated when it's pushed to Tappedout and adds a boolean flag that causes "//" to be replaced with "/" if the flag is true. The changes below fix the issue for all split black bordered cards. The only card that remains broken is the silver card "Who//What//When//Where//Why", which causes an "Unable to analyze the deck" error.

## Screenshots
This change generates the following list: http://tappedout.net/mtg-deckpaste/07-12-17-fij-deck-paste/

The test list is as follows (every black bordered split card):
```
// 62 Maindeck
// 32 Instant
1 Leave // Chance
1 Commit // Memory
1 Failure // Comply
1 Consign // Oblivion
1 Refuse // Cooperate
1 Stand // Deliver
1 Destined // Lead
1 Bound // Determined
1 Odds // Ends
1 Far // Away
1 Farm // Market
1 Fire // Ice
1 Dead // Gone
1 Heaven // Earth
1 Hide // Seek
1 Hit // Run
1 Spite // Malice
1 Night // Day
1 Order // Chaos
1 Prepare // Fight
1 Profit // Loss
1 Protect // Serve
1 Ready // Willing
1 Illusion // Reality
1 Research // Development
1 Reduce // Rubble
1 Start // Finish
1 Struggle // Survive
1 Wear // Tear
1 Trial // Error
1 Turn // Burn
1 Onward // Victory

// 30 Sorcery
1 Alive // Well
1 Appeal // Authority
1 Assault // Battery
1 Reason // Believe
1 Boom // Bust
1 Beck // Call
1 Claim // Fame
1 Crime // Punishment
1 Cut // Ribbons
1 Armed // Dangerous
1 Dusk // Dawn
1 Life // Death
1 Supply // Demand
1 Driven // Despair
1 Down // Dirty
1 Breaking // Entering
1 Flesh // Blood
1 Give // Take
1 Grind // Dust
1 Insult // Injury
1 Spring // Mind
1 Mouth // Feed
1 Pain // Suffering
1 Rags // Riches
1 Catch // Release
1 Never // Return
1 Rise // Fall
1 Pure // Simple
1 Toil // Trouble
1 Rough // Tumble
```