### PR TITLE
[VDS] Refactor: move quick settings to separate class

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -135,6 +135,7 @@ set(cockatrice_SOURCES
     src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_item_widget.cpp
     src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
     src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
+    src/client/ui/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.cpp
     src/client/ui/widgets/visual_deck_storage/visual_deck_storage_search_widget.cpp
     src/client/ui/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
     src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
@@ -90,9 +90,9 @@ void VisualDeckStorageFolderDisplayWidget::createWidgetsForFiles()
                 &VisualDeckStorageWidget::deckLoadRequested);
         connect(display, &DeckPreviewWidget::openDeckEditor, visualDeckStorageWidget,
                 &VisualDeckStorageWidget::openDeckEditor);
-        connect(visualDeckStorageWidget->cardSizeWidget->getSlider(), &QSlider::valueChanged,
+        connect(visualDeckStorageWidget->settings(), &VisualDeckStorageQuickSettingsWidget::cardSizeChanged,
                 display->bannerCardDisplayWidget, &CardInfoPictureWidget::setScaleFactor);
-        display->bannerCardDisplayWidget->setScaleFactor(visualDeckStorageWidget->cardSizeWidget->getSlider()->value());
+        display->bannerCardDisplayWidget->setScaleFactor(visualDeckStorageWidget->settings()->getCardSize());
         allDecks.append(display);
     }
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.cpp
@@ -1,0 +1,155 @@
+#include "visual_deck_storage_quick_settings_widget.h"
+
+#include "../../../../settings/cache_settings.h"
+#include "visual_deck_storage_widget.h"
+
+#include <QCheckBox>
+#include <QSpinBox>
+
+VisualDeckStorageQuickSettingsWidget::VisualDeckStorageQuickSettingsWidget(QWidget *parent)
+    : SettingsButtonWidget(parent)
+{
+    // show folders checkbox
+    showFoldersCheckBox = new QCheckBox(this);
+    showFoldersCheckBox->setChecked(SettingsCache::instance().getVisualDeckStorageShowFolders());
+    connect(showFoldersCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+            &VisualDeckStorageQuickSettingsWidget::showFoldersChanged);
+    connect(showFoldersCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setVisualDeckStorageShowFolders);
+
+    // show tag filter widget checkbox
+    showTagFilterCheckBox = new QCheckBox(this);
+    showTagFilterCheckBox->setChecked(SettingsCache::instance().getVisualDeckStorageShowTagFilter());
+    connect(showTagFilterCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+            &VisualDeckStorageQuickSettingsWidget::showTagFilterChanged);
+    connect(showTagFilterCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setVisualDeckStorageShowTagFilter);
+
+    // show tags on DeckPreviewWidget checkbox
+    showTagsOnDeckPreviewsCheckBox = new QCheckBox(this);
+    showTagsOnDeckPreviewsCheckBox->setChecked(SettingsCache::instance().getVisualDeckStorageShowTagsOnDeckPreviews());
+    connect(showTagsOnDeckPreviewsCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+            &VisualDeckStorageQuickSettingsWidget::showTagsOnDeckPreviewsChanged);
+    connect(showTagsOnDeckPreviewsCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setVisualDeckStorageShowTagsOnDeckPreviews);
+
+    // show banner card selector checkbox
+    showBannerCardComboBoxCheckBox = new QCheckBox(this);
+    showBannerCardComboBoxCheckBox->setChecked(SettingsCache::instance().getVisualDeckStorageShowBannerCardComboBox());
+    connect(showBannerCardComboBoxCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+            &VisualDeckStorageQuickSettingsWidget::showBannerCardComboBoxChanged);
+    connect(showBannerCardComboBoxCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setVisualDeckStorageShowBannerCardComboBox);
+
+    // search folder names checkbox
+    searchFolderNamesCheckBox = new QCheckBox(this);
+    searchFolderNamesCheckBox->setChecked(SettingsCache::instance().getVisualDeckStorageSearchFolderNames());
+    connect(searchFolderNamesCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+            &VisualDeckStorageQuickSettingsWidget::searchFolderNamesChanged);
+    connect(searchFolderNamesCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setVisualDeckStorageSearchFolderNames);
+
+    // draw unused color identities checkbox
+    drawUnusedColorIdentitiesCheckBox = new QCheckBox(this);
+    drawUnusedColorIdentitiesCheckBox->setChecked(
+        SettingsCache::instance().getVisualDeckStorageDrawUnusedColorIdentities());
+    connect(drawUnusedColorIdentitiesCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+            &VisualDeckStorageQuickSettingsWidget::drawUnusedColorIdentitiesChanged);
+    connect(drawUnusedColorIdentitiesCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setVisualDeckStorageDrawUnusedColorIdentities);
+
+    // color identity opacity selector
+    auto unusedColorIdentityOpacityWidget = new QWidget(this);
+
+    unusedColorIdentitiesOpacityLabel = new QLabel(unusedColorIdentityOpacityWidget);
+    unusedColorIdentitiesOpacitySpinBox = new QSpinBox(unusedColorIdentityOpacityWidget);
+
+    unusedColorIdentitiesOpacitySpinBox->setMinimum(0);
+    unusedColorIdentitiesOpacitySpinBox->setMaximum(100);
+    unusedColorIdentitiesOpacitySpinBox->setValue(
+        SettingsCache::instance().getVisualDeckStorageUnusedColorIdentitiesOpacity());
+    connect(unusedColorIdentitiesOpacitySpinBox, QOverload<int>::of(&QSpinBox::valueChanged), this,
+            &VisualDeckStorageQuickSettingsWidget::unusedColorIdentitiesOpacityChanged);
+    connect(unusedColorIdentitiesOpacitySpinBox, QOverload<int>::of(&QSpinBox::valueChanged),
+            &SettingsCache::instance(), &SettingsCache::setVisualDeckStorageUnusedColorIdentitiesOpacity);
+
+    unusedColorIdentitiesOpacityLabel->setBuddy(unusedColorIdentitiesOpacitySpinBox);
+
+    auto unusedColorIdentityOpacityLayout = new QHBoxLayout(unusedColorIdentityOpacityWidget);
+    unusedColorIdentityOpacityLayout->setContentsMargins(11, 0, 11, 0);
+    unusedColorIdentityOpacityLayout->addWidget(unusedColorIdentitiesOpacityLabel);
+    unusedColorIdentityOpacityLayout->addWidget(unusedColorIdentitiesOpacitySpinBox);
+
+    // card size slider
+    cardSizeWidget = new CardSizeWidget(this, nullptr, SettingsCache::instance().getVisualDeckStorageCardSize());
+    connect(cardSizeWidget->getSlider(), &QSlider::valueChanged, this,
+            &VisualDeckStorageQuickSettingsWidget::cardSizeChanged);
+    connect(cardSizeWidget, &CardSizeWidget::cardSizeSettingUpdated, &SettingsCache::instance(),
+            &SettingsCache::setVisualDeckStorageCardSize);
+
+    // putting everything together
+    this->addSettingsWidget(showFoldersCheckBox);
+    this->addSettingsWidget(showTagFilterCheckBox);
+    this->addSettingsWidget(showTagsOnDeckPreviewsCheckBox);
+    this->addSettingsWidget(showBannerCardComboBoxCheckBox);
+    this->addSettingsWidget(searchFolderNamesCheckBox);
+    this->addSettingsWidget(drawUnusedColorIdentitiesCheckBox);
+    this->addSettingsWidget(unusedColorIdentityOpacityWidget);
+    this->addSettingsWidget(cardSizeWidget);
+
+    connect(&SettingsCache::instance(), &SettingsCache::langChanged, this,
+            &VisualDeckStorageQuickSettingsWidget::retranslateUi);
+    retranslateUi();
+}
+
+void VisualDeckStorageQuickSettingsWidget::retranslateUi()
+{
+    showFoldersCheckBox->setText(tr("Show Folders"));
+    showTagFilterCheckBox->setText(tr("Show Tag Filter"));
+    showTagsOnDeckPreviewsCheckBox->setText(tr("Show Tags On Deck Previews"));
+    showBannerCardComboBoxCheckBox->setText(tr("Show Banner Card Selection Option"));
+    searchFolderNamesCheckBox->setText(tr("Include Folder Names in Search"));
+    drawUnusedColorIdentitiesCheckBox->setText(tr("Draw unused Color Identities"));
+    unusedColorIdentitiesOpacityLabel->setText(tr("Unused Color Identities Opacity"));
+    unusedColorIdentitiesOpacitySpinBox->setSuffix("%");
+}
+
+bool VisualDeckStorageQuickSettingsWidget::getShowFolders() const
+{
+    return showFoldersCheckBox->isChecked();
+}
+
+bool VisualDeckStorageQuickSettingsWidget::getDrawUnusedColorIdentities() const
+{
+    return drawUnusedColorIdentitiesCheckBox->isChecked();
+}
+
+bool VisualDeckStorageQuickSettingsWidget::getShowBannerCardComboBox() const
+{
+    return showBannerCardComboBoxCheckBox->isChecked();
+}
+
+bool VisualDeckStorageQuickSettingsWidget::getShowTagFilter() const
+{
+    return showTagFilterCheckBox->isChecked();
+}
+
+bool VisualDeckStorageQuickSettingsWidget::getShowTagsOnDeckPreviews() const
+{
+    return showTagsOnDeckPreviewsCheckBox->isChecked();
+}
+
+bool VisualDeckStorageQuickSettingsWidget::getSearchFolderNames() const
+{
+    return searchFolderNamesCheckBox->isChecked();
+}
+
+int VisualDeckStorageQuickSettingsWidget::getUnusedColorIdentitiesOpacity() const
+{
+    return unusedColorIdentitiesOpacitySpinBox->value();
+}
+
+int VisualDeckStorageQuickSettingsWidget::getCardSize() const
+{
+    return cardSizeWidget->getSlider()->value();
+}

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.h
@@ -1,0 +1,55 @@
+#ifndef VISUAL_DECK_STORAGE_QUICK_SETTINGS_WIDGET_H
+#define VISUAL_DECK_STORAGE_QUICK_SETTINGS_WIDGET_H
+
+#include "../quick_settings/settings_button_widget.h"
+
+class CardSizeWidget;
+class QLabel;
+class QSpinBox;
+class QCheckBox;
+
+/**
+ * The VDS's quick settings menu.
+ * Manages the widgets in the quick settings menu dropdown, as well as syncing their values with SettingsCache.
+ * The current values of the settings are exposed through getters and signals.
+ */
+class VisualDeckStorageQuickSettingsWidget : public SettingsButtonWidget
+{
+    Q_OBJECT
+
+    QCheckBox *showFoldersCheckBox;
+    QCheckBox *drawUnusedColorIdentitiesCheckBox;
+    QCheckBox *showBannerCardComboBoxCheckBox;
+    QCheckBox *showTagFilterCheckBox;
+    QCheckBox *showTagsOnDeckPreviewsCheckBox;
+    QCheckBox *searchFolderNamesCheckBox;
+    QLabel *unusedColorIdentitiesOpacityLabel;
+    QSpinBox *unusedColorIdentitiesOpacitySpinBox;
+    CardSizeWidget *cardSizeWidget;
+
+public:
+    explicit VisualDeckStorageQuickSettingsWidget(QWidget *parent = nullptr);
+
+    void retranslateUi();
+
+    bool getShowFolders() const;
+    bool getDrawUnusedColorIdentities() const;
+    bool getShowBannerCardComboBox() const;
+    bool getShowTagFilter() const;
+    bool getShowTagsOnDeckPreviews() const;
+    bool getSearchFolderNames() const;
+    int getUnusedColorIdentitiesOpacity() const;
+    int getCardSize() const;
+
+signals:
+    void showFoldersChanged(bool enabled);
+    void drawUnusedColorIdentitiesChanged(bool enabled);
+    void showBannerCardComboBoxChanged(bool enabled);
+    void showTagFilterChanged(bool enabled);
+    void showTagsOnDeckPreviewsChanged(bool enabled);
+    void searchFolderNamesChanged(bool enabled);
+    void unusedColorIdentitiesOpacityChanged(int opacity);
+    void cardSizeChanged(int scale);
+};
+
+#endif // VISUAL_DECK_STORAGE_QUICK_SETTINGS_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -41,81 +41,13 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     refreshButton->setFixedSize(32, 32);
     connect(refreshButton, &QPushButton::clicked, this, &VisualDeckStorageWidget::refreshIfPossible);
 
-    // quick settings menu
-    showFoldersCheckBox = new QCheckBox(this);
-    showFoldersCheckBox->setChecked(SettingsCache::instance().getVisualDeckStorageShowFolders());
-    connect(showFoldersCheckBox, &QCheckBox::QT_STATE_CHANGED, this, &VisualDeckStorageWidget::updateShowFolders);
-    connect(showFoldersCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
-            &SettingsCache::setVisualDeckStorageShowFolders);
-
-    tagFilterVisibilityCheckBox = new QCheckBox(this);
-    tagFilterVisibilityCheckBox->setChecked(SettingsCache::instance().getVisualDeckStorageShowTagFilter());
-    connect(tagFilterVisibilityCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+    quickSettingsWidget = new VisualDeckStorageQuickSettingsWidget(this);
+    connect(quickSettingsWidget, &VisualDeckStorageQuickSettingsWidget::showFoldersChanged, this,
+            &VisualDeckStorageWidget::updateShowFolders);
+    connect(quickSettingsWidget, &VisualDeckStorageQuickSettingsWidget::showTagFilterChanged, this,
             &VisualDeckStorageWidget::updateTagsVisibility);
-    connect(tagFilterVisibilityCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
-            &SettingsCache::setVisualDeckStorageShowTagFilter);
-
-    tagsOnWidgetsVisibilityCheckBox = new QCheckBox(this);
-    tagsOnWidgetsVisibilityCheckBox->setChecked(SettingsCache::instance().getVisualDeckStorageShowTagsOnDeckPreviews());
-    connect(tagsOnWidgetsVisibilityCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
-            &SettingsCache::setVisualDeckStorageShowTagsOnDeckPreviews);
-
-    drawUnusedColorIdentitiesCheckBox = new QCheckBox(this);
-    drawUnusedColorIdentitiesCheckBox->setChecked(
-        SettingsCache::instance().getVisualDeckStorageDrawUnusedColorIdentities());
-    connect(drawUnusedColorIdentitiesCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
-            &SettingsCache::setVisualDeckStorageDrawUnusedColorIdentities);
-
-    bannerCardComboBoxVisibilityCheckBox = new QCheckBox(this);
-    bannerCardComboBoxVisibilityCheckBox->setChecked(
-        SettingsCache::instance().getVisualDeckStorageShowBannerCardComboBox());
-    connect(bannerCardComboBoxVisibilityCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
-            &SettingsCache::setVisualDeckStorageShowBannerCardComboBox);
-
-    searchFolderNamesCheckBox = new QCheckBox(this);
-    searchFolderNamesCheckBox->setChecked(SettingsCache::instance().getVisualDeckStorageSearchFolderNames());
-    connect(searchFolderNamesCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+    connect(quickSettingsWidget, &VisualDeckStorageQuickSettingsWidget::searchFolderNamesChanged, this,
             &VisualDeckStorageWidget::updateSearchFilter);
-    connect(searchFolderNamesCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
-            &SettingsCache::setVisualDeckStorageSearchFolderNames);
-
-    // color identity opacity selector
-    auto unusedColorIdentityOpacityWidget = new QWidget(this);
-
-    unusedColorIdentitiesOpacityLabel = new QLabel(unusedColorIdentityOpacityWidget);
-    unusedColorIdentitiesOpacitySpinBox = new QSpinBox(unusedColorIdentityOpacityWidget);
-
-    unusedColorIdentitiesOpacitySpinBox->setMinimum(0);
-    unusedColorIdentitiesOpacitySpinBox->setMaximum(100);
-    unusedColorIdentitiesOpacitySpinBox->setValue(
-        SettingsCache::instance().getVisualDeckStorageUnusedColorIdentitiesOpacity());
-    connect(unusedColorIdentitiesOpacitySpinBox, QOverload<int>::of(&QSpinBox::valueChanged),
-            &SettingsCache::instance(), &SettingsCache::setVisualDeckStorageUnusedColorIdentitiesOpacity);
-
-    unusedColorIdentitiesOpacityLabel->setBuddy(unusedColorIdentitiesOpacitySpinBox);
-
-    unusedColorIdentitiesOpacitySpinBox->setValue(
-        SettingsCache::instance().getVisualDeckStorageUnusedColorIdentitiesOpacity());
-
-    auto unusedColorIdentityOpacityLayout = new QHBoxLayout(unusedColorIdentityOpacityWidget);
-    unusedColorIdentityOpacityLayout->setContentsMargins(11, 0, 11, 0);
-    unusedColorIdentityOpacityLayout->addWidget(unusedColorIdentitiesOpacityLabel);
-    unusedColorIdentityOpacityLayout->addWidget(unusedColorIdentitiesOpacitySpinBox);
-
-    // card size slider
-    cardSizeWidget = new CardSizeWidget(this, nullptr, SettingsCache::instance().getVisualDeckStorageCardSize());
-    connect(cardSizeWidget, &CardSizeWidget::cardSizeSettingUpdated, &SettingsCache::instance(),
-            &SettingsCache::setVisualDeckStorageCardSize);
-
-    quickSettingsWidget = new SettingsButtonWidget(this);
-    quickSettingsWidget->addSettingsWidget(showFoldersCheckBox);
-    quickSettingsWidget->addSettingsWidget(tagFilterVisibilityCheckBox);
-    quickSettingsWidget->addSettingsWidget(tagsOnWidgetsVisibilityCheckBox);
-    quickSettingsWidget->addSettingsWidget(bannerCardComboBoxVisibilityCheckBox);
-    quickSettingsWidget->addSettingsWidget(searchFolderNamesCheckBox);
-    quickSettingsWidget->addSettingsWidget(drawUnusedColorIdentitiesCheckBox);
-    quickSettingsWidget->addSettingsWidget(unusedColorIdentityOpacityWidget);
-    quickSettingsWidget->addSettingsWidget(cardSizeWidget);
 
     searchAndSortLayout->addWidget(deckPreviewColorIdentityFilterWidget);
     searchAndSortLayout->addWidget(sortWidget);
@@ -188,17 +120,16 @@ void VisualDeckStorageWidget::retranslateUi()
 {
     databaseLoadIndicator->setText(tr("Loading database ..."));
 
-    showFoldersCheckBox->setText(tr("Show Folders"));
-    tagFilterVisibilityCheckBox->setText(tr("Show Tag Filter"));
-    tagsOnWidgetsVisibilityCheckBox->setText(tr("Show Tags On Deck Previews"));
-    bannerCardComboBoxVisibilityCheckBox->setText(tr("Show Banner Card Selection Option"));
-    searchFolderNamesCheckBox->setText(tr("Include Folder Names in Search"));
-    drawUnusedColorIdentitiesCheckBox->setText(tr("Draw unused Color Identities"));
-    unusedColorIdentitiesOpacityLabel->setText(tr("Unused Color Identities Opacity"));
-    unusedColorIdentitiesOpacitySpinBox->setSuffix("%");
-
     refreshButton->setToolTip(tr("Refresh loaded files"));
     quickSettingsWidget->setToolTip(tr("Visual Deck Storage Settings"));
+}
+
+/**
+ * Gets a const pointer to the quick settings so that the values can be accessed.
+ */
+const VisualDeckStorageQuickSettingsWidget *VisualDeckStorageWidget::settings() const
+{
+    return quickSettingsWidget;
 }
 
 /**
@@ -215,7 +146,7 @@ void VisualDeckStorageWidget::reapplySortAndFilters()
 void VisualDeckStorageWidget::createRootFolderWidget()
 {
     folderWidget = new VisualDeckStorageFolderDisplayWidget(this, this, SettingsCache::instance().getDeckPath(), false,
-                                                            showFoldersCheckBox->isChecked());
+                                                            quickSettingsWidget->getShowFolders());
 
     scrollArea->setWidget(folderWidget); // this automatically destroys the old folderWidget
     scrollArea->widget()->setMaximumWidth(scrollArea->viewport()->width());
@@ -266,7 +197,7 @@ void VisualDeckStorageWidget::updateSearchFilter()
 {
     if (folderWidget) {
         searchWidget->filterWidgets(folderWidget->findChildren<DeckPreviewWidget *>(), searchWidget->getSearchText(),
-                                    searchFolderNamesCheckBox->isChecked());
+                                    quickSettingsWidget->getSearchFolderNames());
         folderWidget->updateVisibility();
     }
 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -8,6 +8,7 @@
 #include "deck_preview/deck_preview_color_identity_filter_widget.h"
 #include "deck_preview/deck_preview_widget.h"
 #include "visual_deck_storage_folder_display_widget.h"
+#include "visual_deck_storage_quick_settings_widget.h"
 #include "visual_deck_storage_search_widget.h"
 #include "visual_deck_storage_sort_widget.h"
 #include "visual_deck_storage_tag_filter_widget.h"
@@ -29,9 +30,10 @@ public:
     void refreshIfPossible();
     void retranslateUi();
 
-    CardSizeWidget *cardSizeWidget;
     VisualDeckStorageTagFilterWidget *tagFilterWidget;
     bool deckPreviewSelectionAnimationEnabled;
+
+    const VisualDeckStorageQuickSettingsWidget *settings() const;
 
 public slots:
     void createRootFolderWidget(); // Refresh the display of cards based on the current sorting option
@@ -60,15 +62,7 @@ private:
     VisualDeckStorageSearchWidget *searchWidget;
     DeckPreviewColorIdentityFilterWidget *deckPreviewColorIdentityFilterWidget;
     QToolButton *refreshButton;
-    SettingsButtonWidget *quickSettingsWidget;
-    QCheckBox *showFoldersCheckBox;
-    QCheckBox *drawUnusedColorIdentitiesCheckBox;
-    QCheckBox *bannerCardComboBoxVisibilityCheckBox;
-    QCheckBox *tagFilterVisibilityCheckBox;
-    QCheckBox *tagsOnWidgetsVisibilityCheckBox;
-    QCheckBox *searchFolderNamesCheckBox;
-    QLabel *unusedColorIdentitiesOpacityLabel;
-    QSpinBox *unusedColorIdentitiesOpacitySpinBox;
+    VisualDeckStorageQuickSettingsWidget *quickSettingsWidget;
     QScrollArea *scrollArea;
     VisualDeckStorageFolderDisplayWidget *folderWidget;
 


### PR DESCRIPTION
## Related Ticket(s)
- Requires #5903 to be merged first

## Short roundup of the initial problem

Currently, the widgets inside the VDS quick settings dropdown menu are all managed in `VisualDeckStorageWidget`. This is starting to become unwieldy as we add more settings to the quick settings menu. 

It would be cleaner to move the widgets to do with the quick settings into their own class.

## What will change with this Pull Request?
- Created `VisualDeckStorageQuickSettingsWidget` class
  - extends `SettingsButtonWidget`, since that was what we were putting the setting widgets in before.
  - has getters for the setting values as well as signals for settings value change. 
- Moved all the settings widget creation from `VisualDeckStorageWidget` constructor to `VisualDeckStorageQuickSettingsWidget` constructor
- Added a getter for the settings widget to `VisualDeckStorageWidget`, so that other classes can still access the values from the settings that way.

