### PR TITLE
Untranslated string comparison fixed

### DIFF
--- a/cockatrice/src/decklistmodel.cpp
+++ b/cockatrice/src/decklistmodel.cpp
@@ -106,7 +106,10 @@ QVariant DeckListModel::data(const QModelIndex &index, int role) const
                     case 0:
                         return node->recursiveCount(true);
                     case 1:
-                        return node->getVisibleName();
+                        if (role == Qt::DisplayRole)
+                            return node->getVisibleName();
+                        else
+                            return node->getName();
                     default:
                         return QVariant();
                 }

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -962,9 +962,9 @@ void TabDeckEditor::actSwapCard()
     if (!gparent.isValid())
         return;
 
-    const QString zoneName = gparent.sibling(gparent.row(), 1).data().toString();
+    const QString zoneName = gparent.sibling(gparent.row(), 1).data(Qt::EditRole).toString();
     actDecrement();
-    const QString otherZoneName = zoneName == "Maindeck" ? DECK_ZONE_SIDE : DECK_ZONE_MAIN;
+    const QString otherZoneName = zoneName == DECK_ZONE_MAIN ? DECK_ZONE_SIDE : DECK_ZONE_MAIN;
 
     // Third argument (true) says create the card no mater what, even if not in DB
     QModelIndex newCardIndex = deckModel->addCard(cardName, otherZoneName, true);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2139 

## Short roundup of the initial problem
Translated zone name was compared to untranslated "Maindeck" string, which caused errors with card swapping between main- and sidedecks on non-English version of the program.

## What will change with this Pull Request?
`data()` calls with `EditRole` of the deckListModel returns now the universally defined `DECK_ZONE_MAIN` and `DECK_ZONE_SIDE` strings instead of language-dependent ones.