### PR TITLE
CI: Use rolling release

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Render template
         id: template
-        uses: chuhlomin/render-template@v1.7
+        uses: chuhlomin/render-template@v1
         with:
           template: .ci/update_translations_template.md
           vars: |


### PR DESCRIPTION

## Related Ticket(s)
- Supersedes #4900

## Short roundup of the initial problem
Exact versions make dependabot send updates for "dotreleases". 
We use rolling releases everywhere, dependabot will only create pr's for breaking main version bumps with this. 

## What will change with this Pull Request?
- Switch to main version tag
- Automatically use most recent, non-breaking version with all fixes 