### PR TITLE
UI: Improve alignment in user info

### DIFF
--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -64,16 +64,16 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *paren
         connect(&avatarButton, SIGNAL(clicked()), this, SLOT(actAvatar()));
     }
 
-    setWindowTitle(tr("User information"));
+    setWindowTitle(tr("User Information"));
     setLayout(mainLayout);
     retranslateUi();
 }
 
 void UserInfoBox::retranslateUi()
 {
-    realNameLabel1.setText(tr("Real name:"));
+    realNameLabel1.setText(tr("Real Name:"));
     countryLabel1.setText(tr("Location:"));
-    userLevelLabel1.setText(tr("User level:"));
+    userLevelLabel1.setText(tr("User Level:"));
     accountAgeLabel1.setText(tr("Account Age:"));
 
     editButton.setText(tr("Edit"));
@@ -98,7 +98,9 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
 
     if (country.length() != 0) {
         countryLabel2.setPixmap(CountryPixmapGenerator::generatePixmap(15, country));
-        countryLabel3.setText(QString("(%1)").arg(country.toUpper()));
+		//TODO have some extra width here to not clue the coutnry code right to the flag icon
+        countryLabel2.setAlignment(Qt::AlignCenter);
+        countryLabel3.setText(QString("%1").arg(country.toUpper()));
     } else {
         countryLabel2.setText("");
         countryLabel3.setText("");
@@ -106,6 +108,7 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
 
     userLevelLabel2.setPixmap(
         UserLevelPixmapGenerator::generatePixmap(15, userLevel, false, QString::fromStdString(user.privlevel())));
+    userLevelLabel2.setAlignment(Qt::AlignCenter);
     QString userLevelText;
     if (userLevel.testFlag(ServerInfo_User::IsAdmin))
         userLevelText = tr("Administrator");

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -49,7 +49,7 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *paren
     mainLayout->addWidget(&userLevelLabel2, 5, 1, 1, 1);
     mainLayout->addWidget(&userLevelLabel3, 5, 2, 1, 1);
     mainLayout->addWidget(&accountAgeLabel1, 6, 0, 1, 1);
-    mainLayout->addWidget(&accountAgeLabel2, 6, 2, 1, 1);
+    mainLayout->addWidget(&accountAgeLabel2, 6, 1, 1, 2);
     mainLayout->setColumnStretch(2, 10);
 
     if (editable) {

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -98,7 +98,6 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
 
     if (country.length() != 0) {
         countryLabel2.setPixmap(CountryPixmapGenerator::generatePixmap(15, country));
-        // TODO have some extra width here to not clue the coutnry code right to the flag icon
         countryLabel2.setAlignment(Qt::AlignCenter);
         countryLabel3.setText(QString("%1").arg(country.toUpper()));
     } else {

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -98,7 +98,7 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
 
     if (country.length() != 0) {
         countryLabel2.setPixmap(CountryPixmapGenerator::generatePixmap(15, country));
-        //TODO have some extra width here to not clue the coutnry code right to the flag icon
+        // TODO have some extra width here to not clue the coutnry code right to the flag icon
         countryLabel2.setAlignment(Qt::AlignCenter);
         countryLabel3.setText(QString("%1").arg(country.toUpper()));
     } else {

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -49,7 +49,7 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *paren
     mainLayout->addWidget(&userLevelLabel2, 5, 1, 1, 1);
     mainLayout->addWidget(&userLevelLabel3, 5, 2, 1, 1);
     mainLayout->addWidget(&accountAgeLabel1, 6, 0, 1, 1);
-    mainLayout->addWidget(&accountAgeLabel2, 6, 1, 1, 2);
+    mainLayout->addWidget(&accountAgeLabel2, 6, 2, 1, 1);
     mainLayout->setColumnStretch(2, 10);
 
     if (editable) {

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -67,8 +67,6 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *paren
     setWindowTitle(tr("User Information"));
     setLayout(mainLayout);
     retranslateUi();
-    setFixedHeight(sizeHint().height());
-    setFixedWidth(sizeHint().width());
 }
 
 void UserInfoBox::retranslateUi()

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -98,7 +98,7 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
 
     if (country.length() != 0) {
         countryLabel2.setPixmap(CountryPixmapGenerator::generatePixmap(15, country));
-		//TODO have some extra width here to not clue the coutnry code right to the flag icon
+        //TODO have some extra width here to not clue the coutnry code right to the flag icon
         countryLabel2.setAlignment(Qt::AlignCenter);
         countryLabel3.setText(QString("%1").arg(country.toUpper()));
     } else {

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -43,7 +43,7 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *paren
     mainLayout->addWidget(&realNameLabel1, 2, 0, 1, 1);
     mainLayout->addWidget(&realNameLabel2, 2, 1, 1, 2);
     mainLayout->addWidget(&countryLabel1, 4, 0, 1, 1);
-    mainLayout->addWidget(&countryLabel2, 4, 1, 1, 2);
+    mainLayout->addWidget(&countryLabel2, 4, 1, 1, 1);
     mainLayout->addWidget(&countryLabel3, 4, 2, 1, 1);
     mainLayout->addWidget(&userLevelLabel1, 5, 0, 1, 1);
     mainLayout->addWidget(&userLevelLabel2, 5, 1, 1, 1);

--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -43,7 +43,7 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *paren
     mainLayout->addWidget(&realNameLabel1, 2, 0, 1, 1);
     mainLayout->addWidget(&realNameLabel2, 2, 1, 1, 2);
     mainLayout->addWidget(&countryLabel1, 4, 0, 1, 1);
-    mainLayout->addWidget(&countryLabel2, 4, 1, 1, 1);
+    mainLayout->addWidget(&countryLabel2, 4, 1, 1, 1, Qt::AlignCenter);
     mainLayout->addWidget(&countryLabel3, 4, 2, 1, 1);
     mainLayout->addWidget(&userLevelLabel1, 5, 0, 1, 1);
     mainLayout->addWidget(&userLevelLabel2, 5, 1, 1, 1);
@@ -67,6 +67,8 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *paren
     setWindowTitle(tr("User Information"));
     setLayout(mainLayout);
     retranslateUi();
+    setFixedHeight(sizeHint().height());
+    setFixedWidth(sizeHint().width());
 }
 
 void UserInfoBox::retranslateUi()
@@ -98,7 +100,6 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
 
     if (country.length() != 0) {
         countryLabel2.setPixmap(CountryPixmapGenerator::generatePixmap(15, country));
-        countryLabel2.setAlignment(Qt::AlignCenter);
         countryLabel3.setText(QString("%1").arg(country.toUpper()));
     } else {
         countryLabel2.setText("");


### PR DESCRIPTION
## Short roundup of the initial problem
User information is not displayed very pretty.

## What will change with this Pull Request?
- Align account age to the front, same as name
- Uniform capitalization
- Center icons
- Have little spacing between flag and country code

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
- before:
![before](https://user-images.githubusercontent.com/9874850/149623381-72f3b204-bda4-4c58-9d7a-2abb8360b124.png)

- after:
![after](https://user-images.githubusercontent.com/9874850/149626478-6498f5b1-b4ef-4357-9992-c6609a6c4f8a.png)

