### PR TITLE
improve FilterString validation error message

### DIFF
--- a/cockatrice/src/game/filters/filter_string.cpp
+++ b/cockatrice/src/game/filters/filter_string.cpp
@@ -361,7 +361,7 @@ FilterString::FilterString(const QString &expr)
     }
 
     search.log = [&](size_t ln, size_t col, const std::string &msg) {
-        _error = QString("line %1, col %2: %3").arg(ln).arg(col).arg(QString::fromStdString(msg));
+        _error = QString("Error at position %1: %2").arg(col).arg(QString::fromStdString(msg));
     };
 
     if (!search.parse(ba.data(), result)) {

--- a/cockatrice/src/game/filters/filter_string.cpp
+++ b/cockatrice/src/game/filters/filter_string.cpp
@@ -365,7 +365,7 @@ FilterString::FilterString(const QString &expr)
     };
 
     if (!search.parse(ba.data(), result)) {
-        qDebug() << "Filter string error" << _error;
+        qDebug() << "Filter string error for" << expr << ";" << _error;
         result = [](CardData) -> bool { return false; };
     }
 }

--- a/cockatrice/src/game/filters/filter_string.cpp
+++ b/cockatrice/src/game/filters/filter_string.cpp
@@ -365,7 +365,7 @@ FilterString::FilterString(const QString &expr)
     };
 
     if (!search.parse(ba.data(), result)) {
-        qDebug() << "Filter string error for" << expr << ";" << _error;
+        qDebug().nospace() << "FilterString error for " << expr << "; " << _error;
         result = [](CardData) -> bool { return false; };
     }
 }

--- a/cockatrice/src/game/filters/filter_string.cpp
+++ b/cockatrice/src/game/filters/filter_string.cpp
@@ -361,11 +361,11 @@ FilterString::FilterString(const QString &expr)
     }
 
     search.log = [&](size_t ln, size_t col, const std::string &msg) {
-        _error = QString("%1:%2: %3").arg(ln).arg(col).arg(QString::fromStdString(msg));
+        _error = QString("line %1, col %2: %3").arg(ln).arg(col).arg(QString::fromStdString(msg));
     };
 
     if (!search.parse(ba.data(), result)) {
-        qDebug().nospace() << "FilterString error for " << expr << "; " << _error;
+        qDebug().nospace() << "FilterString error for " << expr << "; " << qPrintable(_error);
         result = [](CardData) -> bool { return false; };
     }
 }

--- a/cockatrice/src/game/filters/filter_string.cpp
+++ b/cockatrice/src/game/filters/filter_string.cpp
@@ -360,7 +360,7 @@ FilterString::FilterString(const QString &expr)
         return;
     }
 
-    search.log = [&](size_t ln, size_t col, const std::string &msg) {
+    search.log = [&](size_t /*ln*/, size_t col, const std::string &msg) {
         _error = QString("Error at position %1: %2").arg(col).arg(QString::fromStdString(msg));
     };
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5238

## Short roundup of the initial problem
FilterString validation failure debug message does not contain the expression itself

## What will change with this Pull Request?
Debug message now contains the expression itself

## Screenshots
Before: `Filter string error "1:5: syntax error"`
After: `Filter string error for "asdf:" ; "1:5: syntax error"`
