### PR TITLE
appveyor: reduce version string to basic info

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,5 @@
-version: 2.6.0-branch-{branch}-build-{build}
+version: {branch}-branch_build-{build}
 
-#BUILD!!!
 # Skipping commits affecting specific files (GitHub only).
 # More details here: https://www.appveyor.com/docs/appveyor-yml and https://www.appveyor.com/docs/how-to/filtering-commits
 skip_commits:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: branch:{branch} (build {build})
+version: build {build}
 
 # Skipping commits affecting specific files (GitHub only).
 # More details here: https://www.appveyor.com/docs/appveyor-yml and https://www.appveyor.com/docs/how-to/filtering-commits

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: {branch}-branch_build-{build}
+version: branch:{branch} (build {build})
 
 # Skipping commits affecting specific files (GitHub only).
 # More details here: https://www.appveyor.com/docs/appveyor-yml and https://www.appveyor.com/docs/how-to/filtering-commits


### PR DESCRIPTION
## Short roundup of the initial problem
It was mostly out of date because we have to manually update it with our current version number.
The use of that is suspect anyway, since it only displays in the appveyor build overview.
It also had a redundant info about the branch.

## What will change with this Pull Request?
- remove hard coded version number
- remove branch
- cleanup build trigger from [#3300](https://github.com/Cockatrice/Cockatrice/pull/3300/files#diff-11c909939117928998b102a1fff7d363)
- more readable style

## Screenshots
I did some tests, so don't be confused about the different styles displayed in the history:
<!-- simply drag & drop image files directly into this description! -->
![version](https://user-images.githubusercontent.com/9874850/42664150-876175ac-8639-11e8-9df5-3fdd775440ed.png)
