### PR TITLE
'Rarity' property added to split cards in xml

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -278,6 +278,10 @@ int OracleImporter::importTextSpoiler(CardSetPtr set, const QVariant &data)
                 if (setNumber.isEmpty())
                     setNumber = map.value("number").toString();
             }
+            if (map.contains("rarity")) {
+                if (rarity.isEmpty())
+                    rarity = map.value("rarity").toString();
+            }
 
             extractColors(map.value("colors").toStringList(), colors);
         }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3092 

## What will change with this Pull Request?
Rarity field in the `cards.xml` database will be filled with the first card's rarity data during json parsing.