### PR TITLE
Re-add old names for mana value property to oracle

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -207,8 +207,9 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
 {
     // mtgjson name => xml name
     static const QMap<QString, QString> cardProperties{
-        {"manaCost", "manacost"}, {"manaValue", "cmc"}, {"type", "type"},
-        {"loyalty", "loyalty"},   {"layout", "layout"}, {"side", "side"},
+        {"manaCost", "manacost"},     {"manaValue", "cmc"}, {"type", "type"},
+        {"loyalty", "loyalty"},       {"layout", "layout"}, {"side", "side"},
+        {"convertedManaCost", "cmc"}, // old name for manaValue, for backwards compatibility
     };
 
     // mtgjson name => xml name
@@ -350,7 +351,13 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
 
             // add other face for split cards as card relation
             if (!getStringPropertyFromMap(card, "side").isEmpty()) {
-                properties["cmc"] = getStringPropertyFromMap(card, "faceManaValue");
+                auto faceManaValue = getStringPropertyFromMap(card, "faceManaValue");
+                if (faceManaValue.isEmpty()) {
+                    // check the old name for the property, for backwards compatibility purposes
+                    faceManaValue = getStringPropertyFromMap(card, "faceConvertedManaCost");
+                }
+                properties["cmc"] = faceManaValue;
+
                 if (layout == "meld") { // meld cards don't work
                     static const QRegularExpression meldNameRegex{"then meld them into ([^\\.]*)"};
                     QString additionalName = meldNameRegex.match(text).captured(1);


### PR DESCRIPTION
## Short roundup of the initial problem

Json downloads are used to import cards for custom formats. Since not everyone has updated to the latest Cockatrice version, those jsons need to have both the old and new mv property in order for it to be compatible for all users, which is annoying.

## What will change with this Pull Request?

Oracle now recognizes the old names for the mana value properties.

json used for testing: https://raw.githubusercontent.com/rudyards/field-builder/refs/heads/main/All%20Sets.json

