### PR TITLE
CI: Pin Qt installation to v5.x on mac

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -256,7 +256,7 @@ jobs:
         id: brew_install_qt
         continue-on-error: true
         shell: bash
-        run: brew install qt --force-bottle
+        run: brew install qt@5 --force-bottle
 
       - name: Install QT using actions
         if: steps.brew_install_qt.outcome != 'success'


### PR DESCRIPTION
## Short roundup of the initial problem
All macOS builds are failing in CI.
Homebrew is using Qt6 as default now: https://formulae.brew.sh/formula/qt ([See our logs](https://github.com/Cockatrice/Cockatrice/runs/2058582631#step:4:42))

## What will change with this Pull Request?
- Use [qt@5](https://formulae.brew.sh/formula/qt@5) instead (currently 5.15.2)