### PR TITLE
Add ability to filter games older than 2 hours

### DIFF
--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -29,6 +29,9 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     hideIgnoredUserGames = new QCheckBox(tr("Hide '&ignored user' games"));
     hideIgnoredUserGames->setChecked(gamesProxyModel->getHideIgnoredUserGames());
 
+    hideOldGames = new QCheckBox(tr("Hide games &older than 2 hours"));
+    hideOldGames->setChecked(gamesProxyModel->getHideOldGames());
+
     gameNameFilterEdit = new QLineEdit;
     gameNameFilterEdit->setText(gamesProxyModel->getGameNameFilter());
     QLabel *gameNameFilterLabel = new QLabel(tr("Game &description:"));
@@ -92,6 +95,7 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     restrictionsLayout->addWidget(showPasswordProtectedGames, 1, 0);
     restrictionsLayout->addWidget(showBuddiesOnlyGames, 2, 0);
     restrictionsLayout->addWidget(hideIgnoredUserGames, 3, 0);
+    restrictionsLayout->addWidget(hideOldGames, 4, 0);
 
     QGroupBox *restrictionsGroupBox = new QGroupBox(tr("Restrictions"));
     restrictionsGroupBox->setLayout(restrictionsLayout);
@@ -167,6 +171,16 @@ bool DlgFilterGames::getHideIgnoredUserGames() const
 void DlgFilterGames::setHideIgnoredUserGames(bool _hideIgnoredUserGames)
 {
     hideIgnoredUserGames->setChecked(_hideIgnoredUserGames);
+}
+
+bool DlgFilterGames::getHideOldGames() const
+{
+    return hideOldGames->isChecked();
+}
+
+void DlgFilterGames::setHideOldGames(bool _hideOldGames)
+{
+    hideOldGames->setChecked(_hideOldGames);
 }
 
 QString DlgFilterGames::getGameNameFilter() const

--- a/cockatrice/src/dlg_filter_games.h
+++ b/cockatrice/src/dlg_filter_games.h
@@ -22,6 +22,7 @@ private:
     QCheckBox *unavailableGamesVisibleCheckBox;
     QCheckBox *showPasswordProtectedGames;
     QCheckBox *hideIgnoredUserGames;
+    QCheckBox *hideOldGames;
     QLineEdit *gameNameFilterEdit;
     QLineEdit *creatorNameFilterEdit;
     QMap<int, QCheckBox *> gameTypeFilterCheckBoxes;
@@ -47,6 +48,8 @@ public:
     void setShowBuddiesOnlyGames(bool _showBuddiesOnlyGames);
     bool getHideIgnoredUserGames() const;
     void setHideIgnoredUserGames(bool _hideIgnoredUserGames);
+    bool getHideOldGames() const;
+    void setHideOldGames(bool _hideIgnoredUserGames);
     QString getGameNameFilter() const;
     void setGameNameFilter(const QString &_gameNameFilter);
     QString getCreatorNameFilter() const;

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -155,6 +155,7 @@ void GameSelector::actSetFilter()
     gameListProxyModel->setUnavailableGamesVisible(dlg.getUnavailableGamesVisible());
     gameListProxyModel->setShowPasswordProtectedGames(dlg.getShowPasswordProtectedGames());
     gameListProxyModel->setHideIgnoredUserGames(dlg.getHideIgnoredUserGames());
+    gameListProxyModel->setHideOldGames(dlg.getHideOldGames());
     gameListProxyModel->setGameNameFilter(dlg.getGameNameFilter());
     gameListProxyModel->setCreatorNameFilter(dlg.getCreatorNameFilter());
     gameListProxyModel->setGameTypeFilter(dlg.getGameTypeFilter());

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -72,14 +72,18 @@ private:
     bool hideIgnoredUserGames;
     bool unavailableGamesVisible;
     bool showPasswordProtectedGames;
+    bool hideOldGames;
     QString gameNameFilter, creatorNameFilter;
     QSet<int> gameTypeFilter;
     int maxPlayersFilterMin, maxPlayersFilterMax;
+
+    static const int OLD_GAME_CUTOFF_SECONDS = 2 * 60 * 60;  // 2 hours
 
     static const int DEFAULT_MAX_PLAYERS_MAX = 99;
     static const bool DEFAULT_UNAVAILABLE_GAMES_VISIBLE = false;
     static const bool DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES = true;
     static const bool DEFAULT_SHOW_BUDDIES_ONLY_GAMES = true;
+    static const bool DEFAULT_HIDE_OLD_GAMES = false;
 
 public:
     GamesProxyModel(QObject *parent = nullptr, const TabSupervisor *_tabSupervisor = nullptr);
@@ -104,6 +108,10 @@ public:
         return showPasswordProtectedGames;
     }
     void setShowPasswordProtectedGames(bool _showPasswordProtectedGames);
+    bool getHideOldGames() const {
+        return hideOldGames;
+    }
+    void setHideOldGames(bool _hideOldGames);
     QString getGameNameFilter() const
     {
         return gameNameFilter;

--- a/cockatrice/src/settings/gamefilterssettings.cpp
+++ b/cockatrice/src/settings/gamefilterssettings.cpp
@@ -60,6 +60,17 @@ bool GameFiltersSettings::isHideIgnoredUserGames()
     return previous == QVariant() ? false : previous.toBool();
 }
 
+void GameFiltersSettings::setHideOldGames(bool hide)
+{
+    setValue(hide, "hide_old_games", "filter_games");
+}
+
+bool GameFiltersSettings::isHideOldGames()
+{
+    QVariant previous = getValue("hide_old_games", "filter_games");
+    return previous == QVariant() ? false : previous.toBool();
+}
+
 void GameFiltersSettings::setGameNameFilter(QString gameName)
 {
     setValue(gameName, "game_name_filter", "filter_games");

--- a/cockatrice/src/settings/gamefilterssettings.h
+++ b/cockatrice/src/settings/gamefilterssettings.h
@@ -13,6 +13,7 @@ public:
     bool isUnavailableGamesVisible();
     bool isShowPasswordProtectedGames();
     bool isHideIgnoredUserGames();
+    bool isHideOldGames();
     QString getGameNameFilter();
     int getMinPlayers();
     int getMaxPlayers();
@@ -22,6 +23,7 @@ public:
     void setHideIgnoredUserGames(bool hide);
     void setUnavailableGamesVisible(bool enabled);
     void setShowPasswordProtectedGames(bool show);
+    void setHideOldGames(bool hide);
     void setGameNameFilter(QString gameName);
     void setMinPlayers(int min);
     void setMaxPlayers(int max);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3067

## Short roundup of the initial problem
Users want to filter out old games. Starting with 2 hours per https://github.com/Cockatrice/Cockatrice/issues/3067#issuecomment-362580744.

## What will change with this Pull Request?
Ability to filter out old games (where "old" == "started more than 2 hours ago") is added to game filtering.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
