### PR TITLE
Use enum for ThemeManager brushes

### DIFF
--- a/cockatrice/src/client/ui/theme_manager.cpp
+++ b/cockatrice/src/client/ui/theme_manager.cpp
@@ -120,10 +120,10 @@ void ThemeManager::themeChangedSlot()
     if (dirPath.isEmpty()) {
         // set default values
         QDir::setSearchPaths("theme", DEFAULT_RESOURCE_PATHS);
-        handBgBrush = HANDZONE_BG_DEFAULT;
-        tableBgBrush = TABLEZONE_BG_DEFAULT;
-        playerBgBrush = PLAYERZONE_BG_DEFAULT;
-        stackBgBrush = STACKZONE_BG_DEFAULT;
+        brushes[Role::Hand] = HANDZONE_BG_DEFAULT;
+        brushes[Role::Table] = TABLEZONE_BG_DEFAULT;
+        brushes[Role::Player] = PLAYERZONE_BG_DEFAULT;
+        brushes[Role::Stack] = STACKZONE_BG_DEFAULT;
     } else {
         // resources
         QStringList resources;
@@ -132,73 +132,58 @@ void ThemeManager::themeChangedSlot()
 
         // zones bg
         dir.cd("zones");
-        handBgBrush = loadBrush(HANDZONE_BG_NAME, HANDZONE_BG_DEFAULT);
-        tableBgBrush = loadBrush(TABLEZONE_BG_NAME, TABLEZONE_BG_DEFAULT);
-        playerBgBrush = loadBrush(PLAYERZONE_BG_NAME, PLAYERZONE_BG_DEFAULT);
-        stackBgBrush = loadBrush(STACKZONE_BG_NAME, STACKZONE_BG_DEFAULT);
+        brushes[Role::Hand] = loadBrush(HANDZONE_BG_NAME, HANDZONE_BG_DEFAULT);
+        brushes[Role::Table] = loadBrush(TABLEZONE_BG_NAME, TABLEZONE_BG_DEFAULT);
+        brushes[Role::Player] = loadBrush(PLAYERZONE_BG_NAME, PLAYERZONE_BG_DEFAULT);
+        brushes[Role::Stack] = loadBrush(STACKZONE_BG_NAME, STACKZONE_BG_DEFAULT);
     }
-    tableBgBrushesCache.clear();
-    stackBgBrushesCache.clear();
-    playerBgBrushesCache.clear();
-    handBgBrushesCache.clear();
+    for (auto &brushCache : brushesCache) {
+        brushCache.clear();
+    }
 
     QPixmapCache::clear();
 
     emit themeChanged();
 }
 
-QBrush ThemeManager::getExtraTableBgBrush(QString extraNumber, QBrush &fallbackBrush)
+static QString roleBgName(ThemeManager::Role role)
 {
-    QBrush returnBrush;
+    switch (role) {
+        case ThemeManager::Hand:
+            return HANDZONE_BG_NAME;
 
-    if (!tableBgBrushesCache.contains(extraNumber.toInt())) {
-        returnBrush = loadExtraBrush(TABLEZONE_BG_NAME + extraNumber, fallbackBrush);
-        tableBgBrushesCache.insert(extraNumber.toInt(), returnBrush);
-    } else {
-        returnBrush = tableBgBrushesCache.value(extraNumber.toInt());
+        case ThemeManager::Player:
+            return PLAYERZONE_BG_NAME;
+
+        case ThemeManager::Stack:
+            return STACKZONE_BG_NAME;
+
+        case ThemeManager::Table:
+            return TABLEZONE_BG_NAME;
+
+        default:
+            Q_ASSERT(false);
     }
-
-    return returnBrush;
 }
 
-QBrush ThemeManager::getExtraStackBgBrush(QString extraNumber, QBrush &fallbackBrush)
+QBrush &ThemeManager::getBgBrush(Role role)
 {
-    QBrush returnBrush;
-
-    if (!stackBgBrushesCache.contains(extraNumber.toInt())) {
-        returnBrush = loadExtraBrush(STACKZONE_BG_NAME + extraNumber, fallbackBrush);
-        stackBgBrushesCache.insert(extraNumber.toInt(), returnBrush);
-    } else {
-        returnBrush = stackBgBrushesCache.value(extraNumber.toInt());
-    }
-
-    return returnBrush;
+    return brushes[role];
 }
 
-QBrush ThemeManager::getExtraPlayerBgBrush(QString extraNumber, QBrush &fallbackBrush)
+QBrush ThemeManager::getExtraBgBrush(Role role, int zoneId)
 {
-    QBrush returnBrush;
-
-    if (!playerBgBrushesCache.contains(extraNumber.toInt())) {
-        returnBrush = loadExtraBrush(PLAYERZONE_BG_NAME + extraNumber, fallbackBrush);
-        playerBgBrushesCache.insert(extraNumber.toInt(), returnBrush);
-    } else {
-        returnBrush = playerBgBrushesCache.value(extraNumber.toInt());
+    if (zoneId <= 0) {
+        return getBgBrush(role);
     }
 
-    return returnBrush;
-}
+    QBrushMap &brushCache = brushesCache[role];
 
-QBrush ThemeManager::getExtraHandBgBrush(QString extraNumber, QBrush &fallbackBrush)
-{
-    QBrush returnBrush;
-
-    if (!handBgBrushesCache.contains(extraNumber.toInt())) {
-        returnBrush = loadExtraBrush(HANDZONE_BG_NAME + extraNumber, fallbackBrush);
-        handBgBrushesCache.insert(extraNumber.toInt(), returnBrush);
-    } else {
-        returnBrush = handBgBrushesCache.value(extraNumber.toInt());
+    if (!brushCache.contains(zoneId)) {
+        QBrush brush = loadExtraBrush(roleBgName(role) + QString::number(zoneId), getBgBrush(role));
+        brushCache.insert(zoneId, brush);
+        return brush;
     }
 
-    return returnBrush;
+    return brushCache.value(zoneId);
 }

--- a/cockatrice/src/client/ui/theme_manager.h
+++ b/cockatrice/src/client/ui/theme_manager.h
@@ -9,6 +9,8 @@
 #include <QPixmap>
 #include <QString>
 
+#include <array>
+
 inline Q_LOGGING_CATEGORY(ThemeManagerLog, "theme_manager");
 
 typedef QMap<QString, QString> QStringMap;

--- a/cockatrice/src/client/ui/theme_manager.h
+++ b/cockatrice/src/client/ui/theme_manager.h
@@ -22,13 +22,23 @@ class ThemeManager : public QObject
 public:
     ThemeManager(QObject *parent = nullptr);
 
+    enum Role
+    {
+        MinRole = 0,
+        Hand = MinRole,
+        Stack,
+        Table,
+        Player,
+        MaxRole = Player,
+    };
+
 private:
-    QBrush handBgBrush, stackBgBrush, tableBgBrush, playerBgBrush;
+    std::array<QBrush, Role::MaxRole + 1> brushes;
     QStringMap availableThemes;
     /*
       Internal cache for multiple backgrounds
     */
-    QBrushMap tableBgBrushesCache, stackBgBrushesCache, playerBgBrushesCache, handBgBrushesCache;
+    std::array<QBrushMap, Role::MaxRole + 1> brushesCache;
 
 protected:
     void ensureThemeDirectoryExists();
@@ -36,27 +46,10 @@ protected:
     QBrush loadExtraBrush(QString fileName, QBrush &fallbackBrush);
 
 public:
-    QBrush &getHandBgBrush()
-    {
-        return handBgBrush;
-    }
-    QBrush &getStackBgBrush()
-    {
-        return stackBgBrush;
-    }
-    QBrush &getTableBgBrush()
-    {
-        return tableBgBrush;
-    }
-    QBrush &getPlayerBgBrush()
-    {
-        return playerBgBrush;
-    }
     QStringMap &getAvailableThemes();
-    QBrush getExtraTableBgBrush(QString extraNumber, QBrush &fallbackBrush);
-    QBrush getExtraStackBgBrush(QString extraNumber, QBrush &fallbackBrush);
-    QBrush getExtraPlayerBgBrush(QString extraNumber, QBrush &fallbackBrush);
-    QBrush getExtraHandBgBrush(QString extraNumber, QBrush &fallbackBrush);
+
+    QBrush &getBgBrush(Role zone);
+    QBrush getExtraBgBrush(Role zone, int zoneId = 0);
 protected slots:
     void themeChangedSlot();
 signals:

--- a/cockatrice/src/client/ui/theme_manager.h
+++ b/cockatrice/src/client/ui/theme_manager.h
@@ -8,7 +8,6 @@
 #include <QObject>
 #include <QPixmap>
 #include <QString>
-
 #include <array>
 
 inline Q_LOGGING_CATEGORY(ThemeManagerLog, "theme_manager");

--- a/cockatrice/src/game/deckview/deck_view.cpp
+++ b/cockatrice/src/game/deckview/deck_view.cpp
@@ -172,7 +172,7 @@ void DeckViewCardContainer::paint(QPainter *painter, const QStyleOptionGraphicsI
 {
     qreal totalTextWidth = getCardTypeTextWidth();
 
-    painter->fillRect(boundingRect(), themeManager->getTableBgBrush());
+    painter->fillRect(boundingRect(), themeManager->getBgBrush(ThemeManager::Table));
     painter->setPen(QColor(255, 255, 255, 100));
     painter->drawLine(QPointF(0, separatorY), QPointF(width, separatorY));
 

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -93,12 +93,7 @@ void PlayerArea::updateBg()
 
 void PlayerArea::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
 {
-    QBrush brush = themeManager->getPlayerBgBrush();
-
-    if (playerZoneId > 0) {
-        // If the extra image is not found, load the default one
-        brush = themeManager->getExtraPlayerBgBrush(QString::number(playerZoneId), brush);
-    }
+    QBrush brush = themeManager->getExtraBgBrush(ThemeManager::Player, playerZoneId);
     painter->fillRect(boundingRect(), brush);
 }
 

--- a/cockatrice/src/game/zones/hand_zone.cpp
+++ b/cockatrice/src/game/zones/hand_zone.cpp
@@ -78,12 +78,7 @@ QRectF HandZone::boundingRect() const
 
 void HandZone::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
 {
-    QBrush brush = themeManager->getHandBgBrush();
-
-    if (player->getZoneId() > 0) {
-        // If the extra image is not found, load the default one
-        brush = themeManager->getExtraHandBgBrush(QString::number(player->getZoneId()), brush);
-    }
+    QBrush brush = themeManager->getExtraBgBrush(ThemeManager::Hand, player->getZoneId());
     painter->fillRect(boundingRect(), brush);
 }
 

--- a/cockatrice/src/game/zones/stack_zone.cpp
+++ b/cockatrice/src/game/zones/stack_zone.cpp
@@ -49,12 +49,7 @@ QRectF StackZone::boundingRect() const
 
 void StackZone::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
 {
-    QBrush brush = themeManager->getStackBgBrush();
-
-    if (player->getZoneId() > 0) {
-        // If the extra image is not found, load the default one
-        brush = themeManager->getExtraStackBgBrush(QString::number(player->getZoneId()), brush);
-    }
+    QBrush brush = themeManager->getExtraBgBrush(ThemeManager::Stack, player->getZoneId());
     painter->fillRect(boundingRect(), brush);
 }
 

--- a/cockatrice/src/game/zones/table_zone.cpp
+++ b/cockatrice/src/game/zones/table_zone.cpp
@@ -54,12 +54,7 @@ bool TableZone::isInverted() const
 
 void TableZone::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
 {
-    QBrush brush = themeManager->getTableBgBrush();
-
-    if (player->getZoneId() > 0) {
-        // If the extra image is not found, load the default one
-        brush = themeManager->getExtraTableBgBrush(QString::number(player->getZoneId()), brush);
-    }
+    QBrush brush = themeManager->getExtraBgBrush(ThemeManager::Table, player->getZoneId());
     painter->fillRect(boundingRect(), brush);
 
     if (active) {


### PR DESCRIPTION
This patch introduces an enum to distinguish the different brushes that can be set by the theme (hand, stack, etc.) and generic functions taking the enum rather than having one copy of each function for each brush.

This is preliminary work before merging StackZone and HandZone to simplify #4974.