### PR TITLE
Trim all inputs (except password)

### DIFF
--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -52,7 +52,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     autoConnectCheckBox = new QCheckBox(tr("A&uto connect"));
     autoConnectCheckBox->setToolTip(tr("Automatically connect to the most recent login when Cockatrice opens"));
 
-    publicServersLabel = new QLabel(QString("(<a href=\"%1\">%2</a>").arg(PUBLIC_SERVERS_URL).arg(tr("Public Servers")));
+    publicServersLabel = new QLabel(QString("(<a href=\"%1\">%2</a>)").arg(PUBLIC_SERVERS_URL).arg(tr("Public Servers")));
     publicServersLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
     publicServersLabel->setWordWrap(true);
     publicServersLabel->setTextFormat(Qt::RichText);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3016

This will trim all inputs to the login details except for the password.