### PR TITLE
fix the lock sideboard shortcut

### DIFF
--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -163,6 +163,9 @@ void DeckViewContainer::updateSideboardLockButtonText()
     } else {
         sideboardLockButton->setText(tr("Sideboard locked"));
     }
+    // setting text on a button removes its shortcut
+    ShortcutsSettings &shortcuts = SettingsCache::instance().shortcuts();
+    sideboardLockButton->setShortcut(shortcuts.getSingleShortcut("DeckViewContainer/sideboardLockButton"));
 }
 
 void DeckViewContainer::refreshShortcuts()


### PR DESCRIPTION
## Related Ticket(s)
- fix #3840

## Short roundup of the initial problem
setting text on buttons removes their shortcuts

## What will change with this Pull Request?
- set the shortcut every time the text changes