### PR TITLE
add ubuntu 21.10 to ci

### DIFF
--- a/.ci/UbuntuImpish/Dockerfile
+++ b/.ci/UbuntuImpish/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:groovy
+FROM ubuntu:hirsute
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -17,7 +17,6 @@ RUN apt-get update && \
         libqt5svg5-dev \
         libqt5websockets5-dev \
         protobuf-compiler \
-        qt5-default \
         qtmultimedia5-dev \
         qttools5-dev \
         qttools5-dev-tools \

--- a/.ci/UbuntuImpish/Dockerfile
+++ b/.ci/UbuntuImpish/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
         file \
         g++ \
         git \
+        googletest \
         liblzma-dev \
         libmariadb-dev-compat \
         libprotobuf-dev \

--- a/.ci/UbuntuImpish/Dockerfile
+++ b/.ci/UbuntuImpish/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update && \
         file \
         g++ \
         git \
-        googletest \
         liblzma-dev \
         libmariadb-dev-compat \
         libprotobuf-dev \

--- a/.ci/UbuntuImpish/Dockerfile
+++ b/.ci/UbuntuImpish/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:hirsute
+FROM ubuntu:impish
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -82,10 +82,10 @@ jobs:
       matrix:
         # these names correspond to the files in .ci/$distro
         include:
-          - distro: UbuntuHirsute
+          - distro: UbuntuImpish
             package: DEB
 
-          - distro: UbuntuGroovy
+          - distro: UbuntuHirsute
             package: DEB
             test: skip
 

--- a/cmake/gtest-CMakeLists.txt.in
+++ b/cmake/gtest-CMakeLists.txt.in
@@ -4,7 +4,7 @@ project(gtest-download LANGUAGES NONE)
 
 include(ExternalProject)
 ExternalProject_Add(googletest
-  URL https://github.com/google/googletest/archive/release-1.7.0.zip
+  URL https://github.com/google/googletest/archive/release-1.11.0.zip
   URL_HASH SHA1=f89bc9f55477df2fde082481e2d709bfafdb057b
   SOURCE_DIR "${CMAKE_BINARY_DIR}/gtest-src"
   BINARY_DIR "${CMAKE_BINARY_DIR}/gtest-build"

--- a/cmake/gtest-CMakeLists.txt.in
+++ b/cmake/gtest-CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(gtest-download LANGUAGES NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   URL https://github.com/google/googletest/archive/release-1.11.0.zip
-  URL_HASH SHA1=f89bc9f55477df2fde082481e2d709bfafdb057b
+  URL_HASH SHA1=9ffb7b5923f4a8fcdabf2f42c6540cce299f44c0
   SOURCE_DIR "${CMAKE_BINARY_DIR}/gtest-src"
   BINARY_DIR "${CMAKE_BINARY_DIR}/gtest-build"
   CONFIGURE_COMMAND ""

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ if(NOT GTEST_FOUND)
     # Add the gtest include directory, since gtest
     # doesn't add that dependency to its gtest target
     target_include_directories(gtest INTERFACE
-            "${CMAKE_BINARY_DIR}/gtest-src/include" )
+            "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/gtest-src/include>" )
 
     SET(GTEST_INCLUDE_DIRS "${CMAKE_BINARY_DIR}/gtest-src/include")
     SET(GTEST_BOTH_LIBRARIES gtest)


### PR DESCRIPTION
remove ubuntu 20.10

ubuntu 21.10 Impish Indri has been released at october 14th already, we're a bit late