### PR TITLE
hotfix: Remove menus when closing game

### DIFF
--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -256,6 +256,12 @@ void TabSupervisor::closeEvent(QCloseEvent *event)
     QSet<int> gameTabsToRemove;
     for (auto it = gameTabs.begin(), end = gameTabs.end(); it != end; ++it) {
         if (it.value()->close()) {
+            // Hotfix: the tab owns the `QMenu`s so they need to be cleared,
+            // otherwise we end up with use-after-free bugs.
+            if (it.value() == currentWidget()) {
+                emit setMenu();
+            }
+
             gameTabsToRemove.insert(it.key());
         } else {
             event->ignore();


### PR DESCRIPTION
Version of #5740 that doesn't leave freed `QMenu`s lying around.

This is a hotfix in order to be able to cut a point release with minimal changes as @RickyRister would prefer we don't rush #5741.

(Pending tests from @RickyRister to confirm it fixes the issue since I can't reproduce the crash from #5740 on my machine)