### PR TITLE
use hashed passwords in all commands

### DIFF
--- a/cockatrice/src/abstractclient.cpp
+++ b/cockatrice/src/abstractclient.cpp
@@ -22,7 +22,8 @@
 
 #include <google/protobuf/descriptor.h>
 
-AbstractClient::AbstractClient(QObject *parent) : QObject(parent), nextCmdId(0), status(StatusDisconnected)
+AbstractClient::AbstractClient(QObject *parent)
+    : QObject(parent), nextCmdId(0), status(StatusDisconnected), serverSupportsPasswordHash(false)
 {
     qRegisterMetaType<QVariant>("QVariant");
     qRegisterMetaType<CommandContainer>("CommandContainer");

--- a/cockatrice/src/abstractclient.h
+++ b/cockatrice/src/abstractclient.h
@@ -108,11 +108,11 @@ public:
     void sendCommand(const CommandContainer &cont);
     void sendCommand(PendingCommand *pend);
 
-    bool getServerSupportsPasswordHash()
+    bool getServerSupportsPasswordHash() const
     {
         return serverSupportsPasswordHash;
     }
-    const QString getUserName()
+    const QString &getUserName() const
     {
         return userName;
     }

--- a/cockatrice/src/abstractclient.h
+++ b/cockatrice/src/abstractclient.h
@@ -88,6 +88,7 @@ protected slots:
 protected:
     QMap<int, PendingCommand *> pendingCommands;
     QString userName, password, email, country, realName, token;
+    bool serverSupportsPasswordHash;
     void setStatus(ClientStatus _status);
     int getNewCmdId()
     {
@@ -107,6 +108,10 @@ public:
     void sendCommand(const CommandContainer &cont);
     void sendCommand(PendingCommand *pend);
 
+    bool getServerSupportsPasswordHash()
+    {
+        return serverSupportsPasswordHash;
+    }
     const QString getUserName()
     {
         return userName;

--- a/cockatrice/src/dlg_edit_password.cpp
+++ b/cockatrice/src/dlg_edit_password.cpp
@@ -59,7 +59,11 @@ DlgEditPassword::DlgEditPassword(QWidget *parent) : QDialog(parent)
 
 void DlgEditPassword::actOk()
 {
-    if (newPasswordEdit->text() != newPasswordEdit2->text()) {
+    // TODO this stuff should be using qvalidators
+    if (newPasswordEdit->text().length() < 8) {
+        QMessageBox::critical(this, tr("Error"), tr("Your password is too short."));
+        return;
+    } else if (newPasswordEdit->text() != newPasswordEdit2->text()) {
         QMessageBox::warning(this, tr("Error"), tr("The new passwords don't match."));
         return;
     }

--- a/cockatrice/src/dlg_forgotpasswordreset.cpp
+++ b/cockatrice/src/dlg_forgotpasswordreset.cpp
@@ -123,7 +123,11 @@ void DlgForgotPasswordReset::actOk()
         return;
     }
 
-    if (newpasswordEdit->text() != newpasswordverifyEdit->text()) {
+    // TODO this stuff should be using qvalidators
+    if (newpasswordEdit->text().length() < 8) {
+        QMessageBox::critical(this, tr("Error"), tr("Your password is too short."));
+        return;
+    } else if (newpasswordEdit->text() != newpasswordverifyEdit->text()) {
         QMessageBox::critical(this, tr("Reset Password Error"), tr("The passwords do not match."));
         return;
     }

--- a/cockatrice/src/dlg_register.cpp
+++ b/cockatrice/src/dlg_register.cpp
@@ -356,7 +356,11 @@ DlgRegister::DlgRegister(QWidget *parent) : QDialog(parent)
 
 void DlgRegister::actOk()
 {
-    if (passwordEdit->text() != passwordConfirmationEdit->text()) {
+    // TODO this stuff should be using qvalidators
+    if (passwordEdit->text().length() < 8) {
+        QMessageBox::critical(this, tr("Registration Warning"), tr("Your password is too short."));
+        return;
+    } else if (passwordEdit->text() != passwordConfirmationEdit->text()) {
         QMessageBox::critical(this, tr("Registration Warning"), tr("Your passwords do not match, please try again."));
         return;
     } else if (emailConfirmationEdit->text() != emailEdit->text()) {

--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -132,7 +132,8 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
             auto passwordSalt = PasswordHasher::generateRandomSalt();
             hashedPassword = PasswordHasher::computeHash(password, passwordSalt);
             cmdForgotPasswordReset.set_hashed_new_password(hashedPassword.toStdString());
-        } else {
+        } else if (!password.isEmpty()) {
+            qDebug() << "Warning: using plain text password to reset password";
             cmdForgotPasswordReset.set_new_password(password.toStdString());
         }
         PendingCommand *pend = prepareSessionCommand(cmdForgotPasswordReset);
@@ -161,7 +162,8 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
             auto passwordSalt = PasswordHasher::generateRandomSalt();
             hashedPassword = PasswordHasher::computeHash(password, passwordSalt);
             cmdRegister.set_hashed_password(hashedPassword.toStdString());
-        } else {
+        } else if (!password.isEmpty()) {
+            qDebug() << "Warning: using plain text password to register";
             cmdRegister.set_password(password.toStdString());
         }
         cmdRegister.set_email(email.toStdString());
@@ -231,7 +233,10 @@ void RemoteClient::doLogin()
         // TODO add setting for client to reject unhashed logins
         setStatus(StatusLoggingIn);
         Command_Login cmdLogin = generateCommandLogin();
-        cmdLogin.set_password(password.toStdString());
+        if (!password.isEmpty()) {
+            qDebug() << "Warning: using plain text password to log in";
+            cmdLogin.set_password(password.toStdString());
+        }
 
         PendingCommand *pend = prepareSessionCommand(cmdLogin);
         connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(loginResponse(Response)));

--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -27,7 +27,7 @@ static const unsigned int protocolVersion = 14;
 
 RemoteClient::RemoteClient(QObject *parent)
     : AbstractClient(parent), timeRunning(0), lastDataReceived(0), messageInProgress(false), handshakeStarted(false),
-      usingWebSocket(false), messageLength(0)
+      usingWebSocket(false), messageLength(0), hashedPassword()
 {
 
     clearNewClientFeatures();
@@ -129,8 +129,8 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
         cmdForgotPasswordReset.set_clientid(getSrvClientID(lastHostname).toStdString());
         cmdForgotPasswordReset.set_token(token.toStdString());
         if (!password.isEmpty() && serverSupportsPasswordHash) {
-            const auto passwordSalt = PasswordHasher::generateRandomSalt();
-            const auto hashedPassword = PasswordHasher::computeHash(password, passwordSalt);
+            auto passwordSalt = PasswordHasher::generateRandomSalt();
+            hashedPassword = PasswordHasher::computeHash(password, passwordSalt);
             cmdForgotPasswordReset.set_hashed_new_password(hashedPassword.toStdString());
         } else {
             cmdForgotPasswordReset.set_new_password(password.toStdString());
@@ -158,8 +158,8 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
         Command_Register cmdRegister;
         cmdRegister.set_user_name(userName.toStdString());
         if (!password.isEmpty() && serverSupportsPasswordHash) {
-            const auto passwordSalt = PasswordHasher::generateRandomSalt();
-            const auto hashedPassword = PasswordHasher::computeHash(password, passwordSalt);
+            auto passwordSalt = PasswordHasher::generateRandomSalt();
+            hashedPassword = PasswordHasher::computeHash(password, passwordSalt);
             cmdRegister.set_hashed_password(hashedPassword.toStdString());
         } else {
             cmdRegister.set_password(password.toStdString());
@@ -188,13 +188,7 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
         return;
     }
 
-    if (!password.isEmpty() && serverSupportsPasswordHash) {
-        // TODO store and log in using stored hashed password
-        doRequestPasswordSalt(); // log in using password salt
-    } else {
-        // TODO add setting for client to reject unhashed logins
-        doLogin();
-    }
+    doLogin();
 }
 
 void RemoteClient::doRequestPasswordSalt()
@@ -226,21 +220,30 @@ Command_Login RemoteClient::generateCommandLogin()
 
 void RemoteClient::doLogin()
 {
-    setStatus(StatusLoggingIn);
-    Command_Login cmdLogin = generateCommandLogin();
-    cmdLogin.set_password(password.toStdString());
+    if (!password.isEmpty() && serverSupportsPasswordHash) {
+        // TODO store and log in using stored hashed password
+        if (hashedPassword.isEmpty()) {
+            doRequestPasswordSalt(); // ask salt to create hashedPassword, then log in
+        } else {
+            doHashedLogin(); // log in using hashed password instead
+        }
+    } else {
+        // TODO add setting for client to reject unhashed logins
+        setStatus(StatusLoggingIn);
+        Command_Login cmdLogin = generateCommandLogin();
+        cmdLogin.set_password(password.toStdString());
 
-    PendingCommand *pend = prepareSessionCommand(cmdLogin);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(loginResponse(Response)));
-    sendCommand(pend);
+        PendingCommand *pend = prepareSessionCommand(cmdLogin);
+        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(loginResponse(Response)));
+        sendCommand(pend);
+    }
 }
 
-void RemoteClient::doLogin(const QString &passwordSalt)
+void RemoteClient::doHashedLogin()
 {
     setStatus(StatusLoggingIn);
     Command_Login cmdLogin = generateCommandLogin();
 
-    const auto hashedPassword = PasswordHasher::computeHash(password, passwordSalt);
     cmdLogin.set_hashed_password(hashedPassword.toStdString());
 
     PendingCommand *pend = prepareSessionCommand(cmdLogin);
@@ -257,12 +260,13 @@ void RemoteClient::passwordSaltResponse(const Response &response)
 {
     if (response.response_code() == Response::RespOk) {
         const Response_PasswordSalt &resp = response.GetExtension(Response_PasswordSalt::ext);
-        QString salt = QString::fromStdString(resp.password_salt());
-        if (salt.isEmpty()) { // the server does not recognize the user but allows them to enter unregistered
-            password = "";    // the password will not be used
+        auto passwordSalt = QString::fromStdString(resp.password_salt());
+        if (passwordSalt.isEmpty()) { // the server does not recognize the user but allows them to enter unregistered
+            password = "";            // the password will not be used
             doLogin();
         } else {
-            doLogin(salt);
+            hashedPassword = PasswordHasher::computeHash(password, passwordSalt);
+            doHashedLogin();
         }
     } else if (response.response_code() != Response::RespNotConnected) {
         emit loginError(response.response_code(), {}, 0, {});
@@ -451,6 +455,7 @@ void RemoteClient::doConnectToServer(const QString &hostname,
     password = _password;
     lastHostname = hostname;
     lastPort = port;
+    hashedPassword = "";
 
     connectToHost(hostname, port);
     setStatus(StatusConnecting);
@@ -473,6 +478,7 @@ void RemoteClient::doRegisterToServer(const QString &hostname,
     realName = _realname;
     lastHostname = hostname;
     lastPort = port;
+    hashedPassword = "";
 
     connectToHost(hostname, port);
     setStatus(StatusRegistering);
@@ -661,6 +667,7 @@ void RemoteClient::doSubmitForgotPasswordResetToServer(const QString &hostname,
     lastPort = port;
     token = _token.trimmed();
     password = _newpassword;
+    hashedPassword = "";
 
     connectToHost(lastHostname, lastPort);
     setStatus(StatusSubmitForgotPasswordReset);

--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -267,7 +267,7 @@ void RemoteClient::passwordSaltResponse(const Response &response)
         const Response_PasswordSalt &resp = response.GetExtension(Response_PasswordSalt::ext);
         auto passwordSalt = QString::fromStdString(resp.password_salt());
         if (passwordSalt.isEmpty()) { // the server does not recognize the user but allows them to enter unregistered
-            password = "";            // the password will not be used
+            password.clear();            // the password will not be used
             doLogin();
         } else {
             hashedPassword = PasswordHasher::computeHash(password, passwordSalt);
@@ -460,7 +460,7 @@ void RemoteClient::doConnectToServer(const QString &hostname,
     password = _password;
     lastHostname = hostname;
     lastPort = port;
-    hashedPassword = "";
+    hashedPassword.clear();
 
     connectToHost(hostname, port);
     setStatus(StatusConnecting);
@@ -483,7 +483,7 @@ void RemoteClient::doRegisterToServer(const QString &hostname,
     realName = _realname;
     lastHostname = hostname;
     lastPort = port;
-    hashedPassword = "";
+    hashedPassword.clear();
 
     connectToHost(hostname, port);
     setStatus(StatusRegistering);
@@ -672,7 +672,7 @@ void RemoteClient::doSubmitForgotPasswordResetToServer(const QString &hostname,
     lastPort = port;
     token = _token.trimmed();
     password = _newpassword;
-    hashedPassword = "";
+    hashedPassword.clear();
 
     connectToHost(lastHostname, lastPort);
     setStatus(StatusSubmitForgotPasswordReset);

--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -133,7 +133,7 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
             hashedPassword = PasswordHasher::computeHash(password, passwordSalt);
             cmdForgotPasswordReset.set_hashed_new_password(hashedPassword.toStdString());
         } else if (!password.isEmpty()) {
-            qDebug() << "Warning: using plain text password to reset password";
+            qWarning() << "using plain text password to reset password";
             cmdForgotPasswordReset.set_new_password(password.toStdString());
         }
         PendingCommand *pend = prepareSessionCommand(cmdForgotPasswordReset);
@@ -163,7 +163,7 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
             hashedPassword = PasswordHasher::computeHash(password, passwordSalt);
             cmdRegister.set_hashed_password(hashedPassword.toStdString());
         } else if (!password.isEmpty()) {
-            qDebug() << "Warning: using plain text password to register";
+            qWarning() << "using plain text password to register";
             cmdRegister.set_password(password.toStdString());
         }
         cmdRegister.set_email(email.toStdString());
@@ -234,7 +234,7 @@ void RemoteClient::doLogin()
         setStatus(StatusLoggingIn);
         Command_Login cmdLogin = generateCommandLogin();
         if (!password.isEmpty()) {
-            qDebug() << "Warning: using plain text password to log in";
+            qWarning() << "using plain text password to log in";
             cmdLogin.set_password(password.toStdString());
         }
 
@@ -585,7 +585,7 @@ QString RemoteClient::getSrvClientID(const QString &_hostname)
         QHostAddress hostAddress = hostInfo.addresses().first();
         srvClientID += hostAddress.toString();
     } else {
-        qDebug() << "Warning: ClientID generation host lookup failure [" << hostInfo.errorString() << "]";
+        qWarning() << "ClientID generation host lookup failure [" << hostInfo.errorString() << "]";
         srvClientID += _hostname;
     }
     QString uniqueServerClientID =

--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -110,6 +110,7 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
         setStatus(StatusDisconnecting);
         return;
     }
+    serverSupportsPasswordHash = event.server_options() & Event_ServerIdentification::SupportsPasswordHash;
 
     if (getStatus() == StatusRequestingForgotPassword) {
         Command_ForgotPasswordRequest cmdForgotPasswordRequest;
@@ -127,7 +128,7 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
         cmdForgotPasswordReset.set_user_name(userName.toStdString());
         cmdForgotPasswordReset.set_clientid(getSrvClientID(lastHostname).toStdString());
         cmdForgotPasswordReset.set_token(token.toStdString());
-        if (!password.isEmpty() && event.server_options() & Event_ServerIdentification::SupportsPasswordHash) {
+        if (!password.isEmpty() && serverSupportsPasswordHash) {
             const auto passwordSalt = PasswordHasher::generateRandomSalt();
             const auto hashedPassword = PasswordHasher::computeHash(password, passwordSalt);
             cmdForgotPasswordReset.set_hashed_new_password(hashedPassword.toStdString());
@@ -156,7 +157,7 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
     if (getStatus() == StatusRegistering) {
         Command_Register cmdRegister;
         cmdRegister.set_user_name(userName.toStdString());
-        if (!password.isEmpty() && event.server_options() & Event_ServerIdentification::SupportsPasswordHash) {
+        if (!password.isEmpty() && serverSupportsPasswordHash) {
             const auto passwordSalt = PasswordHasher::generateRandomSalt();
             const auto hashedPassword = PasswordHasher::computeHash(password, passwordSalt);
             cmdRegister.set_hashed_password(hashedPassword.toStdString());
@@ -187,7 +188,7 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
         return;
     }
 
-    if (!password.isEmpty() && event.server_options() & Event_ServerIdentification::SupportsPasswordHash) {
+    if (!password.isEmpty() && serverSupportsPasswordHash) {
         // TODO store and log in using stored hashed password
         doRequestPasswordSalt(); // log in using password salt
     } else {

--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -267,7 +267,7 @@ void RemoteClient::passwordSaltResponse(const Response &response)
         const Response_PasswordSalt &resp = response.GetExtension(Response_PasswordSalt::ext);
         auto passwordSalt = QString::fromStdString(resp.password_salt());
         if (passwordSalt.isEmpty()) { // the server does not recognize the user but allows them to enter unregistered
-            password.clear();            // the password will not be used
+            password.clear();         // the password will not be used
             doLogin();
         } else {
             hashedPassword = PasswordHasher::computeHash(password, passwordSalt);

--- a/cockatrice/src/remoteclient.h
+++ b/cockatrice/src/remoteclient.h
@@ -70,7 +70,7 @@ private slots:
                             const QString &_realname);
     void doRequestPasswordSalt();
     void doLogin();
-    void doLogin(const QString &passwordSalt);
+    void doHashedLogin();
     Command_Login generateCommandLogin();
     void doDisconnectFromServer();
     void doActivateToServer(const QString &_token);
@@ -101,6 +101,7 @@ private:
     QWebSocket *websocket;
     QString lastHostname;
     unsigned int lastPort;
+    QString hashedPassword;
 
     QString getSrvClientID(const QString &_hostname);
     bool newMissingFeatureFound(const QString &_serversMissingFeatures);

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -4,6 +4,7 @@
 #include "dlg_edit_avatar.h"
 #include "dlg_edit_password.h"
 #include "dlg_edit_user.h"
+#include "gettextwithmax.h"
 #include "passwordhasher.h"
 #include "pb/response_get_user_info.pb.h"
 #include "pb/session_commands.pb.h"
@@ -208,9 +209,9 @@ void UserInfoBox::actEditInternal(const Response &r)
             // real password is required to change email
             bool ok = false;
             QString password =
-                QInputDialog::getText(this, tr("Enter Password"),
-                                      tr("Password verification is required in order to change your email address"),
-                                      QLineEdit::Password, "", &ok);
+                getTextWithMax(this, tr("Enter Password"),
+                               tr("Password verification is required in order to change your email address"),
+                               QLineEdit::Password, "", &ok);
             if (!ok)
                 return;
             cmd.set_password_check(password.toStdString());

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -251,7 +251,7 @@ void UserInfoBox::actPassword()
                         changePassword(oldPassword, newPassword);
                     } else {
                         QMessageBox::critical(this, tr("Error"),
-                                              tr("An error occured while trying to update your user information."));
+                                              tr("An error occurred while trying to update your user information."));
                     }
                 });
         client->sendCommand(pend);

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -4,6 +4,7 @@
 #include "dlg_edit_avatar.h"
 #include "dlg_edit_password.h"
 #include "dlg_edit_user.h"
+#include "passwordhasher.h"
 #include "pb/response_get_user_info.pb.h"
 #include "pb/session_commands.pb.h"
 #include "pending_command.h"
@@ -216,9 +217,42 @@ void UserInfoBox::actPassword()
     if (!dlg.exec())
         return;
 
+    auto oldPassword = dlg.getOldPassword();
+    auto newPassword = dlg.getNewPassword();
+
+    if (client->getServerSupportsPasswordHash()) {
+        Command_RequestPasswordSalt cmd;
+        cmd.set_user_name(client->getUserName().toStdString());
+
+        PendingCommand *pend = client->prepareSessionCommand(cmd);
+        connect(pend,
+                // we need qoverload here in order to select the right version of this function
+                QOverload<const Response &, const CommandContainer &, const QVariant &>::of(&PendingCommand::finished),
+                this, [=](const Response &response, const CommandContainer &, const QVariant &) {
+                    if (response.response_code() == Response::RespOk) {
+                        changePassword(oldPassword, newPassword);
+                    } else {
+                        QMessageBox::critical(this, tr("Error"),
+                                              tr("An error occured while trying to update your user information."));
+                    }
+                });
+        client->sendCommand(pend);
+    } else {
+        changePassword(oldPassword, newPassword);
+    }
+}
+
+void UserInfoBox::changePassword(const QString &oldPassword, const QString &newPassword)
+{
     Command_AccountPassword cmd;
-    cmd.set_old_password(dlg.getOldPassword().toStdString());
-    cmd.set_new_password(dlg.getNewPassword().toStdString());
+    cmd.set_old_password(oldPassword.toStdString());
+    if (client->getServerSupportsPasswordHash()) {
+        auto passwordSalt = PasswordHasher::generateRandomSalt();
+        QString hashedPassword = PasswordHasher::computeHash(newPassword, passwordSalt);
+        cmd.set_hashed_new_password(hashedPassword.toStdString());
+    } else {
+        cmd.set_new_password(newPassword.toStdString());
+    }
 
     PendingCommand *pend = client->prepareSessionCommand(cmd);
     connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
@@ -280,7 +314,7 @@ void UserInfoBox::processPasswordResponse(const Response &r)
         case Response::RespInternalError:
         default:
             QMessageBox::critical(this, tr("Error"),
-                                  tr("An error occured while trying to update your user informations."));
+                                  tr("An error occured while trying to update your user information."));
             break;
     }
 }

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -335,7 +335,7 @@ void UserInfoBox::processPasswordResponse(const Response &r)
         case Response::RespInternalError:
         default:
             QMessageBox::critical(this, tr("Error"),
-                                  tr("An error occured while trying to update your user information."));
+                                  tr("An error occurred while trying to update your user information."));
             break;
     }
 }

--- a/cockatrice/src/userinfobox.h
+++ b/cockatrice/src/userinfobox.h
@@ -49,6 +49,7 @@ public slots:
 
 private:
     void resizeEvent(QResizeEvent *event) override;
+    void changePassword(const QString &oldPassword, const QString &newPassword);
 };
 
 #endif

--- a/common/pb/session_commands.proto
+++ b/common/pb/session_commands.proto
@@ -119,7 +119,7 @@ message Command_Register {
     // User name client wants to register
     required string user_name = 1;
     // Hashed password to be inserted into database
-    required string password = 2;
+    optional string password = 2;
     // Email address of the client for user validation
     optional string email = 3;
     // gender = 4; // obsolete
@@ -127,6 +127,7 @@ message Command_Register {
     optional string country = 5;
     optional string real_name = 6;
     optional string clientid = 7;
+    optional string hashed_password = 8;
 }
 
 // User wants to activate an account
@@ -149,6 +150,7 @@ message Command_AccountEdit {
     optional string email = 2;
     // gender = 3; // obsolete
     optional string country = 4;
+    optional string password_check = 100; // password is required to change sensitive information
 }
 
 message Command_AccountImage {
@@ -164,6 +166,8 @@ message Command_AccountPassword {
     }
     optional string old_password = 1;
     optional string new_password = 2;
+    // optional string hashed_old_password = 3; // we don't want users to steal hashed passwords and change them
+    optional string hashed_new_password = 4;
 }
 
 message Command_ForgotPasswordRequest {
@@ -182,6 +186,7 @@ message Command_ForgotPasswordReset {
     optional string clientid = 2;
     optional string token = 3;
     optional string new_password = 4;
+    optional string hashed_new_password = 5;
 }
 
 message Command_ForgotPasswordChallenge {

--- a/common/server_database_interface.h
+++ b/common/server_database_interface.h
@@ -115,6 +115,7 @@ public:
     virtual bool registerUser(const QString & /* userName */,
                               const QString & /* realName */,
                               const QString & /* password */,
+                              bool /* passwordNeedsHash */,
                               const QString & /* emailAddress */,
                               const QString & /* country */,
                               bool /* active = false */)
@@ -151,10 +152,16 @@ public:
     {
         return 0;
     };
+    virtual bool
+    changeUserPassword(const QString & /* user */, const QString & /* password */, bool /* passwordNeedsHash */)
+    {
+        return false;
+    };
     virtual bool changeUserPassword(const QString & /* user */,
                                     const QString & /* oldPassword */,
+                                    bool /* oldPasswordNeedsHash */,
                                     const QString & /* newPassword */,
-                                    const bool & /* force */)
+                                    bool /* newPasswordNeedsHash */)
     {
         return false;
     };

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -31,7 +31,7 @@ Server_ProtocolHandler::Server_ProtocolHandler(Server *_server,
                                                Server_DatabaseInterface *_databaseInterface,
                                                QObject *parent)
     : QObject(parent), Server_AbstractUserInterface(_server), deleted(false), databaseInterface(_databaseInterface),
-      authState(NotLoggedIn), acceptsUserListChanges(false), acceptsRoomListChanges(false),
+      authState(NotLoggedIn), usingRealPassword(false), acceptsUserListChanges(false), acceptsRoomListChanges(false),
       idleClientWarningSent(false), timeRunning(0), lastDataReceived(0), lastActionReceived(0)
 
 {
@@ -515,6 +515,7 @@ Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd
             return Response::RespAccountNotActivated;
         default:
             authState = res;
+            usingRealPassword = needsHash;
     }
 
     // limit the number of non-privileged users that can connect to the server based on configuration settings

--- a/common/server_protocolhandler.h
+++ b/common/server_protocolhandler.h
@@ -52,6 +52,7 @@ protected:
     bool deleted;
     Server_DatabaseInterface *databaseInterface;
     AuthenticationResult authState;
+    bool usingRealPassword;
     bool acceptsUserListChanges;
     bool acceptsRoomListChanges;
     bool idleClientWarningSent;

--- a/common/server_room.cpp
+++ b/common/server_room.cpp
@@ -241,6 +241,8 @@ Response::ResponseCode Server_Room::processJoinGameCommand(const Command_JoinGam
                                                            ResponseContainer &rc,
                                                            Server_AbstractUserInterface *userInterface)
 {
+    if (cmd.password().length() > MAX_NAME_LENGTH)
+        return Response::RespWrongPassword;
     // This function is called from the Server thread and from the S_PH thread.
     // server->roomsMutex is always locked.
 
@@ -265,8 +267,9 @@ Response::ResponseCode Server_Room::processJoinGameCommand(const Command_JoinGam
 
     QMutexLocker gameLocker(&game->gameMutex);
 
-    Response::ResponseCode result = game->checkJoin(userInterface->getUserInfo(), nameFromStdString(cmd.password()),
-                                                    cmd.spectator(), cmd.override_restrictions(), cmd.join_as_judge());
+    Response::ResponseCode result =
+        game->checkJoin(userInterface->getUserInfo(), QString::fromStdString(cmd.password()), cmd.spectator(),
+                        cmd.override_restrictions(), cmd.join_as_judge());
     if (result == Response::RespOk)
         game->addPlayer(userInterface, rc, cmd.spectator(), cmd.join_as_judge());
 

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -198,6 +198,7 @@ bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user, QString 
 bool Servatrice_DatabaseInterface::registerUser(const QString &userName,
                                                 const QString &realName,
                                                 const QString &password,
+                                                bool passwordNeedsHash,
                                                 const QString &emailAddress,
                                                 const QString &country,
                                                 bool active)
@@ -205,7 +206,12 @@ bool Servatrice_DatabaseInterface::registerUser(const QString &userName,
     if (!checkSql())
         return false;
 
-    QString passwordSha512 = PasswordHasher::computeHash(password, PasswordHasher::generateRandomSalt());
+    QString passwordSha512;
+    if (passwordNeedsHash) {
+        passwordSha512 = PasswordHasher::computeHash(password, PasswordHasher::generateRandomSalt());
+    } else {
+        passwordSha512 = password;
+    }
     QString token = active ? QString() : PasswordHasher::generateActivationToken();
 
     QSqlQuery *query =
@@ -936,9 +942,29 @@ void Servatrice_DatabaseInterface::logMessage(const int senderId,
 }
 
 bool Servatrice_DatabaseInterface::changeUserPassword(const QString &user,
+                                                      const QString &password,
+                                                      bool passwordNeedsHash)
+{
+    QString passwordSha512 = password;
+    if (passwordNeedsHash) {
+        passwordSha512 = PasswordHasher::computeHash(password, PasswordHasher::generateRandomSalt());
+    }
+
+    QSqlQuery *passwordQuery = prepareQuery("update {prefix}_users set password_sha512=:password, "
+                                            "passwordLastChangedDate = NOW() where name = :name");
+    passwordQuery->bindValue(":password", passwordSha512);
+    passwordQuery->bindValue(":name", user);
+    if (execSqlQuery(passwordQuery))
+        return true;
+
+    return false;
+}
+
+bool Servatrice_DatabaseInterface::changeUserPassword(const QString &user,
                                                       const QString &oldPassword,
+                                                      bool oldPasswordNeedsHash,
                                                       const QString &newPassword,
-                                                      const bool &force = false)
+                                                      bool newPasswordNeedsHash)
 {
     if (server->getAuthenticationMethod() != Servatrice::AuthenticationSql)
         return false;
@@ -953,30 +979,24 @@ bool Servatrice_DatabaseInterface::changeUserPassword(const QString &user,
     QSqlQuery *passwordQuery = prepareQuery("select password_sha512 from {prefix}_users where name = :name");
     passwordQuery->bindValue(":name", user);
 
-    if (!force) {
-        if (!execSqlQuery(passwordQuery)) {
-            qDebug("Change password denied: SQL error");
-            return false;
-        }
-
-        if (!passwordQuery->next())
-            return false;
-
-        const QString correctPassword = passwordQuery->value(0).toString();
-        if (correctPassword != PasswordHasher::computeHash(oldPassword, correctPassword.left(16)))
-            return false;
+    if (!execSqlQuery(passwordQuery)) {
+        qDebug("Change password denied: SQL error");
+        return false;
     }
 
-    QString passwordSha512 = PasswordHasher::computeHash(newPassword, PasswordHasher::generateRandomSalt());
+    if (!passwordQuery->next())
+        return false;
 
-    passwordQuery = prepareQuery("update {prefix}_users set password_sha512=:password, "
-                                 "passwordLastChangedDate = NOW() where name = :name");
-    passwordQuery->bindValue(":password", passwordSha512);
-    passwordQuery->bindValue(":name", user);
-    if (execSqlQuery(passwordQuery))
-        return true;
+    const QString correctPassword = passwordQuery->value(0).toString();
+    QString oldPasswordSha512 = oldPassword;
+    if (oldPasswordNeedsHash) {
+        QString salt = correctPassword.left(16);
+        oldPasswordSha512 = PasswordHasher::computeHash(oldPassword, salt);
+    }
+    if (correctPassword != oldPasswordSha512)
+        return false;
 
-    return false;
+    return changeUserPassword(user, newPassword, newPasswordNeedsHash);
 }
 
 int Servatrice_DatabaseInterface::getActiveUserCount(QString connectionType)

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -309,7 +309,7 @@ AuthenticationResult Servatrice_DatabaseInterface::checkUserPassword(Server_Prot
             }
 
             if (passwordQuery->next()) {
-                const QString correctPassword = passwordQuery->value(0).toString();
+                const QString correctPasswordSha512 = passwordQuery->value(0).toString();
                 const bool userIsActive = passwordQuery->value(1).toBool();
                 if (!userIsActive) {
                     qDebug("Login denied: user not active");
@@ -317,11 +317,11 @@ AuthenticationResult Servatrice_DatabaseInterface::checkUserPassword(Server_Prot
                 }
                 QString hashedPassword;
                 if (passwordNeedsHash) {
-                    hashedPassword = PasswordHasher::computeHash(password, correctPassword.left(16));
+                    hashedPassword = PasswordHasher::computeHash(password, correctPasswordSha512.left(16));
                 } else {
                     hashedPassword = password;
                 }
-                if (correctPassword == hashedPassword) {
+                if (correctPasswordSha512 == hashedPassword) {
                     qDebug("Login accepted: password right");
                     return PasswordRight;
                 } else {
@@ -987,13 +987,13 @@ bool Servatrice_DatabaseInterface::changeUserPassword(const QString &user,
     if (!passwordQuery->next())
         return false;
 
-    const QString correctPassword = passwordQuery->value(0).toString();
+    const QString correctPasswordSha512 = passwordQuery->value(0).toString();
     QString oldPasswordSha512 = oldPassword;
     if (oldPasswordNeedsHash) {
-        QString salt = correctPassword.left(16);
+        QString salt = correctPasswordSha512.left(16);
         oldPasswordSha512 = PasswordHasher::computeHash(oldPassword, salt);
     }
-    if (correctPassword != oldPasswordSha512)
+    if (correctPasswordSha512 != oldPasswordSha512)
         return false;
 
     return changeUserPassword(user, newPassword, newPasswordNeedsHash);

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -98,6 +98,7 @@ public:
     bool registerUser(const QString &userName,
                       const QString &realName,
                       const QString &password,
+                      bool passwordNeedsHash,
                       const QString &emailAddress,
                       const QString &country,
                       bool active = false);
@@ -111,8 +112,12 @@ public:
                     LogMessage_TargetType targetType,
                     const int targetId,
                     const QString &targetName);
-    bool
-    changeUserPassword(const QString &user, const QString &oldPassword, const QString &newPassword, const bool &force);
+    bool changeUserPassword(const QString &user, const QString &password, bool passwordNeedsHash);
+    bool changeUserPassword(const QString &user,
+                            const QString &oldPassword,
+                            bool oldPasswordNeedsHash,
+                            const QString &newPassword,
+                            bool newPasswordNeedsHash);
     QList<ServerInfo_Ban> getUserBanHistory(const QString userName);
     bool
     addWarning(const QString userName, const QString adminName, const QString warningReason, const QString clientID);

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -1278,32 +1278,27 @@ Response::ResponseCode AbstractServerSocketInterface::cmdAccountEdit(const Comma
             return Response::RespWrongPassword;
         }
     }
-    QString queryText = "update {prefix}_users set ";
-    bool changes = false;
+
+    QStringList queryList({});
     if (cmd.has_real_name()) {
-        queryText += "realname=:realName, ";
-        changes = true;
+        queryList << "realname=:realName";
     }
     if (cmd.has_email()) {
         // a real password is required in order to change the email address
         if (usingRealPassword || checkedPassword) {
-            queryText += "email=:email, ";
-            changes = true;
+            queryList << "email=:email";
         } else {
             return Response::RespFunctionNotAllowed;
         }
     }
     if (cmd.has_country()) {
-        queryText += "country=:country, ";
-        changes = true;
+        queryList << "country=:country";
     }
 
-    if (!changes)
+    if (queryList.isEmpty())
         return Response::RespOk;
 
-    queryText.chop(2); // remove ", "
-    queryText += " where name=:userName";
-
+    QString queryText = QString("update {prefix}_users set %1 where name=:userName").arg(queryList.join(", "));
     QSqlQuery *query = sqlInterface->prepareQuery(queryText);
     if (cmd.has_real_name()) {
         QString realName = nameFromStdString(cmd.real_name());


### PR DESCRIPTION
## Short roundup of the initial problem
passwords are sent in plain text for the registration, change password and reset password commands

## What will change with this Pull Request?
- add hashed password field to commands
- implement server side
- properly split force change password function
- implement client side
- make sure to always log in with hashed password if possible
- add warning when not using hashed password
- add password requirement to change email address when logged in using the hashed password