### PR TITLE
Give every filter type its own button in VDD

### DIFF
--- a/cockatrice/src/client/ui/widgets/quick_settings/settings_button_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/quick_settings/settings_button_widget.cpp
@@ -26,6 +26,11 @@ void SettingsButtonWidget::addSettingsWidget(QWidget *toAdd) const
     popup->addSettingsWidget(toAdd);
 }
 
+void SettingsButtonWidget::setButtonIcon(QPixmap iconMap)
+{
+    button->setIcon(iconMap);
+}
+
 void SettingsButtonWidget::togglePopup()
 {
     if (popup->isVisible()) {

--- a/cockatrice/src/client/ui/widgets/quick_settings/settings_button_widget.h
+++ b/cockatrice/src/client/ui/widgets/quick_settings/settings_button_widget.h
@@ -13,6 +13,7 @@ class SettingsButtonWidget : public QWidget
 public:
     explicit SettingsButtonWidget(QWidget *parent = nullptr);
     void addSettingsWidget(QWidget *toAdd) const;
+    void setButtonIcon(QPixmap iconMap);
 
 protected:
     void mousePressEvent(QMouseEvent *event) override;

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -91,27 +91,42 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
 
     colorFilterWidget = new VisualDatabaseDisplayColorFilterWidget(this, filterModel);
 
-    quickFilterWidget = new SettingsButtonWidget(this);
+    filterContainer = new QWidget(this);
+    filterContainerLayout = new QHBoxLayout(filterContainer);
+    filterContainer->setLayout(filterContainerLayout);
 
+    quickFilterSaveLoadWidget = new SettingsButtonWidget(this);
+    quickFilterSaveLoadWidget->setButtonIcon(QPixmap("theme:icons/lock"));
     saveLoadWidget = new VisualDatabaseDisplayFilterSaveLoadWidget(this, filterModel);
+    quickFilterNameWidget = new SettingsButtonWidget(this);
+    quickFilterNameWidget->setButtonIcon(QPixmap("theme:icons/rename"));
     nameFilterWidget = new VisualDatabaseDisplayNameFilterWidget(this, deckEditor, filterModel);
     mainTypeFilterWidget = new VisualDatabaseDisplayMainTypeFilterWidget(this, filterModel);
+    quickFilterSubTypeWidget = new SettingsButtonWidget(this);
+    quickFilterSubTypeWidget->setButtonIcon(QPixmap("theme:icons/player"));
     subTypeFilterWidget = new VisualDatabaseDisplaySubTypeFilterWidget(this, filterModel);
+    quickFilterSetWidget = new SettingsButtonWidget(this);
+    quickFilterSetWidget->setButtonIcon(QPixmap("theme:icons/scales"));
     setFilterWidget = new VisualDatabaseDisplaySetFilterWidget(this, filterModel);
+    filterContainer->setMaximumHeight(80);
 
-    quickFilterWidget->addSettingsWidget(saveLoadWidget);
-    quickFilterWidget->addSettingsWidget(nameFilterWidget);
-    // quickFilterWidget->addSettingsWidget(mainTypeFilterWidget);
-    quickFilterWidget->addSettingsWidget(subTypeFilterWidget);
-    quickFilterWidget->addSettingsWidget(setFilterWidget);
+    quickFilterSaveLoadWidget->addSettingsWidget(saveLoadWidget);
+    quickFilterNameWidget->addSettingsWidget(nameFilterWidget);
+    quickFilterSubTypeWidget->addSettingsWidget(subTypeFilterWidget);
+    quickFilterSetWidget->addSettingsWidget(setFilterWidget);
+
+    filterContainerLayout->addWidget(mainTypeFilterWidget);
+    filterContainerLayout->addWidget(quickFilterSaveLoadWidget);
+    filterContainerLayout->addWidget(quickFilterNameWidget);
+    filterContainerLayout->addWidget(quickFilterSubTypeWidget);
+    filterContainerLayout->addWidget(quickFilterSetWidget);
 
     searchLayout->addWidget(colorFilterWidget);
-    searchLayout->addWidget(quickFilterWidget);
     searchLayout->addWidget(searchEdit);
 
     mainLayout->addWidget(searchContainer);
 
-    mainLayout->addWidget(mainTypeFilterWidget);
+    mainLayout->addWidget(filterContainer);
 
     mainLayout->addWidget(flowWidget);
 

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.h
@@ -69,11 +69,16 @@ protected slots:
     void updateSearch(const QString &search) const;
 
 private:
-    SettingsButtonWidget *quickFilterWidget;
+    QWidget *filterContainer;
+    QHBoxLayout *filterContainerLayout;
+    SettingsButtonWidget *quickFilterSaveLoadWidget;
     VisualDatabaseDisplayFilterSaveLoadWidget *saveLoadWidget;
+    SettingsButtonWidget *quickFilterNameWidget;
     VisualDatabaseDisplayNameFilterWidget *nameFilterWidget;
     VisualDatabaseDisplayMainTypeFilterWidget *mainTypeFilterWidget;
+    SettingsButtonWidget *quickFilterSubTypeWidget;
     VisualDatabaseDisplaySubTypeFilterWidget *subTypeFilterWidget;
+    SettingsButtonWidget *quickFilterSetWidget;
     VisualDatabaseDisplaySetFilterWidget *setFilterWidget;
     KeySignals searchKeySignals;
     AbstractTabDeckEditor *deckEditor;
@@ -88,7 +93,6 @@ private:
     QVBoxLayout *overlapCategoriesLayout;
     OverlapControlWidget *overlapControlWidget;
     CardSizeWidget *cardSizeWidget;
-    QWidget *container;
     QTimer *debounceTimer;
     QTimer *loadCardsTimer;
 


### PR DESCRIPTION
## Short roundup of the initial problem
Pro: The filters are way easier to navigate
Con: Our icon choices are ass

![image](https://github.com/user-attachments/assets/6aa4ca08-71ff-46a1-8008-69781b9a8d0e)
![image](https://github.com/user-attachments/assets/e8206882-2785-44a5-81c7-b353ec558285)

(This also exposes a new method in the QuickSettingsButtonWidget to set the icon)
