### PR TITLE
fix aftermath cards

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -295,7 +295,7 @@ int OracleImporter::importCardsFromSet(CardSetPtr currentSet, const QList<QVaria
         }
 
         // split cards are considered a single card, enqueue for later merging
-        if (layout == "split") {
+        if (layout == "split" || layout == "aftermath") {
             // get the position of this card part
             int index = additionalNames.indexOf(name);
             // construct full card name


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3736

## Short roundup of the initial problem
MTGJSON (re?)introduced a special layout option for `aftermath` in [v4.4.0](https://mtgjson.com/changelog/#_4-4-0-2019-05-28)

Oracle didn't knew about this layout. Before, aftermath cards had the layout split and got merged into one card correctly.

## What will change with this Pull Request?
- Oracle recognizes the single sides and merges them
- Aftermath cards are handled again just like split cards and are displayed as single card (`Dusk // Dawn`)