### PR TITLE
CMake: Bump version to 2.6.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 # A project name is needed for CPack
 # Version can be overriden by git tags, see cmake/getversion.cmake
-PROJECT("Cockatrice" VERSION 2.6.0)
+PROJECT("Cockatrice" VERSION 2.6.1)
 
 # Use c++11 for all targets
 set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ ISO Standard")


### PR DESCRIPTION
## Short roundup of the initial problem
Was forgotten with 2.6.1 release.
All custom builds show `2.6.0-custom(hash)` currently, which is very confusing since you can connect with them to servers with the 2.6.1 requirement enabled.

## What will change with this Pull Request?
- bump version in CMake to 2.6.1
