### PR TITLE
Hardcode default log level for FlowWidget/FlowLayout

### DIFF
--- a/cockatrice/resources/config/qtlogging.ini
+++ b/cockatrice/resources/config/qtlogging.ini
@@ -47,9 +47,9 @@
 # card_info = false
 # card_list = false
 
-flow_layout.debug = false
-flow_widget.debug = false
-flow_widget.size.debug = false
+#flow_layout = false
+#flow_widget = false
+#flow_widget.size = false
 
 # pixel_map_generator = false
 

--- a/cockatrice/src/client/ui/layouts/flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/flow_layout.h
@@ -7,7 +7,7 @@
 #include <QWidget>
 #include <qstyle.h>
 
-inline Q_LOGGING_CATEGORY(FlowLayoutLog, "flow_layout");
+inline Q_LOGGING_CATEGORY(FlowLayoutLog, "flow_layout", QtInfoMsg);
 
 class FlowLayout : public QLayout
 {

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.h
@@ -7,8 +7,8 @@
 #include <QWidget>
 #include <qscrollarea.h>
 
-inline Q_LOGGING_CATEGORY(FlowWidgetLog, "flow_widget");
-inline Q_LOGGING_CATEGORY(FlowWidgetSizeLog, "flow_widget.size");
+inline Q_LOGGING_CATEGORY(FlowWidgetLog, "flow_widget", QtInfoMsg);
+inline Q_LOGGING_CATEGORY(FlowWidgetSizeLog, "flow_widget.size", QtInfoMsg);
 
 class FlowWidget final : public QWidget
 {


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5576

## Short roundup of the initial problem

We already know that `flow_widget` log spam causes large amounts of lag in the VDS, so we turn off those loggers by default. However, this is done in the `qtlogging.ini`, which means a misconfigured Cockatrice not pointing to the correct log config will cause the lag to appear.

## What will change with this Pull Request?

- Hardcode the default log level for `FlowWidget` and `FlowLayout` to be above debug level, independent of the log config. (see [docs](https://doc.qt.io/qt-6/qloggingcategory.html#default-category-configuration))

