### PR TITLE
Update cards.xsd

### DIFF
--- a/doc/cards.xsd
+++ b/doc/cards.xsd
@@ -13,7 +13,7 @@
       <xs:all>
         <xs:element name="sets" minOccurs="0">
             <xs:complexType>
-                <xs:sequence>
+                <xs:all>
                     <xs:element name="set" maxOccurs="unbounded" minOccurs="0">
                         <xs:complexType>
                             <xs:all>
@@ -24,15 +24,15 @@
                             </xs:all>
                         </xs:complexType>
                     </xs:element>
-                </xs:sequence>
+                </xs:all>
             </xs:complexType>
         </xs:element>
         <xs:element name="cards" minOccurs="0">
             <xs:complexType>
-                <xs:sequence>
+                <xs:all>
                     <xs:element name="card" maxOccurs="unbounded" minOccurs="0">
                         <xs:complexType>
-                            <xs:sequence>
+                            <xs:all>
                                     <xs:element type="xs:string" name="name" />
                                     <xs:element name="set" maxOccurs="unbounded" minOccurs="1">
                                         <xs:complexType>
@@ -62,10 +62,10 @@
                                         <xs:element type="relatedType" name="related" />
                                         <xs:element type="relatedType" name="reverse-related" />
                                     </xs:choice>
-                            </xs:sequence>
+                            </xs:all>
                         </xs:complexType>
                     </xs:element>
-                </xs:sequence>
+                </xs:all>
             </xs:complexType>
         </xs:element>
       </xs:all>

--- a/doc/cards.xsd
+++ b/doc/cards.xsd
@@ -13,7 +13,7 @@
       <xs:all>
         <xs:element name="sets" minOccurs="0">
             <xs:complexType>
-                <xs:all>
+                <xs:sequence>
                     <xs:element name="set" maxOccurs="unbounded" minOccurs="0">
                         <xs:complexType>
                             <xs:all>
@@ -24,48 +24,48 @@
                             </xs:all>
                         </xs:complexType>
                     </xs:element>
-                </xs:all>
+                </xs:sequence>
             </xs:complexType>
         </xs:element>
         <xs:element name="cards" minOccurs="0">
             <xs:complexType>
-                <xs:all>
+                <xs:sequence>
                     <xs:element name="card" maxOccurs="unbounded" minOccurs="0">
                         <xs:complexType>
-                            <xs:all>
-                                    <xs:element type="xs:string" name="name" />
-                                    <xs:element name="set" maxOccurs="unbounded" minOccurs="1">
-                                        <xs:complexType>
-                                            <xs:simpleContent>
-                                                <xs:extension base="xs:string">
-                                                    <xs:attribute type="xs:int" name="muId" use="optional" />
-                                                    <xs:attribute type="xs:anyURI" name="picURL" use="optional" />
-                                                    <xs:attribute type="xs:string" name="num"  use="optional" />
-                                                    <xs:attribute type="xs:string" name="rarity" use="optional" />
-                                                </xs:extension>
-                                            </xs:simpleContent>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element type="xs:string" name="color" minOccurs="0" maxOccurs="5" />
-                                    <xs:element type="relatedType" name="related" minOccurs="0" maxOccurs="unbounded" />
-                                    <xs:element type="xs:string" name="manacost" minOccurs="0" maxOccurs="1" />
-                                    <xs:element type="xs:string" name="cmc" minOccurs="0" maxOccurs="1" default="0" />
-                                    <xs:element type="xs:string" name="type" minOccurs="1" maxOccurs="1" />
-                                    <xs:element type="xs:string" name="pt" minOccurs="0" maxOccurs="1" />
-                                    <xs:element type="xs:integer" name="tablerow" maxOccurs="1" />
-                                    <xs:element type="xs:string" name="text" minOccurs="0" maxOccurs="1" />
-                                    <xs:element type="xs:boolean" name="cipt" minOccurs="0" maxOccurs="1" />
-                                    <xs:element type="xs:string" name="loyalty" minOccurs="0"  maxOccurs="1" />
-                                    <xs:element type="xs:boolean" name="upsidedown" minOccurs="0" maxOccurs="1" />
-                                    <xs:element type="xs:boolean" name="token" minOccurs="0" maxOccurs="1" />
-                                    <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                        <xs:element type="relatedType" name="related" />
-                                        <xs:element type="relatedType" name="reverse-related" />
-                                    </xs:choice>
-                            </xs:all>
+                            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                <xs:element type="xs:string" name="name" />
+                                <xs:element name="set" maxOccurs="unbounded" minOccurs="1">
+                                    <xs:complexType>
+                                        <xs:simpleContent>
+                                            <xs:extension base="xs:string">
+                                                <xs:attribute type="xs:int" name="muId" use="optional" />
+                                                <xs:attribute type="xs:anyURI" name="picURL" use="optional" />
+                                                <xs:attribute type="xs:string" name="num"  use="optional" />
+                                                <xs:attribute type="xs:string" name="rarity" use="optional" />
+                                            </xs:extension>
+                                        </xs:simpleContent>
+                                    </xs:complexType>
+                                </xs:element>
+                                <xs:element type="xs:string" name="color" minOccurs="0" maxOccurs="5" />
+                                <xs:element type="relatedType" name="related" minOccurs="0" maxOccurs="unbounded" />
+                                <xs:element type="xs:string" name="manacost" minOccurs="0" maxOccurs="1" />
+                                <xs:element type="xs:string" name="cmc" minOccurs="0" maxOccurs="1" default="0" />
+                                <xs:element type="xs:string" name="type" minOccurs="1" maxOccurs="1" />
+                                <xs:element type="xs:string" name="pt" minOccurs="0" maxOccurs="1" />
+                                <xs:element type="xs:integer" name="tablerow" maxOccurs="1" />
+                                <xs:element type="xs:string" name="text" minOccurs="0" maxOccurs="1" />
+                                <xs:element type="xs:boolean" name="cipt" minOccurs="0" maxOccurs="1" />
+                                <xs:element type="xs:string" name="loyalty" minOccurs="0"  maxOccurs="1" />
+                                <xs:element type="xs:boolean" name="upsidedown" minOccurs="0" maxOccurs="1" />
+                                <xs:element type="xs:boolean" name="token" minOccurs="0" maxOccurs="1" />
+                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element type="relatedType" name="related" />
+                                    <xs:element type="relatedType" name="reverse-related" />
+                                </xs:choice>
+                            </xs:choice>
                         </xs:complexType>
                     </xs:element>
-                </xs:all>
+                </xs:sequence>
             </xs:complexType>
         </xs:element>
       </xs:all>


### PR DESCRIPTION
In the card schema, the order of the set’s and card’s elements are not important, so we can use `xs:all` here.

## Related Ticket(s)
- Fixes #3237 

## Short roundup of the initial problem
The schema uses `xs:sequence` which, when validating a set file, will fail if it’s not in a specific order (for example, `cmc` must come before `type`). The order of a card’s elements is not important, so it can be changed to `xs:all`.

## What will change with this Pull Request?
- cards.xsd

## Test file
This test file mixes up the order of some card elements.
[cards.xml.zip](https://github.com/Cockatrice/Cockatrice/files/1992249/cards.xml.zip)
