### PR TITLE
remove all instances of the type long

### DIFF
--- a/cockatrice/src/replay_timeline_widget.cpp
+++ b/cockatrice/src/replay_timeline_widget.cpp
@@ -62,7 +62,7 @@ void ReplayTimelineWidget::paintEvent(QPaintEvent * /* event */)
 
 void ReplayTimelineWidget::mousePressEvent(QMouseEvent *event)
 {
-    int newTime = static_cast<int>((long)maxTime * (long)event->x() / width());
+    int newTime = static_cast<int>((qint64)maxTime * (qint64)event->x() / width());
     newTime -= newTime % 200; // Time should always be a multiple of 200
     if (newTime < currentTime) {
         currentTime = 0;

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -211,24 +211,12 @@ Servatrice::~Servatrice()
     clientsLock.unlock();
 
     // client destruction is asynchronous, wait for all clients to be gone
-    bool done = false;
-
-    class SleeperThread : public QThread
-    {
-    public:
-        static void msleep(unsigned long msecs)
-        {
-            QThread::usleep(msecs);
-        }
-    };
-
-    do {
-        SleeperThread::msleep(10);
-        clientsLock.lockForRead();
+    for (;;) {
+        QThread::usleep(10);
+        QReadLocker locker(&clientsLock);
         if (clients.isEmpty())
-            done = true;
-        clientsLock.unlock();
-    } while (!done);
+            break;
+    }
 
     prepareDestroy();
 }


### PR DESCRIPTION

## Related Ticket(s)
- Fixes https://github.com/Cockatrice/Cockatrice/issues/3941

## Short roundup of the initial problem

the long type has different sizes across operating systems and should
not be used

## What will change with this Pull Request?

in the timeline an overflow could occur if the width in pixels
multiplied by the total amount of milliseconds in the replay is larger
than 2^31 which is easy enough considering with only 500 pixels width
you'll reach this number with only 1.2 hours of replay (about 4 million
millis), note that this would be windows exclusive as *nix uses 64 bits

qt-json's own repo suggests using qt5's implementation instead, testing
revealed this is quite a bit faster, contrary to #3480

servatrice uses the qthread usleep function which used to be protected
but is now public

cockatrice is not compatible with qt4 and hasn't been for a while

