### PR TITLE
New signal cardDatabaseLoadingFinished() for CardDatabase to mirror cardDatabaseLoadingFailed()

### DIFF
--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -567,6 +567,7 @@ LoadStatus CardDatabase::loadCardDatabases()
     if (loadStatus == Ok) {
         checkUnknownSets(); // update deck editors, etc
         qDebug() << "CardDatabase::loadCardDatabases success";
+        emit cardDatabaseLoadingFinished();
     } else {
         qDebug() << "CardDatabase::loadCardDatabases failed";
         emit cardDatabaseLoadingFailed(); // bring up the settings dialog

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -441,6 +441,7 @@ public slots:
 protected slots:
     LoadStatus loadCardDatabase(const QString &path);
 signals:
+    void cardDatabaseLoadingFinished();
     void cardDatabaseLoadingFailed();
     void cardDatabaseNewSetsFound(int numUnknownSets, QStringList unknownSetsNames);
     void cardDatabaseAllNewSetsEnabled();


### PR DESCRIPTION
## Related Ticket(s)
- None

## Short roundup of the initial problem
The card database currently does not notify UI components when it has finished loading the database, only when it fails. This is problematic for widgets that may be displayed at application startup but may rely on a loaded database to display their content. The proposed new signal allows UI components to late initialize when database loading has finished.

## What will change with this Pull Request?
- CardDatabase gains a new signal void cardDatabaseLoadingFinished()
-  It will emit this signal in loadCardDatabases(), mirroring the else branch where cardDatabaseLoadingFailed() is emitted.