### PR TITLE
Pass QTime objects instead of references

### DIFF
--- a/cockatrice/src/dialogs/dlg_filter_games.cpp
+++ b/cockatrice/src/dialogs/dlg_filter_games.cpp
@@ -276,7 +276,7 @@ int DlgFilterGames::getMaxPlayersFilterMax() const
     return maxPlayersFilterMaxSpinBox->value();
 }
 
-const QTime &DlgFilterGames::getMaxGameAge() const
+QTime DlgFilterGames::getMaxGameAge() const
 {
     int index = maxGameAgeComboBox->currentIndex();
     if (index < 0 || index >= gameAgeMap.size()) { // index is out of bounds

--- a/cockatrice/src/dialogs/dlg_filter_games.h
+++ b/cockatrice/src/dialogs/dlg_filter_games.h
@@ -67,7 +67,7 @@ public:
     int getMaxPlayersFilterMin() const;
     int getMaxPlayersFilterMax() const;
     void setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlayersFilterMax);
-    const QTime &getMaxGameAge() const;
+    QTime getMaxGameAge() const;
     const QMap<QTime, QString> gameAgeMap;
     bool getShowOnlyIfSpectatorsCanWatch() const;
     bool getShowSpectatorPasswordProtected() const;


### PR DESCRIPTION
- References seem to go to 0 in newer Qt versions(?)

https://doc.qt.io/qt-6/qtime.html
> QTime objects should be passed by value rather than by reference to const; they simply package int.
