### PR TITLE
Colors on split cards sorted in WUBRG order

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -299,6 +299,10 @@ int OracleImporter::importTextSpoiler(CardSetPtr set, const QVariant &data)
         }
 
         colors.removeDuplicates();
+        if (colors.length() > 1) {
+            sortColors(colors);
+        }
+
         // Fortunately, there are no split cards that flip, transform or meld.
         relatedCards = QList<CardRelation *>();
         reverseRelatedCards = QList<CardRelation *>();
@@ -316,6 +320,26 @@ int OracleImporter::importTextSpoiler(CardSetPtr set, const QVariant &data)
     }
 
     return cards;
+}
+
+void OracleImporter::sortColors(QStringList &colors)
+{
+    QMap<QString, unsigned int> colorOrder;
+    colorOrder["W"] = 0;
+    colorOrder["U"] = 1;
+    colorOrder["B"] = 2;
+    colorOrder["R"] = 3;
+    colorOrder["G"] = 4;
+    bool correctOrder = false;
+    while (!correctOrder) {
+        correctOrder = true;
+        for (unsigned int i = 0; i < colors.length() - 1; i++) {
+            if (colorOrder[colors[i]] > colorOrder[colors[i + 1]]) {
+                colors.swap(i, i + 1);
+                correctOrder = false;
+            }
+        }
+    }
 }
 
 int OracleImporter::startImport()

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -93,6 +93,7 @@ public:
 
 protected:
     void extractColors(const QStringList &in, QStringList &out);
+    void sortColors(QStringList &colors);
 };
 
 #endif


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3127

## What will change with this Pull Request?
- Oracle will sort the colors of split cards and store them in WUBRG order
- Only the Color(s) field is affected

## Screenshot
![image](https://user-images.githubusercontent.com/9273978/36994300-f6299a6c-20b0-11e8-9292-04607d285169.png)
