### PR TITLE
send hidden info to judge instead of player

### DIFF
--- a/common/server_response_containers.cpp
+++ b/common/server_response_containers.cpp
@@ -55,9 +55,11 @@ void GameEventStorage::sendToGame(Server_Game *game)
 
     GameEventContainer *contPrivate = new GameEventContainer;
     GameEventContainer *contOthers = new GameEventContainer;
+    int id = privatePlayerId;
     if (forcedByJudge != -1) {
         contPrivate->set_forced_by_judge(forcedByJudge);
         contOthers->set_forced_by_judge(forcedByJudge);
+        id = forcedByJudge;
     }
     for (int i = 0; i < gameEventList.size(); ++i) {
         const GameEvent &event = gameEventList[i]->getGameEvent();
@@ -71,8 +73,8 @@ void GameEventStorage::sendToGame(Server_Game *game)
         contPrivate->mutable_context()->CopyFrom(*gameEventContext);
         contOthers->mutable_context()->CopyFrom(*gameEventContext);
     }
-    game->sendGameEventContainer(contPrivate, GameEventStorageItem::SendToPrivate, privatePlayerId);
-    game->sendGameEventContainer(contOthers, GameEventStorageItem::SendToOthers, privatePlayerId);
+    game->sendGameEventContainer(contPrivate, GameEventStorageItem::SendToPrivate, id);
+    game->sendGameEventContainer(contOthers, GameEventStorageItem::SendToOthers, id);
 }
 
 ResponseContainer::ResponseContainer(int _cmdId) : cmdId(_cmdId), responseExtension(0)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes https://github.com/Cockatrice/Cockatrice/issues/4290

## Short roundup of the initial problem
judges can force an action to be taken by a player, this will tell the player instead of the judge any hidden information in generated event messages

## What will change with this Pull Request?
- the private event message is instead sent to the judge

this has been tested with the judge as spectator.
this is a server only change, older clients are compatible, no part of the actual protocol is changed.
this change displays some glaring issues with the judge mode, such as how things are shown to players in the message log and in corner cases the judge's client does not correctly handle clearing memory and might crash.
I have decided these issues are client side and outside the scope of this change.