### PR TITLE
Disable add to deck submenu if no deck editor tabs are open

### DIFF
--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
@@ -299,7 +299,7 @@ QMenu *CardInfoPictureWidget::createAddToOpenDeckMenu()
     QList<TabDeckEditor *> deckEditorTabs = mainWindow->getTabSupervisor()->getDeckEditorTabs();
 
     for (auto &deckEditorTab : deckEditorTabs) {
-        auto *addCardMenu = new QMenu(tr("Add card to") + " " + deckEditorTab->getTabText());
+        auto *addCardMenu = new QMenu(deckEditorTab->getTabText());
         QAction *addCard = new QAction(this);
         addCard->setText(tr("Mainboard"));
         connect(addCard, &QAction::triggered, this, [this, deckEditorTab] {

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
@@ -298,6 +298,11 @@ QMenu *CardInfoPictureWidget::createAddToOpenDeckMenu()
     auto *mainWindow = qobject_cast<MainWindow *>(window());
     QList<TabDeckEditor *> deckEditorTabs = mainWindow->getTabSupervisor()->getDeckEditorTabs();
 
+    if (deckEditorTabs.isEmpty()) {
+        addToOpenDeckMenu->setEnabled(false);
+        return addToOpenDeckMenu;
+    }
+
     for (auto &deckEditorTab : deckEditorTabs) {
         auto *addCardMenu = addToOpenDeckMenu->addMenu(deckEditorTab->getTabText());
 

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
@@ -299,22 +299,19 @@ QMenu *CardInfoPictureWidget::createAddToOpenDeckMenu()
     QList<TabDeckEditor *> deckEditorTabs = mainWindow->getTabSupervisor()->getDeckEditorTabs();
 
     for (auto &deckEditorTab : deckEditorTabs) {
-        auto *addCardMenu = new QMenu(deckEditorTab->getTabText());
-        QAction *addCard = new QAction(this);
-        addCard->setText(tr("Mainboard"));
+        auto *addCardMenu = addToOpenDeckMenu->addMenu(deckEditorTab->getTabText());
+
+        QAction *addCard = addCardMenu->addAction(tr("Mainboard"));
         connect(addCard, &QAction::triggered, this, [this, deckEditorTab] {
             deckEditorTab->updateCardInfo(info);
             deckEditorTab->addCardHelper(info, DECK_ZONE_MAIN);
         });
-        QAction *addCardSideboard = new QAction(this);
-        addCardSideboard->setText(tr("Sideboard"));
+
+        QAction *addCardSideboard = addCardMenu->addAction(tr("Sideboard"));
         connect(addCardSideboard, &QAction::triggered, this, [this, deckEditorTab] {
             deckEditorTab->updateCardInfo(info);
             deckEditorTab->addCardHelper(info, DECK_ZONE_SIDE);
         });
-        addCardMenu->addAction(addCard);
-        addCardMenu->addAction(addCardSideboard);
-        addToOpenDeckMenu->addMenu(addCardMenu);
     }
 
     return addToOpenDeckMenu;

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
@@ -68,6 +68,8 @@ private:
     QTimer *hoverTimer;
 
     QMenu *createRightClickMenu();
+    QMenu *createViewRelatedCardsMenu();
+    QMenu *createAddToOpenDeckMenu();
 };
 
 #endif


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5512
- requires #5529 to be merged first

## Short roundup of the initial problem

The "Add card to deck" menu is enabled even when no deck editor tabs are open; it just doesn't do anything when hovered over.

<img width="271" alt="Screenshot 2025-01-26 at 2 11 19 AM" src="https://github.com/user-attachments/assets/42cdb7c3-ed8b-4d1b-8d8b-ccbe5e2d563d" />

## What will change with this Pull Request?

https://github.com/user-attachments/assets/a7d982a0-f2ea-477b-af98-72f264e775a2

- "Add card to deck" menu is disabled when no deck editor tabs are open
- Rename the menu options from `"Add card to" + tab name` to just `tab name` since it's already obvious that you're adding the card to a deck

## Screenshots


