### PR TITLE
Filter out non-deck files when building VDS

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
@@ -58,6 +58,12 @@ void VisualDeckStorageFolderDisplayWidget::refreshUi()
     header->setText(bannerText);
 }
 
+/**
+ * Gets all files in the directory that have a .txt or .cod extension
+ *
+ * @param filePath The directory to search through
+ * @param recursive Whether to search through subdirectories
+ */
 static QStringList getAllFiles(const QString &filePath, bool recursive)
 {
     QStringList allFiles;
@@ -65,7 +71,7 @@ static QStringList getAllFiles(const QString &filePath, bool recursive)
     // QDirIterator with QDir::Files ensures only files are listed (no directories)
     auto flags =
         recursive ? QDirIterator::Subdirectories | QDirIterator::FollowSymlinks : QDirIterator::NoIteratorFlags;
-    QDirIterator it(filePath, QDir::Files, flags);
+    QDirIterator it(filePath, {"*.txt", "*.cod"}, QDir::Files, flags);
 
     while (it.hasNext()) {
         allFiles << it.next(); // Add each file path to the list


### PR DESCRIPTION
## Short roundup of the initial problem

Some users have reported VDS loading being very slow. The cause seems to be that they also have some other files in their deck folder, including a large pdf. The VDS still attempts to parse that large file.

## What will change with this Pull Request?

- Filter out non-`text` or `cod` files in the `QDirIterator`