### PR TITLE
Filters phrase *cmdr* when loading from clipboard (helps with TappedOut decks)

### DIFF
--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -551,6 +551,10 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
         rx.setPattern("\\(.*\\)");
         line.remove(rx);
 
+        // Filter out the phrase *cmdr* for commander decks
+        rx.setPattern("\\s*\\*cmdr\\*\\s*");
+        line.remove(rx);
+
         // Filter out post card name editions
         rx.setPattern("\\|.*$");
         line.remove(rx);


### PR DESCRIPTION
## Related Ticket(s)
- Not brought up in tickets.

## Short roundup of the initial problem
If a user loads their deck from clipboard and it shares the same format that TappedOut does for EDH / commander decks, then one of their cards has \*cmdr* written after the card name. Previously, that card would not be loaded correctly and would show up as "_their card name_ \*cmdr*" under the unknown category.

## What will change with this Pull Request?
The phrase \*cmdr* is removed from cards loaded from the clipboard so that EDH / commander decks can be imported easier.