### PR TITLE
Add CONFIGURE_DEPENDS to the GLOB_RECURSE

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 project(Cockatrice VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 
-file(GLOB_RECURSE cockatrice_CPP_FILES ${CMAKE_SOURCE_DIR}/cockatrice/src/*.cpp)
+file(GLOB_RECURSE cockatrice_CPP_FILES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/cockatrice/src/*.cpp)
 
 set(cockatrice_SOURCES ${cockatrice_CPP_FILES} ${VERSION_STRING_CPP})
 


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5716

## Short roundup of the initial problem

Turns out using GLOB to collect source files means cmake won't detect file changes. We need to add CONFIGURE_DEPENDS to get it to detect changes.

[Cmake doc](https://cmake.org/cmake/help/latest/command/file.html#glob) does recommend against using GLOB to collect source files. We can discuss whether to revert that change later, but for now, we can add CONFIGURE_DEPENDS as a temporary fix.