### PR TITLE
update filter widget to allow 0 player games

### DIFF
--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -86,14 +86,14 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
 
     auto *maxPlayersFilterMinLabel = new QLabel(tr("at &least:"));
     maxPlayersFilterMinSpinBox = new QSpinBox;
-    maxPlayersFilterMinSpinBox->setMinimum(1);
+    maxPlayersFilterMinSpinBox->setMinimum(0);
     maxPlayersFilterMinSpinBox->setMaximum(99);
     maxPlayersFilterMinSpinBox->setValue(gamesProxyModel->getMaxPlayersFilterMin());
     maxPlayersFilterMinLabel->setBuddy(maxPlayersFilterMinSpinBox);
 
     auto *maxPlayersFilterMaxLabel = new QLabel(tr("at &most:"));
     maxPlayersFilterMaxSpinBox = new QSpinBox;
-    maxPlayersFilterMaxSpinBox->setMinimum(1);
+    maxPlayersFilterMaxSpinBox->setMinimum(0);
     maxPlayersFilterMaxSpinBox->setMaximum(99);
     maxPlayersFilterMaxSpinBox->setValue(gamesProxyModel->getMaxPlayersFilterMax());
     maxPlayersFilterMaxLabel->setBuddy(maxPlayersFilterMaxSpinBox);


### PR DESCRIPTION
## Short roundup of the initial problem
when spectator game creation was added it set the default minimum player count to 0 instead of 1, yet the widget itself was unchanged.

this however leaves the problem for users that have set their filter settings already, because of our behavior where we always write every setting to file even if they are unchanged from defaults, anyone that has ever touched the ok button on the filter dialog will not get to see spectator created games unless they change the filter settings again.

## What will change with this Pull Request?
- fix filter widget