### PR TITLE
save sets dialog size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ preferences
 compile_commands.json
 .vs/
 .vscode/
+.cache
+.gdb_history

--- a/cockatrice/src/dlg_manage_sets.cpp
+++ b/cockatrice/src/dlg_manage_sets.cpp
@@ -194,6 +194,7 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     auto &headerState = SettingsCache::instance().layouts().getSetsDialogHeaderState();
     if (!headerState.isEmpty()) {
         view->header()->restoreState(headerState);
+        view->header()->setSortIndicator(SORT_RESET, Qt::DescendingOrder);
     } else {
         view->header()->resizeSections(QHeaderView::ResizeToContents);
     }

--- a/cockatrice/src/dlg_manage_sets.cpp
+++ b/cockatrice/src/dlg_manage_sets.cpp
@@ -4,6 +4,7 @@
 #include "main.h"
 #include "pictureloader.h"
 #include "setsmodel.h"
+#include "settingscache.h"
 
 #include <QAction>
 #include <QDebug>
@@ -84,7 +85,6 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     displayModel->setDynamicSortFilter(false);
     view = new QTreeView;
     view->setModel(displayModel);
-    view->setMinimumSize(QSize(500, 250));
 
     view->setAlternatingRowColors(true);
     view->setUniformRowHeights(true);
@@ -97,10 +97,6 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     view->setAcceptDrops(true);
     view->setDropIndicatorShown(true);
     view->setDragDropMode(QAbstractItemView::InternalMove);
-
-    view->header()->setSectionResizeMode(QHeaderView::Stretch);
-    view->header()->setSectionResizeMode(SetsModel::EnabledCol, QHeaderView::ResizeToContents);
-    view->header()->setSectionResizeMode(SetsModel::LongNameCol, QHeaderView::ResizeToContents);
 
     view->sortByColumn(SetsModel::SortKeyCol, Qt::AscendingOrder);
     view->setColumnHidden(SetsModel::SortKeyCol, true);
@@ -170,7 +166,7 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
 
     mainLayout = new QGridLayout;
     mainLayout->addLayout(filterBox, 0, 1, 1, 2);
-    mainLayout->addWidget(setsEditToolBar, 1, 0, 2, 1);
+    mainLayout->addWidget(setsEditToolBar, 1, 0, 4, 1);
     mainLayout->addWidget(view, 1, 1, 1, 2);
     mainLayout->addWidget(enableAllButton, 2, 1);
     mainLayout->addWidget(disableAllButton, 2, 2);
@@ -190,11 +186,32 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     setCentralWidget(centralWidget);
 
     setWindowTitle(tr("Manage sets"));
-    resize(800, 500);
+    setMinimumSize(800, 500);
+    auto &geometry = SettingsCache::instance().getSetsDialogGeometry();
+    if (!geometry.isEmpty()) {
+        restoreGeometry(geometry);
+    }
+    auto &headerState = SettingsCache::instance().layouts().getSetsDialogHeaderState();
+    if (!headerState.isEmpty()) {
+        view->header()->restoreState(headerState);
+    } else {
+        view->header()->resizeSections(QHeaderView::ResizeToContents);
+    }
+    connect(view->header(), &QHeaderView::geometriesChanged, this, &WndSets::saveHeaderState);
 }
 
 WndSets::~WndSets()
 {
+}
+
+void WndSets::closeEvent(QCloseEvent * /*ev*/)
+{
+    SettingsCache::instance().setSetsDialogGeometry(saveGeometry());
+}
+
+void WndSets::saveHeaderState()
+{
+    SettingsCache::instance().layouts().setSetsDialogHeaderState(view->header()->saveState());
 }
 
 void WndSets::rebuildMainLayout(int actionToTake)

--- a/cockatrice/src/dlg_manage_sets.h
+++ b/cockatrice/src/dlg_manage_sets.h
@@ -40,6 +40,8 @@ private:
     QHBoxLayout *filterBox;
     int sortIndex;
     Qt::SortOrder sortOrder;
+    void closeEvent(QCloseEvent *ev) override;
+    void saveHeaderState();
     void rebuildMainLayout(int actionToTake);
     bool setOrderIsSorted;
     enum

--- a/cockatrice/src/settings/layoutssettings.cpp
+++ b/cockatrice/src/settings/layoutssettings.cpp
@@ -68,6 +68,16 @@ void LayoutsSettings::setDeckEditorDbHeaderState(const QByteArray &value)
     setValue(value, "layouts/deckEditorDbHeader_state");
 }
 
+const QByteArray LayoutsSettings::getSetsDialogHeaderState()
+{
+    return getValue("layouts/setsDialogHeader_state").toByteArray();
+}
+
+void LayoutsSettings::setSetsDialogHeaderState(const QByteArray &value)
+{
+    setValue(value, "layouts/setsDialogHeader_state");
+}
+
 void LayoutsSettings::setGamePlayAreaGeometry(const QByteArray &value)
 {
     setValue(value, "layouts/gameplayarea_geometry");

--- a/cockatrice/src/settings/layoutssettings.h
+++ b/cockatrice/src/settings/layoutssettings.h
@@ -17,6 +17,7 @@ public:
     void setDeckEditorDeckSize(const QSize &value);
     void setDeckEditorFilterSize(const QSize &value);
     void setDeckEditorDbHeaderState(const QByteArray &value);
+    void setSetsDialogHeaderState(const QByteArray &value);
 
     void setGamePlayAreaGeometry(const QByteArray &value);
     void setGamePlayAreaState(const QByteArray &value);
@@ -37,6 +38,7 @@ public:
     const QSize getDeckEditorDeckSize();
     const QSize getDeckEditorFilterSize();
     const QByteArray getDeckEditorDbHeaderState();
+    const QByteArray getSetsDialogHeaderState();
 
     const QByteArray getGamePlayAreaLayoutState();
     const QByteArray getGamePlayAreaGeometry();

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -225,6 +225,7 @@ SettingsCache::SettingsCache()
 
     mainWindowGeometry = settings->value("interface/main_window_geometry").toByteArray();
     tokenDialogGeometry = settings->value("interface/token_dialog_geometry").toByteArray();
+    setsDialogGeometry = settings->value("interface/sets_dialog_geometry").toByteArray();
     notificationsEnabled = settings->value("interface/notificationsenabled", true).toBool();
     spectatorNotificationsEnabled = settings->value("interface/specnotificationsenabled", false).toBool();
     buddyConnectNotificationsEnabled = settings->value("interface/buddyconnectnotificationsenabled", true).toBool();
@@ -615,6 +616,12 @@ void SettingsCache::setTokenDialogGeometry(const QByteArray &_tokenDialogGeometr
 {
     tokenDialogGeometry = _tokenDialogGeometry;
     settings->setValue("interface/token_dialog_geometry", tokenDialogGeometry);
+}
+
+void SettingsCache::setSetsDialogGeometry(const QByteArray &_setsDialogGeometry)
+{
+    setsDialogGeometry = _setsDialogGeometry;
+    settings->setValue("interface/sets_dialog_geometry", setsDialogGeometry);
 }
 
 void SettingsCache::setPixmapCacheSize(const int _pixmapCacheSize)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -70,6 +70,7 @@ private:
 
     QByteArray mainWindowGeometry;
     QByteArray tokenDialogGeometry;
+    QByteArray setsDialogGeometry;
     QString lang;
     QString deckPath, replaysPath, picsPath, customPicsPath, cardDatabasePath, customCardDatabasePath, themesPath,
         spoilerDatabasePath, tokenDatabasePath, themeName;
@@ -153,6 +154,10 @@ public:
     const QByteArray &getTokenDialogGeometry() const
     {
         return tokenDialogGeometry;
+    }
+    const QByteArray &getSetsDialogGeometry() const
+    {
+        return setsDialogGeometry;
     }
     QString getLang() const
     {
@@ -493,6 +498,7 @@ public slots:
 
     void setMainWindowGeometry(const QByteArray &_mainWindowGeometry);
     void setTokenDialogGeometry(const QByteArray &_tokenDialog);
+    void setSetsDialogGeometry(const QByteArray &_setsDialog);
     void setLang(const QString &_lang);
     void setShowTipsOnStartup(bool _showTipsOnStartup);
     void setSeenTips(const QList<int> &_seenTips);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -199,6 +199,9 @@ void SettingsCache::setMainWindowGeometry(const QByteArray & /* _mainWindowGeome
 void SettingsCache::setTokenDialogGeometry(const QByteArray & /* _tokenDialogGeometry */)
 {
 }
+void SettingsCache::setSetsDialogGeometry(const QByteArray & /* _setsDialogGeometry */)
+{
+}
 void SettingsCache::setPixmapCacheSize(const int /* _pixmapCacheSize */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -203,6 +203,9 @@ void SettingsCache::setMainWindowGeometry(const QByteArray & /* _mainWindowGeome
 void SettingsCache::setTokenDialogGeometry(const QByteArray & /* _tokenDialogGeometry */)
 {
 }
+void SettingsCache::setSetsDialogGeometry(const QByteArray & /* _setsDialogGeometry */)
+{
+}
 void SettingsCache::setPixmapCacheSize(const int /* _pixmapCacheSize */)
 {
 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4778

## Short roundup of the initial problem
the sets dialog can be resized wrong

## What will change with this Pull Request?
- don't set a minimum size of the list
- set a minimum size for the dialog
- save the dialog size in the settings
- save the header state in the settings
- allow the headers to be resized
