### PR TITLE
refactor getting game age

### DIFF
--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -7,10 +7,10 @@
 #include "userlist.h"
 
 #include <QDateTime>
-#include <QTime>
 #include <QDebug>
 #include <QIcon>
 #include <QStringList>
+#include <QTime>
 
 enum GameListColumn
 {

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -54,7 +54,7 @@ const QString GamesModel::getGameCreatedString(const int secs)
     int amount;
     if (totalRounded.hour()) {
         amount = total.addSecs(halfHourSecs).hour(); // round up separately
-        form = tr("%1%2 h", "short age in hours", amount);
+        form = tr("%1%2 hr", "short age in hours", amount);
     } else if (total.minute() < 2) { // games are new during their first minute
         return tr("new");
     } else {

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -36,17 +36,16 @@ const QString GamesModel::getGameCreatedString(const int secs)
     }
 
     QTime total = zeroTime.addSecs(secs);
-    if (total.minute() < 2) { // games are new during their first minute
-        return tr("New");
-    }
-
     QString unit;
     int amount;
     if (total.hour()) {
         total = total.addSecs(halfHourSecs); // round up
         amount = total.hour();
         unit = tr("hr(s)", "short notation age in hours", amount);
+    } else if (total.minute() < 2) { // games are new during their first minute
+        return tr("New");
     } else {
+
         total = total.addSecs(halfMinSecs); // round up
         amount = total.minute();
         unit = tr("min(s)", "short notation age in minutes", amount);

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -45,7 +45,7 @@ const QString GamesModel::getGameCreatedString(const int secs)
     static const int wrapSeconds = zeroTime.secsTo(zeroTime.addSecs(-halfHourSecs)); // round up
 
     if (secs >= wrapSeconds) { // QTime wraps after a day
-        return tr(">day");
+        return tr(">1 day");
     }
 
     QTime total = zeroTime.addSecs(secs);

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -32,7 +32,7 @@ const QString GamesModel::getGameCreatedString(const int secs)
     static const int wrapSeconds = zeroTime.secsTo(zeroTime.addSecs(-halfHourSecs)); // round up
 
     if (secs >= wrapSeconds) { // QTime wraps after a day
-        return tr("days");
+        return tr(">day");
     }
 
     QTime total = zeroTime.addSecs(secs);

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -51,10 +51,10 @@ const QString GamesModel::getGameCreatedString(const int secs)
 
     for (int aggregate : {40, 20, 10, 5}) { // floor to values in this list
         if (amount >= aggregate) {
-            return form.arg(">", aggregate);
+            return form.arg(">").arg(aggregate);
         }
     }
-    return form.arg("", amount);
+    return form.arg("").arg(amount);
 }
 
 GamesModel::GamesModel(const QMap<int, QString> &_rooms, const QMap<int, GameTypeMap> &_gameTypes, QObject *parent)

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -19,9 +19,6 @@ private:
     QMap<int, GameTypeMap> gameTypes;
 
     static const int NUM_COLS = 8;
-    static const int SECS_PER_MIN = 60;
-    static const int SECS_PER_TEN_MIN = 600;
-    static const int SECS_PER_HOUR = 3600;
 
 public:
     static const int SORT_ROLE = Qt::UserRole + 1;

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -34,7 +34,7 @@ public:
     }
     QVariant data(const QModelIndex &index, int role) const;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
-    const QString getGameCreatedString(const int secs) const;
+    static const QString getGameCreatedString(const int secs);
     const ServerInfo_Game &getGame(int row);
 
     /**


### PR DESCRIPTION
## Related Ticket(s)
- #4092

## Short roundup of the initial problem
#4092 copied these static values for game ages which made me upset, they're added in 25dbfb3 based on 93ab9f9, which introduced these weird values while qt simply has these time classes available.

## What will change with this Pull Request?
- games older than 24 hours will now show their age as tr("days")
- games older than 5/10/20 hours will now show their age as >5/10/20 tr("h")
- games older than 1 hour will show as n tr("h")
- games older than 5/10/20 minutes will show as >5/10/20 tr("min")
- games older than 2 minutes will show as n tr("min")
- games younger than that will show as tr("new")
- h and min can be translated with access to pluralization

![image](https://user-images.githubusercontent.com/36401181/92821198-171e6500-f3cb-11ea-8a5c-d8d11c774cce.png)
