### PR TITLE
Add loadFromFileAsync to deckLoader and connect VisualDeckStorageWidget to it.

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_widget.cpp
@@ -116,7 +116,7 @@ QChar DeckPreviewColorCircleWidget::getColorChar() const
     return colorChar;
 }
 
-DeckPreviewColorIdentityWidget::DeckPreviewColorIdentityWidget(const QString &colorIdentity, QWidget *parent)
+DeckPreviewColorIdentityWidget::DeckPreviewColorIdentityWidget(QWidget *parent, const QString &colorIdentity)
     : QWidget(parent)
 {
     QHBoxLayout *layout = new QHBoxLayout(this);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_widget.h
@@ -11,7 +11,7 @@ class DeckPreviewColorCircleWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit DeckPreviewColorCircleWidget(QChar color, QWidget *parent = nullptr);
+    explicit DeckPreviewColorCircleWidget(QChar color, QWidget *parent);
 
     void setColorActive(bool active);
     QChar getColorChar() const;
@@ -33,7 +33,7 @@ class DeckPreviewColorIdentityWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit DeckPreviewColorIdentityWidget(const QString &colorIdentity, QWidget *parent = nullptr);
+    explicit DeckPreviewColorIdentityWidget(QWidget *parent, const QString &colorIdentity);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -31,25 +31,25 @@ DeckPreviewWidget::DeckPreviewWidget(VisualDeckStorageWidget *_parent, const QSt
 
 void DeckPreviewWidget::initializeUi(const bool deckLoadSuccess)
 {
-    if (deckLoadSuccess) {
-        auto bannerCard = deckLoader->getBannerCard().first.isEmpty()
-                              ? CardInfoPtr()
-                              : CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-                                    deckLoader->getBannerCard().first, deckLoader->getBannerCard().second);
-
-        bannerCardDisplayWidget->setCard(bannerCard);
-        bannerCardDisplayWidget->setOverlayText(deckLoader->getName().isEmpty()
-                                                    ? QFileInfo(deckLoader->getLastFileName()).fileName()
-                                                    : deckLoader->getName());
-        bannerCardDisplayWidget->setFontSize(24);
-        setFilePath(deckLoader->getLastFileName());
-
-        colorIdentityWidget = new DeckPreviewColorIdentityWidget(getColorIdentity());
-        deckTagsDisplayWidget = new DeckPreviewDeckTagsDisplayWidget(this, deckLoader);
-
-        layout->addWidget(colorIdentityWidget);
-        layout->addWidget(deckTagsDisplayWidget);
+    if (!deckLoadSuccess) {
+        return;
     }
+    auto bannerCard = deckLoader->getBannerCard().first.isEmpty()
+                          ? CardInfoPtr()
+                          : CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
+                                deckLoader->getBannerCard().first, deckLoader->getBannerCard().second);
+
+    bannerCardDisplayWidget->setCard(bannerCard);
+    bannerCardDisplayWidget->setOverlayText(
+        deckLoader->getName().isEmpty() ? QFileInfo(deckLoader->getLastFileName()).fileName() : deckLoader->getName());
+    bannerCardDisplayWidget->setFontSize(24);
+    setFilePath(deckLoader->getLastFileName());
+
+    colorIdentityWidget = new DeckPreviewColorIdentityWidget(this, getColorIdentity());
+    deckTagsDisplayWidget = new DeckPreviewDeckTagsDisplayWidget(this, deckLoader);
+
+    layout->addWidget(colorIdentityWidget);
+    layout->addWidget(deckTagsDisplayWidget);
 }
 
 QString DeckPreviewWidget::getColorIdentity()

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -16,12 +16,8 @@ DeckPreviewWidget::DeckPreviewWidget(VisualDeckStorageWidget *_parent, const QSt
     setLayout(layout);
 
     deckLoader = new DeckLoader();
-    deckLoader->loadFromFile(filePath, DeckLoader::CockatriceFormat);
-
-    auto bannerCard = deckLoader->getBannerCard().first.isEmpty()
-                          ? CardInfoPtr()
-                          : CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-                                deckLoader->getBannerCard().first, deckLoader->getBannerCard().second);
+    connect(deckLoader, &DeckLoader::loadFinished, this, &DeckPreviewWidget::initializeUi);
+    deckLoader->loadFromFileAsync(filePath, DeckLoader::CockatriceFormat, false);
 
     bannerCardDisplayWidget = new DeckPreviewCardPictureWidget(this);
 
@@ -30,18 +26,30 @@ DeckPreviewWidget::DeckPreviewWidget(VisualDeckStorageWidget *_parent, const QSt
     connect(bannerCardDisplayWidget, &DeckPreviewCardPictureWidget::imageDoubleClicked, this,
             &DeckPreviewWidget::imageDoubleClickedEvent);
 
-    bannerCardDisplayWidget->setCard(bannerCard);
-    bannerCardDisplayWidget->setOverlayText(
-        deckLoader->getName().isEmpty() ? QFileInfo(deckLoader->getLastFileName()).fileName() : deckLoader->getName());
-    bannerCardDisplayWidget->setFontSize(24);
-    setFilePath(deckLoader->getLastFileName());
-
-    colorIdentityWidget = new DeckPreviewColorIdentityWidget(getColorIdentity());
-    deckTagsDisplayWidget = new DeckPreviewDeckTagsDisplayWidget(this, deckLoader);
-
     layout->addWidget(bannerCardDisplayWidget);
-    layout->addWidget(colorIdentityWidget);
-    layout->addWidget(deckTagsDisplayWidget);
+}
+
+void DeckPreviewWidget::initializeUi(const bool deckLoadSuccess)
+{
+    if (deckLoadSuccess) {
+        auto bannerCard = deckLoader->getBannerCard().first.isEmpty()
+                              ? CardInfoPtr()
+                              : CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
+                                    deckLoader->getBannerCard().first, deckLoader->getBannerCard().second);
+
+        bannerCardDisplayWidget->setCard(bannerCard);
+        bannerCardDisplayWidget->setOverlayText(deckLoader->getName().isEmpty()
+                                                    ? QFileInfo(deckLoader->getLastFileName()).fileName()
+                                                    : deckLoader->getName());
+        bannerCardDisplayWidget->setFontSize(24);
+        setFilePath(deckLoader->getLastFileName());
+
+        colorIdentityWidget = new DeckPreviewColorIdentityWidget(getColorIdentity());
+        deckTagsDisplayWidget = new DeckPreviewDeckTagsDisplayWidget(this, deckLoader);
+
+        layout->addWidget(colorIdentityWidget);
+        layout->addWidget(deckTagsDisplayWidget);
+    }
 }
 
 QString DeckPreviewWidget::getColorIdentity()

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
@@ -35,6 +35,7 @@ public slots:
     void setFilePath(const QString &filePath);
     void imageClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance);
     void imageDoubleClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance);
+    void initializeUi(bool deckLoadSuccess);
 };
 
 #endif // DECK_PREVIEW_WIDGET_H

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -11,10 +11,8 @@
 #include <QFutureWatcher>
 #include <QRegularExpression>
 #include <QStringList>
-#include <qloggingcategory.h>
-#include <qtconcurrentrun.h>
+#include <QtConcurrentRun>
 
-Q_LOGGING_CATEGORY(DeckLoaderLog, "deck_loader")
 
 const QStringList DeckLoader::fileNameFilters = QStringList()
                                                 << QObject::tr("Common deck formats (*.cod *.dec *.dek *.txt *.mwDeck)")
@@ -84,7 +82,7 @@ bool DeckLoader::loadFromFile(const QString &fileName, FileFormat fmt, bool user
 
 bool DeckLoader::loadFromFileAsync(const QString &fileName, FileFormat fmt, bool userRequest)
 {
-    QFutureWatcher<bool> *watcher = new QFutureWatcher<bool>(this);
+    auto *watcher = new QFutureWatcher<bool>(this);
 
     connect(watcher, &QFutureWatcher<bool>::finished, this, [this, watcher, fileName, fmt, userRequest]() {
         const bool result = watcher->result();
@@ -108,23 +106,23 @@ bool DeckLoader::loadFromFileAsync(const QString &fileName, FileFormat fmt, bool
             return false;
         }
 
-        bool result = false;
+
         switch (fmt) {
             case PlainTextFormat:
-                result = loadFromFile_Plain(&file);
-                break;
+                return loadFromFile_Plain(&file);
             case CockatriceFormat: {
+                bool result = false;
                 result = loadFromFile_Native(&file);
                 if (!result) {
                     file.seek(0);
-                    result = loadFromFile_Plain(&file);
+                    return loadFromFile_Plain(&file);
                 }
-                break;
+                return result;
             }
             default:
+                return false;
                 break;
         }
-        return result;
     });
 
     watcher->setFuture(future);

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -13,7 +13,6 @@
 #include <QStringList>
 #include <QtConcurrentRun>
 
-
 const QStringList DeckLoader::fileNameFilters = QStringList()
                                                 << QObject::tr("Common deck formats (*.cod *.dec *.dek *.txt *.mwDeck)")
                                                 << QObject::tr("All files (*.*)");
@@ -105,7 +104,6 @@ bool DeckLoader::loadFromFileAsync(const QString &fileName, FileFormat fmt, bool
         if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
             return false;
         }
-
 
         switch (fmt) {
             case PlainTextFormat:
@@ -229,7 +227,7 @@ struct FormatDeckListForExport
     QString &sideBoardCards;
     // create main operator for struct, allowing the foreachcard to work.
     FormatDeckListForExport(QString &_mainBoardCards, QString &_sideBoardCards)
-        : mainBoardCards(_mainBoardCards), sideBoardCards(_sideBoardCards){};
+        : mainBoardCards(_mainBoardCards), sideBoardCards(_sideBoardCards) {};
 
     void operator()(const InnerDecklistNode *node, const DecklistCardNode *card) const
     {

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -227,7 +227,7 @@ struct FormatDeckListForExport
     QString &sideBoardCards;
     // create main operator for struct, allowing the foreachcard to work.
     FormatDeckListForExport(QString &_mainBoardCards, QString &_sideBoardCards)
-        : mainBoardCards(_mainBoardCards), sideBoardCards(_sideBoardCards) {};
+        : mainBoardCards(_mainBoardCards), sideBoardCards(_sideBoardCards){};
 
     void operator()(const InnerDecklistNode *node, const DecklistCardNode *card) const
     {

--- a/cockatrice/src/deck/deck_loader.h
+++ b/cockatrice/src/deck/deck_loader.h
@@ -3,6 +3,10 @@
 
 #include "decklist.h"
 
+#include <QLoggingCategory>
+
+inline Q_LOGGING_CATEGORY(DeckLoaderLog, "deck_loader")
+
 class DeckLoader : public DeckList
 {
     Q_OBJECT

--- a/cockatrice/src/deck/deck_loader.h
+++ b/cockatrice/src/deck/deck_loader.h
@@ -8,6 +8,7 @@ class DeckLoader : public DeckList
     Q_OBJECT
 signals:
     void deckLoaded();
+    void loadFinished(bool success);
 
 public:
     enum FileFormat
@@ -43,6 +44,7 @@ public:
     static FileFormat getFormatFromName(const QString &fileName);
 
     bool loadFromFile(const QString &fileName, FileFormat fmt, bool userRequest = false);
+    bool loadFromFileAsync(const QString &fileName, FileFormat fmt, bool userRequest);
     bool loadFromRemote(const QString &nativeString, int remoteDeckId);
     bool saveToFile(const QString &fileName, FileFormat fmt);
     bool updateLastLoadedTimestamp(const QString &fileName, FileFormat fmt);

--- a/cockatrice/src/deck/deck_loader.h
+++ b/cockatrice/src/deck/deck_loader.h
@@ -7,7 +7,7 @@
 
 inline Q_LOGGING_CATEGORY(DeckLoaderLog, "deck_loader")
 
-class DeckLoader : public DeckList
+    class DeckLoader : public DeckList
 {
     Q_OBJECT
 signals:


### PR DESCRIPTION
## Short roundup of the initial problem

Loading a lot of decks from file is slow so it should be handled asynchronously.

## What will change with this Pull Request?
- DeckLoader gains the ability to load decks asynchronously from file and notify the calling widget of the load result.
