### PR TITLE
Skip linter run on .md only changes

### DIFF
--- a/.github/workflows/clangify.yml
+++ b/.github/workflows/clangify.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
     - master
+    paths-ignore:
+      - '**.md'
 
 jobs:
   linter:


### PR DESCRIPTION
## Short roundup of the initial problem
As realized in https://github.com/Cockatrice/Cockatrice/pull/4250, we do not skip the `Clangify` CI run in PR's which do only change markdown files.
The workflow for doing builds is correctly skipped.

## What will change with this Pull Request?
- Add exception for `.md` files.