### PR TITLE
Propose to save deck before loading a new one; fix #3699

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -754,6 +754,9 @@ void TabDeckEditor::actNewDeck()
 
 void TabDeckEditor::actLoadDeck()
 {
+    if (!confirmClose())
+        return;
+
     QFileDialog dialog(this, tr("Load deck"));
     dialog.setDirectory(settingsCache->getDeckPath());
     dialog.setNameFilters(DeckLoader::fileNameFilters);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3699

## Short roundup of the initial problem
See #3699

## What will change with this Pull Request?
The deck editor will prompt the user to save the current deck (if modified) before loading a new one.