### PR TITLE
Strip color escape codes in Debug Log window

### DIFF
--- a/cockatrice/src/dialogs/dlg_view_log.cpp
+++ b/cockatrice/src/dialogs/dlg_view_log.cpp
@@ -4,6 +4,7 @@
 #include "../utility/logger.h"
 
 #include <QPlainTextEdit>
+#include <QRegularExpression>
 #include <QVBoxLayout>
 
 DlgViewLog::DlgViewLog(QWidget *parent) : QDialog(parent)
@@ -44,7 +45,12 @@ void DlgViewLog::loadInitialLogBuffer()
 
 void DlgViewLog::logEntryAdded(QString message)
 {
-    logArea->appendPlainText(message);
+    static auto colorEscapeCodePattern = QRegularExpression("\033\\[\\d+m");
+
+    QString sanitizedMessage = message;
+    sanitizedMessage.replace(colorEscapeCodePattern, "");
+
+    logArea->appendPlainText(sanitizedMessage);
 }
 
 void DlgViewLog::closeEvent(QCloseEvent * /* event */)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5540

## Short roundup of the initial problem

Our log format contains color escape codes so that different log levels have different colors. This works when logging to console.

However, we also send the logs to the Debug Log window. The Debug Log window cannot handle color escape codes, and instead prints the codes as garbage characters.

## What will change with this Pull Request?
- `DlgViewLog` now strips the color escape codes from the log message before appending it to the textEdit

## Screenshots
Before

<img width="805" alt="Screenshot 2025-05-05 at 12 10 22 AM" src="https://github.com/user-attachments/assets/f6644531-7206-4d87-9344-a62fe30f2aa2" />

After

<img width="805" alt="Screenshot 2025-05-05 at 12 09 54 AM" src="https://github.com/user-attachments/assets/ab25ef31-c32d-40ba-8ba6-ac7bae071691" />
