### PR TITLE
Refactor files in src/server to new Qt Slot/Signal syntax

### DIFF
--- a/cockatrice/src/server/chat_view/chat_view.cpp
+++ b/cockatrice/src/server/chat_view/chat_view.cpp
@@ -60,7 +60,7 @@ ChatView::ChatView(TabSupervisor *_tabSupervisor, TabGame *_game, bool _showTime
     setReadOnly(true);
     setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::LinksAccessibleByMouse);
     setOpenLinks(false);
-    connect(this, SIGNAL(anchorClicked(const QUrl &)), this, SLOT(openLink(const QUrl &)));
+    connect(this, &ChatView::anchorClicked, this, &ChatView::openLink);
 }
 
 void ChatView::retranslateUi()

--- a/cockatrice/src/server/handle_public_servers.cpp
+++ b/cockatrice/src/server/handle_public_servers.cpp
@@ -19,7 +19,7 @@ void HandlePublicServers::downloadPublicServers()
 {
     QUrl url(QString(PUBLIC_SERVERS_JSON));
     reply = nam->get(QNetworkRequest(url));
-    connect(reply, SIGNAL(finished()), this, SLOT(actFinishParsingDownloadedData()));
+    connect(reply, &QNetworkReply::finished, this, &HandlePublicServers::actFinishParsingDownloadedData);
 }
 
 void HandlePublicServers::actFinishParsingDownloadedData()

--- a/cockatrice/src/server/local_client.cpp
+++ b/cockatrice/src/server/local_client.cpp
@@ -10,7 +10,7 @@ LocalClient::LocalClient(LocalServerInterface *_lsi,
                          QObject *parent)
     : AbstractClient(parent), lsi(_lsi)
 {
-    connect(lsi, SIGNAL(itemToClient(const ServerMessage &)), this, SLOT(itemFromServer(const ServerMessage &)));
+    connect(lsi, &LocalServerInterface::itemToClient, this, &LocalClient::itemFromServer);
 
     userName = _playerName;
 

--- a/cockatrice/src/server/message_log_widget.cpp
+++ b/cockatrice/src/server/message_log_widget.cpp
@@ -820,42 +820,28 @@ void MessageLogWidget::appendHtmlServerMessage(const QString &html, bool optiona
 void MessageLogWidget::connectToPlayer(Player *player)
 {
 
-    connect(player, SIGNAL(logSay(Player *, QString)), this, SLOT(logSay(Player *, QString)));
+    connect(player, &Player::logSay, this, &MessageLogWidget::logSay);
     connect(player, &Player::logShuffle, this, &MessageLogWidget::logShuffle);
-    connect(player, SIGNAL(logRollDie(Player *, int, const QList<uint> &)), this,
-            SLOT(logRollDie(Player *, int, const QList<uint> &)));
-    connect(player, SIGNAL(logCreateArrow(Player *, Player *, QString, Player *, QString, bool)), this,
-            SLOT(logCreateArrow(Player *, Player *, QString, Player *, QString, bool)));
-    connect(player, SIGNAL(logCreateToken(Player *, QString, QString)), this,
-            SLOT(logCreateToken(Player *, QString, QString)));
-    connect(player, SIGNAL(logSetCounter(Player *, QString, int, int)), this,
-            SLOT(logSetCounter(Player *, QString, int, int)));
-    connect(player, SIGNAL(logSetCardCounter(Player *, QString, int, int, int)), this,
-            SLOT(logSetCardCounter(Player *, QString, int, int, int)));
-    connect(player, SIGNAL(logSetTapped(Player *, CardItem *, bool)), this,
-            SLOT(logSetTapped(Player *, CardItem *, bool)));
-    connect(player, SIGNAL(logSetDoesntUntap(Player *, CardItem *, bool)), this,
-            SLOT(logSetDoesntUntap(Player *, CardItem *, bool)));
-    connect(player, SIGNAL(logSetPT(Player *, CardItem *, QString)), this,
-            SLOT(logSetPT(Player *, CardItem *, QString)));
-    connect(player, SIGNAL(logSetAnnotation(Player *, CardItem *, QString)), this,
-            SLOT(logSetAnnotation(Player *, CardItem *, QString)));
-    connect(player, SIGNAL(logMoveCard(Player *, CardItem *, CardZone *, int, CardZone *, int)), this,
-            SLOT(logMoveCard(Player *, CardItem *, CardZone *, int, CardZone *, int)));
-    connect(player, SIGNAL(logFlipCard(Player *, QString, bool)), this, SLOT(logFlipCard(Player *, QString, bool)));
-    connect(player, SIGNAL(logDestroyCard(Player *, QString)), this, SLOT(logDestroyCard(Player *, QString)));
-    connect(player, SIGNAL(logAttachCard(Player *, QString, Player *, QString)), this,
-            SLOT(logAttachCard(Player *, QString, Player *, QString)));
-    connect(player, SIGNAL(logUnattachCard(Player *, QString)), this, SLOT(logUnattachCard(Player *, QString)));
+    connect(player, &Player::logRollDie, this, &MessageLogWidget::logRollDie);
+    connect(player, &Player::logCreateArrow, this, &MessageLogWidget::logCreateArrow);
+    connect(player, &Player::logCreateToken, this, &MessageLogWidget::logCreateToken);
+    connect(player, &Player::logSetCounter, this, &MessageLogWidget::logSetCounter);
+    connect(player, &Player::logSetCardCounter, this, &MessageLogWidget::logSetCardCounter);
+    connect(player, &Player::logSetTapped, this, &MessageLogWidget::logSetTapped);
+    connect(player, &Player::logSetDoesntUntap, this, &MessageLogWidget::logSetDoesntUntap);
+    connect(player, &Player::logSetPT, this, &MessageLogWidget::logSetPT);
+    connect(player, &Player::logSetAnnotation, this, &MessageLogWidget::logSetAnnotation);
+    connect(player, &Player::logMoveCard, this, &MessageLogWidget::logMoveCard);
+    connect(player, &Player::logFlipCard, this, &MessageLogWidget::logFlipCard);
+    connect(player, &Player::logDestroyCard, this, &MessageLogWidget::logDestroyCard);
+    connect(player, &Player::logAttachCard, this, &MessageLogWidget::logAttachCard);
+    connect(player, &Player::logUnattachCard, this, &MessageLogWidget::logUnattachCard);
     connect(player, &Player::logDumpZone, this, &MessageLogWidget::logDumpZone);
-    connect(player, SIGNAL(logDrawCards(Player *, int, bool)), this, SLOT(logDrawCards(Player *, int, bool)));
-    connect(player, SIGNAL(logUndoDraw(Player *, QString)), this, SLOT(logUndoDraw(Player *, QString)));
-    connect(player, SIGNAL(logRevealCards(Player *, CardZone *, int, QString, Player *, bool, int, bool)), this,
-            SLOT(logRevealCards(Player *, CardZone *, int, QString, Player *, bool, int, bool)));
-    connect(player, SIGNAL(logAlwaysRevealTopCard(Player *, CardZone *, bool)), this,
-            SLOT(logAlwaysRevealTopCard(Player *, CardZone *, bool)));
-    connect(player, SIGNAL(logAlwaysLookAtTopCard(Player *, CardZone *, bool)), this,
-            SLOT(logAlwaysLookAtTopCard(Player *, CardZone *, bool)));
+    connect(player, &Player::logDrawCards, this, &MessageLogWidget::logDrawCards);
+    connect(player, &Player::logUndoDraw, this, &MessageLogWidget::logUndoDraw);
+    connect(player, &Player::logRevealCards, this, &MessageLogWidget::logRevealCards);
+    connect(player, &Player::logAlwaysRevealTopCard, this, &MessageLogWidget::logAlwaysRevealTopCard);
+    connect(player, &Player::logAlwaysLookAtTopCard, this, &MessageLogWidget::logAlwaysLookAtTopCard);
 }
 
 MessageLogWidget::MessageLogWidget(TabSupervisor *_tabSupervisor, TabGame *_game, QWidget *parent)

--- a/cockatrice/src/server/remote/remote_client.cpp
+++ b/cockatrice/src/server/remote/remote_client.cpp
@@ -36,42 +36,38 @@ RemoteClient::RemoteClient(QObject *parent)
     int keepalive = SettingsCache::instance().getKeepAlive();
     timer = new QTimer(this);
     timer->setInterval(keepalive * 1000);
-    connect(timer, SIGNAL(timeout()), this, SLOT(ping()));
+    connect(timer, &QTimer::timeout, this, &RemoteClient::ping);
 
     socket = new QTcpSocket(this);
     socket->setSocketOption(QAbstractSocket::LowDelayOption, 1);
-    connect(socket, SIGNAL(connected()), this, SLOT(slotConnected()));
-    connect(socket, SIGNAL(readyRead()), this, SLOT(readData()));
+    connect(socket, &QTcpSocket::connected, this, &RemoteClient::slotConnected);
+    connect(socket, &QTcpSocket::readyRead, this, &RemoteClient::readData);
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     connect(socket, &QTcpSocket::errorOccurred, this, &RemoteClient::slotSocketError);
 #else
-    connect(socket, SIGNAL(error(QAbstractSocket::SocketError)), this,
-            SLOT(slotSocketError(QAbstractSocket::SocketError)));
+    connect(socket, &QTcpSocket::error, this, &RemoteClient::slotSocketError);
 #endif
 
     websocket = new QWebSocket(QString(), QWebSocketProtocol::VersionLatest, this);
     connect(websocket, &QWebSocket::binaryMessageReceived, this, &RemoteClient::websocketMessageReceived);
     connect(websocket, &QWebSocket::connected, this, &RemoteClient::slotConnected);
-    connect(websocket, SIGNAL(error(QAbstractSocket::SocketError)), this,
-            SLOT(slotWebSocketError(QAbstractSocket::SocketError)));
+    connect(websocket, qOverload<QAbstractSocket::SocketError>(&QWebSocket::error), this,
+            &RemoteClient::slotWebSocketError);
 
-    connect(this, SIGNAL(serverIdentificationEventReceived(const Event_ServerIdentification &)), this,
-            SLOT(processServerIdentificationEvent(const Event_ServerIdentification &)));
-    connect(this, SIGNAL(connectionClosedEventReceived(Event_ConnectionClosed)), this,
-            SLOT(processConnectionClosedEvent(Event_ConnectionClosed)));
-    connect(this, SIGNAL(sigConnectToServer(QString, unsigned int, QString, QString)), this,
-            SLOT(doConnectToServer(QString, unsigned int, QString, QString)));
-    connect(this, SIGNAL(sigDisconnectFromServer()), this, SLOT(doDisconnectFromServer()));
-    connect(this, SIGNAL(sigRegisterToServer(QString, unsigned int, QString, QString, QString, QString, QString)), this,
-            SLOT(doRegisterToServer(QString, unsigned int, QString, QString, QString, QString, QString)));
-    connect(this, SIGNAL(sigActivateToServer(QString)), this, SLOT(doActivateToServer(QString)));
-    connect(this, SIGNAL(sigRequestForgotPasswordToServer(QString, unsigned int, QString)), this,
-            SLOT(doRequestForgotPasswordToServer(QString, unsigned int, QString)));
-    connect(this, SIGNAL(sigSubmitForgotPasswordResetToServer(QString, unsigned int, QString, QString, QString)), this,
-            SLOT(doSubmitForgotPasswordResetToServer(QString, unsigned int, QString, QString, QString)));
-    connect(this, SIGNAL(sigSubmitForgotPasswordChallengeToServer(QString, unsigned int, QString, QString)), this,
-            SLOT(doSubmitForgotPasswordChallengeToServer(QString, unsigned int, QString, QString)));
+    connect(this, &RemoteClient::serverIdentificationEventReceived, this,
+            &RemoteClient::processServerIdentificationEvent);
+    connect(this, &RemoteClient::connectionClosedEventReceived, this, &RemoteClient::processConnectionClosedEvent);
+    connect(this, &RemoteClient::sigConnectToServer, this, &RemoteClient::doConnectToServer);
+    connect(this, &RemoteClient::sigDisconnectFromServer, this, &RemoteClient::doDisconnectFromServer);
+    connect(this, &RemoteClient::sigRegisterToServer, this, &RemoteClient::doRegisterToServer);
+    connect(this, &RemoteClient::sigActivateToServer, this, &RemoteClient::doActivateToServer);
+    connect(this, &RemoteClient::sigRequestForgotPasswordToServer, this,
+            &RemoteClient::doRequestForgotPasswordToServer);
+    connect(this, &RemoteClient::sigSubmitForgotPasswordResetToServer, this,
+            &RemoteClient::doSubmitForgotPasswordResetToServer);
+    connect(this, &RemoteClient::sigSubmitForgotPasswordChallengeToServer, this,
+            &RemoteClient::doSubmitForgotPasswordChallengeToServer);
 }
 
 RemoteClient::~RemoteClient()
@@ -124,8 +120,7 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
         cmdForgotPasswordRequest.set_user_name(userName.toStdString());
         cmdForgotPasswordRequest.set_clientid(getSrvClientID(lastHostname).toStdString());
         PendingCommand *pend = prepareSessionCommand(cmdForgotPasswordRequest);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(requestForgotPasswordResponse(Response)));
+        connect(pend, &PendingCommand::finished, this, &RemoteClient::requestForgotPasswordResponse);
         sendCommand(pend);
         return;
     }
@@ -144,8 +139,7 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
             cmdForgotPasswordReset.set_new_password(password.toStdString());
         }
         PendingCommand *pend = prepareSessionCommand(cmdForgotPasswordReset);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(submitForgotPasswordResetResponse(Response)));
+        connect(pend, &PendingCommand::finished, this, &RemoteClient::submitForgotPasswordResetResponse);
         sendCommand(pend);
         return;
     }
@@ -156,8 +150,7 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
         cmdForgotPasswordChallenge.set_clientid(getSrvClientID(lastHostname).toStdString());
         cmdForgotPasswordChallenge.set_email(email.toStdString());
         PendingCommand *pend = prepareSessionCommand(cmdForgotPasswordChallenge);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(submitForgotPasswordChallengeResponse(Response)));
+        connect(pend, &PendingCommand::finished, this, &RemoteClient::submitForgotPasswordChallengeResponse);
         sendCommand(pend);
         return;
     }
@@ -178,7 +171,7 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
         cmdRegister.set_real_name(realName.toStdString());
         cmdRegister.set_clientid(getSrvClientID(lastHostname).toStdString());
         PendingCommand *pend = prepareSessionCommand(cmdRegister);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(registerResponse(Response)));
+        connect(pend, &PendingCommand::finished, this, &RemoteClient::registerResponse);
         sendCommand(pend);
 
         return;
@@ -191,7 +184,7 @@ void RemoteClient::processServerIdentificationEvent(const Event_ServerIdentifica
         cmdActivate.set_clientid(getSrvClientID(lastHostname).toStdString());
 
         PendingCommand *pend = prepareSessionCommand(cmdActivate);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(activateResponse(Response)));
+        connect(pend, &PendingCommand::finished, this, &RemoteClient::activateResponse);
         sendCommand(pend);
 
         return;
@@ -207,7 +200,7 @@ void RemoteClient::doRequestPasswordSalt()
     cmdRqSalt.set_user_name(userName.toStdString());
 
     PendingCommand *pend = prepareSessionCommand(cmdRqSalt);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(passwordSaltResponse(Response)));
+    connect(pend, &PendingCommand::finished, this, &RemoteClient::passwordSaltResponse);
     sendCommand(pend);
 }
 
@@ -246,7 +239,7 @@ void RemoteClient::doLogin()
         }
 
         PendingCommand *pend = prepareSessionCommand(cmdLogin);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(loginResponse(Response)));
+        connect(pend, &PendingCommand::finished, this, &RemoteClient::loginResponse);
         sendCommand(pend);
     }
 }
@@ -259,7 +252,7 @@ void RemoteClient::doHashedLogin()
     cmdLogin.set_hashed_password(hashedPassword.toStdString());
 
     PendingCommand *pend = prepareSessionCommand(cmdLogin);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(loginResponse(Response)));
+    connect(pend, &PendingCommand::finished, this, &RemoteClient::loginResponse);
     sendCommand(pend);
 }
 

--- a/cockatrice/src/server/remote/remote_client.cpp
+++ b/cockatrice/src/server/remote/remote_client.cpp
@@ -46,14 +46,19 @@ RemoteClient::RemoteClient(QObject *parent)
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     connect(socket, &QTcpSocket::errorOccurred, this, &RemoteClient::slotSocketError);
 #else
-    connect(socket, &QTcpSocket::error, this, &RemoteClient::slotSocketError);
+    connect(socket, qOverload<QAbstractSocket::SocketError>(&QTcpSocket::error), this, &RemoteClient::slotSocketError);
 #endif
 
     websocket = new QWebSocket(QString(), QWebSocketProtocol::VersionLatest, this);
     connect(websocket, &QWebSocket::binaryMessageReceived, this, &RemoteClient::websocketMessageReceived);
     connect(websocket, &QWebSocket::connected, this, &RemoteClient::slotConnected);
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+    connect(websocket, &QWebSocket::errorOccurred, this, &RemoteClient::slotWebSocketError);
+#else
     connect(websocket, qOverload<QAbstractSocket::SocketError>(&QWebSocket::error), this,
             &RemoteClient::slotWebSocketError);
+#endif
 
     connect(this, &RemoteClient::serverIdentificationEventReceived, this,
             &RemoteClient::processServerIdentificationEvent);

--- a/cockatrice/src/server/remote/remote_decklist_tree_widget.cpp
+++ b/cockatrice/src/server/remote/remote_decklist_tree_widget.cpp
@@ -263,8 +263,7 @@ void RemoteDeckList_TreeModel::removeNode(RemoteDeckList_TreeModel::Node *node)
 void RemoteDeckList_TreeModel::refreshTree()
 {
     PendingCommand *pend = client->prepareSessionCommand(Command_DeckList());
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-            SLOT(deckListFinished(const Response &)));
+    connect(pend, &PendingCommand::finished, this, &RemoteDeckList_TreeModel::deckListFinished);
 
     client->sendCommand(pend);
 }
@@ -298,7 +297,7 @@ RemoteDeckList_TreeWidget::RemoteDeckList_TreeWidget(AbstractClient *_client, QW
     proxyModel->setDynamicSortFilter(true);
     proxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
     setModel(proxyModel);
-    connect(treeModel, SIGNAL(treeRefreshed()), this, SLOT(expandAll()));
+    connect(treeModel, &RemoteDeckList_TreeModel::treeRefreshed, this, &RemoteDeckList_TreeWidget::expandAll);
 
     header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     setUniformRowHeights(true);

--- a/cockatrice/src/server/remote/remote_replay_list_tree_widget.cpp
+++ b/cockatrice/src/server/remote/remote_replay_list_tree_widget.cpp
@@ -253,8 +253,7 @@ void RemoteReplayList_TreeModel::clearAll()
 void RemoteReplayList_TreeModel::refreshTree()
 {
     PendingCommand *pend = client->prepareSessionCommand(Command_ReplayList());
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-            SLOT(replayListFinished(const Response &)));
+    connect(pend, &PendingCommand::finished, this, &RemoteReplayList_TreeModel::replayListFinished);
 
     client->sendCommand(pend);
 }

--- a/cockatrice/src/server/user/user_context_menu.cpp
+++ b/cockatrice/src/server/user/user_context_menu.cpp
@@ -116,7 +116,7 @@ void UserContextMenu::banUser_processUserInfoResponse(const Response &r)
 
     // The dialog needs to be non-modal in order to not block the event queue of the client.
     BanDialog *dlg = new BanDialog(response.user_info(), static_cast<QWidget *>(parent()));
-    connect(dlg, SIGNAL(accepted()), this, SLOT(banUser_dialogFinished()));
+    connect(dlg, &QDialog::accepted, this, &UserContextMenu::banUser_dialogFinished);
     dlg->show();
 }
 
@@ -129,7 +129,7 @@ void UserContextMenu::warnUser_processGetWarningsListResponse(const Response &r)
 
     // The dialog needs to be non-modal in order to not block the event queue of the client.
     WarningDialog *dlg = new WarningDialog(user, clientid, static_cast<QWidget *>(parent()));
-    connect(dlg, SIGNAL(accepted()), this, SLOT(warnUser_dialogFinished()));
+    connect(dlg, &QDialog::accepted, this, &UserContextMenu::warnUser_dialogFinished);
 
     if (response.warning_size() > 0) {
         for (int i = 0; i < response.warning_size(); ++i) {
@@ -148,8 +148,7 @@ void UserContextMenu::warnUser_processUserInfoResponse(const Response &resp)
     cmd.set_user_name(userInfo.name());
     cmd.set_user_clientid(userInfo.clientid());
     PendingCommand *pend = client->prepareModeratorCommand(cmd);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-            SLOT(warnUser_processGetWarningsListResponse(Response)));
+    connect(pend, &PendingCommand::finished, this, &UserContextMenu::warnUser_processGetWarningsListResponse);
     client->sendCommand(pend);
 }
 
@@ -433,8 +432,7 @@ void UserContextMenu::showContextMenu(const QPoint &pos,
         cmd.set_user_name(userName.toStdString());
 
         PendingCommand *pend = client->prepareSessionCommand(cmd);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(gamesOfUserReceived(Response, CommandContainer)));
+        connect(pend, &PendingCommand::finished, this, &UserContextMenu::gamesOfUserReceived);
 
         client->sendCommand(pend);
     } else if (actionClicked == aAddToBuddyList) {
@@ -471,8 +469,7 @@ void UserContextMenu::showContextMenu(const QPoint &pos,
         cmd.set_user_name(userName.toStdString());
 
         PendingCommand *pend = client->prepareSessionCommand(cmd);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(banUser_processUserInfoResponse(Response)));
+        connect(pend, &PendingCommand::finished, this, &UserContextMenu::banUser_processUserInfoResponse);
         client->sendCommand(pend);
     } else if (actionClicked == aPromoteToMod || actionClicked == aDemoteFromMod) {
         Command_AdjustMod cmd;
@@ -480,8 +477,7 @@ void UserContextMenu::showContextMenu(const QPoint &pos,
         cmd.set_should_be_mod(actionClicked == aPromoteToMod);
 
         PendingCommand *pend = client->prepareAdminCommand(cmd);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(adjustMod_processUserResponse(Response, CommandContainer)));
+        connect(pend, &PendingCommand::finished, this, &UserContextMenu::adjustMod_processUserResponse);
         client->sendCommand(pend);
     } else if (actionClicked == aPromoteToJudge || actionClicked == aDemoteFromJudge) {
         Command_AdjustMod cmd;
@@ -489,36 +485,31 @@ void UserContextMenu::showContextMenu(const QPoint &pos,
         cmd.set_should_be_judge(actionClicked == aPromoteToJudge);
 
         PendingCommand *pend = client->prepareAdminCommand(cmd);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(adjustMod_processUserResponse(Response, CommandContainer)));
+        connect(pend, &PendingCommand::finished, this, &UserContextMenu::adjustMod_processUserResponse);
         client->sendCommand(pend);
     } else if (actionClicked == aBanHistory) {
         Command_GetBanHistory cmd;
         cmd.set_user_name(userName.toStdString());
         PendingCommand *pend = client->prepareModeratorCommand(cmd);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(banUserHistory_processResponse(Response)));
+        connect(pend, &PendingCommand::finished, this, &UserContextMenu::banUserHistory_processResponse);
         client->sendCommand(pend);
     } else if (actionClicked == aWarnUser) {
         Command_GetUserInfo cmd;
         cmd.set_user_name(userName.toStdString());
         PendingCommand *pend = client->prepareSessionCommand(cmd);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(warnUser_processUserInfoResponse(Response)));
+        connect(pend, &PendingCommand::finished, this, &UserContextMenu::warnUser_processUserInfoResponse);
         client->sendCommand(pend);
     } else if (actionClicked == aWarnHistory) {
         Command_GetWarnHistory cmd;
         cmd.set_user_name(userName.toStdString());
         PendingCommand *pend = client->prepareModeratorCommand(cmd);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(warnUserHistory_processResponse(Response)));
+        connect(pend, &PendingCommand::finished, this, &UserContextMenu::warnUserHistory_processResponse);
         client->sendCommand(pend);
     } else if (actionClicked == aGetAdminNotes) {
         Command_GetAdminNotes cmd;
         cmd.set_user_name(userName.toStdString());
         auto *pend = client->prepareModeratorCommand(cmd);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(getAdminNotes_processResponse(Response)));
+        connect(pend, &PendingCommand::finished, this, &UserContextMenu::getAdminNotes_processResponse);
         client->sendCommand(pend);
 
     } else if (actionClicked == aCopyToClipBoard) {

--- a/cockatrice/src/server/user/user_info_box.cpp
+++ b/cockatrice/src/server/user/user_info_box.cpp
@@ -63,9 +63,9 @@ UserInfoBox::UserInfoBox(AbstractClient *_client, bool _editable, QWidget *paren
         buttonsLayout->addWidget(&avatarButton);
         mainLayout->addLayout(buttonsLayout, 7, 0, 1, 3);
 
-        connect(&editButton, SIGNAL(clicked()), this, SLOT(actEdit()));
-        connect(&passwordButton, SIGNAL(clicked()), this, SLOT(actPassword()));
-        connect(&avatarButton, SIGNAL(clicked()), this, SLOT(actAvatar()));
+        connect(&editButton, &QPushButton::clicked, this, &UserInfoBox::actEdit);
+        connect(&passwordButton, &QPushButton::clicked, this, &UserInfoBox::actPassword);
+        connect(&avatarButton, &QPushButton::clicked, this, &UserInfoBox::actAvatar);
     }
 
     setWindowTitle(tr("User Information"));
@@ -185,8 +185,7 @@ void UserInfoBox::updateInfo(const QString &userName)
     cmd.set_user_name(userName.toStdString());
 
     PendingCommand *pend = client->prepareSessionCommand(cmd);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-            SLOT(processResponse(const Response &)));
+    connect(pend, &PendingCommand::finished, this, &UserInfoBox::processResponse);
 
     client->sendCommand(pend);
 }
@@ -204,8 +203,7 @@ void UserInfoBox::actEdit()
     Command_GetUserInfo cmd;
 
     PendingCommand *pend = client->prepareSessionCommand(cmd);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-            SLOT(actEditInternal(const Response &)));
+    connect(pend, &PendingCommand::finished, this, &UserInfoBox::actEditInternal);
 
     client->sendCommand(pend);
 }
@@ -244,8 +242,7 @@ void UserInfoBox::actEditInternal(const Response &r)
     cmd.set_country(dlg.getCountry().toStdString());
 
     PendingCommand *pend = client->prepareSessionCommand(cmd);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-            SLOT(processEditResponse(const Response &)));
+    connect(pend, &PendingCommand::finished, this, &UserInfoBox::processEditResponse);
 
     client->sendCommand(pend);
 }
@@ -291,8 +288,7 @@ void UserInfoBox::changePassword(const QString &oldPassword, const QString &newP
     }
 
     PendingCommand *pend = client->prepareSessionCommand(cmd);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-            SLOT(processPasswordResponse(const Response &)));
+    connect(pend, &PendingCommand::finished, this, &UserInfoBox::processPasswordResponse);
 
     client->sendCommand(pend);
 }
@@ -307,8 +303,7 @@ void UserInfoBox::actAvatar()
     cmd.set_image(dlg.getImage().data(), dlg.getImage().size());
 
     PendingCommand *pend = client->prepareSessionCommand(cmd);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-            SLOT(processAvatarResponse(const Response &)));
+    connect(pend, &PendingCommand::finished, this, &UserInfoBox::processAvatarResponse);
 
     client->sendCommand(pend);
 }

--- a/cockatrice/src/server/user/user_list_widget.cpp
+++ b/cockatrice/src/server/user/user_list_widget.cpp
@@ -63,7 +63,7 @@ BanDialog::BanDialog(const ServerInfo_User &info, QWidget *parent) : QDialog(par
     permanentRadio = new QRadioButton(tr("&permanent ban"));
     temporaryRadio = new QRadioButton(tr("&temporary ban"));
     temporaryRadio->setChecked(true);
-    connect(temporaryRadio, SIGNAL(toggled(bool)), this, SLOT(enableTemporaryEdits(bool)));
+    connect(temporaryRadio, &QRadioButton::toggled, this, &BanDialog::enableTemporaryEdits);
     daysLabel = new QLabel(tr("&Days:"));
     daysEdit = new QSpinBox;
     daysEdit->setMinimum(0);
@@ -106,9 +106,9 @@ BanDialog::BanDialog(const ServerInfo_User &info, QWidget *parent) : QDialog(par
 
     QPushButton *okButton = new QPushButton(tr("&OK"));
     okButton->setAutoDefault(true);
-    connect(okButton, SIGNAL(clicked()), this, SLOT(okClicked()));
+    connect(okButton, &QPushButton::clicked, this, &BanDialog::okClicked);
     QPushButton *cancelButton = new QPushButton(tr("&Cancel"));
-    connect(cancelButton, SIGNAL(clicked()), this, SLOT(reject()));
+    connect(cancelButton, &QPushButton::clicked, this, &BanDialog::reject);
 
     QHBoxLayout *buttonLayout = new QHBoxLayout;
     buttonLayout->addStretch();
@@ -144,9 +144,9 @@ WarningDialog::WarningDialog(const QString userName, const QString clientID, QWi
 
     QPushButton *okButton = new QPushButton(tr("&OK"));
     okButton->setAutoDefault(true);
-    connect(okButton, SIGNAL(clicked()), this, SLOT(okClicked()));
+    connect(okButton, &QPushButton::clicked, this, &WarningDialog::okClicked);
     QPushButton *cancelButton = new QPushButton(tr("&Cancel"));
-    connect(cancelButton, SIGNAL(clicked()), this, SLOT(reject()));
+    connect(cancelButton, &QPushButton::clicked, this, &WarningDialog::reject);
 
     QHBoxLayout *buttonLayout = new QHBoxLayout;
     buttonLayout->addStretch();
@@ -423,7 +423,7 @@ UserListWidget::UserListWidget(TabSupervisor *_tabSupervisor,
 {
     itemDelegate = new UserListItemDelegate(this);
     userContextMenu = new UserContextMenu(tabSupervisor, this);
-    connect(userContextMenu, SIGNAL(openMessageDialog(QString, bool)), this, SIGNAL(openMessageDialog(QString, bool)));
+    connect(userContextMenu, &UserContextMenu::openMessageDialog, this, &UserListWidget::openMessageDialog);
 
     userTree = new QTreeWidget;
     userTree->setColumnCount(3);
@@ -434,7 +434,7 @@ UserListWidget::UserListWidget(TabSupervisor *_tabSupervisor,
     userTree->setIconSize(QSize(20, 18));
     userTree->setItemDelegate(itemDelegate);
     userTree->setAlternatingRowColors(true);
-    connect(userTree, SIGNAL(itemActivated(QTreeWidgetItem *, int)), this, SLOT(userClicked(QTreeWidgetItem *, int)));
+    connect(userTree, &QTreeWidget::itemActivated, this, &UserListWidget::userClicked);
 
     QVBoxLayout *vbox = new QVBoxLayout;
     vbox->addWidget(userTree);


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5432

## What will change with this Pull Request?
- Update all usages of slot/signal in `src/server` to new syntax
- Fix deprecation warning in `RemoteClient`.
