### PR TITLE
add disable tearoffmenu option

### DIFF
--- a/cockatrice/src/abstractcounter.cpp
+++ b/cockatrice/src/abstractcounter.cpp
@@ -30,13 +30,12 @@ AbstractCounter::AbstractCounter(Player *_player,
     shortcutActive = false;
 
     if (player->getLocalOrJudge()) {
-        menu = new QMenu(name);
-        menu->setTearOffEnabled(true);
+        menu = new TearOffMenu(name);
         aSet = new QAction(this);
         connect(aSet, SIGNAL(triggered()), this, SLOT(setCounter()));
         menu->addAction(aSet);
         menu->addSeparator();
-        for (int i = 10; i >= -10; --i)
+        for (int i = 10; i >= -10; --i) {
             if (i == 0) {
                 menu->addSeparator();
             } else {
@@ -49,8 +48,10 @@ AbstractCounter::AbstractCounter(Player *_player,
                 connect(aIncrement, SIGNAL(triggered()), this, SLOT(incrementCounter()));
                 menu->addAction(aIncrement);
             }
-    } else
+        }
+    } else {
         menu = nullptr;
+    }
 
     connect(&settingsCache->shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
     refreshShortcuts();
@@ -107,8 +108,9 @@ void AbstractCounter::setShortcutsInactive()
 
 void AbstractCounter::refreshShortcuts()
 {
-    if (shortcutActive)
+    if (shortcutActive) {
         setShortcutsActive();
+    }
 }
 
 void AbstractCounter::setValue(int _value)

--- a/cockatrice/src/abstractcounter.h
+++ b/cockatrice/src/abstractcounter.h
@@ -1,6 +1,8 @@
 #ifndef COUNTER_H
 #define COUNTER_H
 
+#include "tearoffmenu.h"
+
 #include <QGraphicsItem>
 #include <QInputDialog>
 
@@ -28,7 +30,7 @@ protected:
 
 private:
     QAction *aSet, *aDec, *aInc;
-    QMenu *menu;
+    TearOffMenu *menu;
     bool dialogSemaphore, deleteAfterDialog;
     bool shownInCounterArea;
     bool shortcutActive;

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -382,12 +382,17 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     annotateTokensCheckBox.setChecked(settingsCache->getAnnotateTokens());
     connect(&annotateTokensCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setAnnotateTokens(int)));
 
+    useTearOffMenusCheckBox.setChecked(settingsCache->getUseTearOffMenus());
+    connect(&useTearOffMenusCheckBox, &QCheckBox::stateChanged, settingsCache,
+            [](int state) { settingsCache->setUseTearOffMenus(state == Qt::Checked); });
+
     auto *generalGrid = new QGridLayout;
     generalGrid->addWidget(&notificationsEnabledCheckBox, 0, 0);
     generalGrid->addWidget(&specNotificationsEnabledCheckBox, 1, 0);
     generalGrid->addWidget(&doubleClickToPlayCheckBox, 2, 0);
     generalGrid->addWidget(&playToStackCheckBox, 3, 0);
     generalGrid->addWidget(&annotateTokensCheckBox, 4, 0);
+    generalGrid->addWidget(&useTearOffMenusCheckBox, 5, 0);
 
     generalGroupBox = new QGroupBox;
     generalGroupBox->setLayout(generalGrid);
@@ -421,6 +426,7 @@ void UserInterfaceSettingsPage::retranslateUi()
     doubleClickToPlayCheckBox.setText(tr("&Double-click cards to play them (instead of single-click)"));
     playToStackCheckBox.setText(tr("&Play all nonlands onto the stack (not the battlefield) by default"));
     annotateTokensCheckBox.setText(tr("Annotate card text on tokens"));
+    useTearOffMenusCheckBox.setText(tr("Use tear-off menus, allowing right click menus to persist on screen"));
     animationGroupBox->setTitle(tr("Animation settings"));
     tapAnimationCheckBox.setText(tr("&Tap/untap animation"));
 }

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -111,6 +111,7 @@ private:
     QCheckBox doubleClickToPlayCheckBox;
     QCheckBox playToStackCheckBox;
     QCheckBox annotateTokensCheckBox;
+    QCheckBox useTearOffMenusCheckBox;
     QCheckBox tapAnimationCheckBox;
     QGroupBox *generalGroupBox;
     QGroupBox *animationGroupBox;

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -240,21 +240,18 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
         connect(aMoveBottomCardToGrave, SIGNAL(triggered()), this, SLOT(actMoveBottomCardToGrave()));
     }
 
-    playerMenu = new QMenu(QString());
+    playerMenu = new TearOffMenu();
     table->setMenu(playerMenu);
-    playerMenu->setTearOffEnabled(true);
 
     if (local || judge) {
-        handMenu = playerMenu->addMenu(QString());
-        handMenu->setTearOffEnabled(true);
+        handMenu = playerMenu->addTearOffMenu(QString());
         handMenu->addAction(aViewHand);
         playerLists.append(mRevealHand = handMenu->addMenu(QString()));
         playerLists.append(mRevealRandomHandCard = handMenu->addMenu(QString()));
         handMenu->addSeparator();
         handMenu->addAction(aMulligan);
         handMenu->addSeparator();
-        moveHandMenu = handMenu->addMenu(QString());
-        moveHandMenu->setTearOffEnabled(true);
+        moveHandMenu = handMenu->addTearOffMenu(QString());
         moveHandMenu->addAction(aMoveHandToTopLibrary);
         moveHandMenu->addAction(aMoveHandToBottomLibrary);
         moveHandMenu->addSeparator();
@@ -263,8 +260,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
         moveHandMenu->addAction(aMoveHandToRfg);
         hand->setMenu(handMenu);
 
-        libraryMenu = playerMenu->addMenu(QString());
-        libraryMenu->setTearOffEnabled(true);
+        libraryMenu = playerMenu->addTearOffMenu(QString());
         libraryMenu->addAction(aDrawCard);
         libraryMenu->addAction(aDrawCards);
         libraryMenu->addAction(aUndoDraw);
@@ -294,8 +290,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
         libraryMenu = nullptr;
     }
 
-    graveMenu = playerMenu->addMenu(QString());
-    graveMenu->setTearOffEnabled(true);
+    graveMenu = playerMenu->addTearOffMenu(QString());
     graveMenu->addAction(aViewGraveyard);
 
     if (local || judge) {
@@ -308,15 +303,13 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
     }
     grave->setMenu(graveMenu, aViewGraveyard);
 
-    rfgMenu = playerMenu->addMenu(QString());
-    rfgMenu->setTearOffEnabled(true);
+    rfgMenu = playerMenu->addTearOffMenu(QString());
     rfgMenu->addAction(aViewRfg);
     rfg->setMenu(rfgMenu, aViewRfg);
 
     if (local || judge) {
         graveMenu->addSeparator();
-        moveGraveMenu = graveMenu->addMenu(QString());
-        moveGraveMenu->setTearOffEnabled(true);
+        moveGraveMenu = graveMenu->addTearOffMenu(QString());
         moveGraveMenu->addAction(aMoveGraveToTopLibrary);
         moveGraveMenu->addAction(aMoveGraveToBottomLibrary);
         moveGraveMenu->addSeparator();
@@ -325,8 +318,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
         moveGraveMenu->addAction(aMoveGraveToRfg);
 
         rfgMenu->addSeparator();
-        moveRfgMenu = rfgMenu->addMenu(QString());
-        moveRfgMenu->setTearOffEnabled(true);
+        moveRfgMenu = rfgMenu->addTearOffMenu(QString());
         moveRfgMenu->addAction(aMoveRfgToTopLibrary);
         moveRfgMenu->addAction(aMoveRfgToBottomLibrary);
         moveRfgMenu->addSeparator();

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -5,6 +5,7 @@
 #include "carddatabase.h"
 #include "pb/card_attributes.pb.h"
 #include "pb/game_event.pb.h"
+#include "tearoffmenu.h"
 #include <QInputDialog>
 #include <QMap>
 #include <QPoint>
@@ -203,9 +204,9 @@ private slots:
 
 private:
     TabGame *game;
-    QMenu *playerMenu, *handMenu, *moveHandMenu, *graveMenu, *moveGraveMenu, *rfgMenu, *moveRfgMenu, *libraryMenu,
-        *sbMenu, *countersMenu, *sayMenu, *createPredefinedTokenMenu, *mRevealLibrary, *mRevealTopCard, *mRevealHand,
+    QMenu *sbMenu, *countersMenu, *sayMenu, *createPredefinedTokenMenu, *mRevealLibrary, *mRevealTopCard, *mRevealHand,
         *mRevealRandomHandCard, *mRevealRandomGraveyardCard;
+    TearOffMenu *moveGraveMenu, *moveRfgMenu, *graveMenu, *moveHandMenu, *handMenu, *libraryMenu, *rfgMenu, *playerMenu;
     QList<QMenu *> playerLists;
     QList<QAction *> allPlayersActions;
     QAction *aMoveHandToTopLibrary, *aMoveHandToBottomLibrary, *aMoveHandToGrave, *aMoveHandToRfg,

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -231,6 +231,9 @@ SettingsCache::SettingsCache()
     startingHandSize = settings->value("interface/startinghandsize", 7).toInt();
     annotateTokens = settings->value("interface/annotatetokens", false).toBool();
     tabGameSplitterSizes = settings->value("interface/tabgame_splittersizes").toByteArray();
+    knownMissingFeatures = settings->value("interface/knownmissingfeatures", "").toString();
+    useTearOffMenus = settings->value("interface/usetearoffmenus", true).toBool();
+
     displayCardNames = settings->value("cards/displaycardnames", true).toBool();
     horizontalHand = settings->value("hand/horizontal", true).toBool();
     invertVerticalCoordinate = settings->value("table/invert_vertical", false).toBool();
@@ -278,12 +281,18 @@ SettingsCache::SettingsCache()
     rememberGameSettings = settings->value("game/remembergamesettings", true).toBool();
     clientID = settings->value("personal/clientid", CLIENT_INFO_NOT_SET).toString();
     clientVersion = settings->value("personal/clientversion", CLIENT_INFO_NOT_SET).toString();
-    knownMissingFeatures = settings->value("interface/knownmissingfeatures", "").toString();
 }
 
-void SettingsCache::setKnownMissingFeatures(QString _knownMissingFeatures)
+void SettingsCache::setUseTearOffMenus(bool _useTearOffMenus)
 {
-    knownMissingFeatures = std::move(_knownMissingFeatures);
+    useTearOffMenus = _useTearOffMenus;
+    settings->setValue("interface/usetearoffmenus", useTearOffMenus);
+    emit useTearOffMenusChanged(useTearOffMenus);
+}
+
+void SettingsCache::setKnownMissingFeatures(const QString &_knownMissingFeatures)
+{
+    knownMissingFeatures = _knownMissingFeatures;
     settings->setValue("interface/knownmissingfeatures", knownMissingFeatures);
 }
 
@@ -592,15 +601,15 @@ void SettingsCache::setPixmapCacheSize(const int _pixmapCacheSize)
     emit pixmapCacheSizeChanged(pixmapCacheSize);
 }
 
-void SettingsCache::setClientID(QString _clientID)
+void SettingsCache::setClientID(const QString &_clientID)
 {
-    clientID = std::move(_clientID);
+    clientID = _clientID;
     settings->setValue("personal/clientid", clientID);
 }
 
-void SettingsCache::setClientVersion(QString _clientVersion)
+void SettingsCache::setClientVersion(const QString &_clientVersion)
 {
-    clientVersion = std::move(_clientVersion);
+    clientVersion = _clientVersion;
     settings->setValue("personal/clientversion", clientVersion);
 }
 

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -50,6 +50,7 @@ signals:
     void chatMentionCompleterChanged();
     void downloadSpoilerTimeIndexChanged();
     void downloadSpoilerStatusChanged();
+    void useTearOffMenusChanged(bool state);
 
 private:
     QSettings *settings;
@@ -102,6 +103,7 @@ private:
     QString clientID;
     QString clientVersion;
     QString knownMissingFeatures;
+    bool useTearOffMenus;
     int pixmapCacheSize;
     bool scaleCards;
     bool showMessagePopups;
@@ -398,9 +400,10 @@ public:
     {
         return maxFontSize;
     }
-    void setClientID(QString clientID);
-    void setClientVersion(QString clientVersion);
-    void setKnownMissingFeatures(QString _knownMissingFeatures);
+    void setClientID(const QString &clientID);
+    void setClientVersion(const QString &clientVersion);
+    void setKnownMissingFeatures(const QString &_knownMissingFeatures);
+    void setUseTearOffMenus(bool _useTearOffMenus);
     QString getClientID()
     {
         return clientID;
@@ -412,6 +415,10 @@ public:
     QString getKnownMissingFeatures()
     {
         return knownMissingFeatures;
+    }
+    bool getUseTearOffMenus()
+    {
+        return useTearOffMenus;
     }
     ShortcutsSettings &shortcuts() const
     {

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -1408,8 +1408,7 @@ void TabGame::createMenuItems()
     connect(aLeaveGame, SIGNAL(triggered()), this, SLOT(actLeaveGame()));
     aCloseReplay = nullptr;
 
-    phasesMenu = new QMenu(this);
-    phasesMenu->setTearOffEnabled(true);
+    phasesMenu = new TearOffMenu(this);
 
     for (int i = 0; i < phasesToolbar->phaseCount(); ++i) {
         QAction *temp = new QAction(QString(), this);

--- a/cockatrice/src/tab_game.h
+++ b/cockatrice/src/tab_game.h
@@ -4,6 +4,7 @@
 #include "pb/event_leave.pb.h"
 #include "pb/serverinfo_game.pb.h"
 #include "tab.h"
+#include "tearoffmenu.h"
 #include <QCompleter>
 #include <QMap>
 #include <QPushButton>
@@ -163,8 +164,8 @@ private:
         *replayControlWidget;
     QDockWidget *cardInfoDock, *messageLayoutDock, *playerListDock, *replayDock;
     QAction *playersSeparator;
-    QMenu *gameMenu, *phasesMenu, *viewMenu, *cardInfoDockMenu, *messageLayoutDockMenu, *playerListDockMenu,
-        *replayDockMenu;
+    QMenu *gameMenu, *viewMenu, *cardInfoDockMenu, *messageLayoutDockMenu, *playerListDockMenu, *replayDockMenu;
+    TearOffMenu *phasesMenu;
     QAction *aGameInfo, *aConcede, *aLeaveGame, *aCloseReplay, *aNextPhase, *aNextPhaseAction, *aNextTurn,
         *aReverseTurn, *aRemoveLocalArrows, *aRotateViewCW, *aRotateViewCCW, *aResetLayout, *aResetReplayLayout;
     QAction *aCardInfoDockVisible, *aCardInfoDockFloating, *aMessageLayoutDockVisible, *aMessageLayoutDockFloating,

--- a/cockatrice/src/tearoffmenu.h
+++ b/cockatrice/src/tearoffmenu.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "settingscache.h"
+
+#include <QMenu>
+
+class TearOffMenu : public QMenu
+{
+public:
+    TearOffMenu(const QString &title, QWidget *parent = nullptr) : QMenu(title, parent)
+    {
+        connect(settingsCache, &SettingsCache::useTearOffMenusChanged, this,
+                [=](bool state) { setTearOffEnabled(state); });
+        setTearOffEnabled(settingsCache->getUseTearOffMenus());
+    }
+
+    TearOffMenu(QWidget *parent = nullptr) : QMenu(parent)
+    {
+        connect(settingsCache, &SettingsCache::useTearOffMenusChanged, this,
+                [=](bool state) { setTearOffEnabled(state); });
+        setTearOffEnabled(settingsCache->getUseTearOffMenus());
+    }
+
+    TearOffMenu *addTearOffMenu(const QString &title)
+    {
+        TearOffMenu *menu = new TearOffMenu(title, this);
+        addMenu(menu);
+        return menu;
+    }
+};


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3780
## Short roundup of the initial problem
tearoffmenus were added but no option to disable them existed.

## What will change with this Pull Request?
- a new convenient class that manages if a menu should be tearoff-able is added
- a checkbox in the interface settings is added for disabling tearoff is added

## Screenshots
![image](https://user-images.githubusercontent.com/36401181/65992104-de71ce00-e48e-11e9-85dd-8834810ad7fd.png)
