### PR TITLE
allow backspace/delete button to remove a filter

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -158,8 +158,10 @@ void TabDeckEditor::createFiltersDock()
     filterView->setUniformRowHeights(true);
     filterView->setHeaderHidden(true);
     filterView->setContextMenuPolicy(Qt::CustomContextMenu);
+    filterView->installEventFilter(&filterViewKeySignals);
     connect(filterModel, SIGNAL(layoutChanged()), filterView, SLOT(expandAll()));
     connect(filterView, SIGNAL(customContextMenuRequested(const QPoint &)),this, SLOT(filterViewCustomContextMenu(const QPoint &)));
+    connect(&filterViewKeySignals, SIGNAL(onDelete()), this, SLOT(actClearFilterOne()));
 
     FilterBuilder *filterBuilder = new FilterBuilder;
     filterBuilder->setObjectName("filterBuilder");

--- a/cockatrice/src/tab_deck_editor.h
+++ b/cockatrice/src/tab_deck_editor.h
@@ -108,6 +108,7 @@ private:
     QLabel *hashLabel;
     FilterTreeModel *filterModel;
     QTreeView *filterView;
+    KeySignals filterViewKeySignals;
     QWidget *filterBox;
 
     QMenu *deckMenu, *viewMenu, *cardInfoDockMenu, *deckDockMenu, *filterDockMenu, *analyzeDeckMenu;


### PR DESCRIPTION
Fixes #2950 

If you use the backspace/delete key on a filter, it will remove that component of the filter. Extends the button press to the key bind, so there should be no averse results.
