### PR TITLE
Ctrl drag now adds/removes to selection

### DIFF
--- a/cockatrice/src/game/zones/select_zone.cpp
+++ b/cockatrice/src/game/zones/select_zone.cpp
@@ -83,7 +83,9 @@ void SelectZone::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 void SelectZone::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
     if (event->button() == Qt::LeftButton) {
-        scene()->clearSelection();
+        if (!event->modifiers().testFlag(Qt::ControlModifier)) {
+            scene()->clearSelection();
+        }
 
         selectionOrigin = event->pos();
         static_cast<GameScene *>(scene())->startRubberBand(event->scenePos());

--- a/cockatrice/src/game/zones/select_zone.cpp
+++ b/cockatrice/src/game/zones/select_zone.cpp
@@ -58,11 +58,11 @@ void SelectZone::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
             pos.setY(br.height());
 
         QRectF selectionRect = QRectF(selectionOrigin, pos).normalized();
-        for (int i = 0; i < cards.size(); ++i) {
-            if (cards[i]->getAttachedTo())
-                if (cards[i]->getAttachedTo()->getZone() != this)
-                    continue;
-            cards[i]->setSelected(selectionRect.intersects(cards[i]->mapRectToParent(cards[i]->boundingRect())));
+        for (auto card : cards) {
+            if (card->getAttachedTo() && card->getAttachedTo()->getZone() != this) {
+                continue;
+            }
+            card->setSelected(selectionRect.intersects(card->mapRectToParent(card->boundingRect())));
         }
         static_cast<GameScene *>(scene())->resizeRubberBand(
             deviceTransform(static_cast<GameScene *>(scene())->getViewportTransform()).map(pos));

--- a/cockatrice/src/game/zones/select_zone.cpp
+++ b/cockatrice/src/game/zones/select_zone.cpp
@@ -62,7 +62,17 @@ void SelectZone::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
             if (card->getAttachedTo() && card->getAttachedTo()->getZone() != this) {
                 continue;
             }
-            card->setSelected(selectionRect.intersects(card->mapRectToParent(card->boundingRect())));
+
+            bool inRect = selectionRect.intersects(card->mapRectToParent(card->boundingRect()));
+            if (inRect && !cardsInSelectionRect.contains(card)) {
+                // selection has just expanded to cover the card
+                cardsInSelectionRect.insert(card);
+                card->setSelected(!card->isSelected());
+            } else if (!inRect && cardsInSelectionRect.contains(card)) {
+                // selection has just shrunk to no longer cover the card
+                cardsInSelectionRect.remove(card);
+                card->setSelected(!card->isSelected());
+            }
         }
         static_cast<GameScene *>(scene())->resizeRubberBand(
             deviceTransform(static_cast<GameScene *>(scene())->getViewportTransform()).map(pos));
@@ -85,6 +95,7 @@ void SelectZone::mousePressEvent(QGraphicsSceneMouseEvent *event)
 void SelectZone::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     selectionOrigin = QPoint();
+    cardsInSelectionRect.clear();
     static_cast<GameScene *>(scene())->stopRubberBand();
     event->accept();
 }

--- a/cockatrice/src/game/zones/select_zone.h
+++ b/cockatrice/src/game/zones/select_zone.h
@@ -11,6 +11,7 @@ class SelectZone : public CardZone
     Q_OBJECT
 private:
     QPointF selectionOrigin;
+    QSet<CardItem *> cardsInSelectionRect;
 
 protected:
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event);

--- a/cockatrice/src/game/zones/select_zone.h
+++ b/cockatrice/src/game/zones/select_zone.h
@@ -3,6 +3,8 @@
 
 #include "card_zone.h"
 
+#include <QSet>
+
 /**
  * A CardZone where the cards are laid out, with each card directly interactable by clicking.
  */


### PR DESCRIPTION
## Short roundup of the initial problem

On other apps, holding `Ctrl` while dragging will add to the current selection. Currently, Cockatrice doesn't have any special behavior for `Ctrl` dragging; it will just clear the selection and then select the cards as normal.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/2d810d9d-e30a-41ae-80e1-7e0c12c4521d

Holding `Ctrl` while dragging no longer clears the selection, and will now toggle the selection state of the cards as they are selected over.

The behavior when not holding `Ctrl` is the same as before.