### PR TITLE
Support folder download in deck storage tab

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_storage.h
+++ b/cockatrice/src/client/tabs/tab_deck_storage.h
@@ -34,6 +34,8 @@ private:
     void uploadDeck(const QString &filePath, const QString &targetPath);
     void deleteRemoteDeck(const RemoteDeckList_TreeModel::Node *node);
 
+    void downloadNodeAtIndex(const QModelIndex &curLeft, const QModelIndex &curRight);
+
 private slots:
     void actLocalDoubleClick(const QModelIndex &curLeft);
     void actOpenLocalDeck();


### PR DESCRIPTION
## Short roundup of the initial problem

Replays tab has folder download so we should also add it for deck storage tab

## What will change with this Pull Request?


https://github.com/user-attachments/assets/0fb7372d-5b8e-4752-a62b-fe96bdb60b82


Mostly just copied the code from `tab_replays` lol (including the code for the bug fix)
