### PR TITLE
add missing override and explicit specifiers in src/client

### DIFF
--- a/cockatrice/src/client/game_logic/abstract_client.h
+++ b/cockatrice/src/client/game_logic/abstract_client.h
@@ -98,8 +98,8 @@ protected:
     virtual void sendCommandContainer(const CommandContainer &cont) = 0;
 
 public:
-    AbstractClient(QObject *parent = nullptr);
-    ~AbstractClient();
+    explicit AbstractClient(QObject *parent = nullptr);
+    ~AbstractClient() override;
 
     ClientStatus getStatus() const
     {

--- a/cockatrice/src/client/game_logic/key_signals.h
+++ b/cockatrice/src/client/game_logic/key_signals.h
@@ -23,7 +23,7 @@ signals:
     void onCtrlC();
 
 protected:
-    virtual bool eventFilter(QObject *, QEvent *event);
+    bool eventFilter(QObject *, QEvent *event) override;
 };
 
 #endif

--- a/cockatrice/src/client/network/sets_model.h
+++ b/cockatrice/src/client/network/sets_model.h
@@ -57,28 +57,29 @@ public:
         SortRole = Qt::UserRole
     };
 
-    SetsModel(CardDatabase *_db, QObject *parent = nullptr);
-    ~SetsModel();
-    int rowCount(const QModelIndex &parent = QModelIndex()) const;
-    int columnCount(const QModelIndex &parent = QModelIndex()) const
+    explicit SetsModel(CardDatabase *_db, QObject *parent = nullptr);
+    ~SetsModel() override;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override
     {
         Q_UNUSED(parent);
         return NUM_COLS;
     }
-    QVariant data(const QModelIndex &index, int role) const;
-    bool setData(const QModelIndex &index, const QVariant &value, int role);
-    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
-    Qt::ItemFlags flags(const QModelIndex &index) const;
-    Qt::DropActions supportedDropActions() const;
+    QVariant data(const QModelIndex &index, int role) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role) override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+    Qt::DropActions supportedDropActions() const override;
 
-    QMimeData *mimeData(const QModelIndexList &indexes) const;
-    bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent);
-    QStringList mimeTypes() const;
+    QMimeData *mimeData(const QModelIndexList &indexes) const override;
+    bool
+    dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
+    QStringList mimeTypes() const override;
     void swapRows(int oldRow, int newRow);
     void toggleRow(int row, bool enable);
     void toggleRow(int row);
     void toggleAll(bool);
-    void sort(int column, Qt::SortOrder order = Qt::AscendingOrder);
+    void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
     void save(CardDatabase *db);
     void restore(CardDatabase *db);
     void restoreOriginalOrder();
@@ -88,7 +89,7 @@ class SetsDisplayModel : public QSortFilterProxyModel
 {
     Q_OBJECT
 public:
-    SetsDisplayModel(QObject *parent = NULL);
+    explicit SetsDisplayModel(QObject *parent = nullptr);
 
 protected:
     bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;

--- a/cockatrice/src/client/tapped_out_interface.h
+++ b/cockatrice/src/client/tapped_out_interface.h
@@ -33,7 +33,7 @@ private slots:
     void getAnalyzeRequestData(DeckList *deck, QByteArray *data);
 
 public:
-    TappedOutInterface(CardDatabase &_cardDatabase, QObject *parent = nullptr);
+    explicit TappedOutInterface(CardDatabase &_cardDatabase, QObject *parent = nullptr);
     void analyzeDeck(DeckList *deck);
 };
 

--- a/cockatrice/src/client/update_downloader.h
+++ b/cockatrice/src/client/update_downloader.h
@@ -14,7 +14,7 @@ class UpdateDownloader : public QObject
 {
     Q_OBJECT
 public:
-    UpdateDownloader(QObject *parent);
+    explicit UpdateDownloader(QObject *parent);
     void beginDownload(QUrl url);
 signals:
     void downloadSuccessful(QUrl filepath);


### PR DESCRIPTION
## Short roundup of the initial problem

A lot of classes don't have override specifiers on overridden methods. 

We should do a big cleanup of all the classes at once, so that we don't have override specifier fixes polluting other PRs.

## What will change with this Pull Request?

Added override and explicit specifiers to all classes in `src/client`.