### PR TITLE
[VDS] add deck search query options for name, filename, and path

### DIFF
--- a/cockatrice/resources/help/deck_search.md
+++ b/cockatrice/resources/help/deck_search.md
@@ -8,6 +8,20 @@ searches are case insensitive.
 <dd>[red deck wins](#red deck wins) <small>(Any deck with a display name containing the words red, deck, and wins)</small></dd>
 <dd>["red deck wins"](#%22red deck wins%22) <small>(Any deck with a display name containing the exact phrase "red deck wins")</small></dd>
 
+<dt>Deck <u>N</u>ame:</dt>
+<dd>[n:aggro](#n:aggro) <small>(Any deck with a name containing the word aggro)</small></dd>
+<dd>[n:red n:deck n:wins](#n:red n:deck n:wins) <small>(Any deck with a name containing the words red, deck, and wins)</small></dd>
+<dd>[n:"red deck wins"](#n:%22red deck wins%22) <small>(Any deck with a name containing the exact phrase "red deck wins")</small></dd>
+
+<dt><u>F</u>ile Name:</dt>
+<dd>[f:aggro](#f:aggro) <small>(Any deck with a filename containing the word aggro)</small></dd>
+<dd>[f:red f:deck f:wins](#f:red f:deck f:wins) <small>(Any deck with a filename containing the words red, deck, and wins)</small></dd>
+<dd>[f:"red deck wins"](#f:%22red deck wins%22) <small>(Any deck with a filename containing the exact phrase "red deck wins")</small></dd>
+
+<dt>Relative <u>P</u>ath (starting from the deck folder):</dt>
+<dd>[p:aggro](#p:aggro) <small>(Any deck that has "aggro" somewhere in its relative path)</small></dd>
+<dd>[p:edh/](#p:edh/) <small>(Any deck with "edh/" in its relative path, A.K.A. decks in the "edh" folder)</small></dd>
+
 <dt>Deck Contents (Uses [card search expressions](#cardSearchSyntaxHelp)):</dt>
 <dd><a href="#[[plains]]">[[plains]]</a> <small>(Any deck that contains at least one card with "plains" in its name)</small></dd>
 <dd><a href="#[[t:legendary]]">[[t:legendary]]</a> <small>(Any deck that contains at least one legendary)</small></dd>


### PR DESCRIPTION
## Related Ticket(s)
- Requires #5970 to be merged first

## Short roundup of the initial problem

We made deck search expressions a thing so might as well add some more query options

## What will change with this Pull Request?
- Added 3 more query options
  - `n:` (or `name:` or `deckname:`) purely searches the deck name
  - `f:` (or `file:` or `filename:`) purely searches the file name of the deck file  
  - `p:` (or `path:`) searches the entire relative path (same behavior as when `include path in search` was enabled before)
- Updated syntax help window

## Screenshots

<img width="500" alt="Screenshot 2025-06-10 at 10 53 11 PM" src="https://github.com/user-attachments/assets/ad332172-0687-42e9-9644-6b03483f13af" />

