### PR TITLE
Refactor tab_supervisor to new Qt Slot/Signal syntax

### DIFF
--- a/cockatrice/src/client/game_logic/abstract_client.h
+++ b/cockatrice/src/client/game_logic/abstract_client.h
@@ -48,6 +48,7 @@ class AbstractClient : public QObject
     Q_OBJECT
 signals:
     void statusChanged(ClientStatus _status);
+    void maxPingTime(int seconds, int maxSeconds);
 
     // Room events
     void roomEventReceived(const RoomEvent &event);

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -9,6 +9,7 @@
 #include "pb/event_notify_user.pb.h"
 #include "pb/event_user_message.pb.h"
 #include "pb/game_event_container.pb.h"
+#include "pb/game_replay.pb.h"
 #include "pb/moderator_commands.pb.h"
 #include "pb/room_commands.pb.h"
 #include "pb/room_event.pb.h"

--- a/cockatrice/src/server/remote/remote_client.h
+++ b/cockatrice/src/server/remote/remote_client.h
@@ -13,7 +13,6 @@ class RemoteClient : public AbstractClient
 {
     Q_OBJECT
 signals:
-    void maxPingTime(int seconds, int maxSeconds);
     void serverTimeout();
     void loginError(Response::ResponseCode resp, QString reasonStr, quint32 endTime, QList<QString> missingFeatures);
     void registerError(Response::ResponseCode resp, QString reasonStr, quint32 endTime);


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5423

## What will change with this Pull Request?
Update all usages of slot/signal in `tab_supervisor.cpp` to use the new syntax