### PR TITLE
Disable saving of decks when the deck is empty

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -756,12 +756,10 @@ void TabDeckEditor::actLoadDeck()
     DeckLoader::FileFormat fmt = DeckLoader::getFormatFromName(fileName);
 
     auto *l = new DeckLoader;
-    if (l->loadFromFile(fileName, fmt))
-    {
+    if (l->loadFromFile(fileName, fmt)) {
         setSaveStatus(false);
         setDeck(l);
-    }
-    else
+    } else
         delete l;
 }
 
@@ -999,13 +997,9 @@ void TabDeckEditor::actRemoveCard()
     deckModel->removeRow(currentIndex.row(), currentIndex.parent());
 
     DeckLoader *const deck = deckModel->getDeckList();
-    QString decklistUrlString;
-    if (deck->isEmpty())
-    {
+    if (deck->isEmpty()) {
         setSaveStatus(false);
-    }
-    else
-    {
+    } else {
         setSaveStatus(true);
     }
     setModified(true);

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -989,7 +989,7 @@ void TabDeckEditor::actAddCardToSideboard()
 void TabDeckEditor::actRemoveCard()
 {
     const QModelIndex &currentIndex = deckView->selectionModel()->currentIndex();
-    if (!currentIndex.isValid() || deckModel->hasChildren(currentIndex)) 
+    if (!currentIndex.isValid() || deckModel->hasChildren(currentIndex))
         return;
     deckModel->removeRow(currentIndex.row(), currentIndex.parent());
 

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -254,8 +254,6 @@ void TabDeckEditor::createMenus()
     aSaveDeckToClipboardRaw = new QAction(QString(), this);
     connect(aSaveDeckToClipboardRaw, SIGNAL(triggered()), this, SLOT(actSaveDeckToClipboardRaw()));
 
-    setSaveStatus(false);
-
     aPrintDeck = new QAction(QString(), this);
     connect(aPrintDeck, SIGNAL(triggered()), this, SLOT(actPrintDeck()));
 
@@ -338,6 +336,8 @@ void TabDeckEditor::createMenus()
     aResetLayout = viewMenu->addAction(QString());
     connect(aResetLayout, SIGNAL(triggered()), this, SLOT(restartLayout()));
     viewMenu->addAction(aResetLayout);
+
+    setSaveStatus(false);
 
     addTabMenu(viewMenu);
 }
@@ -1208,4 +1208,7 @@ void TabDeckEditor::setSaveStatus(bool newStatus)
     aSaveDeckAs->setEnabled(newStatus);
     aSaveDeckToClipboard->setEnabled(newStatus);
     aSaveDeckToClipboardRaw->setEnabled(newStatus);
+    saveDeckToClipboardMenu->setEnabled(newStatus);
+    aPrintDeck->setEnabled(newStatus);
+    analyzeDeckMenu->setEnabled(newStatus);
 }

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -675,12 +675,14 @@ void TabDeckEditor::updateName(const QString &name)
 {
     deckModel->getDeckList()->setName(name);
     setModified(true);
+    setSaveStatus(true);
 }
 
 void TabDeckEditor::updateComments()
 {
     deckModel->getDeckList()->setComments(commentsEdit->toPlainText());
     setModified(true);
+    setSaveStatus(true);
 }
 
 void TabDeckEditor::updateCardInfoLeft(const QModelIndex &current, const QModelIndex & /*previous*/)
@@ -761,6 +763,7 @@ void TabDeckEditor::actLoadDeck()
         setDeck(l);
     } else
         delete l;
+    setSaveStatus(true);
 }
 
 void TabDeckEditor::saveDeckRemoteFinished(const Response &response)
@@ -832,8 +835,8 @@ void TabDeckEditor::actLoadDeckFromClipboard()
         return;
 
     setDeck(dlg.getDeckList());
-    setSaveStatus(true);
     setModified(true);
+    setSaveStatus(true);
 }
 
 void TabDeckEditor::actSaveDeckToClipboard()
@@ -971,8 +974,8 @@ void TabDeckEditor::actSwapCard()
     QModelIndex newCardIndex = deckModel->addCard(cardName, otherZoneName, true);
     recursiveExpand(newCardIndex);
 
-    setSaveStatus(true);
     setModified(true);
+    setSaveStatus(true);
 }
 
 void TabDeckEditor::actAddCard()
@@ -987,6 +990,7 @@ void TabDeckEditor::actAddCard()
 void TabDeckEditor::actAddCardToSideboard()
 {
     addCardHelper(DECK_ZONE_SIDE);
+    setSaveStatus(true);
 }
 
 void TabDeckEditor::actRemoveCard()

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -832,7 +832,7 @@ void TabDeckEditor::actLoadDeckFromClipboard()
         return;
 
     setDeck(dlg.getDeckList());
-    setSaveStatus(false);
+    setSaveStatus(true);
     setModified(true);
 }
 

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -241,9 +241,11 @@ void TabDeckEditor::createMenus()
 
     aSaveDeck = new QAction(QString(), this);
     connect(aSaveDeck, SIGNAL(triggered()), this, SLOT(actSaveDeck()));
+	aSaveDeck->setEnabled(false);
 
     aSaveDeckAs = new QAction(QString(), this);
     connect(aSaveDeckAs, SIGNAL(triggered()), this, SLOT(actSaveDeckAs()));
+	aSaveDeckAs->setEnabled(false);
 
     aLoadDeckFromClipboard = new QAction(QString(), this);
     connect(aLoadDeckFromClipboard, SIGNAL(triggered()), this, SLOT(actLoadDeckFromClipboard()));
@@ -975,6 +977,8 @@ void TabDeckEditor::actAddCard()
         actAddCardToSideboard();
     else
         addCardHelper(DECK_ZONE_MAIN);
+	aSaveDeck->setEnabled(true);
+	aSaveDeckAs->setEnabled(true);
 }
 
 void TabDeckEditor::actAddCardToSideboard()
@@ -985,9 +989,20 @@ void TabDeckEditor::actAddCardToSideboard()
 void TabDeckEditor::actRemoveCard()
 {
     const QModelIndex &currentIndex = deckView->selectionModel()->currentIndex();
-    if (!currentIndex.isValid() || deckModel->hasChildren(currentIndex))
-        return;
+	if (!currentIndex.isValid() || deckModel->hasChildren(currentIndex)) 
+		return;
     deckModel->removeRow(currentIndex.row(), currentIndex.parent());
+
+	// Disable saving if the deck is empty
+	DeckLoader *const deck = deckModel->getDeckList();
+	QString decklistUrlString;
+	if (deck) {
+		decklistUrlString = deck->exportDeckToDecklist();
+		if (QString::compare(decklistUrlString, "", Qt::CaseInsensitive) == 0) {
+			aSaveDeck->setEnabled(false);
+			aSaveDeckAs->setEnabled(false);
+		}
+	}
     setModified(true);
 }
 

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -241,11 +241,11 @@ void TabDeckEditor::createMenus()
 
     aSaveDeck = new QAction(QString(), this);
     connect(aSaveDeck, SIGNAL(triggered()), this, SLOT(actSaveDeck()));
-	aSaveDeck->setEnabled(false);
+    aSaveDeck->setEnabled(false);
 
     aSaveDeckAs = new QAction(QString(), this);
     connect(aSaveDeckAs, SIGNAL(triggered()), this, SLOT(actSaveDeckAs()));
-	aSaveDeckAs->setEnabled(false);
+    aSaveDeckAs->setEnabled(false);
 
     aLoadDeckFromClipboard = new QAction(QString(), this);
     connect(aLoadDeckFromClipboard, SIGNAL(triggered()), this, SLOT(actLoadDeckFromClipboard()));
@@ -977,8 +977,8 @@ void TabDeckEditor::actAddCard()
         actAddCardToSideboard();
     else
         addCardHelper(DECK_ZONE_MAIN);
-	aSaveDeck->setEnabled(true);
-	aSaveDeckAs->setEnabled(true);
+    aSaveDeck->setEnabled(true);
+    aSaveDeckAs->setEnabled(true);
 }
 
 void TabDeckEditor::actAddCardToSideboard()
@@ -989,20 +989,20 @@ void TabDeckEditor::actAddCardToSideboard()
 void TabDeckEditor::actRemoveCard()
 {
     const QModelIndex &currentIndex = deckView->selectionModel()->currentIndex();
-	if (!currentIndex.isValid() || deckModel->hasChildren(currentIndex)) 
-		return;
+    if (!currentIndex.isValid() || deckModel->hasChildren(currentIndex)) 
+        return;
     deckModel->removeRow(currentIndex.row(), currentIndex.parent());
 
-	// Disable saving if the deck is empty
-	DeckLoader *const deck = deckModel->getDeckList();
-	QString decklistUrlString;
-	if (deck) {
-		decklistUrlString = deck->exportDeckToDecklist();
-		if (QString::compare(decklistUrlString, "", Qt::CaseInsensitive) == 0) {
-			aSaveDeck->setEnabled(false);
-			aSaveDeckAs->setEnabled(false);
-		}
-	}
+    // Disable saving if the deck is empty
+    DeckLoader *const deck = deckModel->getDeckList();
+    QString decklistUrlString;
+    if (deck) {
+        decklistUrlString = deck->exportDeckToDecklist();
+        if (QString::compare(decklistUrlString, "", Qt::CaseInsensitive) == 0) {
+            aSaveDeck->setEnabled(false);
+            aSaveDeckAs->setEnabled(false);
+        }
+    }
     setModified(true);
 }
 

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -997,11 +997,7 @@ void TabDeckEditor::actRemoveCard()
     deckModel->removeRow(currentIndex.row(), currentIndex.parent());
 
     DeckLoader *const deck = deckModel->getDeckList();
-    if (deck->isEmpty()) {
-        setSaveStatus(false);
-    } else {
-        setSaveStatus(true);
-    }
+    setSaveStatus(!deck->isEmpty());
     setModified(true);
 }
 

--- a/cockatrice/src/tab_deck_editor.h
+++ b/cockatrice/src/tab_deck_editor.h
@@ -95,6 +95,7 @@ private slots:
     void dockFloatingTriggered();
     void dockTopLevelChanged(bool topLevel);
     void saveDbHeaderState();
+    void setSaveStatus(bool newStatus);
 
 private:
     CardInfoPtr currentCardInfo() const;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3339 

## Short roundup of the initial problem
- Empty decks are able to be saved

## What will change with this Pull Request?
- The "save" and "save as" options will be greyed out when the deck is empty
- Code for checking the size of the deck is borrowed from the actExportDeckDecklist() function


## Screenshots
![1](https://user-images.githubusercontent.com/41343559/44968075-401ddc80-af0b-11e8-87e9-5b3d3a340765.PNG)
