### PR TITLE
Allow non-db cards to be moved around

### DIFF
--- a/cockatrice/src/decklistmodel.cpp
+++ b/cockatrice/src/decklistmodel.cpp
@@ -264,11 +264,44 @@ QModelIndex DeckListModel::findCard(const QString &cardName, const QString &zone
     return nodeToIndex(cardNode);
 }
 
-QModelIndex DeckListModel::addCard(const QString &cardName, const QString &zoneName)
+QModelIndex DeckListModel::addCard(const QString &cardName, const QString &zoneName, bool anAddAnyway)
 {
     CardInfo *info = db->getCard(cardName);
     if (info == nullptr)
-        return QModelIndex();
+    {
+        if (anAddAnyway)
+        {
+            // We need to keep this card added no matter what
+            // This is usually called from tab_deck_editor
+            // So we'll create a new CardInfo with the name
+            // and default values for all fields
+            info = new CardInfo(
+                    cardName,
+                    false,
+                    nullptr,
+                    nullptr,
+                    "unknown",
+                    nullptr,
+                    nullptr,
+                    QStringList(),
+                    QList<CardRelation *>(),
+                    QList<CardRelation *>(),
+                    false,
+                    0,
+                    false,
+                    0,
+                    SetList(),
+                    QStringMap(),
+                    MuidMap(),
+                    QStringMap(),
+                    QStringMap()
+            );
+        }
+        else
+        {
+            return QModelIndex();
+        }
+    }
 
     InnerDecklistNode *zoneNode = createNodeIfNeeded(zoneName, root);
 

--- a/cockatrice/src/decklistmodel.cpp
+++ b/cockatrice/src/decklistmodel.cpp
@@ -264,12 +264,12 @@ QModelIndex DeckListModel::findCard(const QString &cardName, const QString &zone
     return nodeToIndex(cardNode);
 }
 
-QModelIndex DeckListModel::addCard(const QString &cardName, const QString &zoneName, bool anAddAnyway)
+QModelIndex DeckListModel::addCard(const QString &cardName, const QString &zoneName, bool abAddAnyway)
 {
     CardInfo *info = db->getCard(cardName);
     if (info == nullptr)
     {
-        if (anAddAnyway)
+        if (abAddAnyway)
         {
             // We need to keep this card added no matter what
             // This is usually called from tab_deck_editor

--- a/cockatrice/src/decklistmodel.h
+++ b/cockatrice/src/decklistmodel.h
@@ -44,7 +44,7 @@ public:
     bool setData(const QModelIndex &index, const QVariant &value, int role);
     bool removeRows(int row, int count, const QModelIndex &parent = QModelIndex());
     QModelIndex findCard(const QString &cardName, const QString &zoneName) const;
-    QModelIndex addCard(const QString &cardName, const QString &zoneName, bool anAddAnyway = false);
+    QModelIndex addCard(const QString &cardName, const QString &zoneName, bool abAddAnyway = false);
     void sort(int column, Qt::SortOrder order = Qt::AscendingOrder);
     void cleanList();
     DeckLoader *getDeckList() const { return deckList; }

--- a/cockatrice/src/decklistmodel.h
+++ b/cockatrice/src/decklistmodel.h
@@ -35,7 +35,7 @@ public:
     DeckListModel(QObject *parent = 0);
     ~DeckListModel();
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
-        int columnCount(const QModelIndex &/*parent*/ = QModelIndex()) const;
+    int columnCount(const QModelIndex &/*parent*/ = QModelIndex()) const;
     QVariant data(const QModelIndex &index, int role) const;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
     QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const;
@@ -44,7 +44,7 @@ public:
     bool setData(const QModelIndex &index, const QVariant &value, int role);
     bool removeRows(int row, int count, const QModelIndex &parent = QModelIndex());
     QModelIndex findCard(const QString &cardName, const QString &zoneName) const;
-    QModelIndex addCard(const QString &cardName, const QString &zoneName);
+    QModelIndex addCard(const QString &cardName, const QString &zoneName, bool anAddAnyway = false);
     void sort(int column, Qt::SortOrder order = Qt::AscendingOrder);
     void cleanList();
     DeckLoader *getDeckList() const { return deckList; }

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -132,7 +132,7 @@ void TabDeckEditor::createCardInfoDock()
     cardInfoFrame->addWidget(cardInfo);
 
     cardInfoDock = new QDockWidget(this);
-    cardInfoDock->setObjectName("cardInfoDock");    
+    cardInfoDock->setObjectName("cardInfoDock");
 
     cardInfoDock->setMinimumSize(QSize(200, 41));
     cardInfoDock->setAllowedAreas(Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea);
@@ -142,7 +142,7 @@ void TabDeckEditor::createCardInfoDock()
     cardInfoDockContents->setLayout(cardInfoFrame);
     cardInfoDock->setWidget(cardInfoDockContents);
 
-    cardInfoDock->installEventFilter(this);    
+    cardInfoDock->installEventFilter(this);
     connect(cardInfoDock, SIGNAL(topLevelChanged(bool)), this, SLOT(dockTopLevelChanged(bool)));
 }
 
@@ -198,7 +198,7 @@ void TabDeckEditor::createFiltersDock()
     QWidget *filterDockContents = new QWidget(this);
     filterDockContents->setObjectName("filterDockContents");
     filterDockContents->setLayout(filterFrame);
-    filterDock->setWidget(filterDockContents);    
+    filterDock->setWidget(filterDockContents);
 
     filterDock->installEventFilter(this);
     connect(filterDock, SIGNAL(topLevelChanged(bool)), this, SLOT(dockTopLevelChanged(bool)));
@@ -329,7 +329,7 @@ void TabDeckEditor::createCentralFrame()
     connect(&searchKeySignals, SIGNAL(onCtrlAltMinus()), this, SLOT(actDecrementCard()));
     connect(&searchKeySignals, SIGNAL(onCtrlAltLBracket()), this, SLOT(actDecrementCardFromSideboard()));
     connect(&searchKeySignals, SIGNAL(onCtrlAltEnter()), this, SLOT(actAddCardToSideboard()));
-    connect(&searchKeySignals, SIGNAL(onCtrlEnter()), this, SLOT(actAddCardToSideboard()));    
+    connect(&searchKeySignals, SIGNAL(onCtrlEnter()), this, SLOT(actAddCardToSideboard()));
 
     databaseModel = new CardDatabaseModel(db, true, this);
     databaseModel->setObjectName("databaseModel");
@@ -519,7 +519,7 @@ TabDeckEditor::TabDeckEditor(TabSupervisor *_tabSupervisor, QWidget *parent)
 
     restartLayout();
 
-    this->installEventFilter(this);    
+    this->installEventFilter(this);
 
     retranslateUi();
     connect(&settingsCache->shortcuts(), SIGNAL(shortCutchanged()),this,SLOT(refreshShortcuts()));
@@ -539,7 +539,7 @@ void TabDeckEditor::retranslateUi()
 
     aClearFilterAll->setText(tr("&Clear all filters"));
     aClearFilterOne->setText(tr("Delete selected"));
-    
+
     nameLabel->setText(tr("Deck &name:"));
     commentsLabel->setText(tr("&Comments:"));
     hashLabel1->setText(tr("Hash:"));
@@ -558,7 +558,7 @@ void TabDeckEditor::retranslateUi()
     aAnalyzeDeckTappedout->setText(tr("Analyze deck (tappedout.net)"));
 
     aClose->setText(tr("&Close"));
-    
+
     aAddCard->setText(tr("Add card to &maindeck"));
     aAddCardToSideboard->setText(tr("Add card to &sideboard"));
 
@@ -567,7 +567,7 @@ void TabDeckEditor::retranslateUi()
     aIncrement->setText(tr("&Increment number"));
 
     aDecrement->setText(tr("&Decrement number"));
-    
+
     deckMenu->setTitle(tr("&Deck Editor"));
 
     cardInfoDock->setWindowTitle(tr("Card Info"));
@@ -680,7 +680,7 @@ void TabDeckEditor::actLoadDeck()
 
     QString fileName = dialog.selectedFiles().at(0);
     DeckLoader::FileFormat fmt = DeckLoader::getFormatFromName(fileName);
-    
+
     DeckLoader *l = new DeckLoader;
     if (l->loadFromFile(fileName, fmt))
         setDeck(l);
@@ -703,11 +703,11 @@ bool TabDeckEditor::actSaveDeck()
         Command_DeckUpload cmd;
         cmd.set_deck_id(deck->getLastRemoteDeckId());
         cmd.set_deck_list(deck->writeToString_Native().toStdString());
-        
+
         PendingCommand *pend = AbstractClient::prepareSessionCommand(cmd);
         connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(saveDeckRemoteFinished(Response)));
         tabSupervisor->getClient()->sendCommand(pend);
-        
+
         return true;
     } else if (deck->getLastFileName().isEmpty())
         return actSaveDeckAs();
@@ -746,11 +746,11 @@ void TabDeckEditor::actLoadDeckFromClipboard()
 {
     if (!confirmClose())
         return;
-    
+
     DlgLoadDeckFromClipboard dlg;
     if (!dlg.exec())
         return;
-    
+
     setDeck(dlg.getDeckList());
     setModified(true);
 }
@@ -845,7 +845,7 @@ CardInfo *TabDeckEditor::currentCardInfo() const
     if (!currentIndex.isValid())
         return NULL;
     const QString cardName = currentIndex.sibling(currentIndex.row(), 0).data().toString();
-    
+
     return db->getCard(cardName);
 }
 
@@ -873,15 +873,16 @@ void TabDeckEditor::actSwapCard()
         return;
     const QString cardName = currentIndex.sibling(currentIndex.row(), 1).data().toString();
     const QModelIndex gparent = currentIndex.parent().parent();
+
     if (!gparent.isValid())
             return;
 
     const QString zoneName = gparent.sibling(gparent.row(), 1).data().toString();
     actDecrement();
-
     const QString otherZoneName = zoneName == "Maindeck" ? DECK_ZONE_SIDE : DECK_ZONE_MAIN;
 
-    QModelIndex newCardIndex = deckModel->addCard(cardName, otherZoneName);
+    // Third argument (true) says create the card no mater what, even if not in DB
+    QModelIndex newCardIndex = deckModel->addCard(cardName, otherZoneName, true);
     recursiveExpand(newCardIndex);
 
     setModified(true);
@@ -1033,7 +1034,7 @@ bool TabDeckEditor::eventFilter(QObject * o, QEvent * e)
             aFilterDockVisible->setChecked(false);
             aFilterDockFloating->setEnabled(false);
         }
-    }   
+    }
     if( o == this && e->type() == QEvent::Hide){
         settingsCache->layouts().setDeckEditorLayoutState(saveState());
         settingsCache->layouts().setDeckEditorGeometry(saveGeometry());


### PR DESCRIPTION
Fixes #2954

Before we could not move cards around if they weren't in the DB b/c if the  card was not in the db, the program would discard the entry. There is now an overload variable that tells the program to pretend it's in the database with default values and continue as directed.

____

Load from Clipboard:
<img width="284" alt="screenshot 2017-12-15 23 51 43" src="https://user-images.githubusercontent.com/7460172/34067395-ed848c84-e1f2-11e7-9565-c0c387f9d01a.png">

Highlight the row and press "S":
<img width="297" alt="screenshot 2017-12-15 23 51 48" src="https://user-images.githubusercontent.com/7460172/34067394-ed4bb3a0-e1f2-11e7-965c-eb67a4d1319a.png">

