### PR TITLE
don't sort split card halves alphabetically

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -377,45 +377,46 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet,
     }
 
     // split cards handling
-    QString splitCardPropSeparator = QString(" // ");
-    QString splitCardTextSeparator = QString("\n\n---\n\n");
+    static const QString splitCardPropSeparator = QString(" // ");
+    static const QString splitCardTextSeparator = QString("\n\n---\n\n");
     for (const QString &nameSplit : splitCards.uniqueKeys()) {
         // get all parts for this specific card
         QList<SplitCardPart> splitCardParts = splitCards.values(nameSplit);
-        // sort them by face name
-        std::sort(splitCardParts.begin(), splitCardParts.end(),
-                  [](const SplitCardPart &a, const SplitCardPart &b) -> bool { return a.getName() < b.getName(); });
+        QSet<QString> done{};
 
         text = QString("");
         properties.clear();
         relatedCards.clear();
 
-        QString lastName{};
         for (const SplitCardPart &tmp : splitCardParts) {
             // some sets have 2 different variations of the same split card,
             // eg. Fire // Ice in WC02. Avoid adding duplicates.
-            if (lastName == tmp.getName())
+            QString splitName = tmp.getName();
+            if (done.contains(splitName)) {
                 continue;
+            }
+            done.insert(splitName);
 
-            lastName = tmp.getName();
-
-            if (!text.isEmpty())
+            if (!text.isEmpty()) {
                 text.append(splitCardTextSeparator);
+            }
             text.append(tmp.getText());
 
             if (properties.isEmpty()) {
                 properties = tmp.getProperties();
                 setInfo = tmp.getSetInfo();
             } else {
-                const QVariantHash &props = tmp.getProperties();
-                for (const QString &prop : props.keys()) {
+                const QVariantHash &tmpProps = tmp.getProperties();
+                for (const QString &prop : tmpProps.keys()) {
                     QString originalPropertyValue = properties.value(prop).toString();
-                    QString thisCardPropertyValue = props.value(prop).toString();
-                    if (originalPropertyValue != thisCardPropertyValue) {
-                        if (prop == "colors") {
+                    QString thisCardPropertyValue = tmpProps.value(prop).toString();
+                    if (!thisCardPropertyValue.isEmpty() && originalPropertyValue != thisCardPropertyValue) {
+                        if (originalPropertyValue.isEmpty()) { // don't create //es if one field is empty
+                            properties.insert(prop, thisCardPropertyValue);
+                        } else if (prop == "colors") { // the card is both colors
                             properties.insert(prop, originalPropertyValue + thisCardPropertyValue);
                         } else if (prop == "maintype") { // don't create maintypes with //es in them
-                            properties.insert(prop, originalPropertyValue);
+                            continue;
                         } else {
                             properties.insert(prop,
                                               originalPropertyValue + splitCardPropSeparator + thisCardPropertyValue);


### PR DESCRIPTION
Split cards are sorted alphabetically before merging, resulting in the lower value half being the top/left/first side.
This affects aftermath, adventure and normal split cards.
examples:
giant killer // chop down
failure // comply
smelt // herd // saw

Instead the order in which they appear in mtgjson is used, which happily coincides with the order in which they should be except for adventures which we reverse in order.

fixes #4241