### PR TITLE
Add setting for "include folder name in VDS search"

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -70,6 +70,13 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     connect(bannerCardComboBoxVisibilityCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setVisualDeckStorageShowBannerCardComboBox);
 
+    searchFolderNamesCheckBox = new QCheckBox(this);
+    searchFolderNamesCheckBox->setChecked(SettingsCache::instance().getVisualDeckStorageSearchFolderNames());
+    connect(searchFolderNamesCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+            &VisualDeckStorageWidget::updateSearchFilter);
+    connect(searchFolderNamesCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setVisualDeckStorageSearchFolderNames);
+
     // card size slider
     cardSizeWidget = new CardSizeWidget(this, nullptr, SettingsCache::instance().getVisualDeckStorageCardSize());
 
@@ -79,6 +86,7 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     quickSettingsWidget->addSettingsWidget(tagsOnWidgetsVisibilityCheckBox);
     quickSettingsWidget->addSettingsWidget(drawUnusedColorIdentitiesCheckBox);
     quickSettingsWidget->addSettingsWidget(bannerCardComboBoxVisibilityCheckBox);
+    quickSettingsWidget->addSettingsWidget(searchFolderNamesCheckBox);
     quickSettingsWidget->addSettingsWidget(cardSizeWidget);
 
     searchAndSortLayout->addWidget(deckPreviewColorIdentityFilterWidget);
@@ -153,6 +161,7 @@ void VisualDeckStorageWidget::retranslateUi()
     tagsOnWidgetsVisibilityCheckBox->setText(tr("Show Tags On Deck Previews"));
     drawUnusedColorIdentitiesCheckBox->setText(tr("Draw not contained Color Identities"));
     bannerCardComboBoxVisibilityCheckBox->setText(tr("Show Banner Card Selection Option"));
+    searchFolderNamesCheckBox->setText(tr("Include Folder Names in Search"));
 }
 
 void VisualDeckStorageWidget::createRootFolderWidget()
@@ -205,7 +214,7 @@ void VisualDeckStorageWidget::updateSearchFilter()
 {
     if (folderWidget) {
         searchWidget->filterWidgets(folderWidget->findChildren<DeckPreviewWidget *>(), searchWidget->getSearchText(),
-                                    showFoldersCheckBox->isChecked());
+                                    searchFolderNamesCheckBox->isChecked());
     }
     emit searchFilterUpdated();
 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -66,6 +66,7 @@ private:
     QCheckBox *bannerCardComboBoxVisibilityCheckBox;
     QCheckBox *tagFilterVisibilityCheckBox;
     QCheckBox *tagsOnWidgetsVisibilityCheckBox;
+    QCheckBox *searchFolderNamesCheckBox;
     QScrollArea *scrollArea;
     VisualDeckStorageFolderDisplayWidget *folderWidget;
 };

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -265,6 +265,7 @@ SettingsCache::SettingsCache()
     visualDeckStorageSortingOrder = settings->value("interface/visualdeckstoragesortingorder", 0).toInt();
     visualDeckStorageShowFolders = settings->value("interface/visualdeckstorageshowfolders", true).toBool();
     visualDeckStorageShowTagFilter = settings->value("interface/visualdeckstorageshowtagfilter", true).toBool();
+    visualDeckStorageSearchFolderNames = settings->value("interface/visualdeckstoragesearchfoldernames", true).toBool();
     visualDeckStorageShowBannerCardComboBox =
         settings->value("interface/visualdeckstorageshowbannercardcombobox", true).toBool();
     visualDeckStorageShowTagsOnDeckPreviews =
@@ -677,6 +678,12 @@ void SettingsCache::setVisualDeckStorageShowTagFilter(QT_STATE_CHANGED_T _showTa
     visualDeckStorageShowTagFilter = _showTags;
     settings->setValue("interface/visualdeckstorageshowtagfilter", visualDeckStorageShowTagFilter);
     emit visualDeckStorageShowTagFilterChanged(visualDeckStorageShowTagFilter);
+}
+
+void SettingsCache::setVisualDeckStorageSearchFolderNames(QT_STATE_CHANGED_T value)
+{
+    visualDeckStorageSearchFolderNames = value;
+    settings->setValue("interface/visualdeckstoragesearchfoldernames", visualDeckStorageSearchFolderNames);
 }
 
 void SettingsCache::setVisualDeckStorageShowBannerCardComboBox(QT_STATE_CHANGED_T _showBannerCardComboBox)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -133,6 +133,7 @@ private:
     bool visualDeckStorageShowBannerCardComboBox;
     bool visualDeckStorageShowTagsOnDeckPreviews;
     bool visualDeckStorageShowTagFilter;
+    bool visualDeckStorageSearchFolderNames;
     int visualDeckStorageCardSize;
     bool visualDeckStorageDrawUnusedColorIdentities;
     int visualDeckStorageUnusedColorIdentitiesOpacity;
@@ -414,6 +415,10 @@ public:
     bool getVisualDeckStorageShowTagFilter() const
     {
         return visualDeckStorageShowTagFilter;
+    }
+    bool getVisualDeckStorageSearchFolderNames() const
+    {
+        return visualDeckStorageSearchFolderNames;
     }
     bool getVisualDeckStorageShowBannerCardComboBox() const
     {
@@ -772,6 +777,7 @@ public slots:
     void setVisualDeckStorageSortingOrder(int _visualDeckStorageSortingOrder);
     void setVisualDeckStorageShowFolders(QT_STATE_CHANGED_T value);
     void setVisualDeckStorageShowTagFilter(QT_STATE_CHANGED_T _showTags);
+    void setVisualDeckStorageSearchFolderNames(QT_STATE_CHANGED_T value);
     void setVisualDeckStorageShowBannerCardComboBox(QT_STATE_CHANGED_T _showBannerCardComboBox);
     void setVisualDeckStorageShowTagsOnDeckPreviews(QT_STATE_CHANGED_T _showTags);
     void setVisualDeckStorageCardSize(int _visualDeckStorageCardSize);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -211,6 +211,9 @@ void SettingsCache::setVisualDeckStorageShowFolders(QT_STATE_CHANGED_T /* value 
 void SettingsCache::setVisualDeckStorageShowTagFilter(QT_STATE_CHANGED_T /* _showTags */)
 {
 }
+void SettingsCache::setVisualDeckStorageSearchFolderNames(QT_STATE_CHANGED_T /* value */)
+{
+}
 void SettingsCache::setVisualDeckStorageShowBannerCardComboBox(QT_STATE_CHANGED_T /* _showBannerCardComboBox */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -215,6 +215,9 @@ void SettingsCache::setVisualDeckStorageShowFolders(QT_STATE_CHANGED_T /* value 
 void SettingsCache::setVisualDeckStorageShowTagFilter(QT_STATE_CHANGED_T /* _showTags */)
 {
 }
+void SettingsCache::setVisualDeckStorageSearchFolderNames(QT_STATE_CHANGED_T /* value */)
+{
+}
 void SettingsCache::setVisualDeckStorageShowBannerCardComboBox(QT_STATE_CHANGED_T /* _showBannerCardComboBox */)
 {
 }


### PR DESCRIPTION
## Related Ticket(s)
- Follow up to #5637

## Short roundup of the initial problem

Sometimes I want to hide the folder view while still being able to search by folder name. It's more flexible to have the option be determined by a setting instead of by whether folders are enabled.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/09d45bf5-1a20-4293-abfc-568aa9075104

- Added the "Include Folder Names in Search" option to the settings popup menu. 
  - This setting now controls whether the search takes folder names into account, instead of the "Show Folders" setting.
  - Made sure to `updateSearchFilter` when the checkbox is clicked

## Screenshots

<img width="394" alt="Screenshot 2025-02-26 at 12 51 46 AM" src="https://github.com/user-attachments/assets/04620f2d-90a1-448b-9c70-8975ab2a7d15" />
