### PR TITLE
Don't open deck in new tab if current tab is blank

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -783,7 +783,7 @@ void TabDeckEditor::actNewDeck()
 
 void TabDeckEditor::actLoadDeck()
 {
-    bool openInNewTab = SettingsCache::instance().getOpenDeckInNewTab();
+    bool openInNewTab = SettingsCache::instance().getOpenDeckInNewTab() && !isBlankNewDeck();
 
     if (!openInNewTab && !confirmClose())
         return;
@@ -876,7 +876,7 @@ bool TabDeckEditor::actSaveDeckAs()
 
 void TabDeckEditor::actLoadDeckFromClipboard()
 {
-    bool openInNewTab = SettingsCache::instance().getOpenDeckInNewTab();
+    bool openInNewTab = SettingsCache::instance().getOpenDeckInNewTab() && !isBlankNewDeck();
 
     if (!openInNewTab && !confirmClose())
         return;
@@ -983,6 +983,15 @@ void TabDeckEditor::recursiveExpand(const QModelIndex &index)
     if (index.parent().isValid())
         recursiveExpand(index.parent());
     deckView->expand(index);
+}
+
+/**
+ * @brief Returns true if this tab is a blank newly opened tab, as if it was just created with the `New Deck` action.
+ */
+bool TabDeckEditor::isBlankNewDeck() const
+{
+    DeckLoader *const deck = deckModel->getDeckList();
+    return !modified && deck->getLastFileName().isEmpty() && deck->getLastRemoteDeckId() == -1;
 }
 
 CardInfoPtr TabDeckEditor::currentCardInfo() const

--- a/cockatrice/src/client/tabs/tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/tab_deck_editor.h
@@ -100,6 +100,7 @@ private slots:
     void showSearchSyntaxHelp();
 
 private:
+    bool isBlankNewDeck() const;
     CardInfoPtr currentCardInfo() const;
     void addCardHelper(QString zoneName);
     void offsetCountAtIndex(const QModelIndex &idx, int offset);


### PR DESCRIPTION
## Related Ticket(s)
- Followup to #5143

## Short roundup of the initial problem

> I feel like when a decklist is empty there is no need to open a new tab. also, opening a new tab takes a solid couple of seconds for me, probably because of the huge card list.

## What will change with this Pull Request?
https://github.com/user-attachments/assets/9d8b0c96-525c-42b2-876a-a08519834b03

When the option `Always open deck in new tab` is enabled, if you try to load a deck while the current deck editor tab is **blank**, the deck will load into the existing tab instead of a new tab.

**Blank**: The decklist is currently unmodified **and** is not saved somewhere.

`New Deck` will still always open a new tab, since if you're using it while the current tab is blank, then there's a good chance you intentionally want to open a new tab.
