### PR TITLE
HotFix: Prevent crashing if a Zone is null with an arrow while a player concedes

### DIFF
--- a/common/server_game.cpp
+++ b/common/server_game.cpp
@@ -571,7 +571,7 @@ void Server_Game::removeArrowsRelatedToPlayer(GameEventStorage &ges, Server_Play
                 toDelete.append(a);
 
             // Don't use else here! It has to happen regardless of whether targetCard == 0.
-            if (a->getStartCard()->getZone()->getPlayer() == player)
+            if (a->getStartCard()->getZone() && a->getStartCard()->getZone()->getPlayer() == player)
                 toDelete.append(a);
         }
         for (int i = 0; i < toDelete.size(); ++i) {


### PR DESCRIPTION
There appears to be a problem where the Zone the original starting card has disappeared before it was supposed to. This adds a (temporary?) check to ensure the zone is valid _before_ we check who owns it.

We should dig deeper, but this hotfix will preserve server uptime.

Backtrace
```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x000055744b4ef8d2 in Server_CardZone::getPlayer (this=0x0) at /root/github/common/server_cardzone.h:88
88              return player;
[Current thread is 1 (Thread 0x7fda5369a5c0 (LWP 1043))]
(gdb) bt
#0  0x000055744b4ef8d2 in Server_CardZone::getPlayer (this=0x0) at /root/github/common/server_cardzone.h:88
#1  0x000055744b4f994e in Server_Game::removeArrowsRelatedToPlayer (this=0x55744dd182a0, ges=..., player=0x557474411e70) at /root/github/common/server_game.cpp:574
#2  0x000055744b50d9b7 in Server_Player::cmdConcede (this=0x557474411e70, ges=...) at /root/github/common/server_player.cpp:860
#3  0x000055744b51521a in Server_Player::processGameCommand (this=0x557474411e70, command=..., rc=..., ges=...) at /root/github/common/server_player.cpp:2169
#4  0x000055744b52eb14 in Server_ProtocolHandler::processGameCommandContainer (this=0x557469330380, cont=..., rc=...) at /root/github/common/server_protocolhandler.cpp:292
#5  0x000055744b52f0d1 in Server_ProtocolHandler::processCommandContainer (this=0x557469330380, cont=...) at /root/github/common/server_protocolhandler.cpp:362
#6  0x000055744b479308 in WebsocketServerSocketInterface::binaryMessageReceived (this=0x557469330380, message=...) at /root/github/servatrice/src/serversocketinterface.cpp:2004
#7  0x000055744b409298 in WebsocketServerSocketInterface::qt_static_metacall (_o=0x557469330380, _c=QMetaObject::InvokeMetaMethod, _id=0, _a=0x7fff865fb720) at /root/github/build/servatrice/servatrice_autogen/UVLADIE3JM/moc_serversocketinterface.cpp:349
#8  0x00007fda53f7b910 in doActivate<false> (sender=0x557463f8c780, signal_index=12, argv=argv@entry=0x7fff865fb720) at /home/qt/work/qt/qtbase/src/corelib/kernel/qobject.cpp:3931
#9  0x00007fda53f73f90 in QMetaObject::activate (sender=<optimized out>, m=m@entry=0x7fda54907940 <QWebSocket::staticMetaObject>, local_signal_index=local_signal_index@entry=9, argv=argv@entry=0x7fff865fb720) at /home/qt/work/qt/qtbase/src/corelib/kernel/qobject.cpp:3979
#10 0x00007fda548e1905 in QWebSocket::binaryMessageReceived (this=<optimized out>, _t1=...) at /home/qt/work/qt/qtwebsockets/src/websockets/WebSockets_autogen/EWIEGA46WW/moc_qwebsocket.cpp:512
#11 0x00007fda53f7b59a in QtPrivate::QSlotObjectBase::call (a=0x7fff865fb800, r=0x557463f8c780, this=<optimized out>) at /home/qt/work/qt/qtbase/src/corelib/kernel/qobjectdefs_impl.h:399
#12 doActivate<false> (sender=0x55745bd7c720, signal_index=9, argv=argv@entry=0x7fff865fb800) at /home/qt/work/qt/qtbase/src/corelib/kernel/qobject.cpp:3919
#13 0x00007fda53f73f90 in QMetaObject::activate (sender=sender@entry=0x55745bd7c720, m=m@entry=0x7fda54907900 <QWebSocketDataProcessor::staticMetaObject>, local_signal_index=local_signal_index@entry=6, argv=argv@entry=0x7fff865fb800)
    at /home/qt/work/qt/qtbase/src/corelib/kernel/qobject.cpp:3979
#14 0x00007fda548e19d5 in QWebSocketDataProcessor::binaryMessageReceived (this=this@entry=0x55745bd7c720, _t1=...) at /home/qt/work/qt/qtwebsockets/src/websockets/WebSockets_autogen/EWIEGA46WW/moc_qwebsocketdataprocessor_p.cpp:285
#15 0x00007fda548f067a in QWebSocketDataProcessor::process (this=0x55745bd7c720, pIoDevice=0x55744dfe39e0) at /home/qt/work/qt/qtwebsockets/src/websockets/qwebsocketdataprocessor.cpp:230
#16 0x00007fda548eb360 in QWebSocketPrivate::processData (this=<optimized out>) at /home/qt/work/qt/qtwebsockets/src/websockets/qwebsocket_p.cpp:1143
#17 QWebSocketPrivate::processData (this=0x55744e11bcc0) at /home/qt/work/qt/qtwebsockets/src/websockets/qwebsocket_p.cpp:1131
#18 0x00007fda53f7b59a in QtPrivate::QSlotObjectBase::call (a=0x7fff865fb940, r=0x557463f8c780, this=<optimized out>) at /home/qt/work/qt/qtbase/src/corelib/kernel/qobjectdefs_impl.h:399
#19 doActivate<false> (sender=0x55744dfe39e0, signal_index=3, argv=0x7fff865fb940, argv@entry=0x0) at /home/qt/work/qt/qtbase/src/corelib/kernel/qobject.cpp:3919
#20 0x00007fda53f73f90 in QMetaObject::activate (sender=sender@entry=0x55744dfe39e0, m=m@entry=0x7fda54443640 <QIODevice::staticMetaObject>, local_signal_index=local_signal_index@entry=0, argv=argv@entry=0x0) at /home/qt/work/qt/qtbase/src/corelib/kernel/qobject.cpp:3979
#21 0x00007fda53ee7740 in QIODevice::readyRead (this=this@entry=0x55744dfe39e0) at /home/qt/work/qt/qtbase/src/corelib/Core_autogen/include/moc_qiodevice.cpp:195
#22 0x00007fda54502d9f in QAbstractSocketPrivate::emitReadyRead (channel=0, this=0x557469804370) at /home/qt/work/qt/qtbase/src/network/socket/qabstractsocket.cpp:1262
#23 QAbstractSocketPrivate::canReadNotification (this=0x557469804370) at /home/qt/work/qt/qtbase/src/network/socket/qabstractsocket.cpp:696
#24 0x00007fda5450a681 in QReadNotifier::event (this=<optimized out>, e=<optimized out>) at /home/qt/work/qt/qtbase/src/network/socket/qnativesocketengine.cpp:1272
#25 0x00007fda53f1bf87 in doNotify (event=0x7fff865fba60, receiver=0x557471652630) at /home/qt/work/qt/qtbase/src/corelib/kernel/qcoreapplication.cpp:1164
#26 QCoreApplication::notify (event=<optimized out>, receiver=<optimized out>, this=<optimized out>) at /home/qt/work/qt/qtbase/src/corelib/kernel/qcoreapplication.cpp:1147
#27 QCoreApplication::notifyInternal2 (receiver=0x557471652630, event=0x7fff865fba60) at /home/qt/work/qt/qtbase/src/corelib/kernel/qcoreapplication.cpp:1068
#28 0x00007fda541bfd24 in socketNotifierSourceDispatch (source=0x55744d1fdee0) at /home/qt/work/qt/qtbase/src/corelib/kernel/qeventdispatcher_glib.cpp:109
#29 0x00007fda5373cd3b in g_main_context_dispatch () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#30 0x00007fda53792258 in ?? () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#31 0x00007fda5373a3e3 in g_main_context_iteration () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#32 0x00007fda541bee6e in QEventDispatcherGlib::processEvents (this=0x55744d1fb1f0, flags=...) at /home/qt/work/qt/qtbase/src/corelib/kernel/qeventdispatcher_glib.cpp:431
#33 0x00007fda53f281eb in QEventLoop::exec (this=this@entry=0x7fff865fbc60, flags=..., flags@entry=...) at /home/qt/work/qt/qtbase/src/corelib/global/qflags.h:70
```