### PR TITLE
Fix up Dockerfile to use ubuntu:bionic and actually build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,6 @@ RUN apt-get update && apt-get install -y\
 COPY . /home/servatrice/code/
 WORKDIR /home/servatrice/code
 
-<<<<<<< HEAD
-=======
-COPY . /home/servatrice/code/
-WORKDIR /home/servatrice/code
-
->>>>>>> 9565b8fa01261d75c26dfae313b05f775d076483
 RUN mkdir oracle
 
 WORKDIR build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
 FROM ubuntu:bionic
 MAINTAINER Zach Halpern <zahalpern+github@gmail.com>
 
-RUN apt-get update && apt-get install -y software-properties-common
 #RUN add-apt-repository -y ppa:smspillaz/cmake-master
 RUN apt-get update && apt-get install -y\
-  build-essential g++\
+  build-essential\
   cmake\
   git\
   libprotobuf-dev\
+  libqt5sql5-mysql\
   protobuf-compiler\
   qt5-default\
   qtbase5-dev\
   qttools5-dev-tools\
   qttools5-dev\
-  libqt5sql5-mysql
+  software-properties-common
 
 COPY . /home/servatrice/code/
 WORKDIR /home/servatrice/code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM ubuntu:trusty
+FROM ubuntu:bionic
 MAINTAINER Zach Halpern <zahalpern+github@gmail.com>
 
 RUN apt-get update && apt-get install -y software-properties-common
-RUN apt-add-repository ppa:ubuntu-sdk-team/ppa
-RUN add-apt-repository -y ppa:smspillaz/cmake-master
+#RUN add-apt-repository -y ppa:smspillaz/cmake-master
 RUN apt-get update && apt-get install -y\
   build-essential g++\
   cmake\
@@ -16,15 +15,10 @@ RUN apt-get update && apt-get install -y\
   qttools5-dev\
   libqt5sql5-mysql
 
-ENV dir /home/servatrice/code
-WORKDIR $dir
+COPY . /home/servatrice/code/
+WORKDIR /home/servatrice/code
+
 RUN mkdir oracle
-COPY LICENSE LICENSE
-COPY CMakeLists.txt CMakeLists.txt
-COPY cmake/ cmake/
-COPY common/ common/
-COPY servatrice/ servatrice/
-COPY README.md README.md
 
 WORKDIR build
 RUN cmake .. -DWITH_SERVER=1 -DWITH_CLIENT=0 -DWITH_ORACLE=0 &&\


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3539

## Short roundup of the initial problem

The servertrice Docker build does not work.

## What will change with this Pull Request?
- `Dockerfile` is revamped to use `ubuntu:bionic`, no PPAs, and transfer all the correct files to the container.
- Building the image specified by the `Dockerfile` now works.

## Screenshots
N/A