### PR TITLE
Add game filtering for spectator attributes

### DIFF
--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -113,23 +113,23 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     auto *restrictionsGroupBox = new QGroupBox(tr("Restrictions"));
     restrictionsGroupBox->setLayout(restrictionsLayout);
 
-    spectatorsCanWatch = new QCheckBox(tr("Show games &spectators can watch"));
-    spectatorsCanWatch->setChecked(true);  // DO NOT SUBMIT get from storage
-    connect(spectatorsCanWatch, SIGNAL(toggled(bool)), this, SLOT(toggleSpectatorCheckboxEnabledness(bool)));
+    showOnlyIfSpectatorsCanWatch = new QCheckBox(tr("Show games only if &spectators can watch"));
+    showOnlyIfSpectatorsCanWatch->setChecked(gamesProxyModel->getShowOnlyIfSpectatorsCanWatch());
+    connect(showOnlyIfSpectatorsCanWatch, SIGNAL(toggled(bool)), this, SLOT(toggleSpectatorCheckboxEnabledness(bool)));
 
-    spectatorsNeedPassword = new QCheckBox(tr("Show if spectators need password"));
-    spectatorsNeedPassword->setChecked(true);  // DO NOT SUBMIT get from storage
-    spectatorsCanChat = new QCheckBox(tr("Show if spectators can chat"));
-    spectatorsCanChat->setChecked(true);  // DO NOT SUBMIT get from storage
-    spectatorsCanSeeHands = new QCheckBox(tr("Show if spectators can see hands"));
-    spectatorsCanSeeHands->setChecked(true);  // DO NOT SUBMIT get from storage
-    toggleSpectatorCheckboxEnabledness(getSpectatorsCanWatch());
+    showSpectatorPasswordProtected = new QCheckBox(tr("Show spectator password p&rotected games"));
+    showSpectatorPasswordProtected->setChecked(gamesProxyModel->getShowSpectatorPasswordProtected());
+    showOnlyIfSpectatorsCanChat = new QCheckBox(tr("Show only if spectators can ch&at"));
+    showOnlyIfSpectatorsCanChat->setChecked(gamesProxyModel->getShowOnlyIfSpectatorsCanChat());
+    showOnlyIfSpectatorsCanSeeHands = new QCheckBox(tr("Show only if spectators can see &hands"));
+    showOnlyIfSpectatorsCanSeeHands->setChecked(gamesProxyModel->getShowOnlyIfSpectatorsCanSeeHands());
+    toggleSpectatorCheckboxEnabledness(getShowOnlyIfSpectatorsCanWatch());
 
     auto *spectatorsLayout = new QGridLayout;
-    spectatorsLayout->addWidget(spectatorsCanWatch, 0, 0);
-    spectatorsLayout->addWidget(spectatorsNeedPassword, 1, 0);
-    spectatorsLayout->addWidget(spectatorsCanChat, 2, 0);
-    spectatorsLayout->addWidget(spectatorsCanSeeHands, 3, 0);
+    spectatorsLayout->addWidget(showOnlyIfSpectatorsCanWatch, 0, 0);
+    spectatorsLayout->addWidget(showSpectatorPasswordProtected, 1, 0);
+    spectatorsLayout->addWidget(showOnlyIfSpectatorsCanChat, 2, 0);
+    spectatorsLayout->addWidget(showOnlyIfSpectatorsCanSeeHands, 3, 0);
 
     auto *spectatorsGroupBox = new QGroupBox(tr("Spectators"));
     spectatorsGroupBox->setLayout(spectatorsLayout);
@@ -170,9 +170,9 @@ void DlgFilterGames::actOk()
 
 void DlgFilterGames::toggleSpectatorCheckboxEnabledness(bool spectatorsEnabled)
 {
-    spectatorsNeedPassword->setDisabled(!spectatorsEnabled);
-    spectatorsCanChat->setDisabled(!spectatorsEnabled);
-    spectatorsCanSeeHands->setDisabled(!spectatorsEnabled);
+    showSpectatorPasswordProtected->setDisabled(!spectatorsEnabled);
+    showOnlyIfSpectatorsCanChat->setDisabled(!spectatorsEnabled);
+    showOnlyIfSpectatorsCanSeeHands->setDisabled(!spectatorsEnabled);
 }
 
 bool DlgFilterGames::getUnavailableGamesVisible() const
@@ -282,7 +282,22 @@ void DlgFilterGames::setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlaye
                                                                     : _maxPlayersFilterMax);
 }
 
-int DlgFilterGames::getSpectatorsCanWatch() const
+bool DlgFilterGames::getShowOnlyIfSpectatorsCanWatch() const
 {
-    return spectatorsCanWatch->isEnabled() && spectatorsCanWatch->isChecked();
+    return showOnlyIfSpectatorsCanWatch->isChecked();
+}
+
+bool DlgFilterGames::getShowSpectatorPasswordProtected() const
+{
+    return showSpectatorPasswordProtected->isEnabled() && showSpectatorPasswordProtected->isChecked();
+}
+
+bool DlgFilterGames::getShowOnlyIfSpectatorsCanChat() const
+{
+    return showOnlyIfSpectatorsCanChat->isEnabled() && showOnlyIfSpectatorsCanChat->isChecked();
+}
+
+bool DlgFilterGames::getShowOnlyIfSpectatorsCanSeeHands() const
+{
+    return showOnlyIfSpectatorsCanSeeHands->isEnabled() && showOnlyIfSpectatorsCanSeeHands->isChecked();
 }

--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -27,8 +27,11 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     showBuddiesOnlyGames = new QCheckBox(tr("Show '&buddies only' games"));
     showBuddiesOnlyGames->setChecked(gamesProxyModel->getShowBuddiesOnlyGames());
 
-    unavailableGamesVisibleCheckBox = new QCheckBox(tr("Show &unavailable games"));
-    unavailableGamesVisibleCheckBox->setChecked(gamesProxyModel->getUnavailableGamesVisible());
+    showFullGames = new QCheckBox(tr("Show &full games"));
+    showFullGames->setChecked(gamesProxyModel->getShowFullGames());
+
+    showGamesThatStarted = new QCheckBox(tr("Show games &that have started"));
+    showGamesThatStarted->setChecked(gamesProxyModel->getShowGamesThatStarted());
 
     showPasswordProtectedGames = new QCheckBox(tr("Show &password protected games"));
     showPasswordProtectedGames->setChecked(gamesProxyModel->getShowPasswordProtectedGames());
@@ -105,10 +108,11 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     maxPlayersGroupBox->setLayout(maxPlayersFilterLayout);
 
     auto *restrictionsLayout = new QGridLayout;
-    restrictionsLayout->addWidget(unavailableGamesVisibleCheckBox, 0, 0);
-    restrictionsLayout->addWidget(showPasswordProtectedGames, 1, 0);
-    restrictionsLayout->addWidget(showBuddiesOnlyGames, 2, 0);
-    restrictionsLayout->addWidget(hideIgnoredUserGames, 3, 0);
+    restrictionsLayout->addWidget(showFullGames, 0, 0);
+    restrictionsLayout->addWidget(showGamesThatStarted, 1, 0);
+    restrictionsLayout->addWidget(showPasswordProtectedGames, 2, 0);
+    restrictionsLayout->addWidget(showBuddiesOnlyGames, 3, 0);
+    restrictionsLayout->addWidget(hideIgnoredUserGames, 4, 0);
 
     auto *restrictionsGroupBox = new QGroupBox(tr("Restrictions"));
     restrictionsGroupBox->setLayout(restrictionsLayout);
@@ -138,14 +142,16 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     leftGrid->addWidget(generalGroupBox, 0, 0, 1, 2);
     leftGrid->addWidget(maxPlayersGroupBox, 2, 0, 1, 2);
     leftGrid->addWidget(restrictionsGroupBox, 3, 0, 1, 2);
-    leftGrid->addWidget(spectatorsGroupBox, 4, 0, 1, 2);
 
     auto *leftColumn = new QVBoxLayout;
     leftColumn->addLayout(leftGrid);
     leftColumn->addStretch();
 
+    auto *rightGrid = new QGridLayout;
+    rightGrid->addWidget(gameTypeFilterGroupBox, 0, 0, 1, 1);
+    rightGrid->addWidget(spectatorsGroupBox, 1, 0, 1, 1);
     auto *rightColumn = new QVBoxLayout;
-    rightColumn->addWidget(gameTypeFilterGroupBox);
+    rightColumn->addLayout(rightGrid);
 
     auto *hbox = new QHBoxLayout;
     hbox->addLayout(leftColumn);
@@ -175,14 +181,14 @@ void DlgFilterGames::toggleSpectatorCheckboxEnabledness(bool spectatorsEnabled)
     showOnlyIfSpectatorsCanSeeHands->setDisabled(!spectatorsEnabled);
 }
 
-bool DlgFilterGames::getUnavailableGamesVisible() const
+bool DlgFilterGames::getShowFullGames() const
 {
-    return unavailableGamesVisibleCheckBox->isChecked();
+    return showFullGames->isChecked();
 }
 
-void DlgFilterGames::setUnavailableGamesVisible(bool _unavailableGamesVisible)
+bool DlgFilterGames::getShowGamesThatStarted() const
 {
-    unavailableGamesVisibleCheckBox->setChecked(_unavailableGamesVisible);
+    return showGamesThatStarted->isChecked();
 }
 
 bool DlgFilterGames::getShowBuddiesOnlyGames() const

--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -41,19 +41,19 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     maxGameAgeComboBox->addItems(gameAgeMap.values());
     QTime gameAge = gamesProxyModel->getMaxGameAge();
     maxGameAgeComboBox->setCurrentIndex(gameAgeMap.keys().indexOf(gameAge)); // index is -1 if unknown
-    QLabel *maxGameAgeLabel = new QLabel(tr("&Newer than:"));
+    auto *maxGameAgeLabel = new QLabel(tr("&Newer than:"));
     maxGameAgeLabel->setBuddy(maxGameAgeComboBox);
 
     gameNameFilterEdit = new QLineEdit;
     gameNameFilterEdit->setText(gamesProxyModel->getGameNameFilter());
-    QLabel *gameNameFilterLabel = new QLabel(tr("Game &description:"));
+    auto *gameNameFilterLabel = new QLabel(tr("Game &description:"));
     gameNameFilterLabel->setBuddy(gameNameFilterEdit);
     creatorNameFilterEdit = new QLineEdit;
     creatorNameFilterEdit->setText(gamesProxyModel->getCreatorNameFilter());
-    QLabel *creatorNameFilterLabel = new QLabel(tr("&Creator name:"));
+    auto *creatorNameFilterLabel = new QLabel(tr("&Creator name:"));
     creatorNameFilterLabel->setBuddy(creatorNameFilterEdit);
 
-    QGridLayout *generalGrid = new QGridLayout;
+    auto *generalGrid = new QGridLayout;
     generalGrid->addWidget(gameNameFilterLabel, 0, 0);
     generalGrid->addWidget(gameNameFilterEdit, 0, 1);
     generalGrid->addWidget(creatorNameFilterLabel, 1, 0);
@@ -63,12 +63,12 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     generalGroupBox = new QGroupBox(tr("General"));
     generalGroupBox->setLayout(generalGrid);
 
-    QVBoxLayout *gameTypeFilterLayout = new QVBoxLayout;
+    auto *gameTypeFilterLayout = new QVBoxLayout;
     QMapIterator<int, QString> gameTypesIterator(allGameTypes);
     while (gameTypesIterator.hasNext()) {
         gameTypesIterator.next();
 
-        QCheckBox *temp = new QCheckBox(gameTypesIterator.value());
+        auto *temp = new QCheckBox(gameTypesIterator.value());
         temp->setChecked(gamesProxyModel->getGameTypeFilter().contains(gameTypesIterator.key()));
 
         gameTypeFilterCheckBoxes.insert(gameTypesIterator.key(), temp);
@@ -79,38 +79,38 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
         gameTypeFilterGroupBox = new QGroupBox(tr("&Game types"));
         gameTypeFilterGroupBox->setLayout(gameTypeFilterLayout);
     } else
-        gameTypeFilterGroupBox = 0;
+        gameTypeFilterGroupBox = nullptr;
 
-    QLabel *maxPlayersFilterMinLabel = new QLabel(tr("at &least:"));
+    auto *maxPlayersFilterMinLabel = new QLabel(tr("at &least:"));
     maxPlayersFilterMinSpinBox = new QSpinBox;
     maxPlayersFilterMinSpinBox->setMinimum(1);
     maxPlayersFilterMinSpinBox->setMaximum(99);
     maxPlayersFilterMinSpinBox->setValue(gamesProxyModel->getMaxPlayersFilterMin());
     maxPlayersFilterMinLabel->setBuddy(maxPlayersFilterMinSpinBox);
 
-    QLabel *maxPlayersFilterMaxLabel = new QLabel(tr("at &most:"));
+    auto *maxPlayersFilterMaxLabel = new QLabel(tr("at &most:"));
     maxPlayersFilterMaxSpinBox = new QSpinBox;
     maxPlayersFilterMaxSpinBox->setMinimum(1);
     maxPlayersFilterMaxSpinBox->setMaximum(99);
     maxPlayersFilterMaxSpinBox->setValue(gamesProxyModel->getMaxPlayersFilterMax());
     maxPlayersFilterMaxLabel->setBuddy(maxPlayersFilterMaxSpinBox);
 
-    QGridLayout *maxPlayersFilterLayout = new QGridLayout;
+    auto *maxPlayersFilterLayout = new QGridLayout;
     maxPlayersFilterLayout->addWidget(maxPlayersFilterMinLabel, 0, 0);
     maxPlayersFilterLayout->addWidget(maxPlayersFilterMinSpinBox, 0, 1);
     maxPlayersFilterLayout->addWidget(maxPlayersFilterMaxLabel, 1, 0);
     maxPlayersFilterLayout->addWidget(maxPlayersFilterMaxSpinBox, 1, 1);
 
-    QGroupBox *maxPlayersGroupBox = new QGroupBox(tr("Maximum player count"));
+    auto *maxPlayersGroupBox = new QGroupBox(tr("Maximum player count"));
     maxPlayersGroupBox->setLayout(maxPlayersFilterLayout);
 
-    QGridLayout *restrictionsLayout = new QGridLayout;
+    auto *restrictionsLayout = new QGridLayout;
     restrictionsLayout->addWidget(unavailableGamesVisibleCheckBox, 0, 0);
     restrictionsLayout->addWidget(showPasswordProtectedGames, 1, 0);
     restrictionsLayout->addWidget(showBuddiesOnlyGames, 2, 0);
     restrictionsLayout->addWidget(hideIgnoredUserGames, 3, 0);
 
-    QGroupBox *restrictionsGroupBox = new QGroupBox(tr("Restrictions"));
+    auto *restrictionsGroupBox = new QGroupBox(tr("Restrictions"));
     restrictionsGroupBox->setLayout(restrictionsLayout);
 
     spectatorsCanWatch = new QCheckBox(tr("Show games &spectators can watch"));
@@ -125,37 +125,37 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     spectatorsCanSeeHands->setChecked(true);  // DO NOT SUBMIT get from storage
     toggleSpectatorCheckboxEnabledness(getSpectatorsCanWatch());
 
-    QGridLayout *spectatorsLayout = new QGridLayout;
+    auto *spectatorsLayout = new QGridLayout;
     spectatorsLayout->addWidget(spectatorsCanWatch, 0, 0);
     spectatorsLayout->addWidget(spectatorsNeedPassword, 1, 0);
     spectatorsLayout->addWidget(spectatorsCanChat, 2, 0);
     spectatorsLayout->addWidget(spectatorsCanSeeHands, 3, 0);
 
-    QGroupBox *spectatorsGroupBox = new QGroupBox(tr("Spectators"));
+    auto *spectatorsGroupBox = new QGroupBox(tr("Spectators"));
     spectatorsGroupBox->setLayout(spectatorsLayout);
 
-    QGridLayout *leftGrid = new QGridLayout;
+    auto *leftGrid = new QGridLayout;
     leftGrid->addWidget(generalGroupBox, 0, 0, 1, 2);
     leftGrid->addWidget(maxPlayersGroupBox, 2, 0, 1, 2);
     leftGrid->addWidget(restrictionsGroupBox, 3, 0, 1, 2);
     leftGrid->addWidget(spectatorsGroupBox, 4, 0, 1, 2);
 
-    QVBoxLayout *leftColumn = new QVBoxLayout;
+    auto *leftColumn = new QVBoxLayout;
     leftColumn->addLayout(leftGrid);
     leftColumn->addStretch();
 
-    QVBoxLayout *rightColumn = new QVBoxLayout;
+    auto *rightColumn = new QVBoxLayout;
     rightColumn->addWidget(gameTypeFilterGroupBox);
 
-    QHBoxLayout *hbox = new QHBoxLayout;
+    auto *hbox = new QHBoxLayout;
     hbox->addLayout(leftColumn);
     hbox->addLayout(rightColumn);
 
-    QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    auto *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
     connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
 
-    QVBoxLayout *mainLayout = new QVBoxLayout;
+    auto *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(hbox);
     mainLayout->addWidget(buttonBox);
 

--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -113,10 +113,32 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     QGroupBox *restrictionsGroupBox = new QGroupBox(tr("Restrictions"));
     restrictionsGroupBox->setLayout(restrictionsLayout);
 
+    spectatorsCanWatch = new QCheckBox(tr("Show games &spectators can watch"));
+    spectatorsCanWatch->setChecked(true);  // DO NOT SUBMIT get from storage
+    connect(spectatorsCanWatch, SIGNAL(toggled(bool)), this, SLOT(toggleSpectatorCheckboxEnabledness(bool)));
+
+    spectatorsNeedPassword = new QCheckBox(tr("Show if spectators need password"));
+    spectatorsNeedPassword->setChecked(true);  // DO NOT SUBMIT get from storage
+    spectatorsCanChat = new QCheckBox(tr("Show if spectators can chat"));
+    spectatorsCanChat->setChecked(true);  // DO NOT SUBMIT get from storage
+    spectatorsCanSeeHands = new QCheckBox(tr("Show if spectators can see hands"));
+    spectatorsCanSeeHands->setChecked(true);  // DO NOT SUBMIT get from storage
+    toggleSpectatorCheckboxEnabledness(getSpectatorsCanWatch());
+
+    QGridLayout *spectatorsLayout = new QGridLayout;
+    spectatorsLayout->addWidget(spectatorsCanWatch, 0, 0);
+    spectatorsLayout->addWidget(spectatorsNeedPassword, 1, 0);
+    spectatorsLayout->addWidget(spectatorsCanChat, 2, 0);
+    spectatorsLayout->addWidget(spectatorsCanSeeHands, 3, 0);
+
+    QGroupBox *spectatorsGroupBox = new QGroupBox(tr("Spectators"));
+    spectatorsGroupBox->setLayout(spectatorsLayout);
+
     QGridLayout *leftGrid = new QGridLayout;
     leftGrid->addWidget(generalGroupBox, 0, 0, 1, 2);
     leftGrid->addWidget(maxPlayersGroupBox, 2, 0, 1, 2);
     leftGrid->addWidget(restrictionsGroupBox, 3, 0, 1, 2);
+    leftGrid->addWidget(spectatorsGroupBox, 4, 0, 1, 2);
 
     QVBoxLayout *leftColumn = new QVBoxLayout;
     leftColumn->addLayout(leftGrid);
@@ -144,6 +166,13 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
 void DlgFilterGames::actOk()
 {
     accept();
+}
+
+void DlgFilterGames::toggleSpectatorCheckboxEnabledness(bool spectatorsEnabled)
+{
+    spectatorsNeedPassword->setDisabled(!spectatorsEnabled);
+    spectatorsCanChat->setDisabled(!spectatorsEnabled);
+    spectatorsCanSeeHands->setDisabled(!spectatorsEnabled);
 }
 
 bool DlgFilterGames::getUnavailableGamesVisible() const
@@ -251,4 +280,9 @@ void DlgFilterGames::setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlaye
     maxPlayersFilterMinSpinBox->setValue(_maxPlayersFilterMin);
     maxPlayersFilterMaxSpinBox->setValue(_maxPlayersFilterMax == -1 ? maxPlayersFilterMaxSpinBox->maximum()
                                                                     : _maxPlayersFilterMax);
+}
+
+int DlgFilterGames::getSpectatorsCanWatch() const
+{
+    return spectatorsCanWatch->isEnabled() && spectatorsCanWatch->isChecked();
 }

--- a/cockatrice/src/dlg_filter_games.h
+++ b/cockatrice/src/dlg_filter_games.h
@@ -22,7 +22,8 @@ class DlgFilterGames : public QDialog
 private:
     QGroupBox *generalGroupBox;
     QCheckBox *showBuddiesOnlyGames;
-    QCheckBox *unavailableGamesVisibleCheckBox;
+    QCheckBox *showFullGames;
+    QCheckBox *showGamesThatStarted;
     QCheckBox *showPasswordProtectedGames;
     QCheckBox *hideIgnoredUserGames;
     QLineEdit *gameNameFilterEdit;
@@ -49,8 +50,8 @@ public:
                    const GamesProxyModel *_gamesProxyModel,
                    QWidget *parent = nullptr);
 
-    bool getUnavailableGamesVisible() const;
-    void setUnavailableGamesVisible(bool _unavailableGamesVisible);
+    bool getShowFullGames() const;
+    bool getShowGamesThatStarted() const;
     bool getShowPasswordProtectedGames() const;
     void setShowPasswordProtectedGames(bool _passwordProtectedGamesHidden);
     bool getShowBuddiesOnlyGames() const;

--- a/cockatrice/src/dlg_filter_games.h
+++ b/cockatrice/src/dlg_filter_games.h
@@ -32,11 +32,17 @@ private:
     QSpinBox *maxPlayersFilterMaxSpinBox;
     QComboBox *maxGameAgeComboBox;
 
+    QCheckBox *spectatorsCanWatch;
+    QCheckBox *spectatorsNeedPassword;
+    QCheckBox *spectatorsCanChat;
+    QCheckBox *spectatorsCanSeeHands;
+
     const QMap<int, QString> &allGameTypes;
     const GamesProxyModel *gamesProxyModel;
 
 private slots:
     void actOk();
+    void toggleSpectatorCheckboxEnabledness(bool spectatorsEnabled);
 
 public:
     DlgFilterGames(const QMap<int, QString> &_allGameTypes,
@@ -62,6 +68,7 @@ public:
     void setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlayersFilterMax);
     const QTime &getMaxGameAge() const;
     const QMap<QTime, QString> gameAgeMap;
+    int getSpectatorsCanWatch() const;
 };
 
 #endif

--- a/cockatrice/src/dlg_filter_games.h
+++ b/cockatrice/src/dlg_filter_games.h
@@ -32,10 +32,10 @@ private:
     QSpinBox *maxPlayersFilterMaxSpinBox;
     QComboBox *maxGameAgeComboBox;
 
-    QCheckBox *spectatorsCanWatch;
-    QCheckBox *spectatorsNeedPassword;
-    QCheckBox *spectatorsCanChat;
-    QCheckBox *spectatorsCanSeeHands;
+    QCheckBox *showOnlyIfSpectatorsCanWatch;
+    QCheckBox *showSpectatorPasswordProtected;
+    QCheckBox *showOnlyIfSpectatorsCanChat;
+    QCheckBox *showOnlyIfSpectatorsCanSeeHands;
 
     const QMap<int, QString> &allGameTypes;
     const GamesProxyModel *gamesProxyModel;
@@ -68,7 +68,10 @@ public:
     void setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlayersFilterMax);
     const QTime &getMaxGameAge() const;
     const QMap<QTime, QString> gameAgeMap;
-    int getSpectatorsCanWatch() const;
+    bool getShowOnlyIfSpectatorsCanWatch() const;
+    bool getShowSpectatorPasswordProtected() const;
+    bool getShowOnlyIfSpectatorsCanChat() const;
+    bool getShowOnlyIfSpectatorsCanSeeHands() const;
 };
 
 #endif

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -152,7 +152,8 @@ void GameSelector::actSetFilter()
         return;
 
     gameListProxyModel->setShowBuddiesOnlyGames(dlg.getShowBuddiesOnlyGames());
-    gameListProxyModel->setUnavailableGamesVisible(dlg.getUnavailableGamesVisible());
+    gameListProxyModel->setShowFullGames(dlg.getShowFullGames());
+    gameListProxyModel->setShowGamesThatStarted(dlg.getShowGamesThatStarted());
     gameListProxyModel->setShowPasswordProtectedGames(dlg.getShowPasswordProtectedGames());
     gameListProxyModel->setHideIgnoredUserGames(dlg.getHideIgnoredUserGames());
     gameListProxyModel->setGameNameFilter(dlg.getGameNameFilter());

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -160,6 +160,10 @@ void GameSelector::actSetFilter()
     gameListProxyModel->setGameTypeFilter(dlg.getGameTypeFilter());
     gameListProxyModel->setMaxPlayersFilter(dlg.getMaxPlayersFilterMin(), dlg.getMaxPlayersFilterMax());
     gameListProxyModel->setMaxGameAge(dlg.getMaxGameAge());
+    gameListProxyModel->setShowOnlyIfSpectatorsCanWatch(dlg.getShowOnlyIfSpectatorsCanWatch());
+    gameListProxyModel->setShowSpectatorPasswordProtected(dlg.getShowSpectatorPasswordProtected());
+    gameListProxyModel->setShowOnlyIfSpectatorsCanChat(dlg.getShowOnlyIfSpectatorsCanChat());
+    gameListProxyModel->setShowOnlyIfSpectatorsCanSeeHands(dlg.getShowOnlyIfSpectatorsCanSeeHands());
     gameListProxyModel->saveFilterParameters(gameTypeMap);
 
     clearFilterButton->setEnabled(!gameListProxyModel->areFilterParametersSetToDefaults());

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -27,7 +27,7 @@ const bool DEFAULT_UNAVAILABLE_GAMES_VISIBLE = false;
 const bool DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES = true;
 const bool DEFAULT_SHOW_BUDDIES_ONLY_GAMES = true;
 const bool DEFAULT_HIDE_IGNORED_USER_GAMES = false;
-const bool DEFAULT_SHOW_ONLY_IF_SPECTATORS_CAN_WATCH = true;
+const bool DEFAULT_SHOW_ONLY_IF_SPECTATORS_CAN_WATCH = false;
 const bool DEFAULT_SHOW_SPECTATOR_PASSWORD_PROTECTED = true;
 const bool DEFAULT_SHOW_ONLY_IF_SPECTATORS_CAN_CHAT = false;
 const bool DEFAULT_SHOW_ONLY_IF_SPECTATORS_CAN_SEE_HANDS = false;
@@ -528,8 +528,7 @@ bool GamesProxyModel::filterAcceptsRow(int sourceRow) const
         }
     }
 
-    if (showOnlyIfSpectatorsCanWatch)
-    {
+    if (showOnlyIfSpectatorsCanWatch) {
         if (!game.spectators_allowed())
             return false;
         if (!showSpectatorPasswordProtected && game.spectators_need_password())

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -80,7 +80,8 @@ private:
     // - filterAcceptsRow()
     bool showBuddiesOnlyGames;
     bool hideIgnoredUserGames;
-    bool unavailableGamesVisible;
+    bool showFullGames;
+    bool showGamesThatStarted;
     bool showPasswordProtectedGames;
     QString gameNameFilter, creatorNameFilter;
     QSet<int> gameTypeFilter;
@@ -102,11 +103,16 @@ public:
         return hideIgnoredUserGames;
     }
     void setHideIgnoredUserGames(bool _hideIgnoredUserGames);
-    bool getUnavailableGamesVisible() const
+    bool getShowFullGames() const
     {
-        return unavailableGamesVisible;
+        return showFullGames;
     }
-    void setUnavailableGamesVisible(bool _unavailableGamesVisible);
+    void setShowFullGames(bool _showFullGames);
+    bool getShowGamesThatStarted() const
+    {
+        return showGamesThatStarted;
+    }
+    void setShowGamesThatStarted(bool _showGamesThatStarted);
     bool getShowPasswordProtectedGames() const
     {
         return showPasswordProtectedGames;

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -86,6 +86,8 @@ private:
     QSet<int> gameTypeFilter;
     quint32 maxPlayersFilterMin, maxPlayersFilterMax;
     QTime maxGameAge;
+    bool showOnlyIfSpectatorsCanWatch, showSpectatorPasswordProtected, showOnlyIfSpectatorsCanChat,
+        showOnlyIfSpectatorsCanSeeHands;
 
 public:
     GamesProxyModel(QObject *parent = nullptr, const TabSupervisor *_tabSupervisor = nullptr);
@@ -139,6 +141,26 @@ public:
         return maxGameAge;
     }
     void setMaxGameAge(const QTime &_maxGameAge);
+    bool getShowOnlyIfSpectatorsCanWatch() const
+    {
+        return showOnlyIfSpectatorsCanWatch;
+    }
+    void setShowOnlyIfSpectatorsCanWatch(bool _showOnlyIfSpectatorsCanWatch);
+    bool getShowSpectatorPasswordProtected() const
+    {
+        return showSpectatorPasswordProtected;
+    }
+    void setShowSpectatorPasswordProtected(bool _showSpectatorPasswordProtected);
+    bool getShowOnlyIfSpectatorsCanChat() const
+    {
+        return showOnlyIfSpectatorsCanChat;
+    }
+    void setShowOnlyIfSpectatorsCanChat(bool _showOnlyIfSpectatorsCanChat);
+    bool getShowOnlyIfSpectatorsCanSeeHands() const
+    {
+        return showOnlyIfSpectatorsCanSeeHands;
+    }
+    void setShowOnlyIfSpectatorsCanSeeHands(bool _showOnlyIfSpectatorsCanSeeHands);
 
     int getNumFilteredGames() const;
     void resetFilterParameters();

--- a/cockatrice/src/settings/gamefilterssettings.cpp
+++ b/cockatrice/src/settings/gamefilterssettings.cpp
@@ -28,14 +28,25 @@ bool GameFiltersSettings::isShowBuddiesOnlyGames()
     return previous == QVariant() ? true : previous.toBool();
 }
 
-void GameFiltersSettings::setUnavailableGamesVisible(bool enabled)
+void GameFiltersSettings::setShowFullGames(bool show)
 {
-    setValue(enabled, "unavailable_games_visible", "filter_games");
+    setValue(show, "show_full_games", "filter_games");
 }
 
-bool GameFiltersSettings::isUnavailableGamesVisible()
+bool GameFiltersSettings::isShowFullGames()
 {
-    QVariant previous = getValue("unavailable_games_visible", "filter_games");
+    QVariant previous = getValue("show_full_games", "filter_games");
+    return previous == QVariant() ? false : previous.toBool();
+}
+
+void GameFiltersSettings::setShowGamesThatStarted(bool show)
+{
+    setValue(show, "show_games_that_started", "filter_games");
+}
+
+bool GameFiltersSettings::isShowGamesThatStarted()
+{
+    QVariant previous = getValue("show_games_that_started", "filter_games");
     return previous == QVariant() ? false : previous.toBool();
 }
 

--- a/cockatrice/src/settings/gamefilterssettings.cpp
+++ b/cockatrice/src/settings/gamefilterssettings.cpp
@@ -138,7 +138,7 @@ void GameFiltersSettings::setShowOnlyIfSpectatorsCanWatch(bool show)
 bool GameFiltersSettings::isShowOnlyIfSpectatorsCanWatch()
 {
     QVariant previous = getValue("show_only_if_spectators_can_watch", "filter_games");
-    return previous == QVariant() ? true : previous.toBool();
+    return previous == QVariant() ? false : previous.toBool();
 }
 
 void GameFiltersSettings::setShowSpectatorPasswordProtected(bool show)

--- a/cockatrice/src/settings/gamefilterssettings.cpp
+++ b/cockatrice/src/settings/gamefilterssettings.cpp
@@ -129,3 +129,47 @@ bool GameFiltersSettings::isGameTypeEnabled(QString gametype)
     QVariant previous = getValue("game_type/" + hashGameType(gametype), "filter_games");
     return previous == QVariant() ? false : previous.toBool();
 }
+
+void GameFiltersSettings::setShowOnlyIfSpectatorsCanWatch(bool show)
+{
+    setValue(show, "show_only_if_spectators_can_watch", "filter_games");
+}
+
+bool GameFiltersSettings::isShowOnlyIfSpectatorsCanWatch()
+{
+    QVariant previous = getValue("show_only_if_spectators_can_watch", "filter_games");
+    return previous == QVariant() ? true : previous.toBool();
+}
+
+void GameFiltersSettings::setShowSpectatorPasswordProtected(bool show)
+{
+    setValue(show, "show_spectator_password_protected", "filter_games");
+}
+
+bool GameFiltersSettings::isShowSpectatorPasswordProtected()
+{
+    QVariant previous = getValue("show_spectator_password_protected", "filter_games");
+    return previous == QVariant() ? true : previous.toBool();
+}
+
+void GameFiltersSettings::setShowOnlyIfSpectatorsCanChat(bool show)
+{
+    setValue(show, "show_only_if_spectators_can_chat", "filter_games");
+}
+
+bool GameFiltersSettings::isShowOnlyIfSpectatorsCanChat()
+{
+    QVariant previous = getValue("show_only_if_spectators_can_chat", "filter_games");
+    return previous == QVariant() ? true : previous.toBool();
+}
+
+void GameFiltersSettings::setShowOnlyIfSpectatorsCanSeeHands(bool show)
+{
+    setValue(show, "show_only_if_spectators_can_see_hands", "filter_games");
+}
+
+bool GameFiltersSettings::isShowOnlyIfSpectatorsCanSeeHands()
+{
+    QVariant previous = getValue("show_only_if_spectators_can_see_hands", "filter_games");
+    return previous == QVariant() ? true : previous.toBool();
+}

--- a/cockatrice/src/settings/gamefilterssettings.h
+++ b/cockatrice/src/settings/gamefilterssettings.h
@@ -19,6 +19,10 @@ public:
     int getMaxPlayers();
     QTime getMaxGameAge();
     bool isGameTypeEnabled(QString gametype);
+    bool isShowOnlyIfSpectatorsCanWatch();
+    bool isShowSpectatorPasswordProtected();
+    bool isShowOnlyIfSpectatorsCanChat();
+    bool isShowOnlyIfSpectatorsCanSeeHands();
 
     void setShowBuddiesOnlyGames(bool show);
     void setHideIgnoredUserGames(bool hide);
@@ -31,6 +35,10 @@ public:
     void setMaxGameAge(const QTime &maxGameAge);
     void setGameTypeEnabled(QString gametype, bool enabled);
     void setGameHashedTypeEnabled(QString gametypeHASHED, bool enabled);
+    void setShowOnlyIfSpectatorsCanWatch(bool show);
+    void setShowSpectatorPasswordProtected(bool show);
+    void setShowOnlyIfSpectatorsCanChat(bool show);
+    void setShowOnlyIfSpectatorsCanSeeHands(bool show);
 signals:
 
 public slots:

--- a/cockatrice/src/settings/gamefilterssettings.h
+++ b/cockatrice/src/settings/gamefilterssettings.h
@@ -10,7 +10,8 @@ class GameFiltersSettings : public SettingsManager
 
 public:
     bool isShowBuddiesOnlyGames();
-    bool isUnavailableGamesVisible();
+    bool isShowFullGames();
+    bool isShowGamesThatStarted();
     bool isShowPasswordProtectedGames();
     bool isHideIgnoredUserGames();
     QString getGameNameFilter();
@@ -26,7 +27,8 @@ public:
 
     void setShowBuddiesOnlyGames(bool show);
     void setHideIgnoredUserGames(bool hide);
-    void setUnavailableGamesVisible(bool enabled);
+    void setShowFullGames(bool show);
+    void setShowGamesThatStarted(bool show);
     void setShowPasswordProtectedGames(bool show);
     void setGameNameFilter(QString gameName);
     void setCreatorNameFilter(QString creatorName);

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -95,7 +95,8 @@ void SettingsCache::translateLegacySettings()
 
     // Game filters
     legacySetting.beginGroup("filter_games");
-    gameFilters().setUnavailableGamesVisible(legacySetting.value("unavailable_games_visible").toBool());
+    gameFilters().setShowFullGames(legacySetting.value("unavailable_games_visible").toBool());
+    gameFilters().setShowGamesThatStarted(legacySetting.value("unavailable_games_visible").toBool());
     gameFilters().setShowPasswordProtectedGames(legacySetting.value("show_password_protected_games").toBool());
     gameFilters().setGameNameFilter(legacySetting.value("game_name_filter").toString());
     gameFilters().setShowBuddiesOnlyGames(legacySetting.value("show_buddies_only_games").toBool());


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2431
- Fixes #388 
- Splits "unavailable" into full/started per #2642 but does not yet split out registered/unregistered users

## Short roundup of the initial problem
Users want to be able to filter games by spectator attributes (are spectators allowed, is password required, can spectators chat, can spectators see hands).

## What will change with this Pull Request?
Add UI and settings plumbing for spectator attribute filtering, see screenshots below.

## Screenshots
Latest:
<img width="631" alt="Screen Shot 2020-10-14 at 11 09 39 PM" src="https://user-images.githubusercontent.com/63179146/96072731-eb334b00-0e72-11eb-8c3e-a74e4d08f334.png">

### Old screenshots
For draft, initial settings filter to show only if spectators can watch (this is easily changed, just proof of concept).
<img width="921" alt="Screen Shot 2020-10-03 at 9 18 33 PM" src="https://user-images.githubusercontent.com/63179146/95004814-3a999180-05be-11eb-9cfd-3ccb5e4a2388.png">

If show-only-if-spectators-can-watch is deselected, the remaining spectator-related filters are disabled in the UI. They are also ignored when actually filtering games.
<img width="920" alt="Screen Shot 2020-10-03 at 9 18 52 PM" src="https://user-images.githubusercontent.com/63179146/95004827-61f05e80-05be-11eb-9608-3847963da326.png">

