### PR TITLE
CI: Bump GitHub actions + submodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,12 +38,12 @@ updates:
     # Limit the amout of open PR's (default = 5, disabled = 0, security updates are not impacted)
     open-pull-requests-limit: 2
 
-  # Enable version updates for npm
-  - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the `webclient` subdirectory
-    directory: "/webclient"
-    # Check the npm registry for updates once a week
-    schedule:
-      interval: "weekly"
-    # Limit the amout of open PR's (default = 5, disabled = 0, security updates are not impacted)
-    open-pull-requests-limit: 5
+ # # Enable version updates for npm
+ # - package-ecosystem: "npm"
+ #   # Look for `package.json` and `lock` files in the `webclient` subdirectory
+ #   directory: "/webclient"
+ #   # Check the npm registry for updates once a week
+ #   schedule:
+ #     interval: "weekly"
+ #   # Limit the amout of open PR's (default = 5, disabled = 0, security updates are not impacted)
+ #   open-pull-requests-limit: 5

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -336,7 +336,7 @@ jobs:
     steps:
       - name: Add msbuild to PATH
         id: add-msbuild
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v1
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -354,7 +354,7 @@ jobs:
           modules: ${{matrix.qt_modules}}
 
       - name: Run vcpkg
-        uses: lukka/run-vcpkg@v10.6
+        uses: lukka/run-vcpkg@v10
         with:
           runVcpkgInstall: true
           appendedCacheKey: ${{matrix.bit}}-bit

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -354,7 +354,7 @@ jobs:
           modules: ${{matrix.qt_modules}}
 
       - name: Run vcpkg
-        uses: lukka/run-vcpkg@v10
+        uses: lukka/run-vcpkg@v11
         with:
           runVcpkgInstall: true
           appendedCacheKey: ${{matrix.bit}}-bit

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -357,7 +357,7 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           runVcpkgInstall: true
-          appendedCacheKey: ${{matrix.bit}}-bit
+          doNotCache: false
         env:
           VCPKG_DEFAULT_TRIPLET: '${{matrix.arch}}-windows'
           VCPKG_DISABLE_METRICS: 1

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Create pull request
         if: github.event_name != 'pull_request'
         id: create_pr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v5
         with:
           add-paths: |
             cockatrice/cockatrice_en@source.ts


### PR DESCRIPTION
## Short roundup of the initial problem
Old versions

## What will change with this Pull Request?
- Use [setup-msbuild v1.3](https://github.com/Cockatrice/Cockatrice/pull/4837) and stay up to date with non-breaking changes and fixes
- Use [run-vcpkg v11.1](https://github.com/Cockatrice/Cockatrice/pull/4836) and stay up to date with non-breaking changes and fixes

  ~~v11.1 with better caching can not be used yet, as this requires a vcpkg bump to at least 2023-03-29 first~~
