### PR TITLE
skip duplicate nonpromos

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -278,7 +278,10 @@ int OracleImporter::importCardsFromSet(CardSetPtr currentSet, const QList<QVaria
 
         if (skipSpecialCards) {
             // skip promo cards if it's not the only print
-            if (getStringPropertyFromMap(card, "isPromo") == "true" || card.contains("frameEffects")) {
+            if (allNameProps.contains(name)) {
+                continue;
+            }
+            if (getStringPropertyFromMap(card, "isPromo") == "true") {
                 specialPromoCards.insert(name, cardVar);
                 continue;
             }

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -278,7 +278,7 @@ int OracleImporter::importCardsFromSet(CardSetPtr currentSet, const QList<QVaria
 
         if (skipSpecialCards) {
             // skip promo cards if it's not the only print
-            if (getStringPropertyFromMap(card, "isPromo") == "true") {
+            if (getStringPropertyFromMap(card, "isPromo") == "true" || card.contains("frameEffects")) {
                 specialPromoCards.insert(name, cardVar);
                 continue;
             }


### PR DESCRIPTION
## Related Ticket(s)
- https://github.com/Cockatrice/Cockatrice/pull/3965

## Short roundup of the initial problem
lotus cobra is shown as an alternative printing with fancy frame in cockatrice as number 307 because it does not have the isAlternative property set

note that for testing this you'd need to clear the image cache and restart cockatrice after running oracle

## What will change with this Pull Request?
- all cards with the frameEffects property will be treated like promos and will be deferred to be added later together with the promos
- if a special set contains only promos and alt frame versions the "non promo" alt frame versions are no longer given priority over the promo versions and either of them might become the selected printing for that set (in practice highest collector number takes precedence afaik)

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
