### PR TITLE
Hide games created/hosted by people on your Ignore List

### DIFF
--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -25,6 +25,9 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     showPasswordProtectedGames = new QCheckBox(tr("Show &password protected games"));
     showPasswordProtectedGames->setChecked(gamesProxyModel->getShowPasswordProtectedGames());
 
+    hideIgnoredUserGames = new QCheckBox(tr("Hide '&ignored user' games"));
+    hideIgnoredUserGames->setChecked(gamesProxyModel->getHideIgnoredUserGames());
+
     gameNameFilterEdit = new QLineEdit;
     gameNameFilterEdit->setText(gamesProxyModel->getGameNameFilter());
     QLabel *gameNameFilterLabel = new QLabel(tr("Game &description:"));
@@ -87,6 +90,7 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     restrictionsLayout->addWidget(unavailableGamesVisibleCheckBox, 0, 0);
     restrictionsLayout->addWidget(showPasswordProtectedGames, 1, 0);
     restrictionsLayout->addWidget(showBuddiesOnlyGames, 2, 0);
+    restrictionsLayout->addWidget(hideIgnoredUserGames, 3, 0);
 
     QGroupBox *restrictionsGroupBox = new QGroupBox(tr("Restrictions"));
     restrictionsGroupBox->setLayout(restrictionsLayout);
@@ -152,6 +156,16 @@ bool DlgFilterGames::getShowPasswordProtectedGames() const
 void DlgFilterGames::setShowPasswordProtectedGames(bool _passwordProtectedGamesHidden)
 {
     showPasswordProtectedGames->setChecked(_passwordProtectedGamesHidden);
+}
+
+bool DlgFilterGames::getHideIgnoredUserGames() const
+{
+    return hideIgnoredUserGames->isChecked();
+}
+
+void DlgFilterGames::setHideIgnoredUserGames(bool _hideIgnoredUserGames)
+{
+    hideIgnoredUserGames->setChecked(_hideIgnoredUserGames);
 }
 
 QString DlgFilterGames::getGameNameFilter() const

--- a/cockatrice/src/dlg_filter_games.h
+++ b/cockatrice/src/dlg_filter_games.h
@@ -20,6 +20,7 @@ private:
     QCheckBox *showBuddiesOnlyGames;
     QCheckBox *unavailableGamesVisibleCheckBox;
     QCheckBox *showPasswordProtectedGames;
+    QCheckBox *hideIgnoredUserGames;
     QLineEdit *gameNameFilterEdit;
     QLineEdit *creatorNameFilterEdit;
     QMap<int, QCheckBox *> gameTypeFilterCheckBoxes;
@@ -43,6 +44,8 @@ public:
     void setShowPasswordProtectedGames(bool _passwordProtectedGamesHidden);
     bool getShowBuddiesOnlyGames() const;
     void setShowBuddiesOnlyGames(bool _showBuddiesOnlyGames);
+    bool getHideIgnoredUserGames() const;
+    void setHideIgnoredUserGames(bool _hideIgnoredUserGames);
     QString getGameNameFilter() const;
     void setGameNameFilter(const QString &_gameNameFilter);
     QString getCreatorNameFilter() const;

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -1,5 +1,5 @@
-#include "abstractclient.h"
 #include "gameselector.h"
+#include "abstractclient.h"
 #include "dlg_creategame.h"
 #include "dlg_filter_games.h"
 #include "gamesmodel.h"
@@ -118,17 +118,20 @@ GameSelector::GameSelector(AbstractClient *_client,
             SLOT(processRemoveFromListEvent(const Event_RemoveFromList &)));
 }
 
-void GameSelector::ignoreListReceived(const QList<ServerInfo_User> &) {
+void GameSelector::ignoreListReceived(const QList<ServerInfo_User> &)
+{
     gameListProxyModel->refresh();
 }
 
-void GameSelector::processAddToListEvent(const Event_AddToList &event) {
+void GameSelector::processAddToListEvent(const Event_AddToList &event)
+{
     if (event.list_name() == "ignore") {
         gameListProxyModel->refresh();
     }
 }
 
-void GameSelector::processRemoveFromListEvent(const Event_RemoveFromList &event) {
+void GameSelector::processRemoveFromListEvent(const Event_RemoveFromList &event)
+{
     if (event.list_name() == "ignore") {
         gameListProxyModel->refresh();
     }

--- a/cockatrice/src/gameselector.h
+++ b/cockatrice/src/gameselector.h
@@ -3,6 +3,8 @@
 
 #include "gametypemap.h"
 #include <QGroupBox>
+#include <common/pb/event_add_to_list.pb.h>
+#include <common/pb/event_remove_from_list.pb.h>
 
 class QTreeView;
 class GamesModel;
@@ -25,6 +27,10 @@ private slots:
     void actJoin();
     void actSelectedGameChanged(const QModelIndex &current, const QModelIndex &previous);
     void checkResponse(const Response &response);
+
+    void ignoreListReceived(const QList<ServerInfo_User> &_ignoreList);
+    void processAddToListEvent(const Event_AddToList &event);
+    void processRemoveFromListEvent(const Event_RemoveFromList &event);
 signals:
     void gameJoined(int gameId);
 

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -256,7 +256,8 @@ void GamesModel::updateGameList(const ServerInfo_Game &game)
 }
 
 GamesProxyModel::GamesProxyModel(QObject *parent, const TabSupervisor *_tabSupervisor)
-    : QSortFilterProxyModel(parent), ownUserIsRegistered(_tabSupervisor->isOwnUserRegistered()), tabSupervisor(_tabSupervisor), showBuddiesOnlyGames(false), hideIgnoredUserGames(false),
+    : QSortFilterProxyModel(parent), ownUserIsRegistered(_tabSupervisor->isOwnUserRegistered()),
+      tabSupervisor(_tabSupervisor), showBuddiesOnlyGames(false), hideIgnoredUserGames(false),
       unavailableGamesVisible(false), showPasswordProtectedGames(true), maxPlayersFilterMin(-1), maxPlayersFilterMax(-1)
 {
     setSortRole(GamesModel::SORT_ROLE);
@@ -377,7 +378,8 @@ bool GamesProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex & /*sour
     if (!showBuddiesOnlyGames && game.only_buddies()) {
         return false;
     }
-    if (hideIgnoredUserGames && tabSupervisor->getUserListsTab()->getIgnoreList()->getUsers().contains(QString::fromStdString(game.creator_info().name()))) {
+    if (hideIgnoredUserGames && tabSupervisor->getUserListsTab()->getIgnoreList()->getUsers().contains(
+                                    QString::fromStdString(game.creator_info().name()))) {
         return false;
     }
     if (!unavailableGamesVisible) {
@@ -412,6 +414,7 @@ bool GamesProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex & /*sour
     return true;
 }
 
-void GamesProxyModel::refresh() {
+void GamesProxyModel::refresh()
+{
     invalidateFilter();
 }

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -3,6 +3,7 @@
 
 #include "gametypemap.h"
 #include "pb/serverinfo_game.pb.h"
+#include "tab_supervisor.h"
 #include <QAbstractTableModel>
 #include <QList>
 #include <QSet>
@@ -65,7 +66,9 @@ class GamesProxyModel : public QSortFilterProxyModel
     Q_OBJECT
 private:
     bool ownUserIsRegistered;
+    const TabSupervisor *tabSupervisor;
     bool showBuddiesOnlyGames;
+    bool hideIgnoredUserGames;
     bool unavailableGamesVisible;
     bool showPasswordProtectedGames;
     QString gameNameFilter, creatorNameFilter;
@@ -75,13 +78,18 @@ private:
     static const int DEFAULT_MAX_PLAYERS_MAX = 99;
 
 public:
-    GamesProxyModel(QObject *parent = nullptr, bool _ownUserIsRegistered = false);
+    GamesProxyModel(QObject *parent = nullptr, const TabSupervisor *_tabSupervisor = nullptr);
 
     bool getShowBuddiesOnlyGames() const
     {
         return showBuddiesOnlyGames;
     }
     void setShowBuddiesOnlyGames(bool _showBuddiesOnlyGames);
+    bool getHideIgnoredUserGames() const
+    {
+        return hideIgnoredUserGames;
+    }
+    void setHideIgnoredUserGames(bool _hideIgnoredUserGames);
     bool getUnavailableGamesVisible() const
     {
         return unavailableGamesVisible;
@@ -119,6 +127,7 @@ public:
     void resetFilterParameters();
     void loadFilterParameters(const QMap<int, QString> &allGameTypes);
     void saveFilterParameters(const QMap<int, QString> &allGameTypes);
+    void refresh();
 
 protected:
     bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;

--- a/cockatrice/src/settings/gamefilterssettings.cpp
+++ b/cockatrice/src/settings/gamefilterssettings.cpp
@@ -48,6 +48,17 @@ bool GameFiltersSettings::isShowPasswordProtectedGames()
     return previous == QVariant() ? true : previous.toBool();
 }
 
+void GameFiltersSettings::setHideIgnoredUserGames(bool hide)
+{
+    setValue(hide, "hide_ignored_user_games", "filter_games");
+}
+
+bool GameFiltersSettings::isHideIgnoredUserGames()
+{
+    QVariant previous = getValue("hide_ignored_user_games", "filter_games");
+    return previous == QVariant() ? false : previous.toBool();
+}
+
 void GameFiltersSettings::setGameNameFilter(QString gameName)
 {
     setValue(gameName, "game_name_filter", "filter_games");

--- a/cockatrice/src/settings/gamefilterssettings.h
+++ b/cockatrice/src/settings/gamefilterssettings.h
@@ -12,12 +12,14 @@ public:
     bool isShowBuddiesOnlyGames();
     bool isUnavailableGamesVisible();
     bool isShowPasswordProtectedGames();
+    bool isHideIgnoredUserGames();
     QString getGameNameFilter();
     int getMinPlayers();
     int getMaxPlayers();
     bool isGameTypeEnabled(QString gametype);
 
     void setShowBuddiesOnlyGames(bool show);
+    void setHideIgnoredUserGames(bool hide);
     void setUnavailableGamesVisible(bool enabled);
     void setShowPasswordProtectedGames(bool show);
     void setGameNameFilter(QString gameName);

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -95,6 +95,7 @@ void SettingsCache::translateLegacySettings()
     gameFilters().setShowPasswordProtectedGames(legacySetting.value("show_password_protected_games").toBool());
     gameFilters().setGameNameFilter(legacySetting.value("game_name_filter").toString());
     gameFilters().setShowBuddiesOnlyGames(legacySetting.value("show_buddies_only_games").toBool());
+    gameFilters().setHideIgnoredUserGames(legacySetting.value("hide_ignored_user_games").toBool());
     gameFilters().setMinPlayers(legacySetting.value("min_players").toInt());
 
     if (legacySetting.value("max_players").toInt() > 1)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #724 

## Short roundup of the initial problem
Implemented new filter on the Game List to allow hiding games created by users who are on your Ignore List.

## What will change with this Pull Request?
- New checkbox in Filter Dialog to enable hiding games whose creator is ignored.
- Game Selector now responds to Ignore List Received and Add To/Remove From List signals, and refreshes the Game List accordingly.

## Screenshots
![Screenshot from 2020-01-06 22-12-02](https://user-images.githubusercontent.com/4104460/71852848-a2738800-30d1-11ea-8559-38b473aa9494.png)

