### PR TITLE
don't reset pt if there is nothing to reset

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2984,7 +2984,7 @@ void Player::actResetPT()
         }
     }
 
-    if (!commandList.empty()){
+    if (!commandList.empty()) {
         game->sendGameCommand(prepareGameCommand(commandList), playerid);
     }
 }


### PR DESCRIPTION
when the client resets the pt of a card it intentionally does not
include cards that already have the correct pt, this can lead to the
client sending an empty command to the server, which will be rejected