### PR TITLE
Always set TabSupervisor as parent in Tab subclasses

### DIFF
--- a/cockatrice/src/client/tabs/tab.cpp
+++ b/cockatrice/src/client/tabs/tab.cpp
@@ -1,13 +1,14 @@
 #include "tab.h"
 
 #include "../ui/widgets/cards/card_info_display_widget.h"
+#include "./tab_supervisor.h"
 
 #include <QApplication>
 #include <QDebug>
 #include <QScreen>
 
-Tab::Tab(TabSupervisor *_tabSupervisor, QWidget *parent)
-    : QMainWindow(parent), tabSupervisor(_tabSupervisor), contentsChanged(false), infoPopup(0)
+Tab::Tab(TabSupervisor *_tabSupervisor)
+    : QMainWindow(_tabSupervisor), tabSupervisor(_tabSupervisor), contentsChanged(false), infoPopup(0)
 {
     setAttribute(Qt::WA_DeleteOnClose);
 }

--- a/cockatrice/src/client/tabs/tab.h
+++ b/cockatrice/src/client/tabs/tab.h
@@ -31,7 +31,7 @@ private:
     QList<QMenu *> tabMenus;
 
 public:
-    explicit Tab(TabSupervisor *_tabSupervisor, QWidget *parent = nullptr);
+    explicit Tab(TabSupervisor *_tabSupervisor);
     const QList<QMenu *> &getTabMenus() const
     {
         return tabMenus;

--- a/cockatrice/src/client/tabs/tab_account.cpp
+++ b/cockatrice/src/client/tabs/tab_account.cpp
@@ -18,11 +18,8 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 
-TabUserLists::TabUserLists(TabSupervisor *_tabSupervisor,
-                           AbstractClient *_client,
-                           const ServerInfo_User &userInfo,
-                           QWidget *parent)
-    : Tab(_tabSupervisor, parent), client(_client)
+TabUserLists::TabUserLists(TabSupervisor *_tabSupervisor, AbstractClient *_client, const ServerInfo_User &userInfo)
+    : Tab(_tabSupervisor), client(_client)
 {
     allUsersList = new UserList(_tabSupervisor, client, UserList::AllUsersList);
     buddyList = new UserList(_tabSupervisor, client, UserList::BuddyList);

--- a/cockatrice/src/client/tabs/tab_account.h
+++ b/cockatrice/src/client/tabs/tab_account.h
@@ -46,10 +46,7 @@ private:
     void addToList(const std::string &listName, const QString &userName);
 
 public:
-    TabUserLists(TabSupervisor *_tabSupervisor,
-                 AbstractClient *_client,
-                 const ServerInfo_User &userInfo,
-                 QWidget *parent = nullptr);
+    TabUserLists(TabSupervisor *_tabSupervisor, AbstractClient *_client, const ServerInfo_User &userInfo);
     void retranslateUi() override;
     QString getTabText() const override
     {

--- a/cockatrice/src/client/tabs/tab_admin.cpp
+++ b/cockatrice/src/client/tabs/tab_admin.cpp
@@ -54,8 +54,8 @@ int ShutdownDialog::getMinutes() const
     return minutesEdit->value();
 }
 
-TabAdmin::TabAdmin(TabSupervisor *_tabSupervisor, AbstractClient *_client, bool _fullAdmin, QWidget *parent)
-    : Tab(_tabSupervisor, parent), locked(true), client(_client), fullAdmin(_fullAdmin)
+TabAdmin::TabAdmin(TabSupervisor *_tabSupervisor, AbstractClient *_client, bool _fullAdmin)
+    : Tab(_tabSupervisor), locked(true), client(_client), fullAdmin(_fullAdmin)
 {
     updateServerMessageButton = new QPushButton;
     connect(updateServerMessageButton, &QPushButton::clicked, this, &TabAdmin::actUpdateServerMessage);

--- a/cockatrice/src/client/tabs/tab_admin.h
+++ b/cockatrice/src/client/tabs/tab_admin.h
@@ -54,7 +54,7 @@ private slots:
     void actLock();
 
 public:
-    TabAdmin(TabSupervisor *_tabSupervisor, AbstractClient *_client, bool _fullAdmin, QWidget *parent = nullptr);
+    TabAdmin(TabSupervisor *_tabSupervisor, AbstractClient *_client, bool _fullAdmin);
     void retranslateUi() override;
     QString getTabText() const override
     {

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -698,8 +698,7 @@ void TabDeckEditor::loadLayout()
     QTimer::singleShot(100, this, SLOT(freeDocksSize()));
 }
 
-TabDeckEditor::TabDeckEditor(TabSupervisor *_tabSupervisor, QWidget *parent)
-    : Tab(_tabSupervisor, parent), modified(false)
+TabDeckEditor::TabDeckEditor(TabSupervisor *_tabSupervisor) : Tab(_tabSupervisor), modified(false)
 {
     setObjectName("TabDeckEditor");
 

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -981,7 +981,7 @@ void TabDeckEditor::closeRequest(bool forced)
     }
 
     emit deckEditorClosing(this);
-    deleteLater();
+    close();
 }
 
 void TabDeckEditor::actNewDeck()

--- a/cockatrice/src/client/tabs/tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/tab_deck_editor.h
@@ -163,7 +163,7 @@ private:
     QWidget *centralWidget;
 
 public:
-    explicit TabDeckEditor(TabSupervisor *_tabSupervisor, QWidget *parent = nullptr);
+    explicit TabDeckEditor(TabSupervisor *_tabSupervisor);
     void retranslateUi() override;
     QString getTabText() const override;
     void setDeck(DeckLoader *_deckLoader);

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -707,7 +707,7 @@ void TabGame::closeRequest(bool forced)
 
     emit gameClosing(this);
 
-    deleteLater();
+    close();
 }
 
 void TabGame::replayNextEvent(Player::EventProcessingOptions options)

--- a/cockatrice/src/client/tabs/tab_logs.cpp
+++ b/cockatrice/src/client/tabs/tab_logs.cpp
@@ -21,8 +21,7 @@
 #include <QtGui>
 #include <QtWidgets>
 
-TabLog::TabLog(TabSupervisor *_tabSupervisor, AbstractClient *_client, QWidget *parent)
-    : Tab(_tabSupervisor, parent), client(_client)
+TabLog::TabLog(TabSupervisor *_tabSupervisor, AbstractClient *_client) : Tab(_tabSupervisor), client(_client)
 {
     roomTable = new QTableWidget();
     roomTable->setColumnCount(6);

--- a/cockatrice/src/client/tabs/tab_logs.h
+++ b/cockatrice/src/client/tabs/tab_logs.h
@@ -53,7 +53,7 @@ private slots:
     void restartLayout();
 
 public:
-    TabLog(TabSupervisor *_tabSupervisor, AbstractClient *_client, QWidget *parent = nullptr);
+    TabLog(TabSupervisor *_tabSupervisor, AbstractClient *_client);
     ~TabLog() override;
     void retranslateUi() override;
     QString getTabText() const override

--- a/cockatrice/src/client/tabs/tab_message.cpp
+++ b/cockatrice/src/client/tabs/tab_message.cpp
@@ -88,7 +88,7 @@ QString TabMessage::getTabText() const
 void TabMessage::closeRequest(bool /*forced*/)
 {
     emit talkClosing(this);
-    deleteLater();
+    close();
 }
 
 void TabMessage::sendMessage()

--- a/cockatrice/src/client/tabs/tab_room.cpp
+++ b/cockatrice/src/client/tabs/tab_room.cpp
@@ -174,7 +174,7 @@ void TabRoom::closeRequest(bool /*forced*/)
 {
     sendRoomCommand(prepareRoomCommand(Command_LeaveRoom()));
     emit roomClosing(this);
-    deleteLater();
+    close();
 }
 
 void TabRoom::tabActivated()

--- a/cockatrice/src/client/tabs/tab_server.cpp
+++ b/cockatrice/src/client/tabs/tab_server.cpp
@@ -138,8 +138,7 @@ void RoomSelector::joinClicked()
     emit joinRoomRequest(id, true);
 }
 
-TabServer::TabServer(TabSupervisor *_tabSupervisor, AbstractClient *_client, QWidget *parent)
-    : Tab(_tabSupervisor, parent), client(_client)
+TabServer::TabServer(TabSupervisor *_tabSupervisor, AbstractClient *_client) : Tab(_tabSupervisor), client(_client)
 {
     roomSelector = new RoomSelector(client);
     serverInfoBox = new QTextBrowser;

--- a/cockatrice/src/client/tabs/tab_server.h
+++ b/cockatrice/src/client/tabs/tab_server.h
@@ -55,7 +55,7 @@ private:
     bool shouldEmitUpdate = false;
 
 public:
-    TabServer(TabSupervisor *_tabSupervisor, AbstractClient *_client, QWidget *parent = nullptr);
+    TabServer(TabSupervisor *_tabSupervisor, AbstractClient *_client);
     void retranslateUi() override;
     QString getTabText() const override
     {

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -339,19 +339,12 @@ void TabSupervisor::updatePingTime(int value, int max)
     setTabIcon(indexOf(tabServer), QIcon(PingPixmapGenerator::generatePixmap(15, value, max)));
 }
 
-void TabSupervisor::closeButtonPressed()
-{
-    Tab *tab = static_cast<Tab *>(static_cast<CloseButton *>(sender())->property("tab").value<QObject *>());
-    tab->closeRequest();
-}
-
 void TabSupervisor::addCloseButtonToTab(Tab *tab, int tabIndex)
 {
-    QTabBar::ButtonPosition closeSide =
-        (QTabBar::ButtonPosition)tabBar()->style()->styleHint(QStyle::SH_TabBar_CloseButtonPosition, 0, tabBar());
-    CloseButton *closeButton = new CloseButton;
-    connect(closeButton, &CloseButton::clicked, this, &TabSupervisor::closeButtonPressed);
-    closeButton->setProperty("tab", QVariant::fromValue((QObject *)tab));
+    auto closeSide = static_cast<QTabBar::ButtonPosition>(
+        tabBar()->style()->styleHint(QStyle::SH_TabBar_CloseButtonPosition, nullptr, tabBar()));
+    auto *closeButton = new CloseButton(tab);
+    connect(closeButton, &CloseButton::clicked, tab, &Tab::closeRequest);
     tabBar()->setTabButton(tabIndex, closeSide, closeButton);
 }
 

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -344,7 +344,7 @@ void TabSupervisor::addCloseButtonToTab(Tab *tab, int tabIndex)
     auto closeSide = static_cast<QTabBar::ButtonPosition>(
         tabBar()->style()->styleHint(QStyle::SH_TabBar_CloseButtonPosition, nullptr, tabBar()));
     auto *closeButton = new CloseButton(tab);
-    connect(closeButton, &CloseButton::clicked, tab, &Tab::closeRequest);
+    connect(closeButton, &CloseButton::clicked, tab, [tab] { tab->closeRequest(); });
     tabBar()->setTabButton(tabIndex, closeSide, closeButton);
 }
 

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -135,7 +135,6 @@ public slots:
     void openReplay(GameReplay *replay);
     void maximizeMainWindow();
 private slots:
-    void closeButtonPressed();
     void updateCurrent(int index);
     void updatePingTime(int value, int max);
     void gameJoined(const Event_GameJoined &event);

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -866,7 +866,7 @@ MainWindow::MainWindow(QWidget *parent)
     createActions();
     createMenus();
 
-    tabSupervisor = new TabSupervisor(client);
+    tabSupervisor = new TabSupervisor(client, this);
     connect(tabSupervisor, &TabSupervisor::setMenu, this, &MainWindow::updateTabMenu);
     connect(tabSupervisor, &TabSupervisor::localGameEnded, this, &MainWindow::localGameEnded);
     connect(tabSupervisor, &TabSupervisor::showWindowIfHidden, this, &MainWindow::showWindowIfHidden);


### PR DESCRIPTION
## Short roundup of the initial problem

`Tab` subclasses do not have a parent set. `Tab` subclasses seem to always be created and managed by `TabSupervisor`, so they should probably have `TabSupervisor` as their parent.  

## What will change with this Pull Request?
- `Tab` constructor now sets the parent to its passeed-in `tabSupervisor`
- `Tab` subclasses now use `close` instead of `deleteLater` in `closeRequest`
- refactor `TabSupervisor::addCloseButtonToTab`