### PR TITLE
UI dialog tweaks: filter + create game(s)

### DIFF
--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -38,6 +38,8 @@ void DlgCreateGame::sharedCtor()
     generalGrid->addWidget(maxPlayersLabel, 1, 0);
     generalGrid->addWidget(maxPlayersEdit, 1, 1);
     generalGrid->addWidget(rememberGameSettings, 2, 0);
+    generalGroupBox = new QGroupBox(tr("General"));
+    generalGroupBox->setLayout(generalGrid);
 
     QVBoxLayout *gameTypeLayout = new QVBoxLayout;
     QMapIterator<int, QString> gameTypeIterator(gameTypes);
@@ -89,7 +91,7 @@ void DlgCreateGame::sharedCtor()
     spectatorsGroupBox->setLayout(spectatorsLayout);
 
     QGridLayout *grid = new QGridLayout;
-    grid->addLayout(generalGrid, 0, 0);
+    grid->addLayout(generalGroupBox, 0, 0);
     grid->addWidget(spectatorsGroupBox, 1, 0);
     grid->addWidget(joinRestrictionsGroupBox, 0, 1);
     grid->addWidget(gameTypeGroupBox, 1, 1);

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -32,6 +32,16 @@ void DlgCreateGame::sharedCtor()
     maxPlayersEdit->setValue(2);
     maxPlayersLabel->setBuddy(maxPlayersEdit);
 
+    QGridLayout *generalGrid = new QGridLayout;
+    generalGrid->addWidget(descriptionLabel, 0, 0);
+    generalGrid->addWidget(descriptionEdit, 0, 1);
+    generalGrid->addWidget(maxPlayersLabel, 1, 0);
+    generalGrid->addWidget(maxPlayersEdit, 1, 1);
+    generalGrid->addWidget(gameTypeGroupBox, 2, 0, 1, 2);
+    generalGroupBox = new QGroupBox(tr("General"));
+
+    grid->addWidget(gameTypeGroupBox, 1, 0);
+
     QVBoxLayout *gameTypeLayout = new QVBoxLayout;
     QMapIterator<int, QString> gameTypeIterator(gameTypes);
     while (gameTypeIterator.hasNext()) {
@@ -42,17 +52,8 @@ void DlgCreateGame::sharedCtor()
         bool isChecked = settingsCache->getGameTypes().contains(gameTypeIterator.value() + ", ");
         gameTypeCheckBoxes[gameTypeIterator.key()]->setChecked(isChecked);
     }
-
     QGroupBox *gameTypeGroupBox = new QGroupBox(tr("Game type"));
     gameTypeGroupBox->setLayout(gameTypeLayout);
-
-    QGridLayout *generalGrid = new QGridLayout;
-    generalGrid->addWidget(descriptionLabel, 0, 0);
-    generalGrid->addWidget(descriptionEdit, 0, 1);
-    generalGrid->addWidget(maxPlayersLabel, 1, 0);
-    generalGrid->addWidget(maxPlayersEdit, 1, 1);
-    generalGrid->addWidget(gameTypeGroupBox, 2, 0, 1, 2);
-    generalGroupBox = new QGroupBox(tr("General"));
 
     passwordLabel = new QLabel(tr("&Password:"));
     passwordEdit = new QLineEdit;

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -37,10 +37,8 @@ void DlgCreateGame::sharedCtor()
     generalGrid->addWidget(descriptionEdit, 0, 1);
     generalGrid->addWidget(maxPlayersLabel, 1, 0);
     generalGrid->addWidget(maxPlayersEdit, 1, 1);
-    generalGrid->addWidget(gameTypeGroupBox, 2, 0, 1, 2);
     generalGroupBox = new QGroupBox(tr("General"));
-
-    grid->addWidget(gameTypeGroupBox, 1, 0);
+    generalGroupBox->setLayout(generalGrid);
 
     QVBoxLayout *gameTypeLayout = new QVBoxLayout;
     QMapIterator<int, QString> gameTypeIterator(gameTypes);
@@ -92,8 +90,9 @@ void DlgCreateGame::sharedCtor()
     spectatorsGroupBox->setLayout(spectatorsLayout);
 
     QGridLayout *grid = new QGridLayout;
-    grid->addWidget(generalGroupBox, 0, 0, 2, 1);
+    grid->addWidget(generalGroupBox, 0, 0);
     grid->addWidget(joinRestrictionsGroupBox, 0, 1);
+    grid->addWidget(gameTypeGroupBox, 1, 0);
     grid->addWidget(spectatorsGroupBox, 1, 1);
     grid->addWidget(rememberGameSettings, 2, 0);
 

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -80,11 +80,11 @@ void DlgCreateGame::sharedCtor()
     spectatorsNeedPasswordCheckBox = new QCheckBox(tr("Spectators &need a password to watch"));
     spectatorsCanTalkCheckBox = new QCheckBox(tr("Spectators can &chat"));
     spectatorsSeeEverythingCheckBox = new QCheckBox(tr("Spectators can see &hands"));
-    QGridLayout *spectatorsLayout = new QVBoxLayout;
-    spectatorsLayout->addWidget(spectatorsAllowedCheckBox, 0, 0);
-    spectatorsLayout->addWidget(spectatorsNeedPasswordCheckBox, 1, 0);
-    spectatorsLayout->addWidget(spectatorsCanTalkCheckBox, 2, 0);
-    spectatorsLayout->addWidget(spectatorsSeeEverythingCheckBox, 3, 0);
+    QVBoxLayout *spectatorsLayout = new QVBoxLayout;
+    spectatorsLayout->addWidget(spectatorsAllowedCheckBox);
+    spectatorsLayout->addWidget(spectatorsNeedPasswordCheckBox);
+    spectatorsLayout->addWidget(spectatorsCanTalkCheckBox);
+    spectatorsLayout->addWidget(spectatorsSeeEverythingCheckBox);
     spectatorsGroupBox = new QGroupBox(tr("Spectators"));
     spectatorsGroupBox->setLayout(spectatorsLayout);
 

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -91,9 +91,9 @@ void DlgCreateGame::sharedCtor()
 
     QGridLayout *grid = new QGridLayout;
     grid->addWidget(generalGroupBox, 0, 0);
-    grid->addWidget(spectatorsGroupBox, 1, 0);
     grid->addWidget(joinRestrictionsGroupBox, 0, 1);
-    grid->addWidget(gameTypeGroupBox, 1, 1);
+    grid->addWidget(gameTypeGroupBox, 1, 0);
+    grid->addWidget(spectatorsGroupBox, 1, 1);
     grid->addWidget(rememberGameSettings, 2, 0);
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok);

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -91,7 +91,7 @@ void DlgCreateGame::sharedCtor()
     spectatorsGroupBox->setLayout(spectatorsLayout);
 
     QGridLayout *grid = new QGridLayout;
-    grid->addLayout(generalGroupBox, 0, 0);
+    grid->addWidget(generalGroupBox, 0, 0);
     grid->addWidget(spectatorsGroupBox, 1, 0);
     grid->addWidget(joinRestrictionsGroupBox, 0, 1);
     grid->addWidget(gameTypeGroupBox, 1, 1);

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -80,7 +80,7 @@ void DlgCreateGame::sharedCtor()
     spectatorsNeedPasswordCheckBox = new QCheckBox(tr("Spectators &need a password to watch"));
     spectatorsCanTalkCheckBox = new QCheckBox(tr("Spectators can &chat"));
     spectatorsSeeEverythingCheckBox = new QCheckBox(tr("Spectators can see &hands"));
-    QGridLayout *spectatorsLayout = new QVBoxLayout;
+    QGridLayout *spectatorsLayout = new QGridLayout;
     spectatorsLayout->addWidget(spectatorsAllowedCheckBox, 0, 0);
     spectatorsLayout->addWidget(spectatorsNeedPasswordCheckBox, 1, 0);
     spectatorsLayout->addWidget(spectatorsCanTalkCheckBox, 2, 0);

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -94,7 +94,7 @@ void DlgCreateGame::sharedCtor()
     grid->addWidget(spectatorsGroupBox, 1, 0);
     grid->addWidget(joinRestrictionsGroupBox, 0, 1);
     grid->addWidget(gameTypeGroupBox, 1, 1);
-    grid->addWidget(rememberGameSettings, 2, 1);
+    grid->addWidget(rememberGameSettings, 2, 0);
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok);
     connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -32,16 +32,6 @@ void DlgCreateGame::sharedCtor()
     maxPlayersEdit->setValue(2);
     maxPlayersLabel->setBuddy(maxPlayersEdit);
 
-    QGridLayout *generalGrid = new QGridLayout;
-    generalGrid->addWidget(descriptionLabel, 0, 0);
-    generalGrid->addWidget(descriptionEdit, 0, 1);
-    generalGrid->addWidget(maxPlayersLabel, 1, 0);
-    generalGrid->addWidget(maxPlayersEdit, 1, 1);
-    generalGrid->addWidget(gameTypeGroupBox, 2, 0, 1, 2);
-    generalGroupBox = new QGroupBox(tr("General"));
-
-    grid->addWidget(gameTypeGroupBox, 1, 0);
-
     QVBoxLayout *gameTypeLayout = new QVBoxLayout;
     QMapIterator<int, QString> gameTypeIterator(gameTypes);
     while (gameTypeIterator.hasNext()) {
@@ -52,8 +42,17 @@ void DlgCreateGame::sharedCtor()
         bool isChecked = settingsCache->getGameTypes().contains(gameTypeIterator.value() + ", ");
         gameTypeCheckBoxes[gameTypeIterator.key()]->setChecked(isChecked);
     }
+
     QGroupBox *gameTypeGroupBox = new QGroupBox(tr("Game type"));
     gameTypeGroupBox->setLayout(gameTypeLayout);
+
+    QGridLayout *generalGrid = new QGridLayout;
+    generalGrid->addWidget(descriptionLabel, 0, 0);
+    generalGrid->addWidget(descriptionEdit, 0, 1);
+    generalGrid->addWidget(maxPlayersLabel, 1, 0);
+    generalGrid->addWidget(maxPlayersEdit, 1, 1);
+    generalGrid->addWidget(gameTypeGroupBox, 2, 0, 1, 2);
+    generalGroupBox = new QGroupBox(tr("General"));
 
     passwordLabel = new QLabel(tr("&Password:"));
     passwordEdit = new QLineEdit;

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -80,7 +80,7 @@ void DlgCreateGame::sharedCtor()
     spectatorsNeedPasswordCheckBox = new QCheckBox(tr("Spectators &need a password to watch"));
     spectatorsCanTalkCheckBox = new QCheckBox(tr("Spectators can &chat"));
     spectatorsSeeEverythingCheckBox = new QCheckBox(tr("Spectators can see &hands"));
-    QGridLayout *spectatorsLayout = new QGridLayout;
+    QGridLayout *spectatorsLayout = new QVBoxLayout;
     spectatorsLayout->addWidget(spectatorsAllowedCheckBox, 0, 0);
     spectatorsLayout->addWidget(spectatorsNeedPasswordCheckBox, 1, 0);
     spectatorsLayout->addWidget(spectatorsCanTalkCheckBox, 2, 0);

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -37,7 +37,6 @@ void DlgCreateGame::sharedCtor()
     generalGrid->addWidget(descriptionEdit, 0, 1);
     generalGrid->addWidget(maxPlayersLabel, 1, 0);
     generalGrid->addWidget(maxPlayersEdit, 1, 1);
-    generalGrid->addWidget(rememberGameSettings, 2, 0);
     generalGroupBox = new QGroupBox(tr("General"));
     generalGroupBox->setLayout(generalGrid);
 
@@ -95,6 +94,7 @@ void DlgCreateGame::sharedCtor()
     grid->addWidget(spectatorsGroupBox, 1, 0);
     grid->addWidget(joinRestrictionsGroupBox, 0, 1);
     grid->addWidget(gameTypeGroupBox, 1, 1);
+    grid->addWidget(rememberGameSettings, 2, 1);
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok);
     connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -37,8 +37,10 @@ void DlgCreateGame::sharedCtor()
     generalGrid->addWidget(descriptionEdit, 0, 1);
     generalGrid->addWidget(maxPlayersLabel, 1, 0);
     generalGrid->addWidget(maxPlayersEdit, 1, 1);
+    generalGrid->addWidget(gameTypeGroupBox, 2, 0, 1, 2);
     generalGroupBox = new QGroupBox(tr("General"));
-    generalGroupBox->setLayout(generalGrid);
+
+    grid->addWidget(gameTypeGroupBox, 1, 0);
 
     QVBoxLayout *gameTypeLayout = new QVBoxLayout;
     QMapIterator<int, QString> gameTypeIterator(gameTypes);
@@ -90,9 +92,8 @@ void DlgCreateGame::sharedCtor()
     spectatorsGroupBox->setLayout(spectatorsLayout);
 
     QGridLayout *grid = new QGridLayout;
-    grid->addWidget(generalGroupBox, 0, 0);
+    grid->addWidget(generalGroupBox, 0, 0, 2, 1);
     grid->addWidget(joinRestrictionsGroupBox, 0, 1);
-    grid->addWidget(gameTypeGroupBox, 1, 0);
     grid->addWidget(spectatorsGroupBox, 1, 1);
     grid->addWidget(rememberGameSettings, 2, 0);
 

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -80,11 +80,11 @@ void DlgCreateGame::sharedCtor()
     spectatorsNeedPasswordCheckBox = new QCheckBox(tr("Spectators &need a password to watch"));
     spectatorsCanTalkCheckBox = new QCheckBox(tr("Spectators can &chat"));
     spectatorsSeeEverythingCheckBox = new QCheckBox(tr("Spectators can see &hands"));
-    QVBoxLayout *spectatorsLayout = new QVBoxLayout;
-    spectatorsLayout->addWidget(spectatorsAllowedCheckBox);
-    spectatorsLayout->addWidget(spectatorsNeedPasswordCheckBox);
-    spectatorsLayout->addWidget(spectatorsCanTalkCheckBox);
-    spectatorsLayout->addWidget(spectatorsSeeEverythingCheckBox);
+    QGridLayout *spectatorsLayout = new QVBoxLayout;
+    spectatorsLayout->addWidget(spectatorsAllowedCheckBox, 0, 0);
+    spectatorsLayout->addWidget(spectatorsNeedPasswordCheckBox, 1, 0);
+    spectatorsLayout->addWidget(spectatorsCanTalkCheckBox, 2, 0);
+    spectatorsLayout->addWidget(spectatorsSeeEverythingCheckBox, 3, 0);
     spectatorsGroupBox = new QGroupBox(tr("Spectators"));
     spectatorsGroupBox->setLayout(spectatorsLayout);
 

--- a/cockatrice/src/dlg_creategame.h
+++ b/cockatrice/src/dlg_creategame.h
@@ -34,7 +34,7 @@ private:
     QMap<int, QString> gameTypes;
     QMap<int, QRadioButton *> gameTypeCheckBoxes;
 
-    QGroupBox *spectatorsGroupBox;
+    QGroupBox *generalGroupBox, *spectatorsGroupBox;
     QLabel *descriptionLabel, *passwordLabel, *maxPlayersLabel;
     QLineEdit *descriptionEdit, *passwordEdit;
     QSpinBox *maxPlayersEdit;

--- a/cockatrice/src/dlg_creategame.h
+++ b/cockatrice/src/dlg_creategame.h
@@ -4,18 +4,17 @@
 #include <QDialog>
 #include <QMap>
 
+class QCheckBox;
+class QDialogButtonBox;
+class QGroupBox;
 class QLabel;
 class QLineEdit;
 class QPushButton;
-class QCheckBox;
 class QRadioButton;
-class QGroupBox;
 class QSpinBox;
-class QDialogButtonBox;
-class TabRoom;
-
 class Response;
 class ServerInfo_Game;
+class TabRoom;
 
 class DlgCreateGame : public QDialog
 {

--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -29,11 +29,16 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     gameNameFilterEdit->setText(gamesProxyModel->getGameNameFilter());
     QLabel *gameNameFilterLabel = new QLabel(tr("Game &description:"));
     gameNameFilterLabel->setBuddy(gameNameFilterEdit);
-
     creatorNameFilterEdit = new QLineEdit;
     creatorNameFilterEdit->setText(gamesProxyModel->getCreatorNameFilter());
     QLabel *creatorNameFilterLabel = new QLabel(tr("&Creator name:"));
     creatorNameFilterLabel->setBuddy(creatorNameFilterEdit);
+
+    QGridLayout *generalGrid = new QGridLayout;
+    generalGrid->addWidget(gameNameFilterLabel, 0, 0);
+    generalGrid->addWidget(gameNameFilterEdit, 0, 1);
+    generalGroupBox = new QGroupBox(tr("General"));
+    generalGroupBox->setLayout(generalGrid);
 
     QVBoxLayout *gameTypeFilterLayout = new QVBoxLayout;
     QMapIterator<int, QString> gameTypesIterator(allGameTypes);
@@ -85,8 +90,7 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     restrictionsGroupBox->setLayout(restrictionsLayout);
 
     QGridLayout *leftGrid = new QGridLayout;
-    leftGrid->addWidget(gameNameFilterLabel, 0, 0);
-    leftGrid->addWidget(gameNameFilterEdit, 0, 1);
+    leftGrid->addWidget(generalGroupBox, 0, 0);
     leftGrid->addWidget(creatorNameFilterLabel, 1, 0);
     leftGrid->addWidget(creatorNameFilterEdit, 1, 1);
     leftGrid->addWidget(maxPlayersGroupBox, 2, 0, 1, 2);

--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -37,6 +37,8 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     QGridLayout *generalGrid = new QGridLayout;
     generalGrid->addWidget(gameNameFilterLabel, 0, 0);
     generalGrid->addWidget(gameNameFilterEdit, 0, 1);
+    generalGrid->addWidget(creatorNameFilterLabel, 1, 0);
+    generalGrid->addWidget(creatorNameFilterEdit, 1, 1);
     generalGroupBox = new QGroupBox(tr("General"));
     generalGroupBox->setLayout(generalGrid);
 

--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -93,8 +93,6 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
 
     QGridLayout *leftGrid = new QGridLayout;
     leftGrid->addWidget(generalGroupBox, 0, 0);
-    leftGrid->addWidget(creatorNameFilterLabel, 1, 0);
-    leftGrid->addWidget(creatorNameFilterEdit, 1, 1);
     leftGrid->addWidget(maxPlayersGroupBox, 2, 0, 1, 2);
     leftGrid->addWidget(restrictionsGroupBox, 3, 0, 1, 2);
 

--- a/cockatrice/src/dlg_filter_games.h
+++ b/cockatrice/src/dlg_filter_games.h
@@ -15,7 +15,7 @@ class DlgFilterGames : public QDialog
 {
     Q_OBJECT
 private:
-    QGroupBox *generalGroupBox
+    QGroupBox *generalGroupBox;
     QCheckBox *showBuddiesOnlyGames;
     QCheckBox *unavailableGamesVisibleCheckBox;
     QCheckBox *showPasswordProtectedGames;

--- a/cockatrice/src/dlg_filter_games.h
+++ b/cockatrice/src/dlg_filter_games.h
@@ -8,6 +8,7 @@
 #include <QSet>
 
 class QCheckBox;
+class QGroupBox;
 class QLineEdit;
 class QSpinBox;
 

--- a/cockatrice/src/dlg_filter_games.h
+++ b/cockatrice/src/dlg_filter_games.h
@@ -15,6 +15,7 @@ class DlgFilterGames : public QDialog
 {
     Q_OBJECT
 private:
+    QGroupBox *generalGroupBox
     QCheckBox *showBuddiesOnlyGames;
     QCheckBox *unavailableGamesVisibleCheckBox;
     QCheckBox *showPasswordProtectedGames;


### PR DESCRIPTION
## Short roundup of the initial problem
Dialogs looked a bit weird and misaligned.

## What will change with this Pull Request?
- add group boxes to both dialogs for general information
- `create game`: move remember check box very visible to the bottom
- `create game`: swap game type selection with spectator box to have all important options on the left

## Screenshots
- `Filter games` before:
![before2](https://user-images.githubusercontent.com/9874850/43144659-f4cedff8-8f5d-11e8-8168-d68ebd6debc3.png)

- `Filter games` after:
![after2](https://user-images.githubusercontent.com/9874850/43144673-fe3f6d78-8f5d-11e8-85c8-e1cded8ed36e.png)


- `Create game` before:
![before](https://user-images.githubusercontent.com/9874850/43144612-deacbfb0-8f5d-11e8-8f1a-428381432d61.png)

- `Create game` after:
![after-new](https://user-images.githubusercontent.com/9874850/43144622-e4119890-8f5d-11e8-94a8-39e2a0dac4a6.png)