### PR TITLE
add missing mysql connector dependencies to docker images

### DIFF
--- a/.ci/ArchLinux/Dockerfile
+++ b/.ci/ArchLinux/Dockerfile
@@ -5,6 +5,7 @@ RUN pacman --sync --refresh --sysupgrade --needed --noconfirm \
         ccache \
         cmake \
         git \
+        mariadb-libs \
         protobuf \
         qt5-base \
         qt5-multimedia \

--- a/.ci/DebianBuster/Dockerfile
+++ b/.ci/DebianBuster/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         g++ \
         git \
         liblzma-dev \
+        libmariadb-dev-compat \
         libprotobuf-dev \
         libqt5multimedia5-plugins \
         libqt5sql5-mysql \

--- a/.ci/Fedora32/Dockerfile
+++ b/.ci/Fedora32/Dockerfile
@@ -10,6 +10,7 @@ RUN dnf install -y \
         git \
         hicolor-icon-theme \
         libappstream-glib \
+        mariadb-devel \
         protobuf-devel \
         qt5-{qttools,qtsvg,qtmultimedia,qtwebsockets}-devel \
         rpm-build \

--- a/.ci/UbuntuBionic/Dockerfile
+++ b/.ci/UbuntuBionic/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         g++ \
         git \
         liblzma-dev \
+        libmariadb-dev-compat \
         libprotobuf-dev \
         libqt5multimedia5-plugins \
         libqt5sql5-mysql \

--- a/.ci/UbuntuFocal/Dockerfile
+++ b/.ci/UbuntuFocal/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
         g++ \
         git \
         liblzma-dev \
+        libmariadb-dev-compat \
         libprotobuf-dev \
         libqt5multimedia5-plugins \
         libqt5sql5-mysql \


### PR DESCRIPTION
## Related Ticket(s)
- possibly #3954

## Short roundup of the initial problem
debian based builds are missing the mysql connector dependency, see https://travis-ci.org/github/Cockatrice/Cockatrice/jobs/740707002#L2032

## What will change with this Pull Request?
- adds the dependency to ubuntu and debian builds
