### PR TITLE
Revert "Use native hover events (#5722)"

### DIFF
--- a/cockatrice/src/game/cards/abstract_card_item.h
+++ b/cockatrice/src/game/cards/abstract_card_item.h
@@ -24,6 +24,7 @@ protected:
     QColor bgColor;
 
 private:
+    bool isHovered;
     qreal realZValue;
 private slots:
     void pixmapUpdated();
@@ -85,6 +86,7 @@ public:
         return realZValue;
     }
     void setRealZValue(qreal _zValue);
+    void setHovered(bool _hovered);
     QString getColor() const
     {
         return color;
@@ -100,6 +102,7 @@ public:
         return facedown;
     }
     void setFaceDown(bool _facedown);
+    void processHoverEvent();
     void deleteCardInfoPopup()
     {
         emit deleteCardInfoPopup(name);
@@ -111,9 +114,6 @@ protected:
     void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
     QVariant itemChange(QGraphicsItem::GraphicsItemChange change, const QVariant &value) override;
     void cacheBgColor();
-
-    void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
-    void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
 };
 
 #endif

--- a/cockatrice/src/game/cards/card_item.cpp
+++ b/cockatrice/src/game/cards/card_item.cpp
@@ -469,6 +469,7 @@ bool CardItem::animationEvent()
                      .translate(CARD_WIDTH_HALF, CARD_HEIGHT_HALF)
                      .rotate(tapAngle)
                      .translate(-CARD_WIDTH_HALF, -CARD_HEIGHT_HALF));
+    setHovered(false);
     update();
 
     return animationIncomplete;

--- a/cockatrice/src/game/deckview/deck_view.cpp
+++ b/cockatrice/src/game/deckview/deck_view.cpp
@@ -158,6 +158,12 @@ void DeckView::mouseDoubleClickEvent(QMouseEvent *event)
     }
 }
 
+void DeckViewCard::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
+{
+    event->accept();
+    processHoverEvent();
+}
+
 DeckViewCardContainer::DeckViewCardContainer(const QString &_name) : QGraphicsItem(), name(_name), width(0), height(0)
 {
     setCacheMode(DeviceCoordinateCache);

--- a/cockatrice/src/game/deckview/deck_view.h
+++ b/cockatrice/src/game/deckview/deck_view.h
@@ -37,6 +37,7 @@ public:
 
 protected:
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
+    void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
 };
 
 class DeckViewCardDragItem : public AbstractCardDragItem

--- a/cockatrice/src/game/game_scene.h
+++ b/cockatrice/src/game/game_scene.h
@@ -30,9 +30,11 @@ private:
     QList<QList<Player *>> playersByColumn;
     QList<ZoneViewWidget *> zoneViews;
     QSize viewSize;
+    QPointer<CardItem> hoveredCard;
     QBasicTimer *animationTimer;
     QSet<CardItem *> cardsToAnimate;
     int playerRotation;
+    void updateHover(const QPointF &scenePos);
 
 public:
     explicit GameScene(PhasesToolbar *_phasesToolbar, QObject *parent = nullptr);
@@ -63,6 +65,7 @@ public slots:
     void rearrange();
 
 protected:
+    bool event(QEvent *event) override;
     void timerEvent(QTimerEvent *event) override;
 signals:
     void sigStartRubberBand(const QPointF &selectionOrigin);

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -2386,6 +2386,7 @@ void Player::eventMoveCard(const Event_MoveCard &event, const GameEventContext &
     card->setFaceDown(event.face_down());
     if (startZone != targetZone) {
         card->setBeingPointedAt(false);
+        card->setHovered(false);
 
         const QList<CardItem *> &attachedCards = card->getAttachedCards();
         for (auto attachedCard : attachedCards) {

--- a/cockatrice/src/game/zones/pile_zone.cpp
+++ b/cockatrice/src/game/zones/pile_zone.cpp
@@ -131,7 +131,6 @@ void PileZone::mouseReleaseEvent(QGraphicsSceneMouseEvent * /*event*/)
 void PileZone::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 {
     if (!cards.isEmpty())
-        emit cards[0]->hovered(cards[0]);
-
+        cards[0]->processHoverEvent();
     QGraphicsItem::hoverEnterEvent(event);
 }


### PR DESCRIPTION
This reverts commit e4f40a82a2f26ac22c27d1d08365624613d118e2.

This change had unintended consequences in the hover behavior, reverting for now.