### PR TITLE
Remember which tabs are open between sessions

### DIFF
--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -278,7 +278,7 @@ void TabSupervisor::initStartupTabs()
 {
     addDeckEditorTab(nullptr);
 
-    checkAndTrigger(aTabVisualDeckStorage, SettingsCache::instance().getVisualDeckStorageShowOnLoad());
+    checkAndTrigger(aTabVisualDeckStorage, SettingsCache::instance().getTabVisualDeckStorageOpen());
 }
 
 /**

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -451,6 +451,7 @@ void TabSupervisor::stop()
 
 void TabSupervisor::actTabVisualDeckStorage(bool checked)
 {
+    SettingsCache::instance().setTabVisualDeckStorageOpen(checked);
     if (checked && !tabVisualDeckStorage) {
         tabVisualDeckStorage = new TabDeckStorageVisual(this, client);
         myAddTab(tabVisualDeckStorage, aTabVisualDeckStorage);
@@ -466,6 +467,7 @@ void TabSupervisor::actTabVisualDeckStorage(bool checked)
 
 void TabSupervisor::actTabServer(bool checked)
 {
+    SettingsCache::instance().setTabServerOpen(checked);
     if (checked && !tabServer) {
         tabServer = new TabServer(this, client);
         connect(tabServer, &TabServer::roomJoined, this, &TabSupervisor::addRoomTab);
@@ -481,6 +483,7 @@ void TabSupervisor::actTabServer(bool checked)
 
 void TabSupervisor::actTabAccount(bool checked)
 {
+    SettingsCache::instance().setTabAccountOpen(checked);
     if (checked && !tabAccount) {
         tabAccount = new TabAccount(this, client, *userInfo);
         connect(tabAccount, &TabAccount::openMessageDialog, this, &TabSupervisor::addMessageTab);
@@ -498,6 +501,7 @@ void TabSupervisor::actTabAccount(bool checked)
 
 void TabSupervisor::actTabDeckStorage(bool checked)
 {
+    SettingsCache::instance().setTabDeckStorageOpen(checked);
     if (checked && !tabDeckStorage) {
         tabDeckStorage = new TabDeckStorage(this, client);
         connect(tabDeckStorage, &TabDeckStorage::openDeckEditor, this, &TabSupervisor::addDeckEditorTab);
@@ -513,6 +517,7 @@ void TabSupervisor::actTabDeckStorage(bool checked)
 
 void TabSupervisor::actTabReplays(bool checked)
 {
+    SettingsCache::instance().setTabReplaysOpen(checked);
     if (checked && !tabReplays) {
         tabReplays = new TabReplays(this, client);
         connect(tabReplays, &TabReplays::openReplay, this, &TabSupervisor::openReplay);
@@ -528,6 +533,7 @@ void TabSupervisor::actTabReplays(bool checked)
 
 void TabSupervisor::actTabAdmin(bool checked)
 {
+    SettingsCache::instance().setTabAdminOpen(checked);
     if (checked && !tabAdmin) {
         tabAdmin = new TabAdmin(this, client, (userInfo->user_level() & ServerInfo_User::IsAdmin));
         connect(tabAdmin, &TabAdmin::adminLockChanged, this, &TabSupervisor::adminLockChanged);
@@ -543,6 +549,7 @@ void TabSupervisor::actTabAdmin(bool checked)
 
 void TabSupervisor::actTabLog(bool checked)
 {
+    SettingsCache::instance().setTabLogOpen(checked);
     if (checked && !tabLog) {
         tabLog = new TabLog(this, client);
         myAddTab(tabLog, aTabLog);

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -295,6 +295,15 @@ int TabSupervisor::myAddTab(Tab *tab)
     return idx;
 }
 
+void TabSupervisor::addCloseButtonToTab(Tab *tab, int tabIndex)
+{
+    auto closeSide = static_cast<QTabBar::ButtonPosition>(
+        tabBar()->style()->styleHint(QStyle::SH_TabBar_CloseButtonPosition, nullptr, tabBar()));
+    auto *closeButton = new CloseButton(tab);
+    connect(closeButton, &CloseButton::clicked, tab, [tab] { tab->closeRequest(); });
+    tabBar()->setTabButton(tabIndex, closeSide, closeButton);
+}
+
 /**
  * Resets the tabs menu to the tabs that are always available
  */
@@ -533,15 +542,6 @@ void TabSupervisor::updatePingTime(int value, int max)
         return;
 
     setTabIcon(indexOf(tabServer), QIcon(PingPixmapGenerator::generatePixmap(15, value, max)));
-}
-
-void TabSupervisor::addCloseButtonToTab(Tab *tab, int tabIndex)
-{
-    auto closeSide = static_cast<QTabBar::ButtonPosition>(
-        tabBar()->style()->styleHint(QStyle::SH_TabBar_CloseButtonPosition, nullptr, tabBar()));
-    auto *closeButton = new CloseButton(tab);
-    connect(closeButton, &CloseButton::clicked, tab, [tab] { tab->closeRequest(); });
-    tabBar()->setTabButton(tabIndex, closeSide, closeButton);
 }
 
 void TabSupervisor::gameJoined(const Event_GameJoined &event)

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -87,6 +87,8 @@ private:
     QAction *aTabDeckEditor, *aTabVisualDeckStorage, *aTabServer, *aTabAccount, *aTabDeckStorage, *aTabReplays,
         *aTabAdmin, *aTabLog;
 
+    void initStartupTabs();
+
     int myAddTab(Tab *tab);
     void addCloseButtonToTab(Tab *tab, int tabIndex);
     QString sanitizeTabName(QString dirty) const;

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -89,8 +89,8 @@ private:
 
     void initStartupTabs();
 
-    int myAddTab(Tab *tab);
-    void addCloseButtonToTab(Tab *tab, int tabIndex);
+    int myAddTab(Tab *tab, QAction *manager = nullptr);
+    void addCloseButtonToTab(Tab *tab, int tabIndex, QAction *manager);
     QString sanitizeTabName(QString dirty) const;
     QString sanitizeHtml(QString dirty) const;
     void resetTabsMenu();

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -346,10 +346,6 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     showShortcutsCheckBox.setChecked(settings.getShowShortcuts());
     connect(&showShortcutsCheckBox, &QCheckBox::QT_STATE_CHANGED, this, &AppearanceSettingsPage::showShortcutsChanged);
 
-    showVisualDeckStorageOnLoadCheckBox.setChecked(settings.getVisualDeckStorageShowOnLoad());
-    connect(&showVisualDeckStorageOnLoadCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings,
-            &SettingsCache::setVisualDeckStorageShowOnLoad);
-
     visualDeckStorageDrawUnusedColorIdentitiesCheckBox.setChecked(
         settings.getVisualDeckStorageDrawUnusedColorIdentities());
     connect(&visualDeckStorageDrawUnusedColorIdentitiesCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings,
@@ -366,10 +362,9 @@ AppearanceSettingsPage::AppearanceSettingsPage()
 
     auto *menuGrid = new QGridLayout;
     menuGrid->addWidget(&showShortcutsCheckBox, 0, 0);
-    menuGrid->addWidget(&showVisualDeckStorageOnLoadCheckBox, 1, 0);
-    menuGrid->addWidget(&visualDeckStorageDrawUnusedColorIdentitiesCheckBox, 2, 0);
-    menuGrid->addWidget(&visualDeckStorageUnusedColorIdentitiesOpacityLabel, 3, 0);
-    menuGrid->addWidget(&visualDeckStorageUnusedColorIdentitiesOpacitySpinBox, 3, 1);
+    menuGrid->addWidget(&visualDeckStorageDrawUnusedColorIdentitiesCheckBox, 1, 0);
+    menuGrid->addWidget(&visualDeckStorageUnusedColorIdentitiesOpacityLabel, 2, 0);
+    menuGrid->addWidget(&visualDeckStorageUnusedColorIdentitiesOpacitySpinBox, 2, 1);
 
     menuGroupBox = new QGroupBox;
     menuGroupBox->setLayout(menuGrid);
@@ -504,7 +499,6 @@ void AppearanceSettingsPage::retranslateUi()
 
     menuGroupBox->setTitle(tr("Menu settings"));
     showShortcutsCheckBox.setText(tr("Show keyboard shortcuts in right-click menus"));
-    showVisualDeckStorageOnLoadCheckBox.setText(tr("Show visual deck storage on database load"));
     visualDeckStorageDrawUnusedColorIdentitiesCheckBox.setText(
         tr("Draw missing color identities in visual deck storage without color label"));
     visualDeckStorageUnusedColorIdentitiesOpacityLabel.setText(tr("Missing color identity opacity"));

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -95,7 +95,6 @@ private:
     QLabel minPlayersForMultiColumnLayoutLabel;
     QLabel maxFontSizeForCardsLabel;
     QCheckBox showShortcutsCheckBox;
-    QCheckBox showVisualDeckStorageOnLoadCheckBox;
     QCheckBox visualDeckStorageDrawUnusedColorIdentitiesCheckBox;
     QLabel visualDeckStorageUnusedColorIdentitiesOpacityLabel;
     QSpinBox visualDeckStorageUnusedColorIdentitiesOpacitySpinBox;

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -212,6 +212,14 @@ SettingsCache::SettingsCache()
 
     themeName = settings->value("theme/name").toString();
 
+    tabVisualDeckStorageOpen = settings->value("tabs/visualDeckStorage", true).toBool();
+    tabServerOpen = settings->value("tabs/server", true).toBool();
+    tabAccountOpen = settings->value("tabs/account", true).toBool();
+    tabDeckStorageOpen = settings->value("tabs/deckStorage", true).toBool();
+    tabReplaysOpen = settings->value("tabs/replays", true).toBool();
+    tabAdminOpen = settings->value("tabs/admin", true).toBool();
+    tabLogOpen = settings->value("tabs/log", true).toBool();
+
     // we only want to reset the cache once, then its up to the user
     bool updateCache = settings->value("revert/pixmapCacheSize", false).toBool();
     if (!updateCache) {
@@ -484,6 +492,48 @@ void SettingsCache::setThemeName(const QString &_themeName)
     themeName = _themeName;
     settings->setValue("theme/name", themeName);
     emit themeChanged();
+}
+
+void SettingsCache::setTabVisualDeckStorageOpen(bool value)
+{
+    tabVisualDeckStorageOpen = value;
+    settings->setValue("tabs/visualDeckStorage", tabVisualDeckStorageOpen);
+}
+
+void SettingsCache::setTabServerOpen(bool value)
+{
+    tabServerOpen = value;
+    settings->setValue("tabs/server", tabServerOpen);
+}
+
+void SettingsCache::setTabAccountOpen(bool value)
+{
+    tabAccountOpen = value;
+    settings->setValue("tabs/account", tabAccountOpen);
+}
+
+void SettingsCache::setTabDeckStorageOpen(bool value)
+{
+    tabDeckStorageOpen = value;
+    settings->setValue("tabs/deckStorage", tabDeckStorageOpen);
+}
+
+void SettingsCache::setTabReplaysOpen(bool value)
+{
+    tabReplaysOpen = value;
+    settings->setValue("tabs/replays", tabReplaysOpen);
+}
+
+void SettingsCache::setTabAdminOpen(bool value)
+{
+    tabAdminOpen = value;
+    settings->setValue("tabs/admin", tabAdminOpen);
+}
+
+void SettingsCache::setTabLogOpen(bool value)
+{
+    tabLogOpen = value;
+    settings->setValue("tabs/log", tabLogOpen);
 }
 
 void SettingsCache::setPicDownload(QT_STATE_CHANGED_T _picDownload)

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -268,7 +268,6 @@ SettingsCache::SettingsCache()
     printingSelectorNavigationButtonsVisible =
         settings->value("cards/printingselectornavigationbuttonsvisible", true).toBool();
     visualDeckStorageCardSize = settings->value("cards/visualdeckstoragecardsize", 100).toInt();
-    visualDeckStorageShowOnLoad = settings->value("interface/visualdeckstorageshowonload", true).toBool();
     visualDeckStorageSortingOrder = settings->value("interface/visualdeckstoragesortingorder", 0).toInt();
     visualDeckStorageDrawUnusedColorIdentities =
         settings->value("interface/visualdeckstoragedrawunusedcoloridentities", true).toBool();
@@ -677,12 +676,6 @@ void SettingsCache::setVisualDeckStorageCardSize(int _visualDeckStorageCardSize)
     visualDeckStorageCardSize = _visualDeckStorageCardSize;
     settings->setValue("cards/visualdeckstoragecardsize", visualDeckStorageCardSize);
     emit visualDeckStorageCardSizeChanged();
-}
-
-void SettingsCache::setVisualDeckStorageShowOnLoad(QT_STATE_CHANGED_T _visualDeckStorageShowOnLoad)
-{
-    visualDeckStorageShowOnLoad = _visualDeckStorageShowOnLoad;
-    settings->setValue("interface/visualdeckstorageshowonload", visualDeckStorageShowOnLoad);
 }
 
 void SettingsCache::setVisualDeckStorageDrawUnusedColorIdentities(

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -130,7 +130,6 @@ private:
     int visualDeckStorageCardSize;
     bool visualDeckStorageDrawUnusedColorIdentities;
     int visualDeckStorageUnusedColorIdentitiesOpacity;
-    bool visualDeckStorageShowOnLoad;
     bool horizontalHand;
     bool invertVerticalCoordinate;
     int minPlayersForMultiColumnLayout;
@@ -420,10 +419,6 @@ public:
     int getVisualDeckStorageUnusedColorIdentitiesOpacity() const
     {
         return visualDeckStorageUnusedColorIdentitiesOpacity;
-    }
-    bool getVisualDeckStorageShowOnLoad() const
-    {
-        return visualDeckStorageShowOnLoad;
     }
     bool getHorizontalHand() const
     {
@@ -744,7 +739,6 @@ public slots:
     void setVisualDeckStorageCardSize(int _visualDeckStorageCardSize);
     void setVisualDeckStorageDrawUnusedColorIdentities(QT_STATE_CHANGED_T _visualDeckStorageDrawUnusedColorIdentities);
     void setVisualDeckStorageUnusedColorIdentitiesOpacity(int _visualDeckStorageUnusedColorIdentitiesOpacity);
-    void setVisualDeckStorageShowOnLoad(QT_STATE_CHANGED_T _visualDeckStorageShowOnLoad);
     void setHorizontalHand(QT_STATE_CHANGED_T _horizontalHand);
     void setInvertVerticalCoordinate(QT_STATE_CHANGED_T _invertVerticalCoordinate);
     void setMinPlayersForMultiColumnLayout(int _minPlayersForMultiColumnLayout);

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -96,6 +96,8 @@ private:
     QString lang;
     QString deckPath, replaysPath, picsPath, redirectCachePath, customPicsPath, cardDatabasePath,
         customCardDatabasePath, themesPath, spoilerDatabasePath, tokenDatabasePath, themeName;
+    bool tabVisualDeckStorageOpen, tabServerOpen, tabAccountOpen, tabDeckStorageOpen, tabReplaysOpen, tabAdminOpen,
+        tabLogOpen;
     bool checkUpdatesOnStartup;
     bool notifyAboutUpdates;
     bool notifyAboutNewVersion;
@@ -253,6 +255,34 @@ public:
     QString getThemeName() const
     {
         return themeName;
+    }
+    bool getTabVisualDeckStorageOpen() const
+    {
+        return tabVisualDeckStorageOpen;
+    }
+    bool getTabServerOpen() const
+    {
+        return tabServerOpen;
+    }
+    bool getTabAccountOpen() const
+    {
+        return tabAccountOpen;
+    }
+    bool getTabDeckStorageOpen() const
+    {
+        return tabDeckStorageOpen;
+    }
+    bool getTabReplaysOpen() const
+    {
+        return tabReplaysOpen;
+    }
+    bool getTabAdminOpen() const
+    {
+        return tabAdminOpen;
+    }
+    bool getTabLogOpen() const
+    {
+        return tabLogOpen;
     }
     QString getChatMentionColor() const
     {
@@ -681,6 +711,13 @@ public slots:
     void setSpoilerDatabasePath(const QString &_spoilerDatabasePath);
     void setTokenDatabasePath(const QString &_tokenDatabasePath);
     void setThemeName(const QString &_themeName);
+    void setTabVisualDeckStorageOpen(bool value);
+    void setTabServerOpen(bool value);
+    void setTabAccountOpen(bool value);
+    void setTabDeckStorageOpen(bool value);
+    void setTabReplaysOpen(bool value);
+    void setTabAdminOpen(bool value);
+    void setTabLogOpen(bool value);
     void setChatMentionColor(const QString &_chatMentionColor);
     void setChatHighlightColor(const QString &_chatHighlightColor);
     void setPicDownload(QT_STATE_CHANGED_T _picDownload);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -124,6 +124,27 @@ void SettingsCache::setTokenDatabasePath(const QString & /* _tokenDatabasePath *
 void SettingsCache::setThemeName(const QString & /* _themeName */)
 {
 }
+void SettingsCache::setTabVisualDeckStorageOpen(bool /*value*/)
+{
+}
+void SettingsCache::setTabServerOpen(bool /*value*/)
+{
+}
+void SettingsCache::setTabAccountOpen(bool /*value*/)
+{
+}
+void SettingsCache::setTabDeckStorageOpen(bool /*value*/)
+{
+}
+void SettingsCache::setTabReplaysOpen(bool /*value*/)
+{
+}
+void SettingsCache::setTabAdminOpen(bool /*value*/)
+{
+}
+void SettingsCache::setTabLogOpen(bool /*value*/)
+{
+}
 void SettingsCache::setPicDownload(QT_STATE_CHANGED_T /* _picDownload */)
 {
 }

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -211,9 +211,6 @@ void SettingsCache::setVisualDeckStorageSortingOrder(int /* _visualDeckStorageSo
 void SettingsCache::setVisualDeckStorageCardSize(int /* _visualDeckStorageCardSize */)
 {
 }
-void SettingsCache::setVisualDeckStorageShowOnLoad(QT_STATE_CHANGED_T /* _visualDeckStorageShowOnLoad */)
-{
-}
 void SettingsCache::setVisualDeckStorageDrawUnusedColorIdentities(
     QT_STATE_CHANGED_T /* _visualDeckStorageDrawUnusedColorIdentities */)
 {

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -215,9 +215,6 @@ void SettingsCache::setVisualDeckStorageSortingOrder(int /* _visualDeckStorageSo
 void SettingsCache::setVisualDeckStorageCardSize(int /* _visualDeckStorageCardSize */)
 {
 }
-void SettingsCache::setVisualDeckStorageShowOnLoad(QT_STATE_CHANGED_T /* _visualDeckStorageShowOnLoad */)
-{
-}
 void SettingsCache::setVisualDeckStorageDrawUnusedColorIdentities(
     QT_STATE_CHANGED_T /* _visualDeckStorageDrawUnusedColorIdentities */)
 {

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -128,6 +128,27 @@ void SettingsCache::setTokenDatabasePath(const QString & /* _tokenDatabasePath *
 void SettingsCache::setThemeName(const QString & /* _themeName */)
 {
 }
+void SettingsCache::setTabVisualDeckStorageOpen(bool /*value*/)
+{
+}
+void SettingsCache::setTabServerOpen(bool /*value*/)
+{
+}
+void SettingsCache::setTabAccountOpen(bool /*value*/)
+{
+}
+void SettingsCache::setTabDeckStorageOpen(bool /*value*/)
+{
+}
+void SettingsCache::setTabReplaysOpen(bool /*value*/)
+{
+}
+void SettingsCache::setTabAdminOpen(bool /*value*/)
+{
+}
+void SettingsCache::setTabLogOpen(bool /*value*/)
+{
+}
 void SettingsCache::setPicDownload(QT_STATE_CHANGED_T /* _picDownload */)
 {
 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5442
- Requires #5464 to be merged first

## What will change with this Pull Request?

The open state of each managed tab is now persisted in settings. Cockatrice will remember which tabs are open between sessions, and between connect/disconnect.

A tab being forcibly closed will not update the persisted state. That means, for example, if you disconnect, then all server-only tabs that were open when you disconnected will be opened again when you reconnect.

- Added the new settings to `global.ini` under `tabs`
  - Removed the `Open Visual Deck Storage on load` setting, since it's redundant now.
- Slightly refactored how TabSupervisor manages the single-instance tabs and how the tab menu actions trigger, in order to facilitate the new changes
  - Moved `addCloseButtonToTab` closer to `myAddTab`
    - added new param to those two methods
    - For single-instance tabs, the close button's trigger will now uncheck the tab's menu action; the menu action will handle the closing of the tab.
