### PR TITLE
Reword spoiler info in settings

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -669,7 +669,7 @@ void DeckEditorSettingsPage::retranslateUi()
     mpSpoilerGroupBox->setTitle(tr("Spoilers"));
     mcDownloadSpoilersCheckBox.setText(tr("Download Spoilers Automatically"));
     mcSpoilerSaveLabel.setText(tr("Spoiler Location:"));
-    lastUpdatedLabel.setText(tr("Last Updated") + ": " + getLastUpdateTime());
+    lastUpdatedLabel.setText(tr("Last Change") + ": " + getLastUpdateTime());
     infoOnSpoilersLabel.setText(tr("Spoilers download automatically on launch") + "\n" +
                                 tr("Press the button to manually update without relaunching") + "\n\n" +
                                 tr("Do not close settings until manual update complete"));


### PR DESCRIPTION
## Short roundup of the initial problem
`Last Updated` could be misunderstood in the way, that users think it's the last time they hit the `Update Spoiler` button (in settings they are right next to each other). But in fact it's the time stamp from the spoiler file, so the last time the file got changed.
For our notifications we use a different wording, too.

## What will change with this Pull Request?
- Use same wording as in the notification (https://github.com/Cockatrice/Cockatrice/blob/master/cockatrice/src/spoilerbackgroundupdater.cpp#L178)


## Screenshots
![last_change](https://user-images.githubusercontent.com/9874850/55615056-b8dd6380-578e-11e9-84a9-743e3a5cf18c.png)
