### PR TITLE
fix QByteArray::append(QString) deprecation in qt 5.15.1

### DIFF
--- a/cockatrice/src/deckstats_interface.cpp
+++ b/cockatrice/src/deckstats_interface.cpp
@@ -52,8 +52,7 @@ void DeckStatsInterface::getAnalyzeRequestData(DeckList *deck, QByteArray *data)
     urlQuery.addQueryItem("deck", deckWithoutTokens.writeToString_Plain());
     urlQuery.addQueryItem("decktitle", deck->getName());
     params.setQuery(urlQuery);
-    QString queryString = params.query(QUrl::EncodeReserved);
-    data->append(queryString.toUtf8());
+    data->append(params.query(QUrl::EncodeReserved).toUtf8());
 }
 
 void DeckStatsInterface::analyzeDeck(DeckList *deck)

--- a/cockatrice/src/deckstats_interface.cpp
+++ b/cockatrice/src/deckstats_interface.cpp
@@ -52,7 +52,8 @@ void DeckStatsInterface::getAnalyzeRequestData(DeckList *deck, QByteArray *data)
     urlQuery.addQueryItem("deck", deckWithoutTokens.writeToString_Plain());
     urlQuery.addQueryItem("decktitle", deck->getName());
     params.setQuery(urlQuery);
-    data->append(params.query(QUrl::EncodeReserved));
+    QString queryString = params.query(QUrl::EncodeReserved);
+    data->append(queryString.toUtf8());
 }
 
 void DeckStatsInterface::analyzeDeck(DeckList *deck)

--- a/cockatrice/src/tappedout_interface.cpp
+++ b/cockatrice/src/tappedout_interface.cpp
@@ -78,7 +78,8 @@ void TappedOutInterface::getAnalyzeRequestData(DeckList *deck, QByteArray *data)
     urlQuery.addQueryItem("mainboard", mainboard.writeToString_Plain(false, true));
     urlQuery.addQueryItem("sideboard", sideboard.writeToString_Plain(false, true));
     params.setQuery(urlQuery);
-    data->append(params.query(QUrl::EncodeReserved));
+    QString queryString = params.query(QUrl::EncodeReserved);
+    data->append(queryString.toUtf8());
 }
 
 void TappedOutInterface::analyzeDeck(DeckList *deck)

--- a/cockatrice/src/tappedout_interface.cpp
+++ b/cockatrice/src/tappedout_interface.cpp
@@ -78,8 +78,7 @@ void TappedOutInterface::getAnalyzeRequestData(DeckList *deck, QByteArray *data)
     urlQuery.addQueryItem("mainboard", mainboard.writeToString_Plain(false, true));
     urlQuery.addQueryItem("sideboard", sideboard.writeToString_Plain(false, true));
     params.setQuery(urlQuery);
-    QString queryString = params.query(QUrl::EncodeReserved);
-    data->append(queryString.toUtf8());
+    data->append(params.query(QUrl::EncodeReserved).toUtf8());
 }
 
 void TappedOutInterface::analyzeDeck(DeckList *deck)

--- a/servatrice/src/smtp/qxtmailattachment.cpp
+++ b/servatrice/src/smtp/qxtmailattachment.cpp
@@ -143,9 +143,9 @@ QHash<QString, QString> QxtMailAttachment::extraHeaders() const
     return qxt_d->extraHeaders;
 }
 
-QString QxtMailAttachment::extraHeader(const QString& key) const
+QByteArray QxtMailAttachment::extraHeader(const QString& key) const
 {
-    return qxt_d->extraHeaders[key.toLower()];
+    return qxt_d->extraHeaders[key.toLower()].toLatin1();
 }
 
 bool QxtMailAttachment::hasExtraHeader(const QString& key) const

--- a/servatrice/src/smtp/qxtmailattachment.h
+++ b/servatrice/src/smtp/qxtmailattachment.h
@@ -57,7 +57,7 @@ public:
     void setContentType(const QString& contentType);
 
     QHash<QString, QString> extraHeaders() const;
-    QString extraHeader(const QString&) const;
+    QByteArray extraHeader(const QString&) const;
     bool hasExtraHeader(const QString&) const;
     void setExtraHeader(const QString& key, const QString& value);
     void setExtraHeaders(const QHash<QString, QString>&);

--- a/servatrice/src/smtp/qxtmailmessage.cpp
+++ b/servatrice/src/smtp/qxtmailmessage.cpp
@@ -143,9 +143,9 @@ QHash<QString, QString> QxtMailMessage::extraHeaders() const
     return qxt_d->extraHeaders;
 }
 
-QString QxtMailMessage::extraHeader(const QString& key) const
+QByteArray QxtMailMessage::extraHeader(const QString& key) const
 {
-    return qxt_d->extraHeaders[key.toLower()];
+    return qxt_d->extraHeaders[key.toLower()].toLatin1();
 }
 
 bool QxtMailMessage::hasExtraHeader(const QString& key) const

--- a/servatrice/src/smtp/qxtmailmessage.h
+++ b/servatrice/src/smtp/qxtmailmessage.h
@@ -64,7 +64,7 @@ public:
     void removeRecipient(const QString&);
 
     QHash<QString, QString> extraHeaders() const;
-    QString extraHeader(const QString&) const;
+    QByteArray extraHeader(const QString&) const;
     bool hasExtraHeader(const QString&) const;
     void setExtraHeader(const QString& key, const QString& value);
     void setExtraHeaders(const QHash<QString, QString>&);


### PR DESCRIPTION
explicitly adds conversion to qbytearray before appending of strings with toUtf8()