### PR TITLE
support shortcuts for tab menu actions

### DIFF
--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -222,7 +222,14 @@ void TabSupervisor::retranslateUi()
 void TabSupervisor::refreshShortcuts()
 {
     ShortcutsSettings &shortcuts = SettingsCache::instance().shortcuts();
-    aTabDeckEditor->setShortcuts(shortcuts.getShortcut("MainWindow/aDeckEditor"));
+    aTabDeckEditor->setShortcuts(shortcuts.getShortcut("Tabs/aTabDeckEditor"));
+    aTabVisualDeckStorage->setShortcuts(shortcuts.getShortcut("Tabs/aTabVisualDeckStorage"));
+    aTabServer->setShortcuts(shortcuts.getShortcut("Tabs/aTabServer"));
+    aTabAccount->setShortcuts(shortcuts.getShortcut("Tabs/aTabAccount"));
+    aTabDeckStorage->setShortcuts(shortcuts.getShortcut("Tabs/aTabDeckStorage"));
+    aTabReplays->setShortcuts(shortcuts.getShortcut("Tabs/aTabReplays"));
+    aTabAdmin->setShortcuts(shortcuts.getShortcut("Tabs/aTabAdmin"));
+    aTabLog->setShortcuts(shortcuts.getShortcut("Tabs/aTabLog"));
 }
 
 bool TabSupervisor::closeRequest()

--- a/cockatrice/src/settings/shortcuts_settings.cpp
+++ b/cockatrice/src/settings/shortcuts_settings.cpp
@@ -215,12 +215,11 @@ bool ShortcutsSettings::isValid(const QString &name, const QString &sequences) c
 }
 
 /**
- * Checks if the key or checkKey is a shortcut that is active in all windows
+ * Checks if the shortcut is a shortcut that is active in all windows
  */
-static bool isAlwaysActiveShortcut(const QString &key, const QString &checkKey)
+static bool isAlwaysActiveShortcut(const QString &shortcutName)
 {
-    return key.startsWith("MainWindow") || checkKey.startsWith("MainWindow") || key.startsWith("Tabs") ||
-           checkKey.startsWith("Tabs");
+    return shortcutName.startsWith("MainWindow") || shortcutName.startsWith("Tabs");
 }
 
 QStringList ShortcutsSettings::findOverlaps(const QString &name, const QString &sequences) const
@@ -230,7 +229,7 @@ QStringList ShortcutsSettings::findOverlaps(const QString &name, const QString &
 
     QStringList overlaps;
     for (const auto &key : shortCuts.keys()) {
-        if (key.startsWith(checkKey) || isAlwaysActiveShortcut(key, checkKey)) {
+        if (key.startsWith(checkKey) || isAlwaysActiveShortcut(key) || isAlwaysActiveShortcut(checkKey)) {
             QString storedSequence = stringifySequence(shortCuts.value(key));
             if (storedSequence.split(sep).contains(checkSequence)) {
                 overlaps.append(getShortcutFriendlyName(key));

--- a/cockatrice/src/settings/shortcuts_settings.cpp
+++ b/cockatrice/src/settings/shortcuts_settings.cpp
@@ -214,6 +214,15 @@ bool ShortcutsSettings::isValid(const QString &name, const QString &sequences) c
     return findOverlaps(name, sequences).isEmpty();
 }
 
+/**
+ * Checks if the key or checkKey is a shortcut that is active in all windows
+ */
+static bool isAlwaysActiveShortcut(const QString &key, const QString &checkKey)
+{
+    return key.startsWith("MainWindow") || checkKey.startsWith("MainWindow") || key.startsWith("Tabs") ||
+           checkKey.startsWith("Tabs");
+}
+
 QStringList ShortcutsSettings::findOverlaps(const QString &name, const QString &sequences) const
 {
     QString checkSequence = sequences.split(sep).last();
@@ -221,7 +230,7 @@ QStringList ShortcutsSettings::findOverlaps(const QString &name, const QString &
 
     QStringList overlaps;
     for (const auto &key : shortCuts.keys()) {
-        if (key.startsWith(checkKey) || key.startsWith("MainWindow") || checkKey.startsWith("MainWindow")) {
+        if (key.startsWith(checkKey) || isAlwaysActiveShortcut(key, checkKey)) {
             QString storedSequence = stringifySequence(shortCuts.value(key));
             if (storedSequence.split(sep).contains(checkSequence)) {
                 overlaps.append(getShortcutFriendlyName(key));

--- a/cockatrice/src/settings/shortcuts_settings.cpp
+++ b/cockatrice/src/settings/shortcuts_settings.cpp
@@ -82,6 +82,14 @@ void ShortcutsSettings::migrateShortcuts()
             shortCutsFile.remove("tab_game/aFocusChat");
         }
 
+        // PR #5564 changes "MainWindow/aDeckEditor" to "Tabs/aTabDeckEditor"
+        if (shortCutsFile.contains("MainWindow/aDeckEditor")) {
+            qCDebug(ShortcutsSettingsLog) << "MainWindow/aDeckEditor shortcut found. Migrating to Tabs/aTabDeckEditor.";
+            QString keySequence = shortCutsFile.value("MainWindow/aDeckEditor", "").toString();
+            this->setShortcuts("Tabs/aTabDeckEditor", keySequence);
+            shortCutsFile.remove("MainWindow/aDeckEditor");
+        }
+
         shortCutsFile.endGroup();
     }
 }

--- a/cockatrice/src/settings/shortcuts_settings.h
+++ b/cockatrice/src/settings/shortcuts_settings.h
@@ -30,7 +30,8 @@ public:
         Chat_room,
         Game_window,
         Load_deck,
-        Replays
+        Replays,
+        Tabs
     };
 
     static QString getGroupName(ShortcutGroup::Groups group)
@@ -72,6 +73,8 @@ public:
                 return QApplication::translate("shortcutsTab", "Load Deck from Clipboard");
             case Replays:
                 return QApplication::translate("shortcutsTab", "Replays");
+            case Tabs:
+                return QApplication::translate("shortcutsTab", "Tabs");
         }
 
         return {};
@@ -150,9 +153,6 @@ private:
         {"MainWindow/aConnect", ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Connect..."),
                                             parseSequenceString("Ctrl+L"),
                                             ShortcutGroup::Main_Window)},
-        {"MainWindow/aDeckEditor", ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Deck Editor"),
-                                               parseSequenceString(""),
-                                               ShortcutGroup::Main_Window)},
         {"MainWindow/aDisconnect", ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Disconnect"),
                                                parseSequenceString(""),
                                                ShortcutGroup::Main_Window)},
@@ -626,7 +626,26 @@ private:
                                            ShortcutGroup::Replays)},
         {"Replays/fastForwardButton", ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Toggle Fast Forward"),
                                                   parseSequenceString("Ctrl+P"),
-                                                  ShortcutGroup::Replays)}};
+                                                  ShortcutGroup::Replays)},
+        {"Tabs/aTabDeckEditor",
+         ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Deck Editor"), parseSequenceString(""), ShortcutGroup::Tabs)},
+        {"Tabs/aTabVisualDeckStorage", ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Visual Deck Storage"),
+                                                   parseSequenceString(""),
+                                                   ShortcutGroup::Tabs)},
+        {"Tabs/aTabDeckStorage",
+         ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Deck Storage"), parseSequenceString(""), ShortcutGroup::Tabs)},
+        {"Tabs/aTabReplays",
+         ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Replays"), parseSequenceString(""), ShortcutGroup::Tabs)},
+        {"Tabs/aTabServer",
+         ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Server"), parseSequenceString(""), ShortcutGroup::Tabs)},
+        {"Tabs/aTabAccount",
+         ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Account"), parseSequenceString(""), ShortcutGroup::Tabs)},
+        {"Tabs/aTabAdmin", ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Administration"),
+                                       parseSequenceString(""),
+                                       ShortcutGroup::Tabs)},
+        {"Tabs/aTabLogs",
+         ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Logs"), parseSequenceString(""), ShortcutGroup::Tabs)},
+    };
 };
 
 #endif // SHORTCUTSSETTINGS_H


### PR DESCRIPTION
## Short roundup of the initial problem

`Tabs` menu's actions don't support shortcuts

## What will change with this Pull Request?

https://github.com/user-attachments/assets/7c56703c-35cb-468b-b1e3-784e89e382f8

- `Tabs` menu's actions now support shortcuts
  - No shortcuts set for them by default
- Moved `Deck Editor tab` shortcut from `Main Window` to `Tabs`

## Screenshots

<img width="697" alt="Screenshot 2025-02-04 at 8 20 42 PM" src="https://github.com/user-attachments/assets/290285fc-d3e7-4fda-b734-78780fb512c5" />

