### PR TITLE
implement a maximum amount of cardmenus generated for views

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -18,9 +18,15 @@
 #include <QMenu>
 #include <QPainter>
 
-CardItem::CardItem(Player *_owner, const QString &_name, int _cardid, bool _revealedCard, QGraphicsItem *parent)
-    : AbstractCardItem(_name, _owner, _cardid, parent), zone(0), revealedCard(_revealedCard), attacking(false),
-      destroyOnZoneChange(false), doesntUntap(false), dragItem(0), attachedTo(0)
+CardItem::CardItem(Player *_owner,
+                   const QString &_name,
+                   int _cardid,
+                   bool _revealedCard,
+                   QGraphicsItem *parent,
+                   CardZone *_zone,
+                   bool updateMenu)
+    : AbstractCardItem(_name, _owner, _cardid, parent), zone(_zone), revealedCard(_revealedCard), attacking(false),
+      destroyOnZoneChange(false), doesntUntap(false), dragItem(nullptr), attachedTo(nullptr)
 {
     owner->addCard(this);
 
@@ -29,7 +35,9 @@ CardItem::CardItem(Player *_owner, const QString &_name, int _cardid, bool _reve
     moveMenu = new QMenu;
 
     retranslateUi();
-    emit updateCardMenu(this);
+    if (updateMenu) { // avoid updating card menu too often
+        emit updateCardMenu(this);
+    }
 }
 
 CardItem::~CardItem()
@@ -382,7 +390,7 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
         }
     }
 
-    if (owner != nullptr){ // cards without owner will be deleted
+    if (owner != nullptr) { // cards without owner will be deleted
         setCursor(Qt::OpenHandCursor);
     }
     AbstractCardItem::mouseReleaseEvent(event);

--- a/cockatrice/src/carditem.h
+++ b/cockatrice/src/carditem.h
@@ -52,7 +52,9 @@ public:
              const QString &_name = QString(),
              int _cardid = -1,
              bool revealedCard = false,
-             QGraphicsItem *parent = nullptr);
+             QGraphicsItem *parent = nullptr,
+             CardZone *_zone = nullptr,
+             bool updateMenu = false);
     ~CardItem();
     void retranslateUi();
     CardZone *getZone() const

--- a/cockatrice/src/zoneviewzone.cpp
+++ b/cockatrice/src/zoneviewzone.cpp
@@ -81,15 +81,19 @@ void ZoneViewZone::initializeCards(const QList<const ServerInfo_Card *> &cardLis
 
 void ZoneViewZone::zoneDumpReceived(const Response &r)
 {
+    static constexpr int MAX_VIEW_MENU = 300;
     const Response_DumpZone &resp = r.GetExtension(Response_DumpZone::ext);
     const int respCardListSize = resp.zone_info().card_list_size();
     for (int i = 0; i < respCardListSize; ++i) {
         const ServerInfo_Card &cardInfo = resp.zone_info().card_list(i);
-        CardItem *card = new CardItem(player, QString::fromStdString(cardInfo.name()), cardInfo.id(), revealZone, this);
-        addCard(card, false, i);
+        auto cardName = QString::fromStdString(cardInfo.name());
+        // stop updating card menus after MAX_VIEW_MENU cards
+        // this means only the first cards in the menu have actions but others can still be dragged
+        auto *card = new CardItem(player, cardName, cardInfo.id(), revealZone, this, this, i < MAX_VIEW_MENU);
+        cards.insert(i, card);
     }
-
     reorganizeCards();
+    emit cardCountChanged();
 }
 
 // Because of boundingRect(), this function must not be called before the zone was added to a scene.


### PR DESCRIPTION
## Related Ticket(s)
- Fixes https://github.com/Cockatrice/Cockatrice/issues/4259

## Short roundup of the initial problem
Opening a large deck in a view results in a long wait while it connects every single action on the card which is expensive af, the smart way to do this would be to only populate the menu when needed but this works for now....

## What will change with this Pull Request?
- only the first 300 cards in card views will get card actions, other cards will have to be dragged to the top of the deck in order to populate the right click menu now
- pressing f3 with a deck containing every card in mtg will not take your soul
- starting the game with that deck will still take forever

also as a note, testing reveals all the bottleneck is concentrated on card menu creation, servers etc do not experience any load at all.
