### PR TITLE
refactor method for positioning cards in ZoneViewZone

### DIFF
--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -133,8 +133,8 @@ ZoneViewZone::GridSize ZoneViewZone::positionCardsForDisplay(CardList &cards, bo
 {
     int cardCount = cards.size();
     if (groupByType) {
-        int typeRow = 0;
-        int typeColumn = 0;
+        int row = 0;
+        int col = 0;
         int longestRow = 0;
         QString lastCardType;
         for (int i = 0; i < cardCount; i++) {
@@ -143,22 +143,22 @@ ZoneViewZone::GridSize ZoneViewZone::positionCardsForDisplay(CardList &cards, bo
 
             if (i) { // if not the first card
                 if (cardType == lastCardType)
-                    typeRow++; // add below current card
-                else {         // if no match then move card to next column
-                    typeColumn++;
-                    typeRow = 0;
+                    row++; // add below current card
+                else {     // if no match then move card to next column
+                    col++;
+                    row = 0;
                 }
             }
 
             lastCardType = cardType;
-            qreal x = typeColumn * CARD_WIDTH;
-            qreal y = typeRow * CARD_HEIGHT / 3;
+            qreal x = col * CARD_WIDTH;
+            qreal y = row * CARD_HEIGHT / 3;
             c->setPos(HORIZONTAL_PADDING + x, VERTICAL_PADDING + y);
             c->setRealZValue(i);
-            longestRow = qMax(typeRow, longestRow);
+            longestRow = qMax(row, longestRow);
         }
 
-        return GridSize{longestRow, qMax(typeColumn + 1, 3)};
+        return GridSize{longestRow, qMax(col + 1, 3)};
 
     } else {
         int cols = qFloor(qSqrt((double)cardCount / 2));

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -163,12 +163,13 @@ ZoneViewZone::GridSize ZoneViewZone::positionCardsForDisplay(CardList &cards, bo
     } else {
         int cols = qMin(qFloor(qSqrt((double)cardCount / 2)), 7);
         int rows = qMax(qCeil((double)cardCount / cols), 1);
-        if (minRows == 0)
+        if (minRows == 0) {
             minRows = rows;
-        else if (rows < minRows) {
+        } else if (rows < minRows) {
             rows = minRows;
             cols = qCeil((double)cardCount / minRows);
         }
+
         if (cols < 2)
             cols = 2;
 

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -161,12 +161,8 @@ ZoneViewZone::GridSize ZoneViewZone::positionCardsForDisplay(CardList &cards, bo
         return GridSize{longestRow, qMax(col + 1, 3)};
 
     } else {
-        int cols = qFloor(qSqrt((double)cardCount / 2));
-        if (cols > 7)
-            cols = 7;
-        int rows = qCeil((double)cardCount / cols);
-        if (rows < 1)
-            rows = 1;
+        int cols = qMin(qFloor(qSqrt((double)cardCount / 2)), 7);
+        int rows = qMax(qCeil((double)cardCount / cols), 1);
         if (minRows == 0)
             minRows = rows;
         else if (rows < minRows) {

--- a/cockatrice/src/game/zones/view_zone.h
+++ b/cockatrice/src/game/zones/view_zone.h
@@ -26,6 +26,14 @@ private:
     bool sortByName, sortByType;
     bool pileView;
 
+    struct GridSize
+    {
+        int rows;
+        int cols;
+    };
+
+    GridSize positionCardsForDisplay(CardList &cards, bool groupByType = false);
+
 public:
     ZoneViewZone(Player *_p,
                  CardZone *_origZone,


### PR DESCRIPTION
## Short roundup of the initial problem
Refactor `ZoneViewZone::reorganizeCards` so that it's less messy when I try to implement additional sort options.

## What will change with this Pull Request?
- moved card positioning logic into own method
  - method returns a struct containing the row and col count to use for the bounding rect calculations