### PR TITLE
Refactor: move last token info into struct

### DIFF
--- a/cockatrice/src/dialogs/dlg_create_token.cpp
+++ b/cockatrice/src/dialogs/dlg_create_token.cpp
@@ -224,27 +224,11 @@ void DlgCreateToken::actReject()
     reject();
 }
 
-QString DlgCreateToken::getName() const
+TokenInfo DlgCreateToken::getTokenInfo() const
 {
-    return nameEdit->text();
-}
-
-QString DlgCreateToken::getColor() const
-{
-    return QString(colorEdit->itemData(colorEdit->currentIndex()).toChar());
-}
-
-QString DlgCreateToken::getPT() const
-{
-    return ptEdit->text();
-}
-
-QString DlgCreateToken::getAnnotation() const
-{
-    return annotationEdit->text();
-}
-
-bool DlgCreateToken::getDestroy() const
-{
-    return destroyCheckBox->isChecked();
+    return {.name = nameEdit->text(),
+            .color = colorEdit->itemData(colorEdit->currentIndex()).toString(),
+            .pt = ptEdit->text(),
+            .annotation = annotationEdit->text(),
+            .destroy = destroyCheckBox->isChecked()};
 }

--- a/cockatrice/src/dialogs/dlg_create_token.h
+++ b/cockatrice/src/dialogs/dlg_create_token.h
@@ -17,16 +17,21 @@ class CardDatabaseModel;
 class TokenDisplayModel;
 class CardInfoPictureWidget;
 
+struct TokenInfo
+{
+    QString name;
+    QString color;
+    QString pt;
+    QString annotation;
+    bool destroy = false;
+};
+
 class DlgCreateToken : public QDialog
 {
     Q_OBJECT
 public:
     explicit DlgCreateToken(const QStringList &_predefinedTokens, QWidget *parent = nullptr);
-    QString getName() const;
-    QString getColor() const;
-    QString getPT() const;
-    QString getAnnotation() const;
-    bool getDestroy() const;
+    TokenInfo getTokenInfo() const;
 
 protected:
     void closeEvent(QCloseEvent *event) override;

--- a/cockatrice/src/dialogs/dlg_create_token.h
+++ b/cockatrice/src/dialogs/dlg_create_token.h
@@ -23,7 +23,7 @@ struct TokenInfo
     QString color;
     QString pt;
     QString annotation;
-    bool destroy = false;
+    bool destroy = true;
 };
 
 class DlgCreateToken : public QDialog

--- a/cockatrice/src/dialogs/dlg_create_token.h
+++ b/cockatrice/src/dialogs/dlg_create_token.h
@@ -29,7 +29,7 @@ public:
     bool getDestroy() const;
 
 protected:
-    void closeEvent(QCloseEvent *event);
+    void closeEvent(QCloseEvent *event) override;
 private slots:
     void tokenSelectionChanged(const QModelIndex &current, const QModelIndex &previous);
     void updateSearch(const QString &search);

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -2,6 +2,7 @@
 #define PLAYER_H
 
 #include "../../client/tearoff_menu.h"
+#include "../../dialogs/dlg_create_token.h"
 #include "../board/abstract_graphics_item.h"
 #include "../cards/card_database.h"
 #include "../filters/filter_string.h"
@@ -291,9 +292,10 @@ private:
     int defaultNumberTopCardsToPlaceBelow = 1;
     int defaultNumberBottomCards = 1;
     int defaultNumberDieRoll = 20;
-    QString lastTokenName, lastTokenColor, lastTokenPT, lastTokenAnnotation;
-    bool lastTokenDestroy;
+
+    TokenInfo lastTokenInfo;
     int lastTokenTableRow;
+
     ServerInfo_User *userInfo;
     int id;
     bool active;


### PR DESCRIPTION
## Short roundup of the initial problem

`DlgCreateToken` and the storage of the `lastTokenXXX` fields in `Player` are messy because everything is being passed and stored as individual variables. It would be nicer if we consolidate those values into a struct.

## What will change with this Pull Request?

- Created a `TokenInfo` struct to store the token values instead of passing each value individually
- replaced the `lastTokenXXX` fields in `Player` with a `lastTokenInfo` field
  - `lastTokenTableRow` is still stored separately since that value seems to be tracked separately from the rest of the token values