### PR TITLE
allow attached cards to be moved to other zones

### DIFF
--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -450,9 +450,13 @@ Response::ResponseCode Server_Player::moveCard(GameEventStorage &ges,
         if (!card) {
             return Response::RespNameNotFound;
         }
-        if (card->getParentCard()) {
+
+        // do not allow attached cards to move around on the table
+        if (card->getParentCard() && targetzone->getName() == "table") {
             continue;
         }
+
+        // do not allow cards with attachments to stack with other cards
         if (!card->getAttachedCards().isEmpty() && !targetzone->isColumnEmpty(xCoord, yCoord)) {
             continue;
         }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5274

## What will change with this Pull Request?

https://github.com/user-attachments/assets/cea64158-91bd-4cae-a0ab-e3b53e1ed179

- server now allows move commands on attached cards to succeed if the attached card is being moved to a non-table zone

No idea if this breaks anything. Everything seems to be working fine for me so far in my testing.
