### PR TITLE
Address macOS issue where right-clicking a username in the main chat

### DIFF
--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -14,10 +14,6 @@
 #include <QLabel>
 #include <QMessageBox>
 
-const quint64 SIXTY = 60;
-const quint64 HOURS_IN_A_DAY = 24;
-const quint64 DAYS_IN_A_YEAR = 365;
-
 UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *parent, Qt::WindowFlags flags)
     : QWidget(parent, flags), client(_client), editable(_editable)
 {
@@ -126,30 +122,35 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
     QString accountAgeString = tr("Unregistered user");
     if (userLevel.testFlag(ServerInfo_User::IsAdmin) || userLevel.testFlag(ServerInfo_User::IsModerator) ||
         userLevel.testFlag(ServerInfo_User::IsRegistered)) {
-        if (user.accountage_secs() == 0)
-            accountAgeString = tr("Unknown");
-        else {
-            quint64 seconds = user.accountage_secs();
-            quint64 minutes = seconds / SIXTY;
-            quint64 hours = minutes / SIXTY;
-            quint64 days = hours / HOURS_IN_A_DAY;
-            quint64 years = days / DAYS_IN_A_YEAR;
-            quint64 daysMinusYears = days - (years * DAYS_IN_A_YEAR);
-
-            accountAgeString = "";
-            if (years >= 1) {
-                accountAgeString = QString::number(years);
-                accountAgeString.append(" ");
-                accountAgeString.append(years == 1 ? tr("Year") : tr("Years"));
-                accountAgeString.append(" ");
-            }
-
-            accountAgeString.append(QString::number(daysMinusYears));
-            accountAgeString.append(" ");
-            accountAgeString.append(days == 1 ? tr("Day") : tr("Days"));
-        }
+        accountAgeString = getAgeString(user.accountage_secs());
     }
     accountAgeLabel2.setText(accountAgeString);
+}
+
+QString UserInfoBox::getAgeString(int ageSeconds)
+{
+    QString accountAgeString = tr("Unknown");
+    if (ageSeconds == 0)
+        return accountAgeString;
+
+    auto date = QDateTime::fromTime_t(QDateTime::currentSecsSinceEpoch() - ageSeconds).date();
+    if (!date.isValid())
+        return accountAgeString;
+
+    QString dateString = QLocale().toString(date, QLocale::ShortFormat);
+    auto now = QDate::currentDate();
+    auto daysAndYears = getDaysAndYearsBetween(date, now);
+
+    QString yearString;
+    if (daysAndYears.second > 0) {
+        yearString = tr("%n Year(s), ", "amount of years (only shown if more than 0)", daysAndYears.second);
+    }
+    accountAgeString =
+        tr("%10%n Day(s) %20", "amount of years (if more than 0), amount of days, date in local short format",
+           daysAndYears.first)
+            .arg(yearString)
+            .arg(dateString);
+    return accountAgeString;
 }
 
 void UserInfoBox::updateInfo(const QString &userName)
@@ -255,7 +256,7 @@ void UserInfoBox::processEditResponse(const Response &r)
         case Response::RespInternalError:
         default:
             QMessageBox::critical(this, tr("Error"),
-                                  tr("An error occured while trying to update your user informations."));
+                                  tr("An error occurred while trying to update your user information."));
             break;
     }
 }

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -11,7 +11,6 @@
 
 #include <QDateTime>
 #include <QGridLayout>
-#include <QHBoxLayout>
 #include <QLabel>
 #include <QMessageBox>
 
@@ -24,7 +23,7 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *paren
 {
     QFont nameFont = nameLabel.font();
     nameFont.setBold(true);
-    nameFont.setPointSize(nameFont.pointSize() * 1.5);
+    nameFont.setPointSize(std::ceil(nameFont.pointSize() * 1.5));
     nameLabel.setFont(nameFont);
 
     avatarLabel.setMinimumSize(200, 200);
@@ -90,7 +89,6 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
         avatarPixmap =
             UserLevelPixmapGenerator::generatePixmap(64, userLevel, false, QString::fromStdString(user.privlevel()));
     }
-    avatarLabel.setPixmap(avatarPixmap.scaled(400, 200, Qt::KeepAspectRatio, Qt::SmoothTransformation));
 
     nameLabel.setText(QString::fromStdString(user.name()));
     realNameLabel2.setText(QString::fromStdString(user.real_name()));
@@ -131,7 +129,7 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
         if (user.accountage_secs() == 0)
             accountAgeString = tr("Unknown");
         else {
-            qint64 seconds = user.accountage_secs();
+            auto seconds = static_cast<qint64>(user.accountage_secs());
             qint64 minutes = seconds / SIXTY;
             qint64 hours = minutes / SIXTY;
             qint64 days = hours / HOURS_IN_A_DAY;
@@ -305,5 +303,6 @@ void UserInfoBox::resizeEvent(QResizeEvent *event)
 {
     QPixmap resizedPixmap = avatarPixmap.scaled(avatarLabel.size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
     avatarLabel.setPixmap(resizedPixmap);
+    resize(sizeHint());
     QWidget::resizeEvent(event);
 }

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -13,7 +13,6 @@
 #include <QGridLayout>
 #include <QLabel>
 #include <QMessageBox>
-#include <cmath>
 
 const qint64 SIXTY = 60;
 const qint64 HOURS_IN_A_DAY = 24;
@@ -24,7 +23,7 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *paren
 {
     QFont nameFont = nameLabel.font();
     nameFont.setBold(true);
-    nameFont.setPointSize(std::ceil(nameFont.pointSize() * 1.5));
+    nameFont.setPointSizeF(nameFont.pointSize() * 1.5);
     nameLabel.setFont(nameFont);
 
     avatarLabel.setMinimumSize(200, 200);
@@ -169,6 +168,7 @@ void UserInfoBox::processResponse(const Response &r)
 {
     const Response_GetUserInfo &response = r.GetExtension(Response_GetUserInfo::ext);
     updateInfo(response.user_info());
+    resize(sizeHint());
     show();
 }
 
@@ -304,6 +304,5 @@ void UserInfoBox::resizeEvent(QResizeEvent *event)
 {
     QPixmap resizedPixmap = avatarPixmap.scaled(avatarLabel.size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
     avatarLabel.setPixmap(resizedPixmap);
-    resize(sizeHint());
     QWidget::resizeEvent(event);
 }

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -13,6 +13,7 @@
 #include <QGridLayout>
 #include <QLabel>
 #include <QMessageBox>
+#include <cmath>
 
 const qint64 SIXTY = 60;
 const qint64 HOURS_IN_A_DAY = 24;

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -14,16 +14,16 @@
 #include <QLabel>
 #include <QMessageBox>
 
-const qint64 SIXTY = 60;
-const qint64 HOURS_IN_A_DAY = 24;
-const qint64 DAYS_IN_A_YEAR = 365;
+const quint64 SIXTY = 60;
+const quint64 HOURS_IN_A_DAY = 24;
+const quint64 DAYS_IN_A_YEAR = 365;
 
 UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *parent, Qt::WindowFlags flags)
     : QWidget(parent, flags), client(_client), editable(_editable)
 {
     QFont nameFont = nameLabel.font();
     nameFont.setBold(true);
-    nameFont.setPointSizeF(nameFont.pointSize() * 1.5);
+    nameFont.setPointSizeF(nameFont.pointSizeF() * 1.5);
     nameLabel.setFont(nameFont);
 
     avatarLabel.setMinimumSize(200, 200);
@@ -129,12 +129,12 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
         if (user.accountage_secs() == 0)
             accountAgeString = tr("Unknown");
         else {
-            auto seconds = static_cast<qint64>(user.accountage_secs());
-            qint64 minutes = seconds / SIXTY;
-            qint64 hours = minutes / SIXTY;
-            qint64 days = hours / HOURS_IN_A_DAY;
-            qint64 years = days / DAYS_IN_A_YEAR;
-            qint64 daysMinusYears = days - (years * DAYS_IN_A_YEAR);
+            quint64 seconds = user.accountage_secs();
+            quint64 minutes = seconds / SIXTY;
+            quint64 hours = minutes / SIXTY;
+            quint64 days = hours / HOURS_IN_A_DAY;
+            quint64 years = days / DAYS_IN_A_YEAR;
+            quint64 daysMinusYears = days - (years * DAYS_IN_A_YEAR);
 
             accountAgeString = "";
             if (years >= 1) {

--- a/cockatrice/src/userinfobox.h
+++ b/cockatrice/src/userinfobox.h
@@ -1,6 +1,7 @@
 #ifndef USERINFOBOX_H
 #define USERINFOBOX_H
 
+#include <QDateTime>
 #include <QLabel>
 #include <QPushButton>
 #include <QWidget>
@@ -20,9 +21,18 @@ private:
     QPushButton editButton, passwordButton, avatarButton;
     QPixmap avatarPixmap;
 
+    static QString getAgeString(int ageSeconds);
+
 public:
     UserInfoBox(AbstractClient *_client, bool editable, QWidget *parent = nullptr, Qt::WindowFlags flags = {});
     void retranslateUi();
+
+    inline static QPair<int, int> getDaysAndYearsBetween(const QDate &then, const QDate &now)
+    {
+        int years = now.addDays(1 - then.dayOfYear()).year() - then.year(); // there is no yearsTo
+        int days = then.addYears(years).daysTo(now);
+        return {days, years};
+    }
 private slots:
     void processResponse(const Response &r);
     void processEditResponse(const Response &r);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,11 +1,13 @@
 enable_testing()
 add_test(NAME dummy_test COMMAND dummy_test)
 add_test(NAME expression_test COMMAND expression_test)
+add_test(NAME test_age_formatting COMMAND test_age_formatting)
 
 # Find GTest
 
 add_executable(dummy_test dummy_test.cpp)
 add_executable(expression_test expression_test.cpp)
+add_executable(test_age_formatting test_age_formatting.cpp)
 
 find_package(GTest)
 
@@ -35,6 +37,7 @@ if(NOT GTEST_FOUND)
     SET(GTEST_BOTH_LIBRARIES gtest)
     add_dependencies(dummy_test gtest)
     add_dependencies(expression_test gtest)
+    add_dependencies(test_age_formatting gtest)
 endif()
 
 find_package(Qt5 COMPONENTS Widgets REQUIRED)
@@ -44,6 +47,7 @@ set(TEST_QT_MODULES Qt5::Widgets)
 include_directories(${GTEST_INCLUDE_DIRS})
 target_link_libraries(dummy_test Threads::Threads ${GTEST_BOTH_LIBRARIES})
 target_link_libraries(expression_test cockatrice_common Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES})
+target_link_libraries(test_age_formatting Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES})
 
 add_subdirectory(carddatabase)
 add_subdirectory(loading_from_clipboard)

--- a/tests/test_age_formatting.cpp
+++ b/tests/test_age_formatting.cpp
@@ -1,0 +1,44 @@
+#include "../cockatrice/src/userinfobox.h"
+
+#include "gtest/gtest.h"
+
+namespace
+{
+using dayyear = QPair<int, int>;
+
+TEST(AgeFormatting, Zero)
+{
+    auto got = UserInfoBox::getDaysAndYearsBetween(QDate(2000, 1, 1), QDate(2000, 1, 1));
+    ASSERT_EQ(got, dayyear(0, 0)) << "these are the same day";
+}
+
+TEST(AgeFormatting, LeapDay)
+{
+    auto got = UserInfoBox::getDaysAndYearsBetween(QDate(2000, 2, 28), QDate(2000, 3, 1));
+    ASSERT_EQ(got, dayyear(2, 0)) << "there is a leap day in between these days";
+}
+
+TEST(AgeFormatting, LeapYear)
+{
+    auto got = UserInfoBox::getDaysAndYearsBetween(QDate(2000, 1, 1), QDate(2001, 1, 1));
+    ASSERT_EQ(got, dayyear(0, 1)) << "there is a leap day in between these dates, but that's fine";
+}
+
+TEST(AgeFormatting, LeapDayWithYear)
+{
+    auto got = UserInfoBox::getDaysAndYearsBetween(QDate(2000, 2, 28), QDate(2001, 3, 1));
+    ASSERT_EQ(got, dayyear(1, 1)) << "there is a leap day in between these days but not in the last year";
+}
+
+TEST(AgeFormatting, LeapDayThisYear)
+{
+    auto got = UserInfoBox::getDaysAndYearsBetween(QDate(2003, 2, 28), QDate(2004, 3, 1));
+    ASSERT_EQ(got, dayyear(2, 1)) << "there is a leap day in between these days this year";
+}
+} // namespace
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
…(or game chat) areas would pop up a seemingly empty user profile. This is because the resize event is overridden and doesn't actually attempt to resize based on the size hint of the dialog. Now that we're explicit with the call, this resize should be forced and have comparable results to popping up user profile from the user list.

## Related Ticket(s)
- Fixes #IssueNumber

Before:
<img width="479" alt="Screen Shot 2022-01-15 at 1 27 54 AM" src="https://user-images.githubusercontent.com/7460172/149611773-8cd70c21-2d07-48fc-82b3-b1c49d25c5df.png">

After:
<img width="713" alt="Screen Shot 2022-01-15 at 1 25 36 AM" src="https://user-images.githubusercontent.com/7460172/149611778-24f1d784-9641-4b4b-9060-04c34dd01069.png">

