### PR TITLE
Refresh VDS when deck is saved in deck editor tab

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -31,6 +31,7 @@ set(cockatrice_SOURCES
     src/server/chat_view/chat_view.cpp
     src/game/board/counter_general.cpp
     src/deck/custom_line_edit.cpp
+    src/deck/deck_edit_event_bus.cpp
     src/deck/deck_loader.cpp
     src/deck/deck_list_model.cpp
     src/deck/deck_stats_interface.cpp

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -746,7 +746,7 @@ TabDeckEditor::TabDeckEditor(TabSupervisor *_tabSupervisor) : Tab(_tabSupervisor
     connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
     refreshShortcuts();
 
-    connect(this, &TabDeckEditor::deckSaved, DeckEditEventBus::instance(), &DeckEditEventBus::deckModified);
+    connect(this, &TabDeckEditor::deckSaved, DeckEditEventBus::instance(), &DeckEditEventBus::deckFileModified);
 
     loadLayout();
 }

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -3,6 +3,7 @@
 #include "../../client/game_logic/abstract_client.h"
 #include "../../client/tapped_out_interface.h"
 #include "../../client/ui/widgets/cards/card_info_frame_widget.h"
+#include "../../deck/deck_edit_event_bus.h"
 #include "../../deck/deck_stats_interface.h"
 #include "../../dialogs/dlg_load_deck.h"
 #include "../../dialogs/dlg_load_deck_from_clipboard.h"
@@ -745,6 +746,8 @@ TabDeckEditor::TabDeckEditor(TabSupervisor *_tabSupervisor) : Tab(_tabSupervisor
     connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
     refreshShortcuts();
 
+    connect(this, &TabDeckEditor::deckSaved, DeckEditEventBus::instance(), &DeckEditEventBus::deckModified);
+
     loadLayout();
 }
 
@@ -1136,6 +1139,8 @@ bool TabDeckEditor::actSaveDeck()
         return actSaveDeckAs();
     else if (deck->saveToFile(deck->getLastFileName(), deck->getLastFileFormat())) {
         setModified(false);
+
+        emit deckSaved(deck->getLastFileName());
         return true;
     }
     QMessageBox::critical(
@@ -1168,6 +1173,7 @@ bool TabDeckEditor::actSaveDeckAs()
 
     SettingsCache::instance().recents().updateRecentlyOpenedDeckPaths(fileName);
 
+    emit deckSaved(fileName);
     return true;
 }
 

--- a/cockatrice/src/client/tabs/tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/tab_deck_editor.h
@@ -189,6 +189,7 @@ public slots:
 signals:
     void openDeckEditor(const DeckLoader *deckLoader);
     void deckEditorClosing(TabDeckEditor *tab);
+    void deckSaved(const QString &filePath);
 };
 
 #endif

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -1,5 +1,6 @@
 #include "visual_deck_storage_widget.h"
 
+#include "../../../../deck/deck_edit_event_bus.h"
 #include "../../../../game/cards/card_database_manager.h"
 #include "../../../../settings/cache_settings.h"
 #include "../quick_settings/settings_button_widget.h"
@@ -110,6 +111,9 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
 
     retranslateUi();
 
+    connect(DeckEditEventBus::instance(), &DeckEditEventBus::deckModified, this,
+            &VisualDeckStorageWidget::handleDeckModified);
+
     // Don't waste time processing the cards if they're going to get refreshed anyway once the db finishes loading
     if (CardDatabaseManager::getInstance()->getLoadStatus() == LoadStatus::Ok) {
         createRootFolderWidget();
@@ -217,4 +221,19 @@ void VisualDeckStorageWidget::updateTagsVisibility(const bool visible)
     } else {
         tagFilterWidget->setHidden(true);
     }
+}
+
+/**
+ * Handles the scenario where a deck file has been modified. Updates the visual deck storage to reflect the change.
+ *
+ * @param filePath filepath to the changed deck
+ */
+void VisualDeckStorageWidget::handleDeckModified(const QString &filePath)
+{
+    // ignore if file isn't in deck folder
+    if (!filePath.startsWith(SettingsCache::instance().getDeckPath())) {
+        return;
+    }
+
+    refreshIfPossible();
 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -111,7 +111,7 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
 
     retranslateUi();
 
-    connect(DeckEditEventBus::instance(), &DeckEditEventBus::deckModified, this,
+    connect(DeckEditEventBus::instance(), &DeckEditEventBus::deckFileModified, this,
             &VisualDeckStorageWidget::handleDeckModified);
 
     // Don't waste time processing the cards if they're going to get refreshed anyway once the db finishes loading

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -39,6 +39,7 @@ public slots:
     void updateSearchFilter();
     void updateTagsVisibility(bool visible);
     void updateSortOrder();
+    void handleDeckModified(const QString &filePath);
     void resizeEvent(QResizeEvent *event) override;
     void showEvent(QShowEvent *event) override;
 

--- a/cockatrice/src/deck/deck_edit_event_bus.cpp
+++ b/cockatrice/src/deck/deck_edit_event_bus.cpp
@@ -1,0 +1,14 @@
+#include "deck_edit_event_bus.h"
+
+DeckEditEventBus::DeckEditEventBus()
+{
+}
+
+/**
+ * Gets the singleton instance of the event bus
+ */
+DeckEditEventBus *DeckEditEventBus::instance()
+{
+    static DeckEditEventBus deckEditEventBus; // Created only once, on first access
+    return &deckEditEventBus;
+}

--- a/cockatrice/src/deck/deck_edit_event_bus.h
+++ b/cockatrice/src/deck/deck_edit_event_bus.h
@@ -21,6 +21,13 @@ private:
 
 public:
     static DeckEditEventBus *instance();
+
+signals:
+    /**
+     * Should be emitted when a change has been written to a deck file.
+     * @param filePath Absolute path to the deck file
+     */
+    void deckModified(const QString &filePath);
 };
 
 #endif // DECK_EDIT_EVENT_BUS_H

--- a/cockatrice/src/deck/deck_edit_event_bus.h
+++ b/cockatrice/src/deck/deck_edit_event_bus.h
@@ -27,7 +27,7 @@ signals:
      * Should be emitted when a change has been written to a deck file.
      * @param filePath Absolute path to the deck file
      */
-    void deckModified(const QString &filePath);
+    void deckFileModified(const QString &filePath);
 };
 
 #endif // DECK_EDIT_EVENT_BUS_H

--- a/cockatrice/src/deck/deck_edit_event_bus.h
+++ b/cockatrice/src/deck/deck_edit_event_bus.h
@@ -1,0 +1,26 @@
+#ifndef DECK_EDIT_EVENT_BUS_H
+#define DECK_EDIT_EVENT_BUS_H
+
+#include <QObject>
+
+/**
+ * A singleton object that can be used to pass signals between objects that are far apart in the object tree.
+ * Contains signals that are related to deck editor and deck storage.
+ */
+class DeckEditEventBus : public QObject
+{
+    Q_OBJECT
+
+private:
+    // hide constructor
+    explicit DeckEditEventBus();
+
+    // Delete copy constructor and assignment operator to enforce singleton
+    DeckEditEventBus(const DeckEditEventBus &) = delete;
+    DeckEditEventBus &operator=(const DeckEditEventBus &) = delete;
+
+public:
+    static DeckEditEventBus *instance();
+};
+
+#endif // DECK_EDIT_EVENT_BUS_H


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5636
- Alternative implementation of feature in #5608

## Short roundup of the initial problem

We had to revert the file watcher because it was causing usability issues. However, having the VDS auto-refresh is still a very nice QoL feature.

## What will change with this Pull Request?

VDS now auto-refreshes whenever you save a deck in the Deck Editor Tab.

https://github.com/user-attachments/assets/1f4dddde-21a3-491d-b356-a036a0dc2e19

- Created a `DeckEditEventBus` singleton object in order to pass the signal from `TabDeckEditor` to `VisualDeckStorageWidget`
  - I know singletons are usually an anti-pattern, but I think doing it this way is still much cleaner than the alternative (where we pass the signal all the way across the object tree)
- `TabDeckEditor` gets `DeckEditEventBus` to emit `deckModified` signal on save
- `VisualDeckStorageWidget` refreshes upon receiving the signal from `DeckEditEventBus`
