### PR TITLE
Bug template: Add debug log

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,13 +9,23 @@ assignees: ''
 ---
 
 <!--                   READ THIS BEFORE POSTING
-Go to "Help → View Debug Log" in Cockatrice and copy all information at the
-top (above the separation line) below "System Information" in this ticket!
+In Cockatrice, go to "Help" → "View Debug Log" and copy all information displayed at the
+top (above the separation line "----"), to below "System Information" section in this ticket!
 If you can't start Cockatrice to access these details, make
-sure to post your OS and the file name of the setup binary instead. -->
+sure to post your OS and the file name of the setup binary instead.
+-->
 
 **System Information:**
+<!-- Read the hint above on where to find the important information to provide here! -->
 
+
+<details><summary>Debug Log:</summary>
+<!--
+In Cockatrice, go to "Help" → "View Debug Log", click the "Copy to clickboard" button and paste the output here.
+-->
+
+
+</details>
 
 _______________________________________________________________________________________
 
@@ -26,7 +36,7 @@ ________________________________________________________________________________
 
 _______________________________________________________________________________________
 
-<!-- Describe the sequence of actions needed to experience the bug -->
+<!-- Describe the sequence of actions needed to experience the bug. -->
 
 **Steps to reproduce:**
  - Do A


### PR DESCRIPTION
## Related Ticket(s)
- Related https://github.com/Cockatrice/Cockatrice/pull/5913

## Short roundup of the initial problem
Logs are often not provided in bug reports.

## What will change with this Pull Request?
- Add collapsible section for the log to not pollute the ticket
- Better explanation
