### PR TITLE
left, right, and S shortcuts modified to use shift

### DIFF
--- a/cockatrice/src/keysignals.cpp
+++ b/cockatrice/src/keysignals.cpp
@@ -21,11 +21,13 @@ bool KeySignals::eventFilter(QObject * /*object*/, QEvent *event)
 
             break;
         case Qt::Key_Right:
-            emit onRight();
+            if (kevent->modifiers() & Qt::ShiftModifier)
+                emit onShiftRight();
 
             break;
         case Qt::Key_Left:
-            emit onLeft();
+            if (kevent->modifiers() & Qt::ShiftModifier)
+                emit onShiftLeft();
 
             break;
         case Qt::Key_Delete:
@@ -54,7 +56,8 @@ bool KeySignals::eventFilter(QObject * /*object*/, QEvent *event)
 
             break;
         case Qt::Key_S:
-            emit onS();
+            if (kevent->modifiers() & Qt::ShiftModifier)
+                emit onShiftS();
 
             break;
         default:

--- a/cockatrice/src/keysignals.h
+++ b/cockatrice/src/keysignals.h
@@ -12,14 +12,14 @@ signals:
     void onEnter();
     void onCtrlEnter();
     void onCtrlAltEnter();
-    void onLeft();
-    void onRight();
+    void onShiftLeft();
+    void onShiftRight();
     void onDelete();
     void onCtrlAltMinus();
     void onCtrlAltEqual();
     void onCtrlAltLBracket();
     void onCtrlAltRBracket();
-    void onS();
+    void onShiftS();
 
 protected:
     virtual bool eventFilter(QObject *, QEvent *event);

--- a/cockatrice/src/shortcutssettings.cpp
+++ b/cockatrice/src/shortcutssettings.cpp
@@ -147,7 +147,9 @@ bool ShortcutsSettings::isKeyAllowed(QString name, QString Sequences)
                                                << "Ctrl+Alt+]"
                                                << "Tab"
                                                << "Space"
-                                               << "S");
+                                               << "Shift+S"
+                                               << "Shift+Left"
+                                               << "Shift+Right");
     if (forbiddenKeys.contains(checkSequence)) {
         return false;
     }

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -67,12 +67,12 @@ void TabDeckEditor::createDeckDock()
     connect(deckView->selectionModel(), SIGNAL(currentRowChanged(const QModelIndex &, const QModelIndex &)), this,
             SLOT(updateCardInfoRight(const QModelIndex &, const QModelIndex &)));
     connect(deckView, SIGNAL(doubleClicked(const QModelIndex &)), this, SLOT(actSwapCard()));
-    connect(&deckViewKeySignals, SIGNAL(onS()), this, SLOT(actSwapCard()));
+    connect(&deckViewKeySignals, SIGNAL(onShiftS()), this, SLOT(actSwapCard()));
     connect(&deckViewKeySignals, SIGNAL(onEnter()), this, SLOT(actIncrement()));
     connect(&deckViewKeySignals, SIGNAL(onCtrlAltEqual()), this, SLOT(actIncrement()));
     connect(&deckViewKeySignals, SIGNAL(onCtrlAltMinus()), this, SLOT(actDecrement()));
-    connect(&deckViewKeySignals, SIGNAL(onRight()), this, SLOT(actIncrement()));
-    connect(&deckViewKeySignals, SIGNAL(onLeft()), this, SLOT(actDecrement()));
+    connect(&deckViewKeySignals, SIGNAL(onShiftRight()), this, SLOT(actIncrement()));
+    connect(&deckViewKeySignals, SIGNAL(onShiftLeft()), this, SLOT(actDecrement()));
     connect(&deckViewKeySignals, SIGNAL(onDelete()), this, SLOT(actRemoveCard()));
 
     nameLabel = new QLabel();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2937 

## Short roundup of the initial problem
'S', 'Left', and 'Right' keys were set as shortcuts in the decbuilder which conflicted with these keys' tree navigation purpose.

## What will change with this Pull Request?
Modified to shortcuts to use respectively: 'Shift+S', 'Shift+Left', and 'Shift+Right' key combinations.
