### PR TITLE
CI: Use concurrency group

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/web-*.yml'
       - '.github/workflows/translations.yml'
 
-# Cancel prior, unfinished workflow runs unless on master test
+# Cancel prior, unfinished workflow runs unless on master
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.ref_name }}"
   cancel-in-progress: ${{ github.ref_name != 'master' }}

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/web-*.yml'
       - '.github/workflows/translations.yml'
 
-# Cancel prior, unfinished workflow runs unless on master
+# Cancel earlier, unfinished runs of this workflow on the same branch (unless on master)
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.ref_name }}"
   cancel-in-progress: ${{ github.ref_name != 'master' }}

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/web-*.yml'
       - '.github/workflows/translations.yml'
 
-# Cancel prior, unfinished workflow runs unless on master
+# Cancel prior, unfinished workflow runs unless on master test
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.ref_name }}"
   cancel-in-progress: ${{ github.ref_name != 'master' }}

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -18,6 +18,11 @@ on:
       - '.github/workflows/web-*.yml'
       - '.github/workflows/translations.yml'
 
+# Cancel prior, unfinished workflow runs unless on master
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref_name }}"
+  cancel-in-progress: ${{ github.ref_name != 'master' }}
+
 jobs:
   configure:
     name: Configure
@@ -26,12 +31,7 @@ jobs:
       tag: ${{steps.configure.outputs.tag}}
       sha: ${{steps.configure.outputs.sha}}
 
-    steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{github.token}} # needs other token https://github.com/styfle/cancel-workflow-action/issues/7
-
+    steps:  
       - name: Configure
         id: configure
         shell: bash


### PR DESCRIPTION
## Related Ticket(s)
- Supersedes #4901

## Short roundup of the initial problem
Action in question is about to get archived as the concurrency feature from GitHub serves the same purpose.

## What will change with this Pull Request?
- Remove https://github.com/styfle/cancel-workflow-action
- Add https://docs.github.com/en/actions/using-jobs/using-concurrency

<br>

```
Canceling since a higher priority waiting request for
'Build Desktop @ 4902/merge' exists
```