### PR TITLE
CI: Update install-qt-action

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -302,7 +302,7 @@ jobs:
           submodules: recursive
 
       - name: Install Qt ${{matrix.qt_version}}
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           cache: true
           setup-python: false


### PR DESCRIPTION
Update to v4

Dependabot is not picking this one up, because a beta branch in the source repo did trigger v4 too early and we closed it.
https://github.com/Cockatrice/Cockatrice/pull/4922