### PR TITLE
Clamp all DeckPreviewWidget children to the card size on resize.

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -51,10 +51,13 @@ void DeckPreviewWidget::retranslateUi()
 void DeckPreviewWidget::resizeEvent(QResizeEvent *event)
 {
     QWidget::resizeEvent(event);
-    if (bannerCardDisplayWidget == nullptr || bannerCardComboBox == nullptr) {
+    if (bannerCardDisplayWidget == nullptr) {
         return;
     }
-    bannerCardComboBox->setMaximumWidth(bannerCardDisplayWidget->width());
+    QList<QWidget *> widgets = findChildren<QWidget *>();
+    for (QWidget *widget : widgets) {
+        widget->setMaximumWidth(bannerCardDisplayWidget->width());
+    }
 }
 
 void DeckPreviewWidget::initializeUi(const bool deckLoadSuccess)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem


## What will change with this Pull Request?
- DeckPreviewWidget now iterates over all QWidget children and sets their maximum width to the width of the bannerCardWidget instead of just the bannerCardComboBoxWidget.

## Screenshots
Previous behavior:

https://github.com/user-attachments/assets/10f94a27-db3d-4f67-91f9-0f60f20938af

New behavior:

https://github.com/user-attachments/assets/f7d59ebf-1999-4189-b52f-7d351e64e225


