### PR TITLE
fix var call

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,7 +90,7 @@ deploy:
   - provider: GitHub
     auth_token:
       secure: p+7wPVry2XEa6TBm9XH8IaQZbBmXQ/J2ldbGmcIxUZD3NkkPrSRRlmE7Of1CBBIO
-    release: "Cockatrice $APPVEYOR_REPO_TAG_NAME"
+    release: "Cockatrice $(APPVEYOR_REPO_TAG_NAME)"
     description: "Beta release of Cockatrice"
     artifact: /.*\.exe/
     force_update: true


### PR DESCRIPTION
## Related Ticket(s)
- Fixes issue with #2976

## Short roundup of the initial problem
Overlooked that unlike travis, appveyor wants variable names in brackets

From the docs:
>You can use environment variables in release name, for example
`product release of v$(appveyor_build_version)`.

## What will change with this Pull Request?
- add brackets to properly use the variable
