### PR TITLE
add keybinds to mill cards

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -219,6 +219,10 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
         connect(aMulligan, SIGNAL(triggered()), this, SLOT(actMulligan()));
         aMoveTopToPlayFaceDown = new QAction(this);
         connect(aMoveTopToPlayFaceDown, SIGNAL(triggered()), this, SLOT(actMoveTopCardToPlayFaceDown()));
+        aMoveTopCardToGrave = new QAction(this);
+        connect(aMoveTopCardToGrave, SIGNAL(triggered()), this, SLOT(actMoveTopCardToGrave()));
+        aMoveTopCardToExile = new QAction(this);
+        connect(aMoveTopCardToExile, SIGNAL(triggered()), this, SLOT(actMoveTopCardToExile()));
         aMoveTopCardsToGrave = new QAction(this);
         connect(aMoveTopCardsToGrave, SIGNAL(triggered()), this, SLOT(actMoveTopCardsToGrave()));
         aMoveTopCardsToExile = new QAction(this);
@@ -266,6 +270,8 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, TabGame *_pare
         libraryMenu->addAction(aMoveTopCardToBottom);
         libraryMenu->addAction(aMoveBottomCardToGrave);
         libraryMenu->addSeparator();
+        libraryMenu->addAction(aMoveTopCardToGrave);
+        libraryMenu->addAction(aMoveTopCardToExile);
         libraryMenu->addAction(aMoveTopCardsToGrave);
         libraryMenu->addAction(aMoveTopCardsToExile);
         libraryMenu->addSeparator();
@@ -652,6 +658,8 @@ void Player::retranslateUi()
         aMulligan->setText(tr("Take &mulligan"));
         aShuffle->setText(tr("&Shuffle"));
         aMoveTopToPlayFaceDown->setText(tr("Play top card &face down"));
+        aMoveTopCardToGrave->setText(tr("Move top card to &graveyard"));
+        aMoveTopCardToExile->setText(tr("Move top card to &exile"));
         aMoveTopCardsToGrave->setText(tr("Move top cards to &graveyard..."));
         aMoveTopCardsToExile->setText(tr("Move top cards to &exile..."));
         aMoveTopCardToBottom->setText(tr("Put top card on &bottom"));
@@ -956,6 +964,38 @@ void Player::actDrawCards()
 void Player::actUndoDraw()
 {
     sendGameCommand(Command_UndoDraw());
+}
+
+void Player::actMoveTopCardToGrave()
+{
+    if (zones.value("deck")->getCards().size() == 0)
+      return;
+
+    Command_MoveCard cmd;
+    cmd.set_start_zone("deck");
+    cmd.mutable_cards_to_move()->add_card()->set_card_id(0);
+    cmd.set_target_player_id(getId());
+    cmd.set_target_zone("grave");
+    cmd.set_x(0);
+    cmd.set_y(0);
+
+    sendGameCommand(cmd);
+}
+
+void Player::actMoveTopCardToExile()
+{
+    if (zones.value("deck")->getCards().size() == 0)
+      return;
+
+    Command_MoveCard cmd;
+    cmd.set_start_zone("deck");
+    cmd.mutable_cards_to_move()->add_card()->set_card_id(0);
+    cmd.set_target_player_id(getId());
+    cmd.set_target_zone("rfg");
+    cmd.set_x(0);
+    cmd.set_y(0);
+
+    sendGameCommand(cmd);
 }
 
 void Player::actMoveTopCardsToGrave()

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -144,6 +144,8 @@ public slots:
     void actUndoDraw();
     void actMulligan();
     void actMoveTopCardToPlayFaceDown();
+    void actMoveTopCardToGrave();
+    void actMoveTopCardToExile();
     void actMoveTopCardsToGrave();
     void actMoveTopCardsToExile();
     void actMoveTopCardToBottom();
@@ -201,10 +203,10 @@ private:
     QAction *aMoveHandToTopLibrary, *aMoveHandToBottomLibrary, *aMoveHandToGrave, *aMoveHandToRfg,
         *aMoveGraveToTopLibrary, *aMoveGraveToBottomLibrary, *aMoveGraveToHand, *aMoveGraveToRfg, *aMoveRfgToTopLibrary,
         *aMoveRfgToBottomLibrary, *aMoveRfgToHand, *aMoveRfgToGrave, *aViewLibrary, *aViewTopCards,
-        *aAlwaysRevealTopCard, *aOpenDeckInDeckEditor, *aMoveTopCardsToGrave, *aMoveTopCardsToExile,
-        *aMoveTopCardToBottom, *aViewGraveyard, *aViewRfg, *aViewSideboard, *aDrawCard, *aDrawCards, *aUndoDraw,
-        *aMulligan, *aShuffle, *aMoveTopToPlayFaceDown, *aUntapAll, *aRollDie, *aCreateToken, *aCreateAnotherToken,
-        *aCardMenu, *aMoveBottomCardToGrave;
+        *aAlwaysRevealTopCard, *aOpenDeckInDeckEditor, *aMoveTopCardToGrave, *aMoveTopCardToExile,
+        *aMoveTopCardsToGrave, *aMoveTopCardsToExile, *aMoveTopCardToBottom, *aViewGraveyard, *aViewRfg,
+        *aViewSideboard, *aDrawCard, *aDrawCards, *aUndoDraw, *aMulligan, *aShuffle, *aMoveTopToPlayFaceDown,
+        *aUntapAll, *aRollDie, *aCreateToken, *aCreateAnotherToken, *aCardMenu, *aMoveBottomCardToGrave;
 
     QList<QAction *> aAddCounter, aSetCounter, aRemoveCounter;
     QAction *aPlay, *aPlayFacedown, *aHide, *aTap, *aDoesntUntap, *aAttach, *aUnattach, *aDrawArrow, *aSetPT, *aResetPT,

--- a/cockatrice/src/sequenceEdit/ui_shortcutstab.h
+++ b/cockatrice/src/sequenceEdit/ui_shortcutstab.h
@@ -279,42 +279,8 @@ public:
     QSpacerItem *verticalSpacer_2;
     QWidget *tab_3;
     QGridLayout *gridLayout_20;
-    QGroupBox *groupBox_15;
-    QGridLayout *gridLayout_15;
-    QLabel *lbl_Player_aMoveToBottomLibrary;
-    SequenceEdit *Player_aMoveToBottomLibrary;
-    QLabel *lbl_Player_aMoveToTopLibrary;
-    SequenceEdit *Player_aMoveToTopLibrary;
-    QLabel *lbl_Player_aMoveToGraveyard;
-    SequenceEdit *Player_aMoveToGraveyard;
-    QLabel *lbl_Player_aMoveToExile;
-    SequenceEdit *Player_aMoveToExile;
-    QLabel *lbl_Player_aMoveToHand;
-    SequenceEdit *Player_aMoveToHand;
-    QLabel *lbl_Player_aMoveTopToPlayFaceDown;
-    SequenceEdit *Player_aMoveTopToPlayFaceDown;
-    QGroupBox *groupBox_16;
-    QGridLayout *gridLayout_16;
-    QLabel *lbl_Player_aViewGraveyard;
-    SequenceEdit *Player_aViewGraveyard;
-    QLabel *lbl_Player_aViewLibrary;
-    SequenceEdit *Player_aViewLibrary;
-    QLabel *lbl_Player_aViewTopCards;
-    SequenceEdit *Player_aViewTopCards;
-    QLabel *lbl_Player_aViewSideboard;
-    SequenceEdit *Player_aViewSideboard;
-    QLabel *lbl_Player_aViewRfg;
-    SequenceEdit *Player_aViewRfg;
-    QLabel *lbl_GameView_aCloseMostRecentZoneView;
-    SequenceEdit *GameView_aCloseMostRecentZoneView;
-    QGroupBox *groupBox_17;
-    QGridLayout *gridLayout_18;
-    SequenceEdit *DeckViewContainer_loadRemoteButton;
-    SequenceEdit *DeckViewContainer_loadLocalButton;
-    QLabel *lbl_DeckViewContainer_loadRemoteButton;
-    QLabel *lbl_DeckViewContainer_loadLocalButton;
-    QGroupBox *groupBox_18;
-    QGridLayout *gridLayout_19;
+    QGroupBox *groupBox_gameplay;
+    QGridLayout *gridLayout_gameplay;
     QLabel *lbl_Player_aDrawArrow;
     SequenceEdit *Player_aDrawArrow;
     QLabel *lbl_TabGame_aLeaveGame;
@@ -331,8 +297,36 @@ public:
     SequenceEdit *Player_aShuffle;
     QLabel *lbl_TabGame_aRotateViewCCW;
     SequenceEdit *TabGame_aRotateViewCCW;
-    QGroupBox *groupBox_14;
-    QGridLayout *gridLayout_14;
+    QGroupBox *groupBox_moveCard;
+    QGridLayout *gridLayout_moveCard;
+    QLabel *lbl_Player_aMoveToBottomLibrary;
+    SequenceEdit *Player_aMoveToBottomLibrary;
+    QLabel *lbl_Player_aMoveToTopLibrary;
+    SequenceEdit *Player_aMoveToTopLibrary;
+    QLabel *lbl_Player_aMoveToGraveyard;
+    SequenceEdit *Player_aMoveToGraveyard;
+    QLabel *lbl_Player_aMoveToExile;
+    SequenceEdit *Player_aMoveToExile;
+    QLabel *lbl_Player_aMoveToHand;
+    SequenceEdit *Player_aMoveToHand;
+    QLabel *lbl_Player_aMoveTopToPlayFaceDown;
+    SequenceEdit *Player_aMoveTopToPlayFaceDown;
+    QGroupBox *groupBox_view;
+    QGridLayout *gridLayout_view;
+    QLabel *lbl_Player_aViewGraveyard;
+    SequenceEdit *Player_aViewGraveyard;
+    QLabel *lbl_Player_aViewLibrary;
+    SequenceEdit *Player_aViewLibrary;
+    QLabel *lbl_Player_aViewTopCards;
+    SequenceEdit *Player_aViewTopCards;
+    QLabel *lbl_Player_aViewSideboard;
+    SequenceEdit *Player_aViewSideboard;
+    QLabel *lbl_Player_aViewRfg;
+    SequenceEdit *Player_aViewRfg;
+    QLabel *lbl_GameView_aCloseMostRecentZoneView;
+    SequenceEdit *GameView_aCloseMostRecentZoneView;
+    QGroupBox *groupBox_draw;
+    QGridLayout *gridLayout_draw;
     QLabel *lbl_Player_aMulligan;
     SequenceEdit *Player_aMulligan;
     QLabel *lbl_Player_aDrawCard;
@@ -343,6 +337,22 @@ public:
     SequenceEdit *Player_aUndoDraw;
     QLabel *lbl_Player_aAlwaysRevealTopCard;
     SequenceEdit *Player_aAlwaysRevealTopCard;
+    QGroupBox *groupBox_moveDeck;
+    QGridLayout *gridLayout_moveDeck;
+    QLabel *lbl_Player_aMoveTopCardToGraveyard;
+    SequenceEdit *Player_aMoveTopCardToGraveyard;
+    QLabel *lbl_Player_aMoveTopCardToExile;
+    SequenceEdit *Player_aMoveTopCardToExile;
+    QLabel *lbl_Player_aMoveTopCardsToGraveyard;
+    SequenceEdit *Player_aMoveTopCardsToGraveyard;
+    QLabel *lbl_Player_aMoveTopCardsToExile;
+    SequenceEdit *Player_aMoveTopCardsToExile;
+    QGroupBox *groupBox_gameLobby;
+    QGridLayout *gridLayout_gameLobby;
+    SequenceEdit *DeckViewContainer_loadRemoteButton;
+    QLabel *lbl_DeckViewContainer_loadRemoteButton;
+    SequenceEdit *DeckViewContainer_loadLocalButton;
+    QLabel *lbl_DeckViewContainer_loadLocalButton;
     QSpacerItem *verticalSpacer_3;
     QWidget *tab_4;
     QLabel *faqLabel;
@@ -1406,304 +1416,332 @@ public:
         tab_3->setObjectName("tab_3");
         gridLayout_20 = new QGridLayout(tab_3);
         gridLayout_20->setObjectName("gridLayout_20");
-        groupBox_15 = new QGroupBox(tab_3);
-        groupBox_15->setObjectName("groupBox_15");
-        gridLayout_15 = new QGridLayout(groupBox_15);
-        gridLayout_15->setObjectName("gridLayout_15");
-        lbl_Player_aMoveToBottomLibrary = new QLabel(groupBox_15);
-        lbl_Player_aMoveToBottomLibrary->setObjectName("lbl_Player_aMoveToBottomLibrary");
 
-        gridLayout_15->addWidget(lbl_Player_aMoveToBottomLibrary, 0, 0, 1, 1);
-
-        Player_aMoveToBottomLibrary = new SequenceEdit("Player/aMoveToBottomLibrary", groupBox_15);
-        Player_aMoveToBottomLibrary->setObjectName("Player_aMoveToBottomLibrary");
-
-        gridLayout_15->addWidget(Player_aMoveToBottomLibrary, 0, 1, 1, 1);
-
-        lbl_Player_aMoveToTopLibrary = new QLabel(groupBox_15);
-        lbl_Player_aMoveToTopLibrary->setObjectName("lbl_Player_aMoveToTopLibrary");
-
-        gridLayout_15->addWidget(lbl_Player_aMoveToTopLibrary, 1, 0, 1, 1);
-
-        Player_aMoveToTopLibrary = new SequenceEdit("Player/aMoveToTopLibrary", groupBox_15);
-        Player_aMoveToTopLibrary->setObjectName("Player_aMoveToTopLibrary");
-
-        gridLayout_15->addWidget(Player_aMoveToTopLibrary, 1, 1, 1, 1);
-
-        lbl_Player_aMoveToGraveyard = new QLabel(groupBox_15);
-        lbl_Player_aMoveToGraveyard->setObjectName("lbl_Player_aMoveToGraveyard");
-
-        gridLayout_15->addWidget(lbl_Player_aMoveToGraveyard, 2, 0, 1, 1);
-
-        Player_aMoveToGraveyard = new SequenceEdit("Player/aMoveToGraveyard", groupBox_15);
-        Player_aMoveToGraveyard->setObjectName("Player_aMoveToGraveyard");
-
-        gridLayout_15->addWidget(Player_aMoveToGraveyard, 2, 1, 1, 1);
-
-        lbl_Player_aMoveToExile = new QLabel(groupBox_15);
-        lbl_Player_aMoveToExile->setObjectName("lbl_Player_aMoveToExile");
-
-        gridLayout_15->addWidget(lbl_Player_aMoveToExile, 3, 0, 1, 1);
-
-        Player_aMoveToExile = new SequenceEdit("Player/aMoveToExile", groupBox_15);
-        Player_aMoveToExile->setObjectName("Player_aMoveToExile");
-
-        gridLayout_15->addWidget(Player_aMoveToExile, 3, 1, 1, 1);
-
-        lbl_Player_aMoveToHand = new QLabel(groupBox_15);
-        lbl_Player_aMoveToHand->setObjectName("lbl_Player_aMoveToHand");
-
-        gridLayout_15->addWidget(lbl_Player_aMoveToHand, 4, 0, 1, 1);
-
-        Player_aMoveToHand = new SequenceEdit("Player/aMoveToHand", groupBox_15);
-        Player_aMoveToHand->setObjectName("Player_aMoveToHand");
-
-        gridLayout_15->addWidget(Player_aMoveToHand, 4, 1, 1, 1);
-
-        lbl_Player_aMoveTopToPlayFaceDown = new QLabel(groupBox_15);
-        lbl_Player_aMoveTopToPlayFaceDown->setObjectName("lbl_Player_aMoveTopToPlayFaceDown");
-
-        gridLayout_15->addWidget(lbl_Player_aMoveTopToPlayFaceDown, 5, 0, 1, 1);
-
-        Player_aMoveTopToPlayFaceDown = new SequenceEdit("Player/aMoveTopToPlayFaceDown", groupBox_15);
-        Player_aMoveTopToPlayFaceDown->setObjectName("Player_aMoveTopToPlayFaceDown");
-
-        gridLayout_15->addWidget(Player_aMoveTopToPlayFaceDown, 5, 1, 1, 1);
-
-        gridLayout_20->addWidget(groupBox_15, 0, 1, 1, 1);
-
-        groupBox_16 = new QGroupBox(tab_3);
-        groupBox_16->setObjectName("groupBox_16");
-        gridLayout_16 = new QGridLayout(groupBox_16);
-        gridLayout_16->setObjectName("gridLayout_16");
-        lbl_Player_aViewGraveyard = new QLabel(groupBox_16);
-        lbl_Player_aViewGraveyard->setObjectName("lbl_Player_aViewGraveyard");
-
-        gridLayout_16->addWidget(lbl_Player_aViewGraveyard, 0, 0, 1, 1);
-
-        Player_aViewGraveyard = new SequenceEdit("Player/aViewGraveyard", groupBox_16);
-        Player_aViewGraveyard->setObjectName("Player_aViewGraveyard");
-
-        gridLayout_16->addWidget(Player_aViewGraveyard, 0, 1, 1, 1);
-
-        lbl_Player_aViewLibrary = new QLabel(groupBox_16);
-        lbl_Player_aViewLibrary->setObjectName("lbl_Player_aViewLibrary");
-
-        gridLayout_16->addWidget(lbl_Player_aViewLibrary, 1, 0, 1, 1);
-
-        Player_aViewLibrary = new SequenceEdit("Player/aViewLibrary", groupBox_16);
-        Player_aViewLibrary->setObjectName("Player_aViewLibrary");
-
-        gridLayout_16->addWidget(Player_aViewLibrary, 1, 1, 1, 1);
-
-        lbl_Player_aViewTopCards = new QLabel(groupBox_16);
-        lbl_Player_aViewTopCards->setObjectName("lbl_Player_aViewTopCards");
-
-        gridLayout_16->addWidget(lbl_Player_aViewTopCards, 2, 0, 1, 1);
-
-        Player_aViewTopCards = new SequenceEdit("Player/aViewTopCards", groupBox_16);
-        Player_aViewTopCards->setObjectName("Player_aViewTopCards");
-
-        gridLayout_16->addWidget(Player_aViewTopCards, 2, 1, 1, 1);
-
-        lbl_Player_aViewSideboard = new QLabel(groupBox_16);
-        lbl_Player_aViewSideboard->setObjectName("lbl_Player_aViewSideboard");
-
-        gridLayout_16->addWidget(lbl_Player_aViewSideboard, 3, 0, 1, 1);
-
-        Player_aViewSideboard = new SequenceEdit("Player/aViewSideboard", groupBox_16);
-        Player_aViewSideboard->setObjectName("Player_aViewSideboard");
-
-        gridLayout_16->addWidget(Player_aViewSideboard, 3, 1, 1, 1);
-
-        lbl_Player_aViewRfg = new QLabel(groupBox_16);
-        lbl_Player_aViewRfg->setObjectName("lbl_Player_aViewRfg");
-
-        gridLayout_16->addWidget(lbl_Player_aViewRfg, 4, 0, 1, 1);
-
-        Player_aViewRfg = new SequenceEdit("Player/aViewRfg", groupBox_16);
-        Player_aViewRfg->setObjectName("Player_aViewRfg");
-
-        gridLayout_16->addWidget(Player_aViewRfg, 4, 1, 1, 1);
-
-        lbl_GameView_aCloseMostRecentZoneView = new QLabel(groupBox_16);
-        lbl_GameView_aCloseMostRecentZoneView->setObjectName("lbl_GameView_aCloseMostRecentZoneView");
-
-        gridLayout_16->addWidget(lbl_GameView_aCloseMostRecentZoneView, 5, 0, 1, 1);
-
-        GameView_aCloseMostRecentZoneView = new SequenceEdit("Player/aCloseMostRecentZoneView", groupBox_16);
-        GameView_aCloseMostRecentZoneView->setObjectName("GameView_aCloseMostRecentZoneView");
-
-        gridLayout_16->addWidget(GameView_aCloseMostRecentZoneView, 5, 1, 1, 1);
-
-        gridLayout_20->addWidget(groupBox_16, 0, 2, 1, 1);
-
-        groupBox_17 = new QGroupBox(tab_3);
-        groupBox_17->setObjectName("groupBox_17");
-        gridLayout_18 = new QGridLayout(groupBox_17);
-        gridLayout_18->setObjectName("gridLayout_18");
-        DeckViewContainer_loadRemoteButton = new SequenceEdit("DeckViewContainer/loadRemoteButton", groupBox_17);
-        DeckViewContainer_loadRemoteButton->setObjectName("DeckViewContainer_loadRemoteButton");
-
-        gridLayout_18->addWidget(DeckViewContainer_loadRemoteButton, 2, 1, 1, 1);
-
-        DeckViewContainer_loadLocalButton = new SequenceEdit("DeckViewContainer/loadLocalButton", groupBox_17);
-        DeckViewContainer_loadLocalButton->setObjectName("DeckViewContainer_loadLocalButton");
-
-        gridLayout_18->addWidget(DeckViewContainer_loadLocalButton, 0, 1, 1, 1);
-
-        lbl_DeckViewContainer_loadRemoteButton = new QLabel(groupBox_17);
-        lbl_DeckViewContainer_loadRemoteButton->setObjectName("lbl_DeckViewContainer_loadRemoteButton");
-
-        gridLayout_18->addWidget(lbl_DeckViewContainer_loadRemoteButton, 2, 0, 1, 1);
-
-        lbl_DeckViewContainer_loadLocalButton = new QLabel(groupBox_17);
-        lbl_DeckViewContainer_loadLocalButton->setObjectName("lbl_DeckViewContainer_loadLocalButton");
-
-        gridLayout_18->addWidget(lbl_DeckViewContainer_loadLocalButton, 0, 0, 1, 1);
-
-        gridLayout_20->addWidget(groupBox_17, 1, 0, 1, 1);
-
-        groupBox_18 = new QGroupBox(tab_3);
-        groupBox_18->setObjectName("groupBox_18");
-        gridLayout_19 = new QGridLayout(groupBox_18);
-        gridLayout_19->setObjectName("gridLayout_19");
-        lbl_Player_aDrawArrow = new QLabel(groupBox_18);
+        groupBox_gameplay = new QGroupBox(tab_3);
+        groupBox_gameplay->setObjectName("groupBox_gameplay");
+        gridLayout_gameplay = new QGridLayout(groupBox_gameplay);
+        gridLayout_gameplay->setObjectName("gridLayout_gameplay");
+        lbl_Player_aDrawArrow = new QLabel(groupBox_gameplay);
         lbl_Player_aDrawArrow->setObjectName("lbl_Player_aDrawArrow");
 
-        gridLayout_19->addWidget(lbl_Player_aDrawArrow, 0, 0, 1, 1);
+        gridLayout_gameplay->addWidget(lbl_Player_aDrawArrow, 0, 0, 1, 1);
 
-        Player_aDrawArrow = new SequenceEdit("Player/aDrawArrow", groupBox_18);
+        Player_aDrawArrow = new SequenceEdit("Player/aDrawArrow", groupBox_gameplay);
         Player_aDrawArrow->setObjectName("Player_aDrawArrow");
 
-        gridLayout_19->addWidget(Player_aDrawArrow, 0, 1, 1, 1);
+        gridLayout_gameplay->addWidget(Player_aDrawArrow, 0, 1, 1, 1);
 
-        lbl_TabGame_aLeaveGame = new QLabel(groupBox_18);
+        lbl_TabGame_aLeaveGame = new QLabel(groupBox_gameplay);
         lbl_TabGame_aLeaveGame->setObjectName("lbl_TabGame_aLeaveGame");
 
-        gridLayout_19->addWidget(lbl_TabGame_aLeaveGame, 0, 2, 1, 1);
+        gridLayout_gameplay->addWidget(lbl_TabGame_aLeaveGame, 0, 2, 1, 1);
 
-        TabGame_aLeaveGame = new SequenceEdit("Player/aLeaveGame", groupBox_18);
+        TabGame_aLeaveGame = new SequenceEdit("Player/aLeaveGame", groupBox_gameplay);
         TabGame_aLeaveGame->setObjectName("TabGame_aLeaveGame");
 
-        gridLayout_19->addWidget(TabGame_aLeaveGame, 0, 3, 1, 1);
+        gridLayout_gameplay->addWidget(TabGame_aLeaveGame, 0, 3, 1, 1);
 
-        lbl_TabGame_aRemoveLocalArrows = new QLabel(groupBox_18);
+        lbl_TabGame_aRemoveLocalArrows = new QLabel(groupBox_gameplay);
         lbl_TabGame_aRemoveLocalArrows->setObjectName("lbl_TabGame_aRemoveLocalArrows");
 
-        gridLayout_19->addWidget(lbl_TabGame_aRemoveLocalArrows, 1, 0, 1, 1);
+        gridLayout_gameplay->addWidget(lbl_TabGame_aRemoveLocalArrows, 1, 0, 1, 1);
 
-        TabGame_aRemoveLocalArrows = new SequenceEdit("Player/aRemoveLocalArrows", groupBox_18);
+        TabGame_aRemoveLocalArrows = new SequenceEdit("Player/aRemoveLocalArrows", groupBox_gameplay);
         TabGame_aRemoveLocalArrows->setObjectName("TabGame_aRemoveLocalArrows");
 
-        gridLayout_19->addWidget(TabGame_aRemoveLocalArrows, 1, 1, 1, 1);
+        gridLayout_gameplay->addWidget(TabGame_aRemoveLocalArrows, 1, 1, 1, 1);
 
-        lbl_TabGame_aConcede = new QLabel(groupBox_18);
+        lbl_TabGame_aConcede = new QLabel(groupBox_gameplay);
         lbl_TabGame_aConcede->setObjectName("lbl_TabGame_aConcede");
 
-        gridLayout_19->addWidget(lbl_TabGame_aConcede, 1, 2, 1, 1);
+        gridLayout_gameplay->addWidget(lbl_TabGame_aConcede, 1, 2, 1, 1);
 
-        TabGame_aConcede = new SequenceEdit("Player/aConcede", groupBox_18);
+        TabGame_aConcede = new SequenceEdit("Player/aConcede", groupBox_gameplay);
         TabGame_aConcede->setObjectName("TabGame_aConcede");
 
-        gridLayout_19->addWidget(TabGame_aConcede, 1, 3, 1, 1);
+        gridLayout_gameplay->addWidget(TabGame_aConcede, 1, 3, 1, 1);
 
-        lbl_Player_aRollDie = new QLabel(groupBox_18);
+        lbl_Player_aRollDie = new QLabel(groupBox_gameplay);
         lbl_Player_aRollDie->setObjectName("lbl_Player_aRollDie");
 
-        gridLayout_19->addWidget(lbl_Player_aRollDie, 2, 0, 1, 1);
+        gridLayout_gameplay->addWidget(lbl_Player_aRollDie, 2, 0, 1, 1);
 
-        Player_aRollDie = new SequenceEdit("Player/aRollDie", groupBox_18);
+        Player_aRollDie = new SequenceEdit("Player/aRollDie", groupBox_gameplay);
         Player_aRollDie->setObjectName("Player_aRollDie");
 
-        gridLayout_19->addWidget(Player_aRollDie, 2, 1, 1, 1);
+        gridLayout_gameplay->addWidget(Player_aRollDie, 2, 1, 1, 1);
 
-        lbl_TabGame_aRotateViewCW = new QLabel(groupBox_18);
+        lbl_TabGame_aRotateViewCW = new QLabel(groupBox_gameplay);
         lbl_TabGame_aRotateViewCW->setObjectName("lbl_TabGame_aRotateViewCW");
 
-        gridLayout_19->addWidget(lbl_TabGame_aRotateViewCW, 2, 2, 1, 1);
+        gridLayout_gameplay->addWidget(lbl_TabGame_aRotateViewCW, 2, 2, 1, 1);
 
-        TabGame_aRotateViewCW = new SequenceEdit("Player/aRotateViewCW", groupBox_18);
+        TabGame_aRotateViewCW = new SequenceEdit("Player/aRotateViewCW", groupBox_gameplay);
         TabGame_aRotateViewCW->setObjectName("TabGame_aRotateViewCW");
 
-        gridLayout_19->addWidget(TabGame_aRotateViewCW, 2, 3, 1, 1);
+        gridLayout_gameplay->addWidget(TabGame_aRotateViewCW, 2, 3, 1, 1);
 
-        lbl_Player_aShuffle = new QLabel(groupBox_18);
+        lbl_Player_aShuffle = new QLabel(groupBox_gameplay);
         lbl_Player_aShuffle->setObjectName("lbl_Player_aShuffle");
 
-        gridLayout_19->addWidget(lbl_Player_aShuffle, 3, 0, 1, 1);
+        gridLayout_gameplay->addWidget(lbl_Player_aShuffle, 3, 0, 1, 1);
 
-        Player_aShuffle = new SequenceEdit("Player/aShuffle", groupBox_18);
+        Player_aShuffle = new SequenceEdit("Player/aShuffle", groupBox_gameplay);
         Player_aShuffle->setObjectName("Player_aShuffle");
 
-        gridLayout_19->addWidget(Player_aShuffle, 3, 1, 1, 1);
+        gridLayout_gameplay->addWidget(Player_aShuffle, 3, 1, 1, 1);
 
-        lbl_TabGame_aRotateViewCCW = new QLabel(groupBox_18);
+        lbl_TabGame_aRotateViewCCW = new QLabel(groupBox_gameplay);
         lbl_TabGame_aRotateViewCCW->setObjectName("lbl_TabGame_aRotateViewCCW");
 
-        gridLayout_19->addWidget(lbl_TabGame_aRotateViewCCW, 3, 2, 1, 1);
+        gridLayout_gameplay->addWidget(lbl_TabGame_aRotateViewCCW, 3, 2, 1, 1);
 
-        TabGame_aRotateViewCCW = new SequenceEdit("Player/aRotateViewCCW", groupBox_18);
+        TabGame_aRotateViewCCW = new SequenceEdit("Player/aRotateViewCCW", groupBox_gameplay);
         TabGame_aRotateViewCCW->setObjectName("TabGame_aRotateViewCCW");
 
-        gridLayout_19->addWidget(TabGame_aRotateViewCCW, 3, 3, 1, 1);
+        gridLayout_gameplay->addWidget(TabGame_aRotateViewCCW, 3, 3, 1, 1);
 
-        gridLayout_20->addWidget(groupBox_18, 1, 1, 1, 2);
+        gridLayout_20->addWidget(groupBox_gameplay, 0, 0, 1, 2);
 
-        groupBox_14 = new QGroupBox(tab_3);
-        groupBox_14->setObjectName("groupBox_14");
-        gridLayout_14 = new QGridLayout(groupBox_14);
-        gridLayout_14->setObjectName("gridLayout_14");
-        lbl_Player_aMulligan = new QLabel(groupBox_14);
+        groupBox_moveCard = new QGroupBox(tab_3);
+        groupBox_moveCard->setObjectName("groupBox_moveCard");
+        gridLayout_moveCard = new QGridLayout(groupBox_moveCard);
+        gridLayout_moveCard->setObjectName("gridLayout_moveCard");
+        lbl_Player_aMoveToBottomLibrary = new QLabel(groupBox_moveCard);
+        lbl_Player_aMoveToBottomLibrary->setObjectName("lbl_Player_aMoveToBottomLibrary");
+
+        gridLayout_moveCard->addWidget(lbl_Player_aMoveToBottomLibrary, 0, 0, 1, 1);
+
+        Player_aMoveToBottomLibrary = new SequenceEdit("Player/aMoveToBottomLibrary", groupBox_moveCard);
+        Player_aMoveToBottomLibrary->setObjectName("Player_aMoveToBottomLibrary");
+
+        gridLayout_moveCard->addWidget(Player_aMoveToBottomLibrary, 0, 1, 1, 1);
+
+        lbl_Player_aMoveToTopLibrary = new QLabel(groupBox_moveCard);
+        lbl_Player_aMoveToTopLibrary->setObjectName("lbl_Player_aMoveToTopLibrary");
+
+        gridLayout_moveCard->addWidget(lbl_Player_aMoveToTopLibrary, 1, 0, 1, 1);
+
+        Player_aMoveToTopLibrary = new SequenceEdit("Player/aMoveToTopLibrary", groupBox_moveCard);
+        Player_aMoveToTopLibrary->setObjectName("Player_aMoveToTopLibrary");
+
+        gridLayout_moveCard->addWidget(Player_aMoveToTopLibrary, 1, 1, 1, 1);
+
+        lbl_Player_aMoveToGraveyard = new QLabel(groupBox_moveCard);
+        lbl_Player_aMoveToGraveyard->setObjectName("lbl_Player_aMoveToGraveyard");
+
+        gridLayout_moveCard->addWidget(lbl_Player_aMoveToGraveyard, 2, 0, 1, 1);
+
+        Player_aMoveToGraveyard = new SequenceEdit("Player/aMoveToGraveyard", groupBox_moveCard);
+        Player_aMoveToGraveyard->setObjectName("Player_aMoveToGraveyard");
+
+        gridLayout_moveCard->addWidget(Player_aMoveToGraveyard, 2, 1, 1, 1);
+
+        lbl_Player_aMoveToExile = new QLabel(groupBox_moveCard);
+        lbl_Player_aMoveToExile->setObjectName("lbl_Player_aMoveToExile");
+
+        gridLayout_moveCard->addWidget(lbl_Player_aMoveToExile, 3, 0, 1, 1);
+
+        Player_aMoveToExile = new SequenceEdit("Player/aMoveToExile", groupBox_moveCard);
+        Player_aMoveToExile->setObjectName("Player_aMoveToExile");
+
+        gridLayout_moveCard->addWidget(Player_aMoveToExile, 3, 1, 1, 1);
+
+        lbl_Player_aMoveToHand = new QLabel(groupBox_moveCard);
+        lbl_Player_aMoveToHand->setObjectName("lbl_Player_aMoveToHand");
+
+        gridLayout_moveCard->addWidget(lbl_Player_aMoveToHand, 4, 0, 1, 1);
+
+        Player_aMoveToHand = new SequenceEdit("Player/aMoveToHand", groupBox_moveCard);
+        Player_aMoveToHand->setObjectName("Player_aMoveToHand");
+
+        gridLayout_moveCard->addWidget(Player_aMoveToHand, 4, 1, 1, 1);
+
+        lbl_Player_aMoveTopToPlayFaceDown = new QLabel(groupBox_moveCard);
+        lbl_Player_aMoveTopToPlayFaceDown->setObjectName("lbl_Player_aMoveTopToPlayFaceDown");
+
+        gridLayout_moveCard->addWidget(lbl_Player_aMoveTopToPlayFaceDown, 5, 0, 1, 1);
+
+        Player_aMoveTopToPlayFaceDown = new SequenceEdit("Player/aMoveTopToPlayFaceDown", groupBox_moveCard);
+        Player_aMoveTopToPlayFaceDown->setObjectName("Player_aMoveTopToPlayFaceDown");
+
+        gridLayout_moveCard->addWidget(Player_aMoveTopToPlayFaceDown, 5, 1, 1, 1);
+
+        gridLayout_20->addWidget(groupBox_moveCard, 0, 1, 1, 1);
+
+        groupBox_view = new QGroupBox(tab_3);
+        groupBox_view->setObjectName("groupBox_view");
+        gridLayout_view = new QGridLayout(groupBox_view);
+        gridLayout_view->setObjectName("gridLayout_view");
+        lbl_Player_aViewGraveyard = new QLabel(groupBox_view);
+        lbl_Player_aViewGraveyard->setObjectName("lbl_Player_aViewGraveyard");
+
+        gridLayout_view->addWidget(lbl_Player_aViewGraveyard, 0, 0, 1, 1);
+
+        Player_aViewGraveyard = new SequenceEdit("Player/aViewGraveyard", groupBox_view);
+        Player_aViewGraveyard->setObjectName("Player_aViewGraveyard");
+
+        gridLayout_view->addWidget(Player_aViewGraveyard, 0, 1, 1, 1);
+
+        lbl_Player_aViewLibrary = new QLabel(groupBox_view);
+        lbl_Player_aViewLibrary->setObjectName("lbl_Player_aViewLibrary");
+
+        gridLayout_view->addWidget(lbl_Player_aViewLibrary, 1, 0, 1, 1);
+
+        Player_aViewLibrary = new SequenceEdit("Player/aViewLibrary", groupBox_view);
+        Player_aViewLibrary->setObjectName("Player_aViewLibrary");
+
+        gridLayout_view->addWidget(Player_aViewLibrary, 1, 1, 1, 1);
+
+        lbl_Player_aViewTopCards = new QLabel(groupBox_view);
+        lbl_Player_aViewTopCards->setObjectName("lbl_Player_aViewTopCards");
+
+        gridLayout_view->addWidget(lbl_Player_aViewTopCards, 2, 0, 1, 1);
+
+        Player_aViewTopCards = new SequenceEdit("Player/aViewTopCards", groupBox_view);
+        Player_aViewTopCards->setObjectName("Player_aViewTopCards");
+
+        gridLayout_view->addWidget(Player_aViewTopCards, 2, 1, 1, 1);
+
+        lbl_Player_aViewSideboard = new QLabel(groupBox_view);
+        lbl_Player_aViewSideboard->setObjectName("lbl_Player_aViewSideboard");
+
+        gridLayout_view->addWidget(lbl_Player_aViewSideboard, 3, 0, 1, 1);
+
+        Player_aViewSideboard = new SequenceEdit("Player/aViewSideboard", groupBox_view);
+        Player_aViewSideboard->setObjectName("Player_aViewSideboard");
+
+        gridLayout_view->addWidget(Player_aViewSideboard, 3, 1, 1, 1);
+
+        lbl_Player_aViewRfg = new QLabel(groupBox_view);
+        lbl_Player_aViewRfg->setObjectName("lbl_Player_aViewRfg");
+
+        gridLayout_view->addWidget(lbl_Player_aViewRfg, 4, 0, 1, 1);
+
+        Player_aViewRfg = new SequenceEdit("Player/aViewRfg", groupBox_view);
+        Player_aViewRfg->setObjectName("Player_aViewRfg");
+
+        gridLayout_view->addWidget(Player_aViewRfg, 4, 1, 1, 1);
+
+        lbl_GameView_aCloseMostRecentZoneView = new QLabel(groupBox_view);
+        lbl_GameView_aCloseMostRecentZoneView->setObjectName("lbl_GameView_aCloseMostRecentZoneView");
+
+        gridLayout_view->addWidget(lbl_GameView_aCloseMostRecentZoneView, 5, 0, 1, 1);
+
+        GameView_aCloseMostRecentZoneView = new SequenceEdit("Player/aCloseMostRecentZoneView", groupBox_view);
+        GameView_aCloseMostRecentZoneView->setObjectName("GameView_aCloseMostRecentZoneView");
+
+        gridLayout_view->addWidget(GameView_aCloseMostRecentZoneView, 5, 1, 1, 1);
+
+        gridLayout_20->addWidget(groupBox_view, 0, 2, 1, 1);
+
+        groupBox_draw = new QGroupBox(tab_3);
+        groupBox_draw->setObjectName("groupBox_draw");
+        gridLayout_draw = new QGridLayout(groupBox_draw);
+        gridLayout_draw->setObjectName("gridLayout_draw");
+        lbl_Player_aMulligan = new QLabel(groupBox_draw);
         lbl_Player_aMulligan->setObjectName("lbl_Player_aMulligan");
 
-        gridLayout_14->addWidget(lbl_Player_aMulligan, 4, 0, 1, 1);
+        gridLayout_draw->addWidget(lbl_Player_aMulligan, 4, 0, 1, 1);
 
-        Player_aMulligan = new SequenceEdit("Player/aMulligan", groupBox_14);
+        Player_aMulligan = new SequenceEdit("Player/aMulligan", groupBox_draw);
         Player_aMulligan->setObjectName("Player_aMulligan");
 
-        gridLayout_14->addWidget(Player_aMulligan, 4, 1, 1, 1);
+        gridLayout_draw->addWidget(Player_aMulligan, 4, 1, 1, 1);
 
-        lbl_Player_aDrawCard = new QLabel(groupBox_14);
+        lbl_Player_aDrawCard = new QLabel(groupBox_draw);
         lbl_Player_aDrawCard->setObjectName("lbl_Player_aDrawCard");
 
-        gridLayout_14->addWidget(lbl_Player_aDrawCard, 0, 0, 1, 1);
+        gridLayout_draw->addWidget(lbl_Player_aDrawCard, 0, 0, 1, 1);
 
-        Player_aDrawCard = new SequenceEdit("Player/aDrawCard", groupBox_14);
+        Player_aDrawCard = new SequenceEdit("Player/aDrawCard", groupBox_draw);
         Player_aDrawCard->setObjectName("Player_aDrawCard");
 
-        gridLayout_14->addWidget(Player_aDrawCard, 0, 1, 1, 1);
+        gridLayout_draw->addWidget(Player_aDrawCard, 0, 1, 1, 1);
 
-        lbl_Player_aDrawCards = new QLabel(groupBox_14);
+        lbl_Player_aDrawCards = new QLabel(groupBox_draw);
         lbl_Player_aDrawCards->setObjectName("lbl_Player_aDrawCards");
 
-        gridLayout_14->addWidget(lbl_Player_aDrawCards, 1, 0, 1, 1);
+        gridLayout_draw->addWidget(lbl_Player_aDrawCards, 1, 0, 1, 1);
 
-        Player_aDrawCards = new SequenceEdit("Player/aDrawCards", groupBox_14);
+        Player_aDrawCards = new SequenceEdit("Player/aDrawCards", groupBox_draw);
         Player_aDrawCards->setObjectName("Player_aDrawCards");
 
-        gridLayout_14->addWidget(Player_aDrawCards, 1, 1, 1, 1);
+        gridLayout_draw->addWidget(Player_aDrawCards, 1, 1, 1, 1);
 
-        lbl_Player_aUndoDraw = new QLabel(groupBox_14);
+        lbl_Player_aUndoDraw = new QLabel(groupBox_draw);
         lbl_Player_aUndoDraw->setObjectName("lbl_Player_aUndoDraw");
 
-        gridLayout_14->addWidget(lbl_Player_aUndoDraw, 2, 0, 1, 1);
+        gridLayout_draw->addWidget(lbl_Player_aUndoDraw, 2, 0, 1, 1);
 
-        Player_aUndoDraw = new SequenceEdit("Player/aUndoDraw", groupBox_14);
+        Player_aUndoDraw = new SequenceEdit("Player/aUndoDraw", groupBox_draw);
         Player_aUndoDraw->setObjectName("Player_aUndoDraw");
 
-        gridLayout_14->addWidget(Player_aUndoDraw, 2, 1, 1, 1);
+        gridLayout_draw->addWidget(Player_aUndoDraw, 2, 1, 1, 1);
 
-        lbl_Player_aAlwaysRevealTopCard = new QLabel(groupBox_14);
+        lbl_Player_aAlwaysRevealTopCard = new QLabel(groupBox_draw);
         lbl_Player_aAlwaysRevealTopCard->setObjectName("lbl_Player_aAlwaysRevealTopCard");
 
-        gridLayout_14->addWidget(lbl_Player_aAlwaysRevealTopCard, 3, 0, 1, 1);
+        gridLayout_draw->addWidget(lbl_Player_aAlwaysRevealTopCard, 3, 0, 1, 1);
 
-        Player_aAlwaysRevealTopCard = new SequenceEdit("Player/aAlwaysRevealTopCard", groupBox_14);
+        Player_aAlwaysRevealTopCard = new SequenceEdit("Player/aAlwaysRevealTopCard", groupBox_draw);
         Player_aAlwaysRevealTopCard->setObjectName("Player_aAlwaysRevealTopCard");
 
-        gridLayout_14->addWidget(Player_aAlwaysRevealTopCard, 3, 1, 1, 1);
-        gridLayout_20->addWidget(groupBox_14, 0, 0, 1, 1);
+        gridLayout_draw->addWidget(Player_aAlwaysRevealTopCard, 3, 1, 1, 1);
+        gridLayout_20->addWidget(groupBox_draw, 0, 1, 1, 1);
+
+        groupBox_moveDeck = new QGroupBox(tab_3);
+        groupBox_moveDeck->setObjectName("groupBox_moveDeck");
+        gridLayout_moveDeck = new QGridLayout(groupBox_moveDeck);
+        gridLayout_moveDeck->setObjectName("gridLayout_moveDeck");
+        lbl_Player_aMoveTopCardToGraveyard = new QLabel(groupBox_moveDeck);
+        lbl_Player_aMoveTopCardToGraveyard->setObjectName("lbl_Player_aMoveTopCardToGraveyard");
+
+        gridLayout_moveDeck->addWidget(lbl_Player_aMoveTopCardToGraveyard, 0, 0, 1, 1);
+
+        lbl_Player_aMoveTopCardToExile = new QLabel(groupBox_moveDeck);
+        lbl_Player_aMoveTopCardToExile->setObjectName("lbl_Player_aMoveTopCardToExile");
+
+        gridLayout_moveDeck->addWidget(lbl_Player_aMoveTopCardToGraveyard, 1, 0, 1, 1);
+
+        lbl_Player_aMoveTopCardsToGraveyard = new QLabel(groupBox_moveDeck);
+        lbl_Player_aMoveTopCardsToGraveyard->setObjectName("lbl_Player_aMoveTopCardToGraveyard");
+
+        gridLayout_moveDeck->addWidget(lbl_Player_aMoveTopCardsToGraveyard, 2, 0, 1, 1);
+
+        lbl_Player_aMoveTopCardsToExile = new QLabel(groupBox_moveDeck);
+        lbl_Player_aMoveTopCardsToExile->setObjectName("lbl_Player_aMoveTopCardToExile");
+
+        gridLayout_moveDeck->addWidget(lbl_Player_aMoveTopCardsToGraveyard, 3, 0, 1, 1);
+
+        gridLayout_20->addWidget(groupBox_moveDeck, 1, 1, 1, 1);
+
+        groupBox_gameLobby = new QGroupBox(tab_3);
+        groupBox_gameLobby->setObjectName("groupBox_gameLobby");
+        gridLayout_gameLobby = new QGridLayout(groupBox_gameLobby);
+        gridLayout_gameLobby->setObjectName("gridLayout_gameLobby");
+        DeckViewContainer_loadRemoteButton = new SequenceEdit("DeckViewContainer/loadRemoteButton", groupBox_gameLobby);
+        DeckViewContainer_loadRemoteButton->setObjectName("DeckViewContainer_loadRemoteButton");
+
+        gridLayout_gameLobby->addWidget(DeckViewContainer_loadRemoteButton, 2, 1, 1, 1);
+
+        DeckViewContainer_loadLocalButton = new SequenceEdit("DeckViewContainer/loadLocalButton", groupBox_gameLobby);
+        DeckViewContainer_loadLocalButton->setObjectName("DeckViewContainer_loadLocalButton");
+
+        gridLayout_gameLobby->addWidget(DeckViewContainer_loadLocalButton, 0, 1, 1, 1);
+
+        lbl_DeckViewContainer_loadRemoteButton = new QLabel(groupBox_gameLobby);
+        lbl_DeckViewContainer_loadRemoteButton->setObjectName("lbl_DeckViewContainer_loadRemoteButton");
+
+        gridLayout_gameLobby->addWidget(lbl_DeckViewContainer_loadRemoteButton, 2, 0, 1, 1);
+
+        lbl_DeckViewContainer_loadLocalButton = new QLabel(groupBox_gameLobby);
+        lbl_DeckViewContainer_loadLocalButton->setObjectName("lbl_DeckViewContainer_loadLocalButton");
+
+        gridLayout_gameLobby->addWidget(lbl_DeckViewContainer_loadLocalButton, 0, 0, 1, 1);
+
+        gridLayout_20->addWidget(groupBox_gameLobby, 1, 2, 1, 1);
+
         verticalSpacer_3 = new QSpacerItem(20, 40, QSizePolicy::Minimum, QSizePolicy::Expanding);
         gridLayout_20->addItem(verticalSpacer_3, 2, 1, 1, 1);
         tabWidget->addTab(tab_3, QString());
@@ -1747,12 +1785,13 @@ public:
         gridLayout_11->setSpacing(3);
         gridLayout_12->setSpacing(3);
         gridLayout_13->setSpacing(3);
-        gridLayout_14->setSpacing(3);
-        gridLayout_15->setSpacing(3);
-        gridLayout_16->setSpacing(3);
+        gridLayout_moveDeck->setSpacing(3);
+        gridLayout_draw->setSpacing(3);
+        gridLayout_moveCard->setSpacing(3);
+        gridLayout_view->setSpacing(3);
+        gridLayout_gameLobby->setSpacing(3);
+        gridLayout_gameplay->setSpacing(3);
         gridLayout_17->setSpacing(3);
-        gridLayout_18->setSpacing(3);
-        gridLayout_19->setSpacing(3);
         gridLayout_20->setSpacing(3);
 
         verticalLayout->setSpacing(3);
@@ -1893,24 +1932,28 @@ public:
         lbl_Player_aSetAnnotation->setText(QApplication::translate("shortcutsTab", "Set annotation", 0));
         tabWidget->setTabText(tabWidget->indexOf(tab_2),
                               QApplication::translate("shortcutsTab", "Phases | P/T | Playing Area", 0));
-        groupBox_15->setTitle(QApplication::translate("shortcutsTab", "Move card to", 0));
+        groupBox_moveCard->setTitle(QApplication::translate("shortcutsTab", "Move selected card to", 0));
         lbl_Player_aMoveToBottomLibrary->setText(QApplication::translate("shortcutsTab", "Bottom library", 0));
         lbl_Player_aMoveToTopLibrary->setText(QApplication::translate("shortcutsTab", "Top library", 0));
         lbl_Player_aMoveToGraveyard->setText(QApplication::translate("shortcutsTab", "Graveyard", 0));
         lbl_Player_aMoveToExile->setText(QApplication::translate("shortcutsTab", "Exile", 0));
         lbl_Player_aMoveToHand->setText(QApplication::translate("shortcutsTab", "Hand", 0));
         lbl_Player_aMoveTopToPlayFaceDown->setText(QApplication::translate("shortcutsTab", "Play face down"));
-        groupBox_16->setTitle(QApplication::translate("shortcutsTab", "View", 0));
+        groupBox_view->setTitle(QApplication::translate("shortcutsTab", "View", 0));
         lbl_Player_aViewGraveyard->setText(QApplication::translate("shortcutsTab", "Graveyard", 0));
         lbl_Player_aViewLibrary->setText(QApplication::translate("shortcutsTab", "Library", 0));
         lbl_Player_aViewTopCards->setText(QApplication::translate("shortcutsTab", "Tops card of library", 0));
         lbl_Player_aViewSideboard->setText(QApplication::translate("shortcutsTab", "Sideboard", 0));
         lbl_Player_aViewRfg->setText(QApplication::translate("shortcutsTab", "Exile", 0));
-        lbl_GameView_aCloseMostRecentZoneView->setText(QApplication::translate("shortcutsTab", "Close recent view", 0));
-        groupBox_17->setTitle(QApplication::translate("shortcutsTab", "Game Lobby", 0));
+        groupBox_moveDeck->setTitle(QApplication::translate("shortcutsTab", "Move top card to", 0));
+        lbl_Player_aMoveTopCardToGraveyard->setText(QApplication::translate("shortcutsTab", "Graveyard Once", 0));
+        lbl_Player_aMoveTopCardsToGraveyard->setText(QApplication::translate("shortcutsTab", "Graveyard Multiple", 0));
+        lbl_Player_aMoveTopCardToExile->setText(QApplication::translate("shortcutsTab", "Exile Once", 0));
+        lbl_Player_aMoveTopCardsToExile->setText(QApplication::translate("shortcutsTab", "Exile Multiple", 0));
+        groupBox_gameLobby->setTitle(QApplication::translate("shortcutsTab", "Game Lobby", 0));
         lbl_DeckViewContainer_loadRemoteButton->setText(QApplication::translate("shortcutsTab", "Load remote deck", 0));
         lbl_DeckViewContainer_loadLocalButton->setText(QApplication::translate("shortcutsTab", "Load local deck", 0));
-        groupBox_18->setTitle(QApplication::translate("shortcutsTab", "Gameplay", 0));
+        groupBox_gameplay->setTitle(QApplication::translate("shortcutsTab", "Gameplay", 0));
         lbl_Player_aDrawArrow->setText(QApplication::translate("shortcutsTab", "Draw arrow", 0));
         lbl_TabGame_aLeaveGame->setText(QApplication::translate("shortcutsTab", "Leave game", 0));
         lbl_TabGame_aRemoveLocalArrows->setText(QApplication::translate("shortcutsTab", "Remove local arrows", 0));
@@ -1919,14 +1962,14 @@ public:
         lbl_TabGame_aRotateViewCW->setText(QApplication::translate("shortcutsTab", "Rotate view CW", 0));
         lbl_Player_aShuffle->setText(QApplication::translate("shortcutsTab", "Shuffle library", 0));
         lbl_TabGame_aRotateViewCCW->setText(QApplication::translate("shortcutsTab", "Rotate view CCW", 0));
-        groupBox_14->setTitle(QApplication::translate("shortcutsTab", "Draw", 0));
+        groupBox_draw->setTitle(QApplication::translate("shortcutsTab", "Draw", 0));
         lbl_Player_aMulligan->setText(QApplication::translate("shortcutsTab", "Mulligan", 0));
         lbl_Player_aDrawCard->setText(QApplication::translate("shortcutsTab", "Draw card", 0));
         lbl_Player_aDrawCards->setText(QApplication::translate("shortcutsTab", "Draw cards", 0));
         lbl_Player_aUndoDraw->setText(QApplication::translate("shortcutsTab", "Undo draw", 0));
         lbl_Player_aAlwaysRevealTopCard->setText(QApplication::translate("shortcutsTab", "Always reveal top card", 0));
         tabWidget->setTabText(tabWidget->indexOf(tab_3),
-                              QApplication::translate("shortcutsTab", "Draw | Move | View | Gameplay", 0));
+                              QApplication::translate("shortcutsTab", "Gameplay | Draw | Move | View", 0));
         tabWidget->setTabText(tabWidget->indexOf(tab_4), QApplication::translate("shortcutsTab", "Counters", 0));
         faqLabel->setText(QString("<a href='%1'>%2</a>")
                               .arg(WIKI)

--- a/cockatrice/src/shortcutssettings.cpp
+++ b/cockatrice/src/shortcutssettings.cpp
@@ -253,6 +253,10 @@ void ShortcutsSettings::fillDefaultShorcuts()
     defaultShortCuts["Player/aMoveToGraveyard"] = parseSequenceString("Ctrl+Del");
     defaultShortCuts["Player/aMoveToHand"] = parseSequenceString("");
     defaultShortCuts["Player/aMoveToTopLibrary"] = parseSequenceString("");
+    defaultShortCuts["Player/aMoveTopCardToGraveyard"] = parseSequenceString("Ctrl+Alt+D");
+    defaultShortCuts["Player/aMoveTopCardsToGraveyard"] = parseSequenceString("Ctrl+Alt+E");
+    defaultShortCuts["Player/aMoveTopCardToExile"] = parseSequenceString("");
+    defaultShortCuts["Player/aMoveTopCardsToExile"] = parseSequenceString("");
     defaultShortCuts["Player/aMulligan"] = parseSequenceString("Ctrl+M");
     defaultShortCuts["Player/aPeek"] = parseSequenceString("");
     defaultShortCuts["Player/aPlay"] = parseSequenceString("");


### PR DESCRIPTION
Add functions to move single card from top of deck to the graveyard and
exile.
Add keybinds to move single or multiple cards from top of deck to exile
or graveyard.
Add new keybinds to settings menu.
Move settings menu items around for a better fit.
Rename a few of the items in the settings menu.
Add default keybinds: ctrl alt d/e for single/multiple cards from top of
deck to the graveyard. No defaults are set for moving to exile.

Note this will require some translating.