### PR TITLE
implement custom protobuf debug string creation

### DIFF
--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -388,7 +388,7 @@ void RemoteClient::readData()
         ServerMessage newServerMessage;
         newServerMessage.ParseFromArray(inputBuffer.data(), messageLength);
 #ifdef QT_DEBUG
-        qDebug() << "IN" << getSafeDebugString(newServerMessage);
+        qDebug().noquote() << "IN" << getSafeDebugString(newServerMessage);
 #endif
         inputBuffer.remove(0, messageLength);
         messageInProgress = false;
@@ -406,7 +406,7 @@ void RemoteClient::websocketMessageReceived(const QByteArray &message)
     ServerMessage newServerMessage;
     newServerMessage.ParseFromArray(message.data(), message.length());
 #ifdef QT_DEBUG
-    qDebug() << "IN" << getSafeDebugString(newServerMessage);
+    qDebug().noquote() << "IN" << getSafeDebugString(newServerMessage);
 #endif
     processProtocolItem(newServerMessage);
 }
@@ -419,7 +419,7 @@ void RemoteClient::sendCommandContainer(const CommandContainer &cont)
     auto size = static_cast<unsigned int>(cont.ByteSize());
 #endif
 #ifdef QT_DEBUG
-    qDebug() << "OUT" << getSafeDebugString(cont);
+    qDebug().noquote() << "OUT" << getSafeDebugString(cont);
 #endif
 
     QByteArray buf;

--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -1,5 +1,6 @@
 #include "remoteclient.h"
 
+#include "debug_pb_message.h"
 #include "main.h"
 #include "passwordhasher.h"
 #include "pb/event_server_identification.pb.h"
@@ -387,7 +388,7 @@ void RemoteClient::readData()
         ServerMessage newServerMessage;
         newServerMessage.ParseFromArray(inputBuffer.data(), messageLength);
 #ifdef QT_DEBUG
-        qDebug() << "IN" << messageLength << QString::fromStdString(newServerMessage.ShortDebugString());
+        qDebug() << "IN" << getSafeDebugString(newServerMessage);
 #endif
         inputBuffer.remove(0, messageLength);
         messageInProgress = false;
@@ -405,7 +406,7 @@ void RemoteClient::websocketMessageReceived(const QByteArray &message)
     ServerMessage newServerMessage;
     newServerMessage.ParseFromArray(message.data(), message.length());
 #ifdef QT_DEBUG
-    qDebug() << "IN" << messageLength << QString::fromStdString(newServerMessage.ShortDebugString());
+    qDebug() << "IN" << getSafeDebugString(newServerMessage);
 #endif
     processProtocolItem(newServerMessage);
 }
@@ -418,7 +419,7 @@ void RemoteClient::sendCommandContainer(const CommandContainer &cont)
     auto size = static_cast<unsigned int>(cont.ByteSize());
 #endif
 #ifdef QT_DEBUG
-    qDebug() << "OUT" << size << QString::fromStdString(cont.ShortDebugString());
+    qDebug() << "OUT" << getSafeDebugString(cont);
 #endif
 
     QByteArray buf;

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -5,6 +5,7 @@
 add_subdirectory(pb)
 
 SET(common_SOURCES
+    debug_pb_message.cpp
     decklist.cpp
     expression.cpp
     featureset.cpp

--- a/common/debug_pb_message.cpp
+++ b/common/debug_pb_message.cpp
@@ -6,8 +6,16 @@
 #include <QString>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/message.h>
-#include <google/protobuf/stubs/strutil.h>
 #include <google/protobuf/text_format.h>
+
+// google/protobuf/stubs/strutil.h is missing on some systems!
+namespace google
+{
+namespace protobuf
+{
+std::string CEscape(const std::string &src);
+} // namespace protobuf
+} // namespace google
 
 // FastFieldValuePrinter is added in protobuf 3.4, going out of our way to add the old FieldValuePrinter is not worth it
 #if GOOGLE_PROTOBUF_VERSION > 3004000
@@ -36,10 +44,8 @@ void LimitedPrinter::PrintString(const std::string &val,
 {
     auto length = val.length();
     if (length > MAX_TEXT_LENGTH) {
-        std::string escaped;
-        ::google::protobuf::CEscapeAndAppend(::google::protobuf::CEscape(val.substr(0, MAX_NAME_LENGTH)), &escaped);
-        generator->PrintString("\"" + escaped + "... ---snip--- (" + ::google::protobuf::StrCat(length) +
-                               " bytes total) \"");
+        generator->PrintString("\"" + ::google::protobuf::CEscape(val.substr(0, MAX_NAME_LENGTH)) + "... ---snip--- (" +
+                               std::to_string(length) + " bytes total) \"");
     } else {
         ::google::protobuf::TextFormat::FastFieldValuePrinter::PrintString(val, generator);
     }

--- a/common/debug_pb_message.cpp
+++ b/common/debug_pb_message.cpp
@@ -1,0 +1,97 @@
+#include "debug_pb_message.h"
+
+#include "stringsizes.h"
+
+#include <QList>
+#include <QString>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/message.h>
+#include <google/protobuf/text_format.h>
+
+// value printer to use for all values, will snip too long contents
+class LimitedPrinter : public ::google::protobuf::TextFormat::FastFieldValuePrinter
+{
+public:
+    void PrintString(const std::string &val,
+                     ::google::protobuf::TextFormat::BaseTextGenerator *generator) const override;
+};
+
+// value printer to use for specifc values, will expunge sensitive info
+class SafePrinter : public ::google::protobuf::TextFormat::FastFieldValuePrinter
+{
+public:
+    void PrintString(const std::string &val,
+                     ::google::protobuf::TextFormat::BaseTextGenerator *generator) const override;
+
+    static void applySafePrinter(const ::google::protobuf::Message &message,
+                                 ::google::protobuf::TextFormat::Printer &printer);
+};
+
+void LimitedPrinter::PrintString(const std::string &val,
+                                 ::google::protobuf::TextFormat::BaseTextGenerator *generator) const
+{
+    auto length = val.length();
+    if (length > MAX_TEXT_LENGTH) {
+        generator->PrintString("\"" + ::google::protobuf::CEscape(val.substr(0, MAX_NAME_LENGTH)) + "... ---snip--- (" +
+                               ::google::protobuf::StrCat(length) + " bytes total) \"");
+    } else {
+        ::google::protobuf::TextFormat::FastFieldValuePrinter::PrintString(val, generator);
+    }
+}
+
+void SafePrinter::PrintString(const std::string & /*val*/,
+                              ::google::protobuf::TextFormat::BaseTextGenerator *generator) const
+{
+    generator->PrintLiteral("\" ---value expunged--- \"");
+}
+
+void SafePrinter::applySafePrinter(const ::google::protobuf::Message &message,
+                                   ::google::protobuf::TextFormat::Printer &printer)
+{
+    const auto *reflection = message.GetReflection();
+    std::vector<const google::protobuf::FieldDescriptor *> fields;
+    reflection->ListFields(message, &fields);
+    for (const auto *field : fields) {
+        switch (field->cpp_type()) {
+            case ::google::protobuf::FieldDescriptor::CPPTYPE_STRING:
+                if (field->name().find("password") != std::string::npos) { // name contains password
+                    auto *safePrinter = new SafePrinter();
+                    if (!printer.RegisterFieldValuePrinter(field, safePrinter))
+                        delete safePrinter; // in case safePrinter has not been taken ownership of
+                }
+                break;
+            case google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE:
+                if (field->is_repeated()) {
+                    for (int i = 0; i < reflection->FieldSize(message, field); ++i) {
+                        applySafePrinter(reflection->GetRepeatedMessage(message, field, i), printer);
+                    }
+                } else {
+                    applySafePrinter(reflection->GetMessage(message, field), printer);
+                }
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+QString getSafeDebugString(const ::google::protobuf::Message &message)
+{
+#if GOOGLE_PROTOBUF_VERSION > 3001000
+    auto size = message.ByteSizeLong();
+#else
+    auto size = message.ByteSize();
+#endif
+
+    ::google::protobuf::TextFormat::Printer printer;
+    printer.SetSingleLineMode(true); // compact mode
+    printer.SetExpandAny(true);      // prints all fields
+    // printer takes ownership of the LimitedPrinter and will delete it
+    printer.SetDefaultFieldValuePrinter(new LimitedPrinter());
+    // check field names an create SafePrinters for necessary fields
+    SafePrinter::applySafePrinter(message, printer);
+
+    std::string debug_string;
+    printer.PrintToString(message, &debug_string);
+    return QString::number(size) + " bytes " + QString::fromStdString(debug_string);
+}

--- a/common/debug_pb_message.cpp
+++ b/common/debug_pb_message.cpp
@@ -8,6 +8,9 @@
 #include <google/protobuf/message.h>
 #include <google/protobuf/text_format.h>
 
+// FastFieldValuePrinter is added in protobuf 3.4, going out of our way to add the old FieldValuePrinter is not worth it
+#if GOOGLE_PROTOBUF_VERSION > 3004000
+
 // value printer to use for all values, will snip too long contents
 class LimitedPrinter : public ::google::protobuf::TextFormat::FastFieldValuePrinter
 {
@@ -32,8 +35,10 @@ void LimitedPrinter::PrintString(const std::string &val,
 {
     auto length = val.length();
     if (length > MAX_TEXT_LENGTH) {
-        generator->PrintString("\"" + ::google::protobuf::CEscape(val.substr(0, MAX_NAME_LENGTH)) + "... ---snip--- (" +
-                               ::google::protobuf::StrCat(length) + " bytes total) \"");
+        std::string escaped;
+        ::google::protobuf::CEscapeAndAppend(::google::protobuf::CEscape(val.substr(0, MAX_NAME_LENGTH)), &escaped);
+        generator->PrintString("\"" + escaped + "... ---snip--- (" + ::google::protobuf::StrCat(length) +
+                               " bytes total) \"");
     } else {
         ::google::protobuf::TextFormat::FastFieldValuePrinter::PrintString(val, generator);
     }
@@ -74,6 +79,7 @@ void SafePrinter::applySafePrinter(const ::google::protobuf::Message &message,
         }
     }
 }
+#endif // GOOGLE_PROTOBUF_VERSION > 3004000
 
 QString getSafeDebugString(const ::google::protobuf::Message &message)
 {
@@ -86,10 +92,16 @@ QString getSafeDebugString(const ::google::protobuf::Message &message)
     ::google::protobuf::TextFormat::Printer printer;
     printer.SetSingleLineMode(true); // compact mode
     printer.SetExpandAny(true);      // prints all fields
+
+#if GOOGLE_PROTOBUF_VERSION > 3004000
     // printer takes ownership of the LimitedPrinter and will delete it
     printer.SetDefaultFieldValuePrinter(new LimitedPrinter());
     // check field names an create SafePrinters for necessary fields
     SafePrinter::applySafePrinter(message, printer);
+#else
+    // removing passwords from debug output will only be supported on newer protobuf versions
+    printer.SetTruncateStringFieldLongerThan(MAX_TEXT_LENGTH);
+#endif // GOOGLE_PROTOBUF_VERSION > 3004000
 
     std::string debug_string;
     printer.PrintToString(message, &debug_string);

--- a/common/debug_pb_message.cpp
+++ b/common/debug_pb_message.cpp
@@ -6,6 +6,7 @@
 #include <QString>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/message.h>
+#include <google/protobuf/stubs/strutil.h>
 #include <google/protobuf/text_format.h>
 
 // FastFieldValuePrinter is added in protobuf 3.4, going out of our way to add the old FieldValuePrinter is not worth it

--- a/common/debug_pb_message.h
+++ b/common/debug_pb_message.h
@@ -1,0 +1,15 @@
+#ifndef DEBUG_PB_MESSAGE_H
+#define DEBUG_PB_MESSAGE_H
+
+class QString;
+namespace google
+{
+namespace protobuf
+{
+class Message;
+}
+} // namespace google
+
+QString getSafeDebugString(const ::google::protobuf::Message &message);
+
+#endif // DEBUG_PB_MESSAGE_H

--- a/common/server.cpp
+++ b/common/server.cpp
@@ -19,6 +19,7 @@
  ***************************************************************************/
 #include "server.h"
 
+#include "debug_pb_message.h"
 #include "featureset.h"
 #include "pb/event_connection_closed.pb.h"
 #include "pb/event_list_rooms.pb.h"
@@ -486,7 +487,7 @@ void Server::externalGameCommandContainerReceived(const CommandContainer &cont,
         GameEventStorage ges;
         for (int i = cont.game_command_size() - 1; i >= 0; --i) {
             const GameCommand &sc = cont.game_command(i);
-            qDebug() << "[ISL]" << QString::fromStdString(sc.ShortDebugString());
+            qDebug() << "[ISL]" << getSafeDebugString(sc);
 
             Response::ResponseCode resp = player->processGameCommand(sc, responseContainer, ges);
 

--- a/servatrice/src/isl_interface.cpp
+++ b/servatrice/src/isl_interface.cpp
@@ -1,5 +1,6 @@
 #include "isl_interface.h"
 
+#include "debug_pb_message.h"
 #include "get_pb_extension.h"
 #include "main.h"
 #include "pb/event_game_joined.pb.h"
@@ -437,7 +438,7 @@ void IslInterface::processRoomCommand(const CommandContainer &cont, qint64 sessi
 
 void IslInterface::processMessage(const IslMessage &item)
 {
-    qDebug() << QString::fromStdString(item.DebugString());
+    qDebug() << getSafeDebugString(item);
 
     switch (item.message_type()) {
         case IslMessage::ROOM_COMMAND_CONTAINER: {

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -104,7 +104,7 @@ Servatrice_ConnectionPool *Servatrice_GameServer::findLeastUsedConnectionPool()
         }
         debugStr.append(QString::number(clientCount));
     }
-    qDebug() << "Pool utilisation:" << debugStr;
+    qDebug().noquote() << "Pool utilisation:" << debugStr.join(", ");
     return connectionPools[poolIndex];
 }
 
@@ -176,7 +176,7 @@ Servatrice_ConnectionPool *Servatrice_WebsocketGameServer::findLeastUsedConnecti
         }
         debugStr.append(QString::number(clientCount));
     }
-    qDebug() << "Pool utilisation:" << debugStr;
+    qDebug().noquote() << "Pool utilisation:" << debugStr.join(", ");
     return connectionPools[poolIndex];
 }
 
@@ -241,18 +241,18 @@ bool Servatrice::initServer()
         authenticationMethod = AuthenticationNone;
     }
 
-    qDebug() << "Store Replays: " << getStoreReplaysEnabled();
-    qDebug() << "Client ID Required: " << getClientIDRequiredEnabled();
-    qDebug() << "Maximum user limit enabled: " << getMaxUserLimitEnabled();
+    qDebug() << "Store Replays:" << getStoreReplaysEnabled();
+    qDebug() << "Client ID Required:" << getClientIDRequiredEnabled();
+    qDebug() << "Maximum user limit enabled:" << getMaxUserLimitEnabled();
 
     if (getMaxUserLimitEnabled()) {
-        qDebug() << "Maximum total user limit: " << getMaxUserTotal();
-        qDebug() << "Maximum tcp user limit: " << getMaxTcpUserLimit();
-        qDebug() << "Maximum websocket user limit: " << getMaxWebSocketUserLimit();
+        qDebug() << "Maximum total user limit:" << getMaxUserTotal();
+        qDebug() << "Maximum tcp user limit:" << getMaxTcpUserLimit();
+        qDebug() << "Maximum websocket user limit:" << getMaxWebSocketUserLimit();
     }
 
-    qDebug() << "Accept registered users only: " << getRegOnlyServerEnabled();
-    qDebug() << "Registration enabled: " << getRegistrationEnabled();
+    qDebug() << "Accept registered users only:" << getRegOnlyServerEnabled();
+    qDebug() << "Registration enabled:" << getRegistrationEnabled();
     if (getRegistrationEnabled()) {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         QStringList emailBlackListFilters = getEmailBlackList().split(",", Qt::SkipEmptyParts);
@@ -261,32 +261,32 @@ bool Servatrice::initServer()
         QStringList emailBlackListFilters = getEmailBlackList().split(",", QString::SkipEmptyParts);
         QStringList emailWhiteListFilters = getEmailWhiteList().split(",", QString::SkipEmptyParts);
 #endif
-        qDebug() << "Email blacklist: " << emailBlackListFilters;
-        qDebug() << "Email whitelist: " << emailWhiteListFilters;
-        qDebug() << "Require email address to register: " << getRequireEmailForRegistrationEnabled();
-        qDebug() << "Require email activation via token: " << getRequireEmailActivationEnabled();
+        qDebug() << "Email blacklist:" << emailBlackListFilters;
+        qDebug() << "Email whitelist:" << emailWhiteListFilters;
+        qDebug() << "Require email address to register:" << getRequireEmailForRegistrationEnabled();
+        qDebug() << "Require email activation via token:" << getRequireEmailActivationEnabled();
         if (getMaxAccountsPerEmail()) {
-            qDebug() << "Maximum number of accounts per email: " << getMaxAccountsPerEmail();
+            qDebug() << "Maximum number of accounts per email:" << getMaxAccountsPerEmail();
         } else {
             qDebug() << "Maximum number of accounts per email: unlimited";
         }
-        qDebug() << "Enable Internal SMTP Client: " << getEnableInternalSMTPClient();
+        qDebug() << "Enable Internal SMTP Client:" << getEnableInternalSMTPClient();
         if (!getEnableInternalSMTPClient()) {
             qDebug() << "WARNING: Registrations are enabled but internal SMTP client is disabled.  Users activation "
                         "emails will not be automatically mailed to users!";
         }
     }
 
-    qDebug() << "Reset password enabled: " << getEnableForgotPassword();
+    qDebug() << "Reset password enabled:" << getEnableForgotPassword();
     if (getEnableForgotPassword()) {
-        qDebug() << "Reset password token life (in minutes): " << getForgotPasswordTokenLife();
-        qDebug() << "Reset password challenge on: " << getEnableForgotPasswordChallenge();
+        qDebug() << "Reset password token life (in minutes):" << getForgotPasswordTokenLife();
+        qDebug() << "Reset password challenge on:" << getEnableForgotPasswordChallenge();
     }
 
-    qDebug() << "Auditing enabled: " << getEnableAudit();
+    qDebug() << "Auditing enabled:" << getEnableAudit();
     if (getEnableAudit()) {
-        qDebug() << "Audit registration attempts enabled: " << getEnableRegistrationAudit();
-        qDebug() << "Audit reset password attepts enabled: " << getEnableForgotPasswordAudit();
+        qDebug() << "Audit registration attempts enabled:" << getEnableRegistrationAudit();
+        qDebug() << "Audit reset password attepts enabled:" << getEnableForgotPasswordAudit();
     }
 
     if (getDBTypeString() == "mysql") {
@@ -423,7 +423,7 @@ bool Servatrice::initServer()
     statusUpdateClock = new QTimer(this);
     connect(statusUpdateClock, SIGNAL(timeout()), this, SLOT(statusUpdate()));
     if (getServerStatusUpdateTime() != 0) {
-        qDebug() << "Starting status update clock, interval " << getServerStatusUpdateTime() << " ms";
+        qDebug() << "Starting status update clock, interval" << getServerStatusUpdateTime() << "ms";
         statusUpdateClock->start(getServerStatusUpdateTime());
     }
 
@@ -459,7 +459,7 @@ bool Servatrice::initServer()
     }
 
     if (getIdleClientTimeout() > 0) {
-        qDebug() << "Idle client timeout value: " << getIdleClientTimeout();
+        qDebug() << "Idle client timeout value:" << getIdleClientTimeout();
         if (getIdleClientTimeout() < 300)
             qDebug() << "WARNING: It is not recommended to set the IdleClientTimeout value very low.  Doing so will "
                         "cause clients to very quickly be disconnected.  Many players when connected may be searching "
@@ -573,7 +573,7 @@ void Servatrice::setRequiredFeatures(const QString featureList)
         foreach (QString reqFeature, listReqFeatures)
             features.enableRequiredFeature(serverRequiredFeatureList, reqFeature);
 
-    qDebug() << "Set required client features to: " << serverRequiredFeatureList;
+    qDebug() << "Set required client features to:" << serverRequiredFeatureList;
 }
 
 void Servatrice::statusUpdate()

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -56,7 +56,7 @@ bool Servatrice_DatabaseInterface::openDatabase()
         sqlDatabase.close();
 
     const QString poolStr = instanceId == -1 ? QString("main") : QString("pool %1").arg(instanceId);
-    qDebug() << QString("[%1] Opening database...").arg(poolStr);
+    qDebug().noquote() << QString("[%1] Opening database...").arg(poolStr);
     if (!sqlDatabase.open()) {
         qCritical() << QString("[%1] Error opening database: %2").arg(poolStr).arg(sqlDatabase.lastError().text());
         return false;

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -1047,7 +1047,7 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
 {
     QString userName = nameFromStdString(cmd.user_name());
     QString clientId = nameFromStdString(cmd.clientid());
-    qDebug() << "Got register command: " << userName;
+    qDebug() << "Got register command for user:" << userName;
 
     bool registrationEnabled = settingsCache->value("registration/enabled", false).toBool();
     if (!registrationEnabled) {
@@ -1189,7 +1189,7 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
                                                    country, !requireEmailActivation);
 
     if (regSucceeded) {
-        qDebug() << "Accepted register command for user: " << userName;
+        qDebug() << "Accepted register command for user:" << userName;
         if (requireEmailActivation) {
             QSqlQuery *query =
                 sqlInterface->prepareQuery("insert into {prefix}_activation_emails (name) values(:name)");
@@ -1393,7 +1393,7 @@ Response::ResponseCode AbstractServerSocketInterface::cmdForgotPasswordRequest(c
     const QString userName = nameFromStdString(cmd.user_name());
     const QString clientId = nameFromStdString(cmd.clientid());
 
-    qDebug() << "Received reset password request from user: " << userName;
+    qDebug() << "Received reset password request from user:" << userName;
 
     if (!servatrice->getEnableForgotPassword()) {
         if (servatrice->getEnableForgotPasswordAudit())
@@ -1475,7 +1475,7 @@ Response::ResponseCode AbstractServerSocketInterface::cmdForgotPasswordReset(con
     Q_UNUSED(rc);
     QString userName = nameFromStdString(cmd.user_name());
     QString clientId = nameFromStdString(cmd.clientid());
-    qDebug() << "Received reset password reset from user: " << userName;
+    qDebug() << "Received reset password reset from user:" << userName;
 
     if (!sqlInterface->doesForgotPasswordExist(userName)) {
         if (servatrice->getEnableForgotPasswordAudit())
@@ -1526,7 +1526,7 @@ AbstractServerSocketInterface::cmdForgotPasswordChallenge(const Command_ForgotPa
     const QString userName = nameFromStdString(cmd.user_name());
     const QString clientId = nameFromStdString(cmd.clientid());
 
-    qDebug() << "Received reset password challenge from user: " << userName;
+    qDebug() << "Received reset password challenge from user:" << userName;
 
     if (!servatrice->getEnableForgotPasswordChallenge()) {
         if (servatrice->getEnableForgotPasswordAudit()) {


### PR DESCRIPTION
## Short roundup of the initial problem
cockatrice generates a lot of debug output, which is great, but some things should not be logged, namely passwords and lengthy pictures/decklists

## What will change with this Pull Request?
- creates function that uses protobuf's text format functionality to extend the normal logging with protective measures
- apply safe logger on all instances of getting a pb message debug string

## example log:
```
IN "62 bytes message_type: SESSION_EVENT session_event { [Event_ServerIdentification.ext] { server_name: \"Rooster Range\" server_version: \"2.8.1-custom(e845c95) (2021-12-27)\" protocol_version: 14 server_options: SupportsPasswordHash } } "
OUT "15 bytes cmd_id: 0 session_command { [Command_RequestPasswordSalt.ext] { user_name: \"ebbit\" } } "
IN "29 bytes message_type: RESPONSE response { cmd_id: 0 response_code: RespOk [Response_PasswordSalt.ext] { password_salt: \" ---value expunged--- \" } } "
OUT "352 bytes cmd_id: 1 session_command { [Command_Login.ext] { user_name: \"ebbit\" clientid: \"1cc5de561762aac\" clientver: \"2.8.1-beta.6 (2022-01-16)\" clientfeatures: \"2.7.0_min_version\" clientfeatures: \"2.8.0_min_version\" clientfeatures: \"client_id\" clientfeatures: \"client_ver\" clientfeatures: \"client_warnings\" clientfeatures: \"feature_set\" clientfeatures: \"forgot_password\" clientfeatures: \"idle_client\" clientfeatures: \"mod_log_lookup\" clientfeatures: \"room_chat_history\" clientfeatures: \"user_ban_history\" clientfeatures: \"websocket\" hashed_password: \" ---value expunged--- \" } } "
IN "2100 bytes message_type: RESPONSE response { cmd_id: 1 response_code: RespOk [Response_Login.ext] { user_info { name: \"ebbit\" user_level: 19 avatar_bmp: \"RIFF\\010\\005\\000\\000WEBPVP8X\\n\\000\\000\\0000\\000\\000\\000\\233\\000\\000;\\000\\000ICCPL\\002\\000\\000\\000\\000\\002Llcms\\0040\\000\\000mntrRGB XYZ \\007\\345\\000\\003\\000\\005\\000\\004\\000\\000\\000\\nacspAPPL\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\366\\326\\000\\001\\000\\000\\000\\000... ---snip--- (65535 bytes total) \" accountage_secs: 179313183 privlevel: \"VIP\" } } "

OUT "128 bytes cmd_id: 12 session_command { [Command_AccountPassword.ext] { old_password: \" ---value expunged--- \" hashed_new_password: \" ---value expunged--- \" } } "
IN "8 bytes message_type: RESPONSE response { cmd_id: 12 response_code: RespPasswordTooShort } "