### PR TITLE
Beta releases: collapsable list of changes

### DIFF
--- a/.ci/prep_release.sh
+++ b/.ci/prep_release.sh
@@ -47,8 +47,10 @@ if [[ $no_beta ]]; then
   fi
   body="${body//--REPLACE-WITH-RELEASE-TITLE--/$title}"
 else
-  body="<details>
-<summary><b>Included commits over previous version</b></summary>
+  body="--REPLACE-WITH-COMMIT-COUNT-- commits have been included over the previous version
+
+<details>
+<summary><b>show changes</b></summary>
 
 --REPLACE-WITH-GENERATED-LIST--
 </details>"
@@ -86,6 +88,7 @@ else
       # --> is the markdown comment escape sequence, emojis are way better
       generated_list="${generated_list//-->/→}"
       body="${body//--REPLACE-WITH-GENERATED-LIST--/$generated_list}"
+      body="${body//--REPLACE-WITH-COMMIT-COUNT--/$count}"
       if [[ $beta_list =~ $whitespace ]]; then
         beta_list="-n there are no betas to delete!"
       else

--- a/.ci/prep_release.sh
+++ b/.ci/prep_release.sh
@@ -47,7 +47,7 @@ if [[ $no_beta ]]; then
   fi
   body="${body//--REPLACE-WITH-RELEASE-TITLE--/$title}"
 else
-  body="--REPLACE-WITH-COMMIT-COUNT-- commits have been included over the previous version
+  body="--REPLACE-WITH-COMMIT-COUNT-- commits have been included over the previous --REPLACE-WITH-PREVIOUS-RELEASE-TYPE--
 
 <details>
 <summary><b>show changes</b></summary>
@@ -83,12 +83,15 @@ else
   if [[ $previous ]]; then
     if generated_list="$(git log "$previous..$TAG" --pretty="- %s")"; then
       count="$(git rev-list --count "$previous..$TAG")"
+      [[ $previous =~ $beta_regex ]] && previousreleasetype="beta release" || previousreleasetype="full release"
       echo "adding list of commits to release notes:"
       echo "'$previous' to '$TAG' ($count commits)"
       # --> is the markdown comment escape sequence, emojis are way better
       generated_list="${generated_list//-->/→}"
       body="${body//--REPLACE-WITH-GENERATED-LIST--/$generated_list}"
       body="${body//--REPLACE-WITH-COMMIT-COUNT--/$count}"
+      body="${body//--REPLACE-WITH-PREVIOUS-RELEASE-TAG--/$previous}"
+      body="${body//--REPLACE-WITH-PREVIOUS-RELEASE-TYPE--/$previousreleasetype}"
       if [[ $beta_list =~ $whitespace ]]; then
         beta_list="-n there are no betas to delete!"
       else

--- a/.ci/prep_release.sh
+++ b/.ci/prep_release.sh
@@ -47,8 +47,11 @@ if [[ $no_beta ]]; then
   fi
   body="${body//--REPLACE-WITH-RELEASE-TITLE--/$title}"
 else
-  body="Included commits over previous version:
---REPLACE-WITH-GENERATED-LIST--"
+  body="<details>
+<summary><b>Included commits over previous version</b></summary>
+
+--REPLACE-WITH-GENERATED-LIST--
+</details>"
 fi
 
 # add git log to release notes

--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -16,8 +16,10 @@ include different targets -->
  - <kbd>Ubuntu 18.04</kbd> ("Bionic Beaver")</i>
  - <kbd>Ubuntu 20.04</kbd> ("Focal Fossa")</i>
  - <kbd>Ubuntu 20.10</kbd> ("Groovy Gorilla")</i>
+ - <kbd>Ubuntu 21.04</kbd> ("Hirsute Hippo")</i>
  - <kbd>Debian 10</kbd> ("Buster")</i>
  - <kbd>Fedora 33</kbd></i>
+ - <kbd>Fedora 34</kbd></i>
 <kbd>We are also packaged in Arch Linux's official community repository, courtesy of @FFY00</kbd></i>
 <kbd>General linux support is available via a flatpak package (Flathub)</kbd></i>
 </pre>
@@ -38,6 +40,11 @@ If you'd like to help contribute to Cockatrice in any way, check out our [README
 
 
 ## Upgrading Cockatrice
+<!-- this optional section puts a warning banner for problems with updating
+> ⚠️ **With this release, we no longer provide a ready-to-install binary for:**
+> --DEPRECATED-OS-HERE--
+ -->
+ 
 - Run the internal software updater: <kbd>Help → Check for Client Updates</kbd>
 
 Don't forget to update your card database right after! (<kbd>Help → Check for Card Updates...</kbd>)
@@ -61,10 +68,9 @@ Remove empty headers when done.
 
 <!-- Complete list of changes (foldable) -->
 <details>
-<summary>📘 <b>Show all changes <code>
-<!-- Count of other changes -->
- 
-</code></b></summary>
+<summary>
+📘 <b>Show all changes</b> (--REPLACE-WITH-COMMIT-COUNT-- commits)
+</summary>
 
 ### User Interface
 ### Under the Hood


### PR DESCRIPTION
## Short roundup of the initial problem
Busy beta releases eat up a lot of space in the list of releases and full releases get hidden:
![Untitled](https://user-images.githubusercontent.com/9874850/117575592-cc342900-b0e2-11eb-841b-c9d07b101255.png)


## What will change with this Pull Request?
- Make the list of changes collapsable

@ebbit1q Please have a look if there is an obvious shell mistake. The extra line break is needed in order to display the list of bullet points within correctly.
