### PR TITLE
Pass log messages by const ref

### DIFF
--- a/cockatrice/src/dialogs/dlg_view_log.cpp
+++ b/cockatrice/src/dialogs/dlg_view_log.cpp
@@ -42,7 +42,7 @@ void DlgViewLog::loadInitialLogBuffer()
         logEntryAdded(message);
 }
 
-void DlgViewLog::logEntryAdded(QString message)
+void DlgViewLog::logEntryAdded(const QString &message)
 {
     logArea->appendPlainText(message);
 }

--- a/cockatrice/src/dialogs/dlg_view_log.cpp
+++ b/cockatrice/src/dialogs/dlg_view_log.cpp
@@ -27,7 +27,7 @@ DlgViewLog::DlgViewLog(QWidget *parent) : QDialog(parent)
     resize(800, 500);
 
     loadInitialLogBuffer();
-    connect(&Logger::getInstance(), &Logger::logEntryAdded, this, &DlgViewLog::logEntryAdded);
+    connect(&Logger::getInstance(), &Logger::logEntryAdded, this, &DlgViewLog::appendLogEntry);
 }
 
 void DlgViewLog::actCheckBoxChanged(bool abNewValue)
@@ -39,10 +39,10 @@ void DlgViewLog::loadInitialLogBuffer()
 {
     QList<QString> logBuffer = Logger::getInstance().getLogBuffer();
     for (const QString &message : logBuffer)
-        logEntryAdded(message);
+        appendLogEntry(message);
 }
 
-void DlgViewLog::logEntryAdded(const QString &message)
+void DlgViewLog::appendLogEntry(const QString &message)
 {
     logArea->appendPlainText(message);
 }

--- a/cockatrice/src/dialogs/dlg_view_log.h
+++ b/cockatrice/src/dialogs/dlg_view_log.h
@@ -22,7 +22,7 @@ private:
 
     void loadInitialLogBuffer();
 private slots:
-    void logEntryAdded(const QString &message);
+    void appendLogEntry(const QString &message);
     void actCheckBoxChanged(bool abNewValue);
 };
 

--- a/cockatrice/src/dialogs/dlg_view_log.h
+++ b/cockatrice/src/dialogs/dlg_view_log.h
@@ -22,7 +22,7 @@ private:
 
     void loadInitialLogBuffer();
 private slots:
-    void logEntryAdded(QString message);
+    void logEntryAdded(const QString &message);
     void actCheckBoxChanged(bool abNewValue);
 };
 

--- a/cockatrice/src/utility/logger.cpp
+++ b/cockatrice/src/utility/logger.cpp
@@ -81,12 +81,12 @@ void Logger::closeLogfileSession()
     fileHandle.close();
 }
 
-void Logger::log(QtMsgType /* type */, const QMessageLogContext & /* ctx */, const QString message)
+void Logger::log(QtMsgType /* type */, const QMessageLogContext & /* ctx */, const QString &message)
 {
     QMetaObject::invokeMethod(this, "internalLog", Qt::QueuedConnection, Q_ARG(const QString &, message));
 }
 
-void Logger::internalLog(QString message)
+void Logger::internalLog(const QString &message)
 {
     QMutexLocker locker(&mutex);
 

--- a/cockatrice/src/utility/logger.h
+++ b/cockatrice/src/utility/logger.h
@@ -28,7 +28,7 @@ public:
     }
 
     void logToFile(bool enabled);
-    void log(QtMsgType type, const QMessageLogContext &ctx, QString message);
+    void log(QtMsgType type, const QMessageLogContext &ctx, const QString &message);
     QString getClientVersion();
     QString getClientOperatingSystem();
     QString getSystemArchitecture();
@@ -57,10 +57,10 @@ protected:
     void closeLogfileSession();
 
 protected slots:
-    void internalLog(QString message);
+    void internalLog(const QString &message);
 
 signals:
-    void logEntryAdded(QString message);
+    void logEntryAdded(const QString &message);
 };
 
 #endif


### PR DESCRIPTION
## Short roundup of the initial problem

In some places around `Logger` and `DlgViewLog`, we're not passing `QString`s by const ref even though we could.

## What will change with this Pull Request?
- Change methods in `Logger` and `DlgViewLog` that don't pass by const ref but could to pass by const ref
- Rename `logEntryAdded` to `appendLogEntry`, since past tense is for signals