### PR TITLE
Disable CardMenu iff no items selected

### DIFF
--- a/cockatrice/src/game/cards/card_item.cpp
+++ b/cockatrice/src/game/cards/card_item.cpp
@@ -486,7 +486,9 @@ QVariant CardItem::itemChange(GraphicsItemChange change, const QVariant &value)
             owner->setCardMenu(cardMenu);
             owner->getGame()->setActiveCard(this);
         } else if (owner->getCardMenu() == cardMenu) {
-            owner->setCardMenu(nullptr);
+            if (scene() && scene()->selectedItems().isEmpty()) {
+                owner->setCardMenu(nullptr);
+            }
             owner->getGame()->setActiveCard(nullptr);
         }
     }


### PR DESCRIPTION
## Related Ticket(s)
- Fix #4372

## Short roundup of the initial problem

If you highlighted N cards and then unhighlighted one, the card menu would be disabled (+ related shortcuts)

## What will change with this Pull Request?

The card menu will only disable if there are no selected cards at all

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
