### PR TITLE
Update CMake usage in README build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,18 +93,16 @@ Oracle can optionally use zlib and xz to load compressed files:
 
 To compile:
 
-    mkdir build
-    cd build
-    cmake ..
-    make
+    cmake -S . -B build
+    cmake --build build
 
 You can then run
 
-    make install
+    cmake --build build --target install
 
 to get a cockatrice installation inside the `release` folder, or:
 
-    make package
+    cmake --build build --target package
 
 to create a system-specific installation package.
 


### PR DESCRIPTION

## Related Ticket(s)
- None

## Short roundup of the initial problem

CMake 3.14.0 released in March 2019 [1] added the command line config options `-S <source-dir>` and `-B <build-dir>` and the build argument `--build <build-dir>` [2]. These options are universally valid independent of the build system used (`make`, `nmake`, `ninja`, `MSBuild`,...), making the provided CMake commands more generic.

As reference Ubuntu 20.04 ships the CMake 3.16.3 [3] version.

- [1] https://gitlab.kitware.com/cmake/cmake/-/tags/v3.14.0
- [2] https://cmake.org/cmake/help/v3.14/release/3.14.html#command-line
- [3] https://packages.ubuntu.com/focal/cmake


## What will change with this Pull Request?
- More generic CMake commands are recommended in the build instructions

## Screenshots
None