### PR TITLE
ci: use Ninja on Linux and macOS builds

### DIFF
--- a/.ci/Arch/Dockerfile
+++ b/.ci/Arch/Dockerfile
@@ -7,6 +7,7 @@ RUN pacman --sync --refresh --sysupgrade --needed --noconfirm \
         git \
         gtest \
         mariadb-libs \
+        ninja \
         protobuf \
         qt6-base \
         qt6-imageformats \

--- a/.ci/Debian11/Dockerfile
+++ b/.ci/Debian11/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
         libqt5sql5-mysql \
         libqt5svg5-dev \
         libqt5websockets5-dev \
+        ninja-build \
         protobuf-compiler \
         qt5-image-formats-plugins \
         qtmultimedia5-dev \

--- a/.ci/Debian12/Dockerfile
+++ b/.ci/Debian12/Dockerfile
@@ -15,13 +15,14 @@ RUN apt-get update && \
         libprotobuf-dev \
         libqt6multimedia6 \
         libqt6sql6-mysql \
-        qt6-svg-dev \
-        qt6-websockets-dev \
+        ninja-build \
         protobuf-compiler \
         qt6-image-formats-plugins \
         qt6-l10n-tools \
         qt6-multimedia-dev \
+        qt6-svg-dev \
         qt6-tools-dev \
         qt6-tools-dev-tools \
+        qt6-websockets-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/.ci/Fedora41/Dockerfile
+++ b/.ci/Fedora41/Dockerfile
@@ -6,6 +6,7 @@ RUN dnf install -y \
         gcc-c++ \
         git \
         mariadb-devel \
+        ninja-build \
         protobuf-devel \
         qt6-{qttools,qtsvg,qtmultimedia,qtwebsockets}-devel \
         qt6-qtimageformats \

--- a/.ci/Fedora42/Dockerfile
+++ b/.ci/Fedora42/Dockerfile
@@ -6,6 +6,7 @@ RUN dnf install -y \
         gcc-c++ \
         git \
         mariadb-devel \
+        ninja-build \
         protobuf-devel \
         qt6-{qttools,qtsvg,qtmultimedia,qtwebsockets}-devel \
         qt6-qtimageformats \

--- a/.ci/Ubuntu22.04/Dockerfile
+++ b/.ci/Ubuntu22.04/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && \
         libqt6sql6-mysql \
         libqt6svg6-dev \
         libqt6websockets6-dev \
+        ninja-build \
         protobuf-compiler \
         qt6-image-formats-plugins \
         qt6-l10n-tools \

--- a/.ci/Ubuntu24.04/Dockerfile
+++ b/.ci/Ubuntu24.04/Dockerfile
@@ -15,13 +15,14 @@ RUN apt-get update && \
         libprotobuf-dev \
         libqt6multimedia6 \
         libqt6sql6-mysql \
-        qt6-svg-dev \
-        qt6-websockets-dev \
+        ninja-build \
         protobuf-compiler \
         qt6-image-formats-plugins \
         qt6-l10n-tools \
         qt6-multimedia-dev \
+        qt6-svg-dev \
         qt6-tools-dev \
         qt6-tools-dev-tools \
+        qt6-websockets-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/.ci/docker.sh
+++ b/.ci/docker.sh
@@ -147,6 +147,7 @@ function RUN ()
     if [[ $CCACHE_DIR ]]; then
       args+=(--mount "type=bind,source=$CCACHE_DIR,target=/.ccache")
       args+=(--env "CCACHE_DIR=/.ccache")
+      args+=(--env "CMAKE_GENERATOR="Ninja"")
     fi
     docker run "${args[@]}" $RUN_ARGS "$IMAGE_NAME" bash "$BUILD_SCRIPT" $RUN_OPTS "$@"
     return $?

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -161,7 +161,7 @@ jobs:
           CMAKE_GENERATOR: '${{env.CMAKE_GENERATOR}}'
         run: |
           source .ci/docker.sh
-          RUN --server --debug --test --ccache "$CCACHE_SIZE" --parallel 4
+          RUN --server --debug --test --ccache "$CCACHE_SIZE"
 
       - name: Build release package
         id: build
@@ -175,7 +175,7 @@ jobs:
         run: |
           source .ci/docker.sh
           RUN --server --release --package "$type" --dir "$BUILD_DIR" \
-                  --ccache "$CCACHE_SIZE" --parallel 4
+                  --ccache "$CCACHE_SIZE"
           .ci/name_build.sh
 
       - name: Upload artifact
@@ -206,7 +206,6 @@ jobs:
             os: macos-13
             xcode: "14.3.1"
             type: Release
-            core_count: 4
             make_package: 1
 
           - target: 14
@@ -214,7 +213,6 @@ jobs:
             os: macos-14
             xcode: "15.4"
             type: Release
-            core_count: 3
             make_package: 1
 
           - target: 15
@@ -222,7 +220,6 @@ jobs:
             os: macos-15
             xcode: "16.2"
             type: Release
-            core_count: 3
             make_package: 1
 
           - target: 15
@@ -230,7 +227,6 @@ jobs:
             os: macos-15
             xcode: "16.2"
             type: Debug
-            core_count: 3
 
     name: macOS ${{matrix.target}}${{ matrix.soc == 'Intel' && ' Intel' || '' }}${{ matrix.type == 'Debug' && ' Debug' || '' }}
     needs: configure
@@ -268,9 +264,6 @@ jobs:
           MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
           CMAKE_GENERATOR: '${{env.CMAKE_GENERATOR}}'
-        # macOS runner have 3 cores usually - only the macos-13 image has 4:
-        # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
-        # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
         run: |
           if [[ -n "$MACOS_CERTIFICATE_NAME" ]]
           then
@@ -282,7 +275,7 @@ jobs:
             security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
             security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
           fi
-          .ci/compile.sh --server --parallel ${{matrix.core_count}}
+          .ci/compile.sh --server
 
       - name: Sign app bundle
         if: matrix.make_package

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -129,6 +129,7 @@ jobs:
       # Cache size over the entire repo is 10Gi:
       # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
       CCACHE_SIZE: 500M
+      CMAKE_GENERATOR: 'Ninja'
 
     steps:
       - name: Checkout
@@ -156,6 +157,8 @@ jobs:
       - name: Build debug and test
         if: matrix.test != 'skip'
         shell: bash
+        env:
+          CMAKE_GENERATOR: '${{env.CMAKE_GENERATOR}}'
         run: |
           source .ci/docker.sh
           RUN --server --debug --test --ccache "$CCACHE_SIZE" --parallel 4
@@ -168,6 +171,7 @@ jobs:
           BUILD_DIR: build
           SUFFIX: '-${{matrix.distro}}${{matrix.version}}'
           type: '${{matrix.package}}'
+          CMAKE_GENERATOR: '${{env.CMAKE_GENERATOR}}'
         run: |
           source .ci/docker.sh
           RUN --server --release --package "$type" --dir "$BUILD_DIR" \
@@ -235,6 +239,7 @@ jobs:
     env:
       DEVELOPER_DIR:
         /Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer
+      CMAKE_GENERATOR: 'Ninja'
 
     steps:
       - name: Checkout
@@ -262,6 +267,7 @@ jobs:
           MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
           MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
+          CMAKE_GENERATOR: '${{env.CMAKE_GENERATOR}}'
         # macOS runner have 3 cores usually - only the macos-13 image has 4:
         # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
         # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
@@ -394,7 +400,6 @@ jobs:
         env:
           PACKAGE_SUFFIX: '-Win${{matrix.target}}'
           CMAKE_GENERATOR: '${{env.CMAKE_GENERATOR}}'
-          CMAKE_GENERATOR_PLATFORM: 'x64'
           QTDIR: '${{github.workspace}}\Qt\${{matrix.qt_version}}\win64_${{matrix.qt_arch}}'
           VCPKG_DISABLE_METRICS: 1
           VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5887 (partially, missing Windows support)

## Short roundup of the initial problem
Ninja is usually faster than make (and Visual Studio builds) 


## What will change with this Pull Request?
- Ninja will be used on CI builds for all linux and macos targets
- Removed manual parallelism settings in favor of letting ninja decide
- This won't affect local builds.

## Screenshots
N/A
