### PR TITLE
fix wrong size flag bounding rect on linux

### DIFF
--- a/cockatrice/src/client/ui/pixel_map_generator.cpp
+++ b/cockatrice/src/client/ui/pixel_map_generator.cpp
@@ -159,7 +159,7 @@ QPixmap CountryPixmapGenerator::generatePixmap(int height, const QString &countr
     painter.setPen(Qt::black);
 
     // width/height offset was determined through trial-and-error
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     painter.drawRect(0, 0, pixmap.width() / 2, pixmap.height() / 2);
 #else
     painter.drawRect(0, 0, pixmap.width() - 1, pixmap.height() - 1);

--- a/cockatrice/src/client/ui/pixel_map_generator.cpp
+++ b/cockatrice/src/client/ui/pixel_map_generator.cpp
@@ -159,10 +159,10 @@ QPixmap CountryPixmapGenerator::generatePixmap(int height, const QString &countr
     painter.setPen(Qt::black);
 
     // width/height offset was determined through trial-and-error
-#ifdef Q_OS_WIN
-    painter.drawRect(0, 0, pixmap.width() - 1, pixmap.height() - 1);
-#else
+#ifdef Q_OS_MAC
     painter.drawRect(0, 0, pixmap.width() / 2, pixmap.height() / 2);
+#else
+    painter.drawRect(0, 0, pixmap.width() - 1, pixmap.height() - 1);
 #endif
 
     pmCache.insert(key, pixmap);


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5556

## Short roundup of the initial problem

Turns out the flag bounding box is also broken on linux

## What will change with this Pull Request?

make the same fix on linux

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
