### PR TITLE
Guess card names on plain text imports

### DIFF
--- a/cockatrice/src/carddatabase.h
+++ b/cockatrice/src/carddatabase.h
@@ -409,6 +409,7 @@ public:
     void removeCard(CardInfoPtr card);
     CardInfoPtr getCard(const QString &cardName) const;
     QList<CardInfoPtr> getCards(const QStringList &cardNames) const;
+    CardInfoPtr guessCard(const QString &cardName) const;
 
     /*
      * Get a card by its simple name. The name will be simplified in this

--- a/cockatrice/src/cardframe.cpp
+++ b/cockatrice/src/cardframe.cpp
@@ -107,7 +107,7 @@ void CardFrame::setCard(CardInfoPtr card)
 
 void CardFrame::setCard(const QString &cardName)
 {
-    setCard(db->getCardBySimpleName(cardName));
+    setCard(db->guessCard(cardName));
 }
 
 void CardFrame::setCard(AbstractCardItem *card)

--- a/cockatrice/src/cardinfowidget.cpp
+++ b/cockatrice/src/cardinfowidget.cpp
@@ -65,9 +65,10 @@ void CardInfoWidget::setCard(CardInfoPtr card)
 
 void CardInfoWidget::setCard(const QString &cardName)
 {
-    setCard(db->getCardBySimpleName(cardName));
-    if (!info)
+    setCard(db->guessCard(cardName));
+    if (info == nullptr) {
         text->setInvalidCardName(cardName);
+    }
 }
 
 void CardInfoWidget::setCard(AbstractCardItem *card)

--- a/cockatrice/src/deck_loader.cpp
+++ b/cockatrice/src/deck_loader.cpp
@@ -291,7 +291,7 @@ QString DeckLoader::getCardZoneFromName(QString cardName, QString currentZoneNam
 QString DeckLoader::getCompleteCardName(const QString cardName) const
 {
     if (db) {
-        CardInfoPtr temp = db->getCardBySimpleName(cardName);
+        CardInfoPtr temp = db->guessCard(cardName);
         if (temp) {
             return temp->getName();
         }

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1242,7 +1242,7 @@ void Player::actCreateToken()
 
     lastTokenName = dlg.getName();
     lastTokenPT = dlg.getPT();
-    CardInfoPtr correctedCard = db->getCardBySimpleName(lastTokenName);
+    CardInfoPtr correctedCard = db->guessCard(lastTokenName);
     if (correctedCard) {
         lastTokenName = correctedCard->getName();
         lastTokenTableRow = TableZone::clampValidTableRow(2 - correctedCard->getTableRow());


### PR DESCRIPTION
## Related Ticket(s)
- Fixes part of https://github.com/dr4fters/dr4ft/issues/1242 but the deck hash will not match

## Short roundup of the initial problem
plaintext import sometimes breaks when a card is using the wrong format for split cards

further suggestions for improvements would be to take the left hand side if the right hand side is given and to hide right hand sides in the deck editor

## What will change with this Pull Request?
- modify up the simplifyCardName function to ignore right halves
- add guessCard function that prioritises full card names the simple ones
-  fix imports for misformatted split cards or double faced cards
- introduces a small concession: not completely formatted names with a
    shared name on the left side will get mixed up, eg "bind" but not "Bind"
  - this should be fine considering how this would fix a lot more cards