### PR TITLE
fix the timezones used for the user info box and add comments

### DIFF
--- a/cockatrice/src/server/user/user_info_box.cpp
+++ b/cockatrice/src/server/user/user_info_box.cpp
@@ -138,17 +138,21 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
 QString UserInfoBox::getAgeString(int ageSeconds)
 {
     QString accountAgeString = tr("Unknown");
-    if (ageSeconds == 0)
+    if (ageSeconds <= 0)
         return accountAgeString;
 
-    auto date = QDateTime::fromSecsSinceEpoch(QDateTime::currentSecsSinceEpoch() - ageSeconds).date();
+    // secsSinceEpoch is in utc
+    auto secsSinceEpoch = QDateTime::currentSecsSinceEpoch() - ageSeconds;
+    // the date is in local time, fromSecsSinceEpoch expects a timestamp from utc and converts it to local time
+    auto date = QDateTime::fromSecsSinceEpoch(secsSinceEpoch).date();
     if (!date.isValid())
         return accountAgeString;
 
-    QString dateString = QLocale().toString(date, QLocale::ShortFormat);
+    // now can be local time as the date is also local time
     auto now = QDate::currentDate();
     auto daysAndYears = getDaysAndYearsBetween(date, now);
 
+    QString dateString = QLocale().toString(date, QLocale::ShortFormat);
     QString yearString;
     if (daysAndYears.second > 0) {
         yearString = tr("%n Year(s), ", "amount of years (only shown if more than 0)", daysAndYears.second);

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -613,7 +613,8 @@ ServerInfo_User Servatrice_DatabaseInterface::evalUserQueryResult(const QSqlQuer
 
         const QDateTime regDate = query->value(7).toDateTime();
         if (!regDate.toString(Qt::ISODate).isEmpty()) {
-            qint64 accountAgeInSeconds = regDate.secsTo(QDateTime::currentDateTime());
+            // the registration date is in utc
+            qint64 accountAgeInSeconds = regDate.secsTo(QDateTime::currentDateTimeUtc());
             result.set_accountage_secs(accountAgeInSeconds);
         }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4605
- cleans up #4526

## Short roundup of the initial problem
the server sends the account age compared to local time, even though it's stored as utc

## What will change with this Pull Request?
- fix timezones used and add some comments
