### PR TITLE
Fix infinite loop when card file save fails

### DIFF
--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -607,35 +607,31 @@ void SaveSetsPage::updateTotalProgress(int cardsImported, int /* setIndex */, co
 
 bool SaveSetsPage::validatePage()
 {
-    bool ok = false;
     QString defaultPath = SettingsCache::instance().getCardDatabasePath();
     QString windowName = tr("Save card database");
     QString fileType = tr("XML; card database (*.xml)");
 
-    do {
-        QString fileName;
-        if (defaultPathCheckBox->isChecked()) {
-            fileName = QFileDialog::getSaveFileName(this, windowName, defaultPath, fileType);
-        } else {
-            fileName = defaultPath;
-        }
+    QString fileName;
+    if (defaultPathCheckBox->isChecked()) {
+        fileName = QFileDialog::getSaveFileName(this, windowName, defaultPath, fileType);
+    } else {
+        fileName = defaultPath;
+    }
 
-        if (fileName.isEmpty()) {
-            return false;
-        }
+    if (fileName.isEmpty()) {
+        return false;
+    }
 
-        QFileInfo fi(fileName);
-        QDir fileDir(fi.path());
-        if (!fileDir.exists() && !fileDir.mkpath(fileDir.absolutePath())) {
-            return false;
-        }
+    QFileInfo fi(fileName);
+    QDir fileDir(fi.path());
+    if (!fileDir.exists() && !fileDir.mkpath(fileDir.absolutePath())) {
+        return false;
+    }
 
-        if (wizard()->importer->saveToFile(fileName, wizard()->getCardSourceUrl(), wizard()->getCardSourceVersion())) {
-            ok = true;
-        } else {
-            QMessageBox::critical(this, tr("Error"), tr("The file could not be saved to %1").arg(fileName));
-        }
-    } while (!ok);
+    if (!wizard()->importer->saveToFile(fileName, wizard()->getCardSourceUrl(), wizard()->getCardSourceVersion())) {
+        QMessageBox::critical(this, tr("Error"), tr("The file could not be saved to %1").arg(fileName));
+        return false;
+    }
 
     return true;
 }

--- a/oracle/src/pagetemplates.cpp
+++ b/oracle/src/pagetemplates.cpp
@@ -144,35 +144,31 @@ void SimpleDownloadFilePage::actDownloadFinished()
 
 bool SimpleDownloadFilePage::saveToFile()
 {
-    bool ok = false;
     QString defaultPath = getDefaultSavePath();
     QString windowName = getWindowTitle();
     QString fileType = getFileType();
 
-    do {
-        QString fileName;
-        if (defaultPathCheckBox->isChecked()) {
-            fileName = QFileDialog::getSaveFileName(this, windowName, defaultPath, fileType);
-        } else {
-            fileName = defaultPath;
-        }
+    QString fileName;
+    if (defaultPathCheckBox->isChecked()) {
+        fileName = QFileDialog::getSaveFileName(this, windowName, defaultPath, fileType);
+    } else {
+        fileName = defaultPath;
+    }
 
-        if (fileName.isEmpty()) {
-            return false;
-        }
+    if (fileName.isEmpty()) {
+        return false;
+    }
 
-        QFileInfo fi(fileName);
-        QDir fileDir(fi.path());
-        if (!fileDir.exists() && !fileDir.mkpath(fileDir.absolutePath())) {
-            return false;
-        }
+    QFileInfo fi(fileName);
+    QDir fileDir(fi.path());
+    if (!fileDir.exists() && !fileDir.mkpath(fileDir.absolutePath())) {
+        return false;
+    }
 
-        if (internalSaveToFile(fileName)) {
-            ok = true;
-        } else {
-            QMessageBox::critical(this, tr("Error"), tr("The file could not be saved to %1").arg(fileName));
-        }
-    } while (!ok);
+    if (!internalSaveToFile(fileName)) {
+        QMessageBox::critical(this, tr("Error"), tr("The file could not be saved to %1").arg(fileName));
+        return false;
+    }
 
     // clean saved downloadData
     downloadData = QByteArray();


### PR DESCRIPTION

## Related Ticket(s)
- Fixes #4069 

## Short roundup of the initial problem

There are some scenario (when locking the cards.xml file for example) where you can't save the cards.xml file and you are stuck in a loop on error popup.

## What will change with this Pull Request?
- this removes the infinite loop. Instead, it just put the user back to the page with the same button, making him able to re-click on save when the conditions are more appropriate.


