### PR TITLE
Remember past entries in "reveal card until X" window

### DIFF
--- a/cockatrice/src/dialogs/dlg_move_top_cards_until.h
+++ b/cockatrice/src/dialogs/dlg_move_top_cards_until.h
@@ -2,10 +2,10 @@
 #define DLG_MOVE_TOP_CARDS_UNTIL_H
 
 #include <QCheckBox>
+#include <QComboBox>
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QLabel>
-#include <QLineEdit>
 #include <QSpinBox>
 
 class FilterString;
@@ -15,7 +15,7 @@ class DlgMoveTopCardsUntil : public QDialog
     Q_OBJECT
 
     QLabel *exprLabel, *numberOfHitsLabel;
-    QLineEdit *exprEdit;
+    QComboBox *exprComboBox;
     QSpinBox *numberOfHitsEdit;
     QDialogButtonBox *buttonBox;
     QCheckBox *autoPlayCheckBox;
@@ -25,10 +25,11 @@ class DlgMoveTopCardsUntil : public QDialog
 
 public:
     explicit DlgMoveTopCardsUntil(QWidget *parent = nullptr,
-                                  QString expr = QString(),
+                                  QStringList exprs = QStringList(),
                                   uint numberOfHits = 1,
                                   bool autoPlay = false);
     QString getExpr() const;
+    QStringList getExprs() const;
     uint getNumberOfHits() const;
     bool isAutoPlay() const;
 };

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -1443,19 +1443,20 @@ void Player::actMoveTopCardsUntil()
 {
     stopMoveTopCardsUntil();
 
-    DlgMoveTopCardsUntil dlg(game, movingCardsUntilExpr, movingCardsUntilNumberOfHits, movingCardsUntilAutoPlay);
+    DlgMoveTopCardsUntil dlg(game, movingCardsUntilExprs, movingCardsUntilNumberOfHits, movingCardsUntilAutoPlay);
     if (!dlg.exec()) {
         return;
     }
 
-    movingCardsUntilExpr = dlg.getExpr();
+    auto expr = dlg.getExpr();
+    movingCardsUntilExprs = dlg.getExprs();
     movingCardsUntilNumberOfHits = dlg.getNumberOfHits();
     movingCardsUntilAutoPlay = dlg.isAutoPlay();
 
     if (zones.value("deck")->getCards().empty()) {
         stopMoveTopCardsUntil();
     } else {
-        movingCardsUntilFilter = FilterString(movingCardsUntilExpr);
+        movingCardsUntilFilter = FilterString(expr);
         movingCardsUntilCounter = movingCardsUntilNumberOfHits;
         movingCardsUntil = true;
         actMoveTopCardToPlay();

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -279,7 +279,7 @@ private:
 
     bool movingCardsUntil;
     QTimer *moveTopCardTimer;
-    QString movingCardsUntilExpr = {};
+    QStringList movingCardsUntilExprs = {};
     int movingCardsUntilNumberOfHits = 1;
     bool movingCardsUntilAutoPlay = false;
     FilterString movingCardsUntilFilter;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5585

## Short roundup of the initial problem



## What will change with this Pull Request?


https://github.com/user-attachments/assets/16be69f3-9f9e-43a9-b417-59bc3eed0dea

- Changed the `QLineEdit` in the dlg window to a editable `QComboBox`
- Save a `QStringList` of recent expressions in `Player` instead of just the most recent string, and load that string list into the dlg
- Manually move currently selected option to the top of the expr list on each confirm, so that the drop down is always in order of most recently used

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
<img width="400" src="https://github.com/user-attachments/assets/bca6bbaa-771a-441b-a9c2-fa41910b91e9" />


