### PR TITLE
Tip of the Day extra features

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -93,15 +93,15 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(&pixmapCacheLabel, 2, 0);
     personalGrid->addWidget(&pixmapCacheEdit, 2, 1);
     personalGrid->addWidget(&updateNotificationCheckBox, 3, 0);
-    personalGrid->addWidget(&picDownloadCheckBox, 4, 0, 1, 3);
-    personalGrid->addWidget(&defaultUrlLabel, 5, 0, 1, 1);
-    personalGrid->addWidget(defaultUrlEdit, 5, 1, 1, 1);
-    personalGrid->addWidget(&defaultUrlRestoreButton, 5, 2, 1, 1);
-    personalGrid->addWidget(&fallbackUrlLabel, 6, 0, 1, 1);
-    personalGrid->addWidget(fallbackUrlEdit, 6, 1, 1, 1);
-    personalGrid->addWidget(&fallbackUrlRestoreButton, 6, 2, 1, 1);
-    personalGrid->addWidget(&showTipsOnStartup, 7, 0);
-    personalGrid->addWidget(&urlLinkLabel, 7, 1, 1, 1);
+    personalGrid->addWidget(&showTipsOnStartup, 4, 0);
+    personalGrid->addWidget(&picDownloadCheckBox, 5, 0);
+    personalGrid->addWidget(&urlLinkLabel, 5, 1);
+    personalGrid->addWidget(&defaultUrlLabel, 6, 0, 1, 1);
+    personalGrid->addWidget(defaultUrlEdit, 6, 1, 1, 1);
+    personalGrid->addWidget(&defaultUrlRestoreButton, 6, 2, 1, 1);
+    personalGrid->addWidget(&fallbackUrlLabel, 7, 0, 1, 1);
+    personalGrid->addWidget(fallbackUrlEdit, 7, 1, 1, 1);
+    personalGrid->addWidget(&fallbackUrlRestoreButton, 7, 2, 1, 1);
     personalGrid->addWidget(&clearDownloadedPicsButton, 8, 0, 1, 3);
 
     urlLinkLabel.setTextInteractionFlags(Qt::LinksAccessibleByMouse);

--- a/cockatrice/src/dlg_tip_of_the_day.cpp
+++ b/cockatrice/src/dlg_tip_of_the_day.cpp
@@ -21,7 +21,7 @@ DlgTipOfTheDay::DlgTipOfTheDay(QWidget *parent) : QDialog(parent)
     QString xmlPath = "theme:tips/tips_of_the_day.xml";
     tipDatabase = new TipsOfTheDay(xmlPath, this);
 
-    if (tipDatabase->rowCount() == 0) {
+    if (tipDatabase->rowCount() == 0 || tipDatabase->rowCount() == settingsCache->getLastShownTip() + 1) {
         return;
     }
 

--- a/cockatrice/src/dlg_tip_of_the_day.cpp
+++ b/cockatrice/src/dlg_tip_of_the_day.cpp
@@ -41,7 +41,19 @@ DlgTipOfTheDay::DlgTipOfTheDay(QWidget *parent) : QDialog(parent)
     tipNumber = new QLabel();
     tipNumber->setAlignment(Qt::AlignCenter);
 
-    currentTip = settingsCache->getLastShownTip() + 1;
+    if (settingsCache->getSeenTips().size() != tipDatabase->rowCount()) {
+        newTipsAvailable = true;
+        QList<int> rangeToMaxTips;
+        for (int i = 0; i < tipDatabase->rowCount(); i++) {
+            rangeToMaxTips.append(i);
+        }
+        QSet<int> unseenTips = rangeToMaxTips.toSet() - settingsCache->getSeenTips().toSet();
+        currentTip = *std::min_element(unseenTips.begin(), unseenTips.end());
+    } else {
+        newTipsAvailable = false;
+        currentTip = settingsCache->getLastShownTip() + 1;
+    }
+
     connect(this, SIGNAL(newTipRequested(int)), this, SLOT(updateTip(int)));
     newTipRequested(currentTip);
 
@@ -96,11 +108,6 @@ DlgTipOfTheDay::~DlgTipOfTheDay()
     previousButton->deleteLater();
     buttonBar->deleteLater();
     delete image;
-}
-
-unsigned int DlgTipOfTheDay::getNumberOfTips()
-{
-    return tipDatabase->rowCount();
 }
 
 void DlgTipOfTheDay::nextClicked()

--- a/cockatrice/src/dlg_tip_of_the_day.cpp
+++ b/cockatrice/src/dlg_tip_of_the_day.cpp
@@ -21,7 +21,7 @@ DlgTipOfTheDay::DlgTipOfTheDay(QWidget *parent) : QDialog(parent)
     QString xmlPath = "theme:tips/tips_of_the_day.xml";
     tipDatabase = new TipsOfTheDay(xmlPath, this);
 
-    if (tipDatabase->rowCount() == 0 || tipDatabase->rowCount() == settingsCache->getLastShownTip() + 1) {
+    if (tipDatabase->rowCount() == 0) {
         return;
     }
 
@@ -98,6 +98,11 @@ DlgTipOfTheDay::~DlgTipOfTheDay()
     delete image;
 }
 
+unsigned int DlgTipOfTheDay::getNumberOfTips()
+{
+    return tipDatabase->rowCount();
+}
+
 void DlgTipOfTheDay::nextClicked()
 {
     emit newTipRequested(currentTip + 1);
@@ -116,6 +121,13 @@ void DlgTipOfTheDay::updateTip(int tipId)
         tipId = tipDatabase->rowCount() - 1;
     } else if (tipId >= tipDatabase->rowCount()) {
         tipId = tipId % tipDatabase->rowCount();
+    }
+
+    // Store tip id as seen
+    QList<int> seenTips = settingsCache->getSeenTips();
+    if (!seenTips.contains(tipId)) {
+        seenTips.append(tipId);
+        settingsCache->setSeenTips(seenTips);
     }
 
     TipOfTheDay tip = tipDatabase->getTip(tipId);

--- a/cockatrice/src/dlg_tip_of_the_day.h
+++ b/cockatrice/src/dlg_tip_of_the_day.h
@@ -21,6 +21,7 @@ public:
     explicit DlgTipOfTheDay(QWidget *parent = nullptr);
     ~DlgTipOfTheDay() override;
     bool successfulInit;
+    unsigned int getNumberOfTips();
 signals:
     void newTipRequested(int tipId);
 

--- a/cockatrice/src/dlg_tip_of_the_day.h
+++ b/cockatrice/src/dlg_tip_of_the_day.h
@@ -21,7 +21,7 @@ public:
     explicit DlgTipOfTheDay(QWidget *parent = nullptr);
     ~DlgTipOfTheDay() override;
     bool successfulInit;
-    unsigned int getNumberOfTips();
+    bool newTipsAvailable;
 signals:
     void newTipRequested(int tipId);
 

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -139,7 +139,7 @@ int main(int argc, char *argv[])
     qDebug("main(): ui.show() finished");
 
     DlgTipOfTheDay tip;
-    if (tip.successfulInit && settingsCache->getShowTipsOnStartup() && settingsCache->getSeenTips().size() != tip.getNumberOfTips()) {
+    if (tip.successfulInit && settingsCache->getShowTipsOnStartup() && tip.newTipsAvailable) {
         tip.show();
     }
 

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -139,7 +139,7 @@ int main(int argc, char *argv[])
     qDebug("main(): ui.show() finished");
 
     DlgTipOfTheDay tip;
-    if (settingsCache->getShowTipsOnStartup() && tip.successfulInit) {
+    if (tip.successfulInit && settingsCache->getShowTipsOnStartup() && settingsCache->getSeenTips().size() != tip.getNumberOfTips()) {
         tip.show();
     }
 

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -7,6 +7,7 @@
 #include <QFile>
 #include <QSettings>
 #include <QStandardPaths>
+#include <QMetaType>
 
 QString SettingsCache::getDataPath()
 {
@@ -143,6 +144,12 @@ QString SettingsCache::getSafeConfigFilePath(QString configEntry, QString defaul
         tmp = defaultPath;
     return tmp;
 }
+
+
+
+Q_DECLARE_METATYPE(QList<int>)
+
+
 SettingsCache::SettingsCache()
 {
     // first, figure out if we are running in portable mode
@@ -166,6 +173,9 @@ SettingsCache::SettingsCache()
     if (!QFile(settingsPath + "global.ini").exists())
         translateLegacySettings();
 
+    QDataStream & operator >> (QDataStream &in, QList<int> &value);
+    qRegisterMetaType<QList<int>>("QList<int>");
+    qRegisterMetaTypeStreamOperators<QList<int>>("QList<int>");
     // updates - don't reorder them or their index in the settings won't match
     // append channels one by one, or msvc will add them in the wrong order.
     releaseChannels << new StableReleaseChannel();
@@ -182,6 +192,8 @@ SettingsCache::SettingsCache()
     // tip of the day settings
     showTipsOnStartup = settings->value("tipOfDay/showTips", true).toBool();
     lastShownTip = settings->value("tipOfDay/lastShown", -1).toInt();
+    seenTips = settings->value("tipOfDay/seenTips").value<QList<int>>();
+
 
     deckPath = getSafeConfigPath("paths/decks", dataPath + "/decks/");
     replaysPath = getSafeConfigPath("paths/replays", dataPath + "/replays/");
@@ -349,6 +361,12 @@ void SettingsCache::setLastShownTip(int _lastShownTip)
 {
     lastShownTip = _lastShownTip;
     settings->setValue("tipOfDay/lastShown", lastShownTip);
+}
+
+void SettingsCache::setSeenTips(const QList<int> &_seenTips)
+{
+    seenTips = _seenTips;
+    settings->setValue("tipOfDay/seenTips", QVariant::fromValue(seenTips));
 }
 
 void SettingsCache::setDeckPath(const QString &_deckPath)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -69,6 +69,7 @@ private:
     bool notifyAboutUpdates;
     bool showTipsOnStartup;
     unsigned int lastShownTip;
+    QList<int> seenTips;
     bool mbDownloadSpoilers;
     int updateReleaseChannel;
     int maxFontSize;
@@ -208,6 +209,10 @@ public:
     unsigned int getLastShownTip() const
     {
         return lastShownTip;
+    }
+    QList<int> getSeenTips() const
+    {
+        return seenTips;
     }
     ReleaseChannel *getUpdateReleaseChannel() const
     {
@@ -445,6 +450,7 @@ public slots:
     void setLang(const QString &_lang);
     void setShowTipsOnStartup(bool _showTipsOnStartup);
     void setLastShownTip(int _lastShowTip);
+    void setSeenTips(const QList<int> &_seenTips);
     void setDeckPath(const QString &_deckPath);
     void setReplaysPath(const QString &_replaysPath);
     void setPicsPath(const QString &_picsPath);

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -316,7 +316,9 @@ void MainWindow::actAbout()
 void MainWindow::actTips()
 {
     DlgTipOfTheDay tip;
-    tip.exec();
+    if (tip.successfulInit) {
+        tip.exec();
+    }
 }
 
 void MainWindow::actUpdate()

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -41,6 +41,7 @@
 #include "dlg_forgotpasswordreset.h"
 #include "dlg_register.h"
 #include "dlg_settings.h"
+#include "dlg_tip_of_the_day.h"
 #include "dlg_update.h"
 #include "dlg_viewlog.h"
 #include "localclient.h"
@@ -310,6 +311,12 @@ void MainWindow::actAbout()
     mb.setIconPixmap(QPixmap("theme:cockatrice").scaled(64, 64));
     mb.setTextInteractionFlags(Qt::TextBrowserInteraction);
     mb.exec();
+}
+
+void MainWindow::actTips()
+{
+    DlgTipOfTheDay tip;
+    tip.exec();
 }
 
 void MainWindow::actUpdate()
@@ -627,6 +634,7 @@ void MainWindow::retranslateUi()
     aEditTokens->setText(tr("Edit &tokens..."));
 
     aAbout->setText(tr("&About Cockatrice"));
+    aTips->setText(tr("&Tip of the Day"));
     aUpdate->setText(tr("Check for Client Updates"));
     aViewLog->setText(tr("View &debug log"));
     helpMenu->setTitle(tr("&Help"));
@@ -659,6 +667,8 @@ void MainWindow::createActions()
 
     aAbout = new QAction(this);
     connect(aAbout, SIGNAL(triggered()), this, SLOT(actAbout()));
+    aTips = new QAction(this);
+    connect(aTips, SIGNAL(triggered()), this, SLOT(actTips()));
     aUpdate = new QAction(this);
     connect(aUpdate, SIGNAL(triggered()), this, SLOT(actUpdate()));
     aViewLog = new QAction(this);
@@ -729,6 +739,7 @@ void MainWindow::createMenus()
 
     helpMenu = menuBar()->addMenu(QString());
     helpMenu->addAction(aAbout);
+    helpMenu->addAction(aTips);
     helpMenu->addAction(aUpdate);
     helpMenu->addAction(aViewLog);
 }

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -72,6 +72,7 @@ private slots:
     void actExit();
     void actForgotPasswordRequest();
     void actAbout();
+    void actTips();
     void actUpdate();
     void actViewLog();
     void forgotPasswordSuccess();
@@ -115,7 +116,7 @@ private:
     QList<QMenu *> tabMenus;
     QMenu *cockatriceMenu, *dbMenu, *helpMenu;
     QAction *aConnect, *aDisconnect, *aSinglePlayer, *aWatchReplay, *aDeckEditor, *aFullScreen, *aSettings, *aExit,
-        *aAbout, *aCheckCardUpdates, *aRegister, *aUpdate, *aViewLog;
+        *aAbout, *aTips, *aCheckCardUpdates, *aRegister, *aUpdate, *aViewLog;
     QAction *aManageSets, *aEditTokens, *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet;
     TabSupervisor *tabSupervisor;
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3139 

## What will change with this Pull Request?
- Added link to open tip of the day from the help menu
- Option to enable/disable tips moved
- Once all the tips have been seen, the window is not shown again at startup. If new tips are added (and it haven't been disabled by the user) it is shown again, starting with the oldest unseen tip.

## Screenshots
Help menu:
![image](https://user-images.githubusercontent.com/9273978/37744964-74808cf4-2d72-11e8-872c-4b4c3789438e.png)
Settings window:
![image](https://user-images.githubusercontent.com/9273978/37744992-a3f32ee2-2d72-11e8-83c7-e329c7c7db61.png)
