### PR TITLE
Add window icons in wayland

### DIFF
--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -151,6 +151,10 @@ int main(int argc, char *argv[])
     qDebug("main(): MainWindow constructor finished");
 
     ui.setWindowIcon(QPixmap("theme:cockatrice"));
+#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+    // set name of the app desktop file; used by wayland to load the window icon
+    QGuiApplication::setDesktopFileName("cockatrice");
+#endif
 
     SettingsCache::instance().setClientID(generateClientID());
 

--- a/oracle/src/main.cpp
+++ b/oracle/src/main.cpp
@@ -62,6 +62,10 @@ int main(int argc, char *argv[])
 
     QIcon icon("theme:appicon.svg");
     wizard.setWindowIcon(icon);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+    // set name of the app desktop file; used by wayland to load the window icon
+    QGuiApplication::setDesktopFileName("oracle");
+#endif
 
     wizard.show();
 


### PR DESCRIPTION
## Short roundup of the initial problem
Wayland handles application icons a bit differently from X11.
In the Qt code, you need to set the name of the ".desktop" file associated to the application, and Wayland will use the icon used by that same desktop file.

## What will change with this Pull Request?
Cockatrice and oracle will display their own icons in windows, instead of using the default wayland one.