### PR TITLE
use grid instead of FlowWidget for PrintingSelector display options

### DIFF
--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_view_options_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_view_options_widget.cpp
@@ -15,12 +15,9 @@ PrintingSelectorViewOptionsWidget::PrintingSelectorViewOptionsWidget(QWidget *pa
                                                                      PrintingSelector *_printingSelector)
     : QWidget(parent), printingSelector(_printingSelector)
 {
-    // Set up the layout for the widget
-    layout = new QHBoxLayout(this);
-    setLayout(layout);
-
     // Create the grid to hold the checkboxes
     gridLayout = new QGridLayout(this);
+    setLayout(gridLayout);
 
     // Create the checkbox for sorting options visibility
     sortCheckBox = new QCheckBox(this);
@@ -63,7 +60,4 @@ PrintingSelectorViewOptionsWidget::PrintingSelectorViewOptionsWidget(QWidget *pa
     gridLayout->addWidget(searchCheckBox, 0, 1);
     gridLayout->addWidget(cardSizeCheckBox, 1, 0);
     gridLayout->addWidget(navigationCheckBox, 1, 1);
-
-    // Add grid to the main layout
-    layout->addLayout(gridLayout);
 }

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_view_options_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_view_options_widget.cpp
@@ -19,11 +19,11 @@ PrintingSelectorViewOptionsWidget::PrintingSelectorViewOptionsWidget(QWidget *pa
     layout = new QHBoxLayout(this);
     setLayout(layout);
 
-    // Create the flow widget to hold the checkboxes
-    flowWidget = new FlowWidget(this, Qt::ScrollBarPolicy::ScrollBarAlwaysOff, Qt::ScrollBarPolicy::ScrollBarAsNeeded);
+    // Create the grid to hold the checkboxes
+    gridLayout = new QGridLayout(this);
 
     // Create the checkbox for sorting options visibility
-    sortCheckBox = new QCheckBox(flowWidget);
+    sortCheckBox = new QCheckBox(this);
     sortCheckBox->setText(tr("Display Sorting Options"));
     sortCheckBox->setChecked(SettingsCache::instance().getPrintingSelectorSortOptionsVisible());
     connect(sortCheckBox, &QCheckBox::QT_STATE_CHANGED, printingSelector,
@@ -32,7 +32,7 @@ PrintingSelectorViewOptionsWidget::PrintingSelectorViewOptionsWidget(QWidget *pa
             &SettingsCache::setPrintingSelectorSortOptionsVisible);
 
     // Create the checkbox for search bar visibility
-    searchCheckBox = new QCheckBox(flowWidget);
+    searchCheckBox = new QCheckBox(this);
     searchCheckBox->setText(tr("Display Search Bar"));
     searchCheckBox->setChecked(SettingsCache::instance().getPrintingSelectorSearchBarVisible());
     connect(searchCheckBox, &QCheckBox::QT_STATE_CHANGED, printingSelector,
@@ -41,7 +41,7 @@ PrintingSelectorViewOptionsWidget::PrintingSelectorViewOptionsWidget(QWidget *pa
             &SettingsCache::setPrintingSelectorSearchBarVisible);
 
     // Create the checkbox for card size slider visibility
-    cardSizeCheckBox = new QCheckBox(flowWidget);
+    cardSizeCheckBox = new QCheckBox(this);
     cardSizeCheckBox->setText(tr("Display Card Size Slider"));
     cardSizeCheckBox->setChecked(SettingsCache::instance().getPrintingSelectorCardSizeSliderVisible());
     connect(cardSizeCheckBox, &QCheckBox::QT_STATE_CHANGED, printingSelector,
@@ -50,7 +50,7 @@ PrintingSelectorViewOptionsWidget::PrintingSelectorViewOptionsWidget(QWidget *pa
             &SettingsCache::setPrintingSelectorCardSizeSliderVisible);
 
     // Create the checkbox for navigation buttons visibility
-    navigationCheckBox = new QCheckBox(flowWidget);
+    navigationCheckBox = new QCheckBox(this);
     navigationCheckBox->setText(tr("Display Navigation Buttons"));
     navigationCheckBox->setChecked(SettingsCache::instance().getPrintingSelectorNavigationButtonsVisible());
     connect(navigationCheckBox, &QCheckBox::QT_STATE_CHANGED, printingSelector,
@@ -58,12 +58,12 @@ PrintingSelectorViewOptionsWidget::PrintingSelectorViewOptionsWidget(QWidget *pa
     connect(navigationCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setPrintingSelectorNavigationButtonsVisible);
 
-    // Add checkboxes to the flow widget
-    flowWidget->addWidget(sortCheckBox);
-    flowWidget->addWidget(searchCheckBox);
-    flowWidget->addWidget(cardSizeCheckBox);
-    flowWidget->addWidget(navigationCheckBox);
+    // Add checkboxes to the grid
+    gridLayout->addWidget(sortCheckBox, 0, 0);
+    gridLayout->addWidget(searchCheckBox, 0, 1);
+    gridLayout->addWidget(cardSizeCheckBox, 1, 0);
+    gridLayout->addWidget(navigationCheckBox, 1, 1);
 
-    // Add flow widget to the main layout
-    layout->addWidget(flowWidget);
+    // Add grid to the main layout
+    layout->addLayout(gridLayout);
 }

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_view_options_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_view_options_widget.h
@@ -17,7 +17,7 @@ public:
 
 private:
     QHBoxLayout *layout;
-    FlowWidget *flowWidget;
+    QGridLayout *gridLayout;
     PrintingSelector *printingSelector;
     QCheckBox *sortCheckBox;
     QCheckBox *searchCheckBox;

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_view_options_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_view_options_widget.h
@@ -16,7 +16,6 @@ public:
     explicit PrintingSelectorViewOptionsWidget(QWidget *parent, PrintingSelector *_printingSelector);
 
 private:
-    QHBoxLayout *layout;
     QGridLayout *gridLayout;
     PrintingSelector *printingSelector;
     QCheckBox *sortCheckBox;


### PR DESCRIPTION
## Short roundup of the initial problem

This looks bad

<img width="400" alt="Screenshot 2024-12-26 at 5 28 27 PM" src="https://github.com/user-attachments/assets/9962dc86-a234-4cd5-9ae8-02fc0eb916c0" />


## What will change with this Pull Request?

Use `QGridLayout` instead of `QFlowWidget`

<img width="400" alt="Screenshot 2024-12-26 at 5 26 30 PM" src="https://github.com/user-attachments/assets/2f609687-6604-44a9-95c8-5bc864a1a118" />
