### PR TITLE
Refactor CardSizeWidget: don't update setting directly

### DIFF
--- a/cockatrice/src/client/ui/widgets/cards/card_size_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_size_widget.cpp
@@ -34,14 +34,7 @@ CardSizeWidget::CardSizeWidget(QWidget *parent, FlowWidget *_flowWidget, int def
 
     // Debounce setup
     debounceTimer.setSingleShot(true);
-    connect(&debounceTimer, &QTimer::timeout, this, [this]() {
-        // Check the type of the parent widget
-        if (qobject_cast<PrintingSelector *>(parentWidget())) {
-            SettingsCache::instance().setPrintingSelectorCardSize(pendingValue);
-        } else if (qobject_cast<VisualDeckStorageWidget *>(parentWidget())) {
-            SettingsCache::instance().setVisualDeckStorageCardSize(pendingValue);
-        }
-    });
+    connect(&debounceTimer, &QTimer::timeout, this, [this] { emit cardSizeSettingUpdated(pendingValue); });
 
     connect(cardSizeSlider, &QSlider::valueChanged, this, &CardSizeWidget::updateCardSizeSetting);
 }

--- a/cockatrice/src/client/ui/widgets/cards/card_size_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_size_widget.h
@@ -17,8 +17,16 @@ public:
     explicit CardSizeWidget(QWidget *parent, FlowWidget *flowWidget = nullptr, int defaultValue = 100);
     [[nodiscard]] QSlider *getSlider() const;
 
-public slots:
+private slots:
     void updateCardSizeSetting(int newValue);
+
+signals:
+    /**
+     * Emitted when the slider value changes, but on a debounce timer.
+     * Any parents that care about saving the value to settings should use this signal to indicate when to save the new
+     * value to settings.
+     */
+    void cardSizeSettingUpdated(int newValue);
 
 private:
     QWidget *parent;

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
@@ -70,6 +70,8 @@ PrintingSelector::PrintingSelector(QWidget *parent, AbstractTabDeckEditor *_deck
 
     cardSizeWidget =
         new CardSizeWidget(displayOptionsWidget, flowWidget, SettingsCache::instance().getPrintingSelectorCardSize());
+    connect(cardSizeWidget, &CardSizeWidget::cardSizeSettingUpdated, &SettingsCache::instance(),
+            &SettingsCache::setPrintingSelectorCardSize);
 
     displayOptionsWidget->addSettingsWidget(sortToolBar);
     displayOptionsWidget->addSettingsWidget(navigationCheckBox);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -104,6 +104,8 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
 
     // card size slider
     cardSizeWidget = new CardSizeWidget(this, nullptr, SettingsCache::instance().getVisualDeckStorageCardSize());
+    connect(cardSizeWidget, &CardSizeWidget::cardSizeSettingUpdated, &SettingsCache::instance(),
+            &SettingsCache::setVisualDeckStorageCardSize);
 
     quickSettingsWidget = new SettingsButtonWidget(this);
     quickSettingsWidget->addSettingsWidget(showFoldersCheckBox);


### PR DESCRIPTION
## Short roundup of the initial problem

The code inside `CardSizeWidget` that updates the `SettingsCache` directly type checks the parent widget in order to determine which setting to update. This is not ideal and can break on refactoring.

## What will change with this Pull Request?
- `CardSizeWidget` now emits a `cardSizeSettingUpdated` signal when the debounce timer runs out
  - The parent widget can then connect that signal to update the `SettingsCache`.
- Also made `updateCardSizeSetting` private since it's not used anywhere else.
