### PR TITLE
Add setting to hide visual deck storage in game lobby

### DIFF
--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -625,10 +625,15 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     connect(&visualDeckStorageAlwaysConvertCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setVisualDeckStorageAlwaysConvert);
 
+    visualDeckStorageInGameCheckBox.setChecked(SettingsCache::instance().getVisualDeckStorageInGame());
+    connect(&visualDeckStorageInGameCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setVisualDeckStorageInGame);
+
     auto *deckEditorGrid = new QGridLayout;
     deckEditorGrid->addWidget(&openDeckInNewTabCheckBox, 0, 0);
     deckEditorGrid->addWidget(&visualDeckStoragePromptForConversionCheckBox, 1, 0);
     deckEditorGrid->addWidget(&visualDeckStorageAlwaysConvertCheckBox, 2, 0);
+    deckEditorGrid->addWidget(&visualDeckStorageInGameCheckBox, 3, 0);
 
     deckEditorGroupBox = new QGroupBox;
     deckEditorGroupBox->setLayout(deckEditorGrid);
@@ -690,6 +695,7 @@ void UserInterfaceSettingsPage::retranslateUi()
     openDeckInNewTabCheckBox.setText(tr("Open deck in new tab by default"));
     visualDeckStoragePromptForConversionCheckBox.setText(tr("Prompt before converting .txt decks to .cod format"));
     visualDeckStorageAlwaysConvertCheckBox.setText(tr("Always convert if not prompted"));
+    visualDeckStorageInGameCheckBox.setText(tr("Use visual deck storage in game lobby"));
     replayGroupBox->setTitle(tr("Replay settings"));
     rewindBufferingMsLabel.setText(tr("Buffer time for backwards skip via shortcut:"));
     rewindBufferingMsBox.setSuffix(" ms");

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -146,6 +146,7 @@ private:
     QCheckBox openDeckInNewTabCheckBox;
     QCheckBox visualDeckStoragePromptForConversionCheckBox;
     QCheckBox visualDeckStorageAlwaysConvertCheckBox;
+    QCheckBox visualDeckStorageInGameCheckBox;
     QLabel rewindBufferingMsLabel;
     QSpinBox rewindBufferingMsBox;
     QGroupBox *generalGroupBox;

--- a/cockatrice/src/game/deckview/deck_view.cpp
+++ b/cockatrice/src/game/deckview/deck_view.cpp
@@ -517,6 +517,11 @@ void DeckView::setDeck(const DeckList &_deck)
     deckViewScene->setDeck(_deck);
 }
 
+void DeckView::clearDeck()
+{
+    deckViewScene->clearContents();
+}
+
 void DeckView::resetSideboardPlan()
 {
     deckViewScene->resetSideboardPlan();

--- a/cockatrice/src/game/deckview/deck_view.h
+++ b/cockatrice/src/game/deckview/deck_view.h
@@ -109,7 +109,6 @@ private:
     DeckList *deck;
     QMap<QString, DeckViewCardContainer *> cardContainers;
     qreal optimalAspectRatio;
-    void clearContents();
     void rebuildTree();
 
 public:
@@ -123,6 +122,7 @@ public:
     {
         return locked;
     }
+    void clearContents();
     void setDeck(const DeckList &_deck);
     void setOptimalAspectRatio(qreal _optimalAspectRatio)
     {
@@ -152,6 +152,7 @@ signals:
 public:
     explicit DeckView(QWidget *parent = nullptr);
     void setDeck(const DeckList &_deck);
+    void clearDeck();
     void setLocked(bool _locked)
     {
         deckViewScene->setLocked(_locked);

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -101,6 +101,9 @@ DeckViewContainer::DeckViewContainer(int _playerId, TabGame *parent)
     connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
     refreshShortcuts();
 
+    connect(&SettingsCache::instance(), &SettingsCache::visualDeckStorageInGameChanged, this,
+            &DeckViewContainer::updateShowVisualDeckStorage);
+
     switchToDeckSelectView();
 }
 
@@ -122,8 +125,8 @@ static void setVisibility(QPushButton *button, bool visible)
 
 void DeckViewContainer::switchToDeckSelectView()
 {
-    deckView->setVisible(false);
-    visualDeckStorageWidget->setVisible(true);
+    deckView->setHidden(SettingsCache::instance().getVisualDeckStorageInGame());
+    visualDeckStorageWidget->setHidden(!SettingsCache::instance().getVisualDeckStorageInGame());
     deckViewLayout->update();
 
     setVisibility(loadLocalButton, true);
@@ -143,8 +146,8 @@ void DeckViewContainer::switchToDeckSelectView()
 
 void DeckViewContainer::switchToDeckLoadedView()
 {
-    deckView->setVisible(true);
-    visualDeckStorageWidget->setVisible(false);
+    deckView->setHidden(false);
+    visualDeckStorageWidget->setHidden(true);
     deckViewLayout->update();
 
     setVisibility(loadLocalButton, false);
@@ -179,8 +182,21 @@ void DeckViewContainer::refreshShortcuts()
     sideboardLockButton->setShortcut(shortcuts.getSingleShortcut("DeckViewContainer/sideboardLockButton"));
 }
 
+/**
+ * Update VDS visibility when settings change
+ */
+void DeckViewContainer::updateShowVisualDeckStorage(bool enabled)
+{
+    // view mode state isn't stored in a field, so we determine state by checking the button
+    if (loadLocalButton->isEnabled()) {
+        deckView->setHidden(enabled);
+        visualDeckStorageWidget->setHidden(!enabled);
+    }
+}
+
 void DeckViewContainer::unloadDeck()
 {
+    deckView->clearDeck();
     switchToDeckSelectView();
 }
 

--- a/cockatrice/src/game/deckview/deck_view_container.h
+++ b/cockatrice/src/game/deckview/deck_view_container.h
@@ -65,6 +65,7 @@ private slots:
     void sideboardLockButtonClicked();
     void updateSideboardLockButtonText();
     void refreshShortcuts();
+    void updateShowVisualDeckStorage(bool enabled);
 signals:
     void newCardAdded(AbstractCardItem *card);
     void notIdle();

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -715,6 +715,7 @@ void SettingsCache::setVisualDeckStorageInGame(QT_STATE_CHANGED_T value)
 {
     visualDeckStorageInGame = value;
     settings->setValue("interface/visualdeckstorageingame", visualDeckStorageInGame);
+    emit visualDeckStorageInGameChanged(visualDeckStorageInGame);
 }
 
 void SettingsCache::setHorizontalHand(QT_STATE_CHANGED_T _horizontalHand)

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -273,6 +273,7 @@ SettingsCache::SettingsCache()
     visualDeckStoragePromptForConversion =
         settings->value("interface/visualdeckstoragepromptforconversion", true).toBool();
     visualDeckStorageAlwaysConvert = settings->value("interface/visualdeckstoragealwaysconvert", false).toBool();
+    visualDeckStorageInGame = settings->value("interface/visualdeckstorageingame", true).toBool();
     horizontalHand = settings->value("hand/horizontal", true).toBool();
     invertVerticalCoordinate = settings->value("table/invert_vertical", false).toBool();
     minPlayersForMultiColumnLayout = settings->value("interface/min_players_multicolumn", 4).toInt();
@@ -708,6 +709,12 @@ void SettingsCache::setVisualDeckStorageAlwaysConvert(QT_STATE_CHANGED_T _visual
 {
     visualDeckStorageAlwaysConvert = _visualDeckStorageAlwaysConvert;
     settings->setValue("interface/visualdeckstoragealwaysconvert", visualDeckStorageAlwaysConvert);
+}
+
+void SettingsCache::setVisualDeckStorageInGame(QT_STATE_CHANGED_T value)
+{
+    visualDeckStorageInGame = value;
+    settings->setValue("interface/visualdeckstorageingame", visualDeckStorageInGame);
 }
 
 void SettingsCache::setHorizontalHand(QT_STATE_CHANGED_T _horizontalHand)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -135,6 +135,7 @@ private:
     int visualDeckStorageUnusedColorIdentitiesOpacity;
     bool visualDeckStoragePromptForConversion;
     bool visualDeckStorageAlwaysConvert;
+    bool visualDeckStorageInGame;
     bool horizontalHand;
     bool invertVerticalCoordinate;
     int minPlayersForMultiColumnLayout;
@@ -433,6 +434,10 @@ public:
     bool getVisualDeckStorageAlwaysConvert() const
     {
         return visualDeckStorageAlwaysConvert;
+    }
+    bool getVisualDeckStorageInGame() const
+    {
+        return visualDeckStorageInGame;
     }
     bool getHorizontalHand() const
     {
@@ -760,6 +765,7 @@ public slots:
     void setVisualDeckStorageUnusedColorIdentitiesOpacity(int _visualDeckStorageUnusedColorIdentitiesOpacity);
     void setVisualDeckStoragePromptForConversion(QT_STATE_CHANGED_T _visualDeckStoragePromptForConversion);
     void setVisualDeckStorageAlwaysConvert(QT_STATE_CHANGED_T _visualDeckStorageAlwaysConvert);
+    void setVisualDeckStorageInGame(QT_STATE_CHANGED_T value);
     void setHorizontalHand(QT_STATE_CHANGED_T _horizontalHand);
     void setInvertVerticalCoordinate(QT_STATE_CHANGED_T _invertVerticalCoordinate);
     void setMinPlayersForMultiColumnLayout(int _minPlayersForMultiColumnLayout);

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -63,6 +63,7 @@ signals:
     void printingSelectorCardSizeSliderVisibleChanged();
     void printingSelectorNavigationButtonsVisibleChanged();
     void visualDeckStorageCardSizeChanged();
+    void visualDeckStorageInGameChanged(bool enabled);
     void horizontalHandChanged();
     void handJustificationChanged();
     void invertVerticalCoordinateChanged();

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -229,6 +229,9 @@ void SettingsCache::setVisualDeckStoragePromptForConversion(
 void SettingsCache::setVisualDeckStorageAlwaysConvert(QT_STATE_CHANGED_T /* _visualDeckStorageAlwaysConvert */)
 {
 }
+void SettingsCache::setVisualDeckStorageInGame(QT_STATE_CHANGED_T /* value */)
+{
+}
 void SettingsCache::setHorizontalHand(QT_STATE_CHANGED_T /* _horizontalHand */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -233,6 +233,9 @@ void SettingsCache::setVisualDeckStoragePromptForConversion(
 void SettingsCache::setVisualDeckStorageAlwaysConvert(QT_STATE_CHANGED_T /* _visualDeckStorageAlwaysConvert */)
 {
 }
+void SettingsCache::setVisualDeckStorageInGame(QT_STATE_CHANGED_T /* value */)
+{
+}
 void SettingsCache::setHorizontalHand(QT_STATE_CHANGED_T /* _horizontalHand */)
 {
 }


### PR DESCRIPTION
## Short roundup of the initial problem

Some people have requested the ability to hide the visual deck storage in the game lobby, since it can be really laggy to load for them, and now they're running into the lag on every game.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/98dad735-4acc-4d78-b2c1-382aec58776e

- Added `Use visual deck storage in game lobby` setting 
- Hide VDS widget in `DeckViewContainer` if setting is unchecked.
- Setting emits a signal on update so `DeckViewContainer` immediately updates the visibility on setting change

## Screenshots

<img width="705" alt="Screenshot 2025-02-06 at 2 52 23 AM" src="https://github.com/user-attachments/assets/8d42997e-c501-40af-9bd0-0a5903d41847" />



