### PR TITLE
Add Ubuntu 24.04 "Noble Numbat" Build

### DIFF
--- a/.ci/UbuntuNoble/Dockerfile
+++ b/.ci/UbuntuNoble/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:noble
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        ccache \
+        clang-format \
+        cmake \
+        file \
+        g++ \
+        git \
+        libgl-dev \
+        liblzma-dev \
+        libmariadb-dev-compat \
+        libprotobuf-dev \
+        libqt6multimedia6 \
+        libqt6sql6-mysql \
+        qt6-svg-dev \
+        qt6-websockets-dev \
+        protobuf-compiler \
+        qt6-image-formats-plugins \
+        qt6-l10n-tools \
+        qt6-multimedia-dev \
+        qt6-tools-dev \
+        qt6-tools-dev-tools \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -15,6 +15,7 @@ include different targets -->
  - <kbd>Ubuntu 18.04 LTS</kbd> ("Bionic Beaver")
  - <kbd>Ubuntu 20.04 LTS</kbd> ("Focal Fossa")
  - <kbd>Ubuntu 22.04 LTS</kbd> ("Jammy Jellyfish")
+ - <kbd>Ubuntu 24.04 LTS</kbd> ("Noble Numbat")
  - <kbd>Debian 11</kbd> ("Bullseye")
  - <kbd>Debian 12</kbd> ("Bookworm")
  - <kbd>Fedora 38</kbd>

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -114,6 +114,9 @@ jobs:
             package: DEB
             test: skip # running tests on all distros is superfluous
 
+          - distro: UbuntuNoble
+            package: DEB
+
     name: ${{matrix.distro}}
     needs: configure
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Short roundup of the initial problem

Ubuntu 24.04 is set to release on April 25, 2024 and will be LTS for five years so it makes sense to build for it in future releases.

## What will change with this Pull Request?
- Adds a dockerfile and a matrix entry for Noble
- Adds Noble to the Release Template