### PR TITLE
fix segfault when bottoming card while viewing deck

### DIFF
--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -282,7 +282,8 @@ void ZoneViewZone::addCardImpl(CardItem *card, int x, int /*y*/)
 {
     if (!isReversed) {
         // if x is negative set it to add at end
-        if (x < 0) {
+        // if x is out-of-bounds then also set it to add at the end
+        if (x < 0 || x >= cards.size()) {
             x = cards.size();
         }
         cards.insert(x, card);
@@ -292,7 +293,8 @@ void ZoneViewZone::addCardImpl(CardItem *card, int x, int /*y*/)
         int insertionIndex = x - firstId;
         if (insertionIndex >= 0) {
             // card was put into a portion of the deck that's in the view
-            cards.insert(insertionIndex, card);
+            // qMin to prevent out-of-bounds error when bottoming a card that is already in the view
+            cards.insert(qMin(insertionIndex, cards.size()), card);
         } else {
             // card was put into a portion of the deck that's not in the view
             updateCardIds(ADD_CARD);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5410

## Short roundup of the initial problem

Cockatrice crashes when you try to bottom a card in the card view window when looking at deck or looking at the bottom X cards.

This is caused by the following sequence:
- View has X card
- Attempt to bottom a card in the view
  - Cockatrice will send a remove card followed by a "insert card at index X+1"
- Card is removed. View now has size X-1
- Attempt to insert card at index X + 1
  - Index out of bounds error

## What will change with this Pull Request?

https://github.com/user-attachments/assets/b478a9e9-cb9c-4bd7-9142-22610059758c

Always cap the insertion index to the size of the card list.
