### PR TITLE
preserve image quality when scaling svg

### DIFF
--- a/cockatrice/src/client/ui/pixel_map_generator.cpp
+++ b/cockatrice/src/client/ui/pixel_map_generator.cpp
@@ -61,6 +61,11 @@ QMap<QString, QPixmap> CounterPixmapGenerator::pmCache;
 
 QPixmap CounterPixmapGenerator::generatePixmap(int height, QString name, bool highlight)
 {
+    // The colorless counter is named "x" by the server but the file is named "general.svg"
+    if (name == "x") {
+        name = "general";
+    }
+
     if (highlight)
         name.append("_highlight");
     QString key = name + QString::number(height);
@@ -68,6 +73,8 @@ QPixmap CounterPixmapGenerator::generatePixmap(int height, QString name, bool hi
         return pmCache.value(key);
 
     QPixmap pixmap = loadSvg("theme:counters/" + name, QSize(height, height));
+
+    // fall back to colorless counter if the name can't be found
     if (pixmap.isNull()) {
         name = "general";
         if (highlight)

--- a/cockatrice/src/client/ui/pixel_map_generator.cpp
+++ b/cockatrice/src/client/ui/pixel_map_generator.cpp
@@ -14,6 +14,8 @@
  *
  * @param svgPath The path to the svg file. Automatically appends ".svg" to the end if not present
  * @param size The desired size of the pixmap
+ *
+ * @return The svg loaded into a Pixmap with the given size, or an empty Pixmap if the loading failed.
  */
 static QPixmap loadSvg(const QString &svgPath, const QSize &size)
 {
@@ -23,6 +25,11 @@ static QPixmap loadSvg(const QString &svgPath, const QSize &size)
     }
 
     QSvgRenderer svgRenderer(path);
+
+    if (!svgRenderer.isValid()) {
+        qCWarning(PixelMapGeneratorLog) << "Failed to load" << path;
+        return {};
+    }
 
     // Makes sure the pixmap is at least as large as the svg, so that we don't lose any detail.
     // QIcon.pixmap(size) will automatically scale down the image, but it won't scale it up.


### PR DESCRIPTION
## Short roundup of the initial problem

Currently, when we need a pixmap of an svg, we load it into the pixmap first and then scale the pixmap, which destroys the image quality.

## What will change with this Pull Request?

- Scale the svg itself instead of the pixmap, so the image quality doesn't get destroyed

## Screenshots
Before

<img width="1399" alt="Screenshot 2025-02-02 at 5 27 32 PM" src="https://github.com/user-attachments/assets/b2a7bf68-eabb-4c47-bc08-7b30db4bd3f4" />

<img width="1402" alt="Screenshot 2025-02-02 at 5 28 02 PM" src="https://github.com/user-attachments/assets/e37f8185-e146-438e-a325-f4fb6e9ce42a" />

After

<img width="1401" alt="Screenshot 2025-02-02 at 5 28 20 PM" src="https://github.com/user-attachments/assets/9bab2830-4790-42d3-8dc3-feba1722e992" />

<img width="1402" alt="Screenshot 2025-02-02 at 5 28 47 PM" src="https://github.com/user-attachments/assets/98362503-9ce5-434c-928b-e4ed916b67b1" />
