### PR TITLE
Some improvements to Servatice network code

### DIFF
--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -29,7 +29,7 @@ port=4747
 ; Set to 0 to disable the tcp server.
 number_pools=1
 
-; Servatrice can listen for clients on websockets, too. Multiple connexction pools are available but
+; Servatrice can listen for clients on websockets, too. Multiple connection pools are available but
 ; unfortunately, due to a Qt limitation, they must run in the same execution thread.
 ; Set to 0 to disable the websocket server.
 websocket_number_pools=1

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -29,12 +29,12 @@ port=4747
 ; Set to 0 to disable the tcp server.
 number_pools=1
 
-; Servatrice can listen for clients on websockets, too. Unfortunately it can't support more than one thread.
+; Servatrice can listen for clients on websockets, too. Multiple connexction pools are available but
+; unfortunately, due to a Qt limitation, they must run in the same execution thread.
 ; Set to 0 to disable the websocket server.
 websocket_number_pools=1
 
 ; The IP address servatrice will listen on for websockets clients; defaults to "any"
-
 websocket_host=any
 
 ; The TCP port number servatrice will listen on for websockets clients; default is 4748

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -111,21 +111,30 @@ Servatrice_ConnectionPool *Servatrice_GameServer::findLeastUsedConnectionPool()
 #define WEBSOCKET_POOL_NUMBER 999
 
 Servatrice_WebsocketGameServer::Servatrice_WebsocketGameServer(Servatrice *_server,
-                                                               int /* _numberPools */,
+                                                               int _numberPools,
                                                                const QSqlDatabase &_sqlDatabase,
                                                                QObject *parent)
     : QWebSocketServer("Servatrice", QWebSocketServer::NonSecureMode, parent), server(_server)
 {
-    // Qt limitation: websockets can't be moved to another thread
-    auto newDatabaseInterface = new Servatrice_DatabaseInterface(WEBSOCKET_POOL_NUMBER, server);
-    auto newPool = new Servatrice_ConnectionPool(newDatabaseInterface);
+    for (int i = 0; i < _numberPools; ++i) {
+        int poolNumber = WEBSOCKET_POOL_NUMBER + i;
+        auto newDatabaseInterface = new Servatrice_DatabaseInterface(poolNumber, server);
+        auto newPool = new Servatrice_ConnectionPool(newDatabaseInterface);
 
-    server->addDatabaseInterface(thread(), newDatabaseInterface);
-    newDatabaseInterface->initDatabase(_sqlDatabase);
+        auto newThread = new QThread;
+        newThread->setObjectName("pool_" + QString::number(poolNumber));
+        newPool->moveToThread(newThread);
+        newDatabaseInterface->moveToThread(newThread);
+        server->addDatabaseInterface(newThread, newDatabaseInterface);
 
-    connectionPools.append(newPool);
+        newThread->start();
+        QMetaObject::invokeMethod(newDatabaseInterface, "initDatabase", Qt::BlockingQueuedConnection,
+                                  Q_ARG(QSqlDatabase, _sqlDatabase));
 
-    connect(this, SIGNAL(newConnection()), this, SLOT(onNewConnection()));
+        connectionPools.append(newPool);
+
+        connect(this, SIGNAL(newConnection()), this, SLOT(onNewConnection()));
+    }
 }
 
 Servatrice_WebsocketGameServer::~Servatrice_WebsocketGameServer()
@@ -143,7 +152,11 @@ void Servatrice_WebsocketGameServer::onNewConnection()
     Servatrice_ConnectionPool *pool = findLeastUsedConnectionPool();
 
     auto ssi = new WebsocketServerSocketInterface(server, pool->getDatabaseInterface());
-    //    ssi->moveToThread(pool->thread());
+    /*
+     * Due to a Qt limitation, websockets can't be moved to another thread.
+     * This will hopefully change in Qt6 if QtWebSocket will be integrated in QtNetwork
+     */
+    //ssi->moveToThread(pool->thread());
     pool->addClient();
     connect(ssi, SIGNAL(destroyed()), pool, SLOT(removeClient()));
 

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -156,7 +156,7 @@ void Servatrice_WebsocketGameServer::onNewConnection()
      * Due to a Qt limitation, websockets can't be moved to another thread.
      * This will hopefully change in Qt6 if QtWebSocket will be integrated in QtNetwork
      */
-    //ssi->moveToThread(pool->thread());
+    // ssi->moveToThread(pool->thread());
     pool->addClient();
     connect(ssi, SIGNAL(destroyed()), pool, SLOT(removeClient()));
 

--- a/servatrice/src/serversocketinterface.h
+++ b/servatrice/src/serversocketinterface.h
@@ -59,6 +59,7 @@ class AbstractServerSocketInterface : public Server_ProtocolHandler
     Q_OBJECT
 protected slots:
     void catchSocketError(QAbstractSocket::SocketError socketError);
+    void catchSocketDisconnected();
     virtual void flushOutputQueue() = 0;
 signals:
     void outputQueueChanged();


### PR DESCRIPTION
1. fix crash on fuzzy connection (tcp server only)
2. ensure websockets are parent()ed to avoid leaking them
3. quick catch disconnect()ed sockets instead of waiting for a socket error to happen
4. supporto mulltiple connection pools on the websocket server; they are still bound to the same thread due to a qt5 limitation.
