### PR TITLE
Use QMessageBox::question for force start confirmation

### DIFF
--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -305,7 +305,7 @@ void DeckViewContainer::forceStart()
 {
     const auto msg = tr("Are you sure you want to force start?\nThis will kick all non-ready players from the game.");
     const auto res =
-        QMessageBox::warning(this, tr("Cockatrice"), msg, QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+        QMessageBox::question(this, tr("Cockatrice"), msg, QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
     if (res == QMessageBox::No) {
         return;
     }


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5797

## Short roundup of the initial problem

Should've used `QMessageBox::question` instead of `QMessageBox::warn`

## What will change with this Pull Request?

- Use `QMessageBox::question` instead of `QMessageBox::warn` for the force start confirmation dialog