### PR TITLE
Enable using a shortcut for playing the top card of the library face down

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -801,6 +801,7 @@ void Player::setShortcutsActive()
     aCreateToken->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aCreateToken"));
     aCreateAnotherToken->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aCreateAnotherToken"));
     aAlwaysRevealTopCard->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aAlwaysRevealTopCard"));
+    aMoveTopToPlayFaceDown->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aMoveTopToPlayFaceDown"));
 }
 
 void Player::setShortcutsInactive()

--- a/cockatrice/src/sequenceEdit/ui_shortcutstab.h
+++ b/cockatrice/src/sequenceEdit/ui_shortcutstab.h
@@ -289,6 +289,8 @@ public:
     SequenceEdit *Player_aMoveToExile;
     QLabel *lbl_Player_aMoveToHand;
     SequenceEdit *Player_aMoveToHand;
+    QLabel *lbl_Player_aMoveTopToPlayFaceDown;
+    SequenceEdit *Player_aMoveTopToPlayFaceDown;
     QGroupBox *groupBox_16;
     QGridLayout *gridLayout_16;
     QLabel *lbl_Player_aViewGraveyard;
@@ -1446,6 +1448,18 @@ public:
 
         gridLayout_15->addWidget(Player_aMoveToHand, 4, 1, 1, 1);
 
+        lbl_Player_aMoveTopToPlayFaceDown = new QLabel(groupBox_15);
+        lbl_Player_aMoveTopToPlayFaceDown->setObjectName("lbl_Player_aMoveTopToPlayFaceDown");
+
+        gridLayout_15->addWidget(lbl_Player_aMoveTopToPlayFaceDown, 5, 0, 1, 1);
+
+        Player_aMoveTopToPlayFaceDown = new SequenceEdit("Player/aMoveTopToPlayFaceDown", groupBox_15);
+        Player_aMoveTopToPlayFaceDown->setObjectName("Player_aMoveTopToPlayFaceDown");
+
+        gridLayout_15->addWidget(Player_aMoveTopToPlayFaceDown, 5, 1, 1, 1);
+
+
+
         gridLayout_20->addWidget(groupBox_15, 0, 1, 1, 1);
 
         groupBox_16 = new QGroupBox(tab_3);
@@ -1874,6 +1888,7 @@ public:
         lbl_Player_aMoveToGraveyard->setText(QApplication::translate("shortcutsTab", "Graveyard", 0));
         lbl_Player_aMoveToExile->setText(QApplication::translate("shortcutsTab", "Exile", 0));
         lbl_Player_aMoveToHand->setText(QApplication::translate("shortcutsTab", "Hand", 0));
+        lbl_Player_aMoveTopToPlayFaceDown->setText(QApplication::translate("shortcutsTab", "Play face down"));
         groupBox_16->setTitle(QApplication::translate("shortcutsTab", "View", 0));
         lbl_Player_aViewGraveyard->setText(QApplication::translate("shortcutsTab", "Graveyard", 0));
         lbl_Player_aViewLibrary->setText(QApplication::translate("shortcutsTab", "Library", 0));

--- a/cockatrice/src/shortcutssettings.cpp
+++ b/cockatrice/src/shortcutssettings.cpp
@@ -325,4 +325,5 @@ void ShortcutsSettings::fillDefaultShorcuts()
     defaultShortCuts["tab_room/aClearChat"] = parseSequenceString("F12");
     defaultShortCuts["DlgLoadDeckFromClipboard/refreshButton"] = parseSequenceString("F5");
     defaultShortCuts["Player/aResetLayout"] = parseSequenceString("");
+    defaultShortCuts["Player/aMoveTopToPlayFaceDown"] = parseSequenceString("Ctrl+Shift+E");
 }

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -756,12 +756,10 @@ void TabDeckEditor::actLoadDeck()
     DeckLoader::FileFormat fmt = DeckLoader::getFormatFromName(fileName);
 
     auto *l = new DeckLoader;
-    if (l->loadFromFile(fileName, fmt))
-    {
+    if (l->loadFromFile(fileName, fmt)) {
         setSaveStatus(false);
         setDeck(l);
-    }
-    else
+    } else
         delete l;
 }
 
@@ -999,13 +997,9 @@ void TabDeckEditor::actRemoveCard()
     deckModel->removeRow(currentIndex.row(), currentIndex.parent());
 
     DeckLoader *const deck = deckModel->getDeckList();
-    QString decklistUrlString;
-    if (deck->isEmpty())
-    {
+    if (deck->isEmpty()) {
         setSaveStatus(false);
-    }
-    else
-    {
+    } else {
         setSaveStatus(true);
     }
     setModified(true);

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -989,7 +989,7 @@ void TabDeckEditor::actAddCardToSideboard()
 void TabDeckEditor::actRemoveCard()
 {
     const QModelIndex &currentIndex = deckView->selectionModel()->currentIndex();
-    if (!currentIndex.isValid() || deckModel->hasChildren(currentIndex)) 
+    if (!currentIndex.isValid() || deckModel->hasChildren(currentIndex))
         return;
     deckModel->removeRow(currentIndex.row(), currentIndex.parent());
 

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -254,8 +254,6 @@ void TabDeckEditor::createMenus()
     aSaveDeckToClipboardRaw = new QAction(QString(), this);
     connect(aSaveDeckToClipboardRaw, SIGNAL(triggered()), this, SLOT(actSaveDeckToClipboardRaw()));
 
-    setSaveStatus(false);
-
     aPrintDeck = new QAction(QString(), this);
     connect(aPrintDeck, SIGNAL(triggered()), this, SLOT(actPrintDeck()));
 
@@ -338,6 +336,8 @@ void TabDeckEditor::createMenus()
     aResetLayout = viewMenu->addAction(QString());
     connect(aResetLayout, SIGNAL(triggered()), this, SLOT(restartLayout()));
     viewMenu->addAction(aResetLayout);
+
+    setSaveStatus(false);
 
     addTabMenu(viewMenu);
 }
@@ -1208,4 +1208,7 @@ void TabDeckEditor::setSaveStatus(bool newStatus)
     aSaveDeckAs->setEnabled(newStatus);
     aSaveDeckToClipboard->setEnabled(newStatus);
     aSaveDeckToClipboardRaw->setEnabled(newStatus);
+    saveDeckToClipboardMenu->setEnabled(newStatus);
+    aPrintDeck->setEnabled(newStatus);
+    analyzeDeckMenu->setEnabled(newStatus);
 }

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -832,7 +832,7 @@ void TabDeckEditor::actLoadDeckFromClipboard()
         return;
 
     setDeck(dlg.getDeckList());
-    setSaveStatus(false);
+    setSaveStatus(true);
     setModified(true);
 }
 

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -241,9 +241,11 @@ void TabDeckEditor::createMenus()
 
     aSaveDeck = new QAction(QString(), this);
     connect(aSaveDeck, SIGNAL(triggered()), this, SLOT(actSaveDeck()));
+	aSaveDeck->setEnabled(false);
 
     aSaveDeckAs = new QAction(QString(), this);
     connect(aSaveDeckAs, SIGNAL(triggered()), this, SLOT(actSaveDeckAs()));
+	aSaveDeckAs->setEnabled(false);
 
     aLoadDeckFromClipboard = new QAction(QString(), this);
     connect(aLoadDeckFromClipboard, SIGNAL(triggered()), this, SLOT(actLoadDeckFromClipboard()));
@@ -975,6 +977,8 @@ void TabDeckEditor::actAddCard()
         actAddCardToSideboard();
     else
         addCardHelper(DECK_ZONE_MAIN);
+	aSaveDeck->setEnabled(true);
+	aSaveDeckAs->setEnabled(true);
 }
 
 void TabDeckEditor::actAddCardToSideboard()
@@ -985,9 +989,20 @@ void TabDeckEditor::actAddCardToSideboard()
 void TabDeckEditor::actRemoveCard()
 {
     const QModelIndex &currentIndex = deckView->selectionModel()->currentIndex();
-    if (!currentIndex.isValid() || deckModel->hasChildren(currentIndex))
-        return;
+	if (!currentIndex.isValid() || deckModel->hasChildren(currentIndex)) 
+		return;
     deckModel->removeRow(currentIndex.row(), currentIndex.parent());
+
+	// Disable saving if the deck is empty
+	DeckLoader *const deck = deckModel->getDeckList();
+	QString decklistUrlString;
+	if (deck) {
+		decklistUrlString = deck->exportDeckToDecklist();
+		if (QString::compare(decklistUrlString, "", Qt::CaseInsensitive) == 0) {
+			aSaveDeck->setEnabled(false);
+			aSaveDeckAs->setEnabled(false);
+		}
+	}
     setModified(true);
 }
 

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -241,11 +241,11 @@ void TabDeckEditor::createMenus()
 
     aSaveDeck = new QAction(QString(), this);
     connect(aSaveDeck, SIGNAL(triggered()), this, SLOT(actSaveDeck()));
-	aSaveDeck->setEnabled(false);
+    aSaveDeck->setEnabled(false);
 
     aSaveDeckAs = new QAction(QString(), this);
     connect(aSaveDeckAs, SIGNAL(triggered()), this, SLOT(actSaveDeckAs()));
-	aSaveDeckAs->setEnabled(false);
+    aSaveDeckAs->setEnabled(false);
 
     aLoadDeckFromClipboard = new QAction(QString(), this);
     connect(aLoadDeckFromClipboard, SIGNAL(triggered()), this, SLOT(actLoadDeckFromClipboard()));
@@ -977,8 +977,8 @@ void TabDeckEditor::actAddCard()
         actAddCardToSideboard();
     else
         addCardHelper(DECK_ZONE_MAIN);
-	aSaveDeck->setEnabled(true);
-	aSaveDeckAs->setEnabled(true);
+    aSaveDeck->setEnabled(true);
+    aSaveDeckAs->setEnabled(true);
 }
 
 void TabDeckEditor::actAddCardToSideboard()
@@ -989,20 +989,20 @@ void TabDeckEditor::actAddCardToSideboard()
 void TabDeckEditor::actRemoveCard()
 {
     const QModelIndex &currentIndex = deckView->selectionModel()->currentIndex();
-	if (!currentIndex.isValid() || deckModel->hasChildren(currentIndex)) 
-		return;
+    if (!currentIndex.isValid() || deckModel->hasChildren(currentIndex)) 
+        return;
     deckModel->removeRow(currentIndex.row(), currentIndex.parent());
 
-	// Disable saving if the deck is empty
-	DeckLoader *const deck = deckModel->getDeckList();
-	QString decklistUrlString;
-	if (deck) {
-		decklistUrlString = deck->exportDeckToDecklist();
-		if (QString::compare(decklistUrlString, "", Qt::CaseInsensitive) == 0) {
-			aSaveDeck->setEnabled(false);
-			aSaveDeckAs->setEnabled(false);
-		}
-	}
+    // Disable saving if the deck is empty
+    DeckLoader *const deck = deckModel->getDeckList();
+    QString decklistUrlString;
+    if (deck) {
+        decklistUrlString = deck->exportDeckToDecklist();
+        if (QString::compare(decklistUrlString, "", Qt::CaseInsensitive) == 0) {
+            aSaveDeck->setEnabled(false);
+            aSaveDeckAs->setEnabled(false);
+        }
+    }
     setModified(true);
 }
 

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -997,11 +997,7 @@ void TabDeckEditor::actRemoveCard()
     deckModel->removeRow(currentIndex.row(), currentIndex.parent());
 
     DeckLoader *const deck = deckModel->getDeckList();
-    if (deck->isEmpty()) {
-        setSaveStatus(false);
-    } else {
-        setSaveStatus(true);
-    }
+    setSaveStatus(!deck->isEmpty());
     setModified(true);
 }
 

--- a/cockatrice/src/tab_deck_editor.h
+++ b/cockatrice/src/tab_deck_editor.h
@@ -95,6 +95,7 @@ private slots:
     void dockFloatingTriggered();
     void dockTopLevelChanged(bool topLevel);
     void saveDbHeaderState();
+    void setSaveStatus(bool newStatus);
 
 private:
     CardInfoPtr currentCardInfo() const;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3381 

## Short roundup of the initial problem
Unable to use/create a shortcut for moving a card from the top of the library to the play area faced down

## What will change with this Pull Request?
- enabled using and setting a shortcut to do the aforementioned action
- set a default shortcut for the aforementioned action

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![image](https://user-images.githubusercontent.com/41343559/45114975-200d3980-b114-11e8-8561-b73a494e22b6.png)

![image](https://user-images.githubusercontent.com/41343559/45115022-4337e900-b114-11e8-88ad-3ab3f29e22c7.png)
