### PR TITLE
Force Oracle run on new install/update

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -53,6 +53,7 @@ GeneralSettingsPage::GeneralSettingsPage()
     updateReleaseChannelBox.setCurrentIndex(settingsCache->getUpdateReleaseChannel()->getIndex());
 
     updateNotificationCheckBox.setChecked(settingsCache->getNotifyAboutUpdates());
+    newVersionOracleCheckBox.setChecked(settingsCache->getNotifyAboutNewVersion());
 
     // pixmap cache
     pixmapCacheEdit.setMinimum(PIXMAPCACHE_SIZE_MIN);
@@ -69,6 +70,7 @@ GeneralSettingsPage::GeneralSettingsPage()
     connect(&updateReleaseChannelBox, SIGNAL(currentIndexChanged(int)), settingsCache,
             SLOT(setUpdateReleaseChannel(int)));
     connect(&updateNotificationCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setNotifyAboutUpdate(int)));
+    connect(&newVersionOracleCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setNotifyAboutNewVersion(int)));
     connect(&showTipsOnStartup, SIGNAL(clicked(bool)), settingsCache, SLOT(setShowTipsOnStartup(bool)));
 
     auto *personalGrid = new QGridLayout;
@@ -79,7 +81,8 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(&pixmapCacheLabel, 2, 0);
     personalGrid->addWidget(&pixmapCacheEdit, 2, 1);
     personalGrid->addWidget(&updateNotificationCheckBox, 3, 0);
-    personalGrid->addWidget(&showTipsOnStartup, 4, 0);
+    personalGrid->addWidget(&newVersionOracleCheckBox, 4, 0);
+    personalGrid->addWidget(&showTipsOnStartup, 5, 0);
 
     personalGroupBox = new QGroupBox;
     personalGroupBox->setLayout(personalGrid);
@@ -242,6 +245,7 @@ void GeneralSettingsPage::retranslateUi()
     pixmapCacheLabel.setText(tr("Picture cache size:"));
     updateReleaseChannelLabel.setText(tr("Update channel"));
     updateNotificationCheckBox.setText(tr("Notify if a feature supported by the server is missing in my client"));
+    newVersionOracleCheckBox.setText(tr("Automatically run Oracle when running a new version of Cockatrice"));
     showTipsOnStartup.setText(tr("Show tips on startup"));
 }
 

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -60,6 +60,7 @@ private:
     QGroupBox *pathsGroupBox;
     QComboBox languageBox;
     QCheckBox updateNotificationCheckBox;
+    QCheckBox newVersionOracleCheckBox;
     QComboBox updateReleaseChannelBox;
     QLabel languageLabel;
     QLabel pixmapCacheLabel;

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -275,6 +275,7 @@ SettingsCache::SettingsCache()
     spectatorsCanSeeEverything = settings->value("game/spectatorscanseeeverything", false).toBool();
     rememberGameSettings = settings->value("game/remembergamesettings", true).toBool();
     clientID = settings->value("personal/clientid", "notset").toString();
+    clientVersion = settings->value("personal/clientversion", "notset").toString();
     knownMissingFeatures = settings->value("interface/knownmissingfeatures", "").toString();
 }
 
@@ -587,6 +588,12 @@ void SettingsCache::setClientID(QString _clientID)
 {
     clientID = std::move(_clientID);
     settings->setValue("personal/clientid", clientID);
+}
+
+void SettingsCache::setClientVersion(QString _clientVersion)
+{
+    clientVersion = std::move(_clientVersion);
+    settings->setValue("personal/clientversion", clientVersion);
 }
 
 QStringList SettingsCache::getCountries() const

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -177,6 +177,7 @@ SettingsCache::SettingsCache()
     mbDownloadSpoilers = settings->value("personal/downloadspoilers", false).toBool();
 
     notifyAboutUpdates = settings->value("personal/updatenotification", true).toBool();
+    notifyAboutNewVersion = settings->value("personal/newversionnotification", true).toBool();
     updateReleaseChannel = settings->value("personal/updatereleasechannel", 0).toInt();
 
     lang = settings->value("personal/lang").toString();
@@ -915,6 +916,12 @@ void SettingsCache::setNotifyAboutUpdate(int _notifyaboutupdate)
 {
     notifyAboutUpdates = static_cast<bool>(_notifyaboutupdate);
     settings->setValue("personal/updatenotification", notifyAboutUpdates);
+}
+
+void SettingsCache::setNotifyAboutNewVersion(int _notifyaboutnewversion)
+{
+    notifyAboutNewVersion = static_cast<bool>(_notifyaboutnewversion);
+    settings->setValue("personal/newversionnotification", notifyAboutNewVersion);
 }
 
 void SettingsCache::setDownloadSpoilerStatus(bool _spoilerStatus)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -97,6 +97,7 @@ private:
     QString picUrl;
     QString picUrlFallback;
     QString clientID;
+    QString clientVersion;
     QString knownMissingFeatures;
     int pixmapCacheSize;
     bool scaleCards;
@@ -387,10 +388,15 @@ public:
         return maxFontSize;
     }
     void setClientID(QString clientID);
+    void setClientVersion(QString clientVersion);
     void setKnownMissingFeatures(QString _knownMissingFeatures);
     QString getClientID()
     {
         return clientID;
+    }
+    QString getClientVersion()
+    {
+        return clientVersion;
     }
     QString getKnownMissingFeatures()
     {

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -66,6 +66,7 @@ private:
     QString deckPath, replaysPath, picsPath, customPicsPath, cardDatabasePath, customCardDatabasePath,
         spoilerDatabasePath, tokenDatabasePath, themeName;
     bool notifyAboutUpdates;
+    bool notifyAboutNewVersion;
     bool showTipsOnStartup;
     QList<int> seenTips;
     bool mbDownloadSpoilers;
@@ -200,6 +201,10 @@ public:
     bool getNotifyAboutUpdates() const
     {
         return notifyAboutUpdates;
+    }
+    bool getNotifyAboutNewVersion() const
+    {
+        return notifyAboutNewVersion;
     }
     bool getShowTipsOnStartup() const
     {
@@ -498,6 +503,7 @@ public slots:
     void setSpectatorsCanSeeEverything(const bool _spectatorsCanSeeEverything);
     void setRememberGameSettings(const bool _rememberGameSettings);
     void setNotifyAboutUpdate(int _notifyaboutupdate);
+    void setNotifyAboutNewVersion(int _notifyaboutnewversion);
     void setUpdateReleaseChannel(int _updateReleaseChannel);
     void setMaxFontSize(int _max);
 };

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -829,9 +829,12 @@ MainWindow::MainWindow(QWidget *parent)
         tip->show();
     }
 
-    auto versionUpdater = new MainUpdateHelper();
-    connect(versionUpdater, SIGNAL(newVersionDetected(QString)), this, SLOT(alertForcedOracleRun(QString)));
-    QtConcurrent::run(versionUpdater, &MainUpdateHelper::testForNewVersion);
+    // Only run the check updater if the user wants it (defaults to on)
+    if (settingsCache->getNotifyAboutNewVersion()) {
+        auto versionUpdater = new MainUpdateHelper();
+        connect(versionUpdater, SIGNAL(newVersionDetected(QString)), this, SLOT(alertForcedOracleRun(QString)));
+        QtConcurrent::run(versionUpdater, &MainUpdateHelper::testForNewVersion);
+    }
 }
 
 void MainWindow::alertForcedOracleRun(const QString &newVersion)
@@ -839,7 +842,8 @@ void MainWindow::alertForcedOracleRun(const QString &newVersion)
     settingsCache->setClientVersion(newVersion);
     QMessageBox::information(this, tr("New Version"),
                              tr("Congratulations on updating to Cockatrice %1!\n"
-                                "Oracle will now launch to update your card database.").arg(newVersion));
+                                "Oracle will now launch to update your card database.")
+                                 .arg(newVersion));
     actCheckCardUpdates();
 }
 

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -317,9 +317,9 @@ void MainWindow::actAbout()
 
 void MainWindow::actTips()
 {
-    if (tip != NULL) {
+    if (tip != nullptr) {
         delete tip;
-        tip = NULL;
+        tip = nullptr;
     }
     tip = new DlgTipOfTheDay();
     if (tip->successfulInit) {
@@ -828,13 +828,26 @@ MainWindow::MainWindow(QWidget *parent)
     if (tip->successfulInit && settingsCache->getShowTipsOnStartup() && tip->newTipsAvailable) {
         tip->show();
     }
+
+    auto versionUpdater = new MainUpdateHelper();
+    connect(versionUpdater, SIGNAL(newVersionDetected(QString)), this, SLOT(alertForcedOracleRun(QString)));
+    QtConcurrent::run(versionUpdater, &MainUpdateHelper::testForNewVersion);
+}
+
+void MainWindow::alertForcedOracleRun(const QString &newVersion)
+{
+    settingsCache->setClientVersion(newVersion);
+    QMessageBox::information(this, tr("New Version"),
+                             tr("Congratulations on updating to Cockatrice %1!\n"
+                                "Oracle will now launch to update your card database.").arg(newVersion));
+    actCheckCardUpdates();
 }
 
 MainWindow::~MainWindow()
 {
-    if (tip != NULL) {
+    if (tip != nullptr) {
         delete tip;
-        tip = NULL;
+        tip = nullptr;
     }
     if (trayIcon) {
         trayIcon->hide();
@@ -1269,5 +1282,12 @@ void MainWindow::promptForgotPasswordReset()
     if (dlg.exec()) {
         client->submitForgotPasswordResetToServer(dlg.getHost(), static_cast<unsigned int>(dlg.getPort()),
                                                   dlg.getPlayerName(), dlg.getToken(), dlg.getPassword());
+    }
+}
+
+void MainUpdateHelper::testForNewVersion()
+{
+    if (settingsCache->getClientVersion() != VERSION_STRING) {
+        emit newVersionDetected(VERSION_STRING);
     }
 }

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -101,6 +101,8 @@ private slots:
     void actManageSets();
     void actEditTokens();
 
+    void alertForcedOracleRun(const QString &);
+
 private:
     static const QString appName;
     static const QStringList fileNameFilters;
@@ -144,6 +146,19 @@ protected:
     void closeEvent(QCloseEvent *event) override;
     void changeEvent(QEvent *event) override;
     QString extractInvalidUsernameMessage(QString &in);
+};
+
+class MainUpdateHelper : public QObject
+{
+    Q_OBJECT
+
+signals:
+    void newVersionDetected(QString);
+
+public:
+    explicit MainUpdateHelper(QWidget *parent = nullptr) {}
+    ~MainUpdateHelper() override = default;
+    void testForNewVersion();
 };
 
 #endif

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -156,7 +156,7 @@ signals:
     void newVersionDetected(QString);
 
 public:
-    explicit MainUpdateHelper(QWidget *parent = nullptr) {}
+    explicit MainUpdateHelper() = default;
     ~MainUpdateHelper() override = default;
     void testForNewVersion();
 };


### PR DESCRIPTION
Whenever Cockatrice is launched for the first time on a new version, it will cause oracle to run