### PR TITLE
remove shortcut workaround; always add card menu to player

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -1005,15 +1005,9 @@ void Player::setShortcutsActive()
     aPlayFacedown->setShortcut(shortcuts.getSingleShortcut("Player/aPlayFacedown"));
     aPlay->setShortcut(shortcuts.getSingleShortcut("Player/aPlay"));
 
+    // Don't enable always-active shortcuts in local games, since it causes keyboard shortcuts to work inconsistently
+    // when there are more than 1 player.
     if (!game->getIsLocalGame()) {
-        /* Attach all card menu actions that also work on the opponent's cards to the TabGame object so that those
-         * shortcuts will be active regardless of whether your card menu currently exists.
-         * Added as a workaround to get the clone keyboard shortcut to work on opponent's cards.
-         */
-        game->addAction(aClone);
-        game->addAction(aDrawArrow);
-        game->addAction(aSelectAll);
-
         // unattach action is only active in card menu if the active card is attached.
         // make unattach shortcut always active so that it consistently works when multiple cards are selected.
         game->addAction(aUnattach);

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -426,14 +426,10 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
         initSayMenu();
     }
 
-    if (local || judge) {
-        aCardMenu = new QAction(this);
-        aCardMenu->setEnabled(false);
-        playerMenu->addSeparator();
-        playerMenu->addAction(aCardMenu);
-    } else {
-        aCardMenu = nullptr;
-    }
+    aCardMenu = new QAction(this);
+    aCardMenu->setEnabled(false);
+    playerMenu->addSeparator();
+    playerMenu->addAction(aCardMenu);
 
     if (local || judge) {
 
@@ -833,12 +829,12 @@ void Player::retranslateUi()
             counterIterator.next().value()->retranslateUi();
         }
 
-        aCardMenu->setText(tr("Selec&ted cards"));
-
         for (auto &allPlayersAction : allPlayersActions) {
             allPlayersAction->setText(tr("&All players"));
         }
     }
+
+    aCardMenu->setText(tr("Selec&ted cards"));
 
     if (local) {
         sayMenu->setTitle(tr("S&ay"));

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -260,10 +260,11 @@ private:
         *aMoveTopCardToExile, *aMoveTopCardsToGraveyard, *aMoveTopCardsToExile, *aMoveTopCardsUntil,
         *aMoveTopCardToBottom, *aViewGraveyard, *aViewRfg, *aViewSideboard, *aDrawCard, *aDrawCards, *aUndoDraw,
         *aMulligan, *aShuffle, *aMoveTopToPlay, *aMoveTopToPlayFaceDown, *aUntapAll, *aRollDie, *aCreateToken,
-        *aCreateAnotherToken, *aCardMenu, *aMoveBottomToPlay, *aMoveBottomToPlayFaceDown, *aMoveBottomCardToTop,
+        *aCreateAnotherToken, *aMoveBottomToPlay, *aMoveBottomToPlayFaceDown, *aMoveBottomCardToTop,
         *aMoveBottomCardToGraveyard, *aMoveBottomCardToExile, *aMoveBottomCardsToGraveyard, *aMoveBottomCardsToExile,
         *aDrawBottomCard, *aDrawBottomCards;
 
+    QAction *aCardMenu;
     QList<QAction *> aAddCounter, aSetCounter, aRemoveCounter;
     QAction *aPlay, *aPlayFacedown, *aHide, *aTap, *aDoesntUntap, *aAttach, *aUnattach, *aDrawArrow, *aSetPT, *aResetPT,
         *aIncP, *aDecP, *aIncT, *aDecT, *aIncPT, *aDecPT, *aFlowP, *aFlowT, *aSetAnnotation, *aFlip, *aPeek, *aClone,


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5251
- Follow-up to #5335

## Short roundup of the initial problem

In the #5251, we made a workaround for shortcuts not working on opponent's cards by making those shortcuts always active. However, this requires us to add all shortcuts that make sense on the opponent's cards to the always active section. Also, we want `Select Row` and `Select Column` to work on opponent's cards, but we don't want those shortcuts to be always active.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/ec24a2b8-5c41-4144-914b-7cdd00200481

We now always add the card menu to the player menu, which means shortcuts are now naturally active on opponent's card menus. #5335 ensures that only shortcuts for actions that work on opponent's cards are active when only opponent's cards are selected.

If there is a multi-selection that contains cards from both sides, then the non-opponent shortcuts will still become active, depending on what the last selected card is, but that already matches the existing behavior.
