### PR TITLE
add missing override and explicit specifiers in src/deck and src/utility

### DIFF
--- a/cockatrice/src/deck/custom_line_edit.h
+++ b/cockatrice/src/deck/custom_line_edit.h
@@ -35,7 +35,7 @@ protected:
     void keyPressEvent(QKeyEvent *event) override;
 
 public:
-    SearchLineEdit() : LineEditUnfocusable(), treeView(nullptr)
+    SearchLineEdit() : treeView(nullptr)
     {
     }
     void setTreeView(QTreeView *_treeView)

--- a/cockatrice/src/deck/deck_loader.h
+++ b/cockatrice/src/deck/deck_loader.h
@@ -29,8 +29,8 @@ private:
 
 public:
     DeckLoader();
-    DeckLoader(const QString &nativeString);
-    DeckLoader(const DeckList &other);
+    explicit DeckLoader(const QString &nativeString);
+    explicit DeckLoader(const DeckList &other);
     DeckLoader(const DeckLoader &other);
     const QString &getLastFileName() const
     {

--- a/cockatrice/src/deck/deck_stats_interface.h
+++ b/cockatrice/src/deck/deck_stats_interface.h
@@ -31,7 +31,7 @@ private slots:
     void getAnalyzeRequestData(DeckList *deck, QByteArray *data);
 
 public:
-    DeckStatsInterface(CardDatabase &_cardDatabase, QObject *parent = nullptr);
+    explicit DeckStatsInterface(CardDatabase &_cardDatabase, QObject *parent = nullptr);
     void analyzeDeck(DeckList *deck);
 };
 

--- a/cockatrice/src/utility/sequence_edit.h
+++ b/cockatrice/src/utility/sequence_edit.h
@@ -11,7 +11,7 @@ class SequenceEdit : public QWidget
 {
     Q_OBJECT
 public:
-    SequenceEdit(const QString &_shortcutName, QWidget *parent = nullptr);
+    explicit SequenceEdit(const QString &_shortcutName, QWidget *parent = nullptr);
     QString getSequence();
     void setShortcutName(const QString &_shortcutName);
     void refreshShortcut();
@@ -23,7 +23,7 @@ private slots:
     void restoreDefault();
 
 protected:
-    bool eventFilter(QObject *, QEvent *event);
+    bool eventFilter(QObject *, QEvent *event) override;
 
 private:
     QString shortcutName;


### PR DESCRIPTION
## Short roundup of the initial problem

A lot of classes don't have override specifiers on overridden methods. 

We should do a big cleanup of all the classes at once, so that we don't have override specifier fixes polluting other PRs.

## What will change with this Pull Request?

Added override and explicit specifiers to all classes in `src/deck`.