### PR TITLE
make sure no //es are added to maintypes

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -392,7 +392,7 @@ int OracleImporter::importCardsFromSet(CardSetPtr currentSet, const QList<QVaria
                     if (originalPropertyValue != thisCardPropertyValue) {
                         if (prop == "colors") {
                             properties.insert(prop, originalPropertyValue + thisCardPropertyValue);
-                        } else if (prop == "maintype") {  // don't create maintypes with //es in them
+                        } else if (prop == "maintype") { // don't create maintypes with //es in them
                             properties.insert(prop, originalPropertyValue);
                         } else {
                             properties.insert(prop,

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -392,7 +392,7 @@ int OracleImporter::importCardsFromSet(CardSetPtr currentSet, const QList<QVaria
                     if (originalPropertyValue != thisCardPropertyValue) {
                         if (prop == "colors") {
                             properties.insert(prop, originalPropertyValue + thisCardPropertyValue);
-                        } else if (prop == "maintype" && layout == "adventure") {
+                        } else if (prop == "maintype") {  // don't create maintypes with //es in them
                             properties.insert(prop, originalPropertyValue);
                         } else {
                             properties.insert(prop,


### PR DESCRIPTION
instead of only avoiding this on adventures they should just be avoided
on any card so the maintype instant // sorcery isn't created for example,
the normal typeline isn't affected by this
    
fixes #3972