### PR TITLE
CI: Tweak ccache for Linux builds

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -139,11 +139,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Generate cache timestamp
-        id: cache_timestamp
-        shell: bash
-        run: echo "timestamp=$(date -u '+%Y%m%d%H%M%S')" >> "$GITHUB_OUTPUT"
-
       - name: Build ${{matrix.distro}} ${{matrix.version}} Docker image
         shell: bash
         run: source .ci/docker.sh --build
@@ -152,10 +147,10 @@ jobs:
         id: ccache_restore
         uses: actions/cache/restore@v4
         env:
-          timestamp: ${{steps.cache_timestamp.outputs.timestamp}}
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         with:
           path: ${{env.CACHE}}
-          key: ccache-${{matrix.distro}}${{matrix.version}}-${{env.timestamp}}
+          key: ccache-${{matrix.distro}}${{matrix.version}}-${{env.BRANCH_NAME}}
           restore-keys: ccache-${{matrix.distro}}${{matrix.version}}-
 
       - name: Build debug and test
@@ -182,8 +177,6 @@ jobs:
       - name: Save compiler cache (ccache)
         if: github.ref == 'refs/heads/master'
         uses: actions/cache/save@v4
-        env:
-          timestamp: ${{steps.cache_timestamp.outputs.timestamp}}
         with:
           path: ${{env.CACHE}}
           key: ${{ steps.ccache_restore.outputs.cache-primary-key }}

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -142,21 +142,21 @@ jobs:
       - name: Generate cache timestamp
         id: cache_timestamp
         shell: bash
-        run: echo "timestamp=$(date -u '+%Y%m%d%H%M%S')" >>"$GITHUB_OUTPUT"
-
-      - name: Restore cache
-        uses: actions/cache@v4
-        env:
-          timestamp: ${{steps.cache_timestamp.outputs.timestamp}}
-        with:
-          path: ${{env.CACHE}}
-          key: docker-${{matrix.distro}}${{matrix.version}}-cache-${{env.timestamp}}
-          restore-keys: |
-            docker-${{matrix.distro}}${{matrix.version}}-cache-
+        run: echo "timestamp=$(date -u '+%Y%m%d%H%M%S')" >> "$GITHUB_OUTPUT"
 
       - name: Build ${{matrix.distro}} ${{matrix.version}} Docker image
         shell: bash
         run: source .ci/docker.sh --build
+
+      - name: Restore compiler cache (ccache)
+        id: ccache_restore
+        uses: actions/cache/restore@v4
+        env:
+          timestamp: ${{steps.cache_timestamp.outputs.timestamp}}
+        with:
+          path: ${{env.CACHE}}
+          key: ccache-${{matrix.distro}}${{matrix.version}}-${{env.timestamp}}
+          restore-keys: ccache-${{matrix.distro}}${{matrix.version}}-
 
       - name: Build debug and test
         if: matrix.test != 'skip'
@@ -178,6 +178,15 @@ jobs:
           RUN --server --release --package "$type" --dir "$BUILD_DIR" \
                   --ccache "$CCACHE_SIZE" --parallel 4
           .ci/name_build.sh
+
+      - name: Save compiler cache (ccache)
+        if: github.ref == 'refs/heads/master'
+        uses: actions/cache/save@v4
+        env:
+          timestamp: ${{steps.cache_timestamp.outputs.timestamp}}
+        with:
+          path: ${{env.CACHE}}
+          key: ${{ steps.ccache_restore.outputs.cache-primary-key }}
 
       - name: Upload artifact
         if: matrix.package != 'skip'


### PR DESCRIPTION
## Related Ticket(s)
- Related https://github.com/Cockatrice/Cockatrice/pull/5935
- Linking #3781

## Short roundup of the initial problem
~75% of all caches (150) stored right now are from Linux builds.
See duplicates here for example from the same branch just with different timestamps:
![image](https://github.com/user-attachments/assets/2e1a8286-b7a9-402e-9084-000525eff178)

Due to the constant recreation with a new name (changing timestamp), even if no actual changes happened, we are always over the 10GB limit and the oldest cache overall we can keep is only 19h old.
![image](https://github.com/user-attachments/assets/55fd276b-178e-4e75-ade4-15579ce1280a)

After the increase in allowed cache size (#5935):
![image](https://github.com/user-attachments/assets/7a1e4799-372a-4ff6-93bf-23160bafd3b8)


Existing caches of the repo can be reviewed here: https://github.com/Cockatrice/Cockatrice/actions/caches

## What will change with this Pull Request?
- Split cache action in `restore` & `save` parts wrapping around the build steps
- Only execute `save` to upload new caches when run on master to reduce amount of similar caches stored in the repo. As all PR's are usually based off master, the cache from there should still be useful.
- Clearer cache naming `ccache-Debian12-[timestamp]`

<br>

I'm sure that's not perfect either and there is probably a better way.
Instead including a timestamp, we could add the source branch in the primary key (`key`) to not have duplicated caches for the "same" change and scope the cache better. Or removing seconds, minutes and maybe also hours from the timestamp to update only once a day is an improvement?

In general, it appears a good strategy to always have a valid cache on the default branch as that would be reused by all branches based off of it. Currently that is not guaranteed as the caches are replaced so often/quickly and only preserved for 1-2 days.
When just going with updating the cache for the default (master) branch, we can probably also remove the timestamp?

Matching keys logic: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#matching-a-cache-key

Hope somebody can chip in to the topic and has experience in reusing compiler caches and which caching strategy to use in GitHub CI.

<br>

macOS and Windows builds do not utilize compiler cache yet and run considerably longer for that reason: #3059