### PR TITLE
Fix multiple "Selected Cards" in Menu on MacOS

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3970,7 +3970,9 @@ void Player::setCardMenu(QMenu *menu)
 {
     if (aCardMenu != nullptr) {
         aCardMenu->setEnabled(menu != nullptr);
-        aCardMenu->setMenu(menu);
+        if (menu) {
+            aCardMenu->setMenu(menu);
+        }
     }
 }
 


### PR DESCRIPTION
Did a lot of testing to make sure shortcuts don't break and only one selected cards ever appears, across both Windows and MacOS