### PR TITLE
add button to open themes location to settings

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -15,6 +15,7 @@
 #include <QCloseEvent>
 #include <QComboBox>
 #include <QDebug>
+#include <QDesktopServices>
 #include <QDesktopWidget>
 #include <QDialogButtonBox>
 #include <QFileDialog>
@@ -291,10 +292,12 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     }
 
     connect(&themeBox, SIGNAL(currentIndexChanged(int)), this, SLOT(themeBoxChanged(int)));
+    connect(&openThemeButton, SIGNAL(clicked()), this, SLOT(openThemeLocation()));
 
     auto *themeGrid = new QGridLayout;
     themeGrid->addWidget(&themeLabel, 0, 0);
     themeGrid->addWidget(&themeBox, 0, 1);
+    themeGrid->addWidget(&openThemeButton, 1, 1);
 
     themeGroupBox = new QGroupBox;
     themeGroupBox->setLayout(themeGrid);
@@ -370,10 +373,24 @@ void AppearanceSettingsPage::themeBoxChanged(int index)
         SettingsCache::instance().setThemeName(themeDirs.at(index));
 }
 
+void AppearanceSettingsPage::openThemeLocation()
+{
+    QString dir = SettingsCache::instance().getThemesPath();
+    QDir dirDir = dir;
+    dirDir.cdUp();
+    // open if dir exists, create if parent dir does exist
+    if (dirDir.exists() && dirDir.mkpath(dir)) {
+        QDesktopServices::openUrl(QUrl::fromLocalFile(dir));
+    } else {
+        QMessageBox::critical(this, tr("Error"), tr("Could not create themes directory at '%1'.").arg(dir));
+    }
+}
+
 void AppearanceSettingsPage::retranslateUi()
 {
     themeGroupBox->setTitle(tr("Theme settings"));
     themeLabel.setText(tr("Current theme:"));
+    openThemeButton.setText(tr("Open themes folder"));
 
     cardsGroupBox->setTitle(tr("Card rendering"));
     displayCardNamesCheckBox.setText(tr("Display card names on cards having a picture"));

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -79,10 +79,12 @@ class AppearanceSettingsPage : public AbstractSettingsPage
     Q_OBJECT
 private slots:
     void themeBoxChanged(int index);
+    void openThemeLocation();
 
 private:
     QLabel themeLabel;
     QComboBox themeBox;
+    QPushButton openThemeButton;
     QLabel minPlayersForMultiColumnLayoutLabel;
     QLabel maxFontSizeForCardsLabel;
     QCheckBox displayCardNamesCheckBox;

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -197,6 +197,7 @@ SettingsCache::SettingsCache()
 
     deckPath = getSafeConfigPath("paths/decks", dataPath + "/decks/");
     replaysPath = getSafeConfigPath("paths/replays", dataPath + "/replays/");
+    themesPath = getSafeConfigPath("paths/themes", dataPath + "/themes/");
     picsPath = getSafeConfigPath("paths/pics", dataPath + "/pics/");
     // this has never been exposed as an user-configurable setting
     if (picsPath.endsWith("/")) {
@@ -386,6 +387,13 @@ void SettingsCache::setReplaysPath(const QString &_replaysPath)
 {
     replaysPath = _replaysPath;
     settings->setValue("paths/replays", replaysPath);
+}
+
+void SettingsCache::setThemesPath(const QString &_themesPath)
+{
+    themesPath = _themesPath;
+    settings->setValue("paths/themes", themesPath);
+    emit themeChanged();
 }
 
 void SettingsCache::setCustomCardDatabasePath(const QString &_customCardDatabasePath)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -66,7 +66,7 @@ private:
     QByteArray mainWindowGeometry;
     QByteArray tokenDialogGeometry;
     QString lang;
-    QString deckPath, replaysPath, picsPath, customPicsPath, cardDatabasePath, customCardDatabasePath,
+    QString deckPath, replaysPath, picsPath, customPicsPath, cardDatabasePath, customCardDatabasePath, themesPath,
         spoilerDatabasePath, tokenDatabasePath, themeName;
     bool notifyAboutUpdates;
     bool notifyAboutNewVersion;
@@ -156,6 +156,10 @@ public:
     QString getReplaysPath() const
     {
         return replaysPath;
+    }
+    QString getThemesPath() const
+    {
+        return themesPath;
     }
     QString getPicsPath() const
     {
@@ -479,6 +483,7 @@ public slots:
     void setSeenTips(const QList<int> &_seenTips);
     void setDeckPath(const QString &_deckPath);
     void setReplaysPath(const QString &_replaysPath);
+    void setThemesPath(const QString &_themesPath);
     void setCustomCardDatabasePath(const QString &_customCardDatabasePath);
     void setPicsPath(const QString &_picsPath);
     void setCardDatabasePath(const QString &_cardDatabasePath);

--- a/cockatrice/themes/CMakeLists.txt
+++ b/cockatrice/themes/CMakeLists.txt
@@ -3,7 +3,6 @@
 # add themes subfolders
 
 SET(defthemes
-    Default
     Fabric
     Leather
     Plasma

--- a/cockatrice/themes/Default/.gitignore
+++ b/cockatrice/themes/Default/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -96,6 +96,9 @@ void SettingsCache::setDeckPath(const QString &/* _deckPath */)
 void SettingsCache::setReplaysPath(const QString &/* _replaysPath */)
 {
 }
+void SettingsCache::setThemesPath(const QString &/* _themesPath */)
+{
+}
 void SettingsCache::setPicsPath(const QString &/* _picsPath */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -100,6 +100,9 @@ void SettingsCache::setDeckPath(const QString &/* _deckPath */)
 void SettingsCache::setReplaysPath(const QString &/* _replaysPath */)
 {
 }
+void SettingsCache::setThemesPath(const QString &/* _themesPath */)
+{
+}
 void SettingsCache::setPicsPath(const QString &/* _picsPath */)
 {
 }


### PR DESCRIPTION

## Related Ticket(s)
- https://github.com/Cockatrice/Cockatrice/issues/4087
- https://github.com/Cockatrice/Cockatrice/issues/4014

## Short roundup of the initial problem
adding a theme is hard, a button could improve the current process by alot

## What will change with this Pull Request?
- botton creates directory if it doesn't exist yet
- themes path is no longer hardcoded but included in settings
- themes now default to None  the default theme is no longer required
- themes set to None  will not look for empty directories anymore
- this is backwards compatible
   - users with a nonexistant theme (Default) set will get the new None  theme


## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![image](https://user-images.githubusercontent.com/36401181/111857171-03325d80-8930-11eb-9a92-87676983c3be.png)
