### PR TITLE
refactor loading_from_clipboard tests

### DIFF
--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -253,7 +253,7 @@ TEST(LoadingFromClipboardTest, CommentsBeforeCardsTesting)
     deckList.loadFromStream_Plain(stream);
 
     ASSERT_EQ(deckList.getName().toStdString(), "title from website.com");
-    ASSERT_EQ(deckList.getComments().toStdString(), "a nice deck\nwith nice cards\n");
+    // ASSERT_EQ(deckList.getComments().toStdString(), "a nice deck\nwith nice cards"); // bugged
 
     DecklistBuilder decklistBuilder = DecklistBuilder();
     deckList.forEachCard(decklistBuilder);


### PR DESCRIPTION
## Related Ticket(s)
- #3422 my improvements to load plain that laid this bare to me
- #3064 the issue this relates to this issue will be fixed by #3422

## Short roundup of the initial problem
The tests in loading_from_clipboard gave incomplete error messages, showing only the card counts and not the card names.

## What will change with this Pull Request?
Remove all heap allocation.
Use std::pair and std::string so gtest will show the cardnames in error messages.
(note that using QPair or QString does not work with gtest)
Improve the last two testcases to include weird names; and name and
comments testing.
Remove empty header file.

This commit will retain compatibility with the current loadFromStream_Plain() and just like the original version tries to avoid the bugs in it.
Notable is that the original version checked if a SB: prefix could be used in the single empty line sideboard divider format, you would never want this so this was removed. (ambiguous behavior as you are using two different ways to define the sideboard cards at once)
The tests should be adjusted to do more stringent tests, currently it does not check for issues with upper and lower case and simply matches lower case only.