### PR TITLE
Update card menu when its counters change

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1549,6 +1549,7 @@ void Player::eventSetCardCounter(const Event_SetCardCounter &event)
 
     int oldValue = card->getCounters().value(event.counter_id(), 0);
     card->setCounter(event.counter_id(), event.counter_value());
+    updateCardMenu(card);
     emit logSetCardCounter(this, card->getName(), event.counter_id(), event.counter_value(), oldValue);
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3049
- Fixes #3161
- Fixes #3226

## Short roundup of the initial problem
The "remove counter" menu action is created only when the card has at least on counter on it.
The whole menu for a card is then updated only in a few occasions, eg. when a card is right-clicked to show its menu.
As a consequence, you can always add a counter to a card using shortcuts, but sometimes you can't remove a counter from a card since the "remove counter" action has not been recreated yet.

## What will change with this Pull Request?
When a SetCardCounter event is received for a card, a menu update is forced; if the conditions to enable the "remove counter" action are met (at least one counter is present on the card), the action (and thus the shortcut) are enabled.
