### PR TITLE
add missing override and explicit specifiers in common

### DIFF
--- a/common/rng_abstract.h
+++ b/common/rng_abstract.h
@@ -8,7 +8,7 @@ class RNG_Abstract : public QObject
 {
     Q_OBJECT
 public:
-    RNG_Abstract(QObject *parent = 0) : QObject(parent)
+    explicit RNG_Abstract(QObject *parent = nullptr) : QObject(parent)
     {
     }
     virtual unsigned int rand(int min, int max) = 0;

--- a/common/rng_sfmt.h
+++ b/common/rng_sfmt.h
@@ -36,8 +36,8 @@ private:
     unsigned int cdf(unsigned int min, unsigned int max);
 
 public:
-    RNG_SFMT(QObject *parent = 0);
-    unsigned int rand(int min, int max);
+    explicit RNG_SFMT(QObject *parent = nullptr);
+    unsigned int rand(int min, int max) override;
 };
 
 #endif

--- a/common/server.h
+++ b/common/server.h
@@ -58,7 +58,7 @@ private slots:
 public:
     mutable QReadWriteLock clientsLock, roomsLock; // locking order: roomsLock before clientsLock
     explicit Server(QObject *parent = nullptr);
-    virtual ~Server() = default;
+    ~Server() override = default;
     AuthenticationResult loginUser(Server_ProtocolHandler *session,
                                    QString &name,
                                    const QString &password,

--- a/common/server_abstractuserinterface.h
+++ b/common/server_abstractuserinterface.h
@@ -26,14 +26,14 @@ protected:
     Server *server;
 
 public:
-    Server_AbstractUserInterface(Server *_server) : server(_server)
+    explicit Server_AbstractUserInterface(Server *_server) : server(_server)
     {
     }
     Server_AbstractUserInterface(Server *_server, const ServerInfo_User_Container &other)
         : ServerInfo_User_Container(other), server(_server)
     {
     }
-    virtual ~Server_AbstractUserInterface()
+    ~Server_AbstractUserInterface() override
     {
     }
 

--- a/common/server_database_interface.h
+++ b/common/server_database_interface.h
@@ -9,7 +9,7 @@ class Server_DatabaseInterface : public QObject
 {
     Q_OBJECT
 public:
-    Server_DatabaseInterface(QObject *parent = 0) : QObject(parent)
+    explicit Server_DatabaseInterface(QObject *parent = nullptr) : QObject(parent)
     {
     }
 

--- a/common/server_game.h
+++ b/common/server_game.h
@@ -108,7 +108,7 @@ public:
                 bool _spectatorsSeeEverything,
                 int startingLifeTotal,
                 Server_Room *parent);
-    ~Server_Game();
+    ~Server_Game() override;
     Server_Room *getRoom() const
     {
         return room;

--- a/common/server_room.h
+++ b/common/server_room.h
@@ -64,7 +64,7 @@ public:
                 const QString &_joinMessage,
                 const QStringList &_gameTypes,
                 Server *parent);
-    ~Server_Room();
+    ~Server_Room() override;
     int getId() const
     {
         return id;

--- a/common/serverinfo_user_container.h
+++ b/common/serverinfo_user_container.h
@@ -9,8 +9,8 @@ protected:
     ServerInfo_User *userInfo;
 
 public:
-    ServerInfo_User_Container(ServerInfo_User *_userInfo = nullptr);
-    ServerInfo_User_Container(const ServerInfo_User &_userInfo);
+    explicit ServerInfo_User_Container(ServerInfo_User *_userInfo = nullptr);
+    explicit ServerInfo_User_Container(const ServerInfo_User &_userInfo);
     ServerInfo_User_Container(const ServerInfo_User_Container &other);
     ServerInfo_User_Container &operator=(const ServerInfo_User_Container &other) = default;
     virtual ~ServerInfo_User_Container();


### PR DESCRIPTION
## Short roundup of the initial problem

A lot of classes don't have override specifiers on overridden methods. 

We should do a big cleanup of all the classes at once, so that we don't have override specifier fixes polluting other PRs.

## What will change with this Pull Request?

Added override and explicit specifiers to all classes in `common`.