### PR TITLE
"Comment" field made resizable in deck builder window

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -84,41 +84,45 @@ void TabDeckEditor::createDeckDock()
     commentsLabel->setObjectName("commentsLabel");
     commentsEdit = new QTextEdit;
     commentsEdit->setObjectName("commentsEdit");
-    commentsEdit->setMinimumHeight(30);
     commentsLabel->setBuddy(commentsEdit);
     connect(commentsEdit, SIGNAL(textChanged()), this, SLOT(updateComments()));
 
+    QGridLayout *upperLayout = new QGridLayout;
+    upperLayout->setObjectName("upperLayout");
+    upperLayout->addWidget(nameLabel, 0, 0);
+    upperLayout->addWidget(nameEdit, 0, 1);
+
+    upperLayout->addWidget(commentsLabel, 1, 0);
+    upperLayout->addWidget(commentsEdit, 1, 1);
+
     hashLabel1 = new QLabel();
     hashLabel1->setObjectName("hashLabel1");
+    QSizePolicy *hashSizePolicy = new QSizePolicy();
+    hashSizePolicy->setHorizontalPolicy(QSizePolicy::Fixed);
+    hashLabel1->setSizePolicy(*hashSizePolicy);
     hashLabel = new QLabel;
     hashLabel->setObjectName("hashLabel");
 
-    QGridLayout *grid = new QGridLayout;
-    grid->setObjectName("grid");
-    grid->addWidget(nameLabel, 0, 0);
-    grid->addWidget(nameEdit, 0, 1);
+    QGridLayout *lowerLayout = new QGridLayout;
+    lowerLayout->setObjectName("lowerLayout");
+    lowerLayout->addWidget(hashLabel1, 0, 0);
+    lowerLayout->addWidget(hashLabel, 0, 1, Qt::AlignLeft);
+    lowerLayout->addWidget(deckView, 1, 0, 1, 2);
 
-    grid->addWidget(commentsLabel, 1, 0);
-    grid->addWidget(commentsEdit, 1, 1);
-
-    QHBoxLayout *hashLayout = new QHBoxLayout;
-    hashLayout->addWidget(hashLabel1);
-    hashLayout->addWidget(hashLabel);
-
-    QVBoxLayout *lowerLayout = new QVBoxLayout;
-    lowerLayout->addLayout(hashLayout);
-    lowerLayout->addWidget(deckView);
-
-    // Create widgets for both layout to make splitter work correctly
+    // Create widgets for both layouts to make splitter work correctly
     QWidget *topWidget = new QWidget;
-    topWidget->setLayout(grid);
+    topWidget->setLayout(upperLayout);
     QWidget *bottomWidget = new QWidget;
     bottomWidget->setLayout(lowerLayout);
 
     QSplitter *split = new QSplitter;
+    split->setObjectName("deckSplitter");
     split->setOrientation(Qt::Vertical);
+    split->setChildrenCollapsible(false);
     split->addWidget(topWidget);
     split->addWidget(bottomWidget);
+    split->setStretchFactor(0, 1);
+    split->setStretchFactor(1, 4);
 
     QVBoxLayout *rightFrame = new QVBoxLayout;
     rightFrame->setObjectName("rightFrame");

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -33,6 +33,7 @@
 #include <QPrintPreviewDialog>
 #include <QProcessEnvironment>
 #include <QPushButton>
+#include <QSplitter>
 #include <QTextEdit>
 #include <QTextStream>
 #include <QTimer>
@@ -41,7 +42,6 @@
 #include <QTreeView>
 #include <QUrl>
 #include <QVBoxLayout>
-#include <QSplitter>
 
 void SearchLineEdit::keyPressEvent(QKeyEvent *event)
 {

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -106,7 +106,7 @@ void TabDeckEditor::createDeckDock()
     QGridLayout *lowerLayout = new QGridLayout;
     lowerLayout->setObjectName("lowerLayout");
     lowerLayout->addWidget(hashLabel1, 0, 0);
-    lowerLayout->addWidget(hashLabel, 0, 1, Qt::AlignLeft);
+    lowerLayout->addWidget(hashLabel, 0, 1);
     lowerLayout->addWidget(deckView, 1, 0, 1, 2);
 
     // Create widgets for both layouts to make splitter work correctly

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -87,7 +87,7 @@ void TabDeckEditor::createDeckDock()
     commentsLabel->setBuddy(commentsEdit);
     connect(commentsEdit, SIGNAL(textChanged()), this, SLOT(updateComments()));
 
-    QGridLayout *upperLayout = new QGridLayout;
+    auto *upperLayout = new QGridLayout;
     upperLayout->setObjectName("upperLayout");
     upperLayout->addWidget(nameLabel, 0, 0);
     upperLayout->addWidget(nameEdit, 0, 1);
@@ -97,13 +97,13 @@ void TabDeckEditor::createDeckDock()
 
     hashLabel1 = new QLabel();
     hashLabel1->setObjectName("hashLabel1");
-    QSizePolicy *hashSizePolicy = new QSizePolicy();
+    auto *hashSizePolicy = new QSizePolicy();
     hashSizePolicy->setHorizontalPolicy(QSizePolicy::Fixed);
     hashLabel1->setSizePolicy(*hashSizePolicy);
     hashLabel = new QLabel;
     hashLabel->setObjectName("hashLabel");
 
-    QGridLayout *lowerLayout = new QGridLayout;
+    auto *lowerLayout = new QGridLayout;
     lowerLayout->setObjectName("lowerLayout");
     lowerLayout->addWidget(hashLabel1, 0, 0);
     lowerLayout->addWidget(hashLabel, 0, 1);
@@ -115,7 +115,7 @@ void TabDeckEditor::createDeckDock()
     QWidget *bottomWidget = new QWidget;
     bottomWidget->setLayout(lowerLayout);
 
-    QSplitter *split = new QSplitter;
+    auto *split = new QSplitter;
     split->setObjectName("deckSplitter");
     split->setOrientation(Qt::Vertical);
     split->setChildrenCollapsible(false);
@@ -124,7 +124,7 @@ void TabDeckEditor::createDeckDock()
     split->setStretchFactor(0, 1);
     split->setStretchFactor(1, 4);
 
-    QVBoxLayout *rightFrame = new QVBoxLayout;
+    auto *rightFrame = new QVBoxLayout;
     rightFrame->setObjectName("rightFrame");
     rightFrame->addWidget(split);
 
@@ -148,7 +148,7 @@ void TabDeckEditor::createCardInfoDock()
 {
     cardInfo = new CardFrame();
     cardInfo->setObjectName("cardInfo");
-    QVBoxLayout *cardInfoFrame = new QVBoxLayout;
+    auto *cardInfoFrame = new QVBoxLayout;
     cardInfoFrame->setObjectName("cardInfoFrame");
     cardInfoFrame->addWidget(cardInfo);
 
@@ -186,21 +186,21 @@ void TabDeckEditor::createFiltersDock()
             SLOT(filterViewCustomContextMenu(const QPoint &)));
     connect(&filterViewKeySignals, SIGNAL(onDelete()), this, SLOT(actClearFilterOne()));
 
-    FilterBuilder *filterBuilder = new FilterBuilder;
+    auto *filterBuilder = new FilterBuilder;
     filterBuilder->setObjectName("filterBuilder");
     connect(filterBuilder, SIGNAL(add(const CardFilter *)), filterModel, SLOT(addFilter(const CardFilter *)));
 
-    QToolButton *filterDelOne = new QToolButton();
+    auto *filterDelOne = new QToolButton();
     filterDelOne->setObjectName("filterDelOne");
     filterDelOne->setDefaultAction(aClearFilterOne);
     filterDelOne->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
 
-    QToolButton *filterDelAll = new QToolButton();
+    auto *filterDelAll = new QToolButton();
     filterDelAll->setObjectName("filterDelAll");
     filterDelAll->setDefaultAction(aClearFilterAll);
     filterDelAll->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
 
-    QGridLayout *filterLayout = new QGridLayout;
+    auto *filterLayout = new QGridLayout;
     filterLayout->setObjectName("filterLayout");
     filterLayout->setContentsMargins(0, 0, 0, 0);
     filterLayout->addWidget(filterBuilder, 0, 0, 1, 3);
@@ -212,7 +212,7 @@ void TabDeckEditor::createFiltersDock()
     filterBox->setObjectName("filterBox");
     filterBox->setLayout(filterLayout);
 
-    QVBoxLayout *filterFrame = new QVBoxLayout;
+    auto *filterFrame = new QVBoxLayout;
     filterFrame->setObjectName("filterFrame");
     filterFrame->addWidget(filterBox);
 
@@ -411,7 +411,7 @@ void TabDeckEditor::createCentralFrame()
     aDecrement->setIcon(QPixmap("theme:icons/decrement"));
     connect(aDecrement, SIGNAL(triggered()), this, SLOT(actDecrement()));
 
-    QToolBar *deckEditToolBar = new QToolBar;
+    auto *deckEditToolBar = new QToolBar;
     deckEditToolBar->setObjectName("deckEditToolBar");
     deckEditToolBar->setOrientation(Qt::Horizontal);
     deckEditToolBar->setIconSize(QSize(24, 24));
@@ -723,7 +723,7 @@ void TabDeckEditor::actLoadDeck()
     QString fileName = dialog.selectedFiles().at(0);
     DeckLoader::FileFormat fmt = DeckLoader::getFormatFromName(fileName);
 
-    DeckLoader *l = new DeckLoader;
+    auto *l = new DeckLoader;
     if (l->loadFromFile(fileName, fmt))
         setDeck(l);
     else
@@ -743,7 +743,7 @@ bool TabDeckEditor::actSaveDeck()
     DeckLoader *const deck = deckModel->getDeckList();
     if (deck->getLastRemoteDeckId() != -1) {
         Command_DeckUpload cmd;
-        cmd.set_deck_id(deck->getLastRemoteDeckId());
+        cmd.set_deck_id(static_cast<google::protobuf::uint32>(deck->getLastRemoteDeckId()));
         cmd.set_deck_list(deck->writeToString_Native().toStdString());
 
         PendingCommand *pend = AbstractClient::prepareSessionCommand(cmd);
@@ -859,15 +859,15 @@ void TabDeckEditor::actExportDeckDecklist()
 
 void TabDeckEditor::actAnalyzeDeckDeckstats()
 {
-    DeckStatsInterface *interface = new DeckStatsInterface(*databaseModel->getDatabase(),
-                                                           this); // it deletes itself when done
+    auto *interface = new DeckStatsInterface(*databaseModel->getDatabase(),
+                                             this); // it deletes itself when done
     interface->analyzeDeck(deckModel->getDeckList());
 }
 
 void TabDeckEditor::actAnalyzeDeckTappedout()
 {
-    TappedOutInterface *interface = new TappedOutInterface(*databaseModel->getDatabase(),
-                                                           this); // it deletes itself when done
+    auto *interface = new TappedOutInterface(*databaseModel->getDatabase(),
+                                             this); // it deletes itself when done
     interface->analyzeDeck(deckModel->getDeckList());
 }
 

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -41,6 +41,7 @@
 #include <QTreeView>
 #include <QUrl>
 #include <QVBoxLayout>
+#include <QSplitter>
 
 void SearchLineEdit::keyPressEvent(QKeyEvent *event)
 {
@@ -83,7 +84,7 @@ void TabDeckEditor::createDeckDock()
     commentsLabel->setObjectName("commentsLabel");
     commentsEdit = new QTextEdit;
     commentsEdit->setObjectName("commentsEdit");
-    commentsEdit->setMaximumHeight(70);
+    commentsEdit->setMinimumHeight(30);
     commentsLabel->setBuddy(commentsEdit);
     connect(commentsEdit, SIGNAL(textChanged()), this, SLOT(updateComments()));
 
@@ -100,13 +101,28 @@ void TabDeckEditor::createDeckDock()
     grid->addWidget(commentsLabel, 1, 0);
     grid->addWidget(commentsEdit, 1, 1);
 
-    grid->addWidget(hashLabel1, 2, 0);
-    grid->addWidget(hashLabel, 2, 1);
+    QHBoxLayout *hashLayout = new QHBoxLayout;
+    hashLayout->addWidget(hashLabel1);
+    hashLayout->addWidget(hashLabel);
+
+    QVBoxLayout *lowerLayout = new QVBoxLayout;
+    lowerLayout->addLayout(hashLayout);
+    lowerLayout->addWidget(deckView);
+
+    // Create widgets for both layout to make splitter work correctly
+    QWidget *topWidget = new QWidget;
+    topWidget->setLayout(grid);
+    QWidget *bottomWidget = new QWidget;
+    bottomWidget->setLayout(lowerLayout);
+
+    QSplitter *split = new QSplitter;
+    split->setOrientation(Qt::Vertical);
+    split->addWidget(topWidget);
+    split->addWidget(bottomWidget);
 
     QVBoxLayout *rightFrame = new QVBoxLayout;
     rightFrame->setObjectName("rightFrame");
-    rightFrame->addLayout(grid);
-    rightFrame->addWidget(deckView, 10);
+    rightFrame->addWidget(split);
 
     deckDock = new QDockWidget(this);
     deckDock->setObjectName("deckDock");


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1504

## What will change with this Pull Request?
Layout of deck-builder changed to make the "Comments" section resizable.
Hash info have been moved from the upper QGridLayout to the bottom in a new grid together with the deckView. These two layouts are merged with a QSplitter object to make resizing possible.

## Screenshots
![resizable_comment_field](https://user-images.githubusercontent.com/9273978/36062846-ae360e8c-0e74-11e8-8fb4-481708e1c726.png)