### PR TITLE
Support getting a user's password salt via initial websocket connection

### DIFF
--- a/cockatrice/src/remoteclient.h
+++ b/cockatrice/src/remoteclient.h
@@ -102,7 +102,7 @@ private:
     QString getSrvClientID(const QString &_hostname);
     bool newMissingFeatureFound(const QString &_serversMissingFeatures);
     void clearNewClientFeatures();
-    void connectToHost(const QString &hostname, unsigned int port);
+    void connectToHost(const QString &hostname, unsigned int port, const QString &username = "");
 
 protected slots:
     void sendCommandContainer(const CommandContainer &cont) override;

--- a/common/pb/event_server_identification.proto
+++ b/common/pb/event_server_identification.proto
@@ -8,4 +8,5 @@ message Event_ServerIdentification {
     optional string server_name = 1;
     optional string server_version = 2;
     optional uint32 protocol_version = 3;
+    optional string password_salt = 4;
 }

--- a/common/server_database_interface.h
+++ b/common/server_database_interface.h
@@ -35,6 +35,10 @@ public:
     {
         return false;
     }
+    virtual QString getUserSalt(const QString & /* user */)
+    {
+        return {};
+    }
     virtual QMap<QString, ServerInfo_User> getBuddyList(const QString & /* name */)
     {
         return QMap<QString, ServerInfo_User>();

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -490,6 +490,28 @@ bool Servatrice_DatabaseInterface::userExists(const QString &user)
     return false;
 }
 
+QString Servatrice_DatabaseInterface::getUserSalt(const QString &user)
+{
+    if (server->getAuthenticationMethod() == Servatrice::AuthenticationSql) {
+        checkSql();
+
+        QSqlQuery *query =
+            prepareQuery("SELECT SUBSTRING(password_sha512, 1, 16) FROM {prefix}_users WHERE name = :name");
+
+        query->bindValue(":name", user);
+        if (!execSqlQuery(query)) {
+            return {};
+        }
+
+        if (!query->next()) {
+            return {};
+        }
+
+        return query->value(0).toString();
+    }
+    return {};
+}
+
 int Servatrice_DatabaseInterface::getUserIdInDB(const QString &name)
 {
     if (server->getAuthenticationMethod() == Servatrice::AuthenticationSql) {

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -59,6 +59,7 @@ public:
 
     bool activeUserExists(const QString &user);
     bool userExists(const QString &user);
+    QString getUserSalt(const QString &user);
     int getUserIdInDB(const QString &name);
     QMap<QString, ServerInfo_User> getBuddyList(const QString &name);
     QMap<QString, ServerInfo_User> getIgnoreList(const QString &name);

--- a/servatrice/src/serversocketinterface.h
+++ b/servatrice/src/serversocketinterface.h
@@ -137,7 +137,7 @@ public:
                                   Servatrice_DatabaseInterface *_databaseInterface,
                                   QObject *parent = 0);
     ~AbstractServerSocketInterface(){};
-    bool initSession();
+    bool initSession(const QString &passwordSalt);
 
     virtual QHostAddress getPeerAddress() const = 0;
     virtual QString getAddress() const = 0;
@@ -198,7 +198,7 @@ class WebsocketServerSocketInterface : public AbstractServerSocketInterface
 public:
     WebsocketServerSocketInterface(Servatrice *_server,
                                    Servatrice_DatabaseInterface *_databaseInterface,
-                                   QObject *parent = 0);
+                                   QObject *parent = nullptr);
     ~WebsocketServerSocketInterface();
 
     QHostAddress getPeerAddress() const
@@ -217,6 +217,7 @@ public:
 private:
     QWebSocket *socket;
     QHostAddress address;
+    QString passwordSalt;
 
 protected:
     void writeToSocket(QByteArray &data)


### PR DESCRIPTION
This change will allow clientside password hashing and storage, removing the need to store passwords in plaintext on a local user's machine (Ref #344) 

We still need a new hashed_password field on user login that will allow us to directly compare hashes instead of calculating the hash before comparing. Should be fairly simple, just outside the scope of this PR.