### PR TITLE
appveyor: restore 32bit compatibility

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,11 +29,11 @@ environment:
           cmake_generator: Visual Studio 14 2015 Win64
           cmake_toolset: v140,host=x64
           target_arch: x86_64
-        - qt_ver: 5.6\msvc2013 # last version compatible with Windows XP, Vista and 32bit systems 
+        - qt_ver: 5.6\msvc2013   # last version compatible with Windows XP + Vista, and 32bit systems 
           protobuf_ver: 3.4.1
           zlib_ver: 1.2.11
           cmake_generator: Visual Studio 14 2015
-          cmake_toolset: v140_xp # use the windows XP compatible toolset
+          cmake_toolset: v120_xp   # use the Windows XP compatible toolset
           target_arch: x86
           
 install:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ environment:
           cmake_generator: Visual Studio 14 2015 Win64
           cmake_toolset: v140,host=x64
           target_arch: x86_64
-        - qt_ver: 5.6\msvc2015 # last version compatible with Windows XP, Vista
+        - qt_ver: 5.6\msvc2013 # last version compatible with Windows XP, Vista and 32bit systems 
           protobuf_ver: 3.4.1
           zlib_ver: 1.2.11
           cmake_generator: Visual Studio 14 2015


### PR DESCRIPTION
## Short roundup of the initial problem
AppVeyor release binary was not working on 32bit systems correctly.
All fonts were crossed out for some reason.

Report from user in Gitter (Dez 2017):
![2 4 0 with xp](https://user-images.githubusercontent.com/9874850/34131859-a55c7310-e44d-11e7-95e8-6e6dde9610fc.jpg)

## What will change with this Pull Request?
Go back to `msvc2013` for 32bit + XP-compatible build
 (switched to all msvc2013 in https://github.com/Cockatrice/Cockatrice/pull/2885)
