### PR TITLE
fix: Use isRebalanced to detect Arena cards

### DIFF
--- a/cockatrice/src/dialogs/dlg_manage_sets.cpp
+++ b/cockatrice/src/dialogs/dlg_manage_sets.cpp
@@ -165,7 +165,7 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
 
     includeRebalancedCards = SettingsCache::instance().getIncludeRebalancedCards();
     QCheckBox *includeRebalancedCardsCheckBox =
-        new QCheckBox(tr("Include rebalanced (Arena) cards in regular sets [requires restart]"));
+        new QCheckBox(tr("Include cards rebalanced for Alchemy [requires restart]"));
     includeRebalancedCardsCheckBox->setChecked(includeRebalancedCards);
     connect(includeRebalancedCardsCheckBox, &QAbstractButton::toggled, this, &WndSets::includeRebalancedCardsChanged);
 

--- a/cockatrice/src/dialogs/dlg_manage_sets.cpp
+++ b/cockatrice/src/dialogs/dlg_manage_sets.cpp
@@ -163,10 +163,11 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     sortWarning->setLayout(sortWarningLayout);
     sortWarning->setVisible(false);
 
-    includeOnlineOnlyCards = SettingsCache::instance().getIncludeOnlineOnlyCards();
-    QCheckBox *onlineOnly = new QCheckBox(tr("Include online-only (Arena) cards [requires restart]"));
-    onlineOnly->setChecked(includeOnlineOnlyCards);
-    connect(onlineOnly, &QAbstractButton::toggled, this, &WndSets::includeOnlineOnlyCardsChanged);
+    includeRebalancedCards = SettingsCache::instance().getIncludeRebalancedCards();
+    QCheckBox *includeRebalancedCardsCheckBox =
+        new QCheckBox(tr("Include rebalanced (Arena) cards in regular sets [requires restart]"));
+    includeRebalancedCardsCheckBox->setChecked(includeRebalancedCards);
+    connect(includeRebalancedCardsCheckBox, &QAbstractButton::toggled, this, &WndSets::includeRebalancedCardsChanged);
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actSave()));
@@ -181,7 +182,7 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     mainLayout->addWidget(enableSomeButton, 2, 1);
     mainLayout->addWidget(disableSomeButton, 2, 2);
     mainLayout->addWidget(sortWarning, 3, 1, 1, 2);
-    mainLayout->addWidget(onlineOnly, 4, 1, 1, 2);
+    mainLayout->addWidget(includeRebalancedCardsCheckBox, 4, 1, 1, 2);
     mainLayout->addWidget(hintsGroupBox, 5, 1, 1, 2);
     mainLayout->addWidget(buttonBox, 6, 1, 1, 2);
     mainLayout->setColumnStretch(1, 1);
@@ -246,15 +247,15 @@ void WndSets::rebuildMainLayout(int actionToTake)
     }
 }
 
-void WndSets::includeOnlineOnlyCardsChanged(bool _includeOnlineOnlyCards)
+void WndSets::includeRebalancedCardsChanged(bool _includeRebalancedCards)
 {
-    includeOnlineOnlyCards = _includeOnlineOnlyCards;
+    includeRebalancedCards = _includeRebalancedCards;
 }
 
 void WndSets::actSave()
 {
     model->save(CardDatabaseManager::getInstance());
-    SettingsCache::instance().setIncludeOnlineOnlyCards(includeOnlineOnlyCards);
+    SettingsCache::instance().setIncludeRebalancedCards(includeRebalancedCards);
     PictureLoader::clearPixmapCache();
     close();
 }

--- a/cockatrice/src/dialogs/dlg_manage_sets.h
+++ b/cockatrice/src/dialogs/dlg_manage_sets.h
@@ -44,7 +44,7 @@ private:
     void saveHeaderState();
     void rebuildMainLayout(int actionToTake);
     bool setOrderIsSorted;
-    bool includeOnlineOnlyCards;
+    bool includeRebalancedCards;
     enum
     {
         NO_SETS_SELECTED,
@@ -74,7 +74,7 @@ private slots:
     void actDisableResetButton(const QString &filterText);
     void actSort(int index);
     void actIgnoreWarning();
-    void includeOnlineOnlyCardsChanged(bool _includeOnlineOnlyCardsChanged);
+    void includeRebalancedCardsChanged(bool _includeRebalancedCardsChanged);
 };
 
 #endif

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
@@ -126,7 +126,7 @@ QVariantHash CockatriceXml4Parser::loadCardPropertiesFromXml(QXmlStreamReader &x
 
 void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
 {
-    bool includeOnlineOnlyCards = SettingsCache::instance().getIncludeOnlineOnlyCards();
+    bool includeRebalancedCards = SettingsCache::instance().getIncludeRebalancedCards();
     while (!xml.atEnd()) {
         if (xml.readNext() == QXmlStreamReader::EndElement) {
             break;
@@ -194,7 +194,7 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
                         // However, this is also true of the `set->getEnabled()`
                         // check above (which is currently bugged as well), so
                         // we'll fix both at the same time.
-                        if (includeOnlineOnlyCards || setInfo.getProperty("isOnlineOnly") != "true") {
+                        if (includeRebalancedCards || setInfo.getProperty("isRebalanced") != "true") {
                             _sets[setName].append(setInfo);
                         }
                     }

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -260,7 +260,7 @@ SettingsCache::SettingsCache()
     bumpSetsWithCardsInDeckToTop = settings->value("cards/bumpsetswithcardsindecktotop", true).toBool();
     printingSelectorSortOrder = settings->value("cards/printingselectorsortorder", 1).toInt();
     printingSelectorCardSize = settings->value("cards/printingselectorcardsize", 100).toInt();
-    includeOnlineOnlyCards = settings->value("cards/includeonlineonlycards", false).toBool();
+    includeRebalancedCards = settings->value("cards/includerebalancedcards", true).toBool();
     printingSelectorNavigationButtonsVisible =
         settings->value("cards/printingselectornavigationbuttonsvisible", true).toBool();
     visualDeckStorageCardSize = settings->value("interface/visualdeckstoragecardsize", 100).toInt();
@@ -656,11 +656,14 @@ void SettingsCache::setPrintingSelectorCardSize(int _printingSelectorCardSize)
     emit printingSelectorCardSizeChanged();
 }
 
-void SettingsCache::setIncludeOnlineOnlyCards(bool _includeOnlineOnlyCards)
+void SettingsCache::setIncludeRebalancedCards(bool _includeRebalancedCards)
 {
-    includeOnlineOnlyCards = _includeOnlineOnlyCards;
-    settings->setValue("cards/includeonlineonlycards", includeOnlineOnlyCards);
-    emit includeOnlineOnlyCardsChanged(includeOnlineOnlyCards);
+    if (includeRebalancedCards == _includeRebalancedCards)
+        return;
+
+    includeRebalancedCards = _includeRebalancedCards;
+    settings->setValue("cards/includerebalancedcards", includeRebalancedCards);
+    emit includeRebalancedCardsChanged(includeRebalancedCards);
 }
 
 void SettingsCache::setPrintingSelectorNavigationButtonsVisible(QT_STATE_CHANGED_T _navigationButtonsVisible)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -59,7 +59,7 @@ signals:
     void bumpSetsWithCardsInDeckToTopChanged();
     void printingSelectorSortOrderChanged();
     void printingSelectorCardSizeChanged();
-    void includeOnlineOnlyCardsChanged(bool _includeOnlineOnlyCards);
+    void includeRebalancedCardsChanged(bool _includeRebalancedCards);
     void printingSelectorNavigationButtonsVisibleChanged();
     void visualDeckStorageShowTagFilterChanged(bool _visible);
     void visualDeckStorageShowBannerCardComboBoxChanged(bool _visible);
@@ -131,7 +131,7 @@ private:
     bool bumpSetsWithCardsInDeckToTop;
     int printingSelectorSortOrder;
     int printingSelectorCardSize;
-    bool includeOnlineOnlyCards;
+    bool includeRebalancedCards;
     bool printingSelectorNavigationButtonsVisible;
     int visualDeckStorageSortingOrder;
     bool visualDeckStorageShowFolders;
@@ -406,9 +406,9 @@ public:
     {
         return printingSelectorCardSize;
     }
-    bool getIncludeOnlineOnlyCards() const
+    bool getIncludeRebalancedCards() const
     {
-        return includeOnlineOnlyCards;
+        return includeRebalancedCards;
     }
     bool getPrintingSelectorNavigationButtonsVisible() const
     {
@@ -787,7 +787,7 @@ public slots:
     void setBumpSetsWithCardsInDeckToTop(QT_STATE_CHANGED_T _bumpSetsWithCardsInDeckToTop);
     void setPrintingSelectorSortOrder(int _printingSelectorSortOrder);
     void setPrintingSelectorCardSize(int _printingSelectorCardSize);
-    void setIncludeOnlineOnlyCards(bool _includeOnlineOnlyCards);
+    void setIncludeRebalancedCards(bool _includeRebalancedCards);
     void setPrintingSelectorNavigationButtonsVisible(QT_STATE_CHANGED_T _navigationButtonsVisible);
     void setVisualDeckStorageSortingOrder(int _visualDeckStorageSortingOrder);
     void setVisualDeckStorageShowFolders(QT_STATE_CHANGED_T value);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -199,7 +199,7 @@ void SettingsCache::setPrintingSelectorSortOrder(int /* _printingSelectorSortOrd
 void SettingsCache::setPrintingSelectorCardSize(int /* _printingSelectorCardSize */)
 {
 }
-void SettingsCache::setIncludeOnlineOnlyCards(bool /* _includeOnlineOnlyCards */)
+void SettingsCache::setIncludeRebalancedCards(bool /* _includeRebalancedCards */)
 {
 }
 void SettingsCache::setPrintingSelectorNavigationButtonsVisible(QT_STATE_CHANGED_T /* _navigationButtonsVisible */)

--- a/doc/carddatabase_v4/cards.xsd
+++ b/doc/carddatabase_v4/cards.xsd
@@ -28,7 +28,8 @@
                 <xs:attribute type="xs:anyURI" name="picURL" use="optional" />
                 <xs:attribute type="xs:string" name="num" use="optional" />
                 <xs:attribute type="xs:string" name="rarity" use="optional" />
-                <xs:attribute type="xs:boolean" name="onlineOnly" use="optional" />
+                <xs:attribute type="xs:boolean" name="isOnlineOnly" use="optional" />
+                <xs:attribute type="xs:boolean" name="isRebalanced" use="optional" />
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -213,7 +213,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
 
     // mtgjson name => xml name
     static const QMap<QString, QString> setInfoProperties{
-        {"number", "num"}, {"rarity", "rarity"}, {"isOnlineOnly", "isOnlineOnly"}};
+        {"number", "num"}, {"rarity", "rarity"}, {"isOnlineOnly", "isOnlineOnly"}, {"isRebalanced", "isRebalanced"}};
 
     // mtgjson name => xml name
     static const QMap<QString, QString> identifierProperties{{"multiverseId", "muid"}, {"scryfallId", "uuid"}};

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -203,7 +203,7 @@ void SettingsCache::setPrintingSelectorSortOrder(int /* _printingSelectorSortOrd
 void SettingsCache::setPrintingSelectorCardSize(int /* _printingSelectorCardSize */)
 {
 }
-void SettingsCache::setIncludeOnlineOnlyCards(bool /* _includeOnlineOnlyCards */)
+void SettingsCache::setIncludeRebalancedCards(bool /* _includeRebalancedCards */)
 {
 }
 void SettingsCache::setPrintingSelectorNavigationButtonsVisible(QT_STATE_CHANGED_T /* _navigationButtonsVisible */)


### PR DESCRIPTION
## Related Ticket(s)

In #5759 we introduced a setting (off by default) to disable the use of Arena cards. 

## Short roundup of the initial problem

This was done by checking the `isOnlineOnly` property of the card, which accidentally also disabled online *printings* of cards that otherwise exist in paper (e.g. Vintage Masters).

## What will change with this Pull Request?

This PR does the same thing but uses the `isRebalanced` property instead, which is `true` for Arena cards only and should have been used from the start. Online-only printings such as Vintage Masters are not affected and available independently of the value of the setting. The settings is on by default.