### PR TITLE
Support regex in card search 

### DIFF
--- a/cockatrice/resources/help/search.md
+++ b/cockatrice/resources/help/search.md
@@ -58,4 +58,9 @@ In this list of examples below, each entry has an explanation and can be clicked
 <dt>Grouping:</dt>
 <dd><a href="#t:angel -(angel or c:w)">t:angel -(angel or c:w)</a> <small>(Any angel that doesn't have angel in its name and isn't white)</small></dd>
 
+<dt>Regular Expression:</dt>
+<dd>[/^fell/](#/^fell/) <small>(Any card name that begins with "fell")</small></dd>
+<dd>[o:/counter target .* spell/](#o:/counter target .* spell/) <small>(Any card text with "counter target *something* spell")</small></dd>
+<dd>[o:/for each .* and\/or .*/](#o:/for each .* and\/or .*/) <small>(/'s can be escaped with a \)</small></dd>
+
 </dl>

--- a/cockatrice/src/game/filters/filter_string.cpp
+++ b/cockatrice/src/game/filters/filter_string.cpp
@@ -20,7 +20,7 @@ QueryPart <- NotQuery / SetQuery / RarityQuery / CMCQuery / FormatQuery / PowerQ
 
 NotQuery <- ('NOT' ws/'-') SomewhatComplexQueryPart
 SetQuery <- ('e'/'set') [:] FlexStringValue
-OracleQuery <- 'o' [:] RegexString
+OracleQuery <- 'o' [:] MatcherString
 
 
 CMCQuery <- ('cmc'/'mv') ws? NumericExpression
@@ -42,7 +42,7 @@ ColorEx <- Color / [mc]
 
 ColorQuery <- [cC] 'olor'? <[iI]?> <[:!]> ColorEx*
 
-FieldQuery <- String [:] RegexString / String ws? NumericExpression
+FieldQuery <- String [:] MatcherString / String ws? NumericExpression
 
 NonDoubleQuoteUnlessEscaped <- '\\\"'. / !["].
 NonSingleQuoteUnlessEscaped <- "\\\'". / !['].
@@ -52,8 +52,10 @@ String <- SingleApostropheString / UnescapedStringListPart+ / ["] <NonDoubleQuot
 StringValue <- String / [(] StringList [)]
 StringList <- StringListString (ws? [,] ws? StringListString)*
 StringListString <- UnescapedStringListPart+
-GenericQuery <- RegexString
-RegexString <- String
+GenericQuery <- MatcherString
+
+# A String that can either be a normal string or a regex search string
+MatcherString <- String
 
 FlexStringValue <- CompactStringSet / String / [(] StringList [)]
 CompactStringSet <- StringListString ([,+] StringListString)+
@@ -261,7 +263,7 @@ static void setupParserRules()
         return QString::fromStdString(std::string(sv.sv()));
     };
 
-    search["RegexString"] = [](const peg::SemanticValues &sv) -> StringMatcher {
+    search["MatcherString"] = [](const peg::SemanticValues &sv) -> StringMatcher {
         auto target = std::any_cast<QString>(sv[0]);
         auto sanitizedTarget = QString(target);
         sanitizedTarget.replace("\\\"", "\"");

--- a/cockatrice/src/game/filters/filter_string.cpp
+++ b/cockatrice/src/game/filters/filter_string.cpp
@@ -263,12 +263,10 @@ static void setupParserRules()
 
     search["RegexString"] = [](const peg::SemanticValues &sv) -> StringMatcher {
         auto target = std::any_cast<QString>(sv[0]);
-        return [=](const QString &s) {
-            auto sanitizedTarget = QString(target);
-            sanitizedTarget.replace("\\\"", "\"");
-            sanitizedTarget.replace("\\'", "'");
-            return s.contains(sanitizedTarget, Qt::CaseInsensitive);
-        };
+        auto sanitizedTarget = QString(target);
+        sanitizedTarget.replace("\\\"", "\"");
+        sanitizedTarget.replace("\\'", "'");
+        return [=](const QString &s) { return s.contains(sanitizedTarget, Qt::CaseInsensitive); };
     };
 
     search["OracleQuery"] = [](const peg::SemanticValues &sv) -> Filter {


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4108

## Short roundup of the initial problem

Scryfall supports regexes using the syntax `[property]:/[regex]/`

Cockatrice should also support it

## What will change with this Pull Request?
- Updated the peg parser to recognize strings surrounded by `/` as regex searches
  - `\/` will be escaped properly
  - `//` (with no characters between) will still be interpreted as a string search
- Handle regex search strings
- Update the search syntax help

Our behavior won't be an exact match of scryfall's behavior, since we're just relying on Qt's regex behavior. It should be close enough for most purposes though.


## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<img width="400" alt="Screenshot 2025-06-09 at 3 02 37 AM" src="https://github.com/user-attachments/assets/7b2528c4-7c5b-453b-9eef-b02677e5e3a4" />
<img width="400" alt="Screenshot 2025-06-09 at 2 59 36 AM" src="https://github.com/user-attachments/assets/51e6f83f-312e-4c25-bbf5-3c4e6b02703b" />
<img width="400" alt="Screenshot 2025-06-09 at 3 09 48 AM" src="https://github.com/user-attachments/assets/c4d40ff8-8da1-4473-8ffe-8a83bbc645e8" />
<img width="400" alt="Screenshot 2025-06-09 at 3 06 30 AM" src="https://github.com/user-attachments/assets/f6d191a8-e92f-4e97-b192-17f93a144548" />


<img width="500" alt="Screenshot 2025-06-09 at 3 06 08 AM" src="https://github.com/user-attachments/assets/6f517201-65ba-4d63-8fb7-37d6e7991a7b" />


