### PR TITLE
[EDHRec] Display name above card, add bars for inclusion and synergy instead of coloring the whole label, card size slider

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -24,7 +24,9 @@ set(cockatrice_SOURCES
     src/client/tabs/api/edhrec/display/commander/edhrec_commander_api_response_navigation_widget.cpp
     src/client/tabs/api/edhrec/display/card_prices/edhrec_api_response_card_prices_display_widget.cpp
     src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.cpp
+    src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_inclusion_display_widget.cpp
     src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_list_display_widget.cpp
+    src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_synergy_display_widget.cpp
     src/client/tabs/api/edhrec/display/commander/edhrec_api_response_commander_details_display_widget.cpp
     src/client/tabs/api/edhrec/display/top_cards/edhrec_top_cards_api_response_display_widget.cpp
     src/client/tabs/api/edhrec/display/top_commander/edhrec_top_commanders_api_response_display_widget.cpp
@@ -99,6 +101,7 @@ set(cockatrice_SOURCES
     src/client/ui/widgets/general/display/dynamic_font_size_label.cpp
     src/client/ui/widgets/general/display/dynamic_font_size_push_button.cpp
     src/client/ui/widgets/general/display/labeled_input.cpp
+    src/client/ui/widgets/general/display/percent_bar_widget.cpp
     src/client/ui/widgets/general/display/shadow_background_label.cpp
     src/client/ui/widgets/general/layout_containers/flow_widget.cpp
     src/client/ui/widgets/general/layout_containers/overlap_control_widget.cpp

--- a/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.cpp
+++ b/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.cpp
@@ -14,34 +14,18 @@ EdhrecApiResponseCardDetailsDisplayWidget::EdhrecApiResponseCardDetailsDisplayWi
     cardPictureWidget = new CardInfoPictureWidget(this);
     cardPictureWidget->setCard(CardDatabaseManager::getInstance()->guessCard(toDisplay.sanitized));
 
-    label = new QLabel(this);
-    label->setText(toDisplay.name + "\n" + toDisplay.label);
-    label->setAlignment(Qt::AlignHCenter);
+    nameLabel = new QLabel(this);
+    nameLabel->setText(toDisplay.name);
+    nameLabel->setAlignment(Qt::AlignHCenter);
 
-    int inclusionRate = 0;
-    // Set label color based on inclusion rate
-    if (toDisplay.potentialDecks != 0) {
-        inclusionRate = (toDisplay.numDecks * 100) / toDisplay.potentialDecks;
-    }
+    inclusionDisplayWidget = new EdhrecApiResponseCardInclusionDisplayWidget(this, toDisplay);
 
-    QColor labelColor;
-    if (inclusionRate <= 30) {
-        labelColor = QColor(255, 0, 0); // Red
-    } else if (inclusionRate <= 60) {
-        int red = 255 - ((inclusionRate - 30) * 2);
-        int green = (inclusionRate - 30) * 4; // Adjust green to make the transition smoother
-        labelColor = QColor(red, green, 0);   // purple-ish
-    } else if (inclusionRate <= 90) {
-        int green = (inclusionRate - 60) * 5; // Increase green
-        labelColor = QColor(100, green, 100); // Green shades
-    } else {
-        labelColor = QColor(100, 200, 100); // Dark Green
-    }
+    synergyDisplayWidget = new EdhrecApiResponseCardSynergyDisplayWidget(this, toDisplay);
 
-    label->setStyleSheet(QString("color: %1").arg(labelColor.name()));
-
+    layout->addWidget(nameLabel);
     layout->addWidget(cardPictureWidget);
-    layout->addWidget(label);
+    layout->addWidget(inclusionDisplayWidget);
+    layout->addWidget(synergyDisplayWidget);
 
     QWidget *currentParent = parentWidget();
     TabEdhRecMain *parentTab = nullptr;

--- a/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.cpp
+++ b/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.cpp
@@ -38,8 +38,11 @@ EdhrecApiResponseCardDetailsDisplayWidget::EdhrecApiResponseCardDetailsDisplayWi
     }
 
     if (parentTab) {
+        cardPictureWidget->setScaleFactor(parentTab->getCardSizeSlider()->getSlider()->value());
         connect(cardPictureWidget, &CardInfoPictureWidget::cardClicked, this,
                 &EdhrecApiResponseCardDetailsDisplayWidget::actRequestPageNavigation);
+        connect(parentTab->getCardSizeSlider()->getSlider(), &QSlider::valueChanged, cardPictureWidget,
+                &CardInfoPictureWidget::setScaleFactor);
         connect(this, &EdhrecApiResponseCardDetailsDisplayWidget::requestUrl, parentTab,
                 &TabEdhRecMain::actNavigatePage);
     }

--- a/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.h
+++ b/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.h
@@ -3,6 +3,8 @@
 
 #include "../../../../../ui/widgets/cards/card_info_picture_widget.h"
 #include "../../api_response/cards/edhrec_api_response_card_details.h"
+#include "edhrec_api_response_card_inclusion_display_widget.h"
+#include "edhrec_api_response_card_synergy_display_widget.h"
 
 #include <QHBoxLayout>
 #include <QLabel>
@@ -22,7 +24,9 @@ private:
     EdhrecApiResponseCardDetails toDisplay;
     QVBoxLayout *layout;
     CardInfoPictureWidget *cardPictureWidget;
-    QLabel *label;
+    QLabel *nameLabel;
+    EdhrecApiResponseCardInclusionDisplayWidget *inclusionDisplayWidget;
+    EdhrecApiResponseCardSynergyDisplayWidget *synergyDisplayWidget;
 };
 
 #endif // EDHREC_COMMANDER_API_RESPONSE_CARD_DETAILS_DISPLAY_WIDGET_H

--- a/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_inclusion_display_widget.cpp
+++ b/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_inclusion_display_widget.cpp
@@ -1,0 +1,34 @@
+#include "edhrec_api_response_card_inclusion_display_widget.h"
+
+EdhrecApiResponseCardInclusionDisplayWidget::EdhrecApiResponseCardInclusionDisplayWidget(
+    QWidget *parent,
+    const EdhrecApiResponseCardDetails &_toDisplay)
+    : QWidget(parent), toDisplay(_toDisplay)
+{
+    layout = new QVBoxLayout(this);
+    setLayout(layout);
+
+    amountLabel = new QLabel(this);
+    amountLabel->setAlignment(Qt::AlignCenter);
+    inclusionLabel = new QLabel(this);
+    inclusionLabel->setAlignment(Qt::AlignCenter);
+    percentBarWidget = new PercentBarWidget(this, toDisplay.inclusion / (toDisplay.potentialDecks / 100.0));
+
+    if (toDisplay.inclusion != 0 && toDisplay.potentialDecks != 0) {
+        layout->addWidget(amountLabel);
+        layout->addWidget(inclusionLabel);
+        layout->addWidget(percentBarWidget);
+    } else {
+        hide();
+    }
+
+    retranslateUi();
+}
+
+void EdhrecApiResponseCardInclusionDisplayWidget::retranslateUi()
+{
+    amountLabel->setText(tr("In %1 decks").arg(QString::number(toDisplay.inclusion)));
+    inclusionLabel->setText(tr("%1% of %2 decks")
+                                .arg(QString::number(toDisplay.inclusion / (toDisplay.potentialDecks / 100.0), 'f', 2),
+                                     QString::number(toDisplay.potentialDecks)));
+}

--- a/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_inclusion_display_widget.cpp
+++ b/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_inclusion_display_widget.cpp
@@ -8,6 +8,8 @@ EdhrecApiResponseCardInclusionDisplayWidget::EdhrecApiResponseCardInclusionDispl
     layout = new QVBoxLayout(this);
     setLayout(layout);
 
+    commanderLabel = new QLabel(this);
+    commanderLabel->setAlignment(Qt::AlignCenter);
     amountLabel = new QLabel(this);
     amountLabel->setAlignment(Qt::AlignCenter);
     inclusionLabel = new QLabel(this);
@@ -18,8 +20,12 @@ EdhrecApiResponseCardInclusionDisplayWidget::EdhrecApiResponseCardInclusionDispl
         layout->addWidget(amountLabel);
         layout->addWidget(inclusionLabel);
         layout->addWidget(percentBarWidget);
+        commanderLabel->hide();
     } else {
-        hide();
+        amountLabel->hide();
+        inclusionLabel->hide();
+        percentBarWidget->hide();
+        layout->addWidget(commanderLabel);
     }
 
     retranslateUi();
@@ -27,6 +33,7 @@ EdhrecApiResponseCardInclusionDisplayWidget::EdhrecApiResponseCardInclusionDispl
 
 void EdhrecApiResponseCardInclusionDisplayWidget::retranslateUi()
 {
+    commanderLabel->setText(toDisplay.label);
     amountLabel->setText(tr("In %1 decks").arg(QString::number(toDisplay.inclusion)));
     inclusionLabel->setText(tr("%1% of %2 decks")
                                 .arg(QString::number(toDisplay.inclusion / (toDisplay.potentialDecks / 100.0), 'f', 2),

--- a/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_inclusion_display_widget.h
+++ b/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_inclusion_display_widget.h
@@ -18,6 +18,7 @@ public:
 private:
     QVBoxLayout *layout;
     EdhrecApiResponseCardDetails toDisplay;
+    QLabel *commanderLabel;
     QLabel *amountLabel;
     QLabel *inclusionLabel;
     PercentBarWidget *percentBarWidget;

--- a/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_inclusion_display_widget.h
+++ b/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_inclusion_display_widget.h
@@ -1,0 +1,26 @@
+#ifndef EDHREC_API_RESPONSE_CARD_INCLUSION_DISPLAY_WIDGET_H
+#define EDHREC_API_RESPONSE_CARD_INCLUSION_DISPLAY_WIDGET_H
+
+#include "../../../../../ui/widgets/general/display/percent_bar_widget.h"
+#include "../../api_response/cards/edhrec_api_response_card_details.h"
+
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QWidget>
+
+class EdhrecApiResponseCardInclusionDisplayWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    EdhrecApiResponseCardInclusionDisplayWidget(QWidget *parent, const EdhrecApiResponseCardDetails &_toDisplay);
+    void retranslateUi();
+
+private:
+    QVBoxLayout *layout;
+    EdhrecApiResponseCardDetails toDisplay;
+    QLabel *amountLabel;
+    QLabel *inclusionLabel;
+    PercentBarWidget *percentBarWidget;
+};
+
+#endif // EDHREC_API_RESPONSE_CARD_INCLUSION_DISPLAY_WIDGET_H

--- a/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_synergy_display_widget.cpp
+++ b/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_synergy_display_widget.cpp
@@ -1,0 +1,28 @@
+#include "edhrec_api_response_card_synergy_display_widget.h"
+
+EdhrecApiResponseCardSynergyDisplayWidget::EdhrecApiResponseCardSynergyDisplayWidget(
+    QWidget *parent,
+    const EdhrecApiResponseCardDetails &_toDisplay)
+    : QWidget(parent), toDisplay(_toDisplay)
+{
+    layout = new QVBoxLayout(this);
+    setLayout(layout);
+
+    label = new QLabel(this);
+    label->setAlignment(Qt::AlignCenter);
+    percentBarWidget = new PercentBarWidget(this, toDisplay.synergy * 100.0);
+
+    if (toDisplay.synergy != 0) {
+        layout->addWidget(label);
+        layout->addWidget(percentBarWidget);
+    } else {
+        hide();
+    }
+
+    retranslateUi();
+}
+
+void EdhrecApiResponseCardSynergyDisplayWidget::retranslateUi()
+{
+    label->setText(tr("%1% Synergy").arg(QString::number(toDisplay.synergy * 100.0, 'f', 1)));
+}

--- a/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_synergy_display_widget.h
+++ b/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_synergy_display_widget.h
@@ -1,0 +1,25 @@
+#ifndef EDHREC_API_RESPONSE_CARD_SYNERGY_DISPLAY_WIDGET_H
+#define EDHREC_API_RESPONSE_CARD_SYNERGY_DISPLAY_WIDGET_H
+
+#include "../../../../../ui/widgets/general/display/percent_bar_widget.h"
+#include "../../api_response/cards/edhrec_api_response_card_details.h"
+
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QWidget>
+
+class EdhrecApiResponseCardSynergyDisplayWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    EdhrecApiResponseCardSynergyDisplayWidget(QWidget *parent, const EdhrecApiResponseCardDetails &_toDisplay);
+    void retranslateUi();
+
+private:
+    QVBoxLayout *layout;
+    EdhrecApiResponseCardDetails toDisplay;
+    QLabel *label;
+    PercentBarWidget *percentBarWidget;
+};
+
+#endif // EDHREC_API_RESPONSE_CARD_SYNERGY_DISPLAY_WIDGET_H

--- a/cockatrice/src/client/tabs/api/edhrec/display/commander/edhrec_api_response_commander_details_display_widget.cpp
+++ b/cockatrice/src/client/tabs/api/edhrec/display/commander/edhrec_api_response_commander_details_display_widget.cpp
@@ -2,6 +2,7 @@
 
 #include "../../../../../../game/cards/card_database_manager.h"
 #include "../../../../../ui/widgets/cards/card_info_picture_widget.h"
+#include "../../tab_edhrec_main.h"
 #include "../card_prices/edhrec_api_response_card_prices_display_widget.h"
 
 EdhrecCommanderResponseCommanderDetailsDisplayWidget::EdhrecCommanderResponseCommanderDetailsDisplayWidget(
@@ -15,6 +16,22 @@ EdhrecCommanderResponseCommanderDetailsDisplayWidget::EdhrecCommanderResponseCom
 
     commanderPicture = new CardInfoPictureWidget(this);
     commanderPicture->setCard(CardDatabaseManager::getInstance()->getCard(commanderDetails.getName()));
+
+    QWidget *currentParent = parentWidget();
+    TabEdhRecMain *parentTab = nullptr;
+
+    while (currentParent) {
+        if ((parentTab = qobject_cast<TabEdhRecMain *>(currentParent))) {
+            break;
+        }
+        currentParent = currentParent->parentWidget();
+    }
+
+    if (parentTab) {
+        connect(parentTab->getCardSizeSlider()->getSlider(), &QSlider::valueChanged, commanderPicture,
+                &CardInfoPictureWidget::setScaleFactor);
+        commanderPicture->setScaleFactor(parentTab->getCardSizeSlider()->getSlider()->value());
+    }
 
     commanderDetails.debugPrint();
 

--- a/cockatrice/src/client/tabs/api/edhrec/tab_edhrec_main.cpp
+++ b/cockatrice/src/client/tabs/api/edhrec/tab_edhrec_main.cpp
@@ -94,11 +94,18 @@ TabEdhRecMain::TabEdhRecMain(TabSupervisor *_tabSupervisor) : Tab(_tabSupervisor
     searchPushButton = new QPushButton(navigationContainer);
     connect(searchPushButton, &QPushButton::clicked, this, [=, this]() { doSearch(); });
 
+    settingsButton = new SettingsButtonWidget(this);
+
+    cardSizeSlider = new CardSizeWidget(this);
+
+    settingsButton->addSettingsWidget(cardSizeSlider);
+
     navigationLayout->addWidget(cardsPushButton);
     navigationLayout->addWidget(topCommandersPushButton);
     navigationLayout->addWidget(tagsPushButton);
     navigationLayout->addWidget(searchBar);
     navigationLayout->addWidget(searchPushButton);
+    navigationLayout->addWidget(settingsButton);
 
     currentPageDisplay = new QWidget(container);
     currentPageLayout = new QVBoxLayout(currentPageDisplay);

--- a/cockatrice/src/client/tabs/api/edhrec/tab_edhrec_main.h
+++ b/cockatrice/src/client/tabs/api/edhrec/tab_edhrec_main.h
@@ -2,7 +2,9 @@
 #define TAB_EDHREC_MAIN_H
 
 #include "../../../../game/cards/card_database.h"
+#include "../../../ui/widgets/cards/card_size_widget.h"
 #include "../../../ui/widgets/general/layout_containers/flow_widget.h"
+#include "../../../ui/widgets/quick_settings/settings_button_widget.h"
 #include "../../tab.h"
 #include "display/commander/edhrec_commander_api_response_display_widget.h"
 
@@ -23,6 +25,11 @@ public:
     {
         auto cardName = cardToQuery.isNull() ? QString() : cardToQuery->getName();
         return tr("EDHREC: ") + cardName;
+    }
+
+    CardSizeWidget* getCardSizeSlider()
+    {
+        return cardSizeSlider;
     }
 
     QNetworkAccessManager *networkManager;
@@ -53,6 +60,8 @@ private:
     QPushButton *tagsPushButton;
     QLineEdit *searchBar;
     QPushButton *searchPushButton;
+    SettingsButtonWidget *settingsButton;
+    CardSizeWidget *cardSizeSlider;
     CardInfoPtr cardToQuery;
     EdhrecCommanderApiResponseDisplayWidget *displayWidget;
 };

--- a/cockatrice/src/client/tabs/api/edhrec/tab_edhrec_main.h
+++ b/cockatrice/src/client/tabs/api/edhrec/tab_edhrec_main.h
@@ -27,7 +27,7 @@ public:
         return tr("EDHREC: ") + cardName;
     }
 
-    CardSizeWidget* getCardSizeSlider()
+    CardSizeWidget *getCardSizeSlider()
     {
         return cardSizeSlider;
     }

--- a/cockatrice/src/client/ui/widgets/general/display/percent_bar_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/display/percent_bar_widget.cpp
@@ -1,0 +1,46 @@
+#include "percent_bar_widget.h"
+
+PercentBarWidget::PercentBarWidget(QWidget *parent, double initialValue) : QWidget(parent), valueToDisplay(initialValue)
+{
+    setMinimumSize(50, 10);
+}
+
+void PercentBarWidget::paintEvent(QPaintEvent *event)
+{
+    Q_UNUSED(event);
+
+    QPainter painter(this);
+    QRect rect = this->rect();
+
+    const int midX = rect.width() / 2;
+    const int height = rect.height();
+
+    // Draw background border (no fill)
+    painter.setPen(QPen(Qt::black, 1));
+    painter.setBrush(Qt::NoBrush);
+    painter.drawRect(rect.adjusted(0, 0, -1, -1)); // Avoid right/bottom overflow
+
+    const double halfWidth = rect.width() / 2.0;
+
+    const int barLength = static_cast<int>((qAbs(valueToDisplay) / 100.0) * halfWidth);
+
+    QRect fillRect;
+    if (valueToDisplay > 0.0) {
+        fillRect = QRect(midX, 0, barLength, height);
+        painter.fillRect(fillRect, Qt::green);
+    } else if (valueToDisplay < 0.0) {
+        fillRect = QRect(midX - barLength, 0, barLength, height);
+        painter.fillRect(fillRect, Qt::red);
+    }
+
+    // Draw center line at 0
+    painter.fillRect(midX - 1, 0, 3, height, Qt::white);
+
+    // Draw tick marks every 10%
+    const int tickHeight = 4;
+
+    for (int percent = -100; percent <= 100; percent += 10) {
+        int x = midX + static_cast<int>((percent / 100.0) * halfWidth);
+        painter.drawLine(x, height - tickHeight, x, height);
+    }
+}

--- a/cockatrice/src/client/ui/widgets/general/display/percent_bar_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/display/percent_bar_widget.h
@@ -1,0 +1,33 @@
+#ifndef PERCENT_BAR_WIDGET_H
+#define PERCENT_BAR_WIDGET_H
+
+#include <QColor>
+#include <QPainter>
+#include <QWidget>
+
+class PercentBarWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit PercentBarWidget(QWidget *parent, double initialValue);
+
+    void setValue(double newValue)
+    {
+        valueToDisplay = qBound(-100.0, newValue, 100.0); // Clamp to [-100, 100]
+        update();                                         // Trigger repaint
+    }
+
+    double value() const
+    {
+        return valueToDisplay;
+    }
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+
+private:
+    double valueToDisplay; // Ranges from -100 to 100
+};
+
+#endif // PERCENT_BAR_WIDGET_H


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem
Currently, we color the whole label which is awful for readability.

## What will change with this Pull Request?
- Move the card name above the card (maybe add mana symbols there too?)
- Add horizontal -100% to +100% bars for inclusion and synergy
- Add a card size slider

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/00795937-decd-4537-a385-4ebb61c633ee)
![image](https://github.com/user-attachments/assets/b5d37891-116e-4e13-b5da-e17f794c40da)
![image](https://github.com/user-attachments/assets/a5f7e792-23c2-4310-a040-01409e648950)

After:
![image](https://github.com/user-attachments/assets/87176657-03ff-44c3-b8a8-c984bc4c7589)
![image](https://github.com/user-attachments/assets/9b498be6-b4f4-4de1-a2b2-772b0d66f3cf)
![image](https://github.com/user-attachments/assets/450669e4-d908-48de-8434-3bd3a54b8624)

