### PR TITLE
Servatrice: make listening host configurable; fix #3241

### DIFF
--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -15,6 +15,11 @@ name="My Cockatrice server"
 ; must have a different id; the default id is 1
 id=1
 
+; The IP address servatrice will listen on for clients; defaults to "any" to listen on all the interfaces,
+; a specific IPv4/v6 addresses can be used, eg for localhost-only 127.0.0.1 for IPv4 or ::1 for IPv6.
+
+host=any
+
 ; The TCP port number servatrice will listen on for clients; default is 4747
 port=4747
 
@@ -27,6 +32,10 @@ number_pools=1
 ; Servatrice can listen for clients on websockets, too. Unfortunately it can't support more than one thread.
 ; Set to 0 to disable the websocket server.
 websocket_number_pools=1
+
+; The IP address servatrice will listen on for websockets clients; defaults to "any"
+
+websocket_host=any
 
 ; The TCP port number servatrice will listen on for websockets clients; default is 4748
 websocket_port=4748
@@ -44,7 +53,7 @@ writelog=1
 ; [ex: C:\\Temp\\server.log ]
 logfile=server.log
 
-; You may want to log only certain messages in the logfile. The default log level is extremely verbose. 
+; You may want to log only certain messages in the logfile. The default log level is extremely verbose.
 ; This setting should contain a comma-separated list of strings that will be selectively logged.
 ; All other lines will be excluded from the log. Default is empty; example: "Registration,_Login,foobar"
 logfilters=""
@@ -147,7 +156,7 @@ disallowedregexp=""
 ; You can prevent users from using certain mail domains for registration.  This setting contains a
 ; comma-seperated list of email provider domains that you would like to prevent users from using
 ; during registration. Comparison's are implicit, so placing an entry such as mail.com will also
-; prevent users from registering accounts with providers such as gmail.com and hotmail.com  
+; prevent users from registering accounts with providers such as gmail.com and hotmail.com
 ; Example: "10minutemail.com,gmail.com"
 ;emailproviderblacklist=""
 
@@ -338,7 +347,7 @@ max_command_count_per_interval=20
 
 [logging]
 ; Admin/Moderators can query the stored logs for information when looking up reports by various players. This
-; option can allow or disallow them from doing so. 
+; option can allow or disallow them from doing so.
 ; !!NOTE!! Enabling this feature puts a very high CPU and DISK load on the server, enable with caution.
 enablelogquery=false
 

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -438,7 +438,8 @@ bool Servatrice::initServer()
                                                                  servatriceDatabaseInterface->getDatabase(), this);
         websocketGameServer->setMaxPendingConnections(1000);
         QHostAddress webSocketHost = getServerWebSocketHost();
-        qDebug() << "Starting websocket server on host" << webSocketHost.toString() << "port" << getServerWebSocketPort();
+        qDebug() << "Starting websocket server on host" << webSocketHost.toString() << "port"
+                 << getServerWebSocketPort();
         if (websocketGameServer->listen(webSocketHost, static_cast<quint16>(getServerWebSocketPort())))
             qDebug() << "Websocket server listening.";
         else {
@@ -929,7 +930,7 @@ int Servatrice::getNumberOfTCPPools() const
 QHostAddress Servatrice::getServerTCPHost() const
 {
     QString host = settingsCache->value("server/host", "any").toString();
-    if(host == "any")
+    if (host == "any")
         return QHostAddress::Any;
     else
         return QHostAddress(host);
@@ -948,7 +949,7 @@ int Servatrice::getNumberOfWebSocketPools() const
 QHostAddress Servatrice::getServerWebSocketHost() const
 {
     QString host = settingsCache->value("server/websocket_host", "any").toString();
-    if(host == "any")
+    if (host == "any")
         return QHostAddress::Any;
     else
         return QHostAddress(host);

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -421,8 +421,9 @@ bool Servatrice::initServer()
         gameServer =
             new Servatrice_GameServer(this, getNumberOfTCPPools(), servatriceDatabaseInterface->getDatabase(), this);
         gameServer->setMaxPendingConnections(1000);
-        qDebug() << "Starting server on port" << getServerTCPPort();
-        if (gameServer->listen(QHostAddress::Any, static_cast<quint16>(getServerTCPPort())))
+        QHostAddress tcpHost = getServerTCPHost();
+        qDebug() << "Starting server on host" << tcpHost.toString() << "port" << getServerTCPPort();
+        if (gameServer->listen(tcpHost, static_cast<quint16>(getServerTCPPort())))
             qDebug() << "Server listening.";
         else {
             qDebug() << "gameServer->listen(): Error:" << gameServer->errorString();
@@ -436,8 +437,9 @@ bool Servatrice::initServer()
         websocketGameServer = new Servatrice_WebsocketGameServer(this, getNumberOfWebSocketPools(),
                                                                  servatriceDatabaseInterface->getDatabase(), this);
         websocketGameServer->setMaxPendingConnections(1000);
-        qDebug() << "Starting websocket server on port" << getServerWebSocketPort();
-        if (websocketGameServer->listen(QHostAddress::Any, static_cast<quint16>(getServerWebSocketPort())))
+        QHostAddress webSocketHost = getServerWebSocketHost();
+        qDebug() << "Starting websocket server on host" << webSocketHost.toString() << "port" << getServerWebSocketPort();
+        if (websocketGameServer->listen(webSocketHost, static_cast<quint16>(getServerWebSocketPort())))
             qDebug() << "Websocket server listening.";
         else {
             qDebug() << "websocketGameServer->listen(): Error:" << websocketGameServer->errorString();
@@ -924,6 +926,15 @@ int Servatrice::getNumberOfTCPPools() const
     return settingsCache->value("server/number_pools", 1).toInt();
 }
 
+QHostAddress Servatrice::getServerTCPHost() const
+{
+    QString host = settingsCache->value("server/host", "any").toString();
+    if(host == "any")
+        return QHostAddress::Any;
+    else
+        return QHostAddress(host);
+}
+
 int Servatrice::getServerTCPPort() const
 {
     return settingsCache->value("server/port", 4747).toInt();
@@ -932,6 +943,15 @@ int Servatrice::getServerTCPPort() const
 int Servatrice::getNumberOfWebSocketPools() const
 {
     return settingsCache->value("server/websocket_number_pools", 1).toInt();
+}
+
+QHostAddress Servatrice::getServerWebSocketHost() const
+{
+    QString host = settingsCache->value("server/websocket_host", "any").toString();
+    if(host == "any")
+        return QHostAddress::Any;
+    else
+        return QHostAddress(host);
 }
 
 int Servatrice::getServerWebSocketPort() const

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -202,6 +202,8 @@ private:
     int getISLNetworkPort() const;
     bool getISLNetworkEnabled() const;
     bool getEnableInternalSMTPClient() const;
+    QHostAddress getServerTCPHost() const;
+    QHostAddress getServerWebSocketHost() const;
 
 public slots:
     void scheduleShutdown(const QString &reason, int minutes);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3241 

## Short roundup of the initial problem
Servatrice will always listen on all available ipv4 and ipv6 addressed on the host it's started from.
This can cause problem on hosts with an ipv6 stack but no ipv6 address available (#3241).
This is also problematic for people that only want to make the connection possible from localhost or that want to bind the server to a specific ip address on hosts with more than one network inteface / alias.

## What will change with this Pull Request?
Two new server/host and server/websocket_host confgiuration options have been added. Each option accepts one ipv4 or ipv6 address or the magic word "any" to listen on all interfaces.
Both options default to "any", to mimic the old behavior.
