### PR TITLE
fix: fix qt5 builds on macos 15

### DIFF
--- a/cockatrice/src/server/remote/remote_client.cpp
+++ b/cockatrice/src/server/remote/remote_client.cpp
@@ -43,7 +43,7 @@ RemoteClient::RemoteClient(QObject *parent)
     connect(socket, &QTcpSocket::connected, this, &RemoteClient::slotConnected);
     connect(socket, &QTcpSocket::readyRead, this, &RemoteClient::readData);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     connect(socket, &QTcpSocket::errorOccurred, this, &RemoteClient::slotSocketError);
 #else
     connect(socket, qOverload<QAbstractSocket::SocketError>(&QTcpSocket::error), this, &RemoteClient::slotSocketError);

--- a/cockatrice/src/settings/shortcut_treeview.cpp
+++ b/cockatrice/src/settings/shortcut_treeview.cpp
@@ -150,7 +150,7 @@ void ShortcutTreeView::currentChanged(const QModelIndex &current, const QModelIn
  */
 void ShortcutTreeView::updateSearchString(const QString &searchString)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION > QT_VERSION_CHECK(5, 14, 0)
     const auto skipEmptyParts = Qt::SkipEmptyParts;
 #else
     const auto skipEmptyParts = QString::SkipEmptyParts;

--- a/cockatrice/src/utility/card_info_comparator.cpp
+++ b/cockatrice/src/utility/card_info_comparator.cpp
@@ -37,17 +37,17 @@ bool CardInfoComparator::compareVariants(const QVariant &a, const QVariant &b) c
 
     // Perform type-specific comparison
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    switch (a.typeId()) {
+    switch (static_cast<int>(a.typeId())) {
 #else
-    switch (a.type()) {
+    switch (static_cast<int>(a.type())) {
 #endif
-        case QMetaType::Int:
+        case static_cast<int>(QMetaType::Int):
             return a.toInt() < b.toInt();
-        case QMetaType::Double:
+        case static_cast<int>(QMetaType::Double):
             return a.toDouble() < b.toDouble();
-        case QMetaType::QString:
+        case static_cast<int>(QMetaType::QString):
             return a.toString() < b.toString();
-        case QMetaType::Bool:
+        case static_cast<int>(QMetaType::Bool):
             return a.toBool() < b.toBool();
         default:
             // Default to comparing as strings


### PR DESCRIPTION
## Related Ticket(s)
N/A

## Short roundup of the initial problem
Although this config is not built on CI, while trying to compile locally, the build failed due to warnings and -Werror. Some qt functions were actually deprecated (but not removed) before version 6.0.0 and clang (righfully) complains about comparison between different types of enums.


## What will change with this Pull Request?
Cockatrice will build with qt5 on macos15, Apple clang version 17.0.0 (clang-1700.0.13.3) locally.

## Screenshots
N/A
