### PR TITLE
Remove macOS 10.15 Catalina Build

### DIFF
--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -11,8 +11,7 @@ include different targets -->
  - <kbd>Windows 7+ (32-bit)</kbd>
  - <kbd>Windows 7+</kbd>
  - <kbd>Windows 10+</kbd>
- - <kbd>macOS 10.15+</kbd> ("Catalina")
- - <kbd>macOS 11+</kbd> ("Big Sur")
+ - <kbd>macOS 11+</kbd> ("Big Sur" or higher)
  - <kbd>Ubuntu 18.04</kbd> ("Bionic Beaver")
  - <kbd>Ubuntu 20.04</kbd> ("Focal Fossa")
  - <kbd>Ubuntu 22.04</kbd> ("Jammy Jellyfish")

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -209,15 +209,6 @@ jobs:
             type: Debug
             do_tests: 1
 
-          - target: 10.15_Catalina
-            os: macos-11
-            xcode: 11.7 # allows using macOS 10.15 SDK
-            qt_version: 6.2.* # LTS (is compatible with 10.14 and 10.15)
-            qt_modules: "qtmultimedia qtwebsockets"
-            type: Release
-            do_tests: 1
-            make_package: 1
-
           - target: 11_Big_Sur
             os: macos-11
             xcode: 12.5.1


### PR DESCRIPTION
## Short roundup of the initial problem
As far as I can tell, macOS 10.15 Catalina became unsupported by Apple on November 30, 2022 so the build can safely be dropped, unless we were hoping to get one more stable release out for 10.15 before removing it.

Should separate builds for macOS 12 and 13 be added or is the 11 build sufficient for all newer macOS?

## What will change with this Pull Request?
- Drop build support for EOL OS

