### PR TITLE
Rename TabUserLists to TabAccount

### DIFF
--- a/cockatrice/src/client/tabs/tab_account.cpp
+++ b/cockatrice/src/client/tabs/tab_account.cpp
@@ -18,7 +18,7 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 
-TabUserLists::TabUserLists(TabSupervisor *_tabSupervisor, AbstractClient *_client, const ServerInfo_User &userInfo)
+TabAccount::TabAccount(TabSupervisor *_tabSupervisor, AbstractClient *_client, const ServerInfo_User &userInfo)
     : Tab(_tabSupervisor), client(_client)
 {
     allUsersList = new UserList(_tabSupervisor, client, UserList::AllUsersList);
@@ -27,22 +27,22 @@ TabUserLists::TabUserLists(TabSupervisor *_tabSupervisor, AbstractClient *_clien
     userInfoBox = new UserInfoBox(client, true);
     userInfoBox->updateInfo(userInfo);
 
-    connect(allUsersList, &UserList::openMessageDialog, this, &TabUserLists::openMessageDialog);
-    connect(buddyList, &UserList::openMessageDialog, this, &TabUserLists::openMessageDialog);
-    connect(ignoreList, &UserList::openMessageDialog, this, &TabUserLists::openMessageDialog);
+    connect(allUsersList, &UserList::openMessageDialog, this, &TabAccount::openMessageDialog);
+    connect(buddyList, &UserList::openMessageDialog, this, &TabAccount::openMessageDialog);
+    connect(ignoreList, &UserList::openMessageDialog, this, &TabAccount::openMessageDialog);
 
-    connect(client, &AbstractClient::userJoinedEventReceived, this, &TabUserLists::processUserJoinedEvent);
-    connect(client, &AbstractClient::userLeftEventReceived, this, &TabUserLists::processUserLeftEvent);
-    connect(client, &AbstractClient::buddyListReceived, this, &TabUserLists::buddyListReceived);
-    connect(client, &AbstractClient::ignoreListReceived, this, &TabUserLists::ignoreListReceived);
-    connect(client, &AbstractClient::addToListEventReceived, this, &TabUserLists::processAddToListEvent);
-    connect(client, &AbstractClient::removeFromListEventReceived, this, &TabUserLists::processRemoveFromListEvent);
+    connect(client, &AbstractClient::userJoinedEventReceived, this, &TabAccount::processUserJoinedEvent);
+    connect(client, &AbstractClient::userLeftEventReceived, this, &TabAccount::processUserLeftEvent);
+    connect(client, &AbstractClient::buddyListReceived, this, &TabAccount::buddyListReceived);
+    connect(client, &AbstractClient::ignoreListReceived, this, &TabAccount::ignoreListReceived);
+    connect(client, &AbstractClient::addToListEventReceived, this, &TabAccount::processAddToListEvent);
+    connect(client, &AbstractClient::removeFromListEventReceived, this, &TabAccount::processRemoveFromListEvent);
 
     PendingCommand *pend = client->prepareSessionCommand(Command_ListUsers());
     connect(pend,
             static_cast<void (PendingCommand::*)(const Response &, const CommandContainer &, const QVariant &)>(
                 &PendingCommand::finished),
-            this, &TabUserLists::processListUsersResponse);
+            this, &TabAccount::processListUsersResponse);
     client->sendCommand(pend);
 
     QVBoxLayout *vbox = new QVBoxLayout;
@@ -53,9 +53,9 @@ TabUserLists::TabUserLists(TabSupervisor *_tabSupervisor, AbstractClient *_clien
     addBuddyEdit = new LineEditUnfocusable;
     addBuddyEdit->setMaxLength(MAX_NAME_LENGTH);
     addBuddyEdit->setPlaceholderText(tr("Add to Buddy List"));
-    connect(addBuddyEdit, &LineEditUnfocusable::returnPressed, this, &TabUserLists::addToBuddyList);
+    connect(addBuddyEdit, &LineEditUnfocusable::returnPressed, this, &TabAccount::addToBuddyList);
     QPushButton *addBuddyButton = new QPushButton("Add");
-    connect(addBuddyButton, &QPushButton::clicked, this, &TabUserLists::addToBuddyList);
+    connect(addBuddyButton, &QPushButton::clicked, this, &TabAccount::addToBuddyList);
     addToBuddyList->addWidget(addBuddyEdit);
     addToBuddyList->addWidget(addBuddyButton);
 
@@ -63,9 +63,9 @@ TabUserLists::TabUserLists(TabSupervisor *_tabSupervisor, AbstractClient *_clien
     addIgnoreEdit = new LineEditUnfocusable;
     addIgnoreEdit->setMaxLength(MAX_NAME_LENGTH);
     addIgnoreEdit->setPlaceholderText(tr("Add to Ignore List"));
-    connect(addIgnoreEdit, &LineEditUnfocusable::returnPressed, this, &TabUserLists::addToIgnoreList);
+    connect(addIgnoreEdit, &LineEditUnfocusable::returnPressed, this, &TabAccount::addToIgnoreList);
     QPushButton *addIgnoreButton = new QPushButton("Add");
-    connect(addIgnoreButton, &QPushButton::clicked, this, &TabUserLists::addToIgnoreList);
+    connect(addIgnoreButton, &QPushButton::clicked, this, &TabAccount::addToIgnoreList);
     addToIgnoreList->addWidget(addIgnoreEdit);
     addToIgnoreList->addWidget(addIgnoreButton);
 
@@ -89,7 +89,7 @@ TabUserLists::TabUserLists(TabSupervisor *_tabSupervisor, AbstractClient *_clien
     setCentralWidget(mainWidget);
 }
 
-void TabUserLists::addToBuddyList()
+void TabAccount::addToBuddyList()
 {
     QString userName = addBuddyEdit->text();
     if (userName.length() < 1)
@@ -100,7 +100,7 @@ void TabUserLists::addToBuddyList()
     addBuddyEdit->clear();
 }
 
-void TabUserLists::addToIgnoreList()
+void TabAccount::addToIgnoreList()
 {
     QString userName = addIgnoreEdit->text();
     if (userName.length() < 1)
@@ -111,7 +111,7 @@ void TabUserLists::addToIgnoreList()
     addIgnoreEdit->clear();
 }
 
-void TabUserLists::addToList(const std::string &listName, const QString &userName)
+void TabAccount::addToList(const std::string &listName, const QString &userName)
 {
     Command_AddToList cmd;
     cmd.set_list(listName);
@@ -120,7 +120,7 @@ void TabUserLists::addToList(const std::string &listName, const QString &userNam
     client->sendCommand(client->prepareSessionCommand(cmd));
 }
 
-void TabUserLists::retranslateUi()
+void TabAccount::retranslateUi()
 {
     allUsersList->retranslateUi();
     buddyList->retranslateUi();
@@ -128,7 +128,7 @@ void TabUserLists::retranslateUi()
     userInfoBox->retranslateUi();
 }
 
-void TabUserLists::processListUsersResponse(const Response &response)
+void TabAccount::processListUsersResponse(const Response &response)
 {
     const Response_ListUsers &resp = response.GetExtension(Response_ListUsers::ext);
 
@@ -146,7 +146,7 @@ void TabUserLists::processListUsersResponse(const Response &response)
     buddyList->sortItems();
 }
 
-void TabUserLists::processUserJoinedEvent(const Event_UserJoined &event)
+void TabAccount::processUserJoinedEvent(const Event_UserJoined &event)
 {
     const ServerInfo_User &info = event.user_info();
     const QString userName = QString::fromStdString(info.name());
@@ -165,7 +165,7 @@ void TabUserLists::processUserJoinedEvent(const Event_UserJoined &event)
     emit userJoined(info);
 }
 
-void TabUserLists::processUserLeftEvent(const Event_UserLeft &event)
+void TabAccount::processUserLeftEvent(const Event_UserLeft &event)
 {
     QString userName = QString::fromStdString(event.name());
 
@@ -182,21 +182,21 @@ void TabUserLists::processUserLeftEvent(const Event_UserLeft &event)
     }
 }
 
-void TabUserLists::buddyListReceived(const QList<ServerInfo_User> &_buddyList)
+void TabAccount::buddyListReceived(const QList<ServerInfo_User> &_buddyList)
 {
     for (int i = 0; i < _buddyList.size(); ++i)
         buddyList->processUserInfo(_buddyList[i], false);
     buddyList->sortItems();
 }
 
-void TabUserLists::ignoreListReceived(const QList<ServerInfo_User> &_ignoreList)
+void TabAccount::ignoreListReceived(const QList<ServerInfo_User> &_ignoreList)
 {
     for (int i = 0; i < _ignoreList.size(); ++i)
         ignoreList->processUserInfo(_ignoreList[i], false);
     ignoreList->sortItems();
 }
 
-void TabUserLists::processAddToListEvent(const Event_AddToList &event)
+void TabAccount::processAddToListEvent(const Event_AddToList &event)
 {
     const ServerInfo_User &info = event.user_info();
     bool online = allUsersList->getUsers().contains(QString::fromStdString(info.name()));
@@ -213,7 +213,7 @@ void TabUserLists::processAddToListEvent(const Event_AddToList &event)
     userList->sortItems();
 }
 
-void TabUserLists::processRemoveFromListEvent(const Event_RemoveFromList &event)
+void TabAccount::processRemoveFromListEvent(const Event_RemoveFromList &event)
 {
     QString list = QString::fromStdString(event.list_name());
     QString user = QString::fromStdString(event.user_name());

--- a/cockatrice/src/client/tabs/tab_account.h
+++ b/cockatrice/src/client/tabs/tab_account.h
@@ -17,7 +17,7 @@ class ServerInfo_User;
 class Event_AddToList;
 class Event_RemoveFromList;
 
-class TabUserLists : public Tab
+class TabAccount : public Tab
 {
     Q_OBJECT
 signals:
@@ -46,7 +46,7 @@ private:
     void addToList(const std::string &listName, const QString &userName);
 
 public:
-    TabUserLists(TabSupervisor *_tabSupervisor, AbstractClient *_client, const ServerInfo_User &userInfo);
+    TabAccount(TabSupervisor *_tabSupervisor, AbstractClient *_client, const ServerInfo_User &userInfo);
     void retranslateUi() override;
     QString getTabText() const override
     {

--- a/cockatrice/src/client/tabs/tab_room.cpp
+++ b/cockatrice/src/client/tabs/tab_room.cpp
@@ -282,7 +282,7 @@ void TabRoom::processRoomSayEvent(const Event_RoomSay &event)
     QString senderName = QString::fromStdString(event.name());
     QString message = QString::fromStdString(event.message());
 
-    if (tabSupervisor->getUserListsTab()->getIgnoreList()->getUsers().contains(senderName))
+    if (tabSupervisor->getTabAccount()->getIgnoreList()->getUsers().contains(senderName))
         return;
 
     UserListTWI *twi = userList->getUsers().value(senderName);

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -102,7 +102,7 @@ void CloseButton::paintEvent(QPaintEvent * /*event*/)
 
 TabSupervisor::TabSupervisor(AbstractClient *_client, QMenu *tabsMenu, QWidget *parent)
     : QTabWidget(parent), userInfo(0), client(_client), tabsMenu(tabsMenu), tabVisualDeckStorage(nullptr), tabServer(0),
-      tabUserLists(0), tabDeckStorage(0), tabReplays(0), tabAdmin(0), tabLog(0)
+      tabAccount(0), tabDeckStorage(0), tabReplays(0), tabAdmin(0), tabLog(0)
 {
     setElideMode(Qt::ElideRight);
     setMovable(true);
@@ -137,9 +137,9 @@ TabSupervisor::TabSupervisor(AbstractClient *_client, QMenu *tabsMenu, QWidget *
     aTabServer->setCheckable(true);
     connect(aTabServer, &QAction::toggled, this, &TabSupervisor::actTabServer);
 
-    aTabUserLists = new QAction(this);
-    aTabUserLists->setCheckable(true);
-    connect(aTabUserLists, &QAction::toggled, this, &TabSupervisor::actTabUserLists);
+    aTabAccount = new QAction(this);
+    aTabAccount->setCheckable(true);
+    connect(aTabAccount, &QAction::toggled, this, &TabSupervisor::actTabAccount);
 
     aTabDeckStorage = new QAction(this);
     aTabDeckStorage->setCheckable(true);
@@ -182,7 +182,7 @@ void TabSupervisor::retranslateUi()
     aTabDeckEditor->setText(tr("Deck Editor"));
     aTabVisualDeckStorage->setText(tr("&Visual Deck storage"));
     aTabServer->setText(tr("Server"));
-    aTabUserLists->setText(tr("Account"));
+    aTabAccount->setText(tr("Account"));
     aTabDeckStorage->setText(tr("Deck storage"));
     aTabReplays->setText(tr("Game replays"));
     aTabAdmin->setText(tr("Administration"));
@@ -194,7 +194,7 @@ void TabSupervisor::retranslateUi()
     tabs.append(tabReplays);
     tabs.append(tabDeckStorage);
     tabs.append(tabAdmin);
-    tabs.append(tabUserLists);
+    tabs.append(tabAccount);
     tabs.append(tabLog);
     QMapIterator<int, TabRoom *> roomIterator(roomTabs);
     while (roomIterator.hasNext())
@@ -295,10 +295,10 @@ void TabSupervisor::start(const ServerInfo_User &_userInfo)
 
     tabsMenu->addSeparator();
     tabsMenu->addAction(aTabServer);
-    tabsMenu->addAction(aTabUserLists);
+    tabsMenu->addAction(aTabAccount);
 
     aTabServer->setChecked(true);
-    aTabUserLists->setChecked(true);
+    aTabAccount->setChecked(true);
 
     updatePingTime(0, -1);
 
@@ -326,7 +326,7 @@ void TabSupervisor::startLocal(const QList<AbstractClient *> &_clients)
 {
     resetTabsMenu();
 
-    tabUserLists = 0;
+    tabAccount = 0;
     tabDeckStorage = 0;
     tabReplays = 0;
     tabAdmin = 0;
@@ -357,8 +357,8 @@ void TabSupervisor::stop()
 
         emit localGameEnded();
     } else {
-        if (tabUserLists) {
-            tabUserLists->closeRequest(true);
+        if (tabAccount) {
+            tabAccount->closeRequest(true);
         }
         if (tabServer) {
             tabServer->closeRequest(true);
@@ -429,20 +429,20 @@ void TabSupervisor::actTabServer(bool checked)
     }
 }
 
-void TabSupervisor::actTabUserLists(bool checked)
+void TabSupervisor::actTabAccount(bool checked)
 {
-    if (checked && !tabUserLists) {
-        tabUserLists = new TabAccount(this, client, *userInfo);
-        connect(tabUserLists, &TabAccount::openMessageDialog, this, &TabSupervisor::addMessageTab);
-        connect(tabUserLists, &TabAccount::userJoined, this, &TabSupervisor::processUserJoined);
-        connect(tabUserLists, &TabAccount::userLeft, this, &TabSupervisor::processUserLeft);
-        myAddTab(tabUserLists);
-        connect(tabUserLists, &Tab::closed, this, [this] {
-            tabUserLists = nullptr;
-            aTabUserLists->setChecked(false);
+    if (checked && !tabAccount) {
+        tabAccount = new TabAccount(this, client, *userInfo);
+        connect(tabAccount, &TabAccount::openMessageDialog, this, &TabSupervisor::addMessageTab);
+        connect(tabAccount, &TabAccount::userJoined, this, &TabSupervisor::processUserJoined);
+        connect(tabAccount, &TabAccount::userLeft, this, &TabSupervisor::processUserLeft);
+        myAddTab(tabAccount);
+        connect(tabAccount, &Tab::closed, this, [this] {
+            tabAccount = nullptr;
+            aTabAccount->setChecked(false);
         });
-    } else if (!checked && tabUserLists) {
-        tabUserLists->closeRequest();
+    } else if (!checked && tabAccount) {
+        tabAccount->closeRequest();
     }
 }
 
@@ -616,7 +616,7 @@ TabMessage *TabSupervisor::addMessageTab(const QString &receiverName, bool focus
         return nullptr;
 
     ServerInfo_User otherUser;
-    UserListTWI *twi = tabUserLists->getAllUsersList()->getUsers().value(receiverName);
+    UserListTWI *twi = tabAccount->getAllUsersList()->getUsers().value(receiverName);
     if (twi)
         otherUser = twi->getUserInfo();
     else
@@ -717,7 +717,7 @@ void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)
     if (!tab)
         tab = messageTabs.value(QString::fromStdString(event.receiver_name()));
     if (!tab) {
-        UserListTWI *twi = tabUserLists->getAllUsersList()->getUsers().value(senderName);
+        UserListTWI *twi = tabAccount->getAllUsersList()->getUsers().value(senderName);
         if (twi) {
             UserLevelFlags userLevel = UserLevelFlags(twi->getUserInfo().user_level());
             if (SettingsCache::instance().getIgnoreUnregisteredUserMessages() &&
@@ -754,7 +754,7 @@ void TabSupervisor::processUserJoined(const ServerInfo_User &userInfoJoined)
 {
     QString userName = QString::fromStdString(userInfoJoined.name());
     if (isUserBuddy(userName)) {
-        Tab *tab = static_cast<Tab *>(getUserListsTab());
+        Tab *tab = static_cast<Tab *>(getTabAccount());
 
         if (tab != currentWidget()) {
             tab->setContentsChanged(true);
@@ -861,33 +861,33 @@ QString TabSupervisor::getOwnUsername() const
 
 bool TabSupervisor::isUserBuddy(const QString &userName) const
 {
-    if (!getUserListsTab())
+    if (!getTabAccount())
         return false;
-    if (!getUserListsTab()->getBuddyList())
+    if (!getTabAccount()->getBuddyList())
         return false;
-    QMap<QString, UserListTWI *> buddyList = getUserListsTab()->getBuddyList()->getUsers();
+    QMap<QString, UserListTWI *> buddyList = getTabAccount()->getBuddyList()->getUsers();
     bool senderIsBuddy = buddyList.contains(userName);
     return senderIsBuddy;
 }
 
 bool TabSupervisor::isUserIgnored(const QString &userName) const
 {
-    if (!getUserListsTab())
+    if (!getTabAccount())
         return false;
-    if (!getUserListsTab()->getIgnoreList())
+    if (!getTabAccount()->getIgnoreList())
         return false;
-    QMap<QString, UserListTWI *> buddyList = getUserListsTab()->getIgnoreList()->getUsers();
+    QMap<QString, UserListTWI *> buddyList = getTabAccount()->getIgnoreList()->getUsers();
     bool senderIsBuddy = buddyList.contains(userName);
     return senderIsBuddy;
 }
 
 const ServerInfo_User *TabSupervisor::getOnlineUser(const QString &userName) const
 {
-    if (!getUserListsTab())
+    if (!getTabAccount())
         return nullptr;
-    if (!getUserListsTab()->getAllUsersList())
+    if (!getTabAccount()->getAllUsersList())
         return nullptr;
-    QMap<QString, UserListTWI *> userList = getUserListsTab()->getAllUsersList()->getUsers();
+    QMap<QString, UserListTWI *> userList = getTabAccount()->getAllUsersList()->getUsers();
     const QString &userNameToMatchLower = userName.toLower();
     QMap<QString, UserListTWI *>::iterator i;
 

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -432,10 +432,10 @@ void TabSupervisor::actTabServer(bool checked)
 void TabSupervisor::actTabUserLists(bool checked)
 {
     if (checked && !tabUserLists) {
-        tabUserLists = new TabUserLists(this, client, *userInfo);
-        connect(tabUserLists, &TabUserLists::openMessageDialog, this, &TabSupervisor::addMessageTab);
-        connect(tabUserLists, &TabUserLists::userJoined, this, &TabSupervisor::processUserJoined);
-        connect(tabUserLists, &TabUserLists::userLeft, this, &TabSupervisor::processUserLeft);
+        tabUserLists = new TabAccount(this, client, *userInfo);
+        connect(tabUserLists, &TabAccount::openMessageDialog, this, &TabSupervisor::addMessageTab);
+        connect(tabUserLists, &TabAccount::userJoined, this, &TabSupervisor::processUserJoined);
+        connect(tabUserLists, &TabAccount::userLeft, this, &TabSupervisor::processUserLeft);
         myAddTab(tabUserLists);
         connect(tabUserLists, &Tab::closed, this, [this] {
             tabUserLists = nullptr;

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -72,7 +72,7 @@ private:
     QMenu *tabsMenu;
     TabDeckStorageVisual *tabVisualDeckStorage;
     TabServer *tabServer;
-    TabAccount *tabUserLists;
+    TabAccount *tabAccount;
     TabDeckStorage *tabDeckStorage;
     TabReplays *tabReplays;
     TabAdmin *tabAdmin;
@@ -84,7 +84,7 @@ private:
     QList<TabDeckEditor *> deckEditorTabs;
     bool isLocalGame;
 
-    QAction *aTabDeckEditor, *aTabVisualDeckStorage, *aTabServer, *aTabUserLists, *aTabDeckStorage, *aTabReplays,
+    QAction *aTabDeckEditor, *aTabVisualDeckStorage, *aTabServer, *aTabAccount, *aTabDeckStorage, *aTabReplays,
         *aTabAdmin, *aTabLog;
 
     int myAddTab(Tab *tab);
@@ -108,9 +108,9 @@ public:
     {
         return gameTabs.size();
     }
-    TabAccount *getUserListsTab() const
+    TabAccount *getTabAccount() const
     {
-        return tabUserLists;
+        return tabAccount;
     }
     ServerInfo_User *getUserInfo() const
     {
@@ -145,7 +145,7 @@ private slots:
 
     void actTabVisualDeckStorage(bool checked);
     void actTabServer(bool checked);
-    void actTabUserLists(bool checked);
+    void actTabAccount(bool checked);
     void actTabDeckStorage(bool checked);
     void actTabReplays(bool checked);
     void actTabAdmin(bool checked);

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -21,7 +21,7 @@ class TabDeckStorage;
 class TabReplays;
 class TabAdmin;
 class TabMessage;
-class TabUserLists;
+class TabAccount;
 class TabDeckEditor;
 class TabLog;
 class RoomEvent;
@@ -72,7 +72,7 @@ private:
     QMenu *tabsMenu;
     TabDeckStorageVisual *tabVisualDeckStorage;
     TabServer *tabServer;
-    TabUserLists *tabUserLists;
+    TabAccount *tabUserLists;
     TabDeckStorage *tabDeckStorage;
     TabReplays *tabReplays;
     TabAdmin *tabAdmin;
@@ -108,7 +108,7 @@ public:
     {
         return gameTabs.size();
     }
-    TabUserLists *getUserListsTab() const
+    TabAccount *getUserListsTab() const
     {
         return tabUserLists;
     }

--- a/cockatrice/src/game/games_model.cpp
+++ b/cockatrice/src/game/games_model.cpp
@@ -508,7 +508,7 @@ bool GamesProxyModel::filterAcceptsRow(int sourceRow) const
     if (!showBuddiesOnlyGames && game.only_buddies()) {
         return false;
     }
-    if (hideIgnoredUserGames && tabSupervisor->getUserListsTab()->getIgnoreList()->getUsers().contains(
+    if (hideIgnoredUserGames && tabSupervisor->getTabAccount()->getIgnoreList()->getUsers().contains(
                                     QString::fromStdString(game.creator_info().name()))) {
         return false;
     }


### PR DESCRIPTION
## Short roundup of the initial problem

The class for the account tab being named `TabUserLists` is unintuitive. Even the file is named `tab_account`.

## What will change with this Pull Request?

- Rename `TabUserLists` and all usages of it to `TabAccount`
