### PR TITLE
add ubuntu 20.04 to travis

### DIFF
--- a/.ci/UbuntuFocal/Dockerfile
+++ b/.ci/UbuntuFocal/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:focal
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
         ccache \
         clang-format \

--- a/.ci/UbuntuFocal/Dockerfile
+++ b/.ci/UbuntuFocal/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:focal
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        ccache \
+        clang-format \
+        cmake \
+        file \
+        g++ \
+        git \
+        liblzma-dev \
+        libprotobuf-dev \
+        libqt5multimedia5-plugins \
+        libqt5sql5-mysql \
+        libqt5svg5-dev \
+        libqt5websockets5-dev \
+        protobuf-compiler \
+        qt5-default \
+        qtmultimedia5-dev \
+        qttools5-dev \
+        qttools5-dev-tools \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
 
 
   #Ubuntu Bionic (on Docker)
-  - name: Ubuntu Bionic (Compile)
+  - name: Ubuntu Bionic (Debug + Tests)
     if: tag IS NOT present
     os: linux
     services: docker
@@ -28,7 +28,7 @@ jobs:
       directories:
       - $CACHE
     before_install: source .ci/travis-docker.sh --build
-    script: RUN --server
+    script: RUN --server --debug --test
 
   - name: Ubuntu Bionic (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present
@@ -43,7 +43,7 @@ jobs:
     script: RUN --server --package $NAME --release
 
   #Ubuntu Focal (on Docker)
-  - name: Ubuntu Focal (Debug + Tests)
+  - name: Ubuntu Focal (Compile)
     if: tag IS NOT present
     os: linux
     services: docker
@@ -53,7 +53,7 @@ jobs:
       directories:
       - $CACHE
     before_install: source .ci/travis-docker.sh --build
-    script: RUN --server --test --debug
+    script: RUN --server
 
   - name: Ubuntu Focal (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
 
 
   #Ubuntu Bionic (on Docker)
-  - name: Ubuntu Bionic (Debug + Tests)
+  - name: Ubuntu Bionic (Compile)
     if: tag IS NOT present
     os: linux
     services: docker
@@ -28,7 +28,7 @@ jobs:
       directories:
       - $CACHE
     before_install: source .ci/travis-docker.sh --build
-    script: RUN --server --test --debug
+    script: RUN --server
 
   - name: Ubuntu Bionic (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present
@@ -42,6 +42,30 @@ jobs:
     before_install: source .ci/travis-docker.sh --build
     script: RUN --server --package $NAME --release
 
+  #Ubuntu Focal (on Docker)
+  - name: Ubuntu Focal (Debug + Tests)
+    if: tag IS NOT present
+    os: linux
+    services: docker
+    language: minimal
+    env: NAME=UbuntuFocal CACHE=$HOME/$NAME
+    cache:
+      directories:
+      - $CACHE
+    before_install: source .ci/travis-docker.sh --build
+    script: RUN --server --test --debug
+
+  - name: Ubuntu Focal (Release)
+    if: (branch = master AND NOT type = pull_request) OR tag IS present
+    os: linux
+    services: docker
+    language: minimal
+    env: NAME=UbuntuFocal CACHE=$HOME/$NAME
+    cache:
+      directories:
+      - $CACHE
+    before_install: source .ci/travis-docker.sh --build
+    script: RUN --server --package $NAME --release
 
   #Debian Buster (on Docker)
   - name: Debian Buster (Compile)

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -1091,13 +1091,13 @@ void MainWindow::actCheckCardUpdates()
      * bypass app translocation: quarantined application will be started from a temporary directory eg.
      * /private/var/folders/tk/qx76cyb50jn5dvj7rrgfscz40000gn/T/AppTranslocation/A0CBBD5A-9264-4106-8547-36B84DB161E2/d/oracle/
      */
-    if(dir.absolutePath().startsWith("/private/var/folders")) {
+    if (dir.absolutePath().startsWith("/private/var/folders")) {
         dir.setPath("/Applications/");
     } else {
         // exit from the Cockatrice application bundle
         dir.cdUp();
         dir.cdUp();
-        dir.cdUp();        
+        dir.cdUp();
     }
 
     binaryName = getCardUpdaterBinaryName();


### PR DESCRIPTION
Enables tests and debug on the newest ubuntu lts, we should keep 18.04 around until users migrate.