### PR TITLE
change settings entry of the cod conversion prompt to a combobox

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.cpp
@@ -106,16 +106,16 @@ void DeckPreviewDeckTagsDisplayWidget::openTagEditDlg()
                     canAddTags = true;
 
                     if (conversionDialog.dontAskAgain()) {
-                        SettingsCache::instance().setVisualDeckStoragePromptForConversion(Qt::CheckState::Unchecked);
-                        SettingsCache::instance().setVisualDeckStorageAlwaysConvert(Qt::CheckState::Checked);
+                        SettingsCache::instance().setVisualDeckStoragePromptForConversion(false);
+                        SettingsCache::instance().setVisualDeckStorageAlwaysConvert(true);
                     }
                 } else {
-                    SettingsCache::instance().setVisualDeckStorageAlwaysConvert(Qt::CheckState::Unchecked);
+                    SettingsCache::instance().setVisualDeckStorageAlwaysConvert(false);
 
                     if (conversionDialog.dontAskAgain()) {
-                        SettingsCache::instance().setVisualDeckStoragePromptForConversion(Qt::CheckState::Unchecked);
+                        SettingsCache::instance().setVisualDeckStoragePromptForConversion(false);
                     } else {
-                        SettingsCache::instance().setVisualDeckStoragePromptForConversion(Qt::CheckState::Checked);
+                        SettingsCache::instance().setVisualDeckStoragePromptForConversion(true);
                     }
                 }
             }

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -563,6 +563,13 @@ void AppearanceSettingsPage::retranslateUi()
     maxFontSizeForCardsLabel.setText(tr("Maximum font size for information displayed on cards:"));
 }
 
+enum visualDeckStoragePromptForConversionIndex
+{
+    visualDeckStoragePromptForConversionIndexNone,
+    visualDeckStoragePromptForConversionIndexPrompt,
+    visualDeckStoragePromptForConversionIndexAlways
+};
+
 UserInterfaceSettingsPage::UserInterfaceSettingsPage()
 {
     // general settings and notification settings
@@ -642,24 +649,33 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     connect(&openDeckInNewTabCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setOpenDeckInNewTab);
 
-    visualDeckStoragePromptForConversionCheckBox.setChecked(
-        SettingsCache::instance().getVisualDeckStoragePromptForConversion());
-    connect(&visualDeckStoragePromptForConversionCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
-            &SettingsCache::setVisualDeckStoragePromptForConversion);
-
-    visualDeckStorageAlwaysConvertCheckBox.setChecked(SettingsCache::instance().getVisualDeckStorageAlwaysConvert());
-    connect(&visualDeckStorageAlwaysConvertCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
-            &SettingsCache::setVisualDeckStorageAlwaysConvert);
-
     visualDeckStorageInGameCheckBox.setChecked(SettingsCache::instance().getVisualDeckStorageInGame());
     connect(&visualDeckStorageInGameCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setVisualDeckStorageInGame);
 
+    visualDeckStoragePromptForConversionSelector.addItem(""); // these will be set in retranslateUI
+    visualDeckStoragePromptForConversionSelector.addItem("");
+    visualDeckStoragePromptForConversionSelector.addItem("");
+    if (SettingsCache::instance().getVisualDeckStoragePromptForConversion()) {
+        visualDeckStoragePromptForConversionSelector.setCurrentIndex(visualDeckStoragePromptForConversionIndexPrompt);
+    } else if (SettingsCache::instance().getVisualDeckStorageAlwaysConvert()) {
+        visualDeckStoragePromptForConversionSelector.setCurrentIndex(visualDeckStoragePromptForConversionIndexAlways);
+    } else {
+        visualDeckStoragePromptForConversionSelector.setCurrentIndex(visualDeckStoragePromptForConversionIndexNone);
+    }
+    connect(&visualDeckStoragePromptForConversionSelector, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            [this](int index) {
+                SettingsCache::instance().setVisualDeckStoragePromptForConversion(
+                    index == visualDeckStoragePromptForConversionIndexPrompt);
+                SettingsCache::instance().setVisualDeckStorageAlwaysConvert(
+                    index == visualDeckStoragePromptForConversionIndexAlways);
+            });
+
     auto *deckEditorGrid = new QGridLayout;
     deckEditorGrid->addWidget(&openDeckInNewTabCheckBox, 0, 0);
-    deckEditorGrid->addWidget(&visualDeckStoragePromptForConversionCheckBox, 1, 0);
-    deckEditorGrid->addWidget(&visualDeckStorageAlwaysConvertCheckBox, 2, 0);
-    deckEditorGrid->addWidget(&visualDeckStorageInGameCheckBox, 3, 0);
+    deckEditorGrid->addWidget(&visualDeckStorageInGameCheckBox, 1, 0);
+    deckEditorGrid->addWidget(&visualDeckStoragePromptForConversionLabel, 2, 0);
+    deckEditorGrid->addWidget(&visualDeckStoragePromptForConversionSelector, 2, 1);
 
     deckEditorGroupBox = new QGroupBox;
     deckEditorGroupBox->setLayout(deckEditorGrid);
@@ -719,9 +735,15 @@ void UserInterfaceSettingsPage::retranslateUi()
     tapAnimationCheckBox.setText(tr("&Tap/untap animation"));
     deckEditorGroupBox->setTitle(tr("Deck editor/storage settings"));
     openDeckInNewTabCheckBox.setText(tr("Open deck in new tab by default"));
-    visualDeckStoragePromptForConversionCheckBox.setText(tr("Prompt before converting .txt decks to .cod format"));
-    visualDeckStorageAlwaysConvertCheckBox.setText(tr("Always convert if not prompted"));
     visualDeckStorageInGameCheckBox.setText(tr("Use visual deck storage in game lobby"));
+    visualDeckStoragePromptForConversionLabel.setText(
+        tr("When adding a tag in the visual deck storage to a .txt deck:"));
+    visualDeckStoragePromptForConversionSelector.setItemText(visualDeckStoragePromptForConversionIndexNone,
+                                                             tr("do nothing"));
+    visualDeckStoragePromptForConversionSelector.setItemText(visualDeckStoragePromptForConversionIndexPrompt,
+                                                             tr("ask to convert to .cod"));
+    visualDeckStoragePromptForConversionSelector.setItemText(visualDeckStoragePromptForConversionIndexAlways,
+                                                             tr("always convert to .cod"));
     replayGroupBox->setTitle(tr("Replay settings"));
     rewindBufferingMsLabel.setText(tr("Buffer time for backwards skip via shortcut:"));
     rewindBufferingMsBox.setSuffix(" ms");

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -664,7 +664,7 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
         visualDeckStoragePromptForConversionSelector.setCurrentIndex(visualDeckStoragePromptForConversionIndexNone);
     }
     connect(&visualDeckStoragePromptForConversionSelector, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
-            [this](int index) {
+            [](int index) {
                 SettingsCache::instance().setVisualDeckStoragePromptForConversion(
                     index == visualDeckStoragePromptForConversionIndexPrompt);
                 SettingsCache::instance().setVisualDeckStorageAlwaysConvert(

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -148,8 +148,8 @@ private:
     QCheckBox useTearOffMenusCheckBox;
     QCheckBox tapAnimationCheckBox;
     QCheckBox openDeckInNewTabCheckBox;
-    QCheckBox visualDeckStoragePromptForConversionCheckBox;
-    QCheckBox visualDeckStorageAlwaysConvertCheckBox;
+    QLabel visualDeckStoragePromptForConversionLabel;
+    QComboBox visualDeckStoragePromptForConversionSelector;
     QCheckBox visualDeckStorageInGameCheckBox;
     QLabel rewindBufferingMsLabel;
     QSpinBox rewindBufferingMsBox;

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -736,13 +736,13 @@ void SettingsCache::setVisualDeckStorageUnusedColorIdentitiesOpacity(int _visual
     emit visualDeckStorageUnusedColorIdentitiesOpacityChanged(visualDeckStorageUnusedColorIdentitiesOpacity);
 }
 
-void SettingsCache::setVisualDeckStoragePromptForConversion(QT_STATE_CHANGED_T _visualDeckStoragePromptForConversion)
+void SettingsCache::setVisualDeckStoragePromptForConversion(bool _visualDeckStoragePromptForConversion)
 {
     visualDeckStoragePromptForConversion = _visualDeckStoragePromptForConversion;
     settings->setValue("interface/visualdeckstoragepromptforconversion", visualDeckStoragePromptForConversion);
 }
 
-void SettingsCache::setVisualDeckStorageAlwaysConvert(QT_STATE_CHANGED_T _visualDeckStorageAlwaysConvert)
+void SettingsCache::setVisualDeckStorageAlwaysConvert(bool _visualDeckStorageAlwaysConvert)
 {
     visualDeckStorageAlwaysConvert = _visualDeckStorageAlwaysConvert;
     settings->setValue("interface/visualdeckstoragealwaysconvert", visualDeckStorageAlwaysConvert);

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -798,8 +798,8 @@ public slots:
     void setVisualDeckStorageCardSize(int _visualDeckStorageCardSize);
     void setVisualDeckStorageDrawUnusedColorIdentities(QT_STATE_CHANGED_T _visualDeckStorageDrawUnusedColorIdentities);
     void setVisualDeckStorageUnusedColorIdentitiesOpacity(int _visualDeckStorageUnusedColorIdentitiesOpacity);
-    void setVisualDeckStoragePromptForConversion(QT_STATE_CHANGED_T _visualDeckStoragePromptForConversion);
-    void setVisualDeckStorageAlwaysConvert(QT_STATE_CHANGED_T _visualDeckStorageAlwaysConvert);
+    void setVisualDeckStoragePromptForConversion(bool _visualDeckStoragePromptForConversion);
+    void setVisualDeckStorageAlwaysConvert(bool _visualDeckStorageAlwaysConvert);
     void setVisualDeckStorageInGame(QT_STATE_CHANGED_T value);
     void setHorizontalHand(QT_STATE_CHANGED_T _horizontalHand);
     void setInvertVerticalCoordinate(QT_STATE_CHANGED_T _invertVerticalCoordinate);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -234,11 +234,10 @@ void SettingsCache::setVisualDeckStorageUnusedColorIdentitiesOpacity(
     int /* _visualDeckStorageUnusedColorIdentitiesOpacity */)
 {
 }
-void SettingsCache::setVisualDeckStoragePromptForConversion(
-    QT_STATE_CHANGED_T /* _visualDeckStoragePromptForConversion */)
+void SettingsCache::setVisualDeckStoragePromptForConversion(bool /* _visualDeckStoragePromptForConversion */)
 {
 }
-void SettingsCache::setVisualDeckStorageAlwaysConvert(QT_STATE_CHANGED_T /* _visualDeckStorageAlwaysConvert */)
+void SettingsCache::setVisualDeckStorageAlwaysConvert(bool /* _visualDeckStorageAlwaysConvert */)
 {
 }
 void SettingsCache::setVisualDeckStorageInGame(QT_STATE_CHANGED_T /* value */)

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -238,11 +238,10 @@ void SettingsCache::setVisualDeckStorageUnusedColorIdentitiesOpacity(
     int /* _visualDeckStorageUnusedColorIdentitiesOpacity */)
 {
 }
-void SettingsCache::setVisualDeckStoragePromptForConversion(
-    QT_STATE_CHANGED_T /* _visualDeckStoragePromptForConversion */)
+void SettingsCache::setVisualDeckStoragePromptForConversion(bool /* _visualDeckStoragePromptForConversion */)
 {
 }
-void SettingsCache::setVisualDeckStorageAlwaysConvert(QT_STATE_CHANGED_T /* _visualDeckStorageAlwaysConvert */)
+void SettingsCache::setVisualDeckStorageAlwaysConvert(bool /* _visualDeckStorageAlwaysConvert */)
 {
 }
 void SettingsCache::setVisualDeckStorageInGame(QT_STATE_CHANGED_T /* value */)


### PR DESCRIPTION

## Related Ticket(s)
- introduced by  #5514

## Short roundup of the initial problem
the settings entry for converting to .cod when adding a tag to a deck in the visual deck selector is unclear in its use, this was shown to me by a translator on the discord: caledor92

## What will change with this Pull Request?
- replace the two checkboxes of which one state is ignored if one is checked with a three state combobox for better user experience

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
![image](https://github.com/user-attachments/assets/0e71c476-b794-4bf0-81e2-ff09e7513182)
