### PR TITLE
Buffer rewinds from backward skips in replays

### DIFF
--- a/cockatrice/src/client/network/replay_timeline_widget.cpp
+++ b/cockatrice/src/client/network/replay_timeline_widget.cpp
@@ -118,8 +118,8 @@ void ReplayTimelineWidget::handleBackwardsSkip(bool doRewindBuffering)
 /// The timeout scales based on the current event number, up to a limit
 int ReplayTimelineWidget::calcRewindBufferingTimeout() const
 {
-    int extraTime = std::min(currentEvent / 100, 100);
-    return BASE_REWIND_BUFFERING_TIMEOUT_MS + extraTime;
+    int extraTime = currentEvent / 100;
+    return std::min(BASE_REWIND_BUFFERING_TIMEOUT_MS + extraTime, MAX_REWIND_BUFFERING_TIMEOUT_MS);
 }
 
 void ReplayTimelineWidget::processRewind()

--- a/cockatrice/src/client/network/replay_timeline_widget.cpp
+++ b/cockatrice/src/client/network/replay_timeline_widget.cpp
@@ -82,12 +82,11 @@ void ReplayTimelineWidget::skipToTime(int newTime)
 
     newTime -= newTime % 200; // Time should always be a multiple of 200
     if (newTime < currentTime) {
-        currentTime = 0;
         currentEvent = 0;
         emit rewound();
     }
-    currentTime = newTime - 200; // 200 is added back in replayTimerTimeout
-    replayTimerTimeout();
+    currentTime = newTime;
+    processNewEvents();
     update();
 }
 
@@ -104,6 +103,16 @@ QSize ReplayTimelineWidget::minimumSizeHint() const
 void ReplayTimelineWidget::replayTimerTimeout()
 {
     currentTime += 200;
+
+    processNewEvents();
+
+    if (!(currentTime % 1000))
+        update();
+}
+
+/// Processes all unprocessed events up to the current time.
+void ReplayTimelineWidget::processNewEvents()
+{
     while ((currentEvent < replayTimeline.size()) && (replayTimeline[currentEvent] < currentTime)) {
         emit processNextEvent();
         ++currentEvent;
@@ -112,9 +121,6 @@ void ReplayTimelineWidget::replayTimerTimeout()
         emit replayFinished();
         replayTimer->stop();
     }
-
-    if (!(currentTime % 1000))
-        update();
 }
 
 void ReplayTimelineWidget::setTimeScaleFactor(qreal _timeScaleFactor)

--- a/cockatrice/src/client/network/replay_timeline_widget.cpp
+++ b/cockatrice/src/client/network/replay_timeline_widget.cpp
@@ -99,12 +99,14 @@ void ReplayTimelineWidget::skipToTime(int newTime, bool doRewindBuffering)
 /// is processed at the end. When false, the backwards skip will always cause an immediate rewind
 void ReplayTimelineWidget::handleBackwardsSkip(bool doRewindBuffering)
 {
-    if (doRewindBuffering && rewindBufferingTimer && rewindBufferingTimer->isActive()) {
+    if (doRewindBuffering) {
         // We use a one-shot timer to implement the rewind buffering.
         // The rewind only happens once the timer runs out.
         // If a backwards skip happens while the timer is already running, we just reset the timer instead of rewinding.
-        rewindBufferingTimer->stop();
-        rewindBufferingTimer->deleteLater();
+        if (rewindBufferingTimer) {
+            rewindBufferingTimer->stop();
+            rewindBufferingTimer->deleteLater();
+        }
 
         rewindBufferingTimer = new QTimer(this);
         rewindBufferingTimer->setSingleShot(true);
@@ -128,11 +130,6 @@ void ReplayTimelineWidget::processRewind()
     currentEvent = 0;
     emit rewound();
     processNewEvents();
-
-    // then start a new dummy timer to buffer any rewinds that happen too quickly afterwards
-    rewindBufferingTimer = new QTimer(this);
-    rewindBufferingTimer->setSingleShot(true);
-    rewindBufferingTimer->start(REWIND_BUFFERING_TIMEOUT_MS);
 }
 
 QSize ReplayTimelineWidget::sizeHint() const

--- a/cockatrice/src/client/network/replay_timeline_widget.cpp
+++ b/cockatrice/src/client/network/replay_timeline_widget.cpp
@@ -130,6 +130,9 @@ void ReplayTimelineWidget::processRewind()
     currentEvent = 0;
     emit rewound();
     processNewEvents();
+
+    // create a dummy timer here because otherwise it segfaults for some reason
+    rewindBufferingTimer = new QTimer(this);
 }
 
 QSize ReplayTimelineWidget::sizeHint() const

--- a/cockatrice/src/client/network/replay_timeline_widget.cpp
+++ b/cockatrice/src/client/network/replay_timeline_widget.cpp
@@ -108,11 +108,18 @@ void ReplayTimelineWidget::handleBackwardsSkip(bool doRewindBuffering)
         // The rewind only happens once the timer runs out.
         // If another backwards skip happens, the timer will just get reset instead of rewinding.
         rewindBufferingTimer->stop();
-        rewindBufferingTimer->start(REWIND_BUFFERING_TIMEOUT_MS);
+        rewindBufferingTimer->start(calcRewindBufferingTimeout());
     } else {
         // otherwise, process the rewind immediately
         processRewind();
     }
+}
+
+/// The timeout scales based on the current event number, up to a limit
+int ReplayTimelineWidget::calcRewindBufferingTimeout() const
+{
+    int extraTime = std::min(currentEvent / 100, 100);
+    return BASE_REWIND_BUFFERING_TIMEOUT_MS + extraTime;
 }
 
 void ReplayTimelineWidget::processRewind()

--- a/cockatrice/src/client/network/replay_timeline_widget.h
+++ b/cockatrice/src/client/network/replay_timeline_widget.h
@@ -18,6 +18,8 @@ signals:
 
 private:
     QTimer *replayTimer;
+    static const int REWIND_THROTTLE_TIMEOUT_MS = 180;
+    QTimer *rewindThrottlingTimer;
     QList<int> replayTimeline;
     QList<int> histogram;
     static const int binLength;
@@ -27,6 +29,8 @@ private:
     int currentEvent;
 
     void skipToTime(int newTime);
+    void handleBackwardsSkip();
+    void processRewind();
     void processNewEvents();
 private slots:
     void replayTimerTimeout();

--- a/cockatrice/src/client/network/replay_timeline_widget.h
+++ b/cockatrice/src/client/network/replay_timeline_widget.h
@@ -18,8 +18,8 @@ signals:
 
 private:
     QTimer *replayTimer;
-    static const int REWIND_THROTTLE_TIMEOUT_MS = 180;
-    QTimer *rewindThrottlingTimer;
+    static const int REWIND_BUFFERING_TIMEOUT_MS = 180;
+    QTimer *rewindBufferingTimer;
     QList<int> replayTimeline;
     QList<int> histogram;
     static const int binLength;
@@ -28,8 +28,8 @@ private:
     int currentTime;
     int currentEvent;
 
-    void skipToTime(int newTime, bool doRewindThrottling);
-    void handleBackwardsSkip(bool doRewindThrottling);
+    void skipToTime(int newTime, bool doRewindBuffering);
+    void handleBackwardsSkip(bool doRewindBuffering);
     void processRewind();
     void processNewEvents();
 private slots:

--- a/cockatrice/src/client/network/replay_timeline_widget.h
+++ b/cockatrice/src/client/network/replay_timeline_widget.h
@@ -27,6 +27,7 @@ private:
     int currentEvent;
 
     void skipToTime(int newTime);
+    void processNewEvents();
 private slots:
     void replayTimerTimeout();
 

--- a/cockatrice/src/client/network/replay_timeline_widget.h
+++ b/cockatrice/src/client/network/replay_timeline_widget.h
@@ -28,8 +28,8 @@ private:
     int currentTime;
     int currentEvent;
 
-    void skipToTime(int newTime);
-    void handleBackwardsSkip();
+    void skipToTime(int newTime, bool doRewindThrottling);
+    void handleBackwardsSkip(bool doRewindThrottling);
     void processRewind();
     void processNewEvents();
 private slots:

--- a/cockatrice/src/client/network/replay_timeline_widget.h
+++ b/cockatrice/src/client/network/replay_timeline_widget.h
@@ -18,7 +18,7 @@ signals:
 
 private:
     QTimer *replayTimer;
-    static const int REWIND_BUFFERING_TIMEOUT_MS = 180;
+    static const int BASE_REWIND_BUFFERING_TIMEOUT_MS = 180;
     QTimer *rewindBufferingTimer;
     QList<int> replayTimeline;
     QList<int> histogram;
@@ -30,6 +30,7 @@ private:
 
     void skipToTime(int newTime, bool doRewindBuffering);
     void handleBackwardsSkip(bool doRewindBuffering);
+    int calcRewindBufferingTimeout() const;
     void processRewind();
     void processNewEvents();
 private slots:

--- a/cockatrice/src/client/network/replay_timeline_widget.h
+++ b/cockatrice/src/client/network/replay_timeline_widget.h
@@ -19,6 +19,7 @@ signals:
 private:
     QTimer *replayTimer;
     static const int BASE_REWIND_BUFFERING_TIMEOUT_MS = 180;
+    static const int MAX_REWIND_BUFFERING_TIMEOUT_MS = 280;
     QTimer *rewindBufferingTimer;
     QList<int> replayTimeline;
     QList<int> histogram;

--- a/cockatrice/src/client/network/replay_timeline_widget.h
+++ b/cockatrice/src/client/network/replay_timeline_widget.h
@@ -18,8 +18,8 @@ signals:
 
 private:
     QTimer *replayTimer;
-    static const int BASE_REWIND_BUFFERING_TIMEOUT_MS = 180;
-    static const int MAX_REWIND_BUFFERING_TIMEOUT_MS = 280;
+    static constexpr int BASE_REWIND_BUFFERING_TIMEOUT_MS = 180;
+    static constexpr int MAX_REWIND_BUFFERING_TIMEOUT_MS = 280;
     QTimer *rewindBufferingTimer;
     QList<int> replayTimeline;
     QList<int> histogram;


### PR DESCRIPTION
## Related Ticket(s)
- Follow up to #5140

## Short roundup of the initial problem
While viewing a replay, you may want to hold down `Left` in order to continually back up in the timeline. However, this results in a lot of small backwards skips in succession. Every single one of those backward skips will force cockatrice to do a rewind, wasting a lot of processing. 

@ebbit1q suggested making cockatrice wait a bit after each backwards skip to make sure there isn't any more backwards skips coming in quick succession, before processing the rewind.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/aeb4d89f-f837-46a2-8a29-531f5887d3d4

When a backwards skip is caused by a keyboard shortcut, we don't process the new board state immediately. Instead, we start a one-shot timer. The rewind and reprocessing will be triggered by the timer finishing. If a timer was already going, then we just restart the timer instead of doing anything else. 

This makes it so the new board state isn't processed until the flurry of backward skips concludes, saving on the number of rewind and reprocess operations.

Backward skips caused by clicks aren't buffered and will still always cause a rewind. Clicks usually don't happen fast enough for buffering to be necessary. I'd rather that the responsiveness of clicks don't change.

`REWIND_BUFFERING_TIMEOUT_MS` wants to be set to a value that's low enough to where it still feels responsive if you're just doing a one-off key press, but high enough for the buffering to take effect in most scenarios where the user is holding or spamming the left key. Currently, I've just set it to a value that felt good enough to me, but it's entirely debatable as to what the final value should be.

Also cleaned up the `ReplayTimelineWidget` class as part of implementing this.