### PR TITLE
Add a new command to reverse turn order

### DIFF
--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -530,6 +530,13 @@ void MessageLogWidget::logRevealCards(Player *player,
     }
 }
 
+void MessageLogWidget::logReverseTurn(Player *player, bool reversed)
+{
+    appendHtmlServerMessage(tr("%1 reversed turn order, now it's %2.")
+                                .arg(sanitizeHtml(player->getName()))
+                                .arg(reversed ? tr("reversed") : tr("normal")));
+}
+
 void MessageLogWidget::logRollDie(Player *player, int sides, int roll)
 {
     if (sides == 2) {

--- a/cockatrice/src/messagelogwidget.h
+++ b/cockatrice/src/messagelogwidget.h
@@ -77,6 +77,7 @@ public slots:
                         Player *otherPlayer,
                         bool faceDown,
                         int amount);
+    void logReverseTurn(Player *player, bool reversed);
     void logRollDie(Player *player, int sides, int roll);
     void logSay(Player *player, QString message);
     void logSetActivePhase(int phase);

--- a/cockatrice/src/tab_game.h
+++ b/cockatrice/src/tab_game.h
@@ -45,6 +45,7 @@ class Event_SetActivePhase;
 class Event_Ping;
 class Event_GameSay;
 class Event_Kicked;
+class Event_ReverseTurn;
 class Player;
 class CardZone;
 class AbstractCardItem;
@@ -165,7 +166,7 @@ private:
     QMenu *gameMenu, *phasesMenu, *viewMenu, *cardInfoDockMenu, *messageLayoutDockMenu, *playerListDockMenu,
         *replayDockMenu;
     QAction *aGameInfo, *aConcede, *aLeaveGame, *aCloseReplay, *aNextPhase, *aNextPhaseAction, *aNextTurn,
-        *aRemoveLocalArrows, *aRotateViewCW, *aRotateViewCCW, *aResetLayout, *aResetReplayLayout;
+        *aReverseTurn, *aRemoveLocalArrows, *aRotateViewCW, *aRotateViewCCW, *aResetLayout, *aResetReplayLayout;
     QAction *aCardInfoDockVisible, *aCardInfoDockFloating, *aMessageLayoutDockVisible, *aMessageLayoutDockFloating,
         *aPlayerListDockVisible, *aPlayerListDockFloating, *aReplayDockVisible, *aReplayDockFloating;
     QList<QAction *> phaseActions;
@@ -193,6 +194,7 @@ private:
     void setActivePhase(int phase);
     void eventSetActivePhase(const Event_SetActivePhase &event, int eventPlayerId, const GameEventContext &context);
     void eventPing(const Event_Ping &event, int eventPlayerId, const GameEventContext &context);
+    void eventReverseTurn(const Event_ReverseTurn &event, int eventPlayerId, const GameEventContext & /*context*/);
     void emitUserEvent();
     void createMenuItems();
     void createReplayMenuItems();
@@ -236,6 +238,7 @@ private slots:
     void actNextPhase();
     void actNextPhaseAction();
     void actNextTurn();
+    void actReverseTurn();
 
     void addMentionTag(QString value);
     void linkCardToChat(QString cardName);

--- a/common/pb/CMakeLists.txt
+++ b/common/pb/CMakeLists.txt
@@ -38,6 +38,7 @@ SET(PROTO_FILES
     command_replay_download.proto
     command_replay_modify_match.proto
     command_reveal_cards.proto
+    command_reverse_turn.proto
     command_roll_die.proto
     command_set_active_phase.proto
     command_set_card_attr.proto
@@ -88,6 +89,7 @@ SET(PROTO_FILES
     event_remove_from_list.proto
     event_replay_added.proto
     event_reveal_cards.proto
+    event_reverse_turn.proto
     event_roll_die.proto
     event_room_say.proto
     event_server_complete_list.proto
@@ -172,7 +174,7 @@ target_link_libraries(cockatrice_protocol ${cockatrice_protocol_LIBS})
 # ubuntu uses an outdated package for protobuf, 3.1.0 is required
 if(${Protobuf_VERSION} VERSION_LESS "3.1.0")
     # remove unused parameter and misleading indentation warnings when compiling to avoid errors
-    set(CMAKE_CXX_FLAGS_DEBUG 
+    set(CMAKE_CXX_FLAGS_DEBUG
         "${CMAKE_CXX_FLAGS_DEBUG} -Wno-unused-parameter -Wno-misleading-indentation")
     message(WARNING "Outdated protobuf version found (${Protobuf_VERSION} < 3.1.0), "
         "disabled warnings to avoid compilation errors.")

--- a/common/pb/command_reverse_turn.proto
+++ b/common/pb/command_reverse_turn.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+import "game_commands.proto";
+message Command_ReverseTurn {
+    extend GameCommand {
+        optional Command_ReverseTurn ext = 1034;
+	}
+}
+

--- a/common/pb/event_reverse_turn.proto
+++ b/common/pb/event_reverse_turn.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+import "game_event.proto";
+
+message Event_ReverseTurn {
+    extend GameEvent {
+        optional Event_ReverseTurn ext = 2021;
+    }
+    optional bool reversed = 1;
+}

--- a/common/pb/game_commands.proto
+++ b/common/pb/game_commands.proto
@@ -35,6 +35,7 @@ message GameCommand {
         CHANGE_ZONE_PROPERTIES = 1031;
         UNCONCEDE = 1032;
         JUDGE = 1033;
+        REVERSE_TURN = 1034;
     }
     extensions 100 to max;
 }

--- a/common/pb/game_event.proto
+++ b/common/pb/game_event.proto
@@ -30,6 +30,7 @@ message GameEvent {
         DUMP_ZONE = 2018;
         STOP_DUMP_ZONE = 2019;
         CHANGE_ZONE_PROPERTIES = 2020;
+        REVERSE_TURN = 2021;
     }
     optional sint32 player_id = 1 [default = -1];
     extensions 100 to max;

--- a/common/server_game.cpp
+++ b/common/server_game.cpp
@@ -66,7 +66,8 @@ Server_Game::Server_Game(const ServerInfo_User &_creatorInfo,
       onlyRegistered(_onlyRegistered), spectatorsAllowed(_spectatorsAllowed),
       spectatorsNeedPassword(_spectatorsNeedPassword), spectatorsCanTalk(_spectatorsCanTalk),
       spectatorsSeeEverything(_spectatorsSeeEverything), inactivityCounter(0), startTimeOfThisGame(0),
-      secondsElapsed(0), firstGameStarted(false), startTime(QDateTime::currentDateTime()), gameMutex(QMutex::Recursive)
+      secondsElapsed(0), firstGameStarted(false), turnOrderReversed(false), startTime(QDateTime::currentDateTime()),
+      gameMutex(QMutex::Recursive)
 {
     currentReplay = new GameReplay;
     currentReplay->set_replay_id(room->getServer()->getDatabaseInterface()->getNextReplayId());
@@ -657,9 +658,17 @@ void Server_Game::nextTurn()
     if (activePlayer != -1)
         listPos = keys.indexOf(activePlayer);
     do {
-        ++listPos;
-        if (listPos == keys.size())
-            listPos = 0;
+        if (turnOrderReversed) {
+            --listPos;
+            if (listPos < 0) {
+                listPos = keys.size() - 1;
+            }
+        } else {
+            ++listPos;
+            if (listPos == keys.size()) {
+                listPos = 0;
+            }
+        }
     } while (players.value(keys[listPos])->getSpectator() || players.value(keys[listPos])->getConceded());
 
     setActivePlayer(keys[listPos]);

--- a/common/server_game.h
+++ b/common/server_game.h
@@ -68,6 +68,7 @@ private:
     int inactivityCounter;
     int startTimeOfThisGame, secondsElapsed;
     bool firstGameStarted;
+    bool turnOrderReversed;
     QDateTime startTime;
     QTimer *pingClock;
     QList<GameReplay *> replayList;
@@ -184,6 +185,10 @@ public:
     int getSecondsElapsed() const
     {
         return secondsElapsed;
+    }
+    bool reverseTurnOrder()
+    {
+        return turnOrderReversed = !turnOrderReversed;
     }
 
     void createGameJoinedEvent(Server_Player *player, ResponseContainer &rc, bool resuming);

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -35,6 +35,7 @@
 #include "pb/command_next_turn.pb.h"
 #include "pb/command_ready_start.pb.h"
 #include "pb/command_reveal_cards.pb.h"
+#include "pb/command_reverse_turn.pb.h"
 #include "pb/command_roll_die.pb.h"
 #include "pb/command_set_active_phase.pb.h"
 #include "pb/command_set_card_attr.pb.h"
@@ -60,6 +61,7 @@
 #include "pb/event_move_card.pb.h"
 #include "pb/event_player_properties_changed.pb.h"
 #include "pb/event_reveal_cards.pb.h"
+#include "pb/event_reverse_turn.pb.h"
 #include "pb/event_roll_die.pb.h"
 #include "pb/event_set_card_attr.pb.h"
 #include "pb/event_set_card_counter.pb.h"
@@ -1991,6 +1993,30 @@ Response::ResponseCode Server_Player::cmdChangeZoneProperties(const Command_Chan
 }
 
 Response::ResponseCode
+Server_Player::cmdReverseTurn(const Command_ReverseTurn &cmd, ResponseContainer & /*rc*/, GameEventStorage &ges)
+{
+    if (spectator) {
+        return Response::RespFunctionNotAllowed;
+    }
+
+    if (!game->getGameStarted()) {
+        return Response::RespGameNotStarted;
+    }
+
+    if (conceded) {
+        return Response::RespContextError;
+    }
+
+    bool reversedTurn = game->reverseTurnOrder();
+
+    Event_ReverseTurn event;
+    event.set_reversed(reversedTurn);
+    ges.enqueueGameEvent(event, playerId);
+
+    return Response::RespOk;
+}
+
+Response::ResponseCode
 Server_Player::processGameCommand(const GameCommand &command, ResponseContainer &rc, GameEventStorage &ges)
 {
     switch ((GameCommand::GameCommandType)getPbExtension(command)) {
@@ -2096,7 +2122,9 @@ Server_Player::processGameCommand(const GameCommand &command, ResponseContainer 
         case GameCommand::JUDGE:
             return cmdJudge(command.GetExtension(Command_Judge::ext), rc, ges);
             break;
-
+        case GameCommand::REVERSE_TURN:
+            return cmdReverseTurn(command.GetExtension(Command_ReverseTurn::ext), rc, ges);
+            break;
         default:
             return Response::RespInvalidCommand;
     }

--- a/common/server_player.h
+++ b/common/server_player.h
@@ -57,6 +57,7 @@ class Command_SetActivePhase;
 class Command_DumpZone;
 class Command_StopDumpZone;
 class Command_RevealCards;
+class Command_ReverseTurn;
 class Command_MoveCard;
 class Command_SetSideboardPlan;
 class Command_DeckSelect;
@@ -227,6 +228,8 @@ public:
     Response::ResponseCode
     cmdStopDumpZone(const Command_StopDumpZone &cmd, ResponseContainer &rc, GameEventStorage &ges);
     Response::ResponseCode cmdRevealCards(const Command_RevealCards &cmd, ResponseContainer &rc, GameEventStorage &ges);
+    Response::ResponseCode
+    cmdReverseTurn(const Command_ReverseTurn &cmd, ResponseContainer & /*rc*/, GameEventStorage &ges);
     Response::ResponseCode
     cmdChangeZoneProperties(const Command_ChangeZoneProperties &cmd, ResponseContainer &rc, GameEventStorage &ges);
 


### PR DESCRIPTION
## Related Ticket(s)
- Related #3795

## Short roundup of the initial problem
The effect of some cards can alter the turn order.
Currently servatrice's turn order id based on the players' ids, so we can't just reorder the players arbitrarily without breaking the id <-> player association (that would cause a lot of problems).

## What will change with this Pull Request?
By now, the most requested feature is just to be able to just reverse turn order, that is implemeted in this PR as a new command / event.

## Screenshots
![Schermata 2019-08-23 alle 12 22 53](https://user-images.githubusercontent.com/1631111/63586245-39b3c500-c5a1-11e9-80e9-76087198a55f.png)
![Schermata 2019-08-23 alle 12 23 15](https://user-images.githubusercontent.com/1631111/63586246-3a4c5b80-c5a1-11e9-81d4-7d705d84bb3b.png)

