### PR TITLE
[VDS] Allow tags to toggle to a NOT state to hide non-matching decks

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_display_widget.h
@@ -29,7 +29,8 @@ public:
     {
         return tagName;
     }
-    TagState getState() const {
+    TagState getState() const
+    {
         return state;
     }
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_display_widget.h
@@ -6,6 +6,12 @@
 #include <QString>
 #include <QWidget>
 
+enum class TagState {
+    NotSelected,
+    Selected,
+    Excluded
+};
+
 class DeckPreviewTagDisplayWidget : public QWidget
 {
     Q_OBJECT
@@ -22,16 +28,13 @@ public:
     {
         return tagName;
     }
-    bool getSelected() const
-    {
-        return isSelected;
-    }
+    TagState getState() const { return state; }
 
-    /**
-     * @brief Sets the selected state of the tag.
-     * @param selected True if the tag is selected, false otherwise.
-     */
-    void setSelected(bool selected);
+    void setState(const TagState newState)
+    {
+        state = newState;
+        update();
+    };
 
 signals:
     /**
@@ -61,7 +64,7 @@ private:
     QLabel *tagLabel;         ///< Label for displaying the tag name.
     QPushButton *closeButton; ///< Button to close/remove the tag.
     QString tagName;          ///< The name of the tag.
-    bool isSelected;          ///< Indicates whether the tag is selected.
+    TagState state;          ///< Indicates whether the tag is unselected, selected, or excluded.
 };
 
 #endif // DECK_PREVIEW_TAG_DISPLAY_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_display_widget.h
@@ -6,7 +6,8 @@
 #include <QString>
 #include <QWidget>
 
-enum class TagState {
+enum class TagState
+{
     NotSelected,
     Selected,
     Excluded
@@ -28,7 +29,9 @@ public:
     {
         return tagName;
     }
-    TagState getState() const { return state; }
+    TagState getState() const {
+        return state;
+    }
 
     void setState(const TagState newState)
     {
@@ -64,7 +67,7 @@ private:
     QLabel *tagLabel;         ///< Label for displaying the tag name.
     QPushButton *closeButton; ///< Button to close/remove the tag.
     QString tagName;          ///< The name of the tag.
-    TagState state;          ///< Indicates whether the tag is unselected, selected, or excluded.
+    TagState state;           ///< Indicates whether the tag is unselected, selected, or excluded.
 };
 
 #endif // DECK_PREVIEW_TAG_DISPLAY_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
@@ -95,7 +95,6 @@ void VisualDeckStorageTagFilterWidget::removeTagsNotInList(const QSet<QString> &
     }
 }
 
-
 void VisualDeckStorageTagFilterWidget::addTagsIfNotPresent(const QSet<QString> &tags)
 {
     for (const QString &tag : tags) {

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
@@ -33,34 +33,45 @@ void VisualDeckStorageTagFilterWidget::showEvent(QShowEvent *event)
 
 void VisualDeckStorageTagFilterWidget::filterDecksBySelectedTags(const QList<DeckPreviewWidget *> &deckPreviews) const
 {
-    // Collect selected tags from DeckPreviewTagDisplayWidget
     QStringList selectedTags;
+    QStringList excludedTags;
+
+    // Collect selected and excluded tags
     for (DeckPreviewTagDisplayWidget *tagWidget : findChildren<DeckPreviewTagDisplayWidget *>()) {
-        if (tagWidget->getSelected()) {
-            selectedTags.append(tagWidget->getTagName());
+        switch (tagWidget->getState()) {
+            case TagState::Selected:
+                selectedTags.append(tagWidget->getTagName());
+                break;
+            case TagState::Excluded:
+                excludedTags.append(tagWidget->getTagName());
+                break;
+            default:
+                break;
         }
     }
 
-    // If no tags are selected, set all decks as visible
-    if (selectedTags.isEmpty()) {
+    // If no tags are selected or excluded, show all
+    if (selectedTags.isEmpty() && excludedTags.isEmpty()) {
         for (DeckPreviewWidget *deckPreview : deckPreviews) {
             deckPreview->filteredByTags = false;
         }
         return;
     }
 
-    // Filter DeckPreviewWidgets that contain all of the selected tags
-    QList<DeckPreviewWidget *> filteredDecks;
     for (DeckPreviewWidget *deckPreview : deckPreviews) {
         QStringList deckTags = deckPreview->deckLoader->getTags();
 
-        // Check if all selectedTags are in deckTags
-        bool allTagsPresent = std::all_of(selectedTags.begin(), selectedTags.end(),
+        bool hasAllSelected = std::all_of(selectedTags.begin(), selectedTags.end(),
                                           [&deckTags](const QString &tag) { return deckTags.contains(tag); });
 
-        deckPreview->filteredByTags = !allTagsPresent;
+        bool hasAnyExcluded = std::any_of(excludedTags.begin(), excludedTags.end(),
+                                          [&deckTags](const QString &tag) { return deckTags.contains(tag); });
+
+        // Filter out if any excluded tag is present or if any selected tag is missing
+        deckPreview->filteredByTags = !(hasAllSelected && !hasAnyExcluded);
     }
 }
+
 
 void VisualDeckStorageTagFilterWidget::refreshTags()
 {
@@ -72,16 +83,19 @@ void VisualDeckStorageTagFilterWidget::refreshTags()
 
 void VisualDeckStorageTagFilterWidget::removeTagsNotInList(const QSet<QString> &tags)
 {
-    // Iterate through all DeckPreviewTagDisplayWidgets
+    auto *flowWidget = findChild<FlowWidget *>();
+
     for (DeckPreviewTagDisplayWidget *tagWidget : findChildren<DeckPreviewTagDisplayWidget *>()) {
-        // If the tag is not in the provided tags list, remove the widget
-        if (!tags.contains(tagWidget->getTagName())) {
-            auto *flowWidget = findChild<FlowWidget *>();
+        const QString &tagName = tagWidget->getTagName();
+
+        // Keep the tag widget if it is either selected or excluded
+        if (!tags.contains(tagName) && tagWidget->getState() == TagState::NotSelected) {
             flowWidget->removeWidget(tagWidget);
-            tagWidget->deleteLater(); // Safely delete the widget
+            tagWidget->deleteLater();
         }
     }
 }
+
 
 void VisualDeckStorageTagFilterWidget::addTagsIfNotPresent(const QSet<QString> &tags)
 {

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
@@ -72,7 +72,6 @@ void VisualDeckStorageTagFilterWidget::filterDecksBySelectedTags(const QList<Dec
     }
 }
 
-
 void VisualDeckStorageTagFilterWidget::refreshTags()
 {
     QSet<QString> allTags = gatherAllTags();


### PR DESCRIPTION
## Related Ticket(s)
- Closes #5889

## Short roundup of the initial problem
Users are able to add tags to the filter to narrow the list one way but not exclude tags to narrow it the inverse way.

## What will change with this Pull Request?
- Introduce Tri-state enum for not selected, selected, excluded.
- Check exclusion state on filter
- Adjust onClick to select on left click, clear on middle mouse click, and exclude on right click.

## Screenshots
![image](https://github.com/user-attachments/assets/cafdd3af-ec82-4102-979e-35530ed8b329)
![image](https://github.com/user-attachments/assets/7792d8c6-c577-424e-9f14-f4230bad1676)

