### PR TITLE
[GDE] Add the option to hide banner card and tags in deck editor.

### DIFF
--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -58,6 +58,28 @@ void DeckEditorDeckDockWidget::createDeckDock()
     nameEdit->setObjectName("nameEdit");
     nameLabel->setBuddy(nameEdit);
     connect(nameEdit, &LineEditUnfocusable::textChanged, this, &DeckEditorDeckDockWidget::updateName);
+
+    quickSettingsWidget = new SettingsButtonWidget(this);
+
+    showBannerCardCheckBox = new QCheckBox();
+    showBannerCardCheckBox->setObjectName("showBannerCardCheckBox");
+    showBannerCardCheckBox->setChecked(SettingsCache::instance().getDeckEditorBannerCardComboBoxVisible());
+    connect(showBannerCardCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setDeckEditorBannerCardComboBoxVisible);
+    connect(&SettingsCache::instance(), &SettingsCache::deckEditorBannerCardComboBoxVisibleChanged, this,
+            &DeckEditorDeckDockWidget::updateShowBannerCardComboBox);
+
+    showTagsWidgetCheckBox = new QCheckBox();
+    showTagsWidgetCheckBox->setObjectName("showTagsWidgetCheckBox");
+    showTagsWidgetCheckBox->setChecked(SettingsCache::instance().getDeckEditorTagsWidgetVisible());
+    connect(showTagsWidgetCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setDeckEditorTagsWidgetVisible);
+    connect(&SettingsCache::instance(), &SettingsCache::deckEditorTagsWidgetVisibleChanged, this,
+            &DeckEditorDeckDockWidget::updateShowTagsWidget);
+
+    quickSettingsWidget->addSettingsWidget(showBannerCardCheckBox);
+    quickSettingsWidget->addSettingsWidget(showTagsWidgetCheckBox);
+
     commentsLabel = new QLabel();
     commentsLabel->setObjectName("commentsLabel");
     commentsEdit = new QTextEdit;
@@ -69,6 +91,7 @@ void DeckEditorDeckDockWidget::createDeckDock()
     bannerCardLabel = new QLabel();
     bannerCardLabel->setObjectName("bannerCardLabel");
     bannerCardLabel->setText(tr("Banner Card"));
+    bannerCardLabel->setHidden(SettingsCache::instance().getDeckEditorBannerCardComboBoxVisible());
     bannerCardComboBox = new QComboBox(this);
     connect(deckModel, &DeckListModel::dataChanged, this, [this]() {
         // Delay the update to avoid race conditions
@@ -76,8 +99,10 @@ void DeckEditorDeckDockWidget::createDeckDock()
     });
     connect(bannerCardComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &DeckEditorDeckDockWidget::setBannerCard);
+    bannerCardComboBox->setHidden(!SettingsCache::instance().getDeckEditorBannerCardComboBoxVisible());
 
     deckTagsDisplayWidget = new DeckPreviewDeckTagsDisplayWidget(this, deckModel->getDeckList());
+    deckTagsDisplayWidget->setHidden(!SettingsCache::instance().getDeckEditorTagsWidgetVisible());
 
     aIncrement = new QAction(QString(), this);
     aIncrement->setIcon(QPixmap("theme:icons/increment"));
@@ -109,6 +134,7 @@ void DeckEditorDeckDockWidget::createDeckDock()
 
     upperLayout->addWidget(nameLabel, 0, 0);
     upperLayout->addWidget(nameEdit, 0, 1);
+    upperLayout->addWidget(quickSettingsWidget, 0, 2);
 
     upperLayout->addWidget(commentsLabel, 1, 0);
     upperLayout->addWidget(commentsEdit, 1, 1);
@@ -289,6 +315,17 @@ void DeckEditorDeckDockWidget::setBannerCard(int /* changedIndex */)
     deckModel->getDeckList()->setBannerCard(
         QPair<QString, QString>(itemData["name"].toString(), itemData["uuid"].toString()));
     emit deckChanged();
+}
+
+void DeckEditorDeckDockWidget::updateShowBannerCardComboBox(const bool visible)
+{
+    bannerCardLabel->setHidden(!visible);
+    bannerCardComboBox->setHidden(!visible);
+}
+
+void DeckEditorDeckDockWidget::updateShowTagsWidget(const bool visible)
+{
+    deckTagsDisplayWidget->setHidden(!visible);
 }
 
 /**
@@ -526,6 +563,8 @@ void DeckEditorDeckDockWidget::retranslateUi()
     setWindowTitle(tr("Deck"));
 
     nameLabel->setText(tr("Deck &name:"));
+    showBannerCardCheckBox->setText(tr("Show banner card selection menu"));
+    showTagsWidgetCheckBox->setText(tr("Show tags selection menu"));
     commentsLabel->setText(tr("&Comments:"));
     hashLabel1->setText(tr("Hash:"));
 

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.h
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.h
@@ -57,6 +57,9 @@ private:
     KeySignals deckViewKeySignals;
     QLabel *nameLabel;
     LineEditUnfocusable *nameEdit;
+    SettingsButtonWidget *quickSettingsWidget;
+    QCheckBox *showBannerCardCheckBox;
+    QCheckBox *showTagsWidgetCheckBox;
     QLabel *commentsLabel;
     QTextEdit *commentsEdit;
     QLabel *bannerCardLabel;
@@ -77,6 +80,8 @@ private slots:
     void setBannerCard(int);
     void updateHash();
     void refreshShortcuts();
+    void updateShowBannerCardComboBox(bool visible);
+    void updateShowTagsWidget(bool visible);
 };
 
 #endif // DECK_EDITOR_DECK_DOCK_WIDGET_H

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -263,6 +263,9 @@ SettingsCache::SettingsCache()
     includeRebalancedCards = settings->value("cards/includerebalancedcards", true).toBool();
     printingSelectorNavigationButtonsVisible =
         settings->value("cards/printingselectornavigationbuttonsvisible", true).toBool();
+    deckEditorBannerCardComboBoxVisible =
+        settings->value("interface/deckeditorbannercardcomboboxvisible", true).toBool();
+    deckEditorTagsWidgetVisible = settings->value("interface/deckeditortagswidgetvisible", true).toBool();
     visualDeckStorageCardSize = settings->value("interface/visualdeckstoragecardsize", 100).toInt();
     visualDeckStorageSortingOrder = settings->value("interface/visualdeckstoragesortingorder", 0).toInt();
     visualDeckStorageShowFolders = settings->value("interface/visualdeckstorageshowfolders", true).toBool();
@@ -679,6 +682,20 @@ void SettingsCache::setPrintingSelectorNavigationButtonsVisible(QT_STATE_CHANGED
     printingSelectorNavigationButtonsVisible = _navigationButtonsVisible;
     settings->setValue("cards/printingselectornavigationbuttonsvisible", printingSelectorNavigationButtonsVisible);
     emit printingSelectorNavigationButtonsVisibleChanged();
+}
+
+void SettingsCache::setDeckEditorBannerCardComboBoxVisible(QT_STATE_CHANGED_T _deckEditorBannerCardComboBoxVisible)
+{
+    deckEditorBannerCardComboBoxVisible = _deckEditorBannerCardComboBoxVisible;
+    settings->setValue("interface/deckeditorbannercardcomboboxvisible", deckEditorBannerCardComboBoxVisible);
+    emit deckEditorBannerCardComboBoxVisibleChanged(deckEditorBannerCardComboBoxVisible);
+}
+
+void SettingsCache::setDeckEditorTagsWidgetVisible(QT_STATE_CHANGED_T _deckEditorTagsWidgetVisible)
+{
+    deckEditorTagsWidgetVisible = _deckEditorTagsWidgetVisible;
+    settings->setValue("interface/deckeditortagswidgetvisible", deckEditorTagsWidgetVisible);
+    emit deckEditorTagsWidgetVisibleChanged(deckEditorTagsWidgetVisible);
 }
 
 void SettingsCache::setVisualDeckStorageSortingOrder(int _visualDeckStorageSortingOrder)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -61,6 +61,8 @@ signals:
     void printingSelectorCardSizeChanged();
     void includeRebalancedCardsChanged(bool _includeRebalancedCards);
     void printingSelectorNavigationButtonsVisibleChanged();
+    void deckEditorBannerCardComboBoxVisibleChanged(bool _visible);
+    void deckEditorTagsWidgetVisibleChanged(bool _visible);
     void visualDeckStorageShowTagFilterChanged(bool _visible);
     void visualDeckStorageShowBannerCardComboBoxChanged(bool _visible);
     void visualDeckStorageShowTagsOnDeckPreviewsChanged(bool _visible);
@@ -134,6 +136,8 @@ private:
     int printingSelectorCardSize;
     bool includeRebalancedCards;
     bool printingSelectorNavigationButtonsVisible;
+    bool deckEditorBannerCardComboBoxVisible;
+    bool deckEditorTagsWidgetVisible;
     int visualDeckStorageSortingOrder;
     bool visualDeckStorageShowFolders;
     bool visualDeckStorageShowBannerCardComboBox;
@@ -419,6 +423,14 @@ public:
     bool getPrintingSelectorNavigationButtonsVisible() const
     {
         return printingSelectorNavigationButtonsVisible;
+    }
+    bool getDeckEditorBannerCardComboBoxVisible() const
+    {
+        return deckEditorBannerCardComboBoxVisible;
+    }
+    bool getDeckEditorTagsWidgetVisible() const
+    {
+        return deckEditorTagsWidgetVisible;
     }
     int getVisualDeckStorageSortingOrder() const
     {
@@ -800,6 +812,8 @@ public slots:
     void setPrintingSelectorCardSize(int _printingSelectorCardSize);
     void setIncludeRebalancedCards(bool _includeRebalancedCards);
     void setPrintingSelectorNavigationButtonsVisible(QT_STATE_CHANGED_T _navigationButtonsVisible);
+    void setDeckEditorBannerCardComboBoxVisible(QT_STATE_CHANGED_T _deckEditorBannerCardComboBoxVisible);
+    void setDeckEditorTagsWidgetVisible(QT_STATE_CHANGED_T _deckEditorTagsWidgetVisible);
     void setVisualDeckStorageSortingOrder(int _visualDeckStorageSortingOrder);
     void setVisualDeckStorageShowFolders(QT_STATE_CHANGED_T value);
     void setVisualDeckStorageShowTagFilter(QT_STATE_CHANGED_T _showTags);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -208,6 +208,13 @@ void SettingsCache::setIncludeRebalancedCards(bool /* _includeRebalancedCards */
 void SettingsCache::setPrintingSelectorNavigationButtonsVisible(QT_STATE_CHANGED_T /* _navigationButtonsVisible */)
 {
 }
+void SettingsCache::setDeckEditorBannerCardComboBoxVisible(
+    QT_STATE_CHANGED_T /* _deckEditorBannerCardComboBoxVisible */)
+{
+}
+void SettingsCache::setDeckEditorTagsWidgetVisible(QT_STATE_CHANGED_T /* _deckEditorTagsWidgetVisible */)
+{
+}
 void SettingsCache::setVisualDeckStorageSortingOrder(int /* _visualDeckStorageSortingOrder */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -212,6 +212,13 @@ void SettingsCache::setIncludeRebalancedCards(bool /* _includeRebalancedCards */
 void SettingsCache::setPrintingSelectorNavigationButtonsVisible(QT_STATE_CHANGED_T /* _navigationButtonsVisible */)
 {
 }
+void SettingsCache::setDeckEditorBannerCardComboBoxVisible(
+    QT_STATE_CHANGED_T /* _deckEditorBannerCardComboBoxVisible */)
+{
+}
+void SettingsCache::setDeckEditorTagsWidgetVisible(QT_STATE_CHANGED_T /* _deckEditorTagsWidgetVisible */)
+{
+}
 void SettingsCache::setVisualDeckStorageSortingOrder(int /* _visualDeckStorageSortingOrder */)
 {
 }


### PR DESCRIPTION
## Related Ticket(s)
- Somewhat fixes #5803
- Fixes #5804

## Short roundup of the initial problem
Some users may not want to use the new features or might just want to temporarily hide them after they are done adjusting them.

## Screenshots

![image](https://github.com/user-attachments/assets/cfd7eabd-db0a-48a7-928e-f0513450d470)
![image](https://github.com/user-attachments/assets/7f9f5074-6702-4e57-92b7-62ac28386724)
![image](https://github.com/user-attachments/assets/e5b7e5c7-b30b-48c1-ab44-3181958d1f4a)
