### PR TITLE
Use scryfall urls

### DIFF
--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -25,6 +25,10 @@
 // never cache more than 300 cards at once for a single deck
 #define CACHED_CARD_PER_DECK_MAX 300
 
+// Other URLs we can use (TODO: Make this less messy)
+#define GATHERER_DEFAULT "http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!cardid!&type=card"
+#define GATHERER_FALLBACK "http://gatherer.wizards.com/Handlers/Image.ashx?name=!name!&type=card"
+
 class PictureToLoad::SetDownloadPriorityComparator
 {
 public:
@@ -48,6 +52,8 @@ PictureToLoad::PictureToLoad(CardInfoPtr _card) : card(std::move(_card))
     /* #2479 will expand this into a list of Urls */
     urlTemplates.append(settingsCache->getPicUrl());
     urlTemplates.append(settingsCache->getPicUrlFallback());
+    urlTemplates.append(GATHERER_DEFAULT);
+    urlTemplates.append(GATHERER_FALLBACK);
 
     if (card) {
         sortedSets = card->getSets();

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -220,8 +220,8 @@ SettingsCache::SettingsCache()
 
     picDownload = settings->value("personal/picturedownload", true).toBool();
 
-    picUrl = settings->value("personal/picUrl", PIC_URL_DEFAULT).toString();
-    picUrlFallback = settings->value("personal/picUrlFallback", PIC_URL_FALLBACK).toString();
+    picUrl = settings->value("personal/picUrlNew", PIC_URL_DEFAULT).toString();
+    picUrlFallback = settings->value("personal/picUrlFallbackNew", PIC_URL_FALLBACK).toString();
 
     mainWindowGeometry = settings->value("interface/main_window_geometry").toByteArray();
     tokenDialogGeometry = settings->value("interface/token_dialog_geometry").toByteArray();

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -418,13 +418,13 @@ void SettingsCache::setPicDownload(int _picDownload)
 void SettingsCache::setPicUrl(const QString &_picUrl)
 {
     picUrl = _picUrl;
-    settings->setValue("personal/picUrl", picUrl);
+    settings->setValue("personal/picUrlNew", picUrl);
 }
 
 void SettingsCache::setPicUrlFallback(const QString &_picUrlFallback)
 {
     picUrlFallback = _picUrlFallback;
-    settings->setValue("personal/picUrlFallback", picUrlFallback);
+    settings->setValue("personal/picUrlFallbackNew", picUrlFallback);
 }
 
 void SettingsCache::setNotificationsEnabled(int _notificationsEnabled)

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -220,8 +220,8 @@ SettingsCache::SettingsCache()
 
     picDownload = settings->value("personal/picturedownload", true).toBool();
 
-    picUrl = settings->value("personal/picUrlNew", PIC_URL_DEFAULT).toString();
-    picUrlFallback = settings->value("personal/picUrlFallbackNew", PIC_URL_FALLBACK).toString();
+    picUrl = settings->value("personal/picUrl", PIC_URL_DEFAULT).toString();
+    picUrlFallback = settings->value("personal/picUrlFallback", PIC_URL_FALLBACK).toString();
 
     mainWindowGeometry = settings->value("interface/main_window_geometry").toByteArray();
     tokenDialogGeometry = settings->value("interface/token_dialog_geometry").toByteArray();
@@ -418,13 +418,13 @@ void SettingsCache::setPicDownload(int _picDownload)
 void SettingsCache::setPicUrl(const QString &_picUrl)
 {
     picUrl = _picUrl;
-    settings->setValue("personal/picUrlNew", picUrl);
+    settings->setValue("personal/picUrl", picUrl);
 }
 
 void SettingsCache::setPicUrlFallback(const QString &_picUrlFallback)
 {
     picUrlFallback = _picUrlFallback;
-    settings->setValue("personal/picUrlFallbackNew", picUrlFallback);
+    settings->setValue("personal/picUrlFallback", picUrlFallback);
 }
 
 void SettingsCache::setNotificationsEnabled(int _notificationsEnabled)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -13,9 +13,9 @@
 
 class ReleaseChannel;
 
-// the falbacks are used for cards without a muid
-#define PIC_URL_DEFAULT "http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!cardid!&type=card"
-#define PIC_URL_FALLBACK "http://gatherer.wizards.com/Handlers/Image.ashx?name=!name!&type=card"
+// Fallbacks used for cards w/o MultiverseId
+#define PIC_URL_DEFAULT "https://api.scryfall.com/cards/multiverse/!cardid!?format=image"
+#define PIC_URL_FALLBACK "https://api.scryfall.com/cards/named?fuzzy=!name!&format=image"
 // size should be a multiple of 64
 #define PIXMAPCACHE_SIZE_DEFAULT 2047
 #define PIXMAPCACHE_SIZE_MIN 64

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -16,6 +16,7 @@ class ReleaseChannel;
 // Fallbacks used for cards w/o MultiverseId
 #define PIC_URL_DEFAULT "https://api.scryfall.com/cards/multiverse/!cardid!?format=image"
 #define PIC_URL_FALLBACK "https://api.scryfall.com/cards/named?fuzzy=!name!&format=image"
+
 // size should be a multiple of 64
 #define PIXMAPCACHE_SIZE_DEFAULT 2047
 #define PIXMAPCACHE_SIZE_MIN 64


### PR DESCRIPTION
Now that we're on V4, we can start changing how things are done with URLs a bit.

To start, we can incorporate Scryfall API urls now instead of Gatherer. This change will modify the "RESET" buttons to use Scryfall. Will _NOT_ force the user to change on their own, as some people may have custom image sources they like already.
