### PR TITLE
Fix #2771: Do not change x coordinates of moved card if it will be destroyed when it leaves the table

### DIFF
--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -433,18 +433,23 @@ Response::ResponseCode Server_Player::moveCard(GameEventStorage &ges,
             lastDrawList.clear();
         }
 
-        if ((startzone == targetzone) && !startzone->hasCoords()) {
-            if (!secondHalf && (originalPosition < x)) {
-                xIndex = -1;
-                secondHalf = true;
-            } else if (secondHalf) {
-                --xIndex;
+        // Only mess about with x coordinates if the card is sticking around, otherwise it can have weird side effects
+        // if multiple cards are moved at once.
+        if (!card->getDestroyOnZoneChange()) {
+            if ((startzone == targetzone) && !startzone->hasCoords()) {
+                if (!secondHalf && (originalPosition < x)) {
+                    xIndex = -1;
+                    secondHalf = true;
+                } else if (secondHalf) {
+                    --xIndex;
+                } else {
+                    ++xIndex;
+                }
             } else {
                 ++xIndex;
             }
-        } else {
-            ++xIndex;
         }
+
         int newX = x + xIndex;
 
         // Attachment relationships can be retained when moving a card onto the opponent's table


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2771

## Short roundup of the initial problem
Graveyard consists of CardA CardB; CardC and TokenD are dragged to graveyard. New Graveyard order is CardA CardC CardB, not expected CardA CardB CardC. (e.g., CardC doesn't go on top of graveyard as expected, it's under the previous top card.) As outlined in #2771, this was also a problem when non-token & token were both dragged to exile or to hand; the non-token card would be one "past" where it was otherwise expected to be.

Note that this actually was not a problem if a token was set to _not_ be destroyed upon leaving the table, as it would go to the next zone with the other card as per usual. Behavior for non-destroyed-tokens does not change with this PR.

## What will change with this Pull Request?
moveCard(...) will now only modify x coordinate for its targetzone->insertCard(...) call [here](https://github.com/Cockatrice/Cockatrice/blob/8e9d4e3a674f4217cf8a2ac1a43e889879654257/common/server_player.cpp#L496) if the card is not set to be destroyed upon leaving the table. That means if moveCard(...) is handling multiple cards, x value will only change for non-tokens/tokens not set to be destroyed upon leaving table.

In addition to screenshots below, manual testing shows this also fixed the issue when dragging such cards to exile and hands (noted as issues in #2771).

## Screenshots
Before: 

https://user-images.githubusercontent.com/63179146/103449238-81f1f580-4c73-11eb-97fa-9746551a1943.mov

Notice that "Mind Stone" remains at the top of the graveyard, not "Ferocity..."

After: 

https://user-images.githubusercontent.com/63179146/103449243-99c97980-4c73-11eb-9b60-851dabd2bbb6.mov

Notice that "Ilharg..." is newly at the top of the graveyard.