### PR TITLE
Cockatrice Docker Image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:18.04
-MAINTAINER Alfredo Foltran <alfoltran@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update \
+RUN apt-get update -y --no-install-recommends \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -21,6 +20,8 @@ RUN apt-get update \
         libqt5websockets5 \
         libqt5widgets5 \
     && dpkg -i ./Cockatrice-Faerie_Tales-2.7.2-UbuntuBionic.deb \
-    && apt-get install -f
+    && apt-get install -f \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 CMD cockatrice

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:18.04
+MAINTAINER Alfredo Foltran <alfoltran@gmail.com>
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+    && curl -LO  https://github.com/Cockatrice/Cockatrice/releases/download/2019-08-31-Release-2.7.2/Cockatrice-Faerie_Tales-2.7.2-UbuntuBionic.deb \
+    && apt-get install -y \
+        libqt5multimedia5-plugins \
+        libqt5svg5 \
+        libprotobuf10 \
+        libqt5core5a \
+        libqt5gui5 \
+        libqt5multimedia5 \
+        libqt5network5 \
+        libqt5printsupport5 \
+        libqt5sql5 \
+        libqt5websockets5 \
+        libqt5widgets5 \
+    && dpkg -i ./Cockatrice-Faerie_Tales-2.7.2-UbuntuBionic.deb \
+    && apt-get install -f
+
+CMD cockatrice

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -3,7 +3,7 @@ VERSION = latest
 
 .PHONY: build build-nocache tag-latest push push-latest release git-tag-version
 
-build: generator.jar
+build:
 	docker build -t $(NAME):$(VERSION) --rm .
 
 build-nocache:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,25 @@
+NAME = cockatrice/cockatrice
+VERSION = latest
+
+.PHONY: build build-nocache tag-latest push push-latest release git-tag-version
+
+build: generator.jar
+	docker build -t $(NAME):$(VERSION) --rm .
+
+build-nocache:
+	docker build -t $(NAME):$(VERSION) --no-cache --rm .
+
+tag-latest:
+	docker tag $(NAME):$(VERSION) $(NAME):latest
+
+push:
+	docker push $(NAME):$(VERSION)
+
+push-latest:
+	docker push $(NAME):latest
+
+release: build tag-latest push push-latest
+
+git-tag-version: release
+	git tag -a v$(VERSION) -m "v$(VERSION)"
+	git push origin v$(VERSION)

--- a/docker/run-cockatrice.sh
+++ b/docker/run-cockatrice.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+
+CONTAINER_NAME=cockatrice
+VERSION=latest
+
+function runDocker {
+    if [ $# -gt 2 ]; then
+        echo "Use: .run.sh <<CONTAINER_NAME>> <<COCKATRICE_VERSION>>"
+        exit 1
+    fi
+
+    if [ $# -gt 0 ]; then
+        CONTAINER_NAME=$1
+    fi
+    if [ $# -gt 1 ]; then
+        VERSION=$2
+    fi
+
+    docker run --privileged --rm -e DISPLAY=$DISPLAY --name ${CONTAINER_NAME} \
+           -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+           -v /home/$USER/.local/share/Cockatrice/Cockatrice:/root/.local/share/Cockatrice/Cockatrice \
+           cockatrice/cockatrice:${VERSION}
+}
+
+(
+    if ( flock -ne 1000 ); then
+        trap "xhost -local:docker" EXIT
+        echo "Starting Cockatrice..."
+        xhost +local:docker
+        runDocker $@
+    else
+        echo "Already there is a process running!"
+    fi
+) 1000>.cockatrice


### PR DESCRIPTION
## Related Ticket(s)
Scripts for client image generation. I am using this image to run the Cockatrice on Fedora.

## Short roundup of the initial problem
I don't know if this is the best place to store these scripts, but these are the scripts I used to create and maintain the images available in [Docker Hub](https://hub.docker.com/r/cockatrice/cockatrice).

I would also like to pass Cockatrice Docker Hub access credentials. So you can upload the image of the servatrice if you wish.