### PR TITLE
Custom image file path corrected

### DIFF
--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -11,7 +11,7 @@
 QString SettingsCache::getDataPath()
 {
     if (isPortableBuild)
-        return qApp->applicationDirPath() + "/data/";
+        return qApp->applicationDirPath() + "/data";
     else
         return QStandardPaths::writableLocation(QStandardPaths::DataLocation);
 }
@@ -183,7 +183,11 @@ SettingsCache::SettingsCache()
     replaysPath = getSafeConfigPath("paths/replays", dataPath + "/replays/");
     picsPath = getSafeConfigPath("paths/pics", dataPath + "/pics/");
     // this has never been exposed as an user-configurable setting
-    customPicsPath = getSafeConfigPath("paths/custompics", picsPath + "/CUSTOM/");
+    if (picsPath.endsWith("/")) {
+        customPicsPath = getSafeConfigPath("paths/custompics", picsPath + "CUSTOM/");
+    } else {
+        customPicsPath = getSafeConfigPath("paths/custompics", picsPath + "/CUSTOM/");
+    }
     // this has never been exposed as an user-configurable setting
     customCardDatabasePath = getSafeConfigPath("paths/customsets", dataPath + "/customsets/");
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2069 

## Short roundup of the initial problem
When you clicked on the "Open custom image folder" menu item the My Documents folder opened instead of the real custom image folder.

## Explanation of the change
- The problem was caused by having a double `/`character in the `customPicsPath` variable: the default `picsPath` endend with `/`, to which the `/CUSTOM/` string was concatenated. Unfortunately, when a custom path is set for the pics folder, the new path will not end with this trailing `/`, thus adding only `CUSTOM/` to it won't work properly. I solved this by checking whether the path ends with a slash or not and adding the appropriate string based on that. This way the fix won't cause a problem to either those who set up a custom path, nor to those who left it on default.
- On portable builds, `/data/` string was added to the data path, while on normal builds the `QStandardPaths::writableLocation` call returns a path without the trailing `/`. This caused an error message on portable versions (see Baccanno's screenshots in the related issue). This has also been solved.
- I tested it on Windows 10 OS, where the fix works for both the portable and the normal versions. Theoretically it shouldn't cause problems on Mac or Linux either, but it still needs to be checked.