### PR TITLE
GitHub Actions: Exclude webclient changes from builds

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths-ignore:
       - '**.md'
+      - 'webclient/**'
     tags:
       - '*'
   pull_request:
@@ -13,6 +14,7 @@ on:
       - master
     paths-ignore:
       - '**.md'
+      - 'webclient/**'
 
 jobs:
   configure:


### PR DESCRIPTION
## Related Ticket(s)
- Related #4269

## Short roundup of the initial problem
Any changes on the Cockatrice webclient triggered our long CI build runs only targeting the Cockatrice desktop app.

## What will change with this Pull Request?
- Exclude changes in the `webclient` folder