### PR TITLE
Move "Games shown" text to top, to match user count list.

### DIFF
--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -36,7 +36,6 @@ GameSelector::GameSelector(AbstractClient *_client,
 {
     gameListView = new QTreeView;
     gameListModel = new GamesModel(_rooms, _gameTypes, this);
-    filteredGamesLabel = new QLabel;
     if (showFilters) {
         gameListProxyModel = new GamesProxyModel(this, tabSupervisor);
         gameListProxyModel->setSourceModel(gameListModel);
@@ -90,7 +89,6 @@ GameSelector::GameSelector(AbstractClient *_client,
     if (showFilters) {
         buttonLayout->addWidget(filterButton);
         buttonLayout->addWidget(clearFilterButton);
-        buttonLayout->addWidget(filteredGamesLabel);
     }
     buttonLayout->addStretch();
     if (room)
@@ -133,7 +131,7 @@ void GameSelector::processAddToListEvent(const Event_AddToList &event)
     if (event.list_name() == "ignore") {
         gameListProxyModel->refresh();
     }
-    setFilteredGamesLabel();
+    updateTitle();
 }
 
 void GameSelector::processRemoveFromListEvent(const Event_RemoveFromList &event)
@@ -141,7 +139,7 @@ void GameSelector::processRemoveFromListEvent(const Event_RemoveFromList &event)
     if (event.list_name() == "ignore") {
         gameListProxyModel->refresh();
     }
-    setFilteredGamesLabel();
+    updateTitle();
 }
 
 void GameSelector::actSetFilter()
@@ -163,7 +161,7 @@ void GameSelector::actSetFilter()
     gameListProxyModel->setMaxPlayersFilter(dlg.getMaxPlayersFilterMin(), dlg.getMaxPlayersFilterMax());
     gameListProxyModel->saveFilterParameters(gameTypeMap);
 
-    setFilteredGamesLabel();
+    updateTitle();
 }
 
 void GameSelector::actClearFilter()
@@ -173,7 +171,7 @@ void GameSelector::actClearFilter()
     gameListProxyModel->resetFilterParameters();
     gameListProxyModel->saveFilterParameters(gameTypeMap);
 
-    setFilteredGamesLabel();
+    updateTitle();
 }
 
 void GameSelector::actCreate()
@@ -185,7 +183,7 @@ void GameSelector::actCreate()
 
     DlgCreateGame dlg(room, room->getGameTypes(), this);
     dlg.exec();
-    setFilteredGamesLabel();
+    updateTitle();
 }
 
 void GameSelector::checkResponse(const Response &response)
@@ -267,7 +265,6 @@ void GameSelector::actJoin()
 
 void GameSelector::retranslateUi()
 {
-    setTitle(tr("Games"));
     filterButton->setText(tr("&Filter games"));
     clearFilterButton->setText(tr("C&lear filter"));
     if (createButton)
@@ -275,13 +272,13 @@ void GameSelector::retranslateUi()
     joinButton->setText(tr("&Join"));
     spectateButton->setText(tr("J&oin as spectator"));
 
-    setFilteredGamesLabel();
+    updateTitle();
 }
 
 void GameSelector::processGameInfo(const ServerInfo_Game &info)
 {
     gameListModel->updateGameList(info);
-    setFilteredGamesLabel();
+    updateTitle();
 }
 
 void GameSelector::actSelectedGameChanged(const QModelIndex &current, const QModelIndex & /* previous */)
@@ -296,11 +293,13 @@ void GameSelector::actSelectedGameChanged(const QModelIndex &current, const QMod
     joinButton->setEnabled(game.player_count() < game.max_players() || overrideRestrictions);
 }
 
-void GameSelector::setFilteredGamesLabel()
+void GameSelector::updateTitle()
 {
     if (showFilters) {
         const int totalGames = gameListModel->rowCount();
         const int shownGames = totalGames - gameListProxyModel->getNumFilteredGames();
-        filteredGamesLabel->setText(tr("Games shown: %1 / %2").arg(shownGames).arg(totalGames));
+        setTitle(tr("Games shown: %1 / %2").arg(shownGames).arg(totalGames));
+    } else {
+        setTitle(tr("Games"));
     }
 }

--- a/cockatrice/src/gameselector.h
+++ b/cockatrice/src/gameselector.h
@@ -45,11 +45,10 @@ private:
     GamesModel *gameListModel;
     GamesProxyModel *gameListProxyModel;
     QPushButton *filterButton, *clearFilterButton, *createButton, *joinButton, *spectateButton;
-    QLabel *filteredGamesLabel;
     const bool showFilters;
     GameTypeMap gameTypeMap;
 
-    void setFilteredGamesLabel();
+    void updateTitle();
 
 public:
     GameSelector(AbstractClient *_client,


### PR DESCRIPTION
Fixes last part of #3068 that isn't already handled by #4088.

## Related Ticket(s)
- Fixes parts of #3068 

## Short roundup of the initial problem
#3068 had a number of requests, including moving the "Games shown: X/Y" label to the title to match user count, rather than being next to the "Clear filters" button. This PR fixes that part of the request, and #4088 handles the rest of the requests in #3068 .

## What will change with this Pull Request?
- "Games shown: X/Y" is at the top of the game selector instead of next to the "Clear filters" button.

## Screenshots
<img width="1007" alt="Screen Shot 2020-09-06 at 8 40 54 PM" src="https://user-images.githubusercontent.com/63179146/92339022-02b43280-f082-11ea-80df-2331a05888ad.png">