### PR TITLE
Enable tear-off on menus.

### DIFF
--- a/cockatrice/src/abstractcounter.cpp
+++ b/cockatrice/src/abstractcounter.cpp
@@ -31,6 +31,7 @@ AbstractCounter::AbstractCounter(Player *_player,
 
     if (player->getLocalOrJudge()) {
         menu = new QMenu(name);
+        menu->setTearOffEnabled(true);
         aSet = new QAction(this);
         connect(aSet, SIGNAL(triggered()), this, SLOT(setCounter()));
         menu->addAction(aSet);

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -243,9 +243,11 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
 
     playerMenu = new QMenu(QString());
     table->setMenu(playerMenu);
+    playerMenu->setTearOffEnabled(true);
 
     if (local || judge) {
         handMenu = playerMenu->addMenu(QString());
+        handMenu->setTearOffEnabled(true);
         handMenu->addAction(aViewHand);
         playerLists.append(mRevealHand = handMenu->addMenu(QString()));
         playerLists.append(mRevealRandomHandCard = handMenu->addMenu(QString()));
@@ -253,6 +255,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
         handMenu->addAction(aMulligan);
         handMenu->addSeparator();
         moveHandMenu = handMenu->addMenu(QString());
+        moveHandMenu->setTearOffEnabled(true);
         moveHandMenu->addAction(aMoveHandToTopLibrary);
         moveHandMenu->addAction(aMoveHandToBottomLibrary);
         moveHandMenu->addSeparator();
@@ -262,6 +265,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
         hand->setMenu(handMenu);
 
         libraryMenu = playerMenu->addMenu(QString());
+        libraryMenu->setTearOffEnabled(true);
         libraryMenu->addAction(aDrawCard);
         libraryMenu->addAction(aDrawCards);
         libraryMenu->addAction(aUndoDraw);
@@ -292,6 +296,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
     }
 
     graveMenu = playerMenu->addMenu(QString());
+    graveMenu->setTearOffEnabled(true);
     graveMenu->addAction(aViewGraveyard);
 
     if (local || judge) {
@@ -305,12 +310,14 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
     grave->setMenu(graveMenu, aViewGraveyard);
 
     rfgMenu = playerMenu->addMenu(QString());
+    rfgMenu->setTearOffEnabled(true);
     rfgMenu->addAction(aViewRfg);
     rfg->setMenu(rfgMenu, aViewRfg);
 
     if (local || judge) {
         graveMenu->addSeparator();
         moveGraveMenu = graveMenu->addMenu(QString());
+        moveGraveMenu->setTearOffEnabled(true);
         moveGraveMenu->addAction(aMoveGraveToTopLibrary);
         moveGraveMenu->addAction(aMoveGraveToBottomLibrary);
         moveGraveMenu->addSeparator();
@@ -320,6 +327,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
 
         rfgMenu->addSeparator();
         moveRfgMenu = rfgMenu->addMenu(QString());
+        moveRfgMenu->setTearOffEnabled(true);
         moveRfgMenu->addAction(aMoveRfgToTopLibrary);
         moveRfgMenu->addAction(aMoveRfgToBottomLibrary);
         moveRfgMenu->addSeparator();

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -1382,6 +1382,8 @@ void TabGame::createMenuItems()
     aCloseReplay = nullptr;
 
     phasesMenu = new QMenu(this);
+    phasesMenu->setTearOffEnabled(true);
+
     for (int i = 0; i < phasesToolbar->phaseCount(); ++i) {
         QAction *temp = new QAction(QString(), this);
         connect(temp, SIGNAL(triggered()), this, SLOT(actPhaseAction()));


### PR DESCRIPTION
## Short roundup of the initial problem
- Menus are hard to use on tablets, so let users tear them off.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![image](https://user-images.githubusercontent.com/671513/60481396-fb092a80-9c41-11e9-827e-3e8ebebb68a8.png)
