### PR TITLE
Add 'persistent' as valid attribute of related

### DIFF
--- a/doc/carddatabase_v4/cards.xsd
+++ b/doc/carddatabase_v4/cards.xsd
@@ -5,6 +5,7 @@
                 <xs:attribute type="xs:string" name="count" use="optional" />
                 <xs:attribute type="xs:string" name="exclude" use="optional" />
                 <xs:attribute type="xs:string" name="attach" use="optional" />
+                <xs:attribute type="xs:string" name="persistent" use="optional" />
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>


### PR DESCRIPTION
## Short roundup of the initial problem
With the recent addition of 'persistent' as an attribute of related in cards.xml, trying to validate the xml using the current v4 cards.xsd file produces several 'fails to validate' messages all relating to persistent.

## What will change with this Pull Request?
-Updates the v4 cards.xsd file to reflect that 'persistent' is now a valid attribute of related.

Please let me know if the cards.xsd file in the carddatabase_v3 folder should be updated similarly.