### PR TITLE
Tips close with the main window

### DIFF
--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -22,7 +22,6 @@
 #include "QtNetwork/QNetworkInterface"
 #include "carddatabase.h"
 #include "dlg_settings.h"
-#include "dlg_tip_of_the_day.h"
 #include "featureset.h"
 #include "logger.h"
 #include "pixmapgenerator.h"
@@ -141,11 +140,6 @@ int main(int argc, char *argv[])
 
     ui.show();
     qDebug("main(): ui.show() finished");
-
-    DlgTipOfTheDay tip;
-    if (tip.successfulInit && settingsCache->getShowTipsOnStartup() && tip.newTipsAvailable) {
-        tip.show();
-    }
 
     app.setAttribute(Qt::AA_UseHighDpiPixmaps);
     app.exec();

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -317,9 +317,10 @@ void MainWindow::actAbout()
 
 void MainWindow::actTips()
 {
-    DlgTipOfTheDay tip;
-    if (tip.successfulInit) {
-        tip.exec();
+    delete tip;
+    tip = new DlgTipOfTheDay();
+    if (tip->successfulInit) {
+        tip->show();
     }
 }
 
@@ -819,10 +820,16 @@ MainWindow::MainWindow(QWidget *parent)
         qDebug() << "Spoilers Disabled";
         QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
     }
+
+    tip = new DlgTipOfTheDay();
+    if (tip->successfulInit && settingsCache->getShowTipsOnStartup() && tip->newTipsAvailable) {
+        tip->show();
+    }
 }
 
 MainWindow::~MainWindow()
 {
+    delete tip;
     if (trayIcon) {
         trayIcon->hide();
         trayIcon->deleteLater();
@@ -885,6 +892,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
         bClosingDown = false;
         return;
     }
+    tip->close();
 
     event->accept();
     settingsCache->setMainWindowGeometry(saveGeometry());

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -317,7 +317,10 @@ void MainWindow::actAbout()
 
 void MainWindow::actTips()
 {
-    delete tip;
+    if (tip != NULL) {
+        delete tip;
+        tip = NULL;
+    }
     tip = new DlgTipOfTheDay();
     if (tip->successfulInit) {
         tip->show();
@@ -829,7 +832,10 @@ MainWindow::MainWindow(QWidget *parent)
 
 MainWindow::~MainWindow()
 {
-    delete tip;
+    if (tip != NULL) {
+        delete tip;
+        tip = NULL;
+    }
     if (trayIcon) {
         trayIcon->hide();
         trayIcon->deleteLater();

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -41,6 +41,7 @@ class RemoteClient;
 class ServerInfo_User;
 class TabSupervisor;
 class WndSets;
+class DlgTipOfTheDay;
 
 class MainWindow : public QMainWindow
 {
@@ -133,6 +134,7 @@ private:
     DlgViewLog *logviewDialog;
     DlgConnect *dlgConnect;
     GameReplay *replay;
+    DlgTipOfTheDay *tip;
 
 public:
     explicit MainWindow(QWidget *parent = nullptr);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3199 

## Short roundup of the initial problem
Tip of the Day window was left open after the main window have been closed. This only happened with the initial tip window, the one opened from the Help menu blocked the main window during running.

## What will change with this Pull Request?
- Main window will be available while a the Tip of The Day window is open (if opened from help menu)
- Tip of the Day window will close as the main window closes
- It was possible to have two opened tip windows at the same time, if one was opened automatically on program start, and one was opened manually from the menu. This bug has been fixed as well.
