### PR TITLE
Fix #3068: Add hint text about game list filters

### DIFF
--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -290,12 +290,13 @@ void GameSelector::actSelectedGameChanged(const QModelIndex &current, const QMod
     joinButton->setEnabled(game.player_count() < game.max_players() || overrideRestrictions);
 }
 
-void GameSelector::setAlteredFiltersText(const int numAlteredFilters) {
+void GameSelector::setAlteredFiltersText(const int numAlteredFilters)
+{
     if (alteredFiltersLabel != nullptr) {
         if (numAlteredFilters == 0) {
             alteredFiltersLabel->setText(tr("Default filters applied"));
         } else {
-            alteredFiltersLabel->setText(tr("%1 filter(s) altered").arg(numAlteredFilters));
+            alteredFiltersLabel->setText(tr("%1 filter(s) applied").arg(numAlteredFilters));
         }
     }
 }

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -18,6 +18,7 @@
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QInputDialog>
+#include <QLabel>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QTreeView>
@@ -75,6 +76,7 @@ GameSelector::GameSelector(AbstractClient *_client,
     clearFilterButton->setIcon(QPixmap("theme:icons/clearsearch"));
     clearFilterButton->setEnabled(true);
     connect(clearFilterButton, SIGNAL(clicked()), this, SLOT(actClearFilter()));
+    alteredFiltersLabel = new QLabel;
 
     if (room) {
         createButton = new QPushButton;
@@ -88,6 +90,7 @@ GameSelector::GameSelector(AbstractClient *_client,
     if (showfilters) {
         buttonLayout->addWidget(filterButton);
         buttonLayout->addWidget(clearFilterButton);
+        buttonLayout->addWidget(alteredFiltersLabel);
     }
     buttonLayout->addStretch();
     if (room)
@@ -157,6 +160,8 @@ void GameSelector::actSetFilter()
     gameListProxyModel->setGameTypeFilter(dlg.getGameTypeFilter());
     gameListProxyModel->setMaxPlayersFilter(dlg.getMaxPlayersFilterMin(), dlg.getMaxPlayersFilterMax());
     gameListProxyModel->saveFilterParameters(gameTypeMap);
+
+    setAlteredFiltersText(gameListProxyModel->getNumberOfAlteredFilters());
 }
 
 void GameSelector::actClearFilter()
@@ -165,6 +170,7 @@ void GameSelector::actClearFilter()
 
     gameListProxyModel->resetFilterParameters();
     gameListProxyModel->saveFilterParameters(gameTypeMap);
+    alteredFiltersLabel->setText(tr("Filters reset to default"));
 }
 
 void GameSelector::actCreate()
@@ -259,7 +265,8 @@ void GameSelector::retranslateUi()
 {
     setTitle(tr("Games"));
     filterButton->setText(tr("&Filter games"));
-    clearFilterButton->setText(tr("C&lear filter"));
+    clearFilterButton->setText(tr("Reset fi&lters"));
+    setAlteredFiltersText(gameListProxyModel->getNumberOfAlteredFilters());
     if (createButton)
         createButton->setText(tr("C&reate"));
     joinButton->setText(tr("&Join"));
@@ -281,4 +288,14 @@ void GameSelector::actSelectedGameChanged(const QModelIndex &current, const QMod
 
     spectateButton->setEnabled(game.spectators_allowed() || overrideRestrictions);
     joinButton->setEnabled(game.player_count() < game.max_players() || overrideRestrictions);
+}
+
+void GameSelector::setAlteredFiltersText(const int numAlteredFilters) {
+    if (alteredFiltersLabel != nullptr) {
+        if (numAlteredFilters == 0) {
+            alteredFiltersLabel->setText(tr("Default filters applied"));
+        } else {
+            alteredFiltersLabel->setText(tr("%1 filter(s) altered").arg(numAlteredFilters));
+        }
+    }
 }

--- a/cockatrice/src/gameselector.h
+++ b/cockatrice/src/gameselector.h
@@ -11,6 +11,7 @@ class QTreeView;
 class GamesModel;
 class GamesProxyModel;
 class QPushButton;
+class QLabel;
 class QCheckBox;
 class AbstractClient;
 class TabSupervisor;
@@ -44,7 +45,10 @@ private:
     GamesModel *gameListModel;
     GamesProxyModel *gameListProxyModel;
     QPushButton *filterButton, *clearFilterButton, *createButton, *joinButton, *spectateButton;
+    QLabel *alteredFiltersLabel;
     GameTypeMap gameTypeMap;
+
+    void setAlteredFiltersText(int numAlteredFilters);
 
 public:
     GameSelector(AbstractClient *_client,

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -368,17 +368,36 @@ void GamesProxyModel::saveFilterParameters(const QMap<int, QString> &allGameType
     settingsCache->gameFilters().setMaxPlayers(maxPlayersFilterMax);
 }
 
-int GamesProxyModel::getNumberOfAlteredFilters() const {
+int GamesProxyModel::getNumberOfAlteredFilters() const
+{
     int numFiltersAltered = 0;
-    if (showBuddiesOnlyGames != DEFAULT_SHOW_BUDDIES_ONLY_GAMES) { numFiltersAltered++; }
-    if (hideIgnoredUserGames) { numFiltersAltered++; }
-    if (unavailableGamesVisible != DEFAULT_UNAVAILABLE_GAMES_VISIBLE) { numFiltersAltered++; }
-    if (showPasswordProtectedGames != DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES) { numFiltersAltered++; }
-    if (!gameNameFilter.isEmpty()) { numFiltersAltered++; }
-    if (!creatorNameFilter.isEmpty()) { numFiltersAltered++; }
-    if (!gameTypeFilter.isEmpty()) { numFiltersAltered++; }
-    if (maxPlayersFilterMin != -1 && maxPlayersFilterMin != 1) { numFiltersAltered++; }
-    if (maxPlayersFilterMax != -1 && maxPlayersFilterMax != DEFAULT_MAX_PLAYERS_MAX) { numFiltersAltered++; }
+    if (showBuddiesOnlyGames != DEFAULT_SHOW_BUDDIES_ONLY_GAMES) {
+        numFiltersAltered++;
+    }
+    if (hideIgnoredUserGames) {
+        numFiltersAltered++;
+    }
+    if (unavailableGamesVisible != DEFAULT_UNAVAILABLE_GAMES_VISIBLE) {
+        numFiltersAltered++;
+    }
+    if (showPasswordProtectedGames != DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES) {
+        numFiltersAltered++;
+    }
+    if (!gameNameFilter.isEmpty()) {
+        numFiltersAltered++;
+    }
+    if (!creatorNameFilter.isEmpty()) {
+        numFiltersAltered++;
+    }
+    if (!gameTypeFilter.isEmpty()) {
+        numFiltersAltered++;
+    }
+    if (maxPlayersFilterMin != -1 && maxPlayersFilterMin != 1) {
+        numFiltersAltered++;
+    }
+    if (maxPlayersFilterMax != -1 && maxPlayersFilterMax != DEFAULT_MAX_PLAYERS_MAX) {
+        numFiltersAltered++;
+    }
     return numFiltersAltered;
 }
 

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -316,9 +316,9 @@ void GamesProxyModel::setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlay
 
 void GamesProxyModel::resetFilterParameters()
 {
-    unavailableGamesVisible = false;
-    showPasswordProtectedGames = true;
-    showBuddiesOnlyGames = true;
+    unavailableGamesVisible = DEFAULT_UNAVAILABLE_GAMES_VISIBLE;
+    showPasswordProtectedGames = DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES;
+    showBuddiesOnlyGames = DEFAULT_SHOW_BUDDIES_ONLY_GAMES;
     gameNameFilter = QString();
     creatorNameFilter = QString();
     gameTypeFilter.clear();
@@ -366,6 +366,20 @@ void GamesProxyModel::saveFilterParameters(const QMap<int, QString> &allGameType
 
     settingsCache->gameFilters().setMinPlayers(maxPlayersFilterMin);
     settingsCache->gameFilters().setMaxPlayers(maxPlayersFilterMax);
+}
+
+int GamesProxyModel::getNumberOfAlteredFilters() const {
+    int numFiltersAltered = 0;
+    if (showBuddiesOnlyGames != DEFAULT_SHOW_BUDDIES_ONLY_GAMES) { numFiltersAltered++; }
+    if (hideIgnoredUserGames) { numFiltersAltered++; }
+    if (unavailableGamesVisible != DEFAULT_UNAVAILABLE_GAMES_VISIBLE) { numFiltersAltered++; }
+    if (showPasswordProtectedGames != DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES) { numFiltersAltered++; }
+    if (!gameNameFilter.isEmpty()) { numFiltersAltered++; }
+    if (!creatorNameFilter.isEmpty()) { numFiltersAltered++; }
+    if (!gameTypeFilter.isEmpty()) { numFiltersAltered++; }
+    if (maxPlayersFilterMin != -1 && maxPlayersFilterMin != 1) { numFiltersAltered++; }
+    if (maxPlayersFilterMax != -1 && maxPlayersFilterMax != DEFAULT_MAX_PLAYERS_MAX) { numFiltersAltered++; }
+    return numFiltersAltered;
 }
 
 bool GamesProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex & /*sourceParent*/) const

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -77,6 +77,9 @@ private:
     int maxPlayersFilterMin, maxPlayersFilterMax;
 
     static const int DEFAULT_MAX_PLAYERS_MAX = 99;
+    static const bool DEFAULT_UNAVAILABLE_GAMES_VISIBLE = false;
+    static const bool DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES = true;
+    static const bool DEFAULT_SHOW_BUDDIES_ONLY_GAMES = true;
 
 public:
     GamesProxyModel(QObject *parent = nullptr, const TabSupervisor *_tabSupervisor = nullptr);
@@ -128,6 +131,7 @@ public:
     void resetFilterParameters();
     void loadFilterParameters(const QMap<int, QString> &allGameTypes);
     void saveFilterParameters(const QMap<int, QString> &allGameTypes);
+    int getNumberOfAlteredFilters() const;
     void refresh();
 
 protected:


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3068 

## Short roundup of the initial problem
Cockatrice remembers filters applied between sessions, but users were not alerted if any filters were altered from their default values. 

## What will change with this Pull Request?
- Display hint text next to former "Clear filters" button, indicating either that default filters are applied or that filters have been altered from default values.
- Rename "Clear filters" to "Reset filters", but keep 'l' as the hotkey. This seems like a more accurate name, as we're not actually clearing all filters (for example, "show password protected games" is true by default and therefore checked in the UI).

## Screenshots

Hint text on initial load, assuming filters are set to default:

<img width="981" alt="default-start" src="https://user-images.githubusercontent.com/63179146/78629507-53bac300-7865-11ea-8047-be9741c7bd6c.png">

Hint text after altering filters:

<img width="992" alt="applied" src="https://user-images.githubusercontent.com/63179146/78629515-561d1d00-7865-11ea-9a3e-1d398ac646d5.png">

Hint text after resetting filters:

<img width="990" alt="reset" src="https://user-images.githubusercontent.com/63179146/78629519-57e6e080-7865-11ea-8b05-056b0ed99847.png">
