### PR TITLE
open replays on double-click in replays tab

### DIFF
--- a/cockatrice/src/client/tabs/tab_replays.cpp
+++ b/cockatrice/src/client/tabs/tab_replays.cpp
@@ -131,6 +131,13 @@ void TabReplays::retranslateUi()
     aDeleteRemoteReplay->setText(tr("Delete"));
 }
 
+void TabReplays::actLocalDoubleClick(const QModelIndex &curLeft)
+{
+    if (!localDirModel->isDir(curLeft)) {
+        actOpenLocalReplay();
+    }
+}
+
 void TabReplays::actOpenLocalReplay()
 {
     QModelIndexList curLefts = localDirView->selectionModel()->selectedRows();
@@ -189,6 +196,13 @@ void TabReplays::actDeleteLocalReplay()
         if (curLeft.isValid()) {
             localDirModel->remove(curLeft);
         }
+    }
+}
+
+void TabReplays::actRemoteDoubleClick(const QModelIndex &curRight)
+{
+    if (serverDirView->getReplay(curRight)) {
+        actOpenRemoteReplay();
     }
 }
 

--- a/cockatrice/src/client/tabs/tab_replays.h
+++ b/cockatrice/src/client/tabs/tab_replays.h
@@ -28,10 +28,12 @@ private:
     QAction *aOpenLocalReplay, *aNewLocalFolder, *aDeleteLocalReplay;
     QAction *aOpenRemoteReplay, *aDownload, *aKeep, *aDeleteRemoteReplay;
 private slots:
+    void actLocalDoubleClick(const QModelIndex &curLeft);
     void actOpenLocalReplay();
     void actNewLocalFolder();
     void actDeleteLocalReplay();
 
+    void actRemoteDoubleClick(const QModelIndex &curLeft);
     void actOpenRemoteReplay();
     void openRemoteReplayFinished(const Response &r);
 

--- a/cockatrice/src/server/remote/remote_replay_list_tree_widget.cpp
+++ b/cockatrice/src/server/remote/remote_replay_list_tree_widget.cpp
@@ -310,6 +310,15 @@ RemoteReplayList_TreeWidget::RemoteReplayList_TreeWidget(AbstractClient *_client
 }
 
 /**
+ * Gets the replay at the given index
+ * @return The replay. Returns nullptr if there is no replay at the index.
+ */
+ServerInfo_Replay const *RemoteReplayList_TreeWidget::getReplay(const QModelIndex &ind) const
+{
+    return treeModel->getReplay(proxyModel->mapToSource(ind));
+}
+
+/**
  * Gets all currently selected replays.
  * Any selection that isn't a replay file (e.g. a folder) will appear as a nullptr in the list.
  * Make sure to check the list for nullptr before using it.

--- a/cockatrice/src/server/remote/remote_replay_list_tree_widget.h
+++ b/cockatrice/src/server/remote/remote_replay_list_tree_widget.h
@@ -107,10 +107,10 @@ class RemoteReplayList_TreeWidget : public QTreeView
 private:
     RemoteReplayList_TreeModel *treeModel;
     QSortFilterProxyModel *proxyModel;
-    ServerInfo_Replay const *getNode(const QModelIndex &ind) const;
 
 public:
     RemoteReplayList_TreeWidget(AbstractClient *_client, QWidget *parent = nullptr);
+    ServerInfo_Replay const *getReplay(const QModelIndex &ind) const;
     QList<ServerInfo_Replay const *> getSelectedReplays() const;
     QSet<ServerInfo_ReplayMatch const *> getSelectedReplayMatches() const;
     void refreshTree();


### PR DESCRIPTION
## What will change with this Pull Request?


https://github.com/user-attachments/assets/6af863a1-9541-45ce-8076-0631d1a74f76


Double click now opens replays for local and remote

Know issues: Doesn't work with multi-select because the first click of the double click will deselect everything else
