### PR TITLE
fix tab-specific menus not present when tab is opened on startup

### DIFF
--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -167,8 +167,6 @@ TabSupervisor::TabSupervisor(AbstractClient *_client, QMenu *tabsMenu, QWidget *
     resetTabsMenu();
 
     retranslateUi();
-
-    initStartupTabs();
 }
 
 TabSupervisor::~TabSupervisor()

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -89,8 +89,6 @@ private:
     QAction *aTabDeckEditor, *aTabVisualDeckStorage, *aTabServer, *aTabAccount, *aTabDeckStorage, *aTabReplays,
         *aTabAdmin, *aTabLog;
 
-    void initStartupTabs();
-
     int myAddTab(Tab *tab, QAction *manager = nullptr);
     void addCloseButtonToTab(Tab *tab, int tabIndex, QAction *manager);
     QString sanitizeTabName(QString dirty) const;
@@ -101,6 +99,7 @@ public:
     explicit TabSupervisor(AbstractClient *_client, QMenu *tabsMenu, QWidget *parent = nullptr);
     ~TabSupervisor() override;
     void retranslateUi();
+    void initStartupTabs();
     void start(const ServerInfo_User &userInfo);
     void startLocal(const QList<AbstractClient *> &_clients);
     void stop();

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -860,6 +860,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(tabSupervisor, &TabSupervisor::setMenu, this, &MainWindow::updateTabMenu);
     connect(tabSupervisor, &TabSupervisor::localGameEnded, this, &MainWindow::localGameEnded);
     connect(tabSupervisor, &TabSupervisor::showWindowIfHidden, this, &MainWindow::showWindowIfHidden);
+    tabSupervisor->initStartupTabs();
 
     setCentralWidget(tabSupervisor);
 


### PR DESCRIPTION
## Short roundup of the initial problem

Currently, the creation of startup tabs get called in `TabSupervisor`'s constructor, before `WindowMain` has a chance to connect to the `changeMenu` signal. This causes the menu bar to not have the tab-specific menus added for tabs that are open on startup, until the tab is changed.

## What will change with this Pull Request?
- Make `initStartupTabs` public and call it from `WindowMain` instead of in the constructor.