### PR TITLE
fix client crash when server goes down during registration

### DIFF
--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -574,6 +574,9 @@ void MainWindow::registerError(Response::ResponseCode r, QString reasonStr, quin
         case Response::RespRegistrationFailed:
             QMessageBox::critical(this, tr("Error"), tr("Registration failed for a technical problem on the server."));
             break;
+        case Response::RespNotConnected:
+            QMessageBox::critical(this, tr("Error"), tr("The connection to the server has been lost."));
+            break;
         default:
             QMessageBox::critical(this, tr("Error"),
                                   tr("Unknown registration error: %1").arg(static_cast<int>(r)) +

--- a/cockatrice/src/server/remote/remote_client.cpp
+++ b/cockatrice/src/server/remote/remote_client.cpp
@@ -339,6 +339,11 @@ void RemoteClient::registerResponse(const Response &response)
             emit registerAcceptedNeedsActivate();
             doLogin();
             break;
+        case Response::RespNotConnected:
+            // this response is created by the client from doDisconnectFromServer, do not call it again!
+            emit registerError(response.response_code(), QString::fromStdString(resp.denied_reason_str()),
+                               static_cast<quint32>(resp.denied_end_time()));
+            break;
         default:
             emit registerError(response.response_code(), QString::fromStdString(resp.denied_reason_str()),
                                static_cast<quint32>(resp.denied_end_time()));


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem
the client crashes if the server connection is lost while it is registering (eg if the server crashes)
this is because when an error occurs the client will disconnect from the server, disconnecting from the server is considered an error, this enters a recursive loop.

## What will change with this Pull Request?
- when disconnecting do not call the disconnect function
- adds an error message for this case

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
