### PR TITLE
Minor cleanup & set RR default for new clients

### DIFF
--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -206,7 +206,7 @@ void DlgConnect::rebuildComboBoxList(int failure)
     }
 
     // If first run, set to RR
-    if (settingsCache->servers().getPrevioushostName().isEmpty()) {
+    if (settingsCache->servers().getPrevioushostName().isEmpty() && previousHosts->count() >= 2) {
         previousHosts->setCurrentIndex(1);
     }
 

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -161,21 +161,6 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
 
 DlgConnect::~DlgConnect() = default;
 
-void DlgConnect::actSaveConfig()
-{
-    bool updateSuccess = settingsCache->servers().updateExistingServer(
-        saveEdit->text().trimmed(), hostEdit->text().trimmed(), portEdit->text().trimmed(),
-        playernameEdit->text().trimmed(), passwordEdit->text(), savePasswordCheckBox->isChecked());
-
-    if (!updateSuccess) {
-        settingsCache->servers().addNewServer(saveEdit->text().trimmed(), hostEdit->text().trimmed(),
-                                              portEdit->text().trimmed(), playernameEdit->text().trimmed(),
-                                              passwordEdit->text(), savePasswordCheckBox->isChecked());
-    }
-
-    preRebuildComboBoxList();
-}
-
 void DlgConnect::downloadThePublicServers()
 {
     btnRefreshServers->setDisabled(true);
@@ -206,7 +191,7 @@ void DlgConnect::rebuildComboBoxList(int failure)
     savedHostList = uci.getServerInfo();
 
     int i = 0;
-    for (auto pair : savedHostList) {
+    for (const auto &pair : savedHostList) {
         auto tmp = pair.second;
         QString saveName = tmp.getSaveName();
         if (saveName.size()) {
@@ -218,6 +203,11 @@ void DlgConnect::rebuildComboBoxList(int failure)
 
             i++;
         }
+    }
+
+    // If first run, set to RR
+    if (settingsCache->servers().getPrevioushostName().isEmpty()) {
+        previousHosts->setCurrentIndex(1);
     }
 
     btnRefreshServers->setDisabled(false);

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -190,23 +190,16 @@ void DlgConnect::rebuildComboBoxList(int failure)
     UserConnection_Information uci;
     savedHostList = uci.getServerInfo();
 
-    int i = 0;
     for (const auto &pair : savedHostList) {
         auto tmp = pair.second;
         QString saveName = tmp.getSaveName();
         if (saveName.size()) {
             previousHosts->addItem(saveName);
-
-            if (settingsCache->servers().getPrevioushostName() == saveName) {
-                previousHosts->setCurrentIndex(i);
-            }
-
-            i++;
         }
     }
 
-    // If first run, set to RR
-    if (settingsCache->servers().getPrevioushostName().isEmpty() && previousHosts->count() >= 2) {
+    // On rebuild, set to RR
+    if (previousHosts->count() >= 2) {
         previousHosts->setCurrentIndex(1);
     }
 

--- a/cockatrice/src/dlg_connect.h
+++ b/cockatrice/src/dlg_connect.h
@@ -52,7 +52,7 @@ public slots:
 
 private slots:
     void actOk();
-    void actSaveConfig();
+
     void passwordSaved(int state);
     void previousHostSelected(bool state);
     void newHostSelected(bool state);
@@ -62,9 +62,9 @@ private slots:
     void rebuildComboBoxList(int failure = -1);
 
 private:
-    QGridLayout *newHostLayout, *connectionLayout, *loginLayout, *serverInfoLayout, *grid;
+    QGridLayout *connectionLayout, *loginLayout, *serverInfoLayout, *grid;
     QHBoxLayout *newHolderLayout;
-    QGroupBox *loginGroupBox, *serverInfoGroupBox, *btnGroupBox, *restrictionsGroupBox;
+    QGroupBox *loginGroupBox, *serverInfoGroupBox, *restrictionsGroupBox;
     QVBoxLayout *mainLayout;
     QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *saveLabel, *serverIssuesLabel,
         *serverContactLabel, *serverContactLink;

--- a/cockatrice/src/handle_public_servers.cpp
+++ b/cockatrice/src/handle_public_servers.cpp
@@ -87,7 +87,7 @@ void HandlePublicServers::updateServerINISettings(QMap<QString, QVariant> jsonMa
         if (serverFound) {
             settingsCache->servers().updateExistingServerWithoutLoss(serverName, serverAddress, serverPort, serverSite);
         } else {
-            settingsCache->servers().addNewServer(serverName, serverAddress, serverPort, "", "", false);
+            settingsCache->servers().addNewServer(serverName, serverAddress, serverPort, "", "", false, serverSite);
         }
     }
 


### PR DESCRIPTION
For new clients, have them support Rooster Ranges (the official development server) as the primary target. Also, some minor cleanup and a fix for first builds that didn't set help websites