### PR TITLE
Adding GlobalDecks Feature

### DIFF
--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -85,6 +85,9 @@ officialwarnings="Flamming,Spamming,Causing Drama,Abusive Language"
 ; Clients will be notified at the 90% time period of pending disconnection if they do not take action.
 idleclienttimeout=3600
 
+; You can define one user whose decks will be available to all users. This is useful for hosting events and distributing preconstructed decks to all users. By default this is unset. This will be matched against the id field in cockatrice_users.
+; globaldecksid=1
+
 [authentication]
 
 ; Servatrice can authenticate users connecting. It currently supports 3 different authentication methods:

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -808,6 +808,11 @@ bool Servatrice::getClientIDRequiredEnabled() const
     return settingsCache->value("server/requireclientid", 0).toBool();
 }
 
+int Servatrice::getGlobalDecksID() const
+{
+    return settingsCache->value("server/globaldecksid", -1).toInt();
+}
+
 bool Servatrice::getRegOnlyServerEnabled() const
 {
     return settingsCache->value("authentication/regonly", 0).toBool();

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -259,6 +259,7 @@ public:
     int getMinPasswordLength() const;
     int getIdleClientTimeout() const override;
     int getServerID() const override;
+    int getGlobalDecksID() const;
     int getMaxGameInactivityTime() const override;
     int getMaxPlayerInactivityTime() const override;
     int getClientKeepAlive() const override;

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -74,6 +74,7 @@
 #include <string>
 
 static const int protocolVersion = 14;
+static const int globalDeckOffset = 10000000;
 
 AbstractServerSocketInterface::AbstractServerSocketInterface(Servatrice *_server,
                                                              Servatrice_DatabaseInterface *_databaseInterface,
@@ -342,12 +343,14 @@ int AbstractServerSocketInterface::getDeckPathId(const QString &path)
     return getDeckPathId(0, path.split("/"));
 }
 
-bool AbstractServerSocketInterface::deckListHelper(int folderId, ServerInfo_DeckStorage_Folder *folder)
+bool AbstractServerSocketInterface::deckListHelper(int folderId, int userId, ServerInfo_DeckStorage_Folder *folder)
 {
+    int offset = (servatrice->getGlobalDecksID() == userId) ? globalDeckOffset : 0;
+
     QSqlQuery *query = sqlInterface->prepareQuery(
         "select id, name from {prefix}_decklist_folders where id_parent = :id_parent and id_user = :id_user");
     query->bindValue(":id_parent", folderId);
-    query->bindValue(":id_user", userInfo->id());
+    query->bindValue(":id_user", userId);
     if (!sqlInterface->execSqlQuery(query))
         return false;
 
@@ -357,23 +360,23 @@ bool AbstractServerSocketInterface::deckListHelper(int folderId, ServerInfo_Deck
 
     foreach (int key, results.keys()) {
         ServerInfo_DeckStorage_TreeItem *newItem = folder->add_items();
-        newItem->set_id(key);
+        newItem->set_id(key+offset);
         newItem->set_name(results.value(key).toStdString());
 
-        if (!deckListHelper(newItem->id(), newItem->mutable_folder()))
+        if (!deckListHelper(key, userId, newItem->mutable_folder()))
             return false;
     }
 
     query = sqlInterface->prepareQuery("select id, name, upload_time from {prefix}_decklist_files where id_folder = "
                                        ":id_folder and id_user = :id_user");
     query->bindValue(":id_folder", folderId);
-    query->bindValue(":id_user", userInfo->id());
+    query->bindValue(":id_user", userId);
     if (!sqlInterface->execSqlQuery(query))
         return false;
 
     while (query->next()) {
         ServerInfo_DeckStorage_TreeItem *newItem = folder->add_items();
-        newItem->set_id(query->value(0).toInt());
+        newItem->set_id(query->value(0).toInt()+offset);
         newItem->set_name(query->value(1).toString().toStdString());
 
         ServerInfo_DeckStorage_File *newFile = newItem->mutable_file();
@@ -397,7 +400,12 @@ Response::ResponseCode AbstractServerSocketInterface::cmdDeckList(const Command_
     Response_DeckList *re = new Response_DeckList;
     ServerInfo_DeckStorage_Folder *root = re->mutable_root();
 
-    if (!deckListHelper(0, root))
+    int globalID = servatrice->getGlobalDecksID();
+    if((globalID != -1) && ((globalID != userInfo->id())))
+        if (!deckListHelper(0, globalID, root))
+            return Response::RespContextError;
+
+    if (!deckListHelper(0, userInfo->id(), root))
         return Response::RespContextError;
 
     rc.setResponseExtension(re);
@@ -568,7 +576,10 @@ Response::ResponseCode AbstractServerSocketInterface::cmdDeckDownload(const Comm
 
     DeckList *deck;
     try {
-        deck = sqlInterface->getDeckFromDatabase(cmd.deck_id(), userInfo->id());
+        if((servatrice->getGlobalDecksID() != -1) && (cmd.deck_id()>globalDeckOffset))
+            deck = sqlInterface->getDeckFromDatabase(cmd.deck_id()-globalDeckOffset, servatrice->getGlobalDecksID());
+        else
+            deck = sqlInterface->getDeckFromDatabase(cmd.deck_id(), userInfo->id());
     } catch (Response::ResponseCode &r) {
         return r;
     }

--- a/servatrice/src/serversocketinterface.h
+++ b/servatrice/src/serversocketinterface.h
@@ -82,7 +82,7 @@ private:
     Response::ResponseCode cmdRemoveFromList(const Command_RemoveFromList &cmd, ResponseContainer &rc);
     int getDeckPathId(int basePathId, QStringList path);
     int getDeckPathId(const QString &path);
-    bool deckListHelper(int folderId, ServerInfo_DeckStorage_Folder *folder);
+    bool deckListHelper(int folderId, int userId, ServerInfo_DeckStorage_Folder *folder);
     Response::ResponseCode cmdDeckList(const Command_DeckList &cmd, ResponseContainer &rc);
     Response::ResponseCode cmdDeckNewDir(const Command_DeckNewDir &cmd, ResponseContainer &rc);
     void deckDelDirHelper(int basePathId);


### PR DESCRIPTION
## Related Ticket(s)
- Implements Feature Issue #3927 

## Short roundup of the initial problem
Allow a list of decks available for download to all server users.

## What will change with this Pull Request?
- Adds new value in servatrice.ini to specify the user account whose decks will be visible to all.
- If set, the DeckList command will return folders/decks of that user to all users.
- Global decks will appear with a deckID that is 10000000 more than its normal, to avoid collision with user's decks.

## Screenshots
No frontend changes were made. 
![image](https://user-images.githubusercontent.com/686781/94391692-2a983280-0124-11eb-8953-2df86d1ecf0c.png)

