### PR TITLE
update sfmt to version 1.5.1 from 1.4.1

### DIFF
--- a/common/sfmt/SFMT-common.h
+++ b/common/sfmt/SFMT-common.h
@@ -28,7 +28,7 @@ extern "C" {
 #include "SFMT.h"
 
 inline static void do_recursion(w128_t * r, w128_t * a, w128_t * b,
-				w128_t * c, w128_t * d);
+                                w128_t * c, w128_t * d);
 
 inline static void rshift128(w128_t *out,  w128_t const *in, int shift);
 inline static void lshift128(w128_t *out,  w128_t const *in, int shift);
@@ -123,24 +123,24 @@ inline static void lshift128(w128_t *out, w128_t const *in, int shift)
  */
 #ifdef ONLY64
 inline static void do_recursion(w128_t *r, w128_t *a, w128_t *b, w128_t *c,
-				w128_t *d) {
+                                w128_t *d) {
     w128_t x;
     w128_t y;
 
     lshift128(&x, a, SFMT_SL2);
     rshift128(&y, c, SFMT_SR2);
     r->u[0] = a->u[0] ^ x.u[0] ^ ((b->u[0] >> SFMT_SR1) & SFMT_MSK2) ^ y.u[0]
-	^ (d->u[0] << SFMT_SL1);
+        ^ (d->u[0] << SFMT_SL1);
     r->u[1] = a->u[1] ^ x.u[1] ^ ((b->u[1] >> SFMT_SR1) & SFMT_MSK1) ^ y.u[1]
-	^ (d->u[1] << SFMT_SL1);
+        ^ (d->u[1] << SFMT_SL1);
     r->u[2] = a->u[2] ^ x.u[2] ^ ((b->u[2] >> SFMT_SR1) & SFMT_MSK4) ^ y.u[2]
-	^ (d->u[2] << SFMT_SL1);
+        ^ (d->u[2] << SFMT_SL1);
     r->u[3] = a->u[3] ^ x.u[3] ^ ((b->u[3] >> SFMT_SR1) & SFMT_MSK3) ^ y.u[3]
-	^ (d->u[3] << SFMT_SL1);
+        ^ (d->u[3] << SFMT_SL1);
 }
 #else
 inline static void do_recursion(w128_t *r, w128_t *a, w128_t *b,
-				w128_t *c, w128_t *d)
+                                w128_t *c, w128_t *d)
 {
     w128_t x;
     w128_t y;
@@ -148,17 +148,17 @@ inline static void do_recursion(w128_t *r, w128_t *a, w128_t *b,
     lshift128(&x, a, SFMT_SL2);
     rshift128(&y, c, SFMT_SR2);
     r->u[0] = a->u[0] ^ x.u[0] ^ ((b->u[0] >> SFMT_SR1) & SFMT_MSK1)
-	^ y.u[0] ^ (d->u[0] << SFMT_SL1);
+        ^ y.u[0] ^ (d->u[0] << SFMT_SL1);
     r->u[1] = a->u[1] ^ x.u[1] ^ ((b->u[1] >> SFMT_SR1) & SFMT_MSK2)
-	^ y.u[1] ^ (d->u[1] << SFMT_SL1);
+        ^ y.u[1] ^ (d->u[1] << SFMT_SL1);
     r->u[2] = a->u[2] ^ x.u[2] ^ ((b->u[2] >> SFMT_SR1) & SFMT_MSK3)
-	^ y.u[2] ^ (d->u[2] << SFMT_SL1);
+        ^ y.u[2] ^ (d->u[2] << SFMT_SL1);
     r->u[3] = a->u[3] ^ x.u[3] ^ ((b->u[3] >> SFMT_SR1) & SFMT_MSK4)
-	^ y.u[3] ^ (d->u[3] << SFMT_SL1);
+        ^ y.u[3] ^ (d->u[3] << SFMT_SL1);
 }
 #endif
-#endif
-
 #if defined(__cplusplus)
 }
 #endif
+
+#endif // SFMT_COMMON_H

--- a/common/sfmt/SFMT-params.h
+++ b/common/sfmt/SFMT-params.h
@@ -46,8 +46,8 @@
 */
 
 /** the parameter of shift right as one 128-bit register.
- * The 128-bit integer is shifted by (SFMT_SL2 * 8) bits.
-#define SFMT_SR21 1
+ * The 128-bit integer is shifted by (SFMT_SR2 * 8) bits.
+#define SFMT_SR2 1
 */
 
 /** A bitmask, used in the recursion.  These parameters are introduced
@@ -59,10 +59,10 @@
 */
 
 /** These definitions are part of a 128-bit period certification vector.
-#define SFMT_PARITY1	0x00000001U
-#define SFMT_PARITY2	0x00000000U
-#define SFMT_PARITY3	0x00000000U
-#define SFMT_PARITY4	0xc98e126aU
+#define SFMT_PARITY1    0x00000001U
+#define SFMT_PARITY2    0x00000000U
+#define SFMT_PARITY3    0x00000000U
+#define SFMT_PARITY4    0xc98e126aU
 */
 
 #if SFMT_MEXP == 607

--- a/common/sfmt/SFMT.h
+++ b/common/sfmt/SFMT.h
@@ -79,6 +79,15 @@ union W128_T {
     uint32_t u[4];
     uint64_t u64[2];
 };
+#elif defined(HAVE_NEON)
+  #include <arm_neon.h>
+
+/** 128-bit data structure */
+union W128_T {
+    uint32_t u[4];
+    uint64_t u64[2];
+    uint32x4_t si;
+};
 #elif defined(HAVE_SSE2)
   #include <emmintrin.h>
 
@@ -247,7 +256,7 @@ inline static double sfmt_genrand_real3(sfmt_t * sfmt)
  */
 inline static double sfmt_to_res53(uint64_t v)
 {
-    return v * (1.0/18446744073709551616.0);
+    return (v >> 11) * (1.0/9007199254740992.0);
 }
 
 /**


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2871

## Short roundup of the initial problem
sfmt is version 1.4.1 released 2013

## What will change with this Pull Request?
- sfmt is version 1.5.1 released 2017
- there are no changes in the library that change functionality
