### PR TITLE
implement search bar in shortcuts menu

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -126,6 +126,7 @@ set(cockatrice_SOURCES
     src/settings/settings_manager.cpp
     src/settings/cache_settings.cpp
     src/settings/shortcuts_settings.cpp
+    src/settings/shortcut_treeview.cpp
     src/client/sound_engine.cpp
     src/client/network/spoiler_background_updater.cpp
     src/game/zones/stack_zone.cpp

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -39,8 +39,6 @@
 #include <QStackedWidget>
 #include <QToolBar>
 #include <QTranslator>
-#include <QTreeWidget>
-#include <QTreeWidgetItem>
 
 #define WIKI_CUSTOM_PIC_URL "https://github.com/Cockatrice/Cockatrice/wiki/Custom-Picture-Download-URLs"
 #define WIKI_CUSTOM_SHORTCUTS "https://github.com/Cockatrice/Cockatrice/wiki/Custom-Keyboard-Shortcuts"

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -6,10 +6,12 @@
 #include "../client/sound_engine.h"
 #include "../client/ui/picture_loader.h"
 #include "../client/ui/theme_manager.h"
+#include "../deck/custom_line_edit.h"
 #include "../game/cards/card_database.h"
 #include "../game/cards/card_database_manager.h"
 #include "../main.h"
 #include "../settings/cache_settings.h"
+#include "../settings/shortcut_treeview.h"
 #include "../utility/sequence_edit.h"
 
 #include <QAction>
@@ -1251,13 +1253,24 @@ void SoundSettingsPage::retranslateUi()
 
 ShortcutSettingsPage::ShortcutSettingsPage()
 {
+    // search bar
+    searchEdit = new SearchLineEdit;
+    searchEdit->setObjectName("searchEdit");
+    searchEdit->setPlaceholderText(tr("Search by shortcut name"));
+    searchEdit->setClearButtonEnabled(true);
+
+    setFocusProxy(searchEdit);
+    setFocusPolicy(Qt::ClickFocus);
+
     // table
-    shortcutsTable = new QTreeWidget();
-    shortcutsTable->setColumnCount(2);
+    shortcutsTable = new ShortcutTreeView(this);
+
     shortcutsTable->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    shortcutsTable->setUniformRowHeights(true);
-    shortcutsTable->setAlternatingRowColors(true);
-    shortcutsTable->header()->resizeSection(0, shortcutsTable->width() / 3 * 2);
+    shortcutsTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    shortcutsTable->setColumnWidth(0, width() / 3 * 2);
+    searchEdit->setTreeView(shortcutsTable);
+
+    connect(searchEdit, &SearchLineEdit::textChanged, shortcutsTable, &ShortcutTreeView::updateSearchString);
 
     // edit widget
     currentActionGroupLabel = new QLabel(this);
@@ -1297,6 +1310,7 @@ ShortcutSettingsPage::ShortcutSettingsPage()
     _buttonsLayout->addWidget(btnClearAll);
 
     auto *_mainLayout = new QVBoxLayout;
+    _mainLayout->addWidget(searchEdit);
     _mainLayout->addWidget(shortcutsTable);
     _mainLayout->addWidget(editShortcutGroupBox);
     _mainLayout->addLayout(_buttonsLayout);
@@ -1305,21 +1319,17 @@ ShortcutSettingsPage::ShortcutSettingsPage()
 
     connect(btnResetAll, SIGNAL(clicked()), this, SLOT(resetShortcuts()));
     connect(btnClearAll, SIGNAL(clicked()), this, SLOT(clearShortcuts()));
-    connect(shortcutsTable, SIGNAL(currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)), this,
-            SLOT(currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)));
-    connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
 
-    createShortcuts();
+    connect(shortcutsTable, &ShortcutTreeView::currentItemChanged, this, &ShortcutSettingsPage::currentItemChanged);
 }
 
-void ShortcutSettingsPage::currentItemChanged(QTreeWidgetItem *current, QTreeWidgetItem * /*previous */)
+void ShortcutSettingsPage::currentItemChanged(const QString &key)
 {
-    if (current == nullptr) {
+    if (key.isEmpty()) {
         currentActionGroupName->setText("");
         currentActionName->setText("");
         editTextBox->setShortcutName("");
     } else {
-        QString key = current->data(2, Qt::DisplayRole).toString();
         QString group = SettingsCache::instance().shortcuts().getShortcut(key).getGroupName();
         QString action = SettingsCache::instance().shortcuts().getShortcut(key).getName();
         currentActionGroupName->setText(group);
@@ -1336,59 +1346,6 @@ void ShortcutSettingsPage::resetShortcuts()
     }
 }
 
-void ShortcutSettingsPage::createShortcuts()
-{
-    QHash<QString, QTreeWidgetItem *> parentItems;
-    QTreeWidgetItem *curParent = nullptr;
-    for (const auto &key : SettingsCache::instance().shortcuts().getAllShortcutKeys()) {
-        QString name = SettingsCache::instance().shortcuts().getShortcut(key).getName();
-        QString group = SettingsCache::instance().shortcuts().getShortcut(key).getGroupName();
-        QString shortcut = SettingsCache::instance().shortcuts().getShortcutString(key);
-
-        if (parentItems.contains(group)) {
-            curParent = parentItems.value(group);
-        } else {
-            curParent = new QTreeWidgetItem((QTreeWidget *)nullptr, QStringList({group, "", ""}));
-            static QFont font = curParent->font(0);
-            font.setBold(true);
-            curParent->setFont(0, font);
-            parentItems.insert(group, curParent);
-        }
-
-        new QTreeWidgetItem(curParent, QStringList({name, shortcut, key}));
-    }
-    shortcutsTable->clear();
-    shortcutsTable->insertTopLevelItems(0, parentItems.values());
-    shortcutsTable->setCurrentItem(nullptr);
-    shortcutsTable->expandAll();
-    shortcutsTable->sortItems(0, Qt::AscendingOrder);
-}
-
-void ShortcutSettingsPage::refreshShortcuts()
-{
-    QTreeWidgetItem *curParent = nullptr;
-    QTreeWidgetItem *curChild = nullptr;
-    for (int i = 0; i < shortcutsTable->topLevelItemCount(); ++i) {
-        curParent = shortcutsTable->topLevelItem(i);
-        for (int j = 0; j < curParent->childCount(); ++j) {
-            curChild = curParent->child(j);
-            QString key = curChild->data(2, Qt::DisplayRole).toString();
-            QString name = SettingsCache::instance().shortcuts().getShortcut(key).getName();
-            QString shortcut = SettingsCache::instance().shortcuts().getShortcutString(key);
-            curChild->setText(0, name);
-            curChild->setText(1, shortcut);
-
-            if (j == 0) {
-                // the first child also updates the parent's group name
-                QString group = SettingsCache::instance().shortcuts().getShortcut(key).getGroupName();
-                curParent->setText(0, group);
-            }
-        }
-    }
-    shortcutsTable->sortItems(0, Qt::AscendingOrder);
-    currentItemChanged(shortcutsTable->currentItem(), nullptr);
-}
-
 void ShortcutSettingsPage::clearShortcuts()
 {
     if (QMessageBox::question(this, tr("Clear all default shortcuts"),
@@ -1399,8 +1356,7 @@ void ShortcutSettingsPage::clearShortcuts()
 
 void ShortcutSettingsPage::retranslateUi()
 {
-    shortcutsTable->setHeaderLabels(QStringList() << tr("Action") << tr("Shortcut"));
-    refreshShortcuts();
+    shortcutsTable->retranslateUi();
 
     currentActionGroupLabel->setText(tr("Section:"));
     currentActionLabel->setText(tr("Action:"));

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -9,9 +9,7 @@
 #include <QGroupBox>
 #include <QLabel>
 #include <QPushButton>
-#include <QSortFilterProxyModel>
 #include <QSpinBox>
-#include <QtGui/qstandarditemmodel.h>
 
 class ShortcutTreeView;
 class SearchLineEdit;
@@ -27,8 +25,6 @@ class QListWidgetItem;
 class QRadioButton;
 class QSlider;
 class QStackedWidget;
-class QTreeWidget;
-class QTreeWidgetItem;
 class QVBoxLayout;
 class SequenceEdit;
 

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -9,8 +9,14 @@
 #include <QGroupBox>
 #include <QLabel>
 #include <QPushButton>
+#include <QSortFilterProxyModel>
 #include <QSpinBox>
+#include <QtGui/qstandarditemmodel.h>
 
+class ShortcutTreeView;
+class SearchLineEdit;
+class QTreeView;
+class QStandardItemModel;
 class CardDatabase;
 class QCloseEvent;
 class QGridLayout;
@@ -267,7 +273,8 @@ public:
     void retranslateUi() override;
 
 private:
-    QTreeWidget *shortcutsTable;
+    SearchLineEdit *searchEdit;
+    ShortcutTreeView *shortcutsTable;
     QVBoxLayout *mainLayout;
     QHBoxLayout *buttonsLayout;
     QGroupBox *editShortcutGroupBox;
@@ -284,10 +291,8 @@ private:
 
 private slots:
     void resetShortcuts();
-    void refreshShortcuts();
-    void createShortcuts();
     void clearShortcuts();
-    void currentItemChanged(QTreeWidgetItem *current, QTreeWidgetItem *previous);
+    void currentItemChanged(const QString &key);
 };
 
 class DlgSettings : public QDialog

--- a/cockatrice/src/settings/shortcut_treeview.cpp
+++ b/cockatrice/src/settings/shortcut_treeview.cpp
@@ -38,7 +38,7 @@ ShortcutTreeView::ShortcutTreeView(QWidget *parent) : QTreeView(parent)
     setSelectionMode(SingleSelection);
     setSelectionBehavior(SelectRows);
 
-    expandRecursively(QModelIndex());
+    expandAll();
 
     connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
             &ShortcutTreeView::refreshShortcuts);
@@ -128,5 +128,5 @@ void ShortcutTreeView::currentChanged(const QModelIndex &current, const QModelIn
 void ShortcutTreeView::updateSearchString(const QString &searchString)
 {
     proxyModel->setFilterFixedString(searchString);
-    expandRecursively(QModelIndex());
+    expandAll();
 }

--- a/cockatrice/src/settings/shortcut_treeview.cpp
+++ b/cockatrice/src/settings/shortcut_treeview.cpp
@@ -1,0 +1,132 @@
+#include "shortcut_treeview.h"
+
+#include "cache_settings.h"
+#include "shortcuts_settings.h"
+
+#include <QHeaderView>
+#include <QSortFilterProxyModel>
+
+ShortcutTreeView::ShortcutTreeView(QWidget *parent) : QTreeView(parent)
+{
+    // model
+    shortcutsModel = new QStandardItemModel(this);
+    shortcutsModel->setColumnCount(3);
+    populateShortcutsModel();
+
+    // filter proxy
+    proxyModel = new QSortFilterProxyModel(this);
+    proxyModel->setRecursiveFilteringEnabled(true);
+    proxyModel->setSourceModel(shortcutsModel);
+    proxyModel->setDynamicSortFilter(true);
+    proxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
+    proxyModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
+    proxyModel->setFilterKeyColumn(0);
+
+    QTreeView::setModel(proxyModel);
+
+    // treeview
+    hideColumn(2);
+
+    setUniformRowHeights(true);
+    setAlternatingRowColors(true);
+
+    setSortingEnabled(true);
+    proxyModel->sort(0, Qt::AscendingOrder);
+
+    header()->setSectionResizeMode(QHeaderView::Interactive);
+    header()->setSortIndicator(0, Qt::AscendingOrder);
+    setSelectionMode(SingleSelection);
+    setSelectionBehavior(SelectRows);
+
+    expandRecursively(QModelIndex());
+
+    connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
+            &ShortcutTreeView::refreshShortcuts);
+}
+
+void ShortcutTreeView::populateShortcutsModel()
+{
+    QHash<QString, QStandardItem *> parentItems;
+    QStandardItem *curParent = nullptr;
+    for (const auto &key : SettingsCache::instance().shortcuts().getAllShortcutKeys()) {
+        QString name = SettingsCache::instance().shortcuts().getShortcut(key).getName();
+        QString group = SettingsCache::instance().shortcuts().getShortcut(key).getGroupName();
+        QString shortcut = SettingsCache::instance().shortcuts().getShortcutString(key);
+
+        if (parentItems.contains(group)) {
+            curParent = parentItems.value(group);
+        } else {
+            curParent = new QStandardItem(group);
+            static QFont font = curParent->font();
+            font.setBold(true);
+            curParent->setFont(font);
+            parentItems.insert(group, curParent);
+        }
+
+        QList<QStandardItem *> list = {};
+        list << new QStandardItem(name) << new QStandardItem(shortcut) << new QStandardItem(key);
+        curParent->appendRow(list);
+    }
+
+    for (const auto &parent : parentItems) {
+        shortcutsModel->appendRow(parent);
+    }
+}
+
+void ShortcutTreeView::retranslateUi()
+{
+    shortcutsModel->setHeaderData(0, Qt::Horizontal, tr("Action"));
+    shortcutsModel->setHeaderData(1, Qt::Horizontal, tr("Shortcut"));
+    refreshShortcuts();
+}
+
+/**
+ * Loops over the model and reloads all rows
+ */
+static void loopOverModel(QAbstractItemModel *model, const QModelIndex &parent = QModelIndex())
+{
+    for (int r = 0; r < model->rowCount(parent); ++r) {
+        const auto friendlyNameIndex = model->index(r, 0, parent);
+
+        if (model->hasChildren(friendlyNameIndex)) {
+            const auto childIndex = model->index(0, 2, friendlyNameIndex);
+            const auto key = model->data(childIndex).toString();
+            const auto shortcutGroupName = SettingsCache::instance().shortcuts().getShortcut(key).getGroupName();
+            model->setData(friendlyNameIndex, shortcutGroupName);
+
+            loopOverModel(model, friendlyNameIndex);
+        } else {
+            const auto shortcutSequenceIndex = model->index(r, 1, parent);
+            const auto keyIndex = model->index(r, 2, parent);
+            const auto key = model->data(keyIndex).toString();
+
+            const auto shortcutKey = SettingsCache::instance().shortcuts().getShortcut(key).getName();
+            const auto shortcutSequence = SettingsCache::instance().shortcuts().getShortcutString(key);
+            model->setData(friendlyNameIndex, shortcutKey);
+            model->setData(shortcutSequenceIndex, shortcutSequence);
+        }
+    }
+}
+
+void ShortcutTreeView::refreshShortcuts()
+{
+    loopOverModel(shortcutsModel);
+}
+
+void ShortcutTreeView::currentChanged(const QModelIndex &current, const QModelIndex & /* previous */)
+{
+    QTreeView::scrollTo(current, QAbstractItemView::EnsureVisible);
+    if (current.parent().isValid()) {
+        auto shortcutName = model()->data(model()->index(current.row(), 2, current.parent())).toString();
+        emit currentItemChanged(shortcutName);
+    } else {
+        // emit empty string if the selection is a category header
+        emit currentItemChanged("");
+    }
+}
+
+void ShortcutTreeView::updateSearchString(const QString &searchString)
+{
+    proxyModel->setFilterFixedString(searchString);
+    expandRecursively(QModelIndex());
+}

--- a/cockatrice/src/settings/shortcut_treeview.h
+++ b/cockatrice/src/settings/shortcut_treeview.h
@@ -1,0 +1,35 @@
+#ifndef SHORTCUT_TREEVIEW_H
+#define SHORTCUT_TREEVIEW_H
+
+#include <QDebug>
+#include <QModelIndex>
+#include <QStandardItemModel>
+#include <QTreeView>
+
+class QSortFilterProxyModel;
+class ShortcutTreeView : public QTreeView
+{
+    Q_OBJECT
+public:
+    explicit ShortcutTreeView(QWidget *parent);
+    void retranslateUi();
+
+signals:
+    void currentItemChanged(const QString &shortcut);
+
+public slots:
+    void updateSearchString(const QString &searchString);
+
+private:
+    QStandardItemModel *shortcutsModel;
+    QSortFilterProxyModel *proxyModel;
+    void populateShortcutsModel();
+
+private slots:
+    void refreshShortcuts();
+
+protected:
+    void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
+};
+
+#endif // SHORTCUT_TREEVIEW_H

--- a/cockatrice/src/settings/shortcut_treeview.h
+++ b/cockatrice/src/settings/shortcut_treeview.h
@@ -1,7 +1,6 @@
 #ifndef SHORTCUT_TREEVIEW_H
 #define SHORTCUT_TREEVIEW_H
 
-#include <QDebug>
 #include <QModelIndex>
 #include <QStandardItemModel>
 #include <QTreeView>


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3648

## What will change with this Pull Request?

https://github.com/user-attachments/assets/e39e3451-389c-4e2e-b68d-9e10b40fb1ad

Shortcut settings menu now has a search bar.

Currently the search bar is a very primitive implementation. It searches for that exact string, including spaces. It doesn't do the thing where it splits on spaces and shows the row if it matches any word in the string.
Perhaps we can improve the functionality of the search bar later.

- Moved the Shortcuts table from a `QTreeWidget` into its own `QTreeView` subclass in a separate file
  - Also moved the view and model logic into the subclass.

## Screenshots
<img width="500" alt="Screenshot 2024-12-21 at 2 53 12 PM" src="https://github.com/user-attachments/assets/911eea17-112b-4b24-a0df-0b568f6db2cf" />

<img width="500" alt="Screenshot 2024-12-21 at 3 03 02 PM" src="https://github.com/user-attachments/assets/c6a850a6-fab8-47a6-8e82-cb33c2b79862" />
