### PR TITLE
put cards on top in a random order

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -855,7 +855,7 @@ void Player::retranslateUi()
         aSetCounter[i]->setText(tr("&Set counters (%1)...").arg(counterColors[i]));
     }
 
-    aMoveToTopLibrary->setText(tr("&Top of library"));
+    aMoveToTopLibrary->setText(tr("&Top of library in random order"));
     aMoveToXfromTopOfLibrary->setText(tr("X cards from the top of library..."));
     aMoveToBottomLibrary->setText(tr("&Bottom of library in random order"));
     aMoveToHand->setText(tr("&Hand"));
@@ -2953,6 +2953,16 @@ void Player::cardMenuAction()
                 cmd->set_target_zone("deck");
                 cmd->set_x(0);
                 cmd->set_y(0);
+
+                if (idList.card_size() > 1) {
+                    auto *scmd = new Command_Shuffle;
+                    scmd->set_zone_name("deck");
+                    scmd->set_start(0);
+                    scmd->set_end(idList.card_size());
+                    // Server process events backwards, so...
+                    commandList.append(scmd);
+                }
+
                 commandList.append(cmd);
                 break;
             }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes https://github.com/Cockatrice/Cockatrice/issues/4938

## Short roundup of the initial problem
putting multiple selected cards on top of the deck always had an unclear order to them, it is now always random. this is similar to #3549 which did the same for moving to the bottom of the deck. to guarantee order players are expected to drag cards one by one to the top of the deck.

## What will change with this Pull Request?
- the top of the deck is shuffled after moving multiple cards to it
- the action to do so now says it will be random