### PR TITLE
Add configuration option to send desktop notification on buddy presence

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -373,6 +373,11 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     connect(&specNotificationsEnabledCheckBox, SIGNAL(stateChanged(int)), settingsCache,
             SLOT(setSpectatorNotificationsEnabled(int)));
 
+    buddyConnectNotificationsEnabledCheckBox.setChecked(settingsCache->getBuddyConnectNotificationsEnabled());
+    buddyConnectNotificationsEnabledCheckBox.setEnabled(settingsCache->getNotificationsEnabled());
+    connect(&buddyConnectNotificationsEnabledCheckBox, SIGNAL(stateChanged(int)), settingsCache,
+            SLOT(setBuddyConnectNotificationsEnabled(int)));
+
     doubleClickToPlayCheckBox.setChecked(settingsCache->getDoubleClickToPlay());
     connect(&doubleClickToPlayCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setDoubleClickToPlay(int)));
 
@@ -387,15 +392,21 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
             [](int state) { settingsCache->setUseTearOffMenus(state == Qt::Checked); });
 
     auto *generalGrid = new QGridLayout;
-    generalGrid->addWidget(&notificationsEnabledCheckBox, 0, 0);
-    generalGrid->addWidget(&specNotificationsEnabledCheckBox, 1, 0);
-    generalGrid->addWidget(&doubleClickToPlayCheckBox, 2, 0);
-    generalGrid->addWidget(&playToStackCheckBox, 3, 0);
-    generalGrid->addWidget(&annotateTokensCheckBox, 4, 0);
-    generalGrid->addWidget(&useTearOffMenusCheckBox, 5, 0);
+    generalGrid->addWidget(&doubleClickToPlayCheckBox, 0, 0);
+    generalGrid->addWidget(&playToStackCheckBox, 1, 0);
+    generalGrid->addWidget(&annotateTokensCheckBox, 2, 0);
+    generalGrid->addWidget(&useTearOffMenusCheckBox, 3, 0);
 
     generalGroupBox = new QGroupBox;
     generalGroupBox->setLayout(generalGrid);
+
+    auto *notificationsGrid = new QGridLayout;
+    notificationsGrid->addWidget(&notificationsEnabledCheckBox, 0, 0);
+    notificationsGrid->addWidget(&specNotificationsEnabledCheckBox, 1, 0);
+    notificationsGrid->addWidget(&buddyConnectNotificationsEnabledCheckBox, 2, 0);
+
+    notificationsGroupBox = new QGroupBox;
+    notificationsGroupBox->setLayout(notificationsGrid);
 
     tapAnimationCheckBox.setChecked(settingsCache->getTapAnimation());
     connect(&tapAnimationCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setTapAnimation(int)));
@@ -408,6 +419,7 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
 
     auto *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(generalGroupBox);
+    mainLayout->addWidget(notificationsGroupBox);
     mainLayout->addWidget(animationGroupBox);
 
     setLayout(mainLayout);
@@ -421,12 +433,14 @@ void UserInterfaceSettingsPage::setSpecNotificationEnabled(int i)
 void UserInterfaceSettingsPage::retranslateUi()
 {
     generalGroupBox->setTitle(tr("General interface settings"));
-    notificationsEnabledCheckBox.setText(tr("Enable notifications in taskbar"));
-    specNotificationsEnabledCheckBox.setText(tr("Notify in the taskbar for game events while you are spectating"));
     doubleClickToPlayCheckBox.setText(tr("&Double-click cards to play them (instead of single-click)"));
     playToStackCheckBox.setText(tr("&Play all nonlands onto the stack (not the battlefield) by default"));
     annotateTokensCheckBox.setText(tr("Annotate card text on tokens"));
     useTearOffMenusCheckBox.setText(tr("Use tear-off menus, allowing right click menus to persist on screen"));
+    notificationsGroupBox->setTitle(tr("Notifications settings"));
+    notificationsEnabledCheckBox.setText(tr("Enable notifications in taskbar"));
+    specNotificationsEnabledCheckBox.setText(tr("Notify in the taskbar for game events while you are spectating"));
+    buddyConnectNotificationsEnabledCheckBox.setText(tr("Notify in the taskbar when users in your buddy list connect"));
     animationGroupBox->setTitle(tr("Animation settings"));
     tapAnimationCheckBox.setText(tr("&Tap/untap animation"));
 }

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -108,12 +108,14 @@ private slots:
 private:
     QCheckBox notificationsEnabledCheckBox;
     QCheckBox specNotificationsEnabledCheckBox;
+    QCheckBox buddyConnectNotificationsEnabledCheckBox;
     QCheckBox doubleClickToPlayCheckBox;
     QCheckBox playToStackCheckBox;
     QCheckBox annotateTokensCheckBox;
     QCheckBox useTearOffMenusCheckBox;
     QCheckBox tapAnimationCheckBox;
     QGroupBox *generalGroupBox;
+    QGroupBox *notificationsGroupBox;
     QGroupBox *animationGroupBox;
 
 public:

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -226,6 +226,7 @@ SettingsCache::SettingsCache()
     tokenDialogGeometry = settings->value("interface/token_dialog_geometry").toByteArray();
     notificationsEnabled = settings->value("interface/notificationsenabled", true).toBool();
     spectatorNotificationsEnabled = settings->value("interface/specnotificationsenabled", false).toBool();
+    buddyConnectNotificationsEnabled = settings->value("interface/buddyconnectnotificationsenabled", false).toBool();
     doubleClickToPlay = settings->value("interface/doubleclicktoplay", true).toBool();
     playToStack = settings->value("interface/playtostack", true).toBool();
     startingHandSize = settings->value("interface/startinghandsize", 7).toInt();
@@ -435,6 +436,12 @@ void SettingsCache::setSpectatorNotificationsEnabled(int _spectatorNotifications
 {
     spectatorNotificationsEnabled = static_cast<bool>(_spectatorNotificationsEnabled);
     settings->setValue("interface/specnotificationsenabled", spectatorNotificationsEnabled);
+}
+
+void SettingsCache::setBuddyConnectNotificationsEnabled(int _buddyConnectNotificationsEnabled)
+{
+    buddyConnectNotificationsEnabled = static_cast<bool>(_buddyConnectNotificationsEnabled);
+    settings->setValue("interface/buddyconnectnotificationsenabled", buddyConnectNotificationsEnabled);
 }
 
 void SettingsCache::setDoubleClickToPlay(int _doubleClickToPlay)

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -226,7 +226,7 @@ SettingsCache::SettingsCache()
     tokenDialogGeometry = settings->value("interface/token_dialog_geometry").toByteArray();
     notificationsEnabled = settings->value("interface/notificationsenabled", true).toBool();
     spectatorNotificationsEnabled = settings->value("interface/specnotificationsenabled", false).toBool();
-    buddyConnectNotificationsEnabled = settings->value("interface/buddyconnectnotificationsenabled", false).toBool();
+    buddyConnectNotificationsEnabled = settings->value("interface/buddyconnectnotificationsenabled", true).toBool();
     doubleClickToPlay = settings->value("interface/doubleclicktoplay", true).toBool();
     playToStack = settings->value("interface/playtostack", true).toBool();
     startingHandSize = settings->value("interface/startinghandsize", 7).toInt();

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -77,6 +77,7 @@ private:
     bool picDownload;
     bool notificationsEnabled;
     bool spectatorNotificationsEnabled;
+    bool buddyConnectNotificationsEnabled;
     bool doubleClickToPlay;
     bool playToStack;
     int startingHandSize;
@@ -201,6 +202,10 @@ public:
     bool getSpectatorNotificationsEnabled() const
     {
         return spectatorNotificationsEnabled;
+    }
+    bool getBuddyConnectNotificationsEnabled() const
+    {
+        return buddyConnectNotificationsEnabled;
     }
     bool getNotifyAboutUpdates() const
     {
@@ -476,6 +481,7 @@ public slots:
     void setPicDownload(int _picDownload);
     void setNotificationsEnabled(int _notificationsEnabled);
     void setSpectatorNotificationsEnabled(int _spectatorNotificationsEnabled);
+    void setBuddyConnectNotificationsEnabled(int _buddyConnectNotificationsEnabled);
     void setDoubleClickToPlay(int _doubleClickToPlay);
     void setPlayToStack(int _playToStack);
     void setStartingHandSize(int _startingHandSize);

--- a/cockatrice/src/tab_room.cpp
+++ b/cockatrice/src/tab_room.cpp
@@ -158,10 +158,15 @@ void TabRoom::focusTab()
 
 void TabRoom::actShowMentionPopup(QString &sender)
 {
+    this->actShowPopup(sender + tr(" mentioned you."));
+}
+
+void TabRoom::actShowPopup(const QString &message)
+{
     if (trayIcon && (tabSupervisor->currentIndex() != tabSupervisor->indexOf(this) ||
-                     QApplication::activeWindow() == 0 || QApplication::focusWidget() == 0)) {
-        disconnect(trayIcon, SIGNAL(messageClicked()), 0, 0);
-        trayIcon->showMessage(sender + tr(" mentioned you."), tr("Click to view"));
+                     QApplication::activeWindow() == nullptr || QApplication::focusWidget() == nullptr)) {
+        disconnect(trayIcon, SIGNAL(messageClicked()), nullptr, nullptr);
+        trayIcon->showMessage(message, tr("Click to view"));
         connect(trayIcon, SIGNAL(messageClicked()), chatView, SLOT(actMessageClicked()));
     }
 }

--- a/cockatrice/src/tab_room.h
+++ b/cockatrice/src/tab_room.h
@@ -76,6 +76,7 @@ private slots:
     void addMentionTag(QString mentionTag);
     void focusTab();
     void actShowMentionPopup(QString &sender);
+    void actShowPopup(const QString &message);
     void actCompleterChanged();
 
     void processListGamesEvent(const Event_ListGames &event);

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -577,8 +577,7 @@ void TabSupervisor::processUserJoined(const ServerInfo_User &userInfo)
         if (tab != currentWidget()) {
             tab->setContentsChanged(true);
             QPixmap avatarPixmap = UserLevelPixmapGenerator::generatePixmap(
-                    13, (UserLevelFlags)userInfo.user_level(), true,
-                    QString::fromStdString(userInfo.privlevel()));
+                13, (UserLevelFlags)userInfo.user_level(), true, QString::fromStdString(userInfo.privlevel()));
             setTabIcon(indexOf(tab), QPixmap(avatarPixmap));
         }
 

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -1,5 +1,6 @@
 #include "tab_supervisor.h"
 #include "abstractclient.h"
+#include "main.h"
 #include "pixmapgenerator.h"
 #include "settingscache.h"
 #include "tab_admin.h"
@@ -17,6 +18,7 @@
 #include <QDebug>
 #include <QMessageBox>
 #include <QPainter>
+#include <QSystemTrayIcon>
 
 #include "pb/event_game_joined.pb.h"
 #include "pb/event_notify_user.pb.h"
@@ -441,7 +443,7 @@ void TabSupervisor::replayLeft(TabGame *tab)
 TabMessage *TabSupervisor::addMessageTab(const QString &receiverName, bool focus)
 {
     if (receiverName == QString::fromStdString(userInfo->name()))
-        return 0;
+        return nullptr;
 
     ServerInfo_User otherUser;
     UserListTWI *twi = tabUserLists->getAllUsersList()->getUsers().value(receiverName);
@@ -561,6 +563,17 @@ void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)
     tab->processUserMessageEvent(event);
 }
 
+void TabSupervisor::actShowPopup(const QString &message)
+{
+    qDebug() << "ACT SHOW POPUP";
+    if (trayIcon && (QApplication::activeWindow() == nullptr || QApplication::focusWidget() == nullptr)) {
+        qDebug() << "LAUNCHING POPUP";
+        // disconnect(trayIcon, SIGNAL(messageClicked()), nullptr, nullptr);
+        trayIcon->showMessage(message, tr("Click to view"));
+        // connect(trayIcon, SIGNAL(messageClicked()), chatView, SLOT(actMessageClicked()));
+    }
+}
+
 void TabSupervisor::processUserLeft(const QString &userName)
 {
     TabMessage *tab = messageTabs.value(userName);
@@ -568,27 +581,29 @@ void TabSupervisor::processUserLeft(const QString &userName)
         tab->processUserLeft();
 }
 
-void TabSupervisor::processUserJoined(const ServerInfo_User &userInfo)
+void TabSupervisor::processUserJoined(const ServerInfo_User &userInfoJoined)
 {
-    QString userName = QString::fromStdString(userInfo.name());
+    QString userName = QString::fromStdString(userInfoJoined.name());
     if (isUserBuddy(userName)) {
         Tab *tab = static_cast<Tab *>(getUserListsTab());
 
         if (tab != currentWidget()) {
             tab->setContentsChanged(true);
-            QPixmap avatarPixmap = UserLevelPixmapGenerator::generatePixmap(
-                13, (UserLevelFlags)userInfo.user_level(), true, QString::fromStdString(userInfo.privlevel()));
+            QPixmap avatarPixmap =
+                UserLevelPixmapGenerator::generatePixmap(13, (UserLevelFlags)userInfoJoined.user_level(), true,
+                                                         QString::fromStdString(userInfoJoined.privlevel()));
             setTabIcon(indexOf(tab), QPixmap(avatarPixmap));
         }
 
         if (settingsCache->getBuddyConnectNotificationsEnabled()) {
             QApplication::alert(this);
+            this->actShowPopup(tr("Your buddy %1 has signed on!").arg(userName));
         }
     }
 
     TabMessage *tab = messageTabs.value(userName);
     if (tab)
-        tab->processUserJoined(userInfo);
+        tab->processUserJoined(userInfoJoined);
 }
 
 void TabSupervisor::updateCurrent(int index)

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -570,7 +570,24 @@ void TabSupervisor::processUserLeft(const QString &userName)
 
 void TabSupervisor::processUserJoined(const ServerInfo_User &userInfo)
 {
-    TabMessage *tab = messageTabs.value(QString::fromStdString(userInfo.name()));
+    QString userName = QString::fromStdString(userInfo.name());
+    if (isUserBuddy(userName)) {
+        Tab *tab = static_cast<Tab *>(getUserListsTab());
+
+        if (tab != currentWidget()) {
+            tab->setContentsChanged(true);
+            QPixmap avatarPixmap = UserLevelPixmapGenerator::generatePixmap(
+                    13, (UserLevelFlags)userInfo.user_level(), true,
+                    QString::fromStdString(userInfo.privlevel()));
+            setTabIcon(indexOf(tab), QPixmap(avatarPixmap));
+        }
+
+        if (settingsCache->getBuddyConnectNotificationsEnabled()) {
+            QApplication::alert(this);
+        }
+    }
+
+    TabMessage *tab = messageTabs.value(userName);
     if (tab)
         tab->processUserJoined(userInfo);
 }

--- a/cockatrice/src/tab_supervisor.h
+++ b/cockatrice/src/tab_supervisor.h
@@ -115,11 +115,13 @@ public:
     bool isUserBuddy(const QString &userName) const;
     bool isUserIgnored(const QString &userName) const;
     const ServerInfo_User *getOnlineUser(const QString &userName) const;
+    void actShowPopup(const QString &message);
 signals:
     void setMenu(const QList<QMenu *> &newMenuList = QList<QMenu *>());
     void localGameEnded();
     void adminLockChanged(bool lock);
     void showWindowIfHidden();
+
 public slots:
     TabDeckEditor *addDeckEditorTab(const DeckLoader *deckToOpen);
     void openReplay(GameReplay *replay);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1636

## Short roundup of the initial problem

There is no obvious visual indicator when a user in your buddy list comes online.

## What will change with this Pull Request?
- Added notification icon to tab when user in your buddy list comes online. Icon is determined using the  existing `UserLevelPixmapGenerator`.
- Added a configuration setting to optionally show a desktop notification as well.
- Split out the notification related settings to their own section in the settings page.

## Screenshots
![Screenshot from 2020-01-13 17-09-03](https://user-images.githubusercontent.com/4104460/72276820-b286ec80-3628-11ea-87a0-0d183a150237.png)
![Screenshot from 2020-01-13 17-17-48](https://user-images.githubusercontent.com/4104460/72276823-b3b81980-3628-11ea-9c21-ab3443275998.png)

