### PR TITLE
travis: switch to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ matrix:
   fast_finish: true
   include:
   - os: linux
-    dist: trusty
+    dist: xenial
     group: stable
     env: BUILDTYPE=Debug
     if: tag IS NOT present
   - os: linux
-    dist: trusty
+    dist: xenial
     group: stable
     env: BUILDTYPE=Release
     if: (branch = master AND NOT type = pull_request) OR tag IS present


### PR DESCRIPTION
## Related Ticket(s)
- Related #https://github.com/Cockatrice/Cockatrice/issues/3294

## Short roundup of the initial problem
Travis uses an old build image with a very outdated os version containing old packages.
Since we use that for deployment and to provide a .deb download a more recent one is highly appreciated.

## What will change with this Pull Request?
- use Ubuntu Xenial (16.04 LTS) over Trusty (14.04 LTS)
- brings Qt from 5.2.1 to 5.5.1