### PR TITLE
rename and refactor some stuff in ZoneViewWidget

### DIFF
--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -185,6 +185,15 @@ void ZoneViewWidget::retranslateUi()
     setWindowTitle(zone->getTranslatedName(false, CaseNominative));
 
     { // We can't change the strings after they're put into the QComboBox, so this is our workaround
+        int oldIndex = groupBySelector.currentIndex();
+        groupBySelector.clear();
+        groupBySelector.addItem(tr("Group by ---"), CardList::NoSort);
+        groupBySelector.addItem(tr("Group by Type"), CardList::SortByType);
+        groupBySelector.addItem(tr("Group by Mana Value"), CardList::SortByManaValue);
+        groupBySelector.setCurrentIndex(oldIndex);
+    }
+
+    {
         int oldIndex = sortBySelector.currentIndex();
         sortBySelector.clear();
         sortBySelector.addItem(tr("Sort by ---"), CardList::NoSort);
@@ -192,15 +201,6 @@ void ZoneViewWidget::retranslateUi()
         sortBySelector.addItem(tr("Sort by Type"), CardList::SortByType);
         sortBySelector.addItem(tr("Sort by Mana Value"), CardList::SortByManaValue);
         sortBySelector.setCurrentIndex(oldIndex);
-    }
-
-    {
-        int oldIndex = groupBySelector.currentIndex();
-        groupBySelector.clear();
-        groupBySelector.addItem(tr("Group by ---"), CardList::NoSort);
-        groupBySelector.addItem(tr("Group by Type"), CardList::SortByType);
-        groupBySelector.addItem(tr("Group by Mana Value"), CardList::SortByManaValue);
-        groupBySelector.setCurrentIndex(oldIndex);
     }
 
     shuffleCheckBox.setText(tr("shuffle when closing"));

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -136,6 +136,8 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
     connect(zone, SIGNAL(beingDeleted()), this, SLOT(zoneDeleted()));
     zone->initializeCards(cardList);
 
+    // QLabel sizes aren't taken into account until the widget is rendered.
+    // Force refresh after 1ms to fix glitchy rendering with long QLabels.
     auto *lastResizeBeforeVisibleTimer = new QTimer(this);
     connect(lastResizeBeforeVisibleTimer, &QTimer::timeout, this, [=] {
         resizeToZoneContents();

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -43,7 +43,7 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
 
     // If the number is < 0, then it means that we can give the option to make the area sorted
     if (numberCards < 0) {
-        QGraphicsLinearLayout *hPilebox = new QGraphicsLinearLayout(Qt::Horizontal);
+        // top row
         QGraphicsLinearLayout *hFilterbox = new QGraphicsLinearLayout(Qt::Horizontal);
 
         // groupBy options
@@ -67,6 +67,9 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
         line->setFrameShadow(QFrame::Sunken);
         lineProxy->setWidget(line);
         vbox->addItem(lineProxy);
+
+        // bottom row
+        QGraphicsLinearLayout *hPilebox = new QGraphicsLinearLayout(Qt::Horizontal);
 
         // pile view options
         QGraphicsProxyWidget *pileViewProxy = new QGraphicsProxyWidget;

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -44,21 +44,21 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
     // If the number is < 0, then it means that we can give the option to make the area sorted
     if (numberCards < 0) {
         // top row
-        QGraphicsLinearLayout *hFilterbox = new QGraphicsLinearLayout(Qt::Horizontal);
+        QGraphicsLinearLayout *hTopRow = new QGraphicsLinearLayout(Qt::Horizontal);
 
         // groupBy options
         QGraphicsProxyWidget *groupBySelectorProxy = new QGraphicsProxyWidget;
         groupBySelectorProxy->setWidget(&groupBySelector);
         groupBySelectorProxy->setZValue(2000000008);
-        hFilterbox->addItem(groupBySelectorProxy);
+        hTopRow->addItem(groupBySelectorProxy);
 
         // sortBy options
         QGraphicsProxyWidget *sortBySelectorProxy = new QGraphicsProxyWidget;
         sortBySelectorProxy->setWidget(&sortBySelector);
         sortBySelectorProxy->setZValue(2000000007);
-        hFilterbox->addItem(sortBySelectorProxy);
+        hTopRow->addItem(sortBySelectorProxy);
 
-        vbox->addItem(hFilterbox);
+        vbox->addItem(hTopRow);
 
         // line
         QGraphicsProxyWidget *lineProxy = new QGraphicsProxyWidget;
@@ -69,22 +69,22 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
         vbox->addItem(lineProxy);
 
         // bottom row
-        QGraphicsLinearLayout *hPilebox = new QGraphicsLinearLayout(Qt::Horizontal);
+        QGraphicsLinearLayout *hBottomRow = new QGraphicsLinearLayout(Qt::Horizontal);
 
         // pile view options
         QGraphicsProxyWidget *pileViewProxy = new QGraphicsProxyWidget;
         pileViewProxy->setWidget(&pileViewCheckBox);
-        hPilebox->addItem(pileViewProxy);
+        hBottomRow->addItem(pileViewProxy);
 
         // shuffle options
         if (_origZone->getIsShufflable() && numberCards == -1) {
             shuffleCheckBox.setChecked(true);
             QGraphicsProxyWidget *shuffleProxy = new QGraphicsProxyWidget;
             shuffleProxy->setWidget(&shuffleCheckBox);
-            hPilebox->addItem(shuffleProxy);
+            hBottomRow->addItem(shuffleProxy);
         }
 
-        vbox->addItem(hPilebox);
+        vbox->addItem(hBottomRow);
     }
 
     extraHeight = vbox->sizeHint(Qt::PreferredSize).height();


### PR DESCRIPTION
## Related Ticket(s)
- Contains some refactorings from #5210

## What will change with this Pull Request?
- reordered the QComboBox resetting in retranslateUi because I realized that it was in the opposite order from what we do everywhere else
- renamed the `QGraphicsLinearLayout` variables since the names are outdated at this point
- added a comment for #5204 since it isn't obvious why we need to do that
