### PR TITLE
assign new arrow id when arrow is moved to transformed card

### DIFF
--- a/cockatrice/src/remoteclient.cpp
+++ b/cockatrice/src/remoteclient.cpp
@@ -32,6 +32,7 @@ RemoteClient::RemoteClient(QObject *parent)
 {
 
     clearNewClientFeatures();
+    maxTimeout = SettingsCache::instance().getTimeOut();
     int keepalive = SettingsCache::instance().getKeepAlive();
     timer = new QTimer(this);
     timer->setInterval(keepalive * 1000);

--- a/cockatrice/src/remoteclient.h
+++ b/cockatrice/src/remoteclient.h
@@ -89,7 +89,7 @@ private slots:
     void submitForgotPasswordChallengeResponse(const Response &response);
 
 private:
-    static const int maxTimeout = 5;
+    int maxTimeout;
     int timeRunning, lastDataReceived;
     QByteArray inputBuffer;
     bool messageInProgress;

--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -195,6 +195,7 @@ SettingsCache::SettingsCache()
 
     lang = settings->value("personal/lang").toString();
     keepalive = settings->value("personal/keepalive", 3).toInt();
+    timeout = settings->value("personal/timeout", 5).toInt();
 
     // tip of the day settings
     showTipsOnStartup = settings->value("tipOfDay/showTips", true).toBool();

--- a/cockatrice/src/settingscache.h
+++ b/cockatrice/src/settingscache.h
@@ -134,6 +134,7 @@ private:
     bool spectatorsCanSeeEverything;
     bool createGameAsSpectator;
     int keepalive;
+    int timeout;
     void translateLegacySettings();
     QString getSafeConfigPath(QString configEntry, QString defaultPath) const;
     QString getSafeConfigFilePath(QString configEntry, QString defaultPath) const;
@@ -433,6 +434,10 @@ public:
     int getKeepAlive() const
     {
         return keepalive;
+    }
+    int getTimeOut() const
+    {
+        return timeout;
     }
     int getMaxFontSize() const
     {

--- a/common/server_arrow.h
+++ b/common/server_arrow.h
@@ -21,6 +21,10 @@ public:
     {
         return id;
     }
+    void setId(int _id)
+    {
+        id = _id;
+    }
     Server_Card *getStartCard() const
     {
         return startCard;

--- a/common/server_player.h
+++ b/common/server_player.h
@@ -164,6 +164,7 @@ public:
 
     void addZone(Server_CardZone *zone);
     void addArrow(Server_Arrow *arrow);
+    void updateArrowId(int id);
     bool deleteArrow(int arrowId);
     void addCounter(Server_Counter *counter);
 


### PR DESCRIPTION
## Related Ticket(s)
- fixes bug introduced in https://github.com/Cockatrice/Cockatrice/pull/4907
- fixes https://github.com/Cockatrice/Cockatrice/issues/5008

## Short roundup of the initial problem
when an arrow was deleted after a card transforms a new arrow object was sent to clients with the same id, deleting this arrow didn't properly work

## What will change with this Pull Request?
- the new arrow object will have a unique id, fixing the problem