### PR TITLE
update deprecated workflow actions

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.6.0
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{github.token}} # needs other token https://github.com/styfle/cancel-workflow-action/issues/7
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Checkout
         if: steps.configure.outputs.tag != null
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -121,7 +121,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get cache timestamp
         id: cache_timestamp
@@ -129,7 +129,7 @@ jobs:
         run: echo "::set-output name=timestamp::$(date -u '+%Y%m%d%H%M%S')"
 
       - name: Restore cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           timestamp: ${{steps.cache_timestamp.outputs.timestamp}}
         with:
@@ -166,7 +166,7 @@ jobs:
 
       - name: Upload artifact
         if: matrix.package != 'skip'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{matrix.distro}}-package
           path: ${{steps.package.outputs.path}}
@@ -237,7 +237,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies using homebrew
         shell: bash
@@ -265,7 +265,7 @@ jobs:
 
       - name: Upload artifact
         if: matrix.make_package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: macOS-${{matrix.target}}-dmg
           path: ${{steps.build.outputs.path}}

--- a/.github/workflows/desktop-lint.yml
+++ b/.github/workflows/desktop-lint.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 20 # should be enough to find merge base
 

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends qttools5-dev-tools
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Update cockatrice translations
         shell: bash

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/web-lint.yml
+++ b/.github/workflows/web-lint.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Node.js
       uses: actions/setup-node@v2


### PR DESCRIPTION

## Short roundup of the initial problem
github has deprecated actions using the out of support node 12: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

## What will change with this Pull Request?
- all actions using this node version now pin the latest version
