### PR TITLE
[Visual Database Display] Display cards as set variants if only a single set is selected

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -195,13 +195,30 @@ void VisualDatabaseDisplayWidget::populateCards()
         databaseDisplayModel->fetchMore(QModelIndex());
     }
 
+    QList<const CardFilter *> setFilters = filterModel->getFiltersOfType(CardFilter::AttrSet);
+    const CardFilter *setFilter = nullptr;
+    if (setFilters.length() == 1) {
+        setFilter = setFilters.at(0);
+    }
+
     for (int row = start; row < end; ++row) {
         qCDebug(VisualDatabaseDisplayLog) << "Adding " << row;
         QModelIndex index = databaseDisplayModel->index(row, CardDatabaseModel::NameColumn);
         QVariant name = databaseDisplayModel->data(index, Qt::DisplayRole);
         qCDebug(VisualDatabaseDisplayLog) << name.toString();
+
         if (CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(name.toString())) {
-            addCard(info);
+            if (setFilter) {
+                CardInfoPerSetMap setMap = info->getSets();
+                if (setMap.contains(setFilter->term())) {
+                    for (CardInfoPerSet cardSetInstance : setMap[setFilter->term()]) {
+                        addCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
+                            name.toString(), cardSetInstance.getProperty("uuid")));
+                    }
+                }
+            } else {
+                addCard(info);
+            }
         } else {
             qCDebug(VisualDatabaseDisplayLog) << "Card not found in database!";
         }


### PR DESCRIPTION
## Short roundup of the initial problem
When selecting a single set in visual database display, you'd expect the cards to be displayed as the printings from THAT set.

## What will change with this Pull Request?
- Display cards as printings from specific set if a single set is selected. This change will display ALL printings within the set.

## Screenshots
Secret Lair Drop selected:
![image](https://github.com/user-attachments/assets/a209f685-fc49-4e7d-b65b-b3d74205a500)
Innistrad: Double Feature selected:
![image](https://github.com/user-attachments/assets/937aafef-cbd8-4572-a064-7b552627d734)

