### PR TITLE
prettify spoiler settings

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -509,7 +509,7 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     connect(mpSpoilerPathButton, SIGNAL(clicked()), this, SLOT(spoilerPathButtonClicked()));
 
     updateNowButton = new QPushButton(tr("Update Spoilers"));
-    updateNowButton->setFixedWidth(120);
+    updateNowButton->setFixedWidth(150);
     connect(updateNowButton, SIGNAL(clicked()), this, SLOT(updateSpoilers()));
 
     // Update the GUI depending on if the box is ticked or not

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -592,7 +592,7 @@ void DeckEditorSettingsPage::setSpoilersEnabled(bool anInput)
     mcSpoilerSaveLabel.setEnabled(anInput);
     mpSpoilerSavePathLineEdit->setEnabled(anInput);
     mpSpoilerPathButton->setEnabled(anInput);
-	lastUpdatedLabel.setEnabled(anInput);
+    lastUpdatedLabel.setEnabled(anInput);
     updateNowButton->setEnabled(anInput);
     infoOnSpoilersLabel.setEnabled(anInput);
 

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -522,7 +522,7 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     lpSpoilerGrid->addWidget(&mcSpoilerSaveLabel, 1, 0);
     lpSpoilerGrid->addWidget(mpSpoilerSavePathLineEdit, 1, 1);
     lpSpoilerGrid->addWidget(mpSpoilerPathButton, 1, 2);
-    lpSpoilerGrid->addWidget(lastUpdateLabel, 2, 0);
+    lpSpoilerGrid->addWidget(lastUpdatedLabel, 2, 0);
     lpSpoilerGrid->addWidget(updateNowButton, 2, 1);
     lpSpoilerGrid->addWidget(&infoOnSpoilersLabel, 3, 0, 1, 3, Qt::AlignTop);
 
@@ -592,7 +592,7 @@ void DeckEditorSettingsPage::setSpoilersEnabled(bool anInput)
     mcSpoilerSaveLabel.setEnabled(anInput);
     mpSpoilerSavePathLineEdit->setEnabled(anInput);
     mpSpoilerPathButton->setEnabled(anInput);
-	lastUpdateLabel.setEnabled(anInput);
+	lastUpdatedLabel.setEnabled(anInput);
     updateNowButton->setEnabled(anInput);
     infoOnSpoilersLabel.setEnabled(anInput);
 
@@ -607,7 +607,7 @@ void DeckEditorSettingsPage::retranslateUi()
     mcDownloadSpoilersCheckBox.setText(tr("Download Spoilers Automatically"));
     mcSpoilerSaveLabel.setText(tr("Spoiler Location:"));
     mcGeneralMessageLabel.setText(tr("Hey, something's here finally!"));
-	lastUpdateLabel.setText(tr("Last Updated") + ": " + getLastUpdateTime());
+    lastUpdatedLabel.setText(tr("Last Updated") + ": " + getLastUpdateTime());
     infoOnSpoilersLabel.setText(tr("Spoilers download automatically on launch") + "\n" +
                                 tr("Press the button to manually update without relaunching") + "\n\n" +
                                 tr("Do not close settings until manual update complete"));

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -522,7 +522,7 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     lpSpoilerGrid->addWidget(&mcSpoilerSaveLabel, 1, 0);
     lpSpoilerGrid->addWidget(mpSpoilerSavePathLineEdit, 1, 1);
     lpSpoilerGrid->addWidget(mpSpoilerPathButton, 1, 2);
-    lpSpoilerGrid->addWidget(lastUpdatedLabel, 2, 0);
+    lpSpoilerGrid->addWidget(&lastUpdatedLabel, 2, 0);
     lpSpoilerGrid->addWidget(updateNowButton, 2, 1);
     lpSpoilerGrid->addWidget(&infoOnSpoilersLabel, 3, 0, 1, 3, Qt::AlignTop);
 

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -519,11 +519,12 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     lpGeneralGrid->addWidget(&mcGeneralMessageLabel, 0, 0);
 
     lpSpoilerGrid->addWidget(&mcDownloadSpoilersCheckBox, 0, 0);
-    lpSpoilerGrid->addWidget(updateNowButton, 0, 2);
     lpSpoilerGrid->addWidget(&mcSpoilerSaveLabel, 1, 0);
     lpSpoilerGrid->addWidget(mpSpoilerSavePathLineEdit, 1, 1);
     lpSpoilerGrid->addWidget(mpSpoilerPathButton, 1, 2);
-    lpSpoilerGrid->addWidget(&infoOnSpoilersLabel, 2, 0, 1, 3, Qt::AlignTop);
+	lpSpoilerGrid->addWidget(lastUpdateLabel, 2, 0);
+    lpSpoilerGrid->addWidget(updateNowButton, 2, 1);
+    lpSpoilerGrid->addWidget(&infoOnSpoilersLabel, 3, 0, 1, 3, Qt::AlignTop);
 
     // On a change to the check box, hide/unhide the other fields
     connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), settingsCache, SLOT(setDownloadSpoilerStatus(bool)));
@@ -591,6 +592,7 @@ void DeckEditorSettingsPage::setSpoilersEnabled(bool anInput)
     mcSpoilerSaveLabel.setEnabled(anInput);
     mpSpoilerSavePathLineEdit->setEnabled(anInput);
     mpSpoilerPathButton->setEnabled(anInput);
+	lastUpdateLabel.setEnabled(anInput);
     updateNowButton->setEnabled(anInput);
     infoOnSpoilersLabel.setEnabled(anInput);
 
@@ -605,8 +607,8 @@ void DeckEditorSettingsPage::retranslateUi()
     mcDownloadSpoilersCheckBox.setText(tr("Download Spoilers Automatically"));
     mcSpoilerSaveLabel.setText(tr("Spoiler Location:"));
     mcGeneralMessageLabel.setText(tr("Hey, something's here finally!"));
-    infoOnSpoilersLabel.setText(tr("Last Updated") + ": " + getLastUpdateTime() + "\n\n" +
-                                tr("Spoilers download automatically on launch") + "\n" +
+	lastUpdateLabel.setText(tr("Last Updated") + ": " + getLastUpdateTime());
+    infoOnSpoilersLabel.setText(tr("Spoilers download automatically on launch") + "\n" +
                                 tr("Press the button to manually update without relaunching") + "\n\n" +
                                 tr("Do not close settings until manual update complete"));
 }

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -522,7 +522,7 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     lpSpoilerGrid->addWidget(&mcSpoilerSaveLabel, 1, 0);
     lpSpoilerGrid->addWidget(mpSpoilerSavePathLineEdit, 1, 1);
     lpSpoilerGrid->addWidget(mpSpoilerPathButton, 1, 2);
-	lpSpoilerGrid->addWidget(lastUpdateLabel, 2, 0);
+    lpSpoilerGrid->addWidget(lastUpdateLabel, 2, 0);
     lpSpoilerGrid->addWidget(updateNowButton, 2, 1);
     lpSpoilerGrid->addWidget(&infoOnSpoilersLabel, 3, 0, 1, 3, Qt::AlignTop);
 

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -556,6 +556,7 @@ void DeckEditorSettingsPage::updateSpoilers()
 void DeckEditorSettingsPage::unlockSettings()
 {
     updateNowButton->setDisabled(false);
+    updateNowButton->setFixedWidth(200);
     updateNowButton->setText(tr("Update Spoilers"));
 }
 

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -509,7 +509,7 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     connect(mpSpoilerPathButton, SIGNAL(clicked()), this, SLOT(spoilerPathButtonClicked()));
 
     updateNowButton = new QPushButton(tr("Update Spoilers"));
-    updateNowButton->setFixedWidth(200);
+    updateNowButton->setFixedWidth(120);
     connect(updateNowButton, SIGNAL(clicked()), this, SLOT(updateSpoilers()));
 
     // Update the GUI depending on if the box is ticked or not

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -509,6 +509,7 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     connect(mpSpoilerPathButton, SIGNAL(clicked()), this, SLOT(spoilerPathButtonClicked()));
 
     updateNowButton = new QPushButton(tr("Update Spoilers"));
+    updateNowButton->setFixedWidth(200);
     connect(updateNowButton, SIGNAL(clicked()), this, SLOT(updateSpoilers()));
 
     // Update the GUI depending on if the box is ticked or not
@@ -556,7 +557,6 @@ void DeckEditorSettingsPage::updateSpoilers()
 void DeckEditorSettingsPage::unlockSettings()
 {
     updateNowButton->setDisabled(false);
-    updateNowButton->setFixedWidth(200);
     updateNowButton->setText(tr("Update Spoilers"));
 }
 

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -156,6 +156,7 @@ private:
     QLineEdit *mpSpoilerSavePathLineEdit;
     QLabel mcSpoilerSaveLabel;
     QLabel mcGeneralMessageLabel;
+    QLabel lastUpdatedLabel
     QLabel infoOnSpoilersLabel;
     QPushButton *mpSpoilerPathButton;
     QPushButton *updateNowButton;

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -156,7 +156,7 @@ private:
     QLineEdit *mpSpoilerSavePathLineEdit;
     QLabel mcSpoilerSaveLabel;
     QLabel mcGeneralMessageLabel;
-    QLabel lastUpdatedLabel
+    QLabel lastUpdatedLabel;
     QLabel infoOnSpoilersLabel;
     QPushButton *mpSpoilerPathButton;
     QPushButton *updateNowButton;


### PR DESCRIPTION
## Short roundup of the initial problem
The button jumped in size with all related column.
Now also placed right next to the last updated field.

## What will change with this Pull Request?
- moved button location
- fixed button width

## Screenshots
- normal button:
![after1](https://user-images.githubusercontent.com/9874850/38505694-17a7ccea-3c18-11e8-995d-724bfd09899d.png)

- clicked button - processing:
![after2](https://user-images.githubusercontent.com/9874850/38505709-1ede11e0-3c18-11e8-9b2a-774be978862e.png)
