### PR TITLE
[VDS] Add setting to show deck filepath in tooltip

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -46,6 +46,8 @@ DeckPreviewWidget::DeckPreviewWidget(QWidget *_parent,
             &DeckPreviewWidget::updateTagsVisibility);
     connect(&SettingsCache::instance(), &SettingsCache::visualDeckStorageShowBannerCardComboBoxChanged, this,
             &DeckPreviewWidget::updateBannerCardComboBoxVisibility);
+    connect(visualDeckStorageWidget->settings(), &VisualDeckStorageQuickSettingsWidget::deckPreviewTooltipChanged, this,
+            &DeckPreviewWidget::refreshBannerCardToolTip);
 
     layout->addWidget(bannerCardDisplayWidget);
 }
@@ -79,7 +81,6 @@ void DeckPreviewWidget::initializeUi(const bool deckLoadSuccess)
 
     bannerCardDisplayWidget->setCard(bannerCard);
     bannerCardDisplayWidget->setFontSize(24);
-    refreshBannerCardText();
     setFilePath(deckLoader->getLastFileName());
 
     colorIdentityWidget = new ColorIdentityWidget(this, getColorIdentity());
@@ -103,6 +104,8 @@ void DeckPreviewWidget::initializeUi(const bool deckLoadSuccess)
     layout->addWidget(deckTagsDisplayWidget);
     layout->addWidget(bannerCardLabel);
     layout->addWidget(bannerCardComboBox);
+
+    refreshBannerCardText();
 
     retranslateUi();
 }
@@ -184,11 +187,29 @@ void DeckPreviewWidget::setFilePath(const QString &_filePath)
     filePath = _filePath;
 }
 
+/**
+ * Refreshes the banner card text.
+ * This also calls `refreshBannerCardToolTip`, since those two often need to be updated together.
+ */
 void DeckPreviewWidget::refreshBannerCardText()
 {
     bannerCardDisplayWidget->setOverlayText(
         deckLoader->getName().isEmpty() ? QFileInfo(deckLoader->getLastFileName()).fileName() : deckLoader->getName());
-    bannerCardDisplayWidget->setToolTip(deckLoader->getLastFileName());
+
+    refreshBannerCardToolTip();
+}
+
+void DeckPreviewWidget::refreshBannerCardToolTip()
+{
+    auto type = visualDeckStorageWidget->settings()->getDeckPreviewTooltip();
+    switch (type) {
+        case VisualDeckStorageQuickSettingsWidget::TooltipType::None:
+            bannerCardDisplayWidget->setToolTip("");
+            break;
+        case VisualDeckStorageQuickSettingsWidget::TooltipType::Filepath:
+            bannerCardDisplayWidget->setToolTip(filePath);
+            break;
+    }
 }
 
 void DeckPreviewWidget::updateBannerCardComboBox()

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -188,6 +188,7 @@ void DeckPreviewWidget::refreshBannerCardText()
 {
     bannerCardDisplayWidget->setOverlayText(
         deckLoader->getName().isEmpty() ? QFileInfo(deckLoader->getLastFileName()).fileName() : deckLoader->getName());
+    bannerCardDisplayWidget->setToolTip(deckLoader->getLastFileName());
 }
 
 void DeckPreviewWidget::updateBannerCardComboBox()

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
@@ -49,6 +49,7 @@ signals:
 public slots:
     void setFilePath(const QString &filePath);
     void refreshBannerCardText();
+    void refreshBannerCardToolTip();
     void updateBannerCardComboBox();
     void setBannerCard(int);
     void imageClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.cpp
@@ -4,6 +4,7 @@
 #include "visual_deck_storage_widget.h"
 
 #include <QCheckBox>
+#include <QComboBox>
 #include <QSpinBox>
 
 VisualDeckStorageQuickSettingsWidget::VisualDeckStorageQuickSettingsWidget(QWidget *parent)
@@ -80,6 +81,26 @@ VisualDeckStorageQuickSettingsWidget::VisualDeckStorageQuickSettingsWidget(QWidg
     unusedColorIdentityOpacityLayout->addWidget(unusedColorIdentitiesOpacityLabel);
     unusedColorIdentityOpacityLayout->addWidget(unusedColorIdentitiesOpacitySpinBox);
 
+    // tooltip selector
+    auto deckPreviewTooltipWidget = new QWidget(this);
+
+    deckPreviewTooltipLabel = new QLabel(deckPreviewTooltipWidget);
+    deckPreviewTooltipComboBox = new QComboBox(deckPreviewTooltipWidget);
+    deckPreviewTooltipComboBox->setFocusPolicy(Qt::StrongFocus);
+    deckPreviewTooltipComboBox->addItem("", TooltipType::None);
+    deckPreviewTooltipComboBox->addItem("", TooltipType::Filepath);
+
+    deckPreviewTooltipComboBox->setCurrentIndex(SettingsCache::instance().getVisualDeckStorageTooltipType());
+    connect(deckPreviewTooltipComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            [this] { emit deckPreviewTooltipChanged(getDeckPreviewTooltip()); });
+    connect(deckPreviewTooltipComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), &SettingsCache::instance(),
+            &SettingsCache::setVisualDeckStorageTooltipType);
+
+    auto deckPreviewTooltipLayout = new QHBoxLayout(deckPreviewTooltipWidget);
+    deckPreviewTooltipLayout->setContentsMargins(11, 0, 11, 0);
+    deckPreviewTooltipLayout->addWidget(deckPreviewTooltipLabel);
+    deckPreviewTooltipLayout->addWidget(deckPreviewTooltipComboBox);
+
     // card size slider
     cardSizeWidget = new CardSizeWidget(this, nullptr, SettingsCache::instance().getVisualDeckStorageCardSize());
     connect(cardSizeWidget->getSlider(), &QSlider::valueChanged, this,
@@ -95,6 +116,7 @@ VisualDeckStorageQuickSettingsWidget::VisualDeckStorageQuickSettingsWidget(QWidg
     this->addSettingsWidget(searchFolderNamesCheckBox);
     this->addSettingsWidget(drawUnusedColorIdentitiesCheckBox);
     this->addSettingsWidget(unusedColorIdentityOpacityWidget);
+    this->addSettingsWidget(deckPreviewTooltipWidget);
     this->addSettingsWidget(cardSizeWidget);
 
     connect(&SettingsCache::instance(), &SettingsCache::langChanged, this,
@@ -112,6 +134,10 @@ void VisualDeckStorageQuickSettingsWidget::retranslateUi()
     drawUnusedColorIdentitiesCheckBox->setText(tr("Draw unused Color Identities"));
     unusedColorIdentitiesOpacityLabel->setText(tr("Unused Color Identities Opacity"));
     unusedColorIdentitiesOpacitySpinBox->setSuffix("%");
+
+    deckPreviewTooltipLabel->setText(tr("Deck tooltip:"));
+    deckPreviewTooltipComboBox->setItemText(0, tr("None"));
+    deckPreviewTooltipComboBox->setItemText(1, tr("Filepath"));
 }
 
 bool VisualDeckStorageQuickSettingsWidget::getShowFolders() const
@@ -147,6 +173,11 @@ bool VisualDeckStorageQuickSettingsWidget::getSearchFolderNames() const
 int VisualDeckStorageQuickSettingsWidget::getUnusedColorIdentitiesOpacity() const
 {
     return unusedColorIdentitiesOpacitySpinBox->value();
+}
+
+VisualDeckStorageQuickSettingsWidget::TooltipType VisualDeckStorageQuickSettingsWidget::getDeckPreviewTooltip() const
+{
+    return deckPreviewTooltipComboBox->currentData().value<TooltipType>();
 }
 
 int VisualDeckStorageQuickSettingsWidget::getCardSize() const

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.h
@@ -39,6 +39,7 @@ public:
         None,
         Filepath
     };
+    Q_ENUM(TooltipType)
 
     explicit VisualDeckStorageQuickSettingsWidget(QWidget *parent = nullptr);
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.h
@@ -7,6 +7,7 @@ class CardSizeWidget;
 class QLabel;
 class QSpinBox;
 class QCheckBox;
+class QComboBox;
 
 /**
  * The VDS's quick settings menu.
@@ -25,9 +26,20 @@ class VisualDeckStorageQuickSettingsWidget : public SettingsButtonWidget
     QCheckBox *searchFolderNamesCheckBox;
     QLabel *unusedColorIdentitiesOpacityLabel;
     QSpinBox *unusedColorIdentitiesOpacitySpinBox;
+    QLabel *deckPreviewTooltipLabel;
+    QComboBox *deckPreviewTooltipComboBox;
     CardSizeWidget *cardSizeWidget;
 
 public:
+    /**
+     * The info to display in the deck preview's banner card tooltip.
+     */
+    enum TooltipType
+    {
+        None,
+        Filepath
+    };
+
     explicit VisualDeckStorageQuickSettingsWidget(QWidget *parent = nullptr);
 
     void retranslateUi();
@@ -39,6 +51,7 @@ public:
     bool getShowTagsOnDeckPreviews() const;
     bool getSearchFolderNames() const;
     int getUnusedColorIdentitiesOpacity() const;
+    TooltipType getDeckPreviewTooltip() const;
     int getCardSize() const;
 
 signals:
@@ -49,6 +62,7 @@ signals:
     void showTagsOnDeckPreviewsChanged(bool enabled);
     void searchFolderNamesChanged(bool enabled);
     void unusedColorIdentitiesOpacityChanged(int opacity);
+    void deckPreviewTooltipChanged(TooltipType tooltip);
     void cardSizeChanged(int scale);
 };
 

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -280,6 +280,7 @@ SettingsCache::SettingsCache()
         settings->value("interface/visualdeckstoragedrawunusedcoloridentities", true).toBool();
     visualDeckStorageUnusedColorIdentitiesOpacity =
         settings->value("interface/visualdeckstorageunusedcoloridentitiesopacity", 15).toInt();
+    visualDeckStorageTooltipType = settings->value("interface/visualdeckstoragetooltiptype", 0).toInt();
     visualDeckStoragePromptForConversion =
         settings->value("interface/visualdeckstoragepromptforconversion", true).toBool();
     visualDeckStorageAlwaysConvert = settings->value("interface/visualdeckstoragealwaysconvert", false).toBool();
@@ -772,6 +773,12 @@ void SettingsCache::setVisualDeckStorageUnusedColorIdentitiesOpacity(int _visual
     settings->setValue("interface/visualdeckstorageunusedcoloridentitiesopacity",
                        visualDeckStorageUnusedColorIdentitiesOpacity);
     emit visualDeckStorageUnusedColorIdentitiesOpacityChanged(visualDeckStorageUnusedColorIdentitiesOpacity);
+}
+
+void SettingsCache::setVisualDeckStorageTooltipType(int value)
+{
+    visualDeckStorageTooltipType = value;
+    settings->setValue("interface/visualdeckstoragetooltiptype", visualDeckStorageTooltipType);
 }
 
 void SettingsCache::setVisualDeckStoragePromptForConversion(bool _visualDeckStoragePromptForConversion)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -150,6 +150,7 @@ private:
     int visualDeckStorageCardSize;
     bool visualDeckStorageDrawUnusedColorIdentities;
     int visualDeckStorageUnusedColorIdentitiesOpacity;
+    int visualDeckStorageTooltipType;
     bool visualDeckStoragePromptForConversion;
     bool visualDeckStorageAlwaysConvert;
     bool visualDeckStorageInGame;
@@ -475,6 +476,10 @@ public:
     int getVisualDeckStorageUnusedColorIdentitiesOpacity() const
     {
         return visualDeckStorageUnusedColorIdentitiesOpacity;
+    }
+    int getVisualDeckStorageTooltipType() const
+    {
+        return visualDeckStorageTooltipType;
     }
     bool getVisualDeckStoragePromptForConversion() const
     {
@@ -852,6 +857,7 @@ public slots:
     void setVisualDeckStorageCardSize(int _visualDeckStorageCardSize);
     void setVisualDeckStorageDrawUnusedColorIdentities(QT_STATE_CHANGED_T _visualDeckStorageDrawUnusedColorIdentities);
     void setVisualDeckStorageUnusedColorIdentitiesOpacity(int _visualDeckStorageUnusedColorIdentitiesOpacity);
+    void setVisualDeckStorageTooltipType(int value);
     void setVisualDeckStoragePromptForConversion(bool _visualDeckStoragePromptForConversion);
     void setVisualDeckStorageAlwaysConvert(bool _visualDeckStorageAlwaysConvert);
     void setVisualDeckStorageInGame(QT_STATE_CHANGED_T value);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -247,6 +247,9 @@ void SettingsCache::setVisualDeckStorageUnusedColorIdentitiesOpacity(
     int /* _visualDeckStorageUnusedColorIdentitiesOpacity */)
 {
 }
+void SettingsCache::setVisualDeckStorageTooltipType(int /* value */)
+{
+}
 void SettingsCache::setVisualDeckStoragePromptForConversion(bool /* _visualDeckStoragePromptForConversion */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -251,6 +251,9 @@ void SettingsCache::setVisualDeckStorageUnusedColorIdentitiesOpacity(
     int /* _visualDeckStorageUnusedColorIdentitiesOpacity */)
 {
 }
+void SettingsCache::setVisualDeckStorageTooltipType(int /* value */)
+{
+}
 void SettingsCache::setVisualDeckStoragePromptForConversion(bool /* _visualDeckStoragePromptForConversion */)
 {
 }


### PR DESCRIPTION
## Short roundup of the initial problem

Sometimes it's hard to figure out which exact file you're opening while in the VDS.

## What will change with this Pull Request?

- Also set the `BannerCardDisplayWidget`'s tooltip to the deck's filepath whenever the overlay text is refreshed.
- This means a tooltip with the deck filepath will pop up if you hover over a banner card for a bit

https://github.com/user-attachments/assets/86dcd185-8fc3-495b-942e-0785241e95e6

