### PR TITLE
Make settings window scrollable

### DIFF
--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -181,6 +181,9 @@ GeneralSettingsPage::GeneralSettingsPage()
     updateReleaseChannelBox.setCurrentIndex(settings.getUpdateReleaseChannelIndex());
 
     setLayout(mainLayout);
+
+    connect(&SettingsCache::instance(), &SettingsCache::langChanged, this, &GeneralSettingsPage::retranslateUi);
+    retranslateUi();
 }
 
 QStringList GeneralSettingsPage::findQmFiles()
@@ -464,6 +467,9 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     mainLayout->addStretch();
 
     setLayout(mainLayout);
+
+    connect(&SettingsCache::instance(), &SettingsCache::langChanged, this, &AppearanceSettingsPage::retranslateUi);
+    retranslateUi();
 }
 
 void AppearanceSettingsPage::themeBoxChanged(int index)
@@ -648,6 +654,9 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     mainLayout->addStretch();
 
     setLayout(mainLayout);
+
+    connect(&SettingsCache::instance(), &SettingsCache::langChanged, this, &UserInterfaceSettingsPage::retranslateUi);
+    retranslateUi();
 }
 
 void UserInterfaceSettingsPage::setNotificationEnabled(QT_STATE_CHANGED_T i)
@@ -820,6 +829,9 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     lpMainLayout->addWidget(mpSpoilerGroupBox);
 
     setLayout(lpMainLayout);
+
+    connect(&SettingsCache::instance(), &SettingsCache::langChanged, this, &DeckEditorSettingsPage::retranslateUi);
+    retranslateUi();
 }
 
 void DeckEditorSettingsPage::resetDownloadedURLsButtonClicked()
@@ -1122,6 +1134,7 @@ MessagesSettingsPage::MessagesSettingsPage()
 
     setLayout(mainLayout);
 
+    connect(&SettingsCache::instance(), &SettingsCache::langChanged, this, &MessagesSettingsPage::retranslateUi);
     retranslateUi();
 }
 
@@ -1296,6 +1309,9 @@ SoundSettingsPage::SoundSettingsPage()
     mainLayout->addStretch();
 
     setLayout(mainLayout);
+
+    connect(&SettingsCache::instance(), &SettingsCache::langChanged, this, &SoundSettingsPage::retranslateUi);
+    retranslateUi();
 }
 
 void SoundSettingsPage::themeBoxChanged(int index)
@@ -1388,6 +1404,9 @@ ShortcutSettingsPage::ShortcutSettingsPage()
     connect(btnClearAll, SIGNAL(clicked()), this, SLOT(clearShortcuts()));
 
     connect(shortcutsTable, &ShortcutTreeView::currentItemChanged, this, &ShortcutSettingsPage::currentItemChanged);
+
+    connect(&SettingsCache::instance(), &SettingsCache::langChanged, this, &ShortcutSettingsPage::retranslateUi);
+    retranslateUi();
 }
 
 void ShortcutSettingsPage::currentItemChanged(const QString &key)
@@ -1475,6 +1494,7 @@ DlgSettings::DlgSettings(QWidget *parent) : QDialog(parent)
     mainLayout->addWidget(buttonBox);
     setLayout(mainLayout);
 
+    connect(&SettingsCache::instance(), &SettingsCache::langChanged, this, &DlgSettings::retranslateUi);
     retranslateUi();
 
     adjustSize();
@@ -1541,13 +1561,6 @@ void DlgSettings::updateLanguage()
 {
     qApp->removeTranslator(translator); // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
     installNewTranslator();
-}
-
-void DlgSettings::changeEvent(QEvent *event)
-{
-    if (event->type() == QEvent::LanguageChange)
-        retranslateUi();
-    QDialog::changeEvent(event);
 }
 
 void DlgSettings::closeEvent(QCloseEvent *event)
@@ -1637,9 +1650,6 @@ void DlgSettings::retranslateUi()
     messagesButton->setText(tr("Chat"));
     soundButton->setText(tr("Sound"));
     shortcutsButton->setText(tr("Shortcuts"));
-
-    for (int i = 0; i < pagesWidget->count(); i++)
-        dynamic_cast<AbstractSettingsPage *>(pagesWidget->widget(i))->retranslateUi();
 
     contentsWidget->reset();
 }

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -1438,7 +1438,7 @@ void ShortcutSettingsPage::retranslateUi()
 DlgSettings::DlgSettings(QWidget *parent) : QDialog(parent)
 {
     auto rec = QGuiApplication::primaryScreen()->availableGeometry();
-    this->setBaseSize(qMin(700, rec.width()), qMin(700, rec.height()));
+    this->setMinimumSize(qMin(700, rec.width()), qMin(700, rec.height()));
 
     connect(&SettingsCache::instance(), SIGNAL(langChanged()), this, SLOT(updateLanguage()));
 

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -34,6 +34,8 @@
 #include <QPushButton>
 #include <QRadioButton>
 #include <QScreen>
+#include <QScrollArea>
+#include <QScrollBar>
 #include <QSlider>
 #include <QSpinBox>
 #include <QStackedWidget>
@@ -1454,6 +1456,19 @@ void ShortcutSettingsPage::retranslateUi()
     searchEdit->setPlaceholderText(tr("Search by shortcut name"));
 }
 
+static QScrollArea *makeScrollable(QWidget *widget)
+{
+    widget->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Maximum);
+
+    auto *scrollArea = new QScrollArea;
+    scrollArea->setWidgetResizable(true);
+    scrollArea->setContentsMargins(0, 0, 0, 0);
+    scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    scrollArea->horizontalScrollBar()->setEnabled(false);
+    scrollArea->setWidget(widget);
+    return scrollArea;
+}
+
 DlgSettings::DlgSettings(QWidget *parent) : QDialog(parent)
 {
     auto rec = QGuiApplication::primaryScreen()->availableGeometry();
@@ -1471,8 +1486,8 @@ DlgSettings::DlgSettings(QWidget *parent) : QDialog(parent)
 
     pagesWidget = new QStackedWidget;
     pagesWidget->addWidget(new GeneralSettingsPage);
-    pagesWidget->addWidget(new AppearanceSettingsPage);
-    pagesWidget->addWidget(new UserInterfaceSettingsPage);
+    pagesWidget->addWidget(makeScrollable(new AppearanceSettingsPage));
+    pagesWidget->addWidget(makeScrollable(new UserInterfaceSettingsPage));
     pagesWidget->addWidget(new DeckEditorSettingsPage);
     pagesWidget->addWidget(new MessagesSettingsPage);
     pagesWidget->addWidget(new SoundSettingsPage);

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -323,7 +323,6 @@ private:
     void retranslateUi();
 
 protected:
-    void changeEvent(QEvent *event) override;
     void closeEvent(QCloseEvent *event) override;
 };
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5380
- Reverts change made in https://github.com/Cockatrice/Cockatrice/commit/3cd7a0400235df72a3f938aaf38a853f9a76a9ef

## Short roundup of the initial problem

We ran out of vertical space in the appearance menu since we added so many new settings, so we made the minimum settings window height uncapped, but that seemed to cause issues for some people

## What will change with this Pull Request?

https://github.com/user-attachments/assets/aab485c9-ad7d-4c71-bee0-ffaf7b1d19c1

- `User Interface` and `Appearance` tabs are now scrollable.
  - Haven't made the other tabs scrollable yet since they still have enough room.

## Screenshots

<img width="711" alt="Screenshot 2025-01-31 at 8 45 07 PM" src="https://github.com/user-attachments/assets/cafab68b-5240-47b1-9a11-f7aee5a0d8fd" />

