### PR TITLE
Allow offline Replays tab

### DIFF
--- a/cockatrice/src/client/tabs/tab_replays.h
+++ b/cockatrice/src/client/tabs/tab_replays.h
@@ -1,8 +1,10 @@
 #ifndef TAB_REPLAYS_H
 #define TAB_REPLAYS_H
 
+#include "../game_logic/abstract_client.h"
 #include "tab.h"
 
+class ServerInfo_User;
 class Response;
 class AbstractClient;
 class QTreeView;
@@ -29,9 +31,14 @@ private:
     QAction *aOpenReplaysFolder;
     QAction *aOpenRemoteReplay, *aDownload, *aKeep, *aDeleteRemoteReplay;
 
+    void setRemoteEnabled(bool enabled);
+
     void downloadNodeAtIndex(const QModelIndex &curLeft, const QModelIndex &curRight);
 
 private slots:
+    void handleConnected(const ServerInfo_User &userInfo);
+    void handleConnectionChanged(ClientStatus status);
+
     void actLocalDoubleClick(const QModelIndex &curLeft);
     void actRenameLocal();
     void actOpenLocalReplay();
@@ -58,7 +65,7 @@ signals:
     void openReplay(GameReplay *replay);
 
 public:
-    TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client);
+    TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client, const ServerInfo_User *currentUserInfo);
     void retranslateUi() override;
     QString getTabText() const override
     {

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -512,7 +512,7 @@ void TabSupervisor::actTabReplays(bool checked)
 {
     SettingsCache::instance().setTabReplaysOpen(checked);
     if (checked && !tabReplays) {
-        tabReplays = new TabReplays(this, client);
+        tabReplays = new TabReplays(this, client, userInfo);
         connect(tabReplays, &TabReplays::openReplay, this, &TabSupervisor::openReplay);
         myAddTab(tabReplays, aTabReplays);
         connect(tabReplays, &Tab::closed, this, [this] {

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -280,6 +280,7 @@ void TabSupervisor::initStartupTabs()
 
     checkAndTrigger(aTabVisualDeckStorage, SettingsCache::instance().getTabVisualDeckStorageOpen());
     checkAndTrigger(aTabDeckStorage, SettingsCache::instance().getTabDeckStorageOpen());
+    checkAndTrigger(aTabReplays, SettingsCache::instance().getTabReplaysOpen());
 }
 
 /**
@@ -336,6 +337,7 @@ void TabSupervisor::resetTabsMenu()
     tabsMenu->addSeparator();
     tabsMenu->addAction(aTabVisualDeckStorage);
     tabsMenu->addAction(aTabDeckStorage);
+    tabsMenu->addAction(aTabReplays);
 }
 
 void TabSupervisor::start(const ServerInfo_User &_userInfo)
@@ -356,12 +358,6 @@ void TabSupervisor::start(const ServerInfo_User &_userInfo)
 
     updatePingTime(0, -1);
 
-    if (userInfo->user_level() & ServerInfo_User::IsRegistered) {
-        tabsMenu->addAction(aTabReplays);
-
-        checkAndTrigger(aTabReplays, SettingsCache::instance().getTabReplaysOpen());
-    }
-
     if (userInfo->user_level() & ServerInfo_User::IsModerator) {
         tabsMenu->addSeparator();
         tabsMenu->addAction(aTabAdmin);
@@ -379,7 +375,6 @@ void TabSupervisor::startLocal(const QList<AbstractClient *> &_clients)
     resetTabsMenu();
 
     tabAccount = nullptr;
-    tabReplays = nullptr;
     tabAdmin = nullptr;
     tabLog = nullptr;
     isLocalGame = true;
@@ -414,9 +409,6 @@ void TabSupervisor::stop()
         }
         if (tabServer) {
             tabServer->closeRequest(true);
-        }
-        if (tabReplays) {
-            tabReplays->closeRequest(true);
         }
         if (tabAdmin) {
             tabAdmin->closeRequest(true);

--- a/cockatrice/src/server/remote/remote_replay_list_tree_widget.cpp
+++ b/cockatrice/src/server/remote/remote_replay_list_tree_widget.cpp
@@ -43,7 +43,7 @@ RemoteReplayList_TreeModel::RemoteReplayList_TreeModel(AbstractClient *_client, 
 
 RemoteReplayList_TreeModel::~RemoteReplayList_TreeModel()
 {
-    clearTree();
+    clearAll();
 }
 
 int RemoteReplayList_TreeModel::rowCount(const QModelIndex &parent) const
@@ -242,7 +242,10 @@ ServerInfo_ReplayMatch const *RemoteReplayList_TreeModel::getEnclosingReplayMatc
     return &node->getMatchInfo();
 }
 
-void RemoteReplayList_TreeModel::clearTree()
+/**
+ * Deletes all items in the model
+ */
+void RemoteReplayList_TreeModel::clearAll()
 {
     for (int i = 0; i < replayMatches.size(); ++i)
         delete replayMatches[i];
@@ -256,6 +259,13 @@ void RemoteReplayList_TreeModel::refreshTree()
             SLOT(replayListFinished(const Response &)));
 
     client->sendCommand(pend);
+}
+
+void RemoteReplayList_TreeModel::clearTree()
+{
+    beginResetModel();
+    clearAll();
+    endResetModel();
 }
 
 void RemoteReplayList_TreeModel::addMatchInfo(const ServerInfo_ReplayMatch &matchInfo)
@@ -294,7 +304,7 @@ void RemoteReplayList_TreeModel::replayListFinished(const Response &r)
     const Response_ReplayList &resp = r.GetExtension(Response_ReplayList::ext);
 
     beginResetModel();
-    clearTree();
+    clearAll();
 
     for (int i = 0; i < resp.match_list_size(); ++i)
         replayMatches.append(new MatchNode(resp.match_list(i)));

--- a/cockatrice/src/server/remote/remote_replay_list_tree_widget.h
+++ b/cockatrice/src/server/remote/remote_replay_list_tree_widget.h
@@ -73,7 +73,7 @@ private:
     QList<MatchNode *> replayMatches;
 
     QIcon dirIcon, fileIcon, lockIcon;
-    void clearTree();
+    void clearAll();
 
     static const int numberOfColumns;
 signals:
@@ -94,6 +94,7 @@ public:
     QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const;
     QModelIndex parent(const QModelIndex &index) const;
     Qt::ItemFlags flags(const QModelIndex &index) const;
+    void clearTree();
     void refreshTree();
     ServerInfo_Replay const *getReplay(const QModelIndex &index) const;
     ServerInfo_ReplayMatch const *getReplayMatch(const QModelIndex &index) const;
@@ -115,6 +116,10 @@ public:
     ServerInfo_ReplayMatch const *getReplayMatch(const QModelIndex &ind) const;
     QList<ServerInfo_Replay const *> getSelectedReplays() const;
     QSet<ServerInfo_ReplayMatch const *> getSelectedReplayMatches() const;
+    void clearTree()
+    {
+        treeModel->clearTree();
+    }
     void refreshTree()
     {
         treeModel->refreshTree();


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5518

## Short roundup of the initial problem

There's no reason the local side of the deck storage and replay tabs can't be perfectly functional while offline.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/5a75ad1b-43ff-4b03-b722-a93a265a89cc

- Made `Game replays` tab an always available tab
  - Moved it to the section of the tab menu that `Visual deck storage` is in
- When disconnected, the remote-only actions will be disabled 
- Update right side on connect/disconnect so that it clears on disconnect and populates on connect
  - Only enables if user is registered (same behavior as before)

## Screenshots
<img width="1435" alt="Screenshot 2025-01-24 at 8 48 06 PM" src="https://github.com/user-attachments/assets/bf3d8cc4-4a5d-4977-a0ce-d62c767367e4" />

<img width="246" alt="Screenshot 2025-01-24 at 8 48 14 PM" src="https://github.com/user-attachments/assets/aa7eea02-c814-4a16-b329-2190cfea13c5" />


