### PR TITLE
refactor: pass ServerInfo_User down to appendMessage

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -882,8 +882,7 @@ void TabGame::closeGame()
 void TabGame::eventSpectatorSay(const Event_GameSay &event, int eventPlayerId, const GameEventContext & /*context*/)
 {
     const ServerInfo_User &userInfo = spectators.value(eventPlayerId);
-    messageLog->logSpectatorSay(QString::fromStdString(userInfo.name()), UserLevelFlags(userInfo.user_level()),
-                                QString::fromStdString(userInfo.privlevel()), QString::fromStdString(event.message()));
+    messageLog->logSpectatorSay(userInfo, QString::fromStdString(event.message()));
 }
 
 void TabGame::eventSpectatorLeave(const Event_Leave &event, int eventPlayerId, const GameEventContext & /*context*/)

--- a/cockatrice/src/client/tabs/tab_message.cpp
+++ b/cockatrice/src/client/tabs/tab_message.cpp
@@ -118,11 +118,8 @@ void TabMessage::messageSent(const Response &response)
 void TabMessage::processUserMessageEvent(const Event_UserMessage &event)
 {
     auto userInfo = event.sender_name() == otherUserInfo->name() ? otherUserInfo : ownUserInfo;
-    const UserLevelFlags userLevel(userInfo->user_level());
-    const QString userPriv = QString::fromStdString(userInfo->privlevel());
 
-    chatView->appendMessage(QString::fromStdString(event.message()), {}, QString::fromStdString(event.sender_name()),
-                            userLevel, userPriv, true);
+    chatView->appendMessage(QString::fromStdString(event.message()), {}, *userInfo, true);
     if (tabSupervisor->currentIndex() != tabSupervisor->indexOf(this))
         soundEngine->playSound("private_message");
     if (SettingsCache::instance().getShowMessagePopup() && shouldShowSystemPopup(event))

--- a/cockatrice/src/client/tabs/tab_room.cpp
+++ b/cockatrice/src/client/tabs/tab_room.cpp
@@ -287,13 +287,11 @@ void TabRoom::processRoomSayEvent(const Event_RoomSay &event)
         return;
 
     UserListTWI *twi = userList->getUsers().value(senderName);
-    UserLevelFlags userLevel;
-    QString userPrivLevel;
+    ServerInfo_User userInfo = {};
     if (twi) {
-        userLevel = UserLevelFlags(twi->getUserInfo().user_level());
-        userPrivLevel = QString::fromStdString(twi->getUserInfo().privlevel());
+        userInfo = twi->getUserInfo();
         if (SettingsCache::instance().getIgnoreUnregisteredUsers() &&
-            !userLevel.testFlag(ServerInfo_User::IsRegistered))
+            !UserLevelFlags(userInfo.user_level()).testFlag(ServerInfo_User::IsRegistered))
             return;
     }
 
@@ -306,7 +304,7 @@ void TabRoom::processRoomSayEvent(const Event_RoomSay &event)
             QString(QDateTime::fromMSecsSinceEpoch(event.time_of()).toLocalTime().toString("d MMM yyyy HH:mm:ss")) +
             "] " + message;
 
-    chatView->appendMessage(message, event.message_type(), senderName, userLevel, userPrivLevel, true);
+    chatView->appendMessage(message, event.message_type(), userInfo, true);
     emit userEvent(false);
 }
 

--- a/cockatrice/src/server/chat_view/chat_view.cpp
+++ b/cockatrice/src/server/chat_view/chat_view.cpp
@@ -149,11 +149,12 @@ void ChatView::appendUrlTag(QTextCursor &cursor, QString url)
 
 void ChatView::appendMessage(QString message,
                              RoomMessageTypeFlags messageType,
-                             const QString &userName,
-                             UserLevelFlags userLevel,
-                             QString UserPrivLevel,
+                             const ServerInfo_User &userInfo,
                              bool playerBold)
 {
+    const QString userName = QString::fromStdString(userInfo.name());
+    const UserLevelFlags userLevel = UserLevelFlags(userInfo.user_level());
+
     bool atBottom = verticalScrollBar()->value() >= verticalScrollBar()->maximum();
     // messageType should be Event_RoomSay::UserMessage though we don't actually check
     bool isUserMessage = !(userName.toLower() == "servatrice" || userName.isEmpty());
@@ -189,8 +190,9 @@ void ChatView::appendMessage(QString message,
         } else {
             const int pixelSize = QFontInfo(cursor.charFormat().font()).pixelSize();
             bool isBuddy = userListProxy->isUserBuddy(userName);
+            const QString privLevel = userInfo.has_privlevel() ? QString::fromStdString(userInfo.privlevel()) : "NONE";
             cursor.insertImage(
-                UserLevelPixmapGenerator::generatePixmap(pixelSize, userLevel, isBuddy, UserPrivLevel).toImage());
+                UserLevelPixmapGenerator::generatePixmap(pixelSize, userLevel, isBuddy, privLevel).toImage());
             cursor.insertText(" ");
             cursor.setCharFormat(senderFormat);
             cursor.insertText(userName);

--- a/cockatrice/src/server/chat_view/chat_view.h
+++ b/cockatrice/src/server/chat_view/chat_view.h
@@ -91,9 +91,7 @@ public:
                                          QString optionalFontColor = QString());
     void appendMessage(QString message,
                        RoomMessageTypeFlags messageType = {},
-                       const QString &userName = QString(),
-                       UserLevelFlags userLevel = UserLevelFlags(),
-                       QString UserPrivLevel = "NONE",
+                       const ServerInfo_User &userInfo = {},
                        bool playerBold = false);
     void clearChat();
     void redactMessages(const QString &userName, int amount);

--- a/cockatrice/src/server/message_log_widget.cpp
+++ b/cockatrice/src/server/message_log_widget.cpp
@@ -606,8 +606,7 @@ void MessageLogWidget::logRollDie(Player *player, int sides, const QList<uint> &
 
 void MessageLogWidget::logSay(Player *player, QString message)
 {
-    appendMessage(std::move(message), {}, player->getName(), UserLevelFlags(player->getUserInfo()->user_level()),
-                  QString::fromStdString(player->getUserInfo()->privlevel()), true);
+    appendMessage(std::move(message), {}, *player->getUserInfo(), true);
 }
 
 void MessageLogWidget::logSetActivePhase(int phaseNumber)
@@ -783,12 +782,9 @@ void MessageLogWidget::logShuffle(Player *player, CardZone *zone, int start, int
     }
 }
 
-void MessageLogWidget::logSpectatorSay(QString spectatorName,
-                                       UserLevelFlags spectatorUserLevel,
-                                       QString userPrivLevel,
-                                       QString message)
+void MessageLogWidget::logSpectatorSay(const ServerInfo_User &spectator, QString message)
 {
-    appendMessage(std::move(message), {}, spectatorName, spectatorUserLevel, userPrivLevel, false);
+    appendMessage(std::move(message), {}, spectator, false);
 }
 
 void MessageLogWidget::logUnattachCard(Player *player, QString cardName)

--- a/cockatrice/src/server/message_log_widget.h
+++ b/cockatrice/src/server/message_log_widget.h
@@ -92,8 +92,7 @@ public slots:
     void logSetSideboardLock(Player *player, bool locked);
     void logSetTapped(Player *player, CardItem *card, bool tapped);
     void logShuffle(Player *player, CardZone *zone, int start, int end);
-    void
-    logSpectatorSay(QString spectatorName, UserLevelFlags spectatorUserLevel, QString userPrivLevel, QString message);
+    void logSpectatorSay(const ServerInfo_User &spectator, QString message);
     void logUnattachCard(Player *player, QString cardName);
     void logUndoDraw(Player *player, QString cardName);
     void setContextJudgeName(QString player);


### PR DESCRIPTION
## Short roundup of the initial problem

Refactor ahead of adding custom pawn colors.

The pawn colors will be stored in `ServerInfo_User`, and we need to pass the pawn color down to the place where we append the chat message.

## What will change with this Pull Request?
- pass the entire `ServerInfo_User` object down to `ChatView::appendMessage` instead of just the parts

