### PR TITLE
refactor: remove ReleaseChannel keeping track of its own indexes

### DIFF
--- a/cockatrice/src/client/network/release_channel.cpp
+++ b/cockatrice/src/client/network/release_channel.cpp
@@ -21,11 +21,8 @@
 
 #define GIT_SHORT_HASH_LEN 7
 
-int ReleaseChannel::sharedIndex = 0;
-
 ReleaseChannel::ReleaseChannel() : netMan(new QNetworkAccessManager(this)), response(nullptr), lastRelease(nullptr)
 {
-    index = sharedIndex++;
 }
 
 ReleaseChannel::~ReleaseChannel()

--- a/cockatrice/src/client/network/release_channel.h
+++ b/cockatrice/src/client/network/release_channel.h
@@ -82,9 +82,6 @@ public:
     ~ReleaseChannel() override;
 
 protected:
-    // shared by all instances
-    static int sharedIndex;
-    int index;
     QNetworkAccessManager *netMan;
     QNetworkReply *response;
     Release *lastRelease;
@@ -94,10 +91,6 @@ protected:
     virtual QString getReleaseChannelUrl() const = 0;
 
 public:
-    int getIndex() const
-    {
-        return index;
-    }
     Release *getLastRelease()
     {
         return lastRelease;

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -174,7 +174,8 @@ GeneralSettingsPage::GeneralSettingsPage()
     GeneralSettingsPage::retranslateUi();
 
     // connect the ReleaseChannel combo box only after the entries are inserted in retranslateUi
-    connect(&updateReleaseChannelBox, SIGNAL(currentIndexChanged(int)), &settings, SLOT(setUpdateReleaseChannel(int)));
+    connect(&updateReleaseChannelBox, SIGNAL(currentIndexChanged(int)), &settings,
+            SLOT(setUpdateReleaseChannelIndex(int)));
     updateReleaseChannelBox.setCurrentIndex(settings.getUpdateReleaseChannelIndex());
 
     setLayout(mainLayout);

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -175,7 +175,7 @@ GeneralSettingsPage::GeneralSettingsPage()
 
     // connect the ReleaseChannel combo box only after the entries are inserted in retranslateUi
     connect(&updateReleaseChannelBox, SIGNAL(currentIndexChanged(int)), &settings, SLOT(setUpdateReleaseChannel(int)));
-    updateReleaseChannelBox.setCurrentIndex(settings.getUpdateReleaseChannel()->getIndex());
+    updateReleaseChannelBox.setCurrentIndex(settings.getUpdateReleaseChannelIndex());
 
     setLayout(mainLayout);
 }
@@ -309,7 +309,7 @@ void GeneralSettingsPage::retranslateUi()
     int oldIndex = updateReleaseChannelBox.currentIndex();
     updateReleaseChannelBox.clear();
     for (ReleaseChannel *chan : settings.getUpdateReleaseChannels()) {
-        updateReleaseChannelBox.insertItem(chan->getIndex(), tr(chan->getName().toUtf8()));
+        updateReleaseChannelBox.addItem(tr(chan->getName().toUtf8()));
     }
     updateReleaseChannelBox.setCurrentIndex(oldIndex);
 }

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -1139,9 +1139,9 @@ void SettingsCache::setDownloadSpoilerStatus(bool _spoilerStatus)
     emit downloadSpoilerStatusChanged();
 }
 
-void SettingsCache::setUpdateReleaseChannel(int _updateReleaseChannel)
+void SettingsCache::setUpdateReleaseChannelIndex(int value)
 {
-    updateReleaseChannel = _updateReleaseChannel;
+    updateReleaseChannel = value;
     settings->setValue("personal/updatereleasechannel", updateReleaseChannel);
 }
 

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -716,7 +716,7 @@ public slots:
     void setCheckUpdatesOnStartup(QT_STATE_CHANGED_T value);
     void setNotifyAboutUpdate(QT_STATE_CHANGED_T _notifyaboutupdate);
     void setNotifyAboutNewVersion(QT_STATE_CHANGED_T _notifyaboutnewversion);
-    void setUpdateReleaseChannel(int _updateReleaseChannel);
+    void setUpdateReleaseChannelIndex(int value);
     void setMaxFontSize(int _max);
 };
 

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -290,6 +290,10 @@ public:
     {
         return seenTips;
     }
+    int getUpdateReleaseChannelIndex() const
+    {
+        return updateReleaseChannel;
+    }
     ReleaseChannel *getUpdateReleaseChannel() const
     {
         return releaseChannels.at(qMax(0, updateReleaseChannel));

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -321,7 +321,7 @@ void SettingsCache::setNotifyAboutNewVersion(QT_STATE_CHANGED_T /* _notifyaboutn
 void SettingsCache::setDownloadSpoilerStatus(bool /* _spoilerStatus */)
 {
 }
-void SettingsCache::setUpdateReleaseChannel(int /* _updateReleaseChannel */)
+void SettingsCache::setUpdateReleaseChannelIndex(int /* value */)
 {
 }
 void SettingsCache::setMaxFontSize(int /* _max */)

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -325,7 +325,7 @@ void SettingsCache::setNotifyAboutNewVersion(QT_STATE_CHANGED_T /* _notifyaboutn
 void SettingsCache::setDownloadSpoilerStatus(bool /* _spoilerStatus */)
 {
 }
-void SettingsCache::setUpdateReleaseChannel(int /* _updateReleaseChannel */)
+void SettingsCache::setUpdateReleaseChannelIndex(int /* value */)
 {
 }
 void SettingsCache::setMaxFontSize(int /* _max */)


### PR DESCRIPTION
## Short roundup of the initial problem

`ReleaseChannel` objects keeping track of their own indexes is unintuitive. The index is used by the `SettingsCache` to track which release channel is selected, so we could just move all the index logic in there

## What will change with this Pull Request?
- Remove index field from `ReleaseChannel`
- Add method to `SettingsCache` to directly get the current release channel index (as an int)
- directly use the index when creating the settings window instead of going through `ReleaseChannel` to get the index