### PR TITLE
fix segfault on exit if any closable tabs were open

### DIFF
--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -304,19 +304,28 @@ void TabSupervisor::stop()
     tabAdmin = 0;
     tabLog = 0;
 
-    QMapIterator<int, TabRoom *> roomIterator(roomTabs);
-    while (roomIterator.hasNext())
-        roomIterator.next().value()->deleteLater();
+    for (const auto tab : deckEditorTabs) {
+        disconnect(tab, nullptr, this, nullptr);
+        tab->deleteLater();
+    }
+    deckEditorTabs.clear();
+
+    for (auto i = roomTabs.cbegin(), end = roomTabs.cend(); i != end; ++i) {
+        disconnect(i.value(), nullptr, this, nullptr);
+        i.value()->deleteLater();
+    }
     roomTabs.clear();
 
-    QMapIterator<int, TabGame *> gameIterator(gameTabs);
-    while (gameIterator.hasNext())
-        gameIterator.next().value()->deleteLater();
+    for (auto i = gameTabs.cbegin(), end = gameTabs.cend(); i != end; ++i) {
+        disconnect(i.value(), nullptr, this, nullptr);
+        i.value()->deleteLater();
+    }
     gameTabs.clear();
 
-    QListIterator<TabGame *> replayIterator(replayTabs);
-    while (replayIterator.hasNext())
-        replayIterator.next()->deleteLater();
+    for (const auto tab : replayTabs) {
+        disconnect(tab, nullptr, this, nullptr);
+        tab->deleteLater();
+    }
     replayTabs.clear();
 
     delete userInfo;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5430

## Short roundup of the initial problem

Switching to the new connect syntax results in different timing of connections being disconnected when objects are destroyed. (see https://forum.qt.io/topic/156111/qobject-connect-behaves-different-when-using-slots-and-signals-makro)

The closable tabs all emit signals in their destructor that `TabSupervisor` is connected to. This causes Cockatrice to segfault on exit if any closable tabs are open, because the connection between `TabSupervisor` and the closable tabs are still active when `TabSupervisor` is being destructed on exit.

https://github.com/user-attachments/assets/0e7fb9dd-9d08-482b-9be4-86be6c66ebaf

## What will change with this Pull Request?

https://github.com/user-attachments/assets/d242984b-000e-4f07-8d67-568009c3bf23

- Manually disconnect any connections between `TabSupervisor` and any closable tabs in `TabSupervisor`'s destructor.
- Also refactor to use for each syntax while at it
