### PR TITLE
removes the pt of face down cards

### DIFF
--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -696,14 +696,19 @@ void MessageLogWidget::logSetPT(Player *player, CardItem *card, QString newPT)
 {
     if (currentContext == MessageContext_MoveCard) {
         moveCardPT.insert(card, newPT);
-    } else if (newPT.isEmpty()) {
-        appendHtmlServerMessage(
-            tr("%1 removes the PT of %2.").arg(sanitizeHtml(player->getName())).arg(cardLink(card->getName())));
     } else {
-        appendHtmlServerMessage(tr("%1 sets PT of %2 to %3.")
-                                    .arg(sanitizeHtml(player->getName()))
-                                    .arg(cardLink(card->getName()))
-                                    .arg(QString("<font color=\"blue\">%1</font>").arg(sanitizeHtml(newPT))));
+        QString name = card->getName();
+        if (name.isEmpty()) {
+            name = QString("<font color=\"blue\">card %1</font>").arg(sanitizeHtml(QString::number(card->getId())));
+        } else {
+            name = cardLink(name);
+        }
+        if (newPT.isEmpty()) {
+            appendHtmlServerMessage(tr("%1 removes the PT of %2.").arg(sanitizeHtml(player->getName())).arg(name));
+        } else {
+            appendHtmlServerMessage(
+                tr("%1 sets PT of %2 to %3.").arg(sanitizeHtml(player->getName())).arg(name).arg(newPT));
+        }
     }
 }
 

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -694,13 +694,17 @@ void MessageLogWidget::logSetDoesntUntap(Player *player, CardItem *card, bool do
 
 void MessageLogWidget::logSetPT(Player *player, CardItem *card, QString newPT)
 {
-    if (currentContext == MessageContext_MoveCard)
+    if (currentContext == MessageContext_MoveCard) {
         moveCardPT.insert(card, newPT);
-    else
+    } else if (newPT.isEmpty()) {
+        appendHtmlServerMessage(
+            tr("%1 removes the PT of %2.").arg(sanitizeHtml(player->getName())).arg(cardLink(card->getName())));
+    } else {
         appendHtmlServerMessage(tr("%1 sets PT of %2 to %3.")
                                     .arg(sanitizeHtml(player->getName()))
                                     .arg(cardLink(card->getName()))
                                     .arg(QString("<font color=\"blue\">%1</font>").arg(sanitizeHtml(newPT))));
+    }
 }
 
 void MessageLogWidget::logSetSideboardLock(Player *player, bool locked)

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -699,7 +699,7 @@ void MessageLogWidget::logSetPT(Player *player, CardItem *card, QString newPT)
     } else {
         QString name = card->getName();
         if (name.isEmpty()) {
-            name = QString("<font color=\"blue\">card %1</font>").arg(sanitizeHtml(QString::number(card->getId())));
+            name = QString("<font color=\"blue\">card #%1</font>").arg(sanitizeHtml(QString::number(card->getId())));
         } else {
             name = cardLink(name);
         }

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2518,12 +2518,18 @@ void Player::actResetPT()
         if (!info) {
             continue;
         }
-        auto *cmd = new Command_SetCardAttr;
+        QString ptString;
+        if (!card->getFaceDown()) { // leave the pt empty if the card is face down
+            ptString = info->getPowTough();
+        }
+        if (ptString == card->getPT()) {
+            continue;
+        }
         QString zoneName = card->getZone()->getName();
+        auto *cmd = new Command_SetCardAttr;
         cmd->set_zone(zoneName.toStdString());
         cmd->set_card_id(card->getId());
         cmd->set_attribute(AttrPT);
-        QString ptString = info->getPowTough();
         cmd->set_attr_value(ptString.toStdString());
         commandList.append(cmd);
 

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2514,13 +2514,12 @@ void Player::actResetPT()
     QListIterator<QGraphicsItem *> selected(scene()->selectedItems());
     while (selected.hasNext()) {
         auto *card = static_cast<CardItem *>(selected.next());
-        CardInfoPtr info = card->getInfo();
-        if (!info) {
-            continue;
-        }
         QString ptString;
         if (!card->getFaceDown()) { // leave the pt empty if the card is face down
-            ptString = info->getPowTough();
+            CardInfoPtr info = card->getInfo();
+            if (info) {
+                ptString = info->getPowTough();
+            }
         }
         if (ptString == card->getPT()) {
             continue;


### PR DESCRIPTION
Instead of setting the pt of a hidden card to the value only known to
you, it's reset to nothing.
Resetting a card while it's already reset does nothing.
Removing the pt of a card is logged as "player removes the pt of card."
instead of "player sets the pt of card to ." (note the missing value).

Another great fix for #3412 
Fixes #3493 