### PR TITLE
Some image sources require that a proper user agent is sent.

### DIFF
--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -386,6 +386,7 @@ void PictureLoaderWorker::startNextPicDownload()
     } else {
         QUrl url(picUrl);
         QNetworkRequest req(url);
+	req.setRawHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36");
         qDebug() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
                  << " set: " << cardBeingDownloaded.getSetName()
                  << "]: Trying to download picture from url:" << url.toDisplayString();


### PR DESCRIPTION
Some image sources require that a proper user agent is sent.

Example:

https://www.hcrealms.com/units/aa001.jpg

