### PR TITLE
support mtgo .dek files

### DIFF
--- a/cockatrice/src/deck_loader.cpp
+++ b/cockatrice/src/deck_loader.cpp
@@ -7,7 +7,7 @@
 #include <QStringList>
 
 const QStringList DeckLoader::fileNameFilters =
-    QStringList() << QObject::tr("Common deck formats (*.cod *.dec *.txt *.mwDeck)") << QObject::tr("All files (*.*)");
+    QStringList() << QObject::tr("Common deck formats (*.cod *.dec *.dek *.txt *.mwDeck)") << QObject::tr("All files (*.*)");
 
 DeckLoader::DeckLoader() : DeckList(), lastFileName(QString()), lastFileFormat(CockatriceFormat), lastRemoteDeckId(-1)
 {

--- a/cockatrice/src/deck_loader.cpp
+++ b/cockatrice/src/deck_loader.cpp
@@ -6,8 +6,9 @@
 #include <QFile>
 #include <QStringList>
 
-const QStringList DeckLoader::fileNameFilters =
-    QStringList() << QObject::tr("Common deck formats (*.cod *.dec *.dek *.txt *.mwDeck)") << QObject::tr("All files (*.*)");
+const QStringList DeckLoader::fileNameFilters = QStringList()
+                                                << QObject::tr("Common deck formats (*.cod *.dec *.dek *.txt *.mwDeck)")
+                                                << QObject::tr("All files (*.*)");
 
 DeckLoader::DeckLoader() : DeckList(), lastFileName(QString()), lastFileFormat(CockatriceFormat), lastRemoteDeckId(-1)
 {


### PR DESCRIPTION
they use plain text internally so we just need to reveal them in the load dialog

## Related Ticket(s)
- N/A

## Short roundup of the initial problem
MTGO .dek files didnt show up in the "load deck" dialog

## What will change with this Pull Request?
- .dek files should show up in the "load deck" dialog
