### PR TITLE
Add setting to auto close card view when empty

### DIFF
--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -561,6 +561,10 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     connect(&playToStackCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setPlayToStack);
 
+    closeEmptyCardViewCheckBox.setChecked(SettingsCache::instance().getCloseEmptyCardView());
+    connect(&closeEmptyCardViewCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setCloseEmptyCardView);
+
     annotateTokensCheckBox.setChecked(SettingsCache::instance().getAnnotateTokens());
     connect(&annotateTokensCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setAnnotateTokens);
@@ -573,8 +577,9 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     generalGrid->addWidget(&doubleClickToPlayCheckBox, 0, 0);
     generalGrid->addWidget(&clickPlaysAllSelectedCheckBox, 1, 0);
     generalGrid->addWidget(&playToStackCheckBox, 2, 0);
-    generalGrid->addWidget(&annotateTokensCheckBox, 3, 0);
-    generalGrid->addWidget(&useTearOffMenusCheckBox, 4, 0);
+    generalGrid->addWidget(&closeEmptyCardViewCheckBox, 3, 0);
+    generalGrid->addWidget(&annotateTokensCheckBox, 4, 0);
+    generalGrid->addWidget(&useTearOffMenusCheckBox, 5, 0);
 
     generalGroupBox = new QGroupBox;
     generalGroupBox->setLayout(generalGrid);
@@ -650,6 +655,7 @@ void UserInterfaceSettingsPage::retranslateUi()
     doubleClickToPlayCheckBox.setText(tr("&Double-click cards to play them (instead of single-click)"));
     clickPlaysAllSelectedCheckBox.setText(tr("&Clicking plays all selected cards (instead of just the clicked card)"));
     playToStackCheckBox.setText(tr("&Play all nonlands onto the stack (not the battlefield) by default"));
+    closeEmptyCardViewCheckBox.setText(tr("Close card view window when last card is removed"));
     annotateTokensCheckBox.setText(tr("Annotate card text on tokens"));
     useTearOffMenusCheckBox.setText(tr("Use tear-off menus, allowing right click menus to persist on screen"));
     notificationsGroupBox->setTitle(tr("Notifications settings"));

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -139,6 +139,7 @@ private:
     QCheckBox doubleClickToPlayCheckBox;
     QCheckBox clickPlaysAllSelectedCheckBox;
     QCheckBox playToStackCheckBox;
+    QCheckBox closeEmptyCardViewCheckBox;
     QCheckBox annotateTokensCheckBox;
     QCheckBox useTearOffMenusCheckBox;
     QCheckBox tapAnimationCheckBox;

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -342,6 +342,12 @@ void ZoneViewZone::removeCard(int position)
 
     CardItem *card = cards.takeAt(position);
     card->deleteLater();
+
+    if (cards.isEmpty() && SettingsCache::instance().getCloseEmptyCardView()) {
+        deleteLater();
+        return;
+    }
+
     updateCardIds(REMOVE_CARD);
     reorganizeCards();
 }

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -253,6 +253,7 @@ SettingsCache::SettingsCache()
     knownMissingFeatures = settings->value("interface/knownmissingfeatures", "").toString();
     useTearOffMenus = settings->value("interface/usetearoffmenus", true).toBool();
     cardViewInitialRowsMax = settings->value("interface/cardViewInitialRowsMax", 14).toInt();
+    closeEmptyCardView = settings->value("interface/closeEmptyCardView", true).toBool();
 
     showShortcuts = settings->value("menu/showshortcuts", true).toBool();
     displayCardNames = settings->value("cards/displaycardnames", true).toBool();
@@ -339,6 +340,12 @@ void SettingsCache::setCardViewInitialRowsMax(int _cardViewInitialRowsMax)
 {
     cardViewInitialRowsMax = _cardViewInitialRowsMax;
     settings->setValue("interface/cardViewInitialRowsMax", cardViewInitialRowsMax);
+}
+
+void SettingsCache::setCloseEmptyCardView(QT_STATE_CHANGED_T value)
+{
+    closeEmptyCardView = value;
+    settings->setValue("interface/closeEmptyCardView", closeEmptyCardView);
 }
 
 void SettingsCache::setKnownMissingFeatures(const QString &_knownMissingFeatures)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -159,6 +159,7 @@ private:
     QString knownMissingFeatures;
     bool useTearOffMenus;
     int cardViewInitialRowsMax;
+    bool closeEmptyCardView;
     int pixmapCacheSize;
     int networkCacheSize;
     int redirectCacheTtl;
@@ -619,6 +620,7 @@ public:
     void setKnownMissingFeatures(const QString &_knownMissingFeatures);
     void setUseTearOffMenus(bool _useTearOffMenus);
     void setCardViewInitialRowsMax(int _cardViewInitialRowsMax);
+    void setCloseEmptyCardView(QT_STATE_CHANGED_T value);
     QString getClientID()
     {
         return clientID;
@@ -638,6 +640,10 @@ public:
     int getCardViewInitialRowsMax() const
     {
         return cardViewInitialRowsMax;
+    }
+    bool getCloseEmptyCardView() const
+    {
+        return closeEmptyCardView;
     }
     ShortcutsSettings &shortcuts() const
     {

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -58,6 +58,9 @@ void SettingsCache::setUseTearOffMenus(bool /* _useTearOffMenus */)
 void SettingsCache::setCardViewInitialRowsMax(int /* _cardViewInitialRowsMax */)
 {
 }
+void SettingsCache::setCloseEmptyCardView(const QT_STATE_CHANGED_T /* value */)
+{
+}
 void SettingsCache::setKnownMissingFeatures(const QString & /* _knownMissingFeatures */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -62,6 +62,9 @@ void SettingsCache::setUseTearOffMenus(bool /* _useTearOffMenus */)
 void SettingsCache::setCardViewInitialRowsMax(int /* _cardViewInitialRowsMax */)
 {
 }
+void SettingsCache::setCloseEmptyCardView(QT_STATE_CHANGED_T /* value */)
+{
+}
 void SettingsCache::setKnownMissingFeatures(const QString & /* _knownMissingFeatures */)
 {
 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1893

## What will change with this Pull Request?

https://github.com/user-attachments/assets/e09006ea-a927-4740-aac2-e047c9d7e3bf

- Added setting `Close card view window when last card is removed` under `User Interface` 
- When settings is enabled, the card view window will automatically close when a card removal from the window causes the window to become empty.
  - You can still open empty card view windows; the automatic closing only triggers when a card removal causes the window to become empty

## Screenshots

<img width="500" alt="Screenshot 2025-01-19 at 5 17 43 PM" src="https://github.com/user-attachments/assets/cff6558f-2996-4fd0-a801-cf23a4e66e1e" />

## Known issues

- When only a single card is in the zone view, dragging the card into the same zone will cause the window to close.
  - Only happens when there is a single card in the zone view; two or more cards are handled fine
  - Not sure how relevant this actually is, since you usually don't have a reason to be dragging a single card into the same zone, unless it's by mistake or something

https://github.com/user-attachments/assets/deab1bd8-67ed-4fcb-8270-d65d95d8f31d


