### PR TITLE
show deck hash even when its invalid

### DIFF
--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -827,7 +827,8 @@ void DeckList::updateDeckHash()
                      (((quint64)(unsigned char)deckHashArray[1]) << 24) +
                      (((quint64)(unsigned char)deckHashArray[2] << 16)) +
                      (((quint64)(unsigned char)deckHashArray[3]) << 8) + (quint64)(unsigned char)deckHashArray[4];
-    deckHash = (isValidDeckList) ? QString::number(number, 32).rightJustified(8, '0') : "INVALID";
+    QString hash = QString::number(number, 32).rightJustified(8, '0');
+    deckHash = (isValidDeckList) ? hash : hash.prepend("INVALID ");
 
     emit deckHashChanged();
 }

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -800,7 +800,6 @@ bool DeckList::deleteNode(AbstractDecklistNode *node, InnerDecklistNode *rootNod
 void DeckList::updateDeckHash()
 {
     QStringList cardList;
-    bool isValidDeckList = true;
     QSet<QString> hashZones, optionalZones;
 
     hashZones << DECK_ZONE_MAIN << DECK_ZONE_SIDE; // Zones in deck to be included in hashing process
@@ -815,9 +814,6 @@ void DeckList::updateDeckHash()
                 for (int k = 0; k < card->getNumber(); ++k) {
                     cardList.append((node->getName() == DECK_ZONE_SIDE ? "SB:" : "") + card->getName().toLower());
                 }
-            } else if (!optionalZones.contains(node->getName())) // Not a valid zone -> cheater?
-            {
-                isValidDeckList = false; // Deck is invalid
             }
         }
     }
@@ -827,8 +823,7 @@ void DeckList::updateDeckHash()
                      (((quint64)(unsigned char)deckHashArray[1]) << 24) +
                      (((quint64)(unsigned char)deckHashArray[2] << 16)) +
                      (((quint64)(unsigned char)deckHashArray[3]) << 8) + (quint64)(unsigned char)deckHashArray[4];
-    QString hash = QString::number(number, 32).rightJustified(8, '0');
-    deckHash = (isValidDeckList) ? hash : hash.prepend("INVALID ");
+    deckHash = QString::number(number, 32).rightJustified(8, '0');
 
     emit deckHashChanged();
 }


### PR DESCRIPTION
## Related Ticket(s)
- N/A

## Short roundup of the initial problem
@Lachee is working to add the ability to search Chickatrice replays by deck, but decks with extra zones (such as a maybeboard) get the string 'INVALID' instead of a unique hash string. This prevent associating a deck with a replay because replays only include the deck hashes, not the full decks. 

## What will change with this Pull Request?
- Decks with extra zones will still be marked as invalid, but now the calculated deck hash is appended so decks can be associated with replays.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
Before:
![2022-03-17-013149_112x42_scrot](https://user-images.githubusercontent.com/6954107/158743543-d0d05df4-2e24-4eee-81e4-0c2ab50b63cf.png)

After:
![2022-03-17-012408_188x51_scrot](https://user-images.githubusercontent.com/6954107/158743456-a2aed41d-76c9-4cc5-ada0-0b9d53b5b9b9.png)
