### PR TITLE
[DO NOT MERGE] Revert "Appveyor: use Qt 5.12 LTS"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,13 +29,13 @@ cache:
 environment:
     matrix:
         - target_arch: win64
-          qt_ver: 5.12\msvc2017_64
+          qt_ver: 5.9\msvc2017_64
           cmake_generator: Visual Studio 15 2017 Win64
           cmake_toolset: v141,host=x64
           vcpkg_arch: x64
 
         - target_arch: win32
-          qt_ver: 5.12\msvc2017
+          qt_ver: 5.9\msvc2015 # Qt doesn't provide a msvc2017_32
           cmake_generator: Visual Studio 15 2017
           cmake_toolset: v141
           vcpkg_arch: x86


### PR DESCRIPTION
Reverts Cockatrice/Cockatrice#3732 for now, see https://github.com/Cockatrice/Cockatrice/issues/3733