### PR TITLE
Fix view bottom cards using the wrong default

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -1139,9 +1139,9 @@ void Player::actViewBottomCards()
     bool ok;
     int number =
         QInputDialog::getInt(game, tr("View bottom cards of library"), tr("Number of cards: (max. %1)").arg(deckSize),
-                             defaultNumberTopCards, 1, deckSize, 1, &ok);
+                             defaultNumberBottomCards, 1, deckSize, 1, &ok);
     if (ok) {
-        defaultNumberTopCards = number;
+        defaultNumberBottomCards = number;
         static_cast<GameScene *>(scene())->toggleZoneView(this, "deck", number, true);
     }
 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5410

## Short roundup of the initial problem

The view bottom cards action uses `defaultNumberTopCards` instead of `defaultNumberBottomCards`

## What will change with this Pull Request?

Correctly use `defaultNumberBottomCards`