### PR TITLE
Display a system tray notification when a player joins your game

### DIFF
--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -1194,8 +1194,9 @@ void TabGame::eventJoin(const Event_Join &event, int /*eventPlayerId*/, const Ga
         Player *newPlayer = addPlayer(playerId, playerInfo.user_info());
         messageLog->logJoin(newPlayer);
         if (trayIcon) {
-            trayIcon->showMessage(tr("A player has joined your game"),
-                                  tr("%1 has joined your game").arg(newPlayer->getName()));
+            QString gameId(QString::number(gameInfo.game_id()));
+            trayIcon->showMessage(tr("A player has joined game #%1").arg(gameId),
+                                  tr("%1 has joined the game").arg(newPlayer->getName()));
         }
     }
     playerListWidget->addPlayer(playerInfo);

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -53,6 +53,7 @@
 #include "replay_timeline_widget.h"
 #include "settingscache.h"
 #include "tab_supervisor.h"
+#include "window_main.h"
 #include "zoneviewwidget.h"
 #include "zoneviewzone.h"
 
@@ -1192,6 +1193,10 @@ void TabGame::eventJoin(const Event_Join &event, int /*eventPlayerId*/, const Ga
     } else {
         Player *newPlayer = addPlayer(playerId, playerInfo.user_info());
         messageLog->logJoin(newPlayer);
+        if (trayIcon) {
+            trayIcon->showMessage(tr("A player has joined your game"),
+                                  tr("%1 has joined your game").arg(newPlayer->getName()));
+        }
     }
     playerListWidget->addPlayer(playerInfo);
     emitUserEvent();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3977 

## Short roundup of the initial problem
There is no notification when a player joins your game.  You get a message in the chat room but that's it.

## What will change with this Pull Request?
You will now receive a system tray notification when a player joins your game.

## Screenshots

<img width="1440" alt="Screen Shot 2020-11-28 at 9 15 53 PM" src="https://user-images.githubusercontent.com/1535686/100533959-1b367380-31bf-11eb-8495-b545132d6924.png">

