### PR TITLE
Refactor files in src/client/tabs to new Qt Slot/Signal syntax

### DIFF
--- a/cockatrice/src/client/menus/deck_editor/deck_editor_menu.cpp
+++ b/cockatrice/src/client/menus/deck_editor/deck_editor_menu.cpp
@@ -6,10 +6,10 @@
 DeckEditorMenu::DeckEditorMenu(AbstractTabDeckEditor *parent) : QMenu(parent), deckEditor(parent)
 {
     aNewDeck = new QAction(QString(), this);
-    connect(aNewDeck, SIGNAL(triggered()), deckEditor, SLOT(actNewDeck()));
+    connect(aNewDeck, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::actNewDeck);
 
     aLoadDeck = new QAction(QString(), this);
-    connect(aLoadDeck, SIGNAL(triggered()), deckEditor, SLOT(actLoadDeck()));
+    connect(aLoadDeck, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::actLoadDeck);
 
     loadRecentDeckMenu = new QMenu(this);
     connect(&SettingsCache::instance().recents(), &RecentsSettings::recentlyOpenedDeckPathsChanged, this,
@@ -21,47 +21,50 @@ DeckEditorMenu::DeckEditorMenu(AbstractTabDeckEditor *parent) : QMenu(parent), d
     updateRecentlyOpened();
 
     aSaveDeck = new QAction(QString(), this);
-    connect(aSaveDeck, SIGNAL(triggered()), deckEditor, SLOT(actSaveDeck()));
+    connect(aSaveDeck, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::actSaveDeck);
 
     aSaveDeckAs = new QAction(QString(), this);
-    connect(aSaveDeckAs, SIGNAL(triggered()), deckEditor, SLOT(actSaveDeckAs()));
+    connect(aSaveDeckAs, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::actSaveDeckAs);
 
     aLoadDeckFromClipboard = new QAction(QString(), this);
-    connect(aLoadDeckFromClipboard, SIGNAL(triggered()), deckEditor, SLOT(actLoadDeckFromClipboard()));
+    connect(aLoadDeckFromClipboard, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::actLoadDeckFromClipboard);
 
     aEditDeckInClipboard = new QAction(QString(), this);
-    connect(aEditDeckInClipboard, SIGNAL(triggered()), deckEditor, SLOT(actEditDeckInClipboard()));
+    connect(aEditDeckInClipboard, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::actEditDeckInClipboard);
 
     aEditDeckInClipboardRaw = new QAction(QString(), this);
-    connect(aEditDeckInClipboardRaw, SIGNAL(triggered()), deckEditor, SLOT(actEditDeckInClipboardRaw()));
+    connect(aEditDeckInClipboardRaw, &QAction::triggered, deckEditor,
+            &AbstractTabDeckEditor::actEditDeckInClipboardRaw);
 
     aSaveDeckToClipboard = new QAction(QString(), this);
-    connect(aSaveDeckToClipboard, SIGNAL(triggered()), deckEditor, SLOT(actSaveDeckToClipboard()));
+    connect(aSaveDeckToClipboard, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::actSaveDeckToClipboard);
 
     aSaveDeckToClipboardNoSetInfo = new QAction(QString(), this);
-    connect(aSaveDeckToClipboardNoSetInfo, SIGNAL(triggered()), deckEditor, SLOT(actSaveDeckToClipboardNoSetInfo()));
+    connect(aSaveDeckToClipboardNoSetInfo, &QAction::triggered, deckEditor,
+            &AbstractTabDeckEditor::actSaveDeckToClipboardNoSetInfo);
 
     aSaveDeckToClipboardRaw = new QAction(QString(), this);
-    connect(aSaveDeckToClipboardRaw, SIGNAL(triggered()), deckEditor, SLOT(actSaveDeckToClipboardRaw()));
+    connect(aSaveDeckToClipboardRaw, &QAction::triggered, deckEditor,
+            &AbstractTabDeckEditor::actSaveDeckToClipboardRaw);
 
     aSaveDeckToClipboardRawNoSetInfo = new QAction(QString(), this);
-    connect(aSaveDeckToClipboardRawNoSetInfo, SIGNAL(triggered()), deckEditor,
-            SLOT(actSaveDeckToClipboardRawNoSetInfo()));
+    connect(aSaveDeckToClipboardRawNoSetInfo, &QAction::triggered, deckEditor,
+            &AbstractTabDeckEditor::actSaveDeckToClipboardRawNoSetInfo);
 
     aPrintDeck = new QAction(QString(), this);
-    connect(aPrintDeck, SIGNAL(triggered()), deckEditor, SLOT(actPrintDeck()));
+    connect(aPrintDeck, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::actPrintDeck);
 
     aExportDeckDecklist = new QAction(QString(), this);
-    connect(aExportDeckDecklist, SIGNAL(triggered()), deckEditor, SLOT(actExportDeckDecklist()));
+    connect(aExportDeckDecklist, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::actExportDeckDecklist);
 
     aExportDeckDecklistXyz = new QAction(QString(), this);
-    connect(aExportDeckDecklistXyz, SIGNAL(triggered()), deckEditor, SLOT(actExportDeckDecklistXyz()));
+    connect(aExportDeckDecklistXyz, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::actExportDeckDecklistXyz);
 
     aAnalyzeDeckDeckstats = new QAction(QString(), this);
-    connect(aAnalyzeDeckDeckstats, SIGNAL(triggered()), deckEditor, SLOT(actAnalyzeDeckDeckstats()));
+    connect(aAnalyzeDeckDeckstats, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::actAnalyzeDeckDeckstats);
 
     aAnalyzeDeckTappedout = new QAction(QString(), this);
-    connect(aAnalyzeDeckTappedout, SIGNAL(triggered()), deckEditor, SLOT(actAnalyzeDeckTappedout()));
+    connect(aAnalyzeDeckTappedout, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::actAnalyzeDeckTappedout);
 
     analyzeDeckMenu = new QMenu(this);
     analyzeDeckMenu->addAction(aExportDeckDecklist);
@@ -102,7 +105,8 @@ DeckEditorMenu::DeckEditorMenu(AbstractTabDeckEditor *parent) : QMenu(parent), d
     addAction(aClose);
 
     retranslateUi();
-    connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
+    connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
+            &DeckEditorMenu::refreshShortcuts);
     refreshShortcuts();
 }
 

--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
@@ -65,7 +65,8 @@ AbstractTabDeckEditor::AbstractTabDeckEditor(TabSupervisor *_tabSupervisor) : Ta
     connect(filterDockWidget, &DeckEditorFilterDockWidget::clearAllDatabaseFilters, databaseDisplayDockWidget,
             &DeckEditorDatabaseDisplayWidget::clearAllDatabaseFilters);
 
-    connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
+    connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
+            &AbstractTabDeckEditor::refreshShortcuts);
 }
 
 void AbstractTabDeckEditor::updateCard(CardInfoPtr _card)
@@ -337,8 +338,7 @@ bool AbstractTabDeckEditor::actSaveDeck()
         cmd.set_deck_list(deckString.toStdString());
 
         PendingCommand *pend = AbstractClient::prepareSessionCommand(cmd);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(saveDeckRemoteFinished(Response)));
+        connect(pend, &PendingCommand::finished, this, &AbstractTabDeckEditor::saveDeckRemoteFinished);
         tabSupervisor->getClient()->sendCommand(pend);
 
         return true;
@@ -457,7 +457,7 @@ void AbstractTabDeckEditor::actSaveDeckToClipboardRawNoSetInfo()
 void AbstractTabDeckEditor::actPrintDeck()
 {
     auto *dlg = new QPrintPreviewDialog(this);
-    connect(dlg, SIGNAL(paintRequested(QPrinter *)), deckDockWidget->deckModel, SLOT(printDeckList(QPrinter *)));
+    connect(dlg, &QPrintPreviewDialog::paintRequested, deckDockWidget->deckModel, &DeckListModel::printDeckList);
     dlg->exec();
 }
 

--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
@@ -30,6 +30,7 @@
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QPrintPreviewDialog>
+#include <QPrinter>
 #include <QProcessEnvironment>
 #include <QPushButton>
 #include <QRegularExpression>

--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.h
@@ -44,6 +44,8 @@ class AbstractTabDeckEditor : public Tab
 {
     Q_OBJECT
 
+    friend class DeckEditorMenu;
+
 public:
     explicit AbstractTabDeckEditor(TabSupervisor *_tabSupervisor);
 

--- a/cockatrice/src/client/tabs/api/edhrec/tab_edhrec.cpp
+++ b/cockatrice/src/client/tabs/api/edhrec/tab_edhrec.cpp
@@ -21,7 +21,7 @@ TabEdhRec::TabEdhRec(TabSupervisor *_tabSupervisor) : Tab(_tabSupervisor)
 #endif
 
     networkManager->setRedirectPolicy(QNetworkRequest::ManualRedirectPolicy);
-    connect(networkManager, SIGNAL(finished(QNetworkReply *)), this, SLOT(processApiJson(QNetworkReply *)));
+    connect(networkManager, &QNetworkAccessManager::finished, this, &TabEdhRec::processApiJson);
 }
 
 void TabEdhRec::retranslateUi()

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -67,36 +67,36 @@ void TabDeckEditor::createMenus()
 
     aCardInfoDockVisible = cardInfoDockMenu->addAction(QString());
     aCardInfoDockVisible->setCheckable(true);
-    connect(aCardInfoDockVisible, SIGNAL(triggered()), this, SLOT(dockVisibleTriggered()));
+    connect(aCardInfoDockVisible, &QAction::triggered, this, &TabDeckEditor::dockVisibleTriggered);
     aCardInfoDockFloating = cardInfoDockMenu->addAction(QString());
     aCardInfoDockFloating->setCheckable(true);
-    connect(aCardInfoDockFloating, SIGNAL(triggered()), this, SLOT(dockFloatingTriggered()));
+    connect(aCardInfoDockFloating, &QAction::triggered, this, &TabDeckEditor::dockFloatingTriggered);
 
     aDeckDockVisible = deckDockMenu->addAction(QString());
     aDeckDockVisible->setCheckable(true);
-    connect(aDeckDockVisible, SIGNAL(triggered()), this, SLOT(dockVisibleTriggered()));
+    connect(aDeckDockVisible, &QAction::triggered, this, &TabDeckEditor::dockVisibleTriggered);
     aDeckDockFloating = deckDockMenu->addAction(QString());
     aDeckDockFloating->setCheckable(true);
-    connect(aDeckDockFloating, SIGNAL(triggered()), this, SLOT(dockFloatingTriggered()));
+    connect(aDeckDockFloating, &QAction::triggered, this, &TabDeckEditor::dockFloatingTriggered);
 
     aFilterDockVisible = filterDockMenu->addAction(QString());
     aFilterDockVisible->setCheckable(true);
-    connect(aFilterDockVisible, SIGNAL(triggered()), this, SLOT(dockVisibleTriggered()));
+    connect(aFilterDockVisible, &QAction::triggered, this, &TabDeckEditor::dockVisibleTriggered);
     aFilterDockFloating = filterDockMenu->addAction(QString());
     aFilterDockFloating->setCheckable(true);
-    connect(aFilterDockFloating, SIGNAL(triggered()), this, SLOT(dockFloatingTriggered()));
+    connect(aFilterDockFloating, &QAction::triggered, this, &TabDeckEditor::dockFloatingTriggered);
 
     aPrintingSelectorDockVisible = printingSelectorDockMenu->addAction(QString());
     aPrintingSelectorDockVisible->setCheckable(true);
-    connect(aPrintingSelectorDockVisible, SIGNAL(triggered()), this, SLOT(dockVisibleTriggered()));
+    connect(aPrintingSelectorDockVisible, &QAction::triggered, this, &TabDeckEditor::dockVisibleTriggered);
     aPrintingSelectorDockFloating = printingSelectorDockMenu->addAction(QString());
     aPrintingSelectorDockFloating->setCheckable(true);
-    connect(aPrintingSelectorDockFloating, SIGNAL(triggered()), this, SLOT(dockFloatingTriggered()));
+    connect(aPrintingSelectorDockFloating, &QAction::triggered, this, &TabDeckEditor::dockFloatingTriggered);
 
     viewMenu->addSeparator();
 
     aResetLayout = viewMenu->addAction(QString());
-    connect(aResetLayout, SIGNAL(triggered()), this, SLOT(restartLayout()));
+    connect(aResetLayout, &QAction::triggered, this, &TabDeckEditor::restartLayout);
     viewMenu->addAction(aResetLayout);
 
     deckMenu->setSaveStatus(false);
@@ -200,7 +200,7 @@ void TabDeckEditor::loadLayout()
     databaseDisplayDockWidget->setMinimumSize(100, 100);
     databaseDisplayDockWidget->setMaximumSize(1400, 5000);
 
-    QTimer::singleShot(100, this, SLOT(freeDocksSize()));
+    QTimer::singleShot(100, this, &TabDeckEditor::freeDocksSize);
 }
 
 void TabDeckEditor::restartLayout()
@@ -236,7 +236,7 @@ void TabDeckEditor::restartLayout()
     splitDockWidget(cardInfoDockWidget, printingSelectorDockWidget, Qt::Horizontal);
     splitDockWidget(cardInfoDockWidget, filterDockWidget, Qt::Vertical);
 
-    QTimer::singleShot(100, this, SLOT(freeDocksSize()));
+    QTimer::singleShot(100, this, &TabDeckEditor::freeDocksSize);
 }
 
 void TabDeckEditor::freeDocksSize()

--- a/cockatrice/src/client/tabs/tab_deck_storage.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_storage.cpp
@@ -105,19 +105,19 @@ TabDeckStorage::TabDeckStorage(TabSupervisor *_tabSupervisor,
     // Left side actions
     aOpenLocalDeck = new QAction(this);
     aOpenLocalDeck->setIcon(QPixmap("theme:icons/pencil"));
-    connect(aOpenLocalDeck, SIGNAL(triggered()), this, SLOT(actOpenLocalDeck()));
+    connect(aOpenLocalDeck, &QAction::triggered, this, &TabDeckStorage::actOpenLocalDeck);
     aRenameLocal = new QAction(this);
     aRenameLocal->setIcon(QPixmap("theme:icons/rename"));
     connect(aRenameLocal, &QAction::triggered, this, &TabDeckStorage::actRenameLocal);
     aUpload = new QAction(this);
     aUpload->setIcon(QPixmap("theme:icons/arrow_right_green"));
-    connect(aUpload, SIGNAL(triggered()), this, SLOT(actUpload()));
+    connect(aUpload, &QAction::triggered, this, &TabDeckStorage::actUpload);
     aNewLocalFolder = new QAction(this);
     aNewLocalFolder->setIcon(qApp->style()->standardIcon(QStyle::SP_FileDialogNewFolder));
     connect(aNewLocalFolder, &QAction::triggered, this, &TabDeckStorage::actNewLocalFolder);
     aDeleteLocalDeck = new QAction(this);
     aDeleteLocalDeck->setIcon(QPixmap("theme:icons/remove_row"));
-    connect(aDeleteLocalDeck, SIGNAL(triggered()), this, SLOT(actDeleteLocalDeck()));
+    connect(aDeleteLocalDeck, &QAction::triggered, this, &TabDeckStorage::actDeleteLocalDeck);
 
     aOpenDecksFolder = new QAction(this);
     aOpenDecksFolder->setIcon(qApp->style()->standardIcon(QStyle::SP_DirOpenIcon));
@@ -126,16 +126,16 @@ TabDeckStorage::TabDeckStorage(TabSupervisor *_tabSupervisor,
     // Right side actions
     aOpenRemoteDeck = new QAction(this);
     aOpenRemoteDeck->setIcon(QPixmap("theme:icons/pencil"));
-    connect(aOpenRemoteDeck, SIGNAL(triggered()), this, SLOT(actOpenRemoteDeck()));
+    connect(aOpenRemoteDeck, &QAction::triggered, this, &TabDeckStorage::actOpenRemoteDeck);
     aDownload = new QAction(this);
     aDownload->setIcon(QPixmap("theme:icons/arrow_left_green"));
-    connect(aDownload, SIGNAL(triggered()), this, SLOT(actDownload()));
+    connect(aDownload, &QAction::triggered, this, &TabDeckStorage::actDownload);
     aNewFolder = new QAction(this);
     aNewFolder->setIcon(qApp->style()->standardIcon(QStyle::SP_FileDialogNewFolder));
-    connect(aNewFolder, SIGNAL(triggered()), this, SLOT(actNewFolder()));
+    connect(aNewFolder, &QAction::triggered, this, &TabDeckStorage::actNewFolder);
     aDeleteRemoteDeck = new QAction(this);
     aDeleteRemoteDeck->setIcon(QPixmap("theme:icons/remove_row"));
-    connect(aDeleteRemoteDeck, SIGNAL(triggered()), this, SLOT(actDeleteRemoteDeck()));
+    connect(aDeleteRemoteDeck, &QAction::triggered, this, &TabDeckStorage::actDeleteRemoteDeck);
 
     // Add actions to toolbars
     leftToolBar->addAction(aOpenLocalDeck);
@@ -339,8 +339,7 @@ void TabDeckStorage::uploadDeck(const QString &filePath, const QString &targetPa
     cmd.set_deck_list(deckString.toStdString());
 
     PendingCommand *pend = client->prepareSessionCommand(cmd);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-            SLOT(uploadFinished(Response, CommandContainer)));
+    connect(pend, &PendingCommand::finished, this, &TabDeckStorage::uploadFinished);
     client->sendCommand(pend);
 }
 
@@ -421,8 +420,7 @@ void TabDeckStorage::actOpenRemoteDeck()
         cmd.set_deck_id(node->getId());
 
         PendingCommand *pend = client->prepareSessionCommand(cmd);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(openRemoteDeckFinished(Response, CommandContainer)));
+        connect(pend, &PendingCommand::finished, this, &TabDeckStorage::openRemoteDeckFinished);
         client->sendCommand(pend);
     }
 }
@@ -479,8 +477,7 @@ void TabDeckStorage::downloadNodeAtIndex(const QModelIndex &curLeft, const QMode
 
         PendingCommand *pend = client->prepareSessionCommand(cmd);
         pend->setExtraData(filePath);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(downloadFinished(Response, CommandContainer, QVariant)));
+        connect(pend, &PendingCommand::finished, this, &TabDeckStorage::downloadFinished);
         client->sendCommand(pend);
     }
     // node at index is invalid
@@ -522,8 +519,7 @@ void TabDeckStorage::actNewFolder()
     cmd.set_dir_name(folder);
 
     PendingCommand *pend = client->prepareSessionCommand(cmd);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-            SLOT(newFolderFinished(Response, CommandContainer)));
+    connect(pend, &PendingCommand::finished, this, &TabDeckStorage::newFolderFinished);
     client->sendCommand(pend);
 }
 
@@ -573,15 +569,13 @@ void TabDeckStorage::deleteRemoteDeck(const RemoteDeckList_TreeModel::Node *curR
         Command_DeckDelDir cmd;
         cmd.set_path(targetPath.toStdString());
         pend = client->prepareSessionCommand(cmd);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(deleteFolderFinished(Response, CommandContainer)));
+        connect(pend, &PendingCommand::finished, this, &TabDeckStorage::deleteFolderFinished);
     } else {
         const auto *deckNode = dynamic_cast<const RemoteDeckList_TreeModel::FileNode *>(curRight);
         Command_DeckDel cmd;
         cmd.set_deck_id(deckNode->getId());
         pend = client->prepareSessionCommand(cmd);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(deleteDeckFinished(Response, CommandContainer)));
+        connect(pend, &PendingCommand::finished, this, &TabDeckStorage::deleteDeckFinished);
     }
 
     client->sendCommand(pend);

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -115,11 +115,12 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, GameReplay *_replay)
     createReplayMenuItems();
     createViewMenuItems();
     retranslateUi();
-    connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
+    connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
+            &TabGame::refreshShortcuts);
     refreshShortcuts();
     messageLog->logReplayStarted(gameInfo.game_id());
 
-    QTimer::singleShot(0, this, SLOT(loadLayout()));
+    QTimer::singleShot(0, this, &TabGame::loadLayout);
 }
 
 TabGame::TabGame(TabSupervisor *_tabSupervisor,
@@ -156,14 +157,15 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor,
     createMenuItems();
     createViewMenuItems();
     retranslateUi();
-    connect(&SettingsCache::instance().shortcuts(), SIGNAL(shortCutChanged()), this, SLOT(refreshShortcuts()));
+    connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
+            &TabGame::refreshShortcuts);
     refreshShortcuts();
 
     // append game to rooms game list for others to see
     for (int i = gameInfo.game_types_size() - 1; i >= 0; i--)
         gameTypes.append(roomGameTypes.find(gameInfo.game_types(i)).value());
 
-    QTimer::singleShot(0, this, SLOT(loadLayout()));
+    QTimer::singleShot(0, this, &TabGame::loadLayout);
 }
 
 void TabGame::addMentionTag(const QString &value)
@@ -628,7 +630,7 @@ Player *TabGame::addPlayer(int playerId, const ServerInfo_User &info)
     }
     scene->addPlayer(newPlayer);
 
-    connect(newPlayer, SIGNAL(newCardAdded(AbstractCardItem *)), this, SLOT(newCardAdded(AbstractCardItem *)));
+    connect(newPlayer, &Player::newCardAdded, this, &TabGame::newCardAdded);
     messageLog->connectToPlayer(newPlayer);
 
     if (local && !spectator) {
@@ -636,7 +638,7 @@ Player *TabGame::addPlayer(int playerId, const ServerInfo_User &info)
             newPlayer->setShortcutsActive();
 
         auto *deckView = new DeckViewContainer(playerId, this);
-        connect(deckView, SIGNAL(newCardAdded(AbstractCardItem *)), this, SLOT(newCardAdded(AbstractCardItem *)));
+        connect(deckView, &DeckViewContainer::newCardAdded, this, &TabGame::newCardAdded);
         deckViewContainers.insert(playerId, deckView);
         deckViewContainerLayout->addWidget(deckView);
 
@@ -784,8 +786,7 @@ void TabGame::sendGameCommand(PendingCommand *pend, int playerId)
     if (!client)
         return;
 
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-            SLOT(commandFinished(const Response &)));
+    connect(pend, &PendingCommand::finished, this, &TabGame::commandFinished);
     client->sendCommand(pend);
 }
 
@@ -796,8 +797,7 @@ void TabGame::sendGameCommand(const google::protobuf::Message &command, int play
         return;
 
     PendingCommand *pend = prepareGameCommand(command);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-            SLOT(commandFinished(const Response &)));
+    connect(pend, &PendingCommand::finished, this, &TabGame::commandFinished);
     client->sendCommand(pend);
 }
 
@@ -1198,10 +1198,11 @@ void TabGame::eventSetActivePhase(const Event_SetActivePhase &event,
 
 void TabGame::newCardAdded(AbstractCardItem *card)
 {
-    connect(card, SIGNAL(hovered(AbstractCardItem *)), cardInfoFrameWidget, SLOT(setCard(AbstractCardItem *)));
+    connect(card, &AbstractCardItem::hovered, cardInfoFrameWidget,
+            qOverload<AbstractCardItem *>(&CardInfoFrameWidget::setCard));
     connect(card, &AbstractCardItem::showCardInfoPopup, this, &TabGame::showCardInfoPopup);
     connect(card, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));
-    connect(card, SIGNAL(cardShiftClicked(QString)), this, SLOT(linkCardToChat(QString)));
+    connect(card, &AbstractCardItem::cardShiftClicked, this, &TabGame::linkCardToChat);
 }
 
 CardItem *TabGame::getCard(int playerId, const QString &zoneName, int cardId) const
@@ -1289,34 +1290,34 @@ void TabGame::updateCardMenu(AbstractCardItem *card)
 void TabGame::createMenuItems()
 {
     aNextPhase = new QAction(this);
-    connect(aNextPhase, SIGNAL(triggered()), this, SLOT(actNextPhase()));
+    connect(aNextPhase, &QAction::triggered, this, &TabGame::actNextPhase);
     aNextPhaseAction = new QAction(this);
-    connect(aNextPhaseAction, SIGNAL(triggered()), this, SLOT(actNextPhaseAction()));
+    connect(aNextPhaseAction, &QAction::triggered, this, &TabGame::actNextPhaseAction);
     aNextTurn = new QAction(this);
-    connect(aNextTurn, SIGNAL(triggered()), this, SLOT(actNextTurn()));
+    connect(aNextTurn, &QAction::triggered, this, &TabGame::actNextTurn);
     aReverseTurn = new QAction(this);
-    connect(aReverseTurn, SIGNAL(triggered()), this, SLOT(actReverseTurn()));
+    connect(aReverseTurn, &QAction::triggered, this, &TabGame::actReverseTurn);
     aRemoveLocalArrows = new QAction(this);
-    connect(aRemoveLocalArrows, SIGNAL(triggered()), this, SLOT(actRemoveLocalArrows()));
+    connect(aRemoveLocalArrows, &QAction::triggered, this, &TabGame::actRemoveLocalArrows);
     aRotateViewCW = new QAction(this);
-    connect(aRotateViewCW, SIGNAL(triggered()), this, SLOT(actRotateViewCW()));
+    connect(aRotateViewCW, &QAction::triggered, this, &TabGame::actRotateViewCW);
     aRotateViewCCW = new QAction(this);
-    connect(aRotateViewCCW, SIGNAL(triggered()), this, SLOT(actRotateViewCCW()));
+    connect(aRotateViewCCW, &QAction::triggered, this, &TabGame::actRotateViewCCW);
     aGameInfo = new QAction(this);
-    connect(aGameInfo, SIGNAL(triggered()), this, SLOT(actGameInfo()));
+    connect(aGameInfo, &QAction::triggered, this, &TabGame::actGameInfo);
     aConcede = new QAction(this);
-    connect(aConcede, SIGNAL(triggered()), this, SLOT(actConcede()));
+    connect(aConcede, &QAction::triggered, this, &TabGame::actConcede);
     aLeaveGame = new QAction(this);
     connect(aLeaveGame, &QAction::triggered, this, [this] { closeRequest(); });
     aFocusChat = new QAction(this);
-    connect(aFocusChat, SIGNAL(triggered()), sayEdit, SLOT(setFocus()));
+    connect(aFocusChat, &QAction::triggered, sayEdit, qOverload<>(&LineEditCompleter::setFocus));
     aCloseReplay = nullptr;
 
     phasesMenu = new TearOffMenu(this);
 
     for (int i = 0; i < phasesToolbar->phaseCount(); ++i) {
         QAction *temp = new QAction(QString(), this);
-        connect(temp, SIGNAL(triggered()), this, SLOT(actPhaseAction()));
+        connect(temp, &QAction::triggered, this, &TabGame::actPhaseAction);
         phasesMenu->addAction(temp);
         phaseActions.append(temp);
     }
@@ -1375,40 +1376,40 @@ void TabGame::createViewMenuItems()
 
     aCardInfoDockVisible = cardInfoDockMenu->addAction(QString());
     aCardInfoDockVisible->setCheckable(true);
-    connect(aCardInfoDockVisible, SIGNAL(triggered()), this, SLOT(dockVisibleTriggered()));
+    connect(aCardInfoDockVisible, &QAction::triggered, this, &TabGame::dockVisibleTriggered);
     aCardInfoDockFloating = cardInfoDockMenu->addAction(QString());
     aCardInfoDockFloating->setCheckable(true);
-    connect(aCardInfoDockFloating, SIGNAL(triggered()), this, SLOT(dockFloatingTriggered()));
+    connect(aCardInfoDockFloating, &QAction::triggered, this, &TabGame::dockFloatingTriggered);
 
     aMessageLayoutDockVisible = messageLayoutDockMenu->addAction(QString());
     aMessageLayoutDockVisible->setCheckable(true);
-    connect(aMessageLayoutDockVisible, SIGNAL(triggered()), this, SLOT(dockVisibleTriggered()));
+    connect(aMessageLayoutDockVisible, &QAction::triggered, this, &TabGame::dockVisibleTriggered);
     aMessageLayoutDockFloating = messageLayoutDockMenu->addAction(QString());
     aMessageLayoutDockFloating->setCheckable(true);
-    connect(aMessageLayoutDockFloating, SIGNAL(triggered()), this, SLOT(dockFloatingTriggered()));
+    connect(aMessageLayoutDockFloating, &QAction::triggered, this, &TabGame::dockFloatingTriggered);
 
     aPlayerListDockVisible = playerListDockMenu->addAction(QString());
     aPlayerListDockVisible->setCheckable(true);
-    connect(aPlayerListDockVisible, SIGNAL(triggered()), this, SLOT(dockVisibleTriggered()));
+    connect(aPlayerListDockVisible, &QAction::triggered, this, &TabGame::dockVisibleTriggered);
     aPlayerListDockFloating = playerListDockMenu->addAction(QString());
     aPlayerListDockFloating->setCheckable(true);
-    connect(aPlayerListDockFloating, SIGNAL(triggered()), this, SLOT(dockFloatingTriggered()));
+    connect(aPlayerListDockFloating, &QAction::triggered, this, &TabGame::dockFloatingTriggered);
 
     if (replayDock) {
         replayDockMenu = viewMenu->addMenu(QString());
 
         aReplayDockVisible = replayDockMenu->addAction(QString());
         aReplayDockVisible->setCheckable(true);
-        connect(aReplayDockVisible, SIGNAL(triggered()), this, SLOT(dockVisibleTriggered()));
+        connect(aReplayDockVisible, &QAction::triggered, this, &TabGame::dockVisibleTriggered);
         aReplayDockFloating = replayDockMenu->addAction(QString());
         aReplayDockFloating->setCheckable(true);
-        connect(aReplayDockFloating, SIGNAL(triggered()), this, SLOT(dockFloatingTriggered()));
+        connect(aReplayDockFloating, &QAction::triggered, this, &TabGame::dockFloatingTriggered);
     }
 
     viewMenu->addSeparator();
 
     aResetLayout = viewMenu->addAction(QString());
-    connect(aResetLayout, SIGNAL(triggered()), this, SLOT(actResetLayout()));
+    connect(aResetLayout, &QAction::triggered, this, &TabGame::actResetLayout);
     viewMenu->addAction(aResetLayout);
 
     addTabMenu(viewMenu);
@@ -1459,7 +1460,7 @@ void TabGame::loadLayout()
         aReplayDockFloating->setChecked(replayDock->isFloating());
     }
 
-    QTimer::singleShot(100, this, SLOT(freeDocksSize()));
+    QTimer::singleShot(100, this, &TabGame::freeDocksSize);
 }
 
 void TabGame::freeDocksSize()
@@ -1525,15 +1526,15 @@ void TabGame::actResetLayout()
         playerListDock->setMaximumSize(250, 50);
     }
 
-    QTimer::singleShot(100, this, SLOT(freeDocksSize()));
+    QTimer::singleShot(100, this, &TabGame::freeDocksSize);
 }
 
 void TabGame::createPlayAreaWidget(bool bReplay)
 {
     phasesToolbar = new PhasesToolbar;
     if (!bReplay)
-        connect(phasesToolbar, SIGNAL(sendGameCommand(const ::google::protobuf::Message &, int)), this,
-                SLOT(sendGameCommand(const ::google::protobuf::Message &, int)));
+        connect(phasesToolbar, &PhasesToolbar::sendGameCommand, this,
+                qOverload<const ::google::protobuf::Message &, int>(&TabGame::sendGameCommand));
     scene = new GameScene(phasesToolbar, this);
     gameView = new GameView(scene);
 
@@ -1551,9 +1552,8 @@ void TabGame::createReplayDock()
     // timeline widget
     timelineWidget = new ReplayTimelineWidget;
     timelineWidget->setTimeline(replayTimeline);
-    connect(timelineWidget, SIGNAL(processNextEvent(Player::EventProcessingOptions)), this,
-            SLOT(replayNextEvent(Player::EventProcessingOptions)));
-    connect(timelineWidget, SIGNAL(replayFinished()), this, SLOT(replayFinished()));
+    connect(timelineWidget, &ReplayTimelineWidget::processNextEvent, this, &TabGame::replayNextEvent);
+    connect(timelineWidget, &ReplayTimelineWidget::replayFinished, this, &TabGame::replayFinished);
     connect(timelineWidget, &ReplayTimelineWidget::rewound, this, &TabGame::replayRewind);
 
     // timeline skip shortcuts
@@ -1585,13 +1585,13 @@ void TabGame::createReplayDock()
     playButtonIcon.addPixmap(QPixmap("theme:replay/pause"), QIcon::Normal, QIcon::On);
     replayPlayButton->setIcon(playButtonIcon);
     replayPlayButton->setCheckable(true);
-    connect(replayPlayButton, SIGNAL(toggled(bool)), this, SLOT(replayPlayButtonToggled(bool)));
+    connect(replayPlayButton, &QToolButton::toggled, this, &TabGame::replayPlayButtonToggled);
 
     replayFastForwardButton = new QToolButton;
     replayFastForwardButton->setIconSize(QSize(32, 32));
     replayFastForwardButton->setIcon(QPixmap("theme:replay/fastforward"));
     replayFastForwardButton->setCheckable(true);
-    connect(replayFastForwardButton, SIGNAL(toggled(bool)), this, SLOT(replayFastForwardButtonToggled(bool)));
+    connect(replayFastForwardButton, &QToolButton::toggled, this, &TabGame::replayFastForwardButtonToggled);
 
     // putting everything together
     replayControlLayout = new QHBoxLayout;
@@ -1611,7 +1611,7 @@ void TabGame::createReplayDock()
     replayDock->setFloating(false);
 
     replayDock->installEventFilter(this);
-    connect(replayDock, SIGNAL(topLevelChanged(bool)), this, SLOT(dockTopLevelChanged(bool)));
+    connect(replayDock, &QDockWidget::topLevelChanged, this, &TabGame::dockTopLevelChanged);
 }
 
 void TabGame::createDeckViewContainerWidget(bool bReplay)
@@ -1652,7 +1652,7 @@ void TabGame::createCardInfoDock(bool bReplay)
     cardInfoDock->setFloating(false);
 
     cardInfoDock->installEventFilter(this);
-    connect(cardInfoDock, SIGNAL(topLevelChanged(bool)), this, SLOT(dockTopLevelChanged(bool)));
+    connect(cardInfoDock, &QDockWidget::topLevelChanged, this, &TabGame::dockTopLevelChanged);
 }
 
 void TabGame::createPlayerListDock(bool bReplay)
@@ -1674,26 +1674,28 @@ void TabGame::createPlayerListDock(bool bReplay)
     playerListDock->setFloating(false);
 
     playerListDock->installEventFilter(this);
-    connect(playerListDock, SIGNAL(topLevelChanged(bool)), this, SLOT(dockTopLevelChanged(bool)));
+    connect(playerListDock, &QDockWidget::topLevelChanged, this, &TabGame::dockTopLevelChanged);
 }
 
 void TabGame::createMessageDock(bool bReplay)
 {
     messageLog = new MessageLogWidget(tabSupervisor, this);
-    connect(messageLog, SIGNAL(cardNameHovered(QString)), cardInfoFrameWidget, SLOT(setCard(QString)));
+    connect(messageLog, &MessageLogWidget::cardNameHovered, cardInfoFrameWidget,
+            qOverload<const QString &>(&CardInfoFrameWidget::setCard));
     connect(messageLog, &MessageLogWidget::showCardInfoPopup, this, &TabGame::showCardInfoPopup);
-    connect(messageLog, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));
+    connect(messageLog, &MessageLogWidget::deleteCardInfoPopup, this, &TabGame::deleteCardInfoPopup);
 
     if (!bReplay) {
-        connect(messageLog, SIGNAL(openMessageDialog(QString, bool)), this, SIGNAL(openMessageDialog(QString, bool)));
-        connect(messageLog, SIGNAL(addMentionTag(QString)), this, SLOT(addMentionTag(QString)));
-        connect(&SettingsCache::instance(), SIGNAL(chatMentionCompleterChanged()), this, SLOT(actCompleterChanged()));
+        connect(messageLog, &MessageLogWidget::openMessageDialog, this, &TabGame::openMessageDialog);
+        connect(messageLog, &MessageLogWidget::addMentionTag, this, &TabGame::addMentionTag);
+        connect(&SettingsCache::instance(), &SettingsCache::chatMentionCompleterChanged, this,
+                &TabGame::actCompleterChanged);
 
         timeElapsedLabel = new QLabel;
         timeElapsedLabel->setAlignment(Qt::AlignCenter);
         gameTimer = new QTimer(this);
         gameTimer->setInterval(1000);
-        connect(gameTimer, SIGNAL(timeout()), this, SLOT(incrementGameTime()));
+        connect(gameTimer, &QTimer::timeout, this, &TabGame::incrementGameTime);
         gameTimer->start();
 
         sayLabel = new QLabel;
@@ -1721,8 +1723,8 @@ void TabGame::createMessageDock(bool bReplay)
             }
         }
 
-        connect(tabSupervisor, SIGNAL(adminLockChanged(bool)), this, SLOT(adminLockChanged(bool)));
-        connect(sayEdit, SIGNAL(returnPressed()), this, SLOT(actSay()));
+        connect(tabSupervisor, &TabSupervisor::adminLockChanged, this, &TabGame::adminLockChanged);
+        connect(sayEdit, &LineEditCompleter::returnPressed, this, &TabGame::actSay);
 
         sayHLayout = new QHBoxLayout;
         sayHLayout->addWidget(sayLabel);
@@ -1748,7 +1750,7 @@ void TabGame::createMessageDock(bool bReplay)
     messageLayoutDock->setFloating(false);
 
     messageLayoutDock->installEventFilter(this);
-    connect(messageLayoutDock, SIGNAL(topLevelChanged(bool)), this, SLOT(dockTopLevelChanged(bool)));
+    connect(messageLayoutDock, &QDockWidget::topLevelChanged, this, &TabGame::dockTopLevelChanged);
 }
 
 void TabGame::hideEvent(QHideEvent *event)

--- a/cockatrice/src/client/tabs/tab_logs.cpp
+++ b/cockatrice/src/client/tabs/tab_logs.cpp
@@ -116,8 +116,7 @@ void TabLog::getClicked()
     cmd.set_date_range(dateRange);
     cmd.set_maximum_results(maximumResults->value());
     PendingCommand *pend = client->prepareModeratorCommand(cmd);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-            SLOT(viewLogHistory_processResponse(Response)));
+    connect(pend, &PendingCommand::finished, this, &TabLog::viewLogHistory_processResponse);
     client->sendCommand(pend);
 }
 
@@ -186,11 +185,11 @@ void TabLog::createDock()
 
     getButton = new QPushButton(tr("Get User Logs"));
     getButton->setAutoDefault(true);
-    connect(getButton, SIGNAL(clicked()), this, SLOT(getClicked()));
+    connect(getButton, &QPushButton::clicked, this, &TabLog::getClicked);
 
     clearButton = new QPushButton(tr("Clear Filters"));
     clearButton->setAutoDefault(true);
-    connect(clearButton, SIGNAL(clicked()), this, SLOT(clearClicked()));
+    connect(clearButton, &QPushButton::clicked, this, &TabLog::clearClicked);
 
     criteriaGrid = new QGridLayout;
     criteriaGrid->addWidget(labelFindUserName, 0, 0);

--- a/cockatrice/src/client/tabs/tab_message.cpp
+++ b/cockatrice/src/client/tabs/tab_message.cpp
@@ -28,11 +28,11 @@ TabMessage::TabMessage(TabSupervisor *_tabSupervisor,
 {
     chatView = new ChatView(tabSupervisor, 0, true);
     connect(chatView, &ChatView::showCardInfoPopup, this, &TabMessage::showCardInfoPopup);
-    connect(chatView, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));
-    connect(chatView, SIGNAL(addMentionTag(QString)), this, SLOT(addMentionTag(QString)));
+    connect(chatView, &ChatView::deleteCardInfoPopup, this, &TabMessage::deleteCardInfoPopup);
+    connect(chatView, &ChatView::addMentionTag, this, &TabMessage::addMentionTag);
     sayEdit = new LineEditUnfocusable;
     sayEdit->setMaxLength(MAX_TEXT_LENGTH);
-    connect(sayEdit, SIGNAL(returnPressed()), this, SLOT(sendMessage()));
+    connect(sayEdit, &LineEditUnfocusable::returnPressed, this, &TabMessage::sendMessage);
 
     QVBoxLayout *vbox = new QVBoxLayout;
     vbox->addWidget(chatView);
@@ -102,7 +102,7 @@ void TabMessage::sendMessage()
     cmd.set_message(sayEdit->text().toStdString());
 
     PendingCommand *pend = client->prepareSessionCommand(cmd);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(messageSent(const Response &)));
+    connect(pend, &PendingCommand::finished, this, &TabMessage::messageSent);
     client->sendCommand(pend);
 
     sayEdit->clear();
@@ -140,10 +140,10 @@ bool TabMessage::shouldShowSystemPopup(const Event_UserMessage &event)
 void TabMessage::showSystemPopup(const Event_UserMessage &event)
 {
     if (trayIcon) {
-        disconnect(trayIcon, SIGNAL(messageClicked()), 0, 0);
+        disconnect(trayIcon, &QSystemTrayIcon::messageClicked, 0, 0);
         trayIcon->showMessage(tr("Private message from") + " " + otherUserInfo->name().c_str(),
                               event.message().c_str());
-        connect(trayIcon, SIGNAL(messageClicked()), this, SLOT(messageClicked()));
+        connect(trayIcon, &QSystemTrayIcon::messageClicked, this, &TabMessage::messageClicked);
     } else {
         qCWarning(TabMessageLog) << "Error: trayIcon is NULL. TabMessage::showSystemPopup failed";
     }

--- a/cockatrice/src/client/tabs/tab_replays.cpp
+++ b/cockatrice/src/client/tabs/tab_replays.cpp
@@ -96,8 +96,8 @@ TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client, c
     // Left side actions
     aOpenLocalReplay = new QAction(this);
     aOpenLocalReplay->setIcon(QPixmap("theme:icons/view"));
-    connect(aOpenLocalReplay, SIGNAL(triggered()), this, SLOT(actOpenLocalReplay()));
-    connect(localDirView, SIGNAL(doubleClicked(const QModelIndex &)), this, SLOT(actOpenLocalReplay()));
+    connect(aOpenLocalReplay, &QAction::triggered, this, &TabReplays::actOpenLocalReplay);
+    connect(localDirView, &QTreeView::doubleClicked, this, &TabReplays::actOpenLocalReplay);
     aRenameLocal = new QAction(this);
     aRenameLocal->setIcon(QPixmap("theme:icons/rename"));
     connect(aRenameLocal, &QAction::triggered, this, &TabReplays::actRenameLocal);
@@ -106,7 +106,7 @@ TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client, c
     connect(aNewLocalFolder, &QAction::triggered, this, &TabReplays::actNewLocalFolder);
     aDeleteLocalReplay = new QAction(this);
     aDeleteLocalReplay->setIcon(QPixmap("theme:icons/remove_row"));
-    connect(aDeleteLocalReplay, SIGNAL(triggered()), this, SLOT(actDeleteLocalReplay()));
+    connect(aDeleteLocalReplay, &QAction::triggered, this, &TabReplays::actDeleteLocalReplay);
 
     aOpenReplaysFolder = new QAction(this);
     aOpenReplaysFolder->setIcon(qApp->style()->standardIcon(QStyle::SP_DirOpenIcon));
@@ -115,17 +115,17 @@ TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client, c
     // Right side actions
     aOpenRemoteReplay = new QAction(this);
     aOpenRemoteReplay->setIcon(QPixmap("theme:icons/view"));
-    connect(aOpenRemoteReplay, SIGNAL(triggered()), this, SLOT(actOpenRemoteReplay()));
-    connect(serverDirView, SIGNAL(doubleClicked(const QModelIndex &)), this, SLOT(actOpenRemoteReplay()));
+    connect(aOpenRemoteReplay, &QAction::triggered, this, &TabReplays::actOpenRemoteReplay);
+    connect(serverDirView, &QTreeView::doubleClicked, this, &TabReplays::actOpenRemoteReplay);
     aDownload = new QAction(this);
     aDownload->setIcon(QPixmap("theme:icons/arrow_left_green"));
-    connect(aDownload, SIGNAL(triggered()), this, SLOT(actDownload()));
+    connect(aDownload, &QAction::triggered, this, &TabReplays::actDownload);
     aKeep = new QAction(this);
     aKeep->setIcon(QPixmap("theme:icons/lock"));
-    connect(aKeep, SIGNAL(triggered()), this, SLOT(actKeepRemoteReplay()));
+    connect(aKeep, &QAction::triggered, this, &TabReplays::actKeepRemoteReplay);
     aDeleteRemoteReplay = new QAction(this);
     aDeleteRemoteReplay->setIcon(QPixmap("theme:icons/remove_row"));
-    connect(aDeleteRemoteReplay, SIGNAL(triggered()), this, SLOT(actDeleteRemoteReplay()));
+    connect(aDeleteRemoteReplay, &QAction::triggered, this, &TabReplays::actDeleteRemoteReplay);
 
     // Add actions to toolbars
     leftToolBar->addAction(aOpenLocalReplay);
@@ -146,8 +146,7 @@ TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client, c
     mainWidget->setLayout(hbox);
     setCentralWidget(mainWidget);
 
-    connect(client, SIGNAL(replayAddedEventReceived(const Event_ReplayAdded &)), this,
-            SLOT(replayAddedEventReceived(const Event_ReplayAdded &)));
+    connect(client, &AbstractClient::replayAddedEventReceived, this, &TabReplays::replayAddedEventReceived);
 
     connect(client, &AbstractClient::userInfoChanged, this, &TabReplays::handleConnected);
     connect(client, &AbstractClient::statusChanged, this, &TabReplays::handleConnectionChanged);
@@ -323,8 +322,7 @@ void TabReplays::actOpenRemoteReplay()
         cmd.set_replay_id(curRight->replay_id());
 
         PendingCommand *pend = client->prepareSessionCommand(cmd);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(openRemoteReplayFinished(const Response &)));
+        connect(pend, &PendingCommand::finished, this, &TabReplays::openRemoteReplayFinished);
         client->sendCommand(pend);
     }
 }
@@ -378,8 +376,7 @@ void TabReplays::downloadNodeAtIndex(const QModelIndex &curLeft, const QModelInd
 
         PendingCommand *pend = client->prepareSessionCommand(cmd);
         pend->setExtraData(filePath);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(downloadFinished(Response, CommandContainer, QVariant)));
+        connect(pend, &PendingCommand::finished, this, &TabReplays::downloadFinished);
         client->sendCommand(pend);
     }
     // node at index was invalid
@@ -416,8 +413,7 @@ void TabReplays::actKeepRemoteReplay()
         cmd.set_do_not_hide(!curRight->do_not_hide());
 
         PendingCommand *pend = client->prepareSessionCommand(cmd);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(keepRemoteReplayFinished(Response, CommandContainer)));
+        connect(pend, &PendingCommand::finished, this, &TabReplays::keepRemoteReplayFinished);
         client->sendCommand(pend);
     }
 }
@@ -455,8 +451,7 @@ void TabReplays::actDeleteRemoteReplay()
         cmd.set_game_id(curRight->game_id());
 
         PendingCommand *pend = client->prepareSessionCommand(cmd);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(deleteRemoteReplayFinished(Response, CommandContainer)));
+        connect(pend, &PendingCommand::finished, this, &TabReplays::deleteRemoteReplayFinished);
         client->sendCommand(pend);
     }
 }

--- a/cockatrice/src/client/tabs/tab_server.cpp
+++ b/cockatrice/src/client/tabs/tab_server.cpp
@@ -33,7 +33,7 @@ RoomSelector::RoomSelector(AbstractClient *_client, QWidget *parent) : QGroupBox
     roomList->header()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
 
     joinButton = new QPushButton;
-    connect(joinButton, SIGNAL(clicked()), this, SLOT(joinClicked()));
+    connect(joinButton, &QPushButton::clicked, this, &RoomSelector::joinClicked);
     QHBoxLayout *buttonLayout = new QHBoxLayout;
     buttonLayout->addStretch();
     buttonLayout->addWidget(joinButton);
@@ -44,9 +44,8 @@ RoomSelector::RoomSelector(AbstractClient *_client, QWidget *parent) : QGroupBox
     retranslateUi();
     setLayout(vbox);
 
-    connect(client, SIGNAL(listRoomsEventReceived(const Event_ListRooms &)), this,
-            SLOT(processListRoomsEvent(const Event_ListRooms &)));
-    connect(roomList, SIGNAL(activated(const QModelIndex &)), this, SLOT(joinClicked()));
+    connect(client, &AbstractClient::listRoomsEventReceived, this, &RoomSelector::processListRoomsEvent);
+    connect(roomList, &QTreeWidget::activated, this, &RoomSelector::joinClicked);
     client->sendCommand(client->prepareSessionCommand(Command_ListRooms()));
 }
 
@@ -144,10 +143,9 @@ TabServer::TabServer(TabSupervisor *_tabSupervisor, AbstractClient *_client) : T
     serverInfoBox = new QTextBrowser;
     serverInfoBox->setOpenExternalLinks(true);
 
-    connect(roomSelector, SIGNAL(joinRoomRequest(int, bool)), this, SLOT(joinRoom(int, bool)));
+    connect(roomSelector, &RoomSelector::joinRoomRequest, this, &TabServer::joinRoom);
 
-    connect(client, SIGNAL(serverMessageEventReceived(const Event_ServerMessage &)), this,
-            SLOT(processServerMessageEvent(const Event_ServerMessage &)));
+    connect(client, &AbstractClient::serverMessageEventReceived, this, &TabServer::processServerMessageEvent);
 
     QVBoxLayout *vbox = new QVBoxLayout;
     vbox->addWidget(roomSelector);
@@ -185,8 +183,7 @@ void TabServer::joinRoom(int id, bool setCurrent)
 
         PendingCommand *pend = client->prepareSessionCommand(cmd);
         pend->setExtraData(setCurrent);
-        connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this,
-                SLOT(joinRoomFinished(Response, CommandContainer, QVariant)));
+        connect(pend, &PendingCommand::finished, this, &TabServer::joinRoomFinished);
 
         client->sendCommand(pend);
 


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5432 

## What will change with this Pull Request?
- Update all but one usage of slot/signal in `src/client/tabs` to new syntax
- Also update usage in `DeckEditorMenu`
  - added `DeckEditorMenu` as a friend class to `AbstractTabDeckEditor`, since it uses protected signals on `AbstractTabDeckEditor`. 
    - Seems like old syntax ignores access modifiers but new syntax doesn't

Only usages of `AbstractCardItem::deleteCardInfoPopup(QString)` isn't updated, because that signal is emitted from `AbstractCardItem`'s destructor, and changing it to use the new syntax causes a segfault on exit.