### PR TITLE
Add -DWARNING_AS_ERROR=1 option to cmake script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,9 @@ elseif(WIN32)
     set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/release)
 endif()
 
+# Treat warnings as errors (Debug builds only)
+option(WARNING_AS_ERROR "Treat warnings as errors in debug builds" ON)
+
 # Define proper compilation flags
 IF(MSVC)
     # Visual Studio:
@@ -104,7 +107,11 @@ ELSEIF (CMAKE_COMPILER_IS_GNUCXX)
     include(CheckCXXCompilerFlag)
 
     set(CMAKE_CXX_FLAGS_RELEASE "-s -O2")
-    set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -O0 -Wall -Wextra -Werror")
+    if(WARNING_AS_ERROR)
+        set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -O0 -Wall -Wextra -Werror")
+    else()
+        set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -O0 -Wall -Wextra")
+    endif()
 
     set(ADDITIONAL_DEBUG_FLAGS -Wcast-align -Wmissing-declarations -Wno-long-long -Wno-error=extra -Wno-error=delete-non-virtual-dtor -Wno-error=sign-compare -Wno-error=missing-declarations)
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Cockatrice uses the [Google Developer Documentation Style Guide](https://develop
 # Translations [![Cockatrice on Transiflex](https://tx-assets.scdn5.secure.raxcdn.com/static/charts/images/tx-logo-micro.c5603f91c780.png)](https://www.transifex.com/projects/p/cockatrice/)
 
 Cockatrice uses Transifex for translations. You can help us bring Cockatrice and Oracle to your language or just edit single wordings right from within your browser by visiting our [Transifex project page](https://www.transifex.com/projects/p/cockatrice/).<br>
-   
+
 | Cockatrice | Oracle |
 |:-:|:-:|
 | [![Cockatrice Translation Status](https://www.transifex.com/projects/p/cockatrice/resource/cockatrice/chart/image_png/)](https://www.transifex.com/projects/p/cockatrice/) | [![Oracle Translation Status](https://www.transifex.com/projects/p/cockatrice/resource/oracle/chart/image_png/)](https://www.transifex.com/projects/p/cockatrice/) |
@@ -83,7 +83,7 @@ Check out our [Translator FAQ](https://github.com/Cockatrice/Cockatrice/wiki/Tra
 **Detailed compiling instructions are on the Cockatrice wiki under [Compiling Cockatrice](https://github.com/Cockatrice/Cockatrice/wiki/Compiling-Cockatrice)**
 
 Dependencies:
-- [Qt](https://www.qt.io/developers/) 
+- [Qt](https://www.qt.io/developers/)
 - [protobuf](https://github.com/google/protobuf)
 - [CMake](https://www.cmake.org/)
 
@@ -96,7 +96,7 @@ To compile:
     cd build
     cmake ..
     make
-    
+
 You can then run
 
     make install
@@ -113,14 +113,15 @@ The following flags can be passed to `cmake`:
 - `-DWITH_CLIENT=0` Whether to build the client (default 1 = yes).
 - `-DWITH_ORACLE=0` Whether to build oracle (default 1 = yes).
 - `-DCMAKE_BUILD_TYPE=Debug` Compile in debug mode. Enables extra logging output, debug symbols, and much more verbose compiler warnings (default `Release`).
+- `-DWARNING_AS_ERROR=0` Whether to treat compilation warnings as errors in debug mode (default 1 = yes).
 - `-DUPDATE_TRANSLATIONS=1` Configure `make` to update the translation .ts files for new strings in the source code. Note: Running `make clean` will remove the .ts files (default 0 = no).
 - `-DTEST=1` Enable regression tests (default 0 = no). Note: needs googletest, will be downloaded on the fly if unavailable. To run tests: ```make test```.
 
 
 # Run
 
-`Cockatrice` is the game client    
-`Oracle` fetches card data    
+`Cockatrice` is the game client
+`Oracle` fetches card data
 `Servatrice` is the server<br>
 
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2343

## Short roundup of the initial problem
Linux builds in debug mode treat warning as errors, this means that even a non-fatal error results in a fail when compiling.
This is good because it helps us spotting problems, but can cause headaches to users when compiling on platforms that we didn't test yet (eg. gcc 8.1 #3240) or that we already know are broken (eg. protobuf 3.0.0 #2343)

## What will change with this Pull Request?
A new "treat warnings as errors" option has been added to the cmake script, default ON (to mimic the old behavior). It can be disabled using `cmake ... -DWARNING_AS_ERROR=0` and it persists on the following builds.
