### PR TITLE
Fix StackZone crash when divideCardSpaceInZone overflows

### DIFF
--- a/cockatrice/resources/config/qtlogging.ini
+++ b/cockatrice/resources/config/qtlogging.ini
@@ -47,8 +47,6 @@
 # card_info = false
 # card_list = false
 
-# stack_zone = false
-
 flow_layout.debug = false
 flow_widget.debug = false
 flow_widget.size.debug = false

--- a/cockatrice/src/game/zones/stack_zone.cpp
+++ b/cockatrice/src/game/zones/stack_zone.cpp
@@ -66,26 +66,25 @@ void StackZone::handleDropEvent(const QList<CardDragItem *> &dragItems, CardZone
     cmd.set_target_zone(getName().toStdString());
 
     int index = 0;
-    if (cards.isEmpty()) {
-        index = 0;
-    } else {
+
+    if (!cards.isEmpty()) {
         const auto cardCount = static_cast<int>(cards.size());
         const auto &card = cards.at(0);
 
-        if (card == nullptr) {
-            qCWarning(StackZoneLog) << "Attempted to move card from" << startZone->getName() << ", but was null";
-            return;
-        }
-
         index = qRound(divideCardSpaceInZone(dropPoint.y(), cardCount, boundingRect().height(),
                                              card->boundingRect().height(), true));
-    }
 
-    if (startZone == this) {
-        const auto &dragItem = dragItems.at(0);
-        const auto &card = cards.at(index);
-        if (card != nullptr && dragItem != nullptr && card->getId() == dragItem->getId()) {
-            return;
+        // divideCardSpaceInZone is not guaranteed to return a valid index
+        // currently, so clamp it to avoid crashes.
+        index = qBound(0, index, cardCount - 1);
+
+        if (startZone == this) {
+            const auto &dragItem = dragItems.at(0);
+            const auto &card = cards.at(index);
+
+            if (card->getId() == dragItem->getId()) {
+                return;
+            }
         }
     }
 

--- a/cockatrice/src/game/zones/stack_zone.h
+++ b/cockatrice/src/game/zones/stack_zone.h
@@ -3,8 +3,6 @@
 
 #include "select_zone.h"
 
-inline Q_LOGGING_CATEGORY(StackZoneLog, "stack_zone");
-
 class StackZone : public SelectZone
 {
     Q_OBJECT


### PR DESCRIPTION
The divideCardSpaceInZone function introduced in #4930 is buggy and sometimes returns an index that is too large for the current zone, which causes us to call `cards.at(index)` with an `index` that's bigger than the amount of cards.

This is the bug that #5609 intended to fix but was improperly diagnosed. Remove part of #5609 as the cases it is guarding against (e.g. null card pointer) cannot actually happen.

Note: `divideCardSpaceInZone` can probably be fixed, but I don't really want to spend time trying to understand how to fix it as I plan on removing it entirely in the new drag-and-drop implementation I'm working on.

Also, no fix is needed for `HandZone` because the drop calculation is done differently and doesn't use `divideCardSpaceInZone` (it only uses the version with `reverse = false` in `reorganizeCards`, but only the version with `reverse = true` is buggy).