### PR TITLE
Optimize cipt parsing by early returning

### DIFF
--- a/oracle/src/parsehelpers.cpp
+++ b/oracle/src/parsehelpers.cpp
@@ -24,6 +24,12 @@
  */
 bool parseCipt(const QString &name, const QString &text)
 {
+    // Use precompiled regex to check if text is a possible candidate, and early return if not
+    static auto prelimCheck = QRegularExpression(" enters( the battlefield)? tapped(?! unless)");
+    if (!prelimCheck.match(text).hasMatch()) {
+        return false;
+    }
+
     // Try to split shortname on most non-alphanumeric characters (including _)
     auto isShortnameDivider = [](const QChar &c) {
         return c == '_' || (!c.isLetterOrNumber() && c != '\'' && c != '\"');


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5712

## Short roundup of the initial problem

`parseCipt` compiles a new regex every call, which is quite wasteful when most card text are nowhere near the cipt syntax.

## What will change with this Pull Request?

Use a static regex to check that the text is a possible candidate for cipt, before doing the expensive operation of compiling a new regex.

## Screenshots

**Before**
<img width="1785" alt="before" src="https://github.com/user-attachments/assets/417a9677-4a83-47a2-a015-c13db715d3d2" />

**After**
<img width="1773" alt="after" src="https://github.com/user-attachments/assets/89d45cd5-3ae1-4c01-8cb0-371dfe44e385" />
