### PR TITLE
Change CardInfo's PixmapCacheKey to be the UUID of the card in the preferred set after database loading has finished. Otherwise, and if no UUID of a preferred set is available, default to the card name.

### DIFF
--- a/cockatrice/src/client/ui/picture_loader.cpp
+++ b/cockatrice/src/client/ui/picture_loader.cpp
@@ -178,7 +178,8 @@ void PictureLoaderWorker::processLoadQueue()
         qDebug().nospace() << "PictureLoader: [card: " << cardName << " set: " << setName
                            << "]: Trying to load picture";
 
-        if (CardDatabaseManager::getInstance()->isUuidForPreferredPrinting(cardName, cardBeingLoaded.getCard()->getPixmapCacheKey())) {
+        if (CardDatabaseManager::getInstance()->isUuidForPreferredPrinting(
+                cardName, cardBeingLoaded.getCard()->getPixmapCacheKey())) {
             if (cardImageExistsOnDisk(setName, correctedCardName)) {
                 continue;
             }

--- a/cockatrice/src/client/ui/picture_loader.cpp
+++ b/cockatrice/src/client/ui/picture_loader.cpp
@@ -47,8 +47,8 @@ PictureToLoad::PictureToLoad(CardInfoPtr _card)
         for (const auto &set : card->getSets()) {
             if (QLatin1String("card_") + QString(set.getProperty("uuid")) == card->getPixmapCacheKey()) {
                 long long setIndex = sortedSets.indexOf(set.getPtr());
-                CardSetPtr set_for_card_uuid = sortedSets.takeAt(setIndex);
-                sortedSets.prepend(set_for_card_uuid);
+                CardSetPtr setForCardUUID = sortedSets.takeAt(setIndex);
+                sortedSets.prepend(setForCardUUID);
             }
         }
         // The first time called, nextSet will also populate the Urls for the first set.

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -444,7 +444,7 @@ QList<CardInfoPtr> CardDatabase::getCards(const QStringList &cardNames) const
 CardInfoPtr CardDatabase::getCardByNameAndUUID(const QString &cardName, const QString &uuid) const
 {
     auto info = getCard(cardName);
-    for (const auto& set : info->getSets()) {
+    for (const auto &set : info->getSets()) {
         if (set.getProperty("uuid") == uuid) {
             CardInfoPtr cardFromSpecificSet = info->clone();
             cardFromSpecificSet->setPixmapCacheKey(QLatin1String("card_") + QString(set.getProperty("uuid")));

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -3,6 +3,7 @@
 #include "../../client/network/spoiler_background_updater.h"
 #include "../../client/ui/picture_loader.h"
 #include "../../settings/cache_settings.h"
+#include "../../utility/card_set_comparator.h"
 #include "../game_specific_terms.h"
 #include "./card_database_parser/cockatrice_xml_3.h"
 #include "./card_database_parser/cockatrice_xml_4.h"
@@ -440,6 +441,19 @@ QList<CardInfoPtr> CardDatabase::getCards(const QStringList &cardNames) const
     return cardInfos;
 }
 
+CardInfoPtr CardDatabase::getCardByNameAndUUID(const QString &cardName, const QString &uuid) const
+{
+    auto info = getCard(cardName);
+    for (const auto& set : info->getSets()) {
+        if (set.getProperty("uuid") == uuid) {
+            CardInfoPtr cardFromSpecificSet = info->clone();
+            cardFromSpecificSet->setPixmapCacheKey(QLatin1String("card_") + QString(set.getProperty("uuid")));
+            return cardFromSpecificSet;
+        }
+    }
+    return {};
+}
+
 CardInfoPtr CardDatabase::getCardBySimpleName(const QString &cardName) const
 {
     return getCardFromMap(simpleNameCards, CardInfo::simplifyName(cardName));
@@ -561,6 +575,8 @@ LoadStatus CardDatabase::loadCardDatabases()
 
     // AFTER all the cards have been loaded
 
+    // Refresh the pixmap cache keys for all cards by setting them to the UUID of the preferred printing
+    refreshPreferredPrintings();
     // resolve the reverse-related tags
     refreshCachedReverseRelatedCards();
 
@@ -575,6 +591,63 @@ LoadStatus CardDatabase::loadCardDatabases()
 
     reloadDatabaseMutex->unlock();
     return loadStatus;
+}
+
+void CardDatabase::refreshPreferredPrintings()
+{
+    for (const CardInfoPtr &card : cards) {
+        card->setPixmapCacheKey(QLatin1String("card_") + QString(getPreferredPrintingUUIDForCard(card->getName())));
+    }
+}
+
+CardInfoPerSet CardDatabase::getPreferredSetForCard(const QString &cardName)
+{
+    CardInfoPtr cardInfo = getCard(cardName);
+    if (!cardInfo) {
+        return CardInfoPerSet(nullptr);
+    }
+
+    CardInfoPerSetMap setMap = cardInfo->getSets();
+    if (setMap.empty()) {
+        return CardInfoPerSet(nullptr);
+    }
+
+    CardSetPtr preferredSet = nullptr;
+    CardInfoPerSet preferredCard;
+    SetPriorityComparator comparator;
+
+    for (auto &cardInfoForSet : setMap) {
+        CardSetPtr currentSet = cardInfoForSet.getPtr();
+        if (!preferredSet || comparator(currentSet, preferredSet)) {
+            preferredSet = currentSet;
+            preferredCard = cardInfoForSet;
+        }
+    }
+
+    if (preferredSet) {
+        return preferredCard;
+    }
+
+    return CardInfoPerSet(nullptr);
+}
+
+QString CardDatabase::getPreferredPrintingUUIDForCard(const QString &cardName)
+{
+    CardInfoPerSet preferredSetCardInfo = getPreferredSetForCard(cardName);
+    QString preferredPrintingUUID = preferredSetCardInfo.getProperty(QString("uuid"));
+    if (preferredPrintingUUID.isEmpty()) {
+        CardInfoPtr defaultCardInfo = getCard(cardName);
+        if (defaultCardInfo.isNull()) {
+            return cardName;
+        }
+        return defaultCardInfo->getName();
+    }
+    return preferredPrintingUUID;
+}
+
+bool CardDatabase::isUuidForPreferredPrinting(const QString &cardName, const QString &uuid)
+{
+    return uuid == getPreferredPrintingUUIDForCard(cardName);
 }
 
 void CardDatabase::refreshCachedReverseRelatedCards()

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -188,6 +188,14 @@ public:
                       bool _cipt = false,
                       int _tableRow = 0,
                       bool _upsideDownArt = false);
+    CardInfo(const CardInfo &other)
+        : QObject(other.parent()), name(other.name), simpleName(other.simpleName), pixmapCacheKey(other.pixmapCacheKey),
+          text(other.text), isToken(other.isToken), properties(other.properties), relatedCards(other.relatedCards),
+          reverseRelatedCards(other.reverseRelatedCards), reverseRelatedCardsToMe(other.reverseRelatedCardsToMe),
+          sets(other.sets), setsNames(other.setsNames), cipt(other.cipt), tableRow(other.tableRow),
+          upsideDownArt(other.upsideDownArt)
+    {
+    }
     ~CardInfo() override;
 
     static CardInfoPtr newInstance(const QString &_name = QString(),
@@ -200,6 +208,14 @@ public:
                                    bool _cipt = false,
                                    int _tableRow = 0,
                                    bool _upsideDownArt = false);
+
+    CardInfoPtr clone() const
+    {
+        // Use the copy constructor to create a new instance
+        CardInfoPtr newCardInfo = CardInfoPtr(new CardInfo(*this));
+        newCardInfo->setSmartPointer(newCardInfo); // Set the smart pointer for the new instance
+        return newCardInfo;
+    }
 
     void setSmartPointer(CardInfoPtr _ptr)
     {
@@ -214,6 +230,10 @@ public:
     const QString &getSimpleName() const
     {
         return simpleName;
+    }
+    void setPixmapCacheKey(QString _pixmapCacheKey)
+    {
+        pixmapCacheKey = _pixmapCacheKey;
     }
     const QString &getPixmapCacheKey() const
     {
@@ -394,6 +414,8 @@ protected:
 private:
     CardInfoPtr getCardFromMap(const CardNameMap &cardMap, const QString &cardName) const;
     void checkUnknownSets();
+    CardInfoPerSet getPreferredSetForCard(const QString &cardName);
+    QString getPreferredPrintingUUIDForCard(const QString &cardName);
     void refreshCachedReverseRelatedCards();
 
     QBasicMutex *reloadDatabaseMutex = new QBasicMutex(), *clearDatabaseMutex = new QBasicMutex(),
@@ -409,6 +431,7 @@ public:
     void removeCard(CardInfoPtr card);
     CardInfoPtr getCard(const QString &cardName) const;
     QList<CardInfoPtr> getCards(const QStringList &cardNames) const;
+    CardInfoPtr getCardByNameAndUUID(const QString &cardName, const QString &uuid) const;
     CardInfoPtr guessCard(const QString &cardName) const;
 
     /*
@@ -418,6 +441,7 @@ public:
     CardInfoPtr getCardBySimpleName(const QString &cardName) const;
 
     CardSetPtr getSet(const QString &setName);
+    bool isUuidForPreferredPrinting(const QString &cardName, const QString &uuid);
     QList<CardInfoPtr> getCardList() const
     {
         return cards.values();
@@ -436,6 +460,7 @@ public:
 
 public slots:
     LoadStatus loadCardDatabases();
+    void refreshPreferredPrintings();
     void addCard(CardInfoPtr card);
     void addSet(CardSetPtr set);
 protected slots:

--- a/cockatrice/src/utility/card_set_comparator.h
+++ b/cockatrice/src/utility/card_set_comparator.h
@@ -1,0 +1,24 @@
+#ifndef SET_PRIORITY_COMPARATOR_H
+#define SET_PRIORITY_COMPARATOR_H
+
+#include "../game/cards/card_database.h"
+
+class SetPriorityComparator
+{
+public:
+    /*
+     * Returns true if a has higher download priority than b
+     * Enabled sets have priority over disabled sets
+     * Both groups follow the user-defined order
+     */
+    inline bool operator()(const CardSetPtr &a, const CardSetPtr &b) const
+    {
+        if (a->getEnabled()) {
+            return !b->getEnabled() || a->getSortKey() < b->getSortKey();
+        } else {
+            return !b->getEnabled() && a->getSortKey() < b->getSortKey();
+        }
+    }
+};
+
+#endif // SET_PRIORITY_COMPARATOR_H


### PR DESCRIPTION
## Related Ticket(s)
- Technical precursor to #486

## Short roundup of the initial problem
Currently, we use a CardInfo's name as the key for the Pixmap Cache. This is problematic because it does not allow us to store different images for a card with the same name (i.e. different printings) in the cache because of a key collision.

## What will change with this Pull Request?
- Use the more unique UUID of the preferred printing as a key for the Pixmap cache key.
- By default, CardInfo will still assign the CardName as the Pixmap cache key.
- On database load completion, the cache keys are refreshed with the uuid of the CardInfoPerSet of the preferred Set.
- Tokens or other cards where the CardInfoPerSet does not contain a UUID will fall back to the card name.
- The PictureLoader will prepend a set to the sortedSets it uses to populate file download urls if the pixmapCacheKey of the card corresponds with the uuid of the card in the set.
