### PR TITLE
Add options to include/exclude set name and collector number during clipboard import/export.

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -337,8 +337,16 @@ void TabDeckEditor::createMenus()
     aSaveDeckToClipboard = new QAction(QString(), this);
     connect(aSaveDeckToClipboard, SIGNAL(triggered()), this, SLOT(actSaveDeckToClipboard()));
 
+    aSaveDeckToClipboardNoSetNameAndNumber = new QAction(QString(), this);
+    connect(aSaveDeckToClipboardNoSetNameAndNumber, SIGNAL(triggered()), this,
+            SLOT(actSaveDeckToClipboardNoSetNameAndNumber()));
+
     aSaveDeckToClipboardRaw = new QAction(QString(), this);
     connect(aSaveDeckToClipboardRaw, SIGNAL(triggered()), this, SLOT(actSaveDeckToClipboardRaw()));
+
+    aSaveDeckToClipboardRawNoSetNameAndNumber = new QAction(QString(), this);
+    connect(aSaveDeckToClipboardRawNoSetNameAndNumber, SIGNAL(triggered()), this,
+            SLOT(actSaveDeckToClipboardRawNoSetNameAndNumber()));
 
     aPrintDeck = new QAction(QString(), this);
     connect(aPrintDeck, SIGNAL(triggered()), this, SLOT(actPrintDeck()));
@@ -370,7 +378,9 @@ void TabDeckEditor::createMenus()
 
     saveDeckToClipboardMenu = new QMenu(this);
     saveDeckToClipboardMenu->addAction(aSaveDeckToClipboard);
+    saveDeckToClipboardMenu->addAction(aSaveDeckToClipboardNoSetNameAndNumber);
     saveDeckToClipboardMenu->addAction(aSaveDeckToClipboardRaw);
+    saveDeckToClipboardMenu->addAction(aSaveDeckToClipboardRawNoSetNameAndNumber);
 
     deckMenu = new QMenu(this);
     deckMenu->addAction(aNewDeck);
@@ -741,7 +751,9 @@ void TabDeckEditor::retranslateUi()
 
     saveDeckToClipboardMenu->setTitle(tr("Save deck to clipboard"));
     aSaveDeckToClipboard->setText(tr("Annotated"));
+    aSaveDeckToClipboardNoSetNameAndNumber->setText(tr("Annotated (No set name or number)"));
     aSaveDeckToClipboardRaw->setText(tr("Not Annotated"));
+    aSaveDeckToClipboardRawNoSetNameAndNumber->setText(tr("Not Annotated (No set name or number"));
 
     aPrintDeck->setText(tr("&Print deck..."));
 
@@ -1172,11 +1184,29 @@ void TabDeckEditor::actSaveDeckToClipboard()
     QApplication::clipboard()->setText(buffer, QClipboard::Selection);
 }
 
+void TabDeckEditor::actSaveDeckToClipboardNoSetNameAndNumber()
+{
+    QString buffer;
+    QTextStream stream(&buffer);
+    deckModel->getDeckList()->saveToStream_Plain(stream, true, false);
+    QApplication::clipboard()->setText(buffer, QClipboard::Clipboard);
+    QApplication::clipboard()->setText(buffer, QClipboard::Selection);
+}
+
 void TabDeckEditor::actSaveDeckToClipboardRaw()
 {
     QString buffer;
     QTextStream stream(&buffer);
     deckModel->getDeckList()->saveToStream_Plain(stream, false);
+    QApplication::clipboard()->setText(buffer, QClipboard::Clipboard);
+    QApplication::clipboard()->setText(buffer, QClipboard::Selection);
+}
+
+void TabDeckEditor::actSaveDeckToClipboardRawNoSetNameAndNumber()
+{
+    QString buffer;
+    QTextStream stream(&buffer);
+    deckModel->getDeckList()->saveToStream_Plain(stream, false, false);
     QApplication::clipboard()->setText(buffer, QClipboard::Clipboard);
     QApplication::clipboard()->setText(buffer, QClipboard::Selection);
 }
@@ -1723,7 +1753,9 @@ void TabDeckEditor::setSaveStatus(bool newStatus)
     aSaveDeck->setEnabled(newStatus);
     aSaveDeckAs->setEnabled(newStatus);
     aSaveDeckToClipboard->setEnabled(newStatus);
+    aSaveDeckToClipboardNoSetNameAndNumber->setEnabled(newStatus);
     aSaveDeckToClipboardRaw->setEnabled(newStatus);
+    aSaveDeckToClipboardRawNoSetNameAndNumber->setEnabled(newStatus);
     saveDeckToClipboardMenu->setEnabled(newStatus);
     aPrintDeck->setEnabled(newStatus);
     analyzeDeckMenu->setEnabled(newStatus);

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -753,7 +753,7 @@ void TabDeckEditor::retranslateUi()
     aSaveDeckToClipboard->setText(tr("Annotated"));
     aSaveDeckToClipboardNoSetNameAndNumber->setText(tr("Annotated (No set name or number)"));
     aSaveDeckToClipboardRaw->setText(tr("Not Annotated"));
-    aSaveDeckToClipboardRawNoSetNameAndNumber->setText(tr("Not Annotated (No set name or number"));
+    aSaveDeckToClipboardRawNoSetNameAndNumber->setText(tr("Not Annotated (No set name or number)"));
 
     aPrintDeck->setText(tr("&Print deck..."));
 

--- a/cockatrice/src/client/tabs/tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/tab_deck_editor.h
@@ -56,7 +56,9 @@ private slots:
     bool actSaveDeckAs();
     void actLoadDeckFromClipboard();
     void actSaveDeckToClipboard();
+    void actSaveDeckToClipboardNoSetNameAndNumber();
     void actSaveDeckToClipboardRaw();
+    void actSaveDeckToClipboardRawNoSetNameAndNumber();
     void actPrintDeck();
     void actExportDeckDecklist();
     void actAnalyzeDeckDeckstats();
@@ -145,7 +147,8 @@ private:
     QMenu *deckMenu, *viewMenu, *cardInfoDockMenu, *deckDockMenu, *filterDockMenu, *printingSelectorDockMenu,
         *analyzeDeckMenu, *saveDeckToClipboardMenu, *loadRecentDeckMenu;
     QAction *aNewDeck, *aLoadDeck, *aClearRecents, *aSaveDeck, *aSaveDeckAs, *aLoadDeckFromClipboard,
-        *aSaveDeckToClipboard, *aSaveDeckToClipboardRaw, *aPrintDeck, *aExportDeckDecklist, *aAnalyzeDeckDeckstats,
+        *aSaveDeckToClipboard, *aSaveDeckToClipboardNoSetNameAndNumber, *aSaveDeckToClipboardRaw,
+        *aSaveDeckToClipboardRawNoSetNameAndNumber, *aPrintDeck, *aExportDeckDecklist, *aAnalyzeDeckDeckstats,
         *aAnalyzeDeckTappedout, *aClose;
     QAction *aClearFilterAll, *aClearFilterOne;
     QAction *aAddCard, *aAddCardToSideboard, *aRemoveCard, *aIncrement, *aDecrement, *aSwapCard;

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -228,7 +228,7 @@ struct FormatDeckListForExport
     QString &sideBoardCards;
     // create main operator for struct, allowing the foreachcard to work.
     FormatDeckListForExport(QString &_mainBoardCards, QString &_sideBoardCards)
-        : mainBoardCards(_mainBoardCards), sideBoardCards(_sideBoardCards) {};
+        : mainBoardCards(_mainBoardCards), sideBoardCards(_sideBoardCards){};
 
     void operator()(const InnerDecklistNode *node, const DecklistCardNode *card) const
     {

--- a/cockatrice/src/deck/deck_loader.h
+++ b/cockatrice/src/deck/deck_loader.h
@@ -45,6 +45,7 @@ public:
         return lastRemoteDeckId;
     }
 
+    void clearSetNamesAndNumbers();
     static FileFormat getFormatFromName(const QString &fileName);
 
     bool loadFromFile(const QString &fileName, FileFormat fmt, bool userRequest = false);
@@ -57,15 +58,19 @@ public:
     void resolveSetNameAndNumberToProviderID();
 
     // overload
-    bool saveToStream_Plain(QTextStream &out, bool addComments = true);
+    bool saveToStream_Plain(QTextStream &out, bool addComments = true, bool addSetNameAndNumber = true);
 
 protected:
     void saveToStream_DeckHeader(QTextStream &out);
-    void saveToStream_DeckZone(QTextStream &out, const InnerDecklistNode *zoneNode, bool addComments = true);
+    void saveToStream_DeckZone(QTextStream &out,
+                               const InnerDecklistNode *zoneNode,
+                               bool addComments = true,
+                               bool addSetNameAndNumber = true);
     void saveToStream_DeckZoneCards(QTextStream &out,
                                     const InnerDecklistNode *zoneNode,
                                     QList<DecklistCardNode *> cards,
-                                    bool addComments = true);
+                                    bool addComments = true,
+                                    bool addSetNameAndNumber = true);
     [[nodiscard]] QString getCardZoneFromName(QString cardName, QString currentZoneName) override;
     [[nodiscard]] QString getCompleteCardName(const QString &cardName) const override;
 };

--- a/cockatrice/src/dialogs/dlg_load_deck_from_clipboard.cpp
+++ b/cockatrice/src/dialogs/dlg_load_deck_from_clipboard.cpp
@@ -4,6 +4,7 @@
 #include "../settings/cache_settings.h"
 
 #include <QApplication>
+#include <QCheckBox>
 #include <QClipboard>
 #include <QDialogButtonBox>
 #include <QMessageBox>
@@ -24,9 +25,16 @@ DlgLoadDeckFromClipboard::DlgLoadDeckFromClipboard(QWidget *parent) : QDialog(pa
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOK()));
     connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
 
+    loadSetNameAndNumberCheckBox = new QCheckBox(tr("Parse Set Name and Number (if available)"));
+    loadSetNameAndNumberCheckBox->setChecked(true);
+
+    auto *buttonLayout = new QHBoxLayout;
+    buttonLayout->addWidget(loadSetNameAndNumberCheckBox);
+    buttonLayout->addWidget(buttonBox);
+
     auto *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(contentsEdit);
-    mainLayout->addWidget(buttonBox);
+    mainLayout->addLayout(buttonLayout);
 
     setLayout(mainLayout);
 
@@ -65,7 +73,11 @@ void DlgLoadDeckFromClipboard::actOK()
         }
     } else if (deckLoader->loadFromStream_Plain(stream)) {
         deckList = deckLoader;
-        deckList->resolveSetNameAndNumberToProviderID();
+        if (loadSetNameAndNumberCheckBox->isChecked()) {
+            deckList->resolveSetNameAndNumberToProviderID();
+        } else {
+            deckList->clearSetNamesAndNumbers();
+        }
         accept();
     } else {
         QMessageBox::critical(this, tr("Error"), tr("Invalid deck list."));

--- a/cockatrice/src/dialogs/dlg_load_deck_from_clipboard.h
+++ b/cockatrice/src/dialogs/dlg_load_deck_from_clipboard.h
@@ -1,6 +1,7 @@
 #ifndef DLG_LOAD_DECK_FROM_CLIPBOARD_H
 #define DLG_LOAD_DECK_FROM_CLIPBOARD_H
 
+#include <QCheckBox>
 #include <QDialog>
 
 class DeckLoader;
@@ -19,6 +20,7 @@ private:
     DeckLoader *deckList;
     QPlainTextEdit *contentsEdit;
     QPushButton *refreshButton;
+    QCheckBox *loadSetNameAndNumberCheckBox;
 
 public:
     explicit DlgLoadDeckFromClipboard(QWidget *parent = nullptr);


### PR DESCRIPTION




## Short roundup of the initial problem
Some users prefer to either not use the printings from the deck list they import or export their decklists without set name and collector number itself.

## What will change with this Pull Request?
- Dialog Load from Clipboard gains a new checkbox that either validates the set name and number into a providerId if checked or deletes the set name and collector number from the CardInfo if not checked.
- Save to clipboard menu gains two new options for either annotated or raw without set name and number.

## Screenshots
![image](https://github.com/user-attachments/assets/53bb3af8-571f-4eb6-9047-7e3b1b2c6f78)
![image](https://github.com/user-attachments/assets/f5bd600a-d176-4fd8-aaa6-fade41bbcfa9)

![Demo Video](https://github.com/user-attachments/assets/b0f520ee-12f0-4563-a2d2-903ab0a72350)