### PR TITLE
ci: deployment config for beta+stable

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,7 +90,7 @@ deploy:
   - provider: GitHub
     auth_token:
       secure: p+7wPVry2XEa6TBm9XH8IaQZbBmXQ/J2ldbGmcIxUZD3NkkPrSRRlmE7Of1CBBIO
-    release: "Cockatrice $APPVEYOR_REPO_TAG_NAME"    
+    release: "Cockatrice $APPVEYOR_REPO_TAG_NAME"
     description: "Beta release of Cockatrice"
     artifact: /.*\.exe/
     force_update: true
@@ -98,7 +98,7 @@ deploy:
     prerelease: true
     on:
       APPVEYOR_REPO_TAG: true
-      APPVEYOR_REPO_TAG_NAME: /(\d|[1-9]\d)(\.(\d|[1-9]\d)){2}-beta(\.([2-9]|[1-9]\d))?$/    # regex to match semver naming convention for beta pre-releases
+      APPVEYOR_REPO_TAG_NAME: /([0-9]|[1-9][0-9])(\.([0-9]|[1-9][0-9])){2}-beta(\.([2-9]|[1-9][0-9]))?$/    # regex to match semver naming convention for beta pre-releases
 
 # Deploy configuration for "stable" releases
   - provider: GitHub
@@ -110,7 +110,7 @@ deploy:
     prerelease: false
     on:
       APPVEYOR_REPO_TAG: true
-      APPVEYOR_REPO_TAG_NAME: /(\d|[1-9]\d)(\.(\d|[1-9]\d)){2}$/    # regex to match semver naming convention for stable full releases
+      APPVEYOR_REPO_TAG_NAME: /([0-9]|[1-9][0-9])(\.([0-9]|[1-9][0-9])){2}$/    # regex to match semver naming convention for stable full releases
 
 
 # official validator for ".appveyor.yml" config file: https://ci.appveyor.com/tools/validate-yaml

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -87,11 +87,12 @@ deploy:
   provider: GitHub
   auth_token:
     secure: p+7wPVry2XEa6TBm9XH8IaQZbBmXQ/J2ldbGmcIxUZD3NkkPrSRRlmE7Of1CBBIO
-  description: "Dev build of Cockatrice"
+#  release: "release name"    
+#  description: "release text"
   artifact: /.*\.exe/
-  draft: false
-  prerelease: true
   force_update: true
+  draft: false
+  prerelease: false
   on:
     appveyor_repo_tag: true
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,13 +14,13 @@ skip_commits:
     - '*.md'
     - Dockerfile
     - LICENSE
-    
+
 image: Visual Studio 2015
 
 cache:
     - c:\protobuf-release
     - c:\zlib-release
-    
+
 environment:
     matrix:
         - qt_ver: 5.9\msvc2015_64
@@ -35,7 +35,7 @@ environment:
           cmake_generator: Visual Studio 14 2015
           cmake_toolset: v140
           target_arch: x86
-          
+
 install:
     - ps: |
         if (Test-Path c:\protobuf-release) {
@@ -56,10 +56,10 @@ install:
             cmake . -G "$env:cmake_generator" -T "$env:cmake_toolset" -DCMAKE_INSTALL_PREFIX=c:/zlib-release
             msbuild INSTALL.vcxproj /p:Configuration=Release
         }
-        
+
 services:
     - mysql
-    
+
 build_script:
     - ps: |
         New-Item -ItemType directory -Path $env:APPVEYOR_BUILD_FOLDER\build
@@ -83,18 +83,35 @@ build_script:
         
 test: off
 
+
+# Builds for pull requests skip the deployment step altogether
 deploy:
-  provider: GitHub
-  auth_token:
-    secure: p+7wPVry2XEa6TBm9XH8IaQZbBmXQ/J2ldbGmcIxUZD3NkkPrSRRlmE7Of1CBBIO
-#  release: "release name"    
-#  description: "release text"
-  artifact: /.*\.exe/
-  force_update: true
-  draft: false
-  prerelease: true
-  on:
-    appveyor_repo_tag: true
+# Deploy configuration for "beta" releases
+  - provider: GitHub
+    auth_token:
+      secure: p+7wPVry2XEa6TBm9XH8IaQZbBmXQ/J2ldbGmcIxUZD3NkkPrSRRlmE7Of1CBBIO
+    release: "Cockatrice $APPVEYOR_REPO_TAG_NAME"    
+    description: "Beta release of Cockatrice"
+    artifact: /.*\.exe/
+    force_update: true
+    draft: false
+    prerelease: true
+    on:
+      APPVEYOR_REPO_TAG: true
+      APPVEYOR_REPO_TAG_NAME: /([0-9]|[1-9][0-9])(.([0-9]|[1-9][0-9])){2}-beta(|.([2-9]|[1-9][0-9]))$/
+
+# Deploy configuration for "stable" releases
+  - provider: GitHub
+    auth_token:
+       secure: p+7wPVry2XEa6TBm9XH8IaQZbBmXQ/J2ldbGmcIxUZD3NkkPrSRRlmE7Of1CBBIO
+    artifact: /.*\.exe/
+    force_update: true
+    draft: false
+    prerelease: false
+    on:
+      APPVEYOR_REPO_TAG: true
+      APPVEYOR_REPO_TAG_NAME: /([0-9]|[1-9][0-9])(.([0-9]|[1-9][0-9])){2}$/
+
 
 # official validator for ".appveyor.yml" config file: https://ci.appveyor.com/tools/validate-yaml
 # appveyor config documentation: https://www.appveyor.com/docs/build-configuration/

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -98,7 +98,7 @@ deploy:
     prerelease: true
     on:
       APPVEYOR_REPO_TAG: true
-      APPVEYOR_REPO_TAG_NAME: /([0-9]|[1-9][0-9])(\.([0-9]|[1-9][0-9])){2}-beta(\.([2-9]|[1-9][0-9]))?$/
+      APPVEYOR_REPO_TAG_NAME: /(\d|[1-9]\d)(\.(\d|[1-9]\d)){2}-beta(\.([2-9]|[1-9]\d))?$/    # regex to match semver naming convention for beta pre-releases
 
 # Deploy configuration for "stable" releases
   - provider: GitHub
@@ -110,7 +110,7 @@ deploy:
     prerelease: false
     on:
       APPVEYOR_REPO_TAG: true
-      APPVEYOR_REPO_TAG_NAME: /([0-9]|[1-9][0-9])(\.([0-9]|[1-9][0-9])){2}$/
+      APPVEYOR_REPO_TAG_NAME: /(\d|[1-9]\d)(\.(\d|[1-9]\d)){2}$/    # regex to match semver naming convention for stable full releases
 
 
 # official validator for ".appveyor.yml" config file: https://ci.appveyor.com/tools/validate-yaml

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -98,7 +98,7 @@ deploy:
     prerelease: true
     on:
       APPVEYOR_REPO_TAG: true
-      APPVEYOR_REPO_TAG_NAME: /([0-9]|[1-9][0-9])(.([0-9]|[1-9][0-9])){2}-beta(|.([2-9]|[1-9][0-9]))$/
+      APPVEYOR_REPO_TAG_NAME: /([0-9]|[1-9][0-9])(\.([0-9]|[1-9][0-9])){2}-beta(\.([2-9]|[1-9][0-9]))?$/
 
 # Deploy configuration for "stable" releases
   - provider: GitHub
@@ -110,7 +110,7 @@ deploy:
     prerelease: false
     on:
       APPVEYOR_REPO_TAG: true
-      APPVEYOR_REPO_TAG_NAME: /([0-9]|[1-9][0-9])(.([0-9]|[1-9][0-9])){2}$/
+      APPVEYOR_REPO_TAG_NAME: /([0-9]|[1-9][0-9])(\.([0-9]|[1-9][0-9])){2}$/
 
 
 # official validator for ".appveyor.yml" config file: https://ci.appveyor.com/tools/validate-yaml

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -92,7 +92,7 @@ deploy:
   artifact: /.*\.exe/
   force_update: true
   draft: false
-  prerelease: false
+  prerelease: true
   on:
     appveyor_repo_tag: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ deploy:
   file: "build/Cockatrice-*"
   overwrite: true
   draft: false
-  prerelease: false
+  prerelease: true
   on:
     tags: true
     repo: Cockatrice/Cockatrice

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ deploy:
     on:
       tags: true
       repo: Cockatrice/Cockatrice
-      condition: "$BUILDTYPE = Release && $TRAVIS_TAG =~ ([0-9]|[1-9][0-9])(.([0-9]|[1-9][0-9])){2}-beta(|.([2-9]|[1-9][0-9]))$"
+      condition: "$BUILDTYPE = Release && $TRAVIS_TAG =~ ([0-9]|[1-9][0-9])(.([0-9]|[1-9][0-9])){2}-beta(.([2-9]|[1-9][0-9]))?$"
       
 # Deploy configuration for "stable" releases
   - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ deploy:
 # Deploy configuration for "beta" releases
   - provider: releases
     api_key:
-      secure: "mLMF41q7xgOR1sjczsilEy7HQis2PkZCzhfOGbn/8FoOQnmmPOZjrsdhn06ZSl3SFsbfCLuClDYXAbFscQmdgjcGN5AmHV+JYfW650QEuQa/f4/lQFsVRtEqUA1O3FQ0OuRxdpCfJubZBdFVH8SbZ93GLC5zXJbkWQNq+xCX1fU="
+      secure: mLMF41q7xgOR1sjczsilEy7HQis2PkZCzhfOGbn/8FoOQnmmPOZjrsdhn06ZSl3SFsbfCLuClDYXAbFscQmdgjcGN5AmHV+JYfW650QEuQa/f4/lQFsVRtEqUA1O3FQ0OuRxdpCfJubZBdFVH8SbZ93GLC5zXJbkWQNq+xCX1fU=
     skip_cleanup: true
     name: "Cockatrice $TRAVIS_TAG"
     body: "Beta release of Cockatrice"
@@ -53,12 +53,12 @@ deploy:
     on:
       tags: true
       repo: Cockatrice/Cockatrice
-      condition: "$BUILDTYPE = Release && $TRAVIS_TAG =~ (\\d|[1-9]\\d)(\\.(\\d|[1-9]\\d)){2}-beta(\\.([2-9]|[1-9]\\d))?$"     # regex to match semver naming convention for beta pre-releases
+      condition: $BUILDTYPE = Release && $TRAVIS_TAG =~ ([0-9]|[1-9][0-9])(\.([0-9]|[1-9][0-9])){2}-beta(\.([2-9]|[1-9][0-9]))?$     # regex to match semver naming convention for beta pre-releases
       
 # Deploy configuration for "stable" releases
   - provider: releases
     api_key:
-      secure: "mLMF41q7xgOR1sjczsilEy7HQis2PkZCzhfOGbn/8FoOQnmmPOZjrsdhn06ZSl3SFsbfCLuClDYXAbFscQmdgjcGN5AmHV+JYfW650QEuQa/f4/lQFsVRtEqUA1O3FQ0OuRxdpCfJubZBdFVH8SbZ93GLC5zXJbkWQNq+xCX1fU="
+      secure: mLMF41q7xgOR1sjczsilEy7HQis2PkZCzhfOGbn/8FoOQnmmPOZjrsdhn06ZSl3SFsbfCLuClDYXAbFscQmdgjcGN5AmHV+JYfW650QEuQa/f4/lQFsVRtEqUA1O3FQ0OuRxdpCfJubZBdFVH8SbZ93GLC5zXJbkWQNq+xCX1fU=
     skip_cleanup: true
     file_glob: true
     file: "build/Cockatrice-*"
@@ -68,7 +68,7 @@ deploy:
     on:
       tags: true
       repo: Cockatrice/Cockatrice
-      condition: "$BUILDTYPE = Release && $TRAVIS_TAG =~ (\\d|[1-9]\\d)(\\.(\\d|[1-9]\\d)){2}$"    # regex to match semver naming convention for stable full releases
+      condition: $BUILDTYPE = Release && $TRAVIS_TAG =~ ([0-9]|[1-9][0-9])(\.([0-9]|[1-9][0-9])){2}$    # regex to match semver naming convention for stable full releases
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,14 @@ deploy:
   provider: releases
   api_key:
     secure: "mLMF41q7xgOR1sjczsilEy7HQis2PkZCzhfOGbn/8FoOQnmmPOZjrsdhn06ZSl3SFsbfCLuClDYXAbFscQmdgjcGN5AmHV+JYfW650QEuQa/f4/lQFsVRtEqUA1O3FQ0OuRxdpCfJubZBdFVH8SbZ93GLC5zXJbkWQNq+xCX1fU="
+  skip_cleanup: true
+#  name: "release name"
+#  body: "release text"
   file_glob: true
   file: "build/Cockatrice-*"
-  prerelease: true
-  skip_cleanup: true
   overwrite: true
+  draft: false
+  prerelease: false
   on:
     tags: true
     repo: Cockatrice/Cockatrice

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ deploy:
     on:
       tags: true
       repo: Cockatrice/Cockatrice
-      condition: "$BUILDTYPE = Release && $TRAVIS_TAG =~ ([0-9]|[1-9][0-9])(.([0-9]|[1-9][0-9])){2}-beta(.([2-9]|[1-9][0-9]))?$"
+      condition: "$BUILDTYPE = Release && $TRAVIS_TAG =~ (\\d|[1-9]\\d)(\\.(\\d|[1-9]\\d)){2}-beta(\\.([2-9]|[1-9]\\d))?$"     # regex to match semver naming convention for beta pre-releases
       
 # Deploy configuration for "stable" releases
   - provider: releases
@@ -68,7 +68,7 @@ deploy:
     on:
       tags: true
       repo: Cockatrice/Cockatrice
-      condition: "$BUILDTYPE = Release && $TRAVIS_TAG =~ ([0-9]|[1-9][0-9])(.([0-9]|[1-9][0-9])){2}$"
+      condition: "$BUILDTYPE = Release && $TRAVIS_TAG =~ (\\d|[1-9]\\d)(\\.(\\d|[1-9]\\d)){2}$"    # regex to match semver naming convention for stable full releases
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,22 +35,41 @@ install: bash ./.travis/travis-dependencies.sh
 
 script: bash ./.travis/travis-compile.sh
 
+
+# Builds for pull requests skip the deployment step altogether
 deploy:
-  provider: releases
-  api_key:
-    secure: "mLMF41q7xgOR1sjczsilEy7HQis2PkZCzhfOGbn/8FoOQnmmPOZjrsdhn06ZSl3SFsbfCLuClDYXAbFscQmdgjcGN5AmHV+JYfW650QEuQa/f4/lQFsVRtEqUA1O3FQ0OuRxdpCfJubZBdFVH8SbZ93GLC5zXJbkWQNq+xCX1fU="
-  skip_cleanup: true
-#  name: "release name"
-#  body: "release text"
-  file_glob: true
-  file: "build/Cockatrice-*"
-  overwrite: true
-  draft: false
-  prerelease: true
-  on:
-    tags: true
-    repo: Cockatrice/Cockatrice
-    condition: $BUILDTYPE = Release
+# Deploy configuration for "beta" releases
+  - provider: releases
+    api_key:
+      secure: "mLMF41q7xgOR1sjczsilEy7HQis2PkZCzhfOGbn/8FoOQnmmPOZjrsdhn06ZSl3SFsbfCLuClDYXAbFscQmdgjcGN5AmHV+JYfW650QEuQa/f4/lQFsVRtEqUA1O3FQ0OuRxdpCfJubZBdFVH8SbZ93GLC5zXJbkWQNq+xCX1fU="
+    skip_cleanup: true
+    name: "Cockatrice $TRAVIS_TAG"
+    body: "Beta release of Cockatrice"
+    file_glob: true
+    file: "build/Cockatrice-*"
+    overwrite: true
+    draft: false
+    prerelease: true
+    on:
+      tags: true
+      repo: Cockatrice/Cockatrice
+      condition: "$BUILDTYPE = Release && $TRAVIS_TAG =~ ([0-9]|[1-9][0-9])(.([0-9]|[1-9][0-9])){2}-beta(|.([2-9]|[1-9][0-9]))$"
+      
+# Deploy configuration for "stable" releases
+  - provider: releases
+    api_key:
+      secure: "mLMF41q7xgOR1sjczsilEy7HQis2PkZCzhfOGbn/8FoOQnmmPOZjrsdhn06ZSl3SFsbfCLuClDYXAbFscQmdgjcGN5AmHV+JYfW650QEuQa/f4/lQFsVRtEqUA1O3FQ0OuRxdpCfJubZBdFVH8SbZ93GLC5zXJbkWQNq+xCX1fU="
+    skip_cleanup: true
+    file_glob: true
+    file: "build/Cockatrice-*"
+    overwrite: true
+    draft: false
+    prerelease: false
+    on:
+      tags: true
+      repo: Cockatrice/Cockatrice
+      condition: "$BUILDTYPE = Release && $TRAVIS_TAG =~ ([0-9]|[1-9][0-9])(.([0-9]|[1-9][0-9])){2}$"
+
 
 notifications:
   webhooks:
@@ -59,6 +78,7 @@ notifications:
     on_success: change
     on_failure: change
     on_start: never
-    
+ 
+ 
 # official validator for ".travis.yml" config file: https://yaml.travis-ci.org
 # travis config documentation: https://docs.travis-ci.com/user/customizing-the-build

--- a/cmake/getversion.cmake
+++ b/cmake/getversion.cmake
@@ -86,7 +86,7 @@ function(get_tag_name commit)
 
 	# Sanity checks: length
 	list(LENGTH GIT_TAG_EXPLODED GIT_TAG_LISTCOUNT)
-	if(${GIT_TAG_LISTCOUNT} LESS 7 OR ${GIT_TAG_LISTCOUNT} GREATER 8)
+	if(${GIT_TAG_LISTCOUNT} LESS 7 OR ${GIT_TAG_LISTCOUNT} GREATER 9)
 		message(WARNING "Invalid tag format, got ${GIT_TAG_LISTCOUNT} tokens")
 		return()
 	endif()


### PR DESCRIPTION
## Related Ticket(s)
- Fixes https://github.com/Cockatrice/Cockatrice/issues/2921

## Short roundup of the initial problem
All drafted changelog text + release name were purged and replaced with "Dev build" phrase and a wrong name for all kind of releases. Also, every release was tagged as *pre-release*.
In return one always has to adjust each published release, no custom config options based on release type were possible.

AS @ZeldaZach put it for stable releases:
```
--Build happens and replaces stuff--
Re-paste release notes
Re-paste release name
Re-publish to no longer be pre-release
```

## What will change with this Pull Request?
With this PR all of above are no longer needed, and it allows for a lot more customization and other future tweaks.

- Utilize multiple deploy provider entries with custom conditions
- Separate config for `Beta` and `Stable` on both CI's
     - Betas will be published as *pre-release*, stable as *full release*
     - Stable releases shouldn't purge the beforehand drafted changelog any longer,
while Betas keep their beta phrase in the description and set a better name per default
- Which config to apply is taken from the GitHub `tag` in a env var (conditional deploy)
- The tag has to comply with [Semantic Versioning 2.0.0](https://semver.org/) schema:
   - `x.y.z` for stable, or `x.y.z-beta`/`x.y.z-beta.n` for beta
    - No leading 0 for single digit numbers
    - Beta appendix has to be `-beta` for the first (no `-beta.1` exists)
Follow ups have to be append a incrementing number, separated by `.` like `-beta.2` and up

The big advantage here is that we can handle both release types with unique configurations while the workflow is the same for both - we only need to tag a commit on GitHub.
The check for a correct semver prevents that a mistyped tag gets deployed and causes wrong file names for our binaries for example. Or version numbers being displayed wrongly in the `About` window and the windows installer for example! Our tag is the basis for all of this and that information gets parsed from it.
So one will recognize little errors before it's too late, and can re-tag correctly.

The ideal case would be that one only has to set a git tag and everything else is done automatically.
But to have it set a release name like `Cockatrice 2.4.1-beta` for example, our tag would need to be in a different form than it is right now.
Even automatically adding a changelog to the description in the future could be possible. It would require having a changelog file we maintain continuously instead the manual writeup of the past 6 month like Zach is doing it now...

I needed to adjust the cmake getversion file, too.

Possible future improvements:
- Have a good automated name for beta + stable releases on GitHub
- And maybe the changelog thing isn't ideal as is now...

<br>

>I'm sure the regex can be smarter, I didn't use *lookaround* for example.
**Improvements welcome!**

<br>

Link library:
https://docs.travis-ci.com/user/deployment/releases/#Advanced-options
https://www.appveyor.com/docs/deployment/github/
https://docs.travis-ci.com/user/deployment/#Conditional-Releases-with-on%3A
https://docs.travis-ci.com/user/conditional-builds-stages-jobs
https://regex101.com/
https://www.regular-expressions.info/quickstart.html
see https://github.com/Cockatrice/Cockatrice/pull/2976#issuecomment-354367340