### PR TITLE
add "open in new tab" button to decklist confirmation dialogue

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -769,8 +769,9 @@ void TabDeckEditor::actNewDeck()
 {
     auto deckOpenLocation = confirmOpen(false);
 
-    if (deckOpenLocation == CANCELLED)
+    if (deckOpenLocation == CANCELLED) {
         return;
+    }
 
     if (deckOpenLocation == NEW_TAB) {
         emit openDeckEditor(nullptr);
@@ -789,8 +790,9 @@ void TabDeckEditor::actLoadDeck()
 {
     auto deckOpenLocation = confirmOpen();
 
-    if (deckOpenLocation == CANCELLED)
+    if (deckOpenLocation == CANCELLED) {
         return;
+    }
 
     QFileDialog dialog(this, tr("Load deck"));
     dialog.setDirectory(SettingsCache::instance().getDeckPath());
@@ -882,8 +884,9 @@ void TabDeckEditor::actLoadDeckFromClipboard()
 {
     auto deckOpenLocation = confirmOpen();
 
-    if (deckOpenLocation == CANCELLED)
+    if (deckOpenLocation == CANCELLED) {
         return;
+    }
 
     DlgLoadDeckFromClipboard dlg(this);
     if (!dlg.exec())
@@ -1028,8 +1031,9 @@ TabDeckEditor::DeckOpenLocation TabDeckEditor::confirmOpen(const bool openInSame
 
     // `exec()` returns an opaque value if a non-standard button was clicked.
     // Directly check if newTabButton was clicked before switching over the standard buttons.
-    if (msgBox.clickedButton() == newTabButton)
+    if (msgBox.clickedButton() == newTabButton) {
         return NEW_TAB;
+    }
 
     switch (ret) {
         case QMessageBox::Save:

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -1016,9 +1016,20 @@ TabDeckEditor::DeckOpenLocation TabDeckEditor::confirmOpen(const bool openInSame
 
     // do the save confirmation dialogue
     tabSupervisor->setCurrentWidget(this);
-    QMessageBox::StandardButton ret = QMessageBox::warning(
-        this, tr("Are you sure?"), tr("The decklist has been modified.\nDo you want to save the changes?"),
-        QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
+
+    QMessageBox msgBox;
+    msgBox.setIcon(QMessageBox::Warning);
+    msgBox.setWindowTitle(tr("Are you sure?"));
+    msgBox.setText(tr("The decklist has been modified.\nDo you want to save the changes?"));
+    msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
+    QPushButton *newTabButton = msgBox.addButton(tr("Open in new tab"), QMessageBox::ApplyRole);
+
+    int ret = msgBox.exec();
+
+    // `exec()` returns an opaque value if a non-standard button was clicked.
+    // Directly check if newTabButton was clicked before switching over the standard buttons.
+    if (msgBox.clickedButton() == newTabButton)
+        return NEW_TAB;
 
     switch (ret) {
         case QMessageBox::Save:

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -748,9 +748,7 @@ bool TabDeckEditor::confirmClose()
 {
     if (modified) {
         tabSupervisor->setCurrentWidget(this);
-        QMessageBox::StandardButton ret = QMessageBox::warning(
-            this, tr("Are you sure?"), tr("The decklist has been modified.\nDo you want to save the changes?"),
-            QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
+        int ret = createSaveConfirmationWindow()->exec();
         if (ret == QMessageBox::Save)
             return actSaveDeck();
         else if (ret == QMessageBox::Cancel)
@@ -1020,18 +1018,14 @@ TabDeckEditor::DeckOpenLocation TabDeckEditor::confirmOpen(const bool openInSame
     // do the save confirmation dialogue
     tabSupervisor->setCurrentWidget(this);
 
-    QMessageBox msgBox;
-    msgBox.setIcon(QMessageBox::Warning);
-    msgBox.setWindowTitle(tr("Are you sure?"));
-    msgBox.setText(tr("The decklist has been modified.\nDo you want to save the changes?"));
-    msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
-    QPushButton *newTabButton = msgBox.addButton(tr("Open in new tab"), QMessageBox::ApplyRole);
+    QMessageBox *msgBox = createSaveConfirmationWindow();
+    QPushButton *newTabButton = msgBox->addButton(tr("Open in new tab"), QMessageBox::ApplyRole);
 
-    int ret = msgBox.exec();
+    int ret = msgBox->exec();
 
     // `exec()` returns an opaque value if a non-standard button was clicked.
     // Directly check if newTabButton was clicked before switching over the standard buttons.
-    if (msgBox.clickedButton() == newTabButton) {
+    if (msgBox->clickedButton() == newTabButton) {
         return NEW_TAB;
     }
 
@@ -1043,6 +1037,21 @@ TabDeckEditor::DeckOpenLocation TabDeckEditor::confirmOpen(const bool openInSame
         default:
             return CANCELLED;
     }
+}
+
+/**
+ * @brief Creates the base save confirmation dialogue box.
+ *
+ * @returns A QMessageBox that can be further modified
+ */
+QMessageBox *TabDeckEditor::createSaveConfirmationWindow()
+{
+    QMessageBox *msgBox = new QMessageBox(this);
+    msgBox->setIcon(QMessageBox::Warning);
+    msgBox->setWindowTitle(tr("Are you sure?"));
+    msgBox->setText(tr("The decklist has been modified.\nDo you want to save the changes?"));
+    msgBox->setStandardButtons(QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
+    return msgBox;
 }
 
 /**

--- a/cockatrice/src/client/tabs/tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/tab_deck_editor.h
@@ -22,6 +22,7 @@ class Response;
 class FilterTreeModel;
 class FilterBuilder;
 class QGroupBox;
+class QMessageBox;
 class QHBoxLayout;
 class QVBoxLayout;
 class QPushButton;
@@ -111,6 +112,7 @@ private:
     };
 
     DeckOpenLocation confirmOpen(const bool openInSameTabIfBlank = true);
+    QMessageBox *createSaveConfirmationWindow();
 
     bool isBlankNewDeck() const;
     CardInfoPtr currentCardInfo() const;

--- a/cockatrice/src/client/tabs/tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/tab_deck_editor.h
@@ -100,6 +100,18 @@ private slots:
     void showSearchSyntaxHelp();
 
 private:
+    /**
+     * @brief Which tab to open the new deck in
+     */
+    enum DeckOpenLocation
+    {
+        CANCELLED,
+        SAME_TAB,
+        NEW_TAB
+    };
+
+    DeckOpenLocation confirmOpen(const bool openInSameTabIfBlank = true);
+
     bool isBlankNewDeck() const;
     CardInfoPtr currentCardInfo() const;
     void addCardHelper(QString zoneName);


### PR DESCRIPTION
## Related Ticket(s)
- Followup to #5143

## Short roundup of the initial problem
> I'd prefer that as a default it could be a third option when it prompts you with the "the decklist has been modified" dialog.

## What will change with this Pull Request?
<img width="324" alt="Screenshot 2024-11-20 at 1 38 22 AM" src="https://github.com/user-attachments/assets/fc94e3b0-db79-4541-8417-5793856a2675">

When the `Always open deck in new tab` setting is disabled, when opening a deck while the current deck is modified, the confirmation dialogue has an additional `Open in new tab` button.

- refactored to have a `confirmOpen` method as well as a `confirmClose` method
  - moved the settings checking logic to inside of `confirmOpen`
  - `confirmClose` is now only used strictly for closing a deck editor tab without trying to open a new deck
  - `actNewDeck`, `actLoadDeck`, and `actLoadDeckFromClipboard` now all use `confirmOpen`
- Added a "Open in new tab" button to `confirmOpen`'s window that does what you expect it to do.
  - The `confirmOpen` window is otherwise exactly the same as before
