### PR TITLE
add ctrl enter as shortcut for ok in load deck from clipboard

### DIFF
--- a/cockatrice/src/dialogs/dlg_load_deck_from_clipboard.cpp
+++ b/cockatrice/src/dialogs/dlg_load_deck_from_clipboard.cpp
@@ -71,3 +71,13 @@ void DlgLoadDeckFromClipboard::actOK()
         delete deckLoader;
     }
 }
+
+void DlgLoadDeckFromClipboard::keyPressEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Return && event->modifiers() & Qt::ControlModifier) {
+        event->accept();
+        actOK();
+        return;
+    }
+    QDialog::keyPressEvent(event);
+}

--- a/cockatrice/src/dialogs/dlg_load_deck_from_clipboard.h
+++ b/cockatrice/src/dialogs/dlg_load_deck_from_clipboard.h
@@ -26,6 +26,9 @@ public:
     {
         return deckList;
     }
+
+protected:
+    void keyPressEvent(QKeyEvent *event) override;
 };
 
 #endif


### PR DESCRIPTION
## Related Ticket(s)
- #4929

## Short roundup of the initial problem

`Ctrl+Enter` shortcut isn't implemented for `load deck from clipboard` dialogue

## What will change with this Pull Request?

https://github.com/user-attachments/assets/fc68160d-d90c-49d9-b967-ace37116d6bb

Implemented `Ctrl+Enter` shortcut for `load deck from clipboard` dialogue
