### PR TITLE
Favor websocket over old TCP connection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,6 @@ RUN cmake .. -DWITH_SERVER=1 -DWITH_CLIENT=0 -DWITH_ORACLE=0 -DWITH_DBCONVERTER=
 
 WORKDIR /home/servatrice
 
-EXPOSE 4747 4748
+EXPOSE 4748
 
 ENTRYPOINT [ "servatrice", "--log-to-console" ]

--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ First, create an image from the Dockerfile<br>
 `cd /path/to/Cockatrice-Repo/`
 `docker build -t servatrice .`<br>
 And then run it<br>
-`docker run -i -p 4747:4747/tcp -t servatrice:latest`<br>
+`docker run -i -p 4748:4748 -t servatrice:latest`<br>
 
->Note: Running this command exposes the TCP port 4747 of the docker container<br>
+>Note: Running this command exposes the port 4748 of the docker container<br>
 to permit connections to the server.
 
 Find more information on how to use Servatrice with Docker in our [wiki](https://github.com/Cockatrice/Cockatrice/wiki/Setting-up-Servatrice#using-docker).
@@ -145,7 +145,7 @@ docker-compose build    # Build the Servatrice image using the same Dockerfile a
 docker-compose up       # Setup and run both the MySQL server and Servatrice.
 ```
 
->Note: Similar to the above Docker setup, this will expose TCP ports 4747 and 4748.
+>Note: Similar to the above Docker setup, this will expose port 4748.
 
 >Note: The first time running the docker-compose setup, the MySQL server will take a little time to run the initial setup scripts. Due to this, the Servatrice instance may fail the first few attempts to connect to the database. Servatrice is set to `restart: always` in the docker-compose.yml, which will allow it to continue attempting to start up. Once the MySQL scripts have completed, Servatrice should then connect automatically on the next attempt.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     depends_on:
       - mysql
     ports:
-      - "4747:4747"
       - "4748:4748"
     entrypoint: "/bin/bash -c 'sleep 10; servatrice --config /tmp/servatrice.ini --log-to-console'"
     restart: always

--- a/docker-compose.yml.windows
+++ b/docker-compose.yml.windows
@@ -20,7 +20,6 @@ services:
     depends_on:
       - mysql
     ports:
-      - "4747:4747"
       - "4748:4748"
     entrypoint: "/bin/bash -c 'sleep 10; servatrice --config /tmp/servatrice.ini --log-to-console'"
     restart: always

--- a/servatrice/scripts/register.py
+++ b/servatrice/scripts/register.py
@@ -9,7 +9,7 @@ from pypb.event_server_identification_pb2 import Event_ServerIdentification as S
 from pypb.response_pb2 import Response
 
 HOST = "localhost"
-PORT = 4747
+PORT = 4748
 
 CMD_ID = 1
 

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -20,7 +20,8 @@ id=1
 
 host=any
 
-; The TCP port number servatrice will listen on for clients; default is 4747
+; The TCP port number Servatrice will listen on for clients; default is 4747;
+; Will be removed in the future, use websocket connection instead
 port=4747
 
 ; Servatrice can scale up to serve big number of users using more than one parallel thread of execution;
@@ -421,7 +422,7 @@ enable_forgotpassword_audit=true
 ; "servers" table of the database. Default is 0 (disabled)
 active=0
 
-; The TCP port number servatrice will listen on for other servers; default is 14747
+; The TCP port number Servatrice will listen on for other servers; default is 14747
 port=14747
 
 ; Server-to-server communication needs a valid certificate in PEM format. Enter its filename in this setting


### PR DESCRIPTION
## Related Ticket(s)
- Related #3537

## Short roundup of the initial problem
TCP will go away at one point.

Cockatrice client supports websockets since 6 years (starting with [Cockatrice 2.7.0](https://github.com/Cockatrice/Cockatrice/releases/tag/2019-03-04-Release-2.7.0)).
All public servers that we are aware of support websockets since 5 years (https://github.com/Cockatrice/Cockatrice/issues/3537#issuecomment-656676848).

## What will change with this Pull Request?
- Favor the websocket ports as default connection in the documentation and examples over the former TCP connection
