### PR TITLE
remove unused variables

### DIFF
--- a/cockatrice/src/deckview.cpp
+++ b/cockatrice/src/deckview.cpp
@@ -272,16 +272,11 @@ void DeckViewCardContainer::rearrangeItems(const QList<QPair<int, int>> &rowsAnd
 {
     currentRowsAndCols = rowsAndCols;
 
-    int totalCols = 0, totalRows = 0;
     qreal yUntilNow = separatorY + paddingY;
     qreal x = (qreal)getCardTypeTextWidth();
     for (int i = 0; i < rowsAndCols.size(); ++i) {
         const int tempRows = rowsAndCols[i].first;
         const int tempCols = rowsAndCols[i].second;
-        totalRows += tempRows;
-        if (tempCols > totalCols)
-            totalCols = tempCols;
-
         QList<QString> cardTypeList = cardsByType.uniqueKeys();
         QList<DeckViewCard *> row = cardsByType.values(cardTypeList[i]);
         std::sort(row.begin(), row.end(), DeckViewCardContainer::sortCardsByName);

--- a/oracle/src/zip/unzip.cpp
+++ b/oracle/src/zip/unzip.cpp
@@ -793,7 +793,6 @@ UnZip::ErrorCode UnzipPrivate::inflateFile(
 
     // extract data
     qint64 read;
-    quint64 tot = 0;
 
     /* Allocate inflate state */
     z_stream zstr;
@@ -826,7 +825,6 @@ UnZip::ErrorCode UnzipPrivate::inflateFile(
             decryptBytes(*keys, buffer1, read);
 
         cur++;
-        tot += read;
 
         zstr.avail_in = (uInt) read;
         zstr.next_in = (Bytef*) buffer1;


### PR DESCRIPTION
## Short roundup of the initial problem
with the help of Crimson#6666 on discord we found some variables that did nothing, causing warnings when compiling with the latest version of apple clang.

## What will change with this Pull Request?
- remove them, they didn't do anything anyway
