### PR TITLE
fix playericon missing in local games

### DIFF
--- a/cockatrice/src/client/ui/pixel_map_generator.cpp
+++ b/cockatrice/src/client/ui/pixel_map_generator.cpp
@@ -264,11 +264,13 @@ static QString getIconType(const bool isBuddy, const QString &privLevel)
 {
     if (isBuddy) {
         return "star";
-    } else if (privLevel.toLower() != "none") {
-        return QString("pawn_%1").arg(privLevel.toLower());
-    } else {
-        return "pawn";
     }
+
+    if (!privLevel.isEmpty() && privLevel.toLower() != "none") {
+        return QString("pawn_%1").arg(privLevel.toLower());
+    }
+
+    return "pawn";
 }
 
 QIcon UserLevelPixmapGenerator::generateIconDefault(int height,


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5560

## Short roundup of the initial problem

player icons are missing in local games because the getPlayerIcon function checks that that privLevel != "none" before trying to load a custom pawn. The privLevel is "" in local games, which passes the check. 

## What will change with this Pull Request?
- Check that privLevel is not empty first
