### PR TITLE
fix crashes in local games because of using uninitialised pointers

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -440,7 +440,9 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor,
     : Tab(_tabSupervisor), clients(_clients), gameInfo(event.game_info()), roomGameTypes(_roomGameTypes),
       hostId(event.host_id()), localPlayerId(event.player_id()), isLocalGame(_tabSupervisor->getIsLocalGame()),
       spectator(event.spectator()), judge(event.judge()), gameStateKnown(false), resuming(event.resuming()),
-      currentPhase(-1), activeCard(nullptr), gameClosed(false), replay(nullptr), replayDock(nullptr)
+      currentPhase(-1), activeCard(nullptr), gameClosed(false), replay(nullptr), replayPlayButton(nullptr),
+      replayFastForwardButton(nullptr), aReplaySkipForward(nullptr), aReplaySkipBackward(nullptr),
+      aReplaySkipForwardBig(nullptr), aReplaySkipBackwardBig(nullptr), replayDock(nullptr)
 {
     // THIS CTOR IS USED ON GAMES
     gameInfo.set_started(false);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem
for some reason since #5140 something changed and the horrible design of multiple constructors in tab_game now causes a crash, in tab_game we have many variables only used by one of the two constructors and none of them got initialised, resulting in undefined behavior when they were used, for the longest time noone cared about this because undefined can mean zero, since this latest change it wasn't zero, at least for me.

## What will change with this Pull Request?
- initialise all the pointers with keybinds so that when they get used they are zero.
- no more random crash when creating a game for me, which might not even be reproducable for others
