### PR TITLE
nsis: add sleep timer to ensure unlocking of vc_redist

### DIFF
--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -244,16 +244,16 @@ ${If} $PortableMode = 0
 	IfFileExists "$INSTDIR\vc_redist.x86.exe" VcRedist86Exists PastVcRedist86Check
 	VcRedist86Exists:
 		ExecWait '"$INSTDIR\vc_redist.x86.exe" /passive /norestart'
-		DetailPrint "Waiting 5s to make sure vc_redist file is unlocked again after installation"
-		Sleep 5000
+		DetailPrint "Sleep to ensure unlock of vc_redist file after installation..."
+		Sleep 4000
 		Delete "$INSTDIR\vc_redist.x86.exe"
 	PastVcRedist86Check:
 
 	IfFileExists "$INSTDIR\vc_redist.x64.exe" VcRedist64Exists PastVcRedist64Check
 	VcRedist64Exists:
 		ExecWait '"$INSTDIR\vc_redist.x64.exe" /passive /norestart'
-		DetailPrint "Waiting 5s to make sure vc_redist file is unlocked again after installation"
-		Sleep 5000
+		DetailPrint "Sleep to ensure unlock of vc_redist file after installation..."
+		Sleep 4000
 		Delete "$INSTDIR\vc_redist.x64.exe"
 	PastVcRedist64Check:
 

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -245,7 +245,7 @@ ${If} $PortableMode = 0
 	VcRedist86Exists:
 		ExecWait '"$INSTDIR\vc_redist.x86.exe" /passive /norestart'
 		DetailPrint "Sleep to ensure unlock of vc_redist file after installation..."
-		Sleep 4000
+		Sleep 3000
 		Delete "$INSTDIR\vc_redist.x86.exe"
 	PastVcRedist86Check:
 
@@ -253,7 +253,7 @@ ${If} $PortableMode = 0
 	VcRedist64Exists:
 		ExecWait '"$INSTDIR\vc_redist.x64.exe" /passive /norestart'
 		DetailPrint "Sleep to ensure unlock of vc_redist file after installation..."
-		Sleep 4000
+		Sleep 3000
 		Delete "$INSTDIR\vc_redist.x64.exe"
 	PastVcRedist64Check:
 

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -244,12 +244,16 @@ ${If} $PortableMode = 0
 	IfFileExists "$INSTDIR\vc_redist.x86.exe" VcRedist86Exists PastVcRedist86Check
 	VcRedist86Exists:
 		ExecWait '"$INSTDIR\vc_redist.x86.exe" /passive /norestart'
+		DetailPrint "Waiting 5s to make sure vc_redist file is unlocked again after installation"
+		Sleep 5000
 		Delete "$INSTDIR\vc_redist.x86.exe"
 	PastVcRedist86Check:
 
 	IfFileExists "$INSTDIR\vc_redist.x64.exe" VcRedist64Exists PastVcRedist64Check
 	VcRedist64Exists:
 		ExecWait '"$INSTDIR\vc_redist.x64.exe" /passive /norestart'
+		DetailPrint "Waiting 5s to make sure vc_redist file is unlocked again after installation"
+		Sleep 5000
 		Delete "$INSTDIR\vc_redist.x64.exe"
 	PastVcRedist64Check:
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3288

## Short roundup of the initial problem
vc_redist was locked after installation and its deletion did not always happen when the installer was closed without enough waiting time.

## What will change with this Pull Request?
- add a short sleep timer + hint to logs

This might not solve the problem in all circumstances, but it's an improvement!