### PR TITLE
fix after merge to use ZoneView::close

### DIFF
--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -350,7 +350,7 @@ void ZoneViewZone::removeCard(int position)
     card->deleteLater();
 
     if (cards.isEmpty() && SettingsCache::instance().getCloseEmptyCardView()) {
-        deleteLater();
+        close();
         return;
     }
 


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5502 and #5507

## Short roundup of the initial problem

One of the PRs made it so we should always use `close` instead of `deleteLater` while another PR was using `close`

## What will change with this Pull Request?
- Use `close` instead of `deleteLater`
