### PR TITLE
Allow cards to transform directly on stack

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -2066,6 +2066,8 @@ void Player::createCard(const CardItem *sourceCard,
             break;
 
         case CardRelation::TransformInto:
+            // allow cards to directly transform on stack
+            cmd.set_zone(sourceCard->getZone()->getName() == "stack" ? "stack" : "table");
             // Transform card zone changes are handled server-side
             cmd.set_target_zone(sourceCard->getZone()->getName().toStdString());
             cmd.set_target_card_id(sourceCard->getId());


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5886

## Short roundup of the initial problem

Creating a transform token on the stack will move the card to the table.

https://github.com/user-attachments/assets/2fc3935c-6caf-4f66-8cb3-8c3fb7329e89

## What will change with this Pull Request?

Creating a transform token on the stack will leave the card on the stack

https://github.com/user-attachments/assets/6a337a41-bd0c-4877-b837-ed33f4ff53a3


