### PR TITLE
link to new AllPrintings file

### DIFF
--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -37,14 +37,14 @@
 #define ZIP_SIGNATURE "PK"
 // Xz stream header: 0xFD + "7zXZ"
 #define XZ_SIGNATURE "\xFD\x37\x7A\x58\x5A"
-#define ALLSETS_URL_FALLBACK "https://mtgjson.com/json/AllSets.json"
+#define ALLSETS_URL_FALLBACK "https://www.mtgjson.com/files/AllPrintings.json"
 
 #ifdef HAS_LZMA
-#define ALLSETS_URL "https://mtgjson.com/json/AllSets.json.xz"
+#define ALLSETS_URL "https://www.mtgjson.com/files/AllPrintings.json.xz"
 #elif defined(HAS_ZLIB)
-#define ALLSETS_URL "https://mtgjson.com/json/AllSets.json.zip"
+#define ALLSETS_URL "https://www.mtgjson.com/files/AllPrintings.json.zip"
 #else
-#define ALLSETS_URL "https://mtgjson.com/json/AllSets.json"
+#define ALLSETS_URL "https://www.mtgjson.com/files/AllPrintings.json"
 #endif
 
 #define TOKENS_URL "https://raw.githubusercontent.com/Cockatrice/Magic-Token/master/tokens.xml"


### PR DESCRIPTION
## Short roundup of the initial problem
MTGJSON changed their endpoint, see https://mtgjson.com/changelog/#_4-6-0-2019-10-28
But redirects should be in place, so nobody will be cut off.

## What will change with this Pull Request?
- use new `AllPrintings` file name
- use new file location in `\files\` folder (used to be `\json\`)

Makes us independent from the redirect.

Tested with the windows build from appveyor. 👍 