### PR TITLE
Disconnect setMenu on close

### DIFF
--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -265,6 +265,9 @@ void TabSupervisor::closeEvent(QCloseEvent *event)
     for (auto tabId : gameTabsToRemove) {
         gameTabs.remove(tabId);
     }
+
+    // Prevent segfaults caused by trying to set menu while the app is in the middle of destructing everything
+    disconnect(this, &TabSupervisor::setMenu, nullptr, nullptr);
 }
 
 AbstractClient *TabSupervisor::getClient() const


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5735

## Short roundup of the initial problem

Cockatrice segfaults when you close it while having a game tab as your current tab. 

The cause is that the close sequence eventually causes `QTabWidget::currentChanged` to be emitted which then triggers `TabSupervisor::updateCurrent` which then emits `TabSupervisor::setMenu` which then triggers `MainWindow::updateTabMenu` which then tries to do stuff with the tabMenu and menuBar while the app is in the middle of destructing everything which then causes a segfault

## What will change with this Pull Request?

Disconnect `TabSupervisor::setMenu` in `TabSupervisor`'s `closeEvent` so that sequence never happens.
