### PR TITLE
check if player is null when updating card menu

### DIFF
--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -1412,12 +1412,15 @@ Player *TabGame::getActiveLocalPlayer() const
 
 void TabGame::updateCardMenu(AbstractCardItem *card)
 {
-    Player *p;
-    if ((clients.size() > 1) || !players.contains(localPlayerId))
-        p = card->getOwner();
-    else
-        p = players.value(localPlayerId);
-    p->updateCardMenu(static_cast<CardItem *>(card));
+    Player *player;
+    if ((clients.size() > 1) || !players.contains(localPlayerId)) {
+        player = card->getOwner();
+    } else {
+        player = players.value(localPlayerId);
+    }
+    if (player != nullptr) {
+        player->updateCardMenu(static_cast<CardItem *>(card));
+    }
 }
 
 void TabGame::createMenuItems()


### PR DESCRIPTION
this should fix this crash:

```
#0  0x000055c5bb6be035 in Player::updateCardMenu (this=0x0, card=0x55c5bf712170)
    at Cockatrice/cockatrice/src/player.cpp:3308
        cardMenu = 0x55c5bb6cb550 <QMapData<int, Player*>::findNode(int const&) const+58>
        ptMenu = 0x55c5bf96c45c
        moveMenu = 0x55c5bdb0cd00
        revealedCard = false
        writeableCard = false
#1  0x000055c5bb75850b in TabGame::updateCardMenu (this=0x55c5bf96c380, card=0x55c5bf712170)
    at Cockatrice/cockatrice/src/tab_game.cpp:1420
        p = 0x0
#2  0x000055c5bb622001 in TabGame::qt_static_metacall (_o=0x55c5bf96c380, 
    _c=QMetaObject::InvokeMetaMethod, _id=16, _a=0x7ffce85e8a20)
    at Cockatrice/build/cockatrice/cockatrice_autogen/UVLADIE3JM/moc_tab_game.cpp:558
        _t = 0x55c5bf96c380
        ```