### PR TITLE
[VDS] Deselect tag if clicked while already selected

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_tag_display_widget.cpp
@@ -50,10 +50,10 @@ void DeckPreviewTagDisplayWidget::mousePressEvent(QMouseEvent *event)
 {
     switch (event->button()) {
         case Qt::LeftButton:
-            setState(TagState::Selected);
+            setState(state != TagState::Selected ? TagState::Selected : TagState::NotSelected);
             break;
         case Qt::RightButton:
-            setState(TagState::Excluded);
+            setState(state != TagState::Excluded ? TagState::Excluded : TagState::NotSelected);
             break;
         case Qt::MiddleButton:
             setState(TagState::NotSelected);


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5920

## Short roundup of the initial problem

#5920 made it so that the only way to deselect a tag is to middle click it. Not everyone uses middle click. I literally cannot deselect tags after selecting them now because I'm on a trackpad and don't use middle click.

## What will change with this Pull Request?
- left/right click now deselects the tag if the tag is already in the corresponding state

https://github.com/user-attachments/assets/5f3b3d52-c094-4593-a200-db5109d6cb2f


