### PR TITLE
CI: Run checks on all PR's

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -11,8 +11,6 @@ on:
     tags:
       - '*'
   pull_request:
-    branches:
-      - master
     paths-ignore:
       - '**.md'
       - 'webclient/**'

--- a/.github/workflows/desktop-lint.yml
+++ b/.github/workflows/desktop-lint.yml
@@ -2,8 +2,6 @@ name: Code Style (C++)
 
 on:
   pull_request:
-    branches:
-    - master
     paths-ignore:
       - '**.md'
       - 'webclient/**'

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -9,8 +9,6 @@ on:
       - 'webclient/**'
       - '!**.md'
   pull_request:
-    branches:
-      - master
     paths:
       - '.github/workflows/web-*.yml'
       - 'webclient/**'

--- a/.github/workflows/web-lint.yml
+++ b/.github/workflows/web-lint.yml
@@ -2,8 +2,6 @@ name: Code Style (TypeScript)
 
 on:
   pull_request:
-    branches:
-    - master
     paths:
       - '.github/workflows/web-*.yml'
       - 'webclient/**'


### PR DESCRIPTION
## Short roundup of the initial problem
GitHub Actions did only run when a PR was created against master.
Sub-PR's that expanded other still ongoing PR's and therefore did not target master were not checked.

## What will change with this Pull Request?
- Remove limitation to branch=master for PR's. The limitation for pushes stays unchanged.