### PR TITLE
fix: Prevent dragged cards getting stuck

### DIFF
--- a/cockatrice/src/game/board/card_drag_item.cpp
+++ b/cockatrice/src/game/board/card_drag_item.cpp
@@ -47,8 +47,19 @@ void CardDragItem::updatePosition(const QPointF &cursorScenePos)
         cursorZone = zoneViewZone;
     else if (cardZone)
         cursorZone = cardZone;
-    if (!cursorZone)
+    if (!cursorZone) {
+        // Temporary fix: avoid the cards getting stuck visually when not over
+        // any zone.
+        QPointF newPos = cursorScenePos - hotSpot;
+
+        if (newPos != pos()) {
+            for (int i = 0; i < childDrags.size(); i++)
+                childDrags[i]->setPos(newPos + childDrags[i]->getHotSpot());
+            setPos(newPos);
+        }
+
         return;
+    }
     currentZone = cursorZone;
 
     QPointF zonePos = currentZone->scenePos();

--- a/cockatrice/src/game/board/card_drag_item.cpp
+++ b/cockatrice/src/game/board/card_drag_item.cpp
@@ -47,8 +47,13 @@ void CardDragItem::updatePosition(const QPointF &cursorScenePos)
         cursorZone = zoneViewZone;
     else if (cardZone)
         cursorZone = cardZone;
+
+    // Always update the current zone, even if its null, to cancel the drag
+    // instead of dropping cards into an non-intuitive location.
+    currentZone = cursorZone;
+
     if (!cursorZone) {
-        // Temporary fix: avoid the cards getting stuck visually when not over
+        // Avoid the cards getting stuck visually when not over
         // any zone.
         QPointF newPos = cursorScenePos - hotSpot;
 
@@ -60,7 +65,6 @@ void CardDragItem::updatePosition(const QPointF &cursorScenePos)
 
         return;
     }
-    currentZone = cursorZone;
 
     QPointF zonePos = currentZone->scenePos();
     QPointF cursorPosInZone = cursorScenePos - zonePos;


### PR DESCRIPTION
Update the position of the card even if it is not above any zone.

## Short roundup of the initial problem

Dragged cards' position does not get updated when the cursor is not over a valid zone, making it look like the card is "stuck".

## What will change with this Pull Request?

Cards keep moving even when the cursor is not over a zone.

## Screenshots

Before:

[Screencast From 2025-05-01 21-21-09.webm](https://github.com/user-attachments/assets/cd6cf831-7453-47da-9632-9905790f04a9)

After:

[Screencast From 2025-05-01 21-21-57.webm](https://github.com/user-attachments/assets/0f2925f2-de23-4691-886b-5e7e49d734cd)
