### PR TITLE
clean up DownloadSettings

### DIFF
--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -878,6 +878,7 @@ void MainWindow::startupConfigCheck()
         // no config found, 99% new clean install
         qDebug() << "Startup: old client version empty, assuming first start after clean install";
         alertForcedOracleRun(VERSION_STRING, false);
+        SettingsCache::instance().downloads().resetToDefaultURLs(); // populate the download urls
         SettingsCache::instance().setClientVersion(VERSION_STRING);
     } else if (SettingsCache::instance().getClientVersion() != VERSION_STRING) {
         // config found, from another (presumably older) version

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -588,8 +588,9 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     connect(urlList->model(), SIGNAL(rowsMoved(const QModelIndex, int, int, const QModelIndex, int)), this,
             SLOT(urlListChanged(const QModelIndex, int, int, const QModelIndex, int)));
 
-    foreach (QString url, SettingsCache::instance().downloads().getAllURLs())
+    for (QString url : SettingsCache::instance().downloads().getAllURLs()) {
         urlList->addItem(url);
+    }
 
     auto aAdd = new QAction(this);
     aAdd->setIcon(QPixmap("theme:icons/increment"));

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -588,8 +588,8 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     connect(urlList->model(), SIGNAL(rowsMoved(const QModelIndex, int, int, const QModelIndex, int)), this,
             SLOT(urlListChanged(const QModelIndex, int, int, const QModelIndex, int)));
 
-    for (int i = 0; i < SettingsCache::instance().downloads().getCount(); i++)
-        urlList->addItem(SettingsCache::instance().downloads().getDownloadUrlAt(i));
+    foreach (QString url, SettingsCache::instance().downloads().getAllURLs())
+        urlList->addItem(url);
 
     auto aAdd = new QAction(this);
     aAdd->setIcon(QPixmap("theme:icons/increment"));
@@ -694,7 +694,7 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
 
 void DeckEditorSettingsPage::resetDownloadedURLsButtonClicked()
 {
-    SettingsCache::instance().downloads().clear();
+    SettingsCache::instance().downloads().resetToDefaultURLs();
     urlList->clear();
     urlList->addItems(SettingsCache::instance().downloads().getAllURLs());
     QMessageBox::information(this, tr("Success"), tr("Download URLs have been reset."));
@@ -774,11 +774,13 @@ void DeckEditorSettingsPage::actEditURL()
 void DeckEditorSettingsPage::storeSettings()
 {
     qInfo() << "URL Priority Reset";
-    SettingsCache::instance().downloads().clear();
+
+    QStringList downloadUrls;
     for (int i = 0; i < urlList->count(); i++) {
         qInfo() << "Priority" << i << ":" << urlList->item(i)->text();
-        SettingsCache::instance().downloads().setDownloadUrlAt(i, urlList->item(i)->text());
+        downloadUrls << urlList->item(i)->text();
     }
+    SettingsCache::instance().downloads().setDownloadUrls(downloadUrls);
 }
 
 void DeckEditorSettingsPage::urlListChanged(const QModelIndex &, int, int, const QModelIndex &, int)

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -588,9 +588,7 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     connect(urlList->model(), SIGNAL(rowsMoved(const QModelIndex, int, int, const QModelIndex, int)), this,
             SLOT(urlListChanged(const QModelIndex, int, int, const QModelIndex, int)));
 
-    for (QString url : SettingsCache::instance().downloads().getAllURLs()) {
-        urlList->addItem(url);
-    }
+    urlList->addItems(SettingsCache::instance().downloads().getAllURLs());
 
     auto aAdd = new QAction(this);
     aAdd->setIcon(QPixmap("theme:icons/increment"));

--- a/cockatrice/src/settings/download_settings.cpp
+++ b/cockatrice/src/settings/download_settings.cpp
@@ -2,6 +2,12 @@
 
 #include "settings_manager.h"
 
+const QStringList DownloadSettings::DEFAULT_DOWNLOAD_URLS = {
+    "https://api.scryfall.com/cards/!set:uuid!?format=image&face=!prop:side!",
+    "https://api.scryfall.com/cards/multiverse/!set:muid!?format=image",
+    "https://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!set:muid!&type=card",
+    "https://gatherer.wizards.com/Handlers/Image.ashx?name=!name!&type=card"};
+
 DownloadSettings::DownloadSettings(const QString &settingPath, QObject *parent = nullptr)
     : SettingsManager(settingPath + "downloads.ini", parent)
 {
@@ -19,10 +25,5 @@ QStringList DownloadSettings::getAllURLs()
 
 void DownloadSettings::resetToDefaultURLs()
 {
-    auto downloadURLs = QStringList();
-    downloadURLs.append("https://api.scryfall.com/cards/!set:uuid!?format=image&face=!prop:side!");
-    downloadURLs.append("https://api.scryfall.com/cards/multiverse/!set:muid!?format=image");
-    downloadURLs.append("https://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!set:muid!&type=card");
-    downloadURLs.append("https://gatherer.wizards.com/Handlers/Image.ashx?name=!name!&type=card");
-    setValue(QVariant::fromValue(downloadURLs), "urls", "downloads");
+    setValue(QVariant::fromValue(DEFAULT_DOWNLOAD_URLS), "urls", "downloads");
 }

--- a/cockatrice/src/settings/download_settings.cpp
+++ b/cockatrice/src/settings/download_settings.cpp
@@ -5,12 +5,10 @@
 DownloadSettings::DownloadSettings(const QString &settingPath, QObject *parent = nullptr)
     : SettingsManager(settingPath + "downloads.ini", parent)
 {
-    downloadURLs = getValue("urls", "downloads").value<QStringList>();
 }
 
-void DownloadSettings::setDownloadUrlAt(int index, const QString &url)
+void DownloadSettings::setDownloadUrls(const QStringList &downloadURLs)
 {
-    downloadURLs.insert(index, url);
     setValue(QVariant::fromValue(downloadURLs), "urls", "downloads");
 }
 
@@ -19,39 +17,22 @@ void DownloadSettings::setDownloadUrlAt(int index, const QString &url)
  */
 QStringList DownloadSettings::getAllURLs()
 {
+    auto downloadURLs = getValue("urls", "downloads").toStringList();
+
     // First run, these will be empty
     if (downloadURLs.count() == 0) {
-        populateDefaultURLs();
+        resetToDefaultURLs();
     }
 
     return downloadURLs;
 }
 
-void DownloadSettings::populateDefaultURLs()
+void DownloadSettings::resetToDefaultURLs()
 {
-    downloadURLs.clear();
+    auto downloadURLs = QStringList();
     downloadURLs.append("https://api.scryfall.com/cards/!set:uuid!?format=image&face=!prop:side!");
     downloadURLs.append("https://api.scryfall.com/cards/multiverse/!set:muid!?format=image");
     downloadURLs.append("https://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!set:muid!&type=card");
     downloadURLs.append("https://gatherer.wizards.com/Handlers/Image.ashx?name=!name!&type=card");
     setValue(QVariant::fromValue(downloadURLs), "urls", "downloads");
-}
-
-QString DownloadSettings::getDownloadUrlAt(int index)
-{
-    if (0 <= index && index < downloadURLs.size()) {
-        return downloadURLs[index];
-    }
-
-    return "";
-}
-
-int DownloadSettings::getCount()
-{
-    return downloadURLs.size();
-}
-
-void DownloadSettings::clear()
-{
-    downloadURLs.clear();
 }

--- a/cockatrice/src/settings/download_settings.cpp
+++ b/cockatrice/src/settings/download_settings.cpp
@@ -12,19 +12,9 @@ void DownloadSettings::setDownloadUrls(const QStringList &downloadURLs)
     setValue(QVariant::fromValue(downloadURLs), "urls", "downloads");
 }
 
-/**
- * If reset or first run, this method contains the default URLs we will populate
- */
 QStringList DownloadSettings::getAllURLs()
 {
-    auto downloadURLs = getValue("urls", "downloads").toStringList();
-
-    // First run, these will be empty
-    if (downloadURLs.count() == 0) {
-        resetToDefaultURLs();
-    }
-
-    return downloadURLs;
+    return getValue("urls", "downloads").toStringList();
 }
 
 void DownloadSettings::resetToDefaultURLs()

--- a/cockatrice/src/settings/download_settings.h
+++ b/cockatrice/src/settings/download_settings.h
@@ -14,16 +14,8 @@ public:
     explicit DownloadSettings(const QString &, QObject *);
 
     QStringList getAllURLs();
-    QString getDownloadUrlAt(int);
-    void setDownloadUrlAt(int, const QString &);
-    int getCount();
-    void clear();
-
-private:
-    QStringList downloadURLs;
-
-private:
-    void populateDefaultURLs();
+    void setDownloadUrls(const QStringList &downloadURLs);
+    void resetToDefaultURLs();
 };
 
 #endif // COCKATRICE_DOWNLOADSETTINGS_H

--- a/cockatrice/src/settings/download_settings.h
+++ b/cockatrice/src/settings/download_settings.h
@@ -10,6 +10,8 @@ class DownloadSettings : public SettingsManager
     Q_OBJECT
     friend class SettingsCache;
 
+    static const QStringList DEFAULT_DOWNLOAD_URLS;
+
 public:
     explicit DownloadSettings(const QString &, QObject *);
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5193 

## Short roundup of the initial problem

In addition to the above bug, `DownloadSettings` (and the usage of it) feels really "beat around the bush" for no reason. 

## What will change with this Pull Request?
- Refactored `DownloadSettings` and its usage to be more direct.
- **Functionality change:** automatic resetting of urls to default now only happens on first run after clean install instead of whenever the urls are empty.
  - It felt weird to me that having an empty url list will forcibly cause it to be reset to default. 
    - There *are* valid reasons to have an empty url list. For example, if you're only playing with custom images.
    - If you *do* want to reset the urls because you messed up, you can always just manually press the reset button.
