### PR TITLE
Fix #4706: don't replace ampersands when loading from plain text

### DIFF
--- a/cockatrice/src/deck_loader.cpp
+++ b/cockatrice/src/deck_loader.cpp
@@ -289,7 +289,7 @@ QString DeckLoader::getCardZoneFromName(QString cardName, QString currentZoneNam
     return currentZoneName;
 }
 
-QString DeckLoader::getCompleteCardName(const QString cardName) const
+QString DeckLoader::getCompleteCardName(const QString &cardName) const
 {
     if (db) {
         CardInfoPtr temp = db->guessCard(cardName);
@@ -299,4 +299,12 @@ QString DeckLoader::getCompleteCardName(const QString cardName) const
     }
 
     return cardName;
+}
+
+bool DeckLoader::cardExists(const QString &cardName) const
+{
+    if (db) {
+        return db->getCard(cardName) != nullptr;
+    }
+    return false;
 }

--- a/cockatrice/src/deck_loader.cpp
+++ b/cockatrice/src/deck_loader.cpp
@@ -300,11 +300,3 @@ QString DeckLoader::getCompleteCardName(const QString &cardName) const
 
     return cardName;
 }
-
-bool DeckLoader::cardExists(const QString &cardName) const
-{
-    if (db) {
-        return db->getCard(cardName) != nullptr;
-    }
-    return false;
-}

--- a/cockatrice/src/deck_loader.h
+++ b/cockatrice/src/deck_loader.h
@@ -58,7 +58,8 @@ protected:
                                     QList<DecklistCardNode *> cards,
                                     bool addComments = true);
     virtual QString getCardZoneFromName(QString cardName, QString currentZoneName);
-    virtual QString getCompleteCardName(const QString cardName) const;
+    virtual QString getCompleteCardName(const QString &cardName) const;
+    virtual bool cardExists(const QString &cardName) const;
 };
 
 #endif

--- a/cockatrice/src/deck_loader.h
+++ b/cockatrice/src/deck_loader.h
@@ -59,7 +59,6 @@ protected:
                                     bool addComments = true);
     virtual QString getCardZoneFromName(QString cardName, QString currentZoneName);
     virtual QString getCompleteCardName(const QString &cardName) const;
-    virtual bool cardExists(const QString &cardName) const;
 };
 
 #endif

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -505,7 +505,8 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
     const QRegularExpression reBraceDigit(R"( ?\([\dA-Z]+\) *\d+$)");
     const QHash<QRegularExpression, QString> differences{{QRegularExpression("’"), QString("'")},
                                                          {QRegularExpression("Æ"), QString("Ae")},
-                                                         {QRegularExpression("æ"), QString("ae")}};
+                                                         {QRegularExpression("æ"), QString("ae")},
+                                                         {QRegularExpression(" ?[|/]+ ?"), QString(" // ")}};
 
     cleanList();
 

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -505,9 +505,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
     const QRegularExpression reBraceDigit(R"( ?\([\dA-Z]+\) *\d+$)");
     const QHash<QRegularExpression, QString> differences{{QRegularExpression("’"), QString("'")},
                                                          {QRegularExpression("Æ"), QString("Ae")},
-                                                         {QRegularExpression("æ"), QString("ae")},
-                                                         {QRegularExpression(" ?[|/]+ ?"), QString(" // ")},
-                                                         {QRegularExpression("(?<![A-Z]) ?& ?"), QString(" // ")}};
+                                                         {QRegularExpression("æ"), QString("ae")}};
 
     cleanList();
 
@@ -614,9 +612,6 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
 
         // replace common differences in cardnames
         for (auto diff = differences.constBegin(); diff != differences.constEnd(); ++diff) {
-            if (cardExists(cardName)) {
-                break;
-            }
             cardName.replace(diff.key(), diff.value());
         }
 

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -528,7 +528,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
     }
 
     // find sideboard position, if marks are used this won't be needed
-    qsizetype sBStart = -1;
+    int sBStart = -1;
     if (inputs.indexOf(reSBMark, deckStart) == -1) {
         sBStart = inputs.indexOf(reSBComment, deckStart);
         if (sBStart == -1) {

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -178,17 +178,21 @@ private:
     QMap<QString, SideboardPlan *> sideboardPlans;
     InnerDecklistNode *root;
     void getCardListHelper(InnerDecklistNode *node, QSet<QString> &result) const;
-    InnerDecklistNode *getZoneObjFromName(QString zoneName);
+    InnerDecklistNode *getZoneObjFromName(const QString &zoneName);
 
 protected:
     virtual QString getCardZoneFromName(const QString /*cardName*/, QString currentZoneName)
     {
         return currentZoneName;
     };
-    virtual QString getCompleteCardName(const QString cardName) const
+    virtual QString getCompleteCardName(const QString &cardName) const
     {
         return cardName;
     };
+    virtual bool cardExists(const QString &cardName) const
+    {
+        return false;
+    }
 
 signals:
     void deckHashChanged();

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -189,10 +189,6 @@ protected:
     {
         return cardName;
     };
-    virtual bool cardExists(const QString &cardName) const
-    {
-        return false;
-    }
 
 signals:
     void deckHashChanged();

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -146,7 +146,11 @@ TEST(LoadingFromClipboardTest, EdgeCaseTesting)
 )");
 
     Result result("DeckName", "Comment 1\n\nComment [two]\n(test) Æ ’ | / (3)",
-                  {{"Aether Adept", 1}, {"Fire // Ice", 2}, {"Minsc & Boo, Timeless Heroes", 1}, {"Pain // Suffering", 3}, {"Forest", 4}},
+                  {{"Aether Adept", 1},
+                   {"Fire // Ice", 2},
+                   {"Minsc & Boo, Timeless Heroes", 1},
+                   {"Pain // Suffering", 3},
+                   {"Forest", 4}},
                   {{"Nature's Resurgence", 5}, {"Gaea's Skyfolk", 6}, {"B.F.M. (Big Furry Monster)", 7}});
     testDeck(clipboard, result);
 }

--- a/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
+++ b/tests/loading_from_clipboard/loading_from_clipboard_test.cpp
@@ -127,9 +127,10 @@ TEST(LoadingFromClipboardTest, EdgeCaseTesting)
 //(test) Æ ’ | / (3)
 
 
-// Mainboard (10 cards)
+// Mainboard (11 cards)
 Æther Adept
-2x Fire & Ice
+2x Fire // Ice
+1 Minsc & Boo, Timeless Heroes
 3 Pain/Suffering
 4X [B] Forest (3)
 
@@ -145,7 +146,7 @@ TEST(LoadingFromClipboardTest, EdgeCaseTesting)
 )");
 
     Result result("DeckName", "Comment 1\n\nComment [two]\n(test) Æ ’ | / (3)",
-                  {{"Aether Adept", 1}, {"Fire // Ice", 2}, {"Pain // Suffering", 3}, {"Forest", 4}},
+                  {{"Aether Adept", 1}, {"Fire // Ice", 2}, {"Minsc & Boo, Timeless Heroes", 1}, {"Pain // Suffering", 3}, {"Forest", 4}},
                   {{"Nature's Resurgence", 5}, {"Gaea's Skyfolk", 6}, {"B.F.M. (Big Furry Monster)", 7}});
     testDeck(clipboard, result);
 }


### PR DESCRIPTION
Tested by loading in from clipboard

```
1 Minsc & Boo, Timeless Heroes
1 Fire & Ice
```