### PR TITLE
clear search bar if all filters cleared

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -823,6 +823,7 @@ void TabDeckEditor::actAnalyzeDeckTappedout()
 void TabDeckEditor::actClearFilterAll()
 {
     databaseDisplayModel->clearFilterAll();
+    searchEdit->setText("");
 }
 
 void TabDeckEditor::actClearFilterOne()


### PR DESCRIPTION
Fixes #2953

When you clear all filters, this will also clear the search bar. I consider that a shortcut filter in itself for names, so I feel it should be cleared.

If there is a disagreement, I can look at clearing filters then enforcing what was typed in the search bar.