### PR TITLE
Move repeated text in sort options out of the QComboBox

### DIFF
--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -45,13 +45,37 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
     if (numberCards < 0) {
         QGraphicsLinearLayout *hFilterbox = new QGraphicsLinearLayout(Qt::Horizontal);
 
+        // groupBy label
+        groupByLabel.setFixedHeight(23);
+        groupByLabel.setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+        groupByLabel.setAlignment(Qt::AlignLeft);
+
+        QGraphicsProxyWidget *groupByLabelProxy = new QGraphicsProxyWidget;
+        groupByLabelProxy->setWidget(&groupByLabel);
+        groupByLabelProxy->setZValue(2000000008);
+        hFilterbox->addItem(groupByLabelProxy);
+
         // groupBy options
+        groupBySelector.setFixedHeight(23);
+
         QGraphicsProxyWidget *groupBySelectorProxy = new QGraphicsProxyWidget;
         groupBySelectorProxy->setWidget(&groupBySelector);
         groupBySelectorProxy->setZValue(2000000008);
         hFilterbox->addItem(groupBySelectorProxy);
 
+        // sortBy label
+        sortByLabel.setFixedHeight(23);
+        sortByLabel.setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+        sortByLabel.setAlignment(Qt::AlignLeft);
+
+        QGraphicsProxyWidget *sortByLabelProxy = new QGraphicsProxyWidget;
+        sortByLabelProxy->setWidget(&sortByLabel);
+        sortByLabelProxy->setZValue(2000000007);
+        hFilterbox->addItem(sortByLabelProxy);
+
         // sortBy options
+        sortBySelector.setFixedHeight(23);
+
         QGraphicsProxyWidget *sortBySelectorProxy = new QGraphicsProxyWidget;
         sortBySelectorProxy->setWidget(&sortBySelector);
         sortBySelectorProxy->setZValue(2000000007);
@@ -185,22 +209,25 @@ void ZoneViewWidget::retranslateUi()
 {
     setWindowTitle(zone->getTranslatedName(false, CaseNominative));
 
+    groupByLabel.setText(tr("Group by"));
+    sortByLabel.setText(tr("Sort by"));
+
     { // We can't change the strings after they're put into the QComboBox, so this is our workaround
         int oldIndex = sortBySelector.currentIndex();
         sortBySelector.clear();
-        sortBySelector.addItem(tr("Sort by ---"), CardList::NoSort);
-        sortBySelector.addItem(tr("Sort by Name"), CardList::SortByName);
-        sortBySelector.addItem(tr("Sort by Type"), CardList::SortByType);
-        sortBySelector.addItem(tr("Sort by Mana Value"), CardList::SortByManaValue);
+        sortBySelector.addItem(tr("---"), CardList::NoSort);
+        sortBySelector.addItem(tr("Name"), CardList::SortByName);
+        sortBySelector.addItem(tr("Type"), CardList::SortByType);
+        sortBySelector.addItem(tr("Mana Value"), CardList::SortByManaValue);
         sortBySelector.setCurrentIndex(oldIndex);
     }
 
     {
         int oldIndex = groupBySelector.currentIndex();
         groupBySelector.clear();
-        groupBySelector.addItem(tr("Group by ---"), CardList::NoSort);
-        groupBySelector.addItem(tr("Group by Type"), CardList::SortByType);
-        groupBySelector.addItem(tr("Group by Mana Value"), CardList::SortByManaValue);
+        groupBySelector.addItem(tr("---"), CardList::NoSort);
+        groupBySelector.addItem(tr("Type"), CardList::SortByType);
+        groupBySelector.addItem(tr("Mana Value"), CardList::SortByManaValue);
         groupBySelector.setCurrentIndex(oldIndex);
     }
 

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -213,6 +213,15 @@ void ZoneViewWidget::retranslateUi()
     sortByLabel.setText(tr("Sort by"));
 
     { // We can't change the strings after they're put into the QComboBox, so this is our workaround
+        int oldIndex = groupBySelector.currentIndex();
+        groupBySelector.clear();
+        groupBySelector.addItem(tr("---"), CardList::NoSort);
+        groupBySelector.addItem(tr("Type"), CardList::SortByType);
+        groupBySelector.addItem(tr("Mana Value"), CardList::SortByManaValue);
+        groupBySelector.setCurrentIndex(oldIndex);
+    }
+
+    {
         int oldIndex = sortBySelector.currentIndex();
         sortBySelector.clear();
         sortBySelector.addItem(tr("---"), CardList::NoSort);
@@ -220,15 +229,6 @@ void ZoneViewWidget::retranslateUi()
         sortBySelector.addItem(tr("Type"), CardList::SortByType);
         sortBySelector.addItem(tr("Mana Value"), CardList::SortByManaValue);
         sortBySelector.setCurrentIndex(oldIndex);
-    }
-
-    {
-        int oldIndex = groupBySelector.currentIndex();
-        groupBySelector.clear();
-        groupBySelector.addItem(tr("---"), CardList::NoSort);
-        groupBySelector.addItem(tr("Type"), CardList::SortByType);
-        groupBySelector.addItem(tr("Mana Value"), CardList::SortByManaValue);
-        groupBySelector.setCurrentIndex(oldIndex);
     }
 
     shuffleCheckBox.setText(tr("shuffle when closing"));

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -43,7 +43,6 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
 
     // If the number is < 0, then it means that we can give the option to make the area sorted
     if (numberCards < 0) {
-        QGraphicsLinearLayout *hPilebox = new QGraphicsLinearLayout(Qt::Horizontal);
         QGraphicsLinearLayout *hFilterbox = new QGraphicsLinearLayout(Qt::Horizontal);
 
         // groupBy options
@@ -67,6 +66,8 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
         line->setFrameShadow(QFrame::Sunken);
         lineProxy->setWidget(line);
         vbox->addItem(lineProxy);
+
+        QGraphicsLinearLayout *hPilebox = new QGraphicsLinearLayout(Qt::Horizontal);
 
         // pile view options
         QGraphicsProxyWidget *pileViewProxy = new QGraphicsProxyWidget;

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -54,6 +54,7 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
         groupByLabelProxy->setWidget(&groupByLabel);
         groupByLabelProxy->setZValue(2000000008);
         hFilterbox->addItem(groupByLabelProxy);
+        hFilterbox->setItemSpacing(0, 0);
 
         // groupBy options
         groupBySelector.setFixedHeight(23);
@@ -63,6 +64,7 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
         groupBySelectorProxy->setZValue(2000000008);
         groupBySelectorProxy->setMinimumWidth(120);
         hFilterbox->addItem(groupBySelectorProxy);
+        hFilterbox->setItemSpacing(1, 1);
 
         // sortBy label
         sortByLabel.setFixedHeight(23);
@@ -73,6 +75,7 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
         sortByLabelProxy->setWidget(&sortByLabel);
         sortByLabelProxy->setZValue(2000000007);
         hFilterbox->addItem(sortByLabelProxy);
+        hFilterbox->setItemSpacing(2, 0);
 
         // sortBy options
         sortBySelector.setFixedHeight(23);
@@ -82,6 +85,7 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
         sortBySelectorProxy->setZValue(2000000007);
         sortBySelectorProxy->setMinimumWidth(120);
         hFilterbox->addItem(sortBySelectorProxy);
+        hFilterbox->setItemSpacing(3, 1);
 
         vbox->addItem(hFilterbox);
 

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -61,6 +61,7 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
         QGraphicsProxyWidget *groupBySelectorProxy = new QGraphicsProxyWidget;
         groupBySelectorProxy->setWidget(&groupBySelector);
         groupBySelectorProxy->setZValue(2000000008);
+        groupBySelectorProxy->setMinimumWidth(120);
         hFilterbox->addItem(groupBySelectorProxy);
 
         // sortBy label
@@ -79,6 +80,7 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
         QGraphicsProxyWidget *sortBySelectorProxy = new QGraphicsProxyWidget;
         sortBySelectorProxy->setWidget(&sortBySelector);
         sortBySelectorProxy->setZValue(2000000007);
+        sortBySelectorProxy->setMinimumWidth(120);
         hFilterbox->addItem(sortBySelectorProxy);
 
         vbox->addItem(hFilterbox);

--- a/cockatrice/src/game/zones/view_zone_widget.h
+++ b/cockatrice/src/game/zones/view_zone_widget.h
@@ -7,8 +7,8 @@
 #include <QComboBox>
 #include <QGraphicsProxyWidget>
 #include <QGraphicsWidget>
+#include <QLabel>
 
-class QLabel;
 class QPushButton;
 class CardZone;
 class ZoneViewZone;
@@ -47,6 +47,8 @@ private:
     QPushButton *closeButton;
     QScrollBar *scrollBar;
     ScrollableGraphicsProxyWidget *scrollBarProxy;
+    QLabel groupByLabel;
+    QLabel sortByLabel;
     QComboBox groupBySelector;
     QComboBox sortBySelector;
     QCheckBox shuffleCheckBox;


### PR DESCRIPTION
## What will change with this Pull Request?
- The `Group by` and `Sort by` text is now a text label beside the `QComboBox` instead of being part of the entry.
- Forced the `QComboBox` to have a minimum width.
  - This does mean that zone views with small number of cards are now wider than before 
- Small refactors
  - reordered the `QComboBox` resetting in `retranslateUi` because I realized that it was in the opposite order from what we do everywhere else 

## Screenshots
<img width="380" alt="Screenshot 2024-11-29 at 11 11 07 PM" src="https://github.com/user-attachments/assets/5a4d2ef2-07ce-4faf-bd61-2c09fb604767">
<img width="380" alt="Screenshot 2024-11-29 at 11 12 21 PM" src="https://github.com/user-attachments/assets/04761174-ab89-4677-98b8-f8b75b9087b7">
<img width="380" alt="Screenshot 2024-11-29 at 11 10 33 PM" src="https://github.com/user-attachments/assets/f2a7db4a-3ee8-479c-9bb0-1c0c9b887308">

