### PR TITLE
Manage sets window: "Enable all/selected" button toggling never disabled

### DIFF
--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -116,7 +116,7 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     connect(enableSomeButton, SIGNAL(clicked()), this, SLOT(actEnableSome()));
     connect(disableSomeButton, SIGNAL(clicked()), this, SLOT(actDisableSome()));
     connect(view->selectionModel(), SIGNAL(selectionChanged(const QItemSelection &, const QItemSelection &)), this,
-            SLOT(actSelectionChanged(const QItemSelection &, const QItemSelection &)));
+            SLOT(actToggleButtons(const QItemSelection &, const QItemSelection &)));
     connect(searchField, SIGNAL(textChanged(const QString &)), displayModel, SLOT(setFilterRegExp(const QString &)));
     connect(view->header(), SIGNAL(sortIndicatorChanged(int, Qt::SortOrder)), this, SLOT(actDisableSortButtons(int)));
     connect(searchField, SIGNAL(textChanged(const QString &)), this, SLOT(actDisableResetButton(const QString &)));
@@ -262,10 +262,10 @@ void WndSets::actDisableSortButtons(int index)
     if (!view->selectionModel()->selection().empty()) {
         view->scrollTo(view->selectionModel()->selectedRows().first());
     }
-    actSelectionChanged(view->selectionModel()->selection(), QItemSelection());
+    actToggleButtons(view->selectionModel()->selection(), QItemSelection());
 }
 
-void WndSets::actSelectionChanged(const QItemSelection &selected, const QItemSelection &)
+void WndSets::actToggleButtons(const QItemSelection &selected, const QItemSelection &)
 {
     bool emptySelection = selected.empty();
     aTop->setDisabled(emptySelection || setOrderIsSorted);

--- a/cockatrice/src/window_sets.h
+++ b/cockatrice/src/window_sets.h
@@ -36,6 +36,7 @@ private:
     int sortIndex;
     Qt::SortOrder sortOrder;
     void rebuildMainLayout(int actionToTake);
+    bool setOrderIsSorted;
     enum
     {
         NO_SETS_SELECTED,
@@ -59,7 +60,7 @@ private slots:
     void actDown();
     void actTop();
     void actBottom();
-    void actToggleButtons(const QItemSelection &selected, const QItemSelection &deselected);
+    void actSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
     void actDisableSortButtons(int index);
     void actRestoreOriginalOrder();
     void actDisableResetButton(const QString &filterText);

--- a/cockatrice/src/window_sets.h
+++ b/cockatrice/src/window_sets.h
@@ -60,7 +60,7 @@ private slots:
     void actDown();
     void actTop();
     void actBottom();
-    void actSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
+    void actToggleButtons(const QItemSelection &selected, const QItemSelection &deselected);
     void actDisableSortButtons(int index);
     void actRestoreOriginalOrder();
     void actDisableResetButton(const QString &filterText);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3314 

## Short roundup of the initial problem
When the view was sorted in the manage sets window, the "Enable/Disable All" buttons never toggled to "Enable/Disable selected" buttons, even when more sets were selected.

## What will change with this Pull Request?
- Selected sets can be enabled/disabled in sorted view as well