### PR TITLE
move replay-related constants into ReplayTimelineWidget

### DIFF
--- a/cockatrice/src/client/network/replay_timeline_widget.cpp
+++ b/cockatrice/src/client/network/replay_timeline_widget.cpp
@@ -85,7 +85,7 @@ void ReplayTimelineWidget::skipToTime(int newTime, bool doRewindBuffering)
         newTime = maxTime;
     }
 
-    newTime -= newTime % 200; // Time should always be a multiple of 200
+    newTime -= newTime % TIMER_INTERVAL_MS; // Time should always be a multiple of the interval
 
     const bool isBackwardsSkip = newTime < currentTime;
     currentTime = newTime;
@@ -145,7 +145,7 @@ QSize ReplayTimelineWidget::minimumSizeHint() const
 
 void ReplayTimelineWidget::replayTimerTimeout()
 {
-    currentTime += 200;
+    currentTime += TIMER_INTERVAL_MS;
 
     processNewEvents(NORMAL_PLAYBACK);
 
@@ -160,8 +160,8 @@ void ReplayTimelineWidget::processNewEvents(PlaybackMode playbackMode)
         Player::EventProcessingOptions options;
 
         // backwards skip => always skip reveal windows
-        // forwards skip => skip reveal windows that don't happen within 10 seconds of the target
-        if (playbackMode == BACKWARD_SKIP || currentTime - replayTimeline[currentEvent] > 10000)
+        // forwards skip => skip reveal windows that don't happen within a big skip of the target
+        if (playbackMode == BACKWARD_SKIP || currentTime - replayTimeline[currentEvent] > BIG_SKIP_MS)
             options |= Player::EventProcessingOption::SKIP_REVEAL_WINDOW;
 
         emit processNextEvent(options);
@@ -176,12 +176,12 @@ void ReplayTimelineWidget::processNewEvents(PlaybackMode playbackMode)
 void ReplayTimelineWidget::setTimeScaleFactor(qreal _timeScaleFactor)
 {
     timeScaleFactor = _timeScaleFactor;
-    replayTimer->setInterval(static_cast<int>(200 / timeScaleFactor));
+    replayTimer->setInterval(static_cast<int>(TIMER_INTERVAL_MS / timeScaleFactor));
 }
 
 void ReplayTimelineWidget::startReplay()
 {
-    replayTimer->start(static_cast<int>(200 / timeScaleFactor));
+    replayTimer->start(static_cast<int>(TIMER_INTERVAL_MS / timeScaleFactor));
 }
 
 void ReplayTimelineWidget::stopReplay()

--- a/cockatrice/src/client/network/replay_timeline_widget.cpp
+++ b/cockatrice/src/client/network/replay_timeline_widget.cpp
@@ -16,25 +16,23 @@ ReplayTimelineWidget::ReplayTimelineWidget(QWidget *parent)
     connect(rewindBufferingTimer, &QTimer::timeout, this, &ReplayTimelineWidget::processRewind);
 }
 
-const int ReplayTimelineWidget::binLength = 5000;
-
 void ReplayTimelineWidget::setTimeline(const QList<int> &_replayTimeline)
 {
     replayTimeline = _replayTimeline;
     histogram.clear();
-    int binEndTime = binLength - 1;
+    int binEndTime = BIN_LENGTH - 1;
     int binValue = 0;
     for (int i : replayTimeline) {
         if (i > binEndTime) {
             histogram.append(binValue);
             if (binValue > maxBinValue)
                 maxBinValue = binValue;
-            while (i > binEndTime + binLength) {
+            while (i > binEndTime + BIN_LENGTH) {
                 histogram.append(0);
-                binEndTime += binLength;
+                binEndTime += BIN_LENGTH;
             }
             binValue = 1;
-            binEndTime += binLength;
+            binEndTime += BIN_LENGTH;
         } else
             ++binValue;
     }

--- a/cockatrice/src/client/network/replay_timeline_widget.h
+++ b/cockatrice/src/client/network/replay_timeline_widget.h
@@ -27,6 +27,7 @@ private:
     };
 
     static constexpr int TIMER_INTERVAL_MS = 200;
+    static constexpr int BIN_LENGTH = 5000;
     static constexpr int BASE_REWIND_BUFFERING_TIMEOUT_MS = 180;
     static constexpr int MAX_REWIND_BUFFERING_TIMEOUT_MS = 280;
 
@@ -34,7 +35,6 @@ private:
     QTimer *rewindBufferingTimer;
     QList<int> replayTimeline;
     QList<int> histogram;
-    static const int binLength;
     int maxBinValue, maxTime;
     qreal timeScaleFactor;
     int currentTime;

--- a/cockatrice/src/client/network/replay_timeline_widget.h
+++ b/cockatrice/src/client/network/replay_timeline_widget.h
@@ -26,9 +26,11 @@ private:
         BACKWARD_SKIP
     };
 
-    QTimer *replayTimer;
+    static constexpr int TIMER_INTERVAL_MS = 200;
     static constexpr int BASE_REWIND_BUFFERING_TIMEOUT_MS = 180;
     static constexpr int MAX_REWIND_BUFFERING_TIMEOUT_MS = 280;
+
+    QTimer *replayTimer;
     QTimer *rewindBufferingTimer;
     QList<int> replayTimeline;
     QList<int> histogram;
@@ -47,6 +49,10 @@ private slots:
     void replayTimerTimeout();
 
 public:
+    static constexpr int SMALL_SKIP_MS = 1000;
+    static constexpr int BIG_SKIP_MS = 10000;
+    static constexpr qreal FAST_FORWARD_SCALE_FACTOR = 10.0;
+
     explicit ReplayTimelineWidget(QWidget *parent = nullptr);
     void setTimeline(const QList<int> &_replayTimeline);
     QSize sizeHint() const override;

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -635,7 +635,7 @@ void TabGame::replayPlayButtonToggled(bool checked)
 
 void TabGame::replayFastForwardButtonToggled(bool checked)
 {
-    timelineWidget->setTimeScaleFactor(checked ? 10.0 : 1.0);
+    timelineWidget->setTimeScaleFactor(checked ? ReplayTimelineWidget::FAST_FORWARD_SCALE_FACTOR : 1.0);
 }
 
 /**
@@ -1742,22 +1742,22 @@ void TabGame::createReplayDock()
     aReplaySkipForward = new QAction(timelineWidget);
     timelineWidget->addAction(aReplaySkipForward);
     connect(aReplaySkipForward, &QAction::triggered, this,
-            [=]() { timelineWidget->skipByAmount(SMALL_SKIP_AMOUNT_MS); });
+            [=]() { timelineWidget->skipByAmount(ReplayTimelineWidget::SMALL_SKIP_MS); });
 
     aReplaySkipBackward = new QAction(timelineWidget);
     timelineWidget->addAction(aReplaySkipBackward);
     connect(aReplaySkipBackward, &QAction::triggered, this,
-            [=]() { timelineWidget->skipByAmount(-SMALL_SKIP_AMOUNT_MS); });
+            [=]() { timelineWidget->skipByAmount(-ReplayTimelineWidget::SMALL_SKIP_MS); });
 
     aReplaySkipForwardBig = new QAction(timelineWidget);
     timelineWidget->addAction(aReplaySkipForwardBig);
     connect(aReplaySkipForwardBig, &QAction::triggered, this,
-            [=]() { timelineWidget->skipByAmount(BIG_SKIP_AMOUNT_MS); });
+            [=]() { timelineWidget->skipByAmount(ReplayTimelineWidget::BIG_SKIP_MS); });
 
     aReplaySkipBackwardBig = new QAction(timelineWidget);
     timelineWidget->addAction(aReplaySkipBackwardBig);
     connect(aReplaySkipBackwardBig, &QAction::triggered, this,
-            [=]() { timelineWidget->skipByAmount(-BIG_SKIP_AMOUNT_MS); });
+            [=]() { timelineWidget->skipByAmount(-ReplayTimelineWidget::BIG_SKIP_MS); });
 
     // buttons
     replayPlayButton = new QToolButton;

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -142,8 +142,6 @@ private:
     QStackedWidget *mainWidget;
 
     // Replay related members
-    static const int SMALL_SKIP_AMOUNT_MS = 1000;
-    static const int BIG_SKIP_AMOUNT_MS = 10000;
     GameReplay *replay;
     int currentReplayStep;
     QList<int> replayTimeline;


### PR DESCRIPTION
## Related Ticket(s)
- mentioned in #5157

## Short roundup of the initial problem
`ReplayTimelineWidget` has several magic numbers that can better be represented as constants. Additionally, some of those magic numbers are spread across both the class itself as well as the classes that use it (such as `tab_game`). 

We should move the magic numbers into constants and consolidate the constants into one place.

## What will change with this Pull Request?
- Moved the replay-related constants that appear in `tab_game` into public static consts in `ReplayTimelineWidget`. 
  - That way all replay-related constants are in one place.
- Moved some magic numbers in `ReplayTimelineWidget` into private static consts.
