### PR TITLE
add werror flags when making a debug build using llvm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,11 @@ ELSEIF (CMAKE_COMPILER_IS_GNUCXX)
 ELSE()
     # other: osx/llvm, bsd/llvm
     set(CMAKE_CXX_FLAGS_RELEASE "-O2")
-    set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
+    if(WARNING_AS_ERROR)
+      set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wextra -Werror")
+    else()
+      set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wextra")
+    endif()
 ENDIF()
 
 # GNU systems need to define the Mersenne exponent for the RNG to compile w/o warning


### PR DESCRIPTION
this would get bugs like
https://github.com/Cockatrice/Cockatrice/pull/4337
get signalled earlier to us

## Short roundup of the initial problem
macos builds do not fail on warnings, this is a useful feature that can give an advance warning of a bug that would be exclusive to macos

## What will change with this Pull Request?
- adds the same flags used for gcc to llvm, hoping they do the same thing
