### PR TITLE
fix bug with uploading unnamed decks ignoring the prompt

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_storage.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_storage.cpp
@@ -176,14 +176,8 @@ void TabDeckStorage::actUpload()
     QFile deckFile(filePath);
     QFileInfo deckFileInfo(deckFile);
 
-    QString deckString;
     DeckLoader deck;
-    bool error = !deck.loadFromFile(filePath, DeckLoader::CockatriceFormat);
-    if (!error) {
-        deckString = deck.writeToString_Native();
-        error = deckString.length() > MAX_FILE_LENGTH;
-    }
-    if (error) {
+    if (!deck.loadFromFile(filePath, DeckLoader::CockatriceFormat)) {
         QMessageBox::critical(this, tr("Error"), tr("Invalid deck file"));
         return;
     }
@@ -200,6 +194,12 @@ void TabDeckStorage::actUpload()
         deck.setName(deckName);
     } else {
         deck.setName(deck.getName().left(MAX_NAME_LENGTH));
+    }
+
+    QString deckString = deck.writeToString_Native();
+    if (deckString.length() > MAX_FILE_LENGTH) {
+        QMessageBox::critical(this, tr("Error"), tr("Invalid deck file"));
+        return;
     }
 
     Command_DeckUpload cmd;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5312 

## What will change with this Pull Request?

https://github.com/user-attachments/assets/57f5095c-56bb-4632-9768-6629c3bea84f

- move the write decklist to string *after* the unnamed deck prompt
