### PR TITLE
Appveyor: use Qt 5.12 LTS

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,13 +29,13 @@ cache:
 environment:
     matrix:
         - target_arch: win64
-          qt_ver: 5.9\msvc2017_64
+          qt_ver: 5.12\msvc2017_64
           cmake_generator: Visual Studio 15 2017 Win64
           cmake_toolset: v141,host=x64
           vcpkg_arch: x64
 
         - target_arch: win32
-          qt_ver: 5.9\msvc2015 # Qt doesn't provide a msvc2017_32
+          qt_ver: 5.12\msvc2017
           cmake_generator: Visual Studio 15 2017
           cmake_toolset: v141
           vcpkg_arch: x86


### PR DESCRIPTION
## What will change with this Pull Request?
- Appveyor always uses newest Qt 5.12 LTS (currently 5.12.2)
- msvc2017 for 64bit **and** 32bit