### PR TITLE
Client Websockets

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -152,7 +152,8 @@ ENDIF(APPLE)
 
 # Qt5
 find_package(Qt5 COMPONENTS Concurrent Multimedia Network PrintSupport Svg Widgets REQUIRED)
-set(COCKATRICE_QT_MODULES Qt5::Concurrent Qt5::Multimedia Qt5::Network Qt5::PrintSupport Qt5::Svg Qt5::Widgets)
+find_package(Qt5WebSockets REQUIRED)
+set(COCKATRICE_QT_MODULES Qt5::Concurrent Qt5::Multimedia Qt5::Network Qt5::PrintSupport Qt5::Svg Qt5::Widgets Qt5::WebSockets)
 
 # Qt5LinguistTools
 find_package(Qt5LinguistTools)
@@ -171,13 +172,6 @@ if(Qt5LinguistTools_FOUND)
     else()
         QT5_ADD_TRANSLATION(cockatrice_QM ${cockatrice_TS})
     endif()
-endif()
-
-find_package(Qt5WebSockets)
-if(Qt5WebSockets_FOUND)
-    list(APPEND COCKATRICE_QT_MODULES Qt5::WebSockets)
-else()
-    MESSAGE(WARNING "Qt5 websocket module not found")
 endif()
 
 QT5_ADD_RESOURCES(cockatrice_RESOURCES_RCC ${cockatrice_RESOURCES})

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -173,6 +173,13 @@ if(Qt5LinguistTools_FOUND)
     endif()
 endif()
 
+find_package(Qt5WebSockets)
+if(Qt5WebSockets_FOUND)
+    list(APPEND COCKATRICE_QT_MODULES Qt5::WebSockets)
+else()
+    MESSAGE(WARNING "Qt5 websocket module not found")
+endif()
+
 QT5_ADD_RESOURCES(cockatrice_RESOURCES_RCC ${cockatrice_RESOURCES})
 
 # Declare path variables

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -151,8 +151,7 @@ if(APPLE)
 ENDIF(APPLE)
 
 # Qt5
-find_package(Qt5 COMPONENTS Concurrent Multimedia Network PrintSupport Svg Widgets REQUIRED)
-find_package(Qt5WebSockets REQUIRED)
+find_package(Qt5 COMPONENTS Concurrent Multimedia Network PrintSupport Svg WebSockets Widgets REQUIRED)
 set(COCKATRICE_QT_MODULES Qt5::Concurrent Qt5::Multimedia Qt5::Network Qt5::PrintSupport Qt5::Svg Qt5::Widgets Qt5::WebSockets)
 
 # Qt5LinguistTools

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -479,8 +479,12 @@ void MessageLogWidget::logRevealCards(Player *player,
     if (cardNameContainsStartZone) {
         cardStr = cardName;
     } else if (cardName.isEmpty()) {
-        cardStr = tr("%1 card(s)", "a card for singular, %1 cards for plural", amount)
-                      .arg("<font color=\"blue\">" + QString::number(amount) + "</font>");
+        if (amount == 0) {
+            cardStr = tr("cards", "an unknown amount of cards");
+        } else {
+            cardStr = tr("%1 card(s)", "a card for singular, %1 cards for plural", amount)
+                          .arg("<font color=\"blue\">" + QString::number(amount) + "</font>");
+        }
     } else {
         cardStr = cardLink(cardName);
     }

--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -18,12 +18,13 @@
 #include <QList>
 #include <QThread>
 #include <QTimer>
+#include <QWebSocket>
 
 static const unsigned int protocolVersion = 14;
 
 RemoteClient::RemoteClient(QObject *parent)
     : AbstractClient(parent), timeRunning(0), lastDataReceived(0), messageInProgress(false), handshakeStarted(false),
-      messageLength(0)
+      usingWebSocket(false), messageLength(0)
 {
 
     clearNewClientFeatures();
@@ -38,6 +39,13 @@ RemoteClient::RemoteClient(QObject *parent)
     connect(socket, SIGNAL(readyRead()), this, SLOT(readData()));
     connect(socket, SIGNAL(error(QAbstractSocket::SocketError)), this,
             SLOT(slotSocketError(QAbstractSocket::SocketError)));
+
+    websocket = new QWebSocket(QString(), QWebSocketProtocol::VersionLatest, this);
+    connect(websocket, &QWebSocket::binaryMessageReceived, this, &RemoteClient::websocketMessageReceived);
+    connect(websocket, &QWebSocket::connected, this, &RemoteClient::slotConnected);
+    connect(websocket, SIGNAL(error(QAbstractSocket::SocketError)), this,
+            SLOT(slotWebSocketError(QAbstractSocket::SocketError)));
+
     connect(this, SIGNAL(serverIdentificationEventReceived(const Event_ServerIdentification &)), this,
             SLOT(processServerIdentificationEvent(const Event_ServerIdentification &)));
     connect(this, SIGNAL(connectionClosedEventReceived(Event_ConnectionClosed)), this,
@@ -69,15 +77,25 @@ void RemoteClient::slotSocketError(QAbstractSocket::SocketError /*error*/)
     emit socketError(errorString);
 }
 
+void RemoteClient::slotWebSocketError(QAbstractSocket::SocketError /*error*/)
+{
+
+    QString errorString = websocket->errorString();
+    doDisconnectFromServer();
+    emit socketError(errorString);
+}
+
 void RemoteClient::slotConnected()
 {
     timeRunning = lastDataReceived = 0;
     timer->start();
 
-    // dirty hack to be compatible with v14 server
-    sendCommandContainer(CommandContainer());
-    getNewCmdId();
-    // end of hack
+    if (!usingWebSocket) {
+        // dirty hack to be compatible with v14 server
+        sendCommandContainer(CommandContainer());
+        getNewCmdId();
+        // end of hack
+    }
 }
 
 void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentification &event)
@@ -301,21 +319,51 @@ void RemoteClient::readData()
     } while (!inputBuffer.isEmpty());
 }
 
+void RemoteClient::websocketMessageReceived(const QByteArray &message)
+{
+    lastDataReceived = timeRunning;
+    ServerMessage newServerMessage;
+    newServerMessage.ParseFromArray(message.data(), message.length());
+#ifdef QT_DEBUG
+    qDebug() << "IN" << messageLength << QString::fromStdString(newServerMessage.ShortDebugString());
+#endif
+    processProtocolItem(newServerMessage);
+}
+
 void RemoteClient::sendCommandContainer(const CommandContainer &cont)
 {
-    QByteArray buf;
+
     unsigned int size = cont.ByteSize();
 #ifdef QT_DEBUG
     qDebug() << "OUT" << size << QString::fromStdString(cont.ShortDebugString());
 #endif
-    buf.resize(size + 4);
-    cont.SerializeToArray(buf.data() + 4, size);
-    buf.data()[3] = (unsigned char)size;
-    buf.data()[2] = (unsigned char)(size >> 8);
-    buf.data()[1] = (unsigned char)(size >> 16);
-    buf.data()[0] = (unsigned char)(size >> 24);
 
-    socket->write(buf);
+    QByteArray buf;
+    if (usingWebSocket) {
+        buf.resize(size);
+        cont.SerializeToArray(buf.data(), size);
+        websocket->sendBinaryMessage(buf);
+    } else {
+        buf.resize(size + 4);
+        cont.SerializeToArray(buf.data() + 4, size);
+        buf.data()[3] = (unsigned char)size;
+        buf.data()[2] = (unsigned char)(size >> 8);
+        buf.data()[1] = (unsigned char)(size >> 16);
+        buf.data()[0] = (unsigned char)(size >> 24);
+
+        socket->write(buf);
+    }
+}
+
+void RemoteClient::connectToHost(const QString &hostname, unsigned int port)
+{
+    usingWebSocket = port == 443 || port == 80 || port == 4748 || port == 8080;
+    if (usingWebSocket) {
+        QUrl url(QString("%1://%2:%3").arg(port == 443 ? "wss" : "ws").arg(hostname).arg(port));
+        websocket->open(url);
+    } else {
+        socket->connectToHost(hostname, port);
+    }
 }
 
 void RemoteClient::doConnectToServer(const QString &hostname,
@@ -330,7 +378,7 @@ void RemoteClient::doConnectToServer(const QString &hostname,
     lastHostname = hostname;
     lastPort = port;
 
-    socket->connectToHost(hostname, port);
+    connectToHost(hostname, port);
     setStatus(StatusConnecting);
 }
 
@@ -354,7 +402,7 @@ void RemoteClient::doRegisterToServer(const QString &hostname,
     lastHostname = hostname;
     lastPort = port;
 
-    socket->connectToHost(hostname, port);
+    connectToHost(hostname, port);
     setStatus(StatusRegistering);
 }
 
@@ -364,7 +412,7 @@ void RemoteClient::doActivateToServer(const QString &_token)
 
     token = _token;
 
-    socket->connectToHost(lastHostname, lastPort);
+    connectToHost(lastHostname, lastPort);
     setStatus(StatusActivating);
 }
 
@@ -388,6 +436,8 @@ void RemoteClient::doDisconnectFromServer()
     pendingCommands.clear();
 
     setStatus(StatusDisconnected);
+    if (websocket->isValid())
+        websocket->close();
     socket->close();
 }
 
@@ -508,7 +558,7 @@ void RemoteClient::doRequestForgotPasswordToServer(const QString &hostname, unsi
     lastHostname = hostname;
     lastPort = port;
 
-    socket->connectToHost(lastHostname, lastPort);
+    connectToHost(lastHostname, lastPort);
     setStatus(StatusRequestingForgotPassword);
 }
 
@@ -540,7 +590,7 @@ void RemoteClient::doSubmitForgotPasswordResetToServer(const QString &hostname,
     token = _token;
     password = _newpassword;
 
-    socket->connectToHost(lastHostname, lastPort);
+    connectToHost(lastHostname, lastPort);
     setStatus(StatusSubmitForgotPasswordReset);
 }
 
@@ -574,7 +624,7 @@ void RemoteClient::doSubmitForgotPasswordChallengeToServer(const QString &hostna
     lastPort = port;
     email = _email;
 
-    socket->connectToHost(lastHostname, lastPort);
+    connectToHost(lastHostname, lastPort);
     setStatus(StatusSubmitForgotPasswordChallenge);
 }
 

--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -235,7 +235,7 @@ void RemoteClient::loginResponse(const Response &response)
                 missingFeatures << QString::fromStdString(resp.missing_features(i));
         }
         emit loginError(response.response_code(), QString::fromStdString(resp.denied_reason_str()),
-                        resp.denied_end_time(), missingFeatures);
+                        static_cast<quint32>(resp.denied_end_time()), missingFeatures);
         setStatus(StatusDisconnecting);
     }
 }
@@ -254,7 +254,7 @@ void RemoteClient::registerResponse(const Response &response)
             break;
         default:
             emit registerError(response.response_code(), QString::fromStdString(resp.denied_reason_str()),
-                               resp.denied_end_time());
+                               static_cast<quint32>(resp.denied_end_time()));
             setStatus(StatusDisconnecting);
             doDisconnectFromServer();
             break;
@@ -333,7 +333,7 @@ void RemoteClient::websocketMessageReceived(const QByteArray &message)
 void RemoteClient::sendCommandContainer(const CommandContainer &cont)
 {
 
-    unsigned int size = cont.ByteSize();
+    auto size = static_cast<unsigned int>(cont.ByteSize());
 #ifdef QT_DEBUG
     qDebug() << "OUT" << size << QString::fromStdString(cont.ShortDebugString());
 #endif
@@ -362,7 +362,7 @@ void RemoteClient::connectToHost(const QString &hostname, unsigned int port)
         QUrl url(QString("%1://%2:%3").arg(port == 443 ? "wss" : "ws").arg(hostname).arg(port));
         websocket->open(url);
     } else {
-        socket->connectToHost(hostname, port);
+        socket->connectToHost(hostname, static_cast<quint16>(port));
     }
 }
 
@@ -412,7 +412,7 @@ void RemoteClient::doActivateToServer(const QString &_token)
 
     token = _token;
 
-    connectToHost(lastHostname, lastPort);
+    connectToHost(lastHostname, static_cast<unsigned int>(lastPort));
     setStatus(StatusActivating);
 }
 
@@ -425,13 +425,13 @@ void RemoteClient::doDisconnectFromServer()
     messageLength = 0;
 
     QList<PendingCommand *> pc = pendingCommands.values();
-    for (int i = 0; i < pc.size(); i++) {
+    for (const auto &i : pc) {
         Response response;
         response.set_response_code(Response::RespNotConnected);
-        response.set_cmd_id(pc[i]->getCommandContainer().cmd_id());
-        pc[i]->processResponse(response);
+        response.set_cmd_id(i->getCommandContainer().cmd_id());
+        i->processResponse(response);
 
-        delete pc[i];
+        delete i;
     }
     pendingCommands.clear();
 
@@ -558,7 +558,7 @@ void RemoteClient::doRequestForgotPasswordToServer(const QString &hostname, unsi
     lastHostname = hostname;
     lastPort = port;
 
-    connectToHost(lastHostname, lastPort);
+    connectToHost(lastHostname, static_cast<unsigned int>(lastPort));
     setStatus(StatusRequestingForgotPassword);
 }
 
@@ -590,7 +590,7 @@ void RemoteClient::doSubmitForgotPasswordResetToServer(const QString &hostname,
     token = _token;
     password = _newpassword;
 
-    connectToHost(lastHostname, lastPort);
+    connectToHost(lastHostname, static_cast<unsigned int>(lastPort));
     setStatus(StatusSubmitForgotPasswordReset);
 }
 
@@ -624,7 +624,7 @@ void RemoteClient::doSubmitForgotPasswordChallengeToServer(const QString &hostna
     lastPort = port;
     email = _email;
 
-    connectToHost(lastHostname, lastPort);
+    connectToHost(lastHostname, static_cast<unsigned int>(lastPort));
     setStatus(StatusSubmitForgotPasswordChallenge);
 }
 

--- a/cockatrice/src/remoteclient.h
+++ b/cockatrice/src/remoteclient.h
@@ -112,9 +112,9 @@ public:
     QString peerName() const
     {
         if (usingWebSocket) {
-            return socket->peerName();
-        } else {
             return websocket->peerName();
+        } else {
+            return socket->peerName();
         }
     }
     void

--- a/cockatrice/src/remoteclient.h
+++ b/cockatrice/src/remoteclient.h
@@ -3,6 +3,7 @@
 
 #include "abstractclient.h"
 #include <QTcpSocket>
+#include <QWebSocket>
 
 class QTimer;
 
@@ -48,7 +49,9 @@ signals:
 private slots:
     void slotConnected();
     void readData();
+    void websocketMessageReceived(const QByteArray &message);
     void slotSocketError(QAbstractSocket::SocketError error);
+    void slotWebSocketError(QAbstractSocket::SocketError error);
     void ping();
     void processServerIdentificationEvent(const Event_ServerIdentification &event);
     void processConnectionClosedEvent(const Event_ConnectionClosed &event);
@@ -89,12 +92,15 @@ private:
     QByteArray inputBuffer;
     bool messageInProgress;
     bool handshakeStarted;
+    bool usingWebSocket;
     bool newMissingFeatureFound(QString _serversMissingFeatures);
     void clearNewClientFeatures();
+    void connectToHost(const QString &hostname, unsigned int port);
     int messageLength;
 
     QTimer *timer;
     QTcpSocket *socket;
+    QWebSocket *websocket;
     QString lastHostname;
     int lastPort;
     QString getSrvClientID(const QString _hostname);
@@ -106,7 +112,11 @@ public:
     ~RemoteClient();
     QString peerName() const
     {
-        return socket->peerName();
+        if (usingWebSocket) {
+            return socket->peerName();
+        } else {
+            return websocket->peerName();
+        }
     }
     void
     connectToServer(const QString &hostname, unsigned int port, const QString &_userName, const QString &_password);

--- a/cockatrice/src/remoteclient.h
+++ b/cockatrice/src/remoteclient.h
@@ -18,7 +18,6 @@ signals:
     void activateError();
     void socketError(const QString &errorString);
     void protocolVersionMismatch(int clientVersion, int serverVersion);
-    void protocolError();
     void
     sigConnectToServer(const QString &hostname, unsigned int port, const QString &_userName, const QString &_password);
     void sigRegisterToServer(const QString &hostname,
@@ -26,7 +25,7 @@ signals:
                              const QString &_userName,
                              const QString &_password,
                              const QString &_email,
-                             const int _gender,
+                             int _gender,
                              const QString &_country,
                              const QString &_realname);
     void sigActivateToServer(const QString &_token);
@@ -65,7 +64,7 @@ private slots:
                             const QString &_userName,
                             const QString &_password,
                             const QString &_email,
-                            const int _gender,
+                            int _gender,
                             const QString &_country,
                             const QString &_realname);
     void doLogin();
@@ -88,28 +87,28 @@ private slots:
 private:
     static const int maxTimeout = 10;
     int timeRunning, lastDataReceived;
-
     QByteArray inputBuffer;
     bool messageInProgress;
     bool handshakeStarted;
     bool usingWebSocket;
-    bool newMissingFeatureFound(QString _serversMissingFeatures);
-    void clearNewClientFeatures();
-    void connectToHost(const QString &hostname, unsigned int port);
     int messageLength;
-
     QTimer *timer;
     QTcpSocket *socket;
     QWebSocket *websocket;
     QString lastHostname;
     int lastPort;
-    QString getSrvClientID(const QString _hostname);
+
+    QString getSrvClientID(QString _hostname);
+    bool newMissingFeatureFound(QString _serversMissingFeatures);
+    void clearNewClientFeatures();
+    void connectToHost(const QString &hostname, unsigned int port);
+
 protected slots:
-    void sendCommandContainer(const CommandContainer &cont);
+    void sendCommandContainer(const CommandContainer &cont) override;
 
 public:
-    RemoteClient(QObject *parent = 0);
-    ~RemoteClient();
+    explicit RemoteClient(QObject *parent = nullptr);
+    ~RemoteClient() override;
     QString peerName() const
     {
         if (usingWebSocket) {
@@ -125,7 +124,7 @@ public:
                           const QString &_userName,
                           const QString &_password,
                           const QString &_email,
-                          const int _gender,
+                          int _gender,
                           const QString &_country,
                           const QString &_realname);
     void activateToServer(const QString &_token);

--- a/servatrice/CMakeLists.txt
+++ b/servatrice/CMakeLists.txt
@@ -43,10 +43,8 @@ if(APPLE)
 ENDIF(APPLE)
 
 # Qt5
-find_package(Qt5 COMPONENTS Network Sql REQUIRED)
-find_package(Qt5WebSockets REQUIRED)
+find_package(Qt5 COMPONENTS Network Sql WebSockets REQUIRED)
 set(SERVATRICE_QT_MODULES Qt5::Core Qt5::Network Qt5::Sql Qt5::WebSockets)
-
 
 QT5_ADD_RESOURCES(servatrice_RESOURCES_RCC ${servatrice_RESOURCES})
 SET(QT_DONT_USE_QTGUI TRUE)

--- a/servatrice/CMakeLists.txt
+++ b/servatrice/CMakeLists.txt
@@ -44,15 +44,9 @@ ENDIF(APPLE)
 
 # Qt5
 find_package(Qt5 COMPONENTS Network Sql REQUIRED)
-set(SERVATRICE_QT_MODULES Qt5::Core Qt5::Network Qt5::Sql)
+find_package(Qt5WebSockets REQUIRED)
+set(SERVATRICE_QT_MODULES Qt5::Core Qt5::Network Qt5::Sql Qt5::WebSockets)
 
-# Qt Websockets
-find_package(Qt5WebSockets)
-if(Qt5WebSockets_FOUND)
-    list(APPEND SERVATRICE_QT_MODULES Qt5::WebSockets)
-else()
-    MESSAGE(WARNING "Qt5 websocket module not found")
-endif()
 
 QT5_ADD_RESOURCES(servatrice_RESOURCES_RCC ${servatrice_RESOURCES})
 SET(QT_DONT_USE_QTGUI TRUE)

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -104,7 +104,6 @@ Servatrice_ConnectionPool *Servatrice_GameServer::findLeastUsedConnectionPool()
     return connectionPools[poolIndex];
 }
 
-#ifdef QT_WEBSOCKETS_LIB
 #define WEBSOCKET_POOL_NUMBER 999
 
 Servatrice_WebsocketGameServer::Servatrice_WebsocketGameServer(Servatrice *_server,
@@ -163,7 +162,6 @@ Servatrice_ConnectionPool *Servatrice_WebsocketGameServer::findLeastUsedConnecti
     qDebug() << "Pool utilisation:" << debugStr;
     return connectionPools[poolIndex];
 }
-#endif
 
 void Servatrice_IslServer::incomingConnection(qintptr socketDescriptor)
 {
@@ -431,7 +429,6 @@ bool Servatrice::initServer()
         }
     }
 
-#ifdef QT_WEBSOCKETS_LIB
     // WEBSOCKET SERVER
     if (getNumberOfWebSocketPools() > 0) {
         websocketGameServer = new Servatrice_WebsocketGameServer(this, getNumberOfWebSocketPools(),
@@ -447,7 +444,6 @@ bool Servatrice::initServer()
             return false;
         }
     }
-#endif
 
     if (getIdleClientTimeout() > 0) {
         qDebug() << "Idle client timeout value: " << getIdleClientTimeout();

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -20,10 +20,6 @@
 #ifndef SERVATRICE_H
 #define SERVATRICE_H
 
-#include <QTcpServer>
-#ifdef QT_WEBSOCKETS_LIB
-#include <QWebSocketServer>
-#endif
 #include "server.h"
 #include <QHostAddress>
 #include <QMetaType>
@@ -32,6 +28,8 @@
 #include <QSqlDatabase>
 #include <QSslCertificate>
 #include <QSslKey>
+#include <QTcpServer>
+#include <QWebSocketServer>
 #include <utility>
 
 Q_DECLARE_METATYPE(QSqlDatabase)
@@ -66,7 +64,6 @@ protected:
     Servatrice_ConnectionPool *findLeastUsedConnectionPool();
 };
 
-#ifdef QT_WEBSOCKETS_LIB
 class Servatrice_WebsocketGameServer : public QWebSocketServer
 {
     Q_OBJECT
@@ -86,7 +83,6 @@ protected:
 protected slots:
     void onNewConnection();
 };
-#endif
 
 class Servatrice_IslServer : public QTcpServer
 {
@@ -158,9 +154,7 @@ private:
     DatabaseType databaseType;
     QTimer *pingClock, *statusUpdateClock;
     Servatrice_GameServer *gameServer;
-#ifdef QT_WEBSOCKETS_LIB
     Servatrice_WebsocketGameServer *websocketGameServer;
-#endif
     Servatrice_IslServer *islServer;
     mutable QMutex loginMessageMutex;
     QString loginMessage;

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -1037,15 +1037,14 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
         return Response::RespUserAlreadyExists;
     }
 
-    if ((sqlInterface->checkNumberOfUserAccounts(emailAddress) >= servatrice->getMaxAccountsPerEmail())) {
-        if (servatrice->getMaxAccountsPerEmail() != 0) {
-            if (servatrice->getEnableRegistrationAudit())
-                sqlInterface->addAuditRecord(QString::fromStdString(cmd.user_name()).simplified(), this->getAddress(),
-                                             QString::fromStdString(cmd.clientid()).simplified(), "REGISTER_ACCOUNT",
-                                             "Too many usernames registered with this email address", false);
+    if (servatrice->getMaxAccountsPerEmail() > 0 &&
+        sqlInterface->checkNumberOfUserAccounts(emailAddress) >= servatrice->getMaxAccountsPerEmail()) {
+        if (servatrice->getEnableRegistrationAudit())
+            sqlInterface->addAuditRecord(QString::fromStdString(cmd.user_name()).simplified(), this->getAddress(),
+                                         QString::fromStdString(cmd.clientid()).simplified(), "REGISTER_ACCOUNT",
+                                         "Too many usernames registered with this email address", false);
 
-            return Response::RespTooManyRequests;
-        }
+        return Response::RespTooManyRequests;
     }
 
     QString banReason;

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -1629,7 +1629,6 @@ bool TcpServerSocketInterface::initTcpSession()
     return true;
 }
 
-#ifdef QT_WEBSOCKETS_LIB
 WebsocketServerSocketInterface::WebsocketServerSocketInterface(Servatrice *_server,
                                                                Servatrice_DatabaseInterface *_databaseInterface,
                                                                QObject *parent)
@@ -1651,7 +1650,7 @@ void WebsocketServerSocketInterface::initConnection(void *_socket)
 
     QByteArray websocketIPHeader = settingsCache->value("server/web_socket_ip_header", "").toByteArray();
     if (websocketIPHeader.length() > 0) {
-#if QT_VERSION > 0x050600
+#if QT_VERSION >= 0x050600
         if (socket->request().hasRawHeader(websocketIPHeader)) {
             QString header(socket->request().rawHeader(websocketIPHeader));
             QHostAddress parsed(header);
@@ -1764,5 +1763,3 @@ void WebsocketServerSocketInterface::binaryMessageReceived(const QByteArray &mes
 
     processCommandContainer(newCommandContainer);
 }
-
-#endif

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -1651,12 +1651,16 @@ void WebsocketServerSocketInterface::initConnection(void *_socket)
 
     QByteArray websocketIPHeader = settingsCache->value("server/web_socket_ip_header", "").toByteArray();
     if (websocketIPHeader.length() > 0) {
+#if QT_VERSION > 0x050600
         if (socket->request().hasRawHeader(websocketIPHeader)) {
             QString header(socket->request().rawHeader(websocketIPHeader));
             QHostAddress parsed(header);
             if (!parsed.isNull())
                 address = parsed;
         }
+#else
+        logger->logMessage(QString("Reading the websocket IP header is unsupported on this version of QT."));
+#endif
     }
 
     connect(socket, SIGNAL(binaryMessageReceived(const QByteArray &)), this,

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -1037,14 +1037,15 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
         return Response::RespUserAlreadyExists;
     }
 
-    if (servatrice->getMaxAccountsPerEmail() &&
-        !(sqlInterface->checkNumberOfUserAccounts(emailAddress) < servatrice->getMaxAccountsPerEmail())) {
-        if (servatrice->getEnableRegistrationAudit())
-            sqlInterface->addAuditRecord(QString::fromStdString(cmd.user_name()).simplified(), this->getAddress(),
-                                         QString::fromStdString(cmd.clientid()).simplified(), "REGISTER_ACCOUNT",
-                                         "Too many usernames registered with this email address", false);
+    if ((sqlInterface->checkNumberOfUserAccounts(emailAddress) >= servatrice->getMaxAccountsPerEmail())) {
+        if (servatrice->getMaxAccountsPerEmail() != 0) {
+            if (servatrice->getEnableRegistrationAudit())
+                sqlInterface->addAuditRecord(QString::fromStdString(cmd.user_name()).simplified(), this->getAddress(),
+                                             QString::fromStdString(cmd.clientid()).simplified(), "REGISTER_ACCOUNT",
+                                             "Too many usernames registered with this email address", false);
 
-        return Response::RespTooManyRequests;
+            return Response::RespTooManyRequests;
+        }
     }
 
     QString banReason;

--- a/servatrice/src/serversocketinterface.h
+++ b/servatrice/src/serversocketinterface.h
@@ -20,13 +20,11 @@
 #ifndef SERVERSOCKETINTERFACE_H
 #define SERVERSOCKETINTERFACE_H
 
-#include <QTcpSocket>
-#ifdef QT_WEBSOCKETS_LIB
-#include <QWebSocket>
-#endif
 #include "server_protocolhandler.h"
 #include <QHostAddress>
 #include <QMutex>
+#include <QTcpSocket>
+#include <QWebSocket>
 
 class Servatrice;
 class Servatrice_DatabaseInterface;
@@ -181,7 +179,6 @@ public slots:
     void initConnection(int socketDescriptor);
 };
 
-#ifdef QT_WEBSOCKETS_LIB
 class WebsocketServerSocketInterface : public AbstractServerSocketInterface
 {
     Q_OBJECT
@@ -224,6 +221,5 @@ protected slots:
 public slots:
     void initConnection(void *_socket);
 };
-#endif
 
 #endif

--- a/servatrice/src/serversocketinterface.h
+++ b/servatrice/src/serversocketinterface.h
@@ -193,11 +193,11 @@ public:
 
     QHostAddress getPeerAddress() const
     {
-        return socket->peerAddress();
+        return address;
     }
     QString getAddress() const
     {
-        return socket->peerAddress().toString();
+        return address.toString();
     }
     QString getConnectionType() const
     {
@@ -206,6 +206,7 @@ public:
 
 private:
     QWebSocket *socket;
+    QHostAddress address;
 
 protected:
     void writeToSocket(QByteArray &data)


### PR DESCRIPTION
## Related Ticket(s)
- Works toward #3537

## Short roundup of the initial problem
- Client can't connect over websockets

## What will change with this Pull Request?
- When selecting a websocket port (80, 443, 8080, 4748) . connect using webosckets instead of raw TCP.
- Servatrice can read the client IP out of an HTTP header to support reverse proxies in front of it. 
