### PR TITLE
cmake: Minor updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,15 @@ if(WIN32)
         message(WARNING "QTDIR variable is missing.  Please set this variable to specify path to Qt (e.g. C:/Qt/5.7/msvc2015_64)")
     endif()
 endif()
+
 # A project name is needed for CPack
 # Version can be overriden by git tags, see cmake/getversion.cmake
 PROJECT("Cockatrice" VERSION 2.7.6)
+
+# Set release name if not provided via env/cmake var
+if(NOT DEFINED GIT_TAG_RELEASENAME)
+    set(GIT_TAG_RELEASENAME "Blessed Sanctuary")
+endif()
 
 # Use c++11 for all targets
 set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ ISO Standard")
@@ -52,7 +58,6 @@ set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true)
 # Search path for cmake modules
 SET(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-# Retrieve git version hash
 include(getversion)
 
 # Create a header and a cpp file containing the version hash
@@ -95,7 +100,7 @@ if(UNIX)
         endif()
     endif()
 elseif(WIN32)
-    set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/release)
+    set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/rundir/${CMAKE_BUILD_TYPE})
 endif()
 
 # Treat warnings as errors (Debug builds only)
@@ -103,10 +108,8 @@ option(WARNING_AS_ERROR "Treat warnings as errors in debug builds" ON)
 
 # Define proper compilation flags
 IF(MSVC)
-    # Visual Studio:
-    # Maximum optimization
-    # Disable warning C4251
-    set(CMAKE_CXX_FLAGS_RELEASE "/Ox /MD /wd4251")
+    # Visual Studio: Maximum optimization, disable warning C4251
+    set(CMAKE_CXX_FLAGS_RELEASE "/Ox /MD /wd4251 ")
     # Generate complete debugging information
     #set(CMAKE_CXX_FLAGS_DEBUG "/Zi")
 ELSEIF (CMAKE_COMPILER_IS_GNUCXX)
@@ -142,14 +145,20 @@ ENDIF()
 FIND_PACKAGE(Threads REQUIRED)
 
 # Find Qt5
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(_lib_suffix 64)
+else()
+    set(_lib_suffix 32)
+endif()
+
 if(DEFINED QTDIR${_lib_suffix})
-	list(APPEND CMAKE_PREFIX_PATH "${QTDIR${_lib_suffix}}")
+    list(APPEND CMAKE_PREFIX_PATH "${QTDIR${_lib_suffix}}")
 elseif(DEFINED QTDIR)
-	list(APPEND CMAKE_PREFIX_PATH "${QTDIR}")
+    list(APPEND CMAKE_PREFIX_PATH "${QTDIR}")
 elseif(DEFINED ENV{QTDIR${_lib_suffix}})
-	list(APPEND CMAKE_PREFIX_PATH "$ENV{QTDIR${_lib_suffix}}")
+    list(APPEND CMAKE_PREFIX_PATH "$ENV{QTDIR${_lib_suffix}}")
 elseif(DEFINED ENV{QTDIR})
-	list(APPEND CMAKE_PREFIX_PATH "$ENV{QTDIR}")
+    list(APPEND CMAKE_PREFIX_PATH "$ENV{QTDIR}")
 endif()
 
 FIND_PACKAGE(Qt5Core 5.5.0 REQUIRED)
@@ -180,7 +189,9 @@ set(CMAKE_AUTOMOC TRUE)
 # Find other needed libraries
 FIND_PACKAGE(Protobuf REQUIRED)
 IF(NOT EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
-  MESSAGE(FATAL_ERROR "No protoc command found!")
+    MESSAGE(FATAL_ERROR "No protoc command found!")
+ELSE()
+    MESSAGE(STATUS "Protoc version ${Protobuf_VERSION} found!")
 ENDIF()
 
 #Find OpenSSL
@@ -272,7 +283,7 @@ if(WITH_ORACLE)
 endif()
 
 # Compile dbconverter (default on)
-option(WITH_DBCONVERTER "build oracle" ON)
+option(WITH_DBCONVERTER "build dbconverter" ON)
 if(WITH_DBCONVERTER)
     add_subdirectory(dbconverter)
     SET(CPACK_INSTALL_CMAKE_PROJECTS "Dbconverter;Dbconverter;ALL;/" ${CPACK_INSTALL_CMAKE_PROJECTS})

--- a/cmake/getversion.cmake
+++ b/cmake/getversion.cmake
@@ -38,23 +38,6 @@ function(get_commit_date)
 	set(GIT_COMMIT_DATE "${GIT_COM_DATE}" PARENT_SCOPE)
 endfunction()
 
-function(clean_release_name name)
-	#  <title>Release Cockatrice 2.7.3: Dawn of Hope · Cockatrice/Cockatrice · GitHub</title>
-	# Remove prefix
-	STRING(REGEX REPLACE "<title>Release Cockatrice [0-9\.]+: " "" name "${name}")
-	# Remove suffix
-	STRING(REPLACE " · Cockatrice/Cockatrice · GitHub</title>" "" name "${name}")
-	# Remove all unwanted chars
-	STRING(REGEX REPLACE "[^A-Za-z0-9_ ]" "" name "${name}")
-	# Strip (trim) whitespaces
-	STRING(STRIP "${name}" name)
-	# Replace all spaces with underscores
-	STRING(REPLACE " " "_" name "${name}")
-
-	MESSAGE(STATUS "Friendly tag name: ${name}")
-	set(GIT_TAG_RELEASENAME "${name}" PARENT_SCOPE)
-endfunction()
-
 function(get_tag_name commit)
 	if(${commit} STREQUAL "unknown")
 		return()
@@ -163,23 +146,8 @@ function(get_tag_name commit)
 		set(PROJECT_VERSION_LABEL ${GIT_TAG_LABEL} PARENT_SCOPE)
 	elseif(${GIT_TAG_TYPE} STREQUAL "Release")
 		set(PROJECT_VERSION_LABEL "" PARENT_SCOPE)
-
-		# get version name from github
-		set(GIT_TAG_TEMP_FILE "${PROJECT_BINARY_DIR}/tag_informations.txt")
-		set(GIT_TAG_TEMP_URL "https://github.com/Cockatrice/Cockatrice/releases/tag/${GIT_TAG}")
-		message(STATUS "Fetching tag informations from ${GIT_TAG_TEMP_URL}")
-		file(REMOVE "${GIT_TAG_TEMP_FILE}")
-		file(DOWNLOAD "${GIT_TAG_TEMP_URL}" "${GIT_TAG_TEMP_FILE}" STATUS status LOG log INACTIVITY_TIMEOUT 30 TIMEOUT 300 SHOW_PROGRESS)
-    	list(GET status 0 err)
-    	list(GET status 1 msg)
-	    if(err)
-	    	message(WARNING "Download failed with error ${msg}: ${log}")
-	    	return()
-    	endif()
-    	file(STRINGS "${GIT_TAG_TEMP_FILE}" GIT_TAG_RAW_RELEASENAME REGEX "<title>Release Cockatrice .*</title>" LIMIT_COUNT 1 ENCODING UTF-8)
-
-    	clean_release_name("${GIT_TAG_RAW_RELEASENAME}")
-    	set(PROJECT_VERSION_RELEASENAME "${GIT_TAG_RELEASENAME}" PARENT_SCOPE)
+		# set release name from env var
+		set(PROJECT_VERSION_RELEASENAME "${GIT_TAG_RELEASENAME}" PARENT_SCOPE)
 	endif()
 
 endfunction()
@@ -188,9 +156,9 @@ endfunction()
 
 # fallback defaults
 set(GIT_COMMIT_ID "unknown")
-set(GIT_COMMIT_DATE "unknown")
-set(GIT_COMMIT_DATE_FRIENDLY "unknown")
-set(PROJECT_VERSION_LABEL "custom(unknown)")
+set(GIT_COMMIT_DATE "")
+set(GIT_COMMIT_DATE_FRIENDLY "")
+set(PROJECT_VERSION_LABEL "")
 set(PROJECT_VERSION_RELEASENAME "")
 
 find_package(Git)


### PR DESCRIPTION
## Related Ticket(s)
n/a

## Short roundup of the initial problem
CMake was a bit messy

## What will change with this Pull Request?
In order of change in the file:

CMakeLists.txt
- Add new cmake var for GIT_TAG_RELEASENAME which replaces the need to pull the release name from a web page
- Update Windows build paths to be more in line with expectations of other Windows projects (non-functional change)
- Cleaned up a comment that was 3 lines to 1 because it was bothering me
- Added missing check for arch for QTDIR (can optionally supply QTDIR32 or QTDIR64 if building both at once, or just QTDIR if only building on one arch), and fixed whitespace issue
- Added a quick message stating that protoc was found if it is. If the check is important enough to be doing, it's important enough to be logging success.
- Fixed typo in dbconverter build flag description

getversion.cmake
- Removed the need to curl a URL and parse the page title. CMake will no longer be making web calls every time it's being run with a valid release/pre-release tag.
- Set a few of the version defaults to blank to avoid potential confusion in third party builds. 
