### PR TITLE
Fix QString missing arg warning in logMoveCard

### DIFF
--- a/cockatrice/src/server/message_log_widget.cpp
+++ b/cockatrice/src/server/message_log_widget.cpp
@@ -293,7 +293,7 @@ void MessageLogWidget::logMoveCard(Player *player,
     }
 
     QString finalStr;
-    bool usesNewX = false;
+    std::optional<QString> fourthArg;
     if (targetZoneName == TABLE_ZONE_NAME) {
         soundEngine->playSound("play_card");
         if (card->getFaceDown()) {
@@ -316,7 +316,7 @@ void MessageLogWidget::logMoveCard(Player *player,
             finalStr = tr("%1 puts %2%3 on top of their library.");
         } else {
             ++newX;
-            usesNewX = true;
+            fourthArg = QString::number(newX);
             finalStr = tr("%1 puts %2%3 into their library %4 cards from the top.");
         }
     } else if (targetZoneName == SIDEBOARD_ZONE_NAME) {
@@ -325,16 +325,17 @@ void MessageLogWidget::logMoveCard(Player *player,
         soundEngine->playSound("play_card");
         finalStr = tr("%1 plays %2%3.");
     } else {
+        fourthArg = targetZoneName;
         finalStr = tr("%1 moves %2%3 to custom zone '%4'.");
     }
 
-    if (usesNewX) {
-        appendHtmlServerMessage(
-            finalStr.arg(sanitizeHtml(player->getName())).arg(cardStr).arg(nameFrom.second).arg(newX));
-    } else {
-        appendHtmlServerMessage(
-            finalStr.arg(sanitizeHtml(player->getName())).arg(cardStr).arg(nameFrom.second).arg(targetZoneName));
+    QString message = finalStr.arg(sanitizeHtml(player->getName()), cardStr, nameFrom.second);
+
+    if (fourthArg.has_value()) {
+        message = message.arg(fourthArg.value());
     }
+
+    appendHtmlServerMessage(message);
 }
 
 void MessageLogWidget::logDrawCards(Player *player, int number, bool deckIsEmpty)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5877

## Short roundup of the initial problem

We get constant warnings in the logs about `QString::arg: Argument missing`. 

```
[2025-06-14 2:15:39.640 W] [unknown] - QString::arg: Argument missing: RickyRister puts <i><a href="card://Valloside, Pure Suzuran">Valloside, Pure Suzuran</a></i> from play into their graveyard., grave [unknown:0]
[2025-06-14 2:15:39.641 W] [unknown] - QString::arg: Argument missing: Hurt_Ze_Querzi puts <i><a href="card://Nue Sign">Nue Sign</a></i> from the stack into their graveyard., grave [unknown:0]
[2025-06-14 2:15:39.643 W] [unknown] - QString::arg: Argument missing: Hurt_Ze_Querzi plays <i><a href="card://Rampant Consumption">Rampant Consumption</a></i> from their hand., stack [unknown:0]
[2025-06-14 2:15:39.649 W] [unknown] - QString::arg: Argument missing: Hurt_Ze_Querzi puts <i><a href="card://Swamp_HQZ 12">Swamp_HQZ 12</a></i> into play from their library., table [unknown:0]
[2025-06-14 2:15:39.650 W] [unknown] - QString::arg: Argument missing: Hurt_Ze_Querzi puts <i><a href="card://Rampant Consumption">Rampant Consumption</a></i> from the stack into their graveyard., grave [unknown:0]
[2025-06-14 2:15:39.654 W] [unknown] - QString::arg: Argument missing: RickyRister puts <i><a href="card://Wayfarer's Shrine">Wayfarer's Shrine</a></i> into play from their hand., table [unknown:0]
[2025-06-14 2:15:39.654 W] [unknown] - QString::arg: Argument missing: RickyRister puts <i><a href="card://Wayfarer's Shrine">Wayfarer's Shrine</a></i> from play into their graveyard., grave [unknown:0]
[2025-06-14 2:15:39.656 W] [unknown] - QString::arg: Argument missing: RickyRister puts <i><a href="card://Forest_WTS">Forest_WTS</a></i> into play from their library., table [unknown:0]
[2025-06-14 2:15:39.660 W] [unknown] - QString::arg: Argument missing: RickyRister puts <i><a href="card://Nanahiyakumi, Song Saint">Nanahiyakumi, Song Saint</a></i> into play from their hand., table [unknown:0]
[2025-06-14 2:15:39.666 W] [unknown] - QString::arg: Argument missing: Hurt_Ze_Querzi plays <i><a href="card://Rampant Consumption">Rampant Consumption</a></i> from their hand., stack [unknown:0]
[2025-06-14 2:15:39.669 W] [unknown] - QString::arg: Argument missing: Hurt_Ze_Querzi puts <i><a href="card://Forest_HQZ 13">Forest_HQZ 13</a></i> into play from their library., table [unknown:0]
```

This seems to be because we added a conditional fourth arg to the `logMoveCard` string to handle custom zones, without considering that the previous strings still only have 3 args.

## What will change with this Pull Request?
- Refactored the string templating logic in `logMoveCard` to be nicer (and to no longer emit that warning)