### PR TITLE
Show correct printing for top card of library

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -2594,8 +2594,12 @@ void Player::eventRevealCards(const Event_RevealCards &event, EventProcessingOpt
         auto cardId = event.card_id_size() == 0 ? -1 : event.card_id(0);
         if (cardList.size() == 1) {
             cardName = QString::fromStdString(cardList.first()->name());
-            if ((cardId == 0) && dynamic_cast<PileZone *>(zone)) {
-                zone->getCards().first()->setName(cardName);
+
+            // Handle case of revealing top card of library in-place
+            if (cardId == 0 && dynamic_cast<PileZone *>(zone)) {
+                auto card = zone->getCards().first();
+                card->setName(cardName);
+                card->setProviderId(QString::fromStdString(cardList.first()->provider_id()));
                 zone->update();
                 showZoneView = false;
             }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5699

## Short roundup of the initial problem

Revealed cards on top of library did not show the correct printing

## What will change with this Pull Request?

Also pass along providerId when revealing top card of library
