### PR TITLE
Fix active player game area highlightning

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1940,7 +1940,7 @@ void Player::processGameEvent(GameEvent::GameEventType type, const GameEvent &ev
     }
 }
 
-void Player::setActivePlayer(bool _active)
+void Player::setActive(bool _active)
 {
     active = _active;
     table->setActive(active);

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -384,7 +384,7 @@ public:
     {
         return active;
     }
-    void setActivePlayer(bool _active);
+    void setActive(bool _active);
     void setShortcutsActive();
     void setShortcutsInactive();
     void updateZones();


### PR DESCRIPTION
## Short roundup of the initial problem
Commit 059ec90fb01655be28fb98d79c27b9da16b5c28f introduced a regression due to the renaming of a method that caused the game area of the active player not being highlighted anymore.

Originally found by @ebbit1q and reported on gitter (also, i stole his pic).

## What will change with this Pull Request?
The method has been renamed back to its original name and the functionality restored.

## Screenshots
![ss](https://files.gitter.im/Cockatrice/Cockatrice/UyfR/image.png)
