### PR TITLE
Add password reset button label

### DIFF
--- a/cockatrice/src/dialogs/dlg_connect.cpp
+++ b/cockatrice/src/dialogs/dlg_connect.cpp
@@ -99,6 +99,9 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     btnForgotPassword->setFixedWidth(30);
     connect(btnForgotPassword, SIGNAL(released()), this, SLOT(actForgotPassword()));
 
+    forgotPasswordLabel = new QLabel(tr("Forgot password?"));
+    forgotPasswordLabel->setBuddy(btnForgotPassword);
+
     btnConnect = new QPushButton(tr("&Connect"));
     connect(btnConnect, SIGNAL(released()), this, SLOT(actOk()));
 
@@ -130,13 +133,17 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     serverInfoLayout->addWidget(serverContactLabel, 1, 0);
     serverInfoLayout->addWidget(serverContactLink, 1, 1, 1, 3);
 
+    forgotPasswordLayout = new QHBoxLayout;
+    forgotPasswordLayout->addWidget(forgotPasswordLabel, 0, Qt::AlignLeft);
+    forgotPasswordLayout->addWidget(btnForgotPassword, 0, Qt::AlignLeft);
+
     loginLayout = new QGridLayout;
     loginLayout->addWidget(playernameLabel, 0, 0);
     loginLayout->addWidget(playernameEdit, 0, 1, 1, 2);
     loginLayout->addWidget(passwordLabel, 1, 0);
-    loginLayout->addWidget(passwordEdit, 1, 1);
-    loginLayout->addWidget(btnForgotPassword, 1, 2);
+    loginLayout->addWidget(passwordEdit, 1, 1, 1, 2);
     loginLayout->addWidget(savePasswordCheckBox, 2, 1);
+    loginLayout->addLayout(forgotPasswordLayout, 3, 1);
 
     loginGroupBox = new QGroupBox(tr("Login"));
     loginGroupBox->setLayout(loginLayout);

--- a/cockatrice/src/dialogs/dlg_connect.h
+++ b/cockatrice/src/dialogs/dlg_connect.h
@@ -65,11 +65,11 @@ private slots:
 
 private:
     QGridLayout *connectionLayout, *loginLayout, *serverInfoLayout, *grid;
-    QHBoxLayout *newHolderLayout;
+    QHBoxLayout *newHolderLayout, *forgotPasswordLayout;
     QGroupBox *loginGroupBox, *serverInfoGroupBox, *restrictionsGroupBox;
     QVBoxLayout *mainLayout;
     QLabel *hostLabel, *portLabel, *playernameLabel, *passwordLabel, *saveLabel, *serverIssuesLabel,
-        *serverContactLabel, *serverContactLink;
+        *serverContactLabel, *serverContactLink, *forgotPasswordLabel;
     QLineEdit *hostEdit, *portEdit, *playernameEdit, *passwordEdit, *saveEdit;
     QCheckBox *savePasswordCheckBox, *autoConnectCheckBox;
     QComboBox *previousHosts;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem

- People were confused with the lock icon and asked questions on how to reset their passwords.

## What will change with this Pull Request?

- Now there's a "Forgot password?" label so people can figure it out!

## Screenshots
![image](https://github.com/user-attachments/assets/f2a3a47f-12e4-4716-82dc-b36115b1518e)


