### PR TITLE
Readme: Remove Gitter chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Downloads are available for full releases and the current beta version in develo
    - To be a Cockatrice Beta Tester, use this version. Find more information [here](https://github.com/Cockatrice/Cockatrice/wiki/Release-Channels)!
    
 
-# Get Involved [![Discord](https://img.shields.io/discord/314987288398659595?label=Discord&logo=discord&logoColor=white)](https://discord.gg/3Z9yzmA) [![Gitter Chat](https://img.shields.io/gitter/room/Cockatrice/Cockatrice)](https://gitter.im/Cockatrice/Cockatrice)
+# Get Involved [![Discord](https://img.shields.io/discord/314987288398659595?label=Discord&logo=discord&logoColor=white)](https://discord.gg/3Z9yzmA)
 
 Join our [Discord community](https://discord.gg/3Z9yzmA) to connect with the project or fellow users of the app. The Cockatrice developers are also available on [Gitter](https://gitter.im/Cockatrice/Cockatrice). Come here to talk about the application, features, or just to hang out.<br>
 For support regarding specific servers, please contact that server's admin or forum for support rather than asking here.<br>


### PR DESCRIPTION
## Short roundup of the initial problem
Gitter chat is no longer used.
Zach removed it from the webpage some time ago already.

## What will change with this Pull Request?
- Remove Gitter badge

