### PR TITLE
check multiple file extension inclusions for custom cards

### DIFF
--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -196,8 +196,11 @@ bool PictureLoaderWorker::cardImageExistsOnDisk(QString &setName, QString &corre
         QString thisPath(it.next());
         QFileInfo thisFileInfo(thisPath);
 
-        if (thisFileInfo.isFile() && thisFileInfo.baseName() == correctedCardname)
+        if (thisFileInfo.isFile() &&
+            (thisFileInfo.fileName() == correctedCardname || thisFileInfo.completeBaseName() == correctedCardname ||
+             thisFileInfo.baseName() == correctedCardname)) {
             picsPaths << thisPath; // Card found in the CUSTOM directory, somewhere
+        }
     }
 
     if (!setName.isEmpty()) {


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4307

## Short roundup of the initial problem
. in cardname causes it to not work for custom cards

## What will change with this Pull Request?
- both full fileName and completeBaseName are now checked as well in order to catch more amounts of dots in filenames
