### PR TITLE
do not edit the zone currently iterated on

### DIFF
--- a/common/server_game.cpp
+++ b/common/server_game.cpp
@@ -577,19 +577,17 @@ void Server_Game::unattachCards(GameEventStorage &ges, Server_Player *player)
 
     for (auto zone : player->getZones()) {
         for (auto card : zone->getCards()) {
-            if (card == nullptr) {
-                continue;
-            }
-
-            const auto &attachedCardsBase = card->getAttachedCards();
-            if (attachedCardsBase.isEmpty()) {
-                continue;
-            }
-
             // Make a copy of the list because the original one gets modified during the loop
-            QList<Server_Card *> attachedCards = {attachedCardsBase};
+            QList<Server_Card *> attachedCards = card->getAttachedCards();
             for (Server_Card *attachedCard : attachedCards) {
-                attachedCard->getZone()->getPlayer()->unattachCard(ges, attachedCard);
+                auto otherPlayer = attachedCard->getZone()->getPlayer();
+                // do not modify the current player's zone!
+                // this would cause the current card iterator to be invalidated!
+                // we only have to return cards owned by other players
+                // because the current player is leaving the game anyway
+                if (otherPlayer != player) {
+                    otherPlayer->unattachCard(ges, attachedCard);
+                }
             }
         }
     }


### PR DESCRIPTION

## Related Ticket(s)
- reverts #4340 and  #4341 which were fixes that didn't work

## Short roundup of the initial problem
unattaching cards invokes the moveCard function which changes the
internal cards list

this can cause the iterator to become invalidated which will crash but
because of the data not always being moved it will often still work as
intended, giving the idea that it is random


## What will change with this Pull Request?
- cards will no longer be unattached when a player leaves play if both cards are controlled by the same player
  - this is unnoticeable to clients as in the same event that player will have all their cards deleted regardless
