### PR TITLE
Capitalize player counters

### DIFF
--- a/cockatrice/src/abstractcounter.cpp
+++ b/cockatrice/src/abstractcounter.cpp
@@ -27,12 +27,14 @@ AbstractCounter::AbstractCounter(Player *_player,
       useNameForShortcut(_useNameForShortcut), hovered(false), aDec(nullptr), aInc(nullptr), dialogSemaphore(false),
       deleteAfterDialog(false), shownInCounterArea(_shownInCounterArea), game(_game)
 {
+    QString displayName = QString(_name);
+    displayName[0] = displayName[0].toTitleCase();
     setAcceptHoverEvents(true);
 
     shortcutActive = false;
 
     if (player->getLocalOrJudge()) {
-        menu = new TearOffMenu(name);
+        menu = new TearOffMenu(displayName);
         aSet = new QAction(this);
         connect(aSet, SIGNAL(triggered()), this, SLOT(setCounter()));
         menu->addAction(aSet);

--- a/cockatrice/src/capitalizecountername.h
+++ b/cockatrice/src/capitalizecountername.h
@@ -1,0 +1,40 @@
+#ifndef CAPITALIZECOUNTERNAME_H
+#define CAPITALIZECOUNTERNAME_H
+
+#include <QString>
+#include <QtCore>
+
+class CapitalizeCounterName
+{
+public:
+    static QString getDisplayName(QString _name)
+    {
+        if (_name == "life") {
+            return QString("Life");
+        }
+        if (_name == "w") {
+            return QString("W");
+        }
+        if (_name == "u") {
+            return QString("U");
+        }
+        if (_name == "b") {
+            return QString("B");
+        }
+        if (_name == "r") {
+            return QString("R");
+        }
+        if (_name == "g") {
+            return QString("G");
+        }
+        if (_name == "x") {
+            return QString("C");
+        }
+        if (_name == "storm") {
+            return QString("Storm");
+        }
+        return QString("Unknown");
+    }
+};
+
+#endif

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -677,13 +677,15 @@ void MessageLogWidget::logSetCardCounter(Player *player, QString cardName, int c
 
 void MessageLogWidget::logSetCounter(Player *player, QString counterName, int value, int oldValue)
 {
-    if (counterName == "life") {
+    QString counterDisplayName = QString(counterName);
+    counterDisplayName[0] = counterDisplayName[0].toTitleCase();
+    if (counterDisplayName == "Life") {
         soundEngine->playSound("life_change");
     }
 
     appendHtmlServerMessage(tr("%1 sets counter %2 to %3 (%4%5).")
                                 .arg(sanitizeHtml(player->getName()))
-                                .arg(QString("<font class=\"blue\">%1</font>").arg(sanitizeHtml(counterName)))
+                                .arg(QString("<font class=\"blue\">%1</font>").arg(sanitizeHtml(counterDisplayName)))
                                 .arg(QString("<font class=\"blue\">%1</font>").arg(value))
                                 .arg(value > oldValue ? "+" : "")
                                 .arg(value - oldValue));


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3992

## Short roundup of the initial problem
Player counters should appear capitalized, not all lower case as current.

## What will change with this Pull Request?
Counter names will appear capitalized in the client. No server-side changes have been included, including changing the name of x to c.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
