### PR TITLE
About dialog build architecture fix #2948

### DIFF
--- a/cockatrice/src/dlg_viewlog.cpp
+++ b/cockatrice/src/dlg_viewlog.cpp
@@ -55,5 +55,5 @@ void DlgViewLog::closeEvent(QCloseEvent * /* event */)
     }
 
     logArea->appendPlainText(Logger::getInstance().getClientVersion());
-    logArea->appendPlainText(Logger::getInstance().printBuildArchitecture());
+    logArea->appendPlainText(Logger::getInstance().getSystemArchitecture());
 }

--- a/cockatrice/src/dlg_viewlog.cpp
+++ b/cockatrice/src/dlg_viewlog.cpp
@@ -55,5 +55,5 @@ void DlgViewLog::closeEvent(QCloseEvent * /* event */)
     }
 
     logArea->appendPlainText(Logger::getInstance().getClientVersion());
-    logArea->appendPlainText(Logger::getInstance().getBuildArchitecture());
+    logArea->appendPlainText(Logger::getInstance().printBuildArchitecture());
 }

--- a/cockatrice/src/dlg_viewlog.cpp
+++ b/cockatrice/src/dlg_viewlog.cpp
@@ -55,4 +55,5 @@ void DlgViewLog::closeEvent(QCloseEvent * /* event */)
     }
 
     logArea->appendPlainText(Logger::getInstance().getClientVersion());
+    logArea->appendPlainText(Logger::getInstance().getBuildArchitecture());
 }

--- a/cockatrice/src/logger.cpp
+++ b/cockatrice/src/logger.cpp
@@ -9,7 +9,9 @@
 Logger::Logger() : logToFileEnabled(false)
 {
     logBuffer.append(getClientVersion());
+    logBuffer.append(getBuildArchitecture());
     std::cerr << getClientVersion().toStdString() << std::endl;
+    std::cerr << getBuildArchitecture().toStdString() << std::endl;
 }
 
 Logger::~Logger()
@@ -47,6 +49,7 @@ void Logger::openLogfileSession()
     fileStream.setDevice(&fileHandle);
     fileStream << "Log session started at " << QDateTime::currentDateTime().toString() << endl;
     fileStream << getClientVersion() << endl;
+    fileStream << getBuildArchitecture() << endl;
     logToFileEnabled = true;
 }
 
@@ -80,4 +83,31 @@ void Logger::internalLog(const QString message)
 
     if (logToFileEnabled)
         fileStream << message << endl; // Print to fileStream
+}
+
+QString Logger::getBuildArchitecture()
+{
+#if   defined(Q_OS_MACOS)
+  QString systemOS = "macOS";
+#elif defined(Q_OS_LINUX)
+  QString systemOS = "Linux";
+#elif defined(Q_OS_WIN)
+  QString systemOS = "Windows";
+#elif defined(Q_OS_ANDROID)
+  QString systemOS = "Android";
+#else
+  QString systemOS = "unknown";
+#endif
+#if   defined(Q_PROCESSOR_X86_32)
+  QString arch = "32-bit";
+#elif defined(Q_PROCESSOR_X86_64)
+  QString arch = "64-bit";
+#elif defined(Q_PROCESSOR_ARM)
+  QString arch = "ARM";
+#else
+  QString arch = "unknown";
+#endif
+    return "Client Operating System: " + systemOS + "\n" +
+           "Build Architecture: " + arch + "\n" +
+           "Qt Version: " + QT_VERSION_STR;
 }

--- a/cockatrice/src/logger.cpp
+++ b/cockatrice/src/logger.cpp
@@ -6,12 +6,18 @@
 #define LOGGER_MAX_ENTRIES 128
 #define LOGGER_FILENAME "qdebug.txt"
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
+
+#include <QSysInfo>
+
+#endif
+
 Logger::Logger() : logToFileEnabled(false)
 {
     logBuffer.append(getClientVersion());
-    logBuffer.append(getBuildArchitecture());
+    logBuffer.append(printBuildArchitecture());
     std::cerr << getClientVersion().toStdString() << std::endl;
-    std::cerr << getBuildArchitecture().toStdString() << std::endl;
+    std::cerr << printBuildArchitecture().toStdString() << std::endl;
 }
 
 Logger::~Logger()
@@ -49,7 +55,7 @@ void Logger::openLogfileSession()
     fileStream.setDevice(&fileHandle);
     fileStream << "Log session started at " << QDateTime::currentDateTime().toString() << endl;
     fileStream << getClientVersion() << endl;
-    fileStream << getBuildArchitecture() << endl;
+    fileStream << printBuildArchitecture() << endl;
     logToFileEnabled = true;
 }
 
@@ -85,29 +91,23 @@ void Logger::internalLog(const QString message)
         fileStream << message << endl; // Print to fileStream
 }
 
-QString Logger::getBuildArchitecture()
+QString Logger::printBuildArchitecture()
 {
-#if   defined(Q_OS_MACOS)
-  QString systemOS = "macOS";
-#elif defined(Q_OS_LINUX)
-  QString systemOS = "Linux";
-#elif defined(Q_OS_WIN)
-  QString systemOS = "Windows";
-#elif defined(Q_OS_ANDROID)
-  QString systemOS = "Android";
-#else
-  QString systemOS = "unknown";
-#endif
-#if   defined(Q_PROCESSOR_X86_32)
-  QString arch = "32-bit";
-#elif defined(Q_PROCESSOR_X86_64)
-  QString arch = "64-bit";
-#elif defined(Q_PROCESSOR_ARM)
-  QString arch = "ARM";
-#else
-  QString arch = "unknown";
-#endif
-    return "Client Operating System: " + systemOS + "\n" +
-           "Build Architecture: " + arch + "\n" +
+    QString result;
+    if(!getClientOperatingSystem().isEmpty())
+    {
+        result += "Client Operating System: " + getClientOperatingSystem() + "\n";
+    }
+    result += "Build Architecture: " + QString::fromStdString(BUILD_ARCHITECTURE) + "\n" +
            "Qt Version: " + QT_VERSION_STR;
+    return result;
+}
+
+QString Logger::getClientOperatingSystem()
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
+    return QSysInfo::prettyProductName();
+#else
+    return "";
+#endif
 }

--- a/cockatrice/src/logger.cpp
+++ b/cockatrice/src/logger.cpp
@@ -6,18 +6,16 @@
 #define LOGGER_MAX_ENTRIES 128
 #define LOGGER_FILENAME "qdebug.txt"
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
-
-#include <QSysInfo>
-
+#if QT_VERSION >= 0x050400
+    #include <QSysInfo>
 #endif
 
 Logger::Logger() : logToFileEnabled(false)
 {
     logBuffer.append(getClientVersion());
-    logBuffer.append(printBuildArchitecture());
+    logBuffer.append(getSystemArchitecture());
     std::cerr << getClientVersion().toStdString() << std::endl;
-    std::cerr << printBuildArchitecture().toStdString() << std::endl;
+    std::cerr << getSystemArchitecture().toStdString() << std::endl;
 }
 
 Logger::~Logger()
@@ -55,7 +53,7 @@ void Logger::openLogfileSession()
     fileStream.setDevice(&fileHandle);
     fileStream << "Log session started at " << QDateTime::currentDateTime().toString() << endl;
     fileStream << getClientVersion() << endl;
-    fileStream << printBuildArchitecture() << endl;
+    fileStream << getSystemArchitecture() << endl;
     logToFileEnabled = true;
 }
 
@@ -91,23 +89,26 @@ void Logger::internalLog(const QString message)
         fileStream << message << endl; // Print to fileStream
 }
 
-QString Logger::printBuildArchitecture()
+QString Logger::getSystemArchitecture()
 {
     QString result;
-    if(!getClientOperatingSystem().isEmpty())
+
+    if (!getClientOperatingSystem().isEmpty())
     {
-        result += "Client Operating System: " + getClientOperatingSystem() + "\n";
+        result.append(tr("Client Operating System") + ": " + getClientOperatingSystem() + "\n");
     }
-    result += "Build Architecture: " + QString::fromStdString(BUILD_ARCHITECTURE) + "\n" +
-           "Qt Version: " + QT_VERSION_STR;
+
+    result.append(tr("Build Architecture") + ": " + QString::fromStdString(BUILD_ARCHITECTURE) + "\n");
+    result.append(tr("Qt Version") + ": " + QT_VERSION_STR);
+
     return result;
 }
 
 QString Logger::getClientOperatingSystem()
 {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
-    return QSysInfo::prettyProductName();
-#else
-    return "";
-#endif
+    #ifdef QSYSINFO_H
+        return QSysInfo::prettyProductName();
+    #endif
+
+    return {};
 }

--- a/cockatrice/src/logger.h
+++ b/cockatrice/src/logger.h
@@ -7,6 +7,16 @@
 #include <QString>
 #include <QMutex>
 
+#if   defined(Q_PROCESSOR_X86_32)
+  #define BUILD_ARCHITECTURE "32-bit"
+#elif defined(Q_PROCESSOR_X86_64)
+  #define BUILD_ARCHITECTURE "64-bit"
+#elif defined(Q_PROCESSOR_ARM)
+  #define BUILD_ARCHITECTURE "ARM"
+#else
+  #define BUILD_ARCHITECTURE "unknown"
+#endif
+
 class Logger : public QObject {
 Q_OBJECT
 public:
@@ -31,7 +41,8 @@ public:
 	void logToFile(bool enabled);
     void log(QtMsgType type, const QMessageLogContext &ctx, const QString message);
     QString getClientVersion();
-    QString getBuildArchitecture();
+    QString getClientOperatingSystem();
+    QString printBuildArchitecture();
     QList<QString> getLogBuffer() { return logBuffer; }
 protected:
     void openLogfileSession();

--- a/cockatrice/src/logger.h
+++ b/cockatrice/src/logger.h
@@ -39,6 +39,7 @@ protected:
 protected slots:
     void internalLog(const QString message);
 signals:
-    void logEntryAdded(QString message);};
+    void logEntryAdded(QString message);
+};
 
 #endif

--- a/cockatrice/src/logger.h
+++ b/cockatrice/src/logger.h
@@ -31,6 +31,7 @@ public:
 	void logToFile(bool enabled);
     void log(QtMsgType type, const QMessageLogContext &ctx, const QString message);
     QString getClientVersion();
+    QString getBuildArchitecture();
     QList<QString> getLogBuffer() { return logBuffer; }
 protected:
     void openLogfileSession();
@@ -38,7 +39,6 @@ protected:
 protected slots:
     void internalLog(const QString message);
 signals:
-    void logEntryAdded(QString message);
-};
+    void logEntryAdded(QString message);};
 
 #endif

--- a/cockatrice/src/logger.h
+++ b/cockatrice/src/logger.h
@@ -7,8 +7,8 @@
 #include <QString>
 #include <QMutex>
 
-#if   defined(Q_PROCESSOR_X86_32)
-  #define BUILD_ARCHITECTURE "32-bit"
+#if defined(Q_PROCESSOR_X86_32)
+    #define BUILD_ARCHITECTURE "32-bit"
 #elif defined(Q_PROCESSOR_X86_64)
   #define BUILD_ARCHITECTURE "64-bit"
 #elif defined(Q_PROCESSOR_ARM)
@@ -17,40 +17,45 @@
   #define BUILD_ARCHITECTURE "unknown"
 #endif
 
-class Logger : public QObject {
-Q_OBJECT
-public:
-    static Logger& getInstance()
-    {
-        static Logger instance;
-        return instance;
-    }
-private:
-    Logger();
-    ~Logger();
-    // Singleton - Don't implement copy constructor and assign operator
-    Logger(Logger const&);
-    void operator=(Logger const&); 
+class Logger : public QObject
+{
+    Q_OBJECT
+    public:
+        static Logger& getInstance()
+        {
+            static Logger instance;
+            return instance;
+        }
 
-    bool logToFileEnabled;
-    QTextStream fileStream;
-    QFile fileHandle;
-    QList<QString> logBuffer;
-    QMutex mutex;
-public:
-	void logToFile(bool enabled);
-    void log(QtMsgType type, const QMessageLogContext &ctx, const QString message);
-    QString getClientVersion();
-    QString getClientOperatingSystem();
-    QString printBuildArchitecture();
-    QList<QString> getLogBuffer() { return logBuffer; }
-protected:
-    void openLogfileSession();
-    void closeLogfileSession();
-protected slots:
-    void internalLog(const QString message);
-signals:
-    void logEntryAdded(QString message);
+        void logToFile(bool enabled);
+        void log(QtMsgType type, const QMessageLogContext &ctx, const QString message);
+        QString getClientVersion();
+        QString getClientOperatingSystem();
+        QString getSystemArchitecture();
+        QList<QString> getLogBuffer() { return logBuffer; }
+
+    private:
+        Logger();
+        ~Logger();
+        // Singleton - Don't implement copy constructor and assign operator
+        Logger(Logger const&);
+        void operator=(Logger const&);
+
+        bool logToFileEnabled;
+        QTextStream fileStream;
+        QFile fileHandle;
+        QList<QString> logBuffer;
+        QMutex mutex;
+
+    protected:
+        void openLogfileSession();
+        void closeLogfileSession();
+
+    protected slots:
+        void internalLog(const QString message);
+
+    signals:
+        void logEntryAdded(QString message);
 };
 
 #endif

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -283,7 +283,7 @@ void MainWindow::actExit()
 void MainWindow::actAbout()
 {
     QMessageBox mb(QMessageBox::NoIcon, tr("About Cockatrice"), QString(
-	"<font size=\"8\"><b>Cockatrice</b></font>(" + QString::fromStdString(BUILD_ARCHITECTURE) + ")<br>"
+	"<font size=\"8\"><b>Cockatrice</b></font> (" + QString::fromStdString(BUILD_ARCHITECTURE) + ")<br>"
         + tr("Version") + QString(" %1").arg(VERSION_STRING)
         + "<br><br><b><a href='" + GITHUB_PAGES_URL + "'>" + tr("Cockatrice Webpage") + "</a></b><br>"
         + "<br><br><b>" + tr("Project Manager:") + "</b><br>Gavin Bisesi<br><br>"

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -32,6 +32,7 @@
 #include <QApplication>
 #include <QtNetwork>
 #include <QtConcurrent>
+#include <QSysInfo>
 
 #include "main.h"
 #include "window_main.h"

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -32,7 +32,6 @@
 #include <QApplication>
 #include <QtNetwork>
 #include <QtConcurrent>
-#include <QSysInfo>
 
 #include "main.h"
 #include "window_main.h"
@@ -282,7 +281,6 @@ void MainWindow::actExit()
 
 void MainWindow::actAbout()
 {
-    QString arch = QSysInfo::buildAbi().split('-')[0];
     QMessageBox mb(QMessageBox::NoIcon, tr("About Cockatrice"), QString(
         "<font size=\"8\"><b>Cockatrice</b></font><br>"
         + tr("Version") + QString(" %1").arg(VERSION_STRING)
@@ -299,7 +297,14 @@ void MainWindow::actAbout()
         + "<a href='" + GITHUB_ISSUES_URL + "'>" + tr("Report an Issue") + "</a><br>"
         + "<a href='" + GITHUB_TROUBLESHOOTING_URL + "'>" + tr("Troubleshooting") + "</a><br>"
         + "<a href='" + GITHUB_FAQ_URL + "'>" + tr("F.A.Q.") + "</a><br>")
-        + "<br><b>" + tr("Build Architecture:") + "</b><br>" + arch + "<br>",
+        + "<br><b>" + tr("Build Architecture:") +
+#ifdef Q_PROCESSOR_X86_32
+        + "</b><br>X86_32<br>",
+#elif defined(Q_PROCESSOR_X86_64)
+       + "</b><br>X86_64<br>",
+#else
+       + "</b><br>unknown<br>",
+#endif
         QMessageBox::Ok, this
     );
     mb.setIconPixmap(QPixmap("theme:cockatrice").scaled(64, 64));

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -281,6 +281,7 @@ void MainWindow::actExit()
 
 void MainWindow::actAbout()
 {
+    QString arch = QSysInfo::buildAbi().split('-')[0];
     QMessageBox mb(QMessageBox::NoIcon, tr("About Cockatrice"), QString(
         "<font size=\"8\"><b>Cockatrice</b></font><br>"
         + tr("Version") + QString(" %1").arg(VERSION_STRING)
@@ -296,7 +297,8 @@ void MainWindow::actAbout()
         + "<b>" + tr("Support:") + "</b><br>"
         + "<a href='" + GITHUB_ISSUES_URL + "'>" + tr("Report an Issue") + "</a><br>"
         + "<a href='" + GITHUB_TROUBLESHOOTING_URL + "'>" + tr("Troubleshooting") + "</a><br>"
-        + "<a href='" + GITHUB_FAQ_URL + "'>" + tr("F.A.Q.") + "</a><br>"),
+        + "<a href='" + GITHUB_FAQ_URL + "'>" + tr("F.A.Q.") + "</a><br>")
+        + "<br><b>" + tr("Build Architecture:") + "</b><br>" + arch + "<br>",
         QMessageBox::Ok, this
     );
     mb.setIconPixmap(QPixmap("theme:cockatrice").scaled(64, 64));

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -281,8 +281,17 @@ void MainWindow::actExit()
 
 void MainWindow::actAbout()
 {
+#if   defined(Q_PROCESSOR_X86_32)
+  QString arch = "(32-bit)";
+#elif defined(Q_PROCESSOR_X86_64)
+  QString arch = "(64-bit)";
+#elif defined(Q_PROCESSOR_ARM)
+  QString arch = "(ARM)";
+#else
+  QString arch = "(unknown)";
+#endif
     QMessageBox mb(QMessageBox::NoIcon, tr("About Cockatrice"), QString(
-        "<font size=\"8\"><b>Cockatrice</b></font><br>"
+        "<font size=\"8\"><b>Cockatrice</b></font>" + arch + "<br>"
         + tr("Version") + QString(" %1").arg(VERSION_STRING)
         + "<br><br><b><a href='" + GITHUB_PAGES_URL + "'>" + tr("Cockatrice Webpage") + "</a></b><br>"
         + "<br><br><b>" + tr("Project Manager:") + "</b><br>Gavin Bisesi<br><br>"
@@ -296,15 +305,7 @@ void MainWindow::actAbout()
         + "<b>" + tr("Support:") + "</b><br>"
         + "<a href='" + GITHUB_ISSUES_URL + "'>" + tr("Report an Issue") + "</a><br>"
         + "<a href='" + GITHUB_TROUBLESHOOTING_URL + "'>" + tr("Troubleshooting") + "</a><br>"
-        + "<a href='" + GITHUB_FAQ_URL + "'>" + tr("F.A.Q.") + "</a><br>")
-        + "<br><b>" + tr("Build Architecture:") +
-#ifdef Q_PROCESSOR_X86_32
-        + "</b><br>X86_32<br>",
-#elif defined(Q_PROCESSOR_X86_64)
-       + "</b><br>X86_64<br>",
-#else
-       + "</b><br>unknown<br>",
-#endif
+        + "<a href='" + GITHUB_FAQ_URL + "'>" + tr("F.A.Q.") + "</a><br>"),
         QMessageBox::Ok, this
     );
     mb.setIconPixmap(QPixmap("theme:cockatrice").scaled(64, 64));

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -48,6 +48,7 @@
 #include "localserver.h"
 #include "localserverinterface.h"
 #include "localclient.h"
+#include "logger.h"
 #include "settingscache.h"
 #include "tab_game.h"
 #include "version_string.h"
@@ -281,17 +282,8 @@ void MainWindow::actExit()
 
 void MainWindow::actAbout()
 {
-#if   defined(Q_PROCESSOR_X86_32)
-  QString arch = "(32-bit)";
-#elif defined(Q_PROCESSOR_X86_64)
-  QString arch = "(64-bit)";
-#elif defined(Q_PROCESSOR_ARM)
-  QString arch = "(ARM)";
-#else
-  QString arch = "(unknown)";
-#endif
     QMessageBox mb(QMessageBox::NoIcon, tr("About Cockatrice"), QString(
-        "<font size=\"8\"><b>Cockatrice</b></font>" + arch + "<br>"
+	"<font size=\"8\"><b>Cockatrice</b></font>(" + QString::fromStdString(BUILD_ARCHITECTURE) + ")<br>"
         + tr("Version") + QString(" %1").arg(VERSION_STRING)
         + "<br><br><b><a href='" + GITHUB_PAGES_URL + "'>" + tr("Cockatrice Webpage") + "</a></b><br>"
         + "<br><br><b>" + tr("Project Manager:") + "</b><br>Gavin Bisesi<br><br>"


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2948

## Short roundup of the initial problem
The About dialog does not currently display the build architecture.

## What will change with this Pull Request?
About dialog has a new item called "Build Architecture" that calls buildAbi() and returns the architecture that Qt was build for, which I expect is the same as the cockatrice application. There's another way to get this information about the cockatrice application itself by checking which of Q_PROCESSOR_X86_32 and Q_PROCESSOR_X86_64 is defined. The buildAbi() way is consistent with how this information is gathered for application updates (see releasechannel.cpp).

## Screenshots
![about_dialog](https://user-images.githubusercontent.com/34066958/34088928-919fa938-e37a-11e7-83b3-24a66c8dd375.png)

