### PR TITLE
populate default debug.ini with more values

### DIFF
--- a/cockatrice/cockatrice.qrc
+++ b/cockatrice/cockatrice.qrc
@@ -41,6 +41,7 @@
         <file>resources/config/deckeditor.svg</file>
         <file>resources/config/shorcuts.svg</file>
         <file>resources/config/sound.svg</file>
+        <file>resources/config/debug.ini</file>
 
         <file>resources/counters/w.svg</file>
         <file>resources/counters/w_highlight.svg</file>

--- a/cockatrice/resources/config/debug.ini
+++ b/cockatrice/resources/config/debug.ini
@@ -1,0 +1,11 @@
+[debug]
+showCardId=false
+
+[localgame]
+onStartup=false
+playerCount=1
+;deck\Player 1=path/to/deck
+;deck\Player 2=path/to/deck
+
+; Fun Fact: You can assign a deck to your username and it will auto load and ready when you join a server game
+;deck\Your Username Here=path/to/deck

--- a/cockatrice/src/settings/debug_settings.cpp
+++ b/cockatrice/src/settings/debug_settings.cpp
@@ -5,14 +5,9 @@
 DebugSettings::DebugSettings(const QString &settingPath, QObject *parent)
     : SettingsManager(settingPath + "debug.ini", parent)
 {
-    // force debug.ini to be created if it doesn't exist yet
+    // Create the default debug.ini if it doesn't exist yet
     if (!QFile(settingPath + "debug.ini").exists()) {
-        setValue(false, "showCardId", "debug");
-
-        setValue(false, "onStartup", "localgame");
-        setValue(1, "playerCount", "localgame");
-        setValue("path/to/deck", "Player 1", "localgame", "deck");
-        setValue("path/to/deck", "Player 2", "localgame", "deck");
+        QFile::copy(":/resources/config/debug.ini", settingPath + "debug.ini");
     }
 }
 

--- a/cockatrice/src/settings/debug_settings.cpp
+++ b/cockatrice/src/settings/debug_settings.cpp
@@ -8,6 +8,11 @@ DebugSettings::DebugSettings(const QString &settingPath, QObject *parent)
     // force debug.ini to be created if it doesn't exist yet
     if (!QFile(settingPath + "debug.ini").exists()) {
         setValue(false, "showCardId", "debug");
+
+        setValue(false, "onStartup", "localgame");
+        setValue(1, "playerCount", "localgame");
+        setValue("path/to/deck", "Player 1", "localgame", "deck");
+        setValue("path/to/deck", "Player 2", "localgame", "deck");
     }
 }
 


### PR DESCRIPTION
## Short roundup of the initial problem

Add more values to default `debug.init` file to use as an example

## What will change with this Pull Request?

Default `debug.ini` is now

```
[debug]
showCardId=false

[localgame]
onStartup=false
playerCount=1
;deck\Player 1=path/to/deck
;deck\Player 2=path/to/deck

; Fun Fact: You can assign a deck to your username and it will auto load and ready when you join a server game
;deck\Your Username Here=path/to/deck
```