### PR TITLE
Connect from commandline

### DIFF
--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -30,6 +30,7 @@
 #include "soundengine.h"
 #include "spoilerbackgroundupdater.h"
 #include "thememanager.h"
+#include "version_string.h"
 #include "window_main.h"
 #include <QApplication>
 #include <QCryptographicHash>
@@ -98,6 +99,7 @@ int main(int argc, char *argv[])
     QCoreApplication::setOrganizationName("Cockatrice");
     QCoreApplication::setOrganizationDomain("cockatrice.de");
     QCoreApplication::setApplicationName("Cockatrice");
+    QCoreApplication::setApplicationVersion(VERSION_STRING);
 
 #ifdef Q_OS_MAC
     qApp->setAttribute(Qt::AA_DontShowIconsInMenus, true);

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -91,9 +91,6 @@ int main(int argc, char *argv[])
     QObject::connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(quit()));
 
     qInstallMessageHandler(CockatriceLogger);
-    if (app.arguments().contains("--debug-output"))
-        Logger::getInstance().logToFile(true);
-
 #ifdef Q_OS_WIN
     app.addLibraryPath(app.applicationDirPath() + "/plugins");
 #endif
@@ -114,6 +111,21 @@ int main(int argc, char *argv[])
     translationPath = qApp->applicationDirPath() + "/../share/cockatrice/translations";
 #endif
 
+    QCommandLineParser parser;
+    parser.setApplicationDescription("Cockatrice");
+    parser.addHelpOption();
+    parser.addVersionOption();
+
+    parser.addOptions(
+        {{{"c", "connect"}, QCoreApplication::translate("main", "Connect on startup"), "user:pass@host:port"},
+         {{"d", "debug-output"}, QCoreApplication::translate("main", "Debug to file")}});
+
+    parser.process(app);
+
+    if (parser.isSet("debug-output")) {
+        Logger::getInstance().logToFile(true);
+    }
+
     rng = new RNG_SFMT;
     settingsCache = new SettingsCache;
     themeManager = new ThemeManager;
@@ -130,6 +142,9 @@ int main(int argc, char *argv[])
     qDebug("main(): starting main program");
 
     MainWindow ui;
+    if (parser.isSet("connect")) {
+        ui.setConnectTo(parser.value("connect"));
+    }
     qDebug("main(): MainWindow constructor finished");
 
     ui.setWindowIcon(QPixmap("theme:cockatrice"));

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -948,7 +948,10 @@ void MainWindow::changeEvent(QEvent *event)
     else if (event->type() == QEvent::ActivationChange) {
         if (isActiveWindow() && !bHasActivated) {
             bHasActivated = true;
-            if (settingsCache->servers().getAutoConnect()) {
+            if (!connectTo.isEmpty()) {
+                qDebug() << "Command line connect to " << connectTo;
+                client->connectToServer(connectTo.host(), connectTo.port(), connectTo.userName(), connectTo.password());
+            } else if (settingsCache->servers().getAutoConnect()) {
                 qDebug() << "Attempting auto-connect...";
                 DlgConnect dlg(this);
                 client->connectToServer(dlg.getHost(), static_cast<unsigned int>(dlg.getPort()), dlg.getPlayerName(),

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -137,9 +137,14 @@ private:
     DlgConnect *dlgConnect;
     GameReplay *replay;
     DlgTipOfTheDay *tip;
+    QUrl connectTo;
 
 public:
     explicit MainWindow(QWidget *parent = nullptr);
+    void setConnectTo(QString url)
+    {
+        connectTo = QUrl(QString("cockatrice://%1").arg(url));
+    }
     ~MainWindow() override;
 
 protected:


### PR DESCRIPTION
## Short roundup of the initial problem
- When testing network options, it is a pain to get multiple test clients connected

## What will change with this Pull Request?
- Add --connect command line option to connect the client
- Normalize argument parsing

## Screenshots
```
./cockatrice --help
Cockatrice

Options:
  -h, --help                           Displays this help.
  -v, --version                        Displays version information.
  -c, --connect <user:pass@host:port>  Connect on startup
  -d, --debug-output                   Debug to file
```
