### PR TITLE
Fix memory leak when refreshing VDS

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -22,6 +22,7 @@ DeckPreviewWidget::DeckPreviewWidget(QWidget *_parent,
     setLayout(layout);
 
     deckLoader = new DeckLoader();
+    deckLoader->setParent(this);
     connect(deckLoader, &DeckLoader::loadFinished, this, &DeckPreviewWidget::initializeUi);
     connect(deckLoader, &DeckLoader::loadFinished, visualDeckStorageWidget->tagFilterWidget,
             &VisualDeckStorageTagFilterWidget::refreshTags);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -160,7 +160,7 @@ void VisualDeckStorageWidget::createRootFolderWidget()
     folderWidget = new VisualDeckStorageFolderDisplayWidget(this, this, SettingsCache::instance().getDeckPath(), false,
                                                             showFoldersCheckBox->isChecked());
 
-    scrollArea->setWidget(folderWidget);
+    scrollArea->setWidget(folderWidget); // this automatically destroys the old folderWidget
     scrollArea->widget()->setMaximumWidth(scrollArea->viewport()->width());
     scrollArea->widget()->adjustSize();
     updateSortOrder();


### PR DESCRIPTION
## Short roundup of the initial problem

Visual Deck Storage leaks memory. Turns out it's because the `DeckLoader`s inside the `DeckPreviewWidget` aren't parented, which means they never get destroyed.

https://github.com/user-attachments/assets/a5895708-a48a-4cd8-9747-279c1308bac1

## What will change with this Pull Request?
- Parent the `DeckLoader`s so that they get destroyed when the `DeckPreviewWidget` gets destroyed 
- Leave a comment, because my first guess for the cause turned out to be incorrect

https://github.com/user-attachments/assets/8b7bea78-78d7-4a6b-aef0-cfcc9d90213f


