### PR TITLE
Prevent bad access potential for removals by checking bounds

### DIFF
--- a/cockatrice/src/arrowtarget.h
+++ b/cockatrice/src/arrowtarget.h
@@ -43,9 +43,8 @@ public:
     }
     void removeArrowFrom(ArrowItem *arrow)
     {
-        arrowsFrom.removeAt(arrowsFrom.indexOf(arrow));
+        arrowsFrom.removeOne(arrow);
     }
-
     const QList<ArrowItem *> &getArrowsTo() const
     {
         return arrowsTo;
@@ -56,8 +55,7 @@ public:
     }
     void removeArrowTo(ArrowItem *arrow)
     {
-        arrowsTo.removeAt(arrowsTo.indexOf(arrow));
+        arrowsTo.removeOne(arrow);
     }
 };
-
 #endif

--- a/cockatrice/src/carditem.h
+++ b/cockatrice/src/carditem.h
@@ -131,7 +131,7 @@ public:
     }
     void removeAttachedCard(CardItem *card)
     {
-        attachedCards.removeAt(attachedCards.indexOf(card));
+        attachedCards.removeOne(card);
     }
     const QList<CardItem *> &getAttachedCards() const
     {

--- a/cockatrice/src/cardzone.cpp
+++ b/cockatrice/src/cardzone.cpp
@@ -187,7 +187,7 @@ CardItem *CardZone::takeCard(int position, int cardId, bool /*canResize*/)
 
 void CardZone::removeCard(CardItem *card)
 {
-    cards.removeAt(cards.indexOf(card));
+    cards.removeOne(card);
     reorganizeCards();
     emit cardCountChanged();
     player->deleteCard(card);

--- a/cockatrice/src/deckview.cpp
+++ b/cockatrice/src/deckview.cpp
@@ -216,7 +216,7 @@ void DeckViewCardContainer::addCard(DeckViewCard *card)
 
 void DeckViewCardContainer::removeCard(DeckViewCard *card)
 {
-    cards.removeAt(cards.indexOf(card));
+    cards.removeOne(card);
     cardsByType.remove(card->getInfo() ? card->getInfo()->getMainCardType() : "", card);
 }
 

--- a/cockatrice/src/gamescene.cpp
+++ b/cockatrice/src/gamescene.cpp
@@ -53,7 +53,7 @@ void GameScene::removePlayer(Player *player)
             zone->close();
         }
     }
-    players.removeAt(players.indexOf(player));
+    players.removeOne(player);
     removeItem(player);
     rearrange();
 }
@@ -178,7 +178,7 @@ void GameScene::addRevealedZoneView(Player *player,
 
 void GameScene::removeZoneView(ZoneViewWidget *item)
 {
-    zoneViews.removeAt(zoneViews.indexOf(item));
+    zoneViews.removeOne(item);
     removeItem(item);
 }
 

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -442,7 +442,7 @@ void TabSupervisor::replayLeft(TabGame *tab)
     if (tab == currentWidget())
         emit setMenu();
 
-    replayTabs.removeAt(replayTabs.indexOf(tab));
+    replayTabs.removeOne(tab);
 }
 
 TabMessage *TabSupervisor::addMessageTab(const QString &receiverName, bool focus)
@@ -508,7 +508,7 @@ void TabSupervisor::deckEditorClosed(TabDeckEditor *tab)
     if (tab == currentWidget())
         emit setMenu();
 
-    deckEditorTabs.removeAt(deckEditorTabs.indexOf(tab));
+    deckEditorTabs.removeOne(tab);
     removeTab(indexOf(tab));
 }
 

--- a/common/server_card.h
+++ b/common/server_card.h
@@ -181,7 +181,7 @@ public:
     }
     void removeAttachedCard(Server_Card *card)
     {
-        attachedCards.removeAt(attachedCards.indexOf(card));
+        attachedCards.removeOne(card);
     }
 
     void resetState();

--- a/common/server_cardzone.cpp
+++ b/common/server_cardzone.cpp
@@ -135,9 +135,7 @@ int Server_CardZone::removeCard(Server_Card *card, bool &wasLookedAt)
     if (wasLookedAt && cardsBeingLookedAt > 0) {
         cardsBeingLookedAt -= 1;
     }
-    if (index != -1) {
-        cards.removeAt(index);
-    }
+    cards.removeAt(index);
     if (has_coords) {
         removeCardFromCoordMap(card, card->getX(), card->getY());
     }

--- a/common/server_cardzone.cpp
+++ b/common/server_cardzone.cpp
@@ -135,7 +135,9 @@ int Server_CardZone::removeCard(Server_Card *card, bool &wasLookedAt)
     if (wasLookedAt && cardsBeingLookedAt > 0) {
         cardsBeingLookedAt -= 1;
     }
-    cards.removeAt(index);
+    if (index != -1) {
+        cards.removeAt(index);
+    }
     if (has_coords) {
         removeCardFromCoordMap(card, card->getX(), card->getY());
     }


### PR DESCRIPTION
Fix #4616

The crash came about because the index was -1 since the card object didn't exist. This PR addresses that issue (by ignoring -1 attempts) and safe handles all access points within the program that can lead to a similar situation.