### PR TITLE
CI: Use windows-2022 image with Visual Studio 17 2022

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -325,6 +325,8 @@ jobs:
       - name: Add msbuild to PATH
         id: add-msbuild
         uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: x64
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -317,9 +317,9 @@ jobs:
 
     name: Windows ${{matrix.target}}
     needs: configure
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
-      CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      CMAKE_GENERATOR: 'Visual Studio 17 2022'
 
     steps:
       - name: Add msbuild to PATH

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -322,6 +322,10 @@ jobs:
       CMAKE_GENERATOR: 'Visual Studio 17 2022'
 
     steps:
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          detached: true
       - name: Add msbuild to PATH
         id: add-msbuild
         uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -322,10 +322,6 @@ jobs:
       CMAKE_GENERATOR: 'Visual Studio 17 2022'
 
     steps:
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        with:
-          detached: true
       - name: Add msbuild to PATH
         id: add-msbuild
         uses: microsoft/setup-msbuild@v2

--- a/cmake/FindVCredistRuntime.cmake
+++ b/cmake/FindVCredistRuntime.cmake
@@ -24,7 +24,7 @@ if(WIN32)
     get_filename_component(_path ${_path}/../../ ABSOLUTE)
 
     foreach(redist_file ${REDIST_FILE_NAMES})
-      if(EXISTS "${_path}/${REDIST_FILE}")
+      if(EXISTS "${_path}/${redist_file}")
         set(VCREDISTRUNTIME_FOUND "YES")
         set(VCREDISTRUNTIME_FILE ${_path}/${redist_file})
         break()

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -248,12 +248,12 @@ ${If} $PortableMode = 0
 	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice" "VersionMajor" "@CPACK_PACKAGE_VERSION_MAJOR@"
 	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice" "VersionMinor" "@CPACK_PACKAGE_VERSION_MINOR@"
 
-	IfFileExists "$INSTDIR\vc_redist.exe" VcRedist86Exists PastVcRedist86Check
+	IfFileExists "$INSTDIR\vc_redist.x86.exe" VcRedist86Exists PastVcRedist86Check
 	VcRedist86Exists:
-		ExecWait '"$INSTDIR\vc_redist_x86.exe" /passive /norestart'
+		ExecWait '"$INSTDIR\vc_redist.x86.exe" /passive /norestart'
 		DetailPrint "Wait to ensure unlock of vc_redist file after installation..."
 		Sleep 3000
-		Delete "$INSTDIR\vc_redist_x86.exe"
+		Delete "$INSTDIR\vc_redist.x86.exe"
 	PastVcRedist86Check:
 
 	IfFileExists "$INSTDIR\vc_redist.x64.exe" VcRedist64Exists PastVcRedist64Check

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -248,20 +248,20 @@ ${If} $PortableMode = 0
 	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice" "VersionMajor" "@CPACK_PACKAGE_VERSION_MAJOR@"
 	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice" "VersionMinor" "@CPACK_PACKAGE_VERSION_MINOR@"
 
-	IfFileExists "$INSTDIR\vcredist_x86.exe" VcRedist86Exists PastVcRedist86Check
+	IfFileExists "$INSTDIR\vc_redist.exe" VcRedist86Exists PastVcRedist86Check
 	VcRedist86Exists:
-		ExecWait '"$INSTDIR\vcredist_x86.exe" /passive /norestart'
+		ExecWait '"$INSTDIR\vc_redist_x86.exe" /passive /norestart'
 		DetailPrint "Wait to ensure unlock of vc_redist file after installation..."
 		Sleep 3000
-		Delete "$INSTDIR\vcredist_x86.exe"
+		Delete "$INSTDIR\vc_redist_x86.exe"
 	PastVcRedist86Check:
 
-	IfFileExists "$INSTDIR\vcredist_x64.exe" VcRedist64Exists PastVcRedist64Check
+	IfFileExists "$INSTDIR\vc_redist.x64.exe" VcRedist64Exists PastVcRedist64Check
 	VcRedist64Exists:
-		ExecWait '"$INSTDIR\vcredist_x64.exe" /passive /norestart'
+		ExecWait '"$INSTDIR\vc_redist.x64.exe" /passive /norestart'
 		DetailPrint "Sleep to ensure unlock of vc_redist file after installation..."
 		Sleep 3000
-		Delete "$INSTDIR\vcredist_x64.exe"
+		Delete "$INSTDIR\vc_redist.x64.exe"
 	PastVcRedist64Check:
 
 ${Else}


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4923

## Short roundup of the initial problem
`vcredist` can not be found by CMake/NSIS with VS 2022:
>    CPack: Create package using NSIS
    CPack: Install projects
    CPack: - Install project: Cockatrice [Release]
    CMake Error at D:/a/Cockatrice/Cockatrice/build/cmake_install.cmake:36 (file):
  Error:     file INSTALL cannot find "C:/Program Files/Microsoft Visual
>      Studio/2022/Enterprise/VC/Redist/MSVC/14.38.33135/vcredist_x64.exe": File
      exists.

VS 2022 uses a different naming for the file. Trying to rename in the NSIS file according to this comment did not solve it yet:
https://github.com/Cockatrice/Cockatrice/blob/1715bcb2166f2a505d35329b7e542c227076ba6f/cmake/FindVCredistRuntime.cmake#L12
See also https://learn.microsoft.com/en-us/cpp/windows/redistributing-visual-cpp-files?view=msvc-170#locate-the-redistributable-files

**I'm wondering why the error message still states `vcredist_x64.exe`, while it should be `vc_redist.x64.exe`**.
Not an CMake expert at all here... any pointer?

## What will change with this Pull Request?
- this
- and this
