### PR TITLE
Fix segfault when multiple cards are dragged from view zone

### DIFF
--- a/cockatrice/src/game/board/abstract_card_drag_item.cpp
+++ b/cockatrice/src/game/board/abstract_card_drag_item.cpp
@@ -19,6 +19,7 @@ AbstractCardDragItem::AbstractCardDragItem(AbstractCardItem *_item,
     if (parentDrag) {
         parentDrag->addChildDrag(this);
         setZValue(2000000007 + hotSpot.x() * 1000000 + hotSpot.y() * 1000 + 1000);
+        connect(parentDrag, &QObject::destroyed, this, &AbstractCardDragItem::deleteLater);
     } else {
         hotSpot = QPointF{qBound(0.0, hotSpot.x(), static_cast<qreal>(CARD_WIDTH - 1)),
                           qBound(0.0, hotSpot.y(), static_cast<qreal>(CARD_HEIGHT - 1))};
@@ -41,12 +42,6 @@ AbstractCardDragItem::AbstractCardDragItem(AbstractCardItem *_item,
     });
 
     connect(item, &QObject::destroyed, this, &AbstractCardDragItem::deleteLater);
-}
-
-AbstractCardDragItem::~AbstractCardDragItem()
-{
-    for (int i = 0; i < childDrags.size(); i++)
-        delete childDrags[i];
 }
 
 QPainterPath AbstractCardDragItem::shape() const

--- a/cockatrice/src/game/board/abstract_card_drag_item.h
+++ b/cockatrice/src/game/board/abstract_card_drag_item.h
@@ -26,7 +26,6 @@ public:
         return Type;
     }
     AbstractCardDragItem(AbstractCardItem *_item, const QPointF &_hotSpot, AbstractCardDragItem *parentDrag = 0);
-    ~AbstractCardDragItem() override;
     QRectF boundingRect() const override
     {
         return QRectF(0, 0, CARD_WIDTH, CARD_HEIGHT);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5911

## Short roundup of the initial problem

Due to the above PR, Cockatrice crashes if you drag multiple cards out of a card view zone.

This is because the `AbstractCardDragItem` is trying to delete all its child dragItem. However, those child dragItems have already been deleted due to their reference cardItem being deleted when moved out of the card view.

## What will change with this Pull Request?

- Changed how child dragItem deletion is handled. 
  - Previous: `AbstractCardDragItem` is responsible for deleting all child dragItems when it itself is destroyed
    - `AbstractCardDragItem` destructor deletes all child dragItems
  - Now: Each child `AbstractCardDragItem` is responsible for deleting itself when its parent gets destroyed.
    - Each `AbstractCardDragItem` connects to its parent's `QObject::destroyed` signal.

