### PR TITLE
Possibily fix missing languages in oracle dropdown

### DIFF
--- a/oracle/src/main.cpp
+++ b/oracle/src/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
 #elif defined(Q_OS_WIN)
     translationPath = qApp->applicationDirPath() + "/translations";
 #else // linux
-    translationPath = qApp->applicationDirPath() + "/../share/cockatrice/translations";
+    translationPath = qApp->applicationDirPath() + "/../share/oracle/translations";
 #endif
 
     settingsCache = new SettingsCache;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3817

## Short roundup of the initial problem
Under linux, oracle was trying to pick up translations files from cockatrice's translation directory

## What will change with this Pull Request?
Oracle will pick up translations from its own directory
