### PR TITLE
Include missing strings for translation

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -1281,8 +1281,8 @@ void ShortcutSettingsPage::retranslateUi()
     currentShortcutLabel->setText(tr("Shortcut:"));
     editTextBox->retranslateUi();
     faqLabel->setText(QString("<a href='%1'>%2</a>").arg(WIKI_CUSTOM_SHORTCUTS).arg(tr("How to set custom shortcuts")));
-    btnResetAll->setText("Restore all default shortcuts");
-    btnClearAll->setText("Clear all shortcuts");
+    btnResetAll->setText(tr("Restore all default shortcuts"));
+    btnClearAll->setText(tr("Clear all shortcuts"));
 }
 
 DlgSettings::DlgSettings(QWidget *parent) : QDialog(parent)


### PR DESCRIPTION
## Short roundup of the initial problem
Those strings were not recognized and extracted as source strings for translations due to missing tr() wrappings. Transifex could never offer them to translators.

## What will change with this Pull Request?
- Add tr()
