### PR TITLE
Check for client updates on startup

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -110,6 +110,7 @@ set(cockatrice_SOURCES
     src/client/ui/widgets/printing_selector/printing_selector_view_options_widget.cpp
     src/client/ui/widgets/printing_selector/set_name_and_collectors_number_display_widget.cpp
     src/client/network/release_channel.cpp
+    src/client/network/client_update_checker.cpp
     src/server/remote/remote_client.cpp
     src/server/remote/remote_decklist_tree_widget.cpp
     src/server/remote/remote_replay_list_tree_widget.cpp

--- a/cockatrice/src/client/network/client_update_checker.cpp
+++ b/cockatrice/src/client/network/client_update_checker.cpp
@@ -1,0 +1,35 @@
+#include "client_update_checker.h"
+
+#include "../../settings/cache_settings.h"
+#include "release_channel.h"
+
+ClientUpdateChecker::ClientUpdateChecker(QObject *parent) : QObject(parent)
+{
+}
+
+void ClientUpdateChecker::check()
+{
+    auto releaseChannel = SettingsCache::instance().getUpdateReleaseChannel();
+
+    finishedCheckConnection =
+        connect(releaseChannel, &ReleaseChannel::finishedCheck, this, &ClientUpdateChecker::actFinishedCheck);
+    errorConnection = connect(releaseChannel, &ReleaseChannel::error, this, &ClientUpdateChecker::actError);
+
+    releaseChannel->checkForUpdates();
+}
+
+void ClientUpdateChecker::actFinishedCheck(bool needToUpdate, bool isCompatible, Release *release)
+{
+    disconnect(finishedCheckConnection);
+    disconnect(errorConnection);
+
+    emit finishedCheck(needToUpdate, isCompatible, release);
+}
+
+void ClientUpdateChecker::actError(const QString &errorString)
+{
+    disconnect(finishedCheckConnection);
+    disconnect(errorConnection);
+
+    emit error(errorString);
+}

--- a/cockatrice/src/client/network/client_update_checker.h
+++ b/cockatrice/src/client/network/client_update_checker.h
@@ -1,0 +1,45 @@
+#ifndef CLIENT_UPDATE_CHECKER_H
+#define CLIENT_UPDATE_CHECKER_H
+#include <QObject>
+
+class Release;
+
+/**
+ * We use a singleton instance of UpdateChannel, which can cause interference and feedback loops when multiple objects
+ * connect to it.
+ *
+ * This class encapsulates the usage of that UpdateChannel to ensure that the check only happens once per connection and
+ * the connection is destroyed after it's been used.
+ */
+class ClientUpdateChecker : public QObject
+{
+    Q_OBJECT
+
+    QMetaObject::Connection finishedCheckConnection;
+    QMetaObject::Connection errorConnection;
+
+    void actFinishedCheck(bool needToUpdate, bool isCompatible, Release *release);
+    void actError(const QString &errorString);
+
+public:
+    explicit ClientUpdateChecker(QObject *parent = nullptr);
+    /**
+     * Actually performs the check, using the currently selected update channel in the settings.
+     * Any resulting signals will only be sent once.
+     * This method should only be called ONCE per instance.
+     */
+    void check();
+
+signals:
+    /**
+     * Forwarded from UpdateChannel::finishedCheck
+     */
+    void finishedCheck(bool needToUpdate, bool isCompatible, Release *release);
+
+    /**
+     * Forwarded from UpdateChannel::error
+     */
+    void error(const QString &errorString);
+};
+
+#endif // CLIENT_UPDATE_CHECKER_H

--- a/cockatrice/src/client/network/release_channel.cpp
+++ b/cockatrice/src/client/network/release_channel.cpp
@@ -112,7 +112,7 @@ void StableReleaseChannel::releaseListFinished()
     QVariantMap resultMap = jsonResponse.toVariant().toMap();
     if (!(resultMap.contains("name") && resultMap.contains("html_url") && resultMap.contains("tag_name") &&
           resultMap.contains("published_at"))) {
-        qWarning() << "Invalid received from the release update server.";
+        qWarning() << "Invalid received from the release update server:" << resultMap;
         emit error(tr("Invalid reply received from the release update server."));
         return;
     }

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -41,6 +41,7 @@
 #include "../../utility/logger.h"
 #include "../get_text_with_max.h"
 #include "../network/client_update_checker.h"
+#include "../network/release_channel.h"
 #include "../tabs/tab_game.h"
 #include "../tabs/tab_supervisor.h"
 #include "pb/event_connection_closed.pb.h"

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -40,6 +40,7 @@
 #include "../../settings/cache_settings.h"
 #include "../../utility/logger.h"
 #include "../get_text_with_max.h"
+#include "../network/client_update_checker.h"
 #include "../tabs/tab_game.h"
 #include "../tabs/tab_supervisor.h"
 #include "pb/event_connection_closed.pb.h"
@@ -879,6 +880,10 @@ MainWindow::MainWindow(QWidget *parent)
 
 void MainWindow::startupConfigCheck()
 {
+    if (SettingsCache::instance().getCheckUpdatesOnStartup()) {
+        actCheckClientUpdates();
+    }
+
     if (SettingsCache::instance().getClientVersion() == CLIENT_INFO_NOT_SET) {
         // no config found, 99% new clean install
         qDebug() << "Startup: old client version empty, assuming first start after clean install";
@@ -1221,6 +1226,21 @@ void MainWindow::actCheckServerUpdates()
     auto hps = new HandlePublicServers(this);
     hps->downloadPublicServers();
     connect(hps, &HandlePublicServers::sigPublicServersDownloadedSuccessfully, [=]() { hps->deleteLater(); });
+}
+
+void MainWindow::actCheckClientUpdates()
+{
+    auto checker = new ClientUpdateChecker(this);
+    connect(checker, &ClientUpdateChecker::finishedCheck, this, &MainWindow::checkClientUpdatesFinished);
+    checker->check();
+}
+
+void MainWindow::checkClientUpdatesFinished(bool needToUpdate, bool /* isCompatible */, Release * /* release */)
+{
+    if (needToUpdate) {
+        DlgUpdate dlg(this);
+        dlg.exec();
+    }
 }
 
 void MainWindow::refreshShortcuts()

--- a/cockatrice/src/client/ui/window_main.h
+++ b/cockatrice/src/client/ui/window_main.h
@@ -30,6 +30,7 @@
 #include <QSystemTrayIcon>
 #include <QtNetwork>
 
+class Release;
 class DlgConnect;
 class DlgViewLog;
 class GameReplay;
@@ -49,6 +50,7 @@ class MainWindow : public QMainWindow
 public slots:
     void actCheckCardUpdates();
     void actCheckServerUpdates();
+    void actCheckClientUpdates();
 private slots:
     void updateTabMenu(const QList<QMenu *> &newMenuList);
     void statusChanged(ClientStatus _status);
@@ -94,6 +96,8 @@ private slots:
     void cardDatabaseLoadingFailed();
     void cardDatabaseNewSetsFound(int numUnknownSets, QStringList unknownSetsNames);
     void cardDatabaseAllNewSetsEnabled();
+
+    void checkClientUpdatesFinished(bool needToUpdate, bool isCompatible, Release *release);
 
     void actOpenCustomFolder();
     void actOpenCustomsetsFolder();

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -61,6 +61,7 @@ GeneralSettingsPage::GeneralSettingsPage()
 
     // updates
     SettingsCache &settings = SettingsCache::instance();
+    startupUpdateCheckCheckBox.setChecked(settings.getCheckUpdatesOnStartup());
     updateNotificationCheckBox.setChecked(settings.getNotifyAboutUpdates());
     newVersionOracleCheckBox.setChecked(settings.getNotifyAboutNewVersion());
 
@@ -68,6 +69,8 @@ GeneralSettingsPage::GeneralSettingsPage()
 
     connect(&languageBox, SIGNAL(currentIndexChanged(int)), this, SLOT(languageBoxChanged(int)));
     connect(&updateReleaseChannelBox, SIGNAL(currentIndexChanged(int)), &settings, SLOT(setUpdateReleaseChannel(int)));
+    connect(&startupUpdateCheckCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings,
+            &SettingsCache::setCheckUpdatesOnStartup);
     connect(&updateNotificationCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings, &SettingsCache::setNotifyAboutUpdate);
     connect(&newVersionOracleCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings,
             &SettingsCache::setNotifyAboutNewVersion);
@@ -78,9 +81,10 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(&languageBox, 0, 1);
     personalGrid->addWidget(&updateReleaseChannelLabel, 1, 0);
     personalGrid->addWidget(&updateReleaseChannelBox, 1, 1);
-    personalGrid->addWidget(&updateNotificationCheckBox, 3, 0, 1, 2);
-    personalGrid->addWidget(&newVersionOracleCheckBox, 4, 0, 1, 2);
-    personalGrid->addWidget(&showTipsOnStartup, 5, 0, 1, 2);
+    personalGrid->addWidget(&startupUpdateCheckCheckBox, 3, 0, 1, 2);
+    personalGrid->addWidget(&updateNotificationCheckBox, 4, 0, 1, 2);
+    personalGrid->addWidget(&newVersionOracleCheckBox, 5, 0, 1, 2);
+    personalGrid->addWidget(&showTipsOnStartup, 6, 0, 1, 2);
 
     personalGroupBox = new QGroupBox;
     personalGroupBox->setLayout(personalGrid);
@@ -288,6 +292,7 @@ void GeneralSettingsPage::retranslateUi()
     customCardDatabasePathLabel.setText(tr("Custom database directory:"));
     tokenDatabasePathLabel.setText(tr("Token database:"));
     updateReleaseChannelLabel.setText(tr("Update channel"));
+    startupUpdateCheckCheckBox.setText(tr("Check for client updates on startup"));
     updateNotificationCheckBox.setText(tr("Notify if a feature supported by the server is missing in my client"));
     newVersionOracleCheckBox.setText(tr("Automatically run Oracle when running a new version of Cockatrice"));
     showTipsOnStartup.setText(tr("Show tips on startup"));

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -65,6 +65,7 @@ private:
     QGroupBox *personalGroupBox;
     QGroupBox *pathsGroupBox;
     QComboBox languageBox;
+    QCheckBox startupUpdateCheckCheckBox;
     QCheckBox updateNotificationCheckBox;
     QCheckBox newVersionOracleCheckBox;
     QComboBox updateReleaseChannelBox;

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -192,6 +192,7 @@ SettingsCache::SettingsCache()
 
     mbDownloadSpoilers = settings->value("personal/downloadspoilers", false).toBool();
 
+    checkUpdatesOnStartup = settings->value("personal/startupUpdateCheck", true).toBool();
     notifyAboutUpdates = settings->value("personal/updatenotification", true).toBool();
     notifyAboutNewVersion = settings->value("personal/newversionnotification", true).toBool();
     updateReleaseChannel = settings->value("personal/updatereleasechannel", 0).toInt();
@@ -1106,6 +1107,12 @@ void SettingsCache::setDefaultStartingLifeTotal(const int _defaultStartingLifeTo
     defaultStartingLifeTotal = _defaultStartingLifeTotal;
     settings->setValue("game/defaultstartinglifetotal", defaultStartingLifeTotal);
 };
+
+void SettingsCache::setCheckUpdatesOnStartup(QT_STATE_CHANGED_T value)
+{
+    checkUpdatesOnStartup = static_cast<bool>(value);
+    settings->setValue("personal/startupUpdateCheck", checkUpdatesOnStartup);
+}
 
 void SettingsCache::setRememberGameSettings(const bool _rememberGameSettings)
 {

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -93,6 +93,7 @@ private:
     QString lang;
     QString deckPath, replaysPath, picsPath, redirectCachePath, customPicsPath, cardDatabasePath,
         customCardDatabasePath, themesPath, spoilerDatabasePath, tokenDatabasePath, themeName;
+    bool checkUpdatesOnStartup;
     bool notifyAboutUpdates;
     bool notifyAboutNewVersion;
     bool showTipsOnStartup;
@@ -268,6 +269,10 @@ public:
     bool getBuddyConnectNotificationsEnabled() const
     {
         return buddyConnectNotificationsEnabled;
+    }
+    bool getCheckUpdatesOnStartup() const
+    {
+        return checkUpdatesOnStartup;
     }
     bool getNotifyAboutUpdates() const
     {
@@ -704,6 +709,7 @@ public slots:
     void setCreateGameAsSpectator(const bool _createGameAsSpectator);
     void setDefaultStartingLifeTotal(const int _defaultStartingLifeTotal);
     void setRememberGameSettings(const bool _rememberGameSettings);
+    void setCheckUpdatesOnStartup(QT_STATE_CHANGED_T value);
     void setNotifyAboutUpdate(QT_STATE_CHANGED_T _notifyaboutupdate);
     void setNotifyAboutNewVersion(QT_STATE_CHANGED_T _notifyaboutnewversion);
     void setUpdateReleaseChannel(int _updateReleaseChannel);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -309,6 +309,9 @@ void SettingsCache::setDefaultStartingLifeTotal(const int /* _startingLifeTotal 
 void SettingsCache::setRememberGameSettings(const bool /* _rememberGameSettings */)
 {
 }
+void SettingsCache::setCheckUpdatesOnStartup(QT_STATE_CHANGED_T /* value */)
+{
+}
 void SettingsCache::setNotifyAboutUpdate(QT_STATE_CHANGED_T /* _notifyaboutupdate */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -313,6 +313,9 @@ void SettingsCache::setDefaultStartingLifeTotal(const int /* _startingLifeTotal 
 void SettingsCache::setRememberGameSettings(const bool /* _rememberGameSettings */)
 {
 }
+void SettingsCache::setCheckUpdatesOnStartup(QT_STATE_CHANGED_T /* value */)
+{
+}
 void SettingsCache::setNotifyAboutUpdate(QT_STATE_CHANGED_T /* _notifyaboutupdate */)
 {
 }


### PR DESCRIPTION
## Short roundup of the initial problem

Cockatrice has the functionality to check for updates, but isn't checking for updates on startup. Checking for updates on startup should make it more likely for people to keep up with newer versions.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/4948b9fa-9aba-452f-80b5-4962f7fe2ea3

Added setting `Check for client updates on startup`. 

When enabled, Cockatrice will do a check for client update in the background on startup. If an update is detected, cockatrice will pop up the `Check for updates` window. If not, or if the check errors out, then cockatrice will not do anything.

- Created a `ClientUpdateChecker` to encapsulate connections from `ReleaseChannel`
  - Otherwise connecting to `&ReleaseChannel::finishedCheck` will cause every `check update` call from any other place in the code to trigger it.
- Added new setting
  - Enabled by default, to encourage people to have it on 
- `MainWindow` now does an update check in the startup code if enabled
  - If an update is detected, it just directly execs `DlgUpdate`
    - This does mean that the update check is reran in `DlgUpdate`, but the update check is pretty cheap, so it should be fine™.

## Screenshots

<img width="400" alt="Screenshot 2024-12-28 at 2 31 56 AM" src="https://github.com/user-attachments/assets/49628a9d-a169-4786-a178-1e09391c046b" />
