### PR TITLE
support multi-select in deck editor

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -1328,7 +1328,6 @@ void TabDeckEditor::offsetCountAtIndex(const QModelIndex &idx, int offset)
     const QModelIndex numberIndex = idx.sibling(idx.row(), 0);
     const int count = deckModel->data(numberIndex, Qt::EditRole).toInt();
     const int new_count = count + offset;
-    deckView->setCurrentIndex(numberIndex);
     if (new_count <= 0)
         deckModel->removeRow(idx.row(), idx.parent());
     else

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -1320,6 +1320,12 @@ void TabDeckEditor::actRemoveCard()
 {
     auto selectedRows = getSelectedCardNodes();
 
+    // hack to maintain the old reselection behavior when currently selected row of a single-selection gets deleted
+    // TODO: remove the hack and also handle reselection when all rows of a multi-selection gets deleted
+    if (selectedRows.length() == 1) {
+        deckView->setSelectionMode(QAbstractItemView::SingleSelection);
+    }
+
     bool modified = false;
     for (const auto &index : selectedRows) {
         if (!index.isValid() || deckModel->hasChildren(index)) {
@@ -1328,6 +1334,8 @@ void TabDeckEditor::actRemoveCard()
         deckModel->removeRow(index.row(), index.parent());
         modified = true;
     }
+
+    deckView->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
     if (modified) {
         DeckLoader *const deck = deckModel->getDeckList();
@@ -1399,9 +1407,17 @@ void TabDeckEditor::actDecrement()
 {
     auto selectedRows = getSelectedCardNodes();
 
+    // hack to maintain the old reselection behavior when currently selected row of a single-selection gets deleted
+    // TODO: remove the hack and also handle reselection when all rows of a multi-selection gets deleted
+    if (selectedRows.length() == 1) {
+        deckView->setSelectionMode(QAbstractItemView::SingleSelection);
+    }
+
     for (const auto &index : selectedRows) {
         offsetCountAtIndex(index, -1);
     }
+
+    deckView->setSelectionMode(QAbstractItemView::ExtendedSelection);
 }
 
 void TabDeckEditor::setDeck(DeckLoader *_deck)

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -1252,6 +1252,7 @@ void TabDeckEditor::addCardHelper(QString zoneName)
 
     QModelIndex newCardIndex = deckModel->addPreferredPrintingCard(info->getName(), zoneName, false);
     recursiveExpand(newCardIndex);
+    deckView->clearSelection();
     deckView->setCurrentIndex(newCardIndex);
     setModified(true);
     searchEdit->setSelection(0, searchEdit->text().length());
@@ -1338,14 +1339,18 @@ void TabDeckEditor::offsetCountAtIndex(const QModelIndex &idx, int offset)
 void TabDeckEditor::decrementCardHelper(QString zoneName)
 {
     const CardInfoPtr info = currentCardInfo();
-    QModelIndex idx;
 
     if (!info)
         return;
     if (info->getIsToken())
         zoneName = DECK_ZONE_TOKENS;
 
-    idx = deckModel->findCard(info->getName(), zoneName);
+    QModelIndex idx = deckModel->findCard(info->getName(), zoneName);
+    if (!idx.isValid()) {
+        return;
+    }
+    deckView->clearSelection();
+    deckView->setCurrentIndex(idx);
     offsetCountAtIndex(idx, -1);
 }
 

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -1321,8 +1321,9 @@ void TabDeckEditor::actRemoveCard()
 
 void TabDeckEditor::offsetCountAtIndex(const QModelIndex &idx, int offset)
 {
-    if (!idx.isValid() || offset == 0)
+    if (!idx.isValid() || deckModel->hasChildren(idx)) {
         return;
+    }
 
     const QModelIndex numberIndex = idx.sibling(idx.row(), 0);
     const int count = deckModel->data(numberIndex, Qt::EditRole).toInt();

--- a/cockatrice/src/client/tabs/tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/tab_deck_editor.h
@@ -111,6 +111,8 @@ private:
     void recursiveExpand(const QModelIndex &index);
     void openDeckFromFile(const QString &fileName, DeckOpenLocation deckOpenLocation);
 
+    QModelIndexList getSelectedCardNodes() const;
+
     CardDatabaseModel *databaseModel;
     CardDatabaseDisplayModel *databaseDisplayModel;
     DeckListModel *deckModel;


### PR DESCRIPTION
## Short roundup of the initial problem

It would be nice to be able to have multi-select in the deck editor

## What will change with this Pull Request?

https://github.com/user-attachments/assets/5af12270-9ddf-41f8-9829-017bdf876c58

- Added ability to select multiple cards in the deck editor
- The three decklist actions now apply to all selected cards
  - gracefully handles rows being removed during the action
- Adding/removing cards from the card database side will reset the selection
- Maintains old the reselection behavior if only single row is selected and that row gets deleted
  - If there's multiple rows selected and they all get deleted in one action, then we don't do any reselection behavior
    - maybe that's something to add in the future

TODO: also apply `swap card to sideboard` action to all selected cards once we add a button for that action