### PR TITLE
Several download URLs have arrived!

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -114,6 +114,7 @@ SET(cockatrice_SOURCES
     src/settings/messagesettings.cpp
     src/settings/gamefilterssettings.cpp
     src/settings/layoutssettings.cpp
+    src/settings/downloadsettings.cpp
     src/update_downloader.cpp
     src/logger.cpp
     src/releasechannel.cpp
@@ -122,7 +123,7 @@ SET(cockatrice_SOURCES
     src/handle_public_servers.cpp
     src/carddbparser/cockatricexml3.cpp
     ${VERSION_STRING_CPP}
-)
+    )
 
 add_subdirectory(sounds)
 add_subdirectory(themes)

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -449,7 +449,9 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     urlList->setAlternatingRowColors(true);
     urlList->setDragEnabled(true);
     urlList->setDragDropMode(QAbstractItemView::InternalMove);
-    connect(urlList, SIGNAL(itemSelectionChanged()), this, SLOT(storeSettings())); // TODO: Make this signal better
+    connect(urlList->model(),
+            SIGNAL(rowsMoved(const QModelIndex, int, int, const QModelIndex, int)), this,
+            SLOT(urlListChanged(const QModelIndex, int, int, const QModelIndex, int)));
 
     for (int i = 0; i < settingsCache->downloads().getCount(); i++)
         urlList->addItem(settingsCache->downloads().getDownloadUrlAt(i));
@@ -589,6 +591,11 @@ void DeckEditorSettingsPage::storeSettings()
         qInfo() << "Priority" << i << ":" << urlList->item(i)->text();
         settingsCache->downloads().setDownloadUrlAt(i, urlList->item(i)->text());
     }
+}
+
+void DeckEditorSettingsPage::urlListChanged(const QModelIndex &parent, int start, int end, const QModelIndex &destination, int row)
+{
+    storeSettings();
 }
 
 void DeckEditorSettingsPage::updateSpoilers()

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -508,7 +508,6 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     setLayout(lpMainLayout);
 }
 
-
 void DeckEditorSettingsPage::resetDownloadedURLsButtonClicked()
 {
     settingsCache->downloads().clear();
@@ -539,17 +538,14 @@ void DeckEditorSettingsPage::clearDownloadedPicsButtonClicked()
             bool success = QDir(picsPath).rmdir(dir);
             if (!success) {
                 qInfo() << "Failed to remove inner directory" << picsPath;
-            }
-            else
-            {
+            } else {
                 qInfo() << "Removed" << currentPath;
             }
         }
     }
     if (outerSuccessRemove) {
         QMessageBox::information(this, tr("Success"), tr("Downloaded card pictures have been reset."));
-    }
-    else {
+    } else {
         QMessageBox::critical(this, tr("Error"), tr("One or more downloaded card pictures could not be cleared."));
     }
 }

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -1156,7 +1156,7 @@ void DlgSettings::retranslateUi()
     generalButton->setText(tr("General"));
     appearanceButton->setText(tr("Appearance"));
     userInterfaceButton->setText(tr("User Interface"));
-    deckEditorButton->setText(tr("Card Resources"));
+    deckEditorButton->setText(tr("Card Sources"));
     messagesButton->setText(tr("Chat"));
     soundButton->setText(tr("Sound"));
     shortcutsButton->setText(tr("Shortcuts"));

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -449,8 +449,7 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     urlList->setAlternatingRowColors(true);
     urlList->setDragEnabled(true);
     urlList->setDragDropMode(QAbstractItemView::InternalMove);
-    connect(urlList->model(),
-            SIGNAL(rowsMoved(const QModelIndex, int, int, const QModelIndex, int)), this,
+    connect(urlList->model(), SIGNAL(rowsMoved(const QModelIndex, int, int, const QModelIndex, int)), this,
             SLOT(urlListChanged(const QModelIndex, int, int, const QModelIndex, int)));
 
     for (int i = 0; i < settingsCache->downloads().getCount(); i++)
@@ -593,7 +592,7 @@ void DeckEditorSettingsPage::storeSettings()
     }
 }
 
-void DeckEditorSettingsPage::urlListChanged(const QModelIndex &parent, int start, int end, const QModelIndex &destination, int row)
+void DeckEditorSettingsPage::urlListChanged(const QModelIndex &, int, int, const QModelIndex &, int)
 {
     storeSettings();
 }

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -131,7 +131,7 @@ public:
 
 private slots:
     void storeSettings();
-    void urlListChanged(const QModelIndex &parent, int start, int end, const QModelIndex &destination, int row);
+    void urlListChanged(const QModelIndex &, int, int, const QModelIndex &, int);
     void setSpoilersEnabled(bool);
     void spoilerPathButtonClicked();
     void updateSpoilers();

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -131,6 +131,7 @@ public:
 
 private slots:
     void storeSettings();
+    void urlListChanged(const QModelIndex &parent, int start, int end, const QModelIndex &destination, int row);
     void setSpoilersEnabled(bool);
     void spoilerPathButtonClicked();
     void updateSpoilers();

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -43,13 +43,9 @@ private slots:
     void deckPathButtonClicked();
     void replaysPathButtonClicked();
     void picsPathButtonClicked();
-    void clearDownloadedPicsButtonClicked();
     void cardDatabasePathButtonClicked();
     void tokenDatabasePathButtonClicked();
     void languageBoxChanged(int index);
-    void setEnabledStatus(bool);
-    void defaultUrlRestoreButtonClicked();
-    void fallbackUrlRestoreButtonClicked();
 
 private:
     QStringList findQmFiles();
@@ -59,13 +55,10 @@ private:
     QLineEdit *picsPathEdit;
     QLineEdit *cardDatabasePathEdit;
     QLineEdit *tokenDatabasePathEdit;
-    QLineEdit *defaultUrlEdit;
-    QLineEdit *fallbackUrlEdit;
     QSpinBox pixmapCacheEdit;
     QGroupBox *personalGroupBox;
     QGroupBox *pathsGroupBox;
     QComboBox languageBox;
-    QCheckBox picDownloadCheckBox;
     QCheckBox updateNotificationCheckBox;
     QComboBox updateReleaseChannelBox;
     QLabel languageLabel;
@@ -77,11 +70,7 @@ private:
     QLabel tokenDatabasePathLabel;
     QLabel defaultUrlLabel;
     QLabel fallbackUrlLabel;
-    QLabel urlLinkLabel;
     QLabel updateReleaseChannelLabel;
-    QPushButton clearDownloadedPicsButton;
-    QPushButton defaultUrlRestoreButton;
-    QPushButton fallbackUrlRestoreButton;
     QCheckBox showTipsOnStartup;
 };
 
@@ -143,19 +132,29 @@ public:
     QString getLastUpdateTime();
 
 private slots:
+    void storeSettings();
     void setSpoilersEnabled(bool);
     void spoilerPathButtonClicked();
     void updateSpoilers();
     void unlockSettings();
+    void actAddURL();
+    void actRemoveURL();
+    void actEditURL();
+    void clearDownloadedPicsButtonClicked();
+    void resetDownloadedURLsButtonClicked();
 
 private:
+    QPushButton clearDownloadedPicsButton;
+    QPushButton resetDownloadURLs;
+    QLabel urlLinkLabel;
+    QCheckBox picDownloadCheckBox;
+    QListWidget *urlList;
     QCheckBox mcDownloadSpoilersCheckBox;
     QLabel msDownloadSpoilersLabel;
     QGroupBox *mpGeneralGroupBox;
     QGroupBox *mpSpoilerGroupBox;
     QLineEdit *mpSpoilerSavePathLineEdit;
     QLabel mcSpoilerSaveLabel;
-    QLabel mcGeneralMessageLabel;
     QLabel lastUpdatedLabel;
     QLabel infoOnSpoilersLabel;
     QPushButton *mpSpoilerPathButton;

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -68,8 +68,6 @@ private:
     QLabel picsPathLabel;
     QLabel cardDatabasePathLabel;
     QLabel tokenDatabasePathLabel;
-    QLabel defaultUrlLabel;
-    QLabel fallbackUrlLabel;
     QLabel updateReleaseChannelLabel;
     QCheckBox showTipsOnStartup;
 };

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -84,12 +84,8 @@ QString const generateClientID()
     return strClientID;
 }
 
-Q_DECLARE_METATYPE(QList<QString>)
-
 int main(int argc, char *argv[])
 {
-    qRegisterMetaTypeStreamOperators<QList<QString>>("QList<QString>");
-
     QApplication app(argc, argv);
 
     QObject::connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(quit()));

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -84,8 +84,12 @@ QString const generateClientID()
     return strClientID;
 }
 
+Q_DECLARE_METATYPE(QList<QString>)
+
 int main(int argc, char *argv[])
 {
+    qRegisterMetaTypeStreamOperators<QList<QString>>("QList<QString>");
+
     QApplication app(argc, argv);
 
     QObject::connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(quit()));

--- a/cockatrice/src/pictureloader.h
+++ b/cockatrice/src/pictureloader.h
@@ -14,7 +14,23 @@ class QThread;
 class PictureToLoad
 {
 private:
-    class SetDownloadPriorityComparator;
+    class SetDownloadPriorityComparator
+    {
+    public:
+        /*
+         * Returns true if a has higher download priority than b
+         * Enabled sets have priority over disabled sets
+         * Both groups follows the user-defined order
+         */
+        inline bool operator()(const CardSetPtr &a, const CardSetPtr &b) const
+        {
+            if (a->getEnabled()) {
+                return !b->getEnabled() || a->getSortKey() < b->getSortKey();
+            } else {
+                return !b->getEnabled() && a->getSortKey() < b->getSortKey();
+            }
+        }
+    };
 
     CardInfoPtr card;
     QList<CardSetPtr> sortedSets;
@@ -24,7 +40,8 @@ private:
     CardSetPtr currentSet;
 
 public:
-    PictureToLoad(CardInfoPtr _card = CardInfoPtr());
+    explicit PictureToLoad(CardInfoPtr _card = CardInfoPtr());
+
     CardInfoPtr getCard() const
     {
         return card;
@@ -42,7 +59,7 @@ public:
         return currentSet;
     }
     QString getSetName() const;
-    QString transformUrl(QString urlTemplate) const;
+    QString transformUrl(const QString &urlTemplate) const;
     bool nextSet();
     bool nextUrl();
     void populateSetUrls();
@@ -52,8 +69,8 @@ class PictureLoaderWorker : public QObject
 {
     Q_OBJECT
 public:
-    PictureLoaderWorker();
-    ~PictureLoaderWorker();
+    explicit PictureLoaderWorker();
+    ~PictureLoaderWorker() override;
 
     void enqueueImageLoad(CardInfoPtr card);
 
@@ -70,8 +87,8 @@ private:
     PictureToLoad cardBeingDownloaded;
     bool picDownload, downloadRunning, loadQueueRunning;
     void startNextPicDownload();
-    bool cardImageExistsOnDisk(QString &setName, QString &correctedCardname);
-    bool imageIsBlackListed(const QByteArray &picData);
+    bool cardImageExistsOnDisk(QString &, QString &);
+    bool imageIsBlackListed(const QByteArray &);
 private slots:
     void picDownloadFinished(QNetworkReply *reply);
     void picDownloadFailed();
@@ -96,8 +113,8 @@ public:
     }
 
 private:
-    PictureLoader();
-    ~PictureLoader();
+    explicit PictureLoader();
+    ~PictureLoader() override;
     // Singleton - Don't implement copy constructor and assign operator
     PictureLoader(PictureLoader const &);
     void operator=(PictureLoader const &);

--- a/cockatrice/src/settings/downloadsettings.cpp
+++ b/cockatrice/src/settings/downloadsettings.cpp
@@ -13,9 +13,27 @@ void DownloadSettings::setDownloadUrlAt(int index, const QString &url)
     setValue(QVariant::fromValue(downloadURLs), "urls", "downloads");
 }
 
+/**
+ * If reset or first run, this method contains the default URLs we will populate
+ */
 QStringList DownloadSettings::getAllURLs()
 {
+    // First run, these will be empty
+    if (downloadURLs.count() == 0) {
+        populateDefaultURLs();
+    }
+
     return downloadURLs;
+}
+
+void DownloadSettings::populateDefaultURLs()
+{
+    downloadURLs.clear();
+    downloadURLs.append("https://api.scryfall.com/cards/!uuid!?format=image");
+    downloadURLs.append("https://api.scryfall.com/cards/multiverse/!cardid!?format=image");
+    downloadURLs.append("http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!cardid!&type=card");
+    downloadURLs.append("http://gatherer.wizards.com/Handlers/Image.ashx?name=!name!&type=card");
+    setValue(QVariant::fromValue(downloadURLs), "urls", "downloads");
 }
 
 QString DownloadSettings::getDownloadUrlAt(int index)

--- a/cockatrice/src/settings/downloadsettings.cpp
+++ b/cockatrice/src/settings/downloadsettings.cpp
@@ -1,0 +1,38 @@
+#include "downloadsettings.h"
+#include "settingsmanager.h"
+
+DownloadSettings::DownloadSettings(const QString &settingPath, QObject *parent = nullptr)
+    : SettingsManager(settingPath + "downloads.ini", parent)
+{
+    downloadURLs = getValue("urls", "downloads").value<QList<QString>>();
+}
+
+void DownloadSettings::setDownloadUrlAt(int index, const QString &url)
+{
+    downloadURLs.insert(index, url);
+    setValue(QVariant::fromValue(downloadURLs), "urls", "downloads");
+}
+
+QStringList DownloadSettings::getAllURLs()
+{
+    return downloadURLs;
+}
+
+QString DownloadSettings::getDownloadUrlAt(int index)
+{
+    if (0 <= index && index < downloadURLs.size()) {
+        return downloadURLs[index];
+    }
+
+    return "";
+}
+
+int DownloadSettings::getCount()
+{
+    return downloadURLs.size();
+}
+
+void DownloadSettings::clear()
+{
+    downloadURLs.clear();
+}

--- a/cockatrice/src/settings/downloadsettings.cpp
+++ b/cockatrice/src/settings/downloadsettings.cpp
@@ -4,7 +4,7 @@
 DownloadSettings::DownloadSettings(const QString &settingPath, QObject *parent = nullptr)
     : SettingsManager(settingPath + "downloads.ini", parent)
 {
-    downloadURLs = getValue("urls", "downloads").value<QList<QString>>();
+    downloadURLs = getValue("urls", "downloads").value<QStringList>();
 }
 
 void DownloadSettings::setDownloadUrlAt(int index, const QString &url)

--- a/cockatrice/src/settings/downloadsettings.h
+++ b/cockatrice/src/settings/downloadsettings.h
@@ -20,6 +20,9 @@ public:
 
 private:
     QStringList downloadURLs;
+
+private:
+    void populateDefaultURLs();
 };
 
 #endif // COCKATRICE_DOWNLOADSETTINGS_H

--- a/cockatrice/src/settings/downloadsettings.h
+++ b/cockatrice/src/settings/downloadsettings.h
@@ -19,7 +19,7 @@ public:
     void clear();
 
 private:
-    QList<QString> downloadURLs;
+    QStringList downloadURLs;
 };
 
 #endif // COCKATRICE_DOWNLOADSETTINGS_H

--- a/cockatrice/src/settings/downloadsettings.h
+++ b/cockatrice/src/settings/downloadsettings.h
@@ -1,0 +1,25 @@
+#ifndef COCKATRICE_DOWNLOADSETTINGS_H
+#define COCKATRICE_DOWNLOADSETTINGS_H
+
+#include "settingsmanager.h"
+#include <QObject>
+
+class DownloadSettings : public SettingsManager
+{
+    Q_OBJECT
+    friend class SettingsCache;
+
+public:
+    explicit DownloadSettings(const QString &, QObject *);
+
+    QStringList getAllURLs();
+    QString getDownloadUrlAt(int);
+    void setDownloadUrlAt(int, const QString &);
+    int getCount();
+    void clear();
+
+private:
+    QList<QString> downloadURLs;
+};
+
+#endif // COCKATRICE_DOWNLOADSETTINGS_H

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -164,6 +164,7 @@ SettingsCache::SettingsCache()
     messageSettings = new MessageSettings(settingsPath, this);
     gameFiltersSettings = new GameFiltersSettings(settingsPath, this);
     layoutsSettings = new LayoutsSettings(settingsPath, this);
+    downloadSettings = new DownloadSettings(settingsPath, this);
 
     if (!QFile(settingsPath + "global.ini").exists())
         translateLegacySettings();
@@ -219,9 +220,6 @@ SettingsCache::SettingsCache()
         pixmapCacheSize = PIXMAPCACHE_SIZE_DEFAULT;
 
     picDownload = settings->value("personal/picturedownload", true).toBool();
-
-    picUrl = settings->value("personal/picUrl", PIC_URL_DEFAULT).toString();
-    picUrlFallback = settings->value("personal/picUrlFallback", PIC_URL_FALLBACK).toString();
 
     mainWindowGeometry = settings->value("interface/main_window_geometry").toByteArray();
     tokenDialogGeometry = settings->value("interface/token_dialog_geometry").toByteArray();
@@ -413,18 +411,6 @@ void SettingsCache::setPicDownload(int _picDownload)
     picDownload = static_cast<bool>(_picDownload);
     settings->setValue("personal/picturedownload", picDownload);
     emit picDownloadChanged();
-}
-
-void SettingsCache::setPicUrl(const QString &_picUrl)
-{
-    picUrl = _picUrl;
-    settings->setValue("personal/picUrl", picUrl);
-}
-
-void SettingsCache::setPicUrlFallback(const QString &_picUrlFallback)
-{
-    picUrlFallback = _picUrlFallback;
-    settings->setValue("personal/picUrlFallback", picUrlFallback);
 }
 
 void SettingsCache::setNotificationsEnabled(int _notificationsEnabled)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -2,6 +2,7 @@
 #define SETTINGSCACHE_H
 
 #include "settings/carddatabasesettings.h"
+#include "settings/downloadsettings.h"
 #include "settings/gamefilterssettings.h"
 #include "settings/layoutssettings.h"
 #include "settings/messagesettings.h"
@@ -12,10 +13,6 @@
 #include <QStringList>
 
 class ReleaseChannel;
-
-// Fallbacks used for cards w/o MultiverseId
-#define PIC_URL_DEFAULT "https://api.scryfall.com/cards/multiverse/!cardid!?format=image"
-#define PIC_URL_FALLBACK "https://api.scryfall.com/cards/named?fuzzy=!name!&format=image"
 
 // size should be a multiple of 64
 #define PIXMAPCACHE_SIZE_DEFAULT 2047
@@ -61,6 +58,7 @@ private:
     MessageSettings *messageSettings;
     GameFiltersSettings *gameFiltersSettings;
     LayoutsSettings *layoutsSettings;
+    DownloadSettings *downloadSettings;
 
     QByteArray mainWindowGeometry;
     QByteArray tokenDialogGeometry;
@@ -303,14 +301,6 @@ public:
     {
         return ignoreUnregisteredUserMessages;
     }
-    QString getPicUrl() const
-    {
-        return picUrl;
-    }
-    QString getPicUrlFallback() const
-    {
-        return picUrlFallback;
-    }
     int getPixmapCacheSize() const
     {
         return pixmapCacheSize;
@@ -430,6 +420,10 @@ public:
     {
         return *layoutsSettings;
     }
+    DownloadSettings &downloads() const
+    {
+        return *downloadSettings;
+    }
     bool getIsPortableBuild() const
     {
         return isPortableBuild;
@@ -478,8 +472,6 @@ public slots:
     void setSoundThemeName(const QString &_soundThemeName);
     void setIgnoreUnregisteredUsers(int _ignoreUnregisteredUsers);
     void setIgnoreUnregisteredUserMessages(int _ignoreUnregisteredUserMessages);
-    void setPicUrl(const QString &_picUrl);
-    void setPicUrlFallback(const QString &_picUrlFallback);
     void setPixmapCacheSize(const int _pixmapCacheSize);
     void setCardScaling(const int _scaleCards);
     void setShowMessagePopups(const int _showMessagePopups);

--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -22,6 +22,7 @@ SET(oracle_SOURCES
     ../cockatrice/src/settings/messagesettings.cpp
     ../cockatrice/src/settings/gamefilterssettings.cpp
     ../cockatrice/src/settings/layoutssettings.cpp
+    ../cockatrice/src/settings/downloadsettings.cpp
     ../cockatrice/src/thememanager.cpp
     ../cockatrice/src/qt-json/json.cpp
     ../cockatrice/src/releasechannel.cpp

--- a/oracle/src/main.cpp
+++ b/oracle/src/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
 
     QCoreApplication::setOrganizationName("Cockatrice");
     QCoreApplication::setOrganizationDomain("cockatrice");
-    // this can't be changed, as it influences the default savepath for cards.xml
+    // this can't be changed, as it influences the default save path for cards.xml
     QCoreApplication::setApplicationName("Cockatrice");
 
     // If the program is opened with the -s flag, it will only do spoilers. Otherwise it will do MTGJSON/Tokens


### PR DESCRIPTION
Not sure which (if any) tickets this solves.

Cockatrice Picture loader uses better defined URLs now. URLs are defined on the Card Properties tab. Instead of Primary/Backup, you can now define a list of URLs. List of URLs can be drag/dropped for priority ordering.

ALSO: Oracle now uses `scryfallId` over `mtgjsonUUID` for `!uuid!` in URLs.

Before:
<img width="955" alt="screenshot 2019-01-07 20 24 14" src="https://user-images.githubusercontent.com/7460172/50804095-8bca0380-12ba-11e9-9b7a-73c6094fe462.png">


After:
<img width="923" alt="screenshot 2019-01-07 20 24 30" src="https://user-images.githubusercontent.com/7460172/50804094-8bca0380-12ba-11e9-95d4-fc1fb1ffd50a.png">
<img width="922" alt="screenshot 2019-01-07 20 24 37" src="https://user-images.githubusercontent.com/7460172/50804093-8bca0380-12ba-11e9-986e-6a342977ecaf.png">