### PR TITLE
use qt6 in arch builds

### DIFF
--- a/.ci/ArchLinux/Dockerfile
+++ b/.ci/ArchLinux/Dockerfile
@@ -8,7 +8,6 @@ RUN pacman --sync --refresh --sysupgrade --needed --noconfirm \
         gtest \
         mariadb-libs \
         protobuf \
-        qt6-5compat \
         qt6-base \
         qt6-multimedia \
         qt6-svg \

--- a/.ci/ArchLinux/Dockerfile
+++ b/.ci/ArchLinux/Dockerfile
@@ -8,9 +8,11 @@ RUN pacman --sync --refresh --sysupgrade --needed --noconfirm \
         gtest \
         mariadb-libs \
         protobuf \
-        qt5-base \
-        qt5-multimedia \
-        qt5-svg \
-        qt5-tools \
-        qt5-websockets \
+        qt6-5compat \
+        qt6-base \
+        qt6-multimedia \
+        qt6-svg \
+        qt6-tools \
+        qt6-translations \
+        qt6-websockets \
     && pacman --sync --clean --clean --noconfirm

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -594,7 +594,7 @@ void Player::removePlayer(Player *player)
 void Player::playerListActionTriggered()
 {
     auto *action = static_cast<QAction *>(sender());
-    auto *menu = static_cast<QMenu *>(action->parentWidget());
+    auto *menu = static_cast<QMenu *>(action->parent());
 
     Command_RevealCards cmd;
     const int otherPlayerId = action->data().toInt();

--- a/servatrice/src/smtp/qxthmac.cpp
+++ b/servatrice/src/smtp/qxthmac.cpp
@@ -167,7 +167,11 @@ bool QxtHmac::verify(const QByteArray& otherInner)
 void QxtHmac::addData(const char* data, int length)
 {
     Q_ASSERT(qxt_d().opad.size());
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 3, 0))
+    qxt_d().ihash->addData(QByteArrayView(data, length));
+#else
     qxt_d().ihash->addData(data, length);
+#endif
     qxt_d().result.clear();
 }
 


### PR DESCRIPTION
updates the arch linux debug build we do to use qt6 instead of qt5