### PR TITLE
Fix racetime condition with token cloning

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -48,22 +48,22 @@ CardItem::~CardItem()
 
 void CardItem::prepareDelete()
 {
-    if (owner) {
+    if (owner != nullptr) {
         if (owner->getCardMenu() == cardMenu) {
-            owner->setCardMenu(0);
-            owner->getGame()->setActiveCard(0);
+            owner->setCardMenu(nullptr);
+            owner->getGame()->setActiveCard(nullptr);
         }
-        owner = 0;
+        owner = nullptr;
     }
 
     while (!attachedCards.isEmpty()) {
-        attachedCards.first()->setZone(0); // so that it won't try to call reorganizeCards()
-        attachedCards.first()->setAttachedTo(0);
+        attachedCards.first()->setZone(nullptr); // so that it won't try to call reorganizeCards()
+        attachedCards.first()->setAttachedTo(nullptr);
     }
 
-    if (attachedTo) {
+    if (attachedTo != nullptr) {
         attachedTo->removeAttachedCard(this);
-        attachedTo = 0;
+        attachedTo = nullptr;
     }
 }
 
@@ -265,9 +265,10 @@ CardDragItem *CardItem::createDragItem(int _id, const QPointF &_pos, const QPoin
 
 void CardItem::deleteDragItem()
 {
-    if (dragItem)
+    if (dragItem) {
         dragItem->deleteLater();
-    dragItem = NULL;
+    }
+    dragItem = nullptr;
 }
 
 void CardItem::drawArrow(const QColor &arrowColor)
@@ -362,7 +363,7 @@ void CardItem::playCard(bool faceDown)
 void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     if (event->button() == Qt::RightButton) {
-        if (cardMenu && !cardMenu->isEmpty() && owner) {
+        if (cardMenu && !cardMenu->isEmpty() && owner != nullptr) {
             owner->updateCardMenu(this);
             cardMenu->exec(event->screenPos());
         }
@@ -381,6 +382,9 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
         }
     }
 
+    if (owner != nullptr){ // cards without owner will be deleted
+        setCursor(Qt::OpenHandCursor);
+    }
     AbstractCardItem::mouseReleaseEvent(event);
 }
 

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -370,7 +370,7 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
                (!SettingsCache::instance().getDoubleClickToPlay())) {
         bool hideCard = false;
         if (zone && zone->getIsView()) {
-            ZoneViewZone *view = static_cast<ZoneViewZone *>(zone);
+            auto *view = static_cast<ZoneViewZone *>(zone);
             if (view->getRevealZone() && !view->getWriteableRevealZone())
                 hideCard = true;
         }
@@ -381,7 +381,6 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
         }
     }
 
-    setCursor(Qt::OpenHandCursor);
     AbstractCardItem::mouseReleaseEvent(event);
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2820

## Short roundup of the initial problem
There was a racetime condition where an opponent would delete an object and the game tried to make a copy of it. The call to `this->setCursor()` triggered the crash because `this` was a null object by the time we got to that call. Removing that call seemed to fix up the issue.