### PR TITLE
add fedora 35 to ci

### DIFF
--- a/.ci/Fedora35/Dockerfile
+++ b/.ci/Fedora35/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:33
+FROM fedora:35
 
 RUN dnf install -y \
         @development-tools \

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -103,9 +103,8 @@ jobs:
           - distro: DebianBuster
             package: DEB
 
-          - distro: Fedora33
+          - distro: Fedora35
             package: RPM
-            test: skip # Fedora is our slowest build
 
           - distro: Fedora34
             package: RPM


### PR DESCRIPTION
remove fedora 33

fedora 35 will release on november 2nd, it'll be best to already have this building in preparation for its release