### PR TITLE
fix crash when right clicking a user's name in a replay

### DIFF
--- a/cockatrice/src/tab_supervisor.cpp
+++ b/cockatrice/src/tab_supervisor.cpp
@@ -687,12 +687,12 @@ void TabSupervisor::processNotifyUserEvent(const Event_NotifyUser &event)
 
 bool TabSupervisor::isOwnUserRegistered() const
 {
-    return static_cast<bool>(getUserInfo()->user_level() & ServerInfo_User::IsRegistered);
+    return userInfo != nullptr && (userInfo->user_level() & ServerInfo_User::IsRegistered) != 0;
 }
 
 QString TabSupervisor::getOwnUsername() const
 {
-    return userInfo ? QString::fromStdString(userInfo->name()) : QString();
+    return userInfo != nullptr ? QString::fromStdString(userInfo->name()) : QString();
 }
 
 bool TabSupervisor::isUserBuddy(const QString &userName) const


### PR DESCRIPTION
this happened when viewing a replay with the "view replay" option in the top menu, instead of using the replays tab while connected to a server. this uses the local game player instead of the online one which does not initialize the player info of the local spectating player, this causes a crash when opening the context menu on another player in the replay from one of their chat messages as it tries to check if you're a registered user and could add them as a friend etc.
it now regards the uninitialized player info as an unregistered user and will not show these options.
