### PR TITLE
Remove spacing in CardInfoWidget caused by invisible button

### DIFF
--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.h
@@ -25,6 +25,9 @@ private:
     QVBoxLayout *tab1Layout, *tab2Layout, *tab3Layout;
     QSplitter *splitter;
 
+    void setViewTransformationButtonVisibility(bool visible);
+    void refreshLayout();
+
 public:
     enum ViewMode
     {


### PR DESCRIPTION
Attempt 2, this time without creating a new class

## Related Ticket(s)
- Fixes issue introduced in #5498

## Short roundup of the initial problem

Card Info Widget now has extra space at the bottom due to the addition of the `view transformation` button, even when the button isn't showing.

<img width="400" alt="before" src="https://github.com/user-attachments/assets/e1740800-54db-406d-a1ad-b8d1d66953d3" />

## What will change with this Pull Request?

https://github.com/user-attachments/assets/cd6cbb8e-e418-47da-8ded-1ce84e560364

Entirely delete the view transformation `QButton` when it's not in use, instead of just hiding it.


- Refactor refreshing the layout to a separate method
- Delete the button entirely when it's not visible
  - keep `viewTransformationButton` as a nullptr when card has no transformation
  - Code now null checks `viewTransformationButton` whenever it needs to do something with it
  - When transformable card appears, button is created and then refresh layout is called
- view transformation button still works as before

