### PR TITLE
Fix inconsistent styling of names for card properties

### DIFF
--- a/cockatrice/src/game_specific_terms.h
+++ b/cockatrice/src/game_specific_terms.h
@@ -26,19 +26,19 @@ QString const ColorIdentity("coloridentity");
 inline static const QString getNicePropertyName(QString key)
 {
     if (key == CardType)
-        return QCoreApplication::translate("Mtg", "Card type");
+        return QCoreApplication::translate("Mtg", "Card Type");
     if (key == ConvertedManaCost)
-        return QCoreApplication::translate("Mtg", "Converted mana cost");
+        return QCoreApplication::translate("Mtg", "Converted Mana Cost");
     if (key == Colors)
         return QCoreApplication::translate("Mtg", "Color(s)");
     if (key == Loyalty)
         return QCoreApplication::translate("Mtg", "Loyalty");
     if (key == MainCardType)
-        return QCoreApplication::translate("Mtg", "Main card type");
+        return QCoreApplication::translate("Mtg", "Main Card Type");
     if (key == ManaCost)
-        return QCoreApplication::translate("Mtg", "Mana cost");
+        return QCoreApplication::translate("Mtg", "Mana Cost");
     if (key == PowTough)
-        return QCoreApplication::translate("Mtg", "P / T");
+        return QCoreApplication::translate("Mtg", "P/T");
     if (key == Side)
         return QCoreApplication::translate("Mtg", "Side");
     if (key == Layout)


### PR DESCRIPTION
## Related Ticket(s)
- Related #3511

## Short roundup of the initial problem
Inconsistent styling of names for card properties

## What will change with this Pull Request?
- Consistent capital styling in line with `Color Identity`
- Remove spaces in `P/T`
