### PR TITLE
Default show status bar to false.

### DIFF
--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -237,7 +237,7 @@ SettingsCache::SettingsCache()
     redirectCacheTtl = settings->value("personal/redirectCacheTtl", NETWORK_REDIRECT_CACHE_TTL_DEFAULT).toInt();
 
     picDownload = settings->value("personal/picturedownload", true).toBool();
-    showStatusBar = settings->value("personal/showStatusBar", true).toBool();
+    showStatusBar = settings->value("personal/showStatusBar", false).toBool();
 
     mainWindowGeometry = settings->value("interface/main_window_geometry").toByteArray();
     tokenDialogGeometry = settings->value("interface/token_dialog_geometry").toByteArray();


### PR DESCRIPTION
## Short roundup of the initial problem
It's a bit big on smaller resolutions and doesn't serve any purpose until explicitly needed so let's hide it by default (while also giving users the option to enable it when relevant)

## What will change with this Pull Request?
- Hide Picture Loader status bar by default

