### PR TITLE
Update Dockerfile to inc missing lib, not build dbconv, and use ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y\
   git\
   libprotobuf-dev\
   libqt5sql5-mysql\
+  libmysqlclient-dev\
   libqt5websockets5-dev\
   protobuf-compiler\
   qt5-default\
@@ -18,7 +19,7 @@ COPY . /home/servatrice/code/
 WORKDIR /home/servatrice/code
 
 WORKDIR build
-RUN cmake .. -DWITH_SERVER=1 -DWITH_CLIENT=0 -DWITH_ORACLE=0 &&\
+RUN cmake .. -DWITH_SERVER=1 -DWITH_CLIENT=0 -DWITH_ORACLE=0 -DWITH_DBCONVERTER=0 &&\
   make &&\
   make install
 
@@ -26,4 +27,5 @@ WORKDIR /home/servatrice
 
 EXPOSE 4747
 
-CMD [ "servatrice", "--log-to-console" ]
+ENTRYPOINT [ "servatrice", "--log-to-console" ]
+


### PR DESCRIPTION
This commit updates the Dockerfile to do the following:

1. Include `libmysqlclient-dev` so that server will be built with SQL support
2. Not build `dbconverter` target because of compilation errors, and because it is not needed here
3. Swap `CMD` for `ENTRYPOINT` so that args on the command line when running the docker are carried over