### PR TITLE
make card view window max initial height configurable

### DIFF
--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -455,7 +455,7 @@ void AppearanceSettingsPage::retranslateUi()
     cardScalingCheckBox.setText(tr("Scale cards on mouse over"));
     verticalCardOverlapPercentLabel.setText(
         tr("Minimum overlap percentage of cards on the stack and in vertical hand"));
-    cardViewInitialRowsMaxLabel.setText(tr("Card view window maximum initial height:"));
+    cardViewInitialRowsMaxLabel.setText(tr("Maximum initial height for card view window:"));
     cardViewInitialRowsMaxBox.setSuffix(tr(" rows"));
 
     handGroupBox->setTitle(tr("Hand layout"));

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -346,7 +346,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     connect(&verticalCardOverlapPercentBox, SIGNAL(valueChanged(int)), &settings,
             SLOT(setStackCardOverlapPercent(int)));
 
-    cardViewInitialRowsMaxBox.setRange(0, 9999);
+    cardViewInitialRowsMaxBox.setRange(1, 9999);
     cardViewInitialRowsMaxBox.setValue(SettingsCache::instance().getCardViewInitialRowsMax());
     connect(&cardViewInitialRowsMaxBox, qOverload<int>(&QSpinBox::valueChanged), &SettingsCache::instance(),
             &SettingsCache::setCardViewInitialRowsMax);

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -346,11 +346,18 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     connect(&verticalCardOverlapPercentBox, SIGNAL(valueChanged(int)), &settings,
             SLOT(setStackCardOverlapPercent(int)));
 
+    cardViewInitialHeightBox.setRange(0, 9999);
+    cardViewInitialHeightBox.setValue(SettingsCache::instance().getCardViewInitialHeight());
+    connect(&cardViewInitialHeightBox, qOverload<int>(&QSpinBox::valueChanged), &SettingsCache::instance(),
+            &SettingsCache::setCardViewInitialHeight);
+
     auto *cardsGrid = new QGridLayout;
     cardsGrid->addWidget(&displayCardNamesCheckBox, 0, 0, 1, 2);
     cardsGrid->addWidget(&cardScalingCheckBox, 1, 0, 1, 2);
     cardsGrid->addWidget(&verticalCardOverlapPercentLabel, 2, 0, 1, 1);
     cardsGrid->addWidget(&verticalCardOverlapPercentBox, 2, 1, 1, 1);
+    cardsGrid->addWidget(&cardViewInitialHeightLabel, 3, 0);
+    cardsGrid->addWidget(&cardViewInitialHeightBox, 3, 1);
 
     cardsGroupBox = new QGroupBox;
     cardsGroupBox->setLayout(cardsGrid);
@@ -448,6 +455,7 @@ void AppearanceSettingsPage::retranslateUi()
     cardScalingCheckBox.setText(tr("Scale cards on mouse over"));
     verticalCardOverlapPercentLabel.setText(
         tr("Minimum overlap percentage of cards on the stack and in vertical hand"));
+    cardViewInitialHeightLabel.setText(tr("Card view window maximum initial height:"));
 
     handGroupBox->setTitle(tr("Hand layout"));
     horizontalHandCheckBox.setText(tr("Display hand horizontally (wastes space)"));
@@ -495,18 +503,11 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     connect(&useTearOffMenusCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             [](const QT_STATE_CHANGED_T state) { SettingsCache::instance().setUseTearOffMenus(state == Qt::Checked); });
 
-    cardViewInitialHeightBox.setRange(0, 9999);
-    cardViewInitialHeightBox.setValue(SettingsCache::instance().getCardViewInitialHeight());
-    connect(&cardViewInitialHeightBox, qOverload<int>(&QSpinBox::valueChanged), &SettingsCache::instance(),
-            &SettingsCache::setCardViewInitialHeight);
-
     auto *generalGrid = new QGridLayout;
     generalGrid->addWidget(&doubleClickToPlayCheckBox, 0, 0);
     generalGrid->addWidget(&playToStackCheckBox, 1, 0);
     generalGrid->addWidget(&annotateTokensCheckBox, 2, 0);
     generalGrid->addWidget(&useTearOffMenusCheckBox, 3, 0);
-    generalGrid->addWidget(&cardViewInitialHeightLabel, 4, 0);
-    generalGrid->addWidget(&cardViewInitialHeightBox, 4, 1);
 
     generalGroupBox = new QGroupBox;
     generalGroupBox->setLayout(generalGrid);
@@ -583,7 +584,6 @@ void UserInterfaceSettingsPage::retranslateUi()
     playToStackCheckBox.setText(tr("&Play all nonlands onto the stack (not the battlefield) by default"));
     annotateTokensCheckBox.setText(tr("Annotate card text on tokens"));
     useTearOffMenusCheckBox.setText(tr("Use tear-off menus, allowing right click menus to persist on screen"));
-    cardViewInitialHeightLabel.setText(tr("Card view window maximum initial height:"));
     notificationsGroupBox->setTitle(tr("Notifications settings"));
     notificationsEnabledCheckBox.setText(tr("Enable notifications in taskbar"));
     specNotificationsEnabledCheckBox.setText(tr("Notify in the taskbar for game events while you are spectating"));

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -346,18 +346,18 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     connect(&verticalCardOverlapPercentBox, SIGNAL(valueChanged(int)), &settings,
             SLOT(setStackCardOverlapPercent(int)));
 
-    cardViewInitialHeightBox.setRange(0, 9999);
-    cardViewInitialHeightBox.setValue(SettingsCache::instance().getCardViewInitialHeight());
-    connect(&cardViewInitialHeightBox, qOverload<int>(&QSpinBox::valueChanged), &SettingsCache::instance(),
-            &SettingsCache::setCardViewInitialHeight);
+    cardViewInitialRowsMaxBox.setRange(0, 9999);
+    cardViewInitialRowsMaxBox.setValue(SettingsCache::instance().getCardViewInitialRowsMax());
+    connect(&cardViewInitialRowsMaxBox, qOverload<int>(&QSpinBox::valueChanged), &SettingsCache::instance(),
+            &SettingsCache::setCardViewInitialRowsMax);
 
     auto *cardsGrid = new QGridLayout;
     cardsGrid->addWidget(&displayCardNamesCheckBox, 0, 0, 1, 2);
     cardsGrid->addWidget(&cardScalingCheckBox, 1, 0, 1, 2);
     cardsGrid->addWidget(&verticalCardOverlapPercentLabel, 2, 0, 1, 1);
     cardsGrid->addWidget(&verticalCardOverlapPercentBox, 2, 1, 1, 1);
-    cardsGrid->addWidget(&cardViewInitialHeightLabel, 3, 0);
-    cardsGrid->addWidget(&cardViewInitialHeightBox, 3, 1);
+    cardsGrid->addWidget(&cardViewInitialRowsMaxLabel, 3, 0);
+    cardsGrid->addWidget(&cardViewInitialRowsMaxBox, 3, 1);
 
     cardsGroupBox = new QGroupBox;
     cardsGroupBox->setLayout(cardsGrid);
@@ -455,7 +455,8 @@ void AppearanceSettingsPage::retranslateUi()
     cardScalingCheckBox.setText(tr("Scale cards on mouse over"));
     verticalCardOverlapPercentLabel.setText(
         tr("Minimum overlap percentage of cards on the stack and in vertical hand"));
-    cardViewInitialHeightLabel.setText(tr("Card view window maximum initial height:"));
+    cardViewInitialRowsMaxLabel.setText(tr("Card view window maximum initial height:"));
+    cardViewInitialRowsMaxBox.setSuffix(tr(" rows"));
 
     handGroupBox->setTitle(tr("Hand layout"));
     horizontalHandCheckBox.setText(tr("Display hand horizontally (wastes space)"));

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -346,7 +346,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     connect(&verticalCardOverlapPercentBox, SIGNAL(valueChanged(int)), &settings,
             SLOT(setStackCardOverlapPercent(int)));
 
-    cardViewInitialRowsMaxBox.setRange(1, 9999);
+    cardViewInitialRowsMaxBox.setRange(1, 999);
     cardViewInitialRowsMaxBox.setValue(SettingsCache::instance().getCardViewInitialRowsMax());
     connect(&cardViewInitialRowsMaxBox, qOverload<int>(&QSpinBox::valueChanged), &SettingsCache::instance(),
             &SettingsCache::setCardViewInitialRowsMax);

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -495,11 +495,18 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     connect(&useTearOffMenusCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             [](const QT_STATE_CHANGED_T state) { SettingsCache::instance().setUseTearOffMenus(state == Qt::Checked); });
 
+    cardViewInitialHeightBox.setRange(0, 9999);
+    cardViewInitialHeightBox.setValue(SettingsCache::instance().getCardViewInitialHeight());
+    connect(&cardViewInitialHeightBox, qOverload<int>(&QSpinBox::valueChanged), &SettingsCache::instance(),
+            &SettingsCache::setCardViewInitialHeight);
+
     auto *generalGrid = new QGridLayout;
     generalGrid->addWidget(&doubleClickToPlayCheckBox, 0, 0);
     generalGrid->addWidget(&playToStackCheckBox, 1, 0);
     generalGrid->addWidget(&annotateTokensCheckBox, 2, 0);
     generalGrid->addWidget(&useTearOffMenusCheckBox, 3, 0);
+    generalGrid->addWidget(&cardViewInitialHeightLabel, 4, 0);
+    generalGrid->addWidget(&cardViewInitialHeightBox, 4, 1);
 
     generalGroupBox = new QGroupBox;
     generalGroupBox->setLayout(generalGrid);
@@ -576,6 +583,7 @@ void UserInterfaceSettingsPage::retranslateUi()
     playToStackCheckBox.setText(tr("&Play all nonlands onto the stack (not the battlefield) by default"));
     annotateTokensCheckBox.setText(tr("Annotate card text on tokens"));
     useTearOffMenusCheckBox.setText(tr("Use tear-off menus, allowing right click menus to persist on screen"));
+    cardViewInitialHeightLabel.setText(tr("Card view window maximum initial height:"));
     notificationsGroupBox->setTitle(tr("Notifications settings"));
     notificationsEnabledCheckBox.setText(tr("Enable notifications in taskbar"));
     specNotificationsEnabledCheckBox.setText(tr("Notify in the taskbar for game events while you are spectating"));

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -96,8 +96,8 @@ private:
     QCheckBox cardScalingCheckBox;
     QLabel verticalCardOverlapPercentLabel;
     QSpinBox verticalCardOverlapPercentBox;
-    QLabel cardViewInitialHeightLabel;
-    QSpinBox cardViewInitialHeightBox;
+    QLabel cardViewInitialRowsMaxLabel;
+    QSpinBox cardViewInitialRowsMaxBox;
     QCheckBox horizontalHandCheckBox;
     QCheckBox leftJustifiedHandCheckBox;
     QCheckBox invertVerticalCoordinateCheckBox;

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -96,6 +96,8 @@ private:
     QCheckBox cardScalingCheckBox;
     QLabel verticalCardOverlapPercentLabel;
     QSpinBox verticalCardOverlapPercentBox;
+    QLabel cardViewInitialHeightLabel;
+    QSpinBox cardViewInitialHeightBox;
     QCheckBox horizontalHandCheckBox;
     QCheckBox leftJustifiedHandCheckBox;
     QCheckBox invertVerticalCoordinateCheckBox;
@@ -126,8 +128,6 @@ private:
     QCheckBox playToStackCheckBox;
     QCheckBox annotateTokensCheckBox;
     QCheckBox useTearOffMenusCheckBox;
-    QLabel cardViewInitialHeightLabel;
-    QSpinBox cardViewInitialHeightBox;
     QCheckBox tapAnimationCheckBox;
     QCheckBox openDeckInNewTabCheckBox;
     QLabel rewindBufferingMsLabel;

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -126,6 +126,8 @@ private:
     QCheckBox playToStackCheckBox;
     QCheckBox annotateTokensCheckBox;
     QCheckBox useTearOffMenusCheckBox;
+    QLabel cardViewInitialHeightLabel;
+    QSpinBox cardViewInitialHeightBox;
     QCheckBox tapAnimationCheckBox;
     QCheckBox openDeckInNewTabCheckBox;
     QLabel rewindBufferingMsLabel;

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -254,6 +254,16 @@ void ZoneViewWidget::resizeEvent(QGraphicsSceneResizeEvent *event)
     scrollBar->setMaximum(totalZoneHeight - newZoneHeight);
 }
 
+/**
+ * Calculates the max initial height from the settings.
+ * The max initial height setting is given as number of rows, so we need to map it to a height.
+ **/
+static qreal calcMaxInitialHeight()
+{
+    const qreal cardsHeight = (SettingsCache::instance().getCardViewInitialRowsMax() + 1) * CARD_HEIGHT * 0.33;
+    return cardsHeight + 2; // +2 padding to make the cutoff look nicer
+}
+
 void ZoneViewWidget::resizeToZoneContents()
 {
     QRectF zoneRect = zone->getOptimumRect();
@@ -265,8 +275,7 @@ void ZoneViewWidget::resizeToZoneContents()
     QSizeF maxSize(width, zoneRect.height() + extraHeight + 10);
     setMaximumSize(maxSize);
 
-    qreal initialZoneHeight =
-        qMin(zoneRect.height(), static_cast<qreal>(SettingsCache::instance().getCardViewInitialHeight()));
+    qreal initialZoneHeight = qMin(zoneRect.height(), calcMaxInitialHeight());
     QSizeF initialSize(width, initialZoneHeight + extraHeight + 10);
     resize(initialSize);
 

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -260,8 +260,7 @@ void ZoneViewWidget::resizeEvent(QGraphicsSceneResizeEvent *event)
  **/
 static qreal calcMaxInitialHeight()
 {
-    const qreal cardsHeight = (SettingsCache::instance().getCardViewInitialRowsMax() + 1) * CARD_HEIGHT * 0.33;
-    return cardsHeight + 2; // +2 padding to make the cutoff look nicer
+    return (SettingsCache::instance().getCardViewInitialRowsMax() + 1) * CARD_HEIGHT / 3;
 }
 
 void ZoneViewWidget::resizeToZoneContents()

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -265,7 +265,8 @@ void ZoneViewWidget::resizeToZoneContents()
     QSizeF maxSize(width, zoneRect.height() + extraHeight + 10);
     setMaximumSize(maxSize);
 
-    qreal initialZoneHeight = qMin(zoneRect.height(), 500.0);
+    qreal initialZoneHeight =
+        qMin(zoneRect.height(), static_cast<qreal>(SettingsCache::instance().getCardViewInitialHeight()));
     QSizeF initialSize(width, initialZoneHeight + extraHeight + 10);
     resize(initialSize);
 

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -260,7 +260,8 @@ void ZoneViewWidget::resizeEvent(QGraphicsSceneResizeEvent *event)
  **/
 static qreal calcMaxInitialHeight()
 {
-    return (SettingsCache::instance().getCardViewInitialRowsMax() + 1) * CARD_HEIGHT / 3;
+    const qreal cardsHeight = (SettingsCache::instance().getCardViewInitialRowsMax() + 1) * (CARD_HEIGHT / 3);
+    return cardsHeight + 5; // +5 padding to make the cutoff look nicer
 }
 
 void ZoneViewWidget::resizeToZoneContents()

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -238,6 +238,7 @@ SettingsCache::SettingsCache()
     tabGameSplitterSizes = settings->value("interface/tabgame_splittersizes").toByteArray();
     knownMissingFeatures = settings->value("interface/knownmissingfeatures", "").toString();
     useTearOffMenus = settings->value("interface/usetearoffmenus", true).toBool();
+    cardViewInitialHeight = settings->value("interface/cardViewInitialHeight", 500).toInt();
 
     showShortcuts = settings->value("menu/showshortcuts", true).toBool();
     displayCardNames = settings->value("cards/displaycardnames", true).toBool();
@@ -298,6 +299,12 @@ void SettingsCache::setUseTearOffMenus(bool _useTearOffMenus)
     useTearOffMenus = _useTearOffMenus;
     settings->setValue("interface/usetearoffmenus", useTearOffMenus);
     emit useTearOffMenusChanged(useTearOffMenus);
+}
+
+void SettingsCache::setCardViewInitialHeight(int _cardViewInitialHeight)
+{
+    cardViewInitialHeight = _cardViewInitialHeight;
+    settings->setValue("interface/cardViewInitialHeight", cardViewInitialHeight);
 }
 
 void SettingsCache::setKnownMissingFeatures(const QString &_knownMissingFeatures)

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -238,7 +238,7 @@ SettingsCache::SettingsCache()
     tabGameSplitterSizes = settings->value("interface/tabgame_splittersizes").toByteArray();
     knownMissingFeatures = settings->value("interface/knownmissingfeatures", "").toString();
     useTearOffMenus = settings->value("interface/usetearoffmenus", true).toBool();
-    cardViewInitialHeight = settings->value("interface/cardViewInitialHeight", 500).toInt();
+    cardViewInitialRowsMax = settings->value("interface/cardViewInitialRowsMax", 14).toInt();
 
     showShortcuts = settings->value("menu/showshortcuts", true).toBool();
     displayCardNames = settings->value("cards/displaycardnames", true).toBool();
@@ -301,10 +301,10 @@ void SettingsCache::setUseTearOffMenus(bool _useTearOffMenus)
     emit useTearOffMenusChanged(useTearOffMenus);
 }
 
-void SettingsCache::setCardViewInitialHeight(int _cardViewInitialHeight)
+void SettingsCache::setCardViewInitialRowsMax(int _cardViewInitialRowsMax)
 {
-    cardViewInitialHeight = _cardViewInitialHeight;
-    settings->setValue("interface/cardViewInitialHeight", cardViewInitialHeight);
+    cardViewInitialRowsMax = _cardViewInitialRowsMax;
+    settings->setValue("interface/cardViewInitialRowsMax", cardViewInitialRowsMax);
 }
 
 void SettingsCache::setKnownMissingFeatures(const QString &_knownMissingFeatures)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -123,6 +123,7 @@ private:
     QString clientVersion;
     QString knownMissingFeatures;
     bool useTearOffMenus;
+    int cardViewInitialHeight;
     int pixmapCacheSize;
     int networkCacheSize;
     int redirectCacheTtl;
@@ -485,6 +486,7 @@ public:
     void setClientVersion(const QString &clientVersion);
     void setKnownMissingFeatures(const QString &_knownMissingFeatures);
     void setUseTearOffMenus(bool _useTearOffMenus);
+    void setCardViewInitialHeight(int _cardViewInitialHeight);
     QString getClientID()
     {
         return clientID;
@@ -500,6 +502,10 @@ public:
     bool getUseTearOffMenus()
     {
         return useTearOffMenus;
+    }
+    int getCardViewInitialHeight()
+    {
+        return cardViewInitialHeight;
     }
     ShortcutsSettings &shortcuts() const
     {

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -123,7 +123,7 @@ private:
     QString clientVersion;
     QString knownMissingFeatures;
     bool useTearOffMenus;
-    int cardViewInitialHeight;
+    int cardViewInitialRowsMax;
     int pixmapCacheSize;
     int networkCacheSize;
     int redirectCacheTtl;
@@ -486,7 +486,7 @@ public:
     void setClientVersion(const QString &clientVersion);
     void setKnownMissingFeatures(const QString &_knownMissingFeatures);
     void setUseTearOffMenus(bool _useTearOffMenus);
-    void setCardViewInitialHeight(int _cardViewInitialHeight);
+    void setCardViewInitialRowsMax(int _cardViewInitialRowsMax);
     QString getClientID()
     {
         return clientID;
@@ -503,9 +503,9 @@ public:
     {
         return useTearOffMenus;
     }
-    int getCardViewInitialHeight()
+    int getCardViewInitialRowsMax() const
     {
-        return cardViewInitialHeight;
+        return cardViewInitialRowsMax;
     }
     ShortcutsSettings &shortcuts() const
     {

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -55,7 +55,7 @@ SettingsCache::SettingsCache()
 void SettingsCache::setUseTearOffMenus(bool /* _useTearOffMenus */)
 {
 }
-void SettingsCache::setCardViewInitialHeight(int /* _cardViewInitialHeight */)
+void SettingsCache::setCardViewInitialRowsMax(int /* _cardViewInitialRowsMax */)
 {
 }
 void SettingsCache::setKnownMissingFeatures(const QString & /* _knownMissingFeatures */)

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -55,6 +55,9 @@ SettingsCache::SettingsCache()
 void SettingsCache::setUseTearOffMenus(bool /* _useTearOffMenus */)
 {
 }
+void SettingsCache::setCardViewInitialHeight(int /* _cardViewInitialHeight */)
+{
+}
 void SettingsCache::setKnownMissingFeatures(const QString & /* _knownMissingFeatures */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -59,6 +59,9 @@ SettingsCache::SettingsCache()
 void SettingsCache::setUseTearOffMenus(bool /* _useTearOffMenus */)
 {
 }
+void SettingsCache::setCardViewInitialHeight(int /* _cardViewInitialHeight */)
+{
+}
 void SettingsCache::setKnownMissingFeatures(const QString & /* _knownMissingFeatures */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -59,7 +59,7 @@ SettingsCache::SettingsCache()
 void SettingsCache::setUseTearOffMenus(bool /* _useTearOffMenus */)
 {
 }
-void SettingsCache::setCardViewInitialHeight(int /* _cardViewInitialHeight */)
+void SettingsCache::setCardViewInitialRowsMax(int /* _cardViewInitialRowsMax */)
 {
 }
 void SettingsCache::setKnownMissingFeatures(const QString & /* _knownMissingFeatures */)


### PR DESCRIPTION
## Related Ticket(s)
- Follow up to #5228

## What will change with this Pull Request?

https://github.com/user-attachments/assets/4221f8c7-74f4-48ae-9b60-a94083366990

- Created new setting for card view window maximum initial height
  - Located at `User Interface` -> `General interface settings` -> `Card view window maximum initial height` 
  - Allowed range is 0 to 9999

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
<img width="420" alt="Screenshot 2024-12-09 at 11 47 09 PM" src="https://github.com/user-attachments/assets/41f189e1-5463-4e30-ae31-7c39fb849b4b">
