### PR TITLE
add a way to replace the user facing list of disallowed words

### DIFF
--- a/cockatrice/src/window_main.cpp
+++ b/cockatrice/src/window_main.cpp
@@ -476,9 +476,22 @@ QString MainWindow::extractInvalidUsernameMessage(QString &in)
                "</li>";
 
         if (rules.size() == 9) {
-            if (rules.at(7).size() > 0)
-                out += "<li>" + tr("can not contain any of the following words: %1").arg(rules.at(7).toHtmlEscaped()) +
-                       "</li>";
+            if (rules.at(7).size() > 0) {
+                QString words = rules.at(7).toHtmlEscaped();
+                if (words.startsWith("\n")) {
+                    out += tr("no unacceptable language as specified by these server rules:",
+                              "note that the following lines will not be translated");
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+                    for (QString &line : words.split("\n", Qt::SkipEmptyParts)) {
+#else
+                    for (QString &line : words.split("\n", QString::SkipEmptyParts)) {
+#endif
+                        out += "<li>" + line + "</li>";
+                    }
+                } else {
+                    out += "<li>" + tr("can not contain any of the following words: %1").arg(words) + "</li>";
+                }
+            }
 
             if (rules.at(8).size() > 0)
                 out += "<li>" +

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -127,6 +127,16 @@ allowpunctuationprefix=false
 ; "admin,user,name"
 disallowedwords="admin"
 
+; Overwrite the words shown to the user when they enter a wrong username,
+; use \n to start a new line. Neither the real wordlist nor the disallowed
+; expressions will be sent to the user if this is set.
+; In the old versions of the client this list will be prefaced with
+; "can not contain any of the following words:"
+; example:
+;displaydisallowedwords="no attempts at impersonating staff\nno unparliamentary language\nno references to controversial figures\nstaff reserves the right to remove accounts deemed inappropriate"
+; Setting it to nothing will simply hide the list:
+;displaydisallowedwords=
+
 ; Disallow usernames matching these regular expressions. This list is comma
 ; separated, e.g. "\\w+\\d+,\\d{2}user", hence you cannot use commas in your
 ; expressions. Backslashes must be escaped, so `\w+\d+` becomes `\\w+\\d+`.

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -153,7 +153,16 @@ bool Servatrice_DatabaseInterface::usernameIsValid(const QString &user, QString 
     QStringList disallowedWords = disallowedWordsStr.split(",", QString::SkipEmptyParts);
 #endif
     disallowedWords.removeDuplicates();
-    QString disallowedRegExpStr = settingsCache->value("users/disallowedregexp", "").toString();
+    QVariant displayDisallowedWords = settingsCache->value("users/displaydisallowedwords");
+    QString disallowedRegExpStr;
+    if (displayDisallowedWords.isValid()) {
+        disallowedWordsStr = displayDisallowedWords.toString().trimmed();
+        if (!disallowedWordsStr.isEmpty()) {
+            disallowedWordsStr.prepend("\n");
+        }
+    } else {
+        disallowedRegExpStr = settingsCache->value("users/disallowedregexp", "").toString();
+    }
 
     error = QString("%1|%2|%3|%4|%5|%6|%7|%8|%9")
                 .arg(minNameLength)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes ##4575

## Short roundup of the initial problem
sorry about forgetting this for so long

## What will change with this Pull Request?
- adds a new field displaydisallowedwords to the server ini, it overrides the user facing list in a partly backwards compatible way.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
The new message looks like this:
![image](https://github.com/Cockatrice/Cockatrice/assets/36401181/a550b52f-0897-4e50-a1c7-97387c19bf14)
Old clients will have them run together like this:
![image](https://github.com/Cockatrice/Cockatrice/assets/36401181/56a7ade4-c695-492c-a60c-d06a9ddb352b)
