### PR TITLE
make translation update script more specific in line selection

### DIFF
--- a/.ci/update_translation_source_strings.sh
+++ b/.ci/update_translation_source_strings.sh
@@ -45,12 +45,14 @@ if ! got="$(lupdate $DIRS -ts "$FILE" | tee /dev/stderr)"; then
 fi
 
 # trim output
-output="${got##*(}" # trim everything before last (
+# the line we are interested in is:
+# Found xxx source text(s) (x new and xxx already existing)
+output="${got##* source text(s) (}" # get stuff in between brackets
 output="${output%%)*}" # trim everything after first )
-if [[ $output == $got ]]; then
+if [[ $output == "$got" ]]; then
   echo "could not parse generated output" >&2
   exit 4;
 fi
 
 # write output to ci environment file
-echo "output=$output" >> $GITHUB_OUTPUT
+echo "output=$output" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Related Ticket(s)
- #4544
- conversation at #4973

## Short roundup of the initial problem
there is a chance of having an extra line of output from lupdate which messes up our fragile output grabbing logic


also note, the create pull request will soon be updated to v6 in order to avoid the node16 warning:
https://github.com/peter-evans/create-pull-request/issues/2444#issuecomment-1909906572

## What will change with this Pull Request?
- we will check for the output by checking more text from the line we are interested in other than just the brackets
- test of this change is here: https://github.com/ebbit1q/Cockatrice/pull/5
