### PR TITLE
Ignore unknown shortcut names in settings

### DIFF
--- a/cockatrice/src/settings/shortcuts_settings.cpp
+++ b/cockatrice/src/settings/shortcuts_settings.cpp
@@ -28,6 +28,13 @@ ShortcutsSettings::ShortcutsSettings(const QString &settingsPath, QObject *paren
         QMap<QString, QString> invalidItems;
         for (QStringList::const_iterator it = customKeys.constBegin(); it != customKeys.constEnd(); ++it) {
             QString stringSequence = shortCutsFile.value(*it).toString();
+
+            // check whether shortcut name exists
+            if (!shortCuts.contains(*it)) {
+                qCWarning(ShortcutsSettingsLog) << "Unknown shortcut name:" << *it;
+                continue;
+            }
+
             // check whether shortcut is forbidden
             if (isKeyAllowed(*it, stringSequence)) {
                 auto shortcut = getShortcut(*it);


### PR DESCRIPTION
## Short roundup of the initial problem

If the shortcuts settings file contains an unknown shortcut name, it gets loaded as an empty entry under `Main Window`

<img width="601" alt="Screenshot 2025-02-04 at 9 00 28 PM" src="https://github.com/user-attachments/assets/37256250-e6cd-4dad-8def-9d563436ff50" />

## What will change with this Pull Request?

Filter out unknown shortcut names when loading the shortcuts in from the settings
