### PR TITLE
move deck conversion settings into deck settings group

### DIFF
--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -573,15 +573,6 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     connect(&useTearOffMenusCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             [](const QT_STATE_CHANGED_T state) { SettingsCache::instance().setUseTearOffMenus(state == Qt::Checked); });
 
-    visualDeckStoragePromptForConversionCheckBox.setChecked(
-        SettingsCache::instance().getVisualDeckStoragePromptForConversion());
-    connect(&visualDeckStoragePromptForConversionCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
-            &SettingsCache::setVisualDeckStoragePromptForConversion);
-
-    visualDeckStorageAlwaysConvertCheckBox.setChecked(SettingsCache::instance().getVisualDeckStorageAlwaysConvert());
-    connect(&visualDeckStorageAlwaysConvertCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
-            &SettingsCache::setVisualDeckStorageAlwaysConvert);
-
     auto *generalGrid = new QGridLayout;
     generalGrid->addWidget(&doubleClickToPlayCheckBox, 0, 0);
     generalGrid->addWidget(&clickPlaysAllSelectedCheckBox, 1, 0);
@@ -589,8 +580,6 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     generalGrid->addWidget(&closeEmptyCardViewCheckBox, 3, 0);
     generalGrid->addWidget(&annotateTokensCheckBox, 4, 0);
     generalGrid->addWidget(&useTearOffMenusCheckBox, 5, 0);
-    generalGrid->addWidget(&visualDeckStoragePromptForConversionCheckBox, 6, 0);
-    generalGrid->addWidget(&visualDeckStorageAlwaysConvertCheckBox, 7, 0);
 
     generalGroupBox = new QGroupBox;
     generalGroupBox->setLayout(generalGrid);
@@ -619,8 +608,19 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     connect(&openDeckInNewTabCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setOpenDeckInNewTab);
 
+    visualDeckStoragePromptForConversionCheckBox.setChecked(
+        SettingsCache::instance().getVisualDeckStoragePromptForConversion());
+    connect(&visualDeckStoragePromptForConversionCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setVisualDeckStoragePromptForConversion);
+
+    visualDeckStorageAlwaysConvertCheckBox.setChecked(SettingsCache::instance().getVisualDeckStorageAlwaysConvert());
+    connect(&visualDeckStorageAlwaysConvertCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setVisualDeckStorageAlwaysConvert);
+
     auto *deckEditorGrid = new QGridLayout;
     deckEditorGrid->addWidget(&openDeckInNewTabCheckBox, 0, 0);
+    deckEditorGrid->addWidget(&visualDeckStoragePromptForConversionCheckBox, 1, 0);
+    deckEditorGrid->addWidget(&visualDeckStorageAlwaysConvertCheckBox, 2, 0);
 
     deckEditorGroupBox = new QGroupBox;
     deckEditorGroupBox->setLayout(deckEditorGrid);
@@ -669,16 +669,16 @@ void UserInterfaceSettingsPage::retranslateUi()
     closeEmptyCardViewCheckBox.setText(tr("Close card view window when last card is removed"));
     annotateTokensCheckBox.setText(tr("Annotate card text on tokens"));
     useTearOffMenusCheckBox.setText(tr("Use tear-off menus, allowing right click menus to persist on screen"));
-    visualDeckStoragePromptForConversionCheckBox.setText(tr("Prompt before converting .txt decks to .cod format"));
-    visualDeckStorageAlwaysConvertCheckBox.setText(tr("Always convert if not prompted"));
     notificationsGroupBox->setTitle(tr("Notifications settings"));
     notificationsEnabledCheckBox.setText(tr("Enable notifications in taskbar"));
     specNotificationsEnabledCheckBox.setText(tr("Notify in the taskbar for game events while you are spectating"));
     buddyConnectNotificationsEnabledCheckBox.setText(tr("Notify in the taskbar when users in your buddy list connect"));
     animationGroupBox->setTitle(tr("Animation settings"));
     tapAnimationCheckBox.setText(tr("&Tap/untap animation"));
-    deckEditorGroupBox->setTitle(tr("Deck editor settings"));
+    deckEditorGroupBox->setTitle(tr("Deck editor/storage settings"));
     openDeckInNewTabCheckBox.setText(tr("Open deck in new tab by default"));
+    visualDeckStoragePromptForConversionCheckBox.setText(tr("Prompt before converting .txt decks to .cod format"));
+    visualDeckStorageAlwaysConvertCheckBox.setText(tr("Always convert if not prompted"));
     replayGroupBox->setTitle(tr("Replay settings"));
     rewindBufferingMsLabel.setText(tr("Buffer time for backwards skip via shortcut:"));
     rewindBufferingMsBox.setSuffix(" ms");

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -142,10 +142,10 @@ private:
     QCheckBox closeEmptyCardViewCheckBox;
     QCheckBox annotateTokensCheckBox;
     QCheckBox useTearOffMenusCheckBox;
-    QCheckBox visualDeckStoragePromptForConversionCheckBox;
-    QCheckBox visualDeckStorageAlwaysConvertCheckBox;
     QCheckBox tapAnimationCheckBox;
     QCheckBox openDeckInNewTabCheckBox;
+    QCheckBox visualDeckStoragePromptForConversionCheckBox;
+    QCheckBox visualDeckStorageAlwaysConvertCheckBox;
     QLabel rewindBufferingMsLabel;
     QSpinBox rewindBufferingMsBox;
     QGroupBox *generalGroupBox;


### PR DESCRIPTION
## Short roundup of the initial problem

The deck conversion settings are in the `General Interface settings`. I feel like it would belong better under the same group as the `open deck editor in new tab` setting.

<img width="747" alt="Screenshot 2025-01-31 at 7 47 59 PM" src="https://github.com/user-attachments/assets/26ff511f-4a9f-467d-b1ae-7dde21241431" />

## What will change with this Pull Request?

* Moved the two deck conversion settings to that group
* Rename that group to `Deck editor/storage settings`

<img width="747" alt="Screenshot 2025-01-31 at 7 47 32 PM" src="https://github.com/user-attachments/assets/c40411cf-02da-4d31-9d9c-2a9a02a820a0" />
