### PR TITLE
Add search filter to card view window

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -157,6 +157,7 @@ set(cockatrice_SOURCES
     src/game/filters/filter_string.cpp
     src/game/filters/filter_tree.cpp
     src/game/filters/filter_tree_model.cpp
+    src/game/filters/syntax_help.cpp
     src/game/game_scene.cpp
     src/game/game_selector.cpp
     src/game/game_view.cpp

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_database_display_widget.cpp
@@ -1,6 +1,7 @@
 #include "deck_editor_database_display_widget.h"
 
 #include "../../../../game/cards/card_database_manager.h"
+#include "../../../../game/filters/syntax_help.h"
 #include "../../../../settings/cache_settings.h"
 #include "../../../tabs/abstract_tab_deck_editor.h"
 #include "../../../tabs/tab_supervisor.h"
@@ -56,7 +57,7 @@ DeckEditorDatabaseDisplayWidget::DeckEditorDatabaseDisplayWidget(AbstractTabDeck
             &DeckEditorDatabaseDisplayWidget::actAddCardToSideboard);
     connect(&searchKeySignals, &KeySignals::onCtrlEnter, this, &DeckEditorDatabaseDisplayWidget::actAddCardToSideboard);
     connect(&searchKeySignals, &KeySignals::onCtrlC, this, &DeckEditorDatabaseDisplayWidget::copyDatabaseCellContents);
-    connect(help, &QAction::triggered, this, &DeckEditorDatabaseDisplayWidget::showSearchSyntaxHelp);
+    connect(help, &QAction::triggered, this, [this] { createSearchSyntaxHelpWindow(searchEdit); });
 
     databaseModel = new CardDatabaseModel(CardDatabaseManager::getInstance(), true, this);
     databaseModel->setObjectName("databaseModel");
@@ -232,42 +233,6 @@ void DeckEditorDatabaseDisplayWidget::copyDatabaseCellContents()
 void DeckEditorDatabaseDisplayWidget::saveDbHeaderState()
 {
     SettingsCache::instance().layouts().setDeckEditorDbHeaderState(databaseView->header()->saveState());
-}
-
-void DeckEditorDatabaseDisplayWidget::showSearchSyntaxHelp()
-{
-
-    QFile file("theme:help/search.md");
-
-    if (!file.open(QFile::ReadOnly | QFile::Text)) {
-        return;
-    }
-
-    QTextStream in(&file);
-    QString text = in.readAll();
-    file.close();
-
-    // Poor Markdown Converter
-    auto opts = QRegularExpression::MultilineOption;
-    text = text.replace(QRegularExpression("^(###)(.*)", opts), "<h3>\\2</h3>")
-               .replace(QRegularExpression("^(##)(.*)", opts), "<h2>\\2</h2>")
-               .replace(QRegularExpression("^(#)(.*)", opts), "<h1>\\2</h1>")
-               .replace(QRegularExpression("^------*", opts), "<hr />")
-               .replace(QRegularExpression(R"(\[([^[]+)\]\(([^\)]+)\))", opts), R"(<a href='\2'>\1</a>)");
-
-    auto browser = new QTextBrowser;
-    browser->setParent(this, Qt::Window | Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowMinMaxButtonsHint |
-                                 Qt::WindowCloseButtonHint | Qt::WindowFullscreenButtonHint);
-    browser->setWindowTitle("Search Help");
-    browser->setReadOnly(true);
-    browser->setMinimumSize({500, 600});
-
-    QString sheet = QString("a { text-decoration: underline; color: rgb(71,158,252) };");
-    browser->document()->setDefaultStyleSheet(sheet);
-
-    browser->setHtml(text);
-    connect(browser, &QTextBrowser::anchorClicked, [this](const QUrl &link) { searchEdit->setText(link.fragment()); });
-    browser->show();
 }
 
 void DeckEditorDatabaseDisplayWidget::setFilterTree(FilterTree *filterTree)

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_database_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_database_display_widget.h
@@ -42,7 +42,6 @@ private:
     QWidget *centralWidget;
 
 private slots:
-    void showSearchSyntaxHelp();
     void retranslateUi();
     void updateSearch(const QString &search);
     void updateCard(const QModelIndex &current, const QModelIndex &);

--- a/cockatrice/src/game/filters/syntax_help.cpp
+++ b/cockatrice/src/game/filters/syntax_help.cpp
@@ -1,0 +1,62 @@
+#include "syntax_help.h"
+
+#include <QFile>
+#include <QRegularExpression>
+#include <QTextStream>
+
+/**
+ * Creates the card search syntax help window
+ *
+ * @return the QTextBrowser
+ */
+static QTextBrowser *createBrowser()
+{
+    QFile file("theme:help/search.md");
+
+    if (!file.open(QFile::ReadOnly | QFile::Text)) {
+        return nullptr;
+    }
+
+    QTextStream in(&file);
+    QString text = in.readAll();
+    file.close();
+
+    // Poor Markdown Converter
+    auto opts = QRegularExpression::MultilineOption;
+    text = text.replace(QRegularExpression("^(###)(.*)", opts), "<h3>\\2</h3>")
+               .replace(QRegularExpression("^(##)(.*)", opts), "<h2>\\2</h2>")
+               .replace(QRegularExpression("^(#)(.*)", opts), "<h1>\\2</h1>")
+               .replace(QRegularExpression("^------*", opts), "<hr />")
+               .replace(QRegularExpression(R"(\[([^[]+)\]\(([^\)]+)\))", opts), R"(<a href='\2'>\1</a>)");
+
+    auto browser = new QTextBrowser();
+    browser->setParent(nullptr, Qt::Window | Qt::WindowTitleHint | Qt::WindowSystemMenuHint |
+                                    Qt::WindowMinMaxButtonsHint | Qt::WindowCloseButtonHint |
+                                    Qt::WindowFullscreenButtonHint);
+    browser->setWindowTitle("Search Help");
+    browser->setReadOnly(true);
+    browser->setMinimumSize({500, 600});
+
+    QString sheet = QString("a { text-decoration: underline; color: rgb(71,158,252) };");
+    browser->document()->setDefaultStyleSheet(sheet);
+    browser->setHtml(text);
+
+    browser->show();
+
+    return browser;
+}
+
+/**
+ * Creates the card search syntax help window and connects its anchorClicked signal to the given QLineEdit.
+ * The window will automatically close when the QLineEdit is destroyed.
+ *
+ * @return the QTextBrowser
+ */
+QTextBrowser *createSearchSyntaxHelpWindow(QLineEdit *lineEdit)
+{
+    auto browser = createBrowser();
+    QObject::connect(browser, &QTextBrowser::anchorClicked,
+                     [lineEdit](const QUrl &link) { lineEdit->setText(link.fragment()); });
+    QObject::connect(lineEdit, &QObject::destroyed, browser, &QTextBrowser::close);
+    return browser;
+}

--- a/cockatrice/src/game/filters/syntax_help.h
+++ b/cockatrice/src/game/filters/syntax_help.h
@@ -1,0 +1,9 @@
+#ifndef SEARCH_SYNTAX_HELP_H
+#define SEARCH_SYNTAX_HELP_H
+
+#include <QLineEdit>
+#include <QTextBrowser>
+
+QTextBrowser *createSearchSyntaxHelpWindow(QLineEdit *lineEdit);
+
+#endif // SEARCH_SYNTAX_HELP_H

--- a/cockatrice/src/game/game_view.cpp
+++ b/cockatrice/src/game/game_view.cpp
@@ -11,7 +11,7 @@ GameView::GameView(GameScene *scene, QWidget *parent) : QGraphicsView(scene, par
 {
     setBackgroundBrush(QBrush(QColor(0, 0, 0)));
     setRenderHints(QPainter::TextAntialiasing | QPainter::Antialiasing);
-    setFocusPolicy(Qt::NoFocus);
+    setFocusPolicy(Qt::ClickFocus);
     setViewportUpdateMode(BoundingRectViewportUpdate);
 
     connect(scene, &GameScene::sceneRectChanged, this, &GameView::updateSceneRect);

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -148,7 +148,16 @@ void ZoneViewZone::updateCardIds(CardAction action)
 // Because of boundingRect(), this function must not be called before the zone was added to a scene.
 void ZoneViewZone::reorganizeCards()
 {
-    CardList cardsToDisplay(cards);
+    // filter cards
+    CardList cardsToDisplay = CardList(cards.getContentsKnown());
+    for (auto card : cards) {
+        if (filterString.check(card->getInfo())) {
+            card->show();
+            cardsToDisplay.append(card);
+        } else {
+            card->hide();
+        }
+    }
 
     // sort cards
     QList<CardList::SortOption> sortOptions;
@@ -261,6 +270,12 @@ ZoneViewZone::GridSize ZoneViewZone::positionCardsForDisplay(CardList &cards, Ca
 
         return GridSize{rows, qMax(cols, 1)};
     }
+}
+
+void ZoneViewZone::setFilterString(const QString &_filterString)
+{
+    filterString = FilterString(_filterString);
+    reorganizeCards();
 }
 
 void ZoneViewZone::setGroupBy(CardList::SortOption _groupBy)

--- a/cockatrice/src/game/zones/view_zone.h
+++ b/cockatrice/src/game/zones/view_zone.h
@@ -1,6 +1,7 @@
 #ifndef ZONEVIEWERZONE_H
 #define ZONEVIEWERZONE_H
 
+#include "../filters/filter_string.h"
 #include "select_zone.h"
 
 #include <QGraphicsLayoutItem>
@@ -35,6 +36,7 @@ private:
     int minRows, numberCards;
     CardZone *origZone;
     bool revealZone, writeableRevealZone;
+    FilterString filterString = FilterString("");
     CardList::SortOption groupBy, sortBy;
     bool pileView;
     bool isReversed;
@@ -96,6 +98,7 @@ public:
     }
 public slots:
     void close();
+    void setFilterString(const QString &_filterString);
     void setGroupBy(CardList::SortOption _groupBy);
     void setSortBy(CardList::SortOption _sortBy);
     void setPileView(int _pileView);

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -1,7 +1,9 @@
 #include "view_zone_widget.h"
 
+#include "../../client/ui/pixel_map_generator.h"
 #include "../../settings/cache_settings.h"
 #include "../cards/card_item.h"
+#include "../filters/syntax_help.h"
 #include "../game_scene.h"
 #include "../player/player.h"
 #include "pb/command_shuffle.pb.h"
@@ -41,9 +43,24 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
     setFlag(ItemIgnoresTransformations);
 
     QGraphicsLinearLayout *vbox = new QGraphicsLinearLayout(Qt::Vertical);
+    vbox->setSpacing(2);
 
     // If the number is < 0, then it means that we can give the option to make the area sorted
     if (numberCards < 0) {
+        // search edit
+        searchEdit.setFocusPolicy(Qt::ClickFocus);
+        searchEdit.setPlaceholderText(tr("Search by card name (or search expressions)"));
+        searchEdit.setClearButtonEnabled(true);
+        searchEdit.addAction(loadColorAdjustedPixmap("theme:icons/search"), QLineEdit::LeadingPosition);
+        auto help = searchEdit.addAction(QPixmap("theme:icons/info"), QLineEdit::TrailingPosition);
+
+        connect(help, &QAction::triggered, this, [this] { createSearchSyntaxHelpWindow(&searchEdit); });
+
+        QGraphicsProxyWidget *searchEditProxy = new QGraphicsProxyWidget;
+        searchEditProxy->setWidget(&searchEdit);
+        searchEditProxy->setZValue(2000000007);
+        vbox->addItem(searchEditProxy);
+
         // top row
         QGraphicsLinearLayout *hTopRow = new QGraphicsLinearLayout(Qt::Horizontal);
 

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -145,6 +145,8 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
         if (CardList::NoSort == static_cast<CardList::SortOption>(groupBySelector.currentData().toInt())) {
             pileViewCheckBox.setEnabled(false);
         }
+
+        connect(&searchEdit, &QLineEdit::textChanged, zone, &ZoneViewZone::setFilterString);
     }
 
     setLayout(vbox);

--- a/cockatrice/src/game/zones/view_zone_widget.h
+++ b/cockatrice/src/game/zones/view_zone_widget.h
@@ -7,6 +7,7 @@
 #include <QComboBox>
 #include <QGraphicsProxyWidget>
 #include <QGraphicsWidget>
+#include <QLineEdit>
 
 class QLabel;
 class QPushButton;
@@ -47,6 +48,8 @@ private:
     QPushButton *closeButton;
     QScrollBar *scrollBar;
     ScrollableGraphicsProxyWidget *scrollBarProxy;
+
+    QLineEdit searchEdit;
     QComboBox groupBySelector;
     QComboBox sortBySelector;
     QCheckBox shuffleCheckBox;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2993 

## Short roundup of the initial problem

We want card search in the card view window

## What will change with this Pull Request?

https://github.com/user-attachments/assets/5c0cfd5c-a0a8-4b43-81d4-55976decb7c2

- Refactored the search syntax help window code into a separate file
  - The `QTextBrowser` is now unparented, but closes when the `QLineEdit` it's connected to is destroyed. 
    - This should still leave to the exact same behavior as before in the deck editor tab.
- Added a search bar to the top of the `ZoneViewWidget`
  - Also reduced widget spacing in `ZoneViewWidget` to make the search bar fit nicer
- Implemented filtering logic 
  - `ZoneViewZone` stores a filterString. 
    - `ZoneViewWidget` sets `ZoneViewZone`'s filterString whenever the `QLineEdit` changes
  - Filtering happens in `ZoneViewZone`, right before sorting happens.
    - if `CardItem`'s `CardInfo` passes the filterString check, it's added to the list to be sorted and set to visible (in order to clear any hides from previous filterStrings)
    - if it doesn't pass the check, then the `CardItem` is hidden
  - Apparently this is all you need to do to implement filtering. Seems to work flawlessly for me so far, even for corner cases.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<img width="400" alt="Screenshot 2025-04-04 at 11 20 26 PM" src="https://github.com/user-attachments/assets/ca179bcd-53a7-4dfa-a2a3-45ee2664fb9b" />

<img width="300" alt="Screenshot 2025-04-04 at 11 20 35 PM" src="https://github.com/user-attachments/assets/6f8de6ea-8c56-4246-96b2-b191e757a37b" />
