### PR TITLE
Re-sort decks in VDS after toggling show folders

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -42,6 +42,7 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
 
     showFoldersCheckBox = new QCheckBox(this);
     showFoldersCheckBox->setChecked(SettingsCache::instance().getVisualDeckStorageShowFolders());
+    connect(showFoldersCheckBox, &QCheckBox::QT_STATE_CHANGED, this, &VisualDeckStorageWidget::updateShowFolders);
     connect(showFoldersCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setVisualDeckStorageShowFolders);
 
@@ -125,13 +126,18 @@ void VisualDeckStorageWidget::createRootFolderWidget()
     folderWidget = new VisualDeckStorageFolderDisplayWidget(this, this, SettingsCache::instance().getDeckPath(), false,
                                                             showFoldersCheckBox->isChecked());
 
-    connect(showFoldersCheckBox, &QCheckBox::QT_STATE_CHANGED, folderWidget,
-            &VisualDeckStorageFolderDisplayWidget::updateShowFolders);
-
     scrollArea->setWidget(folderWidget);
     scrollArea->widget()->setMaximumWidth(scrollArea->viewport()->width());
     scrollArea->widget()->adjustSize();
     updateSortOrder();
+}
+
+void VisualDeckStorageWidget::updateShowFolders(bool enabled)
+{
+    if (folderWidget) {
+        folderWidget->updateShowFolders(enabled);
+        updateSortOrder();
+    }
 }
 
 void VisualDeckStorageWidget::updateSortOrder()

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -33,6 +33,7 @@ public slots:
     void deckPreviewClickedEvent(QMouseEvent *event, DeckPreviewWidget *instance);
     void deckPreviewDoubleClickedEvent(QMouseEvent *event, DeckPreviewWidget *instance);
     void createRootFolderWidget(); // Refresh the display of cards based on the current sorting option
+    void updateShowFolders(bool enabled);
     void updateTagFilter();
     void updateColorFilter();
     void updateSearchFilter();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5575

## Short roundup of the initial problem

Disabling the show folders option and then re-enabling the folders breaks the sorting within the folders

## What will change with this Pull Request?
- call `updateSortOrder` after folders are enabled/disabled
