### PR TITLE
Fix intermittent segfault in VDS sort

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -211,14 +211,16 @@ void VisualDeckStorageWidget::createRootFolderWidget()
     scrollArea->setWidget(folderWidget); // this automatically destroys the old folderWidget
     scrollArea->widget()->setMaximumWidth(scrollArea->viewport()->width());
     scrollArea->widget()->adjustSize();
-    reapplySortAndFilters();
+
+    // Deck sort intermittently segfaults due to invalid DeckPreviewWidget, unless we use QTimer trick
+    QTimer::singleShot(0, this, &VisualDeckStorageWidget::reapplySortAndFilters);
 }
 
 void VisualDeckStorageWidget::updateShowFolders(bool enabled)
 {
     if (folderWidget) {
         folderWidget->updateShowFolders(enabled);
-        reapplySortAndFilters();
+        QTimer::singleShot(0, this, &VisualDeckStorageWidget::reapplySortAndFilters);
     }
 }
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -212,7 +212,9 @@ void VisualDeckStorageWidget::createRootFolderWidget()
     scrollArea->widget()->setMaximumWidth(scrollArea->viewport()->width());
     scrollArea->widget()->adjustSize();
 
-    // Deck sort intermittently segfaults due to invalid DeckPreviewWidget, unless we use QTimer trick
+    /* We have to schedule a QTimer here so that the sorting logic doesn't try to access widgets that haven't been
+     * processed by the event loop yet. Otherwise, deck sorting will intermittently segfault on some systems.
+     */
     QTimer::singleShot(0, this, &VisualDeckStorageWidget::reapplySortAndFilters);
 }
 


### PR DESCRIPTION
## Short roundup of the initial problem

Cockatrice would intermittently segfault inside the VDS sort function for me. No one else has complained about the problem, so I assume it only happens on mac.

Recently, that segfault has started happening way more frequently.

## What will change with this Pull Request?
- call `reapplySortAndFilters` inside a `QTimer::singleShot`.
  - I did some manual testing after the change and it hasn't segfaulted for me yet, so I guess that fixes it?