### PR TITLE
Prettier settings dialog

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -616,7 +616,6 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     auto *lpMainLayout = new QVBoxLayout;
     lpMainLayout->addWidget(mpGeneralGroupBox);
     lpMainLayout->addWidget(mpSpoilerGroupBox);
-    lpMainLayout->addStretch();
 
     setLayout(lpMainLayout);
 }
@@ -891,7 +890,6 @@ MessagesSettingsPage::MessagesSettingsPage()
     mainLayout->addWidget(messageShortcuts);
     mainLayout->addWidget(chatGroupBox);
     mainLayout->addWidget(highlightGroupBox);
-    mainLayout->addStretch();
 
     setLayout(mainLayout);
 

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -177,6 +177,7 @@ GeneralSettingsPage::GeneralSettingsPage()
     auto *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(personalGroupBox);
     mainLayout->addWidget(pathsGroupBox);
+    mainLayout->addStretch();
 
     setLayout(mainLayout);
 }
@@ -384,6 +385,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     mainLayout->addWidget(cardsGroupBox);
     mainLayout->addWidget(handGroupBox);
     mainLayout->addWidget(tableGroupBox);
+    mainLayout->addStretch();
 
     setLayout(mainLayout);
 }
@@ -491,6 +493,7 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     mainLayout->addWidget(generalGroupBox);
     mainLayout->addWidget(notificationsGroupBox);
     mainLayout->addWidget(animationGroupBox);
+    mainLayout->addStretch();
 
     setLayout(mainLayout);
 }
@@ -561,12 +564,15 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
 
     auto aAdd = new QAction(this);
     aAdd->setIcon(QPixmap("theme:icons/increment"));
+    aAdd->setToolTip(tr("Add New URL"));
     connect(aAdd, SIGNAL(triggered()), this, SLOT(actAddURL()));
     auto aEdit = new QAction(this);
     aEdit->setIcon(QPixmap("theme:icons/pencil"));
+    aEdit->setToolTip(tr("Edit URL"));
     connect(aEdit, SIGNAL(triggered()), this, SLOT(actEditURL()));
     auto aRemove = new QAction(this);
     aRemove->setIcon(QPixmap("theme:icons/decrement"));
+    aRemove->setToolTip(tr("Remove URL"));
     connect(aRemove, SIGNAL(triggered()), this, SLOT(actRemoveURL()));
 
     auto *messageToolBar = new QToolBar;
@@ -610,6 +616,7 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     auto *lpMainLayout = new QVBoxLayout;
     lpMainLayout->addWidget(mpGeneralGroupBox);
     lpMainLayout->addWidget(mpSpoilerGroupBox);
+    lpMainLayout->addStretch();
 
     setLayout(lpMainLayout);
 }
@@ -854,16 +861,15 @@ MessagesSettingsPage::MessagesSettingsPage()
 
     aAdd = new QAction(this);
     aAdd->setIcon(QPixmap("theme:icons/increment"));
-    aAdd->setStatusTip(tr("Add New URL"));
-
+    aAdd->setToolTip(tr("Add New Message"));
     connect(aAdd, SIGNAL(triggered()), this, SLOT(actAdd()));
     aEdit = new QAction(this);
     aEdit->setIcon(QPixmap("theme:icons/pencil"));
-    aEdit->setStatusTip(tr("Edit URL"));
+    aEdit->setToolTip(tr("Edit Message"));
     connect(aEdit, SIGNAL(triggered()), this, SLOT(actEdit()));
     aRemove = new QAction(this);
     aRemove->setIcon(QPixmap("theme:icons/decrement"));
-    aRemove->setStatusTip(tr("Remove URL"));
+    aRemove->setToolTip(tr("Remove Message"));
     connect(aRemove, SIGNAL(triggered()), this, SLOT(actRemove()));
 
     auto *messageToolBar = new QToolBar;
@@ -885,6 +891,7 @@ MessagesSettingsPage::MessagesSettingsPage()
     mainLayout->addWidget(messageShortcuts);
     mainLayout->addWidget(chatGroupBox);
     mainLayout->addWidget(highlightGroupBox);
+    mainLayout->addStretch();
 
     setLayout(mainLayout);
 
@@ -1043,6 +1050,7 @@ SoundSettingsPage::SoundSettingsPage()
 
     auto *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(soundGroupBox);
+    mainLayout->addStretch();
 
     setLayout(mainLayout);
 }
@@ -1237,8 +1245,8 @@ DlgSettings::DlgSettings(QWidget *parent) : QDialog(parent)
 #else
     QRect rec = QApplication::desktop()->availableGeometry();
 #endif
-    this->setMinimumSize(rec.width() / 2, rec.height() - 100);
-    this->setBaseSize(rec.width(), rec.height());
+    this->setMaximumSize(rec.width() - 100, rec.height() - 100);
+    this->setMinimumSize(700, 600);
 
     connect(&SettingsCache::instance(), SIGNAL(langChanged()), this, SLOT(updateLanguage()));
 

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -1239,12 +1239,11 @@ void ShortcutSettingsPage::retranslateUi()
 DlgSettings::DlgSettings(QWidget *parent) : QDialog(parent)
 {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
-    QRect rec = qApp->primaryScreen()->availableGeometry();
+    auto rec = qApp->primaryScreen()->availableGeometry();
 #else
-    QRect rec = QApplication::desktop()->availableGeometry();
+    auto rec = QApplication::desktop()->availableGeometry();
 #endif
-    this->setMaximumSize(rec.width() - 100, rec.height() - 100);
-    this->setMinimumSize(700, 600);
+    this->setMinimumSize(qMin(700, rec.width()), qMin(700, rec.height()));
 
     connect(&SettingsCache::instance(), SIGNAL(langChanged()), this, SLOT(updateLanguage()));
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3951

## Short roundup of the initial problem
Settings dialog looks weird and takes up too much space.

## What will change with this Pull Request?
- Add stretch elements to the settings dialog layout to fix layout
- Have reasonable min/max values considering low res screens down to 1024x768 and 1280x720
This needs a test on Mac as they render everything a bit bigger. Maybe @JineteDV can as he had the initial issue back then on small resolution?
- Have tooltips on the icon only buttons

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

|Before|After|
|:--:|:--:|
| ![g_old](https://user-images.githubusercontent.com/9874850/133612976-5224adc1-7333-43a5-9c1e-a1dcfd6f71c9.png) | ![g_new](https://user-images.githubusercontent.com/9874850/133613430-7635e4f2-82bb-4fb9-b047-45a80d7a2982.png) |
| ![set1-1](https://user-images.githubusercontent.com/9874850/118379958-d40e3480-b5de-11eb-9c3a-54ec1df20524.png) | ![set1-2](https://user-images.githubusercontent.com/9874850/118416682-30da1f80-b6b1-11eb-821f-0ab4b0f6ffc3.png) |
| ![set2-1](https://user-images.githubusercontent.com/9874850/118379818-cc9a5b80-b5dd-11eb-946e-a5ef8ea18950.png) | ![set2-2](https://user-images.githubusercontent.com/9874850/118416683-3172b600-b6b1-11eb-854b-42a2baf36b9d.png) |
| ![cs_old](https://user-images.githubusercontent.com/9874850/133612257-9c16c68a-7bf2-4c44-a9eb-83be9d2998de.png) | ![cs_new](https://user-images.githubusercontent.com/9874850/133613608-f2019367-38cc-4fe9-932c-7e6e2f817140.png) |
| ![set3-1](https://user-images.githubusercontent.com/9874850/118379965-dff9f680-b5de-11eb-80b6-c722496d1ac2.png) | ![set3-2](https://user-images.githubusercontent.com/9874850/118418203-b791fb00-b6b7-11eb-9899-3703006934bd.png) |
| ![set4-1](https://user-images.githubusercontent.com/9874850/118379972-ec7e4f00-b5de-11eb-8826-d1bf02c61db8.png) | ![set4-2](https://user-images.githubusercontent.com/9874850/118416767-8adae500-b6b1-11eb-88ad-d5586751f9e3.png) |
| ![s_old](https://user-images.githubusercontent.com/9874850/133613796-300e29f7-a8df-460d-afe3-dc9bdbf5a644.png) | ![s_new](https://user-images.githubusercontent.com/9874850/133613775-2ff63d0c-0b8d-43bc-a44e-1c6febf2bd4f.png) |
