### PR TITLE
Allow starting of games with fewer than max number of players

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -106,11 +106,14 @@ DeckViewContainer::DeckViewContainer(int _playerId, TabGame *parent)
     loadRemoteButton = new QPushButton;
     readyStartButton = new ToggleButton;
     readyStartButton->setEnabled(false);
+    forceStartGameButton = new QPushButton;
+    forceStartGameButton->setEnabled(parent->isHost());
     sideboardLockButton = new ToggleButton;
     sideboardLockButton->setEnabled(false);
 
     connect(loadLocalButton, SIGNAL(clicked()), this, SLOT(loadLocalDeck()));
     connect(readyStartButton, SIGNAL(clicked()), this, SLOT(readyStart()));
+    connect(forceStartGameButton, &QPushButton::clicked, this, &DeckViewContainer::forceStart);
     connect(sideboardLockButton, SIGNAL(clicked()), this, SLOT(sideboardLockButtonClicked()));
     connect(sideboardLockButton, SIGNAL(stateChanged()), this, SLOT(updateSideboardLockButtonText()));
 
@@ -125,6 +128,9 @@ DeckViewContainer::DeckViewContainer(int _playerId, TabGame *parent)
     buttonHBox->addWidget(loadRemoteButton);
     buttonHBox->addWidget(readyStartButton);
     buttonHBox->addWidget(sideboardLockButton);
+    if (forceStartGameButton->isEnabled()) {
+        buttonHBox->addWidget(forceStartGameButton);
+    }
     buttonHBox->setContentsMargins(0, 0, 0, 0);
     buttonHBox->addStretch();
     deckView = new DeckView;
@@ -147,6 +153,7 @@ void DeckViewContainer::retranslateUi()
     loadLocalButton->setText(tr("Load deck..."));
     loadRemoteButton->setText(tr("Load remote deck..."));
     readyStartButton->setText(tr("Ready to start"));
+    forceStartGameButton->setText(tr("Force start"));
     updateSideboardLockButtonText();
 }
 
@@ -155,6 +162,7 @@ void DeckViewContainer::setButtonsVisible(bool _visible)
     loadLocalButton->setVisible(_visible);
     loadRemoteButton->setVisible(_visible);
     readyStartButton->setVisible(_visible);
+    forceStartGameButton->setVisible(_visible);
     sideboardLockButton->setVisible(_visible);
 }
 
@@ -335,6 +343,14 @@ void DeckViewContainer::readyStart()
 {
     Command_ReadyStart cmd;
     cmd.set_ready(!readyStartButton->getState());
+    parentGame->sendGameCommand(cmd, playerId);
+}
+
+void DeckViewContainer::forceStart()
+{
+    Command_ReadyStart cmd;
+    cmd.set_force_start(true);
+    cmd.set_ready(true);
     parentGame->sendGameCommand(cmd, playerId);
 }
 

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -86,7 +86,7 @@ class DeckViewContainer : public QWidget
 {
     Q_OBJECT
 private:
-    QPushButton *loadLocalButton, *loadRemoteButton;
+    QPushButton *loadLocalButton, *loadRemoteButton, *forceStartGameButton;
     ToggleButton *readyStartButton, *sideboardLockButton;
     DeckView *deckView;
     TabGame *parentGame;
@@ -95,6 +95,7 @@ private slots:
     void loadLocalDeck();
     void loadRemoteDeck();
     void readyStart();
+    void forceStart();
     void deckSelectFinished(const Response &r);
     void sideboardPlanChanged();
     void sideboardLockButtonClicked();

--- a/common/pb/command_ready_start.proto
+++ b/common/pb/command_ready_start.proto
@@ -5,4 +5,5 @@ message Command_ReadyStart {
         optional Command_ReadyStart ext = 1016;
     }
     optional bool ready = 1;
+    optional bool force_start = 2;
 }

--- a/common/server_game.h
+++ b/common/server_game.h
@@ -82,11 +82,11 @@ private:
                                      bool withUserInfo);
     void storeGameInformation();
 signals:
-    void sigStartGameIfReady();
+    void sigStartGameIfReady(bool override);
     void gameInfoChanged(ServerInfo_Game gameInfo);
 private slots:
     void pingClockTimeout();
-    void doStartGameIfReady();
+    void doStartGameIfReady(bool forceStartGame = false);
 
 public:
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
@@ -180,7 +180,7 @@ public:
     void removeArrowsRelatedToPlayer(GameEventStorage &ges, Server_Player *player);
     void unattachCards(GameEventStorage &ges, Server_Player *player);
     bool kickPlayer(int playerId);
-    void startGameIfReady();
+    void startGameIfReady(bool forceStartGame);
     void stopGameIfFinished();
     int getActivePlayer() const
     {

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -944,7 +944,7 @@ Server_Player::cmdReadyStart(const Command_ReadyStart &cmd, ResponseContainer & 
         return Response::RespContextError;
     }
 
-    if (readyStart == cmd.ready()) {
+    if (readyStart == cmd.ready() && !cmd.force_start()) {
         return Response::RespContextError;
     }
 
@@ -955,8 +955,13 @@ Server_Player::cmdReadyStart(const Command_ReadyStart &cmd, ResponseContainer & 
     ges.enqueueGameEvent(event, playerId);
     ges.setGameEventContext(Context_ReadyStart());
 
-    if (cmd.ready()) {
-        game->startGameIfReady();
+    if (cmd.force_start()) {
+        if (game->getHostId() != playerId) {
+            return Response::RespFunctionNotAllowed;
+        }
+        game->startGameIfReady(true);
+    } else if (cmd.ready()) {
+        game->startGameIfReady(false);
     }
 
     return Response::RespOk;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #434

## Short roundup of the initial problem

Since the beginning of time, games could only start if everyone was ready'd up and the lobby was full.

## What will change with this Pull Request?

Game hosts can now "Force start" a game, which will only include players that have decks loaded and are ready'd up. Players who don't have a deck ready, and empty player slots, will be kicked/removed from the game.

Future improvement will be to support moving the user to a spectator instead of kicking them, but it's not apart of this PR.

## Screenshots

See videos below.
