### PR TITLE
Hide non-existent card values in infowidget and cardframe

### DIFF
--- a/cockatrice/src/cardinfotext.cpp
+++ b/cockatrice/src/cardinfotext.cpp
@@ -71,39 +71,27 @@ void CardInfoText::setCard(CardInfoPtr card)
         resetLabels();
 
         nameLabel2->setText(card->getName());
-        if(!card->getManaCost().isEmpty())
-        {
+        if (!card->getManaCost().isEmpty()) {
             manacostLabel2->setText(card->getManaCost());
-        }
-        else
-        {
+        } else {
             manacostLabel1->hide();
             manacostLabel2->hide();
         }
-        if(!card->getColors().isEmpty())
-        {
+        if (!card->getColors().isEmpty()) {
             colorLabel2->setText(card->getColors().join(""));
-        }
-        else
-        {
+        } else {
             colorLabel2->setText("Colorless");
         }
         cardtypeLabel2->setText(card->getCardType());
-        if(!card->getPowTough().isEmpty())
-        {
+        if (!card->getPowTough().isEmpty()) {
             powtoughLabel2->setText(card->getPowTough());
-        }
-        else
-        {
+        } else {
             powtoughLabel1->hide();
             powtoughLabel2->hide();
         }
-        if(!card->getLoyalty().isEmpty())
-        {
+        if (!card->getLoyalty().isEmpty()) {
             loyaltyLabel2->setText(card->getLoyalty());
-        }
-        else
-        {
+        } else {
             loyaltyLabel1->hide();
             loyaltyLabel2->hide();
         }

--- a/cockatrice/src/cardinfotext.cpp
+++ b/cockatrice/src/cardinfotext.cpp
@@ -57,19 +57,24 @@ CardInfoText::CardInfoText(QWidget *parent) : QFrame(parent), info(nullptr)
 // Reset every label which is optionally hidden
 void CardInfoText::resetLabels()
 {
+    nameLabel1->show();
+    nameLabel2->show();
     manacostLabel1->show();
     manacostLabel2->show();
+    colorLabel1->show();
+    colorLabel2->show();
+    cardtypeLabel1->show();
+    cardtypeLabel2->show();
     powtoughLabel1->show();
     powtoughLabel2->show();
     loyaltyLabel1->show();
     loyaltyLabel2->show();
+    textLabel->show();
 }
 void CardInfoText::setCard(CardInfoPtr card)
 {
     if (card) {
-
         resetLabels();
-
         nameLabel2->setText(card->getName());
         if (!card->getManaCost().isEmpty()) {
             manacostLabel2->setText(card->getManaCost());
@@ -97,14 +102,24 @@ void CardInfoText::setCard(CardInfoPtr card)
         }
         textLabel->setText(card->getText());
     } else {
-        nameLabel2->setText("");
-        manacostLabel2->setText("");
-        colorLabel2->setText("");
-        cardtypeLabel2->setText("");
-        powtoughLabel2->setText("");
-        loyaltyLabel2->setText("");
-        textLabel->setText("");
+        manacostLabel1->hide();
+        manacostLabel2->hide();
+        colorLabel1->hide();
+        colorLabel2->hide();
+        cardtypeLabel1->hide();
+        cardtypeLabel2->hide();
+        powtoughLabel1->hide();
+        powtoughLabel2->hide();
+        loyaltyLabel1->hide();
+        loyaltyLabel2->hide();
+        textLabel->hide();
     }
+}
+
+void CardInfoText::setInvalidCardName(const QString &cardName)
+{
+    nameLabel1->setText(tr("Unknown card:"));
+    nameLabel2->setText(cardName);
 }
 
 void CardInfoText::retranslateUi()

--- a/cockatrice/src/cardinfotext.cpp
+++ b/cockatrice/src/cardinfotext.cpp
@@ -102,6 +102,8 @@ void CardInfoText::setCard(CardInfoPtr card)
         }
         textLabel->setText(card->getText());
     } else {
+        nameLabel1->hide();
+        nameLabel2->hide();
         manacostLabel1->hide();
         manacostLabel2->hide();
         colorLabel1->hide();
@@ -119,7 +121,9 @@ void CardInfoText::setCard(CardInfoPtr card)
 void CardInfoText::setInvalidCardName(const QString &cardName)
 {
     nameLabel1->setText(tr("Unknown card:"));
+    nameLabel1->show();
     nameLabel2->setText(cardName);
+    nameLabel2->show();
 }
 
 void CardInfoText::retranslateUi()

--- a/cockatrice/src/cardinfotext.cpp
+++ b/cockatrice/src/cardinfotext.cpp
@@ -54,16 +54,59 @@ CardInfoText::CardInfoText(QWidget *parent) : QFrame(parent), info(nullptr)
 
     retranslateUi();
 }
-
+// Reset every label which is optionally hidden
+void CardInfoText::resetLabels()
+{
+    manacostLabel1->show();
+    manacostLabel2->show();
+    powtoughLabel1->show();
+    powtoughLabel2->show();
+    loyaltyLabel1->show();
+    loyaltyLabel2->show();
+}
 void CardInfoText::setCard(CardInfoPtr card)
 {
     if (card) {
+
+        resetLabels();
+
         nameLabel2->setText(card->getName());
-        manacostLabel2->setText(card->getManaCost());
-        colorLabel2->setText(card->getColors().join(""));
+        if(!card->getManaCost().isEmpty())
+        {
+            manacostLabel2->setText(card->getManaCost());
+        }
+        else
+        {
+            manacostLabel1->hide();
+            manacostLabel2->hide();
+        }
+        if(!card->getColors().isEmpty())
+        {
+            colorLabel2->setText(card->getColors().join(""));
+        }
+        else
+        {
+            colorLabel2->setText("Colorless");
+        }
         cardtypeLabel2->setText(card->getCardType());
-        powtoughLabel2->setText(card->getPowTough());
-        loyaltyLabel2->setText(card->getLoyalty());
+        if(!card->getPowTough().isEmpty())
+        {
+            powtoughLabel2->setText(card->getPowTough());
+        }
+        else
+        {
+            powtoughLabel1->hide();
+            powtoughLabel2->hide();
+        }
+        if(!card->getLoyalty().isEmpty())
+        {
+            loyaltyLabel2->setText(card->getLoyalty());
+        }
+        else
+        {
+            loyaltyLabel1->hide();
+            loyaltyLabel1->hide();
+        }
         textLabel->setText(card->getText());
     } else {
         nameLabel2->setText("");

--- a/cockatrice/src/cardinfotext.cpp
+++ b/cockatrice/src/cardinfotext.cpp
@@ -105,7 +105,7 @@ void CardInfoText::setCard(CardInfoPtr card)
         else
         {
             loyaltyLabel1->hide();
-            loyaltyLabel1->hide();
+            loyaltyLabel2->hide();
         }
         textLabel->setText(card->getText());
     } else {

--- a/cockatrice/src/cardinfotext.h
+++ b/cockatrice/src/cardinfotext.h
@@ -27,6 +27,7 @@ private:
 public:
     CardInfoText(QWidget *parent = 0);
     void retranslateUi();
+    void setInvalidCardName(const QString &cardName);
 
 public slots:
     void setCard(CardInfoPtr card);

--- a/cockatrice/src/cardinfotext.h
+++ b/cockatrice/src/cardinfotext.h
@@ -22,6 +22,8 @@ private:
 
     CardInfoPtr info;
 
+    void resetLabels();
+
 public:
     CardInfoText(QWidget *parent = 0);
     void retranslateUi();

--- a/cockatrice/src/cardinfowidget.cpp
+++ b/cockatrice/src/cardinfowidget.cpp
@@ -52,6 +52,8 @@ void CardInfoWidget::setCard(CardInfoPtr card)
 void CardInfoWidget::setCard(const QString &cardName)
 {
     setCard(db->getCardBySimpleName(cardName));
+    if (!info)
+        text->setInvalidCardName(cardName);
 }
 
 void CardInfoWidget::setCard(AbstractCardItem *card)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2972

## Short roundup of the initial problem
When clicking on a card linked in the chat (or displaying it in the deck editor), it contains emtpy values. For example Power/Toughness for spells or mana cost for lands.
![34120202-1c3c75d0-e425-11e7-89d1-f8c9eb152e78](https://user-images.githubusercontent.com/9959527/39940243-e87b1dbe-5558-11e8-8842-c0a99405a650.png)

## What will change with this Pull Request?
- Empty fields will be hidden in both the Infowidget (clicking on cards from chat) and the Deckeditor
- Cards without color will have the Color string "Colorless"

## Screenshots
## Before
![before](https://user-images.githubusercontent.com/9959527/39939629-27080ce2-5557-11e8-930e-3bf53f8325b9.png)
![before2](https://user-images.githubusercontent.com/9959527/39940150-a1271f3a-5558-11e8-991c-15fc661b8e90.png)

## After
![after](https://user-images.githubusercontent.com/9959527/39939958-099f64d8-5558-11e8-96f7-ee152ecfb220.png)
![after2](https://user-images.githubusercontent.com/9959527/39940153-a4a9bec4-5558-11e8-8fae-0b7e4057cdcf.png)


