### PR TITLE
Bump macos14 XCode to 15.4

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -277,10 +277,6 @@ jobs:
           asset_name: ${{steps.build.outputs.name}}
         run: gh release upload "$tag_name" "$asset_path#$asset_name"
 
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
-
   build-windows:
     strategy:
       fail-fast: false

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -277,6 +277,10 @@ jobs:
           asset_name: ${{steps.build.outputs.name}}
         run: gh release upload "$tag_name" "$asset_path#$asset_name"
 
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+
   build-windows:
     strategy:
       fail-fast: false

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -212,7 +212,7 @@ jobs:
           - target: 14
             soc: Apple
             os: macos-14
-            xcode: "14.3.1"
+            xcode: "15.4"
             type: Release
             core_count: 3
             make_package: 1
@@ -220,7 +220,7 @@ jobs:
           - target: 14
             soc: Apple
             os: macos-14
-            xcode: "14.3.1"
+            xcode: "15.4"
             type: Debug
             core_count: 3
 

--- a/cockatrice/src/client/game_logic/abstract_client.cpp
+++ b/cockatrice/src/client/game_logic/abstract_client.cpp
@@ -49,6 +49,8 @@ AbstractClient::AbstractClient(QObject *parent)
     qRegisterMetaType<QList<QString>>("missingFeatures");
     qRegisterMetaType<PendingCommand *>("pendingCommand");
 
+
+    
     FeatureSet features;
     features.initalizeFeatureList(clientFeatures);
 

--- a/cockatrice/src/client/game_logic/abstract_client.cpp
+++ b/cockatrice/src/client/game_logic/abstract_client.cpp
@@ -50,7 +50,7 @@ AbstractClient::AbstractClient(QObject *parent)
     qRegisterMetaType<PendingCommand *>("pendingCommand");
 
 
-    
+
     FeatureSet features;
     features.initalizeFeatureList(clientFeatures);
 

--- a/cockatrice/src/client/game_logic/abstract_client.cpp
+++ b/cockatrice/src/client/game_logic/abstract_client.cpp
@@ -49,8 +49,6 @@ AbstractClient::AbstractClient(QObject *parent)
     qRegisterMetaType<QList<QString>>("missingFeatures");
     qRegisterMetaType<PendingCommand *>("pendingCommand");
 
-
-
     FeatureSet features;
     features.initalizeFeatureList(clientFeatures);
 


### PR DESCRIPTION
macos-14 XCode 14.3.1 was [removed](https://github.com/actions/runner-images/commit/d43ea5c42a151c970bb2b5550596e94508bc83c9) last week. We'll need to bump our GHA runner version.