### PR TITLE
add padding to right side of card reveal window

### DIFF
--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -163,8 +163,8 @@ void ZoneViewZone::reorganizeCards()
 
     qreal aleft = 0;
     qreal atop = 0;
-    qreal awidth = (pileView && sortByType) ? qMax(typeColumn + 1, 3) * CARD_WIDTH + (CARD_WIDTH / 2)
-                                            : qMax(cols, 1) * CARD_WIDTH + (CARD_WIDTH / 2);
+    qreal awidth = (pileView && sortByType) ? qMax(typeColumn + 1, 3) * CARD_WIDTH + (CARD_WIDTH / 2) + 12
+                                            : qMax(cols, 1) * CARD_WIDTH + (CARD_WIDTH / 2) + 12;
     qreal aheight = (pileView && sortByType) ? (longestRow * CARD_HEIGHT) / 3 + CARD_HEIGHT * 1.3
                                              : (rows * CARD_HEIGHT) / 3 + CARD_HEIGHT * 1.3;
     optimumRect = QRectF(aleft, atop, awidth, aheight);

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -161,13 +161,13 @@ void ZoneViewZone::reorganizeCards()
         }
     }
 
+    int totalRows = (pileView && sortByType) ? longestRow : rows;
+    int totalColumns = (pileView && sortByType) ? qMax(typeColumn + 1, 3) : qMax(cols, 1);
+
     qreal aleft = 0;
     qreal atop = 0;
-    qreal awidth = (pileView && sortByType)
-                       ? qMax(typeColumn + 1, 3) * CARD_WIDTH + (CARD_WIDTH / 2) + HORIZONTAL_PADDING
-                       : qMax(cols, 1) * CARD_WIDTH + (CARD_WIDTH / 2) + HORIZONTAL_PADDING;
-    qreal aheight = (pileView && sortByType) ? (longestRow * CARD_HEIGHT) / 3 + CARD_HEIGHT * 1.3
-                                             : (rows * CARD_HEIGHT) / 3 + CARD_HEIGHT * 1.3;
+    qreal awidth = totalColumns * CARD_WIDTH + (CARD_WIDTH / 2) + HORIZONTAL_PADDING;
+    qreal aheight = (totalRows * CARD_HEIGHT) / 3 + CARD_HEIGHT * 1.3;
     optimumRect = QRectF(aleft, atop, awidth, aheight);
 
     updateGeometry();

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -145,26 +145,27 @@ void ZoneViewZone::reorganizeCards()
             }
 
             lastCardType = cardType;
-            qreal x = 7 + (typeColumn * CARD_WIDTH);
+            qreal x = typeColumn * CARD_WIDTH;
             qreal y = typeRow * CARD_HEIGHT / 3;
-            c->setPos(x + 5, y + 5);
+            c->setPos(HORIZONTAL_PADDING + x, VERTICAL_PADDING + y);
             c->setRealZValue(i);
             longestRow = qMax(typeRow, longestRow);
         }
     } else {
         for (int i = 0; i < cardCount; i++) {
             CardItem *c = cardsToDisplay.at(i);
-            qreal x = 7 + ((i / rows) * CARD_WIDTH);
+            qreal x = (i / rows) * CARD_WIDTH;
             qreal y = (i % rows) * CARD_HEIGHT / 3;
-            c->setPos(x + 5, y + 5);
+            c->setPos(HORIZONTAL_PADDING + x, VERTICAL_PADDING + y);
             c->setRealZValue(i);
         }
     }
 
     qreal aleft = 0;
     qreal atop = 0;
-    qreal awidth = (pileView && sortByType) ? qMax(typeColumn + 1, 3) * CARD_WIDTH + (CARD_WIDTH / 2) + 12
-                                            : qMax(cols, 1) * CARD_WIDTH + (CARD_WIDTH / 2) + 12;
+    qreal awidth = (pileView && sortByType)
+                       ? qMax(typeColumn + 1, 3) * CARD_WIDTH + (CARD_WIDTH / 2) + HORIZONTAL_PADDING
+                       : qMax(cols, 1) * CARD_WIDTH + (CARD_WIDTH / 2) + HORIZONTAL_PADDING;
     qreal aheight = (pileView && sortByType) ? (longestRow * CARD_HEIGHT) / 3 + CARD_HEIGHT * 1.3
                                              : (rows * CARD_HEIGHT) / 3 + CARD_HEIGHT * 1.3;
     optimumRect = QRectF(aleft, atop, awidth, aheight);

--- a/cockatrice/src/game/zones/view_zone.h
+++ b/cockatrice/src/game/zones/view_zone.h
@@ -15,6 +15,9 @@ class ZoneViewZone : public SelectZone, public QGraphicsLayoutItem
     Q_OBJECT
     Q_INTERFACES(QGraphicsLayoutItem)
 private:
+    static constexpr int HORIZONTAL_PADDING = 12;
+    static constexpr int VERTICAL_PADDING = 5;
+
     QRectF bRect, optimumRect;
     int minRows, numberCards;
     void handleDropEvent(const QList<CardDragItem *> &dragItems, CardZone *startZone, const QPoint &dropPoint);


### PR DESCRIPTION
## Short roundup of the initial problem
The card reveal window has padding on the left side but no padding on the right side. This actually matters beyond aesthetics, because I have enough room to start a click-and-drag on the left side but don't have enough room on the right side.

<img width="450" alt="Screenshot 2024-11-26 at 2 03 13 AM" src="https://github.com/user-attachments/assets/bc11da6f-c5f5-40f8-9a01-d8c0e73fbdf9">

## What will change with this Pull Request?
<img width="450" alt="Screenshot 2024-11-26 at 2 02 41 AM" src="https://github.com/user-attachments/assets/8408d81c-a95a-4d5a-bcbc-198adbc463c1">

- Increase rect width so that there's also padding on the right now.
- Moved padding values in `ZoneViewZone` into constants.
