### PR TITLE
adjust custom naming, clickable commit hash in brackets

### DIFF
--- a/cmake/getversion.cmake
+++ b/cmake/getversion.cmake
@@ -15,7 +15,7 @@ function(get_commit_id)
 
 	string(REPLACE "\n" "" GIT_COM_ID "${GIT_COM_ID}")
 	set(GIT_COMMIT_ID "${GIT_COM_ID}" PARENT_SCOPE)
-	set(PROJECT_VERSION_LABEL "custom_${GIT_COM_ID}" PARENT_SCOPE)
+	set(PROJECT_VERSION_LABEL "custom[${GIT_COM_ID}]" PARENT_SCOPE)
 endfunction()
 
 function(get_commit_date)
@@ -192,7 +192,7 @@ endfunction()
 set(GIT_COMMIT_ID "unknown")
 set(GIT_COMMIT_DATE "unknown")
 set(GIT_COMMIT_DATE_FRIENDLY "unknown")
-set(PROJECT_VERSION_LABEL "custom_unknown")
+set(PROJECT_VERSION_LABEL "custom[unknown]")
 set(PROJECT_VERSION_RELEASENAME "")
 
 find_package(Git)

--- a/cmake/getversion.cmake
+++ b/cmake/getversion.cmake
@@ -15,7 +15,7 @@ function(get_commit_id)
 
 	string(REPLACE "\n" "" GIT_COM_ID "${GIT_COM_ID}")
 	set(GIT_COMMIT_ID "${GIT_COM_ID}" PARENT_SCOPE)
-	set(PROJECT_VERSION_LABEL "custom\[${GIT_COM_ID}\]" PARENT_SCOPE)
+	set(PROJECT_VERSION_LABEL "custom(${GIT_COM_ID})" PARENT_SCOPE)
 endfunction()
 
 function(get_commit_date)
@@ -192,7 +192,7 @@ endfunction()
 set(GIT_COMMIT_ID "unknown")
 set(GIT_COMMIT_DATE "unknown")
 set(GIT_COMMIT_DATE_FRIENDLY "unknown")
-set(PROJECT_VERSION_LABEL "custom\[unknown\]")
+set(PROJECT_VERSION_LABEL "custom(unknown)")
 set(PROJECT_VERSION_RELEASENAME "")
 
 find_package(Git)

--- a/cmake/getversion.cmake
+++ b/cmake/getversion.cmake
@@ -15,7 +15,7 @@ function(get_commit_id)
 
 	string(REPLACE "\n" "" GIT_COM_ID "${GIT_COM_ID}")
 	set(GIT_COMMIT_ID "${GIT_COM_ID}" PARENT_SCOPE)
-	set(PROJECT_VERSION_LABEL "custom[${GIT_COM_ID}]" PARENT_SCOPE)
+	set(PROJECT_VERSION_LABEL "custom\[${GIT_COM_ID}\]" PARENT_SCOPE)
 endfunction()
 
 function(get_commit_date)
@@ -192,7 +192,7 @@ endfunction()
 set(GIT_COMMIT_ID "unknown")
 set(GIT_COMMIT_DATE "unknown")
 set(GIT_COMMIT_DATE_FRIENDLY "unknown")
-set(PROJECT_VERSION_LABEL "custom[unknown]")
+set(PROJECT_VERSION_LABEL "custom\[unknown\]")
 set(PROJECT_VERSION_RELEASENAME "")
 
 find_package(Git)


### PR DESCRIPTION
## Short roundup of the initial problem
Version got extended with `-custom_GIT-COMMIT-HASH` for non-tagged builds to have a reference where there are build from or what they are based on:
```
-- Commit is not a release or prerelease (no git tag found)
-- Project version: 2.4.1-custom_3af2be4
-- Friendly project version: 2.4.1-custom_3af2be4 (2017-12-19)
-- Project version filename: Cockatrice-2.4.1-custom_3af2be4
```
So people would copy that info when they open a issue to help us with troubleshooting.

Before we used only `GIT-COMMIT-HASH` as version, which had the nice feature that when copied to GitHub it was clickable and linked to the commit itself.
It was then very easy to check and see a date and what the most recent change was about. Because only by looking at the commit hash nobody can tell which version the user was running in detail.

This wasn't possible any more after changing to a version number and appending the hash with a leading underscore like we do it now.

## What will change with this Pull Request?
Wrap the name in brackets and make it clickable.
```
-- Commit is not a release or prerelease (no git tag found)
-- Project version: 2.4.1-custom(77ae2d4)
-- Friendly project version: 2.4.1-custom(77ae2d4) (2017-12-29)
-- Project version filename: Cockatrice-2.4.1-custom(77ae2d4)
```

This will make GitHub detect it and hotlink it again!

Examples from `About` window:
- before: "Version 77ae2d4" (not even sure if there was a date at the beginning...)
- now: "Version 2.4.1-custom_77ae2d4 (2017-12-29)"
- with this PR: "Version 2.4.1-custom(77ae2d4) (2017-12-29)"

Other options don't get recognized by GitHub as well:
- "Version 2.4.1-custom77ae2d4 (2017-12-29)"
- "Version 2.4.1-custom.77ae2d4 (2017-12-29)"
- "Version 2.4.1-custom-77ae2d4 (2017-12-29)"

The name will update in all places where it shows up. Debug log and about window, NSIS installer, file name for build artifacts etc.

---

I preferred `[ ]` brackets and tried them first.
[Cmake shows it correctly](https://ci.appveyor.com/project/Daenyth/cockatrice/build/2.4.1-branch-tooomm-custom_naming-build-804/job/copc9f5e2ixsqysj#L59), but it makes the artifact upload fail on appveyor with this message:
```
Push-AppveyorArtifactInternal : Cannot bind argument to parameter 'FullPath' because it is null.
At C:\Program Files\AppVeyor\BuildAgent\Modules\build-worker-api\build-worker-api.psm1:209 char:42
+     Push-AppveyorArtifactInternal -FullPath $fullPath -FileName $File ...
+                                             ~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Push-AppveyorArtifactInternal], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorNullNotAllowed,Appveyor.BuildAgent.Api.Utils.PushAppveyorArtifactInternalCmdlet
 
Uploading artifact CMakeCache.txt (18,995 bytes)...100%
Uploading artifact latest-x86_64 (201 bytes)...100%
```
(https://ci.appveyor.com/project/Daenyth/cockatrice/build/2.4.1-branch-tooomm-custom_naming-build-804/job/copc9f5e2ixsqysj#L3353)
I think they look cleaner and separate better from the date which is in round brackets already:
"Version 2.4.1-custom[ac5fbe5] (2017-12-29)"

**If somebody has a solution here, let me know!**