### PR TITLE
get UserListProxy from TabSupervisor instead of passing it in the constructor

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -15,6 +15,7 @@
 #include "../../main.h"
 #include "../../server/message_log_widget.h"
 #include "../../server/pending_command.h"
+#include "../../server/user/user_list_manager.h"
 #include "../../settings/cache_settings.h"
 #include "../game_logic/abstract_client.h"
 #include "../network/replay_timeline_widget.h"
@@ -123,16 +124,16 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, GameReplay *_replay)
 }
 
 TabGame::TabGame(TabSupervisor *_tabSupervisor,
-                 UserListProxy *_userListProxy,
                  QList<AbstractClient *> &_clients,
                  const Event_GameJoined &event,
                  const QMap<int, QString> &_roomGameTypes)
-    : Tab(_tabSupervisor), userListProxy(_userListProxy), clients(_clients), gameInfo(event.game_info()),
-      roomGameTypes(_roomGameTypes), hostId(event.host_id()), localPlayerId(event.player_id()),
-      isLocalGame(_tabSupervisor->getIsLocalGame()), spectator(event.spectator()), judge(event.judge()),
-      gameStateKnown(false), resuming(event.resuming()), currentPhase(-1), activeCard(nullptr), gameClosed(false),
-      replay(nullptr), replayPlayButton(nullptr), replayFastForwardButton(nullptr), aReplaySkipForward(nullptr),
-      aReplaySkipBackward(nullptr), aReplaySkipForwardBig(nullptr), aReplaySkipBackwardBig(nullptr), replayDock(nullptr)
+    : Tab(_tabSupervisor), userListProxy(_tabSupervisor->getUserListManager()), clients(_clients),
+      gameInfo(event.game_info()), roomGameTypes(_roomGameTypes), hostId(event.host_id()),
+      localPlayerId(event.player_id()), isLocalGame(_tabSupervisor->getIsLocalGame()), spectator(event.spectator()),
+      judge(event.judge()), gameStateKnown(false), resuming(event.resuming()), currentPhase(-1), activeCard(nullptr),
+      gameClosed(false), replay(nullptr), replayPlayButton(nullptr), replayFastForwardButton(nullptr),
+      aReplaySkipForward(nullptr), aReplaySkipBackward(nullptr), aReplaySkipForwardBig(nullptr),
+      aReplaySkipBackwardBig(nullptr), replayDock(nullptr)
 {
     // THIS CTOR IS USED ON GAMES
     gameInfo.set_started(false);
@@ -1684,7 +1685,7 @@ void TabGame::createPlayerListDock(bool bReplay)
 
 void TabGame::createMessageDock(bool bReplay)
 {
-    messageLog = new MessageLogWidget(tabSupervisor, userListProxy, this);
+    messageLog = new MessageLogWidget(tabSupervisor, this);
     connect(messageLog, SIGNAL(cardNameHovered(QString)), cardInfoFrameWidget, SLOT(setCard(QString)));
     connect(messageLog, &MessageLogWidget::showCardInfoPopup, this, &TabGame::showCardInfoPopup);
     connect(messageLog, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -67,7 +67,7 @@ class TabGame : public Tab
 private:
     QTimer *gameTimer;
     int secondsElapsed;
-    UserListProxy *userListProxy;
+    const UserListProxy *userListProxy;
     QList<AbstractClient *> clients;
     ServerInfo_Game gameInfo;
     QMap<int, QString> roomGameTypes;
@@ -212,7 +212,6 @@ private slots:
 
 public:
     TabGame(TabSupervisor *_tabSupervisor,
-            UserListProxy *_userListProxy,
             QList<AbstractClient *> &_clients,
             const Event_GameJoined &event,
             const QMap<int, QString> &_roomGameTypes);

--- a/cockatrice/src/client/tabs/tab_message.cpp
+++ b/cockatrice/src/client/tabs/tab_message.cpp
@@ -26,7 +26,7 @@ TabMessage::TabMessage(TabSupervisor *_tabSupervisor,
     : Tab(_tabSupervisor), client(_client), ownUserInfo(new ServerInfo_User(_ownUserInfo)),
       otherUserInfo(new ServerInfo_User(_otherUserInfo)), userOnline(true)
 {
-    chatView = new ChatView(tabSupervisor, tabSupervisor->getUserListManager(), 0, true);
+    chatView = new ChatView(tabSupervisor, 0, true);
     connect(chatView, &ChatView::showCardInfoPopup, this, &TabMessage::showCardInfoPopup);
     connect(chatView, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));
     connect(chatView, SIGNAL(addMentionTag(QString)), this, SLOT(addMentionTag(QString)));

--- a/cockatrice/src/client/tabs/tab_room.cpp
+++ b/cockatrice/src/client/tabs/tab_room.cpp
@@ -36,10 +36,9 @@
 TabRoom::TabRoom(TabSupervisor *_tabSupervisor,
                  AbstractClient *_client,
                  ServerInfo_User *_ownUser,
-                 const UserListProxy *_userListProxy,
                  const ServerInfo_Room &info)
     : Tab(_tabSupervisor), client(_client), roomId(info.room_id()), roomName(QString::fromStdString(info.name())),
-      ownUser(_ownUser), userListProxy(_userListProxy)
+      ownUser(_ownUser), userListProxy(_tabSupervisor->getUserListManager())
 {
     const int gameTypeListSize = info.gametype_list_size();
     for (int i = 0; i < gameTypeListSize; ++i)
@@ -53,7 +52,7 @@ TabRoom::TabRoom(TabSupervisor *_tabSupervisor,
     connect(userList, SIGNAL(openMessageDialog(const QString &, bool)), this,
             SIGNAL(openMessageDialog(const QString &, bool)));
 
-    chatView = new ChatView(tabSupervisor, userListProxy, nullptr, true, this);
+    chatView = new ChatView(tabSupervisor, nullptr, true, this);
     connect(chatView, SIGNAL(showMentionPopup(const QString &)), this, SLOT(actShowMentionPopup(const QString &)));
     connect(chatView, SIGNAL(messageClickedSignal()), this, SLOT(focusTab()));
     connect(chatView, SIGNAL(openMessageDialog(QString, bool)), this, SIGNAL(openMessageDialog(QString, bool)));

--- a/cockatrice/src/client/tabs/tab_room.h
+++ b/cockatrice/src/client/tabs/tab_room.h
@@ -92,7 +92,6 @@ public:
     TabRoom(TabSupervisor *_tabSupervisor,
             AbstractClient *_client,
             ServerInfo_User *_ownUser,
-            const UserListProxy *_userListProxy,
             const ServerInfo_Room &info);
     void retranslateUi() override;
     void closeRequest(bool forced = false) override;

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -588,7 +588,7 @@ void TabSupervisor::gameJoined(const Event_GameJoined &event)
             roomGameTypes.insert(event.game_types(i).game_type_id(),
                                  QString::fromStdString(event.game_types(i).description()));
 
-    auto *tab = new TabGame(this, userListManager, QList<AbstractClient *>() << client, event, roomGameTypes);
+    auto *tab = new TabGame(this, QList<AbstractClient *>() << client, event, roomGameTypes);
     connect(tab, &TabGame::gameClosing, this, &TabSupervisor::gameLeft);
     connect(tab, &TabGame::openMessageDialog, this, &TabSupervisor::addMessageTab);
     connect(tab, &TabGame::openDeckEditor, this, &TabSupervisor::addDeckEditorTab);
@@ -599,7 +599,7 @@ void TabSupervisor::gameJoined(const Event_GameJoined &event)
 
 void TabSupervisor::localGameJoined(const Event_GameJoined &event)
 {
-    auto *tab = new TabGame(this, userListManager, localClients, event, QMap<int, QString>());
+    auto *tab = new TabGame(this, localClients, event, QMap<int, QString>());
     connect(tab, &TabGame::gameClosing, this, &TabSupervisor::gameLeft);
     connect(tab, &TabGame::openDeckEditor, this, &TabSupervisor::addDeckEditorTab);
     myAddTab(tab);
@@ -627,7 +627,7 @@ void TabSupervisor::gameLeft(TabGame *tab)
 
 void TabSupervisor::addRoomTab(const ServerInfo_Room &info, bool setCurrent)
 {
-    auto *tab = new TabRoom(this, client, userInfo, userListManager, info);
+    auto *tab = new TabRoom(this, client, userInfo, info);
     connect(tab, &TabRoom::maximizeClient, this, &TabSupervisor::maximizeMainWindow);
     connect(tab, &TabRoom::roomClosing, this, &TabSupervisor::roomLeft);
     connect(tab, &TabRoom::openMessageDialog, this, &TabSupervisor::addMessageTab);

--- a/cockatrice/src/game/player/player_list_widget.cpp
+++ b/cockatrice/src/game/player/player_list_widget.cpp
@@ -72,7 +72,7 @@ PlayerListWidget::PlayerListWidget(TabSupervisor *_tabSupervisor,
         itemDelegate = new PlayerListItemDelegate(this);
         setItemDelegate(itemDelegate);
 
-        userContextMenu = new UserContextMenu(tabSupervisor, tabSupervisor->getUserListManager(), this, game);
+        userContextMenu = new UserContextMenu(tabSupervisor, this, game);
         connect(userContextMenu, &UserContextMenu::openMessageDialog, this, &PlayerListWidget::openMessageDialog);
     } else {
         userContextMenu = nullptr;

--- a/cockatrice/src/server/chat_view/chat_view.cpp
+++ b/cockatrice/src/server/chat_view/chat_view.cpp
@@ -5,6 +5,7 @@
 #include "../../client/ui/pixel_map_generator.h"
 #include "../../settings/cache_settings.h"
 #include "../user/user_context_menu.h"
+#include "../user/user_list_manager.h"
 #include "../user/user_list_proxy.h"
 #include "user_level.h"
 
@@ -22,13 +23,10 @@ UserMessagePosition::UserMessagePosition(QTextCursor &cursor)
     relativePosition = cursor.position() - block.position();
 }
 
-ChatView::ChatView(TabSupervisor *_tabSupervisor,
-                   const UserListProxy *_userListProxy,
-                   TabGame *_game,
-                   bool _showTimestamps,
-                   QWidget *parent)
-    : QTextBrowser(parent), tabSupervisor(_tabSupervisor), game(_game), userListProxy(_userListProxy), evenNumber(true),
-      showTimestamps(_showTimestamps), hoveredItemType(HoveredNothing)
+ChatView::ChatView(TabSupervisor *_tabSupervisor, TabGame *_game, bool _showTimestamps, QWidget *parent)
+    : QTextBrowser(parent), tabSupervisor(_tabSupervisor), game(_game),
+      userListProxy(_tabSupervisor->getUserListManager()), evenNumber(true), showTimestamps(_showTimestamps),
+      hoveredItemType(HoveredNothing)
 {
     if (palette().windowText().color().lightness() > 200) {
         document()->setDefaultStyleSheet(R"(
@@ -46,7 +44,7 @@ ChatView::ChatView(TabSupervisor *_tabSupervisor,
         linkColor = palette().link().color();
     }
 
-    userContextMenu = new UserContextMenu(tabSupervisor, userListProxy, this, game);
+    userContextMenu = new UserContextMenu(tabSupervisor, this, game);
     connect(userContextMenu, SIGNAL(openMessageDialog(QString, bool)), this, SIGNAL(openMessageDialog(QString, bool)));
 
     ownUserName = userListProxy->getOwnUsername();

--- a/cockatrice/src/server/chat_view/chat_view.h
+++ b/cockatrice/src/server/chat_view/chat_view.h
@@ -83,11 +83,7 @@ private slots:
     void actMessageClicked();
 
 public:
-    ChatView(TabSupervisor *_tabSupervisor,
-             const UserListProxy *_userListProxy,
-             TabGame *_game,
-             bool _showTimestamps,
-             QWidget *parent = nullptr);
+    ChatView(TabSupervisor *_tabSupervisor, TabGame *_game, bool _showTimestamps, QWidget *parent = nullptr);
     void retranslateUi();
     void appendHtml(const QString &html);
     void virtual appendHtmlServerMessage(const QString &html,

--- a/cockatrice/src/server/message_log_widget.cpp
+++ b/cockatrice/src/server/message_log_widget.cpp
@@ -862,11 +862,7 @@ void MessageLogWidget::connectToPlayer(Player *player)
             SLOT(logAlwaysLookAtTopCard(Player *, CardZone *, bool)));
 }
 
-MessageLogWidget::MessageLogWidget(TabSupervisor *_tabSupervisor,
-                                   const UserListProxy *_userListProxy,
-                                   TabGame *_game,
-                                   QWidget *parent)
-    : ChatView(_tabSupervisor, _userListProxy, _game, true, parent), mulliganNumber(0),
-      currentContext(MessageContext_None)
+MessageLogWidget::MessageLogWidget(TabSupervisor *_tabSupervisor, TabGame *_game, QWidget *parent)
+    : ChatView(_tabSupervisor, _game, true, parent), mulliganNumber(0), currentContext(MessageContext_None)
 {
 }

--- a/cockatrice/src/server/message_log_widget.h
+++ b/cockatrice/src/server/message_log_widget.h
@@ -103,10 +103,7 @@ public slots:
 
 public:
     void connectToPlayer(Player *player);
-    MessageLogWidget(TabSupervisor *_tabSupervisor,
-                     const UserListProxy *_userListProxy,
-                     TabGame *_game,
-                     QWidget *parent = nullptr);
+    MessageLogWidget(TabSupervisor *_tabSupervisor, TabGame *_game, QWidget *parent = nullptr);
 };
 
 #endif

--- a/cockatrice/src/server/user/user_context_menu.cpp
+++ b/cockatrice/src/server/user/user_context_menu.cpp
@@ -18,6 +18,7 @@
 #include "pb/response_warn_list.pb.h"
 #include "pb/session_commands.pb.h"
 #include "user_info_box.h"
+#include "user_list_manager.h"
 #include "user_list_proxy.h"
 #include "user_list_widget.h"
 
@@ -28,12 +29,9 @@
 #include <QtGui>
 #include <QtWidgets>
 
-UserContextMenu::UserContextMenu(TabSupervisor *_tabSupervisor,
-                                 const UserListProxy *_userListProxy,
-                                 QWidget *parent,
-                                 TabGame *_game)
+UserContextMenu::UserContextMenu(TabSupervisor *_tabSupervisor, QWidget *parent, TabGame *_game)
     : QObject(parent), client(_tabSupervisor->getClient()), tabSupervisor(_tabSupervisor),
-      userListProxy(_userListProxy), game(_game)
+      userListProxy(_tabSupervisor->getUserListManager()), game(_game)
 {
     aUserName = new QAction(QString(), this);
     aUserName->setEnabled(false);

--- a/cockatrice/src/server/user/user_context_menu.h
+++ b/cockatrice/src/server/user/user_context_menu.h
@@ -54,10 +54,7 @@ private slots:
     void gamesOfUserReceived(const Response &resp, const CommandContainer &commandContainer);
 
 public:
-    UserContextMenu(TabSupervisor *_tabSupervisor,
-                    const UserListProxy *_userListProxy,
-                    QWidget *_parent,
-                    TabGame *_game = 0);
+    UserContextMenu(TabSupervisor *_tabSupervisor, QWidget *_parent, TabGame *_game = 0);
     void retranslateUi();
     void showContextMenu(const QPoint &pos,
                          const QString &userName,

--- a/cockatrice/src/server/user/user_list_widget.cpp
+++ b/cockatrice/src/server/user/user_list_widget.cpp
@@ -378,7 +378,7 @@ UserListWidget::UserListWidget(TabSupervisor *_tabSupervisor,
     : QGroupBox(parent), tabSupervisor(_tabSupervisor), client(_client), type(_type), onlineCount(0)
 {
     itemDelegate = new UserListItemDelegate(this);
-    userContextMenu = new UserContextMenu(tabSupervisor, tabSupervisor->getUserListManager(), this);
+    userContextMenu = new UserContextMenu(tabSupervisor, this);
     connect(userContextMenu, SIGNAL(openMessageDialog(QString, bool)), this, SIGNAL(openMessageDialog(QString, bool)));
 
     userTree = new QTreeWidget;


### PR DESCRIPTION
## Short roundup of the initial problem

People are getting random crashes that seem to stem from `UserListProxy` being null in some classes. We don't know why that's happening, but we do know that the `UserListProxy` in `TabSupervisor` should always be valid, since it's created in the constructor. 

Perhaps a way to reduce the crash chances is to, for classes currently that take both a `TabSupervisor` and `UserListProxy` in the constructor, to just get the `UserListProxy` from the `TabSupervisor` inside the class instead of passing it in the constructor.

## What will change with this Pull Request?
- Removed `UserListProxy` from the constructor of all classes that already take `TabSupervisor` in their constructor
