### PR TITLE
Remove debug message in log

### DIFF
--- a/cockatrice/src/carddbparser/cockatricexml3.cpp
+++ b/cockatrice/src/carddbparser/cockatricexml3.cpp
@@ -155,9 +155,7 @@ void CockatriceXml3Parser::loadCardsFromXml(QXmlStreamReader &xml)
             bool upsideDown = false;
 
             while (!xml.atEnd()) {
-                qDebug() << xml.name();
                 if (xml.readNext() == QXmlStreamReader::EndElement) {
-                    qDebug() << "end";
                     break;
                 }
                 // variable - assigned properties


### PR DESCRIPTION
Some debug messages were mistakenly left in #3567; this cause a mess in the debug log.
Remove the unneeded debug messages.