### PR TITLE
CI: Change Qt install method on macOS

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -206,7 +206,7 @@ jobs:
           - target: 10.15_Catalina
             os: macos-10.15
             xcode: 12.4
-            qt_version: 6.*
+            qt_version: 6.3.*
             type: Release
             do_tests: 1
             make_package: 1
@@ -214,7 +214,7 @@ jobs:
           - target: 11_Big_Sur
             os: macos-11
             xcode: 13.2
-            qt_version: 6.*.*
+            qt_version: 6.3.*
             type: Release
             do_tests: 1
             make_package: 1
@@ -263,7 +263,7 @@ jobs:
           MAKE_PACKAGE: '${{matrix.make_package}}'
           PACKAGE_SUFFIX: '-macOS-${{matrix.target}}'
           # set QTDIR to find qt5, qt6 can be found without this
-          QTDIR: '/usr/local/opt/qt5'
+          QTDIR: '/Users/runner/work/Cockatrice/Qt'
         # Mac machines actually have 3 cores
         run: .ci/compile.sh --server --parallel 3
 

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -239,16 +239,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install dependencies using homebrew
+      - name: Install Qt ${{matrix.qt_version}}
+        uses: jurplel/install-qt-action@v3
+        with:
+          cache: true
+          setup-python: false
+          version: ${{matrix.qt_version}}
+
+      - name: Install protobuf using homebrew
         shell: bash
         # cmake cannot find the mysql connector
         # neither of these works: mariadb-connector-c mysql-connector-c++
-        env:
-          qt_version: 'qt@${{matrix.qt_version}}'
         run: |
           brew update
           brew install protobuf
-          brew install "$qt_version" --force-bottle
 
       - name: Build on Xcode ${{matrix.xcode}}
         shell: bash

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -263,7 +263,7 @@ jobs:
           MAKE_PACKAGE: '${{matrix.make_package}}'
           PACKAGE_SUFFIX: '-macOS-${{matrix.target}}'
           # set QTDIR to find qt5, qt6 can be found without this
-          QTDIR: '/Users/runner/work/Cockatrice/Qt'
+          QTDIR: '/usr/local/opt/qt5'
         # Mac machines actually have 3 cores
         run: .ci/compile.sh --server --parallel 3
 

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -191,14 +191,14 @@ jobs:
           - target: Debug # tests only
             os: macos-latest
             xcode: 12.5.1
-            qt_version: 6
+            qt_version: 6.3.*
             type: Debug
             do_tests: 1
 
           - target: 10.14_Mojave
             os: macos-10.15 # runs on Catalina
             xcode: 10.3 # allows compatibility with macOS 10.14
-            qt_version: 5
+            qt_version: 5.15.*
             type: Release
             # do_tests: 1 # tests do not work on qt5?
             make_package: 1
@@ -206,7 +206,7 @@ jobs:
           - target: 10.15_Catalina
             os: macos-10.15
             xcode: 12.4
-            qt_version: 6
+            qt_version: 6.*
             type: Release
             do_tests: 1
             make_package: 1
@@ -214,7 +214,7 @@ jobs:
           - target: 11_Big_Sur
             os: macos-11
             xcode: 13.2
-            qt_version: 6
+            qt_version: 6.*.*
             type: Release
             do_tests: 1
             make_package: 1

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -191,7 +191,7 @@ jobs:
           - target: Debug # tests only
             os: macos-latest
             xcode: 12.5.1
-            qt_version: 6.3.*
+            qt_version: 6.2.*
             type: Debug
             do_tests: 1
 
@@ -206,7 +206,7 @@ jobs:
           - target: 10.15_Catalina
             os: macos-10.15
             xcode: 12.4
-            qt_version: 6.3.*
+            qt_version: 6.0.*
             type: Release
             do_tests: 1
             make_package: 1
@@ -214,7 +214,7 @@ jobs:
           - target: 11_Big_Sur
             os: macos-11
             xcode: 13.2
-            qt_version: 6.3.*
+            qt_version: 6.1.*
             type: Release
             do_tests: 1
             make_package: 1


### PR DESCRIPTION
## Short roundup of the initial problem
Install via homebrew takes a while

## What will change with this Pull Request?
- Use jurplel/install-qt-action, same as for Windows
- The actions has caching build in

---

<details>
<summary>It works for the Qt5 build for "macOS 10.14_Mojave"</summary>

https://github.com/Cockatrice/Cockatrice/runs/8176866997?check_suite_focus=true

</details>

<details>
<summary>It works not for the Qt6 build for "macOS 10.15_Catalina" and the other Qt6 builds</summary>

https://github.com/Cockatrice/Cockatrice/runs/8176867039?check_suite_focus=true#step:5:47

Qt is installed, but CMake doesn't find a suitable version:

>   CMake Error at cmake/FindQtRuntime.cmake:75 (message):
    **No suitable version of Qt was found**
  Call Stack (most recent call first):
  -- Configuring incomplete, errors occurred!
    CMakeLists.txt:214 (include)

Setting `QTDIR` to `/Users/runner/work/Cockatrice/Qt` didn't change that.

</details>
