### PR TITLE
Fix archlinux compilation by fixing error-warnings `ignored qualifiers` and `implicit fallthrough`

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -317,7 +317,7 @@ void CardItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
             2 * QApplication::startDragDistance())
             return;
         if (zone->getIsView()) {
-            const ZoneViewZone *const view = static_cast<const ZoneViewZone *const>(zone);
+            const ZoneViewZone *view = static_cast<const ZoneViewZone *>(zone);
             if (view->getRevealZone() && !view->getWriteableRevealZone())
                 return;
         } else if (!owner->getLocal())

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -196,6 +196,8 @@ QVariant GamesModel::headerData(int section, Qt::Orientation /*orientation*/, in
                     return tr("Age");
                 case Qt::TextAlignmentRole:
                     return Qt::AlignCenter;
+                default:
+                    return QVariant();
             }
         }
         case DESCRIPTION:
@@ -212,6 +214,8 @@ QVariant GamesModel::headerData(int section, Qt::Orientation /*orientation*/, in
                     return tr("Players");
                 case Qt::TextAlignmentRole:
                     return Qt::AlignCenter;
+                default:
+                    return QVariant();
             }
         }
         case SPECTATORS:

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -1029,7 +1029,7 @@ void TabGame::eventPlayerPropertiesChanged(const Event_PlayerPropertiesChanged &
     playerListWidget->updatePlayerProperties(prop, eventPlayerId);
 
     const GameEventContext::ContextType contextType =
-        static_cast<const GameEventContext::ContextType>(getPbExtension(context));
+        static_cast<GameEventContext::ContextType>(getPbExtension(context));
     switch (contextType) {
         case GameEventContext::READY_START: {
             bool ready = prop.ready_start();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3240

## Short roundup of the initial problem
Compiling the newest Cockatrice fails under Archlinux. These are the cmake options I have used:

`-DCMAKE_BUILD_TYPE=Debug -DWITH_SERVER=1`

Output:
https://hastebin.com/ajahasacow.rb
https://hastebin.com/esigarajun.vbs

## What will change with this Pull Request?
- The code will be fixed, so that these warnings will no longer occur.
- Archlinux will be able to compile in Debug mode

