### PR TITLE
Travis: enable ccache usage under macOS; halves compilation time

### DIFF
--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -9,7 +9,10 @@ cd build
 prefix=""
 
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-  export PATH="/usr/local/opt/ccache/libexec:$PATH"
+  mkdir -p "${HOME}/bin"
+  ln -s "$(which ccache)" "${HOME}/bin/${CC}"
+  ln -s "$(which ccache)" "${HOME}/bin/${CXX}"
+  export PATH="${HOME}/bin:${PATH}"
   prefix="-DCMAKE_PREFIX_PATH=$(echo /usr/local/opt/qt*/)"
 fi
 if [[ $TRAVIS_OS_NAME == "linux" ]]; then

--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -10,8 +10,8 @@ prefix=""
 
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then
   mkdir -p "${HOME}/bin"
-  ln -s "$(which ccache)" "${HOME}/bin/${CC}"
-  ln -s "$(which ccache)" "${HOME}/bin/${CXX}"
+  ln -s /usr/local/opt/ccache/bin/ccache "${HOME}/bin/${CC}"
+  ln -s /usr/local/opt/ccache/bin/ccache "${HOME}/bin/${CXX}"
   export PATH="${HOME}/bin:${PATH}"
   prefix="-DCMAKE_PREFIX_PATH=$(echo /usr/local/opt/qt*/)"
 fi

--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -9,11 +9,8 @@ cd build
 prefix=""
 
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+  export PATH="/usr/local/opt/ccache/bin:$PATH"
   prefix="-DCMAKE_PREFIX_PATH=$(echo /usr/local/opt/qt*/)"
-  mkdir -p "${HOME}/bin"
-  ln -s /usr/local/opt/ccache/bin/ccache "${HOME}/bin/${CC}"
-  ln -s /usr/local/opt/ccache/bin/ccache "${HOME}/bin/${CXX}"
-  export PATH="${HOME}/bin:${PATH}"
 fi
 if [[ $TRAVIS_OS_NAME == "linux" ]]; then
   prefix="-DCMAKE_PREFIX_PATH=$(echo /opt/qt5*/lib/cmake/)"

--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -9,15 +9,14 @@ cd build
 prefix=""
 
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+  prefix="-DCMAKE_PREFIX_PATH=$(echo /usr/local/opt/qt*/)"
   mkdir -p "${HOME}/bin"
   ln -s /usr/local/opt/ccache/bin/ccache "${HOME}/bin/${CC}"
   ln -s /usr/local/opt/ccache/bin/ccache "${HOME}/bin/${CXX}"
   export PATH="${HOME}/bin:${PATH}"
-  prefix="-DCMAKE_PREFIX_PATH=$(echo /usr/local/opt/qt*/)"
 fi
 if [[ $TRAVIS_OS_NAME == "linux" ]]; then
   prefix="-DCMAKE_PREFIX_PATH=$(echo /opt/qt5*/lib/cmake/)"
-  export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$(echo /opt/qt5*/lib/)"
 fi
 
 if [[ $BUILDTYPE == "Debug" ]]; then

--- a/.ci/travis-dependencies.sh
+++ b/.ci/travis-dependencies.sh
@@ -2,7 +2,7 @@
 
 if [[ $TRAVIS_OS_NAME == "osx" ]] ; then
   brew install ccache   # enable caching on mac (PATH only set in travis-compile.sh)
-  brew install --force qt@5.7
+  brew install --force qt
   brew install protobuf clang-format
 fi
 if [[ $TRAVIS_OS_NAME == "linux" ]] ; then

--- a/.ci/travis-dependencies.sh
+++ b/.ci/travis-dependencies.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [[ $TRAVIS_OS_NAME == "osx" ]] ; then
-  brew install --force qt@5.7
-  brew install protobuf clang-format ccache
+  brew update
+  brew install ccache clang-format protobuf qt@5.7
 fi
 if [[ $TRAVIS_OS_NAME == "linux" ]] ; then
   echo Skipping... packages are installed with the Travis apt addon for sudo disabled container builds

--- a/.ci/travis-dependencies.sh
+++ b/.ci/travis-dependencies.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 if [[ $TRAVIS_OS_NAME == "osx" ]] ; then
-  brew install ccache clang-format protobuf qt
+  brew install ccache   # enable caching on mac (PATH only set in travis-compile.sh)
+  brew install --force qt@5.7
+  brew install protobuf clang-format
 fi
 if [[ $TRAVIS_OS_NAME == "linux" ]] ; then
   echo Skipping... packages are installed with the Travis apt addon for sudo disabled container builds

--- a/.ci/travis-dependencies.sh
+++ b/.ci/travis-dependencies.sh
@@ -2,7 +2,7 @@
 
 if [[ $TRAVIS_OS_NAME == "osx" ]] ; then
   brew install ccache   # enable caching on mac (PATH only set in travis-compile.sh)
-  brew install --force qt
+  brew install --force qt@5.9
   brew install protobuf clang-format
 fi
 if [[ $TRAVIS_OS_NAME == "linux" ]] ; then

--- a/.ci/travis-dependencies.sh
+++ b/.ci/travis-dependencies.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 if [[ $TRAVIS_OS_NAME == "osx" ]] ; then
-  brew install ccache   # enable caching on mac (PATH only set in travis-compile.sh)
   brew install --force qt@5.7
-  brew install protobuf clang-format
+  brew install protobuf clang-format ccache
 fi
 if [[ $TRAVIS_OS_NAME == "linux" ]] ; then
   echo Skipping... packages are installed with the Travis apt addon for sudo disabled container builds

--- a/.ci/travis-dependencies.sh
+++ b/.ci/travis-dependencies.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 if [[ $TRAVIS_OS_NAME == "osx" ]] ; then
-  brew install ccache   # enable caching on mac (PATH only set in travis-compile.sh)
-  brew install --force qt@5.9
-  brew install protobuf clang-format
+  brew install ccache clang-format protobuf qt
 fi
 if [[ $TRAVIS_OS_NAME == "linux" ]] ; then
   echo Skipping... packages are installed with the Travis apt addon for sudo disabled container builds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,14 @@ ELSE()
    SET(CMAKE_BUILD_TYPE Release CACHE STRING "Type of build")
 ENDIF()
 
+# Early detect ccache
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    # Support Unix Makefiles and Ninja
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+    MESSAGE(STATUS "Found CCache ${CCACHE_PROGRAM}")
+endif()
+
 # A project name is needed for CPack
 # Version can be overriden by git tags, see cmake/getversion.cmake
 PROJECT("Cockatrice" VERSION 2.5.0)
@@ -47,10 +55,28 @@ include(createversionfile)
 # Define a proper install path
 if(UNIX)
     if(APPLE)
-        # MacOS X
+        # macOS
         # Due to the special bundle structure ignore
         # the prefix eventually set by the user.
         set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/release)
+
+        # Force ccache usage if available
+        get_property(RULE_LAUNCH_COMPILE GLOBAL PROPERTY RULE_LAUNCH_COMPILE)
+        if(RULE_LAUNCH_COMPILE)
+            MESSAGE(STATUS "Force enabling CCache usage under macOS")
+            # Set up wrapper scripts
+            configure_file(${CMAKE_MODULE_PATH}/launch-c.in   launch-c)
+            configure_file(${CMAKE_MODULE_PATH}/launch-cxx.in launch-cxx)
+            execute_process(COMMAND chmod a+rx
+                "${CMAKE_BINARY_DIR}/launch-c"
+                "${CMAKE_BINARY_DIR}/launch-cxx")
+
+            # Set Xcode project attributes to route compilation through our scripts
+            set(CMAKE_XCODE_ATTRIBUTE_CC         "${CMAKE_BINARY_DIR}/launch-c")
+            set(CMAKE_XCODE_ATTRIBUTE_CXX        "${CMAKE_BINARY_DIR}/launch-cxx")
+            set(CMAKE_XCODE_ATTRIBUTE_LD         "${CMAKE_BINARY_DIR}/launch-c")
+            set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${CMAKE_BINARY_DIR}/launch-cxx")
+        endif()
     else()
         # Linux / BSD
         if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/cmake/launch-c.in
+++ b/cmake/launch-c.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+export CCACHE_CPP2=true
+exec "${RULE_LAUNCH_COMPILE}" "${CMAKE_C_COMPILER}" "$@"

--- a/cmake/launch-cxx.in
+++ b/cmake/launch-cxx.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+export CCACHE_CPP2=true
+exec "${RULE_LAUNCH_COMPILE}" "${CMAKE_CXX_COMPILER}" "$@"


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2982

## Short roundup of the initial problem
CCache is used to save and restore objects built in previous compilations, lowering a lot compilation times. It was not working under macOS on Travis.

## What will change with this Pull Request?
Travis compilation time under macOS is halved from 8mins to 4mins.