### PR TITLE
Change filter hint text to "Games shown: X / Y" and fix user-game segfault

### DIFF
--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -18,7 +18,6 @@
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QInputDialog>
-#include <QLabel>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QTreeView>
@@ -76,7 +75,6 @@ GameSelector::GameSelector(AbstractClient *_client,
     clearFilterButton->setIcon(QPixmap("theme:icons/clearsearch"));
     clearFilterButton->setEnabled(true);
     connect(clearFilterButton, SIGNAL(clicked()), this, SLOT(actClearFilter()));
-    alteredFiltersLabel = new QLabel;
 
     if (room) {
         createButton = new QPushButton;
@@ -90,7 +88,6 @@ GameSelector::GameSelector(AbstractClient *_client,
     if (showfilters) {
         buttonLayout->addWidget(filterButton);
         buttonLayout->addWidget(clearFilterButton);
-        buttonLayout->addWidget(alteredFiltersLabel);
     }
     buttonLayout->addStretch();
     if (room)
@@ -160,8 +157,6 @@ void GameSelector::actSetFilter()
     gameListProxyModel->setGameTypeFilter(dlg.getGameTypeFilter());
     gameListProxyModel->setMaxPlayersFilter(dlg.getMaxPlayersFilterMin(), dlg.getMaxPlayersFilterMax());
     gameListProxyModel->saveFilterParameters(gameTypeMap);
-
-    setAlteredFiltersText(gameListProxyModel->getNumberOfAlteredFilters());
 }
 
 void GameSelector::actClearFilter()
@@ -170,7 +165,6 @@ void GameSelector::actClearFilter()
 
     gameListProxyModel->resetFilterParameters();
     gameListProxyModel->saveFilterParameters(gameTypeMap);
-    alteredFiltersLabel->setText(tr("Filters reset to default"));
 }
 
 void GameSelector::actCreate()
@@ -265,8 +259,7 @@ void GameSelector::retranslateUi()
 {
     setTitle(tr("Games"));
     filterButton->setText(tr("&Filter games"));
-    clearFilterButton->setText(tr("Reset fi&lters"));
-    setAlteredFiltersText(gameListProxyModel->getNumberOfAlteredFilters());
+    clearFilterButton->setText(tr("C&lear filter"));
     if (createButton)
         createButton->setText(tr("C&reate"));
     joinButton->setText(tr("&Join"));
@@ -288,14 +281,4 @@ void GameSelector::actSelectedGameChanged(const QModelIndex &current, const QMod
 
     spectateButton->setEnabled(game.spectators_allowed() || overrideRestrictions);
     joinButton->setEnabled(game.player_count() < game.max_players() || overrideRestrictions);
-}
-
-void GameSelector::setAlteredFiltersText(const int numAlteredFilters) {
-    if (alteredFiltersLabel != nullptr) {
-        if (numAlteredFilters == 0) {
-            alteredFiltersLabel->setText(tr("Default filters applied"));
-        } else {
-            alteredFiltersLabel->setText(tr("%1 filter(s) altered").arg(numAlteredFilters));
-        }
-    }
 }

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -290,13 +290,12 @@ void GameSelector::actSelectedGameChanged(const QModelIndex &current, const QMod
     joinButton->setEnabled(game.player_count() < game.max_players() || overrideRestrictions);
 }
 
-void GameSelector::setAlteredFiltersText(const int numAlteredFilters)
-{
+void GameSelector::setAlteredFiltersText(const int numAlteredFilters) {
     if (alteredFiltersLabel != nullptr) {
         if (numAlteredFilters == 0) {
             alteredFiltersLabel->setText(tr("Default filters applied"));
         } else {
-            alteredFiltersLabel->setText(tr("%1 filter(s) applied").arg(numAlteredFilters));
+            alteredFiltersLabel->setText(tr("%1 filter(s) altered").arg(numAlteredFilters));
         }
     }
 }

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -32,8 +32,7 @@ GameSelector::GameSelector(AbstractClient *_client,
                            const bool restoresettings,
                            const bool _showfilters,
                            QWidget *parent)
-    : QGroupBox(parent), client(_client), tabSupervisor(_tabSupervisor), room(_room),
-      showFilters(_showfilters)
+    : QGroupBox(parent), client(_client), tabSupervisor(_tabSupervisor), room(_room), showFilters(_showfilters)
 {
     gameListView = new QTreeView;
     gameListModel = new GamesModel(_rooms, _gameTypes, this);

--- a/cockatrice/src/gameselector.h
+++ b/cockatrice/src/gameselector.h
@@ -12,6 +12,7 @@ class GamesModel;
 class GamesProxyModel;
 class QPushButton;
 class QCheckBox;
+class QLabel;
 class AbstractClient;
 class TabSupervisor;
 class TabRoom;
@@ -44,7 +45,11 @@ private:
     GamesModel *gameListModel;
     GamesProxyModel *gameListProxyModel;
     QPushButton *filterButton, *clearFilterButton, *createButton, *joinButton, *spectateButton;
+    QLabel *filteredGamesLabel;
+    const bool showFilters;
     GameTypeMap gameTypeMap;
+
+    void setFilteredGamesLabel();
 
 public:
     GameSelector(AbstractClient *_client,
@@ -53,7 +58,7 @@ public:
                  const QMap<int, QString> &_rooms,
                  const QMap<int, GameTypeMap> &_gameTypes,
                  const bool restoresettings,
-                 const bool showfilters,
+                 const bool _showfilters,
                  QWidget *parent = nullptr);
     void retranslateUi();
     void processGameInfo(const ServerInfo_Game &info);

--- a/cockatrice/src/gameselector.h
+++ b/cockatrice/src/gameselector.h
@@ -11,7 +11,6 @@ class QTreeView;
 class GamesModel;
 class GamesProxyModel;
 class QPushButton;
-class QLabel;
 class QCheckBox;
 class AbstractClient;
 class TabSupervisor;
@@ -45,10 +44,7 @@ private:
     GamesModel *gameListModel;
     GamesProxyModel *gameListProxyModel;
     QPushButton *filterButton, *clearFilterButton, *createButton, *joinButton, *spectateButton;
-    QLabel *alteredFiltersLabel;
     GameTypeMap gameTypeMap;
-
-    void setAlteredFiltersText(int numAlteredFilters);
 
 public:
     GameSelector(AbstractClient *_client,

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -316,9 +316,9 @@ void GamesProxyModel::setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlay
 
 void GamesProxyModel::resetFilterParameters()
 {
-    unavailableGamesVisible = DEFAULT_UNAVAILABLE_GAMES_VISIBLE;
-    showPasswordProtectedGames = DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES;
-    showBuddiesOnlyGames = DEFAULT_SHOW_BUDDIES_ONLY_GAMES;
+    unavailableGamesVisible = false;
+    showPasswordProtectedGames = true;
+    showBuddiesOnlyGames = true;
     gameNameFilter = QString();
     creatorNameFilter = QString();
     gameTypeFilter.clear();
@@ -366,20 +366,6 @@ void GamesProxyModel::saveFilterParameters(const QMap<int, QString> &allGameType
 
     settingsCache->gameFilters().setMinPlayers(maxPlayersFilterMin);
     settingsCache->gameFilters().setMaxPlayers(maxPlayersFilterMax);
-}
-
-int GamesProxyModel::getNumberOfAlteredFilters() const {
-    int numFiltersAltered = 0;
-    if (showBuddiesOnlyGames != DEFAULT_SHOW_BUDDIES_ONLY_GAMES) { numFiltersAltered++; }
-    if (hideIgnoredUserGames) { numFiltersAltered++; }
-    if (unavailableGamesVisible != DEFAULT_UNAVAILABLE_GAMES_VISIBLE) { numFiltersAltered++; }
-    if (showPasswordProtectedGames != DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES) { numFiltersAltered++; }
-    if (!gameNameFilter.isEmpty()) { numFiltersAltered++; }
-    if (!creatorNameFilter.isEmpty()) { numFiltersAltered++; }
-    if (!gameTypeFilter.isEmpty()) { numFiltersAltered++; }
-    if (maxPlayersFilterMin != -1 && maxPlayersFilterMin != 1) { numFiltersAltered++; }
-    if (maxPlayersFilterMax != -1 && maxPlayersFilterMax != DEFAULT_MAX_PLAYERS_MAX) { numFiltersAltered++; }
-    return numFiltersAltered;
 }
 
 bool GamesProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex & /*sourceParent*/) const

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -322,8 +322,9 @@ int GamesProxyModel::getNumFilteredGames() const
 
     int numFilteredGames = 0;
     for (int row = 0; row < model->rowCount(); ++row) {
-        if (!filterAcceptsRow(row))
+        if (!filterAcceptsRow(row)) {
             ++numFilteredGames;
+        }
     }
     return numFilteredGames;
 }

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -38,7 +38,7 @@ const QString GamesModel::getGameCreatedString(const int secs) const
     } else { // from 1 hr onward we show hrs
         int hours = secs / SECS_PER_HOUR;
         if (secs % SECS_PER_HOUR >= SECS_PER_MIN * 30) // if the room is open for 1hr 30 mins, we round to 2hrs
-            hours++;
+            ++hours;
         ret = QString("%1+ h").arg(QString::number(hours));
     }
     return ret;
@@ -321,10 +321,10 @@ int GamesProxyModel::getNumFilteredGames() const
         return 0;
 
     int numFilteredGames = 0;
-    for (int row = 0; row < model->rowCount(); row++)
+    for (int row = 0; row < model->rowCount(); ++row)
     {
         if (!filterAcceptsRow(row))
-            numFilteredGames++;
+            ++numFilteredGames;
     }
     return numFilteredGames;
 }

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -321,8 +321,7 @@ int GamesProxyModel::getNumFilteredGames() const
         return 0;
 
     int numFilteredGames = 0;
-    for (int row = 0; row < model->rowCount(); ++row)
-    {
+    for (int row = 0; row < model->rowCount(); ++row) {
         if (!filterAcceptsRow(row))
             ++numFilteredGames;
     }

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -314,6 +314,21 @@ void GamesProxyModel::setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlay
     invalidateFilter();
 }
 
+int GamesProxyModel::getNumFilteredGames() const
+{
+    GamesModel *model = qobject_cast<GamesModel *>(sourceModel());
+    if (!model)
+        return 0;
+
+    int numFilteredGames = 0;
+    for (int row = 0; row < model->rowCount(); row++)
+    {
+        if (!filterAcceptsRow(row))
+            numFilteredGames++;
+    }
+    return numFilteredGames;
+}
+
 void GamesProxyModel::resetFilterParameters()
 {
     unavailableGamesVisible = false;
@@ -369,6 +384,11 @@ void GamesProxyModel::saveFilterParameters(const QMap<int, QString> &allGameType
 }
 
 bool GamesProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex & /*sourceParent*/) const
+{
+    return filterAcceptsRow(sourceRow);
+}
+
+bool GamesProxyModel::filterAcceptsRow(int sourceRow) const
 {
     GamesModel *model = qobject_cast<GamesModel *>(sourceModel());
     if (!model)

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -368,36 +368,17 @@ void GamesProxyModel::saveFilterParameters(const QMap<int, QString> &allGameType
     settingsCache->gameFilters().setMaxPlayers(maxPlayersFilterMax);
 }
 
-int GamesProxyModel::getNumberOfAlteredFilters() const
-{
+int GamesProxyModel::getNumberOfAlteredFilters() const {
     int numFiltersAltered = 0;
-    if (showBuddiesOnlyGames != DEFAULT_SHOW_BUDDIES_ONLY_GAMES) {
-        numFiltersAltered++;
-    }
-    if (hideIgnoredUserGames) {
-        numFiltersAltered++;
-    }
-    if (unavailableGamesVisible != DEFAULT_UNAVAILABLE_GAMES_VISIBLE) {
-        numFiltersAltered++;
-    }
-    if (showPasswordProtectedGames != DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES) {
-        numFiltersAltered++;
-    }
-    if (!gameNameFilter.isEmpty()) {
-        numFiltersAltered++;
-    }
-    if (!creatorNameFilter.isEmpty()) {
-        numFiltersAltered++;
-    }
-    if (!gameTypeFilter.isEmpty()) {
-        numFiltersAltered++;
-    }
-    if (maxPlayersFilterMin != -1 && maxPlayersFilterMin != 1) {
-        numFiltersAltered++;
-    }
-    if (maxPlayersFilterMax != -1 && maxPlayersFilterMax != DEFAULT_MAX_PLAYERS_MAX) {
-        numFiltersAltered++;
-    }
+    if (showBuddiesOnlyGames != DEFAULT_SHOW_BUDDIES_ONLY_GAMES) { numFiltersAltered++; }
+    if (hideIgnoredUserGames) { numFiltersAltered++; }
+    if (unavailableGamesVisible != DEFAULT_UNAVAILABLE_GAMES_VISIBLE) { numFiltersAltered++; }
+    if (showPasswordProtectedGames != DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES) { numFiltersAltered++; }
+    if (!gameNameFilter.isEmpty()) { numFiltersAltered++; }
+    if (!creatorNameFilter.isEmpty()) { numFiltersAltered++; }
+    if (!gameTypeFilter.isEmpty()) { numFiltersAltered++; }
+    if (maxPlayersFilterMin != -1 && maxPlayersFilterMin != 1) { numFiltersAltered++; }
+    if (maxPlayersFilterMax != -1 && maxPlayersFilterMax != DEFAULT_MAX_PLAYERS_MAX) { numFiltersAltered++; }
     return numFiltersAltered;
 }
 

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -125,6 +125,7 @@ public:
         return maxPlayersFilterMax;
     }
     void setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlayersFilterMax);
+    int getNumFilteredGames() const;
     void resetFilterParameters();
     void loadFilterParameters(const QMap<int, QString> &allGameTypes);
     void saveFilterParameters(const QMap<int, QString> &allGameTypes);
@@ -132,6 +133,7 @@ public:
 
 protected:
     bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
+    bool filterAcceptsRow(int sourceRow) const;
 };
 
 #endif

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -77,9 +77,6 @@ private:
     int maxPlayersFilterMin, maxPlayersFilterMax;
 
     static const int DEFAULT_MAX_PLAYERS_MAX = 99;
-    static const bool DEFAULT_UNAVAILABLE_GAMES_VISIBLE = false;
-    static const bool DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES = true;
-    static const bool DEFAULT_SHOW_BUDDIES_ONLY_GAMES = true;
 
 public:
     GamesProxyModel(QObject *parent = nullptr, const TabSupervisor *_tabSupervisor = nullptr);
@@ -131,7 +128,6 @@ public:
     void resetFilterParameters();
     void loadFilterParameters(const QMap<int, QString> &allGameTypes);
     void saveFilterParameters(const QMap<int, QString> &allGameTypes);
-    int getNumberOfAlteredFilters() const;
     void refresh();
 
 protected:


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3068 (reverts https://github.com/Cockatrice/Cockatrice/pull/3946)
- Fixes #3979 (crash caused in #3946)
- Makes #3957 less obvious to users (though I think there's still something wrong there)

## Short roundup of the initial problem
Cockatrice remembers filters applied between sessions, but users were not alerted if any filters were altered from their default values.

## What will change with this Pull Request?
- Revert https://github.com/Cockatrice/Cockatrice/pull/3946
- Instead, change the hint text to read "Games shown: 13 / 42"
- Update hint text on interesting events, like games being added or newly meeting/not meeting filter criteria
- Fix segfault that occurred when viewing user's games

## Screenshots
Screenshot of "Games shown" text:
<img width="1017" alt="Screen Shot 2020-04-30 at 8 16 55 PM" src="https://user-images.githubusercontent.com/63179146/80770890-a2cfdd00-8b1f-11ea-8b19-d67b6904a1a2.png">

Screenshot of viewing user's games, client did not crash before/during/after:
<img width="931" alt="Screen Shot 2020-04-30 at 8 17 12 PM" src="https://user-images.githubusercontent.com/63179146/80770892-a5323700-8b1f-11ea-8fa9-1c1c49b82e85.png">

