### PR TITLE
Close all player-associated zoneviews when he quits; fix #3799

### DIFF
--- a/cockatrice/src/gamescene.cpp
+++ b/cockatrice/src/gamescene.cpp
@@ -46,6 +46,11 @@ void GameScene::addPlayer(Player *player)
 void GameScene::removePlayer(Player *player)
 {
     qDebug() << "GameScene::removePlayer name=" << player->getName();
+    for(ZoneViewWidget * zone : zoneViews) {
+        if(zone->getPlayer() == player) {
+            zone->close();
+        }
+    }
     players.removeAt(players.indexOf(player));
     removeItem(player);
     rearrange();

--- a/cockatrice/src/zoneviewwidget.h
+++ b/cockatrice/src/zoneviewwidget.h
@@ -58,6 +58,10 @@ public:
     {
         return zone;
     }
+    Player * getPlayer() const
+    {
+        return player;
+    }
     void retranslateUi();
 
 protected:


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3799 

## Short roundup of the initial problem
When a player quits, all the related resources gets removed from memory (cards, zones, etc..).
If a zoneview (eg. hand view of that player) is open, it starts to refer to the already deleted player.
Once you try to close the view, it crashes.

## What will change with this Pull Request?
- All zoneviews associated to a specific player are closed automatically when the player is deleted from the game
