### PR TITLE
Fixed issue #4332 - changed error message for replay folder download

### DIFF
--- a/cockatrice/src/tab_replays.cpp
+++ b/cockatrice/src/tab_replays.cpp
@@ -197,7 +197,7 @@ void TabReplays::actDownload()
 
     if (!curRight) {
         QMessageBox::information(this, tr("Downloading Replays"),
-                                 tr("You cannot download replay folders at this time"));
+                                 tr("Folder download is not yet supported. Please download replays individually."));
         return;
     }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4332

## Short roundup of the initial problem
Error message on user attempting replay folder download was unclear.

## What will change with this Pull Request?
-Error message when user requests replay folder download has been changed to be more clear.

## Screenshots
![image](https://user-images.githubusercontent.com/61558904/139714417-f6e10316-73a7-464e-8034-9256550be8da.png)
