### PR TITLE
fix type mismatch from QT_STATE_CHANGED_T

### DIFF
--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -524,7 +524,7 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     setLayout(mainLayout);
 }
 
-void UserInterfaceSettingsPage::setNotificationEnabled(int i)
+void UserInterfaceSettingsPage::setNotificationEnabled(QT_STATE_CHANGED_T i)
 {
     specNotificationsEnabledCheckBox.setEnabled(i != 0);
     buddyConnectNotificationsEnabledCheckBox.setEnabled(i != 0);

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -113,7 +113,7 @@ class UserInterfaceSettingsPage : public AbstractSettingsPage
 {
     Q_OBJECT
 private slots:
-    void setNotificationEnabled(int);
+    void setNotificationEnabled(QT_STATE_CHANGED_T);
 
 private:
     QCheckBox notificationsEnabledCheckBox;


### PR DESCRIPTION
## Short roundup of the initial problem

`QObject::connect: No such slot UserInterfaceSettingsPage::setNotificationEnabled(Qt::CheckState) in /Users/Ricky/GitHub/Cockatrice/cockatrice/src/dialogs/dlg_settings.cpp:448`

Looks like we missed one when we changed the types in #5137.

## What will change with this Pull Request?
- fixed the type of the parameter for `setNotificationEnabled`