### PR TITLE
Make cards rounded

### DIFF
--- a/cockatrice/src/abstractcarddragitem.cpp
+++ b/cockatrice/src/abstractcarddragitem.cpp
@@ -45,6 +45,13 @@ AbstractCardDragItem::~AbstractCardDragItem()
         delete childDrags[i];
 }
 
+QPainterPath AbstractCardDragItem::shape() const
+{
+    QPainterPath shape;
+    shape.addRoundedRect(boundingRect(), 0.05 * CARD_WIDTH, 0.05 * CARD_WIDTH);
+    return shape;
+}
+
 void AbstractCardDragItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
     item->paint(painter, option, widget);

--- a/cockatrice/src/abstractcarddragitem.cpp
+++ b/cockatrice/src/abstractcarddragitem.cpp
@@ -50,7 +50,7 @@ void AbstractCardDragItem::paint(QPainter *painter, const QStyleOptionGraphicsIt
     item->paint(painter, option, widget);
 
     // adds a mask to the card so it looks like the card hasnt been placed yet
-    painter->fillRect(boundingRect(), GHOST_MASK);
+    painter->fillPath(shape(), GHOST_MASK);
 }
 
 void AbstractCardDragItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)

--- a/cockatrice/src/abstractcarddragitem.h
+++ b/cockatrice/src/abstractcarddragitem.h
@@ -31,6 +31,7 @@ public:
     {
         return QRectF(0, 0, CARD_WIDTH, CARD_HEIGHT);
     }
+    QPainterPath shape() const override;
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
     AbstractCardItem *getItem() const
     {

--- a/cockatrice/src/abstractcarditem.h
+++ b/cockatrice/src/abstractcarditem.h
@@ -54,6 +54,7 @@ public:
                      QGraphicsItem *parent = nullptr);
     ~AbstractCardItem();
     QRectF boundingRect() const;
+    QPainterPath shape() const override;
     QSizeF getTranslatedSize(QPainter *painter) const;
     void paintPicture(QPainter *painter, const QSizeF &translatedSize, int angle);
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);

--- a/cockatrice/src/carddragitem.cpp
+++ b/cockatrice/src/carddragitem.cpp
@@ -24,7 +24,7 @@ void CardDragItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *opti
     AbstractCardDragItem::paint(painter, option, widget);
 
     if (occupied)
-        painter->fillRect(boundingRect(), QColor(200, 0, 0, 100));
+        painter->fillPath(shape(), QColor(200, 0, 0, 100));
 }
 
 void CardDragItem::updatePosition(const QPointF &cursorScenePos)

--- a/cockatrice/src/cardinfopicture.cpp
+++ b/cockatrice/src/cardinfopicture.cpp
@@ -4,8 +4,7 @@
 #include "main.h"
 #include "pictureloader.h"
 
-#include <QPainter>
-#include <QStyle>
+#include <QStylePainter>
 #include <QWidget>
 
 CardInfoPicture::CardInfoPicture(QWidget *parent) : QWidget(parent), info(nullptr), pixmapDirty(true)
@@ -55,6 +54,13 @@ void CardInfoPicture::paintEvent(QPaintEvent *)
     if (pixmapDirty)
         loadPixmap();
 
-    QPainter painter(this);
-    style()->drawItemPixmap(&painter, rect(), Qt::AlignHCenter, resizedPixmap);
+    QSize scaledSize = resizedPixmap.size().scaled(size(), Qt::KeepAspectRatio);
+    QPoint topLeft{(width() - scaledSize.width()) / 2, (height() - scaledSize.height()) / 2};
+    qreal radius = 0.05 * scaledSize.width();
+
+    QStylePainter painter(this);
+    QPainterPath shape;
+    shape.addRoundedRect(QRect(topLeft, scaledSize), radius, radius);
+    painter.setClipPath(shape);
+    painter.drawItemPixmap(QRect(topLeft, scaledSize), Qt::AlignCenter, resizedPixmap);
 }

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -141,21 +141,19 @@ void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
     }
 
     if (getBeingPointedAt()) {
-        painter->fillRect(boundingRect(), QBrush(QColor(255, 0, 0, 100)));
+        painter->fillPath(shape(), QBrush(QColor(255, 0, 0, 100)));
     }
 
     if (doesntUntap) {
         painter->save();
 
         painter->setRenderHint(QPainter::Antialiasing, false);
-        transformPainter(painter, translatedSize, tapAngle);
 
         QPen pen;
         pen.setColor(Qt::magenta);
-        const int penWidth = 1;
-        pen.setWidth(penWidth);
+        pen.setWidth(0); // Cosmetic pen
         painter->setPen(pen);
-        painter->drawRect(QRectF(0, 0, translatedSize.width() + penWidth, translatedSize.height() - penWidth));
+        painter->drawPath(shape());
 
         painter->restore();
     }

--- a/cockatrice/src/deckview.cpp
+++ b/cockatrice/src/deckview.cpp
@@ -89,7 +89,8 @@ void DeckViewCard::paint(QPainter *painter, const QStyleOptionGraphicsItem *opti
     pen.setJoinStyle(Qt::MiterJoin);
     pen.setColor(originZone == DECK_ZONE_MAIN ? Qt::green : Qt::red);
     painter->setPen(pen);
-    painter->drawRoundedRect(QRectF(1.5, 1.5, CARD_WIDTH - 1.5, CARD_HEIGHT - 1.5), 0.05 * CARD_WIDTH, 0.05 * CARD_WIDTH);
+    qreal cardRadius = 0.05 * CARD_WIDTH;
+    painter->drawRoundedRect(QRectF(1.5, 1.5, CARD_WIDTH - 1.5, CARD_HEIGHT - 1.5), cardRadius, cardRadius);
     painter->restore();
 }
 

--- a/cockatrice/src/deckview.cpp
+++ b/cockatrice/src/deckview.cpp
@@ -89,7 +89,7 @@ void DeckViewCard::paint(QPainter *painter, const QStyleOptionGraphicsItem *opti
     pen.setJoinStyle(Qt::MiterJoin);
     pen.setColor(originZone == DECK_ZONE_MAIN ? Qt::green : Qt::red);
     painter->setPen(pen);
-    painter->drawRect(QRectF(1, 1, CARD_WIDTH - 2, CARD_HEIGHT - 2.5));
+    painter->drawRoundedRect(QRectF(1.5, 1.5, CARD_WIDTH - 1.5, CARD_HEIGHT - 1.5), 0.05 * CARD_WIDTH, 0.05 * CARD_WIDTH);
     painter->restore();
 }
 

--- a/cockatrice/src/deckview.cpp
+++ b/cockatrice/src/deckview.cpp
@@ -89,8 +89,8 @@ void DeckViewCard::paint(QPainter *painter, const QStyleOptionGraphicsItem *opti
     pen.setJoinStyle(Qt::MiterJoin);
     pen.setColor(originZone == DECK_ZONE_MAIN ? Qt::green : Qt::red);
     painter->setPen(pen);
-    qreal cardRadius = 0.05 * CARD_WIDTH;
-    painter->drawRoundedRect(QRectF(1.5, 1.5, CARD_WIDTH - 1.5, CARD_HEIGHT - 1.5), cardRadius, cardRadius);
+    qreal cardRadius = 0.05 * (CARD_WIDTH - 3);
+    painter->drawRoundedRect(QRectF(1.5, 1.5, CARD_WIDTH - 3., CARD_HEIGHT - 3.), cardRadius, cardRadius);
     painter->restore();
 }
 

--- a/cockatrice/src/pilezone.cpp
+++ b/cockatrice/src/pilezone.cpp
@@ -28,12 +28,19 @@ QRectF PileZone::boundingRect() const
     return QRectF(0, 0, CARD_WIDTH, CARD_HEIGHT);
 }
 
+QPainterPath PileZone::shape() const
+{
+    QPainterPath shape;
+    shape.addRoundedRect(boundingRect(), 0.05 * CARD_WIDTH, 0.05 * CARD_WIDTH);
+    return shape;
+}
+
 void PileZone::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
 {
+    painter->drawPath(shape());
+
     if (!cards.isEmpty())
         cards.at(0)->paintPicture(painter, cards.at(0)->getTranslatedSize(painter), 90);
-
-    painter->drawRect(QRectF(0.5, 0.5, CARD_WIDTH - 1, CARD_HEIGHT - 1));
 
     painter->translate((float)CARD_WIDTH / 2, (float)CARD_HEIGHT / 2);
     painter->rotate(-90);

--- a/cockatrice/src/pilezone.h
+++ b/cockatrice/src/pilezone.h
@@ -19,6 +19,7 @@ public:
              bool _contentsKnown,
              QGraphicsItem *parent = nullptr);
     QRectF boundingRect() const;
+    QPainterPath shape() const override;
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
     void reorganizeCards();
     void handleDropEvent(const QList<CardDragItem *> &dragItems, CardZone *startZone, const QPoint &dropPoint);


### PR DESCRIPTION
## Short roundup of the initial problem

Magic cards have rounded corners, and playing cards tend to have rounded corners as well, but Cockatrice currently displays rectangular cards.

This can cause visual glitches when using image scans where the border does not extend in the corner, and for this reason Cockatrice always draws a (rectangular) border around the card to try and make it look a bit better.

## What will change with this Pull Request?

In this patch I take a different approach: rather than try to make rounded pegs, er, cards, go into a square hole, the hole is now rounded. More precisely, the AbstractCardItem now has a rounded rectangular shape (with a corner of 5% of the width of the card, identical to that of modern M:TG physical cards).

As a side effect, the card drawing gets a bit simplified by getting rid of transformPainter() when drawing the card outline and using the QPainter::drawPixmap overloads that takes a target QRectF instead.  This means we no longer have to bother about card rotation when painting since that's taken care of by the Graphics View framework (which transformPainter() undoes).

As another side effects, full-art cards look cooler now.

## Screenshots
| Old | New |
| ------|--------|
| ![Old](https://user-images.githubusercontent.com/146210/222900694-deb21846-9349-4f1f-88f1-86534c86e02d.png) |![New](https://user-images.githubusercontent.com/146210/222900843-47d068a6-9dc0-4d9d-9c02-83e096268b5a.png) |
