### PR TITLE
Fix crash when VDS show tags is unchecked

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -80,8 +80,14 @@ bool DeckPreviewWidget::checkVisibility() const
 
 void DeckPreviewWidget::updateTagsVisibility(bool visible)
 {
-    if (deckTagsDisplayWidget) {
-        deckTagsDisplayWidget->setHidden(!visible);
+    if (!deckTagsDisplayWidget) {
+        return;
+    }
+
+    if (visible) {
+        deckTagsDisplayWidget->setVisible(true);
+    } else {
+        deckTagsDisplayWidget->setHidden(true);
     }
 }
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -13,7 +13,8 @@
 DeckPreviewWidget::DeckPreviewWidget(QWidget *_parent,
                                      VisualDeckStorageWidget *_visualDeckStorageWidget,
                                      const QString &_filePath)
-    : QWidget(_parent), visualDeckStorageWidget(_visualDeckStorageWidget), filePath(_filePath)
+    : QWidget(_parent), visualDeckStorageWidget(_visualDeckStorageWidget), filePath(_filePath),
+      colorIdentityWidget(nullptr), deckTagsDisplayWidget(nullptr)
 {
     layout = new QVBoxLayout(this);
     setLayout(layout);
@@ -79,10 +80,8 @@ bool DeckPreviewWidget::checkVisibility() const
 
 void DeckPreviewWidget::updateTagsVisibility(bool visible)
 {
-    if (visible) {
-        deckTagsDisplayWidget->setVisible(true);
-    } else {
-        deckTagsDisplayWidget->setHidden(true);
+    if (deckTagsDisplayWidget) {
+        deckTagsDisplayWidget->setHidden(!visible);
     }
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5604

## Short roundup of the initial problem

Crash was caused by uninitialized pointers `colorIdentityWidget` and `deckTagsDisplayWidget`.

`colorIdentityWidget` and `deckTagsDisplayWidget` get initialized in `DeckPreviewWidget::initializeUi`, which doesn't happen until the signal from `DeckLoader` gets sent, as seen by
```
connect(deckLoader, &DeckLoader::loadFinished, this, &DeckPreviewWidget::initializeUi);
```

## What will change with this Pull Request?

- null out the pointers in the initializer list
- null check before calling methods on `deckTagsDisplayWidget` in `DeckPreviewWidget::updateTagsVisibility`
- refactor `DeckPreviewWidget::updateTagsVisibility` to just use `setHidden` instead of using both `setVisible` and `setHidden`