### PR TITLE
make better use of space in download url settings window

### DIFF
--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -728,9 +728,9 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     lpGeneralGrid->addWidget(&picDownloadCheckBox, 0, 0);
     lpGeneralGrid->addWidget(&resetDownloadURLs, 0, 1);
     lpGeneralGrid->addLayout(urlListLayout, 1, 0, 1, 2);
-    lpGeneralGrid->addLayout(networkCacheLayout, 2, 0, 1, 2);
-    lpGeneralGrid->addLayout(pixmapCacheLayout, 3, 0, 1, 2);
-    lpGeneralGrid->addLayout(networkRedirectCacheLayout, 4, 0, 1, 2);
+    lpGeneralGrid->addLayout(networkCacheLayout, 2, 1);
+    lpGeneralGrid->addLayout(networkRedirectCacheLayout, 3, 0);
+    lpGeneralGrid->addLayout(pixmapCacheLayout, 3, 1);
     lpGeneralGrid->addWidget(&urlLinkLabel, 5, 0);
     lpGeneralGrid->addWidget(&clearDownloadedPicsButton, 5, 1);
 


### PR DESCRIPTION
## Short roundup of the initial problem

#5186 introduced some more buttons to the `Deck Editor`, which caused the layout to become more squished vertically. There's still some empty room that isn't being used.
<img width="400" alt="Screenshot 2024-12-25 at 12 21 33 AM" src="https://github.com/user-attachments/assets/5b2a0fc1-8448-421b-bc46-b2fd4ab82ec3" />

## What will change with this Pull Request?

Moved `Redirect Cache TTL` to the same row as one of the other settings.

<img width="400" alt="Screenshot 2024-12-25 at 12 18 37 AM" src="https://github.com/user-attachments/assets/0c401f64-190b-454f-9e16-9296c0da5736" />

