### PR TITLE
Add folder dropdown icons to VDS

### DIFF
--- a/cockatrice/cockatrice.qrc
+++ b/cockatrice/cockatrice.qrc
@@ -1,5 +1,5 @@
 <RCC>
-    <qresource prefix="/" >
+    <qresource prefix="/">
         <file>resources/cardback.svg</file>
         <file>resources/cockatrice.svg</file>
         <file>resources/hand.svg</file>
@@ -17,6 +17,8 @@
         <file>resources/icons/conceded.svg</file>
         <file>resources/icons/decrement.svg</file>
         <file>resources/icons/delete.svg</file>
+        <file>resources/icons/dropdown_collapsed.svg</file>
+        <file>resources/icons/dropdown_expanded.svg</file>
         <file>resources/icons/forgot_password.svg</file>
         <file>resources/icons/increment.svg</file>
         <file>resources/icons/info.svg</file>

--- a/cockatrice/resources/icons/dropdown_collapsed.svg
+++ b/cockatrice/resources/icons/dropdown_collapsed.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 12.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+        <!ENTITY ns_svg "http://www.w3.org/2000/svg">
+        <!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+        ]>
+<svg version="1.1" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="460.5" height="531.74"
+     viewBox="0 0 460.5 531.74" overflow="visible" enable-background="new 0 0 460.5 531.74" xml:space="preserve">
+<polygon fill="#918d8d" points="0.5,0.866 459.5,265.87 0.5,530.874 "/>
+</svg>

--- a/cockatrice/resources/icons/dropdown_expanded.svg
+++ b/cockatrice/resources/icons/dropdown_expanded.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 12.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+        <!ENTITY ns_svg "http://www.w3.org/2000/svg">
+        <!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+        ]>
+<svg version="1.1" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="531.74" height="460.5"
+     viewBox="0 0 531.74 460.5" overflow="visible" enable-background="new 0 0 531.74 460.5" xml:space="preserve">
+<polygon fill="#918d8d" points="530.874,0.5 265.87,459.5 0.866,0.5 "/>
+</svg>

--- a/cockatrice/src/client/ui/pixel_map_generator.cpp
+++ b/cockatrice/src/client/ui/pixel_map_generator.cpp
@@ -357,6 +357,21 @@ QPixmap LockPixmapGenerator::generatePixmap(int height)
 
 QMap<int, QPixmap> LockPixmapGenerator::pmCache;
 
+QPixmap ExpandIconPixmapGenerator::generatePixmap(int height, bool expanded)
+{
+    QString key = QString::number(expanded) + ":" + QString::number(height);
+    if (pmCache.contains(key))
+        return pmCache.value(key);
+
+    QString name = expanded ? "dropdown_expanded" : "dropdown_collapsed";
+    QPixmap pixmap = tryLoadImage("theme:icons/" + name, QSize(height, height));
+
+    pmCache.insert(key, pixmap);
+    return pixmap;
+}
+
+QMap<QString, QPixmap> ExpandIconPixmapGenerator::pmCache;
+
 QPixmap loadColorAdjustedPixmap(const QString &name)
 {
     if (qApp->palette().windowText().color().lightness() > 200) {

--- a/cockatrice/src/client/ui/pixel_map_generator.cpp
+++ b/cockatrice/src/client/ui/pixel_map_generator.cpp
@@ -364,7 +364,7 @@ QPixmap DropdownIconPixmapGenerator::generatePixmap(int height, bool expanded)
         return pmCache.value(key);
 
     QString name = expanded ? "dropdown_expanded" : "dropdown_collapsed";
-    QPixmap pixmap = tryLoadImage("theme:icons/" + name, QSize(height, height));
+    QPixmap pixmap = tryLoadImage("theme:icons/" + name, QSize(height, height), true);
 
     pmCache.insert(key, pixmap);
     return pixmap;

--- a/cockatrice/src/client/ui/pixel_map_generator.cpp
+++ b/cockatrice/src/client/ui/pixel_map_generator.cpp
@@ -357,7 +357,7 @@ QPixmap LockPixmapGenerator::generatePixmap(int height)
 
 QMap<int, QPixmap> LockPixmapGenerator::pmCache;
 
-QPixmap ExpandIconPixmapGenerator::generatePixmap(int height, bool expanded)
+QPixmap DropdownIconPixmapGenerator::generatePixmap(int height, bool expanded)
 {
     QString key = QString::number(expanded) + ":" + QString::number(height);
     if (pmCache.contains(key))
@@ -370,7 +370,7 @@ QPixmap ExpandIconPixmapGenerator::generatePixmap(int height, bool expanded)
     return pixmap;
 }
 
-QMap<QString, QPixmap> ExpandIconPixmapGenerator::pmCache;
+QMap<QString, QPixmap> DropdownIconPixmapGenerator::pmCache;
 
 QPixmap loadColorAdjustedPixmap(const QString &name)
 {

--- a/cockatrice/src/client/ui/pixel_map_generator.h
+++ b/cockatrice/src/client/ui/pixel_map_generator.h
@@ -106,6 +106,19 @@ public:
     }
 };
 
+class ExpandIconPixmapGenerator
+{
+private:
+    static QMap<QString, QPixmap> pmCache;
+
+public:
+    static QPixmap generatePixmap(int height, bool expanded);
+    static void clear()
+    {
+        pmCache.clear();
+    }
+};
+
 QPixmap loadColorAdjustedPixmap(const QString &name);
 
 #endif

--- a/cockatrice/src/client/ui/pixel_map_generator.h
+++ b/cockatrice/src/client/ui/pixel_map_generator.h
@@ -106,7 +106,7 @@ public:
     }
 };
 
-class ExpandIconPixmapGenerator
+class DropdownIconPixmapGenerator
 {
 private:
     static QMap<QString, QPixmap> pmCache;

--- a/cockatrice/src/client/ui/widgets/general/display/banner_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/display/banner_widget.cpp
@@ -14,7 +14,6 @@ BannerWidget::BannerWidget(QWidget *parent, const QString &text, Qt::Orientation
 
     iconLabel = new QLabel(this);
     iconLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
-    setExpandIconState(true);
 
     // Create the banner label and set properties
     bannerLabel = new QLabel(text, this);
@@ -44,6 +43,12 @@ void BannerWidget::setText(const QString &text) const
     bannerLabel->setText(text);
 }
 
+void BannerWidget::setClickable(bool _clickable)
+{
+    clickable = _clickable;
+    setExpandIconState(true);
+}
+
 void BannerWidget::toggleBuddyVisibility() const
 {
     if (buddy) {
@@ -56,7 +61,12 @@ void BannerWidget::toggleBuddyVisibility() const
 
 void BannerWidget::setExpandIconState(bool expanded) const
 {
-    iconLabel->setPixmap(ExpandIconPixmapGenerator::generatePixmap(24, expanded));
+    if (clickable) {
+        iconLabel->setPixmap(ExpandIconPixmapGenerator::generatePixmap(24, expanded));
+    } else {
+        // we cannot directly hide the iconLabel, since it's needed to center the text; set an empty image instead
+        iconLabel->setPixmap(QPixmap());
+    }
 }
 
 void BannerWidget::paintEvent(QPaintEvent *event)

--- a/cockatrice/src/client/ui/widgets/general/display/banner_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/display/banner_widget.cpp
@@ -1,5 +1,7 @@
 #include "banner_widget.h"
 
+#include "../../../../../client/ui/pixel_map_generator.h"
+
 #include <QLinearGradient>
 #include <QMouseEvent>
 #include <QPainter>
@@ -8,14 +10,20 @@
 BannerWidget::BannerWidget(QWidget *parent, const QString &text, Qt::Orientation orientation, int transparency)
     : QWidget(parent), gradientOrientation(orientation), transparency(qBound(0, transparency, 100))
 {
+    auto layout = new QHBoxLayout(this);
+
+    iconLabel = new QLabel(this);
+    iconLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    setExpandIconState(true);
+
     // Create the banner label and set properties
     bannerLabel = new QLabel(text, this);
     bannerLabel->setAlignment(Qt::AlignCenter);
     bannerLabel->setStyleSheet("font-size: 24px; font-weight: bold; color: white;");
 
-    // Layout to center the banner label
-    layout = new QVBoxLayout(this);
+    layout->addWidget(iconLabel);
     layout->addWidget(bannerLabel);
+    layout->addWidget(new QLabel(this)); // add dummy label to force text label to be centered
     setLayout(layout);
 
     // Set minimum height for the widget
@@ -40,7 +48,15 @@ void BannerWidget::toggleBuddyVisibility() const
 {
     if (buddy) {
         buddy->setVisible(!buddy->isVisible());
+        setExpandIconState(buddy->isVisible());
+    } else {
+        setExpandIconState(false);
     }
+}
+
+void BannerWidget::setExpandIconState(bool expanded) const
+{
+    iconLabel->setPixmap(ExpandIconPixmapGenerator::generatePixmap(24, expanded));
 }
 
 void BannerWidget::paintEvent(QPaintEvent *event)

--- a/cockatrice/src/client/ui/widgets/general/display/banner_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/display/banner_widget.cpp
@@ -46,23 +46,23 @@ void BannerWidget::setText(const QString &text) const
 void BannerWidget::setClickable(bool _clickable)
 {
     clickable = _clickable;
-    setExpandIconState(true);
+    setDropdownIconState(true);
 }
 
 void BannerWidget::toggleBuddyVisibility() const
 {
     if (buddy) {
         buddy->setVisible(!buddy->isVisible());
-        setExpandIconState(buddy->isVisible());
+        setDropdownIconState(buddy->isVisible());
     } else {
-        setExpandIconState(false);
+        setDropdownIconState(false);
     }
 }
 
-void BannerWidget::setExpandIconState(bool expanded) const
+void BannerWidget::setDropdownIconState(bool expanded) const
 {
     if (clickable) {
-        iconLabel->setPixmap(ExpandIconPixmapGenerator::generatePixmap(24, expanded));
+        iconLabel->setPixmap(DropdownIconPixmapGenerator::generatePixmap(24, expanded));
     } else {
         // we cannot directly hide the iconLabel, since it's needed to center the text; set an empty image instead
         iconLabel->setPixmap(QPixmap());

--- a/cockatrice/src/client/ui/widgets/general/display/banner_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/display/banner_widget.h
@@ -40,7 +40,7 @@ signals:
     void buddyVisibilityChanged();
 private slots:
     void toggleBuddyVisibility() const;
-    void setExpandIconState(bool expanded) const;
+    void setDropdownIconState(bool expanded) const;
 };
 
 #endif // BANNER_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/general/display/banner_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/display/banner_widget.h
@@ -33,7 +33,7 @@ protected:
     void paintEvent(QPaintEvent *event) override;
 
 private:
-    QVBoxLayout *layout;
+    QLabel *iconLabel;
     QLabel *bannerLabel;
     Qt::Orientation gradientOrientation;
     int transparency; // Transparency percentage for the gradient
@@ -43,6 +43,7 @@ signals:
     void buddyVisibilityChanged();
 private slots:
     void toggleBuddyVisibility() const;
+    void setExpandIconState(bool expanded) const;
 };
 
 #endif // BANNER_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/general/display/banner_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/display/banner_widget.h
@@ -16,6 +16,7 @@ public:
                           int transparency = 80);
     void mousePressEvent(QMouseEvent *event) override;
     void setText(const QString &text) const;
+    void setClickable(bool _clickable);
     void setBuddy(QWidget *_buddy)
     {
         buddy = _buddy;
@@ -23,10 +24,6 @@ public:
     QString getText() const
     {
         return bannerLabel->text();
-    }
-    void setClickable(bool _clickable)
-    {
-        clickable = _clickable;
     }
 
 protected:


### PR DESCRIPTION
## Short roundup of the initial problem

It's hard to tell which folders are expanded/collapsed in the visual deck storage

## What will change with this Pull Request?

https://github.com/user-attachments/assets/96163bf1-3f8b-408b-9874-c79c4ff5e1c2


- Added folder dropdown icons to the `BannerWidget`s
- Updates dynamically as folder is open/collapsed
- The top-level "Deck Storage" banner (and any unclickable `BannerWidget`s) won't have the icon

## Screenshots

<img width="1182" alt="Screenshot 2025-02-16 at 11 01 19 PM" src="https://github.com/user-attachments/assets/0ee6d5b6-fb5b-42ab-9e1f-d4af92ff1970" />



