### PR TITLE
Expand/shrink card view window on double click

### DIFF
--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -404,6 +404,11 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     connect(&cardViewInitialRowsMaxBox, qOverload<int>(&QSpinBox::valueChanged), &SettingsCache::instance(),
             &SettingsCache::setCardViewInitialRowsMax);
 
+    cardViewExpandedRowsMaxBox.setRange(1, 999);
+    cardViewExpandedRowsMaxBox.setValue(SettingsCache::instance().getCardViewExpandedRowsMax());
+    connect(&cardViewExpandedRowsMaxBox, qOverload<int>(&QSpinBox::valueChanged), &SettingsCache::instance(),
+            &SettingsCache::setCardViewExpandedRowsMax);
+
     auto *cardsGrid = new QGridLayout;
     cardsGrid->addWidget(&displayCardNamesCheckBox, 0, 0, 1, 2);
     cardsGrid->addWidget(&autoRotateSidewaysLayoutCardsCheckBox, 1, 0, 1, 2);
@@ -414,6 +419,8 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     cardsGrid->addWidget(&verticalCardOverlapPercentBox, 5, 1, 1, 1);
     cardsGrid->addWidget(&cardViewInitialRowsMaxLabel, 6, 0);
     cardsGrid->addWidget(&cardViewInitialRowsMaxBox, 6, 1);
+    cardsGrid->addWidget(&cardViewExpandedRowsMaxLabel, 7, 0);
+    cardsGrid->addWidget(&cardViewExpandedRowsMaxBox, 7, 1);
 
     cardsGroupBox = new QGroupBox;
     cardsGroupBox->setLayout(cardsGrid);
@@ -526,6 +533,8 @@ void AppearanceSettingsPage::retranslateUi()
         tr("Minimum overlap percentage of cards on the stack and in vertical hand"));
     cardViewInitialRowsMaxLabel.setText(tr("Maximum initial height for card view window:"));
     cardViewInitialRowsMaxBox.setSuffix(tr(" rows"));
+    cardViewExpandedRowsMaxLabel.setText(tr("Maximum expanded height for card view window:"));
+    cardViewExpandedRowsMaxBox.setSuffix(tr(" rows"));
 
     handGroupBox->setTitle(tr("Hand layout"));
     horizontalHandCheckBox.setText(tr("Display hand horizontally (wastes space)"));

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -401,13 +401,13 @@ AppearanceSettingsPage::AppearanceSettingsPage()
 
     cardViewInitialRowsMaxBox.setRange(1, 999);
     cardViewInitialRowsMaxBox.setValue(SettingsCache::instance().getCardViewInitialRowsMax());
-    connect(&cardViewInitialRowsMaxBox, qOverload<int>(&QSpinBox::valueChanged), &SettingsCache::instance(),
-            &SettingsCache::setCardViewInitialRowsMax);
+    connect(&cardViewInitialRowsMaxBox, qOverload<int>(&QSpinBox::valueChanged), this,
+            &AppearanceSettingsPage::cardViewInitialRowsMaxChanged);
 
     cardViewExpandedRowsMaxBox.setRange(1, 999);
     cardViewExpandedRowsMaxBox.setValue(SettingsCache::instance().getCardViewExpandedRowsMax());
-    connect(&cardViewExpandedRowsMaxBox, qOverload<int>(&QSpinBox::valueChanged), &SettingsCache::instance(),
-            &SettingsCache::setCardViewExpandedRowsMax);
+    connect(&cardViewExpandedRowsMaxBox, qOverload<int>(&QSpinBox::valueChanged), this,
+            &AppearanceSettingsPage::cardViewExpandedRowsMaxChanged);
 
     auto *cardsGrid = new QGridLayout;
     cardsGrid->addWidget(&displayCardNamesCheckBox, 0, 0, 1, 2);
@@ -505,6 +505,32 @@ void AppearanceSettingsPage::showShortcutsChanged(QT_STATE_CHANGED_T value)
 {
     SettingsCache::instance().setShowShortcuts(value);
     qApp->setAttribute(Qt::AA_DontShowShortcutsInContextMenus, value == 0); // 0 = unchecked
+}
+
+/**
+ * Updates the settings for cardViewInitialRowsMax.
+ * Forces expanded rows max to always be >= initial rows max
+ * @param value The new value
+ */
+void AppearanceSettingsPage::cardViewInitialRowsMaxChanged(int value)
+{
+    SettingsCache::instance().setCardViewInitialRowsMax(value);
+    if (cardViewExpandedRowsMaxBox.value() < value) {
+        cardViewExpandedRowsMaxBox.setValue(value);
+    }
+}
+
+/**
+ * Updates the settings for cardViewExpandedRowsMax.
+ * Forces initial rows max to always be <= expanded rows max
+ * @param value The new value
+ */
+void AppearanceSettingsPage::cardViewExpandedRowsMaxChanged(int value)
+{
+    SettingsCache::instance().setCardViewExpandedRowsMax(value);
+    if (cardViewInitialRowsMaxBox.value() > value) {
+        cardViewInitialRowsMaxBox.setValue(value);
+    }
 }
 
 void AppearanceSettingsPage::retranslateUi()

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -110,6 +110,8 @@ private:
     QSpinBox verticalCardOverlapPercentBox;
     QLabel cardViewInitialRowsMaxLabel;
     QSpinBox cardViewInitialRowsMaxBox;
+    QLabel cardViewExpandedRowsMaxLabel;
+    QSpinBox cardViewExpandedRowsMaxBox;
     QCheckBox horizontalHandCheckBox;
     QCheckBox leftJustifiedHandCheckBox;
     QCheckBox invertVerticalCoordinateCheckBox;

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -91,6 +91,9 @@ private slots:
     void openThemeLocation();
     void showShortcutsChanged(QT_STATE_CHANGED_T enabled);
 
+    void cardViewInitialRowsMaxChanged(int value);
+    void cardViewExpandedRowsMaxChanged(int value);
+
 private:
     QLabel themeLabel;
     QComboBox themeBox;

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -259,13 +259,24 @@ void ZoneViewWidget::resizeScrollbar(const qreal newZoneHeight)
 }
 
 /**
+ * Maps a height that is given as number of rows of cards to the actual height, given in pixels.
+ *
+ * @param rows Rows of cards
+ * @return The height in pixels
+ */
+static qreal rowsToHeight(int rows)
+{
+    const qreal cardsHeight = (rows + 1) * (CARD_HEIGHT / 3);
+    return cardsHeight + 5; // +5 padding to make the cutoff look nicer
+}
+
+/**
  * Calculates the max initial height from the settings.
  * The max initial height setting is given as number of rows, so we need to map it to a height.
  **/
 static qreal calcMaxInitialHeight()
 {
-    const qreal cardsHeight = (SettingsCache::instance().getCardViewInitialRowsMax() + 1) * (CARD_HEIGHT / 3);
-    return cardsHeight + 5; // +5 padding to make the cutoff look nicer
+    return rowsToHeight(SettingsCache::instance().getCardViewInitialRowsMax());
 }
 
 /**

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -347,29 +347,38 @@ void ZoneViewWidget::initStyleOption(QStyleOption *option) const
         titleBar->icon = QPixmap("theme:cockatrice");
 }
 
+/**
+ * Expands/shrinks the window, depending on the current height as well as the configured initial and expanded max
+ * heights.
+ */
+void ZoneViewWidget::expandWindow()
+{
+    qreal maxInitialHeight = calcMaxInitialHeight();
+    qreal maxExpandedHeight = rowsToHeight(SettingsCache::instance().getCardViewExpandedRowsMax());
+    qreal height = rect().height() - extraHeight - 10;
+    qreal maxHeight = maximumHeight() - extraHeight - 10;
+
+    // reset window to initial max height if...
+    bool doResetSize =
+        // current height is less than that
+        (height < maxInitialHeight) ||
+        // current height is at expanded max height
+        (height == maxExpandedHeight) ||
+        // current height is at actual max height, and actual max height is less than expanded max height
+        (height == maxHeight && height > maxInitialHeight && height < maxExpandedHeight);
+
+    if (doResetSize) {
+        resizeToZoneContents(true);
+    } else {
+        // expand/shrink window to expanded max height if current height is anywhere at or between initial max height
+        // and actual max height
+        resize(maximumSize().boundedTo({maximumWidth(), maxExpandedHeight + extraHeight + 10}));
+    }
+}
+
 void ZoneViewWidget::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
 {
     if (event->pos().y() <= 0) {
-        qreal maxInitialHeight = calcMaxInitialHeight();
-        qreal maxExpandedHeight = rowsToHeight(SettingsCache::instance().getCardViewExpandedRowsMax());
-        qreal height = rect().height() - extraHeight - 10;
-        qreal maxHeight = maximumHeight() - extraHeight - 10;
-
-        // reset window to initial max height if...
-        bool doResetSize =
-            // current height is less than that
-            (height < maxInitialHeight) ||
-            // current height is at expanded max height
-            (height == maxExpandedHeight) ||
-            // current height is at actual max height, and actual max height is less than expanded max height
-            (height == maxHeight && height > maxInitialHeight && height < maxExpandedHeight);
-
-        if (doResetSize) {
-            resizeToZoneContents(true);
-        } else {
-            // expand/shrink window to expanded max height if current height is anywhere at or between initial max
-            // height and actual max height
-            resize(maximumSize().boundedTo({maximumWidth(), maxExpandedHeight + extraHeight + 10}));
-        }
+        expandWindow();
     }
 }

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -350,12 +350,26 @@ void ZoneViewWidget::initStyleOption(QStyleOption *option) const
 void ZoneViewWidget::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
 {
     if (event->pos().y() <= 0) {
-        // expand window to full height and width if not currently at full height and width
-        // otherwise shrink window to initial max height
-        if (size().height() < maximumHeight() || size().width() < maximumWidth()) {
-            resize(maximumSize());
-        } else {
+        qreal maxInitialHeight = calcMaxInitialHeight();
+        qreal maxExpandedHeight = rowsToHeight(SettingsCache::instance().getCardViewExpandedRowsMax());
+        qreal height = rect().height() - extraHeight - 10;
+        qreal maxHeight = maximumHeight() - extraHeight - 10;
+
+        // reset window to initial max height if...
+        bool doResetSize =
+            // current height is less than that
+            (height < maxInitialHeight) ||
+            // current height is at expanded max height
+            (height == maxExpandedHeight) ||
+            // current height is at actual max height, and actual max height is less than expanded max height
+            (height == maxHeight && height > maxInitialHeight && height < maxExpandedHeight);
+
+        if (doResetSize) {
             resizeToZoneContents(true);
+        } else {
+            // expand/shrink window to expanded max height if current height is anywhere at or between initial max
+            // height and actual max height
+            resize(maximumSize().boundedTo({maximumWidth(), maxExpandedHeight + extraHeight + 10}));
         }
     }
 }

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -282,7 +282,7 @@ static qreal determineNewZoneHeight(qreal oldZoneHeight)
     return calcMaxInitialHeight();
 }
 
-void ZoneViewWidget::resizeToZoneContents()
+void ZoneViewWidget::resizeToZoneContents(bool forceInitialHeight)
 {
     QRectF zoneRect = zone->getOptimumRect();
     qreal totalZoneHeight = zoneRect.height();
@@ -293,7 +293,7 @@ void ZoneViewWidget::resizeToZoneContents()
     QSizeF maxSize(width, zoneRect.height() + extraHeight + 10);
 
     qreal currentZoneHeight = rect().height() - extraHeight - 10;
-    qreal newZoneHeight = determineNewZoneHeight(currentZoneHeight);
+    qreal newZoneHeight = forceInitialHeight ? calcMaxInitialHeight() : determineNewZoneHeight(currentZoneHeight);
 
     QSizeF initialSize(width, newZoneHeight + extraHeight + 10);
 
@@ -334,4 +334,17 @@ void ZoneViewWidget::initStyleOption(QStyleOption *option) const
     QStyleOptionTitleBar *titleBar = qstyleoption_cast<QStyleOptionTitleBar *>(option);
     if (titleBar)
         titleBar->icon = QPixmap("theme:cockatrice");
+}
+
+void ZoneViewWidget::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
+{
+    if (event->pos().y() <= 0) {
+        // expand window to full height and width if not currently at full height and width
+        // otherwise shrink window to initial max height
+        if (size().height() < maximumHeight() || size().width() < maximumWidth()) {
+            resize(maximumSize());
+        } else {
+            resizeToZoneContents(true);
+        }
+    }
 }

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -132,7 +132,7 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
 
     setLayout(vbox);
 
-    connect(zone, &ZoneViewZone::optimumRectChanged, this, &ZoneViewWidget::resizeToZoneContents);
+    connect(zone, &ZoneViewZone::optimumRectChanged, this, [this] { resizeToZoneContents(); });
     connect(zone, &ZoneViewZone::closed, this, &ZoneViewWidget::zoneDeleted);
     zone->initializeCards(cardList);
 

--- a/cockatrice/src/game/zones/view_zone_widget.h
+++ b/cockatrice/src/game/zones/view_zone_widget.h
@@ -68,6 +68,7 @@ private slots:
     void zoneDeleted();
     void moveEvent(QGraphicsSceneMoveEvent * /* event */) override;
     void resizeEvent(QGraphicsSceneResizeEvent * /* event */) override;
+    void expandWindow();
 
 public:
     ZoneViewWidget(Player *_player,

--- a/cockatrice/src/game/zones/view_zone_widget.h
+++ b/cockatrice/src/game/zones/view_zone_widget.h
@@ -63,7 +63,7 @@ private slots:
     void processGroupBy(int value);
     void processSortBy(int value);
     void processSetPileView(QT_STATE_CHANGED_T value);
-    void resizeToZoneContents();
+    void resizeToZoneContents(bool forceInitialHeight = false);
     void handleScrollBarChange(int value);
     void zoneDeleted();
     void moveEvent(QGraphicsSceneMoveEvent * /* event */) override;
@@ -90,6 +90,7 @@ public:
 protected:
     void closeEvent(QCloseEvent *event) override;
     void initStyleOption(QStyleOption *option) const override;
+    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) override;
 };
 
 #endif

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -249,6 +249,7 @@ SettingsCache::SettingsCache()
     knownMissingFeatures = settings->value("interface/knownmissingfeatures", "").toString();
     useTearOffMenus = settings->value("interface/usetearoffmenus", true).toBool();
     cardViewInitialRowsMax = settings->value("interface/cardViewInitialRowsMax", 14).toInt();
+    cardViewExpandedRowsMax = settings->value("interface/cardViewExpandedRowsMax", 20).toInt();
     closeEmptyCardView = settings->value("interface/closeEmptyCardView", true).toBool();
 
     showShortcuts = settings->value("menu/showshortcuts", true).toBool();
@@ -342,6 +343,12 @@ void SettingsCache::setCardViewInitialRowsMax(int _cardViewInitialRowsMax)
 {
     cardViewInitialRowsMax = _cardViewInitialRowsMax;
     settings->setValue("interface/cardViewInitialRowsMax", cardViewInitialRowsMax);
+}
+
+void SettingsCache::setCardViewExpandedRowsMax(int value)
+{
+    cardViewExpandedRowsMax = value;
+    settings->setValue("interface/cardViewExpandedRowsMax", cardViewExpandedRowsMax);
 }
 
 void SettingsCache::setCloseEmptyCardView(QT_STATE_CHANGED_T value)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -165,6 +165,7 @@ private:
     QString knownMissingFeatures;
     bool useTearOffMenus;
     int cardViewInitialRowsMax;
+    int cardViewExpandedRowsMax;
     bool closeEmptyCardView;
     int pixmapCacheSize;
     int networkCacheSize;
@@ -642,6 +643,7 @@ public:
     void setKnownMissingFeatures(const QString &_knownMissingFeatures);
     void setUseTearOffMenus(bool _useTearOffMenus);
     void setCardViewInitialRowsMax(int _cardViewInitialRowsMax);
+    void setCardViewExpandedRowsMax(int value);
     void setCloseEmptyCardView(QT_STATE_CHANGED_T value);
     QString getClientID()
     {
@@ -662,6 +664,10 @@ public:
     int getCardViewInitialRowsMax() const
     {
         return cardViewInitialRowsMax;
+    }
+    int getCardViewExpandedRowsMax() const
+    {
+        return cardViewExpandedRowsMax;
     }
     bool getCloseEmptyCardView() const
     {

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -58,6 +58,9 @@ void SettingsCache::setUseTearOffMenus(bool /* _useTearOffMenus */)
 void SettingsCache::setCardViewInitialRowsMax(int /* _cardViewInitialRowsMax */)
 {
 }
+void SettingsCache::setCardViewExpandedRowsMax(int /* value */)
+{
+}
 void SettingsCache::setCloseEmptyCardView(const QT_STATE_CHANGED_T /* value */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -62,6 +62,9 @@ void SettingsCache::setUseTearOffMenus(bool /* _useTearOffMenus */)
 void SettingsCache::setCardViewInitialRowsMax(int /* _cardViewInitialRowsMax */)
 {
 }
+void SettingsCache::setCardViewExpandedRowsMax(int /* value */)
+{
+}
 void SettingsCache::setCloseEmptyCardView(QT_STATE_CHANGED_T /* value */)
 {
 }


### PR DESCRIPTION
## Related Ticket(s)
- Re-opens #5260

## Short roundup of the initial problem

Expanding the card view window is really finicky to do. The collision in the corner to start a drag is tiny, and the window sometimes glitches out all over the place as you try to expand it.

## What will change with this Pull Request?

Double clicking the top of the card view window will now expand/unexpand it. The collision area for the double-click is the same as the collision for dragging the window around.

The window will get expanded up to its expanded max height. This value is configurable in the settings. The settings dlg guarantees that the initial max height <= expanded max height.

https://github.com/user-attachments/assets/08137699-78e8-4ca2-a91e-20fe403424e1

- Introduce `Maximum expanded height for card view window` setting
  - Defaults to 14 rows
  - Settings dlg forces max initial height <= max expanded height
- Refactor out row to height calculation
- Add logic for determining resizing on double click:
  - max initial height < current < max expanded height -> expand to max expanded height
  - current < max initial height -> expand to max initial height
  - current > max expanded height -> shrink to max expanded height
  - current = max expanded height -> shrink to max initial height
  - current =  actual max height and actual max height < expanded max height -> shrink to max initial height

## Screenshots

<img width="710" alt="Screenshot 2025-02-24 at 7 53 08 AM" src="https://github.com/user-attachments/assets/83c355f9-5d9b-4ea3-acf7-d5870fccb032" />
