### PR TITLE
only invalidate undoDrawList up to moved card

### DIFF
--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -426,11 +426,13 @@ Response::ResponseCode Server_Player::moveCard(GameEventStorage &ges,
         int position = startzone->removeCard(card);
 
         // "Undo draw" should only remain valid if the just-drawn card stays within the user's hand (e.g., they only
-        // reorder their hand). If a just-drawn card leaves the hand then clear lastDrawList to invalidate "undo draw."
+        // reorder their hand). If a just-drawn card leaves the hand then remove cards before it from the list
         // (Ignore the case where the card is currently being un-drawn.)
-        if (startzone->getName() == "hand" && targetzone->getName() != "hand" && lastDrawList.contains(card->getId()) &&
-            !undoingDraw) {
-            lastDrawList.clear();
+        if (startzone->getName() == "hand" && targetzone->getName() != "hand" && !undoingDraw) {
+            int index = lastDrawList.lastIndexOf(card->getId());
+            if (index != -1) {
+                lastDrawList.erase(lastDrawList.begin(), lastDrawList.begin() + index);
+            }
         }
 
         // Attachment relationships can be retained when moving a card onto the opponent's table


### PR DESCRIPTION
## Related Ticket(s)
- https://github.com/Cockatrice/Cockatrice/pull/4152

## Short roundup of the initial problem
#4152 introduced the ability to still undo card draws even after playing other cards
this would introduce inconsistency where you could draw cards and simply continue playing without touching the drawn cards and suddenly undraw it, but not if you touched any of these cards.

## What will change with this Pull Request?
- behavior is now consistent, all cards drawn after the most recently removed card are now possible to undo
  - this means you can still undo a draw if you drew one card too many and continued playing without "compromising" the board state
- another option was to allow the card before it to be "undrawn" until the hand is empty
- the simplest would be to always clear the list if a card leaves it, this was discussed in #4152
