### PR TITLE
card filter: alphabetical ordering for keywords

### DIFF
--- a/cockatrice/src/cardfilter.cpp
+++ b/cockatrice/src/cardfilter.cpp
@@ -20,25 +20,25 @@ const char *CardFilter::attrName(Attr a)
 {
     switch (a) {
         case AttrName:
-            return "name";
+            return "Name";
         case AttrType:
-            return "type";
+            return "Type";
         case AttrColor:
-            return "color";
+            return "Color";
         case AttrText:
-            return "text";
+            return "Text";
         case AttrSet:
-            return "set";
+            return "Set";
         case AttrManaCost:
-            return "mana cost";
+            return "Mana Cost";
         case AttrCmc:
-            return "cmc";
+            return "CMC";
         case AttrRarity:
-            return "rarity";
+            return "Rarity";
         case AttrPow:
-            return "power";
+            return "Power";
         case AttrTough:
-            return "toughness";
+            return "Toughness";
         default:
             return "";
     }

--- a/cockatrice/src/cardfilter.cpp
+++ b/cockatrice/src/cardfilter.cpp
@@ -19,26 +19,26 @@ const char *CardFilter::typeName(Type t)
 const char *CardFilter::attrName(Attr a)
 {
     switch (a) {
-        case AttrCmc:
-            return "CMC";
-        case AttrColor:
-            return "Color";
-        case AttrManaCost:
-            return "Mana Cost";
         case AttrName:
-            return "Name";
-        case AttrPow:
-            return "Power";
-        case AttrRarity:
-            return "Rarity";
-        case AttrSet:
-            return "Set";
-        case AttrText:
-            return "Text";
-        case AttrTough:
-            return "Toughness";
+            return "name";
         case AttrType:
-            return "Type";
+            return "type";
+        case AttrColor:
+            return "color";
+        case AttrText:
+            return "text";
+        case AttrSet:
+            return "set";
+        case AttrManaCost:
+            return "mana cost";
+        case AttrCmc:
+            return "cmc";
+        case AttrRarity:
+            return "rarity";
+        case AttrPow:
+            return "power";
+        case AttrTough:
+            return "toughness";
         default:
             return "";
     }

--- a/cockatrice/src/cardfilter.cpp
+++ b/cockatrice/src/cardfilter.cpp
@@ -19,26 +19,26 @@ const char *CardFilter::typeName(Type t)
 const char *CardFilter::attrName(Attr a)
 {
     switch (a) {
-        case AttrName:
-            return "name";
-        case AttrType:
-            return "type";
-        case AttrColor:
-            return "color";
-        case AttrText:
-            return "text";
-        case AttrSet:
-            return "set";
-        case AttrManaCost:
-            return "mana cost";
         case AttrCmc:
-            return "cmc";
-        case AttrRarity:
-            return "rarity";
+            return "CMC";
+        case AttrColor:
+            return "Color";
+        case AttrManaCost:
+            return "Mana Cost";
+        case AttrName:
+            return "Name";
         case AttrPow:
-            return "power";
+            return "Power";
+        case AttrRarity:
+            return "Rarity";
+        case AttrSet:
+            return "Set";
+        case AttrText:
+            return "Text";
         case AttrTough:
-            return "toughness";
+            return "Toughness";
+        case AttrType:
+            return "Type";
         default:
             return "";
     }

--- a/cockatrice/src/cardfilter.h
+++ b/cockatrice/src/cardfilter.h
@@ -16,16 +16,16 @@ public:
     /* if you add an atribute here you also need to
      * add its string representation in attrName */
     enum Attr {
-        AttrName = 0,
-        AttrType,
-        AttrColor,
+        AttrCmc = 0,
+		AttrColor,
+		AttrManaCost,
+        AttrName,
+		AttrPow,
+		AttrRarity,
+		AttrSet,
         AttrText,
-        AttrSet,
-        AttrManaCost,
-        AttrCmc,
-        AttrRarity,
-        AttrPow,
         AttrTough,
+		AttrType,
         AttrEnd
     };
 

--- a/cockatrice/src/cardfilter.h
+++ b/cockatrice/src/cardfilter.h
@@ -17,15 +17,15 @@ public:
      * add its string representation in attrName */
     enum Attr {
         AttrCmc = 0,
-		AttrColor,
-		AttrManaCost,
+        AttrColor,
+        AttrManaCost,
         AttrName,
-		AttrPow,
-		AttrRarity,
-		AttrSet,
+        AttrPow,
+        AttrRarity,
+        AttrSet,
         AttrText,
         AttrTough,
-		AttrType,
+        AttrType,
         AttrEnd
     };
 

--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -168,9 +168,14 @@ bool FilterItemList::testTypeOrNot(const CardInfo *info, CardFilter::Attr attr) 
     return !testTypeAnd(info, attr);
 }
 
-bool FilterItem::acceptCmc(const CardInfo *info) const
+bool FilterItem::acceptName(const CardInfo *info) const
 {
-    return (info->getCmc() == term);
+    return info->getName().contains(term, Qt::CaseInsensitive);
+}
+
+bool FilterItem::acceptType(const CardInfo *info) const
+{
+    return info->getCardType().contains(term, Qt::CaseInsensitive);
 }
 
 bool FilterItem::acceptColor(const CardInfo *info) const
@@ -217,20 +222,47 @@ bool FilterItem::acceptColor(const CardInfo *info) const
     return match_count == converted_term.length();
 }
 
+bool FilterItem::acceptText(const CardInfo *info) const
+{
+    return info->getText().contains(term, Qt::CaseInsensitive);
+}
+
+bool FilterItem::acceptSet(const CardInfo *info) const
+{
+    bool status = false;
+    for (auto i = info->getSets().constBegin(); i != info->getSets().constEnd(); i++)
+    {
+        if ((*i)->getShortName().compare(term, Qt::CaseInsensitive) == 0
+            || (*i)->getLongName().compare(term, Qt::CaseInsensitive) == 0)
+        {
+            status = true;
+            break;
+        }
+    }
+
+    return status;
+}
+
 bool FilterItem::acceptManaCost(const CardInfo *info) const
 {
     return (info->getManaCost() == term);
 }
 
-bool FilterItem::acceptName(const CardInfo *info) const
+bool FilterItem::acceptCmc(const CardInfo *info) const
 {
-    return info->getName().contains(term, Qt::CaseInsensitive);
+    return (info->getCmc() == term);
 }
 
 bool FilterItem::acceptPower(const CardInfo *info) const
 {
     int slash = info->getPowTough().indexOf("/");
     return (slash != -1) ? (info->getPowTough().mid(0,slash) == term) : false;
+}
+
+bool FilterItem::acceptToughness(const CardInfo *info) const
+{
+    int slash = info->getPowTough().indexOf("/");
+    return (slash != -1) ? (info->getPowTough().mid(slash+1) == term) : false;
 }
 
 bool FilterItem::acceptRarity(const CardInfo *info) const
@@ -271,52 +303,20 @@ bool FilterItem::acceptRarity(const CardInfo *info) const
     return false;
 }
 
-bool FilterItem::acceptSet(const CardInfo *info) const
-{
-    bool status = false;
-    for (auto i = info->getSets().constBegin(); i != info->getSets().constEnd(); i++)
-    {
-        if ((*i)->getShortName().compare(term, Qt::CaseInsensitive) == 0
-            || (*i)->getLongName().compare(term, Qt::CaseInsensitive) == 0)
-        {
-            status = true;
-            break;
-        }
-    }
-
-    return status;
-}
-
-bool FilterItem::acceptText(const CardInfo *info) const
-{
-    return info->getText().contains(term, Qt::CaseInsensitive);
-}
-
-bool FilterItem::acceptToughness(const CardInfo *info) const
-{
-    int slash = info->getPowTough().indexOf("/");
-    return (slash != -1) ? (info->getPowTough().mid(slash+1) == term) : false;
-}
-
-bool FilterItem::acceptType(const CardInfo *info) const
-{
-    return info->getCardType().contains(term, Qt::CaseInsensitive);
-}
-
 bool FilterItem::acceptCardAttr(const CardInfo *info, CardFilter::Attr attr) const
 {
     switch (attr)
     {
-        case CardFilter::AttrCmc: return acceptCmc(info);
-        case CardFilter::AttrColor: return acceptColor(info);
-        case CardFilter::AttrManaCost: return acceptManaCost(info);
         case CardFilter::AttrName: return acceptName(info);
-        case CardFilter::AttrPow: return acceptPower(info);
-        case CardFilter::AttrRarity: return acceptRarity(info);
-        case CardFilter::AttrSet: return acceptSet(info);
-        case CardFilter::AttrText: return acceptText(info);
-        case CardFilter::AttrTough: return acceptToughness(info);
         case CardFilter::AttrType: return acceptType(info);
+        case CardFilter::AttrColor: return acceptColor(info);
+        case CardFilter::AttrText: return acceptText(info);
+        case CardFilter::AttrSet: return acceptSet(info);
+        case CardFilter::AttrManaCost: return acceptManaCost(info);
+        case CardFilter::AttrCmc: return acceptCmc(info);
+        case CardFilter::AttrRarity: return acceptRarity(info);
+        case CardFilter::AttrPow: return acceptPower(info);
+        case CardFilter::AttrTough: return acceptToughness(info);
         default: return true; /* ignore this attribute */
     }
 }

--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -168,14 +168,9 @@ bool FilterItemList::testTypeOrNot(const CardInfo *info, CardFilter::Attr attr) 
     return !testTypeAnd(info, attr);
 }
 
-bool FilterItem::acceptName(const CardInfo *info) const
+bool FilterItem::acceptCmc(const CardInfo *info) const
 {
-    return info->getName().contains(term, Qt::CaseInsensitive);
-}
-
-bool FilterItem::acceptType(const CardInfo *info) const
-{
-    return info->getCardType().contains(term, Qt::CaseInsensitive);
+    return (info->getCmc() == term);
 }
 
 bool FilterItem::acceptColor(const CardInfo *info) const
@@ -222,47 +217,20 @@ bool FilterItem::acceptColor(const CardInfo *info) const
     return match_count == converted_term.length();
 }
 
-bool FilterItem::acceptText(const CardInfo *info) const
-{
-    return info->getText().contains(term, Qt::CaseInsensitive);
-}
-
-bool FilterItem::acceptSet(const CardInfo *info) const
-{
-    bool status = false;
-    for (auto i = info->getSets().constBegin(); i != info->getSets().constEnd(); i++)
-    {
-        if ((*i)->getShortName().compare(term, Qt::CaseInsensitive) == 0
-            || (*i)->getLongName().compare(term, Qt::CaseInsensitive) == 0)
-        {
-            status = true;
-            break;
-        }
-    }
-
-    return status;
-}
-
 bool FilterItem::acceptManaCost(const CardInfo *info) const
 {
     return (info->getManaCost() == term);
 }
 
-bool FilterItem::acceptCmc(const CardInfo *info) const
+bool FilterItem::acceptName(const CardInfo *info) const
 {
-    return (info->getCmc() == term);
+    return info->getName().contains(term, Qt::CaseInsensitive);
 }
 
 bool FilterItem::acceptPower(const CardInfo *info) const
 {
     int slash = info->getPowTough().indexOf("/");
     return (slash != -1) ? (info->getPowTough().mid(0,slash) == term) : false;
-}
-
-bool FilterItem::acceptToughness(const CardInfo *info) const
-{
-    int slash = info->getPowTough().indexOf("/");
-    return (slash != -1) ? (info->getPowTough().mid(slash+1) == term) : false;
 }
 
 bool FilterItem::acceptRarity(const CardInfo *info) const
@@ -303,20 +271,52 @@ bool FilterItem::acceptRarity(const CardInfo *info) const
     return false;
 }
 
+bool FilterItem::acceptSet(const CardInfo *info) const
+{
+    bool status = false;
+    for (auto i = info->getSets().constBegin(); i != info->getSets().constEnd(); i++)
+    {
+        if ((*i)->getShortName().compare(term, Qt::CaseInsensitive) == 0
+            || (*i)->getLongName().compare(term, Qt::CaseInsensitive) == 0)
+        {
+            status = true;
+            break;
+        }
+    }
+
+    return status;
+}
+
+bool FilterItem::acceptText(const CardInfo *info) const
+{
+    return info->getText().contains(term, Qt::CaseInsensitive);
+}
+
+bool FilterItem::acceptToughness(const CardInfo *info) const
+{
+    int slash = info->getPowTough().indexOf("/");
+    return (slash != -1) ? (info->getPowTough().mid(slash+1) == term) : false;
+}
+
+bool FilterItem::acceptType(const CardInfo *info) const
+{
+    return info->getCardType().contains(term, Qt::CaseInsensitive);
+}
+
 bool FilterItem::acceptCardAttr(const CardInfo *info, CardFilter::Attr attr) const
 {
     switch (attr)
     {
-        case CardFilter::AttrName: return acceptName(info);
-        case CardFilter::AttrType: return acceptType(info);
-        case CardFilter::AttrColor: return acceptColor(info);
-        case CardFilter::AttrText: return acceptText(info);
-        case CardFilter::AttrSet: return acceptSet(info);
-        case CardFilter::AttrManaCost: return acceptManaCost(info);
         case CardFilter::AttrCmc: return acceptCmc(info);
-        case CardFilter::AttrRarity: return acceptRarity(info);
+        case CardFilter::AttrColor: return acceptColor(info);
+        case CardFilter::AttrManaCost: return acceptManaCost(info);
+        case CardFilter::AttrName: return acceptName(info);
         case CardFilter::AttrPow: return acceptPower(info);
+        case CardFilter::AttrRarity: return acceptRarity(info);
+        case CardFilter::AttrSet: return acceptSet(info);
+        case CardFilter::AttrText: return acceptText(info);
         case CardFilter::AttrTough: return acceptToughness(info);
+        case CardFilter::AttrType: return acceptType(info);
         default: return true; /* ignore this attribute */
     }
 }


### PR DESCRIPTION
## Short roundup of the initial problem
Keywords used to be unordered.
Because of the missing logical structure it was difficult to quickly find the needed filter.

## What will change with this Pull Request?
- Display filter keywords in alphabetical order
- ~~Filter logic is ordered in the same way in the code now, too~~

## Screenshots
- before:
![untitled1](https://user-images.githubusercontent.com/9874850/34503090-edd6a942-f016-11e7-91c7-506f33db24f3.png)

- after:
![untitled2](https://user-images.githubusercontent.com/9874850/34506301-dc73853e-f02b-11e7-907f-c5eebbc07f87.png)

