### PR TITLE
Correctly report package version to cpack; fix #3235

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # provides the cockatrice binary
 
-PROJECT(Cockatrice)
+PROJECT(Cockatrice VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 
 SET(cockatrice_SOURCES
     src/abstractcounter.cpp
@@ -196,6 +196,7 @@ if(UNIX)
         set(MACOSX_BUNDLE_BUNDLE_NAME "${PROJECT_NAME}")
         set(MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION})
         set(MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION})
+
         set_target_properties(cockatrice PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/cmake/Info.plist)
 
         INSTALL(TARGETS cockatrice BUNDLE DESTINATION ./)

--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # provides the oracle binary
 
-PROJECT(Oracle)
+PROJECT(Oracle VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 
 # paths
 set(DESKTOPDIR share/applications CACHE STRING "path to .desktop files")

--- a/servatrice/CMakeLists.txt
+++ b/servatrice/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # provides the servatrice binary
 
-PROJECT(Servatrice)
+PROJECT(Servatrice VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 
 SET(servatrice_SOURCES
     src/main.cpp


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3235

## Short roundup of the initial problem
Cmake didn't propagate project version to each application's project; this caused cpack not to include the version number in application bundles under macOS.

## What will change with this Pull Request?
Version number s propagated between projects
