### PR TITLE
Add label to "swap cards between maindeck and sideboard" button

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -765,11 +765,10 @@ void TabDeckEditor::retranslateUi()
     aAddCard->setText(tr("Add card to &maindeck"));
     aAddCardToSideboard->setText(tr("Add card to &sideboard"));
 
-    aRemoveCard->setText(tr("&Remove row"));
-
     aIncrement->setText(tr("&Increment number"));
-
     aDecrement->setText(tr("&Decrement number"));
+    aRemoveCard->setText(tr("&Remove row"));
+    aSwapCard->setText(tr("Swap card to/from sideboard"));
 
     deckMenu->setTitle(tr("&Deck Editor"));
 


### PR DESCRIPTION
## Related Ticket(s)
- Follow up to #5175

## Short roundup of the initial problem
No hover label for new button

## What will change with this Pull Request?
- Add `Swap card to/from sideboard` label
- Group buttons and apply order from UI, same as move to maindeck/sideboard buttons

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![image](https://github.com/user-attachments/assets/32727b63-f355-42f6-a9fd-236ae5dd2755)
