### PR TITLE
CI: Update cache location

### DIFF
--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -39,7 +39,14 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{matrix.node_version}}
-          cache: 'npm'
+          # cache: 'npm'
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('webclient/package-lock.json') }}
+          restore-keys: npm-
 
       - name: Install dependencies
         run: npm clean-install

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           node-version: ${{matrix.node_version}}
           cache: 'npm'
-          cache-dependency-path: 'webclient/package-lock.json'
 
       - name: Install dependencies
         run: npm clean-install


### PR DESCRIPTION
**Edit:** My bad, a [`npm cache is not found`](https://github.com/Cockatrice/Cockatrice/runs/5354922044?check_suite_focus=true#step:3:13) message made me wonder...
But a package-lock update in that PR simply invalidated the cache match. 😄 
No need to manually setup the cache, we can simply stick to the cache feature setup-node provides. 👍 

When rerunning the workflow for the same PR, [caches are found](https://github.com/Cockatrice/Cockatrice/runs/5359993438?check_suite_focus=true#step:3:15).