### PR TITLE
chore: Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,12 @@
+# This file lists commits that should be ignored in `git blame` output
+# (typically commits that reformat large amount of code).
+#
+# When adding commits to this file, please include the short (one-liner)
+# description of the commit along with its hash for readability.
+#
+# Use it with:
+#
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Convert rest of source to 4-space indent
+1bc48a78491d8a666d1a833930dc3ab4a5741fb2


### PR DESCRIPTION
This file can be used to list reformatting commit that we don't want to see in `git blame` output. Currently includes a single commit that switched the source to 4-space tabs that shows up everywhere in old code.

To use, set `git config blame.ignoreRevsFile .git-blame-ignore-revs`.