### PR TITLE
implement max lengths for input dialogs that are sent to the server

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -5,126 +5,127 @@
 PROJECT(Cockatrice VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 
 SET(cockatrice_SOURCES
+    src/abstractcarddragitem.cpp
+    src/abstractcarditem.cpp
+    src/abstractclient.cpp
     src/abstractcounter.cpp
+    src/abstractgraphicsitem.cpp
+    src/arrowitem.cpp
+    src/arrowtarget.cpp
+    src/carddatabase.cpp
+    src/carddatabasemodel.cpp
+    src/carddbparser/carddatabaseparser.cpp
+    src/carddbparser/cockatricexml3.cpp
+    src/carddbparser/cockatricexml4.cpp
+    src/carddragitem.cpp
+    src/cardfilter.cpp
+    src/cardframe.cpp
+    src/cardinfopicture.cpp
+    src/cardinfotext.cpp
+    src/cardinfowidget.cpp
+    src/carditem.cpp
+    src/cardlist.cpp
+    src/cardzone.cpp
+    src/chatview/chatview.cpp
     src/counter_general.cpp
-    src/dlg_creategame.cpp
-    src/dlg_filter_games.cpp
+    src/customlineedit.cpp
+    src/deck_loader.cpp
+    src/decklistmodel.cpp
+    src/deckstats_interface.cpp
+    src/deckview.cpp
     src/dlg_connect.cpp
     src/dlg_create_token.cpp
+    src/dlg_creategame.cpp
     src/dlg_edit_avatar.cpp
     src/dlg_edit_password.cpp
     src/dlg_edit_tokens.cpp
     src/dlg_edit_user.cpp
+    src/dlg_filter_games.cpp
+    src/dlg_forgotpasswordchallenge.cpp
     src/dlg_forgotpasswordrequest.cpp
     src/dlg_forgotpasswordreset.cpp
-    src/dlg_forgotpasswordchallenge.cpp
-    src/dlg_manage_sets.cpp
-    src/dlg_register.cpp
-    src/dlg_tip_of_the_day.cpp
-    src/tip_of_the_day.cpp
-    src/dlg_update.cpp
-    src/dlg_viewlog.cpp
-    src/abstractclient.cpp
-    src/remoteclient.cpp
-    src/main.cpp
-    src/window_main.cpp
-    src/gamesmodel.cpp
-    src/player.cpp
-    src/playertarget.cpp
-    src/cardzone.cpp
-    src/selectzone.cpp
-    src/cardlist.cpp
-    src/abstractcarditem.cpp
-    src/carditem.cpp
-    src/tablezone.cpp
-    src/handzone.cpp
-    src/handcounter.cpp
-    src/carddatabase.cpp
-    src/keysignals.cpp
-    src/gameview.cpp
-    src/gameselector.cpp
-    src/decklistmodel.cpp
-    src/deck_loader.cpp
     src/dlg_load_deck_from_clipboard.cpp
     src/dlg_load_remote_deck.cpp
-    src/cardinfowidget.cpp
-    src/cardframe.cpp
-    src/cardinfopicture.cpp
-    src/cardinfotext.cpp
-    src/filterbuilder.cpp
-    src/cardfilter.cpp
-    src/filtertreemodel.cpp
-    src/filtertree.cpp
-    src/messagelogwidget.cpp
-    src/zoneviewzone.cpp
-    src/zoneviewwidget.cpp
-    src/pilezone.cpp
-    src/stackzone.cpp
-    src/carddragitem.cpp
-    src/carddatabasemodel.cpp
-    src/setsmodel.cpp
-    src/abstractgraphicsitem.cpp
-    src/abstractcarddragitem.cpp
+    src/dlg_manage_sets.cpp
+    src/dlg_register.cpp
     src/dlg_settings.cpp
-    src/phasestoolbar.cpp
+    src/dlg_tip_of_the_day.cpp
+    src/dlg_update.cpp
+    src/dlg_viewlog.cpp
+    src/filter_string.cpp
+    src/filterbuilder.cpp
+    src/filtertree.cpp
+    src/filtertreemodel.cpp
     src/gamescene.cpp
-    src/arrowitem.cpp
-    src/arrowtarget.cpp
-    src/tab.cpp
-    src/tab_server.cpp
-    src/tab_room.cpp
-    src/tab_message.cpp
-    src/tab_game.cpp
-    src/tab_deck_storage.cpp
-    src/tab_replays.cpp
-    src/tab_supervisor.cpp
-    src/tab_admin.cpp
-    src/tab_account.cpp
-    src/tab_deck_editor.cpp
-    src/tab_logs.cpp
-    src/replay_timeline_widget.cpp
-    src/deckstats_interface.cpp
-    src/tappedout_interface.cpp
-    src/chatview/chatview.cpp
-    src/userlist.cpp
-    src/userinfobox.cpp
-    src/user_context_menu.cpp
-    src/remotedecklist_treewidget.cpp
-    src/remotereplaylist_treewidget.cpp
-    src/deckview.cpp
-    src/playerlistwidget.cpp
-    src/pixmapgenerator.cpp
-    src/settingscache.cpp
-    src/thememanager.cpp
+    src/gameselector.cpp
+    src/gamesmodel.cpp
+    src/gameview.cpp
+    src/gettextwithmax.cpp
+    src/handcounter.cpp
+    src/handle_public_servers.cpp
+    src/handzone.cpp
+    src/keysignals.cpp
+    src/lineeditcompleter.cpp
+    src/localclient.cpp
     src/localserver.cpp
     src/localserverinterface.cpp
-    src/localclient.cpp
-    src/soundengine.cpp
+    src/logger.cpp
+    src/main.cpp
+    src/messagelogwidget.cpp
     src/pending_command.cpp
+    src/phase.cpp
+    src/phasestoolbar.cpp
     src/pictureloader.cpp
-    src/shortcutssettings.cpp
+    src/pilezone.cpp
+    src/pixmapgenerator.cpp
+    src/player.cpp
+    src/playerlistwidget.cpp
+    src/playertarget.cpp
+    src/releasechannel.cpp
+    src/remoteclient.cpp
+    src/remotedecklist_treewidget.cpp
+    src/remotereplaylist_treewidget.cpp
+    src/replay_timeline_widget.cpp
+    src/selectzone.cpp
     src/sequenceEdit/sequenceedit.cpp
-    src/lineeditcompleter.cpp
-    src/settings/settingsmanager.cpp
+    src/setsmodel.cpp
     src/settings/carddatabasesettings.cpp
-    src/settings/serverssettings.cpp
-    src/settings/messagesettings.cpp
+    src/settings/downloadsettings.cpp
     src/settings/gamefilterssettings.cpp
     src/settings/layoutssettings.cpp
-    src/settings/downloadsettings.cpp
-    src/update_downloader.cpp
-    src/logger.cpp
-    src/releasechannel.cpp
-    src/userconnection_information.cpp
+    src/settings/messagesettings.cpp
+    src/settings/serverssettings.cpp
+    src/settings/settingsmanager.cpp
+    src/settingscache.cpp
+    src/shortcutssettings.cpp
+    src/soundengine.cpp
     src/spoilerbackgroundupdater.cpp
-    src/handle_public_servers.cpp
-    src/carddbparser/carddatabaseparser.cpp
-    src/carddbparser/cockatricexml3.cpp
-    src/carddbparser/cockatricexml4.cpp
-    src/filter_string.cpp
-    src/phase.cpp
-    src/customlineedit.cpp
+    src/stackzone.cpp
+    src/tab.cpp
+    src/tab_account.cpp
+    src/tab_admin.cpp
+    src/tab_deck_editor.cpp
+    src/tab_deck_storage.cpp
+    src/tab_game.cpp
+    src/tab_logs.cpp
+    src/tab_message.cpp
+    src/tab_replays.cpp
+    src/tab_room.cpp
+    src/tab_server.cpp
+    src/tab_supervisor.cpp
+    src/tablezone.cpp
+    src/tappedout_interface.cpp
+    src/thememanager.cpp
+    src/tip_of_the_day.cpp
     src/translatecountername.cpp
+    src/update_downloader.cpp
+    src/user_context_menu.cpp
+    src/userconnection_information.cpp
+    src/userinfobox.cpp
+    src/userlist.cpp
+    src/window_main.cpp
+    src/zoneviewwidget.cpp
+    src/zoneviewzone.cpp
     ${VERSION_STRING_CPP}
     )
 

--- a/cockatrice/src/chatview/chatview.cpp
+++ b/cockatrice/src/chatview/chatview.cpp
@@ -12,8 +12,6 @@
 #include <QDesktopServices>
 #include <QMouseEvent>
 #include <QScrollBar>
-#include <QTextDocumentFragment>
-#include <QTextEdit>
 
 const QColor DEFAULT_MENTION_COLOR = QColor(194, 31, 47);
 

--- a/cockatrice/src/customlineedit.cpp
+++ b/cockatrice/src/customlineedit.cpp
@@ -1,4 +1,3 @@
-
 #include "customlineedit.h"
 
 #include "settingscache.h"
@@ -38,8 +37,8 @@ bool LineEditUnfocusable::isUnfocusShortcut(QKeyEvent *event)
     QKeySequence key(modifier + keyNoMod);
     QList<QKeySequence> unfocusShortcut = SettingsCache::instance().shortcuts().getShortcut("Textbox/unfocusTextBox");
 
-    for (QList<QKeySequence>::iterator i = unfocusShortcut.begin(); i != unfocusShortcut.end(); ++i) {
-        if (key.matches(*i) == QKeySequence::ExactMatch)
+    for (const auto &unfocusKey : unfocusShortcut) {
+        if (key.matches(unfocusKey) == QKeySequence::ExactMatch)
             return true;
     }
     return false;

--- a/cockatrice/src/customlineedit.h
+++ b/cockatrice/src/customlineedit.h
@@ -12,12 +12,13 @@ class QString;
 // shortcuts and other shortcuts
 class LineEditUnfocusable : public QLineEdit
 {
+    Q_OBJECT
 public:
-    LineEditUnfocusable(QWidget *parent = nullptr);
-    LineEditUnfocusable(const QString &contents, QWidget *parent = nullptr);
+    explicit LineEditUnfocusable(QWidget *parent = nullptr);
+    explicit LineEditUnfocusable(const QString &contents, QWidget *parent = nullptr);
 
 private:
-    bool isUnfocusShortcut(QKeyEvent *key);
+    static bool isUnfocusShortcut(QKeyEvent *key);
 
 protected:
     void keyPressEvent(QKeyEvent *event) override;

--- a/cockatrice/src/dlg_connect.cpp
+++ b/cockatrice/src/dlg_connect.cpp
@@ -1,6 +1,7 @@
 #include "dlg_connect.h"
 
 #include "settingscache.h"
+#include "stringsizes.h"
 #include "userconnection_information.h"
 
 #include <QCheckBox>
@@ -39,22 +40,27 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
 
     saveLabel = new QLabel(tr("Name:"));
     saveEdit = new QLineEdit;
+    saveEdit->setMaxLength(MAX_NAME_LENGTH);
     saveLabel->setBuddy(saveEdit);
 
     hostLabel = new QLabel(tr("&Host:"));
     hostEdit = new QLineEdit;
+    hostEdit->setMaxLength(MAX_NAME_LENGTH);
     hostLabel->setBuddy(hostEdit);
 
     portLabel = new QLabel(tr("&Port:"));
     portEdit = new QLineEdit;
+    portEdit->setValidator(new QIntValidator(0, 0xffff, portEdit));
     portLabel->setBuddy(portEdit);
 
     playernameLabel = new QLabel(tr("Player &name:"));
     playernameEdit = new QLineEdit;
+    playernameEdit->setMaxLength(MAX_NAME_LENGTH);
     playernameLabel->setBuddy(playernameEdit);
 
     passwordLabel = new QLabel(tr("P&assword:"));
     passwordEdit = new QLineEdit;
+    passwordEdit->setMaxLength(MAX_NAME_LENGTH);
     passwordLabel->setBuddy(passwordEdit);
     passwordEdit->setEchoMode(QLineEdit::Password);
 

--- a/cockatrice/src/dlg_create_token.cpp
+++ b/cockatrice/src/dlg_create_token.cpp
@@ -5,6 +5,7 @@
 #include "decklist.h"
 #include "main.h"
 #include "settingscache.h"
+#include "stringsizes.h"
 
 #include <QCheckBox>
 #include <QCloseEvent>
@@ -28,6 +29,7 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
 
     nameLabel = new QLabel(tr("&Name:"));
     nameEdit = new QLineEdit(tr("Token"));
+    nameEdit->setMaxLength(MAX_NAME_LENGTH);
     nameEdit->selectAll();
     connect(nameEdit, SIGNAL(textChanged(const QString &)), this, SLOT(updateSearch(const QString &)));
     nameLabel->setBuddy(nameEdit);
@@ -45,10 +47,12 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
 
     ptLabel = new QLabel(tr("&P/T:"));
     ptEdit = new QLineEdit;
+    ptEdit->setMaxLength(MAX_NAME_LENGTH);
     ptLabel->setBuddy(ptEdit);
 
     annotationLabel = new QLabel(tr("&Annotation:"));
     annotationEdit = new QLineEdit;
+    annotationEdit->setMaxLength(MAX_NAME_LENGTH);
     annotationLabel->setBuddy(annotationEdit);
 
     destroyCheckBox = new QCheckBox(tr("&Destroy token when it leaves the table"));

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -27,7 +27,6 @@ void DlgCreateGame::sharedCtor()
     descriptionEdit = new QLineEdit;
     descriptionEdit->setMaxLength(MAX_NAME_LENGTH);
     descriptionLabel->setBuddy(descriptionEdit);
-    descriptionEdit->setMaxLength(60);
 
     maxPlayersLabel = new QLabel(tr("P&layers:"));
     maxPlayersEdit = new QSpinBox();

--- a/cockatrice/src/dlg_creategame.cpp
+++ b/cockatrice/src/dlg_creategame.cpp
@@ -3,6 +3,7 @@
 #include "pb/serverinfo_game.pb.h"
 #include "pending_command.h"
 #include "settingscache.h"
+#include "stringsizes.h"
 #include "tab_room.h"
 
 #include <QApplication>
@@ -24,6 +25,7 @@ void DlgCreateGame::sharedCtor()
     rememberGameSettings = new QCheckBox(tr("Re&member settings"));
     descriptionLabel = new QLabel(tr("&Description:"));
     descriptionEdit = new QLineEdit;
+    descriptionEdit->setMaxLength(MAX_NAME_LENGTH);
     descriptionLabel->setBuddy(descriptionEdit);
     descriptionEdit->setMaxLength(60);
 
@@ -57,6 +59,7 @@ void DlgCreateGame::sharedCtor()
 
     passwordLabel = new QLabel(tr("&Password:"));
     passwordEdit = new QLineEdit;
+    passwordEdit->setMaxLength(MAX_NAME_LENGTH);
     passwordLabel->setBuddy(passwordEdit);
 
     onlyBuddiesCheckBox = new QCheckBox(tr("Only &buddies can join"));

--- a/cockatrice/src/dlg_edit_avatar.cpp
+++ b/cockatrice/src/dlg_edit_avatar.cpp
@@ -1,5 +1,7 @@
 #include "dlg_edit_avatar.h"
 
+#include "stringsizes.h"
+
 #include <QBuffer>
 #include <QDebug>
 #include <QDialogButtonBox>
@@ -75,6 +77,13 @@ QByteArray DlgEditAvatar::getImage()
     QByteArray ba;
     QBuffer buffer(&ba);
     buffer.open(QIODevice::WriteOnly);
-    image.save(&buffer, "JPG");
-    return ba;
+    for (;;) {
+        image.save(&buffer, "JPG");
+        if (ba.length() > MAX_FILE_LENGTH) {
+            ba.clear();
+            image = image.scaledToWidth(image.width() / 2); // divide the amount of pixels in four to get the size down
+        } else {
+            return ba;
+        }
+    }
 }

--- a/cockatrice/src/dlg_edit_password.cpp
+++ b/cockatrice/src/dlg_edit_password.cpp
@@ -1,6 +1,7 @@
 #include "dlg_edit_password.h"
 
 #include "settingscache.h"
+#include "stringsizes.h"
 
 #include <QDialogButtonBox>
 #include <QGridLayout>
@@ -12,6 +13,7 @@ DlgEditPassword::DlgEditPassword(QWidget *parent) : QDialog(parent)
 {
     oldPasswordLabel = new QLabel(tr("Old password:"));
     oldPasswordEdit = new QLineEdit();
+    oldPasswordEdit->setMaxLength(MAX_NAME_LENGTH);
 
     auto &servers = SettingsCache::instance().servers();
     if (servers.getSavePassword()) {
@@ -23,11 +25,13 @@ DlgEditPassword::DlgEditPassword(QWidget *parent) : QDialog(parent)
 
     newPasswordLabel = new QLabel(tr("New password:"));
     newPasswordEdit = new QLineEdit();
+    newPasswordEdit->setMaxLength(MAX_NAME_LENGTH);
     newPasswordLabel->setBuddy(newPasswordLabel);
     newPasswordEdit->setEchoMode(QLineEdit::Password);
 
     newPasswordLabel2 = new QLabel(tr("Confirm new password:"));
     newPasswordEdit2 = new QLineEdit();
+    newPasswordEdit2->setMaxLength(MAX_NAME_LENGTH);
     newPasswordLabel2->setBuddy(newPasswordLabel2);
     newPasswordEdit2->setEchoMode(QLineEdit::Password);
 

--- a/cockatrice/src/dlg_edit_tokens.cpp
+++ b/cockatrice/src/dlg_edit_tokens.cpp
@@ -2,6 +2,7 @@
 
 #include "carddatabase.h"
 #include "carddatabasemodel.h"
+#include "gettextwithmax.h"
 #include "main.h"
 #include "stringsizes.h"
 
@@ -146,9 +147,8 @@ void DlgEditTokens::tokenSelectionChanged(const QModelIndex &current, const QMod
 void DlgEditTokens::actAddToken()
 {
     QString name;
-    bool askAgain = true;
-    do {
-        name = QInputDialog::getText(this, tr("Add token"), tr("Please enter the name of the token:"));
+    for (;;) {
+        name = getTextWithMax(this, tr("Add token"), tr("Please enter the name of the token:"));
         if (name.isEmpty())
             return;
         if (databaseModel->getDatabase()->getCard(name)) {
@@ -156,9 +156,9 @@ void DlgEditTokens::actAddToken()
                                   tr("The chosen name conflicts with an existing card or token.\nMake sure to enable "
                                      "the 'Token' set in the \"Manage sets\" dialog to display them correctly."));
         } else {
-            askAgain = false;
+            break;
         }
-    } while (askAgain);
+    }
 
     QString setName = CardDatabase::TOKENS_SETNAME;
     CardInfoPerSetMap sets;

--- a/cockatrice/src/dlg_edit_tokens.cpp
+++ b/cockatrice/src/dlg_edit_tokens.cpp
@@ -3,6 +3,7 @@
 #include "carddatabase.h"
 #include "carddatabasemodel.h"
 #include "main.h"
+#include "stringsizes.h"
 
 #include <QAction>
 #include <QComboBox>
@@ -23,6 +24,7 @@ DlgEditTokens::DlgEditTokens(QWidget *parent) : QDialog(parent), currentCard(nul
 {
     nameLabel = new QLabel(tr("&Name:"));
     nameEdit = new QLineEdit;
+    nameEdit->setMaxLength(MAX_NAME_LENGTH);
     nameEdit->setEnabled(false);
     nameLabel->setBuddy(nameEdit);
 
@@ -40,11 +42,13 @@ DlgEditTokens::DlgEditTokens(QWidget *parent) : QDialog(parent), currentCard(nul
 
     ptLabel = new QLabel(tr("&P/T:"));
     ptEdit = new QLineEdit;
+    ptEdit->setMaxLength(MAX_NAME_LENGTH);
     ptLabel->setBuddy(ptEdit);
     connect(ptEdit, SIGNAL(textChanged(QString)), this, SLOT(ptChanged(QString)));
 
     annotationLabel = new QLabel(tr("&Annotation:"));
     annotationEdit = new QLineEdit;
+    annotationEdit->setMaxLength(MAX_NAME_LENGTH);
     annotationLabel->setBuddy(annotationEdit);
     connect(annotationEdit, SIGNAL(textChanged(QString)), this, SLOT(annotationChanged(QString)));
 

--- a/cockatrice/src/dlg_edit_user.cpp
+++ b/cockatrice/src/dlg_edit_user.cpp
@@ -1,6 +1,7 @@
 #include "dlg_edit_user.h"
 
 #include "settingscache.h"
+#include "stringsizes.h"
 
 #include <QDebug>
 #include <QDialogButtonBox>
@@ -12,6 +13,7 @@ DlgEditUser::DlgEditUser(QWidget *parent, QString email, QString country, QStrin
 {
     emailLabel = new QLabel(tr("Email:"));
     emailEdit = new QLineEdit();
+    emailEdit->setMaxLength(MAX_NAME_LENGTH);
     emailLabel->setBuddy(emailEdit);
     emailEdit->setText(email);
 
@@ -33,6 +35,7 @@ DlgEditUser::DlgEditUser(QWidget *parent, QString email, QString country, QStrin
 
     realnameLabel = new QLabel(tr("Real name:"));
     realnameEdit = new QLineEdit();
+    realnameEdit->setMaxLength(MAX_NAME_LENGTH);
     realnameLabel->setBuddy(realnameEdit);
     realnameEdit->setText(realName);
 

--- a/cockatrice/src/dlg_forgotpasswordchallenge.cpp
+++ b/cockatrice/src/dlg_forgotpasswordchallenge.cpp
@@ -1,6 +1,7 @@
 #include "dlg_forgotpasswordchallenge.h"
 
 #include "settingscache.h"
+#include "stringsizes.h"
 
 #include <QCheckBox>
 #include <QDebug>
@@ -38,18 +39,22 @@ DlgForgotPasswordChallenge::DlgForgotPasswordChallenge(QWidget *parent) : QDialo
 
     hostLabel = new QLabel(tr("&Host:"));
     hostEdit = new QLineEdit(lastfphost);
+    hostEdit->setMaxLength(MAX_NAME_LENGTH);
     hostLabel->setBuddy(hostEdit);
 
     portLabel = new QLabel(tr("&Port:"));
     portEdit = new QLineEdit(lastfpport);
+    portEdit->setValidator(new QIntValidator(0, 0xffff, portEdit));
     portLabel->setBuddy(portEdit);
 
     playernameLabel = new QLabel(tr("Player &name:"));
     playernameEdit = new QLineEdit(lastfpplayername);
+    playernameEdit->setMaxLength(MAX_NAME_LENGTH);
     playernameLabel->setBuddy(playernameEdit);
 
     emailLabel = new QLabel(tr("Email:"));
     emailEdit = new QLineEdit();
+    emailEdit->setMaxLength(MAX_NAME_LENGTH);
     emailLabel->setBuddy(emailLabel);
 
     if (!servers.getFPHostname().isEmpty() && !servers.getFPPort().isEmpty() && !servers.getFPPlayerName().isEmpty()) {

--- a/cockatrice/src/dlg_forgotpasswordrequest.cpp
+++ b/cockatrice/src/dlg_forgotpasswordrequest.cpp
@@ -1,6 +1,7 @@
 #include "dlg_forgotpasswordrequest.h"
 
 #include "settingscache.h"
+#include "stringsizes.h"
 
 #include <QCheckBox>
 #include <QDebug>
@@ -31,14 +32,17 @@ DlgForgotPasswordRequest::DlgForgotPasswordRequest(QWidget *parent) : QDialog(pa
 
     hostLabel = new QLabel(tr("&Host:"));
     hostEdit = new QLineEdit(lastfphost);
+    hostEdit->setMaxLength(MAX_NAME_LENGTH);
     hostLabel->setBuddy(hostEdit);
 
     portLabel = new QLabel(tr("&Port:"));
     portEdit = new QLineEdit(lastfpport);
+    portEdit->setValidator(new QIntValidator(0, 0xffff, portEdit));
     portLabel->setBuddy(portEdit);
 
     playernameLabel = new QLabel(tr("Player &name:"));
     playernameEdit = new QLineEdit(lastfpplayername);
+    playernameEdit->setMaxLength(MAX_NAME_LENGTH);
     playernameLabel->setBuddy(playernameEdit);
 
     QGridLayout *grid = new QGridLayout;

--- a/cockatrice/src/dlg_forgotpasswordreset.cpp
+++ b/cockatrice/src/dlg_forgotpasswordreset.cpp
@@ -1,6 +1,7 @@
 #include "dlg_forgotpasswordreset.h"
 
 #include "settingscache.h"
+#include "stringsizes.h"
 
 #include <QCheckBox>
 #include <QDebug>
@@ -37,27 +38,33 @@ DlgForgotPasswordReset::DlgForgotPasswordReset(QWidget *parent) : QDialog(parent
 
     hostLabel = new QLabel(tr("&Host:"));
     hostEdit = new QLineEdit(lastfphost);
+    hostEdit->setMaxLength(MAX_NAME_LENGTH);
     hostLabel->setBuddy(hostEdit);
 
     portLabel = new QLabel(tr("&Port:"));
     portEdit = new QLineEdit(lastfpport);
+    portEdit->setValidator(new QIntValidator(0, 0xffff, portEdit));
     portLabel->setBuddy(portEdit);
 
     playernameLabel = new QLabel(tr("Player &name:"));
     playernameEdit = new QLineEdit(lastfpplayername);
+    playernameEdit->setMaxLength(MAX_NAME_LENGTH);
     playernameLabel->setBuddy(playernameEdit);
 
     tokenLabel = new QLabel(tr("Token:"));
     tokenEdit = new QLineEdit();
+    tokenEdit->setMaxLength(MAX_NAME_LENGTH);
     tokenLabel->setBuddy(tokenLabel);
 
     newpasswordLabel = new QLabel(tr("New Password:"));
     newpasswordEdit = new QLineEdit();
+    newpasswordEdit->setMaxLength(MAX_NAME_LENGTH);
     newpasswordLabel->setBuddy(newpasswordEdit);
     newpasswordEdit->setEchoMode(QLineEdit::Password);
 
     newpasswordverifyLabel = new QLabel(tr("New Password:"));
     newpasswordverifyEdit = new QLineEdit();
+    newpasswordverifyEdit->setMaxLength(MAX_NAME_LENGTH);
     newpasswordverifyLabel->setBuddy(newpasswordEdit);
     newpasswordverifyEdit->setEchoMode(QLineEdit::Password);
 

--- a/cockatrice/src/dlg_register.cpp
+++ b/cockatrice/src/dlg_register.cpp
@@ -2,6 +2,7 @@
 
 #include "pb/serverinfo_user.pb.h"
 #include "settingscache.h"
+#include "stringsizes.h"
 
 #include <QCheckBox>
 #include <QDebug>
@@ -20,32 +21,39 @@ DlgRegister::DlgRegister(QWidget *parent) : QDialog(parent)
 
     hostLabel = new QLabel(tr("&Host:"));
     hostEdit = new QLineEdit(servers.getHostname());
+    hostEdit->setMaxLength(MAX_NAME_LENGTH);
     hostLabel->setBuddy(hostEdit);
 
     portLabel = new QLabel(tr("&Port:"));
     portEdit = new QLineEdit(servers.getPort());
+    portEdit->setValidator(new QIntValidator(0, 0xffff, portEdit));
     portLabel->setBuddy(portEdit);
 
     playernameLabel = new QLabel(tr("Player &name:"));
     playernameEdit = new QLineEdit(servers.getPlayerName());
+    playernameEdit->setMaxLength(MAX_NAME_LENGTH);
     playernameLabel->setBuddy(playernameEdit);
 
     passwordLabel = new QLabel(tr("P&assword:"));
     passwordEdit = new QLineEdit();
+    passwordEdit->setMaxLength(MAX_NAME_LENGTH);
     passwordLabel->setBuddy(passwordEdit);
     passwordEdit->setEchoMode(QLineEdit::Password);
 
     passwordConfirmationLabel = new QLabel(tr("Password (again):"));
     passwordConfirmationEdit = new QLineEdit();
+    passwordConfirmationEdit->setMaxLength(MAX_NAME_LENGTH);
     passwordConfirmationLabel->setBuddy(passwordConfirmationEdit);
     passwordConfirmationEdit->setEchoMode(QLineEdit::Password);
 
     emailLabel = new QLabel(tr("Email:"));
     emailEdit = new QLineEdit();
+    emailEdit->setMaxLength(MAX_NAME_LENGTH);
     emailLabel->setBuddy(emailEdit);
 
     emailConfirmationLabel = new QLabel(tr("Email (again):"));
     emailConfirmationEdit = new QLineEdit();
+    emailConfirmationEdit->setMaxLength(MAX_NAME_LENGTH);
     emailConfirmationLabel->setBuddy(emailConfirmationEdit);
 
     countryLabel = new QLabel(tr("Country:"));
@@ -308,6 +316,7 @@ DlgRegister::DlgRegister(QWidget *parent) : QDialog(parent)
 
     realnameLabel = new QLabel(tr("Real name:"));
     realnameEdit = new QLineEdit();
+    realnameEdit->setMaxLength(MAX_NAME_LENGTH);
     realnameLabel->setBuddy(realnameEdit);
 
     QGridLayout *grid = new QGridLayout;

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -1,6 +1,7 @@
 #include "dlg_settings.h"
 
 #include "carddatabase.h"
+#include "gettextwithmax.h"
 #include "main.h"
 #include "releasechannel.h"
 #include "sequenceEdit/sequenceedit.h"
@@ -76,12 +77,9 @@ GeneralSettingsPage::GeneralSettingsPage()
 
     connect(&languageBox, SIGNAL(currentIndexChanged(int)), this, SLOT(languageBoxChanged(int)));
     connect(&pixmapCacheEdit, SIGNAL(valueChanged(int)), &settings, SLOT(setPixmapCacheSize(int)));
-    connect(&updateReleaseChannelBox, SIGNAL(currentIndexChanged(int)), &settings,
-            SLOT(setUpdateReleaseChannel(int)));
-    connect(&updateNotificationCheckBox, SIGNAL(stateChanged(int)), &settings,
-            SLOT(setNotifyAboutUpdate(int)));
-    connect(&newVersionOracleCheckBox, SIGNAL(stateChanged(int)), &settings,
-            SLOT(setNotifyAboutNewVersion(int)));
+    connect(&updateReleaseChannelBox, SIGNAL(currentIndexChanged(int)), &settings, SLOT(setUpdateReleaseChannel(int)));
+    connect(&updateNotificationCheckBox, SIGNAL(stateChanged(int)), &settings, SLOT(setNotifyAboutUpdate(int)));
+    connect(&newVersionOracleCheckBox, SIGNAL(stateChanged(int)), &settings, SLOT(setNotifyAboutNewVersion(int)));
     connect(&showTipsOnStartup, SIGNAL(clicked(bool)), &settings, SLOT(setShowTipsOnStartup(bool)));
 
     auto *personalGrid = new QGridLayout;
@@ -949,7 +947,8 @@ void MessagesSettingsPage::storeSettings()
 void MessagesSettingsPage::actAdd()
 {
     bool ok;
-    QString msg = QInputDialog::getText(this, tr("Add message"), tr("Message:"), QLineEdit::Normal, QString(), &ok);
+    QString msg =
+        getTextWithMax(this, tr("Add message"), tr("Message:"), QLineEdit::Normal, QString(), &ok, MAX_TEXT_LENGTH);
     if (ok) {
         messageList->addItem(msg);
         storeSettings();
@@ -961,7 +960,8 @@ void MessagesSettingsPage::actEdit()
     if (messageList->currentItem()) {
         QString oldText = messageList->currentItem()->text();
         bool ok;
-        QString msg = QInputDialog::getText(this, tr("Edit message"), tr("Message:"), QLineEdit::Normal, oldText, &ok);
+        QString msg =
+            getTextWithMax(this, tr("Edit message"), tr("Message:"), QLineEdit::Normal, oldText, &ok, MAX_TEXT_LENGTH);
         if (ok) {
             messageList->currentItem()->setText(msg);
             storeSettings();

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -4,6 +4,7 @@
 #include "dlg_creategame.h"
 #include "dlg_filter_games.h"
 #include "gamesmodel.h"
+#include "gettextwithmax.h"
 #include "pb/response.pb.h"
 #include "pb/room_commands.pb.h"
 #include "pb/serverinfo_game.pb.h"
@@ -243,7 +244,7 @@ void GameSelector::actJoin()
     QString password;
     if (game.with_password() && !(spectator && !game.spectators_need_password()) && !overrideRestrictions) {
         bool ok;
-        password = QInputDialog::getText(this, tr("Join game"), tr("Password:"), QLineEdit::Password, QString(), &ok);
+        password = getTextWithMax(this, tr("Join game"), tr("Password:"), QLineEdit::Password, QString(), &ok);
         if (!ok)
             return;
     }

--- a/cockatrice/src/gettextwithmax.cpp
+++ b/cockatrice/src/gettextwithmax.cpp
@@ -1,0 +1,32 @@
+#include "gettextwithmax.h"
+
+QString getTextWithMax(QWidget *parent,
+                       const QString &title,
+                       const QString &label,
+                       QLineEdit::EchoMode mode,
+                       const QString &text,
+                       bool *ok,
+                       int max,
+                       Qt::WindowFlags flags,
+                       Qt::InputMethodHints inputMethodHints)
+{
+    auto *dialog = new QInputDialog(parent, flags);
+    dialog->setWindowTitle(title);
+    dialog->setLabelText(label);
+    dialog->setTextValue(text);
+    dialog->setTextEchoMode(mode);
+    dialog->setInputMethodHints(inputMethodHints);
+
+    // find the qlineedit that this dialog holds, there should be only one
+    dialog->findChild<QLineEdit *>()->setMaxLength(max);
+
+    const int ret = dialog->exec();
+    if (ok != nullptr) {
+        *ok = !!ret;
+    }
+    if (ret) {
+        return dialog->textValue();
+    } else {
+        return QString();
+    }
+}

--- a/cockatrice/src/gettextwithmax.h
+++ b/cockatrice/src/gettextwithmax.h
@@ -1,0 +1,23 @@
+// custom QInputDialog::getText implementation that allows configuration of the max length
+#ifndef GETTEXTWITHMAX_H
+#define GETTEXTWITHMAX_H
+
+#include "stringsizes.h"
+
+#include <QInputDialog>
+
+QString getTextWithMax(QWidget *parent,
+                       const QString &title,
+                       const QString &label,
+                       QLineEdit::EchoMode echo = QLineEdit::Normal,
+                       const QString &text = QString(),
+                       bool *ok = nullptr,
+                       int max = MAX_NAME_LENGTH,
+                       Qt::WindowFlags flags = Qt::WindowFlags(),
+                       Qt::InputMethodHints inputMethodHints = Qt::ImhNone);
+static inline QString getTextWithMax(QWidget *parent, const QString &title, const QString &label, int max)
+{
+    return getTextWithMax(parent, title, label, QLineEdit::Normal, QString(), nullptr, max);
+}
+
+#endif // GETTEXTWITHMAX_H

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -10,6 +10,7 @@
 #include "deck_loader.h"
 #include "dlg_create_token.h"
 #include "gamescene.h"
+#include "gettextwithmax.h"
 #include "handcounter.h"
 #include "handzone.h"
 #include "main.h"
@@ -3033,21 +3034,16 @@ void Player::actSetPT()
             oldPT = card->getPT();
         }
     }
-    QInputDialog *ptDialog = new QInputDialog(game);
-    ptDialog->setWindowTitle(tr("Change power/toughness"));
-    ptDialog->setLabelText(tr("Change stats to:"));
-    ptDialog->setTextValue(oldPT);
-    // find the qlineedit that this dialog holds, there should be only one
-    ptDialog->findChild<QLineEdit *>()->setMaxLength(MAX_NAME_LENGTH);
-
+    bool ok;
     dialogSemaphore = true;
-    bool ok = ptDialog->exec();
+    QString pt =
+        getTextWithMax(game, tr("Change power/toughness"), tr("Change stats to:"), QLineEdit::Normal, oldPT, &ok);
     dialogSemaphore = false;
     if (clearCardsToDelete() || !ok) {
         return;
     }
 
-    const auto ptList = parsePT(ptDialog->textValue());
+    const auto ptList = parsePT(pt);
     bool empty = ptList.isEmpty();
 
     QList<const ::google::protobuf::Message *> commandList;

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -56,6 +56,7 @@
 #include "playertarget.h"
 #include "settingscache.h"
 #include "stackzone.h"
+#include "stringsizes.h"
 #include "tab_game.h"
 #include "tablezone.h"
 #include "thememanager.h"
@@ -3032,16 +3033,21 @@ void Player::actSetPT()
             oldPT = card->getPT();
         }
     }
-    bool ok;
+    QInputDialog *ptDialog = new QInputDialog(game);
+    ptDialog->setWindowTitle(tr("Change power/toughness"));
+    ptDialog->setLabelText(tr("Change stats to:"));
+    ptDialog->setTextValue(oldPT);
+    // find the qlineedit that this dialog holds, there should be only one
+    ptDialog->findChild<QLineEdit *>()->setMaxLength(MAX_NAME_LENGTH);
+
     dialogSemaphore = true;
-    QString pt = QInputDialog::getText(game, tr("Change power/toughness"), tr("Change stats to:"), QLineEdit::Normal,
-                                       oldPT, &ok);
+    bool ok = ptDialog->exec();
     dialogSemaphore = false;
     if (clearCardsToDelete() || !ok) {
         return;
     }
 
-    const auto ptList = parsePT(pt);
+    const auto ptList = parsePT(ptDialog->textValue());
     bool empty = ptList.isEmpty();
 
     QList<const ::google::protobuf::Message *> commandList;
@@ -3141,7 +3147,8 @@ void Player::actSetAnnotation()
     bool ok;
     dialogSemaphore = true;
     QString annotation = QInputDialog::getMultiLineText(game, tr("Set annotation"),
-                                                        tr("Please enter the new annotation:"), oldAnnotation, &ok);
+                                                        tr("Please enter the new annotation:"), oldAnnotation, &ok)
+                             .left(MAX_NAME_LENGTH);
     dialogSemaphore = false;
     if (clearCardsToDelete() || !ok) {
         return;

--- a/cockatrice/src/tab_account.cpp
+++ b/cockatrice/src/tab_account.cpp
@@ -10,6 +10,7 @@
 #include "pb/session_commands.pb.h"
 #include "pending_command.h"
 #include "soundengine.h"
+#include "stringsizes.h"
 #include "userinfobox.h"
 #include "userlist.h"
 
@@ -60,6 +61,7 @@ TabUserLists::TabUserLists(TabSupervisor *_tabSupervisor,
 
     QHBoxLayout *addToBuddyList = new QHBoxLayout;
     addBuddyEdit = new LineEditUnfocusable;
+    addBuddyEdit->setMaxLength(MAX_NAME_LENGTH);
     addBuddyEdit->setPlaceholderText(tr("Add to Buddy List"));
     connect(addBuddyEdit, SIGNAL(returnPressed()), this, SLOT(addToBuddyList()));
     QPushButton *addBuddyButton = new QPushButton("Add");
@@ -69,6 +71,7 @@ TabUserLists::TabUserLists(TabSupervisor *_tabSupervisor,
 
     QHBoxLayout *addToIgnoreList = new QHBoxLayout;
     addIgnoreEdit = new LineEditUnfocusable;
+    addIgnoreEdit->setMaxLength(MAX_NAME_LENGTH);
     addIgnoreEdit->setPlaceholderText(tr("Add to Ignore List"));
     connect(addIgnoreEdit, SIGNAL(returnPressed()), this, SLOT(addToIgnoreList()));
     QPushButton *addIgnoreButton = new QPushButton("Add");

--- a/cockatrice/src/tab_admin.cpp
+++ b/cockatrice/src/tab_admin.cpp
@@ -2,6 +2,7 @@
 
 #include "abstractclient.h"
 #include "pb/admin_commands.pb.h"
+#include "stringsizes.h"
 
 #include <QDialogButtonBox>
 #include <QGridLayout>
@@ -18,6 +19,7 @@ ShutdownDialog::ShutdownDialog(QWidget *parent) : QDialog(parent)
 {
     QLabel *reasonLabel = new QLabel(tr("&Reason for shutdown:"));
     reasonEdit = new QLineEdit;
+    reasonEdit->setMaxLength(MAX_TEXT_LENGTH);
     reasonLabel->setBuddy(reasonEdit);
     QLabel *minutesLabel = new QLabel(tr("&Time until shutdown (minutes):"));
     minutesEdit = new QSpinBox;

--- a/cockatrice/src/tab_deck_storage.h
+++ b/cockatrice/src/tab_deck_storage.h
@@ -27,6 +27,7 @@ private:
     QGroupBox *leftGroupBox, *rightGroupBox;
 
     QAction *aOpenLocalDeck, *aUpload, *aDeleteLocalDeck, *aOpenRemoteDeck, *aDownload, *aNewFolder, *aDeleteRemoteDeck;
+    QString getTargetPath() const;
 private slots:
     void actOpenLocalDeck();
 

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -269,14 +269,21 @@ void DeckViewContainer::loadLocalDeck()
 
     QString fileName = dialog.selectedFiles().at(0);
     DeckLoader::FileFormat fmt = DeckLoader::getFormatFromName(fileName);
+    QString deckString;
     DeckLoader deck;
-    if (!deck.loadFromFile(fileName, fmt)) {
+
+    bool error = !deck.loadFromFile(fileName, fmt);
+    if (!error) {
+        deckString = deck.writeToString_Native();
+        error = deckString.length() > MAX_FILE_LENGTH;
+    }
+    if (error) {
         QMessageBox::critical(this, tr("Error"), tr("The selected file could not be loaded."));
         return;
     }
 
     Command_DeckSelect cmd;
-    cmd.set_deck(deck.writeToString_Native().toStdString());
+    cmd.set_deck(deckString.toStdString());
     PendingCommand *pend = parentGame->prepareGameCommand(cmd);
     connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
             SLOT(deckSelectFinished(const Response &)));

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -52,6 +52,7 @@
 #include "playerlistwidget.h"
 #include "replay_timeline_widget.h"
 #include "settingscache.h"
+#include "stringsizes.h"
 #include "tab_supervisor.h"
 #include "window_main.h"
 #include "zoneviewwidget.h"
@@ -1823,6 +1824,7 @@ void TabGame::createMessageDock(bool bReplay)
 
         sayLabel = new QLabel;
         sayEdit = new LineEditCompleter;
+        sayEdit->setMaxLength(MAX_TEXT_LENGTH);
         sayLabel->setBuddy(sayEdit);
         completer = new QCompleter(autocompleteUserList, sayEdit);
         completer->setCaseSensitivity(Qt::CaseInsensitive);

--- a/cockatrice/src/tab_logs.cpp
+++ b/cockatrice/src/tab_logs.cpp
@@ -6,6 +6,7 @@
 #include "pb/moderator_commands.pb.h"
 #include "pb/response_viewlog_history.pb.h"
 #include "pending_command.h"
+#include "stringsizes.h"
 
 #include <QCheckBox>
 #include <QDialogButtonBox>
@@ -148,18 +149,23 @@ void TabLog::createDock()
 {
     labelFindUserName = new QLabel(tr("Username: "));
     findUsername = new LineEditUnfocusable("");
+    findUsername->setMaxLength(MAX_NAME_LENGTH);
     findUsername->setAlignment(Qt::AlignCenter);
     labelFindIPAddress = new QLabel(tr("IP Address: "));
     findIPAddress = new LineEditUnfocusable("");
+    findIPAddress->setMaxLength(MAX_NAME_LENGTH);
     findIPAddress->setAlignment(Qt::AlignCenter);
     labelFindGameName = new QLabel(tr("Game Name: "));
     findGameName = new LineEditUnfocusable("");
+    findGameName->setMaxLength(MAX_NAME_LENGTH);
     findGameName->setAlignment(Qt::AlignCenter);
     labelFindGameID = new QLabel(tr("GameID: "));
     findGameID = new LineEditUnfocusable("");
+    findGameID->setMaxLength(MAX_NAME_LENGTH);
     findGameID->setAlignment(Qt::AlignCenter);
     labelMessage = new QLabel(tr("Message: "));
     findMessage = new LineEditUnfocusable("");
+    findMessage->setMaxLength(MAX_TEXT_LENGTH);
     findMessage->setAlignment(Qt::AlignCenter);
 
     mainRoom = new QCheckBox(tr("Main Room"));

--- a/cockatrice/src/tab_message.cpp
+++ b/cockatrice/src/tab_message.cpp
@@ -10,6 +10,7 @@
 #include "pending_command.h"
 #include "settingscache.h"
 #include "soundengine.h"
+#include "stringsizes.h"
 
 #include <QApplication>
 #include <QDebug>
@@ -29,6 +30,7 @@ TabMessage::TabMessage(TabSupervisor *_tabSupervisor,
     connect(chatView, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));
     connect(chatView, SIGNAL(addMentionTag(QString)), this, SLOT(addMentionTag(QString)));
     sayEdit = new LineEditUnfocusable;
+    sayEdit->setMaxLength(MAX_TEXT_LENGTH);
     connect(sayEdit, SIGNAL(returnPressed()), this, SLOT(sendMessage()));
 
     QVBoxLayout *vbox = new QVBoxLayout;

--- a/cockatrice/src/tab_room.cpp
+++ b/cockatrice/src/tab_room.cpp
@@ -15,6 +15,7 @@
 #include "pb/serverinfo_room.pb.h"
 #include "pending_command.h"
 #include "settingscache.h"
+#include "stringsizes.h"
 #include "tab_account.h"
 #include "tab_supervisor.h"
 #include "userlist.h"
@@ -60,6 +61,7 @@ TabRoom::TabRoom(TabSupervisor *_tabSupervisor,
     connect(&SettingsCache::instance(), SIGNAL(chatMentionCompleterChanged()), this, SLOT(actCompleterChanged()));
     sayLabel = new QLabel;
     sayEdit = new LineEditCompleter;
+    sayEdit->setMaxLength(MAX_TEXT_LENGTH);
     sayLabel->setBuddy(sayEdit);
     connect(sayEdit, SIGNAL(returnPressed()), this, SLOT(sendMessage()));
 

--- a/cockatrice/src/userlist.cpp
+++ b/cockatrice/src/userlist.cpp
@@ -8,6 +8,7 @@
 #include "pb/session_commands.pb.h"
 #include "pending_command.h"
 #include "pixmapgenerator.h"
+#include "stringsizes.h"
 #include "tab_account.h"
 #include "tab_supervisor.h"
 #include "user_context_menu.h"
@@ -36,12 +37,15 @@ BanDialog::BanDialog(const ServerInfo_User &info, QWidget *parent) : QDialog(par
     nameBanCheckBox = new QCheckBox(tr("ban &user name"));
     nameBanCheckBox->setChecked(true);
     nameBanEdit = new QLineEdit(QString::fromStdString(info.name()));
+    nameBanEdit->setMaxLength(MAX_NAME_LENGTH);
     ipBanCheckBox = new QCheckBox(tr("ban &IP address"));
     ipBanCheckBox->setChecked(true);
     ipBanEdit = new QLineEdit(QString::fromStdString(info.address()));
+    ipBanEdit->setMaxLength(MAX_NAME_LENGTH);
     idBanCheckBox = new QCheckBox(tr("ban client I&D"));
     idBanCheckBox->setChecked(true);
     idBanEdit = new QLineEdit(QString::fromStdString(info.clientid()));
+    idBanEdit->setMaxLength(MAX_NAME_LENGTH);
     if (QString::fromStdString(info.clientid()).isEmpty())
         idBanCheckBox->setChecked(false);
 
@@ -129,7 +133,9 @@ WarningDialog::WarningDialog(const QString userName, const QString clientID, QWi
     setAttribute(Qt::WA_DeleteOnClose);
     descriptionLabel = new QLabel(tr("Which warning would you like to send?"));
     nameWarning = new QLineEdit(userName);
+    nameWarning->setMaxLength(MAX_NAME_LENGTH);
     warnClientID = new QLineEdit(clientID);
+    warnClientID->setMaxLength(MAX_NAME_LENGTH);
     warningOption = new QComboBox();
     warningOption->addItem("");
 

--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -31,6 +31,7 @@
 #include "dlg_tip_of_the_day.h"
 #include "dlg_update.h"
 #include "dlg_viewlog.h"
+#include "gettextwithmax.h"
 #include "localclient.h"
 #include "localserver.h"
 #include "localserverinterface.h"
@@ -426,10 +427,10 @@ void MainWindow::loginError(Response::ResponseCode r,
             break;
         case Response::RespAccountNotActivated: {
             bool ok = false;
-            QString token = QInputDialog::getText(this, tr("Account activation"),
-                                                  tr("Your account has not been activated yet.\nYou need to provide "
-                                                     "the activation token received in the activation email."),
-                                                  QLineEdit::Normal, QString(), &ok);
+            QString token = getTextWithMax(this, tr("Account activation"),
+                                           tr("Your account has not been activated yet.\nYou need to provide "
+                                              "the activation token received in the activation email."),
+                                           QLineEdit::Normal, QString(), &ok);
             if (ok && !token.isEmpty()) {
                 client->activateToServer(token);
                 return;

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -462,7 +462,8 @@ Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd
     QMap<QString, bool> receivedClientFeatures;
     QMap<QString, bool> missingClientFeatures;
 
-    for (int i = 0; i < cmd.clientfeatures().size(); ++i) {
+    int featureCount = qMin(cmd.clientfeatures().size(), MAX_NAME_LENGTH);
+    for (int i = 0; i < featureCount; ++i) {
         receivedClientFeatures.insert(nameFromStdString(cmd.clientfeatures(i)).simplified(), false);
     }
 
@@ -766,11 +767,11 @@ bool Server_ProtocolHandler::addSaidMessageSize(int size)
 Response::ResponseCode
 Server_ProtocolHandler::cmdRoomSay(const Command_RoomSay &cmd, Server_Room *room, ResponseContainer & /*rc*/)
 {
-    QString msg = QString::fromStdString(cmd.message());
-
-    if (!addSaidMessageSize(msg.size())) {
+    if (!addSaidMessageSize(cmd.message().size())) {
         return Response::RespChatFlood;
     }
+    QString msg = QString::fromStdString(cmd.message());
+
     msg.replace(QChar('\n'), QChar(' '));
 
     room->say(QString::fromStdString(userInfo->name()), msg);
@@ -808,7 +809,8 @@ Server_ProtocolHandler::cmdCreateGame(const Command_CreateGame &cmd, Server_Room
     }
 
     QList<int> gameTypes;
-    for (int i = cmd.game_type_ids_size() - 1; i >= 0; --i) { // FIXME: why are these iterated in reverse?
+    int gameTypeCount = qMin(cmd.game_type_ids().size(), MAX_NAME_LENGTH);
+    for (int i = 0; i < gameTypeCount; ++i) { // the client actually only sends one of these
         gameTypes.append(cmd.game_type_ids(i));
     }
 

--- a/common/server_room.cpp
+++ b/common/server_room.cpp
@@ -11,6 +11,7 @@
 #include "pb/serverinfo_room.pb.h"
 #include "server_game.h"
 #include "server_protocolhandler.h"
+#include "stringsizes.h"
 
 #include <QDateTime>
 #include <QDebug>
@@ -264,9 +265,8 @@ Response::ResponseCode Server_Room::processJoinGameCommand(const Command_JoinGam
 
     QMutexLocker gameLocker(&game->gameMutex);
 
-    Response::ResponseCode result =
-        game->checkJoin(userInterface->getUserInfo(), QString::fromStdString(cmd.password()), cmd.spectator(),
-                        cmd.override_restrictions(), cmd.join_as_judge());
+    Response::ResponseCode result = game->checkJoin(userInterface->getUserInfo(), nameFromStdString(cmd.password()),
+                                                    cmd.spectator(), cmd.override_restrictions(), cmd.join_as_judge());
     if (result == Response::RespOk)
         game->addPlayer(userInterface, rc, cmd.spectator(), cmd.join_as_judge());
 

--- a/common/stringsizes.h
+++ b/common/stringsizes.h
@@ -1,0 +1,8 @@
+// max sizes of strings used in the protocol
+
+// max size for short strings, like names and things that are generally a single phrase
+constexpr int MAX_NAME_LENGTH = 0xff;
+// max size for chat messages and text contents
+constexpr int MAX_TEXT_LENGTH = 0xfff;
+// max size for deck files and pictures
+constexpr int MAX_FILE_LENGTH = 0xfffff; // about a megabyte

--- a/common/stringsizes.h
+++ b/common/stringsizes.h
@@ -1,4 +1,6 @@
 // max sizes of strings used in the protocol
+#include <QString>
+#include <QtMath>
 
 // max size for short strings, like names and things that are generally a single phrase
 constexpr int MAX_NAME_LENGTH = 0xff;
@@ -6,3 +8,17 @@ constexpr int MAX_NAME_LENGTH = 0xff;
 constexpr int MAX_TEXT_LENGTH = 0xfff;
 // max size for deck files and pictures
 constexpr int MAX_FILE_LENGTH = 0xfffff; // about a megabyte
+
+// optimized functions to get qstrings that are at most that long
+static inline QString nameFromStdString(const std::string &_string)
+{
+    return QString::fromUtf8(_string.data(), std::min(int(_string.size()), MAX_NAME_LENGTH));
+}
+static inline QString textFromStdString(const std::string &_string)
+{
+    return QString::fromUtf8(_string.data(), std::min(int(_string.size()), MAX_TEXT_LENGTH));
+}
+static inline QString fileFromStdString(const std::string &_string)
+{
+    return QString::fromUtf8(_string.data(), std::min(int(_string.size()), MAX_FILE_LENGTH));
+}

--- a/common/stringsizes.h
+++ b/common/stringsizes.h
@@ -1,4 +1,7 @@
 // max sizes of strings used in the protocol
+#ifndef STRINGSIZES_H
+#define STRINGSIZES_H
+
 #include <QString>
 #include <QtMath>
 
@@ -22,3 +25,5 @@ static inline QString fileFromStdString(const std::string &_string)
 {
     return QString::fromUtf8(_string.data(), std::min(int(_string.size()), MAX_FILE_LENGTH));
 }
+
+#endif // STRINGSIZES_H

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -72,9 +72,9 @@
 #include <QHostAddress>
 #include <QRegularExpression>
 #include <QSqlError>
-#include <QtMath>
 #include <QSqlQuery>
 #include <QString>
+#include <QtMath>
 #include <iostream>
 #include <string>
 

--- a/servatrice/src/serversocketinterface.h
+++ b/servatrice/src/serversocketinterface.h
@@ -130,7 +130,7 @@ private:
     bool removeAdminFlagFromUser(const QString &user, int flag);
 
     bool isPasswordLongEnough(const int passwordLength);
-    static QPair<QString, QString> parseEmailAddress(const std::string &stdEmailAddress);
+    static QPair<QString, QString> parseEmailAddress(const QString &emailAddress);
     void removeSaidMessages(const QString &userName, int amount);
 
 public:


### PR DESCRIPTION


## Short roundup of the initial problem
people can enter really long messages where they shouldn't ever need that much

## What will change with this Pull Request?
- add a shared header that contains some constants
- add these constants as a max value to every dialog with info that is sent to the server
- some refactors (this always happens doesn't it)
