### PR TITLE
[WIP] Oracle: Optimize json parsing

### DIFF
--- a/cockatrice/src/qt-json/json.cpp
+++ b/cockatrice/src/qt-json/json.cpp
@@ -1,28 +1,28 @@
 /* Copyright 2011 Eeli Reilin. All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without 
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
- * 1. Redistributions of source code must retain the above copyright notice, 
+ * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation 
+ *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ''AS IS'' AND ANY EXPRESS OR 
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO 
- * EVENT SHALL EELI REILIN OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ''AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL EELI REILIN OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
- * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * The views and conclusions contained in the software and documentation 
- * are those of the authors and should not be interpreted as representing 
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
  * official policies, either expressed or implied, of Eeli Reilin.
  */
 
@@ -503,11 +503,12 @@ QVariant Json::parseNumber(const QString &json, int &index)
  */
 int Json::lastIndexOfNumber(const QString &json, int index)
 {
+        static const QString numericCharacters("0123456789+-.eE");
         int lastIndex;
 
         for(lastIndex = index; lastIndex < json.size(); lastIndex++)
         {
-                if(QString("0123456789+-.eE").indexOf(json[lastIndex]) == -1)
+                if(numericCharacters.indexOf(json[lastIndex]) == -1)
                 {
                         break;
                 }
@@ -521,9 +522,10 @@ int Json::lastIndexOfNumber(const QString &json, int index)
  */
 void Json::eatWhitespace(const QString &json, int &index)
 {
+        static const QString whitespaceChars(" \t\n\r");
         for(; index < json.size(); index++)
         {
-                if(QString(" \t\n\r").indexOf(json[index]) == -1)
+                if(whitespaceChars.indexOf(json[index]) == -1)
                 {
                         break;
                 }


### PR DESCRIPTION
## Related Ticket(s)
- #3458

## Short roundup of the initial problem
Since the move from Mtgson2 to Mtgjson4, the json file size increased a lot. This resulted in increased parsing time in oracle, eg. on my mac from 5-10 second to over a minute. We are not even reporting a progress indicator to users.
Back in the Qt4 days, Qt had no native support for Json, so Cockatrice is embedding a 3rd party library called qt-json: https://github.com/qt-json/qt-json
Nowadays Qt5 has a native solution to parse Json, but it's so optimized for speed on small files that it doesn't handle big json files at all. I've tried to use it, but it end up with a `too large document` error.

## What will change with this Pull Request?
While investigating the speed of the json library, I've found out that a couple optimizations could speed up the parsing by about 3 times. The original patch was found here: https://github.com/qt-json/qt-json/issues/20
On my mac, the parsing time is reduced from 63 to 21 seconds.

I'm keeping this PR open a couple of days to investigate other possible optimizations.