### PR TITLE
travis speedups

### DIFF
--- a/.ci/UbuntuBionic/Dockerfile
+++ b/.ci/UbuntuBionic/Dockerfile
@@ -18,4 +18,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         qttools5-dev \
         qttools5-dev-tools \
         qtmultimedia5-dev \
+    && apt-get clean
     && rm -rf /var/lib/apt/lists/*

--- a/.ci/UbuntuBionic/Dockerfile
+++ b/.ci/UbuntuBionic/Dockerfile
@@ -18,5 +18,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         qttools5-dev \
         qttools5-dev-tools \
         qtmultimedia5-dev \
-    && apt-get clean
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/.ci/travis-docker.sh
+++ b/.ci/travis-docker.sh
@@ -113,7 +113,6 @@ function RUN ()
     if [[ $CCACHE_DIR ]]; then
       args+=" --mount type=bind,source=$CCACHE_DIR,target=/.ccache -e CCACHE_DIR=/.ccache"
     fi
-    echo $args #debug
     docker run $args $RUN_ARGS "$IMAGE_NAME" bash ".ci/travis-compile.sh" $RUN_OPTS $@
     return $?
   else

--- a/.ci/travis-docker.sh
+++ b/.ci/travis-docker.sh
@@ -90,8 +90,9 @@ if [[ $GET ]]; then
     docker images
     unset BUILD # do not overwrite the loaded image with build
     unset SAVE # do not overwrite the stored image with the same image
-    if [[ $(find "$ccache_dir" -print -quit) ]]; then
+    if find "$ccache_dir/*" -print -quit; then
       export CACHE="/tmp/cache" # do not overwrite ccache and save it in tmp
+      echo "preserving cache to $CACHE"
       mkdir -p "$CACHE"
       cp -rn "$ccache_dir" "$CACHE/.ccache"
     fi

--- a/.ci/travis-docker.sh
+++ b/.ci/travis-docker.sh
@@ -90,11 +90,13 @@ if [[ $GET ]]; then
     docker images
     unset BUILD # do not overwrite the loaded image with build
     unset SAVE # do not overwrite the stored image with the same image
-    if find "$ccache_dir/*" -print -quit; then
+    if find "$ccache_dir/*" -quit; then
       export CACHE="/tmp/cache" # do not overwrite ccache and save it in tmp
       echo "preserving cache to $CACHE"
       mkdir -p "$CACHE"
       cp -rn "$ccache_dir" "$CACHE/.ccache"
+    else
+      echo "ccache is empty: $(find $ccache_dir)" >&2
     fi
   else
     echo "could not load cached image, building instead" >&2

--- a/.ci/travis-docker.sh
+++ b/.ci/travis-docker.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# This script is to be used in .travis.yaml from the project root directory, do not use it from somewhere else.
+
+set -e
+
+project_name="cockatrice"
+compile=".ci/travis-compile.sh"
+
+# Read arguments
+while [[ "$@" ]]; do
+  case "$1" in
+    '--build')
+      BUILD=1
+      shift
+      ;;
+    '--get')
+      GET=1
+      shift
+      ;;
+    '--run' | '--run-arg')
+      RUN=1
+      if [[ $1 == --run-arg ]]; then
+        RUN_ARGS="$RUN_ARGS $2"
+      else
+        RUN_OPTS="$RUN_OPTS $2"
+      fi
+      shift 2
+      ;;
+    '--save')
+      SAVE=1
+      shift
+      ;;
+    '--set-cache')
+      CACHE=$2
+      if ! [[ -d $CACHE ]]; then
+        echo "could not find cache path: $CACHE" >&2
+        exit 3
+      fi
+      shift 2
+      ;;
+    *)
+      if [[ $1 == -* ]]; then
+        echo "unrecognized option: $1"
+        exit 3
+      fi
+      NAME="$1"
+      shift
+      ;;
+  esac
+done
+
+# Setup
+if ! [[ $NAME ]]; then
+  echo "no build name given" >&2
+  exit 3
+fi
+
+docker_dir=".ci/$NAME"
+if ! [[ -r $docker_dir/Dockerfile ]]; then
+  echo "could not find dockerfile in $docker_dir" >&2
+  exit 2 # even if the image is cached, we do not want to run if there is no build file associated with this image
+fi
+
+img="${project_name,,}_${NAME,,}"
+
+[[ $CACHE ]] || CACHE="$HOME/$NAME"
+if ! [[ -d $CACHE ]]; then
+  echo "could not find cache dir: $CACHE" >&2
+  unset CACHE
+else
+  img_save="$CACHE/$img.tar.gz"
+  ccache_dir="$CACHE/.ccache"
+  if ! [[ -d $ccache_dir ]]; then
+    echo "could not find ccache dir: $ccache_dir" >&2
+    mkdir -p "$ccache_dir"
+  fi
+fi
+
+
+# Get the docker image
+if [[ $GET ]]; then
+  if [[ $img_save ]] && docker load --input "$img_save"; then
+    echo "loaded image"
+    docker images
+    unset BUILD # do not overwrite the loaded image with build
+    unset SAVE # do not overwrite the stored image with the same image
+  else
+    echo "could not load cached image, building instead" >&2
+    BUILD=1
+  fi
+fi
+
+# Build the docker image
+if [[ $BUILD ]]; then
+  docker build --tag "$img" "$docker_dir"
+  echo "built image"
+  docker images
+fi
+
+# Run compilation on the docker image
+if [[ $RUN ]]; then
+  if docker images | grep "$img"; then
+    args="--mount type=bind,source=$(pwd),target=/src -w=/src"
+    if [[ $ccache_dir ]]; then
+      args+=" --mount type=bind,source=$ccache_dir,target=/.ccache -e CCACHE_DIR=/.ccache"
+    fi
+    docker run $args $RUN_ARGS "$img" bash "$compile" $RUN_OPTS
+  else
+    echo "could not find docker image: $img" >&2
+  fi
+fi
+
+# Save to cache
+if [[ $SAVE ]]; then
+  if [[ $img_save ]]; then
+    docker save --output "$img_save" "$img"
+  else
+    echo "could not save image $img" >&2
+  fi
+fi

--- a/.ci/travis-docker.sh
+++ b/.ci/travis-docker.sh
@@ -91,6 +91,7 @@ if [[ $BUILD ]]; then
     docker images
   else
     echo "could not build image $IMAGE_NAME" >&2
+    return 1
   fi
 fi
 

--- a/.ci/travis-docker.sh
+++ b/.ci/travis-docker.sh
@@ -90,7 +90,7 @@ if [[ $GET ]]; then
     docker images
     unset BUILD # do not overwrite the loaded image with build
     unset SAVE # do not overwrite the stored image with the same image
-    if [[ $(find "$ccache_dir" -type f -quit) ]]; then
+    if [[ $(find "$ccache_dir" -type f -print -quit) ]]; then
       export CACHE="/tmp/cache" # do not overwrite ccache and save it in tmp
       echo "preserving cache to $CACHE"
       mkdir -p "$CACHE"

--- a/.ci/travis-docker.sh
+++ b/.ci/travis-docker.sh
@@ -70,11 +70,7 @@ if [[ $GET ]]; then
     unset BUILD # do not overwrite the loaded image with build
     unset SAVE # do not overwrite the stored image with the same image
     if [[ $(find "$CCACHE_DIR" -type f -print -quit) ]]; then # check contents of ccache
-      old_ccache="$CCACHE_DIR"
-      export CCACHE_DIR="/tmp/.ccache" # do not overwrite ccache and save it in tmp
-      echo "preserving ccache to $CCACHE_DIR"
-      mkdir -p "$CCACHE_DIR"
-      cp -rn "$old_ccache" "$CCACHE_DIR" # copy ccache to new dir
+      export RUN_ARGS="$RUN_ARGS -e CCACHE_READONLY=1" # do not overwrite ccache and save it in tmp
     else
       echo "ccache is empty: $(find "$CCACHE_DIR")" >&2
     fi

--- a/.ci/travis-docker.sh
+++ b/.ci/travis-docker.sh
@@ -90,13 +90,13 @@ if [[ $GET ]]; then
     docker images
     unset BUILD # do not overwrite the loaded image with build
     unset SAVE # do not overwrite the stored image with the same image
-    if find "$ccache_dir/*" -quit; then
+    if [[ $(find "$ccache_dir" -type f -quit) ]]; then
       export CACHE="/tmp/cache" # do not overwrite ccache and save it in tmp
       echo "preserving cache to $CACHE"
       mkdir -p "$CACHE"
       cp -rn "$ccache_dir" "$CACHE/.ccache"
     else
-      echo "ccache is empty: $(find $ccache_dir)" >&2
+      echo "ccache is empty: $(find "$ccache_dir")" >&2
     fi
   else
     echo "could not load cached image, building instead" >&2

--- a/.ci/travis-docker.sh
+++ b/.ci/travis-docker.sh
@@ -90,6 +90,9 @@ if [[ $GET ]]; then
     docker images
     unset BUILD # do not overwrite the loaded image with build
     unset SAVE # do not overwrite the stored image with the same image
+    export CACHE="/tmp/cache" # do not overwrite ccache and save it in tmp
+    mkdir -p "$CACHE"
+    cp -rn "$ccache_dir" "$CACHE/.ccache"
   else
     echo "could not load cached image, building instead" >&2
     BUILD=1

--- a/.ci/travis-docker.sh
+++ b/.ci/travis-docker.sh
@@ -90,9 +90,11 @@ if [[ $GET ]]; then
     docker images
     unset BUILD # do not overwrite the loaded image with build
     unset SAVE # do not overwrite the stored image with the same image
-    export CACHE="/tmp/cache" # do not overwrite ccache and save it in tmp
-    mkdir -p "$CACHE"
-    cp -rn "$ccache_dir" "$CACHE/.ccache"
+    if [[ $(find "$ccache_dir" -print -quit) ]]; then
+      export CACHE="/tmp/cache" # do not overwrite ccache and save it in tmp
+      mkdir -p "$CACHE"
+      cp -rn "$ccache_dir" "$CACHE/.ccache"
+    fi
   else
     echo "could not load cached image, building instead" >&2
     BUILD=1
@@ -114,9 +116,12 @@ if [[ $RUN ]]; then
     if [[ $ccache_dir ]]; then
       args+=" --mount type=bind,source=$ccache_dir,target=/.ccache -e CCACHE_DIR=/.ccache"
     fi
+    set -x
     docker run $args $RUN_ARGS "$img" bash "$compile" $RUN_OPTS
+    set +x
   else
     echo "could not find docker image: $img" >&2
+    exit 1
   fi
 fi
 

--- a/.ci/travis-docker.sh
+++ b/.ci/travis-docker.sh
@@ -70,7 +70,7 @@ if [[ $GET ]]; then
     unset BUILD # do not overwrite the loaded image with build
     unset SAVE # do not overwrite the stored image with the same image
     if [[ $(find "$CCACHE_DIR" -type f -print -quit) ]]; then # check contents of ccache
-      export RUN_ARGS="$RUN_ARGS -e CCACHE_READONLY=1" # do not overwrite ccache and save it in tmp
+      export RUN_ARGS="$RUN_ARGS -e CCACHE_READONLY=1 -e CCACHE_NOSTATS=1" # do not overwrite ccache to avoid reuploading
     else
       echo "ccache is empty: $(find "$CCACHE_DIR")" >&2
     fi

--- a/.ci/travis-docker.sh
+++ b/.ci/travis-docker.sh
@@ -80,18 +80,19 @@ else
     echo "could not find ccache dir: $ccache_dir" >&2
     mkdir -p "$ccache_dir"
   fi
+  cp -rn "$ccache_dir" "$HOME/.ccache" # move our ccache dir to not change its contents
+  ccache_dir="$HOME/.ccache"
 fi
 
 
 # Get the docker image
 if [[ $GET ]]; then
+
   if [[ $img_save ]] && docker load --input "$img_save"; then
     echo "loaded image"
     docker images
     unset BUILD # do not overwrite the loaded image with build
     unset SAVE # do not overwrite the stored image with the same image
-    cp -r "$ccache_dir" "$HOME/.ccache" # move our ccache dir to not change its contents
-    ccache_dir="$HOME/.ccache"
   else
     echo "could not load cached image, building instead" >&2
     BUILD=1

--- a/.ci/travis-docker.sh
+++ b/.ci/travis-docker.sh
@@ -80,14 +80,11 @@ else
     echo "could not find ccache dir: $ccache_dir" >&2
     mkdir -p "$ccache_dir"
   fi
-  cp -rn "$ccache_dir" "$HOME/.ccache" # move our ccache dir to not change its contents
-  ccache_dir="$HOME/.ccache"
 fi
 
 
 # Get the docker image
 if [[ $GET ]]; then
-
   if [[ $img_save ]] && docker load --input "$img_save"; then
     echo "loaded image"
     docker images

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,14 +83,10 @@ matrix:
     language: cpp
     compiler: gcc
     env: HOMEBREW_NO_AUTO_UPDATE=1
-    cache:
-      - ccache
-      - directories:
-        - /usr/local/Cellar/protobuf
-        - /usr/local/Homebrew/Library/Taps/
+    cache: ccache
     before_install:
       - brew install ccache
-      - brew link protobuf || brew install protobuf --without-python@2
+      - brew install protobuf
       - brew install qt
     script: bash .ci/travis-compile.sh --server --install --debug
 
@@ -100,15 +96,11 @@ matrix:
     osx_image: xcode9.2
     language: cpp
     compiler: gcc
-    cache:
-      - ccache
-      - directories:
-        - /usr/local/Cellar/protobuf
-        - /usr/local/Homebrew/Library/Taps/
+    cache: ccache
     before_install:
       - brew update
       - brew install ccache
-      - brew link protobuf || brew install protobuf --without-python@2
+      - brew install protobuf
       - brew install qt
     script: bash .ci/travis-compile.sh --server --package "$TRAVIS_OS_NAME" --release
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,37 +79,30 @@ matrix:
   - name: macOS (Debug)
     if: tag IS NOT present
     os: osx
-    osx_image: xcode8
+    osx_image: xcode9.2
     language: cpp
     compiler: gcc
     cache:
       - ccache
       - directories:
         - /usr/local/Cellar/protobuf
-        - /usr/local/Cellar/qt
     before_install:
       - brew update
       - brew install ccache
       - brew install protobuf --without-python@2
-      - bash -c "sleep 500; echo keep going" &
-      - bash -c "sleep 1000; echo you can do it" &
-      - bash -c "sleep 1500; echo I believe" &
-      - bash -c "sleep 2000; echo please" &
       - brew install qt
-      - kill %4 && kill %3 && kill %2 && kill %1 || true
     script: bash ./.ci/travis-compile.sh --server --install --debug
 
   - name: macOS (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present
     os: osx
-    osx_image: xcode8
+    osx_image: xcode9.2
     language: cpp
     compiler: gcc
     cache:
       - ccache
       - directories:
         - /usr/local/Cellar/protobuf
-        - /usr/local/Cellar/qt
     before_install:
       - brew update
       - brew install ccache

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,8 @@ matrix:
     cache:
       directories:
         - $HOME/$NAME/
-    before_install: docker build -t "cockatrice_${NAME,,}" .ci/$NAME && mkdir -p $HOME/$NAME/.ccache
-    script: docker run --mount "type=bind,source=$(pwd),target=/src" -w="/src"
-          --mount "type=bind,source=$HOME/$NAME/.ccache,target=/.ccache" -e "CCACHE_DIR=/.ccache"
-          "cockatrice_${NAME,,}"
-          bash .ci/travis-compile.sh --server --debug
+    before_install: bash .ci/travis-docker.sh --get --save
+    script: bash .ci/travis-docker.sh --run "--server --debug"
 
   - name: Ubuntu Bionic (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present
@@ -46,11 +43,8 @@ matrix:
     cache:
       directories:
         - $HOME/$NAME/
-    before_install: docker build -t "cockatrice_${NAME,,}" .ci/$NAME && mkdir -p $HOME/$NAME/.ccache
-    script: docker run --mount "type=bind,source=$(pwd),target=/src" -w="/src"
-          --mount "type=bind,source=$HOME/$NAME/.ccache,target=/.ccache" -e "CCACHE_DIR=/.ccache"
-          "cockatrice_${NAME,,}"
-          bash .ci/travis-compile.sh --server --package "$NAME" --release
+    before_install: bash .ci/travis-docker.sh --build --save
+    script: bash .ci/travis-docker.sh --run "--server --package $NAME --release"
 
   #Fedora 29 (on docker)
   - name: Fedora 29 (Debug)
@@ -60,11 +54,8 @@ matrix:
     cache:
       directories:
         - $HOME/$NAME/
-    before_install: docker build -t "cockatrice_${NAME,,}" .ci/$NAME && mkdir -p $HOME/$NAME/.ccache
-    script: docker run --mount "type=bind,source=$(pwd),target=/src" -w="/src"
-          --mount "type=bind,source=$HOME/$NAME/.ccache,target=/.ccache" -e "CCACHE_DIR=/.ccache"
-          "cockatrice_${NAME,,}"
-          bash .ci/travis-compile.sh --server --debug
+    before_install: bash .ci/travis-docker.sh --get --save
+    script: bash .ci/travis-docker.sh --run "--server --debug"
 
   - name: Fedora 29 (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present
@@ -73,18 +64,19 @@ matrix:
     cache:
       directories:
         - $HOME/$NAME/
-    before_install: docker build -t "cockatrice_${NAME,,}" .ci/$NAME && mkdir -p $HOME/$NAME/.ccache
-    script: docker run --mount "type=bind,source=$(pwd),target=/src" -w="/src"
-          --mount "type=bind,source=$HOME/$NAME/.ccache,target=/.ccache" -e "CCACHE_DIR=/.ccache"
-          "cockatrice_${NAME,,}"
-          bash .ci/travis-compile.sh --server --package "$NAME" --release
+    before_install: bash .ci/travis-docker.sh --build --save
+    script: bash .ci/travis-docker.sh --run "--server --package $NAME --release"
 
   #macOS
   - name: macOS (Debug)
     if: tag IS NOT present
     os: osx
     osx_image: xcode8
-    cache: ccache
+    cache:
+      - ccache
+      - directories:
+        - /usr/local/Cellar/protobuf
+        - /usr/local/Cellar/qt
     before_install:
       - brew update
       - brew install ccache
@@ -96,7 +88,11 @@ matrix:
     if: (branch = master AND NOT type = pull_request) OR tag IS present
     os: osx
     osx_image: xcode8
-    cache: ccache
+    cache:
+      - ccache
+      - directories:
+        - /usr/local/Cellar/protobuf
+        - /usr/local/Cellar/qt
     before_install:
       - brew update
       - brew install ccache

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ matrix:
       - directories:
         - /usr/local/Cellar/protobuf
     before_install:
-      - brew update ruby --verbose
+      - brew upgrade ruby --verbose
       - brew install ccache --verbose
       - brew link protobuf || brew install protobuf --without-python@2
       - brew install qt

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,8 +87,8 @@ matrix:
       - directories:
         - /usr/local/Cellar/protobuf
     before_install:
-      - brew upgrade ruby --verbose
-      - brew install ccache --verbose
+      - brew update --verbose
+      - brew install ccache
       - brew link protobuf || brew install protobuf --without-python@2
       - brew install qt
     script: bash ./.ci/travis-compile.sh --server --install --debug
@@ -104,7 +104,7 @@ matrix:
       - directories:
         - /usr/local/Cellar/protobuf
     before_install:
-      - brew update ruby
+      - brew update
       - brew install ccache
       - brew link protobuf || brew install protobuf --without-python@2
       - brew install qt

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ matrix:
     before_install:
       - brew update
       - brew install ccache
-      - brew install protobuf --without-python@2
+      - brew link protobuf || brew install protobuf --without-python@2
       - brew install qt
     script: bash ./.ci/travis-compile.sh --server --install --debug
 
@@ -106,7 +106,7 @@ matrix:
     before_install:
       - brew update
       - brew install ccache
-      - brew install protobuf --without-python@2
+      - brew link protobuf || brew install protobuf --without-python@2
       - brew install qt
     script: bash ./.ci/travis-compile.sh --server --package "$TRAVIS_OS_NAME" --release
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,11 @@ matrix:
     if: tag IS NOT present
     services: docker
     language: minimal
-    env: NAME=UbuntuBionic
+    env: NAME=UbuntuBionic CACHE=$HOME/$NAME
     cache:
       directories:
-        - $HOME/$NAME/.ccache
-        - $HOME/$NAME/image
+        - $CACHE/.ccache
+        - $CACHE/image
     before_install: source .ci/travis-docker.sh --get --save
     script: RUN --server --debug
 
@@ -42,11 +42,11 @@ matrix:
     if: (branch = master AND NOT type = pull_request) OR tag IS present
     services: docker
     language: minimal
-    env: NAME=UbuntuBionic
+    env: NAME=UbuntuBionic CACHE=$HOME/$NAME
     cache:
       directories:
-        - $HOME/$NAME/.ccache
-        - $HOME/$NAME/image
+        - $CACHE/.ccache
+        - $CACHE/image
     before_install: source .ci/travis-docker.sh --build --save
     script: RUN --server --package $NAME --release
 
@@ -55,11 +55,11 @@ matrix:
     if: tag IS NOT present
     services: docker
     language: minimal
-    env: NAME=Fedora29
+    env: NAME=Fedora29 CACHE=$HOME/$NAME
     cache:
       directories:
-        - $HOME/$NAME/.ccache
-        - $HOME/$NAME/image
+        - $CACHE/.ccache
+        - $CACHE/image
     before_install: source .ci/travis-docker.sh --get --save
     script: RUN --server --debug
 
@@ -67,11 +67,11 @@ matrix:
     if: (branch = master AND NOT type = pull_request) OR tag IS present
     services: docker
     language: minimal
-    env: NAME=Fedora29
+    env: NAME=Fedora29 CACHE=$HOME/$NAME
     cache:
       directories:
-        - $HOME/$NAME/.ccache
-        - $HOME/$NAME/image
+        - $CACHE/.ccache
+        - $CACHE/image
     before_install: source .ci/travis-docker.sh --build --save
     script: RUN --server --package $NAME --release
 
@@ -82,13 +82,13 @@ matrix:
     osx_image: xcode9.2
     language: cpp
     compiler: gcc
+    env: HOMEBREW_NO_AUTO_UPDATE=1
     cache:
       - ccache
       - directories:
         - /usr/local/Cellar/protobuf
         - /usr/local/Homebrew/Library/Taps/
     before_install:
-      - HOMEBREW_NO_AUTO_UPDATE=1
       - brew install ccache
       - brew link protobuf || brew install protobuf --without-python@2
       - brew install qt

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,8 +87,8 @@ matrix:
       - directories:
         - /usr/local/Cellar/protobuf
     before_install:
-      - brew update
-      - brew install ccache
+      - brew update ruby --verbose
+      - brew install ccache --verbose
       - brew link protobuf || brew install protobuf --without-python@2
       - brew install qt
     script: bash ./.ci/travis-compile.sh --server --install --debug
@@ -104,7 +104,7 @@ matrix:
       - directories:
         - /usr/local/Cellar/protobuf
     before_install:
-      - brew update
+      - brew update ruby
       - brew install ccache
       - brew link protobuf || brew install protobuf --without-python@2
       - brew install qt

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
         - libqt5svg5-dev
         - libqt5sql5-mysql
         - libqt5websockets5-dev
-    script: bash ./.ci/travis-compile.sh --format --server --test --debug
+    script: bash .ci/travis-compile.sh --format --server --test --debug
 
   #Ubuntu Bionic (on docker)
   - name: Ubuntu Bionic (Debug)
@@ -35,8 +35,8 @@ matrix:
       directories:
         - $HOME/$NAME/.ccache
         - $HOME/$NAME/image
-    before_install: bash .ci/travis-docker.sh --get --save
-    script: bash .ci/travis-docker.sh --run "--server --debug"
+    before_install: source .ci/travis-docker.sh --get --save
+    script: RUN --server --debug
 
   - name: Ubuntu Bionic (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present
@@ -47,8 +47,8 @@ matrix:
       directories:
         - $HOME/$NAME/.ccache
         - $HOME/$NAME/image
-    before_install: bash .ci/travis-docker.sh --build --save
-    script: bash .ci/travis-docker.sh --run "--server --package $NAME --release"
+    before_install: source .ci/travis-docker.sh --build --save
+    script: RUN --server --package $NAME --release
 
   #Fedora 29 (on docker)
   - name: Fedora 29 (Debug)
@@ -60,8 +60,8 @@ matrix:
       directories:
         - $HOME/$NAME/.ccache
         - $HOME/$NAME/image
-    before_install: bash .ci/travis-docker.sh --get --save
-    script: bash .ci/travis-docker.sh --run "--server --debug"
+    before_install: source .ci/travis-docker.sh --get --save
+    script: RUN --server --debug
 
   - name: Fedora 29 (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present
@@ -72,8 +72,8 @@ matrix:
       directories:
         - $HOME/$NAME/.ccache
         - $HOME/$NAME/image
-    before_install: bash .ci/travis-docker.sh --build --save
-    script: bash .ci/travis-docker.sh --run "--server --package $NAME --release"
+    before_install: source .ci/travis-docker.sh --build --save
+    script: RUN --server --package $NAME --release
 
   #macOS
   - name: macOS (Debug)
@@ -88,11 +88,11 @@ matrix:
         - /usr/local/Cellar/protobuf
         - /usr/local/Homebrew/Library/Taps/
     before_install:
-      - brew update --verbose
+      - HOMEBREW_NO_AUTO_UPDATE=1
       - brew install ccache
       - brew link protobuf || brew install protobuf --without-python@2
       - brew install qt
-    script: bash ./.ci/travis-compile.sh --server --install --debug
+    script: bash .ci/travis-compile.sh --server --install --debug
 
   - name: macOS (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present
@@ -110,7 +110,7 @@ matrix:
       - brew install ccache
       - brew link protobuf || brew install protobuf --without-python@2
       - brew install qt
-    script: bash ./.ci/travis-compile.sh --server --package "$TRAVIS_OS_NAME" --release
+    script: bash .ci/travis-compile.sh --server --package "$TRAVIS_OS_NAME" --release
 
 
 # Builds for pull requests skip the deployment step altogether

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,7 @@ matrix:
       - ccache
       - directories:
         - /usr/local/Cellar/protobuf
+        - /usr/local/Homebrew/Library/Taps/
     before_install:
       - brew update --verbose
       - brew install ccache
@@ -103,6 +104,7 @@ matrix:
       - ccache
       - directories:
         - /usr/local/Cellar/protobuf
+        - /usr/local/Homebrew/Library/Taps/
     before_install:
       - brew update
       - brew install ccache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-language: cpp
-compiler: gcc
 
 matrix:
   include:
@@ -9,6 +7,8 @@ matrix:
     os: linux
     dist: xenial
     group: stable
+    language: cpp
+    compiler: gcc
     cache: ccache
     addons:
       apt:
@@ -29,20 +29,24 @@ matrix:
   - name: Ubuntu Bionic (Debug)
     if: tag IS NOT present
     services: docker
+    language: minimal
     env: NAME=UbuntuBionic
     cache:
       directories:
-        - $HOME/$NAME/
+        - $HOME/$NAME/.ccache
+        - $HOME/$NAME/image
     before_install: bash .ci/travis-docker.sh --get --save
     script: bash .ci/travis-docker.sh --run "--server --debug"
 
   - name: Ubuntu Bionic (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present
     services: docker
+    language: minimal
     env: NAME=UbuntuBionic
     cache:
       directories:
-        - $HOME/$NAME/
+        - $HOME/$NAME/.ccache
+        - $HOME/$NAME/image
     before_install: bash .ci/travis-docker.sh --build --save
     script: bash .ci/travis-docker.sh --run "--server --package $NAME --release"
 
@@ -50,20 +54,24 @@ matrix:
   - name: Fedora 29 (Debug)
     if: tag IS NOT present
     services: docker
+    language: minimal
     env: NAME=Fedora29
     cache:
       directories:
-        - $HOME/$NAME/
+        - $HOME/$NAME/.ccache
+        - $HOME/$NAME/image
     before_install: bash .ci/travis-docker.sh --get --save
     script: bash .ci/travis-docker.sh --run "--server --debug"
 
   - name: Fedora 29 (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present
     services: docker
+    language: minimal
     env: NAME=Fedora29
     cache:
       directories:
-        - $HOME/$NAME/
+        - $HOME/$NAME/.ccache
+        - $HOME/$NAME/image
     before_install: bash .ci/travis-docker.sh --build --save
     script: bash .ci/travis-docker.sh --run "--server --package $NAME --release"
 
@@ -72,6 +80,8 @@ matrix:
     if: tag IS NOT present
     os: osx
     osx_image: xcode8
+    language: cpp
+    compiler: gcc
     cache:
       - ccache
       - directories:
@@ -81,13 +91,20 @@ matrix:
       - brew update
       - brew install ccache
       - brew install protobuf --without-python@2
+      - bash -c "sleep 500; echo keep going" &
+      - bash -c "sleep 1000; echo you can do it" &
+      - bash -c "sleep 1500; echo I believe" &
+      - bash -c "sleep 2000; echo please" &
       - brew install qt
+      - kill %4 && kill %3 && kill %2 && kill %1 || true
     script: bash ./.ci/travis-compile.sh --server --install --debug
 
   - name: macOS (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present
     os: osx
     osx_image: xcode8
+    language: cpp
+    compiler: gcc
     cache:
       - ccache
       - directories:


### PR DESCRIPTION
After some testing I got all travis tests to below 3 mins, I also made a bit nicer environment for the docker tests.
- Added a script for setting the docker environment in `.ci/travis-docker.sh`
- Stores and loads docker images between pull requests, this gives some speedup (20 - 40%) but causes longer build times if the image needs to be both built and stored.
- Disables updating the cache (including ccache) in prs, this would reupload the entire image again costing 1 to 1.5 minutes. (we can't cache things more selectively on travis)

Alternatively we could keep rebuilding images for all pull requests or save the image somewhere else than in travis' cache.