### PR TITLE
Add a new dialog that allows editing the default suggested tags.

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_dialog.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_dialog.cpp
@@ -56,7 +56,7 @@ DeckPreviewTagDialog::DeckPreviewTagDialog(const QStringList &knownTags, const Q
     newTagInput_ = new QLineEdit(this);
     addTagButton_ = new QPushButton(this);
     editButton = new QPushButton(this);
-    connect(editButton, &QPushButton::clicked, this, [=, this]() {
+    connect(editButton, &QPushButton::clicked, this, [=]() {
         auto defaultTagsEditor = new DlgDefaultTagsEditor(nullptr);
         defaultTagsEditor->exec();
     });

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_dialog.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_dialog.cpp
@@ -1,5 +1,7 @@
 #include "deck_preview_tag_dialog.h"
 
+#include "../../../../../dialogs/dlg_default_tags_editor.h"
+#include "../../../../../settings/cache_settings.h"
 #include "deck_preview_tag_item_widget.h"
 
 #include <QCheckBox>
@@ -11,89 +13,11 @@
 #include <QVBoxLayout>
 
 DeckPreviewTagDialog::DeckPreviewTagDialog(const QStringList &knownTags, const QStringList &activeTags, QWidget *parent)
-    : QDialog(parent), activeTags_(activeTags)
+    : QDialog(parent), activeTags_(activeTags), knownTags_(knownTags)
 {
     resize(400, 500);
 
-    QStringList defaultTags = {
-        // Strategies
-        "🏃️ Aggro",
-        "🧙‍️ Control",
-        "⚔️ Midrange",
-        "🌀 Combo",
-        "🪓 Mill",
-        "🔒 Stax",
-        "🗺️ Landfall",
-        "🛡️ Pillowfort",
-        "🌱 Ramp",
-        "⚡ Storm",
-        "💀 Aristocrats",
-        "☠️ Reanimator",
-        "👹 Sacrifice",
-        "🔥 Burn",
-        "🌟 Lifegain",
-        "🔮 Spellslinger",
-        "👥 Tokens",
-        "🎭 Blink",
-        "⏳ Time Manipulation",
-        "🌍 Domain",
-        "💫 Proliferate",
-        "📜 Saga",
-        "🎲 Chaos",
-        "🪄 Auras",
-        "🔫 Pingers",
-
-        // Themes
-        "👑 Monarch",
-        "🚀 Vehicles",
-        "💉 Infect",
-        "🩸 Madness",
-        "🌀 Morph",
-
-        // Card Types
-        "⚔️ Creature",
-        "💎 Artifact",
-        "🌔 Enchantment",
-        "📖 Sorcery",
-        "⚡ Instant",
-        "🌌 Planeswalker",
-        "🌏 Land",
-        "🪄 Aura",
-
-        // Kindred Types
-        "🐉 Kindred",
-        "🧙 Humans",
-        "⚔️ Soldiers",
-        "🛡️ Knights",
-        "🎻 Bards",
-        "🧝 Elves",
-        "🌲 Dryads",
-        "😇 Angels",
-        "🎩 Wizards",
-        "🧛 Vampires",
-        "🦴 Skeletons",
-        "💀 Zombies",
-        "👹 Demons",
-        "👾 Eldrazi",
-        "🐉 Dragons",
-        "🐠 Merfolk",
-        "🦁 Cats",
-        "🐺 Wolves",
-        "🐺 Werewolves",
-        "🦇 Bats",
-        "🐀 Rats",
-        "🦅 Birds",
-        "🦗 Insects",
-        "🍄 Fungus",
-        "🐚 Sea Creatures",
-        "🐗 Boars",
-        "🦊 Foxes",
-        "🦄 Unicorns",
-        "🐘 Elephants",
-        "🐻 Bears",
-        "🦏 Rhinos",
-        "🦂 Scorpions",
-    };
+    QStringList defaultTags = SettingsCache::instance().getVisualDeckStorageDefaultTagsList();
 
     // Merge knownTags with defaultTags, ensuring no duplicates
     QStringList combinedTags = defaultTags + knownTags + activeTags;
@@ -131,8 +55,14 @@ DeckPreviewTagDialog::DeckPreviewTagDialog(const QStringList &knownTags, const Q
     auto *addTagLayout = new QHBoxLayout();
     newTagInput_ = new QLineEdit(this);
     addTagButton_ = new QPushButton(this);
+    editButton = new QPushButton(this);
+    connect(editButton, &QPushButton::clicked, this, [=, this]() {
+        auto defaultTagsEditor = new DlgDefaultTagsEditor(nullptr);
+        defaultTagsEditor->exec();
+    });
     addTagLayout->addWidget(newTagInput_);
     addTagLayout->addWidget(addTagButton_);
+    addTagLayout->addWidget(editButton);
     mainLayout->addLayout(addTagLayout);
 
     connect(addTagButton_, &QPushButton::clicked, this, &DeckPreviewTagDialog::addTag);
@@ -141,6 +71,7 @@ DeckPreviewTagDialog::DeckPreviewTagDialog(const QStringList &knownTags, const Q
     auto *buttonLayout = new QHBoxLayout();
     okButton = new QPushButton(this);
     cancelButton = new QPushButton(this);
+
     buttonLayout->addStretch();
     buttonLayout->addWidget(okButton);
     buttonLayout->addWidget(cancelButton);
@@ -148,6 +79,10 @@ DeckPreviewTagDialog::DeckPreviewTagDialog(const QStringList &knownTags, const Q
 
     connect(okButton, &QPushButton::clicked, this, &DeckPreviewTagDialog::accept);
     connect(cancelButton, &QPushButton::clicked, this, &DeckPreviewTagDialog::reject);
+
+    connect(&SettingsCache::instance(), &SettingsCache::visualDeckStorageDefaultTagsListChanged, this,
+            &DeckPreviewTagDialog::refreshTagList);
+
     retranslateUi();
 }
 
@@ -159,7 +94,29 @@ void DeckPreviewTagDialog::retranslateUi()
     addTagButton_->setText(tr("Add Tag"));
     filterInput_->setPlaceholderText(tr("Filter tags..."));
     okButton->setText(tr("OK"));
+    editButton->setText(tr("Edit default tags"));
     cancelButton->setText(tr("Cancel"));
+}
+
+void DeckPreviewTagDialog::refreshTagList()
+{
+    // First, clear the current tags in the list view
+    tagListView_->clear();
+
+    // Get the updated list of tags from SettingsCache
+    QStringList defaultTags = SettingsCache::instance().getVisualDeckStorageDefaultTagsList();
+    QStringList combinedTags = defaultTags + knownTags_ + activeTags_;
+    combinedTags.removeDuplicates();
+
+    // Re-populate the tag list view
+    for (const auto &tag : combinedTags) {
+        auto *item = new QListWidgetItem(tagListView_);
+        auto *tagWidget = new DeckPreviewTagItemWidget(tag, activeTags_.contains(tag), this);
+        tagListView_->addItem(item);
+        tagListView_->setItemWidget(item, tagWidget);
+
+        connect(tagWidget->checkBox(), &QCheckBox::toggled, this, &DeckPreviewTagDialog::onCheckboxStateChanged);
+    }
 }
 
 QStringList DeckPreviewTagDialog::getActiveTags() const

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_dialog.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_dialog.h
@@ -24,6 +24,7 @@ private slots:
     void addTag();
     void onCheckboxStateChanged();
     void retranslateUi();
+    void refreshTagList();
 
 private:
     QLabel *instructionLabel;
@@ -32,8 +33,10 @@ private:
     QLineEdit *newTagInput_;
     QPushButton *addTagButton_;
     QPushButton *okButton;
+    QPushButton *editButton;
     QPushButton *cancelButton;
     QStringList activeTags_;
+    QStringList knownTags_;
 };
 
 #endif // DECK_PREVIEW_TAG_DIALOG_H

--- a/cockatrice/src/dialogs/dlg_default_tags_editor.cpp
+++ b/cockatrice/src/dialogs/dlg_default_tags_editor.cpp
@@ -1,0 +1,155 @@
+#include "dlg_default_tags_editor.h"
+
+#include "../settings/cache_settings.h"
+
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QListWidgetItem>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QWidget>
+
+DlgDefaultTagsEditor::DlgDefaultTagsEditor(QWidget *parent) : QDialog(parent)
+{
+    setWindowModality(Qt::WindowModal); // Steals focus from parent dialog
+
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+
+    // Input field + Add button (horizontal layout)
+    QHBoxLayout *inputLayout = new QHBoxLayout();
+    inputField = new QLineEdit(this);
+    addButton = new QPushButton(this);
+    inputLayout->addWidget(inputField);
+    inputLayout->addWidget(addButton);
+    mainLayout->addLayout(inputLayout);
+
+    // List widget for tags
+    listWidget = new QListWidget(this);
+    listWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+    listWidget->setEditTriggers(QAbstractItemView::DoubleClicked | QAbstractItemView::EditKeyPressed);
+    mainLayout->addWidget(listWidget);
+
+    // Button layout (Confirm and Cancel)
+    QHBoxLayout *buttonLayout = new QHBoxLayout();
+    confirmButton = new QPushButton(this);
+    cancelButton = new QPushButton(this);
+    buttonLayout->addWidget(confirmButton);
+    buttonLayout->addWidget(cancelButton);
+    mainLayout->addLayout(buttonLayout);
+
+    loadStringList();
+    retranslateUi();
+
+    // Connect signals
+    connect(addButton, &QPushButton::clicked, this, &DlgDefaultTagsEditor::addItem);
+    connect(cancelButton, &QPushButton::clicked, this, &DlgDefaultTagsEditor::reject); // Cancel closes dialog
+    connect(confirmButton, &QPushButton::clicked, this, &DlgDefaultTagsEditor::confirmChanges);
+    connect(inputField, &QLineEdit::returnPressed, this, &DlgDefaultTagsEditor::addItem);
+}
+
+void DlgDefaultTagsEditor::retranslateUi()
+{
+    setWindowTitle(tr("Edit Tags"));
+    addButton->setText(tr("Add"));
+    confirmButton->setText(tr("Confirm"));
+    cancelButton->setText(tr("Cancel"));
+    inputField->setPlaceholderText(tr("Enter a tag and press Enter"));
+}
+
+void DlgDefaultTagsEditor::loadStringList()
+{
+    listWidget->clear();
+    QStringList tags = SettingsCache::instance().getVisualDeckStorageDefaultTagsList();
+    for (const QString &tag : tags) {
+        auto *item = new QListWidgetItem(listWidget);
+        QWidget *widget = new QWidget(this);
+        QHBoxLayout *layout = new QHBoxLayout(widget);
+        layout->setContentsMargins(0, 0, 0, 0);
+
+        // Editable tag label
+        QLineEdit *lineEdit = new QLineEdit(tag, this);
+        lineEdit->setFrame(false);
+        lineEdit->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
+        layout->addWidget(lineEdit);
+
+        // Delete button
+        QPushButton *deleteButton = new QPushButton(tr("✖"), this);
+        deleteButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+        deleteButton->setFixedWidth(25);
+        layout->addSpacing(5); // Adds spacing before the delete button
+        layout->addWidget(deleteButton);
+
+        widget->setLayout(layout);
+        listWidget->setItemWidget(item, widget);
+
+        // Delete button signal
+        connect(deleteButton, &QPushButton::clicked, this, [this, item]() { deleteItem(item); });
+    }
+}
+
+void DlgDefaultTagsEditor::addItem()
+{
+    QString newTag = inputField->text().trimmed();
+    if (newTag.isEmpty()) {
+        QMessageBox::warning(this, tr("Invalid Input"), tr("Tag name cannot be empty!"));
+        return;
+    }
+
+    // Prevent duplicate tags
+    for (int i = 0; i < listWidget->count(); ++i) {
+        QWidget *widget = listWidget->itemWidget(listWidget->item(i));
+        if (!widget)
+            continue;
+        QLineEdit *lineEdit = widget->findChild<QLineEdit *>();
+        if (lineEdit && lineEdit->text() == newTag) {
+            QMessageBox::warning(this, tr("Duplicate Tag"), tr("This tag already exists."));
+            return;
+        }
+    }
+
+    // Add new tag
+    auto *item = new QListWidgetItem(listWidget);
+    QWidget *widget = new QWidget(this);
+    QHBoxLayout *layout = new QHBoxLayout(widget);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    // Editable tag label
+    QLineEdit *lineEdit = new QLineEdit(newTag, this);
+    lineEdit->setFrame(false);
+    layout->addWidget(lineEdit);
+
+    // Delete button
+    QPushButton *deleteButton = new QPushButton(tr("✖"), this);
+    deleteButton->setFixedSize(24, 24);
+    layout->addWidget(deleteButton);
+
+    widget->setLayout(layout);
+    listWidget->setItemWidget(item, widget);
+
+    connect(deleteButton, &QPushButton::clicked, this, [this, item]() { deleteItem(item); });
+
+    inputField->clear();
+}
+
+void DlgDefaultTagsEditor::deleteItem(QListWidgetItem *item)
+{
+    delete listWidget->takeItem(listWidget->row(item));
+}
+
+void DlgDefaultTagsEditor::confirmChanges()
+{
+    QStringList updatedList;
+    for (int i = 0; i < listWidget->count(); ++i) {
+        QWidget *widget = listWidget->itemWidget(listWidget->item(i));
+        if (!widget)
+            continue;
+        QLineEdit *lineEdit = widget->findChild<QLineEdit *>();
+        if (lineEdit) {
+            updatedList.append(lineEdit->text());
+        }
+    }
+    SettingsCache::instance().setVisualDeckStorageDefaultTagsList(updatedList);
+    accept(); // Close dialog and confirm changes
+}

--- a/cockatrice/src/dialogs/dlg_default_tags_editor.cpp
+++ b/cockatrice/src/dialogs/dlg_default_tags_editor.cpp
@@ -2,23 +2,17 @@
 
 #include "../settings/cache_settings.h"
 
-#include <QHBoxLayout>
-#include <QLineEdit>
-#include <QListWidget>
-#include <QListWidgetItem>
 #include <QMessageBox>
-#include <QPushButton>
 #include <QVBoxLayout>
-#include <QWidget>
 
 DlgDefaultTagsEditor::DlgDefaultTagsEditor(QWidget *parent) : QDialog(parent)
 {
     setWindowModality(Qt::WindowModal); // Steals focus from parent dialog
 
-    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    auto *mainLayout = new QVBoxLayout(this);
 
     // Input field + Add button (horizontal layout)
-    QHBoxLayout *inputLayout = new QHBoxLayout();
+    auto *inputLayout = new QHBoxLayout();
     inputField = new QLineEdit(this);
     addButton = new QPushButton(this);
     inputLayout->addWidget(inputField);

--- a/cockatrice/src/dialogs/dlg_default_tags_editor.h
+++ b/cockatrice/src/dialogs/dlg_default_tags_editor.h
@@ -6,14 +6,15 @@
 #include <QListWidget>
 #include <QPushButton>
 
-class DlgDefaultTagsEditor : public QDialog {
+class DlgDefaultTagsEditor : public QDialog
+{
     Q_OBJECT
 
 public:
     explicit DlgDefaultTagsEditor(QWidget *parent = nullptr);
 
-    private slots:
-        void addItem();
+private slots:
+    void addItem();
     void deleteItem(QListWidgetItem *item);
     void confirmChanges();
 
@@ -28,4 +29,4 @@ private:
     void retranslateUi();
 };
 
-#endif //DLG_DEFAULT_TAGS_EDITOR_H
+#endif // DLG_DEFAULT_TAGS_EDITOR_H

--- a/cockatrice/src/dialogs/dlg_default_tags_editor.h
+++ b/cockatrice/src/dialogs/dlg_default_tags_editor.h
@@ -1,0 +1,32 @@
+#ifndef DLG_DEFAULT_TAGS_EDITOR_H
+#define DLG_DEFAULT_TAGS_EDITOR_H
+
+#include <QDialog>
+#include <QListWidget>
+#include <QPushButton>
+#include <QHBoxLayout>
+#include <QLineEdit>
+
+class DlgDefaultTagsEditor : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit DlgDefaultTagsEditor(QWidget *parent = nullptr);
+
+    private slots:
+        void addItem();
+    void deleteItem(QListWidgetItem *item);
+    void confirmChanges();
+
+private:
+    QListWidget *listWidget;
+    QLineEdit *inputField;
+    QPushButton *addButton;
+    QPushButton *confirmButton;
+    QPushButton *cancelButton;
+
+    void loadStringList();
+    void retranslateUi();
+};
+
+#endif //DLG_DEFAULT_TAGS_EDITOR_H

--- a/cockatrice/src/dialogs/dlg_default_tags_editor.h
+++ b/cockatrice/src/dialogs/dlg_default_tags_editor.h
@@ -2,10 +2,9 @@
 #define DLG_DEFAULT_TAGS_EDITOR_H
 
 #include <QDialog>
+#include <QLineEdit>
 #include <QListWidget>
 #include <QPushButton>
-#include <QHBoxLayout>
-#include <QLineEdit>
 
 class DlgDefaultTagsEditor : public QDialog {
     Q_OBJECT

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -265,6 +265,8 @@ SettingsCache::SettingsCache()
     visualDeckStorageSortingOrder = settings->value("interface/visualdeckstoragesortingorder", 0).toInt();
     visualDeckStorageShowFolders = settings->value("interface/visualdeckstorageshowfolders", true).toBool();
     visualDeckStorageShowTagFilter = settings->value("interface/visualdeckstorageshowtagfilter", true).toBool();
+    visualDeckStorageDefaultTagsList =
+        settings->value("interface/visualdeckstoragedefaulttagslist", defaultTags).toStringList();
     visualDeckStorageSearchFolderNames = settings->value("interface/visualdeckstoragesearchfoldernames", true).toBool();
     visualDeckStorageShowBannerCardComboBox =
         settings->value("interface/visualdeckstorageshowbannercardcombobox", true).toBool();
@@ -678,6 +680,13 @@ void SettingsCache::setVisualDeckStorageShowTagFilter(QT_STATE_CHANGED_T _showTa
     visualDeckStorageShowTagFilter = _showTags;
     settings->setValue("interface/visualdeckstorageshowtagfilter", visualDeckStorageShowTagFilter);
     emit visualDeckStorageShowTagFilterChanged(visualDeckStorageShowTagFilter);
+}
+
+void SettingsCache::setVisualDeckStorageDefaultTagsList(QStringList _defaultTagsList)
+{
+    visualDeckStorageDefaultTagsList = _defaultTagsList;
+    settings->setValue("interface/visualdeckstoragedefaulttagslist", visualDeckStorageDefaultTagsList);
+    emit visualDeckStorageDefaultTagsListChanged();
 }
 
 void SettingsCache::setVisualDeckStorageSearchFolderNames(QT_STATE_CHANGED_T value)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -42,6 +42,86 @@ constexpr int NETWORK_CACHE_SIZE_MAX = 1024 * 1024;  // 1 TB
 
 #define DEFAULT_FONT_SIZE 12
 
+inline QStringList defaultTags = {
+    // Strategies
+    "🏃️ Aggro",
+    "🧙‍️ Control",
+    "⚔️ Midrange",
+    "🌀 Combo",
+    "🪓 Mill",
+    "🔒 Stax",
+    "🗺️ Landfall",
+    "🛡️ Pillowfort",
+    "🌱 Ramp",
+    "⚡ Storm",
+    "💀 Aristocrats",
+    "☠️ Reanimator",
+    "👹 Sacrifice",
+    "🔥 Burn",
+    "🌟 Lifegain",
+    "🔮 Spellslinger",
+    "👥 Tokens",
+    "🎭 Blink",
+    "⏳ Time Manipulation",
+    "🌍 Domain",
+    "💫 Proliferate",
+    "📜 Saga",
+    "🎲 Chaos",
+    "🪄 Auras",
+    "🔫 Pingers",
+
+    // Themes
+    "👑 Monarch",
+    "🚀 Vehicles",
+    "💉 Infect",
+    "🩸 Madness",
+    "🌀 Morph",
+
+    // Card Types
+    "⚔️ Creature",
+    "💎 Artifact",
+    "🌔 Enchantment",
+    "📖 Sorcery",
+    "⚡ Instant",
+    "🌌 Planeswalker",
+    "🌏 Land",
+    "🪄 Aura",
+
+    // Kindred Types
+    "🐉 Kindred",
+    "🧙 Humans",
+    "⚔️ Soldiers",
+    "🛡️ Knights",
+    "🎻 Bards",
+    "🧝 Elves",
+    "🌲 Dryads",
+    "😇 Angels",
+    "🎩 Wizards",
+    "🧛 Vampires",
+    "🦴 Skeletons",
+    "💀 Zombies",
+    "👹 Demons",
+    "👾 Eldrazi",
+    "🐉 Dragons",
+    "🐠 Merfolk",
+    "🦁 Cats",
+    "🐺 Wolves",
+    "🐺 Werewolves",
+    "🦇 Bats",
+    "🐀 Rats",
+    "🦅 Birds",
+    "🦗 Insects",
+    "🍄 Fungus",
+    "🐚 Sea Creatures",
+    "🐗 Boars",
+    "🦊 Foxes",
+    "🦄 Unicorns",
+    "🐘 Elephants",
+    "🐻 Bears",
+    "🦏 Rhinos",
+    "🦂 Scorpions",
+};
+
 class QSettings;
 
 class SettingsCache : public QObject
@@ -60,6 +140,7 @@ signals:
     void printingSelectorCardSizeChanged();
     void printingSelectorNavigationButtonsVisibleChanged();
     void visualDeckStorageShowTagFilterChanged(bool _visible);
+    void visualDeckStorageDefaultTagsListChanged();
     void visualDeckStorageShowBannerCardComboBoxChanged(bool _visible);
     void visualDeckStorageShowTagsOnDeckPreviewsChanged(bool _visible);
     void visualDeckStorageCardSizeChanged();
@@ -133,6 +214,7 @@ private:
     bool visualDeckStorageShowBannerCardComboBox;
     bool visualDeckStorageShowTagsOnDeckPreviews;
     bool visualDeckStorageShowTagFilter;
+    QStringList visualDeckStorageDefaultTagsList;
     bool visualDeckStorageSearchFolderNames;
     int visualDeckStorageCardSize;
     bool visualDeckStorageDrawUnusedColorIdentities;
@@ -415,6 +497,10 @@ public:
     bool getVisualDeckStorageShowTagFilter() const
     {
         return visualDeckStorageShowTagFilter;
+    }
+    QStringList getVisualDeckStorageDefaultTagsList() const
+    {
+        return visualDeckStorageDefaultTagsList;
     }
     bool getVisualDeckStorageSearchFolderNames() const
     {
@@ -777,6 +863,7 @@ public slots:
     void setVisualDeckStorageSortingOrder(int _visualDeckStorageSortingOrder);
     void setVisualDeckStorageShowFolders(QT_STATE_CHANGED_T value);
     void setVisualDeckStorageShowTagFilter(QT_STATE_CHANGED_T _showTags);
+    void setVisualDeckStorageDefaultTagsList(QStringList _defaultTagsList);
     void setVisualDeckStorageSearchFolderNames(QT_STATE_CHANGED_T value);
     void setVisualDeckStorageShowBannerCardComboBox(QT_STATE_CHANGED_T _showBannerCardComboBox);
     void setVisualDeckStorageShowTagsOnDeckPreviews(QT_STATE_CHANGED_T _showTags);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -211,6 +211,9 @@ void SettingsCache::setVisualDeckStorageShowFolders(QT_STATE_CHANGED_T /* value 
 void SettingsCache::setVisualDeckStorageShowTagFilter(QT_STATE_CHANGED_T /* _showTags */)
 {
 }
+void SettingsCache::setVisualDeckStorageDefaultTagsList(QStringList /* _defaultTagsList */)
+{
+}
 void SettingsCache::setVisualDeckStorageSearchFolderNames(QT_STATE_CHANGED_T /* value */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -215,6 +215,9 @@ void SettingsCache::setVisualDeckStorageShowFolders(QT_STATE_CHANGED_T /* value 
 void SettingsCache::setVisualDeckStorageShowTagFilter(QT_STATE_CHANGED_T /* _showTags */)
 {
 }
+void SettingsCache::setVisualDeckStorageDefaultTagsList(QStringList /* _defaultTagsList */)
+{
+}
 void SettingsCache::setVisualDeckStorageSearchFolderNames(QT_STATE_CHANGED_T /* value */)
 {
 }


### PR DESCRIPTION
## Related Ticket(s)
- Implements #5688

## Short roundup of the initial problem
Users have no way of editing the default suggested tags we provide.

## What will change with this Pull Request?
- Adds a new dialog that does just that
- Also persists the default tags in the settings cache now

## Screenshots
![image](https://github.com/user-attachments/assets/9a01bf2e-d8d5-4886-9291-4e4432a37bb2)
![image](https://github.com/user-attachments/assets/7584a7fc-ecbf-40c4-9c2e-ca360ec9870e)
![image](https://github.com/user-attachments/assets/d8dc79c6-a312-4a5e-8abc-f78472773c87)
![image](https://github.com/user-attachments/assets/70a0614f-2014-465f-96bf-6cfff78ba716)

