### PR TITLE
ci: temporarily remove run-vcpkg step

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -387,7 +387,9 @@ jobs:
           tools: ${{matrix.qt_tools}}
           modules: ${{matrix.qt_modules}}
 
-      - name: Run vcpkg
+      # TODO: re-enable when https://github.com/lukka/run-vcpkg/issues/243 is fixed
+      - if: false
+        name: Run vcpkg (disabled)
         uses: lukka/run-vcpkg@v11
         with:
           runVcpkgInstall: true


### PR DESCRIPTION
## Related Ticket(s)
- Workaround for https://github.com/lukka/run-vcpkg/issues/243

## Short roundup of the initial problem
Windows builds are taking around 1h to complete due to an issue with caching in run-vcpkg.

## What will change with this Pull Request?
- good: windows builds are 20min faster
- bad: the step should be re-enabled when the upstream issue is fixed
