### PR TITLE
Cache redirects properly by implementing our own QSettings cache for urls.

### DIFF
--- a/cockatrice/src/client/ui/picture_loader.cpp
+++ b/cockatrice/src/client/ui/picture_loader.cpp
@@ -136,6 +136,8 @@ PictureLoaderWorker::PictureLoaderWorker()
 #endif
     auto cache = new QNetworkDiskCache(this);
     cache->setCacheDirectory(SettingsCache::instance().getNetworkCachePath());
+    cache->setMaximumCacheSize(1024L * 1024L *
+                               static_cast<qint64>(SettingsCache::instance().getNetworkCacheSizeInMB()));
     // Note: the settings is in MB, but QNetworkDiskCache uses bytes
     connect(&SettingsCache::instance(), &SettingsCache::networkCacheSizeChanged, cache,
             [cache](int newSizeInMB) { cache->setMaximumCacheSize(1024L * 1024L * static_cast<qint64>(newSizeInMB)); });

--- a/cockatrice/src/client/ui/picture_loader.cpp
+++ b/cockatrice/src/client/ui/picture_loader.cpp
@@ -544,7 +544,7 @@ void PictureLoaderWorker::cleanStaleEntries()
 
     auto it = redirectCache.begin();
     while (it != redirectCache.end()) {
-        if (it.value().second.addDays(CacheTTLInDays) < now) {
+        if (it.value().second.addDays(SettingsCache::instance().getRedirectCacheTtl()) < now) {
             it = redirectCache.erase(it); // Remove stale entry
         } else {
             ++it;

--- a/cockatrice/src/client/ui/picture_loader.cpp
+++ b/cockatrice/src/client/ui/picture_loader.cpp
@@ -1,17 +1,14 @@
 #include "picture_loader.h"
 
-#include "../../game/cards/card_database.h"
 #include "../../game/cards/card_database_manager.h"
 #include "../../settings/cache_settings.h"
-#include "theme_manager.h"
 
 #include <QApplication>
 #include <QBuffer>
 #include <QCryptographicHash>
 #include <QDebug>
-#include <QDir>
 #include <QDirIterator>
-#include <QFile>
+#include <QFileInfo>
 #include <QImageReader>
 #include <QMovie>
 #include <QNetworkAccessManager>
@@ -23,7 +20,6 @@
 #include <QRegularExpression>
 #include <QScreen>
 #include <QSet>
-#include <QSvgRenderer>
 #include <QThread>
 #include <QUrl>
 #include <algorithm>
@@ -505,7 +501,7 @@ QUrl PictureLoaderWorker::getCachedRedirect(const QUrl &originalUrl) const
     if (redirectCache.contains(originalUrl)) {
         return redirectCache[originalUrl].first;
     }
-    return QUrl();
+    return {};
 }
 
 void PictureLoaderWorker::loadRedirectCache()
@@ -513,7 +509,7 @@ void PictureLoaderWorker::loadRedirectCache()
     QSettings settings(cacheFilePath, QSettings::IniFormat);
 
     redirectCache.clear();
-    int size = settings.beginReadArray("redirects");
+    int size = settings.beginReadArray(REDIRECT_HEADER_NAME);
     for (int i = 0; i < size; ++i) {
         settings.setArrayIndex(i);
         QUrl originalUrl = settings.value(REDIRECT_ORIGINAL_URL).toUrl();
@@ -531,7 +527,7 @@ void PictureLoaderWorker::saveRedirectCache() const
 {
     QSettings settings(cacheFilePath, QSettings::IniFormat);
 
-    settings.beginWriteArray("redirects", redirectCache.size());
+    settings.beginWriteArray(REDIRECT_HEADER_NAME, static_cast<int>(redirectCache.size()));
     int index = 0;
     for (auto it = redirectCache.cbegin(); it != redirectCache.cend(); ++it) {
         settings.setArrayIndex(index++);

--- a/cockatrice/src/client/ui/picture_loader.cpp
+++ b/cockatrice/src/client/ui/picture_loader.cpp
@@ -147,7 +147,7 @@ PictureLoaderWorker::PictureLoaderWorker()
     networkManager->setRedirectPolicy(QNetworkRequest::ManualRedirectPolicy);
     connect(networkManager, SIGNAL(finished(QNetworkReply *)), this, SLOT(picDownloadFinished(QNetworkReply *)));
 
-    cacheFilePath = SettingsCache::instance().getRedirectCachePath() + "cacheSettings.ini";
+    cacheFilePath = SettingsCache::instance().getRedirectCachePath() + REDIRECT_CACHE_FILENAME;
     loadRedirectCache();
     cleanStaleEntries();
 
@@ -512,9 +512,9 @@ void PictureLoaderWorker::loadRedirectCache()
     int size = settings.beginReadArray("redirects");
     for (int i = 0; i < size; ++i) {
         settings.setArrayIndex(i);
-        QUrl originalUrl = settings.value("original").toUrl();
-        QUrl redirectUrl = settings.value("redirect").toUrl();
-        QDateTime timestamp = settings.value("timestamp").toDateTime();
+        QUrl originalUrl = settings.value(REDIRECT_ORIGINAL_URL).toUrl();
+        QUrl redirectUrl = settings.value(REDIRECT_URL).toUrl();
+        QDateTime timestamp = settings.value(REDIRECT_TIMESTAMP).toDateTime();
 
         if (originalUrl.isValid() && redirectUrl.isValid()) {
             redirectCache[originalUrl] = qMakePair(redirectUrl, timestamp);
@@ -532,9 +532,9 @@ void PictureLoaderWorker::saveRedirectCache() const
     int index = 0;
     for (auto it = redirectCache.cbegin(); it != redirectCache.cend(); ++it) {
         settings.setArrayIndex(index++);
-        settings.setValue("original", it.key());
-        settings.setValue("redirect", it.value().first);
-        settings.setValue("timestamp", it.value().second);
+        settings.setValue(REDIRECT_ORIGINAL_URL, it.key());
+        settings.setValue(REDIRECT_URL, it.value().first);
+        settings.setValue(REDIRECT_TIMESTAMP, it.value().second);
     }
     settings.endArray();
 }

--- a/cockatrice/src/client/ui/picture_loader.cpp
+++ b/cockatrice/src/client/ui/picture_loader.cpp
@@ -459,7 +459,9 @@ QNetworkReply *PictureLoaderWorker::makeRequest(const QUrl &url)
     // Check if the redirect is cached
     QUrl cachedRedirect = getCachedRedirect(url);
     if (!cachedRedirect.isEmpty()) {
-        qDebug() << "Using cached redirect for" << url << "to" << cachedRedirect;
+        qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
+                           << " set: " << cardBeingDownloaded.getSetName() << "]: Using cached redirect for "
+                           << url.toDisplayString() << " to " << cachedRedirect.toDisplayString();
         return makeRequest(cachedRedirect); // Use the cached redirect
     }
 
@@ -481,7 +483,9 @@ QNetworkReply *PictureLoaderWorker::makeRequest(const QUrl &url)
             }
 
             cacheRedirect(url, redirectUrl);
-            qDebug() << "Caching redirect from" << url << "to" << redirectUrl;
+            qDebug().nospace() << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
+                               << " set: " << cardBeingDownloaded.getSetName() << "]: Caching redirect from "
+                               << url.toDisplayString() << " to " << redirectUrl.toDisplayString();
         }
 
         reply->deleteLater();
@@ -525,7 +529,6 @@ void PictureLoaderWorker::loadRedirectCache()
 
 void PictureLoaderWorker::saveRedirectCache() const
 {
-    qDebug() << "Saving redirect cache";
     QSettings settings(cacheFilePath, QSettings::IniFormat);
 
     settings.beginWriteArray("redirects", redirectCache.size());

--- a/cockatrice/src/client/ui/picture_loader.h
+++ b/cockatrice/src/client/ui/picture_loader.h
@@ -11,6 +11,7 @@ class QNetworkAccessManager;
 class QNetworkReply;
 class QThread;
 
+#define REDIRECT_HEADER_NAME "redirects"
 #define REDIRECT_ORIGINAL_URL "original"
 #define REDIRECT_URL "redirect"
 #define REDIRECT_TIMESTAMP "timestamp"
@@ -90,7 +91,7 @@ private:
     QNetworkAccessManager *networkManager;
     QHash<QUrl, QPair<QUrl, QDateTime>> redirectCache; // Stores redirect and timestamp
     QString cacheFilePath;                             // Path to persistent storage
-    static constexpr int CacheTTLInDays = 30;
+    static constexpr int CacheTTLInDays = 30;          // TODO: Make user configurable
     QList<PictureToLoad> cardsToDownload;
     PictureToLoad cardBeingLoaded;
     PictureToLoad cardBeingDownloaded;

--- a/cockatrice/src/client/ui/picture_loader.h
+++ b/cockatrice/src/client/ui/picture_loader.h
@@ -11,6 +11,11 @@ class QNetworkAccessManager;
 class QNetworkReply;
 class QThread;
 
+#define REDIRECT_ORIGINAL_URL "original"
+#define REDIRECT_URL "redirect"
+#define REDIRECT_TIMESTAMP "timestamp"
+#define REDIRECT_CACHE_FILENAME "cache.ini"
+
 class PictureToLoad
 {
 private:
@@ -85,7 +90,7 @@ private:
     QNetworkAccessManager *networkManager;
     QHash<QUrl, QPair<QUrl, QDateTime>> redirectCache; // Stores redirect and timestamp
     QString cacheFilePath;                             // Path to persistent storage
-    int CacheTTLInDays = 30;
+    static constexpr int CacheTTLInDays = 30;
     QList<PictureToLoad> cardsToDownload;
     PictureToLoad cardBeingLoaded;
     PictureToLoad cardBeingDownloaded;

--- a/cockatrice/src/client/ui/picture_loader.h
+++ b/cockatrice/src/client/ui/picture_loader.h
@@ -83,6 +83,9 @@ private:
     QList<PictureToLoad> loadQueue;
     QMutex mutex;
     QNetworkAccessManager *networkManager;
+    QHash<QUrl, QPair<QUrl, QDateTime>> redirectCache; // Stores redirect and timestamp
+    QString cacheFilePath;                             // Path to persistent storage
+    int CacheTTLInDays = 30;
     QList<PictureToLoad> cardsToDownload;
     PictureToLoad cardBeingLoaded;
     PictureToLoad cardBeingDownloaded;
@@ -91,6 +94,12 @@ private:
     bool cardImageExistsOnDisk(QString &setName, QString &correctedCardName);
     bool imageIsBlackListed(const QByteArray &);
     QNetworkReply *makeRequest(const QUrl &url);
+    void cacheRedirect(const QUrl &originalUrl, const QUrl &redirectUrl);
+    QUrl getCachedRedirect(const QUrl &originalUrl) const;
+    void loadRedirectCache();
+    void saveRedirectCache() const;
+    void cleanStaleEntries();
+
 private slots:
     void picDownloadFinished(QNetworkReply *reply);
     void picDownloadFailed();

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -629,10 +629,21 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     networkCacheEdit.setValue(SettingsCache::instance().getNetworkCacheSizeInMB());
     networkCacheEdit.setSuffix(" MB");
 
+    networkRedirectCacheTtlEdit.setMinimum(NETWORK_REDIRECT_CACHE_TTL_MIN);
+    networkRedirectCacheTtlEdit.setMaximum(NETWORK_REDIRECT_CACHE_TTL_MAX);
+    networkRedirectCacheTtlEdit.setSingleStep(1);
+    networkRedirectCacheTtlEdit.setValue(SettingsCache::instance().getRedirectCacheTtl());
+    networkRedirectCacheTtlEdit.setSuffix(" Days");
+
     auto networkCacheLayout = new QHBoxLayout;
     networkCacheLayout->addStretch();
     networkCacheLayout->addWidget(&networkCacheLabel);
     networkCacheLayout->addWidget(&networkCacheEdit);
+
+    auto networkRedirectCacheLayout = new QHBoxLayout;
+    networkRedirectCacheLayout->addStretch();
+    networkRedirectCacheLayout->addWidget(&networkRedirectCacheTtlLabel);
+    networkRedirectCacheLayout->addWidget(&networkRedirectCacheTtlEdit);
 
     auto pixmapCacheLayout = new QHBoxLayout;
     pixmapCacheLayout->addStretch();
@@ -644,9 +655,10 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     lpGeneralGrid->addWidget(&resetDownloadURLs, 0, 1);
     lpGeneralGrid->addLayout(messageListLayout, 1, 0, 1, 2);
     lpGeneralGrid->addLayout(networkCacheLayout, 2, 0, 1, 2);
-    lpGeneralGrid->addLayout(pixmapCacheLayout, 3, 0, 1, 2);
-    lpGeneralGrid->addWidget(&urlLinkLabel, 4, 0);
-    lpGeneralGrid->addWidget(&clearDownloadedPicsButton, 4, 1);
+    lpGeneralGrid->addLayout(networkRedirectCacheLayout, 3, 0, 1, 2);
+    lpGeneralGrid->addLayout(pixmapCacheLayout, 4, 0, 1, 2);
+    lpGeneralGrid->addWidget(&urlLinkLabel, 5, 0);
+    lpGeneralGrid->addWidget(&clearDownloadedPicsButton, 5, 1);
 
     // Spoiler Layout
     lpSpoilerGrid->addWidget(&mcDownloadSpoilersCheckBox, 0, 0);
@@ -662,6 +674,8 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
             SLOT(setDownloadSpoilerStatus(bool)));
     connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), this, SLOT(setSpoilersEnabled(bool)));
     connect(&pixmapCacheEdit, SIGNAL(valueChanged(int)), &SettingsCache::instance(), SLOT(setPixmapCacheSize(int)));
+    connect(&networkRedirectCacheTtlEdit, SIGNAL(valueChanged(int)), &SettingsCache::instance(),
+            SLOT(setNetworkRedirectCacheTtl(int)));
     connect(&networkCacheEdit, SIGNAL(valueChanged(int)), &SettingsCache::instance(),
             SLOT(setNetworkCacheSizeInMB(int)));
 
@@ -846,6 +860,8 @@ void DeckEditorSettingsPage::retranslateUi()
     resetDownloadURLs.setText(tr("Reset Download URLs"));
     networkCacheLabel.setText(tr("Network Cache Size:"));
     networkCacheEdit.setToolTip(tr("On-disk cache for downloaded pictures"));
+    networkRedirectCacheTtlLabel.setText(tr("Redirect cache expiration time in days"));
+    networkRedirectCacheTtlEdit.setToolTip(tr("How long cached redirects for urls are valid for."));
     pixmapCacheLabel.setText(tr("Picture cache size:"));
     pixmapCacheEdit.setToolTip(tr("In-memory cache for pictures not currently on screen"));
 }

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -669,15 +669,15 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     lpSpoilerGrid->addWidget(updateNowButton, 2, 1);
     lpSpoilerGrid->addWidget(&infoOnSpoilersLabel, 3, 0, 1, 3, Qt::AlignTop);
 
-    // On a change to the check box, hide/unhide the other fields
+    // On a change to the checkbox, hide/un-hide the other fields
     connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), &SettingsCache::instance(),
             SLOT(setDownloadSpoilerStatus(bool)));
     connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), this, SLOT(setSpoilersEnabled(bool)));
     connect(&pixmapCacheEdit, SIGNAL(valueChanged(int)), &SettingsCache::instance(), SLOT(setPixmapCacheSize(int)));
-    connect(&networkRedirectCacheTtlEdit, SIGNAL(valueChanged(int)), &SettingsCache::instance(),
-            SLOT(setNetworkRedirectCacheTtl(int)));
     connect(&networkCacheEdit, SIGNAL(valueChanged(int)), &SettingsCache::instance(),
             SLOT(setNetworkCacheSizeInMB(int)));
+    connect(&networkRedirectCacheTtlEdit, SIGNAL(valueChanged(int)), &SettingsCache::instance(),
+            SLOT(setNetworkRedirectCacheTtl(int)));
 
     mpGeneralGroupBox = new QGroupBox;
     mpGeneralGroupBox->setLayout(lpGeneralGrid);

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -844,7 +844,7 @@ void DeckEditorSettingsPage::retranslateUi()
     urlLinkLabel.setText(QString("<a href='%1'>%2</a>").arg(WIKI_CUSTOM_PIC_URL).arg(tr("How to add a custom URL")));
     clearDownloadedPicsButton.setText(tr("Delete Downloaded Images"));
     resetDownloadURLs.setText(tr("Reset Download URLs"));
-    networkCacheLabel.setText(tr("Downloaded images directory size:"));
+    networkCacheLabel.setText(tr("Network Cache Size:"));
     networkCacheEdit.setToolTip(tr("On-disk cache for downloaded pictures"));
     pixmapCacheLabel.setText(tr("Picture cache size:"));
     pixmapCacheEdit.setToolTip(tr("In-memory cache for pictures not currently on screen"));

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -633,7 +633,7 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     networkRedirectCacheTtlEdit.setMaximum(NETWORK_REDIRECT_CACHE_TTL_MAX);
     networkRedirectCacheTtlEdit.setSingleStep(1);
     networkRedirectCacheTtlEdit.setValue(SettingsCache::instance().getRedirectCacheTtl());
-    networkRedirectCacheTtlEdit.setSuffix(" Days");
+    networkRedirectCacheTtlEdit.setSuffix(" " + tr("Day(s)"));
 
     auto networkCacheLayout = new QHBoxLayout;
     networkCacheLayout->addStretch();

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -655,8 +655,8 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     lpGeneralGrid->addWidget(&resetDownloadURLs, 0, 1);
     lpGeneralGrid->addLayout(messageListLayout, 1, 0, 1, 2);
     lpGeneralGrid->addLayout(networkCacheLayout, 2, 0, 1, 2);
-    lpGeneralGrid->addLayout(networkRedirectCacheLayout, 3, 0, 1, 2);
-    lpGeneralGrid->addLayout(pixmapCacheLayout, 4, 0, 1, 2);
+    lpGeneralGrid->addLayout(pixmapCacheLayout, 3, 0, 1, 2);
+    lpGeneralGrid->addLayout(networkRedirectCacheLayout, 4, 0, 1, 2);
     lpGeneralGrid->addWidget(&urlLinkLabel, 5, 0);
     lpGeneralGrid->addWidget(&clearDownloadedPicsButton, 5, 1);
 
@@ -860,9 +860,9 @@ void DeckEditorSettingsPage::retranslateUi()
     resetDownloadURLs.setText(tr("Reset Download URLs"));
     networkCacheLabel.setText(tr("Network Cache Size:"));
     networkCacheEdit.setToolTip(tr("On-disk cache for downloaded pictures"));
-    networkRedirectCacheTtlLabel.setText(tr("Redirect cache expiration time in days"));
+    networkRedirectCacheTtlLabel.setText(tr("Redirect Cache TTL:"));
     networkRedirectCacheTtlEdit.setToolTip(tr("How long cached redirects for urls are valid for."));
-    pixmapCacheLabel.setText(tr("Picture cache size:"));
+    pixmapCacheLabel.setText(tr("Picture Cache Size:"));
     pixmapCacheEdit.setToolTip(tr("In-memory cache for pictures not currently on screen"));
 }
 

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -174,6 +174,8 @@ private:
     QPushButton *updateNowButton;
     QLabel networkCacheLabel;
     QSpinBox networkCacheEdit;
+    QLabel networkRedirectCacheTtlLabel;
+    QSpinBox networkRedirectCacheTtlEdit;
     QSpinBox pixmapCacheEdit;
     QLabel pixmapCacheLabel;
 };

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -1030,7 +1030,7 @@ void SettingsCache::loadPaths()
     replaysPath = getSafeConfigPath("paths/replays", dataPath + "/replays/");
     themesPath = getSafeConfigPath("paths/themes", dataPath + "/themes/");
     picsPath = getSafeConfigPath("paths/pics", dataPath + "/pics/");
-    redirectCachePath = getSafeConfigPath("paths/redirects", dataPath + "/pics/redirects/");
+    redirectCachePath = getSafeConfigPath("paths/redirects", getCachePath() + "/redirects/");
     // this has never been exposed as an user-configurable setting
     if (picsPath.endsWith("/")) {
         customPicsPath = getSafeConfigPath("paths/custompics", picsPath + "CUSTOM/");

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -221,6 +221,7 @@ SettingsCache::SettingsCache()
         pixmapCacheSize = PIXMAPCACHE_SIZE_DEFAULT;
 
     networkCacheSize = settings->value("personal/networkCacheSize", NETWORK_CACHE_SIZE_DEFAULT).toInt();
+    redirectCacheTtl = settings->value("personal/redirectCacheTtl", NETWORK_REDIRECT_CACHE_TTL_DEFAULT).toInt();
 
     picDownload = settings->value("personal/picturedownload", true).toBool();
 
@@ -655,6 +656,13 @@ void SettingsCache::setNetworkCacheSizeInMB(const int _networkCacheSize)
     networkCacheSize = _networkCacheSize;
     settings->setValue("personal/networkCacheSize", networkCacheSize);
     emit networkCacheSizeChanged(networkCacheSize);
+}
+
+void SettingsCache::setRedirectCacheTtl(const int _redirectCacheTtl)
+{
+    redirectCacheTtl = _redirectCacheTtl;
+    settings->setValue("personal/redirectCacheSize", redirectCacheTtl);
+    emit redirectCacheTtlChanged(redirectCacheTtl);
 }
 
 void SettingsCache::setClientID(const QString &_clientID)

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -658,7 +658,7 @@ void SettingsCache::setNetworkCacheSizeInMB(const int _networkCacheSize)
     emit networkCacheSizeChanged(networkCacheSize);
 }
 
-void SettingsCache::setRedirectCacheTtl(const int _redirectCacheTtl)
+void SettingsCache::setNetworkRedirectCacheTtl(const int _redirectCacheTtl)
 {
     redirectCacheTtl = _redirectCacheTtl;
     settings->setValue("personal/redirectCacheSize", redirectCacheTtl);

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -1030,6 +1030,7 @@ void SettingsCache::loadPaths()
     replaysPath = getSafeConfigPath("paths/replays", dataPath + "/replays/");
     themesPath = getSafeConfigPath("paths/themes", dataPath + "/themes/");
     picsPath = getSafeConfigPath("paths/pics", dataPath + "/pics/");
+    redirectCachePath = getSafeConfigPath("paths/redirects", dataPath + "/pics/redirects/");
     // this has never been exposed as an user-configurable setting
     if (picsPath.endsWith("/")) {
         customPicsPath = getSafeConfigPath("paths/custompics", picsPath + "CUSTOM/");

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -16,10 +16,10 @@
 
 class ReleaseChannel;
 
-// size should be a multiple of 64
-#define PIXMAPCACHE_SIZE_DEFAULT 2047
+// In MB (Increments of 64)
+#define PIXMAPCACHE_SIZE_DEFAULT 2048
 #define PIXMAPCACHE_SIZE_MIN 64
-#define PIXMAPCACHE_SIZE_MAX 2047
+#define PIXMAPCACHE_SIZE_MAX 4096
 
 // In MB
 constexpr int NETWORK_CACHE_SIZE_DEFAULT = 1024 * 4; // 4 GB

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -572,7 +572,7 @@ public slots:
     void setIgnoreUnregisteredUserMessages(QT_STATE_CHANGED_T _ignoreUnregisteredUserMessages);
     void setPixmapCacheSize(const int _pixmapCacheSize);
     void setNetworkCacheSizeInMB(const int _networkCacheSize);
-    void setRedirectCacheTtl(const int _redirectCacheTtl);
+    void setNetworkRedirectCacheTtl(const int _redirectCacheTtl);
     void setCardScaling(const QT_STATE_CHANGED_T _scaleCards);
     void setStackCardOverlapPercent(const int _verticalCardOverlapPercent);
     void setShowMessagePopups(const QT_STATE_CHANGED_T _showMessagePopups);

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -26,6 +26,11 @@ constexpr int NETWORK_CACHE_SIZE_DEFAULT = 1024 * 4; // 4 GB
 constexpr int NETWORK_CACHE_SIZE_MIN = 1;            // 1 MB
 constexpr int NETWORK_CACHE_SIZE_MAX = 1024 * 1024;  // 1 TB
 
+// In Days
+#define NETWORK_REDIRECT_CACHE_TTL_DEFAULT 30
+#define NETWORK_REDIRECT_CACHE_TTL_MIN 1
+#define NETWORK_REDIRECT_CACHE_TTL_MAX 90
+
 #define DEFAULT_LANG_NAME "English"
 #define CLIENT_INFO_NOT_SET "notset"
 
@@ -53,6 +58,7 @@ signals:
     void ignoreUnregisteredUserMessagesChanged();
     void pixmapCacheSizeChanged(int newSizeInMBs);
     void networkCacheSizeChanged(int newSizeInMBs);
+    void redirectCacheTtlChanged(int newTtl);
     void masterVolumeChanged(int value);
     void chatMentionCompleterChanged();
     void downloadSpoilerTimeIndexChanged();
@@ -116,6 +122,7 @@ private:
     bool useTearOffMenus;
     int pixmapCacheSize;
     int networkCacheSize;
+    int redirectCacheTtl;
     bool scaleCards;
     int verticalCardOverlapPercent;
     bool showMessagePopups;
@@ -360,6 +367,10 @@ public:
     {
         return networkCacheSize;
     }
+    int getRedirectCacheTtl() const
+    {
+        return redirectCacheTtl;
+    }
     bool getScaleCards() const
     {
         return scaleCards;
@@ -561,6 +572,7 @@ public slots:
     void setIgnoreUnregisteredUserMessages(QT_STATE_CHANGED_T _ignoreUnregisteredUserMessages);
     void setPixmapCacheSize(const int _pixmapCacheSize);
     void setNetworkCacheSizeInMB(const int _networkCacheSize);
+    void setRedirectCacheTtl(const int _redirectCacheTtl);
     void setCardScaling(const QT_STATE_CHANGED_T _scaleCards);
     void setStackCardOverlapPercent(const int _verticalCardOverlapPercent);
     void setShowMessagePopups(const QT_STATE_CHANGED_T _showMessagePopups);

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -73,8 +73,8 @@ private:
     QByteArray tokenDialogGeometry;
     QByteArray setsDialogGeometry;
     QString lang;
-    QString deckPath, replaysPath, picsPath, redirectCachePath, customPicsPath, cardDatabasePath, customCardDatabasePath, themesPath,
-        spoilerDatabasePath, tokenDatabasePath, themeName;
+    QString deckPath, replaysPath, picsPath, redirectCachePath, customPicsPath, cardDatabasePath,
+        customCardDatabasePath, themesPath, spoilerDatabasePath, tokenDatabasePath, themeName;
     bool notifyAboutUpdates;
     bool notifyAboutNewVersion;
     bool showTipsOnStartup;

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -73,7 +73,7 @@ private:
     QByteArray tokenDialogGeometry;
     QByteArray setsDialogGeometry;
     QString lang;
-    QString deckPath, replaysPath, picsPath, customPicsPath, cardDatabasePath, customCardDatabasePath, themesPath,
+    QString deckPath, replaysPath, picsPath, redirectCachePath, customPicsPath, cardDatabasePath, customCardDatabasePath, themesPath,
         spoilerDatabasePath, tokenDatabasePath, themeName;
     bool notifyAboutUpdates;
     bool notifyAboutNewVersion;
@@ -182,6 +182,10 @@ public:
     QString getPicsPath() const
     {
         return picsPath;
+    }
+    QString getRedirectCachePath() const
+    {
+        return redirectCachePath;
     }
     QString getCustomPicsPath() const
     {

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -220,6 +220,9 @@ void SettingsCache::setPixmapCacheSize(const int /* _pixmapCacheSize */)
 void SettingsCache::setNetworkCacheSizeInMB(const int /* _networkCacheSize */)
 {
 }
+void SettingsCache::setNetworkRedirectCacheTtl(const int /* _redirectCacheTtl */)
+{
+}
 void SettingsCache::setClientID(const QString & /* _clientID */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -224,6 +224,9 @@ void SettingsCache::setPixmapCacheSize(const int /* _pixmapCacheSize */)
 void SettingsCache::setNetworkCacheSizeInMB(const int /* _networkCacheSize */)
 {
 }
+void SettingsCache::setNetworkRedirectCacheTtl(const int /* _redirectCacheTtl */)
+{
+}
 void SettingsCache::setClientID(const QString & /* _clientID */)
 {
 }


### PR DESCRIPTION
## Related Ticket(s)
-  Fixes #4989

## Short roundup of the initial problem
We cache the final url of a request but if we get redirected, we don't cache the fact that the original url has lead us to a redirect. This leads to us having to issue a network request for every original url, only to fetch a redirect, realize that we've cached it, and then load the cached url. This change introduces our own cache where we store original urls and their redirection urls, so we can skip the network request and load straight from cache both times. This results in a significant speedup for loading cached pictures.

## What will change with this Pull Request?
- PictureLoaderWorker gains a new redirect cache and cache related functions.
