### PR TITLE
add database migration from blob to mediumblob

### DIFF
--- a/servatrice/migrations/servatrice_0028_to_0029.sql
+++ b/servatrice/migrations/servatrice_0028_to_0029.sql
@@ -1,0 +1,5 @@
+-- Servatrice db migration from version 28 to version 29
+
+ALTER TABLE cockatrice_users MODIFY COLUMN avatar_bmp mediumblob NOT NULL;
+
+UPDATE cockatrice_schema_version SET version=29 WHERE version=28;

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_schema_version` (
   PRIMARY KEY  (`version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
 
-INSERT INTO cockatrice_schema_version VALUES(28);
+INSERT INTO cockatrice_schema_version VALUES(29);
 
 -- users and user data tables
 CREATE TABLE IF NOT EXISTS `cockatrice_users` (
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_users` (
   `password_sha512` char(120) NOT NULL,
   `email` varchar(255) NOT NULL,
   `country` char(2) NOT NULL,
-  `avatar_bmp` blob NOT NULL,
+  `avatar_bmp` mediumblob NOT NULL,
   `registrationDate` datetime NOT NULL,
   `active` tinyint(1) NOT NULL,
   `token` binary(16),

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -9,7 +9,7 @@
 #include <QObject>
 #include <QSqlDatabase>
 
-#define DATABASE_SCHEMA_VERSION 28
+#define DATABASE_SCHEMA_VERSION 29
 
 class Servatrice;
 


### PR DESCRIPTION
related: #4567

with another limit in place that prevents images larger than a certain size we can safely change this to a mediumblob without making the db too big

the other approaches to the problem should still be considered but this one is the easiest to implement

note that enforcing a db version change isn't really necessary for this change as it doesn't cause anything to break (it's always been this broken after all)