### PR TITLE
NSIS: Check for both 32 and 64bit cockatrice when uninstalling; fix #3312

### DIFF
--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -154,17 +154,39 @@ FunctionEnd
 Function componentsPagePre
 ${If} $PortableMode = 0
     SetShellVarContext all
-    ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice" "UninstallString"
-    StrCmp $R0 "" done
 
-    MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "A previous version of Cockatrice must be uninstalled before installing the new one." IDOK uninst
+    # uninstall 32bit version
+    SetRegView 32
+
+    ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice" "UninstallString"
+    StrCmp $R0 "" done32
+
+    MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "A previous version of Cockatrice must be uninstalled before installing the new one." IDOK uninst32
     Abort
 
-    uninst:
+    uninst32:
     ClearErrors
     ExecWait "$R0"
 
-	done:
+	done32:
+
+	# uninstall 64bit version
+	${If} ${NSIS_IS_64_BIT} == 1
+	    SetRegView 64
+
+	    ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice" "UninstallString"
+	    StrCmp $R0 "" done64
+
+	    MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "A previous version of Cockatrice must be uninstalled before installing the new one." IDOK uninst64
+	    Abort
+
+	    uninst64:
+	    ClearErrors
+	    ExecWait "$R0"
+
+		done64:
+	${EndIf}
+
 ${Else}
     Abort
 ${EndIf}


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3312 

## Short roundup of the initial problem
Well explained in #3312, but here's a roundup:
Before #3300,  both 32bit and 64bit cockatrice installed in the 32bit path `c:\program files (x86)` and used the 32bit registry (aka SysWOW64 branch); this was wrong for the 64bit cockatrice package, so it has been fixed.
Now, most users will be in the situation where they have a previous 32bit or 64bit version installed in `c:\program files (x86)`, and we want to uninstall it before installing the new 64bit version in a different path. But since the uninstaller is now using the 64bit registry keys, the previous 32bit uninstaller was not found and you ended up with 2 cockatrice installations.

## What will change with this Pull Request?
The 64bit Cockatrice installer will check for uninstaller existence in both 32bit and 64bit registry keys, and run them all.
In the rare case where you already have two different cockatrice version installed, you'll be asked to uninstall the old version twice, once for each instance.

