### PR TITLE
remove dependency on deprecated qt5 libraries for qt6

### DIFF
--- a/.ci/Fedora36/Dockerfile
+++ b/.ci/Fedora36/Dockerfile
@@ -7,7 +7,7 @@ RUN dnf install -y \
         git \
         mariadb-devel \
         protobuf-devel \
-        qt6-{qttools,qtsvg,qtmultimedia,qtwebsockets,qt5compat}-devel \
+        qt6-{qttools,qtsvg,qtmultimedia,qtwebsockets}-devel \
         rpm-build \
         xz-devel \
         zlib-devel \

--- a/.ci/UbuntuJammy/Dockerfile
+++ b/.ci/UbuntuJammy/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get update && \
         liblzma-dev \
         libmariadb-dev-compat \
         libprotobuf-dev \
-        libqt6core5compat6-dev \
         libqt6multimedia6 \
         libqt6sql6-mysql \
         libqt6svg6-dev \

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -310,7 +310,7 @@ jobs:
             qt_version: 6.3.*
             qt_arch: msvc2019_64
             qt_tools: "tools_openssl_x64"
-            qt_modules: "qt5compat qtmultimedia qtwebsockets"
+            qt_modules: "qtmultimedia qtwebsockets"
 
     name: ${{matrix.target}}
     needs: configure

--- a/cmake/FindQtRuntime.cmake
+++ b/cmake/FindQtRuntime.cmake
@@ -21,8 +21,8 @@ if(WITH_CLIENT)
       Network
       PrintSupport
       Svg
-      Widgets
       WebSockets
+      Widgets
   )
 endif()
 if(WITH_ORACLE)
@@ -41,27 +41,24 @@ set(REQUIRED_QT_COMPONENTS ${REQUIRED_QT_COMPONENTS} ${_SERVATRICE_NEEDED} ${_CO
 list(REMOVE_DUPLICATES REQUIRED_QT_COMPONENTS)
 
 if(NOT FORCE_USE_QT5)
-  # Core5Compat is Qt6 Only, Linguist is now a component in Qt6 instead of an external package
+  # Linguist is now a component in Qt6 instead of an external package
   find_package(
     Qt6 6.2.3
-    COMPONENTS Core5Compat ${REQUIRED_QT_COMPONENTS}
-    OPTIONAL_COMPONENTS Linguist
+    COMPONENTS ${REQUIRED_QT_COMPONENTS} Linguist
     QUIET HINTS ${Qt6_DIR}
   )
 endif()
 if(Qt6_FOUND)
   set(COCKATRICE_QT_VERSION_NAME Qt6)
 
-  if(Qt6LinguistTools_FOUND)
-    list(FIND Qt6LinguistTools_TARGETS Qt6::lrelease QT6_LRELEASE_INDEX)
-    if(QT6_LRELEASE_INDEX EQUAL -1)
-      message(WARNING "Qt6 lrelease not found.")
-    endif()
+  list(FIND Qt6LinguistTools_TARGETS Qt6::lrelease QT6_LRELEASE_INDEX)
+  if(QT6_LRELEASE_INDEX EQUAL -1)
+    message(WARNING "Qt6 lrelease not found.")
+  endif()
 
-    list(FIND Qt6LinguistTools_TARGETS Qt6::lupdate QT6_LUPDATE_INDEX)
-    if(QT6_LUPDATE_INDEX EQUAL -1)
-      message(WARNING "Qt6 lupdate not found.")
-    endif()
+  list(FIND Qt6LinguistTools_TARGETS Qt6::lupdate QT6_LUPDATE_INDEX)
+  if(QT6_LUPDATE_INDEX EQUAL -1)
+    message(WARNING "Qt6 lupdate not found.")
   endif()
 else()
   find_package(
@@ -116,10 +113,5 @@ string(REGEX REPLACE "([^;]+)" "${COCKATRICE_QT_VERSION_NAME}::\\1" COCKATRICE_Q
 string(REGEX REPLACE "([^;]+)" "${COCKATRICE_QT_VERSION_NAME}::\\1" ORACLE_QT_MODULES "${_ORACLE_NEEDED}")
 string(REGEX REPLACE "([^;]+)" "${COCKATRICE_QT_VERSION_NAME}::\\1" DB_CONVERTER_QT_MODULES "${_DBCONVERTER_NEEDED}")
 string(REGEX REPLACE "([^;]+)" "${COCKATRICE_QT_VERSION_NAME}::\\1" TEST_QT_MODULES "${_TEST_NEEDED}")
-if(Qt6_FOUND)
-  list(APPEND SERVATRICE_QT_MODULES ${COCKATRICE_QT_VERSION_NAME}::Core5Compat)
-  list(APPEND COCKATRICE_QT_MODULES ${COCKATRICE_QT_VERSION_NAME}::Core5Compat)
-  list(APPEND ORACLE_QT_MODULES ${COCKATRICE_QT_VERSION_NAME}::Core5Compat)
-endif()
 
 message(STATUS "Found Qt ${${COCKATRICE_QT_VERSION_NAME}_VERSION} at: ${${COCKATRICE_QT_VERSION_NAME}_DIR}")

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -360,7 +360,7 @@ Data = Resources\")
   endif()
 endif()
 
-if(Qt6LinguistTools_FOUND)
+if(Qt6_FOUND AND Qt6LinguistTools_FOUND)
   #Qt6 Translations happen after the executable is built up
   if(UPDATE_TRANSLATIONS)
     qt6_add_translations(

--- a/cockatrice/src/deckstats_interface.cpp
+++ b/cockatrice/src/deckstats_interface.cpp
@@ -7,7 +7,7 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QUrlQuery>
 
 DeckStatsInterface::DeckStatsInterface(CardDatabase &_cardDatabase, QObject *parent)
@@ -20,7 +20,7 @@ DeckStatsInterface::DeckStatsInterface(CardDatabase &_cardDatabase, QObject *par
 void DeckStatsInterface::queryFinished(QNetworkReply *reply)
 {
     if (reply->error() != QNetworkReply::NoError) {
-        QMessageBox::critical(0, tr("Error"), reply->errorString());
+        QMessageBox::critical(nullptr, tr("Error"), reply->errorString());
         reply->deleteLater();
         deleteLater();
         return;
@@ -29,14 +29,15 @@ void DeckStatsInterface::queryFinished(QNetworkReply *reply)
     QString data(reply->readAll());
     reply->deleteLater();
 
-    QRegExp rx("<meta property=\"og:url\" content=\"([^\"]+)\"");
-    if (-1 == rx.indexIn(data)) {
-        QMessageBox::critical(0, tr("Error"), tr("The reply from the server could not be parsed."));
+    static const QRegularExpression rx("<meta property=\"og:url\" content=\"([^\"]+)\"");
+    auto match = rx.match(data);
+    if (!match.hasMatch()) {
+        QMessageBox::critical(nullptr, tr("Error"), tr("The reply from the server could not be parsed."));
         deleteLater();
         return;
     }
 
-    QString deckUrl = rx.cap(1);
+    QString deckUrl = match.captured(1);
     QDesktopServices::openUrl(deckUrl);
 
     deleteLater();

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -43,7 +43,6 @@
 #include <QLibraryInfo>
 #include <QLocale>
 #include <QSystemTrayIcon>
-#include <QTextCodec>
 #include <QTextStream>
 #include <QTranslator>
 #include <QtPlugin>

--- a/cockatrice/src/tappedout_interface.cpp
+++ b/cockatrice/src/tappedout_interface.cpp
@@ -7,7 +7,6 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
-#include <QRegExp>
 #include <QRegularExpression>
 #include <QUrlQuery>
 
@@ -21,7 +20,7 @@ TappedOutInterface::TappedOutInterface(CardDatabase &_cardDatabase, QObject *par
 void TappedOutInterface::queryFinished(QNetworkReply *reply)
 {
     if (reply->error() != QNetworkReply::NoError) {
-        QMessageBox::critical(0, tr("Error"), reply->errorString());
+        QMessageBox::critical(nullptr, tr("Error"), reply->errorString());
         reply->deleteLater();
         deleteLater();
         return;
@@ -42,26 +41,26 @@ void TappedOutInterface::queryFinished(QNetworkReply *reply)
          * from the html. Css pseudo selector for errors: $("div.alert-danger > ul > li")
          */
         QString data(reply->readAll());
-        QString errorMessage = tr("Unable to analyze the deck.");
+        QStringList errorMessageList = {tr("Unable to analyze the deck.")};
 
-        QRegExp rx("<div class=\"alert alert-danger.*<ul>(.*)</ul>");
-        rx.setMinimal(true);
-        int found = rx.indexIn(data);
-        if (found >= 0) {
-            QString errors = rx.cap(1);
-            QRegExp rx2("<li>(.*)</li>");
-            rx2.setMinimal(true);
-
-            int captures = rx2.captureCount();
-            for (int i = 1; i <= captures; i++) {
-                errorMessage += QString("\n") + rx2.cap(i).remove(QRegularExpression("<[^>]*>")).simplified();
+        static const QRegularExpression rx("<div class=\"alert alert-danger.*?<ul>(.*?)</ul>");
+        auto match = rx.match(data);
+        if (match.hasMatch()) {
+            QString errors = match.captured(1);
+            static const QRegularExpression rx2("<li>(.*?)</li>");
+            static const QRegularExpression rxremove("<[^>]*>");
+            auto matchIterator = rx2.globalMatch(errors);
+            while (matchIterator.hasNext()) {
+                auto match2 = matchIterator.next();
+                errorMessageList.append(match2.captured(1).remove(rxremove).simplified());
             }
         }
 
+        QString errorMessage = errorMessageList.join("\n");
         qDebug() << "Tappedout: bad reply, http status" << httpStatus << "size" << data.size() << "message"
                  << errorMessage;
 
-        QMessageBox::critical(0, tr("Error"), errorMessage);
+        QMessageBox::critical(nullptr, tr("Error"), errorMessage);
     }
 
     reply->deleteLater();

--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -252,7 +252,7 @@ Translations = Resources/translations\")
   )
 endif()
 
-if(Qt6LinguistTools_FOUND)
+if(Qt6_FOUND AND Qt6LinguistTools_FOUND)
   #Qt6 Translations happen after the executable is built up
   if(UPDATE_TRANSLATIONS)
     qt6_add_translations(

--- a/oracle/src/main.cpp
+++ b/oracle/src/main.cpp
@@ -8,7 +8,6 @@
 #include <QCommandLineParser>
 #include <QIcon>
 #include <QLibraryInfo>
-#include <QTextCodec>
 #include <QTranslator>
 
 QTranslator *translator, *qtTranslator;

--- a/oracle/src/zip/unzip.cpp
+++ b/oracle/src/zip/unzip.cpp
@@ -465,7 +465,7 @@ UnZip::ErrorCode UnzipPrivate::seekToCentralDirectory()
     quint16 commentLength = getUShort((const unsigned char*)buffer1, UNZIP_EOCD_OFF_COMMLEN + 4);
     if (commentLength != 0) {
         QByteArray c = device->read(commentLength);
-        if (c.count() != commentLength)
+        if (c.size() != commentLength)
             return UnZip::ReadFailed;
 
         comment = c;

--- a/servatrice/src/main.cpp
+++ b/servatrice/src/main.cpp
@@ -32,7 +32,6 @@
 #include <QDateTime>
 #include <QFile>
 #include <QMetaType>
-#include <QTextCodec>
 #include <QtGlobal>
 #include <iostream>
 

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -177,23 +177,23 @@ bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user, QString 
             return false;
     }
 
-    for (const QRegExp &regExp : settingsCache->disallowedRegExp) {
-        if (regExp.exactMatch(user))
+    for (const QRegularExpression &regExp : settingsCache->disallowedRegExp) {
+        if (regExp.match(user).hasMatch())
             return false;
     }
 
-    QString regEx("[");
+    QString regEx("\\A[");
     if (allowLowercase)
         regEx.append("a-z");
     if (allowUppercase)
         regEx.append("A-Z");
     if (allowNumerics)
         regEx.append("0-9");
-    regEx.append(QRegExp::escape(allowedPunctuation));
-    regEx.append("]+");
+    regEx.append(QRegularExpression::escape(allowedPunctuation));
+    regEx.append("]+\\z");
 
-    static QRegExp re = QRegExp(regEx);
-    return re.exactMatch(user);
+    QRegularExpression re = QRegularExpression(regEx);
+    return re.match(user).hasMatch();
 }
 
 bool Servatrice_DatabaseInterface::registerUser(const QString &userName,

--- a/servatrice/src/settingscache.cpp
+++ b/servatrice/src/settingscache.cpp
@@ -19,7 +19,7 @@ SettingsCache::SettingsCache(const QString &fileName, QSettings::Format format, 
 #endif
     disallowedRegExpStr.removeDuplicates();
     for (const QString &regExpStr : disallowedRegExpStr) {
-        disallowedRegExp.append(QRegularExpression(QRegularExpression::anchoredPattern(regExpStr)));
+        disallowedRegExp.append(QRegularExpression(QString("\\A%1\\z").arg(regExpStr)));
     }
 }
 

--- a/servatrice/src/settingscache.cpp
+++ b/servatrice/src/settingscache.cpp
@@ -19,7 +19,7 @@ SettingsCache::SettingsCache(const QString &fileName, QSettings::Format format, 
 #endif
     disallowedRegExpStr.removeDuplicates();
     for (const QString &regExpStr : disallowedRegExpStr) {
-        disallowedRegExp.append(QRegExp(regExpStr));
+        disallowedRegExp.append(QRegularExpression(QRegularExpression::anchoredPattern(regExpStr)));
     }
 }
 

--- a/servatrice/src/settingscache.h
+++ b/servatrice/src/settingscache.h
@@ -2,7 +2,7 @@
 #define SERVATRICE_SETTINGSCACHE_H
 
 #include <QList>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QSettings>
 #include <QString>
 
@@ -17,7 +17,7 @@ public:
                   QSettings::Format format = QSettings::IniFormat,
                   QObject *parent = 0);
     static QString guessConfigurationPath();
-    QList<QRegExp> disallowedRegExp;
+    QList<QRegularExpression> disallowedRegExp;
     bool getIsPortableBuild() const
     {
         return isPortableBuild;

--- a/servatrice/src/smtp/qxtmail_p.h
+++ b/servatrice/src/smtp/qxtmail_p.h
@@ -26,12 +26,10 @@
 #define QXTMAIL_P_H
 
 #include <QByteArray>
-#include <QTextCodec>
 
 #define QXT_MUST_QP(x) (x < char(32) || x > char(126) || x == '=' || x == '?')
 QByteArray qxt_fold_mime_header(const QString &key,
                                 const QString &value,
-                                QTextCodec *latin1,
                                 const QByteArray &prefix = QByteArray());
 
 #endif // QXTMAIL_P_H

--- a/servatrice/src/smtp/qxtmailattachment.cpp
+++ b/servatrice/src/smtp/qxtmailattachment.cpp
@@ -34,7 +34,6 @@
 
 #include "qxtmailattachment.h"
 #include "qxtmail_p.h"
-#include <QTextCodec>
 #include <QBuffer>
 #include <QPointer>
 #include <QFile>
@@ -187,11 +186,10 @@ QByteArray QxtMailAttachment::mimeData()
         return QByteArray();
     }
 
-    QTextCodec* latin1 = QTextCodec::codecForName("latin1");
     QByteArray rv = "Content-Type: " + qxt_d->contentType.toLatin1() + "\r\nContent-Transfer-Encoding: base64\r\n";
     foreach(const QString& r, qxt_d->extraHeaders.keys())
     {
-        rv += qxt_fold_mime_header(r.toLatin1(), extraHeader(r), latin1);
+        rv += qxt_fold_mime_header(r.toLatin1(), extraHeader(r));
     }
     rv += "\r\n";
 

--- a/servatrice/src/smtp/qxtmailmessage.cpp
+++ b/servatrice/src/smtp/qxtmailmessage.cpp
@@ -35,9 +35,16 @@
 #include "qxtmail_p.h"
 
 #include <QDir>
-#include <QTextCodec>
 #include <QUuid>
 #include <QtDebug>
+
+static bool isASCII(const QString &string) {
+  for(const QChar &chr : string){
+    if(chr.unicode() > 0x7f)
+      return false;
+  }
+  return true;
+}
 
 struct QxtMailMessagePrivate : public QSharedData
 {
@@ -204,13 +211,13 @@ void QxtMailMessage::removeAttachment(const QString &filename)
     qxt_d->attachments.remove(filename);
 }
 
-QByteArray qxt_fold_mime_header(const QString &key, const QString &value, QTextCodec *latin1, const QByteArray &prefix)
+QByteArray qxt_fold_mime_header(const QString &key, const QString &value, const QByteArray &prefix)
 {
     QByteArray rv = "";
     QByteArray line = key.toLatin1() + ": ";
     if (!prefix.isEmpty())
         line += prefix;
-    if (!value.contains("=?") && latin1->canEncode(value)) {
+    if (!value.contains("=?") && isASCII(value)) {
         bool firstWord = true;
         foreach (const QByteArray &word, value.toLatin1().split(' ')) {
             if (line.size() > 78) {
@@ -274,26 +281,25 @@ QByteArray QxtMailMessage::rfc2822() const
     // Use base64 if requested
     bool useBase64 = (extraHeader("Content-Transfer-Encoding").toLower() == "base64");
     // Check to see if plain text is ASCII-clean; assume it isn't if QP or base64 was requested
-    QTextCodec *latin1 = QTextCodec::codecForName("latin1");
-    bool bodyIsAscii = latin1->canEncode(body()) && !useQuotedPrintable && !useBase64;
+    bool bodyIsAscii = !useQuotedPrintable && !useBase64 && isASCII(body());
 
     QHash<QString, QxtMailAttachment> attach = attachments();
     QByteArray rv;
 
     if (!sender().isEmpty() && !hasExtraHeader("From")) {
-        rv += qxt_fold_mime_header("From", sender(), latin1);
+        rv += qxt_fold_mime_header("From", sender());
     }
 
     if (!qxt_d->rcptTo.isEmpty()) {
-        rv += qxt_fold_mime_header("To", qxt_d->rcptTo.join(", "), latin1);
+        rv += qxt_fold_mime_header("To", qxt_d->rcptTo.join(", "));
     }
 
     if (!qxt_d->rcptCc.isEmpty()) {
-        rv += qxt_fold_mime_header("Cc", qxt_d->rcptCc.join(", "), latin1);
+        rv += qxt_fold_mime_header("Cc", qxt_d->rcptCc.join(", "));
     }
 
     if (!subject().isEmpty()) {
-        rv += qxt_fold_mime_header("Subject", subject(), latin1);
+        rv += qxt_fold_mime_header("Subject", subject());
     }
 
     if (!bodyIsAscii) {
@@ -338,7 +344,7 @@ QByteArray QxtMailMessage::rfc2822() const
             // Since we're in multipart mode, we'll be outputting this later
             continue;
         }
-        rv += qxt_fold_mime_header(r.toLatin1(), extraHeader(r), latin1);
+        rv += qxt_fold_mime_header(r.toLatin1(), extraHeader(r));
     }
 
     rv += "\r\n";
@@ -366,7 +372,7 @@ QByteArray QxtMailMessage::rfc2822() const
     }
 
     if (bodyIsAscii) {
-        QByteArray b = latin1->fromUnicode(body());
+        QByteArray b = body().toLatin1();
         int len = b.length();
         QByteArray line = "";
         QByteArray word = "";
@@ -460,7 +466,7 @@ QByteArray QxtMailMessage::rfc2822() const
         foreach (const QString &filename, attach.keys()) {
             rv += "--" + qxt_d->boundary + "\r\n";
             rv +=
-                qxt_fold_mime_header("Content-Disposition", QDir(filename).dirName(), latin1, "attachment; filename=");
+                qxt_fold_mime_header("Content-Disposition", QDir(filename).dirName(), "attachment; filename=");
             rv += attach[filename].mimeData();
         }
         rv += "--" + qxt_d->boundary + "--\r\n";


### PR DESCRIPTION
removes the use of qt6-5compat for builds
replaces use of QRegExp with QRegularExpression
fixes incorrect usage of QRegExp
removes use of QTextCodec
fixes incorrect usage of QTextCodec
sets qtlinguist as a required component for qt6