### PR TITLE
add "Set Banner Card" action to VDS right-click menu

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -288,6 +288,8 @@ QMenu *DeckPreviewWidget::createRightClickMenu()
     connect(menu->addAction(tr("Edit Tags")), &QAction::triggered, deckTagsDisplayWidget,
             &DeckPreviewDeckTagsDisplayWidget::openTagEditDlg);
 
+    addSetBannerCardMenu(menu);
+
     menu->addSeparator();
 
     connect(menu->addAction(tr("Rename Deck")), &QAction::triggered, this, &DeckPreviewWidget::actRenameDeck);
@@ -310,6 +312,28 @@ QMenu *DeckPreviewWidget::createRightClickMenu()
     connect(menu->addAction(tr("Delete File")), &QAction::triggered, this, &DeckPreviewWidget::actDeleteFile);
 
     return menu;
+}
+
+/**
+ * Adds the "Set Banner Card" submenu to the given menu. Does nothing if bannerCardComboBox is null.
+ * @param menu The menu to add the submenu to
+ */
+void DeckPreviewWidget::addSetBannerCardMenu(QMenu *menu)
+{
+    if (!bannerCardComboBox) {
+        return;
+    }
+
+    auto bannerCardMenu = menu->addMenu(tr("Set Banner Card"));
+
+    for (int i = 0; i < bannerCardComboBox->count(); ++i) {
+        auto action = bannerCardMenu->addAction(bannerCardComboBox->itemText(i));
+        connect(action, &QAction::triggered, this, [this, i] { bannerCardComboBox->setCurrentIndex(i); });
+
+        // the checkability is purely for visuals
+        action->setCheckable(true);
+        action->setChecked(bannerCardComboBox->currentIndex() == i);
+    }
 }
 
 void DeckPreviewWidget::actRenameDeck()

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
@@ -59,6 +59,7 @@ public slots:
 
 private:
     QMenu *createRightClickMenu();
+    void addSetBannerCardMenu(QMenu *menu);
 
 private slots:
     void actRenameDeck();


### PR DESCRIPTION
## Related Ticket(s)
- Relates to #5618

## Short roundup of the initial problem

I usually keep the banner card selector hidden because it causes a large amount of lag. However, that means whenever I want to change the banner card, I need to reshow the selector, and then hide it afterwards.

Also, "Set Banner Card" is the only action we haven't added to the right click menu.

## What will change with this Pull Request?

Added the "Set Banner Card" action to the VDS right click menu. The submenu contains the same text that is present in the banner selector combo box. The current banner card is marked with a checkmark. Clicking any of the options will correctly update the banner card, the same as if it was done through the combo box.

https://github.com/user-attachments/assets/a299524d-1638-45ba-b4c9-1b15be7fd668

## Screenshots

<img width="578" alt="Screenshot 2025-03-05 at 12 26 20 AM" src="https://github.com/user-attachments/assets/19e00cf5-4831-46ba-8366-89d471ef432b" />

