### PR TITLE
VDS performance fixes

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -231,12 +231,8 @@ void DeckPreviewWidget::updateBannerCardComboBox()
 
     int row = 0;
     for (const auto &pair : pairList) {
-        QVariantMap dataMap;
-        dataMap["name"] = pair.first;
-        dataMap["uuid"] = pair.second;
-
         QStandardItem *item = new QStandardItem(pair.first);
-        item->setData(dataMap, Qt::UserRole);
+        item->setData(QVariant::fromValue(pair), Qt::UserRole);
         model->setItem(row++, 0, item);
     }
 
@@ -264,11 +260,11 @@ void DeckPreviewWidget::updateBannerCardComboBox()
 
 void DeckPreviewWidget::setBannerCard(int /* changedIndex */)
 {
-    QVariantMap itemData = bannerCardComboBox->itemData(bannerCardComboBox->currentIndex()).toMap();
-    deckLoader->setBannerCard(QPair<QString, QString>(itemData["name"].toString(), itemData["uuid"].toString()));
+    QVariant itemData = bannerCardComboBox->itemData(bannerCardComboBox->currentIndex());
+    deckLoader->setBannerCard(QPair<QString, QString>(bannerCardComboBox->currentText(), itemData.toString()));
     deckLoader->saveToFile(filePath, DeckLoader::getFormatFromName(filePath));
     bannerCardDisplayWidget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-        itemData["name"].toString(), itemData["uuid"].toString()));
+        bannerCardComboBox->currentText(), itemData.toString()));
 }
 
 void DeckPreviewWidget::imageClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance)


### PR DESCRIPTION
## Short roundup of the initial problem
Users are complaining that VDS takes too long to load, especially on weaker machines with a lot of decks.

## What will change with this Pull Request?
- Block updates on banner card combo box (little effect but doesn't hurt)
- don't validate cardInfo (i.e. look up a card we already stored in the decklist AGAIN in the card db to ensure it remains valid. If it's in the decklist, it's probably a valid card).
- use ItemModel instead of looped addItem (also relatively little impact)

## Screenshots:
Before:

![image](https://github.com/user-attachments/assets/7e64bf3c-fa25-4ca9-a4be-891d61f6a885)

After: (Refresh tags now taking up the most execution time)

![image](https://github.com/user-attachments/assets/131fc259-c694-4cc6-bfd8-c6639b8005a8)

Further optimized: (All refresh tags calls removed)

![image](https://github.com/user-attachments/assets/fee810d6-e180-4e05-9ad8-31b9a64bd088)
