### PR TITLE
Remove force update appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -84,7 +84,6 @@ deploy:
     release: "Cockatrice $(APPVEYOR_REPO_TAG_NAME)"
     description: "Beta release of Cockatrice"
     artifact: /.*\.exe/
-    force_update: true
     draft: false
     prerelease: true
     on:
@@ -98,7 +97,6 @@ deploy:
     tag: "$(APPVEYOR_REPO_TAG_NAME)"
     release: "Cockatrice $(APPVEYOR_REPO_TAG_NAME)"
     artifact: /.*\.exe/
-    force_update: true
     draft: false
     prerelease: false
     on:


### PR DESCRIPTION
According to https://help.appveyor.com/discussions/questions/16192-build-tag-annotation-overwritten, we don't need force_update to push the files up. This will preserve name/description of the release

## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem


## What will change with this Pull Request?
- this
- and this

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
