### PR TITLE
Added hint when drawing 0 cards

### DIFF
--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -369,7 +369,7 @@ void MessageLogWidget::logDrawCards(Player *player, int number)
     if (currentContext == MessageContext_Mulligan) {
         logMulligan(player, number);
     } else {
-        if (deckSize == 0) {
+        if (deckSize == 0  && number == 0) {
             appendHtmlServerMessage(tr("%1 had no cards left to draw.", "")
                                     .arg(sanitizeHtml(player->getName())));
         }

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -368,7 +368,7 @@ void MessageLogWidget::logDrawCards(Player *player, int number)
     if (currentContext == MessageContext_Mulligan) {
         logMulligan(player, number);
     } else {
-        if (number == 0) {
+        if (number == 0 && player->getZones().find()) {
             appendHtmlServerMessage(tr("%1 had no cards left to draw.", "")
                                     .arg(sanitizeHtml(player->getName())));
         }

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -368,9 +368,15 @@ void MessageLogWidget::logDrawCards(Player *player, int number)
     if (currentContext == MessageContext_Mulligan) {
         logMulligan(player, number);
     } else {
-        appendHtmlServerMessage(tr("%1 draws %2 card(s).", "", number)
+        if (number == 0) {
+            appendHtmlServerMessage(tr("%1 had no cards left to draw.", "")
+                                    .arg(sanitizeHtml(player->getName())));
+        }
+        else {
+            appendHtmlServerMessage(tr("%1 draws %2 card(s).", "", number)
                                     .arg(sanitizeHtml(player->getName()))
                                     .arg("<font class=\"blue\">" + QString::number(number) + "</font>"));
+        }
     }
 }
 

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -364,11 +364,12 @@ void MessageLogWidget::logMoveCard(Player *player,
 
 void MessageLogWidget::logDrawCards(Player *player, int number)
 {
+    int deckSize = player->getZones().value("deck")->getCards().size();
     soundEngine->playSound("draw_card");
     if (currentContext == MessageContext_Mulligan) {
         logMulligan(player, number);
     } else {
-        if (number == 0 && player->getZones().find()) {
+        if (deckSize == 0) {
             appendHtmlServerMessage(tr("%1 had no cards left to draw.", "")
                                     .arg(sanitizeHtml(player->getName())));
         }

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -369,13 +369,11 @@ void MessageLogWidget::logDrawCards(Player *player, int number, bool deckIsEmpty
         logMulligan(player, number);
     } else {
         if (deckIsEmpty && number == 0) {
-            appendHtmlServerMessage(tr("%1 tries to draw from an empty library", "")
-                                    .arg(sanitizeHtml(player->getName())));
-        }
-        else {
+            appendHtmlServerMessage(tr("%1 tries to draw from an empty library").arg(sanitizeHtml(player->getName())));
+        } else {
             appendHtmlServerMessage(tr("%1 draws %2 card(s).", "", number)
-                                    .arg(sanitizeHtml(player->getName()))
-                                    .arg("<font class=\"blue\">" + QString::number(number) + "</font>"));
+                                        .arg(sanitizeHtml(player->getName()))
+                                        .arg("<font class=\"blue\">" + QString::number(number) + "</font>"));
         }
     }
 }

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -362,15 +362,14 @@ void MessageLogWidget::logMoveCard(Player *player,
     }
 }
 
-void MessageLogWidget::logDrawCards(Player *player, int number)
+void MessageLogWidget::logDrawCards(Player *player, int number, bool deckIsEmpty)
 {
-    int deckSize = player->getZones().value("deck")->getCards().size();
     soundEngine->playSound("draw_card");
     if (currentContext == MessageContext_Mulligan) {
         logMulligan(player, number);
     } else {
-        if (deckSize == 0  && number == 0) {
-            appendHtmlServerMessage(tr("%1 has no cards left to draw.")
+        if (deckIsEmpty && number == 0) {
+            appendHtmlServerMessage(tr("%1 tries to draw from an empty library", "")
                                     .arg(sanitizeHtml(player->getName())));
         }
         else {
@@ -824,7 +823,7 @@ void MessageLogWidget::connectToPlayer(Player *player)
             SLOT(logAttachCard(Player *, QString, Player *, QString)));
     connect(player, SIGNAL(logUnattachCard(Player *, QString)), this, SLOT(logUnattachCard(Player *, QString)));
     connect(player, SIGNAL(logDumpZone(Player *, CardZone *, int)), this, SLOT(logDumpZone(Player *, CardZone *, int)));
-    connect(player, SIGNAL(logDrawCards(Player *, int)), this, SLOT(logDrawCards(Player *, int)));
+    connect(player, SIGNAL(logDrawCards(Player *, int, bool)), this, SLOT(logDrawCards(Player *, int, bool)));
     connect(player, SIGNAL(logUndoDraw(Player *, QString)), this, SLOT(logUndoDraw(Player *, QString)));
     connect(player, SIGNAL(logRevealCards(Player *, CardZone *, int, QString, Player *, bool, int)), this,
             SLOT(logRevealCards(Player *, CardZone *, int, QString, Player *, bool, int)));

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -370,7 +370,7 @@ void MessageLogWidget::logDrawCards(Player *player, int number)
         logMulligan(player, number);
     } else {
         if (deckSize == 0  && number == 0) {
-            appendHtmlServerMessage(tr("%1 had no cards left to draw.", "")
+            appendHtmlServerMessage(tr("%1 has no cards left to draw.")
                                     .arg(sanitizeHtml(player->getName())));
         }
         else {

--- a/cockatrice/src/messagelogwidget.h
+++ b/cockatrice/src/messagelogwidget.h
@@ -56,7 +56,7 @@ public slots:
     void logCreateToken(Player *player, QString cardName, QString pt);
     void logDeckSelect(Player *player, QString deckHash, int sideboardSize);
     void logDestroyCard(Player *player, QString cardName);
-    void logDrawCards(Player *player, int number);
+    void logDrawCards(Player *player, int number, bool deckIsEmpty);
     void logDumpZone(Player *player, CardZone *zone, int numberCards);
     void logFlipCard(Player *player, QString cardName, bool faceDown);
     void logGameClosed();

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2215,7 +2215,7 @@ void Player::eventDrawCards(const Event_DrawCards &event)
 
     hand->reorganizeCards();
     deck->reorganizeCards();
-    emit logDrawCards(this, event.number());
+    emit logDrawCards(this, event.number(), deck->getCards().size() == 0);
 }
 
 void Player::eventRevealCards(const Event_RevealCards &event)

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -120,7 +120,7 @@ signals:
                         QString targetCard,
                         bool _playerTarget);
     void logCreateToken(Player *player, QString cardName, QString pt);
-    void logDrawCards(Player *player, int number);
+    void logDrawCards(Player *player, int number, bool deckIsEmpty);
     void logUndoDraw(Player *player, QString cardName);
     void logMoveCard(Player *player, CardItem *card, CardZone *startZone, int oldX, CardZone *targetZone, int newX);
     void logFlipCard(Player *player, QString cardName, bool faceDown);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3530

## Short roundup of the initial problem
When a player drew 0 cards it was unclear why

## What will change with this Pull Request?
- Logging a player drawing 0 cards will now result in the message "player had no cards left to draw."

## Screenshots
