### PR TITLE
Add option to open deck in new tab by default

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/tab_deck_editor.h
@@ -164,6 +164,7 @@ public:
 public slots:
     void closeRequest() override;
 signals:
+    void openDeckEditor(const DeckLoader *deckLoader);
     void deckEditorClosing(TabDeckEditor *tab);
 };
 

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -496,6 +496,7 @@ TabDeckEditor *TabSupervisor::addDeckEditorTab(const DeckLoader *deckToOpen)
     if (deckToOpen)
         tab->setDeck(new DeckLoader(*deckToOpen));
     connect(tab, SIGNAL(deckEditorClosing(TabDeckEditor *)), this, SLOT(deckEditorClosed(TabDeckEditor *)));
+    connect(tab, SIGNAL(openDeckEditor(const DeckLoader *)), this, SLOT(addDeckEditorTab(const DeckLoader *)));
     int tabIndex = myAddTab(tab);
     addCloseButtonToTab(tab, tabIndex);
     deckEditorTabs.append(tab);

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -502,11 +502,23 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     animationGroupBox = new QGroupBox;
     animationGroupBox->setLayout(animationGrid);
 
+    // deck editor settings
+    openDeckInNewTabCheckBox.setChecked(SettingsCache::instance().getOpenDeckInNewTab());
+    connect(&openDeckInNewTabCheckBox, SIGNAL(QT_STATE_CHANGED(QT_STATE_CHANGED_T)), &SettingsCache::instance(),
+            SLOT(setOpenDeckInNewTab(QT_STATE_CHANGED_T)));
+
+    auto *deckEditorGrid = new QGridLayout;
+    deckEditorGrid->addWidget(&openDeckInNewTabCheckBox, 0, 0);
+
+    deckEditorGroupBox = new QGroupBox;
+    deckEditorGroupBox->setLayout(deckEditorGrid);
+
     // putting it all together
     auto *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(generalGroupBox);
     mainLayout->addWidget(notificationsGroupBox);
     mainLayout->addWidget(animationGroupBox);
+    mainLayout->addWidget(deckEditorGroupBox);
     mainLayout->addStretch();
 
     setLayout(mainLayout);
@@ -535,6 +547,8 @@ void UserInterfaceSettingsPage::retranslateUi()
     buddyConnectNotificationsEnabledCheckBox.setText(tr("Notify in the taskbar when users in your buddy list connect"));
     animationGroupBox->setTitle(tr("Animation settings"));
     tapAnimationCheckBox.setText(tr("&Tap/untap animation"));
+    deckEditorGroupBox->setTitle(tr("Deck editor settings"));
+    openDeckInNewTabCheckBox.setText(tr("Always open deck in new tab"));
 }
 
 DeckEditorSettingsPage::DeckEditorSettingsPage()

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -440,6 +440,7 @@ void AppearanceSettingsPage::retranslateUi()
 
 UserInterfaceSettingsPage::UserInterfaceSettingsPage()
 {
+    // general settings and notification settings
     notificationsEnabledCheckBox.setChecked(SettingsCache::instance().getNotificationsEnabled());
     connect(&notificationsEnabledCheckBox, SIGNAL(QT_STATE_CHANGED(QT_STATE_CHANGED_T)), &SettingsCache::instance(),
             SLOT(setNotificationsEnabled(QT_STATE_CHANGED_T)));
@@ -490,6 +491,7 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     notificationsGroupBox = new QGroupBox;
     notificationsGroupBox->setLayout(notificationsGrid);
 
+    // animation settings
     tapAnimationCheckBox.setChecked(SettingsCache::instance().getTapAnimation());
     connect(&tapAnimationCheckBox, SIGNAL(QT_STATE_CHANGED(QT_STATE_CHANGED_T)), &SettingsCache::instance(),
             SLOT(setTapAnimation(QT_STATE_CHANGED_T)));
@@ -500,6 +502,7 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     animationGroupBox = new QGroupBox;
     animationGroupBox->setLayout(animationGrid);
 
+    // putting it all together
     auto *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(generalGroupBox);
     mainLayout->addWidget(notificationsGroupBox);

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -124,9 +124,11 @@ private:
     QCheckBox annotateTokensCheckBox;
     QCheckBox useTearOffMenusCheckBox;
     QCheckBox tapAnimationCheckBox;
+    QCheckBox openDeckInNewTabCheckBox;
     QGroupBox *generalGroupBox;
     QGroupBox *notificationsGroupBox;
     QGroupBox *animationGroupBox;
+    QGroupBox *deckEditorGroupBox;
 
 public:
     UserInterfaceSettingsPage();

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -541,7 +541,7 @@ void SettingsCache::setTapAnimation(QT_STATE_CHANGED_T _tapAnimation)
 void SettingsCache::setOpenDeckInNewTab(QT_STATE_CHANGED_T _openDeckInNewTab)
 {
     openDeckInNewTab = static_cast<bool>(_openDeckInNewTab);
-    settings->setValue("editor/openDeckInNewTab", _openDeckInNewTab);
+    settings->setValue("editor/openDeckInNewTab", openDeckInNewTab);
 }
 
 void SettingsCache::setChatMention(QT_STATE_CHANGED_T _chatMention)

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -243,7 +243,7 @@ SettingsCache::SettingsCache()
     invertVerticalCoordinate = settings->value("table/invert_vertical", false).toBool();
     minPlayersForMultiColumnLayout = settings->value("interface/min_players_multicolumn", 4).toInt();
     tapAnimation = settings->value("cards/tapanimation", true).toBool();
-    openDeckInNewTab = settings->value("editor/open_deck_in_new_tab", true).toBool();
+    openDeckInNewTab = settings->value("editor/openDeckInNewTab", true).toBool();
     chatMention = settings->value("chat/mention", true).toBool();
     chatMentionCompleter = settings->value("chat/mentioncompleter", true).toBool();
     chatMentionForeground = settings->value("chat/mentionforeground", true).toBool();
@@ -541,7 +541,7 @@ void SettingsCache::setTapAnimation(QT_STATE_CHANGED_T _tapAnimation)
 void SettingsCache::setOpenDeckInNewTab(QT_STATE_CHANGED_T _openDeckInNewTab)
 {
     openDeckInNewTab = static_cast<bool>(_openDeckInNewTab);
-    settings->setValue("editor/open_deck_in_new_tab", _openDeckInNewTab);
+    settings->setValue("editor/openDeckInNewTab", _openDeckInNewTab);
 }
 
 void SettingsCache::setChatMention(QT_STATE_CHANGED_T _chatMention)

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -243,6 +243,7 @@ SettingsCache::SettingsCache()
     invertVerticalCoordinate = settings->value("table/invert_vertical", false).toBool();
     minPlayersForMultiColumnLayout = settings->value("interface/min_players_multicolumn", 4).toInt();
     tapAnimation = settings->value("cards/tapanimation", true).toBool();
+    openDeckInNewTab = settings->value("editor/open_deck_in_new_tab", true).toBool();
     chatMention = settings->value("chat/mention", true).toBool();
     chatMentionCompleter = settings->value("chat/mentioncompleter", true).toBool();
     chatMentionForeground = settings->value("chat/mentionforeground", true).toBool();
@@ -535,6 +536,12 @@ void SettingsCache::setTapAnimation(QT_STATE_CHANGED_T _tapAnimation)
 {
     tapAnimation = static_cast<bool>(_tapAnimation);
     settings->setValue("cards/tapanimation", tapAnimation);
+}
+
+void SettingsCache::setOpenDeckInNewTab(QT_STATE_CHANGED_T _openDeckInNewTab)
+{
+    openDeckInNewTab = static_cast<bool>(_openDeckInNewTab);
+    settings->setValue("editor/open_deck_in_new_tab", _openDeckInNewTab);
 }
 
 void SettingsCache::setChatMention(QT_STATE_CHANGED_T _chatMention)

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -243,7 +243,7 @@ SettingsCache::SettingsCache()
     invertVerticalCoordinate = settings->value("table/invert_vertical", false).toBool();
     minPlayersForMultiColumnLayout = settings->value("interface/min_players_multicolumn", 4).toInt();
     tapAnimation = settings->value("cards/tapanimation", true).toBool();
-    openDeckInNewTab = settings->value("editor/openDeckInNewTab", true).toBool();
+    openDeckInNewTab = settings->value("editor/openDeckInNewTab", false).toBool();
     chatMention = settings->value("chat/mention", true).toBool();
     chatMentionCompleter = settings->value("chat/mentioncompleter", true).toBool();
     chatMentionForeground = settings->value("chat/mentionforeground", true).toBool();

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -96,6 +96,7 @@ private:
     bool invertVerticalCoordinate;
     int minPlayersForMultiColumnLayout;
     bool tapAnimation;
+    bool openDeckInNewTab;
     bool chatMention;
     bool chatMentionCompleter;
     QString chatMentionColor;
@@ -294,6 +295,10 @@ public:
     bool getTapAnimation() const
     {
         return tapAnimation;
+    }
+    bool getOpenDeckInNewTab() const
+    {
+        return openDeckInNewTab;
     }
     bool getChatMention() const
     {
@@ -538,6 +543,7 @@ public slots:
     void setInvertVerticalCoordinate(QT_STATE_CHANGED_T _invertVerticalCoordinate);
     void setMinPlayersForMultiColumnLayout(int _minPlayersForMultiColumnLayout);
     void setTapAnimation(QT_STATE_CHANGED_T _tapAnimation);
+    void setOpenDeckInNewTab(QT_STATE_CHANGED_T _openDeckInNewTab);
     void setChatMention(QT_STATE_CHANGED_T _chatMention);
     void setChatMentionCompleter(QT_STATE_CHANGED_T _chatMentionCompleter);
     void setChatMentionForeground(QT_STATE_CHANGED_T _chatMentionForeground);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -163,6 +163,9 @@ void SettingsCache::setMinPlayersForMultiColumnLayout(int /* _minPlayersForMulti
 void SettingsCache::setTapAnimation(QT_STATE_CHANGED_T /* _tapAnimation */)
 {
 }
+void SettingsCache::setOpenDeckInNewTab(QT_STATE_CHANGED_T /* _openDeckInNewTab */)
+{
+}
 void SettingsCache::setChatMention(QT_STATE_CHANGED_T /* _chatMention */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -167,6 +167,9 @@ void SettingsCache::setMinPlayersForMultiColumnLayout(int /* _minPlayersForMulti
 void SettingsCache::setTapAnimation(QT_STATE_CHANGED_T /* _tapAnimation */)
 {
 }
+void SettingsCache::setOpenDeckInNewTab(QT_STATE_CHANGED_T /* _openDeckInNewTab */)
+{
+}
 void SettingsCache::setChatMention(QT_STATE_CHANGED_T /* _chatMention */)
 {
 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5142 

## What will change with this Pull Request?
Added the new setting `Always open deck in new tab`. 
It's located in the new `Deck editor settings` section under `User Interface`.

<img width="691" alt="Screenshot 2024-10-24 at 8 42 42 PM" src="https://github.com/user-attachments/assets/6c5201bc-4853-4a49-9cd1-786c51bd0f6a">

When enabled, `New deck`, `Load deck...`, and `Load deck from clipboard` will open the deck in a new deck editor tab, instead of replacing the deck in the existing tab. Cockatrice won't display the unsaved changes dialogue window, since we're no longer overwriting anything.

https://github.com/user-attachments/assets/19de3e88-55d4-4876-a7d0-62a5ce79094c
