### PR TITLE
Hotfix VDS sizing scrollArea widget incorrectly when created while not visible by setting size in showEvent

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -72,8 +72,10 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
 void VisualDeckStorageWidget::resizeEvent(QResizeEvent *event)
 {
     QWidget::resizeEvent(event);
-    scrollArea->widget()->setMaximumWidth(scrollArea->viewport()->width());
-    scrollArea->widget()->adjustSize();
+    if (scrollArea->widget() == folderWidget) {
+        scrollArea->widget()->setMaximumWidth(scrollArea->viewport()->width());
+        scrollArea->widget()->adjustSize();
+    }
 }
 
 void VisualDeckStorageWidget::retranslateUi()

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -69,6 +69,15 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     }
 }
 
+void VisualDeckStorageWidget::showEvent(QShowEvent *event)
+{
+    QWidget::showEvent(event);
+    if (scrollArea->widget() == folderWidget) {
+        scrollArea->widget()->setMaximumWidth(scrollArea->viewport()->width());
+        scrollArea->widget()->adjustSize();
+    }
+}
+
 void VisualDeckStorageWidget::resizeEvent(QResizeEvent *event)
 {
     QWidget::resizeEvent(event);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -37,6 +37,7 @@ public slots:
     void updateSearchFilter();
     void updateSortOrder();
     void resizeEvent(QResizeEvent *event) override;
+    void showEvent(QShowEvent *event) override;
 
 signals:
     void bannerCardsRefreshed();


### PR DESCRIPTION
## Short roundup of the initial problem
Accidentally didn't push a commit before review, lol whoops.

ScrollAreas are a bit silly and will, for some reason, allow their widget to go just a *little* bit beyond the viewport, even if scrollbars are disabled in that direction. Previously, we set the max width of the scrollArea widget on resize to reign this in, trusting in Qt to resize on show. Turns out, Qt doesn't do this if the widget is already QT-"visible" which can actually mean that the widget is created but not shown in an actually visible Qt element. 

Qt will, however, trigger showEvent each time the UI element actually becomes visible, which means we can implement our clamping there.