### PR TITLE
set the target in the created release

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -67,6 +67,7 @@ jobs:
         env:
           GH_TOKEN: ${{github.token}}
           tag_name: ${{steps.configure.outputs.tag}}
+          target: ${{github.ref}}
           release_name: ${{steps.prepare.outputs.title}}
           body_path: ${{steps.prepare.outputs.body_path}}
           prerelease: ${{steps.prepare.outputs.is_beta}}
@@ -75,7 +76,8 @@ jobs:
             args="--prerelease"
           fi
           gh release create "$tag_name" --draft --verify-tag $args \
-              --title "$release_name" --notes-file "$body_path"
+              --target "$target" --title "$release_name" \
+              --notes-file "$body_path"
 
   build-linux:
     strategy:


### PR DESCRIPTION

## Related Ticket(s)
- Fixes #4751 

## Short roundup of the initial problem
the target needs to be the current short commit hash because it is being compared to by the updater, the default is "master" which breaks the updater.

as noted here https://github.com/Cockatrice/Cockatrice/issues/4751#issuecomment-1434706327

## What will change with this Pull Request?
- add --target to gh release create
