### PR TITLE
Create game as spectator

### DIFF
--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -83,11 +83,13 @@ void DlgCreateGame::sharedCtor()
     spectatorsNeedPasswordCheckBox = new QCheckBox(tr("Spectators &need a password to watch"));
     spectatorsCanTalkCheckBox = new QCheckBox(tr("Spectators can &chat"));
     spectatorsSeeEverythingCheckBox = new QCheckBox(tr("Spectators can see &hands"));
+    createGameAsSpectatorCheckBox = new QCheckBox(tr("Create game as spectator"));
     QVBoxLayout *spectatorsLayout = new QVBoxLayout;
     spectatorsLayout->addWidget(spectatorsAllowedCheckBox);
     spectatorsLayout->addWidget(spectatorsNeedPasswordCheckBox);
     spectatorsLayout->addWidget(spectatorsCanTalkCheckBox);
     spectatorsLayout->addWidget(spectatorsSeeEverythingCheckBox);
+    spectatorsLayout->addWidget(createGameAsSpectatorCheckBox);
     spectatorsGroupBox = new QGroupBox(tr("Spectators"));
     spectatorsGroupBox->setLayout(spectatorsLayout);
 
@@ -129,6 +131,7 @@ DlgCreateGame::DlgCreateGame(TabRoom *_room, const QMap<int, QString> &_gameType
     spectatorsNeedPasswordCheckBox->setChecked(SettingsCache::instance().getSpectatorsNeedPassword());
     spectatorsCanTalkCheckBox->setChecked(SettingsCache::instance().getSpectatorsCanTalk());
     spectatorsSeeEverythingCheckBox->setChecked(SettingsCache::instance().getSpectatorsCanSeeEverything());
+    createGameAsSpectatorCheckBox->setChecked(SettingsCache::instance().getCreateGameAsSpectator());
 
     if (!rememberGameSettings->isChecked()) {
         actReset();
@@ -159,6 +162,7 @@ DlgCreateGame::DlgCreateGame(const ServerInfo_Game &gameInfo, const QMap<int, QS
     spectatorsNeedPasswordCheckBox->setEnabled(false);
     spectatorsCanTalkCheckBox->setEnabled(false);
     spectatorsSeeEverythingCheckBox->setEnabled(false);
+    createGameAsSpectatorCheckBox->setEnabled(false);
 
     descriptionEdit->setText(QString::fromStdString(gameInfo.description()));
     maxPlayersEdit->setValue(gameInfo.max_players());
@@ -200,6 +204,7 @@ void DlgCreateGame::actReset()
     spectatorsNeedPasswordCheckBox->setChecked(false);
     spectatorsCanTalkCheckBox->setChecked(false);
     spectatorsSeeEverythingCheckBox->setChecked(false);
+    createGameAsSpectatorCheckBox->setChecked(false);
 
     QMapIterator<int, QRadioButton *> gameTypeCheckBoxIterator(gameTypeCheckBoxes);
     while (gameTypeCheckBoxIterator.hasNext()) {
@@ -226,6 +231,7 @@ void DlgCreateGame::actOK()
     cmd.set_spectators_can_talk(spectatorsCanTalkCheckBox->isChecked());
     cmd.set_spectators_see_everything(spectatorsSeeEverythingCheckBox->isChecked());
     cmd.set_join_as_judge(QApplication::keyboardModifiers() & Qt::ShiftModifier);
+    cmd.set_join_as_spectator(createGameAsSpectatorCheckBox->isChecked());
 
     QString gameTypes = QString();
     QMapIterator<int, QRadioButton *> gameTypeCheckBoxIterator(gameTypeCheckBoxes);
@@ -247,6 +253,7 @@ void DlgCreateGame::actOK()
         SettingsCache::instance().setSpectatorsNeedPassword(spectatorsNeedPasswordCheckBox->isChecked());
         SettingsCache::instance().setSpectatorsCanTalk(spectatorsCanTalkCheckBox->isChecked());
         SettingsCache::instance().setSpectatorsCanSeeEverything(spectatorsSeeEverythingCheckBox->isChecked());
+        SettingsCache::instance().setCreateGameAsSpectator(createGameAsSpectatorCheckBox->isChecked());
         SettingsCache::instance().setGameTypes(gameTypes);
     }
     PendingCommand *pend = room->prepareRoomCommand(cmd);

--- a/cockatrice/src/dlg_creategame.h
+++ b/cockatrice/src/dlg_creategame.h
@@ -39,7 +39,7 @@ private:
     QSpinBox *maxPlayersEdit;
     QCheckBox *onlyBuddiesCheckBox, *onlyRegisteredCheckBox;
     QCheckBox *spectatorsAllowedCheckBox, *spectatorsNeedPasswordCheckBox, *spectatorsCanTalkCheckBox,
-        *spectatorsSeeEverythingCheckBox;
+        *spectatorsSeeEverythingCheckBox, *createGameAsSpectatorCheckBox;
     QDialogButtonBox *buttonBox;
     QPushButton *clearButton;
     QCheckBox *rememberGameSettings;

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -278,8 +278,6 @@ void GamesModel::updateGameList(const ServerInfo_Game &game)
             return;
         }
     }
-    if (game.player_count() <= 0)
-        return;
     beginInsertRows(QModelIndex(), gameList.size(), gameList.size());
     gameList.append(game);
     endInsertRows();

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -284,6 +284,7 @@ SettingsCache::SettingsCache()
     spectatorsNeedPassword = settings->value("game/spectatorsneedpassword", false).toBool();
     spectatorsCanTalk = settings->value("game/spectatorscantalk", false).toBool();
     spectatorsCanSeeEverything = settings->value("game/spectatorscanseeeverything", false).toBool();
+    createGameAsSpectator = settings->value("game/creategameasspectator", false).toBool();
     rememberGameSettings = settings->value("game/remembergamesettings", true).toBool();
     clientID = settings->value("personal/clientid", CLIENT_INFO_NOT_SET).toString();
     clientVersion = settings->value("personal/clientversion", CLIENT_INFO_NOT_SET).toString();
@@ -938,6 +939,12 @@ void SettingsCache::setSpectatorsCanSeeEverything(const bool _spectatorsCanSeeEv
 {
     spectatorsCanSeeEverything = _spectatorsCanSeeEverything;
     settings->setValue("game/spectatorscanseeeverything", spectatorsCanSeeEverything);
+}
+
+void SettingsCache::setCreateGameAsSpectator(const bool _createGameAsSpectator)
+{
+    createGameAsSpectator = _createGameAsSpectator;
+    settings->setValue("game/creategameasspectator", createGameAsSpectator);
 }
 
 void SettingsCache::setRememberGameSettings(const bool _rememberGameSettings)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -124,6 +124,7 @@ private:
     bool spectatorsNeedPassword;
     bool spectatorsCanTalk;
     bool spectatorsCanSeeEverything;
+    bool createGameAsSpectator;
     int keepalive;
     void translateLegacySettings();
     QString getSafeConfigPath(QString configEntry, QString defaultPath) const;
@@ -394,6 +395,10 @@ public:
     {
         return spectatorsCanSeeEverything;
     }
+    bool getCreateGameAsSpectator() const
+    {
+        return createGameAsSpectator;
+    }
     bool getRememberGameSettings() const
     {
         return rememberGameSettings;
@@ -525,6 +530,7 @@ public slots:
     void setSpectatorsNeedPassword(const bool _spectatorsNeedPassword);
     void setSpectatorsCanTalk(const bool _spectatorsCanTalk);
     void setSpectatorsCanSeeEverything(const bool _spectatorsCanSeeEverything);
+    void setCreateGameAsSpectator(const bool _createGameAsSpectator);
     void setRememberGameSettings(const bool _rememberGameSettings);
     void setNotifyAboutUpdate(int _notifyaboutupdate);
     void setNotifyAboutNewVersion(int _notifyaboutnewversion);

--- a/cockatrice/src/user_context_menu.cpp
+++ b/cockatrice/src/user_context_menu.cpp
@@ -66,7 +66,7 @@ void UserContextMenu::retranslateUi()
     aBanHistory->setText(tr("View user's &ban history"));
     aPromoteToMod->setText(tr("&Promote user to moderator"));
     aDemoteFromMod->setText(tr("Dem&ote user from moderator"));
-    aPromoteToJudge->setText(tr("Promote user to &juge"));
+    aPromoteToJudge->setText(tr("Promote user to &judge"));
     aDemoteFromJudge->setText(tr("Demote user from judge"));
 }
 

--- a/common/pb/room_commands.proto
+++ b/common/pb/room_commands.proto
@@ -37,6 +37,7 @@ message Command_CreateGame {
     optional bool spectators_see_everything = 9;
     repeated uint32 game_type_ids = 10;
     optional bool join_as_judge = 11;
+    optional bool join_as_spectator = 12;
 }
 
 message Command_JoinGame {

--- a/common/server_game.cpp
+++ b/common/server_game.cpp
@@ -452,14 +452,18 @@ void Server_Game::addPlayer(Server_AbstractUserInterface *userInterface,
     sendGameEventContainer(prepareGameEvent(joinEvent, -1));
 
     const QString playerName = QString::fromStdString(newPlayer->getUserInfo()->name());
-    if (spectator)
-        allSpectatorsEver.insert(playerName);
-    else
-        allPlayersEver.insert(playerName);
     players.insert(newPlayer->getPlayerId(), newPlayer);
-    if (newPlayer->getUserInfo()->name() == creatorInfo->name()) {
-        hostId = newPlayer->getPlayerId();
-        sendGameEventContainer(prepareGameEvent(Event_GameHostChanged(), hostId));
+    if (spectator) {
+        allSpectatorsEver.insert(playerName);
+    } else {
+        allPlayersEver.insert(playerName);
+
+        // if the original creator of the game joins, give them host status back
+        // FIXME: transferring host to spectators has side effects
+        if (newPlayer->getUserInfo()->name() == creatorInfo->name()) {
+            hostId = newPlayer->getPlayerId();
+            sendGameEventContainer(prepareGameEvent(Event_GameHostChanged(), hostId));
+        }
     }
 
     if (broadcastUpdate) {

--- a/common/server_game.cpp
+++ b/common/server_game.cpp
@@ -173,20 +173,22 @@ void Server_Game::pingClockTimeout()
         if (player == nullptr)
             continue;
 
-        if (!player->getSpectator())
+        if (!player->getSpectator()) {
             ++playerCount;
+        }
 
         int oldPingTime = player->getPingTime();
         int newPingTime;
-        player->playerMutex.lock();
-        if (player->getUserInterface()) {
-            newPingTime = player->getUserInterface()->getLastCommandTime();
-        } else {
-            newPingTime = -1;
+        {
+            QMutexLocker playerMutexLocker(&player->playerMutex);
+            if (player->getUserInterface()) {
+                newPingTime = player->getUserInterface()->getLastCommandTime();
+            } else {
+                newPingTime = -1;
+            }
         }
-        player->playerMutex.unlock();
 
-        if ((newPingTime != -1) && !player->getSpectator()) {
+        if ((newPingTime != -1) && (!player->getSpectator() || player->getPlayerId() == hostId)) {
             allPlayersInactive = false;
         }
 

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -769,17 +769,21 @@ Server_ProtocolHandler::cmdCreateGame(const Command_CreateGame &cmd, Server_Room
     auto level = userInfo->user_level();
     bool isJudge = level & ServerInfo_User::IsJudge;
     int maxGames = server->getMaxGamesPerUser();
-    if (maxGames > 0 && room->getGamesCreatedByUser(QString::fromStdString(userInfo->name())) >= maxGames) {
+    bool asJudge = cmd.join_as_judge();
+    bool asSpectator = cmd.join_as_spectator();
+    // allow judges to open games as spectator without limit to facilitate bots etc, -1 means no limit
+    if (!(isJudge && asJudge && asSpectator) && maxGames >= 0 &&
+        room->getGamesCreatedByUser(QString::fromStdString(userInfo->name())) >= maxGames) {
         return Response::RespContextError;
     }
 
-    // only if the server disallows normal users to create games as judge is being a judge required
-    if (cmd.join_as_judge() && !(server->permitCreateGameAsJudge() || isJudge)) {
-        return Response::RespContextError;
+    // if a non judge user tries to create a game as judge while not permitted, instead create a normal game
+    if (asJudge && !(server->permitCreateGameAsJudge() || isJudge)) {
+        asJudge = false;
     }
 
     QList<int> gameTypes;
-    for (int i = cmd.game_type_ids_size() - 1; i >= 0; --i) {
+    for (int i = cmd.game_type_ids_size() - 1; i >= 0; --i) { // FIXME: why are these iterated in reverse?
         gameTypes.append(cmd.game_type_ids(i));
     }
 
@@ -792,7 +796,7 @@ Server_ProtocolHandler::cmdCreateGame(const Command_CreateGame &cmd, Server_Room
         cmd.only_buddies(), onlyRegisteredUsers, cmd.spectators_allowed(), cmd.spectators_need_password(),
         cmd.spectators_can_talk(), cmd.spectators_see_everything(), room);
 
-    game->addPlayer(this, rc, false, cmd.join_as_judge(), false);
+    game->addPlayer(this, rc, asSpectator, asJudge, false);
     room->addGame(game);
 
     return Response::RespOk;

--- a/common/server_room.cpp
+++ b/common/server_room.cpp
@@ -263,8 +263,9 @@ Response::ResponseCode Server_Room::processJoinGameCommand(const Command_JoinGam
 
     QMutexLocker gameLocker(&game->gameMutex);
 
-    Response::ResponseCode result = game->checkJoin(userInterface->getUserInfo(), QString::fromStdString(cmd.password()),
-                                                 cmd.spectator(), cmd.override_restrictions(), cmd.join_as_judge());
+    Response::ResponseCode result =
+        game->checkJoin(userInterface->getUserInfo(), QString::fromStdString(cmd.password()), cmd.spectator(),
+                        cmd.override_restrictions(), cmd.join_as_judge());
     if (result == Response::RespOk)
         game->addPlayer(userInterface, rc, cmd.spectator(), cmd.join_as_judge());
 

--- a/common/server_room.cpp
+++ b/common/server_room.cpp
@@ -243,8 +243,8 @@ Response::ResponseCode Server_Room::processJoinGameCommand(const Command_JoinGam
     // server->roomsMutex is always locked.
 
     QReadLocker roomGamesLocker(&gamesLock);
-    Server_Game *g = games.value(cmd.game_id());
-    if (!g) {
+    Server_Game *game = games.value(cmd.game_id());
+    if (!game) {
         if (externalGames.contains(cmd.game_id())) {
             CommandContainer cont;
             cont.set_cmd_id(rc.getCmdId());
@@ -256,16 +256,17 @@ Response::ResponseCode Server_Room::processJoinGameCommand(const Command_JoinGam
                                              userInterface->getUserInfo()->session_id(), id);
 
             return Response::RespNothing;
-        } else
+        } else {
             return Response::RespNameNotFound;
+        }
     }
 
-    QMutexLocker gameLocker(&g->gameMutex);
+    QMutexLocker gameLocker(&game->gameMutex);
 
-    Response::ResponseCode result = g->checkJoin(userInterface->getUserInfo(), QString::fromStdString(cmd.password()),
+    Response::ResponseCode result = game->checkJoin(userInterface->getUserInfo(), QString::fromStdString(cmd.password()),
                                                  cmd.spectator(), cmd.override_restrictions(), cmd.join_as_judge());
     if (result == Response::RespOk)
-        g->addPlayer(userInterface, rc, cmd.spectator(), cmd.join_as_judge());
+        game->addPlayer(userInterface, rc, cmd.spectator(), cmd.join_as_judge());
 
     return result;
 }

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -242,6 +242,9 @@ void SettingsCache::setSpectatorsCanTalk(const bool /* _spectatorsCanTalk */)
 void SettingsCache::setSpectatorsCanSeeEverything(const bool /* _spectatorsCanSeeEverything */)
 {
 }
+void SettingsCache::setCreateGameAsSpectator(const bool /* _createGameAsSpectator */)
+{
+}
 void SettingsCache::setRememberGameSettings(const bool /* _rememberGameSettings */)
 {
 }

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -344,7 +344,7 @@ max_message_size_per_interval=1000
 ; Maximum number of messages in an interval before new messages gets dropped; default is 10
 max_message_count_per_interval=10
 
-; Maximum number of games a single user can create; default is 5
+; Maximum number of games a single user can create; default is 5; set to -1 to disable; 0 disallows game creation
 max_games_per_user=5
 
 ; Servatrice can avoid users from flooding games with large number of game commands in an interval of time.

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -246,6 +246,9 @@ void SettingsCache::setSpectatorsCanTalk(const bool /* _spectatorsCanTalk */)
 void SettingsCache::setSpectatorsCanSeeEverything(const bool /* _spectatorsCanSeeEverything */)
 {
 }
+void SettingsCache::setCreateGameAsSpectator(const bool /* _createGameAsSpectator */)
+{
+}
 void SettingsCache::setRememberGameSettings(const bool /* _rememberGameSettings */)
 {
 }


### PR DESCRIPTION
## Short roundup of the initial problem
This seems to be a useful feature for tournament organisers, allowing to create a game for participants

## What will change with this Pull Request?
- allow creation of games as spectator
- add settings and menu items for this
- allow elevated users to create games as spectator in judge mode without limit
- allow setting the limit to 0 effectively disallowing other users to create games
- change the function for automatically closing inactive games to check for the presence of an active host player instead of counting players, this prevents games being closed automatically while the host is spectating
- allow users to see 0 player games in the games list
- disallow the transfer of the host status to spectators, this caused strange issues where the host status wasn't properly signaled, this issue is also present on master but is harmless, I don't think users rejoining a game as spectator should be given host status

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![image](https://user-images.githubusercontent.com/36401181/111020020-41c19880-83c3-11eb-89cc-bdb8f7599b3d.png)
