### PR TITLE
Fix edit deck in clipboard clearing values

### DIFF
--- a/cockatrice/src/dialogs/dlg_load_deck_from_clipboard.cpp
+++ b/cockatrice/src/dialogs/dlg_load_deck_from_clipboard.cpp
@@ -80,7 +80,7 @@ bool AbstractDlgDeckTextEdit::loadIntoDeck(DeckLoader *deckLoader) const
 
     QTextStream stream(&buffer);
 
-    if (deckLoader->loadFromStream_Plain(stream)) {
+    if (deckLoader->loadFromStream_Plain(stream, true)) {
         if (loadSetNameAndNumberCheckBox->isChecked()) {
             deckLoader->resolveSetNameAndNumberToProviderID();
         } else {

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -548,7 +548,14 @@ bool DeckList::saveToFile_Native(QIODevice *device)
     return true;
 }
 
-bool DeckList::loadFromStream_Plain(QTextStream &in)
+/**
+ * Clears the decklist and loads in a new deck from text
+ *
+ * @param in The text to load
+ * @param preserveMetadata If true, don't clear the existing metadata
+ * @return False if the input was empty, true otherwise.
+ */
+bool DeckList::loadFromStream_Plain(QTextStream &in, bool preserveMetadata)
 {
     const QRegularExpression reCardLine(R"(^\s*[\w\[\(\{].*$)", QRegularExpression::UseUnicodePropertiesOption);
     const QRegularExpression reEmpty("^\\s*$");
@@ -577,7 +584,7 @@ bool DeckList::loadFromStream_Plain(QTextStream &in)
                                                          {QRegularExpression("æ"), QString("ae")},
                                                          {QRegularExpression(" ?[|/]+ ?"), QString(" // ")}};
 
-    cleanList();
+    cleanList(preserveMetadata);
 
     auto inputs = in.readAll().trimmed().split('\n');
     auto max_line = inputs.size();
@@ -752,7 +759,7 @@ InnerDecklistNode *DeckList::getZoneObjFromName(const QString &zoneName)
 bool DeckList::loadFromFile_Plain(QIODevice *device)
 {
     QTextStream in(device);
-    return loadFromStream_Plain(in);
+    return loadFromStream_Plain(in, false);
 }
 
 struct WriteToStream
@@ -801,12 +808,19 @@ QString DeckList::writeToString_Plain(bool prefixSideboardCards, bool slashTappe
     return result;
 }
 
-void DeckList::cleanList()
+/**
+ * Clears all cards and other data from the decklist
+ *
+ * @param preserveMetadata If true, only clear the cards
+ */
+void DeckList::cleanList(bool preserveMetadata)
 {
     root->clearTree();
-    setName();
-    setComments();
-    setTags();
+    if (!preserveMetadata) {
+        setName();
+        setComments();
+        setTags();
+    }
     refreshDeckHash();
 }
 

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -351,13 +351,13 @@ public:
     QString writeToString_Native();
     bool loadFromFile_Native(QIODevice *device);
     bool saveToFile_Native(QIODevice *device);
-    bool loadFromStream_Plain(QTextStream &stream);
+    bool loadFromStream_Plain(QTextStream &stream, bool preserveMetadata);
     bool loadFromFile_Plain(QIODevice *device);
     bool saveToStream_Plain(QTextStream &stream, bool prefixSideboardCards, bool slashTappedOutSplitCards);
     bool saveToFile_Plain(QIODevice *device, bool prefixSideboardCards = true, bool slashTappedOutSplitCards = false);
     QString writeToString_Plain(bool prefixSideboardCards = true, bool slashTappedOutSplitCards = false);
 
-    void cleanList();
+    void cleanList(bool preserveMetadata = false);
     bool isEmpty() const
     {
         return root->isEmpty() && name.isEmpty() && comments.isEmpty() && sideboardPlans.isEmpty();

--- a/tests/loading_from_clipboard/clipboard_testing.cpp
+++ b/tests/loading_from_clipboard/clipboard_testing.cpp
@@ -18,7 +18,7 @@ void testEmpty(const QString &clipboard)
     QString cp(clipboard);
     DeckList deckList;
     QTextStream stream(&cp); // text stream requires local copy
-    deckList.loadFromStream_Plain(stream);
+    deckList.loadFromStream_Plain(stream, false);
 
     ASSERT_TRUE(deckList.getCardList().isEmpty());
 }
@@ -28,7 +28,7 @@ void testDeck(const QString &clipboard, const Result &result)
     QString cp(clipboard);
     DeckList deckList;
     QTextStream stream(&cp); // text stream requires local copy
-    deckList.loadFromStream_Plain(stream);
+    deckList.loadFromStream_Plain(stream, false);
 
     ASSERT_EQ(result.name, deckList.getName().toStdString());
     ASSERT_EQ(result.comments, deckList.getComments().toStdString());


### PR DESCRIPTION
## Related Ticket(s)
- Fixes issue introduced in #5681

## Short roundup of the initial problem

`Edit deck in clipboard` would clear the name, comments, and tags of the deck upon `ok`

## What will change with this Pull Request?

- Add new `preserveMetadata` param to some methods in `DeckList`
- Use that param in order to not clear the values when reading deck from text after using "Edit deck in clipboard"
