### PR TITLE
shortcut search now displays all rows in section

### DIFF
--- a/cockatrice/src/settings/shortcut_treeview.cpp
+++ b/cockatrice/src/settings/shortcut_treeview.cpp
@@ -4,7 +4,22 @@
 #include "shortcuts_settings.h"
 
 #include <QHeaderView>
-#include <QSortFilterProxyModel>
+
+ShortcutFilterProxyModel::ShortcutFilterProxyModel(QObject *parent) : QSortFilterProxyModel(parent)
+{
+}
+
+/**
+ * @return True if this row or its parent matches the search string
+ */
+bool ShortcutFilterProxyModel::filterAcceptsRow(const int sourceRow, const QModelIndex &sourceParent) const
+{
+    QModelIndex nameIndex = sourceModel()->index(sourceRow, filterKeyColumn(), sourceParent);
+    QModelIndex parentIndex = sourceModel()->index(sourceParent.row(), filterKeyColumn(), sourceParent.parent());
+
+    return sourceModel()->data(nameIndex).toString().contains(filterRegularExpression()) ||
+           sourceModel()->data(parentIndex).toString().contains(filterRegularExpression());
+}
 
 ShortcutTreeView::ShortcutTreeView(QWidget *parent) : QTreeView(parent)
 {
@@ -14,7 +29,7 @@ ShortcutTreeView::ShortcutTreeView(QWidget *parent) : QTreeView(parent)
     populateShortcutsModel();
 
     // filter proxy
-    proxyModel = new QSortFilterProxyModel(this);
+    proxyModel = new ShortcutFilterProxyModel(this);
     proxyModel->setRecursiveFilteringEnabled(true);
     proxyModel->setSourceModel(shortcutsModel);
     proxyModel->setDynamicSortFilter(true);

--- a/cockatrice/src/settings/shortcut_treeview.h
+++ b/cockatrice/src/settings/shortcut_treeview.h
@@ -2,10 +2,23 @@
 #define SHORTCUT_TREEVIEW_H
 
 #include <QModelIndex>
+#include <QSortFilterProxyModel>
 #include <QStandardItemModel>
 #include <QTreeView>
 
-class QSortFilterProxyModel;
+/**
+ * Custom implementation of QSortFilterProxyModel that also searches in the parent's string when filtering
+ */
+class ShortcutFilterProxyModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+public:
+    explicit ShortcutFilterProxyModel(QObject *parent = nullptr);
+
+protected:
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
+};
+
 class ShortcutTreeView : public QTreeView
 {
     Q_OBJECT
@@ -21,7 +34,7 @@ public slots:
 
 private:
     QStandardItemModel *shortcutsModel;
-    QSortFilterProxyModel *proxyModel;
+    ShortcutFilterProxyModel *proxyModel;
     void populateShortcutsModel();
 
 private slots:


### PR DESCRIPTION
## Related Ticket(s)
- Follow up to #5285

## Short roundup of the initial problem
Shortcut search did not display children when searching for a section

<img width="279" alt="Screenshot 2024-12-22 at 5 16 06 PM" src="https://github.com/user-attachments/assets/ae3b2606-157d-47f3-89b7-e2a8fe0c817e" />

## What will change with this Pull Request?

https://github.com/user-attachments/assets/81845013-d3bf-4679-b615-732152290f91

Shortcut search now displays all children when searching for a section
<img width="366" alt="Screenshot 2024-12-22 at 5 16 56 PM" src="https://github.com/user-attachments/assets/11779652-1104-4f9e-9f3a-15ea0f82ff6c" />

- Created a subclass of `QSortFilterProxyModel` and overrode the `filterAcceptsRow` method to also check the parent