### PR TITLE
Split card handling added to cmc filter

### DIFF
--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -231,7 +231,21 @@ bool FilterItem::acceptManaCost(const CardInfoPtr info) const
 
 bool FilterItem::acceptCmc(const CardInfoPtr info) const
 {
-    return relationCheck(info->getCmc().toInt());
+    bool convertSuccess;
+    int cmcInt = info->getCmc().toInt(&convertSuccess);
+    if (!convertSuccess) {
+        int cmcSum = 0;
+        foreach (QString cmc, info->getCmc().split("//")) {
+            cmcInt = cmc.toInt();
+            cmcSum += cmcInt;
+            if (relationCheck(cmcInt)) {
+                return true;
+            }
+        }
+        return (cmcSum > 1 ? relationCheck(cmcSum) : false);
+    } else {
+        return relationCheck(cmcInt);
+    }
 }
 
 bool FilterItem::acceptPower(const CardInfoPtr info) const

--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -236,7 +236,7 @@ bool FilterItem::acceptCmc(const CardInfoPtr info) const
     // if conversion failed, check for the "//" separator used in split cards
     if (!convertSuccess) {
         int cmcSum = 0;
-        for (QString cmc : info->getCmc().split("//")) {
+        for (const QString &cmc : info->getCmc().split("//")) {
             cmcInt = cmc.toInt();
             cmcSum += cmcInt;
             if (relationCheck(cmcInt)) {

--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -233,6 +233,7 @@ bool FilterItem::acceptCmc(const CardInfoPtr info) const
 {
     bool convertSuccess;
     int cmcInt = info->getCmc().toInt(&convertSuccess);
+    // if conversion failed, check for the "//" separator used in split cards
     if (!convertSuccess) {
         int cmcSum = 0;
         foreach (QString cmc, info->getCmc().split("//")) {
@@ -242,7 +243,7 @@ bool FilterItem::acceptCmc(const CardInfoPtr info) const
                 return true;
             }
         }
-        return (cmcSum > 1 ? relationCheck(cmcSum) : false);
+        return relationCheck(cmcSum);
     } else {
         return relationCheck(cmcInt);
     }

--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -236,7 +236,7 @@ bool FilterItem::acceptCmc(const CardInfoPtr info) const
     // if conversion failed, check for the "//" separator used in split cards
     if (!convertSuccess) {
         int cmcSum = 0;
-        foreach (QString cmc, info->getCmc().split("//")) {
+        for (QString cmc : info->getCmc().split("//")) {
             cmcInt = cmc.toInt();
             cmcSum += cmcInt;
             if (relationCheck(cmcInt)) {


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3071 

## Short roundup of the initial problem
CMC filter didn't work on split cards in the deck builder

## Screenshots
![split_card_filter](https://user-images.githubusercontent.com/9273978/35923976-06a2873a-0c22-11e8-8c67-541563c018cf.png)
