### PR TITLE
travis: separate lint build

### DIFF
--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -54,7 +54,7 @@ done
 
 # Check formatting using clang-format
 if [[ $CHECK_FORMAT ]]; then
-  bash ./.ci/travis-lint.sh
+  source ./.ci/travis-lint.sh
 fi
 
 set -e

--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -54,7 +54,7 @@ done
 
 # Check formatting using clang-format
 if [[ $CHECK_FORMAT ]]; then
-  sh ./.ci/travis-lint.sh
+  bash ./.ci/travis-lint.sh
 fi
 
 set -e

--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -54,7 +54,7 @@ done
 
 # Check formatting using clang-format
 if [[ $CHECK_FORMAT ]]; then
-  sh ./ci/travis-lint.sh
+  sh ./.ci/travis-lint.sh
 fi
 
 set -e

--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -54,43 +54,7 @@ done
 
 # Check formatting using clang-format
 if [[ $CHECK_FORMAT ]]; then
-  echo "Checking your code using clang-format..."
-  diff="$(./clangify.sh --diff --cf-version)"
-  err=$?
-  case $err in
-    1)
-      cat <<EOM
-***********************************************************
-***                                                     ***
-***    Your code does not comply with our styleguide.   ***
-***                                                     ***
-***  Please correct it or run the "clangify.sh" script. ***
-***  Then commit and push those changes to this branch. ***
-***   Check our CONTRIBUTING.md file for more details.  ***
-***                                                     ***
-***                     Thank you ♥                     ***
-***                                                     ***
-***********************************************************
-
-Used clang-format version:
-${diff%%
-*}
-
-The following changes should be made:
-${diff#*
-}
-
-Exiting...
-EOM
-      exit 2
-      ;;
-    0)
-      echo "Thank you for complying with our code standards."
-      ;;
-    *)
-      echo "Something went wrong in our formatting checks: clangify returned $err" >&2
-      ;;
-  esac
+  sh ./ci/travis-lint.sh
 fi
 
 set -e

--- a/.ci/travis-lint.sh
+++ b/.ci/travis-lint.sh
@@ -1,0 +1,36 @@
+# Check formatting using clang-format
+echo "Checking your code using clang-format..."
+diff="$(./clangify.sh --diff --cf-version)"
+err=$?
+case $err in
+  1)
+    cat <<EOM
+***********************************************************
+***                                                     ***
+***    Your code does not comply with our styleguide.   ***
+***                                                     ***
+***  Please correct it or run the "clangify.sh" script. ***
+***  Then commit and push those changes to this branch. ***
+***   Check our CONTRIBUTING.md file for more details.  ***
+***                                                     ***
+***                     Thank you ♥                     ***
+***                                                     ***
+***********************************************************
+Used clang-format version:
+${diff%%
+*}
+The following changes should be made:
+${diff#*
+}
+Exiting...
+EOM
+      exit 2
+      ;;
+    0)
+      echo "Thank you for complying with our code standards."
+      ;;
+    *)
+      echo "Something went wrong in our formatting checks: clangify returned $err" >&2
+      ;;
+  esac
+fi

--- a/.ci/travis-lint.sh
+++ b/.ci/travis-lint.sh
@@ -35,4 +35,3 @@ EOM
       echo "Something went wrong in our formatting checks: clangify returned $err" >&2
       ;;
   esac
-fi

--- a/.ci/travis-lint.sh
+++ b/.ci/travis-lint.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Check formatting using clang-format
 echo "Checking your code using clang-format..."
 diff="$(./clangify.sh --diff --cf-version)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,31 @@ matrix:
     script: bash ./.ci/travis-lint.sh
 
 
-  #Ubuntu Bionic (on docker)
+  #Ubuntu Xenial (Debug only)
+  - name: Ubuntu Xenial (Debug)
+    if: tag IS NOT present
+    os: linux
+    dist: xenial
+    group: stable
+    cache: ccache
+    addons:
+      apt:
+        packages:
+        - libprotobuf-dev
+        - protobuf-compiler
+        - liblzma-dev
+        - qt5-default
+        - qttools5-dev
+        - qttools5-dev-tools
+        - qtmultimedia5-dev
+        - libqt5multimedia5-plugins
+        - libqt5svg5-dev
+        - libqt5sql5-mysql
+        - libqt5websockets5-dev
+script: bash ./.ci/travis-compile.sh --format --server --test --debug
+
+
+  #Ubuntu Bionic (on Docker)
   - name: Ubuntu Bionic (Debug)
     if: tag IS NOT present
     services: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,27 +16,12 @@ matrix:
 
 
   #Ubuntu Xenial (Debug only)
-  - name: Ubuntu Xenial (Debug)
+  - name: Ubuntu Xenial (--format argument test)
     if: tag IS NOT present
     os: linux
     dist: xenial
     group: stable
-    cache: ccache
-    addons:
-      apt:
-        packages:
-        - libprotobuf-dev
-        - protobuf-compiler
-        - liblzma-dev
-        - qt5-default
-        - qttools5-dev
-        - qttools5-dev-tools
-        - qtmultimedia5-dev
-        - libqt5multimedia5-plugins
-        - libqt5svg5-dev
-        - libqt5sql5-mysql
-        - libqt5websockets5-dev
-    script: bash ./.ci/travis-compile.sh --format --server --test --debug
+    script: bash ./.ci/travis-compile.sh --format
 
 
   #Ubuntu Bionic (on Docker)
@@ -51,7 +36,7 @@ matrix:
     script: docker run --mount "type=bind,source=$(pwd),target=/src" -w="/src"
           --mount "type=bind,source=$HOME/$NAME/.ccache,target=/.ccache" -e "CCACHE_DIR=/.ccache"
           "cockatrice_${NAME,,}"
-          bash .ci/travis-compile.sh --server --debug
+          bash .ci/travis-compile.sh --server --test --debug
 
   - name: Ubuntu Bionic (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,28 +7,13 @@ git:
 matrix:
   include:
 
-  #Ubuntu Xenial (Debug only)
-  - name: Ubuntu Xenial (Debug)
+  #Static Code Analysis
+  - name: Check code style (Linting)
     if: tag IS NOT present
     os: linux
     dist: xenial
     group: stable
-    cache: ccache
-    addons:
-      apt:
-        packages:
-        - libprotobuf-dev
-        - protobuf-compiler
-        - liblzma-dev
-        - qt5-default
-        - qttools5-dev
-        - qttools5-dev-tools
-        - qtmultimedia5-dev
-        - libqt5multimedia5-plugins
-        - libqt5svg5-dev
-        - libqt5sql5-mysql
-        - libqt5websockets5-dev
-    script: bash ./.ci/travis-compile.sh --format --server --test --debug
+    script: bash ./.ci/travis-lint.sh
 
 
   #Ubuntu Bionic (on docker)

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,6 @@ matrix:
     script: bash ./.ci/travis-lint.sh
 
 
-  #Ubuntu Xenial (Debug only)
-  - name: Ubuntu Xenial (--format argument test)
-    if: tag IS NOT present
-    os: linux
-    dist: xenial
-    group: stable
-    script: bash ./.ci/travis-compile.sh --format
-
-
   #Ubuntu Bionic (on Docker)
   - name: Ubuntu Bionic (Debug)
     if: tag IS NOT present

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
 
 
   #Ubuntu Bionic (on Docker)
-  - name: Ubuntu Bionic (Debug)
+  - name: Ubuntu Bionic (Debug + Tests)
     if: tag IS NOT present
     services: docker
     env: NAME=UbuntuBionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,9 @@ matrix:
   include:
 
   #Static Code Analysis
-  - name: Check code style (Linting)
+  - name: Check code style / Linting
     if: tag IS NOT present
     os: linux
-    dist: xenial
     group: stable
     script: bash ./.ci/travis-lint.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
         - libqt5svg5-dev
         - libqt5sql5-mysql
         - libqt5websockets5-dev
-script: bash ./.ci/travis-compile.sh --format --server --test --debug
+    script: bash ./.ci/travis-compile.sh --format --server --test --debug
 
 
   #Ubuntu Bionic (on Docker)


### PR DESCRIPTION
## Short roundup of the initial problem
Old Xenial build was only used to run our tests.
Lint was combined with that same build and reporting back took ~5min.

## What will change with this Pull Request?
- Have separate lint build, reports back in 15s
I created a separate lint script for that purpose. The `--format` argument can still be passed to the compile script which will execute the new script then.
- Move `--test` to the Bionic build
- Remove the old (and slower) Xenial build, we only need Bionic

 ---

Thanks for your help @ebbit1q!