### PR TITLE
Dont create dummy card infos for unkown cards

### DIFF
--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -46,7 +46,7 @@ void AbstractCardItem::cardInfoUpdated()
 {
     info = db->getCard(name);
 
-    if (!info) {
+    if (!info && !name.isEmpty()) {
         QVariantHash properties = QVariantHash();
 
         info = CardInfo::newInstance(name, "", true, QVariantHash(), QList<CardRelation *>(), QList<CardRelation *>(),


### PR DESCRIPTION
## Related Ticket(s)
- Somewhat fixes #3698
- relates #3589

## Short roundup of the initial problem
The change in #3589 added the ability to retrieve a card picture even if the card is not present in the card database, by creating an empty card info (aka a card database entry) for these cards.
A good use case is during a game, when we receive from the server a card name of a card that another player put on the game but that is not present in our card database.
We can still create a dummy card info with just the card name and try to get a picture for it.
Unfortunately the empty card info is created also for card that are unknown "by design", eg. facedown cards in a player's deck. These cards can be easily recognized by the fact that they have no name and a server id of -1.

## What will change with this Pull Request?
The dummy card info won't be created if the name is empty.
This restores the old behavior where the card back is shown.