### PR TITLE
don't close replay tabs and do close message tabs on disconnect

### DIFF
--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -316,10 +316,10 @@ void TabSupervisor::stop()
     }
     gameTabs.clear();
 
-    for (const auto tab : replayTabs) {
-        tabsToDelete << tab;
+    for (auto i = messageTabs.cbegin(), end = messageTabs.cend(); i != end; ++i) {
+        tabsToDelete << i.value();
     }
-    replayTabs.clear();
+    messageTabs.clear();
 
     for (const auto tab : tabsToDelete) {
         tab->closeRequest(true);


### PR DESCRIPTION
## Related Ticket(s)
- Addresses #5443

## Short roundup of the initial problem

Cockatrice was closing all replay tabs on disconnect, which isn't necessary. It was also not closing message tabs on disconnect, which is weird.

## What will change with this Pull Request?
- Don't close replay tabs on disconnect
- Do close message tabs on disconnect