### PR TITLE
allow playing cards directly transformed from hand

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3858,6 +3858,9 @@ void Player::updateCardMenu(const CardItem *card)
                 }
 
                 addRelatedCardView(card, cardMenu);
+                if (card->getZone()->getName() == "hand") {
+                    addRelatedCardActions(card, cardMenu);
+                }
             }
         } else {
             cardMenu->addMenu(moveMenu);


### PR DESCRIPTION
## Short roundup of the initial problem

The Related Card Actions menu works perfectly well from hand. No reason why we shouldn't give the player access to it.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/7ff0c794-d3c7-4771-bc91-cb315bb0a954

- Added Related Card Actions to hand zone's card menu
  - Playing a card transformed will directly put it into play transformed
  - Also means we can create related tokens from hand now
