### PR TITLE
don't autoclose card view if single card gets dragged into same zone

### DIFF
--- a/cockatrice/src/game/zones/card_zone.cpp
+++ b/cockatrice/src/game/zones/card_zone.cpp
@@ -173,7 +173,7 @@ CardItem *CardZone::getCard(int cardId, const QString &cardName)
     return c;
 }
 
-CardItem *CardZone::takeCard(int position, int cardId, bool /*canResize*/)
+CardItem *CardZone::takeCard(int position, int cardId, bool toNewZone)
 {
     if (position == -1) {
         // position == -1 means either that the zone is indexed by card id

--- a/cockatrice/src/game/zones/card_zone.cpp
+++ b/cockatrice/src/game/zones/card_zone.cpp
@@ -190,7 +190,7 @@ CardItem *CardZone::takeCard(int position, int cardId, bool toNewZone)
         return nullptr;
 
     for (auto *view : views) {
-        view->removeCard(position);
+        view->removeCard(position, toNewZone);
     }
 
     CardItem *c = cards.takeAt(position);

--- a/cockatrice/src/game/zones/table_zone.cpp
+++ b/cockatrice/src/game/zones/table_zone.cpp
@@ -244,10 +244,10 @@ void TableZone::toggleTapped()
     player->sendGameCommand(player->prepareGameCommand(cmdList));
 }
 
-CardItem *TableZone::takeCard(int position, int cardId, bool canResize)
+CardItem *TableZone::takeCard(int position, int cardId, bool toNewZone)
 {
     CardItem *result = CardZone::takeCard(position, cardId);
-    if (canResize)
+    if (toNewZone)
         resizeToContents();
     return result;
 }

--- a/cockatrice/src/game/zones/table_zone.h
+++ b/cockatrice/src/game/zones/table_zone.h
@@ -147,10 +147,10 @@ public:
 
        @param position card position
        @param cardId id of card to take
-       @param canResize defaults to true
+       @param toNewZone Whether the destination of the card is not the same as the starting zone. Defaults to true
        @return CardItem that has been removed
      */
-    CardItem *takeCard(int position, int cardId, bool canResize = true) override;
+    CardItem *takeCard(int position, int cardId, bool toNewZone = true) override;
 
     /**
        Resizes the TableZone in case CardItems are within or

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -315,6 +315,11 @@ bool ZoneViewZone::prepareAddCard(int x)
         }
     }
 
+    // autoclose check is done both here and in removeCard
+    if (cards.isEmpty() && !doInsert && SettingsCache::instance().getCloseEmptyCardView()) {
+        close();
+    }
+
     return doInsert;
 }
 
@@ -382,7 +387,11 @@ void ZoneViewZone::removeCard(int position, bool toNewZone)
     CardItem *card = cards.takeAt(position);
     card->deleteLater();
 
-    if (cards.isEmpty() && SettingsCache::instance().getCloseEmptyCardView()) {
+    // The toNewZone check is to prevent the view from auto-closing if the view contains only a single card and that
+    // card gets dragged within the view.
+    // Another autoclose check is done in prepareAddCard so that the view autocloses if the last card was moved to an
+    // unrevealed portion of the same zone.
+    if (cards.isEmpty() && SettingsCache::instance().getCloseEmptyCardView() && toNewZone) {
         close();
         return;
     }

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -365,7 +365,7 @@ void ZoneViewZone::handleDropEvent(const QList<CardDragItem *> &dragItems,
     player->sendGameCommand(cmd);
 }
 
-void ZoneViewZone::removeCard(int position)
+void ZoneViewZone::removeCard(int position, bool toNewZone)
 {
     if (isReversed) {
         position -= cards.first()->getId();

--- a/cockatrice/src/game/zones/view_zone.h
+++ b/cockatrice/src/game/zones/view_zone.h
@@ -71,7 +71,7 @@ public:
     void reorganizeCards() override;
     void initializeCards(const QList<const ServerInfo_Card *> &cardList = QList<const ServerInfo_Card *>());
     bool prepareAddCard(int x);
-    void removeCard(int position);
+    void removeCard(int position, bool toNewZone);
     int getNumberCards() const
     {
         return numberCards;


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5502

## Short roundup of the initial problem

As noted in the previous PR, when only a single card is in the zone view, dragging the card into the same zone will cause the window to close.

## What will change with this Pull Request?

Don't autoclose the window if the card is dragged into the same zone

https://github.com/user-attachments/assets/df2ff434-c0e7-4e7d-8c60-29d63b199de0

- Renamed `CardZone::takeCard`'s `canResize` param to `toNewZone`, since all calls to `takeCard` seem to be passing that value as that param anyways
- `ZoneViewZone::removeCard` now takes `toNewZone`
- Added some extra logic around the autoclose check so that it doesn't close when a single card is dragged into the same view
