### PR TITLE
Fix QImage::mirrored deprecation warning

### DIFF
--- a/cockatrice/src/client/ui/picture_loader/picture_loader.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader.cpp
@@ -140,7 +140,11 @@ void PictureLoader::imageLoaded(CardInfoPtr card, const QImage &image)
         QPixmapCache::insert(card->getPixmapCacheKey(), QPixmap());
     } else {
         if (card->getUpsideDownArt()) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 9, 0))
+            QImage mirrorImage = image.flipped(Qt::Horizontal | Qt::Vertical);
+#else
             QImage mirrorImage = image.mirrored(true, true);
+#endif
             QPixmapCache::insert(card->getPixmapCacheKey(), QPixmap::fromImage(mirrorImage));
         } else {
             QPixmapCache::insert(card->getPixmapCacheKey(), QPixmap::fromImage(image));


### PR DESCRIPTION
## Short roundup of the initial problem

Some builds in CI are now up to Qt 6.9, causing them to fail due to deprecation warnings

```
/Users/runner/work/Cockatrice/Cockatrice/cockatrice/src/client/ui/picture_loader/picture_loader.cpp:143:40: error: 'mirrored' is deprecated: Use flipped(Qt::Orientations) instead [-Werror,-Wdeprecated-declarations]
    143 |             QImage mirrorImage = image.mirrored(true, true);
        |                                        ^
  /opt/homebrew/include/QtGui/qimage.h:219:5: note: 'mirrored' has been explicitly marked deprecated here
    219 |     QT_DEPRECATED_VERSION_X_6_13("Use flipped(Qt::Orientations) instead")
        |     ^
  /opt/homebrew/include/QtCore/qtdeprecationmarkers.h:245:45: note: expanded from macro 'QT_DEPRECATED_VERSION_X_6_13'
    245 | # define QT_DEPRECATED_VERSION_X_6_13(text) QT_DEPRECATED_X(text)
        |                                             ^
  /opt/homebrew/include/QtCore/qtdeprecationmarkers.h:29:33: note: expanded from macro 'QT_DEPRECATED_X'
     29 | #  define QT_DEPRECATED_X(text) Q_DECL_DEPRECATED_X(text)
        |                                 ^
  [ 30%] Building CXX object common/pb/CMakeFiles/cockatrice_protocol.dir/command_create_counter.pb.cc.o
  /opt/homebrew/include/QtCore/qcompilerdetection.h:996:36: note: expanded from macro 'Q_DECL_DEPRECATED_X'
    996 | #  define Q_DECL_DEPRECATED_X(x) [[deprecated(x)]]
        |                                    ^
  1 error generated.
```


## What will change with this Pull Request?
- use `flipped` if Qt version is >= 6.9
