### PR TITLE
Fix move to top of library shuffling an extra card

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3186,7 +3186,7 @@ void Player::cardMenuAction()
                     auto *scmd = new Command_Shuffle;
                     scmd->set_zone_name("deck");
                     scmd->set_start(0);
-                    scmd->set_end(idList.card_size() - 1);
+                    scmd->set_end(idList.card_size() - 1); // inclusive, the indexed card at end will be shuffled
                     // Server process events backwards, so...
                     commandList.append(scmd);
                 }

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3186,7 +3186,7 @@ void Player::cardMenuAction()
                     auto *scmd = new Command_Shuffle;
                     scmd->set_zone_name("deck");
                     scmd->set_start(0);
-                    scmd->set_end(idList.card_size());
+                    scmd->set_end(idList.card_size() - 1);
                     // Server process events backwards, so...
                     commandList.append(scmd);
                 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5611

## Short roundup of the initial problem

"Move to top of library in random order" shuffles one card more than the number that was topped. 

## What will change with this Pull Request?

Seems like shuffle command's start and end index are both inclusive. We forgot a -1 on the end index.
