### PR TITLE
make unattach shortcut work consistently when multiple cards are selected

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -1009,6 +1009,10 @@ void Player::setShortcutsActive()
         game->addAction(aClone);
         game->addAction(aDrawArrow);
         game->addAction(aSelectAll);
+
+        // unattach action is only active in card menu if the active card is attached.
+        // make unattach shortcut always active so that it consistently works when multiple cards are selected.
+        game->addAction(aUnattach);
     }
 }
 
@@ -3491,13 +3495,14 @@ void Player::actAttach()
 
 void Player::actUnattach()
 {
-    if (!game->getActiveCard()) {
-        return;
-    }
-
     QList<const ::google::protobuf::Message *> commandList;
     for (QGraphicsItem *item : scene()->selectedItems()) {
         auto *card = static_cast<CardItem *>(item);
+
+        if (!card->getAttachedTo()) {
+            continue;
+        }
+
         auto *cmd = new Command_AttachCard;
         cmd->set_start_zone(card->getZone()->getName().toStdString());
         cmd->set_card_id(card->getId());


### PR DESCRIPTION
## Short roundup of the initial problem

Unattach shortcut inconsistently works when multiple cards are selected. 

That is because shortcuts are only active when the card menu of the current `activeCard` has that action. The unattach action only shows up in card menus if that card is attached, so if you select multiple cards, the unattach shortcut will only be active if the last selected card is attached.

Ideally, we want the unattach shortcut to consistently be active and try to unattach all selected attached cards.

## What will change with this Pull Request?
- added `aUnattach` to the always-active shortcuts
- `actUnattach` no longer checks for `activeCard`, since it will affect all selected cards anyways
  - now checks that the card is attached before sending unattach command
    - Server already handles an unattach command on an unattached card, but I added the check to reduce flooding.

Note that the fix won't apply to local games. Enabling the always-active shortcuts in local games causes keyboard shortcuts to work inconsistently when there are more than 1 player.
