### PR TITLE
macOS: fix qt plugin installation

### DIFF
--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -20,6 +20,7 @@ if [[ $BUILDTYPE == "Debug" ]]; then
   cmake .. -DWITH_SERVER=1 -DCMAKE_BUILD_TYPE=$BUILDTYPE $prefix -DTEST=1
   make -j2
   make test
+  make install
 
   if [[ $TRAVIS_OS_NAME == "linux" ]]; then
     cd ..
@@ -32,7 +33,7 @@ if [[ $BUILDTYPE == "Debug" ]]; then
       oracle/src/*.cpp \
       servatrice/src/*.h \
       servatrice/src/*.cpp
-    
+
     git clean -f
     git diff --quiet || (
       echo "*****************************************************";

--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -20,7 +20,10 @@ if [[ $BUILDTYPE == "Debug" ]]; then
   cmake .. -DWITH_SERVER=1 -DCMAKE_BUILD_TYPE=$BUILDTYPE $prefix -DTEST=1
   make -j2
   make test
-  make install
+
+  if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+    make install
+  fi
 
   if [[ $TRAVIS_OS_NAME == "linux" ]]; then
     cd ..

--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -10,7 +10,7 @@ prefix=""
 
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then
   export PATH="/usr/local/opt/ccache/bin:$PATH"
-  prefix="-DCMAKE_PREFIX_PATH=$(echo /usr/local/opt/qt*/)"
+  prefix="-DCMAKE_PREFIX_PATH=$(echo /usr/local/opt/qt5/)"
 fi
 if [[ $TRAVIS_OS_NAME == "linux" ]]; then
   prefix="-DCMAKE_PREFIX_PATH=$(echo /opt/qt5*/lib/cmake/)"

--- a/.ci/travis-dependencies.sh
+++ b/.ci/travis-dependencies.sh
@@ -2,7 +2,7 @@
 
 if [[ $TRAVIS_OS_NAME == "osx" ]] ; then
   brew update
-  brew install ccache clang-format protobuf qt@5.5
+  brew install ccache clang-format protobuf qt
 fi
 if [[ $TRAVIS_OS_NAME == "linux" ]] ; then
   echo Skipping... packages are installed with the Travis apt addon for sudo disabled container builds

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -5,12 +5,12 @@
 PROJECT(Cockatrice)
 
 SET(cockatrice_SOURCES
-    src/abstractcounter.cpp 
+    src/abstractcounter.cpp
     src/counter_general.cpp
     src/dlg_creategame.cpp
     src/dlg_filter_games.cpp
-    src/dlg_connect.cpp 
-    src/dlg_create_token.cpp 
+    src/dlg_connect.cpp
+    src/dlg_create_token.cpp
     src/dlg_edit_avatar.cpp
     src/dlg_edit_password.cpp
     src/dlg_edit_tokens.cpp
@@ -18,35 +18,35 @@ SET(cockatrice_SOURCES
     src/dlg_forgotpasswordrequest.cpp
     src/dlg_forgotpasswordreset.cpp
     src/dlg_forgotpasswordchallenge.cpp
-    src/dlg_register.cpp 
+    src/dlg_register.cpp
     src/dlg_tip_of_the_day.cpp
     src/tip_of_the_day.cpp
     src/dlg_update.cpp
     src/dlg_viewlog.cpp
     src/abstractclient.cpp
-    src/remoteclient.cpp 
-    src/main.cpp 
-    src/window_main.cpp 
-    src/gamesmodel.cpp 
-    src/player.cpp 
-    src/playertarget.cpp 
-    src/cardzone.cpp 
-    src/selectzone.cpp 
-    src/cardlist.cpp 
-    src/abstractcarditem.cpp 
-    src/carditem.cpp 
-    src/tablezone.cpp 
-    src/handzone.cpp 
-    src/handcounter.cpp 
-    src/carddatabase.cpp 
+    src/remoteclient.cpp
+    src/main.cpp
+    src/window_main.cpp
+    src/gamesmodel.cpp
+    src/player.cpp
+    src/playertarget.cpp
+    src/cardzone.cpp
+    src/selectzone.cpp
+    src/cardlist.cpp
+    src/abstractcarditem.cpp
+    src/carditem.cpp
+    src/tablezone.cpp
+    src/handzone.cpp
+    src/handcounter.cpp
+    src/carddatabase.cpp
     src/keysignals.cpp
-    src/gameview.cpp 
-    src/gameselector.cpp 
-    src/decklistmodel.cpp 
-    src/deck_loader.cpp 
-    src/dlg_load_deck_from_clipboard.cpp 
-    src/dlg_load_remote_deck.cpp 
-    src/cardinfowidget.cpp 
+    src/gameview.cpp
+    src/gameselector.cpp
+    src/decklistmodel.cpp
+    src/deck_loader.cpp
+    src/dlg_load_deck_from_clipboard.cpp
+    src/dlg_load_remote_deck.cpp
+    src/cardinfowidget.cpp
     src/cardframe.cpp
     src/cardinfopicture.cpp
     src/cardinfotext.cpp
@@ -54,32 +54,32 @@ SET(cockatrice_SOURCES
     src/cardfilter.cpp
     src/filtertreemodel.cpp
     src/filtertree.cpp
-    src/messagelogwidget.cpp 
-    src/zoneviewzone.cpp 
-    src/zoneviewwidget.cpp 
-    src/pilezone.cpp 
-    src/stackzone.cpp 
-    src/carddragitem.cpp 
-    src/carddatabasemodel.cpp 
-    src/setsmodel.cpp 
-    src/window_sets.cpp 
-    src/abstractgraphicsitem.cpp 
-    src/abstractcarddragitem.cpp 
-    src/dlg_settings.cpp 
-    src/phasestoolbar.cpp 
-    src/gamescene.cpp 
-    src/arrowitem.cpp 
-    src/arrowtarget.cpp 
-    src/tab.cpp 
-    src/tab_server.cpp 
-    src/tab_room.cpp 
-    src/tab_message.cpp 
-    src/tab_game.cpp 
-    src/tab_deck_storage.cpp 
-    src/tab_replays.cpp 
-    src/tab_supervisor.cpp 
-    src/tab_admin.cpp 
-    src/tab_userlists.cpp 
+    src/messagelogwidget.cpp
+    src/zoneviewzone.cpp
+    src/zoneviewwidget.cpp
+    src/pilezone.cpp
+    src/stackzone.cpp
+    src/carddragitem.cpp
+    src/carddatabasemodel.cpp
+    src/setsmodel.cpp
+    src/window_sets.cpp
+    src/abstractgraphicsitem.cpp
+    src/abstractcarddragitem.cpp
+    src/dlg_settings.cpp
+    src/phasestoolbar.cpp
+    src/gamescene.cpp
+    src/arrowitem.cpp
+    src/arrowtarget.cpp
+    src/tab.cpp
+    src/tab_server.cpp
+    src/tab_room.cpp
+    src/tab_message.cpp
+    src/tab_game.cpp
+    src/tab_deck_storage.cpp
+    src/tab_replays.cpp
+    src/tab_supervisor.cpp
+    src/tab_admin.cpp
+    src/tab_userlists.cpp
     src/tab_deck_editor.cpp
     src/tab_logs.cpp
     src/replay_timeline_widget.cpp
@@ -87,18 +87,18 @@ SET(cockatrice_SOURCES
     src/tappedout_interface.cpp
     src/chatview/chatview.cpp
     src/chatview/userlistProxy.h
-    src/userlist.cpp 
-    src/userinfobox.cpp 
+    src/userlist.cpp
+    src/userinfobox.cpp
     src/user_context_menu.cpp
-    src/remotedecklist_treewidget.cpp 
-    src/remotereplaylist_treewidget.cpp 
-    src/deckview.cpp 
-    src/playerlistwidget.cpp 
-    src/pixmapgenerator.cpp 
-    src/settingscache.cpp 
-    src/thememanager.cpp 
-    src/localserver.cpp 
-    src/localserverinterface.cpp 
+    src/remotedecklist_treewidget.cpp
+    src/remotereplaylist_treewidget.cpp
+    src/deckview.cpp
+    src/playerlistwidget.cpp
+    src/pixmapgenerator.cpp
+    src/settingscache.cpp
+    src/thememanager.cpp
+    src/localserver.cpp
+    src/localserverinterface.cpp
     src/localclient.cpp
     src/qt-json/json.cpp
     src/soundengine.cpp
@@ -239,7 +239,7 @@ if(UNIX)
         set_target_properties(cockatrice PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/cmake/Info.plist)
 
         INSTALL(TARGETS cockatrice BUNDLE DESTINATION ./)
-        INSTALL(FILES ${cockatrice_QM} DESTINATION ./Cockatrice.app/Contents/Resources/translations)
+        INSTALL(FILES ${cockatrice_QM} DESTINATION ./cockatrice.app/Contents/Resources/translations)
     else()
         # Assume linux
         INSTALL(TARGETS cockatrice RUNTIME DESTINATION bin/)
@@ -255,14 +255,21 @@ endif()
 
 if(APPLE)
     # these needs to be relative to CMAKE_INSTALL_PREFIX
-    set(plugin_dest_dir Cockatrice.app/Contents/Plugins)
-    set(qtconf_dest_dir Cockatrice.app/Contents/Resources)
+    set(plugin_dest_dir cockatrice.app/Contents/Plugins)
+    set(qtconf_dest_dir cockatrice.app/Contents/Resources)
     get_filename_component(QT_LIBRARY_DIR "${QT_LIBRARY_DIR}/.." ABSOLUTE)
 
     # qt5 plugins: audio, iconengines, imageformats, platforms, printsupport
     install(DIRECTORY "${QT_PLUGINS_DIR}/" DESTINATION ${plugin_dest_dir} COMPONENT Runtime
-        FILES_MATCHING REGEX "(audio|iconengines|imageformats|platforms|printsupport)/.*\\.dylib"
-        REGEX ".*_debug\\.dylib" EXCLUDE)
+        FILES_MATCHING
+        PATTERN "*.dSYM" EXCLUDE
+        PATTERN "*_debug.dylib" EXCLUDE
+        PATTERN "audio/*.dylib"
+        PATTERN "iconengines/*.dylib"
+        PATTERN "imageformats/*.dylib"
+        PATTERN "platforms/*.dylib"
+        PATTERN "printsupport/*.dylib"
+    )
 
     install(CODE "
         file(WRITE \"\${CMAKE_INSTALL_PREFIX}/${qtconf_dest_dir}/qt.conf\" \"[Paths]
@@ -276,7 +283,7 @@ Data = Resources\")
             \"\${CMAKE_INSTALL_PREFIX}/${plugin_dest_dir}/*.dylib\")
         set(BU_CHMOD_BUNDLE_ITEMS ON)
         include(BundleUtilities)
-        fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/Cockatrice.app\" \"\${QTPLUGINS}\" \"${QT_LIBRARY_DIR}\")
+        fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/cockatrice.app\" \"\${QTPLUGINS}\" \"${QT_LIBRARY_DIR}\")
         " COMPONENT Runtime)
 endif()
 

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -269,6 +269,7 @@ if(APPLE)
         PATTERN "imageformats/*.dylib"
         PATTERN "platforms/*.dylib"
         PATTERN "printsupport/*.dylib"
+        PATTERN "styles/*.dylib"
     )
 
     install(CODE "

--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -156,8 +156,9 @@ if(APPLE)
         FILES_MATCHING
         PATTERN "*.dSYM" EXCLUDE
         PATTERN "*_debug.dylib" EXCLUDE
-        PATTERN "platforms/*.dylib"
         PATTERN "iconengines/*.dylib"
+        PATTERN "platforms/*.dylib"
+        PATTERN "styles/*.dylib"
     )
 
     install(CODE "

--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -21,7 +21,7 @@ SET(oracle_SOURCES
     ../cockatrice/src/settings/messagesettings.cpp
     ../cockatrice/src/settings/gamefilterssettings.cpp
     ../cockatrice/src/settings/layoutssettings.cpp
-    ../cockatrice/src/thememanager.cpp 
+    ../cockatrice/src/thememanager.cpp
     ../cockatrice/src/qt-json/json.cpp
     ../cockatrice/src/releasechannel.cpp
      ${VERSION_STRING_CPP}
@@ -128,7 +128,7 @@ if(UNIX)
         set_target_properties(oracle PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/cmake/Info.plist)
 
         INSTALL(TARGETS oracle BUNDLE DESTINATION ./)
-        INSTALL(FILES ${oracle_QM} DESTINATION ./Oracle.app/Contents/Resources/translations)
+        INSTALL(FILES ${oracle_QM} DESTINATION ./oracle.app/Contents/Resources/translations)
     else()
         # Assume linux
         INSTALL(TARGETS oracle RUNTIME DESTINATION bin/)
@@ -147,14 +147,18 @@ ENDIF (NOT WIN32 AND NOT APPLE)
 
 if(APPLE)
     # these needs to be relative to CMAKE_INSTALL_PREFIX
-    set(plugin_dest_dir Oracle.app/Contents/Plugins)
-    set(qtconf_dest_dir Oracle.app/Contents/Resources)
+    set(plugin_dest_dir oracle.app/Contents/Plugins)
+    set(qtconf_dest_dir oracle.app/Contents/Resources)
     get_filename_component(QT_LIBRARY_DIR "${QT_LIBRARY_DIR}/.." ABSOLUTE)
 
     # qt5 plugins: iconengines, platforms
     install(DIRECTORY "${QT_PLUGINS_DIR}/" DESTINATION ${plugin_dest_dir} COMPONENT Runtime
-        FILES_MATCHING REGEX "(iconengines|platforms)/.*\\.dylib"
-        REGEX ".*_debug\\.dylib" EXCLUDE)
+        FILES_MATCHING
+        PATTERN "*.dSYM" EXCLUDE
+        PATTERN "*_debug.dylib" EXCLUDE
+        PATTERN "platforms/*.dylib"
+        PATTERN "iconengines/*.dylib"
+    )
 
     install(CODE "
         file(WRITE \"\${CMAKE_INSTALL_PREFIX}/${qtconf_dest_dir}/qt.conf\" \"[Paths]
@@ -167,7 +171,7 @@ Translations = Resources/translations\")
             \"\${CMAKE_INSTALL_PREFIX}/${plugin_dest_dir}/*.dylib\")
         set(BU_CHMOD_BUNDLE_ITEMS ON)
         include(BundleUtilities)
-        fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/Oracle.app\" \"\${QTPLUGINS}\" \"${QT_LIBRARY_DIR}\")
+        fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/oracle.app\" \"\${QTPLUGINS}\" \"${QT_LIBRARY_DIR}\")
         " COMPONENT Runtime)
 endif()
 
@@ -203,4 +207,4 @@ Translations = Resources/translations\")
         include(BundleUtilities)
         fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/Oracle.exe\" \"\${QTPLUGINS}\" \"${libSearchDirs}\")
         " COMPONENT Runtime)
-endif() 
+endif()

--- a/servatrice/CMakeLists.txt
+++ b/servatrice/CMakeLists.txt
@@ -127,8 +127,8 @@ if(UNIX)
         set(MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION})
 
         INSTALL(TARGETS servatrice BUNDLE DESTINATION ./)
-        INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/servatrice.ini.example DESTINATION ./Servatrice.app/Contents/Resources/)
-        INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/servatrice.sql DESTINATION ./Servatrice.app/Contents/Resources/)
+        INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/servatrice.ini.example DESTINATION ./servatrice.app/Contents/Resources/)
+        INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/servatrice.sql DESTINATION ./servatrice.app/Contents/Resources/)
     else()
         # Assume linux
         INSTALL(TARGETS servatrice RUNTIME DESTINATION bin/)
@@ -147,14 +147,18 @@ endif()
 
 if(APPLE)
     # these needs to be relative to CMAKE_INSTALL_PREFIX
-    set(plugin_dest_dir Servatrice.app/Contents/Plugins)
-    set(qtconf_dest_dir Servatrice.app/Contents/Resources)
+    set(plugin_dest_dir servatrice.app/Contents/Plugins)
+    set(qtconf_dest_dir servatrice.app/Contents/Resources)
     get_filename_component(QT_LIBRARY_DIR "${QT_LIBRARY_DIR}/.." ABSOLUTE)
 
     # qt5 plugins: platforms, sqldrivers/mysql
     install(DIRECTORY "${QT_PLUGINS_DIR}/" DESTINATION ${plugin_dest_dir} COMPONENT Runtime
-        FILES_MATCHING REGEX "(platforms/.*|sqldrivers/libqsqlmysql)\\.dylib"
-        REGEX ".*_debug\\.dylib" EXCLUDE)
+        FILES_MATCHING
+        PATTERN "*.dSYM" EXCLUDE
+        PATTERN "*_debug.dylib" EXCLUDE
+        PATTERN "platforms/*.dylib"
+        PATTERN "sqldrivers/libqsqlmysql*.dylib"
+    )
 
     install(CODE "
         file(WRITE \"\${CMAKE_INSTALL_PREFIX}/${qtconf_dest_dir}/qt.conf\" \"[Paths]
@@ -167,7 +171,7 @@ Translations = Resources/translations\")
         \"\${CMAKE_INSTALL_PREFIX}/${plugin_dest_dir}/*.dylib\")
     set(BU_CHMOD_BUNDLE_ITEMS ON)
     include(BundleUtilities)
-    fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/Servatrice.app\" \"\${QTPLUGINS}\" \"${QT_LIBRARY_DIR};${MYSQLCLIENT_LIBRARY_DIR}\")
+    fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/servatrice.app\" \"\${QTPLUGINS}\" \"${QT_LIBRARY_DIR};${MYSQLCLIENT_LIBRARY_DIR}\")
     " COMPONENT Runtime)
 endif()
 


### PR DESCRIPTION
## Short roundup of the initial problem
During the "install" step, cmake installs all the Qt plugins required at runtime by the applications.
Each application needs a different set of plugins (eg. cockatrice needs to be able to load different image formats, while servatrice doesn't but needs to be able to connect to a mysql server), and installing them all means to waste space and time.

With recent Qt versions, the regexp we used to filter only the needed plugins doesn't work anymore as expected, and was basically installing the whole `plugins/` directory (336MB) on each application.

The current cockatrice release is still using Qt 5.5, so is not affected by this problem. This of this PR as some preliminary work to be able to update Qt on macOS in the future.

## What will change with this Pull Request?
 * The plugins filter rules have been rewritten to work both for old and new Qt versions;
 * the Travis compile script has been modified to include the `make install` step under macOS for debug builds, so that we can see what libraries/frameworks/plugins are picked up by cmake;
 * some folder names have been fixed in CMakelists.txt; macOS normally uses a case-insensitive file system, but better be precise than sorry;
 * some unnecessary trailing whitespace has been removed from CMakelists.txt.
 * *EDIT* Qt 5.10.1 seems to have fixed the long-standing bug that forced us to use an old Qt version (see #2490); i've then re-enabled usage of the current Qt version, so that we can get a proper build created and more testing from other people

## Screenshots
not really a screenshot, but here's a log including the `make install` details showing that not all the plugins are being installed:
https://travis-ci.org/ctrlaltca/Cockatrice/jobs/372043082#L7642