### PR TITLE
add clone action to card menu in all zones that it functions in

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3563,6 +3563,7 @@ void Player::updateCardMenu(const CardItem *card)
 
     if (revealedCard) {
         cardMenu->addAction(aHide);
+        cardMenu->addAction(aClone);
         cardMenu->addSeparator();
         cardMenu->addAction(aSelectAll);
         addRelatedCardView(card, cardMenu);
@@ -3666,6 +3667,8 @@ void Player::updateCardMenu(const CardItem *card)
                 initContextualPlayersMenu(revealMenu);
                 connect(revealMenu, &QMenu::triggered, this, &Player::actReveal);
 
+                cardMenu->addSeparator();
+                cardMenu->addAction(aClone);
                 cardMenu->addMenu(moveMenu);
                 cardMenu->addSeparator();
                 cardMenu->addAction(aSelectAll);


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5251

## Short roundup of the initial problem
Now that the clone shortcut is always active, there are some zones that don't have the clone shortcut in their card menu that the clone shortcut functions perfectly well in. There's no reason to hide that functionality from the user.

## What will change with this Pull Request?
- Added aClone to card menu of `hand`, `deck`, `sideboard`, and `reveal windows`
  - Mostly tried to put them above the `move to` action, to match with other existing menus

## Screenshots
<img width="235" alt="Screenshot 2024-12-16 at 10 58 23 PM" src="https://github.com/user-attachments/assets/fa73f685-3475-40e2-aa97-60ee14d1816f" />
<img width="209" alt="Screenshot 2024-12-16 at 10 57 54 PM" src="https://github.com/user-attachments/assets/c4e811b0-bdde-4373-8713-39b2fcf5be93" />
<img width="217" alt="Screenshot 2024-12-16 at 10 57 43 PM" src="https://github.com/user-attachments/assets/40ce68bc-ca43-4b1b-bb0f-098ee0306b48" />

