### PR TITLE
Make SettingsManager params const ref

### DIFF
--- a/cockatrice/src/settings/card_database_settings.cpp
+++ b/cockatrice/src/settings/card_database_settings.cpp
@@ -1,6 +1,6 @@
 #include "card_database_settings.h"
 
-CardDatabaseSettings::CardDatabaseSettings(QString settingPath, QObject *parent)
+CardDatabaseSettings::CardDatabaseSettings(const QString &settingPath, QObject *parent)
     : SettingsManager(settingPath + "cardDatabase.ini", parent)
 {
 }

--- a/cockatrice/src/settings/card_database_settings.h
+++ b/cockatrice/src/settings/card_database_settings.h
@@ -25,7 +25,7 @@ signals:
 public slots:
 
 private:
-    explicit CardDatabaseSettings(QString settingPath, QObject *parent = nullptr);
+    explicit CardDatabaseSettings(const QString &settingPath, QObject *parent = nullptr);
     CardDatabaseSettings(const CardDatabaseSettings & /*other*/);
 };
 

--- a/cockatrice/src/settings/card_override_settings.cpp
+++ b/cockatrice/src/settings/card_override_settings.cpp
@@ -1,6 +1,6 @@
 #include "card_override_settings.h"
 
-CardOverrideSettings::CardOverrideSettings(QString settingPath, QObject *parent)
+CardOverrideSettings::CardOverrideSettings(const QString &settingPath, QObject *parent)
     : SettingsManager(settingPath + "cardPreferenceOverrides.ini", parent)
 {
 }

--- a/cockatrice/src/settings/card_override_settings.h
+++ b/cockatrice/src/settings/card_override_settings.h
@@ -18,7 +18,7 @@ public:
     QString getCardPreferenceOverride(const QString &cardName);
 
 private:
-    explicit CardOverrideSettings(QString settingPath, QObject *parent = nullptr);
+    explicit CardOverrideSettings(const QString &settingPath, QObject *parent = nullptr);
     CardOverrideSettings(const CardOverrideSettings & /*other*/);
 };
 

--- a/cockatrice/src/settings/game_filters_settings.cpp
+++ b/cockatrice/src/settings/game_filters_settings.cpp
@@ -3,7 +3,7 @@
 #include <QCryptographicHash>
 #include <QTime>
 
-GameFiltersSettings::GameFiltersSettings(QString settingPath, QObject *parent)
+GameFiltersSettings::GameFiltersSettings(const QString &settingPath, QObject *parent)
     : SettingsManager(settingPath + "gamefilters.ini", parent)
 {
 }

--- a/cockatrice/src/settings/game_filters_settings.h
+++ b/cockatrice/src/settings/game_filters_settings.h
@@ -46,7 +46,7 @@ signals:
 public slots:
 
 private:
-    explicit GameFiltersSettings(QString settingPath, QObject *parent = nullptr);
+    explicit GameFiltersSettings(const QString &settingPath, QObject *parent = nullptr);
     GameFiltersSettings(const GameFiltersSettings & /*other*/);
 
     QString hashGameType(const QString &gameType) const;

--- a/cockatrice/src/settings/message_settings.cpp
+++ b/cockatrice/src/settings/message_settings.cpp
@@ -1,6 +1,6 @@
 #include "message_settings.h"
 
-MessageSettings::MessageSettings(QString settingPath, QObject *parent)
+MessageSettings::MessageSettings(const QString &settingPath, QObject *parent)
     : SettingsManager(settingPath + "messages.ini", parent)
 {
 }

--- a/cockatrice/src/settings/message_settings.h
+++ b/cockatrice/src/settings/message_settings.h
@@ -20,7 +20,7 @@ signals:
 public slots:
 
 private:
-    explicit MessageSettings(QString settingPath, QObject *parent = nullptr);
+    explicit MessageSettings(const QString &settingPath, QObject *parent = nullptr);
     MessageSettings(const MessageSettings & /*other*/);
 };
 

--- a/cockatrice/src/settings/recents_settings.cpp
+++ b/cockatrice/src/settings/recents_settings.cpp
@@ -2,7 +2,7 @@
 
 #define MAX_RECENT_DECK_COUNT 10
 
-RecentsSettings::RecentsSettings(QString settingPath, QObject *parent)
+RecentsSettings::RecentsSettings(const QString &settingPath, QObject *parent)
     : SettingsManager(settingPath + "recents.ini", parent)
 {
 }

--- a/cockatrice/src/settings/recents_settings.h
+++ b/cockatrice/src/settings/recents_settings.h
@@ -8,7 +8,7 @@ class RecentsSettings : public SettingsManager
     Q_OBJECT
     friend class SettingsCache;
 
-    explicit RecentsSettings(QString settingPath, QObject *parent = nullptr);
+    explicit RecentsSettings(const QString &settingPath, QObject *parent = nullptr);
     RecentsSettings(const RecentsSettings & /*other*/);
 
 public:

--- a/cockatrice/src/settings/servers_settings.cpp
+++ b/cockatrice/src/settings/servers_settings.cpp
@@ -3,7 +3,7 @@
 #include <QDebug>
 #include <utility>
 
-ServersSettings::ServersSettings(QString settingPath, QObject *parent)
+ServersSettings::ServersSettings(const QString &settingPath, QObject *parent)
     : SettingsManager(settingPath + "servers.ini", parent)
 {
 }

--- a/cockatrice/src/settings/servers_settings.h
+++ b/cockatrice/src/settings/servers_settings.h
@@ -61,7 +61,7 @@ public:
     bool getClearDebugLogStatus(bool abDefaultValue);
 
 private:
-    explicit ServersSettings(QString settingPath, QObject *parent = nullptr);
+    explicit ServersSettings(const QString &settingPath, QObject *parent = nullptr);
     ServersSettings(const ServersSettings & /*other*/);
 };
 

--- a/cockatrice/src/settings/settings_manager.cpp
+++ b/cockatrice/src/settings/settings_manager.cpp
@@ -1,6 +1,6 @@
 #include "settings_manager.h"
 
-SettingsManager::SettingsManager(QString settingPath, QObject *parent)
+SettingsManager::SettingsManager(const QString &settingPath, QObject *parent)
     : QObject(parent), settings(settingPath, QSettings::IniFormat)
 {
 }

--- a/cockatrice/src/settings/settings_manager.cpp
+++ b/cockatrice/src/settings/settings_manager.cpp
@@ -5,7 +5,10 @@ SettingsManager::SettingsManager(const QString &settingPath, QObject *parent)
 {
 }
 
-void SettingsManager::setValue(QVariant value, QString name, QString group, QString subGroup)
+void SettingsManager::setValue(const QVariant &value,
+                               const QString &name,
+                               const QString &group,
+                               const QString &subGroup)
 {
     if (!group.isEmpty()) {
         settings.beginGroup(group);
@@ -26,7 +29,7 @@ void SettingsManager::setValue(QVariant value, QString name, QString group, QStr
     }
 }
 
-void SettingsManager::deleteValue(QString name, QString group, QString subGroup)
+void SettingsManager::deleteValue(const QString &name, const QString &group, const QString &subGroup)
 {
     if (!group.isEmpty()) {
         settings.beginGroup(group);
@@ -47,7 +50,7 @@ void SettingsManager::deleteValue(QString name, QString group, QString subGroup)
     }
 }
 
-QVariant SettingsManager::getValue(QString name, QString group, QString subGroup)
+QVariant SettingsManager::getValue(const QString &name, const QString &group, const QString &subGroup)
 {
     if (!group.isEmpty()) {
         settings.beginGroup(group);

--- a/cockatrice/src/settings/settings_manager.h
+++ b/cockatrice/src/settings/settings_manager.h
@@ -10,7 +10,7 @@ class SettingsManager : public QObject
 {
     Q_OBJECT
 public:
-    explicit SettingsManager(QString settingPath, QObject *parent = nullptr);
+    explicit SettingsManager(const QString &settingPath, QObject *parent = nullptr);
     QVariant getValue(QString name, QString group = "", QString subGroup = "");
     void sync();
 

--- a/cockatrice/src/settings/settings_manager.h
+++ b/cockatrice/src/settings/settings_manager.h
@@ -14,10 +14,6 @@ public:
     QVariant getValue(const QString &name, const QString &group = "", const QString &subGroup = "");
     void sync();
 
-signals:
-
-public slots:
-
 protected:
     QSettings settings;
     void setValue(const QVariant &value, const QString &name, const QString &group = "", const QString &subGroup = "");

--- a/cockatrice/src/settings/settings_manager.h
+++ b/cockatrice/src/settings/settings_manager.h
@@ -11,7 +11,7 @@ class SettingsManager : public QObject
     Q_OBJECT
 public:
     explicit SettingsManager(const QString &settingPath, QObject *parent = nullptr);
-    QVariant getValue(QString name, QString group = "", QString subGroup = "");
+    QVariant getValue(const QString &name, const QString &group = "", const QString &subGroup = "");
     void sync();
 
 signals:
@@ -20,8 +20,8 @@ public slots:
 
 protected:
     QSettings settings;
-    void setValue(QVariant value, QString name, QString group = "", QString subGroup = "");
-    void deleteValue(QString name, QString group = "", QString subGroup = "");
+    void setValue(const QVariant &value, const QString &name, const QString &group = "", const QString &subGroup = "");
+    void deleteValue(const QString &name, const QString &group = "", const QString &subGroup = "");
 };
 
 #endif // SETTINGSMANAGER_H

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -1,7 +1,7 @@
 
 #include "mocks.h"
 
-CardDatabaseSettings::CardDatabaseSettings(QString settingPath, QObject *parent)
+CardDatabaseSettings::CardDatabaseSettings(const QString &settingPath, QObject *parent)
     : SettingsManager(settingPath + "cardDatabase.ini", parent)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -1,7 +1,7 @@
 
 #include "mocks.h"
 
-CardDatabaseSettings::CardDatabaseSettings(QString settingPath, QObject *parent)
+CardDatabaseSettings::CardDatabaseSettings(const QString &settingPath, QObject *parent)
     : SettingsManager(settingPath + "cardDatabase.ini", parent)
 {
 }


### PR DESCRIPTION
## Short roundup of the initial problem

`SettingsManager` could be passing its parameters by const ref

## What will change with this Pull Request?

- pass `SettingsManager`'s (and subclasses) method's params by const ref
- clean up some unused code
