### PR TITLE
temporary workaround for arch libc version requiring upgraded host

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -78,13 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: # these names correspond to the files in .ci/$distro
-          - UbuntuGroovy
-          - UbuntuFocal
-          - UbuntuBionic
-          - ArchLinux
-          - DebianBuster
-          - Fedora33
+        # these names correspond to the files in .ci/$distro
         include:
           - distro: UbuntuGroovy
             package: DEB
@@ -140,7 +134,14 @@ jobs:
 
       - name: Build ${{matrix.distro}} Docker image
         shell: bash
-        run: source .ci/docker.sh --build
+        run: |
+          # temporary workaround for arch libc version requiring upgraded host
+          # see https://bugs.archlinux.org/task/69563#comment196582
+          if [[ $NAME == ArchLinux ]]; then
+            wget http://ftp.us.debian.org/debian/pool/main/r/runc/runc_1.0.0~rc93+ds1-2_amd64.deb
+            sudo dpkg -i --force-conflicts runc*.deb
+          fi
+          source .ci/docker.sh --build
 
       - name: Build debug and test
         if: matrix.test != 'skip'


### PR DESCRIPTION
see https://bugs.archlinux.org/task/69563#comment196582

Arch linux builds have some incompatibility when in containers with some host systems, while this isn't a problem for builds it just doesn't look very nice.