### PR TITLE
Fix macos 2

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -270,13 +270,16 @@ jobs:
         # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
         # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
         run: |
-          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
-          security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-          security default-keychain -s build.keychain
-          security set-keychain-settings -t 3600 -l build.keychain
-          security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-          security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+          if [[ -n "$MACOS_CERTIFICATE_NAME" ]]
+          then
+            echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+            security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+            security default-keychain -s build.keychain
+            security set-keychain-settings -t 3600 -l build.keychain
+            security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+            security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+            security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+          fi
           .ci/compile.sh --server --parallel ${{matrix.core_count}}
 
       - name: Sign app bundle
@@ -285,8 +288,11 @@ jobs:
           MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
         run: |
-          security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-          /usr/bin/codesign --sign="$MACOS_CERTIFICATE_NAME" --entitlements=".ci/macos.entitlements" --options=runtime --force --deep --timestamp --verbose ${{steps.build.outputs.path}}
+          if [[ -n "$MACOS_CERTIFICATE_NAME" ]]
+          then
+            security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+            /usr/bin/codesign --sign="$MACOS_CERTIFICATE_NAME" --entitlements=".ci/macos.entitlements" --options=runtime --force --deep --timestamp --verbose ${{steps.build.outputs.path}}
+          fi
 
       - name: Notarize app bundle
         if: matrix.make_package
@@ -295,27 +301,30 @@ jobs:
           MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
           MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
         run: |
-          # Store the notarization credentials so that we can prevent a UI password dialog from blocking the CI
-          echo "Create keychain profile"
-          xcrun notarytool store-credentials "notarytool-profile" --apple-id "$MACOS_NOTARIZATION_APPLE_ID" --team-id "$MACOS_NOTARIZATION_TEAM_ID" --password "$MACOS_NOTARIZATION_PWD"
-
-          # We can't notarize an app bundle directly, but we need to compress it as an archive.
-          # Therefore, we create a zip file containing our app bundle, so that we can send it to the
-          # notarization service
-          echo "Creating temp notarization archive"
-          ditto -c -k --keepParent ${{steps.build.outputs.path}} "notarization.zip"
-
-          # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
-          # This typically takes a few seconds inside a CI environment, but it might take more depending on the App
-          # characteristics. Visit the Notarization docs for more information and strategies on how to optimize it if
-          # you're curious
-          echo "Notarize app"
-          xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
-
-          # Finally, we need to "attach the staple" to our executable, which will allow our app to be
-          # validated by macOS even when an internet connection is not available.
-          echo "Attach staple"
-          xcrun stapler staple ${{steps.build.outputs.path}}
+          if [[ -n "$MACOS_NOTARIZATION_APPLE_ID" ]]
+          then
+            # Store the notarization credentials so that we can prevent a UI password dialog from blocking the CI
+            echo "Create keychain profile"
+            xcrun notarytool store-credentials "notarytool-profile" --apple-id "$MACOS_NOTARIZATION_APPLE_ID" --team-id "$MACOS_NOTARIZATION_TEAM_ID" --password "$MACOS_NOTARIZATION_PWD"
+  
+            # We can't notarize an app bundle directly, but we need to compress it as an archive.
+            # Therefore, we create a zip file containing our app bundle, so that we can send it to the
+            # notarization service
+            echo "Creating temp notarization archive"
+            ditto -c -k --keepParent ${{steps.build.outputs.path}} "notarization.zip"
+  
+            # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
+            # This typically takes a few seconds inside a CI environment, but it might take more depending on the App
+            # characteristics. Visit the Notarization docs for more information and strategies on how to optimize it if
+            # you're curious
+            echo "Notarize app"
+            xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
+  
+            # Finally, we need to "attach the staple" to our executable, which will allow our app to be
+            # validated by macOS even when an internet connection is not available.
+            echo "Attach staple"
+            xcrun stapler staple ${{steps.build.outputs.path}}
+          fi
 
       - name: Upload artifact
         if: matrix.make_package

--- a/cmake/SignMacApplications.cmake
+++ b/cmake/SignMacApplications.cmake
@@ -1,6 +1,8 @@
 # This script re-signs all apps after CPack packages them. This is necessary because CPack modifies
 # the library references used by Cockatrice to App relative paths, invalidating the code signature.
-if(APPLE)
+string(LENGTH $ENV{MACOS_CERTIFICATE_NAME} MACOS_CERTIFICATE_NAME_LEN)
+
+if(APPLE AND MACOS_CERTIFICATE_NAME_LEN GREATER 0)
   set(APPLICATIONS "cockatrice" "servatrice" "oracle" "dbconverter")
   foreach(app_name IN LISTS APPLICATIONS)
     set(FULL_APP_PATH "${CPACK_TEMPORARY_INSTALL_DIRECTORY}/${app_name}.app")


### PR DESCRIPTION
When PRs are made by other entities, we still want them to build, even if we're not going to sign them for distribution