### PR TITLE
fix message when moving cards to bottom of library

### DIFF
--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -326,8 +326,8 @@ void MessageLogWidget::logMoveCard(Player *player,
     } else if (targetZoneName == deckConstant()) {
         if (newX == -1) {
             finalStr = tr("%1 puts %2%3 into their library.");
-        } else if (newX == targetZone->getCards().size() - 1) {
-            finalStr = tr("%1 puts %2%3 on bottom of their library.");
+        } else if (newX == targetZone->getCards().size()) {
+            finalStr = tr("%1 puts %2%3 onto the bottom of their library.");
         } else if (newX == 0) {
             finalStr = tr("%1 puts %2%3 on top of their library.");
         } else {

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -326,7 +326,7 @@ void MessageLogWidget::logMoveCard(Player *player,
     } else if (targetZoneName == deckConstant()) {
         if (newX == -1) {
             finalStr = tr("%1 puts %2%3 into their library.");
-        } else if (newX == targetZone->getCards().size()) {
+        } else if (newX >= targetZone->getCards().size()) {
             finalStr = tr("%1 puts %2%3 onto the bottom of their library.");
         } else if (newX == 0) {
             finalStr = tr("%1 puts %2%3 on top of their library.");


### PR DESCRIPTION
## Related Ticket(s)
- Part of #3978 

## Short roundup of the initial problem
When placing cards on the bottom of a library, Cockatrice currently gives a message along the lines of "player x places card y z cards from the top of their library" instead of just saying "bottom of their library"
