### PR TITLE
settings dialog: fewer space

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -914,7 +914,7 @@ DlgSettings::DlgSettings(QWidget *parent) : QDialog(parent)
 
     auto *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(vboxLayout);
-    mainLayout->addSpacing(6);
+    mainLayout->addSpacing(2);
     mainLayout->addWidget(buttonBox);
     setLayout(mainLayout);
 

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -1,4 +1,4 @@
-<#include "dlg_settings.h"
+#include "dlg_settings.h"
 #include "carddatabase.h"
 #include "main.h"
 #include "releasechannel.h"
@@ -102,7 +102,7 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(&fallbackUrlLabel, 7, 0, 1, 1);
     personalGrid->addWidget(fallbackUrlEdit, 7, 1, 1, 1);
     personalGrid->addWidget(&fallbackUrlRestoreButton, 7, 2, 1, 1);
-    personalGrid->addWidget(&clearDownloadedPicsButton, 8, 0, 1, 3);
+    personalGrid->addWidget(&clearDownloadedPicsButton, 8, 1);
 
     urlLinkLabel.setTextInteractionFlags(Qt::LinksAccessibleByMouse);
     urlLinkLabel.setOpenExternalLinks(true);

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -1,4 +1,4 @@
-#include "dlg_settings.h"
+<#include "dlg_settings.h"
 #include "carddatabase.h"
 #include "main.h"
 #include "releasechannel.h"
@@ -102,7 +102,7 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(&fallbackUrlLabel, 7, 0, 1, 1);
     personalGrid->addWidget(fallbackUrlEdit, 7, 1, 1, 1);
     personalGrid->addWidget(&fallbackUrlRestoreButton, 7, 2, 1, 1);
-    personalGrid->addWidget(&clearDownloadedPicsButton, 8, 1);
+    personalGrid->addWidget(&clearDownloadedPicsButton, 8, 0, 1, 3);
 
     urlLinkLabel.setTextInteractionFlags(Qt::LinksAccessibleByMouse);
     urlLinkLabel.setOpenExternalLinks(true);
@@ -914,7 +914,7 @@ DlgSettings::DlgSettings(QWidget *parent) : QDialog(parent)
 
     auto *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(vboxLayout);
-    mainLayout->addSpacing(12);
+    mainLayout->addSpacing(6);
     mainLayout->addWidget(buttonBox);
     setLayout(mainLayout);
 


### PR DESCRIPTION
## What will change with this Pull Request?
- Tiny optical change
This removes unneeded space between settings body and the default button row at the bottom

## Screenshots
Still enough space between buttons:
![untitled](https://user-images.githubusercontent.com/9874850/39974684-932356aa-572a-11e8-8bbc-5ef54d2fe827.png)
