### PR TITLE
Rename save to clipboard actions in DeckPreviewWidget

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -298,11 +298,11 @@ QMenu *DeckPreviewWidget::createRightClickMenu()
 
     connect(saveToClipboardMenu->addAction(tr("Annotated")), &QAction::triggered, this,
             [this] { deckLoader->saveToClipboard(true, true); });
-    connect(saveToClipboardMenu->addAction(tr("Annotated (No set name or number)")), &QAction::triggered, this,
+    connect(saveToClipboardMenu->addAction(tr("Annotated (No set info)")), &QAction::triggered, this,
             [this] { deckLoader->saveToClipboard(true, false); });
     connect(saveToClipboardMenu->addAction(tr("Not Annotated")), &QAction::triggered, this,
             [this] { deckLoader->saveToClipboard(false, true); });
-    connect(saveToClipboardMenu->addAction(tr("Not Annotated (No set name or number)")), &QAction::triggered, this,
+    connect(saveToClipboardMenu->addAction(tr("Not Annotated (No set info)")), &QAction::triggered, this,
             [this] { deckLoader->saveToClipboard(false, false); });
 
     menu->addSeparator();


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5702

## Short roundup of the initial problem

Forgot to also rename the save to clipboard actions in the `DeckPreviewWidget`

## What will change with this Pull Request?


## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<img width="437" alt="Screenshot 2025-03-16 at 4 07 42 PM" src="https://github.com/user-attachments/assets/b0bf3ec0-c64a-469b-b266-167c2d01885c" />

