### PR TITLE
Fixed layout on Deck Editor not using last layout sizes

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -599,8 +599,6 @@ TabDeckEditor::TabDeckEditor(TabSupervisor *_tabSupervisor, QWidget *parent)
     createCardInfoDock();
     createFiltersDock();
 
-    restartLayout();
-
     this->installEventFilter(this);
 
     retranslateUi();


### PR DESCRIPTION
It was reseting layout on ctor.

## Short roundup of the initial problem
When resizing card info, deck and filters on Deck Editor the application wasn't keeping the layout on app restart. 

## What will change with this Pull Request?
- The app will keep layout of Deck Editor widgets on restart. 


