### PR TITLE
Add option to hide folder structure in Visual Deck Storage

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
@@ -63,10 +63,24 @@ void VisualDeckStorageFolderDisplayWidget::refreshUi()
     header->setText(bannerText);
 }
 
+static QStringList getAllFiles(const QString &filePath)
+{
+    QStringList allFiles;
+
+    // QDirIterator with QDir::Files ensures only files are listed (no directories)
+    QDirIterator it(filePath, QDir::Files);
+
+    while (it.hasNext()) {
+        allFiles << it.next(); // Add each file path to the list
+    }
+
+    return allFiles;
+}
+
 void VisualDeckStorageFolderDisplayWidget::createWidgetsForFiles()
 {
     QList<DeckPreviewWidget *> allDecks;
-    for (const QString &file : getAllFiles()) {
+    for (const QString &file : getAllFiles(filePath)) {
         auto *display = new DeckPreviewWidget(flowWidget, visualDeckStorageWidget, file);
 
         connect(display, &DeckPreviewWidget::deckPreviewClicked, visualDeckStorageWidget,
@@ -121,9 +135,23 @@ bool VisualDeckStorageFolderDisplayWidget::checkVisibility()
     return atLeastOneWidgetVisible;
 }
 
+static QStringList getAllSubFolders(const QString &filePath)
+{
+    QStringList allFolders;
+
+    // QDirIterator with QDir::Files ensures only files are listed (no directories)
+    QDirIterator it(filePath, QDir::Dirs | QDir::NoDotAndDotDot);
+
+    while (it.hasNext()) {
+        allFolders << it.next(); // Add each file path to the list
+    }
+
+    return allFolders;
+}
+
 void VisualDeckStorageFolderDisplayWidget::createWidgetsForFolders()
 {
-    for (const QString &dir : getAllSubFolders()) {
+    for (const QString &dir : getAllSubFolders(filePath)) {
         auto *display = new VisualDeckStorageFolderDisplayWidget(this, visualDeckStorageWidget, dir, true);
         containerLayout->addWidget(display);
     }
@@ -148,32 +176,4 @@ QStringList VisualDeckStorageFolderDisplayWidget::gatherAllTagsFromFlowWidget() 
     allTags.removeDuplicates();
 
     return allTags;
-}
-
-QStringList VisualDeckStorageFolderDisplayWidget::getAllFiles() const
-{
-    QStringList allFiles;
-
-    // QDirIterator with QDir::Files ensures only files are listed (no directories)
-    QDirIterator it(filePath, QDir::Files);
-
-    while (it.hasNext()) {
-        allFiles << it.next(); // Add each file path to the list
-    }
-
-    return allFiles;
-}
-
-QStringList VisualDeckStorageFolderDisplayWidget::getAllSubFolders() const
-{
-    QStringList allFolders;
-
-    // QDirIterator with QDir::Files ensures only files are listed (no directories)
-    QDirIterator it(filePath, QDir::Dirs | QDir::NoDotAndDotDot);
-
-    while (it.hasNext()) {
-        allFolders << it.next(); // Add each file path to the list
-    }
-
-    return allFolders;
 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
@@ -19,6 +19,7 @@ VisualDeckStorageFolderDisplayWidget::VisualDeckStorageFolderDisplayWidget(
 
     header = new BannerWidget(this, "");
     header->setClickable(canBeHidden);
+    header->setHidden(!showFolders);
     layout->addWidget(header);
 
     container = new QWidget(this);
@@ -175,6 +176,8 @@ void VisualDeckStorageFolderDisplayWidget::updateShowFolders(bool enabled)
         createWidgetsForFiles();
         createWidgetsForFolders();
     }
+
+    header->setHidden(!showFolders);
 }
 
 /**

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.h
@@ -15,10 +15,12 @@ public:
     VisualDeckStorageFolderDisplayWidget(QWidget *parent,
                                          VisualDeckStorageWidget *_visualDeckStorageWidget,
                                          QString _filePath,
-                                         bool canBeHidden);
+                                         bool canBeHidden,
+                                         bool _showFolders);
     void refreshUi();
     void createWidgetsForFiles();
     void createWidgetsForFolders();
+    void flattenFolderStructure();
     QStringList gatherAllTagsFromFlowWidget() const;
     FlowWidget *getFlowWidget() const
     {
@@ -28,8 +30,10 @@ public:
 public slots:
     void updateVisibility();
     bool checkVisibility();
+    void updateShowFolders(bool enabled);
 
 private:
+    bool showFolders;
     QVBoxLayout *layout;
     VisualDeckStorageWidget *visualDeckStorageWidget;
     QString filePath;

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.h
@@ -20,8 +20,6 @@ public:
     void createWidgetsForFiles();
     void createWidgetsForFolders();
     QStringList gatherAllTagsFromFlowWidget() const;
-    [[nodiscard]] QStringList getAllFiles() const;
-    [[nodiscard]] QStringList getAllSubFolders() const;
     FlowWidget *getFlowWidget() const
     {
         return flowWidget;

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -56,8 +56,6 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
-    folderWidget = new VisualDeckStorageFolderDisplayWidget(this, this, SettingsCache::instance().getDeckPath(), false);
-
     scrollArea->setWidget(folderWidget);
     scrollArea->setWidgetResizable(true);
 
@@ -123,7 +121,12 @@ void VisualDeckStorageWidget::deckPreviewDoubleClickedEvent(QMouseEvent *event, 
 
 void VisualDeckStorageWidget::createRootFolderWidget()
 {
-    folderWidget = new VisualDeckStorageFolderDisplayWidget(this, this, SettingsCache::instance().getDeckPath(), false);
+    folderWidget =
+        new VisualDeckStorageFolderDisplayWidget(this, this, SettingsCache::instance().getDeckPath(), false, false);
+
+    connect(showFoldersCheckBox, &QCheckBox::QT_STATE_CHANGED, folderWidget,
+            &VisualDeckStorageFolderDisplayWidget::updateShowFolders);
+
     scrollArea->setWidget(folderWidget);
     scrollArea->widget()->setMaximumWidth(scrollArea->viewport()->width());
     scrollArea->widget()->adjustSize();

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -41,6 +41,9 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     checkBoxLayout->setContentsMargins(9, 0, 9, 0);
 
     showFoldersCheckBox = new QCheckBox(this);
+    showFoldersCheckBox->setChecked(SettingsCache::instance().getVisualDeckStorageShowFolders());
+    connect(showFoldersCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setVisualDeckStorageShowFolders);
 
     checkBoxLayout->addWidget(showFoldersCheckBox);
     checkBoxLayout->addStretch();
@@ -121,8 +124,8 @@ void VisualDeckStorageWidget::deckPreviewDoubleClickedEvent(QMouseEvent *event, 
 
 void VisualDeckStorageWidget::createRootFolderWidget()
 {
-    folderWidget =
-        new VisualDeckStorageFolderDisplayWidget(this, this, SettingsCache::instance().getDeckPath(), false, false);
+    folderWidget = new VisualDeckStorageFolderDisplayWidget(this, this, SettingsCache::instance().getDeckPath(), false,
+                                                            showFoldersCheckBox->isChecked());
 
     connect(showFoldersCheckBox, &QCheckBox::QT_STATE_CHANGED, folderWidget,
             &VisualDeckStorageFolderDisplayWidget::updateShowFolders);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -36,6 +36,15 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     searchAndSortLayout->addWidget(sortWidget);
     searchAndSortLayout->addWidget(searchWidget);
 
+    // checkbox row
+    QHBoxLayout *checkBoxLayout = new QHBoxLayout(this);
+    checkBoxLayout->setContentsMargins(9, 0, 9, 0);
+
+    showFoldersCheckBox = new QCheckBox(this);
+
+    checkBoxLayout->addWidget(showFoldersCheckBox);
+    checkBoxLayout->addStretch();
+
     // tag filter box
     tagFilterWidget = new VisualDeckStorageTagFilterWidget(this);
 
@@ -54,6 +63,7 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
 
     // putting everything together
     layout->addLayout(searchAndSortLayout);
+    layout->addLayout(checkBoxLayout);
     layout->addWidget(tagFilterWidget);
     layout->addWidget(scrollArea);
     layout->addWidget(cardSizeWidget);
@@ -96,6 +106,8 @@ void VisualDeckStorageWidget::resizeEvent(QResizeEvent *event)
 void VisualDeckStorageWidget::retranslateUi()
 {
     databaseLoadIndicator->setText(tr("Loading database ..."));
+
+    showFoldersCheckBox->setText(tr("Show Folders"));
 }
 
 void VisualDeckStorageWidget::deckPreviewClickedEvent(QMouseEvent *event, DeckPreviewWidget *instance)

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -23,6 +23,7 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     layout->setContentsMargins(9, 0, 9, 5);
     setLayout(layout);
 
+    // search bar row
     searchAndSortLayout = new QHBoxLayout(this);
     searchAndSortLayout->setSpacing(3);
     searchAndSortLayout->setContentsMargins(9, 0, 9, 0);
@@ -30,15 +31,18 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     deckPreviewColorIdentityFilterWidget = new DeckPreviewColorIdentityFilterWidget(this);
     sortWidget = new VisualDeckStorageSortWidget(this);
     searchWidget = new VisualDeckStorageSearchWidget(this);
-    tagFilterWidget = new VisualDeckStorageTagFilterWidget(this);
 
     searchAndSortLayout->addWidget(deckPreviewColorIdentityFilterWidget);
     searchAndSortLayout->addWidget(sortWidget);
     searchAndSortLayout->addWidget(searchWidget);
-    layout->addLayout(searchAndSortLayout);
-    layout->addWidget(tagFilterWidget);
+
+    // tag filter box
+    tagFilterWidget = new VisualDeckStorageTagFilterWidget(this);
+
+    // card size slider
     cardSizeWidget = new CardSizeWidget(this, nullptr, SettingsCache::instance().getVisualDeckStorageCardSize());
 
+    // deck area
     scrollArea = new QScrollArea(this);
     scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -48,8 +52,10 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     scrollArea->setWidget(folderWidget);
     scrollArea->setWidgetResizable(true);
 
+    // putting everything together
+    layout->addLayout(searchAndSortLayout);
+    layout->addWidget(tagFilterWidget);
     layout->addWidget(scrollArea);
-
     layout->addWidget(cardSizeWidget);
 
     connect(CardDatabaseManager::getInstance(), &CardDatabase::cardDatabaseLoadingFinished, this,

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -11,6 +11,7 @@
 #include "visual_deck_storage_sort_widget.h"
 #include "visual_deck_storage_tag_filter_widget.h"
 
+#include <QCheckBox>
 #include <QFileSystemModel>
 
 class VisualDeckStorageSearchWidget;
@@ -56,6 +57,9 @@ private:
     VisualDeckStorageSortWidget *sortWidget;
     VisualDeckStorageSearchWidget *searchWidget;
     DeckPreviewColorIdentityFilterWidget *deckPreviewColorIdentityFilterWidget;
+
+    QCheckBox *showFoldersCheckBox;
+
     QScrollArea *scrollArea;
     VisualDeckStorageFolderDisplayWidget *folderWidget;
 };

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -266,6 +266,7 @@ SettingsCache::SettingsCache()
         settings->value("cards/printingselectornavigationbuttonsvisible", true).toBool();
     visualDeckStorageCardSize = settings->value("cards/visualdeckstoragecardsize", 100).toInt();
     visualDeckStorageSortingOrder = settings->value("interface/visualdeckstoragesortingorder", 0).toInt();
+    visualDeckStorageShowFolders = settings->value("interface/visualdeckstorageshowfolders", true).toBool();
     visualDeckStorageDrawUnusedColorIdentities =
         settings->value("interface/visualdeckstoragedrawunusedcoloridentities", true).toBool();
     visualDeckStorageUnusedColorIdentitiesOpacity =
@@ -676,6 +677,12 @@ void SettingsCache::setVisualDeckStorageSortingOrder(int _visualDeckStorageSorti
 {
     visualDeckStorageSortingOrder = _visualDeckStorageSortingOrder;
     settings->setValue("interface/visualdeckstoragesortingorder", visualDeckStorageSortingOrder);
+}
+
+void SettingsCache::setVisualDeckStorageShowFolders(QT_STATE_CHANGED_T value)
+{
+    visualDeckStorageShowFolders = value;
+    settings->setValue("interface/visualdeckstorageshowfolders", visualDeckStorageShowFolders);
 }
 
 void SettingsCache::setVisualDeckStorageCardSize(int _visualDeckStorageCardSize)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -131,6 +131,7 @@ private:
     bool printingSelectorCardSizeSliderVisible;
     bool printingSelectorNavigationButtonsVisible;
     int visualDeckStorageSortingOrder;
+    bool visualDeckStorageShowFolders;
     int visualDeckStorageCardSize;
     bool visualDeckStorageDrawUnusedColorIdentities;
     int visualDeckStorageUnusedColorIdentitiesOpacity;
@@ -415,6 +416,10 @@ public:
     int getVisualDeckStorageSortingOrder() const
     {
         return visualDeckStorageSortingOrder;
+    }
+    bool getVisualDeckStorageShowFolders() const
+    {
+        return visualDeckStorageShowFolders;
     }
     int getVisualDeckStorageCardSize() const
     {
@@ -761,6 +766,7 @@ public slots:
     void setPrintingSelectorCardSizeSliderVisible(QT_STATE_CHANGED_T _cardSizeSliderVisible);
     void setPrintingSelectorNavigationButtonsVisible(QT_STATE_CHANGED_T _navigationButtonsVisible);
     void setVisualDeckStorageSortingOrder(int _visualDeckStorageSortingOrder);
+    void setVisualDeckStorageShowFolders(QT_STATE_CHANGED_T value);
     void setVisualDeckStorageCardSize(int _visualDeckStorageCardSize);
     void setVisualDeckStorageDrawUnusedColorIdentities(QT_STATE_CHANGED_T _visualDeckStorageDrawUnusedColorIdentities);
     void setVisualDeckStorageUnusedColorIdentitiesOpacity(int _visualDeckStorageUnusedColorIdentitiesOpacity);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -211,6 +211,9 @@ void SettingsCache::setPrintingSelectorNavigationButtonsVisible(QT_STATE_CHANGED
 void SettingsCache::setVisualDeckStorageSortingOrder(int /* _visualDeckStorageSortingOrder */)
 {
 }
+void SettingsCache::setVisualDeckStorageShowFolders(QT_STATE_CHANGED_T /* value */)
+{
+}
 void SettingsCache::setVisualDeckStorageCardSize(int /* _visualDeckStorageCardSize */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -215,6 +215,9 @@ void SettingsCache::setPrintingSelectorNavigationButtonsVisible(QT_STATE_CHANGED
 void SettingsCache::setVisualDeckStorageSortingOrder(int /* _visualDeckStorageSortingOrder */)
 {
 }
+void SettingsCache::setVisualDeckStorageShowFolders(QT_STATE_CHANGED_T /* value */)
+{
+}
 void SettingsCache::setVisualDeckStorageCardSize(int /* _visualDeckStorageCardSize */)
 {
 }


### PR DESCRIPTION
## Short roundup of the initial problem

Sorting is per-folder, so you can no longer sort across all decks as before. For example, sort by most recently loaded now won't have the most recently loaded deck at the top if that deck is nested in a folder

## What will change with this Pull Request?
- Added checkbox for `show folder`
- While unchecked, all decks will be on the top level and will ignore folders
  - going from checked -> unchecked reparents the `DeckViewWidget`s instead of destroying and recreating them, so it's slightly faster
  - unchecked -> checked still destroys and recreates all the widgets though
- Checkbox state is persisted in settings
- Did some refactoring and moving around and commenting of some code in `VisualDeckStorageWidget` and `VisualDeckStorageFolderDisplayWidget`

## Screenshots

https://github.com/user-attachments/assets/f9f67ab0-45ce-419e-b0cd-9945d869e374


