### PR TITLE
Cache correct providerId cards on deck load

### DIFF
--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
@@ -131,7 +131,8 @@ void AbstractTabDeckEditor::actSwapCard(CardInfoPtr info, QString zoneName)
 void AbstractTabDeckEditor::setDeck(DeckLoader *_deck)
 {
     deckDockWidget->setDeck(_deck);
-    PictureLoader::cacheCardPixmaps(CardDatabaseManager::getInstance()->getCards(getDeckList()->getCardList()));
+    PictureLoader::cacheCardPixmaps(
+        CardDatabaseManager::getInstance()->getCardsByNameAndProviderId(getDeckList()->getCardListWithProviderId()));
     setModified(false);
 
     // If they load a deck, make the deck list appear

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -929,8 +929,8 @@ void TabGame::eventGameStateChanged(const Event_GameStateChanged &event,
                 DeckViewContainer *deckViewContainer = deckViewContainers.value(playerId);
                 if (playerInfo.has_deck_list()) {
                     DeckLoader newDeck(QString::fromStdString(playerInfo.deck_list()));
-                    PictureLoader::cacheCardPixmaps(
-                        CardDatabaseManager::getInstance()->getCards(newDeck.getCardList()));
+                    PictureLoader::cacheCardPixmaps(CardDatabaseManager::getInstance()->getCardsByNameAndProviderId(
+                        newDeck.getCardListWithProviderId()));
                     deckViewContainer->setDeck(newDeck);
                     player->setDeck(newDeck);
                 }

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -480,8 +480,8 @@ QList<CardInfoPtr> CardDatabase::getCards(const QStringList &cardNames) const
 QList<CardInfoPtr> CardDatabase::getCardsByNameAndProviderId(const QMap<QString, QString> &cardNames) const
 {
     QList<CardInfoPtr> cardInfos;
-    for (auto [cardName, providerId] : cardNames.asKeyValueRange()) {
-        CardInfoPtr ptr = getCardByNameAndProviderId(cardName, providerId);
+    for (const QString &cardName : cardNames) {
+        CardInfoPtr ptr = getCardByNameAndProviderId(cardName, cardNames[cardName]);
         if (ptr)
             cardInfos.append(ptr);
     }

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -480,8 +480,8 @@ QList<CardInfoPtr> CardDatabase::getCards(const QStringList &cardNames) const
 QList<CardInfoPtr> CardDatabase::getCardsByNameAndProviderId(const QMap<QString, QString> &cardNames) const
 {
     QList<CardInfoPtr> cardInfos;
-    for (const QString &cardName : cardNames) {
-        CardInfoPtr ptr = getCardByNameAndProviderId(cardName, cardNames[cardName]);
+    for (auto [cardName, providerId] : cardNames.asKeyValueRange()) {
+        CardInfoPtr ptr = getCardByNameAndProviderId(cardName, providerId);
         if (ptr)
             cardInfos.append(ptr);
     }

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -477,6 +477,18 @@ QList<CardInfoPtr> CardDatabase::getCards(const QStringList &cardNames) const
     return cardInfos;
 }
 
+QList<CardInfoPtr> CardDatabase::getCardsByNameAndProviderId(const QMap<QString, QString> &cardNames) const
+{
+    QList<CardInfoPtr> cardInfos;
+    for (const QString &cardName : cardNames) {
+        CardInfoPtr ptr = getCardByNameAndProviderId(cardName, cardNames[cardName]);
+        if (ptr)
+            cardInfos.append(ptr);
+    }
+
+    return cardInfos;
+}
+
 CardInfoPtr CardDatabase::getCardByNameAndProviderId(const QString &cardName, const QString &providerId) const
 {
     auto info = getCard(cardName);

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -472,6 +472,7 @@ public:
     void removeCard(CardInfoPtr card);
     [[nodiscard]] CardInfoPtr getCard(const QString &cardName) const;
     [[nodiscard]] QList<CardInfoPtr> getCards(const QStringList &cardNames) const;
+    QList<CardInfoPtr> getCardsByNameAndProviderId(const QMap<QString, QString> &cardNames) const;
     [[nodiscard]] CardInfoPtr getCardByNameAndProviderId(const QString &cardName, const QString &providerId) const;
     [[nodiscard]] CardInfoPerSet getPreferredSetForCard(const QString &cardName) const;
     [[nodiscard]] CardInfoPerSet getSpecificSetForCard(const QString &cardName, const QString &providerId) const;

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -290,8 +290,8 @@ void DeckViewContainer::deckSelectFinished(const Response &r)
 {
     const Response_DeckDownload &resp = r.GetExtension(Response_DeckDownload::ext);
     DeckLoader newDeck(QString::fromStdString(resp.deck()));
-    // TODO CHANGE THIS TO BE SELECTED BY UUID
-    PictureLoader::cacheCardPixmaps(CardDatabaseManager::getInstance()->getCards(newDeck.getCardList()));
+    PictureLoader::cacheCardPixmaps(
+        CardDatabaseManager::getInstance()->getCardsByNameAndProviderId(newDeck.getCardListWithProviderId()));
     setDeck(newDeck);
     switchToDeckLoadedView();
 }

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -825,11 +825,31 @@ void DeckList::getCardListHelper(InnerDecklistNode *item, QSet<QString> &result)
     }
 }
 
+void DeckList::getCardListWithProviderIdHelper(InnerDecklistNode *item, QMap<QString, QString> &result) const
+{
+    for (int i = 0; i < item->size(); ++i) {
+        auto *node = dynamic_cast<DecklistCardNode *>(item->at(i));
+
+        if (node) {
+            result.insert(node->getName(), node->getCardProviderId());
+        } else {
+            getCardListWithProviderIdHelper(dynamic_cast<InnerDecklistNode *>(item->at(i)), result);
+        }
+    }
+}
+
 QStringList DeckList::getCardList() const
 {
     QSet<QString> result;
     getCardListHelper(root, result);
     return result.values();
+}
+
+QMap<QString, QString> DeckList::getCardListWithProviderId() const
+{
+    QMap<QString, QString> result;
+    getCardListWithProviderIdHelper(root, result);
+    return result;
 }
 
 int DeckList::getSideboardSize() const

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -258,6 +258,7 @@ private:
     QMap<QString, SideboardPlan *> sideboardPlans;
     InnerDecklistNode *root;
     void getCardListHelper(InnerDecklistNode *node, QSet<QString> &result) const;
+    void getCardListWithProviderIdHelper(InnerDecklistNode *item, QMap<QString, QString> &result) const;
     InnerDecklistNode *getZoneObjFromName(const QString &zoneName);
 
 protected:
@@ -358,6 +359,7 @@ public:
         return root->isEmpty() && name.isEmpty() && comments.isEmpty() && sideboardPlans.isEmpty();
     }
     QStringList getCardList() const;
+    QMap<QString, QString> getCardListWithProviderId() const;
 
     int getSideboardSize() const;
 


### PR DESCRIPTION
## Short roundup of the initial problem
Currently, PictureLoader::cacheCardPixmaps gets the cardList to cache from decklist->getCardList which only returns names and then CardDatabase::getCards which also only fetches by name. This means that if a deck is 99% cards that aren't the preferred printing, we spend 99% of our time fetching irrelevant cards.

This PR changes cards to be correctly cached.


## What will change with this Pull Request?
- Implement new method for DeckList to return cardlist with providerId
- Implement a new carddatabase method to fetch a cardlist with name and providerId 
- Changed PictureLoader to use providerId versions of cards for caching.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
