### PR TITLE
Fix picDownloadFinished not being called on failure

### DIFF
--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
@@ -121,6 +121,8 @@ QNetworkReply *PictureLoaderWorker::makeRequest(const QUrl &url, PictureLoaderWo
             }
         } else if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 429) {
             qInfo() << "Too many requests.";
+        } else {
+            worker->picDownloadFinished(reply);
         }
         reply->deleteLater();
     });


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5977

## Short roundup of the initial problem

The picture loader no longer calls `picDownloadFinished` if the reply is an error. This prevents the picture loader from trying the next url for the card.

## What will change with this Pull Request?
- call `picDownloadFinished` in the non-429 error case

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
