### PR TITLE
replace trayicon activation with menu actions

### DIFF
--- a/cockatrice/src/window_main.h
+++ b/cockatrice/src/window_main.h
@@ -84,7 +84,7 @@ private slots:
     void forgotPasswordSuccess();
     void forgotPasswordError();
     void promptForgotPasswordReset();
-    void iconActivated(QSystemTrayIcon::ActivationReason reason);
+    void actShow();
     void promptForgotPasswordChallenge();
     void showWindowIfHidden();
 
@@ -114,7 +114,6 @@ private:
     void createMenus();
 
     void createTrayIcon();
-    void createTrayActions();
     int getNextCustomSetPrefix(QDir dataDir);
     inline QString getCardUpdaterBinaryName()
     {
@@ -125,8 +124,8 @@ private:
     QList<QMenu *> tabMenus;
     QMenu *cockatriceMenu, *dbMenu, *helpMenu, *trayIconMenu;
     QAction *aConnect, *aDisconnect, *aSinglePlayer, *aWatchReplay, *aDeckEditor, *aFullScreen, *aSettings, *aExit,
-        *aAbout, *aTips, *aCheckCardUpdates, *aRegister, *aForgotPassword, *aUpdate, *aViewLog, *closeAction;
-    QAction *aManageSets, *aEditTokens, *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet;
+        *aAbout, *aTips, *aCheckCardUpdates, *aRegister, *aForgotPassword, *aUpdate, *aViewLog, *aManageSets,
+        *aEditTokens, *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet, *aShow;
     TabSupervisor *tabSupervisor;
     WndSets *wndSets;
     RemoteClient *client;


### PR DESCRIPTION
## Related Ticket(s)
- #4607

## Short roundup of the initial problem
tray icon inconsistencies:
on mac the doubleclick is never triggered because we have a menu set: https://doc.qt.io/qt-5/qsystemtrayicon.html#ActivationReason-enum
on linux it's all over the place, some don't trigger anything at all.

this came to my attention in the qt6 conversion:
https://github.com/Cockatrice/Cockatrice/pull/4607#discussion_r864909937

## What will change with this Pull Request?
- replace the activation of the tray icon with a more complete menu
- replace the effect of the effect of the show action with something a bit more sensible:
  - old behavior: if window is minimized: open and focus window, else minimize it (even if not in focus)
  - new behavior: if window is focused: minimize it, else open and focus window

## Screenshots
![image](https://user-images.githubusercontent.com/36401181/170799078-64d30bfb-3b28-4564-9283-4e5eaf3af27b.png)
