### PR TITLE
fix crash when a cardmenu becomes an orphan

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -33,6 +33,8 @@ CardItem::CardItem(Player *_owner,
     ptMenu = new QMenu;
     moveMenu = new QMenu;
 
+    connect(this, SIGNAL(resetCursorSignal()), this, SLOT(resetCursor()));
+
     retranslateUi();
 }
 
@@ -407,10 +409,15 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
         }
     }
 
+    emit resetCursorSignal();
+    AbstractCardItem::mouseReleaseEvent(event);
+}
+
+void CardItem::resetCursor()
+{
     if (owner != nullptr) { // cards without owner will be deleted
         setCursor(Qt::OpenHandCursor);
     }
-    AbstractCardItem::mouseReleaseEvent(event);
 }
 
 void CardItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)

--- a/cockatrice/src/carditem.h
+++ b/cockatrice/src/carditem.h
@@ -37,6 +37,9 @@ private:
     QMenu *cardMenu, *ptMenu, *moveMenu;
 
     void prepareDelete();
+    void resetCursor();
+signals:
+    void resetCursorSignal();
 public slots:
     void deleteLater();
 


### PR DESCRIPTION
when a cardmenu is closed the cursor on that card reverts to the open hand, this crashed the client when that card would be destroyed or moved the act of reverting to the open hand now happens as an emitted signal, this way it just doesn't exist anymore when the card is deleted.

fixes #4465