### PR TITLE
Refactor SettingCache singleton access

### DIFF
--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -22,7 +22,7 @@ AbstractCardItem::AbstractCardItem(const QString &_name, Player *_owner, int _id
     setFlag(ItemIsSelectable);
     setCacheMode(DeviceCoordinateCache);
 
-    connect(settingsCache, SIGNAL(displayCardNamesChanged()), this, SLOT(callUpdate()));
+    connect(&SettingsCache::instance(), SIGNAL(displayCardNamesChanged()), this, SLOT(callUpdate()));
     cardInfoUpdated();
 }
 
@@ -74,7 +74,7 @@ QSizeF AbstractCardItem::getTranslatedSize(QPainter *painter) const
 
 void AbstractCardItem::transformPainter(QPainter *painter, const QSizeF &translatedSize, int angle)
 {
-    const int MAX_FONT_SIZE = settingsCache->getMaxFontSize();
+    const int MAX_FONT_SIZE = SettingsCache::instance().getMaxFontSize();
     const int fontSize = std::max(9, MAX_FONT_SIZE);
 
     QRectF totalBoundingRect = painter->combinedTransform().mapRect(boundingRect());
@@ -133,7 +133,7 @@ void AbstractCardItem::paintPicture(QPainter *painter, const QSizeF &translatedS
     else
         painter->drawRect(QRectF(1, 1, CARD_WIDTH - 2, CARD_HEIGHT - 1.5));
 
-    if (translatedPixmap.isNull() || settingsCache->getDisplayCardNames() || facedown) {
+    if (translatedPixmap.isNull() || SettingsCache::instance().getDisplayCardNames() || facedown) {
         painter->save();
         transformPainter(painter, translatedSize, angle);
         painter->setPen(Qt::white);
@@ -203,7 +203,7 @@ void AbstractCardItem::setHovered(bool _hovered)
         processHoverEvent();
     isHovered = _hovered;
     setZValue(_hovered ? 2000000004 : realZValue);
-    setScale(_hovered && settingsCache->getScaleCards() ? 1.1 : 1);
+    setScale(_hovered && SettingsCache::instance().getScaleCards() ? 1.1 : 1);
     setTransformOriginPoint(_hovered ? CARD_WIDTH / 2 : 0, _hovered ? CARD_HEIGHT / 2 : 0);
     update();
 }
@@ -256,7 +256,7 @@ void AbstractCardItem::setTapped(bool _tapped, bool canAnimate)
         return;
 
     tapped = _tapped;
-    if (settingsCache->getTapAnimation() && canAnimate)
+    if (SettingsCache::instance().getTapAnimation() && canAnimate)
         static_cast<GameScene *>(scene())->registerAnimationItem(this);
     else {
         tapAngle = tapped ? 90 : 0;

--- a/cockatrice/src/abstractcounter.cpp
+++ b/cockatrice/src/abstractcounter.cpp
@@ -57,7 +57,7 @@ AbstractCounter::AbstractCounter(Player *_player,
         menu = nullptr;
     }
 
-    connect(&settingsCache->shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
+    connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
     refreshShortcuts();
     retranslateUi();
 }
@@ -87,16 +87,17 @@ void AbstractCounter::setShortcutsActive()
     if (!player->getLocal()) {
         return;
     }
+    ShortcutsSettings &shortcuts = SettingsCache::instance().shortcuts();
     if (name == "life") {
         shortcutActive = true;
-        aSet->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aSet"));
-        aDec->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aDec"));
-        aInc->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aInc"));
+        aSet->setShortcuts(shortcuts.getShortcut("Player/aSet"));
+        aDec->setShortcuts(shortcuts.getShortcut("Player/aDec"));
+        aInc->setShortcuts(shortcuts.getShortcut("Player/aInc"));
     } else if (useNameForShortcut) {
         shortcutActive = true;
-        aSet->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aSetCounter_" + name));
-        aDec->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aDecCounter_" + name));
-        aInc->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aIncCounter_" + name));
+        aSet->setShortcuts(shortcuts.getShortcut("Player/aSetCounter_" + name));
+        aDec->setShortcuts(shortcuts.getShortcut("Player/aDecCounter_" + name));
+        aInc->setShortcuts(shortcuts.getShortcut("Player/aIncCounter_" + name));
     }
 }
 

--- a/cockatrice/src/arrowitem.cpp
+++ b/cockatrice/src/arrowitem.cpp
@@ -240,12 +240,12 @@ void ArrowDragItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
         if (startZone->getName().compare("hand") == 0) {
             startCard->playCard(false);
             CardInfoPtr ci = startCard->getInfo();
-            if (ci && (((!settingsCache->getPlayToStack() && ci->getTableRow() == 3) ||
-                        ((settingsCache->getPlayToStack() && ci->getTableRow() != 0) &&
+            if (ci && (((!SettingsCache::instance().getPlayToStack() && ci->getTableRow() == 3) ||
+                        ((SettingsCache::instance().getPlayToStack() && ci->getTableRow() != 0) &&
                          startCard->getZone()->getName().toStdString() != "stack"))))
                 cmd.set_start_zone("stack");
             else
-                cmd.set_start_zone(settingsCache->getPlayToStack() ? "stack" : "table");
+                cmd.set_start_zone(SettingsCache::instance().getPlayToStack() ? "stack" : "table");
         }
         player->sendGameCommand(cmd);
     }

--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -68,27 +68,27 @@ QString CardSet::getCorrectedShortName() const
 
 void CardSet::loadSetOptions()
 {
-    sortKey = settingsCache->cardDatabase().getSortKey(shortName);
-    enabled = settingsCache->cardDatabase().isEnabled(shortName);
-    isknown = settingsCache->cardDatabase().isKnown(shortName);
+    sortKey = SettingsCache::instance().cardDatabase().getSortKey(shortName);
+    enabled = SettingsCache::instance().cardDatabase().isEnabled(shortName);
+    isknown = SettingsCache::instance().cardDatabase().isKnown(shortName);
 }
 
 void CardSet::setSortKey(unsigned int _sortKey)
 {
     sortKey = _sortKey;
-    settingsCache->cardDatabase().setSortKey(shortName, _sortKey);
+    SettingsCache::instance().cardDatabase().setSortKey(shortName, _sortKey);
 }
 
 void CardSet::setEnabled(bool _enabled)
 {
     enabled = _enabled;
-    settingsCache->cardDatabase().setEnabled(shortName, _enabled);
+    SettingsCache::instance().cardDatabase().setEnabled(shortName, _enabled);
 }
 
 void CardSet::setIsKnown(bool _isknown)
 {
     isknown = _isknown;
-    settingsCache->cardDatabase().setIsKnown(shortName, _isknown);
+    SettingsCache::instance().cardDatabase().setIsKnown(shortName, _isknown);
 }
 
 class SetList::KeyCompareFunctor
@@ -337,7 +337,7 @@ CardDatabase::CardDatabase(QObject *parent) : QObject(parent), loadStatus(NotLoa
         connect(parser, SIGNAL(addSet(CardSetPtr)), this, SLOT(addSet(CardSetPtr)), Qt::DirectConnection);
     }
 
-    connect(settingsCache, SIGNAL(cardDatabasePathChanged()), this, SLOT(loadCardDatabases()));
+    connect(&SettingsCache::instance(), SIGNAL(cardDatabasePathChanged()), this, SLOT(loadCardDatabases()));
 }
 
 CardDatabase::~CardDatabase()
@@ -515,12 +515,12 @@ LoadStatus CardDatabase::loadCardDatabases()
 
     clear(); // remove old db
 
-    loadStatus = loadCardDatabase(settingsCache->getCardDatabasePath()); // load main card database
-    loadCardDatabase(settingsCache->getTokenDatabasePath());             // load tokens database
-    loadCardDatabase(settingsCache->getSpoilerCardDatabasePath());       // load spoilers database
+    loadStatus = loadCardDatabase(SettingsCache::instance().getCardDatabasePath()); // load main card database
+    loadCardDatabase(SettingsCache::instance().getTokenDatabasePath());             // load tokens database
+    loadCardDatabase(SettingsCache::instance().getSpoilerCardDatabasePath());       // load spoilers database
 
     // load custom card databases
-    QDir dir(settingsCache->getCustomCardDatabasePath());
+    QDir dir(SettingsCache::instance().getCustomCardDatabasePath());
     for (const QString &fileName :
          dir.entryList(QStringList("*.xml"), QDir::Files | QDir::Readable, QDir::Name | QDir::IgnoreCase)) {
         loadCardDatabase(dir.absoluteFilePath(fileName));
@@ -625,7 +625,8 @@ void CardDatabase::notifyEnabledSetsChanged()
 
 bool CardDatabase::saveCustomTokensToFile()
 {
-    QString fileName = settingsCache->getCustomCardDatabasePath() + "/" + CardDatabase::TOKENS_SETNAME + ".xml";
+    QString fileName =
+        SettingsCache::instance().getCustomCardDatabasePath() + "/" + CardDatabase::TOKENS_SETNAME + ".xml";
 
     SetNameMap tmpSets;
     CardSetPtr customTokensSet = getSet(CardDatabase::TOKENS_SETNAME);

--- a/cockatrice/src/cardframe.cpp
+++ b/cockatrice/src/cardframe.cpp
@@ -55,7 +55,7 @@ CardFrame::CardFrame(const QString &cardName, QWidget *parent) : QTabWidget(pare
     tab3Layout->addWidget(splitter);
     tab3->setLayout(tab3Layout);
 
-    setViewMode(settingsCache->getCardInfoViewMode());
+    setViewMode(SettingsCache::instance().getCardInfoViewMode());
 
     setCard(db->getCard(cardName));
 }
@@ -86,7 +86,7 @@ void CardFrame::setViewMode(int mode)
             break;
     }
 
-    settingsCache->setCardInfoViewMode(mode);
+    SettingsCache::instance().setCardInfoViewMode(mode);
 }
 
 void CardFrame::setCard(CardInfoPtr card)

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -367,7 +367,7 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
             cardMenu->exec(event->screenPos());
         }
     } else if ((event->modifiers() != Qt::AltModifier) && (event->button() == Qt::LeftButton) &&
-               (!settingsCache->getDoubleClickToPlay())) {
+               (!SettingsCache::instance().getDoubleClickToPlay())) {
         bool hideCard = false;
         if (zone && zone->getIsView()) {
             ZoneViewZone *view = static_cast<ZoneViewZone *>(zone);
@@ -387,7 +387,7 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 
 void CardItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
 {
-    if ((event->modifiers() != Qt::AltModifier) && (settingsCache->getDoubleClickToPlay()) &&
+    if ((event->modifiers() != Qt::AltModifier) && (SettingsCache::instance().getDoubleClickToPlay()) &&
         (event->buttons() == Qt::LeftButton)) {
         if (revealedCard)
             zone->removeCard(this);

--- a/cockatrice/src/chatview/chatview.cpp
+++ b/cockatrice/src/chatview/chatview.cpp
@@ -218,11 +218,11 @@ void ChatView::appendMessage(QString message,
     }
     cursor.setCharFormat(defaultFormat);
 
-    bool mentionEnabled = settingsCache->getChatMention();
+    bool mentionEnabled = SettingsCache::instance().getChatMention();
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-    highlightedWords = settingsCache->getHighlightWords().split(' ', Qt::SkipEmptyParts);
+    highlightedWords = SettingsCache::instance().getHighlightWords().split(' ', Qt::SkipEmptyParts);
 #else
-    highlightedWords = settingsCache->getHighlightWords().split(' ', QString::SkipEmptyParts);
+    highlightedWords = SettingsCache::instance().getHighlightWords().split(' ', QString::SkipEmptyParts);
 #endif
 
     // parse the message
@@ -321,8 +321,8 @@ void ChatView::checkMention(QTextCursor &cursor, QString &message, QString &send
                 // You have received a valid mention!!
                 soundEngine->playSound("chat_mention");
                 mentionFormat.setBackground(QBrush(getCustomMentionColor()));
-                mentionFormat.setForeground(settingsCache->getChatMentionForeground() ? QBrush(Qt::white)
-                                                                                      : QBrush(Qt::black));
+                mentionFormat.setForeground(SettingsCache::instance().getChatMentionForeground() ? QBrush(Qt::white)
+                                                                                                 : QBrush(Qt::black));
                 cursor.insertText(mention, mentionFormat);
                 message = message.mid(mention.size());
                 showSystemPopup(sender);
@@ -343,8 +343,8 @@ void ChatView::checkMention(QTextCursor &cursor, QString &message, QString &send
             // Moderator Sending Global Message
             soundEngine->playSound("all_mention");
             mentionFormat.setBackground(QBrush(getCustomMentionColor()));
-            mentionFormat.setForeground(settingsCache->getChatMentionForeground() ? QBrush(Qt::white)
-                                                                                  : QBrush(Qt::black));
+            mentionFormat.setForeground(SettingsCache::instance().getChatMentionForeground() ? QBrush(Qt::white)
+                                                                                             : QBrush(Qt::black));
             cursor.insertText("@" + fullMentionUpToSpaceOrEnd, mentionFormat);
             message = message.mid(fullMentionUpToSpaceOrEnd.size() + 1);
             showSystemPopup(sender);
@@ -391,8 +391,8 @@ void ChatView::checkWord(QTextCursor &cursor, QString &message)
         if (fullWordUpToSpaceOrEnd.compare(word, Qt::CaseInsensitive) == 0) {
             // You have received a valid mention of custom word!!
             highlightFormat.setBackground(QBrush(getCustomHighlightColor()));
-            highlightFormat.setForeground(settingsCache->getChatHighlightForeground() ? QBrush(Qt::white)
-                                                                                      : QBrush(Qt::black));
+            highlightFormat.setForeground(SettingsCache::instance().getChatHighlightForeground() ? QBrush(Qt::white)
+                                                                                                 : QBrush(Qt::black));
             cursor.insertText(fullWordUpToSpaceOrEnd, highlightFormat);
             cursor.insertText(rest, defaultFormat);
             QApplication::alert(this);
@@ -448,7 +448,7 @@ void ChatView::actMessageClicked()
 void ChatView::showSystemPopup(QString &sender)
 {
     QApplication::alert(this);
-    if (settingsCache->getShowMentionPopup()) {
+    if (SettingsCache::instance().getShowMentionPopup()) {
         QString ref = sender.left(sender.length() - 2);
         emit showMentionPopup(ref);
     }
@@ -457,14 +457,14 @@ void ChatView::showSystemPopup(QString &sender)
 QColor ChatView::getCustomMentionColor()
 {
     QColor customColor;
-    customColor.setNamedColor("#" + settingsCache->getChatMentionColor());
+    customColor.setNamedColor("#" + SettingsCache::instance().getChatMentionColor());
     return customColor.isValid() ? customColor : DEFAULT_MENTION_COLOR;
 }
 
 QColor ChatView::getCustomHighlightColor()
 {
     QColor customColor;
-    customColor.setNamedColor("#" + settingsCache->getChatHighlightColor());
+    customColor.setNamedColor("#" + SettingsCache::instance().getChatHighlightColor());
     return customColor.isValid() ? customColor : DEFAULT_MENTION_COLOR;
 }
 

--- a/cockatrice/src/customlineedit.cpp
+++ b/cockatrice/src/customlineedit.cpp
@@ -36,7 +36,7 @@ bool LineEditUnfocusable::isUnfocusShortcut(QKeyEvent *event)
     keyNoMod = QKeySequence(event->key()).toString();
 
     QKeySequence key(modifier + keyNoMod);
-    QList<QKeySequence> unfocusShortcut = settingsCache->shortcuts().getShortcut("Textbox/unfocusTextBox");
+    QList<QKeySequence> unfocusShortcut = SettingsCache::instance().shortcuts().getShortcut("Textbox/unfocusTextBox");
 
     for (QList<QKeySequence>::iterator i = unfocusShortcut.begin(); i != unfocusShortcut.end(); ++i) {
         if (key.matches(*i) == QKeySequence::ExactMatch)

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -63,11 +63,11 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     autoConnectCheckBox = new QCheckBox(tr("A&uto connect"));
     autoConnectCheckBox->setToolTip(tr("Automatically connect to the most recent login when Cockatrice opens"));
 
-    if (settingsCache->servers().getSavePassword()) {
-        autoConnectCheckBox->setChecked(static_cast<bool>(settingsCache->servers().getAutoConnect()));
+    if (SettingsCache::instance().servers().getSavePassword()) {
+        autoConnectCheckBox->setChecked(static_cast<bool>(SettingsCache::instance().servers().getAutoConnect()));
         autoConnectCheckBox->setEnabled(true);
     } else {
-        settingsCache->servers().setAutoConnect(0);
+        SettingsCache::instance().servers().setAutoConnect(0);
         autoConnectCheckBox->setChecked(false);
         autoConnectCheckBox->setEnabled(false);
     }
@@ -192,8 +192,8 @@ void DlgConnect::rebuildComboBoxList(int failure)
     UserConnection_Information uci;
     savedHostList = uci.getServerInfo();
 
-    bool autoConnectEnabled = static_cast<bool>(settingsCache->servers().getAutoConnect());
-    QString autoConnectSaveName = settingsCache->servers().getSaveName();
+    bool autoConnectEnabled = static_cast<bool>(SettingsCache::instance().servers().getAutoConnect());
+    QString autoConnectSaveName = SettingsCache::instance().servers().getSaveName();
 
     int index = 0;
 
@@ -297,23 +297,24 @@ void DlgConnect::passwordSaved(int state)
 
 void DlgConnect::actOk()
 {
+    ServersSettings &servers = SettingsCache::instance().servers();
+
     if (newHostButton->isChecked()) {
         if (saveEdit->text().isEmpty()) {
             QMessageBox::critical(this, tr("Connection Warning"), tr("You need to name your new connection profile."));
             return;
         }
 
-        settingsCache->servers().addNewServer(saveEdit->text().trimmed(), hostEdit->text().trimmed(),
-                                              portEdit->text().trimmed(), playernameEdit->text().trimmed(),
-                                              passwordEdit->text(), savePasswordCheckBox->isChecked());
+        servers.addNewServer(saveEdit->text().trimmed(), hostEdit->text().trimmed(), portEdit->text().trimmed(),
+                             playernameEdit->text().trimmed(), passwordEdit->text(), savePasswordCheckBox->isChecked());
     } else {
-        settingsCache->servers().updateExistingServer(saveEdit->text().trimmed(), hostEdit->text().trimmed(),
-                                                      portEdit->text().trimmed(), playernameEdit->text().trimmed(),
-                                                      passwordEdit->text(), savePasswordCheckBox->isChecked());
+        servers.updateExistingServer(saveEdit->text().trimmed(), hostEdit->text().trimmed(), portEdit->text().trimmed(),
+                                     playernameEdit->text().trimmed(), passwordEdit->text(),
+                                     savePasswordCheckBox->isChecked());
     }
 
-    settingsCache->servers().setPrevioushostName(saveEdit->text());
-    settingsCache->servers().setAutoConnect(autoConnectCheckBox->isChecked());
+    servers.setPrevioushostName(saveEdit->text());
+    servers.setAutoConnect(autoConnectCheckBox->isChecked());
 
     if (playernameEdit->text().isEmpty()) {
         QMessageBox::critical(this, tr("Connect Warning"), tr("The player name can't be empty."));

--- a/cockatrice/src/dlg_create_token.cpp
+++ b/cockatrice/src/dlg_create_token.cpp
@@ -77,7 +77,7 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
     chooseTokenFromDeckRadioButton = new QRadioButton(tr("Show tokens from this &deck"));
     connect(chooseTokenFromDeckRadioButton, SIGNAL(toggled(bool)), this, SLOT(actChooseTokenFromDeck(bool)));
 
-    QByteArray deckHeaderState = settingsCache->layouts().getDeckEditorDbHeaderState();
+    QByteArray deckHeaderState = SettingsCache::instance().layouts().getDeckEditorDbHeaderState();
     chooseTokenView = new QTreeView;
     chooseTokenView->setModel(cardDatabaseDisplayModel);
     chooseTokenView->setUniformRowHeights(true);
@@ -137,13 +137,13 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
     setWindowTitle(tr("Create token"));
 
     resize(600, 500);
-    restoreGeometry(settingsCache->getTokenDialogGeometry());
+    restoreGeometry(SettingsCache::instance().getTokenDialogGeometry());
 }
 
 void DlgCreateToken::closeEvent(QCloseEvent *event)
 {
     event->accept();
-    settingsCache->setTokenDialogGeometry(saveGeometry());
+    SettingsCache::instance().setTokenDialogGeometry(saveGeometry());
 }
 
 void DlgCreateToken::tokenSelectionChanged(const QModelIndex &current, const QModelIndex & /*previous*/)
@@ -161,7 +161,7 @@ void DlgCreateToken::tokenSelectionChanged(const QModelIndex &current, const QMo
         const QChar cardColor = cardInfo->getColorChar();
         colorEdit->setCurrentIndex(colorEdit->findData(cardColor, Qt::UserRole, Qt::MatchFixedString));
         ptEdit->setText(cardInfo->getPowTough());
-        if (settingsCache->getAnnotateTokens())
+        if (SettingsCache::instance().getAnnotateTokens())
             annotationEdit->setText(cardInfo->getText());
     } else {
         nameEdit->setText("");
@@ -205,13 +205,13 @@ void DlgCreateToken::actChooseTokenFromDeck(bool checked)
 
 void DlgCreateToken::actOk()
 {
-    settingsCache->setTokenDialogGeometry(saveGeometry());
+    SettingsCache::instance().setTokenDialogGeometry(saveGeometry());
     accept();
 }
 
 void DlgCreateToken::actReject()
 {
-    settingsCache->setTokenDialogGeometry(saveGeometry());
+    SettingsCache::instance().setTokenDialogGeometry(saveGeometry());
     reject();
 }
 

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -49,7 +49,7 @@ void DlgCreateGame::sharedCtor()
         QRadioButton *gameTypeRadioButton = new QRadioButton(gameTypeIterator.value(), this);
         gameTypeLayout->addWidget(gameTypeRadioButton);
         gameTypeCheckBoxes.insert(gameTypeIterator.key(), gameTypeRadioButton);
-        bool isChecked = settingsCache->getGameTypes().contains(gameTypeIterator.value() + ", ");
+        bool isChecked = SettingsCache::instance().getGameTypes().contains(gameTypeIterator.value() + ", ");
         gameTypeCheckBoxes[gameTypeIterator.key()]->setChecked(isChecked);
     }
     QGroupBox *gameTypeGroupBox = new QGroupBox(tr("Game type"));
@@ -115,20 +115,20 @@ DlgCreateGame::DlgCreateGame(TabRoom *_room, const QMap<int, QString> &_gameType
 {
     sharedCtor();
 
-    rememberGameSettings->setChecked(settingsCache->getRememberGameSettings());
-    descriptionEdit->setText(settingsCache->getGameDescription());
-    maxPlayersEdit->setValue(settingsCache->getMaxPlayers());
+    rememberGameSettings->setChecked(SettingsCache::instance().getRememberGameSettings());
+    descriptionEdit->setText(SettingsCache::instance().getGameDescription());
+    maxPlayersEdit->setValue(SettingsCache::instance().getMaxPlayers());
     if (room && room->getUserInfo()->user_level() & ServerInfo_User::IsRegistered) {
-        onlyBuddiesCheckBox->setChecked(settingsCache->getOnlyBuddies());
-        onlyRegisteredCheckBox->setChecked(settingsCache->getOnlyRegistered());
+        onlyBuddiesCheckBox->setChecked(SettingsCache::instance().getOnlyBuddies());
+        onlyRegisteredCheckBox->setChecked(SettingsCache::instance().getOnlyRegistered());
     } else {
         onlyBuddiesCheckBox->setEnabled(false);
         onlyRegisteredCheckBox->setEnabled(false);
     }
-    spectatorsAllowedCheckBox->setChecked(settingsCache->getSpectatorsAllowed());
-    spectatorsNeedPasswordCheckBox->setChecked(settingsCache->getSpectatorsNeedPassword());
-    spectatorsCanTalkCheckBox->setChecked(settingsCache->getSpectatorsCanTalk());
-    spectatorsSeeEverythingCheckBox->setChecked(settingsCache->getSpectatorsCanSeeEverything());
+    spectatorsAllowedCheckBox->setChecked(SettingsCache::instance().getSpectatorsAllowed());
+    spectatorsNeedPasswordCheckBox->setChecked(SettingsCache::instance().getSpectatorsNeedPassword());
+    spectatorsCanTalkCheckBox->setChecked(SettingsCache::instance().getSpectatorsCanTalk());
+    spectatorsSeeEverythingCheckBox->setChecked(SettingsCache::instance().getSpectatorsCanSeeEverything());
 
     if (!rememberGameSettings->isChecked()) {
         actReset();
@@ -237,17 +237,17 @@ void DlgCreateGame::actOK()
         }
     }
 
-    settingsCache->setRememberGameSettings(rememberGameSettings->isChecked());
+    SettingsCache::instance().setRememberGameSettings(rememberGameSettings->isChecked());
     if (rememberGameSettings->isChecked()) {
-        settingsCache->setGameDescription(descriptionEdit->text());
-        settingsCache->setMaxPlayers(maxPlayersEdit->value());
-        settingsCache->setOnlyBuddies(onlyBuddiesCheckBox->isChecked());
-        settingsCache->setOnlyRegistered(onlyRegisteredCheckBox->isChecked());
-        settingsCache->setSpectatorsAllowed(spectatorsAllowedCheckBox->isChecked());
-        settingsCache->setSpectatorsNeedPassword(spectatorsNeedPasswordCheckBox->isChecked());
-        settingsCache->setSpectatorsCanTalk(spectatorsCanTalkCheckBox->isChecked());
-        settingsCache->setSpectatorsCanSeeEverything(spectatorsSeeEverythingCheckBox->isChecked());
-        settingsCache->setGameTypes(gameTypes);
+        SettingsCache::instance().setGameDescription(descriptionEdit->text());
+        SettingsCache::instance().setMaxPlayers(maxPlayersEdit->value());
+        SettingsCache::instance().setOnlyBuddies(onlyBuddiesCheckBox->isChecked());
+        SettingsCache::instance().setOnlyRegistered(onlyRegisteredCheckBox->isChecked());
+        SettingsCache::instance().setSpectatorsAllowed(spectatorsAllowedCheckBox->isChecked());
+        SettingsCache::instance().setSpectatorsNeedPassword(spectatorsNeedPasswordCheckBox->isChecked());
+        SettingsCache::instance().setSpectatorsCanTalk(spectatorsCanTalkCheckBox->isChecked());
+        SettingsCache::instance().setSpectatorsCanSeeEverything(spectatorsSeeEverythingCheckBox->isChecked());
+        SettingsCache::instance().setGameTypes(gameTypes);
     }
     PendingCommand *pend = room->prepareRoomCommand(cmd);
     connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(checkResponse(Response)));

--- a/cockatrice/src/dlg_edit_password.cpp
+++ b/cockatrice/src/dlg_edit_password.cpp
@@ -14,8 +14,8 @@ DlgEditPassword::DlgEditPassword(QWidget *parent) : QDialog(parent)
     oldPasswordLabel = new QLabel(tr("Old password:"));
     oldPasswordEdit = new QLineEdit();
 
-    if (settingsCache->servers().getSavePassword())
-        oldPasswordEdit->setText(settingsCache->servers().getPassword());
+    if (SettingsCache::instance().servers().getSavePassword())
+        oldPasswordEdit->setText(SettingsCache::instance().servers().getPassword());
 
     oldPasswordLabel->setBuddy(oldPasswordEdit);
     oldPasswordEdit->setEchoMode(QLineEdit::Password);
@@ -60,6 +60,6 @@ void DlgEditPassword::actOk()
     }
 
     // always save the password so it will be picked up by the connect dialog
-    settingsCache->servers().setPassword(newPasswordEdit->text());
+    SettingsCache::instance().servers().setPassword(newPasswordEdit->text());
     accept();
 }

--- a/cockatrice/src/dlg_edit_user.cpp
+++ b/cockatrice/src/dlg_edit_user.cpp
@@ -21,7 +21,7 @@ DlgEditUser::DlgEditUser(QWidget *parent, QString email, QString country, QStrin
     countryEdit->insertItem(0, tr("Undefined"));
     countryEdit->setCurrentIndex(0);
 
-    QStringList countries = settingsCache->getCountries();
+    QStringList countries = SettingsCache::instance().getCountries();
     int i = 1;
     foreach (QString c, countries) {
         countryEdit->addItem(QPixmap("theme:countries/" + c.toLower()), c);

--- a/cockatrice/src/dlg_forgotpasswordchallenge.cpp
+++ b/cockatrice/src/dlg_forgotpasswordchallenge.cpp
@@ -16,19 +16,18 @@ DlgForgotPasswordChallenge::DlgForgotPasswordChallenge(QWidget *parent) : QDialo
     QString lastfphost;
     QString lastfpport;
     QString lastfpplayername;
-    lastfphost = settingsCache->servers().getHostname("server.cockatrice.us");
-    lastfpport = settingsCache->servers().getPort("4747");
-    lastfpplayername = settingsCache->servers().getPlayerName("Player");
+    ServersSettings &servers = SettingsCache::instance().servers();
+    lastfphost = servers.getHostname("server.cockatrice.us");
+    lastfpport = servers.getPort("4747");
+    lastfpplayername = servers.getPlayerName("Player");
 
-    if (!settingsCache->servers().getFPHostname().isEmpty() && !settingsCache->servers().getFPPort().isEmpty() &&
-        !settingsCache->servers().getFPPlayerName().isEmpty()) {
-        lastfphost = settingsCache->servers().getFPHostname();
-        lastfpport = settingsCache->servers().getFPPort();
-        lastfpplayername = settingsCache->servers().getFPPlayerName();
+    if (!servers.getFPHostname().isEmpty() && !servers.getFPPort().isEmpty() && !servers.getFPPlayerName().isEmpty()) {
+        lastfphost = servers.getFPHostname();
+        lastfpport = servers.getFPPort();
+        lastfpplayername = servers.getFPPlayerName();
     }
 
-    if (settingsCache->servers().getFPHostname().isEmpty() && settingsCache->servers().getFPPort().isEmpty() &&
-        settingsCache->servers().getFPPlayerName().isEmpty()) {
+    if (servers.getFPHostname().isEmpty() && servers.getFPPort().isEmpty() && servers.getFPPlayerName().isEmpty()) {
         QMessageBox::warning(this, tr("Forgot Password Challenge Warning"),
                              tr("Oops, looks like something has gone wrong.  Please restart the forgot password "
                                 "process by using the forgot password button on the connection screen."));
@@ -51,8 +50,7 @@ DlgForgotPasswordChallenge::DlgForgotPasswordChallenge(QWidget *parent) : QDialo
     emailEdit = new QLineEdit();
     emailLabel->setBuddy(emailLabel);
 
-    if (!settingsCache->servers().getFPHostname().isEmpty() && !settingsCache->servers().getFPPort().isEmpty() &&
-        !settingsCache->servers().getFPPlayerName().isEmpty()) {
+    if (!servers.getFPHostname().isEmpty() && !servers.getFPPort().isEmpty() && !servers.getFPPlayerName().isEmpty()) {
         hostLabel->hide();
         hostEdit->hide();
         portLabel->hide();
@@ -92,9 +90,10 @@ void DlgForgotPasswordChallenge::actOk()
         return;
     }
 
-    settingsCache->servers().setFPHostName(hostEdit->text());
-    settingsCache->servers().setFPPort(portEdit->text());
-    settingsCache->servers().setFPPlayerName(playernameEdit->text());
+    ServersSettings &servers = SettingsCache::instance().servers();
+    servers.setFPHostName(hostEdit->text());
+    servers.setFPPort(portEdit->text());
+    servers.setFPPlayerName(playernameEdit->text());
 
     accept();
 }

--- a/cockatrice/src/dlg_forgotpasswordrequest.cpp
+++ b/cockatrice/src/dlg_forgotpasswordrequest.cpp
@@ -16,15 +16,15 @@ DlgForgotPasswordRequest::DlgForgotPasswordRequest(QWidget *parent) : QDialog(pa
     QString lastfphost;
     QString lastfpport;
     QString lastfpplayername;
-    lastfphost = settingsCache->servers().getHostname("server.cockatrice.us");
-    lastfpport = settingsCache->servers().getPort("4747");
-    lastfpplayername = settingsCache->servers().getPlayerName("Player");
+    ServersSettings &servers = SettingsCache::instance().servers();
+    lastfphost = servers.getHostname("server.cockatrice.us");
+    lastfpport = servers.getPort("4747");
+    lastfpplayername = servers.getPlayerName("Player");
 
-    if (!settingsCache->servers().getFPHostname().isEmpty() && !settingsCache->servers().getFPPort().isEmpty() &&
-        !settingsCache->servers().getFPPlayerName().isEmpty()) {
-        lastfphost = settingsCache->servers().getFPHostname();
-        lastfpport = settingsCache->servers().getFPPort();
-        lastfpplayername = settingsCache->servers().getFPPlayerName();
+    if (!servers.getFPHostname().isEmpty() && !servers.getFPPort().isEmpty() && !servers.getFPPlayerName().isEmpty()) {
+        lastfphost = servers.getFPHostname();
+        lastfpport = servers.getFPPort();
+        lastfpplayername = servers.getFPPlayerName();
     }
 
     hostLabel = new QLabel(tr("&Host:"));
@@ -68,9 +68,10 @@ void DlgForgotPasswordRequest::actOk()
         return;
     }
 
-    settingsCache->servers().setFPHostName(hostEdit->text());
-    settingsCache->servers().setFPPort(portEdit->text());
-    settingsCache->servers().setFPPlayerName(playernameEdit->text());
+    ServersSettings &servers = SettingsCache::instance().servers();
+    servers.setFPHostName(hostEdit->text());
+    servers.setFPPort(portEdit->text());
+    servers.setFPPlayerName(playernameEdit->text());
 
     accept();
 }

--- a/cockatrice/src/dlg_forgotpasswordreset.cpp
+++ b/cockatrice/src/dlg_forgotpasswordreset.cpp
@@ -16,19 +16,18 @@ DlgForgotPasswordReset::DlgForgotPasswordReset(QWidget *parent) : QDialog(parent
     QString lastfphost;
     QString lastfpport;
     QString lastfpplayername;
-    lastfphost = settingsCache->servers().getHostname("server.cockatrice.us");
-    lastfpport = settingsCache->servers().getPort("4747");
-    lastfpplayername = settingsCache->servers().getPlayerName("Player");
+    ServersSettings &servers = SettingsCache::instance().servers();
+    lastfphost = servers.getHostname("server.cockatrice.us");
+    lastfpport = servers.getPort("4747");
+    lastfpplayername = servers.getPlayerName("Player");
 
-    if (!settingsCache->servers().getFPHostname().isEmpty() && !settingsCache->servers().getFPPort().isEmpty() &&
-        !settingsCache->servers().getFPPlayerName().isEmpty()) {
-        lastfphost = settingsCache->servers().getFPHostname();
-        lastfpport = settingsCache->servers().getFPPort();
-        lastfpplayername = settingsCache->servers().getFPPlayerName();
+    if (!servers.getFPHostname().isEmpty() && !servers.getFPPort().isEmpty() && !servers.getFPPlayerName().isEmpty()) {
+        lastfphost = servers.getFPHostname();
+        lastfpport = servers.getFPPort();
+        lastfpplayername = servers.getFPPlayerName();
     }
 
-    if (settingsCache->servers().getFPHostname().isEmpty() && settingsCache->servers().getFPPort().isEmpty() &&
-        settingsCache->servers().getFPPlayerName().isEmpty()) {
+    if (servers.getFPHostname().isEmpty() && servers.getFPPort().isEmpty() && servers.getFPPlayerName().isEmpty()) {
         QMessageBox::warning(this, tr("Forgot Password Reset Warning"),
                              tr("Oops, looks like something has gone wrong. Please re-start the forgot password "
                                 "process by using the forgot password button on the connection screen."));
@@ -61,8 +60,7 @@ DlgForgotPasswordReset::DlgForgotPasswordReset(QWidget *parent) : QDialog(parent
     newpasswordverifyLabel->setBuddy(newpasswordEdit);
     newpasswordverifyEdit->setEchoMode(QLineEdit::Password);
 
-    if (!settingsCache->servers().getFPHostname().isEmpty() && !settingsCache->servers().getFPPort().isEmpty() &&
-        !settingsCache->servers().getFPPlayerName().isEmpty()) {
+    if (!servers.getFPHostname().isEmpty() && !servers.getFPPort().isEmpty() && !servers.getFPPlayerName().isEmpty()) {
         hostLabel->hide();
         hostEdit->hide();
         portLabel->hide();
@@ -121,9 +119,10 @@ void DlgForgotPasswordReset::actOk()
         return;
     }
 
-    settingsCache->servers().setFPHostName(hostEdit->text());
-    settingsCache->servers().setFPPort(portEdit->text());
-    settingsCache->servers().setFPPlayerName(playernameEdit->text());
+    ServersSettings &servers = SettingsCache::instance().servers();
+    servers.setFPHostName(hostEdit->text());
+    servers.setFPPort(portEdit->text());
+    servers.setFPPlayerName(playernameEdit->text());
 
     accept();
 }

--- a/cockatrice/src/dlg_load_deck_from_clipboard.cpp
+++ b/cockatrice/src/dlg_load_deck_from_clipboard.cpp
@@ -34,7 +34,7 @@ DlgLoadDeckFromClipboard::DlgLoadDeckFromClipboard(QWidget *parent) : QDialog(pa
     resize(500, 500);
 
     actRefresh();
-    connect(&settingsCache->shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
+    connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
     refreshShortcuts();
 }
 
@@ -45,7 +45,8 @@ void DlgLoadDeckFromClipboard::actRefresh()
 
 void DlgLoadDeckFromClipboard::refreshShortcuts()
 {
-    refreshButton->setShortcut(settingsCache->shortcuts().getSingleShortcut("DlgLoadDeckFromClipboard/refreshButton"));
+    refreshButton->setShortcut(
+        SettingsCache::instance().shortcuts().getSingleShortcut("DlgLoadDeckFromClipboard/refreshButton"));
 }
 
 void DlgLoadDeckFromClipboard::actOK()

--- a/cockatrice/src/dlg_register.cpp
+++ b/cockatrice/src/dlg_register.cpp
@@ -13,20 +13,21 @@
 
 DlgRegister::DlgRegister(QWidget *parent) : QDialog(parent)
 {
+    ServersSettings &servers = SettingsCache::instance().servers();
     hostLabel = new QLabel(tr("&Host:"));
-    hostEdit = new QLineEdit(settingsCache->servers().getHostname("server.cockatrice.us"));
+    hostEdit = new QLineEdit(servers.getHostname("server.cockatrice.us"));
     hostLabel->setBuddy(hostEdit);
 
     portLabel = new QLabel(tr("&Port:"));
-    portEdit = new QLineEdit(settingsCache->servers().getPort("4747"));
+    portEdit = new QLineEdit(servers.getPort("4747"));
     portLabel->setBuddy(portEdit);
 
     playernameLabel = new QLabel(tr("Player &name:"));
-    playernameEdit = new QLineEdit(settingsCache->servers().getPlayerName("Player"));
+    playernameEdit = new QLineEdit(servers.getPlayerName("Player"));
     playernameLabel->setBuddy(playernameEdit);
 
     passwordLabel = new QLabel(tr("P&assword:"));
-    passwordEdit = new QLineEdit(settingsCache->servers().getPassword());
+    passwordEdit = new QLineEdit(servers.getPassword());
     passwordLabel->setBuddy(passwordEdit);
     passwordEdit->setEchoMode(QLineEdit::Password);
 
@@ -297,7 +298,7 @@ DlgRegister::DlgRegister(QWidget *parent) : QDialog(parent)
     countryEdit->addItem(QPixmap("theme:countries/zm"), "zm");
     countryEdit->addItem(QPixmap("theme:countries/zw"), "zw");
     countryEdit->setCurrentIndex(0);
-    QStringList countries = settingsCache->getCountries();
+    QStringList countries = SettingsCache::instance().getCountries();
     foreach (QString c, countries)
         countryEdit->addItem(QPixmap("theme:countries/" + c.toLower()), c);
 
@@ -354,11 +355,12 @@ void DlgRegister::actOk()
         return;
     }
 
-    settingsCache->servers().setHostName(hostEdit->text());
-    settingsCache->servers().setPort(portEdit->text());
-    settingsCache->servers().setPlayerName(playernameEdit->text());
+    ServersSettings &servers = SettingsCache::instance().servers();
+    servers.setHostName(hostEdit->text());
+    servers.setPort(portEdit->text());
+    servers.setPlayerName(playernameEdit->text());
     // always save the password so it will be picked up by the connect dialog
-    settingsCache->servers().setPassword(passwordEdit->text());
+    servers.setPassword(passwordEdit->text());
 
     accept();
 }

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -42,7 +42,7 @@
 
 GeneralSettingsPage::GeneralSettingsPage()
 {
-    QString setLanguage = settingsCache->getLang();
+    QString setLanguage = SettingsCache::instance().getLang();
     QStringList qmFiles = findQmFiles();
     for (int i = 0; i < qmFiles.size(); i++) {
         QString langName = languageName(qmFiles[i]);
@@ -53,32 +53,34 @@ GeneralSettingsPage::GeneralSettingsPage()
     }
 
     // updates
-    QList<ReleaseChannel *> channels = settingsCache->getUpdateReleaseChannels();
+    QList<ReleaseChannel *> channels = SettingsCache::instance().getUpdateReleaseChannels();
     foreach (ReleaseChannel *chan, channels) {
         updateReleaseChannelBox.insertItem(chan->getIndex(), tr(chan->getName().toUtf8()));
     }
-    updateReleaseChannelBox.setCurrentIndex(settingsCache->getUpdateReleaseChannel()->getIndex());
+    updateReleaseChannelBox.setCurrentIndex(SettingsCache::instance().getUpdateReleaseChannel()->getIndex());
 
-    updateNotificationCheckBox.setChecked(settingsCache->getNotifyAboutUpdates());
-    newVersionOracleCheckBox.setChecked(settingsCache->getNotifyAboutNewVersion());
+    updateNotificationCheckBox.setChecked(SettingsCache::instance().getNotifyAboutUpdates());
+    newVersionOracleCheckBox.setChecked(SettingsCache::instance().getNotifyAboutNewVersion());
 
     // pixmap cache
     pixmapCacheEdit.setMinimum(PIXMAPCACHE_SIZE_MIN);
     // 2047 is the max value to avoid overflowing of QPixmapCache::setCacheLimit(int size)
     pixmapCacheEdit.setMaximum(PIXMAPCACHE_SIZE_MAX);
     pixmapCacheEdit.setSingleStep(64);
-    pixmapCacheEdit.setValue(settingsCache->getPixmapCacheSize());
+    pixmapCacheEdit.setValue(SettingsCache::instance().getPixmapCacheSize());
     pixmapCacheEdit.setSuffix(" MB");
 
-    showTipsOnStartup.setChecked(settingsCache->getShowTipsOnStartup());
+    showTipsOnStartup.setChecked(SettingsCache::instance().getShowTipsOnStartup());
 
     connect(&languageBox, SIGNAL(currentIndexChanged(int)), this, SLOT(languageBoxChanged(int)));
-    connect(&pixmapCacheEdit, SIGNAL(valueChanged(int)), settingsCache, SLOT(setPixmapCacheSize(int)));
-    connect(&updateReleaseChannelBox, SIGNAL(currentIndexChanged(int)), settingsCache,
+    connect(&pixmapCacheEdit, SIGNAL(valueChanged(int)), &SettingsCache::instance(), SLOT(setPixmapCacheSize(int)));
+    connect(&updateReleaseChannelBox, SIGNAL(currentIndexChanged(int)), &SettingsCache::instance(),
             SLOT(setUpdateReleaseChannel(int)));
-    connect(&updateNotificationCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setNotifyAboutUpdate(int)));
-    connect(&newVersionOracleCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setNotifyAboutNewVersion(int)));
-    connect(&showTipsOnStartup, SIGNAL(clicked(bool)), settingsCache, SLOT(setShowTipsOnStartup(bool)));
+    connect(&updateNotificationCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
+            SLOT(setNotifyAboutUpdate(int)));
+    connect(&newVersionOracleCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
+            SLOT(setNotifyAboutNewVersion(int)));
+    connect(&showTipsOnStartup, SIGNAL(clicked(bool)), &SettingsCache::instance(), SLOT(setShowTipsOnStartup(bool)));
 
     auto *personalGrid = new QGridLayout;
     personalGrid->addWidget(&languageLabel, 0, 0);
@@ -94,32 +96,32 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGroupBox = new QGroupBox;
     personalGroupBox->setLayout(personalGrid);
 
-    deckPathEdit = new QLineEdit(settingsCache->getDeckPath());
+    deckPathEdit = new QLineEdit(SettingsCache::instance().getDeckPath());
     deckPathEdit->setReadOnly(true);
     QPushButton *deckPathButton = new QPushButton("...");
     connect(deckPathButton, SIGNAL(clicked()), this, SLOT(deckPathButtonClicked()));
 
-    replaysPathEdit = new QLineEdit(settingsCache->getReplaysPath());
+    replaysPathEdit = new QLineEdit(SettingsCache::instance().getReplaysPath());
     replaysPathEdit->setReadOnly(true);
     QPushButton *replaysPathButton = new QPushButton("...");
     connect(replaysPathButton, SIGNAL(clicked()), this, SLOT(replaysPathButtonClicked()));
 
-    picsPathEdit = new QLineEdit(settingsCache->getPicsPath());
+    picsPathEdit = new QLineEdit(SettingsCache::instance().getPicsPath());
     picsPathEdit->setReadOnly(true);
     QPushButton *picsPathButton = new QPushButton("...");
     connect(picsPathButton, SIGNAL(clicked()), this, SLOT(picsPathButtonClicked()));
 
-    cardDatabasePathEdit = new QLineEdit(settingsCache->getCardDatabasePath());
+    cardDatabasePathEdit = new QLineEdit(SettingsCache::instance().getCardDatabasePath());
     cardDatabasePathEdit->setReadOnly(true);
     QPushButton *cardDatabasePathButton = new QPushButton("...");
     connect(cardDatabasePathButton, SIGNAL(clicked()), this, SLOT(cardDatabasePathButtonClicked()));
 
-    tokenDatabasePathEdit = new QLineEdit(settingsCache->getTokenDatabasePath());
+    tokenDatabasePathEdit = new QLineEdit(SettingsCache::instance().getTokenDatabasePath());
     tokenDatabasePathEdit->setReadOnly(true);
     QPushButton *tokenDatabasePathButton = new QPushButton("...");
     connect(tokenDatabasePathButton, SIGNAL(clicked()), this, SLOT(tokenDatabasePathButtonClicked()));
 
-    if (settingsCache->getIsPortableBuild()) {
+    if (SettingsCache::instance().getIsPortableBuild()) {
         deckPathEdit->setEnabled(false);
         replaysPathEdit->setEnabled(false);
         picsPathEdit->setEnabled(false);
@@ -185,7 +187,7 @@ void GeneralSettingsPage::deckPathButtonClicked()
         return;
 
     deckPathEdit->setText(path);
-    settingsCache->setDeckPath(path);
+    SettingsCache::instance().setDeckPath(path);
 }
 
 void GeneralSettingsPage::replaysPathButtonClicked()
@@ -195,7 +197,7 @@ void GeneralSettingsPage::replaysPathButtonClicked()
         return;
 
     replaysPathEdit->setText(path);
-    settingsCache->setReplaysPath(path);
+    SettingsCache::instance().setReplaysPath(path);
 }
 
 void GeneralSettingsPage::picsPathButtonClicked()
@@ -205,7 +207,7 @@ void GeneralSettingsPage::picsPathButtonClicked()
         return;
 
     picsPathEdit->setText(path);
-    settingsCache->setPicsPath(path);
+    SettingsCache::instance().setPicsPath(path);
 }
 
 void GeneralSettingsPage::cardDatabasePathButtonClicked()
@@ -215,7 +217,7 @@ void GeneralSettingsPage::cardDatabasePathButtonClicked()
         return;
 
     cardDatabasePathEdit->setText(path);
-    settingsCache->setCardDatabasePath(path);
+    SettingsCache::instance().setCardDatabasePath(path);
 }
 
 void GeneralSettingsPage::tokenDatabasePathButtonClicked()
@@ -225,12 +227,12 @@ void GeneralSettingsPage::tokenDatabasePathButtonClicked()
         return;
 
     tokenDatabasePathEdit->setText(path);
-    settingsCache->setTokenDatabasePath(path);
+    SettingsCache::instance().setTokenDatabasePath(path);
 }
 
 void GeneralSettingsPage::languageBoxChanged(int index)
 {
-    settingsCache->setLang(languageBox.itemData(index).toString());
+    SettingsCache::instance().setLang(languageBox.itemData(index).toString());
 }
 
 void GeneralSettingsPage::retranslateUi()
@@ -238,7 +240,7 @@ void GeneralSettingsPage::retranslateUi()
     personalGroupBox->setTitle(tr("Personal settings"));
     languageLabel.setText(tr("Language:"));
 
-    if (settingsCache->getIsPortableBuild()) {
+    if (SettingsCache::instance().getIsPortableBuild()) {
         pathsGroupBox->setTitle(tr("Paths (editing disabled in portable mode)"));
     } else {
         pathsGroupBox->setTitle(tr("Paths"));
@@ -258,7 +260,7 @@ void GeneralSettingsPage::retranslateUi()
 
 AppearanceSettingsPage::AppearanceSettingsPage()
 {
-    QString themeName = settingsCache->getThemeName();
+    QString themeName = SettingsCache::instance().getThemeName();
 
     QStringList themeDirs = themeManager->getAvailableThemes().keys();
     for (int i = 0; i < themeDirs.size(); i++) {
@@ -276,11 +278,12 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     themeGroupBox = new QGroupBox;
     themeGroupBox->setLayout(themeGrid);
 
-    displayCardNamesCheckBox.setChecked(settingsCache->getDisplayCardNames());
-    connect(&displayCardNamesCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setDisplayCardNames(int)));
+    displayCardNamesCheckBox.setChecked(SettingsCache::instance().getDisplayCardNames());
+    connect(&displayCardNamesCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
+            SLOT(setDisplayCardNames(int)));
 
-    cardScalingCheckBox.setChecked(settingsCache->getScaleCards());
-    connect(&cardScalingCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setCardScaling(int)));
+    cardScalingCheckBox.setChecked(SettingsCache::instance().getScaleCards());
+    connect(&cardScalingCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(), SLOT(setCardScaling(int)));
 
     auto *cardsGrid = new QGridLayout;
     cardsGrid->addWidget(&displayCardNamesCheckBox, 0, 0, 1, 2);
@@ -289,11 +292,13 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     cardsGroupBox = new QGroupBox;
     cardsGroupBox->setLayout(cardsGrid);
 
-    horizontalHandCheckBox.setChecked(settingsCache->getHorizontalHand());
-    connect(&horizontalHandCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setHorizontalHand(int)));
+    horizontalHandCheckBox.setChecked(SettingsCache::instance().getHorizontalHand());
+    connect(&horizontalHandCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
+            SLOT(setHorizontalHand(int)));
 
-    leftJustifiedHandCheckBox.setChecked(settingsCache->getLeftJustified());
-    connect(&leftJustifiedHandCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setLeftJustified(int)));
+    leftJustifiedHandCheckBox.setChecked(SettingsCache::instance().getLeftJustified());
+    connect(&leftJustifiedHandCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
+            SLOT(setLeftJustified(int)));
 
     auto *handGrid = new QGridLayout;
     handGrid->addWidget(&horizontalHandCheckBox, 0, 0, 1, 2);
@@ -302,18 +307,18 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     handGroupBox = new QGroupBox;
     handGroupBox->setLayout(handGrid);
 
-    invertVerticalCoordinateCheckBox.setChecked(settingsCache->getInvertVerticalCoordinate());
-    connect(&invertVerticalCoordinateCheckBox, SIGNAL(stateChanged(int)), settingsCache,
+    invertVerticalCoordinateCheckBox.setChecked(SettingsCache::instance().getInvertVerticalCoordinate());
+    connect(&invertVerticalCoordinateCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
             SLOT(setInvertVerticalCoordinate(int)));
 
     minPlayersForMultiColumnLayoutEdit.setMinimum(2);
-    minPlayersForMultiColumnLayoutEdit.setValue(settingsCache->getMinPlayersForMultiColumnLayout());
-    connect(&minPlayersForMultiColumnLayoutEdit, SIGNAL(valueChanged(int)), settingsCache,
+    minPlayersForMultiColumnLayoutEdit.setValue(SettingsCache::instance().getMinPlayersForMultiColumnLayout());
+    connect(&minPlayersForMultiColumnLayoutEdit, SIGNAL(valueChanged(int)), &SettingsCache::instance(),
             SLOT(setMinPlayersForMultiColumnLayout(int)));
     minPlayersForMultiColumnLayoutLabel.setBuddy(&minPlayersForMultiColumnLayoutEdit);
 
-    connect(&maxFontSizeForCardsEdit, SIGNAL(valueChanged(int)), settingsCache, SLOT(setMaxFontSize(int)));
-    maxFontSizeForCardsEdit.setValue(settingsCache->getMaxFontSize());
+    connect(&maxFontSizeForCardsEdit, SIGNAL(valueChanged(int)), &SettingsCache::instance(), SLOT(setMaxFontSize(int)));
+    maxFontSizeForCardsEdit.setValue(SettingsCache::instance().getMaxFontSize());
     maxFontSizeForCardsLabel.setBuddy(&maxFontSizeForCardsEdit);
     maxFontSizeForCardsEdit.setMinimum(9);
     maxFontSizeForCardsEdit.setMaximum(100);
@@ -341,7 +346,7 @@ void AppearanceSettingsPage::themeBoxChanged(int index)
 {
     QStringList themeDirs = themeManager->getAvailableThemes().keys();
     if (index >= 0 && index < themeDirs.count())
-        settingsCache->setThemeName(themeDirs.at(index));
+        SettingsCache::instance().setThemeName(themeDirs.at(index));
 }
 
 void AppearanceSettingsPage::retranslateUi()
@@ -365,33 +370,36 @@ void AppearanceSettingsPage::retranslateUi()
 
 UserInterfaceSettingsPage::UserInterfaceSettingsPage()
 {
-    notificationsEnabledCheckBox.setChecked(settingsCache->getNotificationsEnabled());
-    connect(&notificationsEnabledCheckBox, SIGNAL(stateChanged(int)), settingsCache,
+    notificationsEnabledCheckBox.setChecked(SettingsCache::instance().getNotificationsEnabled());
+    connect(&notificationsEnabledCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
             SLOT(setNotificationsEnabled(int)));
     connect(&notificationsEnabledCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setSpecNotificationEnabled(int)));
 
-    specNotificationsEnabledCheckBox.setChecked(settingsCache->getSpectatorNotificationsEnabled());
-    specNotificationsEnabledCheckBox.setEnabled(settingsCache->getNotificationsEnabled());
-    connect(&specNotificationsEnabledCheckBox, SIGNAL(stateChanged(int)), settingsCache,
+    specNotificationsEnabledCheckBox.setChecked(SettingsCache::instance().getSpectatorNotificationsEnabled());
+    specNotificationsEnabledCheckBox.setEnabled(SettingsCache::instance().getNotificationsEnabled());
+    connect(&specNotificationsEnabledCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
             SLOT(setSpectatorNotificationsEnabled(int)));
 
-    buddyConnectNotificationsEnabledCheckBox.setChecked(settingsCache->getBuddyConnectNotificationsEnabled());
-    buddyConnectNotificationsEnabledCheckBox.setEnabled(settingsCache->getNotificationsEnabled());
-    connect(&buddyConnectNotificationsEnabledCheckBox, SIGNAL(stateChanged(int)), settingsCache,
+    buddyConnectNotificationsEnabledCheckBox.setChecked(
+        SettingsCache::instance().getBuddyConnectNotificationsEnabled());
+    buddyConnectNotificationsEnabledCheckBox.setEnabled(SettingsCache::instance().getNotificationsEnabled());
+    connect(&buddyConnectNotificationsEnabledCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
             SLOT(setBuddyConnectNotificationsEnabled(int)));
 
-    doubleClickToPlayCheckBox.setChecked(settingsCache->getDoubleClickToPlay());
-    connect(&doubleClickToPlayCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setDoubleClickToPlay(int)));
+    doubleClickToPlayCheckBox.setChecked(SettingsCache::instance().getDoubleClickToPlay());
+    connect(&doubleClickToPlayCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
+            SLOT(setDoubleClickToPlay(int)));
 
-    playToStackCheckBox.setChecked(settingsCache->getPlayToStack());
-    connect(&playToStackCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setPlayToStack(int)));
+    playToStackCheckBox.setChecked(SettingsCache::instance().getPlayToStack());
+    connect(&playToStackCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(), SLOT(setPlayToStack(int)));
 
-    annotateTokensCheckBox.setChecked(settingsCache->getAnnotateTokens());
-    connect(&annotateTokensCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setAnnotateTokens(int)));
+    annotateTokensCheckBox.setChecked(SettingsCache::instance().getAnnotateTokens());
+    connect(&annotateTokensCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
+            SLOT(setAnnotateTokens(int)));
 
-    useTearOffMenusCheckBox.setChecked(settingsCache->getUseTearOffMenus());
-    connect(&useTearOffMenusCheckBox, &QCheckBox::stateChanged, settingsCache,
-            [](int state) { settingsCache->setUseTearOffMenus(state == Qt::Checked); });
+    useTearOffMenusCheckBox.setChecked(SettingsCache::instance().getUseTearOffMenus());
+    connect(&useTearOffMenusCheckBox, &QCheckBox::stateChanged, &SettingsCache::instance(),
+            [](int state) { SettingsCache::instance().setUseTearOffMenus(state == Qt::Checked); });
 
     auto *generalGrid = new QGridLayout;
     generalGrid->addWidget(&doubleClickToPlayCheckBox, 0, 0);
@@ -410,8 +418,8 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     notificationsGroupBox = new QGroupBox;
     notificationsGroupBox->setLayout(notificationsGrid);
 
-    tapAnimationCheckBox.setChecked(settingsCache->getTapAnimation());
-    connect(&tapAnimationCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setTapAnimation(int)));
+    tapAnimationCheckBox.setChecked(SettingsCache::instance().getTapAnimation());
+    connect(&tapAnimationCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(), SLOT(setTapAnimation(int)));
 
     auto *animationGrid = new QGridLayout;
     animationGrid->addWidget(&tapAnimationCheckBox, 0, 0);
@@ -449,8 +457,8 @@ void UserInterfaceSettingsPage::retranslateUi()
 
 DeckEditorSettingsPage::DeckEditorSettingsPage()
 {
-    picDownloadCheckBox.setChecked(settingsCache->getPicDownload());
-    connect(&picDownloadCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setPicDownload(int)));
+    picDownloadCheckBox.setChecked(SettingsCache::instance().getPicDownload());
+    connect(&picDownloadCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(), SLOT(setPicDownload(int)));
 
     urlLinkLabel.setTextInteractionFlags(Qt::LinksAccessibleByMouse);
     urlLinkLabel.setOpenExternalLinks(true);
@@ -461,9 +469,9 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     auto *lpGeneralGrid = new QGridLayout;
     auto *lpSpoilerGrid = new QGridLayout;
 
-    mcDownloadSpoilersCheckBox.setChecked(settingsCache->getDownloadSpoilersStatus());
+    mcDownloadSpoilersCheckBox.setChecked(SettingsCache::instance().getDownloadSpoilersStatus());
 
-    mpSpoilerSavePathLineEdit = new QLineEdit(settingsCache->getSpoilerCardDatabasePath());
+    mpSpoilerSavePathLineEdit = new QLineEdit(SettingsCache::instance().getSpoilerCardDatabasePath());
     mpSpoilerSavePathLineEdit->setReadOnly(true);
     mpSpoilerPathButton = new QPushButton("...");
     connect(mpSpoilerPathButton, SIGNAL(clicked()), this, SLOT(spoilerPathButtonClicked()));
@@ -483,8 +491,8 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     connect(urlList->model(), SIGNAL(rowsMoved(const QModelIndex, int, int, const QModelIndex, int)), this,
             SLOT(urlListChanged(const QModelIndex, int, int, const QModelIndex, int)));
 
-    for (int i = 0; i < settingsCache->downloads().getCount(); i++)
-        urlList->addItem(settingsCache->downloads().getDownloadUrlAt(i));
+    for (int i = 0; i < SettingsCache::instance().downloads().getCount(); i++)
+        urlList->addItem(SettingsCache::instance().downloads().getDownloadUrlAt(i));
 
     auto aAdd = new QAction(this);
     aAdd->setIcon(QPixmap("theme:icons/increment"));
@@ -524,7 +532,8 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     lpSpoilerGrid->addWidget(&infoOnSpoilersLabel, 3, 0, 1, 3, Qt::AlignTop);
 
     // On a change to the check box, hide/unhide the other fields
-    connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), settingsCache, SLOT(setDownloadSpoilerStatus(bool)));
+    connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), &SettingsCache::instance(),
+            SLOT(setDownloadSpoilerStatus(bool)));
     connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), this, SLOT(setSpoilersEnabled(bool)));
 
     mpGeneralGroupBox = new QGroupBox;
@@ -542,15 +551,15 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
 
 void DeckEditorSettingsPage::resetDownloadedURLsButtonClicked()
 {
-    settingsCache->downloads().clear();
+    SettingsCache::instance().downloads().clear();
     urlList->clear();
-    urlList->addItems(settingsCache->downloads().getAllURLs());
+    urlList->addItems(SettingsCache::instance().downloads().getAllURLs());
     QMessageBox::information(this, tr("Success"), tr("Download URLs have been reset."));
 }
 
 void DeckEditorSettingsPage::clearDownloadedPicsButtonClicked()
 {
-    QString picsPath = settingsCache->getPicsPath() + "/downloadedPics/";
+    QString picsPath = SettingsCache::instance().getPicsPath() + "/downloadedPics/";
     QStringList dirs = QDir(picsPath).entryList(QDir::AllDirs | QDir::NoDotAndDotDot);
     bool outerSuccessRemove = true;
     for (const auto &dir : dirs) {
@@ -616,10 +625,10 @@ void DeckEditorSettingsPage::actEditURL()
 void DeckEditorSettingsPage::storeSettings()
 {
     qInfo() << "URL Priority Reset";
-    settingsCache->downloads().clear();
+    SettingsCache::instance().downloads().clear();
     for (int i = 0; i < urlList->count(); i++) {
         qInfo() << "Priority" << i << ":" << urlList->item(i)->text();
-        settingsCache->downloads().setDownloadUrlAt(i, urlList->item(i)->text());
+        SettingsCache::instance().downloads().setDownloadUrlAt(i, urlList->item(i)->text());
     }
 }
 
@@ -648,7 +657,7 @@ void DeckEditorSettingsPage::unlockSettings()
 
 QString DeckEditorSettingsPage::getLastUpdateTime()
 {
-    QString fileName = settingsCache->getSpoilerCardDatabasePath();
+    QString fileName = SettingsCache::instance().getSpoilerCardDatabasePath();
     QFileInfo fi(fileName);
     QDir fileDir(fi.path());
     QFile file(fileName);
@@ -668,7 +677,7 @@ void DeckEditorSettingsPage::spoilerPathButtonClicked()
     }
 
     mpSpoilerSavePathLineEdit->setText(lsPath + "/spoiler.xml");
-    settingsCache->setSpoilerDatabasePath(lsPath + "/spoiler.xml");
+    SettingsCache::instance().setSpoilerDatabasePath(lsPath + "/spoiler.xml");
 }
 
 void DeckEditorSettingsPage::setSpoilersEnabled(bool anInput)
@@ -704,43 +713,45 @@ void DeckEditorSettingsPage::retranslateUi()
 
 MessagesSettingsPage::MessagesSettingsPage()
 {
-    chatMentionCheckBox.setChecked(settingsCache->getChatMention());
-    connect(&chatMentionCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setChatMention(int)));
+    chatMentionCheckBox.setChecked(SettingsCache::instance().getChatMention());
+    connect(&chatMentionCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(), SLOT(setChatMention(int)));
 
-    chatMentionCompleterCheckbox.setChecked(settingsCache->getChatMentionCompleter());
-    connect(&chatMentionCompleterCheckbox, SIGNAL(stateChanged(int)), settingsCache,
+    chatMentionCompleterCheckbox.setChecked(SettingsCache::instance().getChatMentionCompleter());
+    connect(&chatMentionCompleterCheckbox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
             SLOT(setChatMentionCompleter(int)));
 
-    ignoreUnregUsersMainChat.setChecked(settingsCache->getIgnoreUnregisteredUsers());
-    ignoreUnregUserMessages.setChecked(settingsCache->getIgnoreUnregisteredUserMessages());
-    connect(&ignoreUnregUsersMainChat, SIGNAL(stateChanged(int)), settingsCache, SLOT(setIgnoreUnregisteredUsers(int)));
-    connect(&ignoreUnregUserMessages, SIGNAL(stateChanged(int)), settingsCache,
+    ignoreUnregUsersMainChat.setChecked(SettingsCache::instance().getIgnoreUnregisteredUsers());
+    ignoreUnregUserMessages.setChecked(SettingsCache::instance().getIgnoreUnregisteredUserMessages());
+    connect(&ignoreUnregUsersMainChat, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
+            SLOT(setIgnoreUnregisteredUsers(int)));
+    connect(&ignoreUnregUserMessages, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
             SLOT(setIgnoreUnregisteredUserMessages(int)));
 
-    invertMentionForeground.setChecked(settingsCache->getChatMentionForeground());
+    invertMentionForeground.setChecked(SettingsCache::instance().getChatMentionForeground());
     connect(&invertMentionForeground, SIGNAL(stateChanged(int)), this, SLOT(updateTextColor(int)));
 
-    invertHighlightForeground.setChecked(settingsCache->getChatHighlightForeground());
+    invertHighlightForeground.setChecked(SettingsCache::instance().getChatHighlightForeground());
     connect(&invertHighlightForeground, SIGNAL(stateChanged(int)), this, SLOT(updateTextHighlightColor(int)));
 
     mentionColor = new QLineEdit();
-    mentionColor->setText(settingsCache->getChatMentionColor());
+    mentionColor->setText(SettingsCache::instance().getChatMentionColor());
     updateMentionPreview();
     connect(mentionColor, SIGNAL(textChanged(QString)), this, SLOT(updateColor(QString)));
 
-    messagePopups.setChecked(settingsCache->getShowMessagePopup());
-    connect(&messagePopups, SIGNAL(stateChanged(int)), settingsCache, SLOT(setShowMessagePopups(int)));
+    messagePopups.setChecked(SettingsCache::instance().getShowMessagePopup());
+    connect(&messagePopups, SIGNAL(stateChanged(int)), &SettingsCache::instance(), SLOT(setShowMessagePopups(int)));
 
-    mentionPopups.setChecked(settingsCache->getShowMentionPopup());
-    connect(&mentionPopups, SIGNAL(stateChanged(int)), settingsCache, SLOT(setShowMentionPopups(int)));
+    mentionPopups.setChecked(SettingsCache::instance().getShowMentionPopup());
+    connect(&mentionPopups, SIGNAL(stateChanged(int)), &SettingsCache::instance(), SLOT(setShowMentionPopups(int)));
 
-    roomHistory.setChecked(settingsCache->getRoomHistory());
-    connect(&roomHistory, SIGNAL(stateChanged(int)), settingsCache, SLOT(setRoomHistory(int)));
+    roomHistory.setChecked(SettingsCache::instance().getRoomHistory());
+    connect(&roomHistory, SIGNAL(stateChanged(int)), &SettingsCache::instance(), SLOT(setRoomHistory(int)));
 
     customAlertString = new QLineEdit();
     customAlertString->setPlaceholderText(tr("Word1 Word2 Word3"));
-    customAlertString->setText(settingsCache->getHighlightWords());
-    connect(customAlertString, SIGNAL(textChanged(QString)), settingsCache, SLOT(setHighlightWords(QString)));
+    customAlertString->setText(SettingsCache::instance().getHighlightWords());
+    connect(customAlertString, SIGNAL(textChanged(QString)), &SettingsCache::instance(),
+            SLOT(setHighlightWords(QString)));
 
     auto *chatGrid = new QGridLayout;
     chatGrid->addWidget(&chatMentionCheckBox, 0, 0);
@@ -757,7 +768,7 @@ MessagesSettingsPage::MessagesSettingsPage()
     chatGroupBox->setLayout(chatGrid);
 
     highlightColor = new QLineEdit();
-    highlightColor->setText(settingsCache->getChatHighlightColor());
+    highlightColor->setText(SettingsCache::instance().getChatHighlightColor());
     updateHighlightPreview();
     connect(highlightColor, SIGNAL(textChanged(QString)), this, SLOT(updateHighlightColor(QString)));
 
@@ -772,9 +783,9 @@ MessagesSettingsPage::MessagesSettingsPage()
 
     messageList = new QListWidget;
 
-    int count = settingsCache->messages().getCount();
+    int count = SettingsCache::instance().messages().getCount();
     for (int i = 0; i < count; i++)
-        messageList->addItem(settingsCache->messages().getMessageAt(i));
+        messageList->addItem(SettingsCache::instance().messages().getMessageAt(i));
 
     aAdd = new QAction(this);
     aAdd->setIcon(QPixmap("theme:icons/increment"));
@@ -820,7 +831,7 @@ void MessagesSettingsPage::updateColor(const QString &value)
     QColor colorToSet;
     colorToSet.setNamedColor("#" + value);
     if (colorToSet.isValid()) {
-        settingsCache->setChatMentionColor(value);
+        SettingsCache::instance().setChatMentionColor(value);
         updateMentionPreview();
     }
 }
@@ -830,40 +841,42 @@ void MessagesSettingsPage::updateHighlightColor(const QString &value)
     QColor colorToSet;
     colorToSet.setNamedColor("#" + value);
     if (colorToSet.isValid()) {
-        settingsCache->setChatHighlightColor(value);
+        SettingsCache::instance().setChatHighlightColor(value);
         updateHighlightPreview();
     }
 }
 
 void MessagesSettingsPage::updateTextColor(int value)
 {
-    settingsCache->setChatMentionForeground(value);
+    SettingsCache::instance().setChatMentionForeground(value);
     updateMentionPreview();
 }
 
 void MessagesSettingsPage::updateTextHighlightColor(int value)
 {
-    settingsCache->setChatHighlightForeground(value);
+    SettingsCache::instance().setChatHighlightForeground(value);
     updateHighlightPreview();
 }
 
 void MessagesSettingsPage::updateMentionPreview()
 {
-    mentionColor->setStyleSheet("QLineEdit{background:#" + settingsCache->getChatMentionColor() +
-                                ";color: " + (settingsCache->getChatMentionForeground() ? "white" : "black") + ";}");
+    mentionColor->setStyleSheet(
+        "QLineEdit{background:#" + SettingsCache::instance().getChatMentionColor() +
+        ";color: " + (SettingsCache::instance().getChatMentionForeground() ? "white" : "black") + ";}");
 }
 
 void MessagesSettingsPage::updateHighlightPreview()
 {
-    highlightColor->setStyleSheet("QLineEdit{background:#" + settingsCache->getChatHighlightColor() + ";color: " +
-                                  (settingsCache->getChatHighlightForeground() ? "white" : "black") + ";}");
+    highlightColor->setStyleSheet(
+        "QLineEdit{background:#" + SettingsCache::instance().getChatHighlightColor() +
+        ";color: " + (SettingsCache::instance().getChatHighlightForeground() ? "white" : "black") + ";}");
 }
 
 void MessagesSettingsPage::storeSettings()
 {
-    settingsCache->messages().setCount(messageList->count());
+    SettingsCache::instance().messages().setCount(messageList->count());
     for (int i = 0; i < messageList->count(); i++)
-        settingsCache->messages().setMessageAt(i, messageList->item(i)->text());
+        SettingsCache::instance().messages().setMessageAt(i, messageList->item(i)->text());
 }
 
 void MessagesSettingsPage::actAdd()
@@ -918,10 +931,10 @@ void MessagesSettingsPage::retranslateUi()
 
 SoundSettingsPage::SoundSettingsPage()
 {
-    soundEnabledCheckBox.setChecked(settingsCache->getSoundEnabled());
-    connect(&soundEnabledCheckBox, SIGNAL(stateChanged(int)), settingsCache, SLOT(setSoundEnabled(int)));
+    soundEnabledCheckBox.setChecked(SettingsCache::instance().getSoundEnabled());
+    connect(&soundEnabledCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(), SLOT(setSoundEnabled(int)));
 
-    QString themeName = settingsCache->getSoundThemeName();
+    QString themeName = SettingsCache::instance().getSoundThemeName();
 
     QStringList themeDirs = soundEngine->getAvailableThemes().keys();
     for (int i = 0; i < themeDirs.size(); i++) {
@@ -936,16 +949,16 @@ SoundSettingsPage::SoundSettingsPage()
     masterVolumeSlider = new QSlider(Qt::Horizontal);
     masterVolumeSlider->setMinimum(0);
     masterVolumeSlider->setMaximum(100);
-    masterVolumeSlider->setValue(settingsCache->getMasterVolume());
-    masterVolumeSlider->setToolTip(QString::number(settingsCache->getMasterVolume()));
-    connect(settingsCache, SIGNAL(masterVolumeChanged(int)), this, SLOT(masterVolumeChanged(int)));
+    masterVolumeSlider->setValue(SettingsCache::instance().getMasterVolume());
+    masterVolumeSlider->setToolTip(QString::number(SettingsCache::instance().getMasterVolume()));
+    connect(&SettingsCache::instance(), SIGNAL(masterVolumeChanged(int)), this, SLOT(masterVolumeChanged(int)));
     connect(masterVolumeSlider, SIGNAL(sliderReleased()), soundEngine, SLOT(testSound()));
-    connect(masterVolumeSlider, SIGNAL(valueChanged(int)), settingsCache, SLOT(setMasterVolume(int)));
+    connect(masterVolumeSlider, SIGNAL(valueChanged(int)), &SettingsCache::instance(), SLOT(setMasterVolume(int)));
 
     masterVolumeSpinBox = new QSpinBox();
     masterVolumeSpinBox->setMinimum(0);
     masterVolumeSpinBox->setMaximum(100);
-    masterVolumeSpinBox->setValue(settingsCache->getMasterVolume());
+    masterVolumeSpinBox->setValue(SettingsCache::instance().getMasterVolume());
     connect(masterVolumeSlider, SIGNAL(valueChanged(int)), masterVolumeSpinBox, SLOT(setValue(int)));
     connect(masterVolumeSpinBox, SIGNAL(valueChanged(int)), masterVolumeSlider, SLOT(setValue(int)));
 
@@ -971,7 +984,7 @@ void SoundSettingsPage::themeBoxChanged(int index)
 {
     QStringList themeDirs = soundEngine->getAvailableThemes().keys();
     if (index >= 0 && index < themeDirs.count())
-        settingsCache->setSoundThemeName(themeDirs.at(index));
+        SettingsCache::instance().setSoundThemeName(themeDirs.at(index));
 }
 
 void SoundSettingsPage::masterVolumeChanged(int value)
@@ -1046,7 +1059,7 @@ ShortcutSettingsPage::ShortcutSettingsPage()
     connect(btnClearAll, SIGNAL(clicked()), this, SLOT(clearShortcuts()));
     connect(shortcutsTable, SIGNAL(currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)), this,
             SLOT(currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)));
-    connect(&settingsCache->shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
+    connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
 
     createShortcuts();
 }
@@ -1059,8 +1072,8 @@ void ShortcutSettingsPage::currentItemChanged(QTreeWidgetItem *current, QTreeWid
         editTextBox->setShortcutName("");
     } else {
         QString key = current->data(2, Qt::DisplayRole).toString();
-        QString group = settingsCache->shortcuts().getShortcut(key).getGroupName();
-        QString action = settingsCache->shortcuts().getShortcut(key).getName();
+        QString group = SettingsCache::instance().shortcuts().getShortcut(key).getGroupName();
+        QString action = SettingsCache::instance().shortcuts().getShortcut(key).getName();
         currentActionGroupName->setText(group);
         currentActionName->setText(action);
         editTextBox->setShortcutName(key);
@@ -1071,7 +1084,7 @@ void ShortcutSettingsPage::resetShortcuts()
 {
     if (QMessageBox::question(this, tr("Restore all default shortcuts"),
                               tr("Do you really want to restore all default shortcuts?")) == QMessageBox::Yes) {
-        settingsCache->shortcuts().resetAllShortcuts();
+        SettingsCache::instance().shortcuts().resetAllShortcuts();
     }
 }
 
@@ -1079,10 +1092,10 @@ void ShortcutSettingsPage::createShortcuts()
 {
     QHash<QString, QTreeWidgetItem *> parentItems;
     QTreeWidgetItem *curParent = nullptr;
-    for (const auto &key : settingsCache->shortcuts().getAllShortcutKeys()) {
-        QString name = settingsCache->shortcuts().getShortcut(key).getName();
-        QString group = settingsCache->shortcuts().getShortcut(key).getGroupName();
-        QString shortcut = settingsCache->shortcuts().getShortcutString(key);
+    for (const auto &key : SettingsCache::instance().shortcuts().getAllShortcutKeys()) {
+        QString name = SettingsCache::instance().shortcuts().getShortcut(key).getName();
+        QString group = SettingsCache::instance().shortcuts().getShortcut(key).getGroupName();
+        QString shortcut = SettingsCache::instance().shortcuts().getShortcutString(key);
 
         if (parentItems.contains(group)) {
             curParent = parentItems.value(group);
@@ -1112,14 +1125,14 @@ void ShortcutSettingsPage::refreshShortcuts()
         for (int j = 0; j < curParent->childCount(); ++j) {
             curChild = curParent->child(j);
             QString key = curChild->data(2, Qt::DisplayRole).toString();
-            QString name = settingsCache->shortcuts().getShortcut(key).getName();
-            QString shortcut = settingsCache->shortcuts().getShortcutString(key);
+            QString name = SettingsCache::instance().shortcuts().getShortcut(key).getName();
+            QString shortcut = SettingsCache::instance().shortcuts().getShortcutString(key);
             curChild->setText(0, name);
             curChild->setText(1, shortcut);
 
             if (j == 0) {
                 // the first child also updates the parent's group name
-                QString group = settingsCache->shortcuts().getShortcut(key).getGroupName();
+                QString group = SettingsCache::instance().shortcuts().getShortcut(key).getGroupName();
                 curParent->setText(0, group);
             }
         }
@@ -1132,7 +1145,7 @@ void ShortcutSettingsPage::clearShortcuts()
 {
     if (QMessageBox::question(this, tr("Clear all default shortcuts"),
                               tr("Do you really want to clear all shortcuts?")) == QMessageBox::Yes) {
-        settingsCache->shortcuts().clearAllShortcuts();
+        SettingsCache::instance().shortcuts().clearAllShortcuts();
     }
 }
 
@@ -1160,7 +1173,7 @@ DlgSettings::DlgSettings(QWidget *parent) : QDialog(parent)
     this->setMinimumSize(rec.width() / 2, rec.height() - 100);
     this->setBaseSize(rec.width(), rec.height());
 
-    connect(settingsCache, SIGNAL(langChanged()), this, SLOT(updateLanguage()));
+    connect(&SettingsCache::instance(), SIGNAL(langChanged()), this, SLOT(updateLanguage()));
 
     contentsWidget = new QListWidget;
     contentsWidget->setViewMode(QListView::IconMode);
@@ -1322,7 +1335,7 @@ void DlgSettings::closeEvent(QCloseEvent *event)
         }
     }
 
-    if (!QDir(settingsCache->getDeckPath()).exists() || settingsCache->getDeckPath().isEmpty()) {
+    if (!QDir(SettingsCache::instance().getDeckPath()).exists() || SettingsCache::instance().getDeckPath().isEmpty()) {
         // TODO: Prompt to create it
         if (QMessageBox::critical(
                 this, tr("Error"),
@@ -1333,7 +1346,7 @@ void DlgSettings::closeEvent(QCloseEvent *event)
         }
     }
 
-    if (!QDir(settingsCache->getPicsPath()).exists() || settingsCache->getPicsPath().isEmpty()) {
+    if (!QDir(SettingsCache::instance().getPicsPath()).exists() || SettingsCache::instance().getPicsPath().isEmpty()) {
         // TODO: Prompt to create it
         if (QMessageBox::critical(this, tr("Error"),
                                   tr("The path to your card pictures directory is invalid. Would you like to go back "

--- a/cockatrice/src/dlg_tip_of_the_day.cpp
+++ b/cockatrice/src/dlg_tip_of_the_day.cpp
@@ -42,7 +42,7 @@ DlgTipOfTheDay::DlgTipOfTheDay(QWidget *parent) : QDialog(parent)
     tipNumber = new QLabel();
     tipNumber->setAlignment(Qt::AlignCenter);
 
-    QList<int> seenTips = settingsCache->getSeenTips();
+    QList<int> seenTips = SettingsCache::instance().getSeenTips();
     newTipsAvailable = false;
     currentTip = 0;
     for (int i = 0; i < tipDatabase->rowCount(); i++) {
@@ -74,8 +74,9 @@ DlgTipOfTheDay::DlgTipOfTheDay(QWidget *parent) : QDialog(parent)
     connect(previousButton, SIGNAL(clicked()), this, SLOT(previousClicked()));
 
     showTipsOnStartupCheck = new QCheckBox("Show tips on startup");
-    showTipsOnStartupCheck->setChecked(settingsCache->getShowTipsOnStartup());
-    connect(showTipsOnStartupCheck, SIGNAL(clicked(bool)), settingsCache, SLOT(setShowTipsOnStartup(bool)));
+    showTipsOnStartupCheck->setChecked(SettingsCache::instance().getShowTipsOnStartup());
+    connect(showTipsOnStartupCheck, SIGNAL(clicked(bool)), &SettingsCache::instance(),
+            SLOT(setShowTipsOnStartup(bool)));
     buttonBar = new QHBoxLayout();
     buttonBar->addWidget(showTipsOnStartupCheck);
     buttonBar->addWidget(tipNumber);
@@ -130,10 +131,10 @@ void DlgTipOfTheDay::updateTip(int tipId)
     }
 
     // Store tip id as seen
-    QList<int> seenTips = settingsCache->getSeenTips();
+    QList<int> seenTips = SettingsCache::instance().getSeenTips();
     if (!seenTips.contains(tipId)) {
         seenTips.append(tipId);
-        settingsCache->setSeenTips(seenTips);
+        SettingsCache::instance().setSeenTips(seenTips);
     }
 
     TipOfTheDay tip = tipDatabase->getTip(tipId);

--- a/cockatrice/src/dlg_update.cpp
+++ b/cockatrice/src/dlg_update.cpp
@@ -24,7 +24,7 @@ DlgUpdate::DlgUpdate(QWidget *parent) : QDialog(parent)
     statusLabel->setWordWrap(true);
     descriptionLabel =
         new QLabel(tr("Current release channel") +
-                       QString(": %1").arg(tr(settingsCache->getUpdateReleaseChannel()->getName().toUtf8())),
+                       QString(": %1").arg(tr(SettingsCache::instance().getUpdateReleaseChannel()->getName().toUtf8())),
                    this);
     progress = new QProgressBar(this);
 
@@ -67,7 +67,7 @@ DlgUpdate::DlgUpdate(QWidget *parent) : QDialog(parent)
     connect(uDownloader, SIGNAL(progressMade(qint64, qint64)), this, SLOT(downloadProgressMade(qint64, qint64)));
     connect(uDownloader, SIGNAL(error(QString)), this, SLOT(downloadError(QString)));
 
-    ReleaseChannel *channel = settingsCache->getUpdateReleaseChannel();
+    ReleaseChannel *channel = SettingsCache::instance().getUpdateReleaseChannel();
     connect(channel, SIGNAL(finishedCheck(bool, bool, Release *)), this,
             SLOT(finishedUpdateCheck(bool, bool, Release *)));
     connect(channel, SIGNAL(error(QString)), this, SLOT(updateCheckError(QString)));
@@ -83,7 +83,7 @@ void DlgUpdate::closeDialog()
 
 void DlgUpdate::gotoDownloadPage()
 {
-    QDesktopServices::openUrl(settingsCache->getUpdateReleaseChannel()->getManualDownloadUrl());
+    QDesktopServices::openUrl(SettingsCache::instance().getUpdateReleaseChannel()->getManualDownloadUrl());
 }
 
 void DlgUpdate::downloadUpdate()
@@ -106,7 +106,7 @@ void DlgUpdate::beginUpdateCheck()
     progress->setMinimum(0);
     progress->setMaximum(0);
     setLabel(tr("Checking for updates..."));
-    settingsCache->getUpdateReleaseChannel()->checkForUpdates();
+    SettingsCache::instance().getUpdateReleaseChannel()->checkForUpdates();
 }
 
 void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Release *release)
@@ -136,7 +136,7 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
                 tr("You are already running the latest version available in the chosen release channel.") + "<br>" +
                 "<b>" + tr("Current version") + QString(":</b> %1<br>").arg(VERSION_STRING) + "<b>" +
                 tr("Selected release channel") +
-                QString(":</b> %1").arg(tr(settingsCache->getUpdateReleaseChannel()->getName().toUtf8())));
+                QString(":</b> %1").arg(tr(SettingsCache::instance().getUpdateReleaseChannel()->getName().toUtf8())));
         return;
     }
 

--- a/cockatrice/src/dlg_viewlog.cpp
+++ b/cockatrice/src/dlg_viewlog.cpp
@@ -17,7 +17,7 @@ DlgViewLog::DlgViewLog(QWidget *parent) : QDialog(parent)
 
     coClearLog = new QCheckBox;
     coClearLog->setText(tr("Clear log when closing"));
-    coClearLog->setChecked(settingsCache->servers().getClearDebugLogStatus(false));
+    coClearLog->setChecked(SettingsCache::instance().servers().getClearDebugLogStatus(false));
     connect(coClearLog, SIGNAL(toggled(bool)), this, SLOT(actCheckBoxChanged(bool)));
     mainLayout->addWidget(coClearLog);
 
@@ -32,7 +32,7 @@ DlgViewLog::DlgViewLog(QWidget *parent) : QDialog(parent)
 
 void DlgViewLog::actCheckBoxChanged(bool abNewValue)
 {
-    settingsCache->servers().setClearDebugLogStatus(abNewValue);
+    SettingsCache::instance().servers().setClearDebugLogStatus(abNewValue);
 }
 
 void DlgViewLog::loadInitialLogBuffer()

--- a/cockatrice/src/gamescene.cpp
+++ b/cockatrice/src/gamescene.cpp
@@ -20,7 +20,7 @@ GameScene::GameScene(PhasesToolbar *_phasesToolbar, QObject *parent)
 {
     animationTimer = new QBasicTimer;
     addItem(phasesToolbar);
-    connect(settingsCache, SIGNAL(minPlayersForMultiColumnLayoutChanged()), this, SLOT(rearrange()));
+    connect(&SettingsCache::instance(), SIGNAL(minPlayersForMultiColumnLayoutChanged()), this, SLOT(rearrange()));
 
     rearrange();
 }
@@ -96,7 +96,7 @@ void GameScene::rearrange()
     }
 
     const int playersCount = playersPlaying.size();
-    const int columns = playersCount < settingsCache->getMinPlayersForMultiColumnLayout() ? 1 : 2;
+    const int columns = playersCount < SettingsCache::instance().getMinPlayersForMultiColumnLayout() ? 1 : 2;
     const int rows = ceil((qreal)playersCount / columns);
     qreal sceneHeight = 0, sceneWidth = -playerAreaSpacing;
     QList<int> columnWidth;

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -345,18 +345,18 @@ void GamesProxyModel::resetFilterParameters()
 
 void GamesProxyModel::loadFilterParameters(const QMap<int, QString> &allGameTypes)
 {
-
-    unavailableGamesVisible = settingsCache->gameFilters().isUnavailableGamesVisible();
-    showPasswordProtectedGames = settingsCache->gameFilters().isShowPasswordProtectedGames();
-    hideIgnoredUserGames = settingsCache->gameFilters().isHideIgnoredUserGames();
-    gameNameFilter = settingsCache->gameFilters().getGameNameFilter();
-    maxPlayersFilterMin = settingsCache->gameFilters().getMinPlayers();
-    maxPlayersFilterMax = settingsCache->gameFilters().getMaxPlayers();
+    GameFiltersSettings &gameFilters = SettingsCache::instance().gameFilters();
+    unavailableGamesVisible = gameFilters.isUnavailableGamesVisible();
+    showPasswordProtectedGames = gameFilters.isShowPasswordProtectedGames();
+    hideIgnoredUserGames = gameFilters.isHideIgnoredUserGames();
+    gameNameFilter = gameFilters.getGameNameFilter();
+    maxPlayersFilterMin = gameFilters.getMinPlayers();
+    maxPlayersFilterMax = gameFilters.getMaxPlayers();
 
     QMapIterator<int, QString> gameTypesIterator(allGameTypes);
     while (gameTypesIterator.hasNext()) {
         gameTypesIterator.next();
-        if (settingsCache->gameFilters().isGameTypeEnabled(gameTypesIterator.value())) {
+        if (gameFilters.isGameTypeEnabled(gameTypesIterator.value())) {
             gameTypeFilter.insert(gameTypesIterator.key());
         }
     }
@@ -366,21 +366,22 @@ void GamesProxyModel::loadFilterParameters(const QMap<int, QString> &allGameType
 
 void GamesProxyModel::saveFilterParameters(const QMap<int, QString> &allGameTypes)
 {
-    settingsCache->gameFilters().setShowBuddiesOnlyGames(showBuddiesOnlyGames);
-    settingsCache->gameFilters().setUnavailableGamesVisible(unavailableGamesVisible);
-    settingsCache->gameFilters().setShowPasswordProtectedGames(showPasswordProtectedGames);
-    settingsCache->gameFilters().setHideIgnoredUserGames(hideIgnoredUserGames);
-    settingsCache->gameFilters().setGameNameFilter(gameNameFilter);
+    GameFiltersSettings &gameFilters = SettingsCache::instance().gameFilters();
+    gameFilters.setShowBuddiesOnlyGames(showBuddiesOnlyGames);
+    gameFilters.setUnavailableGamesVisible(unavailableGamesVisible);
+    gameFilters.setShowPasswordProtectedGames(showPasswordProtectedGames);
+    gameFilters.setHideIgnoredUserGames(hideIgnoredUserGames);
+    gameFilters.setGameNameFilter(gameNameFilter);
 
     QMapIterator<int, QString> gameTypeIterator(allGameTypes);
     while (gameTypeIterator.hasNext()) {
         gameTypeIterator.next();
         bool enabled = gameTypeFilter.contains(gameTypeIterator.key());
-        settingsCache->gameFilters().setGameTypeEnabled(gameTypeIterator.value(), enabled);
+        gameFilters.setGameTypeEnabled(gameTypeIterator.value(), enabled);
     }
 
-    settingsCache->gameFilters().setMinPlayers(maxPlayersFilterMin);
-    settingsCache->gameFilters().setMaxPlayers(maxPlayersFilterMax);
+    gameFilters.setMinPlayers(maxPlayersFilterMin);
+    gameFilters.setMaxPlayers(maxPlayersFilterMax);
 }
 
 bool GamesProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex & /*sourceParent*/) const

--- a/cockatrice/src/gameview.cpp
+++ b/cockatrice/src/gameview.cpp
@@ -24,7 +24,7 @@ GameView::GameView(QGraphicsScene *scene, QWidget *parent) : QGraphicsView(scene
 
     connect(aCloseMostRecentZoneView, SIGNAL(triggered()), scene, SLOT(closeMostRecentZoneView()));
     addAction(aCloseMostRecentZoneView);
-    connect(&settingsCache->shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
+    connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
     refreshShortcuts();
     rubberBand = new QRubberBand(QRubberBand::Rectangle, this);
 }
@@ -65,5 +65,6 @@ void GameView::stopRubberBand()
 
 void GameView::refreshShortcuts()
 {
-    aCloseMostRecentZoneView->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aCloseMostRecentZoneView"));
+    aCloseMostRecentZoneView->setShortcuts(
+        SettingsCache::instance().shortcuts().getShortcut("Player/aCloseMostRecentZoneView"));
 }

--- a/cockatrice/src/handle_public_servers.cpp
+++ b/cockatrice/src/handle_public_servers.cpp
@@ -87,9 +87,11 @@ void HandlePublicServers::updateServerINISettings(QMap<QString, QVariant> jsonMa
         }
 
         if (serverFound) {
-            settingsCache->servers().updateExistingServerWithoutLoss(serverName, serverAddress, serverPort, serverSite);
+            SettingsCache::instance().servers().updateExistingServerWithoutLoss(serverName, serverAddress, serverPort,
+                                                                                serverSite);
         } else {
-            settingsCache->servers().addNewServer(serverName, serverAddress, serverPort, "", "", false, serverSite);
+            SettingsCache::instance().servers().addNewServer(serverName, serverAddress, serverPort, "", "", false,
+                                                             serverSite);
         }
     }
 
@@ -100,7 +102,7 @@ void HandlePublicServers::updateServerINISettings(QMap<QString, QVariant> jsonMa
         QString serverAddr = pair.first;
 
         if (publicServersToRemove.indexOf(serverAddr) != -1) {
-            settingsCache->servers().removeServer(serverAddr);
+            SettingsCache::instance().servers().removeServer(serverAddr);
         }
     }
 

--- a/cockatrice/src/handzone.cpp
+++ b/cockatrice/src/handzone.cpp
@@ -42,7 +42,7 @@ void HandZone::handleDropEvent(const QList<CardDragItem *> &dragItems, CardZone 
 {
     QPoint point = dropPoint + scenePos().toPoint();
     int x = -1;
-    if (settingsCache->getHorizontalHand()) {
+    if (SettingsCache::instance().getHorizontalHand()) {
         for (x = 0; x < cards.size(); x++)
             if (point.x() < static_cast<CardItem *>(cards.at(x))->scenePos().x())
                 break;
@@ -68,7 +68,7 @@ void HandZone::handleDropEvent(const QList<CardDragItem *> &dragItems, CardZone 
 
 QRectF HandZone::boundingRect() const
 {
-    if (settingsCache->getHorizontalHand())
+    if (SettingsCache::instance().getHorizontalHand())
         return QRectF(0, 0, width, CARD_HEIGHT + 10);
     else
         return QRectF(0, 0, 100, zoneHeight);
@@ -83,8 +83,8 @@ void HandZone::reorganizeCards()
 {
     if (!cards.isEmpty()) {
         const int cardCount = cards.size();
-        if (settingsCache->getHorizontalHand()) {
-            bool leftJustified = settingsCache->getLeftJustified();
+        if (SettingsCache::instance().getHorizontalHand()) {
+            bool leftJustified = SettingsCache::instance().getLeftJustified();
             qreal cardWidth = cards.at(0)->boundingRect().width();
             const int xPadding = leftJustified ? cardWidth * 1.4 : 5;
             qreal totalWidth =
@@ -131,7 +131,7 @@ void HandZone::reorganizeCards()
 
 void HandZone::setWidth(qreal _width)
 {
-    if (settingsCache->getHorizontalHand()) {
+    if (SettingsCache::instance().getHorizontalHand()) {
         prepareGeometryChange();
         width = _width;
         reorganizeCards();

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -50,7 +50,6 @@
 
 CardDatabase *db;
 QTranslator *translator, *qtTranslator;
-SettingsCache *settingsCache;
 RNG_Abstract *rng;
 SoundEngine *soundEngine;
 QSystemTrayIcon *trayIcon;
@@ -66,7 +65,7 @@ static void CockatriceLogger(QtMsgType type, const QMessageLogContext &ctx, cons
 
 void installNewTranslator()
 {
-    QString lang = settingsCache->getLang();
+    QString lang = SettingsCache::instance().getLang();
 
     qtTranslator->load("qt_" + lang, QLibraryInfo::location(QLibraryInfo::TranslationsPath));
     qApp->installTranslator(qtTranslator);
@@ -133,7 +132,6 @@ int main(int argc, char *argv[])
     }
 
     rng = new RNG_SFMT;
-    settingsCache = new SettingsCache;
     themeManager = new ThemeManager;
     soundEngine = new SoundEngine;
     db = new CardDatabase;
@@ -154,7 +152,7 @@ int main(int argc, char *argv[])
 
     ui.setWindowIcon(QPixmap("theme:cockatrice"));
 
-    settingsCache->setClientID(generateClientID());
+    SettingsCache::instance().setClientID(generateClientID());
 
     // If spoiler mode is enabled, we will download the spoilers
     // then reload the DB. otherwise just reload the DB
@@ -168,7 +166,6 @@ int main(int argc, char *argv[])
 
     qDebug("Event loop finished, terminating...");
     delete db;
-    delete settingsCache;
     delete rng;
     PingPixmapGenerator::clear();
     CountryPixmapGenerator::clear();

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -101,8 +101,8 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
     userInfo = new ServerInfo_User;
     userInfo->CopyFrom(info);
 
-    connect(settingsCache, SIGNAL(horizontalHandChanged()), this, SLOT(rearrangeZones()));
-    connect(settingsCache, SIGNAL(handJustificationChanged()), this, SLOT(rearrangeZones()));
+    connect(&SettingsCache::instance(), SIGNAL(horizontalHandChanged()), this, SLOT(rearrangeZones()));
+    connect(&SettingsCache::instance(), SIGNAL(handJustificationChanged()), this, SLOT(rearrangeZones()));
 
     playerArea = new PlayerArea(this);
 
@@ -483,7 +483,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
 
     rearrangeZones();
     retranslateUi();
-    connect(&settingsCache->shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
+    connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
     refreshShortcuts();
 }
 
@@ -585,7 +585,7 @@ void Player::playerListActionTriggered()
 void Player::rearrangeZones()
 {
     QPointF base = QPointF(CARD_HEIGHT + counterAreaWidth + 15, 0);
-    if (settingsCache->getHorizontalHand()) {
+    if (SettingsCache::instance().getHorizontalHand()) {
         if (mirrored) {
             if (hand->contentsKnown()) {
                 handVisible = true;
@@ -638,7 +638,7 @@ void Player::updateBoundingRect()
 {
     prepareGeometryChange();
     qreal width = CARD_HEIGHT + 15 + counterAreaWidth + stack->boundingRect().width();
-    if (settingsCache->getHorizontalHand()) {
+    if (SettingsCache::instance().getHorizontalHand()) {
         qreal handHeight = handVisible ? hand->boundingRect().height() : 0;
         bRect = QRectF(0, 0, width + table->boundingRect().width(), table->boundingRect().height() + handHeight);
     } else {
@@ -788,7 +788,7 @@ void Player::retranslateUi()
 void Player::setShortcutsActive()
 {
     shortcutsActive = true;
-    ShortcutsSettings &shortcuts = settingsCache->shortcuts();
+    ShortcutsSettings &shortcuts = SettingsCache::instance().shortcuts();
 
     aPlay->setShortcuts(shortcuts.getShortcut("Player/aPlay"));
     aTap->setShortcuts(shortcuts.getShortcut("Player/aTap"));
@@ -909,10 +909,10 @@ void Player::initSayMenu()
 {
     sayMenu->clear();
 
-    int count = settingsCache->messages().getCount();
+    int count = SettingsCache::instance().messages().getCount();
 
     for (int i = 0; i < count; ++i) {
-        auto *newAction = new QAction(settingsCache->messages().getMessageAt(i), this);
+        auto *newAction = new QAction(SettingsCache::instance().messages().getMessageAt(i), this);
         if (i <= 10) {
             newAction->setShortcut(QKeySequence("Ctrl+" + QString::number((i + 1) % 10)));
         }
@@ -1019,7 +1019,7 @@ void Player::actDrawCard()
 
 void Player::actMulligan()
 {
-    int startSize = settingsCache->getStartingHandSize();
+    int startSize = SettingsCache::instance().getStartingHandSize();
     int handSize = zones.value("hand")->getCards().size();
     int deckSize = zones.value("deck")->getCards().size() + handSize;
     bool ok;
@@ -1040,7 +1040,7 @@ void Player::actMulligan()
     }
     sendGameCommand(cmd);
     if (startSize != number) {
-        settingsCache->setStartingHandSize(number);
+        SettingsCache::instance().setStartingHandSize(number);
     }
 }
 
@@ -1439,7 +1439,7 @@ void Player::createCard(const CardItem *sourceCard, const QString &dbCardName, b
     }
 
     cmd.set_pt(cardInfo->getPowTough().toStdString());
-    if (settingsCache->getAnnotateTokens()) {
+    if (SettingsCache::instance().getAnnotateTokens()) {
         cmd.set_annotation(cardInfo->getText().toStdString());
     } else {
         cmd.set_annotation("");
@@ -2140,7 +2140,7 @@ void Player::playCard(CardItem *card, bool faceDown, bool tapped)
     }
 
     int tableRow = info->getTableRow();
-    bool playToStack = settingsCache->getPlayToStack();
+    bool playToStack = SettingsCache::instance().getPlayToStack();
     QString currentZone = card->getZone()->getName();
     if (currentZone == "stack" && tableRow == 3) {
         cmd.set_target_zone("grave");
@@ -3209,7 +3209,7 @@ void Player::addRelatedCardActions(const CardItem *card, QMenu *cardMenu)
     if (createRelatedCards) {
         if (shortcutsActive) {
             createRelatedCards->setShortcut(
-                settingsCache->shortcuts().getSingleShortcut("Player/aCreateRelatedTokens"));
+                SettingsCache::instance().shortcuts().getSingleShortcut("Player/aCreateRelatedTokens"));
         }
         connect(createRelatedCards, SIGNAL(triggered()), this, SLOT(actCreateAllRelatedCards()));
         cardMenu->addAction(createRelatedCards);
@@ -3239,7 +3239,7 @@ QString Player::getName() const
 qreal Player::getMinimumWidth() const
 {
     qreal result = table->getMinimumWidth() + CARD_HEIGHT + 15 + counterAreaWidth + stack->boundingRect().width();
-    if (!settingsCache->getHorizontalHand()) {
+    if (!SettingsCache::instance().getHorizontalHand()) {
         result += hand->boundingRect().width();
     }
     return result;
@@ -3275,7 +3275,7 @@ void Player::processSceneSizeChange(int newPlayerWidth)
 {
     // Extend table (and hand, if horizontal) to accommodate the new player width.
     qreal tableWidth = newPlayerWidth - CARD_HEIGHT - 15 - counterAreaWidth - stack->boundingRect().width();
-    if (!settingsCache->getHorizontalHand()) {
+    if (!SettingsCache::instance().getHorizontalHand()) {
         tableWidth -= hand->boundingRect().width();
     }
 
@@ -3292,7 +3292,7 @@ void Player::setLastToken(CardInfoPtr cardInfo)
     lastTokenName = cardInfo->getName();
     lastTokenColor = cardInfo->getColors().isEmpty() ? QString() : cardInfo->getColors().left(1).toLower();
     lastTokenPT = cardInfo->getPowTough();
-    lastTokenAnnotation = settingsCache->getAnnotateTokens() ? cardInfo->getText() : "";
+    lastTokenAnnotation = SettingsCache::instance().getAnnotateTokens() ? cardInfo->getText() : "";
     lastTokenTableRow = TableZone::clampValidTableRow(2 - cardInfo->getTableRow());
     lastTokenDestroy = true;
     aCreateAnotherToken->setText(tr("C&reate another %1 token").arg(lastTokenName));

--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -30,7 +30,7 @@ RemoteClient::RemoteClient(QObject *parent)
 {
 
     clearNewClientFeatures();
-    int keepalive = settingsCache->getKeepAlive();
+    int keepalive = SettingsCache::instance().getKeepAlive();
     timer = new QTimer(this);
     timer->setInterval(keepalive * 1000);
     connect(timer, SIGNAL(timeout()), this, SLOT(ping()));
@@ -227,8 +227,8 @@ void RemoteClient::loginResponse(const Response &response)
         emit ignoreListReceived(ignoreList);
 
         if (newMissingFeatureFound(possibleMissingFeatures) && resp.missing_features_size() > 0 &&
-            settingsCache->getNotifyAboutUpdates()) {
-            settingsCache->setKnownMissingFeatures(possibleMissingFeatures);
+            SettingsCache::instance().getNotifyAboutUpdates()) {
+            SettingsCache::instance().setKnownMissingFeatures(possibleMissingFeatures);
             emit notifyUserAboutUpdate();
         }
 
@@ -459,7 +459,7 @@ void RemoteClient::ping()
         }
     }
 
-    int keepalive = settingsCache->getKeepAlive();
+    int keepalive = SettingsCache::instance().getKeepAlive();
     int maxTime = timeRunning - lastDataReceived;
     emit maxPingTime(maxTime, maxTimeout);
     if (maxTime >= (keepalive * maxTimeout)) {
@@ -498,13 +498,13 @@ void RemoteClient::activateToServer(const QString &_token)
 
 void RemoteClient::disconnectFromServer()
 {
-    settingsCache->servers().setAutoConnect(false);
+    SettingsCache::instance().servers().setAutoConnect(false);
     emit sigDisconnectFromServer();
 }
 
 QString RemoteClient::getSrvClientID(const QString _hostname)
 {
-    QString srvClientID = settingsCache->getClientID();
+    QString srvClientID = SettingsCache::instance().getClientID();
     QHostInfo hostInfo = QHostInfo::fromName(_hostname);
     if (!hostInfo.error()) {
         QHostAddress hostAddress = hostInfo.addresses().first();
@@ -524,7 +524,7 @@ bool RemoteClient::newMissingFeatureFound(QString _serversMissingFeatures)
     QStringList serversMissingFeaturesList = _serversMissingFeatures.split(",");
     foreach (const QString &feature, serversMissingFeaturesList) {
         if (!feature.isEmpty()) {
-            if (!settingsCache->getKnownMissingFeatures().contains(feature))
+            if (!SettingsCache::instance().getKnownMissingFeatures().contains(feature))
                 return true;
         }
     }
@@ -534,14 +534,14 @@ bool RemoteClient::newMissingFeatureFound(QString _serversMissingFeatures)
 void RemoteClient::clearNewClientFeatures()
 {
     QString newKnownMissingFeatures;
-    QStringList existingKnownMissingFeatures = settingsCache->getKnownMissingFeatures().split(",");
+    QStringList existingKnownMissingFeatures = SettingsCache::instance().getKnownMissingFeatures().split(",");
     foreach (const QString &existingKnownFeature, existingKnownMissingFeatures) {
         if (!existingKnownFeature.isEmpty()) {
             if (!clientFeatures.contains(existingKnownFeature))
                 newKnownMissingFeatures.append("," + existingKnownFeature);
         }
     }
-    settingsCache->setKnownMissingFeatures(newKnownMissingFeatures);
+    SettingsCache::instance().setKnownMissingFeatures(newKnownMissingFeatures);
 }
 
 void RemoteClient::requestForgotPasswordToServer(const QString &hostname, unsigned int port, const QString &_userName)

--- a/cockatrice/src/sequenceEdit/sequenceedit.cpp
+++ b/cockatrice/src/sequenceEdit/sequenceedit.cpp
@@ -45,7 +45,7 @@ void SequenceEdit::setShortcutName(const QString &_shortcutName)
         clearButton->setEnabled(true);
         defaultButton->setEnabled(true);
         lineEdit->setEnabled(true);
-        lineEdit->setText(settingsCache->shortcuts().getShortcutString(shortcutName));
+        lineEdit->setText(SettingsCache::instance().shortcuts().getShortcutString(shortcutName));
         lineEdit->setPlaceholderText(tr("Hit the key/combination of keys you want to set for this action"));
     }
 }
@@ -72,13 +72,13 @@ void SequenceEdit::removeLastShortcut()
 
 void SequenceEdit::restoreDefault()
 {
-    lineEdit->setText(settingsCache->shortcuts().getDefaultShortcutString(shortcutName));
+    lineEdit->setText(SettingsCache::instance().shortcuts().getDefaultShortcutString(shortcutName));
     updateSettings();
 }
 
 void SequenceEdit::refreshShortcut()
 {
-    lineEdit->setText(settingsCache->shortcuts().getShortcutString(shortcutName));
+    lineEdit->setText(SettingsCache::instance().shortcuts().getShortcutString(shortcutName));
 }
 
 void SequenceEdit::clear()
@@ -159,8 +159,8 @@ void SequenceEdit::finishShortcut()
     QKeySequence sequence(keys);
     if (!sequence.isEmpty() && valid) {
         QString sequenceString = sequence.toString();
-        if (settingsCache->shortcuts().isKeyAllowed(shortcutName, sequenceString)) {
-            if (settingsCache->shortcuts().isValid(shortcutName, sequenceString)) {
+        if (SettingsCache::instance().shortcuts().isKeyAllowed(shortcutName, sequenceString)) {
+            if (SettingsCache::instance().shortcuts().isValid(shortcutName, sequenceString)) {
                 if (!lineEdit->text().isEmpty()) {
                     if (lineEdit->text().contains(sequenceString)) {
                         return;
@@ -184,7 +184,7 @@ void SequenceEdit::finishShortcut()
 
 void SequenceEdit::updateSettings()
 {
-    settingsCache->shortcuts().setShortcuts(shortcutName, lineEdit->text());
+    SettingsCache::instance().shortcuts().setShortcuts(shortcutName, lineEdit->text());
 }
 
 void SequenceEdit::retranslateUi()

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -6,9 +6,12 @@
 #include <QDebug>
 #include <QDir>
 #include <QFile>
+#include <QGlobalStatic>
 #include <QSettings>
 #include <QStandardPaths>
 #include <utility>
+
+Q_GLOBAL_STATIC(SettingsCache, settingsCache);
 
 QString SettingsCache::getDataPath()
 {
@@ -966,4 +969,9 @@ void SettingsCache::setMaxFontSize(int _max)
 {
     maxFontSize = _max;
     settings->setValue("game/maxfontsize", maxFontSize);
+}
+
+SettingsCache &SettingsCache::instance()
+{
+    return *settingsCache;
 }

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -462,6 +462,8 @@ public:
     {
         return mbDownloadSpoilers;
     }
+
+    static SettingsCache &instance();
 public slots:
     void setDownloadSpoilerStatus(bool _spoilerStatus);
 
@@ -528,7 +530,5 @@ public slots:
     void setUpdateReleaseChannel(int _updateReleaseChannel);
     void setMaxFontSize(int _max);
 };
-
-extern SettingsCache *settingsCache;
 
 #endif

--- a/cockatrice/src/soundengine.cpp
+++ b/cockatrice/src/soundengine.cpp
@@ -18,8 +18,8 @@ SoundEngine::SoundEngine(QObject *parent) : QObject(parent), player(0)
     inputBuffer = new QBuffer(this);
 
     ensureThemeDirectoryExists();
-    connect(settingsCache, SIGNAL(soundThemeChanged()), this, SLOT(themeChangedSlot()));
-    connect(settingsCache, SIGNAL(soundEnabledChanged()), this, SLOT(soundEnabledChanged()));
+    connect(&SettingsCache::instance(), SIGNAL(soundThemeChanged()), this, SLOT(themeChangedSlot()));
+    connect(&SettingsCache::instance(), SIGNAL(soundEnabledChanged()), this, SLOT(soundEnabledChanged()));
 
     soundEnabledChanged();
     themeChangedSlot();
@@ -37,7 +37,7 @@ SoundEngine::~SoundEngine()
 
 void SoundEngine::soundEnabledChanged()
 {
-    if (settingsCache->getSoundEnabled()) {
+    if (SettingsCache::instance().getSoundEnabled()) {
         qDebug("SoundEngine: enabling sound");
         if (!player) {
             QAudioFormat format;
@@ -77,7 +77,7 @@ void SoundEngine::playSound(QString fileName)
     inputBuffer->setData(audioData[fileName]);
     inputBuffer->open(QIODevice::ReadOnly);
 
-    player->setVolume(settingsCache->getMasterVolume() / 100.0);
+    player->setVolume(SettingsCache::instance().getMasterVolume() / 100.0);
     player->stop();
     player->start(inputBuffer);
 }
@@ -89,10 +89,10 @@ void SoundEngine::testSound()
 
 void SoundEngine::ensureThemeDirectoryExists()
 {
-    if (settingsCache->getSoundThemeName().isEmpty() ||
-        !getAvailableThemes().contains(settingsCache->getSoundThemeName())) {
+    if (SettingsCache::instance().getSoundThemeName().isEmpty() ||
+        !getAvailableThemes().contains(SettingsCache::instance().getSoundThemeName())) {
         qDebug() << "Sounds theme name not set, setting default value";
-        settingsCache->setSoundThemeName(DEFAULT_THEME_NAME);
+        SettingsCache::instance().setSoundThemeName(DEFAULT_THEME_NAME);
     }
 }
 
@@ -103,7 +103,7 @@ QStringMap &SoundEngine::getAvailableThemes()
 
     // load themes from user profile dir
 
-    dir.setPath(settingsCache->getDataPath() + "/sounds");
+    dir.setPath(SettingsCache::instance().getDataPath() + "/sounds");
 
     foreach (QString themeName, dir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot, QDir::Name)) {
         if (!availableThemes.contains(themeName))
@@ -131,7 +131,7 @@ QStringMap &SoundEngine::getAvailableThemes()
 
 void SoundEngine::themeChangedSlot()
 {
-    QString themeName = settingsCache->getSoundThemeName();
+    QString themeName = SettingsCache::instance().getSoundThemeName();
     qDebug() << "Sound theme changed:" << themeName;
 
     QDir dir = getAvailableThemes().value(themeName);

--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -21,7 +21,7 @@
 
 SpoilerBackgroundUpdater::SpoilerBackgroundUpdater(QObject *apParent) : QObject(apParent), cardUpdateProcess(nullptr)
 {
-    isSpoilerDownloadEnabled = settingsCache->getDownloadSpoilersStatus();
+    isSpoilerDownloadEnabled = SettingsCache::instance().getDownloadSpoilersStatus();
     if (isSpoilerDownloadEnabled) {
         // Start the process of checking if we're in spoiler season
         // File exists means we're in spoiler season
@@ -73,7 +73,7 @@ void SpoilerBackgroundUpdater::actDownloadFinishedSpoilersFile()
 
 bool SpoilerBackgroundUpdater::deleteSpoilerFile()
 {
-    QString fileName = settingsCache->getSpoilerCardDatabasePath();
+    QString fileName = SettingsCache::instance().getSpoilerCardDatabasePath();
     QFileInfo fi(fileName);
     QDir fileDir(fi.path());
     QFile file(fileName);
@@ -124,7 +124,7 @@ void SpoilerBackgroundUpdater::actCheckIfSpoilerSeasonEnabled()
 
 bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
 {
-    QString fileName = settingsCache->getSpoilerCardDatabasePath();
+    QString fileName = SettingsCache::instance().getSpoilerCardDatabasePath();
     QFileInfo fi(fileName);
     QDir fileDir(fi.path());
 

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -415,7 +415,7 @@ void TabDeckEditor::createCentralFrame()
             SLOT(updateCardInfoLeft(const QModelIndex &, const QModelIndex &)));
     connect(databaseView, SIGNAL(doubleClicked(const QModelIndex &)), this, SLOT(actAddCard()));
 
-    QByteArray dbHeaderState = settingsCache->layouts().getDeckEditorDbHeaderState();
+    QByteArray dbHeaderState = SettingsCache::instance().layouts().getDeckEditorDbHeaderState();
     if (dbHeaderState.isNull()) {
         // first run
         databaseView->setColumnWidth(0, 200);
@@ -532,35 +532,35 @@ void TabDeckEditor::freeDocksSize()
 
 void TabDeckEditor::refreshShortcuts()
 {
-    aNewDeck->setShortcuts(settingsCache->shortcuts().getShortcut("TabDeckEditor/aNewDeck"));
-    aLoadDeck->setShortcuts(settingsCache->shortcuts().getShortcut("TabDeckEditor/aLoadDeck"));
-    aSaveDeck->setShortcuts(settingsCache->shortcuts().getShortcut("TabDeckEditor/aSaveDeck"));
-    aExportDeckDecklist->setShortcuts(settingsCache->shortcuts().getShortcut("TabDeckEditor/aExportDeckDecklist"));
-    aSaveDeckAs->setShortcuts(settingsCache->shortcuts().getShortcut("TabDeckEditor/aSaveDeckAs"));
-    aLoadDeckFromClipboard->setShortcuts(
-        settingsCache->shortcuts().getShortcut("TabDeckEditor/aLoadDeckFromClipboard"));
-    aPrintDeck->setShortcuts(settingsCache->shortcuts().getShortcut("TabDeckEditor/aPrintDeck"));
-    aAnalyzeDeckDeckstats->setShortcuts(settingsCache->shortcuts().getShortcut("TabDeckEditor/aAnalyzeDeck"));
-    aClose->setShortcuts(settingsCache->shortcuts().getShortcut("TabDeckEditor/aClose"));
-    aResetLayout->setShortcuts(settingsCache->shortcuts().getShortcut("TabDeckEditor/aResetLayout"));
-    aClearFilterAll->setShortcuts(settingsCache->shortcuts().getShortcut("TabDeckEditor/aClearFilterAll"));
-    aClearFilterOne->setShortcuts(settingsCache->shortcuts().getShortcut("TabDeckEditor/aClearFilterOne"));
+    ShortcutsSettings &shortcuts = SettingsCache::instance().shortcuts();
+    aNewDeck->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aNewDeck"));
+    aLoadDeck->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aLoadDeck"));
+    aSaveDeck->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aSaveDeck"));
+    aExportDeckDecklist->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aExportDeckDecklist"));
+    aSaveDeckAs->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aSaveDeckAs"));
+    aLoadDeckFromClipboard->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aLoadDeckFromClipboard"));
+    aPrintDeck->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aPrintDeck"));
+    aAnalyzeDeckDeckstats->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aAnalyzeDeck"));
+    aClose->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aClose"));
+    aResetLayout->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aResetLayout"));
+    aClearFilterAll->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aClearFilterAll"));
+    aClearFilterOne->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aClearFilterOne"));
 
-    aSaveDeckToClipboard->setShortcuts(settingsCache->shortcuts().getShortcut("TabDeckEditor/aSaveDeckToClipboard"));
-    aSaveDeckToClipboardRaw->setShortcuts(
-        settingsCache->shortcuts().getShortcut("TabDeckEditor/aSaveDeckToClipboardRaw"));
+    aSaveDeckToClipboard->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aSaveDeckToClipboard"));
+    aSaveDeckToClipboardRaw->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aSaveDeckToClipboardRaw"));
 
-    aClearFilterOne->setShortcuts(settingsCache->shortcuts().getShortcut("TabDeckEditor/aClearFilterOne"));
-    aClose->setShortcuts(settingsCache->shortcuts().getShortcut("TabDeckEditor/aClose"));
-    aRemoveCard->setShortcuts(settingsCache->shortcuts().getShortcut("TabDeckEditor/aRemoveCard"));
-    aIncrement->setShortcuts(settingsCache->shortcuts().getShortcut("TabDeckEditor/aIncrement"));
-    aDecrement->setShortcuts(settingsCache->shortcuts().getShortcut("TabDeckEditor/aDecrement"));
+    aClearFilterOne->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aClearFilterOne"));
+    aClose->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aClose"));
+    aRemoveCard->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aRemoveCard"));
+    aIncrement->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aIncrement"));
+    aDecrement->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aDecrement"));
 }
 
 void TabDeckEditor::loadLayout()
 {
-    restoreState(settingsCache->layouts().getDeckEditorLayoutState());
-    restoreGeometry(settingsCache->layouts().getDeckEditorGeometry());
+    LayoutsSettings &layouts = SettingsCache::instance().layouts();
+    restoreState(layouts.getDeckEditorLayoutState());
+    restoreGeometry(layouts.getDeckEditorGeometry());
 
     aCardInfoDockVisible->setChecked(cardInfoDock->isVisible());
     aFilterDockVisible->setChecked(filterDock->isVisible());
@@ -574,14 +574,14 @@ void TabDeckEditor::loadLayout()
     aFilterDockFloating->setChecked(filterDock->isFloating());
     aDeckDockFloating->setChecked(deckDock->isFloating());
 
-    cardInfoDock->setMinimumSize(settingsCache->layouts().getDeckEditorCardSize());
-    cardInfoDock->setMaximumSize(settingsCache->layouts().getDeckEditorCardSize());
+    cardInfoDock->setMinimumSize(layouts.getDeckEditorCardSize());
+    cardInfoDock->setMaximumSize(layouts.getDeckEditorCardSize());
 
-    filterDock->setMinimumSize(settingsCache->layouts().getDeckEditorFilterSize());
-    filterDock->setMaximumSize(settingsCache->layouts().getDeckEditorFilterSize());
+    filterDock->setMinimumSize(layouts.getDeckEditorFilterSize());
+    filterDock->setMaximumSize(layouts.getDeckEditorFilterSize());
 
-    deckDock->setMinimumSize(settingsCache->layouts().getDeckEditorDeckSize());
-    deckDock->setMaximumSize(settingsCache->layouts().getDeckEditorDeckSize());
+    deckDock->setMinimumSize(layouts.getDeckEditorDeckSize());
+    deckDock->setMaximumSize(layouts.getDeckEditorDeckSize());
 
     QTimer::singleShot(100, this, SLOT(freeDocksSize()));
 }
@@ -604,7 +604,7 @@ TabDeckEditor::TabDeckEditor(TabSupervisor *_tabSupervisor, QWidget *parent)
     this->installEventFilter(this);
 
     retranslateUi();
-    connect(&settingsCache->shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
+    connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
     refreshShortcuts();
 
     QTimer::singleShot(0, this, SLOT(loadLayout()));
@@ -766,7 +766,7 @@ void TabDeckEditor::actLoadDeck()
         return;
 
     QFileDialog dialog(this, tr("Load deck"));
-    dialog.setDirectory(settingsCache->getDeckPath());
+    dialog.setDirectory(SettingsCache::instance().getDeckPath());
     dialog.setNameFilters(DeckLoader::fileNameFilters);
     if (!dialog.exec())
         return;
@@ -820,7 +820,7 @@ bool TabDeckEditor::actSaveDeck()
 bool TabDeckEditor::actSaveDeckAs()
 {
     QFileDialog dialog(this, tr("Save deck"));
-    dialog.setDirectory(settingsCache->getDeckPath());
+    dialog.setDirectory(SettingsCache::instance().getDeckPath());
     dialog.setAcceptMode(QFileDialog::AcceptSave);
     dialog.setDefaultSuffix("cod");
     dialog.setNameFilters(DeckLoader::fileNameFilters);
@@ -1144,11 +1144,12 @@ bool TabDeckEditor::eventFilter(QObject *o, QEvent *e)
         }
     }
     if (o == this && e->type() == QEvent::Hide) {
-        settingsCache->layouts().setDeckEditorLayoutState(saveState());
-        settingsCache->layouts().setDeckEditorGeometry(saveGeometry());
-        settingsCache->layouts().setDeckEditorCardSize(cardInfoDock->size());
-        settingsCache->layouts().setDeckEditorFilterSize(filterDock->size());
-        settingsCache->layouts().setDeckEditorDeckSize(deckDock->size());
+        LayoutsSettings &layouts = SettingsCache::instance().layouts();
+        layouts.setDeckEditorLayoutState(saveState());
+        layouts.setDeckEditorGeometry(saveGeometry());
+        layouts.setDeckEditorCardSize(cardInfoDock->size());
+        layouts.setDeckEditorFilterSize(filterDock->size());
+        layouts.setDeckEditorDeckSize(deckDock->size());
     }
     return false;
 }
@@ -1215,7 +1216,7 @@ void TabDeckEditor::dockTopLevelChanged(bool topLevel)
 
 void TabDeckEditor::saveDbHeaderState()
 {
-    settingsCache->layouts().setDeckEditorDbHeaderState(databaseView->header()->saveState());
+    SettingsCache::instance().layouts().setDeckEditorDbHeaderState(databaseView->header()->saveState());
 }
 
 void TabDeckEditor::setSaveStatus(bool newStatus)

--- a/cockatrice/src/tab_deck_storage.cpp
+++ b/cockatrice/src/tab_deck_storage.cpp
@@ -31,7 +31,7 @@ TabDeckStorage::TabDeckStorage(TabSupervisor *_tabSupervisor, AbstractClient *_c
     : Tab(_tabSupervisor), client(_client)
 {
     localDirModel = new QFileSystemModel(this);
-    localDirModel->setRootPath(settingsCache->getDeckPath());
+    localDirModel->setRootPath(SettingsCache::instance().getDeckPath());
     localDirModel->sort(0, Qt::AscendingOrder);
 
     localDirView = new QTreeView;

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -135,7 +135,7 @@ DeckViewContainer::DeckViewContainer(int _playerId, TabGame *parent)
     setLayout(deckViewLayout);
 
     retranslateUi();
-    connect(&settingsCache->shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
+    connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
     refreshShortcuts();
 }
 
@@ -166,97 +166,98 @@ void DeckViewContainer::updateSideboardLockButtonText()
 
 void DeckViewContainer::refreshShortcuts()
 {
-    loadLocalButton->setShortcut(settingsCache->shortcuts().getSingleShortcut("DeckViewContainer/loadLocalButton"));
-    loadRemoteButton->setShortcut(settingsCache->shortcuts().getSingleShortcut("DeckViewContainer/loadRemoteButton"));
-    readyStartButton->setShortcut(settingsCache->shortcuts().getSingleShortcut("DeckViewContainer/readyStartButton"));
-    sideboardLockButton->setShortcut(
-        settingsCache->shortcuts().getSingleShortcut("DeckViewContainer/sideboardLockButton"));
+    ShortcutsSettings &shortcuts = SettingsCache::instance().shortcuts();
+    loadLocalButton->setShortcut(shortcuts.getSingleShortcut("DeckViewContainer/loadLocalButton"));
+    loadRemoteButton->setShortcut(shortcuts.getSingleShortcut("DeckViewContainer/loadRemoteButton"));
+    readyStartButton->setShortcut(shortcuts.getSingleShortcut("DeckViewContainer/readyStartButton"));
+    sideboardLockButton->setShortcut(shortcuts.getSingleShortcut("DeckViewContainer/sideboardLockButton"));
 }
 
 void TabGame::refreshShortcuts()
 {
+    ShortcutsSettings &shortcuts = SettingsCache::instance().shortcuts();
     for (int i = 0; i < phaseActions.size(); ++i) {
         QAction *temp = phaseActions.at(i);
         switch (i) {
             case 0:
-                temp->setShortcuts(settingsCache->shortcuts().getShortcut("Player/phase0"));
+                temp->setShortcuts(shortcuts.getShortcut("Player/phase0"));
                 break;
             case 1:
-                temp->setShortcuts(settingsCache->shortcuts().getShortcut("Player/phase1"));
+                temp->setShortcuts(shortcuts.getShortcut("Player/phase1"));
                 break;
             case 2:
-                temp->setShortcuts(settingsCache->shortcuts().getShortcut("Player/phase2"));
+                temp->setShortcuts(shortcuts.getShortcut("Player/phase2"));
                 break;
             case 3:
-                temp->setShortcuts(settingsCache->shortcuts().getShortcut("Player/phase3"));
+                temp->setShortcuts(shortcuts.getShortcut("Player/phase3"));
                 break;
             case 4:
-                temp->setShortcuts(settingsCache->shortcuts().getShortcut("Player/phase4"));
+                temp->setShortcuts(shortcuts.getShortcut("Player/phase4"));
                 break;
             case 5:
-                temp->setShortcuts(settingsCache->shortcuts().getShortcut("Player/phase5"));
+                temp->setShortcuts(shortcuts.getShortcut("Player/phase5"));
                 break;
             case 6:
-                temp->setShortcuts(settingsCache->shortcuts().getShortcut("Player/phase6"));
+                temp->setShortcuts(shortcuts.getShortcut("Player/phase6"));
                 break;
             case 7:
-                temp->setShortcuts(settingsCache->shortcuts().getShortcut("Player/phase7"));
+                temp->setShortcuts(shortcuts.getShortcut("Player/phase7"));
                 break;
             case 8:
-                temp->setShortcuts(settingsCache->shortcuts().getShortcut("Player/phase8"));
+                temp->setShortcuts(shortcuts.getShortcut("Player/phase8"));
                 break;
             case 9:
-                temp->setShortcuts(settingsCache->shortcuts().getShortcut("Player/phase9"));
+                temp->setShortcuts(shortcuts.getShortcut("Player/phase9"));
                 break;
             case 10:
-                temp->setShortcuts(settingsCache->shortcuts().getShortcut("Player/phase10"));
+                temp->setShortcuts(shortcuts.getShortcut("Player/phase10"));
                 break;
             default:;
         }
     }
 
     if (aNextPhase) {
-        aNextPhase->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aNextPhase"));
+        aNextPhase->setShortcuts(shortcuts.getShortcut("Player/aNextPhase"));
     }
     if (aNextPhaseAction) {
-        aNextPhaseAction->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aNextPhaseAction"));
+        aNextPhaseAction->setShortcuts(shortcuts.getShortcut("Player/aNextPhaseAction"));
     }
     if (aNextTurn) {
-        aNextTurn->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aNextTurn"));
+        aNextTurn->setShortcuts(shortcuts.getShortcut("Player/aNextTurn"));
     }
     if (aReverseTurn) {
-        aReverseTurn->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aReverseTurn"));
+        aReverseTurn->setShortcuts(shortcuts.getShortcut("Player/aReverseTurn"));
     }
     if (aRemoveLocalArrows) {
-        aRemoveLocalArrows->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aRemoveLocalArrows"));
+        aRemoveLocalArrows->setShortcuts(shortcuts.getShortcut("Player/aRemoveLocalArrows"));
     }
     if (aRotateViewCW) {
-        aRotateViewCW->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aRotateViewCW"));
+        aRotateViewCW->setShortcuts(shortcuts.getShortcut("Player/aRotateViewCW"));
     }
     if (aRotateViewCCW) {
-        aRotateViewCCW->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aRotateViewCCW"));
+        aRotateViewCCW->setShortcuts(shortcuts.getShortcut("Player/aRotateViewCCW"));
     }
     if (aConcede) {
-        aConcede->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aConcede"));
+        aConcede->setShortcuts(shortcuts.getShortcut("Player/aConcede"));
     }
     if (aLeaveGame) {
-        aLeaveGame->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aLeaveGame"));
+        aLeaveGame->setShortcuts(shortcuts.getShortcut("Player/aLeaveGame"));
     }
     if (aCloseReplay) {
-        aCloseReplay->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aCloseReplay"));
+        aCloseReplay->setShortcuts(shortcuts.getShortcut("Player/aCloseReplay"));
     }
     if (aResetLayout) {
-        aResetLayout->setShortcuts(settingsCache->shortcuts().getShortcut("Player/aResetLayout"));
+        aResetLayout->setShortcuts(shortcuts.getShortcut("Player/aResetLayout"));
     }
     if (aFocusChat) {
-        aFocusChat->setShortcuts(settingsCache->shortcuts().getShortcut("tab_game/aFocusChat"));
+        aFocusChat->setShortcuts(shortcuts.getShortcut("tab_game/aFocusChat"));
     }
 }
 
 void DeckViewContainer::loadLocalDeck()
 {
     QFileDialog dialog(this, tr("Load deck"));
-    dialog.setDirectory(settingsCache->getDeckPath());
+    dialog.setDirectory(SettingsCache::instance().getDeckPath());
     dialog.setNameFilters(DeckLoader::fileNameFilters);
     if (!dialog.exec())
         return;
@@ -394,7 +395,7 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, GameReplay *_replay)
     createReplayMenuItems();
     createViewMenuItems();
     retranslateUi();
-    connect(&settingsCache->shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
+    connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
     refreshShortcuts();
     messageLog->logReplayStarted(gameInfo.game_id());
 
@@ -433,7 +434,7 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor,
     createMenuItems();
     createViewMenuItems();
     retranslateUi();
-    connect(&settingsCache->shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
+    connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
     refreshShortcuts();
 
     // append game to rooms game list for others to see
@@ -458,7 +459,7 @@ void TabGame::linkCardToChat(QString cardName)
 
 void TabGame::emitUserEvent()
 {
-    bool globalEvent = !spectator || settingsCache->getSpectatorNotificationsEnabled();
+    bool globalEvent = !spectator || SettingsCache::instance().getSpectatorNotificationsEnabled();
     emit userEvent(globalEvent);
     updatePlayerListDockTitle();
 }
@@ -771,7 +772,8 @@ void TabGame::actRotateViewCCW()
 
 void TabGame::actCompleterChanged()
 {
-    settingsCache->getChatMentionCompleter() ? completer->setCompletionRole(2) : completer->setCompletionRole(1);
+    SettingsCache::instance().getChatMentionCompleter() ? completer->setCompletionRole(2)
+                                                        : completer->setCompletionRole(1);
 }
 
 Player *TabGame::addPlayer(int playerId, const ServerInfo_User &info)
@@ -1525,28 +1527,29 @@ void TabGame::createViewMenuItems()
 
 void TabGame::loadLayout()
 {
+    LayoutsSettings &layouts = SettingsCache::instance().layouts();
     if (replayDock) {
-        restoreGeometry(settingsCache->layouts().getReplayPlayAreaGeometry());
-        restoreState(settingsCache->layouts().getReplayPlayAreaLayoutState());
+        restoreGeometry(layouts.getReplayPlayAreaGeometry());
+        restoreState(layouts.getReplayPlayAreaLayoutState());
 
-        cardInfoDock->setMinimumSize(settingsCache->layouts().getReplayCardInfoSize());
-        cardInfoDock->setMaximumSize(settingsCache->layouts().getReplayCardInfoSize());
-        messageLayoutDock->setMinimumSize(settingsCache->layouts().getReplayMessageLayoutSize());
-        messageLayoutDock->setMaximumSize(settingsCache->layouts().getReplayMessageLayoutSize());
-        playerListDock->setMinimumSize(settingsCache->layouts().getReplayPlayerListSize());
-        playerListDock->setMaximumSize(settingsCache->layouts().getReplayPlayerListSize());
-        replayDock->setMinimumSize(settingsCache->layouts().getReplayReplaySize());
-        replayDock->setMaximumSize(settingsCache->layouts().getReplayReplaySize());
+        cardInfoDock->setMinimumSize(layouts.getReplayCardInfoSize());
+        cardInfoDock->setMaximumSize(layouts.getReplayCardInfoSize());
+        messageLayoutDock->setMinimumSize(layouts.getReplayMessageLayoutSize());
+        messageLayoutDock->setMaximumSize(layouts.getReplayMessageLayoutSize());
+        playerListDock->setMinimumSize(layouts.getReplayPlayerListSize());
+        playerListDock->setMaximumSize(layouts.getReplayPlayerListSize());
+        replayDock->setMinimumSize(layouts.getReplayReplaySize());
+        replayDock->setMaximumSize(layouts.getReplayReplaySize());
     } else {
-        restoreGeometry(settingsCache->layouts().getGamePlayAreaGeometry());
-        restoreState(settingsCache->layouts().getGamePlayAreaLayoutState());
+        restoreGeometry(layouts.getGamePlayAreaGeometry());
+        restoreState(layouts.getGamePlayAreaLayoutState());
 
-        cardInfoDock->setMinimumSize(settingsCache->layouts().getGameCardInfoSize());
-        cardInfoDock->setMaximumSize(settingsCache->layouts().getGameCardInfoSize());
-        messageLayoutDock->setMinimumSize(settingsCache->layouts().getGameMessageLayoutSize());
-        messageLayoutDock->setMaximumSize(settingsCache->layouts().getGameMessageLayoutSize());
-        playerListDock->setMinimumSize(settingsCache->layouts().getGamePlayerListSize());
-        playerListDock->setMaximumSize(settingsCache->layouts().getGamePlayerListSize());
+        cardInfoDock->setMinimumSize(layouts.getGameCardInfoSize());
+        cardInfoDock->setMaximumSize(layouts.getGameCardInfoSize());
+        messageLayoutDock->setMinimumSize(layouts.getGameMessageLayoutSize());
+        messageLayoutDock->setMaximumSize(layouts.getGameMessageLayoutSize());
+        playerListDock->setMinimumSize(layouts.getGamePlayerListSize());
+        playerListDock->setMaximumSize(layouts.getGamePlayerListSize());
     }
 
     aCardInfoDockVisible->setChecked(cardInfoDock->isVisible());
@@ -1772,7 +1775,7 @@ void TabGame::createMessageDock(bool bReplay)
     if (!bReplay) {
         connect(messageLog, SIGNAL(openMessageDialog(QString, bool)), this, SIGNAL(openMessageDialog(QString, bool)));
         connect(messageLog, SIGNAL(addMentionTag(QString)), this, SLOT(addMentionTag(QString)));
-        connect(settingsCache, SIGNAL(chatMentionCompleterChanged()), this, SLOT(actCompleterChanged()));
+        connect(&SettingsCache::instance(), SIGNAL(chatMentionCompleterChanged()), this, SLOT(actCompleterChanged()));
 
         timeElapsedLabel = new QLabel;
         timeElapsedLabel->setAlignment(Qt::AlignCenter);
@@ -1846,19 +1849,20 @@ bool TabGame::eventFilter(QObject *o, QEvent *e)
     }
 
     if (o == this && e->type() == QEvent::Hide) {
+        LayoutsSettings &layouts = SettingsCache::instance().layouts();
         if (replay) {
-            settingsCache->layouts().setReplayPlayAreaState(saveState());
-            settingsCache->layouts().setReplayPlayAreaGeometry(saveGeometry());
-            settingsCache->layouts().setReplayCardInfoSize(cardInfoDock->size());
-            settingsCache->layouts().setReplayMessageLayoutSize(messageLayoutDock->size());
-            settingsCache->layouts().setReplayPlayerListSize(playerListDock->size());
-            settingsCache->layouts().setReplayReplaySize(replayDock->size());
+            layouts.setReplayPlayAreaState(saveState());
+            layouts.setReplayPlayAreaGeometry(saveGeometry());
+            layouts.setReplayCardInfoSize(cardInfoDock->size());
+            layouts.setReplayMessageLayoutSize(messageLayoutDock->size());
+            layouts.setReplayPlayerListSize(playerListDock->size());
+            layouts.setReplayReplaySize(replayDock->size());
         } else {
-            settingsCache->layouts().setGamePlayAreaState(saveState());
-            settingsCache->layouts().setGamePlayAreaGeometry(saveGeometry());
-            settingsCache->layouts().setGameCardInfoSize(cardInfoDock->size());
-            settingsCache->layouts().setGameMessageLayoutSize(messageLayoutDock->size());
-            settingsCache->layouts().setGamePlayerListSize(playerListDock->size());
+            layouts.setGamePlayAreaState(saveState());
+            layouts.setGamePlayAreaGeometry(saveGeometry());
+            layouts.setGameCardInfoSize(cardInfoDock->size());
+            layouts.setGameMessageLayoutSize(messageLayoutDock->size());
+            layouts.setGamePlayerListSize(playerListDock->size());
         }
     }
     return false;

--- a/cockatrice/src/tab_message.cpp
+++ b/cockatrice/src/tab_message.cpp
@@ -127,7 +127,7 @@ void TabMessage::processUserMessageEvent(const Event_UserMessage &event)
                             userLevel, userPriv, true);
     if (tabSupervisor->currentIndex() != tabSupervisor->indexOf(this))
         soundEngine->playSound("private_message");
-    if (settingsCache->getShowMessagePopup() && shouldShowSystemPopup(event))
+    if (SettingsCache::instance().getShowMessagePopup() && shouldShowSystemPopup(event))
         showSystemPopup(event);
     if (QString::fromStdString(event.sender_name()).toLower().simplified() == "servatrice")
         sayEdit->setDisabled(true);

--- a/cockatrice/src/tab_replays.cpp
+++ b/cockatrice/src/tab_replays.cpp
@@ -28,7 +28,7 @@
 TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client) : Tab(_tabSupervisor), client(_client)
 {
     localDirModel = new QFileSystemModel(this);
-    localDirModel->setRootPath(settingsCache->getReplaysPath());
+    localDirModel->setRootPath(SettingsCache::instance().getReplaysPath());
     localDirModel->sort(0, Qt::AscendingOrder);
 
     localDirView = new QTreeView;

--- a/cockatrice/src/tab_room.cpp
+++ b/cockatrice/src/tab_room.cpp
@@ -56,7 +56,7 @@ TabRoom::TabRoom(TabSupervisor *_tabSupervisor,
     connect(chatView, SIGNAL(showCardInfoPopup(QPoint, QString)), this, SLOT(showCardInfoPopup(QPoint, QString)));
     connect(chatView, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));
     connect(chatView, SIGNAL(addMentionTag(QString)), this, SLOT(addMentionTag(QString)));
-    connect(settingsCache, SIGNAL(chatMentionCompleterChanged()), this, SLOT(actCompleterChanged()));
+    connect(&SettingsCache::instance(), SIGNAL(chatMentionCompleterChanged()), this, SLOT(actCompleterChanged()));
     sayLabel = new QLabel;
     sayEdit = new LineEditCompleter;
     sayLabel->setBuddy(sayEdit);
@@ -122,7 +122,7 @@ TabRoom::TabRoom(TabSupervisor *_tabSupervisor,
 
     sayEdit->setCompleter(completer);
     actCompleterChanged();
-    connect(&settingsCache->shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
+    connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
     refreshShortcuts();
 
     retranslateUi();
@@ -233,7 +233,8 @@ void TabRoom::actOpenChatSettings()
 
 void TabRoom::actCompleterChanged()
 {
-    settingsCache->getChatMentionCompleter() ? completer->setCompletionRole(2) : completer->setCompletionRole(1);
+    SettingsCache::instance().getChatMentionCompleter() ? completer->setCompletionRole(2)
+                                                        : completer->setCompletionRole(1);
 }
 
 void TabRoom::processRoomEvent(const RoomEvent &event)
@@ -293,11 +294,12 @@ void TabRoom::processRoomSayEvent(const Event_RoomSay &event)
     if (twi) {
         userLevel = UserLevelFlags(twi->getUserInfo().user_level());
         userPrivLevel = QString::fromStdString(twi->getUserInfo().privlevel());
-        if (settingsCache->getIgnoreUnregisteredUsers() && !userLevel.testFlag(ServerInfo_User::IsRegistered))
+        if (SettingsCache::instance().getIgnoreUnregisteredUsers() &&
+            !userLevel.testFlag(ServerInfo_User::IsRegistered))
             return;
     }
 
-    if (event.message_type() == Event_RoomSay::ChatHistory && !settingsCache->getRoomHistory())
+    if (event.message_type() == Event_RoomSay::ChatHistory && !SettingsCache::instance().getRoomHistory())
         return;
 
     if (event.message_type() == Event_RoomSay::ChatHistory)
@@ -312,7 +314,7 @@ void TabRoom::processRoomSayEvent(const Event_RoomSay &event)
 
 void TabRoom::refreshShortcuts()
 {
-    aClearChat->setShortcuts(settingsCache->shortcuts().getShortcut("tab_room/aClearChat"));
+    aClearChat->setShortcuts(SettingsCache::instance().shortcuts().getShortcut("tab_room/aClearChat"));
 }
 
 void TabRoom::addMentionTag(QString mentionTag)

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -515,7 +515,7 @@ void TabSupervisor::tabUserEvent(bool globalEvent)
         tab->setContentsChanged(true);
         setTabIcon(indexOf(tab), QPixmap("theme:icons/tab_changed"));
     }
-    if (globalEvent && settingsCache->getNotificationsEnabled())
+    if (globalEvent && SettingsCache::instance().getNotificationsEnabled())
         QApplication::alert(this);
 }
 
@@ -552,7 +552,7 @@ void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)
         UserListTWI *twi = tabUserLists->getAllUsersList()->getUsers().value(senderName);
         if (twi) {
             UserLevelFlags userLevel = UserLevelFlags(twi->getUserInfo().user_level());
-            if (settingsCache->getIgnoreUnregisteredUserMessages() &&
+            if (SettingsCache::instance().getIgnoreUnregisteredUserMessages() &&
                 !userLevel.testFlag(ServerInfo_User::IsRegistered))
                 // Flags are additive, so reg/mod/admin are all IsRegistered
                 return;
@@ -596,7 +596,7 @@ void TabSupervisor::processUserJoined(const ServerInfo_User &userInfoJoined)
             setTabIcon(indexOf(tab), QPixmap(avatarPixmap));
         }
 
-        if (settingsCache->getBuddyConnectNotificationsEnabled()) {
+        if (SettingsCache::instance().getBuddyConnectNotificationsEnabled()) {
             QApplication::alert(this);
             this->actShowPopup(tr("Your buddy %1 has signed on!").arg(userName));
         }

--- a/cockatrice/src/tablezone.cpp
+++ b/cockatrice/src/tablezone.cpp
@@ -25,7 +25,7 @@ TableZone::TableZone(Player *_p, QGraphicsItem *parent)
     : SelectZone(_p, "table", true, false, true, parent), active(false)
 {
     connect(themeManager, SIGNAL(themeChanged()), this, SLOT(updateBg()));
-    connect(settingsCache, SIGNAL(invertVerticalCoordinateChanged()), this, SLOT(reorganizeCards()));
+    connect(&SettingsCache::instance(), SIGNAL(invertVerticalCoordinateChanged()), this, SLOT(reorganizeCards()));
 
     updateBg();
 
@@ -49,8 +49,8 @@ QRectF TableZone::boundingRect() const
 
 bool TableZone::isInverted() const
 {
-    return ((player->getMirrored() && !settingsCache->getInvertVerticalCoordinate()) ||
-            (!player->getMirrored() && settingsCache->getInvertVerticalCoordinate()));
+    return ((player->getMirrored() && !SettingsCache::instance().getInvertVerticalCoordinate()) ||
+            (!player->getMirrored() && SettingsCache::instance().getInvertVerticalCoordinate()));
 }
 
 void TableZone::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)

--- a/cockatrice/src/tearoffmenu.h
+++ b/cockatrice/src/tearoffmenu.h
@@ -9,16 +9,16 @@ class TearOffMenu : public QMenu
 public:
     TearOffMenu(const QString &title, QWidget *parent = nullptr) : QMenu(title, parent)
     {
-        connect(settingsCache, &SettingsCache::useTearOffMenusChanged, this,
+        connect(&SettingsCache::instance(), &SettingsCache::useTearOffMenusChanged, this,
                 [=](bool state) { setTearOffEnabled(state); });
-        setTearOffEnabled(settingsCache->getUseTearOffMenus());
+        setTearOffEnabled(SettingsCache::instance().getUseTearOffMenus());
     }
 
     TearOffMenu(QWidget *parent = nullptr) : QMenu(parent)
     {
-        connect(settingsCache, &SettingsCache::useTearOffMenusChanged, this,
+        connect(&SettingsCache::instance(), &SettingsCache::useTearOffMenusChanged, this,
                 [=](bool state) { setTearOffEnabled(state); });
-        setTearOffEnabled(settingsCache->getUseTearOffMenus());
+        setTearOffEnabled(SettingsCache::instance().getUseTearOffMenus());
     }
 
     TearOffMenu *addTearOffMenu(const QString &title)

--- a/cockatrice/src/thememanager.cpp
+++ b/cockatrice/src/thememanager.cpp
@@ -19,15 +19,16 @@
 ThemeManager::ThemeManager(QObject *parent) : QObject(parent)
 {
     ensureThemeDirectoryExists();
-    connect(settingsCache, SIGNAL(themeChanged()), this, SLOT(themeChangedSlot()));
+    connect(&SettingsCache::instance(), SIGNAL(themeChanged()), this, SLOT(themeChangedSlot()));
     themeChangedSlot();
 }
 
 void ThemeManager::ensureThemeDirectoryExists()
 {
-    if (settingsCache->getThemeName().isEmpty() || !getAvailableThemes().contains(settingsCache->getThemeName())) {
+    if (SettingsCache::instance().getThemeName().isEmpty() ||
+        !getAvailableThemes().contains(SettingsCache::instance().getThemeName())) {
         qDebug() << "Theme name not set, setting default value";
-        settingsCache->setThemeName(DEFAULT_THEME_NAME);
+        SettingsCache::instance().setThemeName(DEFAULT_THEME_NAME);
     }
 }
 
@@ -37,7 +38,7 @@ QStringMap &ThemeManager::getAvailableThemes()
     availableThemes.clear();
 
     // load themes from user profile dir
-    dir.setPath(settingsCache->getDataPath() + "/themes");
+    dir.setPath(SettingsCache::instance().getDataPath() + "/themes");
 
     foreach (QString themeName, dir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot, QDir::Name)) {
         if (!availableThemes.contains(themeName))
@@ -79,7 +80,7 @@ QBrush ThemeManager::loadBrush(QString fileName, QColor fallbackColor)
 
 void ThemeManager::themeChangedSlot()
 {
-    QString themeName = settingsCache->getThemeName();
+    QString themeName = SettingsCache::instance().getThemeName();
     qDebug() << "Theme changed:" << themeName;
 
     QDir dir = getAvailableThemes().value(themeName);

--- a/cockatrice/src/userconnection_information.cpp
+++ b/cockatrice/src/userconnection_information.cpp
@@ -23,23 +23,18 @@ QMap<QString, std::pair<QString, UserConnection_Information>> UserConnection_Inf
 {
     QMap<QString, std::pair<QString, UserConnection_Information>> serverList;
 
-    int size = settingsCache->servers().getValue("totalServers", "server", "server_details").toInt() + 1;
+    ServersSettings &servers = SettingsCache::instance().servers();
+
+    int size = servers.getValue("totalServers", "server", "server_details").toInt() + 1;
 
     for (int i = 0; i < size; i++) {
-        QString saveName =
-            settingsCache->servers().getValue(QString("saveName%1").arg(i), "server", "server_details").toString();
-        QString serverName =
-            settingsCache->servers().getValue(QString("server%1").arg(i), "server", "server_details").toString();
-        QString portNum =
-            settingsCache->servers().getValue(QString("port%1").arg(i), "server", "server_details").toString();
-        QString userName =
-            settingsCache->servers().getValue(QString("username%1").arg(i), "server", "server_details").toString();
-        QString pass =
-            settingsCache->servers().getValue(QString("password%1").arg(i), "server", "server_details").toString();
-        bool savePass =
-            settingsCache->servers().getValue(QString("savePassword%1").arg(i), "server", "server_details").toBool();
-        QString site =
-            settingsCache->servers().getValue(QString("site%1").arg(i), "server", "server_details").toString();
+        QString saveName = servers.getValue(QString("saveName%1").arg(i), "server", "server_details").toString();
+        QString serverName = servers.getValue(QString("server%1").arg(i), "server", "server_details").toString();
+        QString portNum = servers.getValue(QString("port%1").arg(i), "server", "server_details").toString();
+        QString userName = servers.getValue(QString("username%1").arg(i), "server", "server_details").toString();
+        QString pass = servers.getValue(QString("password%1").arg(i), "server", "server_details").toString();
+        bool savePass = servers.getValue(QString("savePassword%1").arg(i), "server", "server_details").toBool();
+        QString site = servers.getValue(QString("site%1").arg(i), "server", "server_details").toString();
 
         UserConnection_Information userInfo(saveName, serverName, portNum, userName, pass, savePass, site);
         serverList.insert(saveName, std::make_pair(serverName, userInfo));
@@ -52,26 +47,21 @@ QStringList UserConnection_Information::getServerInfo(const QString &find)
 {
     QStringList server;
 
-    int size = settingsCache->servers().getValue("totalServers", "server", "server_details").toInt() + 1;
+    ServersSettings &servers = SettingsCache::instance().servers();
+
+    int size = servers.getValue("totalServers", "server", "server_details").toInt() + 1;
     for (int i = 0; i < size; i++) {
-        QString saveName =
-            settingsCache->servers().getValue(QString("saveName%1").arg(i), "server", "server_details").toString();
+        QString saveName = servers.getValue(QString("saveName%1").arg(i), "server", "server_details").toString();
 
         if (find != saveName)
             continue;
 
-        QString serverName =
-            settingsCache->servers().getValue(QString("server%1").arg(i), "server", "server_details").toString();
-        QString portNum =
-            settingsCache->servers().getValue(QString("port%1").arg(i), "server", "server_details").toString();
-        QString userName =
-            settingsCache->servers().getValue(QString("username%1").arg(i), "server", "server_details").toString();
-        QString pass =
-            settingsCache->servers().getValue(QString("password%1").arg(i), "server", "server_details").toString();
-        bool savePass =
-            settingsCache->servers().getValue(QString("savePassword%1").arg(i), "server", "server_details").toBool();
-        QString site =
-            settingsCache->servers().getValue(QString("site%1").arg(i), "server", "server_details").toString();
+        QString serverName = servers.getValue(QString("server%1").arg(i), "server", "server_details").toString();
+        QString portNum = servers.getValue(QString("port%1").arg(i), "server", "server_details").toString();
+        QString userName = servers.getValue(QString("username%1").arg(i), "server", "server_details").toString();
+        QString pass = servers.getValue(QString("password%1").arg(i), "server", "server_details").toString();
+        bool savePass = servers.getValue(QString("savePassword%1").arg(i), "server", "server_details").toBool();
+        QString site = servers.getValue(QString("site%1").arg(i), "server", "server_details").toString();
 
         server.append(saveName);
         server.append(serverName);

--- a/cockatrice/src/zoneviewwidget.cpp
+++ b/cockatrice/src/zoneviewwidget.cpp
@@ -100,10 +100,10 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
         connect(&sortByNameCheckBox, SIGNAL(stateChanged(int)), this, SLOT(processSortByName(int)));
         connect(&sortByTypeCheckBox, SIGNAL(stateChanged(int)), this, SLOT(processSortByType(int)));
         connect(&pileViewCheckBox, SIGNAL(stateChanged(int)), this, SLOT(processSetPileView(int)));
-        sortByNameCheckBox.setChecked(settingsCache->getZoneViewSortByName());
-        sortByTypeCheckBox.setChecked(settingsCache->getZoneViewSortByType());
-        pileViewCheckBox.setChecked(settingsCache->getZoneViewPileView());
-        if (!settingsCache->getZoneViewSortByType())
+        sortByNameCheckBox.setChecked(SettingsCache::instance().getZoneViewSortByName());
+        sortByTypeCheckBox.setChecked(SettingsCache::instance().getZoneViewSortByType());
+        pileViewCheckBox.setChecked(SettingsCache::instance().getZoneViewPileView());
+        if (!SettingsCache::instance().getZoneViewSortByType())
             pileViewCheckBox.setEnabled(false);
     }
 
@@ -118,20 +118,20 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
 void ZoneViewWidget::processSortByType(int value)
 {
     pileViewCheckBox.setEnabled(value);
-    settingsCache->setZoneViewSortByType(value);
+    SettingsCache::instance().setZoneViewSortByType(value);
     zone->setPileView(pileViewCheckBox.isChecked());
     zone->setSortByType(value);
 }
 
 void ZoneViewWidget::processSortByName(int value)
 {
-    settingsCache->setZoneViewSortByName(value);
+    SettingsCache::instance().setZoneViewSortByName(value);
     zone->setSortByName(value);
 }
 
 void ZoneViewWidget::processSetPileView(int value)
 {
-    settingsCache->setZoneViewPileView(value);
+    SettingsCache::instance().setZoneViewPileView(value);
     zone->setPileView(value);
 }
 

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -51,3 +51,8 @@ void PictureLoader::clearPixmapCache(CardInfoPtr /* card */)
 }
 
 SettingsCache *settingsCache;
+
+SettingsCache& SettingsCache::instance()
+{
+    return *settingsCache;
+}

--- a/dbconverter/src/mocks.h
+++ b/dbconverter/src/mocks.h
@@ -37,6 +37,8 @@ public:
     QString getTokenDatabasePath() const;
     QString getSpoilerCardDatabasePath() const;
     CardDatabaseSettings &cardDatabase() const;
+
+    static SettingsCache& instance();
 signals:
     void cardDatabasePathChanged();
 };

--- a/oracle/src/main.cpp
+++ b/oracle/src/main.cpp
@@ -12,7 +12,6 @@
 #include <QTranslator>
 
 QTranslator *translator, *qtTranslator;
-SettingsCache *settingsCache;
 ThemeManager *themeManager;
 
 const QString translationPrefix = "oracle";
@@ -21,7 +20,7 @@ bool isSpoilersOnly;
 
 void installNewTranslator()
 {
-    QString lang = settingsCache->getLang();
+    QString lang = SettingsCache::instance().getLang();
 
     qtTranslator->load("qt_" + lang, QLibraryInfo::location(QLibraryInfo::TranslationsPath));
     qApp->installTranslator(qtTranslator);
@@ -53,7 +52,6 @@ int main(int argc, char *argv[])
     translationPath = qApp->applicationDirPath() + "/../share/oracle/translations";
 #endif
 
-    settingsCache = new SettingsCache;
     themeManager = new ThemeManager;
 
     qtTranslator = new QTranslator;

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -54,10 +54,10 @@
 
 OracleWizard::OracleWizard(QWidget *parent) : QWizard(parent)
 {
-    settings = new QSettings(settingsCache->getSettingsPath() + "global.ini", QSettings::IniFormat, this);
-    connect(settingsCache, SIGNAL(langChanged()), this, SLOT(updateLanguage()));
+    settings = new QSettings(SettingsCache::instance().getSettingsPath() + "global.ini", QSettings::IniFormat, this);
+    connect(&SettingsCache::instance(), SIGNAL(langChanged()), this, SLOT(updateLanguage()));
 
-    importer = new OracleImporter(settingsCache->getDataPath(), this);
+    importer = new OracleImporter(SettingsCache::instance().getDataPath(), this);
 
     nam = new QNetworkAccessManager(this);
 
@@ -140,7 +140,7 @@ IntroPage::IntroPage(QWidget *parent) : OracleWizardPage(parent)
     languageLabel = new QLabel(this);
     versionLabel = new QLabel(this);
     languageBox = new QComboBox(this);
-    QString setLanguage = settingsCache->getLang();
+    QString setLanguage = SettingsCache::instance().getLang();
 
     QStringList qmFiles = findQmFiles();
     for (int i = 0; i < qmFiles.size(); i++) {
@@ -185,7 +185,7 @@ QString IntroPage::languageName(const QString &qmFile)
 
 void IntroPage::languageBoxChanged(int index)
 {
-    settingsCache->setLang(languageBox->itemData(index).toString());
+    SettingsCache::instance().setLang(languageBox->itemData(index).toString());
 }
 
 void IntroPage::retranslateUi()
@@ -587,7 +587,7 @@ void SaveSetsPage::retranslateUi()
 
     saveLabel->setText(tr("Press \"Save\" to store the imported cards in the Cockatrice database."));
     pathLabel->setText(tr("The card database will be saved at the following location:") + "<br>" +
-                       settingsCache->getCardDatabasePath());
+                       SettingsCache::instance().getCardDatabasePath());
     defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 
     setButtonText(QWizard::NextButton, tr("&Save"));
@@ -608,7 +608,7 @@ void SaveSetsPage::updateTotalProgress(int cardsImported, int /* setIndex */, co
 bool SaveSetsPage::validatePage()
 {
     bool ok = false;
-    QString defaultPath = settingsCache->getCardDatabasePath();
+    QString defaultPath = SettingsCache::instance().getCardDatabasePath();
     QString windowName = tr("Save card database");
     QString fileType = tr("XML; card database (*.xml)");
 
@@ -652,7 +652,7 @@ QString LoadTokensPage::getCustomUrlSettingsKey()
 
 QString LoadTokensPage::getDefaultSavePath()
 {
-    return settingsCache->getTokenDatabasePath();
+    return SettingsCache::instance().getTokenDatabasePath();
 }
 
 QString LoadTokensPage::getWindowTitle()
@@ -673,7 +673,7 @@ void LoadTokensPage::retranslateUi()
     urlLabel->setText(tr("Download URL:"));
     urlButton->setText(tr("Restore default URL"));
     pathLabel->setText(tr("The token database will be saved at the following location:") + "<br>" +
-                       settingsCache->getTokenDatabasePath());
+                       SettingsCache::instance().getTokenDatabasePath());
     defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 }
 
@@ -689,7 +689,7 @@ QString LoadSpoilersPage::getCustomUrlSettingsKey()
 
 QString LoadSpoilersPage::getDefaultSavePath()
 {
-    return settingsCache->getTokenDatabasePath();
+    return SettingsCache::instance().getTokenDatabasePath();
 }
 
 QString LoadSpoilersPage::getWindowTitle()
@@ -710,6 +710,6 @@ void LoadSpoilersPage::retranslateUi()
     urlLabel->setText(tr("Download URL:"));
     urlButton->setText(tr("Restore default URL"));
     pathLabel->setText(tr("The spoiler database will be saved at the following location:") + "<br>" +
-                       settingsCache->getSpoilerCardDatabasePath());
+                       SettingsCache::instance().getSpoilerCardDatabasePath());
     defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -52,3 +52,8 @@ void PictureLoader::clearPixmapCache(CardInfoPtr /* card */)
 }
 
 SettingsCache *settingsCache;
+
+SettingsCache& SettingsCache::instance()
+{
+    return *settingsCache;
+}

--- a/tests/carddatabase/mocks.h
+++ b/tests/carddatabase/mocks.h
@@ -6,10 +6,10 @@
 #include <QObject>
 #include <QString>
 
-#include "../../cockatrice/src/carddatabase.h"
-
 #define SETTINGSCACHE_H
+#define PICTURELOADER_H
 
+#include "../../cockatrice/src/carddatabase.h"
 
 class CardDatabaseSettings
 {
@@ -37,15 +37,16 @@ public:
     QString getTokenDatabasePath() const;
     QString getSpoilerCardDatabasePath() const;
     CardDatabaseSettings &cardDatabase() const;
+
+    static SettingsCache& instance();
 signals:
     void cardDatabasePathChanged();
 };
 
 extern SettingsCache *settingsCache;
 
-#define PICTURELOADER_H
-
 class PictureLoader
 {
-    void clearPixmapCache(CardInfoPtr card);
+public:
+    static void clearPixmapCache(CardInfoPtr card);
 };


### PR DESCRIPTION
Allows to link mocked accessor instead of real one.

## Related Ticket(s)
- Part of solution for #4000

## Short roundup of the initial problem

Trying to refactor access to singleton to be lesser depend on non-inlining mocked functions. It's still doesn't fix issue as carddatabase expects object of real SettingsCache memory layout.

## What will change with this Pull Request?
- Uses Q_GLOBAL_STATIC to declare singleton.
- Uses accessor function to get instance instead of pointer.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
