### PR TITLE
properly enable notification checkboxes

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -411,7 +411,7 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     notificationsEnabledCheckBox.setChecked(SettingsCache::instance().getNotificationsEnabled());
     connect(&notificationsEnabledCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
             SLOT(setNotificationsEnabled(int)));
-    connect(&notificationsEnabledCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setSpecNotificationEnabled(int)));
+    connect(&notificationsEnabledCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setNotificationEnabled(int)));
 
     specNotificationsEnabledCheckBox.setChecked(SettingsCache::instance().getSpectatorNotificationsEnabled());
     specNotificationsEnabledCheckBox.setEnabled(SettingsCache::instance().getNotificationsEnabled());
@@ -473,9 +473,14 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     setLayout(mainLayout);
 }
 
-void UserInterfaceSettingsPage::setSpecNotificationEnabled(int i)
+void UserInterfaceSettingsPage::setNotificationEnabled(int i)
 {
     specNotificationsEnabledCheckBox.setEnabled(i != 0);
+    buddyConnectNotificationsEnabledCheckBox.setEnabled(i != 0);
+    if (i == 0) {
+        specNotificationsEnabledCheckBox.setChecked(false);
+        buddyConnectNotificationsEnabledCheckBox.setChecked(false);
+    }
 }
 
 void UserInterfaceSettingsPage::retranslateUi()

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -108,7 +108,7 @@ class UserInterfaceSettingsPage : public AbstractSettingsPage
 {
     Q_OBJECT
 private slots:
-    void setSpecNotificationEnabled(int);
+    void setNotificationEnabled(int);
 
 private:
     QCheckBox notificationsEnabledCheckBox;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4355

## Short roundup of the initial problem
when unchecking and checking the enable notifications checkbox in the settings the checkbox for notifications for friends connecting misbehaved

## What will change with this Pull Request?
- enable and disable the checkbox properly
- rename the function because it is horribly confusing
- uncheck both checkboxes when the main checkbox is unchecked
