### PR TITLE
Remove release build for former Ubuntu 18.04 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,18 +30,6 @@ jobs:
     before_install: source .ci/travis-docker.sh --build
     script: RUN --server --debug --test
 
-  - name: Ubuntu Bionic (Release)
-    if: (branch = master AND NOT type = pull_request) OR tag IS present
-    os: linux
-    services: docker
-    language: minimal
-    env: NAME=UbuntuBionic CACHE=$HOME/$NAME
-    cache:
-      directories:
-      - $CACHE
-    before_install: source .ci/travis-docker.sh --build
-    script: RUN --server --package $NAME --release
-
   #Ubuntu Focal (on Docker)
   - name: Ubuntu Focal (Compile)
     if: tag IS NOT present

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,22 @@ jobs:
     script: bash ./.ci/travis-lint.sh
 
 
+  #Due to an bug in Qt debug builds do not succeed on 20.04 yet, see https://github.com/Cockatrice/Cockatrice/issues/3993
+  #Ubuntu Bionic (on Docker)
+  - name: Ubuntu Bionic (Debug + Tests)
+    if: tag IS NOT present
+    os: linux
+    services: docker
+    language: minimal
+    env: NAME=UbuntuBionic CACHE=$HOME/$NAME
+    cache:
+      directories:
+      - $CACHE
+    before_install: source .ci/travis-docker.sh --build
+    script: RUN --server --debug --test
+
   #Ubuntu Focal (on Docker)
-  - name: Ubuntu Focal (Debug + Tests)
+  - name: Ubuntu Focal (Compile)
     if: tag IS NOT present
     os: linux
     services: docker
@@ -28,7 +42,7 @@ jobs:
       directories:
       - $CACHE
     before_install: source .ci/travis-docker.sh --build
-    script: RUN --server --debug --test
+    script: RUN --server
 
   - name: Ubuntu Focal (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,21 +17,8 @@ jobs:
     script: bash ./.ci/travis-lint.sh
 
 
-  #Ubuntu Bionic (on Docker)
-  - name: Ubuntu Bionic (Debug + Tests)
-    if: tag IS NOT present
-    os: linux
-    services: docker
-    language: minimal
-    env: NAME=UbuntuBionic CACHE=$HOME/$NAME
-    cache:
-      directories:
-      - $CACHE
-    before_install: source .ci/travis-docker.sh --build
-    script: RUN --server --debug --test
-
   #Ubuntu Focal (on Docker)
-  - name: Ubuntu Focal (Compile)
+  - name: Ubuntu Focal (Debug + Tests)
     if: tag IS NOT present
     os: linux
     services: docker
@@ -41,7 +28,7 @@ jobs:
       directories:
       - $CACHE
     before_install: source .ci/travis-docker.sh --build
-    script: RUN --server
+    script: RUN --server --debug --test
 
   - name: Ubuntu Focal (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present


### PR DESCRIPTION
## What will change with this Pull Request?
- Remove release build for 18.04 LTS, only keep 20.04 LTS
- Add hint and link why we have to keep 18.04 for debug builds for now (Qt bug)