### PR TITLE
Fix new spoiler notifications

### DIFF
--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -171,7 +171,7 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
                 QString timeStamp = QString(line).replace("<createdAt>", "").trimmed();
                 timeStamp.chop(18); // Remove " (UTC)</createdAt>"
 
-                auto utcTime = QLocale().toDateTime(timeStamp, "yyyy-mm-dd hh:mm:ss");
+                auto utcTime = QLocale().toDateTime(timeStamp, "yyyy-MM-dd hh:mm:ss");
                 utcTime.setTimeSpec(Qt::UTC);
 
                 QString localTime = utcTime.toLocalTime().toString("MMM d, hh:mm");

--- a/cockatrice/src/spoilerbackgroundupdater.cpp
+++ b/cockatrice/src/spoilerbackgroundupdater.cpp
@@ -162,16 +162,16 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
     QtConcurrent::run(db, &CardDatabase::loadCardDatabases);
 
     // If the user has notifications enabled, let them know
-    // when the database was last updated
+    // when the spoiler database was last updated
     if (trayIcon) {
         QList<QByteArray> lines = data.split('\n');
 
         foreach (QByteArray line, lines) {
-            if (line.contains("Created At:")) {
-                QString timeStamp = QString(line).replace("Created At:", "").trimmed();
-                timeStamp.chop(6); // Remove " (UTC)"
+            if (line.contains("<createdAt>")) {
+                QString timeStamp = QString(line).replace("<createdAt>", "").trimmed();
+                timeStamp.chop(18); // Remove " (UTC)</createdAt>"
 
-                auto utcTime = QLocale().toDateTime(timeStamp, "ddd, MMM dd yyyy, hh:mm:ss");
+                auto utcTime = QLocale().toDateTime(timeStamp, "yyyy-mm-dd hh:mm:ss");
                 utcTime.setTimeSpec(Qt::UTC);
 
                 QString localTime = utcTime.toLocalTime().toString("MMM d, hh:mm");


### PR DESCRIPTION
## Related Ticket(s)
- https://github.com/Cockatrice/Magic-Spoiler/pull/251

## Short roundup of the initial problem
Currently, as announced in the related PR, notifications for spoiler do currently not trigger notifications when new data is available and updated. The reason for this is the update to db v4 for the spoiler file and utilizing the new `<info>` key instead our former method to hide the update time stamp in a comment.

Old format (https://github.com/Cockatrice/Magic-Spoiler/blob/f347bfdbbfbb3667572ad43c1a926e9ee53595cb/spoiler.xml#L3)
``` 
  <!--
  Created At: Sat, Feb 05 2022, 00:30:45 (UTC)
  (...)
  -->
```

New format: (https://github.com/Cockatrice/Magic-Spoiler/blob/17588cea792e634bd3e2198a7034ef9cfd817f13/spoiler.xml#L8)
```
  <info>
    (...)
    <createdAt>2022-02-14 13:32:28 (UTC)</createdAt>
    (...)
  </info>
```

The new information is placed a few lines down compared to the older one, but is still captured when [only reading the first 512 bytes of the file](https://github.com/Cockatrice/Cockatrice/blob/master/cockatrice/src/spoilerbackgroundupdater.cpp#L193-L214).

## What will change with this Pull Request?
- Adapt for new placement and format

## Screenshot(s)
![Untitled](https://user-images.githubusercontent.com/9874850/153890352-44741279-581d-4549-b33f-742f78a0bcac.png)

<br>

**Note:** This is only a quick, simple fix, and still relies on the same approach to get the data.

**Note 2:** The "Last Change" value displayed in the settings dialog under `Card Sources` does display the last modification time of the spoiler file instead the actual time stamp of the data creation. Thus it does not align with the time information shown in the "new spoiler data available" notification shown. (https://github.com/Cockatrice/Cockatrice/blob/master/cockatrice/src/dlg_settings.cpp#L772)