### PR TITLE
CI: `macOS-10.15` environment is deprecated

### DIFF
--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -8,12 +8,11 @@ git push -d origin --REPLACE-WITH-BETA-LIST--
 include different targets -->
 <pre>
 <b>Pre-compiled binaries we serve:</b>
- - <kbd>Windows 7/8/10/11 (32-bit)</kbd>
- - <kbd>Windows 7/8 (64-bit)</kbd>
- - <kbd>Windows 10/11 (64-bit)</kbd>
- - <kbd>macOS 10.14</kbd> ("Mojave")
- - <kbd>macOS 10.15</kbd> ("Catalina")
- - <kbd>macOS 11.0+</kbd> ("Big Sur")
+ - <kbd>Windows 7+ (32-bit)</kbd>
+ - <kbd>Windows 7+</kbd>
+ - <kbd>Windows 10+</kbd>
+ - <kbd>macOS 10.15+</kbd> ("Catalina")
+ - <kbd>macOS 11+</kbd> ("Big Sur")
  - <kbd>Ubuntu 18.04</kbd> ("Bionic Beaver")
  - <kbd>Ubuntu 20.04</kbd> ("Focal Fossa")
  - <kbd>Ubuntu 22.04</kbd> ("Jammy Jellyfish")

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -190,14 +190,14 @@ jobs:
         include:
           - target: Debug # tests only
             os: macos-latest
-            xcode: 12.5.1
+            xcode: 13.0
             qt_version: 6
             type: Debug
             do_tests: 1
 
           - target: 10.15_Catalina
             os: macos-11
-            xcode: 11.7
+            xcode: 11.7 # allows using macOS 10.15 SDK
             qt_version: 6
             type: Release
             do_tests: 1
@@ -205,7 +205,7 @@ jobs:
 
           - target: 11_Big_Sur
             os: macos-11
-            xcode: 13.2
+            xcode: 13.0
             qt_version: 6
             type: Release
             do_tests: 1

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -195,17 +195,9 @@ jobs:
             type: Debug
             do_tests: 1
 
-          - target: 10.14_Mojave
-            os: macos-10.15 # runs on Catalina
-            xcode: 10.3 # allows compatibility with macOS 10.14
-            qt_version: 5
-            type: Release
-            # do_tests: 1 # tests do not work on qt5?
-            make_package: 1
-
           - target: 10.15_Catalina
-            os: macos-10.15
-            xcode: 12.4
+            os: macos-11
+            xcode: 11.7
             qt_version: 6
             type: Release
             do_tests: 1

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -190,7 +190,7 @@ jobs:
         include:
           - target: Debug # tests only
             os: macos-latest
-            xcode: 13.0
+            xcode: 12.5.1
             qt_version: 6
             type: Debug
             do_tests: 1
@@ -205,7 +205,7 @@ jobs:
 
           - target: 11_Big_Sur
             os: macos-11
-            xcode: 13.0
+            xcode: 12.5.1
             qt_version: 6
             type: Release
             do_tests: 1


### PR DESCRIPTION
## Short roundup of the initial problem
The environment in question will be fully unsupported on GitHub actions by December 1st.
Probably reasonable to have a full release by then (and before merging this) to get macOS 10.14 support once in a release again.


## What will change with this Pull Request?
- macOS 10.14 has to be dropped
- macOS 10.15 builds can still be done via macOS 11 with an old Xcode
- Correctly target our build for macOS 11
- Use most recent working Xcode versions (in respect to the targets)
