### PR TITLE
add new folder button to game replays tab

### DIFF
--- a/cockatrice/src/client/tabs/tab_replays.cpp
+++ b/cockatrice/src/client/tabs/tab_replays.cpp
@@ -78,9 +78,13 @@ TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client) :
     aOpenLocalReplay->setIcon(QPixmap("theme:icons/view"));
     connect(aOpenLocalReplay, SIGNAL(triggered()), this, SLOT(actOpenLocalReplay()));
     connect(localDirView, SIGNAL(doubleClicked(const QModelIndex &)), this, SLOT(actOpenLocalReplay()));
+    aNewLocalFolder = new QAction(this);
+    aNewLocalFolder->setIcon(qApp->style()->standardIcon(QStyle::SP_FileDialogNewFolder));
+    connect(aNewLocalFolder, &QAction::triggered, this, &TabReplays::actNewLocalFolder);
     aDeleteLocalReplay = new QAction(this);
     aDeleteLocalReplay->setIcon(QPixmap("theme:icons/remove_row"));
     connect(aDeleteLocalReplay, SIGNAL(triggered()), this, SLOT(actDeleteLocalReplay()));
+
     aOpenRemoteReplay = new QAction(this);
     aOpenRemoteReplay->setIcon(QPixmap("theme:icons/view"));
     connect(aOpenRemoteReplay, SIGNAL(triggered()), this, SLOT(actOpenRemoteReplay()));
@@ -96,6 +100,7 @@ TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client) :
     connect(aDeleteRemoteReplay, SIGNAL(triggered()), this, SLOT(actDeleteRemoteReplay()));
 
     leftToolBar->addAction(aOpenLocalReplay);
+    leftToolBar->addAction(aNewLocalFolder);
     leftToolBar->addAction(aDeleteLocalReplay);
     rightToolBar->addAction(aOpenRemoteReplay);
     rightToolBar->addAction(aDownload);
@@ -118,6 +123,7 @@ void TabReplays::retranslateUi()
     rightGroupBox->setTitle(tr("Server replay storage"));
 
     aOpenLocalReplay->setText(tr("Watch replay"));
+    aNewLocalFolder->setText(tr("New folder"));
     aDeleteLocalReplay->setText(tr("Delete"));
     aOpenRemoteReplay->setText(tr("Watch replay"));
     aDownload->setText(tr("Download replay"));
@@ -144,6 +150,26 @@ void TabReplays::actOpenLocalReplay()
 
         emit openReplay(replay);
     }
+}
+
+void TabReplays::actNewLocalFolder()
+{
+    QModelIndex curLeft = localDirView->selectionModel()->currentIndex();
+
+    QModelIndex dirIndex;
+    if (curLeft.isValid() && !localDirModel->isDir(curLeft)) {
+        dirIndex = curLeft.parent();
+    } else {
+        dirIndex = curLeft;
+    }
+
+    bool ok;
+    QString folderName =
+        QInputDialog::getText(this, tr("New folder"), tr("Name of new folder:"), QLineEdit::Normal, "", &ok);
+    if (!ok || folderName.isEmpty())
+        return;
+
+    localDirModel->mkdir(dirIndex, folderName);
 }
 
 void TabReplays::actDeleteLocalReplay()

--- a/cockatrice/src/client/tabs/tab_replays.h
+++ b/cockatrice/src/client/tabs/tab_replays.h
@@ -25,10 +25,11 @@ private:
     RemoteReplayList_TreeWidget *serverDirView;
     QGroupBox *leftGroupBox, *rightGroupBox;
 
-    QAction *aOpenLocalReplay, *aDeleteLocalReplay, *aOpenRemoteReplay, *aDownload, *aKeep, *aDeleteRemoteReplay;
+    QAction *aOpenLocalReplay, *aNewLocalFolder, *aDeleteLocalReplay;
+    QAction *aOpenRemoteReplay, *aDownload, *aKeep, *aDeleteRemoteReplay;
 private slots:
     void actOpenLocalReplay();
-
+    void actNewLocalFolder();
     void actDeleteLocalReplay();
 
     void actOpenRemoteReplay();


### PR DESCRIPTION
## Related Ticket(s)
- Follow up to #5309

## What will change with this Pull Request?

https://github.com/user-attachments/assets/abf21084-a2c6-4af9-827d-d976c95c0bfe

Add a new `New Folder` button to local game replays tab
