### PR TITLE
Change visible buttons in game lobby depending on if deck is loaded

### DIFF
--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -79,7 +79,7 @@ DeckViewContainer::DeckViewContainer(int _playerId, TabGame *parent)
     if (forceStartGameButton->isEnabled()) {
         buttonHBox->addWidget(forceStartGameButton);
     }
-    buttonHBox->setContentsMargins(0, 0, 0, 0);
+    buttonHBox->setContentsMargins(11, 0, 11, 0);
     buttonHBox->addStretch();
 
     deckView = new DeckView;

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -114,17 +114,28 @@ void DeckViewContainer::retranslateUi()
     updateSideboardLockButtonText();
 }
 
+static void setVisibility(QPushButton *button, bool visible)
+{
+    button->setHidden(!visible);
+    button->setEnabled(visible);
+}
+
 void DeckViewContainer::switchToDeckSelectView()
 {
     deckView->setVisible(false);
     visualDeckStorageWidget->setVisible(true);
     deckViewLayout->update();
-    unloadDeckButton->setEnabled(false);
-    readyStartButton->setEnabled(false);
+
+    setVisibility(loadLocalButton, true);
+    setVisibility(loadRemoteButton, true);
+    setVisibility(unloadDeckButton, false);
+    setVisibility(readyStartButton, false);
+    setVisibility(sideboardLockButton, false);
+    setVisibility(forceStartGameButton, false);
+
     readyStartButton->setState(false);
-    sideboardLockButton->setEnabled(false);
     sideboardLockButton->setState(false);
-    forceStartGameButton->setEnabled(false);
+
     setReadyStart(false);
 }
 
@@ -132,8 +143,14 @@ void DeckViewContainer::switchToDeckLoadedView()
 {
     deckView->setVisible(true);
     visualDeckStorageWidget->setVisible(false);
-    unloadDeckButton->setEnabled(true);
-    forceStartGameButton->setEnabled(parentGame->isHost());
+    deckViewLayout->update();
+
+    setVisibility(loadLocalButton, false);
+    setVisibility(loadRemoteButton, false);
+    setVisibility(unloadDeckButton, true);
+    setVisibility(readyStartButton, true);
+    setVisibility(sideboardLockButton, true);
+    setVisibility(forceStartGameButton, true);
 }
 
 void DeckViewContainer::updateSideboardLockButtonText()
@@ -177,16 +194,7 @@ void DeckViewContainer::loadVisualDeck(QMouseEvent *event, DeckPreviewWidget *in
 
 void DeckViewContainer::unloadDeck()
 {
-    deckView->setVisible(false);
-    visualDeckStorageWidget->setVisible(true);
-    deckViewLayout->update();
-    unloadDeckButton->setEnabled(false);
-    readyStartButton->setEnabled(false);
-    readyStartButton->setState(false);
-    sideboardLockButton->setEnabled(false);
-    sideboardLockButton->setState(false);
-    forceStartGameButton->setEnabled(false);
-    setReadyStart(false);
+    switchToDeckSelectView();
 }
 
 void DeckViewContainer::loadLocalDeck()
@@ -307,8 +315,5 @@ void DeckViewContainer::setSideboardLocked(bool locked)
 void DeckViewContainer::setDeck(const DeckLoader &deck)
 {
     deckView->setDeck(deck);
-    readyStartButton->setEnabled(true);
-    sideboardLockButton->setState(false);
-    sideboardLockButton->setEnabled(true);
-    forceStartGameButton->setEnabled(true);
+    switchToDeckLoadedView();
 }

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -76,9 +76,8 @@ DeckViewContainer::DeckViewContainer(int _playerId, TabGame *parent)
     buttonHBox->addWidget(unloadDeckButton);
     buttonHBox->addWidget(readyStartButton);
     buttonHBox->addWidget(sideboardLockButton);
-    if (forceStartGameButton->isEnabled()) {
-        buttonHBox->addWidget(forceStartGameButton);
-    }
+    buttonHBox->addWidget(forceStartGameButton);
+
     buttonHBox->setContentsMargins(11, 0, 11, 0);
     buttonHBox->addStretch();
 
@@ -150,7 +149,10 @@ void DeckViewContainer::switchToDeckLoadedView()
     setVisibility(unloadDeckButton, true);
     setVisibility(readyStartButton, true);
     setVisibility(sideboardLockButton, true);
-    setVisibility(forceStartGameButton, true);
+
+    if (parentGame->isHost()) {
+        setVisibility(forceStartGameButton, true);
+    }
 }
 
 void DeckViewContainer::updateSideboardLockButtonText()

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -94,7 +94,7 @@ DeckViewContainer::DeckViewContainer(int _playerId, TabGame *parent)
 
     visualDeckStorageWidget = new VisualDeckStorageWidget(this);
     connect(visualDeckStorageWidget, &VisualDeckStorageWidget::deckPreviewDoubleClicked, this,
-            &DeckViewContainer::replaceDeckStorageWithDeckView);
+            &DeckViewContainer::loadVisualDeck);
 
     deckViewLayout = new QVBoxLayout;
     deckViewLayout->addLayout(buttonHBox);
@@ -148,7 +148,7 @@ void DeckViewContainer::refreshShortcuts()
     sideboardLockButton->setShortcut(shortcuts.getSingleShortcut("DeckViewContainer/sideboardLockButton"));
 }
 
-void DeckViewContainer::replaceDeckStorageWithDeckView(QMouseEvent *event, DeckPreviewWidget *instance)
+void DeckViewContainer::loadVisualDeck(QMouseEvent *event, DeckPreviewWidget *instance)
 {
     Q_UNUSED(event);
     QString deckString = instance->deckLoader->writeToString_Native();

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -136,7 +136,7 @@ void DeckViewContainer::switchToDeckSelectView()
     readyStartButton->setState(false);
     sideboardLockButton->setState(false);
 
-    setReadyStart(false);
+    sendReadyStartCommand(false);
 }
 
 void DeckViewContainer::switchToDeckLoadedView()
@@ -255,9 +255,7 @@ void DeckViewContainer::deckSelectFinished(const Response &r)
 
 void DeckViewContainer::readyStart()
 {
-    Command_ReadyStart cmd;
-    cmd.set_ready(!readyStartButton->getState());
-    parentGame->sendGameCommand(cmd, playerId);
+    sendReadyStartCommand(!readyStartButton->getState());
 }
 
 void DeckViewContainer::forceStart()
@@ -285,6 +283,22 @@ void DeckViewContainer::sideboardPlanChanged()
     parentGame->sendGameCommand(cmd, playerId);
 }
 
+/**
+ * Sends the basic ReadyStart command.
+ */
+void DeckViewContainer::sendReadyStartCommand(bool ready)
+{
+    Command_ReadyStart cmd;
+    cmd.set_ready(ready);
+    parentGame->sendGameCommand(cmd, playerId);
+}
+
+/**
+ * Updates the buttons to make the client-side ready state match the given state.
+ *
+ * Notably, this method only updates the client and *does not* send a ReadyStart command to the server.
+ * This method is intended to be called upon receiving the response from a ReadyStart command.
+ */
 void DeckViewContainer::setReadyStart(bool ready)
 {
     readyStartButton->setState(ready);
@@ -293,15 +307,11 @@ void DeckViewContainer::setReadyStart(bool ready)
 }
 
 /**
- * Sets the ready start to true, then sends the ready command so the server responds to the update
+ * Sends a ReadyStart command with ready=true to the server
  */
 void DeckViewContainer::readyAndUpdate()
 {
-    setReadyStart(true);
-
-    Command_ReadyStart cmd;
-    cmd.set_ready(true);
-    parentGame->sendGameCommand(cmd, playerId);
+    sendReadyStartCommand(true);
 }
 
 void DeckViewContainer::setSideboardLocked(bool locked)

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -118,15 +118,6 @@ void DeckViewContainer::retranslateUi()
     updateSideboardLockButtonText();
 }
 
-void DeckViewContainer::setButtonsVisible(bool _visible)
-{
-    loadLocalButton->setVisible(_visible);
-    loadRemoteButton->setVisible(_visible);
-    readyStartButton->setVisible(_visible);
-    forceStartGameButton->setVisible(_visible);
-    sideboardLockButton->setVisible(_visible);
-}
-
 void DeckViewContainer::updateSideboardLockButtonText()
 {
     if (sideboardLockButton->getState()) {

--- a/cockatrice/src/game/deckview/deck_view_container.h
+++ b/cockatrice/src/game/deckview/deck_view_container.h
@@ -69,7 +69,6 @@ signals:
 public:
     DeckViewContainer(int _playerId, TabGame *parent);
     void retranslateUi();
-    void setButtonsVisible(bool _visible);
     void setReadyStart(bool ready);
     void readyAndUpdate();
     void setSideboardLocked(bool locked);

--- a/cockatrice/src/game/deckview/deck_view_container.h
+++ b/cockatrice/src/game/deckview/deck_view_container.h
@@ -50,6 +50,8 @@ private:
     VisualDeckStorageWidget *visualDeckStorageWidget;
     TabGame *parentGame;
     int playerId;
+
+    void sendReadyStartCommand(bool ready);
 private slots:
     void switchToDeckSelectView();
     void switchToDeckLoadedView();

--- a/cockatrice/src/game/deckview/deck_view_container.h
+++ b/cockatrice/src/game/deckview/deck_view_container.h
@@ -51,7 +51,7 @@ private:
     TabGame *parentGame;
     int playerId;
 private slots:
-    void replaceDeckStorageWithDeckView(QMouseEvent *event, DeckPreviewWidget *instance);
+    void loadVisualDeck(QMouseEvent *event, DeckPreviewWidget *instance);
     void loadLocalDeck();
     void loadRemoteDeck();
     void unloadDeck();

--- a/cockatrice/src/game/deckview/deck_view_container.h
+++ b/cockatrice/src/game/deckview/deck_view_container.h
@@ -51,6 +51,8 @@ private:
     TabGame *parentGame;
     int playerId;
 private slots:
+    void switchToDeckSelectView();
+    void switchToDeckLoadedView();
     void loadVisualDeck(QMouseEvent *event, DeckPreviewWidget *instance);
     void loadLocalDeck();
     void loadRemoteDeck();


### PR DESCRIPTION
## Short roundup of the initial problem

The game lobby is starting to have too many buttons across the top. We don't need to use up that much space when half of them are greyed out when the deck isn't loaded yet.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/576498e0-f87f-4288-a260-9aa9e0d21881

- Increased the button HBox's margins
- Refactored `DeckViewContainer` somewhat
  - renamed `replaceDeckStorageWithDeckView` to `loadVisualDeck` 
  - consolidated all view switching code into `switchToDeckSelectView` and `switchToDeckLoadedView`
- Change which buttons are showing depending on whether a deck is loaded or not
  - will properly clean up everything in the switches
  - buttons are both hidden and disabled, so that shortcuts won't work on hidden buttons
- cleaned up `setReadyStart` usage to be more proper
  - added a `sendReadyStartCommand` method and made sure to always go through that and never directly call `setReadyStart` from inside the class
  - added some comments

## Screenshots

<img width="400" alt="Screenshot 2025-01-15 at 11 28 23 PM" src="https://github.com/user-attachments/assets/04346bb2-8f65-48fb-9a93-678c5b360c7e" />
<img width="400" alt="Screenshot 2025-01-15 at 11 28 31 PM" src="https://github.com/user-attachments/assets/4f34013a-272d-4086-be0d-835d327ba8fa" />
