### PR TITLE
add gtest from arch repos so it doesn't have to download it

### DIFF
--- a/.ci/ArchLinux/Dockerfile
+++ b/.ci/ArchLinux/Dockerfile
@@ -5,6 +5,7 @@ RUN pacman --sync --refresh --sysupgrade --needed --noconfirm \
         ccache \
         cmake \
         git \
+        gtest \
         mariadb-libs \
         protobuf \
         qt5-base \


### PR DESCRIPTION

## Short roundup of the initial problem
arch builds are failing, even though they are set to optional they will still show a red cross when they fail which is confusing

but, it's easier to try to just fix the build?

## What will change with this Pull Request?
- instead of downloading gtest, install it from repos which hopefully isn't broken
