### PR TITLE
multiplePrintings

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -72,9 +72,8 @@ set(cockatrice_SOURCES
     src/server/local_server.cpp
     src/server/local_server_interface.cpp
     src/utility/logger.cpp
-        src/client/ui/widgets/cards/card_info_picture_enlarged_widget.cpp
-        src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
-    src/client/ui/widgets/general/display/labeled_input.cpp
+    src/client/ui/widgets/cards/card_info_picture_enlarged_widget.cpp
+    src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
     src/main.cpp
     src/server/message_log_widget.cpp
     src/server/pending_command.cpp

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -72,6 +72,9 @@ set(cockatrice_SOURCES
     src/server/local_server.cpp
     src/server/local_server_interface.cpp
     src/utility/logger.cpp
+        src/client/ui/widgets/cards/card_info_picture_enlarged_widget.cpp
+        src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
+    src/client/ui/widgets/general/display/labeled_input.cpp
     src/main.cpp
     src/server/message_log_widget.cpp
     src/server/pending_command.cpp

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -58,6 +58,10 @@ set(cockatrice_SOURCES
     src/game/filters/filter_builder.cpp
     src/game/filters/filter_tree.cpp
     src/game/filters/filter_tree_model.cpp
+    src/client/ui/layouts/flow_layout.cpp
+    src/client/ui/layouts/horizontal_flow_layout.cpp
+    src/client/ui/layouts/vertical_flow_layout.cpp
+    src/client/ui/widgets/general/layout_containers/flow_widget.cpp
     src/game/game_scene.cpp
     src/game/game_selector.cpp
     src/game/games_model.cpp

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -20,10 +20,10 @@ set(cockatrice_SOURCES
     src/game/cards/card_database_parser/cockatrice_xml_4.cpp
     src/game/cards/card_drag_item.cpp
     src/game/filters/filter_card.cpp
-    src/game/cards/card_frame.cpp
-    src/game/cards/card_info_picture.cpp
-    src/game/cards/card_info_text.cpp
-    src/game/cards/card_info_widget.cpp
+    src/client/ui/widgets/cards/card_info_frame_widget.cpp
+    src/client/ui/widgets/cards/card_info_picture_widget.cpp
+    src/client/ui/widgets/cards/card_info_text_widget.cpp
+    src/client/ui/widgets/cards/card_info_display_widget.cpp
     src/game/cards/card_item.cpp
     src/game/cards/card_list.cpp
     src/game/zones/card_zone.cpp

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -78,10 +78,12 @@ set(cockatrice_SOURCES
     src/utility/logger.cpp
     src/client/ui/widgets/cards/card_info_picture_enlarged_widget.cpp
     src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
+    src/client/ui/widgets/general/display/labeled_input.cpp
     src/main.cpp
     src/server/message_log_widget.cpp
     src/client/ui/layouts/overlap_layout.cpp
     src/client/ui/widgets/general/layout_containers/overlap_widget.cpp
+    src/client/ui/widgets/general/layout_containers/overlap_control_widget.cpp
     src/server/pending_command.cpp
     src/game/phase.cpp
     src/client/ui/phases_toolbar.cpp

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -80,6 +80,8 @@ set(cockatrice_SOURCES
     src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
     src/main.cpp
     src/server/message_log_widget.cpp
+    src/client/ui/layouts/overlap_layout.cpp
+    src/client/ui/widgets/general/layout_containers/overlap_widget.cpp
     src/server/pending_command.cpp
     src/game/phase.cpp
     src/client/ui/phases_toolbar.cpp

--- a/cockatrice/src/client/tabs/tab.cpp
+++ b/cockatrice/src/client/tabs/tab.cpp
@@ -1,6 +1,6 @@
 #include "tab.h"
 
-#include "../../game/cards/card_info_widget.h"
+#include "../ui/widgets/cards/card_info_display_widget.h"
 
 #include <QApplication>
 #include <QDebug>
@@ -18,7 +18,7 @@ void Tab::showCardInfoPopup(const QPoint &pos, const QString &cardName)
         infoPopup->deleteLater();
     }
     currentCardName = cardName;
-    infoPopup = new CardInfoWidget(
+    infoPopup = new CardInfoDisplayWidget(
         cardName, 0, Qt::Widget | Qt::FramelessWindowHint | Qt::X11BypassWindowManagerHint | Qt::WindowStaysOnTopHint);
     infoPopup->setAttribute(Qt::WA_TransparentForMouseEvents);
 

--- a/cockatrice/src/client/tabs/tab.h
+++ b/cockatrice/src/client/tabs/tab.h
@@ -5,7 +5,7 @@
 
 class QMenu;
 class TabSupervisor;
-class CardInfoWidget;
+class CardInfoDisplayWidget;
 
 class Tab : public QMainWindow
 {
@@ -27,7 +27,7 @@ protected slots:
 private:
     QString currentCardName;
     bool contentsChanged;
-    CardInfoWidget *infoPopup;
+    CardInfoDisplayWidget *infoPopup;
     QList<QMenu *> tabMenus;
 
 public:

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -724,8 +724,10 @@ void TabDeckEditor::updateCardInfoRight(const QModelIndex &current, const QModel
 {
     if (!current.isValid())
         return;
-    if (!current.model()->hasChildren(current.sibling(current.row(), 0)))
-        cardInfo->setCard(current.sibling(current.row(), 1).data().toString());
+    if (!current.model()->hasChildren(current.sibling(current.row(), 0))) {
+        cardInfo->setCard(current.sibling(current.row(), 1).data().toString(),
+                          current.sibling(current.row(), 2).data().toString());
+    }
 }
 
 void TabDeckEditor::updateSearch(const QString &search)

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -7,7 +7,7 @@
 #include "../../dialogs/dlg_load_deck_from_clipboard.h"
 #include "../../game/cards/card_database_manager.h"
 #include "../../game/cards/card_database_model.h"
-#include "../../game/cards/card_frame.h"
+#include "../../client/ui/widgets/cards/card_info_frame_widget.h"
 #include "../../game/filters/filter_builder.h"
 #include "../../game/filters/filter_tree_model.h"
 #include "../../main.h"
@@ -187,7 +187,7 @@ void TabDeckEditor::createDeckDock()
 
 void TabDeckEditor::createCardInfoDock()
 {
-    cardInfo = new CardFrame();
+    cardInfo = new CardInfoFrameWidget();
     cardInfo->setObjectName("cardInfo");
     auto *cardInfoFrame = new QVBoxLayout;
     cardInfoFrame->setObjectName("cardInfoFrame");

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -987,7 +987,7 @@ void TabDeckEditor::addCardHelper(QString zoneName)
     if (info->getIsToken())
         zoneName = DECK_ZONE_TOKENS;
 
-    QModelIndex newCardIndex = deckModel->addCard(info->getName(), zoneName);
+    QModelIndex newCardIndex = deckModel->addPreferredPrintingCard(info->getName(), zoneName, false);
     recursiveExpand(newCardIndex);
     deckView->setCurrentIndex(newCardIndex);
     setModified(true);
@@ -1010,7 +1010,7 @@ void TabDeckEditor::actSwapCard()
     const QString otherZoneName = zoneName == DECK_ZONE_MAIN ? DECK_ZONE_SIDE : DECK_ZONE_MAIN;
 
     // Third argument (true) says create the card no mater what, even if not in DB
-    QModelIndex newCardIndex = deckModel->addCard(cardName, otherZoneName, true);
+    QModelIndex newCardIndex = deckModel->addPreferredPrintingCard(cardName, otherZoneName, true);
     recursiveExpand(newCardIndex);
 
     setModified(true);

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -1002,6 +1002,7 @@ void TabDeckEditor::actSwapCard()
     if (!currentIndex.isValid())
         return;
     const QString cardName = currentIndex.sibling(currentIndex.row(), 1).data().toString();
+    const QString cardUUID = currentIndex.sibling(currentIndex.row(), 2).data().toString();
     const QModelIndex gparent = currentIndex.parent().parent();
 
     if (!gparent.isValid())
@@ -1011,8 +1012,9 @@ void TabDeckEditor::actSwapCard()
     actDecrement();
     const QString otherZoneName = zoneName == DECK_ZONE_MAIN ? DECK_ZONE_SIDE : DECK_ZONE_MAIN;
 
-    // Third argument (true) says create the card no mater what, even if not in DB
-    QModelIndex newCardIndex = deckModel->addPreferredPrintingCard(cardName, otherZoneName, true);
+    // Third argument (true) says create the card no matter what, even if not in DB
+    QModelIndex newCardIndex = deckModel->addCard(
+        cardName, CardDatabaseManager::getInstance()->getSpecificSetForCard(cardName, cardUUID), otherZoneName, true);
     recursiveExpand(newCardIndex);
 
     setModified(true);

--- a/cockatrice/src/client/tabs/tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/tab_deck_editor.h
@@ -14,7 +14,7 @@ class CardDatabaseDisplayModel;
 class DeckListModel;
 class QTreeView;
 
-class CardFrame;
+class CardInfoFrameWidget;
 class QTextEdit;
 class QLabel;
 class DeckLoader;
@@ -113,7 +113,7 @@ private:
 
     QTreeView *deckView;
     KeySignals deckViewKeySignals;
-    CardFrame *cardInfo;
+    CardInfoFrameWidget *cardInfo;
     SearchLineEdit *searchEdit;
     KeySignals searchKeySignals;
 

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -326,6 +326,7 @@ void DeckViewContainer::deckSelectFinished(const Response &r)
 {
     const Response_DeckDownload &resp = r.GetExtension(Response_DeckDownload::ext);
     DeckLoader newDeck(QString::fromStdString(resp.deck()));
+    // TODO CHANGE THIS TO BE SELECTED BY UUID
     PictureLoader::cacheCardPixmaps(CardDatabaseManager::getInstance()->getCards(newDeck.getCardList()));
     setDeck(newDeck);
 }

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -7,8 +7,8 @@
 #include "../../dialogs/dlg_manage_sets.h"
 #include "../../game/board/arrow_item.h"
 #include "../../game/cards/card_database.h"
+#include "../../client/ui/widgets/cards/card_info_frame_widget.h"
 #include "../../game/cards/card_database_manager.h"
-#include "../../game/cards/card_frame.h"
 #include "../../game/cards/card_item.h"
 #include "../../game/game_scene.h"
 #include "../../game/game_view.h"
@@ -597,7 +597,7 @@ void TabGame::retranslateUi()
 
     aResetLayout->setText(tr("Reset layout"));
 
-    cardInfo->retranslateUi();
+    cardInfoFrameWidget->retranslateUi();
 
     QMapIterator<int, Player *> i(players);
     while (i.hasNext())
@@ -1380,7 +1380,7 @@ void TabGame::eventSetActivePhase(const Event_SetActivePhase &event,
 
 void TabGame::newCardAdded(AbstractCardItem *card)
 {
-    connect(card, SIGNAL(hovered(AbstractCardItem *)), cardInfo, SLOT(setCard(AbstractCardItem *)));
+    connect(card, SIGNAL(hovered(AbstractCardItem *)), cardInfoFrameWidget, SLOT(setCard(AbstractCardItem *)));
     connect(card, SIGNAL(showCardInfoPopup(QPoint, QString)), this, SLOT(showCardInfoPopup(QPoint, QString)));
     connect(card, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));
     connect(card, SIGNAL(cardShiftClicked(QString)), this, SLOT(linkCardToChat(QString)));
@@ -1809,18 +1809,18 @@ void TabGame::createDeckViewContainerWidget(bool bReplay)
 
 void TabGame::viewCardInfo(const QString &cardName)
 {
-    cardInfo->setCard(cardName);
+    cardInfoFrameWidget->setCard(cardName);
 }
 
 void TabGame::createCardInfoDock(bool bReplay)
 {
     Q_UNUSED(bReplay);
 
-    cardInfo = new CardFrame();
+    cardInfoFrameWidget = new CardInfoFrameWidget();
     cardHInfoLayout = new QHBoxLayout;
     cardVInfoLayout = new QVBoxLayout;
     cardVInfoLayout->setContentsMargins(0, 0, 0, 0);
-    cardVInfoLayout->addWidget(cardInfo);
+    cardVInfoLayout->addWidget(cardInfoFrameWidget);
     cardVInfoLayout->addLayout(cardHInfoLayout);
 
     cardBoxLayoutWidget = new QWidget;
@@ -1862,7 +1862,7 @@ void TabGame::createPlayerListDock(bool bReplay)
 void TabGame::createMessageDock(bool bReplay)
 {
     messageLog = new MessageLogWidget(tabSupervisor, tabSupervisor, this);
-    connect(messageLog, SIGNAL(cardNameHovered(QString)), cardInfo, SLOT(setCard(QString)));
+    connect(messageLog, SIGNAL(cardNameHovered(QString)), cardInfoFrameWidget, SLOT(setCard(QString)));
     connect(messageLog, SIGNAL(showCardInfoPopup(QPoint, QString)), this, SLOT(showCardInfoPopup(QPoint, QString)));
     connect(messageLog, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));
 

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -16,7 +16,7 @@ class CardDatabase;
 class GameView;
 class DeckView;
 class GameScene;
-class CardFrame;
+class CardInfoFrameWidget;
 class MessageLogWidget;
 class QTimer;
 class QSplitter;
@@ -149,7 +149,7 @@ private:
     QToolButton *replayPlayButton, *replayFastForwardButton;
     QAction *aReplaySkipForward, *aReplaySkipBackward, *aReplaySkipForwardBig, *aReplaySkipBackwardBig;
 
-    CardFrame *cardInfo;
+    CardInfoFrameWidget *cardInfoFrameWidget;
     PlayerListWidget *playerListWidget;
     QLabel *timeElapsedLabel;
     MessageLogWidget *messageLog;

--- a/cockatrice/src/client/ui/layouts/flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/flow_layout.cpp
@@ -1,0 +1,246 @@
+/**
+ * @file flow_layout.cpp
+ * @brief Implementation of the FlowLayout class, a custom layout for dynamically organizing widgets
+ * in rows within the constraints of available width or parent scroll areas.
+ */
+
+#include "flow_layout.h"
+
+#include "../widgets/general/layout_containers/flow_widget.h"
+
+#include <QDebug>
+#include <QLayoutItem>
+#include <QScrollArea>
+
+/**
+ * @brief Constructs a FlowLayout instance with the specified parent widget.
+ * @param parent The parent widget for this layout.
+ */
+FlowLayout::FlowLayout(QWidget *parent) : QLayout(parent)
+{
+}
+
+/**
+ * @brief Destructor for FlowLayout, which cleans up all items in the layout.
+ */
+FlowLayout::~FlowLayout()
+{
+    QLayoutItem *item;
+    while ((item = FlowLayout::takeAt(0))) {
+        delete item;
+    }
+}
+
+/**
+ * @brief Indicates the layout's support for expansion in both horizontal and vertical directions.
+ * @return The orientations (Qt::Horizontal | Qt::Vertical) this layout can expand to fill.
+ */
+Qt::Orientations FlowLayout::expandingDirections() const
+{
+    return Qt::Horizontal | Qt::Vertical;
+}
+
+/**
+ * @brief Indicates that this layout's height depends on its width.
+ * @return True, as the layout adjusts its height to fit the specified width.
+ */
+bool FlowLayout::hasHeightForWidth() const
+{
+    return true;
+}
+
+/**
+ * @brief Calculates the required height to display all items within the specified width.
+ * @param width The available width for arranging items.
+ * @return The total height needed to fit all items in rows constrained by the specified width.
+ */
+int FlowLayout::heightForWidth(int width) const
+{
+    int height = 0;
+    int rowWidth = 0;
+    int rowHeight = 0;
+
+    for (QLayoutItem *item : items) {
+        int itemWidth = item->sizeHint().width();
+        if (rowWidth + itemWidth > width) { // Start a new row if the row width exceeds available width
+            height += rowHeight;
+            rowWidth = itemWidth;
+            rowHeight = item->sizeHint().height();
+        } else {
+            rowWidth += itemWidth;
+            rowHeight = qMax(rowHeight, item->sizeHint().height());
+        }
+    }
+    height += rowHeight; // Add the final row's height
+    return height;
+}
+
+/**
+ * @brief Arranges layout items in rows within the specified rectangle bounds.
+ * @param rect The area within which to position layout items.
+ */
+void FlowLayout::setGeometry(const QRect &rect)
+{
+    QLayout::setGeometry(rect);
+    int availableWidth = qMax(rect.width(), getParentScrollAreaWidth());
+    int totalHeight = layoutRows(rect.x(), rect.y(), availableWidth);
+
+    QWidget *parentWidgetPtr = parentWidget();
+    if (parentWidgetPtr) {
+        parentWidgetPtr->setMinimumSize(availableWidth, totalHeight);
+    }
+}
+
+/**
+ * @brief Arranges items in rows based on the available width.
+ * @param originX The starting x-coordinate for the row layout.
+ * @param originY The starting y-coordinate for the row layout.
+ * @param availableWidth The available width to lay out items.
+ * @return The y-coordinate of the final row's end position.
+ */
+int FlowLayout::layoutRows(int originX, int originY, int availableWidth)
+{
+    QVector<QLayoutItem *> rowItems;
+    int currentXPosition = originX;
+    int currentYPosition = originY;
+
+    int rowWidth = 0;
+    int rowHeight = 0;
+
+    for (QLayoutItem *item : items) {
+        QSize itemSize = item->sizeHint();
+        if (currentXPosition + itemSize.width() > availableWidth) {
+            layoutRow(rowItems, originX, currentYPosition);
+            rowItems.clear();
+            currentXPosition = originX;
+            currentYPosition += rowHeight;
+            rowWidth = 0;
+            rowHeight = 0;
+        }
+        rowItems.append(item);
+        rowWidth += itemSize.width();
+        rowHeight = qMax(rowHeight, itemSize.height());
+        currentXPosition += itemSize.width();
+    }
+
+    layoutRow(rowItems, originX, currentYPosition);
+
+    return currentYPosition + rowHeight;
+}
+
+/**
+ * @brief Helper function for arranging a single row of items within specified bounds.
+ * @param rowItems Items to be arranged in the row.
+ * @param x The x-coordinate for starting the row.
+ * @param y The y-coordinate for starting the row.
+ */
+void FlowLayout::layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y)
+{
+    for (QLayoutItem *item : rowItems) {
+        QSize itemMaxSize = item->widget()->maximumSize();
+        int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
+        int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
+        item->setGeometry(QRect(QPoint(x, y), QSize(itemWidth, itemHeight)));
+        x += itemWidth;
+    }
+}
+
+/**
+ * @brief Returns the preferred size for this layout.
+ * @return The maximum of all item size hints as a QSize.
+ */
+QSize FlowLayout::sizeHint() const
+{
+    QSize size;
+    for (QLayoutItem *item : items) {
+        size = size.expandedTo(item->sizeHint());
+    }
+    return size.isValid() ? size : QSize(0, 0);
+}
+
+/**
+ * @brief Returns the minimum size required to display all layout items.
+ * @return The minimum QSize needed by the layout.
+ */
+QSize FlowLayout::minimumSize() const
+{
+    QSize size;
+    for (QLayoutItem *item : items) {
+        size = size.expandedTo(item->minimumSize());
+    }
+
+    size.setWidth(qMin(size.width(), getParentScrollAreaWidth()));
+    size.setHeight(qMin(size.height(), getParentScrollAreaHeight()));
+
+    return size.isValid() ? size : QSize(0, 0);
+}
+
+/**
+ * @brief Adds a new item to the layout.
+ * @param item The layout item to add.
+ */
+void FlowLayout::addItem(QLayoutItem *item)
+{
+    items.append(item);
+}
+
+/**
+ * @brief Retrieves the count of items in the layout.
+ * @return The number of layout items.
+ */
+int FlowLayout::count() const
+{
+    return items.size();
+}
+
+/**
+ * @brief Returns the layout item at the specified index.
+ * @param index The index of the item to retrieve.
+ * @return A pointer to the item at the specified index, or nullptr if out of range.
+ */
+QLayoutItem *FlowLayout::itemAt(int index) const
+{
+    return items.value(index);
+}
+
+/**
+ * @brief Removes and returns the item at the specified index.
+ * @param index The index of the item to remove.
+ * @return A pointer to the removed item, or nullptr if out of range.
+ */
+QLayoutItem *FlowLayout::takeAt(int index)
+{
+    return (index >= 0 && index < items.size()) ? items.takeAt(index) : nullptr;
+}
+
+/**
+ * @brief Gets the width of the parent scroll area, if any.
+ * @return The width of the scroll area's viewport, or 0 if not found.
+ */
+int FlowLayout::getParentScrollAreaWidth() const
+{
+    QWidget *parent = parentWidget();
+    while (parent) {
+        if (QScrollArea *scrollArea = qobject_cast<QScrollArea *>(parent)) {
+            return scrollArea->viewport()->width();
+        }
+        parent = parent->parentWidget();
+    }
+    return 0;
+}
+
+/**
+ * @brief Gets the height of the parent scroll area, if any.
+ * @return The height of the scroll area's viewport, or 0 if not found.
+ */
+int FlowLayout::getParentScrollAreaHeight() const
+{
+    QWidget *parent = parentWidget();
+    while (parent) {
+        if (QScrollArea *scrollArea = qobject_cast<QScrollArea *>(parent)) {
+            return scrollArea->viewport()->height();
+        }
+        parent = parent->parentWidget();
+    }
+    return 0;
+}

--- a/cockatrice/src/client/ui/layouts/flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/flow_layout.h
@@ -1,0 +1,35 @@
+#ifndef FLOW_LAYOUT_H
+#define FLOW_LAYOUT_H
+
+#include <QLayout>
+#include <QList>
+#include <QWidget>
+
+class FlowLayout : public QLayout
+{
+public:
+    explicit FlowLayout(QWidget *parent = nullptr);
+    ~FlowLayout();
+
+    void addItem(QLayoutItem *item) override;
+    int count() const override;
+    QLayoutItem *itemAt(int index) const override;
+    QLayoutItem *takeAt(int index) override;
+
+    Qt::Orientations expandingDirections() const override;
+    bool hasHeightForWidth() const override;
+    int heightForWidth(int width) const override;
+    int getParentScrollAreaWidth() const;
+    int getParentScrollAreaHeight() const;
+
+    void setGeometry(const QRect &rect) override;
+    virtual int layoutRows(int originX, int originY, int availableWidth);
+    virtual void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y);
+    QSize sizeHint() const override;
+    QSize minimumSize() const override;
+
+protected:
+    QList<QLayoutItem *> items; // List to store layout items
+};
+
+#endif // FLOWLAYOUT_H

--- a/cockatrice/src/client/ui/layouts/flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/flow_layout.h
@@ -4,32 +4,38 @@
 #include <QLayout>
 #include <QList>
 #include <QWidget>
+#include <qstyle.h>
 
 class FlowLayout : public QLayout
 {
 public:
     explicit FlowLayout(QWidget *parent = nullptr);
+    FlowLayout(QWidget *parent, int margin, int hSpacing, int vSpacing);
     ~FlowLayout();
 
     void addItem(QLayoutItem *item) override;
     int count() const override;
     QLayoutItem *itemAt(int index) const override;
     QLayoutItem *takeAt(int index) override;
+    int horizontalSpacing() const;
 
     Qt::Orientations expandingDirections() const override;
     bool hasHeightForWidth() const override;
     int heightForWidth(int width) const override;
+    int verticalSpacing() const;
+    int doLayout(const QRect &rect, bool testOnly) const;
+    int smartSpacing(QStyle::PixelMetric pm) const;
     int getParentScrollAreaWidth() const;
     int getParentScrollAreaHeight() const;
 
     void setGeometry(const QRect &rect) override;
-    virtual int layoutRows(int originX, int originY, int availableWidth);
-    virtual void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y);
     QSize sizeHint() const override;
     QSize minimumSize() const override;
 
 protected:
     QList<QLayoutItem *> items; // List to store layout items
+    int m_hSpace;
+    int m_vSpace;
 };
 
 #endif // FLOWLAYOUT_H

--- a/cockatrice/src/client/ui/layouts/flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/flow_layout.h
@@ -29,6 +29,8 @@ public:
     int getParentScrollAreaHeight() const;
 
     void setGeometry(const QRect &rect) override;
+    virtual int layoutRows(int originX, int originY, int availableWidth);
+    virtual void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y);
     QSize sizeHint() const override;
     QSize minimumSize() const override;
 

--- a/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
@@ -1,0 +1,128 @@
+#include "horizontal_flow_layout.h"
+
+/**
+ * @brief Constructs a HorizontalFlowLayout instance with the specified parent widget.
+ *        This layout arranges items in columns within the given height, automatically adjusting its width.
+ * @param parent The parent widget to which this layout belongs.
+ */
+HorizontalFlowLayout::HorizontalFlowLayout(QWidget *parent) : FlowLayout(parent)
+{
+}
+
+/**
+ * @brief Destructor for HorizontalFlowLayout, responsible for cleaning up layout items.
+ */
+HorizontalFlowLayout::~HorizontalFlowLayout()
+{
+    QLayoutItem *item;
+    while ((item = FlowLayout::takeAt(0))) {
+        delete item;
+    }
+}
+
+/**
+ * @brief Indicates that the layout has a variable width based on its height.
+ * @return True, as the layout adjusts its width according to the available height.
+ */
+bool HorizontalFlowLayout::hasHeightForWidth() const
+{
+    return true;
+}
+
+/**
+ * @brief Calculates the required width to display all items, given a specified height.
+ *        This method arranges items into columns and determines the total width needed.
+ * @param height The available height for arranging layout items.
+ * @return The total width required to fit all items, organized in columns constrained by the given height.
+ */
+int HorizontalFlowLayout::heightForWidth(int height) const
+{
+    int width = 0;
+    int rowWidth = 0;
+    int rowHeight = 0;
+
+    for (QLayoutItem *item : items) {
+        int itemHeight = item->sizeHint().height();
+        if (rowHeight + itemHeight > height) {
+            width += rowWidth;
+            rowHeight = itemHeight;
+            rowWidth = item->sizeHint().width();
+        } else {
+            rowHeight += itemHeight;
+            rowWidth = qMax(rowWidth, item->sizeHint().width());
+        }
+    }
+    width += rowWidth; // Add width of the last column
+    return width;
+}
+
+/**
+ * @brief Sets the geometry of the layout items, arranging them in columns within the given height.
+ * @param rect The rectangle area defining the layout space.
+ */
+void HorizontalFlowLayout::setGeometry(const QRect &rect)
+{
+    int availableHeight = qMax(rect.height(), getParentScrollAreaHeight());
+
+    int totalWidth = layoutRows(rect.x(), rect.y(), availableHeight);
+
+    QWidget *parentWidgetPtr = parentWidget();
+    if (parentWidgetPtr) {
+        parentWidgetPtr->setMinimumSize(availableHeight, totalWidth);
+    }
+}
+
+/**
+ * @brief Lays out items into columns according to the available height, starting from a given origin.
+ *        Each column is arranged within `availableHeight`, wrapping to a new column as necessary.
+ * @param originX The x-coordinate for the layout start position.
+ * @param originY The y-coordinate for the layout start position.
+ * @param availableHeight The height within which each column is constrained.
+ * @return The total width after arranging all columns.
+ */
+int HorizontalFlowLayout::layoutRows(int originX, int originY, int availableHeight)
+{
+    QVector<QLayoutItem *> rowItems;
+    int currentXPosition = originX;
+    int currentYPosition = originY;
+
+    int rowWidth = 0;
+    int rowHeight = 0;
+
+    for (QLayoutItem *item : items) {
+        QSize itemSize = item->sizeHint();
+        if (currentYPosition + itemSize.height() > availableHeight) {
+            layoutRow(rowItems, currentXPosition, originY);
+            rowItems.clear();
+            currentYPosition = originY;
+            currentXPosition += rowWidth;
+            rowWidth = 0;
+            rowHeight = 0;
+        }
+        rowItems.append(item);
+        rowHeight += itemSize.height();
+        rowWidth = qMax(rowWidth, itemSize.width());
+        currentYPosition += itemSize.height();
+    }
+
+    layoutRow(rowItems, currentXPosition, originY);
+
+    return currentXPosition + rowWidth;
+}
+
+/**
+ * @brief Arranges a single column of items within specified x and y starting positions.
+ * @param rowItems A list of items to be arranged in the column.
+ * @param x The starting x-coordinate for the column.
+ * @param y The starting y-coordinate for the column.
+ */
+void HorizontalFlowLayout::layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y)
+{
+    for (QLayoutItem *item : rowItems) {
+        QSize itemMaxSize = item->widget()->maximumSize();
+        int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
+        int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
+        item->setGeometry(QRect(QPoint(x, y), QSize(itemWidth, itemHeight)));
+        y += itemHeight;
+    }
+}

--- a/cockatrice/src/client/ui/layouts/horizontal_flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/horizontal_flow_layout.h
@@ -6,15 +6,15 @@
 class HorizontalFlowLayout : public FlowLayout
 {
 public:
-    explicit HorizontalFlowLayout(QWidget *parent = nullptr);
+    explicit HorizontalFlowLayout(QWidget *parent = nullptr, int margin = 0, int hSpacing = 0, int vSpacing = 0);
     ~HorizontalFlowLayout() override;
 
     bool hasHeightForWidth() const override;
     int heightForWidth(int width) const override;
 
     void setGeometry(const QRect &rect) override;
-    int layoutRows(int originX, int originY, int availableWidth) override;
-    void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y) override;
+    int layoutColumns(int originX, int originY, int availableWidth);
+    void layoutColumn(const QVector<QLayoutItem *> &rowItems, int x, int y);
 };
 
 #endif // HORIZONTAL_FLOW_LAYOUT_H

--- a/cockatrice/src/client/ui/layouts/horizontal_flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/horizontal_flow_layout.h
@@ -1,0 +1,20 @@
+#ifndef HORIZONTAL_FLOW_LAYOUT_H
+#define HORIZONTAL_FLOW_LAYOUT_H
+
+#include "flow_layout.h"
+
+class HorizontalFlowLayout : public FlowLayout
+{
+public:
+    explicit HorizontalFlowLayout(QWidget *parent = nullptr);
+    ~HorizontalFlowLayout() override;
+
+    bool hasHeightForWidth() const override;
+    int heightForWidth(int width) const override;
+
+    void setGeometry(const QRect &rect) override;
+    int layoutRows(int originX, int originY, int availableWidth) override;
+    void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y) override;
+};
+
+#endif // HORIZONTAL_FLOW_LAYOUT_H

--- a/cockatrice/src/client/ui/layouts/overlap_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/overlap_layout.cpp
@@ -300,3 +300,106 @@ void OverlapLayout::setMaxRows(int newValue)
 {
     maxRows = newValue;
 }
+
+/**
+ * @brief Calculates the maximum number of columns for a vertical overlap layout based on the current width.
+ *
+ * This function determines the maximum number of columns that can fit within the layout's width
+ * given the overlap percentage and item size, based on the current layout direction.
+ *
+ * @return Maximum number of columns that can fit within the layout width.
+ */
+int OverlapLayout::calculateMaxColumns() const
+{
+    if (direction != Qt::Vertical || itemList.isEmpty()) {
+        return 1; // Only relevant if the layout direction is vertical
+    }
+
+    // Determine maximum item width
+    int maxItemWidth = 0;
+    for (const QLayoutItem *item : itemList) {
+        if (item->widget()) {
+            QSize itemSize = item->widget()->sizeHint();
+            maxItemWidth = std::max(maxItemWidth, itemSize.width());
+        }
+    }
+
+    int availableWidth = parentWidget() ? parentWidget()->width() : 0;
+    // Determine the maximum number of columns that can fit
+    int columns = availableWidth / maxItemWidth;
+
+    return columns > 0 ? columns : 1;
+}
+
+/**
+ * @brief Calculates the maximum number of rows needed for a given number of columns in a vertical overlap layout.
+ *
+ * Determines how many rows are required to arrange all items given the calculated or specified number of columns.
+ *
+ * @param columns The number of columns available.
+ * @return The total number of rows required.
+ */
+int OverlapLayout::calculateRowsForColumns(int columns) const
+{
+    if (direction != Qt::Vertical || itemList.isEmpty() || columns <= 0) {
+        return 1; // Only relevant if the layout direction is vertical and there are items
+    }
+
+    int totalItems = itemList.size();
+    int rows = std::ceil(static_cast<double>(totalItems) / columns);
+
+    return rows;
+}
+
+/**
+ * @brief Calculates the maximum number of rows for a horizontal overlap layout based on the current height.
+ *
+ * This function determines the maximum number of rows that can fit within the layout's height
+ * given the overlap percentage and item size, based on the current layout direction.
+ *
+ * @return Maximum number of rows that can fit within the layout height.
+ */
+int OverlapLayout::calculateMaxRows() const
+{
+    if (direction != Qt::Horizontal || itemList.isEmpty()) {
+        return 1; // Only relevant if the layout direction is horizontal
+    }
+
+    // Determine maximum item height
+    int maxItemHeight = 0;
+    for (const QLayoutItem *item : itemList) {
+        if (item->widget()) {
+            QSize itemSize = item->widget()->sizeHint();
+            maxItemHeight = std::max(maxItemHeight, itemSize.height());
+        }
+    }
+
+    // Calculate the effective height of each item with the overlap applied
+    int overlapOffsetHeight = (maxItemHeight * (100 - overlapPercentage)) / 100;
+    int availableHeight = parentWidget() ? parentWidget()->height() : 0;
+
+    // Determine the maximum number of rows that can fit
+    int rows = availableHeight / overlapOffsetHeight;
+
+    return rows > 0 ? rows : 1;
+}
+
+/**
+ * @brief Calculates the maximum number of columns needed for a given number of rows in a horizontal overlap layout.
+ *
+ * Determines how many columns are required to arrange all items given the calculated or specified number of rows.
+ *
+ * @param rows The number of rows available.
+ * @return The total number of columns required.
+ */
+int OverlapLayout::calculateColumnsForRows(int rows) const
+{
+    if (direction != Qt::Horizontal || itemList.isEmpty() || rows <= 0) {
+        return 1; // Only relevant if the layout direction is horizontal and there are items
+    }
+
+    int totalItems = itemList.size();
+    int columns = std::ceil(static_cast<double>(totalItems) / rows);
+
+    return columns;
+}

--- a/cockatrice/src/client/ui/layouts/overlap_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/overlap_layout.cpp
@@ -1,0 +1,302 @@
+#include "overlap_layout.h"
+
+#include <QDebug>
+
+/**
+ * @class OverlapLayout
+ * @brief Custom layout class to arrange widgets with overlapping positions.
+ *
+ * The OverlapLayout class is a QLayout subclass that arranges child widgets
+ * in an overlapping configuration, allowing control over the overlap percentage
+ * and the number of rows or columns based on the chosen layout direction. This
+ * layout is particularly useful for visualizing elements that need to partially
+ * stack over one another, either horizontally or vertically.
+ */
+
+/**
+ * @brief Constructs an OverlapLayout with the specified parameters.
+ *
+ * Initializes a new OverlapLayout with the given overlap percentage, row or column limit,
+ * and layout direction. The overlap percentage determines how much each widget will
+ * overlap with the previous one. If maxColumns or maxRows are set to zero, it implies
+ * no limit in that respective dimension.
+ *
+ * @param overlapPercentage An integer representing the percentage of overlap between items (0-100).
+ * @param maxColumns The maximum number of columns allowed in the layout when in horizontal orientation (0 for unlimited).
+ * @param maxRows The maximum number of rows allowed in the layout when in vertical orientation (0 for unlimited).
+ * @param direction The orientation direction of the layout, either Qt::Horizontal or Qt::Vertical.
+ * @param parent The parent widget of this layout.
+ */
+OverlapLayout::OverlapLayout(int overlapPercentage,
+                             int maxColumns,
+                             int maxRows,
+                             Qt::Orientation direction,
+                             QWidget *parent)
+    : QLayout(parent), overlapPercentage(overlapPercentage), maxColumns(maxColumns), maxRows(maxRows),
+      direction(direction)
+{
+}
+
+/**
+ * @brief Destructor for OverlapLayout, ensuring cleanup of all layout items.
+ *
+ * Iterates through all layout items and deletes them. This prevents memory
+ * leaks by removing all child QLayoutItems stored in the layout.
+ */
+OverlapLayout::~OverlapLayout()
+{
+    QLayoutItem *item;
+    while ((item = OverlapLayout::takeAt(0))) {
+        delete item;
+    }
+}
+
+/**
+ * @brief Adds a new item to the layout.
+ *
+ * Appends a QLayoutItem to the internal list, allowing it to be positioned within the
+ * layout during the next geometry update. This method does not directly arrange the
+ * items; it merely adds them to the layout’s tracking.
+ *
+ * @param item Pointer to the QLayoutItem being added to this layout.
+ */
+void OverlapLayout::addItem(QLayoutItem *item)
+{
+    itemList.append(item);
+}
+
+/**
+ * @brief Retrieves the total count of items within the layout.
+ *
+ * Returns the number of items stored in the layout's internal item list.
+ * This count reflects how many widgets or spacers the layout is currently managing.
+ *
+ * @return Integer count of items in the layout.
+ */
+int OverlapLayout::count() const
+{
+    return itemList.size();
+}
+
+/**
+ * @brief Provides access to a layout item at a specified index.
+ *
+ * Allows retrieval of a QLayoutItem from the layout’s internal list
+ * by index. If the index is out of bounds, this function will return nullptr.
+ *
+ * @param index The index of the desired item.
+ * @return Pointer to the QLayoutItem at the specified index, or nullptr if index is invalid.
+ */
+QLayoutItem *OverlapLayout::itemAt(int index) const
+{
+    return itemList.value(index);
+}
+
+/**
+ * @brief Removes and returns a layout item at the specified index.
+ *
+ * Removes a QLayoutItem from the layout at the given index, reducing the layout's count.
+ * If the index is invalid, this function returns nullptr without any effect.
+ *
+ * @param index The index of the item to remove.
+ * @return Pointer to the removed QLayoutItem, or nullptr if index is invalid.
+ */
+QLayoutItem *OverlapLayout::takeAt(int index)
+{
+    if (index >= 0 && index < itemList.size()) {
+        return itemList.takeAt(index);
+    }
+    return nullptr;
+}
+
+/**
+ * @brief Sets the geometry for the layout items, arranging them with the specified overlap.
+ *
+ * Positions each QLayoutItem within the specified rectangle `rect`, respecting
+ * the layout’s direction, overlap percentage, and row/column limits. The method
+ * calculates the maximum allowable size for each item based on the parent widget’s dimensions.
+ * Items are then arranged with an offset based on the overlap percentage, either horizontally
+ * or vertically, depending on the layout direction. The geometry of each item is then set
+ * within the calculated bounds.
+ *
+ * @param rect The rectangle defining the area within which the layout should arrange items.
+ */
+void OverlapLayout::setGeometry(const QRect &rect)
+{
+    QLayout::setGeometry(rect);
+
+    if (itemList.isEmpty())
+        return;
+
+    QWidget *parentWidget = this->parentWidget();
+    if (parentWidget) {
+        int availableWidth = parentWidget->width();
+        int availableHeight = parentWidget->height();
+
+        QMargins margins = parentWidget->contentsMargins();
+        availableWidth -= margins.left() + margins.right();
+        availableHeight -= margins.top() + margins.bottom();
+
+        int maxItemWidth = 0;
+        int maxItemHeight = 0;
+
+        for (const QLayoutItem *item : itemList) {
+            if (item->widget()) {
+                QSize itemSize = item->widget()->sizeHint();
+                maxItemWidth = std::max(maxItemWidth, itemSize.width());
+                maxItemHeight = std::max(maxItemHeight, itemSize.height());
+            }
+        }
+
+        int overlapOffsetWidth = (direction == Qt::Horizontal) ? (maxItemWidth * overlapPercentage / 100) : 0;
+        int overlapOffsetHeight = (direction == Qt::Vertical) ? (maxItemHeight * overlapPercentage / 100) : 0;
+
+        int columns = (direction == Qt::Horizontal)
+                          ? (maxColumns > 0 ? std::min(maxColumns, (availableWidth + overlapOffsetWidth) /
+                                                                       (maxItemWidth - overlapOffsetWidth))
+                                            : INT_MAX)
+                          : INT_MAX;
+        int rows = (direction == Qt::Vertical)
+                       ? (maxRows > 0 ? std::min(maxRows, (availableHeight + overlapOffsetHeight) /
+                                                              (maxItemHeight - overlapOffsetHeight))
+                                      : INT_MAX)
+                       : INT_MAX;
+
+        int currentRow = 0;
+        int currentColumn = 0;
+
+        for (int i = 0; i < itemList.size(); ++i) {
+            QLayoutItem *item = itemList.at(i);
+            int xPos = rect.left() + currentColumn * (maxItemWidth - overlapOffsetWidth);
+            int yPos = rect.top() + currentRow * (maxItemHeight - overlapOffsetHeight);
+            item->setGeometry(QRect(xPos, yPos, maxItemWidth, maxItemHeight));
+
+            if (direction == Qt::Horizontal) {
+                currentColumn++;
+                if (currentColumn >= columns) {
+                    currentColumn = 0;
+                    currentRow++;
+                }
+            } else {
+                currentRow++;
+                if (currentRow >= rows) {
+                    currentRow = 0;
+                    currentColumn++;
+                }
+            }
+        }
+    }
+}
+
+/**
+ * @brief Calculates the preferred size for the layout, considering overlap and orientation.
+ *
+ * Determines an optimal size for the layout by calculating the area needed to arrange all
+ * items with the desired overlap. This calculation considers the number of rows/columns,
+ * item size, overlap offset, and the layout's direction. Useful for setting a size hint
+ * when the layout is used within other widgets.
+ *
+ * @return The preferred layout size as a QSize object.
+ */
+QSize OverlapLayout::calculatePreferredSize() const
+{
+    QSize preferredSize(0, 0);
+
+    int maxItemWidth = 0;
+    int maxItemHeight = 0;
+
+    for (const QLayoutItem *item : itemList) {
+        if (item->widget()) {
+            QSize itemSize = item->widget()->sizeHint();
+            maxItemWidth = std::max(maxItemWidth, itemSize.width());
+            maxItemHeight = std::max(maxItemHeight, itemSize.height());
+        }
+    }
+
+    int extra_for_overlap = (100 - overlapPercentage);
+    int overlapOffsetWidth =
+        (direction == Qt::Horizontal) ? static_cast<int>(std::round((maxItemWidth / 100.0) * extra_for_overlap)) : 0;
+    int overlapOffsetHeight =
+        (direction == Qt::Vertical) ? static_cast<int>(std::round((maxItemHeight / 100.0) * extra_for_overlap)) : 0;
+
+    int totalWidth = 0;
+    int totalHeight = 0;
+
+    if (direction == Qt::Horizontal) {
+        int numColumns = (maxColumns > 0) ? maxColumns : itemList.size();
+        int extra_space_for_overlaps = overlapOffsetWidth * (numColumns - 1);
+        totalWidth = maxItemWidth + extra_space_for_overlaps;
+
+        int numRows = (maxColumns > 0) ? ceil(itemList.size() / static_cast<double>(maxRows)) : 1;
+        totalHeight = maxItemHeight * numRows - (numRows - 1) * overlapOffsetHeight;
+    } else if (direction == Qt::Vertical) {
+        int numColumns = (maxRows != 0) ? ceil(itemList.size() / static_cast<double>(maxRows)) : 1;
+        totalWidth = maxItemWidth * numColumns - (numColumns - 1) * overlapOffsetWidth;
+
+        int numRows = (maxRows > 0) ? maxRows : itemList.size();
+        int extra_space_for_overlaps = overlapOffsetHeight * (numRows - 1);
+        totalHeight = maxItemHeight + extra_space_for_overlaps;
+    }
+
+    preferredSize = QSize(totalWidth, totalHeight);
+
+    return preferredSize;
+}
+
+/**
+ * @brief Returns the size hint for the layout, based on preferred size calculations.
+ *
+ * Provides a recommended size for the layout, useful for layouts that need to fit within
+ * a specific parent container size. This takes into account the preferred size and
+ * any specific item size requirements.
+ *
+ * @return The layout's recommended QSize.
+ */
+QSize OverlapLayout::sizeHint() const
+{
+    return calculatePreferredSize();
+}
+
+/**
+ * @brief Provides the minimum size hint for the layout, ensuring functionality within constraints.
+ *
+ * Defines a minimum workable size for the layout to prevent excessive compression
+ * that could distort item arrangement.
+ *
+ * @return The minimum QSize for this layout.
+ */
+QSize OverlapLayout::minimumSize() const
+{
+    return calculatePreferredSize();
+}
+
+
+/**
+ * @brief Sets the layout's orientation direction.
+ *
+ * @param new_direction The new orientation direction (Qt::Horizontal or Qt::Vertical).
+ */
+void OverlapLayout::setDirection(Qt::Orientation new_direction)
+{
+    direction = new_direction;
+}
+
+/**
+ * @brief Sets the maximum number of columns for horizontal orientation.
+ *
+ * @param newValue New maximum column count.
+ */
+void OverlapLayout::setMaxColumns(int newValue)
+{
+    maxColumns = newValue;
+}
+
+/**
+ * @brief Sets the maximum number of rows for vertical orientation.
+ *
+ * @param newValue New maximum row count.
+ */
+void OverlapLayout::setMaxRows(int newValue)
+{
+    maxRows = newValue;
+}

--- a/cockatrice/src/client/ui/layouts/overlap_layout.h
+++ b/cockatrice/src/client/ui/layouts/overlap_layout.h
@@ -1,0 +1,36 @@
+#ifndef OVERLAP_LAYOUT_H
+#define OVERLAP_LAYOUT_H
+
+#include <QLayout>
+#include <QList>
+#include <QWidget>
+
+
+class OverlapLayout : public QLayout {
+public:
+    OverlapLayout(int overlapPercentage = 10, int maxColumns = 2, int maxRows = 2, Qt::Orientation direction = Qt::Horizontal, QWidget* parent = nullptr);
+    ~OverlapLayout();
+
+    void addItem(QLayoutItem* item) override;
+    int count() const override;
+    QLayoutItem* itemAt(int index) const override;
+    QLayoutItem* takeAt(int index) override;
+    void setGeometry(const QRect& rect) override;
+    QSize minimumSize() const override;
+    QSize sizeHint() const override;
+    void setMaxColumns(int newValue);
+    void setMaxRows(int newValue);
+    void setDirection(Qt::Orientation direction);
+
+private:
+    QList<QLayoutItem*> itemList;
+    int overlapPercentage;
+    int maxColumns;
+    int maxRows;
+    Qt::Orientation direction;
+
+    // Calculate the preferred size of the layout
+    QSize calculatePreferredSize() const;
+};
+
+#endif // OVERLAP_LAYOUT_H

--- a/cockatrice/src/client/ui/layouts/overlap_layout.h
+++ b/cockatrice/src/client/ui/layouts/overlap_layout.h
@@ -20,6 +20,10 @@ public:
     QSize sizeHint() const override;
     void setMaxColumns(int newValue);
     void setMaxRows(int newValue);
+    int calculateMaxColumns() const;
+    int calculateRowsForColumns(int columns) const;
+    int calculateMaxRows() const;
+    int calculateColumnsForRows(int rows) const;
     void setDirection(Qt::Orientation direction);
 
 private:

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
@@ -4,8 +4,12 @@
  * @brief Constructs a VerticalFlowLayout instance with the specified parent widget.
  *        This layout arranges items in rows within the given width, automatically adjusting its height.
  * @param parent The parent widget to which this layout belongs.
+ * @param margin The layout margin.
+ * @param hSpacing The horizontal spacing between items.
+ * @param vSpacing The vertical spacing between items.
  */
-VerticalFlowLayout::VerticalFlowLayout(QWidget *parent) : FlowLayout(parent)
+VerticalFlowLayout::VerticalFlowLayout(QWidget *parent, int margin, int hSpacing, int vSpacing)
+    : FlowLayout(parent, margin, hSpacing, vSpacing)
 {
 }
 
@@ -42,9 +46,9 @@ int VerticalFlowLayout::heightForWidth(int width) const
     int rowHeight = 0;
 
     for (QLayoutItem *item : items) {
-        int itemWidth = item->sizeHint().width();
+        int itemWidth = item->sizeHint().width() + horizontalSpacing();
         if (rowWidth + itemWidth > width) {
-            height += rowHeight;
+            height += rowHeight + verticalSpacing();
             rowWidth = itemWidth;
             rowHeight = item->sizeHint().height();
         } else {
@@ -92,18 +96,21 @@ int VerticalFlowLayout::layoutRows(int originX, int originY, int availableWidth)
 
     for (QLayoutItem *item : items) {
         QSize itemSize = item->sizeHint();
-        if (currentXPosition + itemSize.width() > availableWidth) {
+        int itemWidth = itemSize.width() + horizontalSpacing();
+
+        if (currentXPosition + itemWidth > availableWidth) {
             layoutRow(rowItems, originX, currentYPosition);
             rowItems.clear();
             currentXPosition = originX;
-            currentYPosition += rowHeight;
+            currentYPosition += rowHeight + verticalSpacing();
             rowWidth = 0;
             rowHeight = 0;
         }
+
         rowItems.append(item);
-        rowWidth += itemSize.width();
+        rowWidth += itemWidth;
         rowHeight = qMax(rowHeight, itemSize.height());
-        currentXPosition += itemSize.width();
+        currentXPosition += itemWidth;
     }
 
     layoutRow(rowItems, originX, currentYPosition);
@@ -124,6 +131,6 @@ void VerticalFlowLayout::layoutRow(const QVector<QLayoutItem *> &rowItems, int x
         int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
         int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
         item->setGeometry(QRect(QPoint(x, y), QSize(itemWidth, itemHeight)));
-        x += itemWidth;
+        x += itemWidth + horizontalSpacing(); // Include horizontal spacing between items
     }
 }

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
@@ -108,9 +108,9 @@ int VerticalFlowLayout::layoutRows(int originX, int originY, int availableWidth)
         }
 
         rowItems.append(item);
-        rowWidth += itemWidth;
+        rowWidth += itemWidth + horizontalSpacing();
         rowHeight = qMax(rowHeight, itemSize.height());
-        currentXPosition += itemWidth;
+        currentXPosition += itemWidth + horizontalSpacing();
     }
 
     layoutRow(rowItems, originX, currentYPosition);

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
@@ -1,0 +1,128 @@
+#include "vertical_flow_layout.h"
+
+/**
+ * @brief Constructs a VerticalFlowLayout instance with the specified parent widget.
+ *        This layout arranges items in rows within the given width, automatically adjusting its height.
+ * @param parent The parent widget to which this layout belongs.
+ */
+VerticalFlowLayout::VerticalFlowLayout(QWidget *parent) : FlowLayout(parent)
+{
+}
+
+/**
+ * @brief Destructor for VerticalFlowLayout, responsible for cleaning up layout items.
+ */
+VerticalFlowLayout::~VerticalFlowLayout()
+{
+    QLayoutItem *item;
+    while ((item = FlowLayout::takeAt(0))) {
+        delete item;
+    }
+}
+
+/**
+ * @brief Indicates that the layout has a variable height based on its width.
+ * @return True, as the layout adjusts its height according to the available width.
+ */
+bool VerticalFlowLayout::hasHeightForWidth() const
+{
+    return true;
+}
+
+/**
+ * @brief Calculates the required height to display all items, given a specified width.
+ *        This method arranges items into rows and determines the total height needed.
+ * @param width The available width for arranging layout items.
+ * @return The total height required to fit all items, organized in rows constrained by the given width.
+ */
+int VerticalFlowLayout::heightForWidth(int width) const
+{
+    int height = 0;
+    int rowWidth = 0;
+    int rowHeight = 0;
+
+    for (QLayoutItem *item : items) {
+        int itemWidth = item->sizeHint().width();
+        if (rowWidth + itemWidth > width) {
+            height += rowHeight;
+            rowWidth = itemWidth;
+            rowHeight = item->sizeHint().height();
+        } else {
+            rowWidth += itemWidth;
+            rowHeight = qMax(rowHeight, item->sizeHint().height());
+        }
+    }
+    height += rowHeight; // Add height of the last row
+    return height;
+}
+
+/**
+ * @brief Sets the geometry of the layout items, arranging them in rows within the given width.
+ * @param rect The rectangle area defining the layout space.
+ */
+void VerticalFlowLayout::setGeometry(const QRect &rect)
+{
+    int availableWidth = qMax(rect.width(), getParentScrollAreaWidth());
+
+    int totalHeight = layoutRows(rect.x(), rect.y(), availableWidth);
+
+    QWidget *parentWidgetPtr = parentWidget();
+    if (parentWidgetPtr) {
+        parentWidgetPtr->setMinimumSize(availableWidth, totalHeight);
+    }
+}
+
+/**
+ * @brief Lays out items into rows according to the available width, starting from a given origin.
+ *        Each row is arranged within `availableWidth`, wrapping to a new row as necessary.
+ * @param originX The x-coordinate for the layout start position.
+ * @param originY The y-coordinate for the layout start position.
+ * @param availableWidth The width within which each row is constrained.
+ * @return The total height after arranging all rows.
+ */
+int VerticalFlowLayout::layoutRows(int originX, int originY, int availableWidth)
+{
+    QVector<QLayoutItem *> rowItems;
+    int currentXPosition = originX;
+    int currentYPosition = originY;
+
+    int rowWidth = 0;
+    int rowHeight = 0;
+
+    for (QLayoutItem *item : items) {
+        QSize itemSize = item->sizeHint();
+        if (currentXPosition + itemSize.width() > availableWidth) {
+            layoutRow(rowItems, originX, currentYPosition);
+            rowItems.clear();
+            currentXPosition = originX;
+            currentYPosition += rowHeight;
+            rowWidth = 0;
+            rowHeight = 0;
+        }
+        rowItems.append(item);
+        rowWidth += itemSize.width();
+        rowHeight = qMax(rowHeight, itemSize.height());
+        currentXPosition += itemSize.width();
+    }
+
+    layoutRow(rowItems, originX, currentYPosition);
+
+    return currentYPosition + rowHeight;
+}
+
+/**
+ * @brief Arranges a single row of items within specified x and y starting positions.
+ * @param rowItems A list of items to be arranged in the row.
+ * @param x The starting x-coordinate for the row.
+ * @param y The starting y-coordinate for the row.
+ */
+void VerticalFlowLayout::layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y)
+{
+    for (QLayoutItem *item : rowItems) {
+        QSize itemMaxSize = item->widget()->maximumSize();
+        int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
+        int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
+        item->setGeometry(QRect(QPoint(x, y), QSize(itemWidth, itemHeight)));
+        x += itemWidth;
+    }
+}

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
@@ -62,7 +62,8 @@ int VerticalFlowLayout::heightForWidth(int width) const
  */
 void VerticalFlowLayout::setGeometry(const QRect &rect)
 {
-    int availableWidth = qMax(rect.width(), getParentScrollAreaWidth());
+    // If we have a parent scroll area, we're clamped to that, else we use our own rectangle.
+    int availableWidth = getParentScrollAreaWidth() == 0 ? rect.width() : getParentScrollAreaWidth();
 
     int totalHeight = layoutRows(rect.x(), rect.y(), availableWidth);
 

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.h
@@ -6,15 +6,15 @@
 class VerticalFlowLayout : public FlowLayout
 {
 public:
-    explicit VerticalFlowLayout(QWidget *parent = nullptr);
+    explicit VerticalFlowLayout(QWidget *parent = nullptr, int margin = 0, int hSpacing = 0, int vSpacing = 0);
     ~VerticalFlowLayout() override;
 
     bool hasHeightForWidth() const override;
     int heightForWidth(int width) const override;
 
     void setGeometry(const QRect &rect) override;
-    int layoutRows(int originX, int originY, int availableWidth) override;
-    void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y) override;
+    int layoutRows(int originX, int originY, int availableWidth);
+    void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y);
 };
 
 #endif // VERTICAL_FLOW_LAYOUT_H

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.h
@@ -1,0 +1,20 @@
+#ifndef VERTICAL_FLOW_LAYOUT_H
+#define VERTICAL_FLOW_LAYOUT_H
+
+#include "flow_layout.h"
+
+class VerticalFlowLayout : public FlowLayout
+{
+public:
+    explicit VerticalFlowLayout(QWidget *parent = nullptr);
+    ~VerticalFlowLayout() override;
+
+    bool hasHeightForWidth() const override;
+    int heightForWidth(int width) const override;
+
+    void setGeometry(const QRect &rect) override;
+    int layoutRows(int originX, int originY, int availableWidth) override;
+    void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y) override;
+};
+
+#endif // VERTICAL_FLOW_LAYOUT_H

--- a/cockatrice/src/client/ui/picture_loader.cpp
+++ b/cockatrice/src/client/ui/picture_loader.cpp
@@ -175,8 +175,8 @@ void PictureLoaderWorker::processLoadQueue()
         QString cardName = cardBeingLoaded.getCard()->getName();
         QString correctedCardName = cardBeingLoaded.getCard()->getCorrectedName();
 
-        qDebug().nospace() << "PictureLoader: [card: " << cardName << " set: " << setName
-                           << "]: Trying to load picture";
+        //qDebug().nospace() << "PictureLoader: [card: " << cardName << " set: " << setName
+        //                   << "]: Trying to load picture";
 
         if (CardDatabaseManager::getInstance()->isUuidForPreferredPrinting(
                 cardName, cardBeingLoaded.getCard()->getPixmapCacheKey())) {
@@ -185,8 +185,8 @@ void PictureLoaderWorker::processLoadQueue()
             }
         }
 
-        qDebug().nospace() << "PictureLoader: [card: " << cardName << " set: " << setName
-                           << "]: No custom picture, trying to download";
+        //qDebug().nospace() << "PictureLoader: [card: " << cardName << " set: " << setName
+        //                   << "]: No custom picture, trying to download";
         cardsToDownload.append(cardBeingLoaded);
         cardBeingLoaded.clear();
         if (!downloadRunning) {
@@ -228,22 +228,22 @@ bool PictureLoaderWorker::cardImageExistsOnDisk(QString &setName, QString &corre
     for (const auto &_picsPath : picsPaths) {
         imgReader.setFileName(_picsPath);
         if (imgReader.read(&image)) {
-            qDebug().nospace() << "PictureLoader: [card: " << correctedCardname << " set: " << setName
-                               << "]: Picture found on disk.";
+            //qDebug().nospace() << "PictureLoader: [card: " << correctedCardname << " set: " << setName
+            //                   << "]: Picture found on disk.";
             imageLoaded(cardBeingLoaded.getCard(), image);
             return true;
         }
         imgReader.setFileName(_picsPath + ".full");
         if (imgReader.read(&image)) {
-            qDebug().nospace() << "PictureLoader: [card: " << correctedCardname << " set: " << setName
-                               << "]: Picture.full found on disk.";
+            //qDebug().nospace() << "PictureLoader: [card: " << correctedCardname << " set: " << setName
+            //                   << "]: Picture.full found on disk.";
             imageLoaded(cardBeingLoaded.getCard(), image);
             return true;
         }
         imgReader.setFileName(_picsPath + ".xlhq");
         if (imgReader.read(&image)) {
-            qDebug().nospace() << "PictureLoader: [card: " << correctedCardname << " set: " << setName
-                               << "]: Picture.xlhq found on disk.";
+            //qDebug().nospace() << "PictureLoader: [card: " << correctedCardname << " set: " << setName
+            //                   << "]: Picture.xlhq found on disk.";
             imageLoaded(cardBeingLoaded.getCard(), image);
             return true;
         }
@@ -259,6 +259,8 @@ static int parse(const QString &urlTemplate,
                  std::function<QString(const QString &)> getProperty,
                  QMap<QString, QString> &transformMap)
 {
+    (void) cardName;
+    (void) setName;
     static const QRegularExpression rxFillWith("^(.+)_fill_with_(.+)$");
     static const QRegularExpression rxSubStr("^(.+)_substr_(\\d+)_(\\d+)$");
 
@@ -289,18 +291,18 @@ static int parse(const QString &urlTemplate,
         }
         QString propertyValue = getProperty(cardPropertyName);
         if (propertyValue.isEmpty()) {
-            qDebug().nospace() << "PictureLoader: [card: " << cardName << " set: " << setName << "]: Requested "
-                               << propType << "property (" << cardPropertyName << ") for Url template (" << urlTemplate
-                               << ") is not available";
+            //qDebug().nospace() << "PictureLoader: [card: " << cardName << " set: " << setName << "]: Requested "
+            //                   << propType << "property (" << cardPropertyName << ") for Url template (" << urlTemplate
+            //                   << ") is not available";
             return 1;
         } else {
             int propLength = propertyValue.length();
             if (subStrLen > 0) {
                 if (subStrPos + subStrLen > propLength) {
-                    qDebug().nospace() << "PictureLoader: [card: " << cardName << " set: " << setName << "]: Requested "
-                                       << propType << " property (" << cardPropertyName << ") for Url template ("
-                                       << urlTemplate << ") is smaller than substr specification (" << subStrPos
-                                       << " + " << subStrLen << " > " << propLength << ")";
+                    //qDebug().nospace() << "PictureLoader: [card: " << cardName << " set: " << setName << "]: Requested "
+                    //                   << propType << " property (" << cardPropertyName << ") for Url template ("
+                    //                   << urlTemplate << ") is smaller than substr specification (" << subStrPos
+                    //                   << " + " << subStrLen << " > " << propLength << ")";
                     return 1;
                 } else {
                     propertyValue = propertyValue.mid(subStrPos, subStrLen);
@@ -311,9 +313,9 @@ static int parse(const QString &urlTemplate,
             if (!fillWith.isEmpty()) {
                 int fillLength = fillWith.length();
                 if (fillLength < propLength) {
-                    qDebug().nospace() << "PictureLoader: [card: " << cardName << " set: " << setName << "]: Requested "
-                                       << propType << " property (" << cardPropertyName << ") for Url template ("
-                                       << urlTemplate << ") is longer than fill specification (" << fillWith << ")";
+                    //qDebug().nospace() << "PictureLoader: [card: " << cardName << " set: " << setName << "]: Requested "
+                    //                   << propType << " property (" << cardPropertyName << ") for Url template ("
+                    //                   << urlTemplate << ") is longer than fill specification (" << fillWith << ")";
                     return 1;
                 } else {
 
@@ -380,9 +382,9 @@ QString PictureToLoad::transformUrl(const QString &urlTemplate) const
                  * populated in this card, so it should return an empty string,
                  * indicating an invalid Url.
                  */
-                qDebug().nospace() << "PictureLoader: [card: " << cardName << " set: " << setName
-                                   << "]: Requested information (" << prop << ") for Url template (" << urlTemplate
-                                   << ") is not available";
+                //qDebug().nospace() << "PictureLoader: [card: " << cardName << " set: " << setName
+                //                   << "]: Requested information (" << prop << ") for Url template (" << urlTemplate
+                //                   << ") is not available";
                 return QString();
             }
         }
@@ -410,9 +412,9 @@ void PictureLoaderWorker::startNextPicDownload()
         picDownloadFailed();
     } else {
         QUrl url(picUrl);
-        qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
-                           << " set: " << cardBeingDownloaded.getSetName() << "]: Trying to fetch picture from url "
-                           << url.toDisplayString();
+        //qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
+        //                   << " set: " << cardBeingDownloaded.getSetName() << "]: Trying to fetch picture from url "
+        //                   << url.toDisplayString();
         makeRequest(url);
     }
 }
@@ -428,10 +430,10 @@ void PictureLoaderWorker::picDownloadFailed()
         loadQueue.prepend(cardBeingDownloaded);
         mutex.unlock();
     } else {
-        qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
-                           << " set: " << cardBeingDownloaded.getSetName() << "]: Picture NOT found, "
-                           << (picDownload ? "download failed" : "downloads disabled")
-                           << ", no more url combinations to try: BAILING OUT";
+        //qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
+        //                   << " set: " << cardBeingDownloaded.getSetName() << "]: Picture NOT found, "
+        //                   << (picDownload ? "download failed" : "downloads disabled")
+        //                   << ", no more url combinations to try: BAILING OUT";
         imageLoaded(cardBeingDownloaded.getCard(), QImage());
         cardBeingDownloaded.clear();
     }
@@ -459,19 +461,19 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
 
     if (reply->error()) {
         if (isFromCache) {
-            qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
-                               << " set: " << cardBeingDownloaded.getSetName()
-                               << "]: Removing corrupted cache file for url " << reply->url().toDisplayString()
-                               << " and retrying (" << reply->errorString() << ")";
+            //qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+            //                   << " set: " << cardBeingDownloaded.getSetName()
+            //                   << "]: Removing corrupted cache file for url " << reply->url().toDisplayString()
+            //                   << " and retrying (" << reply->errorString() << ")";
 
             networkManager->cache()->remove(reply->url());
 
             makeRequest(reply->url());
         } else {
-            qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
-                               << " set: " << cardBeingDownloaded.getSetName()
-                               << "]: " << (picDownload ? "Download" : "Cache search") << " failed for url "
-                               << reply->url().toDisplayString() << " (" << reply->errorString() << ")";
+            //qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+            //                   << " set: " << cardBeingDownloaded.getSetName()
+            //                   << "]: " << (picDownload ? "Download" : "Cache search") << " failed for url "
+            //                   << reply->url().toDisplayString() << " (" << reply->errorString() << ")";
 
             picDownloadFailed();
             startNextPicDownload();
@@ -486,9 +488,9 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
     if (statusCode == 301 || statusCode == 302 || statusCode == 303 || statusCode == 305 || statusCode == 307 ||
         statusCode == 308) {
         QUrl redirectUrl = reply->header(QNetworkRequest::LocationHeader).toUrl();
-        qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
-                           << " set: " << cardBeingDownloaded.getSetName() << "]: following "
-                           << (isFromCache ? "cached redirect" : "redirect") << " to " << redirectUrl.toDisplayString();
+        //qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+        //                   << " set: " << cardBeingDownloaded.getSetName() << "]: following "
+        //                   << (isFromCache ? "cached redirect" : "redirect") << " to " << redirectUrl.toDisplayString();
         makeRequest(redirectUrl);
         reply->deleteLater();
         return;
@@ -498,9 +500,9 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
     const QByteArray &picData = reply->peek(reply->size());
 
     if (imageIsBlackListed(picData)) {
-        qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
-                           << " set: " << cardBeingDownloaded.getSetName()
-                           << "]: Picture found, but blacklisted, will consider it as not found";
+        //qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+        //                   << " set: " << cardBeingDownloaded.getSetName()
+        //                   << "]: Picture found, but blacklisted, will consider it as not found";
 
         picDownloadFailed();
         reply->deleteLater();
@@ -533,19 +535,19 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
         imageLoaded(cardBeingDownloaded.getCard(), testImage);
         logSuccessMessage = true;
     } else {
-        qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
-                           << " set: " << cardBeingDownloaded.getSetName() << "]: Possible "
-                           << (isFromCache ? "cached" : "downloaded") << " picture at "
-                           << reply->url().toDisplayString() << " could not be loaded: " << reply->errorString();
+        //qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+        //                   << " set: " << cardBeingDownloaded.getSetName() << "]: Possible "
+        //                   << (isFromCache ? "cached" : "downloaded") << " picture at "
+        //                   << reply->url().toDisplayString() << " could not be loaded: " << reply->errorString();
 
         picDownloadFailed();
     }
 
     if (logSuccessMessage) {
-        qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
-                           << " set: " << cardBeingDownloaded.getSetName() << "]: Image successfully "
-                           << (isFromCache ? "loaded from cached" : "downloaded from") << " url "
-                           << reply->url().toDisplayString();
+        //qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+        //                   << " set: " << cardBeingDownloaded.getSetName() << "]: Image successfully "
+        //                   << (isFromCache ? "loaded from cached" : "downloaded from") << " url "
+        //                   << reply->url().toDisplayString();
     }
 
     reply->deleteLater();
@@ -612,7 +614,7 @@ void PictureLoader::getCardBackPixmap(QPixmap &pixmap, QSize size)
 {
     QString backCacheKey = "_trice_card_back_" + QString::number(size.width()) + QString::number(size.height());
     if (!QPixmapCache::find(backCacheKey, &pixmap)) {
-        qDebug() << "PictureLoader: cache fail for" << backCacheKey;
+        //qDebug() << "PictureLoader: cache fail for" << backCacheKey;
         pixmap = QPixmap("theme:cardback").scaled(size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
         QPixmapCache::insert(backCacheKey, pixmap);
     }

--- a/cockatrice/src/client/ui/widgets/cards/card_info_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_display_widget.cpp
@@ -1,7 +1,7 @@
 #include "card_info_display_widget.h"
 
 #include "../../../../main.h"
-#include "card_database_manager.h"
+#include "../../../../game/cards/card_database_manager.h"
 #include "card_info_picture_widget.h"
 #include "card_info_text_widget.h"
 #include "../../../../game/cards/card_item.h"

--- a/cockatrice/src/client/ui/widgets/cards/card_info_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_display_widget.cpp
@@ -1,23 +1,23 @@
-#include "card_info_widget.h"
+#include "card_info_display_widget.h"
 
-#include "../../main.h"
+#include "../../../../main.h"
 #include "card_database_manager.h"
-#include "card_info_picture.h"
-#include "card_info_text.h"
-#include "card_item.h"
+#include "card_info_picture_widget.h"
+#include "card_info_text_widget.h"
+#include "../../../../game/cards/card_item.h"
 
 #include <QApplication>
 #include <QScreen>
 #include <QVBoxLayout>
 #include <utility>
 
-CardInfoWidget::CardInfoWidget(const QString &cardName, QWidget *parent, Qt::WindowFlags flags)
+CardInfoDisplayWidget::CardInfoDisplayWidget(const QString &cardName, QWidget *parent, Qt::WindowFlags flags)
     : QFrame(parent, flags), aspectRatio((qreal)CARD_HEIGHT / (qreal)CARD_WIDTH), info(nullptr)
 {
     setContentsMargins(3, 3, 3, 3);
-    pic = new CardInfoPicture();
+    pic = new CardInfoPictureWidget();
     pic->setObjectName("pic");
-    text = new CardInfoText();
+    text = new CardInfoTextWidget();
     text->setObjectName("text");
     connect(text, SIGNAL(linkActivated(const QString &)), this, SLOT(setCard(const QString &)));
 
@@ -43,7 +43,7 @@ CardInfoWidget::CardInfoWidget(const QString &cardName, QWidget *parent, Qt::Win
     resize(width(), sizeHint().height());
 }
 
-void CardInfoWidget::setCard(CardInfoPtr card)
+void CardInfoDisplayWidget::setCard(CardInfoPtr card)
 {
     if (info)
         disconnect(info.data(), nullptr, this, nullptr);
@@ -55,7 +55,7 @@ void CardInfoWidget::setCard(CardInfoPtr card)
     pic->setCard(info);
 }
 
-void CardInfoWidget::setCard(const QString &cardName)
+void CardInfoDisplayWidget::setCard(const QString &cardName)
 {
     setCard(CardDatabaseManager::getInstance()->guessCard(cardName));
     if (info == nullptr) {
@@ -63,12 +63,12 @@ void CardInfoWidget::setCard(const QString &cardName)
     }
 }
 
-void CardInfoWidget::setCard(AbstractCardItem *card)
+void CardInfoDisplayWidget::setCard(AbstractCardItem *card)
 {
     setCard(card->getInfo());
 }
 
-void CardInfoWidget::clear()
+void CardInfoDisplayWidget::clear()
 {
     setCard((CardInfoPtr) nullptr);
 }

--- a/cockatrice/src/client/ui/widgets/cards/card_info_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_display_widget.h
@@ -1,28 +1,28 @@
 #ifndef CARDINFOWIDGET_H
 #define CARDINFOWIDGET_H
 
-#include "card_database.h"
+#include "../../../../game/cards/card_database.h"
 
 #include <QComboBox>
 #include <QFrame>
 #include <QStringList>
 
-class CardInfoPicture;
-class CardInfoText;
+class CardInfoPictureWidget;
+class CardInfoTextWidget;
 class AbstractCardItem;
 
-class CardInfoWidget : public QFrame
+class CardInfoDisplayWidget : public QFrame
 {
     Q_OBJECT
 
 private:
     qreal aspectRatio;
     CardInfoPtr info;
-    CardInfoPicture *pic;
-    CardInfoText *text;
+    CardInfoPictureWidget *pic;
+    CardInfoTextWidget *text;
 
 public:
-    explicit CardInfoWidget(const QString &cardName, QWidget *parent = nullptr, Qt::WindowFlags f = {});
+    explicit CardInfoDisplayWidget(const QString &cardName, QWidget *parent = nullptr, Qt::WindowFlags f = {});
 
 public slots:
     void setCard(CardInfoPtr card);

--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
@@ -1,22 +1,22 @@
-#include "card_frame.h"
+#include "card_info_frame_widget.h"
 
-#include "../../main.h"
-#include "../../settings/cache_settings.h"
+#include "../../../../game/cards/card_item.h"
+#include "../../../../main.h"
+#include "../../../../settings/cache_settings.h"
 #include "card_database_manager.h"
-#include "card_info_picture.h"
-#include "card_info_text.h"
-#include "card_item.h"
+#include "card_info_picture_widget.h"
+#include "card_info_text_widget.h"
 
 #include <QSplitter>
 #include <QVBoxLayout>
 #include <utility>
 
-CardFrame::CardFrame(const QString &cardName, QWidget *parent) : QTabWidget(parent), info(nullptr), cardTextOnly(false)
+CardInfoFrameWidget::CardInfoFrameWidget(const QString &cardName, QWidget *parent) : QTabWidget(parent), info(nullptr), cardTextOnly(false)
 {
     setContentsMargins(3, 3, 3, 3);
-    pic = new CardInfoPicture();
+    pic = new CardInfoPictureWidget();
     pic->setObjectName("pic");
-    text = new CardInfoText();
+    text = new CardInfoTextWidget();
     text->setObjectName("text");
     connect(text, SIGNAL(linkActivated(const QString &)), this, SLOT(setCard(const QString &)));
 
@@ -61,14 +61,14 @@ CardFrame::CardFrame(const QString &cardName, QWidget *parent) : QTabWidget(pare
     setCard(CardDatabaseManager::getInstance()->getCard(cardName));
 }
 
-void CardFrame::retranslateUi()
+void CardInfoFrameWidget::retranslateUi()
 {
     setTabText(ImageOnlyView, tr("Image"));
     setTabText(TextOnlyView, tr("Description"));
     setTabText(ImageAndTextView, tr("Both"));
 }
 
-void CardFrame::setViewMode(int mode)
+void CardInfoFrameWidget::setViewMode(int mode)
 {
     if (currentIndex() != mode)
         setCurrentIndex(mode);
@@ -90,7 +90,7 @@ void CardFrame::setViewMode(int mode)
     SettingsCache::instance().setCardInfoViewMode(mode);
 }
 
-void CardFrame::setCard(CardInfoPtr card)
+void CardInfoFrameWidget::setCard(CardInfoPtr card)
 {
     if (info) {
         disconnect(info.data(), nullptr, this, nullptr);
@@ -106,19 +106,19 @@ void CardFrame::setCard(CardInfoPtr card)
     pic->setCard(info);
 }
 
-void CardFrame::setCard(const QString &cardName)
+void CardInfoFrameWidget::setCard(const QString &cardName)
 {
     setCard(CardDatabaseManager::getInstance()->guessCard(cardName));
 }
 
-void CardFrame::setCard(AbstractCardItem *card)
+void CardInfoFrameWidget::setCard(AbstractCardItem *card)
 {
     if (card) {
         setCard(card->getInfo());
     }
 }
 
-void CardFrame::clearCard()
+void CardInfoFrameWidget::clearCard()
 {
     setCard((CardInfoPtr) nullptr);
 }

--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
@@ -3,7 +3,7 @@
 #include "../../../../game/cards/card_item.h"
 #include "../../../../main.h"
 #include "../../../../settings/cache_settings.h"
-#include "card_database_manager.h"
+#include "../../../../game/cards/card_database_manager.h"
 #include "card_info_picture_widget.h"
 #include "card_info_text_widget.h"
 

--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
@@ -111,6 +111,11 @@ void CardInfoFrameWidget::setCard(const QString &cardName)
     setCard(CardDatabaseManager::getInstance()->guessCard(cardName));
 }
 
+void CardInfoFrameWidget::setCard(const QString &cardName, const QString &uuid)
+{
+    setCard(CardDatabaseManager::getInstance()->getCardByNameAndUUID(cardName, uuid));
+}
+
 void CardInfoFrameWidget::setCard(AbstractCardItem *card)
 {
     if (card) {

--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.h
@@ -36,6 +36,7 @@ public:
 public slots:
     void setCard(CardInfoPtr card);
     void setCard(const QString &cardName);
+    void setCard(const QString &cardName, const QString &uuid);
     void setCard(AbstractCardItem *card);
     void clearCard();
     void setViewMode(int mode);

--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.h
@@ -1,23 +1,23 @@
 #ifndef CARDFRAME_H
 #define CARDFRAME_H
 
-#include "card_database.h"
+#include "../../../../game/cards/card_database.h"
 
 #include <QTabWidget>
 
 class AbstractCardItem;
-class CardInfoPicture;
-class CardInfoText;
+class CardInfoPictureWidget;
+class CardInfoTextWidget;
 class QVBoxLayout;
 class QSplitter;
 
-class CardFrame : public QTabWidget
+class CardInfoFrameWidget : public QTabWidget
 {
     Q_OBJECT
 private:
     CardInfoPtr info;
-    CardInfoPicture *pic;
-    CardInfoText *text;
+    CardInfoPictureWidget *pic;
+    CardInfoTextWidget *text;
     bool cardTextOnly;
     QWidget *tab1, *tab2, *tab3;
     QVBoxLayout *tab1Layout, *tab2Layout, *tab3Layout;
@@ -30,7 +30,7 @@ public:
         TextOnlyView,
         ImageAndTextView
     };
-    explicit CardFrame(const QString &cardName = QString(), QWidget *parent = nullptr);
+    explicit CardInfoFrameWidget(const QString &cardName = QString(), QWidget *parent = nullptr);
     void retranslateUi();
 
 public slots:

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_enlarged_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_enlarged_widget.cpp
@@ -1,0 +1,91 @@
+#include "card_info_picture_enlarged_widget.h"
+
+#include "../../picture_loader.h"
+
+#include <QPainterPath>
+#include <QStylePainter>
+
+/**
+ * @brief Constructs a CardPictureEnlargedWidget.
+ * @param parent The parent widget.
+ *
+ * Sets the widget's window flags to keep it displayed as a tooltip overlay.
+ */
+CardInfoPictureEnlargedWidget::CardInfoPictureEnlargedWidget(QWidget *parent)
+    : QWidget(parent), pixmapDirty(true), info(nullptr)
+{
+    setWindowFlags(Qt::ToolTip); // Keeps this widget on top of everything
+    setAttribute(Qt::WA_TranslucentBackground);
+}
+
+/**
+ * @brief Loads the pixmap based on the given size and card information.
+ * @param size The desired size for the loaded pixmap.
+ *
+ * If card information is available, it loads the card's specific pixmap. Otherwise, it loads a default card back pixmap.
+ */
+void CardInfoPictureEnlargedWidget::loadPixmap(const QSize &size)
+{
+    if (info) {
+        PictureLoader::getPixmap(enlargedPixmap, info, size);
+    } else {
+        PictureLoader::getCardBackPixmap(enlargedPixmap, size);
+    }
+    pixmapDirty = false;
+}
+
+/**
+ * @brief Sets the pixmap for the widget based on a provided card.
+ * @param card The card information to load.
+ * @param size The desired size for the pixmap.
+ *
+ * Sets the widget's pixmap to the card image and resizes the widget to match the specified size. Triggers a repaint.
+ */
+void CardInfoPictureEnlargedWidget::setCardPixmap(CardInfoPtr card, QSize size)
+{
+    info = card;
+    loadPixmap(size);
+
+    setFixedSize(size); // Set the widget size to the enlarged size
+
+    update(); // Trigger a repaint
+}
+
+/**
+ * @brief Custom paint event that draws the enlarged card image with rounded corners.
+ * @param event The paint event (unused).
+ *
+ * Checks if the pixmap is valid. Then, calculates the size and position for centering the
+ * scaled pixmap within the widget, applies rounded corners, and draws the pixmap.
+ */
+void CardInfoPictureEnlargedWidget::paintEvent(QPaintEvent *event)
+{
+    Q_UNUSED(event);
+
+    if (width() == 0 || height() == 0 || enlargedPixmap.isNull())
+        return;
+
+    if (pixmapDirty)
+        loadPixmap(size());
+
+    // Scale the size of the pixmap to fit the widget while maintaining the aspect ratio
+    QSize scaledSize = enlargedPixmap.size().scaled(size().width(), size().height(), Qt::KeepAspectRatio);
+
+    // Calculate the position to center the scaled pixmap
+    QPoint topLeft{(width() - scaledSize.width()) / 2, (height() - scaledSize.height()) / 2};
+
+    // Define the radius for rounded corners
+    qreal radius = 0.05 * scaledSize.width(); // Adjust the radius as needed for rounded corners
+
+    QStylePainter painter(this);
+    // Fill the background with transparent color to ensure rounded corners are rendered properly
+    painter.fillRect(rect(), Qt::transparent); // Use the transparent background
+
+    QPainterPath shape;
+    shape.addRoundedRect(QRect(topLeft, scaledSize), radius, radius);
+    painter.setClipPath(shape); // Set the clipping path
+
+    // Draw the pixmap scaled to the calculated size
+    painter.drawItemPixmap(QRect(topLeft, scaledSize), Qt::AlignCenter ,enlargedPixmap.scaled(scaledSize, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+}
+

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_enlarged_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_enlarged_widget.h
@@ -1,0 +1,38 @@
+#ifndef CARD_PICTURE_ENLARGED_WIDGET_H
+#define CARD_PICTURE_ENLARGED_WIDGET_H
+
+#include "../../../../game/cards/card_database.h"
+#include <QWidget>
+#include <QPixmap>
+
+class CardInfoPictureEnlargedWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    // Constructor
+    explicit CardInfoPictureEnlargedWidget(QWidget *parent = nullptr);
+
+    // Sets the card pixmap to display
+    void setCardPixmap(CardInfoPtr card, QSize size);
+
+protected:
+    // Handles the painting event for the enlarged card
+    void paintEvent(QPaintEvent *event) override;
+
+private:
+    // Cached pixmap for the enlarged card
+    QPixmap enlargedPixmap;
+
+    // Tracks if the pixmap needs to be refreshed/redrawn
+    bool pixmapDirty;
+
+    // Card information (card data pointer)
+    CardInfoPtr info;
+
+    // Loads the enlarged card pixmap
+    void loadPixmap(const QSize &size);
+};
+
+
+#endif //CARD_PICTURE_ENLARGED_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
@@ -1,18 +1,18 @@
-#include "card_info_picture.h"
+#include "card_info_picture_widget.h"
 
-#include "../../client/ui/picture_loader.h"
-#include "../../main.h"
-#include "card_item.h"
+#include "../../picture_loader.h"
+#include "../../../../main.h"
+#include "../../../../game/cards/card_item.h"
 
 #include <QStylePainter>
 #include <QWidget>
 
-CardInfoPicture::CardInfoPicture(QWidget *parent) : QWidget(parent), info(nullptr), pixmapDirty(true)
+CardInfoPictureWidget::CardInfoPictureWidget(QWidget *parent) : QWidget(parent), info(nullptr), pixmapDirty(true)
 {
     setMinimumHeight(100);
 }
 
-void CardInfoPicture::setCard(CardInfoPtr card)
+void CardInfoPictureWidget::setCard(CardInfoPtr card)
 {
     if (info) {
         disconnect(info.data(), nullptr, this, nullptr);
@@ -27,18 +27,18 @@ void CardInfoPicture::setCard(CardInfoPtr card)
     updatePixmap();
 }
 
-void CardInfoPicture::resizeEvent(QResizeEvent *)
+void CardInfoPictureWidget::resizeEvent(QResizeEvent *)
 {
     updatePixmap();
 }
 
-void CardInfoPicture::updatePixmap()
+void CardInfoPictureWidget::updatePixmap()
 {
     pixmapDirty = true;
     update();
 }
 
-void CardInfoPicture::loadPixmap()
+void CardInfoPictureWidget::loadPixmap()
 {
     if (info)
         PictureLoader::getPixmap(resizedPixmap, info, size());
@@ -46,7 +46,7 @@ void CardInfoPicture::loadPixmap()
         PictureLoader::getCardBackPixmap(resizedPixmap, size());
 }
 
-void CardInfoPicture::paintEvent(QPaintEvent *)
+void CardInfoPictureWidget::paintEvent(QPaintEvent *)
 {
     if (width() == 0 || height() == 0)
         return;

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
@@ -205,7 +205,6 @@ void CardInfoPictureWidget::mouseMoveEvent(QMouseEvent *event)
  */
 void CardInfoPictureWidget::showEnlargedPixmap()
 {
-    qDebug() << "lol";
     if (info) {
         QSize enlargedSize(size().width() * scaleFactor, static_cast<int>(size().width() * aspectRatio * scaleFactor));
         qDebug() << enlargedSize;

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
@@ -1,17 +1,50 @@
 #include "card_info_picture_widget.h"
 
-#include "../../picture_loader.h"
-#include "../../../../main.h"
 #include "../../../../game/cards/card_item.h"
+#include "../../../../main.h"
+#include "../../picture_loader.h"
 
+#include <QMouseEvent>
 #include <QStylePainter>
 #include <QWidget>
 
-CardInfoPictureWidget::CardInfoPictureWidget(QWidget *parent) : QWidget(parent), info(nullptr), pixmapDirty(true)
+/**
+ * @class CardInfoPictureWidget
+ * @brief Widget that displays an enlarged image of a card, loading the image based on the card's info or showing a default image.
+ *
+ * This widget can optionally display a larger version of the card's image when hovered over,
+ * depending on the `hoverToZoomEnabled` parameter.
+ */
+
+/**
+ * @brief Constructs a CardInfoPictureWidget.
+ * @param parent The parent widget, if any.
+ * @param hoverToZoomEnabled If this widget will spawn a larger widget when hovered over.
+ *
+ * Initializes the widget with a minimum height and sets the pixmap to a dirty state for initial loading.
+ */
+CardInfoPictureWidget::CardInfoPictureWidget(QWidget *parent, bool hoverToZoomEnabled)
+    : QWidget(parent), info(nullptr), pixmapDirty(true), hoverToZoomEnabled(hoverToZoomEnabled)
 {
     setMinimumHeight(100);
+    if (hoverToZoomEnabled)
+        setMouseTracking(true);
+
+    enlargedPixmapWidget = new CardInfoPictureEnlargedWidget(this);
+    enlargedPixmapWidget->hide();
+
+    hoverTimer = new QTimer(this);
+    hoverTimer->setSingleShot(true);
+    connect(hoverTimer, &QTimer::timeout, this, &CardInfoPictureWidget::showEnlargedPixmap);
 }
 
+/**
+ * @brief Sets the card to be displayed and updates the pixmap.
+ * @param card A shared pointer to the card information (CardInfoPtr).
+ *
+ * Disconnects any existing signal connections from the previous card info and connects to the `pixmapUpdated`
+ * signal of the new card to automatically update the pixmap when the card image changes.
+ */
 void CardInfoPictureWidget::setCard(CardInfoPtr card)
 {
     if (info) {
@@ -27,25 +60,77 @@ void CardInfoPictureWidget::setCard(CardInfoPtr card)
     updatePixmap();
 }
 
+/**
+ * @brief Sets the hover to zoom feature.
+ * @param enabled If true, enables the hover-to-zoom functionality; otherwise, disables it.
+ */
+void CardInfoPictureWidget::setHoverToZoomEnabled(bool enabled)
+{
+    hoverToZoomEnabled = enabled;
+    setMouseTracking(enabled);
+}
+
+/**
+ * @brief Handles widget resizing by updating the pixmap size.
+ * @param event The resize event (unused).
+ *
+ * Calls `updatePixmap()` to ensure the image scales appropriately when the widget is resized.
+ */
 void CardInfoPictureWidget::resizeEvent(QResizeEvent *)
 {
     updatePixmap();
 }
 
+/**
+ * @brief Sets the scale factor for the widget.
+ * @param scale The scale factor to apply.
+ *
+ * Adjusts the widget's size according to the scale factor and updates the pixmap.
+ */
+void CardInfoPictureWidget::setScaleFactor(int scale)
+{
+    int newWidth = baseWidth + scale * 20;
+    int newHeight = static_cast<int>(newWidth * aspectRatio);
+
+    scaleFactor = scale;
+
+    setFixedSize(newWidth, newHeight);
+    updatePixmap();
+}
+
+/**
+ * @brief Marks the pixmap as dirty and triggers a widget repaint.
+ *
+ * Sets `pixmapDirty` to true, indicating that the pixmap needs to be reloaded before the next display.
+ */
 void CardInfoPictureWidget::updatePixmap()
 {
     pixmapDirty = true;
     update();
 }
 
+/**
+ * @brief Loads the appropriate pixmap based on the current card info.
+ *
+ * If `info` is valid, loads the card's image. Otherwise, loads a default card back image.
+ */
 void CardInfoPictureWidget::loadPixmap()
 {
     if (info)
         PictureLoader::getPixmap(resizedPixmap, info, size());
     else
         PictureLoader::getCardBackPixmap(resizedPixmap, size());
+
+    pixmapDirty = false;
 }
 
+/**
+ * @brief Custom paint event that draws the card image with rounded corners.
+ * @param event The paint event (unused).
+ *
+ * Checks if the pixmap needs to be reloaded. Then, calculates the size and position for centering the
+ * scaled pixmap within the widget, applies rounded corners, and draws the pixmap.
+ */
 void CardInfoPictureWidget::paintEvent(QPaintEvent *)
 {
     if (width() == 0 || height() == 0)
@@ -63,4 +148,72 @@ void CardInfoPictureWidget::paintEvent(QPaintEvent *)
     shape.addRoundedRect(QRect(topLeft, scaledSize), radius, radius);
     painter.setClipPath(shape);
     painter.drawItemPixmap(QRect(topLeft, scaledSize), Qt::AlignCenter, resizedPixmap);
+}
+
+/**
+ * @brief Provides the recommended size for the widget based on the scale factor.
+ * @return The recommended widget size.
+ */
+QSize CardInfoPictureWidget::sizeHint() const
+{
+    return QSize(baseWidth * scaleFactor, baseHeight * scaleFactor);
+}
+
+/**
+ * @brief Starts the hover timer to show the enlarged pixmap on hover.
+ * @param event The enter event.
+ */
+void CardInfoPictureWidget::enterEvent(QEnterEvent *event)
+{
+    QWidget::enterEvent(event);
+    if (hoverToZoomEnabled) {
+        hoverTimer->start(500);
+    }
+}
+
+/**
+ * @brief Stops the hover timer and hides the enlarged pixmap when the mouse leaves.
+ * @param event The leave event.
+ */
+void CardInfoPictureWidget::leaveEvent(QEvent *event)
+{
+    QWidget::leaveEvent(event);
+    if (hoverToZoomEnabled) {
+        hoverTimer->stop();
+        enlargedPixmapWidget->hide();
+    }
+}
+
+/**
+ * @brief Moves the enlarged pixmap widget to follow the mouse cursor.
+ * @param event The mouse move event.
+ */
+void CardInfoPictureWidget::mouseMoveEvent(QMouseEvent *event)
+{
+    QWidget::mouseMoveEvent(event);
+    if (hoverToZoomEnabled && enlargedPixmapWidget->isVisible()) {
+        QPointF cursorPos = QCursor::pos();
+        enlargedPixmapWidget->move(QPoint(cursorPos.x() + 10, cursorPos.y() + 10));
+    }
+}
+
+/**
+ * @brief Displays the enlarged version of the card's pixmap near the cursor.
+ *
+ * If card information is available, the enlarged pixmap is loaded, positioned near the cursor,
+ * and displayed.
+ */
+void CardInfoPictureWidget::showEnlargedPixmap()
+{
+    qDebug() << "lol";
+    if (info) {
+        QSize enlargedSize(size().width() * scaleFactor, static_cast<int>(size().width() * aspectRatio * scaleFactor));
+        qDebug() << enlargedSize;
+        enlargedPixmapWidget->setCardPixmap(info, enlargedSize);
+
+        QPointF cursorPos = QCursor::pos();
+        enlargedPixmapWidget->move(cursorPos.x() + 10, cursorPos.y() + 10);
+
+        enlargedPixmapWidget->show();
+    }
 }

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
@@ -169,6 +169,8 @@ void CardInfoPictureWidget::enterEvent(QEnterEvent *event)
     if (hoverToZoomEnabled) {
         hoverTimer->start(500);
     }
+
+    emit hoveredOnCard(info);
 }
 
 /**
@@ -207,7 +209,6 @@ void CardInfoPictureWidget::showEnlargedPixmap()
 {
     if (info) {
         QSize enlargedSize(size().width() * scaleFactor, static_cast<int>(size().width() * aspectRatio * scaleFactor));
-        qDebug() << enlargedSize;
         enlargedPixmapWidget->setCardPixmap(info, enlargedSize);
 
         QPointF cursorPos = QCursor::pos();

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
@@ -2,8 +2,10 @@
 #define CARDINFOPICTURE_H
 
 #include "../../../../game/cards/card_database.h"
+#include "card_info_picture_enlarged_widget.h"
 
 #include <QWidget>
+#include <QTimer>
 
 class AbstractCardItem;
 
@@ -11,21 +13,37 @@ class CardInfoPictureWidget : public QWidget
 {
     Q_OBJECT
 
-private:
-    CardInfoPtr info;
-    QPixmap resizedPixmap;
-    bool pixmapDirty;
 
 public:
-    CardInfoPictureWidget(QWidget *parent = nullptr);
+    CardInfoPictureWidget(QWidget *parent = nullptr, bool hoverToZoomEnabled = false);
+    QSize sizeHint() const override;
+    void setHoverToZoomEnabled(bool enabled);
 
 protected:
     void resizeEvent(QResizeEvent *event);
     void paintEvent(QPaintEvent *);
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
     void loadPixmap();
+    const QPixmap& getResizedPixmap() const { return resizedPixmap; }
+    void showEnlargedPixmap();
 public slots:
     void setCard(CardInfoPtr card);
+    void setScaleFactor(int scale); // New slot for scaling
     void updatePixmap();
+
+private:
+    CardInfoPtr info;
+    qreal aspectRatio = 1.396;
+    int baseWidth = 100;
+    int baseHeight = 100;
+    double scaleFactor = 1.5;
+    QPixmap resizedPixmap;
+    bool pixmapDirty;
+    bool hoverToZoomEnabled;
+    CardInfoPictureEnlargedWidget *enlargedPixmapWidget;
+    QTimer *hoverTimer;
 };
 
 #endif

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
@@ -16,8 +16,20 @@ class CardInfoPictureWidget : public QWidget
 
 public:
     CardInfoPictureWidget(QWidget *parent = nullptr, bool hoverToZoomEnabled = false);
+    CardInfoPtr getInfo()
+    {
+        return info;
+    }
     QSize sizeHint() const override;
     void setHoverToZoomEnabled(bool enabled);
+
+public slots:
+    void setCard(CardInfoPtr card);
+    void setScaleFactor(int scale); // New slot for scaling
+    void updatePixmap();
+
+signals:
+    void hoveredOnCard(CardInfoPtr hoveredCard);
 
 protected:
     void resizeEvent(QResizeEvent *event);
@@ -28,16 +40,13 @@ protected:
     void loadPixmap();
     const QPixmap& getResizedPixmap() const { return resizedPixmap; }
     void showEnlargedPixmap();
-public slots:
-    void setCard(CardInfoPtr card);
-    void setScaleFactor(int scale); // New slot for scaling
-    void updatePixmap();
+
 
 private:
     CardInfoPtr info;
     qreal aspectRatio = 1.396;
-    int baseWidth = 100;
-    int baseHeight = 100;
+    int baseWidth = 200;
+    int baseHeight = 200;
     double scaleFactor = 1.5;
     QPixmap resizedPixmap;
     bool pixmapDirty;

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
@@ -1,13 +1,13 @@
 #ifndef CARDINFOPICTURE_H
 #define CARDINFOPICTURE_H
 
-#include "card_database.h"
+#include "../../../../game/cards/card_database.h"
 
 #include <QWidget>
 
 class AbstractCardItem;
 
-class CardInfoPicture : public QWidget
+class CardInfoPictureWidget : public QWidget
 {
     Q_OBJECT
 
@@ -17,7 +17,7 @@ private:
     bool pixmapDirty;
 
 public:
-    CardInfoPicture(QWidget *parent = nullptr);
+    CardInfoPictureWidget(QWidget *parent = nullptr);
 
 protected:
     void resizeEvent(QResizeEvent *event);

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
@@ -84,6 +84,10 @@ void CardInfoPictureWithTextOverlayWidget::setTextAlignment(Qt::Alignment alignm
     update();
 }
 
+void CardInfoPictureWithTextOverlayWidget::mousePressEvent(QMouseEvent *event) {
+    emit imageClicked(event, this);
+}
+
 /**
  * @brief Paints the widget, including both the card image and the text overlay.
  * @param event The paint event.

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
@@ -1,0 +1,208 @@
+#include "card_info_picture_with_text_overlay_widget.h"
+
+#include <QFontMetrics>
+#include <QPainter>
+#include <QPainterPath>
+#include <QStylePainter>
+#include <QTextOption>
+
+/**
+ * @brief Constructs a CardPictureWithTextOverlay widget.
+ * @param parent The parent widget.
+ * @param textColor The color of the overlay text.
+ * @param outlineColor The color of the outline around the text.
+ * @param fontSize The font size of the overlay text.
+ * @param alignment The alignment of the text within the overlay.
+ *
+ * Sets the widget's size policy and default border style.
+ */
+CardInfoPictureWithTextOverlayWidget::CardInfoPictureWithTextOverlayWidget(QWidget *parent,
+                                                       const QColor &textColor,
+                                                       const QColor &outlineColor,
+                                                       int fontSize,
+                                                       Qt::Alignment alignment)
+    : CardInfoPictureWidget(parent),
+      textColor(textColor),
+      outlineColor(outlineColor),
+      fontSize(fontSize),
+      textAlignment(alignment)
+{
+    this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+}
+
+/**
+ * @brief Sets the overlay text to be displayed on the card.
+ * @param text The text to overlay.
+ *
+ * Updates the widget to display the new overlay text.
+ */
+void CardInfoPictureWithTextOverlayWidget::setOverlayText(const QString &text)
+{
+    overlayText = text;
+    update();  // Trigger a redraw to display the updated text
+}
+
+/**
+ * @brief Sets the color of the overlay text.
+ * @param color The new text color.
+ */
+void CardInfoPictureWithTextOverlayWidget::setTextColor(const QColor &color)
+{
+    textColor = color;
+    update();
+}
+
+/**
+ * @brief Sets the outline color around the overlay text.
+ * @param color The new outline color.
+ */
+void CardInfoPictureWithTextOverlayWidget::setOutlineColor(const QColor &color)
+{
+    outlineColor = color;
+    update();
+}
+
+/**
+ * @brief Sets the font size for the overlay text.
+ * @param size The new font size.
+ */
+void CardInfoPictureWithTextOverlayWidget::setFontSize(int size)
+{
+    fontSize = size;
+    update();
+}
+
+/**
+ * @brief Sets the alignment of the overlay text within the widget.
+ * @param alignment The new text alignment.
+ */
+void CardInfoPictureWithTextOverlayWidget::setTextAlignment(Qt::Alignment alignment)
+{
+    textAlignment = alignment;
+    update();
+}
+
+/**
+ * @brief Paints the widget, including both the card image and the text overlay.
+ * @param event The paint event.
+ *
+ * Draws the card image first, then overlays text on top. The text is wrapped and centered within the image.
+ */
+void CardInfoPictureWithTextOverlayWidget::paintEvent(QPaintEvent *event)
+{
+    // Call the base class's paintEvent to draw the card image
+    CardInfoPictureWidget::paintEvent(event);
+
+    // Now add the custom text overlay on top of the image
+    if (!overlayText.isEmpty()) {
+        QStylePainter painter(this);
+
+        // Set text properties
+        QFont font = painter.font();
+        font.setPointSize(fontSize);
+        painter.setFont(font);
+
+        // Get the pixmap from the base class using the getter
+        const QPixmap &pixmap = getResizedPixmap();
+        if (!pixmap.isNull()) {
+            // Calculate size and position for drawing
+            QSize scaledSize = pixmap.size().scaled(size(), Qt::KeepAspectRatio);
+            QPoint topLeft{(width() - scaledSize.width()) / 2, (height() - scaledSize.height()) / 2};
+            QRect pixmapRect(topLeft, scaledSize);
+
+            // Prepare text wrapping
+            QFontMetrics fontMetrics(font);
+            int lineHeight = fontMetrics.height();
+            int textWidth = pixmapRect.width();
+            QString wrappedText;
+
+            // Break the text into multiple lines to fit within the pixmap width
+            QString currentLine;
+            QStringList words = overlayText.split(' ');
+            for (const QString &word : words) {
+                if (fontMetrics.horizontalAdvance(currentLine + " " + word) > textWidth) {
+                    wrappedText += currentLine + '\n';
+                    currentLine = word;
+                } else {
+                    if (!currentLine.isEmpty()) {
+                        currentLine += " ";
+                    }
+                    currentLine += word;
+                }
+            }
+            wrappedText += currentLine;
+
+            // Calculate total text block height
+            int totalTextHeight = wrappedText.count('\n') * lineHeight + lineHeight;
+
+            // Set up the text layout options
+            QTextOption textOption;
+            textOption.setAlignment(textAlignment);
+
+            // Create a text rectangle centered within the pixmap rect
+            QRect textRect = QRect(pixmapRect.left(), pixmapRect.top(), pixmapRect.width(), totalTextHeight);
+            textRect.moveTop((pixmapRect.height() - totalTextHeight) / 2 + pixmapRect.top());
+
+            // Draw the outlined text
+            drawOutlinedText(painter, textRect, wrappedText, textOption);
+        }
+    }
+}
+
+/**
+ * @brief Draws text with an outline for visibility.
+ * @param painter The painter to draw the text.
+ * @param textRect The rectangle area to draw the text in.
+ * @param text The text to display.
+ * @param textOption The text layout options, such as alignment.
+ *
+ * Draws an outline around the text to enhance readability before drawing the main text.
+ */
+void CardInfoPictureWithTextOverlayWidget::drawOutlinedText(QPainter &painter, const QRect &textRect, const QString &text, const QTextOption &textOption)
+{
+    // Draw the black outline (outlineColor)
+    painter.setPen(outlineColor);
+    for (int dx = -1; dx <= 1; ++dx) {
+        for (int dy = -1; dy <= 1; ++dy) {
+            if (dx != 0 || dy != 0) {
+                QRect shiftedTextRect = textRect.translated(dx, dy);
+                painter.drawText(shiftedTextRect, text, textOption);
+            }
+        }
+    }
+
+    // Draw the main text (textColor)
+    painter.setPen(textColor);
+    painter.drawText(textRect, text, textOption);
+}
+
+/**
+ * @brief Provides the recommended size for this widget.
+ * @return The suggested widget size.
+ */
+QSize CardInfoPictureWithTextOverlayWidget::sizeHint() const
+{
+    return CardInfoPictureWidget::sizeHint();
+}
+
+/**
+ * @brief Provides the minimum recommended size for this widget.
+ * @return The minimum widget size.
+ */
+QSize CardInfoPictureWithTextOverlayWidget::minimumSizeHint() const {
+    // Same as sizeHint, but ensure that there is at least some space for the pixmap
+    const QPixmap &pixmap = getResizedPixmap();
+    QSize pixmapSize = pixmap.isNull() ? QSize(0, 0) : pixmap.size();
+
+    // Get the font metrics for the overlay text
+    QFont font;
+    font.setPointSize(fontSize);
+    QFontMetrics fontMetrics(font);
+
+    // Calculate the height required for the text
+    QStringList lines = overlayText.split('\n');
+    int totalTextHeight = lines.size() * fontMetrics.height();
+
+    // Return the maximum width and combined height
+    return QSize(pixmapSize.width(), pixmapSize.height() + totalTextHeight);
+}

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
@@ -9,6 +9,7 @@
 /**
  * @brief Constructs a CardPictureWithTextOverlay widget.
  * @param parent The parent widget.
+ * @param hoverToZoomEnabled If this widget will spawn a larger widget when hovered over.
  * @param textColor The color of the overlay text.
  * @param outlineColor The color of the outline around the text.
  * @param fontSize The font size of the overlay text.
@@ -17,11 +18,12 @@
  * Sets the widget's size policy and default border style.
  */
 CardInfoPictureWithTextOverlayWidget::CardInfoPictureWithTextOverlayWidget(QWidget *parent,
+                                                       bool hoverToZoomEnabled,
                                                        const QColor &textColor,
                                                        const QColor &outlineColor,
                                                        int fontSize,
                                                        Qt::Alignment alignment)
-    : CardInfoPictureWidget(parent),
+    : CardInfoPictureWidget(parent, hoverToZoomEnabled),
       textColor(textColor),
       outlineColor(outlineColor),
       fontSize(fontSize),

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.h
@@ -11,6 +11,7 @@ class CardInfoPictureWithTextOverlayWidget : public CardInfoPictureWidget {
 
 public:
     explicit CardInfoPictureWithTextOverlayWidget(QWidget *parent = nullptr,
+                                        bool hoverToZoomEnabled = false,
                                         const QColor &textColor = Qt::white,
                                         const QColor &outlineColor = Qt::black,
                                         int fontSize = 12,

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.h
@@ -1,0 +1,40 @@
+#ifndef CARD_PICTURE_WITH_TEXT_OVERLAY_H
+#define CARD_PICTURE_WITH_TEXT_OVERLAY_H
+
+#include "card_info_picture_widget.h"
+#include <QColor>
+#include <QSize>
+#include <QTextOption>
+
+class CardInfoPictureWithTextOverlayWidget : public CardInfoPictureWidget {
+    Q_OBJECT
+
+public:
+    explicit CardInfoPictureWithTextOverlayWidget(QWidget *parent = nullptr,
+                                        const QColor &textColor = Qt::white,
+                                        const QColor &outlineColor = Qt::black,
+                                        int fontSize = 12,
+                                        Qt::Alignment alignment = Qt::AlignCenter);
+
+    void setOverlayText(const QString &text);
+    void setTextColor(const QColor &color);
+    void setOutlineColor(const QColor &color);
+    void setFontSize(int size);
+    void setTextAlignment(Qt::Alignment alignment);
+    QSize sizeHint() const override;
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+    QSize minimumSizeHint() const override;
+
+private:
+    void drawOutlinedText(QPainter &painter, const QRect &textRect, const QString &text, const QTextOption &textOption);
+
+    QString overlayText;
+    QColor textColor;
+    QColor outlineColor;
+    int fontSize;
+    Qt::Alignment textAlignment;
+};
+
+#endif // CARD_PICTURE_WITH_TEXT_OVERLAY_H

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.h
@@ -22,10 +22,14 @@ public:
     void setOutlineColor(const QColor &color);
     void setFontSize(int size);
     void setTextAlignment(Qt::Alignment alignment);
+
     QSize sizeHint() const override;
+signals:
+    void imageClicked(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance);
 
 protected:
     void paintEvent(QPaintEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
     QSize minimumSizeHint() const override;
 
 private:

--- a/cockatrice/src/client/ui/widgets/cards/card_info_text_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_text_widget.cpp
@@ -1,14 +1,13 @@
-#include "card_info_text.h"
+#include "card_info_text_widget.h"
 
-#include "../../game/game_specific_terms.h"
-#include "../../main.h"
-#include "card_item.h"
+#include "../../../../game/game_specific_terms.h"
+#include "../../../../game/cards/card_item.h"
 
 #include <QGridLayout>
 #include <QLabel>
 #include <QTextEdit>
 
-CardInfoText::CardInfoText(QWidget *parent) : QFrame(parent), info(nullptr)
+CardInfoTextWidget::CardInfoTextWidget(QWidget *parent) : QFrame(parent), info(nullptr)
 {
     nameLabel = new QLabel;
     nameLabel->setOpenExternalLinks(false);
@@ -27,7 +26,7 @@ CardInfoText::CardInfoText(QWidget *parent) : QFrame(parent), info(nullptr)
     retranslateUi();
 }
 
-void CardInfoText::setCard(CardInfoPtr card)
+void CardInfoTextWidget::setCard(CardInfoPtr card)
 {
     if (card == nullptr) {
         nameLabel->setText("");
@@ -65,13 +64,13 @@ void CardInfoText::setCard(CardInfoPtr card)
     textLabel->setText(card->getText());
 }
 
-void CardInfoText::setInvalidCardName(const QString &cardName)
+void CardInfoTextWidget::setInvalidCardName(const QString &cardName)
 {
     nameLabel->setText(tr("Unknown card:") + " " + cardName);
     textLabel->setText("");
 }
 
-void CardInfoText::retranslateUi()
+void CardInfoTextWidget::retranslateUi()
 {
     /*
      * There's no way we can really translate the text currently being rendered.

--- a/cockatrice/src/client/ui/widgets/cards/card_info_text_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_text_widget.h
@@ -1,13 +1,13 @@
 #ifndef CARDINFOTEXT_H
 #define CARDINFOTEXT_H
 
-#include "card_database.h"
+#include "../../../../game/cards/card_database.h"
 
 #include <QFrame>
 class QLabel;
 class QTextEdit;
 
-class CardInfoText : public QFrame
+class CardInfoTextWidget : public QFrame
 {
     Q_OBJECT
 
@@ -17,7 +17,7 @@ private:
     CardInfoPtr info;
 
 public:
-    explicit CardInfoText(QWidget *parent = nullptr);
+    explicit CardInfoTextWidget(QWidget *parent = nullptr);
     void retranslateUi();
     void setInvalidCardName(const QString &cardName);
 

--- a/cockatrice/src/client/ui/widgets/general/display/labeled_input.cpp
+++ b/cockatrice/src/client/ui/widgets/general/display/labeled_input.cpp
@@ -1,0 +1,41 @@
+#include "labeled_input.h"
+
+LabeledInput::LabeledInput(const QString &labelText, QWidget *parent)
+        : QWidget(parent)
+{
+    label = new QLabel(labelText, this);
+    layout = new QHBoxLayout(this);
+    layout->addWidget(label);
+
+}
+
+QSpinBox* LabeledInput::addSpinBox(int minValue, int maxValue, int defaultValue)
+{
+    QSpinBox *spinBox = new QSpinBox(this);
+    spinBox->setRange(minValue, maxValue);
+    spinBox->setValue(defaultValue);
+    layout->addWidget(spinBox);
+    connect(spinBox, SIGNAL(valueChanged(int)), this, SIGNAL(spinBoxValueChanged(int)));
+    return spinBox;
+}
+
+// Add a QComboBox (for arbitrary selections)
+QComboBox* LabeledInput::addComboBox(const QStringList &items, const QString &defaultItem)
+{
+    QComboBox *comboBox = new QComboBox(this);
+    comboBox->addItems(items);
+    if (!defaultItem.isEmpty()) {
+        comboBox->setCurrentText(defaultItem);
+    }
+    layout->addWidget(comboBox);
+    return comboBox;
+}
+
+// Add a QComboBox specifically for Qt Directions
+QComboBox* LabeledInput::addDirectionComboBox()
+{
+    QStringList directions = {"Qt::Horizontal", "Qt::Vertical"};
+    auto comboBox = addComboBox(directions, "Qt::Vertical");
+    connect(comboBox, SIGNAL(currentTextChanged(QString)), this, SIGNAL(directionComboBoxChanged(QString)));
+    return comboBox;
+}

--- a/cockatrice/src/client/ui/widgets/general/display/labeled_input.h
+++ b/cockatrice/src/client/ui/widgets/general/display/labeled_input.h
@@ -1,0 +1,40 @@
+//
+// Created by ascor on 10/11/24.
+//
+
+#ifndef LABELED_INPUT_H
+#define LABELED_INPUT_H
+
+#include <QLabel>
+#include <QSpinBox>
+#include <QComboBox>
+#include <QHBoxLayout>
+#include <QWidget>
+
+class LabeledInput : public QWidget
+{
+    Q_OBJECT
+
+public:
+    LabeledInput(const QString &labelText, QWidget *parent = nullptr);
+
+    // Add a QSpinBox (for arbitrary numbers)
+    QSpinBox* addSpinBox(int minValue, int maxValue, int defaultValue = 0);
+
+    // Add a QComboBox (for arbitrary selections)
+    QComboBox* addComboBox(const QStringList &items, const QString &defaultItem = QString());
+
+    // Add a QComboBox specifically for Qt Directions
+    QComboBox* addDirectionComboBox();
+
+    signals:
+        void spinBoxValueChanged(int newValue);  // Declare the valueChanged signal
+        void comboBoxValueChanged(int newValue);
+        void directionComboBoxChanged(QString newDirection);
+private:
+    QLabel *label;
+    QHBoxLayout *layout;
+};
+
+
+#endif //LABELED_INPUT_H

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
@@ -96,7 +96,7 @@ void FlowWidget::clearLayout()
     if (flow_layout != nullptr) {
         QLayoutItem *item;
         while ((item = flow_layout->takeAt(0)) != nullptr) {
-            delete item->widget(); // Delete the widget
+            item->widget()->deleteLater(); // Delete the widget
             delete item;           // Delete the layout item
         }
     }

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
@@ -38,7 +38,7 @@ FlowWidget::FlowWidget(QWidget *parent, Qt::ScrollBarPolicy horizontalPolicy, Qt
     } else if (horizontalPolicy == Qt::ScrollBarAlwaysOff && verticalPolicy != Qt::ScrollBarAlwaysOff) {
         flow_layout = new VerticalFlowLayout(container);
     } else {
-        flow_layout = new FlowLayout(container);
+        flow_layout = new FlowLayout(container, 0, 0, 0);
     }
 
     container->setLayout(flow_layout);
@@ -110,7 +110,7 @@ void FlowWidget::clearLayout()
                    scrollArea->verticalScrollBarPolicy() != Qt::ScrollBarAlwaysOff) {
             flow_layout = new VerticalFlowLayout(container);
         } else {
-            flow_layout = new FlowLayout(container);
+            flow_layout = new FlowLayout(container, 0, 0, 0);
         }
         this->container->setLayout(flow_layout);
     }

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
@@ -1,0 +1,142 @@
+/**
+ * @file flow_widget.cpp
+ * @brief Implementation of the FlowWidget class for organizing widgets in a flow layout within a scrollable area.
+ */
+
+#include "flow_widget.h"
+
+#include "../../../layouts/flow_layout.h"
+#include "../../../layouts/horizontal_flow_layout.h"
+#include "../../../layouts/vertical_flow_layout.h"
+
+#include <QHBoxLayout>
+#include <QWidget>
+#include <qscrollarea.h>
+#include <qsizepolicy.h>
+
+/**
+ * @brief Constructs a FlowWidget with a scrollable layout.
+ *
+ * @param parent The parent widget of this FlowWidget.
+ * @param horizontalPolicy The horizontal scroll bar policy for the scroll area.
+ * @param verticalPolicy The vertical scroll bar policy for the scroll area.
+ */
+FlowWidget::FlowWidget(QWidget *parent, Qt::ScrollBarPolicy horizontalPolicy, Qt::ScrollBarPolicy verticalPolicy)
+    : QWidget(parent)
+{
+    // Main Widget and Layout
+    this->setMinimumSize(0, 0);
+    this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    main_layout = new QHBoxLayout();
+    this->setLayout(main_layout);
+
+    // Flow Layout inside the scroll area
+    container = new QWidget();
+
+    if (horizontalPolicy != Qt::ScrollBarAlwaysOff && verticalPolicy == Qt::ScrollBarAlwaysOff) {
+        flow_layout = new HorizontalFlowLayout(container);
+    } else if (horizontalPolicy == Qt::ScrollBarAlwaysOff && verticalPolicy != Qt::ScrollBarAlwaysOff) {
+        flow_layout = new VerticalFlowLayout(container);
+    } else {
+        flow_layout = new FlowLayout(container);
+    }
+
+    container->setLayout(flow_layout);
+    // The container should expand as much as possible, trusting the scrollArea to constrain it.
+    container->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    container->setMinimumSize(0, 0);
+
+    // Scroll Area, which should expand as much as possible, since it should be the only direct child widget.
+    scrollArea = new QScrollArea();
+    scrollArea->setWidgetResizable(true);
+    scrollArea->setMinimumSize(0, 0);
+    scrollArea->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+    // Set scrollbar policies
+    scrollArea->setHorizontalScrollBarPolicy(horizontalPolicy);
+    scrollArea->setVerticalScrollBarPolicy(verticalPolicy);
+
+    // Use the FlowLayout container directly if we disable the ScrollArea
+    if (horizontalPolicy == Qt::ScrollBarAlwaysOff && verticalPolicy == Qt::ScrollBarAlwaysOff) {
+        main_layout->addWidget(container);
+    } else {
+        scrollArea->setWidget(container);
+        main_layout->addWidget(scrollArea);
+    }
+}
+
+/**
+ * @brief Adds a widget to the flow layout within the FlowWidget.
+ *
+ * Adjusts the widget's size policy based on the scroll bar policies.
+ *
+ * @param widget_to_add The widget to add to the flow layout.
+ */
+void FlowWidget::addWidget(QWidget *widget_to_add) const
+{
+    // Adjust size policy if scrollbars are disabled
+    if (scrollArea->horizontalScrollBarPolicy() == Qt::ScrollBarAlwaysOff) {
+        widget_to_add->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
+    }
+    if (scrollArea->verticalScrollBarPolicy() == Qt::ScrollBarAlwaysOff) {
+        widget_to_add->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum);
+    }
+
+    // Add the widget to the flow layout
+    this->flow_layout->addWidget(widget_to_add);
+}
+
+/**
+ * @brief Clears all widgets from the flow layout.
+ *
+ * Deletes each widget and layout item, and recreates the flow layout if it was removed.
+ */
+void FlowWidget::clearLayout()
+{
+    if (flow_layout != nullptr) {
+        QLayoutItem *item;
+        while ((item = flow_layout->takeAt(0)) != nullptr) {
+            delete item->widget(); // Delete the widget
+            delete item;           // Delete the layout item
+        }
+    }
+
+    // If layout is null, create a new layout, otherwise reuse the existing one
+    if (flow_layout == nullptr) {
+        if (scrollArea->horizontalScrollBarPolicy() != Qt::ScrollBarAlwaysOff &&
+            scrollArea->verticalScrollBarPolicy() == Qt::ScrollBarAlwaysOff) {
+            flow_layout = new HorizontalFlowLayout(container);
+        } else if (scrollArea->horizontalScrollBarPolicy() == Qt::ScrollBarAlwaysOff &&
+                   scrollArea->verticalScrollBarPolicy() != Qt::ScrollBarAlwaysOff) {
+            flow_layout = new VerticalFlowLayout(container);
+        } else {
+            flow_layout = new FlowLayout(container);
+        }
+        this->container->setLayout(flow_layout);
+    }
+}
+
+/**
+ * @brief Handles resize events for the FlowWidget.
+ *
+ * Triggers layout recalculation and adjusts the scroll area content size.
+ *
+ * @param event The resize event containing the new size information.
+ */
+void FlowWidget::resizeEvent(QResizeEvent *event)
+{
+    QWidget::resizeEvent(event);
+
+    // Trigger the layout to recalculate
+    if (flow_layout != nullptr) {
+        flow_layout->invalidate(); // Marks the layout as dirty and requires recalculation
+        flow_layout->activate();   // Recalculate the layout based on the new size
+    }
+
+    // Ensure the scroll area and its content adjust correctly
+    if (scrollArea != nullptr) {
+        if (scrollArea->widget() != nullptr) {
+            scrollArea->widget()->adjustSize();
+        }
+    }
+}

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.h
@@ -1,0 +1,29 @@
+#ifndef FLOW_WIDGET_H
+#define FLOW_WIDGET_H
+#include "../../../layouts/flow_layout.h"
+
+#include <QHBoxLayout>
+#include <QWidget>
+#include <qscrollarea.h>
+
+class FlowWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    FlowWidget(QWidget *parent, Qt::ScrollBarPolicy hPolicy, Qt::ScrollBarPolicy vPolicy);
+    void addWidget(QWidget *widget_to_add) const;
+    void clearLayout();
+
+    QScrollArea *scrollArea;
+
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+
+private:
+    QHBoxLayout *main_layout;
+    FlowLayout *flow_layout;
+    QWidget *container;
+};
+
+#endif // FLOW_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_control_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_control_widget.cpp
@@ -1,0 +1,39 @@
+#include "overlap_control_widget.h"
+
+#include "overlap_widget.h"
+
+OverlapControlWidget::OverlapControlWidget(int overlapPercentage, int maxColumns, int maxRows, Qt::Orientation direction, QWidget* parent)
+    : QWidget(parent), overlapPercentage(overlapPercentage), maxColumns(maxColumns), maxRows(maxRows), direction(direction)
+{
+    // Main Widget and Layout
+    this->setMinimumSize(0, 100);
+    //this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    //this->setStyleSheet("border: 10px solid red;");
+
+    layout = new QHBoxLayout(this);
+    this->setLayout(layout);
+
+    card_size_slider = new QSlider(Qt::Horizontal);
+    card_size_slider->setRange(1, 10); // Example range for scaling, adjust as needed
+
+    amount_of_items_to_overlap = new LabeledInput("Cards to overlap:", this);
+    amount_of_items_to_overlap->addSpinBox(0, 999, 10);
+    overlap_percentage_input = new LabeledInput("Overlap percentage:", this);
+    overlap_percentage_input->addSpinBox(0, 100, 80);
+    overlap_direction = new LabeledInput("Overlap direction:", this);
+    overlap_direction->addDirectionComboBox();
+
+    layout->addWidget(card_size_slider);
+    layout->addWidget(amount_of_items_to_overlap);
+    layout->addWidget(overlap_percentage_input);
+    layout->addWidget(overlap_direction);
+
+    // TODO probably connect this to the parent
+    //connect(card_size_slider, &QSlider::valueChanged, display, &CardPicture::setScaleFactor);
+}
+
+void OverlapControlWidget::connectOverlapWidget(OverlapWidget *overlap_widget)
+{
+    connect(amount_of_items_to_overlap, &LabeledInput::spinBoxValueChanged, overlap_widget, &OverlapWidget::maxOverlapItemsChanged);
+    connect(overlap_direction, &LabeledInput::directionComboBoxChanged, overlap_widget, &OverlapWidget::overlapDirectionChanged);
+}

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_control_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_control_widget.h
@@ -1,0 +1,35 @@
+#ifndef OVERLAP_CONTROL_WIDGET_H
+#define OVERLAP_CONTROL_WIDGET_H
+#include "../display/labeled_input.h"
+#include "overlap_widget.h"
+
+#include <QHBoxLayout>
+#include <QSlider>
+#include <QWidget>
+
+class OverlapControlWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    OverlapControlWidget(int overlapPercentage,
+                         int maxColumns,
+                         int maxRows,
+                         Qt::Orientation direction,
+                         QWidget *parent);
+    void connectOverlapWidget(OverlapWidget *overlap_widget);
+
+private:
+    QHBoxLayout *layout;
+    QSlider *card_size_slider;
+    LabeledInput *amount_of_items_to_overlap;
+    LabeledInput *overlap_percentage_input;
+    LabeledInput *overlap_direction;
+    int overlapPercentage;
+    int maxColumns;
+    int maxRows;
+    Qt::Orientation direction;
+
+};
+
+#endif //OVERLAP_CONTROL_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.cpp
@@ -1,0 +1,149 @@
+#include "overlap_widget.h"
+
+#include "../../../../../deck/deck_list_model.h"
+#include "../../../layouts/flow_layout.h"
+
+#include <QWidget>
+#include <qsizepolicy.h>
+
+/**
+ * @class OverlapWidget
+ * @brief A widget for managing overlapping child widgets.
+ *
+ * The OverlapWidget class is a QWidget subclass that utilizes the OverlapLayout
+ * to arrange its child widgets in an overlapping manner. This widget allows
+ * configuration of overlap percentage, maximum columns, maximum rows, and layout
+ * direction, making it suitable for displaying elements that can partially stack
+ * over each other. The widget automatically manages resizing and re-layout of its
+ * child widgets based on the available space and specified parameters.
+ */
+
+/**
+ * @brief Constructs an OverlapWidget with specified layout parameters.
+ *
+ * Initializes the OverlapWidget with the given overlap percentage, maximum number
+ * of columns and rows, and layout direction. Sets size policies to ensure the widget
+ * can expand as needed. A new OverlapLayout is created and assigned to manage the
+ * layout of child widgets.
+ *
+ * @param overlapPercentage The percentage of overlap between child widgets (0-100).
+ * @param maxColumns The maximum number of columns for the layout (0 for unlimited).
+ * @param maxRows The maximum number of rows for the layout (0 for unlimited).
+ * @param direction The orientation of the layout, either Qt::Horizontal or Qt::Vertical.
+ * @param parent The parent widget of this OverlapWidget.
+ */
+OverlapWidget::OverlapWidget(int overlapPercentage, int maxColumns, int maxRows, Qt::Orientation direction, QWidget* parent)
+    : QWidget(parent), overlapPercentage(overlapPercentage), maxColumns(maxColumns), maxRows(maxRows), direction(direction)
+{
+    this->setMinimumSize(0, 0);
+    this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    overlap_layout = new OverlapLayout(overlapPercentage, maxColumns, maxRows, direction, this);
+    this->setLayout(overlap_layout);
+}
+
+/**
+ * @brief Adds a widget to the overlap layout.
+ *
+ * This method appends the specified widget to the internal OverlapLayout, allowing
+ * it to be arranged with the existing child widgets. The widget's visibility and
+ * behavior will be managed by the layout.
+ *
+ * @param widget_to_add A pointer to the QWidget to be added to the layout.
+ */
+void OverlapWidget::addWidget(QWidget *widget_to_add)
+{
+    this->overlap_layout->addWidget(widget_to_add);
+}
+
+/**
+ * @brief Clears all widgets from the layout and deletes them.
+ *
+ * This method removes all child widgets from the OverlapLayout, deleting both the
+ * widget instances and their corresponding layout items. This ensures that the layout
+ * is empty and can be reused or refreshed as needed.
+ */
+void OverlapWidget::clearLayout()
+{
+    if (overlap_layout != nullptr) {
+        QLayoutItem *item;
+        while ((item = overlap_layout->takeAt(0)) != nullptr) {
+            delete item->widget(); // Delete the widget
+            delete item;           // Delete the layout item
+        }
+    }
+
+    // If layout is null, create a new layout; otherwise, reuse the existing one
+    if (overlap_layout == nullptr) {
+        overlap_layout = new OverlapLayout(overlapPercentage, maxColumns, maxRows, direction, this);
+        this->setLayout(overlap_layout);
+    }
+}
+
+/**
+ * @brief Handles resizing events for the widget.
+ *
+ * This overridden method is called when the widget is resized. It invokes layout
+ * recalculation to ensure that the child widgets are correctly arranged based on the
+ * new dimensions. It marks the layout as dirty and activates it to reflect the changes.
+ *
+ * @param event The resize event containing the new size information.
+ */
+void OverlapWidget::resizeEvent(QResizeEvent* event) {
+    QWidget::resizeEvent(event);
+
+    // Trigger the layout to recalculate
+    if (overlap_layout != nullptr) {
+        overlap_layout->invalidate(); // Marks the layout as dirty and requires recalculation
+        overlap_layout->activate();   // Recalculate the layout based on the new size
+    }
+}
+
+/**
+ * @brief Updates the maximum number of overlapping items based on new value.
+ *
+ * This method updates the maximum number of columns or rows for the overlap layout
+ * based on the given new value. It adjusts the layout direction accordingly and
+ * triggers a size adjustment for the widget, ensuring the layout reflects the changes.
+ *
+ * @param newValue The new maximum number of overlapping items allowed in the layout.
+ */
+void OverlapWidget::maxOverlapItemsChanged(int newValue)
+{
+    if (direction == Qt::Horizontal) {
+        maxRows = 0;
+        overlap_layout->setMaxRows(0);
+
+        maxColumns = newValue;
+        overlap_layout->setMaxColumns(newValue);
+    } else {
+        maxRows = newValue;
+        overlap_layout->setMaxRows(newValue);
+
+        maxColumns = 0;
+        overlap_layout->setMaxColumns(0);
+    }
+    this->adjustSize();
+    overlap_layout->invalidate();
+}
+
+/**
+ * @brief Changes the layout direction based on the specified new direction.
+ *
+ * This method modifies the layout direction of the OverlapLayout based on the input
+ * string. It updates the direction and triggers a size adjustment for the widget.
+ * Valid inputs are "Qt::Horizontal" and "Qt::Vertical".
+ *
+ * @param newDirection The new layout direction as a QString.
+ */
+void OverlapWidget::overlapDirectionChanged(QString newDirection)
+{
+    if (newDirection.compare("Qt::Horizontal", Qt::CaseInsensitive) == 0) {
+        direction = Qt::Horizontal;
+        overlap_layout->setDirection(direction);
+    } else if (newDirection.compare("Qt::Vertical", Qt::CaseInsensitive) == 0) {
+        direction = Qt::Vertical;
+        overlap_layout->setDirection(direction);
+    }
+    this->adjustSize();
+    overlap_layout->invalidate();
+}

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.h
@@ -11,9 +11,10 @@ class OverlapWidget : public QWidget
     Q_OBJECT
 
 public:
-    OverlapWidget(int overlapPercentage, int maxColumns, int maxRows, Qt::Orientation direction, QWidget *parent);
+    OverlapWidget(QWidget *parent, int overlapPercentage, int maxColumns, int maxRows, Qt::Orientation direction, bool adjustOnResize = false);
     void addWidget(QWidget *widget_to_add);
     void clearLayout();
+    void adjustMaxColumnsAndRows();
 
 public slots:
     void maxOverlapItemsChanged(int newValue);
@@ -28,6 +29,7 @@ private:
     int maxColumns;
     int maxRows;
     Qt::Orientation direction;
+    bool adjustOnResize = false;
 
 };
 

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.h
@@ -1,0 +1,35 @@
+#ifndef OVERLAP_WIDGET_H
+#define OVERLAP_WIDGET_H
+
+#include "../../../layouts/overlap_layout.h"
+
+#include <QHBoxLayout>
+#include <QWidget>
+
+class OverlapWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    OverlapWidget(int overlapPercentage, int maxColumns, int maxRows, Qt::Orientation direction, QWidget *parent);
+    void addWidget(QWidget *widget_to_add);
+    void clearLayout();
+
+public slots:
+    void maxOverlapItemsChanged(int newValue);
+    void overlapDirectionChanged(QString newDirection);
+
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+
+private:
+    OverlapLayout *overlap_layout;
+    int overlapPercentage;
+    int maxColumns;
+    int maxRows;
+    Qt::Orientation direction;
+
+};
+
+
+#endif //OVERLAP_WIDGET_H

--- a/cockatrice/src/deck/deck_list_model.cpp
+++ b/cockatrice/src/deck/deck_list_model.cpp
@@ -79,24 +79,24 @@ int DeckListModel::rowCount(const QModelIndex &parent) const
 
 int DeckListModel::columnCount(const QModelIndex & /*parent*/) const
 {
-    return 2;
+    return 4;
 }
 
 QVariant DeckListModel::data(const QModelIndex &index, int role) const
 {
     // debugIndexInfo("data", index);
     if (!index.isValid()) {
-        return QVariant();
+        return {};
     }
 
     if (index.column() >= columnCount()) {
-        return QVariant();
+        return {};
     }
 
     auto *temp = static_cast<AbstractDecklistNode *>(index.internalPointer());
     auto *card = dynamic_cast<DecklistModelCardNode *>(temp);
     if (card == nullptr) {
-        auto *node = dynamic_cast<InnerDecklistNode *>(temp);
+        const auto *node = dynamic_cast<InnerDecklistNode *>(temp);
         switch (role) {
             case Qt::FontRole: {
                 QFont f;
@@ -108,13 +108,19 @@ QVariant DeckListModel::data(const QModelIndex &index, int role) const
                 switch (index.column()) {
                     case 0:
                         return node->recursiveCount(true);
-                    case 1:
+                    case 1: {
                         if (role == Qt::DisplayRole)
                             return node->getVisibleName();
-                        else
-                            return node->getName();
+                        return node->getName();
+                    }
+                    case 2: {
+                        return node->getCardUuid();
+                    }
+                    case 3: {
+                        return node->getCardCollectorNumber();
+                    }
                     default:
-                        return QVariant();
+                        return {};
                 }
             }
             case Qt::BackgroundRole: {
@@ -125,7 +131,7 @@ QVariant DeckListModel::data(const QModelIndex &index, int role) const
                 return QBrush(QColor(0, 0, 0));
             }
             default:
-                return QVariant();
+                return {};
         }
     } else {
         switch (role) {
@@ -136,8 +142,12 @@ QVariant DeckListModel::data(const QModelIndex &index, int role) const
                         return card->getNumber();
                     case 1:
                         return card->getName();
+                    case 2:
+                        return card->getCardUuid();
+                    case 3:
+                        return card->getCardCollectorNumber();
                     default:
-                        return QVariant();
+                        return {};
                 }
             }
             case Qt::BackgroundRole: {
@@ -148,28 +158,32 @@ QVariant DeckListModel::data(const QModelIndex &index, int role) const
                 return QBrush(QColor(0, 0, 0));
             }
             default:
-                return QVariant();
+                return {};
         }
     }
 }
 
-QVariant DeckListModel::headerData(int section, Qt::Orientation orientation, int role) const
+QVariant DeckListModel::headerData(const int section, const Qt::Orientation orientation, const int role) const
 {
     if ((role != Qt::DisplayRole) || (orientation != Qt::Horizontal)) {
-        return QVariant();
+        return {};
     }
 
     if (section >= columnCount()) {
-        return QVariant();
+        return {};
     }
 
     switch (section) {
         case 0:
-            return tr("Number");
+            return tr("Count");
         case 1:
             return tr("Card");
+        case 2:
+            return tr("Set");
+        case 3:
+            return tr("Number");
         default:
-            return QVariant();
+            return {};
     }
 }
 
@@ -215,7 +229,7 @@ void DeckListModel::emitRecursiveUpdates(const QModelIndex &index)
     emitRecursiveUpdates(index.parent());
 }
 
-bool DeckListModel::setData(const QModelIndex &index, const QVariant &value, int role)
+bool DeckListModel::setData(const QModelIndex &index, const QVariant &value, const int role)
 {
     auto *node = getNode<DecklistModelCardNode *>(index);
     if (!node || (role != Qt::EditRole)) {
@@ -229,6 +243,12 @@ bool DeckListModel::setData(const QModelIndex &index, const QVariant &value, int
         case 1:
             node->setName(value.toString());
             break;
+        case 2:
+            node->setCardSetCode(value.toString());
+        break;
+        case 3:
+            node->setCardCollectorNumber(value.toString());
+        break;
         default:
             return false;
     }
@@ -318,14 +338,16 @@ QModelIndex DeckListModel::findCard(const QString &cardName, const QString &zone
 
 QModelIndex DeckListModel::addCard(const QString &cardName, const QString &zoneName, bool abAddAnyway)
 {
-    CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(cardName);
-    if (info == nullptr) {
+    CardInfoPtr cardInfo = CardDatabaseManager::getInstance()->getCard(cardName);
+    CardInfoPerSet cardInfoSet = CardDatabaseManager::getInstance()->getPreferredSetForCard(cardName);
+
+    if (cardInfo == nullptr) {
         if (abAddAnyway) {
             // We need to keep this card added no matter what
             // This is usually called from tab_deck_editor
             // So we'll create a new CardInfo with the name
             // and default values for all fields
-            info = CardInfo::newInstance(cardName);
+            cardInfo = CardInfo::newInstance(cardName);
         } else {
             return {};
         }
@@ -333,18 +355,21 @@ QModelIndex DeckListModel::addCard(const QString &cardName, const QString &zoneN
 
     InnerDecklistNode *zoneNode = createNodeIfNeeded(zoneName, root);
 
-    QString cardType = info->getMainCardType();
+    const QString cardType = cardInfo->getMainCardType();
     InnerDecklistNode *cardTypeNode = createNodeIfNeeded(cardType, zoneNode);
 
-    QModelIndex parentIndex = nodeToIndex(cardTypeNode);
+    const QModelIndex parentIndex = nodeToIndex(cardTypeNode);
     auto *cardNode = dynamic_cast<DecklistModelCardNode *>(cardTypeNode->findChild(cardName));
     if (!cardNode) {
-        DecklistCardNode *decklistCard = deckList->addCard(cardName, zoneName);
-        beginInsertRows(parentIndex, cardTypeNode->size(), cardTypeNode->size());
+        auto *decklistCard = deckList->addCard(
+            cardInfo->getName(), zoneName, cardInfoSet.getProperty("uuid"), cardInfoSet.getProperty("num"));
+        beginInsertRows(parentIndex, static_cast<int>(cardTypeNode->size()), static_cast<int>(cardTypeNode->size()));
         cardNode = new DecklistModelCardNode(decklistCard, cardTypeNode);
         endInsertRows();
     } else {
         cardNode->setNumber(cardNode->getNumber() + 1);
+        cardNode->setCardSetCode(cardInfoSet.getProperty("uuid"));
+        cardNode->setCardCollectorNumber(cardInfoSet.getProperty("num"));
         deckList->updateDeckHash();
     }
     sort(lastKnownColumn, lastKnownOrder);

--- a/cockatrice/src/deck/deck_list_model.cpp
+++ b/cockatrice/src/deck/deck_list_model.cpp
@@ -324,7 +324,7 @@ DecklistModelCardNode *DeckListModel::findCardNode(const QString &cardName, cons
     if (uuid.isEmpty()) {
         return dynamic_cast<DecklistModelCardNode *>(typeNode->findChild(cardName));
     }
-    return dynamic_cast<DecklistModelCardNode *>(typeNode->findChild(cardName, uuid));
+    return dynamic_cast<DecklistModelCardNode *>(typeNode->findCardChildByNameAndUUID(cardName, uuid));
 }
 
 QModelIndex DeckListModel::findCard(const QString &cardName, const QString &zoneName, const QString &uuid) const
@@ -366,7 +366,8 @@ QModelIndex DeckListModel::addCard(const QString &cardName, const CardInfoPerSet
     InnerDecklistNode *cardTypeNode = createNodeIfNeeded(cardType, zoneNode);
 
     const QModelIndex parentIndex = nodeToIndex(cardTypeNode);
-    auto *cardNode = dynamic_cast<DecklistModelCardNode *>(cardTypeNode->findChild(cardName, cardInfoSet.getProperty("uuid")));
+    auto *cardNode = dynamic_cast<DecklistModelCardNode *>(
+        cardTypeNode->findCardChildByNameAndUUID(cardName, cardInfoSet.getProperty("uuid")));
     if (!cardNode) {
         auto *decklistCard = deckList->addCard(
             cardInfo->getName(), zoneName, cardInfoSet.getProperty("uuid"), cardInfoSet.getProperty("num"));

--- a/cockatrice/src/deck/deck_list_model.h
+++ b/cockatrice/src/deck/deck_list_model.h
@@ -37,6 +37,22 @@ public:
     {
         dataNode->setName(_name);
     }
+    QString getCardUuid() const override
+    {
+        return dataNode->getCardUuid();
+    }
+    void setCardSetCode(const QString &_cardSetName) override
+    {
+        dataNode->setCardSetCode(_cardSetName);
+    }
+    QString getCardCollectorNumber() const override
+    {
+        return dataNode->getCardCollectorNumber();
+    }
+    void setCardCollectorNumber(const QString &_cardSetNumber) override
+    {
+        dataNode->setCardCollectorNumber(_cardSetNumber);
+    }
     DecklistCardNode *getDataNode() const
     {
         return dataNode;

--- a/cockatrice/src/deck/deck_list_model.h
+++ b/cockatrice/src/deck/deck_list_model.h
@@ -2,6 +2,7 @@
 #define DECKLISTMODEL_H
 
 #include "decklist.h"
+#include "../game/cards/card_database.h"
 
 #include <QAbstractItemModel>
 #include <QList>
@@ -81,8 +82,10 @@ public:
     Qt::ItemFlags flags(const QModelIndex &index) const override;
     bool setData(const QModelIndex &index, const QVariant &value, int role) override;
     bool removeRows(int row, int count, const QModelIndex &parent) override;
-    QModelIndex findCard(const QString &cardName, const QString &zoneName) const;
-    QModelIndex addCard(const QString &cardName, const QString &zoneName, bool abAddAnyway = false);
+    QModelIndex findCard(const QString &cardName, const QString &zoneName, const QString &uuid = "") const;
+    QModelIndex addPreferredPrintingCard(const QString &cardName, const QString &zoneName, bool abAddAnyway);
+    QModelIndex
+    addCard(const ::QString &cardName, CardInfoPerSet cardInfoSet, const QString &zoneName, bool abAddAnyway = false);
     void sort(int column, Qt::SortOrder order) override;
     void cleanList();
     DeckLoader *getDeckList() const
@@ -98,7 +101,7 @@ private:
     Qt::SortOrder lastKnownOrder;
     InnerDecklistNode *createNodeIfNeeded(const QString &name, InnerDecklistNode *parent);
     QModelIndex nodeToIndex(AbstractDecklistNode *node) const;
-    DecklistModelCardNode *findCardNode(const QString &cardName, const QString &zoneName) const;
+    DecklistModelCardNode *findCardNode(const QString &cardName, const QString &zoneName, const QString &uuid = "") const;
     void emitRecursiveUpdates(const QModelIndex &index);
     void sortHelper(InnerDecklistNode *node, Qt::SortOrder order);
 

--- a/cockatrice/src/deck/deck_view.cpp
+++ b/cockatrice/src/deck/deck_view.cpp
@@ -354,7 +354,7 @@ void DeckViewScene::rebuildTree()
                 continue;
 
             for (int k = 0; k < currentCard->getNumber(); ++k) {
-                DeckViewCard *newCard = new DeckViewCard(currentCard->getName(), currentZone->getName(), container);
+                DeckViewCard *newCard = new DeckViewCard(currentCard->getName(), currentCard->getCardUuid(), currentZone->getName(), container);
                 container->addCard(newCard);
                 emit newCardAdded(newCard);
             }

--- a/cockatrice/src/deck/deck_view.cpp
+++ b/cockatrice/src/deck/deck_view.cpp
@@ -68,8 +68,8 @@ void DeckViewCardDragItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
     event->accept();
 }
 
-DeckViewCard::DeckViewCard(const QString &_name, const QString &_originZone, QGraphicsItem *parent)
-    : AbstractCardItem(_name, 0, -1, parent), originZone(_originZone), dragItem(0)
+DeckViewCard::DeckViewCard(const QString &_name, const QString &_uuid, const QString &_originZone, QGraphicsItem *parent)
+    : AbstractCardItem(_name, _uuid, 0, -1, parent), originZone(_originZone), dragItem(0)
 {
     setAcceptHoverEvents(true);
 }

--- a/cockatrice/src/deck/deck_view.h
+++ b/cockatrice/src/deck/deck_view.h
@@ -25,6 +25,7 @@ private:
 
 public:
     DeckViewCard(const QString &_name = QString(),
+                 const QString &_uuid = QString(),
                  const QString &_originZone = QString(),
                  QGraphicsItem *parent = nullptr);
     ~DeckViewCard();

--- a/cockatrice/src/dialogs/dlg_create_token.cpp
+++ b/cockatrice/src/dialogs/dlg_create_token.cpp
@@ -2,7 +2,7 @@
 
 #include "../game/cards/card_database_manager.h"
 #include "../game/cards/card_database_model.h"
-#include "../game/cards/card_info_picture.h"
+#include "../client/ui/widgets/cards/card_info_picture_widget.h"
 #include "../main.h"
 #include "../settings/cache_settings.h"
 #include "decklist.h"
@@ -25,7 +25,7 @@
 DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *parent)
     : QDialog(parent), predefinedTokens(_predefinedTokens)
 {
-    pic = new CardInfoPicture();
+    pic = new CardInfoPictureWidget();
     pic->setObjectName("pic");
 
     nameLabel = new QLabel(tr("&Name:"));

--- a/cockatrice/src/dialogs/dlg_create_token.h
+++ b/cockatrice/src/dialogs/dlg_create_token.h
@@ -15,7 +15,7 @@ class QTreeView;
 class DeckList;
 class CardDatabaseModel;
 class TokenDisplayModel;
-class CardInfoPicture;
+class CardInfoPictureWidget;
 
 class DlgCreateToken : public QDialog
 {
@@ -47,7 +47,7 @@ private:
     QLineEdit *nameEdit, *ptEdit, *annotationEdit;
     QCheckBox *destroyCheckBox;
     QRadioButton *chooseTokenFromAllRadioButton, *chooseTokenFromDeckRadioButton;
-    CardInfoPicture *pic;
+    CardInfoPictureWidget *pic;
     QTreeView *chooseTokenView;
 
     void updateSearchFieldWithoutUpdatingFilter(const QString &newValue) const;

--- a/cockatrice/src/game/cards/abstract_card_item.cpp
+++ b/cockatrice/src/game/cards/abstract_card_item.cpp
@@ -1,7 +1,6 @@
 #include "abstract_card_item.h"
 
 #include "../../client/ui/picture_loader.h"
-#include "../../main.h"
 #include "../../settings/cache_settings.h"
 #include "../game_scene.h"
 #include "card_database.h"
@@ -13,7 +12,11 @@
 #include <QPainter>
 #include <algorithm>
 
-AbstractCardItem::AbstractCardItem(const QString &_name, const QString &_uuid, Player *_owner, int _id, QGraphicsItem *parent)
+AbstractCardItem::AbstractCardItem(const QString &_name,
+                                   const QString &_uuid,
+                                   Player *_owner,
+                                   int _id,
+                                   QGraphicsItem *parent)
     : ArrowTarget(_owner, parent), id(_id), name(_name), uuid(_uuid), tapped(false), facedown(false), tapAngle(0),
       bgColor(Qt::transparent), isHovered(false), realZValue(0)
 {
@@ -50,7 +53,7 @@ void AbstractCardItem::pixmapUpdated()
 
 void AbstractCardItem::cardInfoUpdated()
 {
-    info = CardDatabaseManager::getInstance()->getCard(name);
+    info = CardDatabaseManager::getInstance()->getCardByNameAndUUID(name, uuid);
 
     if (!info && !name.isEmpty()) {
         QVariantHash properties = QVariantHash();

--- a/cockatrice/src/game/cards/abstract_card_item.cpp
+++ b/cockatrice/src/game/cards/abstract_card_item.cpp
@@ -13,8 +13,8 @@
 #include <QPainter>
 #include <algorithm>
 
-AbstractCardItem::AbstractCardItem(const QString &_name, Player *_owner, int _id, QGraphicsItem *parent)
-    : ArrowTarget(_owner, parent), id(_id), name(_name), tapped(false), facedown(false), tapAngle(0),
+AbstractCardItem::AbstractCardItem(const QString &_name, const QString &_uuid, Player *_owner, int _id, QGraphicsItem *parent)
+    : ArrowTarget(_owner, parent), id(_id), name(_name), uuid(_uuid), tapped(false), facedown(false), tapAngle(0),
       bgColor(Qt::transparent), isHovered(false), realZValue(0)
 {
     setCursor(Qt::OpenHandCursor);

--- a/cockatrice/src/game/cards/abstract_card_item.h
+++ b/cockatrice/src/game/cards/abstract_card_item.h
@@ -16,6 +16,7 @@ protected:
     CardInfoPtr info;
     int id;
     QString name;
+    QString uuid;
     bool tapped;
     bool facedown;
     int tapAngle;
@@ -49,6 +50,7 @@ public:
         return Type;
     }
     AbstractCardItem(const QString &_name = QString(),
+                     const QString &_uuid = QString(),
                      Player *_owner = nullptr,
                      int _id = -1,
                      QGraphicsItem *parent = nullptr);
@@ -75,6 +77,14 @@ public:
         return name;
     }
     void setName(const QString &_name = QString());
+    QString getUUID() const
+    {
+        return uuid;
+    }
+    void setUUID(QString _uuid)
+    {
+        uuid = _uuid;
+    }
     qreal getRealZValue() const
     {
         return realZValue;

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -672,6 +672,9 @@ QString CardDatabase::getPreferredPrintingUUIDForCard(const QString &cardName)
 
 bool CardDatabase::isUuidForPreferredPrinting(const QString &cardName, const QString &uuid)
 {
+    if (uuid.startsWith("card_")) {
+        return uuid == QLatin1String("card_") + getPreferredPrintingUUIDForCard(cardName);
+    }
     return uuid == getPreferredPrintingUUIDForCard(cardName);
 }
 

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -635,6 +635,27 @@ CardInfoPerSet CardDatabase::getPreferredSetForCard(const QString &cardName)
     return CardInfoPerSet(nullptr);
 }
 
+CardInfoPerSet CardDatabase::getSpecificSetForCard(const QString &cardName, const QString &uuid) const
+{
+    CardInfoPtr cardInfo = getCard(cardName);
+    if (!cardInfo) {
+        return CardInfoPerSet(nullptr);
+    }
+
+    CardInfoPerSetMap setMap = cardInfo->getSets();
+    if (setMap.empty()) {
+        return CardInfoPerSet(nullptr);
+    }
+
+    for (auto &cardInfoForSet : setMap) {
+        if (cardInfoForSet.getProperty("uuid") == uuid) {
+            return cardInfoForSet;
+        }
+    }
+
+    return CardInfoPerSet(nullptr);
+}
+
 QString CardDatabase::getPreferredPrintingUUIDForCard(const QString &cardName)
 {
     CardInfoPerSet preferredSetCardInfo = getPreferredSetForCard(cardName);

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -444,7 +444,7 @@ QList<CardInfoPtr> CardDatabase::getCards(const QStringList &cardNames) const
 CardInfoPtr CardDatabase::getCardByNameAndUUID(const QString &cardName, const QString &uuid) const
 {
     auto info = getCard(cardName);
-    if (uuid.isNull() || uuid.isEmpty()) {
+    if (uuid.isNull() || uuid.isEmpty() || info.isNull()) {
         return info;
     }
 

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -444,6 +444,10 @@ QList<CardInfoPtr> CardDatabase::getCards(const QStringList &cardNames) const
 CardInfoPtr CardDatabase::getCardByNameAndUUID(const QString &cardName, const QString &uuid) const
 {
     auto info = getCard(cardName);
+    if (uuid.isNull() || uuid.isEmpty()) {
+        return info;
+    }
+
     for (const auto &set : info->getSets()) {
         if (set.getProperty("uuid") == uuid) {
             CardInfoPtr cardFromSpecificSet = info->clone();

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -433,6 +433,9 @@ public:
     CardInfoPerSet getPreferredSetForCard(const QString &cardName);
     QString getPreferredPrintingUUIDForCard(const QString &cardName);
     CardInfoPtr guessCard(const QString &cardName) const;
+    CardInfoPerSet getPreferredSetForCard(const QString &cardName);
+    QString getPreferredPrintingUUIDForCard(const QString &cardName);
+
 
     /*
      * Get a card by its simple name. The name will be simplified in this

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -414,8 +414,6 @@ protected:
 private:
     CardInfoPtr getCardFromMap(const CardNameMap &cardMap, const QString &cardName) const;
     void checkUnknownSets();
-    CardInfoPerSet getPreferredSetForCard(const QString &cardName);
-    QString getPreferredPrintingUUIDForCard(const QString &cardName);
     void refreshCachedReverseRelatedCards();
 
     QBasicMutex *reloadDatabaseMutex = new QBasicMutex(), *clearDatabaseMutex = new QBasicMutex(),
@@ -432,6 +430,8 @@ public:
     CardInfoPtr getCard(const QString &cardName) const;
     QList<CardInfoPtr> getCards(const QStringList &cardNames) const;
     CardInfoPtr getCardByNameAndUUID(const QString &cardName, const QString &uuid) const;
+    CardInfoPerSet getPreferredSetForCard(const QString &cardName);
+    QString getPreferredPrintingUUIDForCard(const QString &cardName);
     CardInfoPtr guessCard(const QString &cardName) const;
 
     /*

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -431,6 +431,7 @@ public:
     QList<CardInfoPtr> getCards(const QStringList &cardNames) const;
     CardInfoPtr getCardByNameAndUUID(const QString &cardName, const QString &uuid) const;
     CardInfoPerSet getPreferredSetForCard(const QString &cardName);
+    CardInfoPerSet getSpecificSetForCard(const QString &cardName, const QString &uuid) const;
     QString getPreferredPrintingUUIDForCard(const QString &cardName);
     CardInfoPtr guessCard(const QString &cardName) const;
 

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -433,9 +433,6 @@ public:
     CardInfoPerSet getPreferredSetForCard(const QString &cardName);
     QString getPreferredPrintingUUIDForCard(const QString &cardName);
     CardInfoPtr guessCard(const QString &cardName) const;
-    CardInfoPerSet getPreferredSetForCard(const QString &cardName);
-    QString getPreferredPrintingUUIDForCard(const QString &cardName);
-
 
     /*
      * Get a card by its simple name. The name will be simplified in this

--- a/cockatrice/src/game/cards/card_item.cpp
+++ b/cockatrice/src/game/cards/card_item.cpp
@@ -1,7 +1,6 @@
 #include "card_item.h"
 
 #include "../../client/tabs/tab_game.h"
-#include "../../main.h"
 #include "../../settings/cache_settings.h"
 #include "../board/arrow_item.h"
 #include "../game_scene.h"
@@ -20,11 +19,12 @@
 
 CardItem::CardItem(Player *_owner,
                    const QString &_name,
+                   const QString &_uuid,
                    int _cardid,
                    bool _revealedCard,
                    QGraphicsItem *parent,
                    CardZone *_zone)
-    : AbstractCardItem(_name, _owner, _cardid, parent), zone(_zone), revealedCard(_revealedCard), attacking(false),
+    : AbstractCardItem(_name, _uuid, _owner, _cardid, parent), zone(_zone), revealedCard(_revealedCard), attacking(false),
       destroyOnZoneChange(false), doesntUntap(false), dragItem(nullptr), attachedTo(nullptr)
 {
     owner->addCard(this);

--- a/cockatrice/src/game/cards/card_item.cpp
+++ b/cockatrice/src/game/cards/card_item.cpp
@@ -24,8 +24,8 @@ CardItem::CardItem(Player *_owner,
                    bool _revealedCard,
                    QGraphicsItem *parent,
                    CardZone *_zone)
-    : AbstractCardItem(_name, _uuid, _owner, _cardid, parent), zone(_zone), revealedCard(_revealedCard), attacking(false),
-      destroyOnZoneChange(false), doesntUntap(false), dragItem(nullptr), attachedTo(nullptr)
+    : AbstractCardItem(_name, _uuid, _owner, _cardid, parent), zone(_zone), revealedCard(_revealedCard),
+      attacking(false), destroyOnZoneChange(false), doesntUntap(false), dragItem(nullptr), attachedTo(nullptr)
 {
     owner->addCard(this);
 
@@ -243,6 +243,7 @@ void CardItem::processCardInfo(const ServerInfo_Card &_info)
     }
 
     setId(_info.id());
+    setUUID(QString::fromStdString(_info.uuid()));
     setName(QString::fromStdString(_info.name()));
     setAttacking(_info.attacking());
     setFaceDown(_info.face_down());

--- a/cockatrice/src/game/cards/card_item.h
+++ b/cockatrice/src/game/cards/card_item.h
@@ -51,6 +51,7 @@ public:
     }
     CardItem(Player *_owner,
              const QString &_name = QString(),
+             const QString &_uuid = QString(),
              int _cardid = -1,
              bool revealedCard = false,
              QGraphicsItem *parent = nullptr,

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -2031,7 +2031,7 @@ void Player::eventCreateToken(const Event_CreateToken &event)
         return;
     }
 
-    CardItem *card = new CardItem(this, QString::fromStdString(event.card_name()), event.card_id());
+    CardItem *card = new CardItem(this, QString::fromStdString(event.card_name()), QString(), event.card_id());
     // use db PT if not provided in event
     if (!QString::fromStdString(event.pt()).isEmpty()) {
         card->setPT(QString::fromStdString(event.pt()));
@@ -2326,6 +2326,7 @@ void Player::eventDrawCards(const Event_DrawCards &event)
         for (int i = 0; i < listSize; ++i) {
             const ServerInfo_Card &cardInfo = event.cards(i);
             CardItem *card = _deck->takeCard(0, cardInfo.id());
+            card->setUUID(QString::fromStdString(cardInfo.uuid()));
             card->setName(QString::fromStdString(cardInfo.name()));
             _hand->addCard(card, false, -1);
         }

--- a/cockatrice/src/game/zones/card_zone.cpp
+++ b/cockatrice/src/game/zones/card_zone.cpp
@@ -126,7 +126,7 @@ void CardZone::addCard(CardItem *card, bool reorganize, int x, int y)
 {
     for (auto *view : views) {
         if ((x <= view->getCards().size()) || (view->getNumberCards() == -1)) {
-            view->addCard(new CardItem(player, card->getName(), card->getId()), reorganize, x, y);
+            view->addCard(new CardItem(player, card->getName(), card->getUUID(), card->getId()), reorganize, x, y);
         }
     }
 

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -56,9 +56,9 @@ void ZoneViewZone::initializeCards(const QList<const ServerInfo_Card *> &cardLis
 {
     if (!cardList.isEmpty()) {
         for (int i = 0; i < cardList.size(); ++i)
-            addCard(
-                new CardItem(player, QString::fromStdString(cardList[i]->name()), cardList[i]->id(), revealZone, this),
-                false, i);
+            addCard(new CardItem(player, QString::fromStdString(cardList[i]->name()),
+                                 QString::fromStdString(cardList[i]->uuid()), cardList[i]->id(), revealZone, this),
+                    false, i);
         reorganizeCards();
     } else if (!origZone->contentsKnown()) {
         Command_DumpZone cmd;
@@ -75,7 +75,7 @@ void ZoneViewZone::initializeCards(const QList<const ServerInfo_Card *> &cardLis
         int number = numberCards == -1 ? c.size() : (numberCards < c.size() ? numberCards : c.size());
         for (int i = 0; i < number; i++) {
             CardItem *card = c.at(i);
-            addCard(new CardItem(player, card->getName(), card->getId(), revealZone, this), false, i);
+            addCard(new CardItem(player, card->getName(), card->getUUID(), card->getId(), revealZone, this), false, i);
         }
         reorganizeCards();
     }
@@ -88,7 +88,8 @@ void ZoneViewZone::zoneDumpReceived(const Response &r)
     for (int i = 0; i < respCardListSize; ++i) {
         const ServerInfo_Card &cardInfo = resp.zone_info().card_list(i);
         auto cardName = QString::fromStdString(cardInfo.name());
-        auto *card = new CardItem(player, cardName, cardInfo.id(), revealZone, this, this);
+        auto cardUuid = QString::fromStdString(cardInfo.uuid());
+        auto *card = new CardItem(player, cardName, cardUuid, cardInfo.id(), revealZone, this, this);
         cards.insert(i, card);
     }
     reorganizeCards();

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -155,6 +155,16 @@ AbstractDecklistNode *InnerDecklistNode::findChild(const QString &_name)
     return nullptr;
 }
 
+AbstractDecklistNode *InnerDecklistNode::findChild(const QString &_name, const QString &_uuid)
+{
+    for (int i = 0; i < size(); i++) {
+        if (at(i)->getName() == _name && at(i)->getCardUuid() == _uuid) {
+            return at(i);
+        }
+    }
+    return nullptr;
+}
+
 int InnerDecklistNode::height() const
 {
     return at(0)->height() + 1;

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -128,6 +128,7 @@ public:
 
     void clearTree();
     AbstractDecklistNode *findChild(const QString &_name);
+    AbstractDecklistNode *findChild(const QString &_name, const QString &_uuid);
     int height() const override;
     int recursiveCount(bool countTotalCards = false) const;
     bool compare(AbstractDecklistNode *other) const override;

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -128,7 +128,7 @@ public:
 
     void clearTree();
     AbstractDecklistNode *findChild(const QString &_name);
-    AbstractDecklistNode *findChild(const QString &_name, const QString &_uuid);
+    AbstractDecklistNode *findCardChildByNameAndUUID(const QString &_name, const QString &_uuid);
     int height() const override;
     int recursiveCount(bool countTotalCards = false) const;
     bool compare(AbstractDecklistNode *other) const override;

--- a/common/pb/serverinfo_card.proto
+++ b/common/pb/serverinfo_card.proto
@@ -4,6 +4,7 @@ import "serverinfo_cardcounter.proto";
 message ServerInfo_Card {
     optional sint32 id = 1 [default = -1];
     optional string name = 2;
+    optional string uuid = 17;
     optional sint32 x = 3 [default = -1];
     optional sint32 y = 4 [default = -1];
     optional bool face_down = 5;

--- a/common/server_card.cpp
+++ b/common/server_card.cpp
@@ -27,8 +27,8 @@
 
 #include <QVariant>
 
-Server_Card::Server_Card(QString _name, int _id, int _coord_x, int _coord_y, Server_CardZone *_zone)
-    : zone(_zone), id(_id), coord_x(_coord_x), coord_y(_coord_y), name(_name), tapped(false), attacking(false),
+Server_Card::Server_Card(QString _name, QString _uuid, int _id, int _coord_x, int _coord_y, Server_CardZone *_zone)
+    : zone(_zone), id(_id), coord_x(_coord_x), coord_y(_coord_y), name(_name), uuid(_uuid), tapped(false), attacking(false),
       facedown(false), color(), ptString(), annotation(), destroyOnZoneChange(false), doesntUntap(false), parentCard(0),
       stashedCard(nullptr)
 {

--- a/common/server_card.cpp
+++ b/common/server_card.cpp
@@ -130,6 +130,7 @@ void Server_Card::getInfo(ServerInfo_Card *info)
     QString displayedName = facedown ? QString() : name;
 
     info->set_id(id);
+    info->set_uuid(uuid.toStdString());
     info->set_name(displayedName.toStdString());
     info->set_x(coord_x);
     info->set_y(coord_y);

--- a/common/server_card.h
+++ b/common/server_card.h
@@ -39,6 +39,7 @@ private:
     int id;
     int coord_x, coord_y;
     QString name;
+    QString uuid;
     QMap<int, int> counters;
     bool tapped;
     bool attacking;
@@ -54,7 +55,7 @@ private:
     Server_Card *stashedCard;
 
 public:
-    Server_Card(QString _name, int _id, int _coord_x, int _coord_y, Server_CardZone *_zone = nullptr);
+    Server_Card(QString _name, QString _uuid, int _id, int _coord_x, int _coord_y, Server_CardZone *_zone = nullptr);
     ~Server_Card() override;
 
     Server_CardZone *getZone() const
@@ -69,6 +70,10 @@ public:
     int getId() const
     {
         return id;
+    }
+    QString getUUID() const
+    {
+        return uuid;
     }
     int getX() const
     {

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -209,7 +209,8 @@ void Server_Player::setupZones()
                 continue;
             }
             for (int k = 0; k < currentCard->getNumber(); ++k) {
-                z->insertCard(new Server_Card(currentCard->getName(), nextCardId++, 0, 0, z), -1, 0);
+                z->insertCard(
+                    new Server_Card(currentCard->getName(), currentCard->getCardUuid(), nextCardId++, 0, 0, z), -1, 0);
             }
         }
     }
@@ -338,6 +339,7 @@ Response::ResponseCode Server_Player::drawCards(GameEventStorage &ges, int numbe
         ServerInfo_Card *cardInfo = eventPrivate.add_cards();
         cardInfo->set_id(card->getId());
         cardInfo->set_name(card->getName().toStdString());
+        cardInfo->set_uuid(card->getUUID().toStdString());
     }
 
     ges.enqueueGameEvent(eventPrivate, playerId, GameEventStorageItem::SendToPrivate, playerId);
@@ -1406,7 +1408,7 @@ Server_Player::cmdCreateToken(const Command_CreateToken &cmd, ResponseContainer 
         yCoord = 0;
     }
 
-    auto *card = new Server_Card(cardName, newCardId(), xCoord, yCoord);
+    auto *card = new Server_Card(cardName, QString(), newCardId(), xCoord, yCoord);
     card->moveToThread(thread());
     card->setPT(nameFromStdString(cmd.pt()));
     card->setColor(nameFromStdString(cmd.color()));
@@ -1941,6 +1943,7 @@ Server_Player::cmdDumpZone(const Command_DumpZone &cmd, ResponseContainer &rc, G
         Server_Card *card = cards[i];
         QString displayedName = card->getFaceDown() ? QString() : card->getName();
         ServerInfo_Card *cardInfo = zoneInfo->add_card_list();
+        cardInfo->set_uuid(card->getUUID().toStdString());
         cardInfo->set_name(displayedName.toStdString());
         if (zone->getType() == ServerInfo_Zone::HiddenZone) {
             cardInfo->set_id(i);
@@ -2058,6 +2061,7 @@ Server_Player::cmdRevealCards(const Command_RevealCards &cmd, ResponseContainer 
         ServerInfo_Card *cardInfo = eventPrivate.add_cards();
 
         cardInfo->set_id(card->getId());
+        cardInfo->set_uuid(card->getUUID().toStdString());
         cardInfo->set_name(card->getName().toStdString());
         cardInfo->set_x(card->getX());
         cardInfo->set_y(card->getY());


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #486

## Short roundup of the initial problem

It's currently not possible to include multiple versions/printings of a card in a deck since Cockatrice does not store this information anywhere. It is also not possible to communicate your chosen version/printing to your opponents.

## What will change with this Pull Request?
- Cockatrice will store this information and allow people to select their favorite printings.
