### PR TITLE
apply clang format to proto files

### DIFF
--- a/.ci/travis-lint.sh
+++ b/.ci/travis-lint.sh
@@ -18,7 +18,7 @@ case $err in
 ***  Then commit and push those changes to this branch. ***
 ***   Check our CONTRIBUTING.md file for more details.  ***
 ***                                                     ***
-***                    Thank you ❤️                     ***
+***                    Thank you ❤️                      ***
 ***                                                     ***
 ***********************************************************
 

--- a/.clang-format
+++ b/.clang-format
@@ -25,3 +25,8 @@ IndentCaseLabels: true
 PointerAlignment: Right
 SortIncludes: true
 IncludeBlocks: Regroup
+---
+Language: Proto
+AllowShortBlocksOnASingleLine: Never
+AllowShortFunctionsOnASingleLine: None
+SpacesInContainerLiterals: false

--- a/.clang-format
+++ b/.clang-format
@@ -27,6 +27,5 @@ SortIncludes: true
 IncludeBlocks: Regroup
 ---
 Language: Proto
-AllowShortBlocksOnASingleLine: Never
 AllowShortFunctionsOnASingleLine: None
 SpacesInContainerLiterals: false

--- a/clangify.sh
+++ b/clangify.sh
@@ -18,7 +18,7 @@ exclude=("servatrice/src/smtp" \
 "oracle/src/zip" \
 "oracle/src/lzma" \
 "oracle/src/qt-json")
-exts=("cpp" "h")
+exts=("cpp" "h" "proto")
 cf_cmd="clang-format"
 branch="origin/master"
 

--- a/common/pb/admin_commands.proto
+++ b/common/pb/admin_commands.proto
@@ -37,4 +37,3 @@ message Command_AdjustMod {
     optional bool should_be_mod = 2;
     optional bool should_be_judge = 3;
 }
-

--- a/common/pb/command_attach_card.proto
+++ b/common/pb/command_attach_card.proto
@@ -10,5 +10,3 @@ message Command_AttachCard {
     optional string target_zone = 4;
     optional sint32 target_card_id = 5 [default = -1];
 }
-
-

--- a/common/pb/command_change_zone_properties.proto
+++ b/common/pb/command_change_zone_properties.proto
@@ -6,6 +6,6 @@ message Command_ChangeZoneProperties {
         optional Command_ChangeZoneProperties ext = 1031;
     }
     optional string zone_name = 1;
-    
+
     optional bool always_reveal_top_card = 10;
 }

--- a/common/pb/command_concede.proto
+++ b/common/pb/command_concede.proto
@@ -6,7 +6,6 @@ message Command_Concede {
     }
 }
 
-
 message Command_Unconcede {
     extend GameCommand {
         optional Command_Unconcede ext = 1032;

--- a/common/pb/command_create_token.proto
+++ b/common/pb/command_create_token.proto
@@ -15,5 +15,3 @@ message Command_CreateToken {
     optional string target_zone = 9;
     optional sint32 target_card_id = 10 [default = -1];
 }
-
-

--- a/common/pb/command_deck_del_dir.proto
+++ b/common/pb/command_deck_del_dir.proto
@@ -7,4 +7,3 @@ message Command_DeckDelDir {
     }
     optional string path = 1;
 }
- 

--- a/common/pb/command_deck_download.proto
+++ b/common/pb/command_deck_download.proto
@@ -7,4 +7,3 @@ message Command_DeckDownload {
     }
     optional sint32 deck_id = 1 [default = -1];
 }
- 

--- a/common/pb/command_deck_new_dir.proto
+++ b/common/pb/command_deck_new_dir.proto
@@ -8,4 +8,3 @@ message Command_DeckNewDir {
     optional string path = 1;
     optional string dir_name = 2;
 }
- 

--- a/common/pb/command_deck_upload.proto
+++ b/common/pb/command_deck_upload.proto
@@ -5,7 +5,7 @@ message Command_DeckUpload {
     extend SessionCommand {
         optional Command_DeckUpload ext = 1013;
     }
-    optional string path = 1;      // to upload a new deck
-    optional uint32 deck_id = 2;   // to replace an existing deck
+    optional string path = 1;    // to upload a new deck
+    optional uint32 deck_id = 2; // to replace an existing deck
     optional string deck_list = 3;
 }

--- a/common/pb/command_draw_cards.proto
+++ b/common/pb/command_draw_cards.proto
@@ -6,4 +6,3 @@ message Command_DrawCards {
     }
     optional uint32 number = 1;
 }
-

--- a/common/pb/command_flip_card.proto
+++ b/common/pb/command_flip_card.proto
@@ -9,5 +9,3 @@ message Command_FlipCard {
     optional bool face_down = 3;
     optional string pt = 4;
 }
-
-

--- a/common/pb/command_game_say.proto
+++ b/common/pb/command_game_say.proto
@@ -6,5 +6,3 @@ message Command_GameSay {
     }
     optional string message = 1;
 }
-
-

--- a/common/pb/command_kick_from_game.proto
+++ b/common/pb/command_kick_from_game.proto
@@ -3,7 +3,6 @@ import "game_commands.proto";
 message Command_KickFromGame {
     extend GameCommand {
         optional Command_KickFromGame ext = 1000;
-}
+    }
     optional sint32 player_id = 1 [default = -1];
 }
-

--- a/common/pb/command_leave_game.proto
+++ b/common/pb/command_leave_game.proto
@@ -5,4 +5,3 @@ message Command_LeaveGame {
         optional Command_LeaveGame ext = 1001;
     }
 }
-

--- a/common/pb/command_move_card.proto
+++ b/common/pb/command_move_card.proto
@@ -23,4 +23,3 @@ message Command_MoveCard {
     optional sint32 x = 6 [default = -1];
     optional sint32 y = 7 [default = -1];
 }
-

--- a/common/pb/command_mulligan.proto
+++ b/common/pb/command_mulligan.proto
@@ -6,4 +6,3 @@ message Command_Mulligan {
     }
     optional uint32 number = 7;
 }
-

--- a/common/pb/command_replay_modify_match.proto
+++ b/common/pb/command_replay_modify_match.proto
@@ -8,4 +8,3 @@ message Command_ReplayModifyMatch {
     optional sint32 game_id = 1 [default = -1];
     optional bool do_not_hide = 2;
 }
- 

--- a/common/pb/command_reverse_turn.proto
+++ b/common/pb/command_reverse_turn.proto
@@ -3,6 +3,5 @@ import "game_commands.proto";
 message Command_ReverseTurn {
     extend GameCommand {
         optional Command_ReverseTurn ext = 1034;
-	}
+    }
 }
-

--- a/common/pb/command_roll_die.proto
+++ b/common/pb/command_roll_die.proto
@@ -6,4 +6,3 @@ message Command_RollDie {
     }
     optional uint32 sides = 1;
 }
-

--- a/common/pb/command_set_sideboard_plan.proto
+++ b/common/pb/command_set_sideboard_plan.proto
@@ -8,4 +8,3 @@ message Command_SetSideboardPlan {
     }
     repeated MoveCard_ToZone move_list = 1;
 }
-

--- a/common/pb/command_shuffle.proto
+++ b/common/pb/command_shuffle.proto
@@ -8,4 +8,3 @@ message Command_Shuffle {
     optional sint32 start = 2 [default = 0];
     optional sint32 end = 3 [default = -1];
 }
-

--- a/common/pb/commands.proto
+++ b/common/pb/commands.proto
@@ -7,10 +7,10 @@ import "admin_commands.proto";
 
 message CommandContainer {
     optional uint64 cmd_id = 1;
-    
+
     optional uint32 game_id = 10;
     optional uint32 room_id = 20;
-    
+
     repeated SessionCommand session_command = 100;
     repeated GameCommand game_command = 101;
     repeated RoomCommand room_command = 102;

--- a/common/pb/event_change_zone_properties.proto
+++ b/common/pb/event_change_zone_properties.proto
@@ -6,6 +6,6 @@ message Event_ChangeZoneProperties {
         optional Event_ChangeZoneProperties ext = 2020;
     }
     optional string zone_name = 1;
-    
+
     optional bool always_reveal_top_card = 10;
 }

--- a/common/pb/event_game_host_changed.proto
+++ b/common/pb/event_game_host_changed.proto
@@ -6,4 +6,3 @@ message Event_GameHostChanged {
         optional Event_GameHostChanged ext = 1003;
     }
 }
- 

--- a/common/pb/event_kicked.proto
+++ b/common/pb/event_kicked.proto
@@ -6,4 +6,3 @@ message Event_Kicked {
         optional Event_Kicked ext = 1004;
     }
 }
-

--- a/common/pb/event_leave_room.proto
+++ b/common/pb/event_leave_room.proto
@@ -7,6 +7,3 @@ message Event_LeaveRoom {
     }
     optional string name = 1;
 }
- 
- 
- 

--- a/common/pb/event_notify_user.proto
+++ b/common/pb/event_notify_user.proto
@@ -4,7 +4,7 @@ import "session_event.proto";
 message Event_NotifyUser {
 
     enum NotificationType {
-        UNKNOWN = 0;  // Default enum value if no "type" is defined when used
+        UNKNOWN = 0; // Default enum value if no "type" is defined when used
         PROMOTED = 1;
         WARNING = 2;
         IDLEWARNING = 3;
@@ -18,5 +18,4 @@ message Event_NotifyUser {
     optional string warning_reason = 2;
     optional string custom_title = 3;
     optional string custom_content = 4;
-
 }

--- a/common/pb/event_room_say.proto
+++ b/common/pb/event_room_say.proto
@@ -14,5 +14,4 @@ message Event_RoomSay {
     optional string message = 2;
     optional RoomMessageType message_type = 3;
     optional uint64 time_of = 4;
-
 }

--- a/common/pb/isl_message.proto
+++ b/common/pb/isl_message.proto
@@ -9,17 +9,17 @@ message IslMessage {
     enum MessageType {
         GAME_COMMAND_CONTAINER = 0;
         ROOM_COMMAND_CONTAINER = 1;
-        
+
         RESPONSE = 10;
         SESSION_EVENT = 11;
         GAME_EVENT_CONTAINER = 12;
         ROOM_EVENT = 13;
     }
     optional MessageType message_type = 1;
-    
+
     optional uint64 session_id = 9;
     optional sint32 player_id = 10 [default = -1];
-    
+
     optional CommandContainer game_command = 100;
     optional CommandContainer room_command = 101;
 

--- a/common/pb/moderator_commands.proto
+++ b/common/pb/moderator_commands.proto
@@ -60,13 +60,12 @@ message Command_ViewLogHistory {
     extend ModeratorCommand {
         optional Command_ViewLogHistory ext = 1005;
     }
-    optional string user_name = 1;  // user that created message
-    optional string ip_address = 2; // ip address of user that created message
-    optional string game_name = 3; // client id of user that created the message
-    optional string game_id = 4; // game number the message was sent to
-    optional string message = 5; // raw message that was sent
-    repeated string log_location = 6; // destination of message (ex: main room, game room, private chat)
-    required uint32 date_range = 7; // the length of time (in minutes) to look back for
+    optional string user_name = 1;       // user that created message
+    optional string ip_address = 2;      // ip address of user that created message
+    optional string game_name = 3;       // client id of user that created the message
+    optional string game_id = 4;         // game number the message was sent to
+    optional string message = 5;         // raw message that was sent
+    repeated string log_location = 6;    // destination of message (ex: main room, game room, private chat)
+    required uint32 date_range = 7;      // the length of time (in minutes) to look back for
     optional uint32 maximum_results = 8; // the maximum number of query results
-
 }

--- a/common/pb/response.proto
+++ b/common/pb/response.proto
@@ -25,21 +25,23 @@ message Response {
         RespAccessDenied = 20;
         RespUsernameInvalid = 21;
         RespRegistrationRequired = 22;
-        RespRegistrationAccepted = 23; // Server agrees to process client's registration request
-        RespUserAlreadyExists = 24; // Client attempted to register a name which is already registered
+        RespRegistrationAccepted = 23;    // Server agrees to process client's registration request
+        RespUserAlreadyExists = 24;       // Client attempted to register a name which is already registered
         RespEmailRequiredToRegister = 25; // Server requires email to register accounts but client did not provide one
-        RespTooManyRequests = 26; // Server refused to complete command because client has sent too many too quickly
+        RespTooManyRequests = 26;  // Server refused to complete command because client has sent too many too quickly
         RespPasswordTooShort = 27; // Server requires a decent password
-        RespAccountNotActivated = 28; // Client attempted to log into a registered username but the account hasn't been activated
+        RespAccountNotActivated =
+            28; // Client attempted to log into a registered username but the account hasn't been activated
         RespRegistrationDisabled = 29; // Server does not allow clients to register
-        RespRegistrationFailed = 30; // Server accepted a reg request but failed to perform the registration
-        RespActivationAccepted = 31; // Server accepted a reg user activation token
-        RespActivationFailed = 32; // Server didn't accept a reg user activation token
-        RespRegistrationAcceptedNeedsActivation = 33; // Server accepted cient registration, but it will need token activation
+        RespRegistrationFailed = 30;   // Server accepted a reg request but failed to perform the registration
+        RespActivationAccepted = 31;   // Server accepted a reg user activation token
+        RespActivationFailed = 32;     // Server didn't accept a reg user activation token
+        RespRegistrationAcceptedNeedsActivation =
+            33;                    // Server accepted cient registration, but it will need token activation
         RespClientIdRequired = 34; // Server requires client to generate and send its client id before allowing access
         RespClientUpdateRequired = 35; // Client is missing features that the server is requiring
-        RespServerFull = 36; // Server user limit reached
-        RespEmailBlackListed = 37; // Server has blacklisted the email address provided for registration
+        RespServerFull = 36;           // Server user limit reached
+        RespEmailBlackListed = 37;     // Server has blacklisted the email address provided for registration
     }
     enum ResponseType {
         JOIN_ROOM = 1000;
@@ -64,6 +66,6 @@ message Response {
     }
     required uint64 cmd_id = 1;
     optional ResponseCode response_code = 2;
-    
+
     extensions 100 to max;
 }

--- a/common/pb/response_adjust_mod.proto
+++ b/common/pb/response_adjust_mod.proto
@@ -1,7 +1,7 @@
 syntax = "proto2";
 import "response.proto";
 
-message Response_AdjustMod{
+message Response_AdjustMod {
     extend Response {
         optional Response_AdjustMod ext = 1011;
     }

--- a/common/pb/response_ban_history.proto
+++ b/common/pb/response_ban_history.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 import "response.proto";
 import "serverinfo_ban.proto";
 
-message Response_BanHistory{
+message Response_BanHistory {
     extend Response {
         optional Response_BanHistory ext = 1012;
     }

--- a/common/pb/response_get_games_of_user.proto
+++ b/common/pb/response_get_games_of_user.proto
@@ -10,4 +10,3 @@ message Response_GetGamesOfUser {
     repeated ServerInfo_Room room_list = 1;
     repeated ServerInfo_Game game_list = 2;
 }
- 

--- a/common/pb/response_get_user_info.proto
+++ b/common/pb/response_get_user_info.proto
@@ -8,5 +8,3 @@ message Response_GetUserInfo {
     }
     optional ServerInfo_User user_info = 1;
 }
- 
- 

--- a/common/pb/response_list_users.proto
+++ b/common/pb/response_list_users.proto
@@ -8,4 +8,3 @@ message Response_ListUsers {
     }
     repeated ServerInfo_User user_list = 1;
 }
- 

--- a/common/pb/response_replay_download.proto
+++ b/common/pb/response_replay_download.proto
@@ -7,4 +7,3 @@ message Response_ReplayDownload {
     }
     optional bytes replay_data = 1;
 }
- 

--- a/common/pb/response_viewlog_history.proto
+++ b/common/pb/response_viewlog_history.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 import "response.proto";
 import "serverinfo_chat_message.proto";
 
-message Response_ViewLogHistory{
+message Response_ViewLogHistory {
     extend Response {
         optional Response_ViewLogHistory ext = 1015;
     }

--- a/common/pb/response_warn_history.proto
+++ b/common/pb/response_warn_history.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 import "response.proto";
 import "serverinfo_warning.proto";
 
-message Response_WarnHistory{
+message Response_WarnHistory {
     extend Response {
         optional Response_WarnHistory ext = 1013;
     }

--- a/common/pb/response_warn_list.proto
+++ b/common/pb/response_warn_list.proto
@@ -1,7 +1,7 @@
 syntax = "proto2";
 import "response.proto";
 
-message Response_WarnList{
+message Response_WarnList {
     extend Response {
         optional Response_WarnList ext = 1014;
     }

--- a/common/pb/server_message.proto
+++ b/common/pb/server_message.proto
@@ -12,7 +12,7 @@ message ServerMessage {
         ROOM_EVENT = 3;
     }
     optional MessageType message_type = 1;
-    
+
     optional Response response = 2;
     optional SessionEvent session_event = 3;
     optional GameEventContainer game_event_container = 4;

--- a/common/pb/serverinfo_ban.proto
+++ b/common/pb/serverinfo_ban.proto
@@ -3,10 +3,10 @@ syntax = "proto2";
  * Historical ban information stored in the ban table
  */
 message ServerInfo_Ban {
-    required string admin_id = 1; // id of the staff member placing the ban
-    required string admin_name = 2; // name of the staff member placing the ban
-    required string ban_time = 3; // start time of the ban
-    required string ban_length = 4; // amount of time in minutes the ban is for
-    optional string ban_reason = 5;  // reason seen only by moderation staff
+    required string admin_id = 1;       // id of the staff member placing the ban
+    required string admin_name = 2;     // name of the staff member placing the ban
+    required string ban_time = 3;       // start time of the ban
+    required string ban_length = 4;     // amount of time in minutes the ban is for
+    optional string ban_reason = 5;     // reason seen only by moderation staff
     optional string visible_reason = 6; // reason shown to the user
 }

--- a/common/pb/serverinfo_chat_message.proto
+++ b/common/pb/serverinfo_chat_message.proto
@@ -5,12 +5,12 @@ syntax = "proto2";
  * These communications are also stored in the DB log table.
  */
 message ServerInfo_ChatMessage {
-    optional string time = 1; // time chat was sent
-    optional string sender_id = 2; // id of sender
+    optional string time = 1;        // time chat was sent
+    optional string sender_id = 2;   // id of sender
     optional string sender_name = 3; // name of sender
-    optional string sender_ip = 4; // ip of sender
-    optional string message = 5;  // message
+    optional string sender_ip = 4;   // ip of sender
+    optional string message = 5;     // message
     optional string target_type = 6; // target type (room,game,chat)
-    optional string target_id = 7; // id of target
+    optional string target_id = 7;   // id of target
     optional string target_name = 8; // name of target
 }

--- a/common/pb/serverinfo_gametype.proto
+++ b/common/pb/serverinfo_gametype.proto
@@ -3,4 +3,3 @@ message ServerInfo_GameType {
     optional sint32 game_type_id = 1;
     optional string description = 2;
 };
-

--- a/common/pb/serverinfo_replay_match.proto
+++ b/common/pb/serverinfo_replay_match.proto
@@ -3,7 +3,7 @@ import "serverinfo_replay.proto";
 
 message ServerInfo_ReplayMatch {
     repeated ServerInfo_Replay replay_list = 1;
-    
+
     optional sint32 game_id = 2 [default = -1];
     optional string room_name = 3;
     optional uint32 time_started = 4;

--- a/common/pb/serverinfo_warning.proto
+++ b/common/pb/serverinfo_warning.proto
@@ -3,8 +3,8 @@ syntax = "proto2";
  * Historical warning information stored in the warnings table
  */
 message ServerInfo_Warning {
-    optional string user_name = 1; // name of user being warned
+    optional string user_name = 1;  // name of user being warned
     optional string admin_name = 2; // name of the moderator making the warning
-    optional string reason = 3; // type of warning being placed
-    optional string time_of = 4; // time of warning
+    optional string reason = 3;     // type of warning being placed
+    optional string time_of = 4;    // time of warning
 }

--- a/common/pb/serverinfo_zone.proto
+++ b/common/pb/serverinfo_zone.proto
@@ -11,7 +11,7 @@ message ServerInfo_Zone {
         // setting beingLookedAt to true.
         // Cards in a zone with the type HiddenZone are referenced by their
         // list index, whereas cards in any other zone are referenced by their ids.
-        
+
         PrivateZone = 0;
         PublicZone = 1;
         HiddenZone = 2;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3060

## Short roundup of the initial problem
proto files are not automatically formatted

## What will change with this Pull Request?
- rules that currently define our proto files are added to .clang-format instructions
- clangify will now pick up the proto extension
- the existing files are formatted