### PR TITLE
Make Visual Deck Storage tab be managed by TabSupervisor

### DIFF
--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -164,6 +164,9 @@ TabSupervisor::TabSupervisor(AbstractClient *_client, QMenu *tabsMenu, QWidget *
     resetTabsMenu();
 
     retranslateUi();
+
+    // open always-available tabs on startup
+    aTabVisualDeckStorage->setChecked(SettingsCache::instance().getVisualDeckStorageShowOnLoad());
 }
 
 TabSupervisor::~TabSupervisor()

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -166,6 +166,8 @@ TabSupervisor::TabSupervisor(AbstractClient *_client, QMenu *tabsMenu, QWidget *
     retranslateUi();
 
     // open always-available tabs on startup
+    addDeckEditorTab(nullptr);
+
     aTabVisualDeckStorage->setChecked(SettingsCache::instance().getVisualDeckStorageShowOnLoad());
 }
 
@@ -402,6 +404,7 @@ void TabSupervisor::actTabVisualDeckStorage(bool checked)
     if (checked && !tabVisualDeckStorage) {
         tabVisualDeckStorage = new TabDeckStorageVisual(this, client);
         myAddTab(tabVisualDeckStorage);
+        setCurrentWidget(tabVisualDeckStorage);
         connect(tabVisualDeckStorage, &Tab::closed, this, [this] {
             tabVisualDeckStorage = nullptr;
             aTabVisualDeckStorage->setChecked(false);

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -70,6 +70,7 @@ private:
     AbstractClient *client;
     QList<AbstractClient *> localClients;
     QMenu *tabsMenu;
+    TabDeckStorageVisual *tabVisualDeckStorage;
     TabServer *tabServer;
     TabUserLists *tabUserLists;
     TabDeckStorage *tabDeckStorage;
@@ -83,7 +84,8 @@ private:
     QList<TabDeckEditor *> deckEditorTabs;
     bool isLocalGame;
 
-    QAction *aTabDeckEditor, *aTabServer, *aTabUserLists, *aTabDeckStorage, *aTabReplays, *aTabAdmin, *aTabLog;
+    QAction *aTabDeckEditor, *aTabVisualDeckStorage, *aTabServer, *aTabUserLists, *aTabDeckStorage, *aTabReplays,
+        *aTabAdmin, *aTabLog;
 
     int myAddTab(Tab *tab);
     void addCloseButtonToTab(Tab *tab, int tabIndex);
@@ -136,12 +138,12 @@ signals:
 
 public slots:
     TabDeckEditor *addDeckEditorTab(const DeckLoader *deckToOpen);
-    TabDeckStorageVisual *addVisualDeckStorageTab();
     void openReplay(GameReplay *replay);
     void maximizeMainWindow();
 private slots:
     void refreshShortcuts();
 
+    void actTabVisualDeckStorage(bool checked);
     void actTabServer(bool checked);
     void actTabUserLists(bool checked);
     void actTabDeckStorage(bool checked);

--- a/cockatrice/src/client/tabs/visual_deck_storage/tab_deck_storage_visual.cpp
+++ b/cockatrice/src/client/tabs/visual_deck_storage/tab_deck_storage_visual.cpp
@@ -58,11 +58,6 @@ TabDeckStorageVisual::TabDeckStorageVisual(TabSupervisor *_tabSupervisor, Abstra
     retranslateUi();
 }
 
-void TabDeckStorageVisual::closeRequest(bool /*forced*/)
-{
-    this->close();
-}
-
 void TabDeckStorageVisual::retranslateUi()
 {
     aOpenLocalDeck->setText(tr("Open in deck editor"));

--- a/cockatrice/src/client/tabs/visual_deck_storage/tab_deck_storage_visual.h
+++ b/cockatrice/src/client/tabs/visual_deck_storage/tab_deck_storage_visual.h
@@ -33,7 +33,6 @@ public:
     }
 public slots:
     void cardUpdateFinished(int exitCode, QProcess::ExitStatus exitStatus);
-    void closeRequest(bool forced) override;
     void actOpenLocalDeck(QMouseEvent *event, DeckPreviewWidget *instance);
     void actDeleteLocalDeck();
 signals:

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -39,6 +39,9 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
 
     cardSizeWidget = new CardSizeWidget(this, flowWidget, SettingsCache::instance().getVisualDeckStorageCardSize());
     layout->addWidget(cardSizeWidget);
+
+    connect(CardDatabaseManager::getInstance(), &CardDatabase::cardDatabaseLoadingFinished, this,
+            &VisualDeckStorageWidget::refreshBannerCards);
 }
 
 void VisualDeckStorageWidget::showEvent(QShowEvent *event)

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -290,11 +290,6 @@ void MainWindow::localGameEnded()
     aSinglePlayer->setEnabled(true);
 }
 
-void MainWindow::actVisualDeckStorage()
-{
-    tabSupervisor->addVisualDeckStorageTab();
-}
-
 void MainWindow::actFullScreen(bool checked)
 {
     if (checked)
@@ -664,7 +659,6 @@ void MainWindow::retranslateUi()
     aDisconnect->setText(tr("&Disconnect"));
     aSinglePlayer->setText(tr("Start &local game..."));
     aWatchReplay->setText(tr("&Watch replay..."));
-    aVisualDeckStorage->setText(tr("&Visual Deck storage"));
     aFullScreen->setText(tr("&Full screen"));
     aRegister->setText(tr("&Register to server..."));
     aForgotPassword->setText(tr("&Restore password..."));
@@ -712,8 +706,6 @@ void MainWindow::createActions()
     connect(aSinglePlayer, &QAction::triggered, this, &MainWindow::actSinglePlayer);
     aWatchReplay = new QAction(this);
     connect(aWatchReplay, &QAction::triggered, this, &MainWindow::actWatchReplay);
-    aVisualDeckStorage = new QAction(this);
-    connect(aVisualDeckStorage, &QAction::triggered, this, &MainWindow::actVisualDeckStorage);
     aFullScreen = new QAction(this);
     aFullScreen->setCheckable(true);
     connect(aFullScreen, &QAction::toggled, this, &MainWindow::actFullScreen);
@@ -799,8 +791,6 @@ void MainWindow::createMenus()
     cockatriceMenu->addSeparator();
     cockatriceMenu->addAction(aSinglePlayer);
     cockatriceMenu->addAction(aWatchReplay);
-    cockatriceMenu->addSeparator();
-    cockatriceMenu->addAction(aVisualDeckStorage);
     cockatriceMenu->addSeparator();
     cockatriceMenu->addAction(aFullScreen);
     cockatriceMenu->addSeparator();
@@ -889,10 +879,6 @@ MainWindow::MainWindow(QWidget *parent)
             &MainWindow::refreshShortcuts);
     refreshShortcuts();
 
-    if (SettingsCache::instance().getVisualDeckStorageShowOnLoad()) {
-        connect(CardDatabaseManager::getInstance(), &CardDatabase::cardDatabaseLoadingFinished, tabSupervisor,
-                &TabSupervisor::addVisualDeckStorageTab);
-    }
     connect(CardDatabaseManager::getInstance(), &CardDatabase::cardDatabaseLoadingFailed, this,
             &MainWindow::cardDatabaseLoadingFailed);
     connect(CardDatabaseManager::getInstance(), &CardDatabase::cardDatabaseNewSetsFound, this,

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -860,7 +860,6 @@ MainWindow::MainWindow(QWidget *parent)
     connect(tabSupervisor, &TabSupervisor::setMenu, this, &MainWindow::updateTabMenu);
     connect(tabSupervisor, &TabSupervisor::localGameEnded, this, &MainWindow::localGameEnded);
     connect(tabSupervisor, &TabSupervisor::showWindowIfHidden, this, &MainWindow::showWindowIfHidden);
-    tabSupervisor->addDeckEditorTab(nullptr);
 
     setCentralWidget(tabSupervisor);
 

--- a/cockatrice/src/client/ui/window_main.h
+++ b/cockatrice/src/client/ui/window_main.h
@@ -73,7 +73,6 @@ private slots:
     void actDisconnect();
     void actSinglePlayer();
     void actWatchReplay();
-    void actVisualDeckStorage();
     void actFullScreen(bool checked);
     void actRegister();
     void actSettings();
@@ -131,10 +130,9 @@ private:
 
     QList<QMenu *> tabMenus;
     QMenu *cockatriceMenu, *dbMenu, *tabsMenu, *helpMenu, *trayIconMenu;
-    QAction *aConnect, *aDisconnect, *aSinglePlayer, *aWatchReplay, *aVisualDeckStorage, *aFullScreen, *aSettings,
-        *aExit, *aAbout, *aTips, *aCheckCardUpdates, *aRegister, *aForgotPassword, *aUpdate, *aViewLog, *aManageSets,
-        *aEditTokens, *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet, *aReloadCardDatabase, *aShow,
-        *aOpenSettingsFolder;
+    QAction *aConnect, *aDisconnect, *aSinglePlayer, *aWatchReplay, *aFullScreen, *aSettings, *aExit, *aAbout, *aTips,
+        *aCheckCardUpdates, *aRegister, *aForgotPassword, *aUpdate, *aViewLog, *aManageSets, *aEditTokens,
+        *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet, *aReloadCardDatabase, *aShow, *aOpenSettingsFolder;
 
     TabSupervisor *tabSupervisor;
     WndSets *wndSets;


### PR DESCRIPTION
## Related Ticket(s)
- Followup to #5451 
- Followup to #5427

## Short roundup of the initial problem

Visual Deck Storage is currently like deck editor in that you can open new instances of it. It should probably be a single-instance tab.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/314429c9-63fa-436a-acce-cf4973e89106

- Make visual deck storage a single-instance tab that is managed by the `Tabs` menu.
- Move visual deck storage stuff from `WindowMain` into `TabSupervisor`
- `VisualDeckStorageWidget` now refreshes itself on db load
  - Tab now immediately opens on startup, instead of after db load finishes
  - Still respects the settings for opening visual deck storage on startup


## Screenshots

<img width="400" alt="Screenshot 2025-01-12 at 8 07 42 PM" src="https://github.com/user-attachments/assets/216f789f-6bde-4d0c-b8b0-4d60895fb726" />
