### PR TITLE
CI: Xcode update, fix Big Sur build

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -190,7 +190,7 @@ jobs:
           - Debug
           - 10.14_Mojave
           - 10.15_Catalina
-          - 11.0_Big_Sur
+          - 11_Big_Sur
         include:
           - target: Debug # tests only
             os: macos-latest
@@ -201,7 +201,7 @@ jobs:
 
           - target: 10.14_Mojave
             os: macos-10.15 # runs on Catalina
-            xcode: 10.3 # allows compatibility with macos 10.14
+            xcode: 10.3 # allows compatibility with macOS 10.14
             type: Release
             do_tests: 0
             make_package: true
@@ -213,9 +213,9 @@ jobs:
             do_tests: 0
             make_package: true
 
-          - target: 11.0_Big_Sur
-            os: macos-11.0
-            xcode: 12.5
+          - target: 11_Big_Sur
+            os: macos-11
+            xcode: 12.5.1
             type: Release
             do_tests: 0
             make_package: true

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -215,7 +215,7 @@ jobs:
 
           - target: 11_Big_Sur
             os: macos-11
-            xcode: 13.0
+            xcode: 12.5.1
             type: Release
             do_tests: 0
             make_package: true

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -215,7 +215,7 @@ jobs:
 
           - target: 11_Big_Sur
             os: macos-11
-            xcode: 12.5.1
+            xcode: 13.0
             type: Release
             do_tests: 0
             make_package: true


### PR DESCRIPTION
This should fix Big Sur builds.

Xcode 12.5 is discontinued since 2 weeks.