### PR TITLE
Refactor: clean up OracleImporter

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -12,7 +12,7 @@
 SplitCardPart::SplitCardPart(const QString &_name,
                              const QString &_text,
                              const QVariantHash &_properties,
-                             const CardInfoPerSet _setInfo)
+                             const CardInfoPerSet &_setInfo)
     : name(_name), text(_text), properties(_properties), setInfo(_setInfo)
 {
 }
@@ -125,11 +125,11 @@ static void sortAndReduceColors(QString &colors)
 }
 
 CardInfoPtr OracleImporter::addCard(QString name,
-                                    QString text,
+                                    const QString &text,
                                     bool isToken,
                                     QVariantHash properties,
-                                    QList<CardRelation *> &relatedCards,
-                                    CardInfoPerSet setInfo)
+                                    const QList<CardRelation *> &relatedCards,
+                                    const CardInfoPerSet &setInfo)
 {
     // Workaround for card name weirdness
     name = name.replace("Æ", "AE");

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -19,7 +19,7 @@ SplitCardPart::SplitCardPart(const QString &_name,
 
 const QRegularExpression OracleImporter::formatRegex = QRegularExpression("^format-");
 
-OracleImporter::OracleImporter(const QString &_dataDir, QObject *parent) : QObject(parent), dataDir(_dataDir)
+OracleImporter::OracleImporter(QObject *parent) : QObject(parent)
 {
 }
 

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -85,13 +85,16 @@ bool OracleImporter::readSetsFromByteArray(const QByteArray &data)
     return true;
 }
 
-QString OracleImporter::getMainCardType(const QStringList &typeList)
+static QString getMainCardType(const QStringList &typeList)
 {
     if (typeList.isEmpty()) {
         return {};
     }
 
-    for (const auto &type : mainCardTypes) {
+    static const QStringList typePriority = {"Planeswalker", "Creature", "Land",       "Sorcery",
+                                             "Instant",      "Artifact", "Enchantment"};
+
+    for (const auto &type : typePriority) {
         if (typeList.contains(type)) {
             return type;
         }

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -47,23 +47,15 @@ bool OracleImporter::readSetsFromByteArray(const QByteArray &data)
     }
 
     QListIterator it(setsMap.values());
-    QVariantMap map;
-
-    QString shortName;
-    QString longName;
-    QList<QVariant> setCards;
-    QString setType;
-    QDate releaseDate;
-    CardSet::Priority priority;
 
     while (it.hasNext()) {
-        map = it.next().toMap();
-        shortName = map.value("code").toString().toUpper();
-        longName = map.value("name").toString();
-        setCards = map.value("cards").toList();
-        setType = map.value("type").toString();
-        releaseDate = map.value("releaseDate").toDate();
-        priority = getSetPriority(setType, shortName);
+        QVariantMap map = it.next().toMap();
+        QString shortName = map.value("code").toString().toUpper();
+        QString longName = map.value("name").toString();
+        QList<QVariant> setCards = map.value("cards").toList();
+        QString setType = map.value("type").toString();
+        QDate releaseDate = map.value("releaseDate").toDate();
+        CardSet::Priority priority = getSetPriority(setType, shortName);
         // capitalize set type
         if (setType.length() > 0) {
             // basic grammar for words that aren't capitalized, like in "From the Vault"

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -23,7 +23,7 @@ OracleImporter::OracleImporter(QObject *parent) : QObject(parent)
 {
 }
 
-CardSet::Priority OracleImporter::getSetPriority(QString &setType, QString &shortName)
+static CardSet::Priority getSetPriority(const QString &setType, const QString &shortName)
 {
     if (!setTypePriorities.contains(setType.toLower())) {
         qDebug() << "warning: Set type" << setType << "unrecognized for prioritization";

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -40,7 +40,7 @@ bool OracleImporter::readSetsFromByteArray(const QByteArray &data)
     QList<SetToDownload> newSetList;
 
     bool ok;
-    setsMap = QtJson::Json::parse(QString(data), ok).toMap().value("data").toMap();
+    auto setsMap = QtJson::Json::parse(QString(data), ok).toMap().value("data").toMap();
     if (!ok) {
         qDebug() << "error: QtJson::Json::parse()";
         return false;

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -164,10 +164,6 @@ public:
         return allSets;
     }
     void clear();
-
-protected:
-    inline QString getStringPropertyFromMap(const QVariantMap &card, const QString &propertyName);
-    void sortAndReduceColors(QString &colors);
 };
 
 #endif

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -92,7 +92,8 @@ public:
 class SplitCardPart
 {
 public:
-    SplitCardPart(const QString &_name, const QString &_text, const QVariantHash &_properties, CardInfoPerSet setInfo);
+    SplitCardPart(const QString &_name, const QString &_text, const QVariantHash &_properties,
+                  const CardInfoPerSet &setInfo);
     inline const QString &getName() const
     {
         return name;
@@ -136,11 +137,11 @@ private:
     QList<SetToDownload> allSets;
 
     CardInfoPtr addCard(QString name,
-                        QString text,
+                        const QString &text,
                         bool isToken,
                         QVariantHash properties,
-                        QList<CardRelation *> &relatedCards,
-                        CardInfoPerSet setInfo);
+                        const QList<CardRelation *> &relatedCards,
+                        const CardInfoPerSet &setInfo);
 signals:
     void setIndexChanged(int cardsImported, int setIndex, const QString &setName);
     void dataReadProgress(int bytesRead, int totalBytes);

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -121,8 +121,6 @@ class OracleImporter : public QObject
 {
     Q_OBJECT
 private:
-    const QStringList mainCardTypes = {"Planeswalker", "Creature", "Land",       "Sorcery",
-                                       "Instant",      "Artifact", "Enchantment"};
     static const QRegularExpression formatRegex;
 
     /**
@@ -137,7 +135,6 @@ private:
 
     QList<SetToDownload> allSets;
 
-    QString getMainCardType(const QStringList &typeList);
     CardInfoPtr addCard(QString name,
                         QString text,
                         bool isToken,

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -136,7 +136,6 @@ private:
     SetNameMap sets;
 
     QList<SetToDownload> allSets;
-    QVariantMap setsMap;
 
     QString getMainCardType(const QStringList &typeList);
     CardInfoPtr addCard(QString name,

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -150,7 +150,6 @@ signals:
 
 public:
     explicit OracleImporter(QObject *parent = nullptr);
-    CardSet::Priority getSetPriority(QString &setType, QString &shortName);
     bool readSetsFromByteArray(const QByteArray &data);
     int startImport();
     bool saveToFile(const QString &fileName, const QString &sourceUrl, const QString &sourceVersion);

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -92,7 +92,9 @@ public:
 class SplitCardPart
 {
 public:
-    SplitCardPart(const QString &_name, const QString &_text, const QVariantHash &_properties,
+    SplitCardPart(const QString &_name,
+                  const QString &_text,
+                  const QVariantHash &_properties,
                   const CardInfoPerSet &setInfo);
     inline const QString &getName() const
     {
@@ -151,7 +153,7 @@ public:
     bool readSetsFromByteArray(const QByteArray &data);
     int startImport();
     bool saveToFile(const QString &fileName, const QString &sourceUrl, const QString &sourceVersion);
-    int importCardsFromSet(const CardSetPtr &currentSet, const QList<QVariant> &cards);
+    int importCardsFromSet(const CardSetPtr &currentSet, const QList<QVariant> &cardsList);
     const CardNameMap &getCardList() const
     {
         return cards;

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -137,7 +137,6 @@ private:
 
     QList<SetToDownload> allSets;
     QVariantMap setsMap;
-    QString dataDir;
 
     QString getMainCardType(const QStringList &typeList);
     CardInfoPtr addCard(QString name,
@@ -151,7 +150,7 @@ signals:
     void dataReadProgress(int bytesRead, int totalBytes);
 
 public:
-    explicit OracleImporter(const QString &_dataDir, QObject *parent = nullptr);
+    explicit OracleImporter(QObject *parent = nullptr);
     CardSet::Priority getSetPriority(QString &setType, QString &shortName);
     bool readSetsFromByteArray(const QByteArray &data);
     int startImport();
@@ -164,10 +163,6 @@ public:
     QList<SetToDownload> &getSets()
     {
         return allSets;
-    }
-    const QString &getDataDir() const
-    {
-        return dataDir;
     }
     void clear();
 

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -60,7 +60,7 @@ OracleWizard::OracleWizard(QWidget *parent) : QWizard(parent)
     settings = new QSettings(SettingsCache::instance().getSettingsPath() + "global.ini", QSettings::IniFormat, this);
     connect(&SettingsCache::instance(), &SettingsCache::langChanged, this, &OracleWizard::updateLanguage);
 
-    importer = new OracleImporter(SettingsCache::instance().getDataPath(), this);
+    importer = new OracleImporter(this);
 
     nam = new QNetworkAccessManager(this);
 


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5868

## What will change with this Pull Request?
- Remove unused or extraneous class variables.
- Make instance methods that don't need to be instance methods into static methods if able.
- Pass by const ref if able
- Join declaration and assignment if able