### PR TITLE
Automatic focus change after filter selection

### DIFF
--- a/cockatrice/src/filterbuilder.cpp
+++ b/cockatrice/src/filterbuilder.cpp
@@ -42,6 +42,7 @@ FilterBuilder::FilterBuilder(QWidget *parent) : QWidget(parent)
 
     setLayout(layout);
 
+    connect(filterCombo, SIGNAL(activated(int)), edit, SLOT(setFocus()));
     connect(edit, SIGNAL(returnPressed()), this, SLOT(emit_add()));
     connect(ok, SIGNAL(released()), this, SLOT(emit_add()));
     fltr = NULL;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3004  

## Short roundup of the initial problem
Focus did not change automatically from the filter combobox to the QLineEdit widget.
