### PR TITLE
Switch from (s) to plural form whenever possible in message log

### DIFF
--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -273,15 +273,15 @@ void DlgConnect::newHostSelected(bool state)
         previousHosts->setDisabled(true);
         btnRefreshServers->setDisabled(true);
         hostEdit->clear();
-        hostEdit->setPlaceholderText("Server URL");
+        hostEdit->setPlaceholderText(tr("Server URL"));
         hostEdit->setDisabled(false);
         portEdit->clear();
-        portEdit->setPlaceholderText("Communication Port");
+        portEdit->setPlaceholderText(tr("Communication Port"));
         portEdit->setDisabled(false);
         playernameEdit->clear();
         passwordEdit->clear();
         saveEdit->clear();
-        saveEdit->setPlaceholderText("Unique Server Name");
+        saveEdit->setPlaceholderText(tr("Unique Server Name"));
         saveEdit->setDisabled(false);
         serverContactLabel->setText("");
         serverContactLink->setText("");

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -649,7 +649,7 @@ MessagesSettingsPage::MessagesSettingsPage()
     connect(&roomHistory, SIGNAL(stateChanged(int)), settingsCache, SLOT(setRoomHistory(int)));
 
     customAlertString = new QLineEdit();
-    customAlertString->setPlaceholderText("Word1 Word2 Word3");
+    customAlertString->setPlaceholderText(tr("Word1 Word2 Word3"));
     customAlertString->setText(settingsCache->getHighlightWords());
     connect(customAlertString, SIGNAL(textChanged(QString)), settingsCache, SLOT(setHighlightWords(QString)));
 

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -354,10 +354,11 @@ void MessageLogWidget::logDumpZone(Player *player, CardZone *zone, int numberCar
                                     .arg(sanitizeHtml(player->getName()))
                                     .arg(zone->getTranslatedName(zone->getPlayer() == player, CaseLookAtZone)));
     else
-        appendHtmlServerMessage(tr("%1 is looking at the top %3 card(s) %2.", "top card for singular, top %3 cards for plural", numberCards)
-                                    .arg(sanitizeHtml(player->getName()))
-                                    .arg(zone->getTranslatedName(zone->getPlayer() == player, CaseTopCardsOfZone))
-                                    .arg("<font color=\"blue\">" + QString::number(numberCards) + "</font>"));
+         appendHtmlServerMessage(
+             tr("%1 is looking at the top %3 card(s) %2.", "top card for singular, top %3 cards for plural", numberCards)
+                 .arg(sanitizeHtml(player->getName()))
+                 .arg(zone->getTranslatedName(zone->getPlayer() == player, CaseTopCardsOfZone))
+                 .arg("<font color=\"blue\">" + QString::number(numberCards) + "</font>"));
 }
 
 void MessageLogWidget::logFlipCard(Player *player, QString cardName, bool faceDown)

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -156,7 +156,7 @@ void MessageLogWidget::logAlwaysRevealTopCard(Player *player, CardZone *zone, bo
 
 void MessageLogWidget::logAttachCard(Player *player, QString cardName, Player *targetPlayer, QString targetCardName)
 {
-    appendHtmlServerMessage(QString("%1 attaches %2 to %3's %4.")
+    appendHtmlServerMessage(tr("%1 attaches %2 to %3's %4.")
                                 .arg(sanitizeHtml(player->getName()))
                                 .arg(cardLink(cardName))
                                 .arg(sanitizeHtml(targetPlayer->getName()))

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -341,7 +341,7 @@ void MessageLogWidget::logDrawCards(Player *player, int number)
         mulliganPlayer = player;
     else {
         soundEngine->playSound("draw_card");
-        appendHtmlServerMessage(tr("%1 draws %2 card(s).")
+        appendHtmlServerMessage(tr("%1 draws %2 card(s).", "", number)
                                     .arg(sanitizeHtml(player->getName()))
                                     .arg("<font color=\"blue\">" + QString::number(number) + "</font>"));
     }
@@ -354,10 +354,10 @@ void MessageLogWidget::logDumpZone(Player *player, CardZone *zone, int numberCar
                                     .arg(sanitizeHtml(player->getName()))
                                     .arg(zone->getTranslatedName(zone->getPlayer() == player, CaseLookAtZone)));
     else
-        appendHtmlServerMessage(tr("%1 is looking at the top %2 card(s) %3.")
+        appendHtmlServerMessage(tr("%1 is looking at the top %3 card(s) %2.", "top card for singular, top %3 cards for plural", numberCards)
                                     .arg(sanitizeHtml(player->getName()))
-                                    .arg("<font color=\"blue\">" + QString::number(numberCards) + "</font>")
-                                    .arg(zone->getTranslatedName(zone->getPlayer() == player, CaseTopCardsOfZone)));
+                                    .arg(zone->getTranslatedName(zone->getPlayer() == player, CaseTopCardsOfZone))
+                                    .arg("<font color=\"blue\">" + QString::number(numberCards) + "</font>"));
 }
 
 void MessageLogWidget::logFlipCard(Player *player, QString cardName, bool faceDown)
@@ -626,20 +626,20 @@ void MessageLogWidget::logSetCardCounter(Player *player, QString cardName, int c
     QString finalStr;
     int delta = abs(oldValue - value);
     if (value > oldValue)
-        finalStr = tr("%1 places %2 %3 counter(s) on %4 (now %5).");
+        finalStr = tr("%1 places %2 %3 on %4 (now %5).");
     else
-        finalStr = tr("%1 removes %2 %3 counter(s) from %4 (now %5).");
+        finalStr = tr("%1 removes %2 %3 from %4 (now %5).");
 
     QString colorStr;
     switch (counterId) {
         case 0:
-            colorStr = tr("red", "", delta);
+            colorStr = tr("red counter(s)", "", delta);
             break;
         case 1:
-            colorStr = tr("yellow", "", delta);
+            colorStr = tr("yellow counter(s)", "", delta);
             break;
         case 2:
-            colorStr = tr("green", "", delta);
+            colorStr = tr("green counter(s)", "", delta);
             break;
         default:;
     }

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -354,11 +354,11 @@ void MessageLogWidget::logDumpZone(Player *player, CardZone *zone, int numberCar
                                     .arg(sanitizeHtml(player->getName()))
                                     .arg(zone->getTranslatedName(zone->getPlayer() == player, CaseLookAtZone)));
     else
-         appendHtmlServerMessage(
-             tr("%1 is looking at the top %3 card(s) %2.", "top card for singular, top %3 cards for plural", numberCards)
-                 .arg(sanitizeHtml(player->getName()))
-                 .arg(zone->getTranslatedName(zone->getPlayer() == player, CaseTopCardsOfZone))
-                 .arg("<font color=\"blue\">" + QString::number(numberCards) + "</font>"));
+        appendHtmlServerMessage(
+            tr("%1 is looking at the top %3 card(s) %2.", "top card for singular, top %3 cards for plural", numberCards)
+                .arg(sanitizeHtml(player->getName()))
+                .arg(zone->getTranslatedName(zone->getPlayer() == player, CaseTopCardsOfZone))
+                .arg("<font color=\"blue\">" + QString::number(numberCards) + "</font>"));
 }
 
 void MessageLogWidget::logFlipCard(Player *player, QString cardName, bool faceDown)


### PR DESCRIPTION
## Related Ticket(s)
- No ticked opened

## Short roundup of the initial problem
- 3 strings that appear in the game log don't use plural forms, and opt for "(s)" instead
- Various missing tr()s

## What will change with this Pull Request?
- Straight up fix for "%1 draws %2 card(s)".
- "%1 is looking at the top %2 card(s) %3" will allow translating into both "at the top card" and "at the top x cards" by switching arguments 2 and 3 as mentioned in tr description.
- For "%1 places %2 %3 counter(s) on %4 (now %5)." i just moved "counter(s)" into argument %3 as plural form is already used there for each color.
- Add the tr()