### PR TITLE
remove arch workaround

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -136,14 +136,7 @@ jobs:
 
       - name: Build ${{matrix.distro}} Docker image
         shell: bash
-        run: |
-          # temporary workaround for arch libc version requiring upgraded host
-          # see https://bugs.archlinux.org/task/69563#comment196582
-          if [[ $NAME == ArchLinux ]]; then
-            wget http://ftp.us.debian.org/debian/pool/main/r/runc/runc_1.0.0~rc93+ds1-2_amd64.deb
-            sudo dpkg -i --force-conflicts runc*.deb
-          fi
-          source .ci/docker.sh --build
+        run: source .ci/docker.sh --build
 
       - name: Build debug and test
         if: matrix.test != 'skip'


### PR DESCRIPTION
workaround introduced in #4258 
the package used seems to no longer be live, first testing if it can be removed entirely before updating it.