### PR TITLE
fix macro shortcuts so that Ctrl+1 is not double-assigned

### DIFF
--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1037,7 +1037,7 @@ void Player::initSayMenu()
 
     for (int i = 0; i < count; ++i) {
         auto *newAction = new QAction(SettingsCache::instance().messages().getMessageAt(i), this);
-        if (i <= 10) {
+        if (i < 10) {
             newAction->setShortcut(QKeySequence("Ctrl+" + QString::number((i + 1) % 10)));
         }
         connect(newAction, SIGNAL(triggered()), this, SLOT(actSayMessage()));


### PR DESCRIPTION
## Related Ticket(s)
- No related tickets

## Short roundup of the initial problem
In the menu Cockatrice > Settings > Chat, you can add In-game message macros. The first several macros are automatically assigned to the shortcuts Ctrl+1 to Ctrl+0. When more than 10 macros are added, Ctrl+1 does not send a message associated to any macro. 

## What will change with this Pull Request?
- When more than 10 macros are added, Ctrl+1 will now send the message associated with the first macro in the list. 
