### PR TITLE
Fix "ghosting" of cards sticking on invalid moves

### DIFF
--- a/cockatrice/src/game/cards/card_drag_item.cpp
+++ b/cockatrice/src/game/cards/card_drag_item.cpp
@@ -95,18 +95,24 @@ void CardDragItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 
     QList<CardDragItem *> dragItemList;
     CardZone *startZone = static_cast<CardItem *>(item)->getZone();
-    if (currentZone && !(static_cast<CardItem *>(item)->getAttachedTo() && (startZone == currentZone)) && !occupied) {
-        dragItemList.append(this);
+    if (currentZone && !(static_cast<CardItem *>(item)->getAttachedTo() && (startZone == currentZone))) {
+        if (!occupied) {
+            dragItemList.append(this);
+        }
+
         for (int i = 0; i < childDrags.size(); i++) {
             CardDragItem *c = static_cast<CardDragItem *>(childDrags[i]);
-            if (!(static_cast<CardItem *>(c->item)->getAttachedTo() && (startZone == currentZone)) && !c->occupied)
+            if (!occupied && !(static_cast<CardItem *>(c->item)->getAttachedTo() && (startZone == currentZone)) &&
+                !c->occupied) {
                 dragItemList.append(c);
+            }
             sc->removeItem(c);
         }
     }
 
-    if (currentZone)
+    if (currentZone) {
         currentZone->handleDropEvent(dragItemList, startZone, (sp - currentZone->scenePos()).toPoint());
+    }
 
     event->accept();
 }


### PR DESCRIPTION
## Related Ticket(s)
- Follow up to #4963

## Short roundup of the initial problem
When trying to move a stack of cards, if the starting position was occupied then the ghost cards would not disappear.

## What will change with this Pull Request?
Scene gets cleaned up of ghosts on each iteration, regardless if the move is successful or not

## Screenshots
![image](https://github.com/user-attachments/assets/77019b19-64a0-4172-aba2-a7cc388afca5)

