### PR TITLE
remove untap option, combine w/ tap

### DIFF
--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -184,7 +184,7 @@ private:
     QList<QAction *> aAddCounter, aSetCounter, aRemoveCounter;
     QAction *aPlay, *aPlayFacedown,
         *aHide,
-        *aTap, *aUntap, *aDoesntUntap, *aAttach, *aUnattach, *aDrawArrow, *aSetPT, *aIncP, *aDecP, *aIncT, *aDecT, *aIncPT, *aDecPT, *aSetAnnotation, *aFlip, *aPeek, *aClone,
+        *aTap, *aDoesntUntap, *aAttach, *aUnattach, *aDrawArrow, *aSetPT, *aIncP, *aDecP, *aIncT, *aDecT, *aIncPT, *aDecPT, *aSetAnnotation, *aFlip, *aPeek, *aClone,
         *aMoveToTopLibrary, *aMoveToBottomLibrary, *aMoveToHand, *aMoveToGraveyard, *aMoveToExile, *aMoveToXfromTopOfLibrary;
 
     bool shortcutsActive;

--- a/cockatrice/src/sequenceEdit/ui_shortcutstab.h
+++ b/cockatrice/src/sequenceEdit/ui_shortcutstab.h
@@ -245,7 +245,6 @@ public:
     QGridLayout *gridLayout_13;
     QLabel *lbl_Player_aTap;
     SequenceEdit *Player_aTap;
-    QLabel *lbl_Player_aUntap;
     SequenceEdit *Player_aUntap;
     QLabel *lbl_Player_aUntapAll;
     SequenceEdit *Player_aUntapAll;
@@ -1247,16 +1246,6 @@ public:
 
         gridLayout_13->addWidget(Player_aTap, 0, 1, 1, 1);
 
-        lbl_Player_aUntap = new QLabel(groupBox_13);
-        lbl_Player_aUntap->setObjectName("lbl_Player_aUntap");
-
-        gridLayout_13->addWidget(lbl_Player_aUntap, 1, 0, 1, 1);
-
-        Player_aUntap = new SequenceEdit("Player/aUntap",groupBox_13);
-        Player_aUntap->setObjectName("Player_aUntap");
-
-        gridLayout_13->addWidget(Player_aUntap, 1, 1, 1, 1);
-
         lbl_Player_aUntapAll = new QLabel(groupBox_13);
         lbl_Player_aUntapAll->setObjectName("lbl_Player_aUntapAll");
 
@@ -1843,8 +1832,7 @@ public:
         lbl_TabGame_aNextPhase->setText(QApplication::translate("shortcutsTab", "Next phase", 0));
         lbl_TabGame_aNextTurn->setText(QApplication::translate("shortcutsTab", "Next turn", 0));
         groupBox_13->setTitle(QApplication::translate("shortcutsTab", "Playing Area", 0));
-        lbl_Player_aTap->setText(QApplication::translate("shortcutsTab", "Tap Card", 0));
-        lbl_Player_aUntap->setText(QApplication::translate("shortcutsTab", "Untap Card", 0));
+        lbl_Player_aTap->setText(QApplication::translate("shortcutsTab", "Tap / Untap Card", 0));
         lbl_Player_aUntapAll->setText(QApplication::translate("shortcutsTab", "Untap all", 0));
         lbl_Player_aDoesntUntap->setText(QApplication::translate("shortcutsTab", "Toggle untap", 0));
         lbl_Player_aFlip->setText(QApplication::translate("shortcutsTab", "Flip card", 0));

--- a/cockatrice/src/shortcutssettings.cpp
+++ b/cockatrice/src/shortcutssettings.cpp
@@ -218,7 +218,6 @@ void ShortcutsSettings::fillDefaultShorcuts()
     defaultShortCuts["Player/aTap"] = parseSequenceString("");
     defaultShortCuts["Player/aUnattach"] = parseSequenceString("");
     defaultShortCuts["Player/aUndoDraw"] = parseSequenceString("Ctrl+Shift+D");
-    defaultShortCuts["Player/aUntap"] = parseSequenceString("");
     defaultShortCuts["Player/aUntapAll"] = parseSequenceString("Ctrl+U");
     defaultShortCuts["Player/aViewGraveyard"] = parseSequenceString("F4");
     defaultShortCuts["Player/aViewLibrary"] = parseSequenceString("F3");


### PR DESCRIPTION
Fixes #2932

Combines Tap and Untap in the right click menu of cards. Also removes the shortcut from the shortcut menu/tab since there's no longer a need and it is combined w/ tap.

General cleanup / fixes also in this on the files.

<img width="348" alt="screenshot 2017-12-16 03 15 27" src="https://user-images.githubusercontent.com/7460172/34068769-6049fdf0-e20f-11e7-83e3-2d08b35c1c5a.png">
<img width="359" alt="screenshot 2017-12-16 03 15 15" src="https://user-images.githubusercontent.com/7460172/34068770-605d1336-e20f-11e7-9e6f-cbbe0a84741a.png">
