### PR TITLE
Server List from JSON

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -119,6 +119,7 @@ SET(cockatrice_SOURCES
     src/releasechannel.cpp
     src/userconnection_information.cpp
     src/spoilerbackgroundupdater.cpp
+    src/handle_public_servers.cpp
     ${VERSION_STRING_CPP}
 )
 

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -3,6 +3,7 @@
 #include "userconnection_information.h"
 #include <QCheckBox>
 #include <QComboBox>
+#include <QDebug>
 #include <QDialogButtonBox>
 #include <QEvent>
 #include <QGridLayout>

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -263,7 +263,6 @@ void DlgConnect::preRebuildComboBoxList()
 
 void DlgConnect::rebuildComboBoxList()
 {
-    int prevHostSize = previousHosts->count();
     previousHosts->clear();
 
     UserConnection_Information uci;

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -21,6 +21,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     previousHosts = new QComboBox(this);
     previousHosts->installEventFilter(new DeleteHighlightedItemWhenShiftDelPressedEventFilter);
 
+    // TODO: Remove the button at the 2.7.0 release
     hps = new HandlePublicServers(this);
     btnRefreshServers = new QPushButton(tr("Refresh Servers"), this);
     connect(hps, SIGNAL(sigPublicServersDownloadedSuccessfully()), this, SLOT(rebuildComboBoxList()));

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -26,7 +26,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     hps = new HandlePublicServers(this);
     btnRefreshServers = new QPushButton(tr("Refresh Servers"), this);
     connect(hps, SIGNAL(sigPublicServersDownloadedSuccessfully()), this, SLOT(rebuildComboBoxList()));
-    connect(hps, SIGNAL(sigPublicServersDownloadedUnsuccessfully()), this, SLOT(rebuildComboBoxList()));
+    connect(hps, SIGNAL(sigPublicServersDownloadedUnsuccessfully(int)), this, SLOT(rebuildComboBoxList(int)));
     connect(btnRefreshServers, SIGNAL(released()), this, SLOT(downloadThePublicServers()));
 
     connect(this, SIGNAL(sigPublicServersDownloaded()), this, SLOT(rebuildComboBoxList()));
@@ -211,7 +211,7 @@ void DlgConnect::downloadThePublicServers()
 {
     previousHosts->clear();
     previousHosts->addItem(placeHolderText);
-    hps->downloadPublicServers(); // Refresh the servers
+    hps->downloadPublicServers();
 }
 
 void DlgConnect::preRebuildComboBoxList()
@@ -226,15 +226,18 @@ void DlgConnect::preRebuildComboBoxList()
     }
 }
 
-void DlgConnect::rebuildComboBoxList()
+void DlgConnect::rebuildComboBoxList(int failure)
 {
+    Q_UNUSED(failure);
+
     previousHosts->clear();
 
     UserConnection_Information uci;
     savedHostList = uci.getServerInfo();
 
     int i = 0;
-    for (UserConnection_Information tmp : savedHostList) {
+    for (auto pair : savedHostList) {
+        auto tmp = pair.second;
         QString saveName = tmp.getSaveName();
         if (saveName.size()) {
             previousHosts->addItem(saveName);

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -222,19 +222,16 @@ void DlgConnect::actFinishParsingDownloadedData()
             }
 
             serversOnWiki.append(serverName);
-            if (! savedHostList.contains(serverName))
-            {
+            if (!savedHostList.contains(serverName)) {
                 // Adds new servers to list (if exists, skip it)
                 settingsCache->servers().addNewServer(serverName, serverAddress, serverPort, "", "", false);
             }
         }
 
         // Now that we added the new servers, we can remove all servers that were not on the public page
-        for (auto server : savedHostList)
-        {
+        for (auto server : savedHostList) {
             QString serverName = server.getSaveName();
-            if (serversOnWiki.indexOf(serverName) < 0)
-            {
+            if (serversOnWiki.indexOf(serverName) < 0) {
                 settingsCache->servers().removeServer(serverName);
             }
         }

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -1,5 +1,4 @@
 #include "dlg_connect.h"
-#include "qt-json/json.h"
 #include "settingscache.h"
 #include "userconnection_information.h"
 #include <QCheckBox>
@@ -11,7 +10,6 @@
 #include <QKeyEvent>
 #include <QLabel>
 #include <QMessageBox>
-#include <QNetworkReply>
 #include <QPushButton>
 #include <QRadioButton>
 
@@ -157,40 +155,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     playernameEdit->setFocus();
 }
 
-DlgConnect::~DlgConnect()
-{
-    hostLabel->deleteLater();
-    portLabel->deleteLater();
-    playernameLabel->deleteLater();
-    passwordLabel->deleteLater();
-    saveLabel->deleteLater();
-    publicServersLabel->deleteLater();
-    hostEdit->deleteLater();
-    portEdit->deleteLater();
-    playernameEdit->deleteLater();
-    passwordEdit->deleteLater();
-    saveEdit->deleteLater();
-    savePasswordCheckBox->deleteLater();
-    autoConnectCheckBox->deleteLater();
-    previousHosts->deleteLater();
-    newHostButton->deleteLater();
-    previousHostButton->deleteLater();
-    btnOk->deleteLater();
-    btnCancel->deleteLater();
-    btnForgotPassword->deleteLater();
-    btnRefreshServers->deleteLater();
-    newHostLayout->deleteLater();
-    connectionLayout->deleteLater();
-    buttons->deleteLater();
-    loginLayout->deleteLater();
-    grid->deleteLater();
-    newHolderLayout->deleteLater();
-    loginGroupBox->deleteLater();
-    btnGroupBox->deleteLater();
-    mainLayout->deleteLater();
-    restrictionsGroupBox->deleteLater();
-    hps->deleteLater();
-}
+DlgConnect::~DlgConnect() = default;
 
 void DlgConnect::actSaveConfig()
 {
@@ -209,6 +174,7 @@ void DlgConnect::actSaveConfig()
 
 void DlgConnect::downloadThePublicServers()
 {
+    btnRefreshServers->setDisabled(true);
     previousHosts->clear();
     previousHosts->addItem(placeHolderText);
     hps->downloadPublicServers();
@@ -249,6 +215,8 @@ void DlgConnect::rebuildComboBoxList(int failure)
             i++;
         }
     }
+
+    btnRefreshServers->setDisabled(false);
 }
 
 void DlgConnect::previousHostSelected(bool state)

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -16,8 +16,7 @@
 #include <QRadioButton>
 
 #define PUBLIC_SERVERS_URL "https://github.com/Cockatrice/Cockatrice/wiki/Public-Servers"
-#define PUBLIC_SERVERS_JSON                                                                                            \
-    "https://raw.githubusercontent.com/Cockatrice/cockatrice.github.io/master/public-servers.json"
+#define PUBLIC_SERVERS_JSON "https://cockatrice.github.io/public-servers.json"
 
 DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
 {

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -167,7 +167,6 @@ void DlgConnect::actSaveConfig()
 
 void DlgConnect::downloadPublicServers()
 {
-    qDebug() << "DOWNLOAD 123";
     QUrl url(QString(PUBLIC_SERVERS_URL));
     auto *nam = new QNetworkAccessManager(this);
     QNetworkReply *reply = nam->get(QNetworkRequest(url));
@@ -180,6 +179,9 @@ void DlgConnect::actFinishParsingDownloadedData()
     QNetworkReply::NetworkError errorCode = reply->error();
 
     if (errorCode == QNetworkReply::NoError) {
+        UserConnection_Information uci;
+        savedHostList = uci.getServerInfo();
+
         QStringList serversOnWiki;
 
         // This will get all the data from the GitHub page and just give us the table data
@@ -217,12 +219,14 @@ void DlgConnect::actFinishParsingDownloadedData()
             }
 
             serversOnWiki.append(serverName);
-            settingsCache->servers().addNewServer(serverName, serverAddress, serverPort, "", "", false);
+            if (! savedHostList.contains(serverName))
+            {
+                // Adds new servers to list (if exists, skip it)
+                settingsCache->servers().addNewServer(serverName, serverAddress, serverPort, "", "", false);
+            }
         }
 
-        UserConnection_Information uci;
-        savedHostList = uci.getServerInfo();
-
+        // Now that we added the new servers, we can remove all servers that were not on the public page
         for (auto server : savedHostList)
         {
             QString serverName = server.getSaveName();

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -92,9 +92,12 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     newHostLayout->addWidget(newHostButton, 0, 1);
     newHostLayout->addWidget(publicServersLabel, 0, 2);
 
+    auto *newHolderLayout = new QHBoxLayout;
+    newHolderLayout->addWidget(previousHostButton);
+    newHolderLayout->addWidget(btnRefreshServers);
+
     auto *connectionLayout = new QGridLayout;
-    connectionLayout->addWidget(previousHostButton, 0, 1);
-    connectionLayout->addWidget(btnRefreshServers, 0, 2);
+    connectionLayout->addLayout(newHolderLayout, 0, 1, 1, 2);
     connectionLayout->addWidget(previousHosts, 1, 1);
     connectionLayout->addLayout(newHostLayout, 2, 1, 1, 2);
     connectionLayout->addWidget(saveLabel, 3, 0);
@@ -286,6 +289,7 @@ void DlgConnect::previousHostSelected(bool state)
     if (state) {
         saveEdit->setDisabled(true);
         previousHosts->setDisabled(false);
+        btnRefreshServers->setDisabled(false);
     }
 }
 
@@ -315,6 +319,7 @@ void DlgConnect::newHostSelected(bool state)
 {
     if (state) {
         previousHosts->setDisabled(true);
+        btnRefreshServers->setDisabled(true);
         hostEdit->clear();
         portEdit->clear();
         playernameEdit->clear();

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -21,9 +21,12 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     previousHosts = new QComboBox(this);
     previousHosts->installEventFilter(new DeleteHighlightedItemWhenShiftDelPressedEventFilter);
 
-    // TODO: Remove the button at the 2.7.0 release
     hps = new HandlePublicServers(this);
-    btnRefreshServers = new QPushButton(tr("Refresh Servers"), this);
+    btnRefreshServers = new QPushButton(this);
+    btnRefreshServers->setIcon(QPixmap("theme:icons/update"));
+    btnRefreshServers->setToolTip(tr("Refresh the server list with known public servers"));
+    btnRefreshServers->setFixedWidth(50);
+
     connect(hps, SIGNAL(sigPublicServersDownloadedSuccessfully()), this, SLOT(rebuildComboBoxList()));
     connect(hps, SIGNAL(sigPublicServersDownloadedUnsuccessfully(int)), this, SLOT(rebuildComboBoxList(int)));
     connect(btnRefreshServers, SIGNAL(released()), this, SLOT(downloadThePublicServers()));
@@ -60,15 +63,6 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     autoConnectCheckBox = new QCheckBox(tr("A&uto connect"));
     autoConnectCheckBox->setToolTip(tr("Automatically connect to the most recent login when Cockatrice opens"));
 
-    publicServersLabel =
-        new QLabel(QString("(<a href=\"%1\">%2</a>)").arg(PUBLIC_SERVERS_URL).arg(tr("Public Servers")));
-    publicServersLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
-    publicServersLabel->setWordWrap(true);
-    publicServersLabel->setTextFormat(Qt::RichText);
-    publicServersLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
-    publicServersLabel->setOpenExternalLinks(true);
-    publicServersLabel->setAlignment(Qt::AlignCenter);
-
     if (savePasswordCheckBox->isChecked()) {
         autoConnectCheckBox->setChecked(static_cast<bool>(settingsCache->servers().getAutoConnect()));
         autoConnectCheckBox->setEnabled(true);
@@ -91,18 +85,14 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     btnCancel->setFixedWidth(100);
     connect(btnCancel, SIGNAL(released()), this, SLOT(actCancel()));
 
-    newHostLayout = new QGridLayout;
-    newHostLayout->addWidget(newHostButton, 0, 1);
-    newHostLayout->addWidget(publicServersLabel, 0, 2);
-
     newHolderLayout = new QHBoxLayout;
-    newHolderLayout->addWidget(previousHostButton);
+    newHolderLayout->addWidget(previousHosts);
     newHolderLayout->addWidget(btnRefreshServers);
 
     connectionLayout = new QGridLayout;
-    connectionLayout->addLayout(newHolderLayout, 0, 1, 1, 2);
-    connectionLayout->addWidget(previousHosts, 1, 1);
-    connectionLayout->addLayout(newHostLayout, 2, 1, 1, 2);
+    connectionLayout->addWidget(previousHostButton, 0, 1);
+    connectionLayout->addLayout(newHolderLayout, 1, 1, 1, 2);
+    connectionLayout->addWidget(newHostButton, 2, 1);
     connectionLayout->addWidget(saveLabel, 3, 0);
     connectionLayout->addWidget(saveEdit, 3, 1);
     connectionLayout->addWidget(hostLabel, 4, 0);

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -280,7 +280,7 @@ void DlgConnect::actOk()
 
         settingsCache->servers().addNewServer(saveEdit->text().trimmed(), hostEdit->text().trimmed(),
                                               portEdit->text().trimmed(), playernameEdit->text().trimmed(),
-                                              passwordEdit->text(), savePasswordCheckBox->isChecked(), true);
+                                              passwordEdit->text(), savePasswordCheckBox->isChecked());
     } else {
         settingsCache->servers().updateExistingServer(saveEdit->text().trimmed(), hostEdit->text().trimmed(),
                                                       portEdit->text().trimmed(), playernameEdit->text().trimmed(),

--- a/cockatrice/src/dlg_connect.h
+++ b/cockatrice/src/dlg_connect.h
@@ -4,6 +4,7 @@
 #include "userconnection_information.h"
 #include <QDialog>
 #include <QLineEdit>
+#include <QUrl>
 
 class QLabel;
 class QPushButton;
@@ -15,7 +16,7 @@ class DeleteHighlightedItemWhenShiftDelPressedEventFilter : public QObject
 {
     Q_OBJECT
 protected:
-    bool eventFilter(QObject *obj, QEvent *event);
+    bool eventFilter(QObject *obj, QEvent *event) override;
 };
 
 class DlgConnect : public QDialog
@@ -23,9 +24,10 @@ class DlgConnect : public QDialog
     Q_OBJECT
 signals:
     void sigStartForgotPasswordRequest();
+    void sigPublicServersDownloaded();
 
 public:
-    DlgConnect(QWidget *parent = 0);
+    explicit DlgConnect(QWidget *parent = nullptr);
     QString getHost() const;
     int getPort() const
     {
@@ -48,7 +50,9 @@ private slots:
     void newHostSelected(bool state);
     void actForgotPassword();
     void updateDisplayInfo(const QString &saveName);
+    void preRebuildComboBoxList();
     void rebuildComboBoxList();
+    void actFinishParsingDownloadedData();
 
 private:
     QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *saveLabel, *publicServersLabel;
@@ -58,5 +62,6 @@ private:
     QRadioButton *newHostButton, *previousHostButton;
     QPushButton *btnOk, *btnCancel, *btnForgotPassword;
     QMap<QString, UserConnection_Information> savedHostList;
+    void downloadPublicServers(QUrl url);
 };
 #endif

--- a/cockatrice/src/dlg_connect.h
+++ b/cockatrice/src/dlg_connect.h
@@ -40,6 +40,7 @@ public:
     {
         return passwordEdit->text();
     }
+
 private slots:
     void actOk();
     void actCancel();
@@ -62,5 +63,6 @@ private:
     QRadioButton *newHostButton, *previousHostButton;
     QPushButton *btnOk, *btnCancel, *btnForgotPassword, *btnRefreshServers;
     QMap<QString, UserConnection_Information> savedHostList;
+    const QString placeHolderText = tr("Downloading...");
 };
 #endif

--- a/cockatrice/src/dlg_connect.h
+++ b/cockatrice/src/dlg_connect.h
@@ -56,7 +56,7 @@ private slots:
     void actForgotPassword();
     void updateDisplayInfo(const QString &saveName);
     void preRebuildComboBoxList();
-    void rebuildComboBoxList();
+    void rebuildComboBoxList(int failure = -1);
     void downloadThePublicServers();
 
 private:
@@ -70,7 +70,7 @@ private:
     QComboBox *previousHosts;
     QRadioButton *newHostButton, *previousHostButton;
     QPushButton *btnOk, *btnCancel, *btnForgotPassword, *btnRefreshServers;
-    QMap<QString, UserConnection_Information> savedHostList;
+    QMap<QString, std::pair<QString, UserConnection_Information>> savedHostList;
     HandlePublicServers *hps;
     const QString placeHolderText = tr("Downloading...");
 };

--- a/cockatrice/src/dlg_connect.h
+++ b/cockatrice/src/dlg_connect.h
@@ -4,7 +4,6 @@
 #include "userconnection_information.h"
 #include <QDialog>
 #include <QLineEdit>
-#include <QUrl>
 
 class QLabel;
 class QPushButton;
@@ -53,6 +52,7 @@ private slots:
     void preRebuildComboBoxList();
     void rebuildComboBoxList();
     void actFinishParsingDownloadedData();
+    void downloadPublicServers();
 
 private:
     QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *saveLabel, *publicServersLabel;
@@ -60,8 +60,7 @@ private:
     QCheckBox *savePasswordCheckBox, *autoConnectCheckBox;
     QComboBox *previousHosts;
     QRadioButton *newHostButton, *previousHostButton;
-    QPushButton *btnOk, *btnCancel, *btnForgotPassword;
+    QPushButton *btnOk, *btnCancel, *btnForgotPassword, *btnRefreshServers;
     QMap<QString, UserConnection_Information> savedHostList;
-    void downloadPublicServers(QUrl url);
 };
 #endif

--- a/cockatrice/src/dlg_connect.h
+++ b/cockatrice/src/dlg_connect.h
@@ -65,7 +65,7 @@ private:
     QHBoxLayout *newHolderLayout;
     QGroupBox *loginGroupBox, *btnGroupBox, *restrictionsGroupBox;
     QVBoxLayout *mainLayout;
-    QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *saveLabel, *publicServersLabel;
+    QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *saveLabel;
     QLineEdit *hostEdit, *portEdit, *playernameEdit, *passwordEdit, *saveEdit;
     QCheckBox *savePasswordCheckBox, *autoConnectCheckBox;
     QComboBox *previousHosts;

--- a/cockatrice/src/dlg_connect.h
+++ b/cockatrice/src/dlg_connect.h
@@ -1,8 +1,12 @@
 #ifndef DLG_CONNECT_H
 #define DLG_CONNECT_H
 
+#include "handle_public_servers.h"
 #include "userconnection_information.h"
 #include <QDialog>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
 #include <QLineEdit>
 
 class QLabel;
@@ -27,6 +31,7 @@ signals:
 
 public:
     explicit DlgConnect(QWidget *parent = nullptr);
+    ~DlgConnect();
     QString getHost() const;
     int getPort() const
     {
@@ -52,10 +57,13 @@ private slots:
     void updateDisplayInfo(const QString &saveName);
     void preRebuildComboBoxList();
     void rebuildComboBoxList();
-    void actFinishParsingDownloadedData();
-    void downloadPublicServers();
+    void downloadThePublicServers();
 
 private:
+    QGridLayout *newHostLayout, *connectionLayout, *buttons, *loginLayout, *grid;
+    QHBoxLayout *newHolderLayout;
+    QGroupBox *loginGroupBox, *btnGroupBox, *restrictionsGroupBox;
+    QVBoxLayout *mainLayout;
     QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *saveLabel, *publicServersLabel;
     QLineEdit *hostEdit, *portEdit, *playernameEdit, *passwordEdit, *saveEdit;
     QCheckBox *savePasswordCheckBox, *autoConnectCheckBox;
@@ -63,6 +71,7 @@ private:
     QRadioButton *newHostButton, *previousHostButton;
     QPushButton *btnOk, *btnCancel, *btnForgotPassword, *btnRefreshServers;
     QMap<QString, UserConnection_Information> savedHostList;
+    HandlePublicServers *hps;
     const QString placeHolderText = tr("Downloading...");
 };
 #endif

--- a/cockatrice/src/dlg_connect.h
+++ b/cockatrice/src/dlg_connect.h
@@ -4,16 +4,17 @@
 #include "handle_public_servers.h"
 #include "userconnection_information.h"
 #include <QDialog>
-#include <QGridLayout>
-#include <QGroupBox>
-#include <QHBoxLayout>
 #include <QLineEdit>
 
-class QLabel;
-class QPushButton;
 class QCheckBox;
 class QComboBox;
+class QGridLayout;
+class QGroupBox;
+class QHBoxLayout;
+class QLabel;
+class QPushButton;
 class QRadioButton;
+class QVBoxLayout;
 
 class DeleteHighlightedItemWhenShiftDelPressedEventFilter : public QObject
 {
@@ -31,7 +32,7 @@ signals:
 
 public:
     explicit DlgConnect(QWidget *parent = nullptr);
-    ~DlgConnect();
+    ~DlgConnect() override;
     QString getHost() const;
     int getPort() const
     {

--- a/cockatrice/src/handle_public_servers.cpp
+++ b/cockatrice/src/handle_public_servers.cpp
@@ -1,0 +1,95 @@
+//
+// Created by Zachary Halpern on 4/6/18.
+//
+
+#include "handle_public_servers.h"
+#include "qt-json/json.h"
+#include "settingscache.h"
+#include <QUrl>
+
+#define PUBLIC_SERVERS_JSON "https://cockatrice.github.io/public-servers.json"
+
+HandlePublicServers::HandlePublicServers(QObject *parent) : QObject(parent)
+{
+}
+
+void HandlePublicServers::downloadPublicServers()
+{
+    QUrl url(QString(PUBLIC_SERVERS_JSON));
+    nam = new QNetworkAccessManager(this);
+    reply = nam->get(QNetworkRequest(url));
+    connect(reply, SIGNAL(finished()), this, SLOT(actFinishParsingDownloadedData()));
+    connect(reply, SIGNAL(finished()), this, SLOT(clearNAM()));
+}
+
+void HandlePublicServers::clearNAM()
+{
+    nam->deleteLater(); // After finished() is called, this object will be deleted
+}
+
+void HandlePublicServers::actFinishParsingDownloadedData()
+{
+    reply = dynamic_cast<QNetworkReply *>(sender());
+    QNetworkReply::NetworkError errorCode = reply->error();
+
+    if (errorCode == QNetworkReply::NoError) {
+        // Get current saved hosts
+        UserConnection_Information uci;
+        savedHostList = uci.getServerInfo();
+
+        // List of public servers
+        // Will be populated below
+        QStringList publicServersAvailable;
+        QStringList publicServersToRemove;
+
+        // Downloaded data from GitHub
+        QString jsonData = QString(reply->readAll());
+        auto jsonMap = QtJson::Json::parse(jsonData).toMap();
+
+        // Servers available
+        auto publicServersJSONList = jsonMap["servers"].toList();
+        for (const auto &server : publicServersJSONList) {
+            // Data inside one server at a time
+            // server: [{ ... }, ..., { ... }]
+            const auto serverMap = server.toMap();
+
+            QString serverName = serverMap["name"].toString();
+
+            if (serverMap["isInactive"].toBool()) {
+                publicServersToRemove.append(serverName);
+                continue;
+            }
+
+            QString serverAddress = serverMap["host"].toString();
+            QString serverPort = serverMap["port"].toString();
+
+            publicServersAvailable.append(serverName);
+
+            if (!savedHostList.contains(serverName)) {
+                settingsCache->servers().addNewServer(serverName, serverAddress, serverPort, "", "", false);
+            } else {
+                settingsCache->servers().updateExistingServerWithoutLoss(serverName, serverAddress, serverPort);
+            }
+        }
+
+        // If a server was removed from the public list,
+        // we will delete it from the local system.
+        // Will not delete "unofficial" servers
+        for (auto server : savedHostList) {
+            QString serverName = server.getSaveName();
+            bool isCustom = server.isCustomServer();
+
+            if (!isCustom && publicServersToRemove.indexOf(serverName) != -1) {
+                settingsCache->servers().removeServer(serverName);
+            }
+        }
+
+        emit sigPublicServersDownloadedSuccessfully();
+    } else {
+        qDebug() << "[CONNECTION DIALOG]"
+                 << "Error Downloading Public Servers" << errorCode;
+        emit sigPublicServersDownloadedUnsuccessfully();
+    }
+
+    reply->deleteLater(); // After an emit() occurs, this object will be deleted
+}

--- a/cockatrice/src/handle_public_servers.cpp
+++ b/cockatrice/src/handle_public_servers.cpp
@@ -9,7 +9,7 @@
 
 #define PUBLIC_SERVERS_JSON "https://cockatrice.github.io/public-servers.json"
 
-HandlePublicServers::HandlePublicServers(QObject *parent) : QObject(parent)
+HandlePublicServers::HandlePublicServers(QObject *parent) : QObject(parent), nam(nullptr), reply(nullptr)
 {
 }
 
@@ -19,18 +19,15 @@ void HandlePublicServers::downloadPublicServers()
     nam = new QNetworkAccessManager(this);
     reply = nam->get(QNetworkRequest(url));
     connect(reply, SIGNAL(finished()), this, SLOT(actFinishParsingDownloadedData()));
-    connect(reply, SIGNAL(finished()), this, SLOT(clearNAM()));
-}
-
-void HandlePublicServers::clearNAM()
-{
-    nam->deleteLater(); // After finished() is called, this object will be deleted
 }
 
 void HandlePublicServers::actFinishParsingDownloadedData()
 {
     reply = dynamic_cast<QNetworkReply *>(sender());
     QNetworkReply::NetworkError errorCode = reply->error();
+
+    // After finished() is called, this object will be deleted
+    nam->deleteLater();
 
     if (errorCode == QNetworkReply::NoError) {
         // Get current saved hosts

--- a/cockatrice/src/handle_public_servers.cpp
+++ b/cockatrice/src/handle_public_servers.cpp
@@ -1,18 +1,20 @@
 #include "handle_public_servers.h"
 #include "qt-json/json.h"
 #include "settingscache.h"
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
 #include <QUrl>
 
 #define PUBLIC_SERVERS_JSON "https://cockatrice.github.io/public-servers.json"
 
-HandlePublicServers::HandlePublicServers(QObject *parent) : QObject(parent), nam(nullptr), reply(nullptr)
+HandlePublicServers::HandlePublicServers(QObject *parent)
+    : QObject(parent), nam(new QNetworkAccessManager(this)), reply(nullptr)
 {
 }
 
 void HandlePublicServers::downloadPublicServers()
 {
     QUrl url(QString(PUBLIC_SERVERS_JSON));
-    nam = new QNetworkAccessManager(this);
     reply = nam->get(QNetworkRequest(url));
     connect(reply, SIGNAL(finished()), this, SLOT(actFinishParsingDownloadedData()));
 }
@@ -21,9 +23,6 @@ void HandlePublicServers::actFinishParsingDownloadedData()
 {
     reply = dynamic_cast<QNetworkReply *>(sender());
     QNetworkReply::NetworkError errorCode = reply->error();
-
-    // After finished() is called, this object will be deleted
-    nam->deleteLater();
 
     if (errorCode == QNetworkReply::NoError) {
         // Get current saved hosts

--- a/cockatrice/src/handle_public_servers.h
+++ b/cockatrice/src/handle_public_servers.h
@@ -1,0 +1,39 @@
+//
+// Created by Zachary Halpern on 4/6/18.
+//
+#ifndef COCKATRICE_HANDLE_PUBLIC_SERVERS_H
+#define COCKATRICE_HANDLE_PUBLIC_SERVERS_H
+
+#include "userconnection_information.h"
+#include <QNetworkReply>
+
+/**
+ * This class is used to update the servers.ini file and ensure
+ * the list of public servers has up-to-date information.
+ * Servers that are added manually by users are not modified.
+ */
+class HandlePublicServers : public QObject
+{
+    Q_OBJECT
+signals:
+    void sigPublicServersDownloadedSuccessfully();
+    void sigPublicServersDownloadedUnsuccessfully();
+
+public:
+    explicit HandlePublicServers(QObject *parent = nullptr);
+    ~HandlePublicServers() = default;
+
+public slots:
+    void downloadPublicServers();
+
+private slots:
+    void actFinishParsingDownloadedData();
+    void clearNAM();
+
+private:
+    QMap<QString, UserConnection_Information> savedHostList;
+    QNetworkAccessManager *nam;
+    QNetworkReply *reply;
+};
+
+#endif // COCKATRICE_HANDLE_PUBLIC_SERVERS_H

--- a/cockatrice/src/handle_public_servers.h
+++ b/cockatrice/src/handle_public_servers.h
@@ -2,7 +2,9 @@
 #define COCKATRICE_HANDLE_PUBLIC_SERVERS_H
 
 #include "userconnection_information.h"
-#include <QNetworkReply>
+
+class QNetworkReply;
+class QNetworkAccessManager;
 
 /**
  * This class is used to update the servers.ini file and ensure
@@ -28,6 +30,7 @@ private slots:
 
 private:
     void updateServerINISettings(QMap<QString, QVariant>);
+
     QStringList publicServersAvailable, publicServersToRemove;
     QMap<QString, std::pair<QString, UserConnection_Information>> savedHostList;
     QNetworkAccessManager *nam;

--- a/cockatrice/src/handle_public_servers.h
+++ b/cockatrice/src/handle_public_servers.h
@@ -21,6 +21,7 @@ signals:
 public:
     explicit HandlePublicServers(QObject *parent = nullptr);
     ~HandlePublicServers() override = default;
+    void askToClearServerList();
 
 public slots:
     void downloadPublicServers();

--- a/cockatrice/src/handle_public_servers.h
+++ b/cockatrice/src/handle_public_servers.h
@@ -1,6 +1,3 @@
-//
-// Created by Zachary Halpern on 4/6/18.
-//
 #ifndef COCKATRICE_HANDLE_PUBLIC_SERVERS_H
 #define COCKATRICE_HANDLE_PUBLIC_SERVERS_H
 
@@ -17,11 +14,11 @@ class HandlePublicServers : public QObject
     Q_OBJECT
 signals:
     void sigPublicServersDownloadedSuccessfully();
-    void sigPublicServersDownloadedUnsuccessfully();
+    void sigPublicServersDownloadedUnsuccessfully(int);
 
 public:
     explicit HandlePublicServers(QObject *parent = nullptr);
-    ~HandlePublicServers() = default;
+    ~HandlePublicServers() override = default;
 
 public slots:
     void downloadPublicServers();
@@ -30,7 +27,9 @@ private slots:
     void actFinishParsingDownloadedData();
 
 private:
-    QMap<QString, UserConnection_Information> savedHostList;
+    void updateServerINISettings(QMap<QString, QVariant>);
+    QStringList publicServersAvailable, publicServersToRemove;
+    QMap<QString, std::pair<QString, UserConnection_Information>> savedHostList;
     QNetworkAccessManager *nam;
     QNetworkReply *reply;
 };

--- a/cockatrice/src/handle_public_servers.h
+++ b/cockatrice/src/handle_public_servers.h
@@ -28,7 +28,6 @@ public slots:
 
 private slots:
     void actFinishParsingDownloadedData();
-    void clearNAM();
 
 private:
     QMap<QString, UserConnection_Information> savedHostList;

--- a/cockatrice/src/handle_public_servers.h
+++ b/cockatrice/src/handle_public_servers.h
@@ -21,7 +21,6 @@ signals:
 public:
     explicit HandlePublicServers(QObject *parent = nullptr);
     ~HandlePublicServers() override = default;
-    void askToClearServerList();
 
 public slots:
     void downloadPublicServers();
@@ -32,7 +31,7 @@ private slots:
 private:
     void updateServerINISettings(QMap<QString, QVariant>);
 
-    QStringList publicServersAvailable, publicServersToRemove;
+    QStringList publicServersToRemove;
     QMap<QString, std::pair<QString, UserConnection_Information>> savedHostList;
     QNetworkAccessManager *nam;
     QNetworkReply *reply;

--- a/cockatrice/src/settings/serverssettings.cpp
+++ b/cockatrice/src/settings/serverssettings.cpp
@@ -181,8 +181,7 @@ void ServersSettings::addNewServer(QString saveName,
                                    QString port,
                                    QString username,
                                    QString password,
-                                   bool savePassword,
-                                   bool isCustom)
+                                   bool savePassword)
 {
     if (updateExistingServer(saveName, serv, port, username, password, savePassword))
         return;
@@ -223,16 +222,12 @@ bool ServersSettings::updateExistingServerWithoutLoss(QString saveName,
                                                       QString port,
                                                       QString username,
                                                       QString password,
-                                                      bool savePassword,
-                                                      bool isCustom)
+                                                      bool savePassword)
 {
     int size = getValue("totalServers", "server", "server_details").toInt() + 1;
 
     for (int i = 0; i < size; i++) {
         if (serv == getValue(QString("server%1").arg(i), "server", "server_details").toString()) {
-            if (!serv.isEmpty()) {
-                setValue(serv, QString("server%1").arg(i), "server", "server_details");
-            }
 
             if (!port.isEmpty()) {
                 setValue(port, QString("port%1").arg(i), "server", "server_details");
@@ -250,7 +245,10 @@ bool ServersSettings::updateExistingServerWithoutLoss(QString saveName,
                 setValue(password, QString("password%1").arg(i), "server", "server_details");
             }
 
-            setValue(isCustom, QString("isCustom%1").arg(i), "server", "server_details");
+            if (!saveName.isEmpty()) {
+                setValue(password, QString("saveName%1").arg(i), "server", "server_details");
+            }
+
             return true;
         }
     }
@@ -262,9 +260,8 @@ bool ServersSettings::updateExistingServer(QString saveName,
                                            QString port,
                                            QString username,
                                            QString password,
-                                           bool savePassword,
-                                           bool isCustom)
+                                           bool savePassword)
 {
     return updateExistingServerWithoutLoss(std::move(saveName), std::move(serv), std::move(port), std::move(username),
-                                           std::move(password), savePassword, isCustom);
+                                           std::move(password), savePassword);
 }

--- a/cockatrice/src/settings/serverssettings.cpp
+++ b/cockatrice/src/settings/serverssettings.cpp
@@ -176,11 +176,11 @@ bool ServersSettings::getClearDebugLogStatus(bool abDefaultValue)
     return cbFlushLog == QVariant() ? abDefaultValue : cbFlushLog.toBool();
 }
 
-void ServersSettings::addNewServer(QString saveName,
-                                   QString serv,
-                                   QString port,
-                                   QString username,
-                                   QString password,
+void ServersSettings::addNewServer(const QString &saveName,
+                                   const QString &serv,
+                                   const QString &port,
+                                   const QString &username,
+                                   const QString &password,
                                    bool savePassword)
 {
     if (updateExistingServer(saveName, serv, port, username, password, savePassword))
@@ -237,17 +237,14 @@ bool ServersSettings::updateExistingServerWithoutLoss(QString saveName,
                 setValue(username, QString("username%1").arg(i), "server", "server_details");
             }
 
-            if (savePassword) {
-                setValue(savePassword, QString("savePassword%1").arg(i), "server", "server_details");
-            }
-
-            if (!password.isEmpty()) {
+            if (savePassword && !password.isEmpty()) {
                 setValue(password, QString("password%1").arg(i), "server", "server_details");
+            } else {
+                setValue(QString(), QString("password%1").arg(i), "server", "server_details");
             }
 
-            if (!saveName.isEmpty()) {
-                setValue(password, QString("saveName%1").arg(i), "server", "server_details");
-            }
+            setValue(savePassword, QString("savePassword%1").arg(i), "server", "server_details");
+            setValue(saveName, QString("saveName%1").arg(i), "server", "server_details");
 
             return true;
         }

--- a/cockatrice/src/settings/serverssettings.cpp
+++ b/cockatrice/src/settings/serverssettings.cpp
@@ -1,5 +1,6 @@
 #include "serverssettings.h"
 #include <QDebug>
+#include <utility>
 
 ServersSettings::ServersSettings(QString settingPath, QObject *parent)
     : SettingsManager(settingPath + "servers.ini", parent)
@@ -36,7 +37,7 @@ QString ServersSettings::getSaveName(QString defaultname)
 {
     int index = getPrevioushostindex(getPrevioushostName());
     QVariant saveName = getValue(QString("saveName%1").arg(index), "server", "server_details");
-    return saveName == QVariant() ? defaultname : saveName.toString();
+    return saveName == QVariant() ? std::move(defaultname) : saveName.toString();
 }
 
 QString ServersSettings::getPrevioushostName()
@@ -64,7 +65,7 @@ QString ServersSettings::getHostname(QString defaultHost)
 {
     int index = getPrevioushostindex(getPrevioushostName());
     QVariant hostname = getValue(QString("server%1").arg(index), "server", "server_details");
-    return hostname == QVariant() ? defaultHost : hostname.toString();
+    return hostname == QVariant() ? std::move(defaultHost) : hostname.toString();
 }
 
 void ServersSettings::setPort(QString port)
@@ -77,7 +78,7 @@ QString ServersSettings::getPort(QString defaultPort)
     int index = getPrevioushostindex(getPrevioushostName());
     QVariant port = getValue(QString("port%1").arg(index), "server", "server_details");
     qDebug() << "getPort() index = " << index << " port.val = " << port.toString();
-    return port == QVariant() ? defaultPort : port.toString();
+    return port == QVariant() ? std::move(defaultPort) : port.toString();
 }
 
 void ServersSettings::setPlayerName(QString playerName)
@@ -90,7 +91,7 @@ QString ServersSettings::getPlayerName(QString defaultName)
     int index = getPrevioushostindex(getPrevioushostName());
     QVariant name = getValue(QString("username%1").arg(index), "server", "server_details");
     qDebug() << "getPlayerName() index = " << index << " name.val = " << name.toString();
-    return name == QVariant() ? defaultName : name.toString();
+    return name == QVariant() ? std::move(defaultName) : name.toString();
 }
 
 QString ServersSettings::getPassword()
@@ -139,7 +140,7 @@ void ServersSettings::setFPHostName(QString hostname)
 QString ServersSettings::getFPHostname(QString defaultHost)
 {
     QVariant hostname = getValue("fphostname", "server");
-    return hostname == QVariant() ? defaultHost : hostname.toString();
+    return hostname == QVariant() ? std::move(defaultHost) : hostname.toString();
 }
 
 void ServersSettings::setFPPort(QString port)
@@ -150,7 +151,7 @@ void ServersSettings::setFPPort(QString port)
 QString ServersSettings::getFPPort(QString defaultPort)
 {
     QVariant port = getValue("fpport", "server");
-    return port == QVariant() ? defaultPort : port.toString();
+    return port == QVariant() ? std::move(defaultPort) : port.toString();
 }
 
 void ServersSettings::setFPPlayerName(QString playerName)
@@ -161,7 +162,7 @@ void ServersSettings::setFPPlayerName(QString playerName)
 QString ServersSettings::getFPPlayerName(QString defaultName)
 {
     QVariant name = getValue("fpplayername", "server");
-    return name == QVariant() ? defaultName : name.toString();
+    return name == QVariant() ? std::move(defaultName) : name.toString();
 }
 
 void ServersSettings::setClearDebugLogStatus(bool abIsChecked)
@@ -180,7 +181,8 @@ void ServersSettings::addNewServer(QString saveName,
                                    QString port,
                                    QString username,
                                    QString password,
-                                   bool savePassword)
+                                   bool savePassword,
+                                   bool isCustom)
 {
     if (updateExistingServer(saveName, serv, port, username, password, savePassword))
         return;
@@ -194,6 +196,7 @@ void ServersSettings::addNewServer(QString saveName,
     setValue(savePassword, QString("savePassword%1").arg(index), "server", "server_details");
     setValue(index, "totalServers", "server", "server_details");
     setValue(password, QString("password%1").arg(index), "server", "server_details");
+    setValue(isCustom, QString("isCustom%1").arg(index), "server", "server_details");
 }
 
 void ServersSettings::removeServer(QString saveName)
@@ -208,9 +211,52 @@ void ServersSettings::removeServer(QString saveName)
             deleteValue(QString("savePassword%1").arg(i), "server", "server_details");
             deleteValue(QString("password%1").arg(i), "server", "server_details");
             deleteValue(QString("saveName%1").arg(i), "server", "server_details");
+            deleteValue(QString("isCustom%1").arg(i), "server", "server_details");
             return;
         }
     }
+}
+
+/**
+ * Will only update fields with new values, ignores empty values
+ */
+bool ServersSettings::updateExistingServerWithoutLoss(QString saveName,
+                                                      QString serv,
+                                                      QString port,
+                                                      QString username,
+                                                      QString password,
+                                                      bool savePassword,
+                                                      bool isCustom)
+{
+    int size = getValue("totalServers", "server", "server_details").toInt() + 1;
+
+    for (int i = 0; i < size; i++) {
+        if (saveName == getValue(QString("saveName%1").arg(i), "server", "server_details").toString()) {
+            if (!serv.isEmpty()) {
+                setValue(serv, QString("server%1").arg(i), "server", "server_details");
+            }
+
+            if (!port.isEmpty()) {
+                setValue(port, QString("port%1").arg(i), "server", "server_details");
+            }
+
+            if (!username.isEmpty()) {
+                setValue(username, QString("username%1").arg(i), "server", "server_details");
+            }
+
+            if (savePassword) {
+                setValue(savePassword, QString("savePassword%1").arg(i), "server", "server_details");
+            }
+
+            if (!password.isEmpty()) {
+                setValue(password, QString("password%1").arg(i), "server", "server_details");
+            }
+
+            setValue(isCustom, QString("isCustom%1").arg(i), "server", "server_details");
+            return true;
+        }
+    }
+    return false;
 }
 
 bool ServersSettings::updateExistingServer(QString saveName,
@@ -218,19 +264,9 @@ bool ServersSettings::updateExistingServer(QString saveName,
                                            QString port,
                                            QString username,
                                            QString password,
-                                           bool savePassword)
+                                           bool savePassword,
+                                           bool isCustom)
 {
-    int size = getValue("totalServers", "server", "server_details").toInt() + 1;
-
-    for (int i = 0; i < size; i++) {
-        if (saveName == getValue(QString("saveName%1").arg(i), "server", "server_details").toString()) {
-            setValue(serv, QString("server%1").arg(i), "server", "server_details");
-            setValue(port, QString("port%1").arg(i), "server", "server_details");
-            setValue(username, QString("username%1").arg(i), "server", "server_details");
-            setValue(savePassword, QString("savePassword%1").arg(i), "server", "server_details");
-            setValue(password, QString("password%1").arg(i), "server", "server_details");
-            return true;
-        }
-    }
-    return false;
+    return updateExistingServerWithoutLoss(std::move(saveName), std::move(serv), std::move(port), std::move(username),
+                                           std::move(password), savePassword, isCustom);
 }

--- a/cockatrice/src/settings/serverssettings.cpp
+++ b/cockatrice/src/settings/serverssettings.cpp
@@ -196,22 +196,20 @@ void ServersSettings::addNewServer(QString saveName,
     setValue(savePassword, QString("savePassword%1").arg(index), "server", "server_details");
     setValue(index, "totalServers", "server", "server_details");
     setValue(password, QString("password%1").arg(index), "server", "server_details");
-    setValue(isCustom, QString("isCustom%1").arg(index), "server", "server_details");
 }
 
-void ServersSettings::removeServer(QString saveName)
+void ServersSettings::removeServer(QString servAddr)
 {
     int size = getValue("totalServers", "server", "server_details").toInt() + 1;
 
     for (int i = 0; i < size; i++) {
-        if (saveName == getValue(QString("saveName%1").arg(i), "server", "server_details").toString()) {
+        if (servAddr == getValue(QString("server%1").arg(i), "server", "server_details").toString()) {
             deleteValue(QString("server%1").arg(i), "server", "server_details");
             deleteValue(QString("port%1").arg(i), "server", "server_details");
             deleteValue(QString("username%1").arg(i), "server", "server_details");
             deleteValue(QString("savePassword%1").arg(i), "server", "server_details");
             deleteValue(QString("password%1").arg(i), "server", "server_details");
             deleteValue(QString("saveName%1").arg(i), "server", "server_details");
-            deleteValue(QString("isCustom%1").arg(i), "server", "server_details");
             return;
         }
     }
@@ -231,7 +229,7 @@ bool ServersSettings::updateExistingServerWithoutLoss(QString saveName,
     int size = getValue("totalServers", "server", "server_details").toInt() + 1;
 
     for (int i = 0; i < size; i++) {
-        if (saveName == getValue(QString("saveName%1").arg(i), "server", "server_details").toString()) {
+        if (serv == getValue(QString("server%1").arg(i), "server", "server_details").toString()) {
             if (!serv.isEmpty()) {
                 setValue(serv, QString("server%1").arg(i), "server", "server_details");
             }

--- a/cockatrice/src/settings/serverssettings.h
+++ b/cockatrice/src/settings/serverssettings.h
@@ -36,7 +36,7 @@ public:
     void setPassword(QString password);
     void setFPPort(QString port);
     void setSavePassword(int save);
-    void setFPPlayerName(QString playerName);
+    void setFPmPlayerName(QString playerName);
     void
     addNewServer(QString saveName, QString serv, QString port, QString username, QString password, bool savePassword);
     bool updateExistingServer(QString saveName,

--- a/cockatrice/src/settings/serverssettings.h
+++ b/cockatrice/src/settings/serverssettings.h
@@ -37,29 +37,22 @@ public:
     void setFPPort(QString port);
     void setSavePassword(int save);
     void setFPPlayerName(QString playerName);
-    void addNewServer(QString saveName,
-                      QString serv,
-                      QString port,
-                      QString username,
-                      QString password,
-                      bool savePassword,
-                      bool isCustom = false);
+    void
+    addNewServer(QString saveName, QString serv, QString port, QString username, QString password, bool savePassword);
     void removeServer(QString servAddr);
     bool updateExistingServer(QString saveName,
                               QString serv,
                               QString port,
                               QString username,
                               QString password,
-                              bool savePassword,
-                              bool isCustom = false);
+                              bool savePassword);
 
     bool updateExistingServerWithoutLoss(QString saveName,
                                          QString serv = QString(),
                                          QString port = QString(),
                                          QString username = QString(),
                                          QString password = QString(),
-                                         bool savePassword = true,
-                                         bool isCustom = false);
+                                         bool savePassword = true);
     void setClearDebugLogStatus(bool abIsChecked);
     bool getClearDebugLogStatus(bool abDefaultValue);
 

--- a/cockatrice/src/settings/serverssettings.h
+++ b/cockatrice/src/settings/serverssettings.h
@@ -63,10 +63,6 @@ public:
     void setClearDebugLogStatus(bool abIsChecked);
     bool getClearDebugLogStatus(bool abDefaultValue);
 
-signals:
-
-public slots:
-
 private:
     explicit ServersSettings(QString settingPath, QObject *parent = nullptr);
     ServersSettings(const ServersSettings & /*other*/);

--- a/cockatrice/src/settings/serverssettings.h
+++ b/cockatrice/src/settings/serverssettings.h
@@ -36,7 +36,7 @@ public:
     void setPassword(QString password);
     void setFPPort(QString port);
     void setSavePassword(int save);
-    void setFPmPlayerName(QString playerName);
+    void setFPPlayerName(QString playerName);
     void
     addNewServer(QString saveName, QString serv, QString port, QString username, QString password, bool savePassword);
     void removeServer(QString saveName);

--- a/cockatrice/src/settings/serverssettings.h
+++ b/cockatrice/src/settings/serverssettings.h
@@ -37,15 +37,29 @@ public:
     void setFPPort(QString port);
     void setSavePassword(int save);
     void setFPPlayerName(QString playerName);
-    void
-    addNewServer(QString saveName, QString serv, QString port, QString username, QString password, bool savePassword);
+    void addNewServer(QString saveName,
+                      QString serv,
+                      QString port,
+                      QString username,
+                      QString password,
+                      bool savePassword,
+                      bool isCustom = false);
     void removeServer(QString saveName);
     bool updateExistingServer(QString saveName,
                               QString serv,
                               QString port,
                               QString username,
                               QString password,
-                              bool savePassword);
+                              bool savePassword,
+                              bool isCustom = false);
+
+    bool updateExistingServerWithoutLoss(QString saveName,
+                                         QString serv = QString(),
+                                         QString port = QString(),
+                                         QString username = QString(),
+                                         QString password = QString(),
+                                         bool savePassword = true,
+                                         bool isCustom = false);
     void setClearDebugLogStatus(bool abIsChecked);
     bool getClearDebugLogStatus(bool abDefaultValue);
 

--- a/cockatrice/src/settings/serverssettings.h
+++ b/cockatrice/src/settings/serverssettings.h
@@ -44,7 +44,7 @@ public:
                       QString password,
                       bool savePassword,
                       bool isCustom = false);
-    void removeServer(QString saveName);
+    void removeServer(QString servAddr);
     bool updateExistingServer(QString saveName,
                               QString serv,
                               QString port,

--- a/cockatrice/src/settings/serverssettings.h
+++ b/cockatrice/src/settings/serverssettings.h
@@ -37,8 +37,12 @@ public:
     void setFPPort(QString port);
     void setSavePassword(int save);
     void setFPPlayerName(QString playerName);
-    void
-    addNewServer(QString saveName, QString serv, QString port, QString username, QString password, bool savePassword);
+    void addNewServer(const QString &saveName,
+                      const QString &serv,
+                      const QString &port,
+                      const QString &username,
+                      const QString &password,
+                      bool savePassword);
     void removeServer(QString servAddr);
     bool updateExistingServer(QString saveName,
                               QString serv,

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -7,6 +7,7 @@
 #include <QFile>
 #include <QSettings>
 #include <QStandardPaths>
+#include <utility>
 
 QString SettingsCache::getDataPath()
 {
@@ -140,7 +141,7 @@ QString SettingsCache::getSafeConfigFilePath(QString configEntry, QString defaul
     // if the config settings is empty or refers to a not-existing file,
     // return the default Path
     if (!QFile::exists(tmp) || tmp.isEmpty())
-        tmp = defaultPath;
+        tmp = std::move(defaultPath);
     return tmp;
 }
 
@@ -182,7 +183,7 @@ SettingsCache::SettingsCache()
 
     // tip of the day settings
     showTipsOnStartup = settings->value("tipOfDay/showTips", true).toBool();
-    for (auto tipNumber : settings->value("tipOfDay/seenTips").toList()) {
+    for (const auto &tipNumber : settings->value("tipOfDay/seenTips").toList()) {
         seenTips.append(tipNumber.toInt());
     }
 
@@ -281,7 +282,7 @@ SettingsCache::SettingsCache()
 
 void SettingsCache::setKnownMissingFeatures(QString _knownMissingFeatures)
 {
-    knownMissingFeatures = _knownMissingFeatures;
+    knownMissingFeatures = std::move(_knownMissingFeatures);
     settings->setValue("interface/knownmissingfeatures", knownMissingFeatures);
 }
 
@@ -306,32 +307,32 @@ void SettingsCache::setMasterVolume(int _masterVolume)
 
 void SettingsCache::setLeftJustified(const int _leftJustified)
 {
-    leftJustified = _leftJustified;
+    leftJustified = (bool)_leftJustified;
     settings->setValue("interface/leftjustified", leftJustified);
     emit handJustificationChanged();
 }
 
 void SettingsCache::setCardScaling(const int _scaleCards)
 {
-    scaleCards = _scaleCards;
+    scaleCards = (bool)_scaleCards;
     settings->setValue("cards/scaleCards", scaleCards);
 }
 
 void SettingsCache::setShowMessagePopups(const int _showMessagePopups)
 {
-    showMessagePopups = _showMessagePopups;
+    showMessagePopups = (bool)_showMessagePopups;
     settings->setValue("chat/showmessagepopups", showMessagePopups);
 }
 
 void SettingsCache::setShowMentionPopups(const int _showMentionPopus)
 {
-    showMentionPopups = _showMentionPopus;
+    showMentionPopups = (bool)_showMentionPopus;
     settings->setValue("chat/showmentionpopups", showMentionPopups);
 }
 
 void SettingsCache::setRoomHistory(const int _roomHistory)
 {
-    roomHistory = _roomHistory;
+    roomHistory = (bool)_roomHistory;
     settings->setValue("chat/roomhistory", roomHistory);
 }
 
@@ -409,7 +410,7 @@ void SettingsCache::setThemeName(const QString &_themeName)
 
 void SettingsCache::setPicDownload(int _picDownload)
 {
-    picDownload = _picDownload;
+    picDownload = static_cast<bool>(_picDownload);
     settings->setValue("personal/picturedownload", picDownload);
     emit picDownloadChanged();
 }
@@ -428,31 +429,31 @@ void SettingsCache::setPicUrlFallback(const QString &_picUrlFallback)
 
 void SettingsCache::setNotificationsEnabled(int _notificationsEnabled)
 {
-    notificationsEnabled = _notificationsEnabled;
+    notificationsEnabled = static_cast<bool>(_notificationsEnabled);
     settings->setValue("interface/notificationsenabled", notificationsEnabled);
 }
 
 void SettingsCache::setSpectatorNotificationsEnabled(int _spectatorNotificationsEnabled)
 {
-    spectatorNotificationsEnabled = _spectatorNotificationsEnabled;
+    spectatorNotificationsEnabled = static_cast<bool>(_spectatorNotificationsEnabled);
     settings->setValue("interface/specnotificationsenabled", spectatorNotificationsEnabled);
 }
 
 void SettingsCache::setDoubleClickToPlay(int _doubleClickToPlay)
 {
-    doubleClickToPlay = _doubleClickToPlay;
+    doubleClickToPlay = static_cast<bool>(_doubleClickToPlay);
     settings->setValue("interface/doubleclicktoplay", doubleClickToPlay);
 }
 
 void SettingsCache::setPlayToStack(int _playToStack)
 {
-    playToStack = _playToStack;
+    playToStack = static_cast<bool>(_playToStack);
     settings->setValue("interface/playtostack", playToStack);
 }
 
 void SettingsCache::setAnnotateTokens(int _annotateTokens)
 {
-    annotateTokens = _annotateTokens;
+    annotateTokens = static_cast<bool>(_annotateTokens);
     settings->setValue("interface/annotatetokens", annotateTokens);
 }
 
@@ -464,21 +465,21 @@ void SettingsCache::setTabGameSplitterSizes(const QByteArray &_tabGameSplitterSi
 
 void SettingsCache::setDisplayCardNames(int _displayCardNames)
 {
-    displayCardNames = _displayCardNames;
+    displayCardNames = static_cast<bool>(_displayCardNames);
     settings->setValue("cards/displaycardnames", displayCardNames);
     emit displayCardNamesChanged();
 }
 
 void SettingsCache::setHorizontalHand(int _horizontalHand)
 {
-    horizontalHand = _horizontalHand;
+    horizontalHand = static_cast<bool>(_horizontalHand);
     settings->setValue("hand/horizontal", horizontalHand);
     emit horizontalHandChanged();
 }
 
 void SettingsCache::setInvertVerticalCoordinate(int _invertVerticalCoordinate)
 {
-    invertVerticalCoordinate = _invertVerticalCoordinate;
+    invertVerticalCoordinate = static_cast<bool>(_invertVerticalCoordinate);
     settings->setValue("table/invert_vertical", invertVerticalCoordinate);
     emit invertVerticalCoordinateChanged();
 }
@@ -492,32 +493,32 @@ void SettingsCache::setMinPlayersForMultiColumnLayout(int _minPlayersForMultiCol
 
 void SettingsCache::setTapAnimation(int _tapAnimation)
 {
-    tapAnimation = _tapAnimation;
+    tapAnimation = static_cast<bool>(_tapAnimation);
     settings->setValue("cards/tapanimation", tapAnimation);
 }
 
 void SettingsCache::setChatMention(int _chatMention)
 {
-    chatMention = _chatMention;
+    chatMention = static_cast<bool>(_chatMention);
     settings->setValue("chat/mention", chatMention);
 }
 
 void SettingsCache::setChatMentionCompleter(const int _enableMentionCompleter)
 {
-    chatMentionCompleter = _enableMentionCompleter;
+    chatMentionCompleter = (bool)_enableMentionCompleter;
     settings->setValue("chat/mentioncompleter", chatMentionCompleter);
     emit chatMentionCompleterChanged();
 }
 
 void SettingsCache::setChatMentionForeground(int _chatMentionForeground)
 {
-    chatMentionForeground = _chatMentionForeground;
+    chatMentionForeground = static_cast<bool>(_chatMentionForeground);
     settings->setValue("chat/mentionforeground", chatMentionForeground);
 }
 
 void SettingsCache::setChatHighlightForeground(int _chatHighlightForeground)
 {
-    chatHighlightForeground = _chatHighlightForeground;
+    chatHighlightForeground = static_cast<bool>(_chatHighlightForeground);
     settings->setValue("chat/highlightforeground", chatHighlightForeground);
 }
 
@@ -535,25 +536,25 @@ void SettingsCache::setChatHighlightColor(const QString &_chatHighlightColor)
 
 void SettingsCache::setZoneViewSortByName(int _zoneViewSortByName)
 {
-    zoneViewSortByName = _zoneViewSortByName;
+    zoneViewSortByName = static_cast<bool>(_zoneViewSortByName);
     settings->setValue("zoneview/sortbyname", zoneViewSortByName);
 }
 
 void SettingsCache::setZoneViewSortByType(int _zoneViewSortByType)
 {
-    zoneViewSortByType = _zoneViewSortByType;
+    zoneViewSortByType = static_cast<bool>(_zoneViewSortByType);
     settings->setValue("zoneview/sortbytype", zoneViewSortByType);
 }
 
 void SettingsCache::setZoneViewPileView(int _zoneViewPileView)
 {
-    zoneViewPileView = _zoneViewPileView;
+    zoneViewPileView = static_cast<bool>(_zoneViewPileView);
     settings->setValue("zoneview/pileview", zoneViewPileView);
 }
 
 void SettingsCache::setSoundEnabled(int _soundEnabled)
 {
-    soundEnabled = _soundEnabled;
+    soundEnabled = static_cast<bool>(_soundEnabled);
     settings->setValue("sound/enabled", soundEnabled);
     emit soundEnabledChanged();
 }
@@ -567,13 +568,13 @@ void SettingsCache::setSoundThemeName(const QString &_soundThemeName)
 
 void SettingsCache::setIgnoreUnregisteredUsers(int _ignoreUnregisteredUsers)
 {
-    ignoreUnregisteredUsers = _ignoreUnregisteredUsers;
+    ignoreUnregisteredUsers = static_cast<bool>(_ignoreUnregisteredUsers);
     settings->setValue("chat/ignore_unregistered", ignoreUnregisteredUsers);
 }
 
 void SettingsCache::setIgnoreUnregisteredUserMessages(int _ignoreUnregisteredUserMessages)
 {
-    ignoreUnregisteredUserMessages = _ignoreUnregisteredUserMessages;
+    ignoreUnregisteredUserMessages = static_cast<bool>(_ignoreUnregisteredUserMessages);
     settings->setValue("chat/ignore_unregistered_messages", ignoreUnregisteredUserMessages);
 }
 
@@ -598,7 +599,7 @@ void SettingsCache::setPixmapCacheSize(const int _pixmapCacheSize)
 
 void SettingsCache::setClientID(QString _clientID)
 {
-    clientID = _clientID;
+    clientID = std::move(_clientID);
     settings->setValue("personal/clientid", clientID);
 }
 

--- a/cockatrice/src/shortcutssettings.cpp
+++ b/cockatrice/src/shortcutssettings.cpp
@@ -150,10 +150,7 @@ bool ShortcutsSettings::isKeyAllowed(QString name, QString Sequences)
                                                << "Shift+S"
                                                << "Shift+Left"
                                                << "Shift+Right");
-    if (forbiddenKeys.contains(checkSequence)) {
-        return false;
-    }
-    return true;
+    return !forbiddenKeys.contains(checkSequence);
 }
 
 bool ShortcutsSettings::isValid(QString name, QString Sequences)

--- a/cockatrice/src/userconnection_information.cpp
+++ b/cockatrice/src/userconnection_information.cpp
@@ -17,9 +17,9 @@ UserConnection_Information::UserConnection_Information(QString _saveName,
 {
 }
 
-QMap<QString, UserConnection_Information> UserConnection_Information::getServerInfo()
+QMap<QString, std::pair<QString, UserConnection_Information>> UserConnection_Information::getServerInfo()
 {
-    QMap<QString, UserConnection_Information> serverList;
+    QMap<QString, std::pair<QString, UserConnection_Information>> serverList;
 
     int size = settingsCache->servers().getValue("totalServers", "server", "server_details").toInt() + 1;
 
@@ -40,7 +40,7 @@ QMap<QString, UserConnection_Information> UserConnection_Information::getServerI
             settingsCache->servers().getValue(QString("isCustom%1").arg(i), "server", "server_details").toBool();
 
         UserConnection_Information userInfo(saveName, serverName, portNum, userName, pass, savePass, isCustom);
-        serverList.insert(saveName, userInfo);
+        serverList.insert(saveName, std::make_pair(serverName, userInfo));
     }
 
     return serverList;

--- a/cockatrice/src/userconnection_information.cpp
+++ b/cockatrice/src/userconnection_information.cpp
@@ -1,19 +1,19 @@
 #include "userconnection_information.h"
 #include "settingscache.h"
 #include <QDebug>
+#include <utility>
 
-UserConnection_Information::UserConnection_Information()
-{
-}
+UserConnection_Information::UserConnection_Information() = default;
 
 UserConnection_Information::UserConnection_Information(QString _saveName,
                                                        QString _serverName,
                                                        QString _portNum,
                                                        QString _userName,
                                                        QString _pass,
-                                                       bool _savePass)
-    : saveName(_saveName), server(_serverName), port(_portNum), username(_userName), password(_pass),
-      savePassword(_savePass)
+                                                       bool _savePass,
+                                                       bool _isCustom)
+    : saveName(std::move(_saveName)), server(std::move(_serverName)), port(std::move(_portNum)),
+      username(std::move(_userName)), password(std::move(_pass)), savePassword(_savePass), isCustom(_isCustom)
 {
 }
 
@@ -36,8 +36,10 @@ QMap<QString, UserConnection_Information> UserConnection_Information::getServerI
             settingsCache->servers().getValue(QString("password%1").arg(i), "server", "server_details").toString();
         bool savePass =
             settingsCache->servers().getValue(QString("savePassword%1").arg(i), "server", "server_details").toBool();
+        bool isCustom =
+            settingsCache->servers().getValue(QString("isCustom%1").arg(i), "server", "server_details").toBool();
 
-        UserConnection_Information userInfo(saveName, serverName, portNum, userName, pass, savePass);
+        UserConnection_Information userInfo(saveName, serverName, portNum, userName, pass, savePass, isCustom);
         serverList.insert(saveName, userInfo);
     }
 
@@ -66,6 +68,8 @@ QStringList UserConnection_Information::getServerInfo(const QString &find)
             settingsCache->servers().getValue(QString("password%1").arg(i), "server", "server_details").toString();
         bool savePass =
             settingsCache->servers().getValue(QString("savePassword%1").arg(i), "server", "server_details").toBool();
+        bool isCustom =
+            settingsCache->servers().getValue(QString("isCustom%1").arg(i), "server", "server_details").toBool();
 
         server.append(saveName);
         server.append(serverName);
@@ -73,10 +77,11 @@ QStringList UserConnection_Information::getServerInfo(const QString &find)
         server.append(userName);
         server.append(pass);
         server.append(savePass ? "1" : "0");
+        server.append(isCustom ? "1" : "0");
         break;
     }
 
-    if (!server.size())
+    if (server.empty())
         qDebug() << "There was a problem!";
 
     return server;

--- a/cockatrice/src/userconnection_information.cpp
+++ b/cockatrice/src/userconnection_information.cpp
@@ -10,10 +10,9 @@ UserConnection_Information::UserConnection_Information(QString _saveName,
                                                        QString _portNum,
                                                        QString _userName,
                                                        QString _pass,
-                                                       bool _savePass,
-                                                       bool _isCustom)
+                                                       bool _savePass)
     : saveName(std::move(_saveName)), server(std::move(_serverName)), port(std::move(_portNum)),
-      username(std::move(_userName)), password(std::move(_pass)), savePassword(_savePass), isCustom(_isCustom)
+      username(std::move(_userName)), password(std::move(_pass)), savePassword(_savePass)
 {
 }
 
@@ -36,10 +35,8 @@ QMap<QString, std::pair<QString, UserConnection_Information>> UserConnection_Inf
             settingsCache->servers().getValue(QString("password%1").arg(i), "server", "server_details").toString();
         bool savePass =
             settingsCache->servers().getValue(QString("savePassword%1").arg(i), "server", "server_details").toBool();
-        bool isCustom =
-            settingsCache->servers().getValue(QString("isCustom%1").arg(i), "server", "server_details").toBool();
 
-        UserConnection_Information userInfo(saveName, serverName, portNum, userName, pass, savePass, isCustom);
+        UserConnection_Information userInfo(saveName, serverName, portNum, userName, pass, savePass);
         serverList.insert(saveName, std::make_pair(serverName, userInfo));
     }
 
@@ -68,8 +65,6 @@ QStringList UserConnection_Information::getServerInfo(const QString &find)
             settingsCache->servers().getValue(QString("password%1").arg(i), "server", "server_details").toString();
         bool savePass =
             settingsCache->servers().getValue(QString("savePassword%1").arg(i), "server", "server_details").toBool();
-        bool isCustom =
-            settingsCache->servers().getValue(QString("isCustom%1").arg(i), "server", "server_details").toBool();
 
         server.append(saveName);
         server.append(serverName);
@@ -77,7 +72,6 @@ QStringList UserConnection_Information::getServerInfo(const QString &find)
         server.append(userName);
         server.append(pass);
         server.append(savePass ? "1" : "0");
-        server.append(isCustom ? "1" : "0");
         break;
     }
 

--- a/cockatrice/src/userconnection_information.h
+++ b/cockatrice/src/userconnection_information.h
@@ -21,35 +21,35 @@ private:
 public:
     UserConnection_Information();
     UserConnection_Information(QString, QString, QString, QString, QString, bool, bool _isCustom = false);
-    QString getSaveName()
+    QString getSaveName() const
     {
         return saveName;
     }
-    QString getServer()
+    QString getServer() const
     {
         return server;
     }
-    QString getPort()
+    QString getPort() const
     {
         return port;
     }
-    QString getUsername()
+    QString getUsername() const
     {
         return username;
     }
-    QString getPassword()
+    QString getPassword() const
     {
         return password;
     }
-    bool getSavePassword()
+    bool getSavePassword() const
     {
         return savePassword;
     }
-    bool isCustomServer()
+    bool isCustomServer() const
     {
         return isCustom;
     }
-    QMap<QString, UserConnection_Information> getServerInfo();
+    QMap<QString, std::pair<QString, UserConnection_Information>> getServerInfo();
     QStringList getServerInfo(const QString &find);
 };
 #endif

--- a/cockatrice/src/userconnection_information.h
+++ b/cockatrice/src/userconnection_information.h
@@ -20,7 +20,7 @@ private:
 
 public:
     UserConnection_Information();
-    UserConnection_Information(QString, QString, QString, QString, QString, bool, bool _isCustom = false);
+    UserConnection_Information(QString, QString, QString, QString, QString, bool);
     QString getSaveName() const
     {
         return saveName;
@@ -44,10 +44,6 @@ public:
     bool getSavePassword() const
     {
         return savePassword;
-    }
-    bool isCustomServer() const
-    {
-        return isCustom;
     }
     QMap<QString, std::pair<QString, UserConnection_Information>> getServerInfo();
     QStringList getServerInfo(const QString &find);

--- a/cockatrice/src/userconnection_information.h
+++ b/cockatrice/src/userconnection_information.h
@@ -16,10 +16,11 @@ private:
     QString username;
     QString password;
     bool savePassword;
+    bool isCustom;
 
 public:
     UserConnection_Information();
-    UserConnection_Information(QString, QString, QString, QString, QString, bool);
+    UserConnection_Information(QString, QString, QString, QString, QString, bool, bool _isCustom = false);
     QString getSaveName()
     {
         return saveName;
@@ -43,6 +44,10 @@ public:
     bool getSavePassword()
     {
         return savePassword;
+    }
+    bool isCustomServer()
+    {
+        return isCustom;
     }
     QMap<QString, UserConnection_Information> getServerInfo();
     QStringList getServerInfo(const QString &find);

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -183,11 +183,14 @@ void MainWindow::activateAccepted()
 
 void MainWindow::actConnect()
 {
-    auto *dlg = new DlgConnect(this);
-    connect(dlg, SIGNAL(sigStartForgotPasswordRequest()), this, SLOT(actForgotPasswordRequest()));
-    if (dlg->exec())
-        client->connectToServer(dlg->getHost(), static_cast<unsigned int>(dlg->getPort()), dlg->getPlayerName(),
-                                dlg->getPassword());
+    dlgConnect = new DlgConnect(this);
+    dlgConnect->setAttribute(Qt::WA_DeleteOnClose);
+    connect(dlgConnect, SIGNAL(sigStartForgotPasswordRequest()), this, SLOT(actForgotPasswordRequest()));
+
+    if (dlgConnect->exec()) {
+        client->connectToServer(dlgConnect->getHost(), static_cast<unsigned int>(dlgConnect->getPort()),
+                                dlgConnect->getPlayerName(), dlgConnect->getPassword());
+    }
 }
 
 void MainWindow::actRegister()

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -203,7 +203,6 @@ void MainWindow::actRegister()
     }
 }
 
-
 void MainWindow::actDisconnect()
 {
     client->disconnectFromServer();
@@ -758,26 +757,18 @@ MainWindow::MainWindow(QWidget *parent)
     pixmapCacheSizeChanged(settingsCache->getPixmapCacheSize());
 
     client = new RemoteClient;
-    connect(client, SIGNAL(connectionClosedEventReceived(
-                                   const Event_ConnectionClosed &)), this,
-            SLOT(processConnectionClosedEvent(
-                         const Event_ConnectionClosed &)));
-    connect(client, SIGNAL(serverShutdownEventReceived(
-                                   const Event_ServerShutdown &)), this,
-            SLOT(processServerShutdownEvent(
-                         const Event_ServerShutdown &)));
+    connect(client, SIGNAL(connectionClosedEventReceived(const Event_ConnectionClosed &)), this,
+            SLOT(processConnectionClosedEvent(const Event_ConnectionClosed &)));
+    connect(client, SIGNAL(serverShutdownEventReceived(const Event_ServerShutdown &)), this,
+            SLOT(processServerShutdownEvent(const Event_ServerShutdown &)));
     connect(client, SIGNAL(loginError(Response::ResponseCode, QString, quint32, QList<QString>)), this,
             SLOT(loginError(Response::ResponseCode, QString, quint32, QList<QString>)));
-    connect(client, SIGNAL(socketError(
-                                   const QString &)), this, SLOT(socketError(
-                                                                         const QString &)));
+    connect(client, SIGNAL(socketError(const QString &)), this, SLOT(socketError(const QString &)));
     connect(client, SIGNAL(serverTimeout()), this, SLOT(serverTimeout()));
     connect(client, SIGNAL(statusChanged(ClientStatus)), this, SLOT(statusChanged(ClientStatus)));
     connect(client, SIGNAL(protocolVersionMismatch(int, int)), this, SLOT(protocolVersionMismatch(int, int)));
-    connect(client, SIGNAL(userInfoChanged(
-                                   const ServerInfo_User &)), this,
-            SLOT(userInfoReceived(
-                         const ServerInfo_User &)), Qt::BlockingQueuedConnection);
+    connect(client, SIGNAL(userInfoChanged(const ServerInfo_User &)), this,
+            SLOT(userInfoReceived(const ServerInfo_User &)), Qt::BlockingQueuedConnection);
     connect(client, SIGNAL(notifyUserAboutUpdate()), this, SLOT(notifyUserAboutUpdate()));
     connect(client, SIGNAL(registerAccepted()), this, SLOT(registerAccepted()));
     connect(client, SIGNAL(registerAcceptedNeedsActivate()), this, SLOT(registerAcceptedNeedsActivate()));
@@ -807,14 +798,12 @@ MainWindow::MainWindow(QWidget *parent)
 
     retranslateUi();
 
-    if (!restoreGeometry(settingsCache->getMainWindowGeometry()))
-    {
+    if (!restoreGeometry(settingsCache->getMainWindowGeometry())) {
         setWindowState(Qt::WindowMaximized);
     }
     aFullScreen->setChecked(static_cast<bool>(windowState() & Qt::WindowFullScreen));
 
-    if (QSystemTrayIcon::isSystemTrayAvailable())
-    {
+    if (QSystemTrayIcon::isSystemTrayAvailable()) {
         createTrayActions();
         createTrayIcon();
     }
@@ -827,8 +816,7 @@ MainWindow::MainWindow(QWidget *parent)
             SLOT(cardDatabaseNewSetsFound(int, QStringList)));
     connect(db, SIGNAL(cardDatabaseAllNewSetsEnabled()), this, SLOT(cardDatabaseAllNewSetsEnabled()));
 
-    if (!settingsCache->getDownloadSpoilersStatus())
-    {
+    if (!settingsCache->getDownloadSpoilersStatus()) {
         qDebug() << "Spoilers Disabled";
         QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
     }

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -143,14 +143,12 @@ void MainWindow::statusChanged(ClientStatus _status)
             aSinglePlayer->setEnabled(true);
             aConnect->setEnabled(true);
             aRegister->setEnabled(true);
-            aRefreshServers->setEnabled(true);
             aDisconnect->setEnabled(false);
             break;
         case StatusLoggingIn:
             aSinglePlayer->setEnabled(false);
             aConnect->setEnabled(false);
             aRegister->setEnabled(false);
-            aRefreshServers->setEnabled(false);
             aDisconnect->setEnabled(true);
             break;
         case StatusConnecting:
@@ -235,7 +233,6 @@ void MainWindow::actSinglePlayer()
 
     aConnect->setEnabled(false);
     aRegister->setEnabled(false);
-    aRefreshServers->setEnabled(false);
     aSinglePlayer->setEnabled(false);
 
     localServer = new LocalServer(this);
@@ -285,7 +282,6 @@ void MainWindow::localGameEnded()
 
     aConnect->setEnabled(true);
     aRegister->setEnabled(true);
-    aRefreshServers->setEnabled(true);
     aSinglePlayer->setEnabled(true);
 }
 
@@ -640,7 +636,6 @@ void MainWindow::retranslateUi()
     aDeckEditor->setText(tr("&Deck editor"));
     aFullScreen->setText(tr("&Full screen"));
     aRegister->setText(tr("&Register to server..."));
-    aRefreshServers->setText(tr("Refresh servers"));
     aSettings->setText(tr("&Settings..."));
     aSettings->setIcon(QPixmap("theme:icons/settings"));
     aExit->setText(tr("&Exit"));
@@ -685,8 +680,6 @@ void MainWindow::createActions()
     connect(aFullScreen, SIGNAL(toggled(bool)), this, SLOT(actFullScreen(bool)));
     aRegister = new QAction(this);
     connect(aRegister, SIGNAL(triggered()), this, SLOT(actRegister()));
-    aRefreshServers = new QAction(this);
-    connect(aRefreshServers, SIGNAL(triggered()), this, SLOT(actRefreshServers()));
     aSettings = new QAction(this);
     connect(aSettings, SIGNAL(triggered()), this, SLOT(actSettings()));
     aExit = new QAction(this);
@@ -741,7 +734,6 @@ void MainWindow::createMenus()
     cockatriceMenu->addAction(aConnect);
     cockatriceMenu->addAction(aDisconnect);
     cockatriceMenu->addAction(aRegister);
-    cockatriceMenu->addAction(aRefreshServers);
     cockatriceMenu->addSeparator();
     cockatriceMenu->addAction(aSinglePlayer);
     cockatriceMenu->addAction(aWatchReplay);

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -686,7 +686,7 @@ void MainWindow::createActions()
     aRegister = new QAction(this);
     connect(aRegister, SIGNAL(triggered()), this, SLOT(actRegister()));
     aRefreshServers = new QAction(this);
-    connect(aRefreshServers, SIGNAL(triggered()), this, SLOT(actRefreshServers())); // TODO
+    connect(aRefreshServers, SIGNAL(triggered()), this, SLOT(actRefreshServers()));
     aSettings = new QAction(this);
     connect(aSettings, SIGNAL(triggered()), this, SLOT(actSettings()));
     aExit = new QAction(this);

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -184,7 +184,6 @@ void MainWindow::activateAccepted()
 void MainWindow::actConnect()
 {
     dlgConnect = new DlgConnect(this);
-    dlgConnect->setAttribute(Qt::WA_DeleteOnClose);
     connect(dlgConnect, SIGNAL(sigStartForgotPasswordRequest()), this, SLOT(actForgotPasswordRequest()));
 
     if (dlgConnect->exec()) {

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -203,20 +203,6 @@ void MainWindow::actRegister()
     }
 }
 
-void MainWindow::actRefreshServers()
-{
-    hps->downloadPublicServers();
-}
-
-void MainWindow::alertUser(int errorCode)
-{
-    if (errorCode != -1) {
-        QMessageBox::warning(nullptr, tr("Public Servers NOT Refreshed"),
-                             tr("Failed to refresh public servers:") + errorCode);
-    } else {
-        QMessageBox::information(nullptr, tr("Public Servers Refreshed"), tr("Public Servers Refreshed"));
-    }
-}
 
 void MainWindow::actDisconnect()
 {
@@ -772,18 +758,26 @@ MainWindow::MainWindow(QWidget *parent)
     pixmapCacheSizeChanged(settingsCache->getPixmapCacheSize());
 
     client = new RemoteClient;
-    connect(client, SIGNAL(connectionClosedEventReceived(const Event_ConnectionClosed &)), this,
-            SLOT(processConnectionClosedEvent(const Event_ConnectionClosed &)));
-    connect(client, SIGNAL(serverShutdownEventReceived(const Event_ServerShutdown &)), this,
-            SLOT(processServerShutdownEvent(const Event_ServerShutdown &)));
+    connect(client, SIGNAL(connectionClosedEventReceived(
+                                   const Event_ConnectionClosed &)), this,
+            SLOT(processConnectionClosedEvent(
+                         const Event_ConnectionClosed &)));
+    connect(client, SIGNAL(serverShutdownEventReceived(
+                                   const Event_ServerShutdown &)), this,
+            SLOT(processServerShutdownEvent(
+                         const Event_ServerShutdown &)));
     connect(client, SIGNAL(loginError(Response::ResponseCode, QString, quint32, QList<QString>)), this,
             SLOT(loginError(Response::ResponseCode, QString, quint32, QList<QString>)));
-    connect(client, SIGNAL(socketError(const QString &)), this, SLOT(socketError(const QString &)));
+    connect(client, SIGNAL(socketError(
+                                   const QString &)), this, SLOT(socketError(
+                                                                         const QString &)));
     connect(client, SIGNAL(serverTimeout()), this, SLOT(serverTimeout()));
     connect(client, SIGNAL(statusChanged(ClientStatus)), this, SLOT(statusChanged(ClientStatus)));
     connect(client, SIGNAL(protocolVersionMismatch(int, int)), this, SLOT(protocolVersionMismatch(int, int)));
-    connect(client, SIGNAL(userInfoChanged(const ServerInfo_User &)), this,
-            SLOT(userInfoReceived(const ServerInfo_User &)), Qt::BlockingQueuedConnection);
+    connect(client, SIGNAL(userInfoChanged(
+                                   const ServerInfo_User &)), this,
+            SLOT(userInfoReceived(
+                         const ServerInfo_User &)), Qt::BlockingQueuedConnection);
     connect(client, SIGNAL(notifyUserAboutUpdate()), this, SLOT(notifyUserAboutUpdate()));
     connect(client, SIGNAL(registerAccepted()), this, SLOT(registerAccepted()));
     connect(client, SIGNAL(registerAcceptedNeedsActivate()), this, SLOT(registerAcceptedNeedsActivate()));
@@ -813,12 +807,14 @@ MainWindow::MainWindow(QWidget *parent)
 
     retranslateUi();
 
-    if (!restoreGeometry(settingsCache->getMainWindowGeometry())) {
+    if (!restoreGeometry(settingsCache->getMainWindowGeometry()))
+    {
         setWindowState(Qt::WindowMaximized);
     }
     aFullScreen->setChecked(static_cast<bool>(windowState() & Qt::WindowFullScreen));
 
-    if (QSystemTrayIcon::isSystemTrayAvailable()) {
+    if (QSystemTrayIcon::isSystemTrayAvailable())
+    {
         createTrayActions();
         createTrayIcon();
     }
@@ -831,14 +827,11 @@ MainWindow::MainWindow(QWidget *parent)
             SLOT(cardDatabaseNewSetsFound(int, QStringList)));
     connect(db, SIGNAL(cardDatabaseAllNewSetsEnabled()), this, SLOT(cardDatabaseAllNewSetsEnabled()));
 
-    if (!settingsCache->getDownloadSpoilersStatus()) {
+    if (!settingsCache->getDownloadSpoilersStatus())
+    {
         qDebug() << "Spoilers Disabled";
         QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
     }
-
-    hps = new HandlePublicServers();
-    connect(hps, SIGNAL(sigPublicServersDownloadedSuccessfully()), this, SLOT(alertUser()));
-    connect(hps, SIGNAL(sigPublicServersDownloadedUnsuccessfully(int)), this, SLOT(alertUser(int)));
 }
 
 MainWindow::~MainWindow()
@@ -1227,9 +1220,9 @@ int MainWindow::getNextCustomSetPrefix(QDir dataDir)
 
 void MainWindow::actManageSets()
 {
-    w = new WndSets;
-    w->setWindowModality(Qt::WindowModal);
-    w->show();
+    wndSets = new WndSets;
+    wndSets->setWindowModality(Qt::WindowModal);
+    wndSets->show();
 }
 
 void MainWindow::actEditTokens()

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -208,21 +208,17 @@ void MainWindow::actRegister()
 void MainWindow::actRefreshServers()
 {
     hps->downloadPublicServers();
-
 }
 
 void MainWindow::alertUser(int errorCode)
 {
-    if (errorCode != -1)
-    {
-        QMessageBox::warning(nullptr, tr("Public Servers NOT Refreshed"), tr("Failed to refresh public servers:")+errorCode);
-    }
-    else
-    {
+    if (errorCode != -1) {
+        QMessageBox::warning(nullptr, tr("Public Servers NOT Refreshed"),
+                             tr("Failed to refresh public servers:") + errorCode);
+    } else {
         QMessageBox::information(nullptr, tr("Public Servers Refreshed"), tr("Public Servers Refreshed"));
     }
 }
-
 
 void MainWindow::actDisconnect()
 {

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -38,6 +38,9 @@ class ServerInfo_User;
 class QThread;
 class DlgViewLog;
 class DlgConnect;
+class HandlePublicServers;
+class WndSets;
+class GameReplay;
 
 class MainWindow : public QMainWindow
 {
@@ -69,6 +72,7 @@ private slots:
     void actDeckEditor();
     void actFullScreen(bool checked);
     void actRegister();
+    void actRefreshServers();
     void actSettings();
     void actExit();
     void actForgotPasswordRequest();
@@ -82,6 +86,7 @@ private slots:
     void iconActivated(QSystemTrayIcon::ActivationReason reason);
     void promptForgotPasswordChallenge();
     void showWindowIfHidden();
+    void alertUser(int errorCode = -1);
 
     void cardUpdateError(QProcess::ProcessError err);
     void cardUpdateFinished(int exitCode, QProcess::ExitStatus exitStatus);
@@ -115,13 +120,13 @@ private:
     };
 
     QList<QMenu *> tabMenus;
-    QMenu *cockatriceMenu, *dbMenu, *helpMenu;
+    QMenu *cockatriceMenu, *dbMenu, *helpMenu, *trayIconMenu;
     QAction *aConnect, *aDisconnect, *aSinglePlayer, *aWatchReplay, *aDeckEditor, *aFullScreen, *aSettings, *aExit,
-        *aAbout, *aTips, *aCheckCardUpdates, *aRegister, *aUpdate, *aViewLog;
+        *aAbout, *aTips, *aCheckCardUpdates, *aRegister, *aUpdate, *aViewLog, *aRefreshServers;
     QAction *aManageSets, *aEditTokens, *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet;
     TabSupervisor *tabSupervisor;
 
-    QMenu *trayIconMenu;
+    WndSets *w;
 
     QAction *closeAction;
 
@@ -138,13 +143,17 @@ private:
 
     DlgConnect *dlgConnect;
 
+    GameReplay *replay;
+
+    HandlePublicServers *hps;
+
 public:
-    MainWindow(QWidget *parent = 0);
-    ~MainWindow();
+    explicit MainWindow(QWidget *parent = nullptr);
+    ~MainWindow() override;
 
 protected:
-    void closeEvent(QCloseEvent *event);
-    void changeEvent(QEvent *event);
+    void closeEvent(QCloseEvent *event) override;
+    void changeEvent(QEvent *event) override;
     QString extractInvalidUsernameMessage(QString &in);
 };
 

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -37,6 +37,7 @@ class LocalServer;
 class ServerInfo_User;
 class QThread;
 class DlgViewLog;
+class DlgConnect;
 
 class MainWindow : public QMainWindow
 {
@@ -134,6 +135,8 @@ private:
     QProcess *cardUpdateProcess;
 
     DlgViewLog *logviewDialog;
+
+    DlgConnect *dlgConnect;
 
 public:
     MainWindow(QWidget *parent = 0);

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -122,7 +122,7 @@ private:
     QList<QMenu *> tabMenus;
     QMenu *cockatriceMenu, *dbMenu, *helpMenu, *trayIconMenu;
     QAction *aConnect, *aDisconnect, *aSinglePlayer, *aWatchReplay, *aDeckEditor, *aFullScreen, *aSettings, *aExit,
-        *aAbout, *aTips, *aCheckCardUpdates, *aRegister, *aUpdate, *aViewLog, *aRefreshServers;
+        *aAbout, *aTips, *aCheckCardUpdates, *aRegister, *aUpdate, *aViewLog;
     QAction *aManageSets, *aEditTokens, *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet;
     TabSupervisor *tabSupervisor;
 

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -30,17 +30,17 @@
 #include "abstractclient.h"
 #include "pb/response.pb.h"
 
-class TabSupervisor;
-class RemoteClient;
+class DlgConnect;
+class DlgViewLog;
+class GameReplay;
+class HandlePublicServers;
 class LocalClient;
 class LocalServer;
-class ServerInfo_User;
 class QThread;
-class DlgViewLog;
-class DlgConnect;
-class HandlePublicServers;
+class RemoteClient;
+class ServerInfo_User;
+class TabSupervisor;
 class WndSets;
-class GameReplay;
 
 class MainWindow : public QMainWindow
 {

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -72,7 +72,6 @@ private slots:
     void actDeckEditor();
     void actFullScreen(bool checked);
     void actRegister();
-    void actRefreshServers();
     void actSettings();
     void actExit();
     void actForgotPasswordRequest();
@@ -86,7 +85,6 @@ private slots:
     void iconActivated(QSystemTrayIcon::ActivationReason reason);
     void promptForgotPasswordChallenge();
     void showWindowIfHidden();
-    void alertUser(int errorCode = -1);
 
     void cardUpdateError(QProcess::ProcessError err);
     void cardUpdateFinished(int exitCode, QProcess::ExitStatus exitStatus);
@@ -122,30 +120,19 @@ private:
     QList<QMenu *> tabMenus;
     QMenu *cockatriceMenu, *dbMenu, *helpMenu, *trayIconMenu;
     QAction *aConnect, *aDisconnect, *aSinglePlayer, *aWatchReplay, *aDeckEditor, *aFullScreen, *aSettings, *aExit,
-        *aAbout, *aTips, *aCheckCardUpdates, *aRegister, *aUpdate, *aViewLog;
+        *aAbout, *aTips, *aCheckCardUpdates, *aRegister, *aUpdate, *aViewLog, *closeAction;
     QAction *aManageSets, *aEditTokens, *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet;
     TabSupervisor *tabSupervisor;
-
-    WndSets *w;
-
-    QAction *closeAction;
-
+    WndSets *wndSets;
     RemoteClient *client;
     QThread *clientThread;
-
     LocalServer *localServer;
     bool bHasActivated;
-
     QMessageBox serverShutdownMessageBox;
     QProcess *cardUpdateProcess;
-
     DlgViewLog *logviewDialog;
-
     DlgConnect *dlgConnect;
-
     GameReplay *replay;
-
-    HandlePublicServers *hps;
 
 public:
     explicit MainWindow(QWidget *parent = nullptr);


### PR DESCRIPTION
Fixes #2226 

This PR will take the servers from the list on <strike>the wiki</strike> [GitHub Public Servers JSON](https://cockatrice.github.io/public-servers.json) and import them to the client, thus removing the dependency on hardcoded values.

When the user "refreshes the servers", we will re-download the list and clear any server not found on the public list.

<img width="624" alt="screenshot 2018-04-08 23 47 24" src="https://user-images.githubusercontent.com/7460172/38478631-1a4aa296-3b88-11e8-8f65-67e8127fc16f.png">
<img width="441" alt="screenshot 2018-04-08 23 47 28" src="https://user-images.githubusercontent.com/7460172/38478632-1a634b52-3b88-11e8-921a-657a8792b01f.png">
