### PR TITLE
Add a button to easily view the transformed version of a card.

### DIFF
--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
@@ -23,6 +23,11 @@ CardInfoFrameWidget::CardInfoFrameWidget(const QString &cardName, QWidget *paren
     text->setObjectName("text");
     connect(text, SIGNAL(linkActivated(const QString &)), this, SLOT(setCard(const QString &)));
 
+    viewTransformationButton = new QPushButton();
+    viewTransformationButton->setObjectName("viewTransformationButton");
+    connect(viewTransformationButton, &QPushButton::clicked, this, &CardInfoFrameWidget::viewTransformation);
+    viewTransformationButton->setVisible(false);
+
     tab1 = new QWidget(this);
     tab2 = new QWidget(this);
     tab3 = new QWidget(this);
@@ -69,6 +74,7 @@ void CardInfoFrameWidget::retranslateUi()
     setTabText(ImageOnlyView, tr("Image"));
     setTabText(TextOnlyView, tr("Description"));
     setTabText(ImageAndTextView, tr("Both"));
+    viewTransformationButton->setText(tr("View transformation"));
 }
 
 void CardInfoFrameWidget::setViewMode(int mode)
@@ -80,10 +86,12 @@ void CardInfoFrameWidget::setViewMode(int mode)
         case ImageOnlyView:
         case TextOnlyView:
             tab1Layout->addWidget(pic);
+            tab1Layout->addWidget(viewTransformationButton);
             tab2Layout->addWidget(text);
             break;
         case ImageAndTextView:
             splitter->addWidget(pic);
+            splitter->addWidget(viewTransformationButton);
             splitter->addWidget(text);
             break;
         default:
@@ -95,6 +103,7 @@ void CardInfoFrameWidget::setViewMode(int mode)
 
 void CardInfoFrameWidget::setCard(CardInfoPtr card)
 {
+    viewTransformationButton->setVisible(false);
     if (info) {
         disconnect(info.data(), nullptr, this, nullptr);
     }
@@ -103,6 +112,16 @@ void CardInfoFrameWidget::setCard(CardInfoPtr card)
 
     if (info) {
         connect(info.data(), SIGNAL(destroyed()), this, SLOT(clearCard()));
+    }
+
+    if (info) {
+        auto relations = info->getAllRelatedCards();
+
+        for (auto relation : relations) {
+            if (relation->getDoesTransform()) {
+                viewTransformationButton->setVisible(true);
+            }
+        }
     }
 
     text->setCard(info);
@@ -123,6 +142,19 @@ void CardInfoFrameWidget::setCard(AbstractCardItem *card)
 {
     if (card) {
         setCard(card->getInfo());
+    }
+}
+
+void CardInfoFrameWidget::viewTransformation()
+{
+    if (info) {
+        auto relations = info->getAllRelatedCards();
+
+        for (auto relation : relations) {
+            if (relation->getDoesTransform()) {
+                setCard(relation->getName());
+            }
+        }
     }
 }
 

--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
@@ -151,7 +151,7 @@ void CardInfoFrameWidget::viewTransformation()
         const auto &cardRelations = info->getAllRelatedCards();
         for (const auto &cardRelation : cardRelations) {
             if (cardRelation->getDoesTransform()) {
-                viewTransformationButton->setVisible(true);
+                setCard(cardRelation->getName());
                 break;
             }
         }

--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
@@ -115,11 +115,11 @@ void CardInfoFrameWidget::setCard(CardInfoPtr card)
     }
 
     if (info) {
-        auto relations = info->getAllRelatedCards();
-
-        for (auto relation : relations) {
-            if (relation->getDoesTransform()) {
+        const auto &cardRelations = info->getAllRelatedCards();
+        for (const auto &cardRelation : cardRelations) {
+            if (cardRelation->getDoesTransform()) {
                 viewTransformationButton->setVisible(true);
+                break;
             }
         }
     }
@@ -148,11 +148,11 @@ void CardInfoFrameWidget::setCard(AbstractCardItem *card)
 void CardInfoFrameWidget::viewTransformation()
 {
     if (info) {
-        auto relations = info->getAllRelatedCards();
-
-        for (auto relation : relations) {
-            if (relation->getDoesTransform()) {
-                setCard(relation->getName());
+        const auto &cardRelations = info->getAllRelatedCards();
+        for (const auto &cardRelation : cardRelations) {
+            if (cardRelation->getDoesTransform()) {
+                viewTransformationButton->setVisible(true);
+                break;
             }
         }
     }

--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.h
@@ -3,6 +3,7 @@
 
 #include "../../../../game/cards/card_database.h"
 
+#include <QPushButton>
 #include <QTabWidget>
 
 class AbstractCardItem;
@@ -18,6 +19,7 @@ private:
     CardInfoPtr info;
     CardInfoPictureWidget *pic;
     CardInfoTextWidget *text;
+    QPushButton *viewTransformationButton;
     bool cardTextOnly;
     QWidget *tab1, *tab2, *tab3;
     QVBoxLayout *tab1Layout, *tab2Layout, *tab3Layout;
@@ -43,6 +45,7 @@ public slots:
     void setCard(const QString &cardName);
     void setCard(const QString &cardName, const QString &providerId);
     void setCard(AbstractCardItem *card);
+    void viewTransformation();
     void clearCard();
     void setViewMode(int mode);
 };


### PR DESCRIPTION
## Related Ticket(s)
- Follow up to #4744

## What will change with this Pull Request?
- Add a new button to the CardInfoFrameWidget that will be visible if the card has a cardrelation that doesAttach. When clicked, it sets the CardInfoFrameWidgets info to that card.

## Screenshots
![image](https://github.com/user-attachments/assets/96211ec4-e354-43a9-8287-6741a017ad5c)
![image](https://github.com/user-attachments/assets/7ba2ccd7-5398-413b-bfc1-28343e7def59)
![image](https://github.com/user-attachments/assets/3683077a-44e5-4bf9-9ec4-2ac56bc68fa1)

