### PR TITLE
Duplicate cards & empty setlist

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -433,6 +433,19 @@ void CardDatabase::addCard(CardInfoPtr card)
         return;
     }
 
+    // if card already exists just add the new set property
+    if (cards.contains(card->getName())) {
+        CardInfoPtr sameCard = cards[card->getName()];
+        for (auto set : card->getSets()) {
+            QString setName = set->getCorrectedShortName();
+            sameCard->setSet(set);
+            sameCard->setMuId(setName, card->getMuId(setName));
+            sameCard->setRarity(setName, card->getRarity(setName));
+            sameCard->setSetNumber(setName, card->getCollectorNumber(setName));
+        }
+        return;
+    }
+
     addCardMutex->lock();
     cards.insert(card->getName(), card);
     simpleNameCards.insert(card->getSimpleName(), card);
@@ -445,10 +458,6 @@ void CardDatabase::removeCard(CardInfoPtr card)
     if (card.isNull()) {
         qDebug() << "removeCard(nullptr)";
         return;
-    }
-
-    if (card->getName() == QString("Act of Treason")) {
-        qDebug() << "vagyok";
     }
 
     for (auto *cardRelation : card->getRelatedCards())

--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -444,19 +444,18 @@ void CardDatabase::removeCard(CardInfoPtr card)
         return;
     }
 
-    foreach (CardRelation *cardRelation, card->getRelatedCards())
+    for (auto *cardRelation : card->getRelatedCards())
         cardRelation->deleteLater();
 
-    foreach (CardRelation *cardRelation, card->getReverseRelatedCards())
+    for (auto *cardRelation : card->getReverseRelatedCards())
         cardRelation->deleteLater();
 
-    foreach (CardRelation *cardRelation, card->getReverseRelatedCards2Me())
+    for (auto *cardRelation : card->getReverseRelatedCards2Me())
         cardRelation->deleteLater();
 
     removeCardMutex->lock();
     cards.remove(card->getName());
     simpleNameCards.remove(card->getSimpleName());
-    card.clear();
     removeCardMutex->unlock();
     emit cardRemoved(card);
 }
@@ -567,8 +566,7 @@ LoadStatus CardDatabase::loadCardDatabases()
 
     // load custom card databases
     QDir dir(settingsCache->getCustomCardDatabasePath());
-    foreach (QString fileName,
-             dir.entryList(QStringList("*.xml"), QDir::Files | QDir::Readable, QDir::Name | QDir::IgnoreCase)) {
+    for (QString fileName : dir.entryList(QStringList("*.xml"), QDir::Files | QDir::Readable, QDir::Name | QDir::IgnoreCase)) {
         loadCardDatabase(dir.absoluteFilePath(fileName));
     }
 

--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -566,7 +566,8 @@ LoadStatus CardDatabase::loadCardDatabases()
 
     // load custom card databases
     QDir dir(settingsCache->getCustomCardDatabasePath());
-    for (QString fileName : dir.entryList(QStringList("*.xml"), QDir::Files | QDir::Readable, QDir::Name | QDir::IgnoreCase)) {
+    for (QString fileName :
+         dir.entryList(QStringList("*.xml"), QDir::Files | QDir::Readable, QDir::Name | QDir::IgnoreCase)) {
         loadCardDatabase(dir.absoluteFilePath(fileName));
     }
 

--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -335,6 +335,11 @@ public:
     // void setLoyalty(int _loyalty) { loyalty = _loyalty; emit cardInfoChanged(smartThis); }
     // void setCustomPicURL(const QString &_set, const QString &_customPicURL) { customPicURLs.insert(_set,
     // _customPicURL); }
+    void setSet(const CardSetPtr &_set)
+    {
+        sets.append(_set);
+        refreshCachedSetNames();
+    }
     void setMuId(const QString &_set, const int &_muId)
     {
         muIds.insert(_set, _muId);

--- a/cockatrice/src/carddbparser/carddatabaseparser.h
+++ b/cockatrice/src/carddbparser/carddatabaseparser.h
@@ -15,6 +15,7 @@ public:
     virtual bool getCanParseFile(const QString &name, QIODevice &device) = 0;
     virtual void parseFile(QIODevice &device) = 0;
     virtual bool saveToFile(SetNameMap sets, CardNameMap cards, const QString &fileName) = 0;
+    virtual void clearSetlist() = 0;
 signals:
     virtual void addCard(CardInfoPtr card) = 0;
 };

--- a/cockatrice/src/carddbparser/cockatricexml3.cpp
+++ b/cockatrice/src/carddbparser/cockatricexml3.cpp
@@ -80,6 +80,10 @@ CardSetPtr CockatriceXml3Parser::internalAddSet(const QString &setName,
     return newSet;
 }
 
+void CockatriceXml3Parser::clearSetlist() {
+    sets.clear();
+}
+
 void CockatriceXml3Parser::loadSetsFromXml(QXmlStreamReader &xml)
 {
     while (!xml.atEnd()) {

--- a/cockatrice/src/carddbparser/cockatricexml3.cpp
+++ b/cockatrice/src/carddbparser/cockatricexml3.cpp
@@ -80,7 +80,8 @@ CardSetPtr CockatriceXml3Parser::internalAddSet(const QString &setName,
     return newSet;
 }
 
-void CockatriceXml3Parser::clearSetlist() {
+void CockatriceXml3Parser::clearSetlist()
+{
     sets.clear();
 }
 

--- a/cockatrice/src/carddbparser/cockatricexml3.h
+++ b/cockatrice/src/carddbparser/cockatricexml3.h
@@ -15,6 +15,7 @@ public:
     bool getCanParseFile(const QString &name, QIODevice &device);
     void parseFile(QIODevice &device);
     bool saveToFile(SetNameMap sets, CardNameMap cards, const QString &fileName);
+    void clearSetlist();
 
 private:
     /*


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3129 and #3264 

## Short roundup of the initial problem
- After running any kind of database update, the cardlist view didn't clear its rows, so after reloading each card got duplicated.
- When spoilers were enabled, reprinted cards in the new set were shown in separate rows instead of grouped with earlier sets (e.g. Act of Treason, or Air Elemental in M19).
- After database update Cockatrice popped up a "first time setup" window, which showed an empty setlist. The manage sets window after this didn't show any sets even after manually reopening it. Only program restart made the sets appear again.

## What will change with this Pull Request?
- Reprint cards in spoilers will be grouped with other cards of the same name.
- The duplicate cards were caused by [this line](https://github.com/Cockatrice/Cockatrice/blob/master/cockatrice/src/carddatabase.cpp#L459). Since the card info got cleared before the `cardRemoved` signal got emitted, the signal contained only an empty pointer which couldn't be processed by the slot of the view (which actually clears the card pointer itself).
- The empty set list was shown because even though the setlist in the card database got cleared after update, a duplicate (subset) of this setlist is stored for each loaded `xml` database which didn't reset. After reload they only emit the `addSet` signal if they recognize a new set, which didn't happen due to them not being cleared by the reload operation. I defined a `clearSetList` interface to them, which now gets called on database reloading.
- Some useless code got removed and some `foreach` blocks got replaced with `for` blocks.