### PR TITLE
[VDS] Add prompt before overwriting existing files when converting to .cod

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.cpp
@@ -12,6 +12,7 @@
 #include <QDirIterator>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QMessageBox>
 
 DeckPreviewDeckTagsDisplayWidget::DeckPreviewDeckTagsDisplayWidget(QWidget *_parent, DeckList *_deckList)
     : QWidget(_parent), deckList(nullptr)
@@ -77,6 +78,23 @@ static QStringList getAllFiles(const QString &filePath)
     return allFiles;
 }
 
+bool confirmOverwriteIfExists(QWidget *parent, const QString &filePath)
+{
+    QFileInfo fileInfo(filePath);
+    QString newFileName = QDir::toNativeSeparators(fileInfo.path() + "/" + fileInfo.completeBaseName() + ".cod");
+
+    if (QFile::exists(newFileName)) {
+        QMessageBox::StandardButton reply = QMessageBox::question(
+            parent,
+            QObject::tr("Overwrite Existing File?"),
+            QObject::tr("A .cod version of this deck already exists. Overwrite it?"),
+            QMessageBox::Yes | QMessageBox::No
+        );
+        return reply == QMessageBox::Yes;
+    }
+    return true; // Safe to proceed
+}
+
 void DeckPreviewDeckTagsDisplayWidget::openTagEditDlg()
 {
     if (qobject_cast<DeckPreviewWidget *>(parentWidget())) {
@@ -91,6 +109,10 @@ void DeckPreviewDeckTagsDisplayWidget::openTagEditDlg()
             // Retrieve saved preference if the prompt is disabled
             if (!SettingsCache::instance().getVisualDeckStoragePromptForConversion()) {
                 if (SettingsCache::instance().getVisualDeckStorageAlwaysConvert()) {
+
+                    if (!confirmOverwriteIfExists(this, deckPreviewWidget->filePath))
+                        return;
+
                     deckPreviewWidget->deckLoader->convertToCockatriceFormat(deckPreviewWidget->filePath);
                     deckPreviewWidget->filePath = deckPreviewWidget->deckLoader->getLastFileName();
                     deckPreviewWidget->refreshBannerCardText();
@@ -100,6 +122,10 @@ void DeckPreviewDeckTagsDisplayWidget::openTagEditDlg()
                 // Show the dialog to the user
                 DialogConvertDeckToCodFormat conversionDialog(parentWidget());
                 if (conversionDialog.exec() == QDialog::Accepted) {
+
+                    if (!confirmOverwriteIfExists(this, deckPreviewWidget->filePath))
+                        return;
+
                     deckPreviewWidget->deckLoader->convertToCockatriceFormat(deckPreviewWidget->filePath);
                     deckPreviewWidget->filePath = deckPreviewWidget->deckLoader->getLastFileName();
                     deckPreviewWidget->refreshBannerCardText();

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.cpp
@@ -84,12 +84,10 @@ bool confirmOverwriteIfExists(QWidget *parent, const QString &filePath)
     QString newFileName = QDir::toNativeSeparators(fileInfo.path() + "/" + fileInfo.completeBaseName() + ".cod");
 
     if (QFile::exists(newFileName)) {
-        QMessageBox::StandardButton reply = QMessageBox::question(
-            parent,
-            QObject::tr("Overwrite Existing File?"),
-            QObject::tr("A .cod version of this deck already exists. Overwrite it?"),
-            QMessageBox::Yes | QMessageBox::No
-        );
+        QMessageBox::StandardButton reply =
+            QMessageBox::question(parent, QObject::tr("Overwrite Existing File?"),
+                                  QObject::tr("A .cod version of this deck already exists. Overwrite it?"),
+                                  QMessageBox::Yes | QMessageBox::No);
         return reply == QMessageBox::Yes;
     }
     return true; // Safe to proceed


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5802

## Short roundup of the initial problem
We blindly save a .txt file with a new .cod extension without checking if the file exists beforehand.

## What will change with this Pull Request?
- Prompt user if overwrite is desirable if file with new extension exists on disk.

## Screenshots
![image](https://github.com/user-attachments/assets/89299507-23e1-4bf1-a9cc-394e4784d430)

