### PR TITLE
Disable darkmode on MacOS

### DIFF
--- a/cmake/Info.plist
+++ b/cmake/Info.plist
@@ -34,5 +34,7 @@
     <string>${MACOSX_BUNDLE_COPYRIGHT}</string>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>NSRequiresAquaSystemAppearance</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Short roundup of the initial problem

On MacOS, when compiling with Qt5.12, dark mode looks pretty bad.

## What will change with this Pull Request?
- Dark mode will be prevented

## Screenshots
![image](https://user-images.githubusercontent.com/671513/51514434-9610f500-1dc4-11e9-80bc-c6581577639c.png)
(What it looks like without this patch.  With it looks normal.)
