### PR TITLE
CI: vcpkg binary caching

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -343,12 +343,22 @@ jobs:
           tools: ${{matrix.qt_tools}}
           modules: ${{matrix.qt_modules}}
 
+      # Set up vcpkg binary cache using GitHub Actions Cache
+      # https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-actions-cache
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');    
+
       - name: Run vcpkg
         uses: lukka/run-vcpkg@v11
         with:
           runVcpkgInstall: true
           doNotCache: false
         env:
+          VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"    # Needed for binary caching
           VCPKG_DEFAULT_TRIPLET: 'x64-windows'
           VCPKG_DISABLE_METRICS: 1
 


### PR DESCRIPTION
Following the MS docs, there are some extra steps needed to use GitHub Actions cache to cache the build package binaries as well:
https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-actions-cache

<br>

>Edit:
This does not work as is and makes the CMake step download & install the vcpkg packages again
>
>Since we use lukka/run-vcpkg, it does it in the background already and is not needed