### PR TITLE
Fix extra .cod in "save deck as" default name

### DIFF
--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
@@ -356,7 +356,7 @@ bool AbstractTabDeckEditor::actSaveDeckAs()
     dialog.setAcceptMode(QFileDialog::AcceptSave);
     dialog.setDefaultSuffix("cod");
     dialog.setNameFilters(DeckLoader::fileNameFilters);
-    dialog.selectFile(getDeckList()->getName().trimmed() + ".cod");
+    dialog.selectFile(getDeckList()->getName().trimmed());
     if (!dialog.exec())
         return false;
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5719

## Short roundup of the initial problem


## What will change with this Pull Request?

https://github.com/user-attachments/assets/26f0a8bd-cc51-422f-8e77-51d3770ea311

- Don't append ".cod" to the end of the deck name, since `setDefaultSuffix` will already apply the `.cod`
  - If the deck name is empty, the file explorer won't display `.cod` extension when entering the text, but if you save it, it'll still save with `.cod` at the end

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
