### PR TITLE
reword "open deck in new tab" setting

### DIFF
--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -613,7 +613,7 @@ void UserInterfaceSettingsPage::retranslateUi()
     animationGroupBox->setTitle(tr("Animation settings"));
     tapAnimationCheckBox.setText(tr("&Tap/untap animation"));
     deckEditorGroupBox->setTitle(tr("Deck editor settings"));
-    openDeckInNewTabCheckBox.setText(tr("Always open deck in new tab"));
+    openDeckInNewTabCheckBox.setText(tr("Open deck in new tab by default"));
     replayGroupBox->setTitle(tr("Replay settings"));
     rewindBufferingMsLabel.setText(tr("Buffer time for backwards skip via shortcut:"));
     rewindBufferingMsBox.setSuffix(tr(" ms"));


### PR DESCRIPTION
## Related Ticket(s)
- Follow up to #5143 and #5169

## Short roundup of the initial problem
`Always open deck in new tab` isn't accurate anymore. We added some logic to still open the deck in the same tab if the tab is empty.

## What will change with this Pull Request?
- Changed to `Open deck in new tab by default`

## Screenshots
<img width="400" alt="Screenshot 2024-12-18 at 9 36 50 PM" src="https://github.com/user-attachments/assets/268b271d-0841-430e-97fe-e1fbde3d5b0e" />
