### PR TITLE
In-game message macros available immediately in active games

### DIFF
--- a/cockatrice/src/dlg_settings.cpp
+++ b/cockatrice/src/dlg_settings.cpp
@@ -1001,6 +1001,7 @@ void MessagesSettingsPage::storeSettings()
     SettingsCache::instance().messages().setCount(messageList->count());
     for (int i = 0; i < messageList->count(); i++)
         SettingsCache::instance().messages().setMessageAt(i, messageList->item(i)->text());
+    emit SettingsCache::instance().messages().messageMacrosChanged();
 }
 
 void MessagesSettingsPage::actAdd()

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -419,6 +419,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
 
     if (local) {
         sayMenu = playerMenu->addMenu(QString());
+        connect(&SettingsCache::instance().messages(), SIGNAL(messageMacrosChanged()), this, SLOT(initSayMenu()));
         initSayMenu();
     }
 

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -1037,7 +1037,7 @@ void Player::initSayMenu()
     sayMenu->setEnabled(count > 0);
 
     for (int i = 0; i < count; ++i) {
-        auto *newAction = new QAction(SettingsCache::instance().messages().getMessageAt(i), this);
+        auto *newAction = new QAction(SettingsCache::instance().messages().getMessageAt(i), sayMenu);
         if (i < 10) {
             newAction->setShortcut(QKeySequence("Ctrl+" + QString::number((i + 1) % 10)));
         }

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -223,7 +223,7 @@ private slots:
     void actPlayFacedown();
     void actReveal(QAction *action);
     void refreshShortcuts();
-    
+
     void initSayMenu();
 
 private:

--- a/cockatrice/src/player.h
+++ b/cockatrice/src/player.h
@@ -223,6 +223,8 @@ private slots:
     void actPlayFacedown();
     void actReveal(QAction *action);
     void refreshShortcuts();
+    
+    void initSayMenu();
 
 private:
     TabGame *game;
@@ -310,7 +312,6 @@ private:
     QMap<int, ArrowItem *> arrows;
     void rearrangeCounters();
 
-    void initSayMenu();
     void initContextualPlayersMenu(QMenu *menu);
 
     // void eventConnectionStateChanged(const Event_ConnectionStateChanged &event);

--- a/cockatrice/src/settings/messagesettings.h
+++ b/cockatrice/src/settings/messagesettings.h
@@ -15,6 +15,7 @@ public:
     void setCount(int count);
     void setMessageAt(int index, QString message);
 signals:
+    void messageMacrosChanged();
 
 public slots:
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4166 

## Short roundup of the initial problem
- Previously, changes made to in-game message macros were not made available in any in-progress games.

## What will change with this Pull Request?
- When users modify the in-game message macros, these changes will now apply immediately to any in-progress games games. 
