### PR TITLE
Reduce spacing in visual deck storage

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_search_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_search_widget.cpp
@@ -11,7 +11,7 @@
 VisualDeckStorageSearchWidget::VisualDeckStorageSearchWidget(VisualDeckStorageWidget *parent) : parent(parent)
 {
     layout = new QHBoxLayout(this);
-    layout->setContentsMargins(9, 0, 9, 0);
+    layout->setContentsMargins(0, 0, 0, 0);
     setLayout(layout);
 
     searchBar = new QLineEdit(this);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
@@ -14,6 +14,7 @@ VisualDeckStorageSortWidget::VisualDeckStorageSortWidget(VisualDeckStorageWidget
     : parent(parent), sortOrder(Alphabetical)
 {
     layout = new QHBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
     setLayout(layout);
 
     // Initialize the ComboBox

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
@@ -16,8 +16,7 @@ VisualDeckStorageTagFilterWidget::VisualDeckStorageTagFilterWidget(VisualDeckSto
 
     // Create layout
     auto *layout = new QHBoxLayout(this);
-    layout->setContentsMargins(5, 5, 5, 5);
-    layout->setSpacing(5);
+    layout->setContentsMargins(5, 0, 5, 0);
 
     setFixedHeight(100);
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -23,10 +23,10 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
 
     searchAndSortLayout = new QHBoxLayout();
 
+    deckPreviewColorIdentityFilterWidget = new DeckPreviewColorIdentityFilterWidget(this);
     sortWidget = new VisualDeckStorageSortWidget(this);
     searchWidget = new VisualDeckStorageSearchWidget(this);
     tagFilterWidget = new VisualDeckStorageTagFilterWidget(this);
-    deckPreviewColorIdentityFilterWidget = new DeckPreviewColorIdentityFilterWidget(this);
 
     searchAndSortLayout->addWidget(deckPreviewColorIdentityFilterWidget);
     searchAndSortLayout->addWidget(sortWidget);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -19,9 +19,13 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     deckListModel->setObjectName("visualDeckModel");
 
     layout = new QVBoxLayout();
+    layout->setSpacing(0);
+    layout->setContentsMargins(9, 0, 9, 5);
     setLayout(layout);
 
     searchAndSortLayout = new QHBoxLayout();
+    searchAndSortLayout->setSpacing(3);
+    searchAndSortLayout->setContentsMargins(9, 0, 9, 0);
 
     deckPreviewColorIdentityFilterWidget = new DeckPreviewColorIdentityFilterWidget(this);
     sortWidget = new VisualDeckStorageSortWidget(this);


### PR DESCRIPTION

## Short roundup of the initial problem

Visual deck storage has some unused space

## What will change with this Pull Request

- Reduced spacing in visual deck storage
- Moved deckPreviewColorIdentityFilterWidget up in the code so it's in order of insertion

## Screenshots

#### Visual Deck Storage Tab
![before 1](https://github.com/user-attachments/assets/86184342-3c5b-4255-92a3-5b44c24a3bda)
![after 1](https://github.com/user-attachments/assets/307e04e9-42b6-4249-9731-09c90b6cecf0)

#### Game Lobby
![before 2](https://github.com/user-attachments/assets/70e981d6-760d-475b-b0ff-d8760e422cff)
![after 2](https://github.com/user-attachments/assets/98734bc5-3e01-47b3-80ac-a6fe17da230d)
