### PR TITLE
fix remaining wonkiness with rewind buffering in replays

### DIFF
--- a/cockatrice/src/client/network/replay_timeline_widget.h
+++ b/cockatrice/src/client/network/replay_timeline_widget.h
@@ -35,7 +35,9 @@ private:
     QList<int> histogram;
     int maxBinValue, maxTime;
     qreal timeScaleFactor;
-    int currentTime;
+    int currentVisualTime;    // time currently displayed by the timeline
+    int currentProcessedTime; // time that events are currently processed up to. Could differ from visual time due to
+                              // rewind buffering
     int currentEvent;
 
     void skipToTime(int newTime, bool doRewindBuffering);


### PR DESCRIPTION
## Related Ticket(s)
- Follow up to #5227 

## Short roundup of the initial problem
https://github.com/user-attachments/assets/d0ceff2f-3c7d-415a-8ef2-7a5172e37903

The behavior I was envisioning for rewind buffering is that doing a forward skip will immediately resolve all buffered rewinds. However, turns out the current behavior doesn't actually match that.

Also, there's weird behavior with mouse click skips not immediately resolving a buffered rewind if you click within an area that was backwards skipped over.

Rewind buffering always had this wonky behavior, but it wasn't apparent because the rewind buffering timeout was hardcoded to a low value. Now that the timeout is configurable, setting the value to a high number makes the wonkiness much more apparent

## What will change with this Pull Request?

https://github.com/user-attachments/assets/e40047bf-2759-4864-b697-2be339f01270

Doing a forward skip or a mouse click skip now immediately ends any ongoing rewind bufferings and sets the board state to the currently displayed time in the timeline.

- Split the `currentTime` variable into `currentVisualTime` and `currentProcessedTime`
  - `currentVisualTime` is what gets modified by all the actions
  - `currentProcessedTime` only gets set to `currentVisualTime` once event processing actually happens
- determining if a rewind needs to happen is now done using `currentProcessedTime` instead of `currentVisualTime`

