### PR TITLE
refactor CardInfoPictureWidget::createRightClickMenu

### DIFF
--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
@@ -353,7 +353,7 @@ QMenu *CardInfoPictureWidget::createAddToOpenDeckMenu()
             deckEditorTab->addCardHelper(info, DECK_ZONE_SIDE);
         });
     }
-  
+
     return addToOpenDeckMenu;
 }
 

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
@@ -266,15 +266,13 @@ QMenu *CardInfoPictureWidget::createViewRelatedCardsMenu()
 {
     auto viewRelatedCards = new QMenu(tr("View related cards"));
 
-    bool atLeastOneGoodRelationFound = false;
     QList<CardRelation *> relatedCards = info->getAllRelatedCards();
-    for (const CardRelation *cardRelation : relatedCards) {
-        CardInfoPtr relatedCard = CardDatabaseManager::getInstance()->getCard(cardRelation->getName());
-        if (relatedCard != nullptr) {
-            atLeastOneGoodRelationFound = true;
-            break;
-        }
-    }
+
+    auto relatedCardExists = [](const CardRelation *cardRelation) {
+        return CardDatabaseManager::getInstance()->getCard(cardRelation->getName()) != nullptr;
+    };
+
+    bool atLeastOneGoodRelationFound = std::any_of(relatedCards.begin(), relatedCards.end(), relatedCardExists);
 
     if (!atLeastOneGoodRelationFound) {
         viewRelatedCards->setEnabled(false);

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
@@ -256,10 +256,46 @@ QMenu *CardInfoPictureWidget::createRightClickMenu()
         return cardMenu;
     }
 
+    cardMenu->addMenu(createViewRelatedCardsMenu());
+    cardMenu->addMenu(createAddToOpenDeckMenu());
+
+    return cardMenu;
+}
+
+QMenu *CardInfoPictureWidget::createViewRelatedCardsMenu()
+{
     auto viewRelatedCards = new QMenu(tr("View related cards"));
+
+    bool atLeastOneGoodRelationFound = false;
+    QList<CardRelation *> relatedCards = info->getAllRelatedCards();
+    for (const CardRelation *cardRelation : relatedCards) {
+        CardInfoPtr relatedCard = CardDatabaseManager::getInstance()->getCard(cardRelation->getName());
+        if (relatedCard != nullptr) {
+            atLeastOneGoodRelationFound = true;
+            break;
+        }
+    }
+
+    if (!atLeastOneGoodRelationFound) {
+        viewRelatedCards->setEnabled(false);
+        return viewRelatedCards;
+    }
+
+    for (const auto &relatedCard : relatedCards) {
+        const auto &relatedCardName = relatedCard->getName();
+        QAction *viewCard = viewRelatedCards->addAction(relatedCardName);
+        connect(viewCard, &QAction::triggered, this, [this, &relatedCardName] {
+            emit cardChanged(CardDatabaseManager::getInstance()->getCard(relatedCardName));
+        });
+        viewRelatedCards->addAction(viewCard);
+    }
+
+    return viewRelatedCards;
+}
+
+QMenu *CardInfoPictureWidget::createAddToOpenDeckMenu()
+{
     auto addToOpenDeckMenu = new QMenu(tr("Add card to deck"));
-    cardMenu->addMenu(viewRelatedCards);
-    cardMenu->addMenu(addToOpenDeckMenu);
 
     auto *mainWindow = qobject_cast<MainWindow *>(window());
     QList<TabDeckEditor *> deckEditorTabs = mainWindow->getTabSupervisor()->getDeckEditorTabs();
@@ -283,31 +319,7 @@ QMenu *CardInfoPictureWidget::createRightClickMenu()
         addToOpenDeckMenu->addMenu(addCardMenu);
     }
 
-    bool atLeastOneGoodRelationFound = false;
-    QList<CardRelation *> relatedCards = info->getAllRelatedCards();
-    for (const CardRelation *cardRelation : relatedCards) {
-        CardInfoPtr relatedCard = CardDatabaseManager::getInstance()->getCard(cardRelation->getName());
-        if (relatedCard != nullptr) {
-            atLeastOneGoodRelationFound = true;
-            break;
-        }
-    }
-
-    if (!atLeastOneGoodRelationFound) {
-        viewRelatedCards->setEnabled(false);
-        return cardMenu;
-    }
-
-    for (const auto &relatedCard : relatedCards) {
-        const auto &relatedCardName = relatedCard->getName();
-        QAction *viewCard = viewRelatedCards->addAction(relatedCardName);
-        connect(viewCard, &QAction::triggered, this, [this, &relatedCardName] {
-            emit cardChanged(CardDatabaseManager::getInstance()->getCard(relatedCardName));
-        });
-        viewRelatedCards->addAction(viewCard);
-    }
-
-    return cardMenu;
+    return addToOpenDeckMenu;
 }
 
 /**

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
@@ -68,6 +68,8 @@ private:
     QTimer *hoverTimer;
 
     QMenu *createRightClickMenu();
+    QMenu *createViewRelatedCardsMenu();
+    QMenu *createAddToOpenDeckMenu();
 };
 
 #endif


### PR DESCRIPTION
## Short roundup of the initial problem

`CardInfoPictureWidget::createRightClickMenu` is a bit messy 

## What will change with this Pull Request?
- Split the creation of each sub-menu into its own method
- use `std::any_of` instead of a for loop