### PR TITLE
Remove unnecessary deck_view.h includes

### DIFF
--- a/cockatrice/src/client/tabs/visual_deck_storage/tab_deck_storage_visual.h
+++ b/cockatrice/src/client/tabs/visual_deck_storage/tab_deck_storage_visual.h
@@ -2,7 +2,6 @@
 #define TAB_DECK_STORAGE_VISUAL_H
 
 #include "../../../deck/deck_list_model.h"
-#include "../../../deck/deck_view.h"
 #include "../../ui/widgets/cards/deck_preview_card_picture_widget.h"
 #include "../../ui/widgets/visual_deck_storage/visual_deck_storage_widget.h"
 #include "../tab.h"

--- a/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.h
@@ -2,7 +2,6 @@
 #define ALL_ZONES_CARD_AMOUNT_WIDGET_H
 #include "../../../../deck/deck_list_model.h"
 #include "../../../../deck/deck_loader.h"
-#include "../../../../deck/deck_view.h"
 #include "card_amount_widget.h"
 
 #include <QVBoxLayout>

--- a/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.cpp
@@ -1,5 +1,6 @@
 #include "card_amount_widget.h"
 
+#include <QPainter>
 #include <QTimer>
 
 /**

--- a/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.h
@@ -3,7 +3,6 @@
 
 #include "../../../../deck/deck_list_model.h"
 #include "../../../../deck/deck_loader.h"
-#include "../../../../deck/deck_view.h"
 #include "../../../../game/cards/card_database.h"
 #include "../../../tabs/tab_deck_editor.h"
 #include "../general/display/dynamic_font_size_push_button.h"

--- a/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.h
@@ -9,7 +9,6 @@
 
 #include <QHBoxLayout>
 #include <QLabel>
-#include <QPropertyAnimation>
 #include <QPushButton>
 #include <QTreeView>
 #include <QWidget>

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.h
@@ -2,7 +2,6 @@
 #define PRINTING_SELECTOR_H
 
 #include "../../../../deck/deck_list_model.h"
-#include "../../../../deck/deck_view.h"
 #include "../../../../game/cards/card_database.h"
 #include "../cards/card_size_widget.h"
 #include "../general/layout_containers/flow_widget.h"

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.h
@@ -3,7 +3,6 @@
 
 #include "../../../../client/ui/widgets/cards/card_info_picture_widget.h"
 #include "../../../../deck/deck_list_model.h"
-#include "../../../../deck/deck_view.h"
 #include "../../../../game/cards/card_database.h"
 #include "../../../tabs/tab_deck_editor.h"
 #include "all_zones_card_amount_widget.h"

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.h
@@ -5,14 +5,10 @@
 #include "../../../../deck/deck_list_model.h"
 #include "../../../../game/cards/card_database.h"
 #include "../../../tabs/tab_deck_editor.h"
-#include "all_zones_card_amount_widget.h"
-#include "card_amount_widget.h"
 #include "printing_selector_card_overlay_widget.h"
 #include "set_name_and_collectors_number_display_widget.h"
 
-#include <QLabel>
 #include <QPainter>
-#include <QPushButton>
 #include <QTreeView>
 #include <QVBoxLayout>
 #include <QWidget>

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.h
@@ -3,7 +3,6 @@
 
 #include "../../../../client/ui/widgets/cards/card_info_picture_widget.h"
 #include "../../../../deck/deck_list_model.h"
-#include "../../../../deck/deck_view.h"
 #include "../../../../game/cards/card_database.h"
 #include "../../../tabs/tab_deck_editor.h"
 #include "all_zones_card_amount_widget.h"

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -2,7 +2,6 @@
 #define VISUAL_DECK_STORAGE_WIDGET_H
 
 #include "../../../../deck/deck_list_model.h"
-#include "../../../../deck/deck_view.h"
 #include "../../../ui/widgets/general/layout_containers/flow_widget.h"
 #include "../cards/card_size_widget.h"
 #include "deck_preview/deck_preview_color_identity_filter_widget.h"
@@ -43,7 +42,6 @@ private:
     QHBoxLayout *searchAndSortLayout;
     FlowWidget *flowWidget;
     DeckListModel *deckListModel;
-    QMap<QString, DeckViewCardContainer *> cardContainers;
 
     VisualDeckStorageSortWidget *sortWidget;
     VisualDeckStorageSearchWidget *searchWidget;


### PR DESCRIPTION
## Short roundup of the initial problem

Some files are including `deck_view.h` despite not using anything in it.

## What will change with this Pull Request?
- Remove `#include deck_view.h` from all files that don't use it
- Also clean up some other includes in those files while at it

