### PR TITLE
Support password reset workflow on Webatrice

### DIFF
--- a/webclient/src/api/AuthenticationService.tsx
+++ b/webclient/src/api/AuthenticationService.tsx
@@ -15,12 +15,24 @@ export default class AuthenticationService {
     SessionCommands.connect(options, WebSocketConnectReason.ACTIVATE_ACCOUNT);
   }
 
+  static resetPasswordRequest(options: WebSocketOptions): void {
+    SessionCommands.connect(options, WebSocketConnectReason.PASSWORD_RESET_REQUEST);
+  }
+
+  static resetPasswordChallenge(options: WebSocketOptions): void {
+    SessionCommands.connect(options, WebSocketConnectReason.PASSWORD_RESET_CHALLENGE);
+  }
+
+  static resetPassword(options: WebSocketOptions): void {
+    SessionCommands.connect(options, WebSocketConnectReason.PASSWORD_RESET);
+  }
+
   static disconnect(): void {
     SessionCommands.disconnect();
   }
 
   static isConnected(state: number): boolean {
-    return state === StatusEnum.LOGGEDIN;
+    return state === StatusEnum.LOGGED_IN;
   }
 
   static isModerator(user: User): boolean {

--- a/webclient/src/forms/LoginForm/LoginForm.tsx
+++ b/webclient/src/forms/LoginForm/LoginForm.tsx
@@ -15,7 +15,7 @@ const LoginForm = (props) => {
   const { dispatch, handleSubmit } = props;
 
   const forgotPassword = () => {
-    console.log('LoginForm.forgotPassword->openForgotPasswordDialog');
+    console.log("Show recover password dialog, then AuthService.forgotPasswordRequest");
   };
 
   const onHostChange = ({ host, port }) => {

--- a/webclient/src/store/server/server.interfaces.ts
+++ b/webclient/src/store/server/server.interfaces.ts
@@ -18,6 +18,20 @@ export interface ServerRegisterParams {
   realName: string;
 }
 
+export interface ForgotPasswordParams {
+  user: string;
+  clientid: string;
+}
+
+export interface ForgotPasswordChallengeParams extends ForgotPasswordParams {
+  email: string;
+}
+
+export interface ForgotPasswordResetParams extends ForgotPasswordParams {
+  token: string;
+  newPassword: string;
+}
+
 export interface AccountActivationParams extends ServerRegisterParams {
   activationCode: string;
   clientid: string;

--- a/webclient/src/types/server.tsx
+++ b/webclient/src/types/server.tsx
@@ -7,28 +7,9 @@ export enum StatusEnum {
   DISCONNECTED,
   CONNECTING,
   CONNECTED,
-  LOGGINGIN,
-  LOGGEDIN,
-  REGISTERING,
-  REGISTERED,
-  ACTIVATING_ACCOUNT,
-  ACCOUNT_ACTIVATED,
-  RECOVERING_PASSWORD,
+  LOGGING_IN,
+  LOGGED_IN,
   DISCONNECTING =  99
-}
-
-export enum StatusEnumLabel {
-  "Disconnected",
-  "Connecting" ,
-  "Connected" ,
-  "Loggingin",
-  "Loggedin",
-  "Registering",
-  "Registered",
-  "ActivatingAccount",
-  "AccountActivated",
-  "RecoveringPassword",
-  "Disconnecting" = 99
 }
 
 export class Host {
@@ -82,14 +63,6 @@ export const KnownHosts = {
   [KnownHost.ROOSTER]: { port: 4748, host: 'server.cockatrice.us', },
   [KnownHost.TETRARCH]:  { port: 443, host: 'mtg.tetrarch.co/servatrice'},
 }
-
-export const getStatusEnumLabel = (statusEnum: number) => {
-  if (StatusEnumLabel[statusEnum] !== undefined) {
-    return StatusEnumLabel[statusEnum];
-  }
-
-  return "Unknown";
-};
 
 export interface Log {
   message: string;

--- a/webclient/src/websocket/commands/SessionCommands.spec.ts
+++ b/webclient/src/websocket/commands/SessionCommands.spec.ts
@@ -51,7 +51,6 @@ describe('SessionCommands', () => {
       SessionCommands.connect(options, WebSocketConnectReason.REGISTER);
 
       expect(SessionCommands.updateStatus).toHaveBeenCalled();
-      expect(SessionCommands.updateStatus).toHaveBeenCalledWith(StatusEnum.REGISTERING, expect.any(String));
 
       expect(webClient.connect).toHaveBeenCalled();
       expect(webClient.connect).toHaveBeenCalledWith({ ...options, reason: WebSocketConnectReason.REGISTER });
@@ -62,7 +61,6 @@ describe('SessionCommands', () => {
       SessionCommands.connect(options, WebSocketConnectReason.ACTIVATE_ACCOUNT);
 
       expect(SessionCommands.updateStatus).toHaveBeenCalled();
-      expect(SessionCommands.updateStatus).toHaveBeenCalledWith(StatusEnum.ACTIVATING_ACCOUNT, expect.any(String));
 
       expect(webClient.connect).toHaveBeenCalled();
       expect(webClient.connect).toHaveBeenCalledWith({ ...options, reason: WebSocketConnectReason.ACTIVATE_ACCOUNT });
@@ -138,7 +136,7 @@ describe('SessionCommands', () => {
 
         expect(SessionCommands.listUsers).toHaveBeenCalled();
         expect(SessionCommands.listRooms).toHaveBeenCalled();
-        expect(SessionCommands.updateStatus).toHaveBeenCalledWith(StatusEnum.LOGGEDIN, 'Logged in.');
+        expect(SessionCommands.updateStatus).toHaveBeenCalledWith(StatusEnum.LOGGED_IN, 'Logged in.');
       });
 
       it('RespClientUpdateRequired should update status', () => {

--- a/webclient/src/websocket/commands/SessionCommands.ts
+++ b/webclient/src/websocket/commands/SessionCommands.ts
@@ -25,8 +25,8 @@ export class SessionCommands {
         SessionCommands.updateStatus(StatusEnum.CONNECTING, 'Connecting...');
         break;
       default:
-        console.error('Connection Failed', reason);
-        break;
+        SessionCommands.updateStatus(StatusEnum.DISCONNECTED, 'Unknown Connection Attempt: ' + reason);
+        return;
     }
 
     webClient.connect({ ...options, reason });
@@ -206,7 +206,6 @@ export class SessionCommands {
           SessionPersistence.accountActivationFailed();
         }
     });
-
   }
 
   static resetPasswordRequest(): void {

--- a/webclient/src/websocket/events/SessionEvents.spec.ts
+++ b/webclient/src/websocket/events/SessionEvents.spec.ts
@@ -300,7 +300,7 @@ describe('SessionEvents', () => {
       event(data);
 
       expect(SessionPersistence.updateInfo).toHaveBeenCalledWith(data.serverName, data.serverVersion);
-      expect(SessionCommands.updateStatus).toHaveBeenCalledWith(StatusEnum.LOGGINGIN, expect.any(String));
+      expect(SessionCommands.updateStatus).toHaveBeenCalledWith(StatusEnum.LOGGING_IN, expect.any(String));
       expect(SessionCommands.login).toHaveBeenCalled();
     });
 
@@ -312,7 +312,6 @@ describe('SessionEvents', () => {
       event(data);
 
       expect(SessionPersistence.updateInfo).toHaveBeenCalledWith(data.serverName, data.serverVersion);
-      expect(SessionCommands.updateStatus).toHaveBeenCalledWith(StatusEnum.REGISTERING, expect.any(String));
       expect(SessionCommands.register).toHaveBeenCalled();
     });
 
@@ -324,7 +323,6 @@ describe('SessionEvents', () => {
       event(data);
 
       expect(SessionPersistence.updateInfo).toHaveBeenCalledWith(data.serverName, data.serverVersion);
-      expect(SessionCommands.updateStatus).toHaveBeenCalledWith(StatusEnum.ACTIVATING_ACCOUNT, expect.any(String));
       expect(SessionCommands.activateAccount).toHaveBeenCalled();
     });
 

--- a/webclient/src/websocket/events/SessionEvents.ts
+++ b/webclient/src/websocket/events/SessionEvents.ts
@@ -38,7 +38,7 @@ function addToList({ listName, userInfo}: AddToListData) {
 }
 
 function connectionClosed({ reason, reasonStr }: ConnectionClosedData) {
-  let message = '';
+  let message;
 
   // @TODO (5)
   if (reasonStr) {
@@ -116,26 +116,30 @@ function serverIdentification(info: ServerIdentificationData) {
   const { serverName, serverVersion, protocolVersion } = info;
 
   if (protocolVersion !== webClient.protocolVersion) {
-    SessionCommands.disconnect();
     SessionCommands.updateStatus(StatusEnum.DISCONNECTED, `Protocol version mismatch: ${protocolVersion}`);
+    SessionCommands.disconnect();
     return;
   }
 
   switch (webClient.options.reason) {
     case WebSocketConnectReason.LOGIN:
-      SessionCommands.updateStatus(StatusEnum.LOGGINGIN, 'Logging in...');
+      SessionCommands.updateStatus(StatusEnum.LOGGING_IN, 'Logging In...');
       SessionCommands.login();
       break;
     case WebSocketConnectReason.REGISTER:
-      SessionCommands.updateStatus(StatusEnum.REGISTERING, 'Registering...');
       SessionCommands.register();
       break;
     case WebSocketConnectReason.ACTIVATE_ACCOUNT:
-      SessionCommands.updateStatus(StatusEnum.ACTIVATING_ACCOUNT, 'Activating account...');
       SessionCommands.activateAccount();
       break;
-    case WebSocketConnectReason.RECOVER_PASSWORD:
-      console.log('ServerIdentificationData.recoverPassword');
+    case WebSocketConnectReason.PASSWORD_RESET_REQUEST:
+      SessionCommands.resetPasswordRequest();
+      break;
+    case WebSocketConnectReason.PASSWORD_RESET_CHALLENGE:
+      SessionCommands.resetPasswordChallenge();
+      break;
+    case WebSocketConnectReason.PASSWORD_RESET:
+      SessionCommands.resetPassword();
       break;
     default:
       console.error("Undefined type", webClient.options.reason);

--- a/webclient/src/websocket/events/SessionEvents.ts
+++ b/webclient/src/websocket/events/SessionEvents.ts
@@ -142,7 +142,8 @@ function serverIdentification(info: ServerIdentificationData) {
       SessionCommands.resetPassword();
       break;
     default:
-      console.error("Undefined type", webClient.options.reason);
+      SessionCommands.updateStatus(StatusEnum.DISCONNECTED, "Unknown Connection Reason: " + webClient.options.reason);
+      SessionCommands.disconnect();
       break;
   }
 

--- a/webclient/src/websocket/persistence/SessionPersistence.ts
+++ b/webclient/src/websocket/persistence/SessionPersistence.ts
@@ -80,4 +80,21 @@ export class SessionPersistence {
   static accountActivationFailed() {
     console.log("Account activation failed, show an action here");
   }
+
+  static resetPasswordChallenge() {
+    console.log("Open Modal asking for Email address associated with account");
+  }
+
+  static resetPassword() {
+    console.log("Open Modal asking for reset token & new password");
+
+  }
+
+  static resetPasswordSuccess() {
+    console.log("User password successfully changed Alert!");
+  }
+
+  static resetPasswordFailed() {
+    console.log("Open Alert telling user their password request failed for some reason");
+  }
 }

--- a/webclient/src/websocket/services/WebSocketService.ts
+++ b/webclient/src/websocket/services/WebSocketService.ts
@@ -20,7 +20,9 @@ export enum WebSocketConnectReason {
   LOGIN,
   REGISTER,
   ACTIVATE_ACCOUNT,
-  RECOVER_PASSWORD,
+  PASSWORD_RESET_REQUEST,
+  PASSWORD_RESET_CHALLENGE,
+  PASSWORD_RESET
 }
 
 export class WebSocketService {


### PR DESCRIPTION
Also fix issue where a user would be disconnected "randomly" if they had a failed login, then successful one. Refactored a bit on Status Labels since they weren't really necessary and added complexity.
