### PR TITLE
Make travis builds on fedora 31, debian 10 and arch

### DIFF
--- a/.ci/ArchLinux/Dockerfile
+++ b/.ci/ArchLinux/Dockerfile
@@ -1,0 +1,12 @@
+from archlinux:latest
+
+RUN pacman --sync --refresh --sysupgrade --needed \
+    base-devel \
+    cmake \
+    git \
+    protobuf \
+    qt5-base \
+    qt5-multimedia \
+    qt5-svg \
+    qt5-tools \
+    qt5-websockets

--- a/.ci/ArchLinux/Dockerfile
+++ b/.ci/ArchLinux/Dockerfile
@@ -1,12 +1,13 @@
 from archlinux:latest
 
-RUN pacman --sync --refresh --sysupgrade --needed \
-    base-devel \
-    cmake \
-    git \
-    protobuf \
-    qt5-base \
-    qt5-multimedia \
-    qt5-svg \
-    qt5-tools \
-    qt5-websockets
+RUN pacman --sync --refresh --sysupgrade --needed --noconfirm \
+        base-devel \
+        ccache \
+        cmake \
+        protobuf \
+        qt5-base \
+        qt5-multimedia \
+        qt5-svg \
+        qt5-tools \
+        qt5-websockets \
+    && pacman --sync --clean --clean --noconfirm

--- a/.ci/ArchLinux/Dockerfile
+++ b/.ci/ArchLinux/Dockerfile
@@ -4,6 +4,7 @@ RUN pacman --sync --refresh --sysupgrade --needed --noconfirm \
         base-devel \
         ccache \
         cmake \
+        git \
         protobuf \
         qt5-base \
         qt5-multimedia \

--- a/.ci/DebianBuster/Dockerfile
+++ b/.ci/DebianBuster/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:buster
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        clang-format \
+        file \
+        g++ \
+        git \
+        ccache \
+        cmake \
+        liblzma-dev \
+        libprotobuf-dev \
+        libqt5multimedia5-plugins \
+        libqt5svg5-dev \
+        libqt5sql5-mysql \
+        libqt5websockets5-dev \
+        protobuf-compiler \
+        qt5-default \
+        qtbase5-dev \
+        qttools5-dev-tools \
+        qtmultimedia5-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/.ci/DebianBuster/Dockerfile
+++ b/.ci/DebianBuster/Dockerfile
@@ -2,21 +2,22 @@ FROM debian:buster
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
+        ccache \
         clang-format \
+        cmake \
         file \
         g++ \
-        ccache \
-        cmake \
+        git \
         liblzma-dev \
         libprotobuf-dev \
         libqt5multimedia5-plugins \
-        libqt5svg5-dev \
         libqt5sql5-mysql \
+        libqt5svg5-dev \
         libqt5websockets5-dev \
         protobuf-compiler \
         qt5-default \
         qtbase5-dev \
-        qttools5-dev-tools \
         qtmultimedia5-dev \
+        qttools5-dev-tools \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/.ci/DebianBuster/Dockerfile
+++ b/.ci/DebianBuster/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         clang-format \
         file \
         g++ \
-        git \
         ccache \
         cmake \
         liblzma-dev \

--- a/.ci/Fedora31/Dockerfile
+++ b/.ci/Fedora31/Dockerfile
@@ -1,0 +1,19 @@
+FROM fedora:31
+
+RUN dnf install -y \
+        @development-tools \
+        ccache \
+        cmake \
+        desktop-file-utils \
+        file \
+        gcc-c++ \
+        hicolor-icon-theme \
+        libappstream-glib \
+        protobuf-devel \
+        qt5-{qttools,qtsvg,qtmultimedia,qtwebsockets}-devel \
+        rpm-build \
+        sqlite-devel \
+        wget \
+        zlib-devel \
+        xz-devel \
+    && dnf clean all

--- a/.ci/Fedora31/Dockerfile
+++ b/.ci/Fedora31/Dockerfile
@@ -7,6 +7,7 @@ RUN dnf install -y \
         desktop-file-utils \
         file \
         gcc-c++ \
+        git \
         hicolor-icon-theme \
         libappstream-glib \
         protobuf-devel \
@@ -14,6 +15,6 @@ RUN dnf install -y \
         rpm-build \
         sqlite-devel \
         wget \
-        zlib-devel \
         xz-devel \
+        zlib-devel \
     && dnf clean all

--- a/.ci/UbuntuBionic/Dockerfile
+++ b/.ci/UbuntuBionic/Dockerfile
@@ -2,21 +2,22 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
+        ccache \
         clang-format \
+        cmake \
         file \
         g++ \
-        ccache \
-        cmake \
+        git \
         liblzma-dev \
         libprotobuf-dev \
         libqt5multimedia5-plugins \
-        libqt5svg5-dev \
         libqt5sql5-mysql \
+        libqt5svg5-dev \
         libqt5websockets5-dev \
         protobuf-compiler \
         qt5-default \
+        qtmultimedia5-dev \
         qttools5-dev \
         qttools5-dev-tools \
-        qtmultimedia5-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/.ci/UbuntuBionic/Dockerfile
+++ b/.ci/UbuntuBionic/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         clang-format \
         file \
         g++ \
-        git \
         ccache \
         cmake \
         liblzma-dev \

--- a/.ci/UbuntuBionic/Dockerfile
+++ b/.ci/UbuntuBionic/Dockerfile
@@ -19,4 +19,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         qttools5-dev \
         qttools5-dev-tools \
         qtmultimedia5-dev \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/.ci/travis-compile.sh
+++ b/.ci/travis-compile.sh
@@ -68,6 +68,10 @@ set -e
 mkdir -p build
 cd build
 
+if ! [[ $CORE_AMOUNT ]]; then
+  CORE_AMOUNT="2" # travis machines have 2 cores
+fi
+
 # Add cmake flags
 if [[ $MAKE_SERVER ]]; then
   flags+=" -DWITH_SERVER=1"
@@ -92,7 +96,7 @@ fi
 # Compile
 cmake --version
 cmake .. $flags
-make -j2
+make -j"$CORE_AMOUNT"
 
 if [[ $MAKE_TEST ]]; then
   make test
@@ -105,9 +109,9 @@ fi
 if [[ $MAKE_PACKAGE ]]; then
   make package
   if [[ $PACKAGE_NAME ]]; then
-    found=$(find . -maxdepth 1 -type f -name "Cockatrice-*.*" -print -quit)
-    path=${found%/*}
-    file=${found##*/}
+    found="$(find . -maxdepth 1 -type f -name "Cockatrice-*.*" -print -quit)"
+    path="${found%/*}"
+    file="${found##*/}"
     if [[ ! $file ]]; then
       echo "could not find package" >&2
       exit 1

--- a/.ci/travis-docker.sh
+++ b/.ci/travis-docker.sh
@@ -68,11 +68,13 @@ if ! [[ -d $CACHE ]]; then
   echo "could not find cache dir: $CACHE" >&2
   unset CACHE
 else
-  img_dir="$CACHE/$image_cache"
-  img_save="$img_dir/$IMAGE_NAME$save_extension"
-  if ! [[ -d $img_dir ]]; then
-    echo "could not find image dir: $img_dir" >&2
-    mkdir -p "$img_dir"
+  if [[ $GET || $SAVE ]]; then
+    img_dir="$CACHE/$image_cache"
+    img_save="$img_dir/$IMAGE_NAME$save_extension"
+    if ! [[ -d $img_dir ]]; then
+      echo "could not find image dir: $img_dir" >&2
+      mkdir -p "$img_dir"
+    fi
   fi
   export CCACHE_DIR="$CACHE/$ccache_cache"
   if ! [[ -d $CCACHE_DIR ]]; then

--- a/.ci/travis-docker.sh
+++ b/.ci/travis-docker.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+# This script is to be sourced in .travis.yaml from the project root directory, do not use it from somewhere else.
+# Creates or loads docker images to use in compilation, creates RUN function to start compilation on the docker image.
+# --get loads the image from a previously saved image cache, will build if no image is found
+# --build builds the image from the Dockerfile in .ci/$NAME
+# --save stores the image, if an image was loaded it will not be stored
+# requires: docker
+# uses env: NAME CACHE BUILD GET SAVE (correspond to args: <name> --set-cache <cache> --build --get --save)
+# sets env: RUN CCACHE_DIR IMAGE_NAME RUN_ARGS RUN_OPTS BUILD_SCRIPT
+# exitcode: 1 for failure, 2 for missing dockerfile, 3 for invalid arguments
+export BUILD_SCRIPT=".ci/travis-compile.sh"
+
+project_name="cockatrice"
+save_extension=".tar.gz"
+image_cache="image"
+ccache_cache=".ccache"
+
+# Read arguments
+while [[ "$@" ]]; do
+  case "$1" in
+    '--build')
+      BUILD=1
+      shift
+      ;;
+    '--get')
+      GET=1
+      shift
+      ;;
+    '--save')
+      SAVE=1
+      shift
+      ;;
+    '--set-cache')
+      CACHE=$2
+      if ! [[ -d $CACHE ]]; then
+        echo "could not find cache path: $CACHE" >&2
+        exit 3
+      fi
+      shift 2
+      ;;
+    *)
+      if [[ $1 == -* ]]; then
+        echo "unrecognized option: $1"
+        return 3
+      fi
+      NAME="$1"
+      shift
+      ;;
+  esac
+done
+
+# Setup
+if ! [[ $NAME ]]; then
+  echo "no build name given" >&2
+  return 3
+fi
+
+export IMAGE_NAME="${project_name,,}_${NAME,,}"
+
+docker_dir=".ci/$NAME"
+if ! [[ -r $docker_dir/Dockerfile ]]; then
+  echo "could not find Dockerfile in $docker_dir" >&2
+  return 2 # even if the image is cached, we do not want to run if there is no way to build this image
+fi
+
+if ! [[ -d $CACHE ]]; then
+  echo "could not find cache dir: $CACHE" >&2
+  unset CACHE
+else
+  img_dir="$CACHE/$image_cache"
+  img_save="$img_dir/$IMAGE_NAME$save_extension"
+  if ! [[ -d $img_dir ]]; then
+    echo "could not find image dir: $img_dir" >&2
+    mkdir -p "$img_dir"
+  fi
+  export CCACHE_DIR="$CACHE/$ccache_cache"
+  if ! [[ -d $CCACHE_DIR ]]; then
+    echo "could not find ccache dir: $CCACHE_DIR" >&2
+    mkdir -p "$CCACHE_DIR"
+  fi
+fi
+
+
+# Get the docker image from previously stored save
+if [[ $GET ]]; then
+  if [[ $img_save ]] && docker load --input "$img_save"; then
+    echo "loaded image"
+    docker images
+    unset BUILD # do not overwrite the loaded image with build
+    unset SAVE # do not overwrite the stored image with the same image
+    if [[ $(find "$CCACHE_DIR" -type f -print -quit) ]]; then # check contents of ccache
+      echo "setting ccache to readonly"
+      export RUN_ARGS="$RUN_ARGS -e CCACHE_READONLY=1 -e CCACHE_NOSTATS=1" # do not overwrite ccache
+    else
+      echo "ccache is empty: $(find "$CCACHE_DIR")" >&2
+    fi
+  else
+    echo "could not load cached image, building instead" >&2
+    BUILD=1
+  fi
+fi
+
+# Build the docker image from dockerfile
+if [[ $BUILD ]]; then
+  if docker build --tag "$IMAGE_NAME" "$docker_dir"; then
+    echo "built image"
+    docker images
+  else
+    echo "could not build image $IMAGE_NAME" >&2
+    return 1
+  fi
+fi
+
+# Save docker image to cache (compressed)
+if [[ $SAVE ]]; then
+  if [[ $img_save ]] && docker save --output "$img_save" "$IMAGE_NAME"; then
+    echo "saved image to: $img_save"
+  else
+    echo "could not save image $IMAGE_NAME" >&2
+  fi
+fi
+
+# Set compile function, runs the compile script on the image, passes arguments to the script
+function RUN ()
+{
+  echo "running image:"
+  if docker images | grep "$IMAGE_NAME"; then
+    args="--mount type=bind,source=$(pwd),target=/src -w=/src"
+    if [[ $CCACHE_DIR ]]; then
+      args+=" --mount type=bind,source=$CCACHE_DIR,target=/.ccache -e CCACHE_DIR=/.ccache"
+    fi
+    docker run $args $RUN_ARGS "$IMAGE_NAME" bash "$BUILD_SCRIPT" $RUN_OPTS $@
+    return $?
+  else
+    echo "could not find docker image: $IMAGE_NAME" >&2
+    return 3
+  fi
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,31 @@ jobs:
     script: RUN --server --package $NAME --release
 
 
+  #Debian Buster (on Docker)
+  - name: Debian Buster (Compile)
+    if: tag IS NOT present
+    os: linux
+    services: docker
+    language: minimal
+    env: NAME=DebianBuster CACHE=$HOME/$NAME
+    cache:
+      directories:
+      - $CACHE
+    before_install: source .ci/travis-docker.sh --build
+    script: RUN --server
+
+  - name: Debian Buster (Release)
+    if: (branch = master AND NOT type = pull_request) OR tag IS present
+    os: linux
+    services: docker
+    language: minimal
+    env: NAME=DebianBuster CACHE=$HOME/$NAME
+    cache:
+      directories:
+      - $CACHE
+    before_install: source .ci/travis-docker.sh --build
+    script: RUN --server --package $NAME --release
+
   #macOS High Sierra
   - name: macOS High Sierra (Debug)
     if: tag IS NOT present

--- a/.travis.yml
+++ b/.travis.yml
@@ -177,6 +177,24 @@ jobs:
     - brew cleanup
 
 
+  #Arch Linux (on Docker)
+  - name: Arch Linux (Debug, Optional)
+    if: tag IS NOT present
+    os: linux
+    services: docker
+    language: minimal
+    env: NAME=ArchLinux CACHE=$HOME/$NAME
+    cache:
+      directories:
+      - $CACHE
+    before_install: source .ci/travis-docker.sh --build
+    script: RUN --server --debug
+
+  allow_failures:
+  - name: Arch Linux (Debug, Optional)
+  fast_finish: true
+
+
 # Builds for pull requests skip the deployment step altogether
 deploy:
 # Deploy configuration for "beta" releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,31 @@ jobs:
     before_install: source .ci/travis-docker.sh --build
     script: RUN --server --package $NAME --release
 
+
+  #Fedora 31 (on docker)
+  - name: Fedora 31 (Compile)
+    if: tag IS NOT present
+    services: docker
+    language: minimal
+    env: NAME=Fedora31 CACHE=$HOME/$NAME
+    cache:
+      directories:
+      - $CACHE
+    before_install: source .ci/travis-docker.sh --build
+    script: RUN --server
+
+  - name: Fedora 31 (Release)
+    if: (branch = master AND NOT type = pull_request) OR tag IS present
+    services: docker
+    language: minimal
+    env: NAME=Fedora31 CACHE=$HOME/$NAME
+    cache:
+      directories:
+      - $CACHE
+    before_install: source .ci/travis-docker.sh --build
+    script: RUN --server --package $NAME RPM --release
+
+
   #macOS High Sierra
   - name: macOS High Sierra (Debug)
     if: tag IS NOT present

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 os: linux
+dist: bionic
 language: cpp
 compiler: gcc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -177,8 +177,8 @@ jobs:
     - brew cleanup
 
 
-  #Arch Linux (on Docker)
-  - name: Arch Linux (Debug, Optional)
+  #Arch Linux (on Docker) (allow failures)
+  - name: Arch Linux (Debug)
     if: tag IS NOT present
     os: linux
     services: docker
@@ -191,7 +191,9 @@ jobs:
     script: RUN --server --debug
 
   allow_failures:
-  - name: Arch Linux (Debug, Optional)
+  # Arch linux is always the latest version and by definition not stable
+  - name: Arch Linux (Debug)
+  # Report build completion even if optional builds are not completed
   fast_finish: true
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,29 +21,25 @@ jobs:
     if: tag IS NOT present
     os: linux
     services: docker
-    env: NAME=UbuntuBionic
+    language: minimal
+    env: NAME=UbuntuBionic CACHE=$HOME/$NAME
     cache:
       directories:
-      - $HOME/$NAME/
-    before_install: docker build -t "cockatrice_${NAME,,}" .ci/$NAME && mkdir -p $HOME/$NAME/.ccache
-    script: docker run --mount "type=bind,source=$(pwd),target=/src" -w="/src"
-          --mount "type=bind,source=$HOME/$NAME/.ccache,target=/.ccache" -e "CCACHE_DIR=/.ccache"
-          "cockatrice_${NAME,,}"
-          bash .ci/travis-compile.sh --server --test --debug
+      - $CACHE
+    before_install: source .ci/travis-docker.sh --build
+    script: RUN --server --test --debug
 
   - name: Ubuntu Bionic (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present
     os: linux
     services: docker
-    env: NAME=UbuntuBionic
+    language: minimal
+    env: NAME=UbuntuBionic CACHE=$HOME/$NAME
     cache:
       directories:
-      - $HOME/$NAME/
-    before_install: docker build -t "cockatrice_${NAME,,}" .ci/$NAME && mkdir -p $HOME/$NAME/.ccache
-    script: docker run --mount "type=bind,source=$(pwd),target=/src" -w="/src"
-          --mount "type=bind,source=$HOME/$NAME/.ccache,target=/.ccache" -e "CCACHE_DIR=/.ccache"
-          "cockatrice_${NAME,,}"
-          bash .ci/travis-compile.sh --server --package "$NAME" --release
+      - $CACHE
+    before_install: source .ci/travis-docker.sh --build
+    script: RUN --server --package $NAME --release
 
 
   #macOS High Sierra


### PR DESCRIPTION
Because windows on travis is not working I made this instead.

Adds compile steps for building debian, fedora, and arch because we can.

That is provided they work without me testing them once.