### PR TITLE
don't redraw PrintingSelector's FlowWidget unless cards actually changed

### DIFF
--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
@@ -57,10 +57,14 @@ PrintingSelector::PrintingSelector(QWidget *parent,
     layout->addWidget(cardSelectionBar);
 
     // Connect deck model data change signal to update display
-    connect(deckModel, &DeckListModel::dataChanged, this, [this]() {
-        // Delay the update to avoid race conditions
-        QTimer::singleShot(100, this, &PrintingSelector::updateDisplay);
-    });
+    connect(deckModel, &DeckListModel::rowsInserted, this, &PrintingSelector::printingsInDeckChanged);
+    connect(deckModel, &DeckListModel::rowsRemoved, this, &PrintingSelector::printingsInDeckChanged);
+}
+
+void PrintingSelector::printingsInDeckChanged()
+{
+    // Delay the update to avoid race conditions
+    QTimer::singleShot(100, this, &PrintingSelector::updateDisplay);
 }
 
 /**
@@ -89,6 +93,12 @@ void PrintingSelector::setCard(const CardInfoPtr &newCard, const QString &_curre
     if (newCard.isNull()) {
         return;
     }
+
+    // we don't need to redraw the widget if the card is the same
+    if (!selectedCard.isNull() && selectedCard->getName() == newCard->getName()) {
+        return;
+    }
+
     selectedCard = newCard;
     currentZone = _currentZone;
     if (isVisible()) {

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.h
@@ -37,6 +37,9 @@ public slots:
     void toggleVisibilityCardSizeSlider(bool _state);
     void toggleVisibilityNavigationButtons(bool _state);
 
+private slots:
+    void printingsInDeckChanged();
+
 private:
     QVBoxLayout *layout;
     PrintingSelectorViewOptionsToolbarWidget *viewOptionsToolbar;


### PR DESCRIPTION
## Short roundup of the initial problem

The `PrintingSelector` FlowWidget jumps back to the top every time a card is added or removed from deck or a different printing of the card is selected in the decklist. This is annoying and unnecessary. 

(Apparently the PrintingSelector is suppose to have printings in deck at the top, which is why it needs the reset, but it doesn't actually do that right now. This change is made assuming that we do support that behavior.)

https://github.com/user-attachments/assets/46ef24c0-20a3-46a9-9930-180679847ba4

## What will change with this Pull Request?

https://github.com/user-attachments/assets/286be96b-e8dd-43e7-81f6-746d598c70b7

- connection in `PrintingSelector` that updates display when decklist changes now only triggers when a new row is added/removed from the deck
  - As opposed to when the count of an existing card changes
- `PrintingSelector::setCard` now early returns if the new card has the same name as the existing card