### PR TITLE
Automatic Spoiler Season

### DIFF
--- a/cmake/getversion.cmake
+++ b/cmake/getversion.cmake
@@ -80,7 +80,7 @@ function(get_tag_name commit)
 
 	# Extract information from tag:
 	# YYYY-MM-DD-Release-MAJ.MIN.PATCH
-	# YYYY-MM-DD-Development-MAJ.MIN.PATCH-betaX
+	# YYYY-MM-DD-Development-MAJ.MIN.PATCH-beta.X
 	string(REPLACE "-" ";" GIT_TAG_EXPLODED "${GIT_TAG}")
 	string(REPLACE "." ";" GIT_TAG_EXPLODED "${GIT_TAG_EXPLODED}")
 
@@ -141,8 +141,16 @@ function(get_tag_name commit)
 	endif()
 
 	# Label
+	# 7 = Full release
+	# 8 = Dev release, first beta so only "beta" attached
+	# 9 = Dev release, not first beta so "beta.N" attached
 	if(${GIT_TAG_LISTCOUNT} EQUAL 8)
 		list(GET GIT_TAG_EXPLODED 7 GIT_TAG_LABEL)
+	elseif(${GIT_TAG_LISTCOUNT} EQUAL 9)
+		list(GET GIT_TAG_EXPLODED 7 GIT_TAG_LABEL)
+		list(GET GIT_TAG_EXPLODED 8 GIT_TAG_LABEL_NUM)
+		set(GIT_TAG_LABEL ${GIT_TAG_LABEL} ${GIT_TAG_LABEL_NUM})
+		string(REPLACE ";" "." GIT_TAG_LABEL "${GIT_TAG_LABEL}")
 	else()
 		SET(GIT_TAG_LABEL "")
 	endif()

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -116,6 +116,7 @@ SET(cockatrice_SOURCES
     src/logger.cpp
     src/releasechannel.cpp
     src/userconnection_information.cpp
+    src/spoilerbackgroundupdater.cpp
     ${VERSION_STRING_CPP}
 )
 

--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -14,7 +14,7 @@ const char* CardDatabase::TOKENS_SETNAME = "TK";
 
 static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardSet *set)
 {
-    if (! set)
+    if (set == nullptr)
     {
         qDebug() << "&operator<< set is nullptr";
         return xml;
@@ -78,9 +78,9 @@ class SetList::KeyCompareFunctor
     public:
         inline bool operator()(CardSet *a, CardSet *b) const
         {
-            if (!a || !b)
+            if (a == nullptr || b == nullptr)
             {
-                qDebug() << "SetList a or b is null";
+                qDebug() << "SetList::KeyCompareFunctor a or b is null";
                 return false;
             }
 
@@ -158,7 +158,7 @@ void SetList::enableAll()
     {
         CardSet *set = at(i);
 
-        if (!set)
+        if (set == nullptr)
         {
             qDebug() << "enabledAll has null";
             continue;
@@ -198,7 +198,7 @@ void SetList::guessSortKeys()
     for (int i = 0; i < size(); ++i)
     {
         CardSet *set = at(i);
-        if (! set)
+        if (set == nullptr)
         {
             qDebug() << "guessSortKeys set is null";
             continue;
@@ -324,7 +324,7 @@ QString CardInfo::getCorrectedName() const
 
 void CardInfo::addToSet(CardSet *set)
 {
-    if (! set)
+    if (set == nullptr)
     {
         qDebug() << "addToSet(nullptr)";
         return;
@@ -387,9 +387,9 @@ const QChar CardInfo::getColorChar() const
 
 static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfo *info)
 {
-    if (! info)
+    if (info == nullptr)
     {
-        qDebug() << "operator<< (~376) info is nullptr";
+        qDebug() << "operator<< info is nullptr";
         return xml;
     }
 
@@ -574,7 +574,7 @@ void CardDatabase::addCard(CardInfo *card)
 
 void CardDatabase::removeCard(CardInfo *card)
 {
-    if (! card)
+    if (card == nullptr)
     {
         qDebug() << "removeCard(nullptr)";
         return;
@@ -939,7 +939,7 @@ bool CardDatabase::saveToFile(const QString &fileName, bool tokens)
     xml.writeStartElement("cockatrice_carddatabase");
     xml.writeAttribute("version", QString::number(versionNeeded));
 
-    if (!tokens)
+    if (! tokens)
     {
         xml.writeStartElement("sets");
         QHashIterator<QString, CardSet *> setIterator(sets);

--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -526,7 +526,7 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfo *info)
 
 CardDatabase::CardDatabase(QObject *parent) : QObject(parent), loadStatus(NotLoaded)
 {
-    connect(settingsCache, SIGNAL(cardDatabasePathChanged()), this, SLOT(loadCardDatabases()), Qt::QueuedConnection);
+    connect(settingsCache, SIGNAL(cardDatabasePathChanged()), this, SLOT(threadSafeReloadCardDatabase()));
 }
 
 CardDatabase::~CardDatabase()

--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -6,9 +6,7 @@
 #include <QCryptographicHash>
 #include <QDebug>
 #include <QDir>
-#include <QDirIterator>
 #include <QFile>
-#include <QTextStream>
 #include <QMessageBox>
 
 const int CardDatabase::versionNeeded = 3;
@@ -16,6 +14,12 @@ const char* CardDatabase::TOKENS_SETNAME = "TK";
 
 static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardSet *set)
 {
+    if (! set)
+    {
+        qDebug() << "&operator<< set is nullptr";
+        return xml;
+    }
+
     xml.writeStartElement("set");
     xml.writeTextElement("name", set->getShortName());
     xml.writeTextElement("longname", set->getLongName());
@@ -69,12 +73,19 @@ void CardSet::setIsKnown(bool _isknown)
     settingsCache->cardDatabase().setIsKnown(shortName,_isknown);
 }
 
-class SetList::KeyCompareFunctor {
-public:
-    inline bool operator()(CardSet *a, CardSet *b) const
-    {
-        return a->getSortKey() < b->getSortKey();
-    }
+class SetList::KeyCompareFunctor
+{
+    public:
+        inline bool operator()(CardSet *a, CardSet *b) const
+        {
+            if (!a || !b)
+            {
+                qDebug() << "SetList a or b is null";
+                return false;
+            }
+
+            return a->getSortKey() < b->getSortKey();
+        }
 };
 
 void SetList::sortByKey()
@@ -84,24 +95,28 @@ void SetList::sortByKey()
 
 int SetList::getEnabledSetsNum()
 {
-    int num=0;
+    int num = 0;
     for (int i = 0; i < size(); ++i)
     {
         CardSet *set = at(i);
-        if(set->getEnabled())
+        if (set && set->getEnabled())
+        {
             ++num;
+        }
     }
     return num;
 }
 
 int SetList::getUnknownSetsNum()
 {
-    int num=0;
+    int num = 0;
     for (int i = 0; i < size(); ++i)
     {
         CardSet *set = at(i);
-        if(!set->getIsKnown() && !set->getIsKnownIgnored())
+        if (set && !set->getIsKnown() && !set->getIsKnownIgnored())
+        {
             ++num;
+        }
     }
     return num;
 }
@@ -112,8 +127,10 @@ QStringList SetList::getUnknownSetsNames()
     for (int i = 0; i < size(); ++i)
     {
         CardSet *set = at(i);
-        if(!set->getIsKnown() && !set->getIsKnownIgnored())
+        if (set && !set->getIsKnown() && !set->getIsKnownIgnored())
+        {
             sets << set->getShortName();
+        }
     }
     return sets;
 }
@@ -123,12 +140,12 @@ void SetList::enableAllUnknown()
     for (int i = 0; i < size(); ++i)
     {
         CardSet *set = at(i);
-        if(!set->getIsKnown() && !set->getIsKnownIgnored())
+        if (set && !set->getIsKnown() && !set->getIsKnownIgnored())
         {
             set->setIsKnown(true);
             set->setEnabled(true);
         }
-        else if (set->getIsKnownIgnored() && !set->getEnabled())
+        else if (set && set->getIsKnownIgnored() && !set->getEnabled())
         {
             set->setEnabled(true);
         }
@@ -140,8 +157,18 @@ void SetList::enableAll()
     for (int i = 0; i < size(); ++i)
     {
         CardSet *set = at(i);
-        if(!set->getIsKnownIgnored())
+
+        if (!set)
+        {
+            qDebug() << "enabledAll has null";
+            continue;
+        }
+
+        if (!set->getIsKnownIgnored())
+        {
             set->setIsKnown(true);
+        }
+
         set->setEnabled(true);
     }
 }
@@ -151,12 +178,12 @@ void SetList::markAllAsKnown()
     for (int i = 0; i < size(); ++i)
     {
         CardSet *set = at(i);
-        if(!set->getIsKnown() && !set->getIsKnownIgnored())
+        if(set && !set->getIsKnown() && !set->getIsKnownIgnored())
         {
             set->setIsKnown(true);
             set->setEnabled(false);
         }
-        else if (set->getIsKnownIgnored() && !set->getEnabled())
+        else if (set && set->getIsKnownIgnored() && !set->getEnabled())
         {
             set->setEnabled(true);
         }
@@ -171,11 +198,21 @@ void SetList::guessSortKeys()
     for (int i = 0; i < size(); ++i)
     {
         CardSet *set = at(i);
+        if (! set)
+        {
+            qDebug() << "guessSortKeys set is null";
+            continue;
+        }
+
         QDate date = set->getReleaseDate();
-        if(date.isNull())
-            set->setSortKey(aHundredYears);
+        if (date.isNull())
+        {
+            set->setSortKey(static_cast<unsigned int>(aHundredYears));
+        }
         else
-            set->setSortKey(date.daysTo(distantFuture));
+        {
+            set->setSortKey(static_cast<unsigned int>(date.daysTo(distantFuture)));
+        }
     }
 }
 
@@ -214,9 +251,9 @@ CardInfo::CardInfo(const QString &_name,
       upsideDownArt(_upsideDownArt),
       loyalty(_loyalty),
       customPicURLs(_customPicURLs),
-      muIds(_muIds),
-      collectorNumbers(_collectorNumbers),
-      rarities(_rarities),
+      muIds(std::move(_muIds)),
+      collectorNumbers(std::move(_collectorNumbers)),
+      rarities(std::move(_rarities)),
       cipt(_cipt),
       tableRow(_tableRow)
 {
@@ -224,7 +261,9 @@ CardInfo::CardInfo(const QString &_name,
     simpleName = CardInfo::simplifyName(name);
 
     for (int i = 0; i < sets.size(); i++)
+    {
         sets[i]->append(this);
+    }
 
     refreshCachedSetNames();
 }
@@ -244,11 +283,20 @@ QString CardInfo::getMainCardType() const
 
     int pos;
     if ((pos = result.indexOf('-')) != -1)
+    {
         result.remove(pos, result.length());
+    }
+
     if ((pos = result.indexOf("—")) != -1)
+    {
         result.remove(pos, result.length());
+    }
+
     if ((pos = result.indexOf("//")) != -1)
+    {
         result.remove(pos, result.length());
+    }
+
     result = result.simplified();
     /*
     Legendary Artifact Creature
@@ -256,7 +304,9 @@ QString CardInfo::getMainCardType() const
     */
 
     if ((pos = result.lastIndexOf(' ')) != -1)
+    {
         result = result.mid(pos + 1);
+    }
     /*
     Creature
     Instant
@@ -274,6 +324,12 @@ QString CardInfo::getCorrectedName() const
 
 void CardInfo::addToSet(CardSet *set)
 {
+    if (! set)
+    {
+        qDebug() << "addToSet(nullptr)";
+        return;
+    }
+
     set->append(this);
     sets << set;
 
@@ -286,14 +342,17 @@ void CardInfo::refreshCachedSetNames()
     QStringList setList;
     for (int i = 0; i < sets.size(); i++)
     {
-        if(sets[i]->getEnabled())
+        if (sets[i]->getEnabled())
+        {
             setList << sets[i]->getShortName();
+        }
     }
     setsNames = setList.join(", ");
 
 }
 
-QString CardInfo::simplifyName(const QString &name) {
+QString CardInfo::simplifyName(const QString &name)
+{
     QString simpleName(name);
 
     // So Aetherling would work, but not Ætherling since 'Æ' would get replaced
@@ -319,25 +378,29 @@ const QChar CardInfo::getColorChar() const
     {
         case 0:
             return QChar();
-            break;
         case 1:
             return colors.first().isEmpty() ? QChar() : colors.first().at(0);
-            break;
         default:
             return QChar('m');
-            break;
     }
 }
 
 static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfo *info)
 {
+    if (! info)
+    {
+        qDebug() << "operator<< (~376) info is nullptr";
+        return xml;
+    }
+
     xml.writeStartElement("card");
     xml.writeTextElement("name", info->getName());
 
     const SetList &sets = info->getSets();
     QString tmpString;
     QString tmpSet;
-    for (int i = 0; i < sets.size(); i++) {
+    for (int i = 0; i < sets.size(); i++)
+    {
         xml.writeStartElement("set");
 
         tmpSet=sets[i]->getShortName();
@@ -345,81 +408,121 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfo *info)
         xml.writeAttribute("muId", QString::number(info->getMuId(tmpSet)));
 
         tmpString = info->getCollectorNumber(tmpSet);
-        if(!tmpString.isEmpty())
+        if (!tmpString.isEmpty())
+        {
             xml.writeAttribute("num", info->getCollectorNumber(tmpSet));
+        }
 
         tmpString = info->getCustomPicURL(tmpSet);
-        if(!tmpString.isEmpty())
+        if (!tmpString.isEmpty())
+        {
             xml.writeAttribute("picURL", tmpString);
+        }
 
         xml.writeCharacters(tmpSet);
         xml.writeEndElement();
     }
     const QStringList &colors = info->getColors();
     for (int i = 0; i < colors.size(); i++)
+    {
         xml.writeTextElement("color", colors[i]);
+    }
 
     const QList<CardRelation *> related = info->getRelatedCards();
-    for (int i = 0; i < related.size(); i++) {
-
+    for (auto i : related)
+    {
         xml.writeStartElement("related");
-        if (related[i]->getDoesAttach())
+        if (i->getDoesAttach())
+        {
             xml.writeAttribute("attach", "attach");
-        if (related[i]->getIsCreateAllExclusion())
+        }
+        if (i->getIsCreateAllExclusion())
+        {
             xml.writeAttribute("exclude", "exclude");
-        if (related[i]->getIsVariable()) {
-            if (1 == related[i]->getDefaultCount())
+        }
+
+        if (i->getIsVariable())
+        {
+            if (1 == i->getDefaultCount())
+            {
                 xml.writeAttribute("count", "x");
+            }
             else
-                xml.writeAttribute("count", "x=" + QString::number(related[i]->getDefaultCount()));
+            {
+                xml.writeAttribute("count", "x=" + QString::number(i->getDefaultCount()));
+            }
         }
-        else if (1 != related[i]->getDefaultCount()) {
-            xml.writeAttribute("count", QString::number(related[i]->getDefaultCount()));
+        else if (1 != i->getDefaultCount())
+        {
+            xml.writeAttribute("count", QString::number(i->getDefaultCount()));
         }
-        xml.writeCharacters(related[i]->getName());
+        xml.writeCharacters(i->getName());
         xml.writeEndElement();
     }
     const QList<CardRelation *> reverseRelated = info->getReverseRelatedCards();
-    for (int i = 0; i < reverseRelated.size(); i++) {
+    for (auto i : reverseRelated)
+    {
         xml.writeStartElement("reverse-related");
-        if (reverseRelated[i]->getDoesAttach())
+        if (i->getDoesAttach())
+        {
             xml.writeAttribute("attach", "attach");
-        if (reverseRelated[i]->getIsCreateAllExclusion())
+        }
+
+        if (i->getIsCreateAllExclusion())
+        {
             xml.writeAttribute("exclude", "exclude");
-        if (reverseRelated[i]->getIsVariable()) {
-            if (1 == reverseRelated[i]->getDefaultCount())
+        }
+
+        if (i->getIsVariable())
+        {
+            if (1 == i->getDefaultCount())
+            {
                 xml.writeAttribute("count", "x");
+            }
             else
-                xml.writeAttribute("count", "x=" + QString::number(reverseRelated[i]->getDefaultCount()));
+            {
+                xml.writeAttribute("count", "x=" + QString::number(i->getDefaultCount()));
+            }
         }
-        else if (1 != reverseRelated[i]->getDefaultCount()) {
-            xml.writeAttribute("count", QString::number(reverseRelated[i]->getDefaultCount()));
+        else if (1 != i->getDefaultCount())
+        {
+            xml.writeAttribute("count", QString::number(i->getDefaultCount()));
         }
-        xml.writeCharacters(reverseRelated[i]->getName());
+        xml.writeCharacters(i->getName());
         xml.writeEndElement();
     }
     xml.writeTextElement("manacost", info->getManaCost());
     xml.writeTextElement("cmc", info->getCmc());
     xml.writeTextElement("type", info->getCardType());
     if (!info->getPowTough().isEmpty())
+    {
         xml.writeTextElement("pt", info->getPowTough());
+    }
     xml.writeTextElement("tablerow", QString::number(info->getTableRow()));
     xml.writeTextElement("text", info->getText());
     if (info->getMainCardType() == "Planeswalker")
+    {
         xml.writeTextElement("loyalty", QString::number(info->getLoyalty()));
+    }
     if (info->getCipt())
+    {
         xml.writeTextElement("cipt", "1");
+    }
     if (info->getIsToken())
+    {
         xml.writeTextElement("token", "1");
+    }
     if (info->getUpsideDownArt())
+    {
         xml.writeTextElement("upsidedown", "1");
+    }
+
     xml.writeEndElement(); // card
 
     return xml;
 }
 
-CardDatabase::CardDatabase(QObject *parent)
-    : QObject(parent), loadStatus(NotLoaded)
+CardDatabase::CardDatabase(QObject *parent) : QObject(parent), loadStatus(NotLoaded)
 {
     connect(settingsCache, SIGNAL(cardDatabasePathChanged()), this, SLOT(loadCardDatabases()));
 }
@@ -432,10 +535,14 @@ CardDatabase::~CardDatabase()
 void CardDatabase::clear()
 {
     QHashIterator<QString, CardInfo *> i(cards);
-    while (i.hasNext()) {
+    while (i.hasNext())
+    {
         i.next();
-        removeCard(i.value());
-        i.value()->deleteLater();
+        if (i.value())
+        {
+            removeCard(i.value());
+            i.value()->deleteLater();
+        }
     }
 
     // The pointers themselves were already deleted, so we don't delete them again.
@@ -443,7 +550,8 @@ void CardDatabase::clear()
     simpleNameCards.clear();
 
     QHashIterator<QString, CardSet *> setIt(sets);
-    while (setIt.hasNext()) {
+    while (setIt.hasNext())
+    {
         setIt.next();
         delete setIt.value();
     }
@@ -454,6 +562,11 @@ void CardDatabase::clear()
 
 void CardDatabase::addCard(CardInfo *card)
 {
+    if (card == nullptr)
+    {
+        qDebug() << "addCard(nullptr)";
+        return;
+    }
     cards.insert(card->getName(), card);
     simpleNameCards.insert(card->getSimpleName(), card);
     emit cardAdded(card);
@@ -461,10 +574,18 @@ void CardDatabase::addCard(CardInfo *card)
 
 void CardDatabase::removeCard(CardInfo *card)
 {
+    if (! card)
+    {
+        qDebug() << "removeCard(nullptr)";
+        return;
+    }
+
     foreach(CardRelation * cardRelation, card->getRelatedCards())
         cardRelation->deleteLater();
+
     foreach(CardRelation * cardRelation, card->getReverseRelatedCards())
         cardRelation->deleteLater();
+
     foreach(CardRelation * cardRelation, card->getReverseRelatedCards2Me())
         cardRelation->deleteLater();
 
@@ -495,8 +616,11 @@ CardInfo *CardDatabase::getCardBySimpleName(const QString &cardName) const
 CardSet *CardDatabase::getSet(const QString &setName)
 {
     if (sets.contains(setName))
+    {
         return sets.value(setName);
-    else {
+    }
+    else
+    {
         CardSet *newSet = new CardSet(setName);
         sets.insert(setName, newSet);
         return newSet;
@@ -507,7 +631,8 @@ SetList CardDatabase::getSetList() const
 {
     SetList result;
     QHashIterator<QString, CardSet *> i(sets);
-    while (i.hasNext()) {
+    while (i.hasNext())
+    {
         i.next();
         result << i.value();
     }
@@ -516,30 +641,48 @@ SetList CardDatabase::getSetList() const
 
 void CardDatabase::loadSetsFromXml(QXmlStreamReader &xml)
 {
-    while (!xml.atEnd()) {
+    while (!xml.atEnd())
+    {
         if (xml.readNext() == QXmlStreamReader::EndElement)
+        {
             break;
-        if (xml.name() == "set") {
+        }
+
+        if (xml.name() == "set")
+        {
             QString shortName, longName, setType;
             QDate releaseDate;
-            while (!xml.atEnd()) {
+            while (!xml.atEnd())
+            {
                 if (xml.readNext() == QXmlStreamReader::EndElement)
+                {
                     break;
+                }
+
                 if (xml.name() == "name")
+                {
                     shortName = xml.readElementText();
+                }
                 else if (xml.name() == "longname")
+                {
                     longName = xml.readElementText();
+                }
                 else if (xml.name() == "settype")
+                {
                     setType = xml.readElementText();
+                }
                 else if (xml.name() == "releasedate")
+                {
                     releaseDate = QDate::fromString(xml.readElementText(), Qt::ISODate);
-                else if (xml.name() != "") {
+                }
+                else if (xml.name() != "")
+                {
                     qDebug() << "[XMLReader] Unknown set property" << xml.name() << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
 
-            CardSet * newSet = getSet(shortName);
+            CardSet *newSet = getSet(shortName);
             newSet->setLongName(longName);
             newSet->setSetType(setType);
             newSet->setReleaseDate(releaseDate);
@@ -549,10 +692,15 @@ void CardDatabase::loadSetsFromXml(QXmlStreamReader &xml)
 
 void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml)
 {
-    while (!xml.atEnd()) {
+    while (!xml.atEnd())
+    {
         if (xml.readNext() == QXmlStreamReader::EndElement)
+        {
             break;
-        if (xml.name() == "card") {
+        }
+
+        if (xml.name() == "card")
+        {
             QString name, manacost, cmc, type, pt, text;
             QStringList colors;
             QList<CardRelation *> relatedCards, reverseRelatedCards;
@@ -565,81 +713,138 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml)
             bool cipt = false;
             bool isToken = false;
             bool upsideDown = false;
-            while (!xml.atEnd()) {
+            while (!xml.atEnd())
+            {
                 if (xml.readNext() == QXmlStreamReader::EndElement)
+                {
                     break;
+                }
+
                 if (xml.name() == "name")
+                {
                     name = xml.readElementText();
+                }
                 else if (xml.name() == "manacost")
+                {
                     manacost = xml.readElementText();
+                }
                 else if (xml.name() == "cmc")
+                {
                     cmc = xml.readElementText();
+                }
                 else if (xml.name() == "type")
+                {
                     type = xml.readElementText();
+                }
                 else if (xml.name() == "pt")
+                {
                     pt = xml.readElementText();
+                }
                 else if (xml.name() == "text")
+                {
                     text = xml.readElementText();
-                else if (xml.name() == "set") {
+                }
+                else if (xml.name() == "set")
+                {
                     QXmlStreamAttributes attrs = xml.attributes();
                     QString setName = xml.readElementText();
                     sets.append(getSet(setName));
-                    if (attrs.hasAttribute("muId")) {
+                    if (attrs.hasAttribute("muId"))
+                    {
                         muids[setName] = attrs.value("muId").toString().toInt();
                     }
-                    if (attrs.hasAttribute("picURL")) {
+
+                    if (attrs.hasAttribute("picURL"))
+                    {
                         customPicURLs[setName] = attrs.value("picURL").toString();
                     }
-                    if (attrs.hasAttribute("num")) {
+
+                    if (attrs.hasAttribute("num"))
+                    {
                         collectorNumbers[setName] = attrs.value("num").toString();
                     }
-                    if (attrs.hasAttribute("rarity")) {
+
+                    if (attrs.hasAttribute("rarity"))
+                    {
                         rarities[setName] = attrs.value("rarity").toString();
                     }
-                } else if (xml.name() == "color")
+                }
+                else if (xml.name() == "color")
+                {
                     colors << xml.readElementText();
-                else if (xml.name() == "related" || xml.name() == "reverse-related") {
+                }
+                else if (xml.name() == "related" || xml.name() == "reverse-related")
+                {
                     bool attach = false;
                     bool exclude = false;
                     bool variable = false;
                     int count = 1;
                     QXmlStreamAttributes attrs = xml.attributes();
                     QString cardName = xml.readElementText();
-                    if (attrs.hasAttribute("count")) {
-                        if (attrs.value("count").toString().indexOf("x=") == 0) {
+                    if (attrs.hasAttribute("count"))
+                    {
+                        if (attrs.value("count").toString().indexOf("x=") == 0)
+                        {
                             variable = true;
                             count = attrs.value("count").toString().remove(0, 2).toInt();
                         }
                         else if (attrs.value("count").toString().indexOf("x") == 0)
+                        {
                             variable = true;
+                        }
                         else
+                        {
                             count = attrs.value("count").toString().toInt();
+                        }
+
                         if (count < 1)
+                        {
                             count = 1;
+                        }
                     }
-                    if (attrs.hasAttribute("attach")) {
+
+                    if (attrs.hasAttribute("attach"))
+                    {
                         attach = true;
                     }
-                    if (attrs.hasAttribute("exclude")) {
+
+                    if (attrs.hasAttribute("exclude"))
+                    {
                         exclude = true;
                     }
-                    CardRelation * relation = new CardRelation(cardName, attach, exclude, variable, count);
-                    if (xml.name() == "reverse-related") {
+
+                    auto *relation = new CardRelation(cardName, attach, exclude, variable, count);
+                    if (xml.name() == "reverse-related")
+                    {
                         reverseRelatedCards << relation;
-                    } else {
+                    }
+                    else
+                    {
                         relatedCards << relation;
                     }
-                } else if (xml.name() == "tablerow")
+                }
+                else if (xml.name() == "tablerow")
+                {
                     tableRow = xml.readElementText().toInt();
+                }
                 else if (xml.name() == "cipt")
+                {
                     cipt = (xml.readElementText() == "1");
+                }
                 else if (xml.name() == "upsidedown")
+                {
                     upsideDown = (xml.readElementText() == "1");
+                }
                 else if (xml.name() == "loyalty")
+                {
                     loyalty = xml.readElementText().toInt();
+                }
                 else if (xml.name() == "token")
-                    isToken = xml.readElementText().toInt();
-                else if (xml.name() != "") {
+                {
+                    isToken = static_cast<bool>(xml.readElementText().toInt());
+                }
+                else if (xml.name() != "")
+                {
                     qDebug() << "[XMLReader] Unknown card property" << xml.name() << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
@@ -653,7 +858,9 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml)
 CardInfo *CardDatabase::getCardFromMap(const CardNameMap &cardMap, const QString &cardName) const
 {
     if (cardMap.contains(cardName))
+    {
         return cardMap.value(cardName);
+    }
 
     return nullptr;
 }
@@ -663,26 +870,45 @@ LoadStatus CardDatabase::loadFromFile(const QString &fileName)
     QFile file(fileName);
     file.open(QIODevice::ReadOnly);
     if (!file.isOpen())
+    {
         return FileError;
+    }
+
 
     QXmlStreamReader xml(&file);
-    while (!xml.atEnd()) {
-        if (xml.readNext() == QXmlStreamReader::StartElement) {
+    while (!xml.atEnd())
+    {
+        if (xml.readNext() == QXmlStreamReader::StartElement)
+        {
             if (xml.name() != "cockatrice_carddatabase")
+            {
                 return Invalid;
+            }
+
             int version = xml.attributes().value("version").toString().toInt();
-            if (version < versionNeeded) {
+            if (version < versionNeeded)
+            {
                 qDebug() << "[XMLReader] Version too old: " << version;
                 return VersionTooOld;
             }
-            while (!xml.atEnd()) {
+
+            while (!xml.atEnd())
+            {
                 if (xml.readNext() == QXmlStreamReader::EndElement)
+                {
                     break;
+                }
+
                 if (xml.name() == "sets")
+                {
                     loadSetsFromXml(xml);
+                }
                 else if (xml.name() == "cards")
+                {
                     loadCardsFromXml(xml);
-                else if (xml.name() != "") {
+                }
+                else if (xml.name() != "")
+                {
                     qDebug() << "[XMLReader] Unknown item" << xml.name() << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
@@ -690,7 +916,10 @@ LoadStatus CardDatabase::loadFromFile(const QString &fileName)
         }
     }
 
-    if (cards.isEmpty()) return NoCards;
+    if (cards.isEmpty())
+    {
+        return NoCards;
+    }
 
     return Ok;
 }
@@ -699,7 +928,10 @@ bool CardDatabase::saveToFile(const QString &fileName, bool tokens)
 {
     QFile file(fileName);
     if (!file.open(QIODevice::WriteOnly))
+    {
         return false;
+    }
+
     QXmlStreamWriter xml(&file);
 
     xml.setAutoFormatting(true);
@@ -707,19 +939,25 @@ bool CardDatabase::saveToFile(const QString &fileName, bool tokens)
     xml.writeStartElement("cockatrice_carddatabase");
     xml.writeAttribute("version", QString::number(versionNeeded));
 
-    if (!tokens) {
+    if (!tokens)
+    {
         xml.writeStartElement("sets");
         QHashIterator<QString, CardSet *> setIterator(sets);
         while (setIterator.hasNext())
+        {
             xml << setIterator.next().value();
+        }
+
         xml.writeEndElement(); // sets
     }
 
     xml.writeStartElement("cards");
     QHashIterator<QString, CardInfo *> cardIterator(cards);
-    while (cardIterator.hasNext()) {
+    while (cardIterator.hasNext())
+    {
         CardInfo *card = cardIterator.next().value();
-        if (tokens == card->getIsToken()) {
+        if (tokens == card->getIsToken())
+        {
             xml << card;
         }
     }
@@ -796,21 +1034,30 @@ void CardDatabase::refreshCachedReverseRelatedCards()
 
     foreach(CardInfo * card, cards)
     {
-        if(card->getReverseRelatedCards().isEmpty())
+        if (card->getReverseRelatedCards().isEmpty())
+        {
             continue;
+        }
 
         QString relatedCardName;
         if (card->getPowTough().size() > 0)
+        {
             relatedCardName = card->getPowTough() + " " + card->getName(); // "n/n name"
+        }
         else
+        {
             relatedCardName = card->getName(); // "name"
+        }
 
         foreach(CardRelation * cardRelation, card->getReverseRelatedCards())
         {
             const QString & targetCard = cardRelation->getName();
             if (!cards.contains(targetCard))
+            {
                 continue;
-            CardRelation *newCardRelation = new CardRelation(relatedCardName, cardRelation->getDoesAttach(),
+            }
+
+            auto *newCardRelation = new CardRelation(relatedCardName, cardRelation->getDoesAttach(),
                     cardRelation->getIsCreateAllExclusion(),
                     cardRelation->getIsVariable(),
                     cardRelation->getDefaultCount());
@@ -823,13 +1070,20 @@ QStringList CardDatabase::getAllColors() const
 {
     QSet<QString> colors;
     QHashIterator<QString, CardInfo *> cardIterator(cards);
-    while (cardIterator.hasNext()) {
+    while (cardIterator.hasNext())
+    {
         const QStringList &cardColors = cardIterator.next().value()->getColors();
         if (cardColors.isEmpty())
+        {
             colors.insert("X");
+        }
         else
+        {
             for (int i = 0; i < cardColors.size(); ++i)
+            {
                 colors.insert(cardColors[i]);
+            }
+        }
     }
     return colors.toList();
 }
@@ -839,7 +1093,9 @@ QStringList CardDatabase::getAllMainCardTypes() const
     QSet<QString> types;
     QHashIterator<QString, CardInfo *> cardIterator(cards);
     while (cardIterator.hasNext())
+    {
         types.insert(cardIterator.next().value()->getMainCardType());
+    }
     return types.toList();
 }
 
@@ -847,7 +1103,7 @@ void CardDatabase::checkUnknownSets()
 {
     SetList sets = getSetList();
 
-    if(sets.getEnabledSetsNum())
+    if (sets.getEnabledSetsNum())
     {
         // if some sets are first found on thus run, ask the user
         int numUnknownSets = sets.getUnknownSetsNum();
@@ -897,11 +1153,14 @@ void CardDatabase::notifyEnabledSetsChanged()
 
 bool CardDatabase::saveCustomTokensToFile()
 {
-    CardSet * customTokensSet = getSet(CardDatabase::TOKENS_SETNAME);
+    CardSet *customTokensSet = getSet(CardDatabase::TOKENS_SETNAME);
     QString fileName = settingsCache->getCustomCardDatabasePath() + "/" + CardDatabase::TOKENS_SETNAME + ".xml";
     QFile file(fileName);
     if (!file.open(QIODevice::WriteOnly))
+    {
         return false;
+    }
+
     QXmlStreamWriter xml(&file);
 
     xml.setAutoFormatting(true);
@@ -911,10 +1170,13 @@ bool CardDatabase::saveCustomTokensToFile()
 
     xml.writeStartElement("cards");
     QHashIterator<QString, CardInfo *> cardIterator(cards);
-    while (cardIterator.hasNext()) {
+    while (cardIterator.hasNext())
+    {
         CardInfo *card = cardIterator.next().value();
-        if(card->getSets().contains(customTokensSet))
+        if (card->getSets().contains(customTokensSet))
+        {
             xml << card;
+        }
     }
     xml.writeEndElement(); // cards
 
@@ -924,23 +1186,20 @@ bool CardDatabase::saveCustomTokensToFile()
     return true;
 }
 
-CardRelation::CardRelation(const QString &_name,
-        bool _doesAttach,
-        bool _isCreateAllExclusion,
-        bool _isVariableCount,
-        int _defaultCount
-        )
-    : name(_name),
-      doesAttach(_doesAttach),
-      isCreateAllExclusion(_isCreateAllExclusion),
-      isVariableCount(_isVariableCount),
-      defaultCount(_defaultCount)
+CardRelation::CardRelation(const QString &_name, bool _doesAttach, bool _isCreateAllExclusion, bool _isVariableCount, int _defaultCount) :
+        name(_name),
+        doesAttach(_doesAttach),
+        isCreateAllExclusion(_isCreateAllExclusion),
+        isVariableCount(_isVariableCount),
+        defaultCount(_defaultCount)
 {
 
 }
 
-void CardInfo::resetReverseRelatedCards2Me() {
-    foreach(CardRelation * cardRelation, this->getReverseRelatedCards2Me()) {
+void CardInfo::resetReverseRelatedCards2Me()
+{
+    foreach(CardRelation * cardRelation, this->getReverseRelatedCards2Me())
+    {
         cardRelation->deleteLater();
     }
     reverseRelatedCardsToMe = QList<CardRelation *>();

--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -852,11 +852,17 @@ void CardDatabase::checkUnknownSets()
         // if some sets are first found on thus run, ask the user
         int numUnknownSets = sets.getUnknownSetsNum();
         QStringList unknownSetNames = sets.getUnknownSetsNames();
-        if(numUnknownSets > 0)
+        if (numUnknownSets > 0)
+        {
             emit cardDatabaseNewSetsFound(numUnknownSets, unknownSetNames);
+        }
         else
+        {
             sets.markAllAsKnown();
-    } else {
+        }
+    }
+    else
+    {
         // No set enabled. Probably this is the first time running trice
         sets.guessSortKeys();
         sets.sortByKey();

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -196,22 +196,17 @@ class CardDatabase : public QObject
 {
     Q_OBJECT
     protected:
-        /*
-         * The cards, indexed by name.
-         */
+        // The cards, indexed by name.
         CardNameMap cards;
 
-        /**
-         * The cards, indexed by their simple name.
-         */
+        // The cards, indexed by their simple name.
         CardNameMap simpleNameCards;
 
-        /*
-         * The sets, indexed by short name.
-         */
+        // The sets, indexed by short name.
         SetNameMap sets;
 
         LoadStatus loadStatus;
+
     private:
         static const int versionNeeded;
         void loadCardsFromXml(QXmlStreamReader &xml);
@@ -221,9 +216,10 @@ class CardDatabase : public QObject
         void checkUnknownSets();
         void refreshCachedReverseRelatedCards();
         void reloadCardDatabases();
+        LoadStatus loadCardDatabases();
+
     public:
         static const char* TOKENS_SETNAME;
-        static void threadSafeReloadCardDatabase();
 
         explicit CardDatabase(QObject *parent = nullptr);
         ~CardDatabase() override;
@@ -253,7 +249,7 @@ class CardDatabase : public QObject
         void notifyEnabledSetsChanged();
 
     public slots:
-        LoadStatus loadCardDatabases();
+        static void threadSafeReloadCardDatabase();
 
     private slots:
         LoadStatus loadCardDatabase(const QString &path);

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -228,7 +228,7 @@ class CardDatabase : public QObject
                 *addCardMutex = new QBasicMutex(),
                 *removeCardMutex = new QBasicMutex();
 
-public:
+    public:
         static const char* TOKENS_SETNAME;
 
         explicit CardDatabase(QObject *parent = nullptr);

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -222,6 +222,7 @@ class CardDatabase : public QObject
         void refreshCachedReverseRelatedCards();
     public:
         static const char* TOKENS_SETNAME;
+        static void threadSafeReloadCardDatabase();
 
         explicit CardDatabase(QObject *parent = nullptr);
         ~CardDatabase() override;

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -18,159 +18,173 @@ typedef QMap<QString, QString> QStringMap;
 // If we don't typedef this, CardInfo::CardInfo will refuse to compile on OS X < 10.9
 typedef QMap<QString, int> MuidMap;
 
-class CardSet : public QList<CardInfo *> {
-private:
-    QString shortName, longName;
-    unsigned int sortKey;
-    QDate releaseDate;
-    QString setType;
-    bool enabled, isknown;
-public:
-    CardSet(const QString &_shortName = QString(), const QString &_longName = QString(), const QString &_setType = QString(), const QDate &_releaseDate = QDate());
-    QString getCorrectedShortName() const;
-    QString getShortName() const { return shortName; }
-    QString getLongName() const { return longName; }
-    QString getSetType() const { return setType; }
-    QDate getReleaseDate() const { return releaseDate; }
-    void setLongName(QString & _longName) { longName = _longName; }
-    void setSetType(QString & _setType) { setType = _setType; }
-    void setReleaseDate(QDate & _releaseDate) { releaseDate = _releaseDate; }
+class CardSet : public QList<CardInfo *>
+{
+    private:
+        QString shortName, longName;
+        unsigned int sortKey;
+        QDate releaseDate;
+        QString setType;
+        bool enabled, isknown;
 
-    void loadSetOptions();
-    int getSortKey() const { return sortKey; }
-    void setSortKey(unsigned int _sortKey);
-    bool getEnabled() const { return enabled; }
-    void setEnabled(bool _enabled);
-    bool getIsKnown() const { return isknown; }
-    void setIsKnown(bool _isknown);
-    //Determine incomplete sets.
-    bool getIsKnownIgnored() const { return longName.length() + setType.length() + releaseDate.toString().length() == 0 ; }
+    public:
+        explicit CardSet(const QString &_shortName = QString(), const QString &_longName = QString(), const QString &_setType = QString(), const QDate &_releaseDate = QDate());
+        QString getCorrectedShortName() const;
+        QString getShortName() const { return shortName; }
+        QString getLongName() const { return longName; }
+        QString getSetType() const { return setType; }
+        QDate getReleaseDate() const { return releaseDate; }
+        void setLongName(QString & _longName) { longName = _longName; }
+        void setSetType(QString & _setType) { setType = _setType; }
+        void setReleaseDate(QDate & _releaseDate) { releaseDate = _releaseDate; }
+
+        void loadSetOptions();
+        int getSortKey() const { return sortKey; }
+        void setSortKey(unsigned int _sortKey);
+        bool getEnabled() const { return enabled; }
+        void setEnabled(bool _enabled);
+        bool getIsKnown() const { return isknown; }
+        void setIsKnown(bool _isknown);
+
+        //Determine incomplete sets.
+        bool getIsKnownIgnored() const { return longName.length() + setType.length() + releaseDate.toString().length() == 0 ; }
 };
 
-class SetList : public QList<CardSet *> {
-private:
-    class KeyCompareFunctor;
-public:
-    void sortByKey();
-    void guessSortKeys();
-    void enableAllUnknown();
-    void enableAll();
-    void markAllAsKnown();
-    int getEnabledSetsNum();
-    int getUnknownSetsNum();
-    QStringList getUnknownSetsNames();
+class SetList : public QList<CardSet *>
+{
+    private:
+        class KeyCompareFunctor;
+
+    public:
+        void sortByKey();
+        void guessSortKeys();
+        void enableAllUnknown();
+        void enableAll();
+        void markAllAsKnown();
+        int getEnabledSetsNum();
+        int getUnknownSetsNum();
+        QStringList getUnknownSetsNames();
 };
 
-class CardInfo : public QObject {
+class CardInfo : public QObject
+{
     Q_OBJECT
-private:
-    QString name;
+    private:
+        QString name;
 
-    /*
-     * The name without punctuation or capitalization, for better card tag name
-     * recognition.
-     */
-    QString simpleName;
+        /*
+         * The name without punctuation or capitalization, for better card tag name
+         * recognition.
+         */
+        QString simpleName;
 
-    bool isToken;
-    SetList sets;
-    QString manacost;
-    QString cmc;
-    QString cardtype;
-    QString powtough;
-    QString text;
-    QStringList colors;
-    // the cards i'm related to
-    QList<CardRelation *> relatedCards;
-    // the card i'm reverse-related to
-    QList<CardRelation *> reverseRelatedCards;
-    // the cards thare are reverse-related to me
-    QList<CardRelation *> reverseRelatedCardsToMe;
-    QString setsNames;
-    bool upsideDownArt;
-    int loyalty;
-    QStringMap customPicURLs;
-    MuidMap muIds;
-    QStringMap collectorNumbers;
-    QStringMap rarities;
-    bool cipt;
-    int tableRow;
-    QString pixmapCacheKey;
-public:
-    CardInfo(const QString &_name = QString(),
-        bool _isToken = false,
-        const QString &_manacost = QString(),
-        const QString &_cmc = QString(),
-        const QString &_cardtype = QString(),
-        const QString &_powtough = QString(),
-        const QString &_text = QString(),
-        const QStringList &_colors = QStringList(),
-        const QList<CardRelation *> &_relatedCards = QList<CardRelation *>(),
-        const QList<CardRelation *> &_reverseRelatedCards = QList<CardRelation *>(),
-        bool _upsideDownArt = false,
-        int _loyalty = 0,
-        bool _cipt = false,
-        int _tableRow = 0,
-        const SetList &_sets = SetList(),
-        const QStringMap &_customPicURLs = QStringMap(),
-        MuidMap muids = MuidMap(),
-        QStringMap _collectorNumbers = QStringMap(),
-        QStringMap _rarities = QStringMap()
-        );
-    ~CardInfo();
-    inline const QString &getName() const { return name; }
-    inline const QString &getSetsNames() const { return setsNames; }
-    const QString &getSimpleName() const { return simpleName; }
-    bool getIsToken() const { return isToken; }
-    const SetList &getSets() const { return sets; }
-    inline const QString &getManaCost() const { return manacost; }
-    inline const QString &getCmc() const { return cmc; }
-    inline const QString &getCardType() const { return cardtype; }
-    inline const QString &getPowTough() const { return powtough; }
-    const QString &getText() const { return text; }
-    const QString &getPixmapCacheKey() const { return pixmapCacheKey; }
-    const int &getLoyalty() const { return loyalty; }
-    bool getCipt() const { return cipt; }
-    void setManaCost(const QString &_manaCost) { manacost = _manaCost; emit cardInfoChanged(this); }
-    void setCmc(const QString &_cmc) { cmc = _cmc; emit cardInfoChanged(this); }
-    void setCardType(const QString &_cardType) { cardtype = _cardType; emit cardInfoChanged(this); }
-    void setPowTough(const QString &_powTough) { powtough = _powTough; emit cardInfoChanged(this); }
-    void setText(const QString &_text) { text = _text; emit cardInfoChanged(this); }
-    void setColors(const QStringList &_colors) { colors = _colors; emit cardInfoChanged(this); }
-    const QChar getColorChar() const;
-    const QStringList &getColors() const { return colors; }
-    const QList<CardRelation *> &getRelatedCards() const { return relatedCards; }
-    const QList<CardRelation *> &getReverseRelatedCards() const { return reverseRelatedCards; }
-    const QList<CardRelation *> &getReverseRelatedCards2Me() const { return reverseRelatedCardsToMe; }
-    void resetReverseRelatedCards2Me();
-    void addReverseRelatedCards2Me(CardRelation * cardRelation) { reverseRelatedCardsToMe.append(cardRelation); }
-    bool getUpsideDownArt() const { return upsideDownArt; }
-    QString getCustomPicURL(const QString &set) const { return customPicURLs.value(set); }
-    int getMuId(const QString &set) const { return muIds.value(set); }
-    QString getCollectorNumber(const QString &set) const { return collectorNumbers.value(set); }
-    QString getRarity(const QString &set) const { return rarities.value(set); }
-    QStringMap getRarities() const { return rarities; }
-    QString getMainCardType() const;
-    QString getCorrectedName() const;
-    int getTableRow() const { return tableRow; }
-    void setTableRow(int _tableRow) { tableRow = _tableRow; }
-    void setLoyalty(int _loyalty) { loyalty = _loyalty; emit cardInfoChanged(this); }
-    void setCustomPicURL(const QString &_set, const QString &_customPicURL) { customPicURLs.insert(_set, _customPicURL); }
-    void setMuId(const QString &_set, const int &_muId) { muIds.insert(_set, _muId); }
-    void setSetNumber(const QString &_set, const QString &_setNumber) { collectorNumbers.insert(_set, _setNumber); }
-    void setRarity(const QString &_set, const QString &_setNumber) { rarities.insert(_set, _setNumber); }
-    void addToSet(CardSet *set);
-    void emitPixmapUpdated() { emit pixmapUpdated(); }
-    void refreshCachedSetNames();
+        bool isToken;
+        SetList sets;
+        QString manacost;
+        QString cmc;
+        QString cardtype;
+        QString powtough;
+        QString text;
+        QStringList colors;
 
-    /**
-     * Simplify a name to have no punctuation and lowercase all letters, for
-     * less strict name-matching.
-     */
-    static QString simplifyName(const QString &name);
-signals:
-    void pixmapUpdated();
-    void cardInfoChanged(CardInfo *card);
+        // the cards i'm related to
+        QList<CardRelation *> relatedCards;
+
+        // the card i'm reverse-related to
+        QList<CardRelation *> reverseRelatedCards;
+
+        // the cards thare are reverse-related to me
+        QList<CardRelation *> reverseRelatedCardsToMe;
+
+        QString setsNames;
+
+        bool upsideDownArt;
+        int loyalty;
+        QStringMap customPicURLs;
+        MuidMap muIds;
+        QStringMap collectorNumbers;
+        QStringMap rarities;
+        bool cipt;
+        int tableRow;
+        QString pixmapCacheKey;
+
+    public:
+        explicit CardInfo(const QString &_name = QString(),
+            bool _isToken = false,
+            const QString &_manacost = QString(),
+            const QString &_cmc = QString(),
+            const QString &_cardtype = QString(),
+            const QString &_powtough = QString(),
+            const QString &_text = QString(),
+            const QStringList &_colors = QStringList(),
+            const QList<CardRelation *> &_relatedCards = QList<CardRelation *>(),
+            const QList<CardRelation *> &_reverseRelatedCards = QList<CardRelation *>(),
+            bool _upsideDownArt = false,
+            int _loyalty = 0,
+            bool _cipt = false,
+            int _tableRow = 0,
+            const SetList &_sets = SetList(),
+            const QStringMap &_customPicURLs = QStringMap(),
+            MuidMap muids = MuidMap(),
+            QStringMap _collectorNumbers = QStringMap(),
+            QStringMap _rarities = QStringMap()
+            );
+        ~CardInfo() override;
+
+        inline const QString &getName() const { return name; }
+        inline const QString &getSetsNames() const { return setsNames; }
+        const QString &getSimpleName() const { return simpleName; }
+        bool getIsToken() const { return isToken; }
+        const SetList &getSets() const { return sets; }
+        inline const QString &getManaCost() const { return manacost; }
+        inline const QString &getCmc() const { return cmc; }
+        inline const QString &getCardType() const { return cardtype; }
+        inline const QString &getPowTough() const { return powtough; }
+        const QString &getText() const { return text; }
+        const QString &getPixmapCacheKey() const { return pixmapCacheKey; }
+        const int &getLoyalty() const { return loyalty; }
+        bool getCipt() const { return cipt; }
+        //void setManaCost(const QString &_manaCost) { manacost = _manaCost; emit cardInfoChanged(this); }
+        //void setCmc(const QString &_cmc) { cmc = _cmc; emit cardInfoChanged(this); }
+        void setCardType(const QString &_cardType) { cardtype = _cardType; emit cardInfoChanged(this); }
+        void setPowTough(const QString &_powTough) { powtough = _powTough; emit cardInfoChanged(this); }
+        void setText(const QString &_text) { text = _text; emit cardInfoChanged(this); }
+        void setColors(const QStringList &_colors) { colors = _colors; emit cardInfoChanged(this); }
+        const QChar getColorChar() const;
+        const QStringList &getColors() const { return colors; }
+        const QList<CardRelation *> &getRelatedCards() const { return relatedCards; }
+        const QList<CardRelation *> &getReverseRelatedCards() const { return reverseRelatedCards; }
+        const QList<CardRelation *> &getReverseRelatedCards2Me() const { return reverseRelatedCardsToMe; }
+        void resetReverseRelatedCards2Me();
+        void addReverseRelatedCards2Me(CardRelation * cardRelation) { reverseRelatedCardsToMe.append(cardRelation); }
+        bool getUpsideDownArt() const { return upsideDownArt; }
+        QString getCustomPicURL(const QString &set) const { return customPicURLs.value(set); }
+        int getMuId(const QString &set) const { return muIds.value(set); }
+        QString getCollectorNumber(const QString &set) const { return collectorNumbers.value(set); }
+        QString getRarity(const QString &set) const { return rarities.value(set); }
+        QStringMap getRarities() const { return rarities; }
+        QString getMainCardType() const;
+        QString getCorrectedName() const;
+        int getTableRow() const { return tableRow; }
+        void setTableRow(int _tableRow) { tableRow = _tableRow; }
+        //void setLoyalty(int _loyalty) { loyalty = _loyalty; emit cardInfoChanged(this); }
+        //void setCustomPicURL(const QString &_set, const QString &_customPicURL) { customPicURLs.insert(_set, _customPicURL); }
+        void setMuId(const QString &_set, const int &_muId) { muIds.insert(_set, _muId); }
+        void setSetNumber(const QString &_set, const QString &_setNumber) { collectorNumbers.insert(_set, _setNumber); }
+        void setRarity(const QString &_set, const QString &_setNumber) { rarities.insert(_set, _setNumber); }
+        void addToSet(CardSet *set);
+        void emitPixmapUpdated() { emit pixmapUpdated(); }
+        void refreshCachedSetNames();
+
+        /**
+         * Simplify a name to have no punctuation and lowercase all letters, for
+         * less strict name-matching.
+         */
+        static QString simplifyName(const QString &name);
+
+    signals:
+        void pixmapUpdated();
+        void cardInfoChanged(CardInfo *card);
 };
 
 enum LoadStatus { Ok, VersionTooOld, Invalid, NotLoaded, FileError, NoCards };
@@ -178,97 +192,99 @@ enum LoadStatus { Ok, VersionTooOld, Invalid, NotLoaded, FileError, NoCards };
 typedef QHash<QString, CardInfo *> CardNameMap;
 typedef QHash<QString, CardSet *> SetNameMap;
 
-class CardDatabase : public QObject {
+class CardDatabase : public QObject
+{
     Q_OBJECT
-protected:
-    /*
-     * The cards, indexed by name.
-     */
-    CardNameMap cards;
+    protected:
+        /*
+         * The cards, indexed by name.
+         */
+        CardNameMap cards;
 
-    /**
-     * The cards, indexed by their simple name.
-     */
-    CardNameMap simpleNameCards;
+        /**
+         * The cards, indexed by their simple name.
+         */
+        CardNameMap simpleNameCards;
 
-    /*
-     * The sets, indexed by short name.
-     */
-    SetNameMap sets;
+        /*
+         * The sets, indexed by short name.
+         */
+        SetNameMap sets;
 
-    LoadStatus loadStatus;
-private:
-    static const int versionNeeded;
-    void loadCardsFromXml(QXmlStreamReader &xml);
-    void loadSetsFromXml(QXmlStreamReader &xml);
+        LoadStatus loadStatus;
+    private:
+        static const int versionNeeded;
+        void loadCardsFromXml(QXmlStreamReader &xml);
+        void loadSetsFromXml(QXmlStreamReader &xml);
 
-    CardInfo *getCardFromMap(const CardNameMap &cardMap, const QString &cardName) const;
-    void checkUnknownSets();
-    void refreshCachedReverseRelatedCards();
-public:
-    static const char* TOKENS_SETNAME;
+        CardInfo *getCardFromMap(const CardNameMap &cardMap, const QString &cardName) const;
+        void checkUnknownSets();
+        void refreshCachedReverseRelatedCards();
+    public:
+        static const char* TOKENS_SETNAME;
 
-    CardDatabase(QObject *parent = 0);
-    ~CardDatabase();
-    void clear();
-    void addCard(CardInfo *card);
-    void removeCard(CardInfo *card);
-    CardInfo *getCard(const QString &cardName) const;
-    QList <CardInfo *> getCards(const QStringList &cardNames) const;
+        explicit CardDatabase(QObject *parent = nullptr);
+        ~CardDatabase() override;
+        void clear();
+        void addCard(CardInfo *card);
+        void removeCard(CardInfo *card);
+        CardInfo *getCard(const QString &cardName) const;
+        QList <CardInfo *> getCards(const QStringList &cardNames) const;
 
-    /*
-     * Get a card by its simple name. The name will be simplified in this
-     * function, so you don't need to simplify it beforehand.
-     */
-    CardInfo *getCardBySimpleName(const QString &cardName) const;
+        /*
+         * Get a card by its simple name. The name will be simplified in this
+         * function, so you don't need to simplify it beforehand.
+         */
+        CardInfo *getCardBySimpleName(const QString &cardName) const;
 
-    CardSet *getSet(const QString &setName);
-    QList<CardInfo *> getCardList() const { return cards.values(); }
-    SetList getSetList() const;
-    LoadStatus loadFromFile(const QString &fileName);
-    bool saveToFile(const QString &fileName, bool tokens = false);
-    bool saveCustomTokensToFile();
-    QStringList getAllColors() const;
-    QStringList getAllMainCardTypes() const;
-    LoadStatus getLoadStatus() const { return loadStatus; }
-    void enableAllUnknownSets();
-    void markAllSetsAsKnown();
-    void notifyEnabledSetsChanged();
+        CardSet *getSet(const QString &setName);
+        QList<CardInfo *> getCardList() const { return cards.values(); }
+        SetList getSetList() const;
+        LoadStatus loadFromFile(const QString &fileName);
+        bool saveToFile(const QString &fileName, bool tokens = false);
+        bool saveCustomTokensToFile();
+        QStringList getAllColors() const;
+        QStringList getAllMainCardTypes() const;
+        LoadStatus getLoadStatus() const { return loadStatus; }
+        void enableAllUnknownSets();
+        void markAllSetsAsKnown();
+        void notifyEnabledSetsChanged();
 
-public slots:
-    LoadStatus loadCardDatabases();
-private slots:
-    LoadStatus loadCardDatabase(const QString &path);
-signals:
-    void cardDatabaseLoadingFailed();
-    void cardDatabaseNewSetsFound(int numUnknownSets, QStringList unknownSetsNames);
-    void cardDatabaseAllNewSetsEnabled();
-    void cardDatabaseEnabledSetsChanged();
-    void cardAdded(CardInfo *card);
-    void cardRemoved(CardInfo *card);
+    public slots:
+        LoadStatus loadCardDatabases();
+    private slots:
+        LoadStatus loadCardDatabase(const QString &path);
+    signals:
+        void cardDatabaseLoadingFailed();
+        void cardDatabaseNewSetsFound(int numUnknownSets, QStringList unknownSetsNames);
+        void cardDatabaseAllNewSetsEnabled();
+        void cardDatabaseEnabledSetsChanged();
+        void cardAdded(CardInfo *card);
+        void cardRemoved(CardInfo *card);
 };
 
-class CardRelation : public QObject {
+class CardRelation : public QObject
+{
     Q_OBJECT
-private:
-    QString name;
-    bool doesAttach;
-    bool isCreateAllExclusion;
-    bool isVariableCount;
-    int defaultCount;
-public:
-    CardRelation(const QString &_name = QString(),
-            bool _doesAttach = false,
-            bool _isCreateAllExclusion = false,
-            bool _isVariableCount = false,
-            int _defaultCount = 1
-            );
-    inline const QString &getName() const { return name; }
-    bool getDoesAttach() const { return doesAttach; }
-    bool getCanCreateAnother() const { return !doesAttach; }
-    bool getIsCreateAllExclusion() const { return isCreateAllExclusion; }
-    bool getIsVariable() const { return isVariableCount; }
-    int getDefaultCount() const { return defaultCount; }
-};
+    private:
+        QString name;
+        bool doesAttach;
+        bool isCreateAllExclusion;
+        bool isVariableCount;
+        int defaultCount;
+    public:
+        explicit CardRelation(const QString &_name = QString(),
+                bool _doesAttach = false,
+                bool _isCreateAllExclusion = false,
+                bool _isVariableCount = false,
+                int _defaultCount = 1
+                );
 
+        inline const QString &getName() const { return name; }
+        bool getDoesAttach() const { return doesAttach; }
+        bool getCanCreateAnother() const { return !doesAttach; }
+        bool getIsCreateAllExclusion() const { return isCreateAllExclusion; }
+        bool getIsVariable() const { return isVariableCount; }
+        int getDefaultCount() const { return defaultCount; }
+};
 #endif

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -220,6 +220,7 @@ class CardDatabase : public QObject
         CardInfo *getCardFromMap(const CardNameMap &cardMap, const QString &cardName) const;
         void checkUnknownSets();
         void refreshCachedReverseRelatedCards();
+        void reloadCardDatabases();
     public:
         static const char* TOKENS_SETNAME;
         static void threadSafeReloadCardDatabase();
@@ -253,8 +254,10 @@ class CardDatabase : public QObject
 
     public slots:
         LoadStatus loadCardDatabases();
+
     private slots:
         LoadStatus loadCardDatabase(const QString &path);
+
     signals:
         void cardDatabaseLoadingFailed();
         void cardDatabaseNewSetsFound(int numUnknownSets, QStringList unknownSetsNames);

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -8,6 +8,7 @@
 #include <QDataStream>
 #include <QList>
 #include <QXmlStreamReader>
+#include <QBasicMutex>
 
 class CardDatabase;
 class CardInfo;

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -16,8 +16,7 @@
 
 #define PUBLIC_SERVERS_URL "https://github.com/Cockatrice/Cockatrice/wiki/Public-Servers"
 
-DlgConnect::DlgConnect(QWidget *parent)
-    : QDialog(parent)
+DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
 {
     previousHostButton = new QRadioButton(tr("Known Hosts"), this);
     previousHosts = new QComboBox(this);
@@ -64,7 +63,7 @@ DlgConnect::DlgConnect(QWidget *parent)
 
     if (savePasswordCheckBox->isChecked())
     {
-        autoConnectCheckBox->setChecked(settingsCache->servers().getAutoConnect());
+        autoConnectCheckBox->setChecked(static_cast<bool>(settingsCache->servers().getAutoConnect()));
         autoConnectCheckBox->setEnabled(true);
     }
     else
@@ -87,11 +86,11 @@ DlgConnect::DlgConnect(QWidget *parent)
     btnCancel->setFixedWidth(100);
     connect(btnCancel, SIGNAL(released()), this, SLOT(actCancel()));
 
-    QGridLayout *newHostLayout = new QGridLayout;
+    auto *newHostLayout = new QGridLayout;
     newHostLayout->addWidget(newHostButton, 0, 1);
     newHostLayout->addWidget(publicServersLabel, 0, 2);
 
-    QGridLayout *connectionLayout = new QGridLayout;
+    auto *connectionLayout = new QGridLayout;
     connectionLayout->addWidget(previousHostButton, 0, 1);
     connectionLayout->addWidget(previousHosts, 1, 1);
     connectionLayout->addLayout(newHostLayout, 2, 1, 1, 2);
@@ -103,7 +102,7 @@ DlgConnect::DlgConnect(QWidget *parent)
     connectionLayout->addWidget(portEdit, 5, 1);
     connectionLayout->addWidget(autoConnectCheckBox, 6, 1);
 
-    QGridLayout *buttons = new QGridLayout;
+    auto *buttons = new QGridLayout;
     buttons->addWidget(btnOk, 0, 0);
     buttons->addWidget(btnForgotPassword, 0, 1);
     buttons->addWidget(btnCancel, 0, 2);
@@ -111,7 +110,7 @@ DlgConnect::DlgConnect(QWidget *parent)
     QGroupBox *restrictionsGroupBox = new QGroupBox(tr("Server"));
     restrictionsGroupBox->setLayout(connectionLayout);
 
-    QGridLayout *loginLayout = new QGridLayout;
+    auto *loginLayout = new QGridLayout;
     loginLayout->addWidget(playernameLabel, 0, 0);
     loginLayout->addWidget(playernameEdit, 0, 1);
     loginLayout->addWidget(passwordLabel, 1, 0);
@@ -124,12 +123,12 @@ DlgConnect::DlgConnect(QWidget *parent)
     QGroupBox *btnGroupBox = new QGroupBox(tr(""));
     btnGroupBox->setLayout(buttons);
 
-    QGridLayout *grid = new QGridLayout;
+    auto *grid = new QGridLayout;
     grid->addWidget(restrictionsGroupBox, 0, 0);
     grid->addWidget(loginGroupBox, 1, 0);
     grid->addWidget(btnGroupBox, 2, 0);
-         
-    QVBoxLayout *mainLayout = new QVBoxLayout;
+
+    auto *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(grid);
     setLayout(mainLayout);
 
@@ -289,9 +288,9 @@ void DlgConnect::actCancel()
 bool DeleteHighlightedItemWhenShiftDelPressedEventFilter::eventFilter(QObject *obj, QEvent *event)
 {
     if (event->type() == QEvent::KeyPress) {
-        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+        auto *keyEvent = dynamic_cast<QKeyEvent *>(event);
         if (keyEvent->key() == Qt::Key_Delete) {
-            QComboBox* combobox = reinterpret_cast<QComboBox *>(obj);
+            auto *combobox = reinterpret_cast<QComboBox *>(obj);
             combobox->removeItem(combobox->currentIndex());
             return true;
         }

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -516,7 +516,6 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     lpSpoilerGrid->addWidget(&infoOnSpoilersLabel, 2, 0, 1, 3, Qt::AlignTop);
 
     // On a change to the check box, hide/unhide the other fields
-    // On a change to the combo box, send a signal to the timer threads
     connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), settingsCache, SLOT(setDownloadSpoilerStatus(bool)));
     connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), this, SLOT(setSpoilersEnabled(bool)));
 

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -527,25 +527,15 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
 
     // Create the layout
     lpSpoilerGrid->addWidget(&mcDownloadSpoilersCheckBox, 0, 0);
-    lpSpoilerGrid->addWidget(&msDownloadSpoilersLabel, 0, 1);
-    lpSpoilerGrid->addWidget(&msDownloadSpoilersTimeIntervalComboBox, 0, 2);
     lpSpoilerGrid->addWidget(&mcSpoilerSaveLabel, 1, 0);
     lpSpoilerGrid->addWidget(mpSpoilerSavePathLineEdit, 1, 1);
     lpSpoilerGrid->addWidget(mpSpoilerPathButton, 1, 2);
-    lpSpoilerGrid->addWidget(&mcNextUpdateTimeToolTipLabel, 2, 0);
-    lpSpoilerGrid->addWidget(&mcNextUpdateTimeLabel, 2, 1);
-
-    lpSpoilerGrid->setColumnStretch(0, 2);
-    lpSpoilerGrid->setColumnStretch(1, 4);
-    lpSpoilerGrid->setColumnStretch(2, 1);
-
     lpGeneralGrid->addWidget(&mcGeneralMessageLabel, 0, 0);
 
     // On a change to the check box, hide/unhide the other fields
     // On a change to the combo box, send a signal to the timer threads
     connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), settingsCache, SLOT(setDownloadSpoilerStatus(bool)));
     connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), this, SLOT(setSpoilersEnabled(bool)));
-    connect(&msDownloadSpoilersTimeIntervalComboBox, SIGNAL(currentTextChanged(QString)), this, SLOT(setDownloadSpoilerTime(QString)));
 
     mpGeneralGroupBox = new QGroupBox;
     mpGeneralGroupBox->setLayout(lpGeneralGrid);
@@ -572,57 +562,12 @@ void DeckEditorSettingsPage::spoilerPathButtonClicked()
     settingsCache->setSpoilerDatabasePath(lsPath + "/spoiler.xml");
 }
 
-void DeckEditorSettingsPage::setDownloadSpoilerTime(QString asValue)
-{
-    // Sets the downloadspoilerstimeMinutes field (stored in MINUTES (int))
-    QMap<int, QString> lacSettingTimes = settingsCache->getDownloadSpoilerTimeIntervals();
-    int lnMinutesToReload = lacSettingTimes.key(asValue);
-
-    // Update settings cache downloadspoilerstimeMinutes
-    settingsCache->setDownloadSpoilerTimeMinutes(lnMinutesToReload);
-
-    // Update the GUI display
-    updateDownloadTimer();
-}
-
 void DeckEditorSettingsPage::setSpoilersEnabled(bool anInput)
 {
     msDownloadSpoilersLabel.setEnabled(anInput);
-    msDownloadSpoilersTimeIntervalComboBox.setEnabled(anInput);
     mcSpoilerSaveLabel.setEnabled(anInput);
     mpSpoilerSavePathLineEdit->setEnabled(anInput);
     mpSpoilerPathButton->setEnabled(anInput);
-    updateDownloadTimer(anInput);
-}
-
-void DeckEditorSettingsPage::updateDownloadTimer(bool abIsEnabled)
-{
-    // Update the display so the user sees when the next download time is or nothing if disabled
-    if (abIsEnabled)
-    {
-        long lnTimeUntilNextUpdate = QDateTime::currentMSecsSinceEpoch() - settingsCache->getDownloadSpoilerLastUpdateTime();
-        long lnTimeToWaitBetween = settingsCache->getDownloadSpoilerTimeMinutes() * 60000;
-
-        QDateTime lTimeNow(QDateTime::currentDateTime());
-
-        // If not defaulted
-        if (settingsCache->getDownloadSpoilerLastUpdateTime() != -1)
-        {
-            mcNextUpdateTimeLabel.setText(lTimeNow.addMSecs(lnTimeToWaitBetween - lnTimeUntilNextUpdate).toString());
-        }
-        else
-        {
-            // Value not set in config, so just show how long until the update based on what we know
-            mcNextUpdateTimeLabel.setText(lTimeNow.addMSecs(lnTimeToWaitBetween).toString());
-        }
-    }
-    else
-    {
-        mcNextUpdateTimeLabel.setText(tr("Never"));
-    }
-
-    mcNextUpdateTimeToolTipLabel.setEnabled(abIsEnabled);
-    mcNextUpdateTimeLabel.setEnabled(abIsEnabled);
 }
 
 void DeckEditorSettingsPage::retranslateUi()
@@ -630,10 +575,7 @@ void DeckEditorSettingsPage::retranslateUi()
     mpSpoilerGroupBox->setTitle(tr("Spoilers"));
     mcDownloadSpoilersCheckBox.setText(tr("Download Spoilers Automatically"));
     mcSpoilerSaveLabel.setText(tr("Spoiler Location:"));
-    msDownloadSpoilersLabel.setText(tr("Check for Updates Every"));
-    msDownloadSpoilersLabel.setAlignment(Qt::AlignRight);
     mcGeneralMessageLabel.setText(tr("Hey, something's here finally!"));
-    mcNextUpdateTimeToolTipLabel.setText(tr("Next Download At:"));
 }
 
 MessagesSettingsPage::MessagesSettingsPage()

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -534,8 +534,18 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
 
 void DeckEditorSettingsPage::updateSpoilers()
 {
-    // This will launch the spoiler checker as if the client was anew
-    new SpoilerBackgroundUpdater();
+    // Disable the button so the user can only press it once at a time
+    updateNowButton->setDisabled(true);
+
+    // Create a new SBU that will act as if the client was just reloaded
+    auto *sbu = new SpoilerBackgroundUpdater();
+    connect(sbu, SIGNAL(spoilerCheckerDone()), this, SLOT(unlockSettings()));
+    connect(sbu, SIGNAL(spoilersUpdatedSuccessfully()), this, SLOT(unlockSettings()));
+}
+
+void DeckEditorSettingsPage::unlockSettings()
+{
+    updateNowButton->setDisabled(false);
 }
 
 QString DeckEditorSettingsPage::getLastUpdateTime()
@@ -588,9 +598,9 @@ void DeckEditorSettingsPage::retranslateUi()
     mcGeneralMessageLabel.setText(tr("Hey, something's here finally!"));
     infoOnSpoilersLabel.setText(
             tr("Last Updated") + ": " + getLastUpdateTime() + "\n\n" +
-            tr("Spoilers will download automatically on launch") + "\n" +
-            tr("Press the button to manually update without relaunching") + "\n" +
-            tr("Please wait a few moments for spoilers to manually download")
+            tr("Spoilers download automatically on launch") + "\n" +
+            tr("Press the button to manually update without relaunching") + "\n\n" +
+            tr("Do not close settings until manual update complete")
     );
 }
 
@@ -889,7 +899,7 @@ DlgSettings::DlgSettings(QWidget *parent) : QDialog(parent)
     vboxLayout->addWidget(contentsWidget);
     vboxLayout->addWidget(pagesWidget);
 
-    QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok);
+    auto *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(close()));
 
     auto *mainLayout = new QVBoxLayout;

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -49,10 +49,10 @@ GeneralSettingsPage::GeneralSettingsPage()
 
     // updates
     QList<ReleaseChannel*> channels = settingsCache->getUpdateReleaseChannels();
-            foreach(ReleaseChannel* chan, channels)
-        {
-            updateReleaseChannelBox.insertItem(chan->getIndex(), tr(chan->getName().toUtf8()));
-        }
+    foreach(ReleaseChannel* chan, channels)
+    {
+        updateReleaseChannelBox.insertItem(chan->getIndex(), tr(chan->getName().toUtf8()));
+    }
     updateReleaseChannelBox.setCurrentIndex(settingsCache->getUpdateReleaseChannel()->getIndex());
 
     updateNotificationCheckBox.setChecked(settingsCache->getNotifyAboutUpdates());
@@ -731,13 +731,13 @@ void MessagesSettingsPage::updateTextHighlightColor(int value)
 void MessagesSettingsPage::updateMentionPreview()
 {
     mentionColor->setStyleSheet("QLineEdit{background:#" + settingsCache->getChatMentionColor() +
-                                ";color: " + (settingsCache->getChatMentionForeground() ? "white" : "black") + ";}");
+        ";color: " + (settingsCache->getChatMentionForeground() ? "white" : "black") + ";}");
 }
 
 void MessagesSettingsPage::updateHighlightPreview()
 {
     highlightColor->setStyleSheet("QLineEdit{background:#" + settingsCache->getChatHighlightColor() +
-                                  ";color: " + (settingsCache->getChatHighlightForeground() ? "white" : "black") + ";}");
+        ";color: " + (settingsCache->getChatHighlightForeground() ? "white" : "black") + ";}");
 }
 
 void MessagesSettingsPage::storeSettings()
@@ -978,7 +978,8 @@ void DlgSettings::closeEvent(QCloseEvent *event)
     QString loadErrorMessage = tr("Unknown Error loading card database");
     LoadStatus loadStatus = db->getLoadStatus();
     qDebug() << "Card Database load status: " << loadStatus;
-    switch(loadStatus) {
+    switch(loadStatus)
+    {
         case Ok:
             showLoadError = false;
             break;
@@ -1020,23 +1021,36 @@ void DlgSettings::closeEvent(QCloseEvent *event)
 
             break;
     }
+
     if (showLoadError)
-        if (QMessageBox::critical(this, tr("Error"), loadErrorMessage, QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) {
+    {
+        if (QMessageBox::critical(this, tr("Error"), loadErrorMessage, QMessageBox::Yes | QMessageBox::No) ==
+            QMessageBox::Yes)
+        {
             event->ignore();
             return;
         }
+    }
+
     if (!QDir(settingsCache->getDeckPath()).exists() || settingsCache->getDeckPath().isEmpty())
+    {
         // TODO: Prompt to create it
-        if (QMessageBox::critical(this, tr("Error"), tr("The path to your deck directory is invalid. Would you like to go back and set the correct path?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) {
+        if (QMessageBox::critical(this, tr("Error"), tr("The path to your deck directory is invalid. Would you like to go back and set the correct path?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes)
+        {
             event->ignore();
             return;
         }
+    }
+
     if (!QDir(settingsCache->getPicsPath()).exists() || settingsCache->getPicsPath().isEmpty())
+    {
         // TODO: Prompt to create it
-        if (QMessageBox::critical(this, tr("Error"), tr("The path to your card pictures directory is invalid. Would you like to go back and set the correct path?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) {
+        if (QMessageBox::critical(this, tr("Error"), tr("The path to your card pictures directory is invalid. Would you like to go back and set the correct path?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes)
+        {
             event->ignore();
             return;
         }
+    }
     event->accept();
 }
 

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -30,6 +30,7 @@
 #include "releasechannel.h"
 #include "soundengine.h"
 #include "sequenceEdit/shortcutstab.h"
+#include "spoilerbackgroundupdater.h"
 
 #define WIKI_CUSTOM_PIC_URL "https://github.com/Cockatrice/Cockatrice/wiki/Custom-Picture-Download-URLs"
 
@@ -81,7 +82,7 @@ GeneralSettingsPage::GeneralSettingsPage()
 
     setEnabledStatus(settingsCache->getPicDownload());
 
-    QGridLayout *personalGrid = new QGridLayout;
+    auto *personalGrid = new QGridLayout;
     personalGrid->addWidget(&languageLabel, 0, 0);
     personalGrid->addWidget(&languageBox, 0, 1);
     personalGrid->addWidget(&updateReleaseChannelLabel, 1, 0);
@@ -130,7 +131,7 @@ GeneralSettingsPage::GeneralSettingsPage()
     QPushButton *tokenDatabasePathButton = new QPushButton("...");
     connect(tokenDatabasePathButton, SIGNAL(clicked()), this, SLOT(tokenDatabasePathButtonClicked()));
     
-    if(settingsCache->getIsPortableBuild())
+    if (settingsCache->getIsPortableBuild())
     {
         deckPathEdit->setEnabled(false);
         replaysPathEdit->setEnabled(false);
@@ -145,7 +146,7 @@ GeneralSettingsPage::GeneralSettingsPage()
         tokenDatabasePathButton->setVisible(false);
     }
 
-    QGridLayout *pathsGrid = new QGridLayout;
+    auto *pathsGrid = new QGridLayout;
     pathsGrid->addWidget(&deckPathLabel, 0, 0);
     pathsGrid->addWidget(deckPathEdit, 0, 1);
     pathsGrid->addWidget(deckPathButton, 0, 2);
@@ -164,7 +165,7 @@ GeneralSettingsPage::GeneralSettingsPage()
     pathsGroupBox = new QGroupBox;
     pathsGroupBox->setLayout(pathsGrid);
 
-    QVBoxLayout *mainLayout = new QVBoxLayout;
+    auto *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(personalGroupBox);
     mainLayout->addWidget(pathsGroupBox);
     
@@ -332,8 +333,8 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     }
 
     connect(&themeBox, SIGNAL(currentIndexChanged(int)), this, SLOT(themeBoxChanged(int)));
-    
-    QGridLayout *themeGrid = new QGridLayout;
+
+    auto *themeGrid = new QGridLayout;
     themeGrid->addWidget(&themeLabel, 0, 0);
     themeGrid->addWidget(&themeBox, 0, 1);
 
@@ -345,8 +346,8 @@ AppearanceSettingsPage::AppearanceSettingsPage()
 
     cardScalingCheckBox.setChecked(settingsCache->getScaleCards());
     connect(&cardScalingCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setCardScaling(int)));
-    
-    QGridLayout *cardsGrid = new QGridLayout;
+
+    auto *cardsGrid = new QGridLayout;
     cardsGrid->addWidget(&displayCardNamesCheckBox, 0, 0, 1, 2);
     cardsGrid->addWidget(&cardScalingCheckBox, 1, 0, 1, 2);
     
@@ -358,8 +359,8 @@ AppearanceSettingsPage::AppearanceSettingsPage()
 
     leftJustifiedHandCheckBox.setChecked(settingsCache->getLeftJustified());
     connect(&leftJustifiedHandCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setLeftJustified(int)));
-    
-    QGridLayout *handGrid = new QGridLayout;
+
+    auto *handGrid = new QGridLayout;
     handGrid->addWidget(&horizontalHandCheckBox, 0, 0, 1, 2);
     handGrid->addWidget(&leftJustifiedHandCheckBox, 1, 0, 1, 2);
     
@@ -380,7 +381,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     maxFontSizeForCardsEdit.setMinimum(9);
     maxFontSizeForCardsEdit.setMaximum(100);
 
-    QGridLayout *tableGrid = new QGridLayout;
+    auto *tableGrid = new QGridLayout;
     tableGrid->addWidget(&invertVerticalCoordinateCheckBox, 0, 0, 1, 2);
     tableGrid->addWidget(&minPlayersForMultiColumnLayoutLabel, 1, 0, 1, 1);
     tableGrid->addWidget(&minPlayersForMultiColumnLayoutEdit, 1, 1, 1, 1);
@@ -389,8 +390,8 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     
     tableGroupBox = new QGroupBox;
     tableGroupBox->setLayout(tableGrid);
-    
-    QVBoxLayout *mainLayout = new QVBoxLayout;
+
+    auto *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(themeGroupBox);
     mainLayout->addWidget(cardsGroupBox);
     mainLayout->addWidget(handGroupBox);
@@ -444,7 +445,7 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     annotateTokensCheckBox.setChecked(settingsCache->getAnnotateTokens());
     connect(&annotateTokensCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setAnnotateTokens(int)));
 
-    QGridLayout *generalGrid = new QGridLayout;
+    auto *generalGrid = new QGridLayout;
     generalGrid->addWidget(&notificationsEnabledCheckBox, 0, 0);
     generalGrid->addWidget(&specNotificationsEnabledCheckBox, 1, 0);
     generalGrid->addWidget(&doubleClickToPlayCheckBox, 2, 0);
@@ -456,14 +457,14 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     
     tapAnimationCheckBox.setChecked(settingsCache->getTapAnimation());
     connect(&tapAnimationCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setTapAnimation(int)));
-    
-    QGridLayout *animationGrid = new QGridLayout;
+
+    auto *animationGrid = new QGridLayout;
     animationGrid->addWidget(&tapAnimationCheckBox, 0, 0);
     
     animationGroupBox = new QGroupBox;
     animationGroupBox->setLayout(animationGrid);
 
-    QVBoxLayout *mainLayout = new QVBoxLayout;
+    auto *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(generalGroupBox);
     mainLayout->addWidget(animationGroupBox);
     
@@ -486,7 +487,6 @@ void UserInterfaceSettingsPage::retranslateUi()
     tapAnimationCheckBox.setText(tr("&Tap/untap animation"));
 }
 
-
 DeckEditorSettingsPage::DeckEditorSettingsPage()
 {
     auto *lpGeneralGrid = new QGridLayout;
@@ -499,15 +499,21 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     mpSpoilerPathButton = new QPushButton("...");
     connect(mpSpoilerPathButton, SIGNAL(clicked()), this, SLOT(spoilerPathButtonClicked()));
 
+    updateNowButton = new QPushButton(tr("Update Spoilers"));
+    connect(updateNowButton, SIGNAL(clicked()), this, SLOT(updateSpoilers()));
+
     // Update the GUI depending on if the box is ticked or not
     setSpoilersEnabled(mcDownloadSpoilersCheckBox.isChecked());
 
     // Create the layout
+    lpGeneralGrid->addWidget(&mcGeneralMessageLabel, 0, 0);
+
     lpSpoilerGrid->addWidget(&mcDownloadSpoilersCheckBox, 0, 0);
+    lpSpoilerGrid->addWidget(updateNowButton, 0, 2);
     lpSpoilerGrid->addWidget(&mcSpoilerSaveLabel, 1, 0);
     lpSpoilerGrid->addWidget(mpSpoilerSavePathLineEdit, 1, 1);
     lpSpoilerGrid->addWidget(mpSpoilerPathButton, 1, 2);
-    lpGeneralGrid->addWidget(&mcGeneralMessageLabel, 0, 0);
+    lpSpoilerGrid->addWidget(&infoOnSpoilersLabel, 2, 0, 1, 3, Qt::AlignTop);
 
     // On a change to the check box, hide/unhide the other fields
     // On a change to the combo box, send a signal to the timer threads
@@ -525,6 +531,12 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     lpMainLayout->addWidget(mpSpoilerGroupBox);
 
     setLayout(lpMainLayout);
+}
+
+void DeckEditorSettingsPage::updateSpoilers()
+{
+    // This will launch the spoiler checker as if the client was anew
+    new SpoilerBackgroundUpdater();
 }
 
 void DeckEditorSettingsPage::spoilerPathButtonClicked()
@@ -545,6 +557,8 @@ void DeckEditorSettingsPage::setSpoilersEnabled(bool anInput)
     mcSpoilerSaveLabel.setEnabled(anInput);
     mpSpoilerSavePathLineEdit->setEnabled(anInput);
     mpSpoilerPathButton->setEnabled(anInput);
+    updateNowButton->setEnabled(anInput);
+    infoOnSpoilersLabel.setEnabled(anInput);
 }
 
 void DeckEditorSettingsPage::retranslateUi()
@@ -553,6 +567,11 @@ void DeckEditorSettingsPage::retranslateUi()
     mcDownloadSpoilersCheckBox.setText(tr("Download Spoilers Automatically"));
     mcSpoilerSaveLabel.setText(tr("Spoiler Location:"));
     mcGeneralMessageLabel.setText(tr("Hey, something's here finally!"));
+    infoOnSpoilersLabel.setText(
+            tr("Spoilers will download automatically on launch") + "\n" +
+            tr("Press the button to manually update without relaunching") + "\n" +
+            tr("It will take a moment to download, so be patient")
+    );
 }
 
 MessagesSettingsPage::MessagesSettingsPage()
@@ -593,7 +612,7 @@ MessagesSettingsPage::MessagesSettingsPage()
     customAlertString->setText(settingsCache->getHighlightWords());
     connect(customAlertString, SIGNAL(textChanged(QString)), settingsCache, SLOT(setHighlightWords(QString)));
 
-    QGridLayout *chatGrid = new QGridLayout;
+    auto *chatGrid = new QGridLayout;
     chatGrid->addWidget(&chatMentionCheckBox, 0, 0);
     chatGrid->addWidget(&invertMentionForeground, 0, 1);
     chatGrid->addWidget(mentionColor, 0, 2);
@@ -612,7 +631,7 @@ MessagesSettingsPage::MessagesSettingsPage()
     updateHighlightPreview();
     connect(highlightColor, SIGNAL(textChanged(QString)), this, SLOT(updateHighlightColor(QString)));
 
-    QGridLayout *highlightNotice = new QGridLayout;
+    auto *highlightNotice = new QGridLayout;
     highlightNotice->addWidget(highlightColor, 0, 2);
     highlightNotice->addWidget(&invertHighlightForeground, 0, 1);
     highlightNotice->addWidget(&hexHighlightLabel, 1, 2);
@@ -634,19 +653,19 @@ MessagesSettingsPage::MessagesSettingsPage()
     aRemove->setIcon(QPixmap("theme:icons/decrement"));
     connect(aRemove, SIGNAL(triggered()), this, SLOT(actRemove()));
 
-    QToolBar *messageToolBar = new QToolBar;
+    auto *messageToolBar = new QToolBar;
     messageToolBar->setOrientation(Qt::Vertical);
     messageToolBar->addAction(aAdd);
     messageToolBar->addAction(aRemove);
 
-    QHBoxLayout *messageListLayout = new QHBoxLayout;
+    auto *messageListLayout = new QHBoxLayout;
     messageListLayout->addWidget(messageToolBar);
     messageListLayout->addWidget(messageList);
 
     messageShortcuts = new QGroupBox;
     messageShortcuts->setLayout(messageListLayout);
 
-    QVBoxLayout *mainLayout = new QVBoxLayout;
+    auto *mainLayout = new QVBoxLayout;
 
     mainLayout->addWidget(messageShortcuts);
     mainLayout->addWidget(chatGroupBox);
@@ -657,7 +676,8 @@ MessagesSettingsPage::MessagesSettingsPage()
     retranslateUi();
 }
 
-void MessagesSettingsPage::updateColor(const QString &value) {
+void MessagesSettingsPage::updateColor(const QString &value)
+{
     QColor colorToSet;
     colorToSet.setNamedColor("#" + value);
     if (colorToSet.isValid()) {
@@ -666,7 +686,8 @@ void MessagesSettingsPage::updateColor(const QString &value) {
     }
 }
 
-void MessagesSettingsPage::updateHighlightColor(const QString &value) {
+void MessagesSettingsPage::updateHighlightColor(const QString &value)
+{
     QColor colorToSet;
     colorToSet.setNamedColor("#" + value);
     if (colorToSet.isValid()) {
@@ -675,22 +696,26 @@ void MessagesSettingsPage::updateHighlightColor(const QString &value) {
     }
 }
 
-void MessagesSettingsPage::updateTextColor(int value) {
+void MessagesSettingsPage::updateTextColor(int value)
+{
     settingsCache->setChatMentionForeground(value);
     updateMentionPreview();
 }
 
-void MessagesSettingsPage::updateTextHighlightColor(int value) {
+void MessagesSettingsPage::updateTextHighlightColor(int value)
+{
     settingsCache->setChatHighlightForeground(value);
     updateHighlightPreview();
 }
 
-void MessagesSettingsPage::updateMentionPreview() {
+void MessagesSettingsPage::updateMentionPreview()
+{
     mentionColor->setStyleSheet("QLineEdit{background:#" + settingsCache->getChatMentionColor() + 
         ";color: " + (settingsCache->getChatMentionForeground() ? "white" : "black") + ";}");
 }
 
-void MessagesSettingsPage::updateHighlightPreview() {
+void MessagesSettingsPage::updateHighlightPreview()
+{
     highlightColor->setStyleSheet("QLineEdit{background:#" + settingsCache->getChatHighlightColor() +
         ";color: " + (settingsCache->getChatHighlightForeground() ? "white" : "black") + ";}");
 }
@@ -773,7 +798,7 @@ SoundSettingsPage::SoundSettingsPage()
     connect(masterVolumeSlider, SIGNAL(valueChanged(int)), masterVolumeSpinBox, SLOT(setValue(int)));
     connect(masterVolumeSpinBox, SIGNAL(valueChanged(int)), masterVolumeSlider, SLOT(setValue(int)));
 
-    QGridLayout *soundGrid = new QGridLayout;
+    auto *soundGrid = new QGridLayout;
     soundGrid->addWidget(&soundEnabledCheckBox, 0, 0, 1, 3);
     soundGrid->addWidget(&masterVolumeLabel, 1, 0);
     soundGrid->addWidget(masterVolumeSlider, 1, 1);
@@ -785,7 +810,7 @@ SoundSettingsPage::SoundSettingsPage()
     soundGroupBox = new QGroupBox;
     soundGroupBox->setLayout(soundGrid);
 
-    QVBoxLayout *mainLayout = new QVBoxLayout;
+    auto *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(soundGroupBox);
 
     setLayout(mainLayout);
@@ -798,11 +823,13 @@ void SoundSettingsPage::themeBoxChanged(int index)
         settingsCache->setSoundThemeName(themeDirs.at(index));
 }
 
-void SoundSettingsPage::masterVolumeChanged(int value) {
+void SoundSettingsPage::masterVolumeChanged(int value)
+{
     masterVolumeSlider->setToolTip(QString::number(value));
 }
 
-void SoundSettingsPage::retranslateUi() {
+void SoundSettingsPage::retranslateUi()
+{
     soundEnabledCheckBox.setText(tr("Enable &sounds"));
     themeLabel.setText(tr("Current sounds theme:"));
     soundTestButton.setText(tr("Test system sound engine"));
@@ -810,8 +837,7 @@ void SoundSettingsPage::retranslateUi() {
     masterVolumeLabel.setText(tr("Master volume"));    
 }
 
-DlgSettings::DlgSettings(QWidget *parent)
-    : QDialog(parent)
+DlgSettings::DlgSettings(QWidget *parent) : QDialog(parent)
 {
     QRect rec = QApplication::desktop()->availableGeometry();
     this->setMinimumSize(rec.width() / 2, rec.height() - 100);
@@ -838,15 +864,15 @@ DlgSettings::DlgSettings(QWidget *parent)
     
     createIcons();
     contentsWidget->setCurrentRow(0);
-    
-    QVBoxLayout *vboxLayout = new QVBoxLayout;
+
+    auto *vboxLayout = new QVBoxLayout;
     vboxLayout->addWidget(contentsWidget);
     vboxLayout->addWidget(pagesWidget);
     
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(close()));
-    
-    QVBoxLayout *mainLayout = new QVBoxLayout;
+
+    auto *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(vboxLayout);
     mainLayout->addSpacing(12);
     mainLayout->addWidget(buttonBox);
@@ -905,7 +931,8 @@ void DlgSettings::changePage(QListWidgetItem *current, QListWidgetItem *previous
     pagesWidget->setCurrentIndex(contentsWidget->row(current));
 }
 
-void DlgSettings::setTab(int index) {
+void DlgSettings::setTab(int index)
+{
     if (index <= contentsWidget->count()-1 && index >= 0) {
         changePage(contentsWidget->item(index), contentsWidget->currentItem());
         contentsWidget->setCurrentRow(index);

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -538,6 +538,21 @@ void DeckEditorSettingsPage::updateSpoilers()
     new SpoilerBackgroundUpdater();
 }
 
+QString DeckEditorSettingsPage::getLastUpdateTime()
+{
+    QString fileName = settingsCache->getSpoilerCardDatabasePath();
+    QFileInfo fi(fileName);
+    QDir fileDir(fi.path());
+    QFile file(fileName);
+
+    if (file.exists())
+    {
+        return fi.lastModified().toString("MMM d, hh:mm");
+    }
+
+    return QString();
+}
+
 void DeckEditorSettingsPage::spoilerPathButtonClicked()
 {
     QString lsPath = QFileDialog::getExistingDirectory(this, tr("Choose path"));
@@ -558,6 +573,11 @@ void DeckEditorSettingsPage::setSpoilersEnabled(bool anInput)
     mpSpoilerPathButton->setEnabled(anInput);
     updateNowButton->setEnabled(anInput);
     infoOnSpoilersLabel.setEnabled(anInput);
+
+    if (! anInput)
+    {
+        SpoilerBackgroundUpdater::deleteSpoilerFile();
+    }
 }
 
 void DeckEditorSettingsPage::retranslateUi()
@@ -567,9 +587,10 @@ void DeckEditorSettingsPage::retranslateUi()
     mcSpoilerSaveLabel.setText(tr("Spoiler Location:"));
     mcGeneralMessageLabel.setText(tr("Hey, something's here finally!"));
     infoOnSpoilersLabel.setText(
+            tr("Last Updated") + ": " + getLastUpdateTime() + "\n\n" +
             tr("Spoilers will download automatically on launch") + "\n" +
             tr("Press the button to manually update without relaunching") + "\n" +
-            tr("It will take a moment to download, so be patient")
+            tr("Please wait a few moments for spoilers to manually download")
     );
 }
 

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -492,29 +492,6 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     auto *lpGeneralGrid = new QGridLayout;
     auto *lpSpoilerGrid = new QGridLayout;
 
-    // Get all the update options and put them into the Combo Box
-    QMap<int, QString> lacSettingTimes = settingsCache->getDownloadSpoilerTimeIntervals();
-    bool lbCurrentIndexDefaulted = true;
-    int lnIndexToInsert = 0;
-    for (auto lIterator = lacSettingTimes.begin(); lIterator != lacSettingTimes.end(); lIterator++, lnIndexToInsert++)
-    {
-        msDownloadSpoilersTimeIntervalComboBox.insertItem(lnIndexToInsert, lIterator.value());
-
-        // If this is the saved value, we can mark it off it
-        if (lIterator.key() == settingsCache->getDownloadSpoilerTimeMinutes())
-        {
-            msDownloadSpoilersTimeIntervalComboBox.setCurrentIndex(lnIndexToInsert);
-            lbCurrentIndexDefaulted = false;
-        }
-    }
-
-    // Set the combo box's selected if we don't have a setting in the settingsCache
-    if (lbCurrentIndexDefaulted)
-    {
-        settingsCache->setDownloadSpoilerTimeMinutes(lacSettingTimes.keys().last()); // greatest value
-        msDownloadSpoilersTimeIntervalComboBox.setCurrentIndex(lacSettingTimes.size() - 1);
-    }
-
     mcDownloadSpoilersCheckBox.setChecked(settingsCache->getDownloadSpoilersStatus());
 
     mpSpoilerSavePathLineEdit = new QLineEdit(settingsCache->getSpoilerCardDatabasePath());

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -536,6 +536,7 @@ void DeckEditorSettingsPage::updateSpoilers()
 {
     // Disable the button so the user can only press it once at a time
     updateNowButton->setDisabled(true);
+    updateNowButton->setText(tr("Updating Spoilers"));
 
     // Create a new SBU that will act as if the client was just reloaded
     auto *sbu = new SpoilerBackgroundUpdater();
@@ -546,6 +547,7 @@ void DeckEditorSettingsPage::updateSpoilers()
 void DeckEditorSettingsPage::unlockSettings()
 {
     updateNowButton->setDisabled(false);
+    updateNowButton->setText(tr("Update Spoilers"));
 }
 
 QString DeckEditorSettingsPage::getLastUpdateTime()

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -489,22 +489,151 @@ void UserInterfaceSettingsPage::retranslateUi()
 
 DeckEditorSettingsPage::DeckEditorSettingsPage()
 {
-    QGridLayout *generalGrid = new QGridLayout;
-    
-    generalGrid->addWidget(new QLabel(tr("Nothing is here... yet")), 0, 0);
-    
-    generalGroupBox = new QGroupBox;
-    generalGroupBox->setLayout(generalGrid);
-    
-    QVBoxLayout *mainLayout = new QVBoxLayout;
-    mainLayout->addWidget(generalGroupBox);
-    
-    setLayout(mainLayout);
+    auto *lpGeneralGrid = new QGridLayout;
+    auto *lpSpoilerGrid = new QGridLayout;
+
+    // Get all the update options and put them into the Combo Box
+    QMap<int, QString> lacSettingTimes = settingsCache->getDownloadSpoilerTimeIntervals();
+    bool lbCurrentIndexDefaulted = true;
+    int lnIndexToInsert = 0;
+    for (auto lIterator = lacSettingTimes.begin(); lIterator != lacSettingTimes.end(); lIterator++, lnIndexToInsert++)
+    {
+        msDownloadSpoilersTimeIntervalComboBox.insertItem(lnIndexToInsert, lIterator.value());
+
+        // If this is the saved value, we can mark it off it
+        if (lIterator.key() == settingsCache->getDownloadSpoilerTimeMinutes())
+        {
+            msDownloadSpoilersTimeIntervalComboBox.setCurrentIndex(lnIndexToInsert);
+            lbCurrentIndexDefaulted = false;
+        }
+    }
+
+    // Set the combo box's selected if we don't have a setting in the settingsCache
+    if (lbCurrentIndexDefaulted)
+    {
+        settingsCache->setDownloadSpoilerTimeMinutes(lacSettingTimes.keys().last()); // greatest value
+        msDownloadSpoilersTimeIntervalComboBox.setCurrentIndex(lacSettingTimes.size() - 1);
+    }
+
+    mcDownloadSpoilersCheckBox.setChecked(settingsCache->getDownloadSpoilersStatus());
+
+    mpSpoilerSavePathLineEdit = new QLineEdit(settingsCache->getSpoilerCardDatabasePath());
+    mpSpoilerSavePathLineEdit->setReadOnly(true);
+    mpSpoilerPathButton = new QPushButton("...");
+    connect(mpSpoilerPathButton, SIGNAL(clicked()), this, SLOT(spoilerPathButtonClicked()));
+
+    // Update the GUI depending on if the box is ticked or not
+    setSpoilersEnabled(mcDownloadSpoilersCheckBox.isChecked());
+
+    // Create the layout
+    lpSpoilerGrid->addWidget(&mcDownloadSpoilersCheckBox, 0, 0);
+    lpSpoilerGrid->addWidget(&msDownloadSpoilersLabel, 0, 1);
+    lpSpoilerGrid->addWidget(&msDownloadSpoilersTimeIntervalComboBox, 0, 2);
+    lpSpoilerGrid->addWidget(&mcSpoilerSaveLabel, 1, 0);
+    lpSpoilerGrid->addWidget(mpSpoilerSavePathLineEdit, 1, 1);
+    lpSpoilerGrid->addWidget(mpSpoilerPathButton, 1, 2);
+    lpSpoilerGrid->addWidget(&mcNextUpdateTimeToolTipLabel, 2, 0);
+    lpSpoilerGrid->addWidget(&mcNextUpdateTimeLabel, 2, 1);
+
+    lpSpoilerGrid->setColumnStretch(0, 2);
+    lpSpoilerGrid->setColumnStretch(1, 4);
+    lpSpoilerGrid->setColumnStretch(2, 1);
+
+    lpGeneralGrid->addWidget(&mcGeneralMessageLabel, 0, 0);
+
+    // On a change to the check box, hide/unhide the other fields
+    // On a change to the combo box, send a signal to the timer threads
+    connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), settingsCache, SLOT(setDownloadSpoilerStatus(bool)));
+    connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), this, SLOT(setSpoilersEnabled(bool)));
+    connect(&msDownloadSpoilersTimeIntervalComboBox, SIGNAL(currentTextChanged(QString)), this, SLOT(setDownloadSpoilerTime(QString)));
+
+    mpGeneralGroupBox = new QGroupBox;
+    mpGeneralGroupBox->setLayout(lpGeneralGrid);
+
+    mpSpoilerGroupBox = new QGroupBox;
+    mpSpoilerGroupBox->setLayout(lpSpoilerGrid);
+
+    auto *lpMainLayout = new QVBoxLayout;
+    lpMainLayout->addWidget(mpGeneralGroupBox);
+    lpMainLayout->addWidget(mpSpoilerGroupBox);
+
+    setLayout(lpMainLayout);
+}
+
+void DeckEditorSettingsPage::spoilerPathButtonClicked()
+{
+    QString lsPath = QFileDialog::getExistingDirectory(this, tr("Choose path"));
+    if (lsPath.isEmpty())
+    {
+        return;
+    }
+
+    mpSpoilerSavePathLineEdit->setText(lsPath + "/spoiler.xml");
+    settingsCache->setSpoilerDatabasePath(lsPath + "/spoiler.xml");
+}
+
+void DeckEditorSettingsPage::setDownloadSpoilerTime(QString asValue)
+{
+    // Sets the downloadspoilerstimeMinutes field (stored in MINUTES (int))
+    QMap<int, QString> lacSettingTimes = settingsCache->getDownloadSpoilerTimeIntervals();
+    int lnMinutesToReload = lacSettingTimes.key(asValue);
+
+    // Update settings cache downloadspoilerstimeMinutes
+    settingsCache->setDownloadSpoilerTimeMinutes(lnMinutesToReload);
+
+    // Update the GUI display
+    updateDownloadTimer();
+}
+
+void DeckEditorSettingsPage::setSpoilersEnabled(bool anInput)
+{
+    msDownloadSpoilersLabel.setEnabled(anInput);
+    msDownloadSpoilersTimeIntervalComboBox.setEnabled(anInput);
+    mcSpoilerSaveLabel.setEnabled(anInput);
+    mpSpoilerSavePathLineEdit->setEnabled(anInput);
+    mpSpoilerPathButton->setEnabled(anInput);
+    updateDownloadTimer(anInput);
+}
+
+void DeckEditorSettingsPage::updateDownloadTimer(bool abIsEnabled)
+{
+    // Update the display so the user sees when the next download time is or nothing if disabled
+    if (abIsEnabled)
+    {
+        long lnTimeUntilNextUpdate = QDateTime::currentMSecsSinceEpoch() - settingsCache->getDownloadSpoilerLastUpdateTime();
+        long lnTimeToWaitBetween = settingsCache->getDownloadSpoilerTimeMinutes() * 60000;
+
+        QDateTime lTimeNow(QDateTime::currentDateTime());
+
+        // If not defaulted
+        if (settingsCache->getDownloadSpoilerLastUpdateTime() != -1)
+        {
+            mcNextUpdateTimeLabel.setText(lTimeNow.addMSecs(lnTimeToWaitBetween - lnTimeUntilNextUpdate).toString());
+        }
+        else
+        {
+            // Value not set in config, so just show how long until the update based on what we know
+            mcNextUpdateTimeLabel.setText(lTimeNow.addMSecs(lnTimeToWaitBetween).toString());
+        }
+    }
+    else
+    {
+        mcNextUpdateTimeLabel.setText(tr("Never"));
+    }
+
+    mcNextUpdateTimeToolTipLabel.setEnabled(abIsEnabled);
+    mcNextUpdateTimeLabel.setEnabled(abIsEnabled);
 }
 
 void DeckEditorSettingsPage::retranslateUi()
 {
-    generalGroupBox->setTitle(tr("General"));
+    mpSpoilerGroupBox->setTitle(tr("Spoilers"));
+    mcDownloadSpoilersCheckBox.setText(tr("Download Spoilers Automatically"));
+    mcSpoilerSaveLabel.setText(tr("Spoiler Location:"));
+    msDownloadSpoilersLabel.setText(tr("Check for Updates Every"));
+    msDownloadSpoilersLabel.setAlignment(Qt::AlignRight);
+    mcGeneralMessageLabel.setText(tr("Hey, something's here finally!"));
+    mcNextUpdateTimeToolTipLabel.setText(tr("Next Download At:"));
 }
 
 MessagesSettingsPage::MessagesSettingsPage()

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -132,7 +132,6 @@ public:
     void retranslateUi();
 private slots:
     void setSpoilersEnabled(bool);
-    void setDownloadSpoilerTime(QString);
     void spoilerPathButtonClicked();
 signals:
 private:
@@ -144,10 +143,7 @@ private:
     QLineEdit *mpSpoilerSavePathLineEdit;
     QLabel mcSpoilerSaveLabel;
     QLabel mcGeneralMessageLabel;
-    QLabel mcNextUpdateTimeToolTipLabel;
-    QLabel mcNextUpdateTimeLabel;
     QPushButton *mpSpoilerPathButton;
-    void updateDownloadTimer(bool abIsEnabled = true);
 };
 
 class MessagesSettingsPage : public AbstractSettingsPage {

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -130,6 +130,7 @@ class DeckEditorSettingsPage : public AbstractSettingsPage
     public:
         DeckEditorSettingsPage();
         void retranslateUi() override;
+        QString getLastUpdateTime();
 
     private slots:
         void setSpoilersEnabled(bool);

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -124,15 +124,30 @@ public:
     void retranslateUi();
 };
 
-class DeckEditorSettingsPage : public AbstractSettingsPage {
-    Q_OBJECT
+class DeckEditorSettingsPage : public AbstractSettingsPage
+{
+Q_OBJECT
 public:
     DeckEditorSettingsPage();
     void retranslateUi();
 private slots:
+    void setSpoilersEnabled(bool);
+    void setDownloadSpoilerTime(QString);
+    void spoilerPathButtonClicked();
 signals:
 private:
-    QGroupBox *generalGroupBox;
+    QCheckBox mcDownloadSpoilersCheckBox;
+    QComboBox msDownloadSpoilersTimeIntervalComboBox;
+    QLabel msDownloadSpoilersLabel;
+    QGroupBox *mpGeneralGroupBox;
+    QGroupBox *mpSpoilerGroupBox;
+    QLineEdit *mpSpoilerSavePathLineEdit;
+    QLabel mcSpoilerSaveLabel;
+    QLabel mcGeneralMessageLabel;
+    QLabel mcNextUpdateTimeToolTipLabel;
+    QLabel mcNextUpdateTimeLabel;
+    QPushButton *mpSpoilerPathButton;
+    void updateDownloadTimer(bool abIsEnabled = true);
 };
 
 class MessagesSettingsPage : public AbstractSettingsPage {

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -121,36 +121,39 @@ private:
     
 public:
     UserInterfaceSettingsPage();
-    void retranslateUi();
+    void retranslateUi() override;
 };
 
 class DeckEditorSettingsPage : public AbstractSettingsPage
 {
-Q_OBJECT
-public:
-    DeckEditorSettingsPage();
-    void retranslateUi();
-private slots:
-    void setSpoilersEnabled(bool);
-    void spoilerPathButtonClicked();
-signals:
-private:
-    QCheckBox mcDownloadSpoilersCheckBox;
-    QComboBox msDownloadSpoilersTimeIntervalComboBox;
-    QLabel msDownloadSpoilersLabel;
-    QGroupBox *mpGeneralGroupBox;
-    QGroupBox *mpSpoilerGroupBox;
-    QLineEdit *mpSpoilerSavePathLineEdit;
-    QLabel mcSpoilerSaveLabel;
-    QLabel mcGeneralMessageLabel;
-    QPushButton *mpSpoilerPathButton;
+    Q_OBJECT
+    public:
+        DeckEditorSettingsPage();
+        void retranslateUi() override;
+
+    private slots:
+        void setSpoilersEnabled(bool);
+        void spoilerPathButtonClicked();
+        void updateSpoilers();
+
+    private:
+        QCheckBox mcDownloadSpoilersCheckBox;
+        QLabel msDownloadSpoilersLabel;
+        QGroupBox *mpGeneralGroupBox;
+        QGroupBox *mpSpoilerGroupBox;
+        QLineEdit *mpSpoilerSavePathLineEdit;
+        QLabel mcSpoilerSaveLabel;
+        QLabel mcGeneralMessageLabel;
+        QLabel infoOnSpoilersLabel;
+        QPushButton *mpSpoilerPathButton;
+        QPushButton *updateNowButton;
 };
 
 class MessagesSettingsPage : public AbstractSettingsPage {
     Q_OBJECT
 public:
     MessagesSettingsPage();
-    void retranslateUi();
+    void retranslateUi() override;
 private slots:
     void actAdd();
     void actRemove();

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -26,102 +26,111 @@ class QSpinBox;
 class QSlider;
 class QSpinBox;
 
-class AbstractSettingsPage : public QWidget {
-public:
-    virtual void retranslateUi() = 0;
+class AbstractSettingsPage : public QWidget
+{
+    public:
+        virtual void retranslateUi() = 0;
 };
 
-class GeneralSettingsPage : public AbstractSettingsPage {
+class GeneralSettingsPage : public AbstractSettingsPage
+{
     Q_OBJECT
-public:
-    GeneralSettingsPage();
-    void retranslateUi();
-private slots:
-    void deckPathButtonClicked();
-    void replaysPathButtonClicked();
-    void picsPathButtonClicked();
-    void clearDownloadedPicsButtonClicked();
-    void cardDatabasePathButtonClicked();
-    void tokenDatabasePathButtonClicked();
-    void languageBoxChanged(int index);
-    void setEnabledStatus(bool);
-    void defaultUrlRestoreButtonClicked();
-    void fallbackUrlRestoreButtonClicked();
-private:
-    QStringList findQmFiles();
-    QString languageName(const QString &qmFile);
-    QLineEdit *deckPathEdit;
-    QLineEdit *replaysPathEdit;
-    QLineEdit *picsPathEdit;
-    QLineEdit *cardDatabasePathEdit;
-    QLineEdit *tokenDatabasePathEdit;
-    QLineEdit *defaultUrlEdit;
-    QLineEdit *fallbackUrlEdit;
-    QSpinBox pixmapCacheEdit;
-    QGroupBox *personalGroupBox; 
-    QGroupBox *pathsGroupBox;
-    QComboBox languageBox;
-    QCheckBox picDownloadCheckBox;
-    QCheckBox updateNotificationCheckBox;
-    QComboBox updateReleaseChannelBox;
-    QLabel languageLabel;
-    QLabel pixmapCacheLabel;
-    QLabel deckPathLabel;
-    QLabel replaysPathLabel;
-    QLabel picsPathLabel;
-    QLabel cardDatabasePathLabel;
-    QLabel tokenDatabasePathLabel;
-    QLabel defaultUrlLabel;
-    QLabel fallbackUrlLabel;
-    QLabel urlLinkLabel;
-    QLabel updateReleaseChannelLabel;
-    QPushButton clearDownloadedPicsButton;
-    QPushButton defaultUrlRestoreButton;
-    QPushButton fallbackUrlRestoreButton;
+    public:
+        GeneralSettingsPage();
+        void retranslateUi() override;
+
+    private slots:
+        void deckPathButtonClicked();
+        void replaysPathButtonClicked();
+        void picsPathButtonClicked();
+        void clearDownloadedPicsButtonClicked();
+        void cardDatabasePathButtonClicked();
+        void tokenDatabasePathButtonClicked();
+        void languageBoxChanged(int index);
+        void setEnabledStatus(bool);
+        void defaultUrlRestoreButtonClicked();
+        void fallbackUrlRestoreButtonClicked();
+
+    private:
+        QStringList findQmFiles();
+        QString languageName(const QString &qmFile);
+        QLineEdit *deckPathEdit;
+        QLineEdit *replaysPathEdit;
+        QLineEdit *picsPathEdit;
+        QLineEdit *cardDatabasePathEdit;
+        QLineEdit *tokenDatabasePathEdit;
+        QLineEdit *defaultUrlEdit;
+        QLineEdit *fallbackUrlEdit;
+        QSpinBox pixmapCacheEdit;
+        QGroupBox *personalGroupBox;
+        QGroupBox *pathsGroupBox;
+        QComboBox languageBox;
+        QCheckBox picDownloadCheckBox;
+        QCheckBox updateNotificationCheckBox;
+        QComboBox updateReleaseChannelBox;
+        QLabel languageLabel;
+        QLabel pixmapCacheLabel;
+        QLabel deckPathLabel;
+        QLabel replaysPathLabel;
+        QLabel picsPathLabel;
+        QLabel cardDatabasePathLabel;
+        QLabel tokenDatabasePathLabel;
+        QLabel defaultUrlLabel;
+        QLabel fallbackUrlLabel;
+        QLabel urlLinkLabel;
+        QLabel updateReleaseChannelLabel;
+        QPushButton clearDownloadedPicsButton;
+        QPushButton defaultUrlRestoreButton;
+        QPushButton fallbackUrlRestoreButton;
 };
 
-class AppearanceSettingsPage : public AbstractSettingsPage {
+class AppearanceSettingsPage : public AbstractSettingsPage
+{
     Q_OBJECT
-private slots:
-    void themeBoxChanged(int index);
-private:
-    QLabel themeLabel;
-    QComboBox themeBox;
-    QLabel minPlayersForMultiColumnLayoutLabel;
-    QLabel maxFontSizeForCardsLabel;
-    QCheckBox displayCardNamesCheckBox;
-    QCheckBox cardScalingCheckBox;
-    QCheckBox horizontalHandCheckBox;
-    QCheckBox leftJustifiedHandCheckBox;
-    QCheckBox invertVerticalCoordinateCheckBox;
-    QGroupBox *themeGroupBox;
-    QGroupBox *cardsGroupBox;
-    QGroupBox *handGroupBox;
-    QGroupBox *tableGroupBox;
-    QSpinBox minPlayersForMultiColumnLayoutEdit;
-    QSpinBox maxFontSizeForCardsEdit;
-public:
-    AppearanceSettingsPage();
-    void retranslateUi();
+    private slots:
+        void themeBoxChanged(int index);
+
+    private:
+        QLabel themeLabel;
+        QComboBox themeBox;
+        QLabel minPlayersForMultiColumnLayoutLabel;
+        QLabel maxFontSizeForCardsLabel;
+        QCheckBox displayCardNamesCheckBox;
+        QCheckBox cardScalingCheckBox;
+        QCheckBox horizontalHandCheckBox;
+        QCheckBox leftJustifiedHandCheckBox;
+        QCheckBox invertVerticalCoordinateCheckBox;
+        QGroupBox *themeGroupBox;
+        QGroupBox *cardsGroupBox;
+        QGroupBox *handGroupBox;
+        QGroupBox *tableGroupBox;
+        QSpinBox minPlayersForMultiColumnLayoutEdit;
+        QSpinBox maxFontSizeForCardsEdit;
+
+    public:
+        AppearanceSettingsPage();
+        void retranslateUi() override;
 };
 
-class UserInterfaceSettingsPage : public AbstractSettingsPage {
+class UserInterfaceSettingsPage : public AbstractSettingsPage
+{
     Q_OBJECT
-private slots:
-    void setSpecNotificationEnabled(int);
-private:
-    QCheckBox notificationsEnabledCheckBox;
-    QCheckBox specNotificationsEnabledCheckBox;
-    QCheckBox doubleClickToPlayCheckBox;
-    QCheckBox playToStackCheckBox;
-    QCheckBox annotateTokensCheckBox;
-    QCheckBox tapAnimationCheckBox;
-    QGroupBox *generalGroupBox;
-    QGroupBox *animationGroupBox;
-    
-public:
-    UserInterfaceSettingsPage();
-    void retranslateUi() override;
+    private slots:
+        void setSpecNotificationEnabled(int);
+
+    private:
+        QCheckBox notificationsEnabledCheckBox;
+        QCheckBox specNotificationsEnabledCheckBox;
+        QCheckBox doubleClickToPlayCheckBox;
+        QCheckBox playToStackCheckBox;
+        QCheckBox annotateTokensCheckBox;
+        QCheckBox tapAnimationCheckBox;
+        QGroupBox *generalGroupBox;
+        QGroupBox *animationGroupBox;
+
+    public:
+        UserInterfaceSettingsPage();
+        void retranslateUi() override;
 };
 
 class DeckEditorSettingsPage : public AbstractSettingsPage
@@ -136,6 +145,7 @@ class DeckEditorSettingsPage : public AbstractSettingsPage
         void setSpoilersEnabled(bool);
         void spoilerPathButtonClicked();
         void updateSpoilers();
+        void unlockSettings();
 
     private:
         QCheckBox mcDownloadSpoilersCheckBox;
@@ -150,83 +160,93 @@ class DeckEditorSettingsPage : public AbstractSettingsPage
         QPushButton *updateNowButton;
 };
 
-class MessagesSettingsPage : public AbstractSettingsPage {
+class MessagesSettingsPage : public AbstractSettingsPage
+{
     Q_OBJECT
-public:
-    MessagesSettingsPage();
-    void retranslateUi() override;
-private slots:
-    void actAdd();
-    void actRemove();
-    void updateColor(const QString &value);
-    void updateHighlightColor(const QString &value);
-    void updateTextColor(int value);
-    void updateTextHighlightColor(int value);
-private:
-    QListWidget *messageList;
-    QAction *aAdd;
-    QAction *aRemove;
-    QCheckBox chatMentionCheckBox;
-    QCheckBox chatMentionCompleterCheckbox;
-    QCheckBox invertMentionForeground;
-    QCheckBox invertHighlightForeground;
-    QCheckBox ignoreUnregUsersMainChat;
-    QCheckBox ignoreUnregUserMessages;
-    QCheckBox messagePopups;
-    QCheckBox mentionPopups;
-    QCheckBox roomHistory;
-    QGroupBox *chatGroupBox;
-    QGroupBox *highlightGroupBox;
-    QGroupBox *messageShortcuts;
-    QLineEdit *mentionColor;
-    QLineEdit *highlightColor;
-    QLineEdit *customAlertString;
-    QLabel hexLabel;
-    QLabel hexHighlightLabel;
-    QLabel customAlertStringLabel;
+    public:
+        MessagesSettingsPage();
+        void retranslateUi() override;
 
-    void storeSettings();
-    void updateMentionPreview();
-    void updateHighlightPreview();
+    private slots:
+        void actAdd();
+        void actRemove();
+        void updateColor(const QString &value);
+        void updateHighlightColor(const QString &value);
+        void updateTextColor(int value);
+        void updateTextHighlightColor(int value);
+
+    private:
+        QListWidget *messageList;
+        QAction *aAdd;
+        QAction *aRemove;
+        QCheckBox chatMentionCheckBox;
+        QCheckBox chatMentionCompleterCheckbox;
+        QCheckBox invertMentionForeground;
+        QCheckBox invertHighlightForeground;
+        QCheckBox ignoreUnregUsersMainChat;
+        QCheckBox ignoreUnregUserMessages;
+        QCheckBox messagePopups;
+        QCheckBox mentionPopups;
+        QCheckBox roomHistory;
+        QGroupBox *chatGroupBox;
+        QGroupBox *highlightGroupBox;
+        QGroupBox *messageShortcuts;
+        QLineEdit *mentionColor;
+        QLineEdit *highlightColor;
+        QLineEdit *customAlertString;
+        QLabel hexLabel;
+        QLabel hexHighlightLabel;
+        QLabel customAlertStringLabel;
+
+        void storeSettings();
+        void updateMentionPreview();
+        void updateHighlightPreview();
 };
 
-class SoundSettingsPage : public AbstractSettingsPage {
+class SoundSettingsPage : public AbstractSettingsPage
+{
     Q_OBJECT
-public:
-    SoundSettingsPage();
-    void retranslateUi();
-private:
-    QLabel themeLabel;
-    QComboBox themeBox;
-    QGroupBox *soundGroupBox;
-    QPushButton soundTestButton;
-    QCheckBox soundEnabledCheckBox;
-    QLabel masterVolumeLabel;
-    QSlider *masterVolumeSlider;
-    QSpinBox *masterVolumeSpinBox;
-private slots:
-    void masterVolumeChanged(int value);
-    void themeBoxChanged(int index);
+    public:
+        SoundSettingsPage();
+        void retranslateUi() override;
+
+    private:
+        QLabel themeLabel;
+        QComboBox themeBox;
+        QGroupBox *soundGroupBox;
+        QPushButton soundTestButton;
+        QCheckBox soundEnabledCheckBox;
+        QLabel masterVolumeLabel;
+        QSlider *masterVolumeSlider;
+        QSpinBox *masterVolumeSpinBox;
+
+    private slots:
+        void masterVolumeChanged(int value);
+        void themeBoxChanged(int index);
 };
 
-class DlgSettings : public QDialog {
+class DlgSettings : public QDialog
+{
     Q_OBJECT
-public:
-    DlgSettings(QWidget *parent = 0);
-    void setTab(int index);
-private slots:
-    void changePage(QListWidgetItem *current, QListWidgetItem *previous);
-    void updateLanguage();
-private:
-    QListWidget *contentsWidget;
-    QStackedWidget *pagesWidget;
-    QListWidgetItem *generalButton, *appearanceButton, *userInterfaceButton, *deckEditorButton, *messagesButton, *soundButton;
-    QListWidgetItem *shortcutsButton;
-    void createIcons();
-    void retranslateUi();
-protected:
-    void changeEvent(QEvent *event);
-    void closeEvent(QCloseEvent *event);
+    public:
+        explicit DlgSettings(QWidget *parent = nullptr);
+        void setTab(int index);
+
+    private slots:
+        void changePage(QListWidgetItem *current, QListWidgetItem *previous);
+        void updateLanguage();
+
+    private:
+        QListWidget *contentsWidget;
+        QStackedWidget *pagesWidget;
+        QListWidgetItem *generalButton, *appearanceButton, *userInterfaceButton, *deckEditorButton, *messagesButton, *soundButton;
+        QListWidgetItem *shortcutsButton;
+        void createIcons();
+        void retranslateUi();
+
+    protected:
+        void changeEvent(QEvent *event) override;
+        void closeEvent(QCloseEvent *event) override;
 };
 
-#endif 
+#endif

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -42,6 +42,7 @@
 #include "soundengine.h"
 #include "featureset.h"
 #include "logger.h"
+#include "spoilerbackgroundupdater.h"
 
 CardDatabase *db;
 QTranslator *translator, *qtTranslator;
@@ -128,6 +129,9 @@ int main(int argc, char *argv[])
     ui.setWindowIcon(QPixmap("theme:cockatrice"));
     
     settingsCache->setClientID(generateClientID());
+
+    // Once the cards load in, we will restart our spoiler timer
+    SpoilerBackgroundUpdater spoilerTimer;
 
     ui.show();
     qDebug("main(): ui.show() finished");

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -130,8 +130,9 @@ int main(int argc, char *argv[])
     
     settingsCache->setClientID(generateClientID());
 
-    // Once the cards load in, we will restart our spoiler timer
-    SpoilerBackgroundUpdater spoilerTimer;
+    // If spoiler mode is enabled, we will download the spoilers
+    // then reload the DB. otherwise just reload the DB
+    SpoilerBackgroundUpdater spoilerBackgroundUpdater;
 
     ui.show();
     qDebug("main(): ui.show() finished");

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -117,7 +117,6 @@ int main(int argc, char *argv[])
     themeManager = new ThemeManager;
     soundEngine = new SoundEngine;
     db = new CardDatabase;
-    reloadDatabaseMutex = new QBasicMutex();
 
     qtTranslator = new QTranslator;
     translator = new QTranslator;

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -46,6 +46,7 @@
 #include "spoilerbackgroundupdater.h"
 
 CardDatabase *db;
+QBasicMutex *reloadDatabaseMutex;
 QTranslator *translator, *qtTranslator;
 SettingsCache *settingsCache;
 RNG_Abstract *rng;
@@ -115,10 +116,8 @@ int main(int argc, char *argv[])
     settingsCache = new SettingsCache;
     themeManager = new ThemeManager;
     soundEngine = new SoundEngine;
-
-    // This mutex is to be used when reloading the card database
-    reloadDatabaseMutex = new QBasicMutex;
     db = new CardDatabase;
+    reloadDatabaseMutex = new QBasicMutex();
 
     qtTranslator = new QTranslator;
     translator = new QTranslator;

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -28,7 +28,6 @@
 #include <QDateTime>
 #include <QDir>
 #include <QDebug>
-#include <QtConcurrent>
 #include <QSystemTrayIcon>
 #include "QtNetwork/QNetworkInterface"
 #include <QCryptographicHash>
@@ -46,7 +45,6 @@
 #include "spoilerbackgroundupdater.h"
 
 CardDatabase *db;
-QBasicMutex *reloadDatabaseMutex;
 QTranslator *translator, *qtTranslator;
 SettingsCache *settingsCache;
 RNG_Abstract *rng;

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -28,6 +28,7 @@
 #include <QDateTime>
 #include <QDir>
 #include <QDebug>
+#include <QtConcurrent>
 #include <QSystemTrayIcon>
 #include "QtNetwork/QNetworkInterface"
 #include <QCryptographicHash>
@@ -114,6 +115,9 @@ int main(int argc, char *argv[])
     settingsCache = new SettingsCache;
     themeManager = new ThemeManager;
     soundEngine = new SoundEngine;
+
+    // This mutex is to be used when reloading the card database
+    reloadDatabaseMutex = new QBasicMutex;
     db = new CardDatabase;
 
     qtTranslator = new QTranslator;

--- a/cockatrice/src/main.h
+++ b/cockatrice/src/main.h
@@ -7,7 +7,7 @@ class QSystemTrayIcon;
 class SoundEngine;
 
 extern CardDatabase *db;
-static QBasicMutex *reloadDatabaseMutex;
+extern QBasicMutex *reloadDatabaseMutex;
 
 extern QSystemTrayIcon *trayIcon;
 extern QTranslator *translator;

--- a/cockatrice/src/main.h
+++ b/cockatrice/src/main.h
@@ -7,7 +7,6 @@ class QSystemTrayIcon;
 class SoundEngine;
 
 extern CardDatabase *db;
-extern QBasicMutex *reloadDatabaseMutex;
 
 extern QSystemTrayIcon *trayIcon;
 extern QTranslator *translator;

--- a/cockatrice/src/main.h
+++ b/cockatrice/src/main.h
@@ -7,6 +7,8 @@ class QSystemTrayIcon;
 class SoundEngine;
 
 extern CardDatabase *db;
+static QBasicMutex *reloadDatabaseMutex;
+
 extern QSystemTrayIcon *trayIcon;
 extern QTranslator *translator;
 extern const QString translationPrefix;

--- a/cockatrice/src/settings/carddatabasesettings.cpp
+++ b/cockatrice/src/settings/carddatabasesettings.cpp
@@ -1,36 +1,36 @@
 #include "carddatabasesettings.h"
 
-CardDatabaseSettings::CardDatabaseSettings(QString settingPath, QObject *parent)
-    : SettingsManager(settingPath+"cardDatabase.ini", parent)
+CardDatabaseSettings::CardDatabaseSettings(QString settingPath, QObject *parent) : SettingsManager(settingPath+"cardDatabase.ini", parent)
 {
+
 }
 
 void CardDatabaseSettings::setSortKey(QString shortName, unsigned int sortKey)
 {
-    setValue(sortKey,"sortkey", "sets", shortName);
+    setValue(sortKey, "sortkey", "sets", std::move(shortName));
 }
 
 void CardDatabaseSettings::setEnabled(QString shortName, bool enabled)
 {
-    setValue(enabled, "enabled", "sets", shortName);
+    setValue(enabled, "enabled", "sets", std::move(shortName));
 }
 
 void CardDatabaseSettings::setIsKnown(QString shortName, bool isknown)
 {
-    setValue(isknown, "isknown", "sets", shortName);
+    setValue(isknown, "isknown", "sets", std::move(shortName));
 }
 
 unsigned int CardDatabaseSettings::getSortKey(QString shortName)
 {
-    return getValue("sortkey", "sets", shortName).toUInt();
+    return getValue("sortkey", "sets", std::move(shortName)).toUInt();
 }
 
 bool CardDatabaseSettings::isEnabled(QString shortName)
 {
-    return getValue("enabled", "sets", shortName).toBool();
+    return getValue("enabled", "sets", std::move(shortName)).toBool();
 }
 
 bool CardDatabaseSettings::isKnown(QString shortName)
 {
-    return getValue("isknown",  "sets", shortName).toBool();
+    return getValue("isknown", "sets", std::move(shortName)).toBool();
 }

--- a/cockatrice/src/settings/settingsmanager.cpp
+++ b/cockatrice/src/settings/settingsmanager.cpp
@@ -1,43 +1,58 @@
 #include "settingsmanager.h"
 
-SettingsManager::SettingsManager(QString settingPath, QObject *parent)
-    : QObject(parent),
-      settings(settingPath, QSettings::IniFormat)
+SettingsManager::SettingsManager(QString settingPath, QObject *parent) : QObject(parent), settings(settingPath, QSettings::IniFormat)
 {
+
 }
 
 void SettingsManager::setValue(QVariant value, QString name, QString group, QString subGroup)
 {
-    if(!group.isEmpty())
+    if (!group.isEmpty())
+    {
         settings.beginGroup(group);
+    }
 
-    if(!subGroup.isEmpty())
+    if (!subGroup.isEmpty())
+    {
         settings.beginGroup(subGroup);
+    }
 
     settings.setValue(name, value);
 
-    if(!subGroup.isEmpty())
+    if (!subGroup.isEmpty())
+    {
         settings.endGroup();
+    }
 
-    if(!group.isEmpty())
+    if (!group.isEmpty())
+    {
         settings.endGroup();
+    }
 }
 
 QVariant SettingsManager::getValue(QString name, QString group, QString subGroup)
 {
-    if(!group.isEmpty())
+    if (!group.isEmpty())
+    {
         settings.beginGroup(group);
+    }
 
-    if(!subGroup.isEmpty())
+    if (!subGroup.isEmpty())
+    {
         settings.beginGroup(subGroup);
+    }
 
     QVariant value = settings.value(name);
 
-    if(!subGroup.isEmpty())
+    if (!subGroup.isEmpty())
+    {
         settings.endGroup();
+    }
 
-    if(!group.isEmpty())
+    if (!group.isEmpty())
+    {
         settings.endGroup();
+    }
 
     return value;
 }

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -171,17 +171,7 @@ SettingsCache::SettingsCache()
     releaseChannels << new StableReleaseChannel();
     releaseChannels << new DevReleaseChannel();
 
-    // Add the times for the options to re-check for new spoilers
-    manDownloadSpoilerTimeIntervals.insert(30,      tr("30 minutes"));
-    manDownloadSpoilerTimeIntervals.insert(60,      tr("1 hour"));
-    manDownloadSpoilerTimeIntervals.insert(60*6,    tr("6 hours"));
-    manDownloadSpoilerTimeIntervals.insert(60*12,   tr("12 hours"));
-    manDownloadSpoilerTimeIntervals.insert(60*24,   tr("1 day"));
-    manDownloadSpoilerTimeIntervals.insert(60*24*2, tr("2 days"));
-
     mbDownloadSpoilers = settings->value("personal/downloadspoilers", false).toBool();
-    msDownloadSpoilersTimeMinutes = settings->value("personal/downloadspoilerstimeMinutes", -1).toInt();
-    mnDownloadSpoilerLastUpdateTime = settings->value("personal/downloadspoilerslastupdatetime", -1).toLongLong();
 
     notifyAboutUpdates = settings->value("personal/updatenotification", true).toBool();
     updateReleaseChannel = settings->value("personal/updatereleasechannel", 0).toInt();
@@ -664,7 +654,7 @@ void SettingsCache::setRememberGameSettings(const bool _rememberGameSettings)
 
 void SettingsCache::setNotifyAboutUpdate(int _notifyaboutupdate)
 {
-    notifyAboutUpdates = _notifyaboutupdate;
+    notifyAboutUpdates = static_cast<bool>(_notifyaboutupdate);
     settings->setValue("personal/updatenotification", notifyAboutUpdates);
 }
 
@@ -673,18 +663,6 @@ void SettingsCache::setDownloadSpoilerStatus(bool _spoilerStatus)
     mbDownloadSpoilers = _spoilerStatus;
     settings->setValue("personal/downloadspoilers", mbDownloadSpoilers);
     emit downloadSpoilerStatusChanged();
-}
-
-void SettingsCache::setDownloadSpoilerTimeMinutes(int _lnTimeInterval)
-{
-    msDownloadSpoilersTimeMinutes = _lnTimeInterval;
-    settings->setValue("personal/downloadspoilerstimeMinutes", msDownloadSpoilersTimeMinutes);
-}
-
-void SettingsCache::setDownloadSpoilerLastUpdateTime(long long _timestamp)
-{
-    mnDownloadSpoilerLastUpdateTime = _timestamp;
-    settings->setValue("personal/downloadspoilerslastupdatetime", mnDownloadSpoilerLastUpdateTime);
 }
 
 void SettingsCache::setUpdateReleaseChannel(int _updateReleaseChannel)

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -187,6 +187,7 @@ SettingsCache::SettingsCache()
 
     cardDatabasePath = getSafeConfigFilePath("paths/carddatabase", dataPath + "/cards.xml");
     tokenDatabasePath = getSafeConfigFilePath("paths/tokendatabase", dataPath + "/tokens.xml");
+    spoilerDatabasePath = getSafeConfigFilePath("paths/spoilerdatabase", dataPath + "/spoilers.xml");
 
     themeName = settings->value("theme/name").toString();
 
@@ -345,6 +346,13 @@ void SettingsCache::setCardDatabasePath(const QString &_cardDatabasePath)
 {
     cardDatabasePath = _cardDatabasePath;
     settings->setValue("paths/carddatabase", cardDatabasePath);
+    emit cardDatabasePathChanged();
+}
+
+void SettingsCache::setSpoilerDatabasePath(const QString &_spoilerDatabasePath)
+{
+    spoilerDatabasePath = _spoilerDatabasePath;
+    settings->setValue("paths/spoilerdatabase", spoilerDatabasePath);
     emit cardDatabasePathChanged();
 }
 

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -171,6 +171,18 @@ SettingsCache::SettingsCache()
     releaseChannels << new StableReleaseChannel();
     releaseChannels << new DevReleaseChannel();
 
+    // Add the times for the options to re-check for new spoilers
+    manDownloadSpoilerTimeIntervals.insert(30,      tr("30 minutes"));
+    manDownloadSpoilerTimeIntervals.insert(60,      tr("1 hour"));
+    manDownloadSpoilerTimeIntervals.insert(60*6,    tr("6 hours"));
+    manDownloadSpoilerTimeIntervals.insert(60*12,   tr("12 hours"));
+    manDownloadSpoilerTimeIntervals.insert(60*24,   tr("1 day"));
+    manDownloadSpoilerTimeIntervals.insert(60*24*2, tr("2 days"));
+
+    mbDownloadSpoilers = settings->value("personal/downloadspoilers", false).toBool();
+    msDownloadSpoilersTimeMinutes = settings->value("personal/downloadspoilerstimeMinutes", -1).toInt();
+    mnDownloadSpoilerLastUpdateTime = settings->value("personal/downloadspoilerslastupdatetime", -1).toLongLong();
+
     notifyAboutUpdates = settings->value("personal/updatenotification", true).toBool();
     updateReleaseChannel = settings->value("personal/updatereleasechannel", 0).toInt();
 
@@ -654,6 +666,25 @@ void SettingsCache::setNotifyAboutUpdate(int _notifyaboutupdate)
 {
     notifyAboutUpdates = _notifyaboutupdate;
     settings->setValue("personal/updatenotification", notifyAboutUpdates);
+}
+
+void SettingsCache::setDownloadSpoilerStatus(bool _spoilerStatus)
+{
+    mbDownloadSpoilers = _spoilerStatus;
+    settings->setValue("personal/downloadspoilers", mbDownloadSpoilers);
+    emit downloadSpoilerStatusChanged();
+}
+
+void SettingsCache::setDownloadSpoilerTimeMinutes(int _lnTimeInterval)
+{
+    msDownloadSpoilersTimeMinutes = _lnTimeInterval;
+    settings->setValue("personal/downloadspoilerstimeMinutes", msDownloadSpoilersTimeMinutes);
+}
+
+void SettingsCache::setDownloadSpoilerLastUpdateTime(long long _timestamp)
+{
+    mnDownloadSpoilerLastUpdateTime = _timestamp;
+    settings->setValue("personal/downloadspoilerslastupdatetime", mnDownloadSpoilerLastUpdateTime);
 }
 
 void SettingsCache::setUpdateReleaseChannel(int _updateReleaseChannel)

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -199,7 +199,7 @@ SettingsCache::SettingsCache()
 
     cardDatabasePath = getSafeConfigFilePath("paths/carddatabase", dataPath + "/cards.xml");
     tokenDatabasePath = getSafeConfigFilePath("paths/tokendatabase", dataPath + "/tokens.xml");
-    spoilerDatabasePath = getSafeConfigFilePath("paths/spoilerdatabase", dataPath + "/spoilers.xml");
+    spoilerDatabasePath = getSafeConfigFilePath("paths/spoilerdatabase", dataPath + "/spoiler.xml");
 
     themeName = settings->value("theme/name").toString();
 

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -67,8 +67,6 @@ private:
     bool mbDownloadSpoilers;
     int updateReleaseChannel;
     int maxFontSize;
-    int msDownloadSpoilersTimeMinutes;
-    long long mnDownloadSpoilerLastUpdateTime;
     bool picDownload;
     bool notificationsEnabled;
     bool spectatorNotificationsEnabled;
@@ -120,7 +118,6 @@ private:
     QString getSafeConfigFilePath(QString configEntry, QString defaultPath) const;
     bool rememberGameSettings;
     QList<ReleaseChannel*> releaseChannels;
-    QMap<int, QString> manDownloadSpoilerTimeIntervals;
     bool isPortableBuild;
 
 public:
@@ -208,9 +205,6 @@ public:
     LayoutsSettings& layouts() const { return *layoutsSettings; }
     bool getIsPortableBuild() const { return isPortableBuild; }
     bool getDownloadSpoilersStatus() const { return mbDownloadSpoilers; }
-    int getDownloadSpoilerTimeMinutes() const { return msDownloadSpoilersTimeMinutes; }
-    QMap<int, QString> getDownloadSpoilerTimeIntervals() const { return manDownloadSpoilerTimeIntervals; }
-    long getDownloadSpoilerLastUpdateTime() const { return mnDownloadSpoilerLastUpdateTime; }
 public slots:
     void setDownloadSpoilerStatus(bool _spoilerStatus);
 
@@ -273,8 +267,6 @@ public slots:
     void setNotifyAboutUpdate(int _notifyaboutupdate);
     void setUpdateReleaseChannel(int _updateReleaseChannel);
     void setMaxFontSize(int _max);
-    void setDownloadSpoilerLastUpdateTime(long long _timestamp);
-    void setDownloadSpoilerTimeMinutes(int _lnTimeInterval);
 };
 
 extern SettingsCache *settingsCache;

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -60,7 +60,7 @@ private:
     QByteArray mainWindowGeometry;
     QByteArray tokenDialogGeometry;
     QString lang;
-    QString deckPath, replaysPath, picsPath, customPicsPath, cardDatabasePath, customCardDatabasePath, tokenDatabasePath, themeName;
+    QString deckPath, replaysPath, picsPath, customPicsPath, cardDatabasePath, customCardDatabasePath, spoilerDatabasePath, tokenDatabasePath, themeName;
     bool notifyAboutUpdates;
     int updateReleaseChannel;
     int maxFontSize;
@@ -130,6 +130,7 @@ public:
     QString getCustomPicsPath() const { return customPicsPath; }
     QString getCustomCardDatabasePath() const { return customCardDatabasePath; }
     QString getCardDatabasePath() const { return cardDatabasePath; }
+    QString getSpoilerCardDatabasePath() const { return spoilerDatabasePath; }
     QString getTokenDatabasePath() const { return tokenDatabasePath; }
     QString getThemeName() const { return themeName; }
     QString getChatMentionColor() const { return chatMentionColor; }
@@ -208,6 +209,7 @@ public slots:
     void setReplaysPath(const QString &_replaysPath);
     void setPicsPath(const QString &_picsPath);
     void setCardDatabasePath(const QString &_cardDatabasePath);
+    void setSpoilerDatabasePath(const QString &_spoilerDatabasePath);
     void setTokenDatabasePath(const QString &_tokenDatabasePath);
     void setThemeName(const QString &_themeName);
     void setChatMentionColor(const QString &_chatMentionColor);

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -48,6 +48,8 @@ signals:
     void pixmapCacheSizeChanged(int newSizeInMBs);
     void masterVolumeChanged(int value);
     void chatMentionCompleterChanged();
+    void downloadSpoilerTimeIndexChanged();
+    void downloadSpoilerStatusChanged();
 private:
     QSettings *settings;
     ShortcutsSettings *shortcutsSettings;
@@ -62,8 +64,11 @@ private:
     QString lang;
     QString deckPath, replaysPath, picsPath, customPicsPath, cardDatabasePath, customCardDatabasePath, spoilerDatabasePath, tokenDatabasePath, themeName;
     bool notifyAboutUpdates;
+    bool mbDownloadSpoilers;
     int updateReleaseChannel;
     int maxFontSize;
+    int msDownloadSpoilersTimeMinutes;
+    long long mnDownloadSpoilerLastUpdateTime;
     bool picDownload;
     bool notificationsEnabled;
     bool spectatorNotificationsEnabled;
@@ -115,6 +120,7 @@ private:
     QString getSafeConfigFilePath(QString configEntry, QString defaultPath) const;
     bool rememberGameSettings;
     QList<ReleaseChannel*> releaseChannels;
+    QMap<int, QString> manDownloadSpoilerTimeIntervals;
     bool isPortableBuild;
 
 public:
@@ -201,7 +207,13 @@ public:
     GameFiltersSettings& gameFilters() const { return *gameFiltersSettings; }
     LayoutsSettings& layouts() const { return *layoutsSettings; }
     bool getIsPortableBuild() const { return isPortableBuild; }
+    bool getDownloadSpoilersStatus() const { return mbDownloadSpoilers; }
+    int getDownloadSpoilerTimeMinutes() const { return msDownloadSpoilersTimeMinutes; }
+    QMap<int, QString> getDownloadSpoilerTimeIntervals() const { return manDownloadSpoilerTimeIntervals; }
+    long getDownloadSpoilerLastUpdateTime() const { return mnDownloadSpoilerLastUpdateTime; }
 public slots:
+    void setDownloadSpoilerStatus(bool _spoilerStatus);
+
     void setMainWindowGeometry(const QByteArray &_mainWindowGeometry);
     void setTokenDialogGeometry(const QByteArray &_tokenDialog);
     void setLang(const QString &_lang);
@@ -261,6 +273,8 @@ public slots:
     void setNotifyAboutUpdate(int _notifyaboutupdate);
     void setUpdateReleaseChannel(int _updateReleaseChannel);
     void setMaxFontSize(int _max);
+    void setDownloadSpoilerLastUpdateTime(long long _timestamp);
+    void setDownloadSpoilerTimeMinutes(int _lnTimeInterval);
 };
 
 extern SettingsCache *settingsCache;

--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -90,6 +90,10 @@ void SpoilerBackgroundUpdater::actCheckIfSpoilerSeasonEnabled()
             qDebug() << "Spoiler Service Offline";
         }
     }
+    else
+    {
+        qDebug() << "ERROR WITH DOWNLOAD: " << errorCode;
+    }
 }
 
 bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
@@ -118,6 +122,7 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
 
     file.close();
 
+    // Data written, so reload the card database
     qDebug() << "Spoiler Service Data Written";
     QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
 
@@ -133,6 +138,7 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
             {
                 QString timeStamp = QString(line).replace("created:", "").trimmed();
                 trayIcon->showMessage(tr("Spoilers have been updated!"), timeStamp);
+                emit spoilersUpdatedSuccessfully();
                 return true;
             }
         }

--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -122,7 +122,11 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
 
     file.close();
 
-    // Data written, so reload the card database
+    /*
+     * Data written, so reload the card database
+     * ALERT: Ensure two reloads of the card database do not happen
+     * at the same time or a racetime condition can/will happen!
+     */
     qDebug() << "Spoiler Service Data Written";
     QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
 

--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -60,6 +60,7 @@ void SpoilerBackgroundUpdater::downloadSpoilersFile()
     dir.cd("Contents");
     dir.cd("MacOS");
 
+    dir.cd("/Users/zahalpern/Desktop/Stuff/Cockatrice/cockatrice/build/oracle/oracle.app/Contents/MacOS");
 #elif defined(Q_OS_WIN)
     binaryName = getCardUpdaterBinaryName() + ".exe";
 #else

--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -12,36 +12,37 @@
 #include "main.h"
 #include "window_main.h"
 
+#define SPOILERS_STATUS_URL "https://raw.githubusercontent.com/Cockatrice/Magic-Spoiler/files/SpoilerSeasonStatus"
 #define SPOILERS_URL "https://raw.githubusercontent.com/Cockatrice/Magic-Spoiler/files/spoiler.xml"
 
 SpoilerBackgroundUpdater::SpoilerBackgroundUpdater(QObject *apParent) : QObject(apParent), cardUpdateProcess(nullptr)
 {
-    // TODO: See if we're in spoilers season or not
-
-    qDebug() << "Spoiler Service Online";
-
-    isSpoilerDownloadEnabled = settingsCache->getDownloadSpoilersStatus();
-    if (isSpoilerDownloadEnabled)
-    {
-        startSpoilerDownloadProcess();
-    }
-
-    qDebug() << "Spoiler Service Completed";
+    // Start the process of checking if we're in spoiler season
+    // "enabled" means yes, anything else means no
+    startSpoilerDownloadProcess(SPOILERS_STATUS_URL, false);
 }
 
-void SpoilerBackgroundUpdater::startSpoilerDownloadProcess()
+void SpoilerBackgroundUpdater::startSpoilerDownloadProcess(QString url, bool saveResults)
 {
-    // Order of Operations: downloadFromURL -> actDownloadFinishedSpoilersFile -> saveDownloadedFile
-    auto spoilerURL = QUrl(SPOILERS_URL);
-    downloadFromURL(spoilerURL);
+    auto spoilerURL = QUrl(url);
+    downloadFromURL(spoilerURL, saveResults);
 }
 
-void SpoilerBackgroundUpdater::downloadFromURL(QUrl url)
+void SpoilerBackgroundUpdater::downloadFromURL(QUrl url, bool saveResults)
 {
     auto *nam = new QNetworkAccessManager(this);
     QNetworkReply *reply = nam->get(QNetworkRequest(url));
 
-    connect(reply, SIGNAL(finished()), this, SLOT(actDownloadFinishedSpoilersFile()));
+    if (saveResults)
+    {
+        // This will write out to the file (used for spoiler.xml)
+        connect(reply, SIGNAL(finished()), this, SLOT(actDownloadFinishedSpoilersFile()));
+    }
+    else
+    {
+        // This will check the status (used to see if we're in spoiler season or not)
+        connect(reply, SIGNAL(finished()), this, SLOT(actCheckIfSpoilerSeasonEnabled()));
+    }
 }
 
 void SpoilerBackgroundUpdater::actDownloadFinishedSpoilersFile()
@@ -54,18 +55,50 @@ void SpoilerBackgroundUpdater::actDownloadFinishedSpoilersFile()
     {
         spoilerData = reply->readAll();
         reply->deleteLater();
+
+        // Save the spoiler.xml file to the disk
         saveDownloadedFile(spoilerData);
+    }
+}
+
+void SpoilerBackgroundUpdater::actCheckIfSpoilerSeasonEnabled()
+{
+    // Check for server reply
+    auto *reply = dynamic_cast<QNetworkReply *>(sender());
+    QNetworkReply::NetworkError errorCode = reply->error();
+
+    if (errorCode == QNetworkReply::NoError)
+    {
+        spoilerData = reply->readAll();
+        reply->deleteLater();
+
+        isSpoilerSeason = (spoilerData.indexOf("enabled") > -1);
+
+        // If it is spoiler season, go through the download process
+        // of spoiler.xml from Cockatrice/Magic-Spoiler
+        if (isSpoilerSeason)
+        {
+            qDebug() << "Spoiler Service Online";
+
+            isSpoilerDownloadEnabled = settingsCache->getDownloadSpoilersStatus();
+            if (isSpoilerDownloadEnabled)
+            {
+                startSpoilerDownloadProcess(SPOILERS_URL, true);
+            }
+        }
+        else
+        {
+            qDebug() << "Spoiler Service Offline";
+        }
     }
 }
 
 bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
 {
     QString fileName = settingsCache->getSpoilerCardDatabasePath();
-    QString windowName = tr("Save spoiler database");
-    QString fileType = tr("XML; card database (*.xml)");
-
     QFileInfo fi(fileName);
     QDir fileDir(fi.path());
+
     if (!fileDir.exists() && !fileDir.mkpath(fileDir.absolutePath()))
     {
         return false;
@@ -87,6 +120,9 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
     file.close();
 
     qDebug() << "Spoiler Service Data Written";
+
+    // If the user has notifications enabled, let them know
+    // when the database was last updated
     if (trayIcon)
     {
         QList<QByteArray> lines = data.split('\n');
@@ -95,8 +131,8 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
         {
             if (line.indexOf("created:") > -1)
             {
-                QString str = QString(line).replace("created:", "").trimmed();
-                trayIcon->showMessage(tr("Spoilers last updated at"), str);
+                QString timeStamp = QString(line).replace("created:", "").trimmed();
+                trayIcon->showMessage(tr("Spoilers have been updated!"), timeStamp);
                 return true;
             }
         }

--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -67,10 +67,12 @@ void SpoilerBackgroundUpdater::actDownloadFinishedSpoilersFile()
         saveDownloadedFile(spoilerData);
 
         reply->deleteLater();
+        emit spoilerCheckerDone();
     }
     else
     {
         qDebug() << "Error downloading spoilers file" << errorCode;
+        emit spoilerCheckerDone();
     }
 }
 
@@ -108,6 +110,7 @@ void SpoilerBackgroundUpdater::actCheckIfSpoilerSeasonEnabled()
         }
 
         qDebug() << "Spoiler Season Offline";
+        emit spoilerCheckerDone();
     }
     else if (errorCode == QNetworkReply::NoError)
     {
@@ -122,6 +125,7 @@ void SpoilerBackgroundUpdater::actCheckIfSpoilerSeasonEnabled()
         }
 
         qDebug() << "Spoiler download failed due to no internet connection";
+        emit spoilerCheckerDone();
     }
     else
     {
@@ -131,6 +135,7 @@ void SpoilerBackgroundUpdater::actCheckIfSpoilerSeasonEnabled()
         }
 
         qDebug() << "Spoiler download failed with reason" << errorCode;
+        emit spoilerCheckerDone();
     }
 }
 

--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -60,10 +60,11 @@ void SpoilerBackgroundUpdater::actDownloadFinishedSpoilersFile()
     if (errorCode == QNetworkReply::NoError)
     {
         spoilerData = reply->readAll();
-        reply->deleteLater();
 
         // Save the spoiler.xml file to the disk
         saveDownloadedFile(spoilerData);
+
+        reply->deleteLater();
     }
     else
     {
@@ -89,6 +90,10 @@ void SpoilerBackgroundUpdater::actCheckIfSpoilerSeasonEnabled()
         if (file.exists() && file.remove())
         {
             qDebug() << "Spoiler Season Offline, Deleting spoiler.xml";
+            if (trayIcon)
+            {
+                trayIcon->showMessage(tr("Spoilers season has ended"), tr("Deleting spoiler.xml. Please run Oracle"));
+            }
         }
 
         /*
@@ -136,12 +141,14 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
     if (!file.open(QIODevice::WriteOnly))
     {
         qDebug() << "Spoiler Service Error: File open (w) failed for" << fileName;
+        file.close();
         return false;
     }
 
     if (file.write(data) == -1)
     {
         qDebug() << "Spoiler Service Error: File write (w) failed for" << fileName;
+        file.close();
         return false;
     }
 
@@ -188,6 +195,8 @@ QByteArray SpoilerBackgroundUpdater::getHash(const QString fileName)
         QCryptographicHash hash(QCryptographicHash::Algorithm::Md5);
         hash.addData(bytes);
 
+        qDebug() << "File Hash =" << hash.result();
+
         file.close();
         return hash.result();
     }
@@ -206,5 +215,8 @@ QByteArray SpoilerBackgroundUpdater::getHash(QByteArray data)
 
     QCryptographicHash hash(QCryptographicHash::Algorithm::Md5);
     hash.addData(bytes);
+
+    qDebug() << "Data Hash =" << hash.result();
+
     return hash.result();
 }

--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -119,6 +119,7 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
     file.close();
 
     qDebug() << "Spoiler Service Data Written";
+    QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
 
     // If the user has notifications enabled, let them know
     // when the database was last updated

--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -185,23 +185,23 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
     {
         QList<QByteArray> lines = data.split('\n');
 
-                foreach (QByteArray line, lines)
+        foreach (QByteArray line, lines)
+        {
+            if (line.indexOf("created:") > -1)
             {
-                if (line.indexOf("created:") > -1)
-                {
-                    QString timeStamp = QString(line).replace("created:", "").trimmed();
-                    timeStamp.chop(6); // Remove " (UTC)"
+                QString timeStamp = QString(line).replace("created:", "").trimmed();
+                timeStamp.chop(6); // Remove " (UTC)"
 
-                    auto utcTime = QDateTime::fromString(timeStamp, QString("ddd, MMM dd yyyy, hh:mm:ss"));
-                    utcTime.setTimeSpec(Qt::UTC);
+                auto utcTime = QDateTime::fromString(timeStamp, QString("ddd, MMM dd yyyy, hh:mm:ss"));
+                utcTime.setTimeSpec(Qt::UTC);
 
-                    QString localTime = utcTime.toLocalTime().toString("MMM d, hh:mm");
+                QString localTime = utcTime.toLocalTime().toString("MMM d, hh:mm");
 
-                    trayIcon->showMessage(tr("Spoilers have been updated!"), tr("Last change:") + " " + localTime);
-                    emit spoilersUpdatedSuccessfully();
-                    return true;
-                }
+                trayIcon->showMessage(tr("Spoilers have been updated!"), tr("Last change:") + " " + localTime);
+                emit spoilersUpdatedSuccessfully();
+                return true;
             }
+        }
     }
 
     return true;

--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -87,7 +87,13 @@ void SpoilerBackgroundUpdater::actCheckIfSpoilerSeasonEnabled()
         }
         else
         {
-            qDebug() << "Spoiler Service Offline";
+            qDebug() << "Spoiler Service Offline, Reloading Database";
+
+            /*
+             * ALERT: Ensure two reloads of the card database do not happen
+             * at the same time or a racetime condition can/will happen!
+             */
+            QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
         }
     }
     else

--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -107,9 +107,8 @@ void SpoilerBackgroundUpdater::runTimer(bool lbStopAndRestart)
 
 /* CARD UPDATER
  * This was taken from window_main.cpp
- * The crossover was not working as expected so a copy was made here
- * If changes made there, they should probably be done here.
- * This is a refactor to do for sure
+ * And then modified slightly.
+ * TODO: Refactor
  */
 void SpoilerBackgroundUpdater::downloadSpoilersFile()
 {
@@ -155,7 +154,7 @@ void SpoilerBackgroundUpdater::downloadSpoilersFile()
         return;
     }
 
-    cardUpdateProcess->start("\"" + updaterCmd + "\"");
+    cardUpdateProcess->start("\"" + updaterCmd + "\"", QStringList("-s"));
 }
 
 void SpoilerBackgroundUpdater::cardUpdateError(QProcess::ProcessError err)

--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -17,9 +17,13 @@
 
 SpoilerBackgroundUpdater::SpoilerBackgroundUpdater(QObject *apParent) : QObject(apParent), cardUpdateProcess(nullptr)
 {
-    // Start the process of checking if we're in spoiler season
-    // "enabled" means yes, anything else means no
-    startSpoilerDownloadProcess(SPOILERS_STATUS_URL, false);
+    isSpoilerDownloadEnabled = settingsCache->getDownloadSpoilersStatus();
+    if (isSpoilerDownloadEnabled)
+    {
+        // Start the process of checking if we're in spoiler season
+        // "enabled" means yes, anything else means no
+        startSpoilerDownloadProcess(SPOILERS_STATUS_URL, false);
+    }
 }
 
 void SpoilerBackgroundUpdater::startSpoilerDownloadProcess(QString url, bool saveResults)
@@ -79,12 +83,7 @@ void SpoilerBackgroundUpdater::actCheckIfSpoilerSeasonEnabled()
         if (isSpoilerSeason)
         {
             qDebug() << "Spoiler Service Online";
-
-            isSpoilerDownloadEnabled = settingsCache->getDownloadSpoilersStatus();
-            if (isSpoilerDownloadEnabled)
-            {
-                startSpoilerDownloadProcess(SPOILERS_URL, true);
-            }
+            startSpoilerDownloadProcess(SPOILERS_URL, true);
         }
         else
         {

--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -24,6 +24,8 @@ SpoilerBackgroundUpdater::SpoilerBackgroundUpdater(QObject *apParent) : QObject(
     {
         // Start the process of checking if we're in spoiler season
         // File exists means we're in spoiler season
+        // We will load the database before attempting to download spoilers, incase they fail
+        CardDatabase::threadSafeReloadCardDatabase();
         startSpoilerDownloadProcess(SPOILERS_STATUS_URL, false);
     }
 }
@@ -72,6 +74,25 @@ void SpoilerBackgroundUpdater::actDownloadFinishedSpoilersFile()
     }
 }
 
+bool SpoilerBackgroundUpdater::deleteSpoilerFile()
+{
+    QString fileName = settingsCache->getSpoilerCardDatabasePath();
+    QFileInfo fi(fileName);
+    QDir fileDir(fi.path());
+    QFile file(fileName);
+
+    // Delete the spoiler.xml file
+    if (file.exists() && file.remove())
+    {
+        qDebug() << "Deleting spoiler.xml";
+        return true;
+
+    }
+
+    qDebug() << "Error: Spoiler.xml not found or not deleted";
+    return false;
+}
+
 void SpoilerBackgroundUpdater::actCheckIfSpoilerSeasonEnabled()
 {
     auto *response = dynamic_cast<QNetworkReply *>(sender());
@@ -81,36 +102,35 @@ void SpoilerBackgroundUpdater::actCheckIfSpoilerSeasonEnabled()
     {
         // Spoiler season is offline at this point, so the spoiler.xml file can be safely deleted
         // The user should run Oracle to get the latest card information
-        QString fileName = settingsCache->getSpoilerCardDatabasePath();
-        QFileInfo fi(fileName);
-        QDir fileDir(fi.path());
-        QFile file(fileName);
-
-        // Delete the spoiler.xml file as we're not in spoiler season
-        if (file.exists() && file.remove())
+        if (deleteSpoilerFile() && trayIcon)
         {
-            qDebug() << "Spoiler Season Offline, Deleting spoiler.xml";
-            if (trayIcon)
-            {
-                trayIcon->showMessage(tr("Spoilers season has ended"), tr("Deleting spoiler.xml. Please run Oracle"));
-            }
+            trayIcon->showMessage(tr("Spoilers season has ended"), tr("Deleting spoiler.xml. Please run Oracle"));
         }
 
-        /*
-         * ALERT: Ensure two reloads of the card database do not happen
-         * at the same time or a racetime condition can/will happen!
-         */
-        qDebug() << "Spoiler Season Offline, Reloading Database";
-        QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
+        qDebug() << "Spoiler Season Offline";
     }
     else if (errorCode == QNetworkReply::NoError)
     {
         qDebug() << "Spoiler Service Online";
         startSpoilerDownloadProcess(SPOILERS_URL, true);
     }
+    else if (errorCode == QNetworkReply::HostNotFoundError)
+    {
+        if (trayIcon)
+        {
+            trayIcon->showMessage(tr("Spoilers download failed"), tr("No internet connection"));
+        }
+
+        qDebug() << "Spoiler download failed due to no internet connection";
+    }
     else
     {
-        qDebug() << "Error: Spoiler download failed with reason" << errorCode;
+        if (trayIcon)
+        {
+            trayIcon->showMessage(tr("Spoilers download failed"), tr("Error") + " " + errorCode);
+        }
+
+        qDebug() << "Spoiler download failed with reason" << errorCode;
     }
 }
 
@@ -132,8 +152,8 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
         {
             trayIcon->showMessage(tr("Spoilers already up to date"), tr("No new spoilers added"));
         }
-        qDebug() << "Spoilers Up to Date, Reloading Database";
-        QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
+
+        qDebug() << "Spoilers Up to Date";
         return false;
     }
 
@@ -154,13 +174,10 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
 
     file.close();
 
-    /*
-     * Data written, so reload the card database
-     * ALERT: Ensure two reloads of the card database do not happen
-     * at the same time or a racetime condition can/will happen!
-     */
-    qDebug() << "Spoiler Service Data Written, Reloading Database";
-    QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
+
+    // Data written, so reload the card database
+    qDebug() << "Spoiler Service Data Written";
+    CardDatabase::threadSafeReloadCardDatabase();
 
     // If the user has notifications enabled, let them know
     // when the database was last updated
@@ -173,7 +190,14 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
             if (line.indexOf("created:") > -1)
             {
                 QString timeStamp = QString(line).replace("created:", "").trimmed();
-                trayIcon->showMessage(tr("Spoilers have been updated!"), tr("Last change:") + " " + timeStamp);
+                timeStamp.chop(6); // Remove " (UTC)"
+
+                auto utcTime = QDateTime::fromString(timeStamp, QString("ddd, MMM dd yyyy, hh:mm:ss"));
+                utcTime.setTimeSpec(Qt::UTC);
+
+                QString localTime = utcTime.toLocalTime().toString("MMM d, hh:mm");
+
+                trayIcon->showMessage(tr("Spoilers have been updated!"), tr("Last change:") + " " + localTime);
                 emit spoilersUpdatedSuccessfully();
                 return true;
             }

--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -1,0 +1,199 @@
+#include <QDateTime>
+#include <QDebug>
+#include <QUrl>
+#include <QNetworkReply>
+#include <QMessageBox>
+#include <QFile>
+#include <QApplication>
+#include <QtConcurrent>
+#include "spoilerbackgroundupdater.h"
+#include "settingscache.h"
+#include "carddatabase.h"
+#include "main.h"
+#include "window_main.h"
+
+SpoilerBackgroundUpdater::SpoilerBackgroundUpdater(QObject *apParent) : QObject(apParent), cardUpdateProcess(nullptr)
+{
+    // If there is a change in the settings, update the timer so we know when to update correctly
+    connect(settingsCache, SIGNAL(downloadSpoilerStatusChanged()), this, SLOT(changeActiveStatus()));
+    connect(settingsCache, SIGNAL(downloadSpoilerTimeIndexChanged()), this, SLOT(handleNewTimeInterval()));
+
+    qDebug() << "Spoiler Service online";
+
+    runTimer();
+    // TODO: User wants spoilers, so lets see if we're in spoiler season or not.
+}
+
+void SpoilerBackgroundUpdater::changeActiveStatus()
+{
+    mbIsActiveThread = (settingsCache->getDownloadSpoilersStatus());
+    qDebug() << "Spoiler Timer running status has been changed to" << mbIsActiveThread;
+
+    // If they enable spoilers, auto-download the file (aka timer expired) and restart the timer
+    if (mbIsActiveThread)
+    {
+        timeoutOccurredTimeToDownloadSpoilers();
+    }
+}
+
+void SpoilerBackgroundUpdater::timeoutOccurredTimeToDownloadSpoilers()
+{
+    qDebug() << "Spoiler Timer has finished";
+
+    settingsCache->setDownloadSpoilerLastUpdateTime(QDateTime::currentMSecsSinceEpoch());
+
+    // If this thread is active, then initiate download
+    if (mbIsActiveThread)
+    {
+        qDebug() << "Timer thread is active, so attempting to download spoilers";
+        downloadSpoilersFile();
+    }
+
+    // Now that we've downloaded the spoiler, reset the timer.
+    // Take it from the top, Jenkins!
+    runTimer(true);
+}
+
+void SpoilerBackgroundUpdater::handleNewTimeInterval()
+{
+    // Cause the timer to stop then restart w/ new interval
+    qDebug() << "Spoiler Timer has new time interval established";
+    runTimer(true);
+}
+
+void SpoilerBackgroundUpdater::runTimer(bool lbStopAndRestart)
+{
+    // If the timer doesn't exist (user ticked checkbox, for example, as an override, create it)
+    if (mpTimerForSpoilers == nullptr)
+    {
+        // When timer ends, cause download of Spoilers XML file
+        mpTimerForSpoilers = new QTimer(this);
+        connect(mpTimerForSpoilers, SIGNAL(timeout()), this, SLOT(timeoutOccurredTimeToDownloadSpoilers()));
+        qDebug() << "Timer was null, established now";
+    }
+
+    // Cause a restart of the timer as if we just restart via start() a timeout() will be
+    // thrown which will trigger a download... which we don't want off time!
+    if (lbStopAndRestart)
+    {
+        mpTimerForSpoilers->stop();
+    }
+
+    // Determine how long to wait between updates (Gets the # of hours from settingsCache / convert Mins -> Millis)
+    int lnTimeToWaitBetween = settingsCache->getDownloadSpoilerTimeMinutes() * 60000;
+
+    // How much time is needed until the next update (NOW() - Last Update Time == Time Remaining)
+    long lnLastUpdateTime = settingsCache->getDownloadSpoilerLastUpdateTime();
+    long lnTimeSinceLastUpdate = QDateTime::currentMSecsSinceEpoch() - lnLastUpdateTime;
+    if (lnTimeSinceLastUpdate <= 500 || lnLastUpdateTime == -1)
+    {
+        // The update just occurred less then half a sec ago, so we will restart the timer from the beginning (time zero)
+        mpTimerForSpoilers->start(lnTimeToWaitBetween);
+    }
+    else if (lnTimeSinceLastUpdate < lnTimeToWaitBetween)
+    {
+        // If we have checked for an update in the past and it's not yet time to check for another update
+        // Start the clock to count down until lnTimeSinceLastUpdate
+        mpTimerForSpoilers->start(static_cast<int>(lnTimeToWaitBetween - lnTimeSinceLastUpdate));
+    }
+    else
+    {
+        // It's been too long since we last checked (above threshold), so we will start now (time inf)
+        mpTimerForSpoilers->start(0);
+    }
+
+    qDebug() << "Spoiler Timer has started and will finish in" << mpTimerForSpoilers->interval()/60000. << "minutes";
+}
+
+/* CARD UPDATER
+ * This was taken from window_main.cpp
+ * The crossover was not working as expected so a copy was made here
+ * If changes made there, they should probably be done here.
+ * This is a refactor to do for sure
+ */
+void SpoilerBackgroundUpdater::downloadSpoilersFile()
+{
+    if (cardUpdateProcess)
+    {
+        QMessageBox::information(nullptr, tr("Information"), tr("A card database update is already running."));
+        return;
+    }
+
+    cardUpdateProcess = new QProcess(this);
+    connect(cardUpdateProcess, SIGNAL(error(QProcess::ProcessError)), this, SLOT(cardUpdateError(QProcess::ProcessError)));
+    connect(cardUpdateProcess, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(cardUpdateFinished(int, QProcess::ExitStatus)));
+
+    // full "run the update" command; leave empty if not present
+    QString updaterCmd;
+    QString binaryName;
+    QDir dir = QDir(QApplication::applicationDirPath());
+
+#if defined(Q_OS_MAC)
+    binaryName = getCardUpdaterBinaryName();
+
+    // exit from the application bundle
+    dir.cdUp();
+    dir.cdUp();
+    dir.cdUp();
+    dir.cd(binaryName + ".app");
+    dir.cd("Contents");
+    dir.cd("MacOS");
+#elif defined(Q_OS_WIN)
+    binaryName = getCardUpdaterBinaryName() + ".exe";
+#else
+    binaryName = getCardUpdaterBinaryName();
+#endif
+
+    if (dir.exists(binaryName))
+    {
+        updaterCmd = dir.absoluteFilePath(binaryName);
+    }
+
+    if (updaterCmd.isEmpty())
+    {
+        QMessageBox::warning(nullptr, tr("Error"), tr("Unable to run the card database updater: ") + dir.absoluteFilePath(binaryName));
+        return;
+    }
+
+    cardUpdateProcess->start("\"" + updaterCmd + "\"");
+}
+
+void SpoilerBackgroundUpdater::cardUpdateError(QProcess::ProcessError err)
+{
+    QString error;
+    switch(err)
+    {
+        case QProcess::FailedToStart:
+            error = tr("failed to start.");
+            break;
+        case QProcess::Crashed:
+            error = tr("crashed.");
+            break;
+        case QProcess::Timedout:
+            error = tr("timed out.");
+            break;
+        case QProcess::WriteError:
+            error = tr("write error.");
+            break;
+        case QProcess::ReadError:
+            error = tr("read error.");
+            break;
+        case QProcess::UnknownError:
+        default:
+            error = tr("unknown error.");
+            break;
+    }
+
+    cardUpdateProcess->deleteLater();
+    cardUpdateProcess = nullptr;
+    QMessageBox::warning(nullptr, tr("Error"), tr("The card database updater exited with an error: %1").arg(error));
+}
+
+void SpoilerBackgroundUpdater::cardUpdateFinished(int, QProcess::ExitStatus)
+{
+    cardUpdateProcess->deleteLater();
+    cardUpdateProcess = nullptr;
+    QMessageBox::information(nullptr, tr("Information"), tr("Update completed successfully.\nCockatrice will now reload the card database."));
+
+    QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
+}

--- a/cockatrice/src/spoilerbackgroundupdater.h
+++ b/cockatrice/src/spoilerbackgroundupdater.h
@@ -24,6 +24,9 @@ class SpoilerBackgroundUpdater : public QObject
         void startSpoilerDownloadProcess(QString url, bool saveResults);
         void downloadFromURL(QUrl url, bool saveResults);
         bool saveDownloadedFile(QByteArray data);
+
+    signals:
+        void spoilersUpdatedSuccessfully();
 };
 
 #endif //COCKATRICE_TIMERTHREAD_H

--- a/cockatrice/src/spoilerbackgroundupdater.h
+++ b/cockatrice/src/spoilerbackgroundupdater.h
@@ -1,0 +1,33 @@
+#ifndef COCKATRICE_TIMERTHREAD_H
+#define COCKATRICE_TIMERTHREAD_H
+
+#include <QObject>
+#include <QTimer>
+#include <QNetworkAccessManager>
+#include <QProcess>
+
+class SpoilerBackgroundUpdater : public QObject
+{
+    Q_OBJECT
+    public:
+        SpoilerBackgroundUpdater(QObject *apParent = nullptr);
+        inline QString getCardUpdaterBinaryName() { return "oracle"; };
+
+    public slots:
+        void timeoutOccurredTimeToDownloadSpoilers();
+        void handleNewTimeInterval();
+
+    private slots:
+        void changeActiveStatus();
+        void cardUpdateError(QProcess::ProcessError err);
+        void cardUpdateFinished(int exitCode, QProcess::ExitStatus exitStatus);
+
+    private:
+        QTimer *mpTimerForSpoilers;
+        bool mbIsActiveThread;
+        void runTimer(bool lbStopAndRestart = false);
+        void downloadSpoilersFile();
+        QProcess *cardUpdateProcess;
+};
+
+#endif //COCKATRICE_TIMERTHREAD_H

--- a/cockatrice/src/spoilerbackgroundupdater.h
+++ b/cockatrice/src/spoilerbackgroundupdater.h
@@ -29,6 +29,7 @@ class SpoilerBackgroundUpdater : public QObject
 
     signals:
         void spoilersUpdatedSuccessfully();
+        void spoilerCheckerDone();
 };
 
 #endif //COCKATRICE_SPOILER_DOWNLOADER_H

--- a/cockatrice/src/spoilerbackgroundupdater.h
+++ b/cockatrice/src/spoilerbackgroundupdater.h
@@ -13,6 +13,7 @@ class SpoilerBackgroundUpdater : public QObject
         inline QString getCardUpdaterBinaryName() { return "oracle"; };
         QByteArray getHash(const QString fileName);
         QByteArray getHash(QByteArray data);
+        static bool deleteSpoilerFile();
 
     private slots:
         void actDownloadFinishedSpoilersFile();

--- a/cockatrice/src/spoilerbackgroundupdater.h
+++ b/cockatrice/src/spoilerbackgroundupdater.h
@@ -11,6 +11,8 @@ class SpoilerBackgroundUpdater : public QObject
     public:
         explicit SpoilerBackgroundUpdater(QObject *apParent = nullptr);
         inline QString getCardUpdaterBinaryName() { return "oracle"; };
+        QByteArray getHash(const QString fileName);
+        QByteArray getHash(QByteArray data);
 
     private slots:
         void actDownloadFinishedSpoilersFile();
@@ -20,7 +22,6 @@ class SpoilerBackgroundUpdater : public QObject
         bool isSpoilerDownloadEnabled;
         QProcess *cardUpdateProcess;
         QByteArray spoilerData;
-        bool isSpoilerSeason;
         void startSpoilerDownloadProcess(QString url, bool saveResults);
         void downloadFromURL(QUrl url, bool saveResults);
         bool saveDownloadedFile(QByteArray data);

--- a/cockatrice/src/spoilerbackgroundupdater.h
+++ b/cockatrice/src/spoilerbackgroundupdater.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QProcess>
+#include <QByteArray>
 
 class SpoilerBackgroundUpdater : public QObject
 {
@@ -12,13 +13,15 @@ class SpoilerBackgroundUpdater : public QObject
         inline QString getCardUpdaterBinaryName() { return "oracle"; };
 
     private slots:
-        void cardUpdateError(QProcess::ProcessError err);
-        void cardUpdateFinished(int exitCode, QProcess::ExitStatus exitStatus);
+        void actDownloadFinishedSpoilersFile();
 
     private:
         bool isSpoilerDownloadEnabled;
-        void downloadSpoilersFile();
         QProcess *cardUpdateProcess;
+        QByteArray spoilerData;
+        void startSpoilerDownloadProcess();
+        void downloadFromURL(QUrl url);
+        bool saveDownloadedFile(QByteArray data);
 };
 
 #endif //COCKATRICE_TIMERTHREAD_H

--- a/cockatrice/src/spoilerbackgroundupdater.h
+++ b/cockatrice/src/spoilerbackgroundupdater.h
@@ -2,30 +2,21 @@
 #define COCKATRICE_TIMERTHREAD_H
 
 #include <QObject>
-#include <QTimer>
-#include <QNetworkAccessManager>
 #include <QProcess>
 
 class SpoilerBackgroundUpdater : public QObject
 {
     Q_OBJECT
     public:
-        SpoilerBackgroundUpdater(QObject *apParent = nullptr);
+        explicit SpoilerBackgroundUpdater(QObject *apParent = nullptr);
         inline QString getCardUpdaterBinaryName() { return "oracle"; };
 
-    public slots:
-        void timeoutOccurredTimeToDownloadSpoilers();
-        void handleNewTimeInterval();
-
     private slots:
-        void changeActiveStatus();
         void cardUpdateError(QProcess::ProcessError err);
         void cardUpdateFinished(int exitCode, QProcess::ExitStatus exitStatus);
 
     private:
-        QTimer *mpTimerForSpoilers;
-        bool mbIsActiveThread;
-        void runTimer(bool lbStopAndRestart = false);
+        bool isSpoilerDownloadEnabled;
         void downloadSpoilersFile();
         QProcess *cardUpdateProcess;
 };

--- a/cockatrice/src/spoilerbackgroundupdater.h
+++ b/cockatrice/src/spoilerbackgroundupdater.h
@@ -1,5 +1,5 @@
-#ifndef COCKATRICE_TIMERTHREAD_H
-#define COCKATRICE_TIMERTHREAD_H
+#ifndef COCKATRICE_SPOILER_DOWNLOADER_H
+#define COCKATRICE_SPOILER_DOWNLOADER_H
 
 #include <QObject>
 #include <QProcess>
@@ -29,4 +29,4 @@ class SpoilerBackgroundUpdater : public QObject
         void spoilersUpdatedSuccessfully();
 };
 
-#endif //COCKATRICE_TIMERTHREAD_H
+#endif //COCKATRICE_SPOILER_DOWNLOADER_H

--- a/cockatrice/src/spoilerbackgroundupdater.h
+++ b/cockatrice/src/spoilerbackgroundupdater.h
@@ -14,13 +14,15 @@ class SpoilerBackgroundUpdater : public QObject
 
     private slots:
         void actDownloadFinishedSpoilersFile();
+        void actCheckIfSpoilerSeasonEnabled();
 
     private:
         bool isSpoilerDownloadEnabled;
         QProcess *cardUpdateProcess;
         QByteArray spoilerData;
-        void startSpoilerDownloadProcess();
-        void downloadFromURL(QUrl url);
+        bool isSpoilerSeason;
+        void startSpoilerDownloadProcess(QString url, bool saveResults);
+        void downloadFromURL(QUrl url, bool saveResults);
         bool saveDownloadedFile(QByteArray data);
 };
 

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -716,7 +716,7 @@ MainWindow::MainWindow(QWidget *parent)
     if (! settingsCache->getDownloadSpoilersStatus())
     {
         qDebug() << "Spoilers Disabled";
-        CardDatabase::threadSafeReloadCardDatabase();
+        QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
     }
 }
 
@@ -864,8 +864,7 @@ void MainWindow::cardDatabaseNewSetsFound(int numUnknownSets, QStringList unknow
     if (msgBox.clickedButton() == yesButton)
     {
         db->enableAllUnknownSets();
-        CardDatabase::threadSafeReloadCardDatabase();
-    }
+        QtConcurrent::run(db, &CardDatabase::loadCardDatabases);    }
     else if (msgBox.clickedButton() == noButton)
     {
         db->markAllSetsAsKnown();
@@ -967,8 +966,7 @@ void MainWindow::cardUpdateFinished(int, QProcess::ExitStatus)
     cardUpdateProcess = nullptr;
 
     QMessageBox::information(this, tr("Information"), tr("Update completed successfully.\nCockatrice will now reload the card database."));
-    CardDatabase::threadSafeReloadCardDatabase();
-}
+    QtConcurrent::run(db, &CardDatabase::loadCardDatabases);}
 
 void MainWindow::refreshShortcuts()
 {
@@ -1083,8 +1081,7 @@ void MainWindow::actAddCustomSet()
     if (res)
     {
         QMessageBox::information(this, tr("Load sets/cards"), tr("The new sets/cards have been added successfully.\nCockatrice will now reload the card database."));
-        CardDatabase::threadSafeReloadCardDatabase();
-    }
+        QtConcurrent::run(db, &CardDatabase::loadCardDatabases);    }
     else
     {
         QMessageBox::warning(this, tr("Load sets/cards"), tr("Sets/cards failed to import."));

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -873,10 +873,9 @@ void MainWindow::cardDatabaseAllNewSetsEnabled()
 }
 
 /* CARD UPDATER */
-
 void MainWindow::actCheckCardUpdates()
 {
-    if(cardUpdateProcess)
+    if (cardUpdateProcess)
     {
         QMessageBox::information(this, tr("Information"), tr("A card database update is already running."));
         return;

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -715,6 +715,10 @@ MainWindow::MainWindow(QWidget *parent)
 
     if (! settingsCache->getDownloadSpoilersStatus())
     {
+        /*
+         * ALERT: Ensure two reloads of the card database do not happen
+         * at the same time or a racetime condition can/will happen!
+         */
         qDebug() << "Spoilers Disabled, Reloading Database";
         QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
     }

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -715,12 +715,8 @@ MainWindow::MainWindow(QWidget *parent)
 
     if (! settingsCache->getDownloadSpoilersStatus())
     {
-        /*
-         * ALERT: Ensure two reloads of the card database do not happen
-         * at the same time or a racetime condition can/will happen!
-         */
-        qDebug() << "Spoilers Disabled, Reloading Database";
-        QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
+        qDebug() << "Spoilers Disabled";
+        CardDatabase::threadSafeReloadCardDatabase();
     }
 }
 
@@ -868,7 +864,7 @@ void MainWindow::cardDatabaseNewSetsFound(int numUnknownSets, QStringList unknow
     if (msgBox.clickedButton() == yesButton)
     {
         db->enableAllUnknownSets();
-        actEditSets();
+        CardDatabase::threadSafeReloadCardDatabase();
     }
     else if (msgBox.clickedButton() == noButton)
     {
@@ -971,7 +967,7 @@ void MainWindow::cardUpdateFinished(int, QProcess::ExitStatus)
     cardUpdateProcess = nullptr;
 
     QMessageBox::information(this, tr("Information"), tr("Update completed successfully.\nCockatrice will now reload the card database."));
-    QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
+    CardDatabase::threadSafeReloadCardDatabase();
 }
 
 void MainWindow::refreshShortcuts()
@@ -1087,7 +1083,7 @@ void MainWindow::actAddCustomSet()
     if (res)
     {
         QMessageBox::information(this, tr("Load sets/cards"), tr("The new sets/cards have been added successfully.\nCockatrice will now reload the card database."));
-        QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
+        CardDatabase::threadSafeReloadCardDatabase();
     }
     else
     {

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -864,7 +864,8 @@ void MainWindow::cardDatabaseNewSetsFound(int numUnknownSets, QStringList unknow
     if (msgBox.clickedButton() == yesButton)
     {
         db->enableAllUnknownSets();
-        QtConcurrent::run(db, &CardDatabase::loadCardDatabases);    }
+        QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
+    }
     else if (msgBox.clickedButton() == noButton)
     {
         db->markAllSetsAsKnown();
@@ -966,7 +967,8 @@ void MainWindow::cardUpdateFinished(int, QProcess::ExitStatus)
     cardUpdateProcess = nullptr;
 
     QMessageBox::information(this, tr("Information"), tr("Update completed successfully.\nCockatrice will now reload the card database."));
-    QtConcurrent::run(db, &CardDatabase::loadCardDatabases);}
+    QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
+}
 
 void MainWindow::refreshShortcuts()
 {
@@ -1081,7 +1083,8 @@ void MainWindow::actAddCustomSet()
     if (res)
     {
         QMessageBox::information(this, tr("Load sets/cards"), tr("The new sets/cards have been added successfully.\nCockatrice will now reload the card database."));
-        QtConcurrent::run(db, &CardDatabase::loadCardDatabases);    }
+        QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
+    }
     else
     {
         QMessageBox::warning(this, tr("Load sets/cards"), tr("Sets/cards failed to import."));

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -40,6 +40,8 @@ class DlgViewLog;
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
+public slots:
+    void actCheckCardUpdates();
 private slots:
     void updateTabMenu(const QList<QMenu *> &newMenuList);
     void statusChanged(ClientStatus _status);
@@ -78,7 +80,6 @@ private slots:
     void promptForgotPasswordChallenge();
     void showWindowIfHidden();
 
-    void actCheckCardUpdates();
     void cardUpdateError(QProcess::ProcessError err);
     void cardUpdateFinished(int exitCode, QProcess::ExitStatus exitStatus);
     void refreshShortcuts();

--- a/oracle/src/main.cpp
+++ b/oracle/src/main.cpp
@@ -3,6 +3,7 @@
 #include <QIcon>
 #include <QTranslator>
 #include <QLibraryInfo>
+#include <QCommandLineParser>
 
 #include "main.h"
 #include "oraclewizard.h"
@@ -15,6 +16,7 @@ ThemeManager *themeManager;
 
 const QString translationPrefix = "oracle";
 QString translationPath;
+bool isSpoilersOnly;
 
 void installNewTranslator()
 {
@@ -34,6 +36,13 @@ int main(int argc, char *argv[])
 	QCoreApplication::setOrganizationDomain("cockatrice");
 	// this can't be changed, as it influences the default savepath for cards.xml
 	QCoreApplication::setApplicationName("Cockatrice");
+
+    // If the program is opened with the -s flag, it will only do spoilers. Otherwise it will do MTGJSON/Tokens
+    QCommandLineParser parser;
+    QCommandLineOption showProgressOption("s", QCoreApplication::translate("main", "Only run in spoiler mode"));
+    parser.addOption(showProgressOption);
+    parser.process(app);
+    isSpoilersOnly = parser.isSet(showProgressOption);
 
 #ifdef Q_OS_MAC
     translationPath = qApp->applicationDirPath() + "/../Resources/translations";

--- a/oracle/src/main.h
+++ b/oracle/src/main.h
@@ -6,6 +6,7 @@ class QTranslator;
 extern QTranslator *translator;
 extern const QString translationPrefix;
 extern QString translationPath;
+extern bool isSpoilersOnly;
 
 void installNewTranslator();
 

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -46,10 +46,9 @@ OracleWizard::OracleWizard(QWidget *parent) : QWizard(parent)
 
     importer = new OracleImporter(settingsCache->getDataPath(), this);
 
-    addPage(new IntroPage);
-
     if (! isSpoilersOnly)
     {
+        addPage(new IntroPage);
         addPage(new LoadSetsPage);
         addPage(new SaveSetsPage);
         addPage(new LoadTokensPage);
@@ -902,6 +901,7 @@ SaveSpoilersPage::SaveSpoilersPage(QWidget *parent) : OracleWizardPage(parent)
     layout->addWidget(defaultPathCheckBox, 0, 0);
 
     setLayout(layout);
+
 }
 
 void SaveSpoilersPage::retranslateUi()
@@ -947,9 +947,6 @@ bool SaveSpoilersPage::validatePage()
         if (wizard()->saveTokensToFile(fileName))
         {
             ok = true;
-            QMessageBox::information(this,
-                                     tr("Success"),
-                                     tr("The spoiler database has been saved successfully to\n%1").arg(fileName));
         }
         else
         {

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -37,10 +37,9 @@
 #endif
 
 #define TOKENS_URL "https://raw.githubusercontent.com/Cockatrice/Magic-Token/master/tokens.xml"
+#define SPOILERS_URL "https://raw.githubusercontent.com/Cockatrice/Magic-Spoiler/files/spoiler.xml"
 
-
-OracleWizard::OracleWizard(QWidget *parent)
-    : QWizard(parent)
+OracleWizard::OracleWizard(QWidget *parent) : QWizard(parent)
 {
     settings = new QSettings(settingsCache->getSettingsPath()+"global.ini",QSettings::IniFormat, this);
     connect(settingsCache, SIGNAL(langChanged()), this, SLOT(updateLanguage()));
@@ -48,10 +47,15 @@ OracleWizard::OracleWizard(QWidget *parent)
     importer = new OracleImporter(settingsCache->getDataPath(), this);
 
     addPage(new IntroPage);
+
+
     addPage(new LoadSetsPage);
     addPage(new SaveSetsPage);
     addPage(new LoadTokensPage);
     addPage(new SaveTokensPage);
+
+    addPage(new LoadSpoilersPage);
+    addPage(new SaveSpoilersPage);
 
     retranslateUi();
 }
@@ -65,7 +69,10 @@ void OracleWizard::updateLanguage()
 void OracleWizard::changeEvent(QEvent *event)
 {
     if (event->type() == QEvent::LanguageChange)
+    {
         retranslateUi();
+    }
+
     QDialog::changeEvent(event);
 }
 
@@ -75,7 +82,9 @@ void OracleWizard::retranslateUi()
     QWizard::setButtonText(QWizard::FinishButton, tr("Save"));
     
     for (int i = 0; i < pageIds().count(); i++)
+    {
         dynamic_cast<OracleWizardPage *>(page(i))->retranslateUi();
+    }
 }
 
 void OracleWizard::accept()
@@ -98,22 +107,23 @@ void OracleWizard::disableButtons()
 bool OracleWizard::saveTokensToFile(const QString & fileName)
 {
     QFile file(fileName);
-    if(!file.open(QIODevice::WriteOnly))
+    if (!file.open(QIODevice::WriteOnly))
     {
         qDebug() << "File open (w) failed for" << fileName;
         return false;
     }
-    if(file.write(tokensData) == -1)
+
+    if (file.write(tokensData) == -1)
     {
         qDebug() << "File write (w) failed for" << fileName;
         return false;
     }
+
     file.close();
     return true;
 }
 
-IntroPage::IntroPage(QWidget *parent)
-    : OracleWizardPage(parent)
+IntroPage::IntroPage(QWidget *parent) : OracleWizardPage(parent)
 {
     label = new QLabel(this);
     label->setWordWrap(true);
@@ -122,16 +132,21 @@ IntroPage::IntroPage(QWidget *parent)
     versionLabel = new QLabel(this);
     languageBox = new QComboBox(this);
     QString setLanguage = settingsCache->getLang();
+
     QStringList qmFiles = findQmFiles();
-    for (int i = 0; i < qmFiles.size(); i++) {
+    for (int i = 0; i < qmFiles.size(); i++)
+    {
         QString langName = languageName(qmFiles[i]);
         languageBox->addItem(langName, qmFiles[i]);
         if ((qmFiles[i] == setLanguage) || (setLanguage.isEmpty() && langName == QCoreApplication::translate("i18n", DEFAULT_LANG_NAME)))
+        {
             languageBox->setCurrentIndex(i);
+        }
     }
+
     connect(languageBox, SIGNAL(currentIndexChanged(int)), this, SLOT(languageBoxChanged(int)));
 
-    QGridLayout *layout = new QGridLayout(this);
+    auto *layout = new QGridLayout(this);
     layout->addWidget(label, 0, 0, 1, 2);
     layout->addWidget(languageLabel, 1, 0);
     layout->addWidget(languageBox, 1, 1);
@@ -150,8 +165,10 @@ QStringList IntroPage::findQmFiles()
 
 QString IntroPage::languageName(const QString &qmFile)
 {
-    if(qmFile == DEFAULT_LANG_CODE)
+    if (qmFile == DEFAULT_LANG_CODE)
+    {
         return DEFAULT_LANG_NAME;
+    }
 
     QTranslator translator;
     translator.load(translationPrefix + "_" + qmFile + ".qm", translationPath);
@@ -173,8 +190,7 @@ void IntroPage::retranslateUi()
     versionLabel->setText(tr("Version:") + QString(" %1").arg(VERSION_STRING));
 }
 
-LoadSetsPage::LoadSetsPage(QWidget *parent)
-    : OracleWizardPage(parent), nam(0)
+LoadSetsPage::LoadSetsPage(QWidget *parent) : OracleWizardPage(parent), nam(nullptr)
 {
     urlRadioButton = new QRadioButton(this);
     fileRadioButton = new QRadioButton(this);
@@ -193,7 +209,7 @@ LoadSetsPage::LoadSetsPage(QWidget *parent)
     fileButton = new QPushButton(this);
     connect(fileButton, SIGNAL(clicked()), this, SLOT(actLoadSetsFile()));
 
-    QGridLayout *layout = new QGridLayout(this);
+    auto *layout = new QGridLayout(this);
     layout->addWidget(urlRadioButton, 0, 0);
     layout->addWidget(urlLineEdit, 0, 1);
     layout->addWidget(urlButton, 1, 1, Qt::AlignRight);
@@ -245,11 +261,15 @@ void LoadSetsPage::actLoadSetsFile()
     dialog.setNameFilter(tr("Sets JSON file (*.json)"));
 #endif
 
-    if(!fileLineEdit->text().isEmpty() && QFile::exists(fileLineEdit->text()))
+    if (!fileLineEdit->text().isEmpty() && QFile::exists(fileLineEdit->text()))
+    {
         dialog.selectFile(fileLineEdit->text());
+    }
 
     if (!dialog.exec())
+    {
         return;
+    }
 
     fileLineEdit->setText(dialog.selectedFiles().at(0));
 }
@@ -257,14 +277,16 @@ void LoadSetsPage::actLoadSetsFile()
 bool LoadSetsPage::validatePage()
 {
     // once the import is finished, we call next(); skip validation
-    if(wizard()->importer->getSets().count() > 0)
+    if (wizard()->importer->getSets().count() > 0)
+    {
         return true;
+    }
 
     // else, try to import sets
-    if(urlRadioButton->isChecked())
+    if (urlRadioButton->isChecked())
     {
         QUrl url = QUrl::fromUserInput(urlLineEdit->text());
-        if(!url.isValid())
+        if (!url.isValid())
         {
             QMessageBox::critical(this, tr("Error"), tr("The provided URL is not valid."));
             return false;
@@ -282,16 +304,19 @@ bool LoadSetsPage::validatePage()
         setEnabled(false);
 
         downloadSetsFile(url);
-    } else if(fileRadioButton->isChecked()) {
+    }
+    else if (fileRadioButton->isChecked())
+    {
         QFile setsFile(fileLineEdit->text());
-        if(!setsFile.exists())
+        if (!setsFile.exists())
         {
             QMessageBox::critical(this, tr("Error"), tr("Please choose a file."));
             return false;
         }
 
-        if (!setsFile.open(QIODevice::ReadOnly)) {
-            QMessageBox::critical(0, tr("Error"), tr("Cannot open file '%1'.").arg(fileLineEdit->text()));
+        if (!setsFile.open(QIODevice::ReadOnly))
+        {
+            QMessageBox::critical(nullptr, tr("Error"), tr("Cannot open file '%1'.").arg(fileLineEdit->text()));
             return false;
         }
 
@@ -301,13 +326,16 @@ bool LoadSetsPage::validatePage()
         readSetsFromByteArray(setsFile.readAll());
 
     }
+
     return false;
 }
 
 void LoadSetsPage::downloadSetsFile(QUrl url)
 {
-    if(!nam)
+    if (!nam)
+    {
         nam = new QNetworkAccessManager(this);
+    }
     QNetworkReply *reply = nam->get(QNetworkRequest(url));
 
     connect(reply, SIGNAL(finished()), this, SLOT(actDownloadFinishedSetsFile()));
@@ -316,10 +344,10 @@ void LoadSetsPage::downloadSetsFile(QUrl url)
 
 void LoadSetsPage::actDownloadProgressSetsFile(qint64 received, qint64 total)
 {
-    if(total > 0)
+    if (total > 0)
     {
-        progressBar->setMaximum(total);
-        progressBar->setValue(received);
+        progressBar->setMaximum(static_cast<int>(total));
+        progressBar->setValue(static_cast<int>(received));
     }
     progressLabel->setText(tr("Downloading (%1MB)").arg((int) received / (1024 * 1024)));
 }
@@ -327,9 +355,10 @@ void LoadSetsPage::actDownloadProgressSetsFile(qint64 received, qint64 total)
 void LoadSetsPage::actDownloadFinishedSetsFile()
 {
     // check for a reply
-    QNetworkReply *reply = static_cast<QNetworkReply *>(sender());
+    auto *reply = dynamic_cast<QNetworkReply *>(sender());
     QNetworkReply::NetworkError errorCode = reply->error();
-    if (errorCode != QNetworkReply::NoError) {
+    if (errorCode != QNetworkReply::NoError)
+    {
         QMessageBox::critical(this, tr("Error"), tr("Network error: %1.").arg(reply->errorString()));
 
         wizard()->enableButtons();
@@ -340,7 +369,8 @@ void LoadSetsPage::actDownloadFinishedSetsFile()
     }
 
     int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-    if (statusCode == 301 || statusCode == 302) {
+    if (statusCode == 301 || statusCode == 302)
+    {
         QUrl redirectUrl = reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
         qDebug() << "following redirect url:" << redirectUrl.toString();
         downloadSetsFile(redirectUrl);
@@ -352,10 +382,14 @@ void LoadSetsPage::actDownloadFinishedSetsFile()
     progressBar->hide();
 
     // save allsets.json url, but only if the user customized it and download was successfull
-    if(urlLineEdit->text() != QString(ALLSETS_URL))
+    if (urlLineEdit->text() != QString(ALLSETS_URL))
+    {
         wizard()->settings->setValue("allsetsurl", urlLineEdit->text());
+    }
     else
+    {
         wizard()->settings->remove("allsetsurl");
+    }
 
     readSetsFromByteArray(reply->readAll());
     reply->deleteLater();
@@ -376,19 +410,20 @@ void LoadSetsPage::readSetsFromByteArray(QByteArray data)
     {
 #ifdef HAS_ZLIB
         // zipped file
-        QBuffer *inBuffer = new QBuffer(&data);
-        QBuffer *outBuffer = new QBuffer(this);
+        auto *inBuffer = new QBuffer(&data);
+        auto *outBuffer = new QBuffer(this);
         QString fileName;
         UnZip::ErrorCode ec;
         UnZip uz;
 
         ec = uz.openArchive(inBuffer);
-        if (ec != UnZip::Ok) {
+        if (ec != UnZip::Ok)
+        {
             zipDownloadFailed(tr("Failed to open Zip archive: %1.").arg(uz.formatError(ec)));
             return;
         }
 
-        if(uz.fileList().size() != 1)
+        if (uz.fileList().size() != 1)
         {
             zipDownloadFailed(tr("Zip extraction failed: the Zip archive doesn't contain exactly one file."));
             return;            
@@ -397,7 +432,8 @@ void LoadSetsPage::readSetsFromByteArray(QByteArray data)
 
         outBuffer->open(QBuffer::ReadWrite);
         ec = uz.extractFile(fileName, outBuffer);
-        if (ec != UnZip::Ok) {
+        if (ec != UnZip::Ok)
+        {
             zipDownloadFailed(tr("Zip extraction failed: %1.").arg(uz.formatError(ec)));
             uz.closeArchive();
             return;
@@ -429,7 +465,8 @@ void LoadSetsPage::zipDownloadFailed(const QString &message)
     progressBar->hide();
 
     QMessageBox::StandardButton reply;
-    reply = QMessageBox::question(this, tr("Error"), message + "<br/>" + tr("Do you want to try to download a fresh copy of the uncompressed file instead?"), QMessageBox::Yes|QMessageBox::No, QMessageBox::Yes);
+    reply = static_cast<QMessageBox::StandardButton>(QMessageBox::question(this, tr("Error"), message + "<br/>" + tr("Do you want to try to download a fresh copy of the uncompressed file instead?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes));
+
     if (reply == QMessageBox::Yes)
     {
         urlRadioButton->setChecked(true);
@@ -446,16 +483,17 @@ void LoadSetsPage::importFinished()
     progressLabel->hide();
     progressBar->hide();
 
-    if(watcher.future().result())
+    if (watcher.future().result())
     {
         wizard()->next();
-    } else {
+    }
+    else
+    {
         QMessageBox::critical(this, tr("Error"), tr("The file was retrieved successfully, but it does not contain any sets data."));
     }
 }
 
-SaveSetsPage::SaveSetsPage(QWidget *parent)
-    : OracleWizardPage(parent)
+SaveSetsPage::SaveSetsPage(QWidget *parent) : OracleWizardPage(parent)
 {
     defaultPathCheckBox = new QCheckBox(this);
     defaultPathCheckBox->setChecked(true);
@@ -463,7 +501,7 @@ SaveSetsPage::SaveSetsPage(QWidget *parent)
     messageLog = new QTextEdit(this);
     messageLog->setReadOnly(true);
 
-    QGridLayout *layout = new QGridLayout(this);
+    auto *layout = new QGridLayout(this);
     layout->addWidget(defaultPathCheckBox, 0, 0);
     layout->addWidget(messageLog, 1, 0);
 
@@ -472,7 +510,7 @@ SaveSetsPage::SaveSetsPage(QWidget *parent)
 
 void SaveSetsPage::cleanupPage()
 {
-    disconnect(wizard()->importer, SIGNAL(setIndexChanged(int, int, const QString &)), 0, 0);
+    disconnect(wizard()->importer, SIGNAL(setIndexChanged(int, int, const QString &)), nullptr, nullptr);
 }
 
 void SaveSetsPage::initializePage()
@@ -482,7 +520,9 @@ void SaveSetsPage::initializePage()
     connect(wizard()->importer, SIGNAL(setIndexChanged(int, int, const QString &)), this, SLOT(updateTotalProgress(int, int, const QString &)));
 
     if (!wizard()->importer->startImport())
+    {
         QMessageBox::critical(this, tr("Error"), tr("No set has been imported."));
+    }
 }
 
 void SaveSetsPage::retranslateUi()
@@ -496,11 +536,15 @@ void SaveSetsPage::retranslateUi()
 
 void SaveSetsPage::updateTotalProgress(int cardsImported, int /* setIndex */, const QString &setName)
 {
-    if (setName.isEmpty()) {
+    if (setName.isEmpty())
+    {
         messageLog->append("<b>" + tr("Import finished: %1 cards.").arg(wizard()->importer->getCardList().size()) + "</b>");
-    } else {
+    }
+    else
+    {
         messageLog->append(tr("%1: %2 cards imported").arg(setName).arg(cardsImported));        
     }
+
     messageLog->verticalScrollBar()->setValue(messageLog->verticalScrollBar()->maximum());
 }
 
@@ -511,39 +555,51 @@ bool SaveSetsPage::validatePage()
     QString windowName = tr("Save card database");
     QString fileType = tr("XML; card database (*.xml)");
 
-    do {
+    do
+    {
         QString fileName;
         if (defaultPathCheckBox->isChecked())
+        {
             fileName = defaultPath;
+        }
         else
+        {
             fileName = QFileDialog::getSaveFileName(this, windowName, defaultPath, fileType);
+        }
 
         if (fileName.isEmpty())
+        {
             return false;
+        }
 
         QFileInfo fi(fileName);
         QDir fileDir(fi.path());
-        if (!fileDir.exists() && !fileDir.mkpath(fileDir.absolutePath())) {
+        if (!fileDir.exists() && !fileDir.mkpath(fileDir.absolutePath()))
+        {
             return false;
         }
+
         if (wizard()->importer->saveToFile(fileName))
         {
             ok = true;
             QMessageBox::information(this,
               tr("Success"),
               tr("The card database has been saved successfully to\n%1").arg(fileName));
-        } else {
+        }
+        else
+        {
             QMessageBox::critical(this, tr("Error"), tr("The file could not be saved to %1").arg(fileName));;
             if (defaultPathCheckBox->isChecked())
+            {
                 defaultPathCheckBox->setChecked(false);
+            }
         }
     } while (!ok);
 
     return true;
 }
 
-LoadTokensPage::LoadTokensPage(QWidget *parent)
-    : OracleWizardPage(parent), nam(0)
+LoadSpoilersPage::LoadSpoilersPage(QWidget *parent) : OracleWizardPage(parent), nam(nullptr)
 {
     urlLabel = new QLabel(this);
     urlLineEdit = new QLineEdit(this);
@@ -554,7 +610,152 @@ LoadTokensPage::LoadTokensPage(QWidget *parent)
     urlButton = new QPushButton(this);
     connect(urlButton, SIGNAL(clicked()), this, SLOT(actRestoreDefaultUrl()));
 
-    QGridLayout *layout = new QGridLayout(this);
+    auto *layout = new QGridLayout(this);
+    layout->addWidget(urlLabel, 0, 0);
+    layout->addWidget(urlLineEdit, 0, 1);
+    layout->addWidget(urlButton, 1, 1, Qt::AlignRight);
+    layout->addWidget(progressLabel, 2, 0);
+    layout->addWidget(progressBar, 2, 1);
+}
+
+void LoadSpoilersPage::actRestoreDefaultUrl()
+{
+    urlLineEdit->setText(SPOILERS_URL);
+}
+
+void LoadSpoilersPage::initializePage()
+{
+    urlLineEdit->setText(wizard()->settings->value("spoilersurl", SPOILERS_URL).toString());
+
+    progressLabel->hide();
+    progressBar->hide();
+}
+
+void LoadSpoilersPage::actDownloadProgressSpoilersFile(qint64 received, qint64 total)
+{
+    if (total > 0)
+    {
+        progressBar->setMaximum(static_cast<int>(total));
+        progressBar->setValue(static_cast<int>(received));
+    }
+
+    progressLabel->setText(tr("Downloading (%1MB)").arg((int) received / (1024 * 1024)));
+}
+
+void LoadSpoilersPage::actDownloadFinishedSpoilersFile()
+{
+    // Check for server reply
+    auto *reply = dynamic_cast<QNetworkReply *>(sender());
+    QNetworkReply::NetworkError errorCode = reply->error();
+
+    if (errorCode != QNetworkReply::NoError)
+    {
+        QMessageBox::critical(this, tr("Error"), tr("Network error: %1.").arg(reply->errorString()));
+
+        wizard()->enableButtons();
+        setEnabled(true);
+
+        reply->deleteLater();
+        return;
+    }
+
+    int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    if (statusCode == 301 || statusCode == 302)
+    {
+        QUrl redirectUrl = reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
+        qDebug() << "following redirect url:" << redirectUrl.toString();
+        downloadSpoilersFile(redirectUrl);
+        reply->deleteLater();
+        return;
+    }
+
+    progressLabel->hide();
+    progressBar->hide();
+
+    // save spoilers.xml url, but only if the user customized it and download was successful
+    if (urlLineEdit->text() != QString(SPOILERS_URL))
+    {
+        wizard()->settings->setValue("spoilersurl", urlLineEdit->text());
+    }
+    else
+    {
+        wizard()->settings->remove("spoilersurl");
+    }
+
+    wizard()->setTokensData(reply->readAll());
+    reply->deleteLater();
+
+    wizard()->enableButtons();
+    setEnabled(true);
+    progressLabel->hide();
+    progressBar->hide();
+
+    wizard()->next();
+}
+
+void LoadSpoilersPage::downloadSpoilersFile(QUrl url)
+{
+    if (!nam)
+    {
+        nam = new QNetworkAccessManager(this);
+    }
+    QNetworkReply *reply = nam->get(QNetworkRequest(url));
+
+    connect(reply, SIGNAL(finished()), this, SLOT(actDownloadFinishedSpoilersFile()));
+    connect(reply, SIGNAL(downloadProgress(qint64, qint64)), this, SLOT(actDownloadProgressSpoilersFile(qint64, qint64)));
+}
+
+bool LoadSpoilersPage::validatePage()
+{
+    // once the import is finished, we call next(); skip validation
+    if (wizard()->hasTokensData())
+    {
+        return true;
+    }
+
+    QUrl url = QUrl::fromUserInput(urlLineEdit->text());
+    if (!url.isValid())
+    {
+        QMessageBox::critical(this, tr("Error"), tr("The provided URL is not valid."));
+        return false;
+    }
+
+    progressLabel->setText(tr("Downloading (0MB)"));
+    // show an infinite progressbar
+    progressBar->setMaximum(0);
+    progressBar->setMinimum(0);
+    progressBar->setValue(0);
+    progressLabel->show();
+    progressBar->show();
+
+    wizard()->disableButtons();
+    setEnabled(false);
+
+    downloadSpoilersFile(url);
+    return false;
+}
+
+void LoadSpoilersPage::retranslateUi()
+{
+    setTitle(tr("Spoilers source selection"));
+    setSubTitle(tr("Please specify a spoiler source."));
+
+    urlLabel->setText(tr("Download URL:"));
+    urlButton->setText(tr("Restore default URL"));
+}
+
+LoadTokensPage::LoadTokensPage(QWidget *parent) : OracleWizardPage(parent), nam(nullptr)
+{
+    urlLabel = new QLabel(this);
+    urlLineEdit = new QLineEdit(this);
+
+    progressLabel = new QLabel(this);
+    progressBar = new QProgressBar(this);
+
+    urlButton = new QPushButton(this);
+    connect(urlButton, SIGNAL(clicked()), this, SLOT(actRestoreDefaultUrl()));
+
+    auto *layout = new QGridLayout(this);
     layout->addWidget(urlLabel, 0, 0);
     layout->addWidget(urlLineEdit, 0, 1);
     layout->addWidget(urlButton, 1, 1, Qt::AlignRight);
@@ -589,11 +790,13 @@ void LoadTokensPage::actRestoreDefaultUrl()
 bool LoadTokensPage::validatePage()
 {
     // once the import is finished, we call next(); skip validation
-    if(wizard()->hasTokensData())
+    if (wizard()->hasTokensData())
+    {
         return true;
+    }
 
     QUrl url = QUrl::fromUserInput(urlLineEdit->text());
-    if(!url.isValid())
+    if (!url.isValid())
     {
         QMessageBox::critical(this, tr("Error"), tr("The provided URL is not valid."));
         return false;
@@ -616,8 +819,10 @@ bool LoadTokensPage::validatePage()
 
 void LoadTokensPage::downloadTokensFile(QUrl url)
 {
-    if(!nam)
+    if (!nam)
+    {
         nam = new QNetworkAccessManager(this);
+    }
     QNetworkReply *reply = nam->get(QNetworkRequest(url));
 
     connect(reply, SIGNAL(finished()), this, SLOT(actDownloadFinishedTokensFile()));
@@ -626,10 +831,10 @@ void LoadTokensPage::downloadTokensFile(QUrl url)
 
 void LoadTokensPage::actDownloadProgressTokensFile(qint64 received, qint64 total)
 {
-    if(total > 0)
+    if (total > 0)
     {
-        progressBar->setMaximum(total);
-        progressBar->setValue(received);
+        progressBar->setMaximum(static_cast<int>(total));
+        progressBar->setValue(static_cast<int>(received));
     }
     progressLabel->setText(tr("Downloading (%1MB)").arg((int) received / (1024 * 1024)));
 }
@@ -637,9 +842,10 @@ void LoadTokensPage::actDownloadProgressTokensFile(qint64 received, qint64 total
 void LoadTokensPage::actDownloadFinishedTokensFile()
 {
     // check for a reply
-    QNetworkReply *reply = static_cast<QNetworkReply *>(sender());
+    auto *reply = dynamic_cast<QNetworkReply *>(sender());
     QNetworkReply::NetworkError errorCode = reply->error();
-    if (errorCode != QNetworkReply::NoError) {
+    if (errorCode != QNetworkReply::NoError)
+    {
         QMessageBox::critical(this, tr("Error"), tr("Network error: %1.").arg(reply->errorString()));
 
         wizard()->enableButtons();
@@ -650,7 +856,8 @@ void LoadTokensPage::actDownloadFinishedTokensFile()
     }
 
     int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-    if (statusCode == 301 || statusCode == 302) {
+    if (statusCode == 301 || statusCode == 302)
+    {
         QUrl redirectUrl = reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
         qDebug() << "following redirect url:" << redirectUrl.toString();
         downloadTokensFile(redirectUrl);
@@ -662,10 +869,14 @@ void LoadTokensPage::actDownloadFinishedTokensFile()
     progressBar->hide();
 
     // save tokens.xml url, but only if the user customized it and download was successfull
-    if(urlLineEdit->text() != QString(TOKENS_URL))
+    if (urlLineEdit->text() != QString(TOKENS_URL))
+    {
         wizard()->settings->setValue("tokensurl", urlLineEdit->text());
+    }
     else
+    {
         wizard()->settings->remove("tokensurl");
+    }
 
     wizard()->setTokensData(reply->readAll());
     reply->deleteLater();
@@ -678,13 +889,83 @@ void LoadTokensPage::actDownloadFinishedTokensFile()
     wizard()->next();
 }
 
-SaveTokensPage::SaveTokensPage(QWidget *parent)
-    : OracleWizardPage(parent)
+SaveSpoilersPage::SaveSpoilersPage(QWidget *parent) : OracleWizardPage(parent)
 {
     defaultPathCheckBox = new QCheckBox(this);
     defaultPathCheckBox->setChecked(true);
 
-    QGridLayout *layout = new QGridLayout(this);
+    auto *layout = new QGridLayout(this);
+    layout->addWidget(defaultPathCheckBox, 0, 0);
+
+    setLayout(layout);
+}
+
+void SaveSpoilersPage::retranslateUi()
+{
+    setTitle(tr("Spoilers imported"));
+    setSubTitle(tr("The spoilers file has been imported. "
+                           "Press \"Save\" to save the imported spoilers to the Cockatrice card database."));
+
+    defaultPathCheckBox->setText(tr("Save to the default path (recommended)"));
+}
+
+bool SaveSpoilersPage::validatePage()
+{
+    bool ok = false;
+    QString defaultPath = settingsCache->getSpoilerCardDatabasePath();
+    QString windowName = tr("Save spoiler database");
+    QString fileType = tr("XML; card database (*.xml)");
+
+    do
+    {
+        QString fileName;
+        if (defaultPathCheckBox->isChecked())
+        {
+            fileName = defaultPath;
+        }
+        else
+        {
+            fileName = QFileDialog::getSaveFileName(this, windowName, defaultPath, fileType);
+        }
+
+        if (fileName.isEmpty())
+        {
+            return false;
+        }
+
+        QFileInfo fi(fileName);
+        QDir fileDir(fi.path());
+        if (!fileDir.exists() && !fileDir.mkpath(fileDir.absolutePath()))
+        {
+            return false;
+        }
+
+        if (wizard()->saveTokensToFile(fileName))
+        {
+            ok = true;
+            QMessageBox::information(this,
+                                     tr("Success"),
+                                     tr("The spoiler database has been saved successfully to\n%1").arg(fileName));
+        }
+        else
+        {
+            QMessageBox::critical(this, tr("Error"), tr("The file could not be saved to %1").arg(fileName));;
+            if (defaultPathCheckBox->isChecked())
+            {
+                defaultPathCheckBox->setChecked(false);
+            }
+        }
+    } while (!ok);
+
+    return true;
+}
+
+SaveTokensPage::SaveTokensPage(QWidget *parent) : OracleWizardPage(parent)
+{
+    defaultPathCheckBox = new QCheckBox(this);
+    defaultPathCheckBox->setChecked(true);
+
+    auto *layout = new QGridLayout(this);
     layout->addWidget(defaultPathCheckBox, 0, 0);
 
     setLayout(layout);
@@ -706,31 +987,45 @@ bool SaveTokensPage::validatePage()
     QString windowName = tr("Save token database");
     QString fileType = tr("XML; token database (*.xml)");
 
-    do {
+    do
+    {
         QString fileName;
         if (defaultPathCheckBox->isChecked())
+        {
             fileName = defaultPath;
+        }
         else
+        {
             fileName = QFileDialog::getSaveFileName(this, windowName, defaultPath, fileType);
+        }
 
         if (fileName.isEmpty())
+        {
             return false;
+        }
+
 
         QFileInfo fi(fileName);
         QDir fileDir(fi.path());
-        if (!fileDir.exists() && !fileDir.mkpath(fileDir.absolutePath())) {
+        if (!fileDir.exists() && !fileDir.mkpath(fileDir.absolutePath()))
+        {
             return false;
         }
+
         if (wizard()->saveTokensToFile(fileName))
         {
             ok = true;
             QMessageBox::information(this,
               tr("Success"),
               tr("The token database has been saved successfully to\n%1").arg(fileName));
-        } else {
+        }
+        else
+        {
             QMessageBox::critical(this, tr("Error"), tr("The file could not be saved to %1").arg(fileName));;
             if (defaultPathCheckBox->isChecked())
+            {
                 defaultPathCheckBox->setChecked(false);
+            }
         }
     } while (!ok);
 

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -676,7 +676,7 @@ void LoadSpoilersPage::actDownloadFinishedSpoilersFile()
     progressLabel->hide();
     progressBar->hide();
 
-    // save spoilers.xml url, but only if the user customized it and download was successful
+    // save spoiler.xml url, but only if the user customized it and download was successful
     if (urlLineEdit->text() != QString(SPOILERS_URL))
     {
         wizard()->settings->setValue("spoilersurl", urlLineEdit->text());

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -48,14 +48,18 @@ OracleWizard::OracleWizard(QWidget *parent) : QWizard(parent)
 
     addPage(new IntroPage);
 
-
-    addPage(new LoadSetsPage);
-    addPage(new SaveSetsPage);
-    addPage(new LoadTokensPage);
-    addPage(new SaveTokensPage);
-
-    addPage(new LoadSpoilersPage);
-    addPage(new SaveSpoilersPage);
+    if (! isSpoilersOnly)
+    {
+        addPage(new LoadSetsPage);
+        addPage(new SaveSetsPage);
+        addPage(new LoadTokensPage);
+        addPage(new SaveTokensPage);
+    }
+    else
+    {
+        addPage(new LoadSpoilersPage);
+        addPage(new SaveSpoilersPage);
+    }
 
     retranslateUi();
 }

--- a/oracle/src/oraclewizard.h
+++ b/oracle/src/oraclewizard.h
@@ -97,7 +97,7 @@ class LoadSetsPage : public OracleWizardPage
         QPushButton *urlButton;
         QPushButton *fileButton;
         QLabel *progressLabel;
-        QProgressBar * progressBar;
+        QProgressBar *progressBar;
 
         QNetworkAccessManager *nam;
         QFutureWatcher<bool> watcher;
@@ -144,7 +144,7 @@ class LoadSpoilersPage : public OracleWizardPage
         QLineEdit *urlLineEdit;
         QPushButton *urlButton;
         QLabel *progressLabel;
-        QProgressBar * progressBar;
+        QProgressBar *progressBar;
         QNetworkAccessManager *nam;
 
     private slots:

--- a/oracle/src/oraclewizard.h
+++ b/oracle/src/oraclewizard.h
@@ -4,6 +4,7 @@
 #include <QWizard>
 #include <QFutureWatcher>
 #include <QFuture>
+#include <utility>
 
 class QCheckBox;
 class QGroupBox;
@@ -20,139 +21,195 @@ class QSettings;
 
 class OracleWizard : public QWizard
 {
-     Q_OBJECT
-public:
-     OracleWizard(QWidget *parent = 0);
-     void accept();
-     void enableButtons();
-     void disableButtons();
-     void retranslateUi();
-     void setTokensData(QByteArray _tokensData) { tokensData = _tokensData; }
-     bool hasTokensData() { return !tokensData.isEmpty(); }
-     bool saveTokensToFile(const QString & fileName);
-public: 
-     OracleImporter *importer;
-     QSettings * settings;
-private slots:
-    void updateLanguage();
-private:
-    QStringList findQmFiles();
-    QString languageName(const QString &qmFile);
-    QByteArray tokensData;
-protected:
-    void changeEvent(QEvent *event);
-};
+    Q_OBJECT
+    public:
+        explicit OracleWizard(QWidget *parent = nullptr);
+        void accept() override;
+        void enableButtons();
+        void disableButtons();
+        void retranslateUi();
+        void setTokensData(QByteArray _tokensData) { tokensData = std::move(_tokensData); }
+        bool hasTokensData() { return !tokensData.isEmpty(); }
+        bool saveTokensToFile(const QString & fileName);
 
+    public:
+        OracleImporter *importer;
+        QSettings *settings;
+
+    private slots:
+        void updateLanguage();
+
+    private:
+        QByteArray tokensData;
+
+    protected:
+        void changeEvent(QEvent *event) override;
+};
 
 class OracleWizardPage : public QWizardPage
 {
-     Q_OBJECT
-public:
-     OracleWizardPage(QWidget *parent = 0): QWizardPage(parent) {};
-     virtual void retranslateUi() = 0;
-protected:
-     inline OracleWizard *wizard() { return (OracleWizard*) QWizardPage::wizard(); };
+    Q_OBJECT
+    public:
+        explicit OracleWizardPage(QWidget *parent = nullptr): QWizardPage(parent) {};
+        virtual void retranslateUi() = 0;
+
+    protected:
+        inline OracleWizard *wizard() { return (OracleWizard*) QWizardPage::wizard(); };
 };
 
 class IntroPage : public OracleWizardPage
 {
-     Q_OBJECT
-public:
-    IntroPage(QWidget *parent = 0);
-    void retranslateUi();
-private:
-    QStringList findQmFiles();
-    QString languageName(const QString &qmFile);
-private:
-     QLabel *label, *languageLabel, *versionLabel;
-     QComboBox *languageBox;
-private slots:
-    void languageBoxChanged(int index);
+    Q_OBJECT
+    public:
+        explicit IntroPage(QWidget *parent = nullptr);
+        void retranslateUi() override;
+
+    private:
+        QStringList findQmFiles();
+        QString languageName(const QString &qmFile);
+
+    private:
+        QLabel *label, *languageLabel, *versionLabel;
+        QComboBox *languageBox;
+
+    private slots:
+        void languageBoxChanged(int index);
 };
 
 class LoadSetsPage : public OracleWizardPage
 {
      Q_OBJECT
-public:
-     LoadSetsPage(QWidget *parent = 0);
-    void retranslateUi();
-protected:
-     void initializePage();
-     bool validatePage();
-     void readSetsFromByteArray(QByteArray data);
-     void downloadSetsFile(QUrl url);
-private:
-     QRadioButton *urlRadioButton;
-     QRadioButton *fileRadioButton;
-     QLineEdit *urlLineEdit;
-     QLineEdit *fileLineEdit;
-     QPushButton *urlButton;
-     QPushButton *fileButton;
-     QLabel *progressLabel;
-     QProgressBar * progressBar;
+    public:
+        explicit LoadSetsPage(QWidget *parent = nullptr);
+        void retranslateUi() override;
 
-     QNetworkAccessManager *nam;
-     QFutureWatcher<bool> watcher;
-     QFuture<bool> future;
-private slots:
-     void actLoadSetsFile();
-     void actRestoreDefaultUrl();
-     void actDownloadProgressSetsFile(qint64 received, qint64 total);
-     void actDownloadFinishedSetsFile();
-     void importFinished();
-     void zipDownloadFailed(const QString &message);
+    protected:
+        void initializePage() override;
+        bool validatePage() override;
+        void readSetsFromByteArray(QByteArray data);
+        void downloadSetsFile(QUrl url);
+
+    private:
+        QRadioButton *urlRadioButton;
+        QRadioButton *fileRadioButton;
+        QLineEdit *urlLineEdit;
+        QLineEdit *fileLineEdit;
+        QPushButton *urlButton;
+        QPushButton *fileButton;
+        QLabel *progressLabel;
+        QProgressBar * progressBar;
+
+        QNetworkAccessManager *nam;
+        QFutureWatcher<bool> watcher;
+        QFuture<bool> future;
+
+    private slots:
+        void actLoadSetsFile();
+        void actRestoreDefaultUrl();
+        void actDownloadProgressSetsFile(qint64 received, qint64 total);
+        void actDownloadFinishedSetsFile();
+        void importFinished();
+        void zipDownloadFailed(const QString &message);
 };
 
 class SaveSetsPage : public OracleWizardPage
 {
-     Q_OBJECT
-public:
-     SaveSetsPage(QWidget *parent = 0);
-    void retranslateUi();
-private:
-     QTextEdit *messageLog;
-     QCheckBox * defaultPathCheckBox;
-protected:
-     void initializePage();
-     void cleanupPage();
-     bool validatePage();
-private slots:
-     void updateTotalProgress(int cardsImported, int setIndex, const QString &setName);
+    Q_OBJECT
+    public:
+        explicit SaveSetsPage(QWidget *parent = nullptr);
+        void retranslateUi() override;
+
+    private:
+        QTextEdit *messageLog;
+        QCheckBox *defaultPathCheckBox;
+
+    protected:
+        void initializePage() override;
+        void cleanupPage() override;
+        bool validatePage() override;
+
+    private slots:
+        void updateTotalProgress(int cardsImported, int setIndex, const QString &setName);
+};
+
+class LoadSpoilersPage : public OracleWizardPage
+{
+    Q_OBJECT
+    public:
+        explicit LoadSpoilersPage(QWidget *parent = nullptr);
+        void retranslateUi() override;
+
+    private:
+        QLabel *urlLabel;
+        QLineEdit *urlLineEdit;
+        QPushButton *urlButton;
+        QLabel *progressLabel;
+        QProgressBar * progressBar;
+        QNetworkAccessManager *nam;
+
+    private slots:
+        void actRestoreDefaultUrl();
+        void actDownloadProgressSpoilersFile(qint64 received, qint64 total);
+        void actDownloadFinishedSpoilersFile();
+
+    protected:
+        void initializePage() override;
+        bool validatePage() override;
+        void downloadSpoilersFile(QUrl url);
+};
+
+class SaveSpoilersPage : public OracleWizardPage
+{
+    Q_OBJECT
+    public:
+        explicit SaveSpoilersPage(QWidget *parent = nullptr);
+        void retranslateUi() override;
+
+    private:
+        QCheckBox *defaultPathCheckBox;
+
+    protected:
+        bool validatePage() override;
 };
 
 class LoadTokensPage : public OracleWizardPage
 {
-     Q_OBJECT
-public:
-     LoadTokensPage(QWidget *parent = 0);
-    void retranslateUi();
-protected:
-     void initializePage();
-     bool validatePage();
-     void downloadTokensFile(QUrl url);
-private:
-     QLabel *urlLabel;
-     QLineEdit *urlLineEdit;
-     QPushButton *urlButton;
-     QLabel *progressLabel;
-     QProgressBar * progressBar;
+    Q_OBJECT
+    public:
+        explicit LoadTokensPage(QWidget *parent = nullptr);
+        void retranslateUi() override;
 
-     QNetworkAccessManager *nam;
-private slots:
-     void actRestoreDefaultUrl();
-     void actDownloadProgressTokensFile(qint64 received, qint64 total);
-     void actDownloadFinishedTokensFile();
+    protected:
+        void initializePage() override;
+        bool validatePage() override;
+        void downloadTokensFile(QUrl url);
+
+    private:
+        QLabel *urlLabel;
+        QLineEdit *urlLineEdit;
+        QPushButton *urlButton;
+        QLabel *progressLabel;
+        QProgressBar *progressBar;
+        QNetworkAccessManager *nam;
+
+    private slots:
+        void actRestoreDefaultUrl();
+        void actDownloadProgressTokensFile(qint64 received, qint64 total);
+        void actDownloadFinishedTokensFile();
 };
 
 class SaveTokensPage : public OracleWizardPage
 {
-     Q_OBJECT
-public:
-     SaveTokensPage(QWidget *parent = 0);
-    void retranslateUi();
-private:
-     QCheckBox * defaultPathCheckBox;
-protected:
-     bool validatePage();
+    Q_OBJECT
+    public:
+        explicit SaveTokensPage(QWidget *parent = nullptr);
+        void retranslateUi() override;
+
+    private:
+        QCheckBox *defaultPathCheckBox;
+
+    protected:
+        bool validatePage() override;
 };
+
 #endif

--- a/tests/carddatabase/carddatabase_test.cpp
+++ b/tests/carddatabase/carddatabase_test.cpp
@@ -14,6 +14,7 @@ SettingsCache::~SettingsCache() { delete cardDatabaseSettings; };
 QString SettingsCache::getCustomCardDatabasePath() const { return QString("%1/customsets/").arg(CARDDB_DATADIR); }
 QString SettingsCache::getCardDatabasePath() const { return QString("%1/cards.xml").arg(CARDDB_DATADIR); }
 QString SettingsCache::getTokenDatabasePath() const { return QString("%1/tokens.xml").arg(CARDDB_DATADIR); }
+QString SettingsCache::getSpoilerCardDatabasePath() const { return QString("%1/spoilers.xml").arg(CARDDB_DATADIR); }
 CardDatabaseSettings& SettingsCache::cardDatabase() const { return *cardDatabaseSettings; }
 
 SettingsCache *settingsCache;
@@ -38,7 +39,7 @@ namespace {
 
         // load dummy cards and test result
         db->loadCardDatabases();
-        ASSERT_EQ(6, db->getCardList().size()) << "Wrong card count after load";
+        ASSERT_EQ(7, db->getCardList().size()) << "Wrong card count after load";
         ASSERT_EQ(3, db->getSetList().size()) << "Wrong sets count after load";
         ASSERT_EQ(4, db->getAllColors().size()) << "Wrong colors count after load";
         ASSERT_EQ(2, db->getAllMainCardTypes().size()) << "Wrong types count after load";

--- a/tests/carddatabase/carddatabase_test.cpp
+++ b/tests/carddatabase/carddatabase_test.cpp
@@ -14,7 +14,7 @@ SettingsCache::~SettingsCache() { delete cardDatabaseSettings; };
 QString SettingsCache::getCustomCardDatabasePath() const { return QString("%1/customsets/").arg(CARDDB_DATADIR); }
 QString SettingsCache::getCardDatabasePath() const { return QString("%1/cards.xml").arg(CARDDB_DATADIR); }
 QString SettingsCache::getTokenDatabasePath() const { return QString("%1/tokens.xml").arg(CARDDB_DATADIR); }
-QString SettingsCache::getSpoilerCardDatabasePath() const { return QString("%1/spoilers.xml").arg(CARDDB_DATADIR); }
+QString SettingsCache::getSpoilerCardDatabasePath() const { return QString("%1/spoiler.xml").arg(CARDDB_DATADIR); }
 CardDatabaseSettings& SettingsCache::cardDatabase() const { return *cardDatabaseSettings; }
 
 SettingsCache *settingsCache;

--- a/tests/carddatabase/carddatabase_test.cpp
+++ b/tests/carddatabase/carddatabase_test.cpp
@@ -39,7 +39,7 @@ namespace {
 
         // load dummy cards and test result
         db->loadCardDatabases();
-        ASSERT_EQ(7, db->getCardList().size()) << "Wrong card count after load";
+        ASSERT_EQ(6, db->getCardList().size()) << "Wrong card count after load";
         ASSERT_EQ(3, db->getSetList().size()) << "Wrong sets count after load";
         ASSERT_EQ(4, db->getAllColors().size()) << "Wrong colors count after load";
         ASSERT_EQ(2, db->getAllMainCardTypes().size()) << "Wrong types count after load";

--- a/tests/carddatabase/carddatabase_test.h
+++ b/tests/carddatabase/carddatabase_test.h
@@ -30,6 +30,7 @@ public:
     QString getCustomCardDatabasePath() const;
     QString getCardDatabasePath() const;
     QString getTokenDatabasePath() const;
+    QString getSpoilerCardDatabasePath() const;
     CardDatabaseSettings& cardDatabase() const;
 signals:
     void cardDatabasePathChanged();

--- a/tests/carddatabase/data/spoilers.xml
+++ b/tests/carddatabase/data/spoilers.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cockatrice_carddatabase version="3">
+    <cards>
+        <card>
+            <name>Fluffy</name>
+            <set muId="311">CAT</set>
+            <color>G</color>
+            <manacost></manacost>
+            <cmc></cmc>
+            <type>Token</type>
+            <pt>0/1</pt>
+            <tablerow>0</tablerow>
+            <text></text>
+            <token>1</token>
+        </card>
+    </cards>
+</cockatrice_carddatabase>


### PR DESCRIPTION
This PR contains a lot, so lets try and break it down a bit.

The goal of this PR is to allow users to automatically download and manage their spoilers through our spoiler service, Magic-Spoiler. In order to accomplish this, I've added components to the settings dialog.

<img width="910" alt="screenshot 2018-01-08 23 52 23" src="https://user-images.githubusercontent.com/7460172/34705532-072050bc-f4cf-11e7-9752-736a25a3274b.png">

If the user ticks the "Download Spoilers Automatically" button, the following gears internally will start turning:
+ On Cockatrice launch, check if the file "SpoilerSeasonEnabled" exists on the Magic-Spoiler repo. If it does not, then we know we are not in spoiler season and will continue with normal launch.

+ If the file does exist, then we will continue and now download spoiler.xml from the Magic-Spoiler repo. The system will then check if the downloaded copy matches the current local copy. If there is no local copy or the file hashes do not match, then we will replace the local copy with the downloaded copy and alert the user.
<img width="377" alt="screenshot 2018-01-08 23 58 02" src="https://user-images.githubusercontent.com/7460172/34705634-c8aa05f2-f4cf-11e7-8f54-3ae9bc304cdd.png">


+ If the file hashes do match, then we know the spoilers are up to date and we discard the downloaded version and alert the user.
<img width="379" alt="screenshot 2018-01-08 23 56 18" src="https://user-images.githubusercontent.com/7460172/34705597-87b367b4-f4cf-11e7-9508-d209e8fcb5cc.png">

+ If the user presses the "Update Spoilers" button in the system settings, it will trigger bullet point 1 above with the SpoilerSeasonEnabled check and continue down the line.

+ If any errors occur, they will be properly logged in the debugger. 

___

In addition to the changes above, there is some general cleanup in the code base (as dictated by CLion's strict IDE policy of ensuring top quality code). Some examples include adding `explicit` to functions or `override`s. In addition, there are some bracket realignments and header realignments to meet the new coding policy (which will be updated in the near future).

Continuing on, the first attempt of this PR used Oracle to download the spoilers. Since I find that code to be useful, I have decided to leave it in the PR as an Easter Egg so it can be used in the future by another process (who knows, maybe we'll want to have Oracle do new things, and this is a great example of what it is capable of!)

Finally, I detected a race-time condition that can come about if the system attempts to reload the card database while a reload is currently in progress. I have added a Mutex to make the card database reload thread safe from now on.

  