### PR TITLE
support right-click menu in VDS

### DIFF
--- a/cockatrice/src/client/ui/widgets/cards/deck_preview_card_picture_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/deck_preview_card_picture_widget.cpp
@@ -38,6 +38,9 @@ void DeckPreviewCardPictureWidget::mousePressEvent(QMouseEvent *event)
     if (event->button() == Qt::LeftButton) {
         lastMouseEvent = event;
         singleClickTimer->start(QApplication::doubleClickInterval());
+    } else {
+        emit imageClicked(event, this);
+        event->accept();
     }
 }
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -257,16 +257,6 @@ void DeckPreviewWidget::setBannerCard(int /* changedIndex */)
         itemData["name"].toString(), itemData["uuid"].toString()));
 }
 
-QMenu *DeckPreviewWidget::createRightClickMenu()
-{
-    auto *menu = new QMenu(this);
-
-    auto loadDeckAction = menu->addAction(tr("Load Deck"));
-    connect(loadDeckAction, &QAction::triggered, this, [this] { emit deckLoadRequested(filePath); });
-
-    return menu;
-}
-
 void DeckPreviewWidget::imageClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance)
 {
     Q_UNUSED(instance);
@@ -281,4 +271,14 @@ void DeckPreviewWidget::imageDoubleClickedEvent(QMouseEvent *event, DeckPreviewC
     Q_UNUSED(event);
     Q_UNUSED(instance);
     emit deckLoadRequested(filePath);
+}
+
+QMenu *DeckPreviewWidget::createRightClickMenu()
+{
+    auto *menu = new QMenu(this);
+
+    auto loadDeckAction = menu->addAction(tr("Load Deck"));
+    connect(loadDeckAction, &QAction::triggered, this, [this] { emit deckLoadRequested(filePath); });
+
+    return menu;
 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -257,10 +257,23 @@ void DeckPreviewWidget::setBannerCard(int /* changedIndex */)
         itemData["name"].toString(), itemData["uuid"].toString()));
 }
 
+QMenu *DeckPreviewWidget::createRightClickMenu()
+{
+    auto *menu = new QMenu(this);
+
+    auto loadDeckAction = menu->addAction(tr("Load Deck"));
+    connect(loadDeckAction, &QAction::triggered, this, [this] { emit deckLoadRequested(filePath); });
+
+    return menu;
+}
+
 void DeckPreviewWidget::imageClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance)
 {
-    Q_UNUSED(event);
     Q_UNUSED(instance);
+
+    if (event && event->button() == Qt::RightButton) {
+        createRightClickMenu()->popup(QCursor::pos());
+    }
 }
 
 void DeckPreviewWidget::imageDoubleClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance)

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
@@ -10,6 +10,7 @@
 #include <QVBoxLayout>
 #include <QWidget>
 
+class QMenu;
 class VisualDeckStorageWidget;
 class DeckPreviewDeckTagsDisplayWidget;
 
@@ -53,6 +54,9 @@ public slots:
     void updateBannerCardComboBoxVisibility(bool visible);
     void updateTagsVisibility(bool visible);
     void resizeEvent(QResizeEvent *event) override;
+
+private:
+    QMenu *createRightClickMenu();
 };
 
 class NoScrollFilter : public QObject


### PR DESCRIPTION
## Related Ticket(s)
- Starts on #5618

## What will change with this Pull Request?

https://github.com/user-attachments/assets/4c3a15c6-9dd7-41aa-a693-f9e0fc87aea1

- Right clicking on a `DeckPreviewWidget` will bring up a right-click menu
  - Currently only has "load deck" action for now; will add more stuff in future PRs

## Screenshots

<img width="728" alt="Screenshot 2025-02-15 at 4 29 45 PM" src="https://github.com/user-attachments/assets/83eaf90b-3cc9-4983-9ac0-99c2450d68be" />

