### PR TITLE
add new folder button to local deck storage tab

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_storage.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_storage.cpp
@@ -272,8 +272,7 @@ void TabDeckStorage::actDeleteLocalDeck()
 {
     const QModelIndexList curLefts = localDirView->selectionModel()->selectedRows();
 
-    auto isDir = [&](const auto &curLeft) { return localDirModel->isDir(curLeft); };
-    if (curLefts.isEmpty() || std::all_of(curLefts.begin(), curLefts.end(), isDir)) {
+    if (curLefts.isEmpty()) {
         return;
     }
 
@@ -282,7 +281,7 @@ void TabDeckStorage::actDeleteLocalDeck()
         return;
 
     for (const auto &curLeft : curLefts) {
-        if (!localDirModel->isDir(curLeft)) {
+        if (curLeft.isValid()) {
             localDirModel->remove(curLeft);
         }
     }

--- a/cockatrice/src/client/tabs/tab_deck_storage.h
+++ b/cockatrice/src/client/tabs/tab_deck_storage.h
@@ -26,7 +26,8 @@ private:
     RemoteDeckList_TreeWidget *serverDirView;
     QGroupBox *leftGroupBox, *rightGroupBox;
 
-    QAction *aOpenLocalDeck, *aUpload, *aDeleteLocalDeck, *aOpenRemoteDeck, *aDownload, *aNewFolder, *aDeleteRemoteDeck;
+    QAction *aOpenLocalDeck, *aUpload, *aNewLocalFolder, *aDeleteLocalDeck;
+    QAction *aOpenRemoteDeck, *aDownload, *aNewFolder, *aDeleteRemoteDeck;
     QString getTargetPath() const;
 
     void uploadDeck(const QString &filePath, const QString &targetPath);
@@ -37,6 +38,7 @@ private slots:
     void actUpload();
     void uploadFinished(const Response &r, const CommandContainer &commandContainer);
 
+    void actNewLocalFolder();
     void actDeleteLocalDeck();
 
     void actOpenRemoteDeck();


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5314

## What will change with this Pull Request?

https://github.com/user-attachments/assets/f6ed5b69-5cc1-418d-b6e3-22e976e818d1

- Added a new `New Folder` button to local deck storage tab
- Allow local delete button to delete folders