### PR TITLE
Support multi-select for remote decks in deck storage tab

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_storage.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_storage.cpp
@@ -242,18 +242,19 @@ void TabDeckStorage::actDeleteLocalDeck()
 
 void TabDeckStorage::actOpenRemoteDeck()
 {
-    RemoteDeckList_TreeModel::FileNode *curRight =
-        dynamic_cast<RemoteDeckList_TreeModel::FileNode *>(serverDirView->getCurrentItem());
-    if (!curRight)
-        return;
+    for (const auto &curRight : serverDirView->getCurrentSelection()) {
+        RemoteDeckList_TreeModel::FileNode *node = dynamic_cast<RemoteDeckList_TreeModel::FileNode *>(curRight);
+        if (!node)
+            return;
 
-    Command_DeckDownload cmd;
-    cmd.set_deck_id(curRight->getId());
+        Command_DeckDownload cmd;
+        cmd.set_deck_id(node->getId());
 
-    PendingCommand *pend = client->prepareSessionCommand(cmd);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-            SLOT(openRemoteDeckFinished(Response, CommandContainer)));
-    client->sendCommand(pend);
+        PendingCommand *pend = client->prepareSessionCommand(cmd);
+        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
+                SLOT(openRemoteDeckFinished(Response, CommandContainer)));
+        client->sendCommand(pend);
+    }
 }
 
 void TabDeckStorage::openRemoteDeckFinished(const Response &r, const CommandContainer &commandContainer)

--- a/cockatrice/src/client/tabs/tab_deck_storage.h
+++ b/cockatrice/src/client/tabs/tab_deck_storage.h
@@ -1,6 +1,7 @@
 #ifndef TAB_DECK_STORAGE_H
 #define TAB_DECK_STORAGE_H
 
+#include "../../server/remote/remote_decklist_tree_widget.h"
 #include "tab.h"
 
 class AbstractClient;
@@ -10,7 +11,6 @@ class QToolBar;
 class QTreeWidget;
 class QTreeWidgetItem;
 class QGroupBox;
-class RemoteDeckList_TreeWidget;
 class CommandContainer;
 class Response;
 class DeckLoader;
@@ -28,6 +28,9 @@ private:
 
     QAction *aOpenLocalDeck, *aUpload, *aDeleteLocalDeck, *aOpenRemoteDeck, *aDownload, *aNewFolder, *aDeleteRemoteDeck;
     QString getTargetPath() const;
+
+    void deleteRemoteDeck(const RemoteDeckList_TreeModel::Node *node);
+
 private slots:
     void actOpenLocalDeck();
 

--- a/cockatrice/src/server/remote/remote_decklist_tree_widget.cpp
+++ b/cockatrice/src/server/remote/remote_decklist_tree_widget.cpp
@@ -300,6 +300,7 @@ RemoteDeckList_TreeWidget::RemoteDeckList_TreeWidget(AbstractClient *_client, QW
 
     header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     setUniformRowHeights(true);
+    setSelectionMode(QAbstractItemView::ExtendedSelection);
     setSortingEnabled(true);
     proxyModel->sort(0, Qt::AscendingOrder);
     header()->setSortIndicator(0, Qt::AscendingOrder);
@@ -313,6 +314,15 @@ RemoteDeckList_TreeModel::Node *RemoteDeckList_TreeWidget::getNode(const QModelI
 RemoteDeckList_TreeModel::Node *RemoteDeckList_TreeWidget::getCurrentItem() const
 {
     return getNode(selectionModel()->currentIndex());
+}
+
+QList<RemoteDeckList_TreeModel::Node *> RemoteDeckList_TreeWidget::getCurrentSelection() const
+{
+    auto list = QList<RemoteDeckList_TreeModel::Node *>();
+    for (const auto &row : selectionModel()->selectedRows()) {
+        list << getNode(row);
+    }
+    return list;
 }
 
 RemoteDeckList_TreeModel::DirectoryNode *RemoteDeckList_TreeWidget::getNodeByPath(const QString &path) const

--- a/cockatrice/src/server/remote/remote_decklist_tree_widget.h
+++ b/cockatrice/src/server/remote/remote_decklist_tree_widget.h
@@ -118,6 +118,7 @@ public:
     RemoteDeckList_TreeWidget(AbstractClient *_client, QWidget *parent = nullptr);
     RemoteDeckList_TreeModel::Node *getNode(const QModelIndex &ind) const;
     RemoteDeckList_TreeModel::Node *getCurrentItem() const;
+    QList<RemoteDeckList_TreeModel::Node *> getCurrentSelection() const;
     RemoteDeckList_TreeModel::DirectoryNode *getNodeByPath(const QString &path) const;
     RemoteDeckList_TreeModel::FileNode *getNodeById(int id) const;
     void addFileToTree(const ServerInfo_DeckStorage_TreeItem &file, RemoteDeckList_TreeModel::DirectoryNode *parent);


### PR DESCRIPTION
## What will change with this Pull Request?


https://github.com/user-attachments/assets/a3ce067c-4be8-45b6-a39a-7e12d69d2f4b

- Enabled multi-select on the remote deck storage tab `TreeView`
-  add method to `RemoteDeckList_TreeWidget` to return a list of all selected nodes instead of just a pointer