### PR TITLE
Support right-click on game list menu

### DIFF
--- a/cockatrice/src/game/game_selector.cpp
+++ b/cockatrice/src/game/game_selector.cpp
@@ -293,9 +293,11 @@ void GameSelector::joinGame(const bool isSpectator)
         return;
     }
 
+    bool spectator = isSpectator || game.player_count() == game.max_players();
+
     bool overrideRestrictions = !tabSupervisor->getAdminLocked();
     QString password;
-    if (game.with_password() && !(isSpectator && !game.spectators_need_password()) && !overrideRestrictions) {
+    if (game.with_password() && !(spectator && !game.spectators_need_password()) && !overrideRestrictions) {
         bool ok;
         password = getTextWithMax(this, tr("Join game"), tr("Password:"), QLineEdit::Password, QString(), &ok);
         if (!ok) {
@@ -306,7 +308,7 @@ void GameSelector::joinGame(const bool isSpectator)
     Command_JoinGame cmd;
     cmd.set_game_id(game.game_id());
     cmd.set_password(password.toStdString());
-    cmd.set_spectator(isSpectator || game.player_count() == game.max_players());
+    cmd.set_spectator(spectator);
     cmd.set_override_restrictions(overrideRestrictions);
     cmd.set_join_as_judge((QApplication::keyboardModifiers() & Qt::ShiftModifier) != 0);
 

--- a/cockatrice/src/game/game_selector.cpp
+++ b/cockatrice/src/game/game_selector.cpp
@@ -38,6 +38,9 @@ GameSelector::GameSelector(AbstractClient *_client,
     : QGroupBox(parent), client(_client), tabSupervisor(_tabSupervisor), room(_room), showFilters(_showfilters)
 {
     gameListView = new QTreeView;
+    gameListView->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(gameListView, &QTreeView::customContextMenuRequested, this, &GameSelector::customContextMenu);
+
     gameListModel = new GamesModel(_rooms, _gameTypes, this);
     if (showFilters) {
         gameListProxyModel = new GamesProxyModel(this, tabSupervisor->getUserListManager());
@@ -113,7 +116,7 @@ GameSelector::GameSelector(AbstractClient *_client,
     setMinimumHeight(200);
 
     connect(joinButton, &QPushButton::clicked, this, &GameSelector::actJoin);
-    connect(spectateButton, &QPushButton::clicked, this, &GameSelector::actJoin);
+    connect(spectateButton, &QPushButton::clicked, this, &GameSelector::actSpectate);
     connect(gameListView->selectionModel(), &QItemSelectionModel::currentRowChanged, this,
             &GameSelector::actSelectedGameChanged);
     connect(gameListView, &QTreeView::activated, this, &GameSelector::actJoin);
@@ -241,27 +244,69 @@ void GameSelector::checkResponse(const Response &response)
 
 void GameSelector::actJoin()
 {
-    QModelIndex ind = gameListView->currentIndex();
-    if (!ind.isValid())
+    return joinGame(false);
+}
+
+void GameSelector::actSpectate()
+{
+    return joinGame(true);
+}
+
+void GameSelector::customContextMenu(const QPoint &point)
+{
+    const auto &index = gameListView->indexAt(point);
+    if (!index.isValid()) {
         return;
+    }
+
+    QAction joinGame(tr("Join Game"));
+    connect(&joinGame, &QAction::triggered, this, &GameSelector::actJoin);
+
+    QAction spectateGame(tr("Spectate Game"));
+    connect(&spectateGame, &QAction::triggered, this, &GameSelector::actSpectate);
+
+    QAction getGameInfo(tr("Game Information"));
+    connect(&getGameInfo, &QAction::triggered, this, [=, this]() {
+        const ServerInfo_Game &gameInfo = gameListModel->getGame(index.data(Qt::UserRole).toInt());
+        const QMap<int, QString> &gameTypes = gameListModel->getGameTypes().value(gameInfo.room_id());
+
+        DlgCreateGame dlg(gameInfo, gameTypes, this);
+        dlg.exec();
+    });
+
+    QMenu menu;
+    menu.addAction(&joinGame);
+    menu.addAction(&spectateGame);
+    menu.addAction(&getGameInfo);
+    menu.exec(gameListView->mapToGlobal(point));
+}
+
+void GameSelector::joinGame(const bool isSpectator)
+{
+    QModelIndex ind = gameListView->currentIndex();
+    if (!ind.isValid()) {
+        return;
+    }
+
     const ServerInfo_Game &game = gameListModel->getGame(ind.data(Qt::UserRole).toInt());
     if (tabSupervisor->switchToGameTabIfAlreadyExists(game.game_id())) {
         return;
     }
-    bool spectator = sender() == spectateButton || game.player_count() == game.max_players();
+
     bool overrideRestrictions = !tabSupervisor->getAdminLocked();
     QString password;
-    if (game.with_password() && !(spectator && !game.spectators_need_password()) && !overrideRestrictions) {
+    if (game.with_password() && !(isSpectator && !game.spectators_need_password()) && !overrideRestrictions) {
         bool ok;
         password = getTextWithMax(this, tr("Join game"), tr("Password:"), QLineEdit::Password, QString(), &ok);
-        if (!ok)
+        if (!ok) {
             return;
+        }
     }
 
     Command_JoinGame cmd;
     cmd.set_game_id(game.game_id());
     cmd.set_password(password.toStdString());
-    cmd.set_spectator(spectator);
+    cmd.set_spectator(isSpectator || game.player_count() == game.max_players());
     cmd.set_override_restrictions(overrideRestrictions);
     cmd.set_join_as_judge((QApplication::keyboardModifiers() & Qt::ShiftModifier) != 0);
 

--- a/cockatrice/src/game/game_selector.h
+++ b/cockatrice/src/game/game_selector.h
@@ -27,7 +27,11 @@ private slots:
     void actSetFilter();
     void actClearFilter();
     void actCreate();
+
     void actJoin();
+    void actSpectate();
+    void customContextMenu(const QPoint &point);
+
     void actSelectedGameChanged(const QModelIndex &current, const QModelIndex &previous);
     void checkResponse(const Response &response);
 
@@ -53,6 +57,7 @@ private:
     void disableButtons();
     void enableButtons();
     void enableButtonsForIndex(const QModelIndex &current);
+    void joinGame(const bool isSpectator);
 
 public:
     GameSelector(AbstractClient *_client,


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1454

## Short roundup of the initial problem

- Right clicking on a game in the game list never did anything

## What will change with this Pull Request?
- You can now right click to get several game actions (Join/Spectate/Room Info)

## Screenshots
![image](https://github.com/user-attachments/assets/0733cd61-3aac-48fc-bc39-38ac58f02c9e)
