### PR TITLE
fix typo in format.sh

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -196,7 +196,7 @@ if [[ $branch ]]; then
   for ex in "${exts[@]}"; do
     for path in "${include[@]}"; do
       for name in "${basenames[@]}"; do
-        rx="^$path/.$ex$"
+        rx="^$path/.*\\.$ex$"
         if [[ $name =~ $rx ]]; then
           names+=("$name")
         fi


### PR DESCRIPTION
I missed part of a regex in https://github.com/Cockatrice/Cockatrice/pull/4627