### PR TITLE
fix segfault that happens when account tab is closed

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -159,6 +159,7 @@ set(cockatrice_SOURCES
     src/server/user/user_context_menu.cpp
     src/server/user/user_info_connection.cpp
     src/server/user/user_info_box.cpp
+    src/server/user/user_list_manager.cpp
     src/server/user/user_list_widget.cpp
     src/client/ui/window_main.cpp
     src/game/zones/view_zone_widget.cpp

--- a/cockatrice/src/client/tabs/tab_account.h
+++ b/cockatrice/src/client/tabs/tab_account.h
@@ -52,18 +52,6 @@ public:
     {
         return tr("Account");
     }
-    const UserListWidget *getAllUsersList() const
-    {
-        return allUsersList;
-    }
-    const UserListWidget *getBuddyList() const
-    {
-        return buddyList;
-    }
-    const UserListWidget *getIgnoreList() const
-    {
-        return ignoreList;
-    }
 };
 
 #endif

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -123,15 +123,16 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, GameReplay *_replay)
 }
 
 TabGame::TabGame(TabSupervisor *_tabSupervisor,
+                 UserlistProxy *_userListProxy,
                  QList<AbstractClient *> &_clients,
                  const Event_GameJoined &event,
                  const QMap<int, QString> &_roomGameTypes)
-    : Tab(_tabSupervisor), clients(_clients), gameInfo(event.game_info()), roomGameTypes(_roomGameTypes),
-      hostId(event.host_id()), localPlayerId(event.player_id()), isLocalGame(_tabSupervisor->getIsLocalGame()),
-      spectator(event.spectator()), judge(event.judge()), gameStateKnown(false), resuming(event.resuming()),
-      currentPhase(-1), activeCard(nullptr), gameClosed(false), replay(nullptr), replayPlayButton(nullptr),
-      replayFastForwardButton(nullptr), aReplaySkipForward(nullptr), aReplaySkipBackward(nullptr),
-      aReplaySkipForwardBig(nullptr), aReplaySkipBackwardBig(nullptr), replayDock(nullptr)
+    : Tab(_tabSupervisor), userListProxy(_userListProxy), clients(_clients), gameInfo(event.game_info()),
+      roomGameTypes(_roomGameTypes), hostId(event.host_id()), localPlayerId(event.player_id()),
+      isLocalGame(_tabSupervisor->getIsLocalGame()), spectator(event.spectator()), judge(event.judge()),
+      gameStateKnown(false), resuming(event.resuming()), currentPhase(-1), activeCard(nullptr), gameClosed(false),
+      replay(nullptr), replayPlayButton(nullptr), replayFastForwardButton(nullptr), aReplaySkipForward(nullptr),
+      aReplaySkipBackward(nullptr), aReplaySkipForwardBig(nullptr), aReplaySkipBackwardBig(nullptr), replayDock(nullptr)
 {
     // THIS CTOR IS USED ON GAMES
     gameInfo.set_started(false);
@@ -1683,7 +1684,7 @@ void TabGame::createPlayerListDock(bool bReplay)
 
 void TabGame::createMessageDock(bool bReplay)
 {
-    messageLog = new MessageLogWidget(tabSupervisor, tabSupervisor, this);
+    messageLog = new MessageLogWidget(tabSupervisor, userListProxy, this);
     connect(messageLog, SIGNAL(cardNameHovered(QString)), cardInfoFrameWidget, SLOT(setCard(QString)));
     connect(messageLog, &MessageLogWidget::showCardInfoPopup, this, &TabGame::showCardInfoPopup);
     connect(messageLog, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -11,6 +11,7 @@
 #include <QCompleter>
 #include <QMap>
 
+class UserlistProxy;
 class DeckViewContainer;
 class AbstractClient;
 class CardDatabase;
@@ -66,6 +67,7 @@ class TabGame : public Tab
 private:
     QTimer *gameTimer;
     int secondsElapsed;
+    UserlistProxy *userListProxy;
     QList<AbstractClient *> clients;
     ServerInfo_Game gameInfo;
     QMap<int, QString> roomGameTypes;
@@ -210,6 +212,7 @@ private slots:
 
 public:
     TabGame(TabSupervisor *_tabSupervisor,
+            UserlistProxy *_userListProxy,
             QList<AbstractClient *> &_clients,
             const Event_GameJoined &event,
             const QMap<int, QString> &_roomGameTypes);

--- a/cockatrice/src/client/tabs/tab_message.cpp
+++ b/cockatrice/src/client/tabs/tab_message.cpp
@@ -4,6 +4,7 @@
 #include "../../main.h"
 #include "../../server/chat_view/chat_view.h"
 #include "../../server/pending_command.h"
+#include "../../server/user/user_list_manager.h"
 #include "../../settings/cache_settings.h"
 #include "../game_logic/abstract_client.h"
 #include "../sound_engine.h"
@@ -25,7 +26,7 @@ TabMessage::TabMessage(TabSupervisor *_tabSupervisor,
     : Tab(_tabSupervisor), client(_client), ownUserInfo(new ServerInfo_User(_ownUserInfo)),
       otherUserInfo(new ServerInfo_User(_otherUserInfo)), userOnline(true)
 {
-    chatView = new ChatView(tabSupervisor, tabSupervisor, 0, true);
+    chatView = new ChatView(tabSupervisor, tabSupervisor->getUserListManager(), 0, true);
     connect(chatView, &ChatView::showCardInfoPopup, this, &TabMessage::showCardInfoPopup);
     connect(chatView, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));
     connect(chatView, SIGNAL(addMentionTag(QString)), this, SLOT(addMentionTag(QString)));

--- a/cockatrice/src/client/tabs/tab_room.h
+++ b/cockatrice/src/client/tabs/tab_room.h
@@ -9,6 +9,8 @@
 #include <QKeyEvent>
 #include <QMap>
 
+class UserlistProxy;
+class UserListManager;
 namespace google
 {
 namespace protobuf
@@ -49,6 +51,7 @@ private:
 
     GameSelector *gameSelector;
     UserListWidget *userList;
+    const UserlistProxy *userListProxy;
     ChatView *chatView;
     QLabel *sayLabel;
     LineEditCompleter *sayEdit;
@@ -89,6 +92,7 @@ public:
     TabRoom(TabSupervisor *_tabSupervisor,
             AbstractClient *_client,
             ServerInfo_User *_ownUser,
+            const UserlistProxy *_userListProxy,
             const ServerInfo_Room &info);
     void retranslateUi() override;
     void closeRequest(bool forced = false) override;

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -11,6 +11,7 @@
 #include <QProxyStyle>
 #include <QTabWidget>
 
+class UserListManager;
 class QMenu;
 class AbstractClient;
 class Tab;
@@ -62,12 +63,13 @@ protected:
     void paintEvent(QPaintEvent *event) override;
 };
 
-class TabSupervisor : public QTabWidget, public UserlistProxy
+class TabSupervisor : public QTabWidget
 {
     Q_OBJECT
 private:
     ServerInfo_User *userInfo;
     AbstractClient *client;
+    UserListManager *userListManager;
     QList<AbstractClient *> localClients;
     QMenu *tabsMenu;
     TabDeckStorageVisual *tabVisualDeckStorage;
@@ -117,17 +119,16 @@ public:
         return userInfo;
     }
     AbstractClient *getClient() const;
+    const UserListManager *getUserListManager() const
+    {
+        return userListManager;
+    }
     const QMap<int, TabRoom *> &getRoomTabs() const
     {
         return roomTabs;
     }
     bool getAdminLocked() const;
     bool closeRequest();
-    bool isOwnUserRegistered() const override;
-    QString getOwnUsername() const override;
-    bool isUserBuddy(const QString &userName) const override;
-    bool isUserIgnored(const QString &userName) const override;
-    const ServerInfo_User *getOnlineUser(const QString &userName) const override;
     bool switchToGameTabIfAlreadyExists(const int gameId);
     void actShowPopup(const QString &message);
 signals:

--- a/cockatrice/src/game/game_selector.cpp
+++ b/cockatrice/src/game/game_selector.cpp
@@ -9,6 +9,7 @@
 #include "../dialogs/dlg_create_game.h"
 #include "../dialogs/dlg_filter_games.h"
 #include "../server/pending_command.h"
+#include "../server/user/user_list_manager.h"
 #include "games_model.h"
 #include "pb/response.pb.h"
 #include "pb/room_commands.pb.h"
@@ -39,7 +40,7 @@ GameSelector::GameSelector(AbstractClient *_client,
     gameListView = new QTreeView;
     gameListModel = new GamesModel(_rooms, _gameTypes, this);
     if (showFilters) {
-        gameListProxyModel = new GamesProxyModel(this, tabSupervisor);
+        gameListProxyModel = new GamesProxyModel(this, tabSupervisor->getUserListManager());
         gameListProxyModel->setSourceModel(gameListModel);
         gameListProxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
         gameListView->setModel(gameListProxyModel);

--- a/cockatrice/src/game/games_model.h
+++ b/cockatrice/src/game/games_model.h
@@ -1,7 +1,6 @@
 #ifndef GAMESMODEL_H
 #define GAMESMODEL_H
 
-#include "../client/tabs/tab_supervisor.h"
 #include "game_type_map.h"
 #include "pb/serverinfo_game.pb.h"
 
@@ -11,6 +10,8 @@
 #include <QSortFilterProxyModel>
 #include <QStringList>
 #include <QTime>
+
+class UserlistProxy;
 
 class GamesModel : public QAbstractTableModel
 {
@@ -65,8 +66,7 @@ class GamesProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
 private:
-    bool ownUserIsRegistered;
-    const TabSupervisor *tabSupervisor;
+    const UserlistProxy *userListProxy;
 
     // If adding any additional filters, make sure to update:
     // - GamesProxyModel()
@@ -88,7 +88,7 @@ private:
         showOnlyIfSpectatorsCanSeeHands;
 
 public:
-    GamesProxyModel(QObject *parent = nullptr, const TabSupervisor *_tabSupervisor = nullptr);
+    GamesProxyModel(QObject *parent = nullptr, const UserlistProxy *_userListProxy = nullptr);
 
     bool getShowBuddiesOnlyGames() const
     {

--- a/cockatrice/src/game/player/player_list_widget.cpp
+++ b/cockatrice/src/game/player/player_list_widget.cpp
@@ -6,6 +6,7 @@
 #include "../../client/tabs/tab_supervisor.h"
 #include "../../client/ui/pixel_map_generator.h"
 #include "../../server/user/user_context_menu.h"
+#include "../../server/user/user_list_manager.h"
 #include "../../server/user/user_list_widget.h"
 #include "pb/command_kick_from_game.pb.h"
 #include "pb/serverinfo_playerproperties.pb.h"
@@ -71,7 +72,7 @@ PlayerListWidget::PlayerListWidget(TabSupervisor *_tabSupervisor,
         itemDelegate = new PlayerListItemDelegate(this);
         setItemDelegate(itemDelegate);
 
-        userContextMenu = new UserContextMenu(tabSupervisor, this, game);
+        userContextMenu = new UserContextMenu(tabSupervisor, tabSupervisor->getUserListManager(), this, game);
         connect(userContextMenu, &UserContextMenu::openMessageDialog, this, &PlayerListWidget::openMessageDialog);
     } else {
         userContextMenu = nullptr;

--- a/cockatrice/src/server/chat_view/chat_view.cpp
+++ b/cockatrice/src/server/chat_view/chat_view.cpp
@@ -45,7 +45,7 @@ ChatView::ChatView(TabSupervisor *_tabSupervisor,
         linkColor = palette().link().color();
     }
 
-    userContextMenu = new UserContextMenu(tabSupervisor, this, game);
+    userContextMenu = new UserContextMenu(tabSupervisor, userlistProxy, this, game);
     connect(userContextMenu, SIGNAL(openMessageDialog(QString, bool)), this, SIGNAL(openMessageDialog(QString, bool)));
 
     ownUserName = userlistProxy->getOwnUsername();

--- a/cockatrice/src/server/user/user_context_menu.h
+++ b/cockatrice/src/server/user/user_context_menu.h
@@ -5,6 +5,7 @@
 
 #include <QObject>
 
+class UserlistProxy;
 class AbstractClient;
 class ChatView;
 class CommandContainer;
@@ -22,6 +23,7 @@ class UserContextMenu : public QObject
 private:
     AbstractClient *client;
     TabSupervisor *tabSupervisor;
+    const UserlistProxy *userListProxy;
     TabGame *game;
 
     QAction *aUserName;
@@ -52,7 +54,10 @@ private slots:
     void gamesOfUserReceived(const Response &resp, const CommandContainer &commandContainer);
 
 public:
-    UserContextMenu(TabSupervisor *_tabSupervisor, QWidget *_parent, TabGame *_game = 0);
+    UserContextMenu(TabSupervisor *_tabSupervisor,
+                    const UserlistProxy *_userListProxy,
+                    QWidget *_parent,
+                    TabGame *_game = 0);
     void retranslateUi();
     void showContextMenu(const QPoint &pos,
                          const QString &userName,

--- a/cockatrice/src/server/user/user_list_manager.cpp
+++ b/cockatrice/src/server/user/user_list_manager.cpp
@@ -1,0 +1,170 @@
+#include "user_list_manager.h"
+
+#include "../../client/game_logic/abstract_client.h"
+#include "../../client/sound_engine.h"
+#include "../pending_command.h"
+#include "pb/event_add_to_list.pb.h"
+#include "pb/event_remove_from_list.pb.h"
+#include "pb/event_user_joined.pb.h"
+#include "pb/event_user_left.pb.h"
+#include "pb/response_list_users.pb.h"
+#include "pb/session_commands.pb.h"
+#include "user_info_box.h"
+
+UserListManager::UserListManager(AbstractClient *_client, QWidget *parent)
+    : QWidget(parent), client(_client), ownUserInfo(nullptr)
+{
+    connect(client, &AbstractClient::userJoinedEventReceived, this, &UserListManager::processUserJoinedEvent);
+    connect(client, &AbstractClient::userLeftEventReceived, this, &UserListManager::processUserLeftEvent);
+    connect(client, &AbstractClient::buddyListReceived, this, &UserListManager::buddyListReceived);
+    connect(client, &AbstractClient::ignoreListReceived, this, &UserListManager::ignoreListReceived);
+    connect(client, &AbstractClient::addToListEventReceived, this, &UserListManager::processAddToListEvent);
+    connect(client, &AbstractClient::removeFromListEventReceived, this, &UserListManager::processRemoveFromListEvent);
+    connect(client, &AbstractClient::userInfoChanged, this, &UserListManager::setOwnUserInfo);
+}
+
+UserListManager::~UserListManager()
+{
+    handleDisconnect();
+}
+
+void UserListManager::handleConnect()
+{
+    populateInitialOnlineUsers();
+}
+
+void UserListManager::handleDisconnect()
+{
+    onlineUsers.clear();
+    buddyUsers.clear();
+    ignoredUsers.clear();
+
+    delete ownUserInfo;
+    ownUserInfo = nullptr;
+}
+
+void UserListManager::setOwnUserInfo(const ServerInfo_User &userInfo)
+{
+    ownUserInfo = new ServerInfo_User(userInfo);
+}
+
+void UserListManager::populateInitialOnlineUsers()
+{
+    PendingCommand *pend = client->prepareSessionCommand(Command_ListUsers());
+    connect(pend, qOverload<const Response &, const CommandContainer &, const QVariant &>(&PendingCommand::finished),
+            this, &UserListManager::processListUsersResponse);
+    client->sendCommand(pend);
+}
+
+void UserListManager::processListUsersResponse(const Response &response)
+{
+    const auto &resp = response.GetExtension(Response_ListUsers::ext);
+
+    const int userListSize = resp.user_list_size();
+    for (int i = 0; i < userListSize; ++i) {
+        const ServerInfo_User &info = resp.user_list(i);
+        const QString &userName = QString::fromStdString(info.name());
+        onlineUsers.insert(userName, info);
+    }
+}
+
+void UserListManager::processUserJoinedEvent(const Event_UserJoined &event)
+{
+    const auto &info = event.user_info();
+    const QString &userName = QString::fromStdString(info.name());
+    onlineUsers.insert(userName, info);
+}
+
+void UserListManager::processUserLeftEvent(const Event_UserLeft &event)
+{
+    const auto &userName = QString::fromStdString(event.name());
+    onlineUsers.remove(userName);
+}
+
+void UserListManager::buddyListReceived(const QList<ServerInfo_User> &_buddyList)
+{
+    for (const auto &user : _buddyList) {
+        const auto &userName = QString::fromStdString(user.name());
+        buddyUsers.insert(userName, user);
+    }
+}
+
+void UserListManager::ignoreListReceived(const QList<ServerInfo_User> &_ignoreList)
+{
+    for (const auto &user : _ignoreList) {
+        const auto &userName = QString::fromStdString(user.name());
+        ignoredUsers.insert(userName, user);
+    }
+}
+
+void UserListManager::processAddToListEvent(const Event_AddToList &event)
+{
+    const auto &user = event.user_info();
+    const auto &userName = QString::fromStdString(user.name());
+
+    const auto &userListType = QString::fromStdString(event.list_name());
+
+    QMap<QString, ServerInfo_User> userMap;
+    if (userListType == "buddy") {
+        userMap = buddyUsers;
+    } else if (userListType == "ignore") {
+        userMap = ignoredUsers;
+    } else {
+        return;
+    }
+
+    userMap.insert(userName, user);
+}
+
+void UserListManager::processRemoveFromListEvent(const Event_RemoveFromList &event)
+{
+    const auto &userListType = QString::fromStdString(event.list_name());
+    const auto &userName = QString::fromStdString(event.user_name());
+
+    QMap<QString, ServerInfo_User> userMap;
+    if (userListType == "buddy") {
+        userMap = buddyUsers;
+    } else if (userListType == "ignore") {
+        userMap = ignoredUsers;
+    } else {
+        return;
+    }
+
+    userMap.remove(userName);
+}
+
+bool UserListManager::isOwnUserRegistered() const
+{
+    return ownUserInfo != nullptr && (ownUserInfo->user_level() & ServerInfo_User::IsRegistered) != 0;
+}
+
+QString UserListManager::getOwnUsername() const
+{
+    return ownUserInfo != nullptr ? QString::fromStdString(ownUserInfo->name()) : QString();
+}
+
+bool UserListManager::isUserBuddy(const QString &userName) const
+{
+    return buddyUsers.contains(userName);
+}
+
+bool UserListManager::isUserIgnored(const QString &userName) const
+{
+    return ignoredUsers.contains(userName);
+}
+
+const ServerInfo_User *UserListManager::getOnlineUser(const QString &userName) const
+{
+    const QString &userNameToMatchLower = userName.toLower();
+
+    const auto it =
+        std::find_if(onlineUsers.begin(), onlineUsers.end(), [&userNameToMatchLower](const ServerInfo_User &user) {
+            return userNameToMatchLower == QString::fromStdString(user.name()).toLower();
+        });
+
+    if (it != onlineUsers.end()) {
+        return &*it;
+    }
+
+    return nullptr;
+};

--- a/cockatrice/src/server/user/user_list_manager.h
+++ b/cockatrice/src/server/user/user_list_manager.h
@@ -1,0 +1,72 @@
+#ifndef COCKATRICE_USER_LIST_MANAGER_H
+#define COCKATRICE_USER_LIST_MANAGER_H
+
+#include "../chat_view/user_list_proxy.h"
+#include "pb/serverinfo_user.pb.h"
+
+#include <QMap>
+#include <QWidget>
+
+class AbstractClient;
+class Event_AddToList;
+class Event_ListRooms;
+class Event_RemoveFromList;
+class Event_UserJoined;
+class Event_UserLeft;
+class Response;
+class ServerInfo_User;
+class TabSupervisor;
+
+class UserListManager : public QWidget, public UserlistProxy
+{
+    Q_OBJECT
+
+private:
+    AbstractClient *client;
+    ServerInfo_User *ownUserInfo;
+    QMap<QString, ServerInfo_User> onlineUsers, buddyUsers, ignoredUsers;
+
+private slots:
+    void setOwnUserInfo(const ServerInfo_User &userInfo);
+    void populateInitialOnlineUsers();
+    void processListUsersResponse(const Response &response);
+    void processUserJoinedEvent(const Event_UserJoined &event);
+    void processUserLeftEvent(const Event_UserLeft &event);
+    void buddyListReceived(const QList<ServerInfo_User> &_buddyList);
+    void ignoreListReceived(const QList<ServerInfo_User> &_ignoreList);
+    void processAddToListEvent(const Event_AddToList &event);
+    void processRemoveFromListEvent(const Event_RemoveFromList &event);
+
+public:
+    explicit UserListManager(AbstractClient *_client, QWidget *parent = nullptr);
+    ~UserListManager() override;
+
+    [[nodiscard]] QMap<QString, ServerInfo_User> getAllUsersList() const
+    {
+        return onlineUsers;
+    }
+    [[nodiscard]] QMap<QString, ServerInfo_User> getBuddyList() const
+    {
+        return buddyUsers;
+    }
+    [[nodiscard]] QMap<QString, ServerInfo_User> getIgnoreList() const
+    {
+        return ignoredUsers;
+    }
+
+    bool isOwnUserRegistered() const override;
+    QString getOwnUsername() const override;
+    bool isUserBuddy(const QString &userName) const override;
+    bool isUserIgnored(const QString &userName) const override;
+    const ServerInfo_User *getOnlineUser(const QString &userName) const override;
+
+public slots:
+    void handleConnect();
+    void handleDisconnect();
+
+signals:
+    void userLeft(const QString &userName);
+    void userJoined(const ServerInfo_User &userInfo);
+};
+
+#endif // COCKATRICE_USER_LIST_MANAGER_H

--- a/cockatrice/src/server/user/user_list_widget.cpp
+++ b/cockatrice/src/server/user/user_list_widget.cpp
@@ -5,6 +5,7 @@
 #include "../../client/tabs/tab_supervisor.h"
 #include "../../client/ui/pixel_map_generator.h"
 #include "../../game/game_selector.h"
+#include "../../server/user/user_list_manager.h"
 #include "../pending_command.h"
 #include "pb/moderator_commands.pb.h"
 #include "pb/response_get_games_of_user.pb.h"
@@ -377,7 +378,7 @@ UserListWidget::UserListWidget(TabSupervisor *_tabSupervisor,
     : QGroupBox(parent), tabSupervisor(_tabSupervisor), client(_client), type(_type), onlineCount(0)
 {
     itemDelegate = new UserListItemDelegate(this);
-    userContextMenu = new UserContextMenu(tabSupervisor, this);
+    userContextMenu = new UserContextMenu(tabSupervisor, tabSupervisor->getUserListManager(), this);
     connect(userContextMenu, SIGNAL(openMessageDialog(QString, bool)), this, SIGNAL(openMessageDialog(QString, bool)));
 
     userTree = new QTreeWidget;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5451

## Short roundup of the initial problem

`TabSupervisor` calls to `TabAccount` to get user info. Some other classes call to `TabSupervisor` for that info. Cockatrice will segfault if the account tab is closed when one of those calls happens.

## What will change with this Pull Request?
- Introduced `UserListManager` class that stores the three user lists and connects to the client to update the lists.
- `UserListManager` implements `UserlistProxy`; `TabSupervisor` now no longer implements that.
- Pass down `UserListManager` and replace user info calls to `TabSupervisor` with calls to `UserListManager`

## TODO in the future

Currently, we are storing user info in both the `UserListManager` as well as the `UserListWidget`. We would like to refactor the `UserListWidget` to source from `UserListManager` so we aren't storing redundant info.