### PR TITLE
add missing cardlink for the flip messages in the message log

### DIFF
--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -380,9 +380,11 @@ void MessageLogWidget::logDumpZone(Player *player, CardZone *zone, int numberCar
 void MessageLogWidget::logFlipCard(Player *player, QString cardName, bool faceDown)
 {
     if (faceDown) {
-        appendHtmlServerMessage(tr("%1 turns %2 face-down.").arg(sanitizeHtml(player->getName())).arg(cardName));
+        appendHtmlServerMessage(
+            tr("%1 turns %2 face-down.").arg(sanitizeHtml(player->getName())).arg(cardLink(cardName)));
     } else {
-        appendHtmlServerMessage(tr("%1 turns %2 face-up.").arg(sanitizeHtml(player->getName())).arg(cardName));
+        appendHtmlServerMessage(
+            tr("%1 turns %2 face-up.").arg(sanitizeHtml(player->getName())).arg(cardLink(cardName)));
     }
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3136

## Short roundup of the initial problem
the flip card messages in the message log were missing their card link, the card name is known information the moment you flip it either way.