### PR TITLE
CI: Do not sign & notarize macOS packages for PR builds

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -298,7 +298,7 @@ jobs:
           key: ${{ steps.ccache_restore.outputs.cache-primary-key }}
 
       - name: Sign app bundle
-        if: matrix.make_package
+        if: matrix.make_package && (github.ref == 'refs/heads/master' || needs.configure.outputs.tag != null)
         env:
           MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
@@ -310,7 +310,7 @@ jobs:
           fi
 
       - name: Notarize app bundle
-        if: matrix.make_package
+        if: matrix.make_package && (github.ref == 'refs/heads/master' || needs.configure.outputs.tag != null)
         env:
           MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
           MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}


### PR DESCRIPTION
## Short roundup of the initial problem
Signing and notarizing takes some minutes, now with compiler caching in place, this reduced the macOS CI builds by up to another 25%.

## What will change with this Pull Request?
- Only sign and notarize macOS packages on `master` or when a tag is created.
- PR builds will finish faster

