### PR TITLE
fix updater with changes in release name

### DIFF
--- a/cockatrice/src/releasechannel.cpp
+++ b/cockatrice/src/releasechannel.cpp
@@ -65,7 +65,7 @@ bool ReleaseChannel::downloadMatchesCurrentOS(const QString &fileName)
     return fileName.contains("32bit");
 #elif Q_PROCESSOR_WORDSIZE == 8
     const QString &version = QSysInfo::productVersion();
-    if(version.startsWith("7") || version.startsWith("8")) {
+    if (version.startsWith("7") || version.startsWith("8")) {
         return fileName.contains("Win7");
     } else {
         return fileName.contains("Win10");

--- a/cockatrice/src/releasechannel.cpp
+++ b/cockatrice/src/releasechannel.cpp
@@ -62,9 +62,14 @@ bool ReleaseChannel::downloadMatchesCurrentOS(const QString &fileName)
 bool ReleaseChannel::downloadMatchesCurrentOS(const QString &fileName)
 {
 #if Q_PROCESSOR_WORDSIZE == 4
-    return fileName.contains("win32");
+    return fileName.contains("32bit");
 #elif Q_PROCESSOR_WORDSIZE == 8
-    return fileName.contains("win64");
+    const QString &version = QSysInfo::productVersion();
+    if(version.startsWith("7") || version.startsWith("8")) {
+        return fileName.contains("Win7");
+    } else {
+        return fileName.contains("Win10");
+    }
 #else
     return false;
 #endif


### PR DESCRIPTION
with the addition of the win7 build the naming has changed to no longer include win32 or win64

I've modified the latest release names to include these so they'll work again

this pr will now search for the changed name and theoretically should get the right build for windows 7