### PR TITLE
check if node is a dir before deletion

### DIFF
--- a/cockatrice/src/tab_deck_storage.cpp
+++ b/cockatrice/src/tab_deck_storage.cpp
@@ -196,6 +196,9 @@ void TabDeckStorage::uploadFinished(const Response &r, const CommandContainer &c
 void TabDeckStorage::actDeleteLocalDeck()
 {
     QModelIndex curLeft = localDirView->selectionModel()->currentIndex();
+    if (localDirModel->isDir(curLeft))
+        return;
+
     if (QMessageBox::warning(this, tr("Delete local file"),
                              tr("Are you sure you want to delete \"%1\"?").arg(localDirModel->fileName(curLeft)),
                              QMessageBox::Yes | QMessageBox::No) != QMessageBox::Yes)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes https://github.com/Cockatrice/Cockatrice/issues/2852

## Short roundup of the initial problem
deleting the current entry while none is selected deletes the user's home directory contents

## What will change with this Pull Request?
- similar to the other buttons simply check if the node is a dir and cancel.
- I tested this by using a separate user, you could also just start cockatrice with HOME=/dir cockatrice to limit damage