### PR TITLE
fix text missing from download url list's buttons when hidden

### DIFF
--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -942,8 +942,11 @@ void DeckEditorSettingsPage::retranslateUi()
     pixmapCacheEdit.setToolTip(tr("In-memory cache for pictures not currently on screen"));
     updateNowButton->setText(tr("Update Spoilers"));
     aAdd->setToolTip(tr("Add New URL"));
+    aAdd->setText(tr("Add New URL"));
     aEdit->setToolTip(tr("Edit URL"));
+    aEdit->setText(tr("Edit URL"));
     aRemove->setToolTip(tr("Remove URL"));
+    aRemove->setText(tr("Remove URL"));
     networkRedirectCacheTtlEdit.setSuffix(" " + tr("Day(s)"));
 }
 


### PR DESCRIPTION
## Short roundup of the initial problem

#5186 introduced some more buttons to the `Deck Editor`, which reduces the space enough to hide some buttons in the download url list's sidebar. There should be a dropdown that contains the hidden actions, but the text is empty

<img width="400" alt="Screenshot 2024-12-25 at 12 04 35 AM" src="https://github.com/user-attachments/assets/f8cbcbbd-56a0-4b2e-bc44-3867015858be" />


## What will change with this Pull Request?
Add text (in addition to the tooltip) to the `QActions` so they show up in the dropdown

<img width="400" alt="Screenshot 2024-12-25 at 12 05 10 AM" src="https://github.com/user-attachments/assets/2e38518f-adb8-4bee-a230-4016033fd3f7" />
