### PR TITLE
ui: Add shortcut for "Save deck as..."

### DIFF
--- a/cockatrice/src/shortcutssettings.h
+++ b/cockatrice/src/shortcutssettings.h
@@ -219,7 +219,7 @@ private:
                                                 parseSequenceString("Ctrl+S"),
                                                 ShortcutGroup::Deck_Editor)},
         {"TabDeckEditor/aSaveDeckAs", ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Save Deck as..."),
-                                                  parseSequenceString(""),
+                                                  parseSequenceString("Ctrl+Shift+S"),
                                                   ShortcutGroup::Deck_Editor)},
         {"TabDeckEditor/aSaveDeckToClipboard",
          ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Save Deck to Clipboard, Annotated"),


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4174

## Short roundup of the initial problem
No shortcut existed for saving as, simple single line change. 

## What will change with this Pull Request?
- Ctrl+Shift+S now opens the "Save deck as..." dialog

Compiled and tested on Windows 10 x64 (2004) against Qt 5.15.2. Works as expected.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![img](https://pub.rachni.com/img/cockatrice_2020-11-26_00-53-03.png)