### PR TITLE
Build ubuntu 18.04 package using appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,18 +90,7 @@ install:
         }
     # Linux
     - sh: sudo apt-get update
-    - sh: sudo apt-get install -y \
-        cmake \
-        libprotobuf-dev \
-        protobuf-compiler \
-        qt5-default \
-        qttools5-dev \
-        qttools5-dev-tools \
-        qtmultimedia5-dev \
-        libqt5multimedia5-plugins \
-        libqt5svg5-dev \
-        libqt5sql5-mysql \
-        libqt5websockets5-dev
+    - sh: sudo apt-get install -y cmake libprotobuf-dev protobuf-compiler qt5-default qttools5-dev qttools5-dev-tools qtmultimedia5-dev libqt5multimedia5-plugins libqt5svg5-dev libqt5sql5-mysql libqt5websockets5-dev
 
 services:
     - mysql

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -111,17 +111,18 @@ build_script:
     - ps: |
         $exe = dir -name *.exe
         $new_name = $exe.Replace(".exe", "-${env:target_arch}.exe")
-        Push-AppveyorArtifact $exe -FileName $new_name
-        $cmake_name = $exe.Replace(".exe", "-${env:target_arch}.cmake.txt")
-        Push-AppveyorArtifact CMakeCache.txt -FileName $cmake_name
-        $json = New-Object PSObject
-        (New-Object PSObject | Add-Member -PassThru NoteProperty bin $new_name | Add-Member -PassThru NoteProperty cmake $cmake_name | Add-Member -PassThru NoteProperty commit $env:APPVEYOR_REPO_COMMIT) | ConvertTo-JSON | Out-File -FilePath "latest-$env:target_arch" -Encoding ASCII
-        Push-AppveyorArtifact "latest-$env:target_arch"
-        $version = $matches['content']
+        Rename-Item -Path "$exe" -NewName "$new_name"
     # Linux
     - sh: mkdir -p build && cd build
     - sh: cmake .. -DWITH_SERVER=1 -DCMAKE_BUILD_TYPE=$buildtype
     - sh: make package -j2
+
+artifacts:
+  - path: '*.exe'
+    name: Cockatrice-win
+
+  - path: '*.deb'
+    name: Cockatrice-ubuntu1804
 
 test: off
 
@@ -135,7 +136,7 @@ deploy:
     tag: "$(APPVEYOR_REPO_TAG_NAME)"
     release: "Cockatrice $(APPVEYOR_REPO_TAG_NAME)"
     description: "Beta release of Cockatrice"
-    artifact: /.*\.exe/
+    artifact: /.*\.(exe|deb)/
     force_update: true
     draft: false
     prerelease: true
@@ -149,7 +150,7 @@ deploy:
        secure: p+7wPVry2XEa6TBm9XH8IaQZbBmXQ/J2ldbGmcIxUZD3NkkPrSRRlmE7Of1CBBIO
     tag: "$(APPVEYOR_REPO_TAG_NAME)"
     release: "Cockatrice $(APPVEYOR_REPO_TAG_NAME)"
-    artifact: /.*\.exe/
+    artifact: /.*\.(exe|deb)/
     force_update: true
     draft: false
     prerelease: false

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ cache:
 environment:
     APPVEYOR_YML_DISABLE_PS_LINUX: true
     openssl_ver: 1.0.2p
-    protobuf_ver: 3.6.0
+    protobuf_ver: 3.6.1
     zlib_ver: 1.2.11
 
     matrix:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,9 @@ skip_branch_with_pr: true
 
 clone_depth: 50    #same as travis, see https://www.appveyor.com/blog/2014/06/04/shallow-clone-for-git-repositories/
 
-image: Visual Studio 2017
+image:
+    - Visual Studio 2017
+    - Ubuntu1804
 
 cache:
     - c:\openssl-release
@@ -33,25 +35,31 @@ cache:
 
 
 environment:
+    APPVEYOR_YML_DISABLE_PS_LINUX: true
     openssl_ver: 1.0.2o
     protobuf_ver: 3.6.0
     zlib_ver: 1.2.11
 
     matrix:
-        - target_arch: win64
+        # Windows
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          target_arch: win64
           qt_ver: 5.9\msvc2017_64
           cmake_generator: Visual Studio 15 2017 Win64
           cmake_toolset: v141,host=x64
           vc_arch: amd64
-
-        - target_arch: win32
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          target_arch: win32
           qt_ver: 5.9\msvc2015 # Qt doesn't provide a msvc2017_32
           cmake_generator: Visual Studio 15 2017
           cmake_toolset: v141
           vc_arch: amd64_x86
-
+        # Linux
+        - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1804
+          buildtype: Release
 
 install:
+    # Windows
     - ps: |
         if (Test-Path c:\openssl-release) {
             echo "using openssl from cache"
@@ -84,11 +92,26 @@ install:
             cmake . -G "$env:cmake_generator" -T "$env:cmake_toolset" -DCMAKE_INSTALL_PREFIX=c:/zlib-release
             msbuild INSTALL.vcxproj /p:Configuration=Release
         }
+    # Linux
+    - sh: sudo apt-get update
+    - sh: sudo apt-get install -y \
+        cmake \
+        libprotobuf-dev \
+        protobuf-compiler \
+        qt5-default \
+        qttools5-dev \
+        qttools5-dev-tools \
+        qtmultimedia5-dev \
+        libqt5multimedia5-plugins \
+        libqt5svg5-dev \
+        libqt5sql5-mysql \
+        libqt5websockets5-dev
 
 services:
     - mysql
 
 build_script:
+    # Windows
     - ps: |
         New-Item -ItemType directory -Path $env:APPVEYOR_BUILD_FOLDER\build
         Set-Location -Path $env:APPVEYOR_BUILD_FOLDER\build
@@ -99,7 +122,7 @@ build_script:
         $mysqldll = "c:\Program Files\MySQL\MySQL Server 5.7\lib\libmysql.dll"
         cmake --version
         cmake .. -G "$env:cmake_generator" -T "$env:cmake_toolset" "-DCMAKE_PREFIX_PATH=c:/Qt/$env:qt_ver;$protodir;$zlibdir;$openssldir" "-DWITH_SERVER=1" "-DPROTOBUF_PROTOC_EXECUTABLE=$protoc" "-DMYSQLCLIENT_LIBRARIES=$mysqldll"
-    - msbuild PACKAGE.vcxproj /p:Configuration=Release
+    - cmd: msbuild PACKAGE.vcxproj /p:Configuration=Release
     - ps: |
         $exe = dir -name *.exe
         $new_name = $exe.Replace(".exe", "-${env:target_arch}.exe")
@@ -110,7 +133,11 @@ build_script:
         (New-Object PSObject | Add-Member -PassThru NoteProperty bin $new_name | Add-Member -PassThru NoteProperty cmake $cmake_name | Add-Member -PassThru NoteProperty commit $env:APPVEYOR_REPO_COMMIT) | ConvertTo-JSON | Out-File -FilePath "latest-$env:target_arch" -Encoding ASCII
         Push-AppveyorArtifact "latest-$env:target_arch"
         $version = $matches['content']
-        
+    # Linux
+    - sh: mkdir -p build && cd build
+    - sh: cmake .. -DWITH_SERVER=1 -DCMAKE_BUILD_TYPE=$buildtype
+    - sh: make package -j2
+
 test: off
 
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -118,10 +118,10 @@ build_script:
     - sh: make package -j2
 
 artifacts:
-  - path: '*.exe'
+  - path: '**/*.exe'
     name: Cockatrice-win
 
-  - path: '*.deb'
+  - path: '**/*.deb'
     name: Cockatrice-ubuntu1804
 
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,10 +21,6 @@ skip_branch_with_pr: true
 
 clone_depth: 50    #same as travis, see https://www.appveyor.com/blog/2014/06/04/shallow-clone-for-git-repositories/
 
-image:
-    - Visual Studio 2017
-    - Ubuntu1804
-
 cache:
     - c:\openssl-release
     - c:\protobuf-release

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -118,10 +118,10 @@ build_script:
     - sh: make package -j2
 
 artifacts:
-  - path: '**/*.exe'
+  - path: 'build/Cockatrice*.exe'
     name: Cockatrice-win
 
-  - path: '**/*.deb'
+  - path: 'build/Cockatrice*.deb'
     name: Cockatrice-ubuntu1804
 
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,7 @@ cache:
 
 environment:
     APPVEYOR_YML_DISABLE_PS_LINUX: true
-    openssl_ver: 1.0.2o
+    openssl_ver: 1.0.2p
     protobuf_ver: 3.6.0
     zlib_ver: 1.2.11
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3294

## What will change with this Pull Request?
- Appveyor compiles a "release" package for ubuntu 18.04;
- ~~some currently broken dependency packages have been updated to working versions (openssl, protobuf)~~ --> See https://github.com/Cockatrice/Cockatrice/pull/3420

EDIT
Notes:
 - ~~win32 is still broken; Qt 5.9.7 has been released 2 days ago, hopefully Appveyor will pick up the update soon~~ --> See https://www.appveyor.com/updates/2018/11/09/
 - the "deploy" part of the script can be been tested only inside Cockatrice's master branch.