### PR TITLE
datetime display fixed for OSs with non-English localization

### DIFF
--- a/cockatrice/src/logger.cpp
+++ b/cockatrice/src/logger.cpp
@@ -1,6 +1,7 @@
 #include "logger.h"
 #include "version_string.h"
 #include <QDateTime>
+#include <QLocale>
 #include <iostream>
 
 #define LOGGER_MAX_ENTRIES 128
@@ -14,6 +15,7 @@ Logger::Logger() : logToFileEnabled(false)
 {
     logBuffer.append(getClientVersion());
     logBuffer.append(getSystemArchitecture());
+    logBuffer.append(getSystemLocale());
     std::cerr << getClientVersion().toStdString() << std::endl;
     std::cerr << getSystemArchitecture().toStdString() << std::endl;
 }
@@ -105,4 +107,11 @@ QString Logger::getClientOperatingSystem()
 #endif
 
     return {};
+}
+
+QString Logger::getSystemLocale()
+{
+    QString result;
+    result.append(tr("System Locale") + ": " + QLocale().name());
+    return result;
 }

--- a/cockatrice/src/logger.h
+++ b/cockatrice/src/logger.h
@@ -32,6 +32,7 @@ public:
     QString getClientVersion();
     QString getClientOperatingSystem();
     QString getSystemArchitecture();
+    QString getSystemLocale();
     QList<QString> getLogBuffer()
     {
         return logBuffer;

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -70,7 +70,7 @@ void installNewTranslator()
     qApp->installTranslator(qtTranslator);
     translator->load(translationPrefix + "_" + lang, translationPath);
     qApp->installTranslator(translator);
-    qDebug() << "Language changed: " << lang;
+    qDebug() << "Language changed:" << lang;
 }
 
 QString const generateClientID()

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -92,7 +92,6 @@ int main(int argc, char *argv[])
     qInstallMessageHandler(CockatriceLogger);
     if (app.arguments().contains("--debug-output"))
         Logger::getInstance().logToFile(true);
-    QLocale::setDefault(QLocale::English);
 
 #ifdef Q_OS_WIN
     app.addLibraryPath(app.applicationDirPath() + "/plugins");
@@ -123,6 +122,8 @@ int main(int argc, char *argv[])
     qtTranslator = new QTranslator;
     translator = new QTranslator;
     installNewTranslator();
+
+    QLocale::setDefault(QLocale::English);
 
     qsrand(QDateTime::currentDateTime().toTime_t());
     qDebug("main(): starting main program");

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -39,6 +39,7 @@
 #include <QDir>
 #include <QFile>
 #include <QLibraryInfo>
+#include <QLocale>
 #include <QSystemTrayIcon>
 #include <QTextCodec>
 #include <QTextStream>
@@ -85,6 +86,7 @@ QString const generateClientID()
 
 int main(int argc, char *argv[])
 {
+    QLocale::setDefault(QLocale::English);
     QApplication app(argc, argv);
 
     qInstallMessageHandler(CockatriceLogger);

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -70,6 +70,7 @@ void installNewTranslator()
     qApp->installTranslator(qtTranslator);
     translator->load(translationPrefix + "_" + lang, translationPath);
     qApp->installTranslator(translator);
+    qDebug() << "Language changed: " << lang;
 }
 
 QString const generateClientID()
@@ -86,12 +87,12 @@ QString const generateClientID()
 
 int main(int argc, char *argv[])
 {
-    QLocale::setDefault(QLocale::English);
     QApplication app(argc, argv);
 
     qInstallMessageHandler(CockatriceLogger);
     if (app.arguments().contains("--debug-output"))
         Logger::getInstance().logToFile(true);
+    QLocale::setDefault(QLocale::English);
 
 #ifdef Q_OS_WIN
     app.addLibraryPath(app.applicationDirPath() + "/plugins");

--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -3,6 +3,7 @@
 #include <QDateTime>
 #include <QDebug>
 #include <QFile>
+#include <QLocale>
 #include <QMessageBox>
 #include <QNetworkReply>
 #include <QUrl>
@@ -165,11 +166,11 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
         QList<QByteArray> lines = data.split('\n');
 
         foreach (QByteArray line, lines) {
-            if (line.indexOf("created:") > -1) {
+            if (line.contains("created:")) {
                 QString timeStamp = QString(line).replace("created:", "").trimmed();
                 timeStamp.chop(6); // Remove " (UTC)"
 
-                auto utcTime = QDateTime::fromString(timeStamp, QString("ddd, MMM dd yyyy, hh:mm:ss"));
+                auto utcTime = QLocale().toDateTime(timeStamp, "ddd, MMM dd yyyy, hh:mm:ss");
                 utcTime.setTimeSpec(Qt::UTC);
 
                 QString localTime = utcTime.toLocalTime().toString("MMM d, hh:mm");


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3140 

## Short roundup of the initial problem
Time of last spoiler update was not displayed on OS-s where the localization was set to other than English. 

`QDateTime::fromString()` method tries to parse the given string based on the OS's default localization setting, which caused an invalid date, since the string was in English. Setting `QLocale` default to English and using it to parse dates instead of `QDateTime` solved the problem.

## Screenshots
![image](https://user-images.githubusercontent.com/9273978/38828011-005571ee-41b5-11e8-921c-cee3157df8d3.png)