### PR TITLE
Fix incorrect deck modified state

### DIFF
--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
@@ -76,7 +76,7 @@ void AbstractTabDeckEditor::updateCard(CardInfoPtr _card)
 
 void AbstractTabDeckEditor::onDeckChanged()
 {
-    setModified(isBlankNewDeck());
+    setModified(!isBlankNewDeck());
     deckMenu->setSaveStatus(!isBlankNewDeck());
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5678

## Short roundup of the initial problem

Deck wasn't being marked as modified when an edit is made from the decklist dock. Also, users on windows would have the blank deck that is created on startup be marked as modified.

## What will change with this Pull Request?

- Inverted a boolean