### PR TITLE
DeckEditor: Initialize the `modified` flag

### DIFF
--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.h
@@ -147,7 +147,7 @@ protected:
     QAction *aCardInfoDockVisible, *aCardInfoDockFloating, *aDeckDockVisible, *aDeckDockFloating;
     QAction *aFilterDockVisible, *aFilterDockFloating, *aPrintingSelectorDockVisible, *aPrintingSelectorDockFloating;
 
-    bool modified;
+    bool modified = false;
 };
 
 #endif // TAB_GENERIC_DECK_EDITOR_H


### PR DESCRIPTION
C++ does not require compilers to zero-initialize value types, so depending on the platform (here: Linux), the deck editor starts up with an uninitialized value in the `modified` flag, which is usually not zero.

(This was driving me crazy)