### PR TITLE
Fixed ptSeparation oracle issue

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -334,7 +334,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet,
 
         power = getStringPropertyFromMap(card, "power");
         toughness = getStringPropertyFromMap(card, "toughness");
-        if (power.isEmpty() || power == "" || toughness.isEmpty() || toughness == ""){
+        if (power.isEmpty() || toughness.isEmpty()){
             ptSeparator = "";
         }
         if (!(power.isEmpty() && toughness.isEmpty())) {

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -334,6 +334,9 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet,
 
         power = getStringPropertyFromMap(card, "power");
         toughness = getStringPropertyFromMap(card, "toughness");
+        if (power.isEmpty() || power == "" || toughness.isEmpty() || toughness == ""){
+            ptSeparator = "";
+        }
         if (!(power.isEmpty() && toughness.isEmpty())) {
             properties.insert("pt", power + ptSeparator + toughness);
         }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes p

## Short roundup of the initial problem
ptSeparation oracle issue is an issue which causes cards from JSON file to have a '/' symbol  between its power and an unexisting toughness value.

## What will change with this Pull Request?
- Additional check will be added to see, if ptSeparator is ever needed.

## Screenshots
The issue examle:
![image](https://user-images.githubusercontent.com/37024644/211180295-a081fe39-a14b-4894-b3ee-c2162ac3a6e4.png)
