### PR TITLE
Rename some save to clipboard actions

### DIFF
--- a/cockatrice/src/client/menus/deck_editor/deck_editor_menu.cpp
+++ b/cockatrice/src/client/menus/deck_editor/deck_editor_menu.cpp
@@ -39,16 +39,15 @@ DeckEditorMenu::DeckEditorMenu(QWidget *parent, AbstractTabDeckEditor *_deckEdit
     aSaveDeckToClipboard = new QAction(QString(), this);
     connect(aSaveDeckToClipboard, SIGNAL(triggered()), deckEditor, SLOT(actSaveDeckToClipboard()));
 
-    aSaveDeckToClipboardNoSetNameAndNumber = new QAction(QString(), this);
-    connect(aSaveDeckToClipboardNoSetNameAndNumber, SIGNAL(triggered()), deckEditor,
-            SLOT(actSaveDeckToClipboardNoSetNameAndNumber()));
+    aSaveDeckToClipboardNoSetInfo = new QAction(QString(), this);
+    connect(aSaveDeckToClipboardNoSetInfo, SIGNAL(triggered()), deckEditor, SLOT(actSaveDeckToClipboardNoSetInfo()));
 
     aSaveDeckToClipboardRaw = new QAction(QString(), this);
     connect(aSaveDeckToClipboardRaw, SIGNAL(triggered()), deckEditor, SLOT(actSaveDeckToClipboardRaw()));
 
-    aSaveDeckToClipboardRawNoSetNameAndNumber = new QAction(QString(), this);
-    connect(aSaveDeckToClipboardRawNoSetNameAndNumber, SIGNAL(triggered()), deckEditor,
-            SLOT(actSaveDeckToClipboardRawNoSetNameAndNumber()));
+    aSaveDeckToClipboardRawNoSetInfo = new QAction(QString(), this);
+    connect(aSaveDeckToClipboardRawNoSetInfo, SIGNAL(triggered()), deckEditor,
+            SLOT(actSaveDeckToClipboardRawNoSetInfo()));
 
     aPrintDeck = new QAction(QString(), this);
     connect(aPrintDeck, SIGNAL(triggered()), deckEditor, SLOT(actPrintDeck()));
@@ -76,9 +75,9 @@ DeckEditorMenu::DeckEditorMenu(QWidget *parent, AbstractTabDeckEditor *_deckEdit
 
     saveDeckToClipboardMenu = new QMenu(this);
     saveDeckToClipboardMenu->addAction(aSaveDeckToClipboard);
-    saveDeckToClipboardMenu->addAction(aSaveDeckToClipboardNoSetNameAndNumber);
+    saveDeckToClipboardMenu->addAction(aSaveDeckToClipboardNoSetInfo);
     saveDeckToClipboardMenu->addAction(aSaveDeckToClipboardRaw);
-    saveDeckToClipboardMenu->addAction(aSaveDeckToClipboardRawNoSetNameAndNumber);
+    saveDeckToClipboardMenu->addAction(aSaveDeckToClipboardRawNoSetInfo);
 
     addAction(aNewDeck);
     addAction(aLoadDeck);
@@ -108,9 +107,9 @@ void DeckEditorMenu::setSaveStatus(bool newStatus)
     aSaveDeck->setEnabled(newStatus);
     aSaveDeckAs->setEnabled(newStatus);
     aSaveDeckToClipboard->setEnabled(newStatus);
-    aSaveDeckToClipboardNoSetNameAndNumber->setEnabled(newStatus);
+    aSaveDeckToClipboardNoSetInfo->setEnabled(newStatus);
     aSaveDeckToClipboardRaw->setEnabled(newStatus);
-    aSaveDeckToClipboardRawNoSetNameAndNumber->setEnabled(newStatus);
+    aSaveDeckToClipboardRawNoSetInfo->setEnabled(newStatus);
     saveDeckToClipboardMenu->setEnabled(newStatus);
     aPrintDeck->setEnabled(newStatus);
     analyzeDeckMenu->setEnabled(newStatus);
@@ -153,9 +152,9 @@ void DeckEditorMenu::retranslateUi()
 
     saveDeckToClipboardMenu->setTitle(tr("Save deck to clipboard"));
     aSaveDeckToClipboard->setText(tr("Annotated"));
-    aSaveDeckToClipboardNoSetNameAndNumber->setText(tr("Annotated (No set name or number)"));
+    aSaveDeckToClipboardNoSetInfo->setText(tr("Annotated (No set info)"));
     aSaveDeckToClipboardRaw->setText(tr("Not Annotated"));
-    aSaveDeckToClipboardRawNoSetNameAndNumber->setText(tr("Not Annotated (No set name or number)"));
+    aSaveDeckToClipboardRawNoSetInfo->setText(tr("Not Annotated (No set info)"));
 
     aPrintDeck->setText(tr("&Print deck..."));
 
@@ -183,10 +182,9 @@ void DeckEditorMenu::refreshShortcuts()
     aClose->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aClose"));
 
     aSaveDeckToClipboard->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aSaveDeckToClipboard"));
-    aSaveDeckToClipboardNoSetNameAndNumber->setShortcuts(
-        shortcuts.getShortcut("TabDeckEditor/aSaveDeckToClipboardNoSetInfo"));
+    aSaveDeckToClipboardNoSetInfo->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aSaveDeckToClipboardNoSetInfo"));
     aSaveDeckToClipboardRaw->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aSaveDeckToClipboardRaw"));
-    aSaveDeckToClipboardRawNoSetNameAndNumber->setShortcuts(
+    aSaveDeckToClipboardRawNoSetInfo->setShortcuts(
         shortcuts.getShortcut("TabDeckEditor/aSaveDeckToClipboardRawNoSetInfo"));
 
     aClose->setShortcuts(shortcuts.getShortcut("TabDeckEditor/aClose"));

--- a/cockatrice/src/client/menus/deck_editor/deck_editor_menu.h
+++ b/cockatrice/src/client/menus/deck_editor/deck_editor_menu.h
@@ -15,8 +15,8 @@ public:
     AbstractTabDeckEditor *deckEditor;
 
     QAction *aNewDeck, *aLoadDeck, *aClearRecents, *aSaveDeck, *aSaveDeckAs, *aLoadDeckFromClipboard,
-        *aEditDeckInClipboard, *aEditDeckInClipboardRaw, *aSaveDeckToClipboard, *aSaveDeckToClipboardNoSetNameAndNumber,
-        *aSaveDeckToClipboardRaw, *aSaveDeckToClipboardRawNoSetNameAndNumber, *aPrintDeck, *aExportDeckDecklist,
+        *aEditDeckInClipboard, *aEditDeckInClipboardRaw, *aSaveDeckToClipboard, *aSaveDeckToClipboardNoSetInfo,
+        *aSaveDeckToClipboardRaw, *aSaveDeckToClipboardRawNoSetInfo, *aPrintDeck, *aExportDeckDecklist,
         *aAnalyzeDeckDeckstats, *aAnalyzeDeckTappedout, *aClose;
     QMenu *loadRecentDeckMenu, *analyzeDeckMenu, *editDeckInClipboardMenu, *saveDeckToClipboardMenu;
 

--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
@@ -433,7 +433,7 @@ void AbstractTabDeckEditor::actSaveDeckToClipboard()
     getDeckList()->saveToClipboard(true, true);
 }
 
-void AbstractTabDeckEditor::actSaveDeckToClipboardNoSetNameAndNumber()
+void AbstractTabDeckEditor::actSaveDeckToClipboardNoSetInfo()
 {
     getDeckList()->saveToClipboard(true, false);
 }
@@ -443,7 +443,7 @@ void AbstractTabDeckEditor::actSaveDeckToClipboardRaw()
     getDeckList()->saveToClipboard(false, true);
 }
 
-void AbstractTabDeckEditor::actSaveDeckToClipboardRawNoSetNameAndNumber()
+void AbstractTabDeckEditor::actSaveDeckToClipboardRawNoSetInfo()
 {
     getDeckList()->saveToClipboard(false, false);
 }

--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.h
@@ -95,9 +95,9 @@ protected slots:
     void actEditDeckInClipboard();
     void actEditDeckInClipboardRaw();
     void actSaveDeckToClipboard();
-    void actSaveDeckToClipboardNoSetNameAndNumber();
+    void actSaveDeckToClipboardNoSetInfo();
     void actSaveDeckToClipboardRaw();
-    void actSaveDeckToClipboardRawNoSetNameAndNumber();
+    void actSaveDeckToClipboardRawNoSetInfo();
     void actPrintDeck();
     void actExportDeckDecklist();
     void actAnalyzeDeckDeckstats();


### PR DESCRIPTION
## Short roundup of the initial problem

`Not Annotated (No set name and number)` is a bit of a mouthful.

## What will change with this Pull Request?
- renamed the action to `Not Annotated (No set info)`
- renamed the variables for the actions

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<img width="564" alt="Screenshot 2025-03-08 at 8 05 30 PM" src="https://github.com/user-attachments/assets/2b84a6bd-8e29-4392-9f35-b8bbc3d4ddb2" />
