### PR TITLE
Remove spacing in CardInfoWidget caused by invisible view transformation button

### DIFF
--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
@@ -82,6 +82,11 @@ void CardInfoFrameWidget::setViewMode(int mode)
     if (currentIndex() != mode)
         setCurrentIndex(mode);
 
+    /* This weird code is to work around the following:
+     * - Widgets can only have one parent; adding an already-parented widget will cause the new parent to "steal" it
+     * from the old parent
+     * - Unparented widgets become freefloating, which we do not want
+     */
     switch (mode) {
         case ImageOnlyView:
         case TextOnlyView:

--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
@@ -39,7 +39,7 @@ CardInfoFrameWidget::CardInfoFrameWidget(const QString &cardName, QWidget *paren
     insertTab(ImageOnlyView, tab1, QString());
     insertTab(TextOnlyView, tab2, QString());
     insertTab(ImageAndTextView, tab3, QString());
-    connect(this, SIGNAL(currentChanged(int)), this, SLOT(setViewMode(int)));
+    connect(this, &CardInfoFrameWidget::currentChanged, this, &CardInfoFrameWidget::setViewMode);
 
     tab1Layout = new QVBoxLayout();
     tab1Layout->setObjectName("tab1Layout");

--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
@@ -26,7 +26,7 @@ CardInfoFrameWidget::CardInfoFrameWidget(const QString &cardName, QWidget *paren
     viewTransformationButton = new QPushButton();
     viewTransformationButton->setObjectName("viewTransformationButton");
     connect(viewTransformationButton, &QPushButton::clicked, this, &CardInfoFrameWidget::viewTransformation);
-    viewTransformationButton->setVisible(false);
+    viewTransformationButton->setHidden(true);
 
     tab1 = new QWidget(this);
     tab2 = new QWidget(this);
@@ -103,7 +103,7 @@ void CardInfoFrameWidget::setViewMode(int mode)
 
 void CardInfoFrameWidget::setCard(CardInfoPtr card)
 {
-    viewTransformationButton->setVisible(false);
+    viewTransformationButton->setHidden(true);
     if (info) {
         disconnect(info.data(), nullptr, this, nullptr);
     }
@@ -118,7 +118,7 @@ void CardInfoFrameWidget::setCard(CardInfoPtr card)
         const auto &cardRelations = info->getAllRelatedCards();
         for (const auto &cardRelation : cardRelations) {
             if (cardRelation->getDoesTransform()) {
-                viewTransformationButton->setVisible(true);
+                viewTransformationButton->setHidden(false);
                 break;
             }
         }

--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.h
@@ -12,14 +12,44 @@ class CardInfoTextWidget;
 class QVBoxLayout;
 class QSplitter;
 
+/**
+ * This widget contains the CardInfoPictureWidget and the "view transformation" button.
+ *
+ * Simply hiding the button will still leave a small gap at the bottom of the CardInfoPictureWidget.
+ * This widget deletes the button when it's not relevant in order to not leave any spaces.
+ */
+class CardPictureAndButtonWidget : public QWidget
+{
+    Q_OBJECT
+
+    CardInfoPictureWidget *pic;
+    QPushButton *viewTransformationButton;
+
+    QPushButton *createViewTransformationButton();
+    void setTransformButtonVisibility(bool visible);
+
+public:
+    explicit CardPictureAndButtonWidget(QWidget *parent = nullptr);
+    void retranslateUi();
+
+public slots:
+    void setCard(const CardInfoPtr &card);
+
+signals:
+    /**
+     * Forwarded from CardInfoPictureWidget::cardChanged
+     */
+    void cardChanged(CardInfoPtr card);
+    void transformationButtonClicked();
+};
+
 class CardInfoFrameWidget : public QTabWidget
 {
     Q_OBJECT
 private:
     CardInfoPtr info;
-    CardInfoPictureWidget *pic;
+    CardPictureAndButtonWidget *pic;
     CardInfoTextWidget *text;
-    QPushButton *viewTransformationButton;
     bool cardTextOnly;
     QWidget *tab1, *tab2, *tab3;
     QVBoxLayout *tab1Layout, *tab2Layout, *tab3Layout;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes issue introduced in #5498

## Short roundup of the initial problem

Card Info Widget now has extra space at the bottom due to the addition of the `view transformation` button, even when the button isn't showing.

<img width="500" alt="before" src="https://github.com/user-attachments/assets/e1740800-54db-406d-a1ad-b8d1d66953d3" />


## What will change with this Pull Request?

Entirely delete the view transformation `QButton` when it's not in use, instead of just hiding it.

<img width="500" alt="after" src="https://github.com/user-attachments/assets/c1ff383d-425b-4bb2-b6fa-d8327bbb1318" />

- Move the picture and button into a single `CardPictureAndButtonWidget` class
  - class manages the creation and deletion of the view transformation button

