### PR TITLE
remove unused include in pb file

### DIFF
--- a/common/pb/session_commands.proto
+++ b/common/pb/session_commands.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "serverinfo_user.proto";
 
 message SessionCommand {
     enum SessionCommandType {


### PR DESCRIPTION
shows as warning on compile:
session_commands.proto:2:1: warning: Import serverinfo_user.proto is unused.
likely related to #4496