### PR TITLE
actCancel cleanup

### DIFF
--- a/cockatrice/src/dlg_edit_avatar.cpp
+++ b/cockatrice/src/dlg_edit_avatar.cpp
@@ -29,7 +29,7 @@ DlgEditAvatar::DlgEditAvatar(QWidget *parent) : QDialog(parent)
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(actCancel()));
+    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(grid);
@@ -44,11 +44,6 @@ DlgEditAvatar::DlgEditAvatar(QWidget *parent) : QDialog(parent)
 void DlgEditAvatar::actOk()
 {
     accept();
-}
-
-void DlgEditAvatar::actCancel()
-{
-    reject();
 }
 
 void DlgEditAvatar::actBrowse()

--- a/cockatrice/src/dlg_edit_avatar.h
+++ b/cockatrice/src/dlg_edit_avatar.h
@@ -17,7 +17,6 @@ public:
     QByteArray getImage();
 private slots:
     void actOk();
-    void actCancel();
     void actBrowse();
 
 private:

--- a/cockatrice/src/dlg_edit_password.cpp
+++ b/cockatrice/src/dlg_edit_password.cpp
@@ -39,7 +39,7 @@ DlgEditPassword::DlgEditPassword(QWidget *parent) : QDialog(parent)
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(actCancel()));
+    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(grid);
@@ -61,9 +61,4 @@ void DlgEditPassword::actOk()
     // always save the password so it will be picked up by the connect dialog
     settingsCache->servers().setPassword(newPasswordEdit->text());
     accept();
-}
-
-void DlgEditPassword::actCancel()
-{
-    reject();
 }

--- a/cockatrice/src/dlg_edit_password.h
+++ b/cockatrice/src/dlg_edit_password.h
@@ -24,7 +24,6 @@ public:
     }
 private slots:
     void actOk();
-    void actCancel();
 
 private:
     QLabel *oldPasswordLabel, *newPasswordLabel, *newPasswordLabel2;

--- a/cockatrice/src/dlg_edit_user.cpp
+++ b/cockatrice/src/dlg_edit_user.cpp
@@ -45,7 +45,7 @@ DlgEditUser::DlgEditUser(QWidget *parent, QString email, QString country, QStrin
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(actCancel()));
+    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(grid);
@@ -60,9 +60,4 @@ DlgEditUser::DlgEditUser(QWidget *parent, QString email, QString country, QStrin
 void DlgEditUser::actOk()
 {
     accept();
-}
-
-void DlgEditUser::actCancel()
-{
-    reject();
 }

--- a/cockatrice/src/dlg_edit_user.h
+++ b/cockatrice/src/dlg_edit_user.h
@@ -35,7 +35,6 @@ public:
     }
 private slots:
     void actOk();
-    void actCancel();
 
 private:
     QLabel *emailLabel, *countryLabel, *realnameLabel;

--- a/cockatrice/src/dlg_forgotpasswordchallenge.cpp
+++ b/cockatrice/src/dlg_forgotpasswordchallenge.cpp
@@ -31,7 +31,7 @@ DlgForgotPasswordChallenge::DlgForgotPasswordChallenge(QWidget *parent) : QDialo
         QMessageBox::warning(this, tr("Forgot Password Challenge Warning"),
                              tr("Oops, looks like something has gone wrong.  Please restart the forgot password "
                                 "process by using the forgot password button on the connection screen."));
-        actCancel();
+        reject();
     }
 
     hostLabel = new QLabel(tr("&Host:"));
@@ -72,7 +72,7 @@ DlgForgotPasswordChallenge::DlgForgotPasswordChallenge(QWidget *parent) : QDialo
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(actCancel()));
+    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(grid);
@@ -96,9 +96,4 @@ void DlgForgotPasswordChallenge::actOk()
     settingsCache->servers().setFPPlayerName(playernameEdit->text());
 
     accept();
-}
-
-void DlgForgotPasswordChallenge::actCancel()
-{
-    reject();
 }

--- a/cockatrice/src/dlg_forgotpasswordchallenge.h
+++ b/cockatrice/src/dlg_forgotpasswordchallenge.h
@@ -32,7 +32,6 @@ public:
     }
 private slots:
     void actOk();
-    void actCancel();
 
 private:
     QLabel *hostLabel, *portLabel, *playernameLabel, *emailLabel;

--- a/cockatrice/src/dlg_forgotpasswordrequest.cpp
+++ b/cockatrice/src/dlg_forgotpasswordrequest.cpp
@@ -48,7 +48,7 @@ DlgForgotPasswordRequest::DlgForgotPasswordRequest(QWidget *parent) : QDialog(pa
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(actCancel()));
+    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(grid);
@@ -72,9 +72,4 @@ void DlgForgotPasswordRequest::actOk()
     settingsCache->servers().setFPPlayerName(playernameEdit->text());
 
     accept();
-}
-
-void DlgForgotPasswordRequest::actCancel()
-{
-    reject();
 }

--- a/cockatrice/src/dlg_forgotpasswordrequest.h
+++ b/cockatrice/src/dlg_forgotpasswordrequest.h
@@ -28,7 +28,6 @@ public:
     }
 private slots:
     void actOk();
-    void actCancel();
 
 private:
     QLabel *hostLabel, *portLabel, *playernameLabel;

--- a/cockatrice/src/dlg_forgotpasswordreset.cpp
+++ b/cockatrice/src/dlg_forgotpasswordreset.cpp
@@ -31,7 +31,7 @@ DlgForgotPasswordReset::DlgForgotPasswordReset(QWidget *parent) : QDialog(parent
         QMessageBox::warning(this, tr("Forgot Password Reset Warning"),
                              tr("Opps, looks like something has gone wrong.  Please re-start the forgot password "
                                 "process by using the forgot password button on the connection screen."));
-        actCancel();
+        reject();
     }
 
     hostLabel = new QLabel(tr("&Host:"));
@@ -86,7 +86,7 @@ DlgForgotPasswordReset::DlgForgotPasswordReset(QWidget *parent) : QDialog(parent
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(actCancel()));
+    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(grid);
@@ -125,9 +125,4 @@ void DlgForgotPasswordReset::actOk()
     settingsCache->servers().setFPPlayerName(playernameEdit->text());
 
     accept();
-}
-
-void DlgForgotPasswordReset::actCancel()
-{
-    reject();
 }

--- a/cockatrice/src/dlg_forgotpasswordreset.h
+++ b/cockatrice/src/dlg_forgotpasswordreset.h
@@ -36,7 +36,6 @@ public:
     }
 private slots:
     void actOk();
-    void actCancel();
 
 private:
     QLabel *hostLabel, *portLabel, *playernameLabel, *tokenLabel, *newpasswordLabel, *newpasswordverifyLabel;

--- a/cockatrice/src/dlg_register.cpp
+++ b/cockatrice/src/dlg_register.cpp
@@ -326,7 +326,7 @@ DlgRegister::DlgRegister(QWidget *parent) : QDialog(parent)
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(actCancel()));
+    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(grid);
@@ -360,9 +360,4 @@ void DlgRegister::actOk()
     settingsCache->servers().setPassword(passwordEdit->text());
 
     accept();
-}
-
-void DlgRegister::actCancel()
-{
-    reject();
 }

--- a/cockatrice/src/dlg_register.h
+++ b/cockatrice/src/dlg_register.h
@@ -48,7 +48,6 @@ public:
     }
 private slots:
     void actOk();
-    void actCancel();
 
 private:
     QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *passwordConfirmationLabel, *emailLabel,


### PR DESCRIPTION
## Short roundup of the initial problem
actCancel was only used to `reject()`

## What will change with this Pull Request?
- call `reject` directly from the button

Realized when doing https://github.com/Cockatrice/Cockatrice/pull/3243/commits/cb4df951b14b2abaa3d358f36354f6d5da868c53 and the corresponding PR.
