### PR TITLE
Refactor window_main to new Qt Slot/Signal syntax

### DIFF
--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -193,7 +193,7 @@ void MainWindow::activateAccepted()
 void MainWindow::actConnect()
 {
     dlgConnect = new DlgConnect(this);
-    connect(dlgConnect, SIGNAL(sigStartForgotPasswordRequest()), this, &MainWindow::actForgotPasswordRequest);
+    connect(dlgConnect, &DlgConnect::sigStartForgotPasswordRequest, this, &MainWindow::actForgotPasswordRequest);
 
     if (dlgConnect->exec()) {
         client->connectToServer(dlgConnect->getHost(), static_cast<unsigned int>(dlgConnect->getPort()),
@@ -717,7 +717,7 @@ void MainWindow::createActions()
     connect(aVisualDeckStorage, &QAction::triggered, this, &MainWindow::actVisualDeckStorage);
     aFullScreen = new QAction(this);
     aFullScreen->setCheckable(true);
-    connect(aFullScreen, SIGNAL(toggled(bool)), this, SLOT(actFullScreen(bool)));
+    connect(aFullScreen, &QAction::toggled, this, &MainWindow::actFullScreen);
     aRegister = new QAction(this);
     connect(aRegister, &QAction::triggered, this, &MainWindow::actRegister);
     aForgotPassword = new QAction(this);
@@ -1157,8 +1157,7 @@ void MainWindow::actCheckCardUpdates()
 
     connect(cardUpdateProcess, &QProcess::errorOccurred, this, &MainWindow::cardUpdateError);
 
-    connect(cardUpdateProcess, SIGNAL(finished(int, QProcess::ExitStatus)), this,
-            SLOT(cardUpdateFinished(int, QProcess::ExitStatus)));
+    connect(cardUpdateProcess, &QProcess::finished, this, &MainWindow::cardUpdateFinished);
 
     // full "run the update" command; leave empty if not present
     QString updaterCmd;

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -834,7 +834,8 @@ MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent), localServer(nullptr), bHasActivated(false), askedForDbUpdater(false),
       cardUpdateProcess(nullptr), logviewDialog(nullptr)
 {
-    connect(&SettingsCache::instance(), SIGNAL(pixmapCacheSizeChanged(int)), this, SLOT(pixmapCacheSizeChanged(int)));
+    connect(&SettingsCache::instance(), &SettingsCache::pixmapCacheSizeChanged, this,
+            &MainWindow::pixmapCacheSizeChanged);
     pixmapCacheSizeChanged(SettingsCache::instance().getPixmapCacheSize());
 
     client = new RemoteClient;
@@ -866,9 +867,9 @@ MainWindow::MainWindow(QWidget *parent)
     createMenus();
 
     tabSupervisor = new TabSupervisor(client);
-    connect(tabSupervisor, SIGNAL(setMenu(QList<QMenu *>)), this, SLOT(updateTabMenu(QList<QMenu *>)));
-    connect(tabSupervisor, SIGNAL(localGameEnded()), this, SLOT(localGameEnded()));
-    connect(tabSupervisor, SIGNAL(showWindowIfHidden()), this, SLOT(showWindowIfHidden()));
+    connect(tabSupervisor, &TabSupervisor::setMenu, this, &MainWindow::updateTabMenu);
+    connect(tabSupervisor, &TabSupervisor::localGameEnded, this, &MainWindow::localGameEnded);
+    connect(tabSupervisor, &TabSupervisor::showWindowIfHidden, this, &MainWindow::showWindowIfHidden);
     tabSupervisor->addDeckEditorTab(nullptr);
 
     setCentralWidget(tabSupervisor);
@@ -884,19 +885,20 @@ MainWindow::MainWindow(QWidget *parent)
         createTrayIcon();
     }
 
-    connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
+    connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
+            &MainWindow::refreshShortcuts);
     refreshShortcuts();
 
     if (SettingsCache::instance().getVisualDeckStorageShowOnLoad()) {
-        connect(CardDatabaseManager::getInstance(), SIGNAL(cardDatabaseLoadingFinished()), tabSupervisor,
-                SLOT(addVisualDeckStorageTab()));
+        connect(CardDatabaseManager::getInstance(), &CardDatabase::cardDatabaseLoadingFinished, tabSupervisor,
+                &TabSupervisor::addVisualDeckStorageTab);
     }
-    connect(CardDatabaseManager::getInstance(), SIGNAL(cardDatabaseLoadingFailed()), this,
-            SLOT(cardDatabaseLoadingFailed()));
-    connect(CardDatabaseManager::getInstance(), SIGNAL(cardDatabaseNewSetsFound(int, QStringList)), this,
-            SLOT(cardDatabaseNewSetsFound(int, QStringList)));
-    connect(CardDatabaseManager::getInstance(), SIGNAL(cardDatabaseAllNewSetsEnabled()), this,
-            SLOT(cardDatabaseAllNewSetsEnabled()));
+    connect(CardDatabaseManager::getInstance(), &CardDatabase::cardDatabaseLoadingFailed, this,
+            &MainWindow::cardDatabaseLoadingFailed);
+    connect(CardDatabaseManager::getInstance(), &CardDatabase::cardDatabaseNewSetsFound, this,
+            &MainWindow::cardDatabaseNewSetsFound);
+    connect(CardDatabaseManager::getInstance(), &CardDatabase::cardDatabaseAllNewSetsEnabled, this,
+            &MainWindow::cardDatabaseAllNewSetsEnabled);
 
     tip = new DlgTipOfTheDay();
 

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -1157,7 +1157,8 @@ void MainWindow::actCheckCardUpdates()
 
     connect(cardUpdateProcess, &QProcess::errorOccurred, this, &MainWindow::cardUpdateError);
 
-    connect(cardUpdateProcess, &QProcess::finished, this, &MainWindow::cardUpdateFinished);
+    connect(cardUpdateProcess, qOverload<int, QProcess::ExitStatus>(&QProcess::finished), this,
+            &MainWindow::cardUpdateFinished);
 
     // full "run the update" command; leave empty if not present
     QString updaterCmd;

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -193,7 +193,7 @@ void MainWindow::activateAccepted()
 void MainWindow::actConnect()
 {
     dlgConnect = new DlgConnect(this);
-    connect(dlgConnect, SIGNAL(sigStartForgotPasswordRequest()), this, SLOT(actForgotPasswordRequest()));
+    connect(dlgConnect, SIGNAL(sigStartForgotPasswordRequest()), this, &MainWindow::actForgotPasswordRequest);
 
     if (dlgConnect->exec()) {
         client->connectToServer(dlgConnect->getHost(), static_cast<unsigned int>(dlgConnect->getPort()),
@@ -703,58 +703,58 @@ void MainWindow::retranslateUi()
 void MainWindow::createActions()
 {
     aConnect = new QAction(this);
-    connect(aConnect, SIGNAL(triggered()), this, SLOT(actConnect()));
+    connect(aConnect, &QAction::triggered, this, &MainWindow::actConnect);
     aDisconnect = new QAction(this);
     aDisconnect->setEnabled(false);
-    connect(aDisconnect, SIGNAL(triggered()), this, SLOT(actDisconnect()));
+    connect(aDisconnect, &QAction::triggered, this, &MainWindow::actDisconnect);
     aSinglePlayer = new QAction(this);
-    connect(aSinglePlayer, SIGNAL(triggered()), this, SLOT(actSinglePlayer()));
+    connect(aSinglePlayer, &QAction::triggered, this, &MainWindow::actSinglePlayer);
     aWatchReplay = new QAction(this);
-    connect(aWatchReplay, SIGNAL(triggered()), this, SLOT(actWatchReplay()));
+    connect(aWatchReplay, &QAction::triggered, this, &MainWindow::actWatchReplay);
     aDeckEditor = new QAction(this);
-    connect(aDeckEditor, SIGNAL(triggered()), this, SLOT(actDeckEditor()));
+    connect(aDeckEditor, &QAction::triggered, this, &MainWindow::actDeckEditor);
     aVisualDeckStorage = new QAction(this);
-    connect(aVisualDeckStorage, SIGNAL(triggered()), this, SLOT(actVisualDeckStorage()));
+    connect(aVisualDeckStorage, &QAction::triggered, this, &MainWindow::actVisualDeckStorage);
     aFullScreen = new QAction(this);
     aFullScreen->setCheckable(true);
     connect(aFullScreen, SIGNAL(toggled(bool)), this, SLOT(actFullScreen(bool)));
     aRegister = new QAction(this);
-    connect(aRegister, SIGNAL(triggered()), this, SLOT(actRegister()));
+    connect(aRegister, &QAction::triggered, this, &MainWindow::actRegister);
     aForgotPassword = new QAction(this);
-    connect(aForgotPassword, SIGNAL(triggered()), this, SLOT(actForgotPasswordRequest()));
+    connect(aForgotPassword, &QAction::triggered, this, &MainWindow::actForgotPasswordRequest);
     aSettings = new QAction(this);
-    connect(aSettings, SIGNAL(triggered()), this, SLOT(actSettings()));
+    connect(aSettings, &QAction::triggered, this, &MainWindow::actSettings);
     aExit = new QAction(this);
-    connect(aExit, SIGNAL(triggered()), this, SLOT(actExit()));
+    connect(aExit, &QAction::triggered, this, &MainWindow::actExit);
 
     aManageSets = new QAction(QString(), this);
-    connect(aManageSets, SIGNAL(triggered()), this, SLOT(actManageSets()));
+    connect(aManageSets, &QAction::triggered, this, &MainWindow::actManageSets);
     aEditTokens = new QAction(QString(), this);
-    connect(aEditTokens, SIGNAL(triggered()), this, SLOT(actEditTokens()));
+    connect(aEditTokens, &QAction::triggered, this, &MainWindow::actEditTokens);
     aOpenCustomFolder = new QAction(QString(), this);
-    connect(aOpenCustomFolder, SIGNAL(triggered()), this, SLOT(actOpenCustomFolder()));
+    connect(aOpenCustomFolder, &QAction::triggered, this, &MainWindow::actOpenCustomFolder);
     aOpenCustomsetsFolder = new QAction(QString(), this);
-    connect(aOpenCustomsetsFolder, SIGNAL(triggered()), this, SLOT(actOpenCustomsetsFolder()));
+    connect(aOpenCustomsetsFolder, &QAction::triggered, this, &MainWindow::actOpenCustomsetsFolder);
     aAddCustomSet = new QAction(QString(), this);
-    connect(aAddCustomSet, SIGNAL(triggered()), this, SLOT(actAddCustomSet()));
+    connect(aAddCustomSet, &QAction::triggered, this, &MainWindow::actAddCustomSet);
     aReloadCardDatabase = new QAction(QString(), this);
-    connect(aReloadCardDatabase, SIGNAL(triggered()), this, SLOT(actReloadCardDatabase()));
+    connect(aReloadCardDatabase, &QAction::triggered, this, &MainWindow::actReloadCardDatabase);
 
     aAbout = new QAction(this);
-    connect(aAbout, SIGNAL(triggered()), this, SLOT(actAbout()));
+    connect(aAbout, &QAction::triggered, this, &MainWindow::actAbout);
     aTips = new QAction(this);
-    connect(aTips, SIGNAL(triggered()), this, SLOT(actTips()));
+    connect(aTips, &QAction::triggered, this, &MainWindow::actTips);
     aUpdate = new QAction(this);
-    connect(aUpdate, SIGNAL(triggered()), this, SLOT(actUpdate()));
+    connect(aUpdate, &QAction::triggered, this, &MainWindow::actUpdate);
     aCheckCardUpdates = new QAction(this);
-    connect(aCheckCardUpdates, SIGNAL(triggered()), this, SLOT(actCheckCardUpdates()));
+    connect(aCheckCardUpdates, &QAction::triggered, this, &MainWindow::actCheckCardUpdates);
     aViewLog = new QAction(this);
-    connect(aViewLog, SIGNAL(triggered()), this, SLOT(actViewLog()));
+    connect(aViewLog, &QAction::triggered, this, &MainWindow::actViewLog);
     aOpenSettingsFolder = new QAction(this);
     connect(aOpenSettingsFolder, &QAction::triggered, this, &MainWindow::actOpenSettingsFolder);
 
     aShow = new QAction(this);
-    connect(aShow, SIGNAL(triggered()), this, SLOT(actShow()));
+    connect(aShow, &QAction::triggered, this, &MainWindow::actShow);
 
 #if defined(__APPLE__) /* For OSX */
     aSettings->setMenuRole(QAction::PreferencesRole);

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -838,29 +838,25 @@ MainWindow::MainWindow(QWidget *parent)
     pixmapCacheSizeChanged(SettingsCache::instance().getPixmapCacheSize());
 
     client = new RemoteClient;
-    connect(client, SIGNAL(connectionClosedEventReceived(const Event_ConnectionClosed &)), this,
-            SLOT(processConnectionClosedEvent(const Event_ConnectionClosed &)));
-    connect(client, SIGNAL(serverShutdownEventReceived(const Event_ServerShutdown &)), this,
-            SLOT(processServerShutdownEvent(const Event_ServerShutdown &)));
-    connect(client, SIGNAL(loginError(Response::ResponseCode, QString, quint32, QList<QString>)), this,
-            SLOT(loginError(Response::ResponseCode, QString, quint32, QList<QString>)));
-    connect(client, SIGNAL(socketError(const QString &)), this, SLOT(socketError(const QString &)));
-    connect(client, SIGNAL(serverTimeout()), this, SLOT(serverTimeout()));
-    connect(client, SIGNAL(statusChanged(ClientStatus)), this, SLOT(statusChanged(ClientStatus)));
-    connect(client, SIGNAL(protocolVersionMismatch(int, int)), this, SLOT(protocolVersionMismatch(int, int)));
-    connect(client, SIGNAL(userInfoChanged(const ServerInfo_User &)), this,
-            SLOT(userInfoReceived(const ServerInfo_User &)), Qt::BlockingQueuedConnection);
-    connect(client, SIGNAL(notifyUserAboutUpdate()), this, SLOT(notifyUserAboutUpdate()));
-    connect(client, SIGNAL(registerAccepted()), this, SLOT(registerAccepted()));
-    connect(client, SIGNAL(registerAcceptedNeedsActivate()), this, SLOT(registerAcceptedNeedsActivate()));
-    connect(client, SIGNAL(registerError(Response::ResponseCode, QString, quint32)), this,
-            SLOT(registerError(Response::ResponseCode, QString, quint32)));
-    connect(client, SIGNAL(activateAccepted()), this, SLOT(activateAccepted()));
-    connect(client, SIGNAL(activateError()), this, SLOT(activateError()));
-    connect(client, SIGNAL(sigForgotPasswordSuccess()), this, SLOT(forgotPasswordSuccess()));
-    connect(client, SIGNAL(sigForgotPasswordError()), this, SLOT(forgotPasswordError()));
-    connect(client, SIGNAL(sigPromptForForgotPasswordReset()), this, SLOT(promptForgotPasswordReset()));
-    connect(client, SIGNAL(sigPromptForForgotPasswordChallenge()), this, SLOT(promptForgotPasswordChallenge()));
+    connect(client, &RemoteClient::connectionClosedEventReceived, this, &MainWindow::processConnectionClosedEvent);
+    connect(client, &RemoteClient::serverShutdownEventReceived, this, &MainWindow::processServerShutdownEvent);
+    connect(client, &RemoteClient::loginError, this, &MainWindow::loginError);
+    connect(client, &RemoteClient::socketError, this, &MainWindow::socketError);
+    connect(client, &RemoteClient::serverTimeout, this, &MainWindow::serverTimeout);
+    connect(client, &RemoteClient::statusChanged, this, &MainWindow::statusChanged);
+    connect(client, &RemoteClient::protocolVersionMismatch, this, &MainWindow::protocolVersionMismatch);
+    connect(client, &RemoteClient::userInfoChanged, this, &MainWindow::userInfoReceived, Qt::BlockingQueuedConnection);
+    connect(client, &RemoteClient::notifyUserAboutUpdate, this, &MainWindow::notifyUserAboutUpdate);
+    connect(client, &RemoteClient::registerAccepted, this, &MainWindow::registerAccepted);
+    connect(client, &RemoteClient::registerAcceptedNeedsActivate, this, &MainWindow::registerAcceptedNeedsActivate);
+    connect(client, &RemoteClient::registerError, this, &MainWindow::registerError);
+    connect(client, &RemoteClient::activateAccepted, this, &MainWindow::activateAccepted);
+    connect(client, &RemoteClient::activateError, this, &MainWindow::activateError);
+    connect(client, &RemoteClient::sigForgotPasswordSuccess, this, &MainWindow::forgotPasswordSuccess);
+    connect(client, &RemoteClient::sigForgotPasswordError, this, &MainWindow::forgotPasswordError);
+    connect(client, &RemoteClient::sigPromptForForgotPasswordReset, this, &MainWindow::promptForgotPasswordReset);
+    connect(client, &RemoteClient::sigPromptForForgotPasswordChallenge, this,
+            &MainWindow::promptForgotPasswordChallenge);
 
     clientThread = new QThread(this);
     client->moveToThread(clientThread);


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5202

## What will change with this Pull Request?
Update all usages of slot/signal in `window_main.cpp` to use the new syntax
