### PR TITLE
Fix size and image quality issues with new user icons

### DIFF
--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -809,10 +809,10 @@ void TabSupervisor::processUserJoined(const ServerInfo_User &userInfoJoined)
         if (auto *tab = getTabAccount()) {
             if (tab != currentWidget()) {
                 tab->setContentsChanged(true);
-                QPixmap avatarPixmap = UserLevelPixmapGenerator::generatePixmap(
+                QIcon avatarIcon = UserLevelPixmapGenerator::generateIcon(
                     13, (UserLevelFlags)userInfoJoined.user_level(), userInfoJoined.pawn_colors(), true,
                     QString::fromStdString(userInfoJoined.privlevel()));
-                setTabIcon(indexOf(tab), QPixmap(avatarPixmap));
+                setTabIcon(indexOf(tab), avatarIcon);
             }
         }
 

--- a/cockatrice/src/client/ui/pixel_map_generator.h
+++ b/cockatrice/src/client/ui/pixel_map_generator.h
@@ -81,7 +81,7 @@ public:
                                   bool isBuddy,
                                   const QString &privLevel);
 
-    static QIcon generateIcon(int height,
+    static QIcon generateIcon(int minHeight,
                               UserLevelFlags userLevel,
                               ServerInfo_User::PawnColorsOverride pawnColors,
                               bool isBuddy,

--- a/cockatrice/src/game/game_selector.cpp
+++ b/cockatrice/src/game/game_selector.cpp
@@ -50,6 +50,7 @@ GameSelector::GameSelector(AbstractClient *_client,
     } else {
         gameListView->setModel(gameListModel);
     }
+    gameListView->setIconSize(QSize(13, 13));
     gameListView->setSortingEnabled(true);
     gameListView->sortByColumn(gameListModel->startTimeColIndex(), Qt::AscendingOrder);
     gameListView->setAlternatingRowColors(true);

--- a/cockatrice/src/game/games_model.cpp
+++ b/cockatrice/src/game/games_model.cpp
@@ -118,11 +118,10 @@ QVariant GamesModel::data(const QModelIndex &index, int role) const
                 case Qt::DisplayRole:
                     return QString::fromStdString(gameentry.creator_info().name());
                 case Qt::DecorationRole: {
-                    QPixmap avatarPixmap = UserLevelPixmapGenerator::generatePixmap(
-                        13, (UserLevelFlags)gameentry.creator_info().user_level(),
+                    return UserLevelPixmapGenerator::generateIcon(
+                        13, UserLevelFlags(gameentry.creator_info().user_level()),
                         gameentry.creator_info().pawn_colors(), false,
                         QString::fromStdString(gameentry.creator_info().privlevel()));
-                    return QIcon(avatarPixmap);
                 }
                 default:
                     return QVariant();

--- a/cockatrice/src/game/player/player_list_widget.cpp
+++ b/cockatrice/src/game/player/player_list_widget.cpp
@@ -140,9 +140,9 @@ void PlayerListWidget::updatePlayerProperties(const ServerInfo_PlayerProperties 
     }
     if (prop.has_user_info()) {
         player->setData(3, Qt::UserRole, prop.user_info().user_level());
-        player->setIcon(3, QIcon(UserLevelPixmapGenerator::generatePixmap(
+        player->setIcon(3, UserLevelPixmapGenerator::generateIcon(
                                12, UserLevelFlags(prop.user_info().user_level()), prop.user_info().pawn_colors(), false,
-                               QString::fromStdString(prop.user_info().privlevel()))));
+                               QString::fromStdString(prop.user_info().privlevel())));
         player->setText(4, QString::fromStdString(prop.user_info().name()));
         const QString country = QString::fromStdString(prop.user_info().country());
         if (!country.isEmpty())

--- a/cockatrice/src/server/user/user_info_box.h
+++ b/cockatrice/src/server/user/user_info_box.h
@@ -20,6 +20,8 @@ private:
         countryLabel3, userLevelLabel1, userLevelLabel2, accountAgeLabel1, accountAgeLabel2;
     QPushButton editButton, passwordButton, avatarButton;
     QPixmap avatarPixmap;
+    bool hasAvatar;
+    const ServerInfo_User *currentUserInfo;
 
     static QString getAgeString(int ageSeconds);
 


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5543

## Short roundup of the initial problem

When the server has custom color user icons enabled:
- Icon in user info window and in-game profile picture is too small
- Icon has low image quality in places where it gets rescaled

## What will change with this Pull Request?

https://github.com/user-attachments/assets/04e94b0a-8648-48b7-ba2b-4d19be877cd1

- refactor some stuff
- svg loader will scale up the svg to at least the given height
  - `QIcon::pixmap(QSize)` automatically scales down the image (without losing image quality), but will not automatically scale up the image
  - we always load the svg with at least source size, but scaled it up if required  
- fix user icon quality and size in game selector
  - directly calling generateIcon instead of pixmap into icon fixes image quality
  -  `gameListView->setIconSize` fixes size

## Screenshots
<img width="1396" alt="Screenshot 2025-02-02 at 3 45 33 AM" src="https://github.com/user-attachments/assets/b921614d-e8aa-498e-9dc6-6eaeba52cf4d" />

<img width="1402" alt="Screenshot 2025-02-02 at 3 45 19 AM" src="https://github.com/user-attachments/assets/0f7dba3f-8149-435d-b004-28780515413a" />

<img width="1402" alt="Screenshot 2025-02-02 at 3 44 54 AM" src="https://github.com/user-attachments/assets/620dfb4b-e25a-4ce6-af7c-3e3b807332c3" />

