### PR TITLE
fix transform from non-table zones not moving card

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -1981,21 +1981,24 @@ void Player::createCard(const CardItem *sourceCard,
         cmd.set_annotation("");
     }
     cmd.set_destroy_on_zone_change(!persistent);
-    cmd.set_target_zone("table"); // we currently only support creating tokens on the table
     cmd.set_x(gridPoint.x());
     cmd.set_y(gridPoint.y());
 
     switch (attachType) {
         case CardRelation::DoesNotAttach:
+            cmd.set_target_zone("table");
             break;
 
         case CardRelation::AttachTo:
+            cmd.set_target_zone("table"); // We currently only support creating tokens on the table
             cmd.set_target_card_id(sourceCard->getId());
             cmd.set_target_mode(Command_CreateToken::ATTACH_TO);
             cmd.set_card_provider_id(sourceCard->getProviderId().toStdString());
             break;
 
         case CardRelation::TransformInto:
+            // Transform card zone changes are handled server-side
+            cmd.set_target_zone(sourceCard->getZone()->getName().toStdString());
             cmd.set_target_card_id(sourceCard->getId());
             cmd.set_target_mode(Command_CreateToken::TRANSFORM_INTO);
             cmd.set_card_provider_id(sourceCard->getProviderId().toStdString());


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5645
- Fixes bug introduced in #5629

## Short roundup of the initial problem

Creating a transformed card from a non-table zone just creates a token and doesn't move the old card to play. This was caused by the change that made attachTo cards work from non-table zones hard-coding the target_zone to "table". 

Turns out transform CardRelations are handled server-side and require the target_zone to be the same as the card's current zone.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/ce1140ca-9da3-4ab6-a673-6b3f1e749136

- set target_zone differently depending on the CardRelation
