### PR TITLE
Fail cmake if protoc doesn't exist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,9 @@ set(CMAKE_AUTOMOC TRUE)
 
 # Find other needed libraries
 FIND_PACKAGE(Protobuf REQUIRED)
+IF(NOT EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
+  MESSAGE(FATAL_ERROR "No protoc command found!")
+ENDIF()
 
 #Find OpenSSL
 IF(WIN32)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3704

## Short roundup of the initial problem
Cmake could succeed even if protoc didn't exist

## What will change with this Pull Request?
- cmake will fail when protoc isn't found

---

There might be a better way to do this; i'm still new to cmake