### PR TITLE
[WIP] Add Shared Zone

### DIFF
--- a/cockatrice/src/cardzone.cpp
+++ b/cockatrice/src/cardzone.cpp
@@ -76,6 +76,8 @@ QString CardZone::getTranslatedName(bool theirOwn, GrammaticalCase gc) const
         return (theirOwn ? tr("their graveyard", "nominative") : tr("%1's graveyard", "nominative").arg(ownerName));
     else if (name == "rfg")
         return (theirOwn ? tr("their exile", "nominative") : tr("%1's exile", "nominative").arg(ownerName));
+    else if (name == "shared")
+        return (theirOwn ? tr("their shared", "nominative") : tr("%1's shared", "nominative").arg(ownerName));
     else if (name == "sb")
         switch (gc) {
             case CaseLookAtZone:

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -39,6 +39,12 @@ const QString MessageLogWidget::deckConstant() const
     return constant;
 }
 
+const QString MessageLogWidget::sharedConstant() const
+{
+    static const QString constant("shared");
+    return constant;
+}
+
 const QString MessageLogWidget::sideboardConstant() const
 {
     static const QString constant("sb");
@@ -76,6 +82,9 @@ MessageLogWidget::getFromStr(CardZone *zone, QString cardName, int position, boo
         fromStr = tr(" from exile");
     } else if (zoneName == handConstant()) {
         fromStr = tr(" from their hand");
+
+    } else if (zoneName == sharedConstant()) {
+        fromStr = tr(" from their shared");
     } else if (zoneName == deckConstant()) {
         if (position == 0) {
             if (cardName.isEmpty()) {
@@ -318,6 +327,8 @@ void MessageLogWidget::logMoveCard(Player *player,
         finalStr = tr("%1 puts %2%3 into their graveyard.");
     } else if (targetZoneName == exileConstant()) {
         finalStr = tr("%1 exiles %2%3.");
+    } else if (targetZoneName == sharedConstant()) {
+        finalStr = tr("%1 moves to shared %2%3.");
     } else if (targetZoneName == handConstant()) {
         finalStr = tr("%1 moves %2%3 to their hand.");
     } else if (targetZoneName == deckConstant()) {

--- a/cockatrice/src/messagelogwidget.h
+++ b/cockatrice/src/messagelogwidget.h
@@ -31,6 +31,7 @@ private:
     const QString exileConstant() const;
     const QString handConstant() const;
     const QString deckConstant() const;
+    const QString sharedConstant() const;
     const QString sideboardConstant() const;
     const QString stackConstant() const;
 

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -204,8 +204,8 @@ private slots:
 private:
     TabGame *game;
     QMenu *playerMenu, *handMenu, *moveHandMenu, *graveMenu, *moveGraveMenu, *rfgMenu, *moveRfgMenu, *libraryMenu,
-        *sbMenu, *countersMenu, *sayMenu, *createPredefinedTokenMenu, *mRevealLibrary, *mRevealTopCard, *mRevealHand,
-        *mRevealRandomHandCard, *mRevealRandomGraveyardCard;
+        *sharedMenu, *sbMenu, *countersMenu, *sayMenu, *createPredefinedTokenMenu, *mRevealLibrary, *mRevealTopCard,
+        *mRevealHand, *mRevealRandomHandCard, *mRevealRandomGraveyardCard;
     QList<QMenu *> playerLists;
     QList<QAction *> allPlayersActions;
     QAction *aMoveHandToTopLibrary, *aMoveHandToBottomLibrary, *aMoveHandToGrave, *aMoveHandToRfg,

--- a/cockatrice/src/zoneviewwidget.cpp
+++ b/cockatrice/src/zoneviewwidget.cpp
@@ -211,8 +211,11 @@ void ZoneViewWidget::closeEvent(QCloseEvent *event)
         cmd.set_zone_name(zone->getName().toStdString());
         player->sendGameCommand(cmd);
     }
-    if (shuffleCheckBox.isChecked())
-        player->sendGameCommand(Command_Shuffle());
+    if (shuffleCheckBox.isChecked()) {
+        Command_Shuffle shuffle;
+        shuffle.set_zone_name(zone->getName().toStdString());
+        player->sendGameCommand(shuffle);
+    }
     emit closePressed(this);
     deleteLater();
     event->accept();


### PR DESCRIPTION
## Related Tickets
Fix #3416 
Fix #2562

## Short roundup of the initial problem
- Shared decks are a huge pain.

## What will change with this Pull Request?
- Each player has an new zone named shared
- Other plays can always view and edit each others shared zones
- Other players can draw from each others shared zones.
- The owner of a shared zone can shuffle it.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![image](https://user-images.githubusercontent.com/671513/53164681-9fd57600-3585-11e9-89b7-cf7f122ba7b0.png)

