### PR TITLE
[GDE] Add a group criteria to the deck list model 

### DIFF
--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -104,6 +104,19 @@ void DeckEditorDeckDockWidget::createDeckDock()
     deckTagsDisplayWidget = new DeckPreviewDeckTagsDisplayWidget(this, deckModel->getDeckList());
     deckTagsDisplayWidget->setHidden(!SettingsCache::instance().getDeckEditorTagsWidgetVisible());
 
+    activeGroupCriteriaLabel = new QLabel(this);
+
+    activeGroupCriteriaComboBox = new QComboBox(this);
+    activeGroupCriteriaComboBox->addItem(tr("Main Type"), DeckListModelGroupCriteria::MAIN_TYPE);
+    activeGroupCriteriaComboBox->addItem(tr("Mana Cost"), DeckListModelGroupCriteria::MANA_COST);
+    activeGroupCriteriaComboBox->addItem(tr("Colors"), DeckListModelGroupCriteria::COLOR);
+    connect(activeGroupCriteriaComboBox, &QComboBox::currentIndexChanged, [this]() {
+        deckModel->setActiveGroupCriteria(
+            static_cast<DeckListModelGroupCriteria>(activeGroupCriteriaComboBox->currentData(Qt::UserRole).toInt()));
+        deckView->expandAll();
+        deckView->expandAll();
+    });
+
     aIncrement = new QAction(QString(), this);
     aIncrement->setIcon(QPixmap("theme:icons/increment"));
     connect(aIncrement, &QAction::triggered, this, &DeckEditorDeckDockWidget::actIncrement);
@@ -144,6 +157,9 @@ void DeckEditorDeckDockWidget::createDeckDock()
 
     upperLayout->addWidget(deckTagsDisplayWidget, 3, 1);
 
+    upperLayout->addWidget(activeGroupCriteriaLabel, 4, 0);
+    upperLayout->addWidget(activeGroupCriteriaComboBox, 4, 1);
+
     hashLabel1 = new QLabel();
     hashLabel1->setObjectName("hashLabel1");
     auto *hashSizePolicy = new QSizePolicy();
@@ -153,6 +169,8 @@ void DeckEditorDeckDockWidget::createDeckDock()
     hashLabel->setObjectName("hashLabel");
     hashLabel->setReadOnly(true);
     hashLabel->setFrame(false);
+
+
 
     auto *lowerLayout = new QGridLayout;
     lowerLayout->setObjectName("lowerLayout");
@@ -578,6 +596,7 @@ void DeckEditorDeckDockWidget::retranslateUi()
     showBannerCardCheckBox->setText(tr("Show banner card selection menu"));
     showTagsWidgetCheckBox->setText(tr("Show tags selection menu"));
     commentsLabel->setText(tr("&Comments:"));
+    activeGroupCriteriaLabel->setText(tr("Group by:"));
     hashLabel1->setText(tr("Hash:"));
 
     aIncrement->setText(tr("&Increment number"));

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -110,7 +110,7 @@ void DeckEditorDeckDockWidget::createDeckDock()
     activeGroupCriteriaComboBox->addItem(tr("Main Type"), DeckListModelGroupCriteria::MAIN_TYPE);
     activeGroupCriteriaComboBox->addItem(tr("Mana Cost"), DeckListModelGroupCriteria::MANA_COST);
     activeGroupCriteriaComboBox->addItem(tr("Colors"), DeckListModelGroupCriteria::COLOR);
-    connect(activeGroupCriteriaComboBox, &QComboBox::currentIndexChanged, [this]() {
+    connect(activeGroupCriteriaComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), [this]() {
         deckModel->setActiveGroupCriteria(
             static_cast<DeckListModelGroupCriteria>(activeGroupCriteriaComboBox->currentData(Qt::UserRole).toInt()));
         deckView->expandAll();
@@ -169,8 +169,6 @@ void DeckEditorDeckDockWidget::createDeckDock()
     hashLabel->setObjectName("hashLabel");
     hashLabel->setReadOnly(true);
     hashLabel->setFrame(false);
-
-
 
     auto *lowerLayout = new QGridLayout;
     lowerLayout->setObjectName("lowerLayout");

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -113,6 +113,7 @@ void DeckEditorDeckDockWidget::createDeckDock()
     connect(activeGroupCriteriaComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), [this]() {
         deckModel->setActiveGroupCriteria(
             static_cast<DeckListModelGroupCriteria>(activeGroupCriteriaComboBox->currentData(Qt::UserRole).toInt()));
+        deckModel->sort(deckView->header()->sortIndicatorSection(), deckView->header()->sortIndicatorOrder());
         deckView->expandAll();
         deckView->expandAll();
     });

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.h
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.h
@@ -70,6 +70,8 @@ private:
     DeckPreviewDeckTagsDisplayWidget *deckTagsDisplayWidget;
     QLabel *hashLabel1;
     LineEditUnfocusable *hashLabel;
+    QLabel* activeGroupCriteriaLabel;
+    QComboBox* activeGroupCriteriaComboBox;
 
     QAction *aRemoveCard, *aIncrement, *aDecrement, *aSwapCard;
 

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.h
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.h
@@ -70,8 +70,8 @@ private:
     DeckPreviewDeckTagsDisplayWidget *deckTagsDisplayWidget;
     QLabel *hashLabel1;
     LineEditUnfocusable *hashLabel;
-    QLabel* activeGroupCriteriaLabel;
-    QComboBox* activeGroupCriteriaComboBox;
+    QLabel *activeGroupCriteriaLabel;
+    QComboBox *activeGroupCriteriaComboBox;
 
     QAction *aRemoveCard, *aIncrement, *aDecrement, *aSwapCard;
 

--- a/cockatrice/src/deck/deck_list_model.cpp
+++ b/cockatrice/src/deck/deck_list_model.cpp
@@ -29,7 +29,8 @@ DeckListModel::~DeckListModel()
     delete root;
 }
 
-QString DeckListModel::getSortCriteriaForCard(CardInfoPtr info){
+QString DeckListModel::getSortCriteriaForCard(CardInfoPtr info)
+{
     if (!info) {
         return "unknown";
     }
@@ -484,7 +485,8 @@ void DeckListModel::sort(int column, Qt::SortOrder order)
     emit layoutChanged();
 }
 
-void DeckListModel::setActiveGroupCriteria(DeckListModelGroupCriteria newCriteria){
+void DeckListModel::setActiveGroupCriteria(DeckListModelGroupCriteria newCriteria)
+{
     activeGroupCriteria = newCriteria;
     rebuildTree();
 }

--- a/cockatrice/src/deck/deck_list_model.cpp
+++ b/cockatrice/src/deck/deck_list_model.cpp
@@ -29,6 +29,23 @@ DeckListModel::~DeckListModel()
     delete root;
 }
 
+QString DeckListModel::getSortCriteriaForCard(CardInfoPtr info){
+    if (!info) {
+        return "unknown";
+    }
+
+    switch (activeGroupCriteria) {
+        case DeckListModelGroupCriteria::MAIN_TYPE:
+            return info->getMainCardType();
+        case DeckListModelGroupCriteria::MANA_COST:
+            return info->getCmc();
+        case DeckListModelGroupCriteria::COLOR:
+            return info->getColors() == "" ? "Colorless" : info->getColors();
+        default:
+            return "unknown";
+    }
+}
+
 void DeckListModel::rebuildTree()
 {
     beginResetModel();
@@ -49,7 +66,7 @@ void DeckListModel::rebuildTree()
             }
 
             CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(currentCard->getName());
-            QString cardType = info ? info->getMainCardType() : "unknown";
+            QString cardType = getSortCriteriaForCard(info);
 
             auto *cardTypeNode = dynamic_cast<InnerDecklistNode *>(node->findChild(cardType));
 
@@ -465,6 +482,11 @@ void DeckListModel::sort(int column, Qt::SortOrder order)
     root->setSortMethod(sortMethod);
     sortHelper(root, order);
     emit layoutChanged();
+}
+
+void DeckListModel::setActiveGroupCriteria(DeckListModelGroupCriteria newCriteria){
+    activeGroupCriteria = newCriteria;
+    rebuildTree();
 }
 
 void DeckListModel::cleanList()

--- a/cockatrice/src/deck/deck_list_model.h
+++ b/cockatrice/src/deck/deck_list_model.h
@@ -12,6 +12,12 @@ class CardDatabase;
 class QPrinter;
 class QTextCursor;
 
+enum DeckListModelGroupCriteria{
+    MAIN_TYPE,
+    MANA_COST,
+    COLOR
+};
+
 class DecklistModelCardNode : public AbstractDecklistCardNode
 {
 private:
@@ -85,6 +91,7 @@ signals:
 public:
     explicit DeckListModel(QObject *parent = nullptr);
     ~DeckListModel() override;
+    QString getSortCriteriaForCard(CardInfoPtr info);
     int rowCount(const QModelIndex &parent) const override;
     int columnCount(const QModelIndex & /*parent*/ = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role) const override;
@@ -113,10 +120,12 @@ public:
     QList<CardInfoPtr> getCardsAsCardInfoPtrs() const;
     QList<CardInfoPtr> getCardsAsCardInfoPtrsForZone(QString zoneName) const;
     QList<QString> *getZones() const;
+    void setActiveGroupCriteria(DeckListModelGroupCriteria newCriteria);
 
 private:
     DeckLoader *deckList;
     InnerDecklistNode *root;
+    DeckListModelGroupCriteria activeGroupCriteria = DeckListModelGroupCriteria::MAIN_TYPE;
     int lastKnownColumn;
     Qt::SortOrder lastKnownOrder;
     InnerDecklistNode *createNodeIfNeeded(const QString &name, InnerDecklistNode *parent);

--- a/cockatrice/src/deck/deck_list_model.h
+++ b/cockatrice/src/deck/deck_list_model.h
@@ -12,7 +12,8 @@ class CardDatabase;
 class QPrinter;
 class QTextCursor;
 
-enum DeckListModelGroupCriteria{
+enum DeckListModelGroupCriteria
+{
     MAIN_TYPE,
     MANA_COST,
     COLOR


### PR DESCRIPTION
and a combo box to the deck dock widget to change it.

## Related Ticket(s)
- Sort of related to #3763, #4408, and #4869

## Short roundup of the initial problem
The DeckListModel always constructs the treeview so that the level directly beneath the root is the card's main type and any other node simply gets inserted below that. That's not necessarily a bad way to do it but it lacks flexibility.

## What will change with this Pull Request?
- Define an activeGroupCriteria enum that the DeckListModel uses to determine which card property to group on and what the relevant property for the current card is.

## Caveat
~~This is currently unsorted until we look at DeckListModel::sortHelper, DeckListModel::sort and InnerDecklistNode::sort further.~~
Sorting isn't perfect but it's there.

## Screenshots
![image](https://github.com/user-attachments/assets/e4575016-9997-4529-983d-fd0a83a60169)
![image](https://github.com/user-attachments/assets/038e3831-8c02-4fb7-b433-9d9e60ed44c8)
