### PR TITLE
fix password length checks

### DIFF
--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -1795,5 +1795,5 @@ void WebsocketServerSocketInterface::binaryMessageReceived(const QByteArray &mes
 
 bool AbstractServerSocketInterface::isPasswordLongEnough(const int passwordLength)
 {
-    return passwordLength < servatrice->getMinPasswordLength();
+    return passwordLength >= servatrice->getMinPasswordLength();
 }


### PR DESCRIPTION
unit testing when

## Related Ticket(s)
- Fixes (a number of support requests in discord)

## Short roundup of the initial problem
isPasswordLongEnough returned true for strings shorter than the minimum, not longer

## What will change with this Pull Request?
- the minimum will be a minimum, not a maximum
