### PR TITLE
Allow Moderators/Admins to Grant Replay Access

### DIFF
--- a/cockatrice/src/client/tabs/tab_admin.h
+++ b/cockatrice/src/client/tabs/tab_admin.h
@@ -1,6 +1,8 @@
 #ifndef TAB_ADMIN_H
 #define TAB_ADMIN_H
 
+#include "pb/commands.pb.h"
+#include "pb/response.pb.h"
 #include "tab.h"
 
 #include <QDialog>
@@ -32,15 +34,18 @@ private:
     bool locked;
     AbstractClient *client;
     bool fullAdmin;
-    QPushButton *updateServerMessageButton, *shutdownServerButton, *reloadConfigButton;
+    QPushButton *updateServerMessageButton, *shutdownServerButton, *reloadConfigButton, *grantReplayAccessButton;
     QGroupBox *adminGroupBox;
     QPushButton *unlockButton, *lockButton;
+    QLineEdit *replayIdToGrant;
 signals:
     void adminLockChanged(bool lock);
 private slots:
     void actUpdateServerMessage();
     void actShutdownServer();
     void actReloadConfig();
+    void actGrantReplayAccess();
+    void grantReplayAccessProcessResponse(const Response &resp, const CommandContainer &, const QVariant &);
 
     void actUnlock();
     void actLock();

--- a/cockatrice/src/client/tabs/tab_replays.cpp
+++ b/cockatrice/src/client/tabs/tab_replays.cpp
@@ -401,5 +401,11 @@ void TabReplays::deleteRemoteReplayFinished(const Response &r, const CommandCont
 
 void TabReplays::replayAddedEventReceived(const Event_ReplayAdded &event)
 {
-    serverDirView->addMatchInfo(event.match_info());
+    if (event.has_match_info()) {
+        // 99.9% of events will have match info (Normal Workflow)
+        serverDirView->addMatchInfo(event.match_info());
+    } else {
+        // When a Moderator force adds a replay, we need to refresh their view
+        serverDirView->refreshTree();
+    }
 }

--- a/cockatrice/src/server/remote/remote_replay_list_tree_widget.h
+++ b/cockatrice/src/server/remote/remote_replay_list_tree_widget.h
@@ -27,7 +27,7 @@ private:
         Node(const QString &_name) : name(_name)
         {
         }
-        virtual ~Node(){};
+        virtual ~Node() {};
         QString getName() const
         {
             return name;
@@ -115,7 +115,9 @@ public:
     ServerInfo_ReplayMatch const *getReplayMatch(const QModelIndex &ind) const;
     QList<ServerInfo_Replay const *> getSelectedReplays() const;
     QSet<ServerInfo_ReplayMatch const *> getSelectedReplayMatches() const;
-    void refreshTree();
+    void refreshTree() {
+        treeModel->refreshTree();
+    }
     void addMatchInfo(const ServerInfo_ReplayMatch &matchInfo)
     {
         treeModel->addMatchInfo(matchInfo);

--- a/cockatrice/src/server/remote/remote_replay_list_tree_widget.h
+++ b/cockatrice/src/server/remote/remote_replay_list_tree_widget.h
@@ -27,7 +27,7 @@ private:
         Node(const QString &_name) : name(_name)
         {
         }
-        virtual ~Node() {};
+        virtual ~Node(){};
         QString getName() const
         {
             return name;
@@ -115,7 +115,8 @@ public:
     ServerInfo_ReplayMatch const *getReplayMatch(const QModelIndex &ind) const;
     QList<ServerInfo_Replay const *> getSelectedReplays() const;
     QSet<ServerInfo_ReplayMatch const *> getSelectedReplayMatches() const;
-    void refreshTree() {
+    void refreshTree()
+    {
         treeModel->refreshTree();
     }
     void addMatchInfo(const ServerInfo_ReplayMatch &matchInfo)

--- a/common/pb/moderator_commands.proto
+++ b/common/pb/moderator_commands.proto
@@ -7,6 +7,7 @@ message ModeratorCommand {
         WARN_HISTORY = 1003;
         WARN_LIST = 1004;
         VIEWLOG_HISTORY = 1005;
+        GRANT_REPLAY_ACCESS = 1006;
     }
     extensions 100 to max;
 }
@@ -70,4 +71,12 @@ message Command_ViewLogHistory {
     repeated string log_location = 6;    // destination of message (ex: main room, game room, private chat)
     required uint32 date_range = 7;      // the length of time (in minutes) to look back for
     optional uint32 maximum_results = 8; // the maximum number of query results
+}
+
+message Command_GrantReplayAccess {
+    extend ModeratorCommand {
+        optional Command_GrantReplayAccess ext = 1006;
+    }
+    optional uint32 replay_id = 1;
+    optional string moderator_name = 2;
 }

--- a/servatrice/src/serversocketinterface.h
+++ b/servatrice/src/serversocketinterface.h
@@ -126,6 +126,7 @@ private:
     Response::ResponseCode cmdAccountEdit(const Command_AccountEdit &cmd, ResponseContainer &rc);
     Response::ResponseCode cmdAccountImage(const Command_AccountImage &cmd, ResponseContainer &rc);
     Response::ResponseCode cmdAccountPassword(const Command_AccountPassword &cmd, ResponseContainer &rc);
+    Response::ResponseCode cmdGrantReplayAccess(const Command_GrantReplayAccess &cmd, ResponseContainer &rc);
 
     bool addAdminFlagToUser(const QString &user, int flag);
     bool removeAdminFlagFromUser(const QString &user, int flag);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1953 

## Short roundup of the initial problem

Moderators have to use an external client panel to perform basic job functionality of auditing games.

## What will change with this Pull Request?

Moderators/Admins can now grant themselves permissions to view replays in-client and have the feed auto refresh, avoiding the clunky need to re-login after using an external tool.
- Replay can only be granted to themselves, at this time


## Screenshots
<!-- simply drag & drop image files directly into this description! -->
