### PR TITLE
simplify search string

### DIFF
--- a/cockatrice/src/filter_string.cpp
+++ b/cockatrice/src/filter_string.cpp
@@ -337,7 +337,7 @@ static void setupParserRules()
 
 FilterString::FilterString(const QString &expr)
 {
-    QByteArray ba = expr.toLocal8Bit();
+    QByteArray ba = expr.simplified().toLocal8Bit();
 
     std::call_once(init, setupParserRules);
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes https://github.com/Cockatrice/Cockatrice/issues/4494

## Short roundup of the initial problem
you can paste weird whitespace in the search and it'd break the search

## What will change with this Pull Request?
- searches are "simplified", this function replaces all stretches of whitespace with single spaces