### PR TITLE
Translate curly apostrophe to ASCII apostrophe (#3395)

### DIFF
--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -3,7 +3,6 @@
 
 #define CARDDBMODEL_COLUMNS 6
 
-
 CardDatabaseModel::CardDatabaseModel(CardDatabase *_db, bool _showOnlyCardsFromEnabledSets, QObject *parent)
     : QAbstractListModel(parent), db(_db), showOnlyCardsFromEnabledSets(_showOnlyCardsFromEnabledSets)
 {
@@ -20,13 +19,7 @@ CardDatabaseModel::~CardDatabaseModel()
 
 // The implementation is done in strings rather than characters is because the curly apostrophes and quotes
 // are considered multi-characters.
-QStringMap CardDatabaseDisplayModel::characterTranslation =
-{
-    { "“", "\"" },
-    { "”", "\"" },
-    { "‘", "\'"},
-    { "’", "\'"}
-};
+QStringMap CardDatabaseDisplayModel::characterTranslation = {{"“", "\""}, {"”", "\""}, {"‘", "\'"}, {"’", "\'"}};
 
 int CardDatabaseModel::rowCount(const QModelIndex & /*parent*/) const
 {
@@ -338,8 +331,7 @@ void CardDatabaseDisplayModel::filterTreeChanged()
 const QString CardDatabaseDisplayModel::sanitizeCardName(const QString &dirtyName, const QStringMap &table)
 {
     QString toReturn(dirtyName);
-    for (QStringMap::const_iterator item = table.constBegin(); item != table.constEnd(); ++item)
-    {
+    for (QStringMap::const_iterator item = table.constBegin(); item != table.constEnd(); ++item) {
         toReturn.replace(item.key(), item.value());
     }
     return toReturn;

--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -18,10 +18,10 @@ CardDatabaseModel::~CardDatabaseModel()
 {
 }
 
-QMap<wchar_t, wchar_t> CardDatabaseDisplayModel::wideCharacterTranslation = {{u'“', u'\"'},
-                                                                             {u'”', u'\"'},
-                                                                             {u'‘', u'\''},
-                                                                             {u'’', u'\''}};
+QMap<wchar_t, wchar_t> CardDatabaseDisplayModel::characterTranslation = {{u'“', u'\"'},
+                                                                         {u'”', u'\"'},
+                                                                         {u'‘', u'\''},
+                                                                         {u'’', u'\''}};
 
 int CardDatabaseModel::rowCount(const QModelIndex & /*parent*/) const
 {
@@ -330,8 +330,7 @@ void CardDatabaseDisplayModel::filterTreeChanged()
     invalidate();
 }
 
-const QString CardDatabaseDisplayModel::charSanitizeCardName(const QString &dirtyName,
-                                                             const QMap<wchar_t, wchar_t> &table)
+const QString CardDatabaseDisplayModel::sanitizeCardName(const QString &dirtyName, const QMap<wchar_t, wchar_t> &table)
 {
     std::wstring toReturn = dirtyName.toStdWString();
     for (wchar_t &ch : toReturn) {

--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -3,6 +3,7 @@
 
 #define CARDDBMODEL_COLUMNS 6
 
+
 CardDatabaseModel::CardDatabaseModel(CardDatabase *_db, bool _showOnlyCardsFromEnabledSets, QObject *parent)
     : QAbstractListModel(parent), db(_db), showOnlyCardsFromEnabledSets(_showOnlyCardsFromEnabledSets)
 {
@@ -16,6 +17,16 @@ CardDatabaseModel::CardDatabaseModel(CardDatabase *_db, bool _showOnlyCardsFromE
 CardDatabaseModel::~CardDatabaseModel()
 {
 }
+
+// The implementation is done in strings rather than characters is because the curly apostrophes and quotes
+// are considered multi-characters.
+QStringMap CardDatabaseDisplayModel::characterTranslation =
+{
+    { "“", "\"" },
+    { "”", "\"" },
+    { "‘", "\'"},
+    { "’", "\'"}
+};
 
 int CardDatabaseModel::rowCount(const QModelIndex & /*parent*/) const
 {
@@ -322,6 +333,16 @@ void CardDatabaseDisplayModel::setFilterTree(FilterTree *filterTree)
 void CardDatabaseDisplayModel::filterTreeChanged()
 {
     invalidate();
+}
+
+const QString CardDatabaseDisplayModel::sanitizeCardName(const QString &dirtyName, const QStringMap &table)
+{
+    QString toReturn(dirtyName);
+    for (QStringMap::const_iterator item = table.constBegin(); item != table.constEnd(); ++item)
+    {
+        toReturn.replace(item.key(), item.value());
+    }
+    return toReturn;
 }
 
 TokenDisplayModel::TokenDisplayModel(QObject *parent) : CardDatabaseDisplayModel(parent)

--- a/cockatrice/src/carddatabasemodel.cpp
+++ b/cockatrice/src/carddatabasemodel.cpp
@@ -18,10 +18,10 @@ CardDatabaseModel::~CardDatabaseModel()
 {
 }
 
-QMap<wchar_t, wchar_t> CardDatabaseDisplayModel::characterTranslation = {{u'“', u'\"'},
-                                                                         {u'”', u'\"'},
-                                                                         {u'‘', u'\''},
-                                                                         {u'’', u'\''}};
+QMap<wchar_t, wchar_t> CardDatabaseDisplayModel::characterTranslation = {{L'“', L'\"'},
+                                                                         {L'”', L'\"'},
+                                                                         {L'‘', L'\''},
+                                                                         {L'’', L'\''}};
 
 int CardDatabaseModel::rowCount(const QModelIndex & /*parent*/) const
 {

--- a/cockatrice/src/carddatabasemodel.h
+++ b/cockatrice/src/carddatabasemodel.h
@@ -73,6 +73,9 @@ private:
     FilterTree *filterTree;
     int loadedRowCount;
 
+    /** The translation table that will be used for sanitizeCardName. */
+    static QStringMap characterTranslation;
+
 public:
     CardDatabaseDisplayModel(QObject *parent = 0);
     void setFilterTree(FilterTree *filterTree);
@@ -88,7 +91,7 @@ public:
     }
     void setCardName(const QString &_cardName)
     {
-        cardName = _cardName;
+        cardName = sanitizeCardName(_cardName, characterTranslation);
         invalidate();
     }
     void setCardNameSet(const QSet<QString> &_cardNameSet)
@@ -127,6 +130,8 @@ protected:
     void fetchMore(const QModelIndex &parent);
 private slots:
     void filterTreeChanged();
+    /** Will translate all undesirable characters in DIRTYNAME according to the TABLE. */
+    const QString sanitizeCardName(const QString &dirtyName, const QStringMap &table);
 };
 
 class TokenDisplayModel : public CardDatabaseDisplayModel

--- a/cockatrice/src/carddatabasemodel.h
+++ b/cockatrice/src/carddatabasemodel.h
@@ -74,7 +74,7 @@ private:
     int loadedRowCount;
 
     /** The translation table that will be used for sanitizeCardName. */
-    static QStringMap characterTranslation;
+    static QMap<wchar_t, wchar_t> wideCharacterTranslation;
 
 public:
     CardDatabaseDisplayModel(QObject *parent = 0);
@@ -91,7 +91,7 @@ public:
     }
     void setCardName(const QString &_cardName)
     {
-        cardName = sanitizeCardName(_cardName, characterTranslation);
+        cardName = charSanitizeCardName(_cardName, wideCharacterTranslation);
         invalidate();
     }
     void setCardNameSet(const QSet<QString> &_cardNameSet)
@@ -131,7 +131,7 @@ protected:
 private slots:
     void filterTreeChanged();
     /** Will translate all undesirable characters in DIRTYNAME according to the TABLE. */
-    const QString sanitizeCardName(const QString &dirtyName, const QStringMap &table);
+    const QString charSanitizeCardName(const QString &dirtyName, const QMap<wchar_t, wchar_t> &table);
 };
 
 class TokenDisplayModel : public CardDatabaseDisplayModel

--- a/cockatrice/src/carddatabasemodel.h
+++ b/cockatrice/src/carddatabasemodel.h
@@ -74,7 +74,7 @@ private:
     int loadedRowCount;
 
     /** The translation table that will be used for sanitizeCardName. */
-    static QMap<wchar_t, wchar_t> wideCharacterTranslation;
+    static QMap<wchar_t, wchar_t> characterTranslation;
 
 public:
     CardDatabaseDisplayModel(QObject *parent = 0);
@@ -91,7 +91,7 @@ public:
     }
     void setCardName(const QString &_cardName)
     {
-        cardName = charSanitizeCardName(_cardName, wideCharacterTranslation);
+        cardName = sanitizeCardName(_cardName, characterTranslation);
         invalidate();
     }
     void setCardNameSet(const QSet<QString> &_cardNameSet)
@@ -131,7 +131,7 @@ protected:
 private slots:
     void filterTreeChanged();
     /** Will translate all undesirable characters in DIRTYNAME according to the TABLE. */
-    const QString charSanitizeCardName(const QString &dirtyName, const QMap<wchar_t, wchar_t> &table);
+    const QString sanitizeCardName(const QString &dirtyName, const QMap<wchar_t, wchar_t> &table);
 };
 
 class TokenDisplayModel : public CardDatabaseDisplayModel

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -700,9 +700,7 @@ void TabDeckEditor::updateCardInfoRight(const QModelIndex &current, const QModel
 
 void TabDeckEditor::updateSearch(const QString &search)
 {
-    QString sanitizedInput = QString(search);
-    sanitizedInput.replace("’", "'");
-    databaseDisplayModel->setCardName(sanitizedInput);
+    databaseDisplayModel->setCardName(search);
     QModelIndexList sel = databaseView->selectionModel()->selectedRows();
     if (sel.isEmpty() && databaseDisplayModel->rowCount())
         databaseView->selectionModel()->setCurrentIndex(databaseDisplayModel->index(0, 0),

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -700,7 +700,9 @@ void TabDeckEditor::updateCardInfoRight(const QModelIndex &current, const QModel
 
 void TabDeckEditor::updateSearch(const QString &search)
 {
-    databaseDisplayModel->setCardName(search);
+    QString sanitizedInput = QString(search);
+    sanitizedInput.replace("’", "'");
+    databaseDisplayModel->setCardName(sanitizedInput);
     QModelIndexList sel = databaseView->selectionModel()->selectedRows();
     if (sel.isEmpty() && databaseDisplayModel->rowCount())
         databaseView->selectionModel()->setCurrentIndex(databaseDisplayModel->index(0, 0),


### PR DESCRIPTION
Treats the curly apostrophe as a straight apostrophe when searching in
the deck editor search bar.

## Related Ticket(s)
- Fixes #3395 

## Short roundup of the initial problem
When users would paste card text into the deck editor search bar, curly apostrophes would not be interpreted as straight ASCII apostrophes.

## What will change with this Pull Request?
- Curly apostrophes will now be interpreted as ASCII apostrophes in the deck editor search bar.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
