### PR TITLE
Revert "Fix #3068: Add hint text about game list filters (#3946)"

### DIFF
--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -18,7 +18,6 @@
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QInputDialog>
-#include <QLabel>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QTreeView>
@@ -76,7 +75,6 @@ GameSelector::GameSelector(AbstractClient *_client,
     clearFilterButton->setIcon(QPixmap("theme:icons/clearsearch"));
     clearFilterButton->setEnabled(true);
     connect(clearFilterButton, SIGNAL(clicked()), this, SLOT(actClearFilter()));
-    alteredFiltersLabel = new QLabel;
 
     if (room) {
         createButton = new QPushButton;
@@ -90,7 +88,6 @@ GameSelector::GameSelector(AbstractClient *_client,
     if (showfilters) {
         buttonLayout->addWidget(filterButton);
         buttonLayout->addWidget(clearFilterButton);
-        buttonLayout->addWidget(alteredFiltersLabel);
     }
     buttonLayout->addStretch();
     if (room)
@@ -160,8 +157,6 @@ void GameSelector::actSetFilter()
     gameListProxyModel->setGameTypeFilter(dlg.getGameTypeFilter());
     gameListProxyModel->setMaxPlayersFilter(dlg.getMaxPlayersFilterMin(), dlg.getMaxPlayersFilterMax());
     gameListProxyModel->saveFilterParameters(gameTypeMap);
-
-    setAlteredFiltersText(gameListProxyModel->getNumberOfAlteredFilters());
 }
 
 void GameSelector::actClearFilter()
@@ -170,7 +165,6 @@ void GameSelector::actClearFilter()
 
     gameListProxyModel->resetFilterParameters();
     gameListProxyModel->saveFilterParameters(gameTypeMap);
-    alteredFiltersLabel->setText(tr("Filters reset to default"));
 }
 
 void GameSelector::actCreate()
@@ -265,8 +259,7 @@ void GameSelector::retranslateUi()
 {
     setTitle(tr("Games"));
     filterButton->setText(tr("&Filter games"));
-    clearFilterButton->setText(tr("Reset fi&lters"));
-    setAlteredFiltersText(gameListProxyModel->getNumberOfAlteredFilters());
+    clearFilterButton->setText(tr("C&lear filter"));
     if (createButton)
         createButton->setText(tr("C&reate"));
     joinButton->setText(tr("&Join"));
@@ -288,15 +281,4 @@ void GameSelector::actSelectedGameChanged(const QModelIndex &current, const QMod
 
     spectateButton->setEnabled(game.spectators_allowed() || overrideRestrictions);
     joinButton->setEnabled(game.player_count() < game.max_players() || overrideRestrictions);
-}
-
-void GameSelector::setAlteredFiltersText(const int numAlteredFilters)
-{
-    if (alteredFiltersLabel != nullptr) {
-        if (numAlteredFilters == 0) {
-            alteredFiltersLabel->setText(tr("Default filters applied"));
-        } else {
-            alteredFiltersLabel->setText(tr("%1 filter(s) applied").arg(numAlteredFilters));
-        }
-    }
 }

--- a/cockatrice/src/gameselector.h
+++ b/cockatrice/src/gameselector.h
@@ -11,7 +11,6 @@ class QTreeView;
 class GamesModel;
 class GamesProxyModel;
 class QPushButton;
-class QLabel;
 class QCheckBox;
 class AbstractClient;
 class TabSupervisor;
@@ -45,10 +44,7 @@ private:
     GamesModel *gameListModel;
     GamesProxyModel *gameListProxyModel;
     QPushButton *filterButton, *clearFilterButton, *createButton, *joinButton, *spectateButton;
-    QLabel *alteredFiltersLabel;
     GameTypeMap gameTypeMap;
-
-    void setAlteredFiltersText(int numAlteredFilters);
 
 public:
     GameSelector(AbstractClient *_client,

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -316,9 +316,9 @@ void GamesProxyModel::setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlay
 
 void GamesProxyModel::resetFilterParameters()
 {
-    unavailableGamesVisible = DEFAULT_UNAVAILABLE_GAMES_VISIBLE;
-    showPasswordProtectedGames = DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES;
-    showBuddiesOnlyGames = DEFAULT_SHOW_BUDDIES_ONLY_GAMES;
+    unavailableGamesVisible = false;
+    showPasswordProtectedGames = true;
+    showBuddiesOnlyGames = true;
     gameNameFilter = QString();
     creatorNameFilter = QString();
     gameTypeFilter.clear();
@@ -366,39 +366,6 @@ void GamesProxyModel::saveFilterParameters(const QMap<int, QString> &allGameType
 
     settingsCache->gameFilters().setMinPlayers(maxPlayersFilterMin);
     settingsCache->gameFilters().setMaxPlayers(maxPlayersFilterMax);
-}
-
-int GamesProxyModel::getNumberOfAlteredFilters() const
-{
-    int numFiltersAltered = 0;
-    if (showBuddiesOnlyGames != DEFAULT_SHOW_BUDDIES_ONLY_GAMES) {
-        numFiltersAltered++;
-    }
-    if (hideIgnoredUserGames) {
-        numFiltersAltered++;
-    }
-    if (unavailableGamesVisible != DEFAULT_UNAVAILABLE_GAMES_VISIBLE) {
-        numFiltersAltered++;
-    }
-    if (showPasswordProtectedGames != DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES) {
-        numFiltersAltered++;
-    }
-    if (!gameNameFilter.isEmpty()) {
-        numFiltersAltered++;
-    }
-    if (!creatorNameFilter.isEmpty()) {
-        numFiltersAltered++;
-    }
-    if (!gameTypeFilter.isEmpty()) {
-        numFiltersAltered++;
-    }
-    if (maxPlayersFilterMin != -1 && maxPlayersFilterMin != 1) {
-        numFiltersAltered++;
-    }
-    if (maxPlayersFilterMax != -1 && maxPlayersFilterMax != DEFAULT_MAX_PLAYERS_MAX) {
-        numFiltersAltered++;
-    }
-    return numFiltersAltered;
 }
 
 bool GamesProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex & /*sourceParent*/) const

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -77,9 +77,6 @@ private:
     int maxPlayersFilterMin, maxPlayersFilterMax;
 
     static const int DEFAULT_MAX_PLAYERS_MAX = 99;
-    static const bool DEFAULT_UNAVAILABLE_GAMES_VISIBLE = false;
-    static const bool DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES = true;
-    static const bool DEFAULT_SHOW_BUDDIES_ONLY_GAMES = true;
 
 public:
     GamesProxyModel(QObject *parent = nullptr, const TabSupervisor *_tabSupervisor = nullptr);
@@ -131,7 +128,6 @@ public:
     void resetFilterParameters();
     void loadFilterParameters(const QMap<int, QString> &allGameTypes);
     void saveFilterParameters(const QMap<int, QString> &allGameTypes);
-    int getNumberOfAlteredFilters() const;
     void refresh();
 
 protected:


### PR DESCRIPTION
This reverts commit 2c3eab9b0c231958ed2e3ad5bfb322db17cecd8a.

## Related Ticket(s)
- Fixes #3979

## Short roundup of the initial problem
- #3946 causes segfault when viewing user's games because code was not guarded behind "showfilters"

## What will change with this Pull Request?
Revert pull request #3946 ; will fix #3068 in #3973 instead.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
