### PR TITLE
Update cipt parsing

### DIFF
--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -15,6 +15,7 @@ set(oracle_SOURCES
     src/oraclewizard.cpp
     src/oracleimporter.cpp
     src/pagetemplates.cpp
+    src/parsehelpers.cpp
     src/qt-json/json.cpp
     ../cockatrice/src/game/cards/card_database.cpp
     ../cockatrice/src/game/cards/card_database_manager.cpp

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -1,6 +1,7 @@
 #include "oracleimporter.h"
 
 #include "game/cards/card_database_parser/cockatrice_xml_4.h"
+#include "parsehelpers.h"
 #include "qt-json/json.h"
 
 #include <QDebug>
@@ -105,19 +106,6 @@ QString OracleImporter::getMainCardType(const QStringList &typeList)
     }
 
     return typeList.first();
-}
-
-/**
- * Parses the card text to determine if the card enters the battlefield tapped.
- *
- * @param name The name of the card
- * @param text The full oracle text of the card
- */
-static bool parseCipt(const QString &name, const QString &text)
-{
-    QRegularExpression ciptRegex("( it|" + QRegularExpression::escape(name) +
-                                 ") enters( the battlefield)? tapped(?! unless)");
-    return ciptRegex.match(text).hasMatch();
 }
 
 CardInfoPtr OracleImporter::addCard(QString name,

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -107,6 +107,19 @@ QString OracleImporter::getMainCardType(const QStringList &typeList)
     return typeList.first();
 }
 
+/**
+ * Parses the card text to determine if the card enters the battlefield tapped.
+ *
+ * @param name The name of the card
+ * @param text The full oracle text of the card
+ */
+static bool parseCipt(const QString &name, const QString &text)
+{
+    QRegularExpression ciptRegex("( it|" + QRegularExpression::escape(name) +
+                                 ") enters( the battlefield)? tapped(?! unless)");
+    return ciptRegex.match(text).hasMatch();
+}
+
 CardInfoPtr OracleImporter::addCard(QString name,
                                     QString text,
                                     bool isToken,
@@ -157,9 +170,7 @@ CardInfoPtr OracleImporter::addCard(QString name,
     // DETECT CARD POSITIONING INFO
 
     // cards that enter the field tapped
-    QRegularExpression ciptRegex("( it|" + QRegularExpression::escape(name) +
-                                 ") enters( the battlefield)? tapped(?! unless)");
-    bool cipt = ciptRegex.match(text).hasMatch();
+    bool cipt = parseCipt(name, text);
 
     bool landscapeOrientation = properties.value("maintype").toString() == "Battle" ||
                                 properties.value("layout").toString() == "split" ||

--- a/oracle/src/parsehelpers.cpp
+++ b/oracle/src/parsehelpers.cpp
@@ -3,30 +3,51 @@
 #include <QRegularExpression>
 
 /**
- * Parses the card text to determine if the card enters the battlefield tapped.
+ * Parses the card text to determine if the card should have the cipt tag
  *
- * The parsing logic will be able to handle the following cases:
- * - "<name> enters tapped..."
- * - shortname, if it appears at the start of the name.
- * - "This <type> enters tapped..."
+ * The parsing logic is able to handle the following cases:
+ * - "<name> enters tapped"
+ * - "<shortname> enters tapped", if the card name starts with the shortname
+ * - "This <type> enters tapped"
+ * - "..., it enters tapped"
  * - Any naming scheme that appends a non-alphanumeric character plus extra text to the end of the name.
- * (e.g. name is "Card Name_SET" or "Card Name (Set)" and text contains "Card Name enters tapped...")
+ * (e.g. name is "Card Name_SET" or "Card Name (Set)" and text contains "Card Name enters tapped")
  *
- * However, it will still miss certain cases:
- * - shortnames that aren't the first word in the card name
+ * However, it will still miss on certain cases:
+ * - shortnames that aren't the at the beginning of the card name
+ *
+ * Note that "...enters tapped unless..." returns false.
  *
  * @param name The name of the card
  * @param text The oracle text of the card
  */
 bool parseCipt(const QString &name, const QString &text)
 {
-    static auto WHITESPACE_REGEX = QRegularExpression("\\s+");
-    QString shortname = name.split(WHITESPACE_REGEX, Qt::SkipEmptyParts).first();
+    // try to split shortname on all non-alphanumeric characters (including _)
+    static auto SHORTNAME_DIVIDERS = QRegularExpression("[^\\w]|_");
 
-    QString namePattern = QString("( it|this [^ ]* |%1|%2.*)")
-                              .arg(QRegularExpression::escape(name), QRegularExpression::escape(shortname));
+    // Try all possible shortnames.
+    // This also handles the case of extra text appended at end.
+    QStringList possibleNames;
+    qsizetype i = 0;
+    while ((i = name.indexOf(SHORTNAME_DIVIDERS, i)) != -1) {
+        possibleNames.append(QRegularExpression::escape(name.first(i)));
+        ++i;
+    }
 
-    QRegularExpression ciptRegex(namePattern + " enters( the battlefield)? tapped(?! unless)");
+    // and the full name
+    possibleNames.append(QRegularExpression::escape(name));
 
-    return ciptRegex.match(text).hasMatch();
+    QString subject = "(it|"            // "..., it enters tapped"
+                      "(T|t)his [^ ]+|" // "This <type> enters tapped"
+                      + possibleNames.join("|") + ")";
+
+    auto ciptPattern = QRegularExpression(
+        // cipt phrase is either first sentence of line, or is after a punctuation mark
+        "(^|(, |\\. ))" + subject +
+            // support old wording, and exclude the "unless" case
+            " enters( the battlefield)? tapped(?! unless)",
+        QRegularExpression::MultilineOption);
+
+    return ciptPattern.match(text).hasMatch();
 }

--- a/oracle/src/parsehelpers.cpp
+++ b/oracle/src/parsehelpers.cpp
@@ -1,5 +1,6 @@
 #include "parsehelpers.h"
 
+#include <QChar>
 #include <QRegularExpression>
 
 /**
@@ -24,9 +25,8 @@
 bool parseCipt(const QString &name, const QString &text)
 {
     // Try to split shortname on most non-alphanumeric characters (including _)
-    static QSet<QChar> exceptions = {'\'', '\"'};
-    static auto isShortnameDivider = [](const QChar &c) {
-        return c == '_' || (!c.isLetterOrNumber() && !exceptions.contains(c));
+    auto isShortnameDivider = [](const QChar &c) {
+        return c == '_' || (!c.isLetterOrNumber() && c != '\'' && c != '\"');
     };
 
     // Try all possible shortnames.
@@ -37,7 +37,7 @@ bool parseCipt(const QString &name, const QString &text)
         if (isShortnameDivider(name.at(i))) {
             if (inAlphanumericPart) {
                 // only add to names on a "falling edge", in order to reduce the amount of redundant splits
-                possibleNames.append(QRegularExpression::escape(name.first(i)));
+                possibleNames.append(QRegularExpression::escape(name.left(i)));
                 inAlphanumericPart = false;
             }
         } else {

--- a/oracle/src/parsehelpers.cpp
+++ b/oracle/src/parsehelpers.cpp
@@ -1,0 +1,32 @@
+#include "parsehelpers.h"
+
+#include <QRegularExpression>
+
+/**
+ * Parses the card text to determine if the card enters the battlefield tapped.
+ *
+ * The parsing logic will be able to handle the following cases:
+ * - "<name> enters tapped..."
+ * - shortname, if it appears at the start of the name.
+ * - "This <type> enters tapped..."
+ * - Any naming scheme that appends a non-alphanumeric character plus extra text to the end of the name.
+ * (e.g. name is "Card Name_SET" or "Card Name (Set)" and text contains "Card Name enters tapped...")
+ *
+ * However, it will still miss certain cases:
+ * - shortnames that aren't the first word in the card name
+ *
+ * @param name The name of the card
+ * @param text The oracle text of the card
+ */
+bool parseCipt(const QString &name, const QString &text)
+{
+    static auto WHITESPACE_REGEX = QRegularExpression("\\s+");
+    QString shortname = name.split(WHITESPACE_REGEX, Qt::SkipEmptyParts).first();
+
+    QString namePattern = QString("( it|this [^ ]* |%1|%2.*)")
+                              .arg(QRegularExpression::escape(name), QRegularExpression::escape(shortname));
+
+    QRegularExpression ciptRegex(namePattern + " enters( the battlefield)? tapped(?! unless)");
+
+    return ciptRegex.match(text).hasMatch();
+}

--- a/oracle/src/parsehelpers.h
+++ b/oracle/src/parsehelpers.h
@@ -1,0 +1,8 @@
+#ifndef PARSEHELPERS_H
+#define PARSEHELPERS_H
+
+#include <QString>
+
+bool parseCipt(const QString &name, const QString &text);
+
+#endif // PARSEHELPERS_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,3 +51,4 @@ target_link_libraries(password_hash_test cockatrice_common Threads::Threads ${GT
 
 add_subdirectory(carddatabase)
 add_subdirectory(loading_from_clipboard)
+add_subdirectory(oracle)

--- a/tests/oracle/CMakeLists.txt
+++ b/tests/oracle/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_executable(
+  parse_cipt_test
+  ../../oracle/src/parsehelpers.cpp
+  parse_cipt_test.cpp
+)
+
+if (NOT GTEST_FOUND)
+    add_dependencies(parse_cipt_test gtest)
+endif ()
+
+set(TEST_QT_MODULES
+  ${COCKATRICE_QT_VERSION_NAME}::Widgets
+)
+
+target_link_libraries(
+  parse_cipt_test cockatrice_common Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES}
+)
+
+add_test(NAME parse_cipt_test COMMAND parse_cipt_test)

--- a/tests/oracle/CMakeLists.txt
+++ b/tests/oracle/CMakeLists.txt
@@ -1,19 +1,11 @@
-add_executable(
-  parse_cipt_test
-  ../../oracle/src/parsehelpers.cpp
-  parse_cipt_test.cpp
-)
+add_executable(parse_cipt_test ../../oracle/src/parsehelpers.cpp parse_cipt_test.cpp)
 
-if (NOT GTEST_FOUND)
-    add_dependencies(parse_cipt_test gtest)
-endif ()
+if(NOT GTEST_FOUND)
+  add_dependencies(parse_cipt_test gtest)
+endif()
 
-set(TEST_QT_MODULES
-  ${COCKATRICE_QT_VERSION_NAME}::Widgets
-)
+set(TEST_QT_MODULES ${COCKATRICE_QT_VERSION_NAME}::Widgets)
 
-target_link_libraries(
-  parse_cipt_test cockatrice_common Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES}
-)
+target_link_libraries(parse_cipt_test cockatrice_common Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES})
 
 add_test(NAME parse_cipt_test COMMAND parse_cipt_test)

--- a/tests/oracle/parse_cipt_test.cpp
+++ b/tests/oracle/parse_cipt_test.cpp
@@ -1,0 +1,219 @@
+#include "../../oracle/src/parsehelpers.h"
+
+#include "gtest/gtest.h"
+
+TEST(ParseCiptTest, parsesThisEntersTapped)
+{
+    auto name = "Boring Fields";
+    auto text = "This land enters tapped.";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, parsesThisEntersTheBattlefieldTapped)
+{
+    auto name = "Boring Fields";
+    auto text = "This land enters the battlefield tapped.\n"
+                "{T}: Add {G}.";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, parsesItEntersTappedAtEndOfSentence)
+{
+    auto name = "Shocking Fields";
+    auto text = "As this land enters, you may pay 2 life. If you don't, it enters tapped.\n"
+                "{T}: Add {G}.";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, parsesThisEntersTappedWhenNotOnFirstLine)
+{
+    auto name = "Boring Fields";
+    auto text = "Flying\n"
+                "This land enters tapped.\n"
+                "{T}: Add {G}.";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, parsesFullNameWithUnderscoreAppendedText)
+{
+    auto name = "Boring Fields_SL50";
+    auto text = "Boring Fields enters tapped.\n"
+                "{T}: Add {G}.";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, parsesFullNameWithBracketsAppendedText)
+{
+    auto name = "Boring Fields (SL50)";
+    auto text = "Boring Fields enters tapped.\n"
+                "{T}: Add {G}.";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, parsesFullNameWithComma)
+{
+    auto name = "Bob, the Legend";
+    auto text = "Bob, the Legend enters tapped.\n"
+                "Whenever Bob attacks, you win the game.";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, parsesFullNameWithCommaAtEndOfSentence)
+{
+    auto name = "Bob, the Legend";
+    auto text = "As Bob, the Legend enters, you may pay 2 life. If you don't, Bob, the Legend enters tapped.\n"
+                "Whenever Bob attacks, you win the game.";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, parsesFullNameWithApostropheAtEndOfSentence)
+{
+    auto name = "Bob's Bobber";
+    auto text = "As Bob's Bobber enters, you may pay 2 life. If you don't, Bob's Bobber enters tapped.\n"
+                "Whenever Bob attacks, you win the game.";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, parsesShortnameEndingWithComma)
+{
+    auto name = "Bob, the Legend";
+    auto text = "Bob enters tapped.\n"
+                "Whenever Bob attacks, you win the game.";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, parsesShortnameEndingWithSpace)
+{
+    auto name = "Bob the Legend";
+    auto text = "Bob enters tapped.\n"
+                "Whenever Bob attacks, you win the game.";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, parsesMultiWordShortnameEndingWithComma)
+{
+    auto name = "Bob Dod, the Legend";
+    auto text = "Bob Dod enters tapped.\n"
+                "Whenever Bob Dod attacks, you win the game.";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, parsesMultiWordShortnameEndingWithSpace)
+{
+    auto name = "Bob Dod the Legend";
+    auto text = "Bob Dod enters tapped.\n"
+                "Whenever Bob Dod attacks, you win the game.";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, parsesShortnameEndingWithSpaceWithUnderscoreAppendedText)
+{
+    auto name = "Bob the Legend_SL50";
+    auto text = "Bob enters tapped.\n"
+                "Whenever Bob attacks, you win the game.";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, parsesShortnameEndingWithSpaceWithBracketsAppendedText)
+{
+    auto name = "Bob the Legend (SL50)";
+    auto text = "Bob enters tapped.\n"
+                "Whenever Bob attacks, you win the game.";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, parsesMultiWordShortnameEndingWithSpaceWithUnderscoreAppendedText)
+{
+    auto name = "Bob Dod the Legend_SL50";
+    auto text = "Bob Dod enters tapped.\n"
+                "Whenever Bob Dod attacks, you win the game.";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, parsesMultiWordShortnameEndingWithSpaceWithBracketsAppendedText)
+{
+    auto name = "Bob Dod the Legend (SL50)";
+    auto text = "Bob Dod enters tapped.\n"
+                "Whenever Bob Dod attacks, you win the game.";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, rejectsEmptyText)
+{
+    auto name = "Vanilla Dude";
+    auto text = "";
+
+    ASSERT_FALSE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, rejectsEntersTappedUnless)
+{
+    auto name = "Fast Fields";
+    auto text = "This land enters tapped unless you control another land.";
+
+    ASSERT_FALSE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, rejectsWhenNameIsDifferent)
+{
+    auto name = "Boring Fields";
+    auto text = "Fast Fields enters tapped.";
+
+    ASSERT_FALSE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, rejectsOtherCreaturesEnterTapped)
+{
+    auto name = "Imposing Guy";
+    auto text = "Other creatures enter tapped.";
+
+    ASSERT_FALSE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, rejectsAbilityGrantingEntersTapped)
+{
+    auto name = "Imposing Guy";
+    auto text = "Other creatures have \"This creature enters tapped\".";
+
+    ASSERT_FALSE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, parsesEntersTappedAndAbilityGrantingEntersTappedOnSameCard)
+{
+    auto name = "Imposing Guy";
+    auto text = "This creature enters tapped."
+                "Other creatures have \"This creature enters tapped\".";
+
+    ASSERT_TRUE(parseCipt(name, text));
+}
+
+TEST(ParseCiptTest, rejectsItEntersTappedAndAttacking)
+{
+    auto name = "Token Maker";
+    auto text = "When Token Maker attacks, create a token. It enters tapped and attacking.";
+
+    ASSERT_FALSE(parseCipt(name, text));
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5704

## Short roundup of the initial problem

We need to update the cipt parsing in order to handle the new oracle changes. 

## What will change with this Pull Request?

- Moved the cipt parsing to a function in a separate file
  - Because I wanted to add unit tests but didn't want to figure out how to configure the cmake to import all the dependencies for `OracleImporter`
- Updated the cipt parsing logic
  - parser now recognizes "this [type] enters tapped", where we assume [type] is a single word
  - parser also handles shortnames now
    - as long as the shortname is at the start of the full name
  - parser handles card names with extra appended text now
    - mostly added it because I'm annoyed by broken cipt scripts in msem

Parser handles shortnames by creating a list of every possible shortname that could be made from the full name, then or'ing that list together in the regex. No idea if that reduces the performance by too much.
