### PR TITLE
Travis: remove sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-sudo: required   # forces legacy build infrastructure
-group: travis_lts   # forces most stable build images
-
 language: cpp
 
 matrix:
@@ -8,10 +5,38 @@ matrix:
   include:
   - os: linux
     dist: trusty
-    env: BUILDTYPE=Debug DIST=trusty
+    env: BUILDTYPE=Debug
+    addons:
+      apt:
+        packages:
+        - bc
+        - cmake  
+        - libprotobuf-dev
+        - protobuf-compiler
+        - qt5-default
+        - qttools5-dev
+        - qttools5-dev-tools
+        - qtmultimedia5-dev
+        - libqt5multimedia5-plugins
+        - libqt5svg5-dev
+        - libqt5sql5-mysql
   - os: linux
     dist: trusty
-    env: BUILDTYPE=Release DIST=trusty
+    env: BUILDTYPE=Release
+    addons:
+      apt:
+        packages:
+        - bc
+        - cmake  
+        - libprotobuf-dev
+        - protobuf-compiler
+        - qt5-default
+        - qttools5-dev
+        - qttools5-dev-tools
+        - qtmultimedia5-dev
+        - libqt5multimedia5-plugins
+        - libqt5svg5-dev
+        - libqt5sql5-mysql
   - os: osx
     osx_image: xcode7.3
     env: BUILDTYPE=Debug
@@ -31,7 +56,7 @@ matrix:
 
 cache: ccache
 
-install: bash ./.travis/travis-dependencies.sh
+before_install: bash ./.travis/travis-dependencies.sh
 
 script: bash ./.travis/travis-compile.sh
 

--- a/.travis/travis-dependencies.sh
+++ b/.travis/travis-dependencies.sh
@@ -4,28 +4,4 @@ if [[ $TRAVIS_OS_NAME == "osx" ]] ; then
   brew install ccache   # enable caching on mac (PATH only set in travis-compile.sh)
   brew install --force qt@5.7
   brew install protobuf
-else
-  # common prerequisites
-  sudo add-apt-repository -y ppa:smspillaz/cmake-master
-  sudo apt-get update -qq
-  sudo apt-get -y purge cmake
-  sudo apt-get install -y \
-    libprotobuf-dev protobuf-compiler \
-    cmake \
-    bc \
-    qt5-default qttools5-dev qttools5-dev-tools \
-    qtmultimedia5-dev libqt5multimedia5-plugins libqt5svg5-dev libqt5sql5-mysql
-
-  # prerequisites for tests
-  if [[ $BUILDTYPE == "Debug" ]]; then
-    sudo apt-get install -y libgtest-dev
-
-    sudo mkdir /usr/src/gtest/build
-    cd /usr/src/gtest/build
-    sudo cmake .. -DBUILD_SHARED_LIBS=1
-    sudo make -j2
-    sudo ln -s /usr/src/gtest/build/libgtest.so /usr/lib/libgtest.so
-    sudo ln -s /usr/src/gtest/build/libgtest_main.so /usr/lib/libgtest_main.so
-    cd -
-  fi
 fi


### PR DESCRIPTION
## What will change with this Pull Request?
Linux builds will install needed packages using Travis's own method instead of `sudo apt-get install ...`. This removes the usage of sudo, so that our builds can run on the (faster) container-based Travis infrastructure.