### PR TITLE
add "open recent" menu option to deck editor tab

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -122,6 +122,7 @@ set(cockatrice_SOURCES
     src/settings/game_filters_settings.cpp
     src/settings/layouts_settings.cpp
     src/settings/message_settings.cpp
+    src/settings/recents_settings.cpp
     src/settings/servers_settings.cpp
     src/settings/settings_manager.cpp
     src/settings/cache_settings.cpp

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -716,7 +716,7 @@ void TabDeckEditor::retranslateUi()
     aNewDeck->setText(tr("&New deck"));
     aLoadDeck->setText(tr("&Load deck..."));
     loadRecentDeckMenu->setTitle(tr("Load recent deck..."));
-    aClearRecents->setText(tr("Clear items..."));
+    aClearRecents->setText(tr("Clear"));
     aSaveDeck->setText(tr("&Save deck"));
     aSaveDeckAs->setText(tr("Save deck &as..."));
     aLoadDeckFromClipboard->setText(tr("Load deck from cl&ipboard..."));

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -292,7 +292,7 @@ void TabDeckEditor::createMenus()
     aLoadDeck = new QAction(QString(), this);
     connect(aLoadDeck, SIGNAL(triggered()), this, SLOT(actLoadDeck()));
 
-    openRecentsMenu = new QMenu(this);
+    loadRecentDeckMenu = new QMenu(this);
     connect(&SettingsCache::instance().recents(), &RecentsSettings::recentlyOpenedDeckPathsChanged, this,
             &TabDeckEditor::updateRecentlyOpened);
 
@@ -351,7 +351,7 @@ void TabDeckEditor::createMenus()
     deckMenu = new QMenu(this);
     deckMenu->addAction(aNewDeck);
     deckMenu->addAction(aLoadDeck);
-    deckMenu->addMenu(openRecentsMenu);
+    deckMenu->addMenu(loadRecentDeckMenu);
     deckMenu->addAction(aSaveDeck);
     deckMenu->addAction(aSaveDeckAs);
     deckMenu->addSeparator();
@@ -715,8 +715,8 @@ void TabDeckEditor::retranslateUi()
 
     aNewDeck->setText(tr("&New deck"));
     aLoadDeck->setText(tr("&Load deck..."));
-    openRecentsMenu->setTitle(tr("Open Recent..."));
-    aClearRecents->setText(tr("Clear Items..."));
+    loadRecentDeckMenu->setTitle(tr("Load recent deck..."));
+    aClearRecents->setText(tr("Clear items..."));
     aSaveDeck->setText(tr("&Save deck"));
     aSaveDeckAs->setText(tr("Save deck &as..."));
     aLoadDeckFromClipboard->setText(tr("Load deck from cl&ipboard..."));
@@ -866,15 +866,15 @@ void TabDeckEditor::updateHash()
 
 void TabDeckEditor::updateRecentlyOpened()
 {
-    openRecentsMenu->clear();
+    loadRecentDeckMenu->clear();
     for (const auto &deckPath : SettingsCache::instance().recents().getRecentlyOpenedDeckPaths()) {
         QAction *aRecentlyOpenedDeck = new QAction(deckPath, this);
-        openRecentsMenu->addAction(aRecentlyOpenedDeck);
+        loadRecentDeckMenu->addAction(aRecentlyOpenedDeck);
         connect(aRecentlyOpenedDeck, &QAction::triggered, this,
                 [=, this] { actOpenRecent(aRecentlyOpenedDeck->text()); });
     }
-    openRecentsMenu->addSeparator();
-    openRecentsMenu->addAction(aClearRecents);
+    loadRecentDeckMenu->addSeparator();
+    loadRecentDeckMenu->addAction(aClearRecents);
     aClearRecents->setEnabled(SettingsCache::instance().recents().getRecentlyOpenedDeckPaths().length() > 0);
 }
 

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -956,10 +956,9 @@ void TabDeckEditor::openDeckFromFile(const QString &fileName, DeckOpenLocation d
 {
     DeckLoader::FileFormat fmt = DeckLoader::getFormatFromName(fileName);
 
-    SettingsCache::instance().recents().updateRecentlyOpenedDeckPaths(fileName);
-
     auto *l = new DeckLoader;
     if (l->loadFromFile(fileName, fmt)) {
+        SettingsCache::instance().recents().updateRecentlyOpenedDeckPaths(fileName);
         if (deckOpenLocation == NEW_TAB) {
             emit openDeckEditor(l);
         } else {

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -966,8 +966,10 @@ void TabDeckEditor::openDeckFromFile(const QString &fileName, DeckOpenLocation d
             setSaveStatus(false);
             setDeck(l);
         }
-    } else
+    } else {
         delete l;
+        QMessageBox::critical(this, tr("Error"), tr("Could not open deck at %1").arg(fileName));
+    }
     setSaveStatus(true);
 }
 

--- a/cockatrice/src/client/tabs/tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/tab_deck_editor.h
@@ -43,9 +43,12 @@ private slots:
     void updateSearch(const QString &search);
     void databaseCustomMenu(QPoint point);
     void decklistCustomMenu(QPoint point);
+    void updateRecentlyOpened();
 
     void actNewDeck();
     void actLoadDeck();
+    void actOpenRecent(const QString &fileName);
+    void actClearRecents();
     bool actSaveDeck();
     bool actSaveDeckAs();
     void actLoadDeckFromClipboard();
@@ -106,6 +109,7 @@ private:
     void offsetCountAtIndex(const QModelIndex &idx, int offset);
     void decrementCardHelper(QString zoneName);
     void recursiveExpand(const QModelIndex &index);
+    void openDeckFromFile(const QString &fileName, DeckOpenLocation deckOpenLocation);
 
     CardDatabaseModel *databaseModel;
     CardDatabaseDisplayModel *databaseDisplayModel;
@@ -131,10 +135,10 @@ private:
     QWidget *filterBox;
 
     QMenu *deckMenu, *viewMenu, *cardInfoDockMenu, *deckDockMenu, *filterDockMenu, *printingSelectorDockMenu,
-        *analyzeDeckMenu, *saveDeckToClipboardMenu;
-    QAction *aNewDeck, *aLoadDeck, *aSaveDeck, *aSaveDeckAs, *aLoadDeckFromClipboard, *aSaveDeckToClipboard,
-        *aSaveDeckToClipboardRaw, *aPrintDeck, *aExportDeckDecklist, *aAnalyzeDeckDeckstats, *aAnalyzeDeckTappedout,
-        *aClose;
+        *analyzeDeckMenu, *saveDeckToClipboardMenu, *openRecentsMenu;
+    QAction *aNewDeck, *aLoadDeck, *aClearRecents, *aSaveDeck, *aSaveDeckAs, *aLoadDeckFromClipboard,
+        *aSaveDeckToClipboard, *aSaveDeckToClipboardRaw, *aPrintDeck, *aExportDeckDecklist, *aAnalyzeDeckDeckstats,
+        *aAnalyzeDeckTappedout, *aClose;
     QAction *aClearFilterAll, *aClearFilterOne;
     QAction *aAddCard, *aAddCardToSideboard, *aRemoveCard, *aIncrement, *aDecrement;
     QAction *aResetLayout;

--- a/cockatrice/src/client/tabs/tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/tab_deck_editor.h
@@ -135,7 +135,7 @@ private:
     QWidget *filterBox;
 
     QMenu *deckMenu, *viewMenu, *cardInfoDockMenu, *deckDockMenu, *filterDockMenu, *printingSelectorDockMenu,
-        *analyzeDeckMenu, *saveDeckToClipboardMenu, *openRecentsMenu;
+        *analyzeDeckMenu, *saveDeckToClipboardMenu, *loadRecentDeckMenu;
     QAction *aNewDeck, *aLoadDeck, *aClearRecents, *aSaveDeck, *aSaveDeckAs, *aLoadDeckFromClipboard,
         *aSaveDeckToClipboard, *aSaveDeckToClipboardRaw, *aPrintDeck, *aExportDeckDecklist, *aAnalyzeDeckDeckstats,
         *aAnalyzeDeckTappedout, *aClose;

--- a/cockatrice/src/client/tabs/tab_deck_storage.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_storage.cpp
@@ -162,6 +162,8 @@ void TabDeckStorage::actOpenLocalDeck()
             return;
         QString filePath = localDirModel->filePath(curLeft);
 
+        SettingsCache::instance().recents().updateRecentlyOpenedDeckPaths(filePath);
+
         DeckLoader deckLoader;
         if (!deckLoader.loadFromFile(filePath, DeckLoader::CockatriceFormat))
             return;

--- a/cockatrice/src/client/tabs/tab_deck_storage.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_storage.cpp
@@ -162,11 +162,11 @@ void TabDeckStorage::actOpenLocalDeck()
             return;
         QString filePath = localDirModel->filePath(curLeft);
 
-        SettingsCache::instance().recents().updateRecentlyOpenedDeckPaths(filePath);
-
         DeckLoader deckLoader;
         if (!deckLoader.loadFromFile(filePath, DeckLoader::CockatriceFormat))
             return;
+
+        SettingsCache::instance().recents().updateRecentlyOpenedDeckPaths(filePath);
 
         emit openDeckEditor(&deckLoader);
     }

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -178,6 +178,7 @@ SettingsCache::SettingsCache()
     gameFiltersSettings = new GameFiltersSettings(settingsPath, this);
     layoutsSettings = new LayoutsSettings(settingsPath, this);
     downloadSettings = new DownloadSettings(settingsPath, this);
+    recentsSettings = new RecentsSettings(settingsPath, this);
 
     if (!QFile(settingsPath + "global.ini").exists())
         translateLegacySettings();

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -7,6 +7,7 @@
 #include "game_filters_settings.h"
 #include "layouts_settings.h"
 #include "message_settings.h"
+#include "recents_settings.h"
 #include "servers_settings.h"
 #include "shortcuts_settings.h"
 
@@ -82,6 +83,7 @@ private:
     GameFiltersSettings *gameFiltersSettings;
     LayoutsSettings *layoutsSettings;
     DownloadSettings *downloadSettings;
+    RecentsSettings *recentsSettings;
 
     QByteArray mainWindowGeometry;
     QByteArray tokenDialogGeometry;
@@ -597,6 +599,10 @@ public:
     DownloadSettings &downloads() const
     {
         return *downloadSettings;
+    }
+    RecentsSettings &recents() const
+    {
+        return *recentsSettings;
     }
     bool getIsPortableBuild() const
     {

--- a/cockatrice/src/settings/recents_settings.cpp
+++ b/cockatrice/src/settings/recents_settings.cpp
@@ -1,0 +1,32 @@
+#include "recents_settings.h"
+
+#define MAX_RECENT_DECK_COUNT 10
+
+RecentsSettings::RecentsSettings(QString settingPath, QObject *parent)
+    : SettingsManager(settingPath + "recents.ini", parent)
+{
+}
+
+QStringList RecentsSettings::getRecentlyOpenedDeckPaths()
+{
+    return getValue("deckpaths", "deckbuilder").toStringList();
+}
+void RecentsSettings::clearRecentlyOpenedDeckPaths()
+{
+    deleteValue("deckpaths", "deckbuilder");
+    emit recentlyOpenedDeckPathsChanged();
+}
+void RecentsSettings::updateRecentlyOpenedDeckPaths(const QString &deckPath)
+{
+    auto deckPaths = getValue("deckpaths", "deckbuilder").toStringList();
+    deckPaths.removeAll(deckPath);
+
+    deckPaths.prepend(deckPath);
+
+    while (deckPaths.size() > MAX_RECENT_DECK_COUNT) {
+        deckPaths.removeLast();
+    }
+
+    setValue(deckPaths, "deckpaths", "deckbuilder");
+    emit recentlyOpenedDeckPathsChanged();
+}

--- a/cockatrice/src/settings/recents_settings.h
+++ b/cockatrice/src/settings/recents_settings.h
@@ -1,0 +1,23 @@
+#ifndef RECENTS_SETTINGS_H
+#define RECENTS_SETTINGS_H
+
+#include "settings_manager.h"
+
+class RecentsSettings : public SettingsManager
+{
+    Q_OBJECT
+    friend class SettingsCache;
+
+    explicit RecentsSettings(QString settingPath, QObject *parent = nullptr);
+    RecentsSettings(const RecentsSettings & /*other*/);
+
+public:
+    QStringList getRecentlyOpenedDeckPaths();
+    void clearRecentlyOpenedDeckPaths();
+    void updateRecentlyOpenedDeckPaths(const QString &deckPath);
+
+signals:
+    void recentlyOpenedDeckPathsChanged();
+};
+
+#endif // RECENTS_SETTINGS_H

--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -28,6 +28,7 @@ set(oracle_SOURCES
     ../cockatrice/src/settings/servers_settings.cpp
     ../cockatrice/src/settings/settings_manager.cpp
     ../cockatrice/src/settings/message_settings.cpp
+    ../cockatrice/src/settings/recents_settings.cpp
     ../cockatrice/src/settings/game_filters_settings.cpp
     ../cockatrice/src/settings/layouts_settings.cpp
     ../cockatrice/src/settings/download_settings.cpp


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5291

## What will change with this Pull Request?

https://github.com/user-attachments/assets/35876fe4-0291-4a12-bfb9-53226a963478

Added a `Open Recent` section to the deck editor tab's menu. It will list recently opened decks, and allow you to open those decks. Opening a recent deck will move it to the top of the list. If the list reaches the max number of entries, it will start evicting the oldest entry.

Max number of entries is currently hardcoded at 10.

Currently, this only tracks decks that are opened with the `Open Deck` option from the deck editor tab. It does not track local decks opened through the deck storage tab.

## Things to do in future PRs
- Allow maximum recent decks to be configurable
- ~~Remember local decks that are loaded through the deck storage tab~~