### PR TITLE
replace simplecards with normal cards

### DIFF
--- a/cockatrice/src/cardframe.cpp
+++ b/cockatrice/src/cardframe.cpp
@@ -105,7 +105,7 @@ void CardFrame::setCard(CardInfoPtr card)
 
 void CardFrame::setCard(const QString &cardName)
 {
-    setCard(db->getCardBySimpleName(cardName));
+    setCard(db->getCard(cardName));
 }
 
 void CardFrame::setCard(AbstractCardItem *card)

--- a/cockatrice/src/cardinfowidget.cpp
+++ b/cockatrice/src/cardinfowidget.cpp
@@ -51,7 +51,7 @@ void CardInfoWidget::setCard(CardInfoPtr card)
 
 void CardInfoWidget::setCard(const QString &cardName)
 {
-    setCard(db->getCardBySimpleName(cardName));
+    setCard(db->getCard(cardName));
     if (!info)
         text->setInvalidCardName(cardName);
 }


### PR DESCRIPTION
Instead of calling db->getCardBySimpleName() use just getCard.
This will load images with non ascii characters in the deck editor correctly.

## Related Ticket(s)
- Fixes #3360

## Short roundup of the initial problem
Images for non ASCII cardnames loaded incorrectly.

## What will change with this Pull Request?
- Cardnames for images in the deck editor will be loaded based on their normal cardname and not their simple cardname.
