### PR TITLE
Fix unbalanced save() restore() in cards painter.

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -142,7 +142,6 @@ void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
 
     if (getBeingPointedAt()) {
         painter->fillRect(boundingRect(), QBrush(QColor(255, 0, 0, 100)));
-        painter->restore();
     }
 
     if (doesntUntap) {
@@ -160,6 +159,8 @@ void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
 
         painter->restore();
     }
+
+    painter->restore();
 }
 
 void CardItem::setAttacking(bool _attacking)


### PR DESCRIPTION
## Short roundup of the initial problem
There are thousands of spam lines in console saying `QPainter::end: Painter ended with 2 saved states`

## What will change with this Pull Request?
No more of that.
