### PR TITLE
Fix .txt decks not getting saved when they're loaded.

### DIFF
--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -139,6 +139,7 @@ bool DeckLoader::updateLastLoadedTimestamp(const QString &fileName, FileFormat f
     // Perform file modifications
     switch (fmt) {
         case PlainTextFormat:
+            result = saveToFile_Plain(&file);
             break;
         case CockatriceFormat:
             setLastLoadedTimestamp(QDateTime::currentDateTime().toString());


### PR DESCRIPTION
## Short roundup of the initial problem
.txt decks reportedly don't get saved when they're loaded.