### PR TITLE
readme: clarify minimum requirements for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Check out our [Translator FAQ](https://github.com/Cockatrice/Cockatrice/wiki/Tra
 
 **Detailed compiling instructions are on the Cockatrice wiki under [Compiling Cockatrice](https://github.com/Cockatrice/Cockatrice/wiki/Compiling-Cockatrice)**
 
-Dependencies:
+Dependencies: *(for minimum requirements search our [CMake file](https://github.com/Cockatrice/Cockatrice/blob/master/CMakeLists.txt))*
 - [Qt](https://www.qt.io/developers/)
 - [protobuf](https://github.com/google/protobuf)
 - [CMake](https://www.cmake.org/)


### PR DESCRIPTION
## Short roundup of the initial problem
No explanation and hint on which min. versions are required.

## What will change with this Pull Request?
- Link to our CMake file which has them listed, e.g:
    - `cmake_minimum_required(VERSION 3.1)`
    - `FIND_PACKAGE(Qt5Core 5.5.0 REQUIRED)`
    - `FIND_PACKAGE(Protobuf REQUIRED)`

It's not a perfect solution, but a good hint and improvement.
I don't want to explicitly name the versions in the README since that would mean we have to maintain them to provide helpful and correct information.


## Screenshots
https://github.com/Cockatrice/Cockatrice/tree/tooomm-patch-1#build--