### PR TITLE
fix deployment on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,7 @@ deploy:
     on:
       tags: true
       repo: Cockatrice/Cockatrice
-      condition: $BUILDTYPE = Release && $TRAVIS_TAG =~ ([0-9]|[1-9][0-9])(\.([0-9]|[1-9][0-9])){2}-beta(\.([2-9]|[1-9][0-9]))?$     # regex to match semver naming convention for beta pre-releases
+      condition: $TRAVIS_TAG =~ ([0-9]|[1-9][0-9])(\.([0-9]|[1-9][0-9])){2}-beta(\.([2-9]|[1-9][0-9]))?$     # regex to match semver naming convention for beta pre-releases
 
 # Deploy configuration for "stable" releases
   - provider: releases
@@ -137,7 +137,7 @@ deploy:
     on:
       tags: true
       repo: Cockatrice/Cockatrice
-      condition: $BUILDTYPE = Release && $TRAVIS_TAG =~ ([0-9]|[1-9][0-9])(\.([0-9]|[1-9][0-9])){2}$    # regex to match semver naming convention for stable full releases
+      condition: $TRAVIS_TAG =~ ([0-9]|[1-9][0-9])(\.([0-9]|[1-9][0-9])){2}$    # regex to match semver naming convention for stable full releases
 
 
 notifications:


### PR DESCRIPTION
## Short roundup of the initial problem
Deployment conditions weren't met, because the $BUILDTYPE variable doesn't exist anymore.
@ebbit1q changed that, and there is a flag now that you pass to the compile script instead.

## What will change with this Pull Request?
- Remove that condition
It's not needed because we make sure via the build config itself that on tags no debug builds are run. This was a double check basically to prevent debug builds beeing deployed.