### PR TITLE
ui: Fix Qt depreaction warnings

### DIFF
--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -287,14 +287,14 @@ void AbstractCardItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
     }
     if (event->button() == Qt::LeftButton)
         setCursor(Qt::ClosedHandCursor);
-    else if (event->button() == Qt::MidButton)
+    else if (event->button() == Qt::MiddleButton)
         emit showCardInfoPopup(event->screenPos(), name);
     event->accept();
 }
 
 void AbstractCardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
-    if (event->button() == Qt::MidButton)
+    if (event->button() == Qt::MiddleButton)
         emit deleteCardInfoPopup(name);
 
     // This function ensures the parent function doesn't mess around with our selection.

--- a/cockatrice/src/abstractcounter.cpp
+++ b/cockatrice/src/abstractcounter.cpp
@@ -127,7 +127,7 @@ void AbstractCounter::setValue(int _value)
 void AbstractCounter::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
     if (isUnderMouse() && player->getLocalOrJudge()) {
-        if (event->button() == Qt::MidButton || (QApplication::keyboardModifiers() & Qt::ShiftModifier)) {
+        if (event->button() == Qt::MiddleButton || (QApplication::keyboardModifiers() & Qt::ShiftModifier)) {
             if (menu)
                 menu->exec(event->screenPos());
             event->accept();

--- a/cockatrice/src/chatview/chatview.cpp
+++ b/cockatrice/src/chatview/chatview.cpp
@@ -529,12 +529,12 @@ void ChatView::mousePressEvent(QMouseEvent *event)
 {
     switch (hoveredItemType) {
         case HoveredCard: {
-            if ((event->button() == Qt::MidButton) || (event->button() == Qt::LeftButton))
+            if ((event->button() == Qt::MiddleButton) || (event->button() == Qt::LeftButton))
                 emit showCardInfoPopup(event->globalPos(), hoveredContent);
             break;
         }
         case HoveredUser: {
-            if (event->button() != Qt::MidButton) {
+            if (event->button() != Qt::MiddleButton) {
                 const int delimiterIndex = hoveredContent.indexOf("_");
                 const QString userName = hoveredContent.mid(delimiterIndex + 1);
                 switch (event->button()) {
@@ -564,7 +564,7 @@ void ChatView::mousePressEvent(QMouseEvent *event)
 
 void ChatView::mouseReleaseEvent(QMouseEvent *event)
 {
-    if ((event->button() == Qt::MidButton) || (event->button() == Qt::LeftButton))
+    if ((event->button() == Qt::MiddleButton) || (event->button() == Qt::LeftButton))
         emit deleteCardInfoPopup(QString("_"));
 
     QTextBrowser::mouseReleaseEvent(event);


### PR DESCRIPTION
## Related Ticket(s)
N/A

## Short roundup of the initial problem
Qt::MidButton has been long since deprecated, use MiddleButton instead cause warning are annoying. This will be required going forward as the alias is being removed in Qt6.

## What will change with this Pull Request?
- warnings go away when compiling

## Screenshots
n/a
