### PR TITLE
hide action now applies to all selected cards

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3433,6 +3433,18 @@ void Player::actCardCounterTrigger()
     sendGameCommand(prepareGameCommand(commandList));
 }
 
+/**
+ * @brief returns true if the zone is a unwritable reveal zone view (eg a card reveal window)
+ */
+static bool isUnwritableRevealZone(CardZone *zone)
+{
+    if (zone && zone->getIsView()) {
+        auto *view = dynamic_cast<ZoneViewZone *>(zone);
+        return view->getRevealZone() && !view->getWriteableRevealZone();
+    }
+    return false;
+}
+
 void Player::actPlay()
 {
     auto *card = game->getActiveCard();
@@ -3451,7 +3463,7 @@ void Player::actHide()
     }
 
     for (auto &card : selectedCards) {
-        if (card) {
+        if (card && isUnwritableRevealZone(card->getZone())) {
             card->getZone()->removeCard(card);
         }
     }

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3444,9 +3444,16 @@ void Player::actPlay()
 
 void Player::actHide()
 {
-    auto *card = game->getActiveCard();
-    if (card) {
-        card->getZone()->removeCard(card);
+    QList<CardItem *> selectedCards;
+    for (const auto &item : scene()->selectedItems()) {
+        auto *card = static_cast<CardItem *>(item);
+        selectedCards.append(card);
+    }
+
+    for (auto &card : selectedCards) {
+        if (card) {
+            card->getZone()->removeCard(card);
+        }
     }
 }
 

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3434,12 +3434,13 @@ void Player::actCardCounterTrigger()
 }
 
 /**
- * @brief returns true if the zone is a unwritable reveal zone view (eg a card reveal window)
+ * @brief returns true if the zone is a unwritable reveal zone view (eg a card reveal window). Will return false if zone
+ * is nullptr.
  */
 static bool isUnwritableRevealZone(CardZone *zone)
 {
     if (zone && zone->getIsView()) {
-        auto *view = dynamic_cast<ZoneViewZone *>(zone);
+        auto *view = static_cast<ZoneViewZone *>(zone);
         return view->getRevealZone() && !view->getWriteableRevealZone();
     }
     return false;

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3441,7 +3441,7 @@ static bool isUnwritableRevealZone(CardZone *zone)
 {
     if (zone && zone->getIsView()) {
         auto *view = static_cast<ZoneViewZone *>(zone);
-        return view->getRevealZone() && !view->getWriteableRevealZone();
+        return view && view->getRevealZone() && !view->getWriteableRevealZone();
     }
     return false;
 }

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3457,13 +3457,8 @@ void Player::actPlay()
 
 void Player::actHide()
 {
-    QList<CardItem *> selectedCards;
     for (const auto &item : scene()->selectedItems()) {
         auto *card = static_cast<CardItem *>(item);
-        selectedCards.append(card);
-    }
-
-    for (auto &card : selectedCards) {
         if (card && isUnwritableRevealZone(card->getZone())) {
             card->getZone()->removeCard(card);
         }


### PR DESCRIPTION
## Related Ticket(s)
- Partially addresses #2680 

## Short roundup of the initial problem
Hide action only applies to the single card instead of the whole selection

## What will change with this Pull Request?
https://github.com/user-attachments/assets/d6ad6a1b-df52-4695-8962-bd8be3ab3b5d

Hide action now applies to entire selection. It will work with selections across different reveal zones, but will only affect selected cards that are in zones that would have the hide action.

- `actHide` now loop over the entire selection
  - checks that the card is in a reveal zone before removing the card

--- 
I'm implementing "`play` action to applies to all selected cards" separately, since card properties get messed up when you use to same sort of looping logic to try to play multiple cards at once from the deck.
