### PR TITLE
Fix Debug build on Ubuntu 18.04+ (faulty protobuf 3.0 version)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ ELSEIF (CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS_RELEASE "-s -O2")
     set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -O0 -Wall -Wextra -Werror")
 
-    set(ADDITIONAL_DEBUG_FLAGS -Wcast-align -Wmissing-declarations -Wno-long-long -Wno-error=extra -Wno-error=delete-non-virtual-dtor -Wno-error=sign-compare -Wno-error=missing-declarations)
+    set(ADDITIONAL_DEBUG_FLAGS -Wcast-align -Wmissing-declarations -Wno-long-long -Wno-error=extra -Wno-error=delete-non-virtual-dtor -Wno-error=sign-compare -Wno-error=missing-declarations -Wno-error=unused-parameter -Wno-error=misleading-indentation)
 
     FOREACH(FLAG ${ADDITIONAL_DEBUG_FLAGS})
         CHECK_CXX_COMPILER_FLAG("${FLAG}" CXX_HAS_WARNING_${FLAG})


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2343

## Short roundup of the initial problem
Due to the faulty protobuf version which is installed by default on Ubuntu 18.04 and 18.10 (discussed in #2343 ), the current cmake configuration throws warning-errors for `unused-parameter` and `misleading-indentation` in the protobuf generated code in Debug build.

Compiler log:
```
Scanning dependencies of target cockatrice_protocol
[ 31%] Building CXX object common/pb/CMakeFiles/cockatrice_protocol.dir/admin_commands.pb.cc.o
/builds/cockatrice/cockatrice/build/common/pb/admin_commands.pb.cc: In member function 'virtual google::protobuf::uint8* AdminCommand::InternalSerializeWithCachedSizesToArray(bool, google::protobuf::uint8*) const':
/builds/cockatrice/cockatrice/build/common/pb/admin_commands.pb.cc:367:10: error: unused parameter 'deterministic' [-Werror=unused-parameter]
     bool deterministic, ::google::protobuf::uint8* target) const {
          ^~~~~~~~~~~~~
/builds/cockatrice/cockatrice/build/common/pb/admin_commands.pb.cc: In member function 'virtual bool AdminCommand::IsInitialized() const':
/builds/cockatrice/cockatrice/build/common/pb/admin_commands.pb.cc:443:3: error: this 'if' clause does not guard... [-Werror=misleading-indentation]
   if (!_extensions_.IsInitialized()) return false;  return true;
   ^~
/builds/cockatrice/cockatrice/build/common/pb/admin_commands.pb.cc:443:53: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
   if (!_extensions_.IsInitialized()) return false;  return true;
                                                     ^~~~~~
/builds/cockatrice/cockatrice/build/common/pb/admin_commands.pb.cc: In member function 'virtual google::protobuf::uint8* Command_UpdateServerMessage::InternalSerializeWithCachedSizesToArray(bool, google::protobuf::uint8*) const':
/builds/cockatrice/cockatrice/build/common/pb/admin_commands.pb.cc:583:10: error: unused parameter 'deterministic' [-Werror=unused-parameter]
     bool deterministic, ::google::protobuf::uint8* target) const {
          ^~~~~~~~~~~~~
/builds/cockatrice/cockatrice/build/common/pb/admin_commands.pb.cc: In member function 'virtual google::protobuf::uint8* Command_ShutdownServer::InternalSerializeWithCachedSizesToArray(bool, google::protobuf::uint8*) const':
/builds/cockatrice/cockatrice/build/common/pb/admin_commands.pb.cc:853:10: error: unused parameter 'deterministic' [-Werror=unused-parameter]
     bool deterministic, ::google::protobuf::uint8* target) const {
          ^~~~~~~~~~~~~
/builds/cockatrice/cockatrice/build/common/pb/admin_commands.pb.cc: In member function 'virtual google::protobuf::uint8* Command_ReloadConfig::InternalSerializeWithCachedSizesToArray(bool, google::protobuf::uint8*) const':
/builds/cockatrice/cockatrice/build/common/pb/admin_commands.pb.cc:1182:10: error: unused parameter 'deterministic' [-Werror=unused-parameter]
     bool deterministic, ::google::protobuf::uint8* target) const {
          ^~~~~~~~~~~~~
/builds/cockatrice/cockatrice/build/common/pb/admin_commands.pb.cc: In member function 'virtual google::protobuf::uint8* Command_AdjustMod::InternalSerializeWithCachedSizesToArray(bool, google::protobuf::uint8*) const':
/builds/cockatrice/cockatrice/build/common/pb/admin_commands.pb.cc:1452:10: error: unused parameter 'deterministic' [-Werror=unused-parameter]
     bool deterministic, ::google::protobuf::uint8* target) const {
          ^~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
common/pb/CMakeFiles/cockatrice_protocol.dir/build.make:1278: recipe for target 'common/pb/CMakeFiles/cockatrice_protocol.dir/admin_commands.pb.cc.o' failed
make[2]: *** [common/pb/CMakeFiles/cockatrice_protocol.dir/admin_commands.pb.cc.o] Error 1
CMakeFiles/Makefile2:1073: recipe for target 'common/pb/CMakeFiles/cockatrice_protocol.dir/all' failed
make[1]: *** [common/pb/CMakeFiles/cockatrice_protocol.dir/all] Error 2
```

## What will change with this Pull Request?
The 2 warning-errors mentioned above and in #2343 will not be treated as errors anymore.


