### PR TITLE
Don't add duplicate CardInfos to set.

### DIFF
--- a/cockatrice/src/game/cards/card_info.cpp
+++ b/cockatrice/src/game/cards/card_info.cpp
@@ -289,8 +289,12 @@ QString CardInfo::getCorrectedName() const
 
 void CardInfo::addToSet(const CardSetPtr &_set, const CardInfoPerSet _info)
 {
-    _set->append(smartThis);
-    sets[_set->getShortName()].append(_info);
+    if (!_set->contains(smartThis)) {
+        _set->append(smartThis);
+    }
+    if (!sets[_set->getShortName()].contains(_info)) {
+        sets[_set->getShortName()].append(_info);
+    }
 
     refreshCachedSetNames();
 }


### PR DESCRIPTION
## Short roundup of the initial problem
Through some quirk I haven't investigated further, we call addToSet multiple times for the same CardInfoPtr. This adds some checks to ensure we don't, which leads to a deduplicated CardInfoPerSetMap

## What will change with this Pull Request?
- Add guards if maps already contain CardInfo
