### PR TITLE
[GDE, VDS & VDE] Tooltips and labels

### DIFF
--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -91,7 +91,7 @@ void DeckEditorDeckDockWidget::createDeckDock()
     bannerCardLabel = new QLabel();
     bannerCardLabel->setObjectName("bannerCardLabel");
     bannerCardLabel->setText(tr("Banner Card"));
-    bannerCardLabel->setHidden(SettingsCache::instance().getDeckEditorBannerCardComboBoxVisible());
+    bannerCardLabel->setHidden(!SettingsCache::instance().getDeckEditorBannerCardComboBoxVisible());
     bannerCardComboBox = new QComboBox(this);
     connect(deckModel, &DeckListModel::dataChanged, this, [this]() {
         // Delay the update to avoid race conditions

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -563,6 +563,7 @@ void DeckEditorDeckDockWidget::retranslateUi()
     setWindowTitle(tr("Deck"));
 
     nameLabel->setText(tr("Deck &name:"));
+    quickSettingsWidget->setToolTip(tr("Banner Card/Tags Visibility Settings"));
     showBannerCardCheckBox->setText(tr("Show banner card selection menu"));
     showTagsWidgetCheckBox->setText(tr("Show tags selection menu"));
     commentsLabel->setText(tr("&Comments:"));

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_color_filter_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_color_filter_widget.cpp
@@ -58,6 +58,8 @@ void VisualDatabaseDisplayColorFilterWidget::retranslateUi()
             toggleButton->setText(tr("Mode: Include/Exclude"));
             break;
     }
+
+    toggleButton->setToolTip(tr("Filter mode (AND/OR/NOT conjunctions of filters)"));
 }
 
 void VisualDatabaseDisplayColorFilterWidget::handleColorToggled(QChar color, bool active)

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_filter_save_load_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_filter_save_load_widget.cpp
@@ -39,6 +39,7 @@ VisualDatabaseDisplayFilterSaveLoadWidget::VisualDatabaseDisplayFilterSaveLoadWi
 void VisualDatabaseDisplayFilterSaveLoadWidget::retranslateUi()
 {
     saveButton->setText(tr("Save Filter"));
+    saveButton->setToolTip(tr("Save all currently applied filters to a file"));
     filenameInput->setPlaceholderText(tr("Enter filename..."));
 }
 

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_main_type_filter_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_main_type_filter_widget.cpp
@@ -47,6 +47,14 @@ VisualDatabaseDisplayMainTypeFilterWidget::VisualDatabaseDisplayMainTypeFilterWi
 
     createMainTypeButtons(); // Populate buttons initially
     updateFilterMode(false); // Initialize toggle button text
+
+    retranslateUi();
+}
+
+void VisualDatabaseDisplayMainTypeFilterWidget::retranslateUi()
+{
+    spinBox->setToolTip(tr("Do not display card main-types with less than this amount of cards in the database"));
+    toggleButton->setToolTip(tr("Filter mode (AND/OR/NOT conjunctions of filters)"));
 }
 
 void VisualDatabaseDisplayMainTypeFilterWidget::createMainTypeButtons()

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_main_type_filter_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_main_type_filter_widget.h
@@ -16,6 +16,7 @@ class VisualDatabaseDisplayMainTypeFilterWidget : public QWidget
     Q_OBJECT
 public:
     explicit VisualDatabaseDisplayMainTypeFilterWidget(QWidget *parent, FilterTreeModel *filterModel);
+    void retranslateUi();
     void createMainTypeButtons();
     void updateMainTypeButtonsVisibility();
     int getMaxMainTypeCount() const;

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_name_filter_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_name_filter_widget.cpp
@@ -45,6 +45,7 @@ void VisualDatabaseDisplayNameFilterWidget::retranslateUi()
 {
     searchBox->setPlaceholderText(tr("Filter by name..."));
     loadFromDeckButton->setText(tr("Load from Deck"));
+    loadFromDeckButton->setToolTip(tr("Apply all card names in currently loaded deck as exact match name filters"));
 }
 
 void VisualDatabaseDisplayNameFilterWidget::actLoadFromDeck()

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_sub_type_filter_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_sub_type_filter_widget.cpp
@@ -51,6 +51,14 @@ VisualDatabaseDisplaySubTypeFilterWidget::VisualDatabaseDisplaySubTypeFilterWidg
 
     createSubTypeButtons();  // Populate buttons initially
     updateFilterMode(false); // Initialize the toggle button text
+
+    retranslateUi();
+}
+
+void VisualDatabaseDisplaySubTypeFilterWidget::retranslateUi()
+{
+    spinBox->setToolTip(tr("Do not display card sub-types with less than this amount of cards in the database"));
+    toggleButton->setToolTip(tr("Filter mode (AND/OR/NOT conjunctions of filters)"));
 }
 
 void VisualDatabaseDisplaySubTypeFilterWidget::createSubTypeButtons()

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_sub_type_filter_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_sub_type_filter_widget.h
@@ -16,6 +16,7 @@ class VisualDatabaseDisplaySubTypeFilterWidget : public QWidget
     Q_OBJECT
 public:
     explicit VisualDatabaseDisplaySubTypeFilterWidget(QWidget *parent, FilterTreeModel *filterModel);
+    void retranslateUi();
     void createSubTypeButtons();
     void updateSubTypeButtonsVisibility();
     int getMaxSubTypeCount() const;

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -150,6 +150,20 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
 
     connect(loadCardsTimer, &QTimer::timeout, this, [this]() { loadCurrentPage(); });
     loadCardsTimer->start(5000);
+
+    retranslateUi();
+}
+
+void VisualDatabaseDisplayWidget::retranslateUi()
+{
+    clearFilterWidget->setToolTip(tr("Clear all filters"));
+
+
+
+    quickFilterSaveLoadWidget->setToolTip(tr("Save and load filters"));
+    quickFilterNameWidget->setToolTip(tr("Filter by exact card name"));
+    quickFilterSubTypeWidget->setToolTip(tr("Filter by card sub-type"));
+    quickFilterSetWidget->setToolTip(tr("Filter by set"));
 }
 
 void VisualDatabaseDisplayWidget::resizeEvent(QResizeEvent *event)

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -158,8 +158,6 @@ void VisualDatabaseDisplayWidget::retranslateUi()
 {
     clearFilterWidget->setToolTip(tr("Clear all filters"));
 
-
-
     quickFilterSaveLoadWidget->setToolTip(tr("Save and load filters"));
     quickFilterNameWidget->setToolTip(tr("Filter by exact card name"));
     quickFilterSubTypeWidget->setToolTip(tr("Filter by card sub-type"));

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.h
@@ -38,6 +38,7 @@ public:
                                          AbstractTabDeckEditor *deckEditor,
                                          CardDatabaseModel *database_model,
                                          CardDatabaseDisplayModel *database_display_model);
+    void retranslateUi();
 
     void adjustCardsPerPage();
     void populateCards();

--- a/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -194,7 +194,8 @@ void VisualDeckEditorWidget::retranslateUi()
                                     "preferred printing to the deck on pressing enter"));
     sortCriteriaButton->setToolTip(tr("Configure how cards are sorted within their groups"));
     displayTypeButton->setText(tr("Flat Layout"));
-    displayTypeButton->setToolTip(tr("Change how cards are displayed within zones (i.e. overlapped or fully visible.)"));
+    displayTypeButton->setToolTip(
+        tr("Change how cards are displayed within zones (i.e. overlapped or fully visible.)"));
 }
 
 void VisualDeckEditorWidget::updateZoneWidgets()

--- a/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -190,7 +190,11 @@ void VisualDeckEditorWidget::retranslateUi()
 {
     sortLabel->setText(tr("Click and drag to change the sort order within the groups"));
     searchPushButton->setText(tr("Quick search and add card"));
+    searchPushButton->setToolTip(tr("Search for closest match in the database (with auto-suggestions) and add "
+                                    "preferred printing to the deck on pressing enter"));
+    sortCriteriaButton->setToolTip(tr("Configure how cards are sorted within their groups"));
     displayTypeButton->setText(tr("Flat Layout"));
+    displayTypeButton->setToolTip(tr("Change how cards are displayed within zones (i.e. overlapped or fully visible.)"));
 }
 
 void VisualDeckEditorWidget::updateZoneWidgets()

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_filter_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_filter_widget.cpp
@@ -47,6 +47,7 @@ void DeckPreviewColorIdentityFilterWidget::retranslateUi()
 {
     // Set the toggle button text based on the current mode
     toggleButton->setText(exactMatchMode ? tr("Mode: Exact Match") : tr("Mode: Includes"));
+    toggleButton->setToolTip(tr("Color identity filter mode (AND/OR/NOT conjunctions of filters)"));
 }
 
 void DeckPreviewColorIdentityFilterWidget::handleColorToggled(QChar color, bool active)

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -194,6 +194,9 @@ void VisualDeckStorageWidget::retranslateUi()
     drawUnusedColorIdentitiesCheckBox->setText(tr("Draw unused Color Identities"));
     unusedColorIdentitiesOpacityLabel->setText(tr("Unused Color Identities Opacity"));
     unusedColorIdentitiesOpacitySpinBox->setSuffix("%");
+
+    refreshButton->setToolTip(tr("Refresh loaded files"));
+    quickSettingsWidget->setToolTip(tr("Visual Deck Storage Settings"));
 }
 
 /**


### PR DESCRIPTION
## Related Ticket(s)
- Addresses #5908

## Short roundup of the initial problem
Tooltips for buttons are lacking. The banner card label visibility isn't correctly inverted on construction, which means it's initially opposite of the combobox.

## What will change with this Pull Request?
- Add temporary tooltips to new buttons.
- Correctly invert label visibility.
