### PR TITLE
Make all tabs closable; add tabs menu

### DIFF
--- a/cockatrice/src/client/tabs/tab.cpp
+++ b/cockatrice/src/client/tabs/tab.cpp
@@ -42,3 +42,8 @@ void Tab::deleteCardInfoPopup(const QString &cardName)
         }
     }
 }
+
+void Tab::closeRequest(bool /*forced*/)
+{
+    close();
+}

--- a/cockatrice/src/client/tabs/tab.cpp
+++ b/cockatrice/src/client/tabs/tab.cpp
@@ -4,6 +4,7 @@
 #include "./tab_supervisor.h"
 
 #include <QApplication>
+#include <QCloseEvent>
 #include <QDebug>
 #include <QScreen>
 
@@ -41,6 +42,15 @@ void Tab::deleteCardInfoPopup(const QString &cardName)
             infoPopup = 0;
         }
     }
+}
+
+/**
+ * Overrides the closeEvent in order to emit a close signal
+ */
+void Tab::closeEvent(QCloseEvent *event)
+{
+    emit closed();
+    event->accept();
 }
 
 void Tab::closeRequest(bool /*forced*/)

--- a/cockatrice/src/client/tabs/tab.h
+++ b/cockatrice/src/client/tabs/tab.h
@@ -56,9 +56,7 @@ public:
      *
      * @param forced whether this close request was initiated by the user or forced by the server.
      */
-    virtual void closeRequest(bool /*forced*/ = false)
-    {
-    }
+    virtual void closeRequest(bool forced = false);
     virtual void tabActivated()
     {
     }

--- a/cockatrice/src/client/tabs/tab.h
+++ b/cockatrice/src/client/tabs/tab.h
@@ -13,6 +13,12 @@ class Tab : public QMainWindow
 signals:
     void userEvent(bool globalEvent = true);
     void tabTextChanged(Tab *tab, const QString &newTabText);
+    /**
+     * Emitted when the tab is closed (because Qt doesn't provide a built-in close signal)
+     * This signal is emitted from this class's overridden Tab::closeEvent method.
+     * Make sure any subclasses that override closeEvent still emit this signal from there.
+     */
+    void closed();
 
 protected:
     TabSupervisor *tabSupervisor;
@@ -23,6 +29,7 @@ protected:
 protected slots:
     void showCardInfoPopup(const QPoint &pos, const QString &cardName, const QString &providerId);
     void deleteCardInfoPopup(const QString &cardName);
+    void closeEvent(QCloseEvent *event) override;
 
 private:
     QString currentCardName, currentProviderId;

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -100,9 +100,9 @@ void CloseButton::paintEvent(QPaintEvent * /*event*/)
     style()->drawPrimitive(QStyle::PE_IndicatorTabClose, &opt, &p, this);
 }
 
-TabSupervisor::TabSupervisor(AbstractClient *_client, QWidget *parent)
-    : QTabWidget(parent), userInfo(0), client(_client), tabServer(0), tabUserLists(0), tabDeckStorage(0), tabReplays(0),
-      tabAdmin(0), tabLog(0)
+TabSupervisor::TabSupervisor(AbstractClient *_client, QMenu *tabsMenu, QWidget *parent)
+    : QTabWidget(parent), userInfo(0), client(_client), tabsMenu(tabsMenu), tabServer(0), tabUserLists(0),
+      tabDeckStorage(0), tabReplays(0), tabAdmin(0), tabLog(0)
 {
     setElideMode(Qt::ElideRight);
     setMovable(true);

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -221,12 +221,14 @@ void TabSupervisor::start(const ServerInfo_User &_userInfo)
     tabServer = new TabServer(this, client);
     connect(tabServer, &TabServer::roomJoined, this, &TabSupervisor::addRoomTab);
     myAddTab(tabServer);
+    connect(tabServer, &Tab::destroyed, this, [this] { tabServer = nullptr; });
 
     tabUserLists = new TabUserLists(this, client, *userInfo);
     connect(tabUserLists, &TabUserLists::openMessageDialog, this, &TabSupervisor::addMessageTab);
     connect(tabUserLists, &TabUserLists::userJoined, this, &TabSupervisor::processUserJoined);
     connect(tabUserLists, &TabUserLists::userLeft, this, &TabSupervisor::processUserLeft);
     myAddTab(tabUserLists);
+    connect(tabUserLists, &Tab::destroyed, this, [this] { tabUserLists = nullptr; });
 
     updatePingTime(0, -1);
 
@@ -234,10 +236,12 @@ void TabSupervisor::start(const ServerInfo_User &_userInfo)
         tabDeckStorage = new TabDeckStorage(this, client);
         connect(tabDeckStorage, &TabDeckStorage::openDeckEditor, this, &TabSupervisor::addDeckEditorTab);
         myAddTab(tabDeckStorage);
+        connect(tabDeckStorage, &Tab::destroyed, this, [this] { tabDeckStorage = nullptr; });
 
         tabReplays = new TabReplays(this, client);
         connect(tabReplays, &TabReplays::openReplay, this, &TabSupervisor::openReplay);
         myAddTab(tabReplays);
+        connect(tabReplays, &Tab::destroyed, this, [this] { tabReplays = nullptr; });
     } else {
         tabDeckStorage = 0;
         tabReplays = 0;
@@ -247,9 +251,11 @@ void TabSupervisor::start(const ServerInfo_User &_userInfo)
         tabAdmin = new TabAdmin(this, client, (userInfo->user_level() & ServerInfo_User::IsAdmin));
         connect(tabAdmin, &TabAdmin::adminLockChanged, this, &TabSupervisor::adminLockChanged);
         myAddTab(tabAdmin);
+        connect(tabAdmin, &Tab::destroyed, this, [this] { tabAdmin = nullptr; });
 
         tabLog = new TabLog(this, client);
         myAddTab(tabLog);
+        connect(tabLog, &Tab::destroyed, this, [this] { tabLog = nullptr; });
     } else {
         tabAdmin = 0;
         tabLog = 0;

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -286,18 +286,24 @@ void TabSupervisor::stop()
 
         emit localGameEnded();
     } else {
-        if (tabUserLists)
-            tabUserLists->deleteLater();
-        if (tabServer)
-            tabServer->deleteLater();
-        if (tabDeckStorage)
-            tabDeckStorage->deleteLater();
-        if (tabReplays)
-            tabReplays->deleteLater();
-        if (tabAdmin)
-            tabAdmin->deleteLater();
-        if (tabLog)
-            tabLog->deleteLater();
+        if (tabUserLists) {
+            tabUserLists->closeRequest(true);
+        }
+        if (tabServer) {
+            tabServer->closeRequest(true);
+        }
+        if (tabDeckStorage) {
+            tabDeckStorage->closeRequest(true);
+        }
+        if (tabReplays) {
+            tabReplays->closeRequest(true);
+        }
+        if (tabAdmin) {
+            tabAdmin->closeRequest(true);
+        }
+        if (tabLog) {
+            tabLog->closeRequest(true);
+        }
     }
     tabUserLists = 0;
     tabServer = 0;

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -208,6 +208,8 @@ int TabSupervisor::myAddTab(Tab *tab)
     int idx = addTab(tab, sanitizeTabName(tabText));
     setTabToolTip(idx, sanitizeHtml(tabText));
 
+    addCloseButtonToTab(tab, idx);
+
     return idx;
 }
 
@@ -363,8 +365,7 @@ void TabSupervisor::gameJoined(const Event_GameJoined &event)
     connect(tab, &TabGame::gameClosing, this, &TabSupervisor::gameLeft);
     connect(tab, &TabGame::openMessageDialog, this, &TabSupervisor::addMessageTab);
     connect(tab, &TabGame::openDeckEditor, this, &TabSupervisor::addDeckEditorTab);
-    int tabIndex = myAddTab(tab);
-    addCloseButtonToTab(tab, tabIndex);
+    myAddTab(tab);
     gameTabs.insert(event.game_info().game_id(), tab);
     setCurrentWidget(tab);
 }
@@ -374,8 +375,7 @@ void TabSupervisor::localGameJoined(const Event_GameJoined &event)
     TabGame *tab = new TabGame(this, localClients, event, QMap<int, QString>());
     connect(tab, &TabGame::gameClosing, this, &TabSupervisor::gameLeft);
     connect(tab, &TabGame::openDeckEditor, this, &TabSupervisor::addDeckEditorTab);
-    int tabIndex = myAddTab(tab);
-    addCloseButtonToTab(tab, tabIndex);
+    myAddTab(tab);
     gameTabs.insert(event.game_info().game_id(), tab);
     setCurrentWidget(tab);
 
@@ -404,8 +404,7 @@ void TabSupervisor::addRoomTab(const ServerInfo_Room &info, bool setCurrent)
     connect(tab, &TabRoom::maximizeClient, this, &TabSupervisor::maximizeMainWindow);
     connect(tab, &TabRoom::roomClosing, this, &TabSupervisor::roomLeft);
     connect(tab, &TabRoom::openMessageDialog, this, &TabSupervisor::addMessageTab);
-    int tabIndex = myAddTab(tab);
-    addCloseButtonToTab(tab, tabIndex);
+    myAddTab(tab);
     roomTabs.insert(info.room_id(), tab);
     if (setCurrent)
         setCurrentWidget(tab);
@@ -424,8 +423,7 @@ void TabSupervisor::openReplay(GameReplay *replay)
 {
     TabGame *replayTab = new TabGame(this, replay);
     connect(replayTab, &TabGame::gameClosing, this, &TabSupervisor::replayLeft);
-    int tabIndex = myAddTab(replayTab);
-    addCloseButtonToTab(replayTab, tabIndex);
+    myAddTab(replayTab);
     replayTabs.append(replayTab);
     setCurrentWidget(replayTab);
 }
@@ -461,8 +459,7 @@ TabMessage *TabSupervisor::addMessageTab(const QString &receiverName, bool focus
     tab = new TabMessage(this, client, *userInfo, otherUser);
     connect(tab, &TabMessage::talkClosing, this, &TabSupervisor::talkLeft);
     connect(tab, &TabMessage::maximizeClient, this, &TabSupervisor::maximizeMainWindow);
-    int tabIndex = myAddTab(tab);
-    addCloseButtonToTab(tab, tabIndex);
+    myAddTab(tab);
     messageTabs.insert(receiverName, tab);
     if (focus)
         setCurrentWidget(tab);
@@ -490,8 +487,7 @@ TabDeckEditor *TabSupervisor::addDeckEditorTab(const DeckLoader *deckToOpen)
         tab->setDeck(new DeckLoader(*deckToOpen));
     connect(tab, &TabDeckEditor::deckEditorClosing, this, &TabSupervisor::deckEditorClosed);
     connect(tab, &TabDeckEditor::openDeckEditor, this, &TabSupervisor::addDeckEditorTab);
-    int tabIndex = myAddTab(tab);
-    addCloseButtonToTab(tab, tabIndex);
+    myAddTab(tab);
     deckEditorTabs.append(tab);
     setCurrentWidget(tab);
     return tab;
@@ -500,8 +496,7 @@ TabDeckEditor *TabSupervisor::addDeckEditorTab(const DeckLoader *deckToOpen)
 TabDeckStorageVisual *TabSupervisor::addVisualDeckStorageTab()
 {
     TabDeckStorageVisual *tab = new TabDeckStorageVisual(this, client);
-    int tabIndex = myAddTab(tab);
-    addCloseButtonToTab(tab, tabIndex);
+    myAddTab(tab);
     setCurrentWidget(tab);
     return tab;
 }

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -280,6 +280,9 @@ void TabSupervisor::startLocal(const QList<AbstractClient *> &_clients)
     connect(localClients.first(), &AbstractClient::gameJoinedEventReceived, this, &TabSupervisor::localGameJoined);
 }
 
+/**
+ * Call this when Cockatrice disconnects from the server in order to clean up.
+ */
 void TabSupervisor::stop()
 {
     if ((!client) && localClients.isEmpty())

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -393,7 +393,7 @@ void TabSupervisor::actTabServer(bool checked)
         tabServer = new TabServer(this, client);
         connect(tabServer, &TabServer::roomJoined, this, &TabSupervisor::addRoomTab);
         myAddTab(tabServer);
-        connect(tabServer, &Tab::destroyed, this, [this] {
+        connect(tabServer, &Tab::closed, this, [this] {
             tabServer = nullptr;
             aTabServer->setChecked(false);
         });
@@ -410,7 +410,7 @@ void TabSupervisor::actTabUserLists(bool checked)
         connect(tabUserLists, &TabUserLists::userJoined, this, &TabSupervisor::processUserJoined);
         connect(tabUserLists, &TabUserLists::userLeft, this, &TabSupervisor::processUserLeft);
         myAddTab(tabUserLists);
-        connect(tabUserLists, &Tab::destroyed, this, [this] {
+        connect(tabUserLists, &Tab::closed, this, [this] {
             tabUserLists = nullptr;
             aTabUserLists->setChecked(false);
         });
@@ -425,7 +425,7 @@ void TabSupervisor::actTabDeckStorage(bool checked)
         tabDeckStorage = new TabDeckStorage(this, client);
         connect(tabDeckStorage, &TabDeckStorage::openDeckEditor, this, &TabSupervisor::addDeckEditorTab);
         myAddTab(tabDeckStorage);
-        connect(tabDeckStorage, &Tab::destroyed, this, [this] {
+        connect(tabDeckStorage, &Tab::closed, this, [this] {
             tabDeckStorage = nullptr;
             aTabDeckStorage->setChecked(false);
         });
@@ -440,7 +440,7 @@ void TabSupervisor::actTabReplays(bool checked)
         tabReplays = new TabReplays(this, client);
         connect(tabReplays, &TabReplays::openReplay, this, &TabSupervisor::openReplay);
         myAddTab(tabReplays);
-        connect(tabReplays, &Tab::destroyed, this, [this] {
+        connect(tabReplays, &Tab::closed, this, [this] {
             tabReplays = nullptr;
             aTabReplays->setChecked(false);
         });
@@ -455,7 +455,7 @@ void TabSupervisor::actTabAdmin(bool checked)
         tabAdmin = new TabAdmin(this, client, (userInfo->user_level() & ServerInfo_User::IsAdmin));
         connect(tabAdmin, &TabAdmin::adminLockChanged, this, &TabSupervisor::adminLockChanged);
         myAddTab(tabAdmin);
-        connect(tabAdmin, &Tab::destroyed, this, [this] {
+        connect(tabAdmin, &Tab::closed, this, [this] {
             tabAdmin = nullptr;
             aTabAdmin->setChecked(false);
         });
@@ -469,7 +469,7 @@ void TabSupervisor::actTabLog(bool checked)
     if (checked && !tabLog) {
         tabLog = new TabLog(this, client);
         myAddTab(tabLog);
-        connect(tabLog, &Tab::destroyed, this, [this] {
+        connect(tabLog, &Tab::closed, this, [this] {
             tabLog = nullptr;
             aTabAdmin->setChecked(false);
         });

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -311,29 +311,20 @@ void TabSupervisor::stop()
             tabLog->closeRequest(true);
         }
     }
-    tabUserLists = 0;
-    tabServer = 0;
-    tabDeckStorage = 0;
-    tabReplays = 0;
-    tabAdmin = 0;
-    tabLog = 0;
 
     QList<Tab *> tabsToDelete;
 
     for (auto i = roomTabs.cbegin(), end = roomTabs.cend(); i != end; ++i) {
         tabsToDelete << i.value();
     }
-    roomTabs.clear();
 
     for (auto i = gameTabs.cbegin(), end = gameTabs.cend(); i != end; ++i) {
         tabsToDelete << i.value();
     }
-    gameTabs.clear();
 
     for (auto i = messageTabs.cbegin(), end = messageTabs.cend(); i != end; ++i) {
         tabsToDelete << i.value();
     }
-    messageTabs.clear();
 
     for (const auto tab : tabsToDelete) {
         tab->closeRequest(true);

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -69,6 +69,7 @@ private:
     ServerInfo_User *userInfo;
     AbstractClient *client;
     QList<AbstractClient *> localClients;
+    QMenu *tabsMenu;
     TabServer *tabServer;
     TabUserLists *tabUserLists;
     TabDeckStorage *tabDeckStorage;
@@ -87,7 +88,7 @@ private:
     bool isLocalGame;
 
 public:
-    explicit TabSupervisor(AbstractClient *_client, QWidget *parent = nullptr);
+    explicit TabSupervisor(AbstractClient *_client, QMenu *tabsMenu, QWidget *parent = nullptr);
     ~TabSupervisor() override;
     void retranslateUi();
     void start(const ServerInfo_User &userInfo);

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -81,11 +81,15 @@ private:
     QList<TabGame *> replayTabs;
     QMap<QString, TabMessage *> messageTabs;
     QList<TabDeckEditor *> deckEditorTabs;
+    bool isLocalGame;
+
+    QAction *aTabDeckEditor, *aTabServer, *aTabUserLists, *aTabDeckStorage, *aTabReplays, *aTabAdmin, *aTabLog;
+
     int myAddTab(Tab *tab);
     void addCloseButtonToTab(Tab *tab, int tabIndex);
     QString sanitizeTabName(QString dirty) const;
     QString sanitizeHtml(QString dirty) const;
-    bool isLocalGame;
+    void resetTabsMenu();
 
 public:
     explicit TabSupervisor(AbstractClient *_client, QMenu *tabsMenu, QWidget *parent = nullptr);
@@ -136,6 +140,15 @@ public slots:
     void openReplay(GameReplay *replay);
     void maximizeMainWindow();
 private slots:
+    void refreshShortcuts();
+
+    void actTabServer(bool checked);
+    void actTabUserLists(bool checked);
+    void actTabDeckStorage(bool checked);
+    void actTabReplays(bool checked);
+    void actTabAdmin(bool checked);
+    void actTabLog(bool checked);
+
     void updateCurrent(int index);
     void updatePingTime(int value, int max);
     void gameJoined(const Event_GameJoined &event);

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -82,6 +82,11 @@ const QString MainWindow::appName = "Cockatrice";
 const QStringList MainWindow::fileNameFilters = QStringList() << QObject::tr("Cockatrice card database (*.xml)")
                                                               << QObject::tr("All files (*.*)");
 
+/**
+ * Replaces the tab-specific menus that are shown in the menuBar.
+ *
+ * @param newMenuList The tab-specific menus to show in the menuBar
+ */
 void MainWindow::updateTabMenu(const QList<QMenu *> &newMenuList)
 {
     for (auto &tabMenu : tabMenus)

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -290,11 +290,6 @@ void MainWindow::localGameEnded()
     aSinglePlayer->setEnabled(true);
 }
 
-void MainWindow::actDeckEditor()
-{
-    tabSupervisor->addDeckEditorTab(nullptr);
-}
-
 void MainWindow::actVisualDeckStorage()
 {
     tabSupervisor->addVisualDeckStorageTab();
@@ -669,7 +664,6 @@ void MainWindow::retranslateUi()
     aDisconnect->setText(tr("&Disconnect"));
     aSinglePlayer->setText(tr("Start &local game..."));
     aWatchReplay->setText(tr("&Watch replay..."));
-    aDeckEditor->setText(tr("&Deck editor"));
     aVisualDeckStorage->setText(tr("&Visual Deck storage"));
     aFullScreen->setText(tr("&Full screen"));
     aRegister->setText(tr("&Register to server..."));
@@ -718,8 +712,6 @@ void MainWindow::createActions()
     connect(aSinglePlayer, &QAction::triggered, this, &MainWindow::actSinglePlayer);
     aWatchReplay = new QAction(this);
     connect(aWatchReplay, &QAction::triggered, this, &MainWindow::actWatchReplay);
-    aDeckEditor = new QAction(this);
-    connect(aDeckEditor, &QAction::triggered, this, &MainWindow::actDeckEditor);
     aVisualDeckStorage = new QAction(this);
     connect(aVisualDeckStorage, &QAction::triggered, this, &MainWindow::actVisualDeckStorage);
     aFullScreen = new QAction(this);
@@ -808,7 +800,6 @@ void MainWindow::createMenus()
     cockatriceMenu->addAction(aSinglePlayer);
     cockatriceMenu->addAction(aWatchReplay);
     cockatriceMenu->addSeparator();
-    cockatriceMenu->addAction(aDeckEditor);
     cockatriceMenu->addAction(aVisualDeckStorage);
     cockatriceMenu->addSeparator();
     cockatriceMenu->addAction(aFullScreen);
@@ -1292,7 +1283,6 @@ void MainWindow::refreshShortcuts()
     aDisconnect->setShortcuts(shortcuts.getShortcut("MainWindow/aDisconnect"));
     aSinglePlayer->setShortcuts(shortcuts.getShortcut("MainWindow/aSinglePlayer"));
     aWatchReplay->setShortcuts(shortcuts.getShortcut("MainWindow/aWatchReplay"));
-    aDeckEditor->setShortcuts(shortcuts.getShortcut("MainWindow/aDeckEditor"));
     aFullScreen->setShortcuts(shortcuts.getShortcut("MainWindow/aFullScreen"));
     aRegister->setShortcuts(shortcuts.getShortcut("MainWindow/aRegister"));
     aSettings->setShortcuts(shortcuts.getShortcut("MainWindow/aSettings"));

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -692,6 +692,8 @@ void MainWindow::retranslateUi()
     aAddCustomSet->setText(tr("Add custom sets/cards"));
     aReloadCardDatabase->setText(tr("Reload card database"));
 
+    tabsMenu->setTitle(tr("Tabs"));
+
     helpMenu->setTitle(tr("&Help"));
     aAbout->setText(tr("&About Cockatrice"));
     aTips->setText(tr("&Tip of the Day"));
@@ -824,6 +826,8 @@ void MainWindow::createMenus()
     dbMenu->addSeparator();
     dbMenu->addAction(aReloadCardDatabase);
 
+    tabsMenu = menuBar()->addMenu(QString());
+
     helpMenu = menuBar()->addMenu(QString());
     helpMenu->addAction(aAbout);
     helpMenu->addAction(aTips);
@@ -871,7 +875,7 @@ MainWindow::MainWindow(QWidget *parent)
     createActions();
     createMenus();
 
-    tabSupervisor = new TabSupervisor(client, this);
+    tabSupervisor = new TabSupervisor(client, tabsMenu, this);
     connect(tabSupervisor, &TabSupervisor::setMenu, this, &MainWindow::updateTabMenu);
     connect(tabSupervisor, &TabSupervisor::localGameEnded, this, &MainWindow::localGameEnded);
     connect(tabSupervisor, &TabSupervisor::showWindowIfHidden, this, &MainWindow::showWindowIfHidden);

--- a/cockatrice/src/client/ui/window_main.h
+++ b/cockatrice/src/client/ui/window_main.h
@@ -73,7 +73,6 @@ private slots:
     void actDisconnect();
     void actSinglePlayer();
     void actWatchReplay();
-    void actDeckEditor();
     void actVisualDeckStorage();
     void actFullScreen(bool checked);
     void actRegister();
@@ -132,10 +131,10 @@ private:
 
     QList<QMenu *> tabMenus;
     QMenu *cockatriceMenu, *dbMenu, *tabsMenu, *helpMenu, *trayIconMenu;
-    QAction *aConnect, *aDisconnect, *aSinglePlayer, *aWatchReplay, *aDeckEditor, *aVisualDeckStorage, *aFullScreen,
-        *aSettings, *aExit, *aAbout, *aTips, *aCheckCardUpdates, *aRegister, *aForgotPassword, *aUpdate, *aViewLog,
-        *aManageSets, *aEditTokens, *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet, *aReloadCardDatabase,
-        *aShow, *aOpenSettingsFolder;
+    QAction *aConnect, *aDisconnect, *aSinglePlayer, *aWatchReplay, *aVisualDeckStorage, *aFullScreen, *aSettings,
+        *aExit, *aAbout, *aTips, *aCheckCardUpdates, *aRegister, *aForgotPassword, *aUpdate, *aViewLog, *aManageSets,
+        *aEditTokens, *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet, *aReloadCardDatabase, *aShow,
+        *aOpenSettingsFolder;
 
     TabSupervisor *tabSupervisor;
     WndSets *wndSets;

--- a/cockatrice/src/client/ui/window_main.h
+++ b/cockatrice/src/client/ui/window_main.h
@@ -131,7 +131,7 @@ private:
     void startLocalGame(int numberPlayers);
 
     QList<QMenu *> tabMenus;
-    QMenu *cockatriceMenu, *dbMenu, *helpMenu, *trayIconMenu;
+    QMenu *cockatriceMenu, *dbMenu, *tabsMenu, *helpMenu, *trayIconMenu;
     QAction *aConnect, *aDisconnect, *aSinglePlayer, *aWatchReplay, *aDeckEditor, *aVisualDeckStorage, *aFullScreen,
         *aSettings, *aExit, *aAbout, *aTips, *aCheckCardUpdates, *aRegister, *aForgotPassword, *aUpdate, *aViewLog,
         *aManageSets, *aEditTokens, *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet, *aReloadCardDatabase,


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1963

## What will change with this Pull Request?

All tabs are now closable. 

Added a `Tabs` menu to the main menuBar, containing the currently openable tabs. (It gets updated on connect/disconnect). 

Open tabs are marked with a checkmark. Tabs can be opened and closed from that menu. That menu will also update if tabs are closed with the X button.

The `Deck Editor` action has also been moved to that menu. It's unique in that it isn't checkable and will always open a new deck editor tab.

https://github.com/user-attachments/assets/36df5d30-4b06-41d7-a5d9-43b0a9776a65

- `Tab`
  - `Tab::closeRequest` calls `close` by default
  - `Tab` now emits `closed` signal on close
    - connecting to the `destroyed` signal in order to react to a tab closing was causing segfaults on exit, so I added a `closed` signal
- `TabSupervisor` 
  - Now creates its tabs through methods that are attached to actions 
  - always attaches close button to created tabs
  - nulls out tab widget and toggles menu check on closed signal
- `MainWindow`
  - removed deck editor action
  - The tabsMenu is created in `WindowMain` and passed into `TabSupervisor`'s constructor 
- Doesn't segfault! (I'm pretty sure, at least)

## Screenshots
<img width="465" alt="Screenshot 2025-01-12 at 2 52 23 AM" src="https://github.com/user-attachments/assets/2a36af14-e51a-4c60-84ec-9d98fd9c9efa" />
