### PR TITLE
Destroy VDS in game lobby once game starts

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -836,6 +836,7 @@ void TabGame::startGame(bool _resuming)
     while (i.hasNext()) {
         i.next();
         i.value()->setReadyStart(false);
+        i.value()->setVisualDeckStorageExists(false);
         i.value()->hide();
     }
 

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -212,11 +212,14 @@ void DeckViewContainer::refreshShortcuts()
 void DeckViewContainer::updateShowVisualDeckStorage(bool enabled)
 {
     if (enabled) {
-        tryCreateVisualDeckStorageWidget();
         // view mode state isn't stored in a field, so we determine state by checking the button
-        bool isDeckSelectView = loadLocalButton->isEnabled();
-        visualDeckStorageWidget->setHidden(!isDeckSelectView);
-        deckView->setHidden(isDeckSelectView);
+        if (loadLocalButton->isEnabled()) {
+            // We only need to handle the setting changing while in deck select state; tryCreate already gets called
+            // when switching from deck loaded to deck select state
+            tryCreateVisualDeckStorageWidget();
+            visualDeckStorageWidget->setHidden(false);
+            deckView->setHidden(true);
+        }
     } else {
         if (visualDeckStorageWidget) {
             visualDeckStorageWidget->deleteLater();

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -97,7 +97,7 @@ DeckViewContainer::DeckViewContainer(int _playerId, TabGame *parent)
     refreshShortcuts();
 
     connect(&SettingsCache::instance(), &SettingsCache::visualDeckStorageInGameChanged, this,
-            &DeckViewContainer::updateShowVisualDeckStorage);
+            &DeckViewContainer::setVisualDeckStorageExists);
 
     switchToDeckSelectView();
 }
@@ -207,11 +207,13 @@ void DeckViewContainer::refreshShortcuts()
 }
 
 /**
- * Update VDS existence when settings change
+ * Updates the existence of the embedded Visual Deck Storage, destroying or creating it if needed.
+ * Note that this change is temporary; the VDS may get recreated when the view transitions to the deck select state,
+ * depending on current settings.
  */
-void DeckViewContainer::updateShowVisualDeckStorage(bool enabled)
+void DeckViewContainer::setVisualDeckStorageExists(bool exists)
 {
-    if (enabled) {
+    if (exists) {
         // view mode state isn't stored in a field, so we determine state by checking the button
         if (loadLocalButton->isEnabled()) {
             // We only need to handle the setting changing while in deck select state; tryCreate already gets called

--- a/cockatrice/src/game/deckview/deck_view_container.h
+++ b/cockatrice/src/game/deckview/deck_view_container.h
@@ -66,7 +66,6 @@ private slots:
     void sideboardLockButtonClicked();
     void updateSideboardLockButtonText();
     void refreshShortcuts();
-    void updateShowVisualDeckStorage(bool enabled);
 signals:
     void newCardAdded(AbstractCardItem *card);
     void notIdle();
@@ -78,6 +77,7 @@ public:
     void readyAndUpdate();
     void setSideboardLocked(bool locked);
     void setDeck(const DeckLoader &deck);
+    void setVisualDeckStorageExists(bool exists);
 
 public slots:
     void loadDeckFromFile(const QString &filePath);


### PR DESCRIPTION
## Short roundup of the initial problem

Currently, the visual deck storage in the game lobby will still stick around after the game starts, simply being hidden. VDS is quite an expensive widget, so there's probably some efficiency gains to be made by deleting the VDS when the game starts. 

Most players playing a best-of-3 won't need to go back to the VDS after the game, and we can always just recreate the VDS if they really want to go back.

## What will change with this Pull Request?
- rename and make public the method that used to handle the signal from the "show VDS in game lobby" setting changing
- Destroy the VDS inside the `DeckViewContainer` when the game starts
- Incidental functional change: If the "show VDS in game lobby" setting is off and then you turn it on while inside a game, the VDS won't get created until you switch to the deck select view. 
