### PR TITLE
Refactor Visual Deck Storage sorting

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
@@ -181,6 +181,32 @@ void VisualDeckStorageFolderDisplayWidget::updateShowFolders(bool enabled)
 }
 
 /**
+ * Sorts the DeckPreviewWidgets in this folder and all subfolders
+ *
+ * @param comparator The comparator to use for sorting
+ */
+void VisualDeckStorageFolderDisplayWidget::sortBy(
+    const std::function<bool(DeckPreviewWidget *, DeckPreviewWidget *)> &comparator)
+{
+    auto deckPreviewWidgets = flowWidget->findChildren<DeckPreviewWidget *>();
+
+    std::sort(deckPreviewWidgets.begin(), deckPreviewWidgets.end(), comparator);
+
+    // manually removing and re-adding is the only way to reorder widgets in a flowWidget
+    for (DeckPreviewWidget *previewWidget : deckPreviewWidgets) {
+        flowWidget->removeWidget(previewWidget);
+    }
+    for (DeckPreviewWidget *previewWidget : deckPreviewWidgets) {
+        flowWidget->addWidget(previewWidget);
+    }
+
+    // also sort all subfolders
+    for (auto *subFolder : findChildren<VisualDeckStorageFolderDisplayWidget *>()) {
+        subFolder->sortBy(comparator);
+    }
+}
+
+/**
  * Steals all DeckPreviewWidgets from this widget's nested subfolders, and deletes those subfolders
  */
 void VisualDeckStorageFolderDisplayWidget::flattenFolderStructure()

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
@@ -181,12 +181,14 @@ void VisualDeckStorageFolderDisplayWidget::updateShowFolders(bool enabled)
 }
 
 /**
- * Sorts the DeckPreviewWidgets in this folder and all subfolders
+ * Sorts the DeckPreviewWidgets in this folder
  *
  * @param comparator The comparator to use for sorting
+ * @param recursive Also sort all nested subfolders
  */
 void VisualDeckStorageFolderDisplayWidget::sortBy(
-    const std::function<bool(DeckPreviewWidget *, DeckPreviewWidget *)> &comparator)
+    const std::function<bool(DeckPreviewWidget *, DeckPreviewWidget *)> &comparator,
+    bool recursive)
 {
     auto deckPreviewWidgets = flowWidget->findChildren<DeckPreviewWidget *>();
 
@@ -200,9 +202,11 @@ void VisualDeckStorageFolderDisplayWidget::sortBy(
         flowWidget->addWidget(previewWidget);
     }
 
-    // also sort all subfolders
-    for (auto *subFolder : findChildren<VisualDeckStorageFolderDisplayWidget *>()) {
-        subFolder->sortBy(comparator);
+    if (recursive) {
+        // also sort all subfolders
+        for (auto *subFolder : findChildren<VisualDeckStorageFolderDisplayWidget *>()) {
+            subFolder->sortBy(comparator, false);
+        }
     }
 }
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.h
@@ -20,6 +20,7 @@ public:
     void refreshUi();
     void createWidgetsForFiles();
     void createWidgetsForFolders();
+    void sortBy(const std::function<bool(DeckPreviewWidget *, DeckPreviewWidget *)> &comparator);
     void flattenFolderStructure();
     QStringList gatherAllTagsFromFlowWidget() const;
     FlowWidget *getFlowWidget() const

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.h
@@ -20,7 +20,7 @@ public:
     void refreshUi();
     void createWidgetsForFiles();
     void createWidgetsForFolders();
-    void sortBy(const std::function<bool(DeckPreviewWidget *, DeckPreviewWidget *)> &comparator);
+    void sortBy(const std::function<bool(DeckPreviewWidget *, DeckPreviewWidget *)> &comparator, bool recursive = true);
     void flattenFolderStructure();
     QStringList gatherAllTagsFromFlowWidget() const;
     FlowWidget *getFlowWidget() const

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
@@ -63,32 +63,13 @@ void VisualDeckStorageSortWidget::updateSortOrder()
     emit sortOrderChanged();
 }
 
-void VisualDeckStorageSortWidget::sortFolder(VisualDeckStorageFolderDisplayWidget *folderWidget)
-{
-    auto children =
-        folderWidget->getFlowWidget()->findChildren<QWidget *>(QString(), Qt::FindChildOption::FindDirectChildrenOnly);
-    for (auto widget : children) {
-        auto deckPreviewWidgets =
-            widget->findChildren<DeckPreviewWidget *>(QString(), Qt::FindChildOption::FindDirectChildrenOnly);
-        sortDecks(deckPreviewWidgets);
-        for (DeckPreviewWidget *previewWidget : deckPreviewWidgets) {
-            folderWidget->getFlowWidget()->removeWidget(previewWidget);
-        }
-        for (DeckPreviewWidget *previewWidget : deckPreviewWidgets) {
-            folderWidget->getFlowWidget()->addWidget(previewWidget);
-        }
-    }
-}
-
 /**
- * Sorts the DeckPreviewWidget list in-place, using the currently selected sortOrder
- *
- * @param widgets The list of widgets to sort
+ * Gets the comparator that is used for the current sortOrder
  */
-void VisualDeckStorageSortWidget::sortDecks(QList<DeckPreviewWidget *> widgets)
+std::function<bool(DeckPreviewWidget *, DeckPreviewWidget *)> VisualDeckStorageSortWidget::getComparator() const
 {
     // Sort the widgets list based on the current sort order
-    std::sort(widgets.begin(), widgets.end(), [this](DeckPreviewWidget *widget1, DeckPreviewWidget *widget2) {
+    return [this](DeckPreviewWidget *widget1, DeckPreviewWidget *widget2) {
         if (!widget1 || !widget2) {
             return false; // Handle null pointers gracefully
         }
@@ -111,5 +92,5 @@ void VisualDeckStorageSortWidget::sortDecks(QList<DeckPreviewWidget *> widgets)
         }
 
         return false; // Default case, no sorting applied
-    });
+    };
 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
@@ -70,17 +70,22 @@ void VisualDeckStorageSortWidget::sortFolder(VisualDeckStorageFolderDisplayWidge
     for (auto widget : children) {
         auto deckPreviewWidgets =
             widget->findChildren<DeckPreviewWidget *>(QString(), Qt::FindChildOption::FindDirectChildrenOnly);
-        auto newOrder = filterFiles(deckPreviewWidgets);
-        for (DeckPreviewWidget *previewWidget : newOrder) {
+        sortDecks(deckPreviewWidgets);
+        for (DeckPreviewWidget *previewWidget : deckPreviewWidgets) {
             folderWidget->getFlowWidget()->removeWidget(previewWidget);
         }
-        for (DeckPreviewWidget *previewWidget : newOrder) {
+        for (DeckPreviewWidget *previewWidget : deckPreviewWidgets) {
             folderWidget->getFlowWidget()->addWidget(previewWidget);
         }
     }
 }
 
-QList<DeckPreviewWidget *> VisualDeckStorageSortWidget::filterFiles(QList<DeckPreviewWidget *> widgets)
+/**
+ * Sorts the DeckPreviewWidget list in-place, using the currently selected sortOrder
+ *
+ * @param widgets The list of widgets to sort
+ */
+void VisualDeckStorageSortWidget::sortDecks(QList<DeckPreviewWidget *> widgets)
 {
     // Sort the widgets list based on the current sort order
     std::sort(widgets.begin(), widgets.end(), [this](DeckPreviewWidget *widget1, DeckPreviewWidget *widget2) {
@@ -107,6 +112,4 @@ QList<DeckPreviewWidget *> VisualDeckStorageSortWidget::filterFiles(QList<DeckPr
 
         return false; // Default case, no sorting applied
     });
-
-    return widgets;
 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
@@ -69,7 +69,7 @@ void VisualDeckStorageSortWidget::updateSortOrder()
 std::function<bool(DeckPreviewWidget *, DeckPreviewWidget *)> VisualDeckStorageSortWidget::getComparator() const
 {
     // Sort the widgets list based on the current sort order
-    return [this](DeckPreviewWidget *widget1, DeckPreviewWidget *widget2) {
+    return [sortOrder = sortOrder](const DeckPreviewWidget *widget1, const DeckPreviewWidget *widget2) {
         if (!widget1 || !widget2) {
             return false; // Handle null pointers gracefully
         }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.h
@@ -19,7 +19,7 @@ public:
     void updateSortOrder();
     void sortFolder(VisualDeckStorageFolderDisplayWidget *folderWidget);
     QString getSearchText();
-    QList<DeckPreviewWidget *> filterFiles(QList<DeckPreviewWidget *> widgets);
+    void sortDecks(QList<DeckPreviewWidget *> widgets);
 
 signals:
     void sortOrderChanged();

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.h
@@ -17,9 +17,9 @@ public:
     explicit VisualDeckStorageSortWidget(VisualDeckStorageWidget *parent);
     void retranslateUi();
     void updateSortOrder();
-    void sortFolder(VisualDeckStorageFolderDisplayWidget *folderWidget);
+    std::function<bool(DeckPreviewWidget *, DeckPreviewWidget *)> getComparator() const;
+
     QString getSearchText();
-    void sortDecks(QList<DeckPreviewWidget *> widgets);
 
 signals:
     void sortOrderChanged();

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -197,11 +197,7 @@ void VisualDeckStorageWidget::updateShowFolders(bool enabled)
 void VisualDeckStorageWidget::updateSortOrder()
 {
     if (folderWidget) {
-        sortWidget->sortFolder(folderWidget);
-        for (VisualDeckStorageFolderDisplayWidget *subFolderWidget :
-             folderWidget->findChildren<VisualDeckStorageFolderDisplayWidget *>()) {
-            sortWidget->sortFolder(subFolderWidget);
-        }
+        folderWidget->sortBy(sortWidget->getComparator());
     }
 }
 


### PR DESCRIPTION
## Short roundup of the initial problem

Sorting code in Visual Deck Storage is unintuitive. The `VisualDeckStorageFolderDisplayWidget` gets passed into the `VisualDeckStorageSortWidget` and then the sort widget recursively goes through and sorts the `DeckPreviewWidget`s that are inside of the `VisualDeckStorageFolderDisplayWidget`.

`VisualDeckStorageFolderDisplayWidget` contains the `DeckPreviewWidget`s so the sorting should really be happening in that class.

## What will change with this Pull Request?
- Sorting of widgets is done inside `VisualDeckStorageFolderDisplayWidget` instead of `VisualDeckStorageSortWidget`
  - `VisualDeckStorageFolderDisplayWidget::sortBy` takes a comparator and sorts all decks in it and all subfolders
  - `VisualDeckStorageSortWidget::getComparator` returns a comparator that sorts according to the current `sortOrder`
- On sort update, the top-level `VisualDeckStorageWidget` gets the comparator from its `VisualDeckStorageSortWidget` and calls `sortBy` on the top-level `VisualDeckStorageFolderDisplayWidget`, which then recursively sorts all the decks

