### PR TITLE
Compute deck hashes lazily

### DIFF
--- a/cockatrice/src/deck/deck_list_model.cpp
+++ b/cockatrice/src/deck/deck_list_model.cpp
@@ -262,7 +262,7 @@ bool DeckListModel::setData(const QModelIndex &index, const QVariant &value, con
     }
 
     emitRecursiveUpdates(index);
-    deckList->updateDeckHash();
+    deckList->refreshDeckHash();
     return true;
 }
 
@@ -398,7 +398,7 @@ QModelIndex DeckListModel::addCard(const QString &cardName,
         cardNode->setCardSetShortName(cardSetName);
         cardNode->setCardCollectorNumber(cardInfoSet.getProperty("num"));
         cardNode->setCardProviderId(cardInfoSet.getProperty("uuid"));
-        deckList->updateDeckHash();
+        deckList->refreshDeckHash();
     }
     sort(lastKnownColumn, lastKnownOrder);
     emitRecursiveUpdates(parentIndex);

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -927,7 +927,7 @@ bool DeckList::deleteNode(AbstractDecklistNode *node, InnerDecklistNode *rootNod
     return false;
 }
 
-static QString calculateDeckHash(const InnerDecklistNode *root)
+static QString computeDeckHash(const InnerDecklistNode *root)
 {
     QStringList cardList;
     QSet<QString> hashZones, optionalZones;
@@ -958,7 +958,7 @@ static QString calculateDeckHash(const InnerDecklistNode *root)
 
 /**
  * Gets the deck hash.
- * The hash is calculated on the first call to this method, and will be cached until the decklist is modified.
+ * The hash is computed on the first call to this method, and is cached until the decklist is modified.
  *
  * @return The deck hash
  */
@@ -968,7 +968,7 @@ QString DeckList::getDeckHash() const
         return cachedDeckHash;
     }
 
-    cachedDeckHash = calculateDeckHash(root);
+    cachedDeckHash = computeDeckHash(root);
     return cachedDeckHash;
 }
 

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -368,8 +368,8 @@ DeckList::DeckList()
 
 // TODO: https://qt-project.org/doc/qt-4.8/qobject.html#no-copy-constructor-or-assignment-operator
 DeckList::DeckList(const DeckList &other)
-    : QObject(), name(other.name), comments(other.comments), bannerCard(other.bannerCard), deckHash(other.deckHash),
-      lastLoadedTimestamp(other.lastLoadedTimestamp), tags(other.tags)
+    : QObject(), name(other.name), comments(other.comments), bannerCard(other.bannerCard),
+      lastLoadedTimestamp(other.lastLoadedTimestamp), tags(other.tags), cachedDeckHash(other.cachedDeckHash)
 {
     root = new InnerDecklistNode(other.getRoot());
 
@@ -378,7 +378,6 @@ DeckList::DeckList(const DeckList &other)
         spIterator.next();
         sideboardPlans.insert(spIterator.key(), new SideboardPlan(spIterator.key(), spIterator.value()->getMoveList()));
     }
-    updateDeckHash();
 }
 
 DeckList::DeckList(const QString &nativeString)
@@ -507,7 +506,7 @@ bool DeckList::loadFromXml(QXmlStreamReader *xml)
             }
         }
     }
-    updateDeckHash();
+    refreshDeckHash();
     if (xml->error()) {
         qDebug() << "Error loading deck from xml: " << xml->errorString();
         return false;
@@ -734,7 +733,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
         new DecklistCardNode(cardName, amount, getZoneObjFromName(zoneName), setCode, collectorNumber);
     }
 
-    updateDeckHash();
+    refreshDeckHash();
     return true;
 }
 
@@ -808,8 +807,7 @@ void DeckList::cleanList()
     setName();
     setComments();
     setTags();
-    deckHash = QString();
-    emit deckHashChanged();
+    refreshDeckHash();
 }
 
 void DeckList::getCardListHelper(InnerDecklistNode *item, QSet<QString> &result) const
@@ -881,7 +879,7 @@ DecklistCardNode *DeckList::addCard(const QString &cardName,
     }
 
     auto *node = new DecklistCardNode(cardName, 1, zoneNode, cardSetName, cardSetCollectorNumber, cardProviderId);
-    updateDeckHash();
+    refreshDeckHash();
 
     return node;
 }
@@ -907,7 +905,7 @@ bool DeckList::deleteNode(AbstractDecklistNode *node, InnerDecklistNode *rootNod
         }
 
         if (updateHash) {
-            updateDeckHash();
+            refreshDeckHash();
         }
 
         return true;
@@ -918,7 +916,7 @@ bool DeckList::deleteNode(AbstractDecklistNode *node, InnerDecklistNode *rootNod
         if (inner) {
             if (deleteNode(node, inner)) {
                 if (updateHash) {
-                    updateDeckHash();
+                    refreshDeckHash();
                 }
 
                 return true;
@@ -929,7 +927,7 @@ bool DeckList::deleteNode(AbstractDecklistNode *node, InnerDecklistNode *rootNod
     return false;
 }
 
-void DeckList::updateDeckHash()
+static QString calculateDeckHash(const InnerDecklistNode *root)
 {
     QStringList cardList;
     QSet<QString> hashZones, optionalZones;
@@ -955,7 +953,30 @@ void DeckList::updateDeckHash()
                      (((quint64)(unsigned char)deckHashArray[1]) << 24) +
                      (((quint64)(unsigned char)deckHashArray[2] << 16)) +
                      (((quint64)(unsigned char)deckHashArray[3]) << 8) + (quint64)(unsigned char)deckHashArray[4];
-    deckHash = QString::number(number, 32).rightJustified(8, '0');
+    return QString::number(number, 32).rightJustified(8, '0');
+}
 
+/**
+ * Gets the deck hash.
+ * The hash is calculated on the first call to this method, and will be cached until the decklist is modified.
+ *
+ * @return The deck hash
+ */
+QString DeckList::getDeckHash() const
+{
+    if (!cachedDeckHash.isEmpty()) {
+        return cachedDeckHash;
+    }
+
+    cachedDeckHash = calculateDeckHash(root);
+    return cachedDeckHash;
+}
+
+/**
+ * Invalidates the cached deckHash and emits the deckHashChanged signal.
+ */
+void DeckList::refreshDeckHash()
+{
+    cachedDeckHash = QString();
     emit deckHashChanged();
 }

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -252,7 +252,6 @@ class DeckList : public QObject
 private:
     QString name, comments;
     QPair<QString, QString> bannerCard;
-    QString deckHash;
     QString lastLoadedTimestamp;
     QStringList tags;
     QMap<QString, SideboardPlan *> sideboardPlans;
@@ -260,6 +259,11 @@ private:
     void getCardListHelper(InnerDecklistNode *node, QSet<QString> &result) const;
     void getCardListWithProviderIdHelper(InnerDecklistNode *item, QMap<QString, QString> &result) const;
     InnerDecklistNode *getZoneObjFromName(const QString &zoneName);
+
+    /**
+     * Empty string indicates invalid cache.
+     */
+    mutable QString cachedDeckHash;
 
 protected:
     virtual QString getCardZoneFromName(const QString /*cardName*/, QString currentZoneName)
@@ -363,12 +367,6 @@ public:
 
     int getSideboardSize() const;
 
-    QString getDeckHash() const
-    {
-        return deckHash;
-    }
-    void updateDeckHash();
-
     InnerDecklistNode *getRoot() const
     {
         return root;
@@ -379,6 +377,9 @@ public:
                               const QString &cardSetCollectorNumber = QString(),
                               const QString &cardProviderId = QString());
     bool deleteNode(AbstractDecklistNode *node, InnerDecklistNode *rootNode = nullptr);
+
+    QString getDeckHash() const;
+    void refreshDeckHash();
 
     /**
      * Calls a given function object for each card in the deck. It must

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -261,7 +261,7 @@ private:
     InnerDecklistNode *getZoneObjFromName(const QString &zoneName);
 
     /**
-     * Empty string indicates invalid cache.
+     * Empty string indicates invalidated cache.
      */
     mutable QString cachedDeckHash;
 


### PR DESCRIPTION
## Related Ticket(s)

- Update to #5705 

## Short roundup of the initial problem

The DeckLoaders that Visual Deck Storage creates are wasting a bunch of resources calculating deck hashes that don't get used anyways. 

We only use deck hashes in a few places, yet every DeckLoader eagerly calculates the deck hash on load.

## What will change with this Pull Request?
- renamed `deckHash` to `cachedDeckHash` and only calculate it for the first time when `getDeckHash` is called
  - deck hashes aren't used in many places, so depending on how often getDeckHash gets called on the same DeckList, it could be the case that it's entirely unnecessary to cache the value. I'm still caching it for now though since I don't know
- Moved some stuff around and renamed some stuff in `DeckList`

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
