### PR TITLE
get swap cards button to work with multi-selections

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/tab_deck_editor.h
@@ -111,6 +111,7 @@ private:
     void addCardHelper(QString zoneName);
     void offsetCountAtIndex(const QModelIndex &idx, int offset);
     void decrementCardHelper(QString zoneName);
+    bool swapCard(const QModelIndex &idx);
     void recursiveExpand(const QModelIndex &index);
     void openDeckFromFile(const QString &fileName, DeckOpenLocation deckOpenLocation);
 


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5175

## Short roundup of the initial problem

The swap cards button interacts weirdly with multi-selections

## What will change with this Pull Request?

https://github.com/user-attachments/assets/a54e5871-2cd0-4ace-bbe4-8b331a94ddaa

The swap cards button now works as expected with multi-selections