### PR TITLE
fix sideboard not being re-locked on load deck

### DIFF
--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -135,6 +135,8 @@ void DeckViewContainer::switchToDeckSelectView()
     readyStartButton->setState(false);
     sideboardLockButton->setState(false);
 
+    deckView->setLocked(true);
+
     sendReadyStartCommand(false);
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5481

## What will change with this Pull Request?

- Deck view gets correctly locked after loading deck while sideboard is unlocked 
