### PR TITLE
add debug settings; option to show cardIds

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -130,6 +130,7 @@ set(cockatrice_SOURCES
     src/settings/shortcuts_settings.cpp
     src/settings/shortcut_treeview.cpp
     src/settings/card_override_settings.cpp
+    src/settings/debug_settings.cpp
     src/client/sound_engine.cpp
     src/client/network/spoiler_background_updater.cpp
     src/game/zones/stack_zone.cpp

--- a/cockatrice/src/game/cards/abstract_card_item.cpp
+++ b/cockatrice/src/game/cards/abstract_card_item.cpp
@@ -141,8 +141,13 @@ void AbstractCardItem::paintPicture(QPainter *painter, const QSizeF &translatedS
         QString nameStr;
         if (facedown)
             nameStr = "# " + QString::number(id);
-        else
-            nameStr = name;
+        else {
+            QString prefix = "";
+            if (SettingsCache::instance().debug().getShowCardId()) {
+                prefix = "#" + QString::number(id) + " ";
+            }
+            nameStr = prefix + name;
+        }
         painter->drawText(QRectF(3 * scaleFactor, 3 * scaleFactor, translatedSize.width() - 6 * scaleFactor,
                                  translatedSize.height() - 6 * scaleFactor),
                           Qt::AlignTop | Qt::AlignLeft | Qt::TextWrapAnywhere, nameStr);

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -181,6 +181,7 @@ SettingsCache::SettingsCache()
     downloadSettings = new DownloadSettings(settingsPath, this);
     recentsSettings = new RecentsSettings(settingsPath, this);
     cardOverrideSettings = new CardOverrideSettings(settingsPath, this);
+    debugSettings = new DebugSettings(settingsPath, this);
 
     if (!QFile(settingsPath + "global.ini").exists())
         translateLegacySettings();

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -4,6 +4,7 @@
 #include "../utility/macros.h"
 #include "card_database_settings.h"
 #include "card_override_settings.h"
+#include "debug_settings.h"
 #include "download_settings.h"
 #include "game_filters_settings.h"
 #include "layouts_settings.h"
@@ -86,6 +87,7 @@ private:
     DownloadSettings *downloadSettings;
     RecentsSettings *recentsSettings;
     CardOverrideSettings *cardOverrideSettings;
+    DebugSettings *debugSettings;
 
     QByteArray mainWindowGeometry;
     QByteArray tokenDialogGeometry;
@@ -618,6 +620,10 @@ public:
     CardOverrideSettings &cardOverrides() const
     {
         return *cardOverrideSettings;
+    }
+    DebugSettings &debug() const
+    {
+        return *debugSettings;
     }
     bool getIsPortableBuild() const
     {

--- a/cockatrice/src/settings/debug_settings.cpp
+++ b/cockatrice/src/settings/debug_settings.cpp
@@ -1,0 +1,10 @@
+#include "debug_settings.h"
+
+DebugSettings::DebugSettings(QString settingPath, QObject *parent) : SettingsManager(settingPath + "debug.ini", parent)
+{
+}
+
+bool DebugSettings::getShowCardId()
+{
+    return getValue("show", "cardId").toBool();
+}

--- a/cockatrice/src/settings/debug_settings.h
+++ b/cockatrice/src/settings/debug_settings.h
@@ -1,0 +1,17 @@
+#ifndef DEBUG_SETTINGS_H
+#define DEBUG_SETTINGS_H
+#include "settings_manager.h"
+
+class DebugSettings : public SettingsManager
+{
+    Q_OBJECT
+    friend class SettingsCache;
+
+    explicit DebugSettings(QString settingPath, QObject *parent = nullptr);
+    DebugSettings(const DebugSettings & /*other*/);
+
+public:
+    bool getShowCardId();
+};
+
+#endif // DEBUG_SETTINGS_H

--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -33,6 +33,7 @@ set(oracle_SOURCES
     ../cockatrice/src/settings/layouts_settings.cpp
     ../cockatrice/src/settings/download_settings.cpp
     ../cockatrice/src/settings/card_override_settings.cpp
+    ../cockatrice/src/settings/debug_settings.cpp
     ../cockatrice/src/client/ui/theme_manager.cpp
     ../cockatrice/src/client/network/release_channel.cpp
     ${VERSION_STRING_CPP}


### PR DESCRIPTION
## Short roundup of the initial problem

We're thinking of adding some debug-only settings to Cockatrice in order to ease testing and debugging work

## What will change with this Pull Request?

https://github.com/user-attachments/assets/85686d9f-319e-471d-a404-8f7ba3190f18

- Added a `DebugSettings` class that reads from `debug.ini`
- Added a `show cardId` setting that will prepend the cardId to the card name
  - Currently no way to edit this setting in-client; will need to directly edit the ini file
  - Currently requires a client restart to sync the setting
