### PR TITLE
updater: remove check for now unused beta file endings

### DIFF
--- a/cockatrice/src/releasechannel.cpp
+++ b/cockatrice/src/releasechannel.cpp
@@ -9,8 +9,8 @@
 #include <QNetworkReply>
 
 #define STABLERELEASE_URL "https://api.github.com/repos/Cockatrice/Cockatrice/releases/latest"
-#define STABLETAG_URL "https://api.github.com/repos/Cockatrice/Cockatrice/git/refs/tags/"
 #define STABLEMANUALDOWNLOAD_URL "https://github.com/Cockatrice/Cockatrice/releases/latest"
+#define STABLETAG_URL "https://api.github.com/repos/Cockatrice/Cockatrice/git/refs/tags/"
 
 #define BETARELEASE_URL "https://api.github.com/repos/Cockatrice/Cockatrice/releases"
 #define BETAMANUALDOWNLOAD_URL "https://github.com/Cockatrice/Cockatrice/releases/"
@@ -53,22 +53,18 @@ bool ReleaseChannel::downloadMatchesCurrentOS(const QString &fileName)
 {
     QString wordSize = QSysInfo::buildAbi().split('-')[2];
     QString arch;
-    QString betaEnd;
 
     if (wordSize == "llp64") {
         arch = "win64";
-        betaEnd = "-x86_64_qt5";
     } else if (wordSize == "ilp32") {
         arch = "win32";
-        betaEnd = "-x86_qt5";
     } else {
         qWarning() << "Error checking for upgrade version: wordSize is" << wordSize;
         return false;
     }
 
     auto exeName = arch + ".exe";
-    auto exeBetaName = betaEnd + ".exe";
-    return (fileName.endsWith(exeName) || fileName.endsWith(exeBetaName));
+    return (fileName.endsWith(exeName));
 }
 #else
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes https://github.com/Cockatrice/Cockatrice/issues/3082

## Short roundup of the initial problem
I went forward with my unanswered assumptions from #3083 as that's how I understand it:
>File names are now always:
>
>      Win (64bit) --> filename-win64.exe
>      Win (32bit) --> filename-win32.exe
>      macOS --> filename.dmg
>      Ubuntu --> filename.deb
>
>(in comparison to stable releases, `filename` part for betas only has a `-beta` or `-beta.X` tag attached)
>
>So there is no need to check for `x86` and `x86_64` any longer!

>Actually, is this `betaEnd` and `exeBetaName` needed alltogether?
>
>We don't use such a pattern like `-x86_64_qt5` for any releases anymore.
Don't we differentiate via the download urls between stable and beta? 



## What will change with this Pull Request?
- remove unused beta naming mentions
