### PR TITLE
prevent the checkboxes' labels from being clipped in settings

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -87,9 +87,9 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(&updateReleaseChannelBox, 1, 1);
     personalGrid->addWidget(&pixmapCacheLabel, 2, 0);
     personalGrid->addWidget(&pixmapCacheEdit, 2, 1);
-    personalGrid->addWidget(&updateNotificationCheckBox, 3, 0);
-    personalGrid->addWidget(&newVersionOracleCheckBox, 4, 0);
-    personalGrid->addWidget(&showTipsOnStartup, 5, 0);
+    personalGrid->addWidget(&updateNotificationCheckBox, 3, 0, 1, 2);
+    personalGrid->addWidget(&newVersionOracleCheckBox, 4, 0, 1, 2);
+    personalGrid->addWidget(&showTipsOnStartup, 5, 0, 1, 2);
 
     personalGroupBox = new QGroupBox;
     personalGroupBox->setLayout(personalGrid);


### PR DESCRIPTION
## Related Ticket(s)
Fixes #3950

## Short roundup of the initial problem
On OSX, the checkboxes' labels could sometimes be cut short when resizing the settings' window (c.f. #3950 for screenshots). The problem didn't seem to appear on Windows due to smaller font sizes.

## What will change with this Pull Request?
The checkboxes now span the two columns of the grid layout rather than a single one, allowing them to extend beneath the comboboxes on the right. This also makes the settings' window slightly less wide.