### PR TITLE
Power/toughness indicator displayed after card flip

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2205,6 +2205,11 @@ void Player::cardMenuAction()
                     cmd->set_zone(card->getZone()->getName().toStdString());
                     cmd->set_card_id(card->getId());
                     cmd->set_face_down(!card->getFaceDown());
+                    if (card->getFaceDown()) {
+                        CardInfoPtr ci = card->getInfo();
+                        if (ci)
+                            cmd->set_pt(ci->getPowTough().toStdString());
+                    }
                     commandList.append(cmd);
                     break;
                 }

--- a/common/pb/command_flip_card.proto
+++ b/common/pb/command_flip_card.proto
@@ -7,6 +7,7 @@ message Command_FlipCard {
     optional string zone = 1;
     optional sint32 card_id = 2 [default = -1];
     optional bool face_down = 3;
+    optional string pt = 4;
 }
 
 

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -1013,6 +1013,10 @@ Server_Player::cmdFlipCard(const Command_FlipCard &cmd, ResponseContainer & /*rc
     event.set_face_down(faceDown);
     ges.enqueueGameEvent(event, playerId);
 
+    QString ptString = QString::fromStdString(cmd.pt());
+    if (!ptString.isEmpty() && !faceDown)
+        setCardAttrHelper(ges, playerId, zone->getName(), card->getId(), AttrPT, ptString);
+
     return Response::RespOk;
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2929 

## Short roundup of the initial problem
When a face down card was flipped on the table the p/t indicator didn't appear.

## What will change with this Pull Request?
When a flip card command is received by the server, a set attribute event will also be generated to make the indicator appear.
