### PR TITLE
NSIS: Show hint when user installs 32bit Cockatrice on 64bit Windows

### DIFF
--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -59,7 +59,8 @@ ${Else}   #NSIS 32bit
         We advise you to use the 64-bit installer instead." \
         IDOK ok IDCANCEL cancel
         ok:
-        cancel: Abort
+	    ExecShell "open" "https://cockatrice.github.io/"
+	    Abort
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -54,7 +54,9 @@ ${If} ${NSIS_IS_64_BIT} == 1
     SetRegView 64
 ${Else}   #NSIS 32bit
     ${If} ${RunningX64}
-        MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system. \nWe advise you to use the 64-bit installer instead."
+        MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
+        "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n \
+        We advise you to use the 64-bit installer instead."
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -57,7 +57,8 @@ ${Else}   #NSIS 32bit
         MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
         "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n$\n\
         We advise you to use the 64-bit installer instead." \
-        IDCANCEL cancel
+        IDOK ok IDCANCEL cancel
+        ok:
         cancel: Abort
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -47,14 +47,17 @@ Function .onInit
 
 ${If} ${NSIS_IS_64_BIT} == 1
     ${IfNot} ${RunningX64}
-        MessageBox MB_OK | MB_ICONERROR "This version of Cockatrice requires a 64-bit Windows system."
+        MessageBox MB_OK|MB_ICONERROR "This version of Cockatrice requires a 64-bit Windows system."
         Abort
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles64\Cockatrice"
     SetRegView 64
 ${Else}   #NSIS 32bit
     ${If} ${RunningX64}
-        MessageBox MB_OKCANCEL | MB_ICONWARNING "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.\n\nWe advise you to use the correct 64-bit installer instead to get around potential issues." IDOK ok IDCANCEL cancel
+        MessageBox MB_OKCANCEL|MB_ICONWARNING \
+        "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n$\n \
+        We advise you to use the correct 64-bit installer instead to get around potential issues." \
+        IDOK ok IDCANCEL cancel
         cancel: Abort
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -56,9 +56,7 @@ ${Else}   #NSIS 32bit
     ${If} ${RunningX64}
         MessageBox MB_OKCANCEL|MB_ICONWARNING \
         "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n$\n \
-        We advise you to use the correct 64-bit installer instead to get around potential issues." \
-        IDOK ok IDCANCEL cancel
-        cancel: Abort
+        We advise you to use the correct 64-bit installer instead to get around potential issues."
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -56,7 +56,7 @@ ${Else}   #NSIS 32bit
     ${If} ${RunningX64}
         MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
         "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n$\n\
-        We advise you to use the 64-bit installer instead."
+        We advise you to use the 64-bit installer instead." \
         IDOK ok IDCANCEL cancel
         cancel: Abort
     ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -56,9 +56,14 @@ ${Else}    #NSIS 32bit
     ${If} ${RunningX64}
         MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
         "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n$\n\
-        We advise you to use the 64-bit installer instead."
-	ExecShell "open" "https://cockatrice.github.io/"
-        Abort
+        We advise you to use the 64-bit installer instead." \
+        IDOK ok IDCANCEL cancel
+        ok:
+	    ExecShell "open" "https://cockatrice.github.io/"
+            goto exit
+        cancel: goto done
+        exit: Abort
+        done:
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -47,14 +47,14 @@ Function .onInit
 
 ${If} ${NSIS_IS_64_BIT} == 1
     ${IfNot} ${RunningX64}
-        MessageBox MB_OK|MB_ICONERROR "This version of Cockatrice requires a 64-bit Windows system."
+        MessageBox MB_OK|MB_ICONSTOP "This version of Cockatrice requires a 64-bit Windows system."
         Abort
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles64\Cockatrice"
     SetRegView 64
 ${Else}   #NSIS 32bit
     ${If} ${RunningX64}
-        MessageBox MB_OKCANCEL|MB_ICONWARNING "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system. \nWe advise you to use the 64-bit installer instead."
+        MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system. \nWe advise you to use the 64-bit installer instead."
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -55,8 +55,8 @@ ${If} ${NSIS_IS_64_BIT} == 1    #NSIS 64bit
     ${If} ${RunningX64}
         MessageBox MB_OK|MB_ICONEXCLAMATION \
         "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n\
-        We advise you to use the correct 64-bit installer instead to get around potential issues.$\n$\n\
-        Download from our webpage at $\"cockatrice.github.io$\"!"
+        We advise you to use the correct 64-bit installer instead to get around potential issues."#$\n$\n\
+        #Download from our webpage at $\"cockatrice.github.io$\"!"
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -47,12 +47,15 @@ Function .onInit
 
 ${If} ${NSIS_IS_64_BIT} == 1
     ${IfNot} ${RunningX64}
-        MessageBox MB_OK|MB_ICONEXCLAMATION "This version of Cockatrice requires a 64-bit Windows system."
+        MessageBox MB_OK|MB_ICONSTOP "This version of Cockatrice requires a 64-bit Windows system."
         Abort
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles64\Cockatrice"
     SetRegView 64
-${Else}
+${Else}   #nsis 32bit
+    ${If} ${RunningX64}
+        MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system. \nWe advise you to use the 64-bit installer instead."
+    ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}
 

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -55,8 +55,10 @@ ${If} ${NSIS_IS_64_BIT} == 1
 ${Else}   #NSIS 32bit
     ${If} ${RunningX64}
         MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
-        "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n \
+        "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n$\n\
         We advise you to use the 64-bit installer instead."
+        IDOK ok IDCANCEL cancel
+        cancel: Abort
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -55,8 +55,7 @@ ${If} ${NSIS_IS_64_BIT} == 1    #NSIS 64bit
     ${If} ${RunningX64}
         MessageBox MB_OK|MB_ICONEXCLAMATION \
         "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n\
-        We advise you to use the correct 64-bit installer instead to get around potential issues."#$\n$\n\
-        #Download from our webpage at $\"cockatrice.github.io$\"!"
+        Download from our webpage at cockatrice.github.io"
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -57,7 +57,7 @@ ${Else}   #NSIS 32bit
         MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
         "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n$\n\
         We advise you to use the 64-bit installer instead." \
-        IDOK ok IDCANCEL cancel
+        IDCANCEL cancel
         cancel: Abort
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -45,18 +45,20 @@ Page Custom PortableModePageCreate PortableModePageLeave
 
 Function .onInit
 
-${If} ${NSIS_IS_64_BIT} == 1
+${If} ${NSIS_IS_64_BIT} == 1    #NSIS 64bit
     ${IfNot} ${RunningX64}
         MessageBox MB_OK|MB_ICONSTOP "This version of Cockatrice requires a 64-bit Windows system."
         Abort
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles64\Cockatrice"
     SetRegView 64
-${Else}   #NSIS 32bit
+${Else}    #NSIS 32bit
     ${If} ${RunningX64}
         MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
         "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n$\n\
         We advise you to use the 64-bit installer instead."
+	ExecShell "open" "https://cockatrice.github.io/"
+        Abort
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -56,7 +56,7 @@ ${If} ${NSIS_IS_64_BIT} == 1    #NSIS 64bit
         MessageBox MB_OK|MB_ICONEXCLAMATION \
         "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n\
         We advise you to use the correct 64-bit installer instead to get around potential issues.$\n$\n\
-        Download at our webpage: cockatrice.github.io"
+        Download from our webpage at $\"cockatrice.github.io$\"!"
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -47,14 +47,16 @@ Function .onInit
 
 ${If} ${NSIS_IS_64_BIT} == 1
     ${IfNot} ${RunningX64}
-        MessageBox MB_OK|MB_ICONSTOP "This version of Cockatrice requires a 64-bit Windows system."
+        MessageBox MB_OK | MB_ICONERROR "This version of Cockatrice requires a 64-bit Windows system."
         Abort
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles64\Cockatrice"
     SetRegView 64
-${Else}   #nsis 32bit
+${Else}   #NSIS 32bit
     ${If} ${RunningX64}
-        MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system. \nWe advise you to use the 64-bit installer instead."
+        MessageBox MB_OKCANCEL | MB_ICONWARNING "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.\n\nWe advise you to use the correct 64-bit installer instead to get around potential issues."
+        case IDCANCEL:
+            Abort
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -52,18 +52,11 @@ ${If} ${NSIS_IS_64_BIT} == 1    #NSIS 64bit
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles64\Cockatrice"
     SetRegView 64
-${Else}    #NSIS 32bit
     ${If} ${RunningX64}
-        MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
-        "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n$\n\
-        We advise you to use the 64-bit installer instead." \
-        IDOK ok IDCANCEL cancel
-        ok:
-	    ExecShell "open" "https://cockatrice.github.io/"
-            goto exit
-        cancel: goto done
-        exit: Abort
-        done:
+        MessageBox MB_OK|MB_ICONEXCLAMATION \
+        "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n\
+        We advise you to use the correct 64-bit installer instead to get around potential issues.$\n$\n\
+        Download at our webpage: https://cockatrice.github.io/"
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -54,9 +54,7 @@ ${If} ${NSIS_IS_64_BIT} == 1
     SetRegView 64
 ${Else}   #NSIS 32bit
     ${If} ${RunningX64}
-        MessageBox MB_OKCANCEL|MB_ICONWARNING \
-        "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n$\n \
-        We advise you to use the correct 64-bit installer instead to get around potential issues."
+        MessageBox MB_OKCANCEL|MB_ICONWARNING "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n$\n We advise you to use the correct 64-bit installer instead to get around potential issues."
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -57,7 +57,7 @@ ${Else}    #NSIS 32bit
         MessageBox MB_OK|MB_ICONEXCLAMATION \
         "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n\
         We advise you to use the correct 64-bit installer instead to get around potential issues.$\n$\n\
-        Download from our webpage at cockatrice.github.io!"
+        Download from our webpage: https://cockatrice.github.io"
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -52,10 +52,12 @@ ${If} ${NSIS_IS_64_BIT} == 1    #NSIS 64bit
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles64\Cockatrice"
     SetRegView 64
+${Else}    #NSIS 32bit
     ${If} ${RunningX64}
         MessageBox MB_OK|MB_ICONEXCLAMATION \
         "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n\
-        Download from our webpage at cockatrice.github.io"
+        We advise you to use the correct 64-bit installer instead to get around potential issues.$\n$\n\
+        Download from our webpage at cockatrice.github.io!"
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -54,9 +54,8 @@ ${If} ${NSIS_IS_64_BIT} == 1
     SetRegView 64
 ${Else}   #NSIS 32bit
     ${If} ${RunningX64}
-        MessageBox MB_OKCANCEL | MB_ICONWARNING "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.\n\nWe advise you to use the correct 64-bit installer instead to get around potential issues."
-        case IDCANCEL:
-            Abort
+        MessageBox MB_OKCANCEL | MB_ICONWARNING "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.\n\nWe advise you to use the correct 64-bit installer instead to get around potential issues." IDOK ok IDCANCEL cancel
+        cancel: Abort
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -56,7 +56,7 @@ ${If} ${NSIS_IS_64_BIT} == 1    #NSIS 64bit
         MessageBox MB_OK|MB_ICONEXCLAMATION \
         "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n\
         We advise you to use the correct 64-bit installer instead to get around potential issues.$\n$\n\
-        Download at our webpage: https://cockatrice.github.io/"
+        Download at our webpage: cockatrice.github.io"
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -56,11 +56,7 @@ ${Else}   #NSIS 32bit
     ${If} ${RunningX64}
         MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
         "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n$\n\
-        We advise you to use the 64-bit installer instead." \
-        IDOK ok IDCANCEL cancel
-        ok:
-	    ExecShell "open" "https://cockatrice.github.io/"
-	    Abort
+        We advise you to use the 64-bit installer instead."
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -54,7 +54,7 @@ ${If} ${NSIS_IS_64_BIT} == 1
     SetRegView 64
 ${Else}   #NSIS 32bit
     ${If} ${RunningX64}
-        MessageBox MB_OKCANCEL|MB_ICONWARNING "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n$\n We advise you to use the correct 64-bit installer instead to get around potential issues."
+        MessageBox MB_OKCANCEL|MB_ICONWARNING "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system. \nWe advise you to use the 64-bit installer instead."
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3330

## Short roundup of the initial problem
Most users simply use the client updater and not even realize they are using a "wrong" version since the updater keeps them on the same bit-ness and doesn't give a choice or even tell them.

## What will change with this Pull Request?
- Show a hint + name webpage url as download source when installing 32bit on 64bit system
- Other install variants are unchanged
- Exchange warning for error icon on other dialog

Having that logic within NSIS is actually better than a solution with the in-client updater, because people might get the binary files elsewhere or people direct link to old releases or share outdated binaries...
NSIS still catches these cases.

Now, we finally get a better understanding of how many user still use/need a 32bit build and when we can safely deprecate it in the future.

>My preferred solution would have been a button that brings you to our webpage if the users wants to (via `ExecShell "open" "https://cockatrice.github.io"`), but I couldn't manage to provide these two functions next to each other or come up with another approach:
>- User wants to cancel the installer and open our webpage to download the "right" 64bit version
>- User skips the hint and still wants to install the "wrong" 32bit version
>
> It looks like one needs to write a custom plugin to alter the button labels, have in-text clickable urls etc.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![v3](https://user-images.githubusercontent.com/9874850/42757396-3429ad9a-8900-11e8-9911-2c3a85335d8f.png)