### PR TITLE
deck editor: add placeholder text to search

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -323,7 +323,7 @@ void TabDeckEditor::createCentralFrame()
     setFocusPolicy(Qt::ClickFocus);
 
     searchEdit->installEventFilter(&searchKeySignals);
-	searchEdit->setPlaceholderText(tr("Search by card name"));
+    searchEdit->setPlaceholderText(tr("Search by card name"));
     searchKeySignals.setObjectName("searchKeySignals");
     connect(searchEdit, SIGNAL(textChanged(const QString &)), this, SLOT(updateSearch(const QString &)));
     connect(&searchKeySignals, SIGNAL(onEnter()), this, SLOT(actAddCard()));

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -323,6 +323,7 @@ void TabDeckEditor::createCentralFrame()
     setFocusPolicy(Qt::ClickFocus);
 
     searchEdit->installEventFilter(&searchKeySignals);
+	searchEdit->setPlaceholderText(tr("Search by card name"));
     searchKeySignals.setObjectName("searchKeySignals");
     connect(searchEdit, SIGNAL(textChanged(const QString &)), this, SLOT(updateSearch(const QString &)));
     connect(&searchKeySignals, SIGNAL(onEnter()), this, SLOT(actAddCard()));


### PR DESCRIPTION
## Short roundup of the initial problem
No hint/description about card search

## What will change with this Pull Request?
- Let users know that the search will only considers a card's name

## Screenshots
![search](https://user-images.githubusercontent.com/9874850/34694678-3bcf0972-f4c8-11e7-82b6-bc4e6d7d249c.png)
Once you start typing the soft greyish placeholder text will vanish.