### PR TITLE
Double click to untap works when multi-zone select

### DIFF
--- a/cockatrice/src/game/zones/table_zone.cpp
+++ b/cockatrice/src/game/zones/table_zone.cpp
@@ -214,15 +214,12 @@ void TableZone::reorganizeCards()
 void TableZone::toggleTapped()
 {
     QList<QGraphicsItem *> selectedItems = scene()->selectedItems();
-    bool tapAll = false;
-    for (int i = 0; i < selectedItems.size(); i++)
-        if (!qgraphicsitem_cast<CardItem *>(selectedItems[i])->getTapped()) {
-            tapAll = true;
-            break;
-        }
+    bool tapAll = std::any_of(selectedItems.begin(), selectedItems.end(), [](const QGraphicsItem *item) {
+        return !qgraphicsitem_cast<const CardItem *>(item)->getTapped();
+    });
     QList<const ::google::protobuf::Message *> cmdList;
-    for (int i = 0; i < selectedItems.size(); i++) {
-        CardItem *temp = qgraphicsitem_cast<CardItem *>(selectedItems[i]);
+    for (const auto &selectedItem : selectedItems) {
+        CardItem *temp = qgraphicsitem_cast<CardItem *>(selectedItem);
         if (temp->getTapped() != tapAll) {
             Command_SetCardAttr *cmd = new Command_SetCardAttr;
             cmd->set_zone(name.toStdString());

--- a/cockatrice/src/game/zones/table_zone.cpp
+++ b/cockatrice/src/game/zones/table_zone.cpp
@@ -213,7 +213,18 @@ void TableZone::reorganizeCards()
 
 void TableZone::toggleTapped()
 {
-    QList<QGraphicsItem *> selectedItems = scene()->selectedItems();
+    QList<QGraphicsItem *> selectedItemsRaw = scene()->selectedItems();
+    QList<QGraphicsItem *> selectedItems;
+
+    auto isCardOnTable = [](const QGraphicsItem *item) {
+        if (auto card = qgraphicsitem_cast<const CardItem *>(item)) {
+            return card->getZone()->getName() == "table";
+        }
+        return false;
+    };
+
+    std::copy_if(selectedItemsRaw.begin(), selectedItemsRaw.end(), std::back_inserter(selectedItems), isCardOnTable);
+
     bool tapAll = std::any_of(selectedItems.begin(), selectedItems.end(), [](const QGraphicsItem *item) {
         return !qgraphicsitem_cast<const CardItem *>(item)->getTapped();
     });


### PR DESCRIPTION
## Short roundup of the initial problem
Double click to tap works if cards are selected across multiple zones, but double click to untap doesn't.

## What will change with this Pull Request?
- Refactor code
- Implement fix

