### PR TITLE
delete overloaded signal in PendingCommand

### DIFF
--- a/cockatrice/src/client/tabs/tab_account.cpp
+++ b/cockatrice/src/client/tabs/tab_account.cpp
@@ -39,10 +39,7 @@ TabAccount::TabAccount(TabSupervisor *_tabSupervisor, AbstractClient *_client, c
     connect(client, &AbstractClient::removeFromListEventReceived, this, &TabAccount::processRemoveFromListEvent);
 
     PendingCommand *pend = client->prepareSessionCommand(Command_ListUsers());
-    connect(pend,
-            static_cast<void (PendingCommand::*)(const Response &, const CommandContainer &, const QVariant &)>(
-                &PendingCommand::finished),
-            this, &TabAccount::processListUsersResponse);
+    connect(pend, &PendingCommand::finished, this, &TabAccount::processListUsersResponse);
     client->sendCommand(pend);
 
     QVBoxLayout *vbox = new QVBoxLayout;

--- a/cockatrice/src/client/tabs/tab_admin.cpp
+++ b/cockatrice/src/client/tabs/tab_admin.cpp
@@ -191,7 +191,7 @@ void TabAdmin::actForceActivateUser()
     client->sendCommand(pend);
 }
 
-void TabAdmin::grantReplayAccessProcessResponse(const Response &response, const CommandContainer &, const QVariant &)
+void TabAdmin::grantReplayAccessProcessResponse(const Response &response)
 {
     auto *event = new Event_ReplayAdded();
 
@@ -209,7 +209,7 @@ void TabAdmin::grantReplayAccessProcessResponse(const Response &response, const 
     }
 }
 
-void TabAdmin::activateUserProcessResponse(const Response &response, const CommandContainer &, const QVariant &)
+void TabAdmin::activateUserProcessResponse(const Response &response)
 {
     switch (response.response_code()) {
         case Response::RespActivationAccepted:

--- a/cockatrice/src/client/tabs/tab_admin.cpp
+++ b/cockatrice/src/client/tabs/tab_admin.cpp
@@ -170,9 +170,7 @@ void TabAdmin::actGrantReplayAccess()
     cmd.set_moderator_name(client->getUserName().toStdString());
 
     auto *pend = client->prepareModeratorCommand(cmd);
-    connect(pend,
-            QOverload<const Response &, const CommandContainer &, const QVariant &>::of(&PendingCommand::finished),
-            this, &TabAdmin::grantReplayAccessProcessResponse);
+    connect(pend, &PendingCommand::finished, this, &TabAdmin::grantReplayAccessProcessResponse);
     client->sendCommand(pend);
 }
 

--- a/cockatrice/src/client/tabs/tab_admin.h
+++ b/cockatrice/src/client/tabs/tab_admin.h
@@ -47,8 +47,8 @@ private slots:
     void actReloadConfig();
     void actGrantReplayAccess();
     void actForceActivateUser();
-    void grantReplayAccessProcessResponse(const Response &resp, const CommandContainer &, const QVariant &);
-    void activateUserProcessResponse(const Response &response, const CommandContainer &, const QVariant &);
+    void grantReplayAccessProcessResponse(const Response &response);
+    void activateUserProcessResponse(const Response &response);
 
     void actUnlock();
     void actLock();

--- a/cockatrice/src/game/game_selector.cpp
+++ b/cockatrice/src/game/game_selector.cpp
@@ -194,9 +194,7 @@ void GameSelector::actCreate()
     updateTitle();
 }
 
-void GameSelector::checkResponse(const Response &response,
-                                 const CommandContainer & /* commandContainer */,
-                                 const QVariant & /* extraData */)
+void GameSelector::checkResponse(const Response &response)
 {
     // NB: We re-enable buttons for the currently selected game, which may not
     // be the same game as the one for which we are processing a response.

--- a/cockatrice/src/game/game_selector.cpp
+++ b/cockatrice/src/game/game_selector.cpp
@@ -274,8 +274,7 @@ void GameSelector::actJoin()
     }
 
     PendingCommand *pend = r->prepareRoomCommand(cmd);
-    connect(pend, qOverload<const Response &, const CommandContainer &, const QVariant &>(&PendingCommand::finished),
-            this, &GameSelector::checkResponse);
+    connect(pend, &PendingCommand::finished, this, &GameSelector::checkResponse);
     r->sendRoomCommand(pend);
 
     disableButtons();

--- a/cockatrice/src/game/game_selector.h
+++ b/cockatrice/src/game/game_selector.h
@@ -29,7 +29,7 @@ private slots:
     void actCreate();
     void actJoin();
     void actSelectedGameChanged(const QModelIndex &current, const QModelIndex &previous);
-    void checkResponse(const Response &response, const CommandContainer &, const QVariant &);
+    void checkResponse(const Response &response);
 
     void ignoreListReceived(const QList<ServerInfo_User> &_ignoreList);
     void processAddToListEvent(const Event_AddToList &event);

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -91,9 +91,7 @@ void ZoneViewZone::initializeCards(const QList<const ServerInfo_Card *> &cardLis
     }
 }
 
-void ZoneViewZone::zoneDumpReceived(const Response &r,
-                                    const CommandContainer & /* commandContainer */,
-                                    const QVariant & /* extraData */)
+void ZoneViewZone::zoneDumpReceived(const Response &r)
 {
     const Response_DumpZone &resp = r.GetExtension(Response_DumpZone::ext);
     const int respCardListSize = resp.zone_info().card_list_size();

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -77,9 +77,7 @@ void ZoneViewZone::initializeCards(const QList<const ServerInfo_Card *> &cardLis
         cmd.set_is_reversed(isReversed);
 
         PendingCommand *pend = player->prepareGameCommand(cmd);
-        connect(pend,
-                qOverload<const Response &, const CommandContainer &, const QVariant &>(&PendingCommand::finished),
-                this, &ZoneViewZone::zoneDumpReceived);
+        connect(pend, &PendingCommand::finished, this, &ZoneViewZone::zoneDumpReceived);
         player->sendGameCommand(pend);
     } else {
         const CardList &c = origZone->getCards();

--- a/cockatrice/src/game/zones/view_zone.h
+++ b/cockatrice/src/game/zones/view_zone.h
@@ -95,7 +95,7 @@ public slots:
     void setSortBy(CardList::SortOption _sortBy);
     void setPileView(int _pileView);
 private slots:
-    void zoneDumpReceived(const Response &r, const CommandContainer &, const QVariant &);
+    void zoneDumpReceived(const Response &r);
 signals:
     void beingDeleted();
     void optimumRectChanged();

--- a/cockatrice/src/server/pending_command.cpp
+++ b/cockatrice/src/server/pending_command.cpp
@@ -23,7 +23,6 @@ QVariant PendingCommand::getExtraData() const
 void PendingCommand::processResponse(const Response &response)
 {
     emit finished(response, commandContainer, extraData);
-    emit finished(response.response_code());
 }
 
 int PendingCommand::tick()

--- a/cockatrice/src/server/pending_command.h
+++ b/cockatrice/src/server/pending_command.h
@@ -11,7 +11,6 @@ class PendingCommand : public QObject
     Q_OBJECT
 signals:
     void finished(const Response &response, const CommandContainer &commandContainer, const QVariant &extraData);
-    void finished(Response::ResponseCode respCode);
 
 private:
     CommandContainer commandContainer;

--- a/cockatrice/src/server/user/user_info_box.cpp
+++ b/cockatrice/src/server/user/user_info_box.cpp
@@ -250,10 +250,8 @@ void UserInfoBox::actPassword()
         cmd.set_user_name(client->getUserName().toStdString());
 
         PendingCommand *pend = client->prepareSessionCommand(cmd);
-        connect(pend,
-                // we need qoverload here in order to select the right version of this function
-                QOverload<const Response &, const CommandContainer &, const QVariant &>::of(&PendingCommand::finished),
-                this, [=, this](const Response &response, const CommandContainer &, const QVariant &) {
+        connect(pend, &PendingCommand::finished, this,
+                [=, this](const Response &response, const CommandContainer &, const QVariant &) {
                     if (response.response_code() == Response::RespOk) {
                         changePassword(oldPassword, newPassword);
                     } else {

--- a/cockatrice/src/server/user/user_info_box.cpp
+++ b/cockatrice/src/server/user/user_info_box.cpp
@@ -250,15 +250,14 @@ void UserInfoBox::actPassword()
         cmd.set_user_name(client->getUserName().toStdString());
 
         PendingCommand *pend = client->prepareSessionCommand(cmd);
-        connect(pend, &PendingCommand::finished, this,
-                [=, this](const Response &response, const CommandContainer &, const QVariant &) {
-                    if (response.response_code() == Response::RespOk) {
-                        changePassword(oldPassword, newPassword);
-                    } else {
-                        QMessageBox::critical(this, tr("Error"),
-                                              tr("An error occurred while trying to update your user information."));
-                    }
-                });
+        connect(pend, &PendingCommand::finished, this, [=, this](const Response &response) {
+            if (response.response_code() == Response::RespOk) {
+                changePassword(oldPassword, newPassword);
+            } else {
+                QMessageBox::critical(this, tr("Error"),
+                                      tr("An error occurred while trying to update your user information."));
+            }
+        });
         client->sendCommand(pend);
     } else {
         changePassword(oldPassword, newPassword);

--- a/cockatrice/src/server/user/user_list_manager.cpp
+++ b/cockatrice/src/server/user/user_list_manager.cpp
@@ -51,8 +51,7 @@ void UserListManager::setOwnUserInfo(const ServerInfo_User &userInfo)
 void UserListManager::populateInitialOnlineUsers()
 {
     PendingCommand *pend = client->prepareSessionCommand(Command_ListUsers());
-    connect(pend, qOverload<const Response &, const CommandContainer &, const QVariant &>(&PendingCommand::finished),
-            this, &UserListManager::processListUsersResponse);
+    connect(pend, &PendingCommand::finished, this, &UserListManager::processListUsersResponse);
     client->sendCommand(pend);
 }
 


### PR DESCRIPTION
## Short roundup of the initial problem

`PendingCommand::finished` is overloaded, forcing us to use a really annoying `qOverload`. Overloading signals is bad practice when using the new signal/slot syntax anyways due to forcing the use of `qOverload`. Also literally nothing was using the signal's other overload.

## What will change with this Pull Request?
- Deleted `PendingCommand::finished(Response::ResponseCode respCode)`
- Removed all no-longer-required usages of `qOverload` for that signal
- Turns out the new slot/signal syntax  *does* allow the slot to have less params than the signal, so I removed any used params from slots that connect to `finished`
