### PR TITLE
Allow revealing specific cards from hand and library

### DIFF
--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -217,6 +217,7 @@ private slots:
     void actPlay();
     void actHide();
     void actPlayFacedown();
+    void actReveal(QAction *action);
     void refreshShortcuts();
 
 private:
@@ -227,6 +228,7 @@ private:
         *bottomLibraryMenu, *rfgMenu, *playerMenu;
     QList<QMenu *> playerLists;
     QList<QAction *> allPlayersActions;
+    QList<QPair<QString, int>> playersInfo;
     QAction *aMoveHandToTopLibrary, *aMoveHandToBottomLibrary, *aMoveHandToGrave, *aMoveHandToRfg,
         *aMoveGraveToTopLibrary, *aMoveGraveToBottomLibrary, *aMoveGraveToHand, *aMoveGraveToRfg, *aMoveRfgToTopLibrary,
         *aMoveRfgToBottomLibrary, *aMoveRfgToHand, *aMoveRfgToGrave, *aViewHand, *aViewLibrary, *aViewTopCards,
@@ -297,6 +299,7 @@ private:
     void rearrangeCounters();
 
     void initSayMenu();
+    void initContextualPlayersMenu(QMenu *menu);
 
     // void eventConnectionStateChanged(const Event_ConnectionStateChanged &event);
     void eventGameSay(const Event_GameSay &event);

--- a/common/pb/command_reveal_cards.proto
+++ b/common/pb/command_reveal_cards.proto
@@ -5,7 +5,7 @@ message Command_RevealCards {
         optional Command_RevealCards ext = 1026;
     }
     optional string zone_name = 1;
-    optional sint32 card_id = 2 [default = -1];
+    repeated sint32 card_id = 2 [packed = false];
     optional sint32 player_id = 3 [default = -1];
     optional bool grant_write_access = 4;
     optional sint32 top_cards = 5 [default = -1];

--- a/common/pb/event_reveal_cards.proto
+++ b/common/pb/event_reveal_cards.proto
@@ -7,7 +7,7 @@ message Event_RevealCards {
         optional Event_RevealCards ext = 2006;
     }
     optional string zone_name = 1;
-    optional sint32 card_id = 2 [default = -1];
+    repeated sint32 card_id = 2 [packed = false];
     optional sint32 other_player_id = 3 [default = -1];
     repeated ServerInfo_Card cards = 4;
     optional bool grant_write_access = 5;


### PR DESCRIPTION
## Short roundup of the initial problem

Currently Cockatrice allows revealing the whole hand, or one card at random from the hand. Sometimes, a player needs to reveal a specific card from their hand instead, which is not supported. To achieve a similar effect, players usually move the corresponding card (or cards) to a public zone, then back to their hand. While this works, it is unsatisfactory (compared to a regular reveal, you can't keep the "revealed" window around, for one) and somewhat non-intuitive.

## What will change with this Pull Request?
- When selecting a single card or a set of cards in your hand and some other zones (e.g. when viewing your library), there is a new "Reveal to..." menu. Using this menu, you can reveal the selected cards to one specific player or to all players.
- Old clients (without the patch) will correctly see the cards revealed by new clients using a new server (with the patch), but they won't be able to reveal their own cards.
- New clients connected to old servers (without the patch) will only be able to reveal cards from their hand one at a time. Trying to reveal multiple cards at once on an old server will only reveal one (unspecified) card amongst the selected cards.

## Technical details

To implement the functionality at the protocol level, the existing RevealCards command is extended to support revealing multiple specific cards. This is done by making `card_id` a non-packed repeated field in the `Command_RevealCards` and `Event_RevealCards` protobufs.  Using a non-packed repeated fields allows maintaining backwards compatibility: an empty optional field is encoded the same way as an empty non-packed list, an optional field with a value is encoded the same way as a one-element non-packed list, and when decoding a multi-elements non-packed list as an optional, only the last item in the list is read.

Since the RevealCards command already exists, and due to the compatible encodings, a new client connecting to an old server can reveal a single specific card from their hand. When trying to reveal multiple cards at once, the old server will only see the request for one of the cards to be revealed, and the player will have to reveal each card separately.

On the other hand, `Event_RevealedCards` already has an explicit list of cards revealed by the server, and the `card_id` field is only used when exactly one card has been revealed: thus, old and new clients will behave identically when receiving a new `Event_RevealedCards`. In particular, if a player using a new client reveals multiple cards from their hand on a new server, another player using an old client will correctly see all the revealed cards.

The approach used to build the "Reveal to..." menu is slightly different from the approach used to build other player selection menus. Because the "Reveal to..." menu is specific to each card, but must also be updated whenever a player is added to or removed from the game, I chose to re-create it on the fly whenever a card is clicked, as that seemed the safest way to avoid both memory leaks and inconsistent state given my understanding of the code.