### PR TITLE
fix text missing from chat macro list's buttons when hidden

### DIFF
--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -1187,9 +1187,9 @@ void MessagesSettingsPage::retranslateUi()
     hexHighlightLabel.setText(tr("(Color is hexadecimal)"));
     customAlertStringLabel.setText(tr("Separate words with a space, alphanumeric characters only"));
     customAlertString->setPlaceholderText(tr("Word1 Word2 Word3"));
-    aAdd->setToolTip(tr("Add New Message"));
-    aEdit->setToolTip(tr("Edit Message"));
-    aRemove->setToolTip(tr("Remove Message"));
+    aAdd->setText(tr("Add New Message"));
+    aEdit->setText(tr("Edit Message"));
+    aRemove->setText(tr("Remove Message"));
 }
 
 SoundSettingsPage::SoundSettingsPage()

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -941,11 +941,8 @@ void DeckEditorSettingsPage::retranslateUi()
     pixmapCacheLabel.setText(tr("Picture Cache Size:"));
     pixmapCacheEdit.setToolTip(tr("In-memory cache for pictures not currently on screen"));
     updateNowButton->setText(tr("Update Spoilers"));
-    aAdd->setToolTip(tr("Add New URL"));
     aAdd->setText(tr("Add New URL"));
-    aEdit->setToolTip(tr("Edit URL"));
     aEdit->setText(tr("Edit URL"));
-    aRemove->setToolTip(tr("Remove URL"));
     aRemove->setText(tr("Remove URL"));
     networkRedirectCacheTtlEdit.setSuffix(" " + tr("Day(s)"));
 }


### PR DESCRIPTION
## Related Ticket(s)
- #5326

## Short roundup of the initial problem
<img width="400" alt="Screenshot 2024-12-25 at 3 32 39 PM" src="https://github.com/user-attachments/assets/3a9df9e9-5794-44f3-bba6-c15227dca87b" />


## What will change with this Pull Request?
<img width="400" alt="Screenshot 2024-12-25 at 3 32 02 PM" src="https://github.com/user-attachments/assets/8f1bca23-8269-41fc-ab6e-871f31955486" />

- Also removed the tooltip text from the previous PR because turns out it just defaults to text if you don't set a tooltip.