### PR TITLE
Allow 2 <cards> elements in xml files

### DIFF
--- a/doc/carddatabase_v4/cards.xsd
+++ b/doc/carddatabase_v4/cards.xsd
@@ -75,7 +75,7 @@
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>
-                <xs:element name="cards" minOccurs="0">
+                <xs:element name="cards" minOccurs="0" maxOccurs="2">
                     <xs:complexType>
                         <xs:sequence>
                             <xs:element type="cardType" name="card" maxOccurs="unbounded" minOccurs="0" />


### PR DESCRIPTION
## Related Ticket(s)
- https://github.com/Cockatrice/Magic-Token/pull/225

## Short roundup of the initial problem

The linked PR changed the tokens.xml file by adding a second `<cards>` element to accommodate the addition of Theros creature tokens to the xml. Under the current validation schema, attempting to validate tokens.xml with xmllint gives the impression that there are too many `<cards>` elements and that the xml is invalid. 

## What will change with this Pull Request?
- Changes the validation schema to allow for up to 2 `<cards>` elements in the xml (up from the default value of 1). Using the new rules, both tokens.xml and cards.xml are viewed as perfectly valid by xmllint.
