### PR TITLE
copy arrows on transform

### DIFF
--- a/common/server_arrow.h
+++ b/common/server_arrow.h
@@ -25,14 +25,16 @@ public:
     {
         return startCard;
     }
-    void setStartCard(Server_Card *startCard_) {
+    void setStartCard(Server_Card *startCard_)
+    {
         startCard = startCard_;
     }
     Server_ArrowTarget *getTargetItem() const
     {
         return targetItem;
     }
-    void setTargetItem(Server_ArrowTarget *targetItem_) {
+    void setTargetItem(Server_ArrowTarget *targetItem_)
+    {
         targetItem = targetItem_;
     }
     const color &getColor() const

--- a/common/server_arrow.h
+++ b/common/server_arrow.h
@@ -25,9 +25,15 @@ public:
     {
         return startCard;
     }
+    void setStartCard(Server_Card *startCard_) {
+        startCard = startCard_;
+    }
     Server_ArrowTarget *getTargetItem() const
     {
         return targetItem;
+    }
+    void setTargetItem(Server_ArrowTarget *targetItem_) {
+        targetItem = targetItem_;
     }
     const color &getColor() const
     {

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -1489,12 +1489,12 @@ Server_Player::cmdCreateToken(const Command_CreateToken &cmd, ResponseContainer 
                         startCard = card;
                     }
                     const auto *targetItem = arrow->getTargetItem();
-                    if (targetItem == targetCard){
+                    if (targetItem == targetCard) {
                         sendGameEvent = true;
                         arrow->setTargetItem(card);
                         targetItem = card;
                     }
-                    if (sendGameEvent){
+                    if (sendGameEvent) {
                         Event_CreateArrow event;
                         ServerInfo_Arrow *arrowInfo = event.mutable_arrow_info();
                         arrowInfo->set_id(arrow->getId());
@@ -1504,7 +1504,7 @@ Server_Player::cmdCreateToken(const Command_CreateToken &cmd, ResponseContainer 
                         const Server_Player *arrowTargetPlayer = qobject_cast<const Server_Player *>(targetItem);
                         if (arrowTargetPlayer != nullptr) {
                             arrowInfo->set_target_player_id(arrowTargetPlayer->getPlayerId());
-                        }else{
+                        } else {
                             const Server_Card *arrowTargetCard = qobject_cast<const Server_Card *>(targetItem);
                             arrowInfo->set_target_player_id(arrowTargetCard->getZone()->getPlayer()->getPlayerId());
                             arrowInfo->set_target_zone(arrowTargetCard->getZone()->getName().toStdString());

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -1475,6 +1475,47 @@ Server_Player::cmdCreateToken(const Command_CreateToken &cmd, ResponseContainer 
                                      attachedCard->getZone()->getPlayer()->getPlayerId());
             }
 
+            // Copy Arrows
+            const QList<Server_Player *> &players = game->getPlayers().values();
+            for (auto player : players) {
+                QMapIterator<int, Server_Arrow *> arrowIterator(player->getArrows());
+                while (arrowIterator.hasNext()) {
+                    Server_Arrow *arrow = arrowIterator.next().value();
+                    bool sendGameEvent = false;
+                    const auto *startCard = arrow->getStartCard();
+                    if (startCard == targetCard) {
+                        sendGameEvent = true;
+                        arrow->setStartCard(card);
+                        startCard = card;
+                    }
+                    const auto *targetItem = arrow->getTargetItem();
+                    if (targetItem == targetCard){
+                        sendGameEvent = true;
+                        arrow->setTargetItem(card);
+                        targetItem = card;
+                    }
+                    if (sendGameEvent){
+                        Event_CreateArrow event;
+                        ServerInfo_Arrow *arrowInfo = event.mutable_arrow_info();
+                        arrowInfo->set_id(arrow->getId());
+                        arrowInfo->set_start_player_id(player->getPlayerId());
+                        arrowInfo->set_start_zone(startCard->getZone()->getName().toStdString());
+                        arrowInfo->set_start_card_id(startCard->getId());
+                        const Server_Player *arrowTargetPlayer = qobject_cast<const Server_Player *>(targetItem);
+                        if (arrowTargetPlayer != nullptr) {
+                            arrowInfo->set_target_player_id(arrowTargetPlayer->getPlayerId());
+                        }else{
+                            const Server_Card *arrowTargetCard = qobject_cast<const Server_Card *>(targetItem);
+                            arrowInfo->set_target_player_id(arrowTargetCard->getZone()->getPlayer()->getPlayerId());
+                            arrowInfo->set_target_zone(arrowTargetCard->getZone()->getName().toStdString());
+                            arrowInfo->set_target_card_id(arrowTargetCard->getId());
+                        }
+                        arrowInfo->mutable_arrow_color()->CopyFrom(arrow->getColor());
+                        ges.enqueueGameEvent(event, player->getPlayerId());
+                    }
+                }
+            }
+
             targetCard->resetState();
             card->setStashedCard(targetCard);
             break;


### PR DESCRIPTION
## Related Ticket(s)
- #4753 

## Short roundup of the initial problem
transforming cards doesn't take into account the arrows pointing at the original card, these are now copied instead of these arrows going to the shadow realm.

## What will change with this Pull Request?
- transforming cards inherit arrows
