### PR TITLE
Creation Date (#4605)

### DIFF
--- a/cockatrice/src/userinfobox.cpp
+++ b/cockatrice/src/userinfobox.cpp
@@ -17,6 +17,7 @@
 #include <QInputDialog>
 #include <QLabel>
 #include <QMessageBox>
+#include <QPair>
 
 UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *parent, Qt::WindowFlags flags)
     : QWidget(parent, flags), client(_client), editable(_editable)
@@ -365,4 +366,31 @@ void UserInfoBox::resizeEvent(QResizeEvent *event)
     QPixmap resizedPixmap = avatarPixmap.scaled(avatarPic.size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
     avatarPic.setPixmap(resizedPixmap);
     QWidget::resizeEvent(event);
+}
+
+QPair<int, int> UserInfoBox::getDaysAndYearsBetween(const QDate &then, const QDate &now)
+{
+    // set dates chronologically
+    int sign = 1;
+    QDate start;
+    QDate end;
+
+    if (then < now) {
+        start = then;
+        end = now;
+    } else {
+        start = now;
+        end = then;
+        sign = -sign; 
+    }
+
+    // calculate years and days
+    int years = 0;
+    while (start.addYears(years + 1) <= end) years++;
+    start = start.addYears(years);
+
+    int days = start.daysTo(end);
+
+    // if then > now, return values will be negative
+    return {sign * days, sign * years};
 }

--- a/cockatrice/src/userinfobox.h
+++ b/cockatrice/src/userinfobox.h
@@ -5,6 +5,7 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QWidget>
+#include <QPair>
 
 class ServerInfo_User;
 class AbstractClient;
@@ -27,12 +28,8 @@ public:
     UserInfoBox(AbstractClient *_client, bool editable, QWidget *parent = nullptr, Qt::WindowFlags flags = {});
     void retranslateUi();
 
-    inline static QPair<int, int> getDaysAndYearsBetween(const QDate &then, const QDate &now)
-    {
-        int years = now.addDays(1 - then.dayOfYear()).year() - then.year(); // there is no yearsTo
-        int days = then.addYears(years).daysTo(now);
-        return {days, years};
-    }
+    static QPair<int, int> getDaysAndYearsBetween(const QDate &then, const QDate &now);
+
 private slots:
     void processResponse(const Response &r);
     void processEditResponse(const Response &r);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4605

## Short roundup of the initial problem
The logic for date comparisons did not account for situation where dates were out of order (then > now).

## What will change with this Pull Request?
- account creation date will calculate correctly, even if dates passed are not chronological. 
- in the event dates are not chronological, the return values for days and years will be negative.
