### PR TITLE
fix rpm builds in travis

### DIFF
--- a/.ci/Fedora29/Dockerfile
+++ b/.ci/Fedora29/Dockerfile
@@ -11,6 +11,7 @@ RUN dnf install -y \
         libappstream-glib \
         protobuf-devel \
         qt5-{qttools,qtsvg,qtmultimedia,qtwebsockets}-devel \
+        rpm-build \
         sqlite-devel \
         wget \
         zlib-devel \

--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -16,9 +16,13 @@ while [[ "$@" ]]; do
     '--package')
       MAKE_PACKAGE=1
       shift
-      if [[ $1 != -* ]]; then
+      if [[ $1 && $1 != -* ]]; then
         PACKAGE_NAME="$1"
         shift
+        if [[ $1 && $1 != -* ]]; then
+          PACKAGE_TYPE="$1"
+          shift
+        fi
       fi
       ;;
     '--server')
@@ -107,6 +111,9 @@ fi
 if [[ $BUILDTYPE ]]; then
   flags+=" -DCMAKE_BUILD_TYPE=$BUILDTYPE"
 fi
+if [[ $PACKAGE_TYPE ]]; then
+  flags+=" -DCPACK_GENERATOR=$PACKAGE_TYPE"
+fi
 
 # Add qt install location when using brew
 if [[ $(uname) == "Darwin" ]]; then
@@ -133,7 +140,7 @@ if [[ $MAKE_PACKAGE ]]; then
     found=$(find . -maxdepth 1 -type f -name "Cockatrice-*.*" -print -quit)
     path=${found%/*}
     file=${found##*/}
-    if [[ $file != *.* ]]; then
+    if [[ ! $file ]]; then
       echo "could not find package" >&2
       exit 1
     fi

--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -16,10 +16,10 @@ while [[ "$@" ]]; do
     '--package')
       MAKE_PACKAGE=1
       shift
-      if [[ $1 && $1 != -* ]]; then
+      if [[ $# != 0 && $1 != -* ]]; then
         PACKAGE_NAME="$1"
         shift
-        if [[ $1 && $1 != -* ]]; then
+        if [[ $# != 0 && $1 != -* ]]; then
           PACKAGE_TYPE="$1"
           shift
         fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
     script: docker run --mount "type=bind,source=$(pwd),target=/src" -w="/src"
           --mount "type=bind,source=$HOME/$NAME/.ccache,target=/.ccache" -e "CCACHE_DIR=/.ccache"
           "cockatrice_${NAME,,}"
-          bash .ci/travis-compile.sh --server --package "$NAME" --release
+          bash .ci/travis-compile.sh --server --package "$NAME" "RPM" --release
 
   #macOS
   - name: macOS (Debug)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #I can't find the issue rn

## Short roundup of the initial problem
Fedora builds in travis create debian packages instead of rpm ones

## What will change with this Pull Request?
- the correct argument will be passed to cmake
- the missing dependency will be added to the image file
