### PR TITLE
travis: add default group key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required   # forces legacy build infrastructure
+group: travis_lts   # forces most stable build images
 
 language: cpp
 


### PR DESCRIPTION
Allow us to easily change to more up to date releases on travis once they are available.
And we hopefully can supply more recent builds for Ubuntu than14.04 sooner than later. :)

Feature got announced here:
https://blog.travis-ci.com/2017-12-01-new-update-schedule-for-linux-build-images