### PR TITLE
put multiple printings of the same dual face/split cards in the xml

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -219,7 +219,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
     static const QMap<QString, QString> identifierProperties{{"multiverseId", "muid"}, {"scryfallId", "uuid"}};
 
     int numCards = 0;
-    QMap<QString, QList<SplitCardPart>> splitCards;
+    QMap<QString, QPair<QList<SplitCardPart>, QString>> splitCards;
     QString ptSeparator("/");
     QVariantMap card;
     QString layout, name, text, colors, colorIdentity, faceName;
@@ -293,6 +293,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
         const QChar lastChar = numProperty.isEmpty() ? QChar() : numProperty.back();
 
         // Un-Sets do some wonky stuff. Split up these cards as individual entries.
+        // these cards will have a num with a letter (abc) behind it, put that letter into the name
         if (setsWithCardsWithSameNameButDifferentText.contains(currentSet->getShortName()) &&
             allNameProps.contains(faceName) && layout == "normal" && lastChar.isLetter()) {
             numComponent = " (" + QString(lastChar).toLower() + ")";
@@ -337,13 +338,13 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
         if (layout == "split" || layout == "aftermath" || layout == "adventure") {
             auto _faceName = getStringPropertyFromMap(card, "faceName");
             SplitCardPart split(_faceName, text, properties, setInfo);
-            auto found_iter = splitCards.find(name);
+            auto found_iter = splitCards.find(name + numProperty);
             if (found_iter == splitCards.end()) {
-                splitCards.insert(name, {split});
+                splitCards.insert(name + numProperty, {{split}, name});
             } else if (layout == "adventure") {
-                found_iter->insert(0, split);
+                found_iter->first.insert(0, split);
             } else {
-                found_iter->append(split);
+                found_iter->first.append(split);
             }
         } else {
             // relations
@@ -397,22 +398,15 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
     static const QString splitCardTextSeparator = QString("\n\n---\n\n");
     for (const QString &nameSplit : splitCards.keys()) {
         // get all parts for this specific card
-        QList<SplitCardPart> splitCardParts = splitCards.value(nameSplit);
-        QSet<QString> done{};
+        QList<SplitCardPart> splitCardParts = splitCards.value(nameSplit).first;
+        name = splitCards.value(nameSplit).second;
 
         text.clear();
         properties.clear();
         relatedCards.clear();
 
         for (const SplitCardPart &tmp : splitCardParts) {
-            // some sets have 2 different variations of the same split card,
-            // eg. Fire // Ice in WC02. Avoid adding duplicates.
             QString splitName = tmp.getName();
-            if (done.contains(splitName)) {
-                continue;
-            }
-            done.insert(splitName);
-
             if (!text.isEmpty()) {
                 text.append(splitCardTextSeparator);
             }
@@ -441,7 +435,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
                 }
             }
         }
-        CardInfoPtr newCard = addCard(nameSplit, text, isToken, properties, relatedCards, setInfo);
+        CardInfoPtr newCard = addCard(name, text, isToken, properties, relatedCards, setInfo);
         numCards++;
     }
 


### PR DESCRIPTION
## Related Ticket(s)
- Partially reverts #4244
- Printing selector added in #5182

## Short roundup of the initial problem
With the new printing selector cards in the xml have all printings added per set instead of just one per set, split cards did not take this into account and only added one per set.
This was brought to my attention by a user on the discord: deloreanfanatic https://discord.com/channels/314987288398659595/431200098978889728/1359702760756351160

## What will change with this Pull Request?
- add all cards with unique name and set number to the printings per set
- add some comments
- remove code that removed the duplicates
- I compared the output of both xmls and the only changes are 139 new lines for the set