### PR TITLE
Oracle: correctly reload source file when needed; fix #2786

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -389,8 +389,6 @@ void OracleImporter::sortAndReduceColors(QString &colors)
 
 int OracleImporter::startImport()
 {
-    clear();
-
     int setCards = 0, setIndex = 0;
     // add an empty set for tokens
     CardSetPtr tokenSet = CardSet::newInstance(TOKENS_SETNAME, tr("Dummy set containing tokens"), "Tokens");
@@ -419,4 +417,10 @@ bool OracleImporter::saveToFile(const QString &fileName)
 {
     CockatriceXml4Parser parser;
     return parser.saveToFile(sets, cards, fileName);
+}
+
+void OracleImporter::clear()
+{
+    CardDatabase::clear();
+    allSets.clear();
 }

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -120,6 +120,7 @@ public:
     {
         return dataDir;
     }
+    void clear();
 
 protected:
     inline QString getStringPropertyFromMap(QVariantMap card, QString propertyName);

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -530,6 +530,7 @@ SaveSetsPage::SaveSetsPage(QWidget *parent) : OracleWizardPage(parent)
 
 void SaveSetsPage::cleanupPage()
 {
+    wizard()->importer->clear();
     disconnect(wizard()->importer, SIGNAL(setIndexChanged(int, int, const QString &)), nullptr, nullptr);
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2786

## Short roundup of the initial problem
See #2786

## What will change with this Pull Request?
Now if you press "back" at the "save sets" step, the "load sets" step will correctly reload the card source
