### PR TITLE
Minor fix to sorted list reconstruction to fix duplication of cards in printing selector.

### DIFF
--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.cpp
@@ -103,7 +103,7 @@ QList<CardInfoPerSet> PrintingSelectorCardSortingWidget::sortSets(const CardInfo
         for (auto it = cardInfoPerSets.begin(); it != cardInfoPerSets.end(); ++it) {
             for (const auto &cardInfoPerSet : it.value()) {
                 if (cardInfoPerSet.getPtr() == set) {
-                    sortedCardInfoPerSets << it.value();
+                    sortedCardInfoPerSets << cardInfoPerSet;
                     break;
                 }
             }


### PR DESCRIPTION
## Short roundup of the initial problem

Cards were getting duplicated because we reconstructed the list in a derpy way.
