### PR TITLE
Fix up some methods to get file format from name

### DIFF
--- a/cockatrice/src/client/tabs/visual_deck_storage/tab_deck_storage_visual.cpp
+++ b/cockatrice/src/client/tabs/visual_deck_storage/tab_deck_storage_visual.cpp
@@ -25,7 +25,7 @@ TabDeckStorageVisual::TabDeckStorageVisual(TabSupervisor *_tabSupervisor)
 void TabDeckStorageVisual::actOpenLocalDeck(QMouseEvent * /*event*/, DeckPreviewWidget *instance)
 {
     DeckLoader deckLoader;
-    if (!deckLoader.loadFromFile(instance->filePath, DeckLoader::CockatriceFormat, true)) {
+    if (!deckLoader.loadFromFile(instance->filePath, DeckLoader::getFormatFromName(instance->filePath), true)) {
         return;
     }
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_addition_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_addition_widget.cpp
@@ -44,7 +44,7 @@ void DeckPreviewTagAdditionWidget::mousePressEvent(QMouseEvent *event)
 
     bool canAddTags = true;
 
-    if (parent->deckLoader->getLastFileFormat() != DeckLoader::CockatriceFormat) {
+    if (DeckLoader::getFormatFromName(parent->parent->filePath) != DeckLoader::CockatriceFormat) {
         canAddTags = false;
         // Retrieve saved preference if the prompt is disabled
         if (!SettingsCache::instance().getVisualDeckStoragePromptForConversion()) {


### PR DESCRIPTION
## Short roundup of the initial problem
Changes a comparison against Cockatrice Format to use the actual instance->filepath instead of the DeckLoaders last used format and changes actOpenLocalDeck to get the file format from the name instead of just defaulting to CockatriceFormat.