### PR TITLE
Update recently opened decks regardless of where the deck is opened from

### DIFF
--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
@@ -129,6 +129,19 @@ void AbstractTabDeckEditor::actSwapCard(CardInfoPtr info, QString zoneName)
 }
 
 /**
+ * Opens the deck in this tab.
+ * @param deck The deck. Takes ownership of the object
+ */
+void AbstractTabDeckEditor::openDeck(DeckLoader *deck)
+{
+    setDeck(deck);
+
+    if (!deck->getLastFileName().isEmpty()) {
+        SettingsCache::instance().recents().updateRecentlyOpenedDeckPaths(deck->getLastFileName());
+    }
+}
+
+/**
  * Sets the currently active deck for this tab
  * @param _deck The deck. Takes ownership of the object
  */
@@ -290,13 +303,12 @@ void AbstractTabDeckEditor::openDeckFromFile(const QString &fileName, DeckOpenLo
 
     auto *l = new DeckLoader;
     if (l->loadFromFile(fileName, fmt, true)) {
-        SettingsCache::instance().recents().updateRecentlyOpenedDeckPaths(fileName);
         if (deckOpenLocation == NEW_TAB) {
             emit openDeckEditor(l);
             l->deleteLater();
         } else {
             deckMenu->setSaveStatus(false);
-            setDeck(l);
+            openDeck(l);
         }
     } else {
         l->deleteLater();

--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.h
@@ -54,7 +54,7 @@ public:
     virtual void retranslateUi() override = 0;
 
     // Deck Management
-    virtual void setDeck(DeckLoader *_deckLoader);
+    void openDeck(DeckLoader *deck);
     DeckLoader *getDeckList() const;
     void setModified(bool _windowModified);
 
@@ -117,6 +117,7 @@ protected slots:
     virtual void dockFloatingTriggered() = 0;
 
 private:
+    virtual void setDeck(DeckLoader *_deck);
     void editDeckInClipboard(bool annotated);
 
 protected:

--- a/cockatrice/src/client/tabs/tab_deck_storage.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_storage.cpp
@@ -246,8 +246,6 @@ void TabDeckStorage::actOpenLocalDeck()
         if (!deckLoader.loadFromFile(filePath, DeckLoader::CockatriceFormat, true))
             continue;
 
-        SettingsCache::instance().recents().updateRecentlyOpenedDeckPaths(filePath);
-
         emit openDeckEditor(&deckLoader);
     }
 }

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -772,7 +772,7 @@ TabDeckEditor *TabSupervisor::addDeckEditorTab(const DeckLoader *deckToOpen)
 {
     auto *tab = new TabDeckEditor(this);
     if (deckToOpen)
-        tab->setDeck(new DeckLoader(*deckToOpen));
+        tab->openDeck(new DeckLoader(*deckToOpen));
     connect(tab, &AbstractTabDeckEditor::deckEditorClosing, this, &TabSupervisor::deckEditorClosed);
     connect(tab, &AbstractTabDeckEditor::openDeckEditor, this, &TabSupervisor::addDeckEditorTab);
     myAddTab(tab);


### PR DESCRIPTION
## Short roundup of the initial problem

Currently, `Open Recent` option in Deck Editor Tab is only updated when a deck is opened from the deck editor tab or from the deck storage tab. This misses the other ways that decks can be opened.

## What will change with this Pull Request?

Recently opened decks now updates regardless of where the deck is opened from. This includes the addition of opening from VDS. This also covers any additional places to open decks from that we might add in the future.

- Created a new `AbstractTabDeckEditor::openDeck` method that just calls `setDeck` and then updates recents.
  - Made `AbstractTabDeckEditor::setDeck` private.
  - `TabSupervisor` and `AbstractDeckEditor::openDeckFromFile` now call `openDeck`
  - the clipboard actions still use `setDeck` since they shouldn't update the recents
- Remove calls to `updateRecentlyOpenedDeckPaths` from other places
  - The only places `updateRecentlyOpenedDeckPaths` is called from now is `openDeck` and `actSaveDeckAs`
