### PR TITLE
fix deprecation of QMutex::Recursive in favor of QRecursiveMutex

### DIFF
--- a/common/server_game.cpp
+++ b/common/server_game.cpp
@@ -69,7 +69,11 @@ Server_Game::Server_Game(const ServerInfo_User &_creatorInfo,
       spectatorsNeedPassword(_spectatorsNeedPassword), spectatorsCanTalk(_spectatorsCanTalk),
       spectatorsSeeEverything(_spectatorsSeeEverything), inactivityCounter(0), startTimeOfThisGame(0),
       secondsElapsed(0), firstGameStarted(false), turnOrderReversed(false), startTime(QDateTime::currentDateTime()),
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+      gameMutex()
+#else
       gameMutex(QMutex::Recursive)
+#endif
 {
     currentReplay = new GameReplay;
     currentReplay->set_replay_id(room->getServer()->getDatabaseInterface()->getNextReplayId());

--- a/common/server_game.h
+++ b/common/server_game.h
@@ -88,7 +88,11 @@ private slots:
     void doStartGameIfReady();
 
 public:
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    mutable QRecursiveMutex gameMutex;
+#else
     mutable QMutex gameMutex;
+#endif
     Server_Game(const ServerInfo_User &_creatorInfo,
                 int _gameId,
                 const QString &_description,


### PR DESCRIPTION
## Short roundup of the initial problem
builds on arch with the latest version of qt stopped working

## What will change with this Pull Request?
- add a version guard
