### PR TITLE
Webatrice: Registration toasts

### DIFF
--- a/webclient/src/components/Toast/ToastContext.tsx
+++ b/webclient/src/components/Toast/ToastContext.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react'
+import { createContext, FC, ReactChild, ReactNode, useContext, useEffect, useReducer } from 'react'
 
 import { ACTIONS, initialState, reducer } from './reducer';
 import Toast from './Toast'
 
 interface Toast {
   isOpen: boolean,
-  children: React.ReactChild,
+  children: ReactChild,
 }
 
 interface ToastContext {
@@ -16,7 +16,7 @@ interface ToastContext {
     removeToast: (key) => void,
 }
 
-const ToastContext: any = React.createContext({
+const ToastContext: any = createContext({
   toasts: new Map(),
   addToast: (key, children) => {},
   openToast: (key) => {},
@@ -24,9 +24,9 @@ const ToastContext: any = React.createContext({
   removeToast: (key) => {},
 });
 
-const ToastProvider: React.FC<React.ReactNode> = (props) => {
+export const ToastProvider: FC<ReactNode> = (props) => {
   const { children } = props
-  const [state, dispatch] = React.useReducer(reducer, initialState)
+  const [state, dispatch] = useReducer(reducer, initialState)
   const providerState = {
     toasts: state.toasts,
     addToast: (key, children) => dispatch({ type: ACTIONS.ADD_TOAST, payload: { key, children } }),
@@ -51,10 +51,15 @@ const ToastProvider: React.FC<React.ReactNode> = (props) => {
   )
 }
 
-function useToast({ key, children }) {
-  const { addToast, openToast, closeToast, removeToast } = React.useContext(ToastContext)
+export interface ToastHookOptions {
+  key: string,
+  children: ReactNode
+}
 
-  React.useEffect(() => {
+export function useToast<ToastHookOptions>({ key, children }) {
+  const { addToast, openToast, closeToast, removeToast } = useContext(ToastContext)
+
+  useEffect(() => {
     addToast(key, children)
   }, [])
 
@@ -63,9 +68,4 @@ function useToast({ key, children }) {
     closeToast: () => closeToast(key),
     removeToast: () => removeToast(key),
   }
-}
-
-export {
-  ToastProvider,
-  useToast
 }

--- a/webclient/src/components/Toast/ToastContext.tsx
+++ b/webclient/src/components/Toast/ToastContext.tsx
@@ -52,7 +52,7 @@ const ToastProvider: React.FC<React.ReactNode> = (props) => {
 }
 
 function useToast({ key, children }) {
-  const { addToast, openToast, closeToast, removeToast, toasts } = React.useContext(ToastContext)
+  const { addToast, openToast, closeToast, removeToast } = React.useContext(ToastContext)
 
   React.useEffect(() => {
     addToast(key, children)

--- a/webclient/src/components/Toast/ToastContext.tsx
+++ b/webclient/src/components/Toast/ToastContext.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react'
+
+import { ACTIONS, initialState, reducer } from './reducer';
+import Toast from './Toast'
+
+interface Toast {
+  isOpen: boolean,
+  children: React.ReactChild,
+}
+
+interface ToastContext {
+    toasts: Toast[],
+    addToast: (key, children) => void,
+    openToast: (key) => void,
+    closeToast: (key) => void,
+    removeToast: (key) => void,
+}
+
+const ToastContext: any = React.createContext({
+  toasts: new Map(),
+  addToast: (key, children) => {},
+  openToast: (key) => {},
+  closeToast: (key) => {},
+  removeToast: (key) => {},
+});
+
+const ToastProvider: React.FC<React.ReactNode> = (props) => {
+  const { children } = props
+  const [state, dispatch] = React.useReducer(reducer, initialState)
+  const providerState = {
+    toasts: state.toasts,
+    addToast: (key, children) => dispatch({ type: ACTIONS.ADD_TOAST, payload: { key, children } }),
+    openToast: key => dispatch({ type: ACTIONS.OPEN_TOAST, payload: key }),
+    closeToast: key => dispatch({ type: ACTIONS.CLOSE_TOAST, payload: key }),
+    removeToast: key => dispatch({ type: ACTIONS.REMOVE_TOAST, payload: key }),
+  }
+  return (
+    <ToastContext.Provider value={providerState}>
+      {children}
+      <div>
+        {Array.from(state.toasts).map(([key, value]) => {
+          const { isOpen, children } = value;
+          return (
+            <Toast key={key} open={isOpen} onClose={() => dispatch({ type: ACTIONS.CLOSE_TOAST, payload: key })}>
+              {children}
+            </Toast>
+          )
+        })}
+      </div>
+    </ToastContext.Provider>
+  )
+}
+
+function useToast({ key, children }) {
+  const { addToast, openToast, closeToast, removeToast, toasts } = React.useContext(ToastContext)
+
+  React.useEffect(() => {
+    addToast(key, children)
+  }, [])
+
+  return {
+    openToast: () => openToast(key),
+    closeToast: () => closeToast(key),
+    removeToast: () => removeToast(key),
+  }
+}
+
+export {
+  ToastProvider,
+  useToast
+}

--- a/webclient/src/components/Toast/ToastContext.tsx
+++ b/webclient/src/components/Toast/ToastContext.tsx
@@ -1,23 +1,23 @@
-import { createContext, FC, ReactChild, ReactNode, useContext, useEffect, useReducer } from 'react'
+import { createContext, FC, ReactChild, ReactNode, useContext, useEffect, useReducer, ContextType, Context } from 'react'
 
 import { ACTIONS, initialState, reducer } from './reducer';
 import Toast from './Toast'
 
-interface Toast {
+interface ToastEntry {
   isOpen: boolean,
   children: ReactChild,
 }
 
-interface ToastContext {
-    toasts: Toast[],
+interface ToastState {
+    toasts: Map<string, ToastEntry>,
     addToast: (key, children) => void,
     openToast: (key) => void,
     closeToast: (key) => void,
     removeToast: (key) => void,
 }
 
-const ToastContext: any = createContext({
-  toasts: new Map(),
+const ToastContext: Context<any> = createContext<ToastState>({
+  toasts: new Map<string, ToastEntry>(),
   addToast: (key, children) => {},
   openToast: (key) => {},
   closeToast: (key) => {},

--- a/webclient/src/components/Toast/index.ts
+++ b/webclient/src/components/Toast/index.ts
@@ -1,0 +1,8 @@
+import { useToast, ToastProvider } from './ToastContext';
+import Toast from './Toast';
+
+export {
+  Toast as default,
+  useToast,
+  ToastProvider,
+}

--- a/webclient/src/components/Toast/reducer.ts
+++ b/webclient/src/components/Toast/reducer.ts
@@ -1,0 +1,48 @@
+export const ACTIONS = {
+  ADD_TOAST: 'ADD_TOAST',
+  OPEN_TOAST: 'OPEN_TOAST',
+  CLOSE_TOAST: 'CLOSE_TOAST',
+  REMOVE_TOAST: 'REMOVE_TOAST',
+}
+
+export const initialState = {
+  toasts: new Map()
+}
+
+export function reducer(state, action) {
+  const { type, payload } = action
+  switch (type) {
+    case ACTIONS.ADD_TOAST: {
+      const newState = { ...state }
+      newState.toasts = new Map(Array.from(state.toasts))
+      const { toasts } = newState;
+      const { key, children } = payload
+      toasts.set(key, { isOpen: false, children })
+      return newState
+    }
+    case ACTIONS.OPEN_TOAST: {
+      const newState = { ...state }
+      newState.toasts = new Map(Array.from(state.toasts))
+      const { toasts } = newState;
+      const toast = toasts.get(payload)
+      toasts.set(payload, { isOpen: true, children: toast.children })
+      return newState
+    }
+    case ACTIONS.CLOSE_TOAST: {
+      const newState = { ...state }
+      newState.toasts = new Map(Array.from(state.toasts))
+      const { toasts } = newState;
+      const toast = toasts.get(payload)
+      toasts.set(payload, { isOpen: false, children: toast.children })
+      return newState
+    }
+    case ACTIONS.REMOVE_TOAST: {
+      const newState = { ...state }
+      newState.toasts = new Map(Array.from(state.toasts))
+      newState.toasts.delete(payload)
+      return newState
+    }
+    default:
+      throw Error('Please pick an available action')
+  }
+}

--- a/webclient/src/containers/App/AppShell.tsx
+++ b/webclient/src/containers/App/AppShell.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line
-import React, { Component } from "react";
+import { Component } from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter as Router } from 'react-router-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
@@ -9,6 +8,8 @@ import Routes from './AppShellRoutes';
 import FeatureDetection from './FeatureDetection';
 
 import './AppShell.css';
+
+import { ToastProvider } from 'components/Toast'
 
 class AppShell extends Component {
   componentDidMount() {
@@ -23,15 +24,17 @@ class AppShell extends Component {
   render() {
     return (
       <Provider store={store}>
-        <CssBaseline />
-        <div className="AppShell" onContextMenu={this.handleContextMenu}>
-          <Router>
-            <Header />
+        <ToastProvider>
+          <CssBaseline />
+          <div className="AppShell" onContextMenu={this.handleContextMenu}>
+            <Router>
+              <Header />
 
-            <FeatureDetection />
-            <Routes />
-          </Router>
-        </div>
+              <FeatureDetection />
+              <Routes />
+            </Router>
+          </div>
+        </ToastProvider>
       </Provider>
     );
   }

--- a/webclient/src/containers/App/AppShell.tsx
+++ b/webclient/src/containers/App/AppShell.tsx
@@ -24,8 +24,8 @@ class AppShell extends Component {
   render() {
     return (
       <Provider store={store}>
+        <CssBaseline />
         <ToastProvider>
-          <CssBaseline />
           <div className="AppShell" onContextMenu={this.handleContextMenu}>
             <Router>
               <Header />

--- a/webclient/src/containers/Login/Login.tsx
+++ b/webclient/src/containers/Login/Login.tsx
@@ -17,6 +17,7 @@ import { RouteEnum, WebSocketConnectOptions, getHostPort } from 'types';
 import { ServerSelectors, ServerTypes } from 'store';
 
 import './Login.css';
+import { useToast } from 'components/Toast';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -68,6 +69,8 @@ const Login = ({ state, description }: LoginProps) => {
   });
   const [userToResetPassword, setUserToResetPassword] = useState(null);
 
+  const passwordResetToast = useToast({key: 'password-reset-success', children: 'Password Reset Successfully'})
+
   useReduxEffect(() => {
     closeRequestPasswordResetDialog();
     openResetPasswordDialog();
@@ -98,6 +101,10 @@ const Login = ({ state, description }: LoginProps) => {
       });
     }
   }, ServerTypes.LOGIN_SUCCESSFUL, [hostIdToRemember]);
+
+  useReduxEffect(() => {
+    passwordResetToast.openToast()
+  }, ServerTypes.RESET_PASSWORD_SUCCESS)
 
   const showDescription = () => {
     return !isConnected && description?.length;

--- a/webclient/src/containers/Login/Login.tsx
+++ b/webclient/src/containers/Login/Login.tsx
@@ -70,6 +70,7 @@ const Login = ({ state, description }: LoginProps) => {
   const [userToResetPassword, setUserToResetPassword] = useState(null);
 
   const passwordResetToast = useToast({key: 'password-reset-success', children: 'Password Reset Successfully'})
+  const accountActivatedToast = useToast({key: 'account-activation-success', children: 'Account Activated Successfully'})
 
   useReduxEffect(() => {
     closeRequestPasswordResetDialog();
@@ -77,10 +78,12 @@ const Login = ({ state, description }: LoginProps) => {
   }, ServerTypes.RESET_PASSWORD_REQUESTED, []);
 
   useReduxEffect(() => {
+    passwordResetToast.openToast()
     closeResetPasswordDialog();
   }, ServerTypes.RESET_PASSWORD_SUCCESS, []);
 
   useReduxEffect(() => {
+    accountActivatedToast.openToast()
     closeActivateAccountDialog();
   }, ServerTypes.ACCOUNT_ACTIVATION_SUCCESS, []);
 
@@ -101,10 +104,6 @@ const Login = ({ state, description }: LoginProps) => {
       });
     }
   }, ServerTypes.LOGIN_SUCCESSFUL, [hostIdToRemember]);
-
-  useReduxEffect(() => {
-    passwordResetToast.openToast()
-  }, ServerTypes.RESET_PASSWORD_SUCCESS)
 
   const showDescription = () => {
     return !isConnected && description?.length;

--- a/webclient/src/containers/Login/Login.tsx
+++ b/webclient/src/containers/Login/Login.tsx
@@ -69,8 +69,8 @@ const Login = ({ state, description }: LoginProps) => {
   });
   const [userToResetPassword, setUserToResetPassword] = useState(null);
 
-  const passwordResetToast = useToast({key: 'password-reset-success', children: 'Password Reset Successfully'})
-  const accountActivatedToast = useToast({key: 'account-activation-success', children: 'Account Activated Successfully'})
+  const passwordResetToast = useToast({ key: 'password-reset-success', children: 'Password Reset Successfully' })
+  const accountActivatedToast = useToast({ key: 'account-activation-success', children: 'Account Activated Successfully' })
 
   useReduxEffect(() => {
     closeRequestPasswordResetDialog();

--- a/webclient/src/forms/RegisterForm/RegisterForm.tsx
+++ b/webclient/src/forms/RegisterForm/RegisterForm.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line
-import React, { Component, useState } from 'react';
+import { useState } from 'react';
 import { connect } from 'react-redux';
 import { Form, Field } from 'react-final-form';
 import { OnChange } from 'react-final-form-listeners';
@@ -14,6 +13,7 @@ import { ServerTypes } from 'store';
 import { FormKey } from 'types';
 
 import './RegisterForm.css';
+import Toast from 'components/Toast/Toast';
 
 const RegisterForm = ({ onSubmit }: RegisterFormProps) => {
   const [emailRequired, setEmailRequired] = useState(false);
@@ -21,6 +21,7 @@ const RegisterForm = ({ onSubmit }: RegisterFormProps) => {
   const [emailError, setEmailError] = useState(null);
   const [passwordError, setPasswordError] = useState(null);
   const [userNameError, setUserNameError] = useState(null);
+  const [showRegSuccessToast, setShowRegSuccessToast] = useState(null)
 
   const onHostChange = (host) => setEmailRequired(false);
   const onEmailChange = () => emailError && setEmailError(null);
@@ -34,6 +35,10 @@ const RegisterForm = ({ onSubmit }: RegisterFormProps) => {
   useReduxEffect(({ error }) => {
     setError(error);
   }, ServerTypes.REGISTRATION_FAILED);
+
+  useReduxEffect(({ error }) => {
+    setShowRegSuccessToast(true)
+  }, ServerTypes.REGISTRATION_SUCCES);
 
   useReduxEffect(({ error }) => {
     setEmailError(error);
@@ -151,6 +156,9 @@ const RegisterForm = ({ onSubmit }: RegisterFormProps) => {
                 <Typography color="error">{error}</Typography>
               </div>
             )}
+            <Toast open={showRegSuccessToast}>
+              Registration Successful!
+            </Toast>
           </>
         );
       }}

--- a/webclient/src/forms/RegisterForm/RegisterForm.tsx
+++ b/webclient/src/forms/RegisterForm/RegisterForm.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { connect } from 'react-redux';
 import { Form, Field } from 'react-final-form';
 import { OnChange } from 'react-final-form-listeners';
 import setFieldTouched from 'final-form-set-field-touched'
@@ -10,10 +9,9 @@ import Typography from '@material-ui/core/Typography';
 import { CountryDropdown, InputField, KnownHosts } from 'components';
 import { useReduxEffect } from 'hooks';
 import { ServerTypes } from 'store';
-import { FormKey } from 'types';
 
 import './RegisterForm.css';
-import Toast from 'components/Toast/Toast';
+import { useToast } from 'components/Toast';
 
 const RegisterForm = ({ onSubmit }: RegisterFormProps) => {
   const [emailRequired, setEmailRequired] = useState(false);
@@ -21,7 +19,7 @@ const RegisterForm = ({ onSubmit }: RegisterFormProps) => {
   const [emailError, setEmailError] = useState(null);
   const [passwordError, setPasswordError] = useState(null);
   const [userNameError, setUserNameError] = useState(null);
-  const [showRegSuccessToast, setShowRegSuccessToast] = useState(null)
+  const { openToast } = useToast({ key: 'registration-success', children: 'Registration Successful!' })
 
   const onHostChange = (host) => setEmailRequired(false);
   const onEmailChange = () => emailError && setEmailError(null);
@@ -36,8 +34,8 @@ const RegisterForm = ({ onSubmit }: RegisterFormProps) => {
     setError(error);
   }, ServerTypes.REGISTRATION_FAILED);
 
-  useReduxEffect(({ error }) => {
-    setShowRegSuccessToast(true)
+  useReduxEffect(() => {
+    openToast()
   }, ServerTypes.REGISTRATION_SUCCES);
 
   useReduxEffect(({ error }) => {
@@ -156,9 +154,6 @@ const RegisterForm = ({ onSubmit }: RegisterFormProps) => {
                 <Typography color="error">{error}</Typography>
               </div>
             )}
-            <Toast open={showRegSuccessToast}>
-              Registration Successful!
-            </Toast>
           </>
         );
       }}

--- a/webclient/src/store/server/server.actions.ts
+++ b/webclient/src/store/server/server.actions.ts
@@ -86,6 +86,9 @@ export const Actions = {
   registrationRequiresEmail: () => ({
     type: Types.REGISTRATION_REQUIRES_EMAIL,
   }),
+  registrationSuccess: () => ({
+    type: Types.REGISTRATION_SUCCES,
+  }),
   registrationFailed: (error) => ({
     type: Types.REGISTRATION_FAILED,
     error

--- a/webclient/src/store/server/server.dispatch.ts
+++ b/webclient/src/store/server/server.dispatch.ts
@@ -77,6 +77,9 @@ export const Dispatch = {
   registrationRequiresEmail: () => {
     store.dispatch(Actions.registrationRequiresEmail());
   },
+  registrationSuccess: () => {
+    store.dispatch(Actions.registrationSuccess())
+  },
   registrationFailed: (error) => {
     store.dispatch(Actions.registrationFailed(error));
   },

--- a/webclient/src/store/server/server.types.ts
+++ b/webclient/src/store/server/server.types.ts
@@ -21,6 +21,7 @@ export const Types = {
   VIEW_LOGS: '[Server] View Logs',
   CLEAR_LOGS: '[Server] Clear Logs',
   REGISTRATION_REQUIRES_EMAIL: '[Server] Registration Requires Email',
+  REGISTRATION_SUCCES: '[Server] Registration Success',
   REGISTRATION_FAILED: '[Server] Registration Failed',
   REGISTRATION_EMAIL_ERROR: '[Server] Registration Email Error',
   REGISTRATION_PASSWORD_ERROR: '[Server] Registration Password Error',

--- a/webclient/src/websocket/commands/SessionCommands.ts
+++ b/webclient/src/websocket/commands/SessionCommands.ts
@@ -208,7 +208,6 @@ export class SessionCommands {
     }
 
     const CmdRegister = webClient.protobuf.controller.Command_Register.create(registerConfig);
-    console.log(CmdRegister)
 
     const sc = webClient.protobuf.controller.SessionCommand.create({
       '.Command_Register.ext': CmdRegister

--- a/webclient/src/websocket/commands/SessionCommands.ts
+++ b/webclient/src/websocket/commands/SessionCommands.ts
@@ -208,6 +208,7 @@ export class SessionCommands {
     }
 
     const CmdRegister = webClient.protobuf.controller.Command_Register.create(registerConfig);
+    console.log(CmdRegister)
 
     const sc = webClient.protobuf.controller.SessionCommand.create({
       '.Command_Register.ext': CmdRegister
@@ -216,6 +217,7 @@ export class SessionCommands {
     webClient.protobuf.sendSessionCommand(sc, raw => {
       if (raw.responseCode === webClient.protobuf.controller.Response.ResponseCode.RespRegistrationAccepted) {
         SessionCommands.login(passwordSalt);
+        SessionPersistence.registrationSuccess()
         return;
       }
 

--- a/webclient/src/websocket/events/SessionEvents.ts
+++ b/webclient/src/websocket/events/SessionEvents.ts
@@ -131,7 +131,6 @@ function serverIdentification(info: ServerIdentificationData) {
       break;
     case WebSocketConnectReason.REGISTER:
       const passwordSalt = passwordSaltSupported(serverOptions, webClient) ? generateSalt() : null;
-      console.log({ passwordSalt })
       SessionCommands.register(passwordSalt);
       break;
     case WebSocketConnectReason.ACTIVATE_ACCOUNT:

--- a/webclient/src/websocket/events/SessionEvents.ts
+++ b/webclient/src/websocket/events/SessionEvents.ts
@@ -131,6 +131,7 @@ function serverIdentification(info: ServerIdentificationData) {
       break;
     case WebSocketConnectReason.REGISTER:
       const passwordSalt = passwordSaltSupported(serverOptions, webClient) ? generateSalt() : null;
+      console.log({ passwordSalt })
       SessionCommands.register(passwordSalt);
       break;
     case WebSocketConnectReason.ACTIVATE_ACCOUNT:

--- a/webclient/src/websocket/persistence/SessionPersistence.ts
+++ b/webclient/src/websocket/persistence/SessionPersistence.ts
@@ -105,6 +105,10 @@ export class SessionPersistence {
     ServerDispatch.registrationRequiresEmail();
   }
 
+  static registrationSuccess() {
+    ServerDispatch.registrationSuccess();
+  }
+
   static registrationFailed(error: string) {
     ServerDispatch.registrationFailed(error);
   }


### PR DESCRIPTION
## Related Ticket(s)
- Completes [Show toast on successful account registration](https://trello.com/c/rFGFhJhL/18-show-toast-on-successful-account-registration)
- Completes [Show toast on successful password reset](https://trello.com/c/a0Hge38B/17-show-toast-on-successful-password-reset)
- Completes [show toast on successful registration validation](https://trello.com/c/LLnUy2At/19-show-toast-on-successful-registration-validation)

## Short roundup of the initial problem
The only feedback a user gets indicating their registration was successful is that they become authenticated.  It's a bit jarring and could use a toast to help close the feedback look cleanly.

## What will change with this Pull Request?
- A new `ToastContext` was added along with an accompanying `useToast` hook.  This ensures that the toast will remain on screen even if the containing component becomes unmounted.
- A new `registrationSuccess` event was piped through redux to allow an event to fire that ultimately renders the toast.

## Discussion Points
- I chose to use a local reducer in `ToastContext` instead of `redux`.  There's certainly a tradeoff between using the established global state management solution (`redux`) and using a localized alternative (`useReducer`).  I believe the tradeoff is worth it, though.  I place a high value on colocation, especially when the entire state management apparatus belongs to a sibling component.  I've seen this have a positive long-term impact on the maintainability of the component.  That said, I'm prepared to rip it out in exchange for `redux` if that's the preference.

- [`immutability-helper`](https://github.com/kolodny/immutability-helper) is worth considering for both `redux` _and_ any `useReducer` implementations.  It adds complexity in that a new DSL must be learned.  However, it's pretty lightweight and automatically handles a LOT of complexity w.r.t. immutability.  I opted against it for now, since it's not that big of a lift to ensure immutability manually in this reducer.

## Remaining Tasks
Since this a draft PR, I still have a few tasks to handle before this becomes ready for final review.
- [x] Toast on password reset
- [x] Toast on successful account validation
