### PR TITLE
clicking to play can now play all selected

### DIFF
--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -492,6 +492,10 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     connect(&doubleClickToPlayCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setDoubleClickToPlay);
 
+    clickPlaysAllSelectedCheckBox.setChecked(SettingsCache::instance().getClickPlaysAllSelected());
+    connect(&clickPlaysAllSelectedCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setClickPlaysAllSelected);
+
     playToStackCheckBox.setChecked(SettingsCache::instance().getPlayToStack());
     connect(&playToStackCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setPlayToStack);
@@ -506,9 +510,10 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
 
     auto *generalGrid = new QGridLayout;
     generalGrid->addWidget(&doubleClickToPlayCheckBox, 0, 0);
-    generalGrid->addWidget(&playToStackCheckBox, 1, 0);
-    generalGrid->addWidget(&annotateTokensCheckBox, 2, 0);
-    generalGrid->addWidget(&useTearOffMenusCheckBox, 3, 0);
+    generalGrid->addWidget(&clickPlaysAllSelectedCheckBox, 1, 0);
+    generalGrid->addWidget(&playToStackCheckBox, 2, 0);
+    generalGrid->addWidget(&annotateTokensCheckBox, 3, 0);
+    generalGrid->addWidget(&useTearOffMenusCheckBox, 4, 0);
 
     generalGroupBox = new QGroupBox;
     generalGroupBox->setLayout(generalGrid);
@@ -582,6 +587,7 @@ void UserInterfaceSettingsPage::retranslateUi()
 {
     generalGroupBox->setTitle(tr("General interface settings"));
     doubleClickToPlayCheckBox.setText(tr("&Double-click cards to play them (instead of single-click)"));
+    clickPlaysAllSelectedCheckBox.setText(tr("&Clicking plays all selected cards (instead of just the clicked card)"));
     playToStackCheckBox.setText(tr("&Play all nonlands onto the stack (not the battlefield) by default"));
     annotateTokensCheckBox.setText(tr("Annotate card text on tokens"));
     useTearOffMenusCheckBox.setText(tr("Use tear-off menus, allowing right click menus to persist on screen"));

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -125,6 +125,7 @@ private:
     QCheckBox specNotificationsEnabledCheckBox;
     QCheckBox buddyConnectNotificationsEnabledCheckBox;
     QCheckBox doubleClickToPlayCheckBox;
+    QCheckBox clickPlaysAllSelectedCheckBox;
     QCheckBox playToStackCheckBox;
     QCheckBox annotateTokensCheckBox;
     QCheckBox useTearOffMenusCheckBox;

--- a/cockatrice/src/game/cards/card_item.cpp
+++ b/cockatrice/src/game/cards/card_item.cpp
@@ -385,14 +385,43 @@ void CardItem::playCard(bool faceDown)
         tz->toggleTapped();
     else {
         if (SettingsCache::instance().getClickPlaysAllSelected()) {
-            if (faceDown) {
-                zone->getPlayer()->actPlayFacedown();
-            } else {
-                zone->getPlayer()->actPlay();
-            }
+            faceDown ? zone->getPlayer()->actPlayFacedown() : zone->getPlayer()->actPlay();
         } else {
             zone->getPlayer()->playCard(this, faceDown, info ? info->getCipt() : false);
         }
+    }
+}
+
+/**
+ * @brief returns true if the zone is a unwritable reveal zone view (eg a card reveal window). Will return false if zone
+ * is nullptr.
+ */
+static bool isUnwritableRevealZone(CardZone *zone)
+{
+    if (zone && zone->getIsView()) {
+        if (auto *view = static_cast<ZoneViewZone *>(zone)) {
+            return view->getRevealZone() && !view->getWriteableRevealZone();
+        }
+    }
+    return false;
+}
+
+/**
+ * This method is called when a "click to play" is done on the card.
+ * This is either triggered by a single click or double click, depending on the settings.
+ *
+ * @param shiftHeld if the shift key was held during the click
+ */
+void CardItem::handleClickedToPlay(bool shiftHeld)
+{
+    if (isUnwritableRevealZone(zone)) {
+        if (SettingsCache::instance().getClickPlaysAllSelected()) {
+            zone->getPlayer()->actHide();
+        } else {
+            zone->removeCard(this);
+        }
+    } else {
+        playCard(shiftHeld);
     }
 }
 
@@ -405,21 +434,7 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
         }
     } else if ((event->modifiers() != Qt::AltModifier) && (event->button() == Qt::LeftButton) &&
                (!SettingsCache::instance().getDoubleClickToPlay())) {
-        bool hideCard = false;
-        if (zone && zone->getIsView()) {
-            auto *view = static_cast<ZoneViewZone *>(zone);
-            if (view->getRevealZone() && !view->getWriteableRevealZone())
-                hideCard = true;
-        }
-        if (zone && hideCard) {
-            if (SettingsCache::instance().getClickPlaysAllSelected()) {
-                zone->getPlayer()->actHide();
-            } else {
-                zone->removeCard(this);
-            }
-        } else {
-            playCard(event->modifiers().testFlag(Qt::ShiftModifier));
-        }
+        handleClickedToPlay(event->modifiers().testFlag(Qt::ShiftModifier));
     }
 
     if (owner != nullptr) { // cards without owner will be deleted
@@ -430,16 +445,9 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 
 void CardItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
 {
-    if ((event->modifiers() != Qt::AltModifier) && (SettingsCache::instance().getDoubleClickToPlay()) &&
-        (event->buttons() == Qt::LeftButton)) {
-        if (revealedCard) {
-            if (SettingsCache::instance().getClickPlaysAllSelected()) {
-                zone->getPlayer()->actHide();
-            } else {
-                zone->removeCard(this);
-            }
-        } else
-            playCard(event->modifiers().testFlag(Qt::ShiftModifier));
+    if ((event->modifiers() != Qt::AltModifier) && (event->buttons() == Qt::LeftButton) &&
+        (SettingsCache::instance().getDoubleClickToPlay())) {
+        handleClickedToPlay(event->modifiers().testFlag(Qt::ShiftModifier));
     }
     event->accept();
 }

--- a/cockatrice/src/game/cards/card_item.cpp
+++ b/cockatrice/src/game/cards/card_item.cpp
@@ -383,8 +383,17 @@ void CardItem::playCard(bool faceDown)
     TableZone *tz = qobject_cast<TableZone *>(zone);
     if (tz)
         tz->toggleTapped();
-    else
-        zone->getPlayer()->playCard(this, faceDown, info ? info->getCipt() : false);
+    else {
+        if (SettingsCache::instance().getClickPlaysAllSelected()) {
+            if (faceDown) {
+                zone->getPlayer()->actPlayFacedown();
+            } else {
+                zone->getPlayer()->actPlay();
+            }
+        } else {
+            zone->getPlayer()->playCard(this, faceDown, info ? info->getCipt() : false);
+        }
+    }
 }
 
 void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
@@ -403,7 +412,11 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
                 hideCard = true;
         }
         if (zone && hideCard) {
-            zone->removeCard(this);
+            if (SettingsCache::instance().getClickPlaysAllSelected()) {
+                zone->getPlayer()->actHide();
+            } else {
+                zone->removeCard(this);
+            }
         } else {
             playCard(event->modifiers().testFlag(Qt::ShiftModifier));
         }
@@ -419,9 +432,13 @@ void CardItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
 {
     if ((event->modifiers() != Qt::AltModifier) && (SettingsCache::instance().getDoubleClickToPlay()) &&
         (event->buttons() == Qt::LeftButton)) {
-        if (revealedCard)
-            zone->removeCard(this);
-        else
+        if (revealedCard) {
+            if (SettingsCache::instance().getClickPlaysAllSelected()) {
+                zone->getPlayer()->actHide();
+            } else {
+                zone->removeCard(this);
+            }
+        } else
             playCard(event->modifiers().testFlag(Qt::ShiftModifier));
     }
     event->accept();

--- a/cockatrice/src/game/cards/card_item.h
+++ b/cockatrice/src/game/cards/card_item.h
@@ -37,6 +37,7 @@ private:
     QMenu *cardMenu, *ptMenu, *moveMenu;
 
     void prepareDelete();
+    void handleClickedToPlay(bool shiftHeld);
 public slots:
     void deleteLater();
 

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3487,6 +3487,9 @@ void Player::actPlay()
         selectedCards.append(card);
     }
 
+    std::sort(selectedCards.begin(), selectedCards.end(),
+              [](const auto &card1, const auto &card2) { return card1->getId() > card2->getId(); });
+
     for (auto &card : selectedCards) {
         if (card && !isUnwritableRevealZone(card->getZone())) {
             const bool cipt = card->getInfo() ? card->getInfo()->getCipt() : false;

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3488,7 +3488,7 @@ void Player::actPlay()
     }
 
     for (auto &card : selectedCards) {
-        if (card) {
+        if (card && !isUnwritableRevealZone(card->getZone())) {
             const bool cipt = card->getInfo() ? card->getInfo()->getCipt() : false;
             playCard(card, false, cipt);
         }
@@ -3514,7 +3514,7 @@ void Player::actPlayFacedown()
     }
 
     for (auto &card : selectedCards) {
-        if (card) {
+        if (card && !isUnwritableRevealZone(card->getZone())) {
             playCard(card, true, false);
         }
     }

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3494,7 +3494,7 @@ void Player::playSelectedCards(const bool faceDown)
               [](const auto &card1, const auto &card2) { return card1->getId() > card2->getId(); });
 
     for (auto &card : selectedCards) {
-        if (card && !isUnwritableRevealZone(card->getZone())) {
+        if (card && !isUnwritableRevealZone(card->getZone()) && card->getZone()->getName() != "table") {
             const bool cipt = !faceDown && card->getInfo() ? card->getInfo()->getCipt() : false;
             playCard(card, faceDown, cipt);
         }

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3481,10 +3481,17 @@ static bool isUnwritableRevealZone(CardZone *zone)
 
 void Player::actPlay()
 {
-    auto *card = game->getActiveCard();
-    if (card) {
-        const bool cipt = card->getInfo() ? card->getInfo()->getCipt() : false;
-        playCard(card, false, cipt);
+    QList<CardItem *> selectedCards;
+    for (const auto &item : scene()->selectedItems()) {
+        auto *card = static_cast<CardItem *>(item);
+        selectedCards.append(card);
+    }
+
+    for (auto &card : selectedCards) {
+        if (card) {
+            const bool cipt = card->getInfo() ? card->getInfo()->getCipt() : false;
+            playCard(card, false, cipt);
+        }
     }
 }
 
@@ -3500,9 +3507,16 @@ void Player::actHide()
 
 void Player::actPlayFacedown()
 {
-    auto *card = game->getActiveCard();
-    if (card) {
-        playCard(card, true, false);
+    QList<CardItem *> selectedCards;
+    for (const auto &item : scene()->selectedItems()) {
+        auto *card = static_cast<CardItem *>(item);
+        selectedCards.append(card);
+    }
+
+    for (auto &card : selectedCards) {
+        if (card) {
+            playCard(card, true, false);
+        }
     }
 }
 

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -224,8 +224,8 @@ private slots:
     void actFlowT();
     void actSetAnnotation();
     void actPlay();
-    void actHide();
     void actPlayFacedown();
+    void actHide();
     void actReveal(QAction *action);
     void refreshShortcuts();
 
@@ -322,6 +322,8 @@ private:
     void moveOneCardUntil(const CardInfoPtr card);
     void addPlayerToList(QMenu *playerList, Player *player);
     static void removePlayerFromList(QMenu *playerList, Player *player);
+
+    void playSelectedCards(bool faceDown = false);
 
     QRectF bRect;
 

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -162,6 +162,11 @@ public slots:
     void actDrawCards();
     void actUndoDraw();
     void actMulligan();
+
+    void actPlay();
+    void actPlayFacedown();
+    void actHide();
+
     void actMoveTopCardToPlay();
     void actMoveTopCardToPlayFaceDown();
     void actMoveTopCardToGrave();
@@ -223,9 +228,6 @@ private slots:
     void actFlowP();
     void actFlowT();
     void actSetAnnotation();
-    void actPlay();
-    void actPlayFacedown();
-    void actHide();
     void actReveal(QAction *action);
     void refreshShortcuts();
 

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -232,6 +232,7 @@ SettingsCache::SettingsCache()
     spectatorNotificationsEnabled = settings->value("interface/specnotificationsenabled", false).toBool();
     buddyConnectNotificationsEnabled = settings->value("interface/buddyconnectnotificationsenabled", true).toBool();
     doubleClickToPlay = settings->value("interface/doubleclicktoplay", true).toBool();
+    clickPlaysAllSelected = settings->value("interface/clickPlaysAllSelected", true).toBool();
     playToStack = settings->value("interface/playtostack", true).toBool();
     startingHandSize = settings->value("interface/startinghandsize", 7).toInt();
     annotateTokens = settings->value("interface/annotatetokens", false).toBool();
@@ -488,6 +489,12 @@ void SettingsCache::setDoubleClickToPlay(QT_STATE_CHANGED_T _doubleClickToPlay)
 {
     doubleClickToPlay = static_cast<bool>(_doubleClickToPlay);
     settings->setValue("interface/doubleclicktoplay", doubleClickToPlay);
+}
+
+void SettingsCache::setClickPlaysAllSelected(QT_STATE_CHANGED_T _clickPlaysAllSelected)
+{
+    clickPlaysAllSelected = static_cast<bool>(_clickPlaysAllSelected);
+    settings->setValue("interface/clickPlaysAllSelected", clickPlaysAllSelected);
 }
 
 void SettingsCache::setPlayToStack(QT_STATE_CHANGED_T _playToStack)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -93,6 +93,7 @@ private:
     bool spectatorNotificationsEnabled;
     bool buddyConnectNotificationsEnabled;
     bool doubleClickToPlay;
+    bool clickPlaysAllSelected;
     bool playToStack;
     int startingHandSize;
     bool annotateTokens;
@@ -274,6 +275,10 @@ public:
     bool getDoubleClickToPlay() const
     {
         return doubleClickToPlay;
+    }
+    bool getClickPlaysAllSelected() const
+    {
+        return clickPlaysAllSelected;
     }
     bool getPlayToStack() const
     {
@@ -572,6 +577,7 @@ public slots:
     void setSpectatorNotificationsEnabled(QT_STATE_CHANGED_T _spectatorNotificationsEnabled);
     void setBuddyConnectNotificationsEnabled(QT_STATE_CHANGED_T _buddyConnectNotificationsEnabled);
     void setDoubleClickToPlay(QT_STATE_CHANGED_T _doubleClickToPlay);
+    void setClickPlaysAllSelected(QT_STATE_CHANGED_T _clickPlaysAllSelected);
     void setPlayToStack(QT_STATE_CHANGED_T _playToStack);
     void setStartingHandSize(int _startingHandSize);
     void setAnnotateTokens(QT_STATE_CHANGED_T _annotateTokens);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -139,6 +139,9 @@ void SettingsCache::setBuddyConnectNotificationsEnabled(QT_STATE_CHANGED_T /* _b
 void SettingsCache::setDoubleClickToPlay(QT_STATE_CHANGED_T /* _doubleClickToPlay */)
 {
 }
+void SettingsCache::setClickPlaysAllSelected(QT_STATE_CHANGED_T /* _clickPlaysAllSelected */)
+{
+}
 void SettingsCache::setPlayToStack(QT_STATE_CHANGED_T /* _playToStack */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -143,6 +143,9 @@ void SettingsCache::setBuddyConnectNotificationsEnabled(QT_STATE_CHANGED_T /* _b
 void SettingsCache::setDoubleClickToPlay(QT_STATE_CHANGED_T /* _doubleClickToPlay */)
 {
 }
+void SettingsCache::setClickPlaysAllSelected(QT_STATE_CHANGED_T /* _clickPlaysAllSelected */)
+{
+}
 void SettingsCache::setPlayToStack(QT_STATE_CHANGED_T /* _playToStack */)
 {
 }


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5252 (This PR requires #5252 to be merged first)

## Short roundup of the initial problem
Double-clicking to play cards doesn't cause all selected cards to get played, because they use a different method from `Player` to play the card.

## What will change with this Pull Request?
Added new setting under `User Interface` -> `General interface settings`. When that setting is enabled, clicking to play will also apply the action to all selected cards.

Clicking will apply the existing "click to play" behavior to all selected cards: Clicking while holding the shift key will play them face down. Clicking on cards in a card reveal menu will hide them.

- When the setting is enabled, `CardItem::playCard` now gets `this->getZone()->getPlayer()` and calls `player->act(Play|PlayFaceDown|Hide)` on it, which will act on all selected cards.
  - When the setting is off, the behavior is as before
- Also refactored `CardItem` while I was at it

## Screenshots

<img width="400" alt="Screenshot 2024-12-16 at 8 31 39 PM" src="https://github.com/user-attachments/assets/2b940214-4a64-44d0-b909-d28d91600767" />
