### PR TITLE
Mana cost filtering for split cards

### DIFF
--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -219,14 +219,21 @@ bool FilterItem::acceptSet(const CardInfoPtr info) const
 bool FilterItem::acceptManaCost(const CardInfoPtr info) const
 {
     QString partialCost = term.toUpper();
-    QString fullManaCost = info->getManaCost();
 
-    // Sort the mana costs so they can be easily compared
+    // Sort the mana cost so it will be easy to find
     std::sort(partialCost.begin(), partialCost.end());
-    std::sort(fullManaCost.begin(), fullManaCost.end());
 
-    // If the partial is found in the full, return true
-    return (fullManaCost.indexOf(partialCost) > -1);
+    // Try to seperate the mana cost in case it's a split card
+    // if it's not a split card the loop will run only once
+    for (QString fullManaCost : info->getManaCost().split("//")) {
+        std::sort(fullManaCost.begin(), fullManaCost.end());
+
+        // If the partial is found in the full, return true
+        if (fullManaCost.contains(partialCost)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool FilterItem::acceptCmc(const CardInfoPtr info) const


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2546 

## Short roundup of the initial problem
Mana cost filter didn't work for split cards

## Screenshots
![split_card_filter_mana_cost](https://user-images.githubusercontent.com/9273978/35991095-571e722a-0d06-11e8-8385-744bda2c40f3.png)
