### PR TITLE
Windows package updates

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,29 +15,41 @@ skip_commits:
     - Dockerfile
     - LICENSE
 
-image: Visual Studio 2015
+image: Visual Studio 2017
 
 cache:
+    - c:\openssl-release
     - c:\protobuf-release
     - c:\zlib-release
 
 environment:
     matrix:
-        - qt_ver: 5.9\msvc2015_64
-          protobuf_ver: 3.4.1
+        - qt_ver: 5.9\msvc2017_64
+          openssl_ver: 1.0.2n-x64_86-win64
+          protobuf_ver: 3.5.1
           zlib_ver: 1.2.11
-          cmake_generator: Visual Studio 14 2015 Win64
-          cmake_toolset: v140,host=x64
+          cmake_generator: Visual Studio 15 2017 Win64
+          cmake_toolset: v141,host=x64
           target_arch: x86_64
-        - qt_ver: 5.9\msvc2015
-          protobuf_ver: 3.4.1
+          vc_arch: amd64
+        - qt_ver: 5.9\msvc2015 # Qt doesn't provide a msvc2017_32
+          openssl_ver: 1.0.2n-i386-win32
+          protobuf_ver: 3.5.1
           zlib_ver: 1.2.11
-          cmake_generator: Visual Studio 14 2015
-          cmake_toolset: v140
+          cmake_generator: Visual Studio 15 2017
+          cmake_toolset: v141
           target_arch: x86
+          vc_arch: amd64_x86
 
 install:
     - ps: |
+        if (Test-Path c:\openssl-release) {
+            echo "using openssl from cache"
+        } else {
+            Invoke-WebRequest "https://indy.fulgan.com/SSL/openssl-$env:openssl_ver.zip" -OutFile c:\openssl-$env:openssl_ver.zip
+            Expand-Archive -Path c:\openssl-$env:openssl_ver.zip -DestinationPath c:\openssl-release
+            Set-Location -Path C:\openssl-release
+        }
         if (Test-Path c:\protobuf-release) {
             echo "using protobuf from cache"
         } else {
@@ -65,10 +77,11 @@ build_script:
         New-Item -ItemType directory -Path $env:APPVEYOR_BUILD_FOLDER\build
         Set-Location -Path $env:APPVEYOR_BUILD_FOLDER\build
         $zlibdir = "c:\zlib-release"
+        $openssldir = "C:\openssl-release"
         $protodir = "c:\protobuf-release"
         $protoc = "c:\protobuf-release\bin\protoc.exe"
         $mysqldll = "c:\Program Files\MySQL\MySQL Server 5.7\lib\libmysql.dll"
-        cmake .. -G "$env:cmake_generator" -T "$env:cmake_toolset" "-DCMAKE_PREFIX_PATH=c:/Qt/$env:qt_ver;$protodir;$zlibdir" "-DWITH_SERVER=1" "-DPROTOBUF_PROTOC_EXECUTABLE=$protoc" "-DMYSQLCLIENT_LIBRARIES=$mysqldll"
+        cmake .. -G "$env:cmake_generator" -T "$env:cmake_toolset" "-DCMAKE_PREFIX_PATH=c:/Qt/$env:qt_ver;$protodir;$zlibdir;$openssldir" "-DWITH_SERVER=1" "-DPROTOBUF_PROTOC_EXECUTABLE=$protoc" "-DMYSQLCLIENT_LIBRARIES=$mysqldll"
     - msbuild PACKAGE.vcxproj /p:Configuration=Release
     - ps: |
         $exe = dir -name *.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,6 @@ endif()
 # Define proper compilation flags
 IF(MSVC)
     # Visual Studio:
-    # Support from Windows XP
-    SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:WINDOWS,5.01")
     # Maximum optimization
     set(CMAKE_CXX_FLAGS_RELEASE "/Ox /MD")
     # Generate complete debugging information
@@ -182,6 +180,15 @@ elseif(WIN32)
         ${CMAKE_MODULE_PATH}/NSIS.definitions.nsh.in
         ${PROJECT_BINARY_DIR}/NSIS.definitions.nsh
     )
+
+    # include vcredist into the package; NSIS will take care of running it
+    IF(MSVC)
+        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+            INSTALL(FILES "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/redist/MSVC/14.12.25810/vc_redist.x64.exe" DESTINATION ./)
+        else()
+            INSTALL(FILES "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/redist/MSVC/14.12.25810/vc_redist.x86.exe" DESTINATION ./)
+        endif()
+    ENDIF()
 endif()
 
 include(CPack)

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -196,6 +196,17 @@ ${If} $PortableMode = 0
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice" "InstallLocation" "$INSTDIR"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice" "DisplayIcon" "$INSTDIR\cockatrice.exe"
 	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice" "EstimatedSize" "$0"
+
+	IfFileExists "$INSTDIR\vc_redist.x86.exe" VcRedist86Exists PastVcRedist86Check
+	VcRedist86Exists:
+		ExecWait '"$INSTDIR\vc_redist.x86.exe"  /quiet /norestart'
+	PastVcRedist86Check:
+
+	IfFileExists "$INSTDIR\vc_redist.x64.exe" VcRedist64Exists PastVcRedist64Check
+	VcRedist64Exists:
+		ExecWait '"$INSTDIR\vc_redist.x64.exe"  /quiet /norestart'
+	PastVcRedist64Check:
+
 ${Else}
     ; Create the file the application uses to detect portable mode
     FileOpen $0 "$INSTDIR\portable.dat" w
@@ -220,20 +231,12 @@ Section "un.Application" UnSecApplication
 	RMDir /r "$INSTDIR\sounds"
 	RMDir /r "$INSTDIR\themes"
 	RMDir /r "$INSTDIR\translations"
-	Delete "$INSTDIR\uninstall.exe"
-	Delete "$INSTDIR\cockatrice.exe"
-	Delete "$INSTDIR\oracle.exe"
-	Delete "$INSTDIR\servatrice.exe"
-	Delete "$INSTDIR\Qt*.dll"
-	Delete "$INSTDIR\libmysql.dll"
-	Delete "$INSTDIR\icu*.dll"
-	Delete "$INSTDIR\libeay32.dll"
-	Delete "$INSTDIR\ssleay32.dll"
+	Delete "$INSTDIR\*.exe"
+	Delete "$INSTDIR\*.dll"
 	Delete "$INSTDIR\qt.conf"
 	Delete "$INSTDIR\qdebug.txt"
 	Delete "$INSTDIR\servatrice.sql"
 	Delete "$INSTDIR\servatrice.ini.example"
-	Delete "$INSTDIR\zlib*.dll"
 	RMDir "$INSTDIR"
 
 	RMDir "$SMPROGRAMS\Cockatrice"


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2994 
- Fixes #2031
- Relates to #2973

## Short roundup of the initial problem
The openssl libraries that we currently bundle depends on the Visual studio 2013 runtime. This means that while Cockatrice (and Oracle, Servatrice) depends on the Visual studio 2015 runtime to start, the Visual studio 2013 runtime is also needed in order to make Qt able to load the openssl libraries and handle https urls.

## What will change with this Pull Request?
 * Appveyor will use Visual Studio 2017 to compile protobuf, zlib and Cockatrice.
 * Protobuf has been updated to 3.5.1
 * Instead of using the appveyor-provided openssl package, we download and bundle a semi-official package from https://indy.fulgan.com (found here: https://wiki.openssl.org/index.php/Binaries ) than has no dependency on any Visual Studio runtime
 * a small compilation warning has been removed (leftover of Windows Xp compatibility)
 * during the "install" step, cmake will install a copy of the correct vcresit packae in the cockatrice tree that will be included in the NSIS package
 * during installation, NSIS will run the vcredist if available inside the package.

As a result of this last change, the package size almost doubled from  ~16 to ~30 MB.


## Screenshots
*(simply drag & drop image files directly into this description!)*
