### PR TITLE
appveyor: version updates + tweaks

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ clone_depth: 50    #same as travis, see https://www.appveyor.com/blog/2014/06/04
 image: Visual Studio 2017
 
 cache:
-#    - c:\openssl-release
+    - c:\openssl-release
     - c:\protobuf-release
     - c:\zlib-release
 # TODO: set dependency on ps skript file (in ./ci) / "-> appveyor.yml" maybe not ideal
@@ -57,8 +57,10 @@ install:
             echo "using openssl from cache"
         } else {
             if ($target_arch -eq "win64") {    # 64bit filename
+                echo "64bit"
                 Invoke-WebRequest "https://indy.fulgan.com/SSL/openssl-$env:openssl_ver-x64_86-win64.zip" -OutFile c:\openssl-$env:openssl_ver.zip
             } else {    # 32bit filename
+                echo "32bit"
                 Invoke-WebRequest "https://indy.fulgan.com/SSL/openssl-$env:openssl_ver-i386-win32.zip" -OutFile c:\openssl-$env:openssl_ver.zip
             }
             Expand-Archive -Path c:\openssl-$env:openssl_ver.zip -DestinationPath c:\openssl-release

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ environment:
     matrix:
         - qt_ver: 5.11\msvc2017_64
           openssl_ver: 1.0.2o-x64_86-win64
-          protobuf_ver: 3.6
+          protobuf_ver: 3.5.1
           zlib_ver: 1.2.11
           cmake_generator: Visual Studio 15 2017 Win64
           cmake_toolset: v141,host=x64
@@ -38,7 +38,7 @@ environment:
           vc_arch: amd64
         - qt_ver: 5.11\msvc2015 # AppVeyor doesn't provide a msvc2017_32
           openssl_ver: 1.0.2o-i386-win32
-          protobuf_ver: 3.6
+          protobuf_ver: 3.5.1
           zlib_ver: 1.2.11
           cmake_generator: Visual Studio 15 2017
           cmake_toolset: v141

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -57,10 +57,10 @@ install:
             echo "using openssl from cache"
         } else {
             if ($env:target_arch -eq "win64") {    # 64bit filename
-                echo "64bit"
+                # echo "downloading 64bit version of openssl"
                 Invoke-WebRequest "https://indy.fulgan.com/SSL/openssl-$env:openssl_ver-x64_86-win64.zip" -OutFile c:\openssl-$env:openssl_ver.zip
             } else {    # 32bit filename
-                echo "32bit"
+                # echo "downloading 32bit version of openssl"
                 Invoke-WebRequest "https://indy.fulgan.com/SSL/openssl-$env:openssl_ver-i386-win32.zip" -OutFile c:\openssl-$env:openssl_ver.zip
             }
             Expand-Archive -Path c:\openssl-$env:openssl_ver.zip -DestinationPath c:\openssl-release

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ clone_depth: 50    #same as travis, see https://www.appveyor.com/blog/2014/06/04
 image: Visual Studio 2017
 
 cache:
-    - c:\openssl-release
+#    - c:\openssl-release
     - c:\protobuf-release
     - c:\zlib-release
 # TODO: set dependency on ps skript file (in ./ci) / "-> appveyor.yml" maybe not ideal
@@ -33,7 +33,7 @@ cache:
 
 
 environment:
-    openssl_ver: 1.0.2n
+    openssl_ver: 1.0.2o
     protobuf_ver: 3.6.0
     zlib_ver: 1.2.11
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -56,7 +56,7 @@ install:
         if (Test-Path c:\openssl-release) {
             echo "using openssl from cache"
         } else {
-            if ($target_arch -eq "win64") {    # 64bit filename
+            if ($env:target_arch -eq "win64") {    # 64bit filename
                 echo "64bit"
                 Invoke-WebRequest "https://indy.fulgan.com/SSL/openssl-$env:openssl_ver-x64_86-win64.zip" -OutFile c:\openssl-$env:openssl_ver.zip
             } else {    # 32bit filename

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,7 +51,7 @@ install:
         if (Test-Path c:\openssl-release) {
             echo "using openssl from cache"
         } else {
-            if (target_arch == win64) {    # 64bit filename
+            if ($env:target_arch == win64) {    # 64bit filename
                 Invoke-WebRequest "https://indy.fulgan.com/SSL/openssl-$env:openssl_ver-x64_86-win64.zip" -OutFile c:\openssl-$env:openssl_ver.zip
             } else {    # 32bit filename
                 Invoke-WebRequest "https://indy.fulgan.com/SSL/openssl-$env:openssl_ver-i386-win32.zip" -OutFile c:\openssl-$env:openssl_ver.zip

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,17 +28,17 @@ cache:
 
 environment:
     matrix:
-        - qt_ver: 5.11\msvc2017_64
-          openssl_ver: 1.0.2o-x64_86-win64
-          protobuf_ver: 3.6.0
+        - qt_ver: latest\msvc2017_64
+          openssl_ver: 1.0.2n-x64_86-win64
+          protobuf_ver: 3.5.1
           zlib_ver: 1.2.11
           cmake_generator: Visual Studio 15 2017 Win64
           cmake_toolset: v141,host=x64
           target_arch: win64
           vc_arch: amd64
-        - qt_ver: 5.11\msvc2015 # AppVeyor doesn't provide a msvc2017_32
-          openssl_ver: 1.0.2o-i386-win32
-          protobuf_ver: 3.6.0
+        - qt_ver: latest\msvc2015 # Qt doesn't provide a msvc2017_32
+          openssl_ver: 1.0.2n-i386-win32
+          protobuf_ver: 3.5.1
           zlib_ver: 1.2.11
           cmake_generator: Visual Studio 15 2017
           cmake_toolset: v141

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,24 +26,26 @@ cache:
     - c:\protobuf-release
     - c:\zlib-release
 
+
 environment:
+    protobuf_ver: 3.6.0
+    zlib_ver: 1.2.11
+
     matrix:
-        - qt_ver: latest\msvc2017_64
-          openssl_ver: 1.0.2n-x64_86-win64
-          protobuf_ver: 3.5.1
-          zlib_ver: 1.2.11
+        - qt_ver: 5.9\msvc2017_64
+          openssl_ver: 1.0.2o-x64_86-win64
           cmake_generator: Visual Studio 15 2017 Win64
           cmake_toolset: v141,host=x64
           target_arch: win64
           vc_arch: amd64
-        - qt_ver: latest\msvc2015 # Qt doesn't provide a msvc2017_32
-          openssl_ver: 1.0.2n-i386-win32
-          protobuf_ver: 3.5.1
-          zlib_ver: 1.2.11
+
+        - qt_ver: 5.9\msvc2015 # Qt doesn't provide a msvc2017_32
+          openssl_ver: 1.0.2o-i386-win32
           cmake_generator: Visual Studio 15 2017
           cmake_toolset: v141
           target_arch: win32
           vc_arch: amd64_x86
+
 
 install:
     - ps: |

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ cache:
 
 
 environment:
-    openssl_ver: 1.0.2o
+    openssl_ver: 1.0.2n
     protobuf_ver: 3.6.0
     zlib_ver: 1.2.11
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,12 +19,17 @@ skip_commits:
 
 skip_branch_with_pr: true
 
+clone_depth: 50    #same as travis, see https://www.appveyor.com/blog/2014/06/04/shallow-clone-for-git-repositories/
+
 image: Visual Studio 2017
 
 cache:
     - c:\openssl-release
     - c:\protobuf-release
     - c:\zlib-release
+# TODO: set dependency on ps skript file (in ./ci) / "-> appveyor.yml" maybe not ideal
+# that way when we update specific cached tools there (like protobuf or zlib), cache will be newly created automatically
+# https://www.appveyor.com/docs/build-cache/#cleaning-up-cache
 
 
 environment:
@@ -51,7 +56,7 @@ install:
         if (Test-Path c:\openssl-release) {
             echo "using openssl from cache"
         } else {
-            if ($target_arch = "win64") {    # 64bit filename
+            if ($target_arch -eq "win64") {    # 64bit filename
                 Invoke-WebRequest "https://indy.fulgan.com/SSL/openssl-$env:openssl_ver-x64_86-win64.zip" -OutFile c:\openssl-$env:openssl_ver.zip
             } else {    # 32bit filename
                 Invoke-WebRequest "https://indy.fulgan.com/SSL/openssl-$env:openssl_ver-i386-win32.zip" -OutFile c:\openssl-$env:openssl_ver.zip

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,7 +51,7 @@ install:
         if (Test-Path c:\openssl-release) {
             echo "using openssl from cache"
         } else {
-            if ($env:target_arch == win64) {    # 64bit filename
+            if ($target_arch = "win64") {    # 64bit filename
                 Invoke-WebRequest "https://indy.fulgan.com/SSL/openssl-$env:openssl_ver-x64_86-win64.zip" -OutFile c:\openssl-$env:openssl_ver.zip
             } else {    # 32bit filename
                 Invoke-WebRequest "https://indy.fulgan.com/SSL/openssl-$env:openssl_ver-i386-win32.zip" -OutFile c:\openssl-$env:openssl_ver.zip

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ environment:
     matrix:
         - qt_ver: 5.11\msvc2017_64
           openssl_ver: 1.0.2o-x64_86-win64
-          protobuf_ver: 3.5.1
+          protobuf_ver: 3.6.0
           zlib_ver: 1.2.11
           cmake_generator: Visual Studio 15 2017 Win64
           cmake_toolset: v141,host=x64
@@ -38,7 +38,7 @@ environment:
           vc_arch: amd64
         - qt_ver: 5.11\msvc2015 # AppVeyor doesn't provide a msvc2017_32
           openssl_ver: 1.0.2o-i386-win32
-          protobuf_ver: 3.5.1
+          protobuf_ver: 3.6.0
           zlib_ver: 1.2.11
           cmake_generator: Visual Studio 15 2017
           cmake_toolset: v141

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,22 +28,21 @@ cache:
 
 
 environment:
+    openssl_ver: 1.0.2o
     protobuf_ver: 3.6.0
     zlib_ver: 1.2.11
 
     matrix:
-        - qt_ver: 5.9\msvc2017_64
-          openssl_ver: 1.0.2o-x64_86-win64
+        - target_arch: win64
+          qt_ver: 5.9\msvc2017_64
           cmake_generator: Visual Studio 15 2017 Win64
           cmake_toolset: v141,host=x64
-          target_arch: win64
           vc_arch: amd64
 
-        - qt_ver: 5.9\msvc2015 # Qt doesn't provide a msvc2017_32
-          openssl_ver: 1.0.2o-i386-win32
+        - target_arch: win32
+          qt_ver: 5.9\msvc2015 # Qt doesn't provide a msvc2017_32
           cmake_generator: Visual Studio 15 2017
           cmake_toolset: v141
-          target_arch: win32
           vc_arch: amd64_x86
 
 
@@ -52,7 +51,11 @@ install:
         if (Test-Path c:\openssl-release) {
             echo "using openssl from cache"
         } else {
-            Invoke-WebRequest "https://indy.fulgan.com/SSL/openssl-$env:openssl_ver.zip" -OutFile c:\openssl-$env:openssl_ver.zip
+            if (target_arch == win64) {    # 64bit filename
+                Invoke-WebRequest "https://indy.fulgan.com/SSL/openssl-$env:openssl_ver-x64_86-win64.zip" -OutFile c:\openssl-$env:openssl_ver.zip
+            } else {    # 32bit filename
+                Invoke-WebRequest "https://indy.fulgan.com/SSL/openssl-$env:openssl_ver-i386-win32.zip" -OutFile c:\openssl-$env:openssl_ver.zip
+            }
             Expand-Archive -Path c:\openssl-$env:openssl_ver.zip -DestinationPath c:\openssl-release
             Set-Location -Path C:\openssl-release
         }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,17 +28,17 @@ cache:
 
 environment:
     matrix:
-        - qt_ver: 5.9\msvc2017_64
-          openssl_ver: 1.0.2n-x64_86-win64
-          protobuf_ver: 3.5.1
+        - qt_ver: 5.11\msvc2017_64
+          openssl_ver: 1.0.2o-x64_86-win64
+          protobuf_ver: 3.6
           zlib_ver: 1.2.11
           cmake_generator: Visual Studio 15 2017 Win64
           cmake_toolset: v141,host=x64
           target_arch: win64
           vc_arch: amd64
-        - qt_ver: 5.9\msvc2015 # Qt doesn't provide a msvc2017_32
-          openssl_ver: 1.0.2n-i386-win32
-          protobuf_ver: 3.5.1
+        - qt_ver: 5.11\msvc2015 # AppVeyor doesn't provide a msvc2017_32
+          openssl_ver: 1.0.2o-i386-win32
+          protobuf_ver: 3.6
           zlib_ver: 1.2.11
           cmake_generator: Visual Studio 15 2017
           cmake_toolset: v141


### PR DESCRIPTION
## Short roundup of the initial problem
AppVeyor had a crazy amount of warnings related to protobuf, which got fixed in https://github.com/google/protobuf/commit/24493eef9395e5b832360e12efabf9c363c9cb15

## What will change with this Pull Request?
- use protobuf 3.6.0
warnings disappear and log has 1k lines less
- use openssl 1.0.2o
- optimized config for build matrix
- use depth=50 for faster git cloning (same as travis ci does per default)

<br>

I tried to update Qt to use 5.11.1 in the process... but simply using `latest` or `5.11` throws errors on 32bit (64 bit works): https://ci.appveyor.com/project/Daenyth/cockatrice/build/build%201146
