### PR TITLE
appveyor: fix dependencies

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,8 +33,8 @@ cache:
 
 
 environment:
-    openssl_ver: 1.0.2o
-    protobuf_ver: 3.6.0
+    openssl_ver: 1.0.2p
+    protobuf_ver: 3.6.1
     zlib_ver: 1.2.11
 
     matrix:


### PR DESCRIPTION
## Related Ticket(s)
- Related https://github.com/Cockatrice/Cockatrice/pull/3415

## Short roundup of the initial problem
Appveyor dependencies were outdated and builds didn't work correctly anymore as realized in other builds like [here](https://ci.appveyor.com/project/Daenyth/cockatrice-8k7y5/builds/19860108/job/gd9ocjy0dt14x3e8?fullLog=true#L38).

I extracted this general build fix from another PR by @ctrlaltca to get it in more quickly.
See https://github.com/Cockatrice/Cockatrice/pull/3415/commits/83a499ba065b8d24d60b838e6b8c3e7a6394feaf and https://github.com/Cockatrice/Cockatrice/pull/3415/commits/147caa2b6b812ac18568f800ae44c13bc3e9cfe6

## What will change with this Pull Request?
- update cmake and protobuf dependencies to working versions