### PR TITLE
travis: update os name for mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ matrix:
         - qt
         - xz
         update: true
-    script: bash ./.ci/travis-compile.sh --server --package "$TRAVIS_OS_NAME" --release
+    script: bash ./.ci/travis-compile.sh --server --package "macos" --release
     before_cache:
     - brew cleanup
 


### PR DESCRIPTION
## Short roundup of the initial problem
Apple rebranded their operating system and uses `macOS` since a while now.

## What will change with this Pull Request?
- replace `osx` with `macos` for the user facing binary for installation