### PR TITLE
Oracle: skip cards with a star in the collectors' number

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -249,6 +249,11 @@ int OracleImporter::importCardsFromSet(CardSetPtr currentSet, const QList<QVaria
                 setInfo.setProperty(xmlPropertyName, propertyValue);
         }
 
+        // skip cards containing a star char in the collectors number
+        if(setInfo.getProperty("num").contains("★")) {
+            continue;
+        }
+
         // special handling properties
         colors = card.value("colors").toStringList().join("");
         if (!colors.isEmpty())

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -250,7 +250,7 @@ int OracleImporter::importCardsFromSet(CardSetPtr currentSet, const QList<QVaria
         }
 
         // skip cards containing a star char in the collectors number
-        if(setInfo.getProperty("num").contains("★")) {
+        if (setInfo.getProperty("num").contains("★")) {
             continue;
         }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3703

## Short roundup of the initial problem
WAR contains alternate printings of cards that are only available in a specific language.
These localized printings are currently being shown instead of the english ones.
All of these printings contains a star character ★ in their collectors' number.

## What will change with this Pull Request?
Oracle will skip importing all hr cards with a ★ in the collectors' number.
