### PR TITLE
Allow Copy from Cardlist in Deck Editor

### DIFF
--- a/cockatrice/src/keysignals.cpp
+++ b/cockatrice/src/keysignals.cpp
@@ -61,6 +61,11 @@ bool KeySignals::eventFilter(QObject * /*object*/, QEvent *event)
                 emit onShiftS();
 
             break;
+        case Qt::Key_C:
+            if (kevent->modifiers() & Qt::ControlModifier)
+                emit onCtrlC();
+
+            break;
         default:
             return false;
     }

--- a/cockatrice/src/keysignals.h
+++ b/cockatrice/src/keysignals.h
@@ -20,6 +20,7 @@ signals:
     void onCtrlAltLBracket();
     void onCtrlAltRBracket();
     void onShiftS();
+    void onCtrlC();
 
 protected:
     virtual bool eventFilter(QObject *, QEvent *event);

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -394,6 +394,7 @@ void TabDeckEditor::createCentralFrame()
     connect(&searchKeySignals, SIGNAL(onCtrlAltLBracket()), this, SLOT(actDecrementCardFromSideboard()));
     connect(&searchKeySignals, SIGNAL(onCtrlAltEnter()), this, SLOT(actAddCardToSideboard()));
     connect(&searchKeySignals, SIGNAL(onCtrlEnter()), this, SLOT(actAddCardToSideboard()));
+    connect(&searchKeySignals, SIGNAL(onCtrlC()), this, SLOT(copyDatabaseCellContents()));
     connect(help, &QAction::triggered, this, &TabDeckEditor::showSearchSyntaxHelp);
 
     databaseModel = new CardDatabaseModel(db, true, this);
@@ -1071,6 +1072,12 @@ void TabDeckEditor::actDecrementCard()
 void TabDeckEditor::actDecrementCardFromSideboard()
 {
     decrementCardHelper(DECK_ZONE_SIDE);
+}
+
+void TabDeckEditor::copyDatabaseCellContents()
+{
+    QVariant data = databaseView->selectionModel()->currentIndex().data();
+    QApplication::clipboard()->setText(data.toString());
 }
 
 void TabDeckEditor::actIncrement()

--- a/cockatrice/src/tab_deck_editor.h
+++ b/cockatrice/src/tab_deck_editor.h
@@ -80,6 +80,7 @@ private slots:
     void actDecrement();
     void actDecrementCard();
     void actDecrementCardFromSideboard();
+    void copyDatabaseCellContents();
 
     void saveDeckRemoteFinished(const Response &r);
     void filterViewCustomContextMenu(const QPoint &point);


### PR DESCRIPTION
# Related Ticket(s)
Adds the functionality requested by Fix #4041

## Brief Description

Previously, you could ctrl-c to grab the name of a card from the deck list, but the same functionality did not exist for the card database. This adds that functionality. Now, pressing ctrl-c in the card database will copy the contents of the currently selected cell to the clipboard.

## Notes

I'm unsure if this is the best way to add this functionality as it exists in the deck list as a default feature of QList. Please suggest a cleaner way of doing this if it exists; I'm by no means an expert in Qt.