### PR TITLE
remove cards being looked at from the count on drawing

### DIFF
--- a/common/server_cardzone.h
+++ b/common/server_cardzone.h
@@ -68,7 +68,7 @@ public:
     }
     void setCardsBeingLookedAt(int _cardsBeingLookedAt)
     {
-        cardsBeingLookedAt = _cardsBeingLookedAt;
+        cardsBeingLookedAt = qMax(0, _cardsBeingLookedAt);
     }
     bool isCardAtPosLookedAt(int pos) const;
     bool hasCoords() const

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -337,7 +337,11 @@ Response::ResponseCode Server_Player::drawCards(GameEventStorage &ges, int numbe
     ges.enqueueGameEvent(eventPrivate, playerId, GameEventStorageItem::SendToPrivate, playerId);
     ges.enqueueGameEvent(eventOthers, playerId, GameEventStorageItem::SendToOthers);
 
-    revealTopCardIfNeeded(deckZone, ges);
+    if (number > 0) {
+        revealTopCardIfNeeded(deckZone, ges);
+        int currentKnownCards = deckZone->getCardsBeingLookedAt();
+        deckZone->setCardsBeingLookedAt(currentKnownCards - number);
+    }
 
     return Response::RespOk;
 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes https://github.com/Cockatrice/Cockatrice/issues/4670

## Short roundup of the initial problem
drawing cards did not trigger the count of cards being looked at getting reduced, unlike moving cards.
this bug seems to have been present since inception of the feature.

## What will change with this Pull Request?
- drawing cards reduces the cards being looked at by that amount
