### PR TITLE
play action now applies to all selected cards

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3487,6 +3487,9 @@ void Player::actPlay()
         selectedCards.append(card);
     }
 
+    std::sort(selectedCards.begin(), selectedCards.end(),
+              [](const auto &card1, const auto &card2) { return card1->getId() > card2->getId(); });
+
     for (auto &card : selectedCards) {
         if (card && !isUnwritableRevealZone(card->getZone())) {
             const bool cipt = card->getInfo() ? card->getInfo()->getCipt() : false;

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3488,7 +3488,7 @@ void Player::actPlay()
     }
 
     for (auto &card : selectedCards) {
-        if (card) {
+        if (card && !isUnwritableRevealZone(card->getZone())) {
             const bool cipt = card->getInfo() ? card->getInfo()->getCipt() : false;
             playCard(card, false, cipt);
         }
@@ -3514,7 +3514,7 @@ void Player::actPlayFacedown()
     }
 
     for (auto &card : selectedCards) {
-        if (card) {
+        if (card && !isUnwritableRevealZone(card->getZone())) {
             playCard(card, true, false);
         }
     }

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3494,7 +3494,7 @@ void Player::playSelectedCards(const bool faceDown)
               [](const auto &card1, const auto &card2) { return card1->getId() > card2->getId(); });
 
     for (auto &card : selectedCards) {
-        if (card && !isUnwritableRevealZone(card->getZone())) {
+        if (card && !isUnwritableRevealZone(card->getZone()) && card->getZone()->getName() != "table") {
             const bool cipt = !faceDown && card->getInfo() ? card->getInfo()->getCipt() : false;
             playCard(card, faceDown, cipt);
         }

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3481,10 +3481,17 @@ static bool isUnwritableRevealZone(CardZone *zone)
 
 void Player::actPlay()
 {
-    auto *card = game->getActiveCard();
-    if (card) {
-        const bool cipt = card->getInfo() ? card->getInfo()->getCipt() : false;
-        playCard(card, false, cipt);
+    QList<CardItem *> selectedCards;
+    for (const auto &item : scene()->selectedItems()) {
+        auto *card = static_cast<CardItem *>(item);
+        selectedCards.append(card);
+    }
+
+    for (auto &card : selectedCards) {
+        if (card) {
+            const bool cipt = card->getInfo() ? card->getInfo()->getCipt() : false;
+            playCard(card, false, cipt);
+        }
     }
 }
 
@@ -3500,9 +3507,16 @@ void Player::actHide()
 
 void Player::actPlayFacedown()
 {
-    auto *card = game->getActiveCard();
-    if (card) {
-        playCard(card, true, false);
+    QList<CardItem *> selectedCards;
+    for (const auto &item : scene()->selectedItems()) {
+        auto *card = static_cast<CardItem *>(item);
+        selectedCards.append(card);
+    }
+
+    for (auto &card : selectedCards) {
+        if (card) {
+            playCard(card, true, false);
+        }
     }
 }
 

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -224,8 +224,8 @@ private slots:
     void actFlowT();
     void actSetAnnotation();
     void actPlay();
-    void actHide();
     void actPlayFacedown();
+    void actHide();
     void actReveal(QAction *action);
     void refreshShortcuts();
 
@@ -322,6 +322,8 @@ private:
     void moveOneCardUntil(const CardInfoPtr card);
     void addPlayerToList(QMenu *playerList, Player *player);
     static void removePlayerFromList(QMenu *playerList, Player *player);
+
+    void playSelectedCards(bool faceDown = false);
 
     QRectF bRect;
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2680

## Short roundup of the initial problem

`Play` and `Play face down` action should apply to all selected cards

## What will change with this Pull Request?

https://github.com/user-attachments/assets/6b17aac3-1292-453a-8073-9c43b964b8e0

`Play` and `Play face down` actions now apply to all selected cards. This works with selections in any zone, except for card reveal windows. 

- `actPlay` will now loop through all selected cards, sort them in descending cardId order, and then play them one-by-one.
  - if we don't sort the cards in descending cardId order, then trying to play multiple cards at the same time from deck will cause the wrong cards to get played, since the cardIds will get shuffled downwards as cards leave the deck.
- refactored `Player::actPlay()` and `Player::actPlayFaceDown()` to consolidate the shared logic in another method.
