### PR TITLE
allow servatrice to exit early based on commandline options

### DIFF
--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -79,7 +79,7 @@ requiredfeatures=""
 ; You can define custom warnings that users are sent when the moderation staff uses the right client warn user
 ; menu option.  This list is comma seperated that each item will appear in the drop down list for staff members
 ; to choose from.  Example: "Flaming,Foul Language"
-officialwarnings="Flamming,Spamming,Causing Drama,Abusive Language"
+officialwarnings="Flaming,Spamming,Causing Drama,Abusive Language"
 
 ; Maximum time in seconds a player can stay connected but idle.  Default is 3600 (0 = disabled)
 ; Clients will be notified at the 90% time period of pending disconnection if they do not take action.

--- a/servatrice/src/main.cpp
+++ b/servatrice/src/main.cpp
@@ -30,6 +30,7 @@
 #include <QCommandLineParser>
 #include <QCoreApplication>
 #include <QDateTime>
+#include <QFile>
 #include <QMetaType>
 #include <QTextCodec>
 #include <QtGlobal>
@@ -140,7 +141,12 @@ int main(int argc, char *argv[])
 
     qRegisterMetaType<QList<int>>("QList<int>");
 
-    configPath = SettingsCache::guessConfigurationPath(configPath);
+    if (configPath.isEmpty()) {
+        configPath = SettingsCache::guessConfigurationPath();
+    } else if (!QFile::exists(configPath)) {
+        qCritical() << "Could not find configuration file at" << configPath;
+        return 1;
+    }
     qWarning() << "Using configuration file: " << configPath;
     settingsCache = new SettingsCache(configPath);
 
@@ -167,10 +173,15 @@ int main(int argc, char *argv[])
 
     PasswordHasher::initialize();
 
-    if (testRandom)
+    if (testRandom) {
         testRNG();
-    if (testHashFunction)
+    }
+    if (testHashFunction) {
         testHash();
+    }
+    if (testRandom || testHashFunction) {
+        return 0;
+    }
 
     smtpClient = new SmtpClient();
 

--- a/servatrice/src/settingscache.cpp
+++ b/servatrice/src/settingscache.cpp
@@ -23,7 +23,7 @@ SettingsCache::SettingsCache(const QString &fileName, QSettings::Format format, 
     }
 }
 
-QString SettingsCache::guessConfigurationPath(QString &specificPath)
+QString SettingsCache::guessConfigurationPath()
 {
     const QString fileName = "servatrice.ini";
     if (QFile::exists(qApp->applicationDirPath() + "/portable.dat")) {
@@ -32,9 +32,6 @@ QString SettingsCache::guessConfigurationPath(QString &specificPath)
     }
 
     QString guessFileName;
-    // specific path
-    if (!specificPath.isEmpty() && QFile::exists(specificPath))
-        return specificPath;
 
     // application directory path
     guessFileName = QCoreApplication::applicationDirPath() + "/" + fileName;

--- a/servatrice/src/settingscache.h
+++ b/servatrice/src/settingscache.h
@@ -16,7 +16,7 @@ public:
     SettingsCache(const QString &fileName = "servatrice.ini",
                   QSettings::Format format = QSettings::IniFormat,
                   QObject *parent = 0);
-    static QString guessConfigurationPath(QString &specificPath);
+    static QString guessConfigurationPath();
     QList<QRegExp> disallowedRegExp;
     bool getIsPortableBuild() const
     {


### PR DESCRIPTION
## Short roundup of the initial problem
servatrice's commandline options are annoying to use because they don't stop the server from launching

## What will change with this Pull Request?
- servatrice will display an error and exit when passed a nonexisting config file
- servatrice will exit after doing tests