### PR TITLE
fix: cockatrice quits properly when the window is closed

### DIFF
--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -88,6 +88,8 @@ int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
 
+    QObject::connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(quit()));
+
     qInstallMessageHandler(CockatriceLogger);
     if (app.arguments().contains("--debug-output"))
         Logger::getInstance().logToFile(true);


### PR DESCRIPTION
Added a call to QApplication::quit() when all the program's windows are closed
This makes sure that the application exits as expected.

Solves an issue on Linux that after closing and opening cockatrice again, some processes of the first instance were still running.