### PR TITLE
gitignore all cmake-build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ mysql.cnf
 .DS_Store
 .idea/
 *.aps
-cmake-build-debug*
+cmake-build*
 preferences
 compile_commands.json
 .vs/


### PR DESCRIPTION
## Short roundup of the initial problem

`cmake-build-release` was not being gitignored

## What will change with this Pull Request?

gitignore everything that starts with `cmake-build`