### PR TITLE
Fix blank line between comments issue

### DIFF
--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -542,10 +542,11 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
         }
 
         // If we have a blank line and it's the _ONLY_ blank line in the paste
+        // and it follows at least one valid card
         // Then we assume it means to start the sideboard section of the paste.
         // If we have the word "Sideboard" appear on any line, then that will
         // also indicate the start of the sideboard.
-        if ((line.isEmpty() && blankLines == 1) || line.startsWith("sideboard")) {
+        if ((line.isEmpty() && blankLines == 1 && okRows > 0) || line.startsWith("sideboard")) {
             inSideboard = true;
             continue; // The line isn't actually a card
         }

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -228,6 +228,21 @@ TEST(LoadingFromClipboardTest, LotsOfStuffInBulkTesting)
     ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
     ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
 }
+
+TEST(LoadingFromClipboardTest, CommentsBeforeCardsTesting)
+{
+    QString *clipboard = new QString("//NAME: Title from Website.com\n"
+                                     "\n"
+                                     "//Main\n"
+                                     "1 test1\n");
+    DeckList *decklist = fromClipboard(clipboard);
+    DecklistBuilder decklistBuilder = DecklistBuilder();
+    decklist->forEachCard(decklistBuilder);
+    CardRows expectedMainboard = CardRows({{"test1", 1}});
+    CardRows expectedSideboard = CardRows({});
+    ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
+    ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
+}
 } // namespace
 
 int main(int argc, char **argv)


### PR DESCRIPTION
## Related Ticket(s)
NA

## Short roundup of the initial problem
If there existed a blank line in between comments before the first card, all cards were interpreted as sideboard. (This is the way deckstats.net exports cards decks with no sideboard).

## What will change with this Pull Request?
- Sideboard will only begin after one mainline card and a blank space
- Test case added to prevent regression
