### PR TITLE
Playing a tableRow 3 card from the stack puts it to grave.

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2058,6 +2058,8 @@ void Player::playCard(CardItem *card, bool faceDown, bool tapped)
     QString currentZone = card->getZone()->getName();
     if (currentZone == "stack" && tableRow == 3) {
         cmd.set_target_zone("grave");
+        cmd.set_x(0);
+        cmd.set_y(0);
     } else if (!faceDown &&
                ((!playToStack && tableRow == 3) || ((playToStack && tableRow != 0) && currentZone != "stack"))) {
         cmd.set_target_zone("stack");

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2066,7 +2066,7 @@ void Player::playCard(CardItem *card, bool faceDown, bool tapped)
         cmd.set_x(0);
         cmd.set_y(0);
     } else {
-        int tableRow = faceDown ? 2 : info->getTableRow();
+        tableRow = faceDown ? 2 : info->getTableRow();
         QPoint gridPoint = QPoint(-1, TableZone::clampValidTableRow(2 - tableRow));
         cardToMove->set_face_down(faceDown);
         cardToMove->set_pt(info->getPowTough().toStdString());

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2052,9 +2052,14 @@ void Player::playCard(CardItem *card, bool faceDown, bool tapped)
     if (!info) {
         return;
     }
-    if (!faceDown && ((!settingsCache->getPlayToStack() && info->getTableRow() == 3) ||
-                      ((settingsCache->getPlayToStack() && info->getTableRow() != 0) &&
-                       card->getZone()->getName().toStdString() != "stack"))) {
+
+    int tableRow = info->getTableRow();
+    bool playToStack = settingsCache->getPlayToStack();
+    QString currentZone = card->getZone()->getName();
+    if (currentZone == "stack" && tableRow == 3) {
+        cmd.set_target_zone("grave");
+    } else if (!faceDown &&
+               ((!playToStack && tableRow == 3) || ((playToStack && tableRow != 0) && currentZone != "stack"))) {
         cmd.set_target_zone("stack");
         cmd.set_x(0);
         cmd.set_y(0);

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -40,7 +40,7 @@ class CommandContainer;
 class GameCommand;
 class GameEvent;
 class GameEventContext;
-class Event_ConnectionStateChanged;
+// class Event_ConnectionStateChanged;
 class Event_GameSay;
 class Event_Shuffle;
 class Event_RollDie;
@@ -265,7 +265,7 @@ private:
 
     void initSayMenu();
 
-    void eventConnectionStateChanged(const Event_ConnectionStateChanged &event);
+    // void eventConnectionStateChanged(const Event_ConnectionStateChanged &event);
     void eventGameSay(const Event_GameSay &event);
     void eventShuffle(const Event_Shuffle &event);
     void eventRollDie(const Event_RollDie &event);


### PR DESCRIPTION
## Short roundup of the initial problem
Double clicking tableRow 0-2 cards from the stack puts them in the correct table row, but tableRow 3 cards generally goto stack to grave.  Currently they do nothing.

## What will change with this Pull Request?
- Double clicking a tableRow 3 card from the stack will send it to the graveyard.

