### PR TITLE
fix bug where piling zone view is too short 

### DIFF
--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -193,7 +193,9 @@ ZoneViewZone::GridSize ZoneViewZone::positionCardsForDisplay(CardList &cards, Ca
             longestRow = qMax(row, longestRow);
         }
 
-        return GridSize{longestRow, qMax(col + 1, 3)};
+        // +1 because the row/col variables used in the calculations are 0-indexed but
+        // GridSize expects the actual row/col count
+        return GridSize{longestRow + 1, qMax(col + 1, 3)};
 
     } else {
         int cols = qMin(qFloor(qSqrt((double)cardCount / 2)), 7);


### PR DESCRIPTION
## Short roundup of the initial problem
A zone view with piling enabled has height equal to a non-piling zone view that has one less row.

## What will change with this Pull Request?
- fix off-by-one error

## Screenshots
<-- Before Fix
After Fix -->

<img height="280" alt="Screenshot 2024-11-30 at 1 18 03 AM" src="https://github.com/user-attachments/assets/2fbc3d5c-1f86-490d-8e32-86a087f3c773"><img height ="280" alt="Screenshot 2024-11-30 at 1 14 45 AM" src="https://github.com/user-attachments/assets/70b58abd-5e13-4f29-9866-16d2ff726704">


