### PR TITLE
turn off flow_widget logger

### DIFF
--- a/cockatrice/resources/config/qtlogging.ini
+++ b/cockatrice/resources/config/qtlogging.ini
@@ -46,6 +46,9 @@
 # cockatrice_xml.xml_4_parser = false
 # card_list = false
 
+# flow_layout = false
+flow_widget.* = false
+
 # pixel_map_generator = false
 
 # filter_string = false


### PR DESCRIPTION
## Short roundup of the initial problem

Turns out `flow_widget` spamming the logs is the cause of Visual Deck Storage lagging so much.

## What will change with this Pull Request?

- disable `flow_widget` logs
- add flow_layout logging category

I'm just temporarily disabling the `flow_widget` logger for now to fix the lag. We can go over and clean up the log levels later. 