### PR TITLE
Add rename and delete actions to VDS right-click menu

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
@@ -60,6 +60,11 @@ public slots:
 
 private:
     QMenu *createRightClickMenu();
+
+private slots:
+    void actRenameDeck();
+    void actRenameFile();
+    void actDeleteFile();
 };
 
 class NoScrollFilter : public QObject

--- a/cockatrice/src/deck/deck_loader.h
+++ b/cockatrice/src/deck/deck_loader.h
@@ -36,6 +36,10 @@ public:
     {
         return lastFileName;
     }
+    void setLastFileName(const QString &_lastFileName)
+    {
+        lastFileName = _lastFileName;
+    }
     FileFormat getLastFileFormat() const
     {
         return lastFileFormat;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5618

## Short roundup of the initial problem

You should have the ability to rename and delete decks from the VDS

## What will change with this Pull Request?

Added three new actions to the VDS right-click menu: `Rename Deck`, `Rename File`, and `Delete File`

https://github.com/user-attachments/assets/3a5786d0-a5c6-4e28-a616-80ec7b1ec8f3

- Add `setLastFileName` to `DeckLoader`
- Add actions to VDS right click menu as well as the code to handle those actions.
  - A lot of the code is copied from `TabDeckStorage`
  - Display text will update immediately upon change
  - Note that sort and filters won't update immediately, and will require a refresh.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<img width="243" alt="Screenshot 2025-03-02 at 9 17 49 PM" src="https://github.com/user-attachments/assets/31aaba7e-8005-4414-9a90-4e0eda79c07b" />
