### PR TITLE
Game filter for games created by buddy

### DIFF
--- a/cockatrice/src/dialogs/dlg_filter_games.cpp
+++ b/cockatrice/src/dialogs/dlg_filter_games.cpp
@@ -37,6 +37,9 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     hideIgnoredUserGames = new QCheckBox(tr("Hide 'ignored user' games"));
     hideIgnoredUserGames->setChecked(gamesProxyModel->getHideIgnoredUserGames());
 
+    hideNotBuddyCreatedGames = new QCheckBox(tr("Hide games not created by buddy"));
+    hideNotBuddyCreatedGames->setChecked(gamesProxyModel->getHideNotBuddyCreatedGames());
+
     maxGameAgeComboBox = new QComboBox();
     maxGameAgeComboBox->setEditable(false);
     maxGameAgeComboBox->addItems(gameAgeMap.values());
@@ -111,6 +114,7 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     restrictionsLayout->addWidget(hidePasswordProtectedGames, 2, 0);
     restrictionsLayout->addWidget(hideBuddiesOnlyGames, 3, 0);
     restrictionsLayout->addWidget(hideIgnoredUserGames, 4, 0);
+    restrictionsLayout->addWidget(hideNotBuddyCreatedGames, 5, 0);
 
     auto *restrictionsGroupBox = new QGroupBox(tr("Restrictions"));
     restrictionsGroupBox->setLayout(restrictionsLayout);
@@ -207,6 +211,11 @@ bool DlgFilterGames::getHidePasswordProtectedGames() const
 bool DlgFilterGames::getHideIgnoredUserGames() const
 {
     return hideIgnoredUserGames->isChecked();
+}
+
+bool DlgFilterGames::getHideNotBuddyCreatedGames() const
+{
+    return hideNotBuddyCreatedGames->isChecked();
 }
 
 QString DlgFilterGames::getGameNameFilter() const

--- a/cockatrice/src/dialogs/dlg_filter_games.h
+++ b/cockatrice/src/dialogs/dlg_filter_games.h
@@ -26,6 +26,7 @@ private:
     QCheckBox *hideGamesThatStarted;
     QCheckBox *hidePasswordProtectedGames;
     QCheckBox *hideIgnoredUserGames;
+    QCheckBox *hideNotBuddyCreatedGames;
     QLineEdit *gameNameFilterEdit;
     QLineEdit *creatorNameFilterEdit;
     QMap<int, QCheckBox *> gameTypeFilterCheckBoxes;
@@ -58,6 +59,7 @@ public:
     void setHideBuddiesOnlyGames(bool _hideBuddiesOnlyGames);
     bool getHideIgnoredUserGames() const;
     void setHideIgnoredUserGames(bool _hideIgnoredUserGames);
+    bool getHideNotBuddyCreatedGames() const;
     QString getGameNameFilter() const;
     void setGameNameFilter(const QString &_gameNameFilter);
     QString getCreatorNameFilter() const;

--- a/cockatrice/src/game/game_selector.cpp
+++ b/cockatrice/src/game/game_selector.cpp
@@ -160,6 +160,7 @@ void GameSelector::actSetFilter()
     gameListProxyModel->setHideGamesThatStarted(dlg.getHideGamesThatStarted());
     gameListProxyModel->setHidePasswordProtectedGames(dlg.getHidePasswordProtectedGames());
     gameListProxyModel->setHideIgnoredUserGames(dlg.getHideIgnoredUserGames());
+    gameListProxyModel->setHideNotBuddyCreatedGames(dlg.getHideNotBuddyCreatedGames());
     gameListProxyModel->setGameNameFilter(dlg.getGameNameFilter());
     gameListProxyModel->setCreatorNameFilter(dlg.getCreatorNameFilter());
     gameListProxyModel->setGameTypeFilter(dlg.getGameTypeFilter());

--- a/cockatrice/src/game/games_model.cpp
+++ b/cockatrice/src/game/games_model.cpp
@@ -314,6 +314,12 @@ void GamesProxyModel::setHidePasswordProtectedGames(bool _showPasswordProtectedG
     invalidateFilter();
 }
 
+void GamesProxyModel::setHideNotBuddyCreatedGames(bool value)
+{
+    hideNotBuddyCreatedGames = value;
+    invalidateFilter();
+}
+
 void GamesProxyModel::setGameNameFilter(const QString &_gameNameFilter)
 {
     gameNameFilter = _gameNameFilter;
@@ -391,6 +397,7 @@ void GamesProxyModel::resetFilterParameters()
     hidePasswordProtectedGames = false;
     hideBuddiesOnlyGames = false;
     hideIgnoredUserGames = false;
+    hideNotBuddyCreatedGames = false;
     gameNameFilter = QString();
     creatorNameFilter = QString();
     gameTypeFilter.clear();
@@ -408,8 +415,8 @@ void GamesProxyModel::resetFilterParameters()
 bool GamesProxyModel::areFilterParametersSetToDefaults() const
 {
     return !hideFullGames && !hideGamesThatStarted && !hidePasswordProtectedGames && !hideBuddiesOnlyGames &&
-           !hideIgnoredUserGames && gameNameFilter.isEmpty() && creatorNameFilter.isEmpty() &&
-           gameTypeFilter.isEmpty() && maxPlayersFilterMin == DEFAULT_MAX_PLAYERS_MIN &&
+           !hideIgnoredUserGames && !hideNotBuddyCreatedGames && gameNameFilter.isEmpty() &&
+           creatorNameFilter.isEmpty() && gameTypeFilter.isEmpty() && maxPlayersFilterMin == DEFAULT_MAX_PLAYERS_MIN &&
            maxPlayersFilterMax == DEFAULT_MAX_PLAYERS_MAX && maxGameAge == DEFAULT_MAX_GAME_AGE &&
            !showOnlyIfSpectatorsCanWatch && !showSpectatorPasswordProtected && !showOnlyIfSpectatorsCanChat &&
            !showOnlyIfSpectatorsCanSeeHands;
@@ -423,6 +430,7 @@ void GamesProxyModel::loadFilterParameters(const QMap<int, QString> &allGameType
     hidePasswordProtectedGames = gameFilters.isHidePasswordProtectedGames();
     hideIgnoredUserGames = gameFilters.isHideIgnoredUserGames();
     hideBuddiesOnlyGames = gameFilters.isHideBuddiesOnlyGames();
+    hideNotBuddyCreatedGames = gameFilters.isHideNotBuddyCreatedGames();
     gameNameFilter = gameFilters.getGameNameFilter();
     creatorNameFilter = gameFilters.getCreatorNameFilter();
     maxPlayersFilterMin = gameFilters.getMinPlayers();
@@ -452,6 +460,7 @@ void GamesProxyModel::saveFilterParameters(const QMap<int, QString> &allGameType
     gameFilters.setHideGamesThatStarted(hideGamesThatStarted);
     gameFilters.setHidePasswordProtectedGames(hidePasswordProtectedGames);
     gameFilters.setHideIgnoredUserGames(hideIgnoredUserGames);
+    gameFilters.setHideNotBuddyCreatedGames(hideNotBuddyCreatedGames);
     gameFilters.setGameNameFilter(gameNameFilter);
     gameFilters.setCreatorNameFilter(creatorNameFilter);
 
@@ -496,6 +505,9 @@ bool GamesProxyModel::filterAcceptsRow(int sourceRow) const
         return false;
     }
     if (hideIgnoredUserGames && userListProxy->isUserIgnored(QString::fromStdString(game.creator_info().name()))) {
+        return false;
+    }
+    if (hideNotBuddyCreatedGames && !userListProxy->isUserBuddy(QString::fromStdString(game.creator_info().name()))) {
         return false;
     }
     if (hideFullGames && game.player_count() == game.max_players())

--- a/cockatrice/src/game/games_model.h
+++ b/cockatrice/src/game/games_model.h
@@ -80,6 +80,7 @@ private:
     bool hideFullGames;
     bool hideGamesThatStarted;
     bool hidePasswordProtectedGames;
+    bool hideNotBuddyCreatedGames;
     QString gameNameFilter, creatorNameFilter;
     QSet<int> gameTypeFilter;
     quint32 maxPlayersFilterMin, maxPlayersFilterMax;
@@ -115,6 +116,11 @@ public:
         return hidePasswordProtectedGames;
     }
     void setHidePasswordProtectedGames(bool _showPasswordProtectedGames);
+    bool getHideNotBuddyCreatedGames() const
+    {
+        return hideNotBuddyCreatedGames;
+    }
+    void setHideNotBuddyCreatedGames(bool value);
     QString getGameNameFilter() const
     {
         return gameNameFilter;

--- a/cockatrice/src/settings/game_filters_settings.cpp
+++ b/cockatrice/src/settings/game_filters_settings.cpp
@@ -72,6 +72,17 @@ bool GameFiltersSettings::isHideIgnoredUserGames()
     return !(previous == QVariant()) && previous.toBool();
 }
 
+void GameFiltersSettings::setHideNotBuddyCreatedGames(bool hide)
+{
+    setValue(hide, "hide_not_buddy_created_games", "filter_games");
+}
+
+bool GameFiltersSettings::isHideNotBuddyCreatedGames()
+{
+    QVariant previous = getValue("hide_not_buddy_created_games", "filter_games");
+    return !(previous == QVariant()) && previous.toBool();
+}
+
 void GameFiltersSettings::setGameNameFilter(QString gameName)
 {
     setValue(gameName, "game_name_filter", "filter_games");

--- a/cockatrice/src/settings/game_filters_settings.h
+++ b/cockatrice/src/settings/game_filters_settings.h
@@ -14,6 +14,7 @@ public:
     bool isHideGamesThatStarted();
     bool isHidePasswordProtectedGames();
     bool isHideIgnoredUserGames();
+    bool isHideNotBuddyCreatedGames();
     QString getGameNameFilter();
     QString getCreatorNameFilter();
     int getMinPlayers();
@@ -30,6 +31,7 @@ public:
     void setHideFullGames(bool hide);
     void setHideGamesThatStarted(bool hide);
     void setHidePasswordProtectedGames(bool hide);
+    void setHideNotBuddyCreatedGames(bool hide);
     void setGameNameFilter(QString gameName);
     void setCreatorNameFilter(QString creatorName);
     void setMinPlayers(int min);


### PR DESCRIPTION
## Related Ticket(s)
- Partially #5990

## Short roundup of the initial problem

We want the ability to filter for games that have a buddy present

Note that this only partially addresses the ticket because I was hoping to filter games by if any buddies are present in the game, not just if they're the creator. However, the game model doesn't expose participant information right now. Implementing the filter for just buddy creators is trivial and still gets us most of the way there with what people will use it for.


## What will change with this Pull Request?
- Added game filter `hide games not created by buddy`
  - filter basically uses the same logic as the `hide ignored users` filters, but in reverse

https://github.com/user-attachments/assets/43397ee8-4a69-4a9c-9f68-d2065f9bbb59

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<img width="637" alt="Screenshot 2025-06-13 at 7 05 20 PM" src="https://github.com/user-attachments/assets/a1afba93-9cef-491d-acc8-4ea4586a184d" />
