### PR TITLE
Card tap/untap animation: ensure card rotation doen't overflow boundaries; possibly fix #3285

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -402,10 +402,19 @@ void CardItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
 bool CardItem::animationEvent()
 {
     int rotation = ROTATION_DEGREES_PER_FRAME;
+    bool animationIncomplete = true;
     if (!tapped)
         rotation *= -1;
 
     tapAngle += rotation;
+    if (tapped && (tapAngle > 90)) {
+        tapAngle = 90;
+        animationIncomplete = false;
+    }
+    if (!tapped && (tapAngle < 0)) {
+        tapAngle = 0;
+        animationIncomplete = false;
+    }
 
     setTransform(QTransform()
                      .translate(CARD_WIDTH_HALF, CARD_HEIGHT_HALF)
@@ -414,9 +423,7 @@ bool CardItem::animationEvent()
     setHovered(false);
     update();
 
-    if ((tapped && (tapAngle >= 90)) || (!tapped && (tapAngle <= 0)))
-        return false;
-    return true;
+    return animationIncomplete;
 }
 
 QVariant CardItem::itemChange(GraphicsItemChange change, const QVariant &value)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3285

## Short roundup of the initial problem
A user reported that, when untapped, cards gets rotated "too much", so they didn't end up being straight.
It looks like the card tap/untap animation moves the card by 10 degrees until the value reaches or exceeds the minimum / maximum (0 or 90 degrees), but it doesn't really enforce these values.

## What will change with this Pull Request?
The card rotation is clamped between 0 and 90 degrees, so that cards can't be rotated out of that range.
