### PR TITLE
Update default theme name

### DIFF
--- a/cockatrice/src/thememanager.cpp
+++ b/cockatrice/src/thememanager.cpp
@@ -9,7 +9,7 @@
 #include <QPixmapCache>
 #include <QStandardPaths>
 
-#define NONE_THEME_NAME "None "
+#define NONE_THEME_NAME "Standard"
 #define STYLE_CSS_NAME "style.css"
 #define HANDZONE_BG_NAME "handzone"
 #define PLAYERZONE_BG_NAME "playerzone"

--- a/cockatrice/src/thememanager.cpp
+++ b/cockatrice/src/thememanager.cpp
@@ -9,7 +9,7 @@
 #include <QPixmapCache>
 #include <QStandardPaths>
 
-#define NONE_THEME_NAME "Standard"
+#define NONE_THEME_NAME "Default"
 #define STYLE_CSS_NAME "style.css"
 #define HANDZONE_BG_NAME "handzone"
 #define PLAYERZONE_BG_NAME "playerzone"


### PR DESCRIPTION
## Short roundup of the initial problem
If no theme is selected, the default theme is used.
Cockatrice labels the default theme as `None`, which is a bit misleading. There is a standard theme used, not none. :)
<img width="561" alt="image" src="https://github.com/Cockatrice/Cockatrice/assets/9874850/16c44eec-52c5-4730-9686-6fa340746796">


## What will change with this Pull Request?
- Name standard visual theme `Default`, same as basic sound theme
