### PR TITLE
Fix windows style; fix #3733

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -260,7 +260,7 @@ if(WIN32)
 
     # qt5 plugins: audio, iconengines, imageformats, platforms, printsupport
     install(DIRECTORY "${QT_PLUGINS_DIR}/" DESTINATION ${plugin_dest_dir} COMPONENT Runtime
-        FILES_MATCHING REGEX "(audio|iconengines|imageformats|platforms|printsupport)/.*[^d]\\.dll")
+        FILES_MATCHING REGEX "(audio|iconengines|imageformats|platforms|printsupport|styles)/.*[^d]\\.dll")
 
     install(CODE "
         file(WRITE \"\${CMAKE_INSTALL_PREFIX}/${qtconf_dest_dir}/qt.conf\" \"[Paths]

--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -187,7 +187,7 @@ IF(WIN32)
     # qt5 plugins: iconengines, platforms
 
     install(DIRECTORY "${QT_PLUGINS_DIR}/" DESTINATION ${plugin_dest_dir} COMPONENT Runtime
-        FILES_MATCHING REGEX "(iconengines|platforms)/.*[^d]\\.dll")
+        FILES_MATCHING REGEX "(iconengines|platforms|styles)/.*[^d]\\.dll")
 
     install(CODE "
         file(WRITE \"\${CMAKE_INSTALL_PREFIX}/${qtconf_dest_dir}/qt.conf\" \"[Paths]


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3733

## Short roundup of the initial problem
Since Qt 5.12, we need to include a new "styles" plugin directory when deploying to windows, in order to include the "windowsvista" style that render controls in a win vista-7-8-10 fashion.

## What will change with this Pull Request?
The needed dll gets deployed
