### PR TITLE
add an ignore button to sort warning

### DIFF
--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -139,13 +139,22 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     hintsGroupBox = new QGroupBox(tr("Hints"));
     hintsGroupBox->setLayout(hintsGrid);
 
-    sortWarning = new QLabel;
-    sortWarning->setWordWrap(true);
-    sortWarning->setText(
-        "<b>" + tr("Warning: ") + "</b><br>" +
+    sortWarning = new QGroupBox(tr("Warning"));
+    QGridLayout *sortWarningLayout = new QGridLayout;
+    sortWarningText = new QLabel;
+    sortWarningText->setWordWrap(true);
+    sortWarningText->setText(
         tr("While the set list is sorted by any of the columns, custom art priority setting is disabled.") + "<br>" +
         tr("To disable sorting click on the same column header again until this message disappears."));
-    sortWarning->setStyleSheet("QLabel { background-color:red;}");
+    sortWarningLayout->addWidget(sortWarningText, 0, 0);
+    sortWarningButton = new QPushButton;
+    sortWarningButton->setText(tr("Ignore"));
+    sortWarningButton->setToolTip(tr("Ignore this warning and keep current sorting"));
+    sortWarningButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    connect(sortWarningButton, SIGNAL(released()), this, SLOT(actIgnoreWarning()));
+    sortWarningLayout->addWidget(sortWarningButton, 0, 1);
+    sortWarning->setStyleSheet("QGroupBox { background-color:red;}");
+    sortWarning->setLayout(sortWarningLayout);
     sortWarning->setVisible(false);
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
@@ -252,6 +261,17 @@ void WndSets::actSort(int index)
             sortWarning->setVisible(false);
         }
     }
+}
+
+void WndSets::actIgnoreWarning()
+{
+    if (sortIndex < 0) {
+        return;
+    }
+    model->sort(sortIndex, sortOrder);
+    view->header()->setSortIndicator(SORT_RESET, Qt::DescendingOrder);
+    sortIndex = -1;
+    sortWarning->setVisible(false);
 }
 
 void WndSets::actDisableSortButtons(int index)

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -143,8 +143,8 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     QGridLayout *sortWarningLayout = new QGridLayout;
     sortWarningText = new QLabel;
     sortWarningText->setWordWrap(true);
-    sortWarningText->setText(tr("Sorting by column allows you to find a set while not changing set priority.") +
-        " " + tr("To enable ordering again, click the column header until this message disappears."));
+    sortWarningText->setText(tr("Sorting by column allows you to find a set while not changing set priority.") + " " +
+                             tr("To enable ordering again, click the column header until this message disappears."));
     sortWarningLayout->addWidget(sortWarningText, 0, 0, 1, 2);
     sortWarningButton = new QPushButton;
     sortWarningButton->setText(tr("Use the current sorting as the set priority instead"));

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -139,21 +139,19 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     hintsGroupBox = new QGroupBox(tr("Hints"));
     hintsGroupBox->setLayout(hintsGrid);
 
-    sortWarning = new QGroupBox(tr("Warning"));
+    sortWarning = new QGroupBox(tr("Note"));
     QGridLayout *sortWarningLayout = new QGridLayout;
     sortWarningText = new QLabel;
     sortWarningText->setWordWrap(true);
-    sortWarningText->setText(
-        tr("While the set list is sorted by any of the columns, custom art priority setting is disabled.") + "<br>" +
-        tr("To disable sorting click on the same column header again until this message disappears."));
-    sortWarningLayout->addWidget(sortWarningText, 0, 0);
+    sortWarningText->setText(tr("Sorting by column allows you to find a set while not changing set priority.") +
+        " " + tr("To enable ordering again, click the column header until this message disappears."));
+    sortWarningLayout->addWidget(sortWarningText, 0, 0, 1, 2);
     sortWarningButton = new QPushButton;
-    sortWarningButton->setText(tr("Ignore"));
-    sortWarningButton->setToolTip(tr("Ignore this warning and keep current sorting"));
+    sortWarningButton->setText(tr("Use the current sorting as the set priority instead"));
+    sortWarningButton->setToolTip(tr("Sorts the set priority using the same column"));
     sortWarningButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     connect(sortWarningButton, SIGNAL(released()), this, SLOT(actIgnoreWarning()));
-    sortWarningLayout->addWidget(sortWarningButton, 0, 1);
-    sortWarning->setStyleSheet("QGroupBox { background-color:red;}");
+    sortWarningLayout->addWidget(sortWarningButton, 1, 0);
     sortWarning->setLayout(sortWarningLayout);
     sortWarning->setVisible(false);
 

--- a/cockatrice/src/window_sets.h
+++ b/cockatrice/src/window_sets.h
@@ -31,7 +31,10 @@ private:
     QAction *aUp, *aDown, *aBottom, *aTop;
     QToolBar *setsEditToolBar;
     QDialogButtonBox *buttonBox;
-    QLabel *labNotes, *searchLabel, *sortWarning;
+    QLabel *labNotes, *searchLabel;
+    QGroupBox *sortWarning;
+    QLabel *sortWarningText;
+    QPushButton *sortWarningButton;
     QLineEdit *searchField;
     QGridLayout *mainLayout;
     QHBoxLayout *filterBox;
@@ -67,6 +70,7 @@ private slots:
     void actRestoreOriginalOrder();
     void actDisableResetButton(const QString &filterText);
     void actSort(int index);
+    void actIgnoreWarning();
 };
 
 #endif


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3359

## Short roundup of the initial problem
The added "feature" allowing you to sort sets while not affecting the actual sorting didn't allow for ignoring this and setting the sorting like that anyway.

## What will change with this Pull Request?
- I've simply added an ignore button next to the warning which will remove the warning, sort the sets like current and remove the current sorting view as the model is ordered like this now anyway.

## Screenshots
![image](https://user-images.githubusercontent.com/36401181/49258627-6550b700-f436-11e8-9f5f-3dde83875e9f.png)

