### PR TITLE
Update cockatricexml3.cpp

### DIFF
--- a/cockatrice/src/carddbparser/cockatricexml3.cpp
+++ b/cockatrice/src/carddbparser/cockatricexml3.cpp
@@ -150,7 +150,7 @@ void CockatriceXml3Parser::loadCardsFromXml(QXmlStreamReader &xml)
                 } else if (xml.name() == "pt") {
                     pt = xml.readElementText();
                 } else if (xml.name() == "text") {
-                    text = xml.readElementText();
+                    text = xml.readElementText(QXmlStreamReader::IncludeChildElements);
                 } else if (xml.name() == "set") {
                     QXmlStreamAttributes attrs = xml.attributes();
                     QString setName = xml.readElementText();


### PR DESCRIPTION
Add support for child elements in a card’s text. Any valid markup that may be present will not cause the parser to stop. Instead, Cockatrice will not style unknown elements.

## Related Ticket(s)
- Fixes #3227, #3112

## Short roundup of the initial problem
The Cockatrice set parser was stopping when it hit an unknown element in the text field. This included any kind of markup that may be present, including tags like`<i>` or `<b>` that may end up being in a card.

## What will change with this Pull Request?
The parser will not stop on childElements found inside a card’s text and simply take in the card. (Any kind of tags it finds will of course be unstyled.)

## Screenshots
Screenshots can be provided upon request.

## Test file
The test file contains three test markup elements: `<B>` in the card “Dust Bunny”, `<i>` in the card “Furious Fusillade” and `<TranquilExpanse>` in the card “Tranquil Expanse”.
[03.DAD.xml.zip](https://github.com/Cockatrice/Cockatrice/files/1990164/03.DAD.xml.zip)
