### PR TITLE
use multiline input dialog for annotations

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -3034,7 +3034,7 @@ void Player::actSetPT()
     }
     bool ok;
     dialogSemaphore = true;
-    QString pt = QInputDialog::getText(nullptr, tr("Change power/toughness"), tr("Change stats to:"), QLineEdit::Normal,
+    QString pt = QInputDialog::getText(game, tr("Change power/toughness"), tr("Change stats to:"), QLineEdit::Normal,
                                        oldPT, &ok);
     dialogSemaphore = false;
     if (clearCardsToDelete() || !ok) {
@@ -3140,8 +3140,8 @@ void Player::actSetAnnotation()
 
     bool ok;
     dialogSemaphore = true;
-    QString annotation = QInputDialog::getText(nullptr, tr("Set annotation"), tr("Please enter the new annotation:"),
-                                               QLineEdit::Normal, oldAnnotation, &ok);
+    QString annotation = QInputDialog::getMultiLineText(game, tr("Set annotation"),
+                                                        tr("Please enter the new annotation:"), oldAnnotation, &ok);
     dialogSemaphore = false;
     if (clearCardsToDelete() || !ok) {
         return;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4430

## Short roundup of the initial problem
it's hard to add new lines to annotations

## What will change with this Pull Request?
- changes the dialog from a text one to multiline text
- pressing enter now makes a new line instead

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![image](https://user-images.githubusercontent.com/36401181/148627861-21bf2588-7c15-46de-8fe8-0f071a421fcf.png)
