### PR TITLE
Support downloading replay folders

### DIFF
--- a/cockatrice/src/client/tabs/tab_replays.h
+++ b/cockatrice/src/client/tabs/tab_replays.h
@@ -27,6 +27,9 @@ private:
 
     QAction *aOpenLocalReplay, *aNewLocalFolder, *aDeleteLocalReplay;
     QAction *aOpenRemoteReplay, *aDownload, *aKeep, *aDeleteRemoteReplay;
+
+    void downloadNodeAtIndex(const QModelIndex &curLeft, const QModelIndex &curRight);
+
 private slots:
     void actLocalDoubleClick(const QModelIndex &curLeft);
     void actOpenLocalReplay();

--- a/cockatrice/src/server/remote/remote_replay_list_tree_widget.cpp
+++ b/cockatrice/src/server/remote/remote_replay_list_tree_widget.cpp
@@ -331,6 +331,15 @@ ServerInfo_Replay const *RemoteReplayList_TreeWidget::getReplay(const QModelInde
 }
 
 /**
+ * Gets the replay match at the given index
+ * @return The replay match. Returns nullptr if there is no replay match at the index.
+ */
+ServerInfo_ReplayMatch const *RemoteReplayList_TreeWidget::getReplayMatch(const QModelIndex &ind) const
+{
+    return treeModel->getReplayMatch(proxyModel->mapToSource(ind));
+}
+
+/**
  * Gets all currently selected replays.
  * Any selection that isn't a replay file (e.g. a folder) will appear as a nullptr in the list.
  * Make sure to check the list for nullptr before using it.

--- a/cockatrice/src/server/remote/remote_replay_list_tree_widget.cpp
+++ b/cockatrice/src/server/remote/remote_replay_list_tree_widget.cpp
@@ -221,6 +221,18 @@ ServerInfo_ReplayMatch const *RemoteReplayList_TreeModel::getReplayMatch(const Q
         return nullptr;
 
     auto *node = dynamic_cast<MatchNode *>(static_cast<Node *>(index.internalPointer()));
+    if (!node)
+        return nullptr;
+
+    return &node->getMatchInfo();
+}
+
+ServerInfo_ReplayMatch const *RemoteReplayList_TreeModel::getEnclosingReplayMatch(const QModelIndex &index) const
+{
+    if (!index.isValid())
+        return nullptr;
+
+    auto *node = dynamic_cast<MatchNode *>(static_cast<Node *>(index.internalPointer()));
     if (!node) {
         auto *_node = dynamic_cast<ReplayNode *>(static_cast<Node *>(index.internalPointer()));
         if (!_node)
@@ -338,6 +350,7 @@ QList<ServerInfo_Replay const *> RemoteReplayList_TreeWidget::getSelectedReplays
 
 /**
  * Gets all currently selected replayMatches.
+ * If a non-folder node is selected, it will return the parent folder of that node.
  *
  * @return A Set of pointers to the selected replayMatches.
  */
@@ -346,7 +359,7 @@ QSet<ServerInfo_ReplayMatch const *> RemoteReplayList_TreeWidget::getSelectedRep
     const auto selection = selectionModel()->selectedRows();
     auto replayMatches = QSet<ServerInfo_ReplayMatch const *>();
     for (const auto &row : selection) {
-        if (const auto replayMatch = treeModel->getReplayMatch(proxyModel->mapToSource(row))) {
+        if (const auto replayMatch = treeModel->getEnclosingReplayMatch(proxyModel->mapToSource(row))) {
             replayMatches << replayMatch;
         }
     }

--- a/cockatrice/src/server/remote/remote_replay_list_tree_widget.h
+++ b/cockatrice/src/server/remote/remote_replay_list_tree_widget.h
@@ -112,6 +112,7 @@ private:
 public:
     RemoteReplayList_TreeWidget(AbstractClient *_client, QWidget *parent = nullptr);
     ServerInfo_Replay const *getReplay(const QModelIndex &ind) const;
+    ServerInfo_ReplayMatch const *getReplayMatch(const QModelIndex &ind) const;
     QList<ServerInfo_Replay const *> getSelectedReplays() const;
     QSet<ServerInfo_ReplayMatch const *> getSelectedReplayMatches() const;
     void refreshTree();

--- a/cockatrice/src/server/remote/remote_replay_list_tree_widget.h
+++ b/cockatrice/src/server/remote/remote_replay_list_tree_widget.h
@@ -97,6 +97,7 @@ public:
     void refreshTree();
     ServerInfo_Replay const *getReplay(const QModelIndex &index) const;
     ServerInfo_ReplayMatch const *getReplayMatch(const QModelIndex &index) const;
+    ServerInfo_ReplayMatch const *getEnclosingReplayMatch(const QModelIndex &index) const;
     void addMatchInfo(const ServerInfo_ReplayMatch &matchInfo);
     void updateMatchInfo(int gameId, const ServerInfo_ReplayMatch &matchInfo);
     void removeMatchInfo(int gameId);


### PR DESCRIPTION
## What will change with this Pull Request?

https://github.com/user-attachments/assets/fc731567-7573-4172-891a-932f8759167e

We can now download folders in the replays tab.
Folders will be downloaded with the name `id`_`game name`

- Refactored some stuff in the replays TreeWidget