### PR TITLE
add missing override and explicit specifiers to all classes in src/game

### DIFF
--- a/cockatrice/src/game/board/abstract_counter.h
+++ b/cockatrice/src/game/board/abstract_counter.h
@@ -88,7 +88,7 @@ public:
     AbstractCounterDialog(const QString &name, const QString &value, QWidget *parent = nullptr);
 
 protected:
-    bool eventFilter(QObject *obj, QEvent *event);
+    bool eventFilter(QObject *obj, QEvent *event) override;
     void changeValue(int diff);
 };
 

--- a/cockatrice/src/game/board/abstract_graphics_item.h
+++ b/cockatrice/src/game/board/abstract_graphics_item.h
@@ -24,7 +24,7 @@ protected:
     void paintNumberEllipse(int number, int radius, const QColor &color, int position, int count, QPainter *painter);
 
 public:
-    AbstractGraphicsItem(QGraphicsItem *parent = nullptr) : QObject(), QGraphicsItem(parent)
+    explicit AbstractGraphicsItem(QGraphicsItem *parent = nullptr) : QGraphicsItem(parent)
     {
     }
 };

--- a/cockatrice/src/game/board/arrow_item.h
+++ b/cockatrice/src/game/board/arrow_item.h
@@ -24,17 +24,17 @@ protected:
     bool targetLocked;
     QColor color;
     bool fullColor;
-    void mousePressEvent(QGraphicsSceneMouseEvent *event);
+    void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
 
 public:
     ArrowItem(Player *_player, int _id, ArrowTarget *_startItem, ArrowTarget *_targetItem, const QColor &color);
-    ~ArrowItem();
-    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
-    QRectF boundingRect() const
+    ~ArrowItem() override;
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
+    QRectF boundingRect() const override
     {
         return path.boundingRect();
     }
-    QPainterPath shape() const
+    QPainterPath shape() const override
     {
         return path;
     }
@@ -83,8 +83,8 @@ public:
     void addChildArrow(ArrowDragItem *childArrow);
 
 protected:
-    void mouseMoveEvent(QGraphicsSceneMouseEvent *event);
-    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
+    void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
 };
 
 class ArrowAttachItem : public ArrowItem
@@ -96,12 +96,12 @@ private:
     void attachCards(CardItem *startCard, const CardItem *targetCard);
 
 public:
-    ArrowAttachItem(ArrowTarget *_startItem);
+    explicit ArrowAttachItem(ArrowTarget *_startItem);
     void addChildArrow(ArrowAttachItem *childArrow);
 
 protected:
-    void mouseMoveEvent(QGraphicsSceneMouseEvent *event);
-    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
+    void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
 };
 
 #endif // ARROWITEM_H

--- a/cockatrice/src/game/board/arrow_target.h
+++ b/cockatrice/src/game/board/arrow_target.h
@@ -19,8 +19,8 @@ private:
     QList<ArrowItem *> arrowsFrom, arrowsTo;
 
 public:
-    ArrowTarget(Player *_owner, QGraphicsItem *parent = nullptr);
-    ~ArrowTarget();
+    explicit ArrowTarget(Player *_owner, QGraphicsItem *parent = nullptr);
+    ~ArrowTarget() override;
 
     Player *getOwner() const
     {

--- a/cockatrice/src/game/board/counter_general.h
+++ b/cockatrice/src/game/board/counter_general.h
@@ -20,8 +20,8 @@ public:
                    bool useNameForShortcut = false,
                    QGraphicsItem *parent = nullptr,
                    QWidget *game = nullptr);
-    QRectF boundingRect() const;
-    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+    QRectF boundingRect() const override;
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 };
 
 #endif

--- a/cockatrice/src/game/cards/abstract_card_drag_item.h
+++ b/cockatrice/src/game/cards/abstract_card_drag_item.h
@@ -26,7 +26,7 @@ public:
         return Type;
     }
     AbstractCardDragItem(AbstractCardItem *_item, const QPointF &_hotSpot, AbstractCardDragItem *parentDrag = 0);
-    ~AbstractCardDragItem();
+    ~AbstractCardDragItem() override;
     QRectF boundingRect() const override
     {
         return QRectF(0, 0, CARD_WIDTH, CARD_HEIGHT);

--- a/cockatrice/src/game/cards/abstract_card_item.h
+++ b/cockatrice/src/game/cards/abstract_card_item.h
@@ -48,12 +48,12 @@ public:
     {
         return Type;
     }
-    AbstractCardItem(QGraphicsItem *parent = nullptr,
-                     const QString &_name = QString(),
-                     const QString &_providerId = QString(),
-                     Player *_owner = nullptr,
-                     int _id = -1);
-    ~AbstractCardItem();
+    explicit AbstractCardItem(QGraphicsItem *parent = nullptr,
+                              const QString &_name = QString(),
+                              const QString &_providerId = QString(),
+                              Player *_owner = nullptr,
+                              int _id = -1);
+    ~AbstractCardItem() override;
     QRectF boundingRect() const override;
     QPainterPath shape() const override;
     QSizeF getTranslatedSize(QPainter *painter) const;

--- a/cockatrice/src/game/cards/card_drag_item.h
+++ b/cockatrice/src/game/cards/card_drag_item.h
@@ -28,11 +28,11 @@ public:
     {
         return faceDown;
     }
-    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
-    void updatePosition(const QPointF &cursorScenePos);
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
+    void updatePosition(const QPointF &cursorScenePos) override;
 
 protected:
-    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
 };
 
 #endif

--- a/cockatrice/src/game/cards/card_item.h
+++ b/cockatrice/src/game/cards/card_item.h
@@ -46,25 +46,25 @@ public:
     {
         Type = typeCard
     };
-    int type() const
+    int type() const override
     {
         return Type;
     }
-    CardItem(Player *_owner,
-             QGraphicsItem *parent = nullptr,
-             const QString &_name = QString(),
-             const QString &_providerId = QString(),
-             int _cardid = -1,
-             bool revealedCard = false,
-             CardZone *_zone = nullptr);
-    ~CardItem();
+    explicit CardItem(Player *_owner,
+                      QGraphicsItem *parent = nullptr,
+                      const QString &_name = QString(),
+                      const QString &_providerId = QString(),
+                      int _cardid = -1,
+                      bool revealedCard = false,
+                      CardZone *_zone = nullptr);
+    ~CardItem() override;
     void retranslateUi();
     CardZone *getZone() const
     {
         return zone;
     }
     void setZone(CardZone *_zone);
-    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
     QPoint getGridPoint() const
     {
         return gridPoint;
@@ -163,10 +163,10 @@ public:
     void playCard(bool faceDown);
 
 protected:
-    void mouseMoveEvent(QGraphicsSceneMouseEvent *event);
-    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
-    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event);
-    QVariant itemChange(GraphicsItemChange change, const QVariant &value);
+    void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
+    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) override;
+    QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
 };
 
 #endif

--- a/cockatrice/src/game/cards/card_list.h
+++ b/cockatrice/src/game/cards/card_list.h
@@ -34,7 +34,7 @@ public:
         SortBySet,
         SortByPrinting
     };
-    CardList(bool _contentsKnown);
+    explicit CardList(bool _contentsKnown);
     CardItem *findCard(const int cardId) const;
     bool getContentsKnown() const
     {

--- a/cockatrice/src/game/deckview/deck_view.h
+++ b/cockatrice/src/game/deckview/deck_view.h
@@ -24,20 +24,20 @@ private:
     DeckViewCardDragItem *dragItem;
 
 public:
-    DeckViewCard(QGraphicsItem *parent = nullptr,
-                 const QString &_name = QString(),
-                 const QString &_providerId = QString(),
-                 const QString &_originZone = QString());
-    ~DeckViewCard();
-    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+    explicit DeckViewCard(QGraphicsItem *parent = nullptr,
+                          const QString &_name = QString(),
+                          const QString &_providerId = QString(),
+                          const QString &_originZone = QString());
+    ~DeckViewCard() override;
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
     const QString &getOriginZone() const
     {
         return originZone;
     }
 
 protected:
-    void mouseMoveEvent(QGraphicsSceneMouseEvent *event);
-    void hoverEnterEvent(QGraphicsSceneHoverEvent *event);
+    void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
+    void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
 };
 
 class DeckViewCardDragItem : public AbstractCardDragItem
@@ -48,10 +48,10 @@ private:
 
 public:
     DeckViewCardDragItem(DeckViewCard *_item, const QPointF &_hotSpot, AbstractCardDragItem *parentDrag = 0);
-    void updatePosition(const QPointF &cursorScenePos);
+    void updatePosition(const QPointF &cursorScenePos) override;
 
 protected:
-    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
 };
 
 class DeckViewCardContainer : public QGraphicsItem
@@ -73,13 +73,13 @@ public:
     {
         Type = typeDeckViewCardContainer
     };
-    int type() const
+    int type() const override
     {
         return Type;
     }
-    DeckViewCardContainer(const QString &_name);
-    QRectF boundingRect() const;
-    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+    explicit DeckViewCardContainer(const QString &_name);
+    QRectF boundingRect() const override;
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
     void addCard(DeckViewCard *card);
     void removeCard(DeckViewCard *card);
     const QList<DeckViewCard *> &getCards() const
@@ -113,8 +113,8 @@ private:
     void rebuildTree();
 
 public:
-    DeckViewScene(QObject *parent = nullptr);
-    ~DeckViewScene();
+    explicit DeckViewScene(QObject *parent = nullptr);
+    ~DeckViewScene() override;
     void setLocked(bool _locked)
     {
         locked = _locked;
@@ -142,7 +142,7 @@ private:
     DeckViewScene *deckViewScene;
 
 protected:
-    void resizeEvent(QResizeEvent *event);
+    void resizeEvent(QResizeEvent *event) override;
 public slots:
     void updateSceneRect(const QRectF &rect);
 signals:
@@ -150,7 +150,7 @@ signals:
     void sideboardPlanChanged();
 
 public:
-    DeckView(QWidget *parent = nullptr);
+    explicit DeckView(QWidget *parent = nullptr);
     void setDeck(const DeckList &_deck);
     void setLocked(bool _locked)
     {
@@ -160,7 +160,7 @@ public:
     {
         return deckViewScene->getSideboardPlan();
     }
-    void mouseDoubleClickEvent(QMouseEvent *event);
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
     void resetSideboardPlan();
 };
 

--- a/cockatrice/src/game/filters/filter_builder.h
+++ b/cockatrice/src/game/filters/filter_builder.h
@@ -21,8 +21,8 @@ private:
     void destroyFilter();
 
 public:
-    FilterBuilder(QWidget *parent = nullptr);
-    ~FilterBuilder();
+    explicit FilterBuilder(QWidget *parent = nullptr);
+    ~FilterBuilder() override;
 
 signals:
     void add(const CardFilter *f);

--- a/cockatrice/src/game/filters/filter_tree_model.h
+++ b/cockatrice/src/game/filters/filter_tree_model.h
@@ -28,19 +28,19 @@ private:
 
 public:
     FilterTreeModel(QObject *parent = nullptr);
-    ~FilterTreeModel();
+    ~FilterTreeModel() override;
     FilterTree *filterTree() const
     {
         return fTree;
     }
-    int rowCount(const QModelIndex &parent = QModelIndex()) const;
-    int columnCount(const QModelIndex & /*parent*/ = QModelIndex()) const;
-    QVariant data(const QModelIndex &index, int role) const;
-    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
-    Qt::ItemFlags flags(const QModelIndex &index) const;
-    QModelIndex parent(const QModelIndex &ind) const;
-    QModelIndex index(int row, int column, const QModelIndex &parent) const;
-    bool removeRows(int row, int count, const QModelIndex &parent);
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex & /*parent*/ = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+    QModelIndex parent(const QModelIndex &ind) const override;
+    QModelIndex index(int row, int column, const QModelIndex &parent) const override;
+    bool removeRows(int row, int count, const QModelIndex &parent) override;
 };
 
 #endif

--- a/cockatrice/src/game/game_scene.h
+++ b/cockatrice/src/game/game_scene.h
@@ -37,8 +37,8 @@ private:
     void updateHover(const QPointF &scenePos);
 
 public:
-    GameScene(PhasesToolbar *_phasesToolbar, QObject *parent = nullptr);
-    ~GameScene();
+    explicit GameScene(PhasesToolbar *_phasesToolbar, QObject *parent = nullptr);
+    ~GameScene() override;
     void retranslateUi();
     void processViewSizeChange(const QSize &newSize);
     QTransform getViewTransform() const;
@@ -65,8 +65,8 @@ public slots:
     void rearrange();
 
 protected:
-    bool event(QEvent *event);
-    void timerEvent(QTimerEvent *event);
+    bool event(QEvent *event) override;
+    void timerEvent(QTimerEvent *event) override;
 signals:
     void sigStartRubberBand(const QPointF &selectionOrigin);
     void sigResizeRubberBand(const QPointF &cursorPoint);

--- a/cockatrice/src/game/game_view.h
+++ b/cockatrice/src/game/game_view.h
@@ -15,7 +15,7 @@ private:
     QPointF selectionOrigin;
 
 protected:
-    void resizeEvent(QResizeEvent *event);
+    void resizeEvent(QResizeEvent *event) override;
 private slots:
     void startRubberBand(const QPointF &selectionOrigin);
     void resizeRubberBand(const QPointF &cursorPoint);
@@ -25,7 +25,7 @@ public slots:
     void updateSceneRect(const QRectF &rect);
 
 public:
-    GameView(GameScene *scene, QWidget *parent = nullptr);
+    explicit GameView(GameScene *scene, QWidget *parent = nullptr);
 };
 
 #endif

--- a/cockatrice/src/game/games_model.h
+++ b/cockatrice/src/game/games_model.h
@@ -27,16 +27,16 @@ public:
     static const int SORT_ROLE = Qt::UserRole + 1;
 
     GamesModel(const QMap<int, QString> &_rooms, const QMap<int, GameTypeMap> &_gameTypes, QObject *parent = nullptr);
-    int rowCount(const QModelIndex &parent = QModelIndex()) const
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override
     {
         return parent.isValid() ? 0 : gameList.size();
     }
-    int columnCount(const QModelIndex & /*parent*/ = QModelIndex()) const
+    int columnCount(const QModelIndex & /*parent*/ = QModelIndex()) const override
     {
         return NUM_COLS;
     }
-    QVariant data(const QModelIndex &index, int role) const;
-    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
+    QVariant data(const QModelIndex &index, int role) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
     static const QString getGameCreatedString(const int secs);
     const ServerInfo_Game &getGame(int row);
 
@@ -88,7 +88,7 @@ private:
         showOnlyIfSpectatorsCanSeeHands;
 
 public:
-    GamesProxyModel(QObject *parent = nullptr, const UserListProxy *_userListProxy = nullptr);
+    explicit GamesProxyModel(QObject *parent = nullptr, const UserListProxy *_userListProxy = nullptr);
 
     bool getShowBuddiesOnlyGames() const
     {
@@ -173,7 +173,7 @@ public:
     void refresh();
 
 protected:
-    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
     bool filterAcceptsRow(int sourceRow) const;
 };
 

--- a/cockatrice/src/game/hand_counter.h
+++ b/cockatrice/src/game/hand_counter.h
@@ -15,7 +15,7 @@ private:
     int number;
 
 protected:
-    void mousePressEvent(QGraphicsSceneMouseEvent *event);
+    void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
 public slots:
     void updateNumber();
 signals:
@@ -26,14 +26,14 @@ public:
     {
         Type = typeOther
     };
-    int type() const
+    int type() const override
     {
         return Type;
     }
-    HandCounter(QGraphicsItem *parent = nullptr);
-    ~HandCounter();
-    QRectF boundingRect() const;
-    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+    explicit HandCounter(QGraphicsItem *parent = nullptr);
+    ~HandCounter() override;
+    QRectF boundingRect() const override;
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 };
 
 #endif

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -522,7 +522,7 @@ class AnnotationDialog : public QInputDialog
     void keyPressEvent(QKeyEvent *e) override;
 
 public:
-    AnnotationDialog(QWidget *parent) : QInputDialog(parent)
+    explicit AnnotationDialog(QWidget *parent) : QInputDialog(parent)
     {
     }
 };

--- a/cockatrice/src/game/player/player_list_widget.h
+++ b/cockatrice/src/game/player/player_list_widget.h
@@ -15,16 +15,18 @@ class UserContextMenu;
 class PlayerListItemDelegate : public QStyledItemDelegate
 {
 public:
-    PlayerListItemDelegate(QObject *const parent);
-    bool
-    editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index);
+    explicit PlayerListItemDelegate(QObject *parent);
+    bool editorEvent(QEvent *event,
+                     QAbstractItemModel *model,
+                     const QStyleOptionViewItem &option,
+                     const QModelIndex &index) override;
 };
 
 class PlayerListTWI : public QTreeWidgetItem
 {
 public:
     PlayerListTWI();
-    bool operator<(const QTreeWidgetItem &other) const;
+    bool operator<(const QTreeWidgetItem &other) const override;
 };
 
 class PlayerListWidget : public QTreeWidget

--- a/cockatrice/src/game/player/player_target.h
+++ b/cockatrice/src/game/player/player_target.h
@@ -19,8 +19,8 @@ public:
                   int _value,
                   QGraphicsItem *parent = nullptr,
                   QWidget *game = nullptr);
-    QRectF boundingRect() const;
-    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+    QRectF boundingRect() const override;
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 };
 
 class PlayerTarget : public ArrowTarget
@@ -38,15 +38,15 @@ public:
     {
         Type = typePlayerTarget
     };
-    int type() const
+    int type() const override
     {
         return Type;
     }
 
-    PlayerTarget(Player *_player = nullptr, QGraphicsItem *parentItem = nullptr, QWidget *_game = nullptr);
-    ~PlayerTarget();
-    QRectF boundingRect() const;
-    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+    explicit PlayerTarget(Player *_player = nullptr, QGraphicsItem *parentItem = nullptr, QWidget *_game = nullptr);
+    ~PlayerTarget() override;
+    QRectF boundingRect() const override;
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
     AbstractCounter *addCounter(int _counterId, const QString &_name, int _value);
 };

--- a/cockatrice/src/game/zones/card_zone.h
+++ b/cockatrice/src/game/zones/card_zone.h
@@ -37,8 +37,8 @@ protected:
     bool isShufflable;
     bool isView;
     bool alwaysRevealTopCard;
-    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event);
-    void mousePressEvent(QGraphicsSceneMouseEvent *event);
+    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) override;
+    void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
     virtual void addCardImpl(CardItem *card, int x, int y) = 0;
 signals:
     void cardCountChanged();
@@ -54,7 +54,7 @@ public:
     {
         Type = typeZone
     };
-    int type() const
+    int type() const override
     {
         return Type;
     }

--- a/cockatrice/src/game/zones/hand_zone.h
+++ b/cockatrice/src/game/zones/hand_zone.h
@@ -15,14 +15,14 @@ public slots:
 
 public:
     HandZone(Player *_p, bool _contentsKnown, int _zoneHeight, QGraphicsItem *parent = nullptr);
-    void handleDropEvent(const QList<CardDragItem *> &dragItems, CardZone *startZone, const QPoint &dropPoint);
-    QRectF boundingRect() const;
-    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
-    void reorganizeCards();
+    void handleDropEvent(const QList<CardDragItem *> &dragItems, CardZone *startZone, const QPoint &dropPoint) override;
+    QRectF boundingRect() const override;
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
+    void reorganizeCards() override;
     void setWidth(qreal _width);
 
 protected:
-    void addCardImpl(CardItem *card, int x, int y);
+    void addCardImpl(CardItem *card, int x, int y) override;
 };
 
 #endif

--- a/cockatrice/src/game/zones/select_zone.h
+++ b/cockatrice/src/game/zones/select_zone.h
@@ -16,9 +16,9 @@ private:
     QSet<CardItem *> cardsInSelectionRect;
 
 protected:
-    void mouseMoveEvent(QGraphicsSceneMouseEvent *event);
-    void mousePressEvent(QGraphicsSceneMouseEvent *event);
-    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
+    void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
+    void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
 
 public:
     SelectZone(Player *_player,

--- a/cockatrice/src/game/zones/stack_zone.h
+++ b/cockatrice/src/game/zones/stack_zone.h
@@ -13,13 +13,13 @@ private slots:
 
 public:
     StackZone(Player *_p, int _zoneHeight, QGraphicsItem *parent = nullptr);
-    void handleDropEvent(const QList<CardDragItem *> &dragItems, CardZone *startZone, const QPoint &dropPoint);
-    QRectF boundingRect() const;
-    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
-    void reorganizeCards();
+    void handleDropEvent(const QList<CardDragItem *> &dragItems, CardZone *startZone, const QPoint &dropPoint) override;
+    QRectF boundingRect() const override;
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
+    void reorganizeCards() override;
 
 protected:
-    void addCardImpl(CardItem *card, int x, int y);
+    void addCardImpl(CardItem *card, int x, int y) override;
 };
 
 #endif

--- a/cockatrice/src/game/zones/table_zone.h
+++ b/cockatrice/src/game/zones/table_zone.h
@@ -89,7 +89,7 @@ public slots:
     /**
        Reorganizes CardItems in the TableZone
      */
-    void reorganizeCards();
+    void reorganizeCards() override;
 
 public:
     /**
@@ -98,12 +98,12 @@ public:
        @param _p the Player
        @param parent defaults to null
      */
-    TableZone(Player *_p, QGraphicsItem *parent = nullptr);
+    explicit TableZone(Player *_p, QGraphicsItem *parent = nullptr);
 
     /**
        @return a QRectF of the TableZone bounding box.
      */
-    QRectF boundingRect() const;
+    QRectF boundingRect() const override;
 
     /**
        Render the TableZone
@@ -111,7 +111,7 @@ public:
        @param painter
        @param option
      */
-    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
     /**
        Toggles the selected items as tapped.
@@ -121,7 +121,7 @@ public:
     /**
        See HandleDropEventByGrid
      */
-    void handleDropEvent(const QList<CardDragItem *> &dragItems, CardZone *startZone, const QPoint &dropPoint);
+    void handleDropEvent(const QList<CardDragItem *> &dragItems, CardZone *startZone, const QPoint &dropPoint) override;
 
     /**
        Handles the placement of cards
@@ -138,7 +138,7 @@ public:
      */
     CardItem *getCardFromCoords(const QPointF &point) const;
 
-    QPointF closestGridPoint(const QPointF &point);
+    QPointF closestGridPoint(const QPointF &point) override;
 
     static int clampValidTableRow(const int row);
 
@@ -150,7 +150,7 @@ public:
        @param canResize defaults to true
        @return CardItem that has been removed
      */
-    CardItem *takeCard(int position, int cardId, bool canResize = true);
+    CardItem *takeCard(int position, int cardId, bool canResize = true) override;
 
     /**
        Resizes the TableZone in case CardItems are within or
@@ -178,7 +178,7 @@ public:
     }
 
 protected:
-    void addCardImpl(CardItem *card, int x, int y);
+    void addCardImpl(CardItem *card, int x, int y) override;
 
 private:
     void paintZoneOutline(QPainter *painter);

--- a/cockatrice/src/game/zones/view_zone.h
+++ b/cockatrice/src/game/zones/view_zone.h
@@ -33,7 +33,6 @@ private:
 
     QRectF bRect, optimumRect;
     int minRows, numberCards;
-    void handleDropEvent(const QList<CardDragItem *> &dragItems, CardZone *startZone, const QPoint &dropPoint);
     CardZone *origZone;
     bool revealZone, writeableRevealZone;
     CardList::SortOption groupBy, sortBy;
@@ -57,6 +56,8 @@ private:
 
     GridSize positionCardsForDisplay(CardList &cards, CardList::SortOption pileOption = CardList::NoSort);
 
+    void handleDropEvent(const QList<CardDragItem *> &dragItems, CardZone *startZone, const QPoint &dropPoint) override;
+
 public:
     ZoneViewZone(Player *_p,
                  CardZone *_origZone,
@@ -65,16 +66,16 @@ public:
                  bool _writeableRevealZone = false,
                  QGraphicsItem *parent = nullptr,
                  bool _isReversed = false);
-    QRectF boundingRect() const;
-    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
-    void reorganizeCards();
+    QRectF boundingRect() const override;
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
+    void reorganizeCards() override;
     void initializeCards(const QList<const ServerInfo_Card *> &cardList = QList<const ServerInfo_Card *>());
     void removeCard(int position);
     int getNumberCards() const
     {
         return numberCards;
     }
-    void setGeometry(const QRectF &rect);
+    void setGeometry(const QRectF &rect) override;
     QRectF getOptimumRect() const
     {
         return optimumRect;
@@ -105,9 +106,9 @@ signals:
     void wheelEventReceived(QGraphicsSceneWheelEvent *event);
 
 protected:
-    void addCardImpl(CardItem *card, int x, int y);
-    QSizeF sizeHint(Qt::SizeHint which, const QSizeF &constraint = QSizeF()) const;
-    void wheelEvent(QGraphicsSceneWheelEvent *event);
+    void addCardImpl(CardItem *card, int x, int y) override;
+    QSizeF sizeHint(Qt::SizeHint which, const QSizeF &constraint = QSizeF()) const override;
+    void wheelEvent(QGraphicsSceneWheelEvent *event) override;
 };
 
 #endif

--- a/cockatrice/src/game/zones/view_zone_widget.h
+++ b/cockatrice/src/game/zones/view_zone_widget.h
@@ -66,8 +66,8 @@ private slots:
     void resizeToZoneContents();
     void handleScrollBarChange(int value);
     void zoneDeleted();
-    void moveEvent(QGraphicsSceneMoveEvent * /* event */);
-    void resizeEvent(QGraphicsSceneResizeEvent * /* event */);
+    void moveEvent(QGraphicsSceneMoveEvent * /* event */) override;
+    void resizeEvent(QGraphicsSceneResizeEvent * /* event */) override;
 
 public:
     ZoneViewWidget(Player *_player,
@@ -88,8 +88,8 @@ public:
     void retranslateUi();
 
 protected:
-    void closeEvent(QCloseEvent *event);
-    void initStyleOption(QStyleOption *option) const;
+    void closeEvent(QCloseEvent *event) override;
+    void initStyleOption(QStyleOption *option) const override;
 };
 
 #endif


### PR DESCRIPTION
## Short roundup of the initial problem

A lot of classes don't have override specifiers on overridden methods. Then when I add a new method and put the override specifier, CI fails due to `Werror inconsistent overrides`, forcing me to put override on all overridden methods in that class.

We should do a big cleanup of all the classes at once, so that we don't have override specifier fixes polluting other PRs.

## What will change with this Pull Request?

Added override and explicit specifiers to all classes in `src/game`.