### PR TITLE
Add a button to quickly clear all filters in VDD, correctly emit signals in filter tree when clearing.

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -95,8 +95,14 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
     filterContainerLayout = new QHBoxLayout(filterContainer);
     filterContainer->setLayout(filterContainerLayout);
 
+    clearFilterWidget = new QToolButton();
+    clearFilterWidget->setFixedSize(32, 32);
+    clearFilterWidget->setIcon(QPixmap("theme:icons/delete"));
+    connect(clearFilterWidget, &QToolButton::clicked, this, [this] { filterModel->clear(); });
+
     quickFilterSaveLoadWidget = new SettingsButtonWidget(this);
     quickFilterSaveLoadWidget->setButtonIcon(QPixmap("theme:icons/lock"));
+
     saveLoadWidget = new VisualDatabaseDisplayFilterSaveLoadWidget(this, filterModel);
     quickFilterNameWidget = new SettingsButtonWidget(this);
     quickFilterNameWidget->setButtonIcon(QPixmap("theme:icons/rename"));
@@ -122,6 +128,7 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
     filterContainerLayout->addWidget(quickFilterSetWidget);
 
     searchLayout->addWidget(colorFilterWidget);
+    searchLayout->addWidget(clearFilterWidget);
     searchLayout->addWidget(searchEdit);
 
     mainLayout->addWidget(searchContainer);

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.h
@@ -69,6 +69,7 @@ protected slots:
     void updateSearch(const QString &search) const;
 
 private:
+    QToolButton *clearFilterWidget;
     QWidget *filterContainer;
     QHBoxLayout *filterContainerLayout;
     SettingsButtonWidget *quickFilterSaveLoadWidget;

--- a/cockatrice/src/game/filters/filter_tree.cpp
+++ b/cockatrice/src/game/filters/filter_tree.cpp
@@ -536,4 +536,5 @@ void FilterTree::clear()
     while (childCount() > 0) {
         deleteAt(0);
     }
+    emit changed();
 }

--- a/cockatrice/src/game/filters/filter_tree_model.cpp
+++ b/cockatrice/src/game/filters/filter_tree_model.cpp
@@ -316,5 +316,7 @@ bool FilterTreeModel::removeRows(int row, int count, const QModelIndex &parent)
 
 void FilterTreeModel::clear()
 {
+    emit layoutAboutToBeChanged();
     fTree->clear();
+    emit layoutChanged();
 }


### PR DESCRIPTION
## Short roundup of the initial problem
There's no way to quickly clear all filters currently and the filter tree doesn't correctly emit the signals it should when clearing.
