### PR TITLE
Keep card annotations on stack

### DIFF
--- a/cockatrice/src/game/cards/card_item.cpp
+++ b/cockatrice/src/game/cards/card_item.cpp
@@ -217,13 +217,15 @@ void CardItem::setAttachedTo(CardItem *_attachedTo)
     }
 }
 
-void CardItem::resetState()
+void CardItem::resetState(bool keepAnnotations)
 {
     attacking = false;
     facedown = false;
     counters.clear();
     pt.clear();
-    annotation.clear();
+    if (!keepAnnotations) {
+        annotation.clear();
+    }
     attachedTo = 0;
     attachedCards.clear();
     setTapped(false, false);

--- a/cockatrice/src/game/cards/card_item.h
+++ b/cockatrice/src/game/cards/card_item.h
@@ -139,7 +139,7 @@ public:
     {
         return attachedCards;
     }
-    void resetState();
+    void resetState(bool keepAnnotations = false);
     void processCardInfo(const ServerInfo_Card &_info);
 
     QMenu *getCardMenu() const

--- a/cockatrice/src/game/zones/stack_zone.cpp
+++ b/cockatrice/src/game/zones/stack_zone.cpp
@@ -37,7 +37,7 @@ void StackZone::addCardImpl(CardItem *card, int x, int /*y*/)
         card->setName();
     }
     card->setParentItem(this);
-    card->resetState();
+    card->resetState(true);
     card->setVisible(true);
     card->update();
 }

--- a/common/server_card.cpp
+++ b/common/server_card.cpp
@@ -54,13 +54,15 @@ Server_Card::~Server_Card()
     }
 }
 
-void Server_Card::resetState()
+void Server_Card::resetState(bool keepAnnotations)
 {
     counters.clear();
     setTapped(false);
     setAttacking(false);
     setPT(QString());
-    setAnnotation(QString());
+    if (!keepAnnotations) {
+        setAnnotation(QString());
+    }
     setDoesntUntap(false);
 }
 

--- a/common/server_card.h
+++ b/common/server_card.h
@@ -218,7 +218,7 @@ public:
         return oldStashedCard;
     }
 
-    void resetState();
+    void resetState(bool keepAnnotations = false);
     QString setAttribute(CardAttribute attribute, const QString &avalue, bool allCards);
     QString setAttribute(CardAttribute attribute, const QString &avalue, Event_SetCardAttr *event = nullptr);
 

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -576,10 +576,6 @@ Response::ResponseCode Server_Player::moveCard(GameEventStorage &ges,
             eventOthers.set_start_player_id(startzone->getPlayer()->getPlayerId());
             eventOthers.set_start_zone(startzone->getName().toStdString());
             eventOthers.set_target_player_id(targetzone->getPlayer()->getPlayerId());
-            if (targetzone->getName() == "stack") {
-                setCardAttrHelper(ges, targetzone->getPlayer()->getPlayerId(), targetzone->getName(), card->getId(),
-                                  AttrAnnotation, card->getAnnotation(), card);
-            }
             if (startzone != targetzone) {
                 eventOthers.set_target_zone(targetzone->getName().toStdString());
             }

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -548,7 +548,7 @@ Response::ResponseCode Server_Player::moveCard(GameEventStorage &ges,
                 newX = targetzone->getFreeGridColumn(newX, yCoord, card->getName(), faceDown);
             } else {
                 yCoord = 0;
-                card->resetState();
+                card->resetState(targetzone->getName() == "stack");
             }
 
             targetzone->insertCard(card, newX, yCoord);
@@ -576,6 +576,10 @@ Response::ResponseCode Server_Player::moveCard(GameEventStorage &ges,
             eventOthers.set_start_player_id(startzone->getPlayer()->getPlayerId());
             eventOthers.set_start_zone(startzone->getName().toStdString());
             eventOthers.set_target_player_id(targetzone->getPlayer()->getPlayerId());
+            if (targetzone->getName() == "stack") {
+                setCardAttrHelper(ges, targetzone->getPlayer()->getPlayerId(), targetzone->getName(), card->getId(),
+                                  AttrAnnotation, card->getAnnotation(), card);
+            }
             if (startzone != targetzone) {
                 eventOthers.set_target_zone(targetzone->getName().toStdString());
             }


### PR DESCRIPTION
Allow cards to be moved to the stack and retain their annotations (Server & Client updates)

- Older clients will still have their annotations wiped locally, but server-side they'll still be there. This is useful as owner tags can still be enacted upon to return the cards