### PR TITLE
reduce vertical spacing in PrintingSelector

### DIFF
--- a/cockatrice/src/client/ui/widgets/cards/card_size_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_size_widget.cpp
@@ -13,6 +13,7 @@ CardSizeWidget::CardSizeWidget(QWidget *parent, FlowWidget *flowWidget, int defa
     : parent(parent), flowWidget(flowWidget)
 {
     cardSizeLayout = new QHBoxLayout(this);
+    cardSizeLayout->setContentsMargins(9, 0, 9, 0);
     setLayout(cardSizeLayout);
 
     cardSizeLabel = new QLabel(tr("Card Size"), this);

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_search_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_search_widget.cpp
@@ -11,6 +11,7 @@
 PrintingSelectorCardSearchWidget::PrintingSelectorCardSearchWidget(PrintingSelector *parent) : parent(parent)
 {
     layout = new QHBoxLayout(this);
+    layout->setContentsMargins(9, 0, 9, 0);
     setLayout(layout);
 
     searchBar = new QLineEdit(this);

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_selection_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_selection_widget.cpp
@@ -11,6 +11,7 @@
 PrintingSelectorCardSelectionWidget::PrintingSelectorCardSelectionWidget(PrintingSelector *parent) : parent(parent)
 {
     cardSelectionBarLayout = new QHBoxLayout(this);
+    cardSelectionBarLayout->setContentsMargins(9, 0, 9, 0);
 
     previousCardButton = new QPushButton(this);
     previousCardButton->setText(tr("Previous Card in Deck"));

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.cpp
@@ -19,6 +19,7 @@ const QStringList PrintingSelectorCardSortingWidget::SORT_OPTIONS = {SORT_OPTION
 PrintingSelectorCardSortingWidget::PrintingSelectorCardSortingWidget(PrintingSelector *parent) : parent(parent)
 {
     sortToolBar = new QHBoxLayout(this);
+    sortToolBar->setContentsMargins(9, 0, 9, 0);
 
     sortOptionsSelector = new QComboBox(this);
     sortOptionsSelector->addItems(SORT_OPTIONS);

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_view_options_toolbar_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_view_options_toolbar_widget.cpp
@@ -17,7 +17,7 @@ PrintingSelectorViewOptionsToolbarWidget::PrintingSelectorViewOptionsToolbarWidg
 {
     // Set up layout for the widget
     layout = new QVBoxLayout();
-    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setContentsMargins(9, 0, 9, 0);
     layout->setSpacing(0);
     setLayout(layout);
 


### PR DESCRIPTION
## Short roundup of the initial problem

There's too much empty vertical space in the PrintingSelector window

![before](https://github.com/user-attachments/assets/c56c5977-3b8f-4bcb-8152-5d9592d40503)

## What will change with this Pull Request?

- Reduced empty vertical spacing between widgets

![after](https://github.com/user-attachments/assets/37a57009-cc15-45ad-aeed-ff14973649cf)
