### PR TITLE
Fix VDS filters not applying after refresh 

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -100,10 +100,7 @@ void DeckPreviewWidget::initializeUi(const bool deckLoadSuccess)
 
 void DeckPreviewWidget::updateVisibility()
 {
-    if (isVisible() != checkVisibility()) {
-        setHidden(!checkVisibility());
-        emit visibilityUpdated();
-    }
+    setHidden(!checkVisibility());
 }
 
 bool DeckPreviewWidget::checkVisibility() const

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
@@ -41,7 +41,6 @@ public:
 signals:
     void deckLoadRequested(const QString &filePath);
     void openDeckEditor(const DeckLoader *deck);
-    void visibilityUpdated();
 
 public slots:
     void setFilePath(const QString &filePath);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -155,6 +155,17 @@ void VisualDeckStorageWidget::retranslateUi()
     bannerCardComboBoxVisibilityCheckBox->setText(tr("Show Banner Card Selection Option"));
 }
 
+/**
+ * Reapplies all sort and filter options by calling the appropriate update methods.
+ */
+void VisualDeckStorageWidget::reapplySortAndFilters()
+{
+    updateSortOrder();
+    updateTagFilter();
+    updateColorFilter();
+    updateSearchFilter();
+}
+
 void VisualDeckStorageWidget::createRootFolderWidget()
 {
     folderWidget = new VisualDeckStorageFolderDisplayWidget(this, this, SettingsCache::instance().getDeckPath(), false,
@@ -163,14 +174,14 @@ void VisualDeckStorageWidget::createRootFolderWidget()
     scrollArea->setWidget(folderWidget); // this automatically destroys the old folderWidget
     scrollArea->widget()->setMaximumWidth(scrollArea->viewport()->width());
     scrollArea->widget()->adjustSize();
-    updateSortOrder();
+    reapplySortAndFilters();
 }
 
 void VisualDeckStorageWidget::updateShowFolders(bool enabled)
 {
     if (folderWidget) {
         folderWidget->updateShowFolders(enabled);
-        updateSortOrder();
+        reapplySortAndFilters();
     }
 }
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -68,6 +68,8 @@ private:
     QCheckBox *tagsOnWidgetsVisibilityCheckBox;
     QScrollArea *scrollArea;
     VisualDeckStorageFolderDisplayWidget *folderWidget;
+
+    void reapplySortAndFilters();
 };
 
 #endif // VISUAL_DECK_STORAGE_WIDGET_H


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5661

## Short roundup of the initial problem

Filters become inactive after a refresh or after enabling/disabling show folders. We never reapply the filters after refreshing

## What will change with this Pull Request?

https://github.com/user-attachments/assets/5ff48d74-b08c-4b89-b6e7-2543579d64dd

- Call all sort and filter update methods after each refresh
- Got rid of a condition check in `DeckPreviewWidget::updateVisibility`. Otherwise disabling `show folders` would still cause all decks to show regardless of filters. 
  - Deleted signal since nothing was using it anyways.


I assume the reason the condition check in `DeckPreviewWidget::updateVisibility` causes problems is because `isVisible` is also contingent on the parent's visibility, and visibility doesn't update until next frame, so the following sequence happens:
  - parent folder widget is hidden, so deck widget never properly gets set to hidden state
  - folder structure flattening happens
  - try to update visibility on all widgets
  - deck widget is still considered invisible due to previous parent, so it never gets set to hidden despite not currently having hidden state
  -  graphical updates happen, and now deck widget is parented by a visible folder widget and has non-hidden state itself, so it ends up being visible

