### PR TITLE
rename "edit sets"

### DIFF
--- a/cockatrice/src/dlg_edit_tokens.cpp
+++ b/cockatrice/src/dlg_edit_tokens.cpp
@@ -142,7 +142,7 @@ void DlgEditTokens::actAddToken()
         if(name.isEmpty())
             return;
         if (databaseModel->getDatabase()->getCard(name)) {
-            QMessageBox::critical(this, tr("Error"), tr("The chosen name conflicts with an existing card or token.\nMake sure to enable the 'token set' in the 'Edit sets...' dialog to display them correctly."));
+            QMessageBox::critical(this, tr("Error"), tr("The chosen name conflicts with an existing card or token.\nMake sure to enable the 'Token' set in the \"Manage sets\" dialog to display them correctly."));
         } else {
             askAgain = false;
         }

--- a/cockatrice/src/sequenceEdit/ui_shortcutstab.h
+++ b/cockatrice/src/sequenceEdit/ui_shortcutstab.h
@@ -68,8 +68,8 @@ class Ui_shortcutsTab
         SequenceEdit *TabDeckEditor_aClose;
         QLabel *lbl_TabDeckEditor_aPrintDeck;
         SequenceEdit *TabDeckEditor_aPrintDeck;
-        QLabel *lbl_TabDeckEditor_aEditSets;
-        SequenceEdit *TabDeckEditor_aEditSets;
+        QLabel *lbl_TabDeckEditor_aManageSets;
+        SequenceEdit *TabDeckEditor_aManageSets;
         QLabel *lbl_TabDeckEditor_aRemoveCard;
         SequenceEdit *TabDeckEditor_aRemoveCard;
         QLabel *lbl_TabDeckEditor_aEditTokens;
@@ -548,15 +548,15 @@ class Ui_shortcutsTab
 
             gridLayout->addWidget(TabDeckEditor_aPrintDeck, 3, 3, 1, 1);
 
-            lbl_TabDeckEditor_aEditSets = new QLabel(groupBox_2);
-            lbl_TabDeckEditor_aEditSets->setObjectName("lbl_TabDeckEditor_aEditSets");
+            lbl_TabDeckEditor_aManageSets = new QLabel(groupBox_2);
+            lbl_TabDeckEditor_aManageSets->setObjectName("lbl_TabDeckEditor_aManageSets");
 
-            gridLayout->addWidget(lbl_TabDeckEditor_aEditSets, 4, 0, 1, 1);
+            gridLayout->addWidget(lbl_TabDeckEditor_aManageSets, 4, 0, 1, 1);
 
-            TabDeckEditor_aEditSets = new SequenceEdit("TabDeckEditor/aEditSets",groupBox_2);
-            TabDeckEditor_aEditSets->setObjectName("TabDeckEditor_aEditSets");
+            TabDeckEditor_aManageSets = new SequenceEdit("TabDeckEditor/aManageSets",groupBox_2);
+            TabDeckEditor_aManageSets->setObjectName("TabDeckEditor_aManageSets");
 
-            gridLayout->addWidget(TabDeckEditor_aEditSets, 4, 1, 1, 1);
+            gridLayout->addWidget(TabDeckEditor_aManageSets, 4, 1, 1, 1);
 
             lbl_TabDeckEditor_aRemoveCard = new QLabel(groupBox_2);
             lbl_TabDeckEditor_aRemoveCard->setObjectName("lbl_TabDeckEditor_aRemoveCard");
@@ -1759,7 +1759,7 @@ class Ui_shortcutsTab
             lbl_TabDeckEditor_aOpenCustomFolder->setText(QApplication::translate("shortcutsTab", "Open custom pic folder", 0));
             lbl_TabDeckEditor_aClose->setText(QApplication::translate("shortcutsTab", "Close", 0));
             lbl_TabDeckEditor_aPrintDeck->setText(QApplication::translate("shortcutsTab", "Print deck", 0));
-            lbl_TabDeckEditor_aEditSets->setText(QApplication::translate("shortcutsTab", "Edit sets", 0));
+            lbl_TabDeckEditor_aManageSets->setText(QApplication::translate("shortcutsTab", "Manage sets", 0));
             lbl_TabDeckEditor_aRemoveCard->setText(QApplication::translate("shortcutsTab", "Delete card", 0));
             lbl_TabDeckEditor_aEditTokens->setText(QApplication::translate("shortcutsTab", "Edit tokens", 0));
             lbl_TabDeckEditor_aResetLayout->setText(QApplication::translate("shortcutsTab", "Reset layout", 0));

--- a/cockatrice/src/shortcutssettings.cpp
+++ b/cockatrice/src/shortcutssettings.cpp
@@ -165,7 +165,7 @@ void ShortcutsSettings::fillDefaultShorcuts()
     defaultShortCuts["TabDeckEditor/aClearFilterOne"] = parseSequenceString("");
     defaultShortCuts["TabDeckEditor/aClose"] = parseSequenceString("");
     defaultShortCuts["TabDeckEditor/aDecrement"] = parseSequenceString("-");
-    defaultShortCuts["TabDeckEditor/aEditSets"] = parseSequenceString("");
+    defaultShortCuts["TabDeckEditor/aManageSets"] = parseSequenceString("");
     defaultShortCuts["TabDeckEditor/aEditTokens"] = parseSequenceString("");
     defaultShortCuts["TabDeckEditor/aExportDeckDecklist"] = parseSequenceString("");
     defaultShortCuts["TabDeckEditor/aIncrement"] = parseSequenceString("+");

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -545,7 +545,7 @@ void MainWindow::retranslateUi()
     aOpenCustomFolder->setText(tr("Open custom image folder"));
     aOpenCustomsetsFolder->setText(tr("Open custom sets folder"));
     aAddCustomSet->setText(tr("Add custom sets/cards"));
-    aEditSets->setText(tr("&Edit sets..."));
+    aManageSets->setText(tr("&Manage sets..."));
     aEditTokens->setText(tr("Edit &tokens..."));
 
     aAbout->setText(tr("&About Cockatrice"));
@@ -598,8 +598,8 @@ void MainWindow::createActions()
     aAddCustomSet = new QAction(QString(), this);
     connect(aAddCustomSet, SIGNAL(triggered()), this, SLOT(actAddCustomSet()));
 
-    aEditSets = new QAction(QString(), this);
-    connect(aEditSets, SIGNAL(triggered()), this, SLOT(actEditSets()));
+    aManageSets = new QAction(QString(), this);
+    connect(aManageSets, SIGNAL(triggered()), this, SLOT(actManageSets()));
 
     aEditTokens = new QAction(QString(), this);
     connect(aEditTokens, SIGNAL(triggered()), this, SLOT(actEditTokens()));
@@ -640,7 +640,7 @@ void MainWindow::createMenus()
     cockatriceMenu->addAction(aExit);
 
     dbMenu = menuBar()->addMenu(QString());
-    dbMenu->addAction(aEditSets);
+    dbMenu->addAction(aManageSets);
     dbMenu->addAction(aEditTokens);
     dbMenu->addSeparator();
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
@@ -874,14 +874,14 @@ void MainWindow::cardDatabaseNewSetsFound(int numUnknownSets, QStringList unknow
     else if (msgBox.clickedButton() == settingsButton)
     {
         db->markAllSetsAsKnown();
-        actEditSets();
+        actManageSets();
     }
 }
 
 void MainWindow::cardDatabaseAllNewSetsEnabled()
 {
-    QMessageBox::information(this, tr("Welcome"), tr("Hi! It seems like you're running this version of Cockatrice for the first time.\nAll the sets in the card database have been enabled.\nRead more about changing the set order or disabling specific sets and consequent effects in the \"Edit Sets\" window."));
-    actEditSets();
+    QMessageBox::information(this, tr("Welcome"), tr("Hi! It seems like you're running this version of Cockatrice for the first time.\nAll the sets in the card database have been enabled.\nRead more about changing the set order or disabling specific sets and consequent effects in the \"Manage Sets\" dialog."));
+    actManageSets();
 }
 
 /* CARD UPDATER */
@@ -984,7 +984,7 @@ void MainWindow::refreshShortcuts()
     aExit->setShortcuts(settingsCache->shortcuts().getShortcut("MainWindow/aExit"));
     aCheckCardUpdates->setShortcuts(settingsCache->shortcuts().getShortcut("MainWindow/aCheckCardUpdates"));
     aOpenCustomFolder->setShortcuts(settingsCache->shortcuts().getShortcut("MainWindow/aOpenCustomFolder"));
-    aEditSets->setShortcuts(settingsCache->shortcuts().getShortcut("MainWindow/aEditSets"));
+    aManageSets->setShortcuts(settingsCache->shortcuts().getShortcut("MainWindow/aManageSets"));
     aEditTokens->setShortcuts(settingsCache->shortcuts().getShortcut("MainWindow/aEditTokens"));
 }
 
@@ -1107,7 +1107,7 @@ int MainWindow::getNextCustomSetPrefix(QDir dataDir)
     return maxIndex + 1;
 }
 
-void MainWindow::actEditSets()
+void MainWindow::actManageSets()
 {
     auto *w = new WndSets;
     w->setWindowModality(Qt::WindowModal);

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -91,7 +91,7 @@ private slots:
     void actOpenCustomsetsFolder();
     void actAddCustomSet();
 
-    void actEditSets();
+    void actManageSets();
     void actEditTokens();
 private:
     static const QString appName;
@@ -111,7 +111,7 @@ private:
     QMenu *cockatriceMenu, *dbMenu, *helpMenu;
     QAction *aConnect, *aDisconnect, *aSinglePlayer, *aWatchReplay, *aDeckEditor, *aFullScreen, *aSettings, *aExit,
         *aAbout, *aCheckCardUpdates, *aRegister, *aUpdate, *aViewLog;
-    QAction *aEditSets, *aEditTokens, *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet;
+    QAction *aManageSets, *aEditTokens, *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet;
     TabSupervisor *tabSupervisor;
 
     QMenu *trayIconMenu;

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -128,7 +128,7 @@ WndSets::WndSets(QWidget *parent)
     centralWidget->setLayout(mainLayout);
     setCentralWidget(centralWidget);
 
-    setWindowTitle(tr("Edit sets"));
+    setWindowTitle(tr("Manage sets"));
     resize(700, 400);
 }
 


### PR DESCRIPTION
## Short roundup of the initial problem
`Edit sets` wasn't about editing sets, maybe used to.
In comparison to `Edit tokens` where you can actually edit things,
with sets you just "manage" them: rearrange, enable/disable etc.

## What will change with this Pull Request?
- rename UI elements
- rename references in code

I hopefully caught all appearances. 😄 
