### PR TITLE
travis: more cleanup

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -97,6 +97,7 @@ build_script:
         $protodir = "c:\protobuf-release"
         $protoc = "c:\protobuf-release\bin\protoc.exe"
         $mysqldll = "c:\Program Files\MySQL\MySQL Server 5.7\lib\libmysql.dll"
+        cmake --version
         cmake .. -G "$env:cmake_generator" -T "$env:cmake_toolset" "-DCMAKE_PREFIX_PATH=c:/Qt/$env:qt_ver;$protodir;$zlibdir;$openssldir" "-DWITH_SERVER=1" "-DPROTOBUF_PROTOC_EXECUTABLE=$protoc" "-DMYSQLCLIENT_LIBRARIES=$mysqldll"
     - msbuild PACKAGE.vcxproj /p:Configuration=Release
     - ps: |

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -145,5 +145,6 @@ deploy:
       APPVEYOR_REPO_TAG_NAME: /([0-9]|[1-9][0-9])(\.([0-9]|[1-9][0-9])){2}$/    # regex to match semver naming convention for stable full releases
 
 
-# official validator for ".appveyor.yml" config file: https://ci.appveyor.com/tools/validate-yaml
-# appveyor config documentation: https://www.appveyor.com/docs/build-configuration/
+# Announcements of build image updates: https://www.appveyor.com/updates/
+# Official validator for ".appveyor.yml" config file: https://ci.appveyor.com/tools/validate-yaml
+# AppVeyor config documentation: https://www.appveyor.com/docs/build-configuration/

--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -16,6 +16,8 @@ if [[ $TRAVIS_OS_NAME == "linux" ]]; then
   prefix="-DCMAKE_PREFIX_PATH=$(echo /opt/qt5*/lib/cmake/)"
 fi
 
+cmake --version
+
 if [[ $BUILDTYPE == "Debug" ]]; then
   cmake .. -DWITH_SERVER=1 -DCMAKE_BUILD_TYPE=$BUILDTYPE $prefix -DTEST=1
   make -j2

--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -27,6 +27,7 @@ if [[ $BUILDTYPE == "Debug" ]]; then
 
   if [[ $TRAVIS_OS_NAME == "linux" ]]; then
     cd ..
+    clang-format -version
     clang-format -i \
       common/*.h \
       common/*.cpp \

--- a/.ci/travis-dependencies.sh
+++ b/.ci/travis-dependencies.sh
@@ -2,7 +2,7 @@
 
 if [[ $TRAVIS_OS_NAME == "osx" ]] ; then
   brew update
-  brew install ccache clang-format protobuf qt
+  brew install ccache protobuf qt
 fi
 if [[ $TRAVIS_OS_NAME == "linux" ]] ; then
   echo Skipping... packages are installed with the Travis apt addon for sudo disabled container builds

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,5 +99,6 @@ notifications:
 
 
 # Announcements of build image updates: https://docs.travis-ci.com/user/build-environment-updates/
+# For precise versions of preinstalled tools on the VM, check “Build system information” in the build log!
 # Official validator for ".travis.yml" config file: https://yaml.travis-ci.org
 # Travis CI config documentation: https://docs.travis-ci.com/user/customizing-the-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,32 +2,33 @@ language: cpp
 
 cache: ccache
 
-
 matrix:
   fast_finish: true
   include:
+  #Ubuntu
   - name: Ubuntu (Debug)
+    if: tag IS NOT present
     os: linux
     dist: xenial
     group: stable
     env: BUILDTYPE=Debug
-    if: tag IS NOT present
   - name: Ubuntu (Release)
+    if: (branch = master AND NOT type = pull_request) OR tag IS present
     os: linux
     dist: xenial
     group: stable
     env: BUILDTYPE=Release
-    if: (branch = master AND NOT type = pull_request) OR tag IS present
+  #macOS
   - name: macOS (Debug)
+    if: tag IS NOT present
     os: osx
     osx_image: xcode8
     env: BUILDTYPE=Debug
-    if: tag IS NOT present
   - name: macOS (Release)
+    if: (branch = master AND NOT type = pull_request) OR tag IS present
     os: osx
     osx_image: xcode8
     env: BUILDTYPE=Release
-    if: (branch = master AND NOT type = pull_request) OR tag IS present
 
 #install dependencies for container-based "linux" builds
 addons:
@@ -46,6 +47,7 @@ addons:
     - libqt5svg5-dev
     - libqt5sql5-mysql
     - libqt5websockets5-dev
+
 
 before_install: bash ./.ci/travis-dependencies.sh
 
@@ -88,6 +90,7 @@ deploy:
 
 
 notifications:
+  email: false
   webhooks:
     urls:
     - https://webhooks.gitter.im/e/d94969c3b01b22cbdcb7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-
+compiler: gcc
 cache: ccache
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ addons:
     - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main'
       key_url: 'http://llvm.org/apt/llvm-snapshot.gpg.key'
     packages:
+    - libprotobuf-dev
+    - protobuf-compiler
     - qt5-default
     - qttools5-dev
     - qttools5-dev-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,6 @@ matrix:
 #install dependencies for container-based "linux" builds
 addons:
   apt:
-    sources:
-    - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main'
-      key_url: 'http://llvm.org/apt/llvm-snapshot.gpg.key'
     packages:
     - libprotobuf-dev
     - protobuf-compiler

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,21 +6,25 @@ cache: ccache
 matrix:
   fast_finish: true
   include:
-  - os: linux
+  - name: Ubuntu (Debug)
+    os: linux
     dist: xenial
     group: stable
     env: BUILDTYPE=Debug
     if: tag IS NOT present
-  - os: linux
+  - name: Ubuntu (Release)
+    os: linux
     dist: xenial
     group: stable
     env: BUILDTYPE=Release
     if: (branch = master AND NOT type = pull_request) OR tag IS present
-  - os: osx
+  - name: macOS (Debug)
+    os: osx
     osx_image: xcode8
     env: BUILDTYPE=Debug
     if: tag IS NOT present
-  - os: osx
+  - name: macOS (Release)
+    os: osx
     osx_image: xcode8
     env: BUILDTYPE=Release
     if: (branch = master AND NOT type = pull_request) OR tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,9 @@ addons:
     packages:
     - libprotobuf-dev
     - protobuf-compiler
-    - qt5-default
-    - qttools5-dev
-    - qttools5-dev-tools
-    - qtmultimedia5-dev
-    - libqt5multimedia5-plugins
-    - libqt5svg5-dev
-    - libqt5sql5-mysql
-    - libqt5websockets5-dev
+#    - qt5-default
+#    - qttools5-dev
+#    - qttools5-dev-tools
 
 before_install: bash ./.ci/travis-dependencies.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ compiler: gcc
 cache: ccache
 
 matrix:
-  fast_finish: true
   include:
   #Ubuntu
   - name: Ubuntu (Debug)

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ addons:
     packages:
     - libprotobuf-dev
     - protobuf-compiler
-#    - qt5-default
-#    - qttools5-dev
-#    - qttools5-dev-tools
+    - qt5-default
+    - qttools5-dev
+    - qttools5-dev-tools
 
 before_install: bash ./.ci/travis-dependencies.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ addons:
     - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main'
       key_url: 'http://llvm.org/apt/llvm-snapshot.gpg.key'
     packages:
-    - clang-format-5.0
     - libprotobuf-dev
     - protobuf-compiler
     - qt5-default

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ addons:
     packages:
     - libprotobuf-dev
     - protobuf-compiler
-    - qt5-default
-    - qttools5-dev
-    - qttools5-dev-tools
+#    - qt5-default
+#    - qttools5-dev
+#    - qttools5-dev-tools
 
 before_install: bash ./.ci/travis-dependencies.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,14 @@ addons:
     packages:
     - libprotobuf-dev
     - protobuf-compiler
-#    - qt5-default
-#    - qttools5-dev
-#    - qttools5-dev-tools
+    - qt5-default
+    - qttools5-dev
+    - qttools5-dev-tools
+    - qtmultimedia5-dev
+    - libqt5multimedia5-plugins
+    - libqt5svg5-dev
+    - libqt5sql5-mysql
+    - libqt5websockets5-dev
 
 before_install: bash ./.ci/travis-dependencies.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ addons:
     packages:
     - bc
     - clang-format-5.0
-    - cmake
     - libprotobuf-dev
     - protobuf-compiler
     - qt5-default

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,6 @@ addons:
     - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main'
       key_url: 'http://llvm.org/apt/llvm-snapshot.gpg.key'
     packages:
-    - libprotobuf-dev
-    - protobuf-compiler
     - qt5-default
     - qttools5-dev
     - qttools5-dev-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,5 +99,6 @@ notifications:
     on_error: change
 
 
-# official validator for ".travis.yml" config file: https://yaml.travis-ci.org
-# travis config documentation: https://docs.travis-ci.com/user/customizing-the-build
+# Announcements of build image updates: https://docs.travis-ci.com/user/build-environment-updates/
+# Official validator for ".travis.yml" config file: https://yaml.travis-ci.org
+# Travis CI config documentation: https://docs.travis-ci.com/user/customizing-the-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: cpp
 
 cache: ccache
 
-conditions: v1
-
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ addons:
     - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main'
       key_url: 'http://llvm.org/apt/llvm-snapshot.gpg.key'
     packages:
-    - bc
     - clang-format-5.0
     - libprotobuf-dev
     - protobuf-compiler

--- a/cockatrice/src/filterbuilder.cpp
+++ b/cockatrice/src/filterbuilder.cpp
@@ -9,7 +9,7 @@
 
 FilterBuilder::FilterBuilder(QWidget *parent) : QWidget(parent)
 {
-	filterCombo = new QComboBox;
+    filterCombo = new QComboBox;
     filterCombo->setObjectName("filterCombo");
     for (int i = 0; i < CardFilter::AttrEnd; i++)
         filterCombo->addItem(tr(CardFilter::attrName(static_cast<CardFilter::Attr>(i))), QVariant(i));

--- a/cockatrice/src/filterbuilder.cpp
+++ b/cockatrice/src/filterbuilder.cpp
@@ -9,7 +9,7 @@
 
 FilterBuilder::FilterBuilder(QWidget *parent) : QWidget(parent)
 {
-    filterCombo = new QComboBox;
+	filterCombo = new QComboBox;
     filterCombo->setObjectName("filterCombo");
     for (int i = 0; i < CardFilter::AttrEnd; i++)
         filterCombo->addItem(tr(CardFilter::attrName(static_cast<CardFilter::Attr>(i))), QVariant(i));


### PR DESCRIPTION
## Short roundup of the initial problem
Unneeded package installs listed in travis.yml

## What will change with this Pull Request?
- *cmake* and *clang* (clang-format is part of it) are already available in the Travis Linux build image:
https://docs.travis-ci.com/user/build-environment-updates/2017-12-12/#Changed
The logs now also print their version numbers.
- *bc* used to be included in the newest version, too
https://travis-ci.org/Cockatrice/Cockatrice/jobs/405156717#L428
- *clang-format* is never used on mac builds (we only check on Linux), remove its installation
- Added links to the related build image changelogs for each ci service
- `conditions` config can be removed as it's the default now
- Add job names
- Remove `fast finish`, which only has effects when allowed failures are configured

I tried to remove the other apt installs which should be already available in the Xenial image regarding this list: https://packages.ubuntu.com/xenial/allpackages (long load time!)
But it didn't work out. 😃 


## Screenshots
![job names](https://user-images.githubusercontent.com/9874850/42969711-5d86145e-8ba7-11e8-8213-ad819527c9b1.png)
