### PR TITLE
Remove translation string

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -592,7 +592,7 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     networkCacheEdit.setMaximum(NETWORK_CACHE_SIZE_MAX);
     networkCacheEdit.setSingleStep(1);
     networkCacheEdit.setValue(SettingsCache::instance().getNetworkCacheSizeInMB());
-    networkCacheEdit.setSuffix(tr(" MB"));
+    networkCacheEdit.setSuffix(" MB");
 
     auto networkCacheLayout = new QHBoxLayout;
     networkCacheLayout->addStretch();


### PR DESCRIPTION
## Short roundup of the initial problem
"MB" doesn't need to be translated, it also removes potential errors with the space beeing included in the translation string.
The other occurence of MB a few lines above is also not translated.

We are speaking about the MB label visible in the cache size selector box.

## What will change with this Pull Request?
- Remove tr() wrapping