### PR TITLE
Log number of cards revealed to other players.

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1854,7 +1854,8 @@ void Player::eventRevealCards(const Event_RevealCards &event)
             static_cast<GameScene *>(scene())->addRevealedZoneView(this, zone, cardList, event.grant_write_access());
         }
 
-        emit logRevealCards(this, zone, event.card_id(), cardName, otherPlayer, false, cardList.size());
+        emit logRevealCards(this, zone, event.card_id(), cardName, otherPlayer, false,
+                            event.has_number_of_cards() ? event.number_of_cards() : cardList.size());
     }
 }
 

--- a/common/pb/event_reveal_cards.proto
+++ b/common/pb/event_reveal_cards.proto
@@ -11,4 +11,5 @@ message Event_RevealCards {
     optional sint32 other_player_id = 3 [default = -1];
     repeated ServerInfo_Card cards = 4;
     optional bool grant_write_access = 5;
+    optional uint32 number_of_cards = 6;
 }

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -1660,6 +1660,7 @@ Server_Player::cmdRevealCards(const Command_RevealCards &cmd, ResponseContainer 
     Event_RevealCards eventOthers;
     eventOthers.set_grant_write_access(cmd.grant_write_access());
     eventOthers.set_zone_name(zone->getName().toStdString());
+    eventOthers.set_number_of_cards(cardsToReveal.size());
     if (cmd.has_card_id())
         eventOthers.set_card_id(cmd.card_id());
     if (cmd.has_player_id())


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3554

## Short roundup of the initial problem
- Players who don't see revealed cards have no clue how many were revealed. 


## What will change with this Pull Request?
- Transmit the number of revealed cards to clients. 
- Use that number in the message log when available.

## Screenshots
![image](https://user-images.githubusercontent.com/671513/52254221-646a5480-28c1-11e9-9142-970e8ee69be9.png)
