### PR TITLE
game: Automatic update of arrow position

### DIFF
--- a/cockatrice/src/game/board/arrow_target.cpp
+++ b/cockatrice/src/game/board/arrow_target.cpp
@@ -6,6 +6,7 @@
 ArrowTarget::ArrowTarget(Player *_owner, QGraphicsItem *parent)
     : AbstractGraphicsItem(parent), owner(_owner), beingPointedAt(false)
 {
+    setFlag(ItemSendsScenePositionChanges);
 }
 
 ArrowTarget::~ArrowTarget()
@@ -24,4 +25,17 @@ void ArrowTarget::setBeingPointedAt(bool _beingPointedAt)
 {
     beingPointedAt = _beingPointedAt;
     update();
+}
+
+QVariant ArrowTarget::itemChange(QGraphicsItem::GraphicsItemChange change, const QVariant &value)
+{
+    if (change == ItemScenePositionHasChanged && scene()) {
+        for (auto *arrow : arrowsFrom)
+            arrow->updatePath();
+
+        for (auto *arrow : arrowsTo)
+            arrow->updatePath();
+    }
+
+    return QGraphicsItem::itemChange(change, value);
 }

--- a/cockatrice/src/game/board/arrow_target.h
+++ b/cockatrice/src/game/board/arrow_target.h
@@ -57,5 +57,8 @@ public:
     {
         arrowsTo.removeOne(arrow);
     }
+
+protected:
+    QVariant itemChange(QGraphicsItem::GraphicsItemChange change, const QVariant &value) override;
 };
 #endif

--- a/cockatrice/src/game/cards/abstract_card_item.cpp
+++ b/cockatrice/src/game/cards/abstract_card_item.cpp
@@ -331,5 +331,5 @@ QVariant AbstractCardItem::itemChange(QGraphicsItem::GraphicsItemChange change, 
         update();
         return value;
     } else
-        return QGraphicsItem::itemChange(change, value);
+        return ArrowTarget::itemChange(change, value);
 }

--- a/cockatrice/src/game/cards/card_item.cpp
+++ b/cockatrice/src/game/cards/card_item.cpp
@@ -487,5 +487,5 @@ QVariant CardItem::itemChange(GraphicsItemChange change, const QVariant &value)
             owner->getGame()->setActiveCard(nullptr);
         }
     }
-    return QGraphicsItem::itemChange(change, value);
+    return AbstractCardItem::itemChange(change, value);
 }

--- a/cockatrice/src/game/zones/stack_zone.cpp
+++ b/cockatrice/src/game/zones/stack_zone.cpp
@@ -109,8 +109,6 @@ void StackZone::handleDropEvent(const QList<CardDragItem *> &dragItems, CardZone
 void StackZone::reorganizeCards()
 {
     if (!cards.isEmpty()) {
-        QSet<ArrowItem *> arrowsToUpdate;
-
         const auto cardCount = static_cast<int>(cards.size());
         qreal totalWidth = boundingRect().width();
         qreal cardWidth = cards.at(0)->boundingRect().width();
@@ -125,16 +123,6 @@ void StackZone::reorganizeCards()
                 divideCardSpaceInZone(i, cardCount, boundingRect().height(), cards.at(0)->boundingRect().height());
             card->setPos(x, y);
             card->setRealZValue(i);
-
-            for (ArrowItem *item : card->getArrowsFrom()) {
-                arrowsToUpdate.insert(item);
-            }
-            for (ArrowItem *item : card->getArrowsTo()) {
-                arrowsToUpdate.insert(item);
-            }
-        }
-        for (ArrowItem *item : arrowsToUpdate) {
-            item->updatePath();
         }
     }
     update();

--- a/cockatrice/src/game/zones/table_zone.cpp
+++ b/cockatrice/src/game/zones/table_zone.cpp
@@ -157,8 +157,6 @@ void TableZone::handleDropEventByGrid(const QList<CardDragItem *> &dragItems,
 
 void TableZone::reorganizeCards()
 {
-    QSet<ArrowItem *> arrowsToUpdate;
-
     // Calculate card stack widths so mapping functions work properly
     computeCardStackWidths();
 
@@ -189,23 +187,7 @@ void TableZone::reorganizeCards()
             qreal childY = y + 5;
             attachedCard->setPos(childX, childY);
             attachedCard->setRealZValue((childY + CARD_HEIGHT) * 100000 + (childX + 1) * 100);
-            for (ArrowItem *item : attachedCard->getArrowsFrom()) {
-                arrowsToUpdate.insert(item);
-            }
-            for (ArrowItem *item : attachedCard->getArrowsTo()) {
-                arrowsToUpdate.insert(item);
-            }
         }
-
-        for (ArrowItem *item : cards[i]->getArrowsFrom()) {
-            arrowsToUpdate.insert(item);
-        }
-        for (ArrowItem *item : cards[i]->getArrowsTo()) {
-            arrowsToUpdate.insert(item);
-        }
-    }
-    for (ArrowItem *item : arrowsToUpdate) {
-        item->updatePath();
     }
 
     resizeToContents();


### PR DESCRIPTION
Currently, zones must keep track of which cards they move in order to manually call `updatePath` on arrows.

This patch sets the `ItemSendsScenePositionChanges` flag on `ArrowTarget`s to automatically update arrow positions without requiring zones to keep track of that information.

This is part of preparatory work for #4974.