### PR TITLE
Fix position for newly added cards in a view zone; fix #3735

### DIFF
--- a/cockatrice/src/zoneviewzone.cpp
+++ b/cockatrice/src/zoneviewzone.cpp
@@ -191,6 +191,7 @@ void ZoneViewZone::addCardImpl(CardItem *card, int x, int /*y*/)
     cards.insert(x, card);
     card->setParentItem(this);
     card->update();
+    reorganizeCards();
 }
 
 void ZoneViewZone::handleDropEvent(const QList<CardDragItem *> &dragItems,


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3735

## Short roundup of the initial problem
When opening a zone view (eg. view hand), cards are arranged by type.
If a new card gets added, it's not positioned correcltly.

## What will change with this Pull Request?
Cards are rearranges when a new card gets added.
