### PR TITLE
CI: Enable CIServer Mode in VS 2022

### DIFF
--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -163,7 +163,7 @@ echo "::group::Build project"
 if [[ $RUNNER_OS == Windows ]]; then
   # Enable MTT, see https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/
   # and https://devblogs.microsoft.com/cppblog/cpp-build-throughput-investigation-and-tune-up/#multitooltask-mtt
-  cmake --build . "${buildflags[@]}" -- -p:UseMultiToolTask=true
+  cmake --build . "${buildflags[@]}" -- -p:UseMultiToolTask=true -p:EnableClServerMode=true
 else
   cmake --build . "${buildflags[@]}"
 fi


### PR DESCRIPTION
## Related Ticket(s)
- Mentioned in #4923

## Short roundup of the initial problem
Trying to further speed up Win builds.

## What will change with this Pull Request?
In addition to MTT (#4998), this feature is available starting VS 2022 which we now have (#4999).

https://devblogs.microsoft.com/cppblog/cpp-build-throughput-investigation-and-tune-up/#multitooltask-mtt

>In VS 2022, the new experimental “ClServer” mode has been added to address the process creation overhead in MTT mode by using server-client model similar to cl.exe /MP. The server would spawn worker cl.exe processes, then dispatch work via IPC. The server resides in MSBuild process so is in-sync with the resource manager while scheduling work dynamically—allocating more workers or freeing resources to scaling down to deal with “long pole” compiles.
>
>To enable this mode the following property should be defined as an environment variable or as an MSBuild property for all projects (see Directory.Build.props sample below):
>
>set `EnableClServerMode=true`

Effect seems small. It doesn't harm to keep it and things might improve in the future.