### PR TITLE
Webclient: Update script

### DIFF
--- a/webclient/package.json
+++ b/webclient/package.json
@@ -36,7 +36,7 @@
     "postinstall:windows": "powershell .\\copy_shared_files.ps1",
     "postinstall:default": "./copy_shared_files.sh",
     "start": "cross-env ESLINT_NO_DEV_ERRORS=true react-scripts start",
-    "build": "react-scripts build",
+    "build": "cross-env DISABLE_ESLINT_PLUGIN=true react-scripts build",
     "test": "cross-env CI=true react-scripts test",
     "test:watch": "react-scripts test",
     "eject": "react-scripts eject",

--- a/webclient/src/websocket/utils/passwordHasher.ts
+++ b/webclient/src/websocket/utils/passwordHasher.ts
@@ -22,7 +22,7 @@ export const generateSalt = (): string => {
     salt += characters.charAt(Math.floor(Math.random() * characters.length));
   }
 
-  return salt;
+	  return salt;
 }
 
 export const passwordSaltSupported = (serverOptions, webClient): number => {

--- a/webclient/src/websocket/utils/passwordHasher.ts
+++ b/webclient/src/websocket/utils/passwordHasher.ts
@@ -22,7 +22,7 @@ export const generateSalt = (): string => {
     salt += characters.charAt(Math.floor(Math.random() * characters.length));
   }
 
-	  return salt;
+  return salt;
 }
 
 export const passwordSaltSupported = (serverOptions, webClient): number => {


### PR DESCRIPTION
## Short roundup of the initial problem
Every tiny linting errors did break production builds, even though the code itself would work perfectly as seen in #4549 ([Example](https://github.com/Cockatrice/Cockatrice/runs/4999739208?check_suite_focus=true)).
We have a dedicated test for linting mistakes to ensure a uniform style. Every PR is checked for it and reveals its result independently.

## What will change with this Pull Request?
- Do not check for linting when building for production
  Use `DISABLE_ESLINT_PLUGIN`, see https://create-react-app.dev/docs/advanced-configuration/
  There are several discussions about the changed behavior with `react-scripts` v4 regarding eslint in the facebook/create-react-app repo before they introduced this flag.
- Do not break `build` script on tiny linting mistakes and focus on the code instead

This results in the checks done in CI to better reflect what is causing the error and if the proposed code change builds at all.
An dedicated ESLint check is still performed.