### PR TITLE
Change method of opening directories to be the same for all oses, including linux

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -46,6 +46,7 @@
 #include "version_string.h"
 #include "window_sets.h"
 
+#include <QDesktopServices>
 #include <QAction>
 #include <QApplication>
 #include <QCloseEvent>
@@ -752,10 +753,8 @@ void MainWindow::createMenus()
     dbMenu->addAction(aManageSets);
     dbMenu->addAction(aEditTokens);
     dbMenu->addSeparator();
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     dbMenu->addAction(aOpenCustomFolder);
     dbMenu->addAction(aOpenCustomsetsFolder);
-#endif
     dbMenu->addAction(aAddCustomSet);
 
     helpMenu = menuBar()->addMenu(QString());
@@ -1206,6 +1205,8 @@ void MainWindow::actOpenCustomFolder()
     QStringList args;
     args << QDir::toNativeSeparators(dir);
     QProcess::startDetached("explorer", args);
+#else // LINUX
+    QDesktopServices::openUrl(QUrl::fromLocalFile(dir));
 #endif
 }
 
@@ -1225,6 +1226,8 @@ void MainWindow::actOpenCustomsetsFolder()
     QStringList args;
     args << QDir::toNativeSeparators(dir);
     QProcess::startDetached("explorer", args);
+#else // LINUX
+    QDesktopServices::openUrl(QUrl::fromLocalFile(dir));
 #endif
 }
 

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -1193,42 +1193,13 @@ void MainWindow::notifyUserAboutUpdate()
 void MainWindow::actOpenCustomFolder()
 {
     QString dir = settingsCache->getCustomPicsPath();
-#if defined(Q_OS_MAC)
-    QStringList scriptArgs;
-    scriptArgs << QLatin1String("-e");
-    scriptArgs << QString::fromLatin1(R"(tell application "Finder" to open POSIX file "%1")").arg(dir);
-    scriptArgs << QLatin1String("-e");
-    scriptArgs << QLatin1String("tell application \"Finder\" to activate");
-
-    QProcess::execute("/usr/bin/osascript", scriptArgs);
-#elif defined(Q_OS_WIN)
-    QStringList args;
-    args << QDir::toNativeSeparators(dir);
-    QProcess::startDetached("explorer", args);
-#else // LINUX
     QDesktopServices::openUrl(QUrl::fromLocalFile(dir));
-#endif
 }
 
 void MainWindow::actOpenCustomsetsFolder()
 {
     QString dir = settingsCache->getCustomCardDatabasePath();
-
-#if defined(Q_OS_MAC)
-    QStringList scriptArgs;
-    scriptArgs << QLatin1String("-e");
-    scriptArgs << QString::fromLatin1(R"(tell application "Finder" to open POSIX file "%1")").arg(dir);
-    scriptArgs << QLatin1String("-e");
-    scriptArgs << QLatin1String("tell application \"Finder\" to activate");
-
-    QProcess::execute("/usr/bin/osascript", scriptArgs);
-#elif defined(Q_OS_WIN)
-    QStringList args;
-    args << QDir::toNativeSeparators(dir);
-    QProcess::startDetached("explorer", args);
-#else // LINUX
     QDesktopServices::openUrl(QUrl::fromLocalFile(dir));
-#endif
 }
 
 void MainWindow::actAddCustomSet()

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -46,11 +46,11 @@
 #include "version_string.h"
 #include "window_sets.h"
 
-#include <QDesktopServices>
 #include <QAction>
 #include <QApplication>
 #include <QCloseEvent>
 #include <QDateTime>
+#include <QDesktopServices>
 #include <QFile>
 #include <QFileDialog>
 #include <QInputDialog>


### PR DESCRIPTION
this uses QDesktopServices to open the url "file://[location]"
by default this is
"file://$HOME/.local/share/Cockatrice/Cockatrice/pics/CUSTOM"

any distro that has a file browser should have an accompanying mime type
specifying the file handler for the file:// protocol using the
inode/directory mime type

see https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-latest.html

if a user were to have removed their mime database this will not work and
it will fail with nothing but a log message, this would be rare and not
worth checking in my opinion

fixes a ticket that hopefully exists but I can't find