### PR TITLE
Display visual feedback of where cards will go

### DIFF
--- a/cockatrice/src/game/cards/card_drag_item.cpp
+++ b/cockatrice/src/game/cards/card_drag_item.cpp
@@ -2,8 +2,6 @@
 
 #include "../game_scene.h"
 #include "../zones/card_zone.h"
-#include "../zones/table_zone.h"
-#include "../zones/view_zone.h"
 #include "card_item.h"
 
 #include <QCursor>
@@ -15,74 +13,68 @@ CardDragItem::CardDragItem(CardItem *_item,
                            const QPointF &_hotSpot,
                            bool _faceDown,
                            AbstractCardDragItem *parentDrag)
-    : AbstractCardDragItem(_item, _hotSpot, parentDrag), id(_id), faceDown(_faceDown), occupied(false), currentZone(0)
+    : AbstractCardDragItem(_item, _hotSpot, parentDrag), id(_id), faceDown(_faceDown), currentZone(0)
 {
+}
+
+CardDragItem::~CardDragItem()
+{
+    if (currentZone) {
+        currentZone->dragLeave(this);
+        currentZone = nullptr;
+    }
 }
 
 void CardDragItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
     AbstractCardDragItem::paint(painter, option, widget);
 
-    if (occupied)
+    if (!isValid) {
         painter->fillPath(shape(), QColor(200, 0, 0, 100));
+    }
 }
 
 void CardDragItem::updatePosition(const QPointF &cursorScenePos)
 {
+    QPointF topLeftScenePos = cursorScenePos - hotSpot;
+    QPointF centerScenePos = topLeftScenePos + QPointF(CARD_WIDTH_HALF, CARD_HEIGHT_HALF);
+
+    // Use center of the card for intersection.
     QList<QGraphicsItem *> colliding =
-        scene()->items(cursorScenePos, Qt::IntersectsItemBoundingRect, Qt::DescendingOrder,
+        scene()->items(centerScenePos, Qt::IntersectsItemBoundingRect, Qt::DescendingOrder,
                        static_cast<GameScene *>(scene())->getViewTransform());
 
-    CardZone *cardZone = 0;
-    ZoneViewZone *zoneViewZone = 0;
-    for (int i = colliding.size() - 1; i >= 0; i--) {
-        CardZone *temp = qgraphicsitem_cast<CardZone *>(colliding.at(i));
-        if (!cardZone)
-            cardZone = temp;
-        if (!zoneViewZone)
-            zoneViewZone = qobject_cast<ZoneViewZone *>(temp);
-    }
-    CardZone *cursorZone = 0;
-    if (zoneViewZone)
-        cursorZone = zoneViewZone;
-    else if (cardZone)
-        cursorZone = cardZone;
-    if (!cursorZone)
-        return;
-    currentZone = cursorZone;
+    CardZone *cardZone = nullptr;
+    for (auto *item : colliding) {
+        cardZone = qgraphicsitem_cast<CardZone *>(item);
 
-    QPointF zonePos = currentZone->scenePos();
-    QPointF cursorPosInZone = cursorScenePos - zonePos;
-
-    // If we are on a Table, we center the card around the cursor, because we
-    // snap it into place and no longer see it being dragged.
-    //
-    // For other zones (where we do display the card under the cursor), we use
-    // the hotspot to feel like the card was dragged at the corresponding
-    // position.
-    TableZone *tableZone = qobject_cast<TableZone *>(cursorZone);
-    QPointF closestGridPoint;
-    if (tableZone)
-        closestGridPoint = tableZone->closestGridPoint(cursorPosInZone);
-    else
-        closestGridPoint = cursorPosInZone - hotSpot;
-
-    QPointF newPos = zonePos + closestGridPoint;
-
-    if (newPos != pos()) {
-        for (int i = 0; i < childDrags.size(); i++)
-            childDrags[i]->setPos(newPos + childDrags[i]->getHotSpot());
-        setPos(newPos);
-
-        bool newOccupied = false;
-        TableZone *table = qobject_cast<TableZone *>(cursorZone);
-        if (table)
-            if (table->getCardFromCoords(closestGridPoint))
-                newOccupied = true;
-        if (newOccupied != occupied) {
-            occupied = newOccupied;
-            update();
+        if (cardZone) {
+            break;
         }
+    }
+
+    if (cardZone != currentZone) {
+        if (currentZone) {
+            currentZone->dragLeave(this);
+            currentZone = nullptr;
+        }
+
+        if (cardZone && cardZone->dragEnter(this, centerScenePos - cardZone->scenePos())) {
+            setValid(true);
+            currentZone = cardZone;
+        } else {
+            setValid(false);
+        }
+    }
+
+    if (currentZone) {
+        currentZone->dragMove(this, centerScenePos - currentZone->scenePos());
+    }
+
+    if (topLeftScenePos != pos()) {
+        for (int i = 0; i < childDrags.size(); i++)
+            childDrags[i]->setPos(topLeftScenePos + childDrags[i]->getHotSpot());
+        setPos(topLeftScenePos);
     }
 }
 
@@ -90,29 +82,43 @@ void CardDragItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     setCursor(Qt::OpenHandCursor);
     QGraphicsScene *sc = scene();
-    QPointF sp = pos();
     sc->removeItem(this);
 
-    QList<CardDragItem *> dragItemList;
-    CardZone *startZone = static_cast<CardItem *>(item)->getZone();
-    if (currentZone && !(static_cast<CardItem *>(item)->getAttachedTo() && (startZone == currentZone))) {
-        if (!occupied) {
-            dragItemList.append(this);
-        }
-
-        for (int i = 0; i < childDrags.size(); i++) {
-            CardDragItem *c = static_cast<CardDragItem *>(childDrags[i]);
-            if (!occupied && !(static_cast<CardItem *>(c->item)->getAttachedTo() && (startZone == currentZone)) &&
-                !c->occupied) {
-                dragItemList.append(c);
-            }
-            sc->removeItem(c);
-        }
+    for (auto *childDrag : childDrags) {
+        sc->removeItem(childDrag);
     }
 
     if (currentZone) {
-        currentZone->handleDropEvent(dragItemList, startZone, (sp - currentZone->scenePos()).toPoint());
+        QPointF cursorScenePos = event->scenePos();
+        QPointF topLeftScenePos = cursorScenePos - hotSpot;
+        QPointF centerScenePos = topLeftScenePos + QPointF(CARD_WIDTH_HALF, CARD_HEIGHT_HALF);
+        currentZone->dragAccept(this, centerScenePos - currentZone->scenePos());
+        currentZone = nullptr;
     }
 
-    event->accept();
+    static_cast<CardItem *>(item)->deleteDragItem();
+    AbstractCardDragItem::mouseReleaseEvent(event);
+}
+
+CardZone *CardDragItem::getStartZone() const
+{
+    return static_cast<CardItem *>(item)->getZone();
+}
+
+QList<CardDragItem *> CardDragItem::getValidItems()
+{
+    QList<CardDragItem *> dragItemList;
+    CardZone *startZone = getStartZone();
+    if (!(static_cast<CardItem *>(item)->getAttachedTo() && startZone == currentZone)) {
+        dragItemList.append(this);
+
+        for (int i = 0; i < childDrags.size(); i++) {
+            CardDragItem *c = static_cast<CardDragItem *>(childDrags[i]);
+            if (!(static_cast<CardItem *>(c->item)->getAttachedTo() && startZone == currentZone)) {
+                dragItemList.append(c);
+            }
+        }
+    }
+
+    return dragItemList;
 }

--- a/cockatrice/src/game/cards/card_drag_item.h
+++ b/cockatrice/src/game/cards/card_drag_item.h
@@ -11,7 +11,7 @@ class CardDragItem : public AbstractCardDragItem
 private:
     int id;
     bool faceDown;
-    bool occupied;
+    bool isValid = true;
     CardZone *currentZone;
 
 public:
@@ -20,6 +20,7 @@ public:
                  const QPointF &_hotSpot,
                  bool _faceDown,
                  AbstractCardDragItem *parentDrag = 0);
+    virtual ~CardDragItem();
     int getId() const
     {
         return id;
@@ -30,6 +31,18 @@ public:
     }
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
     void updatePosition(const QPointF &cursorScenePos) override;
+
+    void setValid(bool _valid)
+    {
+        if (_valid != isValid) {
+            isValid = _valid;
+            update();
+        }
+    }
+
+    CardZone *getStartZone() const;
+
+    QList<CardDragItem *> getValidItems();
 
 protected:
     void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;

--- a/cockatrice/src/game/zones/card_zone.cpp
+++ b/cockatrice/src/game/zones/card_zone.cpp
@@ -1,11 +1,10 @@
 #include "card_zone.h"
 
 #include "../cards/card_database_manager.h"
+#include "../cards/card_drag_item.h"
 #include "../cards/card_item.h"
 #include "../player/player.h"
 #include "pb/command_move_card.pb.h"
-#include "pb/serverinfo_user.pb.h"
-#include "pile_zone.h"
 #include "view_zone.h"
 
 #include <QAction>
@@ -233,7 +232,26 @@ void CardZone::moveAllToZone()
     player->sendGameCommand(cmd);
 }
 
-QPointF CardZone::closestGridPoint(const QPointF &point)
+bool CardZone::dragEnter(CardDragItem *dragItem, const QPointF &pos)
 {
-    return point;
+    Q_UNUSED(dragItem);
+    Q_UNUSED(pos);
+
+    return true;
+}
+
+void CardZone::dragMove(CardDragItem *dragItem, const QPointF &pos)
+{
+    Q_UNUSED(dragItem);
+    Q_UNUSED(pos);
+}
+
+void CardZone::dragAccept(CardDragItem *dragItem, const QPointF &pos)
+{
+    handleDropEvent(dragItem->getValidItems(), dragItem->getStartZone(), pos.toPoint());
+}
+
+void CardZone::dragLeave(CardDragItem *dragItem)
+{
+    Q_UNUSED(dragItem);
 }

--- a/cockatrice/src/game/zones/card_zone.h
+++ b/cockatrice/src/game/zones/card_zone.h
@@ -58,6 +58,26 @@ public:
     {
         return Type;
     }
+
+    /* Called when a card is dragged on top of the zone.
+
+       Return `true` to accept the drag, `false` otherwise.
+    */
+    virtual bool dragEnter(CardDragItem *dragItem, const QPointF &pos);
+
+    /* Called when a card that has been accepted by `dragEnter` is moved over
+       the zone.
+    */
+    virtual void dragMove(CardDragItem *dragItem, const QPointF &pos);
+
+    /* Called when a card that has been accepted by `dragEnter` is dropped onto
+       the zone. */
+    virtual void dragAccept(CardDragItem *dragItem, const QPointF &pos);
+
+    /* Called when a card that has been accepted by `dragEnter` leaves the zone.
+     */
+    virtual void dragLeave(CardDragItem *dragItem);
+
     virtual void
     handleDropEvent(const QList<CardDragItem *> &dragItem, CardZone *startZone, const QPoint &dropPoint) = 0;
     CardZone(Player *_player,
@@ -114,7 +134,6 @@ public:
         return views;
     }
     virtual void reorganizeCards() = 0;
-    virtual QPointF closestGridPoint(const QPointF &point);
     bool getIsView() const
     {
         return isView;

--- a/cockatrice/src/game/zones/table_zone.h
+++ b/cockatrice/src/game/zones/table_zone.h
@@ -77,6 +77,8 @@ private:
      */
     bool active;
 
+    QGraphicsPathItem *m_feedbackItem = nullptr;
+
     bool isInverted() const;
 
 private slots:
@@ -118,6 +120,14 @@ public:
      */
     void toggleTapped();
 
+    bool dragEnter(CardDragItem *dragItem, const QPointF &pos) override;
+
+    void dragMove(CardDragItem *dragItem, const QPointF &pos) override;
+
+    void dragAccept(CardDragItem *dragItem, const QPointF &pos) override;
+
+    void dragLeave(CardDragItem *dragItem) override;
+
     /**
        See HandleDropEventByGrid
      */
@@ -132,13 +142,6 @@ public:
        @return CardItem from grid location
      */
     CardItem *getCardFromGrid(const QPoint &gridPoint) const;
-
-    /**
-       @return CardItem from coordinate location
-     */
-    CardItem *getCardFromCoords(const QPointF &point) const;
-
-    QPointF closestGridPoint(const QPointF &point) override;
 
     static int clampValidTableRow(const int row);
 
@@ -183,6 +186,8 @@ protected:
 private:
     void paintZoneOutline(QPainter *painter);
     void paintLandDivider(QPainter *painter);
+
+    void updateFeedback(CardDragItem *dragItem, const QPointF &point);
 
     /*
     Calculates card stack widths so mapping functions work properly


### PR DESCRIPTION
This is part of the code from #4974, including an improved drag-and-drop API and its use to display visual feedback of card destination on the board.

It does not include the improved logic for pushing cards around as I still need to figure out edge cases there - the logic for choosing where cards go is not changed, so some of the artifacts described in #4817 and #4975 (particularly around multi-card) are still present.

[Screencast From 2025-03-16 16-13-33.webm](https://github.com/user-attachments/assets/975554d8-280a-40b2-838f-de8460a54282)