### PR TITLE
fix #4249

### DIFF
--- a/clangify.sh
+++ b/clangify.sh
@@ -11,7 +11,8 @@ cd "${BASH_SOURCE%/*}/" || exit 2 # could not find path, this could happen with 
 include=("common" \
 "cockatrice/src" \
 "oracle/src" \
-"servatrice/src")
+"servatrice/src" \
+"tests")
 exclude=("servatrice/src/smtp" \
 "common/sfmt" \
 "common/lib" \

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -492,7 +492,9 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
     const QRegularExpression reEmpty("^\\s*$");
     const QRegularExpression reComment("[\\w\\[\\(\\{].*$", QRegularExpression::UseUnicodePropertiesOption);
     const QRegularExpression reSBMark("^\\s*sb:\\s*(.+)", QRegularExpression::CaseInsensitiveOption);
-    const QRegularExpression reSBComment("sideboard", QRegularExpression::CaseInsensitiveOption);
+    const QRegularExpression reSBComment("^sideboard\\b.*$", QRegularExpression::CaseInsensitiveOption);
+    const QRegularExpression reDeckComment("^((main)?deck(list)?|mainboard)\\b",
+                                           QRegularExpression::CaseInsensitiveOption);
 
     // simplified matches
     const QRegularExpression reMultiplier("^[xX\\(\\[]*(\\d+)[xX\\*\\)\\]]* ?(.+)");
@@ -562,6 +564,16 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
         }
     }
     comments.chop(1); // remove last newline
+
+    // discard empty lines
+    while (index < max_line && inputs.at(index).contains(reEmpty)) {
+        ++index;
+    }
+
+    // discard line if it starts with deck or mainboard, all cards until the sideboard starts are in the mainboard
+    if (inputs.at(index).contains(reDeckComment)) {
+        ++index;
+    }
 
     // parse decklist
     for (; index < max_line; ++index) {

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -165,6 +165,39 @@ TEST(LoadingFromClipboardTest, CommentsBeforeCardsTesting)
     testDeck(clipboard, result);
 }
 
+TEST(LoadingFromClipboardTest, mainboardAsLine)
+{
+    QString clipboard("// Deck Name\n"
+                      "\n"
+                      "MainBoard: 3 cards\n"
+                      "3 card\n"
+                      "\n"
+                      "SideBoard: 2 cards\n"
+                      "2 sidecard\n");
+
+    Result result("Deck Name", "", {{"card", 3}}, {{"sidecard", 2}});
+    testDeck(clipboard, result);
+}
+
+TEST(LoadingFromClipboardTest, deckAsCard)
+{
+    QString clipboard("6 Deck of Cards But Animated\n"
+                      "\n"
+                      "7 Sideboard Card\n");
+
+    Result result("", "", {{"Deck of Cards But Animated", 6}}, {{"Sideboard Card", 7}});
+    testDeck(clipboard, result);
+}
+
+TEST(LoadingFromClipboardTest, emptyMainBoard)
+{
+    QString clipboard("deck\n"
+                      "\n"
+                      "sideboard\n");
+
+    testEmpty(clipboard);
+}
+
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION

## Related Ticket(s)
- Fixes #4249

## Short roundup of the initial problem
decklists often start with a header: deck, mainboard, decklist; these are not cards

## What will change with this Pull Request?
ignore "deck" at start of a list
add tests
add tests to clangify.sh
