### PR TITLE
add menu option to reload card db

### DIFF
--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -666,6 +666,7 @@ void MainWindow::retranslateUi()
     aOpenCustomFolder->setText(tr("Open custom image folder"));
     aOpenCustomsetsFolder->setText(tr("Open custom sets folder"));
     aAddCustomSet->setText(tr("Add custom sets/cards"));
+    aReloadCardDatabase->setText(tr("Reload card database"));
 
     helpMenu->setTitle(tr("&Help"));
     aAbout->setText(tr("&About Cockatrice"));
@@ -714,6 +715,8 @@ void MainWindow::createActions()
     connect(aOpenCustomsetsFolder, SIGNAL(triggered()), this, SLOT(actOpenCustomsetsFolder()));
     aAddCustomSet = new QAction(QString(), this);
     connect(aAddCustomSet, SIGNAL(triggered()), this, SLOT(actAddCustomSet()));
+    aReloadCardDatabase = new QAction(QString(), this);
+    connect(aReloadCardDatabase, SIGNAL(triggered()), this, SLOT(actReloadCardDatabase()));
 
     aAbout = new QAction(this);
     connect(aAbout, SIGNAL(triggered()), this, SLOT(actAbout()));
@@ -788,6 +791,8 @@ void MainWindow::createMenus()
     dbMenu->addAction(aOpenCustomFolder);
     dbMenu->addAction(aOpenCustomsetsFolder);
     dbMenu->addAction(aAddCustomSet);
+    dbMenu->addSeparator();
+    dbMenu->addAction(aReloadCardDatabase);
 
     helpMenu = menuBar()->addMenu(QString());
     helpMenu->addAction(aAbout);
@@ -1322,6 +1327,11 @@ int MainWindow::getNextCustomSetPrefix(QDir dataDir)
     }
 
     return maxIndex + 1;
+}
+
+void MainWindow::actReloadCardDatabase()
+{
+    const auto reloadOk1 = QtConcurrent::run([] { CardDatabaseManager::getInstance()->loadCardDatabases(); });
 }
 
 void MainWindow::actManageSets()

--- a/cockatrice/src/client/ui/window_main.h
+++ b/cockatrice/src/client/ui/window_main.h
@@ -98,6 +98,7 @@ private slots:
     void actOpenCustomFolder();
     void actOpenCustomsetsFolder();
     void actAddCustomSet();
+    void actReloadCardDatabase();
 
     void actManageSets();
     void actEditTokens();
@@ -125,7 +126,7 @@ private:
     QMenu *cockatriceMenu, *dbMenu, *helpMenu, *trayIconMenu;
     QAction *aConnect, *aDisconnect, *aSinglePlayer, *aWatchReplay, *aDeckEditor, *aFullScreen, *aSettings, *aExit,
         *aAbout, *aTips, *aCheckCardUpdates, *aRegister, *aForgotPassword, *aUpdate, *aViewLog, *aManageSets,
-        *aEditTokens, *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet, *aShow;
+        *aEditTokens, *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet, *aReloadCardDatabase, *aShow;
     TabSupervisor *tabSupervisor;
     WndSets *wndSets;
     RemoteClient *client;


### PR DESCRIPTION
## What will change with this Pull Request?
- add action to reload card db under deck builder tab -> `Card Database`

## Screenshots
<img width="252" alt="Screenshot 2024-11-24 at 11 40 50 PM" src="https://github.com/user-attachments/assets/ef1da70c-611d-47ba-9b4b-ad616a35eacb">
