### PR TITLE
add sort options to card view window

### DIFF
--- a/cockatrice/src/game/cards/card_list.cpp
+++ b/cockatrice/src/game/cards/card_list.cpp
@@ -3,6 +3,7 @@
 #include "card_database.h"
 #include "card_item.h"
 
+#include <QDebug>
 #include <algorithm>
 
 CardList::CardList(bool _contentsKnown) : QList<CardItem *>(), contentsKnown(_contentsKnown)
@@ -67,7 +68,7 @@ std::function<QString(CardItem *)> CardList::getExtractorFor(SortOption option)
 {
     switch (option) {
         case NoSort:
-            return [](CardItem *c) { return ""; };
+            return [](CardItem *) { return ""; };
         case SortByName:
             return [](CardItem *c) { return c->getName(); };
         case SortByType:
@@ -76,4 +77,8 @@ std::function<QString(CardItem *)> CardList::getExtractorFor(SortOption option)
             // getCmc returns the int as a string. We pad with 0's so that string comp also works on it
             return [](CardItem *c) { return c->getInfo() ? c->getInfo()->getCmc().rightJustified(4, '0') : ""; };
     }
+
+    // this line should never be reached
+    qDebug() << "cardlist.cpp: Could not find extractor for SortOption" << option;
+    return [](CardItem *) { return ""; };
 }

--- a/cockatrice/src/game/cards/card_list.h
+++ b/cockatrice/src/game/cards/card_list.h
@@ -11,10 +11,12 @@ protected:
     bool contentsKnown;
 
 public:
-    enum SortFlags
+    enum SortOption
     {
-        SortByName = 1,
-        SortByType = 2
+        NoSort,
+        SortByName,
+        SortByType,
+        SortByManaValue
     };
     CardList(bool _contentsKnown);
     CardItem *findCard(const int cardId) const;
@@ -22,7 +24,10 @@ public:
     {
         return contentsKnown;
     }
-    void sort(int flags = SortByName);
+
+    void sortBy(const QList<SortOption> &options);
+
+    static std::function<QString(CardItem *)> getExtractorFor(SortOption option);
 };
 
 #endif

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -31,7 +31,7 @@ ZoneViewZone::ZoneViewZone(Player *_p,
                            QGraphicsItem *parent)
     : SelectZone(_p, _origZone->getName(), false, false, true, parent, true), bRect(QRectF()), minRows(0),
       numberCards(_numberCards), origZone(_origZone), revealZone(_revealZone),
-      writeableRevealZone(_writeableRevealZone), sortByName(false), sortByType(false)
+      writeableRevealZone(_writeableRevealZone), groupBy(CardList::NoSort), sortBy(CardList::NoSort)
 {
     if (!(revealZone && !writeableRevealZone)) {
         origZone->getViews().append(this);
@@ -116,20 +116,25 @@ void ZoneViewZone::reorganizeCards()
 
     // sort cards
     QList<CardList::SortOption> sortOptions;
-    if (sortByType) {
-        sortOptions << CardList::SortByType;
+    if (groupBy != CardList::NoSort) {
+        sortOptions << groupBy;
     }
 
-    if (sortByName) {
-        sortOptions << CardList::SortByName;
+    if (sortBy != CardList::NoSort) {
+        sortOptions << sortBy;
+
+        // implicitly sort by name at the end so that cards with the same name appear together
+        if (sortBy != CardList::SortByName) {
+            sortOptions << CardList::SortByName;
+        }
     }
 
     cardsToDisplay.sortBy(sortOptions);
 
     // position cards
     GridSize gridSize;
-    if (pileView && sortByType) {
-        gridSize = positionCardsForDisplay(cardsToDisplay, CardList::SortByType);
+    if (pileView) {
+        gridSize = positionCardsForDisplay(cardsToDisplay, groupBy);
     } else {
         gridSize = positionCardsForDisplay(cardsToDisplay);
     }
@@ -217,17 +222,15 @@ ZoneViewZone::GridSize ZoneViewZone::positionCardsForDisplay(CardList &cards, Ca
     }
 }
 
-void ZoneViewZone::setSortByName(int _sortByName)
+void ZoneViewZone::setGroupBy(CardList::SortOption _groupBy)
 {
-    sortByName = _sortByName;
+    groupBy = _groupBy;
     reorganizeCards();
 }
 
-void ZoneViewZone::setSortByType(int _sortByType)
+void ZoneViewZone::setSortBy(CardList::SortOption _sortBy)
 {
-    sortByType = _sortByType;
-    if (!sortByType)
-        pileView = false;
+    sortBy = _sortBy;
     reorganizeCards();
 }
 

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -113,11 +113,28 @@ void ZoneViewZone::reorganizeCards()
             cards[i]->setId(i);
 
     CardList cardsToDisplay(cards);
-    if (sortByName || sortByType)
-        cardsToDisplay.sort((sortByName ? CardList::SortByName : 0) | (sortByType ? CardList::SortByType : 0));
 
-    auto gridSize = positionCardsForDisplay(cardsToDisplay, pileView && sortByType);
+    // sort cards
+    QList<CardList::SortOption> sortOptions;
+    if (sortByType) {
+        sortOptions << CardList::SortByType;
+    }
 
+    if (sortByName) {
+        sortOptions << CardList::SortByName;
+    }
+
+    cardsToDisplay.sortBy(sortOptions);
+
+    // position cards
+    GridSize gridSize;
+    if (pileView && sortByType) {
+        gridSize = positionCardsForDisplay(cardsToDisplay, CardList::SortByType);
+    } else {
+        gridSize = positionCardsForDisplay(cardsToDisplay);
+    }
+
+    // determine bounding rect
     qreal aleft = 0;
     qreal atop = 0;
     qreal awidth = gridSize.cols * CARD_WIDTH + (CARD_WIDTH / 2) + HORIZONTAL_PADDING;
@@ -132,24 +149,30 @@ void ZoneViewZone::reorganizeCards()
  * @brief Sets the position of each card to the proper position for the view
  *
  * @param cards The cards to reposition. Will modify the cards in the list.
- * @param groupByType Whether to make piles by card type. If true, then expects `cards` to be sorted by type.
+ * @param pileOption Property used to group cards for the piles. Expects `cards` to be sorted by that property. Pass in
+ * NoSort to not make piles.
  *
  * @returns The number of rows and columns to display
  */
-ZoneViewZone::GridSize ZoneViewZone::positionCardsForDisplay(CardList &cards, bool groupByType)
+ZoneViewZone::GridSize ZoneViewZone::positionCardsForDisplay(CardList &cards, CardList::SortOption pileOption)
 {
     int cardCount = cards.size();
-    if (groupByType) {
+
+    if (pileOption != CardList::NoSort) {
         int row = 0;
         int col = 0;
         int longestRow = 0;
-        QString lastCardType;
+
+        QString lastColumnProp;
+
+        const auto extractor = CardList::getExtractorFor(pileOption);
+
         for (int i = 0; i < cardCount; i++) {
             CardItem *c = cards.at(i);
-            QString cardType = c->getInfo() ? c->getInfo()->getMainCardType() : "";
+            QString columnProp = extractor(c);
 
             if (i) { // if not the first card
-                if (cardType == lastCardType)
+                if (columnProp == lastColumnProp)
                     row++; // add below current card
                 else {     // if no match then move card to next column
                     col++;
@@ -157,7 +180,7 @@ ZoneViewZone::GridSize ZoneViewZone::positionCardsForDisplay(CardList &cards, bo
                 }
             }
 
-            lastCardType = cardType;
+            lastColumnProp = columnProp;
             qreal x = col * CARD_WIDTH;
             qreal y = row * CARD_HEIGHT / 3;
             c->setPos(HORIZONTAL_PADDING + x, VERTICAL_PADDING + y);

--- a/cockatrice/src/game/zones/view_zone.h
+++ b/cockatrice/src/game/zones/view_zone.h
@@ -41,7 +41,7 @@ private:
         int cols;
     };
 
-    GridSize positionCardsForDisplay(CardList &cards, bool groupByType = false);
+    GridSize positionCardsForDisplay(CardList &cards, CardList::SortOption pileOption = CardList::NoSort);
 
 public:
     ZoneViewZone(Player *_p,

--- a/cockatrice/src/game/zones/view_zone.h
+++ b/cockatrice/src/game/zones/view_zone.h
@@ -32,7 +32,7 @@ private:
     void handleDropEvent(const QList<CardDragItem *> &dragItems, CardZone *startZone, const QPoint &dropPoint);
     CardZone *origZone;
     bool revealZone, writeableRevealZone;
-    bool sortByName, sortByType;
+    CardList::SortOption groupBy, sortBy;
     bool pileView;
 
     struct GridSize
@@ -75,8 +75,8 @@ public:
     }
     void setWriteableRevealZone(bool _writeableRevealZone);
 public slots:
-    void setSortByName(int _sortByName);
-    void setSortByType(int _sortByType);
+    void setGroupBy(CardList::SortOption _groupBy);
+    void setSortBy(CardList::SortOption _sortBy);
     void setPileView(int _pileView);
 private slots:
     void zoneDumpReceived(const Response &r);

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -141,11 +141,25 @@ void ZoneViewWidget::processGroupBy(int index)
     auto option = static_cast<CardList::SortOption>(groupBySelector.itemData(index).toInt());
     SettingsCache::instance().setZoneViewGroupBy(option);
     zone->setGroupBy(option);
+
+    // reset sortBy if it has the same value as groupBy
+    if (option != CardList::NoSort &&
+        option == static_cast<CardList::SortOption>(sortBySelector.currentData().toInt())) {
+        sortBySelector.setCurrentIndex(1); // set to SortByName
+    }
 }
 
 void ZoneViewWidget::processSortBy(int index)
 {
     auto option = static_cast<CardList::SortOption>(sortBySelector.itemData(index).toInt());
+
+    // set to SortByName instead if it has the same value as groupBy
+    if (option != CardList::NoSort &&
+        option == static_cast<CardList::SortOption>(groupBySelector.currentData().toInt())) {
+        sortBySelector.setCurrentIndex(1); // set to SortByName
+        return;
+    }
+
     SettingsCache::instance().setZoneViewSortBy(option);
     zone->setSortBy(option);
 }

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -126,6 +126,10 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
         groupBySelector.setCurrentIndex(groupBySelector.findData(SettingsCache::instance().getZoneViewGroupBy()));
         sortBySelector.setCurrentIndex(sortBySelector.findData(SettingsCache::instance().getZoneViewSortBy()));
         pileViewCheckBox.setChecked(SettingsCache::instance().getZoneViewPileView());
+
+        if (CardList::NoSort == static_cast<CardList::SortOption>(groupBySelector.currentData().toInt())) {
+            pileViewCheckBox.setEnabled(false);
+        }
     }
 
     retranslateUi();

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -120,8 +120,8 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
 
     // only wire up sort options after creating ZoneViewZone, since it segfaults otherwise.
     if (numberCards < 0) {
-        connect(&groupBySelector, &QComboBox::currentIndexChanged, this, &ZoneViewWidget::processGroupBy);
-        connect(&sortBySelector, &QComboBox::currentIndexChanged, this, &ZoneViewWidget::processSortBy);
+        connect(&groupBySelector, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ZoneViewWidget::processGroupBy);
+        connect(&sortBySelector, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ZoneViewWidget::processSortBy);
         connect(&pileViewCheckBox, &QCheckBox::QT_STATE_CHANGED, this, &ZoneViewWidget::processSetPileView);
         groupBySelector.setCurrentIndex(groupBySelector.findData(SettingsCache::instance().getZoneViewGroupBy()));
         sortBySelector.setCurrentIndex(sortBySelector.findData(SettingsCache::instance().getZoneViewSortBy()));

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -120,8 +120,10 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
 
     // only wire up sort options after creating ZoneViewZone, since it segfaults otherwise.
     if (numberCards < 0) {
-        connect(&groupBySelector, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ZoneViewWidget::processGroupBy);
-        connect(&sortBySelector, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ZoneViewWidget::processSortBy);
+        connect(&groupBySelector, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+                &ZoneViewWidget::processGroupBy);
+        connect(&sortBySelector, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+                &ZoneViewWidget::processSortBy);
         connect(&pileViewCheckBox, &QCheckBox::QT_STATE_CHANGED, this, &ZoneViewWidget::processSetPileView);
         groupBySelector.setCurrentIndex(groupBySelector.findData(SettingsCache::instance().getZoneViewGroupBy()));
         sortBySelector.setCurrentIndex(sortBySelector.findData(SettingsCache::instance().getZoneViewSortBy()));

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -142,6 +142,9 @@ void ZoneViewWidget::processGroupBy(int index)
     SettingsCache::instance().setZoneViewGroupBy(option);
     zone->setGroupBy(option);
 
+    // disable pile view checkbox if we're not grouping by anything
+    pileViewCheckBox.setEnabled(option != CardList::NoSort);
+
     // reset sortBy if it has the same value as groupBy
     if (option != CardList::NoSort &&
         option == static_cast<CardList::SortOption>(sortBySelector.currentData().toInt())) {

--- a/cockatrice/src/game/zones/view_zone_widget.h
+++ b/cockatrice/src/game/zones/view_zone_widget.h
@@ -4,6 +4,7 @@
 #include "../../utility/macros.h"
 
 #include <QCheckBox>
+#include <QComboBox>
 #include <QGraphicsProxyWidget>
 #include <QGraphicsWidget>
 
@@ -14,7 +15,6 @@ class ZoneViewZone;
 class Player;
 class CardDatabase;
 class QScrollBar;
-class QCheckBox;
 class GameScene;
 class ServerInfo_Card;
 class QGraphicsSceneMouseEvent;
@@ -47,8 +47,8 @@ private:
     QPushButton *closeButton;
     QScrollBar *scrollBar;
     ScrollableGraphicsProxyWidget *scrollBarProxy;
-    QCheckBox sortByNameCheckBox;
-    QCheckBox sortByTypeCheckBox;
+    QComboBox groupBySelector;
+    QComboBox sortBySelector;
     QCheckBox shuffleCheckBox;
     QCheckBox pileViewCheckBox;
 
@@ -58,8 +58,8 @@ private:
 signals:
     void closePressed(ZoneViewWidget *zv);
 private slots:
-    void processSortByType(QT_STATE_CHANGED_T value);
-    void processSortByName(QT_STATE_CHANGED_T value);
+    void processGroupBy(int value);
+    void processSortBy(int value);
     void processSetPileView(QT_STATE_CHANGED_T value);
     void resizeToZoneContents();
     void handleScrollBarChange(int value);

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -252,8 +252,8 @@ SettingsCache::SettingsCache()
     chatMentionColor = settings->value("chat/mentioncolor", "A6120D").toString();
     chatHighlightColor = settings->value("chat/highlightcolor", "A6120D").toString();
 
-    zoneViewSortByName = settings->value("zoneview/sortbyname", true).toBool();
-    zoneViewSortByType = settings->value("zoneview/sortbytype", true).toBool();
+    zoneViewGroupBy = settings->value("zoneview/groupby", 2).toInt();
+    zoneViewSortBy = settings->value("zoneview/sortby", 1).toInt();
     zoneViewPileView = settings->value("zoneview/pileview", true).toBool();
 
     soundEnabled = settings->value("sound/enabled", false).toBool();
@@ -582,16 +582,16 @@ void SettingsCache::setChatHighlightColor(const QString &_chatHighlightColor)
     settings->setValue("chat/highlightcolor", chatHighlightColor);
 }
 
-void SettingsCache::setZoneViewSortByName(QT_STATE_CHANGED_T _zoneViewSortByName)
+void SettingsCache::setZoneViewGroupBy(int _zoneViewGroupBy)
 {
-    zoneViewSortByName = static_cast<bool>(_zoneViewSortByName);
-    settings->setValue("zoneview/sortbyname", zoneViewSortByName);
+    zoneViewGroupBy = _zoneViewGroupBy;
+    settings->setValue("zoneview/groupby", zoneViewGroupBy);
 }
 
-void SettingsCache::setZoneViewSortByType(QT_STATE_CHANGED_T _zoneViewSortByType)
+void SettingsCache::setZoneViewSortBy(int _zoneViewSortBy)
 {
-    zoneViewSortByType = static_cast<bool>(_zoneViewSortByType);
-    settings->setValue("zoneview/sortbytype", zoneViewSortByType);
+    zoneViewSortBy = _zoneViewSortBy;
+    settings->setValue("zoneview/sortby", zoneViewSortBy);
 }
 
 void SettingsCache::setZoneViewPileView(QT_STATE_CHANGED_T _zoneViewPileView)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -109,7 +109,8 @@ private:
     QString chatHighlightColor;
     bool chatMentionForeground;
     bool chatHighlightForeground;
-    bool zoneViewSortByName, zoneViewSortByType, zoneViewPileView;
+    int zoneViewSortBy, zoneViewGroupBy;
+    bool zoneViewPileView;
     bool soundEnabled;
     QString soundThemeName;
     bool ignoreUnregisteredUsers;
@@ -327,13 +328,13 @@ public:
     {
         return chatHighlightForeground;
     }
-    bool getZoneViewSortByName() const
+    int getZoneViewGroupBy() const
     {
-        return zoneViewSortByName;
+        return zoneViewGroupBy;
     }
-    bool getZoneViewSortByType() const
+    int getZoneViewSortBy() const
     {
-        return zoneViewSortByType;
+        return zoneViewSortBy;
     }
     /**
        Returns if the view should be sorted into pile view.
@@ -563,8 +564,8 @@ public slots:
     void setChatMentionCompleter(QT_STATE_CHANGED_T _chatMentionCompleter);
     void setChatMentionForeground(QT_STATE_CHANGED_T _chatMentionForeground);
     void setChatHighlightForeground(QT_STATE_CHANGED_T _chatHighlightForeground);
-    void setZoneViewSortByName(QT_STATE_CHANGED_T _zoneViewSortByName);
-    void setZoneViewSortByType(QT_STATE_CHANGED_T _zoneViewSortByType);
+    void setZoneViewGroupBy(const int _zoneViewGroupBy);
+    void setZoneViewSortBy(const int _zoneViewSortBy);
     void setZoneViewPileView(QT_STATE_CHANGED_T _zoneViewPileView);
     void setSoundEnabled(QT_STATE_CHANGED_T _soundEnabled);
     void setSoundThemeName(const QString &_soundThemeName);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -184,10 +184,10 @@ void SettingsCache::setChatMentionColor(const QString & /* _chatMentionColor */)
 void SettingsCache::setChatHighlightColor(const QString & /* _chatHighlightColor */)
 {
 }
-void SettingsCache::setZoneViewSortByName(QT_STATE_CHANGED_T /* _zoneViewSortByName */)
+void SettingsCache::setZoneViewGroupBy(int /* _zoneViewSortByName */)
 {
 }
-void SettingsCache::setZoneViewSortByType(QT_STATE_CHANGED_T /* _zoneViewSortByType */)
+void SettingsCache::setZoneViewSortBy(int /* _zoneViewSortByType */)
 {
 }
 void SettingsCache::setZoneViewPileView(QT_STATE_CHANGED_T /* _zoneViewPileView */)

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -188,10 +188,10 @@ void SettingsCache::setChatMentionColor(const QString & /* _chatMentionColor */)
 void SettingsCache::setChatHighlightColor(const QString & /* _chatHighlightColor */)
 {
 }
-void SettingsCache::setZoneViewSortByName(QT_STATE_CHANGED_T /* _zoneViewSortByName */)
+void SettingsCache::setZoneViewGroupBy(int /* _zoneViewGroupBy */)
 {
 }
-void SettingsCache::setZoneViewSortByType(QT_STATE_CHANGED_T /* _zoneViewSortByType */)
+void SettingsCache::setZoneViewSortBy(int /* _zoneViewSortBy */)
 {
 }
 void SettingsCache::setZoneViewPileView(QT_STATE_CHANGED_T /* _zoneViewPileView */)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4417 
- Fixes #4949

## What will change with this Pull Request?
https://github.com/user-attachments/assets/ae5f8a89-a95e-46b9-9422-b98ba6d88542

The `sort by name` and `sort by type` checkboxes have been replaced by two dropdown menus: `Group by X` and `Sort by X`.

With pile view disabled, the cards are first sorted by the `group by` option, and any cards that have the same value for the `group by` property will be sorted within the group with the `sort by` property. If the cards still have the same value, then we break the tie by sorting by name.

With pile view enabled, this will result in the cards displayed in piles based on the `group by` property and sorted within each pile by the `sort by` property.

Setting `Sort by ---` will turn off sorting within each pile. Setting `Group by ---` will turn off grouping (and disable the pile view checkbox until a different option is selected). Set both to `---` if you want to view the deck in its original order.

Cockatrice will automatically prevent you from selecting the same option on both, since it makes no sense to double-sort. If `Group by` option is set to the same value as the `Sort by` option, the `Sort by` option will automatically be set to `Sort by Name`. If you try to set `Sort by` to the same value as `Group by`, it will instead set the value to `Sort by Name`.

The currently selected option for the two dropdown menus will be remembered between games.

## Technical changes
- Refactored `CardList` to have `SortProperty`s that can be passed in to determine what to sort by.
- Add dropdown menus and stuff so that the new properties can be selected and then used in the sort logic.
- Changed a bunch of config stuff because those cached settings got changed from bool to enum (which we store as an int and then cast to an enum as we retrieve it).
