### PR TITLE
include folder name in VDS search when folders are enabled

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_search_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_search_widget.cpp
@@ -1,5 +1,7 @@
 #include "visual_deck_storage_search_widget.h"
 
+#include "../../../../settings/cache_settings.h"
+
 /**
  * @brief Constructs a PrintingSelectorCardSearchWidget for searching cards by set name or set code.
  *
@@ -38,7 +40,29 @@ QString VisualDeckStorageSearchWidget::getSearchText()
     return searchBar->text();
 }
 
-void VisualDeckStorageSearchWidget::filterWidgets(QList<DeckPreviewWidget *> widgets, const QString &searchText)
+/**
+ * Gets the filename used for the search.
+ *
+ * if includeFolderName is true, then this returns the relative filepath starting from the deck folder.
+ * If the file isn't in the deck folder, or includeFolderName is false, then this will just return the filename.
+ *
+ * @param filePath The filePath to convert into a search name
+ */
+static QString getFileSearchName(const QString &filePath, bool includeFolderName)
+{
+    QString deckPath = SettingsCache::instance().getDeckPath();
+    if (includeFolderName && filePath.startsWith(deckPath)) {
+        return filePath.mid(deckPath.length()).toLower();
+    }
+
+    QFileInfo fileInfo(filePath);
+    QString fileName = fileInfo.fileName().toLower();
+    return fileName;
+}
+
+void VisualDeckStorageSearchWidget::filterWidgets(QList<DeckPreviewWidget *> widgets,
+                                                  const QString &searchText,
+                                                  bool includeFolderName)
 {
     if (searchText.isEmpty() || searchText.isNull()) {
         for (auto widget : widgets) {
@@ -47,9 +71,7 @@ void VisualDeckStorageSearchWidget::filterWidgets(QList<DeckPreviewWidget *> wid
     }
 
     for (auto file : widgets) {
-        QFileInfo fileInfo(file->filePath);
-        QString fileName = fileInfo.fileName().toLower();
-
-        file->filteredBySearch = !fileName.contains(searchText.toLower());
+        QString fileSearchName = getFileSearchName(file->filePath, includeFolderName);
+        file->filteredBySearch = !fileSearchName.contains(searchText.toLower());
     }
 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_search_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_search_widget.h
@@ -16,7 +16,7 @@ class VisualDeckStorageSearchWidget : public QWidget
 public:
     explicit VisualDeckStorageSearchWidget(VisualDeckStorageWidget *parent);
     QString getSearchText();
-    void filterWidgets(QList<DeckPreviewWidget *> widgets, const QString &searchText);
+    void filterWidgets(QList<DeckPreviewWidget *> widgets, const QString &searchText, bool includeFolderName);
 
 private:
     QHBoxLayout *layout;

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -221,7 +221,8 @@ void VisualDeckStorageWidget::updateColorFilter()
 void VisualDeckStorageWidget::updateSearchFilter()
 {
     if (folderWidget) {
-        searchWidget->filterWidgets(folderWidget->findChildren<DeckPreviewWidget *>(), searchWidget->getSearchText());
+        searchWidget->filterWidgets(folderWidget->findChildren<DeckPreviewWidget *>(), searchWidget->getSearchText(),
+                                    showFoldersCheckBox->isChecked());
     }
     emit searchFilterUpdated();
 }


### PR DESCRIPTION
## Short roundup of the initial problem


## What will change with this Pull Request?

When `show folders` is enabled, deck search will take the entire filepath of the deck (starting from the deck folder) into consideration

https://github.com/user-attachments/assets/69f7db2b-8fd2-456a-811b-a9096f56e6e7

