### PR TITLE
add os version name to package filename

### DIFF
--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -17,7 +17,8 @@ while [[ "$@" ]]; do
       ;;
     '--package')
       MAKE_PACKAGE=1
-      shift
+      PACKAGE_NAME="$2"
+      shift 2
       ;;
     '--server')
       MAKE_SERVER=1
@@ -108,4 +109,12 @@ fi
 
 if [[ $MAKE_PACKAGE ]]; then
   make package
+  if [[ $PACKAGE_NAME ]]; then
+    if file=$(find . -maxdepth 1 -type f -name Cockatrice-*.* -print -quit); then
+      mv "$file" "${file%%.*}-$PACKAGE_NAME.${file#*.}"
+    else
+      echo "could not find package" >&2
+      exit 1
+    fi
+  fi
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     services: docker
     script: docker build -t img .ci &&
         docker run --mount "type=bind,source=$(pwd),target=/src" -w="/src" img
-          bash .ci/travis-compile.sh --server --package --release
+          bash .ci/travis-compile.sh --server --package "Ubuntu18.04" --release
 
   #Ubuntu Xenial (Debug only)
   - name: Ubuntu Xenial (Debug)
@@ -62,7 +62,7 @@ matrix:
       - brew unlink python # protobuf python2 install requires this link to be removed
       - brew install protobuf
       - brew install qt
-    script: bash ./.ci/travis-compile.sh --server --package --release
+    script: bash ./.ci/travis-compile.sh --server --package "" --release
 
 
 # Builds for pull requests skip the deployment step altogether


### PR DESCRIPTION
Add CMAKE_SYSTEM_VERSION to the PROJECT_VERSION_FILENAME.
Without this package names are the same for all systems using the same package type, causing them to be overwritten.
If this is added we'll be able to support both Ubuntu 16.04 and 18.04 for example.
See #3433 for the pr adding Ubuntu 18.04 compilation to travis ci.