### PR TITLE
Load plain improvements

### DIFF
--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -487,7 +487,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
     // simplified matches
     const QRegularExpression reMultiplier("^[xX\\(\\[]*(\\d+)[xX\\*\\)\\]]* ?(.+)");
     const QRegularExpression reBrace(" ?[\\[\\{][^\\]\\}]*[\\]\\}] ?"); // not nested
-    const QRegularExpression reRoundBrace("^\\([^\\)]*\\) ?"); // () are only matched at start of string
+    const QRegularExpression reRoundBrace("^\\([^\\)]*\\) ?");          // () are only matched at start of string
     const QRegularExpression reApostrophe("’");
     const QString apostrophe("'");
     const QRegularExpression reAE("Æ");
@@ -540,7 +540,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
             comments += match.captured() + '\n';
         }
     }
-    comments.chop(1); //remove last newline
+    comments.chop(1); // remove last newline
 
     // parse decklist
     for (; index < inputs.size(); ++index) {

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -489,11 +489,21 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
     const QRegularExpression reBrace(" ?[\\[\\{][^\\]\\}]*[\\]\\}] ?"); // not nested
     const QRegularExpression reRoundBrace("^\\([^\\)]*\\) ?");          // () are only matched at start of string
     const QRegularExpression reDigitBrace(" ?\\(\\d*\\) ?");            // () are matched if containing digits
+#if QT_VERSION < 0x050600
+    // this is outdated, current QT versions support initializer lists
+    QHash<QRegularExpression, QString> differences;
+    differences[QRegularExpression("’")] = QString("'");
+    differences[QRegularExpression("Æ")] = QString("Ae");
+    differences[QRegularExpression("æ")] = QString("ae");
+    differences[QRegularExpression(" ?[|/]+ ?")] = QString(" // ");
+    differences[QRegularExpression("(?<![A-Z]) ?& ?")] = QString(" // ");
+#else
     const QHash<QRegularExpression, QString> differences{{QRegularExpression("’"), QString("'")},
                                                          {QRegularExpression("Æ"), QString("Ae")},
                                                          {QRegularExpression("æ"), QString("ae")},
                                                          {QRegularExpression(" ?[|/]+ ?"), QString(" // ")},
                                                          {QRegularExpression("(?<![A-Z]) ?& ?"), QString(" // ")}};
+#endif
 
     cleanList();
 

--- a/tests/loading_from_clipboard/CMakeLists.txt
+++ b/tests/loading_from_clipboard/CMakeLists.txt
@@ -1,6 +1,7 @@
 ADD_DEFINITIONS("-DCARDDB_DATADIR=\"${CMAKE_CURRENT_SOURCE_DIR}/data/\"")
 add_executable(loading_from_clipboard_test
         loading_from_clipboard_test.cpp
+        clipboard_testing.cpp
         ../../common/decklist.cpp
         )
 

--- a/tests/loading_from_clipboard/clipboard_testing.cpp
+++ b/tests/loading_from_clipboard/clipboard_testing.cpp
@@ -1,0 +1,40 @@
+#include "clipboard_testing.h"
+#include <QTextStream>
+
+void Result::operator()(const InnerDecklistNode *innerDecklistNode, const DecklistCardNode *card)
+{
+    if (innerDecklistNode->getName() == DECK_ZONE_MAIN) {
+        mainboard.append({card->getName().toStdString(), card->getNumber()});
+    } else if (innerDecklistNode->getName() == DECK_ZONE_SIDE) {
+        sideboard.append({card->getName().toStdString(), card->getNumber()});
+    } else {
+        FAIL();
+    }
+}
+
+void testEmpty(const QString &clipboard)
+{
+    QString cp(clipboard);
+    DeckList deckList;
+    QTextStream stream(&cp); // text stream requires local copy
+    deckList.loadFromStream_Plain(stream);
+
+    ASSERT_TRUE(deckList.getCardList().isEmpty());
+}
+
+void testDeck(const QString &clipboard, const Result &result)
+{
+    QString cp(clipboard);
+    DeckList deckList;
+    QTextStream stream(&cp); // text stream requires local copy
+    deckList.loadFromStream_Plain(stream);
+
+    ASSERT_EQ(result.name, deckList.getName().toStdString());
+    ASSERT_EQ(result.comments, deckList.getComments().toStdString());
+
+    Result decklistBuilder;
+    deckList.forEachCard(decklistBuilder);
+
+    ASSERT_EQ(result.mainboard, decklistBuilder.mainboard);
+    ASSERT_EQ(result.sideboard, decklistBuilder.sideboard);
+}

--- a/tests/loading_from_clipboard/clipboard_testing.h
+++ b/tests/loading_from_clipboard/clipboard_testing.h
@@ -1,0 +1,27 @@
+#include "../../common/decklist.h"
+#include "gtest/gtest.h"
+
+struct Result
+{
+    // using std types because qt types aren't understood by gtest (without this you'll get less nice errors)
+    using CardRows = QVector<std::pair<std::string, int>>;
+    std::string name;
+    std::string comments;
+    CardRows mainboard;
+    CardRows sideboard;
+
+    Result()
+    {
+    }
+
+    Result(std::string _name, std::string _comments, CardRows _mainboard, CardRows _sideboard)
+        : name(_name), comments(_comments), mainboard(_mainboard), sideboard(_sideboard)
+    {
+    }
+
+    void operator()(const InnerDecklistNode *innerDecklistNode, const DecklistCardNode *card);
+};
+
+void testEmpty(const QString &clipboard);
+
+void testDeck(const QString &clipboard, const Result &result);

--- a/tests/loading_from_clipboard/clipboard_testing.h
+++ b/tests/loading_from_clipboard/clipboard_testing.h
@@ -1,3 +1,6 @@
+#ifndef CLIPBOARD_TESTING_H
+#define CLIPBOARD_TESTING_H
+
 #include "../../common/decklist.h"
 #include "gtest/gtest.h"
 
@@ -25,3 +28,5 @@ struct Result
 void testEmpty(const QString &clipboard);
 
 void testDeck(const QString &clipboard, const Result &result);
+
+#endif // CLIPBOARD_TESTING_H

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -253,7 +253,7 @@ TEST(LoadingFromClipboardTest, CommentsBeforeCardsTesting)
     deckList.loadFromStream_Plain(stream);
 
     ASSERT_EQ(deckList.getName().toStdString(), "title from website.com");
-    ASSERT_EQ(deckList.getComments().toStdString(), "a nice deck\nwith nice cards\n");
+    // ASSERT_EQ(deckList.getComments().toStdString(), "a nice deck\nwith nice cards"); // bugged
 
     DecklistBuilder decklistBuilder = DecklistBuilder();
     deckList.forEachCard(decklistBuilder);

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -1,83 +1,8 @@
-#include "../../common/decklist.h"
-#include "gtest/gtest.h"
-#include <QTextStream>
+#include "clipboard_testing.h"
 
-// using std types because qt types aren't understood by gtest (without this you'll get less nice errors)
-using CardRows = QList<std::pair<std::string, int>>;
+// Testing is done by using the DeckList::loadFromString_Plain function in common/decklist.h
+// It does not check if cards are in the database at all, so no comparisons to the database will be made.
 
-struct DecklistBuilder
-{
-    CardRows actualMainboard;
-    CardRows actualSideboard;
-
-    explicit DecklistBuilder() : actualMainboard({}), actualSideboard({})
-    {
-    }
-
-    void operator()(const InnerDecklistNode *innerDecklistNode, const DecklistCardNode *card)
-    {
-        if (innerDecklistNode->getName() == DECK_ZONE_MAIN) {
-            actualMainboard += {card->getName().toStdString(), card->getNumber()};
-        } else if (innerDecklistNode->getName() == DECK_ZONE_SIDE) {
-            actualSideboard += {card->getName().toStdString(), card->getNumber()};
-        } else {
-            FAIL();
-        }
-    }
-
-    CardRows mainboard()
-    {
-        return actualMainboard;
-    }
-
-    CardRows sideboard()
-    {
-        return actualSideboard;
-    }
-};
-
-struct Result
-{
-    std::string name;
-    std::string comments;
-    CardRows mainboard;
-    CardRows sideboard;
-
-    Result(std::string _name, std::string _comments, CardRows _mainboard, CardRows _sideboard)
-        : name(_name), comments(_comments), mainboard(_mainboard), sideboard(_sideboard)
-    {
-    }
-};
-
-void testEmpty(const QString &clipboard)
-{
-    QString cp(clipboard);
-    DeckList deckList;
-    QTextStream stream(&cp); // text stream requires local copy
-    deckList.loadFromStream_Plain(stream);
-
-    ASSERT_TRUE(deckList.getCardList().isEmpty());
-}
-
-void testDeck(const QString &clipboard, const Result &result)
-{
-    QString cp(clipboard);
-    DeckList deckList;
-    QTextStream stream(&cp); // text stream requires local copy
-    deckList.loadFromStream_Plain(stream);
-
-    ASSERT_EQ(result.name, deckList.getName().toStdString());
-    ASSERT_EQ(result.comments, deckList.getComments().toStdString());
-
-    DecklistBuilder decklistBuilder = DecklistBuilder();
-    deckList.forEachCard(decklistBuilder);
-
-    ASSERT_EQ(result.mainboard, decklistBuilder.mainboard());
-    ASSERT_EQ(result.sideboard, decklistBuilder.sideboard());
-}
-
-namespace
-{
 TEST(LoadingFromClipboardTest, EmptyDeck)
 {
     testEmpty("");
@@ -92,8 +17,8 @@ TEST(LoadingFromClipboardTest, QuantityPrefixed)
 {
     QString clipboard("1 Mountain\n"
                       "2x Island\n"
-                      "3X FOREST\n");
-    Result result("", "", {{"mountain", 1}, {"island", 2}, {"forest", 3}}, {});
+                      "3x Forest\n");
+    Result result("", "", {{"Mountain", 1}, {"Island", 2}, {"Forest", 3}}, {});
     testDeck(clipboard, result);
 }
 
@@ -109,11 +34,11 @@ TEST(LoadingFromClipboardTest, SideboardPrefix)
 {
     QString clipboard("1 Mountain\n"
                       "SB: 1 Mountain\n"
-                      "SB: 2x Island\n"
+                      "sb: 2x Island\n"
                       "2 Swamp\n"
                       "\n"
-                      "3 plains\n");
-    Result result("", "", {{"mountain", 1}, {"swamp", 2}, {"plains", 3}}, {{"mountain", 1}, {"island", 2}});
+                      "3 Plains\n");
+    Result result("", "", {{"Mountain", 1}, {"Swamp", 2}, {"Plains", 3}}, {{"Mountain", 1}, {"Island", 2}});
     testDeck(clipboard, result);
 }
 
@@ -122,30 +47,30 @@ TEST(LoadingFromClipboardTest, SideboardLine)
     QString clipboard("1 Mountain\n"
                       "2 Swamp\n"
                       "\n"
-                      "3 plains\n"
+                      "3 Plains\n"
                       "sideboard\n"
                       "1 Mountain\n"
                       "2x Island\n");
-    Result result("", "", {{"mountain", 1}, {"swamp", 2}, {"plains", 3}}, {{"mountain", 1}, {"island", 2}});
+    Result result("", "", {{"Mountain", 1}, {"Swamp", 2}, {"Plains", 3}}, {{"Mountain", 1}, {"Island", 2}});
     testDeck(clipboard, result);
 }
 
 TEST(LoadingFromClipboardTest, UnknownCardsAreNotDiscarded)
 {
     QString clipboard("1 CardThatDoesNotExistInCardsXml\n");
-    Result result("", "", {{"cardthatdoesnotexistincardsxml", 1}}, {});
+    Result result("", "", {{"CardThatDoesNotExistInCardsXml", 1}}, {});
     testDeck(clipboard, result);
 }
 
 TEST(LoadingFromClipboardTest, WeirdWhitespaceIsIgnored)
 {
-    QString clipboard("  Our Market   Research Shows That Players Like Really Long Card Names           So We Made "
-                      "this Card to Have\tthe Absolute \t Longest Card Name \tEver Elemental\t\n\t");
-    Result result("", "",
-                  {{"our market research shows that players like really long card names so we made this card to have "
-                    "the absolute longest card name ever elemental",
-                    1}},
-                  {});
+    QString clipboard(
+        "\t\tSb:\t1\tOur Market   Research Shows That Players Like  Really Long Card Names           So We Made        "
+        "           This Card to Have\tthe Absolute \t Longest Card Name \tEver Elemental\t\n\t");
+    Result result("", "", {},
+                  {{"Our Market Research Shows That Players Like Really Long Card Names So We Made This Card to Have "
+                    "the Absolute Longest Card Name Ever Elemental",
+                    1}});
     testDeck(clipboard, result);
 }
 
@@ -160,7 +85,7 @@ TEST(LoadingFromClipboardTest, RemoveBlankEntriesFromBeginningAndEnd)
                       "\n"
                       "\n");
 
-    Result result("", "", {{"algae gharial", 1}, {"cardthatdoesnotexistincardsxml", 3}, {"phelddagrif", 2}}, {});
+    Result result("", "", {{"Algae Gharial", 1}, {"CardThatDoesNotExistInCardsXml", 3}, {"Phelddagrif", 2}}, {});
     testDeck(clipboard, result);
 }
 
@@ -171,7 +96,7 @@ TEST(LoadingFromClipboardTest, UseFirstBlankIfOnlyOneBlankToSplitSideboard)
                       "\n"
                       "2x Phelddagrif\n");
 
-    Result result("", "", {{"algae gharial", 1}, {"cardthatdoesnotexistincardsxml", 3}}, {{"phelddagrif", 2}});
+    Result result("", "", {{"Algae Gharial", 1}, {"CardThatDoesNotExistInCardsXml", 3}}, {{"Phelddagrif", 2}});
     testDeck(clipboard, result);
 }
 
@@ -185,39 +110,43 @@ TEST(LoadingFromClipboardTest, IfMultipleScatteredBlanksAllMainBoard)
                       "3 Giant Growth\n");
 
     Result result(
-        "", "", {{"algae gharial", 1}, {"cardthatdoesnotexistincardsxml", 3}, {"phelddagrif", 2}, {"giant growth", 3}},
+        "", "", {{"Algae Gharial", 1}, {"CardThatDoesNotExistInCardsXml", 3}, {"Phelddagrif", 2}, {"Giant Growth", 3}},
         {});
     testDeck(clipboard, result);
 }
 
-TEST(LoadingFromClipboardTest, LotsOfStuffInBulkTesting)
+TEST(LoadingFromClipboardTest, EdgeCaseTesting)
 {
-    QString clipboard("\n"
-                      "\n"
-                      "\n"
-                      "1x Æther Adept\n"
-                      "2x Fire & Ice\n"
-                      "3 Pain/Suffering\n"
-                      "4X [B] FOREST (3)\n"
-                      "testNoValueMB\n"
-                      "\n"
-                      "\n"
-                      "// I like cards\n"
-                      "\n"
-                      "\n"
-                      "5x [WTH] nature’s resurgence\n"
-                      "6X Gaea's skYFOLK\n"
-                      "7  B.F.M. (Big Furry Monster)\n"
-                      "testNoValueSB\n"
-                      "\n"
-                      "\n"
-                      "\n"
-                      "\n");
+    QString clipboard(R"(
+// DeckName
 
-    Result result(
-        "", "",
-        {{"aether adept", 1}, {"fire // ice", 2}, {"pain // suffering", 3}, {"forest", 4}, {"testnovaluemb", 1}},
-        {{"nature's resurgence", 5}, {"gaea's skyfolk", 6}, {"b.f.m. (big furry monster)", 7}, {"testnovaluesb", 1}});
+   // Comment 1
+
+//
+//Comment [two]
+//(test) Æ ’ | / (3)
+
+
+// Mainboard (10 cards)
+Æther Adept
+2x Fire & Ice
+3 Pain/Suffering
+4X [B] Forest (3)
+
+
+// Sideboard (11 cards)
+
+5x [WTH] Nature’s Resurgence
+6X Gaea's Skyfolk
+7  B.F.M. (Big Furry Monster)
+
+
+
+)");
+
+    Result result("DeckName", "Comment 1\n\nComment [two]\n(test) Æ ’ | / (3)",
+                  {{"Aether Adept", 1}, {"Fire // Ice", 2}, {"Pain // Suffering", 3}, {"Forest", 4}},
+                  {{"Nature's Resurgence", 5}, {"Gaea's Skyfolk", 6}, {"B.F.M. (Big Furry Monster)", 7}});
     testDeck(clipboard, result);
 }
 
@@ -235,7 +164,6 @@ TEST(LoadingFromClipboardTest, CommentsBeforeCardsTesting)
     Result result("Title from website.com", "A nice deck\nWith nice cards", {{"test1", 1}}, {{"test2", 2}});
     testDeck(clipboard, result);
 }
-} // namespace
 
 int main(int argc, char **argv)
 {

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -36,24 +36,56 @@ struct DecklistBuilder
     }
 };
 
+struct Result
+{
+    std::string name;
+    std::string comments;
+    CardRows mainboard;
+    CardRows sideboard;
+
+    Result(std::string _name, std::string _comments, CardRows _mainboard, CardRows _sideboard)
+        : name(_name), comments(_comments), mainboard(_mainboard), sideboard(_sideboard)
+    {
+    }
+};
+
+void testEmpty(const QString &clipboard)
+{
+    QString cp(clipboard);
+    DeckList deckList;
+    QTextStream stream(&cp); // text stream requires local copy
+    deckList.loadFromStream_Plain(stream);
+
+    ASSERT_TRUE(deckList.getCardList().isEmpty());
+}
+
+void testDeck(const QString &clipboard, const Result &result)
+{
+    QString cp(clipboard);
+    DeckList deckList;
+    QTextStream stream(&cp); // text stream requires local copy
+    deckList.loadFromStream_Plain(stream);
+
+    ASSERT_EQ(result.name, deckList.getName().toStdString());
+    ASSERT_EQ(result.comments, deckList.getComments().toStdString());
+
+    DecklistBuilder decklistBuilder = DecklistBuilder();
+    deckList.forEachCard(decklistBuilder);
+
+    ASSERT_EQ(result.mainboard, decklistBuilder.mainboard());
+    ASSERT_EQ(result.sideboard, decklistBuilder.sideboard());
+}
+
 namespace
 {
 TEST(LoadingFromClipboardTest, EmptyDeck)
 {
-    DeckList deckList;
-    QString clipboard("");
-    QTextStream stream(&clipboard);
-    deckList.loadFromStream_Plain(stream);
-    ASSERT_TRUE(deckList.getCardList().isEmpty());
+    testEmpty("");
 }
 
 TEST(LoadingFromClipboardTest, EmptySideboard)
 {
-    DeckList deckList;
-    QString clipboard("Sideboard");
-    QTextStream stream(&clipboard);
-    deckList.loadFromStream_Plain(stream);
-    ASSERT_TRUE(deckList.getCardList().isEmpty());
+    testEmpty("Sideboard");
 }
 
 TEST(LoadingFromClipboardTest, QuantityPrefixed)
@@ -61,18 +93,8 @@ TEST(LoadingFromClipboardTest, QuantityPrefixed)
     QString clipboard("1 Mountain\n"
                       "2x Island\n"
                       "3X FOREST\n");
-    DeckList deckList;
-    QTextStream stream(&clipboard);
-    deckList.loadFromStream_Plain(stream);
-
-    DecklistBuilder decklistBuilder = DecklistBuilder();
-    deckList.forEachCard(decklistBuilder);
-
-    CardRows expectedMainboard = CardRows({{"mountain", 1}, {"island", 2}, {"forest", 3}});
-    CardRows expectedSideboard = CardRows({});
-
-    ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
-    ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
+    Result result("", "", {{"mountain", 1}, {"island", 2}, {"forest", 3}}, {});
+    testDeck(clipboard, result);
 }
 
 TEST(LoadingFromClipboardTest, CommentsAreIgnored)
@@ -80,55 +102,51 @@ TEST(LoadingFromClipboardTest, CommentsAreIgnored)
     QString clipboard("//1 Mountain\n"
                       "//2x Island\n"
                       "//SB:2x Island\n");
-
-    DeckList deckList;
-    QTextStream stream(&clipboard);
-    deckList.loadFromStream_Plain(stream);
-
-    DecklistBuilder decklistBuilder = DecklistBuilder();
-    deckList.forEachCard(decklistBuilder);
-
-    CardRows expectedMainboard = CardRows({});
-    CardRows expectedSideboard = CardRows({});
-
-    ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
-    ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
+    testEmpty(clipboard);
 }
 
 TEST(LoadingFromClipboardTest, SideboardPrefix)
 {
     QString clipboard("1 Mountain\n"
                       "SB: 1 Mountain\n"
-                      "SB: 2x Island\n");
-    DeckList deckList;
-    QTextStream stream(&clipboard);
-    deckList.loadFromStream_Plain(stream);
+                      "SB: 2x Island\n"
+                      "2 Swamp\n"
+                      "\n"
+                      "3 plains\n");
+    Result result("", "", {{"mountain", 1}, {"swamp", 2}, {"plains", 3}}, {{"mountain", 1}, {"island", 2}});
+    testDeck(clipboard, result);
+}
 
-    DecklistBuilder decklistBuilder = DecklistBuilder();
-    deckList.forEachCard(decklistBuilder);
-
-    CardRows expectedMainboard = CardRows({{"mountain", 1}});
-    CardRows expectedSideboard = CardRows({{"mountain", 1}, {"island", 2}});
-
-    ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
-    ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
+TEST(LoadingFromClipboardTest, SideboardLine)
+{
+    QString clipboard("1 Mountain\n"
+                      "2 Swamp\n"
+                      "\n"
+                      "3 plains\n"
+                      "sideboard\n"
+                      "1 Mountain\n"
+                      "2x Island\n");
+    Result result("", "", {{"mountain", 1}, {"swamp", 2}, {"plains", 3}}, {{"mountain", 1}, {"island", 2}});
+    testDeck(clipboard, result);
 }
 
 TEST(LoadingFromClipboardTest, UnknownCardsAreNotDiscarded)
 {
     QString clipboard("1 CardThatDoesNotExistInCardsXml\n");
-    DeckList deckList;
-    QTextStream stream(&clipboard);
-    deckList.loadFromStream_Plain(stream);
+    Result result("", "", {{"cardthatdoesnotexistincardsxml", 1}}, {});
+    testDeck(clipboard, result);
+}
 
-    DecklistBuilder decklistBuilder = DecklistBuilder();
-    deckList.forEachCard(decklistBuilder);
-
-    CardRows expectedMainboard = CardRows({{"cardthatdoesnotexistincardsxml", 1}});
-    CardRows expectedSideboard = CardRows({});
-
-    ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
-    ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
+TEST(LoadingFromClipboardTest, WeirdWhitespaceIsIgnored)
+{
+    QString clipboard("  Our Market   Research Shows That Players Like Really Long Card Names           So We Made "
+                      "this Card to Have\tthe Absolute \t Longest Card Name \tEver Elemental\t\n\t");
+    Result result("", "",
+                  {{"our market research shows that players like really long card names so we made this card to have "
+                    "the absolute longest card name ever elemental",
+                    1}},
+                  {});
+    testDeck(clipboard, result);
 }
 
 TEST(LoadingFromClipboardTest, RemoveBlankEntriesFromBeginningAndEnd)
@@ -142,19 +160,8 @@ TEST(LoadingFromClipboardTest, RemoveBlankEntriesFromBeginningAndEnd)
                       "\n"
                       "\n");
 
-    DeckList deckList;
-    QTextStream stream(&clipboard);
-    deckList.loadFromStream_Plain(stream);
-
-    DecklistBuilder decklistBuilder = DecklistBuilder();
-    deckList.forEachCard(decklistBuilder);
-
-    CardRows expectedMainboard =
-        CardRows({{"algae gharial", 1}, {"cardthatdoesnotexistincardsxml", 3}, {"phelddagrif", 2}});
-    CardRows expectedSideboard = CardRows({});
-
-    ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
-    ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
+    Result result("", "", {{"algae gharial", 1}, {"cardthatdoesnotexistincardsxml", 3}, {"phelddagrif", 2}}, {});
+    testDeck(clipboard, result);
 }
 
 TEST(LoadingFromClipboardTest, UseFirstBlankIfOnlyOneBlankToSplitSideboard)
@@ -164,18 +171,8 @@ TEST(LoadingFromClipboardTest, UseFirstBlankIfOnlyOneBlankToSplitSideboard)
                       "\n"
                       "2x Phelddagrif\n");
 
-    DeckList deckList;
-    QTextStream stream(&clipboard);
-    deckList.loadFromStream_Plain(stream);
-
-    DecklistBuilder decklistBuilder = DecklistBuilder();
-    deckList.forEachCard(decklistBuilder);
-
-    CardRows expectedMainboard = CardRows({{"algae gharial", 1}, {"cardthatdoesnotexistincardsxml", 3}});
-    CardRows expectedSideboard = CardRows({{"phelddagrif", 2}});
-
-    ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
-    ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
+    Result result("", "", {{"algae gharial", 1}, {"cardthatdoesnotexistincardsxml", 3}}, {{"phelddagrif", 2}});
+    testDeck(clipboard, result);
 }
 
 TEST(LoadingFromClipboardTest, IfMultipleScatteredBlanksAllMainBoard)
@@ -187,19 +184,10 @@ TEST(LoadingFromClipboardTest, IfMultipleScatteredBlanksAllMainBoard)
                       "\n"
                       "3 Giant Growth\n");
 
-    DeckList deckList;
-    QTextStream stream(&clipboard);
-    deckList.loadFromStream_Plain(stream);
-
-    DecklistBuilder decklistBuilder = DecklistBuilder();
-    deckList.forEachCard(decklistBuilder);
-
-    CardRows expectedMainboard = CardRows(
-        {{"algae gharial", 1}, {"cardthatdoesnotexistincardsxml", 3}, {"phelddagrif", 2}, {"giant growth", 3}});
-    CardRows expectedSideboard = CardRows({});
-
-    ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
-    ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
+    Result result(
+        "", "", {{"algae gharial", 1}, {"cardthatdoesnotexistincardsxml", 3}, {"phelddagrif", 2}, {"giant growth", 3}},
+        {});
+    testDeck(clipboard, result);
 }
 
 TEST(LoadingFromClipboardTest, LotsOfStuffInBulkTesting)
@@ -207,62 +195,45 @@ TEST(LoadingFromClipboardTest, LotsOfStuffInBulkTesting)
     QString clipboard("\n"
                       "\n"
                       "\n"
-                      "1x aether adept\n" // "1x Æther Adept\n" // bugged
+                      "1x Æther Adept\n"
                       "2x Fire & Ice\n"
                       "3 Pain/Suffering\n"
                       "4X [B] FOREST (3)\n"
                       "testNoValueMB\n"
                       "\n"
                       "\n"
+                      "// I like cards\n"
                       "\n"
                       "\n"
                       "5x [WTH] nature’s resurgence\n"
                       "6X Gaea's skYFOLK\n"
+                      "7  B.F.M. (Big Furry Monster)\n"
                       "testNoValueSB\n"
                       "\n"
                       "\n"
                       "\n"
                       "\n");
 
-    DeckList deckList;
-    QTextStream stream(&clipboard);
-    deckList.loadFromStream_Plain(stream);
-
-    DecklistBuilder decklistBuilder = DecklistBuilder();
-    deckList.forEachCard(decklistBuilder);
-
-    CardRows expectedMainboard = CardRows(
-        {{"aether adept", 1}, {"fire // ice", 2}, {"pain // suffering", 3}, {"forest", 4}, {"testnovaluemb", 1}});
-    CardRows expectedSideboard = CardRows({{"nature's resurgence", 5}, {"gaea's skyfolk", 6}, {"testnovaluesb", 1}});
-    ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
-    ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
+    Result result(
+        "", "",
+        {{"aether adept", 1}, {"fire // ice", 2}, {"pain // suffering", 3}, {"forest", 4}, {"testnovaluemb", 1}},
+        {{"nature's resurgence", 5}, {"gaea's skyfolk", 6}, {"b.f.m. (big furry monster)", 7}, {"testnovaluesb", 1}});
+    testDeck(clipboard, result);
 }
 
 TEST(LoadingFromClipboardTest, CommentsBeforeCardsTesting)
 {
-    QString clipboard("// title from website.com\n"
-                      "// a nice deck\n"
-                      "// with nice cards\n"
+    QString clipboard("// Title from website.com\n"
+                      "// A nice deck\n"
+                      "// With nice cards\n"
                       "\n"
+                      "// Mainboard\n"
                       "1 test1\n"
-                      "sideboard\n"
+                      "Sideboard\n"
                       "2 test2\n");
 
-    DeckList deckList;
-    QTextStream stream(&clipboard);
-    deckList.loadFromStream_Plain(stream);
-
-    ASSERT_EQ(deckList.getName().toStdString(), "title from website.com");
-    // ASSERT_EQ(deckList.getComments().toStdString(), "a nice deck\nwith nice cards"); // bugged
-
-    DecklistBuilder decklistBuilder = DecklistBuilder();
-    deckList.forEachCard(decklistBuilder);
-
-    CardRows expectedMainboard = CardRows({{"test1", 1}});
-    CardRows expectedSideboard = CardRows({{"test2", 2}});
-
-    ASSERT_EQ(expectedMainboard, decklistBuilder.mainboard());
-    ASSERT_EQ(expectedSideboard, decklistBuilder.sideboard());
+    Result result("Title from website.com", "A nice deck\nWith nice cards", {{"test1", 1}}, {{"test2", 2}});
+    testDeck(clipboard, result);
 }
 } // namespace
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3064

## Short roundup of the initial problem
Some weirdness in loading plaintext decklists resulted in the name and comments being added wrong when using the same format Cockatrice uses to export plaintext decklists.

## What will change with this Pull Request?
- loading plaintext decklists will be completely rewritten.
- comments and names will no longer be all lowercase when imported.
- the first two comments with mainboard and cardtypes will no longer be seen as names or comments.

I've tested this new function extensively on some weird edgecase decklists but feel free to doublecheck.
Some things that are a bit weird:
- having two entries for the same card inserts them as separate entries, this is the same as the original functionality and might warrant a new issue.
- the original function checked for a pipe `|` and removed everything behind it for some reason, this caused split cards noted like "Fire | Ice" to not register correctly, this functionality didn't seem useful to me and has not been implemented.
- all the regexes are currently defined inside the function but as they are const they might be defined as private members, or as static variables inside the function (I prefer avoiding static), should this be changed?
- the new function regards every weird character that should never occur as the first character of a cardname as a comment, this is good imo but debatable as it might remove the start of a deck comment starting with such a character. (please tell me how many of your decknames start with #, $, or &; and if missing that first character when you plaintext copy it matters)
