### PR TITLE
Fix game phases not being translated in game log

### DIFF
--- a/cockatrice/src/game/phase.cpp
+++ b/cockatrice/src/game/phase.cpp
@@ -1,8 +1,16 @@
 #include "phase.h"
 
-Phase::Phase(const char *_name, QString _color, QString _soundFileName) : color(_color), soundFileName(_soundFileName)
+Phase::Phase(const QString &_name, const QString &_color, const QString &_soundFileName)
+    : name(_name), color(_color), soundFileName(_soundFileName)
 {
-    name = tr(_name);
+}
+
+/**
+ * @return The translated name for the phase
+ */
+QString Phase::getName() const
+{
+    return tr(name.toUtf8().data());
 }
 
 Phase Phases::getPhase(int phase)

--- a/cockatrice/src/game/phase.h
+++ b/cockatrice/src/game/phase.h
@@ -1,16 +1,20 @@
 #ifndef PHASE_H
 #define PHASE_H
 
+#include <QApplication>
 #include <QString>
-#include <QtCore>
 
 class Phase
 {
     Q_DECLARE_TR_FUNCTIONS(Phase)
 
+    QString name;
+
 public:
-    QString name, color, soundFileName;
-    Phase(const char *_name, QString _color, QString _soundFileName);
+    QString color, soundFileName;
+    Phase(const QString &_name, const QString &_color, const QString &_soundFileName);
+
+    QString getName() const;
 };
 
 struct Phases

--- a/cockatrice/src/server/message_log_widget.cpp
+++ b/cockatrice/src/server/message_log_widget.cpp
@@ -616,7 +616,7 @@ void MessageLogWidget::logSetActivePhase(int phaseNumber)
     soundEngine->playSound(phase.soundFileName);
 
     appendHtml("<font color=\"" + phase.color + "\"><b>" + QDateTime::currentDateTime().toString("[hh:mm:ss] ") +
-               phase.name + "</b></font>");
+               phase.getName() + "</b></font>");
 }
 
 void MessageLogWidget::logSetActivePlayer(Player *player)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5789 

## Short roundup of the initial problem

Phase names aren't being translated because the translation happens in the `Phase`'s constructor, but Cockatrice creates a const static array of `Phase`s and uses that for the entire runtime of the program

## What will change with this Pull Request?

https://github.com/user-attachments/assets/a9e9ea86-f60f-4185-a1be-97602d8d66a7

- Change `Phase`'s `name` into a private field with a getter.
  - translate the name in the getter. 

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
