### PR TITLE
CI: Improve Transifex pull action

### DIFF
--- a/.ci/update_translation_source_strings_template.md
+++ b/.ci/update_translation_source_strings_template.md
@@ -7,7 +7,8 @@ Updated source strings for translations:
 Last changes are based on commit {{ .commit }}.
 
 ---
-*This PR is automatically generated and updated by the workflow at `.github/workflows/translations-push.yml`.*<br>
+*This PR is automatically generated and updated by the workflow at `.github/workflows/translations-push.yml`. Review [action runs][2].*<br>
 *After merging, all changes to the source language are available for translation at [Transifex][1] shortly.*
 
 [1]: https://app.transifex.com/cockatrice/cockatrice/
+[2]: https://github.com/Cockatrice/Cockatrice/actions/workflows/translations-push.yml?query=branch%3Amaster

--- a/.github/workflows/translations-pull.yml
+++ b/.github/workflows/translations-pull.yml
@@ -27,7 +27,7 @@ jobs:
           # used config file: https://github.com/Cockatrice/Cockatrice/blob/master/.tx/config
           # https://github.com/transifex/cli#pulling-files-from-transifex
           token: ${{ secrets.TX_TOKEN }}
-          args: pull --all
+          args: pull --force --all
 
       - name: Create pull request
         if: github.event_name != 'pull_request'
@@ -43,17 +43,16 @@ jobs:
           author: github-actions <github-actions@github.com>
           branch: ci-update_translations
           delete-branch: true
-          title: '[Translations] Update translations'
+          title: 'Update translations'
           body: |
-            `pull -all` strings from [Transifex][1]
-            
-            <br>
+            Pulled all translated strings from [Transifex][1].
             
             ---
-            *This PR is automatically generated and updated by the workflow at `.github/workflows/translations-pull.yml`.*<br>
+            *This PR is automatically generated and updated by the workflow at `.github/workflows/translations-pull.yml`. Review [action runs][2].*<br>
             *After merging, all new languages and translations are available in the next build.*
             
             [1]: https://app.transifex.com/cockatrice/cockatrice/
+            [2]: https://github.com/Cockatrice/Cockatrice/actions/workflows/translations-pull.yml?query=branch%3Amaster
           labels: |
             CI
             Translation

--- a/.github/workflows/translations-push.yml
+++ b/.github/workflows/translations-push.yml
@@ -64,9 +64,9 @@ jobs:
           commit-message: Update translation source strings
           # author is the owner of the commit
           author: github-actions <github-actions@github.com>
-          branch: ci-update_translation_source_strings
+          branch: ci-update_translation_source
           delete-branch: true
-          title: '[Translations] Update source strings'
+          title: 'Update source strings'
           body: ${{ steps.template.outputs.result }}
           labels: |
             CI


### PR DESCRIPTION
## Related Ticket(s)
- Enhancements to #4911

## Short roundup of the initial problem
Without using `--use-git-timestamps` or `--force`, many languages are skipped because the timestamp of the freshly cloned repo is newer than the last change at Transifex.

## What will change with this Pull Request?
- Run `tx pull --force --all`
- Some wording tweaks and links
