### PR TITLE
connect dialog tweaks

### DIFF
--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -123,7 +123,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     serverInfoLayout = new QGridLayout;
     serverInfoLayout->addWidget(serverIssuesLabel, 0, 0, 1, 3, Qt::AlignTop);
     serverInfoLayout->addWidget(serverContactLabel, 1, 0);
-    serverInfoLayout->addWidget(serverContactLink, 1, 1, 1, 3, Qt::AlignLeft);
+    serverInfoLayout->addWidget(serverContactLink, 1, 1, 1, 2, Qt::AlignLeft);
 
     loginLayout = new QGridLayout;
     loginLayout->addWidget(playernameLabel, 0, 0);

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -26,7 +26,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     btnRefreshServers = new QPushButton(this);
     btnRefreshServers->setIcon(QPixmap("theme:icons/update"));
     btnRefreshServers->setToolTip(tr("Refresh the server list with known public servers"));
-    btnRefreshServers->setFixedWidth(50);
+    btnRefreshServers->setFixedWidth(40);
 
     connect(hps, SIGNAL(sigPublicServersDownloadedSuccessfully()), this, SLOT(rebuildComboBoxList()));
     connect(hps, SIGNAL(sigPublicServersDownloadedUnsuccessfully(int)), this, SLOT(rebuildComboBoxList(int)));
@@ -232,6 +232,8 @@ void DlgConnect::previousHostSelected(bool state)
 {
     if (state) {
         saveEdit->setDisabled(true);
+        hostEdit->setDisabled(true);
+        portEdit->setDisabled(true);
         previousHosts->setDisabled(false);
         btnRefreshServers->setDisabled(false);
     }
@@ -272,12 +274,16 @@ void DlgConnect::newHostSelected(bool state)
         previousHosts->setDisabled(true);
         btnRefreshServers->setDisabled(true);
         hostEdit->clear();
+        hostEdit->setPlaceholderText("Server URL for Connecting");
+        hostEdit->setDisabled(false);
         portEdit->clear();
+        portEdit->setPlaceholderText("Communication Port");
+        portEdit->setDisabled(false);
         playernameEdit->clear();
         passwordEdit->clear();
         savePasswordCheckBox->setChecked(false);
         saveEdit->clear();
-        saveEdit->setPlaceholderText("New Menu Name");
+        saveEdit->setPlaceholderText("New Name in Server List");
         saveEdit->setDisabled(false);
     } else {
         preRebuildComboBoxList();

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -238,7 +238,6 @@ void DlgConnect::previousHostSelected(bool state)
         portEdit->setDisabled(true);
         previousHosts->setDisabled(false);
         btnRefreshServers->setDisabled(false);
-        savePasswordCheckBox->setChecked(false);
     }
 }
 
@@ -286,7 +285,6 @@ void DlgConnect::newHostSelected(bool state)
         portEdit->setDisabled(false);
         playernameEdit->clear();
         passwordEdit->clear();
-        savePasswordCheckBox->setChecked(false);
         saveEdit->clear();
         saveEdit->setPlaceholderText("Unique Server Name");
         saveEdit->setDisabled(false);

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -26,6 +26,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     btnRefreshServers = new QPushButton(this);
     btnRefreshServers->setIcon(QPixmap("theme:icons/update"));
     btnRefreshServers->setToolTip(tr("Refresh the server list with known public servers"));
+    btnRefreshServers->setFixedWidth(30);
 
     connect(hps, SIGNAL(sigPublicServersDownloadedSuccessfully()), this, SLOT(rebuildComboBoxList()));
     connect(hps, SIGNAL(sigPublicServersDownloadedUnsuccessfully(int)), this, SLOT(rebuildComboBoxList(int)));

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -135,7 +135,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     loginGroupBox = new QGroupBox(tr("Login"));
     loginGroupBox->setLayout(loginLayout);
 
-    serverInfoGroupBox = new QGroupBox(tr("Contact Hint"));
+    serverInfoGroupBox = new QGroupBox(tr("Server Contact"));
     serverInfoGroupBox->setLayout(serverInfoLayout);
 
     btnGroupBox = new QGroupBox(tr(""));
@@ -264,7 +264,8 @@ void DlgConnect::updateDisplayInfo(const QString &saveName)
     }
 
     if (!data.at(6).isEmpty()) {
-        QString formattedLink = "<a href=\"" + data.at(6) + "\">" + data.at(0) + "</a>";
+        QString formattedLink = "<a href=\"" + data.at(6) + "\">" + data.at(6) + "</a>";
+        serverContactLabel->setText(tr("Webpage") + ":");
         serverContactLink->setText(formattedLink);
     } else {
         serverContactLabel->setText("");

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -123,7 +123,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     serverInfoLayout = new QGridLayout;
     serverInfoLayout->addWidget(serverIssuesLabel, 0, 0, 1, 3, Qt::AlignTop);
     serverInfoLayout->addWidget(serverContactLabel, 1, 0);
-    serverInfoLayout->addWidget(serverContactLink, 1, 1);
+    serverInfoLayout->addWidget(serverContactLink, 1, 1, Qt::AlignLeft);
 
     loginLayout = new QGridLayout;
     loginLayout->addWidget(playernameLabel, 0, 0);

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -121,9 +121,9 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     restrictionsGroupBox->setLayout(connectionLayout);
 
     serverInfoLayout = new QGridLayout;
-    serverInfoLayout->addWidget(serverIssuesLabel, 0, 0, 1, 3, Qt::AlignTop);
+    serverInfoLayout->addWidget(serverIssuesLabel, 0, 0, 1, 4, Qt::AlignTop);
     serverInfoLayout->addWidget(serverContactLabel, 1, 0);
-    serverInfoLayout->addWidget(serverContactLink, 1, 1, 1, 2, Qt::AlignLeft);
+    serverInfoLayout->addWidget(serverContactLink, 1, 1, 1, 3);
 
     loginLayout = new QGridLayout;
     loginLayout->addWidget(playernameLabel, 0, 0);

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -123,7 +123,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     serverInfoLayout = new QGridLayout;
     serverInfoLayout->addWidget(serverIssuesLabel, 0, 0, 1, 3, Qt::AlignTop);
     serverInfoLayout->addWidget(serverContactLabel, 1, 0);
-    serverInfoLayout->addWidget(serverContactLink, 1, 1, 1, 3, Qt::AlignTop);
+    serverInfoLayout->addWidget(serverContactLink, 1, 1, 0, -1);
 
     loginLayout = new QGridLayout;
     loginLayout->addWidget(playernameLabel, 0, 0);

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -267,6 +267,7 @@ void DlgConnect::updateDisplayInfo(const QString &saveName)
         QString formattedLink = "<a href=\"" + data.at(6) + "\">" + data.at(0) + "</a>";
         serverContactLink->setText(formattedLink);
     } else {
+        serverContactLabel->setText("");
         serverContactLink->setText("");
     }
 }
@@ -288,6 +289,8 @@ void DlgConnect::newHostSelected(bool state)
         saveEdit->clear();
         saveEdit->setPlaceholderText("Unique Server Name");
         saveEdit->setDisabled(false);
+        serverContactLabel->setText("");
+        serverContactLink->setText("");
     } else {
         preRebuildComboBoxList();
     }

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -26,7 +26,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     btnRefreshServers = new QPushButton(this);
     btnRefreshServers->setIcon(QPixmap("theme:icons/update"));
     btnRefreshServers->setToolTip(tr("Refresh the server list with known public servers"));
-    btnRefreshServers->setFixedWidth(40);
+    btnRefreshServers->setFixedWidth(30);
 
     connect(hps, SIGNAL(sigPublicServersDownloadedSuccessfully()), this, SLOT(rebuildComboBoxList()));
     connect(hps, SIGNAL(sigPublicServersDownloadedUnsuccessfully(int)), this, SLOT(rebuildComboBoxList(int)));
@@ -121,7 +121,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     restrictionsGroupBox->setLayout(connectionLayout);
 
     serverInfoLayout = new QGridLayout;
-    serverInfoLayout->addWidget(serverIssuesLabel, 0, 0);
+    serverInfoLayout->addWidget(serverIssuesLabel, 0, 0, 1, 3, Qt::AlignTop);
     serverInfoLayout->addWidget(serverContactLabel, 1, 0);
     serverInfoLayout->addWidget(serverContactLink, 1, 1);
 
@@ -238,6 +238,7 @@ void DlgConnect::previousHostSelected(bool state)
         portEdit->setDisabled(true);
         previousHosts->setDisabled(false);
         btnRefreshServers->setDisabled(false);
+        savePasswordCheckBox->setChecked(false);
     }
 }
 
@@ -276,7 +277,7 @@ void DlgConnect::newHostSelected(bool state)
         previousHosts->setDisabled(true);
         btnRefreshServers->setDisabled(true);
         hostEdit->clear();
-        hostEdit->setPlaceholderText("Server URL for Connecting");
+        hostEdit->setPlaceholderText("Server URL");
         hostEdit->setDisabled(false);
         portEdit->clear();
         portEdit->setPlaceholderText("Communication Port");
@@ -285,7 +286,7 @@ void DlgConnect::newHostSelected(bool state)
         passwordEdit->clear();
         savePasswordCheckBox->setChecked(false);
         saveEdit->clear();
-        saveEdit->setPlaceholderText("New Name in Server List");
+        saveEdit->setPlaceholderText("Unique Server Name");
         saveEdit->setDisabled(false);
     } else {
         preRebuildComboBoxList();

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -77,7 +77,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     serverIssuesLabel =
         new QLabel(tr("If you have any trouble connecting or registering then contact the server staff for help!"));
     serverIssuesLabel->setWordWrap(true);
-    serverContactLabel = new QLabel (tr("Webpage") + ":");
+    serverContactLabel = new QLabel(tr("Webpage") + ":");
     serverContactLink = new QLabel;
     serverContactLink->setTextFormat(Qt::RichText);
     serverContactLink->setTextInteractionFlags(Qt::TextBrowserInteraction);

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -77,6 +77,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     serverIssuesLabel =
         new QLabel(tr("If you have any trouble connecting or registering then contact the server staff for help!"));
     serverIssuesLabel->setWordWrap(true);
+    serverContactLabel = new QLabel (tr("Webpage") + ":");
     serverContactLink = new QLabel;
     serverContactLink->setTextFormat(Qt::RichText);
     serverContactLink->setTextInteractionFlags(Qt::TextBrowserInteraction);
@@ -121,7 +122,8 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
 
     serverInfoLayout = new QGridLayout;
     serverInfoLayout->addWidget(serverIssuesLabel, 0, 0);
-    serverInfoLayout->addWidget(serverContactLink, 1, 0);
+    serverInfoLayout->addWidget(serverContactLabel, 1, 0);
+    serverInfoLayout->addWidget(serverContactLink, 1, 1);
 
     loginLayout = new QGridLayout;
     loginLayout->addWidget(playernameLabel, 0, 0);

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -135,7 +135,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     loginGroupBox = new QGroupBox(tr("Login"));
     loginGroupBox->setLayout(loginLayout);
 
-    serverInfoGroupBox = new QGroupBox(tr("Server info"));
+    serverInfoGroupBox = new QGroupBox(tr("Contact Hint"));
     serverInfoGroupBox->setLayout(serverInfoLayout);
 
     btnGroupBox = new QGroupBox(tr(""));
@@ -143,8 +143,8 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
 
     grid = new QGridLayout;
     grid->addWidget(restrictionsGroupBox, 0, 0);
-    grid->addWidget(loginGroupBox, 1, 0);
-    grid->addWidget(serverInfoGroupBox, 2, 0);
+    grid->addWidget(serverInfoGroupBox, 1, 0);
+    grid->addWidget(loginGroupBox, 2, 0);
     grid->addWidget(btnGroupBox, 3, 0);
 
     mainLayout = new QVBoxLayout;

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -123,7 +123,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     serverInfoLayout = new QGridLayout;
     serverInfoLayout->addWidget(serverIssuesLabel, 0, 0, 1, 3, Qt::AlignTop);
     serverInfoLayout->addWidget(serverContactLabel, 1, 0);
-    serverInfoLayout->addWidget(serverContactLink, 1, 1, 0, -1);
+    serverInfoLayout->addWidget(serverContactLink, 1, 1, 1, 3, Qt::AlignLeft);
 
     loginLayout = new QGridLayout;
     loginLayout->addWidget(playernameLabel, 0, 0);

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -123,7 +123,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     serverInfoLayout = new QGridLayout;
     serverInfoLayout->addWidget(serverIssuesLabel, 0, 0, 1, 3, Qt::AlignTop);
     serverInfoLayout->addWidget(serverContactLabel, 1, 0);
-    serverInfoLayout->addWidget(serverContactLink, 1, 1, Qt::AlignLeft);
+    serverInfoLayout->addWidget(serverContactLink, 1, 1, 1, 3, Qt::AlignTop);
 
     loginLayout = new QGridLayout;
     loginLayout->addWidget(playernameLabel, 0, 0);

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -26,7 +26,6 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     btnRefreshServers = new QPushButton(this);
     btnRefreshServers->setIcon(QPixmap("theme:icons/update"));
     btnRefreshServers->setToolTip(tr("Refresh the server list with known public servers"));
-    btnRefreshServers->setFixedWidth(30);
 
     connect(hps, SIGNAL(sigPublicServersDownloadedSuccessfully()), this, SLOT(rebuildComboBoxList()));
     connect(hps, SIGNAL(sigPublicServersDownloadedUnsuccessfully(int)), this, SLOT(rebuildComboBoxList(int)));

--- a/cockatrice/src/dlg_connect.h
+++ b/cockatrice/src/dlg_connect.h
@@ -65,7 +65,8 @@ private:
     QHBoxLayout *newHolderLayout;
     QGroupBox *loginGroupBox, *serverInfoGroupBox, *btnGroupBox, *restrictionsGroupBox;
     QVBoxLayout *mainLayout;
-    QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *saveLabel, *serverIssuesLabel, *serverContactLabel, *serverContactLink;
+    QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *saveLabel, *serverIssuesLabel,
+        *serverContactLabel, *serverContactLink;
     QLineEdit *hostEdit, *portEdit, *playernameEdit, *passwordEdit, *saveEdit;
     QCheckBox *savePasswordCheckBox, *autoConnectCheckBox;
     QComboBox *previousHosts;

--- a/cockatrice/src/dlg_connect.h
+++ b/cockatrice/src/dlg_connect.h
@@ -65,7 +65,7 @@ private:
     QHBoxLayout *newHolderLayout;
     QGroupBox *loginGroupBox, *serverInfoGroupBox, *btnGroupBox, *restrictionsGroupBox;
     QVBoxLayout *mainLayout;
-    QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *saveLabel, *serverIssuesLabel, *serverContactLink;
+    QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *saveLabel, *serverIssuesLabel, *serverContactLabel, *serverContactLink;
     QLineEdit *hostEdit, *portEdit, *playernameEdit, *passwordEdit, *saveEdit;
     QCheckBox *savePasswordCheckBox, *autoConnectCheckBox;
     QComboBox *previousHosts;


### PR DESCRIPTION
## What will change with this Pull Request?
- smaller refresh button
- disable host and port fields for known server
- add a webpage label next to the url (hidden for custom server)
- real url is displayed instead mirroring server name
- move box with server contact up
- more explaining placeholder text for adding new custom server

## Screenshots
![new](https://user-images.githubusercontent.com/9874850/39082659-20a9e11e-4557-11e8-9d0c-c8b328d1e569.png)
![new2](https://user-images.githubusercontent.com/9874850/39082661-226533dc-4557-11e8-874e-219f7e456565.png)
