### PR TITLE
fix cards having the wrong printing if rejoin game before card db finishes loading

### DIFF
--- a/cockatrice/src/game/cards/abstract_card_item.cpp
+++ b/cockatrice/src/game/cards/abstract_card_item.cpp
@@ -25,7 +25,7 @@ AbstractCardItem::AbstractCardItem(QGraphicsItem *parent,
     setCacheMode(DeviceCoordinateCache);
 
     connect(&SettingsCache::instance(), SIGNAL(displayCardNamesChanged()), this, SLOT(callUpdate()));
-    cardInfoUpdated();
+    refreshCardInfo();
 }
 
 AbstractCardItem::~AbstractCardItem()
@@ -51,7 +51,7 @@ void AbstractCardItem::pixmapUpdated()
     emit sigPixmapUpdated();
 }
 
-void AbstractCardItem::cardInfoUpdated()
+void AbstractCardItem::refreshCardInfo()
 {
     info = CardDatabaseManager::getInstance()->getCardByNameAndProviderId(name, providerId);
 
@@ -185,7 +185,7 @@ void AbstractCardItem::setName(const QString &_name)
         disconnect(info.data(), nullptr, this, nullptr);
     name = _name;
 
-    cardInfoUpdated();
+    refreshCardInfo();
 }
 
 void AbstractCardItem::setProviderId(const QString &_providerId)
@@ -200,7 +200,7 @@ void AbstractCardItem::setProviderId(const QString &_providerId)
     }
     providerId = _providerId;
 
-    cardInfoUpdated();
+    refreshCardInfo();
 }
 
 void AbstractCardItem::setHovered(bool _hovered)

--- a/cockatrice/src/game/cards/abstract_card_item.h
+++ b/cockatrice/src/game/cards/abstract_card_item.h
@@ -28,11 +28,14 @@ private:
     qreal realZValue;
 private slots:
     void pixmapUpdated();
-    void cardInfoUpdated();
     void callUpdate()
     {
         update();
     }
+
+public slots:
+    void refreshCardInfo();
+
 signals:
     void hovered(AbstractCardItem *card);
     void showCardInfoPopup(const QPoint &pos, const QString &cardName, const QString &providerId);

--- a/cockatrice/src/game/zones/card_zone.cpp
+++ b/cockatrice/src/game/zones/card_zone.cpp
@@ -1,5 +1,6 @@
 #include "card_zone.h"
 
+#include "../cards/card_database_manager.h"
 #include "../cards/card_item.h"
 #include "../player/player.h"
 #include "pb/command_move_card.pb.h"
@@ -31,6 +32,11 @@ CardZone::CardZone(Player *_p,
 {
     if (!isView)
         player->addZone(this);
+
+    // If we join a game before the card db finishes loading, the cards might have the wrong printings.
+    // Force refresh all cards in the zone when db finishes loading to fix that.
+    connect(CardDatabaseManager::getInstance(), &CardDatabase::cardDatabaseLoadingFinished, this,
+            &CardZone::refreshCardInfos);
 }
 
 CardZone::~CardZone()
@@ -117,6 +123,13 @@ bool CardZone::showContextMenu(const QPoint &screenPos)
         return true;
     }
     return false;
+}
+
+void CardZone::refreshCardInfos()
+{
+    for (const auto &cardItem : cards) {
+        cardItem->refreshCardInfo();
+    }
 }
 
 void CardZone::mousePressEvent(QGraphicsSceneMouseEvent *event)

--- a/cockatrice/src/game/zones/card_zone.h
+++ b/cockatrice/src/game/zones/card_zone.h
@@ -43,6 +43,9 @@ public slots:
     void moveAllToZone();
     bool showContextMenu(const QPoint &screenPos);
 
+private slots:
+    void refreshCardInfos();
+
 public:
     enum
     {


### PR DESCRIPTION
## Short roundup of the initial problem

If a player joins a game before their card db finishes loading, the cards won't have the correct printings

This can happen if a user closes cockatrice while they're still in a game and then immediately rejoins the game when they open cockatrice again 

## What will change with this Pull Request?

https://github.com/user-attachments/assets/7a01cc44-e386-4d43-a5d7-a1f1736deb52

- rename `AbstractCardInfo::cardInfoUpdated` to `refreshCardInfo` and make it public
- call `refreshCardInfo` on all cards in zone when card db finishes loading

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
