### PR TITLE
correctly report exit code in clangify

### DIFF
--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -56,8 +56,8 @@ done
 if [[ $CHECK_FORMAT ]]; then
   echo "Checking your code using clang-format..."
   diff="$(./clangify.sh --diff --cf-version)"
-  ok=$?
-  case $ok in
+  err=$?
+  case $err in
     1)
       cat <<EOM
 ***********************************************************


### PR DESCRIPTION
Just a small mistake in travis compile, the exit code was saved to a different name than used to report it.