### PR TITLE
refactor saveDeckToClipboard in AbstractTabDeckEditor

### DIFF
--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
@@ -389,40 +389,33 @@ void AbstractTabDeckEditor::actLoadDeckFromClipboard()
     deckMenu->setSaveStatus(true);
 }
 
-void AbstractTabDeckEditor::actSaveDeckToClipboard()
+static void saveDeckToClipboard(DeckLoader *deckLoader, bool addComments, bool addSetNameAndNumber)
 {
     QString buffer;
     QTextStream stream(&buffer);
-    getDeckList()->saveToStream_Plain(stream);
+    deckLoader->saveToStream_Plain(stream, addComments, addSetNameAndNumber);
     QApplication::clipboard()->setText(buffer, QClipboard::Clipboard);
     QApplication::clipboard()->setText(buffer, QClipboard::Selection);
+}
+
+void AbstractTabDeckEditor::actSaveDeckToClipboard()
+{
+    saveDeckToClipboard(getDeckList(), true, true);
 }
 
 void AbstractTabDeckEditor::actSaveDeckToClipboardNoSetNameAndNumber()
 {
-    QString buffer;
-    QTextStream stream(&buffer);
-    getDeckList()->saveToStream_Plain(stream, true, false);
-    QApplication::clipboard()->setText(buffer, QClipboard::Clipboard);
-    QApplication::clipboard()->setText(buffer, QClipboard::Selection);
+    saveDeckToClipboard(getDeckList(), true, false);
 }
 
 void AbstractTabDeckEditor::actSaveDeckToClipboardRaw()
 {
-    QString buffer;
-    QTextStream stream(&buffer);
-    getDeckList()->saveToStream_Plain(stream, false);
-    QApplication::clipboard()->setText(buffer, QClipboard::Clipboard);
-    QApplication::clipboard()->setText(buffer, QClipboard::Selection);
+    saveDeckToClipboard(getDeckList(), false, true);
 }
 
 void AbstractTabDeckEditor::actSaveDeckToClipboardRawNoSetNameAndNumber()
 {
-    QString buffer;
-    QTextStream stream(&buffer);
-    getDeckList()->saveToStream_Plain(stream, false, false);
-    QApplication::clipboard()->setText(buffer, QClipboard::Clipboard);
-    QApplication::clipboard()->setText(buffer, QClipboard::Selection);
+    saveDeckToClipboard(getDeckList(), false, false);
 }
 
 void AbstractTabDeckEditor::actPrintDeck()

--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
@@ -389,33 +389,24 @@ void AbstractTabDeckEditor::actLoadDeckFromClipboard()
     deckMenu->setSaveStatus(true);
 }
 
-static void saveDeckToClipboard(const DeckLoader *deckLoader, bool addComments, bool addSetNameAndNumber)
-{
-    QString buffer;
-    QTextStream stream(&buffer);
-    deckLoader->saveToStream_Plain(stream, addComments, addSetNameAndNumber);
-    QApplication::clipboard()->setText(buffer, QClipboard::Clipboard);
-    QApplication::clipboard()->setText(buffer, QClipboard::Selection);
-}
-
 void AbstractTabDeckEditor::actSaveDeckToClipboard()
 {
-    saveDeckToClipboard(getDeckList(), true, true);
+    getDeckList()->saveToClipboard(true, true);
 }
 
 void AbstractTabDeckEditor::actSaveDeckToClipboardNoSetNameAndNumber()
 {
-    saveDeckToClipboard(getDeckList(), true, false);
+    getDeckList()->saveToClipboard(true, false);
 }
 
 void AbstractTabDeckEditor::actSaveDeckToClipboardRaw()
 {
-    saveDeckToClipboard(getDeckList(), false, true);
+    getDeckList()->saveToClipboard(false, true);
 }
 
 void AbstractTabDeckEditor::actSaveDeckToClipboardRawNoSetNameAndNumber()
 {
-    saveDeckToClipboard(getDeckList(), false, false);
+    getDeckList()->saveToClipboard(false, false);
 }
 
 void AbstractTabDeckEditor::actPrintDeck()

--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
@@ -389,7 +389,7 @@ void AbstractTabDeckEditor::actLoadDeckFromClipboard()
     deckMenu->setSaveStatus(true);
 }
 
-static void saveDeckToClipboard(DeckLoader *deckLoader, bool addComments, bool addSetNameAndNumber)
+static void saveDeckToClipboard(const DeckLoader *deckLoader, bool addComments, bool addSetNameAndNumber)
 {
     QString buffer;
     QTextStream stream(&buffer);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -278,15 +278,6 @@ void DeckPreviewWidget::imageDoubleClickedEvent(QMouseEvent *event, DeckPreviewC
     emit deckLoadRequested(filePath);
 }
 
-static void saveDeckToClipboard(const DeckLoader *deckLoader, bool addComments, bool addSetNameAndNumber)
-{
-    QString buffer;
-    QTextStream stream(&buffer);
-    deckLoader->saveToStream_Plain(stream, addComments, addSetNameAndNumber);
-    QApplication::clipboard()->setText(buffer, QClipboard::Clipboard);
-    QApplication::clipboard()->setText(buffer, QClipboard::Selection);
-}
-
 QMenu *DeckPreviewWidget::createRightClickMenu()
 {
     auto *menu = new QMenu(this);
@@ -303,13 +294,13 @@ QMenu *DeckPreviewWidget::createRightClickMenu()
     auto saveToClipboardMenu = menu->addMenu(tr("Save Deck to Clipboard"));
 
     connect(saveToClipboardMenu->addAction(tr("Annotated")), &QAction::triggered, this,
-            [this] { saveDeckToClipboard(deckLoader, true, true); });
+            [this] { deckLoader->saveToClipboard(true, true); });
     connect(saveToClipboardMenu->addAction(tr("Annotated (No set name or number)")), &QAction::triggered, this,
-            [this] { saveDeckToClipboard(deckLoader, true, false); });
+            [this] { deckLoader->saveToClipboard(true, false); });
     connect(saveToClipboardMenu->addAction(tr("Not Annotated")), &QAction::triggered, this,
-            [this] { saveDeckToClipboard(deckLoader, false, true); });
+            [this] { deckLoader->saveToClipboard(false, true); });
     connect(saveToClipboardMenu->addAction(tr("Not Annotated (No set name or number)")), &QAction::triggered, this,
-            [this] { saveDeckToClipboard(deckLoader, false, false); });
+            [this] { deckLoader->saveToClipboard(false, false); });
 
     return menu;
 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -278,7 +278,7 @@ void DeckPreviewWidget::imageDoubleClickedEvent(QMouseEvent *event, DeckPreviewC
     emit deckLoadRequested(filePath);
 }
 
-static void saveDeckToClipboard(DeckLoader *deckLoader, bool addComments, bool addSetNameAndNumber)
+static void saveDeckToClipboard(const DeckLoader *deckLoader, bool addComments, bool addSetNameAndNumber)
 {
     QString buffer;
     QTextStream stream(&buffer);

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -372,7 +372,7 @@ DeckLoader::FileFormat DeckLoader::getFormatFromName(const QString &fileName)
     return PlainTextFormat;
 }
 
-bool DeckLoader::saveToStream_Plain(QTextStream &out, bool addComments, bool addSetNameAndNumber)
+bool DeckLoader::saveToStream_Plain(QTextStream &out, bool addComments, bool addSetNameAndNumber) const
 {
     if (addComments) {
         saveToStream_DeckHeader(out);
@@ -391,7 +391,7 @@ bool DeckLoader::saveToStream_Plain(QTextStream &out, bool addComments, bool add
     return true;
 }
 
-void DeckLoader::saveToStream_DeckHeader(QTextStream &out)
+void DeckLoader::saveToStream_DeckHeader(QTextStream &out) const
 {
     if (!getName().isEmpty()) {
         out << "// " << getName() << "\n\n";
@@ -409,7 +409,7 @@ void DeckLoader::saveToStream_DeckHeader(QTextStream &out)
 void DeckLoader::saveToStream_DeckZone(QTextStream &out,
                                        const InnerDecklistNode *zoneNode,
                                        bool addComments,
-                                       bool addSetNameAndNumber)
+                                       bool addSetNameAndNumber) const
 {
     // group cards by card type and count the subtotals
     QMultiMap<QString, DecklistCardNode *> cardsByType;
@@ -457,7 +457,7 @@ void DeckLoader::saveToStream_DeckZoneCards(QTextStream &out,
                                             const InnerDecklistNode *zoneNode,
                                             QList<DecklistCardNode *> cards,
                                             bool addComments,
-                                            bool addSetNameAndNumber)
+                                            bool addSetNameAndNumber) const
 {
     // QMultiMap sorts values in reverse order
     for (int i = cards.size() - 1; i >= 0; --i) {

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -5,6 +5,8 @@
 #include "../main.h"
 #include "decklist.h"
 
+#include <QApplication>
+#include <QClipboard>
 #include <QDebug>
 #include <QDir>
 #include <QFile>
@@ -370,6 +372,15 @@ DeckLoader::FileFormat DeckLoader::getFormatFromName(const QString &fileName)
         return CockatriceFormat;
     }
     return PlainTextFormat;
+}
+
+void DeckLoader::saveToClipboard(bool addComments, bool addSetNameAndNumber) const
+{
+    QString buffer;
+    QTextStream stream(&buffer);
+    saveToStream_Plain(stream, addComments, addSetNameAndNumber);
+    QApplication::clipboard()->setText(buffer, QClipboard::Clipboard);
+    QApplication::clipboard()->setText(buffer, QClipboard::Selection);
 }
 
 bool DeckLoader::saveToStream_Plain(QTextStream &out, bool addComments, bool addSetNameAndNumber) const

--- a/cockatrice/src/deck/deck_loader.h
+++ b/cockatrice/src/deck/deck_loader.h
@@ -63,20 +63,20 @@ public:
     void resolveSetNameAndNumberToProviderID();
 
     // overload
-    bool saveToStream_Plain(QTextStream &out, bool addComments = true, bool addSetNameAndNumber = true);
+    bool saveToStream_Plain(QTextStream &out, bool addComments = true, bool addSetNameAndNumber = true) const;
     bool convertToCockatriceFormat(QString fileName);
 
 protected:
-    void saveToStream_DeckHeader(QTextStream &out);
+    void saveToStream_DeckHeader(QTextStream &out) const;
     void saveToStream_DeckZone(QTextStream &out,
                                const InnerDecklistNode *zoneNode,
                                bool addComments = true,
-                               bool addSetNameAndNumber = true);
+                               bool addSetNameAndNumber = true) const;
     void saveToStream_DeckZoneCards(QTextStream &out,
                                     const InnerDecklistNode *zoneNode,
                                     QList<DecklistCardNode *> cards,
                                     bool addComments = true,
-                                    bool addSetNameAndNumber = true);
+                                    bool addSetNameAndNumber = true) const;
     [[nodiscard]] QString getCardZoneFromName(QString cardName, QString currentZoneName) override;
     [[nodiscard]] QString getCompleteCardName(const QString &cardName) const override;
 };

--- a/cockatrice/src/deck/deck_loader.h
+++ b/cockatrice/src/deck/deck_loader.h
@@ -62,6 +62,8 @@ public:
 
     void resolveSetNameAndNumberToProviderID();
 
+    void saveToClipboard(bool addComments = true, bool addSetNameAndNumber = true) const;
+
     // overload
     bool saveToStream_Plain(QTextStream &out, bool addComments = true, bool addSetNameAndNumber = true) const;
     bool convertToCockatriceFormat(QString fileName);


### PR DESCRIPTION
## Related Ticket(s)
- Repeat of #5623

## Short roundup of the initial problem

Seems like my refactor got lost in the other refactor

## What will change with this Pull Request?

- Reapply the changes made in the other PR to the refactored code
- Make the `DeckLoader` save to stream methods `const`