### PR TITLE
make rewind buffering timeout configurable

### DIFF
--- a/cockatrice/src/client/network/replay_timeline_widget.cpp
+++ b/cockatrice/src/client/network/replay_timeline_widget.cpp
@@ -106,18 +106,11 @@ void ReplayTimelineWidget::handleBackwardsSkip(bool doRewindBuffering)
         // The rewind only happens once the timer runs out.
         // If another backwards skip happens, the timer will just get reset instead of rewinding.
         rewindBufferingTimer->stop();
-        rewindBufferingTimer->start(calcRewindBufferingTimeout());
+        rewindBufferingTimer->start(SettingsCache::instance().getRewindBufferingMs());
     } else {
         // otherwise, process the rewind immediately
         processRewind();
     }
-}
-
-/// The timeout scales based on the current event number, up to a limit
-int ReplayTimelineWidget::calcRewindBufferingTimeout() const
-{
-    int extraTime = currentEvent / 100;
-    return std::min(BASE_REWIND_BUFFERING_TIMEOUT_MS + extraTime, MAX_REWIND_BUFFERING_TIMEOUT_MS);
 }
 
 void ReplayTimelineWidget::processRewind()

--- a/cockatrice/src/client/network/replay_timeline_widget.h
+++ b/cockatrice/src/client/network/replay_timeline_widget.h
@@ -28,8 +28,6 @@ private:
 
     static constexpr int TIMER_INTERVAL_MS = 200;
     static constexpr int BIN_LENGTH = 5000;
-    static constexpr int BASE_REWIND_BUFFERING_TIMEOUT_MS = 180;
-    static constexpr int MAX_REWIND_BUFFERING_TIMEOUT_MS = 280;
 
     QTimer *replayTimer;
     QTimer *rewindBufferingTimer;
@@ -42,7 +40,6 @@ private:
 
     void skipToTime(int newTime, bool doRewindBuffering);
     void handleBackwardsSkip(bool doRewindBuffering);
-    int calcRewindBufferingTimeout() const;
     void processRewind();
     void processNewEvents(PlaybackMode playbackMode);
 private slots:

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -559,7 +559,7 @@ void UserInterfaceSettingsPage::retranslateUi()
     deckEditorGroupBox->setTitle(tr("Deck editor settings"));
     openDeckInNewTabCheckBox.setText(tr("Always open deck in new tab"));
     replayGroupBox->setTitle(tr("Replay settings"));
-    rewindBufferingMsLabel.setText(tr("Amount of time to buffer a backwards skip from keyboard shortcut by:"));
+    rewindBufferingMsLabel.setText(tr("Buffer time for backwards skip via shortcut:"));
     rewindBufferingMsBox.setSuffix(tr(" ms"));
 }
 

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -509,8 +509,8 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     deckEditorGroupBox->setLayout(deckEditorGrid);
 
     // replay settings
-    rewindBufferingMsBox.setValue(SettingsCache::instance().getRewindBufferingMs());
     rewindBufferingMsBox.setRange(0, 9999);
+    rewindBufferingMsBox.setValue(SettingsCache::instance().getRewindBufferingMs());
     connect(&rewindBufferingMsBox, qOverload<int>(&QSpinBox::valueChanged), &SettingsCache::instance(),
             &SettingsCache::setRewindBufferingMs);
 

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -511,7 +511,7 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     // replay settings
     rewindBufferingMsBox.setValue(SettingsCache::instance().getRewindBufferingMs());
     rewindBufferingMsBox.setRange(0, 9999);
-    connect(&rewindBufferingMsBox, &QSpinBox::valueChanged, &SettingsCache::instance(),
+    connect(&rewindBufferingMsBox, qOverload<int>(&QSpinBox::valueChanged), &SettingsCache::instance(),
             &SettingsCache::setRewindBufferingMs);
 
     auto *replayGrid = new QGridLayout;

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -508,12 +508,26 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     deckEditorGroupBox = new QGroupBox;
     deckEditorGroupBox->setLayout(deckEditorGrid);
 
+    // replay settings
+    rewindBufferingMsBox.setValue(SettingsCache::instance().getRewindBufferingMs());
+    rewindBufferingMsBox.setRange(0, 9999);
+    connect(&rewindBufferingMsBox, &QSpinBox::valueChanged, &SettingsCache::instance(),
+            &SettingsCache::setRewindBufferingMs);
+
+    auto *replayGrid = new QGridLayout;
+    replayGrid->addWidget(&rewindBufferingMsLabel, 0, 0, 1, 1);
+    replayGrid->addWidget(&rewindBufferingMsBox, 0, 1, 1, 1);
+
+    replayGroupBox = new QGroupBox;
+    replayGroupBox->setLayout(replayGrid);
+
     // putting it all together
     auto *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(generalGroupBox);
     mainLayout->addWidget(notificationsGroupBox);
     mainLayout->addWidget(animationGroupBox);
     mainLayout->addWidget(deckEditorGroupBox);
+    mainLayout->addWidget(replayGroupBox);
     mainLayout->addStretch();
 
     setLayout(mainLayout);
@@ -544,6 +558,9 @@ void UserInterfaceSettingsPage::retranslateUi()
     tapAnimationCheckBox.setText(tr("&Tap/untap animation"));
     deckEditorGroupBox->setTitle(tr("Deck editor settings"));
     openDeckInNewTabCheckBox.setText(tr("Always open deck in new tab"));
+    replayGroupBox->setTitle(tr("Replay settings"));
+    rewindBufferingMsLabel.setText(tr("Amount of time to buffer a backwards skip from keyboard shortcut by:"));
+    rewindBufferingMsBox.setSuffix(tr(" ms"));
 }
 
 DeckEditorSettingsPage::DeckEditorSettingsPage()

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -125,10 +125,13 @@ private:
     QCheckBox useTearOffMenusCheckBox;
     QCheckBox tapAnimationCheckBox;
     QCheckBox openDeckInNewTabCheckBox;
+    QLabel rewindBufferingMsLabel;
+    QSpinBox rewindBufferingMsBox;
     QGroupBox *generalGroupBox;
     QGroupBox *notificationsGroupBox;
     QGroupBox *animationGroupBox;
     QGroupBox *deckEditorGroupBox;
+    QGroupBox *replayGroupBox;
 
 public:
     UserInterfaceSettingsPage();

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -245,7 +245,7 @@ SettingsCache::SettingsCache()
     minPlayersForMultiColumnLayout = settings->value("interface/min_players_multicolumn", 4).toInt();
     tapAnimation = settings->value("cards/tapanimation", true).toBool();
     openDeckInNewTab = settings->value("editor/openDeckInNewTab", false).toBool();
-    rewindBufferingMs = settings->value("replay/rewindBufferingMs", 200).toBool();
+    rewindBufferingMs = settings->value("replay/rewindBufferingMs", 200).toInt();
     chatMention = settings->value("chat/mention", true).toBool();
     chatMentionCompleter = settings->value("chat/mentioncompleter", true).toBool();
     chatMentionForeground = settings->value("chat/mentionforeground", true).toBool();

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -245,6 +245,7 @@ SettingsCache::SettingsCache()
     minPlayersForMultiColumnLayout = settings->value("interface/min_players_multicolumn", 4).toInt();
     tapAnimation = settings->value("cards/tapanimation", true).toBool();
     openDeckInNewTab = settings->value("editor/openDeckInNewTab", false).toBool();
+    rewindBufferingMs = settings->value("replay/rewindBufferingMs", 200).toBool();
     chatMention = settings->value("chat/mention", true).toBool();
     chatMentionCompleter = settings->value("chat/mentioncompleter", true).toBool();
     chatMentionForeground = settings->value("chat/mentionforeground", true).toBool();
@@ -543,6 +544,12 @@ void SettingsCache::setOpenDeckInNewTab(QT_STATE_CHANGED_T _openDeckInNewTab)
 {
     openDeckInNewTab = static_cast<bool>(_openDeckInNewTab);
     settings->setValue("editor/openDeckInNewTab", openDeckInNewTab);
+}
+
+void SettingsCache::setRewindBufferingMs(int _rewindBufferingMs)
+{
+    rewindBufferingMs = _rewindBufferingMs;
+    settings->setValue("replay/rewindBufferingMs", rewindBufferingMs);
 }
 
 void SettingsCache::setChatMention(QT_STATE_CHANGED_T _chatMention)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -103,6 +103,7 @@ private:
     int minPlayersForMultiColumnLayout;
     bool tapAnimation;
     bool openDeckInNewTab;
+    int rewindBufferingMs;
     bool chatMention;
     bool chatMentionCompleter;
     QString chatMentionColor;
@@ -311,6 +312,10 @@ public:
     bool getOpenDeckInNewTab() const
     {
         return openDeckInNewTab;
+    }
+    int getRewindBufferingMs() const
+    {
+        return rewindBufferingMs;
     }
     bool getChatMention() const
     {
@@ -566,6 +571,7 @@ public slots:
     void setMinPlayersForMultiColumnLayout(int _minPlayersForMultiColumnLayout);
     void setTapAnimation(QT_STATE_CHANGED_T _tapAnimation);
     void setOpenDeckInNewTab(QT_STATE_CHANGED_T _openDeckInNewTab);
+    void setRewindBufferingMs(int _rewindBufferingMs);
     void setChatMention(QT_STATE_CHANGED_T _chatMention);
     void setChatMentionCompleter(QT_STATE_CHANGED_T _chatMentionCompleter);
     void setChatMentionForeground(QT_STATE_CHANGED_T _chatMentionForeground);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -166,6 +166,9 @@ void SettingsCache::setTapAnimation(QT_STATE_CHANGED_T /* _tapAnimation */)
 void SettingsCache::setOpenDeckInNewTab(QT_STATE_CHANGED_T /* _openDeckInNewTab */)
 {
 }
+void SettingsCache::setRewindBufferingMs(int /* _rewindBufferingMs */)
+{
+}
 void SettingsCache::setChatMention(QT_STATE_CHANGED_T /* _chatMention */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -170,6 +170,9 @@ void SettingsCache::setTapAnimation(QT_STATE_CHANGED_T /* _tapAnimation */)
 void SettingsCache::setOpenDeckInNewTab(QT_STATE_CHANGED_T /* _openDeckInNewTab */)
 {
 }
+void SettingsCache::setRewindBufferingMs(int /* _rewindBufferingMs */)
+{
+}
 void SettingsCache::setChatMention(QT_STATE_CHANGED_T /* _chatMention */)
 {
 }


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5141

## What will change with this Pull Request?
- Created new setting for rewind buffering timeout
  - Located under `User Interface` -> `Replay settings`
  - allowed range is 0 to 9999 ms
- Removed the rewind buffering scaling behavior
  - the scaling behavior has always been a compromise to limit the amount of cpu use when spamming rewind near the end of a long replay, by guaranteeing that any reasonable spam frequency there will trigger the buffering.
  - I figured that now users can just set the rewind buffering to a value they're comfortable with, which should consistently make the buffering kick in when they spam the back arrow.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
<img width="400" alt="Screenshot 2024-12-05 at 6 04 26 PM" src="https://github.com/user-attachments/assets/659d94ae-284b-4bf8-be09-22c12fae21fd">
