### PR TITLE
Show current counter value on "set counter" dialog

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2860,12 +2860,12 @@ void Player::actCardCounterTrigger()
             dialogSemaphore = true;
 
             int oldValue = 0;
-            if(scene()->selectedItems().size() == 1) {
+            if (scene()->selectedItems().size() == 1) {
                 auto *card = static_cast<CardItem *>(scene()->selectedItems().first());
                 oldValue = card->getCounters().value(counterId, 0);
             }
-            int number =
-                QInputDialog::getInt(nullptr, tr("Set counters"), tr("Number:"), oldValue, 0, MAX_COUNTERS_ON_CARD, 1, &ok);
+            int number = QInputDialog::getInt(nullptr, tr("Set counters"), tr("Number:"), oldValue, 0,
+                                              MAX_COUNTERS_ON_CARD, 1, &ok);
             dialogSemaphore = false;
             if (clearCardsToDelete() || !ok) {
                 return;

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2858,8 +2858,14 @@ void Player::actCardCounterTrigger()
         case 11: { // set counter with dialog
             bool ok;
             dialogSemaphore = true;
+
+            int oldValue = 0;
+            if(scene()->selectedItems().size() == 1) {
+                auto *card = static_cast<CardItem *>(scene()->selectedItems().first());
+                oldValue = card->getCounters().value(counterId, 0);
+            }
             int number =
-                QInputDialog::getInt(nullptr, tr("Set counters"), tr("Number:"), 0, 0, MAX_COUNTERS_ON_CARD, 1, &ok);
+                QInputDialog::getInt(nullptr, tr("Set counters"), tr("Number:"), oldValue, 0, MAX_COUNTERS_ON_CARD, 1, &ok);
             dialogSemaphore = false;
             if (clearCardsToDelete() || !ok) {
                 return;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes point 10 of issue #655

## Short roundup of the initial problem
When setting a card counter value, the default value shown in the dialog is always zero

## What will change with this Pull Request?
When a single card is selected, we can show the current value for that counter.
