### PR TITLE
CI: Fix logic in translation action after dependency update

### DIFF
--- a/.github/workflows/translations-pull.yml
+++ b/.github/workflows/translations-pull.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           STATUS: ${{ steps.create_pr.outputs.pull-request-operation }}
         run: |
-          if [[ "$STATUS" == "" ]]; then
+          if [[ "$STATUS" == "none" ]]; then
             echo "PR #${{ steps.create_pr.outputs.pull-request-number }} unchanged!" >> $GITHUB_STEP_SUMMARY
           else
             echo "PR #${{ steps.create_pr.outputs.pull-request-number }} $STATUS!" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/translations-push.yml
+++ b/.github/workflows/translations-push.yml
@@ -79,7 +79,7 @@ jobs:
         env:
           STATUS: ${{ steps.create_pr.outputs.pull-request-operation }}
         run: |
-          if [[ "$STATUS" == "" ]]; then
+          if [[ "$STATUS" == "none" ]]; then
             echo "PR #${{ steps.create_pr.outputs.pull-request-number }} unchanged!" >> $GITHUB_STEP_SUMMARY
           else
             echo "PR #${{ steps.create_pr.outputs.pull-request-number }} $STATUS!" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Related Ticket(s)
- Related #5110

## Short roundup of the initial problem
v7 of the action introduces a new output when no operation did happen.
Our logic was based on an empty output before.

From the [changelog](https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.0):
>The `pull-request-operation` output now returns `none` when no operation was executed.

## What will change with this Pull Request?
- Check for `none` instead `""`

