### PR TITLE
Put mutex around returning cards on concede

### DIFF
--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -920,6 +920,8 @@ Server_Player::cmdConcede(const Command_Concede & /*cmd*/, ResponseContainer & /
     game->removeArrowsRelatedToPlayer(ges, this);
     game->unattachCards(ges, this);
 
+    playerMutex.lock();
+
     // Return cards to their rightful owners before conceding the game
     static const QRegularExpression ownerRegex{"Owner: ?([^\n]+)"};
     for (const auto &card : zones.value("table")->getCards()) {
@@ -958,6 +960,8 @@ Server_Player::cmdConcede(const Command_Concede & /*cmd*/, ResponseContainer & /
             break;
         }
     }
+
+    playerMutex.unlock();
 
     // All borrowed cards have been returned, can now continue cleanup process
     clearZones();


### PR DESCRIPTION
## Short roundup of the initial problem

The server has been segfaulting recently.

```
#0  0x00005b583f5b75fa in Server_Card::getId (this=0x14) at /root/cockatrice_github/common/server_card.h:77
#1  0x00005b583f5d7c93 in Server_Player::cmdConcede (this=0x5b5895ed2b60, ges=...) at /root/cockatrice_github/common/server_player.cpp:936
#2  0x00005b583f5e142a in Server_Player::processGameCommand (this=0x5b5895ed2b60, command=..., rc=..., ges=...) at /root/cockatrice_github/common/server_player.cpp:2379
#3  0x00005b583f5fa4eb in Server_ProtocolHandler::processGameCommandContainer (this=0x5b58912f1850, cont=..., rc=...) at /root/cockatrice_github/common/server_protocolhandler.cpp:292
#4  0x00005b583f5faaf7 in Server_ProtocolHandler::processCommandContainer (this=0x5b58912f1850, cont=...) at /root/cockatrice_github/common/server_protocolhandler.cpp:362
#5  0x00005b583f535162 in WebsocketServerSocketInterface::binaryMessageReceived (this=0x5b58912f1850, message=...) at /root/cockatrice_github/servatrice/src/serversocketinterface.cpp:2095
#6  0x00005b583f4c0016 in WebsocketServerSocketInterface::qt_static_metacall (_o=0x5b58912f1850, _c=QMetaObject::InvokeMetaMethod, _id=0, _a=0x7ffea513cd40) at /root/cockatrice_github/build/servatrice/servatrice_autogen/UVLADIE3JM/moc_serversocketinterface.cpp:474
```

Seems like the cause is due to null dereference on the card object in the code for returning cards to their owners on conded. We already null check the card object in that code, so we assume the cause is due to a race condition.

## What will change with this Pull Request?

- Lock the `playerMutex` around the code that returns cards to their owners.

https://github.com/user-attachments/assets/848c8df1-e82c-4a6d-9ca3-be2941665fce

