### PR TITLE
dynamically resize scrollbar when zone view window is resized

### DIFF
--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -249,16 +249,19 @@ void ZoneViewWidget::resizeToZoneContents()
 {
     QRectF zoneRect = zone->getOptimumRect();
     qreal totalZoneHeight = zoneRect.height();
-    if (zoneRect.height() > 500)
-        zoneRect.setHeight(500);
-    QSizeF newSize(qMax(QGraphicsWidget::layout()->effectiveSizeHint(Qt::MinimumSize, QSizeF()).width(),
-                        zoneRect.width() + scrollBar->width() + 10),
-                   zoneRect.height() + extraHeight + 10);
-    setMaximumSize(newSize);
-    resize(newSize);
+
+    qreal width = qMax(QGraphicsWidget::layout()->effectiveSizeHint(Qt::MinimumSize, QSizeF()).width(),
+                       zoneRect.width() + scrollBar->width() + 10);
+
+    QSizeF maxSize(width, zoneRect.height() + extraHeight + 10);
+    setMaximumSize(maxSize);
+
+    qreal initialZoneHeight = qMin(zoneRect.height(), 500.0);
+    QSizeF initialSize(width, initialZoneHeight + extraHeight + 10);
+    resize(initialSize);
 
     zone->setGeometry(QRectF(0, -scrollBar->value(), zoneContainer->size().width(), totalZoneHeight));
-    scrollBar->setMaximum(totalZoneHeight - zoneRect.height());
+    scrollBar->setMaximum(totalZoneHeight - initialZoneHeight);
 
     if (layout())
         layout()->invalidate();

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -245,6 +245,19 @@ void ZoneViewWidget::moveEvent(QGraphicsSceneMoveEvent * /* event */)
         setPos(scenePos);
 }
 
+void ZoneViewWidget::resizeEvent(QGraphicsSceneResizeEvent *event)
+{
+    if (!zone)
+        return;
+
+    // We need to manually resize the scroll bar whenever the window gets resized
+    qreal totalZoneHeight = zone->getOptimumRect().height();
+    qreal newWindowHeight = event->newSize().height();
+    qreal newZoneHeight = newWindowHeight - extraHeight - 10;
+
+    scrollBar->setMaximum(totalZoneHeight - newZoneHeight);
+}
+
 void ZoneViewWidget::resizeToZoneContents()
 {
     QRectF zoneRect = zone->getOptimumRect();
@@ -261,7 +274,6 @@ void ZoneViewWidget::resizeToZoneContents()
     resize(initialSize);
 
     zone->setGeometry(QRectF(0, -scrollBar->value(), zoneContainer->size().width(), totalZoneHeight));
-    scrollBar->setMaximum(totalZoneHeight - initialZoneHeight);
 
     if (layout())
         layout()->invalidate();

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -101,7 +101,7 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
     scrollBar->setMinimum(0);
     scrollBar->setSingleStep(20);
     scrollBar->setPageStep(200);
-    connect(scrollBar, SIGNAL(valueChanged(int)), this, SLOT(handleScrollBarChange(int)));
+    connect(scrollBar, &QScrollBar::valueChanged, this, &ZoneViewWidget::handleScrollBarChange);
     scrollBarProxy = new ScrollableGraphicsProxyWidget;
     scrollBarProxy->setWidget(scrollBar);
     zoneHBox->addItem(scrollBarProxy);

--- a/cockatrice/src/game/zones/view_zone_widget.h
+++ b/cockatrice/src/game/zones/view_zone_widget.h
@@ -65,6 +65,7 @@ private slots:
     void handleScrollBarChange(int value);
     void zoneDeleted();
     void moveEvent(QGraphicsSceneMoveEvent * /* event */);
+    void resizeEvent(QGraphicsSceneResizeEvent * /* event */);
 
 public:
     ZoneViewWidget(Player *_player,


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5219 

## What will change with this Pull Request?

https://github.com/user-attachments/assets/4f997dac-444f-4534-982b-030db3604a91

- Scroll bar now dynamically resizes itself to always cover the entire height of the zone
- Zone view window can now be expanded past its previous max height of 500.

## Known issues

Whenever a card is added or removed from the zone, the height immediately snaps back to the default height. I'm planning on addressing that in a future PR.
