### PR TITLE
Bump Cockatrice version to 2.10.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ endif()
 
 # A project name is needed for CPack
 # Version can be overriden by git tags, see cmake/getversion.cmake
-project("Cockatrice" VERSION 2.9.1)
+project("Cockatrice" VERSION 2.10.0)
 
 # Set release name if not provided via env/cmake var
 if(NOT DEFINED GIT_TAG_RELEASENAME)


### PR DESCRIPTION
Considering the age of the last release and the changes made, a bump from 2.9.0 to 2.10.0 seems reasonable for any next release.