### PR TITLE
change action's text to "unconcede" when player is conceded

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -536,6 +536,12 @@ void TabGame::updatePlayerListDockTitle()
                                    (playerListDock->isWindow() ? tabText : QString()));
 }
 
+bool TabGame::isMainPlayerConceded() const
+{
+    Player *player = players.value(localPlayerId, nullptr);
+    return player && player->getConceded();
+}
+
 void TabGame::retranslateUi()
 {
     QString tabText = " | " + (replay ? tr("Replay") : tr("Game")) + " #" + QString::number(gameInfo.game_id());
@@ -577,7 +583,11 @@ void TabGame::retranslateUi()
     if (aGameInfo)
         aGameInfo->setText(tr("Game &information"));
     if (aConcede) {
-        aConcede->setText(tr("&Concede"));
+        if (isMainPlayerConceded()) {
+            aConcede->setText(tr("Un&concede"));
+        } else {
+            aConcede->setText(tr("&Concede"));
+        }
     }
     if (aLeaveGame) {
         aLeaveGame->setText(tr("&Leave game"));
@@ -873,6 +883,9 @@ Player *TabGame::addPlayer(int playerId, const ServerInfo_User &info)
             }
         }
     }
+
+    // update menu text when player concedes so that "concede" gets updated to "unconcede"
+    connect(newPlayer, &Player::playerCountChanged, this, &TabGame::retranslateUi);
 
     emit playerAdded(newPlayer);
     return newPlayer;

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -177,6 +177,8 @@ private:
 
     Player *addPlayer(int playerId, const ServerInfo_User &info);
 
+    bool isMainPlayerConceded() const;
+
     void startGame(bool resuming);
     void stopGame();
     void closeGame();


### PR DESCRIPTION
## Short roundup of the initial problem

We have an unconcede feature, but a lot of people don't know about it because the button still says "concede"

## What will change with this Pull Request?

https://github.com/user-attachments/assets/c603f1a9-c39d-4d9b-a2b2-c18d7db2390c

`Concede` now changes to `Unconcede` when the player is concede
