### PR TITLE
Release templates

### DIFF
--- a/.ci/prep_release.sh
+++ b/.ci/prep_release.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# sets the properties of ci releases
+# this doesn't have to be 100% foolproof
+# the releases are first made as drafts and will be vetted by a human
+# it just has to provide a template
+# this requires the repo to be unshallowed
+beta_regex='beta'
+name_regex='set\(GIT_TAG_RELEASENAME "([[:print:]]+)")'
+
+if [[ $1 ]]; then
+  TAG="$1"
+fi
+
+# check env
+if [[ ! $TAG ]]; then
+  echo "::error file=$0::TAG is missing"
+  exit 2
+fi
+
+# create title
+if [[ $TAG =~ $beta_regex ]]; then
+  echo "::set-output name=is_beta::yes"
+  title="$TAG"
+  echo "creating beta release '$title'"
+elif [[ ! $(cat CMakeLists.txt) =~ $name_regex ]]; then
+  echo "::error file=$0::could not find releasename in CMakeLists.txt"
+  exit 1
+else
+  echo "::set-output name=is_beta::no"
+  name="${BASH_REMATCH[1]}"
+  version="${TAG##*-}"
+  title="Cockatrice $version: $name"
+  no_beta=1
+  echo "::set-output name=friendly_name::$name"
+  echo "creating full release '$title'"
+fi
+echo "::set-output name=title::$title"
+
+# add release notes template
+if [[ $no_beta ]]; then
+  body="$(cat ".ci/release_template.md")"
+  if [[ ! $body ]]; then
+    echo "::warning file=$0::could not find release template"
+  fi
+  body="${body//__REPLACE_WITH_RELEASE_TITLE__/$title}"
+else
+  body="Included commits over previous version:
+__REPLACE_WITH_GENERATED_LIST__"
+fi
+
+# add git log to release notes
+all_tags="
+$(git tag)" # tags are ordered alphabetically
+before="${all_tags%%
+$TAG*}" # strip line with current tag an all lines after it
+# note the extra newlines are needed to always have a last line
+if [[ $all_tags == $before ]]; then
+  echo "::warning file=$0::could not find current tag"
+else
+  while
+    previous="${before##*
+}" # get the last line
+    # skip this tag if this is a full release and it's a beta or if empty
+    [[ $no_beta && $previous =~ $beta_regex || ! $previous ]]
+  do
+    beta_list+=" $previous" # add to list of skipped betas
+    next_before="${before%
+*}" # strip the last line
+    if [[ $next_before == $before ]]; then
+      echo "::warning file=$0::could not find previous tag"
+      unset previous
+      break
+    fi
+    before="$next_before"
+  done
+  if [[ $previous ]]; then
+    if ! generated_list="$(git log "$previous..$TAG" --pretty="- %s")"; then
+      echo "::warning file=$0::failed to produce git log"
+    fi
+    body="${body//__REPLACE_WITH_GENERATED_LIST__/$generated_list}"
+    body="${body//__REPLACE_WITH_BETA_LIST__/$beta_list}"
+  fi
+fi
+echo "::set-output name=body::$body"

--- a/.ci/prep_release.sh
+++ b/.ci/prep_release.sh
@@ -4,6 +4,8 @@
 # the releases are first made as drafts and will be vetted by a human
 # it just has to provide a template
 # this requires the repo to be unshallowed
+template_path=".ci/release_template.md"
+body_path="/tmp/release.md"
 beta_regex='beta'
 name_regex='set\(GIT_TAG_RELEASENAME "([[:print:]]+)")'
 
@@ -38,7 +40,7 @@ echo "::set-output name=title::$title"
 
 # add release notes template
 if [[ $no_beta ]]; then
-  body="$(cat ".ci/release_template.md")"
+  body="$(cat "$template_path")"
   if [[ ! $body ]]; then
     echo "::warning file=$0::could not find release template"
   fi
@@ -81,4 +83,7 @@ else
     body="${body//__REPLACE_WITH_BETA_LIST__/$beta_list}"
   fi
 fi
-echo "::set-output name=body::$body"
+
+# write to file
+echo "::set-output name=body_path::$body_path"
+echo "$body" >"$body_path"

--- a/.ci/prep_release.sh
+++ b/.ci/prep_release.sh
@@ -8,6 +8,7 @@ template_path=".ci/release_template.md"
 body_path="/tmp/release.md"
 beta_regex='beta'
 name_regex='set\(GIT_TAG_RELEASENAME "([[:print:]]+)")'
+whitespace='^\s*$'
 
 if [[ $1 ]]; then
   TAG="$1"
@@ -81,6 +82,9 @@ else
     # --> is the markdown comment escape sequence, emojis are way better
     generated_list="${generated_list//-->/→}"
     body="${body//--REPLACE-WITH-GENERATED-LIST--/$generated_list}"
+    if [[ $beta_list =~ $whitespace ]]; then
+      beta_list="-n there are no betas to delete!"
+    fi
     body="${body//--REPLACE-WITH-BETA-LIST--/$beta_list}"
   else
     echo "::warning file=$0::could not find previous tag"

--- a/.ci/prep_release.sh
+++ b/.ci/prep_release.sh
@@ -44,10 +44,10 @@ if [[ $no_beta ]]; then
   if [[ ! $body ]]; then
     echo "::warning file=$0::could not find release template"
   fi
-  body="${body//__REPLACE_WITH_RELEASE_TITLE__/$title}"
+  body="${body//--REPLACE-WITH-RELEASE-TITLE--/$title}"
 else
   body="Included commits over previous version:
-__REPLACE_WITH_GENERATED_LIST__"
+--REPLACE-WITH-GENERATED-LIST--"
 fi
 
 # add git log to release notes
@@ -69,7 +69,6 @@ else
     next_before="${before%
 *}" # strip the last line
     if [[ $next_before == $before ]]; then
-      echo "::warning file=$0::could not find previous tag"
       unset previous
       break
     fi
@@ -79,8 +78,12 @@ else
     if ! generated_list="$(git log "$previous..$TAG" --pretty="- %s")"; then
       echo "::warning file=$0::failed to produce git log"
     fi
-    body="${body//__REPLACE_WITH_GENERATED_LIST__/$generated_list}"
-    body="${body//__REPLACE_WITH_BETA_LIST__/$beta_list}"
+    # --> is the markdown comment escape sequence, emojis are way better
+    generated_list="${generated_list//-->/→}"
+    body="${body//--REPLACE-WITH-GENERATED-LIST--/$generated_list}"
+    body="${body//--REPLACE-WITH-BETA-LIST--/$beta_list}"
+  else
+    echo "::warning file=$0::could not find previous tag"
   fi
 fi
 

--- a/.ci/prep_release.sh
+++ b/.ci/prep_release.sh
@@ -76,16 +76,23 @@ else
     before="$next_before"
   done
   if [[ $previous ]]; then
-    if ! generated_list="$(git log "$previous..$TAG" --pretty="- %s")"; then
+    if generated_list="$(git log "$previous..$TAG" --pretty="- %s")"; then
+      count="$(git rev-list --count "$previous..$TAG")"
+      echo "adding list of commits to release notes:"
+      echo "'$previous' to '$TAG' ($count commits)"
+      # --> is the markdown comment escape sequence, emojis are way better
+      generated_list="${generated_list//-->/→}"
+      body="${body//--REPLACE-WITH-GENERATED-LIST--/$generated_list}"
+      if [[ $beta_list =~ $whitespace ]]; then
+        beta_list="-n there are no betas to delete!"
+      else
+        echo "the following betas should be deleted after publishing:"
+        echo "$beta_list"
+      fi
+      body="${body//--REPLACE-WITH-BETA-LIST--/$beta_list}"
+    else
       echo "::warning file=$0::failed to produce git log"
     fi
-    # --> is the markdown comment escape sequence, emojis are way better
-    generated_list="${generated_list//-->/→}"
-    body="${body//--REPLACE-WITH-GENERATED-LIST--/$generated_list}"
-    if [[ $beta_list =~ $whitespace ]]; then
-      beta_list="-n there are no betas to delete!"
-    fi
-    body="${body//--REPLACE-WITH-BETA-LIST--/$beta_list}"
   else
     echo "::warning file=$0::could not find previous tag"
   fi

--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -67,4 +67,5 @@ Use these label badges for highlighting important and key changes:
 
 ## Special Thanks
 <!-- Personalise this a bit! -->
-We continue to find it amazing that so many people contribute their time, knowledge, code, testing and more to the project. We'd like to thank the entire Cockatrice community for their efforts<!--, and we'd like to especially recognize @ZeldaZach, --ADD-CONTRIBUTORS-HERE-- for their help in preparing so many amazing new features for the user base-->.
+We continue to find it amazing that so many people contribute their time, knowledge, code, testing and more to the project. We'd like to thank the entire Cockatrice community for their efforts.
+<!-- We'd like to especially recognize @ZeldaZach, --ADD-CONTRIBUTORS-HERE-- for their help in preparing so many amazing new features for the user base. -->

--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -1,0 +1,70 @@
+<!-- this template comes from .ci/release_template.md -->
+
+<!-- Don't forget to delete the previous betas after publishing this!
+git push -d origin --REPLACE-WITH-BETA-LIST--
+ -->
+
+<!-- This list of binaries should be updated every time the ci is changed to
+include different targets -->
+<pre>
+<b>Pre-compiled binaries we serve:</b>
+ - <kbd>Windows 7/8/10 (32-bit)</kbd></i>
+ - <kbd>Windows 7/8/10 (64-bit)</kbd></i>
+ - <kbd>macOS 10.14</kbd> ("Mojave")</i>
+ - <kbd>macOS 10.15</kbd> ("Catalina")</i>
+ - <kbd>macOS 11.0</kbd> ("Big Sur")</i>
+ - <kbd>Ubuntu 18.04</kbd> ("Bionic Beaver")</i>
+ - <kbd>Ubuntu 20.04</kbd> ("Focal Fossa")</i>
+ - <kbd>Ubuntu 20.10</kbd> ("Groovy Gorilla")</i>
+ - <kbd>Debian 10</kbd> ("Buster")</i>
+ - <kbd>Fedora 33</kbd></i>
+<kbd>We are also packaged in Arch Linux's official community repository, courtesy of @FFY00</kbd></i>
+<kbd>General linux support is available via a flatpak package (Flathub)</kbd></i>
+</pre>
+
+## General Notes
+
+<!-- --REPLACE-WITH-RELEASE-TITLE-- should be placed here by the ci -->
+We're pleased to announce the newest official release: <kbd>--REPLACE-WITH-RELEASE-TITLE--</kbd>
+
+We hope you enjoy the changes made and we have listed all changes, with their corresponding tickets, since the last version of Cockatrice was released for your convenience.
+
+If you ever encounter a bug, have a suggestion or idea, or feel a need for a developer to look into something, please feel free to [open a ticket](https://github.com/Cockatrice/Cockatrice/issues). ([How to create a GitHub Ticket for Cockatrice](https://github.com/Cockatrice/Cockatrice/wiki/How-to-Create-a-GitHub-Ticket-Regarding-Cockatrice))
+
+For any information relating to Cockatrice, please take a look at our official site: **https://cockatrice.github.io**
+
+If you'd like to help contribute to Cockatrice in any way, check out our [README](https://github.com/Cockatrice/Cockatrice#get-involved-). We're always available to answer questions you may have on how the program works and how you can provide a meaningful contribution.
+
+## Upgrading Cockatrice
+- Run the internal software updater: <kbd>Help → Check for Client Updates</kbd>
+
+Don't forget to update your card database right after! (<kbd>Help → Check for Card Updates...</kbd>)
+
+## Changelog
+<!--
+This list is generated and should be moved to their repective header and
+possibly edited a little.
+Move pr numbers of fixups into their main pr to keep the list coherent.
+Remove empty headers after.
+Use these label badges for highlighting important and key changes:
+<kbd>New!</kbd>
+<kbd>Fixed!</kbd> or <kbd>Resolved!</kbd>
+
+--REPLACE-WITH-GENERATED-LIST--
+ -->
+
+### User Interface
+### Under the Hood
+### Oracle
+### Servatrice
+### Webatrice
+
+## Translations
+- **Thanks for over 300 people contributing to 20+ different languages up to now!**
+- Without the help of the community we couldn't offer that great language support... keep up the good work!
+- It's actually very easy to join and help for yourself - find out more here:
+    - [Help us Translate Cockatrice into your native language!](https://github.com/Cockatrice/Cockatrice/wiki/Translation-FAQ)
+
+## Special Thanks
+<!-- Personalise this a bit! -->
+We continue to find it amazing that so many people contribute their time, knowledge, code, testing and more to the project. We'd like to thank the entire Cockatrice community for their efforts<!--, and we'd like to especially recognize @ZeldaZach, --ADD-CONTRIBUTORS-HERE-- for their help in preparing so many amazing new features for the user base-->.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -389,15 +389,10 @@ https://github.com/Cockatrice/Cockatrice/wiki/Translation-FAQ).
 
 ### Publishing A New Release ###
 
-We use [GitHub Releases](https://github.com/Cockatrice/Cockatrice/releases) to publish 
-new stable versions and betas:
-- GitHub Actions will upload binaries (**Linux & macOS**) when any release is published 
-on GitHub.
-- AppVeyor will upload binaries (**Windows**) whenever a
-git "tag" is pushed to the repository.
-
-To trigger both processes correctly you can publish a tagged (pre-)release right on GitHub, 
-or create a tag manually first and use it for the (pre-)release creation afterwards.
+We use [GitHub Releases](https://github.com/Cockatrice/Cockatrice/releases) to
+publish new stable versions and betas.
+Whenever a git tag is pushed to the repository github will create a draft
+release and upload binaries automatically.
 
 To create a tag, simply do the following:
 ```bash
@@ -407,6 +402,7 @@ git pull
 git tag $TAG_NAME
 git push $UPSTREAM $TAG_NAME
 ```
+
 You should define the variables as such:
 ```
 `$UPSTREAM` - the remote for git@github.com:Cockatrice/Cockatrice.git
@@ -416,16 +412,14 @@ You should define the variables as such:
     With *MAJ.MIN.PATCH* being the NEXT release version!
 ```
 
->**Important:** You have to use the naming pattern `-beta` for the first beta release of one 
-version, followed by `-beta.2`, `-beta.3` and counting...
->This is crucial as Appveyor listens only for correct tags matching our defined pattern.
-
 This will cause a tagged release to be established on the GitHub repository,
-which will then lead to the upload of binaries by AppVeyor.
-If you use a SemVer tag including "beta", the release that will be created at GitHub 
-by AppVeyor will be marked as a "Pre-release" automatically.
-The target of the `.../latest` URL will not be changed in that case - 
-it always points to the latest stable release and not pre-releases/betas.
+with the binaries being added to the release whenever they are ready.
+The release is initially a draft, where the path notes can be edited and after
+all is good and ready it can be published on GitHub.
+If you use a SemVer tag including "beta", the release that will be created at
+GitHub will be marked as a "Pre-release" automatically.
+The target of the `.../latest` URL will not be changed in that case, it always
+points to the latest stable release and not pre-releases/betas.
 
 If you accidentally push a tag incorrectly (the tag is outdated, you didn't
 pull in the latest branch accidentally, you named the tag wrong, etc.) you can
@@ -434,32 +428,36 @@ revoke the tag by doing the following:
 git push --delete upstream $TAG_NAME
 git tag -d $TAG_NAME
 ```
+You can also do this on GitHub, you'll also want to delete the new release.
 
-**NOTE:** Unfortunately, due to the method of how AppVeyor works, to publish a
-stable release you will need to make a copy of the drafted release notes locally before 
-pushing the tag, and paste them back into the GitHub releases GUI once the binaries have 
-been uploaded by the CI.
-<br>
-The AppVeyor service will automatically overwrite the name of the release to 
-"Cockatrice $TAG_NAME".
-In addition, for beta releases, the status of the release will be set to "Pre-release", and
-the release body will get renamed to "Beta build of Cockatrice".
-
-**NOTE 2:** In the first lines of [CMakeLists.txt](
+In the first lines of [CMakeLists.txt](
 https://github.com/Cockatrice/Cockatrice/blob/master/CMakeLists.txt)
-there's an hardcoded version number used when compiling from master or custom (not tagged)
-versions. While on tagged versions these numbers are overridden by the version
-numbers coming from the tag title, it's good practice to increment the ones at CMake 
-after every full release to stress that master is ahead of the last stable release.
+there's an hardcoded version number and pretty name used when compiling from
+master or custom (not tagged) versions.
+While on tagged versions these numbers are overridden by the version numbers
+coming from the tag title, it's good practice to increment the ones at CMake
+after every full release to stress that master is ahead of the last stable
+release.
 The preferred flow of operation is:
  * Just before a release, make sure the version number in CMakeLists.txt is set
  to the same release version you are about to tag.
- * Tag the release following the previously described syntax in order to get it correctly 
- built and deployed by CI.
- * Wait for them to upload all binaries, then double check if everything is in order.
- * After the release is complete, update the CMake version number again to the next
- targeted beta version, typically increasing `PROJECT_VERSION_PATCH` by one.
+ * This is also the time to change the pretty name in CMakeLists.txt called
+ GIT_TAG_RELEASENAME and commit and push these changes.
+ * Tag the release following the previously described syntax in order to get it
+ correctly built and deployed by CI.
+ * Wait for the configure step to create the release and update the patch
+ notes.
+ * Check on the github actions page for build progress which should be the top
+ listed [here](
+ https://github.com/Cockatrice/Cockatrice/actions?query=event%3Apush+-branch%3Amaster
+ ).
+ * When the build has been completed you can verify all uploaded files on the
+ release are in order and hit the publish button.
+ * After the release is complete, update the CMake version number again to the
+ next targeted beta version, typically increasing `PROJECT_VERSION_PATCH` by
+ one.
 
-**NOTE 3:** When releasing a new stable version, all previous beta releases (and tags) 
+When releasing a new stable version, all previous beta releases (and tags)
 should be deleted. This is needed for Cockatrice to update users of the "Beta"
 release channel correctly to the latest stable version as well.
+This can be done the same way as revoking tags, mentioned above.

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -72,7 +72,7 @@ jobs:
           release_name: ${{steps.prepare.outputs.title}}
           body_path: ${{steps.prepare.outputs.body_path}}
           draft: true
-          prerelease: ${{steps.configure.prepare.is_beta == 'yes'}}
+          prerelease: ${{steps.prepare.outputs.is_beta == 'yes'}}
 
   build-linux:
     strategy:

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -22,9 +22,8 @@ jobs:
 
     outputs:
       tag: ${{steps.configure.outputs.tag}}
-      upload_url: ${{steps.create_release.outputs.upload_url}}
-      is_beta: ${{steps.configure.outputs.is_beta}}
       sha: ${{steps.configure.outputs.sha}}
+      upload_url: ${{steps.create_release.outputs.upload_url}}
 
     steps:
       - name: Cancel previous runs
@@ -37,20 +36,12 @@ jobs:
         shell: bash
         run: |
           tag_regex='^refs/tags/'
-          beta_regex='beta'
           if [[ $GITHUB_EVENT_NAME == pull-request ]]; then # pull request
             sha="${{github.event.pull_request.head.sha}}"
           elif [[ $GITHUB_REF =~ $tag_regex ]]; then # release
-            tag="${GITHUB_REF/refs\/tags\//}"
             sha="$GITHUB_SHA"
+            tag="${GITHUB_REF/refs\/tags\//}"
             echo "::set-output name=tag::$tag"
-            if [[ $tag =~ beta_regex ]]; then
-              echo "::set-output name=is_beta::yes"
-            else
-              echo "::set-output name=is_beta::no"
-              version="${tag##*-}"
-              echo "::set-output name=version::$version"
-            fi
           else # push to branch
             sha="$GITHUB_SHA"
           fi
@@ -59,29 +50,16 @@ jobs:
       - name: Checkout
         if: steps.configure.outputs.tag != null
         uses: actions/checkout@v2
+        with:
+          depth: 0
 
-      - name: Create release title
-        id: title
+      - name: Prepare release paramaters
+        id: prepare
         if: steps.configure.outputs.tag != null
         shell: bash
-        run: |
-          name_regex='set\(GIT_TAG_RELEASENAME "([[:print:]]+)")'
-          if [[ "${{steps.configure.outputs.is_beta}}" == "yes" ]]; then
-            title="${{steps.configure.outputs.tag}}"
-            echo "creating beta release '$title'"
-          else
-            if [[ $(cat CMakeLists.txt) =~ $name_regex ]]; then
-              name="${BASH_REMATCH[1]}"
-              version="${{steps.configure.outputs.version}}"
-              title="Cockatrice $version: $name"
-              echo "::set-output name=friendly_name::$name"
-              echo "creating full release '$title'"
-            else
-              echo "::error::could not find releasename in CMakeLists.txt"
-              exit 1
-            fi
-          fi
-          echo "::set-output name=title::$title"
+        env:
+          TAG: ${{steps.configure.outputs.tag}}
+        run: .ci/prep_release.sh
 
       - name: Create release
         if: steps.configure.outputs.tag != null
@@ -91,9 +69,10 @@ jobs:
           GITHUB_TOKEN: ${{github.token}}
         with:
           tag_name: ${{github.ref}}
-          release_name: ${{steps.title.outputs.title}}
+          release_name: ${{steps.prepare.outputs.title}}
+          release_body: ${{steps.prepare.outputs.body}}
           draft: true
-          prerelease: ${{steps.configure.outputs.is_beta == 'yes'}}
+          prerelease: ${{steps.configure.prepare.is_beta == 'yes'}}
 
   build-linux:
     strategy:

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -51,7 +51,7 @@ jobs:
         if: steps.configure.outputs.tag != null
         uses: actions/checkout@v2
         with:
-          depth: 0
+          fetch-depth: 0
 
       - name: Prepare release paramaters
         id: prepare
@@ -70,7 +70,7 @@ jobs:
         with:
           tag_name: ${{github.ref}}
           release_name: ${{steps.prepare.outputs.title}}
-          body: ${{steps.prepare.outputs.body}}
+          body_path: ${{steps.prepare.outputs.body_path}}
           draft: true
           prerelease: ${{steps.configure.prepare.is_beta == 'yes'}}
 

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           tag_name: ${{github.ref}}
           release_name: ${{steps.prepare.outputs.title}}
-          release_body: ${{steps.prepare.outputs.body}}
+          body: ${{steps.prepare.outputs.body}}
           draft: true
           prerelease: ${{steps.configure.prepare.is_beta == 'yes'}}
 


### PR DESCRIPTION
## Short roundup of the initial problem
Making software releases is rather bothersome

## What will change with this Pull Request?
- an almost complete template for release notes is generated when a release is drafted
- instructions to creating releases are refined

## Screenshots
here is a test release on my branch that I published after "unhiding" all of the commented out stuff:
https://github.com/ebbit1q/Cockatrice/releases/tag/2021-01-25-Release-2.7.6
