### PR TITLE
[VDS] Remove searchFolderName setting

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.cpp
@@ -42,14 +42,6 @@ VisualDeckStorageQuickSettingsWidget::VisualDeckStorageQuickSettingsWidget(QWidg
     connect(showBannerCardComboBoxCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setVisualDeckStorageShowBannerCardComboBox);
 
-    // search folder names checkbox
-    searchFolderNamesCheckBox = new QCheckBox(this);
-    searchFolderNamesCheckBox->setChecked(SettingsCache::instance().getVisualDeckStorageSearchFolderNames());
-    connect(searchFolderNamesCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
-            &VisualDeckStorageQuickSettingsWidget::searchFolderNamesChanged);
-    connect(searchFolderNamesCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
-            &SettingsCache::setVisualDeckStorageSearchFolderNames);
-
     // draw unused color identities checkbox
     drawUnusedColorIdentitiesCheckBox = new QCheckBox(this);
     drawUnusedColorIdentitiesCheckBox->setChecked(
@@ -113,7 +105,6 @@ VisualDeckStorageQuickSettingsWidget::VisualDeckStorageQuickSettingsWidget(QWidg
     this->addSettingsWidget(showTagFilterCheckBox);
     this->addSettingsWidget(showTagsOnDeckPreviewsCheckBox);
     this->addSettingsWidget(showBannerCardComboBoxCheckBox);
-    this->addSettingsWidget(searchFolderNamesCheckBox);
     this->addSettingsWidget(drawUnusedColorIdentitiesCheckBox);
     this->addSettingsWidget(unusedColorIdentityOpacityWidget);
     this->addSettingsWidget(deckPreviewTooltipWidget);
@@ -130,7 +121,6 @@ void VisualDeckStorageQuickSettingsWidget::retranslateUi()
     showTagFilterCheckBox->setText(tr("Show Tag Filter"));
     showTagsOnDeckPreviewsCheckBox->setText(tr("Show Tags On Deck Previews"));
     showBannerCardComboBoxCheckBox->setText(tr("Show Banner Card Selection Option"));
-    searchFolderNamesCheckBox->setText(tr("Include Folder Names in Search"));
     drawUnusedColorIdentitiesCheckBox->setText(tr("Draw unused Color Identities"));
     unusedColorIdentitiesOpacityLabel->setText(tr("Unused Color Identities Opacity"));
     unusedColorIdentitiesOpacitySpinBox->setSuffix("%");
@@ -163,11 +153,6 @@ bool VisualDeckStorageQuickSettingsWidget::getShowTagFilter() const
 bool VisualDeckStorageQuickSettingsWidget::getShowTagsOnDeckPreviews() const
 {
     return showTagsOnDeckPreviewsCheckBox->isChecked();
-}
-
-bool VisualDeckStorageQuickSettingsWidget::getSearchFolderNames() const
-{
-    return searchFolderNamesCheckBox->isChecked();
 }
 
 int VisualDeckStorageQuickSettingsWidget::getUnusedColorIdentitiesOpacity() const

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.h
@@ -23,7 +23,6 @@ class VisualDeckStorageQuickSettingsWidget : public SettingsButtonWidget
     QCheckBox *showBannerCardComboBoxCheckBox;
     QCheckBox *showTagFilterCheckBox;
     QCheckBox *showTagsOnDeckPreviewsCheckBox;
-    QCheckBox *searchFolderNamesCheckBox;
     QLabel *unusedColorIdentitiesOpacityLabel;
     QSpinBox *unusedColorIdentitiesOpacitySpinBox;
     QLabel *deckPreviewTooltipLabel;
@@ -50,7 +49,6 @@ public:
     bool getShowBannerCardComboBox() const;
     bool getShowTagFilter() const;
     bool getShowTagsOnDeckPreviews() const;
-    bool getSearchFolderNames() const;
     int getUnusedColorIdentitiesOpacity() const;
     TooltipType getDeckPreviewTooltip() const;
     int getCardSize() const;
@@ -61,7 +59,6 @@ signals:
     void showBannerCardComboBoxChanged(bool enabled);
     void showTagFilterChanged(bool enabled);
     void showTagsOnDeckPreviewsChanged(bool enabled);
-    void searchFolderNamesChanged(bool enabled);
     void unusedColorIdentitiesOpacityChanged(int opacity);
     void deckPreviewTooltipChanged(TooltipType tooltip);
     void cardSizeChanged(int scale);

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_search_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_search_widget.cpp
@@ -52,17 +52,15 @@ QString VisualDeckStorageSearchWidget::getSearchText()
 }
 
 /**
- * Gets the filename used for the search.
+ * Converts the filepath into a relative filepath starting from the deck folder.
+ * If the file isn't in the deck folder, then this will just return the filename.
  *
- * if includeFolderName is true, then this returns the relative filepath starting from the deck folder.
- * If the file isn't in the deck folder, or includeFolderName is false, then this will just return the filename.
- *
- * @param filePath The filePath to convert into a search name
+ * @param filePath The filepath to convert into a relative filepath
  */
-static QString getFileSearchName(const QString &filePath, bool includeFolderName)
+static QString toRelativeFilepath(const QString &filePath)
 {
     QString deckPath = SettingsCache::instance().getDeckPath();
-    if (includeFolderName && filePath.startsWith(deckPath)) {
+    if (filePath.startsWith(deckPath)) {
         return filePath.mid(deckPath.length());
     }
 
@@ -71,14 +69,12 @@ static QString getFileSearchName(const QString &filePath, bool includeFolderName
     return fileName;
 }
 
-void VisualDeckStorageSearchWidget::filterWidgets(QList<DeckPreviewWidget *> widgets,
-                                                  const QString &searchText,
-                                                  bool includeFolderName)
+void VisualDeckStorageSearchWidget::filterWidgets(QList<DeckPreviewWidget *> widgets, const QString &searchText)
 {
     auto filterString = DeckFilterString(searchText);
 
     for (auto widget : widgets) {
-        QString fileSearchName = getFileSearchName(widget->filePath, includeFolderName);
-        widget->filteredBySearch = !filterString.check(widget, {fileSearchName});
+        QString relativeFilePath = toRelativeFilepath(widget->filePath);
+        widget->filteredBySearch = !filterString.check(widget, {relativeFilePath});
     }
 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_search_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_search_widget.h
@@ -16,7 +16,7 @@ class VisualDeckStorageSearchWidget : public QWidget
 public:
     explicit VisualDeckStorageSearchWidget(VisualDeckStorageWidget *parent);
     QString getSearchText();
-    void filterWidgets(QList<DeckPreviewWidget *> widgets, const QString &searchText, bool includeFolderName);
+    void filterWidgets(QList<DeckPreviewWidget *> widgets, const QString &searchText);
 
 private:
     QHBoxLayout *layout;

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -46,8 +46,6 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
             &VisualDeckStorageWidget::updateShowFolders);
     connect(quickSettingsWidget, &VisualDeckStorageQuickSettingsWidget::showTagFilterChanged, this,
             &VisualDeckStorageWidget::updateTagsVisibility);
-    connect(quickSettingsWidget, &VisualDeckStorageQuickSettingsWidget::searchFolderNamesChanged, this,
-            &VisualDeckStorageWidget::updateSearchFilter);
 
     searchAndSortLayout->addWidget(deckPreviewColorIdentityFilterWidget);
     searchAndSortLayout->addWidget(sortWidget);
@@ -196,8 +194,7 @@ void VisualDeckStorageWidget::updateColorFilter()
 void VisualDeckStorageWidget::updateSearchFilter()
 {
     if (folderWidget) {
-        searchWidget->filterWidgets(folderWidget->findChildren<DeckPreviewWidget *>(), searchWidget->getSearchText(),
-                                    quickSettingsWidget->getSearchFolderNames());
+        searchWidget->filterWidgets(folderWidget->findChildren<DeckPreviewWidget *>(), searchWidget->getSearchText());
         folderWidget->updateVisibility();
     }
 }

--- a/cockatrice/src/game/filters/deck_filter_string.h
+++ b/cockatrice/src/game/filters/deck_filter_string.h
@@ -17,9 +17,9 @@ inline Q_LOGGING_CATEGORY(DeckFilterStringLog, "deck_filter_string");
 struct ExtraDeckSearchInfo
 {
     /**
-     * The filename used for filtering. Varies based on settings.
+     * The relative filepath starting from the deck folder
      */
-    QString fileSearchName;
+    QString relativeFilePath;
 };
 
 typedef std::function<bool(const DeckPreviewWidget *, const ExtraDeckSearchInfo &)> DeckFilter;

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -271,7 +271,6 @@ SettingsCache::SettingsCache()
     visualDeckStorageSortingOrder = settings->value("interface/visualdeckstoragesortingorder", 0).toInt();
     visualDeckStorageShowFolders = settings->value("interface/visualdeckstorageshowfolders", true).toBool();
     visualDeckStorageShowTagFilter = settings->value("interface/visualdeckstorageshowtagfilter", true).toBool();
-    visualDeckStorageSearchFolderNames = settings->value("interface/visualdeckstoragesearchfoldernames", true).toBool();
     visualDeckStorageShowBannerCardComboBox =
         settings->value("interface/visualdeckstorageshowbannercardcombobox", true).toBool();
     visualDeckStorageShowTagsOnDeckPreviews =
@@ -729,12 +728,6 @@ void SettingsCache::setVisualDeckStorageShowTagFilter(QT_STATE_CHANGED_T _showTa
     visualDeckStorageShowTagFilter = _showTags;
     settings->setValue("interface/visualdeckstorageshowtagfilter", visualDeckStorageShowTagFilter);
     emit visualDeckStorageShowTagFilterChanged(visualDeckStorageShowTagFilter);
-}
-
-void SettingsCache::setVisualDeckStorageSearchFolderNames(QT_STATE_CHANGED_T value)
-{
-    visualDeckStorageSearchFolderNames = value;
-    settings->setValue("interface/visualdeckstoragesearchfoldernames", visualDeckStorageSearchFolderNames);
 }
 
 void SettingsCache::setVisualDeckStorageShowBannerCardComboBox(QT_STATE_CHANGED_T _showBannerCardComboBox)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -146,7 +146,6 @@ private:
     bool visualDeckStorageShowBannerCardComboBox;
     bool visualDeckStorageShowTagsOnDeckPreviews;
     bool visualDeckStorageShowTagFilter;
-    bool visualDeckStorageSearchFolderNames;
     int visualDeckStorageCardSize;
     bool visualDeckStorageDrawUnusedColorIdentities;
     int visualDeckStorageUnusedColorIdentitiesOpacity;
@@ -452,10 +451,6 @@ public:
     bool getVisualDeckStorageShowTagFilter() const
     {
         return visualDeckStorageShowTagFilter;
-    }
-    bool getVisualDeckStorageSearchFolderNames() const
-    {
-        return visualDeckStorageSearchFolderNames;
     }
     bool getVisualDeckStorageShowBannerCardComboBox() const
     {
@@ -851,7 +846,6 @@ public slots:
     void setVisualDeckStorageSortingOrder(int _visualDeckStorageSortingOrder);
     void setVisualDeckStorageShowFolders(QT_STATE_CHANGED_T value);
     void setVisualDeckStorageShowTagFilter(QT_STATE_CHANGED_T _showTags);
-    void setVisualDeckStorageSearchFolderNames(QT_STATE_CHANGED_T value);
     void setVisualDeckStorageShowBannerCardComboBox(QT_STATE_CHANGED_T _showBannerCardComboBox);
     void setVisualDeckStorageShowTagsOnDeckPreviews(QT_STATE_CHANGED_T _showTags);
     void setVisualDeckStorageCardSize(int _visualDeckStorageCardSize);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -227,9 +227,6 @@ void SettingsCache::setVisualDeckStorageShowFolders(QT_STATE_CHANGED_T /* value 
 void SettingsCache::setVisualDeckStorageShowTagFilter(QT_STATE_CHANGED_T /* _showTags */)
 {
 }
-void SettingsCache::setVisualDeckStorageSearchFolderNames(QT_STATE_CHANGED_T /* value */)
-{
-}
 void SettingsCache::setVisualDeckStorageShowBannerCardComboBox(QT_STATE_CHANGED_T /* _showBannerCardComboBox */)
 {
 }

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -231,9 +231,6 @@ void SettingsCache::setVisualDeckStorageShowFolders(QT_STATE_CHANGED_T /* value 
 void SettingsCache::setVisualDeckStorageShowTagFilter(QT_STATE_CHANGED_T /* _showTags */)
 {
 }
-void SettingsCache::setVisualDeckStorageSearchFolderNames(QT_STATE_CHANGED_T /* value */)
-{
-}
 void SettingsCache::setVisualDeckStorageShowBannerCardComboBox(QT_STATE_CHANGED_T /* _showBannerCardComboBox */)
 {
 }


### PR DESCRIPTION
## Related Ticket(s)


## Short roundup of the initial problem

I'm planning on adding more search expressions to the VDS deck search, including expressions for whether to search in the name or the path. For consistency, we should get rid of the `"Include Folder Names in Search"` setting, as that will become redundant.

## What will change with this Pull Request?
- Remove all traces of the `"Include Folder Names in Search"` setting
  - `filterWidgets` will now always include the full search in the path, which means currently the deck search will always search the path. I'm planning on fixing that in a future PR.
- Renamed some stuff that's related to the `fileSearchName`