### PR TITLE
Misc startup improvement

### DIFF
--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -275,8 +275,8 @@ SettingsCache::SettingsCache()
     spectatorsCanTalk = settings->value("game/spectatorscantalk", false).toBool();
     spectatorsCanSeeEverything = settings->value("game/spectatorscanseeeverything", false).toBool();
     rememberGameSettings = settings->value("game/remembergamesettings", true).toBool();
-    clientID = settings->value("personal/clientid", "notset").toString();
-    clientVersion = settings->value("personal/clientversion", "notset").toString();
+    clientID = settings->value("personal/clientid", CLIENT_INFO_NOT_SET).toString();
+    clientVersion = settings->value("personal/clientversion", CLIENT_INFO_NOT_SET).toString();
     knownMissingFeatures = settings->value("interface/knownmissingfeatures", "").toString();
 }
 

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -21,6 +21,7 @@ class ReleaseChannel;
 
 #define DEFAULT_LANG_CODE "en"
 #define DEFAULT_LANG_NAME "English"
+#define CLIENT_INFO_NOT_SET "notset"
 
 #define DEFAULT_FONT_SIZE 12
 

--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -24,9 +24,9 @@ SpoilerBackgroundUpdater::SpoilerBackgroundUpdater(QObject *apParent) : QObject(
     if (isSpoilerDownloadEnabled) {
         // Start the process of checking if we're in spoiler season
         // File exists means we're in spoiler season
-        // We will load the database before attempting to download spoilers, incase they fail
-        QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
         startSpoilerDownloadProcess(SPOILERS_STATUS_URL, false);
+    } else {
+        qDebug() << "Spoilers Disabled";
     }
 }
 

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -847,13 +847,14 @@ MainWindow::MainWindow(QWidget *parent)
 
 void MainWindow::startupConfigCheck()
 {
-    if(settingsCache->getClientVersion() == CLIENT_INFO_NOT_SET) {
+    if (settingsCache->getClientVersion() == CLIENT_INFO_NOT_SET) {
         // no config found, 99% new clean install
         qDebug() << "Startup: old client version empty, assuming first start after clean install";
         alertForcedOracleRun(VERSION_STRING, false);
     } else if (settingsCache->getClientVersion() != VERSION_STRING) {
         // config found, from another (presumably older) version
-        qDebug() << "Startup: old client version" << settingsCache->getClientVersion() << "differs, assuming first start after update";
+        qDebug() << "Startup: old client version" << settingsCache->getClientVersion()
+                 << "differs, assuming first start after update";
         if (settingsCache->getNotifyAboutNewVersion()) {
             alertForcedOracleRun(VERSION_STRING, true);
         }
@@ -874,16 +875,16 @@ void MainWindow::startupConfigCheck()
 void MainWindow::alertForcedOracleRun(const QString &version, bool isUpdate)
 {
     settingsCache->setClientVersion(version);
-    if(isUpdate) {
+    if (isUpdate) {
         QMessageBox::information(this, tr("New Version"),
-                             tr("Congratulations on updating to Cockatrice %1!\n"
-                                "Oracle will now launch to update your card database.")
-                                 .arg(version));
+                                 tr("Congratulations on updating to Cockatrice %1!\n"
+                                    "Oracle will now launch to update your card database.")
+                                     .arg(version));
     } else {
         QMessageBox::information(this, tr("Cockatrice installed"),
-                             tr("Congratulations on installing Cockatrice %1!\n"
-                                "Oracle will now launch to install the initial card database.")
-                                 .arg(version));
+                                 tr("Congratulations on installing Cockatrice %1!\n"
+                                    "Oracle will now launch to install the initial card database.")
+                                     .arg(version));
     }
 
     actCheckCardUpdates();

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -102,7 +102,8 @@ private slots:
     void actManageSets();
     void actEditTokens();
 
-    void alertForcedOracleRun(const QString &);
+    void startupConfigCheck();
+    void alertForcedOracleRun(const QString &version, bool isUpdate);
 
 private:
     static const QString appName;
@@ -152,19 +153,6 @@ protected:
     void closeEvent(QCloseEvent *event) override;
     void changeEvent(QEvent *event) override;
     QString extractInvalidUsernameMessage(QString &in);
-};
-
-class MainUpdateHelper : public QObject
-{
-    Q_OBJECT
-
-signals:
-    void newVersionDetected(QString);
-
-public:
-    explicit MainUpdateHelper() = default;
-    ~MainUpdateHelper() override = default;
-    void testForNewVersion();
 };
 
 #endif

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -214,7 +214,6 @@ void WndSets::actSave()
 {
     model->save(db);
     PictureLoader::clearPixmapCache();
-    QMessageBox::information(this, tr("Success"), tr("The sets database has been saved successfully."));
     close();
 }
 

--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -11,6 +11,7 @@ SET(oracle_SOURCES
     src/main.cpp
     src/oraclewizard.cpp
     src/oracleimporter.cpp
+    src/pagetemplates.cpp
     src/qt-json/json.cpp
     ../cockatrice/src/carddatabase.cpp
     ../cockatrice/src/pictureloader.cpp

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -198,8 +198,9 @@ void IntroPage::retranslateUi()
 void OutroPage::retranslateUi()
 {
     setTitle(tr("Finished"));
-    setSubTitle(tr("The wizard has finished.") + "<br/>" +
-                tr("You can now start using Cockatrice with the newly updated cards."));
+    setSubTitle(tr("The wizard has finished.") + "<br>" +
+				tr("You can now start using Cockatrice with the newly updated cards.") + "<br><br>" +
+				tr("If the card databases don't reload automatically, restart the Cockatrice client."));
 }
 
 LoadSetsPage::LoadSetsPage(QWidget *parent) : OracleWizardPage(parent)
@@ -247,7 +248,7 @@ void LoadSetsPage::initializePage()
 void LoadSetsPage::retranslateUi()
 {
     setTitle(tr("Source selection"));
-    setSubTitle(tr("Please specify a source for the list of sets and cards. "
+    setSubTitle(tr("Please specify a compatible source for the list of sets and cards. "
                    "You can specify a URL address that will be downloaded or "
                    "use an existing file from your computer."));
 
@@ -483,7 +484,7 @@ void LoadSetsPage::zipDownloadFailed(const QString &message)
     QMessageBox::StandardButton reply;
     reply = static_cast<QMessageBox::StandardButton>(QMessageBox::question(
         this, tr("Error"),
-        message + "<br/>" + tr("Do you want to try to download a fresh copy of the uncompressed file instead?"),
+        message + "<br>" + tr("Do you want to try to download a fresh copy of the uncompressed file instead?"),
         QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes));
 
     if (reply == QMessageBox::Yes) {
@@ -522,8 +523,8 @@ SaveSetsPage::SaveSetsPage(QWidget *parent) : OracleWizardPage(parent)
     auto *layout = new QGridLayout(this);
     layout->addWidget(messageLog, 0, 0);
     layout->addWidget(saveLabel, 1, 0);
-    layout->addWidget(pathLabel, 2, 0);
-    layout->addWidget(defaultPathCheckBox, 3, 0);
+    layout->addWidget(pathLabel, 3, 0);
+    layout->addWidget(defaultPathCheckBox, 4, 0);
 
     setLayout(layout);
 }
@@ -548,10 +549,10 @@ void SaveSetsPage::initializePage()
 void SaveSetsPage::retranslateUi()
 {
     setTitle(tr("Sets imported"));
-    setSubTitle(tr("The following sets has been imported."));
+    setSubTitle(tr("The following sets have been found:"));
 
-    saveLabel->setText(tr("Press \"Save\" to save the imported cards to the Cockatrice database."));
-    pathLabel->setText(tr("The card database will be saved at") + "<br/>" + settingsCache->getCardDatabasePath());
+    saveLabel->setText(tr("Press \"Save\" to store the imported cards in the Cockatrice database."));
+    pathLabel->setText(tr("The card database will be saved at the following location:") + "<br>" + settingsCache->getCardDatabasePath());
     defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 
     setButtonText(QWizard::NextButton, tr("&Save"));
@@ -632,11 +633,11 @@ QString LoadTokensPage::getFileType()
 void LoadTokensPage::retranslateUi()
 {
     setTitle(tr("Tokens import"));
-    setSubTitle(tr("Please specify a token source."));
+    setSubTitle(tr("Please specify a compatible source for token data."));
 
     urlLabel->setText(tr("Download URL:"));
     urlButton->setText(tr("Restore default URL"));
-    pathLabel->setText(tr("The token database will be saved at") + "<br/>" + settingsCache->getTokenDatabasePath());
+    pathLabel->setText(tr("The token database will be saved at the following location:") + "<br>" + settingsCache->getTokenDatabasePath());
     defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 }
 
@@ -668,10 +669,10 @@ QString LoadSpoilersPage::getFileType()
 void LoadSpoilersPage::retranslateUi()
 {
     setTitle(tr("Spoilers import"));
-    setSubTitle(tr("Please specify a spoiler source."));
+    setSubTitle(tr("Please specify a compatible source for spoiler data."));
 
     urlLabel->setText(tr("Download URL:"));
     urlButton->setText(tr("Restore default URL"));
-    pathLabel->setText(tr("The spoiler database will be saved at") + "<br/>" + settingsCache->getTokenDatabasePath());
+    pathLabel->setText(tr("The spoiler database will be saved at the following location:") + "<br>" + settingsCache->getTokenDatabasePath());
     defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 }

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -673,6 +673,6 @@ void LoadSpoilersPage::retranslateUi()
 
     urlLabel->setText(tr("Download URL:"));
     urlButton->setText(tr("Restore default URL"));
-    pathLabel->setText(tr("The spoiler database will be saved at the following location:") + "<br>" + settingsCache->getTokenDatabasePath());
+    pathLabel->setText(tr("The spoiler database will be saved at the following location:") + "<br>" + settingsCache->getSpoilerCardDatabasePath());
     defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 }

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -57,15 +57,17 @@ OracleWizard::OracleWizard(QWidget *parent) : QWizard(parent)
 
     importer = new OracleImporter(settingsCache->getDataPath(), this);
 
+    nam = new QNetworkAccessManager(this);
+
     if (!isSpoilersOnly) {
         addPage(new IntroPage);
         addPage(new LoadSetsPage);
         addPage(new SaveSetsPage);
         addPage(new LoadTokensPage);
-        addPage(new SaveTokensPage);
+        addPage(new OutroPage);
     } else {
         addPage(new LoadSpoilersPage);
-        addPage(new SaveSpoilersPage);
+        addPage(new OutroPage);
     }
 
     retranslateUi();
@@ -89,8 +91,6 @@ void OracleWizard::changeEvent(QEvent *event)
 void OracleWizard::retranslateUi()
 {
     setWindowTitle(tr("Oracle Importer"));
-    QWizard::setButtonText(QWizard::FinishButton, tr("Save"));
-
     for (int i = 0; i < pageIds().count(); i++) {
         dynamic_cast<OracleWizardPage *>(page(i))->retranslateUi();
     }
@@ -195,7 +195,14 @@ void IntroPage::retranslateUi()
     versionLabel->setText(tr("Version:") + QString(" %1").arg(VERSION_STRING));
 }
 
-LoadSetsPage::LoadSetsPage(QWidget *parent) : OracleWizardPage(parent), nam(nullptr)
+void OutroPage::retranslateUi()
+{
+    setTitle(tr("Finished"));
+    setSubTitle(tr("The wizard has finished.") + "<br/>" +
+                tr("You can now start using Cockatrice with the newly updated cards."));
+}
+
+LoadSetsPage::LoadSetsPage(QWidget *parent) : OracleWizardPage(parent)
 {
     urlRadioButton = new QRadioButton(this);
     fileRadioButton = new QRadioButton(this);
@@ -330,10 +337,7 @@ bool LoadSetsPage::validatePage()
 
 void LoadSetsPage::downloadSetsFile(QUrl url)
 {
-    if (!nam) {
-        nam = new QNetworkAccessManager(this);
-    }
-    QNetworkReply *reply = nam->get(QNetworkRequest(url));
+    QNetworkReply *reply = wizard()->nam->get(QNetworkRequest(url));
 
     connect(reply, SIGNAL(finished()), this, SLOT(actDownloadFinishedSetsFile()));
     connect(reply, SIGNAL(downloadProgress(qint64, qint64)), this, SLOT(actDownloadProgressSetsFile(qint64, qint64)));
@@ -600,392 +604,74 @@ bool SaveSetsPage::validatePage()
     return true;
 }
 
-LoadSpoilersPage::LoadSpoilersPage(QWidget *parent) : OracleWizardPage(parent), nam(nullptr)
+QString LoadTokensPage::getDefaultUrl()
 {
-    urlLabel = new QLabel(this);
-    urlLineEdit = new QLineEdit(this);
-
-    progressLabel = new QLabel(this);
-    progressBar = new QProgressBar(this);
-
-    urlButton = new QPushButton(this);
-    connect(urlButton, SIGNAL(clicked()), this, SLOT(actRestoreDefaultUrl()));
-
-    auto *layout = new QGridLayout(this);
-    layout->addWidget(urlLabel, 0, 0);
-    layout->addWidget(urlLineEdit, 0, 1);
-    layout->addWidget(urlButton, 1, 1, Qt::AlignRight);
-    layout->addWidget(progressLabel, 2, 0);
-    layout->addWidget(progressBar, 2, 1);
+    return TOKENS_URL;
 }
 
-void LoadSpoilersPage::actRestoreDefaultUrl()
+QString LoadTokensPage::getCustomUrlSettingsKey()
 {
-    urlLineEdit->setText(SPOILERS_URL);
+    return "tokensurl";
 }
 
-void LoadSpoilersPage::initializePage()
+QString LoadTokensPage::getDefaultSavePath()
 {
-    urlLineEdit->setText(wizard()->settings->value("spoilersurl", SPOILERS_URL).toString());
-
-    progressLabel->hide();
-    progressBar->hide();
+    return settingsCache->getTokenDatabasePath();
 }
 
-void LoadSpoilersPage::actDownloadProgressSpoilersFile(qint64 received, qint64 total)
+QString LoadTokensPage::getWindowTitle()
 {
-    if (total > 0) {
-        progressBar->setMaximum(static_cast<int>(total));
-        progressBar->setValue(static_cast<int>(received));
-    }
-
-    progressLabel->setText(tr("Downloading (%1MB)").arg((int)received / (1024 * 1024)));
+    return tr("Save token database");
 }
 
-void LoadSpoilersPage::actDownloadFinishedSpoilersFile()
+QString LoadTokensPage::getFileType()
 {
-    // Check for server reply
-    auto *reply = dynamic_cast<QNetworkReply *>(sender());
-    QNetworkReply::NetworkError errorCode = reply->error();
-
-    if (errorCode != QNetworkReply::NoError) {
-        QMessageBox::critical(this, tr("Error"), tr("Network error: %1.").arg(reply->errorString()));
-
-        wizard()->enableButtons();
-        setEnabled(true);
-
-        reply->deleteLater();
-        return;
-    }
-
-    int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-    if (statusCode == 301 || statusCode == 302) {
-        QUrl redirectUrl = reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
-        qDebug() << "following redirect url:" << redirectUrl.toString();
-        downloadSpoilersFile(redirectUrl);
-        reply->deleteLater();
-        return;
-    }
-
-    progressLabel->hide();
-    progressBar->hide();
-
-    // save spoiler.xml url, but only if the user customized it and download was successful
-    if (urlLineEdit->text() != QString(SPOILERS_URL)) {
-        wizard()->settings->setValue("spoilersurl", urlLineEdit->text());
-    } else {
-        wizard()->settings->remove("spoilersurl");
-    }
-
-    wizard()->setTokensData(reply->readAll());
-    reply->deleteLater();
-
-    wizard()->enableButtons();
-    setEnabled(true);
-    progressLabel->hide();
-    progressBar->hide();
-
-    wizard()->next();
-}
-
-void LoadSpoilersPage::downloadSpoilersFile(QUrl url)
-{
-    if (!nam) {
-        nam = new QNetworkAccessManager(this);
-    }
-    QNetworkReply *reply = nam->get(QNetworkRequest(url));
-
-    connect(reply, SIGNAL(finished()), this, SLOT(actDownloadFinishedSpoilersFile()));
-    connect(reply, SIGNAL(downloadProgress(qint64, qint64)), this,
-            SLOT(actDownloadProgressSpoilersFile(qint64, qint64)));
-}
-
-bool LoadSpoilersPage::validatePage()
-{
-    // once the import is finished, we call next(); skip validation
-    if (wizard()->hasTokensData()) {
-        return true;
-    }
-
-    QUrl url = QUrl::fromUserInput(urlLineEdit->text());
-    if (!url.isValid()) {
-        QMessageBox::critical(this, tr("Error"), tr("The provided URL is not valid."));
-        return false;
-    }
-
-    progressLabel->setText(tr("Downloading (0MB)"));
-    // show an infinite progressbar
-    progressBar->setMaximum(0);
-    progressBar->setMinimum(0);
-    progressBar->setValue(0);
-    progressLabel->show();
-    progressBar->show();
-
-    wizard()->disableButtons();
-    setEnabled(false);
-
-    downloadSpoilersFile(url);
-    return false;
-}
-
-void LoadSpoilersPage::retranslateUi()
-{
-    setTitle(tr("Spoilers source selection"));
-    setSubTitle(tr("Please specify a spoiler source."));
-
-    urlLabel->setText(tr("Download URL:"));
-    urlButton->setText(tr("Restore default URL"));
-}
-
-LoadTokensPage::LoadTokensPage(QWidget *parent) : OracleWizardPage(parent), nam(nullptr)
-{
-    urlLabel = new QLabel(this);
-    urlLineEdit = new QLineEdit(this);
-
-    progressLabel = new QLabel(this);
-    progressBar = new QProgressBar(this);
-
-    urlButton = new QPushButton(this);
-    connect(urlButton, SIGNAL(clicked()), this, SLOT(actRestoreDefaultUrl()));
-
-    auto *layout = new QGridLayout(this);
-    layout->addWidget(urlLabel, 0, 0);
-    layout->addWidget(urlLineEdit, 0, 1);
-    layout->addWidget(urlButton, 1, 1, Qt::AlignRight);
-    layout->addWidget(progressLabel, 2, 0);
-    layout->addWidget(progressBar, 2, 1);
-
-    setLayout(layout);
-}
-
-void LoadTokensPage::initializePage()
-{
-    urlLineEdit->setText(wizard()->settings->value("tokensurl", TOKENS_URL).toString());
-
-    progressLabel->hide();
-    progressBar->hide();
+    return tr("XML; token database (*.xml)");
 }
 
 void LoadTokensPage::retranslateUi()
 {
-    setTitle(tr("Tokens source selection"));
-    setSubTitle(tr("Please specify a source for the list of tokens."));
+    setTitle(tr("Tokens import"));
+    setSubTitle(tr("Please specify a token source."));
 
     urlLabel->setText(tr("Download URL:"));
     urlButton->setText(tr("Restore default URL"));
-}
-
-void LoadTokensPage::actRestoreDefaultUrl()
-{
-    urlLineEdit->setText(TOKENS_URL);
-}
-
-bool LoadTokensPage::validatePage()
-{
-    // once the import is finished, we call next(); skip validation
-    if (wizard()->hasTokensData()) {
-        return true;
-    }
-
-    QUrl url = QUrl::fromUserInput(urlLineEdit->text());
-    if (!url.isValid()) {
-        QMessageBox::critical(this, tr("Error"), tr("The provided URL is not valid."));
-        return false;
-    }
-
-    progressLabel->setText(tr("Downloading (0MB)"));
-    // show an infinite progressbar
-    progressBar->setMaximum(0);
-    progressBar->setMinimum(0);
-    progressBar->setValue(0);
-    progressLabel->show();
-    progressBar->show();
-
-    wizard()->disableButtons();
-    setEnabled(false);
-
-    downloadTokensFile(url);
-    return false;
-}
-
-void LoadTokensPage::downloadTokensFile(QUrl url)
-{
-    if (!nam) {
-        nam = new QNetworkAccessManager(this);
-    }
-    QNetworkReply *reply = nam->get(QNetworkRequest(url));
-
-    connect(reply, SIGNAL(finished()), this, SLOT(actDownloadFinishedTokensFile()));
-    connect(reply, SIGNAL(downloadProgress(qint64, qint64)), this, SLOT(actDownloadProgressTokensFile(qint64, qint64)));
-}
-
-void LoadTokensPage::actDownloadProgressTokensFile(qint64 received, qint64 total)
-{
-    if (total > 0) {
-        progressBar->setMaximum(static_cast<int>(total));
-        progressBar->setValue(static_cast<int>(received));
-    }
-    progressLabel->setText(tr("Downloading (%1MB)").arg((int)received / (1024 * 1024)));
-}
-
-void LoadTokensPage::actDownloadFinishedTokensFile()
-{
-    // check for a reply
-    auto *reply = dynamic_cast<QNetworkReply *>(sender());
-    QNetworkReply::NetworkError errorCode = reply->error();
-    if (errorCode != QNetworkReply::NoError) {
-        QMessageBox::critical(this, tr("Error"), tr("Network error: %1.").arg(reply->errorString()));
-
-        wizard()->enableButtons();
-        setEnabled(true);
-
-        reply->deleteLater();
-        return;
-    }
-
-    int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-    if (statusCode == 301 || statusCode == 302) {
-        QUrl redirectUrl = reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
-        qDebug() << "following redirect url:" << redirectUrl.toString();
-        downloadTokensFile(redirectUrl);
-        reply->deleteLater();
-        return;
-    }
-
-    progressLabel->hide();
-    progressBar->hide();
-
-    // save tokens.xml url, but only if the user customized it and download was successfull
-    if (urlLineEdit->text() != QString(TOKENS_URL)) {
-        wizard()->settings->setValue("tokensurl", urlLineEdit->text());
-    } else {
-        wizard()->settings->remove("tokensurl");
-    }
-
-    wizard()->setTokensData(reply->readAll());
-    reply->deleteLater();
-
-    wizard()->enableButtons();
-    setEnabled(true);
-    progressLabel->hide();
-    progressBar->hide();
-
-    wizard()->next();
-}
-
-SaveSpoilersPage::SaveSpoilersPage(QWidget *parent) : OracleWizardPage(parent)
-{
-    pathLabel = new QLabel(this);
-
-    defaultPathCheckBox = new QCheckBox(this);
-
-    auto *layout = new QGridLayout(this);
-    layout->addWidget(pathLabel, 0, 0);
-    layout->addWidget(defaultPathCheckBox, 1, 0);
-
-    setLayout(layout);
-}
-
-void SaveSpoilersPage::retranslateUi()
-{
-    setTitle(tr("Spoilers imported"));
-    setSubTitle(tr("The spoilers file has been imported. "
-                   "Press \"Save\" to save the imported spoilers to the Cockatrice card database."));
-
-    pathLabel->setText(tr("The spoiler database will be saved at") + "<br/>" +
-                       settingsCache->getSpoilerCardDatabasePath());
-    defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
-}
-
-bool SaveSpoilersPage::validatePage()
-{
-    bool ok = false;
-    QString defaultPath = settingsCache->getSpoilerCardDatabasePath();
-    QString windowName = tr("Save spoiler database");
-    QString fileType = tr("XML; card database (*.xml)");
-
-    do {
-        QString fileName;
-        if (defaultPathCheckBox->isChecked()) {
-            fileName = QFileDialog::getSaveFileName(this, windowName, defaultPath, fileType);
-        } else {
-            fileName = defaultPath;
-        }
-
-        if (fileName.isEmpty()) {
-            return false;
-        }
-
-        QFileInfo fi(fileName);
-        QDir fileDir(fi.path());
-        if (!fileDir.exists() && !fileDir.mkpath(fileDir.absolutePath())) {
-            return false;
-        }
-
-        if (wizard()->saveTokensToFile(fileName)) {
-            ok = true;
-        } else {
-            QMessageBox::critical(this, tr("Error"), tr("The file could not be saved to %1").arg(fileName));
-        }
-    } while (!ok);
-
-    return true;
-}
-
-SaveTokensPage::SaveTokensPage(QWidget *parent) : OracleWizardPage(parent)
-{
-    defaultPathCheckBox = new QCheckBox(this);
-
-    pathLabel = new QLabel(this);
-
-    auto *layout = new QGridLayout(this);
-    layout->addWidget(pathLabel, 0, 0);
-    layout->addWidget(defaultPathCheckBox, 1, 0);
-
-    setLayout(layout);
-}
-
-void SaveTokensPage::retranslateUi()
-{
-    setTitle(tr("Tokens imported"));
-    setSubTitle(tr("The tokens has been imported. "
-                   "Press \"Save\" to save the imported tokens to the Cockatrice tokens database."));
-
     pathLabel->setText(tr("The token database will be saved at") + "<br/>" + settingsCache->getTokenDatabasePath());
     defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 }
 
-bool SaveTokensPage::validatePage()
+QString LoadSpoilersPage::getDefaultUrl()
 {
-    bool ok = false;
-    QString defaultPath = settingsCache->getTokenDatabasePath();
-    QString windowName = tr("Save token database");
-    QString fileType = tr("XML; token database (*.xml)");
+    return SPOILERS_URL;
+}
 
-    do {
-        QString fileName;
-        if (defaultPathCheckBox->isChecked()) {
-            fileName = QFileDialog::getSaveFileName(this, windowName, defaultPath, fileType);
-        } else {
-            fileName = defaultPath;
-        }
+QString LoadSpoilersPage::getCustomUrlSettingsKey()
+{
+    return "spoilersurl";
+}
 
-        if (fileName.isEmpty()) {
-            return false;
-        }
+QString LoadSpoilersPage::getDefaultSavePath()
+{
+    return settingsCache->getTokenDatabasePath();
+}
 
-        QFileInfo fi(fileName);
-        QDir fileDir(fi.path());
-        if (!fileDir.exists() && !fileDir.mkpath(fileDir.absolutePath())) {
-            return false;
-        }
+QString LoadSpoilersPage::getWindowTitle()
+{
+    return tr("Save spoiler database");
+}
 
-        if (wizard()->saveTokensToFile(fileName)) {
-            ok = true;
-        } else {
-            QMessageBox::critical(this, tr("Error"), tr("The file could not be saved to %1").arg(fileName));
-        }
-    } while (!ok);
+QString LoadSpoilersPage::getFileType()
+{
+    return tr("XML; spoiler database (*.xml)");
+}
 
-    return true;
+void LoadSpoilersPage::retranslateUi()
+{
+    setTitle(tr("Spoilers import"));
+    setSubTitle(tr("Please specify a spoiler source."));
+
+    urlLabel->setText(tr("Download URL:"));
+    urlButton->setText(tr("Restore default URL"));
+    pathLabel->setText(tr("The spoiler database will be saved at") + "<br/>" + settingsCache->getTokenDatabasePath());
+    defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 }

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -523,8 +523,8 @@ SaveSetsPage::SaveSetsPage(QWidget *parent) : OracleWizardPage(parent)
     auto *layout = new QGridLayout(this);
     layout->addWidget(messageLog, 0, 0);
     layout->addWidget(saveLabel, 1, 0);
-    layout->addWidget(pathLabel, 3, 0);
-    layout->addWidget(defaultPathCheckBox, 4, 0);
+    layout->addWidget(pathLabel, 2, 0);
+    layout->addWidget(defaultPathCheckBox, 3, 0);
 
     setLayout(layout);
 }

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -507,15 +507,17 @@ void LoadSetsPage::importFinished()
 
 SaveSetsPage::SaveSetsPage(QWidget *parent) : OracleWizardPage(parent)
 {
+    pathLabel = new QLabel(this);
+
     defaultPathCheckBox = new QCheckBox(this);
-    defaultPathCheckBox->setChecked(true);
 
     messageLog = new QTextEdit(this);
     messageLog->setReadOnly(true);
 
     auto *layout = new QGridLayout(this);
-    layout->addWidget(defaultPathCheckBox, 0, 0);
-    layout->addWidget(messageLog, 1, 0);
+    layout->addWidget(pathLabel, 0, 0);
+    layout->addWidget(defaultPathCheckBox, 1, 0);
+    layout->addWidget(messageLog, 2, 0);
 
     setLayout(layout);
 }
@@ -543,7 +545,9 @@ void SaveSetsPage::retranslateUi()
     setSubTitle(tr("The following sets has been imported. "
                    "Press \"Save\" to save the imported cards to the Cockatrice database."));
 
-    defaultPathCheckBox->setText(tr("Save to the default path (recommended)"));
+    pathLabel->setText(tr("The card database will be saved at") + "<br/>" + settingsCache->getTokenDatabasePath());
+    defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
+
     setButtonText(QWizard::NextButton, tr("&Save"));
 }
 
@@ -569,9 +573,9 @@ bool SaveSetsPage::validatePage()
     do {
         QString fileName;
         if (defaultPathCheckBox->isChecked()) {
-            fileName = defaultPath;
-        } else {
             fileName = QFileDialog::getSaveFileName(this, windowName, defaultPath, fileType);
+        } else {
+            fileName = defaultPath;
         }
 
         if (fileName.isEmpty()) {
@@ -586,14 +590,8 @@ bool SaveSetsPage::validatePage()
 
         if (wizard()->importer->saveToFile(fileName)) {
             ok = true;
-            QMessageBox::information(this, tr("Success"),
-                                     tr("The card database has been saved successfully to\n%1").arg(fileName));
         } else {
             QMessageBox::critical(this, tr("Error"), tr("The file could not be saved to %1").arg(fileName));
-            ;
-            if (defaultPathCheckBox->isChecked()) {
-                defaultPathCheckBox->setChecked(false);
-            }
         }
     } while (!ok);
 
@@ -875,11 +873,13 @@ void LoadTokensPage::actDownloadFinishedTokensFile()
 
 SaveSpoilersPage::SaveSpoilersPage(QWidget *parent) : OracleWizardPage(parent)
 {
+    pathLabel = new QLabel(this);
+
     defaultPathCheckBox = new QCheckBox(this);
-    defaultPathCheckBox->setChecked(true);
 
     auto *layout = new QGridLayout(this);
-    layout->addWidget(defaultPathCheckBox, 0, 0);
+    layout->addWidget(pathLabel, 0, 0);
+    layout->addWidget(defaultPathCheckBox, 1, 0);
 
     setLayout(layout);
 }
@@ -890,7 +890,8 @@ void SaveSpoilersPage::retranslateUi()
     setSubTitle(tr("The spoilers file has been imported. "
                    "Press \"Save\" to save the imported spoilers to the Cockatrice card database."));
 
-    defaultPathCheckBox->setText(tr("Save to the default path (recommended)"));
+    pathLabel->setText(tr("The spoiler database will be saved at") + "<br/>" + settingsCache->getTokenDatabasePath());
+    defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 }
 
 bool SaveSpoilersPage::validatePage()
@@ -903,9 +904,9 @@ bool SaveSpoilersPage::validatePage()
     do {
         QString fileName;
         if (defaultPathCheckBox->isChecked()) {
-            fileName = defaultPath;
-        } else {
             fileName = QFileDialog::getSaveFileName(this, windowName, defaultPath, fileType);
+        } else {
+            fileName = defaultPath;
         }
 
         if (fileName.isEmpty()) {
@@ -922,10 +923,6 @@ bool SaveSpoilersPage::validatePage()
             ok = true;
         } else {
             QMessageBox::critical(this, tr("Error"), tr("The file could not be saved to %1").arg(fileName));
-            ;
-            if (defaultPathCheckBox->isChecked()) {
-                defaultPathCheckBox->setChecked(false);
-            }
         }
     } while (!ok);
 
@@ -935,10 +932,12 @@ bool SaveSpoilersPage::validatePage()
 SaveTokensPage::SaveTokensPage(QWidget *parent) : OracleWizardPage(parent)
 {
     defaultPathCheckBox = new QCheckBox(this);
-    defaultPathCheckBox->setChecked(true);
+
+    pathLabel = new QLabel(this);
 
     auto *layout = new QGridLayout(this);
-    layout->addWidget(defaultPathCheckBox, 0, 0);
+    layout->addWidget(pathLabel, 0, 0);
+    layout->addWidget(defaultPathCheckBox, 1, 0);
 
     setLayout(layout);
 }
@@ -949,7 +948,8 @@ void SaveTokensPage::retranslateUi()
     setSubTitle(tr("The tokens has been imported. "
                    "Press \"Save\" to save the imported tokens to the Cockatrice tokens database."));
 
-    defaultPathCheckBox->setText(tr("Save to the default path (recommended)"));
+    pathLabel->setText(tr("The token database will be saved at") + "<br/>" + settingsCache->getTokenDatabasePath());
+    defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 }
 
 bool SaveTokensPage::validatePage()
@@ -962,9 +962,9 @@ bool SaveTokensPage::validatePage()
     do {
         QString fileName;
         if (defaultPathCheckBox->isChecked()) {
-            fileName = defaultPath;
-        } else {
             fileName = QFileDialog::getSaveFileName(this, windowName, defaultPath, fileType);
+        } else {
+            fileName = defaultPath;
         }
 
         if (fileName.isEmpty()) {
@@ -979,14 +979,8 @@ bool SaveTokensPage::validatePage()
 
         if (wizard()->saveTokensToFile(fileName)) {
             ok = true;
-            QMessageBox::information(this, tr("Success"),
-                                     tr("The token database has been saved successfully to\n%1").arg(fileName));
         } else {
             QMessageBox::critical(this, tr("Error"), tr("The file could not be saved to %1").arg(fileName));
-            ;
-            if (defaultPathCheckBox->isChecked()) {
-                defaultPathCheckBox->setChecked(false);
-            }
         }
     } while (!ok);
 

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -199,8 +199,8 @@ void OutroPage::retranslateUi()
 {
     setTitle(tr("Finished"));
     setSubTitle(tr("The wizard has finished.") + "<br>" +
-				tr("You can now start using Cockatrice with the newly updated cards.") + "<br><br>" +
-				tr("If the card databases don't reload automatically, restart the Cockatrice client."));
+                tr("You can now start using Cockatrice with the newly updated cards.") + "<br><br>" +
+                tr("If the card databases don't reload automatically, restart the Cockatrice client."));
 }
 
 LoadSetsPage::LoadSetsPage(QWidget *parent) : OracleWizardPage(parent)
@@ -483,8 +483,7 @@ void LoadSetsPage::zipDownloadFailed(const QString &message)
 
     QMessageBox::StandardButton reply;
     reply = static_cast<QMessageBox::StandardButton>(QMessageBox::question(
-        this, tr("Error"),
-        message + "<br>" + tr("Do you want to download the uncompressed file instead?"),
+        this, tr("Error"), message + "<br>" + tr("Do you want to download the uncompressed file instead?"),
         QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes));
 
     if (reply == QMessageBox::Yes) {
@@ -552,7 +551,8 @@ void SaveSetsPage::retranslateUi()
     setSubTitle(tr("The following sets have been found:"));
 
     saveLabel->setText(tr("Press \"Save\" to store the imported cards in the Cockatrice database."));
-    pathLabel->setText(tr("The card database will be saved at the following location:") + "<br>" + settingsCache->getCardDatabasePath());
+    pathLabel->setText(tr("The card database will be saved at the following location:") + "<br>" +
+                       settingsCache->getCardDatabasePath());
     defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 
     setButtonText(QWizard::NextButton, tr("&Save"));
@@ -637,7 +637,8 @@ void LoadTokensPage::retranslateUi()
 
     urlLabel->setText(tr("Download URL:"));
     urlButton->setText(tr("Restore default URL"));
-    pathLabel->setText(tr("The token database will be saved at the following location:") + "<br>" + settingsCache->getTokenDatabasePath());
+    pathLabel->setText(tr("The token database will be saved at the following location:") + "<br>" +
+                       settingsCache->getTokenDatabasePath());
     defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 }
 
@@ -673,6 +674,7 @@ void LoadSpoilersPage::retranslateUi()
 
     urlLabel->setText(tr("Download URL:"));
     urlButton->setText(tr("Restore default URL"));
-    pathLabel->setText(tr("The spoiler database will be saved at the following location:") + "<br>" + settingsCache->getSpoilerCardDatabasePath());
+    pathLabel->setText(tr("The spoiler database will be saved at the following location:") + "<br>" +
+                       settingsCache->getSpoilerCardDatabasePath());
     defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 }

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -484,7 +484,7 @@ void LoadSetsPage::zipDownloadFailed(const QString &message)
     QMessageBox::StandardButton reply;
     reply = static_cast<QMessageBox::StandardButton>(QMessageBox::question(
         this, tr("Error"),
-        message + "<br>" + tr("Do you want to try to download a fresh copy of the uncompressed file instead?"),
+        message + "<br>" + tr("Do you want to download the uncompressed file instead?"),
         QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes));
 
     if (reply == QMessageBox::Yes) {

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -545,7 +545,7 @@ void SaveSetsPage::retranslateUi()
     setSubTitle(tr("The following sets has been imported. "
                    "Press \"Save\" to save the imported cards to the Cockatrice database."));
 
-    pathLabel->setText(tr("The card database will be saved at") + "<br/>" + settingsCache->getTokenDatabasePath());
+    pathLabel->setText(tr("The card database will be saved at") + "<br/>" + settingsCache->getCardDatabasePath());
     defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 
     setButtonText(QWizard::NextButton, tr("&Save"));
@@ -890,7 +890,7 @@ void SaveSpoilersPage::retranslateUi()
     setSubTitle(tr("The spoilers file has been imported. "
                    "Press \"Save\" to save the imported spoilers to the Cockatrice card database."));
 
-    pathLabel->setText(tr("The spoiler database will be saved at") + "<br/>" + settingsCache->getTokenDatabasePath());
+    pathLabel->setText(tr("The spoiler database will be saved at") + "<br/>" + settingsCache->getSpoilerCardDatabasePath());
     defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 }
 

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -508,6 +508,7 @@ void LoadSetsPage::importFinished()
 SaveSetsPage::SaveSetsPage(QWidget *parent) : OracleWizardPage(parent)
 {
     pathLabel = new QLabel(this);
+    saveLabel = new QLabel(this);
 
     defaultPathCheckBox = new QCheckBox(this);
 
@@ -515,9 +516,10 @@ SaveSetsPage::SaveSetsPage(QWidget *parent) : OracleWizardPage(parent)
     messageLog->setReadOnly(true);
 
     auto *layout = new QGridLayout(this);
-    layout->addWidget(pathLabel, 0, 0);
-    layout->addWidget(defaultPathCheckBox, 1, 0);
-    layout->addWidget(messageLog, 2, 0);
+    layout->addWidget(messageLog, 0, 0);
+    layout->addWidget(saveLabel, 1, 0);
+    layout->addWidget(pathLabel, 2, 0);
+    layout->addWidget(defaultPathCheckBox, 3, 0);
 
     setLayout(layout);
 }
@@ -542,9 +544,9 @@ void SaveSetsPage::initializePage()
 void SaveSetsPage::retranslateUi()
 {
     setTitle(tr("Sets imported"));
-    setSubTitle(tr("The following sets has been imported. "
-                   "Press \"Save\" to save the imported cards to the Cockatrice database."));
+    setSubTitle(tr("The following sets has been imported."));
 
+    saveLabel->setText(tr("Press \"Save\" to save the imported cards to the Cockatrice database."));
     pathLabel->setText(tr("The card database will be saved at") + "<br/>" + settingsCache->getCardDatabasePath());
     defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -890,7 +890,8 @@ void SaveSpoilersPage::retranslateUi()
     setSubTitle(tr("The spoilers file has been imported. "
                    "Press \"Save\" to save the imported spoilers to the Cockatrice card database."));
 
-    pathLabel->setText(tr("The spoiler database will be saved at") + "<br/>" + settingsCache->getSpoilerCardDatabasePath());
+    pathLabel->setText(tr("The spoiler database will be saved at") + "<br/>" +
+                       settingsCache->getSpoilerCardDatabasePath());
     defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 }
 

--- a/oracle/src/oraclewizard.h
+++ b/oracle/src/oraclewizard.h
@@ -19,6 +19,8 @@ class QVBoxLayout;
 class OracleImporter;
 class QSettings;
 
+#include "pagetemplates.h"
+
 class OracleWizard : public QWizard
 {
     Q_OBJECT
@@ -41,6 +43,7 @@ public:
 public:
     OracleImporter *importer;
     QSettings *settings;
+    QNetworkAccessManager *nam;
 
 private slots:
     void updateLanguage();
@@ -50,20 +53,6 @@ private:
 
 protected:
     void changeEvent(QEvent *event) override;
-};
-
-class OracleWizardPage : public QWizardPage
-{
-    Q_OBJECT
-public:
-    explicit OracleWizardPage(QWidget *parent = nullptr) : QWizardPage(parent){};
-    virtual void retranslateUi() = 0;
-
-protected:
-    inline OracleWizard *wizard()
-    {
-        return (OracleWizard *)QWizardPage::wizard();
-    };
 };
 
 class IntroPage : public OracleWizardPage
@@ -83,6 +72,16 @@ private:
 
 private slots:
     void languageBoxChanged(int index);
+};
+
+class OutroPage : public OracleWizardPage
+{
+    Q_OBJECT
+public:
+    explicit OutroPage(QWidget *parent = nullptr)
+    {
+    }
+    void retranslateUi() override;
 };
 
 class LoadSetsPage : public OracleWizardPage
@@ -108,7 +107,6 @@ private:
     QLabel *progressLabel;
     QProgressBar *progressBar;
 
-    QNetworkAccessManager *nam;
     QFutureWatcher<bool> watcher;
     QFuture<bool> future;
 
@@ -143,86 +141,34 @@ private slots:
     void updateTotalProgress(int cardsImported, int setIndex, const QString &setName);
 };
 
-class LoadSpoilersPage : public OracleWizardPage
+class LoadSpoilersPage : public SimpleDownloadFilePage
 {
     Q_OBJECT
 public:
-    explicit LoadSpoilersPage(QWidget *parent = nullptr);
+    explicit LoadSpoilersPage(QWidget *parent = nullptr){};
     void retranslateUi() override;
 
-private:
-    QLabel *urlLabel;
-    QLineEdit *urlLineEdit;
-    QPushButton *urlButton;
-    QLabel *progressLabel;
-    QProgressBar *progressBar;
-    QNetworkAccessManager *nam;
-
-private slots:
-    void actRestoreDefaultUrl();
-    void actDownloadProgressSpoilersFile(qint64 received, qint64 total);
-    void actDownloadFinishedSpoilersFile();
-
 protected:
-    void initializePage() override;
-    bool validatePage() override;
-    void downloadSpoilersFile(QUrl url);
+    QString getDefaultUrl() override;
+    QString getCustomUrlSettingsKey() override;
+    QString getDefaultSavePath() override;
+    QString getWindowTitle() override;
+    QString getFileType() override;
 };
 
-class SaveSpoilersPage : public OracleWizardPage
+class LoadTokensPage : public SimpleDownloadFilePage
 {
     Q_OBJECT
 public:
-    explicit SaveSpoilersPage(QWidget *parent = nullptr);
-    void retranslateUi() override;
-
-private:
-    QCheckBox *defaultPathCheckBox;
-    QLabel *pathLabel;
-
-protected:
-    bool validatePage() override;
-};
-
-class LoadTokensPage : public OracleWizardPage
-{
-    Q_OBJECT
-public:
-    explicit LoadTokensPage(QWidget *parent = nullptr);
+    explicit LoadTokensPage(QWidget *parent = nullptr){};
     void retranslateUi() override;
 
 protected:
-    void initializePage() override;
-    bool validatePage() override;
-    void downloadTokensFile(QUrl url);
-
-private:
-    QLabel *urlLabel;
-    QLineEdit *urlLineEdit;
-    QPushButton *urlButton;
-    QLabel *progressLabel;
-    QProgressBar *progressBar;
-    QNetworkAccessManager *nam;
-
-private slots:
-    void actRestoreDefaultUrl();
-    void actDownloadProgressTokensFile(qint64 received, qint64 total);
-    void actDownloadFinishedTokensFile();
-};
-
-class SaveTokensPage : public OracleWizardPage
-{
-    Q_OBJECT
-public:
-    explicit SaveTokensPage(QWidget *parent = nullptr);
-    void retranslateUi() override;
-
-private:
-    QCheckBox *defaultPathCheckBox;
-    QLabel *pathLabel;
-
-protected:
-    bool validatePage() override;
+    QString getDefaultUrl() override;
+    QString getCustomUrlSettingsKey() override;
+    QString getDefaultSavePath() override;
+    QString getWindowTitle() override;
+    QString getFileType() override;
 };
 
 #endif

--- a/oracle/src/oraclewizard.h
+++ b/oracle/src/oraclewizard.h
@@ -78,7 +78,7 @@ class OutroPage : public OracleWizardPage
 {
     Q_OBJECT
 public:
-    explicit OutroPage(QWidget *parent = nullptr)
+    explicit OutroPage(QWidget * = nullptr)
     {
     }
     void retranslateUi() override;
@@ -145,7 +145,7 @@ class LoadSpoilersPage : public SimpleDownloadFilePage
 {
     Q_OBJECT
 public:
-    explicit LoadSpoilersPage(QWidget *parent = nullptr){};
+    explicit LoadSpoilersPage(QWidget * = nullptr){};
     void retranslateUi() override;
 
 protected:
@@ -160,7 +160,7 @@ class LoadTokensPage : public SimpleDownloadFilePage
 {
     Q_OBJECT
 public:
-    explicit LoadTokensPage(QWidget *parent = nullptr){};
+    explicit LoadTokensPage(QWidget * = nullptr){};
     void retranslateUi() override;
 
 protected:

--- a/oracle/src/oraclewizard.h
+++ b/oracle/src/oraclewizard.h
@@ -132,6 +132,7 @@ private:
     QTextEdit *messageLog;
     QCheckBox *defaultPathCheckBox;
     QLabel *pathLabel;
+    QLabel *saveLabel;
 
 protected:
     void initializePage() override;

--- a/oracle/src/oraclewizard.h
+++ b/oracle/src/oraclewizard.h
@@ -131,6 +131,7 @@ public:
 private:
     QTextEdit *messageLog;
     QCheckBox *defaultPathCheckBox;
+    QLabel *pathLabel;
 
 protected:
     void initializePage() override;
@@ -176,6 +177,7 @@ public:
 
 private:
     QCheckBox *defaultPathCheckBox;
+    QLabel *pathLabel;
 
 protected:
     bool validatePage() override;
@@ -216,6 +218,7 @@ public:
 
 private:
     QCheckBox *defaultPathCheckBox;
+    QLabel *pathLabel;
 
 protected:
     bool validatePage() override;

--- a/oracle/src/pagetemplates.cpp
+++ b/oracle/src/pagetemplates.cpp
@@ -43,7 +43,7 @@ SimpleDownloadFilePage::SimpleDownloadFilePage(QWidget *parent) : OracleWizardPa
 
 void SimpleDownloadFilePage::initializePage()
 {
-    // get custom url from settings if any; otherway use default url
+    // get custom url from settings if any; otherwise use default url
     urlLineEdit->setText(wizard()->settings->value(getCustomUrlSettingsKey(), getDefaultUrl()).toString());
 
     progressLabel->hide();

--- a/oracle/src/pagetemplates.cpp
+++ b/oracle/src/pagetemplates.cpp
@@ -1,0 +1,196 @@
+#include <QCheckBox>
+#include <QDir>
+#include <QFileDialog>
+#include <QGridLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QNetworkReply>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QtGui>
+
+#include "pagetemplates.h"
+#include "oraclewizard.h"
+
+SimpleDownloadFilePage::SimpleDownloadFilePage(QWidget *parent) : OracleWizardPage(parent)
+{
+    urlLabel = new QLabel(this);
+    urlLineEdit = new QLineEdit(this);
+
+    progressLabel = new QLabel(this);
+    progressBar = new QProgressBar(this);
+
+    urlButton = new QPushButton(this);
+    connect(urlButton, SIGNAL(clicked()), this, SLOT(actRestoreDefaultUrl()));
+
+    defaultPathCheckBox = new QCheckBox(this);
+
+    pathLabel = new QLabel(this);
+    pathLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
+    auto *layout = new QGridLayout(this);
+    layout->addWidget(urlLabel, 0, 0);
+    layout->addWidget(urlLineEdit, 0, 1);
+    layout->addWidget(urlButton, 1, 1, Qt::AlignRight);
+    layout->addWidget(pathLabel, 2, 0, 1, 2);
+    layout->addWidget(defaultPathCheckBox, 3, 0, 1, 2);
+    layout->addWidget(progressLabel, 4, 0);
+    layout->addWidget(progressBar, 4, 1);
+
+    setLayout(layout);
+}
+
+void SimpleDownloadFilePage::initializePage()
+{
+    // get custom url from settings if any; otherway use default url
+    urlLineEdit->setText(wizard()->settings->value(getCustomUrlSettingsKey(), getDefaultUrl()).toString());
+
+    progressLabel->hide();
+    progressBar->hide();
+}
+
+void SimpleDownloadFilePage::actRestoreDefaultUrl()
+{
+    urlLineEdit->setText(getDefaultUrl());
+}
+
+bool SimpleDownloadFilePage::validatePage()
+{
+    // if data has already been downloaded, pass directly to the "save" step
+    if (!downloadData.isEmpty()) {
+        if(saveToFile()) {
+            return true;
+        } else {
+            wizard()->enableButtons();
+            return false;
+        }
+    }
+
+    QUrl url = QUrl::fromUserInput(urlLineEdit->text());
+    if (!url.isValid()) {
+        QMessageBox::critical(this, tr("Error"), tr("The provided URL is not valid."));
+        return false;
+    }
+
+    progressLabel->setText(tr("Downloading (0MB)"));
+    // show an infinite progressbar
+    progressBar->setMaximum(0);
+    progressBar->setMinimum(0);
+    progressBar->setValue(0);
+    progressLabel->show();
+    progressBar->show();
+
+    wizard()->disableButtons();
+    downloadFile(url);
+    return false;
+}
+
+void SimpleDownloadFilePage::downloadFile(QUrl url)
+{
+    QNetworkReply *reply = wizard()->nam->get(QNetworkRequest(url));
+
+    connect(reply, SIGNAL(finished()), this, SLOT(actDownloadFinished()));
+    connect(reply, SIGNAL(downloadProgress(qint64, qint64)), this, SLOT(actDownloadProgress(qint64, qint64)));
+}
+
+void SimpleDownloadFilePage::actDownloadProgress(qint64 received, qint64 total)
+{
+    if (total > 0) {
+        progressBar->setMaximum(static_cast<int>(total));
+        progressBar->setValue(static_cast<int>(received));
+    }
+    progressLabel->setText(tr("Downloading (%1MB)").arg((int)received / (1024 * 1024)));
+}
+
+void SimpleDownloadFilePage::actDownloadFinished()
+{
+    // check for a reply
+    auto *reply = dynamic_cast<QNetworkReply *>(sender());
+    QNetworkReply::NetworkError errorCode = reply->error();
+    if (errorCode != QNetworkReply::NoError) {
+        QMessageBox::critical(this, tr("Error"), tr("Network error: %1.").arg(reply->errorString()));
+        wizard()->enableButtons();
+        reply->deleteLater();
+        return;
+    }
+
+    int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    if (statusCode == 301 || statusCode == 302) {
+        QUrl redirectUrl = reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
+        qDebug() << "following redirect url:" << redirectUrl.toString();
+        downloadFile(redirectUrl);
+        reply->deleteLater();
+        return;
+    }
+
+    // save downlaoded file url, but only if the user customized it and download was successfull
+    if (urlLineEdit->text() != getDefaultUrl()) {
+        wizard()->settings->setValue(getCustomUrlSettingsKey(), urlLineEdit->text());
+    } else {
+        wizard()->settings->remove(getCustomUrlSettingsKey());
+    }
+
+    downloadData = reply->readAll();
+    reply->deleteLater();
+
+    wizard()->enableButtons();
+    progressLabel->hide();
+    progressBar->hide();
+
+    wizard()->next();
+}
+
+bool SimpleDownloadFilePage::saveToFile()
+{
+    bool ok = false;
+    QString defaultPath = getDefaultSavePath();
+    QString windowName = getWindowTitle();
+    QString fileType = getFileType();
+
+    do {
+        QString fileName;
+        if (defaultPathCheckBox->isChecked()) {
+            fileName = QFileDialog::getSaveFileName(this, windowName, defaultPath, fileType);
+        } else {
+            fileName = defaultPath;
+        }
+
+        if (fileName.isEmpty()) {
+            return false;
+        }
+
+        QFileInfo fi(fileName);
+        QDir fileDir(fi.path());
+        if (!fileDir.exists() && !fileDir.mkpath(fileDir.absolutePath())) {
+            return false;
+        }
+
+        if (internalSaveToFile(fileName)) {
+            ok = true;
+        } else {
+            QMessageBox::critical(this, tr("Error"), tr("The file could not be saved to %1").arg(fileName));
+        }
+    } while (!ok);
+
+    // clean saved downloadData
+    downloadData = QByteArray();
+    return true;
+}
+
+bool SimpleDownloadFilePage::internalSaveToFile(const QString &fileName)
+{
+    QFile file(fileName);
+    if (!file.open(QIODevice::WriteOnly)) {
+        qDebug() << "File open (w) failed for" << fileName;
+        return false;
+    }
+
+    if (file.write(downloadData) == -1) {
+        qDebug() << "File write (w) failed for" << fileName;
+        return false;
+    }
+
+    file.close();
+    return true;
+}

--- a/oracle/src/pagetemplates.cpp
+++ b/oracle/src/pagetemplates.cpp
@@ -10,8 +10,8 @@
 #include <QPushButton>
 #include <QtGui>
 
-#include "pagetemplates.h"
 #include "oraclewizard.h"
+#include "pagetemplates.h"
 
 SimpleDownloadFilePage::SimpleDownloadFilePage(QWidget *parent) : OracleWizardPage(parent)
 {
@@ -59,7 +59,7 @@ bool SimpleDownloadFilePage::validatePage()
 {
     // if data has already been downloaded, pass directly to the "save" step
     if (!downloadData.isEmpty()) {
-        if(saveToFile()) {
+        if (saveToFile()) {
             return true;
         } else {
             wizard()->enableButtons();

--- a/oracle/src/pagetemplates.h
+++ b/oracle/src/pagetemplates.h
@@ -28,6 +28,7 @@ class SimpleDownloadFilePage : public OracleWizardPage
     Q_OBJECT
 public:
     explicit SimpleDownloadFilePage(QWidget *parent = nullptr);
+
 protected:
     void initializePage() override;
     bool validatePage() override;

--- a/oracle/src/pagetemplates.h
+++ b/oracle/src/pagetemplates.h
@@ -1,0 +1,61 @@
+#ifndef PAGETEMPLATES_H
+#define PAGETEMPLATES_H
+
+#include <QWizardPage>
+
+class OracleWizard;
+class QCheckBox;
+class QLabel;
+class QLineEdit;
+class QProgressBar;
+
+class OracleWizardPage : public QWizardPage
+{
+    Q_OBJECT
+public:
+    explicit OracleWizardPage(QWidget *parent = nullptr) : QWizardPage(parent){};
+    virtual void retranslateUi() = 0;
+
+protected:
+    inline OracleWizard *wizard()
+    {
+        return (OracleWizard *)QWizardPage::wizard();
+    };
+};
+
+class SimpleDownloadFilePage : public OracleWizardPage
+{
+    Q_OBJECT
+public:
+    explicit SimpleDownloadFilePage(QWidget *parent = nullptr);
+protected:
+    void initializePage() override;
+    bool validatePage() override;
+    void downloadFile(QUrl url);
+    virtual QString getDefaultUrl() = 0;
+    virtual QString getCustomUrlSettingsKey() = 0;
+    virtual QString getDefaultSavePath() = 0;
+    virtual QString getWindowTitle() = 0;
+    virtual QString getFileType() = 0;
+    bool saveToFile();
+    bool internalSaveToFile(const QString &fileName);
+
+protected:
+    QByteArray downloadData;
+    QLabel *urlLabel;
+    QLabel *pathLabel;
+    QLineEdit *urlLineEdit;
+    QPushButton *urlButton;
+    QLabel *progressLabel;
+    QProgressBar *progressBar;
+    QCheckBox *defaultPathCheckBox;
+
+signals:
+    void parsedDataReady();
+private slots:
+    void actRestoreDefaultUrl();
+    void actDownloadProgress(qint64 received, qint64 total);
+    void actDownloadFinished();
+};
+
+#endif // PAGETEMPLATES_H


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3738

## Short roundup of the initial problem
See #3738

## What will change with this Pull Request?
The startup routine has been simplified, removing a lot of blocking steps when running a fresh installed or a just updated installation:

 * detect if this is a fresh installation or an update, and show a different welcome dialog informing the user to run oracle; eg. for new install:
![first](https://user-images.githubusercontent.com/1631111/58750087-1be92f00-848e-11e9-930b-31716b0a3de1.png)
 * don't show tips window on first run: having a both a modal welcome dialog and a the tip window coming up at the same time is just too confusing; tip window will only show up on subsequent runs;
 * Tip window: ensure it's raised on top of the main window;
 * remove the "Update completed successfully. Cockatrice will now reload the card database." popup dialog; it's just redundant and you can't avoid it;
 * Remove the "The sets database has been saved successfully." popup when saving the sets dialog: it's redundant to inform the user of something that's expected to happen when confirming a dialog;
 * Remove the "The card database has been saved successfully to ..." popups in oracle. Instead, show the default path on the wizard page. Also, invert the "choose custom path" checkbox logic to make it more user-friendly:
![Schermata 2019-06-01 alle 16 42 13](https://user-images.githubusercontent.com/1631111/58750083-0ffd6d00-848e-11e9-80f5-67a334b6f9f8.png)

I made some tests on fresh install / update / subsquent installs, but I'd really like some external testing on this. Thank you