### PR TITLE
don't disable autoconnect on disconnect

### DIFF
--- a/cockatrice/src/dialogs/dlg_connect.cpp
+++ b/cockatrice/src/dialogs/dlg_connect.cpp
@@ -85,6 +85,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     }
 
     connect(savePasswordCheckBox, &QCheckBox::QT_STATE_CHANGED, this, &DlgConnect::passwordSaved);
+    connect(autoConnectCheckBox, &QCheckBox::QT_STATE_CHANGED, &servers, &ServersSettings::setAutoConnect);
 
     serverIssuesLabel =
         new QLabel(tr("If you have any trouble connecting or registering then contact the server staff for help!"));
@@ -345,7 +346,6 @@ void DlgConnect::actOk()
     }
 
     servers.setPrevioushostName(saveEdit->text());
-    servers.setAutoConnect(autoConnectCheckBox->isChecked());
 
     if (playernameEdit->text().isEmpty()) {
         QMessageBox::critical(this, tr("Connect Warning"), tr("The player name can't be empty."));

--- a/cockatrice/src/server/remote/remote_client.cpp
+++ b/cockatrice/src/server/remote/remote_client.cpp
@@ -579,7 +579,6 @@ void RemoteClient::activateToServer(const QString &_token)
 
 void RemoteClient::disconnectFromServer()
 {
-    SettingsCache::instance().servers().setAutoConnect(false);
     emit sigDisconnectFromServer();
 }
 


### PR DESCRIPTION
## Short roundup of the initial problem

The `auto connect` button becomes unchecked whenever you disconnect. I don't think that behavior is desired by most users.

## What will change with this Pull Request?


https://github.com/user-attachments/assets/e076bb24-0cbc-4840-bfd9-bf573551d176

https://github.com/user-attachments/assets/534385e4-c43e-4562-9736-39585854cd6a


- `auto connect` stays clicked on disconnect
- `auto connect` setting is saved immediately when the checkbox is clicked instead of when connecting