### PR TITLE
fix view transform button disappearing on click

### DIFF
--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
@@ -151,9 +151,6 @@ void CardInfoFrameWidget::setCard(CardInfoPtr card)
         disconnect(info.data(), nullptr, this, nullptr);
     }
 
-    if (viewTransformationButton) {
-        viewTransformationButton->setVisible(false);
-    }
     info = std::move(card);
 
     if (info) {


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5512

## Short roundup of the initial problem

https://github.com/user-attachments/assets/03222c1b-7cb8-449e-bcd6-b0746925aaa2

The `View Transformation` button disappears if you select a new transforming card while the previous card was transforming. That means the button disappears if you click it, since it would set the backside, which is a new card that also transforms.

The cause seems to be extraneous code that was left over because two people merged in two different ways to do the same thing at the same time.

## What will change with this Pull Request?

- Remove the code that sets the transform button visibility, since we always delete the button now instead of hiding it.