### PR TITLE
Make OracleImporter not extend CardDatabase

### DIFF
--- a/cockatrice/src/dialogs/dlg_edit_tokens.cpp
+++ b/cockatrice/src/dialogs/dlg_edit_tokens.cpp
@@ -161,7 +161,7 @@ void DlgEditTokens::actAddToken()
         }
     }
 
-    QString setName = CardDatabase::TOKENS_SETNAME;
+    QString setName = CardSet::TOKENS_SETNAME;
     CardInfoPerSetMap sets;
     sets[setName].append(CardInfoPerSet(databaseModel->getDatabase()->getSet(setName)));
     CardInfoPtr card = CardInfo::newInstance(name, "", true, QVariantHash(), QList<CardRelation *>(),

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -16,8 +16,6 @@
 #include <algorithm>
 #include <utility>
 
-const char *CardDatabase::TOKENS_SETNAME = "TK";
-
 CardDatabase::CardDatabase(QObject *parent) : QObject(parent), loadStatus(NotLoaded)
 {
     qRegisterMetaType<CardInfoPtr>("CardInfoPtr");
@@ -560,16 +558,15 @@ void CardDatabase::notifyEnabledSetsChanged()
 
 bool CardDatabase::saveCustomTokensToFile()
 {
-    QString fileName =
-        SettingsCache::instance().getCustomCardDatabasePath() + "/" + CardDatabase::TOKENS_SETNAME + ".xml";
+    QString fileName = SettingsCache::instance().getCustomCardDatabasePath() + "/" + CardSet::TOKENS_SETNAME + ".xml";
 
     SetNameMap tmpSets;
-    CardSetPtr customTokensSet = getSet(CardDatabase::TOKENS_SETNAME);
-    tmpSets.insert(CardDatabase::TOKENS_SETNAME, customTokensSet);
+    CardSetPtr customTokensSet = getSet(CardSet::TOKENS_SETNAME);
+    tmpSets.insert(CardSet::TOKENS_SETNAME, customTokensSet);
 
     CardNameMap tmpCards;
     for (const CardInfoPtr &card : cards) {
-        if (card->getSets().contains(CardDatabase::TOKENS_SETNAME)) {
+        if (card->getSets().contains(CardSet::TOKENS_SETNAME)) {
             tmpCards.insert(card->getName(), card);
         }
     }

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -61,8 +61,6 @@ private:
                 *removeCardMutex = new QBasicMutex();
 
 public:
-    static const char *TOKENS_SETNAME;
-
     explicit CardDatabase(QObject *parent = nullptr);
     ~CardDatabase() override;
     void clear();

--- a/cockatrice/src/game/cards/card_database_model.cpp
+++ b/cockatrice/src/game/cards/card_database_model.cpp
@@ -387,7 +387,7 @@ TokenEditModel::TokenEditModel(QObject *parent) : CardDatabaseDisplayModel(paren
 bool TokenEditModel::filterAcceptsRow(int sourceRow, const QModelIndex & /*sourceParent*/) const
 {
     CardInfoPtr info = static_cast<CardDatabaseModel *>(sourceModel())->getCard(sourceRow);
-    return info->getIsToken() && info->getSets().contains(CardDatabase::TOKENS_SETNAME) && rowMatchesCardName(info);
+    return info->getIsToken() && info->getSets().contains(CardSet::TOKENS_SETNAME) && rowMatchesCardName(info);
 }
 
 int TokenEditModel::rowCount(const QModelIndex &parent) const

--- a/cockatrice/src/game/cards/card_info.cpp
+++ b/cockatrice/src/game/cards/card_info.cpp
@@ -11,6 +11,8 @@
 #include <algorithm>
 #include <utility>
 
+const char *CardSet::TOKENS_SETNAME = "TK";
+
 CardSet::CardSet(const QString &_shortName,
                  const QString &_longName,
                  const QString &_setType,

--- a/cockatrice/src/game/cards/card_info.h
+++ b/cockatrice/src/game/cards/card_info.h
@@ -43,6 +43,8 @@ public:
         PriorityLowest = 100,
     };
 
+    static const char *TOKENS_SETNAME;
+
 private:
     QString shortName, longName;
     unsigned int sortKey;

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -19,7 +19,7 @@ SplitCardPart::SplitCardPart(const QString &_name,
 
 const QRegularExpression OracleImporter::formatRegex = QRegularExpression("^format-");
 
-OracleImporter::OracleImporter(const QString &_dataDir, QObject *parent) : CardDatabase(parent), dataDir(_dataDir)
+OracleImporter::OracleImporter(const QString &_dataDir, QObject *parent) : QObject(parent), dataDir(_dataDir)
 {
 }
 
@@ -494,6 +494,7 @@ bool OracleImporter::saveToFile(const QString &fileName, const QString &sourceUr
 
 void OracleImporter::clear()
 {
-    CardDatabase::clear();
+    sets.clear();
+    cards.clear();
     allSets.clear();
 }

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -463,8 +463,8 @@ int OracleImporter::startImport()
 {
     int setCards = 0, setIndex = 0;
     // add an empty set for tokens
-    CardSetPtr tokenSet = CardSet::newInstance(TOKENS_SETNAME, tr("Dummy set containing tokens"), "Tokens");
-    sets.insert(TOKENS_SETNAME, tokenSet);
+    CardSetPtr tokenSet = CardSet::newInstance(CardSet::TOKENS_SETNAME, tr("Dummy set containing tokens"), "Tokens");
+    sets.insert(CardSet::TOKENS_SETNAME, tokenSet);
 
     for (const SetToDownload &curSetToParse : allSets) {
         CardSetPtr newSet =

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -4,7 +4,7 @@
 #include <QMap>
 #include <QRegularExpression>
 #include <QVariant>
-#include <game/cards/card_database.h>
+#include <game/cards/card_info.h>
 #include <utility>
 
 // many users prefer not to see these sets with non english arts
@@ -117,13 +117,24 @@ private:
     CardInfoPerSet setInfo;
 };
 
-class OracleImporter : public CardDatabase
+class OracleImporter : public QObject
 {
     Q_OBJECT
 private:
     const QStringList mainCardTypes = {"Planeswalker", "Creature", "Land",       "Sorcery",
                                        "Instant",      "Artifact", "Enchantment"};
     static const QRegularExpression formatRegex;
+
+    /**
+     * The cards, indexed by name.
+     */
+    CardNameMap cards;
+
+    /**
+     * The sets, indexed by short name.
+     */
+    SetNameMap sets;
+
     QList<SetToDownload> allSets;
     QVariantMap setsMap;
     QString dataDir;
@@ -146,6 +157,10 @@ public:
     int startImport();
     bool saveToFile(const QString &fileName, const QString &sourceUrl, const QString &sourceVersion);
     int importCardsFromSet(const CardSetPtr &currentSet, const QList<QVariant> &cards);
+    const CardNameMap &getCardList() const
+    {
+        return cards;
+    }
     QList<SetToDownload> &getSets()
     {
         return allSets;


### PR DESCRIPTION
## Related Ticket(s)
- Relates to #5782

## Short roundup of the initial problem

`OracleImporter` extends `CardDatabase`, even though it's hardly using most of the logic inside `CardDatabase`. It probably shouldn't be doing that. Extending `CardDatabase` causes it to pull in more dependencies than needed.

## What will change with this Pull Request?
- `OracleImporter` extends `QObject` instead of `CardDatabase` now.
  - Copied over the required logic from `CardDatabase`
- Moved `TOKENS_SETNAME` from `CardDatabase` to `CardSet`.