### PR TITLE
Delete CardDragItem when referenced CardItem is destroyed

### DIFF
--- a/cockatrice/src/game/board/abstract_card_drag_item.cpp
+++ b/cockatrice/src/game/board/abstract_card_drag_item.cpp
@@ -39,6 +39,8 @@ AbstractCardDragItem::AbstractCardDragItem(AbstractCardItem *_item,
         prepareGeometryChange();
         update();
     });
+
+    connect(item, &QObject::destroyed, this, &AbstractCardDragItem::deleteLater);
 }
 
 AbstractCardDragItem::~AbstractCardDragItem()


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5904

## Short roundup of the initial problem

Previously, the `CardDragItem` will still persist even if the referenced `CardItem` is destroyed (for example, by closing the card view window using `esc`). This causes Cockatrice to crash once the drag item is released and Cockatrice needs to do stuff with the referenced cardItem.

## What will change with this Pull Request?
- Connect the `AbstractCardItem`'s `destroyed` signal to the `AbstractCardDragItem`'s `deleteLater` so that card drag items are deleted as soon as the referenced CardItem is destroyed.

https://github.com/user-attachments/assets/53c9356d-6b70-4575-b843-4541dc60c0d5


