### PR TITLE
add action for installing custom image to card database

### DIFF
--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -182,12 +182,9 @@ void PictureLoaderWorker::processLoadQueue()
     }
 }
 
-bool PictureLoaderWorker::cardImageExistsOnDisk(QString &setName, QString &correctedCardname)
+QList<QString> findCustomPics(QString &customPicsPath, QString &correctedCardname)
 {
-    QImage image;
-    QImageReader imgReader;
-    imgReader.setDecideFormatFromContent(true);
-    QList<QString> picsPaths = QList<QString>();
+    QList<QString> picsPaths{};
     QDirIterator it(customPicsPath, QDirIterator::Subdirectories);
 
     // Recursively check all subdirectories of the CUSTOM folder
@@ -201,6 +198,15 @@ bool PictureLoaderWorker::cardImageExistsOnDisk(QString &setName, QString &corre
             picsPaths << thisPath; // Card found in the CUSTOM directory, somewhere
         }
     }
+    return picsPaths;
+}
+
+bool PictureLoaderWorker::cardImageExistsOnDisk(QString &setName, QString &correctedCardname)
+{
+    QImage image;
+    QImageReader imgReader;
+    imgReader.setDecideFormatFromContent(true);
+    QList<QString> picsPaths = findCustomPics(customPicsPath, correctedCardname);
 
     if (!setName.isEmpty()) {
         picsPaths << picsPath + "/" + setName + "/" + correctedCardname
@@ -625,6 +631,50 @@ void PictureLoader::imageLoaded(CardInfoPtr card, const QImage &image)
     }
 
     card->emitPixmapUpdated();
+}
+
+void PictureLoader::setCustomImage(CardInfoPtr card, const QString &location)
+{
+    if (card == nullptr) {
+        return;
+    }
+    QString correctedCardname = card->getCorrectedName();
+    QImage image;
+    QImageReader imgReader;
+    imgReader.setDecideFormatFromContent(true);
+
+    imgReader.setFileName(location);
+    auto format = imgReader.format();
+    if (!imgReader.read(&image)) {
+        qDebug().nospace() << "PictureLoader: [card: " << correctedCardname
+                           << "]: Setting custom image failed because the image at " << location << " can't be read.";
+        return;
+    }
+
+    QString customPicsPath = SettingsCache::instance().getCustomPicsPath();
+    auto paths = findCustomPics(customPicsPath, correctedCardname);
+    QString newPath;
+    if (!paths.isEmpty()) {
+        newPath = paths[0];
+        for (auto &path : paths) {
+            QFile file(path);
+            file.remove();
+        }
+    } else {
+        QString newPathDir = customPicsPath + "/" + correctedCardname[0].toLower();
+        newPath = newPathDir + "/" + correctedCardname + "." + format;
+        QDir().mkdir(newPathDir);
+    }
+
+    if (QFile::copy(location, newPath)) {
+        qDebug().nospace() << "PictureLoader: [card: " << correctedCardname << "]: Installed custom image to "
+                           << newPath << ".";
+        getInstance().imageLoaded(card, image);
+    } else {
+        qDebug().nospace() << "PictureLoader: [card: " << correctedCardname
+                           << "]: Setting custom image failed because the file at " << location
+                           << " couldn't be copied to " << newPath << ".";
+    }
 }
 
 void PictureLoader::clearPixmapCache(CardInfoPtr card)

--- a/cockatrice/src/pictureloader.h
+++ b/cockatrice/src/pictureloader.h
@@ -74,6 +74,7 @@ public:
 
     void enqueueImageLoad(CardInfoPtr card);
     void clearNetworkCache();
+    void setCustomImage(CardInfoPtr card, const QString &location);
 
 private:
     static QStringList md5Blacklist;
@@ -127,6 +128,7 @@ private:
 public:
     static void getPixmap(QPixmap &pixmap, CardInfoPtr card, QSize size);
     static void getCardBackPixmap(QPixmap &pixmap, QSize size);
+    static void setCustomImage(CardInfoPtr card, const QString &location);
     static void clearPixmapCache(CardInfoPtr card);
     static void clearPixmapCache();
     static void cacheCardPixmaps(QList<CardInfoPtr> cards);

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -465,11 +465,12 @@ void TabDeckEditor::databaseCustomMenu(QPoint point)
     const CardInfoPtr info = currentCardInfo();
 
     // add to deck and sideboard options
-    QAction *addToDeck, *addToSideboard;
-    addToDeck = menu.addAction(tr("Add to Deck"));
-    addToSideboard = menu.addAction(tr("Add to Sideboard"));
+    QAction *addToDeck = menu.addAction(tr("Add to Deck"));
+    QAction *addToSideboard = menu.addAction(tr("Add to Sideboard"));
+    QAction *setCustomImage = menu.addAction(tr("Set custom image"));
     connect(addToDeck, SIGNAL(triggered()), this, SLOT(actAddCard()));
     connect(addToSideboard, SIGNAL(triggered()), this, SLOT(actAddCardToSideboard()));
+    connect(setCustomImage, SIGNAL(triggered()), this, SLOT(actSetCustomImage()));
 
     // filling out the related cards submenu
     auto *relatedMenu = new QMenu(tr("Show Related cards"));
@@ -1005,6 +1006,20 @@ void TabDeckEditor::actSwapCard()
 
     setModified(true);
     setSaveStatus(true);
+}
+
+void TabDeckEditor::actSetCustomImage()
+{
+    const CardInfoPtr info = currentCardInfo();
+    if (info == nullptr) {
+        return;
+    }
+
+    QString location = QFileDialog::getOpenFileName(this, tr("Select image"), "", "Images (*.png *.jpg)");
+    if (location.isNull()) {
+        return;
+    }
+    PictureLoader::setCustomImage(info, location);
 }
 
 void TabDeckEditor::actAddCard()

--- a/cockatrice/src/tab_deck_editor.h
+++ b/cockatrice/src/tab_deck_editor.h
@@ -72,6 +72,7 @@ private slots:
     void actClearFilterAll();
     void actClearFilterOne();
 
+    void actSetCustomImage();
     void actSwapCard();
     void actAddCard();
     void actAddCardToSideboard();


### PR DESCRIPTION
https://github.com/Cockatrice/Cockatrice/pull/4756#issuecomment-1750761824 mentions difficulty when setting custom card names, this pr eliminates the need to set the card name by adding an action to place a picture in the custom art folder for you.