### PR TITLE
Allow offline Deck Storage tab

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_storage.h
+++ b/cockatrice/src/client/tabs/tab_deck_storage.h
@@ -2,8 +2,10 @@
 #define TAB_DECK_STORAGE_H
 
 #include "../../server/remote/remote_decklist_tree_widget.h"
+#include "../game_logic/abstract_client.h"
 #include "tab.h"
 
+class ServerInfo_User;
 class AbstractClient;
 class QTreeView;
 class QFileSystemModel;
@@ -31,12 +33,17 @@ private:
     QAction *aOpenRemoteDeck, *aDownload, *aNewFolder, *aDeleteRemoteDeck;
     QString getTargetPath() const;
 
+    void setRemoteEnabled(bool enabled);
+
     void uploadDeck(const QString &filePath, const QString &targetPath);
     void deleteRemoteDeck(const RemoteDeckList_TreeModel::Node *node);
 
     void downloadNodeAtIndex(const QModelIndex &curLeft, const QModelIndex &curRight);
 
 private slots:
+    void handleConnected(const ServerInfo_User &userInfo);
+    void handleConnectionChanged(ClientStatus status);
+
     void actLocalDoubleClick(const QModelIndex &curLeft);
     void actOpenLocalDeck();
 
@@ -63,7 +70,7 @@ private slots:
     void deleteDeckFinished(const Response &response, const CommandContainer &commandContainer);
 
 public:
-    TabDeckStorage(TabSupervisor *_tabSupervisor, AbstractClient *_client);
+    TabDeckStorage(TabSupervisor *_tabSupervisor, AbstractClient *_client, const ServerInfo_User *currentUserInfo);
     void retranslateUi() override;
     QString getTabText() const override
     {

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -279,6 +279,7 @@ void TabSupervisor::initStartupTabs()
     addDeckEditorTab(nullptr);
 
     checkAndTrigger(aTabVisualDeckStorage, SettingsCache::instance().getTabVisualDeckStorageOpen());
+    checkAndTrigger(aTabDeckStorage, SettingsCache::instance().getTabDeckStorageOpen());
 }
 
 /**
@@ -334,6 +335,7 @@ void TabSupervisor::resetTabsMenu()
     tabsMenu->addAction(aTabDeckEditor);
     tabsMenu->addSeparator();
     tabsMenu->addAction(aTabVisualDeckStorage);
+    tabsMenu->addAction(aTabDeckStorage);
 }
 
 void TabSupervisor::start(const ServerInfo_User &_userInfo)
@@ -355,10 +357,8 @@ void TabSupervisor::start(const ServerInfo_User &_userInfo)
     updatePingTime(0, -1);
 
     if (userInfo->user_level() & ServerInfo_User::IsRegistered) {
-        tabsMenu->addAction(aTabDeckStorage);
         tabsMenu->addAction(aTabReplays);
 
-        checkAndTrigger(aTabDeckStorage, SettingsCache::instance().getTabDeckStorageOpen());
         checkAndTrigger(aTabReplays, SettingsCache::instance().getTabReplaysOpen());
     }
 
@@ -379,7 +379,6 @@ void TabSupervisor::startLocal(const QList<AbstractClient *> &_clients)
     resetTabsMenu();
 
     tabAccount = nullptr;
-    tabDeckStorage = nullptr;
     tabReplays = nullptr;
     tabAdmin = nullptr;
     tabLog = nullptr;
@@ -415,9 +414,6 @@ void TabSupervisor::stop()
         }
         if (tabServer) {
             tabServer->closeRequest(true);
-        }
-        if (tabDeckStorage) {
-            tabDeckStorage->closeRequest(true);
         }
         if (tabReplays) {
             tabReplays->closeRequest(true);

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -504,7 +504,7 @@ void TabSupervisor::actTabDeckStorage(bool checked)
 {
     SettingsCache::instance().setTabDeckStorageOpen(checked);
     if (checked && !tabDeckStorage) {
-        tabDeckStorage = new TabDeckStorage(this, client);
+        tabDeckStorage = new TabDeckStorage(this, client, userInfo);
         connect(tabDeckStorage, &TabDeckStorage::openDeckEditor, this, &TabSupervisor::addDeckEditorTab);
         myAddTab(tabDeckStorage, aTabDeckStorage);
         connect(tabDeckStorage, &Tab::closed, this, [this] {

--- a/cockatrice/src/server/remote/remote_decklist_tree_widget.cpp
+++ b/cockatrice/src/server/remote/remote_decklist_tree_widget.cpp
@@ -270,15 +270,18 @@ void RemoteDeckList_TreeModel::refreshTree()
     client->sendCommand(pend);
 }
 
+void RemoteDeckList_TreeModel::clearTree()
+{
+    beginResetModel();
+    root->clearTree();
+    endResetModel();
+}
+
 void RemoteDeckList_TreeModel::deckListFinished(const Response &r)
 {
     const Response_DeckList &resp = r.GetExtension(Response_DeckList::ext);
 
-    beginResetModel();
-
-    root->clearTree();
-
-    endResetModel();
+    clearTree();
 
     ServerInfo_DeckStorage_TreeItem tempRoot;
     tempRoot.set_id(0);
@@ -360,4 +363,9 @@ void RemoteDeckList_TreeWidget::removeNode(RemoteDeckList_TreeModel::Node *node)
 void RemoteDeckList_TreeWidget::refreshTree()
 {
     treeModel->refreshTree();
+}
+
+void RemoteDeckList_TreeWidget::clearTree()
+{
+    treeModel->clearTree();
 }

--- a/cockatrice/src/server/remote/remote_decklist_tree_widget.h
+++ b/cockatrice/src/server/remote/remote_decklist_tree_widget.h
@@ -106,6 +106,7 @@ public:
     DirectoryNode *addNamedFolderToTree(const QString &name, DirectoryNode *parent);
     void removeNode(Node *node);
     void refreshTree();
+    void clearTree();
 };
 
 class RemoteDeckList_TreeWidget : public QTreeView
@@ -127,6 +128,7 @@ public:
     void addFolderToTree(const QString &name, RemoteDeckList_TreeModel::DirectoryNode *parent);
     void removeNode(RemoteDeckList_TreeModel::Node *node);
     void refreshTree();
+    void clearTree();
 };
 
 #endif


### PR DESCRIPTION
## Short roundup of the initial problem

There's no reason the local side of the deck storage and replay tabs can't be perfectly functional while offline.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/9a35fe4b-8c1a-483d-9283-cb8ec98d8da8

- Made `Deck storage` tab an always available tab
  - Moved it to the section of the tab menu that `Visual deck storage` is in
- When disconnected, the remote-only actions will be disabled 
- Update right side on connect/disconnect so that it clears on disconnect and populates on connect
  - Only enables if user is registered (same behavior as before)

## Screenshots

<img width="500" alt="Screenshot 2025-01-24 at 2 46 25 AM" src="https://github.com/user-attachments/assets/7fcdc95d-78f9-4b9e-b5f1-216054b67869" />

<img width="259" alt="Screenshot 2025-01-24 at 2 45 37 AM" src="https://github.com/user-attachments/assets/f9c9b3c8-da5a-4cf1-b283-f07f0a85bf61" />

