### PR TITLE
Fix banner card changing when opening deck in new tab

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -1084,10 +1084,6 @@ void TabDeckEditor::openDeckFromFile(const QString &fileName, DeckOpenLocation d
     auto *l = new DeckLoader;
     if (l->loadFromFile(fileName, fmt, true)) {
         SettingsCache::instance().recents().updateRecentlyOpenedDeckPaths(fileName);
-        updateBannerCardComboBox();
-        if (!l->getBannerCard().first.isEmpty()) {
-            bannerCardComboBox->setCurrentIndex(bannerCardComboBox->findText(l->getBannerCard().first));
-        }
         if (deckOpenLocation == NEW_TAB) {
             emit openDeckEditor(l);
         } else {


### PR DESCRIPTION
## Short roundup of the initial problem

When the "Open deck in new tab by default" setting is enabled and you open a new deck from the Deck Editor Tab, the old deck's `bannerCardComboBox` gets its selection set to the new deck's banner card.

## What will change with this Pull Request?
- Remove the code in `openDeckFromFile` that sets the `bannerCardComboBox`
  - The `bannerCardComboBox` already gets updated in `setDeck`

