### PR TITLE
Fix show-buddies-only filter loading, and add handling for creator na…

### DIFF
--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -360,7 +360,9 @@ void GamesProxyModel::loadFilterParameters(const QMap<int, QString> &allGameType
     unavailableGamesVisible = gameFilters.isUnavailableGamesVisible();
     showPasswordProtectedGames = gameFilters.isShowPasswordProtectedGames();
     hideIgnoredUserGames = gameFilters.isHideIgnoredUserGames();
+    showBuddiesOnlyGames = gameFilters.isShowBuddiesOnlyGames();
     gameNameFilter = gameFilters.getGameNameFilter();
+    creatorNameFilter = gameFilters.getCreatorNameFilter();
     maxPlayersFilterMin = gameFilters.getMinPlayers();
     maxPlayersFilterMax = gameFilters.getMaxPlayers();
 
@@ -383,6 +385,7 @@ void GamesProxyModel::saveFilterParameters(const QMap<int, QString> &allGameType
     gameFilters.setShowPasswordProtectedGames(showPasswordProtectedGames);
     gameFilters.setHideIgnoredUserGames(hideIgnoredUserGames);
     gameFilters.setGameNameFilter(gameNameFilter);
+    gameFilters.setCreatorNameFilter(creatorNameFilter);
 
     QMapIterator<int, QString> gameTypeIterator(allGameTypes);
     while (gameTypeIterator.hasNext()) {

--- a/cockatrice/src/settings/gamefilterssettings.cpp
+++ b/cockatrice/src/settings/gamefilterssettings.cpp
@@ -70,6 +70,16 @@ QString GameFiltersSettings::getGameNameFilter()
     return getValue("game_name_filter", "filter_games").toString();
 }
 
+void GameFiltersSettings::setCreatorNameFilter(QString creatorName)
+{
+    setValue(creatorName, "creator_name_filter", "filter_games");
+}
+
+QString GameFiltersSettings::getCreatorNameFilter()
+{
+    return getValue("creator_name_filter", "filter_games").toString();
+}
+
 void GameFiltersSettings::setMinPlayers(int min)
 {
     setValue(min, "min_players", "filter_games");

--- a/cockatrice/src/settings/gamefilterssettings.h
+++ b/cockatrice/src/settings/gamefilterssettings.h
@@ -14,6 +14,7 @@ public:
     bool isShowPasswordProtectedGames();
     bool isHideIgnoredUserGames();
     QString getGameNameFilter();
+    QString getCreatorNameFilter();
     int getMinPlayers();
     int getMaxPlayers();
     bool isGameTypeEnabled(QString gametype);
@@ -23,6 +24,7 @@ public:
     void setUnavailableGamesVisible(bool enabled);
     void setShowPasswordProtectedGames(bool show);
     void setGameNameFilter(QString gameName);
+    void setCreatorNameFilter(QString creatorName);
     void setMinPlayers(int min);
     void setMaxPlayers(int max);
     void setGameTypeEnabled(QString gametype, bool enabled);


### PR DESCRIPTION
…me filter storage/loading.

## Related Ticket(s)
- Fixes #3282

## Short roundup of the initial problem
"Show buddies only" filter setting was not remembered properly. #4088 fixed it to load the proper default of true, but this PR actually reads the stored value.

## What will change with this Pull Request?
- Read the stored value for "show buddies only" filter
- Store and read value for "creator name" filter