### PR TITLE
Oracle: fix typo in card importer

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -132,7 +132,7 @@ CardInfoPtr OracleImporter::addCard(QString name,
         sortAndReduceColors(allColors);
         properties.insert("colors", allColors);
     }
-    QString allColorIdent = properties.value("colorIdenity").toString();
+    QString allColorIdent = properties.value("coloridentity").toString();
     if (allColorIdent.size() > 1) {
         sortAndReduceColors(allColorIdent);
         properties.insert("coloridentity", allColorIdent);


### PR DESCRIPTION
Fix typo in #L135 to conform with #L138

(Not sure whether capitalization is also off further down in #L326 because I lack the context to know whether `card` is an object using the camelCased field names from MTGJSON or not.)
