### PR TITLE
fix tr call for card filter keywords

### DIFF
--- a/cockatrice/src/cardfilter.cpp
+++ b/cockatrice/src/cardfilter.cpp
@@ -20,25 +20,25 @@ const char *CardFilter::attrName(Attr a)
 {
     switch (a) {
         case AttrName:
-            return "name";
+            return tr("Name");
         case AttrType:
-            return "type";
+            return tr("Type");
         case AttrColor:
-            return "color";
+            return tr("Color");
         case AttrText:
-            return "text";
+            return tr("Text");
         case AttrSet:
-            return "set";
+            return tr("Set");
         case AttrManaCost:
-            return "mana cost";
+            return tr("Mana Cost");
         case AttrCmc:
-            return "cmc";
+            return tr("CMC");
         case AttrRarity:
-            return "rarity";
+            return tr("Rarity");
         case AttrPow:
-            return "power";
+            return tr("Power");
         case AttrTough:
-            return "toughness";
+            return tr("Toughness");
         default:
             return "";
     }

--- a/cockatrice/src/filterbuilder.cpp
+++ b/cockatrice/src/filterbuilder.cpp
@@ -14,7 +14,7 @@ FilterBuilder::FilterBuilder(QWidget *parent)
     filterCombo->setObjectName("filterCombo");
     for (int i = 0; i < CardFilter::AttrEnd; i++)
         filterCombo->addItem(
-            tr(CardFilter::attrName(static_cast<CardFilter::Attr>(i))),
+            CardFilter::attrName(static_cast<CardFilter::Attr>(i)),
             QVariant(i)
         );
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2986

## Short roundup of the initial problem
Translation of keywords in the card filter wasn't possible.

## What will change with this Pull Request?
- tr() wrapping right next to the strings
- Use title case capitalization for UI