### PR TITLE
set target to sha in release creation

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -67,7 +67,7 @@ jobs:
         env:
           GH_TOKEN: ${{github.token}}
           tag_name: ${{steps.configure.outputs.tag}}
-          target: ${{github.ref}}
+          target: ${{steps.configure.outputs.sha}}
           release_name: ${{steps.prepare.outputs.title}}
           body_path: ${{steps.prepare.outputs.body_path}}
           prerelease: ${{steps.prepare.outputs.is_beta}}


### PR DESCRIPTION
## Related Ticket(s)
- #4758

## Short roundup of the initial problem
fixes https://github.com/Cockatrice/Cockatrice/actions/runs/4325130272/jobs/7550877370#step:6:18

## What will change with this Pull Request?
- even though the action accepted the ref in order to base the hash off it, this doesn't seem to work the same way for gh release, or maybe this never worked, it doesn't matter as it's fixed now.
