### PR TITLE
Rename "stack until found" feature

### DIFF
--- a/cockatrice/resources/help/search.md
+++ b/cockatrice/resources/help/search.md
@@ -1,6 +1,7 @@
-## Syntax Help
+## Search Syntax Help
 -----
-The search bar recognizes a set of special commands similar to some other card databases. Here is a list with examples. Each entry can be clicked to test the query and has a small explanation. Note that all searches are case insensitive.
+The search bar recognizes a set of special commands similar to some other card databases.<br>
+In this list of examples below, each entry has an explanation and can be clicked to test the query. Note that all searches are case insensitive.
 <dl>
 <dt>Name:</dt>
 <dd>[birds of paradise](#birds of paradise) <small>(Any card name containing the words birds, of, and paradise)</small></dd>

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1313,8 +1313,8 @@ void Player::actMoveTopCardsUntil()
     QString expr = previousMovingCardsUntilExpr;
     for (;;) {
         bool ok;
-        expr = QInputDialog::getText(game, "Put top cards on stack until", "Card name (or search expressions)", {}, expr,
-                                     &ok);
+        expr = QInputDialog::getText(game, "Put top cards on stack until", "Card name (or search expressions)", {},
+                                     expr, &ok);
         if (!ok) {
             return;
         }

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -771,7 +771,7 @@ void Player::retranslateUi()
         aMoveTopCardToExile->setText(tr("Move top card to e&xile"));
         aMoveTopCardsToGraveyard->setText(tr("Move top cards to &graveyard..."));
         aMoveTopCardsToExile->setText(tr("Move top cards to &exile..."));
-        aMoveTopCardsUntil->setText(tr("Take top cards &until..."));
+        aMoveTopCardsUntil->setText(tr("Put top cards on stack &until..."));
 
         aDrawBottomCard->setText(tr("&Draw bottom card"));
         aDrawBottomCards->setText(tr("D&raw bottom cards..."));
@@ -1313,8 +1313,8 @@ void Player::actMoveTopCardsUntil()
     QString expr = previousMovingCardsUntilExpr;
     for (;;) {
         bool ok;
-        expr =
-            QInputDialog::getText(game, "Take top cards until", "Select card (accepts search syntax)", {}, expr, &ok);
+        expr = QInputDialog::getText(game, "Put top cards on stack until", "Card name (or search expressions)", {}, expr,
+                                     &ok);
         if (!ok) {
             return;
         }

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -376,7 +376,7 @@ void TabDeckEditor::createCentralFrame()
 {
     searchEdit = new SearchLineEdit;
     searchEdit->setObjectName("searchEdit");
-    searchEdit->setPlaceholderText(tr("Search by card name"));
+    searchEdit->setPlaceholderText(tr("Search by card name (or search expressions)"));
     searchEdit->setClearButtonEnabled(true);
     searchEdit->addAction(loadColorAdjustedPixmap("theme:icons/search"), QLineEdit::LeadingPosition);
     auto help = searchEdit->addAction(QPixmap("theme:icons/info"), QLineEdit::TrailingPosition);


### PR DESCRIPTION
## Related Ticket(s)
- Related #4648
- Related #4864

## Short roundup of the initial problem
I find the selected "Take top cards until" wording of the recently added "move cards from top of library until" not great.

## What will change with this Pull Request?
- Use "Put top cards on stack until" phrasing, to stay in line with the rest of the options and be more clear of the action:
  <img width="280" alt="image" src="https://github.com/Cockatrice/Cockatrice/assets/9874850/d363dfe7-805e-431b-8cdd-9c08a9d8267e">
- Tried to improve the dialog

<br>

>Which "search syntax" is actually supported in the follow-up dialog?

E.g. `mv<4 -t:land` for cascading