### PR TITLE
implement /card chat command

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -765,6 +765,12 @@ void TabGame::actSay()
     if (completer->popup()->isVisible())
         return;
 
+    if (sayEdit->text().startsWith("/card ")) {
+        cardInfoFrameWidget->setCard(sayEdit->text().mid(6));
+        sayEdit->clear();
+        return;
+    }
+
     if (!sayEdit->text().isEmpty()) {
         Command_GameSay cmd;
         cmd.set_message(sayEdit->text().toStdString());


### PR DESCRIPTION
## What will change with this Pull Request?

https://github.com/user-attachments/assets/8f19a832-c0ca-4c86-976a-212dfb0d9a79

Sending a message that begins with `/card` in chat will cause the game's card info widget to display that card, instead of sending a message in chat. 

Currently does not support different printings or fuzzy matching yet.


