### PR TITLE
fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 <br><pre>
 <b>To get started, &#8674; [view our webpage](https://cockatrice.github.io/)</b><br>
 <b>To get support or suggest changes &#8674; [file an issue](https://github.com/Cockatrice/Cockatrice/issues) ([How?](https://github.com/Cockatrice/Cockatrice/wiki/How-to-Create-a-GitHub-Ticket-Regarding-Cockatrice))</b>
-<b>To help with development, see how to [get involved](#get-involved-)</b>
+<b>To help with development, see how to [get involved](#get-involved--)</b>
 </pre><br>
 
 


### PR DESCRIPTION
## Short roundup of the initial problem
Ones of the links in the header section of the README did not work as intended.

## What will change with this Pull Request?
- Fixes link in README.md to get to the Get Involved section