### PR TITLE
add feature list requirement

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.5.2-branch-{branch}-build-{build}
+version: 2.6.0-branch-{branch}-build-{build}
 
 # Skipping commits affecting specific files (GitHub only). More details here: https://www.appveyor.com/docs/appveyor-yml
 skip_commits:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 # A project name is needed for CPack
 # Version can be overriden by git tags, see cmake/getversion.cmake
-PROJECT("Cockatrice" VERSION 2.5.2)
+PROJECT("Cockatrice" VERSION 2.6.0)
 
 # Use c++11 for all targets
 set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ ISO Standard")

--- a/common/featureset.cpp
+++ b/common/featureset.cpp
@@ -23,6 +23,7 @@ void FeatureSet::initalizeFeatureList(QMap<QString, bool> &featureList)
     featureList.insert("mod_log_lookup", false);
     featureList.insert("idle_client", false);
     featureList.insert("forgot_password", false);
+    featureList.insert("2.6.0_min_version", false); // This is temp to force users onto a newer client
 }
 
 void FeatureSet::enableRequiredFeature(QMap<QString, bool> &featureList, QString featureName)


### PR DESCRIPTION
This adds the requirement for users to be pushed to the newest version. It's a temporary addition while the WW->RR transition occurs, as users need a bit of a 'push' to get off the links and we can disassociate WW from the program.