### PR TITLE
[VDS] Use display name for generic search expression

### DIFF
--- a/cockatrice/resources/help/deck_search.md
+++ b/cockatrice/resources/help/deck_search.md
@@ -4,9 +4,9 @@ The search bar recognizes a set of special commands.<br>
 In this list of examples below, each entry has an explanation and can be clicked to test the query. Note that all
 searches are case insensitive.
 <dl>
-<dt>Filename:</dt>
-<dd>[red deck wins](#red deck wins) <small>(Any deck filename containing the words red, deck, and wins)</small></dd>
-<dd>["red deck wins"](#%22red deck wins%22) <small>(Any deck filename containing the exact phrase "red deck wins")</small></dd>
+<dt>Display Name (The deck name, or the filename if the deck name isn't set):</dt>
+<dd>[red deck wins](#red deck wins) <small>(Any deck with a display name containing the words red, deck, and wins)</small></dd>
+<dd>["red deck wins"](#%22red deck wins%22) <small>(Any deck with a display name containing the exact phrase "red deck wins")</small></dd>
 
 <dt>Deck Contents (Uses [card search expressions](#cardSearchSyntaxHelp)):</dt>
 <dd><a href="#[[plains]]">[[plains]]</a> <small>(Any deck that contains at least one card with "plains" in its name)</small></dd>

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -182,6 +182,15 @@ QString DeckPreviewWidget::getColorIdentity()
     return colorIdentity;
 }
 
+/**
+ * The display name is given by the deck name, or the filename if the deck name is not set.
+ */
+QString DeckPreviewWidget::getDisplayName() const
+{
+    return deckLoader->getName().isEmpty() ? QFileInfo(deckLoader->getLastFileName()).fileName()
+                                           : deckLoader->getName();
+}
+
 void DeckPreviewWidget::setFilePath(const QString &_filePath)
 {
     filePath = _filePath;
@@ -193,8 +202,7 @@ void DeckPreviewWidget::setFilePath(const QString &_filePath)
  */
 void DeckPreviewWidget::refreshBannerCardText()
 {
-    bannerCardDisplayWidget->setOverlayText(
-        deckLoader->getName().isEmpty() ? QFileInfo(deckLoader->getLastFileName()).fileName() : deckLoader->getName());
+    bannerCardDisplayWidget->setOverlayText(getDisplayName());
 
     refreshBannerCardToolTip();
 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
@@ -27,6 +27,7 @@ public:
                                const QString &_filePath);
     void retranslateUi();
     QString getColorIdentity();
+    QString getDisplayName() const;
 
     VisualDeckStorageWidget *visualDeckStorageWidget;
     QVBoxLayout *layout;

--- a/cockatrice/src/game/filters/deck_filter_string.cpp
+++ b/cockatrice/src/game/filters/deck_filter_string.cpp
@@ -131,8 +131,8 @@ static void setupParserRules()
 
     search["GenericQuery"] = [](const peg::SemanticValues &sv) -> DeckFilter {
         auto name = std::any_cast<QString>(sv[0]);
-        return [=](const DeckPreviewWidget *, const ExtraDeckSearchInfo &info) {
-            return info.fileSearchName.contains(name, Qt::CaseInsensitive);
+        return [=](const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &) {
+            return deck->getDisplayName().contains(name, Qt::CaseInsensitive);
         };
     };
 }


### PR DESCRIPTION
## Related Ticket(s)
- Relates to #5970 and #5975

## Short roundup of the initial problem

Since we're adding query options for deck name and filename, we should change the behavior of the default search.

I think it's most intuitive to by default search decks by their display names.

## What will change with this Pull Request?
- Extract `getDisplayName` into a separate method
- Use displayName for search in `GenericQuery`
- Update deck search syntax help window

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
<img width="505" alt="Screenshot 2025-06-10 at 11 19 33 PM" src="https://github.com/user-attachments/assets/d62c8c70-cc9e-42ba-9cce-226007bdbe3f" />
