### PR TITLE
Minor fixes to some std::sort calls

### DIFF
--- a/cockatrice/src/window_sets.cpp
+++ b/cockatrice/src/window_sets.cpp
@@ -364,7 +364,7 @@ void WndSets::actDown()
 {
     QModelIndexList rows = view->selectionModel()->selectedRows();
     // QModelIndex only implements operator<, so we can't use std::greater
-    std::sort(rows.begin(), rows.end(), [](const QModelIndex &a, const QModelIndex &b) { return !(b < a); });
+    std::sort(rows.begin(), rows.end(), [](const QModelIndex &a, const QModelIndex &b) { return b < a; });
     QSet<int> newRows;
 
     if (rows.empty())
@@ -412,7 +412,7 @@ void WndSets::actBottom()
 {
     QModelIndexList rows = view->selectionModel()->selectedRows();
     // QModelIndex only implements operator<, so we can't use std::greater
-    std::sort(rows.begin(), rows.end(), [](const QModelIndex &a, const QModelIndex &b) { return !(b < a); });
+    std::sort(rows.begin(), rows.end(), [](const QModelIndex &a, const QModelIndex &b) { return b < a; });
     QSet<int> newRows;
     int newRow = model->rowCount() - 1;
 

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -254,7 +254,7 @@ public:
     }
     inline bool operator()(QPair<int, AbstractDecklistNode *> a, QPair<int, AbstractDecklistNode *> b) const
     {
-        return (order == Qt::AscendingOrder) ^ (a.second->compare(b.second));
+        return (order == Qt::AscendingOrder) ? (b.second->compare(a.second)) : (a.second->compare(b.second));
     }
 };
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3903 and #3834
- Fix a very minor regression introduced by commit b6df5a4ac36602e0bebb048d3831a37984300e94 preventing the manage sets dialog from moving down multiple sets correctly (and which apparently went under the radar)

## Short roundup of the initial problem

A few (3) calls to std::sort fed it a non-strict comparison operator. However, the standard requires the comparison to be strict. Depending on the standard library with which Cockatrice was compiled, those calls were prone to crashes (e.g. on Mac OSX with apple clang and libc++).
Two of these comparison operators were also incorrectly reversed (causing a minor bug in the manage sets dialog, c.f. screenshots for an example).

## What will change with this Pull Request?
- Loading some specific decks on OSX (and possibly other platforms) doesn't crash anymore (c.f. #3903 or #3834 for examples)
- Selecting multiple sets in the manage sets dialog and clicking on either "move down" or "move to bottom" now behaves correctly.

## Screenshots
example of the manage sets bug:
![movedownscramble](https://user-images.githubusercontent.com/8961335/80103497-39bef700-856c-11ea-8ac5-fdc7d33a339f.png)
Clicking on "move down" with the second and third row selected swapped the 2nd and 3rd row, then the 3rd and 4th row (and added the 3rd row to the selection) instead of swapping the 3rd and 4th row before swapping the 2nd and 3rd row.
