### PR TITLE
Fix updating last ran client version in config file; fix #3783

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -851,6 +851,7 @@ void MainWindow::startupConfigCheck()
         // no config found, 99% new clean install
         qDebug() << "Startup: old client version empty, assuming first start after clean install";
         alertForcedOracleRun(VERSION_STRING, false);
+        settingsCache->setClientVersion(VERSION_STRING);
     } else if (settingsCache->getClientVersion() != VERSION_STRING) {
         // config found, from another (presumably older) version
         qDebug() << "Startup: old client version" << settingsCache->getClientVersion()
@@ -860,6 +861,7 @@ void MainWindow::startupConfigCheck()
         } else {
             QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
         }
+        settingsCache->setClientVersion(VERSION_STRING);
     } else {
         // previous config from this version found
         qDebug() << "Startup: found config with current version";
@@ -876,7 +878,6 @@ void MainWindow::startupConfigCheck()
 
 void MainWindow::alertForcedOracleRun(const QString &version, bool isUpdate)
 {
-    settingsCache->setClientVersion(version);
     if (isUpdate) {
         QMessageBox::information(this, tr("New Version"),
                                  tr("Congratulations on updating to Cockatrice %1!\n"


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3783

## Short roundup of the initial problem
See #3783

## What will change with this Pull Request?
The client version number will be updated correctly in the config file, even if oracle is not run on startup.
