### PR TITLE
Unconcede

### DIFF
--- a/cockatrice/src/gamescene.cpp
+++ b/cockatrice/src/gamescene.cpp
@@ -40,7 +40,7 @@ void GameScene::addPlayer(Player *player)
     players << player;
     addItem(player);
     connect(player, SIGNAL(sizeChanged()), this, SLOT(rearrange()));
-    connect(player, SIGNAL(gameConceded()), this, SLOT(rearrange()));
+    connect(player, SIGNAL(playerCountChanged()), this, SLOT(rearrange()));
 }
 
 void GameScene::removePlayer(Player *player)

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -169,6 +169,12 @@ void MessageLogWidget::logConcede(Player *player)
     appendHtmlServerMessage(tr("%1 has conceded the game.").arg(sanitizeHtml(player->getName())), true);
 }
 
+void MessageLogWidget::logUnconcede(Player *player)
+{
+    soundEngine->playSound("player_concede");
+    appendHtmlServerMessage(tr("%1 has unconceded the game.").arg(sanitizeHtml(player->getName())), true);
+}
+
 void MessageLogWidget::logConnectionStateChanged(Player *player, bool connectionState)
 {
     if (connectionState) {

--- a/cockatrice/src/messagelogwidget.h
+++ b/cockatrice/src/messagelogwidget.h
@@ -57,6 +57,7 @@ public slots:
     void logAlwaysRevealTopCard(Player *player, CardZone *zone, bool reveal);
     void logAttachCard(Player *player, QString cardName, Player *targetPlayer, QString targetCardName);
     void logConcede(Player *player);
+    void logUnconcede(Player *player);
     void logConnectionStateChanged(Player *player, bool connectionState);
     void logCreateArrow(Player *player,
                         Player *startPlayer,

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -3041,8 +3041,8 @@ void Player::setConceded(bool _conceded)
     setVisible(!conceded);
     if (conceded) {
         clear();
-        emit gameConceded();
     }
+    emit playerCountChanged();
 }
 
 void Player::setMirrored(bool _mirrored)

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -132,7 +132,7 @@ signals:
     void logAlwaysRevealTopCard(Player *player, CardZone *zone, bool reveal);
 
     void sizeChanged();
-    void gameConceded();
+    void playerCountChanged();
 public slots:
     void actUntapAll();
     void actRollDie();

--- a/common/pb/command_concede.proto
+++ b/common/pb/command_concede.proto
@@ -5,3 +5,10 @@ message Command_Concede {
         optional Command_Concede ext = 1017;
     }
 }
+
+
+message Command_Unconcede {
+    extend GameCommand {
+        optional Command_Unconcede ext = 1032;
+    }
+}

--- a/common/pb/context_concede.proto
+++ b/common/pb/context_concede.proto
@@ -6,3 +6,9 @@ message Context_Concede {
         optional Context_Concede ext = 1001;
     }
 }
+
+message Context_Unconcede {
+    extend GameEventContext {
+        optional Context_Unconcede ext = 1009;
+    }
+}

--- a/common/pb/game_commands.proto
+++ b/common/pb/game_commands.proto
@@ -33,6 +33,8 @@ message GameCommand {
         DECK_SELECT = 1029;
         SET_SIDEBOARD_LOCK = 1030;
         CHANGE_ZONE_PROPERTIES = 1031;
+        UNCONCEDE = 1032;
+
     }
     extensions 100 to max;
 }

--- a/common/pb/game_event_context.proto
+++ b/common/pb/game_event_context.proto
@@ -10,6 +10,7 @@ message GameEventContext {
         PING_CHANGED = 1006;
         CONNECTION_STATE_CHANGED = 1007;
         SET_SIDEBOARD_LOCK = 1008;
+        UNCONCEDE = 1009;
     }
     extensions 100 to max;
 }

--- a/common/server_game.h
+++ b/common/server_game.h
@@ -77,7 +77,6 @@ private:
                                      Server_Player *playerWhosAsking,
                                      bool omniscient,
                                      bool withUserInfo);
-    void sendGameStateToPlayers();
     void storeGameInformation();
 signals:
     void sigStartGameIfReady();
@@ -192,6 +191,7 @@ public:
     prepareGameEvent(const ::google::protobuf::Message &gameEvent, int playerId, GameEventContext *context = 0);
     GameEventContext prepareGameEventContext(const ::google::protobuf::Message &gameEventContext);
 
+    void sendGameStateToPlayers();
     void sendGameEventContainer(GameEventContainer *cont,
                                 GameEventStorageItem::EventRecipients recipients = GameEventStorageItem::SendToPrivate |
                                                                                    GameEventStorageItem::SendToOthers,

--- a/common/server_player.h
+++ b/common/server_player.h
@@ -46,6 +46,7 @@ class Command_SetCardCounter;
 class Command_IncCardCounter;
 class Command_ReadyStart;
 class Command_Concede;
+class Command_Unconcede;
 class Command_IncCounter;
 class Command_CreateCounter;
 class Command_SetCounter;
@@ -190,6 +191,7 @@ public:
     Response::ResponseCode
     cmdKickFromGame(const Command_KickFromGame &cmd, ResponseContainer &rc, GameEventStorage &ges);
     Response::ResponseCode cmdConcede(const Command_Concede &cmd, ResponseContainer &rc, GameEventStorage &ges);
+    Response::ResponseCode cmdUnconcede(const Command_Unconcede &cmd, ResponseContainer &rc, GameEventStorage &ges);
     Response::ResponseCode cmdReadyStart(const Command_ReadyStart &cmd, ResponseContainer &rc, GameEventStorage &ges);
     Response::ResponseCode cmdDeckSelect(const Command_DeckSelect &cmd, ResponseContainer &rc, GameEventStorage &ges);
     Response::ResponseCode


### PR DESCRIPTION
## Short roundup of the initial problem
- In a multiplayer game, if a player concedes but wants to reenter the game, all the remaining players in the game must also concede, restart the match, and then get their cards back how they were.
- When playing non-magic games like poker, a player can concede to sit out for a few hands, and then unconcede to resume playing. 

## What will change with this Pull Request?
- Clicking concede when a player has already conceded will prompt them asking if they would like to rejoin the game.


