### PR TITLE
Implement a little "raise on enter" animation for deck preview widgets.

### DIFF
--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
@@ -288,11 +288,7 @@ void CardInfoPictureWidget::leaveEvent(QEvent *event)
     }
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void CardInfoPictureWidget::moveEvent(QMoveEvent *event)
-#else
-void CardInfoPictureWidget::moveEvent(QEvent *event)
-#endif
 {
     QWidget::moveEvent(event);
 

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
@@ -6,6 +6,7 @@
 
 #include <QTimer>
 #include <QWidget>
+#include <QPropertyAnimation>
 
 inline Q_LOGGING_CATEGORY(CardInfoPictureWidgetLog, "card_info_picture_widget");
 
@@ -17,17 +18,18 @@ class CardInfoPictureWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit CardInfoPictureWidget(QWidget *parent = nullptr, bool hoverToZoomEnabled = false);
+    explicit CardInfoPictureWidget(QWidget *parent = nullptr, bool hoverToZoomEnabled = false, bool raiseOnEnter = false);
     CardInfoPtr getInfo()
     {
         return info;
     }
     [[nodiscard]] QSize sizeHint() const override;
-    void setHoverToZoomEnabled(bool enabled);
 
 public slots:
     void setCard(CardInfoPtr card);
     void setScaleFactor(int scale); // New slot for scaling
+    void setHoverToZoomEnabled(bool enabled);
+    void setRaiseOnEnterEnabled(bool enabled);
     void updatePixmap();
 
 signals:
@@ -40,8 +42,10 @@ protected:
     void paintEvent(QPaintEvent *) override;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     void enterEvent(QEnterEvent *event) override; // Qt6 signature
+    void moveEvent(QMoveEvent *event) override;
 #else
     void enterEvent(QEvent *event) override; // Qt5 signature
+    void moveEvent(QEvent *event) override;
 #endif
     void leaveEvent(QEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
@@ -64,10 +68,14 @@ private:
     QPixmap resizedPixmap;
     bool pixmapDirty;
     bool hoverToZoomEnabled;
+    bool raiseOnEnter;
     int hoverActivateThresholdInMs = 500;
     CardInfoPictureEnlargedWidget *enlargedPixmapWidget;
     int enlargedPixmapOffset = 10;
     QTimer *hoverTimer;
+    QPropertyAnimation *animation;
+    QPoint originalPos;         // Store the original position
+    const int animationOffset = 10; // Adjust this for how much the widget moves up
 
     QMenu *createRightClickMenu();
     QMenu *createViewRelatedCardsMenu();

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
@@ -4,9 +4,9 @@
 #include "../../../../game/cards/card_database.h"
 #include "card_info_picture_enlarged_widget.h"
 
+#include <QPropertyAnimation>
 #include <QTimer>
 #include <QWidget>
-#include <QPropertyAnimation>
 
 inline Q_LOGGING_CATEGORY(CardInfoPictureWidgetLog, "card_info_picture_widget");
 
@@ -18,7 +18,9 @@ class CardInfoPictureWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit CardInfoPictureWidget(QWidget *parent = nullptr, bool hoverToZoomEnabled = false, bool raiseOnEnter = false);
+    explicit CardInfoPictureWidget(QWidget *parent = nullptr,
+                                   bool hoverToZoomEnabled = false,
+                                   bool raiseOnEnter = false);
     CardInfoPtr getInfo()
     {
         return info;
@@ -74,7 +76,7 @@ private:
     int enlargedPixmapOffset = 10;
     QTimer *hoverTimer;
     QPropertyAnimation *animation;
-    QPoint originalPos;         // Store the original position
+    QPoint originalPos;             // Store the original position
     const int animationOffset = 10; // Adjust this for how much the widget moves up
 
     QMenu *createRightClickMenu();

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
@@ -44,12 +44,11 @@ protected:
     void paintEvent(QPaintEvent *) override;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     void enterEvent(QEnterEvent *event) override; // Qt6 signature
-    void moveEvent(QMoveEvent *event) override;
 #else
     void enterEvent(QEvent *event) override; // Qt5 signature
-    void moveEvent(QEvent *event) override;
 #endif
     void leaveEvent(QEvent *event) override;
+    void moveEvent(QMoveEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
     void loadPixmap();

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
@@ -9,6 +9,7 @@
  * @brief Constructs a CardPictureWithTextOverlay widget.
  * @param parent The parent widget.
  * @param hoverToZoomEnabled If this widget will spawn a larger widget when hovered over.
+ * @param raiseOnEnter If this widget will raise slightly when entered.
  * @param textColor The color of the overlay text.
  * @param outlineColor The color of the outline around the text.
  * @param fontSize The font size of the overlay text.
@@ -18,11 +19,12 @@
  */
 CardInfoPictureWithTextOverlayWidget::CardInfoPictureWithTextOverlayWidget(QWidget *parent,
                                                                            const bool hoverToZoomEnabled,
+                                                                           const bool raiseOnEnter,
                                                                            const QColor &textColor,
                                                                            const QColor &outlineColor,
                                                                            const int fontSize,
                                                                            const Qt::Alignment alignment)
-    : CardInfoPictureWidget(parent, hoverToZoomEnabled), textColor(textColor), outlineColor(outlineColor),
+    : CardInfoPictureWidget(parent, hoverToZoomEnabled, raiseOnEnter), textColor(textColor), outlineColor(outlineColor),
       fontSize(fontSize), textAlignment(alignment)
 {
     this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.h
@@ -14,6 +14,7 @@ class CardInfoPictureWithTextOverlayWidget : public CardInfoPictureWidget
 public:
     explicit CardInfoPictureWithTextOverlayWidget(QWidget *parent = nullptr,
                                                   bool hoverToZoomEnabled = false,
+                                                  bool raiseOnEnter = false,
                                                   const QColor &textColor = Qt::white,
                                                   const QColor &outlineColor = Qt::black,
                                                   int fontSize = 12,

--- a/cockatrice/src/client/ui/widgets/cards/deck_preview_card_picture_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/deck_preview_card_picture_widget.cpp
@@ -1,5 +1,7 @@
 #include "deck_preview_card_picture_widget.h"
 
+#include "../../../../settings/cache_settings.h"
+
 #include <QApplication>
 #include <QFileInfo>
 #include <QFontMetrics>
@@ -22,15 +24,24 @@
  */
 DeckPreviewCardPictureWidget::DeckPreviewCardPictureWidget(QWidget *parent,
                                                            const bool hoverToZoomEnabled,
+                                                           const bool raiseOnEnter,
                                                            const QColor &textColor,
                                                            const QColor &outlineColor,
                                                            const int fontSize,
                                                            const Qt::Alignment alignment)
-    : CardInfoPictureWithTextOverlayWidget(parent, hoverToZoomEnabled, textColor, outlineColor, fontSize, alignment)
+    : CardInfoPictureWithTextOverlayWidget(parent,
+                                           hoverToZoomEnabled,
+                                           raiseOnEnter,
+                                           textColor,
+                                           outlineColor,
+                                           fontSize,
+                                           alignment)
 {
     singleClickTimer = new QTimer(this);
     singleClickTimer->setSingleShot(true);
     connect(singleClickTimer, &QTimer::timeout, this, [this]() { emit imageClicked(lastMouseEvent, this); });
+    connect(&SettingsCache::instance(), &SettingsCache::visualDeckStorageSelectionAnimationChanged, this,
+            &CardInfoPictureWidget::setRaiseOnEnterEnabled);
 }
 
 void DeckPreviewCardPictureWidget::mousePressEvent(QMouseEvent *event)

--- a/cockatrice/src/client/ui/widgets/cards/deck_preview_card_picture_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/deck_preview_card_picture_widget.h
@@ -14,6 +14,7 @@ class DeckPreviewCardPictureWidget final : public CardInfoPictureWithTextOverlay
 public:
     explicit DeckPreviewCardPictureWidget(QWidget *parent,
                                           bool hoverToZoomEnabled = false,
+                                          bool raiseOnEnter = false,
                                           const QColor &textColor = Qt::white,
                                           const QColor &outlineColor = Qt::black,
                                           int fontSize = 12,

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -31,7 +31,8 @@ DeckPreviewWidget::DeckPreviewWidget(QWidget *_parent,
             &VisualDeckStorageTagFilterWidget::refreshTags);
     deckLoader->loadFromFileAsync(filePath, DeckLoader::getFormatFromName(filePath), false);
 
-    bannerCardDisplayWidget = new DeckPreviewCardPictureWidget(this);
+    bannerCardDisplayWidget =
+        new DeckPreviewCardPictureWidget(this, false, visualDeckStorageWidget->deckPreviewSelectionAnimationEnabled);
 
     connect(bannerCardDisplayWidget, &DeckPreviewCardPictureWidget::imageClicked, this,
             &DeckPreviewWidget::imageClickedEvent);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -125,6 +125,10 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     tagFilterWidget = new VisualDeckStorageTagFilterWidget(this);
     updateTagsVisibility(SettingsCache::instance().getVisualDeckStorageShowTagFilter());
 
+    deckPreviewSelectionAnimationEnabled = SettingsCache::instance().getVisualDeckStorageSelectionAnimation();
+    connect(&SettingsCache::instance(), &SettingsCache::visualDeckStorageSelectionAnimationChanged, this,
+            &VisualDeckStorageWidget::updateSelectionAnimationEnabled);
+
     // deck area
     scrollArea = new QScrollArea(this);
     scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
@@ -266,4 +270,9 @@ void VisualDeckStorageWidget::updateTagsVisibility(const bool visible)
     } else {
         tagFilterWidget->setHidden(true);
     }
+}
+
+void VisualDeckStorageWidget::updateSelectionAnimationEnabled(const bool enabled)
+{
+    deckPreviewSelectionAnimationEnabled = enabled;
 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -31,6 +31,7 @@ public:
 
     CardSizeWidget *cardSizeWidget;
     VisualDeckStorageTagFilterWidget *tagFilterWidget;
+    bool deckPreviewSelectionAnimationEnabled;
 
 public slots:
     void createRootFolderWidget(); // Refresh the display of cards based on the current sorting option
@@ -39,6 +40,7 @@ public slots:
     void updateColorFilter();
     void updateSearchFilter();
     void updateTagsVisibility(bool visible);
+    void updateSelectionAnimationEnabled(bool enabled);
     void updateSortOrder();
     void resizeEvent(QResizeEvent *event) override;
     void showEvent(QShowEvent *event) override;

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -673,6 +673,11 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     connect(&visualDeckStorageInGameCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setVisualDeckStorageInGame);
 
+    visualDeckStorageSelectionAnimationCheckBox.setChecked(
+        SettingsCache::instance().getVisualDeckStorageSelectionAnimation());
+    connect(&visualDeckStorageSelectionAnimationCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setVisualDeckStorageSelectionAnimation);
+
     visualDeckStoragePromptForConversionSelector.addItem(""); // these will be set in retranslateUI
     visualDeckStoragePromptForConversionSelector.addItem("");
     visualDeckStoragePromptForConversionSelector.addItem("");
@@ -694,8 +699,9 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     auto *deckEditorGrid = new QGridLayout;
     deckEditorGrid->addWidget(&openDeckInNewTabCheckBox, 0, 0);
     deckEditorGrid->addWidget(&visualDeckStorageInGameCheckBox, 1, 0);
-    deckEditorGrid->addWidget(&visualDeckStoragePromptForConversionLabel, 2, 0);
-    deckEditorGrid->addWidget(&visualDeckStoragePromptForConversionSelector, 2, 1);
+    deckEditorGrid->addWidget(&visualDeckStorageSelectionAnimationCheckBox, 2, 0);
+    deckEditorGrid->addWidget(&visualDeckStoragePromptForConversionLabel, 3, 0);
+    deckEditorGrid->addWidget(&visualDeckStoragePromptForConversionSelector, 3, 1);
 
     deckEditorGroupBox = new QGroupBox;
     deckEditorGroupBox->setLayout(deckEditorGrid);
@@ -756,6 +762,7 @@ void UserInterfaceSettingsPage::retranslateUi()
     deckEditorGroupBox->setTitle(tr("Deck editor/storage settings"));
     openDeckInNewTabCheckBox.setText(tr("Open deck in new tab by default"));
     visualDeckStorageInGameCheckBox.setText(tr("Use visual deck storage in game lobby"));
+    visualDeckStorageSelectionAnimationCheckBox.setText(tr("Use selection animation for Visual Deck Storage"));
     visualDeckStoragePromptForConversionLabel.setText(
         tr("When adding a tag in the visual deck storage to a .txt deck:"));
     visualDeckStoragePromptForConversionSelector.setItemText(visualDeckStoragePromptForConversionIndexNone,

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -154,6 +154,7 @@ private:
     QLabel visualDeckStoragePromptForConversionLabel;
     QComboBox visualDeckStoragePromptForConversionSelector;
     QCheckBox visualDeckStorageInGameCheckBox;
+    QCheckBox visualDeckStorageSelectionAnimationCheckBox;
     QLabel rewindBufferingMsLabel;
     QSpinBox rewindBufferingMsBox;
     QGroupBox *generalGroupBox;

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -280,6 +280,8 @@ SettingsCache::SettingsCache()
         settings->value("interface/visualdeckstoragepromptforconversion", true).toBool();
     visualDeckStorageAlwaysConvert = settings->value("interface/visualdeckstoragealwaysconvert", false).toBool();
     visualDeckStorageInGame = settings->value("interface/visualdeckstorageingame", true).toBool();
+    visualDeckStorageSelectionAnimation =
+        settings->value("interface/visualdeckstorageselectionanimation", true).toBool();
     horizontalHand = settings->value("hand/horizontal", true).toBool();
     invertVerticalCoordinate = settings->value("table/invert_vertical", false).toBool();
     minPlayersForMultiColumnLayout = settings->value("interface/min_players_multicolumn", 4).toInt();
@@ -759,6 +761,13 @@ void SettingsCache::setVisualDeckStorageInGame(QT_STATE_CHANGED_T value)
     visualDeckStorageInGame = value;
     settings->setValue("interface/visualdeckstorageingame", visualDeckStorageInGame);
     emit visualDeckStorageInGameChanged(visualDeckStorageInGame);
+}
+
+void SettingsCache::setVisualDeckStorageSelectionAnimation(QT_STATE_CHANGED_T value)
+{
+    visualDeckStorageSelectionAnimation = value;
+    settings->setValue("interface/visualdeckstorageselectionanimation", visualDeckStorageSelectionAnimation);
+    emit visualDeckStorageSelectionAnimationChanged(visualDeckStorageSelectionAnimation);
 }
 
 void SettingsCache::setHorizontalHand(QT_STATE_CHANGED_T _horizontalHand)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -68,6 +68,7 @@ signals:
     void visualDeckStorageDrawUnusedColorIdentitiesChanged(bool _visible);
     void visualDeckStorageUnusedColorIdentitiesOpacityChanged(bool value);
     void visualDeckStorageInGameChanged(bool enabled);
+    void visualDeckStorageSelectionAnimationChanged(bool enabled);
     void horizontalHandChanged();
     void handJustificationChanged();
     void invertVerticalCoordinateChanged();
@@ -145,6 +146,7 @@ private:
     bool visualDeckStoragePromptForConversion;
     bool visualDeckStorageAlwaysConvert;
     bool visualDeckStorageInGame;
+    bool visualDeckStorageSelectionAnimation;
     bool horizontalHand;
     bool invertVerticalCoordinate;
     int minPlayersForMultiColumnLayout;
@@ -465,6 +467,10 @@ public:
     bool getVisualDeckStorageInGame() const
     {
         return visualDeckStorageInGame;
+    }
+    bool getVisualDeckStorageSelectionAnimation() const
+    {
+        return visualDeckStorageSelectionAnimation;
     }
     bool getHorizontalHand() const
     {
@@ -806,6 +812,7 @@ public slots:
     void setVisualDeckStoragePromptForConversion(bool _visualDeckStoragePromptForConversion);
     void setVisualDeckStorageAlwaysConvert(bool _visualDeckStorageAlwaysConvert);
     void setVisualDeckStorageInGame(QT_STATE_CHANGED_T value);
+    void setVisualDeckStorageSelectionAnimation(QT_STATE_CHANGED_T value);
     void setHorizontalHand(QT_STATE_CHANGED_T _horizontalHand);
     void setInvertVerticalCoordinate(QT_STATE_CHANGED_T _invertVerticalCoordinate);
     void setMinPlayersForMultiColumnLayout(int _minPlayersForMultiColumnLayout);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -246,6 +246,9 @@ void SettingsCache::setVisualDeckStorageAlwaysConvert(bool /* _visualDeckStorage
 void SettingsCache::setVisualDeckStorageInGame(QT_STATE_CHANGED_T /* value */)
 {
 }
+void SettingsCache::setVisualDeckStorageSelectionAnimation(QT_STATE_CHANGED_T /* value */)
+{
+}
 void SettingsCache::setHorizontalHand(QT_STATE_CHANGED_T /* _horizontalHand */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -250,6 +250,9 @@ void SettingsCache::setVisualDeckStorageAlwaysConvert(bool /* _visualDeckStorage
 void SettingsCache::setVisualDeckStorageInGame(QT_STATE_CHANGED_T /* value */)
 {
 }
+void SettingsCache::setVisualDeckStorageSelectionAnimation(QT_STATE_CHANGED_T /* value */)
+{
+}
 void SettingsCache::setHorizontalHand(QT_STATE_CHANGED_T /* _horizontalHand */)
 {
 }


### PR DESCRIPTION
## Short roundup of the initial problem
There's no visual indicator that you're "doing" something to the deck preview widgets in the visual deck storage widget.

## What will change with this Pull Request?
- A funky, fresh, beautiful, innovative, breathtaking and gorgeous new animation is added to the deck preview widgets.
- A setting is added to toggle this behavior.

## Screenshots

https://github.com/user-attachments/assets/66fe55f1-490d-4c0c-80ee-6cdeb9b12e11

