### PR TITLE
Simpler relase channel naming

### DIFF
--- a/cockatrice/src/client/network/release_channel.cpp
+++ b/cockatrice/src/client/network/release_channel.cpp
@@ -86,7 +86,7 @@ QString StableReleaseChannel::getManualDownloadUrl() const
 
 QString StableReleaseChannel::getName() const
 {
-    return tr("Stable Releases");
+    return tr("Default");
 }
 
 QString StableReleaseChannel::getReleaseChannelUrl() const
@@ -200,7 +200,7 @@ QString BetaReleaseChannel::getManualDownloadUrl() const
 
 QString BetaReleaseChannel::getName() const
 {
-    return tr("Beta Releases");
+    return tr("Beta");
 }
 
 QString BetaReleaseChannel::getReleaseChannelUrl() const


### PR DESCRIPTION
## Short roundup of the initial problem
We use unnecessary extensive names for the release channels.
That leads to issues for certain languages or when a translator does not pay close attention to context or details.

The German translation made me think.

I suggest to use a more simple and straight forward naming for the two release channels.

## What will change with this Pull Request?
In the settings, the dropdown option is labelled and described with `Update channel`:
- "Stable Releases" --> `Default`
- "Beta Releases" --> `Beta`
