### PR TITLE
fix row colors swapping when using back button in replays

### DIFF
--- a/cockatrice/src/server/chat_view/chat_view.cpp
+++ b/cockatrice/src/server/chat_view/chat_view.cpp
@@ -494,6 +494,7 @@ void ChatView::clearChat()
 {
     document()->clear();
     lastSender = "";
+    evenNumber = true;
 }
 
 void ChatView::redactMessages(const QString &userName, int amount)


### PR DESCRIPTION
## Related Ticket(s)
- back button introduced in https://github.com/Cockatrice/Cockatrice/pull/5140

## Short roundup of the initial problem
when using the back button in a replay the chat widget gets reset then processes all messages, however the chat widget also has an internal state for alternating the background of messages, this didn't get reset so if there were an uneven amount of rows they'd get swapped

## What will change with this Pull Request?
- now the first message after a chat reset will always use the base color instead of inhereting whatever would be the next color after the last message before resetting
