### PR TITLE
CI bug fix - unlink 2to3 before installing python3

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -239,7 +239,7 @@ jobs:
       # RE: https://discord.com/channels/314987288398659595/401594186983407616/1196451948413595778
       - name: Unlink 2to3
         if: matrix.target == '10.15_Catalina'
-        run: brew unlink python@2
+        run: brew unlink /usr/local/bin/2to3
 
       - name: Install dependencies using homebrew
         shell: bash

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -236,6 +236,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # RE: https://discord.com/channels/314987288398659595/401594186983407616/1196451948413595778
+      - name: Unlink 2to3
+        if: matrix.target == '10.15_Catalina'
+        run: brew unlink python@2
+
       - name: Install dependencies using homebrew
         shell: bash
         # cmake cannot find the mysql connector


### PR DESCRIPTION
See the discord thread here: https://discord.com/channels/314987288398659595/401594186983407616/1196451948413595778

> the builds are failing because of devops stuff.
>I looked into the Mac build and it’s failing because Python is failing to symlink 2to3 since there are multiple Python versions being installed by homebrew and the Catalina image GitHub actions uses 
>Idk why the windows 10 build failed

## Related Ticket(s)

Related to #4982  because i found the issue there

## Short roundup of the initial problem
https://github.com/pypa/pipenv/issues/3831

## What will change with this Pull Request?
github's 2to3 will be unlinked so that the new 2to3 can be linked

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
