### PR TITLE
Fix Qt5 detection when Qt6 is partially present

### DIFF
--- a/cmake/FindQtRuntime.cmake
+++ b/cmake/FindQtRuntime.cmake
@@ -42,31 +42,31 @@ list(REMOVE_DUPLICATES REQUIRED_QT_COMPONENTS)
 
 get_cmake_property(_parent_vars VARIABLES)
 function(have_qt6)
-    # Core5Compat is Qt6 Only, Linguist is now a component in Qt6 instead of an external package
-    find_package(
-      Qt6 6.2.3
-      COMPONENTS Core5Compat ${REQUIRED_QT_COMPONENTS}
-      OPTIONAL_COMPONENTS Linguist
-      QUIET HINTS ${Qt6_DIR}
-    )
-    if(Qt6_FOUND)
-      # Copy all new variables to parent scope, as if we weren't in a function
-      # A bit of an ugly hack, but I don't think there's a nicer way
-      get_cmake_property(_vars VARIABLES)
-      foreach (_var ${_vars})
-          list(FIND _parent_vars ${_var} _idx)
-          # FIND gives the index which starts at 0, or -1 for not found
-          # Add 1 so we have a truthy value for every index and 0 for not found
-          math(EXPR _in_list "${_idx} + 1")
-          # if not in parent_scope (i.e. newly set)
-          if(NOT ${_in_list})
-            set(${_var} ${${_var}} PARENT_SCOPE)
-          endif()
-      endforeach()
-    else()
-      # Only add Qt6_FOUND to parent scope to avoid misconfiguring Qt5 when Qt6 is partially present
-      set(Qt6_FOUND ${Qt6_FOUND} PARENT_SCOPE)
-    endif()
+  # Core5Compat is Qt6 Only, Linguist is now a component in Qt6 instead of an external package
+  find_package(
+    Qt6 6.2.3
+    COMPONENTS Core5Compat ${REQUIRED_QT_COMPONENTS}
+    OPTIONAL_COMPONENTS Linguist
+    QUIET HINTS ${Qt6_DIR}
+  )
+  if(Qt6_FOUND)
+    # Copy all new variables to parent scope, as if we weren't in a function
+    # A bit of an ugly hack, but I don't think there's a nicer way
+    get_cmake_property(_vars VARIABLES)
+    foreach (_var ${_vars})
+      list(FIND _parent_vars ${_var} _idx)
+      # FIND gives the index which starts at 0, or -1 for not found
+      # Add 1 so we have a truthy value for every index and 0 for not found
+      math(EXPR _in_list "${_idx} + 1")
+      # if not in parent_scope (i.e. newly set)
+      if(NOT ${_in_list})
+        set(${_var} ${${_var}} PARENT_SCOPE)
+      endif()
+    endforeach()
+  else()
+    # Only add Qt6_FOUND to parent scope to avoid misconfiguring Qt5 when Qt6 is partially present
+    set(Qt6_FOUND ${Qt6_FOUND} PARENT_SCOPE)
+  endif()
 endfunction()
 
 if(NOT FORCE_USE_QT5)

--- a/cmake/FindQtRuntime.cmake
+++ b/cmake/FindQtRuntime.cmake
@@ -40,15 +40,39 @@ set(REQUIRED_QT_COMPONENTS ${REQUIRED_QT_COMPONENTS} ${_SERVATRICE_NEEDED} ${_CO
 )
 list(REMOVE_DUPLICATES REQUIRED_QT_COMPONENTS)
 
+get_cmake_property(_parent_vars VARIABLES)
+function(have_qt6)
+    # Core5Compat is Qt6 Only, Linguist is now a component in Qt6 instead of an external package
+    find_package(
+      Qt6 6.2.3
+      COMPONENTS Core5Compat ${REQUIRED_QT_COMPONENTS}
+      OPTIONAL_COMPONENTS Linguist
+      QUIET HINTS ${Qt6_DIR}
+    )
+    if(Qt6_FOUND)
+      # Copy all new variables to parent scope, as if we weren't in a function
+      # A bit of an ugly hack, but I don't think there's a nicer way
+      get_cmake_property(_vars VARIABLES)
+      foreach (_var ${_vars})
+          list(FIND _parent_vars ${_var} _idx)
+          # FIND gives the index which starts at 0, or -1 for not found
+          # Add 1 so we have a truthy value for every index and 0 for not found
+          math(EXPR _in_list "${_idx} + 1")
+          # if not in parent_scope (i.e. newly set)
+          if(NOT ${_in_list})
+            set(${_var} ${${_var}} PARENT_SCOPE)
+          endif()
+      endforeach()
+    else()
+      # Only add Qt6_FOUND to parent scope to avoid misconfiguring Qt5 when Qt6 is partially present
+      set(Qt6_FOUND ${Qt6_FOUND} PARENT_SCOPE)
+    endif()
+endfunction()
+
 if(NOT FORCE_USE_QT5)
-  # Core5Compat is Qt6 Only, Linguist is now a component in Qt6 instead of an external package
-  find_package(
-    Qt6 6.2.3
-    COMPONENTS Core5Compat ${REQUIRED_QT_COMPONENTS}
-    OPTIONAL_COMPONENTS Linguist
-    QUIET HINTS ${Qt6_DIR}
-  )
+  have_qt6()
 endif()
+
 if(Qt6_FOUND)
   set(COCKATRICE_QT_VERSION_NAME Qt6)
 

--- a/cmake/FindQtRuntime.cmake
+++ b/cmake/FindQtRuntime.cmake
@@ -53,19 +53,25 @@ function(have_qt6)
     # Copy all new variables to parent scope, as if we weren't in a function
     # A bit of an ugly hack, but I don't think there's a nicer way
     get_cmake_property(_vars VARIABLES)
-    foreach (_var ${_vars})
+    foreach(_var ${_vars})
       list(FIND _parent_vars ${_var} _idx)
       # FIND gives the index which starts at 0, or -1 for not found
       # Add 1 so we have a truthy value for every index and 0 for not found
       math(EXPR _in_list "${_idx} + 1")
       # if not in parent_scope (i.e. newly set)
       if(NOT ${_in_list})
-        set(${_var} ${${_var}} PARENT_SCOPE)
+        set(${_var}
+            ${${_var}}
+            PARENT_SCOPE
+        )
       endif()
     endforeach()
   else()
     # Only add Qt6_FOUND to parent scope to avoid misconfiguring Qt5 when Qt6 is partially present
-    set(Qt6_FOUND ${Qt6_FOUND} PARENT_SCOPE)
+    set(Qt6_FOUND
+        ${Qt6_FOUND}
+        PARENT_SCOPE
+    )
   endif()
 endfunction()
 


### PR DESCRIPTION
## Related Ticket(s)
- N/A

## Short roundup of the initial problem
Building cockatrice against Qt5 when only some of the needed sources for Qt6 were present caused Qt5 to be misconfigured, leading to compilation errors like this one:
```
[ 66%] Automatic MOC for target cockatrice_common
[ 66%] Built target cockatrice_common_autogen
[ 66%] Building CXX object common/CMakeFiles/cockatrice_common.dir/cockatrice_common_autogen/mocs_compilation.cpp.o
In file included from /home/sk/tmp/cockatrice/build/common/cockatrice_common_autogen/mocs_compilation.cpp:2:
/home/sk/tmp/cockatrice/build/common/cockatrice_common_autogen/EWIEGA46WW/moc_decklist.cpp:16:2: error: #error "This file was generated using the moc from 6.3.2. It"
   16 | #error "This file was generated using the moc from 6.3.2. It"
      |  ^~~~~
/home/sk/tmp/cockatrice/build/common/cockatrice_common_autogen/EWIEGA46WW/moc_decklist.cpp:17:2: error: #error "cannot be used with the include files from this version of Qt."
   17 | #error "cannot be used with the include files from this version of Qt."
      |  ^~~~~
/home/sk/tmp/cockatrice/build/common/cockatrice_common_autogen/EWIEGA46WW/moc_decklist.cpp:18:2: error: #error "(The moc has changed too much.)"
   18 | #error "(The moc has changed too much.)"
      |  ^~~~~
```

This is caused by `find_package(Qt6)` setting Qt configuration variables even when it doesnt successfully find Qt6.

## What will change with this Pull Request?
- find_package(Qt6) will only set Qt configuration variables if it finds all required modules

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
