### PR TITLE
fix bug introduced in #5267

### DIFF
--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -252,6 +252,12 @@ CardInfo::~CardInfo()
     PictureLoader::clearPixmapCache(smartThis);
 }
 
+CardInfoPtr CardInfo::newInstance(const QString &_name)
+{
+    return newInstance(_name, QString(), false, QVariantHash(), QList<CardRelation *>(), QList<CardRelation *>(),
+                       CardInfoPerSetMap(), false, false, 0, false);
+}
+
 CardInfoPtr CardInfo::newInstance(const QString &_name,
                                   const QString &_text,
                                   bool _isToken,

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -223,6 +223,8 @@ public:
     }
     ~CardInfo() override;
 
+    static CardInfoPtr newInstance(const QString &_name);
+
     static CardInfoPtr newInstance(const QString &_name,
                                    const QString &_text,
                                    bool _isToken,

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -202,17 +202,17 @@ private:
     bool upsideDownArt;
 
 public:
-    explicit CardInfo(const QString &_name = QString(),
-                      const QString &_text = QString(),
-                      bool _isToken = false,
-                      QVariantHash _properties = QVariantHash(),
-                      const QList<CardRelation *> &_relatedCards = QList<CardRelation *>(),
-                      const QList<CardRelation *> &_reverseRelatedCards = QList<CardRelation *>(),
-                      CardInfoPerSetMap _sets = CardInfoPerSetMap(),
-                      bool _cipt = false,
-                      bool _landscapeOrientation = false,
-                      int _tableRow = 0,
-                      bool _upsideDownArt = false);
+    explicit CardInfo(const QString &_name,
+                      const QString &_text,
+                      bool _isToken,
+                      QVariantHash _properties,
+                      const QList<CardRelation *> &_relatedCards,
+                      const QList<CardRelation *> &_reverseRelatedCards,
+                      CardInfoPerSetMap _sets,
+                      bool _cipt,
+                      bool _landscapeOrientation,
+                      int _tableRow,
+                      bool _upsideDownArt);
     CardInfo(const CardInfo &other)
         : QObject(other.parent()), name(other.name), simpleName(other.simpleName), pixmapCacheKey(other.pixmapCacheKey),
           text(other.text), isToken(other.isToken), properties(other.properties), relatedCards(other.relatedCards),
@@ -223,17 +223,17 @@ public:
     }
     ~CardInfo() override;
 
-    static CardInfoPtr newInstance(const QString &_name = QString(),
-                                   const QString &_text = QString(),
-                                   bool _isToken = false,
-                                   QVariantHash _properties = QVariantHash(),
-                                   const QList<CardRelation *> &_relatedCards = QList<CardRelation *>(),
-                                   const QList<CardRelation *> &_reverseRelatedCards = QList<CardRelation *>(),
-                                   CardInfoPerSetMap _sets = CardInfoPerSetMap(),
-                                   bool _cipt = false,
-                                   bool _landscapeOrientation = false,
-                                   int _tableRow = 0,
-                                   bool _upsideDownArt = false);
+    static CardInfoPtr newInstance(const QString &_name,
+                                   const QString &_text,
+                                   bool _isToken,
+                                   QVariantHash _properties,
+                                   const QList<CardRelation *> &_relatedCards,
+                                   const QList<CardRelation *> &_reverseRelatedCards,
+                                   CardInfoPerSetMap _sets,
+                                   bool _cipt,
+                                   bool _landscapeOrientation,
+                                   int _tableRow,
+                                   bool _upsideDownArt);
 
     CardInfoPtr clone() const
     {

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
@@ -140,6 +140,7 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
             auto _sets = CardInfoPerSetMap();
             int tableRow = 0;
             bool cipt = false;
+            bool landscapeOrientation = false;
             bool isToken = false;
             bool upsideDown = false;
 
@@ -165,6 +166,8 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
                     tableRow = xml.readElementText(QXmlStreamReader::IncludeChildElements).toInt();
                 } else if (xmlName == "cipt") {
                     cipt = (xml.readElementText(QXmlStreamReader::IncludeChildElements) == "1");
+                } else if (xmlName == "landscapeOrientation") {
+                    landscapeOrientation = (xml.readElementText(QXmlStreamReader::IncludeChildElements) == "1");
                 } else if (xmlName == "upsidedown") {
                     upsideDown = (xml.readElementText(QXmlStreamReader::IncludeChildElements) == "1");
                     // sets
@@ -233,8 +236,9 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
                 }
             }
 
-            CardInfoPtr newCard = CardInfo::newInstance(name, text, isToken, properties, relatedCards,
-                                                        reverseRelatedCards, _sets, cipt, tableRow, upsideDown);
+            CardInfoPtr newCard =
+                CardInfo::newInstance(name, text, isToken, properties, relatedCards, reverseRelatedCards, _sets, cipt,
+                                      landscapeOrientation, tableRow, upsideDown);
             emit addCard(newCard);
         }
     }


### PR DESCRIPTION
## Short roundup of the initial problem

Cards are always being played to tablerow 1

https://github.com/user-attachments/assets/68de4568-1fa2-4a9d-8773-2ec190d14b12

Only `CockatriceXml3Parser` got updated with the new parsing logic; `CockatriceXml4Parser` was missed. It still compiled because `CardInfo::newInstance` has default args.

## What will change with this Pull Request?
- update `CockatriceXml4Parser` with the same updates that were done to `CockatriceXml3Parser`
- remove default args from CardInfo constructors to prevent similar bugs in the future
