### PR TITLE
CI: Update release template

### DIFF
--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -11,7 +11,7 @@ include different targets -->
  - <kbd>Windows 7+</kbd>
  - <kbd>Windows 10+</kbd>
  - <kbd>macOS 10.15+</kbd> ("Catalina")
- - <kbd>macOS 12+</kbd> ("Monterey")
+ - <kbd>macOS 13+</kbd> ("Ventura")
  - <kbd>Ubuntu 18.04 LTS</kbd> ("Bionic Beaver")
  - <kbd>Ubuntu 20.04 LTS</kbd> ("Focal Fossa")
  - <kbd>Ubuntu 22.04 LTS</kbd> ("Jammy Jellyfish")


### PR DESCRIPTION
## Related Ticket(s)
- Related #4961

## Short roundup of the initial problem
Above PR removed macOS 12 and added macOS 13 builds.
The template was not changed.

## What will change with this Pull Request?
- Update the template used by scripts in CI for creating new release descriptions.