### PR TITLE
add "open in deck editor" to VDS right-click menu

### DIFF
--- a/cockatrice/src/client/tabs/visual_deck_storage/tab_deck_storage_visual.cpp
+++ b/cockatrice/src/client/tabs/visual_deck_storage/tab_deck_storage_visual.cpp
@@ -14,6 +14,8 @@ TabDeckStorageVisual::TabDeckStorageVisual(TabSupervisor *_tabSupervisor)
     connect(this, &TabDeckStorageVisual::openDeckEditor, tabSupervisor, &TabSupervisor::addDeckEditorTab);
     connect(visualDeckStorageWidget, &VisualDeckStorageWidget::deckLoadRequested, this,
             &TabDeckStorageVisual::actOpenLocalDeck);
+    connect(visualDeckStorageWidget, &VisualDeckStorageWidget::openDeckEditor, this,
+            &TabDeckStorageVisual::openDeckEditor);
 
     auto *widget = new QWidget(this);
     auto *layout = new QVBoxLayout(widget);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -287,8 +287,8 @@ QMenu *DeckPreviewWidget::createRightClickMenu()
 {
     auto *menu = new QMenu(this);
 
-    auto loadDeckAction = menu->addAction(tr("Load Deck"));
-    connect(loadDeckAction, &QAction::triggered, this, [this] { emit deckLoadRequested(filePath); });
+    connect(menu->addAction(tr("Open in deck editor")), &QAction::triggered, this,
+            [this] { emit openDeckEditor(deckLoader); });
 
     menu->addSeparator();
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
@@ -40,6 +40,7 @@ public:
 
 signals:
     void deckLoadRequested(const QString &filePath);
+    void openDeckEditor(const DeckLoader *deck);
     void visibilityUpdated();
 
 public slots:

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
@@ -89,6 +89,8 @@ void VisualDeckStorageFolderDisplayWidget::createWidgetsForFiles()
 
         connect(display, &DeckPreviewWidget::deckLoadRequested, visualDeckStorageWidget,
                 &VisualDeckStorageWidget::deckLoadRequested);
+        connect(display, &DeckPreviewWidget::openDeckEditor, visualDeckStorageWidget,
+                &VisualDeckStorageWidget::openDeckEditor);
         connect(visualDeckStorageWidget->cardSizeWidget->getSlider(), &QSlider::valueChanged,
                 display->bannerCardDisplayWidget, &CardInfoPictureWidget::setScaleFactor);
         display->bannerCardDisplayWidget->setScaleFactor(visualDeckStorageWidget->cardSizeWidget->getSlider()->value());

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -47,6 +47,7 @@ public slots:
 signals:
     void bannerCardsRefreshed();
     void deckLoadRequested(const QString &filePath);
+    void openDeckEditor(const DeckLoader *deck);
     void tagFilterUpdated();
     void colorFilterUpdated();
     void searchFilterUpdated();

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -114,6 +114,7 @@ void DeckViewContainer::tryCreateVisualDeckStorageWidget()
     visualDeckStorageWidget = new VisualDeckStorageWidget(this);
     connect(visualDeckStorageWidget, &VisualDeckStorageWidget::deckLoadRequested, this,
             &DeckViewContainer::loadDeckFromFile);
+    connect(visualDeckStorageWidget, &VisualDeckStorageWidget::openDeckEditor, parentGame, &TabGame::openDeckEditor);
 
     deckViewLayout->addWidget(visualDeckStorageWidget);
 }


### PR DESCRIPTION
## Related Ticket(s)
- Relates to #5618

## Short roundup of the initial problem

Sometimes, I load into a game, load up a deck, then realize that I want to make a few tweaks to the deck before I start. Previously, I would need to go to the visual deck storage tab or deck editor tab and find that deck again.

## What will change with this Pull Request?

Replaced the "Load Deck" action with "Open in deck editor". This action always opens the deck in a new deck editor tab, regardless of where the visual deck storage is. This is equivalent to double-clicking when in the Visual Deck Storage tab, but allows you to do something you couldn't before when in a game lobby.

Double clicking still has existing behavior; It will open deck in deck editor when in the Visual Deck Storage tab and load deck when in a game lobby.

https://github.com/user-attachments/assets/ee3bc0c3-a1ff-44e3-937b-990abedc1206

- Added `openDeckEditor(const DeckLoader *deck)` signal to some classes up the chain, so that we can pass the signal from `DeckPreviewWidget` to `TabGame` and `TabDeckStorageVisual`.
- Replace "Load Deck" menu action with the new action and make it emit the new signal

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<img width="631" alt="Screenshot 2025-02-17 at 12 19 53 AM" src="https://github.com/user-attachments/assets/21817230-ee7f-436f-9d4a-b38009aa04f5" />

