### PR TITLE
Allow loading local xml file in oracle

### DIFF
--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -277,14 +277,14 @@ void LoadSetsPage::actLoadSetsFile()
     QFileDialog dialog(this, tr("Load sets file"));
     dialog.setFileMode(QFileDialog::ExistingFile);
 
-    QString extensions = "*.json";
+    QString extensions = "*.json *.xml";
 #ifdef HAS_ZLIB
     extensions += " *.zip";
 #endif
 #ifdef HAS_LZMA
     extensions += " *.xz";
 #endif
-    dialog.setNameFilter(tr("Sets JSON file (%1)").arg(extensions));
+    dialog.setNameFilter(tr("Sets file (%1)").arg(extensions));
 
     if (!fileLineEdit->text().isEmpty() && QFile::exists(fileLineEdit->text())) {
         dialog.selectFile(fileLineEdit->text());


### PR DESCRIPTION
## Related Ticket(s)
- Fixes omission from #4736

## Short roundup of the initial problem

Oracle can't load local xml files because xml is not part of the file selection dialogue's nameFilters.

## What will change with this Pull Request?
- Add xml to the nameFilters
- Also update the text in the nameFilter
