### PR TITLE
Improve Database Backup Speed

### DIFF
--- a/servatrice/migrations/servatrice_0030_to_0031.sql
+++ b/servatrice/migrations/servatrice_0030_to_0031.sql
@@ -1,0 +1,11 @@
+-- Servatrice db migration from version 30 to version 31
+
+ALTER TABLE cockatrice_log DROP INDEX `target_type`;
+
+ALTER TABLE cockatrice_forgot_password ADD INDEX idx_emailed (`emailed`);
+ALTER TABLE cockatrice_sessions ADD INDEX idx_start_time (`start_time`);
+ALTER TABLE cockatrice_users ADD INDEX idx_admin (`admin`);
+ALTER TABLE cockatrice_users ADD INDEX idx_active (`active`);
+ALTER TABLE cockatrice_users ADD INDEX idx_privlevel (`privlevel`);
+
+UPDATE cockatrice_schema_version SET version=31 WHERE version=30;

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -44,7 +44,10 @@ CREATE TABLE IF NOT EXISTS `cockatrice_users` (
   PRIMARY KEY  (`id`),
   UNIQUE KEY `name` (`name`),
   KEY `token` (`token`),
-  KEY `email` (`email`)
+  KEY `email` (`email`),
+  INDEX `idx_admin` (`admin`),
+  INDEX `idx_active` (`active`)
+  INDEX `idx_privlevel` (`privlevel`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `cockatrice_decklist_files` (
@@ -190,7 +193,8 @@ CREATE TABLE IF NOT EXISTS `cockatrice_sessions` (
   `clientid` varchar(15) NOT NULL,
   `connection_type` ENUM('tcp', 'websocket'),
   PRIMARY KEY (`id`),
-  KEY `username` (`user_name`)
+  KEY `username` (`user_name`),
+  INDEX `idx_start_time` (`start_time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
 
 -- server moderation
@@ -230,7 +234,6 @@ CREATE TABLE IF NOT EXISTS `cockatrice_log` (
   `target_name` varchar(50) NOT NULL,
   KEY `sender_name` (`sender_name`),
   KEY `sender_ip` (`sender_ip`),
-  KEY `target_type` (`target_type`),
   KEY `target_id` (`target_id`),
   KEY `target_name` (`target_name`),
   FOREIGN KEY(`sender_id`) REFERENCES `cockatrice_users`(`id`)  ON DELETE CASCADE ON UPDATE CASCADE
@@ -269,7 +272,8 @@ CREATE TABLE IF NOT EXISTS `cockatrice_forgot_password` (
   `requestDate` datetime NOT NULL default '0000-00-00 00:00:00',
   `emailed` tinyint(1) NOT NULL default 0,
   PRIMARY KEY  (`id`),
-  KEY `user_name` (`name`)
+  KEY `user_name` (`name`),
+  INDEX `idx_emailed` (`emailed`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `cockatrice_audit` (

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_users` (
   KEY `token` (`token`),
   KEY `email` (`email`),
   INDEX `idx_admin` (`admin`),
-  INDEX `idx_active` (`active`)
+  INDEX `idx_active` (`active`),
   INDEX `idx_privlevel` (`privlevel`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
 

--- a/servatrice/servatrice.sql
+++ b/servatrice/servatrice.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `cockatrice_schema_version` (
   PRIMARY KEY  (`version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
 
-INSERT INTO cockatrice_schema_version VALUES(30);
+INSERT INTO cockatrice_schema_version VALUES(31);
 
 -- users and user data tables
 CREATE TABLE IF NOT EXISTS `cockatrice_users` (

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -1210,6 +1210,11 @@ QList<ServerInfo_ChatMessage> Servatrice_DatabaseInterface::getMessageLogHistory
     if (!checkSql())
         return results;
 
+    if (user.isEmpty() && ipaddress.isEmpty() && gameid.isEmpty() && gamename.isEmpty()) {
+        // To ensure quick results and minimal lag, require an indexed field
+        return results;
+    }
+
     // BUILD QUERY STRING BASED ON PASSED IN VALUES
     QString queryString = "SELECT * FROM {prefix}_log WHERE `sender_ip` IS NOT NULL";
     if (!user.isEmpty())

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -9,7 +9,7 @@
 #include <QObject>
 #include <QSqlDatabase>
 
-#define DATABASE_SCHEMA_VERSION 30
+#define DATABASE_SCHEMA_VERSION 31
 
 class Servatrice;
 


### PR DESCRIPTION
@danbopes and I spent some time today cleaning up index/keys for servatrice, allowing us to have better speeds on database backups. This should hopefully reduce/elminate the downtime people have been experiencing over the past many months.

- Also prevent searching only on msg for logs, as that was a source of lag. As long as an index is specified, the log searcher should be fine.