### PR TITLE
Tablerow fixed for non-mana generating artifacts

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -84,10 +84,14 @@ CardInfoPtr OracleImporter::addCard(const QString &setName,
 
         // detect mana generator artifacts
         bool mArtifact = false;
-        if (cardType.endsWith("Artifact"))
-            for (int i = 0; i < cardTextRows.size(); ++i)
-                if (cardTextRows[i].contains("{T}") && cardTextRows[i].contains("to your mana pool"))
+        if (cardType.endsWith("Artifact")) {
+            for (int i = 0; i < cardTextRows.size(); ++i) {
+                cardTextRows[i].remove(QRegularExpression("\\\".*?\\\""));
+                if (cardTextRows[i].contains("{T}") && cardTextRows[i].contains("to your mana pool")) {
                     mArtifact = true;
+                }
+            }
+        }
 
         // detect cards that enter the field tapped
         bool cipt =


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2904 

## What will change with this Pull Request?
As discussed in the related topic, the quoted parts of artifact texts are not taken into consideration when deciding whether they are mana-producing artifacts or not.
The discussion mentioned three such artifacts, but in fact only Treasure Map is affected, because the other two are equipments. This makes the `if (cardType.endsWith("Artifact"))` condition fail on them, so they get `tableRow=1` by default - even without this modification.
See attached shortcut for diff between cards.xml generated with and without the modification.

## Screenshots
![xml_diff](https://user-images.githubusercontent.com/9273978/36061286-a74fa5cc-0e58-11e8-897f-afa055c318f9.png)