### PR TITLE
use new rename icon in replays tab

### DIFF
--- a/cockatrice/src/client/tabs/tab_replays.cpp
+++ b/cockatrice/src/client/tabs/tab_replays.cpp
@@ -99,7 +99,7 @@ TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client, c
     connect(aOpenLocalReplay, SIGNAL(triggered()), this, SLOT(actOpenLocalReplay()));
     connect(localDirView, SIGNAL(doubleClicked(const QModelIndex &)), this, SLOT(actOpenLocalReplay()));
     aRenameLocal = new QAction(this);
-    aRenameLocal->setIcon(QPixmap("theme:icons/pencil"));
+    aRenameLocal->setIcon(QPixmap("theme:icons/rename"));
     connect(aRenameLocal, &QAction::triggered, this, &TabReplays::actRenameLocal);
     aNewLocalFolder = new QAction(this);
     aNewLocalFolder->setIcon(qApp->style()->standardIcon(QStyle::SP_FileDialogNewFolder));


### PR DESCRIPTION
## Related Ticket(s)
- Follow up to #5656

## Short roundup of the initial problem

Now that we have a rename icon, we should use it in the replays tab instead of the edit icon

## What will change with this Pull Request?

- Use rename icon instead of edit icon in replays tab

<img width="1393" alt="Screenshot 2025-02-25 at 6 43 49 PM" src="https://github.com/user-attachments/assets/f7aff714-a542-4084-922e-62c8c47b7ae9" />

