### PR TITLE
PictureLoader: Replace downloadedPics cache with QNetworkCache

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -621,8 +621,8 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), &SettingsCache::instance(),
             SLOT(setDownloadSpoilerStatus(bool)));
     connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), this, SLOT(setSpoilersEnabled(bool)));
-    connect(networkCacheEdit, &QSpinBox::valueChanged, &SettingsCache::instance(),
-            &SettingsCache::setNetworkCacheSizeInMB);
+    connect(networkCacheEdit, SIGNAL(valueChanged(int)), &SettingsCache::instance(),
+            SLOT(setNetworkCacheSizeInMB(int)));
 
     mpGeneralGroupBox = new QGroupBox;
     mpGeneralGroupBox->setLayout(lpGeneralGrid);

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -3,6 +3,7 @@
 #include "carddatabase.h"
 #include "gettextwithmax.h"
 #include "main.h"
+#include "pictureloader.h"
 #include "releasechannel.h"
 #include "sequenceEdit/sequenceedit.h"
 #include "settingscache.h"
@@ -635,6 +636,11 @@ void DeckEditorSettingsPage::resetDownloadedURLsButtonClicked()
 
 void DeckEditorSettingsPage::clearDownloadedPicsButtonClicked()
 {
+    PictureLoader::clearNetworkCache();
+
+    // These are not used anymore, but we don't delete them automatically, so
+    // we should do it here lest we leave pictures hanging around on users'
+    // machines.
     QString picsPath = SettingsCache::instance().getPicsPath() + "/downloadedPics/";
     QStringList dirs = QDir(picsPath).entryList(QDir::AllDirs | QDir::NoDotAndDotDot);
     bool outerSuccessRemove = true;
@@ -662,6 +668,7 @@ void DeckEditorSettingsPage::clearDownloadedPicsButtonClicked()
     }
     if (outerSuccessRemove) {
         QMessageBox::information(this, tr("Success"), tr("Downloaded card pictures have been reset."));
+        QDir(SettingsCache::instance().getPicsPath()).rmdir("downloadedPics");
     } else {
         QMessageBox::critical(this, tr("Error"), tr("One or more downloaded card pictures could not be cleared."));
     }

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -599,14 +599,18 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     networkCacheEdit->setValue(SettingsCache::instance().getNetworkCacheSizeInMB());
     networkCacheEdit->setSuffix(tr(" MB"));
 
+    auto networkCacheLayout = new QHBoxLayout;
+    networkCacheLayout->addWidget(&networkCacheLabel);
+    networkCacheLayout->addWidget(networkCacheEdit);
+    networkCacheLayout->addWidget(&clearDownloadedPicsButton);
+    networkCacheLayout->addStretch();
+
     // Top Layout
     lpGeneralGrid->addWidget(&picDownloadCheckBox, 0, 0);
     lpGeneralGrid->addWidget(&resetDownloadURLs, 0, 1);
     lpGeneralGrid->addLayout(messageListLayout, 1, 0, 1, 2);
-    lpGeneralGrid->addWidget(&networkCacheLabel, 2, 0);
-    lpGeneralGrid->addWidget(networkCacheEdit, 2, 1);
+    lpGeneralGrid->addLayout(networkCacheLayout, 2, 0, 1, 2);
     lpGeneralGrid->addWidget(&urlLinkLabel, 3, 0);
-    lpGeneralGrid->addWidget(&clearDownloadedPicsButton, 3, 1);
 
     // Spoiler Layout
     lpSpoilerGrid->addWidget(&mcDownloadSpoilersCheckBox, 0, 0);
@@ -623,6 +627,7 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), this, SLOT(setSpoilersEnabled(bool)));
     connect(networkCacheEdit, SIGNAL(valueChanged(int)), &SettingsCache::instance(),
             SLOT(setNetworkCacheSizeInMB(int)));
+    connect(&SettingsCache::instance(), SIGNAL(networkCacheSizeChanged(int)), networkCacheEdit, SLOT(setValue(int)));
 
     mpGeneralGroupBox = new QGroupBox;
     mpGeneralGroupBox->setLayout(lpGeneralGrid);
@@ -801,9 +806,9 @@ void DeckEditorSettingsPage::retranslateUi()
                                 tr("Do not close settings until manual update is complete"));
     picDownloadCheckBox.setText(tr("Download card pictures on the fly"));
     urlLinkLabel.setText(QString("<a href='%1'>%2</a>").arg(WIKI_CUSTOM_PIC_URL).arg(tr("How to add a custom URL")));
-    clearDownloadedPicsButton.setText(tr("Delete Downloaded Images"));
+    clearDownloadedPicsButton.setText(tr("Clear", "Delete Downloaded Images"));
     resetDownloadURLs.setText(tr("Reset Download URLs"));
-    networkCacheLabel.setText(tr("Maximum image cache size:"));
+    networkCacheLabel.setText(tr("Size of the downloaded images directory:"));
 }
 
 MessagesSettingsPage::MessagesSettingsPage()

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -592,12 +592,21 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     messageListLayout->addWidget(messageToolBar);
     messageListLayout->addWidget(urlList);
 
+    auto networkCacheEdit = new QSpinBox;
+    networkCacheEdit->setMinimum(NETWORK_CACHE_SIZE_MIN);
+    networkCacheEdit->setMaximum(NETWORK_CACHE_SIZE_MAX);
+    networkCacheEdit->setSingleStep(1);
+    networkCacheEdit->setValue(SettingsCache::instance().getNetworkCacheSizeInMB());
+    networkCacheEdit->setSuffix(tr(" MB"));
+
     // Top Layout
     lpGeneralGrid->addWidget(&picDownloadCheckBox, 0, 0);
     lpGeneralGrid->addWidget(&resetDownloadURLs, 0, 1);
     lpGeneralGrid->addLayout(messageListLayout, 1, 0, 1, 2);
-    lpGeneralGrid->addWidget(&urlLinkLabel, 2, 0);
-    lpGeneralGrid->addWidget(&clearDownloadedPicsButton, 2, 1);
+    lpGeneralGrid->addWidget(&networkCacheLabel, 2, 0);
+    lpGeneralGrid->addWidget(networkCacheEdit, 2, 1);
+    lpGeneralGrid->addWidget(&urlLinkLabel, 3, 0);
+    lpGeneralGrid->addWidget(&clearDownloadedPicsButton, 3, 1);
 
     // Spoiler Layout
     lpSpoilerGrid->addWidget(&mcDownloadSpoilersCheckBox, 0, 0);
@@ -612,6 +621,8 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), &SettingsCache::instance(),
             SLOT(setDownloadSpoilerStatus(bool)));
     connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), this, SLOT(setSpoilersEnabled(bool)));
+    connect(networkCacheEdit, &QSpinBox::valueChanged, &SettingsCache::instance(),
+            &SettingsCache::setNetworkCacheSizeInMB);
 
     mpGeneralGroupBox = new QGroupBox;
     mpGeneralGroupBox->setLayout(lpGeneralGrid);
@@ -792,6 +803,7 @@ void DeckEditorSettingsPage::retranslateUi()
     urlLinkLabel.setText(QString("<a href='%1'>%2</a>").arg(WIKI_CUSTOM_PIC_URL).arg(tr("How to add a custom URL")));
     clearDownloadedPicsButton.setText(tr("Delete Downloaded Images"));
     resetDownloadURLs.setText(tr("Reset Download URLs"));
+    networkCacheLabel.setText(tr("Maximum image cache size:"));
 }
 
 MessagesSettingsPage::MessagesSettingsPage()

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -58,7 +58,6 @@ private:
     QLineEdit *tokenDatabasePathEdit;
     QPushButton *resetAllPathsButton;
     QLabel *allPathsResetLabel;
-    QSpinBox pixmapCacheEdit;
     QGroupBox *personalGroupBox;
     QGroupBox *pathsGroupBox;
     QComboBox languageBox;
@@ -66,7 +65,6 @@ private:
     QCheckBox newVersionOracleCheckBox;
     QComboBox updateReleaseChannelBox;
     QLabel languageLabel;
-    QLabel pixmapCacheLabel;
     QLabel deckPathLabel;
     QLabel replaysPathLabel;
     QLabel picsPathLabel;
@@ -169,6 +167,9 @@ private:
     QPushButton *mpSpoilerPathButton;
     QPushButton *updateNowButton;
     QLabel networkCacheLabel;
+    QSpinBox networkCacheEdit;
+    QSpinBox pixmapCacheEdit;
+    QLabel pixmapCacheLabel;
 };
 
 class MessagesSettingsPage : public AbstractSettingsPage

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -168,6 +168,7 @@ private:
     QLabel infoOnSpoilersLabel;
     QPushButton *mpSpoilerPathButton;
     QPushButton *updateNowButton;
+    QLabel networkCacheLabel;
 };
 
 class MessagesSettingsPage : public AbstractSettingsPage

--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -165,14 +165,15 @@ void PictureLoaderWorker::processLoadQueue()
         QString cardName = cardBeingLoaded.getCard()->getName();
         QString correctedCardName = cardBeingLoaded.getCard()->getCorrectedName();
 
-        qDebug() << "PictureLoader: [card: " << cardName << " set: " << setName << "]: Trying to load picture";
+        qDebug().nospace() << "PictureLoader: [card: " << cardName << " set: " << setName
+                           << "]: Trying to load picture";
 
         if (cardImageExistsOnDisk(setName, correctedCardName)) {
             continue;
         }
 
-        qDebug() << "PictureLoader: [card: " << cardName << " set: " << setName
-                 << "]: No custom picture, trying to download";
+        qDebug().nospace() << "PictureLoader: [card: " << cardName << " set: " << setName
+                           << "]: No custom picture, trying to download";
         cardsToDownload.append(cardBeingLoaded);
         cardBeingLoaded.clear();
         if (!downloadRunning) {
@@ -214,22 +215,22 @@ bool PictureLoaderWorker::cardImageExistsOnDisk(QString &setName, QString &corre
     for (const auto &picsPath : picsPaths) {
         imgReader.setFileName(picsPath);
         if (imgReader.read(&image)) {
-            qDebug() << "PictureLoader: [card: " << correctedCardname << " set: " << setName
-                     << "]: Picture found on disk.";
+            qDebug().nospace() << "PictureLoader: [card: " << correctedCardname << " set: " << setName
+                               << "]: Picture found on disk.";
             imageLoaded(cardBeingLoaded.getCard(), image);
             return true;
         }
         imgReader.setFileName(picsPath + ".full");
         if (imgReader.read(&image)) {
-            qDebug() << "PictureLoader: [card: " << correctedCardname << " set: " << setName
-                     << "]: Picture.full found on disk.";
+            qDebug().nospace() << "PictureLoader: [card: " << correctedCardname << " set: " << setName
+                               << "]: Picture.full found on disk.";
             imageLoaded(cardBeingLoaded.getCard(), image);
             return true;
         }
         imgReader.setFileName(picsPath + ".xlhq");
         if (imgReader.read(&image)) {
-            qDebug() << "PictureLoader: [card: " << correctedCardname << " set: " << setName
-                     << "]: Picture.xlhq found on disk.";
+            qDebug().nospace() << "PictureLoader: [card: " << correctedCardname << " set: " << setName
+                               << "]: Picture.xlhq found on disk.";
             imageLoaded(cardBeingLoaded.getCard(), image);
             return true;
         }
@@ -384,9 +385,10 @@ void PictureLoaderWorker::startNextPicDownload()
         picDownloadFailed();
     } else {
         QUrl url(picUrl);
-        qDebug() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
-                 << " set: " << cardBeingDownloaded.getSetName()
-                 << (picDownload ? "download picture from url" : "load picture from cache") << url.toDisplayString();
+        qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
+                           << " set: " << cardBeingDownloaded.getSetName() << "]: Trying to "
+                           << (picDownload ? "download picture from url" : "load picture from cache")
+                           << url.toDisplayString();
         makeRequest(url);
     }
 }
@@ -402,10 +404,10 @@ void PictureLoaderWorker::picDownloadFailed()
         loadQueue.prepend(cardBeingDownloaded);
         mutex.unlock();
     } else {
-        qDebug() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
-                 << " set: " << cardBeingDownloaded.getSetName()
-                 << "]:  Picture NOT found, download failed, no more url combinations "
-                    "to try: BAILING OUT";
+        qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
+                           << " set: " << cardBeingDownloaded.getSetName()
+                           << "]:  Picture NOT found, download failed, no more url combinations "
+                              "to try: BAILING OUT";
         imageLoaded(cardBeingDownloaded.getCard(), QImage());
         cardBeingDownloaded.clear();
     }
@@ -433,18 +435,19 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
 
     if (reply->error()) {
         if (isFromCache) {
-            qDebug() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
-                     << " set: " << cardBeingDownloaded.getSetName() << "]: Removing corrupted cache file for url "
-                     << reply->url().toDisplayString() << " and retrying (" << reply->errorString() << ")";
+            qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+                               << " set: " << cardBeingDownloaded.getSetName()
+                               << "]: Removing corrupted cache file for url " << reply->url().toDisplayString()
+                               << " and retrying (" << reply->errorString() << ")";
 
             networkManager->cache()->remove(reply->url());
 
             makeRequest(reply->url());
             reply->deleteLater();
         } else {
-            qDebug() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
-                     << " set: " << cardBeingDownloaded.getSetName() << "]: Download failed for url "
-                     << reply->url().toDisplayString() << "(" << reply->errorString() << ")";
+            qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+                               << " set: " << cardBeingDownloaded.getSetName() << "]: Download failed for url "
+                               << reply->url().toDisplayString() << "(" << reply->errorString() << ")";
 
             picDownloadFailed();
             reply->deleteLater();
@@ -459,9 +462,9 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
     if (statusCode == 301 || statusCode == 302 || statusCode == 303 || statusCode == 305 || statusCode == 307 ||
         statusCode == 308) {
         QUrl redirectUrl = reply->header(QNetworkRequest::LocationHeader).toUrl();
-        qDebug() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
-                 << " set: " << cardBeingDownloaded.getSetName() << "]: following "
-                 << (isFromCache ? "cached redirect" : "redirect") << " to " << redirectUrl.toDisplayString();
+        qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+                           << " set: " << cardBeingDownloaded.getSetName() << "]: following "
+                           << (isFromCache ? "cached redirect" : "redirect") << " to " << redirectUrl.toDisplayString();
         makeRequest(redirectUrl);
         reply->deleteLater();
         return;
@@ -471,10 +474,10 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
     const QByteArray &picData = reply->peek(reply->size());
 
     if (imageIsBlackListed(picData)) {
-        qDebug() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
-                 << " set: " << cardBeingDownloaded.getSetName()
-                 << "]:Picture downloaded, but blacklisted, will consider it as "
-                    "not found";
+        qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+                           << " set: " << cardBeingDownloaded.getSetName()
+                           << "]: Picture downloaded, but blacklisted, will consider it as "
+                              "not found";
 
         picDownloadFailed();
         reply->deleteLater();
@@ -490,14 +493,15 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
 
     if (imgReader.read(&testImage)) {
         imageLoaded(cardBeingDownloaded.getCard(), testImage);
-        qDebug() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
-                 << " set: " << cardBeingDownloaded.getSetName() << "]: Image successfully "
-                 << (isFromCache ? "loaded from cached url at" : "downloaded from") << reply->url().toDisplayString();
+        qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+                           << " set: " << cardBeingDownloaded.getSetName() << "]: Image successfully "
+                           << (isFromCache ? "loaded from cached url at" : "downloaded from")
+                           << reply->url().toDisplayString();
     } else {
-        qDebug() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
-                 << " set: " << cardBeingDownloaded.getSetName() << "]: Possible "
-                 << (isFromCache ? "cached" : "downloaded") << " picture at " << reply->url().toDisplayString()
-                 << " could not be loaded";
+        qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+                           << " set: " << cardBeingDownloaded.getSetName() << "]: Possible "
+                           << (isFromCache ? "cached" : "downloaded") << " picture at "
+                           << reply->url().toDisplayString() << " could not be loaded";
 
         picDownloadFailed();
     }

--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -386,8 +386,7 @@ void PictureLoaderWorker::startNextPicDownload()
     } else {
         QUrl url(picUrl);
         qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
-                           << " set: " << cardBeingDownloaded.getSetName() << "]: Trying to "
-                           << (picDownload ? "download picture from url" : "load picture from cache")
+                           << " set: " << cardBeingDownloaded.getSetName() << "]: Trying to fetch picture from url "
                            << url.toDisplayString();
         makeRequest(url);
     }
@@ -406,8 +405,7 @@ void PictureLoaderWorker::picDownloadFailed()
     } else {
         qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
                            << " set: " << cardBeingDownloaded.getSetName()
-                           << "]:  Picture NOT found, download failed, no more url combinations "
-                              "to try: BAILING OUT";
+                           << "]: Picture NOT found, " << (picDownload ? "downloads disabled" : "download failed") << ", no more url combinations to try: BAILING OUT";
         imageLoaded(cardBeingDownloaded.getCard(), QImage());
         cardBeingDownloaded.clear();
     }
@@ -443,17 +441,16 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
             networkManager->cache()->remove(reply->url());
 
             makeRequest(reply->url());
-            reply->deleteLater();
         } else {
             qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
-                               << " set: " << cardBeingDownloaded.getSetName() << "]: Download failed for url "
-                               << reply->url().toDisplayString() << "(" << reply->errorString() << ")";
+                               << " set: " << cardBeingDownloaded.getSetName() << "]: " << (picDownload ? "Download": "Cache search") << " failed for url "
+                               << reply->url().toDisplayString() << " (" << reply->errorString() << ")";
 
             picDownloadFailed();
-            reply->deleteLater();
             startNextPicDownload();
         }
 
+        reply->deleteLater();
         return;
     }
 
@@ -476,8 +473,7 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
     if (imageIsBlackListed(picData)) {
         qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
                            << " set: " << cardBeingDownloaded.getSetName()
-                           << "]: Picture downloaded, but blacklisted, will consider it as "
-                              "not found";
+                           << "]: Picture found, but blacklisted, will consider it as not found";
 
         picDownloadFailed();
         reply->deleteLater();
@@ -495,7 +491,7 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
         imageLoaded(cardBeingDownloaded.getCard(), testImage);
         qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
                            << " set: " << cardBeingDownloaded.getSetName() << "]: Image successfully "
-                           << (isFromCache ? "loaded from cached url at" : "downloaded from")
+                           << (isFromCache ? "loaded from cached" : "downloaded from") << " url "
                            << reply->url().toDisplayString();
     } else {
         qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()

--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -404,8 +404,9 @@ void PictureLoaderWorker::picDownloadFailed()
         mutex.unlock();
     } else {
         qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
-                           << " set: " << cardBeingDownloaded.getSetName()
-                           << "]: Picture NOT found, " << (picDownload ? "downloads disabled" : "download failed") << ", no more url combinations to try: BAILING OUT";
+                           << " set: " << cardBeingDownloaded.getSetName() << "]: Picture NOT found, "
+                           << (picDownload ? "downloads disabled" : "download failed")
+                           << ", no more url combinations to try: BAILING OUT";
         imageLoaded(cardBeingDownloaded.getCard(), QImage());
         cardBeingDownloaded.clear();
     }
@@ -443,7 +444,8 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
             makeRequest(reply->url());
         } else {
             qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
-                               << " set: " << cardBeingDownloaded.getSetName() << "]: " << (picDownload ? "Download": "Cache search") << " failed for url "
+                               << " set: " << cardBeingDownloaded.getSetName()
+                               << "]: " << (picDownload ? "Download" : "Cache search") << " failed for url "
                                << reply->url().toDisplayString() << " (" << reply->errorString() << ")";
 
             picDownloadFailed();

--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -405,7 +405,7 @@ void PictureLoaderWorker::picDownloadFailed()
     } else {
         qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
                            << " set: " << cardBeingDownloaded.getSetName() << "]: Picture NOT found, "
-                           << (picDownload ? "downloads disabled" : "download failed")
+                           << (picDownload ? "download failed" : "downloads disabled")
                            << ", no more url combinations to try: BAILING OUT";
         imageLoaded(cardBeingDownloaded.getCard(), QImage());
         cardBeingDownloaded.clear();

--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -122,7 +122,9 @@ PictureLoaderWorker::PictureLoaderWorker()
     // We need a timeout to ensure requests don't hang indefinitely in case of
     // cache corruption, see related Qt bug: https://bugreports.qt.io/browse/QTBUG-111397
     // Use Qt's default timeout (30s, as of 2023-02-22)
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
     networkManager->setTransferTimeout();
+#endif
     auto cache = new QNetworkDiskCache(this);
     cache->setMaximumCacheSize(1024L * 1024L * SettingsCache::instance().getNetworkCacheSizeInMB());
     cache->setCacheDirectory(SettingsCache::instance().getNetworkCachePath());

--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -384,11 +384,9 @@ void PictureLoaderWorker::startNextPicDownload()
         picDownloadFailed();
     } else {
         QUrl url(picUrl);
-        qDebug() << qPrintable(QString("PictureLoader: [card: %1 set: %2]: Trying to %3: %4")
-                                   .arg(cardBeingDownloaded.getCard()->getCorrectedName())
-                                   .arg(cardBeingDownloaded.getSetName())
-                                   .arg(picDownload ? "download picture from url" : "load picture from cache")
-                                   .arg(url.toDisplayString()));
+        qDebug() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
+                 << " set: " << cardBeingDownloaded.getSetName()
+                 << (picDownload ? "download picture from url" : "load picture from cache") << url.toDisplayString();
         makeRequest(url);
     }
 }
@@ -435,23 +433,18 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
 
     if (reply->error()) {
         if (isFromCache) {
-            qDebug() << qPrintable(
-                QString("PictureLoader: [card: %1 set: %2]: Removing corrupted cache file for url %3 and retrying (%4)")
-                    .arg(cardBeingDownloaded.getCard()->getName())
-                    .arg(cardBeingDownloaded.getSetName())
-                    .arg(reply->url().toDisplayString())
-                    .arg(reply->errorString()));
+            qDebug() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+                     << " set: " << cardBeingDownloaded.getSetName() << "]: Removing corrupted cache file for url "
+                     << reply->url().toDisplayString() << " and retrying (" << reply->errorString() << ")";
 
             networkManager->cache()->remove(reply->url());
 
             makeRequest(reply->url());
             reply->deleteLater();
         } else {
-            qDebug() << qPrintable(QString("PictureLoader: [card: %1 set: %2]: Download failed for url %3 (%4)")
-                                       .arg(cardBeingDownloaded.getCard()->getName())
-                                       .arg(cardBeingDownloaded.getSetName())
-                                       .arg(reply->url().toDisplayString())
-                                       .arg(reply->errorString()));
+            qDebug() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+                     << " set: " << cardBeingDownloaded.getSetName() << "]: Download failed for url "
+                     << reply->url().toDisplayString() << "(" << reply->errorString() << ")";
 
             picDownloadFailed();
             reply->deleteLater();
@@ -466,11 +459,9 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
     if (statusCode == 301 || statusCode == 302 || statusCode == 303 || statusCode == 305 || statusCode == 307 ||
         statusCode == 308) {
         QUrl redirectUrl = reply->header(QNetworkRequest::LocationHeader).toUrl();
-        qDebug() << qPrintable(QString("PictureLoader: [card: %1 set: %2]: Following %3 to %4")
-                                   .arg(cardBeingDownloaded.getCard()->getName())
-                                   .arg(cardBeingDownloaded.getSetName())
-                                   .arg(isFromCache ? "cached redirect" : "redirect")
-                                   .arg(redirectUrl.toDisplayString()));
+        qDebug() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+                 << " set: " << cardBeingDownloaded.getSetName() << "]: following "
+                 << (isFromCache ? "cached redirect" : "redirect") << " to " << redirectUrl.toDisplayString();
         makeRequest(redirectUrl);
         reply->deleteLater();
         return;
@@ -499,18 +490,14 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
 
     if (imgReader.read(&testImage)) {
         imageLoaded(cardBeingDownloaded.getCard(), testImage);
-        qDebug() << qPrintable(QString("PictureLoader: [card: %1 set: %2]: Image successfully %3 %4")
-                                   .arg(cardBeingDownloaded.getCard()->getName())
-                                   .arg(cardBeingDownloaded.getSetName())
-                                   .arg(isFromCache ? "loaded from cached url at" : "downloaded from")
-                                   .arg(reply->url().toDisplayString()));
+        qDebug() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+                 << " set: " << cardBeingDownloaded.getSetName() << "]: Image successfully "
+                 << (isFromCache ? "loaded from cached url at" : "downloaded from") << reply->url().toDisplayString();
     } else {
-        qDebug() << qPrintable(
-            QString("PictureLoader: [card: %1 set: %2]: Possible %3 picture at %4 could not be loaded")
-                .arg(cardBeingDownloaded.getCard()->getName())
-                .arg(cardBeingDownloaded.getSetName())
-                .arg(isFromCache ? "cached" : "downloaded")
-                .arg(reply->url().toDisplayString()));
+        qDebug() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+                 << " set: " << cardBeingDownloaded.getSetName() << "]: Possible "
+                 << (isFromCache ? "cached" : "downloaded") << " picture at " << reply->url().toDisplayString()
+                 << " could not be loaded";
 
         picDownloadFailed();
     }

--- a/cockatrice/src/pictureloader.h
+++ b/cockatrice/src/pictureloader.h
@@ -96,6 +96,7 @@ private slots:
 
     void picDownloadChanged();
     void picsPathChanged();
+    void networkCacheSizeChanged(int newSizeInMB);
 public slots:
     void processLoadQueue();
 signals:

--- a/cockatrice/src/pictureloader.h
+++ b/cockatrice/src/pictureloader.h
@@ -73,6 +73,7 @@ public:
     ~PictureLoaderWorker() override;
 
     void enqueueImageLoad(CardInfoPtr card);
+    void clearNetworkCache();
 
 private:
     static QStringList md5Blacklist;
@@ -87,7 +88,7 @@ private:
     PictureToLoad cardBeingDownloaded;
     bool picDownload, downloadRunning, loadQueueRunning;
     void startNextPicDownload();
-    bool cardImageExistsOnDisk(QString &, QString &);
+    bool cardImageExistsOnDisk(QString &setName, QString &correctedCardName);
     bool imageIsBlackListed(const QByteArray &);
 private slots:
     void picDownloadFinished(QNetworkReply *reply);
@@ -127,6 +128,7 @@ public:
     static void clearPixmapCache(CardInfoPtr card);
     static void clearPixmapCache();
     static void cacheCardPixmaps(QList<CardInfoPtr> cards);
+    static void clearNetworkCache();
 private slots:
     void picDownloadChanged();
     void picsPathChanged();

--- a/cockatrice/src/pictureloader.h
+++ b/cockatrice/src/pictureloader.h
@@ -90,6 +90,7 @@ private:
     void startNextPicDownload();
     bool cardImageExistsOnDisk(QString &setName, QString &correctedCardName);
     bool imageIsBlackListed(const QByteArray &);
+    QNetworkReply *makeRequest(const QUrl &url);
 private slots:
     void picDownloadFinished(QNetworkReply *reply);
     void picDownloadFailed();

--- a/cockatrice/src/pictureloader.h
+++ b/cockatrice/src/pictureloader.h
@@ -97,9 +97,9 @@ private slots:
 
     void picDownloadChanged();
     void picsPathChanged();
-    void networkCacheSizeChanged(int newSizeInMB);
 public slots:
     void processLoadQueue();
+
 signals:
     void startLoadQueue();
     void imageLoaded(CardInfoPtr card, const QImage &image);
@@ -130,10 +130,14 @@ public:
     static void clearPixmapCache(CardInfoPtr card);
     static void clearPixmapCache();
     static void cacheCardPixmaps(QList<CardInfoPtr> cards);
+
+public slots:
     static void clearNetworkCache();
+
 private slots:
     void picDownloadChanged();
     void picsPathChanged();
+
 public slots:
     void imageLoaded(CardInfoPtr card, const QImage &image);
 };

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -28,7 +28,10 @@ QString SettingsCache::getSettingsPath()
 
 QString SettingsCache::getCachePath() const
 {
-    return QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+	if (isPortableBuild)
+        return qApp->applicationDirPath() + "/cache";
+    else
+        return QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
 }
 
 QString SettingsCache::getNetworkCachePath() const

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -26,6 +26,16 @@ QString SettingsCache::getSettingsPath()
     return getDataPath() + "/settings/";
 }
 
+QString SettingsCache::getCachePath() const
+{
+    return QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+}
+
+QString SettingsCache::getNetworkCachePath() const
+{
+    return getCachePath() + "/downloaded/";
+}
+
 void SettingsCache::translateLegacySettings()
 {
     if (isPortableBuild)

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -28,7 +28,7 @@ QString SettingsCache::getSettingsPath()
 
 QString SettingsCache::getCachePath() const
 {
-	if (isPortableBuild)
+    if (isPortableBuild)
         return qApp->applicationDirPath() + "/cache";
     else
         return QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
@@ -218,6 +218,8 @@ SettingsCache::SettingsCache()
     // sanity check
     if (pixmapCacheSize < PIXMAPCACHE_SIZE_MIN || pixmapCacheSize > PIXMAPCACHE_SIZE_MAX)
         pixmapCacheSize = PIXMAPCACHE_SIZE_DEFAULT;
+
+    networkCacheSize = settings->value("personal/networkCacheSize", NETWORK_CACHE_SIZE_DEFAULT).toInt();
 
     picDownload = settings->value("personal/picturedownload", true).toBool();
 
@@ -620,6 +622,13 @@ void SettingsCache::setPixmapCacheSize(const int _pixmapCacheSize)
     pixmapCacheSize = _pixmapCacheSize;
     settings->setValue("personal/pixmapCacheSize", pixmapCacheSize);
     emit pixmapCacheSizeChanged(pixmapCacheSize);
+}
+
+void SettingsCache::setNetworkCacheSizeInMB(const int _networkCacheSize)
+{
+    networkCacheSize = _networkCacheSize;
+    settings->setValue("personal/networkCacheSize", networkCacheSize);
+    emit networkCacheSizeChanged(networkCacheSize);
 }
 
 void SettingsCache::setClientID(const QString &_clientID)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -137,6 +137,8 @@ public:
     SettingsCache();
     QString getDataPath();
     QString getSettingsPath();
+    QString getCachePath() const;
+    QString getNetworkCachePath() const;
     const QByteArray &getMainWindowGeometry() const
     {
         return mainWindowGeometry;

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -20,6 +20,11 @@ class ReleaseChannel;
 #define PIXMAPCACHE_SIZE_MIN 64
 #define PIXMAPCACHE_SIZE_MAX 2047
 
+// In MB
+constexpr int NETWORK_CACHE_SIZE_DEFAULT = 1024 * 4; // 4 GB
+constexpr int NETWORK_CACHE_SIZE_MIN = 1;            // 1 MB
+constexpr int NETWORK_CACHE_SIZE_MAX = 1024 * 1024;  // 1 TB
+
 #define DEFAULT_LANG_NAME "English"
 #define CLIENT_INFO_NOT_SET "notset"
 
@@ -46,6 +51,7 @@ signals:
     void ignoreUnregisteredUsersChanged();
     void ignoreUnregisteredUserMessagesChanged();
     void pixmapCacheSizeChanged(int newSizeInMBs);
+    void networkCacheSizeChanged(int newSizeInMBs);
     void masterVolumeChanged(int value);
     void chatMentionCompleterChanged();
     void downloadSpoilerTimeIndexChanged();
@@ -106,6 +112,7 @@ private:
     QString knownMissingFeatures;
     bool useTearOffMenus;
     int pixmapCacheSize;
+    int networkCacheSize;
     bool scaleCards;
     bool showMessagePopups;
     bool showMentionPopups;
@@ -332,6 +339,10 @@ public:
     {
         return pixmapCacheSize;
     }
+    int getNetworkCacheSizeInMB() const
+    {
+        return networkCacheSize;
+    }
     bool getScaleCards() const
     {
         return scaleCards;
@@ -522,6 +533,7 @@ public slots:
     void setIgnoreUnregisteredUsers(int _ignoreUnregisteredUsers);
     void setIgnoreUnregisteredUserMessages(int _ignoreUnregisteredUserMessages);
     void setPixmapCacheSize(const int _pixmapCacheSize);
+    void setNetworkCacheSizeInMB(const int _networkCacheSize);
     void setCardScaling(const int _scaleCards);
     void setShowMessagePopups(const int _showMessagePopups);
     void setShowMentionPopups(const int _showMentionPopups);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -202,6 +202,9 @@ void SettingsCache::setTokenDialogGeometry(const QByteArray & /* _tokenDialogGeo
 void SettingsCache::setPixmapCacheSize(const int /* _pixmapCacheSize */)
 {
 }
+void SettingsCache::setNetworkCacheSizeInMB(const int /* _networkCacheSize */)
+{
+}
 void SettingsCache::setClientID(const QString & /* _clientID */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -206,6 +206,9 @@ void SettingsCache::setTokenDialogGeometry(const QByteArray & /* _tokenDialogGeo
 void SettingsCache::setPixmapCacheSize(const int /* _pixmapCacheSize */)
 {
 }
+void SettingsCache::setNetworkCacheSizeInMB(const int /* _networkCacheSize */)
+{
+}
 void SettingsCache::setClientID(const QString & /* _clientID */)
 {
 }


### PR DESCRIPTION
## Short roundup of the initial problem

Currently when the "Download card pictures on the fly" option is enabled, Cockatrice stores downloaded pictures into a downloadedPics sub-folder, keyed on set and card name. If a picture is found in that folder, we never try to download a picture for that card ever again (until it is reprinted in a more recent set, I guess).

This has the unfortunate consequence that if you change the URLs for downloading card images, the changes are not applied to cards that already have their picture downloaded. In particular, if you use localized card pictures (through !sflang!), you get a mix of cards in different languages depending on the currently configured language at the time each card was downloaded.

## What will change with this Pull Request?

This patch removes that mechanism in favor of setting a QNetworkDiskCache on the QNetworkAccessManager used by the PictureLoader to download pictures. The QNetworkDiskCache caches the picture keyed on their URL: if the URL changes, a new request will be made. In particular, if you use picture URLs with !sflang! and change the language, pictures for the current language will be downloaded even for cards that already have a picture. The QNetworkDiskCache is configured with a maximum size of 4GB, which should be enough to hold one high-quality JPEG for each M:TG card in existence.

Note that this does not affect the existing mechanism for defining custom card art, either through the CUSTOM directory or the set-based one.  Cockatrice will still read existing cards in the downloadedPics directory as before, it will just no longer write into that directory (since pictures are cached by the QNetworkDiskCache instead). To fully switch to the new cache, users should use the "Delete Downloaded Images" button in the settings: it will clear the QNetworkDiskCache but also remove the downloadedPics directory.