### PR TITLE
Fix segfault when oracle reads card without "num" field

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -289,7 +289,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
 
         QString numComponent;
         const QString numProperty = setInfo.getProperty("num");
-        const QChar lastChar = numProperty.at(numProperty.size() - 1);
+        const QChar lastChar = numProperty.isEmpty() ? QChar() : numProperty.back();
 
         // Un-Sets do some wonky stuff. Split up these cards as individual entries.
         if (setsWithCardsWithSameNameButDifferentText.contains(currentSet->getShortName()) &&


### PR DESCRIPTION
## Short roundup of the initial problem

When oracle reads in a json, if any of the cards in the json are missing the "num" and "number" field, oracle segfaults. This is because oracle tries to get the last char in the num field by indexing at 1 minus the length of the num string, which will index at -1 if num is empty

## What will change with this Pull Request?

- Add empty check before getting the last char of num, and just set the last char to the empty char if num is empty

Tested with this json

[AllCards.json](https://github.com/user-attachments/files/18957364/AllCards.json)
