### PR TITLE
server site added to connect window

### DIFF
--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -75,7 +75,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     connect(savePasswordCheckBox, SIGNAL(stateChanged(int)), this, SLOT(passwordSaved(int)));
 
     serverIssuesLabel =
-        new QLabel(tr("If you have any trouble connecting or registering the you should contact the server staff."));
+        new QLabel(tr("If you have any trouble connecting or registering then contact the server staff for help!"));
     serverIssuesLabel->setWordWrap(true);
     serverContactLink = new QLabel;
     serverContactLink->setTextFormat(Qt::RichText);

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -38,33 +38,32 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     newHostButton = new QRadioButton(tr("New Host"), this);
 
     saveLabel = new QLabel(tr("Name:"));
-    saveEdit = new QLineEdit(settingsCache->servers().getSaveName());
+    saveEdit = new QLineEdit;
     saveLabel->setBuddy(saveEdit);
 
     hostLabel = new QLabel(tr("&Host:"));
-    hostEdit = new QLineEdit(settingsCache->servers().getHostname());
+    hostEdit = new QLineEdit;
     hostLabel->setBuddy(hostEdit);
 
     portLabel = new QLabel(tr("&Port:"));
-    portEdit = new QLineEdit(settingsCache->servers().getPort("4747"));
+    portEdit = new QLineEdit;
     portLabel->setBuddy(portEdit);
 
     playernameLabel = new QLabel(tr("Player &name:"));
-    playernameEdit = new QLineEdit(settingsCache->servers().getPlayerName("Player"));
+    playernameEdit = new QLineEdit;
     playernameLabel->setBuddy(playernameEdit);
 
     passwordLabel = new QLabel(tr("P&assword:"));
-    passwordEdit = new QLineEdit(settingsCache->servers().getPassword());
+    passwordEdit = new QLineEdit;
     passwordLabel->setBuddy(passwordEdit);
     passwordEdit->setEchoMode(QLineEdit::Password);
 
     savePasswordCheckBox = new QCheckBox(tr("&Save password"));
-    savePasswordCheckBox->setChecked(settingsCache->servers().getSavePassword());
 
     autoConnectCheckBox = new QCheckBox(tr("A&uto connect"));
     autoConnectCheckBox->setToolTip(tr("Automatically connect to the most recent login when Cockatrice opens"));
 
-    if (savePasswordCheckBox->isChecked()) {
+    if (settingsCache->servers().getSavePassword()) {
         autoConnectCheckBox->setChecked(static_cast<bool>(settingsCache->servers().getAutoConnect()));
         autoConnectCheckBox->setEnabled(true);
     } else {
@@ -74,6 +73,16 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     }
 
     connect(savePasswordCheckBox, SIGNAL(stateChanged(int)), this, SLOT(passwordSaved(int)));
+
+    serverIssuesLabel =
+        new QLabel(tr("If you have any trouble connecting or registering the you should contact the server staff."));
+    serverIssuesLabel->setWordWrap(true);
+    serverContactLink = new QLabel;
+    serverContactLink->setTextFormat(Qt::RichText);
+    serverContactLink->setTextInteractionFlags(Qt::TextBrowserInteraction);
+    serverContactLink->setOpenExternalLinks(true);
+
+    updateDisplayInfo(previousHosts->currentText());
 
     btnForgotPassword = new QPushButton(tr("Forgot password"));
     connect(btnForgotPassword, SIGNAL(released()), this, SLOT(actForgotPassword()));
@@ -110,6 +119,10 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     restrictionsGroupBox = new QGroupBox(tr("Server"));
     restrictionsGroupBox->setLayout(connectionLayout);
 
+    serverInfoLayout = new QGridLayout;
+    serverInfoLayout->addWidget(serverIssuesLabel, 0, 0);
+    serverInfoLayout->addWidget(serverContactLink, 1, 0);
+
     loginLayout = new QGridLayout;
     loginLayout->addWidget(playernameLabel, 0, 0);
     loginLayout->addWidget(playernameEdit, 0, 1);
@@ -120,13 +133,17 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     loginGroupBox = new QGroupBox(tr("Login"));
     loginGroupBox->setLayout(loginLayout);
 
+    serverInfoGroupBox = new QGroupBox(tr("Server info"));
+    serverInfoGroupBox->setLayout(serverInfoLayout);
+
     btnGroupBox = new QGroupBox(tr(""));
     btnGroupBox->setLayout(buttons);
 
     grid = new QGridLayout;
     grid->addWidget(restrictionsGroupBox, 0, 0);
     grid->addWidget(loginGroupBox, 1, 0);
-    grid->addWidget(btnGroupBox, 2, 0);
+    grid->addWidget(serverInfoGroupBox, 2, 0);
+    grid->addWidget(btnGroupBox, 3, 0);
 
     mainLayout = new QVBoxLayout;
     mainLayout->addLayout(grid);
@@ -239,6 +256,13 @@ void DlgConnect::updateDisplayInfo(const QString &saveName)
 
     if (savePasswordStatus) {
         passwordEdit->setText(data.at(4));
+    }
+
+    if (!data.at(6).isEmpty()) {
+        QString formattedLink = "<a href=\"" + data.at(6) + "\">" + data.at(0) + "</a>";
+        serverContactLink->setText(formattedLink);
+    } else {
+        serverContactLink->setText("");
     }
 }
 

--- a/cockatrice/src/dlg_connect.h
+++ b/cockatrice/src/dlg_connect.h
@@ -61,11 +61,11 @@ private slots:
     void downloadThePublicServers();
 
 private:
-    QGridLayout *newHostLayout, *connectionLayout, *buttons, *loginLayout, *grid;
+    QGridLayout *newHostLayout, *connectionLayout, *buttons, *loginLayout, *serverInfoLayout, *grid;
     QHBoxLayout *newHolderLayout;
-    QGroupBox *loginGroupBox, *btnGroupBox, *restrictionsGroupBox;
+    QGroupBox *loginGroupBox, *serverInfoGroupBox, *btnGroupBox, *restrictionsGroupBox;
     QVBoxLayout *mainLayout;
-    QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *saveLabel;
+    QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *saveLabel, *serverIssuesLabel, *serverContactLink;
     QLineEdit *hostEdit, *portEdit, *playernameEdit, *passwordEdit, *saveEdit;
     QCheckBox *savePasswordCheckBox, *autoConnectCheckBox;
     QComboBox *previousHosts;

--- a/cockatrice/src/handle_public_servers.cpp
+++ b/cockatrice/src/handle_public_servers.cpp
@@ -72,6 +72,7 @@ void HandlePublicServers::updateServerINISettings(QMap<QString, QVariant> jsonMa
 
         QString serverName = serverMap["name"].toString();
         QString serverPort = serverMap["port"].toString();
+        QString serverSite = serverMap["site"].toString();
 
         bool serverFound = false;
         for (const auto &iter : savedHostList) {
@@ -83,7 +84,7 @@ void HandlePublicServers::updateServerINISettings(QMap<QString, QVariant> jsonMa
         }
 
         if (serverFound) {
-            settingsCache->servers().updateExistingServerWithoutLoss(serverName, serverAddress, serverPort);
+            settingsCache->servers().updateExistingServerWithoutLoss(serverName, serverAddress, serverPort, serverSite);
         } else {
             settingsCache->servers().addNewServer(serverName, serverAddress, serverPort, "", "", false);
         }

--- a/cockatrice/src/settings/serverssettings.cpp
+++ b/cockatrice/src/settings/serverssettings.cpp
@@ -40,6 +40,13 @@ QString ServersSettings::getSaveName(QString defaultname)
     return saveName == QVariant() ? std::move(defaultname) : saveName.toString();
 }
 
+QString ServersSettings::getSite(QString defaultSite)
+{
+    int index = getPrevioushostindex(getPrevioushostName());
+    QVariant site = getValue(QString("site%1").arg(index), "server", "server_details");
+    return site == QVariant() ? std::move(defaultSite) : site.toString();
+}
+
 QString ServersSettings::getPrevioushostName()
 {
     return getValue("previoushostName", "server").toString();
@@ -181,9 +188,10 @@ void ServersSettings::addNewServer(const QString &saveName,
                                    const QString &port,
                                    const QString &username,
                                    const QString &password,
-                                   bool savePassword)
+                                   bool savePassword,
+                                   const QString &site)
 {
-    if (updateExistingServer(saveName, serv, port, username, password, savePassword))
+    if (updateExistingServer(saveName, serv, port, username, password, savePassword, site))
         return;
 
     int index = getValue("totalServers", "server", "server_details").toInt() + 1;
@@ -195,6 +203,7 @@ void ServersSettings::addNewServer(const QString &saveName,
     setValue(savePassword, QString("savePassword%1").arg(index), "server", "server_details");
     setValue(index, "totalServers", "server", "server_details");
     setValue(password, QString("password%1").arg(index), "server", "server_details");
+    setValue(site, QString("site%1").arg(index), "server", "server_details");
 }
 
 void ServersSettings::removeServer(QString servAddr)
@@ -209,6 +218,7 @@ void ServersSettings::removeServer(QString servAddr)
             deleteValue(QString("savePassword%1").arg(i), "server", "server_details");
             deleteValue(QString("password%1").arg(i), "server", "server_details");
             deleteValue(QString("saveName%1").arg(i), "server", "server_details");
+            deleteValue(QString("site%1").arg(i), "server", "server_details");
             return;
         }
     }
@@ -220,6 +230,7 @@ void ServersSettings::removeServer(QString servAddr)
 bool ServersSettings::updateExistingServerWithoutLoss(QString saveName,
                                                       QString serv,
                                                       QString port,
+                                                      QString site,
                                                       QString username,
                                                       QString password,
                                                       bool savePassword)
@@ -243,6 +254,10 @@ bool ServersSettings::updateExistingServerWithoutLoss(QString saveName,
                 setValue(QString(), QString("password%1").arg(i), "server", "server_details");
             }
 
+            if (!site.isEmpty()) {
+                setValue(site, QString("site%1").arg(i), "server", "server_details");
+            }
+
             setValue(savePassword, QString("savePassword%1").arg(i), "server", "server_details");
             setValue(saveName, QString("saveName%1").arg(i), "server", "server_details");
 
@@ -257,8 +272,9 @@ bool ServersSettings::updateExistingServer(QString saveName,
                                            QString port,
                                            QString username,
                                            QString password,
-                                           bool savePassword)
+                                           bool savePassword,
+                                           QString site)
 {
-    return updateExistingServerWithoutLoss(std::move(saveName), std::move(serv), std::move(port), std::move(username),
-                                           std::move(password), savePassword);
+    return updateExistingServerWithoutLoss(std::move(saveName), std::move(serv), std::move(port), std::move(site),
+                                           std::move(username), std::move(password), savePassword);
 }

--- a/cockatrice/src/settings/serverssettings.h
+++ b/cockatrice/src/settings/serverssettings.h
@@ -22,6 +22,7 @@ public:
     QString getFPPlayerName(QString defaultName = "");
     QString getPassword();
     QString getSaveName(QString defaultname = "");
+    QString getSite(QString defaultName = "");
     bool getSavePassword();
     int getAutoConnect();
 
@@ -32,6 +33,7 @@ public:
     void setPort(QString port);
     void setPlayerName(QString playerName);
     void setAutoConnect(int autoconnect);
+    void setSite(QString site);
     void setFPHostName(QString hostname);
     void setPassword(QString password);
     void setFPPort(QString port);
@@ -42,18 +44,21 @@ public:
                       const QString &port,
                       const QString &username,
                       const QString &password,
-                      bool savePassword);
+                      bool savePassword,
+                      const QString &site = QString());
     void removeServer(QString servAddr);
     bool updateExistingServer(QString saveName,
                               QString serv,
                               QString port,
                               QString username,
                               QString password,
-                              bool savePassword);
+                              bool savePassword,
+                              QString site = QString());
 
     bool updateExistingServerWithoutLoss(QString saveName,
                                          QString serv = QString(),
                                          QString port = QString(),
+                                         QString site = QString(),
                                          QString username = QString(),
                                          QString password = QString(),
                                          bool savePassword = true);

--- a/cockatrice/src/userconnection_information.cpp
+++ b/cockatrice/src/userconnection_information.cpp
@@ -10,9 +10,10 @@ UserConnection_Information::UserConnection_Information(QString _saveName,
                                                        QString _portNum,
                                                        QString _userName,
                                                        QString _pass,
-                                                       bool _savePass)
+                                                       bool _savePass,
+                                                       QString _site)
     : saveName(std::move(_saveName)), server(std::move(_serverName)), port(std::move(_portNum)),
-      username(std::move(_userName)), password(std::move(_pass)), savePassword(_savePass)
+      username(std::move(_userName)), password(std::move(_pass)), savePassword(_savePass), site(std::move(_site))
 {
 }
 
@@ -35,8 +36,10 @@ QMap<QString, std::pair<QString, UserConnection_Information>> UserConnection_Inf
             settingsCache->servers().getValue(QString("password%1").arg(i), "server", "server_details").toString();
         bool savePass =
             settingsCache->servers().getValue(QString("savePassword%1").arg(i), "server", "server_details").toBool();
+        QString site =
+            settingsCache->servers().getValue(QString("site%1").arg(i), "server", "server_details").toString();
 
-        UserConnection_Information userInfo(saveName, serverName, portNum, userName, pass, savePass);
+        UserConnection_Information userInfo(saveName, serverName, portNum, userName, pass, savePass, site);
         serverList.insert(saveName, std::make_pair(serverName, userInfo));
     }
 
@@ -65,6 +68,8 @@ QStringList UserConnection_Information::getServerInfo(const QString &find)
             settingsCache->servers().getValue(QString("password%1").arg(i), "server", "server_details").toString();
         bool savePass =
             settingsCache->servers().getValue(QString("savePassword%1").arg(i), "server", "server_details").toBool();
+        QString site =
+            settingsCache->servers().getValue(QString("site%1").arg(i), "server", "server_details").toString();
 
         server.append(saveName);
         server.append(serverName);
@@ -72,6 +77,7 @@ QStringList UserConnection_Information::getServerInfo(const QString &find)
         server.append(userName);
         server.append(pass);
         server.append(savePass ? "1" : "0");
+        server.append(site);
         break;
     }
 

--- a/cockatrice/src/userconnection_information.h
+++ b/cockatrice/src/userconnection_information.h
@@ -15,8 +15,8 @@ private:
     QString port;
     QString username;
     QString password;
-    QString site;
     bool savePassword;
+    QString site;
     bool isCustom;
 
 public:

--- a/cockatrice/src/userconnection_information.h
+++ b/cockatrice/src/userconnection_information.h
@@ -15,12 +15,13 @@ private:
     QString port;
     QString username;
     QString password;
+    QString site;
     bool savePassword;
     bool isCustom;
 
 public:
     UserConnection_Information();
-    UserConnection_Information(QString, QString, QString, QString, QString, bool);
+    UserConnection_Information(QString, QString, QString, QString, QString, bool, QString);
     QString getSaveName() const
     {
         return saveName;
@@ -44,6 +45,10 @@ public:
     bool getSavePassword() const
     {
         return savePassword;
+    }
+    QString getSite() const
+    {
+        return site;
     }
     QMap<QString, std::pair<QString, UserConnection_Information>> getServerInfo();
     QStringList getServerInfo(const QString &find);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2906 

## What will change with this Pull Request?
The sites set in the public servers JSON are saved in the user's settings and showed as links on the connect window.

## Screenshots
With official servers after a refresh:
![image](https://user-images.githubusercontent.com/9273978/38584283-1d9e9224-3d16-11e8-964c-89545d6ff19e.png)
With custom servers:
![image](https://user-images.githubusercontent.com/9273978/38584298-29552196-3d16-11e8-890e-3db7cbd2933b.png)
