### PR TITLE
fix crash using uninitialised memory from #5228

### DIFF
--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -88,7 +88,6 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
     }
 
     extraHeight = vbox->sizeHint(Qt::PreferredSize).height();
-    resize(150, 150);
 
     QGraphicsLinearLayout *zoneHBox = new QGraphicsLinearLayout(Qt::Horizontal);
 
@@ -247,9 +246,6 @@ void ZoneViewWidget::moveEvent(QGraphicsSceneMoveEvent * /* event */)
 
 void ZoneViewWidget::resizeEvent(QGraphicsSceneResizeEvent *event)
 {
-    if (!zone)
-        return;
-
     // We need to manually resize the scroll bar whenever the window gets resized
     qreal totalZoneHeight = zone->getOptimumRect().height();
     qreal newWindowHeight = event->newSize().height();


### PR DESCRIPTION
this resize call in the middle of the constructor happens before the zone is initialised, it triggers resizeEvent which then uses unitialised memory, which because of the null check is fine but only if the uninitialised memory is empty, for me it crashes. I have also removed the null check which now isn't needed anymore and kind of obscured the problem. to be honest I don't know what this resize call here did, I don't notice any difference.