### PR TITLE
disable starting life total edit in game information window

### DIFF
--- a/cockatrice/src/dialogs/dlg_create_game.cpp
+++ b/cockatrice/src/dialogs/dlg_create_game.cpp
@@ -180,6 +180,7 @@ DlgCreateGame::DlgCreateGame(const ServerInfo_Game &gameInfo, const QMap<int, QS
     spectatorsCanTalkCheckBox->setEnabled(false);
     spectatorsSeeEverythingCheckBox->setEnabled(false);
     createGameAsSpectatorCheckBox->setEnabled(false);
+    startingLifeTotalEdit->setEnabled(false);
 
     descriptionEdit->setText(QString::fromStdString(gameInfo.description()));
     maxPlayersEdit->setValue(gameInfo.max_players());


### PR DESCRIPTION

## Short roundup of the initial problem
From eon on discord:


> in the game information window, the starting life total box is editable whereas every other box is locked. Editing it doesnt actually do anything, but does look like it unlike all other buttons on that screen

![image-46](https://github.com/user-attachments/assets/79b03adb-ec2c-4a57-a174-fd655d0a6074)
![image-45](https://github.com/user-attachments/assets/5fd5b39a-f1ba-4b39-a989-22f45da48d18)


## What will change with this Pull Request?

Disable starting life total edit in game information window

## Screenshots

<img width="500" alt="Screenshot 2025-01-10 at 8 06 25 PM" src="https://github.com/user-attachments/assets/5f62902f-f1bc-41be-b27c-74bc7f7fa6ba" />
