### PR TITLE
replace foreach macro with standard for each loop

### DIFF
--- a/cockatrice/src/client/network/spoiler_background_updater.cpp
+++ b/cockatrice/src/client/network/spoiler_background_updater.cpp
@@ -167,7 +167,7 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
     if (trayIcon) {
         QList<QByteArray> lines = data.split('\n');
 
-        foreach (QByteArray line, lines) {
+        for (const QByteArray &line : lines) {
             if (line.contains("Created At:")) {
                 QString timeStamp = QString(line).replace("Created At:", "").trimmed();
                 timeStamp.chop(6); // Remove " (UTC)"

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -236,7 +236,7 @@ bool TabSupervisor::closeRequest()
         }
     }
 
-    foreach (TabDeckEditor *tab, deckEditorTabs) {
+    for (TabDeckEditor *tab : deckEditorTabs) {
         if (!tab->confirmClose())
             return false;
     }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
@@ -30,7 +30,7 @@ VisualDeckStorageTagFilterWidget::filterDecksBySelectedTags(const QList<DeckPrev
 {
     // Collect selected tags from DeckPreviewTagDisplayWidget
     QStringList selectedTags;
-    foreach (DeckPreviewTagDisplayWidget *tagWidget, findChildren<DeckPreviewTagDisplayWidget *>()) {
+    for (DeckPreviewTagDisplayWidget *tagWidget : findChildren<DeckPreviewTagDisplayWidget *>()) {
         if (tagWidget->getSelected()) {
             selectedTags.append(tagWidget->getTagName());
         }
@@ -61,7 +61,7 @@ VisualDeckStorageTagFilterWidget::filterDecksBySelectedTags(const QList<DeckPrev
 void VisualDeckStorageTagFilterWidget::removeTagsNotInList(const QStringList &tags)
 {
     // Iterate through all DeckPreviewTagDisplayWidgets
-    foreach (DeckPreviewTagDisplayWidget *tagWidget, findChildren<DeckPreviewTagDisplayWidget *>()) {
+    for (DeckPreviewTagDisplayWidget *tagWidget : findChildren<DeckPreviewTagDisplayWidget *>()) {
         // If the tag is not in the provided tags list, remove the widget
         if (!tags.contains(tagWidget->getTagName())) {
             auto *flowWidget = findChild<FlowWidget *>();
@@ -82,7 +82,7 @@ void VisualDeckStorageTagFilterWidget::addTagIfNotPresent(const QString &tag)
 {
     // Check if the tag already exists in the flow widget
     bool tagExists = false;
-    foreach (DeckPreviewTagDisplayWidget *tagWidget, findChildren<DeckPreviewTagDisplayWidget *>()) {
+    for (DeckPreviewTagDisplayWidget *tagWidget : findChildren<DeckPreviewTagDisplayWidget *>()) {
         if (tagWidget->getTagName() == tag) {
             tagExists = true;
             break;

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -94,7 +94,7 @@ void VisualDeckStorageWidget::refreshBannerCards()
         allFiles << it.next(); // Add each file path to the list
     }
 
-    foreach (const QString &file, allFiles) {
+    for (const QString &file : allFiles) {
         auto *display = new DeckPreviewWidget(this, file);
 
         connect(display, &DeckPreviewWidget::deckPreviewClicked, this,
@@ -117,7 +117,7 @@ void VisualDeckStorageWidget::refreshBannerCards()
 
     flowWidget->clearLayout(); // Clear existing widgets in the flow layout
 
-    foreach (DeckPreviewWidget *deck, filteredFiles) {
+    for (DeckPreviewWidget *deck : filteredFiles) {
         flowWidget->addWidget(deck);
     }
 
@@ -130,7 +130,7 @@ QStringList VisualDeckStorageWidget::gatherAllTagsFromFlowWidget() const
 
     if (flowWidget) {
         // Iterate through all DeckPreviewWidgets
-        foreach (DeckPreviewWidget *display, flowWidget->findChildren<DeckPreviewWidget *>()) {
+        for (DeckPreviewWidget *display : flowWidget->findChildren<DeckPreviewWidget *>()) {
             // Get tags from each DeckPreviewWidget
             QStringList tags = display->deckLoader->getTags();
 

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -394,7 +394,7 @@ void DeckLoader::saveToStream_DeckHeader(QTextStream &out)
 
     if (!getComments().isEmpty()) {
         QStringList commentRows = getComments().split(QRegularExpression("\n|\r\n|\r"));
-        foreach (QString row, commentRows) {
+        for (const QString &row : commentRows) {
             out << "// " << row << "\n";
         }
         out << "\n";
@@ -433,7 +433,7 @@ void DeckLoader::saveToStream_DeckZone(QTextStream &out,
     }
 
     // print cards to stream
-    foreach (QString cardType, cardsByType.uniqueKeys()) {
+    for (const QString &cardType : cardsByType.uniqueKeys()) {
         if (addComments) {
             out << "// " << cardTotalByType[cardType] << " " << cardType << "\n";
         }

--- a/cockatrice/src/dialogs/dlg_edit_user.cpp
+++ b/cockatrice/src/dialogs/dlg_edit_user.cpp
@@ -25,7 +25,7 @@ DlgEditUser::DlgEditUser(QWidget *parent, QString email, QString country, QStrin
 
     QStringList countries = SettingsCache::instance().getCountries();
     int i = 1;
-    foreach (QString c, countries) {
+    for (const QString &c : countries) {
         countryEdit->addItem(QPixmap("theme:countries/" + c.toLower()), c);
         if (c == country)
             countryEdit->setCurrentIndex(i);

--- a/cockatrice/src/dialogs/dlg_register.cpp
+++ b/cockatrice/src/dialogs/dlg_register.cpp
@@ -313,7 +313,7 @@ DlgRegister::DlgRegister(QWidget *parent) : QDialog(parent)
     countryEdit->addItem(QPixmap("theme:countries/zw"), "zw");
     countryEdit->setCurrentIndex(0);
     QStringList countries = SettingsCache::instance().getCountries();
-    foreach (QString c, countries)
+    for (const QString &c : countries)
         countryEdit->addItem(QPixmap("theme:countries/" + c.toLower()), c);
 
     realnameLabel = new QLabel(tr("Real name:"));

--- a/cockatrice/src/dialogs/dlg_view_log.cpp
+++ b/cockatrice/src/dialogs/dlg_view_log.cpp
@@ -38,7 +38,7 @@ void DlgViewLog::actCheckBoxChanged(bool abNewValue)
 void DlgViewLog::loadInitialLogBuffer()
 {
     QList<QString> logBuffer = Logger::getInstance().getLogBuffer();
-    foreach (QString message, logBuffer)
+    for (const QString &message : logBuffer)
         logEntryAdded(message);
 }
 

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -468,7 +468,7 @@ CardInfoPtr CardDatabase::getCard(const QString &cardName) const
 QList<CardInfoPtr> CardDatabase::getCards(const QStringList &cardNames) const
 {
     QList<CardInfoPtr> cardInfos;
-    foreach (QString cardName, cardNames) {
+    for (const QString &cardName : cardNames) {
         CardInfoPtr ptr = getCardFromMap(cards, cardName);
         if (ptr)
             cardInfos.append(ptr);
@@ -783,7 +783,7 @@ void CardDatabase::refreshCachedReverseRelatedCards()
             continue;
         }
 
-        foreach (CardRelation *cardRelation, card->getReverseRelatedCards()) {
+        for (CardRelation *cardRelation : card->getReverseRelatedCards()) {
             const QString &targetCard = cardRelation->getName();
             if (!cards.contains(targetCard)) {
                 continue;
@@ -886,7 +886,7 @@ CardRelation::CardRelation(const QString &_name,
 
 void CardInfo::resetReverseRelatedCards2Me()
 {
-    foreach (CardRelation *cardRelation, this->getReverseRelatedCards2Me()) {
+    for (CardRelation *cardRelation : this->getReverseRelatedCards2Me()) {
         cardRelation->deleteLater();
     }
     reverseRelatedCardsToMe = QList<CardRelation *>();

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -121,7 +121,7 @@ void installNewTranslator()
 QString const generateClientID()
 {
     QString macList;
-    foreach (QNetworkInterface networkInterface, QNetworkInterface::allInterfaces()) {
+    for (const QNetworkInterface &networkInterface : QNetworkInterface::allInterfaces()) {
         if (networkInterface.hardwareAddress() != "")
             if (networkInterface.hardwareAddress() != "00:00:00:00:00:00:00:E0")
                 macList += networkInterface.hardwareAddress() + ".";

--- a/cockatrice/src/server/chat_view/chat_view.cpp
+++ b/cockatrice/src/server/chat_view/chat_view.cpp
@@ -403,7 +403,7 @@ void ChatView::checkWord(QTextCursor &cursor, QString &message)
     }
 
     // check word mentions
-    foreach (QString word, highlightedWords) {
+    for (const QString &word : highlightedWords) {
         if (fullWordUpToSpaceOrEnd.compare(word, Qt::CaseInsensitive) == 0) {
             // You have received a valid mention of custom word!!
             highlightFormat.setBackground(QBrush(getCustomHighlightColor()));

--- a/oracle/src/qt-json/json.cpp
+++ b/oracle/src/qt-json/json.cpp
@@ -53,7 +53,7 @@ static QString sanitizeString(QString str)
 static QByteArray join(const QList<QByteArray> &list, const QByteArray &sep)
 {
     QByteArray res;
-    Q_FOREACH (const QByteArray &i, list) {
+    for (const QByteArray &i : list) {
         if (!res.isEmpty()) {
             res += sep;
         }
@@ -118,7 +118,7 @@ QByteArray Json::serialize(const QVariant &data, bool &success)
     {
         QList<QByteArray> values;
         const QVariantList list = data.toList();
-        Q_FOREACH (const QVariant &v, list) {
+        for (const QVariant &v : list) {
             QByteArray serializedValue = serialize(v);
             if (serializedValue.isNull()) {
                 success = false;

--- a/servatrice/src/server_logger.cpp
+++ b/servatrice/src/server_logger.cpp
@@ -69,7 +69,7 @@ void ServerLogger::logMessage(const QString &message, void *caller)
 
     if (!logFilters.trimmed().isEmpty()) {
         shouldWeSkipLine = true;
-        foreach (QString logFilter, listlogFilters) {
+        for (const QString &logFilter : listlogFilters) {
             if (message.contains(logFilter, Qt::CaseInsensitive)) {
                 shouldWeSkipLine = false;
                 break;

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -375,7 +375,7 @@ bool AbstractServerSocketInterface::deckListHelper(int folderId, ServerInfo_Deck
     while (query->next())
         results[query->value(0).toInt()] = query->value(1).toString();
 
-    foreach (int key, results.keys()) {
+    for (int key : results.keys()) {
         ServerInfo_DeckStorage_TreeItem *newItem = folder->add_items();
         newItem->set_id(key);
         newItem->set_name(results.value(key).toStdString());
@@ -840,7 +840,7 @@ Response::ResponseCode AbstractServerSocketInterface::cmdGetWarnList(const Comma
 #else
     QStringList warningsList = officialWarnings.split(",", QString::SkipEmptyParts);
 #endif
-    foreach (QString warning, warningsList) {
+    for (const QString &warning : warningsList) {
         re->add_warning(warning.toStdString());
     }
     re->set_user_name(nameFromStdString(cmd.user_name()).toStdString());

--- a/servatrice/src/smtp/qxtmailattachment.cpp
+++ b/servatrice/src/smtp/qxtmailattachment.cpp
@@ -161,7 +161,7 @@ void QxtMailAttachment::setExtraHeaders(const QHash<QString, QString>& a)
 {
     QHash<QString, QString>& headers = qxt_d->extraHeaders;
     headers.clear();
-    foreach(const QString& key, a.keys())
+    for (const QString& key: a.keys())
     {
         headers[key.toLower()] = a[key];
     }
@@ -187,7 +187,7 @@ QByteArray QxtMailAttachment::mimeData()
     }
 
     QByteArray rv = "Content-Type: " + qxt_d->contentType.toLatin1() + "\r\nContent-Transfer-Encoding: base64\r\n";
-    foreach(const QString& r, qxt_d->extraHeaders.keys())
+    for(const QString& r: qxt_d->extraHeaders.keys())
     {
         rv += qxt_fold_mime_header(r.toLatin1(), extraHeader(r));
     }

--- a/servatrice/src/smtp/qxtmailmessage.cpp
+++ b/servatrice/src/smtp/qxtmailmessage.cpp
@@ -172,7 +172,7 @@ void QxtMailMessage::setExtraHeaders(const QHash<QString, QString> &a)
 {
     QHash<QString, QString> &headers = qxt_d->extraHeaders;
     headers.clear();
-    foreach (const QString &key, a.keys()) {
+    for (const QString &key : a.keys()) {
         headers[key.toLower()] = a[key];
     }
 }
@@ -219,7 +219,7 @@ QByteArray qxt_fold_mime_header(const QString &key, const QString &value, const 
         line += prefix;
     if (!value.contains("=?") && isASCII(value)) {
         bool firstWord = true;
-        foreach (const QByteArray &word, value.toLatin1().split(' ')) {
+        for (const QByteArray &word : value.toLatin1().split(' ')) {
             if (line.size() > 78) {
                 rv = rv + line + "\r\n";
                 line.clear();
@@ -339,7 +339,7 @@ QByteArray QxtMailMessage::rfc2822() const
         }
     }
 
-    foreach (const QString &r, qxt_d->extraHeaders.keys()) {
+    for (const QString &r : qxt_d->extraHeaders.keys()) {
         if ((r.toLower() == "content-type" || r.toLower() == "content-transfer-encoding") && attach.count()) {
             // Since we're in multipart mode, we'll be outputting this later
             continue;
@@ -463,7 +463,7 @@ QByteArray QxtMailMessage::rfc2822() const
     }
 
     if (attach.count()) {
-        foreach (const QString &filename, attach.keys()) {
+        for (const QString &filename : attach.keys()) {
             rv += "--" + qxt_d->boundary + "\r\n";
             rv +=
                 qxt_fold_mime_header("Content-Disposition", QDir(filename).dirName(), "attachment; filename=");

--- a/servatrice/src/smtp/qxtsmtp.cpp
+++ b/servatrice/src/smtp/qxtsmtp.cpp
@@ -273,7 +273,7 @@ void QxtSmtpPrivate::socketRead()
 void QxtSmtpPrivate::ehlo()
 {
     QByteArray address = "127.0.0.1";
-    foreach (const QHostAddress &addr, QNetworkInterface::allAddresses()) {
+    for (const QHostAddress &addr : QNetworkInterface::allAddresses()) {
         if (addr == QHostAddress::LocalHost || addr == QHostAddress::LocalHostIPv6)
             continue;
         address = addr.toString().toLatin1();
@@ -469,7 +469,7 @@ void QxtSmtpPrivate::sendNext()
     socket->write("mail from:<" + qxt_extract_address(msg.sender()) + ">\r\n");
     if (extensions.contains("PIPELINING")) // almost all do nowadays
     {
-        foreach (const QString &rcpt, recipients) {
+        for (const QString &rcpt : recipients) {
             socket->write("rcpt to:<" + qxt_extract_address(rcpt) + ">\r\n");
         }
         state = RcptAckPending;


### PR DESCRIPTION
## Short roundup of the initial problem

No reason to use Qt's `foreach` macro when we've had for each loops built into the language since C++ 11

## What will change with this Pull Request?

- Replaced all usages of `foreach` with the standard C++ for each loop
