### PR TITLE
Disabled strict mode for MySQL on the docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   mysql:
     image: mysql
+    command: --sql_mode=
     environment:
       - MYSQL_ROOT_PASSWORD=root-password
       - MYSQL_DATABASE=servatrice


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4213

## Short roundup of the initial problem
Servatrice would set all game ids to 0 when running in docker using the provided `docker-compose.yml` file in the repo.

## What will change with this Pull Request?
- This PR disables the strict mode on MySQL [as suggested by Gavin on Gitter](https://gitter.im/Cockatrice/Cockatrice?at=5ea9a91d9f0c955d7d936489)
- This fixes the game IDs being set to zero when using the provided docker-compose file

