### PR TITLE
`Printing Selector` naming

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -754,7 +754,7 @@ void TabDeckEditor::retranslateUi()
     cardInfoDockMenu->setTitle(tr("Card Info"));
     deckDockMenu->setTitle(tr("Deck"));
     filterDockMenu->setTitle(tr("Filters"));
-    printingSelectorDockMenu->setTitle(tr("Printing"));
+    printingSelectorDockMenu->setTitle(tr("Printing Selector"));
 
     aCardInfoDockVisible->setText(tr("Visible"));
     aCardInfoDockFloating->setText(tr("Floating"));


### PR DESCRIPTION
## Related Ticket(s)
- Related to #5182

## Short roundup of the initial problem
The new `Printing Selector` feature is the only one that does not use its widget title in the menu.

## What will change with this Pull Request?
- Uniform naming across the client

If this is about string length, the only alternative I can think of is `Printings`, but then the widget should have the same display name obviously.
IMHO it could be more stressed that this is strictly related to the deck (building) feature, e.g. `Deck - Printings`

Happy to adjust the PR if we can agree on a naming.

<br>

@BruebachL was it intentional that resetting the layout does not show the new widget?

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![image](https://github.com/user-attachments/assets/e0bb59f1-b711-4091-9548-140a3257eff2)

