### PR TITLE
Fix db reconnecting issues

### DIFF
--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -108,7 +108,7 @@ bool Servatrice_DatabaseInterface::checkSql()
     }
 
     auto query = QSqlQuery(sqlDatabase);
-    if (query.exec("select 1") && query.isActive()) {
+    if (query.exec("select 1") && !query.isActive()) {
         return openDatabase();
     }
 


### PR DESCRIPTION
See:

https://github.com/Cockatrice/Cockatrice/commit/c1b0d50237398e2a7f02f8e85ebb35b8b5b491e5#diff-02a32f437187bd4cbfab74877100fee0cfc669dab2c05418681a3557c2cf73f2R109

We should be checking to see if the query is notActive. In this case, we're literally closing and reopening the connection to the database every time `checkSql()` is called, which is called in numerous places.
