### PR TITLE
Add button to open replays folder

### DIFF
--- a/cockatrice/src/client/tabs/tab_replays.cpp
+++ b/cockatrice/src/client/tabs/tab_replays.cpp
@@ -153,6 +153,7 @@ void TabReplays::retranslateUi()
     rightGroupBox->setTitle(tr("Server replay storage"));
 
     aOpenLocalReplay->setText(tr("Watch replay"));
+    aRenameLocal->setText(tr("Rename"));
     aNewLocalFolder->setText(tr("New folder"));
     aDeleteLocalReplay->setText(tr("Delete"));
     aOpenReplaysFolder->setText(tr("Open replays folder"));

--- a/cockatrice/src/client/tabs/tab_replays.cpp
+++ b/cockatrice/src/client/tabs/tab_replays.cpp
@@ -41,6 +41,7 @@ TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client) :
     localDirView->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     localDirView->header()->setSortIndicator(0, Qt::AscendingOrder);
 
+    // Left side layout
     /* put an invisible dummy QToolBar in the leftmost column so that the main toolbar is centered.
      * Really ugly workaround, but I couldn't figure out the proper way to make it centered */
     QToolBar *dummyToolBar = new QToolBar(this);
@@ -68,6 +69,7 @@ TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client) :
     leftGroupBox = new QGroupBox;
     leftGroupBox->setLayout(leftVbox);
 
+    // Right side layout
     rightToolBar = new QToolBar;
     rightToolBar->setOrientation(Qt::Horizontal);
     rightToolBar->setIconSize(QSize(32, 32));
@@ -88,6 +90,7 @@ TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client) :
     hbox->addWidget(leftGroupBox);
     hbox->addWidget(rightGroupBox);
 
+    // Left side actions
     aOpenLocalReplay = new QAction(this);
     aOpenLocalReplay->setIcon(QPixmap("theme:icons/view"));
     connect(aOpenLocalReplay, SIGNAL(triggered()), this, SLOT(actOpenLocalReplay()));
@@ -106,6 +109,7 @@ TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client) :
     aOpenReplaysFolder->setIcon(qApp->style()->standardIcon(QStyle::SP_DirOpenIcon));
     connect(aOpenReplaysFolder, &QAction::triggered, this, &TabReplays::actOpenReplaysFolder);
 
+    // Right side actions
     aOpenRemoteReplay = new QAction(this);
     aOpenRemoteReplay->setIcon(QPixmap("theme:icons/view"));
     connect(aOpenRemoteReplay, SIGNAL(triggered()), this, SLOT(actOpenRemoteReplay()));
@@ -120,6 +124,7 @@ TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client) :
     aDeleteRemoteReplay->setIcon(QPixmap("theme:icons/remove_row"));
     connect(aDeleteRemoteReplay, SIGNAL(triggered()), this, SLOT(actDeleteRemoteReplay()));
 
+    // Add actions to toolbars
     leftToolBar->addAction(aOpenLocalReplay);
     leftToolBar->addAction(aRenameLocal);
     leftToolBar->addAction(aNewLocalFolder);

--- a/cockatrice/src/client/tabs/tab_replays.cpp
+++ b/cockatrice/src/client/tabs/tab_replays.cpp
@@ -24,6 +24,7 @@
 #include <QMessageBox>
 #include <QToolBar>
 #include <QTreeView>
+#include <QUrl>
 #include <QVBoxLayout>
 
 TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client) : Tab(_tabSupervisor), client(_client)

--- a/cockatrice/src/client/tabs/tab_replays.cpp
+++ b/cockatrice/src/client/tabs/tab_replays.cpp
@@ -41,13 +41,26 @@ TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client) :
     localDirView->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     localDirView->header()->setSortIndicator(0, Qt::AscendingOrder);
 
-    leftToolBar = new QToolBar;
+    /* put an invisible dummy QToolBar in the leftmost column so that the main toolbar is centered.
+     * Really ugly workaround, but I couldn't figure out the proper way to make it centered */
+    QToolBar *dummyToolBar = new QToolBar(this);
+    QSizePolicy sizePolicy = dummyToolBar->sizePolicy();
+    sizePolicy.setRetainSizeWhenHidden(true);
+    dummyToolBar->setSizePolicy(sizePolicy);
+    dummyToolBar->setVisible(false);
+
+    leftToolBar = new QToolBar(this);
     leftToolBar->setOrientation(Qt::Horizontal);
     leftToolBar->setIconSize(QSize(32, 32));
-    QHBoxLayout *leftToolBarLayout = new QHBoxLayout;
-    leftToolBarLayout->addStretch();
-    leftToolBarLayout->addWidget(leftToolBar);
-    leftToolBarLayout->addStretch();
+
+    QToolBar *leftRightmostToolBar = new QToolBar(this);
+    leftRightmostToolBar->setOrientation(Qt::Horizontal);
+    leftRightmostToolBar->setIconSize(QSize(32, 32));
+
+    QGridLayout *leftToolBarLayout = new QGridLayout;
+    leftToolBarLayout->addWidget(dummyToolBar, 0, 0, Qt::AlignLeft);
+    leftToolBarLayout->addWidget(leftToolBar, 0, 1, Qt::AlignHCenter);
+    leftToolBarLayout->addWidget(leftRightmostToolBar, 0, 2, Qt::AlignRight);
 
     QVBoxLayout *leftVbox = new QVBoxLayout;
     leftVbox->addWidget(localDirView);
@@ -111,7 +124,9 @@ TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client) :
     leftToolBar->addAction(aRenameLocal);
     leftToolBar->addAction(aNewLocalFolder);
     leftToolBar->addAction(aDeleteLocalReplay);
-    leftToolBar->addAction(aOpenReplaysFolder);
+
+    leftRightmostToolBar->addAction(aOpenReplaysFolder);
+
     rightToolBar->addAction(aOpenRemoteReplay);
     rightToolBar->addAction(aDownload);
     rightToolBar->addAction(aKeep);

--- a/cockatrice/src/client/tabs/tab_replays.cpp
+++ b/cockatrice/src/client/tabs/tab_replays.cpp
@@ -15,6 +15,7 @@
 
 #include <QAction>
 #include <QApplication>
+#include <QDesktopServices>
 #include <QFileSystemModel>
 #include <QGroupBox>
 #include <QHBoxLayout>
@@ -88,6 +89,10 @@ TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client) :
     aDeleteLocalReplay->setIcon(QPixmap("theme:icons/remove_row"));
     connect(aDeleteLocalReplay, SIGNAL(triggered()), this, SLOT(actDeleteLocalReplay()));
 
+    aOpenReplaysFolder = new QAction(this);
+    aOpenReplaysFolder->setIcon(qApp->style()->standardIcon(QStyle::SP_DirOpenIcon));
+    connect(aOpenReplaysFolder, &QAction::triggered, this, &TabReplays::actOpenReplaysFolder);
+
     aOpenRemoteReplay = new QAction(this);
     aOpenRemoteReplay->setIcon(QPixmap("theme:icons/view"));
     connect(aOpenRemoteReplay, SIGNAL(triggered()), this, SLOT(actOpenRemoteReplay()));
@@ -106,6 +111,7 @@ TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client) :
     leftToolBar->addAction(aRenameLocal);
     leftToolBar->addAction(aNewLocalFolder);
     leftToolBar->addAction(aDeleteLocalReplay);
+    leftToolBar->addAction(aOpenReplaysFolder);
     rightToolBar->addAction(aOpenRemoteReplay);
     rightToolBar->addAction(aDownload);
     rightToolBar->addAction(aKeep);
@@ -129,6 +135,7 @@ void TabReplays::retranslateUi()
     aOpenLocalReplay->setText(tr("Watch replay"));
     aNewLocalFolder->setText(tr("New folder"));
     aDeleteLocalReplay->setText(tr("Delete"));
+    aOpenReplaysFolder->setText(tr("Open replays folder"));
     aOpenRemoteReplay->setText(tr("Watch replay"));
     aDownload->setText(tr("Download replay"));
     aKeep->setText(tr("Toggle expiration lock"));
@@ -231,6 +238,12 @@ void TabReplays::actDeleteLocalReplay()
             localDirModel->remove(curLeft);
         }
     }
+}
+
+void TabReplays::actOpenReplaysFolder()
+{
+    QString dir = localDirModel->rootPath();
+    QDesktopServices::openUrl(QUrl::fromLocalFile(dir));
 }
 
 void TabReplays::actRemoteDoubleClick(const QModelIndex &curRight)

--- a/cockatrice/src/client/tabs/tab_replays.cpp
+++ b/cockatrice/src/client/tabs/tab_replays.cpp
@@ -86,6 +86,7 @@ TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client) :
     rightGroupBox = new QGroupBox;
     rightGroupBox->setLayout(rightVbox);
 
+    // combine layouts
     QHBoxLayout *hbox = new QHBoxLayout;
     hbox->addWidget(leftGroupBox);
     hbox->addWidget(rightGroupBox);

--- a/cockatrice/src/client/tabs/tab_replays.h
+++ b/cockatrice/src/client/tabs/tab_replays.h
@@ -26,6 +26,7 @@ private:
     QGroupBox *leftGroupBox, *rightGroupBox;
 
     QAction *aOpenLocalReplay, *aRenameLocal, *aNewLocalFolder, *aDeleteLocalReplay;
+    QAction *aOpenReplaysFolder;
     QAction *aOpenRemoteReplay, *aDownload, *aKeep, *aDeleteRemoteReplay;
 
     void downloadNodeAtIndex(const QModelIndex &curLeft, const QModelIndex &curRight);
@@ -36,6 +37,8 @@ private slots:
     void actOpenLocalReplay();
     void actNewLocalFolder();
     void actDeleteLocalReplay();
+
+    void actOpenReplaysFolder();
 
     void actRemoteDoubleClick(const QModelIndex &curLeft);
     void actOpenRemoteReplay();


### PR DESCRIPTION
## Short roundup of the initial problem

Accessing the replays folder still requires you to manually navigate to the cockatrice app data folder.

Adding a button to directly open the folder will make it more convenient to access replays for when you want to send a replay to someone, for example.

## What will change with this Pull Request?
Added button to replays tab to open the replays folder in your file browser

https://github.com/user-attachments/assets/2d4acfcb-c9e5-4bc4-b3f1-e5ea18dbeadb

- Fix missing text from rename button
- Had to do a wonky workaround with a invisible dummy `QToolBar` in order to keep the main toolbar center-aligned
- Add comments to `TabGame` constructor