### PR TITLE
Move logging from QDebug to QCDebug and introduce LoggingCategories.

### DIFF
--- a/cockatrice/resources/config/qtlogging.ini
+++ b/cockatrice/resources/config/qtlogging.ini
@@ -1,3 +1,47 @@
 [Rules]
-picture_loader.debug = true
-deck_loader.debug = true
+# Uncomment a rule to disable logging for that category
+
+# qt_translator.debug = false // Doesn't work because logging isn't initialized yet in main.cpp
+
+# window_main.debug = false
+# release_channel.debug = false
+# spoiler_background_updater.debug = false
+# theme_manager.debug = false
+# sound_engine.debug = false
+# tapped_out_interface.debug = false
+
+# tab_game.debug = false
+# tab_message.debug = false
+# tab_supervisor.debug = false
+
+# dlg_edit_avatar.debug = false
+# dlg_settings.debug = false
+# dlg_tip_of_the_day.debug = false
+# dlg_update.debug = false
+
+# settings_cache.debug = false
+# servers_settings.debug = false
+# shortcuts_settings.debug = false
+
+# player.debug = false
+# game_scene.debug = false
+# game_scene.debug.player_addition_removal = false
+# card_zone.debug = false
+# view_zone.debug = false
+
+# user_info_connection.debug = false
+
+# picture_loader.* = false
+# picture_loader.debug = false
+# picture_loader.worker.debug = false
+# deck_loader.debug = false
+# card_database.debug = false
+# card_database.debug.loading = false
+# card_database.debug.loading.success_or_failure = false
+# cockatrice_xml.debug.* = false
+# cockatrice_xml.debug.xml_3_parser = false
+# cockatrice_xml.debug.xml_4_parser = false
+# set_list.debug = false
+# card_list.debug = false
+
+# filter_string.debug = false

--- a/cockatrice/resources/config/qtlogging.ini
+++ b/cockatrice/resources/config/qtlogging.ini
@@ -42,7 +42,6 @@
 # cockatrice_xml.* = false
 # cockatrice_xml.xml_3_parser = false
 # cockatrice_xml.xml_4_parser = false
-# set_list = false
 # card_list = false
 
 # filter_string = false

--- a/cockatrice/resources/config/qtlogging.ini
+++ b/cockatrice/resources/config/qtlogging.ini
@@ -1,13 +1,13 @@
 [Rules]
 # Uncomment a rule to disable logging for that category
 
+# main = false
 # qt_translator = false
-
-window_main.* = false
-release_channel = false
-spoiler_background_updater = false
-theme_manager = false
-sound_engine = false
+# window_main.* = false
+# release_channel = false
+# spoiler_background_updater = false
+# theme_manager = false
+# sound_engine = false
 # tapped_out_interface = false
 
 # tab_game = false
@@ -31,14 +31,13 @@ sound_engine = false
 
 # user_info_connection = false
 
-picture_loader.* = false
 # picture_loader = false
 # picture_loader.worker = false
 # deck_loader = false
 # card_database = false
-card_database.loading = false
+# card_database.loading = false
 # card_database.loading.success_or_failure = false
-cockatrice_xml.* = false
+# cockatrice_xml.* = false
 # cockatrice_xml.xml_3_parser = false
 # cockatrice_xml.xml_4_parser = false
 # set_list = false

--- a/cockatrice/resources/config/qtlogging.ini
+++ b/cockatrice/resources/config/qtlogging.ini
@@ -1,47 +1,47 @@
 [Rules]
 # Uncomment a rule to disable logging for that category
 
-# qt_translator.debug = false // Doesn't work because logging isn't initialized yet in main.cpp
+# qt_translator = false
 
-# window_main.debug = false
-# release_channel.debug = false
-# spoiler_background_updater.debug = false
-# theme_manager.debug = false
-# sound_engine.debug = false
-# tapped_out_interface.debug = false
+window_main.* = false
+release_channel = false
+spoiler_background_updater = false
+theme_manager = false
+sound_engine = false
+# tapped_out_interface = false
 
-# tab_game.debug = false
-# tab_message.debug = false
-# tab_supervisor.debug = false
+# tab_game = false
+# tab_message = false
+# tab_supervisor = false
 
-# dlg_edit_avatar.debug = false
-# dlg_settings.debug = false
-# dlg_tip_of_the_day.debug = false
-# dlg_update.debug = false
+# dlg_edit_avatar = false
+# dlg_settings = false
+# dlg_tip_of_the_day = false
+# dlg_update = false
 
-# settings_cache.debug = false
-# servers_settings.debug = false
-# shortcuts_settings.debug = false
+# settings_cache = false
+# servers_settings = false
+# shortcuts_settings = false
 
-# player.debug = false
-# game_scene.debug = false
-# game_scene.debug.player_addition_removal = false
-# card_zone.debug = false
-# view_zone.debug = false
+# player = false
+# game_scene = false
+# game_scene.player_addition_removal = false
+# card_zone = false
+# view_zone = false
 
-# user_info_connection.debug = false
+# user_info_connection = false
 
-# picture_loader.* = false
-# picture_loader.debug = false
-# picture_loader.worker.debug = false
-# deck_loader.debug = false
-# card_database.debug = false
-# card_database.debug.loading = false
-# card_database.debug.loading.success_or_failure = false
-# cockatrice_xml.debug.* = false
-# cockatrice_xml.debug.xml_3_parser = false
-# cockatrice_xml.debug.xml_4_parser = false
-# set_list.debug = false
-# card_list.debug = false
+picture_loader.* = false
+# picture_loader = false
+# picture_loader.worker = false
+# deck_loader = false
+# card_database = false
+card_database.loading = false
+# card_database.loading.success_or_failure = false
+cockatrice_xml.* = false
+# cockatrice_xml.xml_3_parser = false
+# cockatrice_xml.xml_4_parser = false
+# set_list = false
+# card_list = false
 
-# filter_string.debug = false
+# filter_string = false

--- a/cockatrice/resources/config/qtlogging.ini
+++ b/cockatrice/resources/config/qtlogging.ini
@@ -33,6 +33,8 @@
 
 # picture_loader = false
 # picture_loader.worker = false
+# picture_loader.card_back_cache_fail = false
+# picture_loader.picture_to_load = false
 # deck_loader = false
 # card_database = false
 # card_database.loading = false

--- a/cockatrice/src/client/network/release_channel.cpp
+++ b/cockatrice/src/client/network/release_channel.cpp
@@ -33,7 +33,7 @@ ReleaseChannel::~ReleaseChannel()
 void ReleaseChannel::checkForUpdates()
 {
     QString releaseChannelUrl = getReleaseChannelUrl();
-    qDebug() << "Searching for updates on the channel: " << releaseChannelUrl;
+    qCDebug(ReleaseChannelLog) << "Searching for updates on the channel: " << releaseChannelUrl;
     response = netMan->get(QNetworkRequest(releaseChannelUrl));
     connect(response, &QNetworkReply::finished, this, &ReleaseChannel::releaseListFinished);
 }
@@ -145,15 +145,15 @@ void StableReleaseChannel::releaseListFinished()
 
     QString shortHash = lastRelease->getCommitHash().left(GIT_SHORT_HASH_LEN);
     QString myHash = QString(VERSION_COMMIT);
-    qDebug() << "Current hash=" << myHash << "update hash=" << shortHash;
+    qCDebug(ReleaseChannelLog) << "Current hash=" << myHash << "update hash=" << shortHash;
 
-    qDebug() << "Got reply from release server, name=" << lastRelease->getName()
+    qCDebug(ReleaseChannelLog) << "Got reply from release server, name=" << lastRelease->getName()
              << "desc=" << lastRelease->getDescriptionUrl() << "date=" << lastRelease->getPublishDate()
              << "url=" << lastRelease->getDownloadUrl();
 
     const QString &tagName = resultMap["tag_name"].toString();
     QString url = QString(STABLETAG_URL) + tagName;
-    qDebug() << "Searching for commit hash corresponding to stable channel tag: " << tagName;
+    qCDebug(ReleaseChannelLog) << "Searching for commit hash corresponding to stable channel tag: " << tagName;
     response = netMan->get(QNetworkRequest(url));
     connect(response, &QNetworkReply::finished, this, &StableReleaseChannel::tagListFinished);
 }
@@ -178,11 +178,11 @@ void StableReleaseChannel::tagListFinished()
     }
 
     lastRelease->setCommitHash(resultMap["object"].toMap()["sha"].toString());
-    qDebug() << "Got reply from tag server, commit=" << lastRelease->getCommitHash();
+    qCDebug(ReleaseChannelLog) << "Got reply from tag server, commit=" << lastRelease->getCommitHash();
 
     QString shortHash = lastRelease->getCommitHash().left(GIT_SHORT_HASH_LEN);
     QString myHash = QString(VERSION_COMMIT);
-    qDebug() << "Current hash=" << myHash << "update hash=" << shortHash;
+    qCDebug(ReleaseChannelLog) << "Current hash=" << myHash << "update hash=" << shortHash;
     const bool needToUpdate = (QString::compare(shortHash, myHash, Qt::CaseInsensitive) != 0);
 
     emit finishedCheck(needToUpdate, lastRelease->isCompatibleVersionFound(), lastRelease);
@@ -249,13 +249,13 @@ void BetaReleaseChannel::releaseListFinished()
     lastRelease->setName(QString("%1 (%2)").arg(resultMap["tag_name"].toString()).arg(shortHash));
     lastRelease->setDescriptionUrl(QString(BETARELEASE_CHANGESURL).arg(VERSION_COMMIT, shortHash));
 
-    qDebug() << "Got reply from release server, size=" << resultMap.size() << "name=" << lastRelease->getName()
+    qCDebug(ReleaseChannelLog) << "Got reply from release server, size=" << resultMap.size() << "name=" << lastRelease->getName()
              << "desc=" << lastRelease->getDescriptionUrl() << "commit=" << lastRelease->getCommitHash()
              << "date=" << lastRelease->getPublishDate();
 
     QString betaBuildDownloadUrl = resultMap["assets_url"].toString();
 
-    qDebug() << "Searching for a corresponding file on the beta channel: " << betaBuildDownloadUrl;
+    qCDebug(ReleaseChannelLog) << "Searching for a corresponding file on the beta channel: " << betaBuildDownloadUrl;
     response = netMan->get(QNetworkRequest(betaBuildDownloadUrl));
     connect(response, &QNetworkReply::finished, this, &BetaReleaseChannel::fileListFinished);
 }
@@ -275,7 +275,7 @@ void BetaReleaseChannel::fileListFinished()
     QVariantList resultList = jsonResponse.toVariant().toList();
     QString shortHash = lastRelease->getCommitHash().left(GIT_SHORT_HASH_LEN);
     QString myHash = QString(VERSION_COMMIT);
-    qDebug() << "Current hash=" << myHash << "update hash=" << shortHash;
+    qCDebug(ReleaseChannelLog) << "Current hash=" << myHash << "update hash=" << shortHash;
 
     bool needToUpdate = (QString::compare(shortHash, myHash, Qt::CaseInsensitive) != 0);
     bool compatibleVersion = false;
@@ -292,7 +292,7 @@ void BetaReleaseChannel::fileListFinished()
         if (downloadMatchesCurrentOS(*url)) {
             compatibleVersion = true;
             lastRelease->setDownloadUrl(*url);
-            qDebug() << "Found compatible version url=" << *url;
+            qCDebug(ReleaseChannelLog) << "Found compatible version url=" << *url;
             break;
         }
     }

--- a/cockatrice/src/client/network/release_channel.cpp
+++ b/cockatrice/src/client/network/release_channel.cpp
@@ -148,8 +148,8 @@ void StableReleaseChannel::releaseListFinished()
     qCDebug(ReleaseChannelLog) << "Current hash=" << myHash << "update hash=" << shortHash;
 
     qCDebug(ReleaseChannelLog) << "Got reply from release server, name=" << lastRelease->getName()
-             << "desc=" << lastRelease->getDescriptionUrl() << "date=" << lastRelease->getPublishDate()
-             << "url=" << lastRelease->getDownloadUrl();
+                               << "desc=" << lastRelease->getDescriptionUrl()
+                               << "date=" << lastRelease->getPublishDate() << "url=" << lastRelease->getDownloadUrl();
 
     const QString &tagName = resultMap["tag_name"].toString();
     QString url = QString(STABLETAG_URL) + tagName;
@@ -249,9 +249,9 @@ void BetaReleaseChannel::releaseListFinished()
     lastRelease->setName(QString("%1 (%2)").arg(resultMap["tag_name"].toString()).arg(shortHash));
     lastRelease->setDescriptionUrl(QString(BETARELEASE_CHANGESURL).arg(VERSION_COMMIT, shortHash));
 
-    qCDebug(ReleaseChannelLog) << "Got reply from release server, size=" << resultMap.size() << "name=" << lastRelease->getName()
-             << "desc=" << lastRelease->getDescriptionUrl() << "commit=" << lastRelease->getCommitHash()
-             << "date=" << lastRelease->getPublishDate();
+    qCDebug(ReleaseChannelLog) << "Got reply from release server, size=" << resultMap.size()
+                               << "name=" << lastRelease->getName() << "desc=" << lastRelease->getDescriptionUrl()
+                               << "commit=" << lastRelease->getCommitHash() << "date=" << lastRelease->getPublishDate();
 
     QString betaBuildDownloadUrl = resultMap["assets_url"].toString();
 

--- a/cockatrice/src/client/network/release_channel.h
+++ b/cockatrice/src/client/network/release_channel.h
@@ -8,7 +8,7 @@
 #include <QVariantMap>
 #include <utility>
 
-inline Q_LOGGING_CATEGORY(ReleaseChannelLog, "release_channel.debug")
+inline Q_LOGGING_CATEGORY(ReleaseChannelLog, "release_channel")
 
     class QNetworkReply;
 class QNetworkAccessManager;

--- a/cockatrice/src/client/network/release_channel.h
+++ b/cockatrice/src/client/network/release_channel.h
@@ -8,9 +8,9 @@
 #include <QVariantMap>
 #include <utility>
 
-inline Q_LOGGING_CATEGORY(ReleaseChannelLog, "release_channel")
+inline Q_LOGGING_CATEGORY(ReleaseChannelLog, "release_channel");
 
-    class QNetworkReply;
+class QNetworkReply;
 class QNetworkAccessManager;
 
 class Release

--- a/cockatrice/src/client/network/release_channel.h
+++ b/cockatrice/src/client/network/release_channel.h
@@ -2,12 +2,15 @@
 #define RELEASECHANNEL_H
 
 #include <QDate>
+#include <QLoggingCategory>
 #include <QObject>
 #include <QString>
 #include <QVariantMap>
 #include <utility>
 
-class QNetworkReply;
+inline Q_LOGGING_CATEGORY(ReleaseChannelLog, "release_channel.debug")
+
+    class QNetworkReply;
 class QNetworkAccessManager;
 
 class Release

--- a/cockatrice/src/client/network/spoiler_background_updater.cpp
+++ b/cockatrice/src/client/network/spoiler_background_updater.cpp
@@ -28,7 +28,7 @@ SpoilerBackgroundUpdater::SpoilerBackgroundUpdater(QObject *apParent) : QObject(
         // File exists means we're in spoiler season
         startSpoilerDownloadProcess(SPOILERS_STATUS_URL, false);
     } else {
-        qDebug() << "Spoilers Disabled";
+        qCDebug(SpoilerBackgroundUpdaterLog) << "Spoilers Disabled";
     }
 }
 
@@ -67,7 +67,7 @@ void SpoilerBackgroundUpdater::actDownloadFinishedSpoilersFile()
         reply->deleteLater();
         emit spoilerCheckerDone();
     } else {
-        qDebug() << "Error downloading spoilers file" << errorCode;
+        qCDebug(SpoilerBackgroundUpdaterLog) << "Error downloading spoilers file" << errorCode;
         emit spoilerCheckerDone();
     }
 }
@@ -81,11 +81,11 @@ bool SpoilerBackgroundUpdater::deleteSpoilerFile()
 
     // Delete the spoiler.xml file
     if (file.exists() && file.remove()) {
-        qDebug() << "Deleting spoiler.xml";
+        qCDebug(SpoilerBackgroundUpdaterLog) << "Deleting spoiler.xml";
         return true;
     }
 
-    qDebug() << "Error: Spoiler.xml not found or not deleted";
+    qCDebug(SpoilerBackgroundUpdaterLog) << "Error: Spoiler.xml not found or not deleted";
     return false;
 }
 
@@ -101,24 +101,24 @@ void SpoilerBackgroundUpdater::actCheckIfSpoilerSeasonEnabled()
             trayIcon->showMessage(tr("Spoilers season has ended"), tr("Deleting spoiler.xml. Please run Oracle"));
         }
 
-        qDebug() << "Spoiler Season Offline";
+        qCDebug(SpoilerBackgroundUpdaterLog) << "Spoiler Season Offline";
         emit spoilerCheckerDone();
     } else if (errorCode == QNetworkReply::NoError) {
-        qDebug() << "Spoiler Service Online";
+        qCDebug(SpoilerBackgroundUpdaterLog) << "Spoiler Service Online";
         startSpoilerDownloadProcess(SPOILERS_URL, true);
     } else if (errorCode == QNetworkReply::HostNotFoundError) {
         if (trayIcon) {
             trayIcon->showMessage(tr("Spoilers download failed"), tr("No internet connection"));
         }
 
-        qDebug() << "Spoiler download failed due to no internet connection";
+        qCDebug(SpoilerBackgroundUpdaterLog) << "Spoiler download failed due to no internet connection";
         emit spoilerCheckerDone();
     } else {
         if (trayIcon) {
             trayIcon->showMessage(tr("Spoilers download failed"), tr("Error") + " " + (short)errorCode);
         }
 
-        qDebug() << "Spoiler download failed with reason" << errorCode;
+        qCDebug(SpoilerBackgroundUpdaterLog) << "Spoiler download failed with reason" << errorCode;
         emit spoilerCheckerDone();
     }
 }
@@ -139,19 +139,19 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
             trayIcon->showMessage(tr("Spoilers already up to date"), tr("No new spoilers added"));
         }
 
-        qDebug() << "Spoilers Up to Date";
+        qCDebug(SpoilerBackgroundUpdaterLog) << "Spoilers Up to Date";
         return false;
     }
 
     QFile file(fileName);
     if (!file.open(QIODevice::WriteOnly)) {
-        qDebug() << "Spoiler Service Error: File open (w) failed for" << fileName;
+        qCDebug(SpoilerBackgroundUpdaterLog) << "Spoiler Service Error: File open (w) failed for" << fileName;
         file.close();
         return false;
     }
 
     if (file.write(data) == -1) {
-        qDebug() << "Spoiler Service Error: File write (w) failed for" << fileName;
+        qCDebug(SpoilerBackgroundUpdaterLog) << "Spoiler Service Error: File write (w) failed for" << fileName;
         file.close();
         return false;
     }
@@ -159,7 +159,7 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
     file.close();
 
     // Data written, so reload the card database
-    qDebug() << "Spoiler Service Data Written";
+    qCDebug(SpoilerBackgroundUpdaterLog) << "Spoiler Service Data Written";
     const auto reloadOk = QtConcurrent::run([] { CardDatabaseManager::getInstance()->loadCardDatabases(); });
 
     // If the user has notifications enabled, let them know
@@ -202,12 +202,12 @@ QByteArray SpoilerBackgroundUpdater::getHash(const QString fileName)
         QCryptographicHash hash(QCryptographicHash::Algorithm::Md5);
         hash.addData(bytes);
 
-        qDebug() << "File Hash =" << hash.result();
+        qCDebug(SpoilerBackgroundUpdaterLog) << "File Hash =" << hash.result();
 
         file.close();
         return hash.result();
     } else {
-        qDebug() << "getHash ReadOnly failed!";
+        qCDebug(SpoilerBackgroundUpdaterLog) << "getHash ReadOnly failed!";
         file.close();
         return QByteArray();
     }
@@ -221,7 +221,7 @@ QByteArray SpoilerBackgroundUpdater::getHash(QByteArray data)
     QCryptographicHash hash(QCryptographicHash::Algorithm::Md5);
     hash.addData(bytes);
 
-    qDebug() << "Data Hash =" << hash.result();
+    qCDebug(SpoilerBackgroundUpdaterLog) << "Data Hash =" << hash.result();
 
     return hash.result();
 }

--- a/cockatrice/src/client/network/spoiler_background_updater.h
+++ b/cockatrice/src/client/network/spoiler_background_updater.h
@@ -4,6 +4,9 @@
 #include <QByteArray>
 #include <QObject>
 #include <QProcess>
+#include <QLoggingCategory>
+
+inline Q_LOGGING_CATEGORY(SpoilerBackgroundUpdaterLog, "spoiler_background_updater.debug");
 
 class SpoilerBackgroundUpdater : public QObject
 {

--- a/cockatrice/src/client/network/spoiler_background_updater.h
+++ b/cockatrice/src/client/network/spoiler_background_updater.h
@@ -2,9 +2,9 @@
 #define COCKATRICE_SPOILER_DOWNLOADER_H
 
 #include <QByteArray>
+#include <QLoggingCategory>
 #include <QObject>
 #include <QProcess>
-#include <QLoggingCategory>
 
 inline Q_LOGGING_CATEGORY(SpoilerBackgroundUpdaterLog, "spoiler_background_updater.debug");
 

--- a/cockatrice/src/client/network/spoiler_background_updater.h
+++ b/cockatrice/src/client/network/spoiler_background_updater.h
@@ -6,7 +6,7 @@
 #include <QObject>
 #include <QProcess>
 
-inline Q_LOGGING_CATEGORY(SpoilerBackgroundUpdaterLog, "spoiler_background_updater.debug");
+inline Q_LOGGING_CATEGORY(SpoilerBackgroundUpdaterLog, "spoiler_background_updater");
 
 class SpoilerBackgroundUpdater : public QObject
 {

--- a/cockatrice/src/client/sound_engine.cpp
+++ b/cockatrice/src/client/sound_engine.cpp
@@ -37,7 +37,7 @@ SoundEngine::~SoundEngine()
 void SoundEngine::soundEnabledChanged()
 {
     if (SettingsCache::instance().getSoundEnabled()) {
-        qDebug() << "SoundEngine: enabling sound with" << audioData.size() << "sounds";
+        qCDebug(SoundEngineLog) << "SoundEngine: enabling sound with" << audioData.size() << "sounds";
         if (!player) {
             player = new QMediaPlayer;
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
@@ -46,7 +46,7 @@ void SoundEngine::soundEnabledChanged()
 #endif
         }
     } else {
-        qDebug() << "SoundEngine: disabling sound";
+        qCDebug(SoundEngineLog) << "SoundEngine: disabling sound";
         if (player) {
             player->stop();
             player->deleteLater();
@@ -90,7 +90,7 @@ void SoundEngine::ensureThemeDirectoryExists()
 {
     if (SettingsCache::instance().getSoundThemeName().isEmpty() ||
         !getAvailableThemes().contains(SettingsCache::instance().getSoundThemeName())) {
-        qDebug() << "Sounds theme name not set, setting default value";
+        qCDebug(SoundEngineLog) << "Sounds theme name not set, setting default value";
         SettingsCache::instance().setSoundThemeName(DEFAULT_THEME_NAME);
     }
 }
@@ -131,7 +131,7 @@ QStringMap &SoundEngine::getAvailableThemes()
 void SoundEngine::themeChangedSlot()
 {
     QString themeName = SettingsCache::instance().getSoundThemeName();
-    qDebug() << "Sound theme changed:" << themeName;
+    qCDebug(SoundEngineLog) << "Sound theme changed:" << themeName;
 
     QDir dir = getAvailableThemes().value(themeName);
 

--- a/cockatrice/src/client/sound_engine.h
+++ b/cockatrice/src/client/sound_engine.h
@@ -6,6 +6,9 @@
 #include <QMediaPlayer>
 #include <QObject>
 #include <QString>
+#include <QLoggingCategory>
+
+inline Q_LOGGING_CATEGORY(SoundEngineLog, "sound_engine.debug");
 
 class QBuffer;
 

--- a/cockatrice/src/client/sound_engine.h
+++ b/cockatrice/src/client/sound_engine.h
@@ -2,11 +2,11 @@
 #define SOUNDENGINE_H
 
 #include <QAudioOutput>
+#include <QLoggingCategory>
 #include <QMap>
 #include <QMediaPlayer>
 #include <QObject>
 #include <QString>
-#include <QLoggingCategory>
 
 inline Q_LOGGING_CATEGORY(SoundEngineLog, "sound_engine.debug");
 

--- a/cockatrice/src/client/sound_engine.h
+++ b/cockatrice/src/client/sound_engine.h
@@ -8,7 +8,7 @@
 #include <QObject>
 #include <QString>
 
-inline Q_LOGGING_CATEGORY(SoundEngineLog, "sound_engine.debug");
+inline Q_LOGGING_CATEGORY(SoundEngineLog, "sound_engine");
 
 class QBuffer;
 

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -1578,12 +1578,10 @@ void TabDeckEditor::actDecrement()
 
 void TabDeckEditor::setDeck(DeckLoader *_deck)
 {
-    qDebug() << " ORIGINAL BANNER CARD " << _deck->getBannerCard().first;
     deckModel->setDeckList(_deck);
 
     nameEdit->setText(deckModel->getDeckList()->getName());
     commentsEdit->setText(deckModel->getDeckList()->getComments());
-    qDebug() << deckModel->getDeckList()->getBannerCard() << " was the banner card";
     bannerCardComboBox->setCurrentText(deckModel->getDeckList()->getBannerCard().first);
     updateBannerCardComboBox();
     updateHash();

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -759,7 +759,7 @@ void TabGame::processGameEventContainer(const GameEventContainer &cont,
                 default: {
                     Player *player = players.value(playerId, 0);
                     if (!player) {
-                        qDebug() << "unhandled game event: invalid player id";
+                        qCDebug(TabGameLog) << "unhandled game event: invalid player id";
                         break;
                     }
                     player->processGameEvent(eventType, event, context, options);

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -10,6 +10,9 @@
 
 #include <QCompleter>
 #include <QMap>
+#include <QLoggingCategory>
+
+inline Q_LOGGING_CATEGORY(TabGameLog, "tab_game.debug");
 
 class UserListProxy;
 class DeckViewContainer;

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -9,8 +9,8 @@
 #include "tab.h"
 
 #include <QCompleter>
-#include <QMap>
 #include <QLoggingCategory>
+#include <QMap>
 
 inline Q_LOGGING_CATEGORY(TabGameLog, "tab_game.debug");
 

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -12,7 +12,7 @@
 #include <QLoggingCategory>
 #include <QMap>
 
-inline Q_LOGGING_CATEGORY(TabGameLog, "tab_game.debug");
+inline Q_LOGGING_CATEGORY(TabGameLog, "tab_game");
 
 class UserListProxy;
 class DeckViewContainer;

--- a/cockatrice/src/client/tabs/tab_message.cpp
+++ b/cockatrice/src/client/tabs/tab_message.cpp
@@ -148,7 +148,7 @@ void TabMessage::showSystemPopup(const Event_UserMessage &event)
                               event.message().c_str());
         connect(trayIcon, SIGNAL(messageClicked()), this, SLOT(messageClicked()));
     } else {
-        qDebug() << "Error: trayIcon is NULL. TabMessage::showSystemPopup failed";
+        qCDebug(TabMessageLog) << "Error: trayIcon is NULL. TabMessage::showSystemPopup failed";
     }
 }
 

--- a/cockatrice/src/client/tabs/tab_message.h
+++ b/cockatrice/src/client/tabs/tab_message.h
@@ -3,6 +3,10 @@
 
 #include "tab.h"
 
+#include <QLoggingCategory>
+
+inline Q_LOGGING_CATEGORY(TabMessageLog, "tab_message.debug");
+
 class AbstractClient;
 class ChatView;
 class LineEditUnfocusable;

--- a/cockatrice/src/client/tabs/tab_message.h
+++ b/cockatrice/src/client/tabs/tab_message.h
@@ -5,7 +5,7 @@
 
 #include <QLoggingCategory>
 
-inline Q_LOGGING_CATEGORY(TabMessageLog, "tab_message.debug");
+inline Q_LOGGING_CATEGORY(TabMessageLog, "tab_message");
 
 class AbstractClient;
 class ChatView;

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -760,7 +760,7 @@ void TabSupervisor::processGameEventContainer(const GameEventContainer &cont)
     if (tab)
         tab->processGameEventContainer(cont, qobject_cast<AbstractClient *>(sender()), {});
     else
-        qDebug() << "gameEvent: invalid gameId";
+        qCDebug(TabSupervisorLog) << "gameEvent: invalid gameId";
 }
 
 void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)
@@ -787,9 +787,9 @@ void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)
 
 void TabSupervisor::actShowPopup(const QString &message)
 {
-    qDebug() << "ACT SHOW POPUP";
+    qCDebug(TabSupervisorLog) << "ACT SHOW POPUP";
     if (trayIcon && (QApplication::activeWindow() == nullptr || QApplication::focusWidget() == nullptr)) {
-        qDebug() << "LAUNCHING POPUP";
+        qCDebug(TabSupervisorLog) << "LAUNCHING POPUP";
         // disconnect(trayIcon, SIGNAL(messageClicked()), nullptr, nullptr);
         trayIcon->showMessage(message, tr("Click to view"));
         // connect(trayIcon, SIGNAL(messageClicked()), chatView, SLOT(actMessageClicked()));

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -7,9 +7,12 @@
 
 #include <QAbstractButton>
 #include <QCommonStyle>
+#include <QLoggingCategory>
 #include <QMap>
 #include <QProxyStyle>
 #include <QTabWidget>
+
+inline Q_LOGGING_CATEGORY(TabSupervisorLog, "tab_supervisor.debug");
 
 class UserListManager;
 class QMenu;

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -12,7 +12,7 @@
 #include <QProxyStyle>
 #include <QTabWidget>
 
-inline Q_LOGGING_CATEGORY(TabSupervisorLog, "tab_supervisor.debug");
+inline Q_LOGGING_CATEGORY(TabSupervisorLog, "tab_supervisor");
 
 class UserListManager;
 class QMenu;

--- a/cockatrice/src/client/tapped_out_interface.cpp
+++ b/cockatrice/src/client/tapped_out_interface.cpp
@@ -98,7 +98,7 @@ struct CopyMainOrSide
     DeckList &mainboard, &sideboard;
 
     CopyMainOrSide(CardDatabase &_cardDatabase, DeckList &_mainboard, DeckList &_sideboard)
-        : cardDatabase(_cardDatabase), mainboard(_mainboard), sideboard(_sideboard) {};
+        : cardDatabase(_cardDatabase), mainboard(_mainboard), sideboard(_sideboard){};
 
     void operator()(const InnerDecklistNode *node, const DecklistCardNode *card) const
     {

--- a/cockatrice/src/client/tapped_out_interface.cpp
+++ b/cockatrice/src/client/tapped_out_interface.cpp
@@ -33,7 +33,7 @@ void TappedOutInterface::queryFinished(QNetworkReply *reply)
          * can be extracted from the header. The http status is a 302 "redirect".
          */
         QString deckUrl = reply->rawHeader("Location");
-        qDebug() << "Tappedout: good reply, http status" << httpStatus << "location" << deckUrl;
+        qCDebug(TappedOutInterfaceLog) << "Tappedout: good reply, http status" << httpStatus << "location" << deckUrl;
         QDesktopServices::openUrl("https://tappedout.net" + deckUrl);
     } else {
         /*
@@ -57,7 +57,7 @@ void TappedOutInterface::queryFinished(QNetworkReply *reply)
         }
 
         QString errorMessage = errorMessageList.join("\n");
-        qDebug() << "Tappedout: bad reply, http status" << httpStatus << "size" << data.size() << "message"
+        qCDebug(TappedOutInterfaceLog) << "Tappedout: bad reply, http status" << httpStatus << "size" << data.size() << "message"
                  << errorMessage;
 
         QMessageBox::critical(nullptr, tr("Error"), errorMessage);

--- a/cockatrice/src/client/tapped_out_interface.cpp
+++ b/cockatrice/src/client/tapped_out_interface.cpp
@@ -57,8 +57,8 @@ void TappedOutInterface::queryFinished(QNetworkReply *reply)
         }
 
         QString errorMessage = errorMessageList.join("\n");
-        qCDebug(TappedOutInterfaceLog) << "Tappedout: bad reply, http status" << httpStatus << "size" << data.size() << "message"
-                 << errorMessage;
+        qCDebug(TappedOutInterfaceLog) << "Tappedout: bad reply, http status" << httpStatus << "size" << data.size()
+                                       << "message" << errorMessage;
 
         QMessageBox::critical(nullptr, tr("Error"), errorMessage);
     }
@@ -98,7 +98,7 @@ struct CopyMainOrSide
     DeckList &mainboard, &sideboard;
 
     CopyMainOrSide(CardDatabase &_cardDatabase, DeckList &_mainboard, DeckList &_sideboard)
-        : cardDatabase(_cardDatabase), mainboard(_mainboard), sideboard(_sideboard){};
+        : cardDatabase(_cardDatabase), mainboard(_mainboard), sideboard(_sideboard) {};
 
     void operator()(const InnerDecklistNode *node, const DecklistCardNode *card) const
     {

--- a/cockatrice/src/client/tapped_out_interface.h
+++ b/cockatrice/src/client/tapped_out_interface.h
@@ -7,7 +7,7 @@
 #include <QLoggingCategory>
 #include <QObject>
 
-inline Q_LOGGING_CATEGORY(TappedOutInterfaceLog, "tapped_out_interface.debug")
+inline Q_LOGGING_CATEGORY(TappedOutInterfaceLog, "tapped_out_interface")
 
     class QByteArray;
 class QNetworkAccessManager;

--- a/cockatrice/src/client/tapped_out_interface.h
+++ b/cockatrice/src/client/tapped_out_interface.h
@@ -5,6 +5,9 @@
 #include "decklist.h"
 
 #include <QObject>
+#include <QLoggingCategory>
+
+inline Q_LOGGING_CATEGORY(TappedOutInterfaceLog, "tapped_out_interface.debug")
 
 class QByteArray;
 class QNetworkAccessManager;

--- a/cockatrice/src/client/tapped_out_interface.h
+++ b/cockatrice/src/client/tapped_out_interface.h
@@ -7,9 +7,9 @@
 #include <QLoggingCategory>
 #include <QObject>
 
-inline Q_LOGGING_CATEGORY(TappedOutInterfaceLog, "tapped_out_interface")
+inline Q_LOGGING_CATEGORY(TappedOutInterfaceLog, "tapped_out_interface");
 
-    class QByteArray;
+class QByteArray;
 class QNetworkAccessManager;
 class QNetworkReply;
 class DeckList;

--- a/cockatrice/src/client/tapped_out_interface.h
+++ b/cockatrice/src/client/tapped_out_interface.h
@@ -4,12 +4,12 @@
 #include "../game/cards/card_database.h"
 #include "decklist.h"
 
-#include <QObject>
 #include <QLoggingCategory>
+#include <QObject>
 
 inline Q_LOGGING_CATEGORY(TappedOutInterfaceLog, "tapped_out_interface.debug")
 
-class QByteArray;
+    class QByteArray;
 class QNetworkAccessManager;
 class QNetworkReply;
 class DeckList;

--- a/cockatrice/src/client/ui/picture_loader/picture_loader.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader.cpp
@@ -15,10 +15,7 @@
 #include <QScreen>
 #include <QThread>
 #include <algorithm>
-#include <qloggingcategory.h>
 #include <utility>
-
-Q_LOGGING_CATEGORY(PictureLoaderLog, "picture_loader")
 
 // never cache more than 300 cards at once for a single deck
 #define CACHED_CARD_PER_DECK_MAX 300

--- a/cockatrice/src/client/ui/picture_loader/picture_loader.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader.cpp
@@ -89,7 +89,7 @@ void PictureLoader::getPixmap(QPixmap &pixmap, CardInfoPtr card, QSize size)
     }
 
     // add the card to the load queue
-    qCDebug(PictureLoaderLog) << "PictureLoader: Enqueuing " << card->getName() << " for " << card->getPixmapCacheKey();
+    qCDebug(PictureLoaderLog) << "Enqueuing " << card->getName() << " for " << card->getPixmapCacheKey();
     getInstance().worker->enqueueImageLoad(card);
 }
 

--- a/cockatrice/src/client/ui/picture_loader/picture_loader.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader.cpp
@@ -49,7 +49,7 @@ void PictureLoader::getCardBackLoadingInProgressPixmap(QPixmap &pixmap, QSize si
 {
     QString backCacheKey = "_trice_card_back_" + QString::number(size.width()) + QString::number(size.height());
     if (!QPixmapCache::find(backCacheKey, &pixmap)) {
-        qCDebug(PictureLoaderLog) << "PictureLoader: cache fail for" << backCacheKey;
+        qCDebug(PictureLoaderCardBackCacheFailLog) << "PictureLoader: cache fail for" << backCacheKey;
         pixmap = QPixmap("theme:cardback").scaled(size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
         QPixmapCache::insert(backCacheKey, pixmap);
     }
@@ -59,7 +59,7 @@ void PictureLoader::getCardBackLoadingFailedPixmap(QPixmap &pixmap, QSize size)
 {
     QString backCacheKey = "_trice_card_back_" + QString::number(size.width()) + QString::number(size.height());
     if (!QPixmapCache::find(backCacheKey, &pixmap)) {
-        qCDebug(PictureLoaderLog) << "PictureLoader: cache fail for" << backCacheKey;
+        qCDebug(PictureLoaderCardBackCacheFailLog) << "PictureLoader: cache fail for" << backCacheKey;
         pixmap = QPixmap("theme:cardback").scaled(size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
         QPixmapCache::insert(backCacheKey, pixmap);
     }
@@ -89,6 +89,7 @@ void PictureLoader::getPixmap(QPixmap &pixmap, CardInfoPtr card, QSize size)
     }
 
     // add the card to the load queue
+    qCDebug(PictureLoaderLog) << "PictureLoader: Enqueuing " << card->getName() << " for " << card->getPixmapCacheKey();
     getInstance().worker->enqueueImageLoad(card);
 }
 

--- a/cockatrice/src/client/ui/picture_loader/picture_loader.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader.h
@@ -7,6 +7,7 @@
 #include <QLoggingCategory>
 
 inline Q_LOGGING_CATEGORY(PictureLoaderLog, "picture_loader")
+inline Q_LOGGING_CATEGORY(PictureLoaderCardBackCacheFailLog, "picture_loader.card_back_cache_fail");
 
     class PictureLoader : public QObject
 {

--- a/cockatrice/src/client/ui/picture_loader/picture_loader.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader.h
@@ -6,10 +6,11 @@
 
 #include <QLoggingCategory>
 
-inline Q_LOGGING_CATEGORY(PictureLoaderLog, "picture_loader")
-inline Q_LOGGING_CATEGORY(PictureLoaderCardBackCacheFailLog, "picture_loader.card_back_cache_fail");
+inline Q_LOGGING_CATEGORY(PictureLoaderLog,
+                          "picture_loader") inline Q_LOGGING_CATEGORY(PictureLoaderCardBackCacheFailLog,
+                                                                      "picture_loader.card_back_cache_fail");
 
-    class PictureLoader : public QObject
+class PictureLoader : public QObject
 {
     Q_OBJECT
 public:

--- a/cockatrice/src/client/ui/picture_loader/picture_loader.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader.h
@@ -4,7 +4,11 @@
 #include "../../../game/cards/card_database.h"
 #include "picture_loader_worker.h"
 
-class PictureLoader : public QObject
+#include <QLoggingCategory>
+
+inline Q_LOGGING_CATEGORY(PictureLoaderLog, "picture_loader")
+
+    class PictureLoader : public QObject
 {
     Q_OBJECT
 public:

--- a/cockatrice/src/client/ui/picture_loader/picture_loader.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader.h
@@ -6,9 +6,8 @@
 
 #include <QLoggingCategory>
 
-inline Q_LOGGING_CATEGORY(PictureLoaderLog,
-                          "picture_loader") inline Q_LOGGING_CATEGORY(PictureLoaderCardBackCacheFailLog,
-                                                                      "picture_loader.card_back_cache_fail");
+inline Q_LOGGING_CATEGORY(PictureLoaderLog, "picture_loader");
+inline Q_LOGGING_CATEGORY(PictureLoaderCardBackCacheFailLog, "picture_loader.card_back_cache_fail");
 
 class PictureLoader : public QObject
 {

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
@@ -90,8 +90,8 @@ void PictureLoaderWorker::processLoadQueue()
             }
         }
 
-        qCDebug(PictureLoaderWorkerLog).nospace() << "[card: " << cardName << " set: " << setName
-                                                  << "]: No custom picture, trying to download";
+        qCDebug(PictureLoaderWorkerLog).nospace()
+            << "[card: " << cardName << " set: " << setName << "]: No custom picture, trying to download";
         cardsToDownload.append(cardBeingLoaded);
         cardBeingLoaded.clear();
         if (!downloadRunning) {
@@ -140,15 +140,15 @@ bool PictureLoaderWorker::cardImageExistsOnDisk(QString &setName, QString &corre
         }
         imgReader.setFileName(_picsPath + ".full");
         if (imgReader.read(&image)) {
-            qCDebug(PictureLoaderWorkerLog).nospace() << "[card: " << correctedCardname
-                                                      << " set: " << setName << "]: Picture.full found on disk.";
+            qCDebug(PictureLoaderWorkerLog).nospace()
+                << "[card: " << correctedCardname << " set: " << setName << "]: Picture.full found on disk.";
             imageLoaded(cardBeingLoaded.getCard(), image);
             return true;
         }
         imgReader.setFileName(_picsPath + ".xlhq");
         if (imgReader.read(&image)) {
-            qCDebug(PictureLoaderWorkerLog).nospace() << "[card: " << correctedCardname
-                                                      << " set: " << setName << "]: Picture.xlhq found on disk.";
+            qCDebug(PictureLoaderWorkerLog).nospace()
+                << "[card: " << correctedCardname << " set: " << setName << "]: Picture.xlhq found on disk.";
             imageLoaded(cardBeingLoaded.getCard(), image);
             return true;
         }
@@ -176,10 +176,9 @@ void PictureLoaderWorker::startNextPicDownload()
         picDownloadFailed();
     } else {
         QUrl url(picUrl);
-        qCDebug(PictureLoaderWorkerLog).nospace()
-            << "[card: " << cardBeingDownloaded.getCard()->getCorrectedName()
-            << " set: " << cardBeingDownloaded.getSetName() << "]: Trying to fetch picture from url "
-            << url.toDisplayString();
+        qCDebug(PictureLoaderWorkerLog).nospace() << "[card: " << cardBeingDownloaded.getCard()->getCorrectedName()
+                                                  << " set: " << cardBeingDownloaded.getSetName()
+                                                  << "]: Trying to fetch picture from url " << url.toDisplayString();
         makeRequest(url);
     }
 }
@@ -323,18 +322,18 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
     if (reply->error()) {
         if (isFromCache) {
             qCDebug(PictureLoaderWorkerLog).nospace()
-                << "[card: " << cardBeingDownloaded.getCard()->getName()
-                << " set: " << cardBeingDownloaded.getSetName() << "]: Removing corrupted cache file for url "
-                << reply->url().toDisplayString() << " and retrying (" << reply->errorString() << ")";
+                << "[card: " << cardBeingDownloaded.getCard()->getName() << " set: " << cardBeingDownloaded.getSetName()
+                << "]: Removing corrupted cache file for url " << reply->url().toDisplayString() << " and retrying ("
+                << reply->errorString() << ")";
 
             networkManager->cache()->remove(reply->url());
 
             makeRequest(reply->url());
         } else {
             qCDebug(PictureLoaderWorkerLog).nospace()
-                << "[card: " << cardBeingDownloaded.getCard()->getName()
-                << " set: " << cardBeingDownloaded.getSetName() << "]: " << (picDownload ? "Download" : "Cache search")
-                << " failed for url " << reply->url().toDisplayString() << " (" << reply->errorString() << ")";
+                << "[card: " << cardBeingDownloaded.getCard()->getName() << " set: " << cardBeingDownloaded.getSetName()
+                << "]: " << (picDownload ? "Download" : "Cache search") << " failed for url "
+                << reply->url().toDisplayString() << " (" << reply->errorString() << ")";
 
             picDownloadFailed();
             startNextPicDownload();
@@ -350,9 +349,9 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
         statusCode == 308) {
         QUrl redirectUrl = reply->header(QNetworkRequest::LocationHeader).toUrl();
         qCDebug(PictureLoaderWorkerLog).nospace()
-            << "[card: " << cardBeingDownloaded.getCard()->getName()
-            << " set: " << cardBeingDownloaded.getSetName() << "]: following "
-            << (isFromCache ? "cached redirect" : "redirect") << " to " << redirectUrl.toDisplayString();
+            << "[card: " << cardBeingDownloaded.getCard()->getName() << " set: " << cardBeingDownloaded.getSetName()
+            << "]: following " << (isFromCache ? "cached redirect" : "redirect") << " to "
+            << redirectUrl.toDisplayString();
         makeRequest(redirectUrl);
         reply->deleteLater();
         return;
@@ -363,8 +362,7 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
 
     if (imageIsBlackListed(picData)) {
         qCDebug(PictureLoaderWorkerLog).nospace()
-            << "[card: " << cardBeingDownloaded.getCard()->getName()
-            << " set: " << cardBeingDownloaded.getSetName()
+            << "[card: " << cardBeingDownloaded.getCard()->getName() << " set: " << cardBeingDownloaded.getSetName()
             << "]: Picture found, but blacklisted, will consider it as not found";
 
         picDownloadFailed();
@@ -399,18 +397,18 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
         logSuccessMessage = true;
     } else {
         qCDebug(PictureLoaderWorkerLog).nospace()
-            << "[card: " << cardBeingDownloaded.getCard()->getName()
-            << " set: " << cardBeingDownloaded.getSetName() << "]: Possible " << (isFromCache ? "cached" : "downloaded")
-            << " picture at " << reply->url().toDisplayString() << " could not be loaded: " << reply->errorString();
+            << "[card: " << cardBeingDownloaded.getCard()->getName() << " set: " << cardBeingDownloaded.getSetName()
+            << "]: Possible " << (isFromCache ? "cached" : "downloaded") << " picture at "
+            << reply->url().toDisplayString() << " could not be loaded: " << reply->errorString();
 
         picDownloadFailed();
     }
 
     if (logSuccessMessage) {
         qCDebug(PictureLoaderWorkerLog).nospace()
-            << "[card: " << cardBeingDownloaded.getCard()->getName()
-            << " set: " << cardBeingDownloaded.getSetName() << "]: Image successfully "
-            << (isFromCache ? "loaded from cached" : "downloaded from") << " url " << reply->url().toDisplayString();
+            << "[card: " << cardBeingDownloaded.getCard()->getName() << " set: " << cardBeingDownloaded.getSetName()
+            << "]: Image successfully " << (isFromCache ? "loaded from cached" : "downloaded from") << " url "
+            << reply->url().toDisplayString();
     }
 
     reply->deleteLater();

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
@@ -81,7 +81,7 @@ void PictureLoaderWorker::processLoadQueue()
         QString correctedCardName = cardBeingLoaded.getCard()->getCorrectedName();
 
         qCDebug(PictureLoaderWorkerLog).nospace()
-            << "PictureLoader: [card: " << cardName << " set: " << setName << "]: Trying to load picture";
+            << "[card: " << cardName << " set: " << setName << "]: Trying to load picture";
 
         if (CardDatabaseManager::getInstance()->isProviderIdForPreferredPrinting(
                 cardName, cardBeingLoaded.getCard()->getPixmapCacheKey())) {
@@ -90,7 +90,7 @@ void PictureLoaderWorker::processLoadQueue()
             }
         }
 
-        qCDebug(PictureLoaderWorkerLog).nospace() << "PictureLoader: [card: " << cardName << " set: " << setName
+        qCDebug(PictureLoaderWorkerLog).nospace() << "[card: " << cardName << " set: " << setName
                                                   << "]: No custom picture, trying to download";
         cardsToDownload.append(cardBeingLoaded);
         cardBeingLoaded.clear();
@@ -134,20 +134,20 @@ bool PictureLoaderWorker::cardImageExistsOnDisk(QString &setName, QString &corre
         imgReader.setFileName(_picsPath);
         if (imgReader.read(&image)) {
             qCDebug(PictureLoaderWorkerLog).nospace()
-                << "PictureLoader: [card: " << correctedCardname << " set: " << setName << "]: Picture found on disk.";
+                << "[card: " << correctedCardname << " set: " << setName << "]: Picture found on disk.";
             imageLoaded(cardBeingLoaded.getCard(), image);
             return true;
         }
         imgReader.setFileName(_picsPath + ".full");
         if (imgReader.read(&image)) {
-            qCDebug(PictureLoaderWorkerLog).nospace() << "PictureLoader: [card: " << correctedCardname
+            qCDebug(PictureLoaderWorkerLog).nospace() << "[card: " << correctedCardname
                                                       << " set: " << setName << "]: Picture.full found on disk.";
             imageLoaded(cardBeingLoaded.getCard(), image);
             return true;
         }
         imgReader.setFileName(_picsPath + ".xlhq");
         if (imgReader.read(&image)) {
-            qCDebug(PictureLoaderWorkerLog).nospace() << "PictureLoader: [card: " << correctedCardname
+            qCDebug(PictureLoaderWorkerLog).nospace() << "[card: " << correctedCardname
                                                       << " set: " << setName << "]: Picture.xlhq found on disk.";
             imageLoaded(cardBeingLoaded.getCard(), image);
             return true;
@@ -177,7 +177,7 @@ void PictureLoaderWorker::startNextPicDownload()
     } else {
         QUrl url(picUrl);
         qCDebug(PictureLoaderWorkerLog).nospace()
-            << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
+            << "[card: " << cardBeingDownloaded.getCard()->getCorrectedName()
             << " set: " << cardBeingDownloaded.getSetName() << "]: Trying to fetch picture from url "
             << url.toDisplayString();
         makeRequest(url);
@@ -196,7 +196,7 @@ void PictureLoaderWorker::picDownloadFailed()
         mutex.unlock();
     } else {
         qCDebug(PictureLoaderWorkerLog).nospace()
-            << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
+            << "[card: " << cardBeingDownloaded.getCard()->getCorrectedName()
             << " set: " << cardBeingDownloaded.getSetName() << "]: Picture NOT found, "
             << (picDownload ? "download failed" : "downloads disabled")
             << ", no more url combinations to try: BAILING OUT";
@@ -218,7 +218,7 @@ QNetworkReply *PictureLoaderWorker::makeRequest(const QUrl &url)
     QUrl cachedRedirect = getCachedRedirect(url);
     if (!cachedRedirect.isEmpty()) {
         qCDebug(PictureLoaderWorkerLog).nospace()
-            << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
+            << "[card: " << cardBeingDownloaded.getCard()->getCorrectedName()
             << " set: " << cardBeingDownloaded.getSetName() << "]: Using cached redirect for " << url.toDisplayString()
             << " to " << cachedRedirect.toDisplayString();
         return makeRequest(cachedRedirect); // Use the cached redirect
@@ -243,7 +243,7 @@ QNetworkReply *PictureLoaderWorker::makeRequest(const QUrl &url)
 
             cacheRedirect(url, redirectUrl);
             qCDebug(PictureLoaderWorkerLog).nospace()
-                << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getCorrectedName()
+                << "[card: " << cardBeingDownloaded.getCard()->getCorrectedName()
                 << " set: " << cardBeingDownloaded.getSetName() << "]: Caching redirect from " << url.toDisplayString()
                 << " to " << redirectUrl.toDisplayString();
         }
@@ -323,7 +323,7 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
     if (reply->error()) {
         if (isFromCache) {
             qCDebug(PictureLoaderWorkerLog).nospace()
-                << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+                << "[card: " << cardBeingDownloaded.getCard()->getName()
                 << " set: " << cardBeingDownloaded.getSetName() << "]: Removing corrupted cache file for url "
                 << reply->url().toDisplayString() << " and retrying (" << reply->errorString() << ")";
 
@@ -332,7 +332,7 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
             makeRequest(reply->url());
         } else {
             qCDebug(PictureLoaderWorkerLog).nospace()
-                << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+                << "[card: " << cardBeingDownloaded.getCard()->getName()
                 << " set: " << cardBeingDownloaded.getSetName() << "]: " << (picDownload ? "Download" : "Cache search")
                 << " failed for url " << reply->url().toDisplayString() << " (" << reply->errorString() << ")";
 
@@ -350,7 +350,7 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
         statusCode == 308) {
         QUrl redirectUrl = reply->header(QNetworkRequest::LocationHeader).toUrl();
         qCDebug(PictureLoaderWorkerLog).nospace()
-            << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+            << "[card: " << cardBeingDownloaded.getCard()->getName()
             << " set: " << cardBeingDownloaded.getSetName() << "]: following "
             << (isFromCache ? "cached redirect" : "redirect") << " to " << redirectUrl.toDisplayString();
         makeRequest(redirectUrl);
@@ -363,7 +363,7 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
 
     if (imageIsBlackListed(picData)) {
         qCDebug(PictureLoaderWorkerLog).nospace()
-            << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+            << "[card: " << cardBeingDownloaded.getCard()->getName()
             << " set: " << cardBeingDownloaded.getSetName()
             << "]: Picture found, but blacklisted, will consider it as not found";
 
@@ -399,7 +399,7 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
         logSuccessMessage = true;
     } else {
         qCDebug(PictureLoaderWorkerLog).nospace()
-            << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+            << "[card: " << cardBeingDownloaded.getCard()->getName()
             << " set: " << cardBeingDownloaded.getSetName() << "]: Possible " << (isFromCache ? "cached" : "downloaded")
             << " picture at " << reply->url().toDisplayString() << " could not be loaded: " << reply->errorString();
 
@@ -408,7 +408,7 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
 
     if (logSuccessMessage) {
         qCDebug(PictureLoaderWorkerLog).nospace()
-            << "PictureLoader: [card: " << cardBeingDownloaded.getCard()->getName()
+            << "[card: " << cardBeingDownloaded.getCard()->getName()
             << " set: " << cardBeingDownloaded.getSetName() << "]: Image successfully "
             << (isFromCache ? "loaded from cached" : "downloaded from") << " url " << reply->url().toDisplayString();
     }

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
@@ -5,13 +5,10 @@
 
 #include <QBuffer>
 #include <QDirIterator>
-#include <QLoggingCategory>
 #include <QMovie>
 #include <QNetworkDiskCache>
 #include <QNetworkReply>
 #include <QThread>
-
-Q_LOGGING_CATEGORY(PictureLoaderWorkerLog, "picture_loader.worker");
 
 // Card back returned by gatherer when card is not found
 QStringList PictureLoaderWorker::md5Blacklist = QStringList() << "db0c48db407a907c16ade38de048a441";

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.h
@@ -4,6 +4,7 @@
 #include "../../../game/cards/card_database.h"
 #include "picture_to_load.h"
 
+#include <QLoggingCategory>
 #include <QMutex>
 #include <QNetworkAccessManager>
 #include <QObject>
@@ -13,6 +14,8 @@
 #define REDIRECT_URL "redirect"
 #define REDIRECT_TIMESTAMP "timestamp"
 #define REDIRECT_CACHE_FILENAME "cache.ini"
+
+inline Q_LOGGING_CATEGORY(PictureLoaderWorkerLog, "picture_loader.worker");
 
 class PictureLoaderWorker : public QObject
 {

--- a/cockatrice/src/client/ui/picture_loader/picture_to_load.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_to_load.cpp
@@ -7,9 +7,6 @@
 #include <QRegularExpression>
 #include <QUrl>
 #include <algorithm>
-#include <qloggingcategory.h>
-
-Q_LOGGING_CATEGORY(PictureToLoadLog, "picture_loader.picture_to_load")
 
 PictureToLoad::PictureToLoad(CardInfoPtr _card)
     : card(std::move(_card)), urlTemplates(SettingsCache::instance().downloads().getAllURLs())

--- a/cockatrice/src/client/ui/picture_loader/picture_to_load.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_to_load.h
@@ -3,7 +3,11 @@
 
 #include "../../../game/cards/card_database.h"
 
-class PictureToLoad
+#include <QLoggingCategory>
+
+inline Q_LOGGING_CATEGORY(PictureToLoadLog, "picture_loader.picture_to_load")
+
+    class PictureToLoad
 {
 private:
     class SetDownloadPriorityComparator

--- a/cockatrice/src/client/ui/picture_loader/picture_to_load.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_to_load.h
@@ -5,9 +5,9 @@
 
 #include <QLoggingCategory>
 
-inline Q_LOGGING_CATEGORY(PictureToLoadLog, "picture_loader.picture_to_load")
+inline Q_LOGGING_CATEGORY(PictureToLoadLog, "picture_loader.picture_to_load");
 
-    class PictureToLoad
+class PictureToLoad
 {
 private:
     class SetDownloadPriorityComparator

--- a/cockatrice/src/client/ui/theme_manager.cpp
+++ b/cockatrice/src/client/ui/theme_manager.cpp
@@ -32,7 +32,7 @@ void ThemeManager::ensureThemeDirectoryExists()
 {
     if (SettingsCache::instance().getThemeName().isEmpty() ||
         !getAvailableThemes().contains(SettingsCache::instance().getThemeName())) {
-        qDebug() << "Theme name not set, setting default value";
+        qCDebug(ThemeManagerLog) << "Theme name not set, setting default value";
         SettingsCache::instance().setThemeName(NONE_THEME_NAME);
     }
 }
@@ -105,7 +105,7 @@ QBrush ThemeManager::loadExtraBrush(QString fileName, QBrush &fallbackBrush)
 void ThemeManager::themeChangedSlot()
 {
     QString themeName = SettingsCache::instance().getThemeName();
-    qDebug() << "Theme changed:" << themeName;
+    qCDebug(ThemeManagerLog) << "Theme changed:" << themeName;
 
     QString dirPath = getAvailableThemes().value(themeName);
     QDir dir = dirPath;

--- a/cockatrice/src/client/ui/theme_manager.h
+++ b/cockatrice/src/client/ui/theme_manager.h
@@ -9,7 +9,7 @@
 #include <QPixmap>
 #include <QString>
 
-inline Q_LOGGING_CATEGORY(ThemeManagerLog, "theme_manager.debug");
+inline Q_LOGGING_CATEGORY(ThemeManagerLog, "theme_manager");
 
 typedef QMap<QString, QString> QStringMap;
 typedef QMap<int, QBrush> QBrushMap;

--- a/cockatrice/src/client/ui/theme_manager.h
+++ b/cockatrice/src/client/ui/theme_manager.h
@@ -3,10 +3,13 @@
 
 #include <QBrush>
 #include <QDir>
+#include <QLoggingCategory>
 #include <QMap>
 #include <QObject>
 #include <QPixmap>
 #include <QString>
+
+inline Q_LOGGING_CATEGORY(ThemeManagerLog, "theme_manager.debug");
 
 typedef QMap<QString, QString> QStringMap;
 typedef QMap<int, QBrush> QBrushMap;

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -904,14 +904,16 @@ void MainWindow::startupConfigCheck()
 
     if (SettingsCache::instance().getClientVersion() == CLIENT_INFO_NOT_SET) {
         // no config found, 99% new clean install
-        qCDebug(WindowMainStartupVersionLog) << "Startup: old client version empty, assuming first start after clean install";
+        qCDebug(WindowMainStartupVersionLog)
+            << "Startup: old client version empty, assuming first start after clean install";
         alertForcedOracleRun(VERSION_STRING, false);
         SettingsCache::instance().downloads().resetToDefaultURLs(); // populate the download urls
         SettingsCache::instance().setClientVersion(VERSION_STRING);
     } else if (SettingsCache::instance().getClientVersion() != VERSION_STRING) {
         // config found, from another (presumably older) version
-        qCDebug(WindowMainStartupVersionLog) << "Startup: old client version" << SettingsCache::instance().getClientVersion()
-                 << "differs, assuming first start after update";
+        qCDebug(WindowMainStartupVersionLog)
+            << "Startup: old client version" << SettingsCache::instance().getClientVersion()
+            << "differs, assuming first start after update";
         if (SettingsCache::instance().getNotifyAboutNewVersion()) {
             alertForcedOracleRun(VERSION_STRING, true);
         } else {

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -904,13 +904,13 @@ void MainWindow::startupConfigCheck()
 
     if (SettingsCache::instance().getClientVersion() == CLIENT_INFO_NOT_SET) {
         // no config found, 99% new clean install
-        qDebug() << "Startup: old client version empty, assuming first start after clean install";
+        qCDebug(WindowMainStartupVersionLog) << "Startup: old client version empty, assuming first start after clean install";
         alertForcedOracleRun(VERSION_STRING, false);
         SettingsCache::instance().downloads().resetToDefaultURLs(); // populate the download urls
         SettingsCache::instance().setClientVersion(VERSION_STRING);
     } else if (SettingsCache::instance().getClientVersion() != VERSION_STRING) {
         // config found, from another (presumably older) version
-        qDebug() << "Startup: old client version" << SettingsCache::instance().getClientVersion()
+        qCDebug(WindowMainStartupVersionLog) << "Startup: old client version" << SettingsCache::instance().getClientVersion()
                  << "differs, assuming first start after update";
         if (SettingsCache::instance().getNotifyAboutNewVersion()) {
             alertForcedOracleRun(VERSION_STRING, true);
@@ -918,13 +918,13 @@ void MainWindow::startupConfigCheck()
             const auto reloadOk0 = QtConcurrent::run([] { CardDatabaseManager::getInstance()->loadCardDatabases(); });
         }
 
-        qDebug() << "[MainWindow] Migrating shortcuts after update detected.";
+        qCDebug(WindowMainStartupShortcutsLog) << "[MainWindow] Migrating shortcuts after update detected.";
         SettingsCache::instance().shortcuts().migrateShortcuts();
 
         SettingsCache::instance().setClientVersion(VERSION_STRING);
     } else {
         // previous config from this version found
-        qDebug() << "Startup: found config with current version";
+        qCDebug(WindowMainStartupVersionLog) << "Startup: found config with current version";
         const auto reloadOk1 = QtConcurrent::run([] { CardDatabaseManager::getInstance()->loadCardDatabases(); });
 
         // Run the tips dialog only on subsequent startups.
@@ -1036,11 +1036,11 @@ void MainWindow::changeEvent(QEvent *event)
         if (isActiveWindow() && !bHasActivated) {
             bHasActivated = true;
             if (!connectTo.isEmpty()) {
-                qDebug() << "Command line connect to " << connectTo;
+                qCDebug(WindowMainStartupAutoconnectLog) << "Command line connect to " << connectTo;
                 client->connectToServer(connectTo.host(), connectTo.port(), connectTo.userName(), connectTo.password());
             } else if (SettingsCache::instance().servers().getAutoConnect() &&
                        !SettingsCache::instance().debug().getLocalGameOnStartup()) {
-                qDebug() << "Attempting auto-connect...";
+                qCDebug(WindowMainStartupAutoconnectLog) << "Attempting auto-connect...";
                 DlgConnect dlg(this);
                 client->connectToServer(dlg.getHost(), static_cast<unsigned int>(dlg.getPort()), dlg.getPlayerName(),
                                         dlg.getPassword());

--- a/cockatrice/src/client/ui/window_main.h
+++ b/cockatrice/src/client/ui/window_main.h
@@ -24,11 +24,18 @@
 #include "pb/response.pb.h"
 
 #include <QList>
+#include <QLoggingCategory>
 #include <QMainWindow>
 #include <QMessageBox>
 #include <QProcess>
 #include <QSystemTrayIcon>
 #include <QtNetwork>
+
+inline Q_LOGGING_CATEGORY(WindowMainLog, "window_main.debug");
+inline Q_LOGGING_CATEGORY(WindowMainStartupLog, "window_main.debug.startup");
+inline Q_LOGGING_CATEGORY(WindowMainStartupVersionLog, "window_main.debug.startup.version");
+inline Q_LOGGING_CATEGORY(WindowMainStartupShortcutsLog, "window_main.debug.startup.shortcuts");
+inline Q_LOGGING_CATEGORY(WindowMainStartupAutoconnectLog, "window_main.debug.startup.autoconnect");
 
 class Release;
 class DlgConnect;

--- a/cockatrice/src/client/ui/window_main.h
+++ b/cockatrice/src/client/ui/window_main.h
@@ -31,11 +31,11 @@
 #include <QSystemTrayIcon>
 #include <QtNetwork>
 
-inline Q_LOGGING_CATEGORY(WindowMainLog, "window_main.debug");
-inline Q_LOGGING_CATEGORY(WindowMainStartupLog, "window_main.debug.startup");
-inline Q_LOGGING_CATEGORY(WindowMainStartupVersionLog, "window_main.debug.startup.version");
-inline Q_LOGGING_CATEGORY(WindowMainStartupShortcutsLog, "window_main.debug.startup.shortcuts");
-inline Q_LOGGING_CATEGORY(WindowMainStartupAutoconnectLog, "window_main.debug.startup.autoconnect");
+inline Q_LOGGING_CATEGORY(WindowMainLog, "window_main");
+inline Q_LOGGING_CATEGORY(WindowMainStartupLog, "window_main.startup");
+inline Q_LOGGING_CATEGORY(WindowMainStartupVersionLog, "window_main.startup.version");
+inline Q_LOGGING_CATEGORY(WindowMainStartupShortcutsLog, "window_main.startup.shortcuts");
+inline Q_LOGGING_CATEGORY(WindowMainStartupAutoconnectLog, "window_main.startup.autoconnect");
 
 class Release;
 class DlgConnect;

--- a/cockatrice/src/dialogs/dlg_edit_avatar.cpp
+++ b/cockatrice/src/dialogs/dlg_edit_avatar.cpp
@@ -61,7 +61,7 @@ void DlgEditAvatar::actBrowse()
     imgReader.setDecideFormatFromContent(true);
     imgReader.setFileName(fileName);
     if (!imgReader.read(&image)) {
-        qDebug() << "Avatar image loading failed for file:" << fileName;
+        qCDebug(DlgEditAvatarLog) << "Avatar image loading failed for file:" << fileName;
         imageLabel->setText(tr("Invalid image chosen."));
         return;
     }

--- a/cockatrice/src/dialogs/dlg_edit_avatar.h
+++ b/cockatrice/src/dialogs/dlg_edit_avatar.h
@@ -6,7 +6,7 @@
 #include <QLineEdit>
 #include <QLoggingCategory>
 
-inline Q_LOGGING_CATEGORY(DlgEditAvatarLog, "dlg_edit_avatar.debug")
+inline Q_LOGGING_CATEGORY(DlgEditAvatarLog, "dlg_edit_avatar")
 
     class QLabel;
 class QPushButton;

--- a/cockatrice/src/dialogs/dlg_edit_avatar.h
+++ b/cockatrice/src/dialogs/dlg_edit_avatar.h
@@ -8,7 +8,7 @@
 
 inline Q_LOGGING_CATEGORY(DlgEditAvatarLog, "dlg_edit_avatar.debug")
 
-class QLabel;
+    class QLabel;
 class QPushButton;
 class QCheckBox;
 

--- a/cockatrice/src/dialogs/dlg_edit_avatar.h
+++ b/cockatrice/src/dialogs/dlg_edit_avatar.h
@@ -6,9 +6,9 @@
 #include <QLineEdit>
 #include <QLoggingCategory>
 
-inline Q_LOGGING_CATEGORY(DlgEditAvatarLog, "dlg_edit_avatar")
+inline Q_LOGGING_CATEGORY(DlgEditAvatarLog, "dlg_edit_avatar");
 
-    class QLabel;
+class QLabel;
 class QPushButton;
 class QCheckBox;
 

--- a/cockatrice/src/dialogs/dlg_edit_avatar.h
+++ b/cockatrice/src/dialogs/dlg_edit_avatar.h
@@ -4,6 +4,9 @@
 #include <QComboBox>
 #include <QDialog>
 #include <QLineEdit>
+#include <QLoggingCategory>
+
+inline Q_LOGGING_CATEGORY(DlgEditAvatarLog, "dlg_edit_avatar.debug")
 
 class QLabel;
 class QPushButton;

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -198,7 +198,8 @@ QString GeneralSettingsPage::languageName(const QString &lang)
     QString appNameHint = translationPrefix + "_" + lang;
     bool appTranslationLoaded = qTranslator.load(appNameHint, translationPath);
     if (!appTranslationLoaded) {
-        qCDebug(DlgSettingsLog) << "Unable to load" << translationPrefix << "translation" << appNameHint << "at" << translationPath;
+        qCDebug(DlgSettingsLog) << "Unable to load" << translationPrefix << "translation" << appNameHint << "at"
+                                << translationPath;
     }
 
     return qTranslator.translate("i18n", DEFAULT_LANG_NAME);

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -198,7 +198,7 @@ QString GeneralSettingsPage::languageName(const QString &lang)
     QString appNameHint = translationPrefix + "_" + lang;
     bool appTranslationLoaded = qTranslator.load(appNameHint, translationPath);
     if (!appTranslationLoaded) {
-        qDebug() << "Unable to load" << translationPrefix << "translation" << appNameHint << "at" << translationPath;
+        qCDebug(DlgSettingsLog) << "Unable to load" << translationPrefix << "translation" << appNameHint << "at" << translationPath;
     }
 
     return qTranslator.translate("i18n", DEFAULT_LANG_NAME);
@@ -1535,7 +1535,7 @@ void DlgSettings::closeEvent(QCloseEvent *event)
     bool showLoadError = true;
     QString loadErrorMessage = tr("Unknown Error loading card database");
     LoadStatus loadStatus = CardDatabaseManager::getInstance()->getLoadStatus();
-    qDebug() << "Card Database load status: " << loadStatus;
+    qCDebug(DlgSettingsLog) << "Card Database load status: " << loadStatus;
     switch (loadStatus) {
         case Ok:
             showLoadError = false;

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -12,7 +12,7 @@
 #include <QPushButton>
 #include <QSpinBox>
 
-inline Q_LOGGING_CATEGORY(DlgSettingsLog, "dlg_settings.debug");
+inline Q_LOGGING_CATEGORY(DlgSettingsLog, "dlg_settings");
 
 class ShortcutTreeView;
 class SearchLineEdit;

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -8,8 +8,11 @@
 #include <QDialog>
 #include <QGroupBox>
 #include <QLabel>
+#include <QLoggingCategory>
 #include <QPushButton>
 #include <QSpinBox>
+
+inline Q_LOGGING_CATEGORY(DlgSettingsLog, "dlg_settings.debug");
 
 class ShortcutTreeView;
 class SearchLineEdit;

--- a/cockatrice/src/dialogs/dlg_tip_of_the_day.cpp
+++ b/cockatrice/src/dialogs/dlg_tip_of_the_day.cpp
@@ -146,7 +146,7 @@ void DlgTipOfTheDay::updateTip(int tipId)
     tipTextContent->setText(contentText);
 
     if (!image->load(imagePath)) {
-        qDebug() << "Image failed to load from" << imagePath;
+        qCDebug(DlgTipOfTheDayLog) << "Image failed to load from" << imagePath;
         imageLabel->clear();
     } else {
         int h = std::min(std::max(imageLabel->height(), MIN_TIP_IMAGE_HEIGHT), MAX_TIP_IMAGE_HEIGHT);

--- a/cockatrice/src/dialogs/dlg_tip_of_the_day.h
+++ b/cockatrice/src/dialogs/dlg_tip_of_the_day.h
@@ -5,9 +5,12 @@
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QHBoxLayout>
+#include <QLoggingCategory>
 #include <QLineEdit>
 #include <QPushButton>
 #include <QVBoxLayout>
+
+inline Q_LOGGING_CATEGORY(DlgTipOfTheDayLog, "dlg_tip_of_the_day.debug");
 
 class QLabel;
 class QPushButton;

--- a/cockatrice/src/dialogs/dlg_tip_of_the_day.h
+++ b/cockatrice/src/dialogs/dlg_tip_of_the_day.h
@@ -5,8 +5,8 @@
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QHBoxLayout>
-#include <QLoggingCategory>
 #include <QLineEdit>
+#include <QLoggingCategory>
 #include <QPushButton>
 #include <QVBoxLayout>
 

--- a/cockatrice/src/dialogs/dlg_tip_of_the_day.h
+++ b/cockatrice/src/dialogs/dlg_tip_of_the_day.h
@@ -10,7 +10,7 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 
-inline Q_LOGGING_CATEGORY(DlgTipOfTheDayLog, "dlg_tip_of_the_day.debug");
+inline Q_LOGGING_CATEGORY(DlgTipOfTheDayLog, "dlg_tip_of_the_day");
 
 class QLabel;
 class QPushButton;

--- a/cockatrice/src/dialogs/dlg_update.cpp
+++ b/cockatrice/src/dialogs/dlg_update.cpp
@@ -221,7 +221,7 @@ void DlgUpdate::downloadSuccessful(const QUrl &filepath)
     // Try to open the installer. If it opens, quit Cockatrice
     if (QDesktopServices::openUrl(filepath)) {
         QMetaObject::invokeMethod(static_cast<MainWindow *>(parent()), "close", Qt::QueuedConnection);
-        qDebug() << "Opened downloaded update file successfully - closing Cockatrice";
+        qCDebug(DlgUpdateLog) << "Opened downloaded update file successfully - closing Cockatrice";
         close();
     } else {
         setLabel(tr("Error"));

--- a/cockatrice/src/dialogs/dlg_update.h
+++ b/cockatrice/src/dialogs/dlg_update.h
@@ -8,7 +8,7 @@
 #include <QProgressDialog>
 #include <QtNetwork>
 
-inline Q_LOGGING_CATEGORY(DlgUpdateLog, "dlg_update.debug");
+inline Q_LOGGING_CATEGORY(DlgUpdateLog, "dlg_update");
 
 class Release;
 

--- a/cockatrice/src/dialogs/dlg_update.h
+++ b/cockatrice/src/dialogs/dlg_update.h
@@ -4,8 +4,12 @@
 #include "../client/update_downloader.h"
 
 #include <QDialogButtonBox>
+#include <QLoggingCategory>
 #include <QProgressDialog>
 #include <QtNetwork>
+
+inline Q_LOGGING_CATEGORY(DlgUpdateLog, "dlg_update.debug");
+
 class Release;
 
 class DlgUpdate : public QDialog

--- a/cockatrice/src/game/board/arrow_item.cpp
+++ b/cockatrice/src/game/board/arrow_item.cpp
@@ -22,7 +22,6 @@ ArrowItem::ArrowItem(Player *_player, int _id, ArrowTarget *_startItem, ArrowTar
     : QGraphicsItem(), player(_player), id(_id), startItem(_startItem), targetItem(_targetItem), targetLocked(false),
       color(_color), fullColor(true)
 {
-    qDebug() << "ArrowItem constructor: startItem=" << static_cast<QGraphicsItem *>(startItem);
     setZValue(2000000005);
 
     if (startItem)
@@ -36,7 +35,6 @@ ArrowItem::ArrowItem(Player *_player, int _id, ArrowTarget *_startItem, ArrowTar
 
 ArrowItem::~ArrowItem()
 {
-    qDebug() << "ArrowItem destructor";
 }
 
 void ArrowItem::delArrow()

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -583,7 +583,8 @@ LoadStatus CardDatabase::loadCardDatabase(const QString &path)
 
     int msecs = startTime.msecsTo(QTime::currentTime());
     qCDebug(CardDatabaseLoadingLog) << "[CardDatabase] loadCardDatabase(): Path =" << path
-                                    << "Status =" << tempLoadStatus << "Cards =" << cards.size() << "Sets =" << sets.size() << QString("%1ms").arg(msecs);
+                                    << "Status =" << tempLoadStatus << "Cards =" << cards.size()
+                                    << "Sets =" << sets.size() << QString("%1ms").arg(msecs);
 
     return tempLoadStatus;
 }

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -102,7 +102,7 @@ public:
     inline bool operator()(const CardSetPtr &a, const CardSetPtr &b) const
     {
         if (a.isNull() || b.isNull()) {
-            qDebug() << "SetList::KeyCompareFunctor a or b is null";
+            qCDebug(SetListLog) << "SetList::KeyCompareFunctor a or b is null";
             return false;
         }
 
@@ -170,7 +170,7 @@ void SetList::enableAll()
         CardSetPtr set = at(i);
 
         if (set == nullptr) {
-            qDebug() << "enabledAll has null";
+            qCDebug(SetListLog) << "enabledAll has null";
             continue;
         }
 
@@ -201,7 +201,7 @@ void SetList::guessSortKeys()
     for (int i = 0; i < size(); ++i) {
         CardSetPtr set = at(i);
         if (set.isNull()) {
-            qDebug() << "guessSortKeys set is null";
+            qCDebug(SetListLog) << "guessSortKeys set is null";
             continue;
         }
         set->setSortKey(i);
@@ -415,7 +415,7 @@ void CardDatabase::clear()
 void CardDatabase::addCard(CardInfoPtr card)
 {
     if (card == nullptr) {
-        qDebug() << "addCard(nullptr)";
+        qCDebug(CardDatabaseLog) << "CardDatabase::addCard(nullptr)";
         return;
     }
 
@@ -440,7 +440,7 @@ void CardDatabase::addCard(CardInfoPtr card)
 void CardDatabase::removeCard(CardInfoPtr card)
 {
     if (card.isNull()) {
-        qDebug() << "removeCard(nullptr)";
+        qCDebug(CardDatabaseLog) << "CardDatabase::removeCard(nullptr)";
         return;
     }
 
@@ -582,8 +582,8 @@ LoadStatus CardDatabase::loadCardDatabase(const QString &path)
     }
 
     int msecs = startTime.msecsTo(QTime::currentTime());
-    qDebug() << "[CardDatabase] loadCardDatabase(): Path =" << path << "Status =" << tempLoadStatus
-             << "Cards =" << cards.size() << "Sets =" << sets.size() << QString("%1ms").arg(msecs);
+    qCDebug(CardDatabaseLoadingLog) << "[CardDatabase] loadCardDatabase(): Path =" << path
+                                    << "Status =" << tempLoadStatus << "Cards =" << cards.size() << "Sets =" << sets.size() << QString("%1ms").arg(msecs);
 
     return tempLoadStatus;
 }
@@ -592,7 +592,7 @@ LoadStatus CardDatabase::loadCardDatabases()
 {
     reloadDatabaseMutex->lock();
 
-    qDebug() << "CardDatabase::loadCardDatabases start";
+    qCDebug(CardDatabaseLoadingLog) << "CardDatabase::loadCardDatabases start";
 
     clear(); // remove old db
 
@@ -613,7 +613,7 @@ LoadStatus CardDatabase::loadCardDatabases()
 
     for (auto i = 0; i < databasePaths.size(); ++i) {
         const auto &databasePath = databasePaths.at(i);
-        qDebug() << "Loading Custom Set" << i << "(" << databasePath << ")";
+        qCDebug(CardDatabaseLoadingLog) << "Loading Custom Set" << i << "(" << databasePath << ")";
         loadCardDatabase(databasePath);
     }
 
@@ -626,10 +626,10 @@ LoadStatus CardDatabase::loadCardDatabases()
 
     if (loadStatus == Ok) {
         checkUnknownSets(); // update deck editors, etc
-        qDebug() << "CardDatabase::loadCardDatabases success";
+        qCDebug(CardDatabaseLoadingSuccessOrFailureLog) << "CardDatabase::loadCardDatabases success";
         emit cardDatabaseLoadingFinished();
     } else {
-        qDebug() << "CardDatabase::loadCardDatabases failed";
+        qCDebug(CardDatabaseLoadingSuccessOrFailureLog) << "CardDatabase::loadCardDatabases failed";
         emit cardDatabaseLoadingFailed(); // bring up the settings dialog
     }
 

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -582,8 +582,7 @@ LoadStatus CardDatabase::loadCardDatabase(const QString &path)
     }
 
     int msecs = startTime.msecsTo(QTime::currentTime());
-    qCDebug(CardDatabaseLoadingLog) << "Path =" << path
-                                    << "Status =" << tempLoadStatus << "Cards =" << cards.size()
+    qCDebug(CardDatabaseLoadingLog) << "Path =" << path << "Status =" << tempLoadStatus << "Cards =" << cards.size()
                                     << "Sets =" << sets.size() << QString("%1ms").arg(msecs);
 
     return tempLoadStatus;

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -102,7 +102,7 @@ public:
     inline bool operator()(const CardSetPtr &a, const CardSetPtr &b) const
     {
         if (a.isNull() || b.isNull()) {
-            qCDebug(SetListLog) << "SetList::KeyCompareFunctor a or b is null";
+            qCDebug(CardDatabaseLog) << "SetList::KeyCompareFunctor a or b is null";
             return false;
         }
 
@@ -170,7 +170,7 @@ void SetList::enableAll()
         CardSetPtr set = at(i);
 
         if (set == nullptr) {
-            qCDebug(SetListLog) << "enabledAll has null";
+            qCDebug(CardDatabaseLog) << "enabledAll has null";
             continue;
         }
 
@@ -201,7 +201,7 @@ void SetList::guessSortKeys()
     for (int i = 0; i < size(); ++i) {
         CardSetPtr set = at(i);
         if (set.isNull()) {
-            qCDebug(SetListLog) << "guessSortKeys set is null";
+            qCDebug(CardDatabaseLog) << "guessSortKeys set is null";
             continue;
         }
         set->setSortKey(i);

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -582,7 +582,7 @@ LoadStatus CardDatabase::loadCardDatabase(const QString &path)
     }
 
     int msecs = startTime.msecsTo(QTime::currentTime());
-    qCDebug(CardDatabaseLoadingLog) << "[CardDatabase] loadCardDatabase(): Path =" << path
+    qCDebug(CardDatabaseLoadingLog) << "Path =" << path
                                     << "Status =" << tempLoadStatus << "Cards =" << cards.size()
                                     << "Sets =" << sets.size() << QString("%1ms").arg(msecs);
 
@@ -593,7 +593,7 @@ LoadStatus CardDatabase::loadCardDatabases()
 {
     reloadDatabaseMutex->lock();
 
-    qCDebug(CardDatabaseLoadingLog) << "CardDatabase::loadCardDatabases start";
+    qCDebug(CardDatabaseLoadingLog) << "Started";
 
     clear(); // remove old db
 
@@ -627,10 +627,10 @@ LoadStatus CardDatabase::loadCardDatabases()
 
     if (loadStatus == Ok) {
         checkUnknownSets(); // update deck editors, etc
-        qCDebug(CardDatabaseLoadingSuccessOrFailureLog) << "CardDatabase::loadCardDatabases success";
+        qCDebug(CardDatabaseLoadingSuccessOrFailureLog) << "Success";
         emit cardDatabaseLoadingFinished();
     } else {
-        qCDebug(CardDatabaseLoadingSuccessOrFailureLog) << "CardDatabase::loadCardDatabases failed";
+        qCDebug(CardDatabaseLoadingSuccessOrFailureLog) << "Failed";
         emit cardDatabaseLoadingFailed(); // bring up the settings dialog
     }
 

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -14,10 +14,10 @@
 #include <QVector>
 #include <utility>
 
-inline Q_LOGGING_CATEGORY(SetListLog, "set_list.debug");
-inline Q_LOGGING_CATEGORY(CardDatabaseLog, "card_database.debug");
-inline Q_LOGGING_CATEGORY(CardDatabaseLoadingLog, "card_database.debug.loading");
-inline Q_LOGGING_CATEGORY(CardDatabaseLoadingSuccessOrFailureLog, "card_database.debug.loading.success_or_failure");
+inline Q_LOGGING_CATEGORY(SetListLog, "set_list");
+inline Q_LOGGING_CATEGORY(CardDatabaseLog, "card_database");
+inline Q_LOGGING_CATEGORY(CardDatabaseLoadingLog, "card_database.loading");
+inline Q_LOGGING_CATEGORY(CardDatabaseLoadingSuccessOrFailureLog, "card_database.loading.success_or_failure");
 
 class CardDatabase;
 class CardInfo;

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -14,7 +14,6 @@
 #include <QVector>
 #include <utility>
 
-inline Q_LOGGING_CATEGORY(SetListLog, "set_list");
 inline Q_LOGGING_CATEGORY(CardDatabaseLog, "card_database");
 inline Q_LOGGING_CATEGORY(CardDatabaseLoadingLog, "card_database.loading");
 inline Q_LOGGING_CATEGORY(CardDatabaseLoadingSuccessOrFailureLog, "card_database.loading.success_or_failure");

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -5,6 +5,7 @@
 #include <QDate>
 #include <QHash>
 #include <QList>
+#include <QLoggingCategory>
 #include <QMap>
 #include <QMetaType>
 #include <QSharedPointer>
@@ -12,6 +13,11 @@
 #include <QVariant>
 #include <QVector>
 #include <utility>
+
+inline Q_LOGGING_CATEGORY(SetListLog, "set_list.debug");
+inline Q_LOGGING_CATEGORY(CardDatabaseLog, "card_database.debug");
+inline Q_LOGGING_CATEGORY(CardDatabaseLoadingLog, "card_database.debug.loading");
+inline Q_LOGGING_CATEGORY(CardDatabaseLoadingSuccessOrFailureLog, "card_database.debug.loading.success_or_failure");
 
 class CardDatabase;
 class CardInfo;

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
@@ -58,8 +58,7 @@ void CockatriceXml3Parser::parseFile(QIODevice &device)
                 } else if (name == "cards") {
                     loadCardsFromXml(xml);
                 } else if (!name.isEmpty()) {
-                    qCDebug(CockatriceXml3Log)
-                        << "Unknown item" << name << ", trying to continue anyway";
+                    qCDebug(CockatriceXml3Log) << "Unknown item" << name << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -94,8 +93,7 @@ void CockatriceXml3Parser::loadSetsFromXml(QXmlStreamReader &xml)
                     releaseDate =
                         QDate::fromString(xml.readElementText(QXmlStreamReader::IncludeChildElements), Qt::ISODate);
                 } else if (!name.isEmpty()) {
-                    qCDebug(CockatriceXml3Log)
-                        << "Unknown set property" << name << ", trying to continue anyway";
+                    qCDebug(CockatriceXml3Log) << "Unknown set property" << name << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -265,8 +263,7 @@ void CockatriceXml3Parser::loadCardsFromXml(QXmlStreamReader &xml)
                         relatedCards << relation;
                     }
                 } else if (!xmlName.isEmpty()) {
-                    qCDebug(CockatriceXml3Log)
-                        << "Unknown card property" << xmlName << ", trying to continue anyway";
+                    qCDebug(CockatriceXml3Log) << "Unknown card property" << xmlName << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
@@ -13,10 +13,10 @@
 
 bool CockatriceXml3Parser::getCanParseFile(const QString &fileName, QIODevice &device)
 {
-    qCDebug(CockatriceXml3Log) << "[CockatriceXml3Parser] Trying to parse: " << fileName;
+    qCDebug(CockatriceXml3Log) << "Trying to parse: " << fileName;
 
     if (!fileName.endsWith(".xml", Qt::CaseInsensitive)) {
-        qCDebug(CockatriceXml3Log) << "[CockatriceXml3Parser] Parsing failed: wrong extension";
+        qCDebug(CockatriceXml3Log) << "Parsing failed: wrong extension";
         return false;
     }
 
@@ -28,12 +28,12 @@ bool CockatriceXml3Parser::getCanParseFile(const QString &fileName, QIODevice &d
                 if (version == COCKATRICE_XML3_TAGVER) {
                     return true;
                 } else {
-                    qCDebug(CockatriceXml3Log) << "[CockatriceXml3Parser] Parsing failed: wrong version" << version;
+                    qCDebug(CockatriceXml3Log) << "Parsing failed: wrong version" << version;
                     return false;
                 }
 
             } else {
-                qCDebug(CockatriceXml3Log) << "[CockatriceXml3Parser] Parsing failed: wrong element tag" << xml.name();
+                qCDebug(CockatriceXml3Log) << "Parsing failed: wrong element tag" << xml.name();
                 return false;
             }
         }
@@ -59,7 +59,7 @@ void CockatriceXml3Parser::parseFile(QIODevice &device)
                     loadCardsFromXml(xml);
                 } else if (!name.isEmpty()) {
                     qCDebug(CockatriceXml3Log)
-                        << "[CockatriceXml3Parser] Unknown item" << name << ", trying to continue anyway";
+                        << "Unknown item" << name << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -95,7 +95,7 @@ void CockatriceXml3Parser::loadSetsFromXml(QXmlStreamReader &xml)
                         QDate::fromString(xml.readElementText(QXmlStreamReader::IncludeChildElements), Qt::ISODate);
                 } else if (!name.isEmpty()) {
                     qCDebug(CockatriceXml3Log)
-                        << "[CockatriceXml3Parser] Unknown set property" << name << ", trying to continue anyway";
+                        << "Unknown set property" << name << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -266,7 +266,7 @@ void CockatriceXml3Parser::loadCardsFromXml(QXmlStreamReader &xml)
                     }
                 } else if (!xmlName.isEmpty()) {
                     qCDebug(CockatriceXml3Log)
-                        << "[CockatriceXml3Parser] Unknown card property" << xmlName << ", trying to continue anyway";
+                        << "Unknown card property" << xmlName << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
@@ -13,10 +13,10 @@
 
 bool CockatriceXml3Parser::getCanParseFile(const QString &fileName, QIODevice &device)
 {
-    qDebug() << "[CockatriceXml3Parser] Trying to parse: " << fileName;
+    qCDebug(CockatriceXml3Log) << "[CockatriceXml3Parser] Trying to parse: " << fileName;
 
     if (!fileName.endsWith(".xml", Qt::CaseInsensitive)) {
-        qDebug() << "[CockatriceXml3Parser] Parsing failed: wrong extension";
+        qCDebug(CockatriceXml3Log) << "[CockatriceXml3Parser] Parsing failed: wrong extension";
         return false;
     }
 
@@ -28,12 +28,12 @@ bool CockatriceXml3Parser::getCanParseFile(const QString &fileName, QIODevice &d
                 if (version == COCKATRICE_XML3_TAGVER) {
                     return true;
                 } else {
-                    qDebug() << "[CockatriceXml3Parser] Parsing failed: wrong version" << version;
+                    qCDebug(CockatriceXml3Log) << "[CockatriceXml3Parser] Parsing failed: wrong version" << version;
                     return false;
                 }
 
             } else {
-                qDebug() << "[CockatriceXml3Parser] Parsing failed: wrong element tag" << xml.name();
+                qCDebug(CockatriceXml3Log) << "[CockatriceXml3Parser] Parsing failed: wrong element tag" << xml.name();
                 return false;
             }
         }
@@ -58,7 +58,8 @@ void CockatriceXml3Parser::parseFile(QIODevice &device)
                 } else if (name == "cards") {
                     loadCardsFromXml(xml);
                 } else if (!name.isEmpty()) {
-                    qDebug() << "[CockatriceXml3Parser] Unknown item" << name << ", trying to continue anyway";
+                    qCDebug(CockatriceXml3Log)
+                        << "[CockatriceXml3Parser] Unknown item" << name << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -93,7 +94,8 @@ void CockatriceXml3Parser::loadSetsFromXml(QXmlStreamReader &xml)
                     releaseDate =
                         QDate::fromString(xml.readElementText(QXmlStreamReader::IncludeChildElements), Qt::ISODate);
                 } else if (!name.isEmpty()) {
-                    qDebug() << "[CockatriceXml3Parser] Unknown set property" << name << ", trying to continue anyway";
+                    qCDebug(CockatriceXml3Log)
+                        << "[CockatriceXml3Parser] Unknown set property" << name << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -263,8 +265,8 @@ void CockatriceXml3Parser::loadCardsFromXml(QXmlStreamReader &xml)
                         relatedCards << relation;
                     }
                 } else if (!xmlName.isEmpty()) {
-                    qDebug() << "[CockatriceXml3Parser] Unknown card property" << xmlName
-                             << ", trying to continue anyway";
+                    qCDebug(CockatriceXml3Log)
+                        << "[CockatriceXml3Parser] Unknown card property" << xmlName << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -281,7 +283,7 @@ void CockatriceXml3Parser::loadCardsFromXml(QXmlStreamReader &xml)
 static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardSetPtr &set)
 {
     if (set.isNull()) {
-        qDebug() << "&operator<< set is nullptr";
+        qCDebug(CockatriceXml3Log) << "&operator<< set is nullptr";
         return xml;
     }
 
@@ -298,7 +300,7 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardSetPtr &set
 static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfoPtr &info)
 {
     if (info.isNull()) {
-        qDebug() << "operator<< info is nullptr";
+        qCDebug(CockatriceXml3Log) << "operator<< info is nullptr";
         return xml;
     }
 

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.h
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.h
@@ -3,9 +3,12 @@
 
 #include "card_database_parser.h"
 
+#include <QLoggingCategory>
 #include <QXmlStreamReader>
 
-class CockatriceXml3Parser : public ICardDatabaseParser
+inline Q_LOGGING_CATEGORY(CockatriceXml3Log, "cockatrice_xml.debug.xml_3_parser")
+
+    class CockatriceXml3Parser : public ICardDatabaseParser
 {
     Q_OBJECT
     Q_INTERFACES(ICardDatabaseParser)

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.h
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.h
@@ -6,9 +6,9 @@
 #include <QLoggingCategory>
 #include <QXmlStreamReader>
 
-inline Q_LOGGING_CATEGORY(CockatriceXml3Log, "cockatrice_xml.xml_3_parser")
+inline Q_LOGGING_CATEGORY(CockatriceXml3Log, "cockatrice_xml.xml_3_parser");
 
-    class CockatriceXml3Parser : public ICardDatabaseParser
+class CockatriceXml3Parser : public ICardDatabaseParser
 {
     Q_OBJECT
     Q_INTERFACES(ICardDatabaseParser)

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.h
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.h
@@ -6,7 +6,7 @@
 #include <QLoggingCategory>
 #include <QXmlStreamReader>
 
-inline Q_LOGGING_CATEGORY(CockatriceXml3Log, "cockatrice_xml.debug.xml_3_parser")
+inline Q_LOGGING_CATEGORY(CockatriceXml3Log, "cockatrice_xml.xml_3_parser")
 
     class CockatriceXml3Parser : public ICardDatabaseParser
 {

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
@@ -58,8 +58,7 @@ void CockatriceXml4Parser::parseFile(QIODevice &device)
                 } else if (xmlName == "cards") {
                     loadCardsFromXml(xml);
                 } else if (!xmlName.isEmpty()) {
-                    qCDebug(CockatriceXml4Log)
-                        << "Unknown item" << xmlName << ", trying to continue anyway";
+                    qCDebug(CockatriceXml4Log) << "Unknown item" << xmlName << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -97,8 +96,7 @@ void CockatriceXml4Parser::loadSetsFromXml(QXmlStreamReader &xml)
                 } else if (xmlName == "priority") {
                     priority = xml.readElementText(QXmlStreamReader::IncludeChildElements).toShort();
                 } else if (!xmlName.isEmpty()) {
-                    qCDebug(CockatriceXml4Log)
-                        << "Unknown set property" << xmlName << ", trying to continue anyway";
+                    qCDebug(CockatriceXml4Log) << "Unknown set property" << xmlName << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -231,8 +229,7 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
                         relatedCards << relation;
                     }
                 } else if (!xmlName.isEmpty()) {
-                    qCDebug(CockatriceXml4Log)
-                        << "Unknown card property" << xmlName << ", trying to continue anyway";
+                    qCDebug(CockatriceXml4Log) << "Unknown card property" << xmlName << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
@@ -13,10 +13,10 @@
 
 bool CockatriceXml4Parser::getCanParseFile(const QString &fileName, QIODevice &device)
 {
-    qCDebug(CockatriceXml4Log) << "[CockatriceXml4Parser] Trying to parse: " << fileName;
+    qCDebug(CockatriceXml4Log) << "Trying to parse: " << fileName;
 
     if (!fileName.endsWith(".xml", Qt::CaseInsensitive)) {
-        qCDebug(CockatriceXml4Log) << "[CockatriceXml4Parser] Parsing failed: wrong extension";
+        qCDebug(CockatriceXml4Log) << "Parsing failed: wrong extension";
         return false;
     }
 
@@ -28,12 +28,12 @@ bool CockatriceXml4Parser::getCanParseFile(const QString &fileName, QIODevice &d
                 if (version == COCKATRICE_XML4_TAGVER) {
                     return true;
                 } else {
-                    qCDebug(CockatriceXml4Log) << "[CockatriceXml4Parser] Parsing failed: wrong version" << version;
+                    qCDebug(CockatriceXml4Log) << "Parsing failed: wrong version" << version;
                     return false;
                 }
 
             } else {
-                qCDebug(CockatriceXml4Log) << "[CockatriceXml4Parser] Parsing failed: wrong element tag" << xml.name();
+                qCDebug(CockatriceXml4Log) << "Parsing failed: wrong element tag" << xml.name();
                 return false;
             }
         }
@@ -59,7 +59,7 @@ void CockatriceXml4Parser::parseFile(QIODevice &device)
                     loadCardsFromXml(xml);
                 } else if (!xmlName.isEmpty()) {
                     qCDebug(CockatriceXml4Log)
-                        << "[CockatriceXml4Parser] Unknown item" << xmlName << ", trying to continue anyway";
+                        << "Unknown item" << xmlName << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -98,7 +98,7 @@ void CockatriceXml4Parser::loadSetsFromXml(QXmlStreamReader &xml)
                     priority = xml.readElementText(QXmlStreamReader::IncludeChildElements).toShort();
                 } else if (!xmlName.isEmpty()) {
                     qCDebug(CockatriceXml4Log)
-                        << "[CockatriceXml4Parser] Unknown set property" << xmlName << ", trying to continue anyway";
+                        << "Unknown set property" << xmlName << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -232,7 +232,7 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
                     }
                 } else if (!xmlName.isEmpty()) {
                     qCDebug(CockatriceXml4Log)
-                        << "[CockatriceXml4Parser] Unknown card property" << xmlName << ", trying to continue anyway";
+                        << "Unknown card property" << xmlName << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
@@ -13,10 +13,10 @@
 
 bool CockatriceXml4Parser::getCanParseFile(const QString &fileName, QIODevice &device)
 {
-    qDebug() << "[CockatriceXml4Parser] Trying to parse: " << fileName;
+    qCDebug(CockatriceXml4Log) << "[CockatriceXml4Parser] Trying to parse: " << fileName;
 
     if (!fileName.endsWith(".xml", Qt::CaseInsensitive)) {
-        qDebug() << "[CockatriceXml4Parser] Parsing failed: wrong extension";
+        qCDebug(CockatriceXml4Log) << "[CockatriceXml4Parser] Parsing failed: wrong extension";
         return false;
     }
 
@@ -28,12 +28,12 @@ bool CockatriceXml4Parser::getCanParseFile(const QString &fileName, QIODevice &d
                 if (version == COCKATRICE_XML4_TAGVER) {
                     return true;
                 } else {
-                    qDebug() << "[CockatriceXml4Parser] Parsing failed: wrong version" << version;
+                    qCDebug(CockatriceXml4Log) << "[CockatriceXml4Parser] Parsing failed: wrong version" << version;
                     return false;
                 }
 
             } else {
-                qDebug() << "[CockatriceXml4Parser] Parsing failed: wrong element tag" << xml.name();
+                qCDebug(CockatriceXml4Log) << "[CockatriceXml4Parser] Parsing failed: wrong element tag" << xml.name();
                 return false;
             }
         }
@@ -58,7 +58,8 @@ void CockatriceXml4Parser::parseFile(QIODevice &device)
                 } else if (xmlName == "cards") {
                     loadCardsFromXml(xml);
                 } else if (!xmlName.isEmpty()) {
-                    qDebug() << "[CockatriceXml4Parser] Unknown item" << xmlName << ", trying to continue anyway";
+                    qCDebug(CockatriceXml4Log)
+                        << "[CockatriceXml4Parser] Unknown item" << xmlName << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -96,8 +97,8 @@ void CockatriceXml4Parser::loadSetsFromXml(QXmlStreamReader &xml)
                 } else if (xmlName == "priority") {
                     priority = xml.readElementText(QXmlStreamReader::IncludeChildElements).toShort();
                 } else if (!xmlName.isEmpty()) {
-                    qDebug() << "[CockatriceXml4Parser] Unknown set property" << xmlName
-                             << ", trying to continue anyway";
+                    qCDebug(CockatriceXml4Log)
+                        << "[CockatriceXml4Parser] Unknown set property" << xmlName << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -230,8 +231,8 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
                         relatedCards << relation;
                     }
                 } else if (!xmlName.isEmpty()) {
-                    qDebug() << "[CockatriceXml4Parser] Unknown card property" << xmlName
-                             << ", trying to continue anyway";
+                    qCDebug(CockatriceXml4Log)
+                        << "[CockatriceXml4Parser] Unknown card property" << xmlName << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -247,7 +248,7 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
 static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardSetPtr &set)
 {
     if (set.isNull()) {
-        qDebug() << "&operator<< set is nullptr";
+        qCDebug(CockatriceXml4Log) << "&operator<< set is nullptr";
         return xml;
     }
 
@@ -265,7 +266,7 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardSetPtr &set
 static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfoPtr &info)
 {
     if (info.isNull()) {
-        qDebug() << "operator<< info is nullptr";
+        qCDebug(CockatriceXml4Log) << "operator<< info is nullptr";
         return xml;
     }
 

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.h
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.h
@@ -6,7 +6,7 @@
 #include <QLoggingCategory>
 #include <QXmlStreamReader>
 
-inline Q_LOGGING_CATEGORY(CockatriceXml4Log, "cockatrice_xml.debug.xml_4_parser")
+inline Q_LOGGING_CATEGORY(CockatriceXml4Log, "cockatrice_xml.xml_4_parser")
 
     class CockatriceXml4Parser : public ICardDatabaseParser
 {

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.h
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.h
@@ -3,9 +3,12 @@
 
 #include "card_database_parser.h"
 
+#include <QLoggingCategory>
 #include <QXmlStreamReader>
 
-class CockatriceXml4Parser : public ICardDatabaseParser
+inline Q_LOGGING_CATEGORY(CockatriceXml4Log, "cockatrice_xml.debug.xml_4_parser")
+
+    class CockatriceXml4Parser : public ICardDatabaseParser
 {
     Q_OBJECT
     Q_INTERFACES(ICardDatabaseParser)

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.h
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.h
@@ -6,9 +6,9 @@
 #include <QLoggingCategory>
 #include <QXmlStreamReader>
 
-inline Q_LOGGING_CATEGORY(CockatriceXml4Log, "cockatrice_xml.xml_4_parser")
+inline Q_LOGGING_CATEGORY(CockatriceXml4Log, "cockatrice_xml.xml_4_parser");
 
-    class CockatriceXml4Parser : public ICardDatabaseParser
+class CockatriceXml4Parser : public ICardDatabaseParser
 {
     Q_OBJECT
     Q_INTERFACES(ICardDatabaseParser)

--- a/cockatrice/src/game/cards/card_list.cpp
+++ b/cockatrice/src/game/cards/card_list.cpp
@@ -151,6 +151,6 @@ std::function<QString(CardItem *)> CardList::getExtractorFor(SortOption option)
     }
 
     // this line should never be reached
-    qDebug() << "cardlist.cpp: Could not find extractor for SortOption" << option;
+    qCDebug(CardListLog) << "cardlist.cpp: Could not find extractor for SortOption" << option;
     return [](CardItem *) { return ""; };
 }

--- a/cockatrice/src/game/cards/card_list.h
+++ b/cockatrice/src/game/cards/card_list.h
@@ -2,6 +2,9 @@
 #define CARDLIST_H
 
 #include <QList>
+#include <QLoggingCategory>
+
+inline Q_LOGGING_CATEGORY(CardListLog, "card_list.debug");
 
 class CardItem;
 

--- a/cockatrice/src/game/cards/card_list.h
+++ b/cockatrice/src/game/cards/card_list.h
@@ -4,7 +4,7 @@
 #include <QList>
 #include <QLoggingCategory>
 
-inline Q_LOGGING_CATEGORY(CardListLog, "card_list.debug");
+inline Q_LOGGING_CATEGORY(CardListLog, "card_list");
 
 class CardItem;
 

--- a/cockatrice/src/game/filters/filter_string.cpp
+++ b/cockatrice/src/game/filters/filter_string.cpp
@@ -382,7 +382,7 @@ FilterString::FilterString(const QString &expr)
     });
 
     if (!search.parse(ba.data(), result)) {
-        qDebug().nospace() << "FilterString error for " << expr << "; " << qPrintable(_error);
+        qCDebug(FilterStringLog).nospace() << "FilterString error for " << expr << "; " << qPrintable(_error);
         result = [](const CardData &) -> bool { return false; };
     }
 }

--- a/cockatrice/src/game/filters/filter_string.h
+++ b/cockatrice/src/game/filters/filter_string.h
@@ -4,10 +4,13 @@
 #include "../cards/card_database.h"
 #include "filter_tree.h"
 
+#include <QLoggingCategory>
 #include <QMap>
 #include <QString>
 #include <functional>
 #include <utility>
+
+inline Q_LOGGING_CATEGORY(FilterStringLog, "filter_string.debug");
 
 typedef CardInfoPtr CardData;
 typedef std::function<bool(const CardData &)> Filter;

--- a/cockatrice/src/game/filters/filter_string.h
+++ b/cockatrice/src/game/filters/filter_string.h
@@ -10,7 +10,7 @@
 #include <functional>
 #include <utility>
 
-inline Q_LOGGING_CATEGORY(FilterStringLog, "filter_string.debug");
+inline Q_LOGGING_CATEGORY(FilterStringLog, "filter_string");
 
 typedef CardInfoPtr CardData;
 typedef std::function<bool(const CardData &)> Filter;

--- a/cockatrice/src/game/game_scene.cpp
+++ b/cockatrice/src/game/game_scene.cpp
@@ -39,7 +39,7 @@ void GameScene::retranslateUi()
 
 void GameScene::addPlayer(Player *player)
 {
-    qDebug() << "GameScene::addPlayer name=" << player->getName();
+    qCDebug(GameScenePlayerAdditionRemovalLog) << "GameScene::addPlayer name=" << player->getName();
     players << player;
     addItem(player);
     connect(player, &Player::sizeChanged, this, &GameScene::rearrange);
@@ -48,7 +48,7 @@ void GameScene::addPlayer(Player *player)
 
 void GameScene::removePlayer(Player *player)
 {
-    qDebug() << "GameScene::removePlayer name=" << player->getName();
+    qCDebug(GameScenePlayerAdditionRemovalLog) << "GameScene::removePlayer name=" << player->getName();
     for (ZoneViewWidget *zone : zoneViews) {
         if (zone->getPlayer() == player) {
             zone->close();

--- a/cockatrice/src/game/game_scene.h
+++ b/cockatrice/src/game/game_scene.h
@@ -3,8 +3,12 @@
 
 #include <QGraphicsScene>
 #include <QList>
+#include <QLoggingCategory>
 #include <QPointer>
 #include <QSet>
+
+inline Q_LOGGING_CATEGORY(GameSceneLog, "game_scene.debug");
+inline Q_LOGGING_CATEGORY(GameScenePlayerAdditionRemovalLog, "game_scene.debug.player_addition_removal");
 
 class Player;
 class ZoneViewWidget;

--- a/cockatrice/src/game/game_scene.h
+++ b/cockatrice/src/game/game_scene.h
@@ -7,8 +7,8 @@
 #include <QPointer>
 #include <QSet>
 
-inline Q_LOGGING_CATEGORY(GameSceneLog, "game_scene.debug");
-inline Q_LOGGING_CATEGORY(GameScenePlayerAdditionRemovalLog, "game_scene.debug.player_addition_removal");
+inline Q_LOGGING_CATEGORY(GameSceneLog, "game_scene");
+inline Q_LOGGING_CATEGORY(GameScenePlayerAdditionRemovalLog, "game_scene.player_addition_removal");
 
 class Player;
 class ZoneViewWidget;

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -562,7 +562,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
 
 Player::~Player()
 {
-    qDebug() << "Player destructor:" << getName();
+    qCDebug(PlayerLog) << "Player destructor:" << getName();
 
     static_cast<GameScene *>(scene())->removePlayer(this);
 

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -9,9 +9,12 @@
 #include "pb/game_event.pb.h"
 
 #include <QInputDialog>
+#include <QLoggingCategory>
 #include <QMap>
 #include <QPoint>
 #include <QTimer>
+
+inline Q_LOGGING_CATEGORY(PlayerLog, "player.debug");
 
 namespace google
 {

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -14,7 +14,7 @@
 #include <QPoint>
 #include <QTimer>
 
-inline Q_LOGGING_CATEGORY(PlayerLog, "player.debug");
+inline Q_LOGGING_CATEGORY(PlayerLog, "player");
 
 namespace google
 {

--- a/cockatrice/src/game/zones/card_zone.cpp
+++ b/cockatrice/src/game/zones/card_zone.cpp
@@ -42,7 +42,7 @@ CardZone::CardZone(Player *_p,
 
 CardZone::~CardZone()
 {
-    qDebug() << "CardZone destructor: " << name;
+    qCDebug(CardZoneLog) << "CardZone destructor: " << name;
     for (auto *view : views) {
         if (view != nullptr) {
             view->deleteLater();
@@ -147,7 +147,7 @@ void CardZone::mousePressEvent(QGraphicsSceneMouseEvent *event)
 void CardZone::addCard(CardItem *card, const bool reorganize, const int x, const int y)
 {
     if (!card) {
-        qDebug() << "CardZone::addCard() card is null, this shouldn't normally happen";
+        qCDebug(CardZoneLog) << "CardZone::addCard() card is null, this shouldn't normally happen";
         return;
     }
 
@@ -171,7 +171,7 @@ CardItem *CardZone::getCard(int cardId, const QString &cardName)
 {
     CardItem *c = cards.findCard(cardId);
     if (!c) {
-        qDebug() << "CardZone::getCard: card id=" << cardId << "not found";
+        qCDebug(CardZoneLog) << "CardZone::getCard: card id=" << cardId << "not found";
         return nullptr;
     }
     // If the card's id is -1, this zone is invisible,
@@ -216,7 +216,7 @@ CardItem *CardZone::takeCard(int position, int cardId, bool /*canResize*/)
 void CardZone::removeCard(CardItem *card)
 {
     if (!card) {
-        qDebug() << "CardZone::removeCard: card is null, this shouldn't normally happen";
+        qCDebug(CardZoneLog) << "CardZone::removeCard: card is null, this shouldn't normally happen";
         return;
     }
 

--- a/cockatrice/src/game/zones/card_zone.h
+++ b/cockatrice/src/game/zones/card_zone.h
@@ -5,7 +5,10 @@
 #include "../board/abstract_graphics_item.h"
 #include "../cards/card_list.h"
 
+#include <QLoggingCategory>
 #include <QString>
+
+inline Q_LOGGING_CATEGORY(CardZoneLog, "card_zone.debug");
 
 class Player;
 class ZoneViewZone;

--- a/cockatrice/src/game/zones/card_zone.h
+++ b/cockatrice/src/game/zones/card_zone.h
@@ -8,7 +8,7 @@
 #include <QLoggingCategory>
 #include <QString>
 
-inline Q_LOGGING_CATEGORY(CardZoneLog, "card_zone.debug");
+inline Q_LOGGING_CATEGORY(CardZoneLog, "card_zone");
 
 class Player;
 class ZoneViewZone;

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -246,7 +246,7 @@ ZoneViewZone::GridSize ZoneViewZone::positionCardsForDisplay(CardList &cards, Ca
         if (cols < 2)
             cols = 2;
 
-        qDebug() << "reorganizeCards: rows=" << rows << "cols=" << cols;
+        qCDebug(ViewZoneLog) << "reorganizeCards: rows=" << rows << "cols=" << cols;
 
         for (int i = 0; i < cardCount; i++) {
             CardItem *c = cards.at(i);

--- a/cockatrice/src/game/zones/view_zone.h
+++ b/cockatrice/src/game/zones/view_zone.h
@@ -7,7 +7,7 @@
 #include <QLoggingCategory>
 #include <pb/commands.pb.h>
 
-inline Q_LOGGING_CATEGORY(ViewZoneLog, "view_zone.debug")
+inline Q_LOGGING_CATEGORY(ViewZoneLog, "view_zone")
 
     class ZoneViewWidget;
 class Response;

--- a/cockatrice/src/game/zones/view_zone.h
+++ b/cockatrice/src/game/zones/view_zone.h
@@ -4,9 +4,12 @@
 #include "select_zone.h"
 
 #include <QGraphicsLayoutItem>
+#include <QLoggingCategory>
 #include <pb/commands.pb.h>
 
-class ZoneViewWidget;
+inline Q_LOGGING_CATEGORY(ViewZoneLog, "view_zone.debug")
+
+    class ZoneViewWidget;
 class Response;
 class ServerInfo_Card;
 class QGraphicsSceneWheelEvent;

--- a/cockatrice/src/game/zones/view_zone.h
+++ b/cockatrice/src/game/zones/view_zone.h
@@ -7,9 +7,9 @@
 #include <QLoggingCategory>
 #include <pb/commands.pb.h>
 
-inline Q_LOGGING_CATEGORY(ViewZoneLog, "view_zone")
+inline Q_LOGGING_CATEGORY(ViewZoneLog, "view_zone");
 
-    class ZoneViewWidget;
+class ZoneViewWidget;
 class Response;
 class ServerInfo_Card;
 class QGraphicsSceneWheelEvent;

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -154,7 +154,10 @@ int main(int argc, char *argv[])
 
     // Set the QT_LOGGING_CONF environment variable
     qputenv("QT_LOGGING_CONF", "./qtlogging.ini");
-qSetMessagePattern("\033[0m[%{time yyyy-MM-dd h:mm:ss.zzz} %{if-debug}\033[36mD%{endif}%{if-info}\033[32mI%{endif}%{if-warning}\033[33mW%{endif}%{if-critical}\033[31mC%{endif}%{if-fatal}\033[1;31mF%{endif}\033[0m] [%{function}] - %{message} [%{file}:%{line}]");
+    qSetMessagePattern(
+        "\033[0m[%{time yyyy-MM-dd h:mm:ss.zzz} "
+        "%{if-debug}\033[36mD%{endif}%{if-info}\033[32mI%{endif}%{if-warning}\033[33mW%{endif}%{if-critical}\033[31mC%{"
+        "endif}%{if-fatal}\033[1;31mF%{endif}\033[0m] [%{function}] - %{message} [%{file}:%{line}]");
     QApplication app(argc, argv);
 
     QObject::connect(&app, &QApplication::lastWindowClosed, &app, &QApplication::quit);

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -194,13 +194,13 @@ int main(int argc, char *argv[])
 
     QLocale::setDefault(QLocale::English);
 
-    qDebug("main(): starting main program");
+    qCDebug(MainLog) << "main(): starting main program";
 
     MainWindow ui;
     if (parser.isSet("connect")) {
         ui.setConnectTo(parser.value("connect"));
     }
-    qDebug("main(): MainWindow constructor finished");
+    qCDebug(MainLog) << "main(): MainWindow constructor finished";
 
     ui.setWindowIcon(QPixmap("theme:cockatrice"));
 #if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
@@ -215,7 +215,7 @@ int main(int argc, char *argv[])
     SpoilerBackgroundUpdater spoilerBackgroundUpdater;
 
     ui.show();
-    qDebug("main(): ui.show() finished");
+    qCDebug(MainLog) << "main(): ui.show() finished";
 
     // force shortcuts to be shown/hidden in right-click menus, regardless of system defaults
     qApp->setAttribute(Qt::AA_DontShowShortcutsInContextMenus, !SettingsCache::instance().getShowShortcuts());

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -102,7 +102,7 @@ void installNewTranslator()
 
     bool qtTranslationLoaded = qtTranslator->load(qtNameHint, qtTranslationPath);
     if (!qtTranslationLoaded) {
-        qCDebug(QtTranslatorDebug) << "aaUnable to load qt translation" << qtNameHint << "at" << qtTranslationPath;
+        qCDebug(QtTranslatorDebug) << "Unable to load qt translation" << qtNameHint << "at" << qtTranslationPath;
     } else {
         qCDebug(QtTranslatorDebug) << "Loaded qt translation" << qtNameHint << "at" << qtTranslationPath;
     }
@@ -111,10 +111,11 @@ void installNewTranslator()
     QString appNameHint = translationPrefix + "_" + lang;
     bool appTranslationLoaded = qtTranslator->load(appNameHint, translationPath);
     if (!appTranslationLoaded) {
-        qCDebug(QtTranslatorDebug) << "aaUnable to load" << translationPrefix << "translation" << appNameHint << "at"
+        qCDebug(QtTranslatorDebug) << "Unable to load" << translationPrefix << "translation" << appNameHint << "at"
                                    << translationPath;
     } else {
-        qCDebug(QtTranslatorDebug) << "Loaded" << translationPrefix << "translation" << appNameHint << "at" << translationPath;
+        qCDebug(QtTranslatorDebug) << "Loaded" << translationPrefix << "translation" << appNameHint << "at"
+                                   << translationPath;
     }
     qApp->installTranslator(translator);
 }

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -61,7 +61,7 @@ static void CockatriceLogger(QtMsgType type, const QMessageLogContext &ctx, cons
     QString logMessage = qFormatLogMessage(type, ctx, message);
 
     // Regular expression to match the full path in the square brackets and extract only the filename and line number
-    QRegularExpression regex(R"(\[\/.*\/([^\/]+\:\d+)\])");
+    QRegularExpression regex(R"(\[(?:.:)?[\/\\].*[\/\\]([^\/\\]+\:\d+)\])");
     QRegularExpressionMatch match = regex.match(logMessage);
 
     if (match.hasMatch()) {

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -102,18 +102,19 @@ void installNewTranslator()
 
     bool qtTranslationLoaded = qtTranslator->load(qtNameHint, qtTranslationPath);
     if (!qtTranslationLoaded) {
-        qDebug() << "Unable to load qt translation" << qtNameHint << "at" << qtTranslationPath;
+        qCDebug(QtTranslatorDebug) << "aaUnable to load qt translation" << qtNameHint << "at" << qtTranslationPath;
     } else {
-        qDebug() << "Loaded qt translation" << qtNameHint << "at" << qtTranslationPath;
+        qCDebug(QtTranslatorDebug) << "Loaded qt translation" << qtNameHint << "at" << qtTranslationPath;
     }
     qApp->installTranslator(qtTranslator);
 
     QString appNameHint = translationPrefix + "_" + lang;
     bool appTranslationLoaded = qtTranslator->load(appNameHint, translationPath);
     if (!appTranslationLoaded) {
-        qDebug() << "Unable to load" << translationPrefix << "translation" << appNameHint << "at" << translationPath;
+        qCDebug(QtTranslatorDebug) << "aaUnable to load" << translationPrefix << "translation" << appNameHint << "at"
+                                   << translationPath;
     } else {
-        qDebug() << "Loaded" << translationPrefix << "translation" << appNameHint << "at" << translationPath;
+        qCDebug(QtTranslatorDebug) << "Loaded" << translationPrefix << "translation" << appNameHint << "at" << translationPath;
     }
     qApp->installTranslator(translator);
 }

--- a/cockatrice/src/main.h
+++ b/cockatrice/src/main.h
@@ -3,6 +3,10 @@
 
 #include "utility/macros.h"
 
+#include <QLoggingCategory>
+
+inline Q_LOGGING_CATEGORY(QtTranslatorDebug, "qt_translator.debug");
+
 class CardDatabase;
 class QString;
 class QSystemTrayIcon;

--- a/cockatrice/src/main.h
+++ b/cockatrice/src/main.h
@@ -5,6 +5,7 @@
 
 #include <QLoggingCategory>
 
+inline Q_LOGGING_CATEGORY(MainLog, "main");
 inline Q_LOGGING_CATEGORY(QtTranslatorDebug, "qt_translator");
 
 class CardDatabase;

--- a/cockatrice/src/main.h
+++ b/cockatrice/src/main.h
@@ -5,7 +5,7 @@
 
 #include <QLoggingCategory>
 
-inline Q_LOGGING_CATEGORY(QtTranslatorDebug, "qt_translator.debug");
+inline Q_LOGGING_CATEGORY(QtTranslatorDebug, "qt_translator");
 
 class CardDatabase;
 class QString;

--- a/cockatrice/src/server/user/user_info_connection.cpp
+++ b/cockatrice/src/server/user/user_info_connection.cpp
@@ -74,7 +74,7 @@ QStringList UserConnection_Information::getServerInfo(const QString &find)
     }
 
     if (_server.empty())
-        qDebug() << "There was a problem!";
+        qCDebug(UserInfoConnectionLog) << "There was a problem!";
 
     return _server;
 }

--- a/cockatrice/src/server/user/user_info_connection.h
+++ b/cockatrice/src/server/user/user_info_connection.h
@@ -8,7 +8,7 @@
 #include <QSettings>
 #include <QStandardPaths>
 
-inline Q_LOGGING_CATEGORY(UserInfoConnectionLog, "user_info_connection.debug");
+inline Q_LOGGING_CATEGORY(UserInfoConnectionLog, "user_info_connection");
 
 class UserConnection_Information
 {

--- a/cockatrice/src/server/user/user_info_connection.h
+++ b/cockatrice/src/server/user/user_info_connection.h
@@ -4,8 +4,11 @@
 #include <QApplication>
 #include <QDir>
 #include <QFile>
+#include <QLoggingCategory>
 #include <QSettings>
 #include <QStandardPaths>
+
+inline Q_LOGGING_CATEGORY(UserInfoConnectionLog, "user_info_connection.debug");
 
 class UserConnection_Information
 {

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -144,7 +144,7 @@ QString SettingsCache::getSafeConfigPath(QString configEntry, QString defaultPat
     // ensure that the defaut path exists and return it
     if (tmp.isEmpty() || !QDir(tmp).exists()) {
         if (!QDir().mkpath(defaultPath))
-            qDebug() << "[SettingsCache] Could not create folder:" << defaultPath;
+            qCDebug(SettingsCacheLog) << "[SettingsCache] Could not create folder:" << defaultPath;
         tmp = defaultPath;
     }
     return tmp;
@@ -165,7 +165,7 @@ SettingsCache::SettingsCache()
     // first, figure out if we are running in portable mode
     isPortableBuild = QFile::exists(qApp->applicationDirPath() + "/portable.dat");
     if (isPortableBuild)
-        qDebug() << "Portable mode enabled";
+        qCDebug(SettingsCacheLog) << "Portable mode enabled";
 
     // define a dummy context that will be used where needed
     QString dummy = QT_TRANSLATE_NOOP("i18n", "English");

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -13,9 +13,12 @@
 #include "servers_settings.h"
 #include "shortcuts_settings.h"
 
+#include <QLoggingCategory>
 #include <QObject>
 #include <QSize>
 #include <QStringList>
+
+inline Q_LOGGING_CATEGORY(SettingsCacheLog, "settings_cache.debug");
 
 class ReleaseChannel;
 

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -18,7 +18,7 @@
 #include <QSize>
 #include <QStringList>
 
-inline Q_LOGGING_CATEGORY(SettingsCacheLog, "settings_cache.debug");
+inline Q_LOGGING_CATEGORY(SettingsCacheLog, "settings_cache");
 
 class ReleaseChannel;
 

--- a/cockatrice/src/settings/servers_settings.cpp
+++ b/cockatrice/src/settings/servers_settings.cpp
@@ -76,7 +76,7 @@ QString ServersSettings::getPort(QString defaultPort)
 {
     int index = getPrevioushostindex(getPrevioushostName());
     QVariant port = getValue(QString("port%1").arg(index), "server", "server_details");
-    qDebug() << "getPort() index = " << index << " port.val = " << port.toString();
+    qCDebug(ServersSettingsLog) << "getPort() index = " << index << " port.val = " << port.toString();
     return port == QVariant() ? std::move(defaultPort) : port.toString();
 }
 
@@ -84,7 +84,7 @@ QString ServersSettings::getPlayerName(QString defaultName)
 {
     int index = getPrevioushostindex(getPrevioushostName());
     QVariant name = getValue(QString("username%1").arg(index), "server", "server_details");
-    qDebug() << "getPlayerName() index = " << index << " name.val = " << name.toString();
+    qCDebug(ServersSettingsLog) << "getPlayerName() index = " << index << " name.val = " << name.toString();
     return name == QVariant() ? std::move(defaultName) : name.toString();
 }
 

--- a/cockatrice/src/settings/servers_settings.h
+++ b/cockatrice/src/settings/servers_settings.h
@@ -8,7 +8,7 @@
 #define SERVERSETTINGS_DEFAULT_HOST "server.cockatrice.us"
 #define SERVERSETTINGS_DEFAULT_PORT "4748"
 
-inline Q_LOGGING_CATEGORY(ServersSettingsLog, "servers_settings.debug");
+inline Q_LOGGING_CATEGORY(ServersSettingsLog, "servers_settings");
 
 class ServersSettings : public SettingsManager
 {

--- a/cockatrice/src/settings/servers_settings.h
+++ b/cockatrice/src/settings/servers_settings.h
@@ -3,9 +3,12 @@
 
 #include "settings_manager.h"
 
+#include <QLoggingCategory>
 #include <QObject>
 #define SERVERSETTINGS_DEFAULT_HOST "server.cockatrice.us"
 #define SERVERSETTINGS_DEFAULT_PORT "4748"
+
+inline Q_LOGGING_CATEGORY(ServersSettingsLog, "servers_settings.debug");
 
 class ServersSettings : public SettingsManager
 {

--- a/cockatrice/src/settings/shortcuts_settings.cpp
+++ b/cockatrice/src/settings/shortcuts_settings.cpp
@@ -67,7 +67,7 @@ void ShortcutsSettings::migrateShortcuts()
         shortCutsFile.beginGroup(custom);
 
         if (shortCutsFile.contains("Textbox/unfocusTextBox")) {
-            qDebug()
+            qCDebug(ShortcutsSettingsLog)
                 << "[ShortcutsSettings] Textbox/unfocusTextBox shortcut found. Migrating to Player/unfocusTextBox.";
             QString unfocusTextBox = shortCutsFile.value("Textbox/unfocusTextBox", "").toString();
             this->setShortcuts("Player/unfocusTextBox", unfocusTextBox);
@@ -75,7 +75,8 @@ void ShortcutsSettings::migrateShortcuts()
         }
 
         if (shortCutsFile.contains("tab_game/aFocusChat")) {
-            qDebug() << "[ShortcutsSettings] tab_game/aFocusChat shortcut found. Migrating to Player/aFocusChat.";
+            qCDebug(ShortcutsSettingsLog)
+                << "[ShortcutsSettings] tab_game/aFocusChat shortcut found. Migrating to Player/aFocusChat.";
             QString aFocusChat = shortCutsFile.value("tab_game/aFocusChat", "").toString();
             this->setShortcuts("Player/aFocusChat", aFocusChat);
             shortCutsFile.remove("tab_game/aFocusChat");

--- a/cockatrice/src/settings/shortcuts_settings.h
+++ b/cockatrice/src/settings/shortcuts_settings.h
@@ -6,7 +6,7 @@
 #include <QLoggingCategory>
 #include <QSettings>
 
-inline Q_LOGGING_CATEGORY(ShortcutsSettingsLog, "shortcuts_settings.debug");
+inline Q_LOGGING_CATEGORY(ShortcutsSettingsLog, "shortcuts_settings");
 
 class ShortcutGroup
 {

--- a/cockatrice/src/settings/shortcuts_settings.h
+++ b/cockatrice/src/settings/shortcuts_settings.h
@@ -3,7 +3,10 @@
 
 #include <QApplication>
 #include <QKeySequence>
+#include <QLoggingCategory>
 #include <QSettings>
+
+inline Q_LOGGING_CATEGORY(ShortcutsSettingsLog, "shortcuts_settings.debug");
 
 class ShortcutGroup
 {


### PR DESCRIPTION
## Related Ticket(s)
- Follow up to #5419 

## Short roundup of the initial problem
See #5419. Currently we only use QDebug, which leads to everything getting logged to the console, all the time. This discourages logging, lest the developer clutter up the consoles of other developers with unnecessary information. What information we do log, is always printed, whether necessary or not, which hinders even temporary local debug statements.

With this change, everything gains a category, which allows it to be silenced on demand. Developers are encouraged to provide a logging category for their classes and implement more debugging statements. Logging categories can be sub-categorized for fine control. Developers can then customize their local qtlogging.ini to only include relevant logging for their changes.

# As is

![image](https://github.com/user-attachments/assets/1ce00367-ec3d-4b1f-be39-954debbf056e)

# Minimal

![image](https://github.com/user-attachments/assets/93c32970-8550-41df-81b6-98feb3453345)

# Specific use cases

![image](https://github.com/user-attachments/assets/ad590350-f3fa-4bd7-95fb-5aab56738a92)

![image](https://github.com/user-attachments/assets/e5b4aff7-cd1f-489e-b469-4f9e853e03ae)

