### PR TITLE
Bump version to 2.6.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 # A project name is needed for CPack
 # Version can be overriden by git tags, see cmake/getversion.cmake
-PROJECT("Cockatrice" VERSION 2.6.2)
+PROJECT("Cockatrice" VERSION 2.6.3)
 
 # Use c++11 for all targets
 set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ ISO Standard")


### PR DESCRIPTION
## Short roundup of the initial problem
A beta release for 2.6.3 has been relesed, but the codebase is still at 2.6.2

## What will change with this Pull Request?
Bumped version to 2.6.3
