### PR TITLE
Added Chickatrice.net to Hosts

### DIFF
--- a/cockatrice/translations/cockatrice_en@source.ts
+++ b/cockatrice/translations/cockatrice_en@source.ts
@@ -1664,40 +1664,40 @@ Your email will be used to verify your account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dlg_register.cpp" line="317"/>
+        <location filename="../src/dlg_register.cpp" line="319"/>
         <source>Real name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dlg_register.cpp" line="352"/>
+        <location filename="../src/dlg_register.cpp" line="354"/>
         <source>Register to server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dlg_register.cpp" line="361"/>
-        <location filename="../src/dlg_register.cpp" line="364"/>
-        <location filename="../src/dlg_register.cpp" line="367"/>
-        <location filename="../src/dlg_register.cpp" line="372"/>
+        <location filename="../src/dlg_register.cpp" line="363"/>
+        <location filename="../src/dlg_register.cpp" line="366"/>
+        <location filename="../src/dlg_register.cpp" line="369"/>
+        <location filename="../src/dlg_register.cpp" line="374"/>
         <source>Registration Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dlg_register.cpp" line="361"/>
+        <location filename="../src/dlg_register.cpp" line="363"/>
         <source>Your password is too short.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dlg_register.cpp" line="364"/>
+        <location filename="../src/dlg_register.cpp" line="366"/>
         <source>Your passwords do not match, please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dlg_register.cpp" line="368"/>
+        <location filename="../src/dlg_register.cpp" line="370"/>
         <source>Your email addresses do not match, please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dlg_register.cpp" line="372"/>
+        <location filename="../src/dlg_register.cpp" line="374"/>
         <source>The player name can&apos;t be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4362,12 +4362,12 @@ Cockatrice will now reload the card database.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="2707"/>
+        <location filename="../src/player.cpp" line="2727"/>
         <source>Which position should this card be placed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="2707"/>
+        <location filename="../src/player.cpp" line="2727"/>
         <source>(max. %1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4388,7 +4388,7 @@ Cockatrice will now reload the card database.</source>
     </message>
     <message>
         <location filename="../src/player.cpp" line="1703"/>
-        <location filename="../src/player.cpp" line="3224"/>
+        <location filename="../src/player.cpp" line="3244"/>
         <source>Number:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4509,7 +4509,7 @@ Cockatrice will now reload the card database.</source>
     </message>
     <message>
         <location filename="../src/player.cpp" line="1559"/>
-        <location filename="../src/player.cpp" line="3605"/>
+        <location filename="../src/player.cpp" line="3625"/>
         <source>C&amp;reate another %1 token</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4519,52 +4519,52 @@ Cockatrice will now reload the card database.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="2706"/>
+        <location filename="../src/player.cpp" line="2726"/>
         <source>Place card X cards from top of library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="3031"/>
+        <location filename="../src/player.cpp" line="3051"/>
         <source>Change power/toughness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="3031"/>
+        <location filename="../src/player.cpp" line="3051"/>
         <source>Change stats to:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="3136"/>
+        <location filename="../src/player.cpp" line="3156"/>
         <source>Set annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="3137"/>
+        <location filename="../src/player.cpp" line="3157"/>
         <source>Please enter the new annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="3224"/>
+        <location filename="../src/player.cpp" line="3244"/>
         <source>Set counters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="3443"/>
+        <location filename="../src/player.cpp" line="3463"/>
         <source>View related cards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="3481"/>
+        <location filename="../src/player.cpp" line="3501"/>
         <source>Token: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="3483"/>
+        <location filename="../src/player.cpp" line="3503"/>
         <source>Attach to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/player.cpp" line="3497"/>
+        <location filename="../src/player.cpp" line="3517"/>
         <source>All tokens</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4628,6 +4628,21 @@ Cockatrice will now reload the card database.</source>
     <message>
         <location filename="../src/deck_loader.cpp" line="12"/>
         <source>Common deck formats (*.cod *.dec *.dek *.txt *.mwDeck)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/decklist.cpp" line="111"/>
+        <source>Maindeck</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/decklist.cpp" line="113"/>
+        <source>Sideboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/decklist.cpp" line="115"/>
+        <source>Tokens</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4810,6 +4825,39 @@ Cockatrice will now reload the card database.</source>
     <message>
         <location filename="../src/tab_server.cpp" line="63"/>
         <source>Games</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SequenceEdit</name>
+    <message>
+        <location filename="../src/sequenceEdit/sequenceedit.cpp" line="43"/>
+        <source>Choose an action from the table</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/sequenceEdit/sequenceedit.cpp" line="49"/>
+        <source>Hit the key/combination of keys you want to set for this action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/sequenceEdit/sequenceedit.cpp" line="172"/>
+        <source>Shortcut already in use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/sequenceEdit/sequenceedit.cpp" line="175"/>
+        <source>Invalid key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/sequenceEdit/sequenceedit.cpp" line="192"/>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/sequenceEdit/sequenceedit.cpp" line="193"/>
+        <source>Restore default</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6802,12 +6850,12 @@ Please refrain from engaging in this activity or further actions may be taken ag
 <context>
     <name>main</name>
     <message>
-        <location filename="../src/main.cpp" line="126"/>
+        <location filename="../src/main.cpp" line="125"/>
         <source>Connect on startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="127"/>
+        <location filename="../src/main.cpp" line="126"/>
         <source>Debug to file</source>
         <translation type="unfinished"></translation>
     </message>

--- a/oracle/translations/oracle_en@source.ts
+++ b/oracle/translations/oracle_en@source.ts
@@ -382,6 +382,147 @@
     </message>
 </context>
 <context>
+    <name>UnZip</name>
+    <message>
+        <location filename="../src/zip/unzip.cpp" line="1177"/>
+        <source>ZIP operation completed successfully.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/unzip.cpp" line="1178"/>
+        <source>Failed to initialize or load zlib library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/unzip.cpp" line="1179"/>
+        <source>zlib library error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/unzip.cpp" line="1180"/>
+        <source>Unable to create or open file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/unzip.cpp" line="1181"/>
+        <source>Partially corrupted archive. Some files might be extracted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/unzip.cpp" line="1182"/>
+        <source>Corrupted archive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/unzip.cpp" line="1183"/>
+        <source>Wrong password.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/unzip.cpp" line="1184"/>
+        <source>No archive has been created yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/unzip.cpp" line="1185"/>
+        <source>File or directory does not exist.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/unzip.cpp" line="1186"/>
+        <source>File read error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/unzip.cpp" line="1187"/>
+        <source>File write error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/unzip.cpp" line="1188"/>
+        <source>File seek error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/unzip.cpp" line="1189"/>
+        <source>Unable to create a directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/unzip.cpp" line="1190"/>
+        <source>Invalid device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/unzip.cpp" line="1191"/>
+        <source>Invalid or incompatible zip archive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/unzip.cpp" line="1192"/>
+        <source>Inconsistent headers. Archive might be corrupted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/unzip.cpp" line="1196"/>
+        <source>Unknown error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Zip</name>
+    <message>
+        <location filename="../src/zip/zip.cpp" line="1604"/>
+        <source>ZIP operation completed successfully.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/zip.cpp" line="1605"/>
+        <source>Failed to initialize or load zlib library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/zip.cpp" line="1606"/>
+        <source>zlib library error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/zip.cpp" line="1607"/>
+        <source>Unable to create or open file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/zip.cpp" line="1608"/>
+        <source>No archive has been created yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/zip.cpp" line="1609"/>
+        <source>File or directory does not exist.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/zip.cpp" line="1610"/>
+        <source>File read error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/zip.cpp" line="1611"/>
+        <source>File write error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/zip.cpp" line="1612"/>
+        <source>File seek error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/zip/zip.cpp" line="1616"/>
+        <source>Unknown error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>i18n</name>
     <message>
         <location filename="../src/oraclewizard.cpp" line="58"/>

--- a/webclient/src/types/server.tsx
+++ b/webclient/src/types/server.tsx
@@ -55,6 +55,12 @@ export class Host {
 
 export const DefaultHosts: Host[] = [
   {
+    name: 'Chickatrice',
+    host: 'mtg.chickatrice.net/servatrice',
+    port: '443',
+    editable: false,
+  },
+  {
     name: 'Rooster',
     host: 'server.cockatrice.us/servatrice',
     port: '4748',
@@ -93,11 +99,13 @@ export const getHostPort = (host: Host): { host: string, port: string } => {
 };
 
 export enum KnownHost {
+  CHICKATRICE = 'Chickatrice',
   ROOSTER = 'Rooster',
   TETRARCH = 'Tetrarch',
 }
 
 export const KnownHosts = {
+  [KnownHost.CHICKATRICE]: { port: 443, host: 'mtg.chickatrice.net', },
   [KnownHost.ROOSTER]: { port: 4748, host: 'server.cockatrice.us', },
   [KnownHost.TETRARCH]: { port: 443, host: 'mtg.tetrarch.co/servatrice' },
 }


### PR DESCRIPTION
Chickatrice has sorted out its SSL for websockets, and webatrice can now connect to it without any issues.
This PR adds it to the known hosts.

## Short roundup of the initial problem
Chickatrice was not present in the default hosts.

## What will change with this Pull Request?
- Adds chickatrice to the list of default hosts and known hosts.

## Screenshots

## Additional
I have placed Chickatrice alphabetically, but it is completely reasonable for this early stage of development to want Rooster ranges to be default since it is most likely to have the most compatible server. The Chickatrice entry can be easily moved down between Tetrarch and Rooster Beta.