### PR TITLE
fix bug with multi-attach sometimes only attaching one card

### DIFF
--- a/cockatrice/src/game/board/arrow_item.h
+++ b/cockatrice/src/game/board/arrow_item.h
@@ -21,6 +21,7 @@ protected:
     Player *player;
     int id;
     ArrowTarget *startItem, *targetItem;
+    bool targetLocked;
     QColor color;
     bool fullColor;
     void mousePressEvent(QGraphicsSceneMouseEvent *event);
@@ -63,6 +64,10 @@ public:
     ArrowTarget *getTargetItem() const
     {
         return targetItem;
+    }
+    void setTargetLocked(bool _targetLocked)
+    {
+        targetLocked = _targetLocked;
     }
     void delArrow();
 };


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5271

## Short roundup of the initial problem
Cause of bug, as a step-by-step:
- parent arrow's `mouseReleaseEvent` is processed
- `startItem` of the parent arrow becomes attached and gets moved the new position
- `startItem` is now right under the cursor, so the child arrows all retarget to it
- child arrows get processed, now pointing to the parent's `startItem`
- attach fails for child arrows since target is already attached.

## What will change with this Pull Request?
- Introduce a `targetLocked` field to `ArrowItem` class
- When processing a `mouseReleaseEvent`, the parent arrow will `targetLock` all its child arrows before attaching the startItem, so that the children can't retarget to `startItem` in the instant between `startItem` being attached and the child arrow being processed.


