### PR TITLE
Travis: minor changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
 addons:
   apt:
     sources:
-    - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main'
+    - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main'
       key_url: 'http://llvm.org/apt/llvm-snapshot.gpg.key'
     packages:
     - bc
@@ -46,6 +46,7 @@ addons:
     - libqt5multimedia5-plugins
     - libqt5svg5-dev
     - libqt5sql5-mysql
+    - libqt5websockets5-dev
 
 before_install: bash ./.ci/travis-dependencies.sh
 
@@ -70,7 +71,7 @@ deploy:
       tags: true
       repo: Cockatrice/Cockatrice
       condition: $BUILDTYPE = Release && $TRAVIS_TAG =~ ([0-9]|[1-9][0-9])(\.([0-9]|[1-9][0-9])){2}-beta(\.([2-9]|[1-9][0-9]))?$     # regex to match semver naming convention for beta pre-releases
-      
+
 # Deploy configuration for "stable" releases
   - provider: releases
     api_key:
@@ -96,7 +97,7 @@ notifications:
     on_start: never
     on_cancel: change
     on_error: change
- 
- 
+
+
 # official validator for ".travis.yml" config file: https://yaml.travis-ci.org
 # travis config documentation: https://docs.travis-ci.com/user/customizing-the-build


### PR DESCRIPTION
Minor changes after the merge of #3320:
 * Use the xenial version of llvm's toolchain for clang-format
 * Add qt5 websocket library for servatrice: the package didn't exist in qt5.2, but is now available in xenial's qt5.5
