### PR TITLE
add face down to the string if the card is face down

### DIFF
--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -316,7 +316,11 @@ void MessageLogWidget::logMoveCard(Player *player,
     bool usesNewX = false;
     if (targetZoneName == tableConstant()) {
         soundEngine->playSound("play_card");
-        finalStr = tr("%1 puts %2 into play%3.");
+        if (card->getFaceDown()) {
+            finalStr = tr("%1 puts %2 into play%3 face down.");
+        } else {
+            finalStr = tr("%1 puts %2 into play%3.");
+        }
     } else if (targetZoneName == graveyardConstant()) {
         finalStr = tr("%1 puts %2%3 into their graveyard.");
     } else if (targetZoneName == exileConstant()) {


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2738

## Short roundup of the initial problem
cards in log could specify if they're face down

## What will change with this Pull Request?
- cards in the log specify if they are face down when played

## Screenshots
![image](https://user-images.githubusercontent.com/36401181/95031050-043e3e00-06b4-11eb-9ab5-cbd3df129706.png)
