### PR TITLE
Add Ubuntu 23.04 Lunar Lobster Build

### DIFF
--- a/.ci/UbuntuLunar/Dockerfile
+++ b/.ci/UbuntuLunar/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:lunar
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        ccache \
+        clang-format \
+        cmake \
+        file \
+        g++ \
+        git \
+        libgl-dev \
+        liblzma-dev \
+        libmariadb-dev-compat \
+        libprotobuf-dev \
+        libqt6multimedia6 \
+        libqt6sql6-mysql \
+        qt6-svg-dev \
+        qt6-websockets-dev \
+        protobuf-compiler \
+        qt6-l10n-tools \
+        qt6-multimedia-dev \
+        qt6-tools-dev \
+        qt6-tools-dev-tools \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -17,6 +17,7 @@ include different targets -->
  - <kbd>Ubuntu 20.04</kbd> ("Focal Fossa")
  - <kbd>Ubuntu 22.04</kbd> ("Jammy Jellyfish")
  - <kbd>Ubuntu 22.10</kbd> ("Kinetic Kudu")
+ - <kbd>Ubuntu 23.04</kbd> ("Lunar Lobster")
  - <kbd>Debian 10</kbd> ("Buster")
  - <kbd>Debian 11</kbd> ("Bullseye")
  - <kbd>Fedora 36</kbd>

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -116,6 +116,9 @@ jobs:
 
           - distro: UbuntuKinetic
             package: DEB
+            
+          - distro: UbuntuLunar
+            package: DEB
 
     name: ${{matrix.distro}}
     needs: configure


### PR DESCRIPTION
## Short roundup of the initial problem
Ubuntu 23.04 (Lunar Lobster) will be officially released next Thursday (April 20) so users will probably want builds for it soon.

## What will change with this Pull Request?
- Adds a dockerfile and a matrix entry for Lunar
- Adds Lunar to the Release template

The names of the packages for Qt6 SVG and websockets development files were changed in Lunar, so the docker file looks slightly different.

I put this together based on the previous PR that added Kinetic so please let me know if I've missed anything.
