### PR TITLE
Move card view window's searchbar to bottom

### DIFF
--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -47,20 +47,6 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
 
     // If the number is < 0, then it means that we can give the option to make the area sorted
     if (numberCards < 0) {
-        // search edit
-        searchEdit.setFocusPolicy(Qt::ClickFocus);
-        searchEdit.setPlaceholderText(tr("Search by card name (or search expressions)"));
-        searchEdit.setClearButtonEnabled(true);
-        searchEdit.addAction(loadColorAdjustedPixmap("theme:icons/search"), QLineEdit::LeadingPosition);
-        auto help = searchEdit.addAction(QPixmap("theme:icons/info"), QLineEdit::TrailingPosition);
-
-        connect(help, &QAction::triggered, this, [this] { createSearchSyntaxHelpWindow(&searchEdit); });
-
-        QGraphicsProxyWidget *searchEditProxy = new QGraphicsProxyWidget;
-        searchEditProxy->setWidget(&searchEdit);
-        searchEditProxy->setZValue(2000000007);
-        vbox->addItem(searchEditProxy);
-
         // top row
         QGraphicsLinearLayout *hTopRow = new QGraphicsLinearLayout(Qt::Horizontal);
 
@@ -103,6 +89,20 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
         }
 
         vbox->addItem(hBottomRow);
+
+        // search edit
+        searchEdit.setFocusPolicy(Qt::ClickFocus);
+        searchEdit.setPlaceholderText(tr("Search by card name (or search expressions)"));
+        searchEdit.setClearButtonEnabled(true);
+        searchEdit.addAction(loadColorAdjustedPixmap("theme:icons/search"), QLineEdit::LeadingPosition);
+        auto help = searchEdit.addAction(QPixmap("theme:icons/info"), QLineEdit::TrailingPosition);
+
+        connect(help, &QAction::triggered, this, [this] { createSearchSyntaxHelpWindow(&searchEdit); });
+
+        QGraphicsProxyWidget *searchEditProxy = new QGraphicsProxyWidget;
+        searchEditProxy->setWidget(&searchEdit);
+        searchEditProxy->setZValue(2000000006);
+        vbox->addItem(searchEditProxy);
     }
 
     extraHeight = vbox->sizeHint(Qt::PreferredSize).height();


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5791

## Short roundup of the initial problem

Even though putting the search bar at the top of the card view window's menus looks more pleasing aesthetically, I think moving the search bar to the bottom is better for users, since there's less distance between typing and selecting.

## What will change with this Pull Request?

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

Before

<img width="446" alt="Screenshot 2025-05-02 at 10 56 35 PM" src="https://github.com/user-attachments/assets/cf5cd9e1-91c6-4f27-87e2-6dbc23f6e4c7" />

After

<img width="445" alt="Screenshot 2025-05-02 at 10 56 18 PM" src="https://github.com/user-attachments/assets/e432b6d4-f27e-4916-b16a-fe19417059bf" />
