### PR TITLE
Combine card legalities in Oracle

### DIFF
--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -304,6 +304,17 @@ void CardInfo::addToSet(const CardSetPtr &_set, const CardInfoPerSet _info)
     refreshCachedSetNames();
 }
 
+void CardInfo::combineLegalities(const QVariantHash &props)
+{
+    QHashIterator<QString, QVariant> it(props);
+    while (it.hasNext()) {
+        it.next();
+        if (it.key().startsWith("format-")) {
+            smartThis->setProperty(it.key(), it.value().toString());
+        }
+    }
+}
+
 void CardInfo::refreshCachedSetNames()
 {
     QStringList setList;

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -390,6 +390,7 @@ public:
     }
     QString getCorrectedName() const;
     void addToSet(const CardSetPtr &_set, CardInfoPerSet _info = CardInfoPerSet());
+    void combineLegalities(const QVariantHash &props);
     void emitPixmapUpdated()
     {
         emit pixmapUpdated();

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -16,6 +16,8 @@ SplitCardPart::SplitCardPart(const QString &_name,
 {
 }
 
+const QRegularExpression OracleImporter::formatRegex = QRegularExpression("^format-");
+
 OracleImporter::OracleImporter(const QString &_dataDir, QObject *parent) : CardDatabase(parent), dataDir(_dataDir)
 {
 }
@@ -118,6 +120,9 @@ CardInfoPtr OracleImporter::addCard(QString name,
     if (cards.contains(name)) {
         CardInfoPtr card = cards.value(name);
         card->addToSet(setInfo.getPtr(), setInfo);
+        if (card->getProperties().filter(formatRegex).empty()) {
+            card->combineLegalities(properties);
+        }
         return card;
     }
 

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -2,6 +2,7 @@
 #define ORACLEIMPORTER_H
 
 #include <QMap>
+#include <QRegularExpression>
 #include <QVariant>
 #include <game/cards/card_database.h>
 #include <utility>
@@ -122,6 +123,7 @@ class OracleImporter : public CardDatabase
 private:
     const QStringList mainCardTypes = {"Planeswalker", "Creature", "Land",       "Sorcery",
                                        "Instant",      "Artifact", "Enchantment"};
+    static const QRegularExpression formatRegex;
     QList<SetToDownload> allSets;
     QVariantMap setsMap;
     QString dataDir;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4783

## Short roundup of the initial problem
Card legalities aren't consistent across printings, so if an empty setup appears, it can be a problem.

## What will change with this Pull Request?

Since we know legalities are all or nothing, based on printings, if we have no legalities then we UNION with the next printing, repeating until we have a legalities established.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
