### PR TITLE
Fix weird bug when selecting folder for custom card arts

### DIFF
--- a/cockatrice/src/settingscache.cpp
+++ b/cockatrice/src/settingscache.cpp
@@ -412,7 +412,11 @@ void SettingsCache::setPicsPath(const QString &_picsPath)
     picsPath = _picsPath;
     settings->setValue("paths/pics", picsPath);
     // get a new value for customPicsPath, currently derived from picsPath
-    customPicsPath = getSafeConfigPath("paths/custompics", picsPath + "CUSTOM/");
+    if (picsPath.endsWith("/")) {
+        customPicsPath = getSafeConfigPath("paths/custompics", picsPath + "CUSTOM/");
+    } else {
+        customPicsPath = getSafeConfigPath("paths/custompics", picsPath + "/CUSTOM/");
+    }
     emit picsPathChanged();
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5132 

## What will change with this Pull Request?
settingscache will now correctly put a `/` between the `picsPath` and `"CUSTOM"`.

---
Looks like settingcache already checked trailing slashes correctly in
https://github.com/Cockatrice/Cockatrice/blob/038ce3dcece00dabebfb1ec59b8d14972445ffc3/cockatrice/src/settingscache.cpp#L1023-L1027

but didn't check in the other place lol.