### PR TITLE
warn if "play top card until" filter expression doesn't match any card in database

### DIFF
--- a/cockatrice/src/dialogs/dlg_move_top_cards_until.cpp
+++ b/cockatrice/src/dialogs/dlg_move_top_cards_until.cpp
@@ -1,5 +1,7 @@
 #include "dlg_move_top_cards_until.h"
 
+#include "../game/cards/card_database.h"
+#include "../game/cards/card_database_manager.h"
 #include "../game/filters/filter_string.h"
 #include "trice_limits.h"
 
@@ -45,14 +47,57 @@ DlgMoveTopCardsUntil::DlgMoveTopCardsUntil(QWidget *parent, QString _expr, uint 
     setWindowTitle(tr("Put top cards on stack until..."));
 }
 
+/**
+ * @brief Checks if a card matching the expr exists in the card database.
+ *
+ * @returns true if a card matching the expression exists.
+ */
+static bool matchExistsInDb(const FilterString &filterString)
+{
+    const auto cardDatabase = CardDatabaseManager::getInstance();
+    const auto allCards = cardDatabase->getCardList();
+
+    const auto it = std::find_if(allCards.begin(), allCards.end(),
+                                 [&filterString](const CardInfoPtr &card) { return filterString.check(card); });
+
+    return it != allCards.end();
+}
+
+/**
+ * @brief Validates that a card matching the expr exists in the card database.
+ * If no match is found, then pop up a window to warn the user, giving them a chance to back out.
+ *
+ * @returns whether to proceed with the action
+ */
+bool DlgMoveTopCardsUntil::validateMatchExists(const FilterString &filterString)
+{
+    if (matchExistsInDb(filterString)) {
+        return true;
+    }
+
+    const auto msg = tr("No cards matching the search expression exists in the card database. Proceed anyways?");
+    const auto res =
+        QMessageBox::warning(this, tr("Cockatrice"), msg, QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+    if (res == QMessageBox::No) {
+        return false;
+    }
+
+    return true;
+}
+
 void DlgMoveTopCardsUntil::validateAndAccept()
 {
     auto movingCardsUntilFilter = FilterString(exprEdit->text());
-    if (movingCardsUntilFilter.valid()) {
-        accept();
-    } else {
+    if (!movingCardsUntilFilter.valid()) {
         QMessageBox::warning(this, tr("Invalid filter"), movingCardsUntilFilter.error(), QMessageBox::Ok);
+        return;
     }
+
+    if (!validateMatchExists(movingCardsUntilFilter)) {
+        return;
+    }
+
+    accept();
 }
 
 QString DlgMoveTopCardsUntil::getExpr() const

--- a/cockatrice/src/dialogs/dlg_move_top_cards_until.h
+++ b/cockatrice/src/dialogs/dlg_move_top_cards_until.h
@@ -6,7 +6,8 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QSpinBox>
-#include <QString>
+
+class FilterString;
 
 class DlgMoveTopCardsUntil : public QDialog
 {
@@ -18,6 +19,7 @@ class DlgMoveTopCardsUntil : public QDialog
     QDialogButtonBox *buttonBox;
 
     void validateAndAccept();
+    bool validateMatchExists(const FilterString &filterString);
 
 public:
     explicit DlgMoveTopCardsUntil(QWidget *parent = nullptr, QString expr = QString(), uint numberOfHits = 1);

--- a/cockatrice/src/game/filters/filter_string.h
+++ b/cockatrice/src/game/filters/filter_string.h
@@ -26,7 +26,7 @@ class FilterString
 public:
     FilterString();
     explicit FilterString(const QString &exp);
-    bool check(const CardData &card)
+    bool check(const CardData &card) const
     {
         return result(card);
     }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5241

## What will change with this Pull Request?

https://github.com/user-attachments/assets/a9ceee81-2dc6-48e2-a1d1-659690c88261

After clicking "Okay" on the "play top card to stack until" window, Cockatrice will check if the expression matches any card in the card database. If no matches are found, Cockatrice will pop up a warning window and give them a chance to back out of the action. 

- Also made `FilterString::check` const

## Screenshots

<img width="348" alt="Screenshot 2024-12-12 at 10 26 26 PM" src="https://github.com/user-attachments/assets/2e92bedb-7bbe-4114-b9d9-77e015653025" />

