### PR TITLE
Update artifact naming for e.g. PR testing

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -330,7 +330,7 @@ jobs:
         if: matrix.make_package
         uses: actions/upload-artifact@v4
         with:
-          name: macOS${{matrix.target}}${{ matrix.soc == 'Intel' && '_Intel' || '' }}${{ matrix.type == 'Debug' && '_Debug' || '' }}-dmg
+          name: macOS${{matrix.target}}${{ matrix.soc == 'Intel' && '_Intel' || '' }}${{ matrix.type == 'Debug' && '_Debug' || '' }}-package
           path: ${{steps.build.outputs.path}}
           if-no-files-found: error
 


### PR DESCRIPTION
## Short roundup of the initial problem
Tiny change to uniformize the way our artifacts are displayed in GitHub Actions.
For all Linux variants we use `-package`,
For Windows it's `-installer`,
For macOS it's `-dmg`.

We do not use file extensions (like -deb or -rpm for Linux, or -exe for Windows), but for macOS.

See e.g. https://github.com/Cockatrice/Cockatrice/actions/runs/13223510869#artifacts:
![image](https://github.com/user-attachments/assets/2d2792cf-cffb-4f09-9568-442f8794015a)

Background:
The jobs for each OS upload a file to the context of the workflow to allow e.g. simple testing of changes in a PR and allow issue reports to confirm fixes.
**When downloading, it will be a zip file with the defined name, containing the actual binary with different name (the one used for releases).**
**This PR does not effect final binary names, our releases or how files are uploaded there!**

## What will change with this Pull Request?
- Label the macOS artifacts with `-package`, and not the file extension `-dmg`