### PR TITLE
Support creating face-down tokens

### DIFF
--- a/cockatrice/src/dialogs/dlg_create_token.cpp
+++ b/cockatrice/src/dialogs/dlg_create_token.cpp
@@ -63,6 +63,9 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
     destroyCheckBox = new QCheckBox(tr("&Destroy token when it leaves the table"));
     destroyCheckBox->setChecked(true);
 
+    faceDownCheckBox = new QCheckBox(tr("Create face-down token"));
+    faceDownCheckBox->setChecked(false);
+
     QGridLayout *grid = new QGridLayout;
     grid->addWidget(nameLabel, 0, 0);
     grid->addWidget(nameEdit, 0, 1);
@@ -73,6 +76,7 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
     grid->addWidget(annotationLabel, 3, 0);
     grid->addWidget(annotationEdit, 3, 1);
     grid->addWidget(destroyCheckBox, 4, 0, 1, 2);
+    grid->addWidget(faceDownCheckBox, 5, 0, 1, 2);
 
     QGroupBox *tokenDataGroupBox = new QGroupBox(tr("Token data"));
     tokenDataGroupBox->setLayout(grid);
@@ -230,5 +234,6 @@ TokenInfo DlgCreateToken::getTokenInfo() const
             .color = colorEdit->itemData(colorEdit->currentIndex()).toString(),
             .pt = ptEdit->text(),
             .annotation = annotationEdit->text(),
-            .destroy = destroyCheckBox->isChecked()};
+            .destroy = destroyCheckBox->isChecked(),
+            .faceDown = faceDownCheckBox->isChecked()};
 }

--- a/cockatrice/src/dialogs/dlg_create_token.cpp
+++ b/cockatrice/src/dialogs/dlg_create_token.cpp
@@ -63,7 +63,7 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
     destroyCheckBox = new QCheckBox(tr("&Destroy token when it leaves the table"));
     destroyCheckBox->setChecked(true);
 
-    faceDownCheckBox = new QCheckBox(tr("Create face-down token"));
+    faceDownCheckBox = new QCheckBox(tr("Create face-down (Only hides name)"));
     connect(faceDownCheckBox, &QCheckBox::toggled, this, &DlgCreateToken::faceDownCheckBoxToggled);
 
     QGridLayout *grid = new QGridLayout;
@@ -167,9 +167,6 @@ void DlgCreateToken::faceDownCheckBoxToggled(bool checked)
         ptEdit->clear();
         ptEdit->clearFocus();
         ptEdit->setEnabled(false);
-        annotationEdit->clear();
-        annotationEdit->clearFocus();
-        annotationEdit->setEnabled(false);
     } else {
         colorEdit->setEnabled(true);
         ptEdit->setEnabled(true);

--- a/cockatrice/src/dialogs/dlg_create_token.cpp
+++ b/cockatrice/src/dialogs/dlg_create_token.cpp
@@ -64,7 +64,7 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
     destroyCheckBox->setChecked(true);
 
     faceDownCheckBox = new QCheckBox(tr("Create face-down token"));
-    faceDownCheckBox->setChecked(false);
+    connect(faceDownCheckBox, &QCheckBox::toggled, this, &DlgCreateToken::faceDownCheckBoxToggled);
 
     QGridLayout *grid = new QGridLayout;
     grid->addWidget(nameLabel, 0, 0);
@@ -157,6 +157,21 @@ void DlgCreateToken::closeEvent(QCloseEvent *event)
 {
     event->accept();
     SettingsCache::instance().setTokenDialogGeometry(saveGeometry());
+}
+
+void DlgCreateToken::faceDownCheckBoxToggled(bool checked)
+{
+    if (checked) {
+        ptEdit->clear();
+        ptEdit->clearFocus();
+        ptEdit->setEnabled(false);
+        annotationEdit->clear();
+        annotationEdit->clearFocus();
+        annotationEdit->setEnabled(false);
+    } else {
+        ptEdit->setEnabled(true);
+        annotationEdit->setEnabled(true);
+    }
 }
 
 void DlgCreateToken::tokenSelectionChanged(const QModelIndex &current, const QModelIndex & /*previous*/)

--- a/cockatrice/src/dialogs/dlg_create_token.cpp
+++ b/cockatrice/src/dialogs/dlg_create_token.cpp
@@ -162,6 +162,8 @@ void DlgCreateToken::closeEvent(QCloseEvent *event)
 void DlgCreateToken::faceDownCheckBoxToggled(bool checked)
 {
     if (checked) {
+        colorEdit->setCurrentIndex(6);
+        colorEdit->setEnabled(false);
         ptEdit->clear();
         ptEdit->clearFocus();
         ptEdit->setEnabled(false);
@@ -169,6 +171,7 @@ void DlgCreateToken::faceDownCheckBoxToggled(bool checked)
         annotationEdit->clearFocus();
         annotationEdit->setEnabled(false);
     } else {
+        colorEdit->setEnabled(true);
         ptEdit->setEnabled(true);
         annotationEdit->setEnabled(true);
     }

--- a/cockatrice/src/dialogs/dlg_create_token.h
+++ b/cockatrice/src/dialogs/dlg_create_token.h
@@ -37,6 +37,7 @@ public:
 protected:
     void closeEvent(QCloseEvent *event) override;
 private slots:
+    void faceDownCheckBoxToggled(bool checked);
     void tokenSelectionChanged(const QModelIndex &current, const QModelIndex &previous);
     void updateSearch(const QString &search);
     void actChooseTokenFromAll(bool checked);

--- a/cockatrice/src/dialogs/dlg_create_token.h
+++ b/cockatrice/src/dialogs/dlg_create_token.h
@@ -24,6 +24,7 @@ struct TokenInfo
     QString pt;
     QString annotation;
     bool destroy = true;
+    bool faceDown = false;
 };
 
 class DlgCreateToken : public QDialog
@@ -51,6 +52,7 @@ private:
     QComboBox *colorEdit;
     QLineEdit *nameEdit, *ptEdit, *annotationEdit;
     QCheckBox *destroyCheckBox;
+    QCheckBox *faceDownCheckBox;
     QRadioButton *chooseTokenFromAllRadioButton, *chooseTokenFromDeckRadioButton;
     CardInfoPictureWidget *pic;
     QTreeView *chooseTokenView;

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -1855,6 +1855,7 @@ void Player::actCreateAnotherToken()
     cmd.set_pt(lastTokenInfo.pt.toStdString());
     cmd.set_annotation(lastTokenInfo.annotation.toStdString());
     cmd.set_destroy_on_zone_change(lastTokenInfo.destroy);
+    cmd.set_face_down(lastTokenInfo.faceDown);
     cmd.set_x(-1);
     cmd.set_y(lastTokenTableRow);
 

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -2246,7 +2246,7 @@ void Player::eventCreateToken(const Event_CreateToken &event)
     card->setDestroyOnZoneChange(event.destroy_on_zone_change());
     card->setFaceDown(event.face_down());
 
-    emit logCreateToken(this, card->getName(), card->getPT());
+    emit logCreateToken(this, card->getName(), card->getPT(), card->getFaceDown());
     zone->addCard(card, true, event.x(), event.y());
 }
 

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -2232,10 +2232,10 @@ void Player::eventCreateToken(const Event_CreateToken &event)
 
     CardItem *card = new CardItem(this, nullptr, QString::fromStdString(event.card_name()),
                                   QString::fromStdString(event.card_provider_id()), event.card_id());
-    // use db PT if not provided in event
+    // use db PT if not provided in event and not face-down
     if (!QString::fromStdString(event.pt()).isEmpty()) {
         card->setPT(QString::fromStdString(event.pt()));
-    } else {
+    } else if (!event.face_down()) {
         CardInfoPtr dbCard = card->getInfo();
         if (dbCard) {
             card->setPT(dbCard->getPowTough());
@@ -2244,6 +2244,7 @@ void Player::eventCreateToken(const Event_CreateToken &event)
     card->setColor(QString::fromStdString(event.color()));
     card->setAnnotation(QString::fromStdString(event.annotation()));
     card->setDestroyOnZoneChange(event.destroy_on_zone_change());
+    card->setFaceDown(event.face_down());
 
     emit logCreateToken(this, card->getName(), card->getPT());
     zone->addCard(card, true, event.x(), event.y());

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -128,7 +128,7 @@ signals:
                         Player *targetPlayer,
                         QString targetCard,
                         bool _playerTarget);
-    void logCreateToken(Player *player, QString cardName, QString pt);
+    void logCreateToken(Player *player, QString cardName, QString pt, bool faceDown);
     void logDrawCards(Player *player, int number, bool deckIsEmpty);
     void logUndoDraw(Player *player, QString cardName);
     void logMoveCard(Player *player, CardItem *card, CardZone *startZone, int oldX, CardZone *targetZone, int newX);

--- a/cockatrice/src/server/message_log_widget.cpp
+++ b/cockatrice/src/server/message_log_widget.cpp
@@ -217,7 +217,7 @@ void MessageLogWidget::logCreateArrow(Player *player,
 void MessageLogWidget::logCreateToken(Player *player, QString cardName, QString pt, bool faceDown)
 {
     if (faceDown) {
-        appendHtmlServerMessage(tr("%1 creates face down token.").arg(sanitizeHtml(player->getName())));
+        appendHtmlServerMessage(tr("%1 creates a face down token.").arg(sanitizeHtml(player->getName())));
     } else {
         appendHtmlServerMessage(tr("%1 creates token: %2%3.")
                                     .arg(sanitizeHtml(player->getName()))

--- a/cockatrice/src/server/message_log_widget.cpp
+++ b/cockatrice/src/server/message_log_widget.cpp
@@ -214,12 +214,16 @@ void MessageLogWidget::logCreateArrow(Player *player,
     }
 }
 
-void MessageLogWidget::logCreateToken(Player *player, QString cardName, QString pt)
+void MessageLogWidget::logCreateToken(Player *player, QString cardName, QString pt, bool faceDown)
 {
-    appendHtmlServerMessage(tr("%1 creates token: %2%3.")
-                                .arg(sanitizeHtml(player->getName()))
-                                .arg(cardLink(std::move(cardName)))
-                                .arg(pt.isEmpty() ? QString() : QString(" (%1)").arg(sanitizeHtml(pt))));
+    if (faceDown) {
+        appendHtmlServerMessage(tr("%1 creates face down token.").arg(sanitizeHtml(player->getName())));
+    } else {
+        appendHtmlServerMessage(tr("%1 creates token: %2%3.")
+                                    .arg(sanitizeHtml(player->getName()))
+                                    .arg(cardLink(std::move(cardName)))
+                                    .arg(pt.isEmpty() ? QString() : QString(" (%1)").arg(sanitizeHtml(pt))));
+    }
 }
 
 void MessageLogWidget::logDeckSelect(Player *player, QString deckHash, int sideboardSize)

--- a/cockatrice/src/server/message_log_widget.h
+++ b/cockatrice/src/server/message_log_widget.h
@@ -41,7 +41,7 @@ public slots:
                         Player *targetPlayer,
                         QString targetCard,
                         bool playerTarget);
-    void logCreateToken(Player *player, QString cardName, QString pt);
+    void logCreateToken(Player *player, QString cardName, QString pt, bool faceDown);
     void logDeckSelect(Player *player, QString deckHash, int sideboardSize);
     void logDestroyCard(Player *player, QString cardName);
     void logDrawCards(Player *player, int number, bool deckIsEmpty);

--- a/common/pb/command_create_token.proto
+++ b/common/pb/command_create_token.proto
@@ -27,4 +27,5 @@ message Command_CreateToken {
     optional TargetMode target_mode = 11;
 
     optional string card_provider_id = 12;
+    optional bool face_down = 13;
 }

--- a/common/pb/event_create_token.proto
+++ b/common/pb/event_create_token.proto
@@ -15,4 +15,5 @@ message Event_CreateToken {
     optional sint32 x = 8;
     optional sint32 y = 9;
     optional string card_provider_id = 10;
+    optional bool face_down = 11;
 }

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -1519,8 +1519,8 @@ Server_Player::cmdCreateToken(const Command_CreateToken &cmd, ResponseContainer 
     if (!cmd.face_down()) {
         card->setColor(nameFromStdString(cmd.color()));
         card->setPT(nameFromStdString(cmd.pt()));
-        card->setAnnotation(nameFromStdString(cmd.annotation()));
     }
+    card->setAnnotation(nameFromStdString(cmd.annotation()));
     card->setDestroyOnZoneChange(cmd.destroy_on_zone_change());
     card->setFaceDown(cmd.face_down());
 

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -401,9 +401,9 @@ makeCreateTokenEvent(Server_CardZone *zone, Server_Card *card, int xCoord, int y
     if (!card->getFaceDown() || revealFacedownInfo) {
         event.set_card_name(card->getName().toStdString());
         event.set_card_provider_id(card->getProviderId().toStdString());
-        event.set_color(card->getColor().toStdString());
     }
 
+    event.set_color(card->getColor().toStdString());
     event.set_pt(card->getPT().toStdString());
     event.set_annotation(card->getAnnotation().toStdString());
     event.set_destroy_on_zone_change(card->getDestroyOnZoneChange());
@@ -1515,9 +1515,9 @@ Server_Player::cmdCreateToken(const Command_CreateToken &cmd, ResponseContainer 
 
     auto *card = new Server_Card(cardName, cardProviderId, newCardId(), xCoord, yCoord);
     card->moveToThread(thread());
-    card->setColor(nameFromStdString(cmd.color()));
     // Client should already prevent face-down tokens from having attributes; this just an extra server-side check
     if (!cmd.face_down()) {
+        card->setColor(nameFromStdString(cmd.color()));
         card->setPT(nameFromStdString(cmd.pt()));
         card->setAnnotation(nameFromStdString(cmd.annotation()));
     }

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -386,14 +386,24 @@ void Server_Player::revealTopCardIfNeeded(Server_CardZone *zone, GameEventStorag
     }
 }
 
-static Event_CreateToken makeCreateTokenEvent(Server_CardZone *zone, Server_Card *card, int xCoord, int yCoord)
+/**
+ * Creates the create token event.
+ * By default, will set event's name and color fields to empty if the token is face-down
+ */
+static Event_CreateToken
+makeCreateTokenEvent(Server_CardZone *zone, Server_Card *card, int xCoord, int yCoord, bool revealFacedownInfo = false)
 {
     Event_CreateToken event;
     event.set_zone_name(zone->getName().toStdString());
     event.set_card_id(card->getId());
-    event.set_card_name(card->getName().toStdString());
-    event.set_card_provider_id(card->getProviderId().toStdString());
-    event.set_color(card->getColor().toStdString());
+    event.set_face_down(card->getFaceDown());
+
+    if (!card->getFaceDown() || revealFacedownInfo) {
+        event.set_card_name(card->getName().toStdString());
+        event.set_card_provider_id(card->getProviderId().toStdString());
+        event.set_color(card->getColor().toStdString());
+    }
+
     event.set_pt(card->getPT().toStdString());
     event.set_annotation(card->getAnnotation().toStdString());
     event.set_destroy_on_zone_change(card->getDestroyOnZoneChange());
@@ -401,7 +411,6 @@ static Event_CreateToken makeCreateTokenEvent(Server_CardZone *zone, Server_Card
     event.set_y(yCoord);
     return event;
 }
-
 static Event_AttachCard makeAttachCardEvent(Server_Card *attachedCard, Server_Card *parentCard = nullptr)
 {
     Event_AttachCard event;
@@ -1494,7 +1503,8 @@ Server_Player::cmdCreateToken(const Command_CreateToken &cmd, ResponseContainer 
     const QString cardName = nameFromStdString(cmd.card_name());
     const QString cardProviderId = nameFromStdString(cmd.card_provider_id());
     if (zone->hasCoords()) {
-        xCoord = zone->getFreeGridColumn(xCoord, yCoord, cardName, false);
+        bool dontStackSameName = cmd.face_down();
+        xCoord = zone->getFreeGridColumn(xCoord, yCoord, cardName, dontStackSameName);
     }
     if (xCoord < 0) {
         xCoord = 0;
@@ -1505,13 +1515,17 @@ Server_Player::cmdCreateToken(const Command_CreateToken &cmd, ResponseContainer 
 
     auto *card = new Server_Card(cardName, cardProviderId, newCardId(), xCoord, yCoord);
     card->moveToThread(thread());
-    card->setPT(nameFromStdString(cmd.pt()));
     card->setColor(nameFromStdString(cmd.color()));
-    card->setAnnotation(nameFromStdString(cmd.annotation()));
+    // Client should already prevent face-down tokens from having attributes; this just an extra server-side check
+    if (!cmd.face_down()) {
+        card->setPT(nameFromStdString(cmd.pt()));
+        card->setAnnotation(nameFromStdString(cmd.annotation()));
+    }
     card->setDestroyOnZoneChange(cmd.destroy_on_zone_change());
+    card->setFaceDown(cmd.face_down());
 
     zone->insertCard(card, xCoord, yCoord);
-    ges.enqueueGameEvent(makeCreateTokenEvent(zone, card, xCoord, yCoord), playerId);
+    sendCreateTokenEvents(zone, card, xCoord, yCoord, ges);
 
     // check if the token is a replacement for an existing card
     if (!targetCard) {
@@ -1640,6 +1654,38 @@ Server_Player::cmdCreateToken(const Command_CreateToken &cmd, ResponseContainer 
     }
 
     return Response::RespOk;
+}
+
+/**
+ * Creates and sends the events required to properly communicate the given token creation.
+ * Primarily written to handle creating face-down tokens.
+ */
+void Server_Player::sendCreateTokenEvents(Server_CardZone *zone,
+                                          Server_Card *card,
+                                          int xCoord,
+                                          int yCoord,
+                                          GameEventStorage &ges)
+{
+    // Token is not face-down; things are easy
+    if (!card->getFaceDown()) {
+        ges.enqueueGameEvent(makeCreateTokenEvent(zone, card, xCoord, yCoord), playerId);
+        return;
+    }
+
+    // Token is face-down. We have to send different info to each player
+    auto eventOthers = makeCreateTokenEvent(zone, card, xCoord, yCoord, false);
+    ges.enqueueGameEvent(eventOthers, playerId, GameEventStorageItem::SendToOthers);
+
+    auto eventPrivate = makeCreateTokenEvent(zone, card, xCoord, yCoord, true);
+    ges.enqueueGameEvent(eventPrivate, playerId, GameEventStorageItem::SendToPrivate, playerId);
+
+    // Event_CreateToken didn't use to have face_down field; send attribute event afterward for backwards compatibility
+    Event_SetCardAttr event;
+    event.set_zone_name(zone->getName().toStdString());
+    event.set_card_id(card->getId());
+    event.set_attribute(AttrFaceDown);
+    event.set_attr_value("1");
+    ges.enqueueGameEvent(event, playerId);
 }
 
 Response::ResponseCode

--- a/common/server_player.h
+++ b/common/server_player.h
@@ -84,6 +84,7 @@ private:
     bool conceded;
     bool sideboardLocked;
     void revealTopCardIfNeeded(Server_CardZone *zone, GameEventStorage &ges);
+    void sendCreateTokenEvents(Server_CardZone *zone, Server_Card *card, int xCoord, int yCoord, GameEventStorage &ges);
 
 public:
     mutable QMutex playerMutex;


### PR DESCRIPTION
## Related Ticket(s)

* Fixes #4994
* Partially addresses #3278

## Short roundup of the initial problem

Users want a way to write hidden information in Cockatrice, which we've decided to handle through face-down tokens

## What will change with this Pull Request?

https://github.com/user-attachments/assets/b7bd9809-f030-45e6-99f6-4ab441b1b6d4

- Added a new `Create face-down token` checkbox to the token creation dialog 
  - Checking the checkbox will disable the pt and annotation line edits
    - Those attributes aren't supported on face-down tokens, since Cockatrice currently can't hide those values on non-predefined tokens
- Updated create token command and event proto to add `face_down` bool field.
- Updated server and client code to handle new face down token creation
- Updated game log to log face-down tokens with "PLAYER creates face down token."

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<img width="400" alt="Screenshot 2025-04-14 at 1 23 26 AM" src="https://github.com/user-attachments/assets/1d7f2aba-e18f-4f69-a943-45b40c56e642" />
