### PR TITLE
add missing override and explicit specifiers in src/dialogs

### DIFF
--- a/cockatrice/src/dialogs/dlg_create_token.h
+++ b/cockatrice/src/dialogs/dlg_create_token.h
@@ -21,7 +21,7 @@ class DlgCreateToken : public QDialog
 {
     Q_OBJECT
 public:
-    DlgCreateToken(const QStringList &_predefinedTokens, QWidget *parent = nullptr);
+    explicit DlgCreateToken(const QStringList &_predefinedTokens, QWidget *parent = nullptr);
     QString getName() const;
     QString getColor() const;
     QString getPT() const;

--- a/cockatrice/src/dialogs/dlg_edit_avatar.h
+++ b/cockatrice/src/dialogs/dlg_edit_avatar.h
@@ -16,7 +16,7 @@ class DlgEditAvatar : public QDialog
 {
     Q_OBJECT
 public:
-    DlgEditAvatar(QWidget *parent = nullptr);
+    explicit DlgEditAvatar(QWidget *parent = nullptr);
     QByteArray getImage();
 private slots:
     void actOk();

--- a/cockatrice/src/dialogs/dlg_edit_password.h
+++ b/cockatrice/src/dialogs/dlg_edit_password.h
@@ -13,7 +13,7 @@ class DlgEditPassword : public QDialog
 {
     Q_OBJECT
 public:
-    DlgEditPassword(QWidget *parent = nullptr);
+    explicit DlgEditPassword(QWidget *parent = nullptr);
     QString getOldPassword() const
     {
         return oldPasswordEdit->text();

--- a/cockatrice/src/dialogs/dlg_edit_user.h
+++ b/cockatrice/src/dialogs/dlg_edit_user.h
@@ -13,10 +13,10 @@ class DlgEditUser : public QDialog
 {
     Q_OBJECT
 public:
-    DlgEditUser(QWidget *parent = nullptr,
-                QString email = QString(),
-                QString country = QString(),
-                QString realName = QString());
+    explicit DlgEditUser(QWidget *parent = nullptr,
+                         QString email = QString(),
+                         QString country = QString(),
+                         QString realName = QString());
     QString getEmail() const
     {
         return emailEdit->text();

--- a/cockatrice/src/dialogs/dlg_forgot_password_challenge.h
+++ b/cockatrice/src/dialogs/dlg_forgot_password_challenge.h
@@ -13,7 +13,7 @@ class DlgForgotPasswordChallenge : public QDialog
 {
     Q_OBJECT
 public:
-    DlgForgotPasswordChallenge(QWidget *parent = nullptr);
+    explicit DlgForgotPasswordChallenge(QWidget *parent = nullptr);
     QString getHost() const
     {
         return hostEdit->text();

--- a/cockatrice/src/dialogs/dlg_forgot_password_request.h
+++ b/cockatrice/src/dialogs/dlg_forgot_password_request.h
@@ -13,7 +13,7 @@ class DlgForgotPasswordRequest : public QDialog
 {
     Q_OBJECT
 public:
-    DlgForgotPasswordRequest(QWidget *parent = nullptr);
+    explicit DlgForgotPasswordRequest(QWidget *parent = nullptr);
     QString getHost() const
     {
         return hostEdit->text();

--- a/cockatrice/src/dialogs/dlg_forgot_password_reset.h
+++ b/cockatrice/src/dialogs/dlg_forgot_password_reset.h
@@ -13,7 +13,7 @@ class DlgForgotPasswordReset : public QDialog
 {
     Q_OBJECT
 public:
-    DlgForgotPasswordReset(QWidget *parent = nullptr);
+    explicit DlgForgotPasswordReset(QWidget *parent = nullptr);
     QString getHost() const
     {
         return hostEdit->text();

--- a/cockatrice/src/dialogs/dlg_load_remote_deck.h
+++ b/cockatrice/src/dialogs/dlg_load_remote_deck.h
@@ -20,7 +20,7 @@ private slots:
     void currentItemChanged(const QModelIndex &current, const QModelIndex &previous);
 
 public:
-    DlgLoadRemoteDeck(AbstractClient *_client, QWidget *parent = nullptr);
+    explicit DlgLoadRemoteDeck(AbstractClient *_client, QWidget *parent = nullptr);
     int getDeckId() const;
 };
 

--- a/cockatrice/src/dialogs/dlg_manage_sets.h
+++ b/cockatrice/src/dialogs/dlg_manage_sets.h
@@ -51,8 +51,8 @@ private:
     };
 
 public:
-    WndSets(QWidget *parent = nullptr);
-    ~WndSets();
+    explicit WndSets(QWidget *parent = nullptr);
+    ~WndSets() override;
 
 protected:
     void selectRows(QSet<int> rows);

--- a/cockatrice/src/dialogs/dlg_register.h
+++ b/cockatrice/src/dialogs/dlg_register.h
@@ -13,7 +13,7 @@ class DlgRegister : public QDialog
 {
     Q_OBJECT
 public:
-    DlgRegister(QWidget *parent = nullptr);
+    explicit DlgRegister(QWidget *parent = nullptr);
     QString getHost() const
     {
         return hostEdit->text();

--- a/cockatrice/src/dialogs/dlg_update.h
+++ b/cockatrice/src/dialogs/dlg_update.h
@@ -16,7 +16,7 @@ class DlgUpdate : public QDialog
 {
     Q_OBJECT
 public:
-    DlgUpdate(QWidget *parent);
+    explicit DlgUpdate(QWidget *parent);
 
 private slots:
     void finishedUpdateCheck(bool needToUpdate, bool isCompatible, Release *release);


### PR DESCRIPTION
## Short roundup of the initial problem

A lot of classes don't have override specifiers on overridden methods. 

We should do a big cleanup of all the classes at once, so that we don't have override specifier fixes polluting other PRs.

## What will change with this Pull Request?

Added override and explicit specifiers to all classes in `src/dialogs`.