### PR TITLE
Add ability to edit chat macros; Fix #3296

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -690,6 +690,9 @@ MessagesSettingsPage::MessagesSettingsPage()
     aAdd = new QAction(this);
     aAdd->setIcon(QPixmap("theme:icons/increment"));
     connect(aAdd, SIGNAL(triggered()), this, SLOT(actAdd()));
+    aEdit = new QAction(this);
+    aEdit->setIcon(QPixmap("theme:icons/pencil"));
+    connect(aEdit, SIGNAL(triggered()), this, SLOT(actEdit()));
     aRemove = new QAction(this);
     aRemove->setIcon(QPixmap("theme:icons/decrement"));
     connect(aRemove, SIGNAL(triggered()), this, SLOT(actRemove()));
@@ -698,6 +701,8 @@ MessagesSettingsPage::MessagesSettingsPage()
     messageToolBar->setOrientation(Qt::Vertical);
     messageToolBar->addAction(aAdd);
     messageToolBar->addAction(aRemove);
+    messageToolBar->addAction(aEdit);
+    messageToolBar->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::MinimumExpanding);
 
     auto *messageListLayout = new QHBoxLayout;
     messageListLayout->addWidget(messageToolBar);
@@ -775,6 +780,19 @@ void MessagesSettingsPage::actAdd()
     if (ok) {
         messageList->addItem(msg);
         storeSettings();
+    }
+}
+
+void MessagesSettingsPage::actEdit()
+{
+    if (messageList->currentItem()) {
+        QString oldText = messageList->currentItem()->text();
+        bool ok;
+        QString msg = QInputDialog::getText(this, tr("Edit message"), tr("Message:"), QLineEdit::Normal, oldText, &ok);
+        if (ok) {
+            messageList->currentItem()->setText(msg);
+            storeSettings();
+        }
     }
 }
 

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -171,6 +171,7 @@ public:
 
 private slots:
     void actAdd();
+    void actEdit();
     void actRemove();
     void updateColor(const QString &value);
     void updateHighlightColor(const QString &value);
@@ -180,6 +181,7 @@ private slots:
 private:
     QListWidget *messageList;
     QAction *aAdd;
+    QAction *aEdit;
     QAction *aRemove;
     QCheckBox chatMentionCheckBox;
     QCheckBox chatMentionCompleterCheckbox;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3296

## Short roundup of the initial problem
Chat macros are not editable, you can only add or remove them

## What will change with this Pull Request?
- A new "edit" button is added to the list.

## Screenshots
![schermata 2018-06-19 alle 17 39 21](https://user-images.githubusercontent.com/1631111/41608014-bdab8724-73e7-11e8-8bee-012062a9028c.png)

