### PR TITLE
CI: Fix permission for attestations

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,5 +1,9 @@
 name: Build Desktop
 
+permissions:
+  id-token: write
+  attestations: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
## Related Ticket(s)
- Fixes https://github.com/Cockatrice/Cockatrice/pull/5967

## Short roundup of the initial problem
Workflow was missing the needed permissions

## What will change with this Pull Request?
- Add write permissions for `id-token` and `attestations` 
https://github.com/actions/attest-build-provenance?tab=readme-ov-file#usage
