### PR TITLE
add missing override and explicit specifiers in src/server

### DIFF
--- a/cockatrice/src/server/chat_view/chat_view.h
+++ b/cockatrice/src/server/chat_view/chat_view.h
@@ -100,14 +100,14 @@ public:
 
 protected:
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-    void enterEvent(QEnterEvent *event);
+    void enterEvent(QEnterEvent *event) override;
 #else
-    void enterEvent(QEvent *event);
+    void enterEvent(QEvent *event) override;
 #endif
-    void leaveEvent(QEvent *event);
-    void mouseMoveEvent(QMouseEvent *event);
-    void mousePressEvent(QMouseEvent *event);
-    void mouseReleaseEvent(QMouseEvent *event);
+    void leaveEvent(QEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
 signals:
     void openMessageDialog(const QString &userName, bool focus);
     void cardNameHovered(QString cardName);

--- a/cockatrice/src/server/local_client.h
+++ b/cockatrice/src/server/local_client.h
@@ -16,9 +16,9 @@ public:
                 const QString &_playerName,
                 const QString &_clientId,
                 QObject *parent = nullptr);
-    ~LocalClient();
+    ~LocalClient() override;
 
-    void sendCommandContainer(const CommandContainer &cont);
+    void sendCommandContainer(const CommandContainer &cont) override;
 private slots:
     void itemFromServer(const ServerMessage &item);
 };

--- a/cockatrice/src/server/local_server.h
+++ b/cockatrice/src/server/local_server.h
@@ -10,8 +10,8 @@ class LocalServer : public Server
 {
     Q_OBJECT
 public:
-    LocalServer(QObject *parent = nullptr);
-    ~LocalServer();
+    explicit LocalServer(QObject *parent = nullptr);
+    ~LocalServer() override;
 
     LocalServerInterface *newConnection();
 };
@@ -23,27 +23,27 @@ private:
     LocalServer *localServer;
 
 protected:
-    ServerInfo_User getUserData(const QString &name, bool withId = false);
+    ServerInfo_User getUserData(const QString &name, bool withId = false) override;
 
 public:
-    LocalServer_DatabaseInterface(LocalServer *_localServer);
-    ~LocalServer_DatabaseInterface() = default;
+    explicit LocalServer_DatabaseInterface(LocalServer *_localServer);
+    ~LocalServer_DatabaseInterface() override = default;
     AuthenticationResult checkUserPassword(Server_ProtocolHandler *handler,
                                            const QString &user,
                                            const QString &password,
                                            const QString &clientId,
                                            QString &reasonStr,
                                            int &secondsLeft,
-                                           bool passwordNeedsHash);
-    int getNextGameId()
+                                           bool passwordNeedsHash) override;
+    int getNextGameId() override
     {
         return localServer->getNextLocalGameId();
     }
-    int getNextReplayId()
+    int getNextReplayId() override
     {
         return -1;
     }
-    int getActiveUserCount(QString /* connectionType */)
+    int getActiveUserCount(QString /* connectionType */) override
     {
         return 0;
     }

--- a/cockatrice/src/server/local_server_interface.h
+++ b/cockatrice/src/server/local_server_interface.h
@@ -10,17 +10,17 @@ class LocalServerInterface : public Server_ProtocolHandler
     Q_OBJECT
 public:
     LocalServerInterface(LocalServer *_server, Server_DatabaseInterface *_databaseInterface);
-    ~LocalServerInterface();
+    ~LocalServerInterface() override;
 
-    QString getAddress() const
+    QString getAddress() const override
     {
         return QString();
     }
-    QString getConnectionType() const
+    QString getConnectionType() const override
     {
         return "local";
     };
-    void transmitProtocolItem(const ServerMessage &item);
+    void transmitProtocolItem(const ServerMessage &item) override;
 signals:
     void itemToClient(const ServerMessage &item);
 public slots:

--- a/cockatrice/src/server/pending_command.h
+++ b/cockatrice/src/server/pending_command.h
@@ -18,7 +18,7 @@ private:
     int ticks;
 
 public:
-    PendingCommand(const CommandContainer &_commandContainer, QVariant _extraData = QVariant());
+    explicit PendingCommand(const CommandContainer &_commandContainer, QVariant _extraData = QVariant());
     CommandContainer &getCommandContainer();
     void setExtraData(const QVariant &_extraData);
     QVariant getExtraData() const;

--- a/cockatrice/src/server/remote/remote_decklist_tree_widget.h
+++ b/cockatrice/src/server/remote/remote_decklist_tree_widget.h
@@ -23,10 +23,10 @@ public:
         QString name;
 
     public:
-        Node(const QString &_name, DirectoryNode *_parent = nullptr) : parent(_parent), name(_name)
+        explicit Node(const QString &_name, DirectoryNode *_parent = nullptr) : parent(_parent), name(_name)
         {
         }
-        virtual ~Node(){};
+        virtual ~Node() = default;
         DirectoryNode *getParent() const
         {
             return parent;
@@ -39,8 +39,8 @@ public:
     class DirectoryNode : public Node, public QList<Node *>
     {
     public:
-        DirectoryNode(const QString &_name = QString(), DirectoryNode *_parent = nullptr);
-        ~DirectoryNode();
+        explicit DirectoryNode(const QString &_name = QString(), DirectoryNode *_parent = nullptr);
+        ~DirectoryNode() override;
         void clearTree();
         QString getPath() const;
         DirectoryNode *getNodeByPath(QStringList path);
@@ -87,15 +87,15 @@ private slots:
     void deckListFinished(const Response &r);
 
 public:
-    RemoteDeckList_TreeModel(AbstractClient *_client, QObject *parent = nullptr);
-    ~RemoteDeckList_TreeModel();
-    int rowCount(const QModelIndex &parent = QModelIndex()) const;
-    int columnCount(const QModelIndex & /*parent*/ = QModelIndex()) const;
-    QVariant data(const QModelIndex &index, int role) const;
-    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
-    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const;
-    QModelIndex parent(const QModelIndex &index) const;
-    Qt::ItemFlags flags(const QModelIndex &index) const;
+    explicit RemoteDeckList_TreeModel(AbstractClient *_client, QObject *parent = nullptr);
+    ~RemoteDeckList_TreeModel() override;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex & /*parent*/ = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
+    QModelIndex parent(const QModelIndex &index) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
 
     DirectoryNode *getRoot() const
     {
@@ -116,7 +116,7 @@ private:
     QSortFilterProxyModel *proxyModel;
 
 public:
-    RemoteDeckList_TreeWidget(AbstractClient *_client, QWidget *parent = nullptr);
+    explicit RemoteDeckList_TreeWidget(AbstractClient *_client, QWidget *parent = nullptr);
     RemoteDeckList_TreeModel::Node *getNode(const QModelIndex &ind) const;
     RemoteDeckList_TreeModel::Node *getCurrentItem() const;
     QList<RemoteDeckList_TreeModel::Node *> getCurrentSelection() const;

--- a/cockatrice/src/server/remote/remote_replay_list_tree_widget.h
+++ b/cockatrice/src/server/remote/remote_replay_list_tree_widget.h
@@ -24,10 +24,10 @@ private:
         QString name;
 
     public:
-        Node(const QString &_name) : name(_name)
+        explicit Node(const QString &_name) : name(_name)
         {
         }
-        virtual ~Node(){};
+        virtual ~Node() = default;
         QString getName() const
         {
             return name;
@@ -39,8 +39,8 @@ private:
         ServerInfo_ReplayMatch matchInfo;
 
     public:
-        MatchNode(const ServerInfo_ReplayMatch &_matchInfo);
-        ~MatchNode();
+        explicit MatchNode(const ServerInfo_ReplayMatch &_matchInfo);
+        ~MatchNode() override;
         void clearTree();
         const ServerInfo_ReplayMatch &getMatchInfo()
         {
@@ -82,18 +82,18 @@ private slots:
     void replayListFinished(const Response &r);
 
 public:
-    RemoteReplayList_TreeModel(AbstractClient *_client, QObject *parent = nullptr);
-    ~RemoteReplayList_TreeModel();
-    int rowCount(const QModelIndex &parent = QModelIndex()) const;
-    int columnCount(const QModelIndex & /*parent*/ = QModelIndex()) const
+    explicit RemoteReplayList_TreeModel(AbstractClient *_client, QObject *parent = nullptr);
+    ~RemoteReplayList_TreeModel() override;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex & /*parent*/ = QModelIndex()) const override
     {
         return numberOfColumns;
     }
-    QVariant data(const QModelIndex &index, int role) const;
-    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
-    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const;
-    QModelIndex parent(const QModelIndex &index) const;
-    Qt::ItemFlags flags(const QModelIndex &index) const;
+    QVariant data(const QModelIndex &index, int role) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
+    QModelIndex parent(const QModelIndex &index) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
     void clearTree();
     void refreshTree();
     ServerInfo_Replay const *getReplay(const QModelIndex &index) const;
@@ -111,7 +111,7 @@ private:
     QSortFilterProxyModel *proxyModel;
 
 public:
-    RemoteReplayList_TreeWidget(AbstractClient *_client, QWidget *parent = nullptr);
+    explicit RemoteReplayList_TreeWidget(AbstractClient *_client, QWidget *parent = nullptr);
     ServerInfo_Replay const *getReplay(const QModelIndex &ind) const;
     ServerInfo_ReplayMatch const *getReplayMatch(const QModelIndex &ind) const;
     QList<ServerInfo_Replay const *> getSelectedReplays() const;

--- a/cockatrice/src/server/user/user_list_widget.h
+++ b/cockatrice/src/server/user/user_list_widget.h
@@ -39,7 +39,7 @@ private slots:
     void enableTemporaryEdits(bool enabled);
 
 public:
-    BanDialog(const ServerInfo_User &info, QWidget *parent = nullptr);
+    explicit BanDialog(const ServerInfo_User &info, QWidget *parent = nullptr);
     QString getBanName() const;
     QString getBanIP() const;
     QString getBanId() const;
@@ -90,9 +90,11 @@ public:
 class UserListItemDelegate : public QStyledItemDelegate
 {
 public:
-    UserListItemDelegate(QObject *const parent);
-    bool
-    editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index);
+    explicit UserListItemDelegate(QObject *const parent);
+    bool editorEvent(QEvent *event,
+                     QAbstractItemModel *model,
+                     const QStyleOptionViewItem &option,
+                     const QModelIndex &index) override;
 };
 
 class UserListTWI : public QTreeWidgetItem
@@ -101,14 +103,14 @@ private:
     ServerInfo_User userInfo;
 
 public:
-    UserListTWI(const ServerInfo_User &_userInfo);
+    explicit UserListTWI(const ServerInfo_User &_userInfo);
     const ServerInfo_User &getUserInfo() const
     {
         return userInfo;
     }
     void setUserInfo(const ServerInfo_User &_userInfo);
     void setOnline(bool online);
-    bool operator<(const QTreeWidgetItem &other) const;
+    bool operator<(const QTreeWidgetItem &other) const override;
 };
 
 class UserListWidget : public QGroupBox


### PR DESCRIPTION
## Short roundup of the initial problem

A lot of classes don't have override specifiers on overridden methods. 

We should do a big cleanup of all the classes at once, so that we don't have override specifier fixes polluting other PRs.

## What will change with this Pull Request?

Added override and explicit specifiers to all classes in `src/server`.