### PR TITLE
VDS: Optimize refreshTags in VisualDeckStorageTagFilterWidget

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
@@ -64,13 +64,13 @@ void VisualDeckStorageTagFilterWidget::filterDecksBySelectedTags(const QList<Dec
 
 void VisualDeckStorageTagFilterWidget::refreshTags()
 {
-    QStringList allTags = gatherAllTags();
+    QSet<QString> allTags = gatherAllTags();
     removeTagsNotInList(allTags);
     addTagsIfNotPresent(allTags);
     sortTags();
 }
 
-void VisualDeckStorageTagFilterWidget::removeTagsNotInList(const QStringList &tags)
+void VisualDeckStorageTagFilterWidget::removeTagsNotInList(const QSet<QString> &tags)
 {
     // Iterate through all DeckPreviewTagDisplayWidgets
     for (DeckPreviewTagDisplayWidget *tagWidget : findChildren<DeckPreviewTagDisplayWidget *>()) {
@@ -83,7 +83,7 @@ void VisualDeckStorageTagFilterWidget::removeTagsNotInList(const QStringList &ta
     }
 }
 
-void VisualDeckStorageTagFilterWidget::addTagsIfNotPresent(const QStringList &tags)
+void VisualDeckStorageTagFilterWidget::addTagsIfNotPresent(const QSet<QString> &tags)
 {
     for (const QString &tag : tags) {
         addTagIfNotPresent(tag);
@@ -136,14 +136,16 @@ void VisualDeckStorageTagFilterWidget::sortTags()
     }
 }
 
-QStringList VisualDeckStorageTagFilterWidget::gatherAllTags() const
+QSet<QString> VisualDeckStorageTagFilterWidget::gatherAllTags() const
 {
-    QStringList allTags;
+    QSet<QString> allTags;
     QList<DeckPreviewWidget *> deckWidgets = parent->findChildren<DeckPreviewWidget *>();
 
     for (DeckPreviewWidget *widget : deckWidgets) {
         if (widget->checkVisibility()) {
-            allTags << widget->deckLoader->getTags();
+            for (const QString &tag : widget->deckLoader->getTags()) {
+                allTags.insert(tag);
+            }
         }
     }
     return allTags;

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
@@ -65,8 +65,8 @@ void VisualDeckStorageTagFilterWidget::filterDecksBySelectedTags(const QList<Dec
 void VisualDeckStorageTagFilterWidget::refreshTags()
 {
     QStringList allTags = gatherAllTags();
-    removeTagsNotInList(gatherAllTags());
-    addTagsIfNotPresent(gatherAllTags());
+    removeTagsNotInList(allTags);
+    addTagsIfNotPresent(allTags);
     sortTags();
 }
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
@@ -136,7 +136,7 @@ void VisualDeckStorageTagFilterWidget::sortTags()
     }
 }
 
-QStringList VisualDeckStorageTagFilterWidget::gatherAllTags()
+QStringList VisualDeckStorageTagFilterWidget::gatherAllTags() const
 {
     QStringList allTags;
     QList<DeckPreviewWidget *> deckWidgets = parent->findChildren<DeckPreviewWidget *>();
@@ -149,7 +149,7 @@ QStringList VisualDeckStorageTagFilterWidget::gatherAllTags()
     return allTags;
 }
 
-QStringList VisualDeckStorageTagFilterWidget::getAllKnownTags()
+QStringList VisualDeckStorageTagFilterWidget::getAllKnownTags() const
 {
     QStringList allTags;
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.h
@@ -10,16 +10,18 @@ class VisualDeckStorageTagFilterWidget : public QWidget
 {
     Q_OBJECT
 
-public:
-    explicit VisualDeckStorageTagFilterWidget(VisualDeckStorageWidget *_parent);
+    VisualDeckStorageWidget *parent;
+
     QStringList gatherAllTags() const;
-    void filterDecksBySelectedTags(const QList<DeckPreviewWidget *> &deckPreviews) const;
     void removeTagsNotInList(const QStringList &tags);
     void addTagsIfNotPresent(const QStringList &tags);
     void addTagIfNotPresent(const QString &tag);
     void sortTags();
+
+public:
+    explicit VisualDeckStorageTagFilterWidget(VisualDeckStorageWidget *_parent);
     QStringList getAllKnownTags() const;
-    VisualDeckStorageWidget *parent;
+    void filterDecksBySelectedTags(const QList<DeckPreviewWidget *> &deckPreviews) const;
 
 public slots:
     void refreshTags();

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.h
@@ -12,13 +12,13 @@ class VisualDeckStorageTagFilterWidget : public QWidget
 
 public:
     explicit VisualDeckStorageTagFilterWidget(VisualDeckStorageWidget *_parent);
-    QStringList gatherAllTags();
+    QStringList gatherAllTags() const;
     void filterDecksBySelectedTags(const QList<DeckPreviewWidget *> &deckPreviews) const;
     void removeTagsNotInList(const QStringList &tags);
     void addTagsIfNotPresent(const QStringList &tags);
     void addTagIfNotPresent(const QString &tag);
     void sortTags();
-    QStringList getAllKnownTags();
+    QStringList getAllKnownTags() const;
     VisualDeckStorageWidget *parent;
 
 public slots:

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.h
@@ -12,9 +12,9 @@ class VisualDeckStorageTagFilterWidget : public QWidget
 
     VisualDeckStorageWidget *parent;
 
-    QStringList gatherAllTags() const;
-    void removeTagsNotInList(const QStringList &tags);
-    void addTagsIfNotPresent(const QStringList &tags);
+    QSet<QString> gatherAllTags() const;
+    void removeTagsNotInList(const QSet<QString> &tags);
+    void addTagsIfNotPresent(const QSet<QString> &tags);
     void addTagIfNotPresent(const QString &tag);
     void sortTags();
 


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5848

## Short roundup of the initial problem

After the optimizations in the above PR, Refresh tags now taking up the most execution time. There are some simple optimizations that can be made in `VisualDeckStorageTagFilterWidget`.

## What will change with this Pull Request?

- Remove accidental redundant calls to `gatherAllTags`
- Gather tags into a `QSet` instead of `QStringList`.
  - `removeTagsNotInList` calls `tags.contains` in a loop. There could be quite a large number of tags, so using a set instead of a list here should be a performance improvement. 
- Also did some minor refactoring 
  - Made the collect tag methods const 
  - Moved some methods and the `VisualDeckStorageWidget` field to private, since they probably should've been private in the first place.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

Before
<img width="953" alt="Screenshot 2025-04-19 at 1 38 15 AM" src="https://github.com/user-attachments/assets/87a4bd8f-fb0b-4a8e-8e16-3bf760e431bf" />

After
<img width="989" alt="Screenshot 2025-04-19 at 1 38 00 AM" src="https://github.com/user-attachments/assets/cf4dac0c-3331-435f-bd12-965a269e6304" />

