### PR TITLE
Message log: handle "shuffle after moving card to deck"; fix #3553

### DIFF
--- a/cockatrice/src/abstractcarddragitem.cpp
+++ b/cockatrice/src/abstractcarddragitem.cpp
@@ -39,7 +39,6 @@ AbstractCardDragItem::AbstractCardDragItem(AbstractCardItem *_item,
 
 AbstractCardDragItem::~AbstractCardDragItem()
 {
-    qDebug("CardDragItem destructor");
     for (int i = 0; i < childDrags.size(); i++)
         delete childDrags[i];
 }

--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -52,7 +52,9 @@ void AbstractCardItem::cardInfoUpdated()
         info = CardInfo::newInstance(name, "", true, QVariantHash(), QList<CardRelation *>(), QList<CardRelation *>(),
                                      CardInfoPerSetMap(), false, -1, false);
     }
-    connect(info.data(), SIGNAL(pixmapUpdated()), this, SLOT(pixmapUpdated()));
+    if(info.data()) {
+        connect(info.data(), SIGNAL(pixmapUpdated()), this, SLOT(pixmapUpdated()));
+    }
 
     cacheBgColor();
     update();

--- a/cockatrice/src/messagelogwidget.h
+++ b/cockatrice/src/messagelogwidget.h
@@ -21,6 +21,14 @@ struct LogMoveCard
     int newX;
 };
 
+struct LogShuffle
+{
+    Player *player;
+    CardZone *zone;
+    int start;
+    int end;
+};
+
 class MessageLogWidget : public ChatView
 {
     Q_OBJECT
@@ -29,15 +37,16 @@ private:
     {
         MessageContext_None,
         MessageContext_MoveCard,
-        MessageContext_Mulligan
+        MessageContext_Mulligan,
+        MessageContext_ShuffleAfterMove,
     };
 
     int mulliganNumber;
     Player *mulliganPlayer;
     MessageContext currentContext;
     QList<LogMoveCard> moveCardQueue;
+    QList<LogShuffle> shuffleQueue;
     QMap<CardItem *, bool> moveCardTapped;
-    QList<QString> moveCardExtras;
     QString messagePrefix, messageSuffix;
 
     const QString tableConstant() const;
@@ -70,6 +79,7 @@ public slots:
     void logDeckSelect(Player *player, QString deckHash, int sideboardSize);
     void logDestroyCard(Player *player, QString cardName);
     void logDoMoveCard(LogMoveCard &lmc);
+    void logDoShuffle(LogShuffle &ls);
     void logDrawCards(Player *player, int number);
     void logDumpZone(Player *player, CardZone *zone, int numberCards);
     void logFlipCard(Player *player, QString cardName, bool faceDown);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3553

## Short roundup of the initial problem
The messagelogwidget contains a workaround that forces card moves to be always logged last.
This causes problems with logging of command that both moves a card and make some other actions (eg #3549, move+shuffle) since events are logged in the wrong order.

## What will change with this Pull Request?
This is one attempt of fixing the problem by adding yet another workaround for this specific case.
Also, 2 minor fixes are included to avoid warning spam in the log.


