### PR TITLE
Use local-aware compare in VDS file name sort

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
@@ -95,7 +95,7 @@ QList<DeckPreviewWidget *> VisualDeckStorageSortWidget::filterFiles(QList<DeckPr
             case ByName:
                 return widget1->deckLoader->getName() < widget2->deckLoader->getName();
             case Alphabetical:
-                return info1.fileName().toLower() < info2.fileName().toLower();
+                return QString::localeAwareCompare(info1.fileName(), info2.fileName()) <= 0;
             case ByLastModified:
                 return info1.lastModified() > info2.lastModified();
             case ByLastLoaded: {


### PR DESCRIPTION
## Short roundup of the initial problem

Visual Deck Storage's file name sort is different from my system's file name sort


<img width="199" alt="Screenshot 2025-02-08 at 8 12 29 PM" src="https://github.com/user-attachments/assets/4de04bd6-39ce-4bf7-8074-f8521e55e8a9" />

<img width="600" alt="Screenshot 2025-02-08 at 8 18 35 PM" src="https://github.com/user-attachments/assets/26034627-4a5f-4a59-929f-3c9057e33429" />

## What will change with this Pull Request?

- Use `QString::localeAwareCompare` so that the sort order is consistent with the system's file name sort

<img width="600" alt="Screenshot 2025-02-08 at 8 12 03 PM" src="https://github.com/user-attachments/assets/11d08b09-15b6-419e-a9ad-1f8df854b1e4" />
