### PR TITLE
Fix for poor performance with large decks

### DIFF
--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -272,7 +272,6 @@ void AbstractCardItem::setFaceDown(bool _facedown)
 {
     facedown = _facedown;
     update();
-    emit updateCardMenu(this);
 }
 
 void AbstractCardItem::mousePressEvent(QGraphicsSceneMouseEvent *event)

--- a/cockatrice/src/abstractcarditem.h
+++ b/cockatrice/src/abstractcarditem.h
@@ -36,7 +36,6 @@ signals:
     void hovered(AbstractCardItem *card);
     void showCardInfoPopup(QPoint pos, QString cardName);
     void deleteCardInfoPopup(QString cardName);
-    void updateCardMenu(AbstractCardItem *card);
     void sigPixmapUpdated();
     void cardShiftClicked(QString cardName);
 

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -364,8 +364,9 @@ void CardItem::playCard(bool faceDown)
 void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     if (event->button() == Qt::RightButton) {
+        updateCardMenu(this);
         if (cardMenu && !cardMenu->isEmpty() && owner != nullptr) {
-            updateCardMenu(this);
+            owner->updateCardMenu(this);
             cardMenu->exec(event->screenPos());
         }
     } else if ((event->modifiers() != Qt::AltModifier) && (event->button() == Qt::LeftButton) &&

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -36,7 +36,10 @@ CardItem::CardItem(Player *_owner,
 
     retranslateUi();
     if (updateMenu) { // avoid updating card menu too often
-        emit updateCardMenu(this);
+        // Add a lambda that updates the card menu on right clicked
+        connect(getPTMenu(), &QMenu::triggered, this, [this] { emit updateCardMenu(this); });
+        connect(getCardMenu(), &QMenu::triggered, this, [this] { emit updateCardMenu(this); });
+        connect(getMoveMenu(), &QMenu::triggered, this, [this] { emit updateCardMenu(this); });
     }
 }
 
@@ -84,7 +87,6 @@ void CardItem::deleteLater()
 void CardItem::setZone(CardZone *_zone)
 {
     zone = _zone;
-    emit updateCardMenu(this);
 }
 
 void CardItem::retranslateUi()
@@ -372,7 +374,6 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     if (event->button() == Qt::RightButton) {
         if (cardMenu && !cardMenu->isEmpty() && owner != nullptr) {
-            owner->updateCardMenu(this);
             cardMenu->exec(event->screenPos());
         }
     } else if ((event->modifiers() != Qt::AltModifier) && (event->button() == Qt::LeftButton) &&

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -94,8 +94,8 @@ void CardItem::setZone(CardZone *_zone)
 void CardItem::retranslateUi()
 {
     moveMenu->setTitle(tr("&Move to"));
-    ptMenu->setTitle(tr("&Power / toughness"));    
-    
+    ptMenu->setTitle(tr("&Power / toughness"));
+
     // If this card is selected then update the menus
     if (owner) {
         if (owner->getCardMenu() == cardMenu) {
@@ -232,7 +232,7 @@ void CardItem::setAttachedTo(CardItem *_attachedTo)
 
     if (zone)
         zone->reorganizeCards();
-    
+
     // If this card is selected then update the menus
     if (owner) {
         if (owner->getCardMenu() == cardMenu) {
@@ -468,11 +468,11 @@ QVariant CardItem::itemChange(GraphicsItemChange change, const QVariant &value)
             owner->setCardMenu(0);
             owner->getGame()->setActiveCard(0);
         }
-        
+
         updateCardMenu(this);
         if (cardMenu && owner != nullptr) {
             owner->updateCardMenu(this);
         }
-    }                                                                               
+    }
     return QGraphicsItem::itemChange(change, value);
 }

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -87,6 +87,7 @@ void CardItem::deleteLater()
 void CardItem::setZone(CardZone *_zone)
 {
     zone = _zone;
+    emit updateCardMenu(this);
 }
 
 void CardItem::retranslateUi()

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -87,7 +87,6 @@ void CardItem::deleteLater()
 void CardItem::setZone(CardZone *_zone)
 {
     zone = _zone;
-    emit updateCardMenu(this);
 }
 
 void CardItem::retranslateUi()

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -23,8 +23,7 @@ CardItem::CardItem(Player *_owner,
                    int _cardid,
                    bool _revealedCard,
                    QGraphicsItem *parent,
-                   CardZone *_zone,
-                   bool updateMenu)
+                   CardZone *_zone)
     : AbstractCardItem(_name, _owner, _cardid, parent), zone(_zone), revealedCard(_revealedCard), attacking(false),
       destroyOnZoneChange(false), doesntUntap(false), dragItem(nullptr), attachedTo(nullptr)
 {
@@ -35,12 +34,6 @@ CardItem::CardItem(Player *_owner,
     moveMenu = new QMenu;
 
     retranslateUi();
-    if (updateMenu) { // avoid updating card menu too often
-        // Add a lambda that updates the card menu on right clicked
-        connect(getPTMenu(), &QMenu::aboutToShow, this, [this] { emit updateCardMenu(this); });
-        connect(getCardMenu(), &QMenu::aboutToShow, this, [this] { emit updateCardMenu(this); });
-        connect(getMoveMenu(), &QMenu::aboutToShow, this, [this] { emit updateCardMenu(this); });
-    }
 }
 
 CardItem::~CardItem()
@@ -220,8 +213,6 @@ void CardItem::setAttachedTo(CardItem *_attachedTo)
 
     if (zone)
         zone->reorganizeCards();
-
-    emit updateCardMenu(this);
 }
 
 void CardItem::resetState()
@@ -374,6 +365,7 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     if (event->button() == Qt::RightButton) {
         if (cardMenu && !cardMenu->isEmpty() && owner != nullptr) {
+            updateCardMenu(this);
             cardMenu->exec(event->screenPos());
         }
     } else if ((event->modifiers() != Qt::AltModifier) && (event->button() == Qt::LeftButton) &&

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -80,31 +80,12 @@ void CardItem::deleteLater()
 void CardItem::setZone(CardZone *_zone)
 {
     zone = _zone;
-    // If this card is selected then update the menus
-    if (owner) {
-        if (owner->getCardMenu() == cardMenu) {
-            updateCardMenu(this);
-            if (cardMenu && owner != nullptr) {
-                owner->updateCardMenu(this);
-            }
-        }
-    }
 }
 
 void CardItem::retranslateUi()
 {
     moveMenu->setTitle(tr("&Move to"));
     ptMenu->setTitle(tr("&Power / toughness"));
-
-    // If this card is selected then update the menus
-    if (owner) {
-        if (owner->getCardMenu() == cardMenu) {
-            updateCardMenu(this);
-            if (cardMenu && owner != nullptr) {
-                owner->updateCardMenu(this);
-            }
-        }
-    }
 }
 
 void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
@@ -217,30 +198,24 @@ void CardItem::setPT(const QString &_pt)
 
 void CardItem::setAttachedTo(CardItem *_attachedTo)
 {
-    if (attachedTo)
+    if (attachedTo != nullptr) {
         attachedTo->removeAttachedCard(this);
+    }
 
     gridPoint.setX(-1);
     attachedTo = _attachedTo;
-    if (attachedTo) {
+    if (attachedTo != nullptr) {
         setParentItem(attachedTo->getZone());
         attachedTo->addAttachedCard(this);
-        if (zone != attachedTo->getZone())
+        if (zone != attachedTo->getZone()) {
             attachedTo->getZone()->reorganizeCards();
-    } else
-        setParentItem(zone);
-
-    if (zone)
-        zone->reorganizeCards();
-
-    // If this card is selected then update the menus
-    if (owner) {
-        if (owner->getCardMenu() == cardMenu) {
-            updateCardMenu(this);
-            if (cardMenu && owner != nullptr) {
-                owner->updateCardMenu(this);
-            }
         }
+    } else {
+        setParentItem(zone);
+    }
+
+    if (zone != nullptr) {
+        zone->reorganizeCards();
     }
 }
 
@@ -393,9 +368,7 @@ void CardItem::playCard(bool faceDown)
 void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     if (event->button() == Qt::RightButton) {
-        updateCardMenu(this);
-        if (cardMenu && owner != nullptr) {
-            owner->updateCardMenu(this);
+        if (cardMenu != nullptr && !cardMenu->isEmpty() && owner != nullptr) {
             cardMenu->exec(event->screenPos());
         }
     } else if ((event->modifiers() != Qt::AltModifier) && (event->button() == Qt::LeftButton) &&
@@ -460,18 +433,13 @@ bool CardItem::animationEvent()
 
 QVariant CardItem::itemChange(GraphicsItemChange change, const QVariant &value)
 {
-    if ((change == ItemSelectedHasChanged) && owner) {
+    if ((change == ItemSelectedHasChanged) && owner != nullptr) {
         if (value == true) {
             owner->setCardMenu(cardMenu);
             owner->getGame()->setActiveCard(this);
         } else if (owner->getCardMenu() == cardMenu) {
-            owner->setCardMenu(0);
-            owner->getGame()->setActiveCard(0);
-        }
-
-        updateCardMenu(this);
-        if (cardMenu && owner != nullptr) {
-            owner->updateCardMenu(this);
+            owner->setCardMenu(nullptr);
+            owner->getGame()->setActiveCard(nullptr);
         }
     }
     return QGraphicsItem::itemChange(change, value);

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -37,9 +37,9 @@ CardItem::CardItem(Player *_owner,
     retranslateUi();
     if (updateMenu) { // avoid updating card menu too often
         // Add a lambda that updates the card menu on right clicked
-        connect(getPTMenu(), &QMenu::triggered, this, [this] { emit updateCardMenu(this); });
-        connect(getCardMenu(), &QMenu::triggered, this, [this] { emit updateCardMenu(this); });
-        connect(getMoveMenu(), &QMenu::triggered, this, [this] { emit updateCardMenu(this); });
+        connect(getPTMenu(), &QMenu::aboutToShow, this, [this] { emit updateCardMenu(this); });
+        connect(getCardMenu(), &QMenu::aboutToShow, this, [this] { emit updateCardMenu(this); });
+        connect(getMoveMenu(), &QMenu::aboutToShow, this, [this] { emit updateCardMenu(this); });
     }
 }
 

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -80,12 +80,31 @@ void CardItem::deleteLater()
 void CardItem::setZone(CardZone *_zone)
 {
     zone = _zone;
+    // If this card is selected then update the menus
+    if (owner) {
+        if (owner->getCardMenu() == cardMenu) {
+            updateCardMenu(this);
+            if (cardMenu && owner != nullptr) {
+                owner->updateCardMenu(this);
+            }
+        }
+    }
 }
 
 void CardItem::retranslateUi()
 {
     moveMenu->setTitle(tr("&Move to"));
-    ptMenu->setTitle(tr("&Power / toughness"));
+    ptMenu->setTitle(tr("&Power / toughness"));    
+    
+    // If this card is selected then update the menus
+    if (owner) {
+        if (owner->getCardMenu() == cardMenu) {
+            updateCardMenu(this);
+            if (cardMenu && owner != nullptr) {
+                owner->updateCardMenu(this);
+            }
+        }
+    }
 }
 
 void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
@@ -213,6 +232,16 @@ void CardItem::setAttachedTo(CardItem *_attachedTo)
 
     if (zone)
         zone->reorganizeCards();
+    
+    // If this card is selected then update the menus
+    if (owner) {
+        if (owner->getCardMenu() == cardMenu) {
+            updateCardMenu(this);
+            if (cardMenu && owner != nullptr) {
+                owner->updateCardMenu(this);
+            }
+        }
+    }
 }
 
 void CardItem::resetState()
@@ -439,6 +468,11 @@ QVariant CardItem::itemChange(GraphicsItemChange change, const QVariant &value)
             owner->setCardMenu(0);
             owner->getGame()->setActiveCard(0);
         }
-    }
+        
+        updateCardMenu(this);
+        if (cardMenu && owner != nullptr) {
+            owner->updateCardMenu(this);
+        }
+    }                                                                               
     return QGraphicsItem::itemChange(change, value);
 }

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -365,7 +365,7 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     if (event->button() == Qt::RightButton) {
         updateCardMenu(this);
-        if (cardMenu && !cardMenu->isEmpty() && owner != nullptr) {
+        if (cardMenu && owner != nullptr) {
             owner->updateCardMenu(this);
             cardMenu->exec(event->screenPos());
         }

--- a/cockatrice/src/carditem.h
+++ b/cockatrice/src/carditem.h
@@ -53,8 +53,7 @@ public:
              int _cardid = -1,
              bool revealedCard = false,
              QGraphicsItem *parent = nullptr,
-             CardZone *_zone = nullptr,
-             bool updateMenu = false);
+             CardZone *_zone = nullptr);
     ~CardItem();
     void retranslateUi();
     CardZone *getZone() const

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -3301,8 +3301,7 @@ void Player::updateCardMenu(const CardItem *card)
 {
     /**
      * Regarding issue https://github.com/Cockatrice/Cockatrice/issues/4284
-     * The best fix is to add the QActions when a card is right clicked on,
-     * so this method is not needed
+     * The best fix is to add the QActions when a card is right clicked on
      */
     // If bad card OR is a spectator (as spectators don't need card menus), return
     if (card == nullptr || (game->isSpectator() && !judge)) {

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1946,7 +1946,6 @@ void Player::eventSetCardCounter(const Event_SetCardCounter &event)
 
     int oldValue = card->getCounters().value(event.counter_id(), 0);
     card->setCounter(event.counter_id(), event.counter_value());
-    updateCardMenu(card);
     emit logSetCardCounter(this, card->getName(), event.counter_id(), event.counter_value(), oldValue);
 }
 
@@ -3295,15 +3294,16 @@ void Player::refreshShortcuts()
 {
     if (shortcutsActive) {
         setShortcutsActive();
-
-        for (const CardItem *cardItem : table->getCards()) {
-            updateCardMenu(cardItem);
-        }
     }
 }
 
 void Player::updateCardMenu(const CardItem *card)
 {
+    /**
+     * Regarding issue https://github.com/Cockatrice/Cockatrice/issues/4284
+     * The best fix is to add the QActions when a card is right clicked on,
+     * so this method is not needed
+     */
     // If bad card OR is a spectator (as spectators don't need card menus), return
     if (card == nullptr || (game->isSpectator() && !judge)) {
         return;

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -3545,7 +3545,11 @@ void Player::setCardMenu(QMenu *menu)
 
 QMenu *Player::getCardMenu() const
 {
-    return aCardMenu->menu(); // can return nullptr
+    if (aCardMenu != nullptr) {
+        return aCardMenu->menu();
+    } else {
+        return nullptr;
+    }
 }
 
 QString Player::getName() const

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -1346,7 +1346,6 @@ void TabGame::newCardAdded(AbstractCardItem *card)
     connect(card, SIGNAL(hovered(AbstractCardItem *)), cardInfo, SLOT(setCard(AbstractCardItem *)));
     connect(card, SIGNAL(showCardInfoPopup(QPoint, QString)), this, SLOT(showCardInfoPopup(QPoint, QString)));
     connect(card, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));
-    connect(card, SIGNAL(updateCardMenu(AbstractCardItem *)), this, SLOT(updateCardMenu(AbstractCardItem *)));
     connect(card, SIGNAL(cardShiftClicked(QString)), this, SLOT(linkCardToChat(QString)));
 }
 
@@ -1408,6 +1407,12 @@ Player *TabGame::getActiveLocalPlayer() const
     }
 
     return nullptr;
+}
+
+void TabGame::setActiveCard(CardItem *card)
+{
+    activeCard = card;
+    updateCardMenu(card);
 }
 
 void TabGame::updateCardMenu(AbstractCardItem *card)

--- a/cockatrice/src/tab_game.h
+++ b/cockatrice/src/tab_game.h
@@ -298,10 +298,7 @@ public:
     Player *getActiveLocalPlayer() const;
     AbstractClient *getClientForPlayer(int playerId) const;
 
-    void setActiveCard(CardItem *_card)
-    {
-        activeCard = _card;
-    }
+    void setActiveCard(CardItem *card);
     CardItem *getActiveCard() const
     {
         return activeCard;

--- a/cockatrice/src/zoneviewzone.cpp
+++ b/cockatrice/src/zoneviewzone.cpp
@@ -83,15 +83,12 @@ void ZoneViewZone::initializeCards(const QList<const ServerInfo_Card *> &cardLis
 
 void ZoneViewZone::zoneDumpReceived(const Response &r)
 {
-    static constexpr int MAX_VIEW_MENU = 300;
     const Response_DumpZone &resp = r.GetExtension(Response_DumpZone::ext);
     const int respCardListSize = resp.zone_info().card_list_size();
     for (int i = 0; i < respCardListSize; ++i) {
         const ServerInfo_Card &cardInfo = resp.zone_info().card_list(i);
         auto cardName = QString::fromStdString(cardInfo.name());
-        // stop updating card menus after MAX_VIEW_MENU cards
-        // this means only the first cards in the menu have actions but others can still be dragged
-        auto *card = new CardItem(player, cardName, cardInfo.id(), revealZone, this, this, i < MAX_VIEW_MENU);
+        auto *card = new CardItem(player, cardName, cardInfo.id(), revealZone, this, this);
         cards.insert(i, card);
     }
     reorganizeCards();


### PR DESCRIPTION
-> The menus have the update menu thing emitted when they get triggered.
| -> works surprising well https://youtu.be/KOOmhxvHA2c is a demo on a 10000ish card deck

## Related Ticket(s)
- Fixes #4284

## Short roundup of the initial problem
The client was slow when opening large decks for games or having large amounts of cards played. The bottleneck was the action menu being updated,

## What will change with this Pull Request?
- Made the menus update when they get triggered.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
