### PR TITLE
make phase highlighting transitions look more natural when rewinding in replays

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -648,8 +648,7 @@ void TabGame::replayRewind()
     messageLog->clearChat();
 
     // reset phase markers
-    currentPhase = -1;
-    phasesToolbar->reset();
+    setActivePhase(-1);
 }
 
 void TabGame::incrementGameTime()

--- a/cockatrice/src/client/ui/phases_toolbar.cpp
+++ b/cockatrice/src/client/ui/phases_toolbar.cpp
@@ -86,23 +86,6 @@ void PhaseButton::updateAnimation()
     update();
 }
 
-/**
- * @brief Immediately resets the button to the inactive state, without going through the animation.
- */
-void PhaseButton::reset()
-{
-    activeAnimationTimer->stop();
-    active = false;
-
-    if (highlightable) {
-        activeAnimationCounter = 0;
-    } else {
-        activeAnimationCounter = 9;
-    }
-
-    update();
-}
-
 void PhaseButton::mousePressEvent(QGraphicsSceneMouseEvent * /*event*/)
 {
     emit clicked();
@@ -266,16 +249,6 @@ void PhasesToolbar::phaseButtonClicked()
     cmd.set_phase(static_cast<google::protobuf::uint32>(buttonList.indexOf(button)));
 
     emit sendGameCommand(cmd, -1);
-}
-
-/**
- * @brief Immediately resets the toolbar to its initial state, with all phases inactive.
- */
-void PhasesToolbar::reset()
-{
-    for (auto &i : buttonList) {
-        i->reset();
-    }
 }
 
 void PhasesToolbar::actNextTurn()

--- a/cockatrice/src/client/ui/phases_toolbar.h
+++ b/cockatrice/src/client/ui/phases_toolbar.h
@@ -45,7 +45,6 @@ public:
     {
         return active;
     }
-    void reset();
     void triggerDoubleClickAction();
 signals:
     void clicked();
@@ -86,7 +85,6 @@ public:
 public slots:
     void setActivePhase(int phase);
     void triggerPhaseAction(int phase);
-    void reset();
 private slots:
     void phaseButtonClicked();
     void actNextTurn();


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5161

## Short roundup of the initial problem
https://github.com/user-attachments/assets/abc56989-aa33-4dd3-bcbc-fba3fc5567b7

Turns out all the code for force-resetting the phase highlighting timer in #5161 was completely unnecessary. Fixing the conditional logic for updating the`activeAnimationCounter` was all that was required to fix the bug.

Removing the force-resetting code also means the highlighted phase doesn't blink every time we rewind.

## What will change with this Pull Request?
https://github.com/user-attachments/assets/1c0a1450-0353-4ee3-83af-29fdbb939e4b

- When rewinding from a replay, `tab_game` just calls `setActivePhase(-1)` instead of calling the `reset` function on the `PhaseToolbar` that forcibly resets the phase while skipping the fades.
  - Removed those `reset` methods in `phases_toolbar` since they're no longer used
