### PR TITLE
show error message when open deck fails in VDS

### DIFF
--- a/cockatrice/src/client/tabs/visual_deck_storage/tab_deck_storage_visual.cpp
+++ b/cockatrice/src/client/tabs/visual_deck_storage/tab_deck_storage_visual.cpp
@@ -6,6 +6,7 @@
 #include "../tab_supervisor.h"
 #include "pb/command_deck_del.pb.h"
 
+#include <QMessageBox>
 #include <QMouseEvent>
 
 TabDeckStorageVisual::TabDeckStorageVisual(TabSupervisor *_tabSupervisor)
@@ -26,6 +27,7 @@ void TabDeckStorageVisual::actOpenLocalDeck(const QString &filePath)
 {
     DeckLoader deckLoader;
     if (!deckLoader.loadFromFile(filePath, DeckLoader::getFormatFromName(filePath), true)) {
+        QMessageBox::critical(this, tr("Error"), tr("Could not open deck at %1").arg(filePath));
         return;
     }
 


### PR DESCRIPTION
## Short roundup of the initial problem

Currently, nothing happens if opening a deck fails in the visual deck storage tab. There is no feedback at all.

There *is* an error message if VDS deck loading fails in the game lobby though

## What will change with this Pull Request?

Pop up error window when deck loading fails.

https://github.com/user-attachments/assets/cce21d41-329e-4b36-b40f-506a22754de7

## Screenshots

<img width="295" alt="Screenshot 2025-02-19 at 12 43 01 AM" src="https://github.com/user-attachments/assets/d929e96e-9eb7-4c88-9872-e99e4b47c694" />
