### PR TITLE
fix bug with scrollbar not resizing when window is at max initial height

### DIFF
--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -247,10 +247,12 @@ void ZoneViewWidget::moveEvent(QGraphicsSceneMoveEvent * /* event */)
 void ZoneViewWidget::resizeEvent(QGraphicsSceneResizeEvent *event)
 {
     // We need to manually resize the scroll bar whenever the window gets resized
-    qreal totalZoneHeight = zone->getOptimumRect().height();
-    qreal newWindowHeight = event->newSize().height();
-    qreal newZoneHeight = newWindowHeight - extraHeight - 10;
+    resizeScrollbar(event->newSize().height() - extraHeight - 10);
+}
 
+void ZoneViewWidget::resizeScrollbar(const qreal newZoneHeight)
+{
+    qreal totalZoneHeight = zone->getOptimumRect().height();
     scrollBar->setMaximum(totalZoneHeight - newZoneHeight);
 }
 
@@ -278,6 +280,7 @@ void ZoneViewWidget::resizeToZoneContents()
     qreal initialZoneHeight = qMin(zoneRect.height(), calcMaxInitialHeight());
     QSizeF initialSize(width, initialZoneHeight + extraHeight + 10);
     resize(initialSize);
+    resizeScrollbar(initialZoneHeight);
 
     zone->setGeometry(QRectF(0, -scrollBar->value(), zoneContainer->size().width(), totalZoneHeight));
 

--- a/cockatrice/src/game/zones/view_zone_widget.h
+++ b/cockatrice/src/game/zones/view_zone_widget.h
@@ -55,6 +55,8 @@ private:
     bool canBeShuffled;
     int extraHeight;
     Player *player;
+
+    void resizeScrollbar(qreal newZoneHeight);
 signals:
     void closePressed(ZoneViewWidget *zv);
 private slots:


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced by #5228 

## Short roundup of the initial problem
https://github.com/user-attachments/assets/aa8fb42f-7dbc-46c4-96e6-38300b3f310c

`resizeEvent` doesn't get called if `resize()` was called on the window but the size didn't actually change, for example if the window was already at its max initial size. 

## What will change with this Pull Request?
https://github.com/user-attachments/assets/bcf8216e-00c9-4738-8048-aea8af6e5902

- Moved scrollbar resizing code to a separate method that is called in `resize`
- Call `resizeScrollbar` in `resizeToZoneContents` so that we always force a scrollbar resize after the zone contents change.





