### PR TITLE
improve translating section of CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -177,33 +177,30 @@ You can find more information on how we use Protobuf on [our wiki!](https://gith
 
 # Translations #
 
-**Basic workflow for translations:**
+Basic workflow for translations:
  1. Developer adds a `tr("foo")` string in the code;
  2. Every few days, a maintainer updates the `*_en.ts files` with the new strings;
  3. Transifex picks up the new files from github every 24 hours;
  4. Translators translate the new untraslated strings on Transifex;
  5. Before a release, a maintainer fetches the updated translations from Transifex.
 
-### Translations (for developers) ###
+### Using Translations (for developers) ###
 
-**Step 1: Adding translatable strings to the code (`tr("foo")`)**
-
-All the user-interface strings inside Cockatrice's source code must be written in
-english language.<br>
+All the user-interface strings inside Cockatrice's source code must be written in english.
 Translations to other languages are managed using [Transifex](https://www.transifex.com/projects/p/cockatrice/).
 
-If you're about to propose a change that adds or modifies any translatable string
-in the code, you don't need to take care of adding the new strings to the
-translation files. Every few days, or when a lot of new strings have been added,
-someone from the development team will take care of extracing all the new strings,
-adding them to the english translation files and making them available to
-translators on Transifex.
+Adding a new string to translate is as easy as adding the string in the 'tr("")' function, the string will be picked up as translatable automatically and translated as needed.
+For example setting the text of this label in a way that the string "My name is:" can be translated:
+```c++
+nameLabel.setText(tr("My name is:"));
+```
 
-### Translations (for maintainers) ###
+If you're about to propose a change that adds or modifies any translatable string in the code, you don't need to take care of adding the new strings to the translation files.
+Every few days, or when a lot of new strings have been added, someone from the development team will take care of extracing all the new strings and adding them to the english translation files and making them available to translators on Transifex.
 
-**Step 2: Updating `*_en.ts` files with new strings**
+### Maintaining Translations (for maintainers) ###
 
-When new translatable strings have been added to the code, it would be nice to
+When new translatable strings have been added to the code, a maintainer should
 make them available to translators on Transifex. Every few days, or when a lot
 of new strings have been added, a maintainer should take care of extracing all
 the new strings and add them to the english translation files.
@@ -233,14 +230,12 @@ cmake .. -DUPDATE_TRANSLATIONS=OFF
 ```
 Now you are ready to propose your change.
 
-**Step 3: Automatic pushing to Transifex**
-
 Once your change gets merged, Transifex will pick up the modified files automatically (checks every 24 hours)
 and update the interface where translators will be able to translate the new strings.
 
-**Step 5: Fetching new translations from Transifex**
+### Releasing Translations (for maintainers) ###
 
-Before rushing out a new release, it would be nice to fetch the most up to date
+Before rushing out a new release, a maintainer should fetch the most up to date
 translations from Transifex and commit them into the Cockatrice source code.
 This can be done manually from the Transifex web interface, but it's quite time
 consuming.
@@ -252,10 +247,9 @@ As an alternative, you can install the Transifex CLI:
 You'll then be able to use a git-like cli command to push and pull translations
 from Transifex to the source code and vice versa.
 
-### Translations (for translators) ###
+### Adding Translations (for translators) ###
 
-**Step 4: Editing translations at Transifex**
-
+As a translator you can help translate the new strings on [Transifex](https://www.transifex.com/projects/p/cockatrice/).
 Please have a look at the specific [FAQ for translators](https://github.com/Cockatrice/Cockatrice/wiki/Translation-FAQ).
 
 


### PR DESCRIPTION
Remove the weird out of order numbering and replace it with just chapters for specific users.
Add a bit of explanation to adding translations as a developer.

This is just a recommendation for an improvement, jumplist could be added and/or #3423 merged with this. (it fixes the typos)