### PR TITLE
Update configuration path to be backwards compatible

### DIFF
--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -18,7 +18,7 @@ QString SettingsCache::getDataPath()
     if (isPortableBuild)
         return qApp->applicationDirPath() + "/data";
     else
-        return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+        return QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
 }
 
 QString SettingsCache::getSettingsPath()
@@ -181,7 +181,7 @@ SettingsCache::SettingsCache()
     updateReleaseChannel = settings->value("personal/updatereleasechannel", 0).toInt();
 
     lang = settings->value("personal/lang").toString();
-    keepalive = settings->value("personal/keepalive", 5).toInt();
+    keepalive = settings->value("personal/keepalive", 5).toInt();database
 
     // tip of the day settings
     showTipsOnStartup = settings->value("tipOfDay/showTips", true).toBool();

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -181,7 +181,7 @@ SettingsCache::SettingsCache()
     updateReleaseChannel = settings->value("personal/updatereleasechannel", 0).toInt();
 
     lang = settings->value("personal/lang").toString();
-    keepalive = settings->value("personal/keepalive", 5).toInt();database
+    keepalive = settings->value("personal/keepalive", 5).toInt();
 
     // tip of the day settings
     showTipsOnStartup = settings->value("tipOfDay/showTips", true).toBool();

--- a/servatrice/src/settingscache.cpp
+++ b/servatrice/src/settingscache.cpp
@@ -45,6 +45,6 @@ QString SettingsCache::guessConfigurationPath()
         return guessFileName;
 #endif
 
-    guessFileName = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/" + fileName;
+    guessFileName = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/" + fileName;
     return guessFileName;
 }


### PR DESCRIPTION
Windows users have used AppData/Local/Cockatrice, whereas the new system was using AppData/Roaming/Cockatrice. This reverts the behavior in a Qt5/6 way.
