### PR TITLE
Revert file watcher in VDS

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -11,7 +11,6 @@
 
 #include <QComboBox>
 #include <QDirIterator>
-#include <QFileSystemWatcher>
 #include <QMouseEvent>
 #include <QVBoxLayout>
 
@@ -118,28 +117,12 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     } else {
         scrollArea->setWidget(databaseLoadIndicator);
     }
-
-    addRecursiveWatch(watcher, SettingsCache::instance().getDeckPath());
-
-    // Signals for changes
-    connect(&watcher, &QFileSystemWatcher::fileChanged, this, &VisualDeckStorageWidget::refreshIfPossible);
-    connect(&watcher, &QFileSystemWatcher::directoryChanged, this, &VisualDeckStorageWidget::refreshIfPossible);
 }
 
 void VisualDeckStorageWidget::refreshIfPossible()
 {
     if (scrollArea->widget() != databaseLoadIndicator) {
         createRootFolderWidget();
-    }
-}
-
-void VisualDeckStorageWidget::addRecursiveWatch(QFileSystemWatcher &watcher, const QString &dirPath)
-{
-    QDir dir(dirPath);
-    watcher.addPath(dirPath); // Watch the root directory
-
-    for (const QFileInfo &entry : dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot)) {
-        addRecursiveWatch(watcher, entry.absoluteFilePath());
     }
 }
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -14,7 +14,6 @@
 
 #include <QCheckBox>
 #include <QFileSystemModel>
-#include <QFileSystemWatcher>
 
 class VisualDeckStorageSearchWidget;
 class VisualDeckStorageSortWidget;
@@ -27,7 +26,6 @@ class VisualDeckStorageWidget final : public QWidget
 public:
     explicit VisualDeckStorageWidget(QWidget *parent);
     void refreshIfPossible();
-    void addRecursiveWatch(QFileSystemWatcher &watcher, const QString &dirPath);
     void retranslateUi();
 
     CardSizeWidget *cardSizeWidget;
@@ -69,7 +67,6 @@ private:
     QCheckBox *tagsOnWidgetsVisibilityCheckBox;
     QScrollArea *scrollArea;
     VisualDeckStorageFolderDisplayWidget *folderWidget;
-    QFileSystemWatcher watcher;
 };
 
 #endif // VISUAL_DECK_STORAGE_WIDGET_H


### PR DESCRIPTION
## Related Ticket(s)
- Reverts changes made in #5608

## Short roundup of the initial problem

Adding File watcher to visual deck storage is causing lot of issues and is making Cockatrice unusable for some users. We should revert the change for now.

## What will change with this Pull Request?
- Remove file watcher from visual deck storage