### PR TITLE
[VDE] Deck analytics visibility

### DIFF
--- a/cockatrice/src/client/ui/widgets/deck_analytics/deck_analytics_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_analytics/deck_analytics_widget.cpp
@@ -6,14 +6,25 @@ DeckAnalyticsWidget::DeckAnalyticsWidget(QWidget *parent, DeckListModel *_deckLi
     mainLayout = new QVBoxLayout();
     setLayout(mainLayout);
 
+    scrollArea = new QScrollArea(this);
+    scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    scrollArea->setWidgetResizable(true);
+    mainLayout->addWidget(scrollArea);
+
+    container = new QWidget(scrollArea);
+    containerLayout = new QVBoxLayout(container);
+    container->setLayout(containerLayout);
+    scrollArea->setWidget(container);
+
     manaCurveWidget = new ManaCurveWidget(this, deckListModel);
-    mainLayout->addWidget(manaCurveWidget);
+    containerLayout->addWidget(manaCurveWidget);
 
     manaDevotionWidget = new ManaDevotionWidget(this, deckListModel);
-    mainLayout->addWidget(manaDevotionWidget);
+    containerLayout->addWidget(manaDevotionWidget);
 
     manaBaseWidget = new ManaBaseWidget(this, deckListModel);
-    mainLayout->addWidget(manaBaseWidget);
+    containerLayout->addWidget(manaBaseWidget);
 }
 
 void DeckAnalyticsWidget::refreshDisplays(DeckListModel *_deckModel)

--- a/cockatrice/src/client/ui/widgets/deck_analytics/deck_analytics_widget.h
+++ b/cockatrice/src/client/ui/widgets/deck_analytics/deck_analytics_widget.h
@@ -8,9 +8,10 @@
 #include "mana_devotion_widget.h"
 
 #include <QHBoxLayout>
+#include <QScrollArea>
+#include <QVBoxLayout>
 #include <QWidget>
 #include <decklist.h>
-#include <qscrollarea.h>
 
 class DeckAnalyticsWidget : public QWidget
 {
@@ -25,6 +26,11 @@ public:
 private:
     DeckListModel *deckListModel;
     QVBoxLayout *mainLayout;
+
+    QWidget *container;
+    QVBoxLayout *containerLayout;
+
+    QScrollArea *scrollArea;
 
     ManaCurveWidget *manaCurveWidget;
     ManaDevotionWidget *manaDevotionWidget;

--- a/cockatrice/src/client/ui/widgets/deck_analytics/mana_curve_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_analytics/mana_curve_widget.cpp
@@ -91,7 +91,7 @@ void ManaCurveWidget::updateDisplay()
     // Add new widgets to the layout in sorted order
     for (const auto &entry : sortedManaCurve) {
         BarWidget *barWidget =
-            new BarWidget(QString::number(entry.first), entry.second, highestEntry, QColor(11, 11, 11), this);
+            new BarWidget(QString::number(entry.first), entry.second, highestEntry, QColor(122, 122, 122), this);
         barLayout->addWidget(barWidget);
     }
 


### PR DESCRIPTION
## Related Ticket(s)
- Closes #5908 with #5916 and #5917

## Short roundup of the initial problem
The bars for the mana curve widget are colored black which causes visibility issues due to the black font. There is also apparently no scrollbar. I can't confirm this since the widgets resize correctly for me.

## What will change with this Pull Request?
- Change bar color to grey
- Add a preemptive scrollArea

## Screenshots
![image](https://github.com/user-attachments/assets/622628a8-ea36-44bf-9ae0-b7b45e775074)
