### PR TITLE
try to use fabs instead of abs to see if flatpack cares

### DIFF
--- a/common/expression.cpp
+++ b/common/expression.cpp
@@ -38,7 +38,7 @@ Expression::Expression(double initial) : value(initial)
         default_functions->insert("log", [](double a) { return log(a); });
         default_functions->insert("log10", [](double a) { return log(a); });
         default_functions->insert("trunc", [](double a) { return trunc(a); });
-        default_functions->insert("abs", [](double a) { return abs(a); });
+        default_functions->insert("abs", [](double a) { return fabs(a); });
 
         default_functions->insert("floor", [](double a) { return floor(a); });
         default_functions->insert("ceil", [](double a) { return ceil(a); });


### PR DESCRIPTION
For some reason builds on flatpack aren't working, this is a test if using fabs instead of abs is the issue.

To elaborate on this issue: abs(double) is not in c++11, it was added in c++17 and this is why we can still compile it.
Now fabs(double) is the exact same operation and available from c++11 onwards.