### PR TITLE
Support Moderator/Admin force activating users

### DIFF
--- a/cockatrice/src/client/tabs/tab_admin.h
+++ b/cockatrice/src/client/tabs/tab_admin.h
@@ -34,7 +34,8 @@ private:
     bool locked;
     AbstractClient *client;
     bool fullAdmin;
-    QPushButton *updateServerMessageButton, *shutdownServerButton, *reloadConfigButton, *grantReplayAccessButton, *activateUserButton;
+    QPushButton *updateServerMessageButton, *shutdownServerButton, *reloadConfigButton, *grantReplayAccessButton,
+        *activateUserButton;
     QGroupBox *adminGroupBox;
     QPushButton *unlockButton, *lockButton;
     QLineEdit *replayIdToGrant, *userToActivate;

--- a/cockatrice/src/client/tabs/tab_admin.h
+++ b/cockatrice/src/client/tabs/tab_admin.h
@@ -34,10 +34,10 @@ private:
     bool locked;
     AbstractClient *client;
     bool fullAdmin;
-    QPushButton *updateServerMessageButton, *shutdownServerButton, *reloadConfigButton, *grantReplayAccessButton;
+    QPushButton *updateServerMessageButton, *shutdownServerButton, *reloadConfigButton, *grantReplayAccessButton, *activateUserButton;
     QGroupBox *adminGroupBox;
     QPushButton *unlockButton, *lockButton;
-    QLineEdit *replayIdToGrant;
+    QLineEdit *replayIdToGrant, *userToActivate;
 signals:
     void adminLockChanged(bool lock);
 private slots:
@@ -45,7 +45,9 @@ private slots:
     void actShutdownServer();
     void actReloadConfig();
     void actGrantReplayAccess();
+    void actForceActivateUser();
     void grantReplayAccessProcessResponse(const Response &resp, const CommandContainer &, const QVariant &);
+    void activateUserProcessResponse(const Response &response, const CommandContainer &, const QVariant &);
 
     void actUnlock();
     void actLock();

--- a/common/pb/moderator_commands.proto
+++ b/common/pb/moderator_commands.proto
@@ -8,6 +8,7 @@ message ModeratorCommand {
         WARN_LIST = 1004;
         VIEWLOG_HISTORY = 1005;
         GRANT_REPLAY_ACCESS = 1006;
+        FORCE_ACTIVATE_USER = 1007;
     }
     extensions 100 to max;
 }
@@ -78,5 +79,13 @@ message Command_GrantReplayAccess {
         optional Command_GrantReplayAccess ext = 1006;
     }
     optional uint32 replay_id = 1;
+    optional string moderator_name = 2;
+}
+
+message Command_ForceActivateUser {
+    extend ModeratorCommand {
+        optional Command_ForceActivateUser ext = 1007;
+    }
+    optional string username_to_activate = 1;
     optional string moderator_name = 2;
 }

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -1713,9 +1713,11 @@ Response::ResponseCode AbstractServerSocketInterface::cmdForceActivateUser(const
     auto *getUserTokenQuery = sqlInterface->prepareQuery("select token from {prefix}_users WHERE name = :name");
     getUserTokenQuery->bindValue(":name", QString::fromStdString(cmd.username_to_activate()));
     if (!sqlInterface->execSqlQuery(getUserTokenQuery)) {
+        // Internal server error
         return Response::RespInternalError;
     }
     if (!getUserTokenQuery->next()) {
+        // User doesn't exist
         return Response::RespNameNotFound;
     }
     const auto &token = getUserTokenQuery->value(0).toString();
@@ -1730,7 +1732,7 @@ Response::ResponseCode AbstractServerSocketInterface::cmdForceActivateUser(const
     cmdActivate.set_user_name(cmd.username_to_activate());
     cmdActivate.set_token(token.toStdString());
 
-    // Send activation request
+    // Send activation request -- Either User exists or User activated
     return cmdActivateAccount(cmdActivate, rc);
 }
 

--- a/servatrice/src/serversocketinterface.h
+++ b/servatrice/src/serversocketinterface.h
@@ -127,6 +127,7 @@ private:
     Response::ResponseCode cmdAccountImage(const Command_AccountImage &cmd, ResponseContainer &rc);
     Response::ResponseCode cmdAccountPassword(const Command_AccountPassword &cmd, ResponseContainer &rc);
     Response::ResponseCode cmdGrantReplayAccess(const Command_GrantReplayAccess &cmd, ResponseContainer &rc);
+    Response::ResponseCode cmdForceActivateUser(const Command_ForceActivateUser &cmd, ResponseContainer &rc);
 
     bool addAdminFlagToUser(const QString &user, int flag);
     bool removeAdminFlagFromUser(const QString &user, int flag);


### PR DESCRIPTION
## Related Ticket(s)
- Partially Addresses #1793

## Short roundup of the initial problem

Moderators couldn't activate users in-client before.

## What will change with this Pull Request?

Moderators can now activate users in-client.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
