### PR TITLE
Fix card menu not unsetting in local multiplayer

### DIFF
--- a/cockatrice/src/game/cards/card_item.cpp
+++ b/cockatrice/src/game/cards/card_item.cpp
@@ -496,6 +496,7 @@ QVariant CardItem::itemChange(GraphicsItemChange change, const QVariant &value)
             // If selection is cleared while multiple cards are selected, there might still be items in the selection
             // when this itemChange triggers.
             // Delay empty check by 1 frame to ensure the entire selection is cleared first.
+            // TODO: This is a temp fix that still leaves bugs (see #5764). We need to rework card menu logic
             QTimer::singleShot(1, this, [this] {
                 if (scene() && !hasCardsOwnedBy(scene()->selectedItems(), owner)) {
                     owner->setCardMenu(nullptr);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes issue introduced in #5376

## Short roundup of the initial problem

In local multiplayer games, card menus would sometimes fail to be unset when a multi-selection is deselected. 
The order that the itemChanged events get triggered in is inconsistent, so sometimes the `scene()->selectedItems().isEmpty()` check will fail, and not cause the menu to be unset.

With both card menus active at the same time, this causes multiple actions with the same shortcut to be active. Qt will just ignore conflicting shortcuts, thus causing the behavior that shortcuts sometimes stop working in local multiplayer games

## What will change with this Pull Request?

- Put the empty selection check on a 1 frame timer. 
  - This ensures that if a multi-selection deslection happens, the empty check will occur after the selection actually gets cleared.
  - Dunno if the introduces the possibility of a use-after-free bug. I tested closing the game while having a selection a few times, and no crashes so far
- Also check the owner of the card when doing the empty check.
  -  Fixes the edge case of selecting one player's cards then directly selecting the other player's cards causing menu to not get unset, since the empty check fails since there is always a selected card during the sequence
