### PR TITLE
Fix xml v4 picURL.

### DIFF
--- a/cockatrice/src/carddbparser/cockatricexml4.cpp
+++ b/cockatrice/src/carddbparser/cockatricexml4.cpp
@@ -158,7 +158,10 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
                     QString setName = xml.readElementText(QXmlStreamReader::IncludeChildElements);
                     CardInfoPerSet setInfo(internalAddSet(setName));
                     for (QXmlStreamAttribute attr : attrs) {
-                        setInfo.setProperty(attr.name().toString(), attr.value().toString());
+                        QString attrName = attr.name().toString();
+                        if (attrName == "picURL")
+                            attrName = "picurl";
+                        setInfo.setProperty(attrName, attr.value().toString());
                     }
                     sets.insert(setName, setInfo);
                     // relatd cards


### PR DESCRIPTION
Make v4 Cockatrice XML importer convert` picURL` to `picurl` to match v3 behavior and allow picURL images to load.

## Short roundup of the initial problem
v4 XML files mishandle picURL

## What will change with this Pull Request?
picURL will work.
