### PR TITLE
Fix `Unload Deck` button label

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -164,7 +164,7 @@ void DeckViewContainer::retranslateUi()
 {
     loadLocalButton->setText(tr("Load deck..."));
     loadRemoteButton->setText(tr("Load remote deck..."));
-    unloadDeckButton->setText(tr("Unload deck..."));
+    unloadDeckButton->setText(tr("Unload deck"));
     readyStartButton->setText(tr("Ready to start"));
     forceStartGameButton->setText(tr("Force start"));
     updateSideboardLockButtonText();


### PR DESCRIPTION
## Related Ticket(s)
- Related #5290

## Short roundup of the initial problem
Label of the button was `Unload deck...`
We use dots to indicate that buttons or options open a follow up window, but here immediate action is taken.

## What will change with this Pull Request?
- Relabel to `Unload deck` only, same as e.g. the ready button.

