### PR TITLE
Fix card database load after update

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -857,6 +857,8 @@ void MainWindow::startupConfigCheck()
                  << "differs, assuming first start after update";
         if (settingsCache->getNotifyAboutNewVersion()) {
             alertForcedOracleRun(VERSION_STRING, true);
+        } else {
+            QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
         }
     } else {
         // previous config from this version found


### PR DESCRIPTION
## Short roundup of the initial problem
#3740 simplified the startup merging the handling for 3 different cases:
 1. first run after cockatrice install
 2. first run after cockatrice update
 3. subsequent runs

In the second case, if the user disabled the "Automatically run Oracle when running a new version of Cockatrice" option, cockatrice would skip to load the card database at startup.

## What will change with this Pull Request?
Fix this case
