### PR TITLE
[NO MERGE] Debugging Popups

### DIFF
--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -162,17 +162,31 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
     // If the user has notifications enabled, let them know
     // when the database was last updated
     if (trayIcon) {
+        qDebug() << "[SBU]"
+                 << "Attempting to display";
         QList<QByteArray> lines = data.split('\n');
 
-        foreach (QByteArray line, lines) {
+        for (const QByteArray &line : lines) {
+            qDebug() << "[SBU]"
+                     << "LINE:" << line;
             if (line.indexOf("created:") > -1) {
                 QString timeStamp = QString(line).replace("created:", "").trimmed();
+                qDebug() << "[SBU]"
+                         << "TIMESTAMP BEFORE CHOMP:" << timeStamp;
                 timeStamp.chop(6); // Remove " (UTC)"
+                qDebug() << "[SBU]"
+                         << "TIMESTAMP AFTER CHOMP:" << timeStamp;
 
                 auto utcTime = QDateTime::fromString(timeStamp, QString("ddd, MMM dd yyyy, hh:mm:ss"));
+                qDebug() << "[SBU]"
+                         << "TIME BEFORE TIMEZONE" << utcTime;
                 utcTime.setTimeSpec(Qt::UTC);
+                qDebug() << "[SBU]"
+                         << "TIME AFTER TIMEZONE" << utcTime;
 
                 QString localTime = utcTime.toLocalTime().toString("MMM d, hh:mm");
+                qDebug() << "[SBU]"
+                         << "LOCAL TIME (WHAT SHOULD BE CORRECT):" << localTime;
 
                 trayIcon->showMessage(tr("Spoilers have been updated!"), tr("Last change:") + " " + localTime);
                 emit spoilersUpdatedSuccessfully();


### PR DESCRIPTION
Debug build for Windows/Linux trial.

1) Delete local spoiler.xml that was written by system
2) Restart client
3) View debug logs

```
macOS 10.13.4:
[SBU] Attempting to display
CardDatabase::loadCardDatabases start
[SBU] LINE: "<?xml version=\"1.0\" ?><cockatrice_carddatabase version=\"3\">\t"
[SBU] LINE: "\t<!--"
[SBU] LINE: "        created: Tue, Apr 10 2018, 19:34:21 (UTC)"
[SBU] TIMESTAMP BEFORE CHOMP: "Tue, Apr 10 2018, 19:34:21 (UTC)"
[SBU] TIMESTAMP AFTER CHOMP: "Tue, Apr 10 2018, 19:34:21"
[SBU] TIME BEFORE TIMEZONE QDateTime(2018-04-10 19:34:21.000 EDT Qt::TimeSpec(LocalTime))
[SBU] TIME AFTER TIMEZONE QDateTime(2018-04-10 19:34:21.000 UTC Qt::TimeSpec(UTC))
[SBU] LOCAL TIME (WHAT SHOULD BE CORRECT): "Apr 10, 15:34"
```