### PR TITLE
Add the ability to define starting life total during game creation.

### DIFF
--- a/cockatrice/src/dialogs/dlg_create_game.cpp
+++ b/cockatrice/src/dialogs/dlg_create_game.cpp
@@ -95,12 +95,26 @@ void DlgCreateGame::sharedCtor()
     spectatorsGroupBox = new QGroupBox(tr("Spectators"));
     spectatorsGroupBox->setLayout(spectatorsLayout);
 
+    startingLifeTotalLabel = new QLabel(tr("Starting life total:"));
+    startingLifeTotalEdit = new QSpinBox();
+    startingLifeTotalEdit->setMinimum(1);
+    startingLifeTotalEdit->setMaximum(99999); ///< Arbitrary but we can raise this when people start complaining.
+    startingLifeTotalEdit->setValue(20);
+    startingLifeTotalLabel->setBuddy(startingLifeTotalEdit);
+
+    QGridLayout *gameSetupOptionsLayout = new QGridLayout;
+    gameSetupOptionsLayout->addWidget(startingLifeTotalLabel, 0, 0);
+    gameSetupOptionsLayout->addWidget(startingLifeTotalEdit, 0, 1);
+    gameSetupOptionsGroupBox = new QGroupBox(tr("Game setup options"));
+    gameSetupOptionsGroupBox->setLayout(gameSetupOptionsLayout);
+
     QGridLayout *grid = new QGridLayout;
     grid->addWidget(generalGroupBox, 0, 0);
     grid->addWidget(joinRestrictionsGroupBox, 0, 1);
     grid->addWidget(gameTypeGroupBox, 1, 0);
     grid->addWidget(spectatorsGroupBox, 1, 1, Qt::AlignTop);
-    grid->addWidget(rememberGameSettings, 2, 0);
+    grid->addWidget(gameSetupOptionsGroupBox, 2, 0);
+    grid->addWidget(rememberGameSettings, 3, 0);
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok);
     connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
@@ -134,6 +148,7 @@ DlgCreateGame::DlgCreateGame(TabRoom *_room, const QMap<int, QString> &_gameType
     spectatorsCanTalkCheckBox->setChecked(SettingsCache::instance().getSpectatorsCanTalk());
     spectatorsSeeEverythingCheckBox->setChecked(SettingsCache::instance().getSpectatorsCanSeeEverything());
     createGameAsSpectatorCheckBox->setChecked(SettingsCache::instance().getCreateGameAsSpectator());
+    startingLifeTotalEdit->setValue(SettingsCache::instance().getDefaultStartingLifeTotal());
 
     if (!rememberGameSettings->isChecked()) {
         actReset();
@@ -208,6 +223,8 @@ void DlgCreateGame::actReset()
     spectatorsSeeEverythingCheckBox->setChecked(false);
     createGameAsSpectatorCheckBox->setChecked(false);
 
+    startingLifeTotalEdit->setValue(20);
+
     QMapIterator<int, QRadioButton *> gameTypeCheckBoxIterator(gameTypeCheckBoxes);
     while (gameTypeCheckBoxIterator.hasNext()) {
         gameTypeCheckBoxIterator.next();
@@ -234,6 +251,7 @@ void DlgCreateGame::actOK()
     cmd.set_spectators_see_everything(spectatorsSeeEverythingCheckBox->isChecked());
     cmd.set_join_as_judge(QApplication::keyboardModifiers() & Qt::ShiftModifier);
     cmd.set_join_as_spectator(createGameAsSpectatorCheckBox->isChecked());
+    cmd.set_starting_life_total(startingLifeTotalEdit->value());
 
     QString _gameTypes = QString();
     QMapIterator<int, QRadioButton *> gameTypeCheckBoxIterator(gameTypeCheckBoxes);
@@ -256,6 +274,7 @@ void DlgCreateGame::actOK()
         SettingsCache::instance().setSpectatorsCanTalk(spectatorsCanTalkCheckBox->isChecked());
         SettingsCache::instance().setSpectatorsCanSeeEverything(spectatorsSeeEverythingCheckBox->isChecked());
         SettingsCache::instance().setCreateGameAsSpectator(createGameAsSpectatorCheckBox->isChecked());
+        SettingsCache::instance().setDefaultStartingLifeTotal(startingLifeTotalEdit->value());
         SettingsCache::instance().setGameTypes(_gameTypes);
     }
     PendingCommand *pend = room->prepareRoomCommand(cmd);

--- a/cockatrice/src/dialogs/dlg_create_game.h
+++ b/cockatrice/src/dialogs/dlg_create_game.h
@@ -35,10 +35,10 @@ private:
     QMap<int, QString> gameTypes;
     QMap<int, QRadioButton *> gameTypeCheckBoxes;
 
-    QGroupBox *generalGroupBox, *spectatorsGroupBox;
-    QLabel *descriptionLabel, *passwordLabel, *maxPlayersLabel;
+    QGroupBox *generalGroupBox, *spectatorsGroupBox, *gameSetupOptionsGroupBox;
+    QLabel *descriptionLabel, *passwordLabel, *maxPlayersLabel, *startingLifeTotalLabel;
     QLineEdit *descriptionEdit, *passwordEdit;
-    QSpinBox *maxPlayersEdit;
+    QSpinBox *maxPlayersEdit, *startingLifeTotalEdit;
     QCheckBox *onlyBuddiesCheckBox, *onlyRegisteredCheckBox;
     QCheckBox *spectatorsAllowedCheckBox, *spectatorsNeedPasswordCheckBox, *spectatorsCanTalkCheckBox,
         *spectatorsSeeEverythingCheckBox, *createGameAsSpectatorCheckBox;

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -301,6 +301,7 @@ SettingsCache::SettingsCache()
     spectatorsCanTalk = settings->value("game/spectatorscantalk", false).toBool();
     spectatorsCanSeeEverything = settings->value("game/spectatorscanseeeverything", false).toBool();
     createGameAsSpectator = settings->value("game/creategameasspectator", false).toBool();
+    defaultStartingLifeTotal = settings->value("game/defaultstartinglifetotal", 20).toInt();
     rememberGameSettings = settings->value("game/remembergamesettings", true).toBool();
     clientID = settings->value("personal/clientid", CLIENT_INFO_NOT_SET).toString();
     clientVersion = settings->value("personal/clientversion", CLIENT_INFO_NOT_SET).toString();
@@ -1088,6 +1089,12 @@ void SettingsCache::setCreateGameAsSpectator(const bool _createGameAsSpectator)
     createGameAsSpectator = _createGameAsSpectator;
     settings->setValue("game/creategameasspectator", createGameAsSpectator);
 }
+
+void SettingsCache::setDefaultStartingLifeTotal(const int _defaultStartingLifeTotal)
+{
+    defaultStartingLifeTotal = _defaultStartingLifeTotal;
+    settings->setValue("game/defaultstartinglifetotal", defaultStartingLifeTotal);
+};
 
 void SettingsCache::setRememberGameSettings(const bool _rememberGameSettings)
 {

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -163,6 +163,7 @@ private:
     bool spectatorsCanTalk;
     bool spectatorsCanSeeEverything;
     bool createGameAsSpectator;
+    int defaultStartingLifeTotal;
     int keepalive;
     int timeout;
     void translateLegacySettings();
@@ -515,6 +516,10 @@ public:
     {
         return spectatorsCanSeeEverything;
     }
+    int getDefaultStartingLifeTotal() const
+    {
+        return defaultStartingLifeTotal;
+    }
     bool getCreateGameAsSpectator() const
     {
         return createGameAsSpectator;
@@ -679,6 +684,7 @@ public slots:
     void setSpectatorsCanTalk(const bool _spectatorsCanTalk);
     void setSpectatorsCanSeeEverything(const bool _spectatorsCanSeeEverything);
     void setCreateGameAsSpectator(const bool _createGameAsSpectator);
+    void setDefaultStartingLifeTotal(const int _defaultStartingLifeTotal);
     void setRememberGameSettings(const bool _rememberGameSettings);
     void setNotifyAboutUpdate(QT_STATE_CHANGED_T _notifyaboutupdate);
     void setNotifyAboutNewVersion(QT_STATE_CHANGED_T _notifyaboutnewversion);

--- a/common/pb/room_commands.proto
+++ b/common/pb/room_commands.proto
@@ -38,6 +38,7 @@ message Command_CreateGame {
     repeated uint32 game_type_ids = 10;
     optional bool join_as_judge = 11;
     optional bool join_as_spectator = 12;
+    optional uint32 starting_life_total = 13;
 }
 
 message Command_JoinGame {

--- a/common/server_game.cpp
+++ b/common/server_game.cpp
@@ -61,14 +61,15 @@ Server_Game::Server_Game(const ServerInfo_User &_creatorInfo,
                          bool _spectatorsNeedPassword,
                          bool _spectatorsCanTalk,
                          bool _spectatorsSeeEverything,
+                         int _startingLifeTotal,
                          Server_Room *_room)
     : QObject(), room(_room), nextPlayerId(0), hostId(0), creatorInfo(new ServerInfo_User(_creatorInfo)),
       gameStarted(false), gameClosed(false), gameId(_gameId), password(_password), maxPlayers(_maxPlayers),
       gameTypes(_gameTypes), activePlayer(-1), activePhase(-1), onlyBuddies(_onlyBuddies),
       onlyRegistered(_onlyRegistered), spectatorsAllowed(_spectatorsAllowed),
       spectatorsNeedPassword(_spectatorsNeedPassword), spectatorsCanTalk(_spectatorsCanTalk),
-      spectatorsSeeEverything(_spectatorsSeeEverything), inactivityCounter(0), startTimeOfThisGame(0),
-      secondsElapsed(0), firstGameStarted(false), turnOrderReversed(false), startTime(QDateTime::currentDateTime()),
+      spectatorsSeeEverything(_spectatorsSeeEverything), startingLifeTotal(_startingLifeTotal), inactivityCounter(0),
+      startTimeOfThisGame(0), secondsElapsed(0), firstGameStarted(false), turnOrderReversed(false), startTime(QDateTime::currentDateTime()),
       pingClock(nullptr),
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
       gameMutex()
@@ -323,7 +324,7 @@ void Server_Game::doStartGameIfReady()
     }
     for (Server_Player *player : players.values()) {
         if (!player->getSpectator())
-            player->setupZones(room->getGameTypes());
+            player->setupZones();
     }
 
     gameStarted = true;

--- a/common/server_game.cpp
+++ b/common/server_game.cpp
@@ -69,8 +69,8 @@ Server_Game::Server_Game(const ServerInfo_User &_creatorInfo,
       onlyRegistered(_onlyRegistered), spectatorsAllowed(_spectatorsAllowed),
       spectatorsNeedPassword(_spectatorsNeedPassword), spectatorsCanTalk(_spectatorsCanTalk),
       spectatorsSeeEverything(_spectatorsSeeEverything), startingLifeTotal(_startingLifeTotal), inactivityCounter(0),
-      startTimeOfThisGame(0), secondsElapsed(0), firstGameStarted(false), turnOrderReversed(false), startTime(QDateTime::currentDateTime()),
-      pingClock(nullptr),
+      startTimeOfThisGame(0), secondsElapsed(0), firstGameStarted(false), turnOrderReversed(false),
+      startTime(QDateTime::currentDateTime()), pingClock(nullptr),
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
       gameMutex()
 #else

--- a/common/server_game.cpp
+++ b/common/server_game.cpp
@@ -323,7 +323,7 @@ void Server_Game::doStartGameIfReady()
     }
     for (Server_Player *player : players.values()) {
         if (!player->getSpectator())
-            player->setupZones();
+            player->setupZones(room->getGameTypes());
     }
 
     gameStarted = true;

--- a/common/server_game.h
+++ b/common/server_game.h
@@ -66,6 +66,7 @@ private:
     bool spectatorsNeedPassword;
     bool spectatorsCanTalk;
     bool spectatorsSeeEverything;
+    int startingLifeTotal;
     int inactivityCounter;
     int startTimeOfThisGame, secondsElapsed;
     bool firstGameStarted;
@@ -105,6 +106,7 @@ public:
                 bool _spectatorsNeedPassword,
                 bool _spectatorsCanTalk,
                 bool _spectatorsSeeEverything,
+                int startingLifeTotal,
                 Server_Room *parent);
     ~Server_Game();
     Server_Room *getRoom() const
@@ -161,6 +163,10 @@ public:
     bool getSpectatorsSeeEverything() const
     {
         return spectatorsSeeEverything;
+    }
+    int getStartingLifeTotal() const
+    {
+        return startingLifeTotal;
     }
     Response::ResponseCode
     checkJoin(ServerInfo_User *user, const QString &_password, bool spectator, bool overrideRestrictions, bool asJudge);

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -1,5 +1,7 @@
 #include "server_player.h"
 
+#include "../servatrice/src/main.h"
+#include "../servatrice/src/server_logger.h"
 #include "color.h"
 #include "decklist.h"
 #include "get_pb_extension.h"
@@ -162,7 +164,7 @@ int Server_Player::newArrowId() const
     return id + 1;
 }
 
-void Server_Player::setupZones()
+void Server_Player::setupZones(const QStringList &gameTypes)
 {
     // This may need to be customized according to the game rules.
     // ------------------------------------------------------------------
@@ -178,7 +180,11 @@ void Server_Player::setupZones()
     addZone(new Server_CardZone(this, "grave", false, ServerInfo_Zone::PublicZone));
     addZone(new Server_CardZone(this, "rfg", false, ServerInfo_Zone::PublicZone));
 
-    addCounter(new Server_Counter(0, "life", makeColor(255, 255, 255), 25, 20));
+    if (gameTypes.contains(QString("Commander"))) {
+        addCounter(new Server_Counter(0, "life", makeColor(255, 255, 255), 25, 40));
+    } else {
+        addCounter(new Server_Counter(0, "life", makeColor(255, 255, 255), 25, 20));
+    }
     addCounter(new Server_Counter(1, "w", makeColor(255, 255, 150), 20, 0));
     addCounter(new Server_Counter(2, "u", makeColor(150, 150, 255), 20, 0));
     addCounter(new Server_Counter(3, "b", makeColor(150, 150, 150), 20, 0));
@@ -904,7 +910,7 @@ Server_Player::cmdUnconcede(const Command_Unconcede & /*cmd*/, ResponseContainer
     ges.enqueueGameEvent(event, playerId);
     ges.setGameEventContext(Context_Unconcede());
 
-    setupZones();
+    setupZones(game->getRoom()->getGameTypes());
 
     game->sendGameStateToPlayers();
 

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -162,7 +162,7 @@ int Server_Player::newArrowId() const
     return id + 1;
 }
 
-void Server_Player::setupZones(const QStringList &gameTypes)
+void Server_Player::setupZones()
 {
     // This may need to be customized according to the game rules.
     // ------------------------------------------------------------------
@@ -178,11 +178,7 @@ void Server_Player::setupZones(const QStringList &gameTypes)
     addZone(new Server_CardZone(this, "grave", false, ServerInfo_Zone::PublicZone));
     addZone(new Server_CardZone(this, "rfg", false, ServerInfo_Zone::PublicZone));
 
-    if (gameTypes.contains(QString("Commander"))) {
-        addCounter(new Server_Counter(0, "life", makeColor(255, 255, 255), 25, 40));
-    } else {
-        addCounter(new Server_Counter(0, "life", makeColor(255, 255, 255), 25, 20));
-    }
+    addCounter(new Server_Counter(0, "life", makeColor(255, 255, 255), 25, game->getStartingLifeTotal()));
     addCounter(new Server_Counter(1, "w", makeColor(255, 255, 150), 20, 0));
     addCounter(new Server_Counter(2, "u", makeColor(150, 150, 255), 20, 0));
     addCounter(new Server_Counter(3, "b", makeColor(150, 150, 150), 20, 0));
@@ -908,7 +904,7 @@ Server_Player::cmdUnconcede(const Command_Unconcede & /*cmd*/, ResponseContainer
     ges.enqueueGameEvent(event, playerId);
     ges.setGameEventContext(Context_Unconcede());
 
-    setupZones(game->getRoom()->getGameTypes());
+    setupZones();
 
     game->sendGameStateToPlayers();
 

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -1,7 +1,5 @@
 #include "server_player.h"
 
-#include "../servatrice/src/main.h"
-#include "../servatrice/src/server_logger.h"
 #include "color.h"
 #include "decklist.h"
 #include "get_pb_extension.h"

--- a/common/server_player.h
+++ b/common/server_player.h
@@ -169,7 +169,7 @@ public:
     void addCounter(Server_Counter *counter);
 
     void clearZones();
-    void setupZones(const QStringList &gameTypes);
+    void setupZones();
 
     Response::ResponseCode drawCards(GameEventStorage &ges, int number);
     Response::ResponseCode moveCard(GameEventStorage &ges,

--- a/common/server_player.h
+++ b/common/server_player.h
@@ -169,7 +169,7 @@ public:
     void addCounter(Server_Counter *counter);
 
     void clearZones();
-    void setupZones();
+    void setupZones(const QStringList& gameTypes);
 
     Response::ResponseCode drawCards(GameEventStorage &ges, int number);
     Response::ResponseCode moveCard(GameEventStorage &ges,

--- a/common/server_player.h
+++ b/common/server_player.h
@@ -169,7 +169,7 @@ public:
     void addCounter(Server_Counter *counter);
 
     void clearZones();
-    void setupZones(const QStringList& gameTypes);
+    void setupZones(const QStringList &gameTypes);
 
     Response::ResponseCode drawCards(GameEventStorage &ges, int number);
     Response::ResponseCode moveCard(GameEventStorage &ges,

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -815,13 +815,14 @@ Server_ProtocolHandler::cmdCreateGame(const Command_CreateGame &cmd, Server_Room
     }
 
     QString description = nameFromStdString(cmd.description());
+    int startingLifeTotal = cmd.has_starting_life_total() ? cmd.starting_life_total() : 20;
 
     // When server doesn't permit registered users to exist, do not honor only-reg setting
     bool onlyRegisteredUsers = cmd.only_registered() && (server->permitUnregisteredUsers());
     Server_Game *game = new Server_Game(
         copyUserInfo(false), gameId, description, QString::fromStdString(cmd.password()), cmd.max_players(), gameTypes,
         cmd.only_buddies(), onlyRegisteredUsers, cmd.spectators_allowed(), cmd.spectators_need_password(),
-        cmd.spectators_can_talk(), cmd.spectators_see_everything(), cmd.starting_life_total(), room);
+        cmd.spectators_can_talk(), cmd.spectators_see_everything(), startingLifeTotal, room);
 
     game->addPlayer(this, rc, asSpectator, asJudge, false);
     room->addGame(game);

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -821,7 +821,7 @@ Server_ProtocolHandler::cmdCreateGame(const Command_CreateGame &cmd, Server_Room
     Server_Game *game = new Server_Game(
         copyUserInfo(false), gameId, description, QString::fromStdString(cmd.password()), cmd.max_players(), gameTypes,
         cmd.only_buddies(), onlyRegisteredUsers, cmd.spectators_allowed(), cmd.spectators_need_password(),
-        cmd.spectators_can_talk(), cmd.spectators_see_everything(), room);
+        cmd.spectators_can_talk(), cmd.spectators_see_everything(), cmd.starting_life_total(), room);
 
     game->addPlayer(this, rc, asSpectator, asJudge, false);
     room->addGame(game);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -300,6 +300,9 @@ void SettingsCache::setSpectatorsCanSeeEverything(const bool /* _spectatorsCanSe
 void SettingsCache::setCreateGameAsSpectator(const bool /* _createGameAsSpectator */)
 {
 }
+void SettingsCache::setDefaultStartingLifeTotal(const int /* _startingLifeTotal */)
+{
+}
 void SettingsCache::setRememberGameSettings(const bool /* _rememberGameSettings */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -304,6 +304,9 @@ void SettingsCache::setSpectatorsCanSeeEverything(const bool /* _spectatorsCanSe
 void SettingsCache::setCreateGameAsSpectator(const bool /* _createGameAsSpectator */)
 {
 }
+void SettingsCache::setDefaultStartingLifeTotal(const int /* _startingLifeTotal */)
+{
+}
 void SettingsCache::setRememberGameSettings(const bool /* _rememberGameSettings */)
 {
 }


### PR DESCRIPTION
## Related Ticket(s)
- Contradicts #1740 by hard-coding some logic into the server.
- Properly partially closes #4858, which was closed because it related too closely to #1740.
- Properly partially closes #4693, which was closed because it related too closely to #1740.

## Short roundup of the initial problem

Currently, Cockatrice will always set the life total to 20 since this is the default life total for "Standard". However, most, or a large portion of our user base, consists of commander players. This small change allows the ServerPlayer to respect the defined game types selected during room setup. If this includes Commander, we instead set the Life Total to 40. Since this change is purely opt-in and highly requested, I propose to merge this despite the above mentioned hard-coding.

## What will change with this Pull Request?
- ServerPlayer::setupZones is now passed the room->getGameTypes();
- ServerPlayer::setupZones now checks if the GameType String includes "Commander" and then sets the life total to 40 instead.

