### PR TITLE
Fix wrong Message Dock widget order from #5942

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -1688,8 +1688,6 @@ void TabGame::createMessageDock(bool bReplay)
     connect(messageLog, &MessageLogWidget::showCardInfoPopup, this, &TabGame::showCardInfoPopup);
     connect(messageLog, &MessageLogWidget::deleteCardInfoPopup, this, &TabGame::deleteCardInfoPopup);
 
-    messageLogLayout->addWidget(messageLog);
-
     if (!bReplay) {
         connect(messageLog, &MessageLogWidget::openMessageDialog, this, &TabGame::openMessageDialog);
         connect(messageLog, &MessageLogWidget::addMentionTag, this, &TabGame::addMentionTag);
@@ -1704,7 +1702,11 @@ void TabGame::createMessageDock(bool bReplay)
         gameTimer->start();
 
         messageLogLayout->addWidget(timeElapsedLabel);
+    }
 
+    messageLogLayout->addWidget(messageLog);
+
+    if (!bReplay) {
         sayLabel = new QLabel;
         sayEdit = new LineEditCompleter;
         sayEdit->setMaxLength(MAX_TEXT_LENGTH);

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -1682,6 +1682,19 @@ void TabGame::createMessageDock(bool bReplay)
     auto messageLogLayout = new QVBoxLayout;
     messageLogLayout->setContentsMargins(0, 0, 0, 0);
 
+    // clock
+    if (!bReplay) {
+        timeElapsedLabel = new QLabel;
+        timeElapsedLabel->setAlignment(Qt::AlignCenter);
+        gameTimer = new QTimer(this);
+        gameTimer->setInterval(1000);
+        connect(gameTimer, &QTimer::timeout, this, &TabGame::incrementGameTime);
+        gameTimer->start();
+
+        messageLogLayout->addWidget(timeElapsedLabel);
+    }
+
+    // message log
     messageLog = new MessageLogWidget(tabSupervisor, this);
     connect(messageLog, &MessageLogWidget::cardNameHovered, cardInfoFrameWidget,
             qOverload<const QString &>(&CardInfoFrameWidget::setCard));
@@ -1693,19 +1706,11 @@ void TabGame::createMessageDock(bool bReplay)
         connect(messageLog, &MessageLogWidget::addMentionTag, this, &TabGame::addMentionTag);
         connect(&SettingsCache::instance(), &SettingsCache::chatMentionCompleterChanged, this,
                 &TabGame::actCompleterChanged);
-
-        timeElapsedLabel = new QLabel;
-        timeElapsedLabel->setAlignment(Qt::AlignCenter);
-        gameTimer = new QTimer(this);
-        gameTimer->setInterval(1000);
-        connect(gameTimer, &QTimer::timeout, this, &TabGame::incrementGameTime);
-        gameTimer->start();
-
-        messageLogLayout->addWidget(timeElapsedLabel);
     }
 
     messageLogLayout->addWidget(messageLog);
 
+    // chat entry
     if (!bReplay) {
         sayLabel = new QLabel;
         sayEdit = new LineEditCompleter;
@@ -1742,6 +1747,7 @@ void TabGame::createMessageDock(bool bReplay)
         messageLogLayout->addLayout(sayHLayout);
     }
 
+    // dock
     auto messageLogLayoutWidget = new QWidget;
     messageLogLayoutWidget->setLayout(messageLogLayout);
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced by #5942

## Short roundup of the initial problem

The timer is between the message log and the chat entry now

<img width="476" alt="Screenshot 2025-05-18 at 4 01 56 AM" src="https://github.com/user-attachments/assets/0543f228-720c-4e6e-87b9-d90c5ab25a63" />

## What will change with this Pull Request?

- Correct widget order in message dock
- Refactor and leave comments in message dock creation method

<img width="496" alt="Screenshot 2025-05-18 at 4 01 13 AM" src="https://github.com/user-attachments/assets/0930fa75-8922-4e37-8d19-8999237da90b" />
