### PR TITLE
Added horizontal layout and stretch for player icon

### DIFF
--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -48,7 +48,7 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *paren
     mainLayout->addWidget(&userLevelLabel1, 5, 0, 1, 1);
     mainLayout->addWidget(&userLevelLabel2, 5, 1, 1, 1);
     mainLayout->addWidget(&userLevelLabel3, 5, 2, 1, 1);
-    mainLayout->addWidget(&accountAgeLebel1, 6, 0, 1, 1);
+    mainLayout->addWidget(&accountAgeLabel1, 6, 0, 1, 1);
     mainLayout->addWidget(&accountAgeLabel2, 6, 2, 1, 1);
     mainLayout->setColumnStretch(2, 10);
 
@@ -74,7 +74,7 @@ void UserInfoBox::retranslateUi()
     realNameLabel1.setText(tr("Real name:"));
     countryLabel1.setText(tr("Location:"));
     userLevelLabel1.setText(tr("User level:"));
-    accountAgeLebel1.setText(tr("Account Age:"));
+    accountAgeLabel1.setText(tr("Account Age:"));
 
     editButton.setText(tr("Edit"));
     passwordButton.setText(tr("Change password"));

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -30,8 +30,14 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *paren
     avatarLabel.setMinimumSize(200, 200);
     avatarLabel.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
+    QHBoxLayout *avatarLayout = new QHBoxLayout;
+    avatarLayout->setContentsMargins(0, 0, 0, 0);
+    avatarLayout->addStretch(1);
+    avatarLayout->addWidget(&avatarLabel, 3);
+    avatarLayout->addStretch(1);
+
     QGridLayout *mainLayout = new QGridLayout;
-    mainLayout->addWidget(&avatarLabel, 0, 1, 1, 1);
+    mainLayout->addLayout(avatarLayout, 0, 0, 1, 3);
     mainLayout->addWidget(&nameLabel, 1, 0, 1, 3);
     mainLayout->addWidget(&realNameLabel1, 2, 0, 1, 1);
     mainLayout->addWidget(&realNameLabel2, 2, 1, 1, 2);
@@ -43,7 +49,7 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *paren
     mainLayout->addWidget(&userLevelLabel3, 5, 2, 1, 1);
     mainLayout->addWidget(&accountAgeLebel1, 6, 0, 1, 1);
     mainLayout->addWidget(&accountAgeLabel2, 6, 2, 1, 1);
-    mainLayout->setColumnStretch(1, 10);
+    mainLayout->setColumnStretch(2, 10);
 
     if (editable) {
         QHBoxLayout *buttonsLayout = new QHBoxLayout;

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -29,6 +29,7 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *paren
 
     avatarLabel.setMinimumSize(200, 200);
     avatarLabel.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    avatarLabel.setAlignment(Qt::AlignCenter);
 
     QHBoxLayout *avatarLayout = new QHBoxLayout;
     avatarLayout->setContentsMargins(0, 0, 0, 0);

--- a/cockatrice/src/userinfobox.h
+++ b/cockatrice/src/userinfobox.h
@@ -16,7 +16,7 @@ private:
     AbstractClient *client;
     bool editable;
     QLabel avatarLabel, nameLabel, realNameLabel1, realNameLabel2, countryLabel1, countryLabel2, countryLabel3,
-        userLevelLabel1, userLevelLabel2, userLevelLabel3, accountAgeLebel1, accountAgeLabel2;
+        userLevelLabel1, userLevelLabel2, userLevelLabel3, accountAgeLabel1, accountAgeLabel2;
     QPushButton editButton, passwordButton, avatarButton;
     QPixmap avatarPixmap;
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4051 

## Short roundup of the initial problem
Previous fix for #2874 via #4009 (making user information box resizable) had effect of separating the user info columns below the player icon.

## What will change with this Pull Request?
- Added a horizontal layout in which there are 2 spacers which keep the player icon centered (while still allowing an expanding size policy)
- Changed the player icon's cell in the grid layout to occupy all three columns instead of just one; changed the stretch factor to be on the second column (as it was before #4009); added center alignment on avatar QLabel to center its QPixmap

## Screenshots
![image](https://user-images.githubusercontent.com/17144156/88448906-84246e00-ce10-11ea-9d94-c94e76ae5005.png)

