### PR TITLE
nix: Add development utilities to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,7 @@
       # Build tools
       cmake
       cmake-format
+      ninja
       bash
       curl
       git
@@ -12,6 +13,7 @@
       # Debug / Test 
       valgrind
       gdb
+      clang-tools
 
       # Compiler
       gcc
@@ -23,4 +25,8 @@
       qt6.full
       qt6.wrapQtAppsHook
     ];
+
+    # Make debug builds work
+    # https://github.com/NixOS/nixpkgs/issues/18995
+    hardeningDisable = [ "fortify" ];
   }


### PR DESCRIPTION
 - Remove hardening flags to allow debug builds (otherwise GCC complains because nix adds the FORTIFY_SOURCE flag, which is not compatible with -O0)

 - Allow ninja as build system

 - Add clang-tools dependency for LSP support