### PR TITLE
Fix cards loading bug; fix #3262

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -388,8 +388,8 @@ CardDatabase::CardDatabase(QObject *parent) : QObject(parent), loadStatus(NotLoa
     availableParsers << new CockatriceXml3Parser;
 
     for (auto &parser : availableParsers) {
-        connect(parser, SIGNAL(addCard(CardInfoPtr)), this, SLOT(addCard(CardInfoPtr)));
-        connect(parser, SIGNAL(addSet(CardSetPtr)), this, SLOT(addSet(CardSetPtr)));
+        connect(parser, SIGNAL(addCard(CardInfoPtr)), this, SLOT(addCard(CardInfoPtr)), Qt::DirectConnection);
+        connect(parser, SIGNAL(addSet(CardSetPtr)), this, SLOT(addSet(CardSetPtr)), Qt::DirectConnection);
     }
 
     connect(settingsCache, SIGNAL(cardDatabasePathChanged()), this, SLOT(loadCardDatabases()));


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3262

## Short roundup of the initial problem
After the card database files gets loaded, a few steps are executed:
 * resolve reverse-related cards
 * check if no set is enabled or new sets are available
Due to a change introduced in #3223, under windows/linux these steps could happen to be executed before card databases are fully loaded, creating the following problems:
 * reverse related cards (mostly tokens) are not available;
 * at startup, the "no sets found" popup gets shown

## What will change with this Pull Request?
This trivial change ensures that cards are added at the right time, before the final steps gets executed.
