### PR TITLE
"Show related card" option added to ingame context menu

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -25,6 +25,7 @@
 #include <QMenu>
 #include <QPainter>
 #include <QRegExp>
+#include <QSignalMapper>
 
 #include "pb/command_attach_card.pb.h"
 #include "pb/command_change_zone_properties.pb.h"
@@ -2685,6 +2686,27 @@ void Player::updateCardMenu(const CardItem *card)
             cardMenu->addAction(aClone);
         }
     }
+    addRelatedCardView(card, cardMenu);
+}
+
+void Player::addRelatedCardView(const CardItem *card, QMenu *cardMenu)
+{
+    if (card == nullptr || cardMenu == nullptr || card->getInfo() == nullptr)
+        return;
+
+    QList<CardRelation *> relatedCards = card->getInfo()->getRelatedCards();
+    if (relatedCards.isEmpty()) {
+        return;
+    }
+
+    cardMenu->addSeparator();
+    auto *signalMapper = new QSignalMapper(this);
+    for (const CardRelation *relatedCard : relatedCards) {
+        QAction *viewCard = cardMenu->addAction("Show card: \"" + relatedCard->getName() + "\"");
+        connect(viewCard, SIGNAL(triggered()), signalMapper, SLOT(map()));
+        signalMapper->setMapping(viewCard, relatedCard->getName());
+    }
+    connect(signalMapper, SIGNAL(mapped(const QString &)), game, SLOT(viewCardInfo(const QString &)));
 }
 
 void Player::addRelatedCardActions(const CardItem *card, QMenu *cardMenu)

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2676,7 +2676,7 @@ void Player::updateCardMenu(const CardItem *card)
                 cardMenu->addAction(aClone);
                 cardMenu->addMenu(moveMenu);
             } else {
-                // Card is in hand
+                // Card is in hand or a custom zone specified by server
                 cardMenu->addAction(aPlay);
                 cardMenu->addAction(aPlayFacedown);
                 cardMenu->addMenu(moveMenu);

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2612,6 +2612,8 @@ void Player::updateCardMenu(const CardItem *card)
 
         if (card->getZone()) {
             if (card->getZone()->getName() == "table") {
+                // Card is on the battlefield
+
                 if (ptMenu->isEmpty()) {
                     ptMenu->addAction(aIncP);
                     ptMenu->addAction(aDecP);
@@ -2632,6 +2634,7 @@ void Player::updateCardMenu(const CardItem *card)
                     cardMenu->addAction(aPeek);
                 }
 
+                addRelatedCardView(card, cardMenu);
                 addRelatedCardActions(card, cardMenu);
 
                 cardMenu->addSeparator();
@@ -2657,22 +2660,27 @@ void Player::updateCardMenu(const CardItem *card)
                 }
                 cardMenu->addSeparator();
             } else if (card->getZone()->getName() == "stack") {
+                // Card is on the stack
                 cardMenu->addAction(aDrawArrow);
                 cardMenu->addSeparator();
                 cardMenu->addAction(aClone);
                 cardMenu->addMenu(moveMenu);
 
+                addRelatedCardView(card, cardMenu);
                 addRelatedCardActions(card, cardMenu);
             } else if (card->getZone()->getName() == "rfg" || card->getZone()->getName() == "grave") {
+                // Card is in the graveyard or exile
                 cardMenu->addAction(aPlay);
                 cardMenu->addAction(aPlayFacedown);
                 cardMenu->addSeparator();
                 cardMenu->addAction(aClone);
                 cardMenu->addMenu(moveMenu);
             } else {
+                // Card is in hand
                 cardMenu->addAction(aPlay);
                 cardMenu->addAction(aPlayFacedown);
                 cardMenu->addMenu(moveMenu);
+                addRelatedCardView(card, cardMenu);
             }
         } else {
             cardMenu->addMenu(moveMenu);
@@ -2681,12 +2689,12 @@ void Player::updateCardMenu(const CardItem *card)
         if (card->getZone() && card->getZone()->getName() != "hand") {
             cardMenu->addAction(aDrawArrow);
             cardMenu->addSeparator();
+            addRelatedCardView(card, cardMenu);
             addRelatedCardActions(card, cardMenu);
             cardMenu->addSeparator();
             cardMenu->addAction(aClone);
         }
     }
-    addRelatedCardView(card, cardMenu);
 }
 
 void Player::addRelatedCardView(const CardItem *card, QMenu *cardMenu)
@@ -2701,7 +2709,7 @@ void Player::addRelatedCardView(const CardItem *card, QMenu *cardMenu)
     }
 
     cardMenu->addSeparator();
-    auto viewRelatedCards = new QMenu(tr("View related card info:"));
+    auto viewRelatedCards = new QMenu(tr("View related cards"));
     cardMenu->addMenu(viewRelatedCards);
     auto *signalMapper = new QSignalMapper(this);
     for (const CardRelation *relatedCard : relatedCards) {

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2597,6 +2597,7 @@ void Player::updateCardMenu(const CardItem *card)
 
     if (revealedCard) {
         cardMenu->addAction(aHide);
+        addRelatedCardView(card, cardMenu);
     } else if (writeableCard) {
         if (moveMenu->isEmpty()) {
             moveMenu->addAction(aMoveToTopLibrary);

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2702,7 +2702,7 @@ void Player::addRelatedCardView(const CardItem *card, QMenu *cardMenu)
     cardMenu->addSeparator();
     auto *signalMapper = new QSignalMapper(this);
     for (const CardRelation *relatedCard : relatedCards) {
-        QAction *viewCard = cardMenu->addAction("Show card: \"" + relatedCard->getName() + "\"");
+        QAction *viewCard = cardMenu->addAction("Show Card: \"" + relatedCard->getName() + "\"");
         connect(viewCard, SIGNAL(triggered()), signalMapper, SLOT(map()));
         signalMapper->setMapping(viewCard, relatedCard->getName());
     }

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2701,9 +2701,11 @@ void Player::addRelatedCardView(const CardItem *card, QMenu *cardMenu)
     }
 
     cardMenu->addSeparator();
+    auto viewRelatedCards = new QMenu(tr("View related card info:"));
+    cardMenu->addMenu(viewRelatedCards);
     auto *signalMapper = new QSignalMapper(this);
     for (const CardRelation *relatedCard : relatedCards) {
-        QAction *viewCard = cardMenu->addAction("Show Card: \"" + relatedCard->getName() + "\"");
+        QAction *viewCard = viewRelatedCards->addAction(relatedCard->getName());
         connect(viewCard, SIGNAL(triggered()), signalMapper, SLOT(map()));
         signalMapper->setMapping(viewCard, relatedCard->getName());
     }

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2691,8 +2691,9 @@ void Player::updateCardMenu(const CardItem *card)
 
 void Player::addRelatedCardView(const CardItem *card, QMenu *cardMenu)
 {
-    if (card == nullptr || cardMenu == nullptr || card->getInfo() == nullptr)
+    if (card == nullptr || cardMenu == nullptr || card->getInfo() == nullptr) {
         return;
+    }
 
     QList<CardRelation *> relatedCards = card->getInfo()->getRelatedCards();
     if (relatedCards.isEmpty()) {

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -244,6 +244,7 @@ private:
                            const QString &avalue,
                            bool allCards);
     void addRelatedCardActions(const CardItem *card, QMenu *cardMenu);
+    void addRelatedCardView(const CardItem *card, QMenu *cardMenu);
     void createCard(const CardItem *sourceCard, const QString &dbCardName, bool attach = false);
     void createAttachedCard(const CardItem *sourceCard, const QString &dbCardName);
     bool createRelatedFromRelation(const CardItem *sourceCard, const CardRelation *cardRelation);

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -1604,6 +1604,11 @@ void TabGame::createDeckViewContainerWidget(bool bReplay)
     deckViewContainerWidget->setLayout(deckViewContainerLayout);
 }
 
+void TabGame::viewCardInfo(const QString &cardName)
+{
+    cardInfo->setCard(cardName);
+}
+
 void TabGame::createCardInfoDock(bool bReplay)
 {
     Q_UNUSED(bReplay);

--- a/cockatrice/src/tab_game.h
+++ b/cockatrice/src/tab_game.h
@@ -306,6 +306,7 @@ public:
 public slots:
     void sendGameCommand(PendingCommand *pend, int playerId = -1);
     void sendGameCommand(const ::google::protobuf::Message &command, int playerId = -1);
+    void viewCardInfo(const QString &cardName);
 };
 
 #endif


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1993 

## Short roundup of the initial problem
There was no way to know the details of a card's reverse side without actually creating that card in-game.

## What will change with this Pull Request?
- "Show Card" option added to in-game right click menus in all zones and pop-up card lists (e.g. on top cards of library view)
- Each related card is a menu new menu item, when clicked it updates the card info widget with its details
- Context menu on cards without related cards haven't changed

## Screenshots
<img width="510" alt="screenshot 2018-02-17 02 43 38" src="https://user-images.githubusercontent.com/7460172/36339130-70585b52-138c-11e8-9bbd-014740f73ccb.png">
<img width="612" alt="screenshot 2018-02-17 02 43 24" src="https://user-images.githubusercontent.com/7460172/36339131-709cd700-138c-11e8-8969-8c65d1e04a62.png">
<img width="607" alt="screenshot 2018-02-17 02 43 17" src="https://user-images.githubusercontent.com/7460172/36339132-70eaff52-138c-11e8-8a77-4cb8bafd7178.png">
<img width="401" alt="screenshot 2018-02-17 02 43 09" src="https://user-images.githubusercontent.com/7460172/36339133-711f9cc6-138c-11e8-8a33-b0ba3bffea9f.png">
