### PR TITLE
add checkbox option to clear log

### DIFF
--- a/cockatrice/src/dlg_viewlog.cpp
+++ b/cockatrice/src/dlg_viewlog.cpp
@@ -1,17 +1,25 @@
 #include "dlg_viewlog.h"
 #include "logger.h"
+#include "settingscache.h"
 
 #include <QVBoxLayout>
 #include <QPlainTextEdit>
 
-DlgViewLog::DlgViewLog(QWidget *parent)
-: QDialog(parent)
+DlgViewLog::DlgViewLog(QWidget *parent) : QDialog(parent)
 {
+
+
     logArea = new QPlainTextEdit;
     logArea->setReadOnly(true);
     
-    QVBoxLayout *mainLayout = new QVBoxLayout;
+    auto *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(logArea);
+
+    coClearLog = new QCheckBox;
+    coClearLog->setText(tr("Clear log when closing"));
+    coClearLog->setChecked(settingsCache->servers().getClearDebugLogStatus(true));
+    connect(coClearLog, SIGNAL(toggled(bool)), this, SLOT(actCheckBoxChanged(bool)));
+    mainLayout->addWidget(coClearLog);
 
     setLayout(mainLayout);
 
@@ -20,6 +28,11 @@ DlgViewLog::DlgViewLog(QWidget *parent)
 
     loadInitialLogBuffer();
     connect(&Logger::getInstance(), SIGNAL(logEntryAdded(QString)), this, SLOT(logEntryAdded(QString)));    
+}
+
+void DlgViewLog::actCheckBoxChanged(bool abNewValue)
+{
+    settingsCache->servers().setClearDebugLogStatus(abNewValue);
 }
 
 void DlgViewLog::loadInitialLogBuffer()
@@ -36,6 +49,10 @@ void DlgViewLog::logEntryAdded(QString message)
 
 void DlgViewLog::closeEvent(QCloseEvent * /* event */)
 {
-    logArea->clear();
+    if (coClearLog->isChecked())
+    {
+        logArea->clear();
+    }
+
     logArea->appendPlainText(Logger::getInstance().getClientVersion());
 }

--- a/cockatrice/src/dlg_viewlog.h
+++ b/cockatrice/src/dlg_viewlog.h
@@ -2,6 +2,7 @@
 #define DLG_VIEWLOG_H
 
 #include <QDialog>
+#include <QCheckBox>
 
 class QPlainTextEdit;
 class QCloseEvent;
@@ -13,11 +14,13 @@ public:
 protected:
     void closeEvent(QCloseEvent *event);
 private:
-	QPlainTextEdit *logArea;
+    QPlainTextEdit *logArea;
+    QCheckBox *coClearLog;
 
-	void loadInitialLogBuffer();
+    void loadInitialLogBuffer();
+    void actCheckBoxChanged(bool abNewValue);
 private slots:
-	void logEntryAdded(QString message);
+    void logEntryAdded(QString message);
 };
 
 #endif

--- a/cockatrice/src/logger.cpp
+++ b/cockatrice/src/logger.cpp
@@ -21,9 +21,13 @@ Logger::~Logger()
 void Logger::logToFile(bool enabled)
 {
     if (enabled)
+    {
         openLogfileSession();
+    }
     else
+    {
         closeLogfileSession();
+    }
 }
 
 QString Logger::getClientVersion()
@@ -34,7 +38,9 @@ QString Logger::getClientVersion()
 void Logger::openLogfileSession()
 {
     if (logToFileEnabled)
+    {
         return;
+    }
 
     fileHandle.setFileName(LOGGER_FILENAME);
     fileHandle.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text);

--- a/cockatrice/src/settings/serverssettings.cpp
+++ b/cockatrice/src/settings/serverssettings.cpp
@@ -164,6 +164,17 @@ QString ServersSettings::getFPPlayerName(QString defaultName)
     return name == QVariant() ? defaultName : name.toString();
 }
 
+void ServersSettings::setClearDebugLogStatus(bool abIsChecked)
+{
+    setValue(abIsChecked, "save_debug_log", "server");
+}
+
+bool ServersSettings::getClearDebugLogStatus(bool abDefaultValue)
+{
+    QVariant cbFlushLog = getValue("save_debug_log", "server");
+    return cbFlushLog == QVariant() ? abDefaultValue : cbFlushLog.toBool();
+}
+
 void ServersSettings::addNewServer(QString saveName, QString serv, QString port, QString username, QString password, bool savePassword)
 {
     if (updateExistingServer(saveName, serv, port, username, password, savePassword))

--- a/cockatrice/src/settings/serverssettings.h
+++ b/cockatrice/src/settings/serverssettings.h
@@ -39,6 +39,9 @@ public:
     void setFPPlayerName(QString playerName);
     void addNewServer(QString saveName, QString serv, QString port, QString username, QString password, bool savePassword);
     bool updateExistingServer(QString saveName, QString serv, QString port, QString username, QString password, bool savePassword);
+    void setClearDebugLogStatus(bool abIsChecked);
+    bool getClearDebugLogStatus(bool abDefaultValue);
+
 signals:
 
 public slots:


### PR DESCRIPTION
Fixes #2939

This will add a checkbox option (that is persistent) to the logs. If checked (default), logs will be cleared when closing the popup. Otherwise, they will be saved.

<img width="669" alt="screenshot 2017-12-16 02 52 55" src="https://user-images.githubusercontent.com/7460172/34068613-39d3c032-e20c-11e7-9c80-7d8bc6202690.png">