### PR TITLE
fix bug with release channel setting not being remembered

### DIFF
--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -68,7 +68,6 @@ GeneralSettingsPage::GeneralSettingsPage()
     showTipsOnStartup.setChecked(settings.getShowTipsOnStartup());
 
     connect(&languageBox, SIGNAL(currentIndexChanged(int)), this, SLOT(languageBoxChanged(int)));
-    connect(&updateReleaseChannelBox, SIGNAL(currentIndexChanged(int)), &settings, SLOT(setUpdateReleaseChannel(int)));
     connect(&startupUpdateCheckCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings,
             &SettingsCache::setCheckUpdatesOnStartup);
     connect(&updateNotificationCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings, &SettingsCache::setNotifyAboutUpdate);
@@ -171,6 +170,13 @@ GeneralSettingsPage::GeneralSettingsPage()
     mainLayout->addWidget(personalGroupBox);
     mainLayout->addWidget(pathsGroupBox);
     mainLayout->addStretch();
+
+    GeneralSettingsPage::retranslateUi();
+
+    // connect the ReleaseChannel combo box only after the entries are inserted in retranslateUi
+    connect(&updateReleaseChannelBox, &QComboBox::currentIndexChanged, &settings,
+            &SettingsCache::setUpdateReleaseChannel);
+    updateReleaseChannelBox.setCurrentIndex(settings.getUpdateReleaseChannel()->getIndex());
 
     setLayout(mainLayout);
 }
@@ -299,12 +305,14 @@ void GeneralSettingsPage::retranslateUi()
     resetAllPathsButton->setText(tr("Reset all paths"));
 
     const auto &settings = SettingsCache::instance();
-    QList<ReleaseChannel *> channels = settings.getUpdateReleaseChannels();
+
+    // We can't change the strings after they're put into the QComboBox, so this is our workaround
+    int oldIndex = updateReleaseChannelBox.currentIndex();
     updateReleaseChannelBox.clear();
-    for (ReleaseChannel *chan : channels) {
+    for (ReleaseChannel *chan : settings.getUpdateReleaseChannels()) {
         updateReleaseChannelBox.insertItem(chan->getIndex(), tr(chan->getName().toUtf8()));
     }
-    updateReleaseChannelBox.setCurrentIndex(settings.getUpdateReleaseChannel()->getIndex());
+    updateReleaseChannelBox.setCurrentIndex(oldIndex);
 }
 
 AppearanceSettingsPage::AppearanceSettingsPage()

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -174,8 +174,7 @@ GeneralSettingsPage::GeneralSettingsPage()
     GeneralSettingsPage::retranslateUi();
 
     // connect the ReleaseChannel combo box only after the entries are inserted in retranslateUi
-    connect(&updateReleaseChannelBox, &QComboBox::currentIndexChanged, &settings,
-            &SettingsCache::setUpdateReleaseChannel);
+    connect(&updateReleaseChannelBox, SIGNAL(currentIndexChanged(int)), &settings, SLOT(setUpdateReleaseChannel(int)));
     updateReleaseChannelBox.setCurrentIndex(settings.getUpdateReleaseChannel()->getIndex());
 
     setLayout(mainLayout);

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -292,7 +292,7 @@ public:
     }
     ReleaseChannel *getUpdateReleaseChannel() const
     {
-        return releaseChannels.at(updateReleaseChannel);
+        return releaseChannels.at(qMax(0, updateReleaseChannel));
     }
     QList<ReleaseChannel *> getUpdateReleaseChannels() const
     {


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5292

## Short roundup of the initial problem

The release channel setting isn't being loaded properly, causing the settings dialogue to always load the first option 

https://github.com/user-attachments/assets/771916d5-9048-4f50-9f07-f054749f0746


## What will change with this Pull Request?

https://github.com/user-attachments/assets/7784abf5-7214-47c9-9649-618db15b9677

Settings Dlg now loads the correct release channel combo box entry on initialization.

