### PR TITLE
Attempt fix crash case

### DIFF
--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -895,9 +895,12 @@ Server_Player::cmdConcede(const Command_Concede & /*cmd*/, ResponseContainer & /
             continue;
         }
 
-        const auto &regexResult = ownerRegex.match(card->getAnnotation());
-        if (!regexResult.hasMatch()) {
-            continue;
+        const QString cardAnnotation = card->getAnnotation();
+        if (!cardAnnotation.isEmpty()) {
+            const auto &regexResult = ownerRegex.match(cardAnnotation);
+            if (!regexResult.hasMatch()) {
+                continue;
+            }
         }
 
         CardToMove cardToMove;


### PR DESCRIPTION
```
#0  0x000064db6781d90f in std::__atomic_base<int>::operator++ (this=0x10001) at /usr/include/c++/13/bits/atomic_base.h:402
#1  0x000064db6781cd1b in QAtomicOps<int>::ref<int> (_q_value=<error reading variable: Cannot access memory at address 0x10001>) at /opt/Qt/6.3.0/gcc_64/include/QtCore/qatomic_cxx11.h:281
#2  0x000064db6781ba10 in QBasicAtomicInteger<int>::ref (this=0x10001) at /opt/Qt/6.3.0/gcc_64/include/QtCore/qbasicatomic.h:101
#3  0x000064db67818360 in QArrayData::ref (this=0x10001) at /opt/Qt/6.3.0/gcc_64/include/QtCore/qarraydata.h:87
#4  0x000064db6781cfed in QArrayDataPointer<char16_t>::ref (this=0x7ffe2b9f19f0) at /opt/Qt/6.3.0/gcc_64/include/QtCore/qarraydatapointer.h:325
#5  0x000064db6781bf1e in QArrayDataPointer<char16_t>::QArrayDataPointer (this=0x7ffe2b9f19f0, other=...) at /opt/Qt/6.3.0/gcc_64/include/QtCore/qarraydatapointer.h:71
#6  0x000064db67818a65 in QString::QString (this=0x7ffe2b9f19f0, other=...) at /opt/Qt/6.3.0/gcc_64/include/QtCore/qstring.h:1243
#7  0x000064db67937518 in Server_Card::getAnnotation (this=0x64db854a4900) at /root/github/common/server_card.h:125
#8  0x000064db679292ba in Server_Player::cmdConcede (this=0x64db811365c0, ges=...) at /root/github/common/server_player.cpp:898
#9  0x000064db67932694 in Server_Player::processGameCommand (this=0x64db811365c0, command=..., rc=..., ges=...) at /root/github/common/server_player.cpp:2307
#10 0x000064db6794b5a9 in Server_ProtocolHandler::processGameCommandContainer (this=0x64db9d70bfc0, cont=..., rc=...) at /root/github/common/server_protocolhandler.cpp:292
#11 0x000064db6794bbb5 in Server_ProtocolHandler::processCommandContainer (this=0x64db9d70bfc0, cont=...) at /root/github/common/server_protocolhandler.cpp:362
```