### PR TITLE
Sending card name to chat on shift+click

### DIFF
--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -271,7 +271,9 @@ void AbstractCardItem::setFaceDown(bool _facedown)
 
 void AbstractCardItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-    if ((event->modifiers() & Qt::ControlModifier)) {
+    if ((event->modifiers() & Qt::ShiftModifier) && event->button() == Qt::LeftButton) {
+        emit cardShiftClicked(name);
+    } else if ((event->modifiers() & Qt::ControlModifier)) {
         setSelected(!isSelected());
     } else if (!isSelected()) {
         scene()->clearSelection();

--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -271,7 +271,7 @@ void AbstractCardItem::setFaceDown(bool _facedown)
 
 void AbstractCardItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-    if ((event->modifiers() & Qt::ShiftModifier) && event->button() == Qt::LeftButton) {
+    if ((event->modifiers() & Qt::AltModifier) && event->button() == Qt::LeftButton) {
         emit cardShiftClicked(name);
     } else if ((event->modifiers() & Qt::ControlModifier)) {
         setSelected(!isSelected());

--- a/cockatrice/src/abstractcarditem.h
+++ b/cockatrice/src/abstractcarditem.h
@@ -38,6 +38,7 @@ signals:
     void deleteCardInfoPopup(QString cardName);
     void updateCardMenu(AbstractCardItem *card);
     void sigPixmapUpdated();
+    void cardShiftClicked(QString cardName);
 
 public:
     enum

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -368,7 +368,8 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
             owner->updateCardMenu(this);
             cardMenu->exec(event->screenPos());
         }
-    } else if ((event->button() == Qt::LeftButton) && !settingsCache->getDoubleClickToPlay()) {
+    } else if ((event->modifiers() != Qt::AltModifier) && (event->button() == Qt::LeftButton) &&
+               (!settingsCache->getDoubleClickToPlay())) {
         bool hideCard = false;
         if (zone && zone->getIsView()) {
             ZoneViewZone *view = static_cast<ZoneViewZone *>(zone);
@@ -388,7 +389,8 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 
 void CardItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
 {
-    if (settingsCache->getDoubleClickToPlay() && event->buttons() == Qt::LeftButton) {
+    if ((event->modifiers() != Qt::AltModifier) && (settingsCache->getDoubleClickToPlay()) &&
+        (event->buttons() == Qt::LeftButton)) {
         if (revealedCard)
             zone->removeCard(this);
         else

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -431,6 +431,12 @@ void TabGame::addMentionTag(QString value)
     sayEdit->setFocus();
 }
 
+void TabGame::linkCardToChat(QString cardName)
+{
+    sayEdit->insert("[[" + cardName + "]] ");
+    sayEdit->setFocus();
+}
+
 void TabGame::emitUserEvent()
 {
     bool globalEvent = !spectator || settingsCache->getSpectatorNotificationsEnabled();
@@ -1224,6 +1230,7 @@ void TabGame::newCardAdded(AbstractCardItem *card)
     connect(card, SIGNAL(showCardInfoPopup(QPoint, QString)), this, SLOT(showCardInfoPopup(QPoint, QString)));
     connect(card, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));
     connect(card, SIGNAL(updateCardMenu(AbstractCardItem *)), this, SLOT(updateCardMenu(AbstractCardItem *)));
+    connect(card, SIGNAL(cardShiftClicked(QString)), this, SLOT(linkCardToChat(QString)));
 }
 
 CardItem *TabGame::getCard(int playerId, const QString &zoneName, int cardId) const

--- a/cockatrice/src/tab_game.h
+++ b/cockatrice/src/tab_game.h
@@ -236,6 +236,7 @@ private slots:
     void actNextTurn();
 
     void addMentionTag(QString value);
+    void linkCardToChat(QString cardName);
     void commandFinished(const Response &response);
 
     void refreshShortcuts();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2629 

## What will change with this Pull Request?
When a user shift+left clicks a card, its name will be added to his/her chat text field, enclosed by double brackets.
The issue asks for ctrl+click, but that combination is already used for selecting multiple cards.