### PR TITLE
macOS: Fix qt5.12 scale issues and dark mode

### DIFF
--- a/cmake/Info.plist
+++ b/cmake/Info.plist
@@ -34,7 +34,5 @@
     <string>${MACOSX_BUNDLE_COPYRIGHT}</string>
     <key>NSHighResolutionCapable</key>
     <true/>
-    <key>NSRequiresAquaSystemAppearance</key>
-    <true/>
 </dict>
 </plist>

--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -71,13 +71,11 @@ void AbstractCardItem::transformPainter(QPainter *painter, const QSizeF &transla
 
     QRectF totalBoundingRect = painter->combinedTransform().mapRect(boundingRect());
 
-    painter->resetTransform();
+    resetPainterTransform(painter);
 
-    QTransform pixmapTransform;
-    pixmapTransform.translate(totalBoundingRect.width() / 2, totalBoundingRect.height() / 2);
-    pixmapTransform.rotate(angle);
-    pixmapTransform.translate(-translatedSize.width() / 2, -translatedSize.height() / 2);
-    painter->setTransform(pixmapTransform);
+    painter->translate(totalBoundingRect.width() / 2, totalBoundingRect.height() / 2);
+    painter->rotate(angle);
+    painter->translate(-translatedSize.width() / 2, -translatedSize.height() / 2);
 
     QFont f;
     f.setPixelSize(fontSize);

--- a/cockatrice/src/abstractgraphicsitem.cpp
+++ b/cockatrice/src/abstractgraphicsitem.cpp
@@ -49,3 +49,8 @@ void AbstractGraphicsItem::paintNumberEllipse(int number,
 
     painter->restore();
 }
+void resetPainterTransform(QPainter *painter)
+{
+    painter->resetTransform();
+    painter->setTransform(painter->deviceTransform().inverted());
+}

--- a/cockatrice/src/abstractgraphicsitem.h
+++ b/cockatrice/src/abstractgraphicsitem.h
@@ -26,4 +26,6 @@ public:
     }
 };
 
+void resetPainterTransform(QPainter *painter);
+
 #endif

--- a/cockatrice/src/chatview/chatview.cpp
+++ b/cockatrice/src/chatview/chatview.cpp
@@ -34,7 +34,7 @@ ChatView::ChatView(const TabSupervisor *_tabSupervisor,
     mentionFormat.setFontWeight(QFont::Bold);
 
     mentionFormatOtherUser.setFontWeight(QFont::Bold);
-    mentionFormatOtherUser.setForeground(Qt::blue);
+    mentionFormatOtherUser.setForeground(palette().link());
     mentionFormatOtherUser.setAnchor(true);
 
     viewport()->setCursor(Qt::IBeamCursor);
@@ -60,7 +60,11 @@ QTextCursor ChatView::prepareBlock(bool same)
     } else {
         QTextBlockFormat blockFormat;
         if ((evenNumber = !evenNumber))
-            blockFormat.setBackground(palette().alternateBase());
+            blockFormat.setBackground(palette().window());
+        else
+            blockFormat.setBackground(palette().base());
+
+        blockFormat.setForeground(palette().text());
         blockFormat.setBottomMargin(4);
         cursor.insertBlock(blockFormat);
     }
@@ -95,7 +99,7 @@ void ChatView::appendCardTag(QTextCursor &cursor, const QString &cardName)
 {
     QTextCharFormat oldFormat = cursor.charFormat();
     QTextCharFormat anchorFormat = oldFormat;
-    anchorFormat.setForeground(Qt::blue);
+    anchorFormat.setForeground(palette().link());
     anchorFormat.setAnchor(true);
     anchorFormat.setAnchorHref("card://" + cardName);
     anchorFormat.setFontItalic(true);
@@ -112,10 +116,10 @@ void ChatView::appendUrlTag(QTextCursor &cursor, QString url)
 
     QTextCharFormat oldFormat = cursor.charFormat();
     QTextCharFormat anchorFormat = oldFormat;
-    anchorFormat.setForeground(Qt::blue);
+    anchorFormat.setForeground(palette().link());
     anchorFormat.setAnchor(true);
     anchorFormat.setAnchorHref(url);
-    anchorFormat.setUnderlineColor(Qt::blue);
+    anchorFormat.setUnderlineColor(palette().link().color());
     anchorFormat.setFontUnderline(true);
 
     cursor.setCharFormat(anchorFormat);

--- a/cockatrice/src/counter_general.cpp
+++ b/cockatrice/src/counter_general.cpp
@@ -1,4 +1,5 @@
 #include "counter_general.h"
+#include "abstractgraphicsitem.h"
 #include "pixmapgenerator.h"
 #include <QPainter>
 
@@ -28,7 +29,7 @@ void GeneralCounter::paint(QPainter *painter, const QStyleOptionGraphicsItem * /
     QPixmap pixmap = CounterPixmapGenerator::generatePixmap(translatedHeight, name, hovered);
 
     painter->save();
-    painter->resetTransform();
+    resetPainterTransform(painter);
     painter->drawPixmap(QPoint(0, 0), pixmap);
 
     if (value) {

--- a/cockatrice/src/handcounter.cpp
+++ b/cockatrice/src/handcounter.cpp
@@ -33,7 +33,7 @@ void HandCounter::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*op
         cachedPixmap = QPixmap("theme:hand").scaled(translatedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
         QPixmapCache::insert("handCounter" + QString::number(translatedSize.width()), cachedPixmap);
     }
-    painter->resetTransform();
+    resetPainterTransform(painter);
     painter->drawPixmap(cachedPixmap.rect(), cachedPixmap, cachedPixmap.rect());
     painter->restore();
 

--- a/cockatrice/src/phasestoolbar.cpp
+++ b/cockatrice/src/phasestoolbar.cpp
@@ -48,7 +48,7 @@ void PhaseButton::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*op
     painter->setPen(Qt::gray);
     painter->drawRect(0, 0, static_cast<int>(width - 1), static_cast<int>(width - 1));
     painter->save();
-    painter->resetTransform();
+    resetPainterTransform(painter);
     painter->drawPixmap(iconPixmap.rect().translated(static_cast<int>(round(3 * scaleFactor)),
                                                      static_cast<int>(round(3 * scaleFactor))),
                         iconPixmap, iconPixmap.rect());

--- a/cockatrice/src/phasestoolbar.h
+++ b/cockatrice/src/phasestoolbar.h
@@ -1,6 +1,7 @@
 #ifndef PHASESTOOLBAR_H
 #define PHASESTOOLBAR_H
 
+#include "abstractgraphicsitem.h"
 #include <QFrame>
 #include <QGraphicsObject>
 #include <QList>

--- a/cockatrice/src/playerlistwidget.cpp
+++ b/cockatrice/src/playerlistwidget.cpp
@@ -173,7 +173,7 @@ void PlayerListWidget::setActivePlayer(int playerId)
     while (i.hasNext()) {
         i.next();
         QTreeWidgetItem *twi = i.value();
-        QColor c = i.key() == playerId ? QColor(150, 255, 150) : Qt::white;
+        QColor c = i.key() == playerId ? QColor(150, 255, 150) : palette().base().color();
         twi->setBackground(4, c);
     }
 }

--- a/cockatrice/src/playertarget.cpp
+++ b/cockatrice/src/playertarget.cpp
@@ -110,7 +110,7 @@ void PlayerTarget::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*o
     }
 
     painter->save();
-    painter->resetTransform();
+    resetPainterTransform(painter);
     painter->translate((translatedSize.width() - cachedPixmap.width()) / 2.0, 0);
     painter->drawPixmap(translatedRect, cachedPixmap, cachedPixmap.rect());
     painter->restore();
@@ -120,7 +120,7 @@ void PlayerTarget::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*o
     QRectF translatedNameRect = painter->combinedTransform().mapRect(nameRect);
 
     painter->save();
-    painter->resetTransform();
+    resetPainterTransform(painter);
 
     QString name = QString::fromStdString(info->name());
     if (name.size() > 13)

--- a/cockatrice/src/userlist.cpp
+++ b/cockatrice/src/userlist.cpp
@@ -10,6 +10,7 @@
 #include "tab_supervisor.h"
 #include "tab_userlists.h"
 #include "user_context_menu.h"
+#include <QApplication>
 #include <QCheckBox>
 #include <QHBoxLayout>
 #include <QHeaderView>
@@ -23,6 +24,7 @@
 #include <QRadioButton>
 #include <QSpinBox>
 #include <QVBoxLayout>
+#include <QWidget>
 
 BanDialog::BanDialog(const ServerInfo_User &info, QWidget *parent) : QDialog(parent)
 {
@@ -296,7 +298,7 @@ void UserListTWI::setUserInfo(const ServerInfo_User &_userInfo)
 void UserListTWI::setOnline(bool online)
 {
     setData(0, Qt::UserRole + 1, online);
-    setData(2, Qt::ForegroundRole, online ? QBrush() : QBrush(Qt::gray));
+    setData(2, Qt::ForegroundRole, online ? qApp->palette().brush(QPalette::WindowText) : QBrush(Qt::gray));
 }
 
 bool UserListTWI::operator<(const QTreeWidgetItem &other) const


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3522

## Short roundup of the initial problem
- Scale of play area is all messed up in Qt5.12

## What will change with this Pull Request?
- Maybe it will work.

## Screenshot
![image](https://user-images.githubusercontent.com/671513/53283528-b9e59480-36fc-11e9-858d-e75877759476.png)

