### PR TITLE
Address connect errors in logs

### DIFF
--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -85,7 +85,7 @@ void Servatrice_GameServer::incomingConnection(qintptr socketDescriptor)
     Servatrice_ConnectionPool *pool = findLeastUsedConnectionPool();
 
     auto ssi = new TcpServerSocketInterface(server, pool->getDatabaseInterface());
-    connect(ssi, SIGNAL(incTxBytes), this, SLOT(incTxBytes));
+    connect(ssi, SIGNAL(incTxBytes(qint64)), this, SLOT(incTxBytes(qint64)));
     ssi->moveToThread(pool->thread());
     pool->addClient();
     connect(ssi, SIGNAL(destroyed()), pool, SLOT(removeClient()));
@@ -155,7 +155,7 @@ void Servatrice_WebsocketGameServer::onNewConnection()
     Servatrice_ConnectionPool *pool = findLeastUsedConnectionPool();
 
     auto ssi = new WebsocketServerSocketInterface(server, pool->getDatabaseInterface());
-    connect(ssi, SIGNAL(incTxBytes), this, SLOT(incTxBytes));
+    connect(ssi, SIGNAL(incTxBytes(quint64)), this, SLOT(incTxBytes(quint64)));
     /*
      * Due to a Qt limitation, websockets can't be moved to another thread.
      * This will hopefully change in Qt6 if QtWebSocket will be integrated in QtNetwork

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -1701,9 +1701,14 @@ TcpServerSocketInterface::TcpServerSocketInterface(Servatrice *_server,
     socket = new QTcpSocket(this);
     socket->setSocketOption(QAbstractSocket::LowDelayOption, 1);
     connect(socket, SIGNAL(readyRead()), this, SLOT(readClient()));
+    connect(socket, SIGNAL(disconnected()), this, SLOT(catchSocketDisconnected()));
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    connect(socket, SIGNAL(errorOccurred(QAbstractSocket::SocketError)), this,
+            SLOT(catchSocketError(QAbstractSocket::SocketError)));
+#else
     connect(socket, SIGNAL(error(QAbstractSocket::SocketError)), this,
             SLOT(catchSocketError(QAbstractSocket::SocketError)));
-    connect(socket, SIGNAL(disconnected()), this, SLOT(catchSocketDisconnected()));
+#endif
 }
 
 TcpServerSocketInterface::~TcpServerSocketInterface()


### PR DESCRIPTION
```
4316025:Sun Oct 1 14:33:27 2023 QObject::connect: Parentheses expected, signal WebsocketServerSocketInterface::incTxBytes in /root/github/servatrice/src/servatrice.cpp:158

4316242:Sun Oct 1 14:33:32 2023 QObject::connect: No such signal QTcpSocket::error(QAbstractSocket::SocketError) in /root/github/servatrice/src/serversocketinterface.cpp:1704

4316243:Sun Oct 1 14:33:32 2023 QObject::connect: Parentheses expected, signal TcpServerSocketInterface::incTxBytes in /root/github/servatrice/src/servatrice.cpp:88
```
