### PR TITLE
reduce vertical spacing in DeckPreviewWidget

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_widget.cpp
@@ -121,7 +121,7 @@ DeckPreviewColorIdentityWidget::DeckPreviewColorIdentityWidget(QWidget *parent, 
 {
     QHBoxLayout *layout = new QHBoxLayout(this);
     layout->setSpacing(5);
-    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setContentsMargins(0, 3, 0, 0);
     setLayout(layout);
 
     setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.cpp
@@ -16,7 +16,7 @@ DeckPreviewDeckTagsDisplayWidget::DeckPreviewDeckTagsDisplayWidget(DeckPreviewWi
 
     // Create layout
     auto *layout = new QHBoxLayout(this);
-    layout->setContentsMargins(5, 5, 5, 5);
+    layout->setContentsMargins(5, 0, 5, 0);
     layout->setSpacing(5);
 
     setFixedHeight(100);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -15,6 +15,7 @@ DeckPreviewWidget::DeckPreviewWidget(QWidget *_parent,
     : QWidget(_parent), visualDeckStorageWidget(_visualDeckStorageWidget), filePath(_filePath)
 {
     layout = new QVBoxLayout(this);
+    layout->setSpacing(0);
     setLayout(layout);
 
     deckLoader = new DeckLoader();


### PR DESCRIPTION
## Short roundup of the initial problem

`DeckPreviewWidget` has some unused space

## What will change with this Pull Request?

Before
![before 1](https://github.com/user-attachments/assets/7f55cff9-dc99-4bd0-bc71-c5e32f5b2e5e)

After
![after 1](https://github.com/user-attachments/assets/84daab8e-ca07-45fa-90f2-c4d493c1beda)

---

Before
![before 2](https://github.com/user-attachments/assets/11212d05-5de1-4f45-8766-c933f2dfd444)

After
![after 2](https://github.com/user-attachments/assets/e90469c5-8b3e-471f-b6f0-739972fec60f)

