### PR TITLE
keep wrong project domain for proper settings storage

### DIFF
--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -98,8 +98,10 @@ int main(int argc, char *argv[])
     app.addLibraryPath(app.applicationDirPath() + "/plugins");
 #endif
 
+    // These values are only used by the settings loader/saver
+    // Having wrong or outdated values here doesn't hurt too much
     QCoreApplication::setOrganizationName("Cockatrice");
-    QCoreApplication::setOrganizationDomain("https://cockatrice.github.io/");
+    QCoreApplication::setOrganizationDomain("cockatrice.de");
     QCoreApplication::setApplicationName("Cockatrice");
 
 #ifdef Q_OS_MAC

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
 #endif
 
     // These values are only used by the settings loader/saver
-    // Having wrong or outdated values here doesn't hurt too much
+    // Wrong or outdated values are kept to not break things
     QCoreApplication::setOrganizationName("Cockatrice");
     QCoreApplication::setOrganizationDomain("cockatrice.de");
     QCoreApplication::setApplicationName("Cockatrice");

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
 #endif
 
     QCoreApplication::setOrganizationName("Cockatrice");
-    QCoreApplication::setOrganizationDomain("cockatrice.de");
+    QCoreApplication::setOrganizationDomain("https://cockatrice.github.io/");
     QCoreApplication::setApplicationName("Cockatrice");
 
 #ifdef Q_OS_MAC


### PR DESCRIPTION
## Short roundup of the initial problem
Old brukie domain was left in code

## What will change with this Pull Request?
- Add explaining hint why we have to keep a wrong value

Looks like it is used for storing and loading settings:
https://doc.qt.io/qt-5/qcoreapplication.html#applicationName-prop