### PR TITLE
Pause npm updates for webclient

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,12 +38,12 @@ updates:
     # Limit the amout of open PR's (default = 5, disabled = 0, security updates are not impacted)
     open-pull-requests-limit: 2
 
-  # Enable version updates for npm
-  - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the `webclient` subdirectory
-    directory: "/webclient"
-    # Check the npm registry for updates once a week
-    schedule:
-      interval: "weekly"
-    # Limit the amout of open PR's (default = 5, disabled = 0, security updates are not impacted)
-    open-pull-requests-limit: 5
+ # # Enable version updates for npm
+ # - package-ecosystem: "npm"
+ #   # Look for `package.json` and `lock` files in the `webclient` subdirectory
+ #   directory: "/webclient"
+ #   # Check the npm registry for updates once a week
+ #   schedule:
+ #     interval: "weekly"
+ #   # Limit the amout of open PR's (default = 5, disabled = 0, security updates are not impacted)
+ #   open-pull-requests-limit: 5


### PR DESCRIPTION
## Short roundup of the initial problem
- npm updates prove working and are configured correctly
- Webclient is not actively developed
- Many packages are outdated, hence its spamming the repo

## What will change with this Pull Request?
- Pause updates until development is picked up again
- Critical security updates will still be proposed 
