### PR TITLE
Reload card database action now also reloads the download urls

### DIFF
--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -1332,7 +1332,10 @@ int MainWindow::getNextCustomSetPrefix(QDir dataDir)
 
 void MainWindow::actReloadCardDatabase()
 {
-    const auto reloadOk1 = QtConcurrent::run([] { CardDatabaseManager::getInstance()->loadCardDatabases(); });
+    const auto reloadOk1 = QtConcurrent::run([] {
+        CardDatabaseManager::getInstance()->loadCardDatabases();
+        SettingsCache::instance().downloads().sync();
+    });
 }
 
 void MainWindow::actManageSets()

--- a/cockatrice/src/settings/settings_manager.cpp
+++ b/cockatrice/src/settings/settings_manager.cpp
@@ -69,3 +69,11 @@ QVariant SettingsManager::getValue(QString name, QString group, QString subGroup
 
     return value;
 }
+
+/**
+ * Calls sync on the underlying QSettings object
+ */
+void SettingsManager::sync()
+{
+    settings.sync();
+}

--- a/cockatrice/src/settings/settings_manager.h
+++ b/cockatrice/src/settings/settings_manager.h
@@ -12,6 +12,7 @@ class SettingsManager : public QObject
 public:
     explicit SettingsManager(QString settingPath, QObject *parent = nullptr);
     QVariant getValue(QString name, QString group = "", QString subGroup = "");
+    void sync();
 
 signals:
 


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5196

## Short roundup of the initial problem
I have a script that lets me automatically switch the cards.xml file used by Cockatrice. It also switches the download url settings file. 

Previously, I would just restart Cockatrice to load the new cards. After adding the `reload card database` action, I still need to restart Cockatrice, because the download urls aren't reloaded.

## What will change with this Pull Request?
- Added `sync` method to `SettingsManager` that calls `sync` on the underlying `QSettings`
- `aReloadCardDatabase` now calls `sync` on the downloads `SettingsManager` after reloading the card database
