### PR TITLE
Braces left in for split mana costs in xml

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -78,9 +78,17 @@ CardInfoPtr OracleImporter::addCard(const QString &setName,
     if (cards.contains(cardName)) {
         card = cards.value(cardName);
     } else {
-        // Remove {} around mana costs
-        cardCost.remove(QChar('{'));
-        cardCost.remove(QChar('}'));
+        // Remove {} around mana costs, except if it's split cost
+        QStringList symbols = cardCost.split("}");
+        QString formattedCardCost = QString();
+        for (QString symbol : symbols) {
+            if (symbol.contains(QRegExp("[BWUGR]/[BWUGR]"))) {
+                symbol.append("}");
+            } else {
+                symbol.remove(QChar('{'));
+            }
+            formattedCardCost.append(symbol);
+        }
 
         // detect mana generator artifacts
         bool mArtifact = false;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3017

## Short roundup of the initial problem
Split mana costs were not displayed correctly: without the braces `{G/W}{G/W}` looked like `G/WG/W`, which can be easily misinterpreted.

## Screenshots
![split_mana_costs](https://user-images.githubusercontent.com/9273978/36183040-d8e15618-112c-11e8-9806-55c0eefdf0ed.PNG)