### PR TITLE
Fix Windows FlowWidget duplication

### DIFF
--- a/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
@@ -102,8 +102,8 @@ void FlowWidget::clearLayout()
     if (flowLayout != nullptr) {
         QLayoutItem *item;
         while ((item = flowLayout->takeAt(0)) != nullptr) {
-            item->widget()->deleteLater(); // Delete the widget
-            delete item;                   // Delete the layout item
+            delete item->widget(); // Delete the widget
+            delete item;           // Delete the layout item
         }
     } else {
         if (scrollArea->horizontalScrollBarPolicy() != Qt::ScrollBarAlwaysOff &&


### PR DESCRIPTION
- Delete the item widget right away, as the delay is too great with deleteLater

# Current Behavior
## Before DB Loads
![image](https://github.com/user-attachments/assets/bacc4bd3-0c2a-469c-af4f-d2110882126e)

## After DB Loads
![image](https://github.com/user-attachments/assets/453f3b2a-bf69-4fcd-8349-c5237031cf0e)


# New Behavior
## Before DB Loads
![image](https://github.com/user-attachments/assets/b154ab37-06b9-4b3f-9c0f-831affb2d2b9)

## After DB Loads
![image](https://github.com/user-attachments/assets/4b52b396-8873-4e20-8e94-330b233e8dcb)
