### PR TITLE
Remove redundant "show unused color identities" settings

### DIFF
--- a/cockatrice/src/client/ui/widgets/cards/additional_info/mana_symbol_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/additional_info/mana_symbol_widget.cpp
@@ -15,6 +15,9 @@ ManaSymbolWidget::ManaSymbolWidget(QWidget *parent, QString _symbol, bool _isAct
     opacityEffect = new QGraphicsOpacityEffect(this);
     setGraphicsEffect(opacityEffect);
     updateOpacity();
+
+    connect(&SettingsCache::instance(), &SettingsCache::visualDeckStorageUnusedColorIdentitiesOpacityChanged, this,
+            &ManaSymbolWidget::updateOpacity);
 }
 
 void ManaSymbolWidget::setColorActive(bool active)

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -12,6 +12,7 @@
 #include <QComboBox>
 #include <QDirIterator>
 #include <QMouseEvent>
+#include <QSpinBox>
 #include <QVBoxLayout>
 
 VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(parent), folderWidget(nullptr)
@@ -40,6 +41,7 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     refreshButton->setFixedSize(32, 32);
     connect(refreshButton, &QPushButton::clicked, this, &VisualDeckStorageWidget::refreshIfPossible);
 
+    // quick settings menu
     showFoldersCheckBox = new QCheckBox(this);
     showFoldersCheckBox->setChecked(SettingsCache::instance().getVisualDeckStorageShowFolders());
     connect(showFoldersCheckBox, &QCheckBox::QT_STATE_CHANGED, this, &VisualDeckStorageWidget::updateShowFolders);
@@ -77,6 +79,29 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     connect(searchFolderNamesCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setVisualDeckStorageSearchFolderNames);
 
+    // color identity opacity selector
+    auto unusedColorIdentityOpacityWidget = new QWidget(this);
+
+    unusedColorIdentitiesOpacityLabel = new QLabel(unusedColorIdentityOpacityWidget);
+    unusedColorIdentitiesOpacitySpinBox = new QSpinBox(unusedColorIdentityOpacityWidget);
+
+    unusedColorIdentitiesOpacitySpinBox->setMinimum(0);
+    unusedColorIdentitiesOpacitySpinBox->setMaximum(100);
+    unusedColorIdentitiesOpacitySpinBox->setValue(
+        SettingsCache::instance().getVisualDeckStorageUnusedColorIdentitiesOpacity());
+    connect(unusedColorIdentitiesOpacitySpinBox, QOverload<int>::of(&QSpinBox::valueChanged),
+            &SettingsCache::instance(), &SettingsCache::setVisualDeckStorageUnusedColorIdentitiesOpacity);
+
+    unusedColorIdentitiesOpacityLabel->setBuddy(unusedColorIdentitiesOpacitySpinBox);
+
+    unusedColorIdentitiesOpacitySpinBox->setValue(
+        SettingsCache::instance().getVisualDeckStorageUnusedColorIdentitiesOpacity());
+
+    auto unusedColorIdentityOpacityLayout = new QHBoxLayout(unusedColorIdentityOpacityWidget);
+    unusedColorIdentityOpacityLayout->setContentsMargins(11, 0, 11, 0);
+    unusedColorIdentityOpacityLayout->addWidget(unusedColorIdentitiesOpacityLabel);
+    unusedColorIdentityOpacityLayout->addWidget(unusedColorIdentitiesOpacitySpinBox);
+
     // card size slider
     cardSizeWidget = new CardSizeWidget(this, nullptr, SettingsCache::instance().getVisualDeckStorageCardSize());
 
@@ -84,9 +109,10 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     quickSettingsWidget->addSettingsWidget(showFoldersCheckBox);
     quickSettingsWidget->addSettingsWidget(tagFilterVisibilityCheckBox);
     quickSettingsWidget->addSettingsWidget(tagsOnWidgetsVisibilityCheckBox);
-    quickSettingsWidget->addSettingsWidget(drawUnusedColorIdentitiesCheckBox);
     quickSettingsWidget->addSettingsWidget(bannerCardComboBoxVisibilityCheckBox);
     quickSettingsWidget->addSettingsWidget(searchFolderNamesCheckBox);
+    quickSettingsWidget->addSettingsWidget(drawUnusedColorIdentitiesCheckBox);
+    quickSettingsWidget->addSettingsWidget(unusedColorIdentityOpacityWidget);
     quickSettingsWidget->addSettingsWidget(cardSizeWidget);
 
     searchAndSortLayout->addWidget(deckPreviewColorIdentityFilterWidget);
@@ -159,9 +185,11 @@ void VisualDeckStorageWidget::retranslateUi()
     showFoldersCheckBox->setText(tr("Show Folders"));
     tagFilterVisibilityCheckBox->setText(tr("Show Tag Filter"));
     tagsOnWidgetsVisibilityCheckBox->setText(tr("Show Tags On Deck Previews"));
-    drawUnusedColorIdentitiesCheckBox->setText(tr("Draw not contained Color Identities"));
     bannerCardComboBoxVisibilityCheckBox->setText(tr("Show Banner Card Selection Option"));
     searchFolderNamesCheckBox->setText(tr("Include Folder Names in Search"));
+    drawUnusedColorIdentitiesCheckBox->setText(tr("Draw not contained Color Identities"));
+    unusedColorIdentitiesOpacityLabel->setText(tr("Not contained Color Identities Opacity"));
+    unusedColorIdentitiesOpacitySpinBox->setSuffix("%");
 }
 
 /**

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -15,6 +15,7 @@
 #include <QCheckBox>
 #include <QFileSystemModel>
 
+class QSpinBox;
 class VisualDeckStorageSearchWidget;
 class VisualDeckStorageSortWidget;
 class VisualDeckStorageTagFilterWidget;
@@ -64,6 +65,8 @@ private:
     QCheckBox *tagFilterVisibilityCheckBox;
     QCheckBox *tagsOnWidgetsVisibilityCheckBox;
     QCheckBox *searchFolderNamesCheckBox;
+    QLabel *unusedColorIdentitiesOpacityLabel;
+    QSpinBox *unusedColorIdentitiesOpacitySpinBox;
     QScrollArea *scrollArea;
     VisualDeckStorageFolderDisplayWidget *folderWidget;
 

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -358,25 +358,8 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     showShortcutsCheckBox.setChecked(settings.getShowShortcuts());
     connect(&showShortcutsCheckBox, &QCheckBox::QT_STATE_CHANGED, this, &AppearanceSettingsPage::showShortcutsChanged);
 
-    visualDeckStorageDrawUnusedColorIdentitiesCheckBox.setChecked(
-        settings.getVisualDeckStorageDrawUnusedColorIdentities());
-    connect(&visualDeckStorageDrawUnusedColorIdentitiesCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings,
-            &SettingsCache::setVisualDeckStorageDrawUnusedColorIdentities);
-
-    visualDeckStorageUnusedColorIdentitiesOpacitySpinBox.setMinimum(0);
-    visualDeckStorageUnusedColorIdentitiesOpacitySpinBox.setMaximum(100);
-    visualDeckStorageUnusedColorIdentitiesOpacitySpinBox.setValue(
-        settings.getVisualDeckStorageUnusedColorIdentitiesOpacity());
-    connect(&visualDeckStorageUnusedColorIdentitiesOpacitySpinBox, QOverload<int>::of(&QSpinBox::valueChanged),
-            &settings, &SettingsCache::setVisualDeckStorageUnusedColorIdentitiesOpacity);
-
-    visualDeckStorageUnusedColorIdentitiesOpacityLabel.setBuddy(&visualDeckStorageUnusedColorIdentitiesOpacitySpinBox);
-
     auto *menuGrid = new QGridLayout;
     menuGrid->addWidget(&showShortcutsCheckBox, 0, 0);
-    menuGrid->addWidget(&visualDeckStorageDrawUnusedColorIdentitiesCheckBox, 1, 0);
-    menuGrid->addWidget(&visualDeckStorageUnusedColorIdentitiesOpacityLabel, 2, 0);
-    menuGrid->addWidget(&visualDeckStorageUnusedColorIdentitiesOpacitySpinBox, 2, 1);
 
     menuGroupBox = new QGroupBox;
     menuGroupBox->setLayout(menuGrid);
@@ -547,10 +530,6 @@ void AppearanceSettingsPage::retranslateUi()
 
     menuGroupBox->setTitle(tr("Menu settings"));
     showShortcutsCheckBox.setText(tr("Show keyboard shortcuts in right-click menus"));
-    visualDeckStorageDrawUnusedColorIdentitiesCheckBox.setText(
-        tr("Draw missing color identities in visual deck storage without color label"));
-    visualDeckStorageUnusedColorIdentitiesOpacityLabel.setText(tr("Missing color identity opacity"));
-    visualDeckStorageUnusedColorIdentitiesOpacitySpinBox.setSuffix("%");
 
     cardsGroupBox->setTitle(tr("Card rendering"));
     displayCardNamesCheckBox.setText(tr("Display card names on cards having a picture"));

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -102,9 +102,6 @@ private:
     QLabel minPlayersForMultiColumnLayoutLabel;
     QLabel maxFontSizeForCardsLabel;
     QCheckBox showShortcutsCheckBox;
-    QCheckBox visualDeckStorageDrawUnusedColorIdentitiesCheckBox;
-    QLabel visualDeckStorageUnusedColorIdentitiesOpacityLabel;
-    QSpinBox visualDeckStorageUnusedColorIdentitiesOpacitySpinBox;
     QCheckBox displayCardNamesCheckBox;
     QCheckBox autoRotateSidewaysLayoutCardsCheckBox;
     QCheckBox overrideAllCardArtWithPersonalPreferenceCheckBox;

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -721,6 +721,7 @@ void SettingsCache::setVisualDeckStorageUnusedColorIdentitiesOpacity(int _visual
     visualDeckStorageUnusedColorIdentitiesOpacity = _visualDeckStorageUnusedColorIdentitiesOpacity;
     settings->setValue("interface/visualdeckstorageunusedcoloridentitiesopacity",
                        visualDeckStorageUnusedColorIdentitiesOpacity);
+    emit visualDeckStorageUnusedColorIdentitiesOpacityChanged(visualDeckStorageUnusedColorIdentitiesOpacity);
 }
 
 void SettingsCache::setVisualDeckStoragePromptForConversion(QT_STATE_CHANGED_T _visualDeckStoragePromptForConversion)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -64,6 +64,7 @@ signals:
     void visualDeckStorageShowTagsOnDeckPreviewsChanged(bool _visible);
     void visualDeckStorageCardSizeChanged();
     void visualDeckStorageDrawUnusedColorIdentitiesChanged(bool _visible);
+    void visualDeckStorageUnusedColorIdentitiesOpacityChanged(bool value);
     void visualDeckStorageInGameChanged(bool enabled);
     void horizontalHandChanged();
     void handJustificationChanged();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem

We have the "show unused color identities" settings in both the VDS dropdown menu as well as the settings window.

## What will change with this Pull Request?
- Remove the settings from the settings window
- Add the opacity setting to the VDS dropdown menu
- Switch around the order of the VDS dropdown menu so the two settings are next to each other


https://github.com/user-attachments/assets/1b28a1fe-3abc-46cc-929c-e606c1597c40

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<img width="372" alt="Screenshot 2025-03-17 at 10 25 28 PM" src="https://github.com/user-attachments/assets/f90da54e-755d-467d-8439-41c64fc5ff5a" />

<img width="600" alt="Screenshot 2025-03-17 at 10 41 04 PM" src="https://github.com/user-attachments/assets/bd6bd562-7e23-46d5-82f0-ee8937886cc3" />


