### PR TITLE
Add custom QStyle class to tab bar to fix render issue on macOS. 

### DIFF
--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -30,8 +30,7 @@
 
 QRect MacOSTabFixStyle::subElementRect(SubElement element, const QStyleOption *option, const QWidget *widget) const
 {
-    if(element != SE_TabBarTabText)
-    {
+    if (element != SE_TabBarTabText) {
         return QProxyStyle::subElementRect(element, option, widget);
     }
 
@@ -100,11 +99,11 @@ TabSupervisor::TabSupervisor(AbstractClient *_client, QWidget *parent)
     setMovable(true);
     setIconSize(QSize(15, 15));
 
-    #if defined(Q_OS_MAC)
+#if defined(Q_OS_MAC)
     // This is necessary to fix an issue on macOS with qt5.10,
     // where tabs with icons and buttons get drawn incorrectly
     tabBar()->setStyle(new MacOSTabFixStyle);
-    #endif
+#endif
 
     connect(this, SIGNAL(currentChanged(int)), this, SLOT(updateCurrent(int)));
 

--- a/cockatrice/src/tab_supervisor.h
+++ b/cockatrice/src/tab_supervisor.h
@@ -4,10 +4,10 @@
 #include "chatview/userlistProxy.h"
 #include "deck_loader.h"
 #include <QAbstractButton>
-#include <QMap>
-#include <QTabWidget>
-#include <QProxyStyle>
 #include <QCommonStyle>
+#include <QMap>
+#include <QProxyStyle>
+#include <QTabWidget>
 
 class QMenu;
 class AbstractClient;

--- a/cockatrice/src/tab_supervisor.h
+++ b/cockatrice/src/tab_supervisor.h
@@ -6,6 +6,8 @@
 #include <QAbstractButton>
 #include <QMap>
 #include <QTabWidget>
+#include <QProxyStyle>
+#include <QCommonStyle>
 
 class QMenu;
 class AbstractClient;
@@ -29,6 +31,13 @@ class ServerInfo_Room;
 class ServerInfo_User;
 class GameReplay;
 class DeckList;
+
+class MacOSTabFixStyle : public QProxyStyle
+{
+    Q_OBJECT
+public:
+    QRect subElementRect(SubElement, const QStyleOption *, const QWidget *) const;
+};
 
 class CloseButton : public QAbstractButton
 {


### PR DESCRIPTION
This fixes a rendering issue on macOS with qt5.10
## Related Ticket(s)
- Fixes #3070
