### PR TITLE
Loyalty filter added

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -235,7 +235,7 @@ CardInfo::CardInfo(const QString &_name,
                    const QList<CardRelation *> &_relatedCards,
                    const QList<CardRelation *> &_reverseRelatedCards,
                    bool _upsideDownArt,
-                   int _loyalty,
+                   const QString &_loyalty,
                    bool _cipt,
                    int _tableRow,
                    const SetList &_sets,
@@ -271,7 +271,7 @@ CardInfoPtr CardInfo::newInstance(const QString &_name,
                                   const QList<CardRelation *> &_relatedCards,
                                   const QList<CardRelation *> &_reverseRelatedCards,
                                   bool _upsideDownArt,
-                                  int _loyalty,
+                                  const QString &_loyalty,
                                   bool _cipt,
                                   int _tableRow,
                                   const SetList &_sets,
@@ -488,7 +488,7 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfoPtr &in
     xml.writeTextElement("tablerow", QString::number(info->getTableRow()));
     xml.writeTextElement("text", info->getText());
     if (info->getMainCardType() == "Planeswalker") {
-        xml.writeTextElement("loyalty", QString::number(info->getLoyalty()));
+        xml.writeTextElement("loyalty", info->getLoyalty());
     }
     if (info->getCipt()) {
         xml.writeTextElement("cipt", "1");
@@ -665,7 +665,7 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml)
         }
 
         if (xml.name() == "card") {
-            QString name, manacost, cmc, type, pt, text;
+            QString name, manacost, cmc, type, pt, text, loyalty;
             QStringList colors;
             QList<CardRelation *> relatedCards, reverseRelatedCards;
             QStringMap customPicURLs;
@@ -673,7 +673,6 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml)
             QStringMap collectorNumbers, rarities;
             SetList sets;
             int tableRow = 0;
-            int loyalty = -1;
             bool cipt = false;
             bool isToken = false;
             bool upsideDown = false;
@@ -758,7 +757,7 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml)
                 } else if (xml.name() == "upsidedown") {
                     upsideDown = (xml.readElementText() == "1");
                 } else if (xml.name() == "loyalty") {
-                    loyalty = xml.readElementText().toInt();
+                    loyalty = xml.readElementText();
                 } else if (xml.name() == "token") {
                     isToken = static_cast<bool>(xml.readElementText().toInt());
                 } else if (xml.name() != "") {

--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -673,7 +673,7 @@ void CardDatabase::loadCardsFromXml(QXmlStreamReader &xml)
             QStringMap collectorNumbers, rarities;
             SetList sets;
             int tableRow = 0;
-            int loyalty = 0;
+            int loyalty = -1;
             bool cipt = false;
             bool isToken = false;
             bool upsideDown = false;

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -131,7 +131,6 @@ private:
     QString cardtype;
     QString powtough;
     QString text;
-    QString loyalty;
     QStringList colors;
 
     // the cards i'm related to
@@ -146,6 +145,7 @@ private:
     QString setsNames;
 
     bool upsideDownArt;
+    QString loyalty;
     QStringMap customPicURLs;
     MuidMap muIds;
     QStringMap collectorNumbers;

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -131,6 +131,7 @@ private:
     QString cardtype;
     QString powtough;
     QString text;
+    QString loyalty;
     QStringList colors;
 
     // the cards i'm related to
@@ -145,7 +146,6 @@ private:
     QString setsNames;
 
     bool upsideDownArt;
-    int loyalty;
     QStringMap customPicURLs;
     MuidMap muIds;
     QStringMap collectorNumbers;
@@ -166,7 +166,7 @@ public:
                       const QList<CardRelation *> &_relatedCards = QList<CardRelation *>(),
                       const QList<CardRelation *> &_reverseRelatedCards = QList<CardRelation *>(),
                       bool _upsideDownArt = false,
-                      int _loyalty = 0,
+                      const QString &_loyalty = QString(),
                       bool _cipt = false,
                       int _tableRow = 0,
                       const SetList &_sets = SetList(),
@@ -187,7 +187,7 @@ public:
                                    const QList<CardRelation *> &_relatedCards = QList<CardRelation *>(),
                                    const QList<CardRelation *> &_reverseRelatedCards = QList<CardRelation *>(),
                                    bool _upsideDownArt = false,
-                                   int _loyalty = 0,
+                                   const QString &_loyalty = QString(),
                                    bool _cipt = false,
                                    int _tableRow = 0,
                                    const SetList &_sets = SetList(),
@@ -245,7 +245,7 @@ public:
     {
         return pixmapCacheKey;
     }
-    const int &getLoyalty() const
+    const QString &getLoyalty() const
     {
         return loyalty;
     }

--- a/cockatrice/src/cardfilter.cpp
+++ b/cockatrice/src/cardfilter.cpp
@@ -39,6 +39,8 @@ const char *CardFilter::attrName(Attr a)
             return "Power";
         case AttrTough:
             return "Toughness";
+        case AttrLoyalty:
+            return "Loyalty";
         default:
             return "";
     }

--- a/cockatrice/src/cardfilter.h
+++ b/cockatrice/src/cardfilter.h
@@ -21,6 +21,7 @@ public:
     {
         AttrCmc = 0,
         AttrColor,
+        AttrLoyalty,
         AttrManaCost,
         AttrName,
         AttrPow,

--- a/cockatrice/src/cardinfotext.cpp
+++ b/cockatrice/src/cardinfotext.cpp
@@ -63,7 +63,7 @@ void CardInfoText::setCard(CardInfoPtr card)
         colorLabel2->setText(card->getColors().join(""));
         cardtypeLabel2->setText(card->getCardType());
         powtoughLabel2->setText(card->getPowTough());
-        loyaltyLabel2->setText(card->getLoyalty() > 0 ? QString::number(card->getLoyalty()) : QString());
+        loyaltyLabel2->setText(card->getLoyalty() != "" ? card->getLoyalty() : QString());
         textLabel->setText(card->getText());
     } else {
         nameLabel2->setText("");

--- a/cockatrice/src/cardinfotext.cpp
+++ b/cockatrice/src/cardinfotext.cpp
@@ -63,7 +63,7 @@ void CardInfoText::setCard(CardInfoPtr card)
         colorLabel2->setText(card->getColors().join(""));
         cardtypeLabel2->setText(card->getCardType());
         powtoughLabel2->setText(card->getPowTough());
-        loyaltyLabel2->setText(card->getLoyalty() != "" ? card->getLoyalty() : QString());
+        loyaltyLabel2->setText(card->getLoyalty());
         textLabel->setText(card->getText());
     } else {
         nameLabel2->setText("");

--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -234,6 +234,11 @@ bool FilterItem::acceptCmc(const CardInfoPtr info) const
     return relationCheck(info->getCmc().toInt());
 }
 
+bool FilterItem::acceptLoyalty(const CardInfoPtr info) const
+{
+    return relationCheck(info->getLoyalty());
+}
+
 bool FilterItem::acceptPower(const CardInfoPtr info) const
 {
     int slash = info->getPowTough().indexOf("/");
@@ -351,6 +356,8 @@ bool FilterItem::acceptCardAttr(const CardInfoPtr info, CardFilter::Attr attr) c
             return acceptPower(info);
         case CardFilter::AttrTough:
             return acceptToughness(info);
+        case CardFilter::AttrLoyalty:
+            return acceptLoyalty(info);
         default:
             return true; /* ignore this attribute */
     }

--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -236,7 +236,8 @@ bool FilterItem::acceptCmc(const CardInfoPtr info) const
 
 bool FilterItem::acceptLoyalty(const CardInfoPtr info) const
 {
-    return relationCheck(info->getLoyalty());
+    int loyalty = info->getLoyalty();
+    return loyalty >= 0 ? relationCheck(loyalty) : false;
 }
 
 bool FilterItem::acceptPower(const CardInfoPtr info) const

--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -236,18 +236,17 @@ bool FilterItem::acceptCmc(const CardInfoPtr info) const
 
 bool FilterItem::acceptLoyalty(const CardInfoPtr info) const
 {
-    if (info->getLoyalty() == "")
+    if (info->getLoyalty().isEmpty()) {
         return false;
-    else {
+    } else {
         bool success;
         // if loyalty can't be converted to "int" it must be "X"
         int loyalty = info->getLoyalty().toInt(&success);
         if (success) {
             return relationCheck(loyalty);
-        } else if (term.trimmed().toUpper() == info->getLoyalty()) {
-            return true;
-        } else
-            return false;
+        } else {
+            return term.trimmed().toUpper() == info->getLoyalty();
+        }
     }
 }
 
@@ -304,7 +303,7 @@ bool FilterItem::acceptRarity(const CardInfoPtr info) const
         }
     }
 
-    foreach (QString rareLevel, info->getRarities()) {
+    for (const QString &rareLevel : info->getRarities()) {
         if (rareLevel.compare(converted_term, Qt::CaseInsensitive) == 0) {
             return true;
         }

--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -236,8 +236,19 @@ bool FilterItem::acceptCmc(const CardInfoPtr info) const
 
 bool FilterItem::acceptLoyalty(const CardInfoPtr info) const
 {
-    int loyalty = info->getLoyalty();
-    return loyalty >= 0 ? relationCheck(loyalty) : false;
+    if (info->getLoyalty() == "")
+        return false;
+    else {
+        bool success;
+        // if loyalty can't be converted to "int" it must be "X"
+        int loyalty = info->getLoyalty().toInt(&success);
+        if (success) {
+            return relationCheck(loyalty);
+        } else if (term.trimmed().toUpper() == info->getLoyalty()) {
+            return true;
+        } else
+            return false;
+    }
 }
 
 bool FilterItem::acceptPower(const CardInfoPtr info) const

--- a/cockatrice/src/filtertree.h
+++ b/cockatrice/src/filtertree.h
@@ -212,6 +212,7 @@ public:
     bool acceptCmc(const CardInfoPtr info) const;
     bool acceptPower(const CardInfoPtr info) const;
     bool acceptToughness(const CardInfoPtr info) const;
+    bool acceptLoyalty(const CardInfoPtr info) const;
     bool acceptRarity(const CardInfoPtr info) const;
     bool acceptCardAttr(const CardInfoPtr info, CardFilter::Attr attr) const;
     bool relationCheck(int cardInfo) const;

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -60,7 +60,7 @@ CardInfoPtr OracleImporter::addCard(const QString &setName,
                                     QString &cmc,
                                     const QString &cardType,
                                     const QString &cardPT,
-                                    int cardLoyalty,
+                                    const QString &cardLoyalty,
                                     const QString &cardText,
                                     const QStringList &colors,
                                     const QList<CardRelation *> &relatedCards,
@@ -152,7 +152,7 @@ int OracleImporter::importTextSpoiler(CardSetPtr set, const QVariant &data)
     int cardId;
     QString setNumber;
     QString rarity;
-    int cardLoyalty;
+    QString cardLoyalty;
     bool upsideDown = false;
     QMap<int, QVariantMap> splitCards;
 
@@ -184,7 +184,7 @@ int OracleImporter::importTextSpoiler(CardSetPtr set, const QVariant &data)
         cardId = map.contains("multiverseid") ? map.value("multiverseid").toInt() : 0;
         setNumber = map.contains("number") ? map.value("number").toString() : QString("");
         rarity = map.contains("rarity") ? map.value("rarity").toString() : QString("");
-        cardLoyalty = map.contains("loyalty") ? map.value("loyalty").toInt() : 0;
+        cardLoyalty = map.contains("loyalty") ? map.value("loyalty").toString() : QString("");
         relatedCards = QList<CardRelation *>();
         if (map.contains("names"))
             foreach (const QString &name, map.value("names").toStringList()) {
@@ -237,9 +237,8 @@ int OracleImporter::importTextSpoiler(CardSetPtr set, const QVariant &data)
         cardText = "";
         setNumber = "";
         rarity = "";
+        cardLoyalty = "";
         colors.clear();
-        // this is currently an integer; can't accept 2 values
-        cardLoyalty = 0;
 
         // loop cards and merge their contents
         QString prefix = QString(" // ");

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -66,7 +66,7 @@ private:
                         QString &cmc,
                         const QString &cardType,
                         const QString &cardPT,
-                        int cardLoyalty,
+                        const QString &cardLoyalty,
                         const QString &cardText,
                         const QStringList &colors,
                         const QList<CardRelation *> &relatedCards,


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3084 

## Short roundup of the initial problem
"Loyalty" was missing from the possible options for card filter.

## Screenshots
![loyalty_filter](https://user-images.githubusercontent.com/9273978/35890116-91e007ca-0b9e-11e8-90bc-c3d5dcec6228.png)