### PR TITLE
refactor how double click signal gets passed up in VDS

### DIFF
--- a/cockatrice/src/client/tabs/visual_deck_storage/tab_deck_storage_visual.cpp
+++ b/cockatrice/src/client/tabs/visual_deck_storage/tab_deck_storage_visual.cpp
@@ -12,7 +12,7 @@ TabDeckStorageVisual::TabDeckStorageVisual(TabSupervisor *_tabSupervisor)
     : Tab(_tabSupervisor), visualDeckStorageWidget(new VisualDeckStorageWidget(this))
 {
     connect(this, &TabDeckStorageVisual::openDeckEditor, tabSupervisor, &TabSupervisor::addDeckEditorTab);
-    connect(visualDeckStorageWidget, &VisualDeckStorageWidget::deckPreviewDoubleClicked, this,
+    connect(visualDeckStorageWidget, &VisualDeckStorageWidget::deckLoadRequested, this,
             &TabDeckStorageVisual::actOpenLocalDeck);
 
     auto *widget = new QWidget(this);
@@ -22,10 +22,10 @@ TabDeckStorageVisual::TabDeckStorageVisual(TabSupervisor *_tabSupervisor)
     layout->addWidget(visualDeckStorageWidget);
 }
 
-void TabDeckStorageVisual::actOpenLocalDeck(QMouseEvent * /*event*/, DeckPreviewWidget *instance)
+void TabDeckStorageVisual::actOpenLocalDeck(const QString &filePath)
 {
     DeckLoader deckLoader;
-    if (!deckLoader.loadFromFile(instance->filePath, DeckLoader::getFormatFromName(instance->filePath), true)) {
+    if (!deckLoader.loadFromFile(filePath, DeckLoader::getFormatFromName(filePath), true)) {
         return;
     }
 

--- a/cockatrice/src/client/tabs/visual_deck_storage/tab_deck_storage_visual.h
+++ b/cockatrice/src/client/tabs/visual_deck_storage/tab_deck_storage_visual.h
@@ -28,7 +28,7 @@ public:
     }
 
 public slots:
-    void actOpenLocalDeck(QMouseEvent * /*event*/, DeckPreviewWidget *instance);
+    void actOpenLocalDeck(const QString &filePath);
 
 signals:
     void openDeckEditor(const DeckLoader *deckLoader);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -6,6 +6,7 @@
 #include "deck_preview_deck_tags_display_widget.h"
 
 #include <QFileInfo>
+#include <QMenu>
 #include <QMouseEvent>
 #include <QSet>
 #include <QVBoxLayout>
@@ -258,12 +259,13 @@ void DeckPreviewWidget::setBannerCard(int /* changedIndex */)
 
 void DeckPreviewWidget::imageClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance)
 {
+    Q_UNUSED(event);
     Q_UNUSED(instance);
-    emit deckPreviewClicked(event, this);
 }
 
 void DeckPreviewWidget::imageDoubleClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance)
 {
+    Q_UNUSED(event);
     Q_UNUSED(instance);
-    emit deckPreviewDoubleClicked(event, this);
+    emit deckLoadRequested(filePath);
 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
@@ -12,6 +12,7 @@
 
 class VisualDeckStorageWidget;
 class DeckPreviewDeckTagsDisplayWidget;
+
 class DeckPreviewWidget final : public QWidget
 {
     Q_OBJECT
@@ -37,8 +38,7 @@ public:
     bool checkVisibility() const;
 
 signals:
-    void deckPreviewClicked(QMouseEvent *event, DeckPreviewWidget *instance);
-    void deckPreviewDoubleClicked(QMouseEvent *event, DeckPreviewWidget *instance);
+    void deckLoadRequested(const QString &filePath);
     void visibilityUpdated();
 
 public slots:

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
@@ -87,10 +87,8 @@ void VisualDeckStorageFolderDisplayWidget::createWidgetsForFiles()
     for (const QString &file : getAllFiles(filePath, !showFolders)) {
         auto *display = new DeckPreviewWidget(flowWidget, visualDeckStorageWidget, file);
 
-        connect(display, &DeckPreviewWidget::deckPreviewClicked, visualDeckStorageWidget,
-                &VisualDeckStorageWidget::deckPreviewClickedEvent);
-        connect(display, &DeckPreviewWidget::deckPreviewDoubleClicked, visualDeckStorageWidget,
-                &VisualDeckStorageWidget::deckPreviewDoubleClickedEvent);
+        connect(display, &DeckPreviewWidget::deckLoadRequested, visualDeckStorageWidget,
+                &VisualDeckStorageWidget::deckLoadRequested);
         connect(visualDeckStorageWidget->cardSizeWidget->getSlider(), &QSlider::valueChanged,
                 display->bannerCardDisplayWidget, &CardInfoPictureWidget::setScaleFactor);
         display->bannerCardDisplayWidget->setScaleFactor(visualDeckStorageWidget->cardSizeWidget->getSlider()->value());

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -172,17 +172,6 @@ void VisualDeckStorageWidget::retranslateUi()
     bannerCardComboBoxVisibilityCheckBox->setText(tr("Show Banner Card Selection Option"));
 }
 
-void VisualDeckStorageWidget::deckPreviewClickedEvent(QMouseEvent *event, DeckPreviewWidget *instance)
-{
-    emit deckPreviewClicked(event, instance);
-}
-
-void VisualDeckStorageWidget::deckPreviewDoubleClickedEvent(QMouseEvent *event, DeckPreviewWidget *instance)
-{
-    emit deckPreviewDoubleClicked(event, instance);
-    emit deckLoadRequested(instance->filePath);
-}
-
 void VisualDeckStorageWidget::createRootFolderWidget()
 {
     folderWidget = new VisualDeckStorageFolderDisplayWidget(this, this, SettingsCache::instance().getDeckPath(), false,

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -34,8 +34,6 @@ public:
     VisualDeckStorageTagFilterWidget *tagFilterWidget;
 
 public slots:
-    void deckPreviewClickedEvent(QMouseEvent *event, DeckPreviewWidget *instance);
-    void deckPreviewDoubleClickedEvent(QMouseEvent *event, DeckPreviewWidget *instance);
     void createRootFolderWidget(); // Refresh the display of cards based on the current sorting option
     void updateShowFolders(bool enabled);
     void updateTagFilter();
@@ -48,9 +46,7 @@ public slots:
 
 signals:
     void bannerCardsRefreshed();
-    void deckPreviewClicked(QMouseEvent *event, DeckPreviewWidget *instance);
-    void deckPreviewDoubleClicked(QMouseEvent *event, DeckPreviewWidget *instance);
-    void deckLoadRequested(QString &filePath);
+    void deckLoadRequested(const QString &filePath);
     void tagFilterUpdated();
     void colorFilterUpdated();
     void searchFilterUpdated();


### PR DESCRIPTION
## Related Ticket(s):
- Precursor to #5618

## Short roundup of the initial problem

The double click signal originating from `DeckPreviewCardPictureWidget` gets passed as a double click signal (containing the MouseEvent and the `DeckPreviewWidget` itself) all the way up to `TabDeckStorageVisual`, which then extracts the filePath from the passed `DeckPreviewWidget` to load the deck. 

We do not need to pass the double-click signal all the way up when all we need is the filepath.

The main reason I wanted to do this is because moving `deckLoadRequested` to `DeckPreviewWidget` means I can emit that signal from other places in `DeckPreviewWidget`.

## What will change with this Pull Request?
- convert the double click signal into a `deckLoadRequested(filePath)` signal at the `DeckPreviewWidget` level.
- remove unnecessary `deckPreviewClicked` and `deckPreviewDoubleClicked` signals from classes up the chain.