### PR TITLE
Add setting to auto focus search bar when opening card view window

### DIFF
--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -630,6 +630,10 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     connect(&closeEmptyCardViewCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setCloseEmptyCardView);
 
+    focusCardViewSearchBarCheckBox.setChecked(SettingsCache::instance().getFocusCardViewSearchBar());
+    connect(&focusCardViewSearchBarCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setFocusCardViewSearchBar);
+
     annotateTokensCheckBox.setChecked(SettingsCache::instance().getAnnotateTokens());
     connect(&annotateTokensCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setAnnotateTokens);
@@ -643,8 +647,9 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     generalGrid->addWidget(&clickPlaysAllSelectedCheckBox, 1, 0);
     generalGrid->addWidget(&playToStackCheckBox, 2, 0);
     generalGrid->addWidget(&closeEmptyCardViewCheckBox, 3, 0);
-    generalGrid->addWidget(&annotateTokensCheckBox, 4, 0);
-    generalGrid->addWidget(&useTearOffMenusCheckBox, 5, 0);
+    generalGrid->addWidget(&focusCardViewSearchBarCheckBox, 4, 0);
+    generalGrid->addWidget(&annotateTokensCheckBox, 5, 0);
+    generalGrid->addWidget(&useTearOffMenusCheckBox, 6, 0);
 
     generalGroupBox = new QGroupBox;
     generalGroupBox->setLayout(generalGrid);
@@ -763,6 +768,7 @@ void UserInterfaceSettingsPage::retranslateUi()
     clickPlaysAllSelectedCheckBox.setText(tr("&Clicking plays all selected cards (instead of just the clicked card)"));
     playToStackCheckBox.setText(tr("&Play all nonlands onto the stack (not the battlefield) by default"));
     closeEmptyCardViewCheckBox.setText(tr("Close card view window when last card is removed"));
+    focusCardViewSearchBarCheckBox.setText(tr("Focus search bar when new card view window is opened"));
     annotateTokensCheckBox.setText(tr("Annotate card text on tokens"));
     useTearOffMenusCheckBox.setText(tr("Use tear-off menus, allowing right click menus to persist on screen"));
     notificationsGroupBox->setTitle(tr("Notifications settings"));

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -768,7 +768,7 @@ void UserInterfaceSettingsPage::retranslateUi()
     clickPlaysAllSelectedCheckBox.setText(tr("&Clicking plays all selected cards (instead of just the clicked card)"));
     playToStackCheckBox.setText(tr("&Play all nonlands onto the stack (not the battlefield) by default"));
     closeEmptyCardViewCheckBox.setText(tr("Close card view window when last card is removed"));
-    focusCardViewSearchBarCheckBox.setText(tr("Focus search bar when new card view window is opened"));
+    focusCardViewSearchBarCheckBox.setText(tr("Auto focus search bar when card view window is opened"));
     annotateTokensCheckBox.setText(tr("Annotate card text on tokens"));
     useTearOffMenusCheckBox.setText(tr("Use tear-off menus, allowing right click menus to persist on screen"));
     notificationsGroupBox->setTitle(tr("Notifications settings"));

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -147,6 +147,7 @@ private:
     QCheckBox clickPlaysAllSelectedCheckBox;
     QCheckBox playToStackCheckBox;
     QCheckBox closeEmptyCardViewCheckBox;
+    QCheckBox focusCardViewSearchBarCheckBox;
     QCheckBox annotateTokensCheckBox;
     QCheckBox useTearOffMenusCheckBox;
     QCheckBox tapAnimationCheckBox;

--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -56,6 +56,11 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
 
         connect(help, &QAction::triggered, this, [this] { createSearchSyntaxHelpWindow(&searchEdit); });
 
+        if (SettingsCache::instance().getFocusCardViewSearchBar()) {
+            this->setActive(true);
+            searchEdit.setFocus();
+        }
+
         QGraphicsProxyWidget *searchEditProxy = new QGraphicsProxyWidget;
         searchEditProxy->setWidget(&searchEdit);
         searchEditProxy->setZValue(2000000007);

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -251,6 +251,7 @@ SettingsCache::SettingsCache()
     cardViewInitialRowsMax = settings->value("interface/cardViewInitialRowsMax", 14).toInt();
     cardViewExpandedRowsMax = settings->value("interface/cardViewExpandedRowsMax", 20).toInt();
     closeEmptyCardView = settings->value("interface/closeEmptyCardView", true).toBool();
+    focusCardViewSearchBar = settings->value("interface/focusCardViewSearchBar", true).toBool();
 
     showShortcuts = settings->value("menu/showshortcuts", true).toBool();
     displayCardNames = settings->value("cards/displaycardnames", true).toBool();
@@ -368,6 +369,12 @@ void SettingsCache::setCloseEmptyCardView(QT_STATE_CHANGED_T value)
 {
     closeEmptyCardView = value;
     settings->setValue("interface/closeEmptyCardView", closeEmptyCardView);
+}
+
+void SettingsCache::setFocusCardViewSearchBar(QT_STATE_CHANGED_T value)
+{
+    focusCardViewSearchBar = value;
+    settings->setValue("interface/focusCardViewSearchBar", focusCardViewSearchBar);
 }
 
 void SettingsCache::setKnownMissingFeatures(const QString &_knownMissingFeatures)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -184,6 +184,7 @@ private:
     int cardViewInitialRowsMax;
     int cardViewExpandedRowsMax;
     bool closeEmptyCardView;
+    bool focusCardViewSearchBar;
     int pixmapCacheSize;
     int networkCacheSize;
     int redirectCacheTtl;
@@ -699,6 +700,7 @@ public:
     void setCardViewInitialRowsMax(int _cardViewInitialRowsMax);
     void setCardViewExpandedRowsMax(int value);
     void setCloseEmptyCardView(QT_STATE_CHANGED_T value);
+    void setFocusCardViewSearchBar(QT_STATE_CHANGED_T value);
     QString getClientID()
     {
         return clientID;
@@ -726,6 +728,10 @@ public:
     bool getCloseEmptyCardView() const
     {
         return closeEmptyCardView;
+    }
+    bool getFocusCardViewSearchBar() const
+    {
+        return focusCardViewSearchBar;
     }
     ShortcutsSettings &shortcuts() const
     {

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -64,7 +64,7 @@ void SettingsCache::setCardViewExpandedRowsMax(int /* value */)
 void SettingsCache::setCloseEmptyCardView(const QT_STATE_CHANGED_T /* value */)
 {
 }
-void SettingsCache::setFocusCardViewSearchBar(QT_STATE_CHANGED_T value)
+void SettingsCache::setFocusCardViewSearchBar(QT_STATE_CHANGED_T /* value */)
 {
 }
 void SettingsCache::setKnownMissingFeatures(const QString & /* _knownMissingFeatures */)

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -64,6 +64,9 @@ void SettingsCache::setCardViewExpandedRowsMax(int /* value */)
 void SettingsCache::setCloseEmptyCardView(const QT_STATE_CHANGED_T /* value */)
 {
 }
+void SettingsCache::setFocusCardViewSearchBar(QT_STATE_CHANGED_T value)
+{
+}
 void SettingsCache::setKnownMissingFeatures(const QString & /* _knownMissingFeatures */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -68,6 +68,9 @@ void SettingsCache::setCardViewExpandedRowsMax(int /* value */)
 void SettingsCache::setCloseEmptyCardView(QT_STATE_CHANGED_T /* value */)
 {
 }
+void SettingsCache::setFocusCardViewSearchBar(QT_STATE_CHANGED_T value)
+{
+}
 void SettingsCache::setKnownMissingFeatures(const QString & /* _knownMissingFeatures */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -68,7 +68,7 @@ void SettingsCache::setCardViewExpandedRowsMax(int /* value */)
 void SettingsCache::setCloseEmptyCardView(QT_STATE_CHANGED_T /* value */)
 {
 }
-void SettingsCache::setFocusCardViewSearchBar(QT_STATE_CHANGED_T value)
+void SettingsCache::setFocusCardViewSearchBar(QT_STATE_CHANGED_T /* value */)
 {
 }
 void SettingsCache::setKnownMissingFeatures(const QString & /* _knownMissingFeatures */)


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5791 

## Short roundup of the initial problem

Too often I find myself going through this sequence:
1. Press `view deck` shortcut
2. Move cursor over to search bar and click it
3. Type in search terms
4. Move cursor down to the card area.
5. Double click the card I want

Moving the cursor actually takes some time since I need to switch between keyboard and trackpad.

It would be a quality of life improvement if we can cut out the first two steps so that it's just:
1. Press `view deck` shortcut
2. Type in search terms
3. Move cursor over to card area
4. Double click the card I want

This removes the keyboard/trackpad switching in the first two steps, which dramatically speeds things up for me.

## What will change with this Pull Request?
https://github.com/user-attachments/assets/a1207019-995e-4038-9ac7-80faed532197

- Added setting `Auto focus search bar when card view window is opened`
  - Under `general interface settings`
- When enabled, `ZoneViewWidget`'s constructor will set focus to the `searchEdit` after it's created

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<img width="695" alt="Screenshot 2025-05-04 at 2 42 02 AM" src="https://github.com/user-attachments/assets/bae1bd9b-ee24-4913-bd68-b587c7afe157" />

