### PR TITLE
add local rename button to replays tab

### DIFF
--- a/cockatrice/src/client/tabs/tab_replays.h
+++ b/cockatrice/src/client/tabs/tab_replays.h
@@ -25,13 +25,14 @@ private:
     RemoteReplayList_TreeWidget *serverDirView;
     QGroupBox *leftGroupBox, *rightGroupBox;
 
-    QAction *aOpenLocalReplay, *aNewLocalFolder, *aDeleteLocalReplay;
+    QAction *aOpenLocalReplay, *aRenameLocal, *aNewLocalFolder, *aDeleteLocalReplay;
     QAction *aOpenRemoteReplay, *aDownload, *aKeep, *aDeleteRemoteReplay;
 
     void downloadNodeAtIndex(const QModelIndex &curLeft, const QModelIndex &curRight);
 
 private slots:
     void actLocalDoubleClick(const QModelIndex &curLeft);
+    void actRenameLocal();
     void actOpenLocalReplay();
     void actNewLocalFolder();
     void actDeleteLocalReplay();


### PR DESCRIPTION
## Short roundup of the initial problem

We don't have an easy way to rename the replays after downloading them

## What will change with this Pull Request?

https://github.com/user-attachments/assets/451c51cd-934d-44d3-9913-8f7487f19580

Added a rename button to the local replays tab

- Works on both files and folders
- Only prompts for the basename and automatically keeps track of the extension
- Rename works with multi-select and will prompt the user for a rename one-by-one
  - Cancelling will terminate all remaining renames
- If rename fails, will pop up a error window before continuing

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
