### PR TITLE
improve shortcut search to split by word

### DIFF
--- a/cockatrice/src/settings/shortcut_treeview.cpp
+++ b/cockatrice/src/settings/shortcut_treeview.cpp
@@ -150,7 +150,7 @@ void ShortcutTreeView::currentChanged(const QModelIndex &current, const QModelIn
  */
 void ShortcutTreeView::updateSearchString(const QString &searchString)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     const auto skipEmptyParts = Qt::SkipEmptyParts;
 #else
     const auto skipEmptyParts = QString::SkipEmptyParts;

--- a/cockatrice/src/settings/shortcut_treeview.cpp
+++ b/cockatrice/src/settings/shortcut_treeview.cpp
@@ -10,15 +10,19 @@ ShortcutFilterProxyModel::ShortcutFilterProxyModel(QObject *parent) : QSortFilte
 }
 
 /**
- * @return True if this row or its parent matches the search string
+ * Appends the parent and source row together before doing the regex match.
  */
 bool ShortcutFilterProxyModel::filterAcceptsRow(const int sourceRow, const QModelIndex &sourceParent) const
 {
     QModelIndex nameIndex = sourceModel()->index(sourceRow, filterKeyColumn(), sourceParent);
     QModelIndex parentIndex = sourceModel()->index(sourceParent.row(), filterKeyColumn(), sourceParent.parent());
 
-    return sourceModel()->data(nameIndex).toString().contains(filterRegularExpression()) ||
-           sourceModel()->data(parentIndex).toString().contains(filterRegularExpression());
+    QString name = sourceModel()->data(nameIndex).toString();
+    QString parentName = sourceModel()->data(parentIndex).toString();
+
+    QString searchedString = parentName + " " + name;
+
+    return searchedString.contains(filterRegularExpression());
 }
 
 ShortcutTreeView::ShortcutTreeView(QWidget *parent) : QTreeView(parent)
@@ -140,8 +144,19 @@ void ShortcutTreeView::currentChanged(const QModelIndex &current, const QModelIn
     }
 }
 
+/**
+ * The search string is split by word.
+ * A String is a match as long as it contains all the words in the search string in order
+ */
 void ShortcutTreeView::updateSearchString(const QString &searchString)
 {
-    proxyModel->setFilterFixedString(searchString);
+    QStringList searchWords = searchString.split(" ", Qt::SkipEmptyParts);
+
+    auto escapeRegex = [](const QString &s) { return QRegularExpression::escape(s); };
+    std::transform(searchWords.begin(), searchWords.end(), searchWords.begin(), escapeRegex);
+
+    auto regex = QRegularExpression(searchWords.join(".*"), QRegularExpression::CaseInsensitiveOption);
+
+    proxyModel->setFilterRegularExpression(regex);
     expandAll();
 }

--- a/cockatrice/src/settings/shortcut_treeview.cpp
+++ b/cockatrice/src/settings/shortcut_treeview.cpp
@@ -150,7 +150,12 @@ void ShortcutTreeView::currentChanged(const QModelIndex &current, const QModelIn
  */
 void ShortcutTreeView::updateSearchString(const QString &searchString)
 {
-    QStringList searchWords = searchString.split(" ", Qt::SkipEmptyParts);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    const auto skipEmptyParts = Qt::SkipEmptyParts;
+#else
+    const auto skipEmptyParts = QString::SkipEmptyParts;
+#endif
+    QStringList searchWords = searchString.split(" ", skipEmptyParts);
 
     auto escapeRegex = [](const QString &s) { return QRegularExpression::escape(s); };
     std::transform(searchWords.begin(), searchWords.end(), searchWords.begin(), escapeRegex);

--- a/cockatrice/src/settings/shortcut_treeview.h
+++ b/cockatrice/src/settings/shortcut_treeview.h
@@ -7,7 +7,7 @@
 #include <QTreeView>
 
 /**
- * Custom implementation of QSortFilterProxyModel that also searches in the parent's string when filtering
+ * Custom implementation of QSortFilterProxyModel that appends the source and parent strings together when filtering
  */
 class ShortcutFilterProxyModel : public QSortFilterProxyModel
 {


### PR DESCRIPTION
## Short roundup of the initial problem

Shortcut search still requires the fixed string to exactly match a continuous section of either the source or the parent. It can't  only match only some words with gaps between, or have the match be split across levels.  

## What will change with this Pull Request?

https://github.com/user-attachments/assets/e11ac8fa-bcf0-4e8c-9f19-f49b288f33fc

- Shortcut search now splits the search by word and inserts `.*` between each word
- Shortcut search now appends the parent and source together, so the single combined regex search works across both levels