### PR TITLE
add option to delete a user's messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ mysql.cnf
 *.aps
 cmake-build-debug/
 preferences
+compile_commands.json
+.vs/

--- a/cockatrice/src/chatview/chatview.h
+++ b/cockatrice/src/chatview/chatview.h
@@ -18,6 +18,17 @@ class QMouseEvent;
 class UserContextMenu;
 class TabGame;
 
+class UserMessagePosition
+{
+public:
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
+    UserMessagePosition() = default; // older qt versions require a default constructor to use in containers
+#endif
+    UserMessagePosition(QTextCursor &cursor);
+    int relativePosition;
+    QTextBlock block;
+};
+
 class ChatView : public QTextBrowser
 {
     Q_OBJECT
@@ -36,7 +47,7 @@ private:
     const UserlistProxy *const userlistProxy;
     UserContextMenu *userContextMenu;
     QString lastSender;
-    QString userName;
+    QString ownUserName;
     QString mention;
     QTextCharFormat mentionFormat;
     QTextCharFormat highlightFormat;
@@ -48,16 +59,18 @@ private:
     HoveredItemType hoveredItemType;
     QString hoveredContent;
     QAction *messageClicked;
+    QMap<QString, QVector<UserMessagePosition>> userMessagePositions;
+
     QTextFragment getFragmentUnderMouse(const QPoint &pos) const;
     QTextCursor prepareBlock(bool same = false);
     void appendCardTag(QTextCursor &cursor, const QString &cardName);
     void appendUrlTag(QTextCursor &cursor, QString url);
     QColor getCustomMentionColor();
     QColor getCustomHighlightColor();
-    void showSystemPopup(QString &sender);
+    void showSystemPopup(const QString &userName);
     bool isModeratorSendingGlobal(QFlags<ServerInfo_User::UserLevelFlag> userLevelFlag, QString message);
     void checkTag(QTextCursor &cursor, QString &message);
-    void checkMention(QTextCursor &cursor, QString &message, QString &sender, UserLevelFlags userLevel);
+    void checkMention(QTextCursor &cursor, QString &message, const QString &userName, UserLevelFlags userLevel);
     void checkWord(QTextCursor &cursor, QString &message);
     QString extractNextWord(QString &message, QString &rest);
 
@@ -82,11 +95,12 @@ public:
                                          QString optionalFontColor = QString());
     void appendMessage(QString message,
                        RoomMessageTypeFlags messageType = {},
-                       QString sender = QString(),
+                       const QString &userName = QString(),
                        UserLevelFlags userLevel = UserLevelFlags(),
                        QString UserPrivLevel = "NONE",
                        bool playerBold = false);
     void clearChat();
+    void redactMessages(const QString &userName, int amount);
 
 protected:
     void enterEvent(QEvent *event);
@@ -101,7 +115,7 @@ signals:
     void deleteCardInfoPopup(QString cardName);
     void addMentionTag(QString mentionTag);
     void messageClickedSignal();
-    void showMentionPopup(QString &sender);
+    void showMentionPopup(const QString &userName);
 };
 
 #endif

--- a/cockatrice/src/tab_room.cpp
+++ b/cockatrice/src/tab_room.cpp
@@ -9,6 +9,7 @@
 #include "pb/event_join_room.pb.h"
 #include "pb/event_leave_room.pb.h"
 #include "pb/event_list_games.pb.h"
+#include "pb/event_remove_messages.pb.h"
 #include "pb/event_room_say.pb.h"
 #include "pb/room_commands.pb.h"
 #include "pb/serverinfo_room.pb.h"
@@ -49,7 +50,7 @@ TabRoom::TabRoom(TabSupervisor *_tabSupervisor,
     connect(userList, SIGNAL(openMessageDialog(const QString &, bool)), this,
             SIGNAL(openMessageDialog(const QString &, bool)));
 
-    chatView = new ChatView(tabSupervisor, tabSupervisor, 0, true);
+    chatView = new ChatView(tabSupervisor, tabSupervisor, nullptr, true, this);
     connect(chatView, SIGNAL(showMentionPopup(QString &)), this, SLOT(actShowMentionPopup(QString &)));
     connect(chatView, SIGNAL(messageClickedSignal()), this, SLOT(focusTab()));
     connect(chatView, SIGNAL(openMessageDialog(QString, bool)), this, SIGNAL(openMessageDialog(QString, bool)));
@@ -310,6 +311,13 @@ void TabRoom::processRoomSayEvent(const Event_RoomSay &event)
 
     chatView->appendMessage(message, event.message_type(), senderName, userLevel, userPrivLevel, true);
     emit userEvent(false);
+}
+
+void TabRoom::processRemoveMessagesEvent(const Event_RemoveMessages &event)
+{
+    QString userName = QString::fromStdString(event.name());
+    int amount = event.amount();
+    chatView->redactMessages(userName, amount);
 }
 
 void TabRoom::refreshShortcuts()

--- a/cockatrice/src/tab_room.cpp
+++ b/cockatrice/src/tab_room.cpp
@@ -253,6 +253,9 @@ void TabRoom::processRoomEvent(const RoomEvent &event)
         case RoomEvent::ROOM_SAY:
             processRoomSayEvent(event.GetExtension(Event_RoomSay::ext));
             break;
+        case RoomEvent::REMOVE_MESSAGES:
+            processRemoveMessagesEvent(event.GetExtension(Event_RemoveMessages::ext));
+            break;
         default:;
     }
 }

--- a/cockatrice/src/tab_room.h
+++ b/cockatrice/src/tab_room.h
@@ -30,6 +30,7 @@ class Event_ListGames;
 class Event_JoinRoom;
 class Event_LeaveRoom;
 class Event_RoomSay;
+class Event_RemoveMessages;
 class GameSelector;
 class Response;
 class PendingCommand;
@@ -82,6 +83,7 @@ private slots:
     void processJoinRoomEvent(const Event_JoinRoom &event);
     void processLeaveRoomEvent(const Event_LeaveRoom &event);
     void processRoomSayEvent(const Event_RoomSay &event);
+    void processRemoveMessagesEvent(const Event_RemoveMessages &event);
     void refreshShortcuts();
 
 public:

--- a/cockatrice/src/user_context_menu.h
+++ b/cockatrice/src/user_context_menu.h
@@ -5,14 +5,16 @@
 
 #include <QObject>
 
-class QAction;
-class TabSupervisor;
-class TabGame;
-class QPoint;
-class CommandContainer;
-class Response;
 class AbstractClient;
+class ChatView;
+class CommandContainer;
+class QAction;
+class QMenu;
+class QPoint;
+class Response;
 class ServerInfo_User;
+class TabGame;
+class TabSupervisor;
 
 class UserContextMenu : public QObject
 {
@@ -54,12 +56,14 @@ public:
                          UserLevelFlags userLevel,
                          bool online = true,
                          int playerId = -1);
+    void showContextMenu(const QPoint &pos, const QString &userName, UserLevelFlags userLevel, ChatView *chatView);
     void showContextMenu(const QPoint &pos,
                          const QString &userName,
                          UserLevelFlags userLevel,
                          bool online,
                          int playerId,
-                         const QString &deckHash);
+                         const QString &deckHash,
+                         ChatView *chatView = nullptr);
 };
 
 #endif

--- a/cockatrice/src/userlist.cpp
+++ b/cockatrice/src/userlist.cpp
@@ -97,6 +97,8 @@ BanDialog::BanDialog(const ServerInfo_User &info, QWidget *parent) : QDialog(par
         new QLabel(tr("Please enter the reason for the ban that will be visible to the banned person."));
     visibleReasonEdit = new QPlainTextEdit;
 
+    deleteMessages = new QCheckBox(tr("Redact all messages from this user in all rooms"));
+
     QPushButton *okButton = new QPushButton(tr("&OK"));
     okButton->setAutoDefault(true);
     connect(okButton, SIGNAL(clicked()), this, SLOT(okClicked()));
@@ -115,6 +117,7 @@ BanDialog::BanDialog(const ServerInfo_User &info, QWidget *parent) : QDialog(par
     vbox->addWidget(reasonEdit);
     vbox->addWidget(visibleReasonLabel);
     vbox->addWidget(visibleReasonEdit);
+    vbox->addWidget(deleteMessages);
     vbox->addLayout(buttonLayout);
 
     setLayout(vbox);
@@ -129,6 +132,8 @@ WarningDialog::WarningDialog(const QString userName, const QString clientID, QWi
     warnClientID = new QLineEdit(clientID);
     warningOption = new QComboBox();
     warningOption->addItem("");
+
+    deleteMessages = new QCheckBox(tr("Redact all messages from this user in all rooms"));
 
     QPushButton *okButton = new QPushButton(tr("&OK"));
     okButton->setAutoDefault(true);
@@ -145,6 +150,7 @@ WarningDialog::WarningDialog(const QString userName, const QString clientID, QWi
     vbox->addWidget(descriptionLabel);
     vbox->addWidget(nameWarning);
     vbox->addWidget(warningOption);
+    vbox->addWidget(deleteMessages);
     vbox->addLayout(buttonLayout);
     setLayout(vbox);
     setWindowTitle(tr("Warn user for misconduct"));
@@ -180,6 +186,11 @@ QString WarningDialog::getWarnID() const
 QString WarningDialog::getReason() const
 {
     return warningOption->currentText().simplified();
+}
+
+int WarningDialog::getDeleteMessages() const
+{
+    return deleteMessages->isChecked() ? -1 : 0;
 }
 
 void WarningDialog::addWarningOption(const QString warning)
@@ -260,6 +271,11 @@ QString BanDialog::getReason() const
 QString BanDialog::getVisibleReason() const
 {
     return visibleReasonEdit->toPlainText();
+}
+
+int BanDialog::getDeleteMessages() const
+{
+    return deleteMessages->isChecked() ? -1 : 0;
 }
 
 UserListItemDelegate::UserListItemDelegate(QObject *const parent) : QStyledItemDelegate(parent)

--- a/cockatrice/src/userlist.h
+++ b/cockatrice/src/userlist.h
@@ -28,7 +28,7 @@ class BanDialog : public QDialog
     Q_OBJECT
 private:
     QLabel *daysLabel, *hoursLabel, *minutesLabel;
-    QCheckBox *nameBanCheckBox, *ipBanCheckBox, *idBanCheckBox;
+    QCheckBox *nameBanCheckBox, *ipBanCheckBox, *idBanCheckBox, *deleteMessages;
     QLineEdit *nameBanEdit, *ipBanEdit, *idBanEdit;
     QSpinBox *daysEdit, *hoursEdit, *minutesEdit;
     QRadioButton *permanentRadio, *temporaryRadio;
@@ -45,6 +45,7 @@ public:
     int getMinutes() const;
     QString getReason() const;
     QString getVisibleReason() const;
+    int getDeleteMessages() const;
 };
 
 class WarningDialog : public QDialog
@@ -55,6 +56,7 @@ private:
     QLineEdit *nameWarning;
     QComboBox *warningOption;
     QLineEdit *warnClientID;
+    QCheckBox *deleteMessages;
 private slots:
     void okClicked();
 
@@ -63,6 +65,7 @@ public:
     QString getName() const;
     QString getWarnID() const;
     QString getReason() const;
+    int getDeleteMessages() const;
     void addWarningOption(const QString warning);
 };
 

--- a/common/pb/CMakeLists.txt
+++ b/common/pb/CMakeLists.txt
@@ -91,6 +91,7 @@ SET(PROTO_FILES
     event_reverse_turn.proto
     event_roll_die.proto
     event_room_say.proto
+    event_remove_messages.proto
     event_server_complete_list.proto
     event_server_identification.proto
     event_server_message.proto

--- a/common/pb/event_remove_messages.proto
+++ b/common/pb/event_remove_messages.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+import "room_event.proto";
+
+message Event_RemoveMessages {
+    extend RoomEvent {
+        optional Event_RemoveMessages ext = 1004;
+    }
+    optional string name = 1;
+    optional uint32 amount = 2;
+}

--- a/common/pb/moderator_commands.proto
+++ b/common/pb/moderator_commands.proto
@@ -21,6 +21,7 @@ message Command_BanFromServer {
     optional string reason = 4;
     optional string visible_reason = 5;
     optional string clientid = 6;
+    optional uint32 remove_messages = 7;
 }
 
 message Command_GetBanHistory {
@@ -38,6 +39,7 @@ message Command_WarnUser {
     optional string user_name = 1;
     optional string reason = 2;
     optional string clientid = 3;
+    optional uint32 remove_messages = 4;
 }
 
 message Command_GetWarnHistory {

--- a/common/pb/room_event.proto
+++ b/common/pb/room_event.proto
@@ -5,6 +5,7 @@ message RoomEvent {
         JOIN_ROOM = 1001;
         ROOM_SAY = 1002;
         LIST_GAMES = 1003;
+        REMOVE_MESSAGES = 1004;
     }
     optional sint32 room_id = 1;
     extensions 100 to max;

--- a/common/server.cpp
+++ b/common/server.cpp
@@ -389,6 +389,19 @@ void Server::externalRoomSay(int roomId, const QString &userName, const QString 
                                        room->getId(), room->getName());
 }
 
+void Server::externalRoomRemoveMessages(int roomId, const QString &userName, int amount)
+{
+    // This function is always called from the main thread via signal/slot.
+    QReadLocker locker(&roomsLock);
+
+    Server_Room *room = rooms.value(roomId);
+    if (room == nullptr) {
+        qDebug() << "externalRoomRemoveMessages: room id=" << roomId << "not found";
+        return;
+    }
+    room->removeSaidMessages(userName, amount);
+}
+
 void Server::externalRoomGameListChanged(int roomId, const ServerInfo_Game &gameInfo)
 {
     // This function is always called from the main thread via signal/slot.

--- a/common/server.h
+++ b/common/server.h
@@ -223,6 +223,7 @@ protected slots:
     void externalRoomUserJoined(int roomId, const ServerInfo_User &userInfo);
     void externalRoomUserLeft(int roomId, const QString &userName);
     void externalRoomSay(int roomId, const QString &userName, const QString &message);
+    void externalRoomRemoveMessages(int roomId, const QString &userName, int amount);
     void externalRoomGameListChanged(int roomId, const ServerInfo_Game &gameInfo);
     void
     externalJoinGameCommandReceived(const Command_JoinGame &cmd, int cmdId, int roomId, int serverId, qint64 sessionId);

--- a/common/server_room.h
+++ b/common/server_room.h
@@ -132,6 +132,7 @@ public:
                                                   Server_AbstractUserInterface *userInterface);
 
     void say(const QString &userName, const QString &s, bool sendToIsl = true);
+    void removeSaidMessages(const QString &userName, int amount, bool sendToIsl = true);
 
     void addGame(Server_Game *game);
     void removeGame(Server_Game *game);

--- a/servatrice/src/isl_interface.cpp
+++ b/servatrice/src/isl_interface.cpp
@@ -6,6 +6,7 @@
 #include "pb/event_join_room.pb.h"
 #include "pb/event_leave_room.pb.h"
 #include "pb/event_list_games.pb.h"
+#include "pb/event_remove_messages.pb.h"
 #include "pb/event_room_say.pb.h"
 #include "pb/event_server_complete_list.pb.h"
 #include "pb/event_user_joined.pb.h"
@@ -348,6 +349,11 @@ void IslInterface::roomEvent_ListGames(int roomId, const Event_ListGames &event)
     }
 }
 
+void IslInterface::roomEvent_RemoveMessages(int roomId, const Event_RemoveMessages &event)
+{
+    emit externalRoomRemoveMessages(roomId, QString::fromStdString(event.name()), event.amount());
+}
+
 void IslInterface::roomCommand_JoinGame(const Command_JoinGame &cmd, int cmdId, int roomId, qint64 sessionId)
 {
     emit joinGameCommandReceived(cmd, cmdId, roomId, serverId, sessionId);
@@ -408,6 +414,9 @@ void IslInterface::processRoomEvent(const RoomEvent &event)
             break;
         case RoomEvent::LIST_GAMES:
             roomEvent_ListGames(event.room_id(), event.GetExtension(Event_ListGames::ext));
+            break;
+        case RoomEvent::REMOVE_MESSAGES:
+            roomEvent_RemoveMessages(event.room_id(), event.GetExtension(Event_RemoveMessages::ext));
             break;
         default:;
     }

--- a/servatrice/src/isl_interface.h
+++ b/servatrice/src/isl_interface.h
@@ -22,6 +22,7 @@ class Event_JoinRoom;
 class Event_LeaveRoom;
 class Event_RoomSay;
 class Event_ListGames;
+class Event_RemoveMessages;
 class Command_JoinGame;
 
 class IslInterface : public QObject
@@ -40,6 +41,7 @@ signals:
     void externalRoomUserLeft(int roomId, QString userName);
     void externalRoomSay(int roomId, QString userName, QString message);
     void externalRoomGameListChanged(int roomId, ServerInfo_Game gameInfo);
+    void externalRoomRemoveMessages(int roomId, QString userName, int amount);
     void joinGameCommandReceived(const Command_JoinGame &cmd, int cmdId, int roomId, int serverId, qint64 sessionId);
     void gameCommandContainerReceived(const CommandContainer &cont, int playerId, int serverId, qint64 sessionId);
     void responseReceived(const Response &resp, qint64 sessionId);
@@ -68,6 +70,7 @@ private:
     void roomEvent_UserLeft(int roomId, const Event_LeaveRoom &event);
     void roomEvent_Say(int roomId, const Event_RoomSay &event);
     void roomEvent_ListGames(int roomId, const Event_ListGames &event);
+    void roomEvent_RemoveMessages(int roomId, const Event_RemoveMessages &event);
 
     void roomCommand_JoinGame(const Command_JoinGame &cmd, int cmdId, int roomId, qint64 sessionId);
 

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -749,6 +749,8 @@ void Servatrice::addIslInterface(int serverId, IslInterface *interface)
     connect(interface, SIGNAL(externalRoomUserLeft(int, QString)), this, SLOT(externalRoomUserLeft(int, QString)));
     connect(interface, SIGNAL(externalRoomSay(int, QString, QString)), this,
             SLOT(externalRoomSay(int, QString, QString)));
+    connect(interface, SIGNAL(externalRoomRemoveMessages(int, QString, int)), this,
+            SLOT(externalRoomRemoveMessages(int, QString, int)));
     connect(interface, SIGNAL(externalRoomGameListChanged(int, ServerInfo_Game)), this,
             SLOT(externalRoomGameListChanged(int, ServerInfo_Game)));
     connect(interface, SIGNAL(joinGameCommandReceived(Command_JoinGame, int, int, int, qint64)), this,

--- a/servatrice/src/serversocketinterface.h
+++ b/servatrice/src/serversocketinterface.h
@@ -126,6 +126,7 @@ private:
 
     bool isPasswordLongEnough(const int passwordLength);
     static QString parseEmailAddress(const std::string &stdEmailAddress);
+    void removeSaidMessages(const QString &userName, int amount);
 
 public:
     AbstractServerSocketInterface(Servatrice *_server,


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3917

## Short roundup of the initial problem
users say mean things sometimes and we'd like to forget that

## What will change with this Pull Request?
- add options to redact messages when warning or banning a user
- add event to clients that redacts said messages when requested
