### PR TITLE
Also parse "colors" field in Xml3Parser

### DIFF
--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
@@ -173,7 +173,7 @@ void CockatriceXml3Parser::loadCardsFromXml(QXmlStreamReader &xml)
                     name = xml.readElementText(QXmlStreamReader::IncludeChildElements);
                 } else if (xmlName == "text") {
                     text = xml.readElementText(QXmlStreamReader::IncludeChildElements);
-                } else if (xmlName == "color") {
+                } else if (xmlName == "color" || xmlName == "colors") {
                     colors.append(xml.readElementText(QXmlStreamReader::IncludeChildElements));
                 } else if (xmlName == "token") {
                     isToken = static_cast<bool>(xml.readElementText(QXmlStreamReader::IncludeChildElements).toInt());


### PR DESCRIPTION
## Short roundup of the initial problem

The log is being spammed by these lines whenever I try to load the card database

```
[2025-02-17 16:17:46.034 D] [CockatriceXml3Parser::loadCardsFromXml] - Unknown card property "colors" , trying to continue anyway [cockatrice_xml_3.cpp:266]
[2025-02-17 16:17:46.034 D] [CockatriceXml3Parser::loadCardsFromXml] - Unknown card property "colors" , trying to continue anyway [cockatrice_xml_3.cpp:266]
[2025-02-17 16:17:46.035 D] [CockatriceXml3Parser::loadCardsFromXml] - Unknown card property "colors" , trying to continue anyway [cockatrice_xml_3.cpp:266]
[2025-02-17 16:17:46.035 D] [CockatriceXml3Parser::loadCardsFromXml] - Unknown card property "colors" , trying to continue anyway [cockatrice_xml_3.cpp:266]
[2025-02-17 16:17:46.035 D] [CockatriceXml3Parser::loadCardsFromXml] - Unknown card property "colors" , trying to continue anyway [cockatrice_xml_3.cpp:266]
[2025-02-17 16:17:46.035 D] [CockatriceXml3Parser::loadCardsFromXml] - Unknown card property "colors" , trying to continue anyway [cockatrice_xml_3.cpp:266]
[2025-02-17 16:17:46.035 D] [CockatriceXml3Parser::loadCardsFromXml] - Unknown card property "colors" , trying to continue anyway [cockatrice_xml_3.cpp:266]
[2025-02-17 16:17:46.035 D] [CockatriceXml3Parser::loadCardsFromXml] - Unknown card property "colors" , trying to continue anyway [cockatrice_xml_3.cpp:266]
[2025-02-17 16:17:46.035 D] [CockatriceXml3Parser::loadCardsFromXml] - Unknown card property "colors" , trying to continue anyway [cockatrice_xml_3.cpp:266]
[2025-02-17 16:17:46.035 D] [CockatriceXml3Parser::loadCardsFromXml] - Unknown card property "colors" , trying to continue anyway [cockatrice_xml_3.cpp:266]
[2025-02-17 16:17:46.035 D] [CockatriceXml3Parser::loadCardsFromXml] - Unknown card property "colors" , trying to continue anyway [cockatrice_xml_3.cpp:266]
```

The cards.xml has the field as `colors` but Cockatrice only looks in the `color` field.

This also makes it so the card info doesn't read in the colors field. I think Cockatrice just fills in the colors from the color identity if the colors field is not present, so that's why it's gone unnoticed for so long.

## What will change with this Pull Request?
- Accept `colors` in addition to `color`

