### PR TITLE
Fix mwDeck edition tag parsing on deck load

### DIFF
--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -562,9 +562,9 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
         }
 
         // Filter out MWS edition symbols and basic land extras
-        QRegExp rx("\\[.*\\]\s?]");
+        QRegExp rx("\\[.*\\]\s?");
         line.remove(rx);
-        rx.setPattern("\\(.*\\)\s");
+        rx.setPattern("\\\s(.*\\)");
         line.remove(rx);
 
         // Filter out post card name editions

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -564,7 +564,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
         // Filter out MWS edition symbols and basic land extras
         QRegExp rx("\\[.*\\]\\s?");
         line.remove(rx);
-        rx.setPattern("\\\\s(.*\\)");
+        rx.setPattern("\\(.*\\)");
         line.remove(rx);
 
         // Filter out post card name editions

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -562,9 +562,9 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
         }
 
         // Filter out MWS edition symbols and basic land extras
-        QRegExp rx("\\[.*\\]");
+        QRegExp rx("\\[.*\\]\s?]");
         line.remove(rx);
-        rx.setPattern("\\(.*\\)");
+        rx.setPattern("\\(.*\\)\s");
         line.remove(rx);
 
         // Filter out post card name editions

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -564,7 +564,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
         // Filter out MWS edition symbols and basic land extras
         QRegExp rx("\\[.*\\]\\s?");
         line.remove(rx);
-        rx.setPattern("\\\\s?(.*\\)");
+        rx.setPattern("\\s?\\(.*\\)");
         line.remove(rx);
 
         // Filter out post card name editions

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -564,7 +564,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
         // Filter out MWS edition symbols and basic land extras
         QRegExp rx("\\[.*\\]\\s?");
         line.remove(rx);
-        rx.setPattern("\\(.*\\)");
+        rx.setPattern("\\\\s?(.*\\)");
         line.remove(rx);
 
         // Filter out post card name editions

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -562,9 +562,9 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
         }
 
         // Filter out MWS edition symbols and basic land extras
-        QRegExp rx("\\[.*\\]\s?");
+        QRegExp rx("\\[.*\\]\\s?");
         line.remove(rx);
-        rx.setPattern("\\\s(.*\\)");
+        rx.setPattern("\\\\s(.*\\)");
         line.remove(rx);
 
         // Filter out post card name editions


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3038 

## Short roundup of the initial problem
MWS uses a special style for their .mwDeck format in decklists.
They add the set tag in square brackets before the card name (e.g. `[RIX]`), and append an additional number in round brackets (e.g. `(3)`) to specify a particular card if there are more than one with the same name in that set (several forest cards with different art for example).

The code in place to remove those additions left a space behind.

## What will change with this Pull Request?
- RegEx update