### PR TITLE
apply chat flood prevention in games next to rooms

### DIFF
--- a/common/server_abstractuserinterface.h
+++ b/common/server_abstractuserinterface.h
@@ -38,6 +38,7 @@ public:
     }
 
     virtual int getLastCommandTime() const = 0;
+    virtual bool addSaidMessageSize(int size) = 0;
 
     void playerRemovedFromGame(Server_Game *game);
     void playerAddedToGame(int gameId, int roomId, int playerId);

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -945,6 +945,9 @@ Server_Player::cmdGameSay(const Command_GameSay &cmd, ResponseContainer & /*rc*/
         }
     }
 
+    if (!userInterface->addSaidMessageSize(cmd.message().size())) {
+        return Response::RespChatFlood;
+    }
     Event_GameSay event;
     event.set_message(cmd.message());
     ges.enqueueGameEvent(event, playerId);

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -555,10 +555,15 @@ Response::ResponseCode Server_ProtocolHandler::cmdMessage(const Command_Message 
 
     QString receiver = QString::fromStdString(cmd.user_name());
     Server_AbstractUserInterface *userInterface = server->findUser(receiver);
-    if (!userInterface)
+    if (!userInterface) {
         return Response::RespNameNotFound;
-    if (databaseInterface->isInIgnoreList(receiver, QString::fromStdString(userInfo->name())))
+    }
+    if (databaseInterface->isInIgnoreList(receiver, QString::fromStdString(userInfo->name()))) {
         return Response::RespInIgnoreList;
+    }
+    if (!addSaidMessageSize(cmd.message().size())) {
+        return Response::RespChatFlood;
+    }
 
     Event_UserMessage event;
     event.set_sender_name(userInfo->name());

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -719,32 +719,41 @@ Server_ProtocolHandler::cmdLeaveRoom(const Command_LeaveRoom & /*cmd*/, Server_R
     return Response::RespOk;
 }
 
+bool Server_ProtocolHandler::addSaidMessageSize(int size)
+{
+    if (server->getMessageCountingInterval() <= 0) {
+        return true;
+    }
+
+    int totalSize = 0, totalCount = 0;
+    if (messageSizeOverTime.isEmpty()) {
+        messageSizeOverTime.prepend(0);
+    }
+
+    messageSizeOverTime[0] += size;
+    for (int messageSize : messageSizeOverTime) {
+        totalSize += messageSize;
+    }
+
+    if (messageCountOverTime.isEmpty()) {
+        messageCountOverTime.prepend(0);
+    }
+
+    messageCountOverTime[0] += 1;
+    for (int messageCount : messageCountOverTime) {
+        totalCount += messageCount;
+    }
+
+    return totalSize <= server->getMaxMessageSizePerInterval() && totalCount <= server->getMaxMessageCountPerInterval();
+}
+
 Response::ResponseCode
 Server_ProtocolHandler::cmdRoomSay(const Command_RoomSay &cmd, Server_Room *room, ResponseContainer & /*rc*/)
 {
     QString msg = QString::fromStdString(cmd.message());
 
-    if (server->getMessageCountingInterval() > 0) {
-        int totalSize = 0, totalCount = 0;
-        if (messageSizeOverTime.isEmpty())
-            messageSizeOverTime.prepend(0);
-        messageSizeOverTime[0] += msg.size();
-        for (int i = 0; i < messageSizeOverTime.size(); ++i)
-            totalSize += messageSizeOverTime[i];
-
-        if (messageCountOverTime.isEmpty())
-            messageCountOverTime.prepend(0);
-        ++messageCountOverTime[0];
-        for (int i = 0; i < messageCountOverTime.size(); ++i) {
-            totalCount += messageCountOverTime[i];
-        }
-
-        int maxMessageSizePerInterval = server->getMaxMessageSizePerInterval();
-        int maxMessageCountPerInterval = server->getMaxMessageCountPerInterval();
-        if ((maxMessageSizePerInterval > 0 && totalSize > maxMessageSizePerInterval) ||
-            (maxMessageCountPerInterval > 0 && totalCount > maxMessageCountPerInterval)) {
-            return Response::RespChatFlood;
-        }
+    if (!addSaidMessageSize(msg.size())) {
+        return Response::RespChatFlood;
     }
     msg.replace(QChar('\n'), QChar(' '));
 

--- a/common/server_protocolhandler.h
+++ b/common/server_protocolhandler.h
@@ -129,6 +129,7 @@ public:
     {
         return timeRunning - lastDataReceived;
     }
+    bool addSaidMessageSize(int size);
     void processCommandContainer(const CommandContainer &cont);
 
     void sendProtocolItem(const Response &item);

--- a/common/server_remoteuserinterface.h
+++ b/common/server_remoteuserinterface.h
@@ -15,6 +15,10 @@ public:
     {
         return 0;
     }
+    bool addSaidMessageSize(int /*size*/)
+    {
+        return true;
+    }
 
     void sendProtocolItem(const Response &item);
     void sendProtocolItem(const SessionEvent &item);


### PR DESCRIPTION
users can send chat messages without any reasonable character limit to other users and in games, this will instead make it follow the same rules as the main rooms (1000 chars/10 seconds is the default)
this limit is shared over all games and all chat rooms and all their private messages at the same time and isn't very high, but this will stop users from sending too much text quite effectively.
this will sidestep the major performance complications associated with the way we parse for trigger words.