### PR TITLE
catch nullptr on websocket connections

### DIFF
--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -1693,7 +1693,7 @@ WebsocketServerSocketInterface::~WebsocketServerSocketInterface()
 void WebsocketServerSocketInterface::initConnection(void *_socket)
 {
     if (_socket == nullptr) {
-      return;
+        return;
     }
     socket = (QWebSocket *)_socket;
     socket->setParent(this);

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -1692,6 +1692,9 @@ WebsocketServerSocketInterface::~WebsocketServerSocketInterface()
 
 void WebsocketServerSocketInterface::initConnection(void *_socket)
 {
+    if (_socket == nullptr) {
+      return;
+    }
     socket = (QWebSocket *)_socket;
     socket->setParent(this);
     address = socket->peerAddress();


### PR DESCRIPTION
fixes: https://github.com/Cockatrice/Cockatrice/issues/4299

sometimes this seems to be called with a null ptr causing a crash, it seems to work correctly now?

trace:
```
#0  0x00007f89a49357c4 in QObject::setParent(QObject*) ()
   from /lib/x86_64-linux-gnu/libQt5Core.so.5
#1  0x000055895c9d3cd2 in WebsocketServerSocketInterface::initConnection (
    this=0x55895d906b30, _socket=0x0)
    at /home/ebbit/repo/trice/Cockatrice/servatrice/src/serversocketinterface.cpp:1696
#2  0x000055895c98fb5a in WebsocketServerSocketInterface::qt_static_metacall (
    _o=0x55895d906b30, _c=QMetaObject::InvokeMetaMethod, _id=2, 
    _a=0x55895d9015d8)
    at /home/ebbit/repo/trice/Cockatrice/build/servatrice/servatrice_autogen/UVLADIE3JM/moc_serversocketinterface.cpp:328
#3  0x00007f89a492d651 in QObject::event(QEvent*) ()
   from /lib/x86_64-linux-gnu/libQt5Core.so.5
#4  0x00007f89a49011a7 in QCoreApplication::notifyInternal2(QObject*, QEvent*)
    () from /lib/x86_64-linux-gnu/libQt5Core.so.5
#5  0x00007f89a4903bc1 in QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) () from /lib/x86_64-linux-gnu/libQt5Core.so.5
#6  0x00007f89a49591c7 in ?? () from /lib/x86_64-linux-gnu/libQt5Core.so.5
#7  0x00007f89a396462b in g_main_context_dispatch ()
   from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#8  0x00007f89a39648d8 in ?? () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#9  0x00007f89a39649a3 in g_main_context_iteration ()
   from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#10 0x00007f89a4958843 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () from /lib/x86_64-linux-gnu/libQt5Core.so.5
#11 0x00007f89a48ffa4b in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () from /lib/x86_64-linux-gnu/libQt5Core.so.5
#12 0x00007f89a4907fc6 in QCoreApplication::exec() ()
   from /lib/x86_64-linux-gnu/libQt5Core.so.5
#13 0x000055895c994570 in main (argc=3, argv=0x7ffda0aa7638)
    at /home/ebbit/repo/trice/Cockatrice/servatrice/src/main.cpp:186
```

this method seems to get connected here https://github.com/Cockatrice/Cockatrice/blob/master/servatrice/src/servatrice.cpp#L163
this means QWebSocket::nextPendingConnection() returned a nullptr, I'm pretty sure it shouldn't do that but it does anyway, and this check doesn't really hurt.