### PR TITLE
Differentiate logging in order to silence certain modules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ compile_commands.json
 .vscode/
 .cache
 .gdb_history
+cockatrice/resources/config/qtlogging.ini

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -164,8 +164,9 @@ set(cockatrice_SOURCES
 
 add_subdirectory(sounds)
 add_subdirectory(themes)
-configure_file(${CMAKE_SOURCE_DIR}/cockatrice/resources/config/qtlogging.ini
-        ${CMAKE_BINARY_DIR}/cockatrice/qtlogging.ini COPYONLY)
+configure_file(
+  ${CMAKE_SOURCE_DIR}/cockatrice/resources/config/qtlogging.ini ${CMAKE_BINARY_DIR}/cockatrice/qtlogging.ini COPYONLY
+)
 
 set(cockatrice_RESOURCES cockatrice.qrc)
 

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -164,6 +164,8 @@ set(cockatrice_SOURCES
 
 add_subdirectory(sounds)
 add_subdirectory(themes)
+configure_file(${CMAKE_SOURCE_DIR}/cockatrice/resources/config/qtlogging.ini
+        ${CMAKE_BINARY_DIR}/cockatrice/qtlogging.ini COPYONLY)
 
 set(cockatrice_RESOURCES cockatrice.qrc)
 

--- a/cockatrice/cockatrice.qrc
+++ b/cockatrice/cockatrice.qrc
@@ -42,6 +42,7 @@
         <file>resources/config/shorcuts.svg</file>
         <file>resources/config/sound.svg</file>
         <file>resources/config/debug.ini</file>
+        <file>resources/config/qtlogging.ini</file>
 
         <file>resources/counters/w.svg</file>
         <file>resources/counters/w_highlight.svg</file>

--- a/cockatrice/resources/config/qtlogging.ini
+++ b/cockatrice/resources/config/qtlogging.ini
@@ -1,0 +1,2 @@
+[Rules]
+picture_loader.debug = true

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -136,6 +136,9 @@ int main(int argc, char *argv[])
     SetUnhandledExceptionFilter(CockatriceUnhandledExceptionFilter);
 #endif
 
+    // Set the QT_LOGGING_CONF environment variable
+    qputenv("QT_LOGGING_CONF", "./qtlogging.ini");
+
     QApplication app(argc, argv);
 
     QObject::connect(&app, &QApplication::lastWindowClosed, &app, &QApplication::quit);


### PR DESCRIPTION
## Short roundup of the initial problem
We just use qDebug() for now, which means there is no way to filter out certain debug messages on demand. If we use qCDebug(<category>) we can configure certain <category>s through qtlogging.ini and selectively enable/disable them.

## What will change with this Pull Request?
- Introduce a qtlogging.ini
- Add a picture_loader class to silence the picture loader being very verbose.
