### PR TITLE
Fix AttachTo tokens not having card info

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -2064,7 +2064,6 @@ void Player::createCard(const CardItem *sourceCard,
             cmd.set_target_zone("table"); // We currently only support creating tokens on the table
             cmd.set_target_card_id(sourceCard->getId());
             cmd.set_target_mode(Command_CreateToken::ATTACH_TO);
-            cmd.set_card_provider_id(sourceCard->getProviderId().toStdString());
             break;
 
         case CardRelation::TransformInto:


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5746
- Fixes bug introduced in #5182

## Short roundup of the initial problem

Tokens that have the `AttachTo` property do not have card info when created, causing them to not have art or text.

The cause is that when creating an `AttachTo` token, the providerId of the token is set to the providerId of the sourceCard. This is incorrect. We should only be doing that for `TransformInto` tokens.

This leads to the token having an invalid cardName + providerId combination. Our code currently does not fall back to the default printing for cardName, and instead just gives up and uses an empty info.

## What will change with this Pull Request?

- Leave the providerId blank

https://github.com/user-attachments/assets/dea65913-aee5-4272-aded-a0b443d72909


