### PR TITLE
travis: temporary downgrade mac builds to qt5.5

### DIFF
--- a/.ci/travis-dependencies.sh
+++ b/.ci/travis-dependencies.sh
@@ -2,7 +2,7 @@
 
 if [[ $TRAVIS_OS_NAME == "osx" ]] ; then
   brew update
-  brew install ccache clang-format protobuf qt@5.7
+  brew install ccache clang-format protobuf qt@5.5
 fi
 if [[ $TRAVIS_OS_NAME == "linux" ]] ; then
   echo Skipping... packages are installed with the Travis apt addon for sudo disabled container builds


### PR DESCRIPTION
## Short roundup of the initial problem
[`qt@5.7`](http://formulae.brew.sh/formula/qt@5.7) is no longer available at homebrew

## What will change with this Pull Request?
- Use [`qt@5.5`](http://formulae.brew.sh/formula/qt@5.5) instead
- This is only a temporary workaround because `qt@5.5` won't be there forever
The general [`qt`](http://formulae.brew.sh/formula/qt) package defaults to Qt 5.10 at the moment which conflicts with https://github.com/Cockatrice/Cockatrice/issues/2647

<br>

Can somebody with a mac give this a run and test if the client works the same before we deploy dmg's based on that?