### PR TITLE
Workaround fedora compilation problem on Travis; fix #3508

### DIFF
--- a/.ci/Fedora29/Dockerfile
+++ b/.ci/Fedora29/Dockerfile
@@ -10,7 +10,7 @@ RUN dnf install -y \
         hicolor-icon-theme \
         libappstream-glib \
         protobuf-devel \
-        qt5-{qttools,qtsvg,qtmultimedia,qtwebsockets}-devel \
+        qt5-{qttools,qtsvg,qtmultimedia,qtwebsockets}-devel-5.11.1-4.fc29 \
         rpm-build \
         sqlite-devel \
         wget \

--- a/.ci/Fedora29/Dockerfile
+++ b/.ci/Fedora29/Dockerfile
@@ -10,7 +10,7 @@ RUN dnf install -y \
         hicolor-icon-theme \
         libappstream-glib \
         protobuf-devel \
-        qt5-{qttools,qtsvg,qtmultimedia,qtwebsockets}-devel-5.11.1-4.fc29 \
+        qt5-{qttools,qtsvg,qtmultimedia,qtwebsockets}-devel-5.11.1-2.fc29 \
         rpm-build \
         sqlite-devel \
         wget \


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3508

## Short roundup of the initial problem
See #3508

## What will change with this Pull Request?
Forcing an old, working Qt version still available on the fedora repository seems to workaround the issue.

