### PR TITLE
Improve color selection for dark mode. 

### DIFF
--- a/cockatrice/src/chatview/chatview.cpp
+++ b/cockatrice/src/chatview/chatview.cpp
@@ -29,11 +29,13 @@ ChatView::ChatView(const TabSupervisor *_tabSupervisor,
         )");
         serverMessageColor = QColor(0xFF, 0x73, 0x83);
         otherUserColor = otherUserColor.lighter(150);
+        linkColor = QColor(71, 158, 252);
     } else {
         document()->setDefaultStyleSheet(R"(
             a { text-decoration: none; color: blue; }
             .blue { color: blue }
         )");
+        linkColor = palette().link().color();
     }
 
     userContextMenu = new UserContextMenu(tabSupervisor, this, game);
@@ -45,7 +47,7 @@ ChatView::ChatView(const TabSupervisor *_tabSupervisor,
     mentionFormat.setFontWeight(QFont::Bold);
 
     mentionFormatOtherUser.setFontWeight(QFont::Bold);
-    mentionFormatOtherUser.setForeground(palette().link());
+    mentionFormatOtherUser.setForeground(linkColor);
     mentionFormatOtherUser.setAnchor(true);
 
     viewport()->setCursor(Qt::IBeamCursor);
@@ -111,7 +113,7 @@ void ChatView::appendCardTag(QTextCursor &cursor, const QString &cardName)
 {
     QTextCharFormat oldFormat = cursor.charFormat();
     QTextCharFormat anchorFormat = oldFormat;
-    anchorFormat.setForeground(palette().link());
+    anchorFormat.setForeground(linkColor);
     anchorFormat.setAnchor(true);
     anchorFormat.setAnchorHref("card://" + cardName);
     anchorFormat.setFontItalic(true);
@@ -128,10 +130,10 @@ void ChatView::appendUrlTag(QTextCursor &cursor, QString url)
 
     QTextCharFormat oldFormat = cursor.charFormat();
     QTextCharFormat anchorFormat = oldFormat;
-    anchorFormat.setForeground(palette().link());
+    anchorFormat.setForeground(linkColor);
     anchorFormat.setAnchor(true);
     anchorFormat.setAnchorHref(url);
-    anchorFormat.setUnderlineColor(palette().link().color());
+    anchorFormat.setUnderlineColor(linkColor);
     anchorFormat.setFontUnderline(true);
 
     cursor.setCharFormat(anchorFormat);

--- a/cockatrice/src/chatview/chatview.h
+++ b/cockatrice/src/chatview/chatview.h
@@ -62,6 +62,7 @@ private:
 
     QColor otherUserColor = QColor(0, 65, 255); // dark blue
     QColor serverMessageColor = QColor(0x85, 0x15, 0x15);
+    QColor linkColor;
 
 private slots:
     void openLink(const QUrl &link);

--- a/cockatrice/src/pixmapgenerator.cpp
+++ b/cockatrice/src/pixmapgenerator.cpp
@@ -1,6 +1,8 @@
 #include "pixmapgenerator.h"
 #include "pb/serverinfo_user.pb.h"
+#include <QApplication>
 #include <QPainter>
+#include <QPalette>
 #include <cmath>
 #ifdef _WIN32
 #include "round.h"
@@ -163,3 +165,16 @@ QPixmap LockPixmapGenerator::generatePixmap(int height)
 }
 
 QMap<int, QPixmap> LockPixmapGenerator::pmCache;
+
+const QPixmap loadColorAdjustedPixmap(QString name)
+{
+    if (qApp->palette().windowText().color().lightness() > 200) {
+        QImage img(name);
+        img.invertPixels();
+        QPixmap result;
+        result.convertFromImage(img);
+        return result;
+    } else {
+        return QPixmap(name);
+    }
+}

--- a/cockatrice/src/pixmapgenerator.h
+++ b/cockatrice/src/pixmapgenerator.h
@@ -97,4 +97,6 @@ public:
     }
 };
 
+const QPixmap loadColorAdjustedPixmap(QString name);
+
 #endif

--- a/cockatrice/src/playerlistwidget.cpp
+++ b/cockatrice/src/playerlistwidget.cpp
@@ -57,9 +57,9 @@ PlayerListWidget::PlayerListWidget(TabSupervisor *_tabSupervisor,
     readyIcon = QPixmap("theme:icons/ready_start");
     notReadyIcon = QPixmap("theme:icons/not_ready_start");
     concededIcon = QPixmap("theme:icons/conceded");
-    playerIcon = QPixmap("theme:icons/player");
-    judgeIcon = QPixmap("theme:icons/scales");
-    spectatorIcon = QPixmap("theme:icons/spectator");
+    playerIcon = loadColorAdjustedPixmap("theme:icons/player");
+    judgeIcon = loadColorAdjustedPixmap("theme:icons/scales");
+    spectatorIcon = loadColorAdjustedPixmap("theme:icons/spectator");
     lockIcon = QPixmap("theme:icons/lock");
 
     if (tabSupervisor) {
@@ -173,8 +173,13 @@ void PlayerListWidget::setActivePlayer(int playerId)
     while (i.hasNext()) {
         i.next();
         QTreeWidgetItem *twi = i.value();
-        QColor c = i.key() == playerId ? QColor(150, 255, 150) : palette().base().color();
-        twi->setBackground(4, c);
+        if (i.key() == playerId) {
+            twi->setBackground(4, QColor(150, 255, 150));
+            twi->setTextColor(4, QColor(0, 0, 0));
+        } else {
+            twi->setBackground(4, palette().base().color());
+            twi->setTextColor(4, palette().text().color());
+        }
     }
 }
 

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -12,6 +12,7 @@
 #include "pb/response.pb.h"
 #include "pending_command.h"
 #include "pictureloader.h"
+#include "pixmapgenerator.h"
 #include "settingscache.h"
 #include "tab_supervisor.h"
 #include "tappedout_interface.h"
@@ -350,7 +351,7 @@ void TabDeckEditor::createCentralFrame()
     searchEdit->setObjectName("searchEdit");
     searchEdit->setPlaceholderText(tr("Search by card name"));
     searchEdit->setClearButtonEnabled(true);
-    searchEdit->addAction(QPixmap("theme:icons/search"), QLineEdit::LeadingPosition);
+    searchEdit->addAction(loadColorAdjustedPixmap("theme:icons/search"), QLineEdit::LeadingPosition);
     auto help = searchEdit->addAction(QPixmap("theme:icons/info"), QLineEdit::TrailingPosition);
     searchEdit->installEventFilter(&searchKeySignals);
 


### PR DESCRIPTION


## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem
- Dark mode still looks a little crappy.

## What will change with this Pull Request?
- Change some SVGs from black to white if their background is too dark.
- Change some hard-coded colors to take into account their background.

## Screenshots
![image](https://user-images.githubusercontent.com/671513/54094018-cef82f80-435a-11e9-81f5-56830aed4851.png)

