### PR TITLE
Add "landscapeOrientation" as a valid element

### DIFF
--- a/doc/carddatabase_v4/cards.xsd
+++ b/doc/carddatabase_v4/cards.xsd
@@ -56,6 +56,7 @@
             <xs:element type="xs:integer" name="tablerow" minOccurs="0" maxOccurs="1" />
             <xs:element type="xs:boolean" name="cipt" minOccurs="0" maxOccurs="1" />
             <xs:element type="xs:boolean" name="upsidedown" minOccurs="0" maxOccurs="1" />
+            <xs:element type="xs:boolean" name="landscapeOrientation" minOccurs="0" maxOccurs="1" />
         </xs:sequence>
     </xs:complexType>
     <xs:element name="cockatrice_carddatabase">


### PR DESCRIPTION
## Short roundup of the initial problem

https://github.com/Cockatrice/Cockatrice/pull/5264 added `landscapeOrientation` as a useful xml element to display horizontal cards such as sieges properly. However, our current v4 schema does not recognize it as a valid element when parsing. 

## What will change with this Pull Request?
- Adds "landscapeOrientation" as a valid element to prevent errors when validating xmls
