### PR TITLE
Refactor codebase to new Qt Slot/Signal syntax

### DIFF
--- a/cockatrice/src/client/game_logic/abstract_client.cpp
+++ b/cockatrice/src/client/game_logic/abstract_client.cpp
@@ -52,7 +52,7 @@ AbstractClient::AbstractClient(QObject *parent)
     FeatureSet features;
     features.initalizeFeatureList(clientFeatures);
 
-    connect(this, SIGNAL(sigQueuePendingCommand(PendingCommand *)), this, SLOT(queuePendingCommand(PendingCommand *)));
+    connect(this, &AbstractClient::sigQueuePendingCommand, this, &AbstractClient::queuePendingCommand);
 }
 
 AbstractClient::~AbstractClient()

--- a/cockatrice/src/client/network/release_channel.cpp
+++ b/cockatrice/src/client/network/release_channel.cpp
@@ -38,7 +38,7 @@ void ReleaseChannel::checkForUpdates()
     QString releaseChannelUrl = getReleaseChannelUrl();
     qDebug() << "Searching for updates on the channel: " << releaseChannelUrl;
     response = netMan->get(QNetworkRequest(releaseChannelUrl));
-    connect(response, SIGNAL(finished()), this, SLOT(releaseListFinished()));
+    connect(response, &QNetworkReply::finished, this, &ReleaseChannel::releaseListFinished);
 }
 
 // Different release channel checking functions for different operating systems
@@ -158,7 +158,7 @@ void StableReleaseChannel::releaseListFinished()
     QString url = QString(STABLETAG_URL) + tagName;
     qDebug() << "Searching for commit hash corresponding to stable channel tag: " << tagName;
     response = netMan->get(QNetworkRequest(url));
-    connect(response, SIGNAL(finished()), this, SLOT(tagListFinished()));
+    connect(response, &QNetworkReply::finished, this, &StableReleaseChannel::tagListFinished);
 }
 
 void StableReleaseChannel::tagListFinished()
@@ -260,7 +260,7 @@ void BetaReleaseChannel::releaseListFinished()
 
     qDebug() << "Searching for a corresponding file on the beta channel: " << betaBuildDownloadUrl;
     response = netMan->get(QNetworkRequest(betaBuildDownloadUrl));
-    connect(response, SIGNAL(finished()), this, SLOT(fileListFinished()));
+    connect(response, &QNetworkReply::finished, this, &BetaReleaseChannel::fileListFinished);
 }
 
 void BetaReleaseChannel::fileListFinished()

--- a/cockatrice/src/client/network/replay_timeline_widget.cpp
+++ b/cockatrice/src/client/network/replay_timeline_widget.cpp
@@ -9,7 +9,7 @@ ReplayTimelineWidget::ReplayTimelineWidget(QWidget *parent)
     : QWidget(parent), maxBinValue(1), maxTime(1), timeScaleFactor(1.0), currentTime(0), currentEvent(0)
 {
     replayTimer = new QTimer(this);
-    connect(replayTimer, SIGNAL(timeout()), this, SLOT(replayTimerTimeout()));
+    connect(replayTimer, &QTimer::timeout, this, &ReplayTimelineWidget::replayTimerTimeout);
 
     rewindBufferingTimer = new QTimer(this);
     rewindBufferingTimer->setSingleShot(true);

--- a/cockatrice/src/client/network/spoiler_background_updater.cpp
+++ b/cockatrice/src/client/network/spoiler_background_updater.cpp
@@ -45,10 +45,10 @@ void SpoilerBackgroundUpdater::downloadFromURL(QUrl url, bool saveResults)
 
     if (saveResults) {
         // This will write out to the file (used for spoiler.xml)
-        connect(reply, SIGNAL(finished()), this, SLOT(actDownloadFinishedSpoilersFile()));
+        connect(reply, &QNetworkReply::finished, this, &SpoilerBackgroundUpdater::actDownloadFinishedSpoilersFile);
     } else {
         // This will check the status (used to see if we're in spoiler season or not)
-        connect(reply, SIGNAL(finished()), this, SLOT(actCheckIfSpoilerSeasonEnabled()));
+        connect(reply, &QNetworkReply::finished, this, &SpoilerBackgroundUpdater::actCheckIfSpoilerSeasonEnabled);
     }
 }
 

--- a/cockatrice/src/client/sound_engine.cpp
+++ b/cockatrice/src/client/sound_engine.cpp
@@ -15,8 +15,8 @@
 SoundEngine::SoundEngine(QObject *parent) : QObject(parent), player(nullptr)
 {
     ensureThemeDirectoryExists();
-    connect(&SettingsCache::instance(), SIGNAL(soundThemeChanged()), this, SLOT(themeChangedSlot()));
-    connect(&SettingsCache::instance(), SIGNAL(soundEnabledChanged()), this, SLOT(soundEnabledChanged()));
+    connect(&SettingsCache::instance(), &SettingsCache::soundThemeChanged, this, &SoundEngine::themeChangedSlot);
+    connect(&SettingsCache::instance(), &SettingsCache::soundEnabledChanged, this, &SoundEngine::soundEnabledChanged);
 
     soundEnabledChanged();
     themeChangedSlot();

--- a/cockatrice/src/client/tabs/tab_account.cpp
+++ b/cockatrice/src/client/tabs/tab_account.cpp
@@ -30,29 +30,22 @@ TabUserLists::TabUserLists(TabSupervisor *_tabSupervisor,
     userInfoBox = new UserInfoBox(client, true);
     userInfoBox->updateInfo(userInfo);
 
-    connect(allUsersList, SIGNAL(openMessageDialog(const QString &, bool)), this,
-            SIGNAL(openMessageDialog(const QString &, bool)));
-    connect(buddyList, SIGNAL(openMessageDialog(const QString &, bool)), this,
-            SIGNAL(openMessageDialog(const QString &, bool)));
-    connect(ignoreList, SIGNAL(openMessageDialog(const QString &, bool)), this,
-            SIGNAL(openMessageDialog(const QString &, bool)));
+    connect(allUsersList, &UserList::openMessageDialog, this, &TabUserLists::openMessageDialog);
+    connect(buddyList, &UserList::openMessageDialog, this, &TabUserLists::openMessageDialog);
+    connect(ignoreList, &UserList::openMessageDialog, this, &TabUserLists::openMessageDialog);
 
-    connect(client, SIGNAL(userJoinedEventReceived(const Event_UserJoined &)), this,
-            SLOT(processUserJoinedEvent(const Event_UserJoined &)));
-    connect(client, SIGNAL(userLeftEventReceived(const Event_UserLeft &)), this,
-            SLOT(processUserLeftEvent(const Event_UserLeft &)));
-    connect(client, SIGNAL(buddyListReceived(const QList<ServerInfo_User> &)), this,
-            SLOT(buddyListReceived(const QList<ServerInfo_User> &)));
-    connect(client, SIGNAL(ignoreListReceived(const QList<ServerInfo_User> &)), this,
-            SLOT(ignoreListReceived(const QList<ServerInfo_User> &)));
-    connect(client, SIGNAL(addToListEventReceived(const Event_AddToList &)), this,
-            SLOT(processAddToListEvent(const Event_AddToList &)));
-    connect(client, SIGNAL(removeFromListEventReceived(const Event_RemoveFromList &)), this,
-            SLOT(processRemoveFromListEvent(const Event_RemoveFromList &)));
+    connect(client, &AbstractClient::userJoinedEventReceived, this, &TabUserLists::processUserJoinedEvent);
+    connect(client, &AbstractClient::userLeftEventReceived, this, &TabUserLists::processUserLeftEvent);
+    connect(client, &AbstractClient::buddyListReceived, this, &TabUserLists::buddyListReceived);
+    connect(client, &AbstractClient::ignoreListReceived, this, &TabUserLists::ignoreListReceived);
+    connect(client, &AbstractClient::addToListEventReceived, this, &TabUserLists::processAddToListEvent);
+    connect(client, &AbstractClient::removeFromListEventReceived, this, &TabUserLists::processRemoveFromListEvent);
 
     PendingCommand *pend = client->prepareSessionCommand(Command_ListUsers());
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-            SLOT(processListUsersResponse(const Response &)));
+    connect(pend,
+            static_cast<void (PendingCommand::*)(const Response &, const CommandContainer &, const QVariant &)>(
+                &PendingCommand::finished),
+            this, &TabUserLists::processListUsersResponse);
     client->sendCommand(pend);
 
     QVBoxLayout *vbox = new QVBoxLayout;
@@ -63,9 +56,9 @@ TabUserLists::TabUserLists(TabSupervisor *_tabSupervisor,
     addBuddyEdit = new LineEditUnfocusable;
     addBuddyEdit->setMaxLength(MAX_NAME_LENGTH);
     addBuddyEdit->setPlaceholderText(tr("Add to Buddy List"));
-    connect(addBuddyEdit, SIGNAL(returnPressed()), this, SLOT(addToBuddyList()));
+    connect(addBuddyEdit, &LineEditUnfocusable::returnPressed, this, &TabUserLists::addToBuddyList);
     QPushButton *addBuddyButton = new QPushButton("Add");
-    connect(addBuddyButton, SIGNAL(clicked()), this, SLOT(addToBuddyList()));
+    connect(addBuddyButton, &QPushButton::clicked, this, &TabUserLists::addToBuddyList);
     addToBuddyList->addWidget(addBuddyEdit);
     addToBuddyList->addWidget(addBuddyButton);
 
@@ -73,9 +66,9 @@ TabUserLists::TabUserLists(TabSupervisor *_tabSupervisor,
     addIgnoreEdit = new LineEditUnfocusable;
     addIgnoreEdit->setMaxLength(MAX_NAME_LENGTH);
     addIgnoreEdit->setPlaceholderText(tr("Add to Ignore List"));
-    connect(addIgnoreEdit, SIGNAL(returnPressed()), this, SLOT(addToIgnoreList()));
+    connect(addIgnoreEdit, &LineEditUnfocusable::returnPressed, this, &TabUserLists::addToIgnoreList);
     QPushButton *addIgnoreButton = new QPushButton("Add");
-    connect(addIgnoreButton, SIGNAL(clicked()), this, SLOT(addToIgnoreList()));
+    connect(addIgnoreButton, &QPushButton::clicked, this, &TabUserLists::addToIgnoreList);
     addToIgnoreList->addWidget(addIgnoreEdit);
     addToIgnoreList->addWidget(addIgnoreButton);
 

--- a/cockatrice/src/client/tabs/tab_admin.cpp
+++ b/cockatrice/src/client/tabs/tab_admin.cpp
@@ -29,8 +29,8 @@ ShutdownDialog::ShutdownDialog(QWidget *parent) : QDialog(parent)
     minutesEdit->setMaximum(999);
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &ShutdownDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &ShutdownDialog::reject);
 
     QGridLayout *mainLayout = new QGridLayout;
     mainLayout->addWidget(reasonLabel, 0, 0);
@@ -57,11 +57,11 @@ TabAdmin::TabAdmin(TabSupervisor *_tabSupervisor, AbstractClient *_client, bool 
     : Tab(_tabSupervisor, parent), locked(true), client(_client), fullAdmin(_fullAdmin)
 {
     updateServerMessageButton = new QPushButton;
-    connect(updateServerMessageButton, SIGNAL(clicked()), this, SLOT(actUpdateServerMessage()));
+    connect(updateServerMessageButton, &QPushButton::clicked, this, &TabAdmin::actUpdateServerMessage);
     shutdownServerButton = new QPushButton;
-    connect(shutdownServerButton, SIGNAL(clicked()), this, SLOT(actShutdownServer()));
+    connect(shutdownServerButton, &QPushButton::clicked, this, &TabAdmin::actShutdownServer);
     reloadConfigButton = new QPushButton;
-    connect(reloadConfigButton, SIGNAL(clicked()), this, SLOT(actReloadConfig()));
+    connect(reloadConfigButton, &QPushButton::clicked, this, &TabAdmin::actReloadConfig);
 
     QVBoxLayout *vbox = new QVBoxLayout;
     vbox->addWidget(updateServerMessageButton);
@@ -74,10 +74,10 @@ TabAdmin::TabAdmin(TabSupervisor *_tabSupervisor, AbstractClient *_client, bool 
     adminGroupBox->setEnabled(false);
 
     unlockButton = new QPushButton;
-    connect(unlockButton, SIGNAL(clicked()), this, SLOT(actUnlock()));
+    connect(unlockButton, &QPushButton::clicked, this, &TabAdmin::actUnlock);
     lockButton = new QPushButton;
     lockButton->setEnabled(false);
-    connect(lockButton, SIGNAL(clicked()), this, SLOT(actLock()));
+    connect(lockButton, &QPushButton::clicked, this, &TabAdmin::actLock);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(adminGroupBox);

--- a/cockatrice/src/client/tapped_out_interface.cpp
+++ b/cockatrice/src/client/tapped_out_interface.cpp
@@ -14,7 +14,7 @@ TappedOutInterface::TappedOutInterface(CardDatabase &_cardDatabase, QObject *par
     : QObject(parent), cardDatabase(_cardDatabase)
 {
     manager = new QNetworkAccessManager(this);
-    connect(manager, SIGNAL(finished(QNetworkReply *)), this, SLOT(queryFinished(QNetworkReply *)));
+    connect(manager, &QNetworkAccessManager::finished, this, &TappedOutInterface::queryFinished);
 }
 
 void TappedOutInterface::queryFinished(QNetworkReply *reply)

--- a/cockatrice/src/client/update_downloader.cpp
+++ b/cockatrice/src/client/update_downloader.cpp
@@ -15,8 +15,8 @@ void UpdateDownloader::beginDownload(QUrl downloadUrl)
         originalUrl = downloadUrl;
 
     response = netMan->get(QNetworkRequest(downloadUrl));
-    connect(response, QNetworkReply::finished, this, fileFinished);
-    connect(response, QNetworkReply::downloadProgress, this, downloadProgress);
+    connect(response, &QNetworkReply::finished, this, &fileFinished);
+    connect(response, &QNetworkReply::downloadProgress, this, &downloadProgress);
     connect(this, &UpdateDownloader::stopDownload, response, &QNetworkReply::abort);
 }
 

--- a/cockatrice/src/client/update_downloader.cpp
+++ b/cockatrice/src/client/update_downloader.cpp
@@ -15,9 +15,9 @@ void UpdateDownloader::beginDownload(QUrl downloadUrl)
         originalUrl = downloadUrl;
 
     response = netMan->get(QNetworkRequest(downloadUrl));
-    connect(response, SIGNAL(finished()), this, SLOT(fileFinished()));
-    connect(response, SIGNAL(downloadProgress(qint64, qint64)), this, SLOT(downloadProgress(qint64, qint64)));
-    connect(this, SIGNAL(stopDownload()), response, SLOT(abort()));
+    connect(response, QNetworkReply::finished, this, fileFinished);
+    connect(response, QNetworkReply::downloadProgress, this, downloadProgress);
+    connect(this, &UpdateDownloader::stopDownload, response, &QNetworkReply::abort);
 }
 
 void UpdateDownloader::downloadError(QNetworkReply::NetworkError)

--- a/cockatrice/src/client/update_downloader.cpp
+++ b/cockatrice/src/client/update_downloader.cpp
@@ -15,8 +15,8 @@ void UpdateDownloader::beginDownload(QUrl downloadUrl)
         originalUrl = downloadUrl;
 
     response = netMan->get(QNetworkRequest(downloadUrl));
-    connect(response, &QNetworkReply::finished, this, &fileFinished);
-    connect(response, &QNetworkReply::downloadProgress, this, &downloadProgress);
+    connect(response, &QNetworkReply::finished, this, &UpdateDownloader::fileFinished);
+    connect(response, &QNetworkReply::downloadProgress, this, &UpdateDownloader::downloadProgress);
     connect(this, &UpdateDownloader::stopDownload, response, &QNetworkReply::abort);
 }
 

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
 
-    QObject::connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(quit()));
+    QObject::connect(&app, QApplication::lastWindowClosed, &app, QApplication::quit);
 
     qInstallMessageHandler(CockatriceLogger);
 #ifdef Q_OS_WIN

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
 
-    QObject::connect(&app, QApplication::lastWindowClosed, &app, QApplication::quit);
+    QObject::connect(&app, &QApplication::lastWindowClosed, &app, &QApplication::quit);
 
     qInstallMessageHandler(CockatriceLogger);
 #ifdef Q_OS_WIN


### PR DESCRIPTION
## Short roundup of the initial problem


## What will change with this Pull Request?
Example:
- connect(text, SIGNAL(linkActivated(const QString &)), this, SLOT(setCard(const QString &)));
- will change to
- connect(text, &CardInfoTextWidget::linkActivated, this, &CardInfoDisplayWidget::setCard);
