### PR TITLE
check that target card is in play before attaching

### DIFF
--- a/cockatrice/src/game/board/arrow_item.cpp
+++ b/cockatrice/src/game/board/arrow_item.cpp
@@ -309,8 +309,8 @@ void ArrowAttachItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 
 void ArrowAttachItem::attachCards(CardItem *startCard, const CardItem *targetCard)
 {
-    // do nothing if target is already attached to another card
-    if (targetCard->getAttachedTo()) {
+    // do nothing if target is already attached to another card or is not in play
+    if (targetCard->getAttachedTo() || targetCard->getZone()->getName() != "table") {
         return;
     }
 


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5250  

## Short roundup of the initial problem

Trying to attach cards in non-table zones to a card in a non-table zone will cause the attaching cards to get played and nothing else to happen.

https://github.com/user-attachments/assets/8fcd2c99-818d-403b-85de-82befeef9011

## What will change with this Pull Request?

https://github.com/user-attachments/assets/fbe86acd-3965-4430-98f1-662e71dd941d

Trying to attach to a card that's not on the table now does nothing.

- Check that the target card is in table zone before going through the attaching process.
