### PR TITLE
Enable buttons for current game when receiving server response

### DIFF
--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -295,7 +295,7 @@ void GameSelector::disableButtons()
 void GameSelector::enableButtons()
 {
     if (createButton)
-        createButton->setEnabled(false);
+        createButton->setEnabled(true);
 
     // Enable buttons for the currently selected game
     enableButtonsForIndex(gameListView->currentIndex());

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -275,12 +275,9 @@ void GameSelector::actJoin()
 
     PendingCommand *pend = r->prepareRoomCommand(cmd);
     connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(checkResponse(Response)));
-
-    // Disable the buttons before sending the command to avoid unlikely but
-    // possible race conditions if the response is received before we disable
-    // the buttons.
-    disableButtons();
     r->sendRoomCommand(pend);
+
+    disableButtons();
 }
 
 void GameSelector::disableButtons()

--- a/cockatrice/src/gameselector.h
+++ b/cockatrice/src/gameselector.h
@@ -49,6 +49,9 @@ private:
     GameTypeMap gameTypeMap;
 
     void updateTitle();
+    void disableButtons();
+    void enableButtons();
+    void enableButtonsForIndex(const QModelIndex &current);
 
 public:
     GameSelector(AbstractClient *_client,


### PR DESCRIPTION
Previously, upon joining a game, we were unconditionally re-enabling the "Join" button in the lobby, even if it was not enabled in the first place, causing #4698. This could also lead to issues where if the user selects a different game after joining (which they can do in case of e.g. network connectivity issues), the "Join as spectator" button could get incorrectly disabled.

This fixes #4698 by re-enabling the buttons based on the state of the currently selected game at the time the response is received. This also avoids inconsistencies if a different game has been selected in between joining and receiving a response from the server.

## Related Ticket(s)
- Fixes #4698