### PR TITLE
store sort option in settings as QComboBox index instead of enum value

### DIFF
--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -125,8 +125,8 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
         connect(&sortBySelector, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
                 &ZoneViewWidget::processSortBy);
         connect(&pileViewCheckBox, &QCheckBox::QT_STATE_CHANGED, this, &ZoneViewWidget::processSetPileView);
-        groupBySelector.setCurrentIndex(groupBySelector.findData(SettingsCache::instance().getZoneViewGroupByIndex()));
-        sortBySelector.setCurrentIndex(sortBySelector.findData(SettingsCache::instance().getZoneViewSortByIndex()));
+        groupBySelector.setCurrentIndex(SettingsCache::instance().getZoneViewGroupByIndex());
+        sortBySelector.setCurrentIndex(SettingsCache::instance().getZoneViewSortByIndex());
         pileViewCheckBox.setChecked(SettingsCache::instance().getZoneViewPileView());
 
         if (CardList::NoSort == static_cast<CardList::SortOption>(groupBySelector.currentData().toInt())) {
@@ -154,7 +154,7 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
 void ZoneViewWidget::processGroupBy(int index)
 {
     auto option = static_cast<CardList::SortOption>(groupBySelector.itemData(index).toInt());
-    SettingsCache::instance().setZoneViewGroupByIndex(option);
+    SettingsCache::instance().setZoneViewGroupByIndex(index);
     zone->setGroupBy(option);
 
     // disable pile view checkbox if we're not grouping by anything
@@ -178,7 +178,7 @@ void ZoneViewWidget::processSortBy(int index)
         return;
     }
 
-    SettingsCache::instance().setZoneViewSortByIndex(option);
+    SettingsCache::instance().setZoneViewSortByIndex(index);
     zone->setSortBy(option);
 }
 

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -125,8 +125,8 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
         connect(&sortBySelector, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
                 &ZoneViewWidget::processSortBy);
         connect(&pileViewCheckBox, &QCheckBox::QT_STATE_CHANGED, this, &ZoneViewWidget::processSetPileView);
-        groupBySelector.setCurrentIndex(groupBySelector.findData(SettingsCache::instance().getZoneViewGroupBy()));
-        sortBySelector.setCurrentIndex(sortBySelector.findData(SettingsCache::instance().getZoneViewSortBy()));
+        groupBySelector.setCurrentIndex(groupBySelector.findData(SettingsCache::instance().getZoneViewGroupByIndex()));
+        sortBySelector.setCurrentIndex(sortBySelector.findData(SettingsCache::instance().getZoneViewSortByIndex()));
         pileViewCheckBox.setChecked(SettingsCache::instance().getZoneViewPileView());
 
         if (CardList::NoSort == static_cast<CardList::SortOption>(groupBySelector.currentData().toInt())) {
@@ -154,7 +154,7 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
 void ZoneViewWidget::processGroupBy(int index)
 {
     auto option = static_cast<CardList::SortOption>(groupBySelector.itemData(index).toInt());
-    SettingsCache::instance().setZoneViewGroupBy(option);
+    SettingsCache::instance().setZoneViewGroupByIndex(option);
     zone->setGroupBy(option);
 
     // disable pile view checkbox if we're not grouping by anything
@@ -178,7 +178,7 @@ void ZoneViewWidget::processSortBy(int index)
         return;
     }
 
-    SettingsCache::instance().setZoneViewSortBy(option);
+    SettingsCache::instance().setZoneViewSortByIndex(option);
     zone->setSortBy(option);
 }
 

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -252,7 +252,7 @@ SettingsCache::SettingsCache()
     chatMentionColor = settings->value("chat/mentioncolor", "A6120D").toString();
     chatHighlightColor = settings->value("chat/highlightcolor", "A6120D").toString();
 
-    zoneViewGroupByIndex = settings->value("zoneview/groupby", 2).toInt();
+    zoneViewGroupByIndex = settings->value("zoneview/groupby", 1).toInt();
     zoneViewSortByIndex = settings->value("zoneview/sortby", 1).toInt();
     zoneViewPileView = settings->value("zoneview/pileview", true).toBool();
 

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -252,8 +252,8 @@ SettingsCache::SettingsCache()
     chatMentionColor = settings->value("chat/mentioncolor", "A6120D").toString();
     chatHighlightColor = settings->value("chat/highlightcolor", "A6120D").toString();
 
-    zoneViewGroupBy = settings->value("zoneview/groupby", 2).toInt();
-    zoneViewSortBy = settings->value("zoneview/sortby", 1).toInt();
+    zoneViewGroupByIndex = settings->value("zoneview/groupby", 2).toInt();
+    zoneViewSortByIndex = settings->value("zoneview/sortby", 1).toInt();
     zoneViewPileView = settings->value("zoneview/pileview", true).toBool();
 
     soundEnabled = settings->value("sound/enabled", false).toBool();
@@ -582,16 +582,16 @@ void SettingsCache::setChatHighlightColor(const QString &_chatHighlightColor)
     settings->setValue("chat/highlightcolor", chatHighlightColor);
 }
 
-void SettingsCache::setZoneViewGroupBy(int _zoneViewGroupBy)
+void SettingsCache::setZoneViewGroupByIndex(int _zoneViewGroupByIndex)
 {
-    zoneViewGroupBy = _zoneViewGroupBy;
-    settings->setValue("zoneview/groupby", zoneViewGroupBy);
+    zoneViewGroupByIndex = _zoneViewGroupByIndex;
+    settings->setValue("zoneview/groupby", zoneViewGroupByIndex);
 }
 
-void SettingsCache::setZoneViewSortBy(int _zoneViewSortBy)
+void SettingsCache::setZoneViewSortByIndex(int _zoneViewSortByIndex)
 {
-    zoneViewSortBy = _zoneViewSortBy;
-    settings->setValue("zoneview/sortby", zoneViewSortBy);
+    zoneViewSortByIndex = _zoneViewSortByIndex;
+    settings->setValue("zoneview/sortby", zoneViewSortByIndex);
 }
 
 void SettingsCache::setZoneViewPileView(QT_STATE_CHANGED_T _zoneViewPileView)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -109,7 +109,7 @@ private:
     QString chatHighlightColor;
     bool chatMentionForeground;
     bool chatHighlightForeground;
-    int zoneViewSortBy, zoneViewGroupBy;
+    int zoneViewSortByIndex, zoneViewGroupByIndex;
     bool zoneViewPileView;
     bool soundEnabled;
     QString soundThemeName;
@@ -328,13 +328,19 @@ public:
     {
         return chatHighlightForeground;
     }
-    int getZoneViewGroupBy() const
+    /**
+     * Currently selected index for the `Group by X` QComboBox
+     */
+    int getZoneViewGroupByIndex() const
     {
-        return zoneViewGroupBy;
+        return zoneViewGroupByIndex;
     }
-    int getZoneViewSortBy() const
+    /**
+     * Currently selected index for the `Sort by X` QComboBox
+     */
+    int getZoneViewSortByIndex() const
     {
-        return zoneViewSortBy;
+        return zoneViewSortByIndex;
     }
     /**
        Returns if the view should be sorted into pile view.
@@ -564,8 +570,8 @@ public slots:
     void setChatMentionCompleter(QT_STATE_CHANGED_T _chatMentionCompleter);
     void setChatMentionForeground(QT_STATE_CHANGED_T _chatMentionForeground);
     void setChatHighlightForeground(QT_STATE_CHANGED_T _chatHighlightForeground);
-    void setZoneViewGroupBy(const int _zoneViewGroupBy);
-    void setZoneViewSortBy(const int _zoneViewSortBy);
+    void setZoneViewGroupByIndex(const int _zoneViewGroupByIndex);
+    void setZoneViewSortByIndex(const int _zoneViewSortByIndex);
     void setZoneViewPileView(QT_STATE_CHANGED_T _zoneViewPileView);
     void setSoundEnabled(QT_STATE_CHANGED_T _soundEnabled);
     void setSoundThemeName(const QString &_soundThemeName);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -184,10 +184,10 @@ void SettingsCache::setChatMentionColor(const QString & /* _chatMentionColor */)
 void SettingsCache::setChatHighlightColor(const QString & /* _chatHighlightColor */)
 {
 }
-void SettingsCache::setZoneViewGroupBy(int /* _zoneViewSortByName */)
+void SettingsCache::setZoneViewGroupByIndex(int /* _zoneViewGroupByIndex */)
 {
 }
-void SettingsCache::setZoneViewSortBy(int /* _zoneViewSortByType */)
+void SettingsCache::setZoneViewSortByIndex(int /* _zoneViewSortByIndex */)
 {
 }
 void SettingsCache::setZoneViewPileView(QT_STATE_CHANGED_T /* _zoneViewPileView */)

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -188,10 +188,10 @@ void SettingsCache::setChatMentionColor(const QString & /* _chatMentionColor */)
 void SettingsCache::setChatHighlightColor(const QString & /* _chatHighlightColor */)
 {
 }
-void SettingsCache::setZoneViewGroupBy(int /* _zoneViewGroupBy */)
+void SettingsCache::setZoneViewGroupByIndex(int /* _zoneViewGroupByIndex */)
 {
 }
-void SettingsCache::setZoneViewSortBy(int /* _zoneViewSortBy */)
+void SettingsCache::setZoneViewSortByIndex(int /* _zoneViewSortByIndex */)
 {
 }
 void SettingsCache::setZoneViewPileView(QT_STATE_CHANGED_T /* _zoneViewPileView */)


### PR DESCRIPTION
## Related Ticket(s)
- Followup to #5206

## What will change with this Pull Request?
The settings cache now stores the sort option values as the `QComboBox` index instead of the `SortOption` enum value. That way we can add more `SortOption`s and it won't mess up existing settings if the order of the enum entries gets changed. 
(it also just makes the code cleaner)

