### PR TITLE
Add Debian 12 "Bookworm" Build

### DIFF
--- a/.ci/Debian12/Dockerfile
+++ b/.ci/Debian12/Dockerfile
@@ -1,0 +1,26 @@
+FROM debian:12
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        ccache \
+        clang-format \
+        cmake \
+        file \
+        g++ \
+        git \
+        libgl-dev \
+        liblzma-dev \
+        libmariadb-dev-compat \
+        libprotobuf-dev \
+        libqt6multimedia6 \
+        libqt6sql6-mysql \
+        qt6-svg-dev \
+        qt6-websockets-dev \
+        protobuf-compiler \
+        qt6-l10n-tools \
+        qt6-multimedia-dev \
+        qt6-tools-dev \
+        qt6-tools-dev-tools \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/.ci/Debian12/Dockerfile
+++ b/.ci/Debian12/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:12
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/.ci/Debian12/Dockerfile
+++ b/.ci/Debian12/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12
+FROM debian:bookworm
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -19,6 +19,7 @@ include different targets -->
  - <kbd>Ubuntu 22.10</kbd> ("Kinetic Kudu")
  - <kbd>Ubuntu 23.04</kbd> ("Lunar Lobster")
  - <kbd>Debian 11</kbd> ("Bullseye")
+ - <kbd>Debian 12</kbd> ("Bookworm")
  - <kbd>Fedora 36</kbd>
  - <kbd>Fedora 37</kbd>
  - <kbd>Fedora 38</kbd>

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -92,6 +92,9 @@ jobs:
           - distro: Debian11
             package: DEB
 
+          - distro: Debian12
+            package: DEB
+
           - distro: Fedora36
             package: RPM
             test: skip


### PR DESCRIPTION
## Short roundup of the initial problem

Debian 12 "Bookworm" is set to [release on June 10, 2023](https://wiki.debian.org/DebianBookworm) so users will probably want a build for it soon.

## What will change with this Pull Request?
- Adds a dockerfile and a matrix entry for Bookworm
- Adds Bookworm to the Release template

The dependencies in the docker build are very different from Debian 11 as Debian 12 has Qt6 by default and also uses the new qt6-svg-dev and qt6-websockets-dev packages that Ubuntu recently switched over to. I have tested building with these dependencies in a VM of Debian 12 RC4 and it seemed to work well. I will test the Github Actions build there too if it succeeds.
