### PR TITLE
move brackets out of link tags

### DIFF
--- a/cockatrice/src/dlg_update.cpp
+++ b/cockatrice/src/dlg_update.cpp
@@ -147,8 +147,8 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
             this, tr("Update Available"),
             tr("A new version of Cockatrice is available!") + "<br><br>" + "<b>" + tr("New version") +
                 QString(":</b> %1<br>").arg(release->getName()) + "<b>" + tr("Released") +
-                QString(":</b> %1 <a href=\"%2\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") +
-                ")</a><br><br>" + tr("Do you want to update now?"),
+                QString(":</b> %1 (<a href=\"%2\">").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") +
+                "</a>)<br><br>" + tr("Do you want to update now?"),
             QMessageBox::Yes | QMessageBox::No);
 
         if (reply == QMessageBox::Yes)
@@ -158,8 +158,8 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
             this, tr("Update Available"),
             tr("A new version of Cockatrice is available!") + "<br><br>" + "<b>" + tr("New version") +
                 QString(":</b> %1<br>").arg(release->getName()) + "<b>" + tr("Released") +
-                QString(":</b> %1 <a href=\"%2\">(").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") +
-                ")</a><br><br>" +
+                QString(":</b> %1 (<a href=\"%2\">").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") +
+                "</a>)<br><br>" +
                 tr("Unfortunately there are no download packages available for your operating system. \nYou may have "
                    "to build from source yourself.") +
                 "<br><br>" +


### PR DESCRIPTION
## Short roundup of the initial problem
The brackets used to be part of the link

## What will change with this Pull Request?
- only the `Changelog` keyword is linked and clickable now