### PR TITLE
reduce empty spacing in game selector

### DIFF
--- a/cockatrice/src/game/game_selector.cpp
+++ b/cockatrice/src/game/game_selector.cpp
@@ -94,6 +94,7 @@ GameSelector::GameSelector(AbstractClient *_client,
     spectateButton = new QPushButton;
 
     QHBoxLayout *buttonLayout = new QHBoxLayout;
+    buttonLayout->setSpacing(7);
     if (showFilters) {
         buttonLayout->addWidget(filterButton);
         buttonLayout->addWidget(clearFilterButton);
@@ -106,6 +107,8 @@ GameSelector::GameSelector(AbstractClient *_client,
     buttonLayout->setAlignment(Qt::AlignTop);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
+    mainLayout->setSpacing(2);
+    mainLayout->setContentsMargins(11, 11, 11, 0);
     mainLayout->addWidget(gameListView);
     mainLayout->addLayout(buttonLayout);
 


### PR DESCRIPTION
## Short roundup of the initial problem

Game Selector has some unused space

## What will change with this Pull Request?

Before

![before](https://github.com/user-attachments/assets/03c8b830-aa4c-4f0a-913a-2979ba37e611)


After

![after](https://github.com/user-attachments/assets/78823fd4-aacc-4913-9b2f-8a7c6b3288fe)


Do you think it looks better this way?