### PR TITLE
Travis: go back to macOS 10.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,7 +159,7 @@ jobs:
     before_cache:
     - brew cleanup
 
-  #macOS Mojave
+  #macOS Mojave (additional build to offer Dark Mode support introduced in macOS 10.14)
   - name: macOS Mojave (Debug)
     if: tag IS NOT present
     os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -159,11 +159,11 @@ jobs:
     before_cache:
     - brew cleanup
 
-  #macOS Catalina
-  - name: macOS Catalina (Debug)
+  #macOS Mojave
+  - name: macOS Mojave (Debug)
     if: tag IS NOT present
     os: osx
-    osx_image: xcode11.6
+    osx_image: xcode11.3
     cache:
     - ccache
     - directories:
@@ -180,11 +180,11 @@ jobs:
     before_cache:
     - brew cleanup
 
-  - name: macOS Catalina (Release)
+  - name: macOS Mojave (Release)
     if: (branch = master AND NOT type = pull_request) OR tag IS present
     os: osx
-    osx_image: xcode11.6
-    env: OSX_VERSION=10.15
+    osx_image: xcode11.3
+    env: OSX_VERSION=10.14
     cache:
     - ccache
     - directories:


### PR DESCRIPTION
## Related Ticket(s)
- Related #4059

## Short roundup of the initial problem
As noticed in the last image update (https://github.com/Cockatrice/Cockatrice/pull/4059) users **need** to update their OS in order to keep using Dark Mode support with that change as the new 10.15 zip file will not work on 10.14 any longer! While the hardware requirements mostly don't prevent that, users on 10.14 suddenly still lost Dark Mode support when updating Cockatrice without knowing.
Our approach used to be to reach most users with our release binaries. Following that we should go back to 10.14 for our extra Dark Mode binary, users on Catalina can still use that one.

## What will change with this Pull Request?
- Update the travis images to use macOS 10.14 again with the most recent Xcode 11.3