### PR TITLE
Shuffle attachments command

### DIFF
--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -13,13 +13,12 @@
 #include <algorithm>
 
 AbstractCardItem::AbstractCardItem(const QString &_name, Player *_owner, int _id, QGraphicsItem *parent)
-    : ArrowTarget(_owner, parent), id(_id), name(_name), tapped(false), facedown(false), tapAngle(0),
+    : ArrowTarget(_owner, parent), id(_id), name(_name), tapped(false), facedown(false), obscured(false), tapAngle(0),
       bgColor(Qt::transparent), isHovered(false), realZValue(0)
 {
     setCursor(Qt::OpenHandCursor);
     setFlag(ItemIsSelectable);
     setCacheMode(DeviceCoordinateCache);
-    setObscured(false);
 
     connect(&SettingsCache::instance(), SIGNAL(displayCardNamesChanged()), this, SLOT(callUpdate()));
     cardInfoUpdated();

--- a/cockatrice/src/abstractcarditem.cpp
+++ b/cockatrice/src/abstractcarditem.cpp
@@ -19,6 +19,7 @@ AbstractCardItem::AbstractCardItem(const QString &_name, Player *_owner, int _id
     setCursor(Qt::OpenHandCursor);
     setFlag(ItemIsSelectable);
     setCacheMode(DeviceCoordinateCache);
+    setObscured(false);
 
     connect(&SettingsCache::instance(), SIGNAL(displayCardNamesChanged()), this, SLOT(callUpdate()));
     cardInfoUpdated();
@@ -139,7 +140,7 @@ void AbstractCardItem::paintPicture(QPainter *painter, const QSizeF &translatedS
         painter->setBackgroundMode(Qt::OpaqueMode);
         QString nameStr;
         if (facedown)
-            nameStr = "# " + QString::number(id);
+            nameStr = "# " + (obscured ? "???" : QString::number(id));
         else
             nameStr = name;
         painter->drawText(QRectF(3 * scaleFactor, 3 * scaleFactor, translatedSize.width() - 6 * scaleFactor,
@@ -270,6 +271,11 @@ void AbstractCardItem::setFaceDown(bool _facedown)
 {
     facedown = _facedown;
     update();
+}
+
+void AbstractCardItem::setObscured(bool _obscured)
+{
+    obscured = _obscured;
 }
 
 void AbstractCardItem::mousePressEvent(QGraphicsSceneMouseEvent *event)

--- a/cockatrice/src/abstractcarditem.h
+++ b/cockatrice/src/abstractcarditem.h
@@ -18,6 +18,7 @@ protected:
     QString name;
     bool tapped;
     bool facedown;
+    bool obscured;
     int tapAngle;
     QString color;
     QColor bgColor;
@@ -95,6 +96,11 @@ public:
         return facedown;
     }
     void setFaceDown(bool _facedown);
+    bool getObscured() const
+    {
+        return obscured;
+    }
+    void setObscured(bool _obscured);
     void processHoverEvent();
     void deleteCardInfoPopup()
     {

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -200,6 +200,8 @@ void CardItem::setAttachedTo(CardItem *_attachedTo)
 {
     if (attachedTo != nullptr) {
         attachedTo->removeAttachedCard(this);
+    } else {
+        setObscured(false);
     }
 
     gridPoint.setX(-1);
@@ -216,6 +218,25 @@ void CardItem::setAttachedTo(CardItem *_attachedTo)
 
     if (zone != nullptr) {
         zone->reorganizeCards();
+    }
+}
+
+void CardItem::swapAttachedCards(int ind1, int ind2, bool last)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+    attachedCards.swapItemsAt(ind1, ind2);
+#else
+    attachedCards.swap(ind1, ind2);
+#endif
+    attachedCards[ind1]->setObscured(true);
+    if (attachedCards[ind1]->getFaceDown()) {
+        attachedCards[ind1]->setName("");
+    }
+    if (last) {
+        attachedCards[0]->setObscured(true);
+        if (attachedCards[0]->getFaceDown()) {
+            attachedCards[0]->setName("");
+        }
     }
 }
 

--- a/cockatrice/src/carditem.h
+++ b/cockatrice/src/carditem.h
@@ -140,8 +140,7 @@ public:
     }
     void shuffleAttachedCards()
     {
-        if (attachedCards.size() < 2)
-        {
+        if (attachedCards.size() < 2) {
             return; //cards are already sorted
         }
         for (int i = attachedCards.size()-1; i > 0; i--) {

--- a/cockatrice/src/carditem.h
+++ b/cockatrice/src/carditem.h
@@ -2,6 +2,7 @@
 #define CARDITEM_H
 
 #include "abstractcarditem.h"
+#include "rng_abstract.h"
 #include "server_card.h"
 
 class CardDatabase;
@@ -136,6 +137,21 @@ public:
     const QList<CardItem *> &getAttachedCards() const
     {
         return attachedCards;
+    }
+    void shuffleAttachedCards()
+    {
+        if (attachedCards.size() < 2)
+        {
+            return; //cards are already sorted
+        }
+        for (int i = attachedCards.size()-1; i > 0; i--) {
+            int j = rng->rand(0, i);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+            attachedCards.swapItemsAt(j, i);
+#else
+            attachedCards.swap(j, i);
+#endif
+        }
     }
     void resetState();
     void processCardInfo(const ServerInfo_Card &info);

--- a/cockatrice/src/carditem.h
+++ b/cockatrice/src/carditem.h
@@ -2,7 +2,6 @@
 #define CARDITEM_H
 
 #include "abstractcarditem.h"
-#include "pb/event_move_card.pb.h"
 #include "server_card.h"
 
 class CardDatabase;
@@ -133,23 +132,14 @@ public:
     void removeAttachedCard(CardItem *card)
     {
         attachedCards.removeOne(card);
+        card->setObscured(false);
     }
     const QList<CardItem *> &getAttachedCards() const
     {
         return attachedCards;
     }
-    void shuffleAttachedCards(const Event_MoveCard &event)
-    {
-        int indCount = event.swap_indexes_size();
-        for (int i = indCount; i > 0; i--) {
-            int temp = event.swap_indexes(indCount - i);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
-            attachedCards.swapItemsAt(temp, i);
-#else
-            attachedCards.swap(temp, i);
-#endif
-        }
-    }
+    void swapAttachedCards(int ind1, int ind2, bool last = false);
+
     void resetState();
     void processCardInfo(const ServerInfo_Card &info);
 

--- a/cockatrice/src/carditem.h
+++ b/cockatrice/src/carditem.h
@@ -2,7 +2,7 @@
 #define CARDITEM_H
 
 #include "abstractcarditem.h"
-#include "rng_abstract.h"
+#include "pb/event_move_card.pb.h"
 #include "server_card.h"
 
 class CardDatabase;
@@ -138,17 +138,15 @@ public:
     {
         return attachedCards;
     }
-    void shuffleAttachedCards()
+    void shuffleAttachedCards(const Event_MoveCard &event)
     {
-        if (attachedCards.size() < 2) {
-            return; //cards are already sorted
-        }
-        for (int i = attachedCards.size()-1; i > 0; i--) {
-            int j = rng->rand(0, i);
+        int indCount = event.swap_indexes_size();
+        for (int i = indCount; i > 0; i--) {
+            int temp = event.swap_indexes(indCount - i);
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
-            attachedCards.swapItemsAt(j, i);
+            attachedCards.swapItemsAt(temp, i);
 #else
-            attachedCards.swap(j, i);
+            attachedCards.swap(temp, i);
 #endif
         }
     }

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -293,8 +293,8 @@ void MessageLogWidget::logMoveCard(Player *player,
 
     // do not log if moved within the same zone unless we're shuffling
     if (!shuffleAttached && ((startZoneName == tableConstant() && targetZoneName == tableConstant() && !ownerChanged) ||
-                            (startZoneName == handConstant() && targetZoneName == handConstant()) ||
-                            (startZoneName == exileConstant() && targetZoneName == exileConstant()))) {
+                             (startZoneName == handConstant() && targetZoneName == handConstant()) ||
+                             (startZoneName == exileConstant() && targetZoneName == exileConstant()))) {
         return;
     }
 
@@ -318,6 +318,7 @@ void MessageLogWidget::logMoveCard(Player *player,
         appendHtmlServerMessage(tr("%1 shuffles %2's attachments.").arg(sanitizeHtml(player->getName())).arg(cardStr));
         return;
     }
+
     if (ownerChanged && (startZone->getPlayer() == player)) {
         appendHtmlServerMessage(tr("%1 gives %2 control over %3.")
                                     .arg(sanitizeHtml(player->getName()))

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -293,8 +293,8 @@ void MessageLogWidget::logMoveCard(Player *player,
 
     // do not log if moved within the same zone unless we're shuffling
     if (!shuffleAttached && ((startZoneName == tableConstant() && targetZoneName == tableConstant() && !ownerChanged) ||
-        (startZoneName == handConstant() && targetZoneName == handConstant()) ||
-        (startZoneName == exileConstant() && targetZoneName == exileConstant()))) {
+                            (startZoneName == handConstant() && targetZoneName == handConstant()) ||
+                            (startZoneName == exileConstant() && targetZoneName == exileConstant()))) {
         return;
     }
 
@@ -312,12 +312,10 @@ void MessageLogWidget::logMoveCard(Player *player,
     } else {
         cardStr = cardLink(cardName);
     }
-    
+
     // log shuffled attached cards
     if (shuffleAttached) {
-        appendHtmlServerMessage(tr("%1 shuffles %2's attachments.")
-                                    .arg(sanitizeHtml(player->getName()))
-                                    .arg(cardStr));
+        appendHtmlServerMessage(tr("%1 shuffles %2's attachments.").arg(sanitizeHtml(player->getName())).arg(cardStr));
         return;
     }
     if (ownerChanged && (startZone->getPlayer() == player)) {

--- a/cockatrice/src/messagelogwidget.h
+++ b/cockatrice/src/messagelogwidget.h
@@ -68,12 +68,12 @@ public slots:
     void logLeaveSpectator(QString name, QString reason);
     void logNotReadyStart(Player *player);
     void logMoveCard(Player *player,
-                        CardItem *card,
-                        CardZone *startZone,
-                        int oldX,
-                        CardZone *targetZone,
-                        int newX,
-                        bool shuffleAttached = false);
+                     CardItem *card,
+                     CardZone *startZone,
+                     int oldX,
+                     CardZone *targetZone,
+                     int newX,
+                     bool shuffleAttached = false);
     void logMulligan(Player *player, int number);
     void logReplayStarted(int gameId);
     void logReadyStart(Player *player);

--- a/cockatrice/src/messagelogwidget.h
+++ b/cockatrice/src/messagelogwidget.h
@@ -67,7 +67,13 @@ public slots:
     void logLeave(Player *player, QString reason);
     void logLeaveSpectator(QString name, QString reason);
     void logNotReadyStart(Player *player);
-    void logMoveCard(Player *player, CardItem *card, CardZone *startZone, int oldX, CardZone *targetZone, int newX, bool shuffleAttached = false);
+    void logMoveCard(Player *player,
+                        CardItem *card,
+                        CardZone *startZone,
+                        int oldX,
+                        CardZone *targetZone,
+                        int newX,
+                        bool shuffleAttached = false);
     void logMulligan(Player *player, int number);
     void logReplayStarted(int gameId);
     void logReadyStart(Player *player);

--- a/cockatrice/src/messagelogwidget.h
+++ b/cockatrice/src/messagelogwidget.h
@@ -67,7 +67,7 @@ public slots:
     void logLeave(Player *player, QString reason);
     void logLeaveSpectator(QString name, QString reason);
     void logNotReadyStart(Player *player);
-    void logMoveCard(Player *player, CardItem *card, CardZone *startZone, int oldX, CardZone *targetZone, int newX);
+    void logMoveCard(Player *player, CardItem *card, CardZone *startZone, int oldX, CardZone *targetZone, int newX, bool shuffleAttached = false);
     void logMulligan(Player *player, int number);
     void logReplayStarted(int gameId);
     void logReadyStart(Player *player);

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2030,7 +2030,7 @@ void Player::eventMoveCard(const Event_MoveCard &event, const GameEventContext &
     if (!startZone || !targetZone) {
         return;
     }
-	
+
     int position = event.position();
     int x = event.x();
     int y = event.y();
@@ -2061,8 +2061,9 @@ void Player::eventMoveCard(const Event_MoveCard &event, const GameEventContext &
 
     card->setId(event.new_card_id());
     card->setFaceDown(event.face_down());
-    if(event.shuffle_attached())
+    if(event.shuffle_attached()) {
         card->shuffleAttachedCards();
+	}
     if (startZone != targetZone) {
         card->setBeingPointedAt(false);
         card->setHovered(false);
@@ -2661,7 +2662,7 @@ void Player::rearrangeCounters()
 
 PendingCommand *Player::prepareGameCommand(const google::protobuf::Message &cmd)
 {
-	
+
     if (judge && !local) {
         Command_Judge base;
         GameCommand *c = base.add_game_command();
@@ -3395,8 +3396,8 @@ void Player::updateCardMenu(const CardItem *card)
                     cardMenu->addAction(aPeek);
                 }
                 if(card->getAttachedCards().size()) {
-		    cardMenu->addAction(aShuffleAttached);
-		}
+                    cardMenu->addAction(aShuffleAttached);
+                }
                 addRelatedCardView(card, cardMenu);
                 addRelatedCardActions(card, cardMenu);
 

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2044,6 +2044,7 @@ void Player::eventMoveCard(const Event_MoveCard &event, const GameEventContext &
     if (card == nullptr) {
         return;
     }
+
     if (startZone != targetZone) {
         card->deleteCardInfoPopup();
     }
@@ -2061,9 +2062,11 @@ void Player::eventMoveCard(const Event_MoveCard &event, const GameEventContext &
 
     card->setId(event.new_card_id());
     card->setFaceDown(event.face_down());
-    if(event.shuffle_attached()) {
-        card->shuffleAttachedCards();
-	}
+
+    if (event.swap_indexes_size()) {
+        card->shuffleAttachedCards(event);
+    }
+
     if (startZone != targetZone) {
         card->setBeingPointedAt(false);
         card->setHovered(false);
@@ -2083,7 +2086,7 @@ void Player::eventMoveCard(const Event_MoveCard &event, const GameEventContext &
     if (context.HasExtension(Context_UndoDraw::ext)) {
         emit logUndoDraw(this, card->getName());
     } else {
-        emit logMoveCard(this, card, startZone, logPosition, targetZone, logX, event.shuffle_attached());
+        emit logMoveCard(this, card, startZone, logPosition, targetZone, logX, event.swap_indexes_size() > 0);
     }
 
     targetZone->addCard(card, true, x, y);
@@ -3395,9 +3398,10 @@ void Player::updateCardMenu(const CardItem *card)
                 if (card->getFaceDown()) {
                     cardMenu->addAction(aPeek);
                 }
-                if(card->getAttachedCards().size()) {
+                if (card->getAttachedCards().size() > 1) {
                     cardMenu->addAction(aShuffleAttached);
                 }
+
                 addRelatedCardView(card, cardMenu);
                 addRelatedCardActions(card, cardMenu);
 

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2063,8 +2063,11 @@ void Player::eventMoveCard(const Event_MoveCard &event, const GameEventContext &
     card->setId(event.new_card_id());
     card->setFaceDown(event.face_down());
 
-    if (event.swap_indexes_size()) {
-        card->shuffleAttachedCards(event);
+    if (event.swap_indexes_size() > 0 && event.swap_indexes_size() <= card->getAttachedCards().size()) {
+        int indCount = event.swap_indexes_size();
+        for (int i = indCount; i > 0; i--) {
+            card->swapAttachedCards(i, event.swap_indexes(indCount - i), i == 1);
+        }
     }
 
     if (startZone != targetZone) {

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2063,7 +2063,7 @@ void Player::eventMoveCard(const Event_MoveCard &event, const GameEventContext &
     card->setId(event.new_card_id());
     card->setFaceDown(event.face_down());
 
-    if (event.swap_indexes_size() > 0 && event.swap_indexes_size() <= card->getAttachedCards().size()) {
+    if (0 < event.swap_indexes_size() && event.swap_indexes_size() <= card->getAttachedCards().size()) {
         int indCount = event.swap_indexes_size();
         for (int i = indCount; i > 0; i--) {
             card->swapAttachedCards(i, event.swap_indexes(indCount - i), i == 1);

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -122,7 +122,13 @@ signals:
     void logCreateToken(Player *player, QString cardName, QString pt);
     void logDrawCards(Player *player, int number);
     void logUndoDraw(Player *player, QString cardName);
-    void logMoveCard(Player *player, CardItem *card, CardZone *startZone, int oldX, CardZone *targetZone, int newX, bool shuffleAttached = false);
+    void logMoveCard(Player *player,
+                        CardItem *card,
+                        CardZone *startZone,
+                        int oldX,
+                        CardZone *targetZone,
+                        int newX,
+                        bool shuffleAttached = false);
     void logFlipCard(Player *player, QString cardName, bool faceDown);
     void logDestroyCard(Player *player, QString cardName);
     void logAttachCard(Player *player, QString cardName, Player *targetPlayer, QString targetCardName);

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -122,7 +122,7 @@ signals:
     void logCreateToken(Player *player, QString cardName, QString pt);
     void logDrawCards(Player *player, int number);
     void logUndoDraw(Player *player, QString cardName);
-    void logMoveCard(Player *player, CardItem *card, CardZone *startZone, int oldX, CardZone *targetZone, int newX);
+    void logMoveCard(Player *player, CardItem *card, CardZone *startZone, int oldX, CardZone *targetZone, int newX, bool shuffleAttached = false);
     void logFlipCard(Player *player, QString cardName, bool faceDown);
     void logDestroyCard(Player *player, QString cardName);
     void logAttachCard(Player *player, QString cardName, Player *targetPlayer, QString targetCardName);
@@ -241,7 +241,7 @@ private:
     QList<QAction *> aAddCounter, aSetCounter, aRemoveCounter;
     QAction *aPlay, *aPlayFacedown, *aHide, *aTap, *aDoesntUntap, *aAttach, *aUnattach, *aDrawArrow, *aSetPT, *aResetPT,
         *aIncP, *aDecP, *aIncT, *aDecT, *aIncPT, *aDecPT, *aFlowP, *aFlowT, *aSetAnnotation, *aFlip, *aPeek, *aClone,
-        *aMoveToTopLibrary, *aMoveToBottomLibrary, *aMoveToHand, *aMoveToGraveyard, *aMoveToExile,
+        *aMoveToTopLibrary, *aMoveToBottomLibrary, *aMoveToHand, *aMoveToGraveyard, *aMoveToExile, *aShuffleAttached,
         *aMoveToXfromTopOfLibrary;
 
     bool shortcutsActive;
@@ -332,6 +332,7 @@ public:
         cmFlip,
         cmPeek,
         cmClone,
+        cmShuffleAttached,
         cmMoveToTopLibrary,
         cmMoveToBottomLibrary,
         cmMoveToHand,

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -123,12 +123,12 @@ signals:
     void logDrawCards(Player *player, int number);
     void logUndoDraw(Player *player, QString cardName);
     void logMoveCard(Player *player,
-                        CardItem *card,
-                        CardZone *startZone,
-                        int oldX,
-                        CardZone *targetZone,
-                        int newX,
-                        bool shuffleAttached = false);
+                     CardItem *card,
+                     CardZone *startZone,
+                     int oldX,
+                     CardZone *targetZone,
+                     int newX,
+                     bool shuffleAttached = false);
     void logFlipCard(Player *player, QString cardName, bool faceDown);
     void logDestroyCard(Player *player, QString cardName);
     void logAttachCard(Player *player, QString cardName, Player *targetPlayer, QString targetCardName);

--- a/common/pb/command_move_card.proto
+++ b/common/pb/command_move_card.proto
@@ -22,4 +22,5 @@ message Command_MoveCard {
     optional string target_zone = 5;
     optional sint32 x = 6 [default = -1];
     optional sint32 y = 7 [default = -1];
+    optional bool shuffle_attached = 8 [default = false];
 }

--- a/common/pb/event_move_card.proto
+++ b/common/pb/event_move_card.proto
@@ -16,4 +16,5 @@ message Event_MoveCard {
     optional sint32 y = 9 [default = -1];
     optional sint32 new_card_id = 10 [default = -1];
     optional bool face_down = 11;
+    optional bool shuffle_attached = 12 [default = false];
 }

--- a/common/pb/event_move_card.proto
+++ b/common/pb/event_move_card.proto
@@ -16,5 +16,5 @@ message Event_MoveCard {
     optional sint32 y = 9 [default = -1];
     optional sint32 new_card_id = 10 [default = -1];
     optional bool face_down = 11;
-    optional bool shuffle_attached = 12 [default = false];
+    repeated sint32 swap_indexes = 12;
 }

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -574,6 +574,7 @@ Response::ResponseCode Server_Player::moveCard(GameEventStorage &ges,
             }
 
             if (shuffleAttached) {
+                // send swap instructions to each player to stay in sync
                 for (int i = card->getAttachedCards().size() - 1; i > 0; i--) {
                     int j = rng->rand(0, i);
                     eventOthers.add_swap_indexes(j);

--- a/common/server_player.h
+++ b/common/server_player.h
@@ -178,7 +178,8 @@ public:
                                     int xCoord,
                                     int yCoord,
                                     bool fixFreeSpaces = true,
-                                    bool undoingDraw = false);
+                                    bool undoingDraw = false,
+                                    bool shuffleAttached = false);
     void unattachCard(GameEventStorage &ges, Server_Card *card);
     Response::ResponseCode setCardAttrHelper(GameEventStorage &ges,
                                              int targetPlayerId,


### PR DESCRIPTION
## Related Ticket(s)
None

## Short roundup of the initial problem
Cockatrice's only way to randomize a set of cards is to put them on the bottom of the library in a random order, which is pretty inconvenient for mini-decks like Scheme or Contraption decks.

## What will change with this Pull Request?
- Cards with attachments will have a "Shuffle attached cards" menu option.
- Using this will randomize the order of the cards attached to it, and log that the player has shuffled the card's attachments.

## Other notes
- This doesn't currently update shortcuts or translations.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![shuffle command](https://user-images.githubusercontent.com/12363371/179372902-986668df-0f40-4aba-8158-aacad701ef70.png)
![shuffled](https://user-images.githubusercontent.com/12363371/179372906-b5226042-5398-4b7f-9110-96a64f44fe2e.png)

