### PR TITLE
fix bug where zone view with single card has wrong height

### DIFF
--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -196,7 +196,7 @@ ZoneViewZone::GridSize ZoneViewZone::positionCardsForDisplay(CardList &cards, Ca
         return GridSize{longestRow, qMax(col + 1, 3)};
 
     } else {
-        int cols = qMin(qFloor(qSqrt((double)cardCount / 2)), 7);
+        int cols = qBound(1, qFloor(qSqrt((double)cardCount / 2)), 7);
         int rows = qMax(qCeil((double)cardCount / cols), 1);
         if (minRows == 0) {
             minRows = rows;


### PR DESCRIPTION
## Short roundup of the initial problem
A (non-pile view) zone view containing a single card has the height for a zone view with zero cards.

## What will change with this Pull Request?
- Fix divide by zero bug

## Screenshots
<-- Before Fix
After Fix -->

<img height="267" alt="Screenshot 2024-11-30 at 12 15 17 AM" src="https://github.com/user-attachments/assets/ec632edc-16fe-47ad-be50-3b90871db5e0">
<img height ="267" alt="Screenshot 2024-11-30 at 12 11 28 AM" src="https://github.com/user-attachments/assets/1759449c-05ee-4866-af3e-b6bd9786d21c">

