### PR TITLE
Fix delete action in filters not working

### DIFF
--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_filter_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_filter_dock_widget.cpp
@@ -96,11 +96,11 @@ void DeckEditorFilterDockWidget::filterViewCustomContextMenu(const QPoint &point
 
     action = menu.addAction(QString("delete"));
     action->setData(point);
-    connect(&menu, SIGNAL(triggered(QAction *)), this, SLOT(filterRemove(QAction *)));
+    connect(&menu, &QMenu::triggered, this, &DeckEditorFilterDockWidget::filterRemove);
     menu.exec(filterView->mapToGlobal(point));
 }
 
-void DeckEditorFilterDockWidget::filterRemove(QAction *action)
+void DeckEditorFilterDockWidget::filterRemove(const QAction *action)
 {
     QPoint point;
     QModelIndex idx;

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_filter_dock_widget.h
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_filter_dock_widget.h
@@ -28,7 +28,7 @@ private:
     KeySignals filterViewKeySignals;
     QWidget *filterBox;
 
-    void filterRemove(QAction *action);
+    void filterRemove(const QAction *action);
 
 private slots:
     void filterViewCustomContextMenu(const QPoint &point);

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_filter_dock_widget.h
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_filter_dock_widget.h
@@ -28,10 +28,9 @@ private:
     KeySignals filterViewKeySignals;
     QWidget *filterBox;
 
-    void filterRemove(const QAction *action);
-
 private slots:
     void filterViewCustomContextMenu(const QPoint &point);
+    void filterRemove(const QAction *action);
     void actClearFilterAll();
     void actClearFilterOne();
     void refreshShortcuts();


### PR DESCRIPTION
## Short roundup of the initial problem

Delete action in right click menu in deck editor tab's filters dock doesn't work

## What will change with this Pull Request?

- It works now

https://github.com/user-attachments/assets/3577e859-da0d-4bef-8069-bdd7d4c529bd
