### PR TITLE
Switch current tab when opening a single-instance tab

### DIFF
--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -285,9 +285,15 @@ void TabSupervisor::initStartupTabs()
 {
     addDeckEditorTab(nullptr);
 
-    checkAndTrigger(aTabVisualDeckStorage, SettingsCache::instance().getTabVisualDeckStorageOpen());
-    checkAndTrigger(aTabDeckStorage, SettingsCache::instance().getTabDeckStorageOpen());
-    checkAndTrigger(aTabReplays, SettingsCache::instance().getTabReplaysOpen());
+    if (SettingsCache::instance().getTabVisualDeckStorageOpen()) {
+        openTabVisualDeckStorage(false);
+    }
+    if (SettingsCache::instance().getTabDeckStorageOpen()) {
+        openTabDeckStorage(false);
+    }
+    if (SettingsCache::instance().getTabReplaysOpen()) {
+        openTabReplays(false);
+    }
 }
 
 /**
@@ -365,8 +371,12 @@ void TabSupervisor::start(const ServerInfo_User &_userInfo)
     tabsMenu->addAction(aTabServer);
     tabsMenu->addAction(aTabAccount);
 
-    checkAndTrigger(aTabServer, SettingsCache::instance().getTabServerOpen());
-    checkAndTrigger(aTabAccount, SettingsCache::instance().getTabAccountOpen());
+    if (SettingsCache::instance().getTabServerOpen()) {
+        openTabServer(false);
+    }
+    if (SettingsCache::instance().getTabAccountOpen()) {
+        openTabAccount(false);
+    }
 
     updatePingTime(0, -1);
 
@@ -375,8 +385,12 @@ void TabSupervisor::start(const ServerInfo_User &_userInfo)
         tabsMenu->addAction(aTabAdmin);
         tabsMenu->addAction(aTabLog);
 
-        checkAndTrigger(aTabAdmin, SettingsCache::instance().getTabAdminOpen());
-        checkAndTrigger(aTabLog, SettingsCache::instance().getTabLogOpen());
+        if (SettingsCache::instance().getTabAdminOpen()) {
+            openTabAdmin(false);
+        }
+        if (SettingsCache::instance().getTabLogOpen()) {
+            openTabLog(false);
+        }
     }
 
     retranslateUi();
@@ -472,6 +486,7 @@ void TabSupervisor::openTabVisualDeckStorage(bool setCurrent)
         tabVisualDeckStorage = nullptr;
         aTabVisualDeckStorage->setChecked(false);
     });
+    aTabVisualDeckStorage->setChecked(true);
 }
 
 void TabSupervisor::actTabServer(bool checked)
@@ -493,6 +508,7 @@ void TabSupervisor::openTabServer(bool setCurrent)
         tabServer = nullptr;
         aTabServer->setChecked(false);
     });
+    aTabServer->setChecked(true);
 }
 
 void TabSupervisor::actTabAccount(bool checked)
@@ -516,6 +532,7 @@ void TabSupervisor::openTabAccount(bool setCurrent)
         tabAccount = nullptr;
         aTabAccount->setChecked(false);
     });
+    aTabAccount->setChecked(true);
 }
 
 void TabSupervisor::actTabDeckStorage(bool checked)
@@ -537,6 +554,7 @@ void TabSupervisor::openTabDeckStorage(bool setCurrent)
         tabDeckStorage = nullptr;
         aTabDeckStorage->setChecked(false);
     });
+    aTabDeckStorage->setChecked(true);
 }
 
 void TabSupervisor::actTabReplays(bool checked)
@@ -558,6 +576,7 @@ void TabSupervisor::openTabReplays(bool setCurrent)
         tabReplays = nullptr;
         aTabReplays->setChecked(false);
     });
+    aTabReplays->setChecked(true);
 }
 
 void TabSupervisor::actTabAdmin(bool checked)
@@ -579,6 +598,7 @@ void TabSupervisor::openTabAdmin(bool setCurrent)
         tabAdmin = nullptr;
         aTabAdmin->setChecked(false);
     });
+    aTabAdmin->setChecked(true);
 }
 
 void TabSupervisor::actTabLog(bool checked)
@@ -599,6 +619,7 @@ void TabSupervisor::openTabLog(bool setCurrent)
         tabLog = nullptr;
         aTabAdmin->setChecked(false);
     });
+    aTabAdmin->setChecked(true);
 }
 
 void TabSupervisor::updatePingTime(int value, int max)

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -466,112 +466,147 @@ void TabSupervisor::actTabVisualDeckStorage(bool checked)
 {
     SettingsCache::instance().setTabVisualDeckStorageOpen(checked);
     if (checked && !tabVisualDeckStorage) {
-        tabVisualDeckStorage = new TabDeckStorageVisual(this);
-        myAddTab(tabVisualDeckStorage, !isReopeningTabs, aTabVisualDeckStorage);
-        connect(tabVisualDeckStorage, &Tab::closed, this, [this] {
-            tabVisualDeckStorage = nullptr;
-            aTabVisualDeckStorage->setChecked(false);
-        });
+        openTabVisualDeckStorage(true);
     } else if (!checked && tabVisualDeckStorage) {
         tabVisualDeckStorage->closeRequest();
     }
+}
+
+void TabSupervisor::openTabVisualDeckStorage(bool setCurrent)
+{
+    tabVisualDeckStorage = new TabDeckStorageVisual(this);
+    myAddTab(tabVisualDeckStorage, setCurrent, aTabVisualDeckStorage);
+    connect(tabVisualDeckStorage, &Tab::closed, this, [this] {
+        tabVisualDeckStorage = nullptr;
+        aTabVisualDeckStorage->setChecked(false);
+    });
 }
 
 void TabSupervisor::actTabServer(bool checked)
 {
     SettingsCache::instance().setTabServerOpen(checked);
     if (checked && !tabServer) {
-        tabServer = new TabServer(this, client);
-        connect(tabServer, &TabServer::roomJoined, this, &TabSupervisor::addRoomTab);
-        myAddTab(tabServer, !isReopeningTabs, aTabServer);
-        connect(tabServer, &Tab::closed, this, [this] {
-            tabServer = nullptr;
-            aTabServer->setChecked(false);
-        });
+        openTabServer(true);
     } else if (!checked && tabServer) {
         tabServer->closeRequest();
     }
+}
+
+void TabSupervisor::openTabServer(bool setCurrent)
+{
+    tabServer = new TabServer(this, client);
+    connect(tabServer, &TabServer::roomJoined, this, &TabSupervisor::addRoomTab);
+    myAddTab(tabServer, setCurrent, aTabServer);
+    connect(tabServer, &Tab::closed, this, [this] {
+        tabServer = nullptr;
+        aTabServer->setChecked(false);
+    });
 }
 
 void TabSupervisor::actTabAccount(bool checked)
 {
     SettingsCache::instance().setTabAccountOpen(checked);
     if (checked && !tabAccount) {
-        tabAccount = new TabAccount(this, client, *userInfo);
-        connect(tabAccount, &TabAccount::openMessageDialog, this, &TabSupervisor::addMessageTab);
-        connect(tabAccount, &TabAccount::userJoined, this, &TabSupervisor::processUserJoined);
-        connect(tabAccount, &TabAccount::userLeft, this, &TabSupervisor::processUserLeft);
-        myAddTab(tabAccount, !isReopeningTabs, aTabAccount);
-        connect(tabAccount, &Tab::closed, this, [this] {
-            tabAccount = nullptr;
-            aTabAccount->setChecked(false);
-        });
+        openTabAccount(true);
     } else if (!checked && tabAccount) {
         tabAccount->closeRequest();
     }
+}
+
+void TabSupervisor::openTabAccount(bool setCurrent)
+{
+    tabAccount = new TabAccount(this, client, *userInfo);
+    connect(tabAccount, &TabAccount::openMessageDialog, this, &TabSupervisor::addMessageTab);
+    connect(tabAccount, &TabAccount::userJoined, this, &TabSupervisor::processUserJoined);
+    connect(tabAccount, &TabAccount::userLeft, this, &TabSupervisor::processUserLeft);
+    myAddTab(tabAccount, setCurrent, aTabAccount);
+    connect(tabAccount, &Tab::closed, this, [this] {
+        tabAccount = nullptr;
+        aTabAccount->setChecked(false);
+    });
 }
 
 void TabSupervisor::actTabDeckStorage(bool checked)
 {
     SettingsCache::instance().setTabDeckStorageOpen(checked);
     if (checked && !tabDeckStorage) {
-        tabDeckStorage = new TabDeckStorage(this, client, userInfo);
-        connect(tabDeckStorage, &TabDeckStorage::openDeckEditor, this, &TabSupervisor::addDeckEditorTab);
-        myAddTab(tabDeckStorage, !isReopeningTabs, aTabDeckStorage);
-        connect(tabDeckStorage, &Tab::closed, this, [this] {
-            tabDeckStorage = nullptr;
-            aTabDeckStorage->setChecked(false);
-        });
+        openTabDeckStorage(true);
     } else if (!checked && tabDeckStorage) {
         tabDeckStorage->closeRequest();
     }
+}
+
+void TabSupervisor::openTabDeckStorage(bool setCurrent)
+{
+    tabDeckStorage = new TabDeckStorage(this, client, userInfo);
+    connect(tabDeckStorage, &TabDeckStorage::openDeckEditor, this, &TabSupervisor::addDeckEditorTab);
+    myAddTab(tabDeckStorage, setCurrent, aTabDeckStorage);
+    connect(tabDeckStorage, &Tab::closed, this, [this] {
+        tabDeckStorage = nullptr;
+        aTabDeckStorage->setChecked(false);
+    });
 }
 
 void TabSupervisor::actTabReplays(bool checked)
 {
     SettingsCache::instance().setTabReplaysOpen(checked);
     if (checked && !tabReplays) {
-        tabReplays = new TabReplays(this, client, userInfo);
-        connect(tabReplays, &TabReplays::openReplay, this, &TabSupervisor::openReplay);
-        myAddTab(tabReplays, !isReopeningTabs, aTabReplays);
-        connect(tabReplays, &Tab::closed, this, [this] {
-            tabReplays = nullptr;
-            aTabReplays->setChecked(false);
-        });
+        openTabReplays(true);
     } else if (!checked && tabReplays) {
         tabReplays->closeRequest();
     }
+}
+
+void TabSupervisor::openTabReplays(bool setCurrent)
+{
+    tabReplays = new TabReplays(this, client, userInfo);
+    connect(tabReplays, &TabReplays::openReplay, this, &TabSupervisor::openReplay);
+    myAddTab(tabReplays, setCurrent, aTabReplays);
+    connect(tabReplays, &Tab::closed, this, [this] {
+        tabReplays = nullptr;
+        aTabReplays->setChecked(false);
+    });
 }
 
 void TabSupervisor::actTabAdmin(bool checked)
 {
     SettingsCache::instance().setTabAdminOpen(checked);
     if (checked && !tabAdmin) {
-        tabAdmin = new TabAdmin(this, client, (userInfo->user_level() & ServerInfo_User::IsAdmin));
-        connect(tabAdmin, &TabAdmin::adminLockChanged, this, &TabSupervisor::adminLockChanged);
-        myAddTab(tabAdmin, !isReopeningTabs, aTabAdmin);
-        connect(tabAdmin, &Tab::closed, this, [this] {
-            tabAdmin = nullptr;
-            aTabAdmin->setChecked(false);
-        });
+        openTabAdmin(true);
     } else if (!checked && tabAdmin) {
         tabAdmin->closeRequest();
     }
+}
+
+void TabSupervisor::openTabAdmin(bool setCurrent)
+{
+    tabAdmin = new TabAdmin(this, client, (userInfo->user_level() & ServerInfo_User::IsAdmin));
+    connect(tabAdmin, &TabAdmin::adminLockChanged, this, &TabSupervisor::adminLockChanged);
+    myAddTab(tabAdmin, setCurrent, aTabAdmin);
+    connect(tabAdmin, &Tab::closed, this, [this] {
+        tabAdmin = nullptr;
+        aTabAdmin->setChecked(false);
+    });
 }
 
 void TabSupervisor::actTabLog(bool checked)
 {
     SettingsCache::instance().setTabLogOpen(checked);
     if (checked && !tabLog) {
-        tabLog = new TabLog(this, client);
-        myAddTab(tabLog, !isReopeningTabs, aTabLog);
-        connect(tabLog, &Tab::closed, this, [this] {
-            tabLog = nullptr;
-            aTabAdmin->setChecked(false);
-        });
+        openTabLog(true);
     } else if (!checked && tabLog) {
         tabLog->closeRequest();
     }
+}
+
+void TabSupervisor::openTabLog(bool setCurrent)
+{
+    tabLog = new TabLog(this, client);
+    myAddTab(tabLog, setCurrent, aTabLog);
+    connect(tabLog, &Tab::closed, this, [this] {
+        tabLog = nullptr;
+        aTabAdmin->setChecked(false);
+    });
 }
 
 void TabSupervisor::updatePingTime(int value, int max)

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -101,7 +101,7 @@ void CloseButton::paintEvent(QPaintEvent * /*event*/)
 TabSupervisor::TabSupervisor(AbstractClient *_client, QMenu *tabsMenu, QWidget *parent)
     : QTabWidget(parent), userInfo(nullptr), client(_client), tabsMenu(tabsMenu), tabVisualDeckStorage(nullptr),
       tabServer(nullptr), tabAccount(nullptr), tabDeckStorage(nullptr), tabReplays(nullptr), tabAdmin(nullptr),
-      tabLog(nullptr), isLocalGame(false), isReopeningTabs(false)
+      tabLog(nullptr), isLocalGame(false)
 {
     setElideMode(Qt::ElideRight);
     setMovable(true);
@@ -285,13 +285,9 @@ void TabSupervisor::initStartupTabs()
 {
     addDeckEditorTab(nullptr);
 
-    isReopeningTabs = true;
-
     checkAndTrigger(aTabVisualDeckStorage, SettingsCache::instance().getTabVisualDeckStorageOpen());
     checkAndTrigger(aTabDeckStorage, SettingsCache::instance().getTabDeckStorageOpen());
     checkAndTrigger(aTabReplays, SettingsCache::instance().getTabReplaysOpen());
-
-    isReopeningTabs = false;
 }
 
 /**
@@ -365,8 +361,6 @@ void TabSupervisor::start(const ServerInfo_User &_userInfo)
 
     resetTabsMenu();
 
-    isReopeningTabs = true;
-
     tabsMenu->addSeparator();
     tabsMenu->addAction(aTabServer);
     tabsMenu->addAction(aTabAccount);
@@ -384,8 +378,6 @@ void TabSupervisor::start(const ServerInfo_User &_userInfo)
         checkAndTrigger(aTabAdmin, SettingsCache::instance().getTabAdminOpen());
         checkAndTrigger(aTabLog, SettingsCache::instance().getTabLogOpen());
     }
-
-    isReopeningTabs = false;
 
     retranslateUi();
 }

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -93,7 +93,7 @@ private:
     QAction *aTabDeckEditor, *aTabVisualDeckStorage, *aTabServer, *aTabAccount, *aTabDeckStorage, *aTabReplays,
         *aTabAdmin, *aTabLog;
 
-    int myAddTab(Tab *tab, bool setCurrent, QAction *manager = nullptr);
+    int myAddTab(Tab *tab, QAction *manager = nullptr);
     void addCloseButtonToTab(Tab *tab, int tabIndex, QAction *manager);
     static QString sanitizeTabName(QString dirty);
     static QString sanitizeHtml(QString dirty);
@@ -162,13 +162,13 @@ private slots:
     void actTabAdmin(bool checked);
     void actTabLog(bool checked);
 
-    void openTabVisualDeckStorage(bool setCurrent);
-    void openTabServer(bool setCurrent);
-    void openTabAccount(bool setCurrent);
-    void openTabDeckStorage(bool setCurrent);
-    void openTabReplays(bool setCurrent);
-    void openTabAdmin(bool setCurrent);
-    void openTabLog(bool setCurrent);
+    void openTabVisualDeckStorage();
+    void openTabServer();
+    void openTabAccount();
+    void openTabDeckStorage();
+    void openTabReplays();
+    void openTabAdmin();
+    void openTabLog();
 
     void updateCurrent(int index);
     void updatePingTime(int value, int max);

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -167,6 +167,14 @@ private slots:
     void actTabAdmin(bool checked);
     void actTabLog(bool checked);
 
+    void openTabVisualDeckStorage(bool setCurrent);
+    void openTabServer(bool setCurrent);
+    void openTabAccount(bool setCurrent);
+    void openTabDeckStorage(bool setCurrent);
+    void openTabReplays(bool setCurrent);
+    void openTabAdmin(bool setCurrent);
+    void openTabLog(bool setCurrent);
+
     void updateCurrent(int index);
     void updatePingTime(int value, int max);
     void gameJoined(const Event_GameJoined &event);

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -90,11 +90,6 @@ private:
     QList<TabDeckEditor *> deckEditorTabs;
     bool isLocalGame;
 
-    /**
-     * Whether we're in the middle of reopening tabs that have their open state persisted in the settings.
-     */
-    bool isReopeningTabs;
-
     QAction *aTabDeckEditor, *aTabVisualDeckStorage, *aTabServer, *aTabAccount, *aTabDeckStorage, *aTabReplays,
         *aTabAdmin, *aTabLog;
 

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -90,10 +90,15 @@ private:
     QList<TabDeckEditor *> deckEditorTabs;
     bool isLocalGame;
 
+    /**
+     * Whether we're in the middle of reopening tabs that have their open state persisted in the settings.
+     */
+    bool isReopeningTabs;
+
     QAction *aTabDeckEditor, *aTabVisualDeckStorage, *aTabServer, *aTabAccount, *aTabDeckStorage, *aTabReplays,
         *aTabAdmin, *aTabLog;
 
-    int myAddTab(Tab *tab, QAction *manager = nullptr);
+    int myAddTab(Tab *tab, bool setCurrent, QAction *manager = nullptr);
     void addCloseButtonToTab(Tab *tab, int tabIndex, QAction *manager);
     static QString sanitizeTabName(QString dirty);
     static QString sanitizeHtml(QString dirty);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5650

## Short roundup of the initial problem

Cockatrice currently does not switch the current tab to the new tab when opening a new single-instance tab. 

## What will change with this Pull Request?

Opening a single-instance managed tab will now switch the current tab to the new tab. Note that this only counts tabs that are directly opened by the user. Tabs getting opened on startup or on connect still won't cause current tab to change

https://github.com/user-attachments/assets/df83a7c5-1c5b-467e-bb2a-49105c51baf1

- Add `isReopeningTabs` field to `TabSupervisor` to track when tabs are being re-opened from settings so that those tabs don't get auto-focused.
  - Probably not best practice to rely on a mutable field to keep track of stuff like this, but the alternative is a lot messier
    - There shouldn't be any race conditions because I'm pretty sure the tab reopening code is all ran on the same thread.
- add `setCurrent` param to `myAddTab`
  - the managed tabs now call `myAddTab` with `setCurrent` = `!isReopeningTabs`
  - modify existing tab opens that already set current to use that param