### PR TITLE
don't update the deckhash on load

### DIFF
--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -368,7 +368,8 @@ DeckList::DeckList() : QObject(), deckHashDirty(true)
 
 // TODO: https://qt-project.org/doc/qt-4.8/qobject.html#no-copy-constructor-or-assignment-operator
 DeckList::DeckList(const DeckList &other)
-    : QObject(), name(other.name), comments(other.comments), bannerCard(other.bannerCard), deckHash(other.deckHash), deckHashDirty(other.deckHashDirty), lastLoadedTimestamp(other.lastLoadedTimestamp), tags(other.tags)
+    : QObject(), name(other.name), comments(other.comments), bannerCard(other.bannerCard), deckHash(other.deckHash),
+      deckHashDirty(other.deckHashDirty), lastLoadedTimestamp(other.lastLoadedTimestamp), tags(other.tags)
 {
     root = new InnerDecklistNode(other.getRoot());
 

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -253,6 +253,7 @@ private:
     QString name, comments;
     QPair<QString, QString> bannerCard;
     QString deckHash;
+    bool deckHashDirty;
     QString lastLoadedTimestamp;
     QStringList tags;
     QMap<QString, SideboardPlan *> sideboardPlans;
@@ -363,10 +364,7 @@ public:
 
     int getSideboardSize() const;
 
-    QString getDeckHash() const
-    {
-        return deckHash;
-    }
+    QString getDeckHash();
     void updateDeckHash();
 
     InnerDecklistNode *getRoot() const


### PR DESCRIPTION
add a new property to decklists that tracks if the deck needs to update the deckhash

only update the deckhash if needed when it is asked for

this saves computing the deckhash for every loaded deck as performed by the visual deck selector with impunity

the copy constructor also now no longer computes the deck hash again

the deck hash is now only computed once, on deck load, as expected, resulting in massive amounts of cpu cycles not being wasted