### PR TITLE
Improve dialogs

### DIFF
--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -95,7 +95,7 @@ void DlgCreateGame::sharedCtor()
     grid->addWidget(generalGroupBox, 0, 0);
     grid->addWidget(joinRestrictionsGroupBox, 0, 1);
     grid->addWidget(gameTypeGroupBox, 1, 0);
-    grid->addWidget(spectatorsGroupBox, 1, 1, 2);
+    grid->addWidget(spectatorsGroupBox, 1, 1, Qt::AlignTop);
     grid->addWidget(rememberGameSettings, 2, 0);
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok);

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -95,7 +95,7 @@ void DlgCreateGame::sharedCtor()
     grid->addWidget(generalGroupBox, 0, 0);
     grid->addWidget(joinRestrictionsGroupBox, 0, 1);
     grid->addWidget(gameTypeGroupBox, 1, 0);
-    grid->addWidget(spectatorsGroupBox, 1, 1);
+    grid->addWidget(spectatorsGroupBox, 1, 1, -1);
     grid->addWidget(rememberGameSettings, 2, 0);
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok);

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -95,7 +95,7 @@ void DlgCreateGame::sharedCtor()
     grid->addWidget(generalGroupBox, 0, 0);
     grid->addWidget(joinRestrictionsGroupBox, 0, 1);
     grid->addWidget(gameTypeGroupBox, 1, 0);
-    grid->addWidget(spectatorsGroupBox, 1, 1, -1);
+    grid->addWidget(spectatorsGroupBox, 1, 1, 2);
     grid->addWidget(rememberGameSettings, 2, 0);
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok);

--- a/cockatrice/src/dlg_update.cpp
+++ b/cockatrice/src/dlg_update.cpp
@@ -52,6 +52,9 @@ DlgUpdate::DlgUpdate(QWidget *parent) : QDialog(parent)
     parentLayout->addWidget(buttonBox);
 
     setLayout(parentLayout);
+    setWindowTitle(tr("Check for Client Updates"));
+
+    setFixedHeight(sizeHint().height());
 
     // Check for SSL (this probably isn't necessary)
     if (!QSslSocket::supportsSsl()) {

--- a/cockatrice/src/dlg_update.cpp
+++ b/cockatrice/src/dlg_update.cpp
@@ -55,6 +55,7 @@ DlgUpdate::DlgUpdate(QWidget *parent) : QDialog(parent)
     setWindowTitle(tr("Check for Client Updates"));
 
     setFixedHeight(sizeHint().height());
+    setFixedWidth(sizeHint().width());
 
     // Check for SSL (this probably isn't necessary)
     if (!QSslSocket::supportsSsl()) {


### PR DESCRIPTION
## Short roundup of the initial problem
Spectator options stretched over all available space in the create game dialog.
Check for updates dialog had no title and can be resized for no reason.

## What will change with this Pull Request?
- Spectator GroupBox is now top aligned in its grid slot.
- Client update check dialog has a name and has its height and width auto fixed as resizing just makes the dialog worse.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![Untitled](https://user-images.githubusercontent.com/9874850/97757376-e28e7600-1afc-11eb-8996-bbd460d809fa.png)
