### PR TITLE
Right-click menu added for card database view

### DIFF
--- a/cockatrice/src/tab_deck_editor.h
+++ b/cockatrice/src/tab_deck_editor.h
@@ -55,6 +55,7 @@ private slots:
     void updateCardInfoLeft(const QModelIndex &current, const QModelIndex &previous);
     void updateCardInfoRight(const QModelIndex &current, const QModelIndex &previous);
     void updateSearch(const QString &search);
+    void databaseCustomMenu(QPoint point);
 
     void actNewDeck();
     void actLoadDeck();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2013

## Short roundup of the initial problem
There was no way to track related cards (e.g. transforms, melds, etc.) in the card database view.

## What will change with this Pull Request?
- Right click menu added with options to add selected card to either main deck or sideboard
- Where applicable the third "Show Related Cards" option is enabled, and filled with the related cards as a submenu
- When a related card is clicked from this submenu, the card info widgets updates to show the related card

## Screenshots
Context menu on a normal card:
![card_db_context_menu_1](https://user-images.githubusercontent.com/9273978/36233182-fecdec34-11e4-11e8-95d3-0bfbb9cbb8fb.png)

Menu where a related card exists:
![card_db_context_menu_2](https://user-images.githubusercontent.com/9273978/36233183-feecff52-11e4-11e8-9061-c8a850c2c40b.png)

After clicking the related card:
![card_db_context_menu_3](https://user-images.githubusercontent.com/9273978/36233184-ff077e7c-11e4-11e8-9d79-00bfe340cc94.png)

Layout with a meld card:
![card_db_context_menu_4](https://user-images.githubusercontent.com/9273978/36233185-ff24101e-11e4-11e8-8c3f-b644510a544a.png)
