### PR TITLE
fix #4070

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -1107,8 +1107,9 @@ void MainWindow::actCheckCardUpdates()
     binaryName = getCardUpdaterBinaryName();
 #endif
 
-    if (dir.exists(binaryName))
+    if (dir.exists(binaryName)) {
         updaterCmd = dir.absoluteFilePath(binaryName);
+    }
 
     if (updaterCmd.isEmpty()) {
         QMessageBox::warning(this, tr("Error"),
@@ -1116,7 +1117,7 @@ void MainWindow::actCheckCardUpdates()
         return;
     }
 
-    cardUpdateProcess->start("\"" + updaterCmd + "\"", QStringList());
+    cardUpdateProcess->start(updaterCmd, QStringList());
 }
 
 void MainWindow::cardUpdateError(QProcess::ProcessError err)


### PR DESCRIPTION
fixes #4070 
removes the slashes that were part of the old command function, the new one separates the args differently anyway.