### PR TITLE
Prevent server crash if DB is down and game is attempted to be created

### DIFF
--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -790,9 +790,6 @@ Server_ProtocolHandler::cmdCreateGame(const Command_CreateGame &cmd, Server_Room
 {
     if (authState == NotLoggedIn)
         return Response::RespLoginNeeded;
-    const int gameId = databaseInterface->getNextGameId();
-    if (gameId == -1)
-        return Response::RespInternalError;
     if (cmd.password().length() > MAX_NAME_LENGTH)
         return Response::RespContextError;
 
@@ -820,6 +817,11 @@ Server_ProtocolHandler::cmdCreateGame(const Command_CreateGame &cmd, Server_Room
 
     QString description = nameFromStdString(cmd.description());
     int startingLifeTotal = cmd.has_starting_life_total() ? cmd.starting_life_total() : 20;
+
+    const int gameId = databaseInterface->getNextGameId();
+    if (gameId == -1) {
+        return Response::RespInternalError;
+    }
 
     // When server doesn't permit registered users to exist, do not honor only-reg setting
     bool onlyRegisteredUsers = cmd.only_registered() && (server->permitUnregisteredUsers());

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -709,7 +709,9 @@ bool Servatrice_DatabaseInterface::userSessionExists(const QString &userName)
         "select 1 from {prefix}_sessions where user_name = :user_name and id_server = :id_server and end_time is null");
     query->bindValue(":id_server", server->getServerID());
     query->bindValue(":user_name", userName);
-    execSqlQuery(query);
+    if (!execSqlQuery(query)) {
+        return false;
+    };
     return query->next();
 }
 
@@ -745,14 +747,8 @@ void Servatrice_DatabaseInterface::endSession(qint64 sessionId)
     if (!checkSql())
         return;
 
-    QSqlQuery *query = prepareQuery("lock tables {prefix}_sessions write");
-    execSqlQuery(query);
-
-    query = prepareQuery("update {prefix}_sessions set end_time=NOW() where id = :id_session");
+    auto *query = prepareQuery("update {prefix}_sessions set end_time=NOW() where id = :id_session");
     query->bindValue(":id_session", sessionId);
-    execSqlQuery(query);
-
-    query = prepareQuery("unlock tables");
     execSqlQuery(query);
 }
 
@@ -811,7 +807,10 @@ int Servatrice_DatabaseInterface::getNextGameId()
         return -1;
 
     QSqlQuery *query = prepareQuery("insert into {prefix}_games (time_started) values (now())");
-    execSqlQuery(query);
+
+    if (!execSqlQuery(query)) {
+        return -1;
+    }
 
     return query->lastInsertId().toInt();
 }
@@ -822,7 +821,10 @@ int Servatrice_DatabaseInterface::getNextReplayId()
         return -1;
 
     QSqlQuery *query = prepareQuery("insert into {prefix}_replays (id_game) values (NULL)");
-    execSqlQuery(query);
+
+    if (!execSqlQuery(query)) {
+        return -1;
+    }
 
     return query->lastInsertId().toInt();
 }


### PR DESCRIPTION

- Only generate the gameId when we know it'll be used (Partial cleanup towards #5598)
- Check if getNextGameId and getNextReplayId succeed before returning out a value (Crash Case)
- Remove locks around endSession calls, as they seem outdated and aren't necessary