### PR TITLE
Reduce redundant recursion in VDS

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
@@ -98,10 +98,11 @@ void VisualDeckStorageFolderDisplayWidget::createWidgetsForFiles()
 }
 
 /**
- * Updates the visibility of this folder and all its DeckPreviewWidgets, as well as all its subfolders and their
- * DeckPreviewWidgets.
+ * Updates the visibility of this folder and all its DeckPreviewWidgets
+ *
+ * @param recursive Also update the visibility of all subfolders and their DeckPreviewWidgets.
  */
-void VisualDeckStorageFolderDisplayWidget::updateVisibility()
+void VisualDeckStorageFolderDisplayWidget::updateVisibility(bool recursive)
 {
     bool atLeastOneWidgetVisible = checkVisibility();
     if (atLeastOneWidgetVisible) {
@@ -109,8 +110,10 @@ void VisualDeckStorageFolderDisplayWidget::updateVisibility()
         for (DeckPreviewWidget *display : flowWidget->findChildren<DeckPreviewWidget *>()) {
             display->updateVisibility();
         }
-        for (VisualDeckStorageFolderDisplayWidget *subFolder : findChildren<VisualDeckStorageFolderDisplayWidget *>()) {
-            subFolder->updateVisibility();
+        if (recursive) {
+            for (auto *subFolder : findChildren<VisualDeckStorageFolderDisplayWidget *>()) {
+                subFolder->updateVisibility(false);
+            }
         }
     } else {
         setVisible(false);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
@@ -33,13 +33,6 @@ VisualDeckStorageFolderDisplayWidget::VisualDeckStorageFolderDisplayWidget(
     flowWidget = new FlowWidget(this, Qt::Horizontal, Qt::ScrollBarAlwaysOff, Qt::ScrollBarAlwaysOff);
     containerLayout->addWidget(flowWidget);
 
-    connect(visualDeckStorageWidget, &VisualDeckStorageWidget::tagFilterUpdated, this,
-            &VisualDeckStorageFolderDisplayWidget::updateVisibility);
-    connect(visualDeckStorageWidget, &VisualDeckStorageWidget::colorFilterUpdated, this,
-            &VisualDeckStorageFolderDisplayWidget::updateVisibility);
-    connect(visualDeckStorageWidget, &VisualDeckStorageWidget::searchFilterUpdated, this,
-            &VisualDeckStorageFolderDisplayWidget::updateVisibility);
-
     createWidgetsForFiles();
     createWidgetsForFolders();
 
@@ -104,6 +97,10 @@ void VisualDeckStorageFolderDisplayWidget::createWidgetsForFiles()
     }
 }
 
+/**
+ * Updates the visibility of this folder and all its DeckPreviewWidgets, as well as all its subfolders and their
+ * DeckPreviewWidgets.
+ */
 void VisualDeckStorageFolderDisplayWidget::updateVisibility()
 {
     bool atLeastOneWidgetVisible = checkVisibility();

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
@@ -181,32 +181,13 @@ void VisualDeckStorageFolderDisplayWidget::updateShowFolders(bool enabled)
 }
 
 /**
- * Recursively gets all DeckPreviewWidgets in this folder and its subfolders
- */
-static QList<DeckPreviewWidget *> getAllDecksRecursive(VisualDeckStorageFolderDisplayWidget *folder)
-{
-    QList<DeckPreviewWidget *> allDecks;
-
-    if (auto *flowWidget = folder->getFlowWidget()) {
-        // Iterate through all DeckPreviewWidgets in this folder
-        allDecks << flowWidget->findChildren<DeckPreviewWidget *>();
-    }
-
-    for (auto *subFolder : folder->findChildren<VisualDeckStorageFolderDisplayWidget *>()) {
-        allDecks << getAllDecksRecursive(subFolder);
-    }
-
-    return allDecks;
-}
-
-/**
- * Recursively steals all DeckPreviewWidgets from this widget's subfolders, and deletes all subfolders
+ * Steals all DeckPreviewWidgets from this widget's nested subfolders, and deletes those subfolders
  */
 void VisualDeckStorageFolderDisplayWidget::flattenFolderStructure()
 {
-    for (VisualDeckStorageFolderDisplayWidget *subFolder : findChildren<VisualDeckStorageFolderDisplayWidget *>()) {
-        // steal all DeckPreviewWidgets from the subfolder and all its subfolders
-        for (auto *deck : getAllDecksRecursive(subFolder)) {
+    for (auto *subFolder : findChildren<VisualDeckStorageFolderDisplayWidget *>()) {
+        // steal all DeckPreviewWidgets from the subfolder
+        for (auto *deck : subFolder->getFlowWidget()->findChildren<DeckPreviewWidget *>()) {
             flowWidget->addWidget(deck);
         }
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.h
@@ -28,7 +28,7 @@ public:
     };
 
 public slots:
-    void updateVisibility();
+    void updateVisibility(bool recursive = true);
     bool checkVisibility();
     void updateShowFolders(bool enabled);
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -198,6 +198,7 @@ void VisualDeckStorageWidget::updateTagFilter()
 {
     if (folderWidget) {
         tagFilterWidget->filterDecksBySelectedTags(folderWidget->findChildren<DeckPreviewWidget *>());
+        folderWidget->updateVisibility();
     }
     emit tagFilterUpdated();
 }
@@ -206,6 +207,7 @@ void VisualDeckStorageWidget::updateColorFilter()
 {
     if (folderWidget) {
         deckPreviewColorIdentityFilterWidget->filterWidgets(folderWidget->findChildren<DeckPreviewWidget *>());
+        folderWidget->updateVisibility();
     }
     emit colorFilterUpdated();
 }
@@ -215,6 +217,7 @@ void VisualDeckStorageWidget::updateSearchFilter()
     if (folderWidget) {
         searchWidget->filterWidgets(folderWidget->findChildren<DeckPreviewWidget *>(), searchWidget->getSearchText(),
                                     searchFolderNamesCheckBox->isChecked());
+        folderWidget->updateVisibility();
     }
     emit searchFilterUpdated();
 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -200,7 +200,6 @@ void VisualDeckStorageWidget::updateTagFilter()
         tagFilterWidget->filterDecksBySelectedTags(folderWidget->findChildren<DeckPreviewWidget *>());
         folderWidget->updateVisibility();
     }
-    emit tagFilterUpdated();
 }
 
 void VisualDeckStorageWidget::updateColorFilter()
@@ -209,7 +208,6 @@ void VisualDeckStorageWidget::updateColorFilter()
         deckPreviewColorIdentityFilterWidget->filterWidgets(folderWidget->findChildren<DeckPreviewWidget *>());
         folderWidget->updateVisibility();
     }
-    emit colorFilterUpdated();
 }
 
 void VisualDeckStorageWidget::updateSearchFilter()
@@ -219,7 +217,6 @@ void VisualDeckStorageWidget::updateSearchFilter()
                                     searchFolderNamesCheckBox->isChecked());
         folderWidget->updateVisibility();
     }
-    emit searchFilterUpdated();
 }
 
 void VisualDeckStorageWidget::updateTagsVisibility(const bool visible)

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -46,9 +46,6 @@ signals:
     void bannerCardsRefreshed();
     void deckLoadRequested(const QString &filePath);
     void openDeckEditor(const DeckLoader *deck);
-    void tagFilterUpdated();
-    void colorFilterUpdated();
-    void searchFilterUpdated();
 
 private:
     QVBoxLayout *layout;


### PR DESCRIPTION
## Short roundup of the initial problem

Visual Deck Storage has some code that uses unnecessary recursion and redundantly calls a method on the same object multiple times:

- `flattenFolderStructure` recursively calls all its subfolders' `flattenFolderStructure`, even though `findChildren` already recursively finds all nested subfolders.
- Each folder widget connects the filter updated signals to their `updateVisibility` method, but `updateVisibility` already recursively calls `updateVisibility` on each subfolder.

Although refreshing VDS / updating filters / unchecking show folders is still basically instant for me, I could imagine this inefficiency having an impact for someone on a weaker computer and with more decks.

## What will change with this Pull Request?

- Remove recursion from `flattenFolderStructure`
  - `findChildren` is recursive by default and will already recursively find all child `DeckPreviewWidgets`
- Remove connecting the filter updated signals to `updateVisibility` inside of each folder widget
  - instead just trigger the update by calling `updateVisibility` on the root folder widget
- Add `recursive` param to `updateVisibility` 
  - so that when the top-level folder widget recursively gets all subfolders with findChildren and calls `updateVisibility` on them, it doesn't cause more redundant recursive calls
- Delete now-unused filter updated signals
   
