### PR TITLE
Fix resizing for game filter dialog

### DIFF
--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -169,6 +169,8 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
 
     setLayout(mainLayout);
     setWindowTitle(tr("Filter games"));
+
+    setFixedHeight(sizeHint().height());
 }
 
 void DlgFilterGames::actOk()

--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -150,8 +150,10 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     auto *rightGrid = new QGridLayout;
     rightGrid->addWidget(gameTypeFilterGroupBox, 0, 0, 1, 1);
     rightGrid->addWidget(spectatorsGroupBox, 1, 0, 1, 1);
+
     auto *rightColumn = new QVBoxLayout;
     rightColumn->addLayout(rightGrid);
+    rightColumn->addStretch();
 
     auto *hbox = new QHBoxLayout;
     hbox->addLayout(leftColumn);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes https://github.com/Cockatrice/Cockatrice/issues/4148

## Short roundup of the initial problem
Dialog behaved weird on resizing.

## What will change with this Pull Request?
- Added a stretch element to the right "column" as well. Game types or spectator options will not stretch any longer
- As there is no reason in making the dialog longer, it's now always the suggested vertical size (same as the `Create game` dialog)

## Screenshots
- before:
![image](https://user-images.githubusercontent.com/36401181/96750302-17e3e700-13cc-11eb-822b-a7cd05f5537b.png)

- after:
with long list of game types
![stretchfixed](https://user-images.githubusercontent.com/9874850/97476170-63f3d600-194e-11eb-9fbc-543a500f18c4.png)

    with short list of games types
    ![stretchfix2](https://user-images.githubusercontent.com/9874850/97476480-b9c87e00-194e-11eb-8d8b-127169120802.png)
