### PR TITLE
Reduce tag display widget spacing

### DIFF
--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -105,6 +105,8 @@ void DeckEditorDeckDockWidget::createDeckDock()
 
     auto *upperLayout = new QGridLayout;
     upperLayout->setObjectName("upperLayout");
+    upperLayout->setContentsMargins(11, 11, 11, 0);
+
     upperLayout->addWidget(nameLabel, 0, 0);
     upperLayout->addWidget(nameEdit, 0, 1);
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.cpp
@@ -21,8 +21,7 @@ DeckPreviewDeckTagsDisplayWidget::DeckPreviewDeckTagsDisplayWidget(QWidget *_par
 
     // Create layout
     auto *layout = new QHBoxLayout(this);
-    layout->setContentsMargins(5, 5, 5, 5);
-    layout->setSpacing(5);
+    layout->setContentsMargins(0, 0, 0, 0);
 
     setFixedHeight(100);
 


### PR DESCRIPTION
## Short roundup of the initial problem


## What will change with this Pull Request?

Removed the content margins from the tag display widget and reduce the empty space between the deck display widget and the divider.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
Before
<img width="665" alt="Screenshot 2025-03-15 at 10 26 56 PM" src="https://github.com/user-attachments/assets/33fe27fc-0655-4636-8379-add0a0d686cf" />

After
<img width="665" alt="Screenshot 2025-03-15 at 10 44 49 PM" src="https://github.com/user-attachments/assets/1b02eac3-229f-41fb-96bf-2d9b4e7c81d1" />

---

Before
<img width="1370" alt="Screenshot 2025-03-15 at 10 27 31 PM" src="https://github.com/user-attachments/assets/9973fc4c-06f2-4cd7-9470-0141168a066e" />

After
<img width="1366" alt="Screenshot 2025-03-15 at 10 28 00 PM" src="https://github.com/user-attachments/assets/19ff4116-5aef-45bd-bcde-a593a93c9fe1" />
