### PR TITLE
FIX: re-add CMAKE_GENERATOR_PLATFORM: 'x64'

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -395,6 +395,7 @@ jobs:
         env:
           PACKAGE_SUFFIX: '-Win${{matrix.target}}'
           CMAKE_GENERATOR: '${{env.CMAKE_GENERATOR}}'
+          CMAKE_GENERATOR_PLATFORM: 'x64'
           QTDIR: '${{github.workspace}}\Qt\${{matrix.qt_version}}\win64_${{matrix.qt_arch}}'
           VCPKG_DISABLE_METRICS: 1
           VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5953

## Short roundup of the initial problem
CMAKE_GENERATOR_PLATFORM: 'x64' was removed by accident when switching to Ninja. Actually it was an early but failed attempt to also use ninja on windows, and some code spilled over on the linux/macos PR.

Tested the win10 artifact from https://github.com/brunoalr/Cockatrice/actions/runs/15173834505 on Windows -> no warning.

## What will change with this Pull Request?
- No more warnings about 32bit installation on 64bit Windows machines.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
