### PR TITLE
use a regex to remove all reserved characters from file names

### DIFF
--- a/cockatrice/src/carddatabase.cpp
+++ b/cockatrice/src/carddatabase.cpp
@@ -266,9 +266,14 @@ CardInfoPtr CardInfo::newInstance(const QString &_name,
 
 QString CardInfo::getCorrectedName() const
 {
+    // remove all the characters reserved in windows file paths,
+    // other oses only disallow a subset of these so it covers all
+    static const QRegularExpression rmrx(R"(( // |[*<>:"\\?\x00-\x08\x10-\x1f]))");
+    static const QRegularExpression spacerx(R"([/\x09-\x0f])");
+    static const QString space(' ');
     QString result = name;
     // Fire // Ice, Circle of Protection: Red, "Ach! Hans, Run!", Who/What/When/Where/Why, Question Elemental?
-    return result.remove(" // ").remove(':').remove('"').remove('?').replace('/', ' ');
+    return result.remove(rmrx).replace(spacerx, space);
 }
 
 void CardInfo::addToSet(const CardSetPtr &_set, const CardInfoPerSet _info)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4802

## Short roundup of the initial problem
some characters that weren't allowed in windows file paths could get used in the picture loader

## What will change with this Pull Request?
- this stops that by improving our conversion with some regexes, it is kept the same across platforms even if they would allow you to use eg newlines in picture names, this makes them not use those when looking for custom images (the url cache means they won't be saved on disk anymore)
- this will be mostly backwards compatible, windows users will notice nothing and other platforms will only notice this if their card database had cards with one of these characters in them (normally they won't, #4802 showed what happens if they do but was solved upstream in a day)
