### PR TITLE
Fix crash when right click floating card info window

### DIFF
--- a/cockatrice/resources/config/qtlogging.ini
+++ b/cockatrice/resources/config/qtlogging.ini
@@ -51,6 +51,8 @@
 #flow_widget = false
 #flow_widget.size = false
 
+# card_info_picture_widget = false
+
 # pixel_map_generator = false
 
 # filter_string = false

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
@@ -312,11 +312,26 @@ QMenu *CardInfoPictureWidget::createViewRelatedCardsMenu()
     return viewRelatedCards;
 }
 
+/**
+ * Finds the single instance of the MainWindow in this application.
+ */
+static MainWindow *findMainWindow()
+{
+    for (auto widget : QApplication::topLevelWidgets()) {
+        if (auto mainWindow = qobject_cast<MainWindow *>(widget)) {
+            return mainWindow;
+        }
+    }
+    // This code should be unreachable
+    qCritical() << "Could not find MainWindow in QApplication::topLevelWidgets";
+    return nullptr;
+}
+
 QMenu *CardInfoPictureWidget::createAddToOpenDeckMenu()
 {
     auto addToOpenDeckMenu = new QMenu(tr("Add card to deck"));
 
-    auto *mainWindow = qobject_cast<MainWindow *>(window());
+    auto mainWindow = findMainWindow();
     QList<AbstractTabDeckEditor *> deckEditorTabs = mainWindow->getTabSupervisor()->getDeckEditorTabs();
 
     if (deckEditorTabs.isEmpty()) {

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
@@ -7,6 +7,8 @@
 #include <QTimer>
 #include <QWidget>
 
+inline Q_LOGGING_CATEGORY(CardInfoPictureWidgetLog, "card_info_picture_widget");
+
 class AbstractCardItem;
 class QMenu;
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5766

## Short roundup of the initial problem

`CardInfoPictureWidget` segfaults if you right click it while it's floating.

This is because the code to create the "add to deck editor" submenu assumes that calling `window()` will return the app's `MainWindow` instance. This does not work if the widget is floating, since it's no longer part of the main window.

## What will change with this Pull Request?

- Iterate through `QApplication::topLevelWidgets` to find the `MainWindow`
  - This should work regardless of whether the widget is floating
- Add logging to to `card_info_picture_widget` in case `MainWindow` fails to be found

https://github.com/user-attachments/assets/5a91115c-5f89-4ab7-b94f-9a5b124bd5fe
