### PR TITLE
Change default log level to info

### DIFF
--- a/cockatrice/resources/config/qtlogging.ini
+++ b/cockatrice/resources/config/qtlogging.ini
@@ -1,5 +1,9 @@
 [Rules]
-# Uncomment a rule to disable logging for that category
+# The default log level is info
+*.debug = false
+
+# Uncomment a rule to disable logging for that category,
+# or set .debug = true for that category to see debug level logs
 
 # main = false
 # qt_translator = false

--- a/cockatrice/src/client/network/release_channel.cpp
+++ b/cockatrice/src/client/network/release_channel.cpp
@@ -38,7 +38,7 @@ ReleaseChannel::~ReleaseChannel()
 void ReleaseChannel::checkForUpdates()
 {
     QString releaseChannelUrl = getReleaseChannelUrl();
-    qCDebug(ReleaseChannelLog) << "Searching for updates on the channel: " << releaseChannelUrl;
+    qCInfo(ReleaseChannelLog) << "Searching for updates on the channel: " << releaseChannelUrl;
     response = netMan->get(QNetworkRequest(releaseChannelUrl));
     connect(response, &QNetworkReply::finished, this, &ReleaseChannel::releaseListFinished);
 }
@@ -152,15 +152,15 @@ void StableReleaseChannel::releaseListFinished()
 
     QString shortHash = lastRelease->getCommitHash().left(GIT_SHORT_HASH_LEN);
     QString myHash = QString(VERSION_COMMIT);
-    qCDebug(ReleaseChannelLog) << "Current hash=" << myHash << "update hash=" << shortHash;
+    qCInfo(ReleaseChannelLog) << "Current hash=" << myHash << "update hash=" << shortHash;
 
-    qCDebug(ReleaseChannelLog) << "Got reply from release server, name=" << lastRelease->getName()
-                               << "desc=" << lastRelease->getDescriptionUrl()
-                               << "date=" << lastRelease->getPublishDate() << "url=" << lastRelease->getDownloadUrl();
+    qCInfo(ReleaseChannelLog) << "Got reply from release server, name=" << lastRelease->getName()
+                              << "desc=" << lastRelease->getDescriptionUrl() << "date=" << lastRelease->getPublishDate()
+                              << "url=" << lastRelease->getDownloadUrl();
 
     const QString &tagName = resultMap["tag_name"].toString();
     QString url = QString(STABLETAG_URL) + tagName;
-    qCDebug(ReleaseChannelLog) << "Searching for commit hash corresponding to stable channel tag: " << tagName;
+    qCInfo(ReleaseChannelLog) << "Searching for commit hash corresponding to stable channel tag: " << tagName;
     response = netMan->get(QNetworkRequest(url));
     connect(response, &QNetworkReply::finished, this, &StableReleaseChannel::tagListFinished);
 }
@@ -185,11 +185,11 @@ void StableReleaseChannel::tagListFinished()
     }
 
     lastRelease->setCommitHash(resultMap["object"].toMap()["sha"].toString());
-    qCDebug(ReleaseChannelLog) << "Got reply from tag server, commit=" << lastRelease->getCommitHash();
+    qCInfo(ReleaseChannelLog) << "Got reply from tag server, commit=" << lastRelease->getCommitHash();
 
     QString shortHash = lastRelease->getCommitHash().left(GIT_SHORT_HASH_LEN);
     QString myHash = QString(VERSION_COMMIT);
-    qCDebug(ReleaseChannelLog) << "Current hash=" << myHash << "update hash=" << shortHash;
+    qCInfo(ReleaseChannelLog) << "Current hash=" << myHash << "update hash=" << shortHash;
     const bool needToUpdate = (QString::compare(shortHash, myHash, Qt::CaseInsensitive) != 0);
 
     emit finishedCheck(needToUpdate, lastRelease->isCompatibleVersionFound(), lastRelease);
@@ -256,13 +256,13 @@ void BetaReleaseChannel::releaseListFinished()
     lastRelease->setName(QString("%1 (%2)").arg(resultMap["tag_name"].toString()).arg(shortHash));
     lastRelease->setDescriptionUrl(QString(BETARELEASE_CHANGESURL).arg(VERSION_COMMIT, shortHash));
 
-    qCDebug(ReleaseChannelLog) << "Got reply from release server, size=" << resultMap.size()
-                               << "name=" << lastRelease->getName() << "desc=" << lastRelease->getDescriptionUrl()
-                               << "commit=" << lastRelease->getCommitHash() << "date=" << lastRelease->getPublishDate();
+    qCInfo(ReleaseChannelLog) << "Got reply from release server, size=" << resultMap.size()
+                              << "name=" << lastRelease->getName() << "desc=" << lastRelease->getDescriptionUrl()
+                              << "commit=" << lastRelease->getCommitHash() << "date=" << lastRelease->getPublishDate();
 
     QString betaBuildDownloadUrl = resultMap["assets_url"].toString();
 
-    qCDebug(ReleaseChannelLog) << "Searching for a corresponding file on the beta channel: " << betaBuildDownloadUrl;
+    qCInfo(ReleaseChannelLog) << "Searching for a corresponding file on the beta channel: " << betaBuildDownloadUrl;
     response = netMan->get(QNetworkRequest(betaBuildDownloadUrl));
     connect(response, &QNetworkReply::finished, this, &BetaReleaseChannel::fileListFinished);
 }
@@ -282,7 +282,7 @@ void BetaReleaseChannel::fileListFinished()
     QVariantList resultList = jsonResponse.toVariant().toList();
     QString shortHash = lastRelease->getCommitHash().left(GIT_SHORT_HASH_LEN);
     QString myHash = QString(VERSION_COMMIT);
-    qCDebug(ReleaseChannelLog) << "Current hash=" << myHash << "update hash=" << shortHash;
+    qCInfo(ReleaseChannelLog) << "Current hash=" << myHash << "update hash=" << shortHash;
 
     bool needToUpdate = (QString::compare(shortHash, myHash, Qt::CaseInsensitive) != 0);
     bool compatibleVersion = false;
@@ -299,7 +299,7 @@ void BetaReleaseChannel::fileListFinished()
         if (downloadMatchesCurrentOS(*url)) {
             compatibleVersion = true;
             lastRelease->setDownloadUrl(*url);
-            qCDebug(ReleaseChannelLog) << "Found compatible version url=" << *url;
+            qCInfo(ReleaseChannelLog) << "Found compatible version url=" << *url;
             break;
         }
     }

--- a/cockatrice/src/client/network/spoiler_background_updater.cpp
+++ b/cockatrice/src/client/network/spoiler_background_updater.cpp
@@ -28,7 +28,7 @@ SpoilerBackgroundUpdater::SpoilerBackgroundUpdater(QObject *apParent) : QObject(
         // File exists means we're in spoiler season
         startSpoilerDownloadProcess(SPOILERS_STATUS_URL, false);
     } else {
-        qCDebug(SpoilerBackgroundUpdaterLog) << "Spoilers Disabled";
+        qCInfo(SpoilerBackgroundUpdaterLog) << "Spoilers Disabled";
     }
 }
 
@@ -67,7 +67,7 @@ void SpoilerBackgroundUpdater::actDownloadFinishedSpoilersFile()
         reply->deleteLater();
         emit spoilerCheckerDone();
     } else {
-        qCDebug(SpoilerBackgroundUpdaterLog) << "Error downloading spoilers file" << errorCode;
+        qCWarning(SpoilerBackgroundUpdaterLog) << "Error downloading spoilers file" << errorCode;
         emit spoilerCheckerDone();
     }
 }
@@ -81,11 +81,11 @@ bool SpoilerBackgroundUpdater::deleteSpoilerFile()
 
     // Delete the spoiler.xml file
     if (file.exists() && file.remove()) {
-        qCDebug(SpoilerBackgroundUpdaterLog) << "Deleting spoiler.xml";
+        qCInfo(SpoilerBackgroundUpdaterLog) << "Deleting spoiler.xml";
         return true;
     }
 
-    qCDebug(SpoilerBackgroundUpdaterLog) << "Error: Spoiler.xml not found or not deleted";
+    qCInfo(SpoilerBackgroundUpdaterLog) << "Error: Spoiler.xml not found or not deleted";
     return false;
 }
 
@@ -101,24 +101,24 @@ void SpoilerBackgroundUpdater::actCheckIfSpoilerSeasonEnabled()
             trayIcon->showMessage(tr("Spoilers season has ended"), tr("Deleting spoiler.xml. Please run Oracle"));
         }
 
-        qCDebug(SpoilerBackgroundUpdaterLog) << "Spoiler Season Offline";
+        qCInfo(SpoilerBackgroundUpdaterLog) << "Spoiler Season Offline";
         emit spoilerCheckerDone();
     } else if (errorCode == QNetworkReply::NoError) {
-        qCDebug(SpoilerBackgroundUpdaterLog) << "Spoiler Service Online";
+        qCInfo(SpoilerBackgroundUpdaterLog) << "Spoiler Service Online";
         startSpoilerDownloadProcess(SPOILERS_URL, true);
     } else if (errorCode == QNetworkReply::HostNotFoundError) {
         if (trayIcon) {
             trayIcon->showMessage(tr("Spoilers download failed"), tr("No internet connection"));
         }
 
-        qCDebug(SpoilerBackgroundUpdaterLog) << "Spoiler download failed due to no internet connection";
+        qCWarning(SpoilerBackgroundUpdaterLog) << "Spoiler download failed due to no internet connection";
         emit spoilerCheckerDone();
     } else {
         if (trayIcon) {
             trayIcon->showMessage(tr("Spoilers download failed"), tr("Error") + " " + (short)errorCode);
         }
 
-        qCDebug(SpoilerBackgroundUpdaterLog) << "Spoiler download failed with reason" << errorCode;
+        qCWarning(SpoilerBackgroundUpdaterLog) << "Spoiler download failed with reason" << errorCode;
         emit spoilerCheckerDone();
     }
 }
@@ -139,19 +139,19 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
             trayIcon->showMessage(tr("Spoilers already up to date"), tr("No new spoilers added"));
         }
 
-        qCDebug(SpoilerBackgroundUpdaterLog) << "Spoilers Up to Date";
+        qCInfo(SpoilerBackgroundUpdaterLog) << "Spoilers Up to Date";
         return false;
     }
 
     QFile file(fileName);
     if (!file.open(QIODevice::WriteOnly)) {
-        qCDebug(SpoilerBackgroundUpdaterLog) << "Spoiler Service Error: File open (w) failed for" << fileName;
+        qCWarning(SpoilerBackgroundUpdaterLog) << "Spoiler Service Error: File open (w) failed for" << fileName;
         file.close();
         return false;
     }
 
     if (file.write(data) == -1) {
-        qCDebug(SpoilerBackgroundUpdaterLog) << "Spoiler Service Error: File write (w) failed for" << fileName;
+        qCWarning(SpoilerBackgroundUpdaterLog) << "Spoiler Service Error: File write (w) failed for" << fileName;
         file.close();
         return false;
     }
@@ -159,7 +159,7 @@ bool SpoilerBackgroundUpdater::saveDownloadedFile(QByteArray data)
     file.close();
 
     // Data written, so reload the card database
-    qCDebug(SpoilerBackgroundUpdaterLog) << "Spoiler Service Data Written";
+    qCInfo(SpoilerBackgroundUpdaterLog) << "Spoiler Service Data Written";
     const auto reloadOk = QtConcurrent::run([] { CardDatabaseManager::getInstance()->loadCardDatabases(); });
 
     // If the user has notifications enabled, let them know
@@ -202,12 +202,12 @@ QByteArray SpoilerBackgroundUpdater::getHash(const QString fileName)
         QCryptographicHash hash(QCryptographicHash::Algorithm::Md5);
         hash.addData(bytes);
 
-        qCDebug(SpoilerBackgroundUpdaterLog) << "File Hash =" << hash.result();
+        qCInfo(SpoilerBackgroundUpdaterLog) << "File Hash =" << hash.result();
 
         file.close();
         return hash.result();
     } else {
-        qCDebug(SpoilerBackgroundUpdaterLog) << "getHash ReadOnly failed!";
+        qCWarning(SpoilerBackgroundUpdaterLog) << "getHash ReadOnly failed!";
         file.close();
         return QByteArray();
     }
@@ -221,7 +221,7 @@ QByteArray SpoilerBackgroundUpdater::getHash(QByteArray data)
     QCryptographicHash hash(QCryptographicHash::Algorithm::Md5);
     hash.addData(bytes);
 
-    qCDebug(SpoilerBackgroundUpdaterLog) << "Data Hash =" << hash.result();
+    qCInfo(SpoilerBackgroundUpdaterLog) << "Data Hash =" << hash.result();
 
     return hash.result();
 }

--- a/cockatrice/src/client/sound_engine.cpp
+++ b/cockatrice/src/client/sound_engine.cpp
@@ -37,7 +37,7 @@ SoundEngine::~SoundEngine()
 void SoundEngine::soundEnabledChanged()
 {
     if (SettingsCache::instance().getSoundEnabled()) {
-        qCDebug(SoundEngineLog) << "SoundEngine: enabling sound with" << audioData.size() << "sounds";
+        qCInfo(SoundEngineLog) << "SoundEngine: enabling sound with" << audioData.size() << "sounds";
         if (!player) {
             player = new QMediaPlayer;
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
@@ -46,7 +46,7 @@ void SoundEngine::soundEnabledChanged()
 #endif
         }
     } else {
-        qCDebug(SoundEngineLog) << "SoundEngine: disabling sound";
+        qCInfo(SoundEngineLog) << "SoundEngine: disabling sound";
         if (player) {
             player->stop();
             player->deleteLater();
@@ -90,7 +90,7 @@ void SoundEngine::ensureThemeDirectoryExists()
 {
     if (SettingsCache::instance().getSoundThemeName().isEmpty() ||
         !getAvailableThemes().contains(SettingsCache::instance().getSoundThemeName())) {
-        qCDebug(SoundEngineLog) << "Sounds theme name not set, setting default value";
+        qCInfo(SoundEngineLog) << "Sounds theme name not set, setting default value";
         SettingsCache::instance().setSoundThemeName(DEFAULT_THEME_NAME);
     }
 }
@@ -131,7 +131,7 @@ QStringMap &SoundEngine::getAvailableThemes()
 void SoundEngine::themeChangedSlot()
 {
     QString themeName = SettingsCache::instance().getSoundThemeName();
-    qCDebug(SoundEngineLog) << "Sound theme changed:" << themeName;
+    qCInfo(SoundEngineLog) << "Sound theme changed:" << themeName;
 
     QDir dir = getAvailableThemes().value(themeName);
 

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -753,7 +753,7 @@ void TabGame::processGameEventContainer(const GameEventContainer &cont,
                 default: {
                     Player *player = players.value(playerId, 0);
                     if (!player) {
-                        qCDebug(TabGameLog) << "unhandled game event: invalid player id";
+                        qCWarning(TabGameLog) << "unhandled game event: invalid player id";
                         break;
                     }
                     player->processGameEvent(eventType, event, context, options);

--- a/cockatrice/src/client/tabs/tab_message.cpp
+++ b/cockatrice/src/client/tabs/tab_message.cpp
@@ -145,7 +145,7 @@ void TabMessage::showSystemPopup(const Event_UserMessage &event)
                               event.message().c_str());
         connect(trayIcon, SIGNAL(messageClicked()), this, SLOT(messageClicked()));
     } else {
-        qCDebug(TabMessageLog) << "Error: trayIcon is NULL. TabMessage::showSystemPopup failed";
+        qCWarning(TabMessageLog) << "Error: trayIcon is NULL. TabMessage::showSystemPopup failed";
     }
 }
 

--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -856,7 +856,7 @@ void TabSupervisor::processGameEventContainer(const GameEventContainer &cont)
     if (tab)
         tab->processGameEventContainer(cont, qobject_cast<AbstractClient *>(sender()), {});
     else
-        qCDebug(TabSupervisorLog) << "gameEvent: invalid gameId";
+        qCInfo(TabSupervisorLog) << "gameEvent: invalid gameId" << cont.game_id();
 }
 
 void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)

--- a/cockatrice/src/client/tapped_out_interface.cpp
+++ b/cockatrice/src/client/tapped_out_interface.cpp
@@ -33,7 +33,7 @@ void TappedOutInterface::queryFinished(QNetworkReply *reply)
          * can be extracted from the header. The http status is a 302 "redirect".
          */
         QString deckUrl = reply->rawHeader("Location");
-        qCDebug(TappedOutInterfaceLog) << "Tappedout: good reply, http status" << httpStatus << "location" << deckUrl;
+        qCInfo(TappedOutInterfaceLog) << "Tappedout: good reply, http status" << httpStatus << "location" << deckUrl;
         QDesktopServices::openUrl("https://tappedout.net" + deckUrl);
     } else {
         /*
@@ -57,8 +57,8 @@ void TappedOutInterface::queryFinished(QNetworkReply *reply)
         }
 
         QString errorMessage = errorMessageList.join("\n");
-        qCDebug(TappedOutInterfaceLog) << "Tappedout: bad reply, http status" << httpStatus << "size" << data.size()
-                                       << "message" << errorMessage;
+        qCWarning(TappedOutInterfaceLog) << "Tappedout: bad reply, http status" << httpStatus << "size" << data.size()
+                                         << "message" << errorMessage;
 
         QMessageBox::critical(nullptr, tr("Error"), errorMessage);
     }

--- a/cockatrice/src/client/ui/picture_loader/picture_loader.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader.cpp
@@ -115,7 +115,7 @@ void PictureLoader::getPixmap(QPixmap &pixmap, CardInfoPtr card, QSize size)
     QPixmap bigPixmap;
     if (QPixmapCache::find(key, &bigPixmap)) {
         if (bigPixmap.isNull()) {
-            qCWarning(PictureLoaderLog) << "Cached pixmap for key" << key << "is NULL!";
+            qCDebug(PictureLoaderLog) << "Cached pixmap for key" << key << "is NULL!";
             return;
         }
 

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
@@ -213,7 +213,7 @@ void PictureLoaderWorker::picDownloadFailed()
         loadQueue.prepend(cardBeingDownloaded);
         mutex.unlock();
     } else {
-        qCDebug(PictureLoaderWorkerLog).nospace()
+        qCWarning(PictureLoaderWorkerLog).nospace()
             << "[card: " << cardBeingDownloaded.getCard()->getCorrectedName()
             << " set: " << cardBeingDownloaded.getSetName() << "]: Picture NOT found, "
             << (picDownload ? "download failed" : "downloads disabled")
@@ -424,7 +424,7 @@ void PictureLoaderWorker::picDownloadFinished(QNetworkReply *reply)
     }
 
     if (logSuccessMessage) {
-        qCDebug(PictureLoaderWorkerLog).nospace()
+        qCInfo(PictureLoaderWorkerLog).nospace()
             << "[card: " << cardBeingDownloaded.getCard()->getName() << " set: " << cardBeingDownloaded.getSetName()
             << "]: Image successfully " << (isFromCache ? "loaded from cached" : "downloaded from") << " url "
             << reply->url().toDisplayString();

--- a/cockatrice/src/client/ui/theme_manager.cpp
+++ b/cockatrice/src/client/ui/theme_manager.cpp
@@ -32,7 +32,7 @@ void ThemeManager::ensureThemeDirectoryExists()
 {
     if (SettingsCache::instance().getThemeName().isEmpty() ||
         !getAvailableThemes().contains(SettingsCache::instance().getThemeName())) {
-        qCDebug(ThemeManagerLog) << "Theme name not set, setting default value";
+        qCInfo(ThemeManagerLog) << "Theme name not set, setting default value";
         SettingsCache::instance().setThemeName(NONE_THEME_NAME);
     }
 }
@@ -105,7 +105,7 @@ QBrush ThemeManager::loadExtraBrush(QString fileName, QBrush &fallbackBrush)
 void ThemeManager::themeChangedSlot()
 {
     QString themeName = SettingsCache::instance().getThemeName();
-    qCDebug(ThemeManagerLog) << "Theme changed:" << themeName;
+    qCInfo(ThemeManagerLog) << "Theme changed:" << themeName;
 
     QString dirPath = getAvailableThemes().value(themeName);
     QDir dir = dirPath;

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -904,14 +904,14 @@ void MainWindow::startupConfigCheck()
 
     if (SettingsCache::instance().getClientVersion() == CLIENT_INFO_NOT_SET) {
         // no config found, 99% new clean install
-        qCDebug(WindowMainStartupVersionLog)
+        qCInfo(WindowMainStartupVersionLog)
             << "Startup: old client version empty, assuming first start after clean install";
         alertForcedOracleRun(VERSION_STRING, false);
         SettingsCache::instance().downloads().resetToDefaultURLs(); // populate the download urls
         SettingsCache::instance().setClientVersion(VERSION_STRING);
     } else if (SettingsCache::instance().getClientVersion() != VERSION_STRING) {
         // config found, from another (presumably older) version
-        qCDebug(WindowMainStartupVersionLog)
+        qCInfo(WindowMainStartupVersionLog)
             << "Startup: old client version" << SettingsCache::instance().getClientVersion()
             << "differs, assuming first start after update";
         if (SettingsCache::instance().getNotifyAboutNewVersion()) {
@@ -920,13 +920,13 @@ void MainWindow::startupConfigCheck()
             const auto reloadOk0 = QtConcurrent::run([] { CardDatabaseManager::getInstance()->loadCardDatabases(); });
         }
 
-        qCDebug(WindowMainStartupShortcutsLog) << "[MainWindow] Migrating shortcuts after update detected.";
+        qCInfo(WindowMainStartupShortcutsLog) << "[MainWindow] Migrating shortcuts after update detected.";
         SettingsCache::instance().shortcuts().migrateShortcuts();
 
         SettingsCache::instance().setClientVersion(VERSION_STRING);
     } else {
         // previous config from this version found
-        qCDebug(WindowMainStartupVersionLog) << "Startup: found config with current version";
+        qCInfo(WindowMainStartupVersionLog) << "Startup: found config with current version";
         const auto reloadOk1 = QtConcurrent::run([] { CardDatabaseManager::getInstance()->loadCardDatabases(); });
 
         // Run the tips dialog only on subsequent startups.
@@ -1038,11 +1038,11 @@ void MainWindow::changeEvent(QEvent *event)
         if (isActiveWindow() && !bHasActivated) {
             bHasActivated = true;
             if (!connectTo.isEmpty()) {
-                qCDebug(WindowMainStartupAutoconnectLog) << "Command line connect to " << connectTo;
+                qCInfo(WindowMainStartupAutoconnectLog) << "Command line connect to " << connectTo;
                 client->connectToServer(connectTo.host(), connectTo.port(), connectTo.userName(), connectTo.password());
             } else if (SettingsCache::instance().servers().getAutoConnect() &&
                        !SettingsCache::instance().debug().getLocalGameOnStartup()) {
-                qCDebug(WindowMainStartupAutoconnectLog) << "Attempting auto-connect...";
+                qCInfo(WindowMainStartupAutoconnectLog) << "Attempting auto-connect...";
                 DlgConnect dlg(this);
                 client->connectToServer(dlg.getHost(), static_cast<unsigned int>(dlg.getPort()), dlg.getPlayerName(),
                                         dlg.getPassword());

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -55,9 +55,9 @@ bool DeckLoader::loadFromFile(const QString &fileName, FileFormat fmt, bool user
             break;
         case CockatriceFormat: {
             result = loadFromFile_Native(&file);
-            qCDebug(DeckLoaderLog) << "Loaded from" << fileName << "-" << result;
+            qCInfo(DeckLoaderLog) << "Loaded from" << fileName << "-" << result;
             if (!result) {
-                qCDebug(DeckLoaderLog) << "Retrying as plain format";
+                qCInfo(DeckLoaderLog) << "Retrying as plain format";
                 file.seek(0);
                 result = loadFromFile_Plain(&file);
                 fmt = PlainTextFormat;
@@ -79,7 +79,7 @@ bool DeckLoader::loadFromFile(const QString &fileName, FileFormat fmt, bool user
         emit deckLoaded();
     }
 
-    qCDebug(DeckLoaderLog) << "Deck was loaded -" << result;
+    qCInfo(DeckLoaderLog) << "Deck was loaded -" << result;
     return result;
 }
 

--- a/cockatrice/src/dialogs/dlg_edit_avatar.cpp
+++ b/cockatrice/src/dialogs/dlg_edit_avatar.cpp
@@ -61,7 +61,7 @@ void DlgEditAvatar::actBrowse()
     imgReader.setDecideFormatFromContent(true);
     imgReader.setFileName(fileName);
     if (!imgReader.read(&image)) {
-        qCDebug(DlgEditAvatarLog) << "Avatar image loading failed for file:" << fileName;
+        qCWarning(DlgEditAvatarLog) << "Avatar image loading failed for file:" << fileName;
         imageLabel->setText(tr("Invalid image chosen."));
         return;
     }

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -209,8 +209,8 @@ QString GeneralSettingsPage::languageName(const QString &lang)
     QString appNameHint = translationPrefix + "_" + lang;
     bool appTranslationLoaded = qTranslator.load(appNameHint, translationPath);
     if (!appTranslationLoaded) {
-        qCDebug(DlgSettingsLog) << "Unable to load" << translationPrefix << "translation" << appNameHint << "at"
-                                << translationPath;
+        qCWarning(DlgSettingsLog) << "Unable to load" << translationPrefix << "translation" << appNameHint << "at"
+                                  << translationPath;
     }
 
     return qTranslator.translate("i18n", DEFAULT_LANG_NAME);
@@ -1615,7 +1615,7 @@ void DlgSettings::closeEvent(QCloseEvent *event)
     bool showLoadError = true;
     QString loadErrorMessage = tr("Unknown Error loading card database");
     LoadStatus loadStatus = CardDatabaseManager::getInstance()->getLoadStatus();
-    qCDebug(DlgSettingsLog) << "Card Database load status: " << loadStatus;
+    qCInfo(DlgSettingsLog) << "Card Database load status: " << loadStatus;
     switch (loadStatus) {
         case Ok:
             showLoadError = false;

--- a/cockatrice/src/dialogs/dlg_tip_of_the_day.cpp
+++ b/cockatrice/src/dialogs/dlg_tip_of_the_day.cpp
@@ -147,7 +147,7 @@ void DlgTipOfTheDay::updateTip(int tipId)
     tipTextContent->setTextFormat(Qt::RichText);
 
     if (!image->load(imagePath)) {
-        qCDebug(DlgTipOfTheDayLog) << "Image failed to load from" << imagePath;
+        qCWarning(DlgTipOfTheDayLog) << "Image failed to load from" << imagePath;
         imageLabel->clear();
     } else {
         int h = std::min(std::max(imageLabel->height(), MIN_TIP_IMAGE_HEIGHT), MAX_TIP_IMAGE_HEIGHT);

--- a/cockatrice/src/dialogs/dlg_update.cpp
+++ b/cockatrice/src/dialogs/dlg_update.cpp
@@ -223,7 +223,7 @@ void DlgUpdate::downloadSuccessful(const QUrl &filepath)
     // Try to open the installer. If it opens, quit Cockatrice
     if (QDesktopServices::openUrl(filepath)) {
         QMetaObject::invokeMethod(static_cast<MainWindow *>(parent()), "close", Qt::QueuedConnection);
-        qCDebug(DlgUpdateLog) << "Opened downloaded update file successfully - closing Cockatrice";
+        qCInfo(DlgUpdateLog) << "Opened downloaded update file successfully - closing Cockatrice";
         close();
     } else {
         setLabel(tr("Error"));

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -68,7 +68,7 @@ void CardDatabase::clear()
 void CardDatabase::addCard(CardInfoPtr card)
 {
     if (card == nullptr) {
-        qCDebug(CardDatabaseLog) << "CardDatabase::addCard(nullptr)";
+        qCWarning(CardDatabaseLog) << "CardDatabase::addCard(nullptr)";
         return;
     }
 
@@ -93,7 +93,7 @@ void CardDatabase::addCard(CardInfoPtr card)
 void CardDatabase::removeCard(CardInfoPtr card)
 {
     if (card.isNull()) {
-        qCDebug(CardDatabaseLog) << "CardDatabase::removeCard(nullptr)";
+        qCWarning(CardDatabaseLog) << "CardDatabase::removeCard(nullptr)";
         return;
     }
 
@@ -247,8 +247,8 @@ LoadStatus CardDatabase::loadCardDatabase(const QString &path)
     }
 
     int msecs = startTime.msecsTo(QTime::currentTime());
-    qCDebug(CardDatabaseLoadingLog) << "Path =" << path << "Status =" << tempLoadStatus << "Cards =" << cards.size()
-                                    << "Sets =" << sets.size() << QString("%1ms").arg(msecs);
+    qCInfo(CardDatabaseLoadingLog) << "Path =" << path << "Status =" << tempLoadStatus << "Cards =" << cards.size()
+                                   << "Sets =" << sets.size() << QString("%1ms").arg(msecs);
 
     return tempLoadStatus;
 }
@@ -257,7 +257,7 @@ LoadStatus CardDatabase::loadCardDatabases()
 {
     reloadDatabaseMutex->lock();
 
-    qCDebug(CardDatabaseLoadingLog) << "Started";
+    qCInfo(CardDatabaseLoadingLog) << "Card Database Loading Started";
 
     clear(); // remove old db
 
@@ -278,7 +278,7 @@ LoadStatus CardDatabase::loadCardDatabases()
 
     for (auto i = 0; i < databasePaths.size(); ++i) {
         const auto &databasePath = databasePaths.at(i);
-        qCDebug(CardDatabaseLoadingLog) << "Loading Custom Set" << i << "(" << databasePath << ")";
+        qCInfo(CardDatabaseLoadingLog) << "Loading Custom Set" << i << "(" << databasePath << ")";
         loadCardDatabase(databasePath);
     }
 
@@ -291,10 +291,10 @@ LoadStatus CardDatabase::loadCardDatabases()
 
     if (loadStatus == Ok) {
         checkUnknownSets(); // update deck editors, etc
-        qCDebug(CardDatabaseLoadingSuccessOrFailureLog) << "Success";
+        qCInfo(CardDatabaseLoadingSuccessOrFailureLog) << "Card Database Loading Success";
         emit cardDatabaseLoadingFinished();
     } else {
-        qCDebug(CardDatabaseLoadingSuccessOrFailureLog) << "Failed";
+        qCInfo(CardDatabaseLoadingSuccessOrFailureLog) << "Card Database Loading Failed";
         emit cardDatabaseLoadingFailed(); // bring up the settings dialog
     }
 

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
@@ -13,10 +13,10 @@
 
 bool CockatriceXml3Parser::getCanParseFile(const QString &fileName, QIODevice &device)
 {
-    qCDebug(CockatriceXml3Log) << "Trying to parse: " << fileName;
+    qCInfo(CockatriceXml3Log) << "Trying to parse: " << fileName;
 
     if (!fileName.endsWith(".xml", Qt::CaseInsensitive)) {
-        qCDebug(CockatriceXml3Log) << "Parsing failed: wrong extension";
+        qCInfo(CockatriceXml3Log) << "Parsing failed: wrong extension";
         return false;
     }
 
@@ -28,12 +28,12 @@ bool CockatriceXml3Parser::getCanParseFile(const QString &fileName, QIODevice &d
                 if (version == COCKATRICE_XML3_TAGVER) {
                     return true;
                 } else {
-                    qCDebug(CockatriceXml3Log) << "Parsing failed: wrong version" << version;
+                    qCInfo(CockatriceXml3Log) << "Parsing failed: wrong version" << version;
                     return false;
                 }
 
             } else {
-                qCDebug(CockatriceXml3Log) << "Parsing failed: wrong element tag" << xml.name();
+                qCInfo(CockatriceXml3Log) << "Parsing failed: wrong element tag" << xml.name();
                 return false;
             }
         }
@@ -58,7 +58,7 @@ void CockatriceXml3Parser::parseFile(QIODevice &device)
                 } else if (name == "cards") {
                     loadCardsFromXml(xml);
                 } else if (!name.isEmpty()) {
-                    qCDebug(CockatriceXml3Log) << "Unknown item" << name << ", trying to continue anyway";
+                    qCInfo(CockatriceXml3Log) << "Unknown item" << name << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -93,7 +93,7 @@ void CockatriceXml3Parser::loadSetsFromXml(QXmlStreamReader &xml)
                     releaseDate =
                         QDate::fromString(xml.readElementText(QXmlStreamReader::IncludeChildElements), Qt::ISODate);
                 } else if (!name.isEmpty()) {
-                    qCDebug(CockatriceXml3Log) << "Unknown set property" << name << ", trying to continue anyway";
+                    qCInfo(CockatriceXml3Log) << "Unknown set property" << name << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -263,7 +263,7 @@ void CockatriceXml3Parser::loadCardsFromXml(QXmlStreamReader &xml)
                         relatedCards << relation;
                     }
                 } else if (!xmlName.isEmpty()) {
-                    qCDebug(CockatriceXml3Log) << "Unknown card property" << xmlName << ", trying to continue anyway";
+                    qCInfo(CockatriceXml3Log) << "Unknown card property" << xmlName << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -280,7 +280,7 @@ void CockatriceXml3Parser::loadCardsFromXml(QXmlStreamReader &xml)
 static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardSetPtr &set)
 {
     if (set.isNull()) {
-        qCDebug(CockatriceXml3Log) << "&operator<< set is nullptr";
+        qCWarning(CockatriceXml3Log) << "&operator<< set is nullptr";
         return xml;
     }
 
@@ -297,7 +297,7 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardSetPtr &set
 static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfoPtr &info)
 {
     if (info.isNull()) {
-        qCDebug(CockatriceXml3Log) << "operator<< info is nullptr";
+        qCWarning(CockatriceXml3Log) << "operator<< info is nullptr";
         return xml;
     }
 

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
@@ -15,10 +15,10 @@
 
 bool CockatriceXml4Parser::getCanParseFile(const QString &fileName, QIODevice &device)
 {
-    qCDebug(CockatriceXml4Log) << "Trying to parse: " << fileName;
+    qCInfo(CockatriceXml4Log) << "Trying to parse: " << fileName;
 
     if (!fileName.endsWith(".xml", Qt::CaseInsensitive)) {
-        qCDebug(CockatriceXml4Log) << "Parsing failed: wrong extension";
+        qCInfo(CockatriceXml4Log) << "Parsing failed: wrong extension";
         return false;
     }
 
@@ -30,12 +30,12 @@ bool CockatriceXml4Parser::getCanParseFile(const QString &fileName, QIODevice &d
                 if (version == COCKATRICE_XML4_TAGVER) {
                     return true;
                 } else {
-                    qCDebug(CockatriceXml4Log) << "Parsing failed: wrong version" << version;
+                    qCInfo(CockatriceXml4Log) << "Parsing failed: wrong version" << version;
                     return false;
                 }
 
             } else {
-                qCDebug(CockatriceXml4Log) << "Parsing failed: wrong element tag" << xml.name();
+                qCInfo(CockatriceXml4Log) << "Parsing failed: wrong element tag" << xml.name();
                 return false;
             }
         }
@@ -60,7 +60,7 @@ void CockatriceXml4Parser::parseFile(QIODevice &device)
                 } else if (xmlName == "cards") {
                     loadCardsFromXml(xml);
                 } else if (!xmlName.isEmpty()) {
-                    qCDebug(CockatriceXml4Log) << "Unknown item" << xmlName << ", trying to continue anyway";
+                    qCInfo(CockatriceXml4Log) << "Unknown item" << xmlName << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -98,7 +98,7 @@ void CockatriceXml4Parser::loadSetsFromXml(QXmlStreamReader &xml)
                 } else if (xmlName == "priority") {
                     priority = xml.readElementText(QXmlStreamReader::IncludeChildElements).toShort();
                 } else if (!xmlName.isEmpty()) {
-                    qCDebug(CockatriceXml4Log) << "Unknown set property" << xmlName << ", trying to continue anyway";
+                    qCInfo(CockatriceXml4Log) << "Unknown set property" << xmlName << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -242,7 +242,7 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
                         relatedCards << relation;
                     }
                 } else if (!xmlName.isEmpty()) {
-                    qCDebug(CockatriceXml4Log) << "Unknown card property" << xmlName << ", trying to continue anyway";
+                    qCInfo(CockatriceXml4Log) << "Unknown card property" << xmlName << ", trying to continue anyway";
                     xml.skipCurrentElement();
                 }
             }
@@ -258,7 +258,7 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
 static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardSetPtr &set)
 {
     if (set.isNull()) {
-        qCDebug(CockatriceXml4Log) << "&operator<< set is nullptr";
+        qCWarning(CockatriceXml4Log) << "&operator<< set is nullptr";
         return xml;
     }
 
@@ -276,7 +276,7 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardSetPtr &set
 static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfoPtr &info)
 {
     if (info.isNull()) {
-        qCDebug(CockatriceXml4Log) << "operator<< info is nullptr";
+        qCWarning(CockatriceXml4Log) << "operator<< info is nullptr";
         return xml;
     }
 

--- a/cockatrice/src/game/cards/card_info.cpp
+++ b/cockatrice/src/game/cards/card_info.cpp
@@ -93,7 +93,7 @@ public:
     inline bool operator()(const CardSetPtr &a, const CardSetPtr &b) const
     {
         if (a.isNull() || b.isNull()) {
-            qCDebug(CardInfoLog) << "SetList::KeyCompareFunctor a or b is null";
+            qCWarning(CardInfoLog) << "SetList::KeyCompareFunctor a or b is null";
             return false;
         }
 
@@ -161,7 +161,7 @@ void SetList::enableAll()
         CardSetPtr set = at(i);
 
         if (set == nullptr) {
-            qCDebug(CardInfoLog) << "enabledAll has null";
+            qCWarning(CardInfoLog) << "enabledAll has null";
             continue;
         }
 
@@ -192,7 +192,7 @@ void SetList::guessSortKeys()
     for (int i = 0; i < size(); ++i) {
         CardSetPtr set = at(i);
         if (set.isNull()) {
-            qCDebug(CardInfoLog) << "guessSortKeys set is null";
+            qCWarning(CardInfoLog) << "guessSortKeys set is null";
             continue;
         }
         set->setSortKey(i);

--- a/cockatrice/src/game/cards/card_list.cpp
+++ b/cockatrice/src/game/cards/card_list.cpp
@@ -151,6 +151,6 @@ std::function<QString(CardItem *)> CardList::getExtractorFor(SortOption option)
     }
 
     // this line should never be reached
-    qCDebug(CardListLog) << "cardlist.cpp: Could not find extractor for SortOption" << option;
+    qCWarning(CardListLog) << "cardlist.cpp: Could not find extractor for SortOption" << option;
     return [](CardItem *) { return ""; };
 }

--- a/cockatrice/src/game/filters/filter_string.cpp
+++ b/cockatrice/src/game/filters/filter_string.cpp
@@ -382,7 +382,7 @@ FilterString::FilterString(const QString &expr)
     });
 
     if (!search.parse(ba.data(), result)) {
-        qCDebug(FilterStringLog).nospace() << "FilterString error for " << expr << "; " << qPrintable(_error);
+        qCInfo(FilterStringLog).nospace() << "FilterString error for " << expr << "; " << qPrintable(_error);
         result = [](const CardData &) -> bool { return false; };
     }
 }

--- a/cockatrice/src/game/game_scene.cpp
+++ b/cockatrice/src/game/game_scene.cpp
@@ -46,7 +46,7 @@ void GameScene::retranslateUi()
 
 void GameScene::addPlayer(Player *player)
 {
-    qCDebug(GameScenePlayerAdditionRemovalLog) << "GameScene::addPlayer name=" << player->getName();
+    qCInfo(GameScenePlayerAdditionRemovalLog) << "GameScene::addPlayer name=" << player->getName();
     players << player;
     addItem(player);
     connect(player, &Player::sizeChanged, this, &GameScene::rearrange);
@@ -55,7 +55,7 @@ void GameScene::addPlayer(Player *player)
 
 void GameScene::removePlayer(Player *player)
 {
-    qCDebug(GameScenePlayerAdditionRemovalLog) << "GameScene::removePlayer name=" << player->getName();
+    qCInfo(GameScenePlayerAdditionRemovalLog) << "GameScene::removePlayer name=" << player->getName();
     for (ZoneViewWidget *zone : zoneViews) {
         if (zone->getPlayer() == player) {
             zone->close();

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -568,7 +568,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
 
 Player::~Player()
 {
-    qCDebug(PlayerLog) << "Player destructor:" << getName();
+    qCInfo(PlayerLog) << "Player destructor:" << getName();
 
     QMapIterator<QString, CardZone *> i(zones);
     while (i.hasNext())

--- a/cockatrice/src/game/zones/card_zone.cpp
+++ b/cockatrice/src/game/zones/card_zone.cpp
@@ -136,7 +136,7 @@ void CardZone::mousePressEvent(QGraphicsSceneMouseEvent *event)
 void CardZone::addCard(CardItem *card, const bool reorganize, const int x, const int y)
 {
     if (!card) {
-        qCDebug(CardZoneLog) << "CardZone::addCard() card is null, this shouldn't normally happen";
+        qCWarning(CardZoneLog) << "CardZone::addCard() card is null; this shouldn't normally happen";
         return;
     }
 
@@ -160,7 +160,7 @@ CardItem *CardZone::getCard(int cardId, const QString &cardName)
 {
     CardItem *c = cards.findCard(cardId);
     if (!c) {
-        qCDebug(CardZoneLog) << "CardZone::getCard: card id=" << cardId << "not found";
+        qCWarning(CardZoneLog) << "CardZone::getCard: card id=" << cardId << "not found";
         return nullptr;
     }
     // If the card's id is -1, this zone is invisible,
@@ -205,7 +205,7 @@ CardItem *CardZone::takeCard(int position, int cardId, bool toNewZone)
 void CardZone::removeCard(CardItem *card)
 {
     if (!card) {
-        qCDebug(CardZoneLog) << "CardZone::removeCard: card is null, this shouldn't normally happen";
+        qCWarning(CardZoneLog) << "CardZone::removeCard: card is null, this shouldn't normally happen";
         return;
     }
 

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -141,20 +141,20 @@ void installNewTranslator()
 
     bool qtTranslationLoaded = qtTranslator->load(qtNameHint, qtTranslationPath);
     if (!qtTranslationLoaded) {
-        qCDebug(QtTranslatorDebug) << "Unable to load qt translation" << qtNameHint << "at" << qtTranslationPath;
+        qCWarning(QtTranslatorDebug) << "Unable to load qt translation" << qtNameHint << "at" << qtTranslationPath;
     } else {
-        qCDebug(QtTranslatorDebug) << "Loaded qt translation" << qtNameHint << "at" << qtTranslationPath;
+        qCInfo(QtTranslatorDebug) << "Loaded qt translation" << qtNameHint << "at" << qtTranslationPath;
     }
     qApp->installTranslator(qtTranslator);
 
     QString appNameHint = translationPrefix + "_" + lang;
     bool appTranslationLoaded = qtTranslator->load(appNameHint, translationPath);
     if (!appTranslationLoaded) {
-        qCDebug(QtTranslatorDebug) << "Unable to load" << translationPrefix << "translation" << appNameHint << "at"
-                                   << translationPath;
+        qCWarning(QtTranslatorDebug) << "Unable to load" << translationPrefix << "translation" << appNameHint << "at"
+                                     << translationPath;
     } else {
-        qCDebug(QtTranslatorDebug) << "Loaded" << translationPrefix << "translation" << appNameHint << "at"
-                                   << translationPath;
+        qCInfo(QtTranslatorDebug) << "Loaded" << translationPrefix << "translation" << appNameHint << "at"
+                                  << translationPath;
     }
     qApp->installTranslator(translator);
 }
@@ -251,13 +251,13 @@ int main(int argc, char *argv[])
 
     QLocale::setDefault(QLocale::English);
 
-    qCDebug(MainLog) << "Starting main program";
+    qCInfo(MainLog) << "Starting main program";
 
     MainWindow ui;
     if (parser.isSet("connect")) {
         ui.setConnectTo(parser.value("connect"));
     }
-    qCDebug(MainLog) << "MainWindow constructor finished";
+    qCInfo(MainLog) << "MainWindow constructor finished";
 
     ui.setWindowIcon(QPixmap("theme:cockatrice"));
 #if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
@@ -272,7 +272,7 @@ int main(int argc, char *argv[])
     SpoilerBackgroundUpdater spoilerBackgroundUpdater;
 
     ui.show();
-    qCDebug(MainLog) << "ui.show() finished";
+    qCInfo(MainLog) << "ui.show() finished";
 
     // force shortcuts to be shown/hidden in right-click menus, regardless of system defaults
     qApp->setAttribute(Qt::AA_DontShowShortcutsInContextMenus, !SettingsCache::instance().getShowShortcuts());
@@ -282,7 +282,7 @@ int main(int argc, char *argv[])
 #endif
     app.exec();
 
-    qDebug("Event loop finished, terminating...");
+    qCInfo(MainLog) << "Event loop finished, terminating...";
     delete rng;
     PingPixmapGenerator::clear();
     CountryPixmapGenerator::clear();

--- a/cockatrice/src/server/user/user_info_connection.cpp
+++ b/cockatrice/src/server/user/user_info_connection.cpp
@@ -74,7 +74,7 @@ QStringList UserConnection_Information::getServerInfo(const QString &find)
     }
 
     if (_server.empty())
-        qCDebug(UserInfoConnectionLog) << "There was a problem!";
+        qCWarning(UserInfoConnectionLog) << "There was a problem!";
 
     return _server;
 }

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -140,7 +140,7 @@ QString SettingsCache::getSafeConfigPath(QString configEntry, QString defaultPat
     // ensure that the defaut path exists and return it
     if (tmp.isEmpty() || !QDir(tmp).exists()) {
         if (!QDir().mkpath(defaultPath))
-            qCDebug(SettingsCacheLog) << "[SettingsCache] Could not create folder:" << defaultPath;
+            qCInfo(SettingsCacheLog) << "[SettingsCache] Could not create folder:" << defaultPath;
         tmp = defaultPath;
     }
     return tmp;
@@ -161,7 +161,7 @@ SettingsCache::SettingsCache()
     // first, figure out if we are running in portable mode
     isPortableBuild = QFile::exists(qApp->applicationDirPath() + "/portable.dat");
     if (isPortableBuild)
-        qCDebug(SettingsCacheLog) << "Portable mode enabled";
+        qCInfo(SettingsCacheLog) << "Portable mode enabled";
 
     // define a dummy context that will be used where needed
     QString dummy = QT_TRANSLATE_NOOP("i18n", "English");

--- a/cockatrice/src/settings/shortcuts_settings.cpp
+++ b/cockatrice/src/settings/shortcuts_settings.cpp
@@ -74,7 +74,7 @@ void ShortcutsSettings::migrateShortcuts()
         shortCutsFile.beginGroup(custom);
 
         if (shortCutsFile.contains("Textbox/unfocusTextBox")) {
-            qCDebug(ShortcutsSettingsLog)
+            qCInfo(ShortcutsSettingsLog)
                 << "[ShortcutsSettings] Textbox/unfocusTextBox shortcut found. Migrating to Player/unfocusTextBox.";
             QString unfocusTextBox = shortCutsFile.value("Textbox/unfocusTextBox", "").toString();
             this->setShortcuts("Player/unfocusTextBox", unfocusTextBox);
@@ -82,7 +82,7 @@ void ShortcutsSettings::migrateShortcuts()
         }
 
         if (shortCutsFile.contains("tab_game/aFocusChat")) {
-            qCDebug(ShortcutsSettingsLog)
+            qCInfo(ShortcutsSettingsLog)
                 << "[ShortcutsSettings] tab_game/aFocusChat shortcut found. Migrating to Player/aFocusChat.";
             QString aFocusChat = shortCutsFile.value("tab_game/aFocusChat", "").toString();
             this->setShortcuts("Player/aFocusChat", aFocusChat);
@@ -91,7 +91,7 @@ void ShortcutsSettings::migrateShortcuts()
 
         // PR #5564 changes "MainWindow/aDeckEditor" to "Tabs/aTabDeckEditor"
         if (shortCutsFile.contains("MainWindow/aDeckEditor")) {
-            qCDebug(ShortcutsSettingsLog) << "MainWindow/aDeckEditor shortcut found. Migrating to Tabs/aTabDeckEditor.";
+            qCInfo(ShortcutsSettingsLog) << "MainWindow/aDeckEditor shortcut found. Migrating to Tabs/aTabDeckEditor.";
             QString keySequence = shortCutsFile.value("MainWindow/aDeckEditor", "").toString();
             this->setShortcuts("Tabs/aTabDeckEditor", keySequence);
             shortCutsFile.remove("MainWindow/aDeckEditor");


### PR DESCRIPTION
## Short roundup of the initial problem

Keeping the default log level at debug causes the logs to get spammed with logs from picture loading and server messages.

We tell users to paste their logs into their bug reports, but the debug spam just makes those logs long, noisy, and pointless.

## What will change with this Pull Request?
- Update `qtlogging.ini` so that the default log level is info
- bump up some `qCDebug`s to `qCInfo` and `qCWarning`
- Notably, the following are still at debug level:
    - Stuff in `PictureLoader` and its children, other than the final success and failure
    - `RemoteClient`'s server messages
    - everything in `FlowWidget` and `FlowLayout`
- The following got bumped to warning level: 
    - Failure logs
    - Logs that occur after defensive null checks. Let me know if that's too much.
- Xml parser encountering an unrecognized property is now at info level. This I'm less sure about since it has the potential to spam the logs, since a malformed xml is likely to have multiple entries with the unrecognized property 


