### PR TITLE
Start in maximized window on first start

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -782,8 +782,7 @@ MainWindow::MainWindow(QWidget *parent)
 
     retranslateUi();
 
-    if (!restoreGeometry(settingsCache->getMainWindowGeometry()))
-    {
+    if (!restoreGeometry(settingsCache->getMainWindowGeometry())) {
         this->setWindowState(Qt::WindowMaximized);
     }
     aFullScreen->setChecked(static_cast<bool>(windowState() & Qt::WindowFullScreen));

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -783,7 +783,7 @@ MainWindow::MainWindow(QWidget *parent)
     retranslateUi();
 
     if (!restoreGeometry(settingsCache->getMainWindowGeometry())) {
-        this->setWindowState(Qt::WindowMaximized);
+        setWindowState(Qt::WindowMaximized);
     }
     aFullScreen->setChecked(static_cast<bool>(windowState() & Qt::WindowFullScreen));
 

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -782,8 +782,10 @@ MainWindow::MainWindow(QWidget *parent)
 
     retranslateUi();
 
-    resize(900, 700);
-    restoreGeometry(settingsCache->getMainWindowGeometry());
+    if (!restoreGeometry(settingsCache->getMainWindowGeometry()))
+    {
+        this->setWindowState(Qt::WindowMaximized);
+    }
     aFullScreen->setChecked(static_cast<bool>(windowState() & Qt::WindowFullScreen));
 
     if (QSystemTrayIcon::isSystemTrayAvailable()) {


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1871 

## What will change with this Pull Request?
When window restoration on start fails (e.g. missing settings due to first running) it will start in maximized instead of a fix-sized window.
