### PR TITLE
fix replay download not working if replay folder is empty

### DIFF
--- a/cockatrice/src/client/tabs/tab_replays.cpp
+++ b/cockatrice/src/client/tabs/tab_replays.cpp
@@ -335,7 +335,8 @@ void TabReplays::downloadNodeAtIndex(const QModelIndex &curLeft, const QModelInd
         }
     } else if (const auto replay = serverDirView->getReplay(curRight)) {
         // node at index is a replay
-        const QString filePath = localDirModel->filePath(curLeft) + QString("/replay_%1.cor").arg(replay->replay_id());
+        const QString dirPath = curLeft.isValid() ? localDirModel->filePath(curLeft) : localDirModel->rootPath();
+        const QString filePath = dirPath + QString("/replay_%1.cor").arg(replay->replay_id());
 
         Command_ReplayDownload cmd;
         cmd.set_replay_id(replay->replay_id());

--- a/cockatrice/src/client/tabs/tab_replays.cpp
+++ b/cockatrice/src/client/tabs/tab_replays.cpp
@@ -326,7 +326,8 @@ void TabReplays::downloadNodeAtIndex(const QModelIndex &curLeft, const QModelInd
         const QString name =
             QString::number(replayMatch->game_id()) + "_" + QString::fromStdString(replayMatch->game_name());
 
-        const auto newDirIndex = localDirModel->mkdir(curLeft, name);
+        const auto dirIndex = curLeft.isValid() ? curLeft : localDirModel->index(localDirModel->rootPath());
+        const auto newDirIndex = localDirModel->mkdir(dirIndex, name);
 
         int rows = serverDirView->model()->rowCount(curRight);
         for (int i = 0; i < rows; i++) {


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5325

## Short roundup of the initial problem

Code didn't check if the index of the currently selected left element is valid. If it was invalid, it would just leave the directory string blank, causing the file to (fail to be) created in the user's `/` directory

## What will change with this Pull Request?

If the index is invalid, use the rootPath as the directory string

https://github.com/user-attachments/assets/07ebe0cb-9677-4544-9616-355e35e70c55