### PR TITLE
Remember last opened directory when loading decks

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -56,6 +56,7 @@ set(cockatrice_SOURCES
     src/dialogs/dlg_tip_of_the_day.cpp
     src/dialogs/dlg_update.cpp
     src/dialogs/dlg_view_log.cpp
+    src/dialogs/dlg_load_deck.cpp
     src/game/filters/filter_string.cpp
     src/game/filters/filter_builder.cpp
     src/game/filters/filter_tree.cpp

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -5,6 +5,7 @@
 #include "../../client/ui/widgets/cards/card_info_frame_widget.h"
 #include "../../deck/deck_list_model.h"
 #include "../../deck/deck_stats_interface.h"
+#include "../../dialogs/dlg_load_deck.h"
 #include "../../dialogs/dlg_load_deck_from_clipboard.h"
 #include "../../game/cards/card_database_manager.h"
 #include "../../game/cards/card_database_model.h"
@@ -927,19 +928,9 @@ void TabDeckEditor::actLoadDeck()
         return;
     }
 
-    QFileDialog dialog(this, tr("Load deck"));
-
-    QString startingDir = SettingsCache::instance().recents().getLatestDeckDirPath();
-    if (startingDir.isEmpty()) {
-        startingDir = SettingsCache::instance().getDeckPath();
-    }
-
-    dialog.setDirectory(startingDir);
-    dialog.setNameFilters(DeckLoader::fileNameFilters);
+    DlgLoadDeck dialog(this);
     if (!dialog.exec())
         return;
-
-    SettingsCache::instance().recents().setLatestDeckDirPath(dialog.directory().absolutePath());
 
     QString fileName = dialog.selectedFiles().at(0);
     openDeckFromFile(fileName, deckOpenLocation);

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -928,10 +928,18 @@ void TabDeckEditor::actLoadDeck()
     }
 
     QFileDialog dialog(this, tr("Load deck"));
-    dialog.setDirectory(SettingsCache::instance().getDeckPath());
+
+    QString startingDir = SettingsCache::instance().recents().getLatestDeckDirPath();
+    if (startingDir.isEmpty()) {
+        startingDir = SettingsCache::instance().getDeckPath();
+    }
+
+    dialog.setDirectory(startingDir);
     dialog.setNameFilters(DeckLoader::fileNameFilters);
     if (!dialog.exec())
         return;
+
+    SettingsCache::instance().recents().setLatestDeckDirPath(dialog.directory().absolutePath());
 
     QString fileName = dialog.selectedFiles().at(0);
     openDeckFromFile(fileName, deckOpenLocation);

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -4,6 +4,7 @@
 #include "../../deck/deck_loader.h"
 #include "../../deck/deck_view.h"
 #include "../../dialogs/dlg_create_game.h"
+#include "../../dialogs/dlg_load_deck.h"
 #include "../../dialogs/dlg_load_remote_deck.h"
 #include "../../dialogs/dlg_manage_sets.h"
 #include "../../game/board/arrow_item.h"
@@ -288,19 +289,9 @@ void TabGame::refreshShortcuts()
 
 void DeckViewContainer::loadLocalDeck()
 {
-    QFileDialog dialog(this, tr("Load deck"));
-
-    QString startingDir = SettingsCache::instance().recents().getLatestDeckDirPath();
-    if (startingDir.isEmpty()) {
-        startingDir = SettingsCache::instance().getDeckPath();
-    }
-
-    dialog.setDirectory(startingDir);
-    dialog.setNameFilters(DeckLoader::fileNameFilters);
+    DlgLoadDeck dialog(this);
     if (!dialog.exec())
         return;
-
-    SettingsCache::instance().recents().setLatestDeckDirPath(dialog.directory().absolutePath());
 
     loadDeckFromFile(dialog.selectedFiles().at(0));
 }

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -289,10 +289,18 @@ void TabGame::refreshShortcuts()
 void DeckViewContainer::loadLocalDeck()
 {
     QFileDialog dialog(this, tr("Load deck"));
-    dialog.setDirectory(SettingsCache::instance().getDeckPath());
+
+    QString startingDir = SettingsCache::instance().recents().getLatestDeckDirPath();
+    if (startingDir.isEmpty()) {
+        startingDir = SettingsCache::instance().getDeckPath();
+    }
+
+    dialog.setDirectory(startingDir);
     dialog.setNameFilters(DeckLoader::fileNameFilters);
     if (!dialog.exec())
         return;
+
+    SettingsCache::instance().recents().setLatestDeckDirPath(dialog.directory().absolutePath());
 
     loadDeckFromFile(dialog.selectedFiles().at(0));
 }

--- a/cockatrice/src/dialogs/dlg_load_deck.cpp
+++ b/cockatrice/src/dialogs/dlg_load_deck.cpp
@@ -1,0 +1,22 @@
+#include "dlg_load_deck.h"
+
+#include "../deck/deck_loader.h"
+#include "../settings/cache_settings.h"
+
+DlgLoadDeck::DlgLoadDeck(QWidget *parent) : QFileDialog(parent, tr("Load Deck"))
+{
+    QString startingDir = SettingsCache::instance().recents().getLatestDeckDirPath();
+    if (startingDir.isEmpty()) {
+        startingDir = SettingsCache::instance().getDeckPath();
+    }
+
+    setDirectory(startingDir);
+    setNameFilters(DeckLoader::fileNameFilters);
+
+    connect(this, &DlgLoadDeck::accepted, this, &DlgLoadDeck::actAccepted);
+}
+
+void DlgLoadDeck::actAccepted()
+{
+    SettingsCache::instance().recents().setLatestDeckDirPath(directory().absolutePath());
+}

--- a/cockatrice/src/dialogs/dlg_load_deck.h
+++ b/cockatrice/src/dialogs/dlg_load_deck.h
@@ -1,0 +1,21 @@
+
+#ifndef DLG_LOAD_DECK_H
+#define DLG_LOAD_DECK_H
+
+#include <QFileDialog>
+
+/**
+ * The file dialog for "Load Deck" operations.
+ * Handles remembering the most recently used deck loading directory.
+ */
+class DlgLoadDeck : public QFileDialog
+{
+    Q_OBJECT
+
+    void actAccepted();
+
+public:
+    explicit DlgLoadDeck(QWidget *parent = nullptr);
+};
+
+#endif // DLG_LOAD_DECK_H

--- a/cockatrice/src/settings/recents_settings.cpp
+++ b/cockatrice/src/settings/recents_settings.cpp
@@ -30,3 +30,13 @@ void RecentsSettings::updateRecentlyOpenedDeckPaths(const QString &deckPath)
     setValue(deckPaths, "deckpaths", "deckbuilder");
     emit recentlyOpenedDeckPathsChanged();
 }
+
+QString RecentsSettings::getLatestDeckDirPath()
+{
+    return getValue("latestDeckDir", "dirs").toString();
+}
+
+void RecentsSettings::setLatestDeckDirPath(const QString &dirPath)
+{
+    setValue(dirPath, "latestDeckDir", "dirs");
+}

--- a/cockatrice/src/settings/recents_settings.h
+++ b/cockatrice/src/settings/recents_settings.h
@@ -16,6 +16,9 @@ public:
     void clearRecentlyOpenedDeckPaths();
     void updateRecentlyOpenedDeckPaths(const QString &deckPath);
 
+    QString getLatestDeckDirPath();
+    void setLatestDeckDirPath(const QString &dirPath);
+
 signals:
     void recentlyOpenedDeckPathsChanged();
 };


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5402 

## What will change with this Pull Request?

https://github.com/user-attachments/assets/bf517bf4-42cb-45a5-82c6-88e3261425cb

- Remember the last opened directory when loading decks and start at that directory when you `load deck` again
  - Setting is stored in `dirs/latestDeckDir` in `recents.ini`
- Affects `Load deck` action in both Deck Editor and Game Lobby
