### PR TITLE
Minor translation issue fix

### DIFF
--- a/cockatrice/src/sequenceEdit/ui_shortcutstab.h
+++ b/cockatrice/src/sequenceEdit/ui_shortcutstab.h
@@ -1983,7 +1983,7 @@ public:
         lbl_TabGame_aRotateViewCW->setText(QApplication::translate("shortcutsTab", "Rotate view CW", 0));
         lbl_Player_aShuffle->setText(QApplication::translate("shortcutsTab", "Shuffle library", 0));
         lbl_TabGame_aRotateViewCCW->setText(QApplication::translate("shortcutsTab", "Rotate view CCW", 0));
-        groupBox_draw->setTitle(QApplication::translate("shortcutsTab", "Draw", 0));
+        groupBox_draw->setTitle(QApplication::translate("shortcutsTab", "Drawing", 0));
         lbl_Player_aMulligan->setText(QApplication::translate("shortcutsTab", "Mulligan", 0));
         lbl_Player_aDrawCard->setText(QApplication::translate("shortcutsTab", "Draw card", 0));
         lbl_Player_aDrawCards->setText(QApplication::translate("shortcutsTab", "Draw cards", 0));


### PR DESCRIPTION
## Related Ticket(s)
No issue opened cause it's not worth it for such a simple problem

## Short roundup of the initial problem
We have 2 identical "Draw" strings in ui_shortcutstab.h. One refers the action of drawing a card (first screenshot), the other to the Draw Step (second screenshot). This causes side effects when translating said strings.

## What will change with this Pull Request?
It merely changes one of the two strings so that both can be translated separately: I went for the first one.

## Screenshots
![cattura](https://user-images.githubusercontent.com/12029224/50527485-dabcaf80-0ae8-11e9-80c4-046397cd0911.PNG)
![cattura2](https://user-images.githubusercontent.com/12029224/50527486-db554600-0ae8-11e9-890b-15dac4a4ad68.PNG)
