### PR TITLE
Mark deck as modified when banner card is changed

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -113,8 +113,6 @@ void TabDeckEditor::createDeckDock()
     });
     connect(bannerCardComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &TabDeckEditor::setBannerCard);
-    connect(bannerCardComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
-            [this] { setModified(true); });
 
     deckTagsDisplayWidget = new DeckPreviewDeckTagsDisplayWidget(this, deckModel->getDeckList());
 
@@ -914,6 +912,7 @@ void TabDeckEditor::setBannerCard(int /* changedIndex */)
     QVariantMap itemData = bannerCardComboBox->itemData(bannerCardComboBox->currentIndex()).toMap();
     deckModel->getDeckList()->setBannerCard(
         QPair<QString, QString>(itemData["name"].toString(), itemData["uuid"].toString()));
+    setModified(true);
 }
 
 void TabDeckEditor::updateCardInfo(CardInfoPtr _card)

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -102,6 +102,7 @@ void TabDeckEditor::createDeckDock()
     commentsEdit->setObjectName("commentsEdit");
     commentsLabel->setBuddy(commentsEdit);
     connect(commentsEdit, SIGNAL(textChanged()), this, SLOT(updateComments()));
+
     bannerCardLabel = new QLabel();
     bannerCardLabel->setObjectName("bannerCardLabel");
     bannerCardLabel->setText(tr("Banner Card"));
@@ -112,6 +113,8 @@ void TabDeckEditor::createDeckDock()
     });
     connect(bannerCardComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &TabDeckEditor::setBannerCard);
+    connect(bannerCardComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            [this] { setModified(true); });
 
     deckTagsDisplayWidget = new DeckPreviewDeckTagsDisplayWidget(this, deckModel->getDeckList());
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5639

## Short roundup of the initial problem

Changing the banner card in the deck editor tab doesn't mark the deck as modified.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/3dc01301-25f7-469f-bcf3-c64549e0d4dd

- Mark deck as modified when banner card combo box's index changes
