### PR TITLE
Refactor TabGame: inline some QLayout and QWidget class fields

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -1538,7 +1538,7 @@ void TabGame::createPlayAreaWidget(bool bReplay)
     scene = new GameScene(phasesToolbar, this);
     gameView = new GameView(scene);
 
-    gamePlayAreaVBox = new QVBoxLayout;
+    auto gamePlayAreaVBox = new QVBoxLayout;
     gamePlayAreaVBox->setContentsMargins(0, 0, 0, 0);
     gamePlayAreaVBox->addWidget(gameView);
 
@@ -1594,7 +1594,7 @@ void TabGame::createReplayDock()
     connect(replayFastForwardButton, &QToolButton::toggled, this, &TabGame::replayFastForwardButtonToggled);
 
     // putting everything together
-    replayControlLayout = new QHBoxLayout;
+    auto replayControlLayout = new QHBoxLayout;
     replayControlLayout->addWidget(timelineWidget, 10);
     replayControlLayout->addWidget(replayPlayButton);
     replayControlLayout->addWidget(replayFastForwardButton);
@@ -1635,8 +1635,8 @@ void TabGame::createCardInfoDock(bool bReplay)
     Q_UNUSED(bReplay);
 
     cardInfoFrameWidget = new CardInfoFrameWidget();
-    cardHInfoLayout = new QHBoxLayout;
-    cardVInfoLayout = new QVBoxLayout;
+    auto cardHInfoLayout = new QHBoxLayout;
+    auto cardVInfoLayout = new QVBoxLayout;
     cardVInfoLayout->setContentsMargins(0, 0, 0, 0);
     cardVInfoLayout->addWidget(cardInfoFrameWidget);
     cardVInfoLayout->addLayout(cardHInfoLayout);
@@ -1679,11 +1679,16 @@ void TabGame::createPlayerListDock(bool bReplay)
 
 void TabGame::createMessageDock(bool bReplay)
 {
+    auto messageLogLayout = new QVBoxLayout;
+    messageLogLayout->setContentsMargins(0, 0, 0, 0);
+
     messageLog = new MessageLogWidget(tabSupervisor, this);
     connect(messageLog, &MessageLogWidget::cardNameHovered, cardInfoFrameWidget,
             qOverload<const QString &>(&CardInfoFrameWidget::setCard));
     connect(messageLog, &MessageLogWidget::showCardInfoPopup, this, &TabGame::showCardInfoPopup);
     connect(messageLog, &MessageLogWidget::deleteCardInfoPopup, this, &TabGame::deleteCardInfoPopup);
+
+    messageLogLayout->addWidget(messageLog);
 
     if (!bReplay) {
         connect(messageLog, &MessageLogWidget::openMessageDialog, this, &TabGame::openMessageDialog);
@@ -1697,6 +1702,8 @@ void TabGame::createMessageDock(bool bReplay)
         gameTimer->setInterval(1000);
         connect(gameTimer, &QTimer::timeout, this, &TabGame::incrementGameTime);
         gameTimer->start();
+
+        messageLogLayout->addWidget(timeElapsedLabel);
 
         sayLabel = new QLabel;
         sayEdit = new LineEditCompleter;
@@ -1726,18 +1733,12 @@ void TabGame::createMessageDock(bool bReplay)
         connect(tabSupervisor, &TabSupervisor::adminLockChanged, this, &TabGame::adminLockChanged);
         connect(sayEdit, &LineEditCompleter::returnPressed, this, &TabGame::actSay);
 
-        sayHLayout = new QHBoxLayout;
+        auto sayHLayout = new QHBoxLayout;
         sayHLayout->addWidget(sayLabel);
         sayHLayout->addWidget(sayEdit);
-    }
 
-    messageLogLayout = new QVBoxLayout;
-    messageLogLayout->setContentsMargins(0, 0, 0, 0);
-    if (!bReplay)
-        messageLogLayout->addWidget(timeElapsedLabel);
-    messageLogLayout->addWidget(messageLog);
-    if (!bReplay)
         messageLogLayout->addLayout(sayHLayout);
+    }
 
     messageLogLayoutWidget = new QWidget;
     messageLogLayoutWidget->setLayout(messageLogLayout);

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -1599,7 +1599,7 @@ void TabGame::createReplayDock()
     replayControlLayout->addWidget(replayPlayButton);
     replayControlLayout->addWidget(replayFastForwardButton);
 
-    replayControlWidget = new QWidget();
+    auto replayControlWidget = new QWidget();
     replayControlWidget->setObjectName("replayControlWidget");
     replayControlWidget->setLayout(replayControlLayout);
 
@@ -1641,7 +1641,7 @@ void TabGame::createCardInfoDock(bool bReplay)
     cardVInfoLayout->addWidget(cardInfoFrameWidget);
     cardVInfoLayout->addLayout(cardHInfoLayout);
 
-    cardBoxLayoutWidget = new QWidget;
+    auto cardBoxLayoutWidget = new QWidget;
     cardBoxLayoutWidget->setLayout(cardVInfoLayout);
 
     cardInfoDock = new QDockWidget(this);
@@ -1740,7 +1740,7 @@ void TabGame::createMessageDock(bool bReplay)
         messageLogLayout->addLayout(sayHLayout);
     }
 
-    messageLogLayoutWidget = new QWidget;
+    auto messageLogLayoutWidget = new QWidget;
     messageLogLayoutWidget->setLayout(messageLogLayout);
 
     messageLayoutDock = new QDockWidget(this);

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -111,8 +111,7 @@ private:
     GameScene *scene;
     GameView *gameView;
     QMap<int, DeckViewContainer *> deckViewContainers;
-    QVBoxLayout *cardVInfoLayout, *messageLogLayout, *gamePlayAreaVBox, *deckViewContainerLayout;
-    QHBoxLayout *cardHInfoLayout, *sayHLayout, *mainHLayout, *replayControlLayout;
+    QVBoxLayout *deckViewContainerLayout;
     QWidget *cardBoxLayoutWidget, *messageLogLayoutWidget, *gamePlayAreaWidget, *deckViewContainerWidget,
         *replayControlWidget;
     QDockWidget *cardInfoDock, *messageLayoutDock, *playerListDock, *replayDock;

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -112,8 +112,7 @@ private:
     GameView *gameView;
     QMap<int, DeckViewContainer *> deckViewContainers;
     QVBoxLayout *deckViewContainerLayout;
-    QWidget *cardBoxLayoutWidget, *messageLogLayoutWidget, *gamePlayAreaWidget, *deckViewContainerWidget,
-        *replayControlWidget;
+    QWidget *gamePlayAreaWidget, *deckViewContainerWidget;
     QDockWidget *cardInfoDock, *messageLayoutDock, *playerListDock, *replayDock;
     QAction *playersSeparator;
     QMenu *gameMenu, *viewMenu, *cardInfoDockMenu, *messageLayoutDockMenu, *playerListDockMenu, *replayDockMenu;


### PR DESCRIPTION
## Short roundup of the initial problem

In `TabGame`, some nested `QLayout`s and `QWidget`s are saved as class fields, even though they are only used during widget creation and never referenced again.

## What will change with this Pull Request?
- Removed some `QLayout` and `QWidget` class fields that are only used during dock creation.
  - Instead, just directly declare the layout or widget in the method that uses it

This is part of an effort to refactor `TabGame` into separate classes for replays and live games.