### PR TITLE
skip misprints marked with †

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -225,7 +225,7 @@ int OracleImporter::importCardsFromSet(CardSetPtr currentSet, const QList<QVaria
     QVariantHash properties;
     CardInfoPerSet setInfo;
     QList<CardRelation *> relatedCards;
-    static const QList<QString> specialNumChars = {"★", "s"};
+    static const QList<QString> specialNumChars = {"★", "s", "†"};
     QMap<QString, QVariant> specialPromoCards;
     QList<QString> allNameProps;
 


### PR DESCRIPTION
## Short roundup of the initial problem
misprints have a  † in the collector's number and would take precedence to normal printings before 14fcb2e5d7afaff44ab76624742bb81fcb63263b
for example https://scryfall.com/card/ogw/162†

## What will change with this Pull Request?
- add † to skipped chars in numbers
- this makes sure if one of these misprints is found before a normal printing it is skipped