### PR TITLE
save downloaded xmls in oracle

### DIFF
--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -300,7 +300,7 @@ void LoadSetsPage::actLoadSetsFile()
 bool LoadSetsPage::validatePage()
 {
     // once the import is finished, we call next(); skip validation
-    if (wizard()->importer->getSets().count() > 0) {
+    if (wizard()->downloadedPlainXml || wizard()->importer->getSets().count() > 0) {
         return true;
     }
 
@@ -354,7 +354,6 @@ bool LoadSetsPage::validatePage()
     return false;
 }
 
-#include <iostream>
 void LoadSetsPage::downloadSetsFile(const QUrl &url)
 {
     wizard()->setCardSourceVersion("unknown");
@@ -449,12 +448,20 @@ void LoadSetsPage::readSetsFromByteArray(QByteArray data)
     progressLabel->show();
     progressBar->show();
 
+    wizard()->downloadedPlainXml = false;
+    wizard()->xmlData.clear();
+    readSetsFromByteArrayRef(data);
+}
+
+void LoadSetsPage::readSetsFromByteArrayRef(QByteArray &data)
+{
     // unzip the file if needed
     if (data.startsWith(XZ_SIGNATURE)) {
 #ifdef HAS_LZMA
         // zipped file
         auto *inBuffer = new QBuffer(&data);
-        auto *outBuffer = new QBuffer(this);
+        auto newData = QByteArray();
+        auto *outBuffer = new QBuffer(&newData);
         inBuffer->open(QBuffer::ReadOnly);
         outBuffer->open(QBuffer::WriteOnly);
         XzDecompressor xz;
@@ -462,11 +469,8 @@ void LoadSetsPage::readSetsFromByteArray(QByteArray data)
             zipDownloadFailed(tr("Xz extraction failed."));
             return;
         }
-        const auto &outBufferData = outBuffer->data();
-
-        future = QtConcurrent::run(
-            [this, &outBufferData] { return wizard()->importer->readSetsFromByteArray(outBufferData); });
-        watcher.setFuture(future);
+        data.clear();
+        readSetsFromByteArrayRef(newData);
         return;
 #else
         zipDownloadFailed(tr("Sorry, this version of Oracle does not support xz compressed files."));
@@ -481,7 +485,8 @@ void LoadSetsPage::readSetsFromByteArray(QByteArray data)
 #ifdef HAS_ZLIB
         // zipped file
         auto *inBuffer = new QBuffer(&data);
-        auto *outBuffer = new QBuffer(this);
+        auto newData = QByteArray();
+        auto *outBuffer = new QBuffer(&newData);
         QString fileName;
         UnZip::ErrorCode ec;
         UnZip uz;
@@ -505,11 +510,8 @@ void LoadSetsPage::readSetsFromByteArray(QByteArray data)
             uz.closeArchive();
             return;
         }
-        const auto &outBufferData = outBuffer->data();
-
-        future = QtConcurrent::run(
-            [this, &outBufferData] { return wizard()->importer->readSetsFromByteArray(outBufferData); });
-        watcher.setFuture(future);
+        data.clear();
+        readSetsFromByteArrayRef(newData);
         return;
 #else
         zipDownloadFailed(tr("Sorry, this version of Oracle does not support zipped files."));
@@ -520,10 +522,23 @@ void LoadSetsPage::readSetsFromByteArray(QByteArray data)
         progressBar->hide();
         return;
 #endif
+    } else if (data.startsWith("{")) {
+        // Start the computation.
+        jsonData = std::move(data);
+        future = QtConcurrent::run([this] { return wizard()->importer->readSetsFromByteArray(std::move(jsonData)); });
+        watcher.setFuture(future);
+    } else if (data.startsWith("<")) {
+        // save xml file and don't do any processing
+        wizard()->downloadedPlainXml = true;
+        wizard()->xmlData = std::move(data);
+        importFinished();
+    } else {
+        wizard()->enableButtons();
+        setEnabled(true);
+        progressLabel->hide();
+        progressBar->hide();
+        QMessageBox::critical(this, tr("Error"), tr("Failed to interpret downloaded data."));
     }
-    // Start the computation.
-    future = QtConcurrent::run([this, &data] { return wizard()->importer->readSetsFromByteArray(data); });
-    watcher.setFuture(future);
 }
 
 void LoadSetsPage::zipDownloadFailed(const QString &message)
@@ -553,7 +568,7 @@ void LoadSetsPage::importFinished()
     progressLabel->hide();
     progressBar->hide();
 
-    if (watcher.future().result()) {
+    if (wizard()->downloadedPlainXml || watcher.future().result()) {
         wizard()->next();
     } else {
         QMessageBox::critical(this, tr("Error"),
@@ -590,6 +605,12 @@ void SaveSetsPage::initializePage()
 {
     messageLog->clear();
 
+    retranslateUi();
+    if (wizard()->downloadedPlainXml) {
+        messageLog->hide();
+        return;
+    }
+    messageLog->show();
     connect(wizard()->importer, SIGNAL(setIndexChanged(int, int, const QString &)), this,
             SLOT(updateTotalProgress(int, int, const QString &)));
 
@@ -601,7 +622,12 @@ void SaveSetsPage::initializePage()
 void SaveSetsPage::retranslateUi()
 {
     setTitle(tr("Sets imported"));
-    setSubTitle(tr("The following sets have been found:"));
+    if (wizard()->downloadedPlainXml) {
+        setSubTitle(tr("A cockatrice database file of %1 MB has been downloaded.")
+                        .arg(qRound(wizard()->xmlData.size() / 1000000.0)));
+    } else {
+        setSubTitle(tr("The following sets have been found:"));
+    }
 
     saveLabel->setText(tr("Press \"Save\" to store the imported cards in the Cockatrice database."));
     pathLabel->setText(tr("The card database will be saved at the following location:") + "<br>" +
@@ -646,7 +672,19 @@ bool SaveSetsPage::validatePage()
         return false;
     }
 
-    if (!wizard()->importer->saveToFile(fileName, wizard()->getCardSourceUrl(), wizard()->getCardSourceVersion())) {
+    if (wizard()->downloadedPlainXml) {
+        QFile file(fileName);
+        if (!file.open(QIODevice::WriteOnly)) {
+            qDebug() << "File write (w) failed for" << fileName;
+            return false;
+        }
+        if (file.write(wizard()->xmlData) < 1) {
+            qDebug() << "File write (w) failed for" << fileName;
+            return false;
+        }
+        wizard()->xmlData.clear();
+    } else if (!wizard()->importer->saveToFile(fileName, wizard()->getCardSourceUrl(),
+                                               wizard()->getCardSourceVersion())) {
         QMessageBox::critical(this, tr("Error"), tr("The file could not be saved to %1").arg(fileName));
         return false;
     }

--- a/oracle/src/oraclewizard.h
+++ b/oracle/src/oraclewizard.h
@@ -60,6 +60,8 @@ public:
     OracleImporter *importer;
     QSettings *settings;
     QNetworkAccessManager *nam;
+    bool downloadedPlainXml = false;
+    QByteArray xmlData;
 
 private slots:
     void updateLanguage();
@@ -113,6 +115,7 @@ protected:
     void initializePage() override;
     bool validatePage() override;
     void readSetsFromByteArray(QByteArray data);
+    void readSetsFromByteArrayRef(QByteArray &data);
     void downloadSetsFile(const QUrl &url);
 
 private:
@@ -127,6 +130,7 @@ private:
 
     QFutureWatcher<bool> watcher;
     QFuture<bool> future;
+    QByteArray jsonData;
 
 private slots:
     void actLoadSetsFile();

--- a/oracle/src/qt-json/json.cpp
+++ b/oracle/src/qt-json/json.cpp
@@ -80,12 +80,11 @@ QVariant Json::parse(const QString &json, bool &success)
 
     // Return an empty QVariant if the JSON data is either null or empty
     if (!json.isNull() || !json.isEmpty()) {
-        QString data = json;
         // We'll start from index 0
         int index = 0;
 
         // Parse the first value
-        QVariant value = Json::parseValue(data, index, success);
+        QVariant value = Json::parseValue(json, index, success);
 
         // Return the parsed value
         return value;


### PR DESCRIPTION
## Related Ticket(s)
- https://github.com/Cockatrice/Cockatrice/issues/4109
- 
## Short roundup of the initial problem
oracle is the main way to download the cards.xml and the application doesn't have any other ways to simply download an xml to there right now, this is sort of an intermediate hack so we can phase out oracle entirely in the future, allowing this version to be somewhat future compatible. This might also help users that have issues running oracle because of it's absolutely ridiculous ram usage rn. As well as allow easier downloads of custom card databases.

## What will change with this Pull Request?
- oracle can download xmls including compressed ones
- downloading xmls is substantially less memory intensive
- downloading json is still as memory intensive (2.8GB)
