### PR TITLE
fix wrong size flag bounding rect on windows

### DIFF
--- a/cockatrice/src/client/ui/pixel_map_generator.cpp
+++ b/cockatrice/src/client/ui/pixel_map_generator.cpp
@@ -127,8 +127,13 @@ QPixmap CountryPixmapGenerator::generatePixmap(int height, const QString &countr
 
     QPainter painter(&pixmap);
     painter.setPen(Qt::black);
+
+#ifdef Q_OS_WIN
+    painter.drawRect(0, 0, pixmap.width(), pixmap.height());
+#else
     // determined through trial-and-error that /2 maps the pixmap coords to the painter coords
     painter.drawRect(0, 0, pixmap.width() / 2, pixmap.height() / 2);
+#endif
 
     pmCache.insert(key, pixmap);
     return pixmap;

--- a/cockatrice/src/client/ui/pixel_map_generator.cpp
+++ b/cockatrice/src/client/ui/pixel_map_generator.cpp
@@ -128,10 +128,10 @@ QPixmap CountryPixmapGenerator::generatePixmap(int height, const QString &countr
     QPainter painter(&pixmap);
     painter.setPen(Qt::black);
 
+    // width/height offset was determined through trial-and-error
 #ifdef Q_OS_WIN
-    painter.drawRect(0, 0, pixmap.width(), pixmap.height());
+    painter.drawRect(0, 0, pixmap.width() - 1, pixmap.height() - 1);
 #else
-    // determined through trial-and-error that /2 maps the pixmap coords to the painter coords
     painter.drawRect(0, 0, pixmap.width() / 2, pixmap.height() / 2);
 #endif
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes issue introduced in #5554

## Short roundup of the initial problem

On windows, flag bounding rect is too small

![image-47](https://github.com/user-attachments/assets/c81b7528-45b5-4424-919a-72a7aabb9a56)

## What will change with this Pull Request?

- Don't do the `size / 2` on windows 

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
