### PR TITLE
Propagate display type from visual deck editor to card group display widget correctly on initialization

### DIFF
--- a/cockatrice/src/client/ui/widgets/cards/deck_card_zone_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/deck_card_zone_display_widget.cpp
@@ -12,12 +12,13 @@ DeckCardZoneDisplayWidget::DeckCardZoneDisplayWidget(QWidget *parent,
                                                      QString _zoneName,
                                                      QString _activeGroupCriteria,
                                                      QStringList _activeSortCriteria,
+                                                     DisplayType _displayType,
                                                      int bannerOpacity,
                                                      int subBannerOpacity,
                                                      CardSizeWidget *_cardSizeWidget)
     : QWidget(parent), deckListModel(_deckListModel), zoneName(_zoneName), activeGroupCriteria(_activeGroupCriteria),
-      activeSortCriteria(_activeSortCriteria), bannerOpacity(bannerOpacity), subBannerOpacity(subBannerOpacity),
-      cardSizeWidget(_cardSizeWidget)
+      activeSortCriteria(_activeSortCriteria), displayType(_displayType), bannerOpacity(bannerOpacity),
+      subBannerOpacity(subBannerOpacity), cardSizeWidget(_cardSizeWidget)
 {
     layout = new QVBoxLayout(this);
     setLayout(layout);
@@ -60,7 +61,7 @@ void DeckCardZoneDisplayWidget::displayCards()
     deleteCardGroupIfItDoesNotExist();
 }
 
-void DeckCardZoneDisplayWidget::refreshDisplayType(const QString &_displayType)
+void DeckCardZoneDisplayWidget::refreshDisplayType(const DisplayType &_displayType)
 {
     displayType = _displayType;
     QLayoutItem *item;
@@ -102,7 +103,7 @@ void DeckCardZoneDisplayWidget::addCardGroupIfItDoesNotExist()
             continue;
         }
 
-        if (displayType == "overlap") {
+        if (displayType == DisplayType::Overlap) {
             auto *display_widget = new OverlappedCardGroupDisplayWidget(
                 cardGroupContainer, deckListModel, zoneName, cardGroup, activeGroupCriteria, activeSortCriteria,
                 subBannerOpacity, cardSizeWidget);
@@ -112,7 +113,7 @@ void DeckCardZoneDisplayWidget::addCardGroupIfItDoesNotExist()
             connect(this, &DeckCardZoneDisplayWidget::activeSortCriteriaChanged, display_widget,
                     &CardGroupDisplayWidget::onActiveSortCriteriaChanged);
             cardGroupLayout->addWidget(display_widget);
-        } else if (displayType == "flat") {
+        } else if (displayType == DisplayType::Flat) {
             auto *display_widget = new FlatCardGroupDisplayWidget(cardGroupContainer, deckListModel, zoneName,
                                                                   cardGroup, activeGroupCriteria, activeSortCriteria,
                                                                   subBannerOpacity, cardSizeWidget);

--- a/cockatrice/src/client/ui/widgets/cards/deck_card_zone_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/deck_card_zone_display_widget.h
@@ -5,6 +5,7 @@
 #include "../../../../game/cards/card_info.h"
 #include "../general/display/banner_widget.h"
 #include "../general/layout_containers/overlap_widget.h"
+#include "../visual_deck_editor/visual_deck_editor_widget.h"
 #include "card_info_picture_with_text_overlay_widget.h"
 #include "card_size_widget.h"
 
@@ -21,6 +22,7 @@ public:
                               QString zoneName,
                               QString activeGroupCriteria,
                               QStringList activeSortCriteria,
+                              DisplayType displayType,
                               int bannerOpacity,
                               int subBannerOpacity,
                               CardSizeWidget *_cardSizeWidget);
@@ -33,7 +35,7 @@ public slots:
     void onClick(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *card);
     void onHover(CardInfoPtr card);
     void displayCards();
-    void refreshDisplayType(const QString &displayType);
+    void refreshDisplayType(const DisplayType &displayType);
     void addCardGroupIfItDoesNotExist();
     void deleteCardGroupIfItDoesNotExist();
     void onActiveGroupCriteriaChanged(QString activeGroupCriteria);
@@ -48,6 +50,7 @@ signals:
 private:
     QString activeGroupCriteria;
     QStringList activeSortCriteria;
+    DisplayType displayType = DisplayType::Overlap;
     int bannerOpacity = 20;
     int subBannerOpacity = 10;
     CardSizeWidget *cardSizeWidget;
@@ -55,7 +58,6 @@ private:
     BannerWidget *banner;
     QWidget *cardGroupContainer;
     QVBoxLayout *cardGroupLayout;
-    QString displayType = "flat";
     OverlapWidget *overlapWidget;
 };
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -193,7 +193,7 @@ void VisualDeckEditorWidget::retranslateUi()
     searchPushButton->setToolTip(tr("Search for closest match in the database (with auto-suggestions) and add "
                                     "preferred printing to the deck on pressing enter"));
     sortCriteriaButton->setToolTip(tr("Configure how cards are sorted within their groups"));
-    displayTypeButton->setText(tr("Flat Layout"));
+    displayTypeButton->setText(tr("Overlap Layout"));
     displayTypeButton->setToolTip(
         tr("Change how cards are displayed within zones (i.e. overlapped or fully visible.)"));
 }
@@ -212,14 +212,13 @@ void VisualDeckEditorWidget::updateDisplayType()
     // Update UI and emit signal
     switch (currentDisplayType) {
         case DisplayType::Flat:
-            emit displayTypeChanged("flat");
             displayTypeButton->setText(tr("Flat Layout"));
             break;
         case DisplayType::Overlap:
-            emit displayTypeChanged("overlap");
             displayTypeButton->setText(tr("Overlap Layout"));
             break;
     }
+    emit displayTypeChanged(currentDisplayType);
 }
 
 void VisualDeckEditorWidget::addZoneIfDoesNotExist()
@@ -239,8 +238,9 @@ void VisualDeckEditorWidget::addZoneIfDoesNotExist()
         if (found) {
             continue;
         }
-        DeckCardZoneDisplayWidget *zoneDisplayWidget = new DeckCardZoneDisplayWidget(
-            zoneContainer, deckListModel, zone, activeGroupCriteria, activeSortCriteria, 20, 10, cardSizeWidget);
+        DeckCardZoneDisplayWidget *zoneDisplayWidget =
+            new DeckCardZoneDisplayWidget(zoneContainer, deckListModel, zone, activeGroupCriteria, activeSortCriteria,
+                                          currentDisplayType, 20, 10, cardSizeWidget);
         connect(zoneDisplayWidget, &DeckCardZoneDisplayWidget::cardHovered, this, &VisualDeckEditorWidget::onHover);
         connect(zoneDisplayWidget, &DeckCardZoneDisplayWidget::cardClicked, this, &VisualDeckEditorWidget::onCardClick);
         connect(this, &VisualDeckEditorWidget::activeSortCriteriaChanged, zoneDisplayWidget,

--- a/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.h
@@ -50,7 +50,7 @@ signals:
     void activeSortCriteriaChanged(QStringList activeSortCriteria);
     void cardClicked(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance, QString zoneName);
     void cardAdditionRequested(CardInfoPtr card);
-    void displayTypeChanged(QString displayType);
+    void displayTypeChanged(DisplayType displayType);
 
 protected slots:
     void onHover(CardInfoPtr hoveredCard);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes some mislabeling and incorrect layout selection on first button press.

## Short roundup of the initial problem
Card group display widget is supposed to start in overlap layout (or at least so VDE says) but all the labels say Flat and the card group actually starts in flat layout. It's magic value'd, which this change removes by propagating the displayType variable from the VDE to the card group display correctly.
