### PR TITLE
Permit use of up/down keys to increment/decrement counter value; Fix #3618

### DIFF
--- a/cockatrice/src/abstractcounter.cpp
+++ b/cockatrice/src/abstractcounter.cpp
@@ -163,14 +163,11 @@ void AbstractCounter::incrementCounter()
 void AbstractCounter::setCounter()
 {
     dialogSemaphore = true;
-    QInputDialog *dialog = new AbstractCounterDialog(name, QString::number(value));
-    dialog->open(this, SLOT(setCounterAccepted(QString)));
-}
-
-void AbstractCounter::setCounterAccepted(QString expression)
-{
+    AbstractCounterDialog dialog(name, QString::number(value));
+    if(!dialog.exec())
+        return;
     Expression exp(value);
-    int newValue = static_cast<int>(exp.parse(expression));
+    int newValue = static_cast<int>(exp.parse(dialog.textValue()));
 
     if (deleteAfterDialog) {
         deleteLater();
@@ -187,8 +184,6 @@ void AbstractCounter::setCounterAccepted(QString expression)
 AbstractCounterDialog::AbstractCounterDialog(const QString &name, const QString &value) : QInputDialog(nullptr)
 {
     setWindowTitle(tr("Set counter"));
-    setWindowModality(Qt::ApplicationModal);
-    setAttribute(Qt::WA_DeleteOnClose, true);
     setLabelText(tr("New value for counter '%1':").arg(name));
     setTextValue(value);
     qApp->installEventFilter(this);

--- a/cockatrice/src/abstractcounter.cpp
+++ b/cockatrice/src/abstractcounter.cpp
@@ -185,8 +185,7 @@ void AbstractCounter::setCounterAccepted(QString expression)
     player->sendGameCommand(cmd);
 }
 
-AbstractCounterDialog::AbstractCounterDialog(const QString &name, const QString &value)
- : QInputDialog(nullptr)
+AbstractCounterDialog::AbstractCounterDialog(const QString &name, const QString &value) : QInputDialog(nullptr)
 {
     setWindowTitle(tr("Set counter"));
     setLabelText(tr("New value for counter '%1':").arg(name));
@@ -196,11 +195,9 @@ AbstractCounterDialog::AbstractCounterDialog(const QString &name, const QString 
 
 bool AbstractCounterDialog::eventFilter(QObject *obj, QEvent *event)
 {
-    if (event->type() == QEvent::KeyPress)
-    {
+    if (event->type() == QEvent::KeyPress) {
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
-        switch(keyEvent->key())
-        {
+        switch (keyEvent->key()) {
             case Qt::Key_Up:
                 changeValue(+1);
                 return true;
@@ -216,7 +213,7 @@ void AbstractCounterDialog::changeValue(int diff)
 {
     bool ok;
     int curValue = textValue().toInt(&ok);
-    if(!ok)
+    if (!ok)
         return;
     curValue += diff;
     setTextValue(QString::number(curValue));

--- a/cockatrice/src/abstractcounter.cpp
+++ b/cockatrice/src/abstractcounter.cpp
@@ -187,6 +187,8 @@ void AbstractCounter::setCounterAccepted(QString expression)
 AbstractCounterDialog::AbstractCounterDialog(const QString &name, const QString &value) : QInputDialog(nullptr)
 {
     setWindowTitle(tr("Set counter"));
+    setWindowModality(Qt::ApplicationModal);
+    setAttribute(Qt::WA_DeleteOnClose, true);
     setLabelText(tr("New value for counter '%1':").arg(name));
     setTextValue(value);
     qApp->installEventFilter(this);

--- a/cockatrice/src/abstractcounter.cpp
+++ b/cockatrice/src/abstractcounter.cpp
@@ -164,16 +164,19 @@ void AbstractCounter::setCounter()
 {
     dialogSemaphore = true;
     AbstractCounterDialog dialog(name, QString::number(value));
-    if(!dialog.exec())
-        return;
-    Expression exp(value);
-    int newValue = static_cast<int>(exp.parse(dialog.textValue()));
+    const int ok = dialog.exec();
 
     if (deleteAfterDialog) {
         deleteLater();
         return;
     }
     dialogSemaphore = false;
+
+    if (!ok)
+        return;
+
+    Expression exp(value);
+    int newValue = static_cast<int>(exp.parse(dialog.textValue()));
 
     Command_SetCounter cmd;
     cmd.set_counter_id(id);

--- a/cockatrice/src/abstractcounter.cpp
+++ b/cockatrice/src/abstractcounter.cpp
@@ -8,8 +8,10 @@
 #include <QApplication>
 #include <QGraphicsSceneHoverEvent>
 #include <QGraphicsSceneMouseEvent>
+#include <QKeyEvent>
 #include <QMenu>
 #include <QPainter>
+#include <QString>
 
 AbstractCounter::AbstractCounter(Player *_player,
                                  int _id,
@@ -162,9 +164,12 @@ void AbstractCounter::setCounter()
 {
     bool ok;
     dialogSemaphore = true;
-    QString expression = QInputDialog::getText(nullptr, tr("Set counter"), tr("New value for counter '%1':").arg(name),
-                                               QLineEdit::Normal, QString::number(value), &ok);
+    QInputDialog *dialog = new AbstractCounterDialog(name, QString::number(value));
+    dialog->open(this, SLOT(setCounterAccepted(QString)));
+}
 
+void AbstractCounter::setCounterAccepted(QString expression)
+{
     Expression exp(value);
     int newValue = static_cast<int>(exp.parse(expression));
 
@@ -173,11 +178,46 @@ void AbstractCounter::setCounter()
         return;
     }
     dialogSemaphore = false;
-    if (!ok)
-        return;
 
     Command_SetCounter cmd;
     cmd.set_counter_id(id);
     cmd.set_value(newValue);
     player->sendGameCommand(cmd);
+}
+
+AbstractCounterDialog::AbstractCounterDialog(const QString &name, const QString &value)
+ : QInputDialog(nullptr)
+{
+    setWindowTitle(tr("Set counter"));
+    setLabelText(tr("New value for counter '%1':").arg(name));
+    setTextValue(value);
+    qApp->installEventFilter(this);
+}
+
+bool AbstractCounterDialog::eventFilter(QObject *obj, QEvent *event)
+{
+    if (event->type() == QEvent::KeyPress)
+    {
+        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+        switch(keyEvent->key())
+        {
+            case Qt::Key_Up:
+                changeValue(+1);
+                return true;
+            case Qt::Key_Down:
+                changeValue(-1);
+                return true;
+        }
+    }
+    return false;
+}
+
+void AbstractCounterDialog::changeValue(int diff)
+{
+    bool ok;
+    int curValue = textValue().toInt(&ok);
+    if(!ok)
+        return;
+    curValue += diff;
+    setTextValue(QString::number(curValue));
 }

--- a/cockatrice/src/abstractcounter.cpp
+++ b/cockatrice/src/abstractcounter.cpp
@@ -162,7 +162,6 @@ void AbstractCounter::incrementCounter()
 
 void AbstractCounter::setCounter()
 {
-    bool ok;
     dialogSemaphore = true;
     QInputDialog *dialog = new AbstractCounterDialog(name, QString::number(value));
     dialog->open(this, SLOT(setCounterAccepted(QString)));
@@ -195,6 +194,7 @@ AbstractCounterDialog::AbstractCounterDialog(const QString &name, const QString 
 
 bool AbstractCounterDialog::eventFilter(QObject *obj, QEvent *event)
 {
+    Q_UNUSED(obj);
     if (event->type() == QEvent::KeyPress) {
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
         switch (keyEvent->key()) {

--- a/cockatrice/src/abstractcounter.h
+++ b/cockatrice/src/abstractcounter.h
@@ -78,11 +78,12 @@ public:
     }
 };
 
-class AbstractCounterDialog: public QInputDialog
+class AbstractCounterDialog : public QInputDialog
 {
     Q_OBJECT
 public:
     AbstractCounterDialog(const QString &name, const QString &value);
+
 protected:
     bool eventFilter(QObject *obj, QEvent *event);
     void changeValue(int diff);

--- a/cockatrice/src/abstractcounter.h
+++ b/cockatrice/src/abstractcounter.h
@@ -2,10 +2,13 @@
 #define COUNTER_H
 
 #include <QGraphicsItem>
+#include <QInputDialog>
 
 class Player;
-class QMenu;
 class QAction;
+class QKeyEvent;
+class QMenu;
+class QString;
 
 class AbstractCounter : public QObject, public QGraphicsItem
 {
@@ -34,6 +37,7 @@ private slots:
     void refreshShortcuts();
     void incrementCounter();
     void setCounter();
+    void setCounterAccepted(QString expression);
 
 public:
     AbstractCounter(Player *_player,
@@ -72,6 +76,16 @@ public:
     {
         return value;
     }
+};
+
+class AbstractCounterDialog: public QInputDialog
+{
+    Q_OBJECT
+public:
+    AbstractCounterDialog(const QString &name, const QString &value);
+protected:
+    bool eventFilter(QObject *obj, QEvent *event);
+    void changeValue(int diff);
 };
 
 #endif

--- a/cockatrice/src/abstractcounter.h
+++ b/cockatrice/src/abstractcounter.h
@@ -37,7 +37,6 @@ private slots:
     void refreshShortcuts();
     void incrementCounter();
     void setCounter();
-    void setCounterAccepted(QString expression);
 
 public:
     AbstractCounter(Player *_player,


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3618

## Short roundup of the initial problem
#3534 introduced the possibility of using formulas in the "set counter" dialog.
Previously the dialog was only accepting numerical values, so the up/down arrow keys could be used to increment/decrement the value.
Now the dialog accepts a text value, so those keys can't be used anymore.

## What will change with this Pull Request?
We explicitly listen for the up/down keypress and increment/decrement the value if the text is numerical.