### PR TITLE
add reset paths button to settings

### DIFF
--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -44,6 +44,7 @@ private slots:
     void cardDatabasePathButtonClicked();
     void customCardDatabaseButtonClicked();
     void tokenDatabasePathButtonClicked();
+    void resetAllPathsClicked();
     void languageBoxChanged(int index);
 
 private:
@@ -55,6 +56,8 @@ private:
     QLineEdit *cardDatabasePathEdit;
     QLineEdit *customCardDatabasePathEdit;
     QLineEdit *tokenDatabasePathEdit;
+    QPushButton *resetAllPathsButton;
+    QLabel *allPathsResetLabel;
     QSpinBox pixmapCacheEdit;
     QGroupBox *personalGroupBox;
     QGroupBox *pathsGroupBox;

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -129,6 +129,7 @@ private:
     void translateLegacySettings();
     QString getSafeConfigPath(QString configEntry, QString defaultPath) const;
     QString getSafeConfigFilePath(QString configEntry, QString defaultPath) const;
+    void loadPaths();
     bool rememberGameSettings;
     QList<ReleaseChannel *> releaseChannels;
     bool isPortableBuild;
@@ -473,6 +474,8 @@ public:
     }
 
     static SettingsCache &instance();
+    void resetPaths();
+
 public slots:
     void setDownloadSpoilerStatus(bool _spoilerStatus);
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes https://github.com/Cockatrice/Cockatrice/issues/1223

## Short roundup of the initial problem
there is no option to restore the default settings in the client, short of deleting the settings directory

## What will change with this Pull Request?
- allow resetting paths and reloading database when needed
- add a button to the settings
- add a label to the settings that tells you it has been reset

 
## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![image](https://user-images.githubusercontent.com/36401181/122980875-787f5580-d399-11eb-80ef-41ea1bf5b83a.png)
