### PR TITLE
Capitalize filter connectors

### DIFF
--- a/cockatrice/src/cardfilter.cpp
+++ b/cockatrice/src/cardfilter.cpp
@@ -4,13 +4,13 @@ const char *CardFilter::typeName(Type t)
 {
     switch (t) {
         case TypeAnd:
-            return "and";
+            return "AND";
         case TypeOr:
-            return "or";
+            return "OR";
         case TypeAndNot:
-            return "and not";
+            return "AND NOT";
         case TypeOrNot:
-            return "or not";
+            return "OR NOT";
         default:
             return "";
     }

--- a/cockatrice/src/filterbuilder.cpp
+++ b/cockatrice/src/filterbuilder.cpp
@@ -22,7 +22,7 @@ FilterBuilder::FilterBuilder(QWidget *parent)
     typeCombo->setObjectName("typeCombo");
     for (int i = 0; i < CardFilter::TypeEnd; i++)
         typeCombo->addItem(
-            tr(CardFilter::typeName(static_cast<CardFilter::Type>(i))),
+            CardFilter::typeName(static_cast<CardFilter::Type>(i)),
             QVariant(i)
         );
 


### PR DESCRIPTION
## Short roundup of the initial problem
They used to be all lowercase compared to proper capitalization for the filter types.

## What will change with this Pull Request?
- Display them in all capital letters, and stress that they are logical operators
- This fixed terms should not be translatable (not that it was working right now anyway 😄 - https://github.com/Cockatrice/Cockatrice/issues/2986)
