### PR TITLE
Add debug setting to start local game on startup

### DIFF
--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -886,6 +886,10 @@ MainWindow::MainWindow(QWidget *parent)
 
 void MainWindow::startupConfigCheck()
 {
+    if (SettingsCache::instance().debug().getLocalGameOnStartup()) {
+        startLocalGame(SettingsCache::instance().debug().getLocalGamePlayerCount());
+    }
+
     if (SettingsCache::instance().getCheckUpdatesOnStartup()) {
         actCheckClientUpdates();
     }

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -1030,7 +1030,8 @@ void MainWindow::changeEvent(QEvent *event)
             if (!connectTo.isEmpty()) {
                 qDebug() << "Command line connect to " << connectTo;
                 client->connectToServer(connectTo.host(), connectTo.port(), connectTo.userName(), connectTo.password());
-            } else if (SettingsCache::instance().servers().getAutoConnect()) {
+            } else if (SettingsCache::instance().servers().getAutoConnect() &&
+                       !SettingsCache::instance().debug().getLocalGameOnStartup()) {
                 qDebug() << "Attempting auto-connect...";
                 DlgConnect dlg(this);
                 client->connectToServer(dlg.getHost(), static_cast<unsigned int>(dlg.getPort()), dlg.getPlayerName(),

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -223,6 +223,11 @@ void MainWindow::actSinglePlayer()
     if (!ok)
         return;
 
+    startLocalGame(numberPlayers);
+}
+
+void MainWindow::startLocalGame(int numberPlayers)
+{
     aConnect->setEnabled(false);
     aRegister->setEnabled(false);
     aForgotPassword->setEnabled(false);

--- a/cockatrice/src/client/ui/window_main.h
+++ b/cockatrice/src/client/ui/window_main.h
@@ -126,6 +126,8 @@ private:
     };
     void exitCardDatabaseUpdate();
 
+    void startLocalGame(int numberPlayers);
+
     QList<QMenu *> tabMenus;
     QMenu *cockatriceMenu, *dbMenu, *helpMenu, *trayIconMenu;
     QAction *aConnect, *aDisconnect, *aSinglePlayer, *aWatchReplay, *aDeckEditor, *aFullScreen, *aSettings, *aExit,

--- a/cockatrice/src/settings/debug_settings.cpp
+++ b/cockatrice/src/settings/debug_settings.cpp
@@ -15,3 +15,13 @@ bool DebugSettings::getShowCardId()
 {
     return getValue("showCardId", "debug").toBool();
 }
+
+bool DebugSettings::getLocalGameOnStartup()
+{
+    return getValue("onStartup", "localgame").toBool();
+}
+
+int DebugSettings::getLocalGamePlayerCount()
+{
+    return getValue("playerCount", "localgame").toInt();
+}

--- a/cockatrice/src/settings/debug_settings.h
+++ b/cockatrice/src/settings/debug_settings.h
@@ -12,6 +12,9 @@ class DebugSettings : public SettingsManager
 
 public:
     bool getShowCardId();
+
+    bool getLocalGameOnStartup();
+    int getLocalGamePlayerCount();
 };
 
 #endif // DEBUG_SETTINGS_H


### PR DESCRIPTION
## What will change with this Pull Request?


https://github.com/user-attachments/assets/3eef98d1-356d-4910-a5d6-530e30fa2b48

Added debug setting to start local game on startup.

Settings are in `debug.ini` as
```
[localgame]
onStartup=true
playerCount=1
```

Disables autoconnect while enabled.
