### PR TITLE
Hide load from remote button in local games

### DIFF
--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -65,6 +65,7 @@ DeckViewContainer::DeckViewContainer(int _playerId, TabGame *parent)
     connect(sideboardLockButton, SIGNAL(stateChanged()), this, SLOT(updateSideboardLockButtonText()));
 
     if (parentGame->getIsLocalGame()) {
+        loadRemoteButton->setVisible(false);
         loadRemoteButton->setEnabled(false);
     } else {
         connect(loadRemoteButton, SIGNAL(clicked()), this, SLOT(loadRemoteDeck()));
@@ -126,7 +127,11 @@ void DeckViewContainer::switchToDeckSelectView()
     deckViewLayout->update();
 
     setVisibility(loadLocalButton, true);
-    setVisibility(loadRemoteButton, true);
+    if (parentGame->getIsLocalGame()) {
+        setVisibility(loadRemoteButton, false);
+    } else {
+        setVisibility(loadRemoteButton, true);
+    }
     setVisibility(unloadDeckButton, false);
     setVisibility(readyStartButton, false);
     setVisibility(sideboardLockButton, false);

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -127,11 +127,7 @@ void DeckViewContainer::switchToDeckSelectView()
     deckViewLayout->update();
 
     setVisibility(loadLocalButton, true);
-    if (parentGame->getIsLocalGame()) {
-        setVisibility(loadRemoteButton, false);
-    } else {
-        setVisibility(loadRemoteButton, true);
-    }
+    setVisibility(loadRemoteButton, !parentGame->getIsLocalGame());
     setVisibility(unloadDeckButton, false);
     setVisibility(readyStartButton, false);
     setVisibility(sideboardLockButton, false);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5495

## Short roundup of the initial problem
The load from remote button is visible in local games which doesn't make much sense.

## What will change with this Pull Request?
- Change the visibility of load from remote to only be visible if the parentGame is not a local game.