### PR TITLE
Fix mistyped signal name

### DIFF
--- a/cockatrice/src/tab_room.cpp
+++ b/cockatrice/src/tab_room.cpp
@@ -121,7 +121,7 @@ TabRoom::TabRoom(TabSupervisor *_tabSupervisor,
 
     sayEdit->setCompleter(completer);
     actCompleterChanged();
-    connect(&settingsCache->shortcuts(), SIGNAL(shortCutchanged()), this, SLOT(refreshShortcuts()));
+    connect(&settingsCache->shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
     refreshShortcuts();
 
     retranslateUi();


### PR DESCRIPTION
## Short roundup of the initial problem
While playing around i noticed an error:
```
QObject::connect: No such signal ShortcutsSettings::shortCutchanged()
```

## What will change with this Pull Request?
Signal name has been fixed.