### PR TITLE
braces are only left for split cards

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -83,7 +83,7 @@ CardInfoPtr OracleImporter::addCard(const QString &setName,
         QStringList symbols = cardCost.split("}");
         QString formattedCardCost = QString();
         for (QString symbol : symbols) {
-            if (symbol.contains(QRegExp("[BWUGR]/[BWUGR]"))) {
+            if (symbol.contains(QChar('/'))) {
                 symbol.append("}");
             } else {
                 symbol.remove(QChar('{'));
@@ -108,8 +108,8 @@ CardInfoPtr OracleImporter::addCard(const QString &setName,
                                               !cardText.contains(cardName + " enters the battlefield tapped unless"));
 
         // insert the card and its properties
-        card = CardInfo::newInstance(cardName, isToken, cardCost, cmc, cardType, cardPT, cardText, colors, relatedCards,
-                                     reverseRelatedCards, upsideDown, cardLoyalty, cipt);
+        card = CardInfo::newInstance(cardName, isToken, formattedCardCost, cmc, cardType, cardPT, cardText, colors,
+                                     relatedCards, reverseRelatedCards, upsideDown, cardLoyalty, cipt);
         int tableRow = 1;
         QString mainCardType = card->getMainCardType();
         if ((mainCardType == "Land") || mArtifact)


### PR DESCRIPTION
## Short roundup of the initial problem
Due to a mistake in #3108 all mana costs are shown in braces instead of only split costs. This PR fixes that.

## Screenshots
![image](https://user-images.githubusercontent.com/9273978/39404343-cc3e7c02-4b91-11e8-939d-e66f11e92021.png)
