### PR TITLE
Re-Add ability to share editable deck views

### DIFF
--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -481,7 +481,8 @@ void MessageLogWidget::logRevealCards(Player *player,
                                       QString cardName,
                                       Player *otherPlayer,
                                       bool faceDown,
-                                      int amount)
+                                      int amount,
+                                      bool isLentToAnotherPlayer)
 {
     // getFromStr uses cardname.empty() to check if it should contain the start zone, it's not actually used
     QPair<QString, QString> temp = getFromStr(zone, amount == 1 ? cardName : QString::number(amount), cardId, false);
@@ -507,10 +508,17 @@ void MessageLogWidget::logRevealCards(Player *player,
     }
     if (cardId == -1) {
         if (otherPlayer) {
-            appendHtmlServerMessage(tr("%1 reveals %2 to %3.")
-                                        .arg(sanitizeHtml(player->getName()))
-                                        .arg(zone->getTranslatedName(true, CaseRevealZone))
-                                        .arg(sanitizeHtml(otherPlayer->getName())));
+            if (isLentToAnotherPlayer) {
+                appendHtmlServerMessage(tr("%1 lends %2 to %3.")
+                                            .arg(sanitizeHtml(player->getName()))
+                                            .arg(zone->getTranslatedName(true, CaseRevealZone))
+                                            .arg(sanitizeHtml(otherPlayer->getName())));
+            } else {
+                appendHtmlServerMessage(tr("%1 reveals %2 to %3.")
+                                            .arg(sanitizeHtml(player->getName()))
+                                            .arg(zone->getTranslatedName(true, CaseRevealZone))
+                                            .arg(sanitizeHtml(otherPlayer->getName())));
+            }
         } else {
             appendHtmlServerMessage(tr("%1 reveals %2.")
                                         .arg(sanitizeHtml(player->getName()))
@@ -845,8 +853,8 @@ void MessageLogWidget::connectToPlayer(Player *player)
     connect(player, SIGNAL(logDumpZone(Player *, CardZone *, int)), this, SLOT(logDumpZone(Player *, CardZone *, int)));
     connect(player, SIGNAL(logDrawCards(Player *, int, bool)), this, SLOT(logDrawCards(Player *, int, bool)));
     connect(player, SIGNAL(logUndoDraw(Player *, QString)), this, SLOT(logUndoDraw(Player *, QString)));
-    connect(player, SIGNAL(logRevealCards(Player *, CardZone *, int, QString, Player *, bool, int)), this,
-            SLOT(logRevealCards(Player *, CardZone *, int, QString, Player *, bool, int)));
+    connect(player, SIGNAL(logRevealCards(Player *, CardZone *, int, QString, Player *, bool, int, bool)), this,
+            SLOT(logRevealCards(Player *, CardZone *, int, QString, Player *, bool, int, bool)));
     connect(player, SIGNAL(logAlwaysRevealTopCard(Player *, CardZone *, bool)), this,
             SLOT(logAlwaysRevealTopCard(Player *, CardZone *, bool)));
     connect(player, SIGNAL(logAlwaysLookAtTopCard(Player *, CardZone *, bool)), this,

--- a/cockatrice/src/messagelogwidget.h
+++ b/cockatrice/src/messagelogwidget.h
@@ -77,7 +77,8 @@ public slots:
                         QString cardName,
                         Player *otherPlayer,
                         bool faceDown,
-                        int amount);
+                        int amount,
+                        bool isLentToAnotherPlayer);
     void logReverseTurn(Player *player, bool reversed);
     void logRollDie(Player *player, int sides, const QList<uint> &rolls);
     void logSay(Player *player, QString message);

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -142,7 +142,8 @@ signals:
                         QString cardName,
                         Player *otherPlayer,
                         bool faceDown,
-                        int amount);
+                        int amount,
+                        bool isLentToAnotherPlayer = false);
     void logAlwaysRevealTopCard(Player *player, CardZone *zone, bool reveal);
     void logAlwaysLookAtTopCard(Player *player, CardZone *zone, bool reveal);
 
@@ -225,11 +226,12 @@ private slots:
 
 private:
     TabGame *game;
-    QMenu *sbMenu, *countersMenu, *sayMenu, *createPredefinedTokenMenu, *mRevealLibrary, *mRevealTopCard, *mRevealHand,
-        *mRevealRandomHandCard, *mRevealRandomGraveyardCard;
+    QMenu *sbMenu, *countersMenu, *sayMenu, *createPredefinedTokenMenu, *mRevealLibrary, *mLendLibrary, *mRevealTopCard,
+        *mRevealHand, *mRevealRandomHandCard, *mRevealRandomGraveyardCard;
     TearOffMenu *moveGraveMenu, *moveRfgMenu, *graveMenu, *moveHandMenu, *handMenu, *libraryMenu, *topLibraryMenu,
         *bottomLibraryMenu, *rfgMenu, *playerMenu;
     QList<QMenu *> playerLists;
+    QList<QMenu *> singlePlayerLists;
     QList<QAction *> allPlayersActions;
     QList<QPair<QString, int>> playersInfo;
     QAction *aMoveHandToTopLibrary, *aMoveHandToBottomLibrary, *aMoveHandToGrave, *aMoveHandToRfg,
@@ -299,6 +301,8 @@ private:
                     bool persistent = false);
     bool createRelatedFromRelation(const CardItem *sourceCard, const CardRelation *cardRelation);
     void moveOneCardUntil(const CardInfoPtr card);
+    void addPlayerToList(QMenu *playerList, Player *player);
+    static void removePlayerFromList(QMenu *playerList, Player *player);
 
     QRectF bRect;
 


### PR DESCRIPTION
Allows cards like [Praetor's Grasp](https://scryfall.com/card/nph/71/praetors-grasp) to be functional

- Rolls back 68118191619b26ffa908c86679c51c4db0d61125
- Follow up to adbb607700908f43d52cfa988eed8101683db22e

## Related Ticket(s)
- Fixes #625