### PR TITLE
Extend decklist parsing

### DIFF
--- a/cockatrice/src/client/tapped_out_interface.cpp
+++ b/cockatrice/src/client/tapped_out_interface.cpp
@@ -115,7 +115,7 @@ struct CopyMainOrSide
     }
 };
 
-void TappedOutInterface::copyDeckSplitMainAndSide(const DeckList &source, DeckList &mainboard, DeckList &sideboard)
+void TappedOutInterface::copyDeckSplitMainAndSide(DeckList &source, DeckList &mainboard, DeckList &sideboard)
 {
     CopyMainOrSide copyMainOrSide(cardDatabase, mainboard, sideboard);
     source.forEachCard(copyMainOrSide);

--- a/cockatrice/src/client/tapped_out_interface.h
+++ b/cockatrice/src/client/tapped_out_interface.h
@@ -24,7 +24,7 @@ private:
     QNetworkAccessManager *manager;
 
     CardDatabase &cardDatabase;
-    void copyDeckSplitMainAndSide(const DeckList &source, DeckList &mainboard, DeckList &sideboard);
+    void copyDeckSplitMainAndSide(DeckList &source, DeckList &mainboard, DeckList &sideboard);
 private slots:
     void queryFinished(QNetworkReply *reply);
     void getAnalyzeRequestData(DeckList *deck, QByteArray *data);

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -120,7 +120,7 @@ struct FormatDeckListForExport
     QString &sideBoardCards;
     // create main operator for struct, allowing the foreachcard to work.
     FormatDeckListForExport(QString &_mainBoardCards, QString &_sideBoardCards)
-        : mainBoardCards(_mainBoardCards), sideBoardCards(_sideBoardCards) {};
+        : mainBoardCards(_mainBoardCards), sideBoardCards(_sideBoardCards){};
 
     void operator()(const InnerDecklistNode *node, const DecklistCardNode *card) const
     {

--- a/cockatrice/src/deck/deck_loader.h
+++ b/cockatrice/src/deck/deck_loader.h
@@ -47,6 +47,8 @@ public:
     bool saveToFile(const QString &fileName, FileFormat fmt);
     QString exportDeckToDecklist();
 
+    void resolveSetNameAndNumberToProviderID();
+
     // overload
     bool saveToStream_Plain(QTextStream &out, bool addComments = true);
 

--- a/cockatrice/src/deck/deck_stats_interface.cpp
+++ b/cockatrice/src/deck/deck_stats_interface.cpp
@@ -85,7 +85,7 @@ struct CopyIfNotAToken
     }
 };
 
-void DeckStatsInterface::copyDeckWithoutTokens(const DeckList &source, DeckList &destination)
+void DeckStatsInterface::copyDeckWithoutTokens(DeckList &source, DeckList &destination)
 {
     CopyIfNotAToken copyIfNotAToken(cardDatabase, destination);
     source.forEachCard(copyIfNotAToken);

--- a/cockatrice/src/deck/deck_stats_interface.h
+++ b/cockatrice/src/deck/deck_stats_interface.h
@@ -24,7 +24,7 @@ private:
      * closest non-token card instead. So we construct a new deck which has no
      * tokens.
      */
-    void copyDeckWithoutTokens(const DeckList &source, DeckList &destination);
+    void copyDeckWithoutTokens(DeckList &source, DeckList &destination);
 
 private slots:
     void queryFinished(QNetworkReply *reply);

--- a/cockatrice/src/dialogs/dlg_load_deck_from_clipboard.cpp
+++ b/cockatrice/src/dialogs/dlg_load_deck_from_clipboard.cpp
@@ -65,6 +65,7 @@ void DlgLoadDeckFromClipboard::actOK()
         }
     } else if (deckLoader->loadFromStream_Plain(stream)) {
         deckList = deckLoader;
+        deckList->resolveSetNameAndNumberToProviderID();
         accept();
     } else {
         QMessageBox::critical(this, tr("Error"), tr("Invalid deck list."));

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -704,6 +704,32 @@ CardInfoPerSet CardDatabase::getSpecificSetForCard(const QString &cardName, cons
     return CardInfoPerSet(nullptr);
 }
 
+CardInfoPerSet CardDatabase::getSpecificSetForCard(const QString &cardName,
+                                                   const QString &setShortName,
+                                                   const QString &collectorNumber) const
+{
+    CardInfoPtr cardInfo = getCard(cardName);
+    if (!cardInfo) {
+        return CardInfoPerSet(nullptr);
+    }
+
+    CardInfoPerSetMap setMap = cardInfo->getSets();
+    if (setMap.empty()) {
+        return CardInfoPerSet(nullptr);
+    }
+
+    for (const auto &cardInfoPerSetList : setMap) {
+        for (auto &cardInfoForSet : cardInfoPerSetList) {
+            if (cardInfoForSet.getPtr()->getShortName() == setShortName &&
+                cardInfoForSet.getProperty("num") == collectorNumber) {
+                return cardInfoForSet;
+            }
+        }
+    }
+
+    return CardInfoPerSet(nullptr);
+}
+
 QString CardDatabase::getPreferredPrintingProviderIdForCard(const QString &cardName)
 {
     CardInfoPerSet preferredSetCardInfo = getPreferredSetForCard(cardName);

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -465,6 +465,8 @@ public:
     [[nodiscard]] CardInfoPtr getCardByNameAndProviderId(const QString &cardName, const QString &providerId) const;
     [[nodiscard]] CardInfoPerSet getPreferredSetForCard(const QString &cardName) const;
     [[nodiscard]] CardInfoPerSet getSpecificSetForCard(const QString &cardName, const QString &providerId) const;
+    CardInfoPerSet
+    getSpecificSetForCard(const QString &cardName, const QString &setShortName, const QString &collectorNumber) const;
     QString getPreferredPrintingProviderIdForCard(const QString &cardName);
     [[nodiscard]] CardInfoPtr guessCard(const QString &cardName, const QString &providerId = QString()) const;
 

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -648,6 +648,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
             isFoil = true;
             cardName.chop(3); // Remove the "*F*" from the card name
         }
+        Q_UNUSED(isFoil);
 
         // Attempt to match the hyphen-separated format (PLST-2094)
         match = reHyphenFormat.match(cardName);

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -352,14 +352,14 @@ public:
      * take a InnerDecklistNode* as its first argument and a
      * DecklistCardNode* as its second.
      */
-    template <typename Callback> void forEachCard(Callback &callback) const
+    template <typename Callback> void forEachCard(Callback &callback)
     {
         // Support for this is only possible if the internal structure
         // doesn't get more complicated.
         for (int i = 0; i < root->size(); i++) {
-            const InnerDecklistNode *node = dynamic_cast<InnerDecklistNode *>(root->at(i));
+            InnerDecklistNode *node = dynamic_cast<InnerDecklistNode *>(root->at(i));
             for (int j = 0; j < node->size(); j++) {
-                const DecklistCardNode *card = dynamic_cast<DecklistCardNode *>(node->at(j));
+                DecklistCardNode *card = dynamic_cast<DecklistCardNode *>(node->at(j));
                 callback(node, card);
             }
         }


### PR DESCRIPTION
## Short roundup of the initial problem
Moxfield offers the most comprehensive and detailed export format that I know of. This change extends the current parsing logic to extract all the information a moxfield export can provide us, to be as compatible as possible in the future.

## What will change with this Pull Request?
- The decklist can and will parse the setName and the collectorNumber from a clipboard load now.
- The decklist will also now parse special collectorNumbers correctly (Foil ones, with a star next to it).
- After clipboard loading is done, the deckLoader will attempt to resolve setName and collectorNumber to a providerId.

## Screenshots
![image](https://github.com/user-attachments/assets/d204ca87-b1ad-4e2e-a60b-bbef32829e0f)
