### PR TITLE
[VDD] Defer filter tree assignment

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_set_filter_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_set_filter_widget.cpp
@@ -37,7 +37,12 @@ VisualDatabaseDisplaySetFilterWidget::VisualDatabaseDisplaySetFilterWidget(QWidg
             [this]() { QTimer::singleShot(100, this, &VisualDatabaseDisplaySetFilterWidget::syncWithFilterModel); });
 
     createSetButtons();      // Populate buttons initially
-    updateFilterMode(false); // Initialize toggle button text
+    retranslateUi();
+}
+
+void VisualDatabaseDisplaySetFilterWidget::retranslateUi()
+{
+    toggleButton->setText(exactMatchMode ? tr("Mode: Exact Match") : tr("Mode: Includes"));
 }
 
 void VisualDatabaseDisplaySetFilterWidget::createSetButtons()
@@ -190,6 +195,6 @@ void VisualDatabaseDisplaySetFilterWidget::syncWithFilterModel()
 void VisualDatabaseDisplaySetFilterWidget::updateFilterMode(bool checked)
 {
     exactMatchMode = checked;
-    toggleButton->setText(exactMatchMode ? tr("Mode: Exact Match") : tr("Mode: Includes"));
     updateSetFilter();
+    retranslateUi();
 }

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_set_filter_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_set_filter_widget.cpp
@@ -36,7 +36,7 @@ VisualDatabaseDisplaySetFilterWidget::VisualDatabaseDisplaySetFilterWidget(QWidg
     connect(filterModel, &FilterTreeModel::layoutChanged, this,
             [this]() { QTimer::singleShot(100, this, &VisualDatabaseDisplaySetFilterWidget::syncWithFilterModel); });
 
-    createSetButtons();      // Populate buttons initially
+    createSetButtons(); // Populate buttons initially
     retranslateUi();
 }
 

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_set_filter_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_set_filter_widget.h
@@ -16,6 +16,7 @@ class VisualDatabaseDisplaySetFilterWidget : public QWidget
     Q_OBJECT
 public:
     explicit VisualDatabaseDisplaySetFilterWidget(QWidget *parent, FilterTreeModel *filterModel);
+    void retranslateUi();
     void createSetButtons();
     void updateSetButtonsVisibility();
     void handleSetToggled(const QString &setShortName, bool active);

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -62,9 +62,6 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
 
     filterModel = new FilterTreeModel();
     filterModel->setObjectName("filterModel");
-    databaseDisplayModel->setFilterTree(filterModel->filterTree());
-
-    connect(filterModel, &FilterTreeModel::layoutChanged, this, &VisualDatabaseDisplayWidget::searchModelChanged);
 
     searchKeySignals.setObjectName("searchKeySignals");
     connect(searchEdit, &QLineEdit::textChanged, this, &VisualDatabaseDisplayWidget::updateSearch);
@@ -143,6 +140,10 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
     debounceTimer->setSingleShot(true); // Ensure it only fires once after the timeout
 
     connect(debounceTimer, &QTimer::timeout, this, &VisualDatabaseDisplayWidget::searchModelChanged);
+
+    databaseDisplayModel->setFilterTree(filterModel->filterTree());
+
+    connect(filterModel, &FilterTreeModel::layoutChanged, this, &VisualDatabaseDisplayWidget::searchModelChanged);
 
     loadCardsTimer = new QTimer(this);
     loadCardsTimer->setSingleShot(true); // Ensure it only fires once after the timeout


### PR DESCRIPTION
## Short roundup of the initial problem
Currently, we set the filter tree before we initialize the filter widgets, which means that every single time they emit layoutChanged during their initialization, the database gets filtered anew, which leads to a lot of lag when opening the tab. This defers assigning the filterTree until after the filter widgets are initialized, which only filters the database once.
