### PR TITLE
Fix compilation on Qt 5.11; fix #3257

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -150,14 +150,12 @@ ENDIF(APPLE)
 
 # Qt5
 find_package(Qt5 COMPONENTS Concurrent Multimedia Network PrintSupport Svg Widgets REQUIRED)
-include_directories(${Qt5Concurrent_INCLUDE_DIRS} ${Qt5Multimedia_INCLUDE_DIRS} ${Qt5Network_INCLUDE_DIRS} ${Qt5PrintSupport_INCLUDE_DIRS} ${Qt5Svg_INCLUDE_DIRS} ${Qt5Widgets_INCLUDE_DIRS})
-set(COCKATRICE_QT_MODULES Concurrent Multimedia Network PrintSupport Svg Widgets)
+set(COCKATRICE_QT_MODULES Qt5::Concurrent Qt5::Multimedia Qt5::Network Qt5::PrintSupport Qt5::Svg Qt5::Widgets)
 
 # Qt5LinguistTools
 find_package(Qt5LinguistTools)
 if(Qt5LinguistTools_FOUND)
-    include_directories(${Qt5LinguistTools_INCLUDE_DIRS})
-    list(APPEND COCKATRICE_LIBS LinguistTools)
+    list(APPEND COCKATRICE_LIBS Qt5::LinguistTools)
 
     if(NOT Qt5_LRELEASE_EXECUTABLE)
         MESSAGE(WARNING "Qt's lrelease not found.")
@@ -188,8 +186,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 # Build cockatrice binary and link it
 ADD_EXECUTABLE(cockatrice WIN32 MACOSX_BUNDLE ${cockatrice_SOURCES} ${cockatrice_QM} ${cockatrice_RESOURCES_RCC} ${cockatrice_MOC_SRCS})
 
-TARGET_LINK_LIBRARIES(cockatrice cockatrice_common)
-qt5_use_modules(cockatrice ${COCKATRICE_QT_MODULES})
+TARGET_LINK_LIBRARIES(cockatrice cockatrice_common ${COCKATRICE_QT_MODULES})
 
 if(UNIX)
     if(APPLE)

--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -50,14 +50,12 @@ ENDIF(APPLE)
 
 # Qt5
 find_package(Qt5 COMPONENTS Concurrent Network Svg Widgets REQUIRED)
-include_directories(${Qt5Concurrent_INCLUDE_DIRS} ${Qt5Multimedia_INCLUDE_DIRS} ${Qt5Network_INCLUDE_DIRS} ${Qt5PrintSupport_INCLUDE_DIRS} ${Qt5Svg_INCLUDE_DIRS} ${Qt5Widgets_INCLUDE_DIRS})
-set(ORACLE_QT_MODULES Concurrent Multimedia Network PrintSupport Svg Widgets)
+set(ORACLE_QT_MODULES Qt5::Concurrent Qt5::Network Qt5::Svg Qt5::Widgets)
 
 # Qt5LinguistTools
 find_package(Qt5LinguistTools)
 if(Qt5LinguistTools_FOUND)
-    include_directories(${Qt5LinguistTools_INCLUDE_DIRS})
-    list(APPEND ORACLE_LIBS LinguistTools)
+    list(APPEND ORACLE_LIBS Qt5::LinguistTools)
 
     if(NOT Qt5_LRELEASE_EXECUTABLE)
         MESSAGE(WARNING "Qt's lrelease not found.")
@@ -95,10 +93,10 @@ ENDIF()
 # Build oracle binary and link it
 ADD_EXECUTABLE(oracle WIN32 MACOSX_BUNDLE ${oracle_SOURCES} ${oracle_QM} ${oracle_RESOURCES_RCC} ${oracle_MOC_SRCS})
 
-qt5_use_modules(oracle ${ORACLE_QT_MODULES})
-
 IF(ZLIB_FOUND)
-    TARGET_LINK_LIBRARIES(oracle ${ZLIB_LIBRARIES})
+    TARGET_LINK_LIBRARIES(oracle ${ORACLE_QT_MODULES} ${ZLIB_LIBRARIES})
+ELSE()
+    TARGET_LINK_LIBRARIES(oracle ${ORACLE_QT_MODULES})
 ENDIF()
 
 if(UNIX)

--- a/servatrice/CMakeLists.txt
+++ b/servatrice/CMakeLists.txt
@@ -38,16 +38,12 @@ ENDIF(APPLE)
 
 # Qt5
 find_package(Qt5 COMPONENTS Network Sql REQUIRED)
-include_directories(${Qt5Core_INCLUDE_DIRS})
-include_directories(${Qt5Network_INCLUDE_DIRS})
-include_directories(${Qt5Sql_INCLUDE_DIRS})
-set(SERVATRICE_QT_MODULES Core Network Sql)
+set(SERVATRICE_QT_MODULES Qt5::Core Qt5::Network Qt5::Sql)
 
 # Qt Websockets
 find_package(Qt5WebSockets)
 if(Qt5WebSockets_FOUND)
-    include_directories(${Qt5WebSockets_INCLUDE_DIRS})
-     list(APPEND SERVATRICE_QT_MODULES WebSockets)
+    list(APPEND SERVATRICE_QT_MODULES Qt5::WebSockets)
 else()
     MESSAGE(WARNING "Qt5 websocket module not found")
 endif()
@@ -91,11 +87,10 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 ADD_EXECUTABLE(servatrice MACOSX_BUNDLE ${servatrice_SOURCES} ${servatrice_RESOURCES_RCC} ${servatrice_MOC_SRCS})
 
 if(MSVC)
-    TARGET_LINK_LIBRARIES(servatrice cockatrice_common ${CMAKE_THREAD_LIBS_INIT} Qt5::WinMain)
+    TARGET_LINK_LIBRARIES(servatrice cockatrice_common ${CMAKE_THREAD_LIBS_INIT} ${SERVATRICE_QT_MODULES} Qt5::WinMain)
 else()
-    TARGET_LINK_LIBRARIES(servatrice cockatrice_common ${CMAKE_THREAD_LIBS_INIT})
+    TARGET_LINK_LIBRARIES(servatrice cockatrice_common ${CMAKE_THREAD_LIBS_INIT} ${SERVATRICE_QT_MODULES})
 endif()
-qt5_use_modules(servatrice ${SERVATRICE_QT_MODULES})
 
 # install rules
 if(UNIX)

--- a/tests/carddatabase/CMakeLists.txt
+++ b/tests/carddatabase/CMakeLists.txt
@@ -8,25 +8,9 @@ add_executable(carddatabase_test
 if(NOT GTEST_FOUND)
     add_dependencies(carddatabase_test gtest)
 endif()
-target_link_libraries(carddatabase_test ${GTEST_BOTH_LIBRARIES})
+
+find_package(Qt5 COMPONENTS Concurrent Network Widgets REQUIRED)
+set(TEST_QT_MODULES Qt5::Concurrent Qt5::Network Qt5::Widgets)
+
+target_link_libraries(carddatabase_test ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES})
 add_test(NAME carddatabase_test COMMAND carddatabase_test)
-
-# qt5 stuff
-include_directories(${Qt5Widgets_INCLUDE_DIRS})
-list(APPEND COCKATRICE_LIBS Widgets)
-
-# QtConcurrent
-find_package(Qt5Concurrent)
-if(Qt5Concurrent_FOUND)
-    include_directories(${Qt5Concurrent_INCLUDE_DIRS})
-    list(APPEND ORACLE_LIBS Concurrent)
-endif()
-
-# QtNetwork
-find_package(Qt5Network)
-if(Qt5Network_FOUND)
-    include_directories(${Qt5Network_INCLUDE_DIRS})
-    list(APPEND COCKATRICE_LIBS Network)
-endif()
-
-qt5_use_modules(carddatabase_test ${COCKATRICE_LIBS})

--- a/tests/loading_from_clipboard/CMakeLists.txt
+++ b/tests/loading_from_clipboard/CMakeLists.txt
@@ -8,32 +8,8 @@ if(NOT GTEST_FOUND)
     add_dependencies(loading_from_clipboard_test gtest)
 endif()
 
-target_link_libraries(loading_from_clipboard_test ${GTEST_BOTH_LIBRARIES})
-target_link_libraries(loading_from_clipboard_test cockatrice_common)
+find_package(Qt5 COMPONENTS Concurrent Network Widgets REQUIRED)
+set(TEST_QT_MODULES Qt5::Concurrent Qt5::Network Qt5::Widgets)
 
+target_link_libraries(loading_from_clipboard_test cockatrice_common ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES})
 add_test(NAME loading_from_clipboard_test COMMAND loading_from_clipboard_test)
-
-#### I feel like the rest of this file should not be necessary and
-#### is (effective) cargo culting of tests/carddatabase/CMakeLists.txt.
-#### Ideally we would only need to say "hey this test is against something from cockatrice_common",
-#### and cockatrice_common would declare all of it's dependencies. I need to learn more about CMake.
-
-# qt5 stuff
-include_directories(${Qt5Widgets_INCLUDE_DIRS})
-list(APPEND COCKATRICE_LIBS Widgets)
-
-# QtConcurrent
-find_package(Qt5Concurrent)
-if(Qt5Concurrent_FOUND)
-    include_directories(${Qt5Concurrent_INCLUDE_DIRS})
-    list(APPEND ORACLE_LIBS Concurrent)
-endif()
-
-# QtNetwork
-find_package(Qt5Network)
-if(Qt5Network_FOUND)
-    include_directories(${Qt5Network_INCLUDE_DIRS})
-    list(APPEND COCKATRICE_LIBS Network)
-endif()
-
-qt5_use_modules(loading_from_clipboard_test ${COCKATRICE_LIBS})


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3257

## Short roundup of the initial problem
In the newly-released Qt version 5.11's cmake modules some deprecated methods used to link Qt libraries have been removed

## What will change with this Pull Request?
Switched to the new methods. I'm unsure whether this will work on on ancient Qt version.
**EDIT**: it works with CMake >= 2.8.11 and Qt >= 5.1, so we should be fine.
In CMakeLists.txt we require Qt 5.0.3, so we should probably raise that number, but i have no way to test all the old Qt versions on linux right now.