### PR TITLE
open decks on double-click in deck storage tab

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_storage.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_storage.cpp
@@ -45,6 +45,8 @@ TabDeckStorage::TabDeckStorage(TabSupervisor *_tabSupervisor, AbstractClient *_c
     localDirView->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     localDirView->header()->setSortIndicator(0, Qt::AscendingOrder);
 
+    connect(localDirView, &QTreeView::doubleClicked, this, &TabDeckStorage::actLocalDoubleClick);
+
     leftToolBar = new QToolBar;
     leftToolBar->setOrientation(Qt::Horizontal);
     leftToolBar->setIconSize(QSize(32, 32));
@@ -68,6 +70,8 @@ TabDeckStorage::TabDeckStorage(TabSupervisor *_tabSupervisor, AbstractClient *_c
     rightToolBarLayout->addStretch();
 
     serverDirView = new RemoteDeckList_TreeWidget(client);
+
+    connect(serverDirView, &QTreeView::doubleClicked, this, &TabDeckStorage::actRemoteDoubleClick);
 
     QVBoxLayout *rightVbox = new QVBoxLayout;
     rightVbox->addWidget(serverDirView);
@@ -151,6 +155,13 @@ QString TabDeckStorage::getTargetPath() const
         }
     } else {
         return dir->getPath();
+    }
+}
+
+void TabDeckStorage::actLocalDoubleClick(const QModelIndex &curLeft)
+{
+    if (!localDirModel->isDir(curLeft)) {
+        actOpenLocalDeck();
     }
 }
 
@@ -286,6 +297,13 @@ void TabDeckStorage::actDeleteLocalDeck()
         if (curLeft.isValid()) {
             localDirModel->remove(curLeft);
         }
+    }
+}
+
+void TabDeckStorage::actRemoteDoubleClick(const QModelIndex &curRight)
+{
+    if (dynamic_cast<RemoteDeckList_TreeModel::FileNode *>(serverDirView->getNode(curRight))) {
+        actOpenRemoteDeck();
     }
 }
 

--- a/cockatrice/src/client/tabs/tab_deck_storage.h
+++ b/cockatrice/src/client/tabs/tab_deck_storage.h
@@ -34,6 +34,7 @@ private:
     void deleteRemoteDeck(const RemoteDeckList_TreeModel::Node *node);
 
 private slots:
+    void actLocalDoubleClick(const QModelIndex &curLeft);
     void actOpenLocalDeck();
 
     void actUpload();
@@ -42,6 +43,7 @@ private slots:
     void actNewLocalFolder();
     void actDeleteLocalDeck();
 
+    void actRemoteDoubleClick(const QModelIndex &curRight);
     void actOpenRemoteDeck();
     void openRemoteDeckFinished(const Response &r, const CommandContainer &commandContainer);
 


### PR DESCRIPTION
## What will change with this Pull Request?

https://github.com/user-attachments/assets/ac950bf1-191d-4b5b-8ebe-84e098b4d809

Double click now opens deck for local and remote

Know issues: Doesn't work with multi-select because the first click of the double click will deselect everything else
