### PR TITLE
Refactor files in src/utility and src/deck to new Qt Slot/Signal syntax

### DIFF
--- a/cockatrice/src/deck/deck_list_model.cpp
+++ b/cockatrice/src/deck/deck_list_model.cpp
@@ -18,8 +18,8 @@ DeckListModel::DeckListModel(QObject *parent)
     : QAbstractItemModel(parent), lastKnownColumn(1), lastKnownOrder(Qt::AscendingOrder)
 {
     deckList = new DeckLoader;
-    connect(deckList, SIGNAL(deckLoaded()), this, SLOT(rebuildTree()));
-    connect(deckList, SIGNAL(deckHashChanged()), this, SIGNAL(deckHashChanged()));
+    connect(deckList, &DeckLoader::deckLoaded, this, &DeckListModel::rebuildTree);
+    connect(deckList, &DeckLoader::deckHashChanged, this, &DeckListModel::deckHashChanged);
     root = new InnerDecklistNode;
 }
 
@@ -474,8 +474,8 @@ void DeckListModel::setDeckList(DeckLoader *_deck)
 {
     delete deckList;
     deckList = _deck;
-    connect(deckList, SIGNAL(deckLoaded()), this, SLOT(rebuildTree()));
-    connect(deckList, SIGNAL(deckHashChanged()), this, SIGNAL(deckHashChanged()));
+    connect(deckList, &DeckLoader::deckLoaded, this, &DeckListModel::rebuildTree);
+    connect(deckList, &DeckLoader::deckHashChanged, this, &DeckListModel::deckHashChanged);
     rebuildTree();
 }
 

--- a/cockatrice/src/deck/deck_stats_interface.cpp
+++ b/cockatrice/src/deck/deck_stats_interface.cpp
@@ -73,7 +73,7 @@ struct CopyIfNotAToken
     DeckList &destination;
 
     CopyIfNotAToken(CardDatabase &_cardDatabase, DeckList &_destination)
-        : cardDatabase(_cardDatabase), destination(_destination) {};
+        : cardDatabase(_cardDatabase), destination(_destination){};
 
     void operator()(const InnerDecklistNode *node, const DecklistCardNode *card) const
     {

--- a/cockatrice/src/deck/deck_stats_interface.cpp
+++ b/cockatrice/src/deck/deck_stats_interface.cpp
@@ -14,7 +14,7 @@ DeckStatsInterface::DeckStatsInterface(CardDatabase &_cardDatabase, QObject *par
     : QObject(parent), cardDatabase(_cardDatabase)
 {
     manager = new QNetworkAccessManager(this);
-    connect(manager, SIGNAL(finished(QNetworkReply *)), this, SLOT(queryFinished(QNetworkReply *)));
+    connect(manager, &QNetworkAccessManager::finished, this, &DeckStatsInterface::queryFinished);
 }
 
 void DeckStatsInterface::queryFinished(QNetworkReply *reply)
@@ -73,7 +73,7 @@ struct CopyIfNotAToken
     DeckList &destination;
 
     CopyIfNotAToken(CardDatabase &_cardDatabase, DeckList &_destination)
-        : cardDatabase(_cardDatabase), destination(_destination){};
+        : cardDatabase(_cardDatabase), destination(_destination) {};
 
     void operator()(const InnerDecklistNode *node, const DecklistCardNode *card) const
     {

--- a/cockatrice/src/deck/deck_view.cpp
+++ b/cockatrice/src/deck/deck_view.cpp
@@ -496,9 +496,9 @@ DeckView::DeckView(QWidget *parent) : QGraphicsView(parent)
     setRenderHints(QPainter::TextAntialiasing | QPainter::Antialiasing /* | QPainter::SmoothPixmapTransform*/);
     setScene(deckViewScene);
 
-    connect(deckViewScene, SIGNAL(sceneRectChanged(const QRectF &)), this, SLOT(updateSceneRect(const QRectF &)));
-    connect(deckViewScene, SIGNAL(newCardAdded(AbstractCardItem *)), this, SIGNAL(newCardAdded(AbstractCardItem *)));
-    connect(deckViewScene, SIGNAL(sideboardPlanChanged()), this, SIGNAL(sideboardPlanChanged()));
+    connect(deckViewScene, &DeckViewScene::sceneRectChanged, this, &DeckView::updateSceneRect);
+    connect(deckViewScene, &DeckViewScene::newCardAdded, this, &DeckView::newCardAdded);
+    connect(deckViewScene, &DeckViewScene::sideboardPlanChanged, this, &DeckView::sideboardPlanChanged);
 }
 
 void DeckView::resizeEvent(QResizeEvent *event)

--- a/cockatrice/src/utility/sequence_edit.cpp
+++ b/cockatrice/src/utility/sequence_edit.cpp
@@ -24,8 +24,8 @@ SequenceEdit::SequenceEdit(const QString &_shortcutName, QWidget *parent) : QWid
     layout->addWidget(clearButton);
     layout->addWidget(defaultButton);
 
-    connect(clearButton, SIGNAL(clicked()), this, SLOT(removeLastShortcut()));
-    connect(defaultButton, SIGNAL(clicked()), this, SLOT(restoreDefault()));
+    connect(clearButton, &QPushButton::clicked, this, &SequenceEdit::removeLastShortcut);
+    connect(defaultButton, &QPushButton::clicked, this, &SequenceEdit::restoreDefault);
     lineEdit->installEventFilter(this);
 
     setShortcutName(_shortcutName);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5430

## What will change with this Pull Request?
Update all usages of slot/signal in `src/utility` and `src/deck` folder to use the new syntax
