### PR TITLE
Use createSearchSyntaxHelpWindow in visual database display

### DIFF
--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_database_display_widget.cpp
@@ -235,42 +235,6 @@ void DeckEditorDatabaseDisplayWidget::saveDbHeaderState()
     SettingsCache::instance().layouts().setDeckEditorDbHeaderState(databaseView->header()->saveState());
 }
 
-void DeckEditorDatabaseDisplayWidget::showSearchSyntaxHelp()
-{
-
-    QFile file("theme:help/search.md");
-
-    if (!file.open(QFile::ReadOnly | QFile::Text)) {
-        return;
-    }
-
-    QTextStream in(&file);
-    QString text = in.readAll();
-    file.close();
-
-    // Poor Markdown Converter
-    auto opts = QRegularExpression::MultilineOption;
-    text = text.replace(QRegularExpression("^(###)(.*)", opts), "<h3>\\2</h3>")
-               .replace(QRegularExpression("^(##)(.*)", opts), "<h2>\\2</h2>")
-               .replace(QRegularExpression("^(#)(.*)", opts), "<h1>\\2</h1>")
-               .replace(QRegularExpression("^------*", opts), "<hr />")
-               .replace(QRegularExpression(R"(\[([^[]+)\]\(([^\)]+)\))", opts), R"(<a href='\2'>\1</a>)");
-
-    auto browser = new QTextBrowser;
-    browser->setParent(this, Qt::Window | Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowMinMaxButtonsHint |
-                                 Qt::WindowCloseButtonHint | Qt::WindowFullscreenButtonHint);
-    browser->setWindowTitle("Search Help");
-    browser->setReadOnly(true);
-    browser->setMinimumSize({500, 600});
-
-    QString sheet = QString("a { text-decoration: underline; color: rgb(71,158,252) };");
-    browser->document()->setDefaultStyleSheet(sheet);
-
-    browser->setHtml(text);
-    connect(browser, &QTextBrowser::anchorClicked, [this](const QUrl &link) { searchEdit->setText(link.fragment()); });
-    browser->show();
-}
-
 void DeckEditorDatabaseDisplayWidget::setFilterTree(FilterTree *filterTree)
 {
     databaseDisplayModel->setFilterTree(filterTree);

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_database_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_database_display_widget.h
@@ -22,7 +22,6 @@ public:
     CardDatabaseDisplayModel *databaseDisplayModel;
 
 public slots:
-    void showSearchSyntaxHelp();
     CardInfoPtr currentCardInfo() const;
     void setFilterTree(FilterTree *filterTree);
     void clearAllDatabaseFilters();

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -4,6 +4,7 @@
 #include "../../../../game/cards/card_database.h"
 #include "../../../../game/cards/card_database_manager.h"
 #include "../../../../game/filters/filter_tree_model.h"
+#include "../../../../game/filters/syntax_help.h"
 #include "../../../../settings/cache_settings.h"
 #include "../../../../utility/card_info_comparator.h"
 #include "../../pixel_map_generator.h"
@@ -53,6 +54,7 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
     searchEdit->setClearButtonEnabled(true);
     searchEdit->addAction(loadColorAdjustedPixmap("theme:icons/search"), QLineEdit::LeadingPosition);
     auto help = searchEdit->addAction(QPixmap("theme:icons/info"), QLineEdit::TrailingPosition);
+    connect(help, &QAction::triggered, this, [this] { createSearchSyntaxHelpWindow(searchEdit); });
     searchEdit->installEventFilter(&searchKeySignals);
 
     setFocusProxy(searchEdit);
@@ -74,8 +76,6 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
     connect(&searchKeySignals, SIGNAL(onCtrlAltEnter()), this, SLOT(actAddCardToSideboard()));
     connect(&searchKeySignals, SIGNAL(onCtrlEnter()), this, SLOT(actAddCardToSideboard()));
     connect(&searchKeySignals, SIGNAL(onCtrlC()), this, SLOT(copyDatabaseCellContents()));*/
-    connect(help, &QAction::triggered, deckEditor->databaseDisplayDockWidget,
-            &DeckEditorDatabaseDisplayWidget::showSearchSyntaxHelp);
 
     databaseView = new QTreeView(this);
     databaseView->setObjectName("databaseView");


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5822

## Short roundup of the initial problem

In #5791 we moved the search syntax creation to a common method, since there is now two places where it appears. Visual database display now also uses that window, so we should change it to also use that common method.

## What will change with this Pull Request?
- Visual database display will now use the common `createSearchSyntaxHelpWindow` instead of having its own copy of the method.
