### PR TITLE
Add hint on version downloading

### DIFF
--- a/cockatrice/src/dialogs/dlg_update.cpp
+++ b/cockatrice/src/dialogs/dlg_update.cpp
@@ -88,7 +88,7 @@ void DlgUpdate::gotoDownloadPage()
 
 void DlgUpdate::downloadUpdate(const QString &releaseName)
 {
-    setLabel(tr("Downloading update") + QString(": %1").arg(releaseName));
+    setLabel(tr("Downloading update: %1").arg(releaseName));
     addStopDownloadAndRemoveOthers(true); // Will remove all other buttons
     uDownloader->beginDownload(updateUrl);
 }

--- a/cockatrice/src/dialogs/dlg_update.cpp
+++ b/cockatrice/src/dialogs/dlg_update.cpp
@@ -86,9 +86,9 @@ void DlgUpdate::gotoDownloadPage()
     QDesktopServices::openUrl(SettingsCache::instance().getUpdateReleaseChannel()->getManualDownloadUrl());
 }
 
-void DlgUpdate::downloadUpdate()
+void DlgUpdate::downloadUpdate(const QString &releaseName)
 {
-    setLabel(tr("Downloading update..."));
+    setLabel(tr("Downloading update") + QString(": %1").arg(releaseName));
     addStopDownloadAndRemoveOthers(true); // Will remove all other buttons
     uDownloader->beginDownload(updateUrl);
 }
@@ -157,7 +157,7 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
             QMessageBox::Yes | QMessageBox::No);
 
         if (reply == QMessageBox::Yes)
-            downloadUpdate();
+            downloadUpdate(release->getName());
     } else {
         QMessageBox::information(
             this, tr("Update Available"),

--- a/cockatrice/src/dialogs/dlg_update.h
+++ b/cockatrice/src/dialogs/dlg_update.h
@@ -21,7 +21,7 @@ public:
 private slots:
     void finishedUpdateCheck(bool needToUpdate, bool isCompatible, Release *release);
     void gotoDownloadPage();
-    void downloadUpdate();
+    void downloadUpdate(const QString &releaseName);
     void cancelDownload();
     void updateCheckError(const QString &errorString);
     void downloadSuccessful(const QUrl &filepath);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3209 

## Short roundup of the initial problem
Provide information to the user on what update they're downloading.

## What will change with this Pull Request?
- Update DlgUpdate::downloadUpdate to include function argument for version release.
- Display version release in download label

## Screenshots
![image](https://github.com/user-attachments/assets/595a594f-917f-4cab-bfcc-ba656bc5d28f)