### PR TITLE
CI: Fix install Qt step for Windows

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -380,7 +380,7 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           cache: true
-          setup-python: false
+          setup-python: true
           version: ${{matrix.qt_version}}
           arch: win64_${{matrix.qt_arch}}
           tools: ${{matrix.qt_tools}}


### PR DESCRIPTION
## Short roundup of the initial problem
There have been breaking changes and deprecations of old versions of the official action/cache by GitHub. We are updated in the repo for our workflow files since a while.
However, some actions that we use (e.g. install-qt and run-vcpkg) do also rely on it internally to provide caching and started to fail.

I did report this upstream last week, the maintainers are aware and partially have adapted already.

## What will change with this Pull Request?
- `install-qt` action is already updated, but "setup-python" needs to be performed

No solution for caching in the `run-vcpkg` action yet. GHA binary caching was used there, which will go away. A respective PR to remove the used internal APIs is already open in the vcpkg-tools repo. There is no obvious replacement or path yet.
This step takes ~20min to complete now, and cmake uses another ~40min to build the app (and dependencies) because of the missing cache and running vcpkg install again.
