### PR TITLE
fix load remote deck window being empty

### DIFF
--- a/cockatrice/src/dialogs/dlg_load_remote_deck.cpp
+++ b/cockatrice/src/dialogs/dlg_load_remote_deck.cpp
@@ -11,6 +11,7 @@
 DlgLoadRemoteDeck::DlgLoadRemoteDeck(AbstractClient *_client, QWidget *parent) : QDialog(parent), client(_client)
 {
     dirView = new RemoteDeckList_TreeWidget(client);
+    dirView->refreshTree();
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5612
- Fixes bug introduced in #5533

## Short roundup of the initial problem

In #5533 we removed the `refreshTree` call in the constructor of `RemoteDeckList_TreeWidget` since the deck storage tab can now open while offline, so the deck storage tab was now responsible for calling `refreshTree`

However, we didn't realize that `RemoteDeckList_TreeWidget` was also used in `DlgLoadRemoteDeck`

## What will change with this Pull Request?
- call `refreshTree` after creating the `RemoteDeckList_TreeWidget` in `DlgLoadRemoteDeck`

