### PR TITLE
Allow DeckName/Comments to be resized more

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -26,8 +26,6 @@
 #include <QDir>
 #include <QDockWidget>
 #include <QFileDialog>
-#include <QGroupBox>
-#include <QHBoxLayout>
 #include <QHeaderView>
 #include <QLabel>
 #include <QLineEdit>
@@ -89,6 +87,7 @@ void TabDeckEditor::createDeckDock()
     commentsLabel = new QLabel();
     commentsLabel->setObjectName("commentsLabel");
     commentsEdit = new QTextEdit;
+    commentsEdit->setMinimumHeight(nameEdit->minimumSizeHint().height());
     commentsEdit->setObjectName("commentsEdit");
     commentsLabel->setBuddy(commentsEdit);
     connect(commentsEdit, SIGNAL(textChanged()), this, SLOT(updateComments()));
@@ -147,7 +146,7 @@ void TabDeckEditor::createDeckDock()
     auto *split = new QSplitter;
     split->setObjectName("deckSplitter");
     split->setOrientation(Qt::Vertical);
-    split->setChildrenCollapsible(false);
+    split->setChildrenCollapsible(true);
     split->addWidget(topWidget);
     split->addWidget(bottomWidget);
     split->setStretchFactor(0, 1);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #566

## Short roundup of the initial problem
The comments section had too large of a maximum height, and there was no way to get just pure deck viewing. The default is the same, but if a user wants to resize the limits can be seen below

## What will change with this Pull Request?
<img width="376" alt="Screen Shot 2020-11-01 at 4 25 59 PM" src="https://user-images.githubusercontent.com/7460172/97815883-416c0080-1c5f-11eb-8511-7aae35d95264.png">

<img width="401" alt="Screen Shot 2020-11-01 at 4 26 03 PM" src="https://user-images.githubusercontent.com/7460172/97815882-40d36a00-1c5f-11eb-8147-3f184aa154d4.png">
