### PR TITLE
make cards on the stack slightly overlap to stress order

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -299,6 +299,7 @@ void GeneralSettingsPage::retranslateUi()
 
 AppearanceSettingsPage::AppearanceSettingsPage()
 {
+    SettingsCache &settings = SettingsCache::instance();
     QString themeName = SettingsCache::instance().getThemeName();
 
     QStringList themeDirs = themeManager->getAvailableThemes().keys();
@@ -319,27 +320,31 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     themeGroupBox = new QGroupBox;
     themeGroupBox->setLayout(themeGrid);
 
-    displayCardNamesCheckBox.setChecked(SettingsCache::instance().getDisplayCardNames());
-    connect(&displayCardNamesCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
-            SLOT(setDisplayCardNames(int)));
+    displayCardNamesCheckBox.setChecked(settings.getDisplayCardNames());
+    connect(&displayCardNamesCheckBox, SIGNAL(stateChanged(int)), &settings, SLOT(setDisplayCardNames(int)));
 
-    cardScalingCheckBox.setChecked(SettingsCache::instance().getScaleCards());
-    connect(&cardScalingCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(), SLOT(setCardScaling(int)));
+    cardScalingCheckBox.setChecked(settings.getScaleCards());
+    connect(&cardScalingCheckBox, SIGNAL(stateChanged(int)), &settings, SLOT(setCardScaling(int)));
+
+    verticalCardOverlapPercentBox.setValue(settings.getStackCardOverlapPercent());
+    verticalCardOverlapPercentBox.setRange(0, 80);
+    connect(&verticalCardOverlapPercentBox, SIGNAL(valueChanged(int)), &settings,
+            SLOT(setStackCardOverlapPercent(int)));
 
     auto *cardsGrid = new QGridLayout;
     cardsGrid->addWidget(&displayCardNamesCheckBox, 0, 0, 1, 2);
     cardsGrid->addWidget(&cardScalingCheckBox, 1, 0, 1, 2);
+    cardsGrid->addWidget(&verticalCardOverlapPercentLabel, 2, 0, 1, 1);
+    cardsGrid->addWidget(&verticalCardOverlapPercentBox, 2, 1, 1, 1);
 
     cardsGroupBox = new QGroupBox;
     cardsGroupBox->setLayout(cardsGrid);
 
-    horizontalHandCheckBox.setChecked(SettingsCache::instance().getHorizontalHand());
-    connect(&horizontalHandCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
-            SLOT(setHorizontalHand(int)));
+    horizontalHandCheckBox.setChecked(settings.getHorizontalHand());
+    connect(&horizontalHandCheckBox, SIGNAL(stateChanged(int)), &settings, SLOT(setHorizontalHand(int)));
 
-    leftJustifiedHandCheckBox.setChecked(SettingsCache::instance().getLeftJustified());
-    connect(&leftJustifiedHandCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
-            SLOT(setLeftJustified(int)));
+    leftJustifiedHandCheckBox.setChecked(settings.getLeftJustified());
+    connect(&leftJustifiedHandCheckBox, SIGNAL(stateChanged(int)), &settings, SLOT(setLeftJustified(int)));
 
     auto *handGrid = new QGridLayout;
     handGrid->addWidget(&horizontalHandCheckBox, 0, 0, 1, 2);
@@ -348,18 +353,18 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     handGroupBox = new QGroupBox;
     handGroupBox->setLayout(handGrid);
 
-    invertVerticalCoordinateCheckBox.setChecked(SettingsCache::instance().getInvertVerticalCoordinate());
-    connect(&invertVerticalCoordinateCheckBox, SIGNAL(stateChanged(int)), &SettingsCache::instance(),
+    invertVerticalCoordinateCheckBox.setChecked(settings.getInvertVerticalCoordinate());
+    connect(&invertVerticalCoordinateCheckBox, SIGNAL(stateChanged(int)), &settings,
             SLOT(setInvertVerticalCoordinate(int)));
 
     minPlayersForMultiColumnLayoutEdit.setMinimum(2);
-    minPlayersForMultiColumnLayoutEdit.setValue(SettingsCache::instance().getMinPlayersForMultiColumnLayout());
-    connect(&minPlayersForMultiColumnLayoutEdit, SIGNAL(valueChanged(int)), &SettingsCache::instance(),
+    minPlayersForMultiColumnLayoutEdit.setValue(settings.getMinPlayersForMultiColumnLayout());
+    connect(&minPlayersForMultiColumnLayoutEdit, SIGNAL(valueChanged(int)), &settings,
             SLOT(setMinPlayersForMultiColumnLayout(int)));
     minPlayersForMultiColumnLayoutLabel.setBuddy(&minPlayersForMultiColumnLayoutEdit);
 
-    connect(&maxFontSizeForCardsEdit, SIGNAL(valueChanged(int)), &SettingsCache::instance(), SLOT(setMaxFontSize(int)));
-    maxFontSizeForCardsEdit.setValue(SettingsCache::instance().getMaxFontSize());
+    connect(&maxFontSizeForCardsEdit, SIGNAL(valueChanged(int)), &settings, SLOT(setMaxFontSize(int)));
+    maxFontSizeForCardsEdit.setValue(settings.getMaxFontSize());
     maxFontSizeForCardsLabel.setBuddy(&maxFontSizeForCardsEdit);
     maxFontSizeForCardsEdit.setMinimum(9);
     maxFontSizeForCardsEdit.setMaximum(100);
@@ -413,6 +418,7 @@ void AppearanceSettingsPage::retranslateUi()
     cardsGroupBox->setTitle(tr("Card rendering"));
     displayCardNamesCheckBox.setText(tr("Display card names on cards having a picture"));
     cardScalingCheckBox.setText(tr("Scale cards on mouse over"));
+    verticalCardOverlapPercentLabel.setText(tr("Minimum overlap percentage of cards in vertical hand and stack"));
 
     handGroupBox->setTitle(tr("Hand layout"));
     horizontalHandCheckBox.setText(tr("Display hand horizontally (wastes space)"));

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -418,7 +418,8 @@ void AppearanceSettingsPage::retranslateUi()
     cardsGroupBox->setTitle(tr("Card rendering"));
     displayCardNamesCheckBox.setText(tr("Display card names on cards having a picture"));
     cardScalingCheckBox.setText(tr("Scale cards on mouse over"));
-    verticalCardOverlapPercentLabel.setText(tr("Minimum overlap percentage of cards on the stack and in vertical hand"));
+    verticalCardOverlapPercentLabel.setText(
+        tr("Minimum overlap percentage of cards on the stack and in vertical hand"));
 
     handGroupBox->setTitle(tr("Hand layout"));
     horizontalHandCheckBox.setText(tr("Display hand horizontally (wastes space)"));

--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -418,7 +418,7 @@ void AppearanceSettingsPage::retranslateUi()
     cardsGroupBox->setTitle(tr("Card rendering"));
     displayCardNamesCheckBox.setText(tr("Display card names on cards having a picture"));
     cardScalingCheckBox.setText(tr("Scale cards on mouse over"));
-    verticalCardOverlapPercentLabel.setText(tr("Minimum overlap percentage of cards in vertical hand and stack"));
+    verticalCardOverlapPercentLabel.setText(tr("Minimum overlap percentage of cards on the stack and in vertical hand"));
 
     handGroupBox->setTitle(tr("Hand layout"));
     horizontalHandCheckBox.setText(tr("Display hand horizontally (wastes space)"));

--- a/cockatrice/src/dlg_settings.h
+++ b/cockatrice/src/dlg_settings.h
@@ -90,6 +90,8 @@ private:
     QLabel maxFontSizeForCardsLabel;
     QCheckBox displayCardNamesCheckBox;
     QCheckBox cardScalingCheckBox;
+    QLabel verticalCardOverlapPercentLabel;
+    QSpinBox verticalCardOverlapPercentBox;
     QCheckBox horizontalHandCheckBox;
     QCheckBox leftJustifiedHandCheckBox;
     QCheckBox invertVerticalCoordinateCheckBox;

--- a/cockatrice/src/handzone.cpp
+++ b/cockatrice/src/handzone.cpp
@@ -114,23 +114,18 @@ void HandZone::reorganizeCards()
             }
         } else {
             qreal totalWidth = boundingRect().width();
-            qreal totalHeight = boundingRect().height();
             qreal cardWidth = cards.at(0)->boundingRect().width();
-            qreal cardHeight = cards.at(0)->boundingRect().height();
             qreal xspace = 5;
             qreal x1 = xspace;
             qreal x2 = totalWidth - xspace - cardWidth;
 
             for (int i = 0; i < cardCount; i++) {
-                CardItem *c = cards.at(i);
+                CardItem *card = cards.at(i);
                 qreal x = (i % 2) ? x2 : x1;
-                // If the total height of the cards is smaller than the available height,
-                // the cards do not need to overlap and are displayed in the center of the area.
-                if (cardHeight * cardCount > totalHeight)
-                    c->setPos(x, ((qreal)i) * (totalHeight - cardHeight) / (cardCount - 1));
-                else
-                    c->setPos(x, ((qreal)i) * cardHeight + (totalHeight - cardCount * cardHeight) / 2);
-                c->setRealZValue(i);
+                qreal y =
+                    divideCardSpaceInZone(i, cardCount, boundingRect().height(), cards.at(0)->boundingRect().height());
+                card->setPos(x, y);
+                card->setRealZValue(i);
             }
         }
     }

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -2567,7 +2567,7 @@ void Player::playCard(CardItem *card, bool faceDown, bool tapped)
     } else if (!faceDown &&
                ((!playToStack && tableRow == 3) || ((playToStack && tableRow != 0) && currentZone != "stack"))) {
         cmd.set_target_zone("stack");
-        cmd.set_x(0);
+        cmd.set_x(-1);
         cmd.set_y(0);
     } else {
         tableRow = faceDown ? 2 : info->getTableRow();

--- a/cockatrice/src/selectzone.cpp
+++ b/cockatrice/src/selectzone.cpp
@@ -2,9 +2,35 @@
 
 #include "carditem.h"
 #include "gamescene.h"
+#include "settingscache.h"
 
 #include <QDebug>
 #include <QGraphicsSceneMouseEvent>
+
+qreal divideCardSpaceInZone(qreal index, int cardCount, qreal totalHeight, qreal cardHeight, bool reverse)
+{
+    qreal cardMinOverlap = cardHeight * SettingsCache::instance().getStackCardOverlapPercent() / 100;
+    qreal desiredHeight = cardHeight * cardCount - cardMinOverlap * (cardCount - 1);
+    qreal y;
+    if (desiredHeight > totalHeight) {
+        if (reverse) {
+            y = index / ((totalHeight - cardHeight) / (cardCount - 1));
+        } else {
+            y = index * (totalHeight - cardHeight) / (cardCount - 1);
+        }
+    } else {
+        qreal start = (totalHeight - desiredHeight) / 2;
+        if (reverse) {
+            if (index <= start) {
+                return 0;
+            }
+            y = (index - start) / (cardHeight - cardMinOverlap);
+        } else {
+            y = index * (cardHeight - cardMinOverlap) + start;
+        }
+    }
+    return y;
+}
 
 SelectZone::SelectZone(Player *_player,
                        const QString &_name,

--- a/cockatrice/src/selectzone.h
+++ b/cockatrice/src/selectzone.h
@@ -24,4 +24,6 @@ public:
                bool isView = false);
 };
 
+qreal divideCardSpaceInZone(qreal index, int cardCount, qreal totalHeight, qreal cardHeight, bool reverse = false);
+
 #endif

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -262,6 +262,7 @@ SettingsCache::SettingsCache()
     ignoreUnregisteredUserMessages = settings->value("chat/ignore_unregistered_messages", false).toBool();
 
     scaleCards = settings->value("cards/scaleCards", true).toBool();
+    verticalCardOverlapPercent = settings->value("cards/verticalCardOverlapPercent", 33).toInt();
     showMessagePopups = settings->value("chat/showmessagepopups", true).toBool();
     showMentionPopups = settings->value("chat/showmentionpopups", true).toBool();
     roomHistory = settings->value("chat/roomhistory", true).toBool();
@@ -330,6 +331,12 @@ void SettingsCache::setCardScaling(const int _scaleCards)
 {
     scaleCards = (bool)_scaleCards;
     settings->setValue("cards/scaleCards", scaleCards);
+}
+
+void SettingsCache::setStackCardOverlapPercent(const int _verticalCardOverlapPercent)
+{
+    verticalCardOverlapPercent = _verticalCardOverlapPercent;
+    settings->setValue("cards/verticalCardOverlapPercent", verticalCardOverlapPercent);
 }
 
 void SettingsCache::setShowMessagePopups(const int _showMessagePopups)

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -115,6 +115,7 @@ private:
     int pixmapCacheSize;
     int networkCacheSize;
     bool scaleCards;
+    int verticalCardOverlapPercent;
     bool showMessagePopups;
     bool showMentionPopups;
     bool roomHistory;
@@ -352,6 +353,10 @@ public:
     {
         return scaleCards;
     }
+    int getStackCardOverlapPercent() const
+    {
+        return verticalCardOverlapPercent;
+    }
     bool getShowMessagePopup() const
     {
         return showMessagePopups;
@@ -541,6 +546,7 @@ public slots:
     void setPixmapCacheSize(const int _pixmapCacheSize);
     void setNetworkCacheSizeInMB(const int _networkCacheSize);
     void setCardScaling(const int _scaleCards);
+    void setStackCardOverlapPercent(const int _verticalCardOverlapPercent);
     void setShowMessagePopups(const int _showMessagePopups);
     void setShowMentionPopups(const int _showMentionPopups);
     void setRoomHistory(const int _roomHistory);

--- a/cockatrice/src/stackzone.h
+++ b/cockatrice/src/stackzone.h
@@ -8,8 +8,6 @@ class StackZone : public SelectZone
     Q_OBJECT
 private:
     qreal zoneHeight;
-    int cardCount;
-    qreal cardLocationByIndex(qreal index, bool reverse = false);
 private slots:
     void updateBg();
 

--- a/cockatrice/src/stackzone.h
+++ b/cockatrice/src/stackzone.h
@@ -8,6 +8,8 @@ class StackZone : public SelectZone
     Q_OBJECT
 private:
     qreal zoneHeight;
+    int cardCount;
+    qreal cardLocationByIndex(qreal index, bool reverse = false);
 private slots:
     void updateBg();
 

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -67,6 +67,9 @@ void SettingsCache::setLeftJustified(const int /* _leftJustified */)
 void SettingsCache::setCardScaling(const int /* _scaleCards */)
 {
 }
+void SettingsCache::setStackCardOverlapPercent(const int /* _verticalCardOverlapPercent */)
+{
+}
 void SettingsCache::setShowMessagePopups(const int /* _showMessagePopups */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -71,6 +71,9 @@ void SettingsCache::setLeftJustified(const int /* _leftJustified */)
 void SettingsCache::setCardScaling(const int /* _scaleCards */)
 {
 }
+void SettingsCache::setStackCardOverlapPercent(const int /* _verticalCardOverlapPercent */)
+{
+}
 void SettingsCache::setShowMessagePopups(const int /* _showMessagePopups */)
 {
 }


### PR DESCRIPTION

## Related Ticket(s)
- Fixes #4872

## Short roundup of the initial problem
the order of cards on the stack was difficult to understand

## What will change with this Pull Request?
- dragging cards to the stack now places the card at the location it is dropped
- cards on the stack will overlap by 1/3rd always

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![image](https://github.com/Cockatrice/Cockatrice/assets/36401181/f2ec1d06-4cb0-45f6-aeac-ba7b324ad93a)
