### PR TITLE
ability to directly attach from other zones

### DIFF
--- a/cockatrice/src/game/board/arrow_item.cpp
+++ b/cockatrice/src/game/board/arrow_item.cpp
@@ -341,7 +341,9 @@ void ArrowAttachItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
     if (targetItem && (targetItem != startItem)) {
         auto startCard = qgraphicsitem_cast<CardItem *>(startItem);
         auto targetCard = qgraphicsitem_cast<CardItem *>(targetItem);
-        attachCards(startCard, targetCard);
+        if (startCard && targetCard) {
+            attachCards(startCard, targetCard);
+        }
     }
 
     delArrow();

--- a/cockatrice/src/game/board/arrow_item.cpp
+++ b/cockatrice/src/game/board/arrow_item.cpp
@@ -318,8 +318,14 @@ void ArrowAttachItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
         CardItem *targetCard = qgraphicsitem_cast<CardItem *>(targetItem);
         CardZone *targetZone = targetCard->getZone();
 
+        // move card onto table first if attaching from some other zone
+        if (startZone->getName() != "table") {
+            auto info = startCard->getInfo();
+            player->playCardToTable(startCard, false, info ? info->getCipt() : false);
+        }
+
         Command_AttachCard cmd;
-        cmd.set_start_zone(startZone->getName().toStdString());
+        cmd.set_start_zone("table");
         cmd.set_card_id(startCard->getId());
         cmd.set_target_player_id(targetZone->getPlayer()->getId());
         cmd.set_target_zone(targetZone->getName().toStdString());

--- a/cockatrice/src/game/board/arrow_item.h
+++ b/cockatrice/src/game/board/arrow_item.h
@@ -88,6 +88,8 @@ class ArrowAttachItem : public ArrowItem
 private:
     QList<ArrowAttachItem *> childArrows;
 
+    void attachCards(CardItem *startCard, const CardItem *targetCard);
+
 public:
     ArrowAttachItem(ArrowTarget *_startItem);
     void addChildArrow(ArrowAttachItem *childArrow);

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3714,9 +3714,13 @@ void Player::updateCardMenu(const CardItem *card)
 
                 cardMenu->addMenu(moveMenu);
 
-                cardMenu->addSeparator();
-                cardMenu->addAction(aAttach);
-                cardMenu->addAction(aDrawArrow);
+                // actions that are really wonky when done from deck or sideboard
+                if (card->getZone()->getName() == "hand") {
+                    cardMenu->addSeparator();
+                    cardMenu->addAction(aAttach);
+                    cardMenu->addAction(aDrawArrow);
+                }
+
                 cardMenu->addSeparator();
                 cardMenu->addAction(aSelectAll);
 

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3635,6 +3635,7 @@ void Player::updateCardMenu(const CardItem *card)
                 cardMenu->addSeparator();
             } else if (card->getZone()->getName() == "stack") {
                 // Card is on the stack
+                cardMenu->addAction(aAttach);
                 cardMenu->addAction(aDrawArrow);
                 cardMenu->addSeparator();
                 cardMenu->addAction(aClone);
@@ -3649,11 +3650,16 @@ void Player::updateCardMenu(const CardItem *card)
                 cardMenu->addAction(aSelectAll);
                 cardMenu->addAction(aPlay);
                 cardMenu->addAction(aPlayFacedown);
+
                 cardMenu->addSeparator();
                 cardMenu->addAction(aClone);
                 cardMenu->addMenu(moveMenu);
                 cardMenu->addSeparator();
                 cardMenu->addAction(aSelectAll);
+
+                cardMenu->addSeparator();
+                cardMenu->addAction(aAttach);
+                cardMenu->addAction(aDrawArrow);
 
                 addRelatedCardView(card, cardMenu);
                 addRelatedCardActions(card, cardMenu);
@@ -3667,8 +3673,13 @@ void Player::updateCardMenu(const CardItem *card)
                 connect(revealMenu, &QMenu::triggered, this, &Player::actReveal);
 
                 cardMenu->addMenu(moveMenu);
+
+                cardMenu->addSeparator();
+                cardMenu->addAction(aAttach);
+                cardMenu->addAction(aDrawArrow);
                 cardMenu->addSeparator();
                 cardMenu->addAction(aSelectAll);
+
                 addRelatedCardView(card, cardMenu);
             }
         } else {

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -390,6 +390,7 @@ public:
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
     void playCard(CardItem *c, bool faceDown, bool tapped);
+    void playCardToTable(CardItem *c, bool faceDown, bool tapped);
     void addCard(CardItem *c);
     void deleteCard(CardItem *c);
     void addZone(CardZone *z);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2068

## What will change with this Pull Request?
https://github.com/user-attachments/assets/0e916b76-f898-49b7-86aa-680cec969d22

The `attach to` action now functions in zones other than the table. When attaching from a zone other than the table, the card will be first played to the table, then attached.

More specifically, the `attach to` action now functions in `hand`, `graveyard`, `exile`, and `stack`. It still does not currently function in `deck` or `sideboard` because those zones are really wonky when you try to play multiple cards at the same time from them.

The card will be played to the table with all the properties (tablerow, etb tapped, p/t etc.) that it would have if played to the table normally. If a card with tablerow 3 (the stack) is played this way, it will be played to tablerow 2.

Also added the `draw arrow` action to all card menus that I added `attach to` to, since those two actions always seem to appear together.

### Technical Changes
- Added `Player::playCardToTable` method.
  - Copy-pasted from `Player::playCard` except I removed the logic for deciding which zone the card goes to.
- refactored card attachment logic in `ArrowAttachItem` to new method so that I can early return if the target card is already attached
  - this is to prevent cards from being played to table and then not attached if you try to attach to an already attached card.
- added `aAttach` and `aDrawArrow` actions to a bunch more card menus
  - Not super sold on the placement of the new actions into the dropdown menu. Let me know what you think
  - Honestly, we might need to go back and reorganize the options in the dropdown menu one day

## Screenshots

<img width="251" alt="Screenshot 2024-12-15 at 6 34 15 PM" src="https://github.com/user-attachments/assets/79e17151-e970-4fa7-9d49-d6792c3160f7" />

<img width="249" alt="Screenshot 2024-12-15 at 6 34 06 PM" src="https://github.com/user-attachments/assets/6196b2fc-2dfa-4b65-a4c3-0337b883ba17" />

<img width="195" alt="Screenshot 2024-12-15 at 6 34 01 PM" src="https://github.com/user-attachments/assets/fb71f0b9-fcee-467a-b1c8-782d220877dd" />
