### PR TITLE
Remove hardcoded path to vc_redist.exe; Fix #3252

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,11 @@ IF(WIN32)
     FIND_PACKAGE(Win32SslRuntime)
 ENDIF()
 
+#Find VCredist
+IF(MSVC)
+    FIND_PACKAGE(VCredistRuntime)
+ENDIF()
+
 # Package builder
 set(CPACK_PACKAGE_CONTACT "Gavin Bisesi <Daenyth+github@gmail.com>")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY ${PROJECT_NAME})
@@ -206,13 +211,9 @@ elseif(WIN32)
     )
 
     # include vcredist into the package; NSIS will take care of running it
-    IF(MSVC)
-        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-            INSTALL(FILES "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/redist/MSVC/14.14.26405/vc_redist.x64.exe" DESTINATION ./)
-        else()
-            INSTALL(FILES "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/redist/MSVC/14.14.26405/vc_redist.x86.exe" DESTINATION ./)
-        endif()
-    ENDIF()
+    if(VCREDISTRUNTIME_FOUND)
+        INSTALL(FILES "${VCREDISTRUNTIME_FILE}" DESTINATION ./)
+    endif()
 endif()
 
 include(CPack)

--- a/cmake/FindVCredistRuntime.cmake
+++ b/cmake/FindVCredistRuntime.cmake
@@ -1,0 +1,36 @@
+# Find the MS Visual Studio VC redistributable package
+
+if (WIN32)
+    set(VCREDISTRUNTIME_FOUND "NO")
+
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8) # 64-bit
+        set(REDIST_ARCH x64)
+    else()
+        set(REDIST_ARCH x86)
+    endif()
+
+    set(REDIST_FILE vc_redist.${REDIST_ARCH}.exe)
+
+    set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE)
+    include(InstallRequiredSystemLibraries)
+
+    # Check if the list contains minimum one element, to get the path from
+    list(LENGTH CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS libsCount)
+    if (libsCount GREATER 0)
+        list(GET CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS 0 _path)
+
+        get_filename_component(_path ${_path} DIRECTORY)
+        get_filename_component(_path ${_path}/../../ ABSOLUTE)
+
+        if (EXISTS "${_path}/${REDIST_FILE}") # VS 2017
+            set(VCREDISTRUNTIME_FOUND "YES")
+            set(VCREDISTRUNTIME_FILE ${_path}/${REDIST_FILE})
+        endif()
+    endif()
+
+    if(VCREDISTRUNTIME_FOUND)
+      message(STATUS "Found VCredist ${VCREDISTRUNTIME_FILE}")
+    else()
+      message(WARNING "Could not find VCredist package. It's not required for compiling, but needs to be available at runtime.")
+    endif()
+endif()


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3252

## Short roundup of the initial problem
We bundle the MS visual studio redistributable libraries package (vcredist) inside out windows NSIS package.
The path to the vcredist was hardcoded inside CMakeLists.txt, but it contains the MSVC version number, so every time Visual Studio gets updated the path changes.

## What will change with this Pull Request?
The path to vcredist gets deduced dynamically from the path where the basic MSVC libraries are found by cmake.

