### PR TITLE
Add logging to LocalClient

### DIFF
--- a/cockatrice/resources/config/qtlogging.ini
+++ b/cockatrice/resources/config/qtlogging.ini
@@ -27,6 +27,7 @@
 # servers_settings = false
 # shortcuts_settings = false
 
+# local_client = false
 # remote_client = false
 
 # player = false

--- a/cockatrice/src/server/local_client.cpp
+++ b/cockatrice/src/server/local_client.cpp
@@ -1,5 +1,6 @@
 #include "local_client.h"
 
+#include "debug_pb_message.h"
 #include "local_server_interface.h"
 #include "pb/session_commands.pb.h"
 
@@ -10,6 +11,8 @@ LocalClient::LocalClient(LocalServerInterface *_lsi,
     : AbstractClient(parent), lsi(_lsi)
 {
     connect(lsi, SIGNAL(itemToClient(const ServerMessage &)), this, SLOT(itemFromServer(const ServerMessage &)));
+
+    userName = _playerName;
 
     Command_Login loginCmd;
     loginCmd.set_user_name(_playerName.toStdString());
@@ -27,10 +30,14 @@ LocalClient::~LocalClient()
 
 void LocalClient::sendCommandContainer(const CommandContainer &cont)
 {
+    qCDebug(LocalClientLog).noquote() << userName << "OUT" << getSafeDebugString(cont);
+
     lsi->itemFromClient(cont);
 }
 
 void LocalClient::itemFromServer(const ServerMessage &item)
 {
+    qCDebug(LocalClientLog).noquote() << userName << "IN" << getSafeDebugString(item);
+
     processProtocolItem(item);
 }

--- a/cockatrice/src/server/local_client.h
+++ b/cockatrice/src/server/local_client.h
@@ -3,6 +3,10 @@
 
 #include "../client/game_logic/abstract_client.h"
 
+#include <QLoggingCategory>
+
+inline Q_LOGGING_CATEGORY(LocalClientLog, "local_client");
+
 class LocalServerInterface;
 
 class LocalClient : public AbstractClient


### PR DESCRIPTION
## Short roundup of the initial problem

`LocalClient` does not have logging yet. I need logging in order to debug some stuff in the face-down tokens PR.

## What will change with this Pull Request?
- add logging to `LocalClient`
  - Copied the format from `RemoteClient`
- save `playerName` in `LocalClient` constructor so that it can be used in the log later.

Example of logs: [logs.txt](https://github.com/user-attachments/files/19728594/logs.txt)

