### PR TITLE
add werror flags when making a debug build using llvm

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -280,6 +280,7 @@ jobs:
 
       - name: Build on Xcode ${{matrix.xcode}}
         shell: bash
+        env: CMAKE_BUILD_PARALLEL_LEVEL=3  # mac machines actually have 3 cores
         run: .ci/compile.sh ${{matrix.type}} --server
 
       - name: Test

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -280,7 +280,8 @@ jobs:
 
       - name: Build on Xcode ${{matrix.xcode}}
         shell: bash
-        env: CMAKE_BUILD_PARALLEL_LEVEL=3  # mac machines actually have 3 cores
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: 3  # mac machines actually have 3 cores
         run: .ci/compile.sh ${{matrix.type}} --server
 
       - name: Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,11 @@ ELSEIF (CMAKE_COMPILER_IS_GNUCXX)
 ELSE()
     # other: osx/llvm, bsd/llvm
     set(CMAKE_CXX_FLAGS_RELEASE "-O2")
-    set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
+    if(WARNING_AS_ERROR)
+      set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wextra -Werror")
+    else()
+      set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wextra")
+    endif()
 ENDIF()
 
 # GNU systems need to define the Mersenne exponent for the RNG to compile w/o warning

--- a/cockatrice/src/userconnection_information.h
+++ b/cockatrice/src/userconnection_information.h
@@ -17,7 +17,6 @@ private:
     QString password;
     bool savePassword;
     QString site;
-    bool isCustom;
 
 public:
     UserConnection_Information();

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -201,14 +201,13 @@ bool Servatrice_DatabaseInterface::registerUser(const QString &userName,
                                                 const QString &password,
                                                 const QString &emailAddress,
                                                 const QString &country,
-                                                QString &token,
                                                 bool active)
 {
     if (!checkSql())
         return false;
 
     QString passwordSha512 = PasswordHasher::computeHash(password, PasswordHasher::generateRandomSalt());
-    token = active ? QString() : PasswordHasher::generateActivationToken();
+    QString token = active ? QString() : PasswordHasher::generateActivationToken();
 
     QSqlQuery *query =
         prepareQuery("insert into {prefix}_users "

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -99,7 +99,6 @@ public:
                       const QString &password,
                       const QString &emailAddress,
                       const QString &country,
-                      QString &token,
                       bool active = false);
     bool activateUser(const QString &userName, const QString &token);
     void updateUsersClientID(const QString &userName, const QString &userClientID);

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -1099,9 +1099,8 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
         return Response::RespPasswordTooShort;
     }
 
-    QString token;
     bool requireEmailActivation = settingsCache->value("registration/requireemailactivation", true).toBool();
-    bool regSucceeded = sqlInterface->registerUser(userName, realName, gender, password, emailAddress, country, token,
+    bool regSucceeded = sqlInterface->registerUser(userName, realName, gender, password, emailAddress, country,
                                                    !requireEmailActivation);
 
     if (regSucceeded) {


### PR DESCRIPTION
this would get bugs like
https://github.com/Cockatrice/Cockatrice/pull/4337
get signalled earlier to us

## Short roundup of the initial problem
macos builds do not fail on warnings, this is a useful feature that can give an advance warning of a bug that would be exclusive to macos

## What will change with this Pull Request?
- adds the same flags used for gcc to llvm, hoping they do the same thing

don't merge this like https://github.com/Cockatrice/Cockatrice/pull/4338 until it actually compiles please
