### PR TITLE
Update README.md

### DIFF
--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - '**.md'
   release:
     types:
       - published

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Check out our [Translator FAQ](https://github.com/Cockatrice/Cockatrice/wiki/Tra
 
 <!-- link to zachs appveyor not correct yet -->
 
-**Detailed compiling instructions are on the Cockatrice wiki under [Compiling Cockatrice](https://github.com/Cockatrice/Cockatrice/wiki/Compiling-Cockatrice)**
+**Detailed compiling instructions can be found on the Cockatrice wiki under [Compiling Cockatrice](https://github.com/Cockatrice/Cockatrice/wiki/Compiling-Cockatrice)**
 
 Dependencies: *(for minimum requirements search our [CMake file](https://github.com/Cockatrice/Cockatrice/blob/master/CMakeLists.txt))*
 - [Qt](https://www.qt.io/developers/)


### PR DESCRIPTION
Testing #4183

Edit: Works, the linux builds are correctly skipped for 1862633: https://github.com/Cockatrice/Cockatrice/pull/4189/checks?sha=18626338884398e4b54bcec441af4d7e937aee2e 👍 

---

Now that we know it works, I'm extending this PR to also skip our mac builds.