### PR TITLE
CI: Enable MTT over parallel flag for Windows

### DIFF
--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -160,7 +160,13 @@ cmake .. "${flags[@]}"
 echo "::endgroup::"
 
 echo "::group::Build project"
-cmake --build . "${buildflags[@]}"
+if [[ $RUNNER_OS == Windows ]]; then
+  # Enable MTT, see https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/
+  # and https://devblogs.microsoft.com/cppblog/cpp-build-throughput-investigation-and-tune-up/#multitooltask-mtt
+  cmake --build . "${buildflags[@]}" -- -p:UseMultiToolTask=true
+else
+  cmake --build . "${buildflags[@]}"
+fi
 echo "::endgroup::"
 
 if [[ $USE_CCACHE ]]; then

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -358,7 +358,9 @@ jobs:
           CMAKE_GENERATOR: '${{env.CMAKE_GENERATOR}}'
           CMAKE_GENERATOR_PLATFORM: 'x64'
           QTDIR: '${{github.workspace}}\Qt\${{matrix.qt_version}}\win64_${{matrix.qt_arch}}'
-        run: .ci/compile.sh --server --release --test --package --parallel 4
+        # No need for --parallel flag, MTT is added in the compile script to let cmake/msbuild manage core count,
+        # project and process parallelism: https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/
+        run: .ci/compile.sh --server --release --test --package
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Related Ticket(s)
- Supersedes and implements results from #4615

## Short roundup of the initial problem
1) Windows was not utilizing parallel builds at all despite using the CMake flag. That was partially caused by process parallelism being set to 1 by default and only project parallelism being enabled by that flag for CMake/msbuild: https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7926

    For us, that was not giving benefits, as [MS notes](https://learn.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes?view=msvc-160#the-msbuild-tool): 
      >The guideline for deciding whether to use MSBuild or /MP technology is as follows:
      >
      >  - If there are **many projects with few files in each project**, use the MSBuild tool with the /maxcpucount option.
      >  - If there are **few projects with many files in each project**, use the /MP option.
      >  - If the **number of projects and files per project is balanced**, use both MSBuild and /MP. Initially set the /maxcpucount option to the number of projects to build and the /MP option to the number of processors on your computer. Measure performance and then adjust your settings to yield the best results. Repeat that cycle until you're satisfied with the total build time.

    Despite that changing just recently as seen in the linked PR above, I did not manage to set `/MP` properly to speed things up.

    I found out about another, newer possibility called Multi Tool Task, which decreased build time considerably.
    You can read more about it here:
      - https://learn.microsoft.com/en-us/visualstudio/msbuild/multitooltask-task?view=vs-2019
      - https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild
      - https://devblogs.microsoft.com/cppblog/cpp-build-throughput-investigation-and-tune-up

2) After adjusting the core count from 2 to 4 to reflect the most recent changes to the GitHub hosted Windows runner, Windows builds suddenly failed 90% of the time.
That's no longer an issue with this change.

## What will change with this Pull Request?
- Do not use CMake's `--parallel` flag on Windows
- Enable Multi Tool Task parameter instead

As a result, Windows builds in our CI setup are ~25% faster.