### PR TITLE
Use native hover events

### DIFF
--- a/cockatrice/src/game/cards/abstract_card_item.cpp
+++ b/cockatrice/src/game/cards/abstract_card_item.cpp
@@ -10,8 +10,8 @@
 #include <QGraphicsScene>
 #include <QGraphicsSceneMouseEvent>
 #include <QPainter>
-#include <algorithm>
 #include <QStyleOption>
+#include <algorithm>
 
 AbstractCardItem::AbstractCardItem(QGraphicsItem *parent,
                                    const QString &_name,

--- a/cockatrice/src/game/cards/abstract_card_item.cpp
+++ b/cockatrice/src/game/cards/abstract_card_item.cpp
@@ -11,7 +11,7 @@
 #include <QGraphicsSceneMouseEvent>
 #include <QPainter>
 #include <algorithm>
-#include <qstyleoption.h>
+#include <QStyleOption>
 
 AbstractCardItem::AbstractCardItem(QGraphicsItem *parent,
                                    const QString &_name,

--- a/cockatrice/src/game/cards/abstract_card_item.h
+++ b/cockatrice/src/game/cards/abstract_card_item.h
@@ -24,7 +24,6 @@ protected:
     QColor bgColor;
 
 private:
-    bool isHovered;
     qreal realZValue;
 private slots:
     void pixmapUpdated();
@@ -86,7 +85,6 @@ public:
         return realZValue;
     }
     void setRealZValue(qreal _zValue);
-    void setHovered(bool _hovered);
     QString getColor() const
     {
         return color;
@@ -102,7 +100,6 @@ public:
         return facedown;
     }
     void setFaceDown(bool _facedown);
-    void processHoverEvent();
     void deleteCardInfoPopup()
     {
         emit deleteCardInfoPopup(name);
@@ -114,6 +111,9 @@ protected:
     void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
     QVariant itemChange(QGraphicsItem::GraphicsItemChange change, const QVariant &value) override;
     void cacheBgColor();
+
+    void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
+    void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
 };
 
 #endif

--- a/cockatrice/src/game/cards/card_item.cpp
+++ b/cockatrice/src/game/cards/card_item.cpp
@@ -470,7 +470,6 @@ bool CardItem::animationEvent()
                      .translate(CARD_WIDTH_HALF, CARD_HEIGHT_HALF)
                      .rotate(tapAngle)
                      .translate(-CARD_WIDTH_HALF, -CARD_HEIGHT_HALF));
-    setHovered(false);
     update();
 
     return animationIncomplete;

--- a/cockatrice/src/game/deckview/deck_view.cpp
+++ b/cockatrice/src/game/deckview/deck_view.cpp
@@ -158,12 +158,6 @@ void DeckView::mouseDoubleClickEvent(QMouseEvent *event)
     }
 }
 
-void DeckViewCard::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
-{
-    event->accept();
-    processHoverEvent();
-}
-
 DeckViewCardContainer::DeckViewCardContainer(const QString &_name) : QGraphicsItem(), name(_name), width(0), height(0)
 {
     setCacheMode(DeviceCoordinateCache);

--- a/cockatrice/src/game/deckview/deck_view.h
+++ b/cockatrice/src/game/deckview/deck_view.h
@@ -37,7 +37,6 @@ public:
 
 protected:
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
-    void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
 };
 
 class DeckViewCardDragItem : public AbstractCardDragItem

--- a/cockatrice/src/game/game_scene.cpp
+++ b/cockatrice/src/game/game_scene.cpp
@@ -253,51 +253,6 @@ void GameScene::processViewSizeChange(const QSize &newSize)
     }
 }
 
-void GameScene::updateHover(const QPointF &scenePos)
-{
-    QList<QGraphicsItem *> itemList =
-        items(scenePos, Qt::IntersectsItemBoundingRect, Qt::DescendingOrder, getViewTransform());
-
-    // Search for the topmost zone and ignore all cards not belonging to that zone.
-    CardZone *zone = 0;
-    for (int i = 0; i < itemList.size(); ++i)
-        if ((zone = qgraphicsitem_cast<CardZone *>(itemList[i])))
-            break;
-
-    CardItem *maxZCard = 0;
-    if (zone) {
-        qreal maxZ = -1;
-        for (int i = 0; i < itemList.size(); ++i) {
-            CardItem *card = qgraphicsitem_cast<CardItem *>(itemList[i]);
-            if (!card)
-                continue;
-            if (card->getAttachedTo()) {
-                if (card->getAttachedTo()->getZone() != zone)
-                    continue;
-            } else if (card->getZone() != zone)
-                continue;
-
-            if (card->getRealZValue() > maxZ) {
-                maxZ = card->getRealZValue();
-                maxZCard = card;
-            }
-        }
-    }
-    if (hoveredCard && (maxZCard != hoveredCard))
-        hoveredCard->setHovered(false);
-    if (maxZCard && (maxZCard != hoveredCard))
-        maxZCard->setHovered(true);
-    hoveredCard = maxZCard;
-}
-
-bool GameScene::event(QEvent *event)
-{
-    if (event->type() == QEvent::GraphicsSceneMouseMove)
-        updateHover(static_cast<QGraphicsSceneMouseEvent *>(event)->scenePos());
-
-    return QGraphicsScene::event(event);
-}
-
 void GameScene::timerEvent(QTimerEvent * /*event*/)
 {
     QMutableSetIterator<CardItem *> i(cardsToAnimate);

--- a/cockatrice/src/game/game_scene.h
+++ b/cockatrice/src/game/game_scene.h
@@ -30,11 +30,9 @@ private:
     QList<QList<Player *>> playersByColumn;
     QList<ZoneViewWidget *> zoneViews;
     QSize viewSize;
-    QPointer<CardItem> hoveredCard;
     QBasicTimer *animationTimer;
     QSet<CardItem *> cardsToAnimate;
     int playerRotation;
-    void updateHover(const QPointF &scenePos);
 
 public:
     explicit GameScene(PhasesToolbar *_phasesToolbar, QObject *parent = nullptr);
@@ -65,7 +63,6 @@ public slots:
     void rearrange();
 
 protected:
-    bool event(QEvent *event) override;
     void timerEvent(QTimerEvent *event) override;
 signals:
     void sigStartRubberBand(const QPointF &selectionOrigin);

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -2392,7 +2392,6 @@ void Player::eventMoveCard(const Event_MoveCard &event, const GameEventContext &
     card->setFaceDown(event.face_down());
     if (startZone != targetZone) {
         card->setBeingPointedAt(false);
-        card->setHovered(false);
 
         const QList<CardItem *> &attachedCards = card->getAttachedCards();
         for (auto attachedCard : attachedCards) {

--- a/cockatrice/src/game/zones/pile_zone.cpp
+++ b/cockatrice/src/game/zones/pile_zone.cpp
@@ -131,6 +131,7 @@ void PileZone::mouseReleaseEvent(QGraphicsSceneMouseEvent * /*event*/)
 void PileZone::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 {
     if (!cards.isEmpty())
-        cards[0]->processHoverEvent();
+        emit cards[0]->hovered(cards[0]);
+
     QGraphicsItem::hoverEnterEvent(event);
 }


### PR DESCRIPTION
This is preliminary cleanup work for the improved drag-and-drop behavior in #4974

Get rid of Cockatrice's custom card hover logic in favor of Qt's builtin hover events.