### PR TITLE
group printings together when sorting in card reveal window

### DIFF
--- a/cockatrice/src/game/cards/card_list.cpp
+++ b/cockatrice/src/game/cards/card_list.cpp
@@ -146,6 +146,8 @@ std::function<QString(CardItem *)> CardList::getExtractorFor(SortOption option)
             return [](CardItem *c) { return c->getInfo() ? c->getInfo()->getPowTough().rightJustified(10, '0') : ""; };
         case SortBySet:
             return [](CardItem *c) { return c->getInfo() ? c->getInfo()->getSetsNames() : ""; };
+        case SortByPrinting:
+            return [](CardItem *c) { return c->getProviderId(); };
     }
 
     // this line should never be reached

--- a/cockatrice/src/game/cards/card_list.h
+++ b/cockatrice/src/game/cards/card_list.h
@@ -28,7 +28,8 @@ public:
         SortByManaCost,
         SortByColors,
         SortByPt,
-        SortBySet
+        SortBySet,
+        SortByPrinting
     };
     CardList(bool _contentsKnown);
     CardItem *findCard(const int cardId) const;

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -164,6 +164,9 @@ void ZoneViewZone::reorganizeCards()
         if (sortBy != CardList::SortByName) {
             sortOptions << CardList::SortByName;
         }
+
+        // group printings together
+        sortOptions << CardList::SortByPrinting;
     }
 
     cardsToDisplay.sortBy(sortOptions);


### PR DESCRIPTION

## Short roundup of the initial problem

When sorting is enabled in the card view window, different printings of the same card don't have a sort order, and so will appear in deck order.

## What will change with this Pull Request?

Sort by `providerId` as the final tiebreaker so that printings are grouped together

#### Before

<img width="368" alt="Screenshot 2025-01-14 at 11 56 33 PM" src="https://github.com/user-attachments/assets/2a210512-5832-484b-9fcf-51f2bbbaf7de" />

#### After

<img width="370" alt="Screenshot 2025-01-14 at 11 49 25 PM" src="https://github.com/user-attachments/assets/c2deb5fe-f38a-459a-895b-de6e32345486" />


