### PR TITLE
Allow Logs/Admin to be closed/opened

### DIFF
--- a/cockatrice/src/tab_admin.cpp
+++ b/cockatrice/src/tab_admin.cpp
@@ -91,6 +91,11 @@ TabAdmin::TabAdmin(TabSupervisor *_tabSupervisor, AbstractClient *_client, bool 
     actUnlock();
 }
 
+void TabAdmin::closeRequest()
+{
+    deleteLater();
+}
+
 void TabAdmin::retranslateUi()
 {
     updateServerMessageButton->setText(tr("Update server &message"));

--- a/cockatrice/src/tab_admin.h
+++ b/cockatrice/src/tab_admin.h
@@ -44,11 +44,12 @@ private slots:
 
     void actUnlock();
     void actLock();
+    void closeRequest() override;
 
 public:
     TabAdmin(TabSupervisor *_tabSupervisor, AbstractClient *_client, bool _fullAdmin, QWidget *parent = nullptr);
-    void retranslateUi();
-    QString getTabText() const
+    void retranslateUi() override;
+    QString getTabText() const override
     {
         return tr("Administration");
     }

--- a/cockatrice/src/tab_logs.cpp
+++ b/cockatrice/src/tab_logs.cpp
@@ -57,6 +57,11 @@ TabLog::~TabLog()
 {
 }
 
+void TabLog::closeRequest()
+{
+    deleteLater();
+}
+
 void TabLog::retranslateUi()
 {
 }

--- a/cockatrice/src/tab_logs.h
+++ b/cockatrice/src/tab_logs.h
@@ -44,6 +44,7 @@ private:
     QTableWidget *roomTable, *gameTable, *chatTable;
 
     void createDock();
+    void closeRequest() override;
 signals:
 
 private slots:
@@ -55,8 +56,8 @@ private slots:
 public:
     TabLog(TabSupervisor *_tabSupervisor, AbstractClient *_client, QWidget *parent = nullptr);
     ~TabLog();
-    void retranslateUi();
-    QString getTabText() const
+    void retranslateUi() override;
+    QString getTabText() const override
     {
         return tr("Logs");
     }

--- a/cockatrice/src/tab_supervisor.h
+++ b/cockatrice/src/tab_supervisor.h
@@ -125,6 +125,8 @@ signals:
 
 public slots:
     TabDeckEditor *addDeckEditorTab(const DeckLoader *deckToOpen);
+    TabLog *addAdminLogTab();
+    TabAdmin *addAdminConsoleTab();
     void openReplay(GameReplay *replay);
     void maximizeMainWindow();
 private slots:

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -277,6 +277,16 @@ void MainWindow::actDeckEditor()
     tabSupervisor->addDeckEditorTab(nullptr);
 }
 
+void MainWindow::actAdminLogTab()
+{
+    tabSupervisor->addAdminLogTab();
+}
+
+void MainWindow::actAdminConsoleTab()
+{
+    tabSupervisor->addAdminConsoleTab();
+}
+
 void MainWindow::actFullScreen(bool checked)
 {
     if (checked)
@@ -631,6 +641,8 @@ void MainWindow::retranslateUi()
     aSettings->setText(tr("&Settings..."));
     aSettings->setIcon(QPixmap("theme:icons/settings"));
     aExit->setText(tr("&Exit"));
+    aAdminLogTab->setText(tr("Admin - Logs"));
+    aAdminConsoleTab->setText(tr("Admin - Console"));
 
 #if defined(__APPLE__) /* For OSX */
     cockatriceMenu->setTitle(tr("A&ctions"));
@@ -667,6 +679,10 @@ void MainWindow::createActions()
     connect(aWatchReplay, SIGNAL(triggered()), this, SLOT(actWatchReplay()));
     aDeckEditor = new QAction(this);
     connect(aDeckEditor, SIGNAL(triggered()), this, SLOT(actDeckEditor()));
+    aAdminLogTab = new QAction(this);
+    connect(aAdminLogTab, SIGNAL(triggered()), this, SLOT(actAdminLogTab()));
+    aAdminConsoleTab = new QAction(this);
+    connect(aAdminConsoleTab, SIGNAL(triggered()), this, SLOT(actAdminConsoleTab()));
     aFullScreen = new QAction(this);
     aFullScreen->setCheckable(true);
     connect(aFullScreen, SIGNAL(toggled(bool)), this, SLOT(actFullScreen(bool)));
@@ -766,6 +782,27 @@ void MainWindow::createMenus()
     helpMenu->addAction(aCheckCardUpdates);
     helpMenu->addSeparator();
     helpMenu->addAction(aViewLog);
+}
+
+void MainWindow::keyPressEvent(QKeyEvent *event)
+{
+    // Shift + Control in either order = Admin Ops
+    if ((event->key() == Qt::Key_Control && QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier)) ||
+        (event->key() == Qt::Key_Shift && QApplication::keyboardModifiers().testFlag(Qt::ControlModifier))) {
+        cockatriceMenu->addAction(aAdminLogTab);
+        cockatriceMenu->addAction(aAdminConsoleTab);
+    }
+}
+
+void MainWindow::keyReleaseEvent(QKeyEvent *)
+{
+    if (cockatriceMenu->actions().contains(aAdminLogTab)) {
+        cockatriceMenu->removeAction(aAdminLogTab);
+    }
+
+    if (cockatriceMenu->actions().contains(aAdminConsoleTab)) {
+        cockatriceMenu->removeAction(aAdminConsoleTab);
+    }
 }
 
 MainWindow::MainWindow(QWidget *parent)

--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -50,6 +50,8 @@ public slots:
     void actCheckCardUpdates();
     void actCheckServerUpdates();
 private slots:
+    void keyPressEvent(QKeyEvent *event) override;
+    void keyReleaseEvent(QKeyEvent *) override;
     void updateTabMenu(const QList<QMenu *> &newMenuList);
     void statusChanged(ClientStatus _status);
     void processConnectionClosedEvent(const Event_ConnectionClosed &event);
@@ -72,6 +74,8 @@ private slots:
     void actSinglePlayer();
     void actWatchReplay();
     void actDeckEditor();
+    void actAdminLogTab();
+    void actAdminConsoleTab();
     void actFullScreen(bool checked);
     void actRegister();
     void actSettings();
@@ -124,8 +128,9 @@ private:
 
     QList<QMenu *> tabMenus;
     QMenu *cockatriceMenu, *dbMenu, *helpMenu, *trayIconMenu;
-    QAction *aConnect, *aDisconnect, *aSinglePlayer, *aWatchReplay, *aDeckEditor, *aFullScreen, *aSettings, *aExit,
-        *aAbout, *aTips, *aCheckCardUpdates, *aRegister, *aUpdate, *aViewLog, *closeAction;
+    QAction *aConnect, *aDisconnect, *aSinglePlayer, *aWatchReplay, *aDeckEditor, *aAdminLogTab, *aAdminConsoleTab,
+        *aFullScreen, *aSettings, *aExit, *aAbout, *aTips, *aCheckCardUpdates, *aRegister, *aUpdate, *aViewLog,
+        *closeAction;
     QAction *aManageSets, *aEditTokens, *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet;
     TabSupervisor *tabSupervisor;
     WndSets *wndSets;


### PR DESCRIPTION
This PR allows moderators and administrators to close/reopen the Logs and Administration tabs. By default, the Logs tab will show for mods & admins, whereas the Administration tab will only show for admins.

A moderator or administrator can press SHIFT + CONTROL + Click on the Cockatrice/Actions menu to reveal a hidden menu to reopen these tabs. If a normal users were to attempt at accessing the service tools, they would be unable to view any content, as the data is returned as a server sided check on the user account.