### PR TITLE
Allow more characters in bare searches

### DIFF
--- a/cockatrice/src/filter_string.cpp
+++ b/cockatrice/src/filter_string.cpp
@@ -42,11 +42,11 @@ ColorQuery <- [cC] 'olor'? <[iI]?> <[:!]> ColorEx*
 FieldQuery <- String [:] RegexString / String ws? NumericExpression
 
 NonQuote <- !["].
-UnescapedStringListPart <- [a-zA-Z0-9/\']+
-String <- UnescapedStringListPart / ["] <NonQuote*> ["]
+UnescapedStringListPart <- ![":<>=! ].
+String <- UnescapedStringListPart+ / ["] <NonQuote*> ["]
 StringValue <- String / [(] StringList [)]
 StringList <- StringListString (ws? [,] ws? StringListString)*
-StringListString <- UnescapedStringListPart
+StringListString <- UnescapedStringListPart+
 GenericQuery <- RegexString
 RegexString <- String
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3620

## Short roundup of the initial problem
It's hard to search for cards with weird charafters

## What will change with this Pull Request?
- We allow almost all characters in bare searches


