### PR TITLE
Add rename action to deck storage tab

### DIFF
--- a/cockatrice/cockatrice.qrc
+++ b/cockatrice/cockatrice.qrc
@@ -27,6 +27,7 @@
         <file>resources/icons/ready_start.svg</file>
         <file>resources/icons/reload.svg</file>
         <file>resources/icons/remove_row.svg</file>
+        <file>resources/icons/rename.svg</file>
         <file>resources/icons/scales.svg</file>
         <file>resources/icons/search.svg</file>
         <file>resources/icons/settings.svg</file>

--- a/cockatrice/resources/icons/rename.svg
+++ b/cockatrice/resources/icons/rename.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1200pt" height="1200pt" version="1.1" viewBox="0 0 1200 1200" xmlns="http://www.w3.org/2000/svg">
+    <path transform="scale(50)" d="m17 16h4v-8h-4" fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2"/>
+    <path transform="scale(50)" d="m12 8h-9v8h9" fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2"/>
+    <path transform="scale(50)" d="m6 12h5" fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2"/>
+    <path transform="scale(50)" d="m20 4h-2c-1.1 0-2 0.9-2 2v12c0 1.1 0.9 2 2 2h2" fill="none" stroke="#000"
+          stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2"/>
+    <path transform="scale(50)" d="m12 20h2c1.1 0 2-0.9 2-2v-12c0-1.1-0.9-2-2-2h-2" fill="none" stroke="#000"
+          stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2"/>
+</svg>

--- a/cockatrice/src/client/tabs/tab_deck_storage.h
+++ b/cockatrice/src/client/tabs/tab_deck_storage.h
@@ -28,7 +28,7 @@ private:
     RemoteDeckList_TreeWidget *serverDirView;
     QGroupBox *leftGroupBox, *rightGroupBox;
 
-    QAction *aOpenLocalDeck, *aUpload, *aNewLocalFolder, *aDeleteLocalDeck;
+    QAction *aOpenLocalDeck, *aRenameLocal, *aUpload, *aNewLocalFolder, *aDeleteLocalDeck;
     QAction *aOpenDecksFolder;
     QAction *aOpenRemoteDeck, *aDownload, *aNewFolder, *aDeleteRemoteDeck;
     QString getTargetPath() const;
@@ -46,6 +46,8 @@ private slots:
 
     void actLocalDoubleClick(const QModelIndex &curLeft);
     void actOpenLocalDeck();
+
+    void actRenameLocal();
 
     void actUpload();
     void uploadFinished(const Response &r, const CommandContainer &commandContainer);


### PR DESCRIPTION
## Short roundup of the initial problem

There is no way to rename decks from within cockatrice. The user must open the deck folder and rename the files outside of cockatrice.

## What will change with this Pull Request?

- Added rename action to deck storage tab
  - Has the exact same logic as the rename action from replays tab
- Icon is public domain

https://github.com/user-attachments/assets/d9771278-411e-4d2b-8afa-442b7bf121a5

## Screenshots

<img width="1435" alt="Screenshot 2025-02-24 at 11 04 21 PM" src="https://github.com/user-attachments/assets/f35aad13-7e81-4e97-bb67-def2e891e277" />

<img width="300" src="https://github.com/user-attachments/assets/de94ea3b-c32a-4b26-86de-fc8aaa14cb34"/>

