### PR TITLE
Attempt to allow users to temporarily modify preferences (until next card DB update)

### DIFF
--- a/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.cpp
@@ -24,7 +24,7 @@ AllZonesCardAmountWidget::AllZonesCardAmountWidget(QWidget *parent,
                                                    QTreeView *deckView,
                                                    QSlider *cardSizeSlider,
                                                    CardInfoPtr rootCard,
-                                                   CardInfoPerSet setInfoForCard)
+                                                   CardInfoPerSet *setInfoForCard)
     : QWidget(parent), deckEditor(deckEditor), deckModel(deckModel), deckView(deckView), cardSizeSlider(cardSizeSlider),
       rootCard(rootCard), setInfoForCard(setInfoForCard)
 {

--- a/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.h
@@ -18,7 +18,7 @@ public:
                                       QTreeView *deckView,
                                       QSlider *cardSizeSlider,
                                       CardInfoPtr rootCard,
-                                      CardInfoPerSet setInfoForCard);
+                                      CardInfoPerSet *setInfoForCard);
     int getMainboardAmount();
     int getSideboardAmount();
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
@@ -37,7 +37,7 @@ private:
     QTreeView *deckView;
     QSlider *cardSizeSlider;
     CardInfoPtr rootCard;
-    CardInfoPerSet setInfoForCard;
+    CardInfoPerSet *setInfoForCard;
     QLabel *zoneLabelMainboard;
     CardAmountWidget *buttonBoxMainboard;
     QLabel *zoneLabelSideboard;

--- a/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.cpp
@@ -20,7 +20,7 @@ CardAmountWidget::CardAmountWidget(QWidget *parent,
                                    QTreeView *deckView,
                                    QSlider *cardSizeSlider,
                                    CardInfoPtr &rootCard,
-                                   CardInfoPerSet &setInfoForCard,
+                                   CardInfoPerSet *setInfoForCard,
                                    const QString &zoneName)
     : QWidget(parent), deckEditor(deckEditor), deckModel(deckModel), deckView(deckView), cardSizeSlider(cardSizeSlider),
       rootCard(rootCard), setInfoForCard(setInfoForCard), zoneName(zoneName), hovered(false)
@@ -141,18 +141,18 @@ void CardAmountWidget::updateCardCount()
  */
 void CardAmountWidget::addPrinting(const QString &zone)
 {
-    auto newCardIndex = deckModel->addCard(rootCard->getName(), setInfoForCard, zone);
+    auto newCardIndex = deckModel->addCard(rootCard->getName(), *setInfoForCard, zone);
     recursiveExpand(newCardIndex);
     QModelIndex find_card = deckModel->findCard(rootCard->getName(), zone);
     if (find_card.isValid() && find_card != newCardIndex) {
         auto amount = deckModel->data(find_card, Qt::DisplayRole);
         for (int i = 0; i < amount.toInt() - 1; i++) {
-            deckModel->addCard(rootCard->getName(), setInfoForCard, zone);
+            deckModel->addCard(rootCard->getName(), *setInfoForCard, zone);
         }
         deckModel->removeRow(find_card.row(), find_card.parent());
     }
-    newCardIndex = deckModel->findCard(rootCard->getName(), zone, setInfoForCard.getProperty("uuid"),
-                                       setInfoForCard.getProperty("num"));
+    newCardIndex = deckModel->findCard(rootCard->getName(), zone, setInfoForCard->getProperty("uuid"),
+                                       setInfoForCard->getProperty("num"));
     deckView->setCurrentIndex(newCardIndex);
     deckView->setFocus(Qt::FocusReason::MouseFocusReason);
 }
@@ -233,8 +233,8 @@ void CardAmountWidget::offsetCountAtIndex(const QModelIndex &idx, int offset)
  */
 void CardAmountWidget::decrementCardHelper(const QString &zone)
 {
-    QModelIndex idx = deckModel->findCard(rootCard->getName(), zone, setInfoForCard.getProperty("uuid"),
-                                          setInfoForCard.getProperty("num"));
+    QModelIndex idx = deckModel->findCard(rootCard->getName(), zone, setInfoForCard->getProperty("uuid"),
+                                          setInfoForCard->getProperty("num"));
     offsetCountAtIndex(idx, -1);
 }
 
@@ -246,7 +246,7 @@ void CardAmountWidget::decrementCardHelper(const QString &zone)
  */
 int CardAmountWidget::countCardsInZone(const QString &deckZone)
 {
-    if (setInfoForCard.getProperty("uuid").isEmpty()) {
+    if (setInfoForCard->getProperty("uuid").isEmpty()) {
         return 0; // Cards without uuids/providerIds CANNOT match another card, they are undefined for us.
     }
 
@@ -283,7 +283,7 @@ int CardAmountWidget::countCardsInZone(const QString &deckZone)
             }
 
             for (int k = 0; k < currentCard->getNumber(); ++k) {
-                if (currentCard->getCardProviderId() == setInfoForCard.getProperty("uuid")) {
+                if (currentCard->getCardProviderId() == setInfoForCard->getProperty("uuid")) {
                     count++;
                 }
             }

--- a/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.h
@@ -25,7 +25,7 @@ public:
                               QTreeView *deckView,
                               QSlider *cardSizeSlider,
                               CardInfoPtr &rootCard,
-                              CardInfoPerSet &setInfoForCard,
+                              CardInfoPerSet *setInfoForCard,
                               const QString &zoneName);
     int countCardsInZone(const QString &deckZone);
 
@@ -43,7 +43,7 @@ private:
     QTreeView *deckView;
     QSlider *cardSizeSlider;
     CardInfoPtr rootCard;
-    CardInfoPerSet setInfoForCard;
+    CardInfoPerSet *setInfoForCard;
     QString zoneName;
     QHBoxLayout *layout;
     DynamicFontSizePushButton *incrementButton;

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
@@ -179,7 +179,7 @@ void PrintingSelector::getAllSetsForCurrentCard()
         for (int i = 0; i < BATCH_SIZE && currentIndex < setsToUse.size(); ++i, ++currentIndex) {
             auto *cardDisplayWidget = new PrintingSelectorCardDisplayWidget(this, deckEditor, deckModel, deckView,
                                                                             cardSizeWidget->getSlider(), selectedCard,
-                                                                            setsToUse[currentIndex], currentZone);
+                                                                            &setsToUse[currentIndex], currentZone);
             flowWidget->addWidget(cardDisplayWidget);
             cardDisplayWidget->clampSetNameToPicture();
         }

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.cpp
@@ -33,7 +33,7 @@ PrintingSelectorCardDisplayWidget::PrintingSelectorCardDisplayWidget(QWidget *pa
                                                                      QTreeView *_deckView,
                                                                      QSlider *_cardSizeSlider,
                                                                      CardInfoPtr _rootCard,
-                                                                     const CardInfoPerSet &_setInfoForCard,
+                                                                     CardInfoPerSet *_setInfoForCard,
                                                                      QString &_currentZone)
     : QWidget(parent), deckEditor(_deckEditor), deckModel(_deckModel), deckView(_deckView),
       cardSizeSlider(_cardSizeSlider), rootCard(std::move(_rootCard)), setInfoForCard(_setInfoForCard),
@@ -49,9 +49,9 @@ PrintingSelectorCardDisplayWidget::PrintingSelectorCardDisplayWidget(QWidget *pa
 
     // Create the widget to display the set name and collector's number
     const QString combinedSetName =
-        QString(setInfoForCard.getPtr()->getLongName() + " (" + setInfoForCard.getPtr()->getShortName() + ")");
+        QString(setInfoForCard->getPtr()->getLongName() + " (" + setInfoForCard->getPtr()->getShortName() + ")");
     setNameAndCollectorsNumberDisplayWidget = new SetNameAndCollectorsNumberDisplayWidget(
-        this, combinedSetName, setInfoForCard.getProperty("num"), cardSizeSlider);
+        this, combinedSetName, setInfoForCard->getProperty("num"), cardSizeSlider);
 
     // Add the widgets to the layout
     layout->addWidget(overlayWidget, 0, Qt::AlignHCenter);

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.h
@@ -29,7 +29,7 @@ public:
                                       QTreeView *_deckView,
                                       QSlider *_cardSizeSlider,
                                       CardInfoPtr _rootCard,
-                                      const CardInfoPerSet &_setInfoForCard,
+                                      CardInfoPerSet *_setInfoForCard,
                                       QString &_currentZone);
 
 public slots:
@@ -44,7 +44,7 @@ private:
     QSlider *cardSizeSlider;
     CardInfoPtr rootCard;
     CardInfoPtr setCard;
-    CardInfoPerSet setInfoForCard;
+    CardInfoPerSet *setInfoForCard;
     QString currentZone;
     PrintingSelectorCardOverlayWidget *overlayWidget;
 };

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.h
@@ -21,7 +21,7 @@ public:
                                                QTreeView *_deckView,
                                                QSlider *_cardSizeSlider,
                                                CardInfoPtr _rootCard,
-                                               const CardInfoPerSet &_setInfoForCard);
+                                               CardInfoPerSet *_setInfoForCard);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -43,7 +43,7 @@ private:
     QSlider *cardSizeSlider;
     CardInfoPtr rootCard;
     CardInfoPtr setCard;
-    CardInfoPerSet setInfoForCard;
+    CardInfoPerSet *setInfoForCard;
 };
 
 #endif // PRINTING_SELECTOR_CARD_OVERLAY_WIDGET_H

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -814,6 +814,14 @@ void CardDatabase::notifyEnabledSetsChanged()
     emit cardDatabaseEnabledSetsChanged();
 }
 
+bool CardDatabase::saveCardsToFile()
+{
+    QString fileName = SettingsCache::instance().getCustomCardDatabasePath() + "/cards.xml";
+
+    availableParsers.first()->saveToFile(sets, cards, fileName);
+    return true;
+}
+
 bool CardDatabase::saveCustomTokensToFile()
 {
     QString fileName =

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -491,6 +491,7 @@ public:
     void enableAllUnknownSets();
     void markAllSetsAsKnown();
     void notifyEnabledSetsChanged();
+    bool saveCardsToFile();
 
 public slots:
     LoadStatus loadCardDatabases();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes users asking for this feature in discord

## Short roundup of the initial problem
People have to scroll (instead of using the search bar as intended) to find their favorite printings so we have to add this to reduce friction.

## What will change with this Pull Request?
- Users will be able to temporarily mark a printing as "preferred"
