### PR TITLE
Enable using a shortcut for playing the top card of the library face down (fixed)

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -801,6 +801,7 @@ void Player::setShortcutsActive()
     aCreateToken->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aCreateToken"));
     aCreateAnotherToken->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aCreateAnotherToken"));
     aAlwaysRevealTopCard->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aAlwaysRevealTopCard"));
+    aMoveTopToPlayFaceDown->setShortcut(settingsCache->shortcuts().getSingleShortcut("Player/aMoveTopToPlayFaceDown"));
 }
 
 void Player::setShortcutsInactive()

--- a/cockatrice/src/sequenceEdit/ui_shortcutstab.h
+++ b/cockatrice/src/sequenceEdit/ui_shortcutstab.h
@@ -289,6 +289,8 @@ public:
     SequenceEdit *Player_aMoveToExile;
     QLabel *lbl_Player_aMoveToHand;
     SequenceEdit *Player_aMoveToHand;
+    QLabel *lbl_Player_aMoveTopToPlayFaceDown;
+    SequenceEdit *Player_aMoveTopToPlayFaceDown;
     QGroupBox *groupBox_16;
     QGridLayout *gridLayout_16;
     QLabel *lbl_Player_aViewGraveyard;
@@ -1446,6 +1448,18 @@ public:
 
         gridLayout_15->addWidget(Player_aMoveToHand, 4, 1, 1, 1);
 
+        lbl_Player_aMoveTopToPlayFaceDown = new QLabel(groupBox_15);
+        lbl_Player_aMoveTopToPlayFaceDown->setObjectName("lbl_Player_aMoveTopToPlayFaceDown");
+
+        gridLayout_15->addWidget(lbl_Player_aMoveTopToPlayFaceDown, 5, 0, 1, 1);
+
+        Player_aMoveTopToPlayFaceDown = new SequenceEdit("Player/aMoveTopToPlayFaceDown", groupBox_15);
+        Player_aMoveTopToPlayFaceDown->setObjectName("Player_aMoveTopToPlayFaceDown");
+
+        gridLayout_15->addWidget(Player_aMoveTopToPlayFaceDown, 5, 1, 1, 1);
+
+
+
         gridLayout_20->addWidget(groupBox_15, 0, 1, 1, 1);
 
         groupBox_16 = new QGroupBox(tab_3);
@@ -1874,6 +1888,7 @@ public:
         lbl_Player_aMoveToGraveyard->setText(QApplication::translate("shortcutsTab", "Graveyard", 0));
         lbl_Player_aMoveToExile->setText(QApplication::translate("shortcutsTab", "Exile", 0));
         lbl_Player_aMoveToHand->setText(QApplication::translate("shortcutsTab", "Hand", 0));
+        lbl_Player_aMoveTopToPlayFaceDown->setText(QApplication::translate("shortcutsTab", "Play face down"));
         groupBox_16->setTitle(QApplication::translate("shortcutsTab", "View", 0));
         lbl_Player_aViewGraveyard->setText(QApplication::translate("shortcutsTab", "Graveyard", 0));
         lbl_Player_aViewLibrary->setText(QApplication::translate("shortcutsTab", "Library", 0));

--- a/cockatrice/src/shortcutssettings.cpp
+++ b/cockatrice/src/shortcutssettings.cpp
@@ -325,4 +325,5 @@ void ShortcutsSettings::fillDefaultShorcuts()
     defaultShortCuts["tab_room/aClearChat"] = parseSequenceString("F12");
     defaultShortCuts["DlgLoadDeckFromClipboard/refreshButton"] = parseSequenceString("F5");
     defaultShortCuts["Player/aResetLayout"] = parseSequenceString("");
+    defaultShortCuts["Player/aMoveTopToPlayFaceDown"] = parseSequenceString("Ctrl+Shift+E");
 }


### PR DESCRIPTION
This pull request was made because the one I made before was branched off of the wrong branch

## Related Ticket(s)
- Fixes #3381 

## Short roundup of the initial problem
Unable to use/create a shortcut for moving a card from the top of the library to the play area faced down


## What will change with this Pull Request?
- enabled using and setting a shortcut to do the aforementioned action
- set a default shortcut for the aforementioned action

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![image](https://user-images.githubusercontent.com/41343559/45116374-1a195780-b118-11e8-9074-4f41a0a6b3c7.png)
![image](https://user-images.githubusercontent.com/41343559/45116379-1d144800-b118-11e8-92c4-be99056025a9.png)
