### PR TITLE
Refactor banner card ComboBox

### DIFF
--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -303,11 +303,7 @@ void DeckEditorDeckDockWidget::updateBannerCardComboBox()
     });
 
     for (const auto &pair : pairList) {
-        QVariantMap dataMap;
-        dataMap["name"] = pair.first;
-        dataMap["uuid"] = pair.second;
-
-        bannerCardComboBox->addItem(pair.first, dataMap);
+        bannerCardComboBox->addItem(pair.first, QVariant::fromValue(pair));
     }
 
     // Try to restore the previous selection by finding the currentText
@@ -315,7 +311,7 @@ void DeckEditorDeckDockWidget::updateBannerCardComboBox()
     if (restoredIndex != -1) {
         bannerCardComboBox->setCurrentIndex(restoredIndex);
         if (deckModel->getDeckList()->getBannerCard().second !=
-            bannerCardComboBox->itemData(bannerCardComboBox->currentIndex()).toMap()["uuid"].toString()) {
+            bannerCardComboBox->currentData().value<QPair<QString, QString>>().second) {
             setBannerCard(restoredIndex);
         }
     } else {
@@ -335,9 +331,8 @@ void DeckEditorDeckDockWidget::updateBannerCardComboBox()
 
 void DeckEditorDeckDockWidget::setBannerCard(int /* changedIndex */)
 {
-    QVariantMap itemData = bannerCardComboBox->itemData(bannerCardComboBox->currentIndex()).toMap();
-    deckModel->getDeckList()->setBannerCard(
-        QPair<QString, QString>(itemData["name"].toString(), itemData["uuid"].toString()));
+    auto cardAndId = bannerCardComboBox->currentData().value<QPair<QString, QString>>();
+    deckModel->getDeckList()->setBannerCard(cardAndId);
     emit deckModified();
 }
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -282,11 +282,11 @@ void DeckPreviewWidget::updateBannerCardComboBox()
 
 void DeckPreviewWidget::setBannerCard(int /* changedIndex */)
 {
-    QVariant itemData = bannerCardComboBox->itemData(bannerCardComboBox->currentIndex());
-    deckLoader->setBannerCard(QPair<QString, QString>(bannerCardComboBox->currentText(), itemData.toString()));
+    auto nameAndId = bannerCardComboBox->currentData().value<QPair<QString, QString>>();
+    deckLoader->setBannerCard(nameAndId);
     deckLoader->saveToFile(filePath, DeckLoader::getFormatFromName(filePath));
-    bannerCardDisplayWidget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-        bannerCardComboBox->currentText(), itemData.toString()));
+    bannerCardDisplayWidget->setCard(
+        CardDatabaseManager::getInstance()->getCardByNameAndProviderId(nameAndId.first, nameAndId.second));
 }
 
 void DeckPreviewWidget::imageClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance)


### PR DESCRIPTION
## Short roundup of the initial problem

The deck editor banner card selection code did not get updated with the same changes that the VDS one did. The code for extracting the values out of the ComboBox could also be nicer.

## What will change with this Pull Request?
- In `DeckEditorDeckDockWidget`, directly use a `QVariant` of the `QPair` for the item data instead of creating a `QVariantMap`
- use `comboBox->currentData()` instead of `comboBox->itemData(comboBox->currentIndex())` to get the selected item's data.
- use `.value<QPair<QString, QString>>()` to convert the `QVariant` back to a `QPair`