### PR TITLE
double clicking the card view window now expands/unexpands it

### DIFF
--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -333,3 +333,16 @@ void ZoneViewWidget::initStyleOption(QStyleOption *option) const
     if (titleBar)
         titleBar->icon = QPixmap("theme:cockatrice");
 }
+
+void ZoneViewWidget::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
+{
+    if (event->pos().y() <= 0) {
+        // expand window to full height and width if not currently at full height and width
+        // otherwise shrink window to initial max height
+        if (size().height() < maximumHeight() || size().width() < maximumWidth()) {
+            resize(maximumSize());
+        } else {
+            resizeToZoneContents();
+        }
+    }
+}

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -281,7 +281,7 @@ static qreal determineNewZoneHeight(qreal oldZoneHeight)
     return calcMaxInitialHeight();
 }
 
-void ZoneViewWidget::resizeToZoneContents()
+void ZoneViewWidget::resizeToZoneContents(bool forceInitialHeight)
 {
     QRectF zoneRect = zone->getOptimumRect();
     qreal totalZoneHeight = zoneRect.height();
@@ -292,7 +292,7 @@ void ZoneViewWidget::resizeToZoneContents()
     QSizeF maxSize(width, zoneRect.height() + extraHeight + 10);
 
     qreal currentZoneHeight = rect().height() - extraHeight - 10;
-    qreal newZoneHeight = determineNewZoneHeight(currentZoneHeight);
+    qreal newZoneHeight = forceInitialHeight ? calcMaxInitialHeight() : determineNewZoneHeight(currentZoneHeight);
 
     QSizeF initialSize(width, newZoneHeight + extraHeight + 10);
 
@@ -342,7 +342,7 @@ void ZoneViewWidget::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
         if (size().height() < maximumHeight() || size().width() < maximumWidth()) {
             resize(maximumSize());
         } else {
-            resizeToZoneContents();
+            resizeToZoneContents(true);
         }
     }
 }

--- a/cockatrice/src/game/zones/view_zone_widget.h
+++ b/cockatrice/src/game/zones/view_zone_widget.h
@@ -66,8 +66,8 @@ private slots:
     void resizeToZoneContents();
     void handleScrollBarChange(int value);
     void zoneDeleted();
-    void moveEvent(QGraphicsSceneMoveEvent * /* event */);
-    void resizeEvent(QGraphicsSceneResizeEvent * /* event */);
+    void moveEvent(QGraphicsSceneMoveEvent * /* event */) override;
+    void resizeEvent(QGraphicsSceneResizeEvent * /* event */) override;
 
 public:
     ZoneViewWidget(Player *_player,
@@ -87,8 +87,8 @@ public:
     void retranslateUi();
 
 protected:
-    void closeEvent(QCloseEvent *event);
-    void initStyleOption(QStyleOption *option) const;
+    void closeEvent(QCloseEvent *event) override;
+    void initStyleOption(QStyleOption *option) const override;
 };
 
 #endif

--- a/cockatrice/src/game/zones/view_zone_widget.h
+++ b/cockatrice/src/game/zones/view_zone_widget.h
@@ -89,6 +89,7 @@ public:
 protected:
     void closeEvent(QCloseEvent *event) override;
     void initStyleOption(QStyleOption *option) const override;
+    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) override;
 };
 
 #endif

--- a/cockatrice/src/game/zones/view_zone_widget.h
+++ b/cockatrice/src/game/zones/view_zone_widget.h
@@ -63,7 +63,7 @@ private slots:
     void processGroupBy(int value);
     void processSortBy(int value);
     void processSetPileView(QT_STATE_CHANGED_T value);
-    void resizeToZoneContents();
+    void resizeToZoneContents(bool forceInitialHeight = false);
     void handleScrollBarChange(int value);
     void zoneDeleted();
     void moveEvent(QGraphicsSceneMoveEvent * /* event */) override;


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5228

## Short roundup of the initial problem
Expanding the card view window is really finicky to do. The collision in the corner to start a drag is *tiny*, and the window sometimes glitches out all over the place as you try to expand it.

## What will change with this Pull Request?
https://github.com/user-attachments/assets/2241fade-28af-4efb-8dea-efc8f295d5bc

Double clicking the top of the card view window will now expand/unexpand it. The collision area for the double-click is the same as the collision for dragging the window around.

Double clicking the window while it's not at its max width and height will cause the window to be resized to its max width and height. Double clicking while it is will cause the window to reset back to the size that it would be at when it was resized due to a card view change.

- add override qualifiers to overriden methods in `ViewZoneWidget` because it wasn't compiling for me otherwise