### PR TITLE
Made user information window resizable

### DIFF
--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -27,11 +27,11 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *paren
     nameFont.setPointSize(nameFont.pointSize() * 1.5);
     nameLabel.setFont(nameFont);
 
-    avatarLabel.setMaximumWidth(400);
-    avatarLabel.setMaximumHeight(200);
+    avatarLabel.setScaledContents(true);
+    avatarLabel.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     QGridLayout *mainLayout = new QGridLayout;
-    mainLayout->addWidget(&avatarLabel, 0, 0, 1, 3, Qt::AlignCenter);
+    mainLayout->addWidget(&avatarLabel, 0, 0, 1, 3);
     mainLayout->addWidget(&nameLabel, 1, 0, 1, 3);
     mainLayout->addWidget(&realNameLabel1, 2, 0, 1, 1);
     mainLayout->addWidget(&realNameLabel2, 2, 1, 1, 2);
@@ -83,7 +83,7 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
     if (!avatarPixmap.loadFromData((const uchar *)bmp.data(), bmp.size()))
         avatarPixmap =
             UserLevelPixmapGenerator::generatePixmap(64, userLevel, false, QString::fromStdString(user.privlevel()));
-    avatarLabel.setPixmap(avatarPixmap.scaled(avatarLabel.size(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
+    avatarLabel.setPixmap(avatarPixmap.scaled(400, 200, Qt::KeepAspectRatio, Qt::SmoothTransformation));
 
     nameLabel.setText(QString::fromStdString(user.name()));
     realNameLabel2.setText(QString::fromStdString(user.real_name()));
@@ -163,7 +163,6 @@ void UserInfoBox::processResponse(const Response &r)
 {
     const Response_GetUserInfo &response = r.GetExtension(Response_GetUserInfo::ext);
     updateInfo(response.user_info());
-    setFixedSize(sizeHint());
     show();
 }
 

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -294,8 +294,9 @@ void UserInfoBox::processAvatarResponse(const Response &r)
     }
 }
 
-void UserInfoBox::resizeEvent(QResizeEvent *)
+void UserInfoBox::resizeEvent(QResizeEvent *event)
 {
     QPixmap resizedPixmap = avatarPixmap.scaled(avatarLabel.size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
     avatarLabel.setPixmap(resizedPixmap);
+    QWidget::resizeEvent(event);
 }

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -27,11 +27,11 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *paren
     nameFont.setPointSize(nameFont.pointSize() * 1.5);
     nameLabel.setFont(nameFont);
 
-    avatarLabel.setScaledContents(true);
+    avatarLabel.setMinimumSize(200, 200);
     avatarLabel.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     QGridLayout *mainLayout = new QGridLayout;
-    mainLayout->addWidget(&avatarLabel, 0, 0, 1, 3);
+    mainLayout->addWidget(&avatarLabel, 0, 1, 1, 1);
     mainLayout->addWidget(&nameLabel, 1, 0, 1, 3);
     mainLayout->addWidget(&realNameLabel1, 2, 0, 1, 1);
     mainLayout->addWidget(&realNameLabel2, 2, 1, 1, 2);
@@ -43,7 +43,7 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *paren
     mainLayout->addWidget(&userLevelLabel3, 5, 2, 1, 1);
     mainLayout->addWidget(&accountAgeLebel1, 6, 0, 1, 1);
     mainLayout->addWidget(&accountAgeLabel2, 6, 2, 1, 1);
-    mainLayout->setColumnStretch(2, 10);
+    mainLayout->setColumnStretch(1, 10);
 
     if (editable) {
         QHBoxLayout *buttonsLayout = new QHBoxLayout;
@@ -78,7 +78,6 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
 {
     const UserLevelFlags userLevel(user.user_level());
 
-    QPixmap avatarPixmap;
     const std::string bmp = user.avatar_bmp();
     if (!avatarPixmap.loadFromData((const uchar *)bmp.data(), bmp.size()))
         avatarPixmap =
@@ -293,4 +292,10 @@ void UserInfoBox::processAvatarResponse(const Response &r)
             QMessageBox::critical(this, tr("Error"), tr("An error occured while trying to updater your avatar."));
             break;
     }
+}
+
+void UserInfoBox::resizeEvent(QResizeEvent *)
+{
+    QPixmap resizedPixmap = avatarPixmap.scaled(avatarLabel.size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    avatarLabel.setPixmap(resizedPixmap);
 }

--- a/cockatrice/src/userinfobox.h
+++ b/cockatrice/src/userinfobox.h
@@ -36,8 +36,9 @@ private slots:
 public slots:
     void updateInfo(const ServerInfo_User &user);
     void updateInfo(const QString &userName);
+
 private:
-    void resizeEvent(QResizeEvent *event);
+    void resizeEvent(QResizeEvent *event) override;
 };
 
 #endif

--- a/cockatrice/src/userinfobox.h
+++ b/cockatrice/src/userinfobox.h
@@ -37,7 +37,7 @@ public slots:
     void updateInfo(const ServerInfo_User &user);
     void updateInfo(const QString &userName);
 private:
-    void resizeEvent(QResizeEvent *);
+    void resizeEvent(QResizeEvent *event);
 };
 
 #endif

--- a/cockatrice/src/userinfobox.h
+++ b/cockatrice/src/userinfobox.h
@@ -18,6 +18,7 @@ private:
     QLabel avatarLabel, nameLabel, realNameLabel1, realNameLabel2, countryLabel1, countryLabel2, countryLabel3,
         userLevelLabel1, userLevelLabel2, userLevelLabel3, accountAgeLebel1, accountAgeLabel2;
     QPushButton editButton, passwordButton, avatarButton;
+    QPixmap avatarPixmap;
 
 public:
     UserInfoBox(AbstractClient *_client, bool editable, QWidget *parent = nullptr, Qt::WindowFlags flags = {});
@@ -35,6 +36,8 @@ private slots:
 public slots:
     void updateInfo(const ServerInfo_User &user);
     void updateInfo(const QString &userName);
+private:
+    void resizeEvent(QResizeEvent *);
 };
 
 #endif


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2874

## Short roundup of the initial problem
Makes the user information window resizable by the user.

## What will change with this Pull Request?
- Removed the call to setFixedSize (which locked the widget's size as its sizeHint) in UserInfoBox.

## Screenshots
Before resizing:
![image](https://user-images.githubusercontent.com/17144156/82503823-fce11400-9ac7-11ea-88c9-7a2a1ee323de.png)

After resizing (example):
![image](https://user-images.githubusercontent.com/17144156/82503802-f2267f00-9ac7-11ea-89ef-246071e35153.png)


