### PR TITLE
env vars don't go into docker containers like that

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -160,11 +160,11 @@ jobs:
         if: matrix.package != 'skip'
         shell: bash
         env:
-          PACKAGE_SUFFIX: '-${{matrix.distro}}'
-          CPACK_GENERATOR: '${{matrix.package}}'
+          suffix: '-${{matrix.distro}}'
+          type: '${{matrix.package}}'
         run: |
           source .ci/docker.sh
-          RUN --server --release --package
+          RUN --server --release --package "$type" --suffix "$suffix"
 
       - name: Upload artifact
         if: matrix.package != 'skip'


### PR DESCRIPTION
reverts a bit of #4580 92ed53e13ad937b588202a21f92e7f050d855e95

linux builds erroneously uploaded the entire build dir instead of the package