### PR TITLE
Don't re-sort VisualDeckStorage every time it gets tabbed to

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
@@ -20,21 +20,26 @@ VisualDeckStorageSortWidget::VisualDeckStorageSortWidget(VisualDeckStorageWidget
     sortComboBox = new QComboBox(this);
     layout->addWidget(sortComboBox);
 
+    // Need to retranslateUi first so that the sortComboBox actually has entries and doesn't get its currentIndex
+    // immediately capped to 0 when we try to set it
+    retranslateUi();
+
     // Set the current sort order
     sortComboBox->setCurrentIndex(SettingsCache::instance().getVisualDeckStorageSortingOrder());
+    sortOrder = static_cast<SortOrder>(sortComboBox->currentIndex());
 
     // Connect sorting change signal to refresh the file list
     connect(sortComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &VisualDeckStorageSortWidget::updateSortOrder);
     connect(this, &VisualDeckStorageSortWidget::sortOrderChanged, parent, &VisualDeckStorageWidget::updateSortOrder);
-
-    retranslateUi();
 }
 
 void VisualDeckStorageSortWidget::retranslateUi()
 {
     // Block signals to avoid triggering unnecessary updates while changing text
     sortComboBox->blockSignals(true);
+
+    int oldIndex = sortComboBox->currentIndex();
 
     // Clear and repopulate the ComboBox with translated items
     sortComboBox->clear();
@@ -44,7 +49,7 @@ void VisualDeckStorageSortWidget::retranslateUi()
     sortComboBox->addItem(tr("Sort by Last Loaded"), ByLastLoaded);
 
     // Restore the current index
-    sortComboBox->setCurrentIndex(SettingsCache::instance().getVisualDeckStorageSortingOrder());
+    sortComboBox->setCurrentIndex(oldIndex);
 
     // Re-enable signals
     sortComboBox->blockSignals(false);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
@@ -50,13 +50,6 @@ void VisualDeckStorageSortWidget::retranslateUi()
     sortComboBox->blockSignals(false);
 }
 
-void VisualDeckStorageSortWidget::showEvent(QShowEvent *event)
-{
-    QWidget::showEvent(event);
-    sortComboBox->setCurrentIndex(SettingsCache::instance().getVisualDeckStorageSortingOrder());
-    updateSortOrder();
-}
-
 void VisualDeckStorageSortWidget::updateSortOrder()
 {
     sortOrder = static_cast<SortOrder>(sortComboBox->currentIndex());

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.h
@@ -19,9 +19,6 @@ public:
     QString getSearchText();
     QList<DeckPreviewWidget *> &filterFiles(QList<DeckPreviewWidget *> &widgets);
 
-public slots:
-    void showEvent(QShowEvent *event) override;
-
 signals:
     void sortOrderChanged();
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -42,6 +42,11 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
 
     connect(CardDatabaseManager::getInstance(), &CardDatabase::cardDatabaseLoadingFinished, this,
             &VisualDeckStorageWidget::refreshBannerCards);
+
+    // Don't waste time processing the cards if they're going to get refreshed anyway once the db finishes loading
+    if (CardDatabaseManager::getInstance()->getLoadStatus() == LoadStatus::Ok) {
+        refreshBannerCards();
+    }
 }
 
 void VisualDeckStorageWidget::updateSortOrder()

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -44,12 +44,6 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
             &VisualDeckStorageWidget::refreshBannerCards);
 }
 
-void VisualDeckStorageWidget::showEvent(QShowEvent *event)
-{
-    QWidget::showEvent(event);
-    updateSortOrder();
-}
-
 void VisualDeckStorageWidget::updateSortOrder()
 {
     refreshBannerCards(); // Refresh the banner cards with the new sort order

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -29,7 +29,6 @@ public slots:
     void refreshBannerCards(); // Refresh the display of cards based on the current sorting option
     QStringList gatherAllTagsFromFlowWidget() const;
     QStringList gatherAllTags(const QList<DeckPreviewWidget *> &allDecks);
-    void showEvent(QShowEvent *event) override;
     void updateSortOrder();
 
 signals:


### PR DESCRIPTION
## Short roundup of the initial problem

Currently, `VisualDeckStorageWidget` has a overridden `showEvent` method that calls the method to re-sort the decks. `showEvent` will get triggered every time the tab changes to it, causing every tab change to visual deck editor to have a small delay. This is completely unnecessary.

https://github.com/user-attachments/assets/96225278-c985-43d0-b0c2-0056a5694b04

## What will change with this Pull Request?
- Removed the overridden `showEvent` methods from `VisualDeckStorageWidget` and `VisualDeckStorageSortWidget`
  - Tabbing to visual deck storage now has no delay
- Made some fixes so that the decks get loaded with the proper sort order on startup and on tab open.

https://github.com/user-attachments/assets/2746a7f1-42ce-453e-a0b0-d25815bfcbcc

