### PR TITLE
Fix related cards menu in deck editor

### DIFF
--- a/cockatrice/src/cardinfotext.cpp
+++ b/cockatrice/src/cardinfotext.cpp
@@ -47,18 +47,12 @@ void CardInfoText::setCard(CardInfoPtr card)
             QString("<tr><td>%1</td><td></td><td>%2</td></tr>").arg(keyText, card->getProperty(key).toHtmlEscaped());
     }
 
-    auto relatedCards = card->getRelatedCards();
-    auto reverserelatedCards2Me = card->getReverseRelatedCards2Me();
-    if (!relatedCards.empty() || !reverserelatedCards2Me.empty()) {
+    auto relatedCards = card->getAllRelatedCards();
+    if (!relatedCards.empty()) {
         text += QString("<tr><td>%1</td><td width=\"5\"></td><td>").arg(tr("Related cards:"));
 
         for (auto *relatedCard : relatedCards) {
             QString tmp = relatedCard->getName().toHtmlEscaped();
-            text += "<a href=\"" + tmp + "\">" + tmp + "</a><br>";
-        }
-
-        for (auto *i : reverserelatedCards2Me) {
-            QString tmp = i->getName().toHtmlEscaped();
             text += "<a href=\"" + tmp + "\">" + tmp + "</a><br>";
         }
 

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1229,9 +1229,7 @@ void Player::actCreateRelatedCard()
     }
     auto *action = static_cast<QAction *>(sender());
     // If there is a better way of passing a CardRelation through a QAction, please add it here.
-    QList<CardRelation *> relatedCards = QList<CardRelation *>();
-    relatedCards.append(sourceCard->getInfo()->getRelatedCards());
-    relatedCards.append(sourceCard->getInfo()->getReverseRelatedCards2Me());
+    auto relatedCards = sourceCard->getInfo()->getAllRelatedCards();
     CardRelation *cardRelation = relatedCards.at(action->data().toInt());
 
     /*
@@ -1251,9 +1249,8 @@ void Player::actCreateAllRelatedCards()
         return;
     }
 
-    QList<CardRelation *> relatedCards = sourceCard->getInfo()->getRelatedCards();
-    relatedCards.append(sourceCard->getInfo()->getReverseRelatedCards2Me());
-    if (relatedCards.empty()) {
+    auto relatedCards = sourceCard->getInfo()->getAllRelatedCards();
+    if (relatedCards.isEmpty()) {
         return;
     }
 

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -460,11 +460,12 @@ void TabDeckEditor::databaseCustomMenu(QPoint point)
     // filling out the related cards submenu
     auto *relatedMenu = new QMenu(tr("Show Related cards"));
     menu.addMenu(relatedMenu);
-    if (info->getRelatedCards().isEmpty()) {
+    auto relatedCards = info->getAllRelatedCards();
+    if (relatedCards.isEmpty()) {
         relatedMenu->setDisabled(true);
     } else {
         auto *signalMapper = new QSignalMapper(this);
-        for (const CardRelation *rel : info->getRelatedCards()) {
+        for (const CardRelation *rel : relatedCards) {
             QAction *relatedCard;
             relatedCard = relatedMenu->addAction(rel->getName());
             connect(relatedCard, SIGNAL(triggered()), signalMapper, SLOT(map()));


### PR DESCRIPTION
## Related Ticket(s)
- related #3113

## Short roundup of the initial problem
The right-click menu on the card database in the deck editor (introduced in #3113) doesn't show reverse-related cards.

## What will change with this Pull Request?
There are a few places in the code where the list of related cards and reverse-related cards were retrieved separately. A method to get them all in a single call already exists, so just use it instead.
