### PR TITLE
Drop MacOS 10.15/11 Support :(

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -243,6 +243,7 @@ jobs:
         # neither of these works: mariadb-connector-c mysql-connector-c++
         env:
           install_qt: ${{matrix.qt_version}}
+          force_overwrite_python: ${{matrix.force_overwrite_python}}
           use_old_protobuf: ${{matrix.use_old_protobuf}}
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -219,7 +219,7 @@ jobs:
             do_tests: 1
             make_package: 1
 
-    name: macOS ${{matrix.target}}
+    name: macOS_${{matrix.target}}
     needs: configure
     runs-on: ${{matrix.os}}
     continue-on-error: ${{matrix.allow-failure == 'yes'}}
@@ -302,7 +302,7 @@ jobs:
             qt_tools: "tools_opensslv3_x64"
             qt_modules: "qtmultimedia qtwebsockets"
 
-    name: Windows ${{matrix.target}}
+    name: Windows_${{matrix.target}}
     needs: configure
     runs-on: windows-2022
     env:

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -249,7 +249,6 @@ jobs:
         run: |
           brew update
           if [[ $force_overwrite_python == 1 ]]; then
-            brew install --overwrite python@3.12
             brew link --force python@3.12
             rm /opt/homebrew/Cellar/python\@3*/**/EXTERNALLY-MANAGED
           fi

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -250,9 +250,9 @@ jobs:
           brew update
           if [[ $force_overwrite_python == 1 ]]; then
             brew install --overwrite python@3.11
-            brew link --force python@3.11
             brew install --overwrite python@3.12
             brew link --force python@3.12
+            rm /opt/homebrew/Cellar/python\@3*/**/EXTERNALLY-MANAGED
           fi
           if [[ $use_old_protobuf == 1 ]]; then
             brew install protobuf@21
@@ -345,7 +345,6 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           cache: true
-          setup-python: false
           version: ${{matrix.qt_version}}
           arch: win64_${{matrix.qt_arch}}
           tools: ${{matrix.qt_tools}}

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -248,8 +248,10 @@ jobs:
         run: |
           brew update
           if [[ $force_overwrite_python == 1 ]]; then
-            brew install --overwrite python@3.11 
+            brew install --overwrite python@3.11
+            brew link --force python@3.11
             brew install --overwrite python@3.12
+            brew link --force python@3.12
           fi
           if [[ $use_old_protobuf == 1 ]]; then
             brew install protobuf@21

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -198,7 +198,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: 12_Monteray
+          - target: 12_Monterey
             os: macos-12
             xcode: "13.1"
             type: Release

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -237,6 +237,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          detached: true
+
       - name: Install dependencies using homebrew
         shell: bash
         # cmake cannot find the mysql connector

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -255,7 +255,6 @@ jobs:
           brew update
           if [[ $force_overwrite_python == 1 ]]; then
             brew link --force python@3.12
-            rm /opt/homebrew/Cellar/python\@3*/**/EXTERNALLY-MANAGED
           fi
           if [[ $use_old_protobuf == 1 ]]; then
             brew install protobuf@21
@@ -275,7 +274,6 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           cache: true
-          setup-python: false
           version: ${{matrix.qt_version}}
           modules: ${{matrix.qt_modules}}
           py7zrversion: ${{matrix.qt_py7zrversion}}

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -231,11 +231,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        with:
-          detached: true
-
       - name: Install dependencies using homebrew
         shell: bash
         # cmake cannot find the mysql connector
@@ -247,14 +242,6 @@ jobs:
           brew install protobuf
           brew link --force protobuf
           brew install qt --force-bottle
-
-      - name: Install Qt ${{matrix.qt_version}} for ${{matrix.target}}
-        if: matrix.qt_version != 'homebrew'
-        uses: jurplel/install-qt-action@v3
-        with:
-          cache: true
-          version: ${{matrix.qt_version}}
-          modules: ${{matrix.qt_modules}}
 
       - name: Build on Xcode ${{matrix.xcode}}
         shell: bash

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -249,7 +249,6 @@ jobs:
         run: |
           brew update
           if [[ $force_overwrite_python == 1 ]]; then
-            brew install --overwrite python@3.11
             brew install --overwrite python@3.12
             brew link --force python@3.12
             rm /opt/homebrew/Cellar/python\@3*/**/EXTERNALLY-MANAGED

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -214,6 +214,7 @@ jobs:
             do_tests: 1
             make_package: 1
             use_old_protobuf: 1
+            force_overwrite_python: 1
             qt_py7zrversion: '==0.20.*'
 
           - target: 13_Ventura
@@ -246,6 +247,10 @@ jobs:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
           brew update
+          if [[ $force_overwrite_python == 1 ]]; then
+            brew install python@3.12
+            brew link --overwrite python@3.12
+          fi
           if [[ $use_old_protobuf == 1 ]]; then
             brew install protobuf@21
             brew link --force protobuf@21

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -198,27 +198,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: 12_Monterey
+          - target: 12_Monterey_and_13_Ventura
             os: macos-12
-            xcode: "13.1"
-            type: Release
-            make_package: 1
-
-          - target: 13_Ventura
-            os: macos-13
-            xcode: "14.1"
+            xcode: "14.0.1"
             type: Release
             make_package: 1
 
           - target: 14_Sonoma
             os: macos-14
-            xcode: "14.3.1"
+            xcode: "15.4"
             type: Release
             make_package: 1
 
           - target: 14_Sonoma_Debug
             os: macos-14
-            xcode: "14.3.1"
+            xcode: "15.4"
             type: Debug
 
     name: macOS${{matrix.target}}

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -198,29 +198,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: Debug # tests only
-            os: macos-latest
-            xcode: 14.3.1 # Lowest supported version on GHA
-            qt_version: homebrew
-            type: Debug
-            do_tests: 1
-
-          - target: 10.15_Catalina
-            os: macos-11
-            xcode: 11.7 # allows using macOS 10.15 SDK, Lowest supported version on GHA
-            qt_version: 6.2.* # 6.2 is last LTS compatible with 10.15, see https://doc.qt.io/qt-6.5/macos.html
-            qt_modules: "qtmultimedia qtwebsockets"
+          - target: 12_Monteray
+            os: macos-12
+            xcode: "13.1"
             type: Release
             do_tests: 1
             make_package: 1
-            use_old_protobuf: 1
-            force_overwrite_python: 1
-            qt_py7zrversion: '==0.20.*'
 
           - target: 13_Ventura
             os: macos-13
-            xcode: 14.1 # Lowest supported version on GHA
-            qt_version: homebrew
+            xcode: "14.1"
+            type: Release
+            do_tests: 1
+            make_package: 1
+
+          - target: 14_Sonoma
+            os: macos-14
+            xcode: "14.3.1"
             type: Release
             do_tests: 1
             make_package: 1
@@ -247,27 +241,12 @@ jobs:
         # cmake cannot find the mysql connector
         # neither of these works: mariadb-connector-c mysql-connector-c++
         env:
-          install_qt: ${{matrix.qt_version}}
-          force_overwrite_python: ${{matrix.force_overwrite_python}}
-          use_old_protobuf: ${{matrix.use_old_protobuf}}
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
           brew update
-          if [[ $force_overwrite_python == 1 ]]; then
-            brew link --force python@3.12
-          fi
-          if [[ $use_old_protobuf == 1 ]]; then
-            brew install protobuf@21
-            brew link --force protobuf@21
-          else
-            brew install protobuf
-            brew link --force protobuf
-          fi
-          if [[ $install_qt == homebrew ]]; then
-            brew install qt --force-bottle
-          else # for some reason the tests fail with the action installed qt?
-            brew install googletest
-          fi
+          brew install protobuf
+          brew link --force protobuf
+          brew install qt --force-bottle
 
       - name: Install Qt ${{matrix.qt_version}} for ${{matrix.target}}
         if: matrix.qt_version != 'homebrew'
@@ -276,7 +255,6 @@ jobs:
           cache: true
           version: ${{matrix.qt_version}}
           modules: ${{matrix.qt_modules}}
-          py7zrversion: ${{matrix.qt_py7zrversion}}
 
       - name: Build on Xcode ${{matrix.xcode}}
         shell: bash

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -248,8 +248,8 @@ jobs:
         run: |
           brew update
           if [[ $force_overwrite_python == 1 ]]; then
-            brew install python@3.12
-            brew link --overwrite python@3.12
+            brew install --overwrite python@3.11 
+            brew install --overwrite python@3.12
           fi
           if [[ $use_old_protobuf == 1 ]]; then
             brew install protobuf@21

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -219,7 +219,7 @@ jobs:
             do_tests: 1
             make_package: 1
 
-    name: macOS_${{matrix.target}}
+    name: macOS${{matrix.target}}
     needs: configure
     runs-on: ${{matrix.os}}
     continue-on-error: ${{matrix.allow-failure == 'yes'}}
@@ -289,7 +289,7 @@ jobs:
             qt_tools: "tools_opensslv3_x64"
             qt_modules: "qtmultimedia qtwebsockets"
 
-    name: Windows_${{matrix.target}}
+    name: Windows${{matrix.target}}
     needs: configure
     runs-on: windows-2022
     env:

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -202,22 +202,24 @@ jobs:
             os: macos-12
             xcode: "13.1"
             type: Release
-            do_tests: 1
             make_package: 1
 
           - target: 13_Ventura
             os: macos-13
             xcode: "14.1"
             type: Release
-            do_tests: 1
             make_package: 1
 
           - target: 14_Sonoma
             os: macos-14
             xcode: "14.3.1"
             type: Release
-            do_tests: 1
             make_package: 1
+
+          - target: 14_Sonoma_Debug
+            os: macos-14
+            xcode: "14.3.1"
+            type: Debug
 
     name: macOS${{matrix.target}}
     needs: configure
@@ -231,7 +233,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install dependencies using homebrew
+      - name: Install dependencies using Homebrew
         shell: bash
         # cmake cannot find the mysql connector
         # neither of these works: mariadb-connector-c mysql-connector-c++
@@ -239,16 +241,14 @@ jobs:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
           brew update
-          brew install protobuf
-          brew link --force protobuf
-          brew install qt --force-bottle
+          brew install protobuf qt --force-bottle
 
       - name: Build on Xcode ${{matrix.xcode}}
         shell: bash
         id: build
         env:
           BUILDTYPE: '${{matrix.type}}'
-          MAKE_TEST: '${{matrix.do_tests}}'
+          MAKE_TEST: 1
           MAKE_PACKAGE: '${{matrix.make_package}}'
           PACKAGE_SUFFIX: '-macOS-${{matrix.target}}'
         # macOS runner actually have only 3 cores
@@ -289,7 +289,7 @@ jobs:
             qt_tools: "tools_opensslv3_x64"
             qt_modules: "qtmultimedia qtwebsockets"
 
-    name: Windows${{matrix.target}}
+    name: Windows ${{matrix.target}}
     needs: configure
     runs-on: windows-2022
     env:
@@ -311,6 +311,7 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           cache: true
+          setup-python: false
           version: ${{matrix.qt_version}}
           arch: win64_${{matrix.qt_arch}}
           tools: ${{matrix.qt_tools}}


### PR DESCRIPTION
## Related Ticket(s)
- Closes #5007
- Closes #4924

## Short roundup of the initial problem
- GitHub Runners are removing MacOS 11 support next month, which removes our ability to generate MacOS 10.15 and MacOS 11 builds. 

## What will change with this Pull Request?
- Update Mac Builds to use macOS 12,~~13~~,14

