### PR TITLE
Support Mod/Admin Notes Section

### DIFF
--- a/cockatrice/src/server/user/user_context_menu.h
+++ b/cockatrice/src/server/user/user_context_menu.h
@@ -35,6 +35,7 @@ private:
     QAction *aPromoteToMod, *aDemoteFromMod;
     QAction *aPromoteToJudge, *aDemoteFromJudge;
     QAction *aWarnUser, *aWarnHistory;
+    QAction *aGetAdminNotes;
 signals:
     void openMessageDialog(const QString &userName, bool focus);
 private slots:
@@ -43,9 +44,11 @@ private slots:
     void warnUser_processUserInfoResponse(const Response &resp);
     void banUserHistory_processResponse(const Response &resp);
     void warnUserHistory_processResponse(const Response &resp);
+    void getAdminNotes_processResponse(const Response &resp);
     void adjustMod_processUserResponse(const Response &resp, const CommandContainer &commandContainer);
     void banUser_dialogFinished();
     void warnUser_dialogFinished();
+    void updateAdminNotes_dialogFinished();
     void gamesOfUserReceived(const Response &resp, const CommandContainer &commandContainer);
 
 public:

--- a/cockatrice/src/server/user/user_list.cpp
+++ b/cockatrice/src/server/user/user_list.cpp
@@ -284,6 +284,32 @@ int BanDialog::getDeleteMessages() const
     return deleteMessages->isChecked() ? -1 : 0;
 }
 
+AdminNotesDialog::AdminNotesDialog(const QString &_userName, const QString &_notes, QWidget *_parent)
+    : userName(_userName), QDialog(_parent)
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    auto *updateButton = new QPushButton(tr("Update Notes"));
+    updateButton->setEnabled(false);
+    connect(updateButton, &QPushButton::clicked, this, &AdminNotesDialog::accept);
+
+    notes = new QPlainTextEdit(_notes);
+    notes->setMinimumWidth(500);
+    connect(notes, &QPlainTextEdit::textChanged, this, [=]() { updateButton->setEnabled(true); });
+
+    auto *vbox = new QVBoxLayout;
+    vbox->addWidget(notes);
+    vbox->addWidget(updateButton);
+
+    setLayout(vbox);
+    setWindowTitle(tr("Admin Notes for %1").arg(_userName));
+}
+
+QString AdminNotesDialog::getNotes() const
+{
+    return notes->toPlainText();
+}
+
 UserListItemDelegate::UserListItemDelegate(QObject *const parent) : QStyledItemDelegate(parent)
 {
 }

--- a/cockatrice/src/server/user/user_list.cpp
+++ b/cockatrice/src/server/user/user_list.cpp
@@ -285,7 +285,7 @@ int BanDialog::getDeleteMessages() const
 }
 
 AdminNotesDialog::AdminNotesDialog(const QString &_userName, const QString &_notes, QWidget *_parent)
-    : userName(_userName), QDialog(_parent)
+    : QDialog(_parent), userName(_userName)
 {
     setAttribute(Qt::WA_DeleteOnClose);
 

--- a/cockatrice/src/server/user/user_list.h
+++ b/cockatrice/src/server/user/user_list.h
@@ -8,6 +8,7 @@
 #include <QDialog>
 #include <QGroupBox>
 #include <QStyledItemDelegate>
+#include <QTextEdit>
 #include <QTreeWidgetItem>
 
 class QTreeWidget;
@@ -67,6 +68,23 @@ public:
     QString getReason() const;
     int getDeleteMessages() const;
     void addWarningOption(const QString warning);
+};
+
+class AdminNotesDialog : public QDialog
+{
+    Q_OBJECT
+
+private:
+    QString userName;
+    QPlainTextEdit *notes;
+
+public:
+    explicit AdminNotesDialog(const QString &_userName, const QString &_notes, QWidget *_parent = nullptr);
+    QString getName() const
+    {
+        return userName;
+    }
+    QString getNotes() const;
 };
 
 class UserListItemDelegate : public QStyledItemDelegate

--- a/common/pb/CMakeLists.txt
+++ b/common/pb/CMakeLists.txt
@@ -134,6 +134,7 @@ set(PROTO_FILES
     response_viewlog_history.proto
     response_warn_history.proto
     response_warn_list.proto
+    response_get_admin_notes.proto
     response.proto
     room_commands.proto
     room_event.proto

--- a/common/pb/moderator_commands.proto
+++ b/common/pb/moderator_commands.proto
@@ -9,6 +9,8 @@ message ModeratorCommand {
         VIEWLOG_HISTORY = 1005;
         GRANT_REPLAY_ACCESS = 1006;
         FORCE_ACTIVATE_USER = 1007;
+        GET_ADMIN_NOTES = 1008;
+        UPDATE_ADMIN_NOTES = 1009;
     }
     extensions 100 to max;
 }
@@ -88,4 +90,19 @@ message Command_ForceActivateUser {
     }
     optional string username_to_activate = 1;
     optional string moderator_name = 2;
+}
+
+message Command_GetAdminNotes {
+    extend ModeratorCommand {
+        optional Command_GetAdminNotes ext = 1008;
+    }
+    optional string user_name = 1;
+}
+
+message Command_UpdateAdminNotes {
+    extend ModeratorCommand {
+        optional Command_UpdateAdminNotes ext = 1009;
+    }
+    optional string user_name = 1;
+    optional string notes = 2;
 }

--- a/common/pb/response.proto
+++ b/common/pb/response.proto
@@ -62,6 +62,7 @@ message Response {
         VIEW_LOG = 1015;
         FORGOT_PASSWORD_REQUEST = 1016;
         PASSWORD_SALT = 1017;
+        GET_ADMIN_NOTES = 1018;
         REPLAY_LIST = 1100;
         REPLAY_DOWNLOAD = 1101;
     }

--- a/common/pb/response_get_admin_notes.proto
+++ b/common/pb/response_get_admin_notes.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+import "response.proto";
+
+message Response_GetAdminNotes {
+    extend Response {
+        optional Response_GetAdminNotes ext = 1018;
+    }
+    optional string user_name = 1;
+    optional string notes = 2;
+}

--- a/servatrice/migrations/servatrice_0029_to_0030.sql
+++ b/servatrice/migrations/servatrice_0029_to_0030.sql
@@ -1,0 +1,5 @@
+-- Servatrice db migration from version 29 to version 30
+
+ALTER TABLE cockatrice_users ADD COLUMN adminnotes mediumtext NOT NULL;
+
+UPDATE cockatrice_schema_version SET version=30 WHERE version=29;

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_schema_version` (
   PRIMARY KEY  (`version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
 
-INSERT INTO cockatrice_schema_version VALUES(29);
+INSERT INTO cockatrice_schema_version VALUES(30);
 
 -- users and user data tables
 CREATE TABLE IF NOT EXISTS `cockatrice_users` (
@@ -36,6 +36,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_users` (
   `active` tinyint(1) NOT NULL,
   `token` binary(16),
   `clientid` varchar(15) NOT NULL,
+  `adminnotes` mediumtext NOT NULL,
   `privlevel` enum("NONE","VIP","DONATOR") NOT NULL,
   `privlevelStartDate` datetime NOT NULL,
   `privlevelEndDate` datetime NOT NULL,

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -9,7 +9,7 @@
 #include <QObject>
 #include <QSqlDatabase>
 
-#define DATABASE_SCHEMA_VERSION 29
+#define DATABASE_SCHEMA_VERSION 30
 
 class Servatrice;
 

--- a/servatrice/src/serversocketinterface.h
+++ b/servatrice/src/serversocketinterface.h
@@ -129,6 +129,9 @@ private:
     Response::ResponseCode cmdGrantReplayAccess(const Command_GrantReplayAccess &cmd, ResponseContainer &rc);
     Response::ResponseCode cmdForceActivateUser(const Command_ForceActivateUser &cmd, ResponseContainer &rc);
 
+    Response::ResponseCode cmdGetAdminNotes(const Command_GetAdminNotes &cmd, ResponseContainer &rc);
+    Response::ResponseCode cmdUpdateAdminNotes(const Command_UpdateAdminNotes &cmd, ResponseContainer &rc);
+
     bool addAdminFlagToUser(const QString &user, int flag);
     bool removeAdminFlagFromUser(const QString &user, int flag);
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1306

## Short roundup of the initial problem

There was no way, in-client, for moderators to communicate asynchronously about user problems.

## What will change with this Pull Request?

There is now an adminnotes attached to each user that moderators/admins can participate in.
Hopefully this reduces the dependency on 3rd party solutions to keep track of user issues.

## Screenshots
![image](https://github.com/user-attachments/assets/8dcf856f-e2de-4b3b-8fd3-00fe672bd8a0)
![image](https://github.com/user-attachments/assets/58da6a52-1d25-427f-a0ec-550f4df4838d)
