### PR TITLE
Add Oracle support for persistent & Fix persistent on reverse-related

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -589,7 +589,8 @@ void CardDatabase::refreshCachedReverseRelatedCards()
 
             auto *newCardRelation = new CardRelation(card->getName(), cardRelation->getDoesAttach(),
                                                      cardRelation->getIsCreateAllExclusion(),
-                                                     cardRelation->getIsVariable(), cardRelation->getDefaultCount());
+                                                     cardRelation->getIsVariable(), cardRelation->getDefaultCount(),
+                                                     cardRelation->getIsPersistent());
             cards.value(targetCard)->addReverseRelatedCards2Me(newCardRelation);
         }
     }

--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -587,10 +587,9 @@ void CardDatabase::refreshCachedReverseRelatedCards()
                 continue;
             }
 
-            auto *newCardRelation = new CardRelation(card->getName(), cardRelation->getDoesAttach(),
-                                                     cardRelation->getIsCreateAllExclusion(),
-                                                     cardRelation->getIsVariable(), cardRelation->getDefaultCount(),
-                                                     cardRelation->getIsPersistent());
+            auto *newCardRelation = new CardRelation(
+                card->getName(), cardRelation->getDoesAttach(), cardRelation->getIsCreateAllExclusion(),
+                cardRelation->getIsVariable(), cardRelation->getDefaultCount(), cardRelation->getIsPersistent());
             cards.value(targetCard)->addReverseRelatedCards2Me(newCardRelation);
         }
     }

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -334,7 +334,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet,
 
         power = getStringPropertyFromMap(card, "power");
         toughness = getStringPropertyFromMap(card, "toughness");
-        if (power.isEmpty() || toughness.isEmpty()){
+        if (power.isEmpty() || toughness.isEmpty()) {
             ptSeparator = "";
         }
         if (!(power.isEmpty() && toughness.isEmpty())) {
@@ -380,7 +380,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet,
                 }
                 name = faceName;
             }
-            
+
             // mtgjon related cards
             if (card.contains("relatedCards")) {
                 QVariantMap givenRelated = card.value("relatedCards").toMap();

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -380,6 +380,18 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet,
                 }
                 name = faceName;
             }
+            
+            // mtgjon related cards
+            if (card.contains("relatedCards")) {
+                QVariantMap givenRelated = card.value("relatedCards").toMap();
+                // conjured cards from a spellbook
+                if (givenRelated.contains("spellbook")) {
+                    auto spbk = givenRelated.value("spellbook").toStringList();
+                    for (const QString &spbkName : spbk) {
+                        relatedCards.append(new CardRelation(spbkName, false, false, false, 1, true));
+                    }
+                }
+            }
 
             CardInfoPtr newCard = addCard(name + numComponent, text, isToken, properties, relatedCards, setInfo);
             numCards++;


### PR DESCRIPTION
## Related Ticket(s)
- #4646 

## Short roundup of the initial problem
This is the followup to #4646 to add persistent relations into Oracle now that MTGJson supports Conjure spellbooks. It also fixes reverse-related cardRelations not staying persistent.

## What will change with this Pull Request?
- Oracle now checks MTGJson's `relatedCards:{spellbook:[]}` property and sets a persistent relation for each of those cards
- refreshCachedReverseRelatedCards now does getIsPersistent so persistent reverse-related cardRelations don't get reset to not persistent.

## Other
- Smaller sets json used for testing: [YDMU.zip](https://github.com/Cockatrice/Cockatrice/files/10660056/YDMU.zip)
- I recognize this might become redundant with #4736, but I assume we'd still need Oracle to make that xml in the first place.
