### PR TITLE
use correct settings group for command interval settings

### DIFF
--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -286,11 +286,13 @@ Response::ResponseCode Server_ProtocolHandler::processGameCommandContainer(const
             if (!antifloodCommandsWhiteList.contains((GameCommand::GameCommandType)getPbExtension(sc)))
                 ++commandCountOverTime[0];
 
-            for (int i = 0; i < commandCountOverTime.size(); ++i)
+            for (int i = 0; i < commandCountOverTime.size(); ++i) {
                 totalCount += commandCountOverTime[i];
+            }
 
-            if (totalCount > maxCommandCountPerInterval)
+            if (maxCommandCountPerInterval > 0 && totalCount > maxCommandCountPerInterval) {
                 return Response::RespChatFlood;
+            }
         }
 
         Response::ResponseCode resp = player->processGameCommand(sc, rc, ges);
@@ -733,12 +735,16 @@ Server_ProtocolHandler::cmdRoomSay(const Command_RoomSay &cmd, Server_Room *room
         if (messageCountOverTime.isEmpty())
             messageCountOverTime.prepend(0);
         ++messageCountOverTime[0];
-        for (int i = 0; i < messageCountOverTime.size(); ++i)
+        for (int i = 0; i < messageCountOverTime.size(); ++i) {
             totalCount += messageCountOverTime[i];
+        }
 
-        if ((totalSize > server->getMaxMessageSizePerInterval()) ||
-            (totalCount > server->getMaxMessageCountPerInterval()))
+        int maxMessageSizePerInterval = server->getMaxMessageSizePerInterval();
+        int maxMessageCountPerInterval = server->getMaxMessageCountPerInterval();
+        if ((maxMessageSizePerInterval > 0 && totalSize > maxMessageSizePerInterval) ||
+            (maxMessageCountPerInterval > 0 && totalCount > maxMessageCountPerInterval)) {
             return Response::RespChatFlood;
+        }
     }
     msg.replace(QChar('\n'), QChar(' '));
 

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -955,12 +955,12 @@ int Servatrice::getMaxGamesPerUser() const
 
 int Servatrice::getCommandCountingInterval() const
 {
-    return settingsCache->value("game/command_counting_interval", 10).toInt();
+    return settingsCache->value("security/command_counting_interval", 10).toInt();
 }
 
 int Servatrice::getMaxCommandCountPerInterval() const
 {
-    return settingsCache->value("game/max_command_count_per_interval", 20).toInt();
+    return settingsCache->value("security/max_command_count_per_interval", 20).toInt();
 }
 
 int Servatrice::getServerStatusUpdateTime() const


### PR DESCRIPTION
## Related Ticket(s)
- Missed in https://github.com/Cockatrice/Cockatrice/pull/829 and has gone unnoticed for 5 years, my theory is copy paste error.

## Short roundup of the initial problem
https://github.com/Cockatrice/Cockatrice/pull/959#issuecomment-92231375

## What will change with this Pull Request?
- the settings command_counting_interval and max_command_count_per_interval are now in the [security] group as hinted by their location in servatrice.ini.example
- check values of comand interval settings before use