### PR TITLE
add option to auto-play "put top card on stack until" hits

### DIFF
--- a/cockatrice/src/dialogs/dlg_move_top_cards_until.cpp
+++ b/cockatrice/src/dialogs/dlg_move_top_cards_until.cpp
@@ -14,7 +14,8 @@
 #include <QVBoxLayout>
 #include <QWidget>
 
-DlgMoveTopCardsUntil::DlgMoveTopCardsUntil(QWidget *parent, QString _expr, uint _numberOfHits) : QDialog(parent)
+DlgMoveTopCardsUntil::DlgMoveTopCardsUntil(QWidget *parent, QString _expr, uint _numberOfHits, bool autoPlay)
+    : QDialog(parent)
 {
     exprLabel = new QLabel(tr("Card name (or search expressions):"));
 
@@ -33,6 +34,9 @@ DlgMoveTopCardsUntil::DlgMoveTopCardsUntil(QWidget *parent, QString _expr, uint 
     grid->addWidget(numberOfHitsLabel, 0, 0);
     grid->addWidget(numberOfHitsEdit, 0, 1);
 
+    autoPlayCheckBox = new QCheckBox(tr("Auto play hits"));
+    autoPlayCheckBox->setChecked(autoPlay);
+
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgMoveTopCardsUntil::validateAndAccept);
     connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
@@ -41,6 +45,7 @@ DlgMoveTopCardsUntil::DlgMoveTopCardsUntil(QWidget *parent, QString _expr, uint 
     mainLayout->addWidget(exprLabel);
     mainLayout->addWidget(exprEdit);
     mainLayout->addItem(grid);
+    mainLayout->addWidget(autoPlayCheckBox);
     mainLayout->addWidget(buttonBox);
 
     setLayout(mainLayout);
@@ -108,4 +113,9 @@ QString DlgMoveTopCardsUntil::getExpr() const
 uint DlgMoveTopCardsUntil::getNumberOfHits() const
 {
     return numberOfHitsEdit->text().toUInt();
+}
+
+bool DlgMoveTopCardsUntil::isAutoPlay() const
+{
+    return autoPlayCheckBox->isChecked();
 }

--- a/cockatrice/src/dialogs/dlg_move_top_cards_until.h
+++ b/cockatrice/src/dialogs/dlg_move_top_cards_until.h
@@ -1,6 +1,7 @@
 #ifndef DLG_MOVE_TOP_CARDS_UNTIL_H
 #define DLG_MOVE_TOP_CARDS_UNTIL_H
 
+#include <QCheckBox>
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QLabel>
@@ -17,14 +18,19 @@ class DlgMoveTopCardsUntil : public QDialog
     QLineEdit *exprEdit;
     QSpinBox *numberOfHitsEdit;
     QDialogButtonBox *buttonBox;
+    QCheckBox *autoPlayCheckBox;
 
     void validateAndAccept();
     bool validateMatchExists(const FilterString &filterString);
 
 public:
-    explicit DlgMoveTopCardsUntil(QWidget *parent = nullptr, QString expr = QString(), uint numberOfHits = 1);
+    explicit DlgMoveTopCardsUntil(QWidget *parent = nullptr,
+                                  QString expr = QString(),
+                                  uint numberOfHits = 1,
+                                  bool autoPlay = false);
     QString getExpr() const;
     uint getNumberOfHits() const;
+    bool isAutoPlay() const;
 };
 
 #endif // DLG_MOVE_TOP_CARDS_UNTIL_H

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -1341,19 +1341,19 @@ void Player::actMoveTopCardsUntil()
 {
     stopMoveTopCardsUntil();
 
-    DlgMoveTopCardsUntil dlg(game, previousMovingCardsUntilExpr, previousMovingCardsUntilNumberOfHits);
+    DlgMoveTopCardsUntil dlg(game, movingCardsUntilExpr, movingCardsUntilNumberOfHits);
     if (!dlg.exec()) {
         return;
     }
 
-    previousMovingCardsUntilExpr = dlg.getExpr();
-    previousMovingCardsUntilNumberOfHits = dlg.getNumberOfHits();
+    movingCardsUntilExpr = dlg.getExpr();
+    movingCardsUntilNumberOfHits = dlg.getNumberOfHits();
 
     if (zones.value("deck")->getCards().empty()) {
         stopMoveTopCardsUntil();
     } else {
-        movingCardsUntilFilter = FilterString(previousMovingCardsUntilExpr);
-        movingCardsUntilCounter = previousMovingCardsUntilNumberOfHits;
+        movingCardsUntilFilter = FilterString(movingCardsUntilExpr);
+        movingCardsUntilCounter = movingCardsUntilNumberOfHits;
         movingCardsUntil = true;
         actMoveTopCardToPlay();
     }

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -1365,7 +1365,7 @@ void Player::moveOneCardUntil(CardItem *card)
 {
     moveTopCardTimer->stop();
 
-    const bool isMatch = movingCardsUntilFilter.check(card->getInfo());
+    const bool isMatch = card && movingCardsUntilFilter.check(card->getInfo());
 
     if (isMatch && movingCardsUntilAutoPlay) {
         // Directly calling playCard will deadlock, since we are already in the middle of processing an event.

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -268,8 +268,8 @@ private:
 
     bool movingCardsUntil;
     QTimer *moveTopCardTimer;
-    QString previousMovingCardsUntilExpr = {};
-    int previousMovingCardsUntilNumberOfHits = 1;
+    QString movingCardsUntilExpr = {};
+    int movingCardsUntilNumberOfHits = 1;
     FilterString movingCardsUntilFilter;
     int movingCardsUntilCounter = 0;
     void stopMoveTopCardsUntil();

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -270,6 +270,7 @@ private:
     QTimer *moveTopCardTimer;
     QString movingCardsUntilExpr = {};
     int movingCardsUntilNumberOfHits = 1;
+    bool movingCardsUntilAutoPlay = false;
     FilterString movingCardsUntilFilter;
     int movingCardsUntilCounter = 0;
     void stopMoveTopCardsUntil();
@@ -319,7 +320,7 @@ private:
                     CardRelation::AttachType attach = CardRelation::DoesNotAttach,
                     bool persistent = false);
     bool createRelatedFromRelation(const CardItem *sourceCard, const CardRelation *cardRelation);
-    void moveOneCardUntil(const CardInfoPtr card);
+    void moveOneCardUntil(CardItem *card);
     void addPlayerToList(QMenu *playerList, Player *player);
     static void removePlayerFromList(QMenu *playerList, Player *player);
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5255

## What will change with this Pull Request?

https://github.com/user-attachments/assets/d848a562-fa93-41f8-96c2-d1fdf027bf5f

Added a new checkbox option to the `Put top cards on stack until` window. When selected, Cockatrice will automatically `play` any matching cards right after they're put on the stack.

The code literally calls `playCard` on the flipped card, so the behavior of the card play will be the same as if you did the `play` action on that card while it was on the stack. (Aka permanents will be moved to their appropriate rows and instant/sorceries will be put into the yard.)

- also renamed some `move from top until`-related variables in `Player`

## Screenshots

<img width="259" alt="Screenshot 2024-12-16 at 10 30 35 PM" src="https://github.com/user-attachments/assets/17c8dc1b-1a9c-4ac3-aef9-f896a410aeba" />
