### PR TITLE
Set Banner Card again when restoring index on deckList data changes.

### DIFF
--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -294,6 +294,9 @@ void DeckEditorDeckDockWidget::updateBannerCardComboBox()
     int restoredIndex = bannerCardComboBox->findText(currentText);
     if (restoredIndex != -1) {
         bannerCardComboBox->setCurrentIndex(restoredIndex);
+        if (deckModel->getDeckList()->getBannerCard().second != bannerCardComboBox->itemData(bannerCardComboBox->currentIndex()).toMap()["uuid"].toString()){
+            setBannerCard(restoredIndex);
+        }
     } else {
         // Add a placeholder "-" and set it as the current selection
         int bannerIndex = bannerCardComboBox->findText(deckModel->getDeckList()->getBannerCard().first);

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -294,7 +294,8 @@ void DeckEditorDeckDockWidget::updateBannerCardComboBox()
     int restoredIndex = bannerCardComboBox->findText(currentText);
     if (restoredIndex != -1) {
         bannerCardComboBox->setCurrentIndex(restoredIndex);
-        if (deckModel->getDeckList()->getBannerCard().second != bannerCardComboBox->itemData(bannerCardComboBox->currentIndex()).toMap()["uuid"].toString()){
+        if (deckModel->getDeckList()->getBannerCard().second !=
+            bannerCardComboBox->itemData(bannerCardComboBox->currentIndex()).toMap()["uuid"].toString()) {
             setBannerCard(restoredIndex);
         }
     } else {


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5810

## Short roundup of the initial problem
When the decklist's dataChanged signal is emitted, we correctly update the banner card combo box. 

![Image](https://github.com/user-attachments/assets/901c3857-9b23-4e73-89fe-cfd498a62421)

However, when we restore the index to the combo box, we don't call setBannerCard() again, which means the decklist does not fetch this new providerId data.

![Image](https://github.com/user-attachments/assets/c44a6855-49f0-4a36-81d4-249af1efb108)

## What will change with this Pull Request?
- setBannerCard again on restoration if the providerId doesn't match the currently stored one.
