### PR TITLE
Support fractional scaling when scaling card images

### DIFF
--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -621,7 +621,7 @@ void PictureLoader::getPixmap(QPixmap &pixmap, CardInfoPtr card, QSize size)
     QPixmap bigPixmap;
     if (QPixmapCache::find(key, &bigPixmap)) {
         QScreen *screen = qApp->primaryScreen();
-        int dpr = screen->devicePixelRatio();
+        qreal dpr = screen->devicePixelRatio();
         pixmap = bigPixmap.scaled(size * dpr, Qt::KeepAspectRatio, Qt::SmoothTransformation);
         pixmap.setDevicePixelRatio(dpr);
         QPixmapCache::insert(sizeKey, pixmap);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4880

## Short roundup of the initial problem

Card pictures are blurry when using fractional scaling (i.e. non-integer scales, such as 125% or 150% which translates to 1.25 and 1.50 respectively).

## What will change with this Pull Request?

Card pictures are no longer blurry with fractional scaling.

## Screenshots

Screenshots taken with 1.5 scaling.

Current master:
![Before](https://github.com/Cockatrice/Cockatrice/assets/146210/65303f7f-d7c3-4c8a-adec-2ebfcc51e6a7)

This PR:
![After](https://github.com/Cockatrice/Cockatrice/assets/146210/b38fbfbb-f22c-494e-b252-91cb16885bd0)
