### PR TITLE
remove refreshTree call in remote model's constructors

### DIFF
--- a/cockatrice/src/server/remote/remote_decklist_tree_widget.cpp
+++ b/cockatrice/src/server/remote/remote_decklist_tree_widget.cpp
@@ -86,7 +86,6 @@ RemoteDeckList_TreeModel::RemoteDeckList_TreeModel(AbstractClient *_client, QObj
     fileIcon = fip.icon(QFileIconProvider::File);
 
     root = new DirectoryNode;
-    refreshTree();
 }
 
 RemoteDeckList_TreeModel::~RemoteDeckList_TreeModel()

--- a/cockatrice/src/server/remote/remote_replay_list_tree_widget.cpp
+++ b/cockatrice/src/server/remote/remote_replay_list_tree_widget.cpp
@@ -37,8 +37,6 @@ RemoteReplayList_TreeModel::RemoteReplayList_TreeModel(AbstractClient *_client, 
     dirIcon = fip.icon(QFileIconProvider::Folder);
     fileIcon = fip.icon(QFileIconProvider::File);
     lockIcon = QPixmap("theme:icons/lock");
-
-    refreshTree();
 }
 
 RemoteReplayList_TreeModel::~RemoteReplayList_TreeModel()


### PR DESCRIPTION
## Short roundup of the initial problem

Cockatrice logs a warn when the deck storage tab or replays tab is opened while offline, due to it trying to get the remote info and failing.

![image-47](https://github.com/user-attachments/assets/5942ea85-fc46-4825-b3ba-0ec0d6de75b5)


## What will change with this Pull Request?

Don't call `refreshTree` in the model's constructor. The tab already handles calling refreshTree depending on if the client is connected or not, so this extra call to `refreshTree` is redundant anyways 
