### PR TITLE
change vcredist install option from "/quiet" to "/passive"

### DIFF
--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -199,12 +199,12 @@ ${If} $PortableMode = 0
 
 	IfFileExists "$INSTDIR\vc_redist.x86.exe" VcRedist86Exists PastVcRedist86Check
 	VcRedist86Exists:
-		ExecWait '"$INSTDIR\vc_redist.x86.exe"  /norestart'
+		ExecWait '"$INSTDIR\vc_redist.x86.exe" /passive /norestart'
 	PastVcRedist86Check:
 
 	IfFileExists "$INSTDIR\vc_redist.x64.exe" VcRedist64Exists PastVcRedist64Check
 	VcRedist64Exists:
-		ExecWait '"$INSTDIR\vc_redist.x64.exe"  /norestart'
+		ExecWait '"$INSTDIR\vc_redist.x64.exe" /passive /norestart'
 	PastVcRedist64Check:
 
 ${Else}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -199,12 +199,12 @@ ${If} $PortableMode = 0
 
 	IfFileExists "$INSTDIR\vc_redist.x86.exe" VcRedist86Exists PastVcRedist86Check
 	VcRedist86Exists:
-		ExecWait '"$INSTDIR\vc_redist.x86.exe"  /quiet /norestart'
+		ExecWait '"$INSTDIR\vc_redist.x86.exe"  /norestart'
 	PastVcRedist86Check:
 
 	IfFileExists "$INSTDIR\vc_redist.x64.exe" VcRedist64Exists PastVcRedist64Check
 	VcRedist64Exists:
-		ExecWait '"$INSTDIR\vc_redist.x64.exe"  /quiet /norestart'
+		ExecWait '"$INSTDIR\vc_redist.x64.exe"  /norestart'
 	PastVcRedist64Check:
 
 ${Else}


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3169
- Fixes #3125

## Short roundup of the initial problem
Some users reported problems with the install process. Like it got stuck sometimes or didn't trigger.
Due to the `\quiet` option there was no hint or error message presented to the user.

## What will change with this Pull Request?
- use `\passive` instead
> (from https://github.com/Cockatrice/Cockatrice/issues/3169#issuecomment-379431979)
>
> It pops up a dialog which immediately closes again if it's already installed...
Otherwise it'll show you a dialog with the install progress which automatically closes after it's done.
In @msi1289's case he probably would have seen some kind of error there without the need to check some logs which are placed in the TEMP folder regarding your last screen.

I also tried to remove the `\quiet` option without substitution, but the result was less appealing as described in https://github.com/Cockatrice/Cockatrice/issues/3169#issuecomment-379290427.

Thanks for pointing in the right direction @ctrlaltca 👍 

## Screenshots
![vcinstall](https://user-images.githubusercontent.com/9874850/38454120-3c23b42a-3a61-11e8-9e29-91ded820ffa8.png)
