### PR TITLE
Convert lastLoaded timestamp into proper QDateTime for correct comparison.

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
@@ -67,6 +67,10 @@ QList<DeckPreviewWidget *> &VisualDeckStorageSortWidget::filterFiles(QList<DeckP
 {
     // Sort the widgets list based on the current sort order
     std::sort(widgets.begin(), widgets.end(), [this](DeckPreviewWidget *widget1, DeckPreviewWidget *widget2) {
+        if (!widget1 || !widget2) {
+            return false; // Handle null pointers gracefully
+        }
+
         QFileInfo info1(widget1->filePath);
         QFileInfo info2(widget2->filePath);
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
@@ -67,10 +67,6 @@ QList<DeckPreviewWidget *> &VisualDeckStorageSortWidget::filterFiles(QList<DeckP
 {
     // Sort the widgets list based on the current sort order
     std::sort(widgets.begin(), widgets.end(), [this](DeckPreviewWidget *widget1, DeckPreviewWidget *widget2) {
-        if (!widget1 || !widget2) {
-            return false; // Handle null pointers gracefully
-        }
-
         QFileInfo info1(widget1->filePath);
         QFileInfo info2(widget2->filePath);
 
@@ -81,8 +77,11 @@ QList<DeckPreviewWidget *> &VisualDeckStorageSortWidget::filterFiles(QList<DeckP
                 return info1.fileName().toLower() < info2.fileName().toLower();
             case ByLastModified:
                 return info1.lastModified() > info2.lastModified();
-            case ByLastLoaded:
-                return widget1->deckLoader->getLastLoadedTimestamp() > widget2->deckLoader->getLastLoadedTimestamp();
+            case ByLastLoaded: {
+                QDateTime time1 = QDateTime::fromString(widget1->deckLoader->getLastLoadedTimestamp());
+                QDateTime time2 = QDateTime::fromString(widget2->deckLoader->getLastLoadedTimestamp());
+                return time1 > time2;
+            }
         }
 
         return false; // Default case, no sorting applied


### PR DESCRIPTION
## Short roundup of the initial problem
Stuff isn't sorting correctly because I forgot to convert the lastLoadedTimestamp back to a QDateTime on comparison (in my defense, lastModified just above works just fine (because the QFileInfo generates it :P)

## What will change with this Pull Request?
- Sort VDS properly on last load property.