### PR TITLE
Fix #3957: Properly set filters to defaults on initial load and disable "Clear filters" button if filters are set to defaults.

### DIFF
--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -75,7 +75,11 @@ GameSelector::GameSelector(AbstractClient *_client,
     connect(filterButton, SIGNAL(clicked()), this, SLOT(actSetFilter()));
     clearFilterButton = new QPushButton;
     clearFilterButton->setIcon(QPixmap("theme:icons/clearsearch"));
-    clearFilterButton->setEnabled(true);
+    if (showFilters && gameListProxyModel->areFilterParametersSetToDefaults()) {
+        clearFilterButton->setEnabled(false);
+    } else {
+        clearFilterButton->setEnabled(true);
+    }
     connect(clearFilterButton, SIGNAL(clicked()), this, SLOT(actClearFilter()));
 
     if (room) {
@@ -151,8 +155,6 @@ void GameSelector::actSetFilter()
     if (!dlg.exec())
         return;
 
-    clearFilterButton->setEnabled(true);
-
     gameListProxyModel->setShowBuddiesOnlyGames(dlg.getShowBuddiesOnlyGames());
     gameListProxyModel->setUnavailableGamesVisible(dlg.getUnavailableGamesVisible());
     gameListProxyModel->setShowPasswordProtectedGames(dlg.getShowPasswordProtectedGames());
@@ -162,6 +164,8 @@ void GameSelector::actSetFilter()
     gameListProxyModel->setGameTypeFilter(dlg.getGameTypeFilter());
     gameListProxyModel->setMaxPlayersFilter(dlg.getMaxPlayersFilterMin(), dlg.getMaxPlayersFilterMax());
     gameListProxyModel->saveFilterParameters(gameTypeMap);
+
+    clearFilterButton->setEnabled(!gameListProxyModel->areFilterParametersSetToDefaults());
 
     setFilteredGamesLabel();
 }

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -258,11 +258,9 @@ void GamesModel::updateGameList(const ServerInfo_Game &game)
 
 GamesProxyModel::GamesProxyModel(QObject *parent, const TabSupervisor *_tabSupervisor)
     : QSortFilterProxyModel(parent), ownUserIsRegistered(_tabSupervisor->isOwnUserRegistered()),
-      tabSupervisor(_tabSupervisor), showBuddiesOnlyGames(DEFAULT_SHOW_BUDDIES_ONLY_GAMES),
-      hideIgnoredUserGames(DEFAULT_HIDE_IGNORED_USER_GAMES), unavailableGamesVisible(DEFAULT_UNAVAILABLE_GAMES_VISIBLE),
-      showPasswordProtectedGames(DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES), maxPlayersFilterMin(MAX_PLAYERS_FILTER_OFF),
-      maxPlayersFilterMax(MAX_PLAYERS_FILTER_OFF)
+      tabSupervisor(_tabSupervisor)
 {
+    resetFilterParameters();
     setSortRole(GamesModel::SORT_ROLE);
     setDynamicSortFilter(true);
 }
@@ -352,9 +350,8 @@ bool GamesProxyModel::areFilterParametersSetToDefaults() const
            showPasswordProtectedGames == DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES &&
            showBuddiesOnlyGames == DEFAULT_SHOW_BUDDIES_ONLY_GAMES &&
            hideIgnoredUserGames == DEFAULT_HIDE_IGNORED_USER_GAMES && gameNameFilter.isEmpty() &&
-           creatorNameFilter.isEmpty() && gameTypeFilter.isEmpty() &&
-           (maxPlayersFilterMin == DEFAULT_MAX_PLAYERS_MIN || maxPlayersFilterMin == MAX_PLAYERS_FILTER_OFF) &&
-           (maxPlayersFilterMax == DEFAULT_MAX_PLAYERS_MAX || maxPlayersFilterMax == MAX_PLAYERS_FILTER_OFF);
+           creatorNameFilter.isEmpty() && gameTypeFilter.isEmpty() && maxPlayersFilterMin == DEFAULT_MAX_PLAYERS_MIN &&
+           maxPlayersFilterMax == DEFAULT_MAX_PLAYERS_MAX;
 }
 
 void GamesProxyModel::loadFilterParameters(const QMap<int, QString> &allGameTypes)
@@ -442,9 +439,9 @@ bool GamesProxyModel::filterAcceptsRow(int sourceRow) const
     if (!gameTypeFilter.isEmpty() && gameTypes.intersect(gameTypeFilter).isEmpty())
         return false;
 
-    if ((maxPlayersFilterMin != MAX_PLAYERS_FILTER_OFF) && ((int)game.max_players() < maxPlayersFilterMin))
+    if ((int)game.max_players() < maxPlayersFilterMin)
         return false;
-    if ((maxPlayersFilterMax != MAX_PLAYERS_FILTER_OFF) && ((int)game.max_players() > maxPlayersFilterMax))
+    if ((int)game.max_players() > maxPlayersFilterMax)
         return false;
 
     return true;

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -258,8 +258,10 @@ void GamesModel::updateGameList(const ServerInfo_Game &game)
 
 GamesProxyModel::GamesProxyModel(QObject *parent, const TabSupervisor *_tabSupervisor)
     : QSortFilterProxyModel(parent), ownUserIsRegistered(_tabSupervisor->isOwnUserRegistered()),
-      tabSupervisor(_tabSupervisor), showBuddiesOnlyGames(false), hideIgnoredUserGames(false),
-      unavailableGamesVisible(false), showPasswordProtectedGames(true), maxPlayersFilterMin(-1), maxPlayersFilterMax(-1)
+      tabSupervisor(_tabSupervisor), showBuddiesOnlyGames(DEFAULT_SHOW_BUDDIES_ONLY_GAMES),
+      hideIgnoredUserGames(DEFAULT_HIDE_IGNORED_USER_GAMES), unavailableGamesVisible(DEFAULT_UNAVAILABLE_GAMES_VISIBLE),
+      showPasswordProtectedGames(DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES), maxPlayersFilterMin(MAX_PLAYERS_FILTER_OFF),
+      maxPlayersFilterMax(MAX_PLAYERS_FILTER_OFF)
 {
     setSortRole(GamesModel::SORT_ROLE);
     setDynamicSortFilter(true);
@@ -331,16 +333,28 @@ int GamesProxyModel::getNumFilteredGames() const
 
 void GamesProxyModel::resetFilterParameters()
 {
-    unavailableGamesVisible = false;
-    showPasswordProtectedGames = true;
-    showBuddiesOnlyGames = true;
+    unavailableGamesVisible = DEFAULT_UNAVAILABLE_GAMES_VISIBLE;
+    showPasswordProtectedGames = DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES;
+    showBuddiesOnlyGames = DEFAULT_SHOW_BUDDIES_ONLY_GAMES;
+    hideIgnoredUserGames = DEFAULT_HIDE_IGNORED_USER_GAMES;
     gameNameFilter = QString();
     creatorNameFilter = QString();
     gameTypeFilter.clear();
-    maxPlayersFilterMin = 1;
+    maxPlayersFilterMin = DEFAULT_MAX_PLAYERS_MIN;
     maxPlayersFilterMax = DEFAULT_MAX_PLAYERS_MAX;
 
     invalidateFilter();
+}
+
+bool GamesProxyModel::areFilterParametersSetToDefaults() const
+{
+    return unavailableGamesVisible == DEFAULT_UNAVAILABLE_GAMES_VISIBLE &&
+           showPasswordProtectedGames == DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES &&
+           showBuddiesOnlyGames == DEFAULT_SHOW_BUDDIES_ONLY_GAMES &&
+           hideIgnoredUserGames == DEFAULT_HIDE_IGNORED_USER_GAMES && gameNameFilter.isEmpty() &&
+           creatorNameFilter.isEmpty() && gameTypeFilter.isEmpty() &&
+           (maxPlayersFilterMin == DEFAULT_MAX_PLAYERS_MIN || maxPlayersFilterMin == MAX_PLAYERS_FILTER_OFF) &&
+           (maxPlayersFilterMax == DEFAULT_MAX_PLAYERS_MAX || maxPlayersFilterMax == MAX_PLAYERS_FILTER_OFF);
 }
 
 void GamesProxyModel::loadFilterParameters(const QMap<int, QString> &allGameTypes)
@@ -428,9 +442,9 @@ bool GamesProxyModel::filterAcceptsRow(int sourceRow) const
     if (!gameTypeFilter.isEmpty() && gameTypes.intersect(gameTypeFilter).isEmpty())
         return false;
 
-    if ((maxPlayersFilterMin != -1) && ((int)game.max_players() < maxPlayersFilterMin))
+    if ((maxPlayersFilterMin != MAX_PLAYERS_FILTER_OFF) && ((int)game.max_players() < maxPlayersFilterMin))
         return false;
-    if ((maxPlayersFilterMax != -1) && ((int)game.max_players() > maxPlayersFilterMax))
+    if ((maxPlayersFilterMax != MAX_PLAYERS_FILTER_OFF) && ((int)game.max_players() > maxPlayersFilterMax))
         return false;
 
     return true;

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -76,6 +76,12 @@ private:
     QSet<int> gameTypeFilter;
     int maxPlayersFilterMin, maxPlayersFilterMax;
 
+    static const bool DEFAULT_UNAVAILABLE_GAMES_VISIBLE = false;
+    static const bool DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES = true;
+    static const bool DEFAULT_SHOW_BUDDIES_ONLY_GAMES = true;
+    static const bool DEFAULT_HIDE_IGNORED_USER_GAMES = false;
+    static const int MAX_PLAYERS_FILTER_OFF = -1;
+    static const int DEFAULT_MAX_PLAYERS_MIN = 1;
     static const int DEFAULT_MAX_PLAYERS_MAX = 99;
 
 public:
@@ -127,6 +133,7 @@ public:
     void setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlayersFilterMax);
     int getNumFilteredGames() const;
     void resetFilterParameters();
+    bool areFilterParametersSetToDefaults() const;
     void loadFilterParameters(const QMap<int, QString> &allGameTypes);
     void saveFilterParameters(const QMap<int, QString> &allGameTypes);
     void refresh();

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -80,7 +80,6 @@ private:
     static const bool DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES = true;
     static const bool DEFAULT_SHOW_BUDDIES_ONLY_GAMES = true;
     static const bool DEFAULT_HIDE_IGNORED_USER_GAMES = false;
-    static const int MAX_PLAYERS_FILTER_OFF = -1;
     static const int DEFAULT_MAX_PLAYERS_MIN = 1;
     static const int DEFAULT_MAX_PLAYERS_MAX = 99;
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3957 
- Partially addresses #3282 (in that "Show 'buddies only' games" should be true on initial load, but this does not address the fact that filters in general are not actually read from storage)
- Address most concerns (other than text placement) of #3068 

## Short roundup of the initial problem
During beta testing for #3946 , we realized "defaults" were not loading properly. Cold-opening Cockatrice showed 2 "altered" filters.

## What will change with this Pull Request?
- Default filter values are stored as GamesProxyModel private members, and referenced throughout class for consistency
- GamesProxyModel instantiates values to new defaults (matching old default values)
- gameselector.cpp checks a new fn on GamesProxyModel to see whether filters match default values; if so, disables the "Clear filters" button (rather than setting to enabled on load)

## Screenshots
Can see "Clear filters" disabled on initial load:

<img width="1006" alt="initial load" src="https://user-images.githubusercontent.com/63179146/92338398-21b0c580-f07e-11ea-8a1b-71d92ab20273.png">

Can see "show 'buddies only' games" is newly enabled by default:

<img width="990" alt="filtering" src="https://user-images.githubusercontent.com/63179146/92338409-355c2c00-f07e-11ea-86ed-33927157450a.png">

Can see that filtering by 'f' for creator name does filter properly, and the "Clear filters" button is now enabled:

<img width="1005" alt="filtered" src="https://user-images.githubusercontent.com/63179146/92338416-4442de80-f07e-11ea-9472-64b6bd02a07b.png">

If you were to manually go back to filters and remove the 'f' creator name filter, the "Clear filters" button would be disabled again.