### PR TITLE
disallow rich text in deck comments

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -87,6 +87,7 @@ void TabDeckEditor::createDeckDock()
     commentsLabel = new QLabel();
     commentsLabel->setObjectName("commentsLabel");
     commentsEdit = new QTextEdit;
+    commentsEdit->setAcceptRichText(false);
     commentsEdit->setMinimumHeight(nameEdit->minimumSizeHint().height());
     commentsEdit->setObjectName("commentsEdit");
     commentsLabel->setBuddy(commentsEdit);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4255

## Short roundup of the initial problem
comments allow rich text formatting when pasted into

## What will change with this Pull Request?
- turns it off