### PR TITLE
Corrected edition search syntax

### DIFF
--- a/cockatrice/resources/help/search.md
+++ b/cockatrice/resources/help/search.md
@@ -46,8 +46,7 @@ The search bar recognizes a set of special commands similar to some other card d
 
 <dt><u>E</u>dition:</dt>
 <dd>[set:lea](#set:lea) <small>(Cards that appear in Alpha, which has the set code LEA)</small></dd>
-<dd>[e:lea,leb](#e:lea,leb) <small>(Cards that appear in Alpha or Beta)</small></dd>
-<dd><a href="#e:lea,leb -(e:lea e:leb)">e:lea,leb -(e:lea e:leb)</a> <small>(Cards that appear in Alpha or Beta but not in both editions)</small></dd>
+<dd>[e:lea or e:leb](#e:lea or e:leb) <small>(Cards that appear in Alpha or Beta)</small></dd>
 
 <dt>Negate:</dt>
 <dd>[c:wu -c:m](#c:wu -c:m) <small>(Any card that is white or blue, but not multicolored)</small></dd>


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4508 

## Short roundup of the initial problem

The Search Help pop-up incorrectly lists set names separated by "," as a valid way to specify "or" in Cockatrice. It also lists (e:lea e:leb) as a valid construction but two set searches in a row within a grouping is invalid in Cockatrice. Both of these constructions work in Scryfall search; however, which is likely where this incorrect syntax was copied from.

## What will change with this Pull Request?

The Search Help pop up will only list constructions that are valid in Cockatrice. I checked all the other constructions listed and they seem to be valid.

Please let me know if I edited the correct file to do this (just took a guess based on the contents and the tab_deck_editor.cpp code) or if further changes are required outside of this file. 