### PR TITLE
place the os nametag after the version

### DIFF
--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -137,6 +137,6 @@ if [[ $MAKE_PACKAGE ]]; then
       echo "could not find package" >&2
       exit 1
     fi
-    mv "$path/$file" "$path/${file%%.*}-$PACKAGE_NAME.${file#*.}"
+    mv "$path/$file" "$path/${file%.*}-$PACKAGE_NAME.${file##*.}"
   fi
 fi


### PR DESCRIPTION
When i added the appended os nametags I didn't account for the dots inside the version, this will place the nametag before the last dot instead of after the first dot.