### PR TITLE
Give deckList a signal to emit when the tags change and hook up the display widget to that.

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.cpp
@@ -21,11 +21,21 @@ DeckPreviewDeckTagsDisplayWidget::DeckPreviewDeckTagsDisplayWidget(DeckPreviewWi
 
     setFixedHeight(100);
 
-    auto *flowWidget = new FlowWidget(this, Qt::ScrollBarAlwaysOff, Qt::ScrollBarAsNeeded);
+    connect(deckLoader, &DeckList::deckTagsChanged, this, &DeckPreviewDeckTagsDisplayWidget::refreshTags);
 
+    flowWidget = new FlowWidget(this, Qt::ScrollBarAlwaysOff, Qt::ScrollBarAsNeeded);
     for (const QString &tag : this->deckLoader->getTags()) {
         flowWidget->addWidget(new DeckPreviewTagDisplayWidget(this, tag));
     }
     flowWidget->addWidget(new DeckPreviewTagAdditionWidget(this, tr("Edit tags ...")));
     layout->addWidget(flowWidget);
+}
+
+void DeckPreviewDeckTagsDisplayWidget::refreshTags()
+{
+    flowWidget->clearLayout();
+    for (const QString &tag : this->deckLoader->getTags()) {
+        flowWidget->addWidget(new DeckPreviewTagDisplayWidget(this, tag));
+    }
+    flowWidget->addWidget(new DeckPreviewTagAdditionWidget(this, tr("Edit tags ...")));
 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.h
@@ -13,7 +13,9 @@ class DeckPreviewDeckTagsDisplayWidget : public QWidget
 
 public:
     explicit DeckPreviewDeckTagsDisplayWidget(DeckPreviewWidget *_parent, DeckLoader *_deckLoader);
+    void refreshTags();
     DeckPreviewWidget *parent;
     DeckLoader *deckLoader;
+    FlowWidget *flowWidget;
 };
 #endif // DECK_PREVIEW_DECK_TAGS_DISPLAY_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_addition_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_addition_widget.cpp
@@ -45,7 +45,6 @@ void DeckPreviewTagAdditionWidget::mousePressEvent(QMouseEvent *event)
         QStringList updatedTags = dialog.getActiveTags();
         parent->deckLoader->setTags(updatedTags);
         parent->deckLoader->saveToFile(parent->parent->filePath, DeckLoader::CockatriceFormat);
-        parent->parent->parent->refreshBannerCards();
     }
 }
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -78,6 +78,7 @@ void VisualDeckStorageWidget::deckPreviewClickedEvent(QMouseEvent *event, DeckPr
 void VisualDeckStorageWidget::deckPreviewDoubleClickedEvent(QMouseEvent *event, DeckPreviewWidget *instance)
 {
     emit deckPreviewDoubleClicked(event, instance);
+    emit deckLoadRequested(instance->filePath);
 }
 
 void VisualDeckStorageWidget::refreshBannerCards()

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -35,6 +35,7 @@ signals:
     void bannerCardsRefreshed();
     void deckPreviewClicked(QMouseEvent *event, DeckPreviewWidget *instance);
     void deckPreviewDoubleClicked(QMouseEvent *event, DeckPreviewWidget *instance);
+    void deckLoadRequested(QString &filePath);
 
 private:
     QVBoxLayout *layout;

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -181,6 +181,7 @@ void DeckViewContainer::refreshShortcuts()
 void DeckViewContainer::loadVisualDeck(QMouseEvent *event, DeckPreviewWidget *instance)
 {
     Q_UNUSED(event);
+    instance->deckLoader->loadFromFile(instance->filePath, DeckLoader::CockatriceFormat, false);
     QString deckString = instance->deckLoader->writeToString_Native();
 
     if (deckString.length() > MAX_FILE_LENGTH) {

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -86,8 +86,8 @@ DeckViewContainer::DeckViewContainer(int _playerId, TabGame *parent)
     connect(deckView, SIGNAL(sideboardPlanChanged()), this, SLOT(sideboardPlanChanged()));
 
     visualDeckStorageWidget = new VisualDeckStorageWidget(this);
-    connect(visualDeckStorageWidget, &VisualDeckStorageWidget::deckPreviewDoubleClicked, this,
-            &DeckViewContainer::loadVisualDeck);
+    connect(visualDeckStorageWidget, &VisualDeckStorageWidget::deckLoadRequested, this,
+            &DeckViewContainer::loadDeckFromFile);
 
     deckViewLayout = new QVBoxLayout;
     deckViewLayout->addLayout(buttonHBox);
@@ -176,25 +176,6 @@ void DeckViewContainer::refreshShortcuts()
     loadRemoteButton->setShortcut(shortcuts.getSingleShortcut("DeckViewContainer/loadRemoteButton"));
     readyStartButton->setShortcut(shortcuts.getSingleShortcut("DeckViewContainer/readyStartButton"));
     sideboardLockButton->setShortcut(shortcuts.getSingleShortcut("DeckViewContainer/sideboardLockButton"));
-}
-
-void DeckViewContainer::loadVisualDeck(QMouseEvent *event, DeckPreviewWidget *instance)
-{
-    Q_UNUSED(event);
-    instance->deckLoader->loadFromFile(instance->filePath, DeckLoader::CockatriceFormat, false);
-    QString deckString = instance->deckLoader->writeToString_Native();
-
-    if (deckString.length() > MAX_FILE_LENGTH) {
-        QMessageBox::critical(this, tr("Error"), tr("The selected file could not be loaded."));
-        return;
-    }
-
-    Command_DeckSelect cmd;
-    cmd.set_deck(deckString.toStdString());
-    PendingCommand *pend = parentGame->prepareGameCommand(cmd);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-            SLOT(deckSelectFinished(const Response &)));
-    parentGame->sendGameCommand(pend, playerId);
 }
 
 void DeckViewContainer::unloadDeck()

--- a/cockatrice/src/game/deckview/deck_view_container.h
+++ b/cockatrice/src/game/deckview/deck_view_container.h
@@ -55,7 +55,6 @@ private:
 private slots:
     void switchToDeckSelectView();
     void switchToDeckLoadedView();
-    void loadVisualDeck(QMouseEvent *event, DeckPreviewWidget *instance);
     void loadLocalDeck();
     void loadRemoteDeck();
     void unloadDeck();
@@ -77,6 +76,8 @@ public:
     void readyAndUpdate();
     void setSideboardLocked(bool locked);
     void setDeck(const DeckLoader &deck);
+
+public slots:
     void loadDeckFromFile(const QString &filePath);
 };
 

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -272,6 +272,7 @@ protected:
 
 signals:
     void deckHashChanged();
+    void deckTagsChanged();
 
 public slots:
     void setName(const QString &_name = QString())
@@ -285,14 +286,17 @@ public slots:
     void setTags(const QStringList &_tags = QStringList())
     {
         tags = _tags;
+        emit deckTagsChanged();
     }
     void addTag(const QString &_tag)
     {
         tags.append(_tag);
+        emit deckTagsChanged();
     }
     void clearTags()
     {
         tags.clear();
+        emit deckTagsChanged();
     }
     void setBannerCard(const QPair<QString, QString> &_bannerCard = QPair<QString, QString>())
     {


### PR DESCRIPTION
## Short roundup of the initial problem
Editing a decks tags causes all of the bannerCard widgets to get reconstructed.

## What will change with this Pull Request?
- Give deckList a signal to emit when the tags change and hook up the display widget to that instead of refreshing all banner cards.
- DeckViewContainer now reloads the DeckPreviewWidgets deck from file when loading a deck to ensure it has the latest decklist if it has been modified.