### PR TITLE
Remove `isView` flag from CardZone

### DIFF
--- a/cockatrice/src/game/cards/card_item.cpp
+++ b/cockatrice/src/game/cards/card_item.cpp
@@ -337,8 +337,7 @@ void CardItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
         if ((event->screenPos() - event->buttonDownScreenPos(Qt::LeftButton)).manhattanLength() <
             2 * QApplication::startDragDistance())
             return;
-        if (zone->getIsView()) {
-            const ZoneViewZone *view = static_cast<const ZoneViewZone *>(zone);
+        if (const ZoneViewZone *view = qobject_cast<const ZoneViewZone *>(zone)) {
             if (view->getRevealZone() && !view->getWriteableRevealZone())
                 return;
         } else if (!owner->getLocalOrJudge())
@@ -395,10 +394,8 @@ void CardItem::playCard(bool faceDown)
  */
 static bool isUnwritableRevealZone(CardZone *zone)
 {
-    if (zone && zone->getIsView()) {
-        if (auto *view = static_cast<ZoneViewZone *>(zone)) {
-            return view->getRevealZone() && !view->getWriteableRevealZone();
-        }
+    if (auto *view = qobject_cast<ZoneViewZone *>(zone)) {
+        return view->getRevealZone() && !view->getWriteableRevealZone();
     }
     return false;
 }

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -407,7 +407,14 @@ public:
     void playCardToTable(const CardItem *c, bool faceDown);
     void addCard(CardItem *c);
     void deleteCard(CardItem *c);
-    void addZone(CardZone *z);
+
+    template <typename T, typename ...Args>
+    T* addZone(Args&& ...args)
+    {
+        T* zone = new T(std::forward<Args>(args)...);
+        zones.insert(zone->getName(), zone);
+        return zone;
+    }
 
     AbstractCounter *addCounter(const ServerInfo_Counter &counter);
     AbstractCounter *addCounter(int counterId, const QString &name, QColor color, int radius, int value);

--- a/cockatrice/src/game/zones/card_zone.cpp
+++ b/cockatrice/src/game/zones/card_zone.cpp
@@ -26,14 +26,10 @@ CardZone::CardZone(Player *_p,
                    bool _hasCardAttr,
                    bool _isShufflable,
                    bool _contentsKnown,
-                   QGraphicsItem *parent,
-                   bool _isView)
+                   QGraphicsItem *parent)
     : AbstractGraphicsItem(parent), player(_p), name(_name), cards(_contentsKnown), views{}, menu(nullptr),
-      doubleClickAction(0), hasCardAttr(_hasCardAttr), isShufflable(_isShufflable), isView(_isView)
+      doubleClickAction(0), hasCardAttr(_hasCardAttr), isShufflable(_isShufflable)
 {
-    if (!isView)
-        player->addZone(this);
-
     // If we join a game before the card db finishes loading, the cards might have the wrong printings.
     // Force refresh all cards in the zone when db finishes loading to fix that.
     connect(CardDatabaseManager::getInstance(), &CardDatabase::cardDatabaseLoadingFinished, this,

--- a/cockatrice/src/game/zones/card_zone.h
+++ b/cockatrice/src/game/zones/card_zone.h
@@ -35,7 +35,6 @@ protected:
     QAction *doubleClickAction;
     bool hasCardAttr;
     bool isShufflable;
-    bool isView;
     bool alwaysRevealTopCard;
     void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) override;
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
@@ -65,8 +64,7 @@ public:
              bool _hasCardAttr,
              bool _isShufflable,
              bool _contentsKnown,
-             QGraphicsItem *parent = nullptr,
-             bool _isView = false);
+             QGraphicsItem *parent = nullptr);
     void retranslateUi();
     void clearContents();
     bool getHasCardAttr() const
@@ -115,10 +113,6 @@ public:
     }
     virtual void reorganizeCards() = 0;
     virtual QPointF closestGridPoint(const QPointF &point);
-    bool getIsView() const
-    {
-        return isView;
-    }
     bool getAlwaysRevealTopCard() const
     {
         return alwaysRevealTopCard;

--- a/cockatrice/src/game/zones/select_zone.cpp
+++ b/cockatrice/src/game/zones/select_zone.cpp
@@ -37,9 +37,8 @@ SelectZone::SelectZone(Player *_player,
                        bool _hasCardAttr,
                        bool _isShufflable,
                        bool _contentsKnown,
-                       QGraphicsItem *parent,
-                       bool isView)
-    : CardZone(_player, _name, _hasCardAttr, _isShufflable, _contentsKnown, parent, isView)
+                       QGraphicsItem *parent)
+    : CardZone(_player, _name, _hasCardAttr, _isShufflable, _contentsKnown, parent)
 {
 }
 

--- a/cockatrice/src/game/zones/select_zone.h
+++ b/cockatrice/src/game/zones/select_zone.h
@@ -26,8 +26,7 @@ public:
                bool _hasCardAttr,
                bool _isShufflable,
                bool _contentsKnown,
-               QGraphicsItem *parent = nullptr,
-               bool isView = false);
+               QGraphicsItem *parent = nullptr);
 };
 
 qreal divideCardSpaceInZone(qreal index, int cardCount, qreal totalHeight, qreal cardHeight, bool reverse = false);

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -30,7 +30,7 @@ ZoneViewZone::ZoneViewZone(Player *_p,
                            bool _writeableRevealZone,
                            QGraphicsItem *parent,
                            bool _isReversed)
-    : SelectZone(_p, _origZone->getName(), false, false, true, parent, true), bRect(QRectF()), minRows(0),
+    : SelectZone(_p, _origZone->getName(), false, false, true, parent), bRect(QRectF()), minRows(0),
       numberCards(_numberCards), origZone(_origZone), revealZone(_revealZone),
       writeableRevealZone(_writeableRevealZone), groupBy(CardList::NoSort), sortBy(CardList::NoSort),
       isReversed(_isReversed)


### PR DESCRIPTION
This flag is used for two purposes:

 1. It is used as a check for casting to a zone to a `ZoneViewZone`;

 2. Non-view zones are added to the player's zones on construction

This patch removes the `isView` flag and instead:

 1. We directly cast zones to `ZoneViewZone` using a dynamic (qobject) cast and use the result of the cast instead of the `isView` flag to detect if we are a view zone or not;

 2. The player records its own zones when they are created, simplifying control flow.