### PR TITLE
Focus tab for quit game dialog

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -506,10 +506,12 @@ void TabGame::actConcede()
 bool TabGame::leaveGame()
 {
     if (!gameClosed) {
-        if (!spectator)
+        if (!spectator) {
+            tabSupervisor->setCurrentWidget(this);
             if (QMessageBox::question(this, tr("Leave game"), tr("Are you sure you want to leave this game?"),
                                       QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes)
                 return false;
+        }
 
         if (!replay)
             sendGameCommand(Command_LeaveGame());


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1014 

## Short roundup of the initial problem
When you try to quit a game and a confirmation dialog pops up, it doesn't focus onto the tab the game that's being quitted from, like how it works for quitting a unsaved deck.

## What will change with this Pull Request?
- Sets current widget to the game with tabSupervisor.

## Screenshots
![output](https://github.com/user-attachments/assets/172e6faf-005d-46a5-83db-8b4fc7445d7d)
