### PR TITLE
Multiple background images on all zones

### DIFF
--- a/cockatrice/src/handzone.cpp
+++ b/cockatrice/src/handzone.cpp
@@ -83,7 +83,6 @@ void HandZone::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*optio
         brush = themeManager->getExtraHandBgBrush(QString::number(player->getZoneId()), brush);
     }
     painter->fillRect(boundingRect(), brush);
-    // painter->fillRect(boundingRect(), themeManager->getHandBgBrush());
 }
 
 void HandZone::reorganizeCards()

--- a/cockatrice/src/handzone.cpp
+++ b/cockatrice/src/handzone.cpp
@@ -76,7 +76,14 @@ QRectF HandZone::boundingRect() const
 
 void HandZone::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
 {
-    painter->fillRect(boundingRect(), themeManager->getHandBgBrush());
+    QBrush brush = themeManager->getHandBgBrush();
+
+    if (player->getZoneId() > 0) {
+        // If the extra image is not found, load the default one
+        brush = themeManager->getExtraHandBgBrush(QString::number(player->getZoneId()), brush);
+    }
+    painter->fillRect(boundingRect(), brush);
+    // painter->fillRect(boundingRect(), themeManager->getHandBgBrush());
 }
 
 void HandZone::reorganizeCards()

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -90,7 +90,6 @@ void PlayerArea::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*opt
         brush = themeManager->getExtraPlayerBgBrush(QString::number(playerZoneId), brush);
     }
     painter->fillRect(boundingRect(), brush);
-    // painter->fillRect(bRect, themeManager->getPlayerBgBrush());
 }
 
 void PlayerArea::setSize(qreal width, qreal height)

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -83,13 +83,25 @@ void PlayerArea::updateBg()
 
 void PlayerArea::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
 {
-    painter->fillRect(bRect, themeManager->getPlayerBgBrush());
+    QBrush brush = themeManager->getPlayerBgBrush();
+
+    if (playerZoneId > 0) {
+        // If the extra image is not found, load the default one
+        brush = themeManager->getExtraPlayerBgBrush(QString::number(playerZoneId), brush);
+    }
+    painter->fillRect(boundingRect(), brush);
+    // painter->fillRect(bRect, themeManager->getPlayerBgBrush());
 }
 
 void PlayerArea::setSize(qreal width, qreal height)
 {
     prepareGeometryChange();
     bRect = QRectF(0, 0, width, height);
+}
+
+void PlayerArea::setPlayerZoneId(int _playerZoneId)
+{
+    playerZoneId = _playerZoneId;
 }
 
 Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, TabGame *_parent)
@@ -3266,6 +3278,7 @@ void Player::setConceded(bool _conceded)
 void Player::setZoneId(int _zoneId)
 {
     zoneId = _zoneId;
+    playerArea->setPlayerZoneId(_zoneId);
 }
 
 void Player::setMirrored(bool _mirrored)

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -73,6 +73,7 @@ class PlayerArea : public QObject, public QGraphicsItem
     Q_INTERFACES(QGraphicsItem)
 private:
     QRectF bRect;
+    int playerZoneId;
 private slots:
     void updateBg();
 
@@ -94,6 +95,12 @@ public:
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
     void setSize(qreal width, qreal height);
+
+    void setPlayerZoneId(int _playerZoneId);
+    int getPlayerZoneId() const
+    {
+        return playerZoneId;
+    }
 };
 
 class Player : public QObject, public QGraphicsItem

--- a/cockatrice/src/stackzone.cpp
+++ b/cockatrice/src/stackzone.cpp
@@ -47,7 +47,13 @@ QRectF StackZone::boundingRect() const
 
 void StackZone::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
 {
-    painter->fillRect(boundingRect(), themeManager->getStackBgBrush());
+    QBrush brush = themeManager->getStackBgBrush();
+
+    if (player->getZoneId() > 0) {
+        // If the extra image is not found, load the default one
+        brush = themeManager->getExtraStackBgBrush(QString::number(player->getZoneId()), brush);
+    }
+    painter->fillRect(boundingRect(), brush);
 }
 
 void StackZone::handleDropEvent(const QList<CardDragItem *> &dragItems,

--- a/cockatrice/src/thememanager.cpp
+++ b/cockatrice/src/thememanager.cpp
@@ -118,6 +118,7 @@ void ThemeManager::themeChangedSlot()
     playerBgBrush = loadBrush(PLAYERZONE_BG_NAME, QColor(200, 200, 200));
     stackBgBrush = loadBrush(STACKZONE_BG_NAME, QColor(113, 43, 43));
     tableBgBrushesCache.clear();
+    stackBgBrushesCache.clear();
 
     QPixmapCache::clear();
 
@@ -133,6 +134,20 @@ QBrush ThemeManager::getExtraTableBgBrush(QString extraNumber, QBrush &fallbackB
         tableBgBrushesCache.insert(extraNumber.toInt(), returnBrush);
     } else {
         returnBrush = tableBgBrushesCache.value(extraNumber.toInt());
+    }
+
+    return returnBrush;
+}
+
+QBrush ThemeManager::getExtraStackBgBrush(QString extraNumber, QBrush &fallbackBrush)
+{
+    QBrush returnBrush;
+
+    if (!stackBgBrushesCache.contains(extraNumber.toInt())) {
+        returnBrush = loadExtraBrush(STACKZONE_BG_NAME + extraNumber, fallbackBrush);
+        stackBgBrushesCache.insert(extraNumber.toInt(), returnBrush);
+    } else {
+        returnBrush = stackBgBrushesCache.value(extraNumber.toInt());
     }
 
     return returnBrush;

--- a/cockatrice/src/thememanager.cpp
+++ b/cockatrice/src/thememanager.cpp
@@ -120,6 +120,7 @@ void ThemeManager::themeChangedSlot()
     tableBgBrushesCache.clear();
     stackBgBrushesCache.clear();
     playerBgBrushesCache.clear();
+    handBgBrushesCache.clear();
 
     QPixmapCache::clear();
 
@@ -163,6 +164,20 @@ QBrush ThemeManager::getExtraPlayerBgBrush(QString extraNumber, QBrush &fallback
         playerBgBrushesCache.insert(extraNumber.toInt(), returnBrush);
     } else {
         returnBrush = playerBgBrushesCache.value(extraNumber.toInt());
+    }
+
+    return returnBrush;
+}
+
+QBrush ThemeManager::getExtraHandBgBrush(QString extraNumber, QBrush &fallbackBrush)
+{
+    QBrush returnBrush;
+
+    if (!handBgBrushesCache.contains(extraNumber.toInt())) {
+        returnBrush = loadExtraBrush(HANDZONE_BG_NAME + extraNumber, fallbackBrush);
+        handBgBrushesCache.insert(extraNumber.toInt(), returnBrush);
+    } else {
+        returnBrush = handBgBrushesCache.value(extraNumber.toInt());
     }
 
     return returnBrush;

--- a/cockatrice/src/thememanager.cpp
+++ b/cockatrice/src/thememanager.cpp
@@ -119,6 +119,7 @@ void ThemeManager::themeChangedSlot()
     stackBgBrush = loadBrush(STACKZONE_BG_NAME, QColor(113, 43, 43));
     tableBgBrushesCache.clear();
     stackBgBrushesCache.clear();
+    playerBgBrushesCache.clear();
 
     QPixmapCache::clear();
 
@@ -148,6 +149,20 @@ QBrush ThemeManager::getExtraStackBgBrush(QString extraNumber, QBrush &fallbackB
         stackBgBrushesCache.insert(extraNumber.toInt(), returnBrush);
     } else {
         returnBrush = stackBgBrushesCache.value(extraNumber.toInt());
+    }
+
+    return returnBrush;
+}
+
+QBrush ThemeManager::getExtraPlayerBgBrush(QString extraNumber, QBrush &fallbackBrush)
+{
+    QBrush returnBrush;
+
+    if (!playerBgBrushesCache.contains(extraNumber.toInt())) {
+        returnBrush = loadExtraBrush(PLAYERZONE_BG_NAME + extraNumber, fallbackBrush);
+        playerBgBrushesCache.insert(extraNumber.toInt(), returnBrush);
+    } else {
+        returnBrush = playerBgBrushesCache.value(extraNumber.toInt());
     }
 
     return returnBrush;

--- a/cockatrice/src/thememanager.h
+++ b/cockatrice/src/thememanager.h
@@ -23,9 +23,9 @@ private:
     QBrush handBgBrush, stackBgBrush, tableBgBrush, playerBgBrush;
     QStringMap availableThemes;
     /*
-      Internal cache for table backgrounds
+      Internal cache for multiple backgrounds
     */
-    QBrushMap tableBgBrushesCache;
+    QBrushMap tableBgBrushesCache, stackBgBrushesCache;
 
 protected:
     void ensureThemeDirectoryExists();
@@ -51,6 +51,7 @@ public:
     }
     QStringMap &getAvailableThemes();
     QBrush getExtraTableBgBrush(QString extraNumber, QBrush &fallbackBrush);
+    QBrush getExtraStackBgBrush(QString extraNumber, QBrush &fallbackBrush);
 protected slots:
     void themeChangedSlot();
 signals:

--- a/cockatrice/src/thememanager.h
+++ b/cockatrice/src/thememanager.h
@@ -25,7 +25,7 @@ private:
     /*
       Internal cache for multiple backgrounds
     */
-    QBrushMap tableBgBrushesCache, stackBgBrushesCache, playerBgBrushesCache;
+    QBrushMap tableBgBrushesCache, stackBgBrushesCache, playerBgBrushesCache, handBgBrushesCache;
 
 protected:
     void ensureThemeDirectoryExists();
@@ -53,6 +53,7 @@ public:
     QBrush getExtraTableBgBrush(QString extraNumber, QBrush &fallbackBrush);
     QBrush getExtraStackBgBrush(QString extraNumber, QBrush &fallbackBrush);
     QBrush getExtraPlayerBgBrush(QString extraNumber, QBrush &fallbackBrush);
+    QBrush getExtraHandBgBrush(QString extraNumber, QBrush &fallbackBrush);
 protected slots:
     void themeChangedSlot();
 signals:

--- a/cockatrice/src/thememanager.h
+++ b/cockatrice/src/thememanager.h
@@ -25,7 +25,7 @@ private:
     /*
       Internal cache for multiple backgrounds
     */
-    QBrushMap tableBgBrushesCache, stackBgBrushesCache;
+    QBrushMap tableBgBrushesCache, stackBgBrushesCache, playerBgBrushesCache;
 
 protected:
     void ensureThemeDirectoryExists();
@@ -52,6 +52,7 @@ public:
     QStringMap &getAvailableThemes();
     QBrush getExtraTableBgBrush(QString extraNumber, QBrush &fallbackBrush);
     QBrush getExtraStackBgBrush(QString extraNumber, QBrush &fallbackBrush);
+    QBrush getExtraPlayerBgBrush(QString extraNumber, QBrush &fallbackBrush);
 protected slots:
     void themeChangedSlot();
 signals:


### PR DESCRIPTION
## Related Ticket(s)
- Related to #3985

## Short roundup of the initial problem
Now you may have a different tablezone background image for each player but not different handzones, playerzones or stackzones.

## What will change with this Pull Request?
With this you can have a different handzone, playerzone and stackzone background image for each player.

