### PR TITLE
travis: use identical osx environments again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ matrix:
   - name: macOS (Debug)
     if: tag IS NOT present
     os: osx
-    osx_image: xcode10.1
+    osx_image: xcode9.2
     cache: ccache
     addons:
       homebrew:
@@ -96,6 +96,7 @@ matrix:
         - protobuf
         - qt
         - xz
+        update: true
     script: bash ./.ci/travis-compile.sh --server --install --debug
 
   - name: macOS (Release)


### PR DESCRIPTION
## Short roundup of the initial problem
Travis wasn't installing qt properly anymore

## What will change with this Pull Request?
- update homebrew again
- use same osx environment for `Debug` and `Release` again