### PR TITLE
The printingSelector should set the deckEditor modified flag

### DIFF
--- a/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.cpp
@@ -155,6 +155,7 @@ void CardAmountWidget::addPrinting(const QString &zone)
                                        setInfoForCard.getProperty("num"));
     deckView->setCurrentIndex(newCardIndex);
     deckView->setFocus(Qt::FocusReason::MouseFocusReason);
+    deckEditor->setModified(true);
 }
 
 /**
@@ -236,6 +237,7 @@ void CardAmountWidget::decrementCardHelper(const QString &zone)
     QModelIndex idx = deckModel->findCard(rootCard->getName(), zone, setInfoForCard.getProperty("uuid"),
                                           setInfoForCard.getProperty("num"));
     offsetCountAtIndex(idx, -1);
+    deckEditor->setModified(true);
 }
 
 /**


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem
We don't set the modified flag for the deckEditor, which prevents saving and doesn't make the "Are you sure you want to discard your changes"-dialog pop up.

## What will change with this Pull Request?
- We set the modified flag when we add or remove printings.
