### PR TITLE
allow filter string error to be translated

### DIFF
--- a/cockatrice/src/game/filters/filter_string.cpp
+++ b/cockatrice/src/game/filters/filter_string.cpp
@@ -364,6 +364,15 @@ FilterString::FilterString()
     _error = "Not initialized";
 }
 
+void FilterString::logger(size_t ln, size_t col, const std::string &msg) {
+    if(ln == 0) {
+        _error = tr("Error at position %1: %2").arg(col).arg(QString::fromStdString(msg));
+    }else{
+        _error = tr("Error at line %1, position %2: %3").arg(ln).arg(col).arg(QString::fromStdString(msg));
+    }
+    }
+
+
 FilterString::FilterString(const QString &expr)
 {
     QByteArray ba = expr.simplified().toUtf8();
@@ -377,9 +386,7 @@ FilterString::FilterString(const QString &expr)
         return;
     }
 
-    search.set_logger([&](size_t /*ln*/, size_t col, const std::string &msg) {
-        _error = QString("Error at position %1: %2").arg(col).arg(QString::fromStdString(msg));
-    });
+    search.set_logger([this](size_t ln, size_t col, const std::string &msg){logger(ln, col, msg);});
 
     if (!search.parse(ba.data(), result)) {
         qDebug().nospace() << "FilterString error for " << expr << "; " << qPrintable(_error);

--- a/cockatrice/src/game/filters/filter_string.h
+++ b/cockatrice/src/game/filters/filter_string.h
@@ -21,8 +21,10 @@ struct EmptyType;
 typedef AstBase<EmptyType> Ast;
 } // namespace peg
 
-class FilterString
+class FilterString : QObject
 {
+    Q_OBJECT
+
 public:
     FilterString();
     explicit FilterString(const QString &exp);
@@ -42,6 +44,8 @@ public:
     }
 
 private:
+    void logger(size_t ln, size_t col, const std::string &msg);
+
     QString _error;
     Filter result;
 };


### PR DESCRIPTION
## Related Ticket(s)
- Fixes https://github.com/Cockatrice/Cockatrice/pull/5240#discussion_r1884719138

## Short roundup of the initial problem
this error is displayed in a dialog but is never translateable

however, implementing this will lead to translated strings in the log, which we don't want. we should reconsider using the debug output for user facing strings.

## What will change with this Pull Request?
- filterstring is now a qobject
- use tr in error logging
