### PR TITLE
Add URL to explain message macros

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -890,14 +890,14 @@ MessagesSettingsPage::MessagesSettingsPage()
     messageListLayout->addWidget(messageToolBar);
     messageListLayout->addWidget(messageList);
 
-    auto *messagesLayout = new QVBoxLayout; //combines the explainer label with the actual messages widget pieces
+    auto *messagesLayout = new QVBoxLayout; // combines the explainer label with the actual messages widget pieces
     messagesLayout->addLayout(messageListLayout);
     messagesLayout->addWidget(&explainMessagesLabel);
 
-    messageGroupBox = new QGroupBox; //draws a box around the above layout and allows it to be titled
+    messageGroupBox = new QGroupBox; // draws a box around the above layout and allows it to be titled
     messageGroupBox->setLayout(messagesLayout);
 
-    auto *mainLayout = new QVBoxLayout; //combines the messages groupbox with the rest of the menu
+    auto *mainLayout = new QVBoxLayout; // combines the messages groupbox with the rest of the menu
     mainLayout->addWidget(messageGroupBox);
     mainLayout->addWidget(chatGroupBox);
     mainLayout->addWidget(highlightGroupBox);
@@ -1000,7 +1000,8 @@ void MessagesSettingsPage::retranslateUi()
     chatMentionCheckBox.setText(tr("Enable chat mentions"));
     chatMentionCompleterCheckbox.setText(tr("Enable mention completer"));
     messageGroupBox->setTitle(tr("In-game message macros"));
-    explainMessagesLabel.setText(QString("<a href='%1'>%2</a>").arg(WIKI_CUSTOM_SHORTCUTS).arg(tr("How to use in-game message macros")));
+    explainMessagesLabel.setText(
+        QString("<a href='%1'>%2</a>").arg(WIKI_CUSTOM_SHORTCUTS).arg(tr("How to use in-game message macros")));
     ignoreUnregUsersMainChat.setText(tr("Ignore chat room messages sent by unregistered users"));
     ignoreUnregUserMessages.setText(tr("Ignore private messages sent by unregistered users"));
     invertMentionForeground.setText(tr("Invert text color"));

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -39,7 +39,7 @@
 #include <QTreeWidgetItem>
 
 #define WIKI_CUSTOM_PIC_URL "https://github.com/Cockatrice/Cockatrice/wiki/Custom-Picture-Download-URLs"
-#define WIKI_CUSTOM_SHORTCUTS "https://github.com/Cockatrice/Cockatrice/wiki/Custom-Keyboard-Shortcuts"
+#define WIKI_CUSTOM_SHORTCUTS "https://github.com/Cockatrice/Cockatrice/wiki/Custom-Keyboard-Shortcuts-and-Message-Macros"
 
 GeneralSettingsPage::GeneralSettingsPage()
 {
@@ -796,6 +796,9 @@ MessagesSettingsPage::MessagesSettingsPage()
     connect(&chatMentionCompleterCheckbox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
             SLOT(setChatMentionCompleter(int)));
 
+    explainMessagesLabel.setTextInteractionFlags(Qt::LinksAccessibleByMouse);
+    explainMessagesLabel.setOpenExternalLinks(true);
+
     ignoreUnregUsersMainChat.setChecked(SettingsCache::instance().getIgnoreUnregisteredUsers());
     ignoreUnregUserMessages.setChecked(SettingsCache::instance().getIgnoreUnregisteredUserMessages());
     connect(&ignoreUnregUsersMainChat, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
@@ -887,12 +890,15 @@ MessagesSettingsPage::MessagesSettingsPage()
     messageListLayout->addWidget(messageToolBar);
     messageListLayout->addWidget(messageList);
 
-    messageShortcuts = new QGroupBox;
-    messageShortcuts->setLayout(messageListLayout);
+    auto *messagesLayout = new QVBoxLayout; //combines the explainer label with the actual messages widget pieces
+    messagesLayout->addLayout(messageListLayout);
+    messagesLayout->addWidget(&explainMessagesLabel);
 
-    auto *mainLayout = new QVBoxLayout;
+    messageGroupBox = new QGroupBox; //draws a box around the above layout and allows it to be titled
+    messageGroupBox->setLayout(messagesLayout);
 
-    mainLayout->addWidget(messageShortcuts);
+    auto *mainLayout = new QVBoxLayout; //combines the messages groupbox with the rest of the menu
+    mainLayout->addWidget(messageGroupBox);
     mainLayout->addWidget(chatGroupBox);
     mainLayout->addWidget(highlightGroupBox);
 
@@ -993,7 +999,8 @@ void MessagesSettingsPage::retranslateUi()
     highlightGroupBox->setTitle(tr("Custom alert words"));
     chatMentionCheckBox.setText(tr("Enable chat mentions"));
     chatMentionCompleterCheckbox.setText(tr("Enable mention completer"));
-    messageShortcuts->setTitle(tr("In-game message macros"));
+    messageGroupBox->setTitle(tr("In-game message macros"));
+    explainMessagesLabel.setText(QString("<a href='%1'>%2</a>").arg(WIKI_CUSTOM_SHORTCUTS).arg(tr("How to use in-game message macros")));
     ignoreUnregUsersMainChat.setText(tr("Ignore chat room messages sent by unregistered users"));
     ignoreUnregUserMessages.setText(tr("Ignore private messages sent by unregistered users"));
     invertMentionForeground.setText(tr("Invert text color"));

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -39,7 +39,7 @@
 #include <QTreeWidgetItem>
 
 #define WIKI_CUSTOM_PIC_URL "https://github.com/Cockatrice/Cockatrice/wiki/Custom-Picture-Download-URLs"
-#define WIKI_CUSTOM_SHORTCUTS "https://github.com/Cockatrice/Cockatrice/wiki/Custom-Keyboard-Shortcuts-and-Message-Macros"
+#define WIKI_CUSTOM_SHORTCUTS "https://github.com/Cockatrice/Cockatrice/wiki/Custom-Keyboard-Shortcuts"
 
 GeneralSettingsPage::GeneralSettingsPage()
 {

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -202,13 +202,14 @@ private:
     QCheckBox roomHistory;
     QGroupBox *chatGroupBox;
     QGroupBox *highlightGroupBox;
-    QGroupBox *messageShortcuts;
+    QGroupBox *messageGroupBox;
     QLineEdit *mentionColor;
     QLineEdit *highlightColor;
     QLineEdit *customAlertString;
     QLabel hexLabel;
     QLabel hexHighlightLabel;
     QLabel customAlertStringLabel;
+    QLabel explainMessagesLabel;
 
     void storeSettings();
     void updateMentionPreview();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #267 

## Short roundup of the initial problem
The in-game message macro feature is undocumented and many users don't know it exists.

## What will change with this Pull Request?
- Adds a URL in the Settings>Chat window that links to the [new wiki explanation on message macros](https://github.com/Cockatrice/Cockatrice/wiki/Custom-Keyboard-Shortcuts-and-Message-Macros)
~~- Also edits the link in Settings>Shortcuts since I changed the name (and thus the link) of that article to include info on message macros.~~ The article name has been reverted to not break existing links elsewhere.

## Screenshots
Current:
![Screenshot from 2022-11-29 23-34-25](https://user-images.githubusercontent.com/71394296/204708685-a812ff8a-de68-4d8f-8e7b-575377d0e5ea.png)

Proposed:
![Screenshot from 2022-11-29 23-35-37](https://user-images.githubusercontent.com/71394296/204708694-429ce3fe-c0e9-4d2a-b77a-c729c43b9539.png)
