### PR TITLE
fix image downscaling

### DIFF
--- a/cockatrice/src/dlg_edit_avatar.cpp
+++ b/cockatrice/src/dlg_edit_avatar.cpp
@@ -74,13 +74,12 @@ QByteArray DlgEditAvatar::getImage()
         return QByteArray();
     }
 
-    QByteArray ba;
-    QBuffer buffer(&ba);
-    buffer.open(QIODevice::WriteOnly);
     for (;;) {
+        QByteArray ba;
+        QBuffer buffer(&ba);
+        buffer.open(QIODevice::WriteOnly);
         image.save(&buffer, "JPG");
         if (ba.length() > MAX_FILE_LENGTH) {
-            ba.clear();
             image = image.scaledToWidth(image.width() / 2); // divide the amount of pixels in four to get the size down
         } else {
             return ba;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes https://github.com/Cockatrice/Cockatrice/issues/4540

## Short roundup of the initial problem
the image was cleared instead of downscaled

## What will change with this Pull Request?
- just make a new buffer instead of clearing it


the default size of the database is not 0xfffff but rather 0xffff, on rooster ranges this limit is increased to 0xffffff.
these limits correspond with the sql blob and mediumblob field types, if we want servers to accept the image size we currently enforce on pictures by default we have three options:
- create a smaller definition of profile images at 0xffff, meaning profile pictures will be smaller, we should consider more sophisticated downscaling code on the client side in this case
- make a database migration changing the field from blob to medium blob by default, this is what is currently on rooster ranges
- make a configurable limit that the server enforces, this would mean a protocol expansion to communicate the limit to clients