### PR TITLE
[Picture Loader] Consider local images, remove some unused variables.

### DIFF
--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
@@ -15,17 +15,8 @@
 // Card back returned by gatherer when card is not found
 QStringList PictureLoaderWorker::md5Blacklist = QStringList() << "db0c48db407a907c16ade38de048a441";
 
-PictureLoaderWorker::PictureLoaderWorker()
-    : QObject(nullptr), picsPath(SettingsCache::instance().getPicsPath()),
-      customPicsPath(SettingsCache::instance().getCustomPicsPath()),
-      picDownload(SettingsCache::instance().getPicDownload()), downloadRunning(false), loadQueueRunning(false),
-      overrideAllCardArtWithPersonalPreference(SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference())
+PictureLoaderWorker::PictureLoaderWorker() : QObject(nullptr), picDownload(SettingsCache::instance().getPicDownload())
 {
-    connect(&SettingsCache::instance(), SIGNAL(picsPathChanged()), this, SLOT(picsPathChanged()));
-    connect(&SettingsCache::instance(), SIGNAL(picDownloadChanged()), this, SLOT(picDownloadChanged()));
-    connect(&SettingsCache::instance(), &SettingsCache::overrideAllCardArtWithPersonalPreferenceChanged, this,
-            &PictureLoaderWorker::setOverrideAllCardArtWithPersonalPreference);
-
     networkManager = new QNetworkAccessManager(this);
     // We need a timeout to ensure requests don't hang indefinitely in case of
     // cache corruption, see related Qt bug: https://bugreports.qt.io/browse/QTBUG-111397
@@ -209,24 +200,6 @@ void PictureLoaderWorker::cleanStaleEntries()
             ++it;
         }
     }
-}
-
-void PictureLoaderWorker::picDownloadChanged()
-{
-    QMutexLocker locker(&mutex);
-    picDownload = SettingsCache::instance().getPicDownload();
-}
-
-void PictureLoaderWorker::picsPathChanged()
-{
-    QMutexLocker locker(&mutex);
-    picsPath = SettingsCache::instance().getPicsPath();
-    customPicsPath = SettingsCache::instance().getCustomPicsPath();
-}
-
-void PictureLoaderWorker::setOverrideAllCardArtWithPersonalPreference(bool _overrideAllCardArtWithPersonalPreference)
-{
-    overrideAllCardArtWithPersonalPreference = _overrideAllCardArtWithPersonalPreference;
 }
 
 void PictureLoaderWorker::clearNetworkCache()

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
@@ -16,12 +16,23 @@
 QStringList PictureLoaderWorkerWork::md5Blacklist = QStringList() << "db0c48db407a907c16ade38de048a441";
 
 PictureLoaderWorkerWork::PictureLoaderWorkerWork(PictureLoaderWorker *_worker, const CardInfoPtr &toLoad)
-    : QThread(nullptr), worker(_worker), cardToDownload(toLoad)
+    : QThread(nullptr), worker(_worker), cardToDownload(toLoad), picsPath(SettingsCache::instance().getPicsPath()),
+      customPicsPath(SettingsCache::instance().getCustomPicsPath()),
+      overrideAllCardArtWithPersonalPreference(SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference())
+
 {
+    // Hook up signals to the orchestrator
     connect(this, &PictureLoaderWorkerWork::requestImageDownload, worker, &PictureLoaderWorker::queueRequest,
             Qt::QueuedConnection);
     connect(this, &PictureLoaderWorkerWork::imageLoaded, worker, &PictureLoaderWorker::imageLoadedSuccessfully,
             Qt::QueuedConnection);
+
+    // Hook up signals to settings
+    connect(&SettingsCache::instance(), SIGNAL(picsPathChanged()), this, SLOT(picsPathChanged()));
+    connect(&SettingsCache::instance(), SIGNAL(picDownloadChanged()), this, SLOT(picDownloadChanged()));
+    connect(&SettingsCache::instance(), &SettingsCache::overrideAllCardArtWithPersonalPreferenceChanged, this,
+            &PictureLoaderWorkerWork::setOverrideAllCardArtWithPersonalPreference);
+
     pictureLoaderThread = new QThread;
     pictureLoaderThread->start(QThread::LowPriority);
     moveToThread(pictureLoaderThread);
@@ -33,32 +44,34 @@ PictureLoaderWorkerWork::~PictureLoaderWorkerWork()
     pictureLoaderThread->deleteLater();
 }
 
-bool PictureLoaderWorkerWork::cardImageExistsOnDisk(QString &setName, QString &correctedCardname)
+bool PictureLoaderWorkerWork::cardImageExistsOnDisk(QString &setName, QString &correctedCardname, bool searchCustomPics)
 {
     QImage image;
     QImageReader imgReader;
     imgReader.setDecideFormatFromContent(true);
     QList<QString> picsPaths = QList<QString>();
-    QDirIterator it(SettingsCache::instance().getCustomPicsPath(),
-                    QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
 
-    // Recursively check all subdirectories of the CUSTOM folder
-    while (it.hasNext()) {
-        QString thisPath(it.next());
-        QFileInfo thisFileInfo(thisPath);
+    if (searchCustomPics) {
+        QDirIterator it(customPicsPath, QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
 
-        if (thisFileInfo.isFile() &&
-            (thisFileInfo.fileName() == correctedCardname || thisFileInfo.completeBaseName() == correctedCardname ||
-             thisFileInfo.baseName() == correctedCardname)) {
-            picsPaths << thisPath; // Card found in the CUSTOM directory, somewhere
+        // Recursively check all subdirectories of the CUSTOM folder
+        while (it.hasNext()) {
+            QString thisPath(it.next());
+            QFileInfo thisFileInfo(thisPath);
+
+            if (thisFileInfo.isFile() &&
+                (thisFileInfo.fileName() == correctedCardname || thisFileInfo.completeBaseName() == correctedCardname ||
+                 thisFileInfo.baseName() == correctedCardname)) {
+                picsPaths << thisPath; // Card found in the CUSTOM directory, somewhere
+            }
         }
     }
 
     if (!setName.isEmpty()) {
-        picsPaths << SettingsCache::instance().getPicsPath() + "/" + setName + "/" + correctedCardname
+        picsPaths << picsPath + "/" + setName + "/" + correctedCardname
                   // We no longer store downloaded images there, but don't just ignore
                   // stuff that old versions have put there.
-                  << SettingsCache::instance().getPicsPath() + "/downloadedPics/" + setName + "/" + correctedCardname;
+                  << picsPath + "/downloadedPics/" + setName + "/" + correctedCardname;
     }
 
     // Iterates through the list of paths, searching for images with the desired
@@ -67,22 +80,22 @@ bool PictureLoaderWorkerWork::cardImageExistsOnDisk(QString &setName, QString &c
     for (const auto &_picsPath : picsPaths) {
         imgReader.setFileName(_picsPath);
         if (imgReader.read(&image)) {
-            qCDebug(PictureLoaderWorkerWorkLog).nospace()
-                << "PictureLoader: [card: " << correctedCardname << " set: " << setName << "]: Picture found on disk.";
+            qCDebug(PictureLoaderWorkerLog).nospace()
+                << "[card: " << correctedCardname << " set: " << setName << "]: Picture found on disk.";
             imageLoaded(cardToDownload.getCard(), image);
             return true;
         }
         imgReader.setFileName(_picsPath + ".full");
         if (imgReader.read(&image)) {
-            qCDebug(PictureLoaderWorkerWorkLog).nospace() << "PictureLoader: [card: " << correctedCardname
-                                                          << " set: " << setName << "]: Picture.full found on disk.";
+            qCDebug(PictureLoaderWorkerLog).nospace()
+                << "[card: " << correctedCardname << " set: " << setName << "]: Picture.full found on disk.";
             imageLoaded(cardToDownload.getCard(), image);
             return true;
         }
         imgReader.setFileName(_picsPath + ".xlhq");
         if (imgReader.read(&image)) {
-            qCDebug(PictureLoaderWorkerWorkLog).nospace() << "PictureLoader: [card: " << correctedCardname
-                                                          << " set: " << setName << "]: Picture.xlhq found on disk.";
+            qCDebug(PictureLoaderWorkerLog).nospace()
+                << "[card: " << correctedCardname << " set: " << setName << "]: Picture.xlhq found on disk.";
             imageLoaded(cardToDownload.getCard(), image);
             return true;
         }
@@ -99,6 +112,32 @@ void PictureLoaderWorkerWork::startNextPicDownload()
         downloadRunning = false;
         picDownloadFailed();
     } else {
+        QString setName = cardToDownload.getSetName();
+        QString cardName = cardToDownload.getCard()->getName();
+        QString correctedCardName = cardToDownload.getCard()->getCorrectedName();
+
+        qCDebug(PictureLoaderWorkerLog).nospace()
+            << "[card: " << cardName << " set: " << setName << "]: Trying to load picture";
+
+        // FIXME: This is a hack so that to keep old Cockatrice behavior
+        // (ignoring provider ID) when the "override all card art with personal
+        // preference" is set.
+        //
+        // Figure out a proper way to integrate the two systems at some point.
+        //
+        // Note: need to go through a member for
+        // overrideAllCardArtWithPersonalPreference as reading from the
+        // SettingsCache instance from the PictureLoaderWorker thread could
+        // cause race conditions.
+        //
+        // XXX: Reading from the CardDatabaseManager instance from the
+        // PictureLoaderWorker thread might not be safe either
+        bool searchCustomPics = overrideAllCardArtWithPersonalPreference ||
+                                CardDatabaseManager::getInstance()->isProviderIdForPreferredPrinting(
+                                    cardName, cardToDownload.getCard()->getPixmapCacheKey());
+        if (searchCustomPics && cardImageExistsOnDisk(setName, correctedCardName, searchCustomPics)) {
+            return;
+        }
         QUrl url(picUrl);
         qCDebug(PictureLoaderWorkerWorkLog).nospace()
             << "PictureLoader: [card: " << cardToDownload.getCard()->getCorrectedName()
@@ -227,6 +266,23 @@ void PictureLoaderWorkerWork::picDownloadFinished(QNetworkReply *reply)
     }
 
     reply->deleteLater();
+}
+
+void PictureLoaderWorkerWork::picDownloadChanged()
+{
+    picDownload = SettingsCache::instance().getPicDownload();
+}
+
+void PictureLoaderWorkerWork::picsPathChanged()
+{
+    picsPath = SettingsCache::instance().getPicsPath();
+    customPicsPath = SettingsCache::instance().getCustomPicsPath();
+}
+
+void PictureLoaderWorkerWork::setOverrideAllCardArtWithPersonalPreference(
+    bool _overrideAllCardArtWithPersonalPreference)
+{
+    overrideAllCardArtWithPersonalPreference = _overrideAllCardArtWithPersonalPreference;
 }
 
 bool PictureLoaderWorkerWork::imageIsBlackListed(const QByteArray &picData)

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.h
@@ -28,18 +28,27 @@ public:
     ~PictureLoaderWorkerWork() override;
     PictureLoaderWorker *worker;
     PictureToLoad cardToDownload;
+
 public slots:
     void picDownloadFinished(QNetworkReply *reply);
     void picDownloadFailed();
 
 private:
+    QString picsPath, customPicsPath;
+    bool overrideAllCardArtWithPersonalPreference;
     static QStringList md5Blacklist;
     QThread *pictureLoaderThread;
     QNetworkAccessManager *networkManager;
     bool picDownload, downloadRunning, loadQueueRunning;
+
     void startNextPicDownload();
-    bool cardImageExistsOnDisk(QString &setName, QString &correctedCardName);
+    bool cardImageExistsOnDisk(QString &setName, QString &correctedCardName, bool searchCustomPics);
     bool imageIsBlackListed(const QByteArray &);
+
+private slots:
+    void picDownloadChanged();
+    void picsPathChanged();
+    void setOverrideAllCardArtWithPersonalPreference(bool _overrideAllCardArtWithPersonalPreference);
 
 signals:
     void startLoadQueue();

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.h
@@ -6,6 +6,8 @@
 
 #include <QWidget>
 
+inline bool confirmOverwriteIfExists(QWidget *parent, const QString &filePath);
+
 class DeckPreviewWidget;
 class DeckPreviewDeckTagsDisplayWidget : public QWidget
 {


### PR DESCRIPTION
## Short roundup of the initial problem
We didn't consider local images in the new parallel picture loader. Also, PictureLoaderWorker had some variables that either belong to PictureLoaderWorkerWork now OR are obsolete.
