### PR TITLE
Improve drag & drop behavior

### DIFF
--- a/cockatrice/src/abstractcarddragitem.cpp
+++ b/cockatrice/src/abstractcarddragitem.cpp
@@ -20,15 +20,8 @@ AbstractCardDragItem::AbstractCardDragItem(AbstractCardItem *_item,
         parentDrag->addChildDrag(this);
         setZValue(2000000007 + hotSpot.x() * 1000000 + hotSpot.y() * 1000 + 1000);
     } else {
-        if ((hotSpot.x() < 0) || (hotSpot.y() < 0)) {
-            qDebug() << "CardDragItem: coordinate overflow: x =" << hotSpot.x() << ", y =" << hotSpot.y();
-            hotSpot = QPointF{qMax(hotSpot.x(), 0.0), qMax(hotSpot.y(), 0.0)};
-        }
-        if ((hotSpot.x() > CARD_WIDTH) || (hotSpot.y() > CARD_HEIGHT)) {
-            qDebug() << "CardDragItem: coordinate overflow: x =" << hotSpot.x() << ", y =" << hotSpot.y();
-            hotSpot = QPointF{qMin(hotSpot.x(), static_cast<qreal>(CARD_WIDTH)),
-                              qMin(hotSpot.y(), static_cast<qreal>(CARD_HEIGHT))};
-        }
+        hotSpot = QPointF{qBound(0.0, hotSpot.x(), static_cast<qreal>(CARD_WIDTH - 1)),
+                          qBound(0.0, hotSpot.y(), static_cast<qreal>(CARD_HEIGHT - 1))};
         setCursor(Qt::ClosedHandCursor);
         setZValue(2000000007);
     }

--- a/cockatrice/src/abstractcarddragitem.cpp
+++ b/cockatrice/src/abstractcarddragitem.cpp
@@ -22,10 +22,12 @@ AbstractCardDragItem::AbstractCardDragItem(AbstractCardItem *_item,
     } else {
         if ((hotSpot.x() < 0) || (hotSpot.y() < 0)) {
             qDebug() << "CardDragItem: coordinate overflow: x =" << hotSpot.x() << ", y =" << hotSpot.y();
-            hotSpot = QPointF();
-        } else if ((hotSpot.x() > CARD_WIDTH) || (hotSpot.y() > CARD_HEIGHT)) {
+            hotSpot = QPointF{qMax(hotSpot.x(), 0.0), qMax(hotSpot.y(), 0.0)};
+        }
+        if ((hotSpot.x() > CARD_WIDTH) || (hotSpot.y() > CARD_HEIGHT)) {
             qDebug() << "CardDragItem: coordinate overflow: x =" << hotSpot.x() << ", y =" << hotSpot.y();
-            hotSpot = QPointF(CARD_WIDTH, CARD_HEIGHT);
+            hotSpot = QPointF{qMin(hotSpot.x(), static_cast<qreal>(CARD_WIDTH)),
+                              qMin(hotSpot.y(), static_cast<qreal>(CARD_HEIGHT))};
         }
         setCursor(Qt::ClosedHandCursor);
         setZValue(2000000007);

--- a/cockatrice/src/carddragitem.cpp
+++ b/cockatrice/src/carddragitem.cpp
@@ -53,8 +53,20 @@ void CardDragItem::updatePosition(const QPointF &cursorScenePos)
 
     QPointF zonePos = currentZone->scenePos();
     QPointF cursorPosInZone = cursorScenePos - zonePos;
-    QPointF cardTopLeft = cursorPosInZone - hotSpot;
-    QPointF closestGridPoint = cursorZone->closestGridPoint(cardTopLeft);
+
+    // If we are on a Table, we center the card around the cursor, because we
+    // snap it into place and no longer see it being dragged.
+    //
+    // For other zones (where we do display the card under the cursor), we use
+    // the hotspot to feel like the card was dragged at the corresponding
+    // position.
+    TableZone *tableZone = qobject_cast<TableZone *>(cursorZone);
+    QPointF closestGridPoint;
+    if (tableZone)
+        closestGridPoint = tableZone->closestGridPoint(cursorPosInZone);
+    else
+        closestGridPoint = cursorPosInZone - hotSpot;
+
     QPointF newPos = zonePos + closestGridPoint;
 
     if (newPos != pos()) {

--- a/cockatrice/src/carddragitem.cpp
+++ b/cockatrice/src/carddragitem.cpp
@@ -95,7 +95,7 @@ void CardDragItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 
     QList<CardDragItem *> dragItemList;
     CardZone *startZone = static_cast<CardItem *>(item)->getZone();
-    if (currentZone && !(static_cast<CardItem *>(item)->getAttachedTo() && (startZone == currentZone))) {
+    if (currentZone && !(static_cast<CardItem *>(item)->getAttachedTo() && (startZone == currentZone)) && !occupied) {
         dragItemList.append(this);
         for (int i = 0; i < childDrags.size(); i++) {
             CardDragItem *c = static_cast<CardDragItem *>(childDrags[i]);

--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -348,7 +348,9 @@ void CardItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 
         bool forceFaceDown = event->modifiers().testFlag(Qt::ShiftModifier);
 
-        createDragItem(id, event->pos(), event->scenePos(), facedown || forceFaceDown);
+        // Use the buttonDownPos to align the hot spot with the position when
+        // the user originally clicked
+        createDragItem(id, event->buttonDownPos(Qt::LeftButton), event->scenePos(), facedown || forceFaceDown);
         dragItem->grabMouse();
 
         int childIndex = 0;

--- a/cockatrice/src/tablezone.cpp
+++ b/cockatrice/src/tablezone.cpp
@@ -387,8 +387,10 @@ QPointF TableZone::closestGridPoint(const QPointF &point)
 {
     QPoint gridPoint = mapToGrid(point);
     gridPoint.setX((gridPoint.x() / 3) * 3);
-    while (CardItem *card = getCardFromGrid(gridPoint))
-        gridPoint.setX(gridPoint.x() + (card->getAttachedCards().isEmpty() ? 1 : 3));
+    if (getCardFromGrid(gridPoint))
+        gridPoint.setX(gridPoint.x() + 1);
+    if (getCardFromGrid(gridPoint))
+        gridPoint.setX(gridPoint.x() + 1);
     return mapFromGrid(gridPoint);
 }
 

--- a/cockatrice/src/tablezone.cpp
+++ b/cockatrice/src/tablezone.cpp
@@ -346,7 +346,7 @@ QPoint TableZone::mapToGrid(const QPointF &mapPoint) const
 
     // Below calculation effectively rounds to the nearest grid point.
     const int gridPointHeight = CARD_HEIGHT + PADDING_Y;
-    int gridPointY = (y + gridPointHeight / 2) / gridPointHeight;
+    int gridPointY = (y + PADDING_Y / 2) / gridPointHeight;
 
     gridPointY = clampValidTableRow(gridPointY);
 
@@ -357,7 +357,7 @@ QPoint TableZone::mapToGrid(const QPointF &mapPoint) const
     // widths of each card stack along the row.
 
     // Offset point by the margin amount to reference point within grid area.
-    int x = mapPoint.x() - MARGIN_LEFT;
+    int x = mapPoint.x() - MARGIN_LEFT + PADDING_X / 2;
 
     // Maximum value is a card width from the right margin, referenced to the
     // grid area.
@@ -385,12 +385,10 @@ QPoint TableZone::mapToGrid(const QPointF &mapPoint) const
 
 QPointF TableZone::closestGridPoint(const QPointF &point)
 {
-    QPoint gridPoint = mapToGrid(point + QPoint(1, 1));
+    QPoint gridPoint = mapToGrid(point);
     gridPoint.setX((gridPoint.x() / 3) * 3);
-    if (getCardFromGrid(gridPoint))
-        gridPoint.setX(gridPoint.x() + 1);
-    if (getCardFromGrid(gridPoint))
-        gridPoint.setX(gridPoint.x() + 1);
+    while (CardItem *card = getCardFromGrid(gridPoint))
+        gridPoint.setX(gridPoint.x() + (card->getAttachedCards().isEmpty() ? 1 : 3));
     return mapFromGrid(gridPoint);
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4817 (partially)

## Short roundup of the initial problem

Drag & drop placement on the grid is unintuitive.

## What will change with this Pull Request?

This patch tweaks the drag & drop behavior (in particular, the grid placement) to be more intuitive. More precisely, with this patch the drag & drop will:

 - Only use the "hot spot" (i.e. position of the cursor on the card) for zones where the card is actually displayed around the cursor (in particular, not on the table where the card snaps to the grid).

 - Use better boundaries computed with respect to the center of the card (rather than its top left corner) for determining which grid cell a card should go to

 - Align behavior of the preview and the actual effect when overflow of the 3-card stacks occurs

 - Avoid visual glitches where the cursor ends up outside of the card or at incorrect offsets when moving the mouse too fast (which translates to overflows of the hot spot computation)

Note that this patch does not include fixes for the group moves covered [here](https://github.com/Cockatrice/Cockatrice/issues/4817#issuecomment-1854808313).

## Screenshots

### Moving a single card

On current `master` 

https://github.com/Cockatrice/Cockatrice/assets/146210/4f0856be-3aae-4a3c-b43b-5640cc55dd1e

With this PR


https://github.com/Cockatrice/Cockatrice/assets/146210/bc59463b-27a5-4fbe-b9a6-bd8d0cd213fa

### Moving to an occupied position

On current `master`


https://github.com/Cockatrice/Cockatrice/assets/146210/f5634e72-361e-4cef-8135-ad18cf68c953


With this PR


https://github.com/Cockatrice/Cockatrice/assets/146210/8128cfd7-538c-4dd9-b631-724a00f9e189


### Moving to a position with an attachment

On current `master`


https://github.com/Cockatrice/Cockatrice/assets/146210/a4173483-11e6-4f0f-a3fd-ed758054d60b


With this PR


https://github.com/Cockatrice/Cockatrice/assets/146210/4887cb53-6e68-450f-abb4-f7d34899b955

