### PR TITLE
Application Display Name (#4767)

### DIFF
--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -119,6 +119,7 @@ int main(int argc, char *argv[])
     QCoreApplication::setOrganizationName("Cockatrice");
     QCoreApplication::setOrganizationDomain("cockatrice.de");
     QCoreApplication::setApplicationName("Cockatrice");
+    QCoreApplication::setApplicationDisplayName("Cockatrice");
     QCoreApplication::setApplicationVersion(VERSION_STRING);
 
 #ifdef Q_OS_MAC

--- a/dbconverter/src/main.cpp
+++ b/dbconverter/src/main.cpp
@@ -33,6 +33,7 @@ int main(int argc, char *argv[])
     QCoreApplication app(argc, argv);
     app.setOrganizationName("Cockatrice");
     app.setApplicationName("Dbconverter");
+    app.setApplicationDisplayName("Dbconverter");
     app.setApplicationVersion(VERSION_STRING);
 
     QCommandLineParser parser;

--- a/oracle/src/main.cpp
+++ b/oracle/src/main.cpp
@@ -54,6 +54,7 @@ int main(int argc, char *argv[])
     QCoreApplication::setOrganizationDomain("cockatrice");
     // this can't be changed, as it influences the default save path for cards.xml
     QCoreApplication::setApplicationName("Cockatrice");
+    QCoreApplication::setApplicationDisplayName("Cockatrice");
 
     // If the program is opened with the -s flag, it will only do spoilers. Otherwise it will do MTGJSON/Tokens
     QCommandLineParser parser;

--- a/servatrice/src/main.cpp
+++ b/servatrice/src/main.cpp
@@ -112,6 +112,7 @@ int main(int argc, char *argv[])
     QCoreApplication app(argc, argv);
     QCoreApplication::setOrganizationName("Cockatrice");
     QCoreApplication::setApplicationName("Servatrice");
+    QCoreApplication::setApplicationDisplayName("Servatrice");
     QCoreApplication::setApplicationVersion(VERSION_STRING);
 
     QCommandLineParser parser;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4767 

## Short roundup of the initial problem
- System toast notifications shows filename instead of application name

## What will change with this Pull Request?
- application name will display "Cockatrice" instead of "cockatrice.exe"

## Screenshot
![original](https://github.com/user-attachments/assets/97bcf7c5-9c97-408b-b07d-5bb489cc61a9)
![resolution](https://github.com/user-attachments/assets/71dee999-6e87-455c-9f21-374317d6f938)

