### PR TITLE
support multi-select for local decks in deck storage tab

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_storage.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_storage.cpp
@@ -244,16 +244,22 @@ void TabDeckStorage::uploadFinished(const Response &r, const CommandContainer &c
 
 void TabDeckStorage::actDeleteLocalDeck()
 {
-    QModelIndex curLeft = localDirView->selectionModel()->currentIndex();
-    if (localDirModel->isDir(curLeft))
-        return;
+    const QModelIndexList curLefts = localDirView->selectionModel()->selectedRows();
 
-    if (QMessageBox::warning(this, tr("Delete local file"),
-                             tr("Are you sure you want to delete \"%1\"?").arg(localDirModel->fileName(curLeft)),
+    auto isDir = [&](const auto &curLeft) { return localDirModel->isDir(curLeft); };
+    if (curLefts.isEmpty() || std::all_of(curLefts.begin(), curLefts.end(), isDir)) {
+        return;
+    }
+
+    if (QMessageBox::warning(this, tr("Delete local file"), tr("Are you sure you want to delete the selected files?"),
                              QMessageBox::Yes | QMessageBox::No) != QMessageBox::Yes)
         return;
 
-    localDirModel->remove(curLeft);
+    for (const auto &curLeft : curLefts) {
+        if (!localDirModel->isDir(curLeft)) {
+            localDirModel->remove(curLeft);
+        }
+    }
 }
 
 void TabDeckStorage::actOpenRemoteDeck()

--- a/cockatrice/src/client/tabs/tab_deck_storage.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_storage.cpp
@@ -150,16 +150,18 @@ QString TabDeckStorage::getTargetPath() const
 
 void TabDeckStorage::actOpenLocalDeck()
 {
-    QModelIndex curLeft = localDirView->selectionModel()->currentIndex();
-    if (localDirModel->isDir(curLeft))
-        return;
-    QString filePath = localDirModel->filePath(curLeft);
+    QModelIndexList curLefts = localDirView->selectionModel()->selectedRows();
+    for (const auto &curLeft : curLefts) {
+        if (localDirModel->isDir(curLeft))
+            return;
+        QString filePath = localDirModel->filePath(curLeft);
 
-    DeckLoader deckLoader;
-    if (!deckLoader.loadFromFile(filePath, DeckLoader::CockatriceFormat))
-        return;
+        DeckLoader deckLoader;
+        if (!deckLoader.loadFromFile(filePath, DeckLoader::CockatriceFormat))
+            return;
 
-    emit openDeckEditor(&deckLoader);
+        emit openDeckEditor(&deckLoader);
+    }
 }
 
 void TabDeckStorage::actUpload()

--- a/cockatrice/src/client/tabs/tab_deck_storage.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_storage.cpp
@@ -164,16 +164,29 @@ void TabDeckStorage::actOpenLocalDeck()
 
 void TabDeckStorage::actUpload()
 {
-    QModelIndex curLeft = localDirView->selectionModel()->currentIndex();
-    if (localDirModel->isDir(curLeft))
+    QModelIndexList curLefts = localDirView->selectionModel()->selectedRows();
+    if (curLefts.isEmpty()) {
         return;
+    }
+
     QString targetPath = getTargetPath();
     if (targetPath.length() > MAX_NAME_LENGTH) {
         qCritical() << "target path to upload to is too long" << targetPath;
         return;
     }
 
-    QString filePath = localDirModel->filePath(curLeft);
+    for (const auto &curLeft : curLefts) {
+        if (localDirModel->isDir(curLeft)) {
+            continue;
+        }
+
+        QString filePath = localDirModel->filePath(curLeft);
+        uploadDeck(filePath, targetPath);
+    }
+}
+
+void TabDeckStorage::uploadDeck(const QString &filePath, const QString &targetPath)
+{
     QFile deckFile(filePath);
     QFileInfo deckFileInfo(deckFile);
 

--- a/cockatrice/src/client/tabs/tab_deck_storage.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_storage.cpp
@@ -41,6 +41,7 @@ TabDeckStorage::TabDeckStorage(TabSupervisor *_tabSupervisor, AbstractClient *_c
     localDirView->setColumnHidden(1, true);
     localDirView->setRootIndex(localDirModel->index(localDirModel->rootPath(), 0));
     localDirView->setSortingEnabled(true);
+    localDirView->setSelectionMode(QAbstractItemView::ExtendedSelection);
     localDirView->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     localDirView->header()->setSortIndicator(0, Qt::AscendingOrder);
 

--- a/cockatrice/src/client/tabs/tab_deck_storage.h
+++ b/cockatrice/src/client/tabs/tab_deck_storage.h
@@ -28,6 +28,9 @@ private:
 
     QAction *aOpenLocalDeck, *aUpload, *aDeleteLocalDeck, *aOpenRemoteDeck, *aDownload, *aNewFolder, *aDeleteRemoteDeck;
     QString getTargetPath() const;
+
+    void uploadDeck(const QString &filePath, const QString &targetPath);
+
 private slots:
     void actOpenLocalDeck();
 


### PR DESCRIPTION
## What will change with this Pull Request?

https://github.com/user-attachments/assets/5db8603a-ddd5-4f5c-8391-a669cfe78645

- Enabled multi-select on the local deck storage TreeView
- `Open Deck`, `Upload Deck`, and `Delete Deck` now act on the entire selection

