### PR TITLE
add debug setting to load deck and ready on join

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -382,6 +382,15 @@ void DeckViewContainer::setReadyStart(bool ready)
     sideboardLockButton->setEnabled(!readyStartButton->getState() && readyStartButton->isEnabled());
 }
 
+/**
+ * Sets the ready start to true, then sends the ready command so the server responds to the update
+ */
+void DeckViewContainer::readyAndUpdate()
+{
+    setReadyStart(true);
+    readyStart();
+}
+
 void DeckViewContainer::setSideboardLocked(bool locked)
 {
     sideboardLockButton->setState(!locked);

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -294,12 +294,16 @@ void DeckViewContainer::loadLocalDeck()
     if (!dialog.exec())
         return;
 
-    QString fileName = dialog.selectedFiles().at(0);
-    DeckLoader::FileFormat fmt = DeckLoader::getFormatFromName(fileName);
+    loadDeckFromFile(dialog.selectedFiles().at(0));
+}
+
+void DeckViewContainer::loadDeckFromFile(const QString &filePath)
+{
+    DeckLoader::FileFormat fmt = DeckLoader::getFormatFromName(filePath);
     QString deckString;
     DeckLoader deck;
 
-    bool error = !deck.loadFromFile(fileName, fmt);
+    bool error = !deck.loadFromFile(filePath, fmt);
     if (!error) {
         deckString = deck.writeToString_Native();
         error = deckString.length() > MAX_FILE_LENGTH;

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -112,6 +112,7 @@ public:
     void setReadyStart(bool ready);
     void setSideboardLocked(bool locked);
     void setDeck(const DeckLoader &deck);
+    void loadDeckFromFile(const QString &filePath);
 };
 
 class TabGame : public Tab

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -110,6 +110,7 @@ public:
     void retranslateUi();
     void setButtonsVisible(bool _visible);
     void setReadyStart(bool ready);
+    void readyAndUpdate();
     void setSideboardLocked(bool locked);
     void setDeck(const DeckLoader &deck);
     void loadDeckFromFile(const QString &filePath);

--- a/cockatrice/src/settings/debug_settings.cpp
+++ b/cockatrice/src/settings/debug_settings.cpp
@@ -25,3 +25,8 @@ int DebugSettings::getLocalGamePlayerCount()
 {
     return getValue("playerCount", "localgame").toInt();
 }
+
+QString DebugSettings::getDeckPathForPlayer(const QString &playerName)
+{
+    return getValue(playerName, "localgame", "deck").toString();
+}

--- a/cockatrice/src/settings/debug_settings.h
+++ b/cockatrice/src/settings/debug_settings.h
@@ -15,6 +15,8 @@ public:
 
     bool getLocalGameOnStartup();
     int getLocalGamePlayerCount();
+
+    QString getDeckPathForPlayer(const QString &playerName);
 };
 
 #endif // DEBUG_SETTINGS_H


### PR DESCRIPTION
## Related Ticket(s)
- Requires #5408 to be merged first


## What will change with this Pull Request?

https://github.com/user-attachments/assets/21f05961-3142-4bba-aaf4-5db4941685ab

Added a debug setting that makes a player automatically load up a deck and ready upon joining a game.
Use it alongside the local game on startup in order to basically have a game going on startup.

Example config:

```
[localgame]
onStartup=true
playerCount=1
deck\Player 1=/Users/Ricky/Library/Application Support/Cockatrice/Cockatrice/decks/test.cod
deck\Player 2=/Users/Ricky/Library/Application Support/Cockatrice/Cockatrice/decks/_basics.cod
```