### PR TITLE
add deck hash copying functions

### DIFF
--- a/cockatrice/src/playerlistwidget.cpp
+++ b/cockatrice/src/playerlistwidget.cpp
@@ -216,6 +216,7 @@ void PlayerListWidget::showContextMenu(const QPoint &pos, const QModelIndex &ind
     const QString &userName = index.sibling(index.row(), 4).data(Qt::UserRole).toString();
     int playerId = index.sibling(index.row(), 4).data(Qt::UserRole + 1).toInt();
     UserLevelFlags userLevel(index.sibling(index.row(), 3).data(Qt::UserRole).toInt());
+    QString deckHash = index.sibling(index.row(), 5).data().toString();
 
-    userContextMenu->showContextMenu(pos, userName, userLevel, true, playerId);
+    userContextMenu->showContextMenu(pos, userName, userLevel, true, playerId, deckHash);
 }

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -121,8 +121,10 @@ void TabDeckEditor::createDeckDock()
     auto *hashSizePolicy = new QSizePolicy();
     hashSizePolicy->setHorizontalPolicy(QSizePolicy::Fixed);
     hashLabel1->setSizePolicy(*hashSizePolicy);
-    hashLabel = new QLabel;
+    hashLabel = new QLineEdit;
     hashLabel->setObjectName("hashLabel");
+    hashLabel->setReadOnly(true);
+    hashLabel->setFrame(false);
 
     auto *lowerLayout = new QGridLayout;
     lowerLayout->setObjectName("lowerLayout");

--- a/cockatrice/src/tab_deck_editor.h
+++ b/cockatrice/src/tab_deck_editor.h
@@ -121,7 +121,7 @@ private:
     QLabel *commentsLabel;
     QTextEdit *commentsEdit;
     QLabel *hashLabel1;
-    QLabel *hashLabel;
+    QLineEdit *hashLabel;
     FilterTreeModel *filterModel;
     QTreeView *filterView;
     KeySignals filterViewKeySignals;

--- a/cockatrice/src/user_context_menu.cpp
+++ b/cockatrice/src/user_context_menu.cpp
@@ -278,11 +278,25 @@ void UserContextMenu::showContextMenu(const QPoint &pos,
                                       bool online,
                                       int playerId)
 {
+    showContextMenu(pos, userName, userLevel, online, playerId, QString());
+}
+void UserContextMenu::showContextMenu(const QPoint &pos,
+                                      const QString &userName,
+                                      UserLevelFlags userLevel,
+                                      bool online,
+                                      int playerId,
+                                      const QString &deckHash)
+{
+    QAction *aCopyToClipBoard;
     aUserName->setText(userName);
 
     QMenu *menu = new QMenu(static_cast<QWidget *>(parent()));
     menu->addAction(aUserName);
     menu->addSeparator();
+    if (!deckHash.isEmpty()) {
+        aCopyToClipBoard = new QAction(tr("Copy hash to clipboard"), this);
+        menu->addAction(aCopyToClipBoard);
+    }
     menu->addAction(aDetails);
     menu->addAction(aShowGames);
     menu->addAction(aChat);
@@ -351,9 +365,9 @@ void UserContextMenu::showContextMenu(const QPoint &pos,
                             Qt::Dialog | Qt::WindowTitleHint | Qt::CustomizeWindowHint | Qt::WindowCloseButtonHint);
         infoWidget->setAttribute(Qt::WA_DeleteOnClose);
         infoWidget->updateInfo(userName);
-    } else if (actionClicked == aChat)
+    } else if (actionClicked == aChat) {
         emit openMessageDialog(userName, true);
-    else if (actionClicked == aShowGames) {
+    } else if (actionClicked == aShowGames) {
         Command_GetGamesOfUser cmd;
         cmd.set_user_name(userName.toStdString());
 
@@ -438,6 +452,9 @@ void UserContextMenu::showContextMenu(const QPoint &pos,
         connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
                 SLOT(warnUserHistory_processResponse(Response)));
         client->sendCommand(pend);
+    } else if (actionClicked == aCopyToClipBoard) {
+        QClipboard *clipboard = QGuiApplication::clipboard();
+        clipboard->setText(deckHash);
     }
 
     delete menu;

--- a/cockatrice/src/user_context_menu.cpp
+++ b/cockatrice/src/user_context_menu.cpp
@@ -280,6 +280,7 @@ void UserContextMenu::showContextMenu(const QPoint &pos,
 {
     showContextMenu(pos, userName, userLevel, online, playerId, QString());
 }
+
 void UserContextMenu::showContextMenu(const QPoint &pos,
                                       const QString &userName,
                                       UserLevelFlags userLevel,

--- a/cockatrice/src/user_context_menu.h
+++ b/cockatrice/src/user_context_menu.h
@@ -53,6 +53,12 @@ public:
                          UserLevelFlags userLevel,
                          bool online = true,
                          int playerId = -1);
+    void showContextMenu(const QPoint &pos,
+                         const QString &userName,
+                         UserLevelFlags userLevel,
+                         bool online,
+                         int playerId,
+                         const QString &deckHash);
 };
 
 #endif


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3880

## Short roundup of the initial problem
comparing deck hashes is difficult because you can't copy them

## What will change with this Pull Request?
- the deck hash in the deck editor is turned into a readonly qlineedit, making it selectable and copyable
- an action is added to the context menu in the in game playerlist widget to copy the hash to clipboard

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![image](https://user-images.githubusercontent.com/36401181/71842460-00986f00-30c2-11ea-85f3-b873d6e1ea01.png)
![image](https://user-images.githubusercontent.com/36401181/71842563-376e8500-30c2-11ea-9669-77abb5cfc458.png)
