### PR TITLE
update recently opened decks when saving a new deck

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -1038,6 +1038,9 @@ bool TabDeckEditor::actSaveDeckAs()
         return false;
     }
     setModified(false);
+
+    SettingsCache::instance().recents().updateRecentlyOpenedDeckPaths(fileName);
+
     return true;
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Follow up to #5319

## Short roundup of the initial problem

Recently opened decks doesn't update when you `Save as...` a new deck

## What will change with this Pull Request?

https://github.com/user-attachments/assets/141a99f5-3ad5-41f6-b988-72a1ec37aa1b

Update recently opened decks after saving a new deck
