### PR TITLE
add logging category for remote_client

### DIFF
--- a/cockatrice/resources/config/qtlogging.ini
+++ b/cockatrice/resources/config/qtlogging.ini
@@ -23,6 +23,8 @@
 # servers_settings = false
 # shortcuts_settings = false
 
+# remote_client = false
+
 # player = false
 # game_scene = false
 # game_scene.player_addition_removal = false

--- a/cockatrice/src/server/remote/remote_client.cpp
+++ b/cockatrice/src/server/remote/remote_client.cpp
@@ -140,7 +140,7 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
             hashedPassword = PasswordHasher::computeHash(password, passwordSalt);
             cmdForgotPasswordReset.set_hashed_new_password(hashedPassword.toStdString());
         } else if (!password.isEmpty()) {
-            qWarning() << "using plain text password to reset password";
+            qCWarning(RemoteClientLog) << "using plain text password to reset password";
             cmdForgotPasswordReset.set_new_password(password.toStdString());
         }
         PendingCommand *pend = prepareSessionCommand(cmdForgotPasswordReset);
@@ -170,7 +170,7 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
             hashedPassword = PasswordHasher::computeHash(password, passwordSalt);
             cmdRegister.set_hashed_password(hashedPassword.toStdString());
         } else if (!password.isEmpty()) {
-            qWarning() << "using plain text password to register";
+            qCWarning(RemoteClientLog) << "using plain text password to register";
             cmdRegister.set_password(password.toStdString());
         }
         cmdRegister.set_email(email.toStdString());
@@ -241,7 +241,7 @@ void RemoteClient::doLogin()
         setStatus(StatusLoggingIn);
         Command_Login cmdLogin = generateCommandLogin();
         if (!password.isEmpty()) {
-            qWarning() << "using plain text password to log in";
+            qCWarning(RemoteClientLog) << "using plain text password to log in";
             cmdLogin.set_password(password.toStdString());
         }
 
@@ -394,7 +394,7 @@ void RemoteClient::readData()
         ServerMessage newServerMessage;
         newServerMessage.ParseFromArray(inputBuffer.data(), messageLength);
 #ifdef QT_DEBUG
-        qDebug().noquote() << "IN" << getSafeDebugString(newServerMessage);
+        qCDebug(RemoteClientLog).noquote() << "IN" << getSafeDebugString(newServerMessage);
 #endif
         inputBuffer.remove(0, messageLength);
         messageInProgress = false;
@@ -412,7 +412,7 @@ void RemoteClient::websocketMessageReceived(const QByteArray &message)
     ServerMessage newServerMessage;
     newServerMessage.ParseFromArray(message.data(), message.length());
 #ifdef QT_DEBUG
-    qDebug().noquote() << "IN" << getSafeDebugString(newServerMessage);
+    qCDebug(RemoteClientLog).noquote() << "IN" << getSafeDebugString(newServerMessage);
 #endif
     processProtocolItem(newServerMessage);
 }
@@ -425,7 +425,7 @@ void RemoteClient::sendCommandContainer(const CommandContainer &cont)
     auto size = static_cast<unsigned int>(cont.ByteSize());
 #endif
 #ifdef QT_DEBUG
-    qDebug().noquote() << "OUT" << getSafeDebugString(cont);
+    qCDebug(RemoteClientLog).noquote() << "OUT" << getSafeDebugString(cont);
 #endif
 
     QByteArray buf;
@@ -590,7 +590,7 @@ QString RemoteClient::getSrvClientID(const QString &_hostname)
         QHostAddress hostAddress = hostInfo.addresses().first();
         srvClientID += hostAddress.toString();
     } else {
-        qWarning() << "ClientID generation host lookup failure [" << hostInfo.errorString() << "]";
+        qCWarning(RemoteClientLog) << "ClientID generation host lookup failure [" << hostInfo.errorString() << "]";
         srvClientID += _hostname;
     }
     QString uniqueServerClientID =

--- a/cockatrice/src/server/remote/remote_client.cpp
+++ b/cockatrice/src/server/remote/remote_client.cpp
@@ -393,9 +393,9 @@ void RemoteClient::readData()
 
         ServerMessage newServerMessage;
         newServerMessage.ParseFromArray(inputBuffer.data(), messageLength);
-#ifdef QT_DEBUG
+
         qCDebug(RemoteClientLog).noquote() << "IN" << getSafeDebugString(newServerMessage);
-#endif
+
         inputBuffer.remove(0, messageLength);
         messageInProgress = false;
 
@@ -411,9 +411,9 @@ void RemoteClient::websocketMessageReceived(const QByteArray &message)
     lastDataReceived = timeRunning;
     ServerMessage newServerMessage;
     newServerMessage.ParseFromArray(message.data(), message.length());
-#ifdef QT_DEBUG
+
     qCDebug(RemoteClientLog).noquote() << "IN" << getSafeDebugString(newServerMessage);
-#endif
+
     processProtocolItem(newServerMessage);
 }
 
@@ -424,9 +424,8 @@ void RemoteClient::sendCommandContainer(const CommandContainer &cont)
 #else
     auto size = static_cast<unsigned int>(cont.ByteSize());
 #endif
-#ifdef QT_DEBUG
+
     qCDebug(RemoteClientLog).noquote() << "OUT" << getSafeDebugString(cont);
-#endif
 
     QByteArray buf;
     if (usingWebSocket) {

--- a/cockatrice/src/server/remote/remote_client.h
+++ b/cockatrice/src/server/remote/remote_client.h
@@ -4,8 +4,11 @@
 #include "../../client/game_logic/abstract_client.h"
 #include "pb/commands.pb.h"
 
+#include <QLoggingCategory>
 #include <QTcpSocket>
 #include <QWebSocket>
+
+inline Q_LOGGING_CATEGORY(RemoteClientLog, "remote_client");
 
 class QTimer;
 


### PR DESCRIPTION
## Short roundup of the initial problem

`RemoteClient` outputs a lot of log spam. Somehow we haven't set a logging category for it yet

## What will change with this Pull Request?

- Add logging category for `RemoteClient`
- use logging category in `RemoteClient`
  - Removed the `#ifdef QT_DEBUG` around the debug calls