### PR TITLE
better null checks for painter

### DIFF
--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -88,6 +88,11 @@ void AbstractCardItem::transformPainter(QPainter *painter, const QSizeF &transla
 
 void AbstractCardItem::paintPicture(QPainter *painter, const QSizeF &translatedSize, int angle)
 {
+    if (painter == nullptr)
+    {
+        return;
+    }
+
     qreal scaleFactor = translatedSize.width() / boundingRect().width();
     QPixmap translatedPixmap;
     bool paintImage = true;
@@ -150,6 +155,11 @@ void AbstractCardItem::paintPicture(QPainter *painter, const QSizeF &translatedS
 
 void AbstractCardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
 {
+    if (painter == nullptr)
+    {
+        return;
+    }
+
     painter->save();
 
     QSizeF translatedSize = getTranslatedSize(painter);

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -85,6 +85,11 @@ void CardItem::retranslateUi()
 
 void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
+    if (painter == nullptr)
+    {
+        return;
+    }
+
     painter->save();
     AbstractCardItem::paint(painter, option, widget);
     


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3042

Better null checks _should_ prevent the painter from crashing the program.