### PR TITLE
refactor: remove cipt param from Player::playCard

### DIFF
--- a/cockatrice/src/game/board/arrow_item.cpp
+++ b/cockatrice/src/game/board/arrow_item.cpp
@@ -319,8 +319,7 @@ void ArrowAttachItem::attachCards(CardItem *startCard, const CardItem *targetCar
 
     // move card onto table first if attaching from some other zone
     if (startZone->getName() != "table") {
-        auto info = startCard->getInfo();
-        player->playCardToTable(startCard, false, info ? info->getCipt() : false);
+        player->playCardToTable(startCard, false);
     }
 
     Command_AttachCard cmd;

--- a/cockatrice/src/game/cards/card_item.cpp
+++ b/cockatrice/src/game/cards/card_item.cpp
@@ -387,7 +387,7 @@ void CardItem::playCard(bool faceDown)
         if (SettingsCache::instance().getClickPlaysAllSelected()) {
             faceDown ? zone->getPlayer()->actPlayFacedown() : zone->getPlayer()->actPlay();
         } else {
-            zone->getPlayer()->playCard(this, faceDown, info ? info->getCipt() : false);
+            zone->getPlayer()->playCard(this, faceDown);
         }
     }
 }

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -1380,10 +1380,7 @@ void Player::moveOneCardUntil(CardItem *card)
     if (isMatch && movingCardsUntilAutoPlay) {
         // Directly calling playCard will deadlock, since we are already in the middle of processing an event.
         // Use QTimer::singleShot to queue up the playCard on the event loop.
-        QTimer::singleShot(0, this, [card, this] {
-            bool cipt = card && card->getInfo() && card->getInfo()->getCipt();
-            playCard(card, false, cipt);
-        });
+        QTimer::singleShot(0, this, [card, this] { playCard(card, false); });
     }
 
     if (zones.value("deck")->getCards().empty() || !card) {
@@ -2644,7 +2641,7 @@ void Player::processCardAttachment(const ServerInfo_Player &info)
     }
 }
 
-void Player::playCard(CardItem *card, bool faceDown, bool tapped)
+void Player::playCard(CardItem *card, bool faceDown)
 {
     if (card == nullptr) {
         return;
@@ -2681,7 +2678,7 @@ void Player::playCard(CardItem *card, bool faceDown, bool tapped)
         if (!faceDown) {
             cardToMove->set_pt(info->getPowTough().toStdString());
         }
-        cardToMove->set_tapped(faceDown ? false : tapped);
+        cardToMove->set_tapped(!faceDown && info->getCipt());
         if (tableRow != 3)
             cmd.set_target_zone("table");
         cmd.set_x(gridPoint.x());
@@ -2694,7 +2691,7 @@ void Player::playCard(CardItem *card, bool faceDown, bool tapped)
  * Like {@link Player::playCard}, but forces the card to be played to the table zone.
  * Cards with tablerow 3 (the stack) will be played to tablerow 1 (the noncreatures row).
  */
-void Player::playCardToTable(CardItem *card, bool faceDown, bool tapped)
+void Player::playCardToTable(CardItem *card, bool faceDown)
 {
     if (card == nullptr) {
         return;
@@ -2723,7 +2720,7 @@ void Player::playCardToTable(CardItem *card, bool faceDown, bool tapped)
     if (!faceDown) {
         cardToMove->set_pt(info->getPowTough().toStdString());
     }
-    cardToMove->set_tapped(faceDown ? false : tapped);
+    cardToMove->set_tapped(!faceDown && info->getCipt());
     cmd.set_target_zone("table");
     cmd.set_x(gridPoint.x());
     cmd.set_y(gridPoint.y());
@@ -3570,8 +3567,7 @@ void Player::playSelectedCards(const bool faceDown)
 
     for (auto &card : selectedCards) {
         if (card && !isUnwritableRevealZone(card->getZone()) && card->getZone()->getName() != "table") {
-            const bool cipt = !faceDown && card->getInfo() ? card->getInfo()->getCipt() : false;
-            playCard(card, faceDown, cipt);
+            playCard(card, faceDown);
         }
     }
 }

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -394,8 +394,8 @@ public:
     QRectF boundingRect() const override;
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
-    void playCard(CardItem *c, bool faceDown, bool tapped);
-    void playCardToTable(CardItem *c, bool faceDown, bool tapped);
+    void playCard(CardItem *c, bool faceDown);
+    void playCardToTable(CardItem *c, bool faceDown);
     void addCard(CardItem *c);
     void deleteCard(CardItem *c);
     void addZone(CardZone *z);


### PR DESCRIPTION
## Short roundup of the initial problem

The cipt param of `Player::playCard ` is unnecessary. `cipt` can be entirely determined from the other two params

## What will change with this Pull Request?
- Removed `cipt` param from `playCard` and `playCardToTable`
- determine if card is tapped from other to params
  - card is tapped if it has cipt property and isn't faceDown
