### PR TITLE
[VDE] Don't force size unnecessarily, correctly parent scrollArea.

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -29,7 +29,6 @@ VisualDeckEditorWidget::VisualDeckEditorWidget(QWidget *parent, DeckListModel *_
     connect(deckListModel, &DeckListModel::dataChanged, this, &VisualDeckEditorWidget::decklistDataChanged);
 
     // The Main Widget and Main Layout, which contain a single Widget: The Scroll Area
-    setMinimumSize(0, 0);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     mainLayout = new QVBoxLayout(this);
     setLayout(mainLayout);
@@ -162,7 +161,7 @@ VisualDeckEditorWidget::VisualDeckEditorWidget(QWidget *parent, DeckListModel *_
     groupAndSortLayout->addWidget(sortCriteriaButton);
     groupAndSortLayout->addWidget(displayTypeButton);
 
-    scrollArea = new QScrollArea();
+    scrollArea = new QScrollArea(this);
     scrollArea->setWidgetResizable(true);
     scrollArea->setMinimumSize(0, 0);
 


### PR DESCRIPTION
## Related Ticket(s)
- Possibly fixes #5859

## Short roundup of the initial problem
When opening the visual deck editor, the size of the main widgets gets maximized beyond what it should.

## What will change with this Pull Request?
- Don't set the minimum size of the main widget to unlimited.
