### PR TITLE
Consolidate play/pause buttons in replays

### DIFF
--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -601,16 +601,13 @@ void TabGame::replayNextEvent()
 void TabGame::replayFinished()
 {
     replayPlayButton->setChecked(false);
-    replayFastForwardButton->setEnabled(false);
 }
 
 void TabGame::replayPlayButtonToggled(bool checked)
 {
     if (checked) { // start replay
-        replayFastForwardButton->setEnabled(true);
         timelineWidget->startReplay();
     } else { // pause replay
-        replayFastForwardButton->setEnabled(false);
         timelineWidget->stopReplay();
     }
 }
@@ -1713,7 +1710,6 @@ void TabGame::createReplayDock()
     
     replayFastForwardButton = new QToolButton;
     replayFastForwardButton->setIconSize(QSize(32, 32));
-    replayFastForwardButton->setEnabled(false);
     replayFastForwardButton->setIcon(QPixmap("theme:replay/fastforward"));
     replayFastForwardButton->setCheckable(true);
     connect(replayFastForwardButton, SIGNAL(toggled(bool)), this, SLOT(replayFastForwardButtonToggled(bool)));

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -1707,7 +1707,7 @@ void TabGame::createReplayDock()
     replayPlayButton->setIcon(playButtonIcon);
     replayPlayButton->setCheckable(true);
     connect(replayPlayButton, SIGNAL(toggled(bool)), this, SLOT(replayPlayButtonToggled(bool)));
-    
+
     replayFastForwardButton = new QToolButton;
     replayFastForwardButton->setIconSize(QSize(32, 32));
     replayFastForwardButton->setIcon(QPixmap("theme:replay/fastforward"));

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -600,27 +600,19 @@ void TabGame::replayNextEvent()
 
 void TabGame::replayFinished()
 {
-    replayStartButton->setEnabled(true);
-    replayPauseButton->setEnabled(false);
+    replayPlayButton->setChecked(false);
     replayFastForwardButton->setEnabled(false);
 }
 
-void TabGame::replayStartButtonClicked()
+void TabGame::replayPlayButtonToggled(bool checked)
 {
-    replayStartButton->setEnabled(false);
-    replayPauseButton->setEnabled(true);
-    replayFastForwardButton->setEnabled(true);
-
-    timelineWidget->startReplay();
-}
-
-void TabGame::replayPauseButtonClicked()
-{
-    replayStartButton->setEnabled(true);
-    replayPauseButton->setEnabled(false);
-    replayFastForwardButton->setEnabled(false);
-
-    timelineWidget->stopReplay();
+    if (checked) { // start replay
+        replayFastForwardButton->setEnabled(true);
+        timelineWidget->startReplay();
+    } else { // pause replay
+        replayFastForwardButton->setEnabled(false);
+        timelineWidget->stopReplay();
+    }
 }
 
 void TabGame::replayFastForwardButtonToggled(bool checked)
@@ -1710,15 +1702,15 @@ void TabGame::createReplayDock()
     connect(timelineWidget, SIGNAL(replayFinished()), this, SLOT(replayFinished()));
     connect(timelineWidget, &ReplayTimelineWidget::rewound, messageLog, &ChatView::clearChat);
 
-    replayStartButton = new QToolButton;
-    replayStartButton->setIconSize(QSize(32, 32));
-    replayStartButton->setIcon(QPixmap("theme:replay/start"));
-    connect(replayStartButton, SIGNAL(clicked()), this, SLOT(replayStartButtonClicked()));
-    replayPauseButton = new QToolButton;
-    replayPauseButton->setIconSize(QSize(32, 32));
-    replayPauseButton->setEnabled(false);
-    replayPauseButton->setIcon(QPixmap("theme:replay/pause"));
-    connect(replayPauseButton, SIGNAL(clicked()), this, SLOT(replayPauseButtonClicked()));
+    replayPlayButton = new QToolButton;
+    replayPlayButton->setIconSize(QSize(32, 32));
+    QIcon playButtonIcon = QIcon();
+    playButtonIcon.addPixmap(QPixmap("theme:replay/start"), QIcon::Normal, QIcon::Off);
+    playButtonIcon.addPixmap(QPixmap("theme:replay/pause"), QIcon::Normal, QIcon::On);
+    replayPlayButton->setIcon(playButtonIcon);
+    replayPlayButton->setCheckable(true);
+    connect(replayPlayButton, SIGNAL(toggled(bool)), this, SLOT(replayPlayButtonToggled(bool)));
+    
     replayFastForwardButton = new QToolButton;
     replayFastForwardButton->setIconSize(QSize(32, 32));
     replayFastForwardButton->setEnabled(false);
@@ -1728,8 +1720,7 @@ void TabGame::createReplayDock()
 
     replayControlLayout = new QHBoxLayout;
     replayControlLayout->addWidget(timelineWidget, 10);
-    replayControlLayout->addWidget(replayStartButton);
-    replayControlLayout->addWidget(replayPauseButton);
+    replayControlLayout->addWidget(replayPlayButton);
     replayControlLayout->addWidget(replayFastForwardButton);
 
     replayControlWidget = new QWidget();

--- a/cockatrice/src/tab_game.h
+++ b/cockatrice/src/tab_game.h
@@ -146,7 +146,7 @@ private:
     int currentReplayStep;
     QList<int> replayTimeline;
     ReplayTimelineWidget *timelineWidget;
-    QToolButton *replayStartButton, *replayPauseButton, *replayFastForwardButton;
+    QToolButton *replayPlayButton, *replayFastForwardButton;
 
     CardFrame *cardInfo;
     PlayerListWidget *playerListWidget;
@@ -220,8 +220,7 @@ signals:
 private slots:
     void replayNextEvent();
     void replayFinished();
-    void replayStartButtonClicked();
-    void replayPauseButtonClicked();
+    void replayPlayButtonToggled(bool checked);
     void replayFastForwardButtonToggled(bool checked);
 
     void incrementGameTime();


### PR DESCRIPTION
## Related Ticket(s)
- fixes #1661

## Short roundup of the initial problem
quoting from the issue,
> Since a replay can never being playing and paused at the same time, the Play and Pause buttons should be consolidated into one button (Play/Pause) whose image changes depending on the state.

## What will change with this Pull Request?
- The start and pause buttons are now a single button that toggles when you click it.
- While paused, the button displays the play icon; while unpaused, the button displays the pause icon
  - I could see it being the other way around too. Let me know what you think.

<img width="1435" alt="Screenshot 2024-10-15 at 10 39 26 PM" src="https://github.com/user-attachments/assets/46e10769-6521-4fdf-995e-19fd59ee235a">
<img width="1433" alt="Screenshot 2024-10-15 at 10 39 12 PM" src="https://github.com/user-attachments/assets/0030705b-7efc-434e-805f-a53359e9e078">

**Known issues:** The play button is still darkened when in the playing state. Ideally, the play button shouldn't change color when clicked, since we are changing the icon to indicate state. However, I spent two days on it and still can't figure out how to get it to not change. Hopefully someone who's better at Qt than me can come along in the future and fix it.

- I also made it so the fast forward button is always interactable. 
  - It made no sense to me why pausing would disable interaction with the fast-forward button, because if you pause while fast-forward is active, the fast-forward is still active after unpausing.
<img width="194" alt="Screenshot 2024-10-15 at 10 40 08 PM" src="https://github.com/user-attachments/assets/859beb29-19f2-4a38-989d-fddba211b589">
<img width="158" alt="Screenshot 2024-10-15 at 10 43 25 PM" src="https://github.com/user-attachments/assets/b3d809cd-cb28-4489-a497-0a594c51692d">

<img width="196" alt="Screenshot 2024-10-15 at 10 40 14 PM" src="https://github.com/user-attachments/assets/3127dac8-357d-4756-9a8e-590e5539e8d1">
<img width="167" alt="Screenshot 2024-10-15 at 10 40 18 PM" src="https://github.com/user-attachments/assets/3d2d860a-bf4f-4437-9822-80694ef2747a">
