### PR TITLE
add more info to dialogs

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -510,6 +510,7 @@ LoadStatus CardDatabase::loadFromFile(const QString &fileName)
 
 LoadStatus CardDatabase::loadCardDatabase(const QString &path)
 {
+  auto startTime = QTime::currentTime();
     LoadStatus tempLoadStatus = NotLoaded;
     if (!path.isEmpty()) {
         loadFromFileMutex->lock();
@@ -517,8 +518,9 @@ LoadStatus CardDatabase::loadCardDatabase(const QString &path)
         loadFromFileMutex->unlock();
     }
 
+  int msecs = startTime.msecsTo(QTime::currentTime());
     qDebug() << "[CardDatabase] loadCardDatabase(): Path =" << path << "Status =" << tempLoadStatus
-             << "Cards =" << cards.size() << "Sets=" << sets.size();
+             << "Cards =" << cards.size() << "Sets =" << sets.size() << QString("%1ms").arg(msecs);
 
     return tempLoadStatus;
 }

--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -510,7 +510,7 @@ LoadStatus CardDatabase::loadFromFile(const QString &fileName)
 
 LoadStatus CardDatabase::loadCardDatabase(const QString &path)
 {
-  auto startTime = QTime::currentTime();
+    auto startTime = QTime::currentTime();
     LoadStatus tempLoadStatus = NotLoaded;
     if (!path.isEmpty()) {
         loadFromFileMutex->lock();
@@ -518,7 +518,7 @@ LoadStatus CardDatabase::loadCardDatabase(const QString &path)
         loadFromFileMutex->unlock();
     }
 
-  int msecs = startTime.msecsTo(QTime::currentTime());
+    int msecs = startTime.msecsTo(QTime::currentTime());
     qDebug() << "[CardDatabase] loadCardDatabase(): Path =" << path << "Status =" << tempLoadStatus
              << "Cards =" << cards.size() << "Sets =" << sets.size() << QString("%1ms").arg(msecs);
 

--- a/cockatrice/src/carddbparser/cockatricexml4.cpp
+++ b/cockatrice/src/carddbparser/cockatricexml4.cpp
@@ -160,14 +160,17 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
                     // NOTE: attributes but be read before readElementText()
                     QXmlStreamAttributes attrs = xml.attributes();
                     QString setName = xml.readElementText(QXmlStreamReader::IncludeChildElements);
-                    CardInfoPerSet setInfo(internalAddSet(setName));
-                    for (QXmlStreamAttribute attr : attrs) {
-                        QString attrName = attr.name().toString();
-                        if (attrName == "picURL")
-                            attrName = "picurl";
-                        setInfo.setProperty(attrName, attr.value().toString());
+                    auto set = internalAddSet(setName);
+                    if (set->getEnabled()) {
+                        CardInfoPerSet setInfo(set);
+                        for (QXmlStreamAttribute attr : attrs) {
+                            QString attrName = attr.name().toString();
+                            if (attrName == "picURL")
+                                attrName = "picurl";
+                            setInfo.setProperty(attrName, attr.value().toString());
+                        }
+                        sets.insert(setName, setInfo);
                     }
-                    sets.insert(setName, setInfo);
                     // relatd cards
                 } else if (xml.name() == "related" || xml.name() == "reverse-related") {
                     bool attach = false;

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -63,11 +63,12 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     autoConnectCheckBox = new QCheckBox(tr("A&uto connect"));
     autoConnectCheckBox->setToolTip(tr("Automatically connect to the most recent login when Cockatrice opens"));
 
-    if (SettingsCache::instance().servers().getSavePassword()) {
-        autoConnectCheckBox->setChecked(static_cast<bool>(SettingsCache::instance().servers().getAutoConnect()));
+    auto &servers = SettingsCache::instance().servers();
+    if (servers.getSavePassword()) {
+        autoConnectCheckBox->setChecked(servers.getAutoConnect() > 0);
         autoConnectCheckBox->setEnabled(true);
     } else {
-        SettingsCache::instance().servers().setAutoConnect(0);
+        servers.setAutoConnect(0);
         autoConnectCheckBox->setChecked(false);
         autoConnectCheckBox->setEnabled(false);
     }
@@ -192,9 +193,10 @@ void DlgConnect::rebuildComboBoxList(int failure)
     UserConnection_Information uci;
     savedHostList = uci.getServerInfo();
 
-    bool autoConnectEnabled = static_cast<bool>(SettingsCache::instance().servers().getAutoConnect());
-    QString previousHostName = SettingsCache::instance().servers().getPrevioushostName();
-    QString autoConnectSaveName = SettingsCache::instance().servers().getSaveName();
+    auto &servers = SettingsCache::instance().servers();
+    bool autoConnectEnabled = servers.getAutoConnect() > 0;
+    QString previousHostName = servers.getPrevioushostName();
+    QString autoConnectSaveName = servers.getSaveName();
 
     int index = 0;
 

--- a/cockatrice/src/dlg_edit_password.cpp
+++ b/cockatrice/src/dlg_edit_password.cpp
@@ -10,12 +10,13 @@
 
 DlgEditPassword::DlgEditPassword(QWidget *parent) : QDialog(parent)
 {
-
     oldPasswordLabel = new QLabel(tr("Old password:"));
     oldPasswordEdit = new QLineEdit();
 
-    if (SettingsCache::instance().servers().getSavePassword())
-        oldPasswordEdit->setText(SettingsCache::instance().servers().getPassword());
+    auto &servers = SettingsCache::instance().servers();
+    if (servers.getSavePassword()) {
+        oldPasswordEdit->setText(servers.getPassword());
+    }
 
     oldPasswordLabel->setBuddy(oldPasswordEdit);
     oldPasswordEdit->setEchoMode(QLineEdit::Password);
@@ -59,7 +60,5 @@ void DlgEditPassword::actOk()
         return;
     }
 
-    // always save the password so it will be picked up by the connect dialog
-    SettingsCache::instance().servers().setPassword(newPasswordEdit->text());
     accept();
 }

--- a/cockatrice/src/dlg_forgotpasswordchallenge.cpp
+++ b/cockatrice/src/dlg_forgotpasswordchallenge.cpp
@@ -12,14 +12,13 @@
 
 DlgForgotPasswordChallenge::DlgForgotPasswordChallenge(QWidget *parent) : QDialog(parent)
 {
-
     QString lastfphost;
     QString lastfpport;
     QString lastfpplayername;
     ServersSettings &servers = SettingsCache::instance().servers();
-    lastfphost = servers.getHostname("server.cockatrice.us");
-    lastfpport = servers.getPort("4747");
-    lastfpplayername = servers.getPlayerName("Player");
+    lastfphost = servers.getHostname();
+    lastfpport = servers.getPort();
+    lastfpplayername = servers.getPlayerName();
 
     if (!servers.getFPHostname().isEmpty() && !servers.getFPPort().isEmpty() && !servers.getFPPlayerName().isEmpty()) {
         lastfphost = servers.getFPHostname();
@@ -33,6 +32,10 @@ DlgForgotPasswordChallenge::DlgForgotPasswordChallenge(QWidget *parent) : QDialo
                                 "process by using the forgot password button on the connection screen."));
         reject();
     }
+
+    infoLabel =
+        new QLabel(tr("Enter the information of the server and the account you'd like to request a new password for."));
+    infoLabel->setWordWrap(true);
 
     hostLabel = new QLabel(tr("&Host:"));
     hostEdit = new QLineEdit(lastfphost);
@@ -60,14 +63,15 @@ DlgForgotPasswordChallenge::DlgForgotPasswordChallenge(QWidget *parent) : QDialo
     }
 
     QGridLayout *grid = new QGridLayout;
-    grid->addWidget(hostLabel, 0, 0);
-    grid->addWidget(hostEdit, 0, 1);
-    grid->addWidget(portLabel, 1, 0);
-    grid->addWidget(portEdit, 1, 1);
-    grid->addWidget(playernameLabel, 2, 0);
-    grid->addWidget(playernameEdit, 2, 1);
-    grid->addWidget(emailLabel, 3, 0);
-    grid->addWidget(emailEdit, 3, 1);
+    grid->addWidget(infoLabel, 0, 0, 1, 2);
+    grid->addWidget(hostLabel, 1, 0);
+    grid->addWidget(hostEdit, 1, 1);
+    grid->addWidget(portLabel, 2, 0);
+    grid->addWidget(portEdit, 2, 1);
+    grid->addWidget(playernameLabel, 3, 0);
+    grid->addWidget(playernameEdit, 3, 1);
+    grid->addWidget(emailLabel, 4, 0);
+    grid->addWidget(emailEdit, 4, 1);
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));

--- a/cockatrice/src/dlg_forgotpasswordchallenge.h
+++ b/cockatrice/src/dlg_forgotpasswordchallenge.h
@@ -34,7 +34,7 @@ private slots:
     void actOk();
 
 private:
-    QLabel *hostLabel, *portLabel, *playernameLabel, *emailLabel;
+    QLabel *infoLabel, *hostLabel, *portLabel, *playernameLabel, *emailLabel;
     QLineEdit *hostEdit, *portEdit, *playernameEdit, *emailEdit;
 };
 

--- a/cockatrice/src/dlg_forgotpasswordrequest.cpp
+++ b/cockatrice/src/dlg_forgotpasswordrequest.cpp
@@ -12,20 +12,22 @@
 
 DlgForgotPasswordRequest::DlgForgotPasswordRequest(QWidget *parent) : QDialog(parent)
 {
-
     QString lastfphost;
     QString lastfpport;
     QString lastfpplayername;
     ServersSettings &servers = SettingsCache::instance().servers();
-    lastfphost = servers.getHostname("server.cockatrice.us");
-    lastfpport = servers.getPort("4747");
-    lastfpplayername = servers.getPlayerName("Player");
+    lastfphost = servers.getHostname();
+    lastfpport = servers.getPort();
+    lastfpplayername = servers.getPlayerName();
 
     if (!servers.getFPHostname().isEmpty() && !servers.getFPPort().isEmpty() && !servers.getFPPlayerName().isEmpty()) {
         lastfphost = servers.getFPHostname();
         lastfpport = servers.getFPPort();
         lastfpplayername = servers.getFPPlayerName();
     }
+
+    infoLabel = new QLabel(tr("Enter the information of the server you'd like to request a new password for."));
+    infoLabel->setWordWrap(true);
 
     hostLabel = new QLabel(tr("&Host:"));
     hostEdit = new QLineEdit(lastfphost);
@@ -40,12 +42,13 @@ DlgForgotPasswordRequest::DlgForgotPasswordRequest(QWidget *parent) : QDialog(pa
     playernameLabel->setBuddy(playernameEdit);
 
     QGridLayout *grid = new QGridLayout;
-    grid->addWidget(hostLabel, 0, 0);
-    grid->addWidget(hostEdit, 0, 1);
-    grid->addWidget(portLabel, 1, 0);
-    grid->addWidget(portEdit, 1, 1);
-    grid->addWidget(playernameLabel, 2, 0);
-    grid->addWidget(playernameEdit, 2, 1);
+    grid->addWidget(infoLabel, 0, 0, 1, 2);
+    grid->addWidget(hostLabel, 1, 0);
+    grid->addWidget(hostEdit, 1, 1);
+    grid->addWidget(portLabel, 2, 0);
+    grid->addWidget(portEdit, 2, 1);
+    grid->addWidget(playernameLabel, 3, 0);
+    grid->addWidget(playernameEdit, 3, 1);
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));

--- a/cockatrice/src/dlg_forgotpasswordrequest.h
+++ b/cockatrice/src/dlg_forgotpasswordrequest.h
@@ -30,7 +30,7 @@ private slots:
     void actOk();
 
 private:
-    QLabel *hostLabel, *portLabel, *playernameLabel;
+    QLabel *infoLabel, *hostLabel, *portLabel, *playernameLabel;
     QLineEdit *hostEdit, *portEdit, *playernameEdit;
 };
 

--- a/cockatrice/src/dlg_forgotpasswordreset.cpp
+++ b/cockatrice/src/dlg_forgotpasswordreset.cpp
@@ -12,14 +12,13 @@
 
 DlgForgotPasswordReset::DlgForgotPasswordReset(QWidget *parent) : QDialog(parent)
 {
-
     QString lastfphost;
     QString lastfpport;
     QString lastfpplayername;
     ServersSettings &servers = SettingsCache::instance().servers();
-    lastfphost = servers.getHostname("server.cockatrice.us");
-    lastfpport = servers.getPort("4747");
-    lastfpplayername = servers.getPlayerName("Player");
+    lastfphost = servers.getHostname();
+    lastfpport = servers.getPort();
+    lastfpplayername = servers.getPlayerName();
 
     if (!servers.getFPHostname().isEmpty() && !servers.getFPPort().isEmpty() && !servers.getFPPlayerName().isEmpty()) {
         lastfphost = servers.getFPHostname();
@@ -33,6 +32,9 @@ DlgForgotPasswordReset::DlgForgotPasswordReset(QWidget *parent) : QDialog(parent
                                 "process by using the forgot password button on the connection screen."));
         reject();
     }
+
+    infoLabel = new QLabel(tr("Enter the received token and the new password in order to set your new password."));
+    infoLabel->setWordWrap(true);
 
     hostLabel = new QLabel(tr("&Host:"));
     hostEdit = new QLineEdit(lastfphost);
@@ -70,18 +72,19 @@ DlgForgotPasswordReset::DlgForgotPasswordReset(QWidget *parent) : QDialog(parent
     }
 
     QGridLayout *grid = new QGridLayout;
-    grid->addWidget(hostLabel, 0, 0);
-    grid->addWidget(hostEdit, 0, 1);
-    grid->addWidget(portLabel, 1, 0);
-    grid->addWidget(portEdit, 1, 1);
-    grid->addWidget(playernameLabel, 2, 0);
-    grid->addWidget(playernameEdit, 2, 1);
-    grid->addWidget(tokenLabel, 3, 0);
-    grid->addWidget(tokenEdit, 3, 1);
-    grid->addWidget(newpasswordLabel, 4, 0);
-    grid->addWidget(newpasswordEdit, 4, 1);
-    grid->addWidget(newpasswordverifyLabel, 5, 0);
-    grid->addWidget(newpasswordverifyEdit, 5, 1);
+    grid->addWidget(infoLabel, 0, 0, 1, 2);
+    grid->addWidget(hostLabel, 1, 0);
+    grid->addWidget(hostEdit, 1, 1);
+    grid->addWidget(portLabel, 2, 0);
+    grid->addWidget(portEdit, 2, 1);
+    grid->addWidget(playernameLabel, 3, 0);
+    grid->addWidget(playernameEdit, 3, 1);
+    grid->addWidget(tokenLabel, 4, 0);
+    grid->addWidget(tokenEdit, 4, 1);
+    grid->addWidget(newpasswordLabel, 5, 0);
+    grid->addWidget(newpasswordEdit, 5, 1);
+    grid->addWidget(newpasswordverifyLabel, 6, 0);
+    grid->addWidget(newpasswordverifyEdit, 6, 1);
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));

--- a/cockatrice/src/dlg_forgotpasswordreset.h
+++ b/cockatrice/src/dlg_forgotpasswordreset.h
@@ -38,7 +38,8 @@ private slots:
     void actOk();
 
 private:
-    QLabel *hostLabel, *portLabel, *playernameLabel, *tokenLabel, *newpasswordLabel, *newpasswordverifyLabel;
+    QLabel *infoLabel, *hostLabel, *portLabel, *playernameLabel, *tokenLabel, *newpasswordLabel,
+        *newpasswordverifyLabel;
     QLineEdit *hostEdit, *portEdit, *playernameEdit, *tokenEdit, *newpasswordEdit, *newpasswordverifyEdit;
 };
 

--- a/cockatrice/src/dlg_manage_sets.cpp
+++ b/cockatrice/src/dlg_manage_sets.cpp
@@ -131,12 +131,12 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     labNotes->setOpenExternalLinks(true);
     labNotes->setText(tr("Use ctrl+a to select all sets in the view.") + "<br><b>" + tr("Deck Editor") + ":</b> " +
                       tr("Only cards in enabled sets will appear in the card list of the deck editor.") + "<br><b>" +
-                      tr("Card Art") + ":</b> " + tr("Image priority is decided in the following order:") + "<ol><li>" +
-                      tr("CUSTOM Folder") +
-                      " (<a href='https://github.com/Cockatrice/Cockatrice/wiki/Custom-Cards-%26-Sets"
-                      "#to-add-custom-art-for-cards-the-easiest-way-is-to-use-the-custom-folder'>" +
-                      tr("How to use custom card art") + "</a>)</li><li>" + tr("Enabled Sets (Top to Bottom)") +
-                      "</li><li>" + tr("Disabled Sets (Top to Bottom)") + "</li></ol>");
+                      tr("Card Art") + ":</b> " + tr("Image priority is decided in the following order:") + "<br>" +
+                      tr("first the CUSTOM Folder (%1), then the Enabled Sets in this dialog (Top to Bottom)",
+                         "%1 is a link to the wiki")
+                          .arg("<a href='https://github.com/Cockatrice/Cockatrice/wiki/Custom-Cards-%26-Sets"
+                               "#to-add-custom-art-for-cards-the-easiest-way-is-to-use-the-custom-folder'>" +
+                               tr("How to use custom card art") + "</a>"));
 
     QGridLayout *hintsGrid = new QGridLayout;
     hintsGrid->setMargin(2);

--- a/cockatrice/src/dlg_manage_sets.cpp
+++ b/cockatrice/src/dlg_manage_sets.cpp
@@ -84,6 +84,7 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     displayModel->setDynamicSortFilter(false);
     view = new QTreeView;
     view->setModel(displayModel);
+    view->setMinimumSize(QSize(500, 250));
 
     view->setAlternatingRowColors(true);
     view->setUniformRowHeights(true);
@@ -128,16 +129,17 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     labNotes->setWordWrap(true);
     labNotes->setTextInteractionFlags(Qt::TextBrowserInteraction);
     labNotes->setOpenExternalLinks(true);
-    labNotes->setText("<b>" + tr("Deck Editor") + ":</b> " +
-                      tr("Only cards in enabled sets will appear in the card list of the deck editor") + "<br><br>" +
-                      "<b>" + tr("Card Art") + ":</b> " + tr("Image priority is decided in the following order") +
-                      "<ol><li>" + tr("CUSTOM Folder") +
+    labNotes->setText(tr("Use ctrl+a to select all sets in the view.") + "<br><b>" + tr("Deck Editor") + ":</b> " +
+                      tr("Only cards in enabled sets will appear in the card list of the deck editor.") + "<br><b>" +
+                      tr("Card Art") + ":</b> " + tr("Image priority is decided in the following order:") + "<ol><li>" +
+                      tr("CUSTOM Folder") +
                       " (<a href='https://github.com/Cockatrice/Cockatrice/wiki/Custom-Cards-%26-Sets"
                       "#to-add-custom-art-for-cards-the-easiest-way-is-to-use-the-custom-folder'>" +
                       tr("How to use custom card art") + "</a>)</li><li>" + tr("Enabled Sets (Top to Bottom)") +
                       "</li><li>" + tr("Disabled Sets (Top to Bottom)") + "</li></ol>");
 
     QGridLayout *hintsGrid = new QGridLayout;
+    hintsGrid->setMargin(2);
     hintsGrid->addWidget(labNotes, 0, 0);
     hintsGroupBox = new QGroupBox(tr("Hints"));
     hintsGroupBox->setLayout(hintsGrid);
@@ -163,8 +165,8 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     connect(buttonBox, SIGNAL(rejected()), this, SLOT(actRestore()));
 
     mainLayout = new QGridLayout;
-    mainLayout->addWidget(setsEditToolBar, 1, 0, 2, 1);
     mainLayout->addLayout(filterBox, 0, 1, 1, 2);
+    mainLayout->addWidget(setsEditToolBar, 1, 0, 2, 1);
     mainLayout->addWidget(view, 1, 1, 1, 2);
     mainLayout->addWidget(enableAllButton, 2, 1);
     mainLayout->addWidget(disableAllButton, 2, 2);
@@ -184,7 +186,7 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     setCentralWidget(centralWidget);
 
     setWindowTitle(tr("Manage sets"));
-    resize(700, 400);
+    resize(800, 500);
 }
 
 WndSets::~WndSets()

--- a/cockatrice/src/dlg_register.cpp
+++ b/cockatrice/src/dlg_register.cpp
@@ -31,7 +31,7 @@ DlgRegister::DlgRegister(QWidget *parent) : QDialog(parent)
     playernameLabel->setBuddy(playernameEdit);
 
     passwordLabel = new QLabel(tr("P&assword:"));
-    passwordEdit = new QLineEdit(servers.getPassword());
+    passwordEdit = new QLineEdit();
     passwordLabel->setBuddy(passwordEdit);
     passwordEdit->setEchoMode(QLineEdit::Password);
 
@@ -359,13 +359,6 @@ void DlgRegister::actOk()
         QMessageBox::critical(this, tr("Registration Warning"), tr("The player name can't be empty."));
         return;
     }
-
-    ServersSettings &servers = SettingsCache::instance().servers();
-    servers.setHostName(hostEdit->text());
-    servers.setPort(portEdit->text());
-    servers.setPlayerName(playernameEdit->text());
-    // always save the password so it will be picked up by the connect dialog
-    servers.setPassword(passwordEdit->text());
 
     accept();
 }

--- a/cockatrice/src/dlg_register.cpp
+++ b/cockatrice/src/dlg_register.cpp
@@ -14,16 +14,20 @@
 DlgRegister::DlgRegister(QWidget *parent) : QDialog(parent)
 {
     ServersSettings &servers = SettingsCache::instance().servers();
+    infoLabel = new QLabel(tr("Enter your information and the information of the server you'd like to register to.\n"
+                              "Your email will be used to verify your account."));
+    infoLabel->setWordWrap(true);
+
     hostLabel = new QLabel(tr("&Host:"));
-    hostEdit = new QLineEdit(servers.getHostname("server.cockatrice.us"));
+    hostEdit = new QLineEdit(servers.getHostname());
     hostLabel->setBuddy(hostEdit);
 
     portLabel = new QLabel(tr("&Port:"));
-    portEdit = new QLineEdit(servers.getPort("4747"));
+    portEdit = new QLineEdit(servers.getPort());
     portLabel->setBuddy(portEdit);
 
     playernameLabel = new QLabel(tr("Player &name:"));
-    playernameEdit = new QLineEdit(servers.getPlayerName("Player"));
+    playernameEdit = new QLineEdit(servers.getPlayerName());
     playernameLabel->setBuddy(playernameEdit);
 
     passwordLabel = new QLabel(tr("P&assword:"));
@@ -307,24 +311,25 @@ DlgRegister::DlgRegister(QWidget *parent) : QDialog(parent)
     realnameLabel->setBuddy(realnameEdit);
 
     QGridLayout *grid = new QGridLayout;
-    grid->addWidget(hostLabel, 0, 0);
-    grid->addWidget(hostEdit, 0, 1);
-    grid->addWidget(portLabel, 1, 0);
-    grid->addWidget(portEdit, 1, 1);
-    grid->addWidget(playernameLabel, 2, 0);
-    grid->addWidget(playernameEdit, 2, 1);
-    grid->addWidget(passwordLabel, 3, 0);
-    grid->addWidget(passwordEdit, 3, 1);
-    grid->addWidget(passwordConfirmationLabel, 4, 0);
-    grid->addWidget(passwordConfirmationEdit, 4, 1);
-    grid->addWidget(emailLabel, 5, 0);
-    grid->addWidget(emailEdit, 5, 1);
-    grid->addWidget(emailConfirmationLabel, 6, 0);
-    grid->addWidget(emailConfirmationEdit, 6, 1);
-    grid->addWidget(countryLabel, 8, 0);
-    grid->addWidget(countryEdit, 8, 1);
-    grid->addWidget(realnameLabel, 9, 0);
-    grid->addWidget(realnameEdit, 9, 1);
+    grid->addWidget(infoLabel, 0, 0, 1, 2);
+    grid->addWidget(hostLabel, 1, 0);
+    grid->addWidget(hostEdit, 1, 1);
+    grid->addWidget(portLabel, 2, 0);
+    grid->addWidget(portEdit, 2, 1);
+    grid->addWidget(playernameLabel, 3, 0);
+    grid->addWidget(playernameEdit, 3, 1);
+    grid->addWidget(passwordLabel, 4, 0);
+    grid->addWidget(passwordEdit, 4, 1);
+    grid->addWidget(passwordConfirmationLabel, 5, 0);
+    grid->addWidget(passwordConfirmationEdit, 5, 1);
+    grid->addWidget(emailLabel, 6, 0);
+    grid->addWidget(emailEdit, 6, 1);
+    grid->addWidget(emailConfirmationLabel, 7, 0);
+    grid->addWidget(emailConfirmationEdit, 7, 1);
+    grid->addWidget(countryLabel, 9, 0);
+    grid->addWidget(countryEdit, 9, 1);
+    grid->addWidget(realnameLabel, 10, 0);
+    grid->addWidget(realnameEdit, 10, 1);
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));

--- a/cockatrice/src/dlg_register.h
+++ b/cockatrice/src/dlg_register.h
@@ -50,8 +50,8 @@ private slots:
     void actOk();
 
 private:
-    QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *passwordConfirmationLabel, *emailLabel,
-        *emailConfirmationLabel, *countryLabel, *realnameLabel;
+    QLabel *infoLabel, *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *passwordConfirmationLabel,
+        *emailLabel, *emailConfirmationLabel, *countryLabel, *realnameLabel;
     QLineEdit *hostEdit, *portEdit, *playernameEdit, *passwordEdit, *passwordConfirmationEdit, *emailEdit,
         *emailConfirmationEdit, *realnameEdit;
     QComboBox *countryEdit;

--- a/cockatrice/src/settings/serverssettings.cpp
+++ b/cockatrice/src/settings/serverssettings.cpp
@@ -56,18 +56,13 @@ QString ServersSettings::getPrevioushostName()
 
 int ServersSettings::getPrevioushostindex(const QString &saveName)
 {
-    int size = getValue("totalServers", "server", "server_details").toInt() + 1;
+    int size = getValue("totalServers", "server", "server_details").toInt();
 
-    for (int i = 0; i < size; i++)
+    for (int i = 0; i <= size; ++i)
         if (saveName == getValue(QString("saveName%1").arg(i), "server", "server_details").toString())
             return i;
 
     return -1;
-}
-
-void ServersSettings::setHostName(QString hostname)
-{
-    setValue(hostname, "hostname", "server");
 }
 
 QString ServersSettings::getHostname(QString defaultHost)
@@ -77,27 +72,19 @@ QString ServersSettings::getHostname(QString defaultHost)
     return hostname == QVariant() ? std::move(defaultHost) : hostname.toString();
 }
 
-void ServersSettings::setPort(QString port)
-{
-    setValue(port, "port", "server");
-}
-
 QString ServersSettings::getPort(QString defaultPort)
 {
     int index = getPrevioushostindex(getPrevioushostName());
     QVariant port = getValue(QString("port%1").arg(index), "server", "server_details");
+    qDebug() << "getPort() index = " << index << " port.val = " << port.toString();
     return port == QVariant() ? std::move(defaultPort) : port.toString();
-}
-
-void ServersSettings::setPlayerName(QString playerName)
-{
-    setValue(playerName, "playername", "server");
 }
 
 QString ServersSettings::getPlayerName(QString defaultName)
 {
     int index = getPrevioushostindex(getPrevioushostName());
     QVariant name = getValue(QString("username%1").arg(index), "server", "server_details");
+    qDebug() << "getPlayerName() index = " << index << " name.val = " << name.toString();
     return name == QVariant() ? std::move(defaultName) : name.toString();
 }
 
@@ -116,16 +103,6 @@ bool ServersSettings::getSavePassword()
     int index = getPrevioushostindex(getPrevioushostName());
     bool save = getValue(QString("savePassword%1").arg(index), "server", "server_details").toBool();
     return save;
-}
-
-void ServersSettings::setPassword(QString password)
-{
-    setValue(password, "password", "server");
-}
-
-void ServersSettings::setSavePassword(int save)
-{
-    setValue(save, "save_password", "server");
 }
 
 void ServersSettings::setAutoConnect(int autoconnect)
@@ -208,19 +185,47 @@ void ServersSettings::addNewServer(const QString &saveName,
 
 void ServersSettings::removeServer(QString servAddr)
 {
-    int size = getValue("totalServers", "server", "server_details").toInt() + 1;
+    int size = getValue("totalServers", "server", "server_details").toInt();
 
-    for (int i = 0; i < size; i++) {
-        if (servAddr == getValue(QString("server%1").arg(i), "server", "server_details").toString()) {
-            deleteValue(QString("server%1").arg(i), "server", "server_details");
-            deleteValue(QString("port%1").arg(i), "server", "server_details");
-            deleteValue(QString("username%1").arg(i), "server", "server_details");
-            deleteValue(QString("savePassword%1").arg(i), "server", "server_details");
-            deleteValue(QString("password%1").arg(i), "server", "server_details");
-            deleteValue(QString("saveName%1").arg(i), "server", "server_details");
-            deleteValue(QString("site%1").arg(i), "server", "server_details");
-            return;
+    bool found = false;
+    for (int i = 0; i <= size; ++i) {
+        if (!found) {
+            // find entry and overwrite it
+            if (servAddr == getValue(QString("server%1").arg(i), "server", "server_details").toString()) {
+                found = true;
+            }
+        } else {
+            // move all other entries after it one back, overwriting the previous one
+            int previous = i - 1; // we delete only one entry
+            setValue(getValue(QString("server%1").arg(i), "server", "server_details"),
+                     QString("server%1").arg(previous), "server", "server_details");
+            setValue(getValue(QString("port%1").arg(i), "server", "server_details"), QString("port%1").arg(previous),
+                     "server", "server_details");
+            setValue(getValue(QString("username%1").arg(i), "server", "server_details"),
+                     QString("username%1").arg(previous), "server", "server_details");
+            setValue(getValue(QString("savePassword%1").arg(i), "server", "server_details"),
+                     QString("savePassword%1").arg(previous), "server", "server_details");
+            setValue(getValue(QString("password%1").arg(i), "server", "server_details"),
+                     QString("password%1").arg(previous), "server", "server_details");
+            setValue(getValue(QString("saveName%1").arg(i), "server", "server_details"),
+                     QString("saveName%1").arg(previous), "server", "server_details");
+            setValue(getValue(QString("site%1").arg(i), "server", "server_details"), QString("site%1").arg(previous),
+                     "server", "server_details");
         }
+    }
+
+    // if we have deleted an entry, adjust the total
+    if (found) {
+        setValue(size - 1, "totalServers", "server", "server_details");
+
+        // delete last value
+        deleteValue(QString("server%1").arg(size), "server", "server_details");
+        deleteValue(QString("port%1").arg(size), "server", "server_details");
+        deleteValue(QString("username%1").arg(size), "server", "server_details");
+        deleteValue(QString("savePassword%1").arg(size), "server", "server_details");
+        deleteValue(QString("password%1").arg(size), "server", "server_details");
+        deleteValue(QString("saveName%1").arg(size), "server", "server_details");
+        deleteValue(QString("site%1").arg(size), "server", "server_details");
     }
 }
 
@@ -229,9 +234,9 @@ void ServersSettings::removeServer(QString servAddr)
  */
 bool ServersSettings::updateExistingServerWithoutLoss(QString saveName, QString serv, QString port, QString site)
 {
-    int size = getValue("totalServers", "server", "server_details").toInt() + 1;
+    int size = getValue("totalServers", "server", "server_details").toInt();
 
-    for (int i = 0; i < size; i++) {
+    for (int i = 0; i <= size; ++i) {
         if (serv == getValue(QString("server%1").arg(i), "server", "server_details").toString()) {
             if (!port.isEmpty()) {
                 setValue(port, QString("port%1").arg(i), "server", "server_details");
@@ -257,9 +262,9 @@ bool ServersSettings::updateExistingServer(QString saveName,
                                            bool savePassword,
                                            QString site)
 {
-    int size = getValue("totalServers", "server", "server_details").toInt() + 1;
+    int size = getValue("totalServers", "server", "server_details").toInt();
 
-    for (int i = 0; i < size; i++) {
+    for (int i = 0; i <= size; ++i) {
         if (serv == getValue(QString("server%1").arg(i), "server", "server_details").toString()) {
             setValue(port, QString("port%1").arg(i), "server", "server_details");
             if (!username.isEmpty()) {

--- a/cockatrice/src/settings/serverssettings.cpp
+++ b/cockatrice/src/settings/serverssettings.cpp
@@ -86,7 +86,6 @@ QString ServersSettings::getPort(QString defaultPort)
 {
     int index = getPrevioushostindex(getPrevioushostName());
     QVariant port = getValue(QString("port%1").arg(index), "server", "server_details");
-    qDebug() << "getPort() index = " << index << " port.val = " << port.toString();
     return port == QVariant() ? std::move(defaultPort) : port.toString();
 }
 
@@ -99,7 +98,6 @@ QString ServersSettings::getPlayerName(QString defaultName)
 {
     int index = getPrevioushostindex(getPrevioushostName());
     QVariant name = getValue(QString("username%1").arg(index), "server", "server_details");
-    qDebug() << "getPlayerName() index = " << index << " name.val = " << name.toString();
     return name == QVariant() ? std::move(defaultName) : name.toString();
 }
 

--- a/cockatrice/src/settings/serverssettings.h
+++ b/cockatrice/src/settings/serverssettings.h
@@ -32,15 +32,10 @@ public:
     void setPreviousHostLogin(int previous);
     void setPrevioushostName(const QString &);
     void setPreviousHostList(QStringList list);
-    void setHostName(QString hostname);
-    void setPort(QString port);
-    void setPlayerName(QString playerName);
     void setAutoConnect(int autoconnect);
     void setSite(QString site);
     void setFPHostName(QString hostname);
-    void setPassword(QString password);
     void setFPPort(QString port);
-    void setSavePassword(int save);
     void setFPPlayerName(QString playerName);
     void addNewServer(const QString &saveName,
                       const QString &serv,

--- a/cockatrice/src/settings/serverssettings.h
+++ b/cockatrice/src/settings/serverssettings.h
@@ -4,6 +4,8 @@
 #include "settingsmanager.h"
 
 #include <QObject>
+#define SERVERSETTINGS_DEFAULT_HOST "server.cockatrice.us"
+#define SERVERSETTINGS_DEFAULT_PORT "4748"
 
 class ServersSettings : public SettingsManager
 {
@@ -15,11 +17,11 @@ public:
     int getPrevioushostindex(const QString &);
     QStringList getPreviousHostList();
     QString getPrevioushostName();
-    QString getHostname(QString defaultHost = "");
-    QString getPort(QString defaultPort = "");
+    QString getHostname(QString defaultHost = SERVERSETTINGS_DEFAULT_HOST);
+    QString getPort(QString defaultPort = SERVERSETTINGS_DEFAULT_PORT);
     QString getPlayerName(QString defaultName = "");
-    QString getFPHostname(QString defaultHost = "");
-    QString getFPPort(QString defaultPort = "");
+    QString getFPHostname(QString defaultHost = SERVERSETTINGS_DEFAULT_HOST);
+    QString getFPPort(QString defaultPort = SERVERSETTINGS_DEFAULT_PORT);
     QString getFPPlayerName(QString defaultName = "");
     QString getPassword();
     QString getSaveName(QString defaultname = "");

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -60,11 +60,6 @@ void SettingsCache::translateLegacySettings()
     legacySetting.beginGroup("server");
     servers().setPreviousHostLogin(legacySetting.value("previoushostlogin").toInt());
     servers().setPreviousHostList(legacySetting.value("previoushosts").toStringList());
-    servers().setHostName(legacySetting.value("hostname").toString());
-    servers().setPort(legacySetting.value("port").toString());
-    servers().setPlayerName(legacySetting.value("playername").toString());
-    servers().setPassword(legacySetting.value("password").toString());
-    servers().setSavePassword(legacySetting.value("save_password").toInt());
     servers().setAutoConnect(legacySetting.value("auto_connect").toInt());
     servers().setFPHostName(legacySetting.value("fphostname").toString());
     servers().setFPPort(legacySetting.value("fpport").toString());


### PR DESCRIPTION
adds descriptive strings to the register, password reset request,
password reset challenge request, password reset token dialogs
adds tip to set manager to use ctrl a to select all sets
change sizes in set manager
moves default server info to settings instead of having it hardcoded in
each dialog

default size of sets manager is now this
![image](https://user-images.githubusercontent.com/36401181/112248786-d5625700-8c56-11eb-820d-de51dd4e340e.png)
