### PR TITLE
Handle Qt6.6 Deprecations

### DIFF
--- a/cockatrice/src/chatview/chatview.cpp
+++ b/cockatrice/src/chatview/chatview.cpp
@@ -470,15 +470,23 @@ void ChatView::showSystemPopup(const QString &userName)
 
 QColor ChatView::getCustomMentionColor()
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+    QColor customColor = QColor::fromString("#" + SettingsCache::instance().getChatMentionColor());
+#else
     QColor customColor;
     customColor.setNamedColor("#" + SettingsCache::instance().getChatMentionColor());
+#endif
     return customColor.isValid() ? customColor : DEFAULT_MENTION_COLOR;
 }
 
 QColor ChatView::getCustomHighlightColor()
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+    QColor customColor = QColor::fromString("#" + SettingsCache::instance().getChatMentionColor());
+#else
     QColor customColor;
-    customColor.setNamedColor("#" + SettingsCache::instance().getChatHighlightColor());
+    customColor.setNamedColor("#" + SettingsCache::instance().getChatMentionColor());
+#endif
     return customColor.isValid() ? customColor : DEFAULT_MENTION_COLOR;
 }
 

--- a/cockatrice/src/chatview/chatview.h
+++ b/cockatrice/src/chatview/chatview.h
@@ -65,8 +65,8 @@ private:
     QTextCursor prepareBlock(bool same = false);
     void appendCardTag(QTextCursor &cursor, const QString &cardName);
     void appendUrlTag(QTextCursor &cursor, QString url);
-    QColor getCustomMentionColor();
-    QColor getCustomHighlightColor();
+    static QColor getCustomMentionColor();
+    static QColor getCustomHighlightColor();
     void showSystemPopup(const QString &userName);
     bool isModeratorSendingGlobal(QFlags<ServerInfo_User::UserLevelFlag> userLevelFlag, QString message);
     void checkTag(QTextCursor &cursor, QString &message);

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -937,8 +937,12 @@ MessagesSettingsPage::MessagesSettingsPage()
 
 void MessagesSettingsPage::updateColor(const QString &value)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+    QColor colorToSet = QColor::fromString("#" + value);
+#else
     QColor colorToSet;
     colorToSet.setNamedColor("#" + value);
+#endif
     if (colorToSet.isValid()) {
         SettingsCache::instance().setChatMentionColor(value);
         updateMentionPreview();
@@ -947,8 +951,12 @@ void MessagesSettingsPage::updateColor(const QString &value)
 
 void MessagesSettingsPage::updateHighlightColor(const QString &value)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+    QColor colorToSet = QColor::fromString("#" + value);
+#else
     QColor colorToSet;
     colorToSet.setNamedColor("#" + value);
+#endif
     if (colorToSet.isValid()) {
         SettingsCache::instance().setChatHighlightColor(value);
         updateHighlightPreview();

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -106,7 +106,8 @@ bool Servatrice_DatabaseInterface::checkSql()
     if (!sqlDatabase.isValid())
         return false;
 
-    if (!sqlDatabase.exec("select 1").isActive())
+    auto query = QSqlQuery(sqlDatabase);
+    if (query.exec("select 1") && query.isActive())
         return openDatabase();
     return true;
 }


### PR DESCRIPTION
- Use QSqlQuery.exec instead of QDatabase.exec
- Use QColor::fromString instead of QColor.setNamedColor