### PR TITLE
Add a button to swap the card between mainboard and sideboard to the DeckEditor

### DIFF
--- a/cockatrice/cockatrice.qrc
+++ b/cockatrice/cockatrice.qrc
@@ -29,6 +29,7 @@
         <file>resources/icons/search.svg</file>
         <file>resources/icons/settings.svg</file>
         <file>resources/icons/spectator.svg</file>
+        <file>resources/icons/swap.svg</file>
         <file>resources/icons/sync.svg</file>
         <file>resources/icons/tab_changed.svg</file>
         <file>resources/icons/update.png</file>

--- a/cockatrice/resources/icons/swap.svg
+++ b/cockatrice/resources/icons/swap.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" fill="#000000" version="1.1" id="Capa_1"
+     xmlns="http://www.w3.org/2000/svg"
+     width="800px" height="800px" viewBox="0 0 71.753 71.753"
+     xml:space="preserve">
+<g>
+	<path d="M39.798,20.736H28.172v20.738L11.625,41.47V20.736H0L19.899,0.839L39.798,20.736z M51.855,70.914l19.897-19.896H60.129
+		V30.282l-16.547-0.004v20.74H31.957L51.855,70.914z"/>
+</g>
+</svg>

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -113,6 +113,12 @@ void TabDeckEditor::createDeckDock()
     auto *tbRemoveCard = new QToolButton(this);
     tbRemoveCard->setDefaultAction(aRemoveCard);
 
+    aSwapCard = new QAction(QString(), this);
+    aSwapCard->setIcon(QPixmap("theme:icons/swap"));
+    connect(aSwapCard, SIGNAL(triggered()), this, SLOT(actSwapCard()));
+    auto *tbSwapCard = new QToolButton(this);
+    tbSwapCard->setDefaultAction(aSwapCard);
+
     auto *upperLayout = new QGridLayout;
     upperLayout->setObjectName("upperLayout");
     upperLayout->addWidget(nameLabel, 0, 0);
@@ -138,6 +144,7 @@ void TabDeckEditor::createDeckDock()
     lowerLayout->addWidget(tbIncrement, 0, 2);
     lowerLayout->addWidget(tbDecrement, 0, 3);
     lowerLayout->addWidget(tbRemoveCard, 0, 4);
+    lowerLayout->addWidget(tbSwapCard, 0, 5);
     lowerLayout->addWidget(deckView, 1, 0, 1, 5);
 
     // Create widgets for both layouts to make splitter work correctly

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -145,7 +145,7 @@ void TabDeckEditor::createDeckDock()
     lowerLayout->addWidget(tbDecrement, 0, 3);
     lowerLayout->addWidget(tbRemoveCard, 0, 4);
     lowerLayout->addWidget(tbSwapCard, 0, 5);
-    lowerLayout->addWidget(deckView, 1, 0, 1, 5);
+    lowerLayout->addWidget(deckView, 1, 0, 1, 6);
 
     // Create widgets for both layouts to make splitter work correctly
     auto *topWidget = new QWidget;
@@ -1306,6 +1306,7 @@ void TabDeckEditor::actSwapCard()
 
     setModified(true);
     setSaveStatus(true);
+    update();
 }
 
 void TabDeckEditor::actAddCard()

--- a/cockatrice/src/client/tabs/tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/tab_deck_editor.h
@@ -142,7 +142,7 @@ private:
         *aSaveDeckToClipboard, *aSaveDeckToClipboardRaw, *aPrintDeck, *aExportDeckDecklist, *aAnalyzeDeckDeckstats,
         *aAnalyzeDeckTappedout, *aClose;
     QAction *aClearFilterAll, *aClearFilterOne;
-    QAction *aAddCard, *aAddCardToSideboard, *aRemoveCard, *aIncrement, *aDecrement;
+    QAction *aAddCard, *aAddCardToSideboard, *aRemoveCard, *aIncrement, *aDecrement, *aSwapCard;
     QAction *aResetLayout;
     QAction *aCardInfoDockVisible, *aCardInfoDockFloating, *aDeckDockVisible, *aDeckDockFloating, *aFilterDockVisible,
         *aFilterDockFloating, *aPrintingSelectorDockVisible, *aPrintingSelectorDockFloating;


### PR DESCRIPTION
## Related Ticket(s)
- Closes #4030

## Short roundup of the initial problem
Some people wished for a button to easily swap cards between mainboard and sideboard. Since this is an accessibility issues, I've added one. Please let me know how to proceed with the icons, I've currently used:

https://www.svgrepo.com/svg/25529/up-and-down-arrows

which is [CC0 License](https://www.svgrepo.com/page/licensing/#CC0)d

## What will change with this Pull Request?
- TabDeckEditor gains a new button to swap cards.
