### PR TITLE
Add confirmation dialog for force start

### DIFF
--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -303,6 +303,13 @@ void DeckViewContainer::readyStart()
 
 void DeckViewContainer::forceStart()
 {
+    const auto msg = tr("Are you sure you want to force start?\nThis will kick all non-ready players from the game.");
+    const auto res =
+        QMessageBox::warning(this, tr("Cockatrice"), msg, QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+    if (res == QMessageBox::No) {
+        return;
+    }
+
     Command_ReadyStart cmd;
     cmd.set_force_start(true);
     cmd.set_ready(true);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5795

## Short roundup of the initial problem


## What will change with this Pull Request?

https://github.com/user-attachments/assets/ca58eb2e-84c6-4575-b56b-2984d93ae131

- Force start button now brings up a confirmation dialog
  - default button is yes

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<img width="265" alt="Screenshot 2025-04-06 at 12 21 59 AM" src="https://github.com/user-attachments/assets/80bea8f9-82df-41f7-a1e9-e2a4fd867778" />

