### PR TITLE
move SearchLineEdit into custom_line_edit file

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -50,22 +50,6 @@
 #include <QUrl>
 #include <QVBoxLayout>
 
-void SearchLineEdit::keyPressEvent(QKeyEvent *event)
-{
-    // List of key events that must be handled by the card list instead of the search box
-    static const QVector<Qt::Key> forwardToTreeView = {Qt::Key_Up, Qt::Key_Down, Qt::Key_PageDown, Qt::Key_PageUp};
-    // forward only if the search text is empty
-    static const QVector<Qt::Key> forwardWhenEmpty = {Qt::Key_Home, Qt::Key_End};
-    Qt::Key key = static_cast<Qt::Key>(event->key());
-    if (treeView) {
-        if (forwardToTreeView.contains(key))
-            QCoreApplication::sendEvent(treeView, event);
-        if (text().isEmpty() && forwardWhenEmpty.contains(key))
-            QCoreApplication::sendEvent(treeView, event);
-    }
-    LineEditUnfocusable::keyPressEvent(event);
-}
-
 void TabDeckEditor::createDeckDock()
 {
     deckModel = new DeckListModel(this);

--- a/cockatrice/src/client/tabs/tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/tab_deck_editor.h
@@ -29,24 +29,6 @@ class QVBoxLayout;
 class QPushButton;
 class QDockWidget;
 
-class SearchLineEdit : public LineEditUnfocusable
-{
-private:
-    QTreeView *treeView;
-
-protected:
-    void keyPressEvent(QKeyEvent *event) override;
-
-public:
-    SearchLineEdit() : LineEditUnfocusable(), treeView(nullptr)
-    {
-    }
-    void setTreeView(QTreeView *_treeView)
-    {
-        treeView = _treeView;
-    }
-};
-
 class TabDeckEditor : public Tab
 {
     Q_OBJECT

--- a/cockatrice/src/deck/custom_line_edit.cpp
+++ b/cockatrice/src/deck/custom_line_edit.cpp
@@ -6,6 +6,7 @@
 #include <QKeyEvent>
 #include <QLineEdit>
 #include <QObject>
+#include <QTreeView>
 #include <QWidget>
 
 LineEditUnfocusable::LineEditUnfocusable(QWidget *parent) : QLineEdit(parent)
@@ -68,4 +69,20 @@ bool LineEditUnfocusable::eventFilter(QObject *watched, QEvent *event)
     }
 
     return QLineEdit::eventFilter(watched, event);
+}
+
+void SearchLineEdit::keyPressEvent(QKeyEvent *event)
+{
+    // List of key events that must be handled by the card list instead of the search box
+    static const QVector<Qt::Key> forwardToTreeView = {Qt::Key_Up, Qt::Key_Down, Qt::Key_PageDown, Qt::Key_PageUp};
+    // forward only if the search text is empty
+    static const QVector<Qt::Key> forwardWhenEmpty = {Qt::Key_Home, Qt::Key_End};
+    Qt::Key key = static_cast<Qt::Key>(event->key());
+    if (treeView) {
+        if (forwardToTreeView.contains(key))
+            QCoreApplication::sendEvent(treeView, event);
+        if (text().isEmpty() && forwardWhenEmpty.contains(key))
+            QCoreApplication::sendEvent(treeView, event);
+    }
+    LineEditUnfocusable::keyPressEvent(event);
 }

--- a/cockatrice/src/deck/custom_line_edit.h
+++ b/cockatrice/src/deck/custom_line_edit.h
@@ -4,6 +4,7 @@
 
 #include <QLineEdit>
 
+class QTreeView;
 class QKeyEvent;
 class QWidget;
 class QString;
@@ -23,6 +24,24 @@ private:
 protected:
     void keyPressEvent(QKeyEvent *event) override;
     bool eventFilter(QObject *watched, QEvent *event) override;
+};
+
+class SearchLineEdit : public LineEditUnfocusable
+{
+private:
+    QTreeView *treeView;
+
+protected:
+    void keyPressEvent(QKeyEvent *event) override;
+
+public:
+    SearchLineEdit() : LineEditUnfocusable(), treeView(nullptr)
+    {
+    }
+    void setTreeView(QTreeView *_treeView)
+    {
+        treeView = _treeView;
+    }
 };
 
 #endif


### PR DESCRIPTION

## Short roundup of the initial problem
I want to use `SearchLineEdit` somewhere else

## What will change with this Pull Request?
- Moved `SearchLineEdit` out of `tab_deck_editor` and into `custom_line_edit`
