### PR TITLE
[WIP] Card image loading: Fallback on 404

### DIFF
--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -265,7 +265,8 @@ QString PictureToLoad::transformUrl(QString urlTemplate) const
                 /* This means the template is requesting information that is not populated
                  * in this card, so it should return an empty string, indicating an invalid Url.
                  */
-                qDebug() << "Requested information (" << prop << ") for Url template (" << urlTemplate << ") is not available for card:" << card->getName();
+                qDebug() << "Requested information (" << prop << ") for Url template (" << urlTemplate
+                         << ") is not available for card:" << card->getName();
                 return QString();
             }
         }
@@ -286,10 +287,8 @@ QString PictureToLoad::transformUrl(QString urlTemplate) const
                 /* This means the template is requesting information that is not populated
                  * in this card, so it should return an empty string, indicating an invalid Url.
                  */
-                qDebug() << "Requested information (" << prop <<
-                            ") for Url template (" << urlTemplate <<
-                            ") is not available for card (" << card->getName() <<
-                            ") in set (" << getSetName() << ")";
+                qDebug() << "Requested information (" << prop << ") for Url template (" << urlTemplate
+                         << ") is not available for card (" << card->getName() << ") in set (" << getSetName() << ")";
                 return QString();
             }
         }

--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -43,10 +43,7 @@ public:
     }
 };
 
-PictureToLoad::PictureToLoad(CardInfoPtr _card) :
-    card(std::move(_card)),
-    setIndex(0),
-    urlIndex(0)
+PictureToLoad::PictureToLoad(CardInfoPtr _card) : card(std::move(_card)), setIndex(0), urlIndex(0)
 {
     // This will be replaced with an expandable list ideally
     urlTemplates.append(settingsCache->getPicUrl());
@@ -69,7 +66,7 @@ void PictureToLoad::populateSetUrls()
         currentSetUrls.append(setCustomURL);
     }
 
-    for (int i; i< urlTemplates.size(); i++) {
+    for (int i; i < urlTemplates.size(); i++) {
         QString transformedUrl = transformUrl(urlTemplates[i]);
 
         if (!transformedUrl.isEmpty()) {
@@ -96,29 +93,24 @@ bool PictureToLoad::nextUrl()
      * will repopulate the list of urls.
      */
     if (urlIndex == currentSetUrls.size() - 1) {
-        if (nextSet()){
+        if (nextSet()) {
             // There is a new set to check, so test the Url again
             // UrlIndex would have been reset inside nextSet()
             if (urlIndex == currentSetUrls.size() - 1) {
                 // The newly populated set did not yield any usable Urls.
                 return false;
-            }
-            else
-            {
+            } else {
                 // Set was updated, UrlIndex is reset, proceed checking Urls.
                 return true;
             }
-        }
-        else
-        {
+        } else {
             // Because there is not another set, there are not more Urls to check.
             return false;
         }
-    }
-    else
-    {
+    } else {
         // We are still in the middle of the list, increment and return
-        // This must be inside the else to protect against UrlIndex being incremented
+        // This must be inside the else to protect against UrlIndex being
+        // incremented
         // when the set is moved to the next set.
         ++urlIndex;
         return true;
@@ -149,8 +141,10 @@ CardSetPtr PictureToLoad::getCurrentSet() const
         return {};
 }
 
-QStringList PictureLoaderWorker::md5Blacklist =
-    QStringList() << "db0c48db407a907c16ade38de048a441"; // card back returned by gatherer when card is not found
+QStringList PictureLoaderWorker::md5Blacklist = QStringList()
+                                                << "db0c48db407a907c16ade38de048a441"; // card back returned
+                                                                                       // by gatherer when
+                                                                                       // card is not found
 
 PictureLoaderWorker::PictureLoaderWorker() : QObject(nullptr), downloadRunning(false), loadQueueRunning(false)
 {
@@ -208,14 +202,16 @@ void PictureLoaderWorker::processLoadQueue()
                 startNextPicDownload();
         } else {
             if (cardBeingLoaded.nextSet()) {
-                qDebug() << "Picture NOT found and download disabled, moving to next set (newset: " << setName
-                         << " card: " << cardName << ")";
+                qDebug() << "Picture NOT found and download disabled, moving to next "
+                            "set (newset: "
+                         << setName << " card: " << cardName << ")";
                 mutex.lock();
                 loadQueue.prepend(cardBeingLoaded);
                 cardBeingLoaded.clear();
                 mutex.unlock();
             } else {
-                qDebug() << "Picture NOT found, download disabled, no more sets to try: BAILING OUT (oldset: "
+                qDebug() << "Picture NOT found, download disabled, no more sets to "
+                            "try: BAILING OUT (oldset: "
                          << setName << " card: " << cardName << ")";
                 imageLoaded(cardBeingLoaded.getCard(), QImage());
             }
@@ -245,7 +241,8 @@ bool PictureLoaderWorker::cardImageExistsOnDisk(QString &setName, QString &corre
                   << picsPath + "/downloadedPics/" + setName + "/" + correctedCardname;
     }
 
-    // Iterates through the list of paths, searching for images with the desired name with any QImageReader-supported
+    // Iterates through the list of paths, searching for images with the desired
+    // name with any QImageReader-supported
     // extension
     for (int i = 0; i < picsPaths.length(); i++) {
         imgReader.setFileName(picsPaths.at(i));
@@ -286,9 +283,11 @@ QString PictureToLoad::transformUrl(QString urlTemplate) const
     transformedUrl.replace("!cardid!", QUrl::toPercentEncoding(QString::number(muid)));
 
     if (set) {
-        // renamed from !setnumber! to !collectornumber! on 20160819. Remove the old one when convenient.
+        // renamed from !setnumber! to !collectornumber! on 20160819. Remove the old
+        // one when convenient.
         transformedUrl.replace("!setnumber!", QUrl::toPercentEncoding(card->getCollectorNumber(set->getShortName())));
-        transformedUrl.replace("!collectornumber!", QUrl::toPercentEncoding(card->getCollectorNumber(set->getShortName())));
+        transformedUrl.replace("!collectornumber!",
+                               QUrl::toPercentEncoding(card->getCollectorNumber(set->getShortName())));
 
         transformedUrl.replace("!setcode!", QUrl::toPercentEncoding(set->getShortName()));
         transformedUrl.replace("!setcode_lower!", QUrl::toPercentEncoding(set->getShortName().toLower()));
@@ -296,16 +295,11 @@ QString PictureToLoad::transformUrl(QString urlTemplate) const
         transformedUrl.replace("!setname_lower!", QUrl::toPercentEncoding(set->getLongName().toLower()));
     }
 
-    if (transformedUrl.contains("!name!") ||
-            transformedUrl.contains("!name_lower!") ||
-            transformedUrl.contains("!corrected_name!") ||
-            transformedUrl.contains("!corrected_name_lower!") ||
-            transformedUrl.contains("!setnumber!") ||
-            transformedUrl.contains("!setcode!") ||
-            transformedUrl.contains("!setcode_lower!") ||
-            transformedUrl.contains("!setname!") ||
-            transformedUrl.contains("!setname_lower!") ||
-            transformedUrl.contains("!cardid!")) {
+    if (transformedUrl.contains("!name!") || transformedUrl.contains("!name_lower!") ||
+        transformedUrl.contains("!corrected_name!") || transformedUrl.contains("!corrected_name_lower!") ||
+        transformedUrl.contains("!setnumber!") || transformedUrl.contains("!setcode!") ||
+        transformedUrl.contains("!setcode_lower!") || transformedUrl.contains("!setname!") ||
+        transformedUrl.contains("!setname_lower!") || transformedUrl.contains("!cardid!")) {
         qDebug() << "Insufficient card data to download" << card->getName() << "Url:" << urlTemplates[urlIndex];
         return QString();
     }
@@ -343,14 +337,16 @@ void PictureLoaderWorker::startNextPicDownload()
 void PictureLoaderWorker::picDownloadFailed()
 {
     if (cardBeingDownloaded.nextUrl()) {
-        //qDebug() << "Picture NOT found, download failed, moving to next url (url: " << cardBeingDownloaded.getCurrentUrl()
+        // qDebug() << "Picture NOT found, download failed, moving to next url (url:
+        // " << cardBeingDownloaded.getCurrentUrl()
         //         << " set: " << cardBeingDownloaded.getSetName()
         //         << " card: " << cardBeingDownloaded.getCard()->getName() << ")";
         mutex.lock();
         loadQueue.prepend(cardBeingDownloaded);
         mutex.unlock();
     } else {
-        qDebug() << "Picture NOT found, download failed, no more url combinations to try: BAILING OUT for card: "
+        qDebug() << "Picture NOT found, download failed, no more url combinations "
+                    "to try: BAILING OUT for card: "
                  << cardBeingDownloaded.getCard()->getName() << ")";
         imageLoaded(cardBeingDownloaded.getCard(), QImage());
         cardBeingDownloaded.clear();
@@ -379,8 +375,8 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
         return;
     }
 
-    const QByteArray &picData =
-        reply->peek(reply->size()); // peek is used to keep the data in the buffer for use by QImageReader
+    const QByteArray &picData = reply->peek(reply->size()); // peek is used to keep the data in the buffer
+                                                            // for use by QImageReader
 
     if (imageIsBlackListed(picData)) {
         qDebug() << "Picture downloaded, but blacklisted, will consider it as not found";
@@ -395,8 +391,10 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
     QImageReader imgReader;
     imgReader.setDecideFormatFromContent(true);
     imgReader.setDevice(reply);
-    QString extension = "." + imgReader.format(); // the format is determined prior to reading the QImageReader data
-                                                  // into a QImage object, as that wipes the QImageReader buffer
+    QString extension = "." + imgReader.format(); // the format is determined
+                                                  // prior to reading the
+                                                  // QImageReader data
+    // into a QImage object, as that wipes the QImageReader buffer
     if (extension == ".jpeg")
         extension = ".jpg";
 

--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -315,8 +315,7 @@ void PictureLoaderWorker::startNextPicDownload()
         downloadRunning = false;
         picDownloadFailed();
     } else {
-        QUrl url(picUrl); // For now, just use the first one, like always.
-
+        QUrl url(picUrl);
         QNetworkRequest req(url);
         qDebug() << "PictureLoader: Trying to download picture for card:" << cardBeingDownloaded.getCard()->getName()
                  << " from set:" << cardBeingDownloaded.getSetName() << "from url:" << picUrl;

--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -268,8 +268,9 @@ QString PictureToLoad::transformUrl(QString urlTemplate) const
             if (!cardProperties[prop].isEmpty()) {
                 transformedUrl.replace(prop, QUrl::toPercentEncoding(cardProperties[prop]));
             } else {
-                /* This means the template is requesting information that is not populated
-                 * in this card, so it should return an empty string, indicating an invalid Url.
+                /* This means the template is requesting information that is not
+                 * populated in this card, so it should return an empty string,
+                 * indicating an invalid Url.
                  */
                 qDebug() << "PictureLoader: [card: " << card->getName() << " set: " << getSetName()
                          << "]: Requested information (" << prop << ") for Url template (" << urlTemplate
@@ -291,8 +292,9 @@ QString PictureToLoad::transformUrl(QString urlTemplate) const
             if (set && !setProperties[prop].isEmpty()) {
                 transformedUrl.replace(prop, QUrl::toPercentEncoding(setProperties[prop]));
             } else {
-                /* This means the template is requesting information that is not populated
-                 * in this card, so it should return an empty string, indicating an invalid Url.
+                /* This means the template is requesting information that is not
+                 * populated in this card, so it should return an empty string,
+                 * indicating an invalid Url.
                  */
                 qDebug() << "PictureLoader: [card: " << card->getName() << " set: " << getSetName()
                          << "]: Requested information (" << prop << ") for Url template (" << urlTemplate
@@ -378,7 +380,8 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
     if (imageIsBlackListed(picData)) {
         qDebug() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
                  << " set: " << cardBeingDownloaded.getSetName()
-                 << "]:Picture downloaded, but blacklisted, will consider it as not found";
+                 << "]:Picture downloaded, but blacklisted, will consider it as "
+                    "not found";
         picDownloadFailed();
         reply->deleteLater();
         startNextPicDownload();

--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -45,7 +45,7 @@ public:
 
 PictureToLoad::PictureToLoad(CardInfoPtr _card) : card(std::move(_card))
 {
-    // This will be replaced with an expandable list ideally
+    /* #2479 will expand this into a list of Urls */
     urlTemplates.append(settingsCache->getPicUrl());
     urlTemplates.append(settingsCache->getPicUrlFallback());
 
@@ -76,11 +76,9 @@ void PictureToLoad::populateSetUrls()
         }
     }
 
-    if (!currentSetUrls.isEmpty()) {
-        currentUrl = currentSetUrls.takeFirst();
-    } else {
-        currentUrl = QString();
-    }
+    /* Call nextUrl to make sure currentUrl is up-to-date
+       but we don't need the result here. */
+    (void)nextUrl();
 }
 
 bool PictureToLoad::nextSet()

--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -255,7 +255,7 @@ QString PictureToLoad::transformUrl(QString urlTemplate) const
     cardProperties["!name_lower!"] = card->getName().toLower();
     cardProperties["!corrected_name!"] = card->getCorrectedName();
     cardProperties["!corrected_name_lower!"] = card->getCorrectedName().toLower();
-    cardProperties["!cardid"] = muid;
+    cardProperties["!cardid!"] = muid;
 
     foreach (QString prop, cardProperties.keys()) {
         if (transformedUrl.contains(prop)) {
@@ -277,7 +277,7 @@ QString PictureToLoad::transformUrl(QString urlTemplate) const
     setProperties["!setcode!"] = set->getShortName();
     setProperties["!setcode_lower!"] = set->getShortName().toLower();
     setProperties["!setname!"] = set->getLongName();
-    setProperties["!setname_lower"] = set->getLongName().toLower();
+    setProperties["!setname_lower!"] = set->getLongName().toLower();
 
     foreach (QString prop, setProperties.keys()) {
         if (transformedUrl.contains(prop)) {

--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -255,49 +255,36 @@ QString PictureToLoad::transformUrl(QString urlTemplate) const
        for downloading images.  If information is requested by the template that is
        not populated for this specific card/set combination, an empty string is returned.*/
 
-    QString muid = QString();
     QString transformedUrl = urlTemplate;
     CardSetPtr set = getCurrentSet();
 
+    QMap<QString, QString> transformMap = QMap<QString, QString>();
+
+    transformMap["!name!"] = card->getName();
+    transformMap["!name_lower!"] = card->getName().toLower();
+    transformMap["!corrected_name!"] = card->getCorrectedName();
+    transformMap["!corrected_name_lower!"] = card->getCorrectedName().toLower();
+
     if (set) {
-        muid = QString::number(card->getMuId(set->getShortName()));
+        transformMap["!cardid!"] = QString::number(card->getMuId(set->getShortName()));
+        transformMap["!collectornumber!"] = card->getCollectorNumber(set->getShortName());
+        transformMap["!setcode!"] = set->getShortName();
+        transformMap["!setcode_lower!"] = set->getShortName().toLower();
+        transformMap["!setname!"] = set->getLongName();
+        transformMap["!setname_lower!"] = set->getLongName().toLower();
+    } else {
+        transformMap["!cardid!"] = QString();
+        transformMap["!collectornumber!"] = QString();
+        transformMap["!setcode!"] = QString();
+        transformMap["!setcode_lower!"] = QString();
+        transformMap["!setname!"] = QString();
+        transformMap["!setname_lower!"] = QString();
     }
 
-    QMap<QString, QString> cardProperties = QMap<QString, QString>();
-    cardProperties["!name!"] = card->getName();
-    cardProperties["!name_lower!"] = card->getName().toLower();
-    cardProperties["!corrected_name!"] = card->getCorrectedName();
-    cardProperties["!corrected_name_lower!"] = card->getCorrectedName().toLower();
-    cardProperties["!cardid!"] = muid;
-
-    foreach (QString prop, cardProperties.keys()) {
+    foreach (QString prop, transformMap.keys()) {
         if (transformedUrl.contains(prop)) {
-            if (!cardProperties[prop].isEmpty()) {
-                transformedUrl.replace(prop, QUrl::toPercentEncoding(cardProperties[prop]));
-            } else {
-                /* This means the template is requesting information that is not
-                 * populated in this card, so it should return an empty string,
-                 * indicating an invalid Url.
-                 */
-                qDebug() << "PictureLoader: [card: " << card->getName() << " set: " << getSetName()
-                         << "]: Requested information (" << prop << ") for Url template (" << urlTemplate
-                         << ") is not available";
-                return QString();
-            }
-        }
-    }
-
-    QMap<QString, QString> setProperties = QMap<QString, QString>();
-    setProperties["!collectornumber!"] = card->getCollectorNumber(set->getShortName());
-    setProperties["!setcode!"] = set->getShortName();
-    setProperties["!setcode_lower!"] = set->getShortName().toLower();
-    setProperties["!setname!"] = set->getLongName();
-    setProperties["!setname_lower!"] = set->getLongName().toLower();
-
-    foreach (QString prop, setProperties.keys()) {
-        if (transformedUrl.contains(prop)) {
-            if (set && !setProperties[prop].isEmpty()) {
-                transformedUrl.replace(prop, QUrl::toPercentEncoding(setProperties[prop]));
+            if (!transformMap[prop].isEmpty()) {
+                transformedUrl.replace(prop, QUrl::toPercentEncoding(transformMap[prop]));
             } else {
                 /* This means the template is requesting information that is not
                  * populated in this card, so it should return an empty string,

--- a/cockatrice/src/pictureloader.h
+++ b/cockatrice/src/pictureloader.h
@@ -70,7 +70,6 @@ private:
     PictureToLoad cardBeingDownloaded;
     bool picDownload, downloadRunning, loadQueueRunning;
     void startNextPicDownload();
-    QList<QString> getAllPicUrls();
     bool cardImageExistsOnDisk(QString &setName, QString &correctedCardname);
     bool imageIsBlackListed(const QByteArray &picData);
 private slots:

--- a/cockatrice/src/pictureloader.h
+++ b/cockatrice/src/pictureloader.h
@@ -20,8 +20,8 @@ private:
     QList<CardSetPtr> sortedSets;
     QList<QString> urlTemplates;
     QList<QString> currentSetUrls;
-    int setIndex;
-    int urlIndex;
+    QString currentUrl;
+    CardSetPtr currentSet;
 
 public:
     PictureToLoad(CardInfoPtr _card = CardInfoPtr());
@@ -33,8 +33,14 @@ public:
     {
         card.clear();
     }
-    CardSetPtr getCurrentSet() const;
-    QString getCurrentUrl() const;
+    QString getCurrentUrl() const
+    {
+        return currentUrl;
+    }
+    CardSetPtr getCurrentSet() const
+    {
+        return currentSet;
+    }
     QString getSetName() const;
     QString transformUrl(QString urlTemplate) const;
     bool nextSet();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2479

## Short roundup of the initial problem
See #3363 

## What will change with this Pull Request?
- Relative to #3363, the work has been updated to no longer use separately managed indices, and instead uses lists and takeFirst() to empty them.

- Method for substituting information into Urls now gives more feedback about which items are failing, and will also return empty string instead of leaving empty strings inside the return Url.

## Screenshots

