### PR TITLE
fix pm notification pop-up for languages others than en

### DIFF
--- a/cockatrice/src/tab_message.cpp
+++ b/cockatrice/src/tab_message.cpp
@@ -135,7 +135,7 @@ bool TabMessage::shouldShowSystemPopup(const Event_UserMessage &event) {
 void TabMessage::showSystemPopup(const Event_UserMessage &event) {
     if (trayIcon) {
         disconnect(trayIcon, SIGNAL(messageClicked()), 0, 0);
-        trayIcon->showMessage(tr("Private message from ") + otherUserInfo->name().c_str(), event.message().c_str());
+        trayIcon->showMessage(tr("Private message from") + " " + otherUserInfo->name().c_str(), event.message().c_str());
         connect(trayIcon, SIGNAL(messageClicked()), this, SLOT(messageClicked()));
     }
     else


### PR DESCRIPTION
## Short roundup of the initial problem
A space at the end of the source string caused problems with translating. It wasn't picked up by transifex (or is simply not visible in the interface), therefore people translated it without a additional space at the end...

## What will change with this Pull Request?
- Force a space at the end of that string

## Screenshots
Looked like that once you use a different localization than english:
![msg](https://user-images.githubusercontent.com/9874850/34507780-d7f92168-f039-11e7-9103-ccca210317e4.png)
