### PR TITLE
Fix Deck Popup Glitchy Rendering

### DIFF
--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -120,6 +120,15 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
     connect(zone, SIGNAL(optimumRectChanged()), this, SLOT(resizeToZoneContents()));
     connect(zone, SIGNAL(beingDeleted()), this, SLOT(zoneDeleted()));
     zone->initializeCards(cardList);
+
+    auto *lastResizeBeforeVisibleTimer = new QTimer(this);
+    connect(lastResizeBeforeVisibleTimer, &QTimer::timeout, this, [=] {
+        resizeToZoneContents();
+        disconnect(lastResizeBeforeVisibleTimer);
+        lastResizeBeforeVisibleTimer->deleteLater();
+    });
+    lastResizeBeforeVisibleTimer->setSingleShot(true);
+    lastResizeBeforeVisibleTimer->start(1);
 }
 
 void ZoneViewWidget::processSortByType(QT_STATE_CHANGED_T value)


### PR DESCRIPTION
- QLabel sizes weren't taken into account until the widget is rendered
- Long QLabels can cause exacerbated issues
- Force refresh after 1ms to take QLabels into account

Exaggerated Example:
<img width="517" alt="Screenshot_2024-11-28_at_4 20 33_PM" src="https://github.com/user-attachments/assets/469546df-53f9-46d8-884e-c7a68fb62f53">

Fixed Example:
<img width="288" alt="Screenshot_2024-11-28_at_4 18 01_PM" src="https://github.com/user-attachments/assets/cb66ec19-b016-4bbe-99b8-d2a0ae5329d9">
