### PR TITLE
fix keepalive being multiplied in server timeout

### DIFF
--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -541,10 +541,9 @@ void RemoteClient::ping()
         }
     }
 
-    int keepalive = SettingsCache::instance().getKeepAlive();
     int maxTime = timeRunning - lastDataReceived;
     emit maxPingTime(maxTime, maxTimeout);
-    if (maxTime >= (keepalive * maxTimeout)) {
+    if (maxTime >= maxTimeout) {
         disconnectFromServer();
         emit serverTimeout();
     } else {

--- a/cockatrice/src/remoteclient.h
+++ b/cockatrice/src/remoteclient.h
@@ -89,7 +89,7 @@ private slots:
     void submitForgotPasswordChallengeResponse(const Response &response);
 
 private:
-    static const int maxTimeout = 10;
+    static const int maxTimeout = 5;
     int timeRunning, lastDataReceived;
     QByteArray inputBuffer;
     bool messageInProgress;

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -181,7 +181,7 @@ SettingsCache::SettingsCache()
     updateReleaseChannel = settings->value("personal/updatereleasechannel", 0).toInt();
 
     lang = settings->value("personal/lang").toString();
-    keepalive = settings->value("personal/keepalive", 5).toInt();
+    keepalive = settings->value("personal/keepalive", 3).toInt();
 
     // tip of the day settings
     showTipsOnStartup = settings->value("tipOfDay/showTips", true).toBool();


### PR DESCRIPTION
## Short roundup of the initial problem
a timeout happened after the client not receiving anything for `keepalive * keepalive * maxtimeout` (5 * 5 * 10) seconds instead of what you'd expect. seems to have been an oversight in https://github.com/Cockatrice/Cockatrice/pull/1313

## What will change with this Pull Request?
it now only uses keepalive once instead of twice, this means it should now take 50 seconds to time out when disconnected, we could also change the value of the max timeout (currently 10) to something like 6 to time out in 30 seconds instead.
