### PR TITLE
Fix wrong position and scaling of svg pixmaps when zoomed out

### DIFF
--- a/cockatrice/src/game/player/player_target.cpp
+++ b/cockatrice/src/game/player/player_target.cpp
@@ -88,6 +88,7 @@ void PlayerTarget::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*o
     const QString cacheKey = "avatar" + QString::number(translatedSize.width()) + "_" +
                              QString::number(info->user_level()) + "_" + QString::number(fullPixmap.cacheKey());
     if (!QPixmapCache::find(cacheKey, &cachedPixmap)) {
+        qDebug() << "TRACK cache miss" << cacheKey;
         cachedPixmap = QPixmap(translatedSize.width(), translatedSize.height());
 
         QPainter tempPainter(&cachedPixmap);
@@ -101,16 +102,21 @@ void PlayerTarget::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*o
         grad.setColorAt(0, QColor(180, 180, 180));
         tempPainter.fillRect(QRectF(0, 0, translatedSize.width(), translatedSize.height()), grad);
 
-        QPixmap tempPixmap;
-        if (fullPixmap.isNull())
-            tempPixmap = UserLevelPixmapGenerator::generatePixmap(
-                translatedSize.height(), UserLevelFlags(info->user_level()), info->pawn_colors(), false,
+        if (fullPixmap.isNull()) {
+            int sideLength = translatedSize.height();
+            QPixmap tempPixmap = UserLevelPixmapGenerator::generatePixmap(
+                sideLength, UserLevelFlags(info->user_level()), info->pawn_colors(), false,
                 QString::fromStdString(info->privlevel()));
-        else
-            tempPixmap = fullPixmap.scaled(translatedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+            int x = (translatedSize.width() - sideLength) / 2;
+            int y = 0;
+            tempPainter.drawPixmap(x, y, tempPixmap);
+        } else {
+            QPixmap tempPixmap = fullPixmap.scaled(translatedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+            int x = (translatedSize.width() - tempPixmap.width()) / 2;
+            int y = (translatedSize.height() - tempPixmap.height()) / 2;
+            tempPainter.drawPixmap(x, y, tempPixmap);
+        }
 
-        tempPainter.drawPixmap((translatedSize.width() - tempPixmap.width()) / 2,
-                               (translatedSize.height() - tempPixmap.height()) / 2, tempPixmap);
         QPixmapCache::insert(cacheKey, cachedPixmap);
     }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes issue introduced in #5554

## Short roundup of the initial problem

Pixmaps from svg's become wrongly positioned and scale when you zoom out a lot. 

This is because the code that loads the svg into the pixmap makes sure the pixmap is at least the svg's dimensions. The pixmap is scaled down afterwards using the "convert to icon and back" trick, but `pixmap.size` will still return the unscaled size, causing calculations to be thrown off

https://github.com/user-attachments/assets/f6722b5a-fc2a-4ce1-8a82-7d2f509022d5

## What will change with this Pull Request?

https://github.com/user-attachments/assets/e660bdd4-0e7b-4caa-b212-f3ee34800b0c

- Moved the svg size preserving behavior into a boolean param.
  - country flags and lock icon still need to set that to true
- Changed `PlayerTarget` default avatar calculations to not use the pixmap's size since those values are unreliable
