### PR TITLE
Deal with recent Qt methods deprecation

### DIFF
--- a/cockatrice/src/abstractgraphicsitem.cpp
+++ b/cockatrice/src/abstractgraphicsitem.cpp
@@ -16,7 +16,12 @@ void AbstractGraphicsItem::paintNumberEllipse(int number,
     font.setWeight(QFont::Bold);
 
     QFontMetrics fm(font);
-    double w = fm.width(numStr) * 1.3;
+    double w = 1.3 *
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+               fm.horizontalAdvance(numStr);
+#else
+               fm.width(numStr);
+#endif
     double h = fm.height() * 1.3;
     if (w < h)
         w = h;

--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -11,6 +11,7 @@
 #include <QDir>
 #include <QFile>
 #include <QMessageBox>
+#include <algorithm>
 #include <utility>
 
 const char *CardDatabase::TOKENS_SETNAME = "TK";
@@ -105,7 +106,7 @@ public:
 
 void SetList::sortByKey()
 {
-    qSort(begin(), end(), KeyCompareFunctor());
+    std::sort(begin(), end(), KeyCompareFunctor());
 }
 
 int SetList::getEnabledSetsNum()

--- a/cockatrice/src/cardinfowidget.cpp
+++ b/cockatrice/src/cardinfowidget.cpp
@@ -5,7 +5,12 @@
 #include "cardinfowidget.h"
 #include "carditem.h"
 #include "main.h"
+#include <QApplication>
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+#include <QScreen>
+#else
 #include <QDesktopWidget>
+#endif
 #include <QVBoxLayout>
 
 CardInfoWidget::CardInfoWidget(const QString &cardName, QWidget *parent, Qt::WindowFlags flags)
@@ -27,8 +32,13 @@ CardInfoWidget::CardInfoWidget(const QString &cardName, QWidget *parent, Qt::Win
     setLayout(layout);
 
     setFrameStyle(QFrame::Panel | QFrame::Raised);
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+    int pixmapHeight = qApp->primaryScreen()->geometry().height() / 3;
+#else
     QDesktopWidget desktopWidget;
     int pixmapHeight = desktopWidget.screenGeometry().height() / 3;
+#endif
     int pixmapWidth = static_cast<int>(pixmapHeight / aspectRatio);
     pic->setFixedWidth(pixmapWidth);
     pic->setFixedHeight(pixmapHeight);

--- a/cockatrice/src/cardlist.cpp
+++ b/cockatrice/src/cardlist.cpp
@@ -2,6 +2,8 @@
 #include "carddatabase.h"
 #include "carditem.h"
 
+#include <algorithm>
+
 CardList::CardList(bool _contentsKnown) : QList<CardItem *>(), contentsKnown(_contentsKnown)
 {
 }
@@ -56,5 +58,5 @@ public:
 void CardList::sort(int flags)
 {
     compareFunctor cf(flags);
-    qSort(begin(), end(), cf);
+    std::sort(begin(), end(), cf);
 }

--- a/cockatrice/src/deckview.cpp
+++ b/cockatrice/src/deckview.cpp
@@ -7,6 +7,7 @@
 #include <QApplication>
 #include <QGraphicsSceneMouseEvent>
 #include <QMouseEvent>
+#include <algorithm>
 #include <math.h>
 
 DeckViewCardDragItem::DeckViewCardDragItem(DeckViewCard *_item,
@@ -283,7 +284,7 @@ void DeckViewCardContainer::rearrangeItems(const QList<QPair<int, int>> &rowsAnd
 
         QList<QString> cardTypeList = cardsByType.uniqueKeys();
         QList<DeckViewCard *> row = cardsByType.values(cardTypeList[i]);
-        qSort(row.begin(), row.end(), DeckViewCardContainer::sortCardsByName);
+        std::sort(row.begin(), row.end(), DeckViewCardContainer::sortCardsByName);
         for (int j = 0; j < row.size(); ++j) {
             DeckViewCard *card = row[j];
             card->setPos(x + (j % tempCols) * CARD_WIDTH, yUntilNow + (j / tempCols) * CARD_HEIGHT);

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -26,6 +26,7 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QRadioButton>
+#include <QScreen>
 #include <QSlider>
 #include <QSpinBox>
 #include <QStackedWidget>
@@ -1129,7 +1130,12 @@ void ShortcutSettingsPage::retranslateUi()
 
 DlgSettings::DlgSettings(QWidget *parent) : QDialog(parent)
 {
-    QRect rec = QApplication::desktop()->availableGeometry();
+    QRect rec =
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+        qApp->primaryScreen()->availableGeometry();
+#else
+        QRect rec = QApplication::desktop()->availableGeometry();
+#endif
     this->setMinimumSize(rec.width() / 2, rec.height() - 100);
     this->setBaseSize(rec.width(), rec.height());
 

--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -20,6 +20,7 @@
 #include <QSvgRenderer>
 #include <QThread>
 #include <QUrl>
+#include <algorithm>
 #include <utility>
 
 // never cache more than 300 cards at once for a single deck
@@ -36,7 +37,7 @@ PictureToLoad::PictureToLoad(CardInfoPtr _card) : card(std::move(_card))
         if (sortedSets.empty()) {
             sortedSets << CardSet::newInstance("", "", "", QDate());
         }
-        qSort(sortedSets.begin(), sortedSets.end(), SetDownloadPriorityComparator());
+        std::sort(sortedSets.begin(), sortedSets.end(), SetDownloadPriorityComparator());
         // The first time called, nextSet will also populate the Urls for the first set.
         nextSet();
     }

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -26,7 +26,6 @@
 #include <QPainter>
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
-#include <QSignalMapper>
 
 #include "pb/command_attach_card.pb.h"
 #include "pb/command_change_zone_properties.pb.h"
@@ -3128,13 +3127,11 @@ void Player::addRelatedCardView(const CardItem *card, QMenu *cardMenu)
     cardMenu->addSeparator();
     auto viewRelatedCards = new QMenu(tr("View related cards"));
     cardMenu->addMenu(viewRelatedCards);
-    auto *signalMapper = new QSignalMapper(this);
     for (const CardRelation *relatedCard : relatedCards) {
-        QAction *viewCard = viewRelatedCards->addAction(relatedCard->getName());
-        connect(viewCard, SIGNAL(triggered()), signalMapper, SLOT(map()));
-        signalMapper->setMapping(viewCard, relatedCard->getName());
+        QString relatedCardName = relatedCard->getName();
+        QAction *viewCard = viewRelatedCards->addAction(relatedCardName);
+        connect(viewCard, &QAction::triggered, game, [this, relatedCardName] { game->viewCardInfo(relatedCardName); });
     }
-    connect(signalMapper, SIGNAL(mapped(const QString &)), game, SLOT(viewCardInfo(const QString &)));
 }
 
 void Player::addRelatedCardActions(const CardItem *card, QMenu *cardMenu)

--- a/cockatrice/src/playerlistwidget.cpp
+++ b/cockatrice/src/playerlistwidget.cpp
@@ -176,10 +176,10 @@ void PlayerListWidget::setActivePlayer(int playerId)
         QTreeWidgetItem *twi = i.value();
         if (i.key() == playerId) {
             twi->setBackground(4, QColor(150, 255, 150));
-            twi->setTextColor(4, QColor(0, 0, 0));
+            twi->setForeground(4, QColor(0, 0, 0));
         } else {
             twi->setBackground(4, palette().base().color());
-            twi->setTextColor(4, palette().text().color());
+            twi->setForeground(4, palette().text().color());
         }
     }
 }

--- a/cockatrice/src/soundengine.cpp
+++ b/cockatrice/src/soundengine.cpp
@@ -102,7 +102,7 @@ QStringMap &SoundEngine::getAvailableThemes()
 
     // load themes from user profile dir
 
-    dir = settingsCache->getDataPath() + "/sounds";
+    dir.setPath(settingsCache->getDataPath() + "/sounds");
 
     foreach (QString themeName, dir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot, QDir::Name)) {
         if (!availableThemes.contains(themeName))
@@ -110,14 +110,15 @@ QStringMap &SoundEngine::getAvailableThemes()
     }
 
     // load themes from cockatrice system dir
-    dir = qApp->applicationDirPath() +
+    dir.setPath(qApp->applicationDirPath() +
 #ifdef Q_OS_MAC
-          "/../Resources/sounds";
+                "/../Resources/sounds"
 #elif defined(Q_OS_WIN)
-          "/sounds";
+                "/sounds"
 #else // linux
-          "/../share/cockatrice/sounds";
+                "/../share/cockatrice/sounds"
 #endif
+    );
 
     foreach (QString themeName, dir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot, QDir::Name)) {
         if (!availableThemes.contains(themeName))

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -35,7 +35,6 @@
 #include <QProcessEnvironment>
 #include <QPushButton>
 #include <QRegularExpression>
-#include <QSignalMapper>
 #include <QSplitter>
 #include <QTextBrowser>
 #include <QTextEdit>
@@ -471,14 +470,12 @@ void TabDeckEditor::databaseCustomMenu(QPoint point)
     if (relatedCards.isEmpty()) {
         relatedMenu->setDisabled(true);
     } else {
-        auto *signalMapper = new QSignalMapper(this);
         for (const CardRelation *rel : relatedCards) {
-            QAction *relatedCard;
-            relatedCard = relatedMenu->addAction(rel->getName());
-            connect(relatedCard, SIGNAL(triggered()), signalMapper, SLOT(map()));
-            signalMapper->setMapping(relatedCard, rel->getName());
+            QString relatedCardName = rel->getName();
+            QAction *relatedCard = relatedMenu->addAction(relatedCardName);
+            connect(relatedCard, &QAction::triggered, cardInfo,
+                    [this, relatedCardName] { cardInfo->setCard(relatedCardName); });
         }
-        connect(signalMapper, SIGNAL(mapped(const QString &)), cardInfo, SLOT(setCard(const QString &)));
     }
     menu.exec(databaseView->mapToGlobal(point));
 }
@@ -820,7 +817,6 @@ bool TabDeckEditor::actSaveDeckAs()
     QFileDialog dialog(this, tr("Save deck"));
     dialog.setDirectory(settingsCache->getDeckPath());
     dialog.setAcceptMode(QFileDialog::AcceptSave);
-    dialog.setConfirmOverwrite(true);
     dialog.setDefaultSuffix("cod");
     dialog.setNameFilters(DeckLoader::fileNameFilters);
     dialog.selectFile(deckModel->getDeckList()->getName().trimmed() + ".cod");

--- a/cockatrice/src/thememanager.cpp
+++ b/cockatrice/src/thememanager.cpp
@@ -35,7 +35,7 @@ QStringMap &ThemeManager::getAvailableThemes()
     availableThemes.clear();
 
     // load themes from user profile dir
-    dir = settingsCache->getDataPath() + "/themes";
+    dir.setPath(settingsCache->getDataPath() + "/themes");
 
     foreach (QString themeName, dir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot, QDir::Name)) {
         if (!availableThemes.contains(themeName))
@@ -43,14 +43,15 @@ QStringMap &ThemeManager::getAvailableThemes()
     }
 
     // load themes from cockatrice system dir
-    dir = qApp->applicationDirPath() +
+    dir.setPath(qApp->applicationDirPath() +
 #ifdef Q_OS_MAC
-          "/../Resources/themes";
+                "/../Resources/themes"
 #elif defined(Q_OS_WIN)
-          "/themes";
+                "/themes"
 #else // linux
-          "/../share/cockatrice/themes";
+                "/../share/cockatrice/themes"
 #endif
+    );
 
     foreach (QString themeName, dir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot, QDir::Name)) {
         if (!availableThemes.contains(themeName))

--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -17,6 +17,8 @@
 #include <QToolBar>
 #include <QTreeView>
 
+#include <algorithm>
+
 #define SORT_RESET -1
 
 WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
@@ -338,7 +340,7 @@ void WndSets::actDisableSome()
 void WndSets::actUp()
 {
     QModelIndexList rows = view->selectionModel()->selectedRows();
-    qSort(rows.begin(), rows.end(), qLess<QModelIndex>());
+    std::sort(rows.begin(), rows.end(), std::less<QModelIndex>());
     QSet<int> newRows;
 
     if (rows.empty())
@@ -360,7 +362,8 @@ void WndSets::actUp()
 void WndSets::actDown()
 {
     QModelIndexList rows = view->selectionModel()->selectedRows();
-    qSort(rows.begin(), rows.end(), qGreater<QModelIndex>());
+    // QModelIndex only implements operator<, so we can't use std::greater
+    std::sort(rows.begin(), rows.end(), [](const QModelIndex &a, const QModelIndex &b) { return !(b < a); });
     QSet<int> newRows;
 
     if (rows.empty())
@@ -382,7 +385,7 @@ void WndSets::actDown()
 void WndSets::actTop()
 {
     QModelIndexList rows = view->selectionModel()->selectedRows();
-    qSort(rows.begin(), rows.end(), qLess<QModelIndex>());
+    std::sort(rows.begin(), rows.end(), std::less<QModelIndex>());
     QSet<int> newRows;
     int newRow = 0;
 
@@ -407,7 +410,8 @@ void WndSets::actTop()
 void WndSets::actBottom()
 {
     QModelIndexList rows = view->selectionModel()->selectedRows();
-    qSort(rows.begin(), rows.end(), qGreater<QModelIndex>());
+    // QModelIndex only implements operator<, so we can't use std::greater
+    std::sort(rows.begin(), rows.end(), [](const QModelIndex &a, const QModelIndex &b) { return !(b < a); });
     QSet<int> newRows;
     int newRow = model->rowCount() - 1;
 

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -4,6 +4,7 @@
 #include <QFile>
 #include <QRegularExpression>
 #include <QTextStream>
+#include <algorithm>
 
 #if QT_VERSION < 0x050600
 // qHash on QRegularExpression was added in 5.6, FIX IT
@@ -316,7 +317,7 @@ QVector<QPair<int, int>> InnerDecklistNode::sort(Qt::SortOrder order)
 
     // Sort temporary list
     compareFunctor cmp(order);
-    qSort(tempList.begin(), tempList.end(), cmp);
+    std::sort(tempList.begin(), tempList.end(), cmp);
 
     // Map old indexes to new indexes and
     // copy temporary list to the current one

--- a/common/server_cardzone.cpp
+++ b/common/server_cardzone.cpp
@@ -59,7 +59,11 @@ void Server_CardZone::shuffle(int start, int end)
 
     for (int i = end; i > start; i--) {
         int j = rng->rand(start, i);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+        cards.swapItemsAt(j, i);
+#else
         cards.swap(j, i);
+#endif
     }
     playersWithWritePermission.clear();
 }

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -82,6 +82,7 @@
 #include "pb/context_undo_draw.pb.h"
 
 #include <QDebug>
+#include <algorithm>
 
 Server_Player::Server_Player(Server_Game *_game,
                              int _playerId,
@@ -407,7 +408,7 @@ Response::ResponseCode Server_Player::moveCard(GameEventStorage &ges,
     // 0 performs no sorting
     // 1 reverses the sorting
     MoveCardCompareFunctor cmp(0);
-    qSort(cardsToMove.begin(), cardsToMove.end(), cmp);
+    std::sort(cardsToMove.begin(), cardsToMove.end(), cmp);
 
     bool secondHalf = false;
     int xIndex = -1;

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -3,6 +3,7 @@
 
 #include <QDebug>
 #include <QtWidgets>
+#include <algorithm>
 #include <climits>
 
 #include "qt-json/json.h"
@@ -70,7 +71,7 @@ bool OracleImporter::readSetsFromByteArray(const QByteArray &data)
         newSetList.append(SetToDownload(shortName, longName, setCards, setType, releaseDate));
     }
 
-    qSort(newSetList);
+    std::sort(newSetList.begin(), newSetList.end());
 
     if (newSetList.isEmpty()) {
         return false;
@@ -337,8 +338,8 @@ int OracleImporter::importCardsFromSet(CardSetPtr currentSet, const QList<QVaria
         // get all parts for this specific card
         QList<SplitCardPart> splitCardParts = splitCards.values(nameSplit);
         // sort them by index (aka position)
-        qSort(splitCardParts.begin(), splitCardParts.end(),
-              [](const SplitCardPart &a, const SplitCardPart &b) -> bool { return a.getIndex() < b.getIndex(); });
+        std::sort(splitCardParts.begin(), splitCardParts.end(),
+                  [](const SplitCardPart &a, const SplitCardPart &b) -> bool { return a.getIndex() < b.getIndex(); });
 
         text = QString("");
         isToken = false;


### PR DESCRIPTION
 * Use std::sort, std::less instead of qSort/qLess
 * Use QFontMetrics::horizontalAdvance instead of ::width
 * Use qApp->primaryScreen() instead of QDesktopWidget
 * use lambas instead of QSignalMapper
 * Use QTreeWidgetItem::setForeground instead of ::setTextColor
 * Use QDir::setPath instead of operator=(QString)
 * Use QList::swapItemsAt instead of ::swap

## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem


## What will change with this Pull Request?
- this
- and this

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
