### PR TITLE
travis: exclude mac debug build on tagged release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ matrix:
 
   #macOS
   - name: macOS (Debug)
+    if: tag IS NOT present
     os: osx
     osx_image: xcode8
     before_install:


### PR DESCRIPTION
On tagged releases we only build `BUILDTYPE=release` for a speedy deployment.

This got left out in #3433 during the refactor.