### PR TITLE
Fix rarity filter; fix #3675

### DIFF
--- a/cockatrice/src/filtertree.cpp
+++ b/cockatrice/src/filtertree.cpp
@@ -307,17 +307,16 @@ bool FilterItem::acceptRarity(const CardInfoPtr info) const
      * replacement OR we go through all possible cases.
      * Will also need to replace just "mythic"
      */
-    converted_term.replace("mythic", "mythic rare", Qt::CaseInsensitive);
     for (int i = 0; converted_term.length() <= 3 && i <= 6; i++) {
         switch (i) {
             case 0:
-                converted_term.replace("mr", "mythic rare", Qt::CaseInsensitive);
+                converted_term.replace("mr", "mythic", Qt::CaseInsensitive);
                 break;
             case 1:
-                converted_term.replace("m r", "mythic rare", Qt::CaseInsensitive);
+                converted_term.replace("m r", "mythic", Qt::CaseInsensitive);
                 break;
             case 2:
-                converted_term.replace("m", "mythic rare", Qt::CaseInsensitive);
+                converted_term.replace("m", "mythic", Qt::CaseInsensitive);
                 break;
             case 3:
                 converted_term.replace("c", "common", Qt::CaseInsensitive);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3675

## Short roundup of the initial problem
The rarity filter in the tree filters doesn't work correctly; the "inline" filter (on the search bar) is not affected.
Looks like the tree filter's rarity check is expecting the card database to contain "mythic rare" in a card's rarity property value, while it only contains "mythic".

## What will change with this Pull Request?
The filter is changes to check for "mythic" instead of "mythic rare".

