### PR TITLE
skip tap animation when backward skipping in replays

### DIFF
--- a/cockatrice/src/client/network/replay_timeline_widget.cpp
+++ b/cockatrice/src/client/network/replay_timeline_widget.cpp
@@ -162,6 +162,10 @@ void ReplayTimelineWidget::processNewEvents(PlaybackMode playbackMode)
         if (playbackMode == BACKWARD_SKIP || currentTime - replayTimeline[currentEvent] > BIG_SKIP_MS)
             options |= Player::EventProcessingOption::SKIP_REVEAL_WINDOW;
 
+        // backwards skip => always skip tap animation
+        if (playbackMode == BACKWARD_SKIP)
+            options |= Player::EventProcessingOption::SKIP_TAP_ANIMATION;
+
         emit processNextEvent(options);
         ++currentEvent;
     }

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -229,7 +229,8 @@ private slots:
 public:
     enum EventProcessingOption
     {
-        SKIP_REVEAL_WINDOW = 0x0001
+        SKIP_REVEAL_WINDOW = 0x0001,
+        SKIP_TAP_ANIMATION = 0x0002
     };
     Q_DECLARE_FLAGS(EventProcessingOptions, EventProcessingOption)
 
@@ -301,7 +302,8 @@ private:
                            CardItem *card,
                            CardAttribute attribute,
                            const QString &avalue,
-                           bool allCards);
+                           bool allCards,
+                           EventProcessingOptions options);
     void addRelatedCardActions(const CardItem *card, QMenu *cardMenu);
     void addRelatedCardView(const CardItem *card, QMenu *cardMenu);
     void createCard(const CardItem *sourceCard,
@@ -328,7 +330,8 @@ private:
     void eventCreateArrow(const Event_CreateArrow &event);
     void eventDeleteArrow(const Event_DeleteArrow &event);
     void eventCreateToken(const Event_CreateToken &event);
-    void eventSetCardAttr(const Event_SetCardAttr &event, const GameEventContext &context);
+    void
+    eventSetCardAttr(const Event_SetCardAttr &event, const GameEventContext &context, EventProcessingOptions options);
     void eventSetCardCounter(const Event_SetCardCounter &event);
     void eventCreateCounter(const Event_CreateCounter &event);
     void eventSetCounter(const Event_SetCounter &event);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5167 

## Short roundup of the initial problem

Due to how rewinding works, Cockatrice will always play the tap animation when backwards skipping to a permanent that is tapped.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/c808b481-b6f3-4cb2-87e1-71479622b5c9

- Skip tap/untap animations when rewinding; the permanents will immediately snap to their present state
  - add `SKIP_TAP_ANIMATION` to `EventProcessingOptions` 
  - events sent during a rewind will have that flag enabled
  - `Player::eventSetCardAttr` will set animation to false if the flag is enabled
- still kept around the animations when forward skipping, because I honestly think the animations looks kinda nice 
