### PR TITLE
workaround for foreign card arts getting priority by default

### DIFF
--- a/oracle/src/main.h
+++ b/oracle/src/main.h
@@ -2,6 +2,7 @@
 #define MAIN_H
 
 class QTranslator;
+class QString;
 
 extern QTranslator *translator;
 extern const QString translationPrefix;

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -46,16 +46,22 @@ bool OracleImporter::readSetsFromByteArray(const QByteArray &data)
         setCards = map.value("cards").toList();
         setType = map.value("type").toString();
         // capitalize set type
-        if (setType.length() > 0)
+        if (setType.length() > 0) {
             setType[0] = setType[0].toUpper();
-        releaseDate = map.value("releaseDate").toDate();
+        }
+        if (!nonEnglishSets.contains(shortName)) {
+            releaseDate = map.value("releaseDate").toDate();
+        } else {
+            releaseDate = QDate();
+        }
         newSetList.append(SetToDownload(shortName, longName, setCards, setType, releaseDate));
     }
 
     qSort(newSetList);
 
-    if (newSetList.isEmpty())
+    if (newSetList.isEmpty()) {
         return false;
+    }
     allSets = newSetList;
     return true;
 }

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -6,6 +6,13 @@
 #include <carddatabase.h>
 #include <utility>
 
+// many users prefer not to see these sets with non english arts
+// as a solution we remove the date property on these sets
+// that way they will be sorted last by default
+// this will cause their art to not get priority over english cards
+// users will still be able to find these sets and prioritize them manually
+const QStringList nonEnglishSets = {"FBB", "PS11", "PSAL", "REN"};
+
 class SetToDownload
 {
 private:


### PR DESCRIPTION
fixes #3623 

many users prefer not to see these sets with non english arts
as a solution we remove the date property on these sets
that way they will be sorted last by default
this will cause their art to not get priority over english cards
users will still be able to find these sets and prioritize them manually

Not a very gratifying fix but it works and doesn't require cockatrice to be aware of it.