### PR TITLE
add support for adventures to oracle

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -184,6 +184,12 @@ CardInfoPtr OracleImporter::addCard(QString name,
         // reset the side property, since the card has no back image
         properties.insert("side", "front");
     }
+  
+    // Adventure cards
+    if (layout == "adventure") {
+        // both parts of an adventure are on the front side
+        properties.insert("side", "front");
+    }
 
     // insert the card and its properties
     QList<CardRelation *> reverseRelatedCards;

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -378,7 +378,7 @@ int OracleImporter::importCardsFromSet(CardSetPtr currentSet, const QList<QVaria
                         if (prop == "colors") {
                             properties.insert(prop, originalPropertyValue + thisCardPropertyValue);
                         } else if (prop == "maintype" && layout == "adventure") {
-                            properties.insert(prop, "Creature");
+                            properties.insert(prop, originalPropertyValue);
                         } else {
                             properties.insert(prop,
                                               originalPropertyValue + splitCardPropSeparator + thisCardPropertyValue);

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -184,12 +184,6 @@ CardInfoPtr OracleImporter::addCard(QString name,
         // reset the side property, since the card has no back image
         properties.insert("side", "front");
     }
-  
-    // Adventure cards
-    if (layout == "adventure") {
-        // both parts of an adventure are on the front side
-        properties.insert("side", "front");
-    }
 
     // insert the card and its properties
     QList<CardRelation *> reverseRelatedCards;
@@ -322,7 +316,7 @@ int OracleImporter::importCardsFromSet(CardSetPtr currentSet, const QList<QVaria
         }
 
         // split cards are considered a single card, enqueue for later merging
-        if (layout == "split" || layout == "aftermath") {
+        if (layout == "split" || layout == "aftermath" || layout == "adventure") {
             // get the position of this card part
             int index = additionalNames.indexOf(name);
             // construct full card name
@@ -376,12 +370,15 @@ int OracleImporter::importCardsFromSet(CardSetPtr currentSet, const QList<QVaria
                 setInfo = tmp.getSetInfo();
             } else {
                 const QVariantHash &props = tmp.getProperties();
+                layout = properties.value("layout").toString();
                 for (const QString &prop : props.keys()) {
                     QString originalPropertyValue = properties.value(prop).toString();
                     QString thisCardPropertyValue = props.value(prop).toString();
                     if (originalPropertyValue != thisCardPropertyValue) {
                         if (prop == "colors") {
                             properties.insert(prop, originalPropertyValue + thisCardPropertyValue);
+                        } else if (prop == "maintype" && layout == "adventure") {
+                            properties.insert(prop, "Creature");
                         } else {
                             properties.insert(prop,
                                               originalPropertyValue + splitCardPropSeparator + thisCardPropertyValue);


### PR DESCRIPTION
## Related Ticket(s)
- N/A

## Short roundup of the initial problem
without this, oracle treats adventures like 2-faced cards, with the creature having the front, and the adventure having the back. in reality, both are on the front side, so requests to scryfall for the adventure image error out

## What will change with this Pull Request?
- adventure cards will be treated like split cards
- scryfall will see less 422s

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
N/A