### PR TITLE
Add keyboard shortcuts for replays

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -1713,6 +1713,7 @@ void TabGame::createReplayDock()
     replayFastForwardButton->setIconSize(QSize(32, 32));
     replayFastForwardButton->setIcon(QPixmap("theme:replay/fastforward"));
     replayFastForwardButton->setCheckable(true);
+    replayFastForwardButton->setShortcut(Qt::CTRL | Qt::Key_Right);
     connect(replayFastForwardButton, SIGNAL(toggled(bool)), this, SLOT(replayFastForwardButtonToggled(bool)));
 
     replayControlLayout = new QHBoxLayout;

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -1706,6 +1706,7 @@ void TabGame::createReplayDock()
     playButtonIcon.addPixmap(QPixmap("theme:replay/pause"), QIcon::Normal, QIcon::On);
     replayPlayButton->setIcon(playButtonIcon);
     replayPlayButton->setCheckable(true);
+    replayPlayButton->setShortcut(Qt::Key_Space);
     connect(replayPlayButton, SIGNAL(toggled(bool)), this, SLOT(replayPlayButtonToggled(bool)));
 
     replayFastForwardButton = new QToolButton;

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -257,6 +257,12 @@ void TabGame::refreshShortcuts()
     if (aFocusChat) {
         aFocusChat->setShortcuts(shortcuts.getShortcut("tab_game/aFocusChat"));
     }
+    if (replayPlayButton) {
+        replayPlayButton->setShortcut(shortcuts.getSingleShortcut("Replays/playButton"));
+    }
+    if (replayFastForwardButton) {
+        replayFastForwardButton->setShortcut(shortcuts.getSingleShortcut("Replays/fastForwardButton"));
+    }
 }
 
 void DeckViewContainer::loadLocalDeck()
@@ -1706,14 +1712,12 @@ void TabGame::createReplayDock()
     playButtonIcon.addPixmap(QPixmap("theme:replay/pause"), QIcon::Normal, QIcon::On);
     replayPlayButton->setIcon(playButtonIcon);
     replayPlayButton->setCheckable(true);
-    replayPlayButton->setShortcut(Qt::Key_Space);
     connect(replayPlayButton, SIGNAL(toggled(bool)), this, SLOT(replayPlayButtonToggled(bool)));
 
     replayFastForwardButton = new QToolButton;
     replayFastForwardButton->setIconSize(QSize(32, 32));
     replayFastForwardButton->setIcon(QPixmap("theme:replay/fastforward"));
     replayFastForwardButton->setCheckable(true);
-    replayFastForwardButton->setShortcut(Qt::CTRL | Qt::Key_Right);
     connect(replayFastForwardButton, SIGNAL(toggled(bool)), this, SLOT(replayFastForwardButtonToggled(bool)));
 
     replayControlLayout = new QHBoxLayout;

--- a/cockatrice/src/settings/shortcuts_settings.h
+++ b/cockatrice/src/settings/shortcuts_settings.h
@@ -591,11 +591,11 @@ private:
                                                                parseSequenceString("F5"),
                                                                ShortcutGroup::Load_deck)},
         {"Replays/playButton", ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Play/Pause"),
-                                         parseSequenceString("Space"),
-                                         ShortcutGroup::Replays)},
+                                           parseSequenceString("Space"),
+                                           ShortcutGroup::Replays)},
         {"Replays/fastForwardButton", ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Toggle Fast Forward"),
-                                         parseSequenceString("Ctrl+Right"),
-                                         ShortcutGroup::Replays)}};
+                                                  parseSequenceString("Ctrl+Right"),
+                                                  ShortcutGroup::Replays)}};
 };
 
 #endif // SHORTCUTSSETTINGS_H

--- a/cockatrice/src/settings/shortcuts_settings.h
+++ b/cockatrice/src/settings/shortcuts_settings.h
@@ -28,7 +28,8 @@ public:
         Drawing,
         Chat_room,
         Game_window,
-        Load_deck
+        Load_deck,
+        Replays
     };
 
     static QString getGroupName(ShortcutGroup::Groups group)
@@ -68,6 +69,8 @@ public:
                 return QApplication::translate("shortcutsTab", "Game Window");
             case Load_deck:
                 return QApplication::translate("shortcutsTab", "Load Deck from Clipboard");
+            case Replays:
+                return QApplication::translate("shortcutsTab", "Replays");
         }
 
         return {};
@@ -586,7 +589,13 @@ private:
                                             ShortcutGroup::Game_window)},
         {"DlgLoadDeckFromClipboard/refreshButton", ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Refresh"),
                                                                parseSequenceString("F5"),
-                                                               ShortcutGroup::Load_deck)}};
+                                                               ShortcutGroup::Load_deck)},
+        {"Replays/playButton", ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Play/Pause"),
+                                         parseSequenceString("Space"),
+                                         ShortcutGroup::Replays)},
+        {"Replays/fastForwardButton", ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Toggle Fast Forward"),
+                                         parseSequenceString("Ctrl+Right"),
+                                         ShortcutGroup::Replays)}};
 };
 
 #endif // SHORTCUTSSETTINGS_H


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1536 

## What will change with this Pull Request?
- `space` now toggles play/pause
- `Ctrl+ -->` (or the OS equivalent) now toggles fast-forward