### PR TITLE
Increase macos version, drop sierra support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
   - name: macOS (Debug)
     if: tag IS NOT present
     os: osx
-    osx_image: xcode9.2
+    osx_image: xcode10.1
     cache:
     - ccache
     - directories:
@@ -67,7 +67,7 @@ matrix:
   - name: macOS (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present
     os: osx
-    osx_image: xcode9.2
+    osx_image: xcode10.1
     cache:
     - ccache
     - directories:


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/commit/800b0f4b2fba1b50a1157ee216a2ddca75b52f0d homebrew no longer provides a bottle for protobuf, which is so big we can't do without a precompiled version. This means we can no longer support sierra 10.12 and have to use high sierra 10.13, this does not seem like a very painful upgrade however as there are no differences in hardware requirements between the two and any user on sierra can upgrade to high sierra if they wanted to.