### PR TITLE
Webclient: Add Toasts component and show on known host CUD operations

### DIFF
--- a/webclient/package-lock.json
+++ b/webclient/package-lock.json
@@ -1856,6 +1856,18 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.60",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.60.tgz",
+      "integrity": "sha512-fadlYsPJF+0fx2lRuyqAuJj7hAS1tLDdIEEdov5jlrpb5pp4b+mRDUqQTUxi4inRZHS1bEXpU8QWUhO6xX88aA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.11.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.11.4",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.4.tgz",

--- a/webclient/package.json
+++ b/webclient/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "^4.0.0-alpha.60",
     "@material-ui/styles": "^4.11.4",
     "crypto-js": "^4.1.1",
     "dexie": "^3.0.3",

--- a/webclient/src/components/KnownHosts/KnownHosts.tsx
+++ b/webclient/src/components/KnownHosts/KnownHosts.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Select, MenuItem } from '@material-ui/core';
 import Button from '@material-ui/core/Button';
 import FormControl from '@material-ui/core/FormControl';
@@ -14,6 +13,7 @@ import ErrorOutlinedIcon from '@material-ui/icons/ErrorOutlined';
 import { KnownHostDialog } from 'dialogs';
 import { HostDTO } from 'services';
 import { DefaultHosts, Host, getHostPort } from 'types';
+import Toast from 'components/Toast/Toast';
 
 import './KnownHosts.css';
 
@@ -43,6 +43,10 @@ const KnownHosts = (props) => {
     open: false,
     edit: null,
   });
+
+  const [showCreateToast, setShowCreateToast] = useState(false)
+  const [showDeleteToast, setShowDeleteToast] = useState(false)
+  const [showEditToast, setShowEditToast] = useState(false)
 
   const loadKnownHosts = useCallback(async () => {
     const hosts = await HostDTO.getAll();
@@ -96,6 +100,7 @@ const KnownHosts = (props) => {
 
     closeKnownHostDialog();
     HostDTO.delete(id);
+    setShowDeleteToast(true)
   };
 
   const handleDialogSubmit = async ({ id, name, host, port }) => {
@@ -111,6 +116,7 @@ const KnownHosts = (props) => {
         hosts: s.hosts.map(h => h.id === id ? hostDTO : h),
         selectedHost: hostDTO
       }));
+      setShowEditToast(true)
     } else {
       const newHost: Host = { name, host, port, editable: true };
       newHost.id = await HostDTO.add(newHost) as number;
@@ -120,6 +126,7 @@ const KnownHosts = (props) => {
         hosts: [...s.hosts, newHost],
         selectedHost: newHost,
       }));
+      setShowCreateToast(true)
     }
 
     closeKnownHostDialog();
@@ -206,6 +213,9 @@ const KnownHosts = (props) => {
         onSubmit={handleDialogSubmit}
         handleClose={closeKnownHostDialog}
       />
+      <Toast open={showCreateToast} onClose={() => setShowCreateToast(false)}>Host successfully created.</Toast>
+      <Toast open={showDeleteToast} onClose={() => setShowDeleteToast(false)}>Host successfully deleted.</Toast>
+      <Toast open={showEditToast} onClose={() => setShowEditToast(false)}>Host successfully edited.</Toast>
     </div>
   )
 };

--- a/webclient/src/components/Toast/Toast.tsx
+++ b/webclient/src/components/Toast/Toast.tsx
@@ -6,7 +6,6 @@ import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import Slide, { SlideProps } from '@material-ui/core/Slide';
 import Snackbar from '@material-ui/core/Snackbar';
 
-
 const iconMapping = {
   success: <CheckCircleIcon />
 }
@@ -62,6 +61,5 @@ Toast.defaultProps = {
 function TransitionLeft(props) {
   return <Slide {...props} direction="left" />;
 }
-
 
 export default Toast

--- a/webclient/src/components/Toast/Toast.tsx
+++ b/webclient/src/components/Toast/Toast.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react'
+import Snackbar from '@material-ui/core/Snackbar';
+import Alert, { AlertProps } from '@material-ui/lab/Alert';
+import ReactDOM from 'react-dom'
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+
+const iconMapping = {
+  success: <CheckCircleIcon />
+}
+
+function Toast(props) {
+  const { open, onClose, severity, autoHideDuration, children } = props
+
+  const rootElemRef = React.useRef(document.createElement('div'));
+
+  React.useEffect(() => {
+    document.body.appendChild(rootElemRef.current)
+    return () => {
+      rootElemRef.current.remove();
+    }
+  }, [rootElemRef])
+
+  const handleClose = (event?: React.SyntheticEvent, reason?: string) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+
+    onClose(event);
+  };
+  const node = (
+    <Snackbar open={open} autoHideDuration={autoHideDuration} onClose={handleClose}>
+      <Alert onClose={handleClose} severity={severity} iconMapping={iconMapping}>
+        {children}
+      </Alert>
+    </Snackbar>
+  )
+  if (!rootElemRef.current) {
+    return null
+  }
+
+  return ReactDOM.createPortal(
+    node,
+    rootElemRef.current
+  );
+}
+
+Toast.defaultProps = {
+  severity: 'success',
+  autoHideDuration: 6000,
+}
+
+export default Toast

--- a/webclient/src/components/Toast/Toast.tsx
+++ b/webclient/src/components/Toast/Toast.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react'
-import Snackbar from '@material-ui/core/Snackbar';
-import Alert, { AlertProps } from '@material-ui/lab/Alert';
 import ReactDOM from 'react-dom'
+
+import Alert, { AlertProps } from '@material-ui/lab/Alert';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import Slide, { SlideProps } from '@material-ui/core/Slide';
+import Snackbar from '@material-ui/core/Snackbar';
+
 
 const iconMapping = {
   success: <CheckCircleIcon />
@@ -24,11 +27,17 @@ function Toast(props) {
     if (reason === 'clickaway') {
       return;
     }
-
     onClose(event);
   };
+
   const node = (
-    <Snackbar open={open} autoHideDuration={autoHideDuration} onClose={handleClose}>
+    <Snackbar
+      open={open}
+      autoHideDuration={autoHideDuration}
+      onClose={handleClose}
+      TransitionComponent={TransitionLeft}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+    >
       <Alert onClose={handleClose} severity={severity} iconMapping={iconMapping}>
         {children}
       </Alert>
@@ -46,7 +55,13 @@ function Toast(props) {
 
 Toast.defaultProps = {
   severity: 'success',
-  autoHideDuration: 6000,
+  // 10s wait before automatically dismissing the Toast.
+  autoHideDuration: 10000,
 }
+
+function TransitionLeft(props) {
+  return <Slide {...props} direction="left" />;
+}
+
 
 export default Toast

--- a/webclient/src/containers/Login/Login.tsx
+++ b/webclient/src/containers/Login/Login.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line
-import React, { useState, useCallback } from "react";
+import { useState, useCallback } from 'react';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';


### PR DESCRIPTION
## Related Ticket(s)
[Show toast on add edit delete known host](https://trello.com/c/XX0OSp3e/16-show-toast-on-add-edit-delete-knownhost)

## Short roundup of the initial problem

When creating, updating, or deleting a know host there was no feedback provided to the user on success.  The modal simply closed and success was implied, but certainly not guaranteed.


## What will change with this Pull Request?
- Users will now see a success message when a known host is created, updated, or deleted.
- A new `<Toast>` component was added to the repo for all to use.

## Screenshots
![image of success Toast in bottom right corner](https://p193.p3.n0.cdn.getcloudapp.com/items/X6u8QvKl/004754c4-0931-45cc-9281-2a138ba0e9ef.jpg?source=viewer&v=0681343ac8c85ecbb4f3fc492b466933)
