### PR TITLE
Release template: macOS version fix + more

### DIFF
--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -4,13 +4,13 @@
 git push -d origin --REPLACE-WITH-BETA-LIST--
  -->
 
-<!-- This list of binaries should be updated every time the ci is changed to
+<!-- This list of binaries should be updated every time the CI is changed to
 include different targets -->
 <pre>
 <b>Pre-compiled binaries we serve:</b>
  - <kbd>Windows 10+</kbd>
  - <kbd>Windows 7+</kbd>
- - <kbd>macOS 13+</kbd> ("Ventura") / Apple M
+ - <kbd>macOS 14+</kbd> ("Sonoma") / Apple M
  - <kbd>macOS 13+</kbd> ("Ventura") / Intel
  - <kbd>Ubuntu 24.04 LTS</kbd> ("Noble Numbat")
  - <kbd>Ubuntu 22.04 LTS</kbd> ("Jammy Jellyfish")
@@ -19,8 +19,9 @@ include different targets -->
  - <kbd>Debian 11</kbd> ("Bullseye")
  - <kbd>Fedora 41</kbd>
  - <kbd>Fedora 40</kbd>
-<kbd>We are also packaged in Arch Linux's official "extra" repository, courtesy of @FFY00</kbd></i>
-<kbd>General Linux support is available via a flatpak package (Flathub)</kbd></i>
+ 
+<i>We are also packaged in <kbd>Arch Linux</kbd>'s official "extra" repository, courtesy of @FFY00</i>
+<i>General Linux support is available via a <kbd>flatpak</kbd> package (Flathub)</i>
 </pre>
 
 
@@ -28,22 +29,24 @@ include different targets -->
 
 We're pleased to announce the newest official release: <kbd>--REPLACE-WITH-RELEASE-TITLE--</kbd>
 
-We hope you enjoy the changes made and we have listed all changes, with their corresponding tickets, since the last version of Cockatrice was released for your convenience.
+We hope you enjoy the changes made! All improvements with their corresponding tickets since the last version of Cockatrice are listed in the changelog below.
 
-If you ever encounter a bug, have a suggestion or idea, or feel a need for a developer to look into something, please feel free to [open a ticket](https://github.com/Cockatrice/Cockatrice/issues). ([How to create a GitHub Ticket for Cockatrice](https://github.com/Cockatrice/Cockatrice/wiki/How-to-Create-a-GitHub-Ticket-Regarding-Cockatrice))
+If you ever encounter a bug, have a suggestion or idea, or feel a need for a developer to look into something, please feel free to [open a ticket](https://github.com/Cockatrice/Cockatrice/issues). ([How to create a Ticket for Cockatrice](https://github.com/Cockatrice/Cockatrice/wiki/How-to-Create-a-GitHub-Ticket-Regarding-Cockatrice))
 
-For any information relating to Cockatrice, please take a look at our official site: **https://cockatrice.github.io**
+For basic information related to the app and getting started, please take a look at our official site: **https://cockatrice.github.io**
 
-If you'd like to help contribute to Cockatrice in any way, check out our [README](https://github.com/Cockatrice/Cockatrice#get-involved-). We're always available to answer questions you may have on how the program works and how you can provide a meaningful contribution.
+If you'd like to help and contribute to Cockatrice in any way, check out our [README](https://github.com/Cockatrice/Cockatrice#get-involved-).  
+We're always available to answer questions you may have on how the program works and how you can provide a meaningful contribution.
 
 
 ## Upgrading Cockatrice
 <!-- this optional section puts a warning banner for problems with updating
-> ⚠️ **With this release, we no longer provide a ready-to-install binary for:**
+> [!IMPORTANT]  
+> **With this release, we no longer provide a ready-to-install binary for:**  
 > --DEPRECATED-OS-HERE--
  -->
 
-- Run the internal software updater: <kbd>Help → Check for Client Updates</kbd>
+Run the internal software updater: <kbd>Help → Check for Client Updates</kbd>
 
 Don't forget to update your card database right after! (<kbd>Help → Check for Card Updates...</kbd>)
 
@@ -60,14 +63,14 @@ Remove empty headers when done.
  -->
 
 <!-- Highlights of the release -->
-### ⚠️ Important:
+### 🔖 Highlights:
 ### ✨ New Features:
-### 🐛 Fixed Bugs / Resolved issues:
+### 🐛 Fixed Bugs / Resolved Issues:
 
 <!-- Complete list of changes (foldable) -->
 <details>
 <summary>
-📘 <b>Show all changes</b> (--REPLACE-WITH-COMMIT-COUNT-- commits)
+<b>Show all changes</b> (--REPLACE-WITH-COMMIT-COUNT-- commits)
 </summary>
 
 ### User Interface
@@ -88,5 +91,6 @@ Remove empty headers when done.
 
 ## Special Thanks
 <!-- Personalise this a bit! -->
-We continue to find it amazing that so many people contribute their time, knowledge, code, testing and more to the project. We'd like to thank the entire Cockatrice community for their efforts.
+It's amazing that so many people contribute their time, knowledge, code, testing and more to the project.  
+We'd like to thank the entire Cockatrice community for their efforts! 🙏
 <!-- We'd like to especially recognize @ZeldaZach, --ADD-CONTRIBUTORS-HERE-- for their help in preparing so many amazing new features for the user base. -->


### PR DESCRIPTION
## Related Ticket(s)
- Related #5040
- Related #5188

## Short roundup of the initial problem
With https://github.com/Cockatrice/Cockatrice/pull/5040/commits/f31495b057ae8568797232b21325eaf77bd67353 the Apple M targets labels got updated to macOS 14, but not the template.
With the recent Xcode version bump, those targets actually build for 14 now, too.

## What will change with this Pull Request?
- Update template with correct macOS version
- Rename + more friendly and better suited icon for notable changes (You prefer 🎉 over the bookmark?)
- Removed icon for "all changes" to stress the main categories (If anything, I suggest 📋 over the "blue box" aka book 📘)
- Some rewording
- Better highlighting for OS version deprecation hint:
> [!IMPORTANT]  
> **This is an important note.**
