### PR TITLE
Make AttachTo tokens work from non-table zones

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -1981,7 +1981,7 @@ void Player::createCard(const CardItem *sourceCard,
         cmd.set_annotation("");
     }
     cmd.set_destroy_on_zone_change(!persistent);
-    cmd.set_target_zone(sourceCard->getZone()->getName().toStdString());
+    cmd.set_target_zone("table"); // we currently only support creating tokens on the table
     cmd.set_x(gridPoint.x());
     cmd.set_y(gridPoint.y());
 

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -402,7 +402,7 @@ public:
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
     void playCard(CardItem *c, bool faceDown);
-    void playCardToTable(CardItem *c, bool faceDown);
+    void playCardToTable(const CardItem *c, bool faceDown);
     void addCard(CardItem *c);
     void deleteCard(CardItem *c);
     void addZone(CardZone *z);

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -1358,6 +1358,9 @@ Server_Player::cmdAttachCard(const Command_AttachCard &cmd, ResponseContainer & 
             return Response::RespNameNotFound;
         }
     }
+
+    // prevent attaching from non-table zones
+    // (attaching from non-table zones is handled client-side by moving the card to table zone first)
     if (!startzone->hasCoords()) {
         return Response::RespContextError;
     }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5627

## Short roundup of the initial problem

Creating an "attach to" token from a zone other than the TableZone will create the token in the TableZone but not do anything with the original card.

## What will change with this Pull Request?

AttachTo token creation now works as expected from non-table zones. Creating the token automatically puts the card into play attached to the token

https://github.com/user-attachments/assets/14475ddc-1a6f-4d8d-904e-fa11819b8e1b
