### PR TITLE
fix incorrect values in deck editor tab's views menu on init

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -668,10 +668,10 @@ void TabDeckEditor::loadLayout()
         restoreGeometry(layouts.getDeckEditorGeometry());
     }
 
-    aCardInfoDockVisible->setChecked(cardInfoDock->isVisible());
-    aFilterDockVisible->setChecked(filterDock->isVisible());
-    aDeckDockVisible->setChecked(deckDock->isVisible());
-    aPrintingSelectorDockVisible->setChecked(printingSelectorDock->isVisible());
+    aCardInfoDockVisible->setChecked(!cardInfoDock->isHidden());
+    aFilterDockVisible->setChecked(!filterDock->isHidden());
+    aDeckDockVisible->setChecked(!deckDock->isHidden());
+    aPrintingSelectorDockVisible->setChecked(!printingSelectorDock->isHidden());
 
     aCardInfoDockFloating->setEnabled(aCardInfoDockVisible->isChecked());
     aDeckDockFloating->setEnabled(aDeckDockVisible->isChecked());
@@ -1641,25 +1641,25 @@ void TabDeckEditor::dockVisibleTriggered()
 {
     QObject *o = sender();
     if (o == aCardInfoDockVisible) {
-        cardInfoDock->setVisible(aCardInfoDockVisible->isChecked());
+        cardInfoDock->setHidden(!aCardInfoDockVisible->isChecked());
         aCardInfoDockFloating->setEnabled(aCardInfoDockVisible->isChecked());
         return;
     }
 
     if (o == aDeckDockVisible) {
-        deckDock->setVisible(aDeckDockVisible->isChecked());
+        deckDock->setHidden(!aDeckDockVisible->isChecked());
         aDeckDockFloating->setEnabled(aDeckDockVisible->isChecked());
         return;
     }
 
     if (o == aFilterDockVisible) {
-        filterDock->setVisible(aFilterDockVisible->isChecked());
+        filterDock->setHidden(!aFilterDockVisible->isChecked());
         aFilterDockFloating->setEnabled(aFilterDockVisible->isChecked());
         return;
     }
 
     if (o == aPrintingSelectorDockVisible) {
-        printingSelectorDock->setVisible(aPrintingSelectorDockVisible->isChecked());
+        printingSelectorDock->setHidden(!aPrintingSelectorDockVisible->isChecked());
         aPrintingSelectorDockFloating->setEnabled(aPrintingSelectorDockVisible->isChecked());
         return;
     }


### PR DESCRIPTION
## Short roundup of the initial problem

When opening a new deck editor tab, the deck editor tab's views menu is entirely unchecked. This is regardless of which widgets are actually open.

https://github.com/user-attachments/assets/be0aac6f-2939-40ac-a819-af045a7b693c

This is caused by the startup code using `isVisible()` to check if the widget is shown. However, `isVisible()` returns whether the widget is actually visible on screen, meaning it will return false if you're not in that tab or if the widget hasn't finished rendering yet. `isHidden()` is the correct method to use here.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/df00f5c6-29a4-4b77-ac2b-69095037b689

- Use `isHidden` instead of `isVisible`
- Also use `setHidden` instead of `setVisible` as a precaution