### PR TITLE
Fix dynamic loading of openssl libraries on windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,7 +42,7 @@ environment:
 
 install:
     - cd C:\Tools\vcpkg
-    - git pull
+    - git pull -q
     - .\bootstrap-vcpkg.bat
     - cd %APPVEYOR_BUILD_FOLDER%
     - vcpkg remove --outdated --recurse

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,6 +41,7 @@ environment:
           vcpkg_arch: x86
 
 install:
+    - cd C:\Tools\vcpkg && .\bootstrap-vcpkg.bat
     - cd C:\Tools\vcpkg && git pull -q
     - vcpkg remove --outdated --recurse
     - vcpkg install openssl protobuf liblzma zlib --triplet %vcpkg_arch%-windows

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,8 +23,8 @@ clone_depth: 15
 
 image: Visual Studio 2017
 
-# cache:
-#    - c:\Tools\vcpkg\installed
+cache:
+    - c:\Tools\vcpkg\installed
 
 environment:
     matrix:
@@ -41,6 +41,7 @@ environment:
           vcpkg_arch: x86
 
 install:
+    - cd C:\Tools\vcpkg && git pull -q
     - vcpkg remove --outdated --recurse
     - vcpkg install openssl protobuf liblzma zlib --triplet %vcpkg_arch%-windows
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,8 +23,8 @@ clone_depth: 15
 
 image: Visual Studio 2017
 
-cache:
-    - c:\Tools\vcpkg\installed
+# cache:
+#    - c:\Tools\vcpkg\installed
 
 environment:
     matrix:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,8 +41,10 @@ environment:
           vcpkg_arch: x86
 
 install:
-    - cd C:\Tools\vcpkg && .\bootstrap-vcpkg.bat
-    - cd C:\Tools\vcpkg && git pull -q
+    - cd C:\Tools\vcpkg
+    - git pull
+    - .\bootstrap-vcpkg.bat
+    - cd %APPVEYOR_BUILD_FOLDER%
     - vcpkg remove --outdated --recurse
     - vcpkg install openssl protobuf liblzma zlib --triplet %vcpkg_arch%-windows
 

--- a/cmake/FindWin32SslRuntime.cmake
+++ b/cmake/FindWin32SslRuntime.cmake
@@ -52,8 +52,8 @@ set(_OPENSSL_ROOT_HINTS_AND_PATHS
 
 # For OpenSSL < 1.1, they are named libeay32 and ssleay32 and even if the dll is 64bit, it's still suffixed as *32.dll
 # For OpenSSL >= 1.1, they are named libcrypto and libssl with no suffix
-FIND_FILE(WIN32SSLRUNTIME_LIBEAY NAMES libeay32.dll libcrypto.dll ${_OPENSSL_ROOT_HINTS_AND_PATHS})
-FIND_FILE(WIN32SSLRUNTIME_SSLEAY NAMES ssleay32.dll libssl.dll ${_OPENSSL_ROOT_HINTS_AND_PATHS})
+FIND_FILE(WIN32SSLRUNTIME_LIBEAY NAMES libcrypto-1_1.dll libcrypto.dll libeay32.dll ${_OPENSSL_ROOT_HINTS_AND_PATHS})
+FIND_FILE(WIN32SSLRUNTIME_SSLEAY NAMES libssl-1_1.dll libssl.dll ssleay32.dll${_OPENSSL_ROOT_HINTS_AND_PATHS})
 
 
 IF(WIN32SSLRUNTIME_LIBEAY AND WIN32SSLRUNTIME_SSLEAY)

--- a/cmake/FindWin32SslRuntime.cmake
+++ b/cmake/FindWin32SslRuntime.cmake
@@ -53,7 +53,7 @@ set(_OPENSSL_ROOT_HINTS_AND_PATHS
 # For OpenSSL < 1.1, they are named libeay32 and ssleay32 and even if the dll is 64bit, it's still suffixed as *32.dll
 # For OpenSSL >= 1.1, they are named libcrypto and libssl with no suffix
 FIND_FILE(WIN32SSLRUNTIME_LIBEAY NAMES libcrypto-1_1.dll libcrypto.dll libeay32.dll ${_OPENSSL_ROOT_HINTS_AND_PATHS})
-FIND_FILE(WIN32SSLRUNTIME_SSLEAY NAMES libssl-1_1.dll libssl.dll ssleay32.dll${_OPENSSL_ROOT_HINTS_AND_PATHS})
+FIND_FILE(WIN32SSLRUNTIME_SSLEAY NAMES libssl-1_1.dll libssl.dll ssleay32.dll ${_OPENSSL_ROOT_HINTS_AND_PATHS})
 
 
 IF(WIN32SSLRUNTIME_LIBEAY AND WIN32SSLRUNTIME_SSLEAY)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3910

## Short roundup of the initial problem
Since Qt 5.12.4, Qt is built linking against openssl 1.1.x, that is incompatible with the old openssl 1.0.x.
Appveyor builds are now using Qt 5.12.6, but the openssl version available in vcpkg is still the old 1.0.2.

## What will change with this Pull Request?
A forced update of vcpkg is made before compiling cockatrice.
Also, the cmake script that looks for the openssl's dlls has been updated with the names used by openssl libraries when installed by vcpkg.

