### PR TITLE
add override specifier to tab subclasses

### DIFF
--- a/cockatrice/src/client/tabs/tab.h
+++ b/cockatrice/src/client/tabs/tab.h
@@ -31,7 +31,7 @@ private:
     QList<QMenu *> tabMenus;
 
 public:
-    Tab(TabSupervisor *_tabSupervisor, QWidget *parent = nullptr);
+    explicit Tab(TabSupervisor *_tabSupervisor, QWidget *parent = nullptr);
     const QList<QMenu *> &getTabMenus() const
     {
         return tabMenus;

--- a/cockatrice/src/client/tabs/tab_account.h
+++ b/cockatrice/src/client/tabs/tab_account.h
@@ -50,8 +50,8 @@ public:
                  AbstractClient *_client,
                  const ServerInfo_User &userInfo,
                  QWidget *parent = nullptr);
-    void retranslateUi();
-    QString getTabText() const
+    void retranslateUi() override;
+    QString getTabText() const override
     {
         return tr("Account");
     }

--- a/cockatrice/src/client/tabs/tab_admin.h
+++ b/cockatrice/src/client/tabs/tab_admin.h
@@ -22,7 +22,7 @@ private:
     QSpinBox *minutesEdit;
 
 public:
-    ShutdownDialog(QWidget *parent = nullptr);
+    explicit ShutdownDialog(QWidget *parent = nullptr);
     QString getReason() const;
     int getMinutes() const;
 };
@@ -55,8 +55,8 @@ private slots:
 
 public:
     TabAdmin(TabSupervisor *_tabSupervisor, AbstractClient *_client, bool _fullAdmin, QWidget *parent = nullptr);
-    void retranslateUi();
-    QString getTabText() const
+    void retranslateUi() override;
+    QString getTabText() const override
     {
         return tr("Administration");
     }

--- a/cockatrice/src/client/tabs/tab_deck_storage.h
+++ b/cockatrice/src/client/tabs/tab_deck_storage.h
@@ -64,8 +64,8 @@ private slots:
 
 public:
     TabDeckStorage(TabSupervisor *_tabSupervisor, AbstractClient *_client);
-    void retranslateUi();
-    QString getTabText() const
+    void retranslateUi() override;
+    QString getTabText() const override
     {
         return tr("Deck storage");
     }

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -72,7 +72,7 @@ signals:
     void stateChanged();
 
 public:
-    ToggleButton(QWidget *parent = nullptr);
+    explicit ToggleButton(QWidget *parent = nullptr);
     bool getState() const
     {
         return state;
@@ -80,7 +80,7 @@ public:
     void setState(bool _state);
 
 protected:
-    void paintEvent(QPaintEvent *event);
+    void paintEvent(QPaintEvent *event) override;
 };
 
 class DeckViewContainer : public QWidget

--- a/cockatrice/src/client/tabs/tab_logs.h
+++ b/cockatrice/src/client/tabs/tab_logs.h
@@ -54,9 +54,9 @@ private slots:
 
 public:
     TabLog(TabSupervisor *_tabSupervisor, AbstractClient *_client, QWidget *parent = nullptr);
-    ~TabLog();
-    void retranslateUi();
-    QString getTabText() const
+    ~TabLog() override;
+    void retranslateUi() override;
+    QString getTabText() const override
     {
         return tr("Logs");
     }

--- a/cockatrice/src/client/tabs/tab_message.h
+++ b/cockatrice/src/client/tabs/tab_message.h
@@ -39,12 +39,12 @@ public:
                AbstractClient *_client,
                const ServerInfo_User &_ownUserInfo,
                const ServerInfo_User &_otherUserInfo);
-    ~TabMessage();
-    void retranslateUi();
-    void closeRequest();
-    void tabActivated();
+    ~TabMessage() override;
+    void retranslateUi() override;
+    void closeRequest() override;
+    void tabActivated() override;
     QString getUserName() const;
-    QString getTabText() const;
+    QString getTabText() const override;
 
     void processUserMessageEvent(const Event_UserMessage &event);
 

--- a/cockatrice/src/client/tabs/tab_replays.h
+++ b/cockatrice/src/client/tabs/tab_replays.h
@@ -59,8 +59,8 @@ signals:
 
 public:
     TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client);
-    void retranslateUi();
-    QString getTabText() const
+    void retranslateUi() override;
+    QString getTabText() const override
     {
         return tr("Game replays");
     }

--- a/cockatrice/src/client/tabs/tab_room.h
+++ b/cockatrice/src/client/tabs/tab_room.h
@@ -91,10 +91,10 @@ public:
             AbstractClient *_client,
             ServerInfo_User *_ownUser,
             const ServerInfo_Room &info);
-    ~TabRoom();
-    void retranslateUi();
-    void closeRequest();
-    void tabActivated();
+    ~TabRoom() override;
+    void retranslateUi() override;
+    void closeRequest() override;
+    void tabActivated() override;
     void processRoomEvent(const RoomEvent &event);
     int getRoomId() const
     {
@@ -108,7 +108,7 @@ public:
     {
         return roomName;
     }
-    QString getTabText() const
+    QString getTabText() const override
     {
         return roomName;
     }

--- a/cockatrice/src/client/tabs/tab_server.h
+++ b/cockatrice/src/client/tabs/tab_server.h
@@ -34,7 +34,7 @@ signals:
     void joinRoomRequest(int, bool setCurrent);
 
 public:
-    RoomSelector(AbstractClient *_client, QWidget *parent = nullptr);
+    explicit RoomSelector(AbstractClient *_client, QWidget *parent = nullptr);
     void retranslateUi();
 };
 
@@ -56,8 +56,8 @@ private:
 
 public:
     TabServer(TabSupervisor *_tabSupervisor, AbstractClient *_client, QWidget *parent = nullptr);
-    void retranslateUi();
-    QString getTabText() const
+    void retranslateUi() override;
+    QString getTabText() const override
     {
         return tr("Server");
     }

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -38,28 +38,28 @@ class MacOSTabFixStyle : public QProxyStyle
 {
     Q_OBJECT
 public:
-    QRect subElementRect(SubElement, const QStyleOption *, const QWidget *) const;
+    QRect subElementRect(SubElement, const QStyleOption *, const QWidget *) const override;
 };
 
 class CloseButton : public QAbstractButton
 {
     Q_OBJECT
 public:
-    CloseButton(QWidget *parent = nullptr);
-    QSize sizeHint() const;
-    inline QSize minimumSizeHint() const
+    explicit CloseButton(QWidget *parent = nullptr);
+    QSize sizeHint() const override;
+    inline QSize minimumSizeHint() const override
     {
         return sizeHint();
     }
 
 protected:
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-    void enterEvent(QEnterEvent *event);
+    void enterEvent(QEnterEvent *event) override;
 #else
-    void enterEvent(QEvent *event);
+    void enterEvent(QEvent *event) override;
 #endif
-    void leaveEvent(QEvent *event);
-    void paintEvent(QPaintEvent *event);
+    void leaveEvent(QEvent *event) override;
+    void paintEvent(QPaintEvent *event) override;
 };
 
 class TabSupervisor : public QTabWidget, public UserlistProxy
@@ -87,8 +87,8 @@ private:
     bool isLocalGame;
 
 public:
-    TabSupervisor(AbstractClient *_client, QWidget *parent = nullptr);
-    ~TabSupervisor();
+    explicit TabSupervisor(AbstractClient *_client, QWidget *parent = nullptr);
+    ~TabSupervisor() override;
     void retranslateUi();
     void start(const ServerInfo_User &userInfo);
     void startLocal(const QList<AbstractClient *> &_clients);
@@ -116,11 +116,11 @@ public:
     }
     bool getAdminLocked() const;
     bool closeRequest();
-    bool isOwnUserRegistered() const;
-    QString getOwnUsername() const;
-    bool isUserBuddy(const QString &userName) const;
-    bool isUserIgnored(const QString &userName) const;
-    const ServerInfo_User *getOnlineUser(const QString &userName) const;
+    bool isOwnUserRegistered() const override;
+    QString getOwnUsername() const override;
+    bool isUserBuddy(const QString &userName) const override;
+    bool isUserIgnored(const QString &userName) const override;
+    const ServerInfo_User *getOnlineUser(const QString &userName) const override;
     bool switchToGameTabIfAlreadyExists(const int gameId);
     void actShowPopup(const QString &message);
 signals:


### PR DESCRIPTION
## Short roundup of the initial problem

-Werror fails compile if a class with overriden methods only partially marks the overrides.
Just fixing this ahead of time so I don't get compile errors when I try to modify the tab suclasses.

## What will change with this Pull Request?
- Add override specifier to all tab subclasses
- Mark constructors explicit on the advice of clang-tidy
