### PR TITLE
Consolidate accepted decklist file extensions

### DIFF
--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
@@ -355,7 +355,7 @@ bool AbstractTabDeckEditor::actSaveDeckAs()
     dialog.setDirectory(SettingsCache::instance().getDeckPath());
     dialog.setAcceptMode(QFileDialog::AcceptSave);
     dialog.setDefaultSuffix("cod");
-    dialog.setNameFilters(DeckLoader::fileNameFilters);
+    dialog.setNameFilters(DeckLoader::FILE_NAME_FILTERS);
     dialog.selectFile(getDeckList()->getName().trimmed());
     if (!dialog.exec())
         return false;

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
@@ -71,7 +71,7 @@ static QStringList getAllFiles(const QString &filePath, bool recursive)
     // QDirIterator with QDir::Files ensures only files are listed (no directories)
     auto flags =
         recursive ? QDirIterator::Subdirectories | QDirIterator::FollowSymlinks : QDirIterator::NoIteratorFlags;
-    QDirIterator it(filePath, {"*.txt", "*.cod"}, QDir::Files, flags);
+    QDirIterator it(filePath, DeckLoader::ACCEPTED_FILE_EXTENSIONS, QDir::Files, flags);
 
     while (it.hasNext()) {
         allFiles << it.next(); // Add each file path to the list

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -16,9 +16,10 @@
 #include <QStringList>
 #include <QtConcurrentRun>
 
-const QStringList DeckLoader::fileNameFilters = QStringList()
-                                                << QObject::tr("Common deck formats (*.cod *.dec *.dek *.txt *.mwDeck)")
-                                                << QObject::tr("All files (*.*)");
+const QStringList DeckLoader::ACCEPTED_FILE_EXTENSIONS = {"*.cod", "*.dec", "*.dek", "*.txt", "*.mwDeck"};
+
+const QStringList DeckLoader::fileNameFilters = {tr("Common deck formats (%1)").arg(ACCEPTED_FILE_EXTENSIONS.join(" ")),
+                                                 tr("All files (*.*)")};
 
 DeckLoader::DeckLoader() : DeckList(), lastFileName(QString()), lastFileFormat(CockatriceFormat), lastRemoteDeckId(-1)
 {

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -18,8 +18,8 @@
 
 const QStringList DeckLoader::ACCEPTED_FILE_EXTENSIONS = {"*.cod", "*.dec", "*.dek", "*.txt", "*.mwDeck"};
 
-const QStringList DeckLoader::fileNameFilters = {tr("Common deck formats (%1)").arg(ACCEPTED_FILE_EXTENSIONS.join(" ")),
-                                                 tr("All files (*.*)")};
+const QStringList DeckLoader::FILE_NAME_FILTERS = {
+    tr("Common deck formats (%1)").arg(ACCEPTED_FILE_EXTENSIONS.join(" ")), tr("All files (*.*)")};
 
 DeckLoader::DeckLoader() : DeckList(), lastFileName(QString()), lastFileFormat(CockatriceFormat), lastRemoteDeckId(-1)
 {

--- a/cockatrice/src/deck/deck_loader.h
+++ b/cockatrice/src/deck/deck_loader.h
@@ -25,7 +25,11 @@ public:
      * Supported file extensions for decklist files
      */
     static const QStringList ACCEPTED_FILE_EXTENSIONS;
-    static const QStringList fileNameFilters;
+
+    /**
+     * For use with `QFileDialog::setNameFilters`
+     */
+    static const QStringList FILE_NAME_FILTERS;
 
 private:
     QString lastFileName;

--- a/cockatrice/src/deck/deck_loader.h
+++ b/cockatrice/src/deck/deck_loader.h
@@ -20,6 +20,11 @@ public:
         PlainTextFormat,
         CockatriceFormat
     };
+
+    /**
+     * Supported file extensions for decklist files
+     */
+    static const QStringList ACCEPTED_FILE_EXTENSIONS;
     static const QStringList fileNameFilters;
 
 private:

--- a/cockatrice/src/dialogs/dlg_load_deck.cpp
+++ b/cockatrice/src/dialogs/dlg_load_deck.cpp
@@ -11,7 +11,7 @@ DlgLoadDeck::DlgLoadDeck(QWidget *parent) : QFileDialog(parent, tr("Load Deck"))
     }
 
     setDirectory(startingDir);
-    setNameFilters(DeckLoader::fileNameFilters);
+    setNameFilters(DeckLoader::FILE_NAME_FILTERS);
 
     connect(this, &DlgLoadDeck::accepted, this, &DlgLoadDeck::actAccepted);
 }


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5748

## Short roundup of the initial problem

The change in #5748 that filters out non-deck files ends up filtering out file extensions that cockatrice does support.

## What will change with this Pull Request?

- Create static const in DeckLoader that contains the Cockatrice's accepted decklist file extensions and use that list in the VDS file filter.
- Rename the existing static const in DeckLoader
