### PR TITLE
Improve release template

### DIFF
--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -48,17 +48,23 @@ Don't forget to update your card database right after! (<kbd>Help → Check for 
 This list is generated and should be moved to their respective header and
 possibly edited a little.
 Append PR numbers of fixups to their main PR to keep the list coherent.
-Remove empty headers after.
+Put the quantity of remaining PR's below the highlights section.
+Remove empty headers at the end.
 
 --REPLACE-WITH-GENERATED-LIST--
  -->
 
+<!-- Highlights of the release -->
 ### ⚠️ Important:
 ### ✨ New Features:
 ### 🐛 Fixed Bugs / Resolved issues:
 
+<!-- Complete list of changes (foldable) -->
 <details>
-<summary>📘 <b>Show all changes <code> <!-- NUMBER OF CHANGES --> </code></b></summary>
+<summary>📘 <b>Show all changes <code>
+<!-- Count of other changes -->
+ 
+</code></b></summary>
 
 ### User Interface
 ### Under the Hood

--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -49,7 +49,7 @@ This list is generated and should be moved to their respective header and
 possibly edited a little.
 Append PR numbers of fixups to their main PR to keep the list coherent.
 Put the quantity of remaining PR's below the highlights section.
-Remove empty headers at the end.
+Remove empty headers when done.
 
 --REPLACE-WITH-GENERATED-LIST--
  -->

--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -47,7 +47,7 @@ Don't forget to update your card database right after! (<kbd>Help → Check for 
 <!--
 This list is generated and should be moved to their respective header and
 possibly edited a little.
-Append PR numbers of fixups into their main PR to keep the list coherent.
+Append PR numbers of fixups to their main PR to keep the list coherent.
 Remove empty headers after.
 Use these label badges for highlighting important and key changes:
 <kbd>New!</kbd>

--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -53,11 +53,16 @@ Use these label badges for highlighting important and key changes:
 --REPLACE-WITH-GENERATED-LIST--
  -->
 
+<details>
+<summary>Show complete list of changes</summary>
+
 ### User Interface
 ### Under the Hood
 ### Oracle
 ### Servatrice
 ### Webatrice
+
+</details>
 
 ## Translations
 - **Thanks for over 300 people contributing to 20+ different languages up to now!**

--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -49,18 +49,13 @@ This list is generated and should be moved to their respective header and
 possibly edited a little.
 Append PR numbers of fixups to their main PR to keep the list coherent.
 Remove empty headers after.
-Use these label badges for highlighting important and key changes:
-<kbd>New!</kbd>
-<kbd>Fixed!</kbd> or <kbd>Resolved!</kbd>
 
 --REPLACE-WITH-GENERATED-LIST--
  -->
 
- - ⚠️ **Important:**
-
- - ✨ **New Features:**
-
- - 🐛 **Fixed Bugs / Resolved issues:**
+### ⚠️ Important:
+### ✨ New Features:
+### 🐛 Fixed Bugs / Resolved issues:
 
 <details>
 <summary>📘 <b>Show all changes <code> <!-- NUMBER OF CHANGES --> </code></b></summary>

--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -22,6 +22,7 @@ include different targets -->
 <kbd>General linux support is available via a flatpak package (Flathub)</kbd></i>
 </pre>
 
+
 ## General Notes
 
 <!-- --REPLACE-WITH-RELEASE-TITLE-- should be placed here by the ci -->
@@ -35,16 +36,18 @@ For any information relating to Cockatrice, please take a look at our official s
 
 If you'd like to help contribute to Cockatrice in any way, check out our [README](https://github.com/Cockatrice/Cockatrice#get-involved-). We're always available to answer questions you may have on how the program works and how you can provide a meaningful contribution.
 
+
 ## Upgrading Cockatrice
 - Run the internal software updater: <kbd>Help → Check for Client Updates</kbd>
 
 Don't forget to update your card database right after! (<kbd>Help → Check for Card Updates...</kbd>)
 
+
 ## Changelog
 <!--
-This list is generated and should be moved to their repective header and
+This list is generated and should be moved to their respective header and
 possibly edited a little.
-Move pr numbers of fixups into their main pr to keep the list coherent.
+Append PR numbers of fixups into their main PR to keep the list coherent.
 Remove empty headers after.
 Use these label badges for highlighting important and key changes:
 <kbd>New!</kbd>
@@ -53,8 +56,17 @@ Use these label badges for highlighting important and key changes:
 --REPLACE-WITH-GENERATED-LIST--
  -->
 
+ - ⚠️ **Important:**
+    - --REPLACE-WITH-HIGHLIGHTED-IMPORTANT-CHANGES--
+
+ - ✨ **New Features:**
+    - --REPLACE-WITH-HIGHLIGHTED-NEW-FEATURES--
+
+ - 🐛 **Fixed Bugs / Resolved issues:**
+    - --REPLACE-WITH-HIGHLIGHTED-FIXED-BUGS--
+
 <details>
-<summary>Show complete list of changes</summary>
+<summary>📘 <b>Show all changes <code> --REPLACE-WITH-CHANGES-COUNT-- </code></b></summary>
 
 ### User Interface
 ### Under the Hood
@@ -63,6 +75,7 @@ Use these label badges for highlighting important and key changes:
 ### Webatrice
 
 </details>
+
 
 ## Translations
 - **Thanks for over 300 people contributing to 20+ different languages up to now!**

--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -57,16 +57,13 @@ Use these label badges for highlighting important and key changes:
  -->
 
  - ⚠️ **Important:**
-    - --REPLACE-WITH-HIGHLIGHTED-IMPORTANT-CHANGES--
 
  - ✨ **New Features:**
-    - --REPLACE-WITH-HIGHLIGHTED-NEW-FEATURES--
 
  - 🐛 **Fixed Bugs / Resolved issues:**
-    - --REPLACE-WITH-HIGHLIGHTED-FIXED-BUGS--
 
 <details>
-<summary>📘 <b>Show all changes <code> --REPLACE-WITH-CHANGES-COUNT-- </code></b></summary>
+<summary>📘 <b>Show all changes <code> xx </code></b></summary>
 
 ### User Interface
 ### Under the Hood
@@ -82,6 +79,7 @@ Use these label badges for highlighting important and key changes:
 - Without the help of the community we couldn't offer that great language support... keep up the good work!
 - It's actually very easy to join and help for yourself - find out more here:
     - [Help us Translate Cockatrice into your native language!](https://github.com/Cockatrice/Cockatrice/wiki/Translation-FAQ)
+
 
 ## Special Thanks
 <!-- Personalise this a bit! -->

--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -63,7 +63,7 @@ Use these label badges for highlighting important and key changes:
  - 🐛 **Fixed Bugs / Resolved issues:**
 
 <details>
-<summary>📘 <b>Show all changes <code> xx </code></b></summary>
+<summary>📘 <b>Show all changes <code> <!-- NUMBER OF CHANGES --> </code></b></summary>
 
 ### User Interface
 ### Under the Hood


### PR DESCRIPTION
## Short roundup of the initial problem
Our releases feature many words and lines... they contain a lot of information and details.
While it makes no sense to leave half of them out, we could improve them still to transport the important information to users better.

If a user gets linked to a release in order to download the app for example, he has to scroll a lot and eventually finds the files he is looking for at the very bottom. GitHub used to have them at the top at one point I guess. They moved to the very end again.
Also, many every day users might not even be interested in the long and often technical list of every detailed change.

## What will change with this Pull Request?
- Make the long list of single changes viewable with a single click, but prominently hidden in the `Changelog` section
- Binaries are easier accessible at the bottom
- Release page/notes are more clear and less overwhelming in general

This would reduces the total required space of the most recent release by ~60% for example.
Any user interested in the changes in detail can still easily access them. It's not a hidden option somewhere in the dark.

**Idea if you think the actual changes are not visible and stressed enough with this:**
We could have a `Highlights` section with the most important and relevant changes to users above the collapsible one. Maybe along the lines with what we try to do with the <kbd>Fixed!</kbd> and <kbd>New</kbd> tags already. Just that they are mostly buried in the masses currently.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

- hidden
![small](https://user-images.githubusercontent.com/9874850/107539376-32cda780-6bc5-11eb-8b54-ae676b9e4b10.png)

- shown
![big](https://user-images.githubusercontent.com/9874850/107539396-36612e80-6bc5-11eb-9c40-e9814b9add58.png)

- end result after styling and release highlight section:
![Untitled](https://user-images.githubusercontent.com/9874850/107708937-a3a7b900-6cc4-11eb-92af-b988fe766d0e.png)