### PR TITLE
fix bug with phase highlighting in replays

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -637,6 +637,19 @@ void TabGame::replayFastForwardButtonToggled(bool checked)
     timelineWidget->setTimeScaleFactor(checked ? 10.0 : 1.0);
 }
 
+/**
+ * @brief Handles everything that needs to be reset when doing a replay rewind.
+ */
+void TabGame::replayRewind()
+{
+    // reset chat log
+    messageLog->clearChat();
+
+    // reset phase markers
+    currentPhase = -1;
+    phasesToolbar->reset();
+}
+
 void TabGame::incrementGameTime()
 {
     int seconds = ++secondsElapsed;
@@ -1718,7 +1731,7 @@ void TabGame::createReplayDock()
     timelineWidget->setTimeline(replayTimeline);
     connect(timelineWidget, SIGNAL(processNextEvent()), this, SLOT(replayNextEvent()));
     connect(timelineWidget, SIGNAL(replayFinished()), this, SLOT(replayFinished()));
-    connect(timelineWidget, &ReplayTimelineWidget::rewound, messageLog, &ChatView::clearChat);
+    connect(timelineWidget, &ReplayTimelineWidget::rewound, this, &TabGame::replayRewind);
 
     // timeline skip shortcuts
     aReplaySkipForward = new QAction(timelineWidget);

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -225,6 +225,7 @@ private slots:
     void replayFinished();
     void replayPlayButtonToggled(bool checked);
     void replayFastForwardButtonToggled(bool checked);
+    void replayRewind();
 
     void incrementGameTime();
     void adminLockChanged(bool lock);

--- a/cockatrice/src/client/ui/phases_toolbar.cpp
+++ b/cockatrice/src/client/ui/phases_toolbar.cpp
@@ -84,6 +84,17 @@ void PhaseButton::updateAnimation()
     update();
 }
 
+/**
+ * @brief Immediately resets the button to the inactive state, without going through the animation.
+ */
+void PhaseButton::reset()
+{
+    activeAnimationTimer->stop();
+    active = false;
+    activeAnimationCounter = highlightable ? 0 : 9;
+    update();
+}
+
 void PhaseButton::mousePressEvent(QGraphicsSceneMouseEvent * /*event*/)
 {
     emit clicked();
@@ -247,6 +258,16 @@ void PhasesToolbar::phaseButtonClicked()
     cmd.set_phase(static_cast<google::protobuf::uint32>(buttonList.indexOf(button)));
 
     emit sendGameCommand(cmd, -1);
+}
+
+/**
+ * @brief Immediately resets the toolbar to its initial state, with all phases inactive.
+ */
+void PhasesToolbar::reset()
+{
+    for (auto &i : buttonList) {
+        i->reset();
+    }
 }
 
 void PhasesToolbar::actNextTurn()

--- a/cockatrice/src/client/ui/phases_toolbar.cpp
+++ b/cockatrice/src/client/ui/phases_toolbar.cpp
@@ -93,7 +93,13 @@ void PhaseButton::reset()
 {
     activeAnimationTimer->stop();
     active = false;
-    activeAnimationCounter = highlightable ? 0 : 9;
+
+    if (highlightable) {
+        activeAnimationCounter = 0;
+    } else {
+        activeAnimationCounter = 9;
+    }
+
     update();
 }
 

--- a/cockatrice/src/client/ui/phases_toolbar.cpp
+++ b/cockatrice/src/client/ui/phases_toolbar.cpp
@@ -76,9 +76,9 @@ void PhaseButton::updateAnimation()
 
     // the counter ticks up to 10 when active and down to 0 when inactive
     if (active && activeAnimationCounter < 10) {
-        activeAnimationCounter++;
+        ++activeAnimationCounter;
     } else if (!active && activeAnimationCounter > 0) {
-        activeAnimationCounter--;
+        --activeAnimationCounter;
     } else {
         activeAnimationTimer->stop();
     }

--- a/cockatrice/src/client/ui/phases_toolbar.cpp
+++ b/cockatrice/src/client/ui/phases_toolbar.cpp
@@ -74,13 +74,15 @@ void PhaseButton::updateAnimation()
     if (!highlightable)
         return;
 
-    if (active) {
-        if (++activeAnimationCounter >= 10)
-            activeAnimationTimer->stop();
+    // the counter ticks up to 10 when active and down to 0 when inactive
+    if (active && activeAnimationCounter < 10) {
+        activeAnimationCounter++;
+    } else if (!active && activeAnimationCounter > 0) {
+        activeAnimationCounter--;
     } else {
-        if (--activeAnimationCounter <= 0)
-            activeAnimationTimer->stop();
+        activeAnimationTimer->stop();
     }
+
     update();
 }
 

--- a/cockatrice/src/client/ui/phases_toolbar.h
+++ b/cockatrice/src/client/ui/phases_toolbar.h
@@ -45,6 +45,7 @@ public:
     {
         return active;
     }
+    void reset();
     void triggerDoubleClickAction();
 signals:
     void clicked();
@@ -85,6 +86,7 @@ public:
 public slots:
     void setActivePhase(int phase);
     void triggerPhaseAction(int phase);
+    void reset();
 private slots:
     void phaseButtonClicked();
     void actNextTurn();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5160

## Short roundup of the initial problem
When watching a replay, if you do backward skips, the phase button highlighting will bug out. Multiple phases will stay highlighted.

## What will change with this Pull Request?
- The `rewound()` signal from `ReplayTimelineWidget` will now trigger `TabGame` to properly reset the phases.
- Added a `reset()` method to the phase toolbar classes that will immediately reset the `PhaseButton`, skipping any animations.
- Also did some minor refactoring of `PhaseButton::updateAnimation()` when fixing a new bug that I introduced while fixing this bug.
