### PR TITLE
Attach and Unattach apply to entire selection

### DIFF
--- a/cockatrice/src/arrowitem.cpp
+++ b/cockatrice/src/arrowitem.cpp
@@ -260,6 +260,11 @@ ArrowAttachItem::ArrowAttachItem(ArrowTarget *_startItem)
 {
 }
 
+void ArrowAttachItem::addChildArrow(ArrowAttachItem *childArrow)
+{
+    childArrows.append(childArrow);
+}
+
 void ArrowAttachItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 {
     if (!startItem)
@@ -295,9 +300,13 @@ void ArrowAttachItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
         updatePath();
     }
     update();
+    
+    for (int i = 0; i < childArrows.size(); ++i) {
+        childArrows[i]->mouseMoveEvent(event);
+    }
 }
 
-void ArrowAttachItem::mouseReleaseEvent(QGraphicsSceneMouseEvent * /*event*/)
+void ArrowAttachItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     if (!startItem)
         return;
@@ -319,4 +328,8 @@ void ArrowAttachItem::mouseReleaseEvent(QGraphicsSceneMouseEvent * /*event*/)
     }
 
     delArrow();
+    
+    for (int i = 0; i < childArrows.size(); ++i) {
+        childArrows[i]->mouseReleaseEvent(event);
+    }
 }

--- a/cockatrice/src/arrowitem.cpp
+++ b/cockatrice/src/arrowitem.cpp
@@ -138,8 +138,8 @@ void ArrowItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
     }
 
     QList<QGraphicsItem *> colliding = scene()->items(event->scenePos());
-    for (int i = 0; i < colliding.size(); ++i) {
-        if (qgraphicsitem_cast<CardItem *>(colliding[i])) {
+    for (QGraphicsItem *item : colliding) {
+        if (qgraphicsitem_cast<CardItem *>(item)) {
             event->ignore();
             return;
         }
@@ -205,8 +205,8 @@ void ArrowDragItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
     }
     update();
 
-    for (int i = 0; i < childArrows.size(); ++i) {
-        childArrows[i]->mouseMoveEvent(event);
+    for (ArrowDragItem *child : childArrows) {
+        child->mouseMoveEvent(event);
     }
 }
 
@@ -251,8 +251,9 @@ void ArrowDragItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
     }
     delArrow();
 
-    for (int i = 0; i < childArrows.size(); ++i)
-        childArrows[i]->mouseReleaseEvent(event);
+    for (ArrowDragItem *child : childArrows) {
+        child->mouseReleaseEvent(event);
+    }
 }
 
 ArrowAttachItem::ArrowAttachItem(ArrowTarget *_startItem)
@@ -300,9 +301,9 @@ void ArrowAttachItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
         updatePath();
     }
     update();
-    
-    for (int i = 0; i < childArrows.size(); ++i) {
-        childArrows[i]->mouseMoveEvent(event);
+
+    for (ArrowAttachItem *child : childArrows) {
+        child->mouseMoveEvent(event);
     }
 }
 
@@ -328,8 +329,8 @@ void ArrowAttachItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
     }
 
     delArrow();
-    
-    for (int i = 0; i < childArrows.size(); ++i) {
-        childArrows[i]->mouseReleaseEvent(event);
+
+    for (ArrowAttachItem *child : childArrows) {
+        child->mouseReleaseEvent(event);
     }
 }

--- a/cockatrice/src/arrowitem.h
+++ b/cockatrice/src/arrowitem.h
@@ -87,6 +87,7 @@ class ArrowAttachItem : public ArrowItem
     Q_OBJECT
 private:
     QList<ArrowAttachItem *> childArrows;
+
 public:
     ArrowAttachItem(ArrowTarget *_startItem);
     void addChildArrow(ArrowAttachItem *childArrow);

--- a/cockatrice/src/arrowitem.h
+++ b/cockatrice/src/arrowitem.h
@@ -85,8 +85,11 @@ protected:
 class ArrowAttachItem : public ArrowItem
 {
     Q_OBJECT
+private:
+    QList<ArrowAttachItem *> childArrows;
 public:
     ArrowAttachItem(ArrowTarget *_startItem);
+    void addChildArrow(ArrowAttachItem *childArrow);
 
 protected:
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event);

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -300,6 +300,29 @@ void CardItem::drawArrow(const QColor &arrowColor)
     }
 }
 
+void CardItem::drawAttachArrow()
+{
+    if (static_cast<TabGame *>(owner->parent())->getSpectator())
+        return;
+
+    auto *arrow = new ArrowAttachItem(this);
+    scene()->addItem(arrow);
+    arrow->grabMouse();
+
+    QListIterator<QGraphicsItem *> itemIterator(scene()->selectedItems());
+    while(itemIterator.hasNext()) {
+        CardItem *c = qgraphicsitem_cast<CardItem *>(itemIterator.next());
+        if (!c)
+            continue;
+        if (c->getZone() != zone)
+            continue;
+
+        ArrowAttachItem *childArrow = new ArrowAttachItem(c);
+        scene()->addItem(childArrow);
+        arrow->addChildArrow(childArrow);
+    }
+}
+
 void CardItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 {
     if (event->buttons().testFlag(Qt::RightButton)) {

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -286,15 +286,14 @@ void CardItem::drawArrow(const QColor &arrowColor)
     scene()->addItem(arrow);
     arrow->grabMouse();
 
-    QListIterator<QGraphicsItem *> itemIterator(scene()->selectedItems());
-    while (itemIterator.hasNext()) {
-        CardItem *c = qgraphicsitem_cast<CardItem *>(itemIterator.next());
-        if (!c || (c == this))
+    for (const auto &item : scene()->selectedItems()) {
+        CardItem *card = qgraphicsitem_cast<CardItem *>(item);
+        if (card == nullptr || card == this)
             continue;
-        if (c->getZone() != zone)
+        if (card->getZone() != zone)
             continue;
 
-        ArrowDragItem *childArrow = new ArrowDragItem(arrowOwner, c, arrowColor);
+        ArrowDragItem *childArrow = new ArrowDragItem(arrowOwner, card, arrowColor);
         scene()->addItem(childArrow);
         arrow->addChildArrow(childArrow);
     }
@@ -309,15 +308,14 @@ void CardItem::drawAttachArrow()
     scene()->addItem(arrow);
     arrow->grabMouse();
 
-    QListIterator<QGraphicsItem *> itemIterator(scene()->selectedItems());
-    while(itemIterator.hasNext()) {
-        CardItem *c = qgraphicsitem_cast<CardItem *>(itemIterator.next());
-        if (!c)
+    for (const auto &item : scene()->selectedItems()) {
+        CardItem *card = qgraphicsitem_cast<CardItem *>(item);
+        if (card == nullptr)
             continue;
-        if (c->getZone() != zone)
+        if (card->getZone() != zone)
             continue;
 
-        ArrowAttachItem *childArrow = new ArrowAttachItem(c);
+        ArrowAttachItem *childArrow = new ArrowAttachItem(card);
         scene()->addItem(childArrow);
         arrow->addChildArrow(childArrow);
     }
@@ -355,19 +353,19 @@ void CardItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
         createDragItem(id, event->pos(), event->scenePos(), facedown || forceFaceDown);
         dragItem->grabMouse();
 
-        QList<QGraphicsItem *> sel = scene()->selectedItems();
-        int j = 0;
-        for (int i = 0; i < sel.size(); i++) {
-            CardItem *c = static_cast<CardItem *>(sel.at(i));
-            if ((c == this) || (c->getZone() != zone))
+        int childIndex = 0;
+        for (const auto &item : scene()->selectedItems()) {
+            CardItem *card = static_cast<CardItem *>(item);
+            if ((card == this) || (card->getZone() != zone))
                 continue;
-            ++j;
+            ++childIndex;
             QPointF childPos;
             if (zone->getHasCardAttr())
-                childPos = c->pos() - pos();
+                childPos = card->pos() - pos();
             else
-                childPos = QPointF(j * CARD_WIDTH / 2, 0);
-            CardDragItem *drag = new CardDragItem(c, c->getId(), childPos, c->getFaceDown() || forceFaceDown, dragItem);
+                childPos = QPointF(childIndex * CARD_WIDTH / 2, 0);
+            CardDragItem *drag =
+                new CardDragItem(card, card->getId(), childPos, card->getFaceDown() || forceFaceDown, dragItem);
             drag->setPos(dragItem->pos() + childPos);
             scene()->addItem(drag);
         }

--- a/cockatrice/src/carditem.h
+++ b/cockatrice/src/carditem.h
@@ -157,6 +157,7 @@ public:
     CardDragItem *createDragItem(int _id, const QPointF &_pos, const QPointF &_scenePos, bool faceDown);
     void deleteDragItem();
     void drawArrow(const QColor &arrowColor);
+    void drawAttachArrow();
     void playCard(bool faceDown);
 
 protected:

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -3186,9 +3186,7 @@ void Player::actAttach()
         return;
     }
 
-    auto *arrow = new ArrowAttachItem(card);
-    scene()->addItem(arrow);
-    arrow->grabMouse();
+    game->getActiveCard()->drawAttachArrow();
 }
 
 void Player::actUnattach()
@@ -3197,10 +3195,16 @@ void Player::actUnattach()
         return;
     }
 
-    Command_AttachCard cmd;
-    cmd.set_start_zone(game->getActiveCard()->getZone()->getName().toStdString());
-    cmd.set_card_id(game->getActiveCard()->getId());
-    sendGameCommand(cmd);
+    QList<const ::google::protobuf::Message *> commandList;
+    auto sel = scene()->selectedItems();
+    for (const auto &item : sel) {
+        auto *card = static_cast<CardItem *>(item);
+        auto *cmd = new Command_AttachCard;
+        cmd->set_start_zone(card->getZone()->getName().toStdString());
+        cmd->set_card_id(card->getId());
+        commandList.append(cmd);
+    }
+    sendGameCommand(prepareGameCommand(commandList));
 }
 
 void Player::actCardCounterTrigger()

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -3186,7 +3186,7 @@ void Player::actAttach()
         return;
     }
 
-    game->getActiveCard()->drawAttachArrow();
+    card->drawAttachArrow();
 }
 
 void Player::actUnattach()
@@ -3196,8 +3196,7 @@ void Player::actUnattach()
     }
 
     QList<const ::google::protobuf::Message *> commandList;
-    auto sel = scene()->selectedItems();
-    for (const auto &item : sel) {
+    for (QGraphicsItem *item : scene()->selectedItems()) {
         auto *card = static_cast<CardItem *>(item);
         auto *cmd = new Command_AttachCard;
         cmd->set_start_zone(card->getZone()->getName().toStdString());


### PR DESCRIPTION
## Related Ticket(s)
Doesn't look like anyone's ticketed this before.

## Short roundup of the initial problem
If you select multiple cards and use the menu option to Attach them or Unattach them, only the active card is moved and the rest stay where they were.

## What will change with this Pull Request?
- Added childArrows to AttachArrowItem and added them to the mouseEvents.
- Added drawAttachArrow to CardItem. This is mostly identical to drawArrow, but doesn't skip the childArrow that's == this. If that is skipped, the active card is still the only one moved as before.
- actAttach and actUnattach are changed so the menu action now applies to the entire selection.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![arrows](https://user-images.githubusercontent.com/12363371/179401107-0c3e0fe2-6b58-4ff3-8cf7-76ae694bc424.png)
![all in a row](https://user-images.githubusercontent.com/12363371/179401109-d2b9f075-a495-40bb-8469-8b45b748fa8e.png)


