### PR TITLE
replace cipt check with regex

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -141,9 +141,9 @@ CardInfoPtr OracleImporter::addCard(QString name,
     // DETECT CARD POSITIONING INFO
 
     // cards that enter the field tapped
-    bool cipt = text.contains(" it enters the battlefield tapped") ||
-                (text.contains(name + " enters the battlefield tapped") &&
-                 !text.contains(name + " enters the battlefield tapped unless"));
+    QRegularExpression ciptRegex("( it|" + QRegularExpression::escape(name) +
+                                 ") enters( the battlefield)? tapped(?! unless)");
+    bool cipt = ciptRegex.match(text).hasMatch();
 
     // table row
     int tableRow = 1;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5093

## Short roundup of the initial problem
the august 2nd bloomburrow release came with an expansive oracle text errata, all instances of "enters the battlefield" have been changed to just "enters".
this impacts oracle which check the oracle text for instances of the text "cardname enters the battlefield tapped" which now is shortened to "cardname enters tapped".

## What will change with this Pull Request?
- the cipt check in oracle is replaced with a regex that accounts for this

because the mtgjson upstream has been changed it's difficult to compare if this change works as intended, we would need an old version of the mtgjson file from before august 2nd to check if the cards that this code marks cipt are now the same and how it affects performance.