### PR TITLE
Fix shortcuts on mac; fix #3482

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,6 @@ matrix:
     if: tag IS NOT present
     os: osx
     osx_image: xcode9.2
-    env: HOMEBREW_NO_AUTO_UPDATE=1
     cache: ccache
     before_install:
       - brew install ccache protobuf qt xz
@@ -95,7 +94,6 @@ matrix:
     if: (branch = master AND NOT type = pull_request) OR tag IS present
     os: osx
     osx_image: xcode9.2
-    env: HOMEBREW_NO_AUTO_UPDATE=1
     cache: ccache
     before_install:
       - brew install ccache protobuf qt xz

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,10 +84,15 @@ matrix:
   - name: macOS (Debug)
     if: tag IS NOT present
     os: osx
-    osx_image: xcode9.2
+    osx_image: xcode10.1
     cache: ccache
-    before_install:
-      - brew install ccache protobuf qt xz
+    addons:
+      homebrew:
+        packages:
+        - ccache
+        - protobuf
+        - qt
+        - xz
     script: bash ./.ci/travis-compile.sh --server --install --debug
 
   - name: macOS (Release)
@@ -95,10 +100,15 @@ matrix:
     os: osx
     osx_image: xcode9.2
     cache: ccache
-    before_install:
-      - brew install ccache protobuf qt xz
+    addons:
+      homebrew:
+        packages:
+        - ccache
+        - protobuf
+        - qt
+        - xz
+        update: true
     script: bash ./.ci/travis-compile.sh --server --package "$TRAVIS_OS_NAME" --release
-
 
 # Builds for pull requests skip the deployment step altogether
 deploy:


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3482

## Short roundup of the initial problem
Due to recent changes to our travis script, we are using the old, known problematic version of Qt 5.9.3 in our builds. The original issues are described here: https://github.com/Cockatrice/Cockatrice/issues/2647 

## What will change with this Pull Request?
As a first attempt, we let homebrew update itself to get a recent, working Qt version installed.
The brew update+install step requires about 7 mins, and the entire build time goes up to 13 mins.
As an alternative, we could try a more recent macOS image on Travis, but this means dropping support for macOS 10.12.
