### PR TITLE
fix clone shortcut not working on opponent's cards

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -995,6 +995,15 @@ void Player::setShortcutsActive()
     aMoveBottomCardToTop->setShortcut(shortcuts.getSingleShortcut("Player/aMoveBottomCardToTop"));
     aPlayFacedown->setShortcut(shortcuts.getSingleShortcut("Player/aPlayFacedown"));
     aPlay->setShortcut(shortcuts.getSingleShortcut("Player/aPlay"));
+
+    if (!game->getIsLocalGame()) {
+        /* Attach all card menu actions that also work on the opponent's cards to the TabGame object so that those
+         * shortcuts will be active regardless of whether your card menu currently exists.
+         * Added as a workaround to get the clone keyboard shortcut to work on opponent's cards.
+         */
+        game->addAction(aClone);
+        game->addAction(aDrawArrow);
+    }
 }
 
 void Player::setShortcutsInactive()

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -1003,6 +1003,7 @@ void Player::setShortcutsActive()
          */
         game->addAction(aClone);
         game->addAction(aDrawArrow);
+        game->addAction(aSelectAll);
     }
 }
 

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3026,12 +3026,23 @@ void Player::cardMenuAction()
             }
         }
     } else {
+        CardZone *zone = cardList[0]->getZone();
+        if (!zone) {
+            return;
+        }
+
+        Player *startPlayer = zone->getPlayer();
+        if (!startPlayer) {
+            return;
+        }
+
+        int startPlayerId = startPlayer->getId();
+        QString startZone = zone->getName();
+
         ListOfCardsToMove idList;
         for (const auto &i : cardList) {
             idList.add_card()->set_card_id(i->getId());
         }
-        int startPlayerId = cardList[0]->getZone()->getPlayer()->getId();
-        QString startZone = cardList[0]->getZone()->getName();
 
         switch (static_cast<CardMenuActionType>(a->data().toInt())) {
             case cmMoveToTopLibrary: {


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5231

## Short roundup of the initial problem

The clone shortcut didn't work on opponent's cards, because the card menu containing the `aClone` isn't active when you only have opponent's cards selected. The workaround is to add `aClone` to the `game` widget itself so that the shortcut is always active. 

## What will change with this Pull Request?
- Attach `aClone` and `aDrawArrow` to the `game` widget so that that those shortcuts will always be active.
  - we check that it's not a local game first, because clone shortcuts on opponents cards *do* currently work properly in local games, and changing it actually screws it up.
- Also fixed a nullptr bug
  - Not sure if it's related to my changes, but I encountered the bug while I was testing, so might as well fix it 
