### PR TITLE
fix off-by-one maxUsers check on session init

### DIFF
--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -103,7 +103,7 @@ bool AbstractServerSocketInterface::initSession()
         return true;
 
     int maxUsers = servatrice->getMaxUsersPerAddress();
-    if ((maxUsers > 0) && (servatrice->getUsersWithAddress(getPeerAddress()) >= maxUsers)) {
+    if ((maxUsers > 0) && (servatrice->getUsersWithAddress(getPeerAddress()) > maxUsers)) {
         Event_ConnectionClosed event;
         event.set_reason(Event_ConnectionClosed::TOO_MANY_CONNECTIONS);
         SessionEvent *se = prepareSessionEvent(event);


### PR DESCRIPTION
The returned number of users from `getUsersWithAddress` will include the already connected user. The predicate `>= maxUsers` is incorrectly assuming that the new user is not already counted by `getUsersWithAddress`. This change corrects this off-by-one error by only closing connections after their are strictly too many users.