### PR TITLE
Invert "Show" games, so all games are visible by default

### DIFF
--- a/cockatrice/src/dialogs/dlg_filter_games.cpp
+++ b/cockatrice/src/dialogs/dlg_filter_games.cpp
@@ -24,19 +24,19 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
                   {QTime(1, 0), tr("1 hour")},
                   {QTime(2, 0), tr("2 hours")}})
 {
-    showBuddiesOnlyGames = new QCheckBox(tr("Show '&buddies only' games"));
+    showBuddiesOnlyGames = new QCheckBox(tr("Hide 'buddies only' games"));
     showBuddiesOnlyGames->setChecked(gamesProxyModel->getShowBuddiesOnlyGames());
 
-    showFullGames = new QCheckBox(tr("Show &full games"));
+    showFullGames = new QCheckBox(tr("Hide full games"));
     showFullGames->setChecked(gamesProxyModel->getShowFullGames());
 
-    showGamesThatStarted = new QCheckBox(tr("Show games &that have started"));
+    showGamesThatStarted = new QCheckBox(tr("Hide games that have started"));
     showGamesThatStarted->setChecked(gamesProxyModel->getShowGamesThatStarted());
 
-    showPasswordProtectedGames = new QCheckBox(tr("Show &password protected games"));
+    showPasswordProtectedGames = new QCheckBox(tr("Hide password protected games"));
     showPasswordProtectedGames->setChecked(gamesProxyModel->getShowPasswordProtectedGames());
 
-    hideIgnoredUserGames = new QCheckBox(tr("Hide '&ignored user' games"));
+    hideIgnoredUserGames = new QCheckBox(tr("Hide 'ignored user' games"));
     hideIgnoredUserGames->setChecked(gamesProxyModel->getHideIgnoredUserGames());
 
     maxGameAgeComboBox = new QComboBox();

--- a/cockatrice/src/dialogs/dlg_filter_games.cpp
+++ b/cockatrice/src/dialogs/dlg_filter_games.cpp
@@ -6,12 +6,10 @@
 #include <QDialogButtonBox>
 #include <QGridLayout>
 #include <QGroupBox>
-#include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
 #include <QSpinBox>
-#include <QVBoxLayout>
 
 DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
                                const GamesProxyModel *_gamesProxyModel,
@@ -24,17 +22,17 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
                   {QTime(1, 0), tr("1 hour")},
                   {QTime(2, 0), tr("2 hours")}})
 {
-    showBuddiesOnlyGames = new QCheckBox(tr("Hide 'buddies only' games"));
-    showBuddiesOnlyGames->setChecked(gamesProxyModel->getShowBuddiesOnlyGames());
+    hideBuddiesOnlyGames = new QCheckBox(tr("Hide 'buddies only' games"));
+    hideBuddiesOnlyGames->setChecked(gamesProxyModel->getHideBuddiesOnlyGames());
 
-    showFullGames = new QCheckBox(tr("Hide full games"));
-    showFullGames->setChecked(gamesProxyModel->getShowFullGames());
+    hideFullGames = new QCheckBox(tr("Hide full games"));
+    hideFullGames->setChecked(gamesProxyModel->getHideFullGames());
 
-    showGamesThatStarted = new QCheckBox(tr("Hide games that have started"));
-    showGamesThatStarted->setChecked(gamesProxyModel->getShowGamesThatStarted());
+    hideGamesThatStarted = new QCheckBox(tr("Hide games that have started"));
+    hideGamesThatStarted->setChecked(gamesProxyModel->getHideGamesThatStarted());
 
-    showPasswordProtectedGames = new QCheckBox(tr("Hide password protected games"));
-    showPasswordProtectedGames->setChecked(gamesProxyModel->getShowPasswordProtectedGames());
+    hidePasswordProtectedGames = new QCheckBox(tr("Hide password protected games"));
+    hidePasswordProtectedGames->setChecked(gamesProxyModel->getHidePasswordProtectedGames());
 
     hideIgnoredUserGames = new QCheckBox(tr("Hide 'ignored user' games"));
     hideIgnoredUserGames->setChecked(gamesProxyModel->getHideIgnoredUserGames());
@@ -108,10 +106,10 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     maxPlayersGroupBox->setLayout(maxPlayersFilterLayout);
 
     auto *restrictionsLayout = new QGridLayout;
-    restrictionsLayout->addWidget(showFullGames, 0, 0);
-    restrictionsLayout->addWidget(showGamesThatStarted, 1, 0);
-    restrictionsLayout->addWidget(showPasswordProtectedGames, 2, 0);
-    restrictionsLayout->addWidget(showBuddiesOnlyGames, 3, 0);
+    restrictionsLayout->addWidget(hideFullGames, 0, 0);
+    restrictionsLayout->addWidget(hideGamesThatStarted, 1, 0);
+    restrictionsLayout->addWidget(hidePasswordProtectedGames, 2, 0);
+    restrictionsLayout->addWidget(hideBuddiesOnlyGames, 3, 0);
     restrictionsLayout->addWidget(hideIgnoredUserGames, 4, 0);
 
     auto *restrictionsGroupBox = new QGroupBox(tr("Restrictions"));
@@ -185,34 +183,24 @@ void DlgFilterGames::toggleSpectatorCheckboxEnabledness(bool spectatorsEnabled)
     showOnlyIfSpectatorsCanSeeHands->setDisabled(!spectatorsEnabled);
 }
 
-bool DlgFilterGames::getShowFullGames() const
+bool DlgFilterGames::getHideFullGames() const
 {
-    return showFullGames->isChecked();
+    return hideFullGames->isChecked();
 }
 
-bool DlgFilterGames::getShowGamesThatStarted() const
+bool DlgFilterGames::getHideGamesThatStarted() const
 {
-    return showGamesThatStarted->isChecked();
+    return hideGamesThatStarted->isChecked();
 }
 
-bool DlgFilterGames::getShowBuddiesOnlyGames() const
+bool DlgFilterGames::getHideBuddiesOnlyGames() const
 {
-    return showBuddiesOnlyGames->isChecked();
+    return hideBuddiesOnlyGames->isChecked();
 }
 
-void DlgFilterGames::setShowBuddiesOnlyGames(bool _showBuddiesOnlyGames)
+bool DlgFilterGames::getHidePasswordProtectedGames() const
 {
-    showBuddiesOnlyGames->setChecked(_showBuddiesOnlyGames);
-}
-
-bool DlgFilterGames::getShowPasswordProtectedGames() const
-{
-    return showPasswordProtectedGames->isChecked();
-}
-
-void DlgFilterGames::setShowPasswordProtectedGames(bool _passwordProtectedGamesHidden)
-{
-    showPasswordProtectedGames->setChecked(_passwordProtectedGamesHidden);
+    return hidePasswordProtectedGames->isChecked();
 }
 
 bool DlgFilterGames::getHideIgnoredUserGames() const
@@ -220,29 +208,14 @@ bool DlgFilterGames::getHideIgnoredUserGames() const
     return hideIgnoredUserGames->isChecked();
 }
 
-void DlgFilterGames::setHideIgnoredUserGames(bool _hideIgnoredUserGames)
-{
-    hideIgnoredUserGames->setChecked(_hideIgnoredUserGames);
-}
-
 QString DlgFilterGames::getGameNameFilter() const
 {
     return gameNameFilterEdit->text();
 }
 
-void DlgFilterGames::setGameNameFilter(const QString &_gameNameFilter)
-{
-    gameNameFilterEdit->setText(_gameNameFilter);
-}
-
 QString DlgFilterGames::getCreatorNameFilter() const
 {
     return creatorNameFilterEdit->text();
-}
-
-void DlgFilterGames::setCreatorNameFilter(const QString &_creatorNameFilter)
-{
-    creatorNameFilterEdit->setText(_creatorNameFilter);
 }
 
 QSet<int> DlgFilterGames::getGameTypeFilter() const
@@ -255,15 +228,6 @@ QSet<int> DlgFilterGames::getGameTypeFilter() const
             result.insert(i.key());
     }
     return result;
-}
-
-void DlgFilterGames::setGameTypeFilter(const QSet<int> &_gameTypeFilter)
-{
-    QMapIterator<int, QCheckBox *> i(gameTypeFilterCheckBoxes);
-    while (i.hasNext()) {
-        i.next();
-        i.value()->setChecked(_gameTypeFilter.contains(i.key()));
-    }
 }
 
 int DlgFilterGames::getMaxPlayersFilterMin() const
@@ -283,13 +247,6 @@ QTime DlgFilterGames::getMaxGameAge() const
         return gamesProxyModel->getMaxGameAge();   // leave the setting unchanged
     }
     return gameAgeMap.keys().at(index);
-}
-
-void DlgFilterGames::setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlayersFilterMax)
-{
-    maxPlayersFilterMinSpinBox->setValue(_maxPlayersFilterMin);
-    maxPlayersFilterMaxSpinBox->setValue(_maxPlayersFilterMax == -1 ? maxPlayersFilterMaxSpinBox->maximum()
-                                                                    : _maxPlayersFilterMax);
 }
 
 bool DlgFilterGames::getShowOnlyIfSpectatorsCanWatch() const

--- a/cockatrice/src/dialogs/dlg_filter_games.h
+++ b/cockatrice/src/dialogs/dlg_filter_games.h
@@ -21,10 +21,10 @@ class DlgFilterGames : public QDialog
     Q_OBJECT
 private:
     QGroupBox *generalGroupBox;
-    QCheckBox *showBuddiesOnlyGames;
-    QCheckBox *showFullGames;
-    QCheckBox *showGamesThatStarted;
-    QCheckBox *showPasswordProtectedGames;
+    QCheckBox *hideBuddiesOnlyGames;
+    QCheckBox *hideFullGames;
+    QCheckBox *hideGamesThatStarted;
+    QCheckBox *hidePasswordProtectedGames;
     QCheckBox *hideIgnoredUserGames;
     QLineEdit *gameNameFilterEdit;
     QLineEdit *creatorNameFilterEdit;
@@ -50,12 +50,12 @@ public:
                    const GamesProxyModel *_gamesProxyModel,
                    QWidget *parent = nullptr);
 
-    bool getShowFullGames() const;
-    bool getShowGamesThatStarted() const;
-    bool getShowPasswordProtectedGames() const;
+    bool getHideFullGames() const;
+    bool getHideGamesThatStarted() const;
+    bool getHidePasswordProtectedGames() const;
     void setShowPasswordProtectedGames(bool _passwordProtectedGamesHidden);
-    bool getShowBuddiesOnlyGames() const;
-    void setShowBuddiesOnlyGames(bool _showBuddiesOnlyGames);
+    bool getHideBuddiesOnlyGames() const;
+    void setHideBuddiesOnlyGames(bool _hideBuddiesOnlyGames);
     bool getHideIgnoredUserGames() const;
     void setHideIgnoredUserGames(bool _hideIgnoredUserGames);
     QString getGameNameFilter() const;

--- a/cockatrice/src/game/game_selector.cpp
+++ b/cockatrice/src/game/game_selector.cpp
@@ -151,10 +151,10 @@ void GameSelector::actSetFilter()
     if (!dlg.exec())
         return;
 
-    gameListProxyModel->setShowBuddiesOnlyGames(dlg.getShowBuddiesOnlyGames());
-    gameListProxyModel->setShowFullGames(dlg.getShowFullGames());
-    gameListProxyModel->setShowGamesThatStarted(dlg.getShowGamesThatStarted());
-    gameListProxyModel->setShowPasswordProtectedGames(dlg.getShowPasswordProtectedGames());
+    gameListProxyModel->setHideBuddiesOnlyGames(dlg.getHideBuddiesOnlyGames());
+    gameListProxyModel->setHideFullGames(dlg.getHideFullGames());
+    gameListProxyModel->setHideGamesThatStarted(dlg.getHideGamesThatStarted());
+    gameListProxyModel->setHidePasswordProtectedGames(dlg.getHidePasswordProtectedGames());
     gameListProxyModel->setHideIgnoredUserGames(dlg.getHideIgnoredUserGames());
     gameListProxyModel->setGameNameFilter(dlg.getGameNameFilter());
     gameListProxyModel->setCreatorNameFilter(dlg.getCreatorNameFilter());

--- a/cockatrice/src/game/games_model.cpp
+++ b/cockatrice/src/game/games_model.cpp
@@ -26,8 +26,8 @@ enum GameListColumn
     SPECTATORS
 };
 
-const bool DEFAULT_SHOW_FULL_GAMES = false;
-const bool DEFAULT_SHOW_GAMES_THAT_STARTED = false;
+const bool DEFAULT_SHOW_FULL_GAMES = true;
+const bool DEFAULT_SHOW_GAMES_THAT_STARTED = true;
 const bool DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES = true;
 const bool DEFAULT_SHOW_BUDDIES_ONLY_GAMES = true;
 const bool DEFAULT_HIDE_IGNORED_USER_GAMES = false;

--- a/cockatrice/src/game/games_model.cpp
+++ b/cockatrice/src/game/games_model.cpp
@@ -26,15 +26,6 @@ enum GameListColumn
     SPECTATORS
 };
 
-const bool DEFAULT_SHOW_FULL_GAMES = true;
-const bool DEFAULT_SHOW_GAMES_THAT_STARTED = true;
-const bool DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES = true;
-const bool DEFAULT_SHOW_BUDDIES_ONLY_GAMES = true;
-const bool DEFAULT_HIDE_IGNORED_USER_GAMES = false;
-const bool DEFAULT_SHOW_ONLY_IF_SPECTATORS_CAN_WATCH = false;
-const bool DEFAULT_SHOW_SPECTATOR_PASSWORD_PROTECTED = true;
-const bool DEFAULT_SHOW_ONLY_IF_SPECTATORS_CAN_CHAT = false;
-const bool DEFAULT_SHOW_ONLY_IF_SPECTATORS_CAN_SEE_HANDS = false;
 const int DEFAULT_MAX_PLAYERS_MIN = 1;
 const int DEFAULT_MAX_PLAYERS_MAX = 99;
 constexpr QTime DEFAULT_MAX_GAME_AGE = QTime();
@@ -295,7 +286,7 @@ GamesProxyModel::GamesProxyModel(QObject *parent, const UserListProxy *_userList
 
 void GamesProxyModel::setShowBuddiesOnlyGames(bool _showBuddiesOnlyGames)
 {
-    showBuddiesOnlyGames = _showBuddiesOnlyGames;
+    hideBuddiesOnlyGames = _showBuddiesOnlyGames;
     invalidateFilter();
 }
 
@@ -307,19 +298,19 @@ void GamesProxyModel::setHideIgnoredUserGames(bool _hideIgnoredUserGames)
 
 void GamesProxyModel::setShowFullGames(bool _showFullGames)
 {
-    showFullGames = _showFullGames;
+    hideFullGames = _showFullGames;
     invalidateFilter();
 }
 
 void GamesProxyModel::setShowGamesThatStarted(bool _showGamesThatStarted)
 {
-    showGamesThatStarted = _showGamesThatStarted;
+    hideGamesThatStarted = _showGamesThatStarted;
     invalidateFilter();
 }
 
 void GamesProxyModel::setShowPasswordProtectedGames(bool _showPasswordProtectedGames)
 {
-    showPasswordProtectedGames = _showPasswordProtectedGames;
+    hidePasswordProtectedGames = _showPasswordProtectedGames;
     invalidateFilter();
 }
 
@@ -395,47 +386,43 @@ int GamesProxyModel::getNumFilteredGames() const
 
 void GamesProxyModel::resetFilterParameters()
 {
-    showFullGames = DEFAULT_SHOW_FULL_GAMES;
-    showGamesThatStarted = DEFAULT_SHOW_GAMES_THAT_STARTED;
-    showPasswordProtectedGames = DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES;
-    showBuddiesOnlyGames = DEFAULT_SHOW_BUDDIES_ONLY_GAMES;
-    hideIgnoredUserGames = DEFAULT_HIDE_IGNORED_USER_GAMES;
+    hideFullGames = false;
+    hideGamesThatStarted = false;
+    hidePasswordProtectedGames = false;
+    hideBuddiesOnlyGames = false;
+    hideIgnoredUserGames = false;
     gameNameFilter = QString();
     creatorNameFilter = QString();
     gameTypeFilter.clear();
     maxPlayersFilterMin = DEFAULT_MAX_PLAYERS_MIN;
     maxPlayersFilterMax = DEFAULT_MAX_PLAYERS_MAX;
     maxGameAge = DEFAULT_MAX_GAME_AGE;
-    showOnlyIfSpectatorsCanWatch = DEFAULT_SHOW_ONLY_IF_SPECTATORS_CAN_WATCH;
-    showSpectatorPasswordProtected = DEFAULT_SHOW_SPECTATOR_PASSWORD_PROTECTED;
-    showOnlyIfSpectatorsCanChat = DEFAULT_SHOW_ONLY_IF_SPECTATORS_CAN_CHAT;
-    showOnlyIfSpectatorsCanSeeHands = DEFAULT_SHOW_ONLY_IF_SPECTATORS_CAN_SEE_HANDS;
+    showOnlyIfSpectatorsCanWatch = false;
+    showSpectatorPasswordProtected = false;
+    showOnlyIfSpectatorsCanChat = false;
+    showOnlyIfSpectatorsCanSeeHands = false;
 
     invalidateFilter();
 }
 
 bool GamesProxyModel::areFilterParametersSetToDefaults() const
 {
-    return showFullGames == DEFAULT_SHOW_FULL_GAMES && showGamesThatStarted == DEFAULT_SHOW_GAMES_THAT_STARTED &&
-           showPasswordProtectedGames == DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES &&
-           showBuddiesOnlyGames == DEFAULT_SHOW_BUDDIES_ONLY_GAMES &&
-           hideIgnoredUserGames == DEFAULT_HIDE_IGNORED_USER_GAMES && gameNameFilter.isEmpty() &&
-           creatorNameFilter.isEmpty() && gameTypeFilter.isEmpty() && maxPlayersFilterMin == DEFAULT_MAX_PLAYERS_MIN &&
+    return !hideFullGames && !hideGamesThatStarted && !hidePasswordProtectedGames && !hideBuddiesOnlyGames &&
+           !hideIgnoredUserGames && gameNameFilter.isEmpty() && creatorNameFilter.isEmpty() &&
+           gameTypeFilter.isEmpty() && maxPlayersFilterMin == DEFAULT_MAX_PLAYERS_MIN &&
            maxPlayersFilterMax == DEFAULT_MAX_PLAYERS_MAX && maxGameAge == DEFAULT_MAX_GAME_AGE &&
-           showOnlyIfSpectatorsCanWatch == DEFAULT_SHOW_ONLY_IF_SPECTATORS_CAN_WATCH &&
-           showSpectatorPasswordProtected == DEFAULT_SHOW_SPECTATOR_PASSWORD_PROTECTED &&
-           showOnlyIfSpectatorsCanChat == DEFAULT_SHOW_ONLY_IF_SPECTATORS_CAN_CHAT &&
-           showOnlyIfSpectatorsCanSeeHands == DEFAULT_SHOW_ONLY_IF_SPECTATORS_CAN_SEE_HANDS;
+           !showOnlyIfSpectatorsCanWatch && !showSpectatorPasswordProtected && !showOnlyIfSpectatorsCanChat &&
+           !showOnlyIfSpectatorsCanSeeHands;
 }
 
 void GamesProxyModel::loadFilterParameters(const QMap<int, QString> &allGameTypes)
 {
     GameFiltersSettings &gameFilters = SettingsCache::instance().gameFilters();
-    showFullGames = gameFilters.isShowFullGames();
-    showGamesThatStarted = gameFilters.isShowGamesThatStarted();
-    showPasswordProtectedGames = gameFilters.isShowPasswordProtectedGames();
+    hideFullGames = gameFilters.isHideFullGames();
+    hideGamesThatStarted = gameFilters.isHideGamesThatStarted();
+    hidePasswordProtectedGames = gameFilters.isHidePasswordProtectedGames();
     hideIgnoredUserGames = gameFilters.isHideIgnoredUserGames();
-    showBuddiesOnlyGames = gameFilters.isShowBuddiesOnlyGames();
+    hideBuddiesOnlyGames = gameFilters.isHideBuddiesOnlyGames();
     gameNameFilter = gameFilters.getGameNameFilter();
     creatorNameFilter = gameFilters.getCreatorNameFilter();
     maxPlayersFilterMin = gameFilters.getMinPlayers();
@@ -460,10 +447,10 @@ void GamesProxyModel::loadFilterParameters(const QMap<int, QString> &allGameType
 void GamesProxyModel::saveFilterParameters(const QMap<int, QString> &allGameTypes)
 {
     GameFiltersSettings &gameFilters = SettingsCache::instance().gameFilters();
-    gameFilters.setShowBuddiesOnlyGames(showBuddiesOnlyGames);
-    gameFilters.setShowFullGames(showFullGames);
-    gameFilters.setShowGamesThatStarted(showGamesThatStarted);
-    gameFilters.setShowPasswordProtectedGames(showPasswordProtectedGames);
+    gameFilters.setHideBuddiesOnlyGames(hideBuddiesOnlyGames);
+    gameFilters.setHideFullGames(hideFullGames);
+    gameFilters.setHideGamesThatStarted(hideGamesThatStarted);
+    gameFilters.setHidePasswordProtectedGames(hidePasswordProtectedGames);
     gameFilters.setHideIgnoredUserGames(hideIgnoredUserGames);
     gameFilters.setGameNameFilter(gameNameFilter);
     gameFilters.setCreatorNameFilter(creatorNameFilter);
@@ -505,20 +492,20 @@ bool GamesProxyModel::filterAcceptsRow(int sourceRow) const
 
     const ServerInfo_Game &game = model->getGame(sourceRow);
 
-    if (!showBuddiesOnlyGames && game.only_buddies()) {
+    if (hideBuddiesOnlyGames && game.only_buddies()) {
         return false;
     }
     if (hideIgnoredUserGames && userListProxy->isUserIgnored(QString::fromStdString(game.creator_info().name()))) {
         return false;
     }
-    if (!showFullGames && game.player_count() == game.max_players())
+    if (hideFullGames && game.player_count() == game.max_players())
         return false;
-    if (!showGamesThatStarted && game.started())
+    if (hideGamesThatStarted && game.started())
         return false;
     if (!userListProxy->isOwnUserRegistered())
         if (game.only_registered())
             return false;
-    if (!showPasswordProtectedGames && game.with_password())
+    if (hidePasswordProtectedGames && game.with_password())
         return false;
     if (!gameNameFilter.isEmpty())
         if (!QString::fromStdString(game.description()).contains(gameNameFilter, Qt::CaseInsensitive))

--- a/cockatrice/src/game/games_model.cpp
+++ b/cockatrice/src/game/games_model.cpp
@@ -284,7 +284,7 @@ GamesProxyModel::GamesProxyModel(QObject *parent, const UserListProxy *_userList
     setDynamicSortFilter(true);
 }
 
-void GamesProxyModel::setShowBuddiesOnlyGames(bool _showBuddiesOnlyGames)
+void GamesProxyModel::setHideBuddiesOnlyGames(bool _showBuddiesOnlyGames)
 {
     hideBuddiesOnlyGames = _showBuddiesOnlyGames;
     invalidateFilter();
@@ -296,19 +296,19 @@ void GamesProxyModel::setHideIgnoredUserGames(bool _hideIgnoredUserGames)
     invalidateFilter();
 }
 
-void GamesProxyModel::setShowFullGames(bool _showFullGames)
+void GamesProxyModel::setHideFullGames(bool _showFullGames)
 {
     hideFullGames = _showFullGames;
     invalidateFilter();
 }
 
-void GamesProxyModel::setShowGamesThatStarted(bool _showGamesThatStarted)
+void GamesProxyModel::setHideGamesThatStarted(bool _showGamesThatStarted)
 {
     hideGamesThatStarted = _showGamesThatStarted;
     invalidateFilter();
 }
 
-void GamesProxyModel::setShowPasswordProtectedGames(bool _showPasswordProtectedGames)
+void GamesProxyModel::setHidePasswordProtectedGames(bool _showPasswordProtectedGames)
 {
     hidePasswordProtectedGames = _showPasswordProtectedGames;
     invalidateFilter();

--- a/cockatrice/src/game/games_model.h
+++ b/cockatrice/src/game/games_model.h
@@ -75,11 +75,11 @@ private:
     // - loadFilterParameters()
     // - saveFilterParameters()
     // - filterAcceptsRow()
-    bool showBuddiesOnlyGames;
+    bool hideBuddiesOnlyGames;
     bool hideIgnoredUserGames;
-    bool showFullGames;
-    bool showGamesThatStarted;
-    bool showPasswordProtectedGames;
+    bool hideFullGames;
+    bool hideGamesThatStarted;
+    bool hidePasswordProtectedGames;
     QString gameNameFilter, creatorNameFilter;
     QSet<int> gameTypeFilter;
     quint32 maxPlayersFilterMin, maxPlayersFilterMax;
@@ -92,7 +92,7 @@ public:
 
     bool getShowBuddiesOnlyGames() const
     {
-        return showBuddiesOnlyGames;
+        return hideBuddiesOnlyGames;
     }
     void setShowBuddiesOnlyGames(bool _showBuddiesOnlyGames);
     bool getHideIgnoredUserGames() const
@@ -102,17 +102,17 @@ public:
     void setHideIgnoredUserGames(bool _hideIgnoredUserGames);
     bool getShowFullGames() const
     {
-        return showFullGames;
+        return hideFullGames;
     }
     void setShowFullGames(bool _showFullGames);
     bool getShowGamesThatStarted() const
     {
-        return showGamesThatStarted;
+        return hideGamesThatStarted;
     }
     void setShowGamesThatStarted(bool _showGamesThatStarted);
     bool getShowPasswordProtectedGames() const
     {
-        return showPasswordProtectedGames;
+        return hidePasswordProtectedGames;
     }
     void setShowPasswordProtectedGames(bool _showPasswordProtectedGames);
     QString getGameNameFilter() const

--- a/cockatrice/src/game/games_model.h
+++ b/cockatrice/src/game/games_model.h
@@ -90,31 +90,31 @@ private:
 public:
     explicit GamesProxyModel(QObject *parent = nullptr, const UserListProxy *_userListProxy = nullptr);
 
-    bool getShowBuddiesOnlyGames() const
+    bool getHideBuddiesOnlyGames() const
     {
         return hideBuddiesOnlyGames;
     }
-    void setShowBuddiesOnlyGames(bool _showBuddiesOnlyGames);
+    void setHideBuddiesOnlyGames(bool _showBuddiesOnlyGames);
     bool getHideIgnoredUserGames() const
     {
         return hideIgnoredUserGames;
     }
     void setHideIgnoredUserGames(bool _hideIgnoredUserGames);
-    bool getShowFullGames() const
+    bool getHideFullGames() const
     {
         return hideFullGames;
     }
-    void setShowFullGames(bool _showFullGames);
-    bool getShowGamesThatStarted() const
+    void setHideFullGames(bool _showFullGames);
+    bool getHideGamesThatStarted() const
     {
         return hideGamesThatStarted;
     }
-    void setShowGamesThatStarted(bool _showGamesThatStarted);
-    bool getShowPasswordProtectedGames() const
+    void setHideGamesThatStarted(bool _showGamesThatStarted);
+    bool getHidePasswordProtectedGames() const
     {
         return hidePasswordProtectedGames;
     }
-    void setShowPasswordProtectedGames(bool _showPasswordProtectedGames);
+    void setHidePasswordProtectedGames(bool _showPasswordProtectedGames);
     QString getGameNameFilter() const
     {
         return gameNameFilter;

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -104,11 +104,7 @@ void SettingsCache::translateLegacySettings()
 
     // Game filters
     legacySetting.beginGroup("filter_games");
-    gameFilters().setShowFullGames(legacySetting.value("unavailable_games_visible").toBool());
-    gameFilters().setShowGamesThatStarted(legacySetting.value("unavailable_games_visible").toBool());
-    gameFilters().setShowPasswordProtectedGames(legacySetting.value("show_password_protected_games").toBool());
     gameFilters().setGameNameFilter(legacySetting.value("game_name_filter").toString());
-    gameFilters().setShowBuddiesOnlyGames(legacySetting.value("show_buddies_only_games").toBool());
     gameFilters().setHideIgnoredUserGames(legacySetting.value("hide_ignored_user_games").toBool());
     gameFilters().setMinPlayers(legacySetting.value("min_players").toInt());
 

--- a/cockatrice/src/settings/game_filters_settings.cpp
+++ b/cockatrice/src/settings/game_filters_settings.cpp
@@ -17,48 +17,48 @@ QString GameFiltersSettings::hashGameType(const QString &gameType) const
     return QCryptographicHash::hash(gameType.toUtf8(), QCryptographicHash::Md5).toHex();
 }
 
-void GameFiltersSettings::setShowBuddiesOnlyGames(bool show)
+void GameFiltersSettings::setHideBuddiesOnlyGames(bool hide)
 {
-    setValue(show, "show_buddies_only_games", "filter_games");
+    setValue(hide, "hide_buddies_only_games", "filter_games");
 }
 
-bool GameFiltersSettings::isShowBuddiesOnlyGames()
+bool GameFiltersSettings::isHideBuddiesOnlyGames()
 {
-    QVariant previous = getValue("show_buddies_only_games", "filter_games");
-    return previous == QVariant() ? true : previous.toBool();
+    QVariant previous = getValue("hide_buddies_only_games", "filter_games");
+    return previous == QVariant() || previous.toBool();
 }
 
-void GameFiltersSettings::setShowFullGames(bool show)
+void GameFiltersSettings::setHideFullGames(bool hide)
 {
-    setValue(show, "show_full_games", "filter_games");
+    setValue(hide, "hide_full_games", "filter_games");
 }
 
-bool GameFiltersSettings::isShowFullGames()
+bool GameFiltersSettings::isHideFullGames()
 {
-    QVariant previous = getValue("show_full_games", "filter_games");
-    return previous == QVariant() ? false : previous.toBool();
+    QVariant previous = getValue("hide_full_games", "filter_games");
+    return !(previous == QVariant()) && previous.toBool();
 }
 
-void GameFiltersSettings::setShowGamesThatStarted(bool show)
+void GameFiltersSettings::setHideGamesThatStarted(bool hide)
 {
-    setValue(show, "show_games_that_started", "filter_games");
+    setValue(hide, "hide_games_that_started", "filter_games");
 }
 
-bool GameFiltersSettings::isShowGamesThatStarted()
+bool GameFiltersSettings::isHideGamesThatStarted()
 {
-    QVariant previous = getValue("show_games_that_started", "filter_games");
-    return previous == QVariant() ? false : previous.toBool();
+    QVariant previous = getValue("hide_games_that_started", "filter_games");
+    return !(previous == QVariant()) && previous.toBool();
 }
 
-void GameFiltersSettings::setShowPasswordProtectedGames(bool show)
+void GameFiltersSettings::setHidePasswordProtectedGames(bool hide)
 {
-    setValue(show, "show_password_protected_games", "filter_games");
+    setValue(hide, "hide_password_protected_games", "filter_games");
 }
 
-bool GameFiltersSettings::isShowPasswordProtectedGames()
+bool GameFiltersSettings::isHidePasswordProtectedGames()
 {
-    QVariant previous = getValue("show_password_protected_games", "filter_games");
-    return previous == QVariant() ? true : previous.toBool();
+    QVariant previous = getValue("hide_password_protected_games", "filter_games");
+    return previous == QVariant() || previous.toBool();
 }
 
 void GameFiltersSettings::setHideIgnoredUserGames(bool hide)
@@ -69,7 +69,7 @@ void GameFiltersSettings::setHideIgnoredUserGames(bool hide)
 bool GameFiltersSettings::isHideIgnoredUserGames()
 {
     QVariant previous = getValue("hide_ignored_user_games", "filter_games");
-    return previous == QVariant() ? false : previous.toBool();
+    return !(previous == QVariant()) && previous.toBool();
 }
 
 void GameFiltersSettings::setGameNameFilter(QString gameName)

--- a/cockatrice/src/settings/game_filters_settings.h
+++ b/cockatrice/src/settings/game_filters_settings.h
@@ -9,10 +9,10 @@ class GameFiltersSettings : public SettingsManager
     friend class SettingsCache;
 
 public:
-    bool isShowBuddiesOnlyGames();
-    bool isShowFullGames();
-    bool isShowGamesThatStarted();
-    bool isShowPasswordProtectedGames();
+    bool isHideBuddiesOnlyGames();
+    bool isHideFullGames();
+    bool isHideGamesThatStarted();
+    bool isHidePasswordProtectedGames();
     bool isHideIgnoredUserGames();
     QString getGameNameFilter();
     QString getCreatorNameFilter();
@@ -25,11 +25,11 @@ public:
     bool isShowOnlyIfSpectatorsCanChat();
     bool isShowOnlyIfSpectatorsCanSeeHands();
 
-    void setShowBuddiesOnlyGames(bool show);
+    void setHideBuddiesOnlyGames(bool hide);
     void setHideIgnoredUserGames(bool hide);
-    void setShowFullGames(bool show);
-    void setShowGamesThatStarted(bool show);
-    void setShowPasswordProtectedGames(bool show);
+    void setHideFullGames(bool hide);
+    void setHideGamesThatStarted(bool hide);
+    void setHidePasswordProtectedGames(bool hide);
     void setGameNameFilter(QString gameName);
     void setCreatorNameFilter(QString creatorName);
     void setMinPlayers(int min);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4185

## Short roundup of the initial problem

- Filters didn't work exactly as filters, and the defaults were a bit wonky

## What will change with this Pull Request?
- Filter menu is now a true filter, having all values shown if empty and narrowing down from there

