### PR TITLE
Fix banner and tags not resetting on blank new deck

### DIFF
--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -314,6 +314,9 @@ DeckLoader *DeckEditorDeckDockWidget::getDeckList()
     return deckModel->getDeckList();
 }
 
+/**
+ * Resets the tab to the state for a blank new tab.
+ */
 void DeckEditorDeckDockWidget::cleanDeck()
 {
     deckModel->cleanList();
@@ -321,6 +324,7 @@ void DeckEditorDeckDockWidget::cleanDeck()
     commentsEdit->setText(QString());
     hashLabel->setText(QString());
     updateBannerCardComboBox();
+    deckTagsDisplayWidget->connectDeckList(deckModel->getDeckList());
 }
 
 void DeckEditorDeckDockWidget::recursiveExpand(const QModelIndex &index)

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -320,6 +320,7 @@ void DeckEditorDeckDockWidget::cleanDeck()
     nameEdit->setText(QString());
     commentsEdit->setText(QString());
     hashLabel->setText(QString());
+    updateBannerCardComboBox();
 }
 
 void DeckEditorDeckDockWidget::recursiveExpand(const QModelIndex &index)


### PR DESCRIPTION
## Short roundup of the initial problem

The banner widget and tag widget didn't reset if you use the `new deck` action and open the new blank deck in the same tab.

## What will change with this Pull Request?
- `DeckEditorDeckDockWidget::cleanDeck` also resets the banner widget and tag widget now
