### PR TITLE
Fix crash due to null mCardCounters

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -849,6 +849,8 @@ void Player::retranslateUi()
         aCreateAnotherToken->setText(tr("C&reate another token"));
         createPredefinedTokenMenu->setTitle(tr("Cr&eate predefined token"));
 
+        mCardCounters->setTitle(tr("Ca&rd counters"));
+
         QMapIterator<int, AbstractCounter *> counterIterator(counters);
         while (counterIterator.hasNext()) {
             counterIterator.next().value()->retranslateUi();
@@ -898,7 +900,6 @@ void Player::retranslateUi()
 
     auto &cardCounterSettings = SettingsCache::instance().cardCounters();
 
-    mCardCounters->setTitle(tr("Ca&rd counters"));
     for (int i = 0; i < aAddCounter.size(); ++i) {
         aAddCounter[i]->setText(tr("&Add counter (%1)").arg(cardCounterSettings.displayName(i)));
     }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced by #5882

## Short roundup of the initial problem

Cockatrice crashes if you join a remote game because we try to set the text on a null `mCardCounters`. This can happen because the code that instantiates `mCardCounters` is inside a `if (local || judge)` block, but the code that sets the text on it doesn't have the same check.

## What will change with this Pull Request?
- Move the `mCardCounters->setText` call to inside the `if (local || judge)` block
