### PR TITLE
More changes to GitHub Actions

### DIFF
--- a/.github/workflows/linux-builds.yml
+++ b/.github/workflows/linux-builds.yml
@@ -1,6 +1,9 @@
 name: Build on Linux (Docker)
 
 on:
+  push:
+    branches: 
+      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/linux-builds.yml
+++ b/.github/workflows/linux-builds.yml
@@ -2,7 +2,7 @@ name: Build on Linux (Docker)
 
 on:
   push:
-    branches: 
+    branches:
       - master
   pull_request:
     branches:

--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -1,6 +1,9 @@
 name: Build on macOS
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align='center'>
    <a href="#cockatrice"><b>Cockatrice</b></a> <b>|</b>
    <a href="#download-">Download</a> <b>|</b>
-   <a href="#get-involved-">Get Involved</a> <b>|</b>
+   <a href="#get-involved--">Get Involved</a> <b>|</b>
    <a href="#community-resources">Community</a> <b>|</b>
    <a href="#translations-">Translations</a> <b>|</b>
    <a href="#build---">Build</a> <b>|</b>
@@ -79,7 +79,9 @@ Cockatrice uses Transifex for translations. You can help us bring Cockatrice and
 Check out our [Translator FAQ](https://github.com/Cockatrice/Cockatrice/wiki/Translation-FAQ) for more information about contributing!<br>
 
 
-# Build ![macOS builds](https://github.com/Cockatrice/Cockatrice/workflows/Build%20on%20macOS/badge.svg) ![linux builds](https://github.com/Cockatrice/Cockatrice/workflows/Build%20on%20Linux%20(Docker)/badge.svg) [![Appveyor Build Status - master](https://ci.appveyor.com/api/projects/status/oauxf5a0sj689rcg/branch/master?svg=true)](https://ci.appveyor.com/project/ZeldaZach/cockatrice/branch/master) <!-- link to zachs appveyor not correct yet -->
+# Build [![Linux builds - master](https://github.com/Cockatrice/Cockatrice/workflows/Build%20on%20Linux%20(Docker)/badge.svg)](https://github.com/Cockatrice/Cockatrice/actions?query=workflow%3A%22Build+on+Linux+%28Docker%29%22+branch%3Amaster) [![macOS builds - master](https://github.com/Cockatrice/Cockatrice/workflows/Build%20on%20macOS/badge.svg)](https://github.com/Cockatrice/Cockatrice/actions?query=workflow%3A%22Build+on+macOS%22+branch%3Amaster) [![Windows builds - master](https://ci.appveyor.com/api/projects/status/oauxf5a0sj689rcg/branch/master?svg=true)](https://ci.appveyor.com/project/ZeldaZach/cockatrice/branch/master)
+
+<!-- link to zachs appveyor not correct yet -->
 
 **Detailed compiling instructions are on the Cockatrice wiki under [Compiling Cockatrice](https://github.com/Cockatrice/Cockatrice/wiki/Compiling-Cockatrice)**
 


### PR DESCRIPTION
## Related Ticket(s)
- Related #4164

## Short roundup of the initial problem
GH Actions only build for created PR's

## What will change with this Pull Request?
- Workflows (except clangify) are also run on changes to master branch to show repo status
- Update badges, they now also link to the build results on master
- Fix ToC links in README