### PR TITLE
Hotfix/2950 delete filters with keyboard

### DIFF
--- a/cockatrice/src/sequenceEdit/sequenceedit.cpp
+++ b/cockatrice/src/sequenceEdit/sequenceedit.cpp
@@ -139,19 +139,23 @@ int SequenceEdit::translateModifiers(Qt::KeyboardModifiers state, const QString 
 
 void SequenceEdit::finishShortcut()
 {
-    QKeySequence secuence(keys);
-    if (!secuence.isEmpty() && valid) {
-        QString secuenceString = secuence.toString();
-        if (settingsCache->shortcuts().isValid(shorcutName, secuenceString)) {
-            if (!lineEdit->text().isEmpty()) {
-                if (lineEdit->text().contains(secuenceString)) {
-                    return;
+    QKeySequence sequence(keys);
+    if (!sequence.isEmpty() && valid) {
+        QString sequenceString = sequence.toString();
+        if (settingsCache->shortcuts().isKeyAllowed(sequenceString)) {
+            if (settingsCache->shortcuts().isValid(shorcutName, sequenceString)) {
+                if (!lineEdit->text().isEmpty()) {
+                    if (lineEdit->text().contains(sequenceString)) {
+                        return;
+                    }
+                    lineEdit->setText(lineEdit->text() + ";");
                 }
-                lineEdit->setText(lineEdit->text() + ";");
+                lineEdit->setText(lineEdit->text() + sequenceString);
+            } else {
+                QToolTip::showText(lineEdit->mapToGlobal(QPoint()), tr("Shortcut already in use"));
             }
-            lineEdit->setText(lineEdit->text() + secuenceString);
         } else {
-            QToolTip::showText(lineEdit->mapToGlobal(QPoint()), tr("Shortcut already in use"));
+            QToolTip::showText(lineEdit->mapToGlobal(QPoint()), tr("Invalid key"));
         }
     }
 

--- a/cockatrice/src/sequenceEdit/sequenceedit.cpp
+++ b/cockatrice/src/sequenceEdit/sequenceedit.cpp
@@ -142,7 +142,7 @@ void SequenceEdit::finishShortcut()
     QKeySequence sequence(keys);
     if (!sequence.isEmpty() && valid) {
         QString sequenceString = sequence.toString();
-        if (settingsCache->shortcuts().isKeyAllowed(sequenceString)) {
+        if (settingsCache->shortcuts().isKeyAllowed(shorcutName, sequenceString)) {
             if (settingsCache->shortcuts().isValid(shorcutName, sequenceString)) {
                 if (!lineEdit->text().isEmpty()) {
                     if (lineEdit->text().contains(sequenceString)) {

--- a/cockatrice/src/shortcutssettings.cpp
+++ b/cockatrice/src/shortcutssettings.cpp
@@ -31,7 +31,7 @@ ShortcutsSettings::ShortcutsSettings(QString settingsPath, QObject *parent) : QO
         shortCutsFile.endGroup();
 
         // set default shortcut where stored value was invalid
-        for (QString key : invalidKeys) {
+        for (const QString &key : invalidKeys) {
             setShortcuts(key, getDefaultShortcutString(key));
         }
     }

--- a/cockatrice/src/shortcutssettings.cpp
+++ b/cockatrice/src/shortcutssettings.cpp
@@ -17,6 +17,7 @@ ShortcutsSettings::ShortcutsSettings(QString settingsPath, QObject *parent) : QO
     if (exists) {
         shortCutsFile.beginGroup("Custom");
         const QStringList customKeys = shortCutsFile.allKeys();
+
         QStringList invalidKeys = QStringList();
         for (QStringList::const_iterator it = customKeys.constBegin(); it != customKeys.constEnd(); ++it) {
             QString stringSequence = shortCutsFile.value(*it).toString();
@@ -28,6 +29,7 @@ ShortcutsSettings::ShortcutsSettings(QString settingsPath, QObject *parent) : QO
                 invalidKeys.append(*it);
             }
         }
+
         shortCutsFile.endGroup();
 
         // set default shortcut where stored value was invalid

--- a/cockatrice/src/shortcutssettings.cpp
+++ b/cockatrice/src/shortcutssettings.cpp
@@ -24,8 +24,7 @@ ShortcutsSettings::ShortcutsSettings(QString settingsPath, QObject *parent) : QO
             if (isValid(*it, stringSequence)) {
                 QList<QKeySequence> SequenceList = parseSequenceString(stringSequence);
                 shortCuts.insert(*it, SequenceList);
-            }
-            else {
+            } else {
                 invalidKeys.append(*it);
             }
         }
@@ -114,8 +113,15 @@ bool ShortcutsSettings::isValid(QString name, QString Sequences)
 
     QString checkSequence = Sequences.split(";").last();
 
-    QStringList forbiddenKeys = (QStringList() << "Del" << "Down" << "Up" << "Left" << "Right"
-        << "Return" << "Enter" << "Backspace" << "Esc");
+    QStringList forbiddenKeys = (QStringList() << "Del"
+                                               << "Down"
+                                               << "Up"
+                                               << "Left"
+                                               << "Right"
+                                               << "Return"
+                                               << "Enter"
+                                               << "Backspace"
+                                               << "Esc");
     if (forbiddenKeys.contains(checkSequence)) {
         return false;
     }

--- a/cockatrice/src/shortcutssettings.cpp
+++ b/cockatrice/src/shortcutssettings.cpp
@@ -23,7 +23,7 @@ ShortcutsSettings::ShortcutsSettings(QString settingsPath, QObject *parent) : QO
         for (QStringList::const_iterator it = customKeys.constBegin(); it != customKeys.constEnd(); ++it) {
             QString stringSequence = shortCutsFile.value(*it).toString();
             // check whether shortcut is forbidden
-            if (isKeyAllowed(stringSequence)) {
+            if (isKeyAllowed(*it, stringSequence)) {
                 QList<QKeySequence> SequenceList = parseSequenceString(stringSequence);
                 shortCuts.insert(*it, SequenceList);
             } else {
@@ -34,13 +34,12 @@ ShortcutsSettings::ShortcutsSettings(QString settingsPath, QObject *parent) : QO
         shortCutsFile.endGroup();
 
         if (!invalidItems.isEmpty()) {
-
             // warning message in case of invalid items
             QMessageBox msgBox;
             msgBox.setIcon(QMessageBox::Warning);
             msgBox.setText(tr("Your configuration file contained invalid shortcuts.\n"
                               "Please check your shortcut settings!"));
-            QString detailedMessage = QString();
+            QString detailedMessage = tr("The following shortcuts have been set to default:\n");
             for (QMap<QString, QString>::const_iterator item = invalidItems.constBegin();
                  item != invalidItems.constEnd(); ++item) {
                 detailedMessage += item.key() + " - \"" + item.value() + "\"\n";
@@ -126,8 +125,12 @@ void ShortcutsSettings::setShortcuts(QString name, QString Sequences)
     setShortcuts(std::move(name), parseSequenceString(std::move(Sequences)));
 }
 
-bool ShortcutsSettings::isKeyAllowed(QString Sequences)
+bool ShortcutsSettings::isKeyAllowed(QString name, QString Sequences)
 {
+    // if the shortcut is not to be used in deck-editor then it doesn't matter
+    if (name.startsWith("Player")) {
+        return true;
+    }
     QString checkSequence = Sequences.split(";").last();
     QStringList forbiddenKeys = (QStringList() << "Del"
                                                << "Backspace"
@@ -137,7 +140,14 @@ bool ShortcutsSettings::isKeyAllowed(QString Sequences)
                                                << "Right"
                                                << "Return"
                                                << "Enter"
-                                               << "Menu");
+                                               << "Menu"
+                                               << "Ctrl+Alt+-"
+                                               << "Ctrl+Alt+="
+                                               << "Ctrl+Alt+["
+                                               << "Ctrl+Alt+]"
+                                               << "Tab"
+                                               << "Space"
+                                               << "S");
     if (forbiddenKeys.contains(checkSequence)) {
         return false;
     }

--- a/cockatrice/src/shortcutssettings.h
+++ b/cockatrice/src/shortcutssettings.h
@@ -22,7 +22,7 @@ public:
     void setShortcuts(QString name, QKeySequence Sequence);
     void setShortcuts(QString name, QString Sequences);
 
-    bool isKeyAllowed(QString Sequences);
+    bool isKeyAllowed(QString name, QString Sequences);
     bool isValid(QString name, QString Sequences);
 
     void resetAllShortcuts();

--- a/cockatrice/src/shortcutssettings.h
+++ b/cockatrice/src/shortcutssettings.h
@@ -22,6 +22,7 @@ public:
     void setShortcuts(QString name, QKeySequence Sequence);
     void setShortcuts(QString name, QString Sequences);
 
+    bool isKeyAllowed(QString Sequences);
     bool isValid(QString name, QString Sequences);
 
     void resetAllShortcuts();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2950 

## Short roundup of the initial problem
`Del` key didn't clear the selected filter in the deckbuilder

## What will change with this Pull Request?
- "Remove card" default shortcut removed from `Del`
- Setting up shortcuts to some important keys is made impossible
- Shortcut key validity is checked on startup as well: users won't be able to insert such invalid keys from a tampered `shortcuts.ini` file either