### PR TITLE
appveyor: add tag

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,6 +90,7 @@ deploy:
   - provider: GitHub
     auth_token:
       secure: p+7wPVry2XEa6TBm9XH8IaQZbBmXQ/J2ldbGmcIxUZD3NkkPrSRRlmE7Of1CBBIO
+    tag: "$(APPVEYOR_REPO_TAG_NAME)"
     release: "Cockatrice $(APPVEYOR_REPO_TAG_NAME)"
     description: "Beta release of Cockatrice"
     artifact: /.*\.exe/
@@ -104,6 +105,8 @@ deploy:
   - provider: GitHub
     auth_token:
        secure: p+7wPVry2XEa6TBm9XH8IaQZbBmXQ/J2ldbGmcIxUZD3NkkPrSRRlmE7Of1CBBIO
+    tag: "$(APPVEYOR_REPO_TAG_NAME)"
+    release: "Cockatrice $(APPVEYOR_REPO_TAG_NAME)"
     artifact: /.*\.exe/
     force_update: true
     draft: false


### PR DESCRIPTION
## Related Ticket(s)
- Fixes issue with #2976

## Short roundup of the initial problem
For appveyor a tag must be set, otherwise one is assumed which doesn't fit our created tag.
That leads to a new tag+release+build being created.

## What will change with this Pull Request?
- force to use same tag from variable
