### PR TITLE
Follow symlinks when iterating through the custom image folder

### DIFF
--- a/cockatrice/src/pictureloader.cpp
+++ b/cockatrice/src/pictureloader.cpp
@@ -190,7 +190,7 @@ bool PictureLoaderWorker::cardImageExistsOnDisk(QString &setName, QString &corre
     QImageReader imgReader;
     imgReader.setDecideFormatFromContent(true);
     QList<QString> picsPaths = QList<QString>();
-    QDirIterator it(customPicsPath, QDirIterator::Subdirectories);
+    QDirIterator it(customPicsPath, QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
 
     // Recursively check all subdirectories of the CUSTOM folder
     while (it.hasNext()) {


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5125 

## Short roundup of the initial problem
Cockatrice currently does not traverse symlinked directories when looking for card images in the custom image folder (`pics/CUSTOM`).

This is because the `QDirIterator` responsible for iterating through the custom image folder is missing the [`QDirIterator::FollowSymlinks`](https://doc.qt.io/qt-6/qdiriterator.html#IteratorFlag-enum) flag, meaning it will not recursively traverse symlinked directories.

## What will change with this Pull Request?
Added the `FollowSymlinks` flag to the `QDirIterator`. This fixes the bug.

## Screenshots
Custom card image is located inside a symlinked directory inside pics/CUSTOM
<img width="806" alt="Screenshot 2024-10-10 at 12 39 57 AM" src="https://github.com/user-attachments/assets/895137e4-2712-45ec-a9b6-7f976cdff308">
...and cockatrice successfully loads the image for that card!
<img width="1000" alt="Screenshot 2024-10-10 at 12 40 21 AM" src="https://github.com/user-attachments/assets/c2cde0f1-110c-483c-bf85-8e13d213ac6e">


