### PR TITLE
Remove 32bit leftovers

### DIFF
--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -153,37 +153,22 @@ Function componentsPagePre
 ${If} $PortableMode = 0
     SetShellVarContext all
 
-    # uninstall 32bit version
-    SetRegView 32
+# uninstall 64bit version
+${If} ${NSIS_IS_64_BIT} == 1
+    SetRegView 64
 
     ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice" "UninstallString"
-    StrCmp $R0 "" done32
+    StrCmp $R0 "" done64
 
-    MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "A previous version of Cockatrice must be uninstalled before installing the new one." IDOK uninst32
+    MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "A previous version of Cockatrice must be uninstalled before installing the new one." IDOK uninst64
     Abort
 
-    uninst32:
+    uninst64:
     ClearErrors
     ExecWait "$R0"
 
-	done32:
-
-	# uninstall 64bit version
-	${If} ${NSIS_IS_64_BIT} == 1
-	    SetRegView 64
-
-	    ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice" "UninstallString"
-	    StrCmp $R0 "" done64
-
-	    MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "A previous version of Cockatrice must be uninstalled before installing the new one." IDOK uninst64
-	    Abort
-
-	    uninst64:
-	    ClearErrors
-	    ExecWait "$R0"
-
-		done64:
-	${EndIf}
+	done64:
+${EndIf}
 
 ${Else}
     Abort

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -45,21 +45,13 @@ Page Custom PortableModePageCreate PortableModePageLeave
 
 Function .onInit
 
-${If} ${NSIS_IS_64_BIT} == 1    #NSIS 64bit
+${If} ${NSIS_IS_64_BIT} == 1
     ${IfNot} ${RunningX64}
         MessageBox MB_OK|MB_ICONSTOP "This version of Cockatrice requires a 64-bit Windows system."
         Abort
     ${EndIf}
     StrCpy $NormalDestDir "$ProgramFiles64\Cockatrice"
     SetRegView 64
-${Else}    #NSIS 32bit
-    ${If} ${RunningX64}
-        MessageBox MB_OK|MB_ICONEXCLAMATION \
-        "You are about to install a 32-bit version of Cockatrice on a 64-bit Windows system.$\n\
-        We advise you to use the correct 64-bit installer instead to get around potential issues.$\n$\n\
-        Download from our webpage: https://cockatrice.github.io"
-    ${EndIf}
-    StrCpy $NormalDestDir "$ProgramFiles\Cockatrice"
 ${EndIf}
 
 StrCpy $PortableDestDir "$Desktop\CockatricePortable"

--- a/cockatrice/src/logger.h
+++ b/cockatrice/src/logger.h
@@ -7,9 +7,7 @@
 #include <QTextStream>
 #include <QVector>
 
-#if defined(Q_PROCESSOR_X86_32)
-#define BUILD_ARCHITECTURE "32-bit"
-#elif defined(Q_PROCESSOR_X86_64)
+#if defined(Q_PROCESSOR_X86_64)
 #define BUILD_ARCHITECTURE "64-bit"
 #elif defined(Q_PROCESSOR_ARM)
 #define BUILD_ARCHITECTURE "ARM"

--- a/cockatrice/src/releasechannel.cpp
+++ b/cockatrice/src/releasechannel.cpp
@@ -67,9 +67,6 @@ bool ReleaseChannel::downloadMatchesCurrentOS(const QString &fileName)
     } else {
         return fileName.contains("Win10");
     }
-#else
-    return false;
-#endif
 }
 #else
 bool ReleaseChannel::downloadMatchesCurrentOS(const QString &)

--- a/cockatrice/src/releasechannel.cpp
+++ b/cockatrice/src/releasechannel.cpp
@@ -61,9 +61,6 @@ bool ReleaseChannel::downloadMatchesCurrentOS(const QString &fileName)
 #elif defined(Q_OS_WIN)
 bool ReleaseChannel::downloadMatchesCurrentOS(const QString &fileName)
 {
-#if Q_PROCESSOR_WORDSIZE == 4
-    return fileName.contains("32bit");
-#elif Q_PROCESSOR_WORDSIZE == 8
     const QString &version = QSysInfo::productVersion();
     if (version.startsWith("7") || version.startsWith("8")) {
         return fileName.contains("Win7");


### PR DESCRIPTION
## Related Ticket(s)
- No more Windows 32bit version (#4883)

## Short roundup of the initial problem
Many bits and pieces related to 32bit still.

## What will change with this Pull Request?
- Remove NSIS installer warning introduced in #3331
- Remove 32bit NSIS uninstall
- Remove logging of 32bit installs
- Remove 32bit logic in updater


---

There is more:
- https://github.com/Cockatrice/Cockatrice/blob/master/CMakeLists.txt#L195
- https://github.com/Cockatrice/Cockatrice/blob/master/cmake/FindVCredistRuntime.cmake

Feel free to add commits to this PR.