### PR TITLE
add option to show keyboard shortcuts in right click menu

### DIFF
--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -326,6 +326,8 @@ AppearanceSettingsPage::AppearanceSettingsPage()
 
     // Menu settings
     showShortcutsCheckBox.setChecked(settings.getShowShortcuts());
+    connect(&showShortcutsCheckBox, &QCheckBox::QT_STATE_CHANGED, this, &AppearanceSettingsPage::showShortcutsChanged);
+
     auto *menuGrid = new QGridLayout;
     menuGrid->addWidget(&showShortcutsCheckBox, 0, 0);
 
@@ -424,6 +426,12 @@ void AppearanceSettingsPage::openThemeLocation()
     } else {
         QMessageBox::critical(this, tr("Error"), tr("Could not create themes directory at '%1'.").arg(dir));
     }
+}
+
+void AppearanceSettingsPage::showShortcutsChanged(QT_STATE_CHANGED_T value)
+{
+    SettingsCache::instance().setShowShortcuts(value);
+    qApp->setAttribute(Qt::AA_DontShowShortcutsInContextMenus, value == 0); // 0 = unchecked
 }
 
 void AppearanceSettingsPage::retranslateUi()

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -324,6 +324,14 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     themeGroupBox = new QGroupBox;
     themeGroupBox->setLayout(themeGrid);
 
+    // Menu settings
+    showShortcutsCheckBox.setChecked(settings.getShowShortcuts());
+    auto *menuGrid = new QGridLayout;
+    menuGrid->addWidget(&showShortcutsCheckBox, 0, 0);
+
+    menuGroupBox = new QGroupBox;
+    menuGroupBox->setLayout(menuGrid);
+
     // Card rendering
     displayCardNamesCheckBox.setChecked(settings.getDisplayCardNames());
     connect(&displayCardNamesCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings, &SettingsCache::setDisplayCardNames);
@@ -389,6 +397,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     // putting it all together
     auto *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(themeGroupBox);
+    mainLayout->addWidget(menuGroupBox);
     mainLayout->addWidget(cardsGroupBox);
     mainLayout->addWidget(handGroupBox);
     mainLayout->addWidget(tableGroupBox);
@@ -422,6 +431,9 @@ void AppearanceSettingsPage::retranslateUi()
     themeGroupBox->setTitle(tr("Theme settings"));
     themeLabel.setText(tr("Current theme:"));
     openThemeButton.setText(tr("Open themes folder"));
+
+    menuGroupBox->setTitle(tr("Menu settings"));
+    showShortcutsCheckBox.setText(tr("Show keyboard shortcuts in right-click menus"));
 
     cardsGroupBox->setTitle(tr("Card rendering"));
     displayCardNamesCheckBox.setText(tr("Display card names on cards having a picture"));

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -302,6 +302,8 @@ void GeneralSettingsPage::retranslateUi()
 AppearanceSettingsPage::AppearanceSettingsPage()
 {
     SettingsCache &settings = SettingsCache::instance();
+
+    // Theme settings
     QString themeName = SettingsCache::instance().getThemeName();
 
     QStringList themeDirs = themeManager->getAvailableThemes().keys();
@@ -322,6 +324,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     themeGroupBox = new QGroupBox;
     themeGroupBox->setLayout(themeGrid);
 
+    // Card rendering
     displayCardNamesCheckBox.setChecked(settings.getDisplayCardNames());
     connect(&displayCardNamesCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings, &SettingsCache::setDisplayCardNames);
 
@@ -342,6 +345,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     cardsGroupBox = new QGroupBox;
     cardsGroupBox->setLayout(cardsGrid);
 
+    // Hand layout
     horizontalHandCheckBox.setChecked(settings.getHorizontalHand());
     connect(&horizontalHandCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings, &SettingsCache::setHorizontalHand);
 
@@ -355,6 +359,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     handGroupBox = new QGroupBox;
     handGroupBox->setLayout(handGrid);
 
+    // table grid layout
     invertVerticalCoordinateCheckBox.setChecked(settings.getInvertVerticalCoordinate());
     connect(&invertVerticalCoordinateCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings,
             &SettingsCache::setInvertVerticalCoordinate);
@@ -381,6 +386,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     tableGroupBox = new QGroupBox;
     tableGroupBox->setLayout(tableGrid);
 
+    // putting it all together
     auto *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(themeGroupBox);
     mainLayout->addWidget(cardsGroupBox);

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -90,6 +90,7 @@ private:
     QPushButton openThemeButton;
     QLabel minPlayersForMultiColumnLayoutLabel;
     QLabel maxFontSizeForCardsLabel;
+    QCheckBox showShortcutsCheckBox;
     QCheckBox displayCardNamesCheckBox;
     QCheckBox cardScalingCheckBox;
     QLabel verticalCardOverlapPercentLabel;
@@ -98,6 +99,7 @@ private:
     QCheckBox leftJustifiedHandCheckBox;
     QCheckBox invertVerticalCoordinateCheckBox;
     QGroupBox *themeGroupBox;
+    QGroupBox *menuGroupBox;
     QGroupBox *cardsGroupBox;
     QGroupBox *handGroupBox;
     QGroupBox *tableGroupBox;

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -83,6 +83,7 @@ class AppearanceSettingsPage : public AbstractSettingsPage
 private slots:
     void themeBoxChanged(int index);
     void openThemeLocation();
+    void showShortcutsChanged(QT_STATE_CHANGED_T enabled);
 
 private:
     QLabel themeLabel;

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -180,6 +180,9 @@ int main(int argc, char *argv[])
     ui.show();
     qDebug("main(): ui.show() finished");
 
+    // If enabled, force shortcuts to be shown in right-click menus regardless of system defaults
+    qApp->setAttribute(Qt::AA_DontShowShortcutsInContextMenus, !SettingsCache::instance().getShowShortcuts());
+
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     app.setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
     ui.show();
     qDebug("main(): ui.show() finished");
 
-    // If enabled, force shortcuts to be shown in right-click menus regardless of system defaults
+    // force shortcuts to be shown/hidden in right-click menus, regardless of system defaults
     qApp->setAttribute(Qt::AA_DontShowShortcutsInContextMenus, !SettingsCache::instance().getShowShortcuts());
 
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -509,7 +509,7 @@ void SettingsCache::setTabGameSplitterSizes(const QByteArray &_tabGameSplitterSi
 void SettingsCache::setShowShortcuts(QT_STATE_CHANGED_T _showShortcuts)
 {
     showShortcuts = static_cast<bool>(_showShortcuts);
-    settings->setValue("menu/ShowShortcuts", showShortcuts);
+    settings->setValue("menu/showshortcuts", showShortcuts);
 }
 
 void SettingsCache::setDisplayCardNames(QT_STATE_CHANGED_T _displayCardNames)

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -239,6 +239,7 @@ SettingsCache::SettingsCache()
     knownMissingFeatures = settings->value("interface/knownmissingfeatures", "").toString();
     useTearOffMenus = settings->value("interface/usetearoffmenus", true).toBool();
 
+    showShortcuts = settings->value("menu/showshortcuts", true).toBool();
     displayCardNames = settings->value("cards/displaycardnames", true).toBool();
     horizontalHand = settings->value("hand/horizontal", true).toBool();
     invertVerticalCoordinate = settings->value("table/invert_vertical", false).toBool();
@@ -503,6 +504,12 @@ void SettingsCache::setTabGameSplitterSizes(const QByteArray &_tabGameSplitterSi
 {
     tabGameSplitterSizes = _tabGameSplitterSizes;
     settings->setValue("interface/tabgame_splittersizes", tabGameSplitterSizes);
+}
+
+void SettingsCache::setShowShortcuts(QT_STATE_CHANGED_T _showShortcuts)
+{
+    showShortcuts = static_cast<bool>(_showShortcuts);
+    settings->setValue("menu/ShowShortcuts", showShortcuts);
 }
 
 void SettingsCache::setDisplayCardNames(QT_STATE_CHANGED_T _displayCardNames)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -97,6 +97,7 @@ private:
     int startingHandSize;
     bool annotateTokens;
     QByteArray tabGameSplitterSizes;
+    bool showShortcuts;
     bool displayCardNames;
     bool horizontalHand;
     bool invertVerticalCoordinate;
@@ -287,6 +288,10 @@ public:
     QByteArray getTabGameSplitterSizes() const
     {
         return tabGameSplitterSizes;
+    }
+    bool getShowShortcuts() const
+    {
+        return showShortcuts;
     }
     bool getDisplayCardNames() const
     {
@@ -560,6 +565,7 @@ public slots:
     void setStartingHandSize(int _startingHandSize);
     void setAnnotateTokens(QT_STATE_CHANGED_T _annotateTokens);
     void setTabGameSplitterSizes(const QByteArray &_tabGameSplitterSizes);
+    void setShowShortcuts(QT_STATE_CHANGED_T _showShortcuts);
     void setDisplayCardNames(QT_STATE_CHANGED_T _displayCardNames);
     void setHorizontalHand(QT_STATE_CHANGED_T _horizontalHand);
     void setInvertVerticalCoordinate(QT_STATE_CHANGED_T _invertVerticalCoordinate);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -148,6 +148,9 @@ void SettingsCache::setAnnotateTokens(QT_STATE_CHANGED_T /* _annotateTokens */)
 void SettingsCache::setTabGameSplitterSizes(const QByteArray & /* _tabGameSplitterSizes */)
 {
 }
+void SettingsCache::setShowShortcuts(QT_STATE_CHANGED_T /* _showShortcuts */)
+{
+}
 void SettingsCache::setDisplayCardNames(QT_STATE_CHANGED_T /* _displayCardNames */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -152,6 +152,9 @@ void SettingsCache::setAnnotateTokens(QT_STATE_CHANGED_T /* _annotateTokens */)
 void SettingsCache::setTabGameSplitterSizes(const QByteArray & /* _tabGameSplitterSizes */)
 {
 }
+void SettingsCache::setShowShortcuts(QT_STATE_CHANGED_T /* _showShortcuts */)
+{
+}
 void SettingsCache::setDisplayCardNames(QT_STATE_CHANGED_T /* _displayCardNames */)
 {
 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3878

## What will change with this Pull Request?
https://github.com/user-attachments/assets/f0329ec3-90d6-4208-82f1-53932cfa64ff

- Added setting `Appearance -> Menu items -> Show keyboard shortcuts in right-click menus`
- if the setting is enabled, we set the `Qt::AA_DontShowShortcutsInContextMenus` attribute to false, which forces shortcuts to be shown in right-click menus
  - we set the attribute on startup in `main.cc` as well as when the setting is changed
  
## Screenshots
<img width="500" alt="Screenshot 2024-12-05 at 2 48 29 AM" src="https://github.com/user-attachments/assets/b40c4eba-ba60-45ab-beec-4a7bf1ba746d">
<img width="500" alt="Screenshot 2024-12-05 at 2 52 27 AM" src="https://github.com/user-attachments/assets/a036ab09-f23e-409e-a8bc-88034fba6dee">


## Screenshots

