### PR TITLE
fix release run on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,14 @@ matrix:
     dist: trusty
     group: stable
     env: BUILDTYPE=Release
-    if: branch = master AND NOT type = pull_request
+    if: (branch = master AND NOT type = pull_request) OR tag IS present
   - os: osx
     osx_image: xcode8
     env: BUILDTYPE=Debug
   - os: osx
     osx_image: xcode8
     env: BUILDTYPE=Release
-    if: branch = master AND NOT type = pull_request
+    if: (branch = master AND NOT type = pull_request) OR tag IS present
 
 #install dependencies for container-based "linux" builds
 addons:


### PR DESCRIPTION
## Related Ticket(s)
- Addition to #3041

## Short roundup of the initial problem
@ZeldaZach realized in https://travis-ci.org/Cockatrice/Cockatrice/builds/332115868 that tags only build with `Debug`. This resulted in no binaries being deployed because that'll only happen from `Release`.

It looks like tagging a commit on master will not trigger a run from master branch. :)

## What will change with this Pull Request?
- `Release` builds will run on any tags/tagged commits (also the ones not on master branch)

<br>

**Tested this on my fork!** :shipit: 