### PR TITLE
token creation context menu improvements

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2676,7 +2676,7 @@ void Player::addRelatedCardActions(const CardItem *card, QMenu *cardMenu) {
             if (relatedCards.at(0)->getDoesAttach()) {
                 createRelatedCards = new QAction(tr("Token: ") + tr("Attach to ") + "\"" + relatedCards.at(0)->getName() + "\"", this);
             } else
-                createRelatedCards = new QAction(tr("Token: ") + (relatedCards.at(0)->getIsVariable() ? "X " : QString(relatedCards.at(0)->getDefaultCount() == 1 ? "1x " : QString::number(relatedCards.at(0)->getDefaultCount()) + "x ")) + relatedCards.at(0)->getName(), this);
+                createRelatedCards = new QAction(tr("Token: ") + (relatedCards.at(0)->getIsVariable() ? "X " : QString(relatedCards.at(0)->getDefaultCount() == 1 ? QString() : QString::number(relatedCards.at(0)->getDefaultCount()) + "x ")) + relatedCards.at(0)->getName(), this);
             connect(createRelatedCards, SIGNAL(triggered()), this, SLOT(actCreateAllRelatedCards()));
             if (shortcutsActive) {
                 createRelatedCards->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aCreateRelatedTokens"));
@@ -2692,9 +2692,9 @@ void Player::addRelatedCardActions(const CardItem *card, QMenu *cardMenu) {
                 QString cardName = cardRelation->getName();
                 QAction *createRelated;
                 if (cardRelation->getDoesAttach())
-                    createRelated = new QAction(tr("Token: ") + tr("Attach to ") + cardName, this);
+                    createRelated = new QAction(tr("Token: ") + tr("Attach to ") + "\"" + cardName + "\"", this);
                 else
-                    createRelated = new QAction(tr("Token: ") + (cardRelation->getIsVariable() ? "X " : QString(cardRelation->getDefaultCount() == 1 ? QString() : QString::number(cardRelation->getDefaultCount()) + " ")) + cardName, this);
+                    createRelated = new QAction(tr("Token: ") + (cardRelation->getIsVariable() ? "X " : QString(cardRelation->getDefaultCount() == 1 ? QString() : QString::number(cardRelation->getDefaultCount()) + "x ")) + cardName, this);
                 createRelated->setData(QVariant(i));
                 connect(createRelated, SIGNAL(triggered()), this, SLOT(actCreateRelatedCard()));
                 cardMenu->addAction(createRelated);

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2676,7 +2676,7 @@ void Player::addRelatedCardActions(const CardItem *card, QMenu *cardMenu) {
             if (relatedCards.at(0)->getDoesAttach()) {
                 createRelatedCards = new QAction(tr("Token: ") + tr("Attach to ") + relatedCards.at(0)->getName(), this);
             } else
-                createRelatedCards = new QAction(tr("Token: ") + (relatedCards.at(0)->getIsVariable() ? "X " : QString(relatedCards.at(0)->getDefaultCount() == 1 ? QString() : QString::number(relatedCards.at(0)->getDefaultCount()) + " ")) + relatedCards.at(0)->getName(), this);
+                createRelatedCards = new QAction(tr("Token: ") + (relatedCards.at(0)->getIsVariable() ? "X " : QString(relatedCards.at(0)->getDefaultCount() == 1 ? "1x " : QString::number(relatedCards.at(0)->getDefaultCount()) + "x ")) + relatedCards.at(0)->getName(), this);
             connect(createRelatedCards, SIGNAL(triggered()), this, SLOT(actCreateAllRelatedCards()));
             if (shortcutsActive) {
                 createRelatedCards->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aCreateRelatedTokens"));

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2674,7 +2674,7 @@ void Player::addRelatedCardActions(const CardItem *card, QMenu *cardMenu) {
             cardMenu->addSeparator();
             QAction *createRelatedCards;
             if (relatedCards.at(0)->getDoesAttach()) {
-                createRelatedCards = new QAction(tr("Token: ") + tr("Attach to ") + relatedCards.at(0)->getName(), this);
+                createRelatedCards = new QAction(tr("Token: ") + tr("Attach to ") + "\"" + relatedCards.at(0)->getName() + "\"", this);
             } else
                 createRelatedCards = new QAction(tr("Token: ") + (relatedCards.at(0)->getIsVariable() ? "X " : QString(relatedCards.at(0)->getDefaultCount() == 1 ? "1x " : QString::number(relatedCards.at(0)->getDefaultCount()) + "x ")) + relatedCards.at(0)->getName(), this);
             connect(createRelatedCards, SIGNAL(triggered()), this, SLOT(actCreateAllRelatedCards()));


### PR DESCRIPTION
## What will change with this Pull Request?
- better visual display and separation of card names that other cards get attached to
- make quantity of tokens more clear, the quantity digit and token strength digit visually merged easily 

## Screenshots
- before:
![abbey-old](https://user-images.githubusercontent.com/9874850/34692422-6c7618d4-f4c0-11e7-9ee0-74c9d3589ea8.png)
![alarm-old](https://user-images.githubusercontent.com/9874850/34692430-721608e4-f4c0-11e7-9122-238c5e84c0c1.png)
![old](https://user-images.githubusercontent.com/9874850/34692251-d17f45c6-f4bf-11e7-9f04-af186a73f6a0.png)

- after:
![abbey](https://user-images.githubusercontent.com/9874850/34692259-da8bb226-f4bf-11e7-8cd0-6a28d93d3fcd.png)
![alarm](https://user-images.githubusercontent.com/9874850/34692265-dd2aa53c-f4bf-11e7-8cff-95e07676cec9.png)
![new](https://user-images.githubusercontent.com/9874850/34692253-d66e4636-f4bf-11e7-9cd3-77e9e1dc110e.png)
![morph](https://user-images.githubusercontent.com/9874850/34692628-0a21ae68-f4c1-11e7-9984-2c041ac2efb2.png)


Note that single numbered tokens and flexible quantity "X" won't change and aren't affected.
Also, nothing changes for translators.

Please double check code context and logic.
  