### PR TITLE
Consistent use of 'beta' tag across the project

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -264,7 +264,7 @@ Please have a look at the specific [FAQ for translators](https://github.com/Cock
 ### Publishing A New Beta Release ###
 
 Travis and AppVeyor have been configured to upload files to GitHub Releases whenever a <kbd>tag</kbd> is pushed.<br>
-Usually, tags are created through publishing a release, but there's a way around that.
+Usually, tags are created through publishing a (pre-)release, but there's a way around that.
 
 To trigger Travis and AppVeyor, simply do the following:
 ```bash
@@ -279,13 +279,13 @@ You should define the variables as such:
 ```
 upstream - git@github.com:Cockatrice/Cockatrice.git
 $COCKATRICE_REPO - /Location/of/repository/cockatrice.git
-$TAG_NAME
-  - If stable release, YYYY-MM-DD-Release-MAJ.MIN.PATCH
-  - If beta release, YYYY-MM-DD-Development-MAJ.MIN.PATCH-beta.X
-        - MAJ.MIN.PATCH will be the NEXT release version
+`$TAG_NAME` should be:
+  - `YYYY-MM-DD-Release-MAJ.MIN.PATCH` for **stable releases**
+  - `YYYY-MM-DD-Development-MAJ.MIN.PATCH-beta.X` for **beta releases**<br>
+    With *MAJ.MIN.PATCH* being the NEXT release version!
 ```
 
-This will cause a tag release to be established on the GitHub repository, which will then lead to the upload of binaries. If you use this method, the tags (releases) that you create will be marked as a "Pre-release". The `/latest` URL will not be impacted (for stable release downloads) so that's good.
+This will cause a tagged release to be established on the GitHub repository, which will then lead to the upload of binaries. If you use this method, the tags (releases) that you create will be marked as a "Pre-release". The `/latest` URL will not be impacted (for stable release downloads) so that's good.
 
 If you accidentally push a tag incorrectly (the tag is outdated, you didn't pull in the latest branch accidentally, you named the tag wrong, etc.) you can revoke the tag by doing the following:
 ```bash
@@ -293,11 +293,11 @@ git push --delete upstream $TAG_NAME
 git tag -d $TAG_NAME
 ```
 
-**NOTE:** Unfortunately, due to the method of how Travis and AppVeyor work, to publish a full release you will need to make a copy of the release notes locally and then paste them into the GitHub GUI once the binaries have been uploaded by them. These CI services will automatically overwrite the name of the release (to "Cockatrice $TAG_NAME"), the status of the release (to "Pre-release"), and the release body (to "Beta build of Cockatrice").
+**NOTE:** Unfortunately, due to the method of how Travis and AppVeyor work, to publish a stable release you will need to make a copy of the release notes locally and then paste them into the GitHub GUI once the binaries have been uploaded by them. These CI services will automatically overwrite the name of the release (to "Cockatrice $TAG_NAME"), the status of the release (to "Pre-release"), and the release body (to "Beta build of Cockatrice").
 
 **NOTE 2:** In the first lines of https://github.com/Cockatrice/Cockatrice/blob/master/CMakeLists.txt there's an hardcoded version number used when compiling custom (not tagged) versions. While on tagged versions these numbers are overriden by the version numbers coming from the tag title, it's a good practice to keep them aligned with the real ones.
 The preferred flow of operations is:
  * just before a release, update the version number in CMakeLists.txt to "next release version";
  * tag the release following the previously described syntax in order to get it built by CI;
  * wait for CI to upload the binaries, double check if everything is in order
- * after the release is complete, update the version number again to "next beta version", typically increasing `PROJECT_VERSION_PATCH` by one.
+ * after the release is complete, update the version number again to "next targeted beta version", typically increasing `PROJECT_VERSION_PATCH` by one.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -261,9 +261,10 @@ Please have a look at the specific [FAQ for translators](https://github.com/Cock
 
 # Release Management #
 
-### Publish A New Development Snapshot ###
+### Publishing A New Beta Release ###
 
-Travis and AppVeyor have been configured to upload files to GitHub Releases whenever a <kbd>tag</kbd> is pushed. Usually, tags are created through publishing a release, but there's a way around that.
+Travis and AppVeyor have been configured to upload files to GitHub Releases whenever a <kbd>tag</kbd> is pushed.<br>
+Usually, tags are created through publishing a release, but there's a way around that.
 
 To trigger Travis and AppVeyor, simply do the following:
 ```bash

--- a/README.md
+++ b/README.md
@@ -20,17 +20,16 @@ Cockatrice is an open-source, multiplatform program for playing tabletop card ga
 
 # Downloads [![Cockatrice Eternal Download Count](https://img.shields.io/github/downloads/cockatrice/cockatrice/total.svg)](https://tooomm.github.io/github-release-stats/?username=Cockatrice&repository=Cockatrice)
 
-Downloads are available for full releases and the current development version.<br>
+Downloads are available for full releases and the current beta version in development.<br>
 Full releases are checkpoints featuring major feature or UI enhancements - we recommend to use those. There is no strict schedule for new full releases.
 
-The development version contains the most recently added features and bugfixes, but can be unstable. They are released as we feel need.
+The beta release contains the most recently added features and bugfixes, but can be unstable. They are released as we feel need.
 
 - Latest full release (**recommended**): [![Download from GitHub Releases](https://img.shields.io/github/release/cockatrice/cockatrice.svg)](https://github.com/cockatrice/cockatrice/releases/latest) [![Download Count on Latest Release](https://img.shields.io/github/downloads/cockatrice/cockatrice/latest/total.svg)](https://tooomm.github.io/github-release-stats/?username=Cockatrice&repository=Cockatrice)<br>
 
-- Latest development version: [![Download from GitHub Pre-Releases](https://img.shields.io/github/release/cockatrice/cockatrice/all.svg)](https://github.com/cockatrice/cockatrice/releases) 
-   - Development builds may be unstable and contain bugs.
-   - To be a Cockatrice Beta Tester, use this version.
-   - Find more information on the development build [here](https://github.com/Cockatrice/Cockatrice/wiki/Release-Channels)
+- Latest beta release: [![Download from GitHub Pre-Releases](https://img.shields.io/github/release/cockatrice/cockatrice/all.svg)](https://github.com/cockatrice/cockatrice/releases) 
+   - Beta versions may be unstable and contain bugs.
+   - To be a Cockatrice Beta Tester, use this version. Find more information [here](https://github.com/Cockatrice/Cockatrice/wiki/Release-Channels)!
 
 
 # Get Involved [![Gitter Chat](https://img.shields.io/gitter/room/Cockatrice/Cockatrice.svg)](https://gitter.im/Cockatrice/Cockatrice)

--- a/cmake/getversion.cmake
+++ b/cmake/getversion.cmake
@@ -141,9 +141,9 @@ function(get_tag_name commit)
 	endif()
 
 	# Label
-	# 7 = Full release
+	# 7 = Stable release
 	# 8 = Dev release, first beta so only "beta" attached
-	# 9 = Dev release, not first beta so "beta.N" attached
+	# 9 = Dev release, subsequent beta so "beta.N" attached (N>=2)
 	if(${GIT_TAG_LISTCOUNT} EQUAL 8)
 		list(GET GIT_TAG_EXPLODED 7 GIT_TAG_LABEL)
 	elseif(${GIT_TAG_LISTCOUNT} EQUAL 9)

--- a/cockatrice/src/releasechannel.cpp
+++ b/cockatrice/src/releasechannel.cpp
@@ -12,9 +12,9 @@
 #define STABLETAG_URL "https://api.github.com/repos/Cockatrice/Cockatrice/git/refs/tags/"
 #define STABLEMANUALDOWNLOAD_URL "https://github.com/Cockatrice/Cockatrice/releases/latest"
 
-#define DEVRELEASE_URL "https://api.github.com/repos/Cockatrice/Cockatrice/releases"
-#define DEVMANUALDOWNLOAD_URL "https://github.com/Cockatrice/Cockatrice/releases/"
-#define DEVRELEASE_DESCURL "https://github.com/Cockatrice/Cockatrice/compare/%1...%2"
+#define BETARELEASE_URL "https://api.github.com/repos/Cockatrice/Cockatrice/releases"
+#define BETAMANUALDOWNLOAD_URL "https://github.com/Cockatrice/Cockatrice/releases/"
+#define BETARELEASE_CHANGESURL "https://github.com/Cockatrice/Cockatrice/compare/%1...%2"
 
 #define GIT_SHORT_HASH_LEN 7
 
@@ -53,22 +53,22 @@ bool ReleaseChannel::downloadMatchesCurrentOS(const QString &fileName)
 {
     QString wordSize = QSysInfo::buildAbi().split('-')[2];
     QString arch;
-    QString devSnapshotEnd;
+    QString betaEnd;
 
     if (wordSize == "llp64") {
         arch = "win64";
-        devSnapshotEnd = "-x86_64_qt5";
+        betaEnd = "-x86_64_qt5";
     } else if (wordSize == "ilp32") {
         arch = "win32";
-        devSnapshotEnd = "-x86_qt5";
+        betaEnd = "-x86_qt5";
     } else {
         qWarning() << "Error checking for upgrade version: wordSize is" << wordSize;
         return false;
     }
 
     auto exeName = arch + ".exe";
-    auto exeDevName = devSnapshotEnd + ".exe";
-    return (fileName.endsWith(exeName) || fileName.endsWith(exeDevName));
+    auto exeBetaName = betaEnd + ".exe";
+    return (fileName.endsWith(exeName) || fileName.endsWith(exeBetaName));
 }
 #else
 
@@ -87,7 +87,7 @@ QString StableReleaseChannel::getManualDownloadUrl() const
 
 QString StableReleaseChannel::getName() const
 {
-    return tr("Stable releases");
+    return tr("Stable Releases");
 }
 
 QString StableReleaseChannel::getReleaseChannelUrl() const
@@ -197,22 +197,22 @@ void StableReleaseChannel::fileListFinished()
     return;
 }
 
-QString DevReleaseChannel::getManualDownloadUrl() const
+QString BetaReleaseChannel::getManualDownloadUrl() const
 {
-    return QString(DEVMANUALDOWNLOAD_URL);
+    return QString(BETAMANUALDOWNLOAD_URL);
 }
 
-QString DevReleaseChannel::getName() const
+QString BetaReleaseChannel::getName() const
 {
-    return tr("Development snapshots");
+    return tr("Beta Releases");
 }
 
-QString DevReleaseChannel::getReleaseChannelUrl() const
+QString BetaReleaseChannel::getReleaseChannelUrl() const
 {
-    return QString(DEVRELEASE_URL);
+    return QString(BETARELEASE_URL);
 }
 
-void DevReleaseChannel::releaseListFinished()
+void BetaReleaseChannel::releaseListFinished()
 {
     QNetworkReply *reply = static_cast<QNetworkReply *>(sender());
     QByteArray jsonData = reply->readAll();
@@ -251,20 +251,20 @@ void DevReleaseChannel::releaseListFinished()
 
     QString shortHash = lastRelease->getCommitHash().left(GIT_SHORT_HASH_LEN);
     lastRelease->setName(QString("%1 (%2)").arg(resultMap["tag_name"].toString()).arg(shortHash));
-    lastRelease->setDescriptionUrl(QString(DEVRELEASE_DESCURL).arg(VERSION_COMMIT, shortHash));
+    lastRelease->setDescriptionUrl(QString(BETARELEASE_CHANGESURL).arg(VERSION_COMMIT, shortHash));
 
     qDebug() << "Got reply from release server, size=" << resultMap.size() << "name=" << lastRelease->getName()
              << "desc=" << lastRelease->getDescriptionUrl() << "commit=" << lastRelease->getCommitHash()
              << "date=" << lastRelease->getPublishDate();
 
-    QString devBuildDownloadUrl = resultMap["assets_url"].toString();
+    QString betaBuildDownloadUrl = resultMap["assets_url"].toString();
 
-    qDebug() << "Searching for a corresponding file on the dev channel: " << devBuildDownloadUrl;
-    response = netMan->get(QNetworkRequest(devBuildDownloadUrl));
+    qDebug() << "Searching for a corresponding file on the beta channel: " << betaBuildDownloadUrl;
+    response = netMan->get(QNetworkRequest(betaBuildDownloadUrl));
     connect(response, SIGNAL(finished()), this, SLOT(fileListFinished()));
 }
 
-void DevReleaseChannel::fileListFinished()
+void BetaReleaseChannel::fileListFinished()
 {
     QNetworkReply *reply = static_cast<QNetworkReply *>(sender());
     QByteArray jsonData = reply->readAll();

--- a/cockatrice/src/releasechannel.h
+++ b/cockatrice/src/releasechannel.h
@@ -12,7 +12,7 @@ class QNetworkAccessManager;
 class Release
 {
     friend class StableReleaseChannel;
-    friend class DevReleaseChannel;
+    friend class BetaReleaseChannel;
 
 public:
     Release(){};
@@ -129,12 +129,12 @@ protected slots:
     virtual void fileListFinished();
 };
 
-class DevReleaseChannel : public ReleaseChannel
+class BetaReleaseChannel : public ReleaseChannel
 {
     Q_OBJECT
 public:
-    DevReleaseChannel(){};
-    ~DevReleaseChannel(){};
+    BetaReleaseChannel(){};
+    ~BetaReleaseChannel(){};
     virtual QString getManualDownloadUrl() const;
     virtual QString getName() const;
 

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -169,7 +169,7 @@ SettingsCache::SettingsCache()
     // updates - don't reorder them or their index in the settings won't match
     // append channels one by one, or msvc will add them in the wrong order.
     releaseChannels << new StableReleaseChannel();
-    releaseChannels << new DevReleaseChannel();
+    releaseChannels << new BetaReleaseChannel();
 
     mbDownloadSpoilers = settings->value("personal/downloadspoilers", false).toBool();
 


### PR DESCRIPTION
## Short roundup of the initial problem
Before, we used terms like `development snapshots` in the UI and code to name our "nightly" builds back when we deployed all commits from master to bintray.

Also we sometimes use *full releases*  and sometimes *stable releases* for the same thing.

## What will change with this Pull Request?
- Consistently use `Beta`
That's what it is, and we use all the time. (Pre-release names, tags, semver appendixes...)