### PR TITLE
appveyor: skip branches with open pull requests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,6 +17,8 @@ skip_commits:
     - Dockerfile
     - LICENSE
 
+skip_branch_with_pr: true
+
 image: Visual Studio 2017
 
 cache:


### PR DESCRIPTION
## Short roundup of the initial problem
If the source branch for a pr was in our repo, two builds got created for appveyor.
One for the branch and one for the pr.

## What will change with this Pull Request?
- only build the pr commit

See https://www.appveyor.com/docs/appveyor-yml/

(for travis, this is not yet possible)