### PR TITLE
Add exclude term to search hints

### DIFF
--- a/cockatrice/resources/help/search.md
+++ b/cockatrice/resources/help/search.md
@@ -49,7 +49,7 @@ The search bar recognizes a set of special commands similar to some other card d
 <dd>[e:lea,leb](#e:lea,leb) <small>(Cards that appear in Alpha or Beta)</small></dd>
 <dd><a href="#e:lea,leb -(e:lea e:leb)">e:lea,leb -(e:lea e:leb)</a> <small>(Cards that appear in Alpha or Beta but not in both editions)</small></dd>
 
-<dt>Inverse:</dt>
+<dt>Inverse/Exclude:</dt>
 <dd>[c:wu -c:m](#c:wu -c:m) <small>(Any card that is white or blue, but not multicolored)</small></dd>
 
 <dt>Branching:</dt>

--- a/cockatrice/resources/help/search.md
+++ b/cockatrice/resources/help/search.md
@@ -49,7 +49,7 @@ The search bar recognizes a set of special commands similar to some other card d
 <dd>[e:lea,leb](#e:lea,leb) <small>(Cards that appear in Alpha or Beta)</small></dd>
 <dd><a href="#e:lea,leb -(e:lea e:leb)">e:lea,leb -(e:lea e:leb)</a> <small>(Cards that appear in Alpha or Beta but not in both editions)</small></dd>
 
-<dt>Inverse/Exclude:</dt>
+<dt>Negate:</dt>
 <dd>[c:wu -c:m](#c:wu -c:m) <small>(Any card that is white or blue, but not multicolored)</small></dd>
 
 <dt>Branching:</dt>


### PR DESCRIPTION
## Short roundup of the initial problem
People might search for the more common (?) `Exclude` term, but can't find it within the explanations/hints.

## What will change with this Pull Request?
- add `Exlude` next to `Inverse`