### PR TITLE
Allow /\ in simple searches.

### DIFF
--- a/cockatrice/src/filter_string.cpp
+++ b/cockatrice/src/filter_string.cpp
@@ -42,7 +42,7 @@ ColorQuery <- [cC] 'olor'? <[iI]?> <[:!]> ColorEx*
 FieldQuery <- String [:] RegexString / String ws? NumericExpression
 
 NonQuote <- !["].
-UnescapedStringListPart <- [a-zA-Z0-9']+
+UnescapedStringListPart <- [a-zA-Z0-9/\']+
 String <- UnescapedStringListPart / ["] <NonQuote*> ["]
 StringValue <- String / [(] StringList [)]
 StringList <- StringListString (ws? [,] ws? StringListString)*


### PR DESCRIPTION
You can search for Fire // Ice now.