### PR TITLE
Selecting game already open in a tab brings user to that tab.

### DIFF
--- a/cockatrice/src/chatview/chatview.cpp
+++ b/cockatrice/src/chatview/chatview.cpp
@@ -21,7 +21,7 @@ UserMessagePosition::UserMessagePosition(QTextCursor &cursor)
     relativePosition = cursor.position() - block.position();
 }
 
-ChatView::ChatView(const TabSupervisor *_tabSupervisor,
+ChatView::ChatView(TabSupervisor *_tabSupervisor,
                    const UserlistProxy *_userlistProxy,
                    TabGame *_game,
                    bool _showTimestamps,

--- a/cockatrice/src/chatview/chatview.h
+++ b/cockatrice/src/chatview/chatview.h
@@ -33,7 +33,7 @@ class ChatView : public QTextBrowser
 {
     Q_OBJECT
 protected:
-    const TabSupervisor *const tabSupervisor;
+    TabSupervisor *const tabSupervisor;
     TabGame *const game;
 
 private:
@@ -83,7 +83,7 @@ private slots:
     void actMessageClicked();
 
 public:
-    ChatView(const TabSupervisor *_tabSupervisor,
+    ChatView(TabSupervisor *_tabSupervisor,
              const UserlistProxy *_userlistProxy,
              TabGame *_game,
              bool _showTimestamps,

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -10,6 +10,7 @@
 #include "pb/serverinfo_game.pb.h"
 #include "pending_command.h"
 #include "tab_account.h"
+#include "tab_game.h"
 #include "tab_room.h"
 #include "tab_supervisor.h"
 
@@ -26,7 +27,7 @@
 #include <QVBoxLayout>
 
 GameSelector::GameSelector(AbstractClient *_client,
-                           const TabSupervisor *_tabSupervisor,
+                           TabSupervisor *_tabSupervisor,
                            TabRoom *_room,
                            const QMap<int, QString> &_rooms,
                            const QMap<int, GameTypeMap> &_gameTypes,
@@ -239,32 +240,34 @@ void GameSelector::actJoin()
     if (!ind.isValid())
         return;
     const ServerInfo_Game &game = gameListModel->getGame(ind.data(Qt::UserRole).toInt());
-    bool spectator = sender() == spectateButton || game.player_count() == game.max_players();
-    bool overrideRestrictions = !tabSupervisor->getAdminLocked();
-    QString password;
-    if (game.with_password() && !(spectator && !game.spectators_need_password()) && !overrideRestrictions) {
-        bool ok;
-        password = getTextWithMax(this, tr("Join game"), tr("Password:"), QLineEdit::Password, QString(), &ok);
-        if (!ok)
+    if (!tabSupervisor->switchToGameTabIfAlreadyExists(game.game_id())) {
+        bool spectator = sender() == spectateButton || game.player_count() == game.max_players();
+        bool overrideRestrictions = !tabSupervisor->getAdminLocked();
+        QString password;
+        if (game.with_password() && !(spectator && !game.spectators_need_password()) && !overrideRestrictions) {
+            bool ok;
+            password = getTextWithMax(this, tr("Join game"), tr("Password:"), QLineEdit::Password, QString(), &ok);
+            if (!ok)
+                return;
+        }
+
+        Command_JoinGame cmd;
+        cmd.set_game_id(game.game_id());
+        cmd.set_password(password.toStdString());
+        cmd.set_spectator(spectator);
+        cmd.set_override_restrictions(overrideRestrictions);
+        cmd.set_join_as_judge((QApplication::keyboardModifiers() & Qt::ShiftModifier) != 0);
+
+        TabRoom *r = tabSupervisor->getRoomTabs().value(game.room_id());
+        if (!r) {
+            QMessageBox::critical(this, tr("Error"), tr("Please join the respective room first."));
             return;
+        }
+
+        PendingCommand *pend = r->prepareRoomCommand(cmd);
+        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(checkResponse(Response)));
+        r->sendRoomCommand(pend);
     }
-
-    Command_JoinGame cmd;
-    cmd.set_game_id(game.game_id());
-    cmd.set_password(password.toStdString());
-    cmd.set_spectator(spectator);
-    cmd.set_override_restrictions(overrideRestrictions);
-    cmd.set_join_as_judge((QApplication::keyboardModifiers() & Qt::ShiftModifier) != 0);
-
-    TabRoom *r = tabSupervisor->getRoomTabs().value(game.room_id());
-    if (!r) {
-        QMessageBox::critical(this, tr("Error"), tr("Please join the respective room first."));
-        return;
-    }
-
-    PendingCommand *pend = r->prepareRoomCommand(cmd);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(checkResponse(Response)));
-    r->sendRoomCommand(pend);
 
     if (createButton)
         createButton->setEnabled(false);

--- a/cockatrice/src/gameselector.h
+++ b/cockatrice/src/gameselector.h
@@ -38,7 +38,7 @@ signals:
 
 private:
     AbstractClient *client;
-    const TabSupervisor *tabSupervisor;
+    TabSupervisor *tabSupervisor;
     TabRoom *room;
 
     QTreeView *gameListView;
@@ -52,7 +52,7 @@ private:
 
 public:
     GameSelector(AbstractClient *_client,
-                 const TabSupervisor *_tabSupervisor,
+                 TabSupervisor *_tabSupervisor,
                  TabRoom *_room,
                  const QMap<int, QString> &_rooms,
                  const QMap<int, GameTypeMap> &_gameTypes,

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -827,7 +827,7 @@ void MessageLogWidget::connectToPlayer(Player *player)
             SLOT(logAlwaysLookAtTopCard(Player *, CardZone *, bool)));
 }
 
-MessageLogWidget::MessageLogWidget(const TabSupervisor *_tabSupervisor,
+MessageLogWidget::MessageLogWidget(TabSupervisor *_tabSupervisor,
                                    const UserlistProxy *_userlistProxy,
                                    TabGame *_game,
                                    QWidget *parent)

--- a/cockatrice/src/messagelogwidget.h
+++ b/cockatrice/src/messagelogwidget.h
@@ -102,7 +102,7 @@ public slots:
 
 public:
     void connectToPlayer(Player *player);
-    MessageLogWidget(const TabSupervisor *_tabSupervisor,
+    MessageLogWidget(TabSupervisor *_tabSupervisor,
                      const UserlistProxy *_userlistProxy,
                      TabGame *_game,
                      QWidget *parent = nullptr);

--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -735,3 +735,16 @@ const ServerInfo_User *TabSupervisor::getOnlineUser(const QString &userName) con
 
     return nullptr;
 };
+
+bool TabSupervisor::switchToGameTabIfAlreadyExists(const int gameId)
+{
+    bool isGameTabExists = false;
+    if (gameTabs.contains(gameId)) {
+        isGameTabExists = true;
+        TabGame *tabGame = gameTabs[gameId];
+        const int gameTabIndex = indexOf(tabGame);
+        setCurrentIndex(gameTabIndex);
+    }
+
+    return isGameTabExists;
+}

--- a/cockatrice/src/tab_supervisor.h
+++ b/cockatrice/src/tab_supervisor.h
@@ -120,6 +120,7 @@ public:
     bool isUserBuddy(const QString &userName) const;
     bool isUserIgnored(const QString &userName) const;
     const ServerInfo_User *getOnlineUser(const QString &userName) const;
+    bool switchToGameTabIfAlreadyExists(const int gameId);
     void actShowPopup(const QString &message);
 signals:
     void setMenu(const QList<QMenu *> &newMenuList = QList<QMenu *>());

--- a/cockatrice/src/user_context_menu.cpp
+++ b/cockatrice/src/user_context_menu.cpp
@@ -26,7 +26,7 @@
 #include <QtGui>
 #include <QtWidgets>
 
-UserContextMenu::UserContextMenu(const TabSupervisor *_tabSupervisor, QWidget *parent, TabGame *_game)
+UserContextMenu::UserContextMenu(TabSupervisor *_tabSupervisor, QWidget *parent, TabGame *_game)
     : QObject(parent), client(_tabSupervisor->getClient()), tabSupervisor(_tabSupervisor), game(_game)
 {
     aUserName = new QAction(QString(), this);

--- a/cockatrice/src/user_context_menu.h
+++ b/cockatrice/src/user_context_menu.h
@@ -21,7 +21,7 @@ class UserContextMenu : public QObject
     Q_OBJECT
 private:
     AbstractClient *client;
-    const TabSupervisor *tabSupervisor;
+    TabSupervisor *tabSupervisor;
     TabGame *game;
 
     QAction *aUserName;
@@ -49,7 +49,7 @@ private slots:
     void gamesOfUserReceived(const Response &resp, const CommandContainer &commandContainer);
 
 public:
-    UserContextMenu(const TabSupervisor *_tabSupervisor, QWidget *_parent, TabGame *_game = 0);
+    UserContextMenu(TabSupervisor *_tabSupervisor, QWidget *_parent, TabGame *_game = 0);
     void retranslateUi();
     void showContextMenu(const QPoint &pos,
                          const QString &userName,


### PR DESCRIPTION

## Related Ticket(s)
_none_

## Short roundup of the initial problem
When already in game X (with it as an open tab), selecting game X from the game list won't bring the user to that game tab. When spectating multiple games (with multiple game tabs open) it's quite frustrating when selecting a game already joined and not being able to open it.

## What will change with this Pull Request?
- Before sending `Command_JoinGame` to the server, it does a check to see if the game is open in a tab, and if so sets that tab as `TabSupervisor`'s current tab. The request to join is still sent to the server. Only change is that client-side check.

## Screenshots
Before:
![before](https://user-images.githubusercontent.com/1865818/179426109-ad53bd9d-ce2e-49bc-90ad-abc232e03137.gif)

After:
![after](https://user-images.githubusercontent.com/1865818/179426112-9e712b6a-d47a-4754-8127-609739b2973e.gif)
