### PR TITLE
Refactor files in common to new Qt Slot/Signal syntax

### DIFF
--- a/common/server_game.cpp
+++ b/common/server_game.cpp
@@ -87,7 +87,7 @@ Server_Game::Server_Game(const ServerInfo_User &_creatorInfo,
 
     if (room->getServer()->getGameShouldPing()) {
         pingClock = new QTimer(this);
-        connect(pingClock, SIGNAL(timeout()), this, SLOT(pingClockTimeout()));
+        connect(pingClock, &QTimer::timeout, this, &Server_Game::pingClockTimeout);
         pingClock->start(1000);
     }
 }

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -36,7 +36,7 @@ Server_ProtocolHandler::Server_ProtocolHandler(Server *_server,
       idleClientWarningSent(false), timeRunning(0), lastDataReceived(0), lastActionReceived(0)
 
 {
-    connect(server, SIGNAL(pingClockTimeout()), this, SLOT(pingClockTimeout()));
+    connect(server, &Server::pingClockTimeout, this, &Server_ProtocolHandler::pingClockTimeout);
 }
 
 Server_ProtocolHandler::~Server_ProtocolHandler()

--- a/common/server_room.cpp
+++ b/common/server_room.cpp
@@ -31,8 +31,9 @@ Server_Room::Server_Room(int _id,
       permissionLevel(_permissionLevel), privilegeLevel(_privilegeLevel), autoJoin(_autoJoin),
       joinMessage(_joinMessage), gameTypes(_gameTypes), gamesLock(QReadWriteLock::Recursive)
 {
-    connect(this, SIGNAL(gameListChanged(ServerInfo_Game)), this, SLOT(broadcastGameListUpdate(ServerInfo_Game)),
-            Qt::QueuedConnection);
+    connect(
+        this, &Server_Room::gameListChanged, this, [this](auto gameInfo) { broadcastGameListUpdate(gameInfo); },
+        Qt::QueuedConnection);
 }
 
 Server_Room::~Server_Room()
@@ -352,7 +353,7 @@ void Server_Room::addGame(Server_Game *game)
     roomInfo.set_room_id(id);
 
     gamesLock.lockForWrite();
-    connect(game, SIGNAL(gameInfoChanged(ServerInfo_Game)), this, SLOT(broadcastGameListUpdate(ServerInfo_Game)));
+    connect(game, &Server_Game::gameInfoChanged, this, [this](auto gameInfo) { broadcastGameListUpdate(gameInfo); });
 
     game->gameMutex.lock();
     games.insert(game->getGameId(), game);


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5869

## What will change with this Pull Request?
- Update all usages of slot/signal in `common` to new syntax