### PR TITLE
#3945 deck list: Navigation keys (PageUp/Down, Home/End) 

### DIFF
--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -54,11 +54,11 @@ void SearchLineEdit::keyPressEvent(QKeyEvent *event)
     static const QVector<Qt::Key> forwardToTreeView = {Qt::Key_Up, Qt::Key_Down, Qt::Key_PageDown, Qt::Key_PageUp};
     // forward only if the search text is empty
     static const QVector<Qt::Key> forwardWhenEmpty = {Qt::Key_Home, Qt::Key_End};
-
+    Qt::Key key = static_cast<Qt::Key>(event->key());
     if (treeView) {
-        if (forwardToTreeView.contains(event->key()))
+        if (forwardToTreeView.contains(key))
             QCoreApplication::sendEvent(treeView, event);
-        if (text().isEmpty() && forwardWhenEmpty.contains(event->key()))
+        if (text().isEmpty() && forwardWhenEmpty.contains(key))
             QCoreApplication::sendEvent(treeView, event);
     }
     LineEditUnfocusable::keyPressEvent(event);

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -50,7 +50,10 @@
 
 void SearchLineEdit::keyPressEvent(QKeyEvent *event)
 {
-    if (treeView && ((event->key() == Qt::Key_Up) || (event->key() == Qt::Key_Down)))
+    // List of key events that must be handled by the card list instead of the search box
+    static const QVector<Qt::Key> forwardToTreeView = {Qt::Key_Up,     Qt::Key_Down, Qt::Key_PageDown,
+                                                       Qt::Key_PageUp, Qt::Key_End,  Qt::Key_Home};
+    if (treeView && forwardToTreeView.contains(event->key()))
         QCoreApplication::sendEvent(treeView, event);
     LineEditUnfocusable::keyPressEvent(event);
 }

--- a/cockatrice/src/tab_deck_editor.cpp
+++ b/cockatrice/src/tab_deck_editor.cpp
@@ -51,10 +51,16 @@
 void SearchLineEdit::keyPressEvent(QKeyEvent *event)
 {
     // List of key events that must be handled by the card list instead of the search box
-    static const QVector<Qt::Key> forwardToTreeView = {Qt::Key_Up,     Qt::Key_Down, Qt::Key_PageDown,
-                                                       Qt::Key_PageUp, Qt::Key_End,  Qt::Key_Home};
-    if (treeView && forwardToTreeView.contains(event->key()))
-        QCoreApplication::sendEvent(treeView, event);
+    static const QVector<Qt::Key> forwardToTreeView = {Qt::Key_Up, Qt::Key_Down, Qt::Key_PageDown, Qt::Key_PageUp};
+    // forward only if the search text is empty
+    static const QVector<Qt::Key> forwardWhenEmpty = {Qt::Key_Home, Qt::Key_End};
+
+    if (treeView) {
+        if (forwardToTreeView.contains(event->key()))
+            QCoreApplication::sendEvent(treeView, event);
+        if (text().isEmpty() && forwardWhenEmpty.contains(event->key()))
+            QCoreApplication::sendEvent(treeView, event);
+    }
     LineEditUnfocusable::keyPressEvent(event);
 }
 


### PR DESCRIPTION

## Related Ticket(s)
- Fixes #3945

## Short roundup of the initial problem
No navigation possible when writing in the card search text box apart from going on card up/down.

## What will change with this Pull Request?
When focusing the card list or the search text box in the deck editor:
- `PageDown`, `PageUp` scrolls one page down or up the card list respectively.
- `Home` scrolls to the top the complete list, `End` to the bottom

