### PR TITLE
Allow empty collectorNumber

### DIFF
--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -386,9 +386,10 @@ CardInfoPerSet CardDatabase::getSpecificSetForCard(const QString &cardName,
 
     for (const auto &cardInfoPerSetList : setMap) {
         for (auto &cardInfoForSet : cardInfoPerSetList) {
-            if (cardInfoForSet.getPtr()->getShortName() == setShortName &&
-                cardInfoForSet.getProperty("num") == collectorNumber) {
-                return cardInfoForSet;
+            if (cardInfoForSet.getPtr()->getShortName() == setShortName) {
+                if (cardInfoForSet.getProperty("num") == collectorNumber || collectorNumber.isEmpty()) {
+                    return cardInfoForSet;
+                }
             }
         }
     }


### PR DESCRIPTION
## Short roundup of the initial problem
We can only fetch the set for a card if we know the set name and the collector number.

## What will change with this Pull Request?
- Allow an empty collectorNumber for flexibility.