### PR TITLE
macOS: test a simple way to bypass apptranslocation

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -1087,12 +1087,21 @@ void MainWindow::actCheckCardUpdates()
     QDir dir = QDir(QApplication::applicationDirPath());
 
 #if defined(Q_OS_MAC)
+    /*
+     * bypass app translocation: quarantined application will be started from a temporary directory eg.
+     * /private/var/folders/tk/qx76cyb50jn5dvj7rrgfscz40000gn/T/AppTranslocation/A0CBBD5A-9264-4106-8547-36B84DB161E2/d/oracle/
+     */
+    if(dir.absolutePath().startsWith("/private/var/folders")) {
+        dir.setPath("/Applications/");
+    } else {
+        // exit from the Cockatrice application bundle
+        dir.cdUp();
+        dir.cdUp();
+        dir.cdUp();        
+    }
+
     binaryName = getCardUpdaterBinaryName();
 
-    // exit from the application bundle
-    dir.cdUp();
-    dir.cdUp();
-    dir.cdUp();
     dir.cd(binaryName + ".app");
     dir.cd("Contents");
     dir.cd("MacOS");


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3942

## Short roundup of the initial problem
Under macOS, when you download a file from the Internet, an extended attribute will be set on that file, called "com.apple.quarantine".
If the downloaded file is a dmg image (the format we ship Cockatrice) the attirbute will be set recursively on its conents.
When the user copies cockatrice and oracle to /Applications, the files will keep this attribute.
As a consequence:
 * the first time the application is started, macOS will refuse it to run because it's not signed. This is sucha  common issue that most users know how to bypass this by rightclicking on the app and choosing "open" instead of ust doubleclicking on it
 * the application will be run from a temporary "AppTranslocation" directory, something like:
```
/private/var/folders/tk/qx76cyb50jn5dvj7rrgfscz40000gn/T/AppTranslocation/A0CBBD5A-9264-4106-8547-36B84DB161E2/d/
```
Cockatrice on the first run will ask the user to run oracle to download the initial card database, but since it's being run from that temporary directory it won't be able to find oracle.
## What will change with this Pull Request?
Cockatrice will try to guess if it's being run from an AppTranslocation directory. If it does, instead of trying to run oracle from its own directory, it will run oracle from "/Applications".
