### PR TITLE
Fix spoiler update message

### DIFF
--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -167,8 +167,8 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
         QList<QByteArray> lines = data.split('\n');
 
         foreach (QByteArray line, lines) {
-            if (line.contains("created:")) {
-                QString timeStamp = QString(line).replace("created:", "").trimmed();
+            if (line.contains("Created At:")) {
+                QString timeStamp = QString(line).replace("Created At:", "").trimmed();
                 timeStamp.chop(6); // Remove " (UTC)"
 
                 auto utcTime = QLocale().toDateTime(timeStamp, "ddd, MMM dd yyyy, hh:mm:ss");


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3689

## Short roundup of the initial problem
The format at Magic-Spoiler changed at one point a long time ago to `Created At:`.
https://github.com/Cockatrice/Magic-Spoiler/blob/files/spoiler.xml#L3

## What will change with this Pull Request?
- Update the way Cockatrice parses the file accordingly.

Sometimes having a look at the code doesn't hurt. :)