### PR TITLE
travis: remove unneeded debug builds on tags for faster release deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: cpp
 
 cache: ccache
 
+conditions: v1
+
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     dist: trusty
     group: stable
     env: BUILDTYPE=Debug
-    # if: tag IS NOT present    see https://github.com/travis-ci/travis-conditions/pull/1
+    if: tag IS NOT present
   - os: linux
     dist: trusty
     group: stable
@@ -19,7 +19,7 @@ matrix:
   - os: osx
     osx_image: xcode8
     env: BUILDTYPE=Debug
-    # if: tag IS NOT present    see https://github.com/travis-ci/travis-conditions/pull/1
+    if: tag IS NOT present
   - os: osx
     osx_image: xcode8
     env: BUILDTYPE=Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
     dist: trusty
     group: stable
     env: BUILDTYPE=Debug
+    # if: tag IS NOT present    see https://github.com/travis-ci/travis-conditions/pull/1
   - os: linux
     dist: trusty
     group: stable
@@ -18,6 +19,7 @@ matrix:
   - os: osx
     osx_image: xcode8
     env: BUILDTYPE=Debug
+    # if: tag IS NOT present    see https://github.com/travis-ci/travis-conditions/pull/1
   - os: osx
     osx_image: xcode8
     env: BUILDTYPE=Release


### PR DESCRIPTION
```
ONLY merge once https://github.com/travis-ci/travis-conditions/pull/1 is merged

Update:
They put a doc pr up, too: https://github.com/travis-ci/docs-travis-ci-com/pull/1884
```


## Short roundup of the initial problem
Even on tagged commits which we only use to automatically deploy releases from master from within the release build, there was a debug build created at travis. This delays the deployment process itself.
When the tag is added, the same commit which is receiving the tag was build as debug from master branch before anyway. So we are not skipping something.

## What will change with this Pull Request?
- always create debug build, except for tags