### PR TITLE
actually delete VDS when hiding it in game lobby

### DIFF
--- a/cockatrice/src/game/deckview/deck_view_container.h
+++ b/cockatrice/src/game/deckview/deck_view_container.h
@@ -51,6 +51,7 @@ private:
     TabGame *parentGame;
     int playerId;
 
+    void tryCreateVisualDeckStorageWidget();
     void sendReadyStartCommand(bool ready);
 private slots:
     void switchToDeckSelectView();


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5570

## Short roundup of the initial problem

Turns out just hiding the VDS still doesn't reduce lag by enough, so we need to entirely not create and delete the VDS.

## What will change with this Pull Request?

- `DeckViewContainer` skips creating VDS widget if setting is not checked
- settings changed slot now creates/deletes VDS widget as appropriate