### PR TITLE
Don't display unusable actions in opponent's card menus

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3711,7 +3711,9 @@ void Player::updateCardMenu(const CardItem *card)
         cardMenu->addAction(aSelectColumn);
         addRelatedCardView(card, cardMenu);
     } else if (writeableCard) {
-        if (moveMenu->isEmpty()) {
+        bool canModifyCard = judge || card->getOwner() == this;
+
+        if (moveMenu->isEmpty() && canModifyCard) {
             moveMenu->addAction(aMoveToTopLibrary);
             moveMenu->addAction(aMoveToXfromTopOfLibrary);
             moveMenu->addAction(aMoveToBottomLibrary);
@@ -3726,6 +3728,20 @@ void Player::updateCardMenu(const CardItem *card)
         if (card->getZone()) {
             if (card->getZone()->getName() == "table") {
                 // Card is on the battlefield
+
+                if (!canModifyCard) {
+                    addRelatedCardView(card, cardMenu);
+                    addRelatedCardActions(card, cardMenu);
+
+                    cardMenu->addSeparator();
+                    cardMenu->addAction(aDrawArrow);
+                    cardMenu->addSeparator();
+                    cardMenu->addAction(aClone);
+                    cardMenu->addSeparator();
+                    cardMenu->addAction(aSelectAll);
+                    cardMenu->addAction(aSelectRow);
+                    return;
+                }
 
                 if (ptMenu->isEmpty()) {
                     ptMenu->addAction(aIncP);
@@ -3780,32 +3796,48 @@ void Player::updateCardMenu(const CardItem *card)
                 cardMenu->addSeparator();
             } else if (card->getZone()->getName() == "stack") {
                 // Card is on the stack
-                cardMenu->addAction(aAttach);
-                cardMenu->addAction(aDrawArrow);
-                cardMenu->addSeparator();
-                cardMenu->addAction(aClone);
-                cardMenu->addMenu(moveMenu);
-                cardMenu->addSeparator();
-                cardMenu->addAction(aSelectAll);
+                if (canModifyCard) {
+                    cardMenu->addAction(aAttach);
+                    cardMenu->addAction(aDrawArrow);
+                    cardMenu->addSeparator();
+                    cardMenu->addAction(aClone);
+                    cardMenu->addMenu(moveMenu);
+                    cardMenu->addSeparator();
+                    cardMenu->addAction(aSelectAll);
+                } else {
+                    cardMenu->addAction(aDrawArrow);
+                    cardMenu->addSeparator();
+                    cardMenu->addAction(aClone);
+                    cardMenu->addSeparator();
+                    cardMenu->addAction(aSelectAll);
+                }
 
                 addRelatedCardView(card, cardMenu);
                 addRelatedCardActions(card, cardMenu);
             } else if (card->getZone()->getName() == "rfg" || card->getZone()->getName() == "grave") {
                 // Card is in the graveyard or exile
-                cardMenu->addAction(aSelectAll);
-                cardMenu->addAction(aPlay);
-                cardMenu->addAction(aPlayFacedown);
+                if (canModifyCard) {
+                    cardMenu->addAction(aPlay);
+                    cardMenu->addAction(aPlayFacedown);
 
-                cardMenu->addSeparator();
-                cardMenu->addAction(aClone);
-                cardMenu->addMenu(moveMenu);
-                cardMenu->addSeparator();
-                cardMenu->addAction(aSelectAll);
-                cardMenu->addAction(aSelectColumn);
+                    cardMenu->addSeparator();
+                    cardMenu->addAction(aClone);
+                    cardMenu->addMenu(moveMenu);
+                    cardMenu->addSeparator();
+                    cardMenu->addAction(aSelectAll);
+                    cardMenu->addAction(aSelectColumn);
 
-                cardMenu->addSeparator();
-                cardMenu->addAction(aAttach);
-                cardMenu->addAction(aDrawArrow);
+                    cardMenu->addSeparator();
+                    cardMenu->addAction(aAttach);
+                    cardMenu->addAction(aDrawArrow);
+                } else {
+                    cardMenu->addAction(aClone);
+                    cardMenu->addSeparator();
+                    cardMenu->addAction(aSelectAll);
+                    cardMenu->addAction(aSelectColumn);
+                    cardMenu->addSeparator();
+                    cardMenu->addAction(aDrawArrow);
+                }
 
                 addRelatedCardView(card, cardMenu);
                 addRelatedCardActions(card, cardMenu);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5334

## What will change with this Pull Request?

https://github.com/user-attachments/assets/840db46f-df35-49a9-b36e-a852975516df

Opponent's card menus will now only have usable actions in them. Usable actions include `Draw Arrow`, `Clone`, options related to viewing and creating related cards, and the selection actions.

Changes were made to the card menus in the opponent's `table`, `stack`, `graveyard`, and `exile` zone. The other zones don't need to be changed since they weren't modifiable or accessible to an opponent anyways.

Local games are unaffected

## Screenshots
<img width="296" alt="Screenshot 2024-12-26 at 12 26 22 AM" src="https://github.com/user-attachments/assets/cf3a3b54-36ff-4284-aa92-27ad5c93ae4f" />

<img width="295" alt="Screenshot 2024-12-26 at 12 26 28 AM" src="https://github.com/user-attachments/assets/a55881bb-ebaf-42c8-a8a1-6bc4645df8f0" />

<img width="283" alt="Screenshot 2024-12-26 at 12 26 46 AM" src="https://github.com/user-attachments/assets/e7ed01a4-65b4-4c08-8b50-0abf2bdc5a2c" />
