### PR TITLE
Display Welcome Message as Most Recent Message

### DIFF
--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -692,7 +692,7 @@ Response::ResponseCode Server_ProtocolHandler::cmdJoinRoom(const Command_JoinRoo
             QDateTime::fromString(QString::fromStdString(chatMessage.time())).toMSecsSinceEpoch());
         rc.enqueuePostResponseItem(ServerMessage::ROOM_EVENT, room->prepareRoomEvent(roomChatHistory));
     }
-  
+
     Event_RoomSay joinMessageEvent;
     joinMessageEvent.set_message(room->getJoinMessage().toStdString());
     joinMessageEvent.set_message_type(Event_RoomSay::Welcome);

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -680,11 +680,6 @@ Response::ResponseCode Server_ProtocolHandler::cmdJoinRoom(const Command_JoinRoo
     room->addClient(this);
     rooms.insert(room->getId(), room);
 
-    Event_RoomSay joinMessageEvent;
-    joinMessageEvent.set_message(room->getJoinMessage().toStdString());
-    joinMessageEvent.set_message_type(Event_RoomSay::Welcome);
-    rc.enqueuePostResponseItem(ServerMessage::ROOM_EVENT, room->prepareRoomEvent(joinMessageEvent));
-
     QReadLocker chatHistoryLocker(&room->historyLock);
     QList<ServerInfo_ChatMessage> chatHistory = room->getChatHistory();
     ServerInfo_ChatMessage chatMessage;
@@ -697,6 +692,11 @@ Response::ResponseCode Server_ProtocolHandler::cmdJoinRoom(const Command_JoinRoo
             QDateTime::fromString(QString::fromStdString(chatMessage.time())).toMSecsSinceEpoch());
         rc.enqueuePostResponseItem(ServerMessage::ROOM_EVENT, room->prepareRoomEvent(roomChatHistory));
     }
+  
+    Event_RoomSay joinMessageEvent;
+    joinMessageEvent.set_message(room->getJoinMessage().toStdString());
+    joinMessageEvent.set_message_type(Event_RoomSay::Welcome);
+    rc.enqueuePostResponseItem(ServerMessage::ROOM_EVENT, room->prepareRoomEvent(joinMessageEvent));
 
     Response_JoinRoom *re = new Response_JoinRoom;
     room->getInfo(*re->mutable_room_info(), true);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4110 

## Short roundup of the initial problem
Room welcome message is currently displayed as the first message in the chat and then immediately buried by any old messages from people talking in the room before the user joins.

## What will change with this Pull Request?
- Room welcome message will display as the most recent message in the chat box, instead of the oldest

## Screenshots
Screenshots are from a locally built server, hence the sparsity.

Current code:
![Screenshot from 2022-12-10 15-37-38](https://user-images.githubusercontent.com/71394296/206877502-d04f481d-bb08-4e7e-a9e0-816916bf41c4.png)

Proposed change:
![Screenshot from 2022-12-10 15-39-21](https://user-images.githubusercontent.com/71394296/206877495-533a3c12-d1b1-43de-a5d8-ce21234940aa.png)
