### PR TITLE
smaller clear pic button

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -92,16 +92,16 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(&updateReleaseChannelBox, 1, 1);
     personalGrid->addWidget(&updateNotificationCheckBox, 2, 0);
     personalGrid->addWidget(&showTipsOnStartup, 3, 0);
-    personalGrid->addWidget(&pixmapCacheLabel, 4, 0);
-    personalGrid->addWidget(&pixmapCacheEdit, 4, 1);
-    personalGrid->addWidget(&picDownloadCheckBox, 5, 0);
-    personalGrid->addWidget(&urlLinkLabel, 5, 1);
-    personalGrid->addWidget(&defaultUrlLabel, 6, 0, 1, 1);
-    personalGrid->addWidget(defaultUrlEdit, 6, 1, 1, 1);
-    personalGrid->addWidget(&defaultUrlRestoreButton, 6, 2, 1, 1);
-    personalGrid->addWidget(&fallbackUrlLabel, 7, 0, 1, 1);
-    personalGrid->addWidget(fallbackUrlEdit, 7, 1, 1, 1);
-    personalGrid->addWidget(&fallbackUrlRestoreButton, 7, 2, 1, 1);
+    personalGrid->addWidget(&picDownloadCheckBox, 4, 0);
+    personalGrid->addWidget(&urlLinkLabel, 4, 1);
+    personalGrid->addWidget(&defaultUrlLabel, 5, 0, 1, 1);
+    personalGrid->addWidget(defaultUrlEdit, 5, 1, 1, 1);
+    personalGrid->addWidget(&defaultUrlRestoreButton, 5, 2, 1, 1);
+    personalGrid->addWidget(&fallbackUrlLabel, 6, 0, 1, 1);
+    personalGrid->addWidget(fallbackUrlEdit, 6, 1, 1, 1);
+    personalGrid->addWidget(&fallbackUrlRestoreButton, 6, 2, 1, 1);
+    personalGrid->addWidget(&pixmapCacheLabel, 7, 0);
+    personalGrid->addWidget(&pixmapCacheEdit, 7, 1);
     personalGrid->addWidget(&clearDownloadedPicsButton, 8, 1);
 
     urlLinkLabel.setTextInteractionFlags(Qt::LinksAccessibleByMouse);
@@ -323,6 +323,7 @@ void GeneralSettingsPage::setEnabledStatus(bool status)
     fallbackUrlEdit->setEnabled(status);
     defaultUrlRestoreButton.setEnabled(status);
     fallbackUrlRestoreButton.setEnabled(status);
+    pixmapCacheEdit.setEnabled(status);
 }
 
 AppearanceSettingsPage::AppearanceSettingsPage()

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -90,18 +90,18 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(&languageBox, 0, 1);
     personalGrid->addWidget(&updateReleaseChannelLabel, 1, 0);
     personalGrid->addWidget(&updateReleaseChannelBox, 1, 1);
-    personalGrid->addWidget(&updateNotificationCheckBox, 2, 0);
-    personalGrid->addWidget(&showTipsOnStartup, 3, 0);
-    personalGrid->addWidget(&picDownloadCheckBox, 4, 0);
-    personalGrid->addWidget(&urlLinkLabel, 4, 1);
-    personalGrid->addWidget(&defaultUrlLabel, 5, 0, 1, 1);
-    personalGrid->addWidget(defaultUrlEdit, 5, 1, 1, 1);
-    personalGrid->addWidget(&defaultUrlRestoreButton, 5, 2, 1, 1);
-    personalGrid->addWidget(&fallbackUrlLabel, 6, 0, 1, 1);
-    personalGrid->addWidget(fallbackUrlEdit, 6, 1, 1, 1);
-    personalGrid->addWidget(&fallbackUrlRestoreButton, 6, 2, 1, 1);
-    personalGrid->addWidget(&pixmapCacheLabel, 7, 0);
-    personalGrid->addWidget(&pixmapCacheEdit, 7, 1);
+    personalGrid->addWidget(&pixmapCacheLabel, 2, 0);
+    personalGrid->addWidget(&pixmapCacheEdit, 2, 1);
+    personalGrid->addWidget(&updateNotificationCheckBox, 3, 0);
+    personalGrid->addWidget(&showTipsOnStartup, 4, 0);
+    personalGrid->addWidget(&picDownloadCheckBox, 5, 0);
+    personalGrid->addWidget(&urlLinkLabel, 5, 1);
+    personalGrid->addWidget(&defaultUrlLabel, 6, 0, 1, 1);
+    personalGrid->addWidget(defaultUrlEdit, 6, 1, 1, 1);
+    personalGrid->addWidget(&defaultUrlRestoreButton, 6, 2, 1, 1);
+    personalGrid->addWidget(&fallbackUrlLabel, 7, 0, 1, 1);
+    personalGrid->addWidget(fallbackUrlEdit, 7, 1, 1, 1);
+    personalGrid->addWidget(&fallbackUrlRestoreButton, 7, 2, 1, 1);
     personalGrid->addWidget(&clearDownloadedPicsButton, 8, 1);
 
     urlLinkLabel.setTextInteractionFlags(Qt::LinksAccessibleByMouse);
@@ -323,7 +323,6 @@ void GeneralSettingsPage::setEnabledStatus(bool status)
     fallbackUrlEdit->setEnabled(status);
     defaultUrlRestoreButton.setEnabled(status);
     fallbackUrlRestoreButton.setEnabled(status);
-    pixmapCacheEdit->setEnabled(status);
 }
 
 AppearanceSettingsPage::AppearanceSettingsPage()

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -92,16 +92,16 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(&updateReleaseChannelBox, 1, 1);
     personalGrid->addWidget(&updateNotificationCheckBox, 2, 0);
     personalGrid->addWidget(&showTipsOnStartup, 3, 0);
-    personalGrid->addWidget(&picDownloadCheckBox, 4, 0);
-    personalGrid->addWidget(&urlLinkLabel, 4, 1);
-    personalGrid->addWidget(&defaultUrlLabel, 5, 0, 1, 1);
-    personalGrid->addWidget(defaultUrlEdit, 5, 1, 1, 1);
-    personalGrid->addWidget(&defaultUrlRestoreButton, 5, 2, 1, 1);
-    personalGrid->addWidget(&fallbackUrlLabel, 6, 0, 1, 1);
-    personalGrid->addWidget(fallbackUrlEdit, 6, 1, 1, 1);
-    personalGrid->addWidget(&fallbackUrlRestoreButton, 6, 2, 1, 1);
-    personalGrid->addWidget(&pixmapCacheLabel, 7, 0);
-    personalGrid->addWidget(&pixmapCacheEdit, 7, 1);
+    personalGrid->addWidget(&pixmapCacheLabel, 4, 0);
+    personalGrid->addWidget(&pixmapCacheEdit, 4, 1);
+    personalGrid->addWidget(&picDownloadCheckBox, 5, 0);
+    personalGrid->addWidget(&urlLinkLabel, 5, 1);
+    personalGrid->addWidget(&defaultUrlLabel, 6, 0, 1, 1);
+    personalGrid->addWidget(defaultUrlEdit, 6, 1, 1, 1);
+    personalGrid->addWidget(&defaultUrlRestoreButton, 6, 2, 1, 1);
+    personalGrid->addWidget(&fallbackUrlLabel, 7, 0, 1, 1);
+    personalGrid->addWidget(fallbackUrlEdit, 7, 1, 1, 1);
+    personalGrid->addWidget(&fallbackUrlRestoreButton, 7, 2, 1, 1);
     personalGrid->addWidget(&clearDownloadedPicsButton, 8, 1);
 
     urlLinkLabel.setTextInteractionFlags(Qt::LinksAccessibleByMouse);
@@ -323,7 +323,6 @@ void GeneralSettingsPage::setEnabledStatus(bool status)
     fallbackUrlEdit->setEnabled(status);
     defaultUrlRestoreButton.setEnabled(status);
     fallbackUrlRestoreButton.setEnabled(status);
-    pixmapCacheEdit.setEnabled(status);
 }
 
 AppearanceSettingsPage::AppearanceSettingsPage()

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -323,7 +323,7 @@ void GeneralSettingsPage::setEnabledStatus(bool status)
     fallbackUrlEdit->setEnabled(status);
     defaultUrlRestoreButton.setEnabled(status);
     fallbackUrlRestoreButton.setEnabled(status);
-    pixmapCacheEdit.setEnabled(status);
+    pixmapCacheEdit->setEnabled(status);
 }
 
 AppearanceSettingsPage::AppearanceSettingsPage()

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -90,18 +90,18 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(&languageBox, 0, 1);
     personalGrid->addWidget(&updateReleaseChannelLabel, 1, 0);
     personalGrid->addWidget(&updateReleaseChannelBox, 1, 1);
-    personalGrid->addWidget(&pixmapCacheLabel, 2, 0);
-    personalGrid->addWidget(&pixmapCacheEdit, 2, 1);
-    personalGrid->addWidget(&updateNotificationCheckBox, 3, 0);
-    personalGrid->addWidget(&showTipsOnStartup, 4, 0);
-    personalGrid->addWidget(&picDownloadCheckBox, 5, 0);
-    personalGrid->addWidget(&urlLinkLabel, 5, 1);
-    personalGrid->addWidget(&defaultUrlLabel, 6, 0, 1, 1);
-    personalGrid->addWidget(defaultUrlEdit, 6, 1, 1, 1);
-    personalGrid->addWidget(&defaultUrlRestoreButton, 6, 2, 1, 1);
-    personalGrid->addWidget(&fallbackUrlLabel, 7, 0, 1, 1);
-    personalGrid->addWidget(fallbackUrlEdit, 7, 1, 1, 1);
-    personalGrid->addWidget(&fallbackUrlRestoreButton, 7, 2, 1, 1);
+    personalGrid->addWidget(&updateNotificationCheckBox, 2, 0);
+    personalGrid->addWidget(&showTipsOnStartup, 3, 0);
+    personalGrid->addWidget(&picDownloadCheckBox, 4, 0);
+    personalGrid->addWidget(&urlLinkLabel, 4, 1);
+    personalGrid->addWidget(&defaultUrlLabel, 5, 0, 1, 1);
+    personalGrid->addWidget(defaultUrlEdit, 5, 1, 1, 1);
+    personalGrid->addWidget(&defaultUrlRestoreButton, 5, 2, 1, 1);
+    personalGrid->addWidget(&fallbackUrlLabel, 6, 0, 1, 1);
+    personalGrid->addWidget(fallbackUrlEdit, 6, 1, 1, 1);
+    personalGrid->addWidget(&fallbackUrlRestoreButton, 6, 2, 1, 1);
+    personalGrid->addWidget(&pixmapCacheLabel, 7, 0);
+    personalGrid->addWidget(&pixmapCacheEdit, 7, 1);
     personalGrid->addWidget(&clearDownloadedPicsButton, 8, 1);
 
     urlLinkLabel.setTextInteractionFlags(Qt::LinksAccessibleByMouse);
@@ -323,6 +323,7 @@ void GeneralSettingsPage::setEnabledStatus(bool status)
     fallbackUrlEdit->setEnabled(status);
     defaultUrlRestoreButton.setEnabled(status);
     fallbackUrlRestoreButton.setEnabled(status);
+    pixmapCacheEdit->setEnabled(status);
 }
 
 AppearanceSettingsPage::AppearanceSettingsPage()

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -323,7 +323,7 @@ void GeneralSettingsPage::setEnabledStatus(bool status)
     fallbackUrlEdit->setEnabled(status);
     defaultUrlRestoreButton.setEnabled(status);
     fallbackUrlRestoreButton.setEnabled(status);
-    pixmapCacheEdit->setEnabled(status);
+    pixmapCacheEdit.setEnabled(status);
 }
 
 AppearanceSettingsPage::AppearanceSettingsPage()

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -102,7 +102,7 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(&fallbackUrlLabel, 7, 0, 1, 1);
     personalGrid->addWidget(fallbackUrlEdit, 7, 1, 1, 1);
     personalGrid->addWidget(&fallbackUrlRestoreButton, 7, 2, 1, 1);
-    personalGrid->addWidget(&clearDownloadedPicsButton, 8, 0, 1, 3);
+    personalGrid->addWidget(&clearDownloadedPicsButton, 8, 1);
 
     urlLinkLabel.setTextInteractionFlags(Qt::LinksAccessibleByMouse);
     urlLinkLabel.setOpenExternalLinks(true);

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -92,8 +92,6 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(&updateReleaseChannelBox, 1, 1);
     personalGrid->addWidget(&updateNotificationCheckBox, 2, 0);
     personalGrid->addWidget(&showTipsOnStartup, 3, 0);
-    personalGrid->addWidget(&pixmapCacheLabel, 4, 0);
-    personalGrid->addWidget(&pixmapCacheEdit, 4, 1);
     personalGrid->addWidget(&picDownloadCheckBox, 5, 0);
     personalGrid->addWidget(&urlLinkLabel, 5, 1);
     personalGrid->addWidget(&defaultUrlLabel, 6, 0, 1, 1);
@@ -103,6 +101,8 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(fallbackUrlEdit, 7, 1, 1, 1);
     personalGrid->addWidget(&fallbackUrlRestoreButton, 7, 2, 1, 1);
     personalGrid->addWidget(&clearDownloadedPicsButton, 8, 1);
+    personalGrid->addWidget(&pixmapCacheLabel, 9, 0);
+    personalGrid->addWidget(&pixmapCacheEdit, 9, 1);
 
     urlLinkLabel.setTextInteractionFlags(Qt::LinksAccessibleByMouse);
     urlLinkLabel.setOpenExternalLinks(true);

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -92,6 +92,8 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(&updateReleaseChannelBox, 1, 1);
     personalGrid->addWidget(&updateNotificationCheckBox, 2, 0);
     personalGrid->addWidget(&showTipsOnStartup, 3, 0);
+    personalGrid->addWidget(&pixmapCacheLabel, 4, 0);
+    personalGrid->addWidget(&pixmapCacheEdit, 4, 1);
     personalGrid->addWidget(&picDownloadCheckBox, 5, 0);
     personalGrid->addWidget(&urlLinkLabel, 5, 1);
     personalGrid->addWidget(&defaultUrlLabel, 6, 0, 1, 1);
@@ -101,8 +103,6 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(fallbackUrlEdit, 7, 1, 1, 1);
     personalGrid->addWidget(&fallbackUrlRestoreButton, 7, 2, 1, 1);
     personalGrid->addWidget(&clearDownloadedPicsButton, 8, 1);
-    personalGrid->addWidget(&pixmapCacheLabel, 9, 0);
-    personalGrid->addWidget(&pixmapCacheEdit, 9, 1);
 
     urlLinkLabel.setTextInteractionFlags(Qt::LinksAccessibleByMouse);
     urlLinkLabel.setOpenExternalLinks(true);


### PR DESCRIPTION
## Short roundup of the initial problem
Huge button spanning over all settings page

## What will change with this Pull Request?
- more normal sized button (still big)



## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![clear_pic](https://user-images.githubusercontent.com/9874850/39565272-a385b48c-4eb7-11e8-8825-a7f13b2fb5a2.png)