### PR TITLE
Avoid double `close` in `TabSupervisor`

### DIFF
--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
@@ -554,5 +554,5 @@ void AbstractTabDeckEditor::closeRequest(bool forced)
     }
 
     emit deckEditorClosing(this);
-    close();
+    deleteLater();
 }

--- a/cockatrice/src/client/tabs/tab.cpp
+++ b/cockatrice/src/client/tabs/tab.cpp
@@ -44,16 +44,7 @@ void Tab::deleteCardInfoPopup(const QString &cardName)
     }
 }
 
-/**
- * Overrides the closeEvent in order to emit a close signal
- */
-void Tab::closeEvent(QCloseEvent *event)
-{
-    emit closed();
-    event->accept();
-}
-
 void Tab::closeRequest(bool /*forced*/)
 {
-    close();
+    deleteLater();
 }

--- a/cockatrice/src/client/tabs/tab.h
+++ b/cockatrice/src/client/tabs/tab.h
@@ -13,12 +13,6 @@ class Tab : public QMainWindow
 signals:
     void userEvent(bool globalEvent = true);
     void tabTextChanged(Tab *tab, const QString &newTabText);
-    /**
-     * Emitted when the tab is closed (because Qt doesn't provide a built-in close signal)
-     * This signal is emitted from this class's overridden Tab::closeEvent method.
-     * Make sure any subclasses that override closeEvent still emit this signal from there.
-     */
-    void closed();
 
 protected:
     TabSupervisor *tabSupervisor;
@@ -29,7 +23,6 @@ protected:
 protected slots:
     void showCardInfoPopup(const QPoint &pos, const QString &cardName, const QString &providerId);
     void deleteCardInfoPopup(const QString &cardName);
-    void closeEvent(QCloseEvent *event) override;
 
 private:
     QString currentCardName, currentProviderId;

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -405,7 +405,7 @@ void TabGame::closeRequest(bool forced)
 
     emit gameClosing(this);
 
-    close();
+    deleteLater();
 }
 
 void TabGame::replayNextEvent(Player::EventProcessingOptions options)

--- a/cockatrice/src/client/tabs/tab_message.cpp
+++ b/cockatrice/src/client/tabs/tab_message.cpp
@@ -89,7 +89,7 @@ QString TabMessage::getTabText() const
 void TabMessage::closeRequest(bool /*forced*/)
 {
     emit talkClosing(this);
-    close();
+    deleteLater();
 }
 
 void TabMessage::sendMessage()

--- a/cockatrice/src/client/tabs/tab_room.cpp
+++ b/cockatrice/src/client/tabs/tab_room.cpp
@@ -175,7 +175,7 @@ void TabRoom::closeRequest(bool /*forced*/)
 {
     sendRoomCommand(prepareRoomCommand(Command_LeaveRoom()));
     emit roomClosing(this);
-    close();
+    deleteLater();
 }
 
 void TabRoom::tabActivated()


### PR DESCRIPTION
In #5447, the `TabSupervisor` logic was changed to go through `closeRequest` instead of `deleteLater`.

Unfortunately, this introduced a bug where we close every (most) tabs twice due to `closeRequest` calling `close()`, which is a high-level widget function that triggers a whole lot of events, including `QHideEvent`s, which manifests through #5697. #5735 was a tentative fix for the issue, but it mis-diagnosed the problem and does not actually fix it, as shown by #5740.

This patch makes `closeRequest` call `deleteLater` instead, which is a low-level function that doesn't trigger all those events. To make sure slots happening on tab close are still processed, use the `QObject::destroyed` signal instead of the custom `Tab::closed` event.

This also fixes what I believe was the missing piece in #5447: `TabSupervisor`'s destructor calling `TabSupervisor::stop`, which in turn sends out a bunch of signals which is never a good idea while in the middle of destruction. Instead, `TabSupervisor`'s destructor now simply deletes its (non-`QObject`) children.

I suspect that with `TabSupervisor`'s destructor no longer calling `TabSupervisor::stop` the `closeRequest` API can be simplified again; this is left for later as this PR is focused on fixing the crashes.

Supersedes #5735 and #5740.

Fixes #5697 (again).