### PR TITLE
Refactor files in src/dialogs to new Qt Slot/Signal syntax

### DIFF
--- a/cockatrice/src/dialogs/dlg_connect.cpp
+++ b/cockatrice/src/dialogs/dlg_connect.cpp
@@ -34,11 +34,12 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     btnRefreshServers->setToolTip(tr("Refresh the server list with known public servers"));
     btnRefreshServers->setFixedWidth(30);
 
-    connect(hps, SIGNAL(sigPublicServersDownloadedSuccessfully()), this, SLOT(rebuildComboBoxList()));
-    connect(hps, SIGNAL(sigPublicServersDownloadedUnsuccessfully(int)), this, SLOT(rebuildComboBoxList(int)));
-    connect(btnRefreshServers, SIGNAL(released()), this, SLOT(downloadThePublicServers()));
+    connect(hps, &HandlePublicServers::sigPublicServersDownloadedSuccessfully, this, [this] { rebuildComboBoxList(); });
+    connect(hps, &HandlePublicServers::sigPublicServersDownloadedUnsuccessfully, this,
+            &DlgConnect::rebuildComboBoxList);
+    connect(btnRefreshServers, &QPushButton::released, this, &DlgConnect::downloadThePublicServers);
 
-    connect(this, SIGNAL(sigPublicServersDownloaded()), this, SLOT(rebuildComboBoxList()));
+    connect(this, &DlgConnect::sigPublicServersDownloaded, this, [this] { rebuildComboBoxList(); });
     preRebuildComboBoxList();
 
     newHostButton = new QRadioButton(tr("New Host"), this);
@@ -102,17 +103,17 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     btnForgotPassword->setIcon(QPixmap("theme:icons/forgot_password"));
     btnForgotPassword->setToolTip(tr("Reset Password"));
     btnForgotPassword->setFixedWidth(30);
-    connect(btnForgotPassword, SIGNAL(released()), this, SLOT(actForgotPassword()));
+    connect(btnForgotPassword, &QPushButton::released, this, &DlgConnect::actForgotPassword);
 
     forgotPasswordLabel = new QLabel(tr("Forgot password?"));
     forgotPasswordLabel->setBuddy(btnForgotPassword);
 
     btnConnect = new QPushButton(tr("&Connect"));
-    connect(btnConnect, SIGNAL(released()), this, SLOT(actOk()));
+    connect(btnConnect, &QPushButton::released, this, &DlgConnect::actOk);
 
     auto *buttonBox = new QDialogButtonBox(QDialogButtonBox::Cancel);
     buttonBox->addButton(btnConnect, QDialogButtonBox::AcceptRole);
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &DlgConnect::reject);
 
     newHolderLayout = new QHBoxLayout;
     newHolderLayout->addWidget(previousHosts);
@@ -171,12 +172,12 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     setFixedHeight(sizeHint().height());
     setMinimumWidth(300);
 
-    connect(previousHostButton, SIGNAL(toggled(bool)), this, SLOT(previousHostSelected(bool)));
-    connect(newHostButton, SIGNAL(toggled(bool)), this, SLOT(newHostSelected(bool)));
+    connect(previousHostButton, &QRadioButton::toggled, this, &DlgConnect::previousHostSelected);
+    connect(newHostButton, &QRadioButton::toggled, this, &DlgConnect::newHostSelected);
 
     previousHostButton->setChecked(true);
 
-    connect(previousHosts, SIGNAL(currentTextChanged(const QString &)), this, SLOT(updateDisplayInfo(const QString &)));
+    connect(previousHosts, &QComboBox::currentTextChanged, this, &DlgConnect::updateDisplayInfo);
 
     playernameEdit->setFocus();
 }

--- a/cockatrice/src/dialogs/dlg_create_game.cpp
+++ b/cockatrice/src/dialogs/dlg_create_game.cpp
@@ -117,7 +117,7 @@ void DlgCreateGame::sharedCtor()
     grid->addWidget(rememberGameSettings, 3, 0);
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok);
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &DlgCreateGame::reject);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(grid);
@@ -158,8 +158,8 @@ DlgCreateGame::DlgCreateGame(TabRoom *_room, const QMap<int, QString> &_gameType
     clearButton = new QPushButton(tr("&Clear"));
     buttonBox->addButton(QDialogButtonBox::Cancel);
     buttonBox->addButton(clearButton, QDialogButtonBox::ActionRole);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOK()));
-    connect(clearButton, SIGNAL(clicked()), this, SLOT(actReset()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgCreateGame::actOK);
+    connect(clearButton, &QPushButton::clicked, this, &DlgCreateGame::actReset);
 
     setWindowTitle(tr("Create game"));
 }
@@ -204,7 +204,7 @@ DlgCreateGame::DlgCreateGame(const ServerInfo_Game &gameInfo, const QMap<int, QS
         gameTypeCheckBox->setChecked(types.contains(gameTypeIterator.key()));
     }
 
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgCreateGame::accept);
 
     setWindowTitle(tr("Game information"));
 }
@@ -279,7 +279,7 @@ void DlgCreateGame::actOK()
         SettingsCache::instance().setGameTypes(_gameTypes);
     }
     PendingCommand *pend = room->prepareRoomCommand(cmd);
-    connect(pend, SIGNAL(finished(Response, CommandContainer, QVariant)), this, SLOT(checkResponse(Response)));
+    connect(pend, &PendingCommand::finished, this, &DlgCreateGame::checkResponse);
     room->sendRoomCommand(pend);
 
     buttonBox->setEnabled(false);

--- a/cockatrice/src/dialogs/dlg_create_token.cpp
+++ b/cockatrice/src/dialogs/dlg_create_token.cpp
@@ -36,7 +36,7 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
         nameEdit->setFocus();
     });
 
-    connect(nameEdit, SIGNAL(textChanged(const QString &)), this, SLOT(updateSearch(const QString &)));
+    connect(nameEdit, &QLineEdit::textChanged, this, &DlgCreateToken::updateSearch);
     nameLabel->setBuddy(nameEdit);
 
     colorLabel = new QLabel(tr("C&olor:"));
@@ -82,9 +82,9 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
     cardDatabaseDisplayModel->setSourceModel(cardDatabaseModel);
 
     chooseTokenFromAllRadioButton = new QRadioButton(tr("Show &all tokens"));
-    connect(chooseTokenFromAllRadioButton, SIGNAL(toggled(bool)), this, SLOT(actChooseTokenFromAll(bool)));
+    connect(chooseTokenFromAllRadioButton, &QRadioButton::toggled, this, &DlgCreateToken::actChooseTokenFromAll);
     chooseTokenFromDeckRadioButton = new QRadioButton(tr("Show tokens from this &deck"));
-    connect(chooseTokenFromDeckRadioButton, SIGNAL(toggled(bool)), this, SLOT(actChooseTokenFromDeck(bool)));
+    connect(chooseTokenFromDeckRadioButton, &QRadioButton::toggled, this, &DlgCreateToken::actChooseTokenFromDeck);
 
     QByteArray deckHeaderState = SettingsCache::instance().layouts().getDeckEditorDbHeaderState();
     chooseTokenView = new QTreeView;
@@ -104,9 +104,9 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
     chooseTokenView->header()->hideSection(1);                                         // Sets
     chooseTokenView->header()->hideSection(2);                                         // Mana Cost
     chooseTokenView->header()->setSectionResizeMode(5, QHeaderView::ResizeToContents); // Color(s)
-    connect(chooseTokenView->selectionModel(), SIGNAL(currentRowChanged(QModelIndex, QModelIndex)), this,
-            SLOT(tokenSelectionChanged(QModelIndex, QModelIndex)));
-    connect(chooseTokenView, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(actOk()));
+    connect(chooseTokenView->selectionModel(), &QItemSelectionModel::currentRowChanged, this,
+            &DlgCreateToken::tokenSelectionChanged);
+    connect(chooseTokenView, &QTreeView::doubleClicked, this, &DlgCreateToken::actOk);
 
     if (predefinedTokens.isEmpty()) {
         chooseTokenFromAllRadioButton->setChecked(true);
@@ -135,8 +135,8 @@ DlgCreateToken::DlgCreateToken(const QStringList &_predefinedTokens, QWidget *pa
     hbox->setColumnStretch(1, 1);
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(actReject()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgCreateToken::actOk);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &DlgCreateToken::actReject);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(hbox);

--- a/cockatrice/src/dialogs/dlg_edit_avatar.cpp
+++ b/cockatrice/src/dialogs/dlg_edit_avatar.cpp
@@ -22,7 +22,7 @@ DlgEditAvatar::DlgEditAvatar(QWidget *parent) : QDialog(parent), image()
     textLabel = new QLabel(tr("To change your avatar, choose a new image.\nTo remove your current avatar, confirm "
                               "without choosing a new image."));
     browseButton = new QPushButton(tr("Browse..."));
-    connect(browseButton, SIGNAL(clicked()), this, SLOT(actBrowse()));
+    connect(browseButton, &QPushButton::clicked, this, &DlgEditAvatar::actBrowse);
 
     QGridLayout *grid = new QGridLayout;
     grid->addWidget(imageLabel, 0, 0, 1, 2);
@@ -30,8 +30,8 @@ DlgEditAvatar::DlgEditAvatar(QWidget *parent) : QDialog(parent), image()
     grid->addWidget(browseButton, 1, 1);
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgEditAvatar::actOk);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &DlgEditAvatar::reject);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(grid);

--- a/cockatrice/src/dialogs/dlg_edit_password.cpp
+++ b/cockatrice/src/dialogs/dlg_edit_password.cpp
@@ -44,8 +44,8 @@ DlgEditPassword::DlgEditPassword(QWidget *parent) : QDialog(parent)
     grid->addWidget(newPasswordEdit2, 2, 1);
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgEditPassword::actOk);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &DlgEditPassword::reject);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(grid);

--- a/cockatrice/src/dialogs/dlg_edit_tokens.cpp
+++ b/cockatrice/src/dialogs/dlg_edit_tokens.cpp
@@ -40,19 +40,19 @@ DlgEditTokens::DlgEditTokens(QWidget *parent) : QDialog(parent), currentCard(nul
     colorEdit->addItem(tr("multicolor"), QChar('m'));
     colorEdit->addItem(tr("colorless"), QChar());
     colorLabel->setBuddy(colorEdit);
-    connect(colorEdit, SIGNAL(currentIndexChanged(int)), this, SLOT(colorChanged(int)));
+    connect(colorEdit, &QComboBox::currentIndexChanged, this, &DlgEditTokens::colorChanged);
 
     ptLabel = new QLabel(tr("&P/T:"));
     ptEdit = new QLineEdit;
     ptEdit->setMaxLength(MAX_NAME_LENGTH);
     ptLabel->setBuddy(ptEdit);
-    connect(ptEdit, SIGNAL(textChanged(QString)), this, SLOT(ptChanged(QString)));
+    connect(ptEdit, &QLineEdit::textChanged, this, &DlgEditTokens::ptChanged);
 
     annotationLabel = new QLabel(tr("&Annotation:"));
     annotationEdit = new QLineEdit;
     annotationEdit->setMaxLength(MAX_NAME_LENGTH);
     annotationLabel->setBuddy(annotationEdit);
-    connect(annotationEdit, SIGNAL(textChanged(QString)), this, SLOT(annotationChanged(QString)));
+    connect(annotationEdit, &QLineEdit::textChanged, this, &DlgEditTokens::annotationChanged);
 
     auto *grid = new QGridLayout;
     grid->addWidget(nameLabel, 0, 0);
@@ -87,15 +87,15 @@ DlgEditTokens::DlgEditTokens(QWidget *parent) : QDialog(parent), currentCard(nul
     chooseTokenView->header()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
     chooseTokenView->header()->setSectionResizeMode(4, QHeaderView::ResizeToContents);
 
-    connect(chooseTokenView->selectionModel(), SIGNAL(currentRowChanged(QModelIndex, QModelIndex)), this,
-            SLOT(tokenSelectionChanged(QModelIndex, QModelIndex)));
+    connect(chooseTokenView->selectionModel(), &QItemSelectionModel::currentRowChanged, this,
+            &DlgEditTokens::tokenSelectionChanged);
 
     QAction *aAddToken = new QAction(tr("Add token"), this);
     aAddToken->setIcon(QPixmap("theme:icons/increment"));
-    connect(aAddToken, SIGNAL(triggered()), this, SLOT(actAddToken()));
+    connect(aAddToken, &QAction::triggered, this, &DlgEditTokens::actAddToken);
     QAction *aRemoveToken = new QAction(tr("Remove token"), this);
     aRemoveToken->setIcon(QPixmap("theme:icons/decrement"));
-    connect(aRemoveToken, SIGNAL(triggered()), this, SLOT(actRemoveToken()));
+    connect(aRemoveToken, &QAction::triggered, this, &DlgEditTokens::actRemoveToken);
 
     auto *databaseToolBar = new QToolBar;
     databaseToolBar->addAction(aAddToken);
@@ -110,8 +110,8 @@ DlgEditTokens::DlgEditTokens(QWidget *parent) : QDialog(parent), currentCard(nul
     hbox->addWidget(tokenDataGroupBox);
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Close);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgEditTokens::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &DlgEditTokens::reject);
 
     auto *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(hbox);

--- a/cockatrice/src/dialogs/dlg_edit_tokens.cpp
+++ b/cockatrice/src/dialogs/dlg_edit_tokens.cpp
@@ -40,7 +40,7 @@ DlgEditTokens::DlgEditTokens(QWidget *parent) : QDialog(parent), currentCard(nul
     colorEdit->addItem(tr("multicolor"), QChar('m'));
     colorEdit->addItem(tr("colorless"), QChar());
     colorLabel->setBuddy(colorEdit);
-    connect(colorEdit, &QComboBox::currentIndexChanged, this, &DlgEditTokens::colorChanged);
+    connect(colorEdit, qOverload<int>(&QComboBox::currentIndexChanged), this, &DlgEditTokens::colorChanged);
 
     ptLabel = new QLabel(tr("&P/T:"));
     ptEdit = new QLineEdit;

--- a/cockatrice/src/dialogs/dlg_edit_user.cpp
+++ b/cockatrice/src/dialogs/dlg_edit_user.cpp
@@ -48,8 +48,8 @@ DlgEditUser::DlgEditUser(QWidget *parent, QString email, QString country, QStrin
     grid->addWidget(realnameEdit, 3, 1);
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgEditUser::actOk);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &DlgEditUser::reject);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(grid);

--- a/cockatrice/src/dialogs/dlg_filter_games.cpp
+++ b/cockatrice/src/dialogs/dlg_filter_games.cpp
@@ -117,7 +117,8 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
 
     showOnlyIfSpectatorsCanWatch = new QCheckBox(tr("Show games only if &spectators can watch"));
     showOnlyIfSpectatorsCanWatch->setChecked(gamesProxyModel->getShowOnlyIfSpectatorsCanWatch());
-    connect(showOnlyIfSpectatorsCanWatch, SIGNAL(toggled(bool)), this, SLOT(toggleSpectatorCheckboxEnabledness(bool)));
+    connect(showOnlyIfSpectatorsCanWatch, &QCheckBox::toggled, this,
+            &DlgFilterGames::toggleSpectatorCheckboxEnabledness);
 
     showSpectatorPasswordProtected = new QCheckBox(tr("Show spectator password p&rotected games"));
     showSpectatorPasswordProtected->setChecked(gamesProxyModel->getShowSpectatorPasswordProtected());
@@ -158,8 +159,8 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     hbox->addLayout(rightColumn);
 
     auto *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgFilterGames::actOk);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &DlgFilterGames::reject);
 
     auto *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(hbox);

--- a/cockatrice/src/dialogs/dlg_forgot_password_challenge.cpp
+++ b/cockatrice/src/dialogs/dlg_forgot_password_challenge.cpp
@@ -78,8 +78,8 @@ DlgForgotPasswordChallenge::DlgForgotPasswordChallenge(QWidget *parent) : QDialo
     grid->addWidget(emailEdit, 4, 1);
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgForgotPasswordChallenge::actOk);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &DlgForgotPasswordChallenge::reject);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(grid);

--- a/cockatrice/src/dialogs/dlg_forgot_password_request.cpp
+++ b/cockatrice/src/dialogs/dlg_forgot_password_request.cpp
@@ -55,8 +55,8 @@ DlgForgotPasswordRequest::DlgForgotPasswordRequest(QWidget *parent) : QDialog(pa
     grid->addWidget(playernameEdit, 3, 1);
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgForgotPasswordRequest::actOk);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &DlgForgotPasswordRequest::reject);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(grid);

--- a/cockatrice/src/dialogs/dlg_forgot_password_reset.cpp
+++ b/cockatrice/src/dialogs/dlg_forgot_password_reset.cpp
@@ -93,8 +93,8 @@ DlgForgotPasswordReset::DlgForgotPasswordReset(QWidget *parent) : QDialog(parent
     grid->addWidget(newpasswordverifyEdit, 6, 1);
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgForgotPasswordReset::actOk);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &DlgForgotPasswordReset::reject);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(grid);

--- a/cockatrice/src/dialogs/dlg_load_remote_deck.cpp
+++ b/cockatrice/src/dialogs/dlg_load_remote_deck.cpp
@@ -15,8 +15,8 @@ DlgLoadRemoteDeck::DlgLoadRemoteDeck(AbstractClient *_client, QWidget *parent) :
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgLoadRemoteDeck::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &DlgLoadRemoteDeck::reject);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(dirView);
@@ -28,8 +28,8 @@ DlgLoadRemoteDeck::DlgLoadRemoteDeck(AbstractClient *_client, QWidget *parent) :
     setMinimumWidth(sizeHint().width());
     resize(400, 600);
 
-    connect(dirView->selectionModel(), SIGNAL(currentChanged(const QModelIndex &, const QModelIndex &)), this,
-            SLOT(currentItemChanged(const QModelIndex &, const QModelIndex &)));
+    connect(dirView->selectionModel(), &QItemSelectionModel::currentChanged, this,
+            &DlgLoadRemoteDeck::currentItemChanged);
 }
 
 void DlgLoadRemoteDeck::currentItemChanged(const QModelIndex &current, const QModelIndex & /*previous*/)

--- a/cockatrice/src/dialogs/dlg_manage_sets.cpp
+++ b/cockatrice/src/dialogs/dlg_manage_sets.cpp
@@ -39,28 +39,28 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     aTop->setIcon(QPixmap("theme:icons/arrow_top_green"));
     aTop->setToolTip(tr("Move selected set to the top"));
     aTop->setEnabled(false);
-    connect(aTop, SIGNAL(triggered()), this, SLOT(actTop()));
+    connect(aTop, &QAction::triggered, this, &WndSets::actTop);
     setsEditToolBar->addAction(aTop);
 
     aUp = new QAction(QString(), this);
     aUp->setIcon(QPixmap("theme:icons/arrow_up_green"));
     aUp->setToolTip(tr("Move selected set up"));
     aUp->setEnabled(false);
-    connect(aUp, SIGNAL(triggered()), this, SLOT(actUp()));
+    connect(aUp, &QAction::triggered, this, &WndSets::actUp);
     setsEditToolBar->addAction(aUp);
 
     aDown = new QAction(QString(), this);
     aDown->setIcon(QPixmap("theme:icons/arrow_down_green"));
     aDown->setToolTip(tr("Move selected set down"));
     aDown->setEnabled(false);
-    connect(aDown, SIGNAL(triggered()), this, SLOT(actDown()));
+    connect(aDown, &QAction::triggered, this, &WndSets::actDown);
     setsEditToolBar->addAction(aDown);
 
     aBottom = new QAction(QString(), this);
     aBottom->setIcon(QPixmap("theme:icons/arrow_bottom_green"));
     aBottom->setToolTip(tr("Move selected set to the bottom"));
     aBottom->setEnabled(false);
-    connect(aBottom, SIGNAL(triggered()), this, SLOT(actBottom()));
+    connect(aBottom, &QAction::triggered, this, &WndSets::actBottom);
     setsEditToolBar->addAction(aBottom);
 
     // search field
@@ -74,7 +74,7 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     defaultSortButton = new QPushButton(tr("Default order"));
     defaultSortButton->setToolTip(tr("Restore original art priority order"));
 
-    connect(defaultSortButton, SIGNAL(clicked()), this, SLOT(actRestoreOriginalOrder()));
+    connect(defaultSortButton, &QPushButton::clicked, this, &WndSets::actRestoreOriginalOrder);
 
     filterBox = new QHBoxLayout;
     filterBox->addWidget(searchField);
@@ -106,7 +106,7 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     view->setColumnHidden(SetsModel::PriorityCol, true);
     view->setRootIsDecorated(false);
 
-    connect(view->header(), SIGNAL(sectionClicked(int)), this, SLOT(actSort(int)));
+    connect(view->header(), &QHeaderView::sectionClicked, this, &WndSets::actSort);
 
     // bottom buttons
     enableAllButton = new QPushButton(tr("Enable all sets"));
@@ -114,20 +114,15 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     enableSomeButton = new QPushButton(tr("Enable selected set(s)"));
     disableSomeButton = new QPushButton(tr("Disable selected set(s)"));
 
-    connect(enableAllButton, SIGNAL(clicked()), this, SLOT(actEnableAll()));
-    connect(disableAllButton, SIGNAL(clicked()), this, SLOT(actDisableAll()));
-    connect(enableSomeButton, SIGNAL(clicked()), this, SLOT(actEnableSome()));
-    connect(disableSomeButton, SIGNAL(clicked()), this, SLOT(actDisableSome()));
-    connect(view->selectionModel(), SIGNAL(selectionChanged(const QItemSelection &, const QItemSelection &)), this,
-            SLOT(actToggleButtons(const QItemSelection &, const QItemSelection &)));
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
-    connect(searchField, SIGNAL(textChanged(const QString &)), displayModel,
-            SLOT(setFilterRegularExpression(const QString &)));
-#else
-    connect(searchField, SIGNAL(textChanged(const QString &)), displayModel, SLOT(setFilterRegExp(const QString &)));
-#endif
-    connect(view->header(), SIGNAL(sortIndicatorChanged(int, Qt::SortOrder)), this, SLOT(actDisableSortButtons(int)));
-    connect(searchField, SIGNAL(textChanged(const QString &)), this, SLOT(actDisableResetButton(const QString &)));
+    connect(enableAllButton, &QPushButton::clicked, this, &WndSets::actEnableAll);
+    connect(disableAllButton, &QPushButton::clicked, this, &WndSets::actDisableAll);
+    connect(enableSomeButton, &QPushButton::clicked, this, &WndSets::actEnableSome);
+    connect(disableSomeButton, &QPushButton::clicked, this, &WndSets::actDisableSome);
+    connect(view->selectionModel(), &QItemSelectionModel::selectionChanged, this, &WndSets::actToggleButtons);
+    connect(searchField, &LineEditUnfocusable::textChanged, displayModel,
+            qOverload<const QString &>(&SetsDisplayModel::setFilterRegularExpression));
+    connect(view->header(), &QHeaderView::sortIndicatorChanged, this, &WndSets::actDisableSortButtons);
+    connect(searchField, &LineEditUnfocusable::textChanged, this, &WndSets::actDisableResetButton);
 
     labNotes = new QLabel;
     labNotes->setWordWrap(true);
@@ -158,7 +153,7 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     sortWarningButton->setText(tr("Use the current sorting as the set priority instead"));
     sortWarningButton->setToolTip(tr("Sorts the set priority using the same column"));
     sortWarningButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-    connect(sortWarningButton, SIGNAL(released()), this, SLOT(actIgnoreWarning()));
+    connect(sortWarningButton, &QPushButton::released, this, &WndSets::actIgnoreWarning);
     sortWarningLayout->addWidget(sortWarningButton, 1, 0);
     sortWarning->setLayout(sortWarningLayout);
     sortWarning->setVisible(false);
@@ -170,8 +165,8 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     connect(includeRebalancedCardsCheckBox, &QAbstractButton::toggled, this, &WndSets::includeRebalancedCardsChanged);
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(actSave()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(actRestore()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &WndSets::actSave);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &WndSets::actRestore);
 
     mainLayout = new QGridLayout;
     mainLayout->addLayout(filterBox, 0, 1, 1, 2);

--- a/cockatrice/src/dialogs/dlg_register.cpp
+++ b/cockatrice/src/dialogs/dlg_register.cpp
@@ -343,8 +343,8 @@ DlgRegister::DlgRegister(QWidget *parent) : QDialog(parent)
     grid->addWidget(realnameEdit, 10, 1);
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOk()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgRegister::actOk);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &DlgRegister::reject);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(grid);

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -74,7 +74,8 @@ GeneralSettingsPage::GeneralSettingsPage()
     advertiseTranslationPageLabel.setTextInteractionFlags(Qt::LinksAccessibleByMouse);
     advertiseTranslationPageLabel.setOpenExternalLinks(true);
 
-    connect(&languageBox, &QComboBox::currentIndexChanged, this, &GeneralSettingsPage::languageBoxChanged);
+    connect(&languageBox, qOverload<int>(&QComboBox::currentIndexChanged), this,
+            &GeneralSettingsPage::languageBoxChanged);
     connect(&startupUpdateCheckCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings,
             &SettingsCache::setCheckUpdatesOnStartup);
     connect(&updateNotificationCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings, &SettingsCache::setNotifyAboutUpdate);
@@ -194,7 +195,7 @@ GeneralSettingsPage::GeneralSettingsPage()
     GeneralSettingsPage::retranslateUi();
 
     // connect the ReleaseChannel combo box only after the entries are inserted in retranslateUi
-    connect(&updateReleaseChannelBox, &QComboBox::currentIndexChanged, &settings,
+    connect(&updateReleaseChannelBox, qOverload<int>(&QComboBox::currentIndexChanged), &settings,
             &SettingsCache::setUpdateReleaseChannelIndex);
     updateReleaseChannelBox.setCurrentIndex(settings.getUpdateReleaseChannelIndex());
 
@@ -365,7 +366,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
             themeBox.setCurrentIndex(i);
     }
 
-    connect(&themeBox, &QComboBox::currentIndexChanged, this, &AppearanceSettingsPage::themeBoxChanged);
+    connect(&themeBox, qOverload<int>(&QComboBox::currentIndexChanged), this, &AppearanceSettingsPage::themeBoxChanged);
     connect(&openThemeButton, &QPushButton::clicked, this, &AppearanceSettingsPage::openThemeLocation);
 
     auto *themeGrid = new QGridLayout;
@@ -1351,7 +1352,7 @@ SoundSettingsPage::SoundSettingsPage()
             themeBox.setCurrentIndex(i);
     }
 
-    connect(&themeBox, &QComboBox::currentIndexChanged, this, &SoundSettingsPage::themeBoxChanged);
+    connect(&themeBox, qOverload<int>(&QComboBox::currentIndexChanged), this, &SoundSettingsPage::themeBoxChanged);
     connect(&soundTestButton, &QPushButton::clicked, soundEngine, &SoundEngine::testSound);
 
     masterVolumeSlider = new QSlider(Qt::Horizontal);

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -74,13 +74,13 @@ GeneralSettingsPage::GeneralSettingsPage()
     advertiseTranslationPageLabel.setTextInteractionFlags(Qt::LinksAccessibleByMouse);
     advertiseTranslationPageLabel.setOpenExternalLinks(true);
 
-    connect(&languageBox, SIGNAL(currentIndexChanged(int)), this, SLOT(languageBoxChanged(int)));
+    connect(&languageBox, &QComboBox::currentIndexChanged, this, &GeneralSettingsPage::languageBoxChanged);
     connect(&startupUpdateCheckCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings,
             &SettingsCache::setCheckUpdatesOnStartup);
     connect(&updateNotificationCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings, &SettingsCache::setNotifyAboutUpdate);
     connect(&newVersionOracleCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings,
             &SettingsCache::setNotifyAboutNewVersion);
-    connect(&showTipsOnStartup, SIGNAL(clicked(bool)), &settings, SLOT(setShowTipsOnStartup(bool)));
+    connect(&showTipsOnStartup, &QCheckBox::clicked, &settings, &SettingsCache::setShowTipsOnStartup);
 
     auto *personalGrid = new QGridLayout;
     personalGrid->addWidget(&languageLabel, 0, 0);
@@ -99,37 +99,38 @@ GeneralSettingsPage::GeneralSettingsPage()
     deckPathEdit = new QLineEdit(settings.getDeckPath());
     deckPathEdit->setReadOnly(true);
     QPushButton *deckPathButton = new QPushButton("...");
-    connect(deckPathButton, SIGNAL(clicked()), this, SLOT(deckPathButtonClicked()));
+    connect(deckPathButton, &QPushButton::clicked, this, &GeneralSettingsPage::deckPathButtonClicked);
 
     filtersPathEdit = new QLineEdit(settings.getFiltersPath());
     filtersPathEdit->setReadOnly(true);
     QPushButton *filtersPathButton = new QPushButton("...");
-    connect(filtersPathButton, SIGNAL(clicked()), this, SLOT(filtersPathButtonClicked()));
+    connect(filtersPathButton, &QPushButton::clicked, this, &GeneralSettingsPage::filtersPathButtonClicked);
 
     replaysPathEdit = new QLineEdit(settings.getReplaysPath());
     replaysPathEdit->setReadOnly(true);
     QPushButton *replaysPathButton = new QPushButton("...");
-    connect(replaysPathButton, SIGNAL(clicked()), this, SLOT(replaysPathButtonClicked()));
+    connect(replaysPathButton, &QPushButton::clicked, this, &GeneralSettingsPage::replaysPathButtonClicked);
 
     picsPathEdit = new QLineEdit(settings.getPicsPath());
     picsPathEdit->setReadOnly(true);
     QPushButton *picsPathButton = new QPushButton("...");
-    connect(picsPathButton, SIGNAL(clicked()), this, SLOT(picsPathButtonClicked()));
+    connect(picsPathButton, &QPushButton::clicked, this, &GeneralSettingsPage::picsPathButtonClicked);
 
     cardDatabasePathEdit = new QLineEdit(settings.getCardDatabasePath());
     cardDatabasePathEdit->setReadOnly(true);
     QPushButton *cardDatabasePathButton = new QPushButton("...");
-    connect(cardDatabasePathButton, SIGNAL(clicked()), this, SLOT(cardDatabasePathButtonClicked()));
+    connect(cardDatabasePathButton, &QPushButton::clicked, this, &GeneralSettingsPage::cardDatabasePathButtonClicked);
 
     customCardDatabasePathEdit = new QLineEdit(settings.getCustomCardDatabasePath());
     customCardDatabasePathEdit->setReadOnly(true);
     QPushButton *customCardDatabasePathButton = new QPushButton("...");
-    connect(customCardDatabasePathButton, SIGNAL(clicked()), this, SLOT(customCardDatabaseButtonClicked()));
+    connect(customCardDatabasePathButton, &QPushButton::clicked, this,
+            &GeneralSettingsPage::customCardDatabaseButtonClicked);
 
     tokenDatabasePathEdit = new QLineEdit(settings.getTokenDatabasePath());
     tokenDatabasePathEdit->setReadOnly(true);
     QPushButton *tokenDatabasePathButton = new QPushButton("...");
-    connect(tokenDatabasePathButton, SIGNAL(clicked()), this, SLOT(tokenDatabasePathButtonClicked()));
+    connect(tokenDatabasePathButton, &QPushButton::clicked, this, &GeneralSettingsPage::tokenDatabasePathButtonClicked);
 
     // Required init here to avoid crashing on Portable builds
     resetAllPathsButton = new QPushButton;
@@ -151,7 +152,7 @@ GeneralSettingsPage::GeneralSettingsPage()
         customCardDatabasePathButton->setVisible(false);
         tokenDatabasePathButton->setVisible(false);
     } else {
-        connect(resetAllPathsButton, SIGNAL(clicked()), this, SLOT(resetAllPathsClicked()));
+        connect(resetAllPathsButton, &QPushButton::clicked, this, &GeneralSettingsPage::resetAllPathsClicked);
         allPathsResetLabel = new QLabel(tr("All paths have been reset"));
         allPathsResetLabel->setVisible(false);
     }
@@ -193,8 +194,8 @@ GeneralSettingsPage::GeneralSettingsPage()
     GeneralSettingsPage::retranslateUi();
 
     // connect the ReleaseChannel combo box only after the entries are inserted in retranslateUi
-    connect(&updateReleaseChannelBox, SIGNAL(currentIndexChanged(int)), &settings,
-            SLOT(setUpdateReleaseChannelIndex(int)));
+    connect(&updateReleaseChannelBox, &QComboBox::currentIndexChanged, &settings,
+            &SettingsCache::setUpdateReleaseChannelIndex);
     updateReleaseChannelBox.setCurrentIndex(settings.getUpdateReleaseChannelIndex());
 
     setLayout(mainLayout);
@@ -364,8 +365,8 @@ AppearanceSettingsPage::AppearanceSettingsPage()
             themeBox.setCurrentIndex(i);
     }
 
-    connect(&themeBox, SIGNAL(currentIndexChanged(int)), this, SLOT(themeBoxChanged(int)));
-    connect(&openThemeButton, SIGNAL(clicked()), this, SLOT(openThemeLocation()));
+    connect(&themeBox, &QComboBox::currentIndexChanged, this, &AppearanceSettingsPage::themeBoxChanged);
+    connect(&openThemeButton, &QPushButton::clicked, this, &AppearanceSettingsPage::openThemeLocation);
 
     auto *themeGrid = new QGridLayout;
     themeGrid->addWidget(&themeLabel, 0, 0);
@@ -409,8 +410,8 @@ AppearanceSettingsPage::AppearanceSettingsPage()
 
     verticalCardOverlapPercentBox.setValue(settings.getStackCardOverlapPercent());
     verticalCardOverlapPercentBox.setRange(0, 80);
-    connect(&verticalCardOverlapPercentBox, SIGNAL(valueChanged(int)), &settings,
-            SLOT(setStackCardOverlapPercent(int)));
+    connect(&verticalCardOverlapPercentBox, &QSpinBox::valueChanged, &settings,
+            &SettingsCache::setStackCardOverlapPercent);
 
     cardViewInitialRowsMaxBox.setRange(1, 999);
     cardViewInitialRowsMaxBox.setValue(SettingsCache::instance().getCardViewInitialRowsMax());
@@ -460,11 +461,11 @@ AppearanceSettingsPage::AppearanceSettingsPage()
 
     minPlayersForMultiColumnLayoutEdit.setMinimum(2);
     minPlayersForMultiColumnLayoutEdit.setValue(settings.getMinPlayersForMultiColumnLayout());
-    connect(&minPlayersForMultiColumnLayoutEdit, SIGNAL(valueChanged(int)), &settings,
-            SLOT(setMinPlayersForMultiColumnLayout(int)));
+    connect(&minPlayersForMultiColumnLayoutEdit, &QSpinBox::valueChanged, &settings,
+            &SettingsCache::setMinPlayersForMultiColumnLayout);
     minPlayersForMultiColumnLayoutLabel.setBuddy(&minPlayersForMultiColumnLayoutEdit);
 
-    connect(&maxFontSizeForCardsEdit, SIGNAL(valueChanged(int)), &settings, SLOT(setMaxFontSize(int)));
+    connect(&maxFontSizeForCardsEdit, &QSpinBox::valueChanged, &settings, &SettingsCache::setMaxFontSize);
     maxFontSizeForCardsEdit.setValue(settings.getMaxFontSize());
     maxFontSizeForCardsLabel.setBuddy(&maxFontSizeForCardsEdit);
     maxFontSizeForCardsEdit.setMinimum(9);
@@ -778,8 +779,9 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     urlLinkLabel.setTextInteractionFlags(Qt::LinksAccessibleByMouse);
     urlLinkLabel.setOpenExternalLinks(true);
 
-    connect(&clearDownloadedPicsButton, SIGNAL(clicked()), this, SLOT(clearDownloadedPicsButtonClicked()));
-    connect(&resetDownloadURLs, SIGNAL(clicked()), this, SLOT(resetDownloadedURLsButtonClicked()));
+    connect(&clearDownloadedPicsButton, &QPushButton::clicked, this,
+            &DeckEditorSettingsPage::clearDownloadedPicsButtonClicked);
+    connect(&resetDownloadURLs, &QPushButton::clicked, this, &DeckEditorSettingsPage::resetDownloadedURLsButtonClicked);
 
     auto *lpGeneralGrid = new QGridLayout;
     auto *lpSpoilerGrid = new QGridLayout;
@@ -789,11 +791,11 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     mpSpoilerSavePathLineEdit = new QLineEdit(SettingsCache::instance().getSpoilerCardDatabasePath());
     mpSpoilerSavePathLineEdit->setReadOnly(true);
     mpSpoilerPathButton = new QPushButton("...");
-    connect(mpSpoilerPathButton, SIGNAL(clicked()), this, SLOT(spoilerPathButtonClicked()));
+    connect(mpSpoilerPathButton, &QPushButton::clicked, this, &DeckEditorSettingsPage::spoilerPathButtonClicked);
 
     updateNowButton = new QPushButton;
     updateNowButton->setFixedWidth(150);
-    connect(updateNowButton, SIGNAL(clicked()), this, SLOT(updateSpoilers()));
+    connect(updateNowButton, &QPushButton::clicked, this, &DeckEditorSettingsPage::updateSpoilers);
 
     // Update the GUI depending on if the box is ticked or not
     setSpoilersEnabled(mcDownloadSpoilersCheckBox.isChecked());
@@ -803,22 +805,21 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     urlList->setAlternatingRowColors(true);
     urlList->setDragEnabled(true);
     urlList->setDragDropMode(QAbstractItemView::InternalMove);
-    connect(urlList->model(), SIGNAL(rowsMoved(const QModelIndex, int, int, const QModelIndex, int)), this,
-            SLOT(urlListChanged(const QModelIndex, int, int, const QModelIndex, int)));
+    connect(urlList->model(), &QAbstractItemModel::rowsMoved, this, &DeckEditorSettingsPage::urlListChanged);
 
     urlList->addItems(SettingsCache::instance().downloads().getAllURLs());
 
     aAdd = new QAction(this);
     aAdd->setIcon(QPixmap("theme:icons/increment"));
-    connect(aAdd, SIGNAL(triggered()), this, SLOT(actAddURL()));
+    connect(aAdd, &QAction::triggered, this, &DeckEditorSettingsPage::actAddURL);
 
     aEdit = new QAction(this);
     aEdit->setIcon(QPixmap("theme:icons/pencil"));
-    connect(aEdit, SIGNAL(triggered()), this, SLOT(actEditURL()));
+    connect(aEdit, &QAction::triggered, this, &DeckEditorSettingsPage::actEditURL);
 
     aRemove = new QAction(this);
     aRemove->setIcon(QPixmap("theme:icons/decrement"));
-    connect(aRemove, SIGNAL(triggered()), this, SLOT(actRemoveURL()));
+    connect(aRemove, &QAction::triggered, this, &DeckEditorSettingsPage::actRemoveURL);
 
     auto *urlToolBar = new QToolBar;
     urlToolBar->setOrientation(Qt::Vertical);
@@ -885,14 +886,14 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     lpSpoilerGrid->addWidget(&infoOnSpoilersLabel, 3, 0, 1, 3, Qt::AlignTop);
 
     // On a change to the checkbox, hide/un-hide the other fields
-    connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), &SettingsCache::instance(),
-            SLOT(setDownloadSpoilerStatus(bool)));
-    connect(&mcDownloadSpoilersCheckBox, SIGNAL(toggled(bool)), this, SLOT(setSpoilersEnabled(bool)));
-    connect(&pixmapCacheEdit, SIGNAL(valueChanged(int)), &SettingsCache::instance(), SLOT(setPixmapCacheSize(int)));
-    connect(&networkCacheEdit, SIGNAL(valueChanged(int)), &SettingsCache::instance(),
-            SLOT(setNetworkCacheSizeInMB(int)));
-    connect(&networkRedirectCacheTtlEdit, SIGNAL(valueChanged(int)), &SettingsCache::instance(),
-            SLOT(setNetworkRedirectCacheTtl(int)));
+    connect(&mcDownloadSpoilersCheckBox, &QCheckBox::toggled, &SettingsCache::instance(),
+            &SettingsCache::setDownloadSpoilerStatus);
+    connect(&mcDownloadSpoilersCheckBox, &QCheckBox::toggled, this, &DeckEditorSettingsPage::setSpoilersEnabled);
+    connect(&pixmapCacheEdit, &QSpinBox::valueChanged, &SettingsCache::instance(), &SettingsCache::setPixmapCacheSize);
+    connect(&networkCacheEdit, &QSpinBox::valueChanged, &SettingsCache::instance(),
+            &SettingsCache::setNetworkCacheSizeInMB);
+    connect(&networkRedirectCacheTtlEdit, &QSpinBox::valueChanged, &SettingsCache::instance(),
+            &SettingsCache::setNetworkRedirectCacheTtl);
 
     mpGeneralGroupBox = new QGroupBox;
     mpGeneralGroupBox->setLayout(lpGeneralGrid);
@@ -1014,8 +1015,8 @@ void DeckEditorSettingsPage::updateSpoilers()
 
     // Create a new SBU that will act as if the client was just reloaded
     auto *sbu = new SpoilerBackgroundUpdater();
-    connect(sbu, SIGNAL(spoilerCheckerDone()), this, SLOT(unlockSettings()));
-    connect(sbu, SIGNAL(spoilersUpdatedSuccessfully()), this, SLOT(unlockSettings()));
+    connect(sbu, &SpoilerBackgroundUpdater::spoilerCheckerDone, this, &DeckEditorSettingsPage::unlockSettings);
+    connect(sbu, &SpoilerBackgroundUpdater::spoilersUpdatedSuccessfully, this, &DeckEditorSettingsPage::unlockSettings);
 }
 
 void DeckEditorSettingsPage::unlockSettings()
@@ -1121,7 +1122,7 @@ MessagesSettingsPage::MessagesSettingsPage()
     mentionColor = new QLineEdit();
     mentionColor->setText(SettingsCache::instance().getChatMentionColor());
     updateMentionPreview();
-    connect(mentionColor, SIGNAL(textChanged(QString)), this, SLOT(updateColor(QString)));
+    connect(mentionColor, &QLineEdit::textChanged, this, &MessagesSettingsPage::updateColor);
 
     messagePopups.setChecked(SettingsCache::instance().getShowMessagePopup());
     connect(&messagePopups, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
@@ -1136,8 +1137,7 @@ MessagesSettingsPage::MessagesSettingsPage()
 
     customAlertString = new QLineEdit();
     customAlertString->setText(SettingsCache::instance().getHighlightWords());
-    connect(customAlertString, SIGNAL(textChanged(QString)), &SettingsCache::instance(),
-            SLOT(setHighlightWords(QString)));
+    connect(customAlertString, &QLineEdit::textChanged, &SettingsCache::instance(), &SettingsCache::setHighlightWords);
 
     auto *chatGrid = new QGridLayout;
     chatGrid->addWidget(&chatMentionCheckBox, 0, 0);
@@ -1156,7 +1156,7 @@ MessagesSettingsPage::MessagesSettingsPage()
     highlightColor = new QLineEdit();
     highlightColor->setText(SettingsCache::instance().getChatHighlightColor());
     updateHighlightPreview();
-    connect(highlightColor, SIGNAL(textChanged(QString)), this, SLOT(updateHighlightColor(QString)));
+    connect(highlightColor, &QLineEdit::textChanged, this, &MessagesSettingsPage::updateHighlightColor);
 
     auto *highlightNotice = new QGridLayout;
     highlightNotice->addWidget(highlightColor, 0, 2);
@@ -1175,15 +1175,15 @@ MessagesSettingsPage::MessagesSettingsPage()
 
     aAdd = new QAction(this);
     aAdd->setIcon(QPixmap("theme:icons/increment"));
-    connect(aAdd, SIGNAL(triggered()), this, SLOT(actAdd()));
+    connect(aAdd, &QAction::triggered, this, &MessagesSettingsPage::actAdd);
 
     aEdit = new QAction(this);
     aEdit->setIcon(QPixmap("theme:icons/pencil"));
-    connect(aEdit, SIGNAL(triggered()), this, SLOT(actEdit()));
+    connect(aEdit, &QAction::triggered, this, &MessagesSettingsPage::actEdit);
 
     aRemove = new QAction(this);
     aRemove->setIcon(QPixmap("theme:icons/decrement"));
-    connect(aRemove, SIGNAL(triggered()), this, SLOT(actRemove()));
+    connect(aRemove, &QAction::triggered, this, &MessagesSettingsPage::actRemove);
 
     auto *messageToolBar = new QToolBar;
     messageToolBar->setOrientation(Qt::Vertical);
@@ -1349,24 +1349,25 @@ SoundSettingsPage::SoundSettingsPage()
             themeBox.setCurrentIndex(i);
     }
 
-    connect(&themeBox, SIGNAL(currentIndexChanged(int)), this, SLOT(themeBoxChanged(int)));
-    connect(&soundTestButton, SIGNAL(clicked()), soundEngine, SLOT(testSound()));
+    connect(&themeBox, &QComboBox::currentIndexChanged, this, &SoundSettingsPage::themeBoxChanged);
+    connect(&soundTestButton, &QPushButton::clicked, soundEngine, &SoundEngine::testSound);
 
     masterVolumeSlider = new QSlider(Qt::Horizontal);
     masterVolumeSlider->setMinimum(0);
     masterVolumeSlider->setMaximum(100);
     masterVolumeSlider->setValue(SettingsCache::instance().getMasterVolume());
     masterVolumeSlider->setToolTip(QString::number(SettingsCache::instance().getMasterVolume()));
-    connect(&SettingsCache::instance(), SIGNAL(masterVolumeChanged(int)), this, SLOT(masterVolumeChanged(int)));
-    connect(masterVolumeSlider, SIGNAL(sliderReleased()), soundEngine, SLOT(testSound()));
-    connect(masterVolumeSlider, SIGNAL(valueChanged(int)), &SettingsCache::instance(), SLOT(setMasterVolume(int)));
+    connect(&SettingsCache::instance(), &SettingsCache::masterVolumeChanged, this,
+            &SoundSettingsPage::masterVolumeChanged);
+    connect(masterVolumeSlider, &QSlider::sliderReleased, soundEngine, &SoundEngine::testSound);
+    connect(masterVolumeSlider, &QSlider::valueChanged, &SettingsCache::instance(), &SettingsCache::setMasterVolume);
 
     masterVolumeSpinBox = new QSpinBox();
     masterVolumeSpinBox->setMinimum(0);
     masterVolumeSpinBox->setMaximum(100);
     masterVolumeSpinBox->setValue(SettingsCache::instance().getMasterVolume());
-    connect(masterVolumeSlider, SIGNAL(valueChanged(int)), masterVolumeSpinBox, SLOT(setValue(int)));
-    connect(masterVolumeSpinBox, SIGNAL(valueChanged(int)), masterVolumeSlider, SLOT(setValue(int)));
+    connect(masterVolumeSlider, &QSlider::valueChanged, masterVolumeSpinBox, &QSpinBox::setValue);
+    connect(masterVolumeSpinBox, &QSpinBox::valueChanged, masterVolumeSlider, &QSlider::setValue);
 
     auto *soundGrid = new QGridLayout;
     soundGrid->addWidget(&soundEnabledCheckBox, 0, 0, 1, 3);
@@ -1476,8 +1477,8 @@ ShortcutSettingsPage::ShortcutSettingsPage()
 
     setLayout(_mainLayout);
 
-    connect(btnResetAll, SIGNAL(clicked()), this, SLOT(resetShortcuts()));
-    connect(btnClearAll, SIGNAL(clicked()), this, SLOT(clearShortcuts()));
+    connect(btnResetAll, &QPushButton::clicked, this, &ShortcutSettingsPage::resetShortcuts);
+    connect(btnClearAll, &QPushButton::clicked, this, &ShortcutSettingsPage::clearShortcuts);
 
     connect(shortcutsTable, &ShortcutTreeView::currentItemChanged, this, &ShortcutSettingsPage::currentItemChanged);
 
@@ -1548,7 +1549,7 @@ DlgSettings::DlgSettings(QWidget *parent) : QDialog(parent)
     auto rec = QGuiApplication::primaryScreen()->availableGeometry();
     this->setMinimumSize(qMin(700, rec.width()), qMin(700, rec.height()));
 
-    connect(&SettingsCache::instance(), SIGNAL(langChanged()), this, SLOT(updateLanguage()));
+    connect(&SettingsCache::instance(), &SettingsCache::langChanged, this, &DlgSettings::updateLanguage);
 
     contentsWidget = new QListWidget;
     contentsWidget->setViewMode(QListView::IconMode);
@@ -1575,7 +1576,7 @@ DlgSettings::DlgSettings(QWidget *parent) : QDialog(parent)
     vboxLayout->addWidget(pagesWidget);
 
     auto *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(close()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgSettings::close);
 
     auto *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(vboxLayout);
@@ -1626,8 +1627,7 @@ void DlgSettings::createIcons()
     shortcutsButton->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
     shortcutsButton->setIcon(QPixmap("theme:config/shorcuts"));
 
-    connect(contentsWidget, SIGNAL(currentItemChanged(QListWidgetItem *, QListWidgetItem *)), this,
-            SLOT(changePage(QListWidgetItem *, QListWidgetItem *)));
+    connect(contentsWidget, &QListWidget::currentItemChanged, this, &DlgSettings::changePage);
 }
 
 void DlgSettings::changePage(QListWidgetItem *current, QListWidgetItem *previous)

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -410,7 +410,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
 
     verticalCardOverlapPercentBox.setValue(settings.getStackCardOverlapPercent());
     verticalCardOverlapPercentBox.setRange(0, 80);
-    connect(&verticalCardOverlapPercentBox, &QSpinBox::valueChanged, &settings,
+    connect(&verticalCardOverlapPercentBox, qOverload<int>(&QSpinBox::valueChanged), &settings,
             &SettingsCache::setStackCardOverlapPercent);
 
     cardViewInitialRowsMaxBox.setRange(1, 999);
@@ -461,11 +461,12 @@ AppearanceSettingsPage::AppearanceSettingsPage()
 
     minPlayersForMultiColumnLayoutEdit.setMinimum(2);
     minPlayersForMultiColumnLayoutEdit.setValue(settings.getMinPlayersForMultiColumnLayout());
-    connect(&minPlayersForMultiColumnLayoutEdit, &QSpinBox::valueChanged, &settings,
+    connect(&minPlayersForMultiColumnLayoutEdit, qOverload<int>(&QSpinBox::valueChanged), &settings,
             &SettingsCache::setMinPlayersForMultiColumnLayout);
     minPlayersForMultiColumnLayoutLabel.setBuddy(&minPlayersForMultiColumnLayoutEdit);
 
-    connect(&maxFontSizeForCardsEdit, &QSpinBox::valueChanged, &settings, &SettingsCache::setMaxFontSize);
+    connect(&maxFontSizeForCardsEdit, qOverload<int>(&QSpinBox::valueChanged), &settings,
+            &SettingsCache::setMaxFontSize);
     maxFontSizeForCardsEdit.setValue(settings.getMaxFontSize());
     maxFontSizeForCardsLabel.setBuddy(&maxFontSizeForCardsEdit);
     maxFontSizeForCardsEdit.setMinimum(9);
@@ -889,10 +890,11 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     connect(&mcDownloadSpoilersCheckBox, &QCheckBox::toggled, &SettingsCache::instance(),
             &SettingsCache::setDownloadSpoilerStatus);
     connect(&mcDownloadSpoilersCheckBox, &QCheckBox::toggled, this, &DeckEditorSettingsPage::setSpoilersEnabled);
-    connect(&pixmapCacheEdit, &QSpinBox::valueChanged, &SettingsCache::instance(), &SettingsCache::setPixmapCacheSize);
-    connect(&networkCacheEdit, &QSpinBox::valueChanged, &SettingsCache::instance(),
+    connect(&pixmapCacheEdit, qOverload<int>(&QSpinBox::valueChanged), &SettingsCache::instance(),
+            &SettingsCache::setPixmapCacheSize);
+    connect(&networkCacheEdit, qOverload<int>(&QSpinBox::valueChanged), &SettingsCache::instance(),
             &SettingsCache::setNetworkCacheSizeInMB);
-    connect(&networkRedirectCacheTtlEdit, &QSpinBox::valueChanged, &SettingsCache::instance(),
+    connect(&networkRedirectCacheTtlEdit, qOverload<int>(&QSpinBox::valueChanged), &SettingsCache::instance(),
             &SettingsCache::setNetworkRedirectCacheTtl);
 
     mpGeneralGroupBox = new QGroupBox;
@@ -1367,7 +1369,7 @@ SoundSettingsPage::SoundSettingsPage()
     masterVolumeSpinBox->setMaximum(100);
     masterVolumeSpinBox->setValue(SettingsCache::instance().getMasterVolume());
     connect(masterVolumeSlider, &QSlider::valueChanged, masterVolumeSpinBox, &QSpinBox::setValue);
-    connect(masterVolumeSpinBox, &QSpinBox::valueChanged, masterVolumeSlider, &QSlider::setValue);
+    connect(masterVolumeSpinBox, qOverload<int>(&QSpinBox::valueChanged), masterVolumeSlider, &QSlider::setValue);
 
     auto *soundGrid = new QGridLayout;
     soundGrid->addWidget(&soundEnabledCheckBox, 0, 0, 1, 3);

--- a/cockatrice/src/dialogs/dlg_tip_of_the_day.cpp
+++ b/cockatrice/src/dialogs/dlg_tip_of_the_day.cpp
@@ -53,7 +53,7 @@ DlgTipOfTheDay::DlgTipOfTheDay(QWidget *parent) : QDialog(parent)
         }
     }
 
-    connect(this, SIGNAL(newTipRequested(int)), this, SLOT(updateTip(int)));
+    connect(this, &DlgTipOfTheDay::newTipRequested, this, &DlgTipOfTheDay::updateTip);
     newTipRequested(currentTip);
 
     content = new QVBoxLayout;
@@ -69,14 +69,14 @@ DlgTipOfTheDay::DlgTipOfTheDay(QWidget *parent) : QDialog(parent)
     buttonBox->addButton(nextButton, QDialogButtonBox::ActionRole);
     buttonBox->addButton(QDialogButtonBox::Ok);
     buttonBox->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(nextButton, SIGNAL(clicked()), this, SLOT(nextClicked()));
-    connect(previousButton, SIGNAL(clicked()), this, SLOT(previousClicked()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgTipOfTheDay::accept);
+    connect(nextButton, &QPushButton::clicked, this, &DlgTipOfTheDay::nextClicked);
+    connect(previousButton, &QPushButton::clicked, this, &DlgTipOfTheDay::previousClicked);
 
     showTipsOnStartupCheck = new QCheckBox("Show tips on startup");
     showTipsOnStartupCheck->setChecked(SettingsCache::instance().getShowTipsOnStartup());
-    connect(showTipsOnStartupCheck, SIGNAL(clicked(bool)), &SettingsCache::instance(),
-            SLOT(setShowTipsOnStartup(bool)));
+    connect(showTipsOnStartupCheck, &QCheckBox::clicked, &SettingsCache::instance(),
+            &SettingsCache::setShowTipsOnStartup);
     buttonBar = new QHBoxLayout();
     buttonBar->addWidget(showTipsOnStartupCheck);
     buttonBar->addWidget(tipNumber);

--- a/cockatrice/src/dialogs/dlg_update.cpp
+++ b/cockatrice/src/dialogs/dlg_update.cpp
@@ -42,6 +42,7 @@ DlgUpdate::DlgUpdate(QWidget *parent) : QDialog(parent)
     buttonBox->addButton(ok, QDialogButtonBox::AcceptRole);
 
     connect(gotoDownload, &QPushButton::clicked, this, &DlgUpdate::gotoDownloadPage);
+    // TODO: make reinstall button actually do something when clicked
     // connect(manualDownload, &QPushButton::clicked, this, &DlgUpdate::downloadUpdate);
     connect(stopDownload, &QPushButton::clicked, this, &DlgUpdate::cancelDownload);
     connect(ok, &QPushButton::clicked, this, &DlgUpdate::closeDialog);

--- a/cockatrice/src/dialogs/dlg_update.cpp
+++ b/cockatrice/src/dialogs/dlg_update.cpp
@@ -41,10 +41,10 @@ DlgUpdate::DlgUpdate(QWidget *parent) : QDialog(parent)
     enableUpdateButton(false);             // Unless we know there's an update available, you can't install
     buttonBox->addButton(ok, QDialogButtonBox::AcceptRole);
 
-    connect(gotoDownload, SIGNAL(clicked()), this, SLOT(gotoDownloadPage()));
-    connect(manualDownload, SIGNAL(clicked()), this, SLOT(downloadUpdate()));
-    connect(stopDownload, SIGNAL(clicked()), this, SLOT(cancelDownload()));
-    connect(ok, SIGNAL(clicked()), this, SLOT(closeDialog()));
+    connect(gotoDownload, &QPushButton::clicked, this, &DlgUpdate::gotoDownloadPage);
+    // connect(manualDownload, &QPushButton::clicked, this, &DlgUpdate::downloadUpdate);
+    connect(stopDownload, &QPushButton::clicked, this, &DlgUpdate::cancelDownload);
+    connect(ok, &QPushButton::clicked, this, &DlgUpdate::closeDialog);
 
     auto *parentLayout = new QVBoxLayout(this);
     parentLayout->addWidget(descriptionLabel);
@@ -68,9 +68,9 @@ DlgUpdate::DlgUpdate(QWidget *parent) : QDialog(parent)
 
     // Initialize the checker and downloader class
     uDownloader = new UpdateDownloader(this);
-    connect(uDownloader, SIGNAL(downloadSuccessful(QUrl)), this, SLOT(downloadSuccessful(QUrl)));
-    connect(uDownloader, SIGNAL(progressMade(qint64, qint64)), this, SLOT(downloadProgressMade(qint64, qint64)));
-    connect(uDownloader, SIGNAL(error(QString)), this, SLOT(downloadError(QString)));
+    connect(uDownloader, &UpdateDownloader::downloadSuccessful, this, &DlgUpdate::downloadSuccessful);
+    connect(uDownloader, &UpdateDownloader::progressMade, this, &DlgUpdate::downloadProgressMade);
+    connect(uDownloader, &UpdateDownloader::error, this, &DlgUpdate::downloadError);
 
     // Check for updates
     beginUpdateCheck();
@@ -108,9 +108,8 @@ void DlgUpdate::beginUpdateCheck()
     setLabel(tr("Checking for updates..."));
 
     auto checker = new ClientUpdateChecker(this);
-    connect(checker, SIGNAL(finishedCheck(bool, bool, Release *)), this,
-            SLOT(finishedUpdateCheck(bool, bool, Release *)));
-    connect(checker, SIGNAL(error(QString)), this, SLOT(updateCheckError(QString)));
+    connect(checker, &ClientUpdateChecker::finishedCheck, this, &DlgUpdate::finishedUpdateCheck);
+    connect(checker, &ClientUpdateChecker::error, this, &DlgUpdate::updateCheckError);
     checker->check();
 }
 

--- a/cockatrice/src/dialogs/dlg_view_log.cpp
+++ b/cockatrice/src/dialogs/dlg_view_log.cpp
@@ -18,7 +18,7 @@ DlgViewLog::DlgViewLog(QWidget *parent) : QDialog(parent)
     coClearLog = new QCheckBox;
     coClearLog->setText(tr("Clear log when closing"));
     coClearLog->setChecked(SettingsCache::instance().servers().getClearDebugLogStatus(false));
-    connect(coClearLog, SIGNAL(toggled(bool)), this, SLOT(actCheckBoxChanged(bool)));
+    connect(coClearLog, &QCheckBox::toggled, this, &DlgViewLog::actCheckBoxChanged);
     mainLayout->addWidget(coClearLog);
 
     setLayout(mainLayout);
@@ -27,7 +27,7 @@ DlgViewLog::DlgViewLog(QWidget *parent) : QDialog(parent)
     resize(800, 500);
 
     loadInitialLogBuffer();
-    connect(&Logger::getInstance(), SIGNAL(logEntryAdded(QString)), this, SLOT(logEntryAdded(QString)));
+    connect(&Logger::getInstance(), &Logger::logEntryAdded, this, &DlgViewLog::logEntryAdded);
 }
 
 void DlgViewLog::actCheckBoxChanged(bool abNewValue)


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5432

## What will change with this Pull Request?
- Update all usages of slot/signal in `src/server` to new syntax
- Put a TODO comment on `DlgUpdate`'s reinstall button connection, since the previous connection didn't actually do anything
