### PR TITLE
Printing Selector Bulk Editor

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -169,6 +169,7 @@ set(cockatrice_SOURCES
     src/dialogs/dlg_move_top_cards_until.cpp
     src/dialogs/dlg_register.cpp
     src/dialogs/dlg_roll_dice.cpp
+    src/dialogs/dlg_select_set_for_cards.cpp
     src/dialogs/dlg_settings.cpp
     src/dialogs/dlg_tip_of_the_day.cpp
     src/dialogs/dlg_update.cpp

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
@@ -88,13 +88,6 @@ PrintingSelector::PrintingSelector(QWidget *parent, AbstractTabDeckEditor *_deck
 
     sortAndOptionsLayout->addWidget(searchBar);
     sortAndOptionsLayout->addWidget(displayOptionsWidget);
-    searchAndSetLayout->addWidget(searchBar);
-
-    selectSetForCardsButton = new QPushButton(this);
-    connect(selectSetForCardsButton, &QPushButton::clicked, this, &PrintingSelector::selectSetForCards);
-    searchAndSetLayout->addWidget(selectSetForCardsButton);
-
-    layout->addLayout(searchAndSetLayout);
 
     layout->addWidget(sortAndOptionsContainer);
 
@@ -114,7 +107,6 @@ PrintingSelector::PrintingSelector(QWidget *parent, AbstractTabDeckEditor *_deck
 void PrintingSelector::retranslateUi()
 {
     navigationCheckBox->setText(tr("Display Navigation Buttons"));
-    selectSetForCardsButton->setText(tr("Bulk Selection"));
 
     if (warningLabel) {
         warningLabel->setText(
@@ -276,12 +268,4 @@ void PrintingSelector::getAllSetsForCurrentCard()
 void PrintingSelector::toggleVisibilityNavigationButtons(bool _state)
 {
     cardSelectionBar->setVisible(_state);
-}
-
-void PrintingSelector::selectSetForCards()
-{
-    DlgSelectSetForCards *setSelectionDialog = new DlgSelectSetForCards(nullptr, deckModel);
-    if (!setSelectionDialog->exec()) {
-        return;
-    }
 }

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
@@ -1,5 +1,6 @@
 #include "printing_selector.h"
 
+#include "../../../../dialogs/dlg_select_set_for_cards.h"
 #include "../../../../settings/cache_settings.h"
 #include "../../picture_loader/picture_loader.h"
 #include "printing_selector_card_display_widget.h"
@@ -87,6 +88,13 @@ PrintingSelector::PrintingSelector(QWidget *parent, AbstractTabDeckEditor *_deck
 
     sortAndOptionsLayout->addWidget(searchBar);
     sortAndOptionsLayout->addWidget(displayOptionsWidget);
+    searchAndSetLayout->addWidget(searchBar);
+
+    selectSetForCardsButton = new QPushButton(this);
+    connect(selectSetForCardsButton, &QPushButton::clicked, this, &PrintingSelector::selectSetForCards);
+    searchAndSetLayout->addWidget(selectSetForCardsButton);
+
+    layout->addLayout(searchAndSetLayout);
 
     layout->addWidget(sortAndOptionsContainer);
 
@@ -267,4 +275,10 @@ void PrintingSelector::getAllSetsForCurrentCard()
 void PrintingSelector::toggleVisibilityNavigationButtons(bool _state)
 {
     cardSelectionBar->setVisible(_state);
+}
+
+void PrintingSelector::selectSetForCards()
+{
+    DlgSelectSetForCards *setSelectionDialog = new DlgSelectSetForCards(nullptr, deckModel);
+    setSelectionDialog->show();
 }

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
@@ -280,5 +280,7 @@ void PrintingSelector::toggleVisibilityNavigationButtons(bool _state)
 void PrintingSelector::selectSetForCards()
 {
     DlgSelectSetForCards *setSelectionDialog = new DlgSelectSetForCards(nullptr, deckModel);
-    setSelectionDialog->show();
+    if (!setSelectionDialog->exec()) {
+        return;
+    }
 }

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
@@ -114,6 +114,7 @@ PrintingSelector::PrintingSelector(QWidget *parent, AbstractTabDeckEditor *_deck
 void PrintingSelector::retranslateUi()
 {
     navigationCheckBox->setText(tr("Display Navigation Buttons"));
+    selectSetForCardsButton->setText(tr("Bulk Selection"));
 
     if (warningLabel) {
         warningLabel->setText(

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.h
@@ -50,7 +50,6 @@ private:
     QCheckBox *navigationCheckBox;
     QLabel *warningLabel;
     PrintingSelectorCardSortingWidget *sortToolBar;
-    QHBoxLayout *searchAndSetLayout;
     PrintingSelectorCardSearchWidget *searchBar;
     QPushButton *selectSetForCardsButton;
     FlowWidget *flowWidget;

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.h
@@ -9,6 +9,7 @@
 
 #include <QCheckBox>
 #include <QLabel>
+#include <QPushButton>
 #include <QTreeView>
 #include <QVBoxLayout>
 #include <QWidget>
@@ -36,6 +37,7 @@ public slots:
     void selectPreviousCard();
     void selectNextCard();
     void toggleVisibilityNavigationButtons(bool _state);
+    void selectSetForCards();
 
 private slots:
     void printingsInDeckChanged();
@@ -48,7 +50,9 @@ private:
     QCheckBox *navigationCheckBox;
     QLabel *warningLabel;
     PrintingSelectorCardSortingWidget *sortToolBar;
+    QHBoxLayout *searchAndSetLayout;
     PrintingSelectorCardSearchWidget *searchBar;
+    QPushButton *selectSetForCardsButton;
     FlowWidget *flowWidget;
     CardSizeWidget *cardSizeWidget;
     PrintingSelectorCardSelectionWidget *cardSelectionBar;

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.h
@@ -30,6 +30,10 @@ public:
 
     void setCard(const CardInfoPtr &newCard, const QString &_currentZone);
     void getAllSetsForCurrentCard();
+    DeckListModel *getDeckModel() const
+    {
+        return deckModel;
+    };
 
 public slots:
     void retranslateUi();
@@ -37,7 +41,6 @@ public slots:
     void selectPreviousCard();
     void selectNextCard();
     void toggleVisibilityNavigationButtons(bool _state);
-    void selectSetForCards();
 
 private slots:
     void printingsInDeckChanged();
@@ -51,7 +54,6 @@ private:
     QLabel *warningLabel;
     PrintingSelectorCardSortingWidget *sortToolBar;
     PrintingSelectorCardSearchWidget *searchBar;
-    QPushButton *selectSetForCardsButton;
     FlowWidget *flowWidget;
     CardSizeWidget *cardSizeWidget;
     PrintingSelectorCardSelectionWidget *cardSelectionBar;

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_selection_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_selection_widget.cpp
@@ -1,5 +1,7 @@
 #include "printing_selector_card_selection_widget.h"
 
+#include "../../../../dialogs/dlg_select_set_for_cards.h"
+
 /**
  * @brief Constructs a PrintingSelectorCardSelectionWidget for navigating through cards in the deck.
  *
@@ -16,12 +18,18 @@ PrintingSelectorCardSelectionWidget::PrintingSelectorCardSelectionWidget(Printin
     previousCardButton = new QPushButton(this);
     previousCardButton->setText(tr("Previous Card in Deck"));
 
+    selectSetForCardsButton = new QPushButton(this);
+    connect(selectSetForCardsButton, &QPushButton::clicked, this,
+            &PrintingSelectorCardSelectionWidget::selectSetForCards);
+    selectSetForCardsButton->setText(tr("Bulk Selection"));
+
     nextCardButton = new QPushButton(this);
     nextCardButton->setText(tr("Next Card in Deck"));
 
     connectSignals();
 
     cardSelectionBarLayout->addWidget(previousCardButton);
+    cardSelectionBarLayout->addWidget(selectSetForCardsButton);
     cardSelectionBarLayout->addWidget(nextCardButton);
 }
 
@@ -35,4 +43,12 @@ void PrintingSelectorCardSelectionWidget::connectSignals()
 {
     connect(previousCardButton, &QPushButton::clicked, parent, &PrintingSelector::selectPreviousCard);
     connect(nextCardButton, &QPushButton::clicked, parent, &PrintingSelector::selectNextCard);
+}
+
+void PrintingSelectorCardSelectionWidget::selectSetForCards()
+{
+    DlgSelectSetForCards *setSelectionDialog = new DlgSelectSetForCards(nullptr, parent->getDeckModel());
+    if (!setSelectionDialog->exec()) {
+        return;
+    }
 }

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_selection_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_selection_widget.h
@@ -16,10 +16,14 @@ public:
 
     void connectSignals();
 
+public slots:
+    void selectSetForCards();
+
 private:
     PrintingSelector *parent;
     QHBoxLayout *cardSelectionBarLayout;
     QPushButton *previousCardButton;
+    QPushButton *selectSetForCardsButton;
     QPushButton *nextCardButton;
 };
 

--- a/cockatrice/src/deck/deck_loader.h
+++ b/cockatrice/src/deck/deck_loader.h
@@ -78,6 +78,7 @@ public:
     bool saveToFile(const QString &fileName, FileFormat fmt);
     bool updateLastLoadedTimestamp(const QString &fileName, FileFormat fmt);
     QString exportDeckToDecklist(DecklistWebsite website);
+    void setProviderIdToPreferredPrinting();
 
     void resolveSetNameAndNumberToProviderID();
 

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -1,0 +1,438 @@
+#include "dlg_select_set_for_cards.h"
+
+#include "../client/ui/widgets/cards/card_info_picture_widget.h"
+#include "../client/ui/widgets/general/layout_containers/flow_widget.h"
+#include "../deck/deck_loader.h"
+#include "../game/cards/card_database_manager.h"
+#include "dlg_select_set_for_cards.h"
+
+#include <QCheckBox>
+#include <QLabel>
+#include <QMimeData>
+#include <QPainter>
+#include <QPushButton>
+#include <QSplitter>
+#include <QVBoxLayout>
+#include <algorithm>
+#include <qdrag.h>
+#include <qevent.h>
+
+DlgSelectSetForCards::DlgSelectSetForCards(QWidget *parent, DeckListModel *_model)
+    : QDialog(parent), model(_model)
+{
+    setMinimumSize(500, 500);
+    setAcceptDrops(true);
+
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    setLayout(mainLayout);
+
+    QSplitter *splitter = new QSplitter(Qt::Vertical, this);
+    mainLayout->addWidget(splitter);
+
+    // Top scroll area
+    scrollArea = new QScrollArea(this);
+    scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    scrollArea->setWidgetResizable(true);
+
+    listContainer = new QWidget(scrollArea);
+    listLayout = new QVBoxLayout(listContainer);
+    listContainer->setLayout(listLayout);
+    scrollArea->setWidget(listContainer);
+
+    // Bottom section container
+    QWidget *bottomContainer = new QWidget(this);
+    QVBoxLayout *bottomLayout = new QVBoxLayout(bottomContainer);
+    bottomLayout->setContentsMargins(0, 0, 0, 0);
+
+    uneditedCardsLabel = new QLabel("Unmodified Cards:", this);
+    uneditedCardsArea = new QScrollArea(this);
+    uneditedCardsArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    uneditedCardsArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    uneditedCardsArea->setWidgetResizable(true);
+
+    uneditedCardsFlowWidget = new FlowWidget(uneditedCardsArea, Qt::Horizontal, Qt::ScrollBarAlwaysOff, Qt::ScrollBarAsNeeded);
+    uneditedCardsArea->setWidget(uneditedCardsFlowWidget);
+
+    bottomLayout->addWidget(uneditedCardsLabel);
+    bottomLayout->addWidget(uneditedCardsArea);
+    bottomContainer->setLayout(bottomLayout);
+
+    // Add widgets to the splitter
+    splitter->addWidget(scrollArea);
+    splitter->addWidget(bottomContainer);
+
+    sortSetsByCount();
+    updateCardLists();
+
+    // Set stretch factors: top (2:3), bottom (1:3)
+    splitter->setStretchFactor(0, 3);
+    splitter->setStretchFactor(1, 1);
+}
+
+void DlgSelectSetForCards::sortSetsByCount()
+{
+    QMap<QString, int> setsForCards = getSetsForCards();
+
+    // Convert map to a sortable list
+    QVector<QPair<QString, int>> setList;
+    for (auto it = setsForCards.begin(); it != setsForCards.end(); ++it) {
+        setList.append(qMakePair(it.key(), it.value()));
+    }
+
+    // Sort in descending order of count
+    std::sort(setList.begin(), setList.end(),
+              [](const QPair<QString, int> &a, const QPair<QString, int> &b) { return a.second > b.second; });
+
+    // Clear existing entries
+    qDeleteAll(setEntries);
+    setEntries.clear();
+
+    // Populate with sorted entries
+    for (const auto &entry : setList) {
+        SetEntryWidget *widget = new SetEntryWidget(this, entry.first, entry.second);
+        listLayout->addWidget(widget);
+        setEntries.insert(entry.first, widget);
+    }
+}
+
+QMap<QString, int> DlgSelectSetForCards::getSetsForCards()
+{
+    QMap<QString, int> setCounts;
+    if (!model)
+        return setCounts;
+
+    DeckList *decklist = model->getDeckList();
+    if (!decklist)
+        return setCounts;
+
+    InnerDecklistNode *listRoot = decklist->getRoot();
+    if (!listRoot)
+        return setCounts;
+
+    for (auto *i : *listRoot) {
+        auto *countCurrentZone = dynamic_cast<InnerDecklistNode *>(i);
+        if (!countCurrentZone)
+            continue;
+
+        for (auto *cardNode : *countCurrentZone) {
+            auto *currentCard = dynamic_cast<DecklistCardNode *>(cardNode);
+            if (!currentCard)
+                continue;
+
+            CardInfoPtr infoPtr = CardDatabaseManager::getInstance()->getCard(currentCard->getName());
+            if (!infoPtr)
+                continue;
+
+            CardInfoPerSetMap infoPerSetMap = infoPtr->getSets();
+            for (auto it = infoPerSetMap.begin(); it != infoPerSetMap.end(); ++it) {
+                setCounts[it.key()]++;
+            }
+        }
+    }
+    return setCounts;
+}
+
+void DlgSelectSetForCards::updateCardLists()
+{
+    QList<SetEntryWidget*> entry_widgets;
+    for (int i = 0; i < listLayout->count(); ++i) {
+        QWidget *widget = listLayout->itemAt(i)->widget();
+        if (auto entry = qobject_cast<SetEntryWidget*>(widget)) {
+            entry_widgets.append(entry);
+        }
+    }
+    for (SetEntryWidget *entryWidget : entry_widgets) {
+        if (entryWidget->expanded) {
+            entryWidget->populateCardList();
+        }
+    }
+
+    uneditedCardsFlowWidget->clearLayout();
+
+    QStringList selectedCards;
+    for (SetEntryWidget *entryWidget : entry_widgets) {
+        if (entryWidget->isChecked()) {
+            QStringList cardsInSet = entryWidget->getAllCardsForSet();
+            for (QString cardInSet : cardsInSet) {
+                selectedCards.append(cardInSet);
+            }
+        }
+    }
+    selectedCards.removeDuplicates();
+
+    DeckList *decklist = model->getDeckList();
+    if (!decklist)
+        return;
+
+    InnerDecklistNode *listRoot = decklist->getRoot();
+    if (!listRoot)
+        return;
+
+    for (auto *i : *listRoot) {
+        auto *countCurrentZone = dynamic_cast<InnerDecklistNode *>(i);
+        if (!countCurrentZone)
+            continue;
+
+        for (auto *cardNode : *countCurrentZone) {
+            auto *currentCard = dynamic_cast<DecklistCardNode *>(cardNode);
+            if (!currentCard)
+                continue;
+
+            if (!selectedCards.contains(currentCard->getName())) {
+                CardInfoPtr infoPtr = CardDatabaseManager::getInstance()->getCard(currentCard->getName());
+                CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(uneditedCardsFlowWidget);
+                picture_widget->setCard(infoPtr);
+                uneditedCardsFlowWidget->addWidget(picture_widget);
+            }
+        }
+    }
+}
+
+
+
+void DlgSelectSetForCards::dragEnterEvent(QDragEnterEvent *event)
+{
+    if (event->mimeData()->hasFormat("application/x-setentrywidget")) {
+        event->acceptProposedAction();
+    }
+}
+
+void DlgSelectSetForCards::dropEvent(QDropEvent *event)
+{
+    QByteArray itemData = event->mimeData()->data("application/x-setentrywidget");
+    QString draggedSetName = QString::fromUtf8(itemData);
+
+    int dropIndex = -1;
+    for (int i = 0; i < listLayout->count(); ++i) {
+        QWidget *widget = listLayout->itemAt(i)->widget();
+        if (widget && widget->geometry().contains(event->position().toPoint())) {
+            dropIndex = i;
+            break;
+        }
+    }
+
+    if (dropIndex != -1) {
+        // Find the dragged widget
+        SetEntryWidget *draggedWidget = setEntries.value(draggedSetName, nullptr);
+        if (draggedWidget) {
+            listLayout->removeWidget(draggedWidget);
+            listLayout->insertWidget(dropIndex, draggedWidget);
+        }
+    }
+
+    event->acceptProposedAction();
+}
+
+
+SetEntryWidget::SetEntryWidget(DlgSelectSetForCards *_parent, const QString &_setName, int count)
+    : QWidget(_parent), parent(_parent), setName(_setName), expanded(false)
+{
+    layout = new QVBoxLayout(this);
+    setLayout(layout);
+
+    QHBoxLayout *headerLayout = new QHBoxLayout();
+    checkBox = new QCheckBox(setName, this);
+    connect(checkBox, &QCheckBox::checkStateChanged, parent, &DlgSelectSetForCards::updateCardLists);
+    expandButton = new QPushButton("+", this);
+    countLabel = new QLabel(QString::number(count), this);
+
+    connect(expandButton, &QPushButton::clicked, this, &SetEntryWidget::toggleExpansion);
+
+    headerLayout->addWidget(checkBox);
+    headerLayout->addWidget(countLabel);
+    headerLayout->addWidget(expandButton);
+    layout->addLayout(headerLayout);
+
+    possibleCardsLabel = new QLabel(this);
+    possibleCardsLabel->setText("Unselected cards in set:");
+    possibleCardsLabel->hide();
+
+    cardListContainer = new FlowWidget(this, Qt::Horizontal, Qt::ScrollBarAlwaysOff, Qt::ScrollBarAlwaysOff);
+    cardListContainer->hide();
+
+    alreadySelectedCardsLabel = new QLabel(this);
+    alreadySelectedCardsLabel->setText("Cards in set already selected in higher priority set:");
+    alreadySelectedCardsLabel->hide();
+
+    alreadySelectedCardListContainer = new FlowWidget(this, Qt::Horizontal, Qt::ScrollBarAlwaysOff, Qt::ScrollBarAlwaysOff);
+    alreadySelectedCardListContainer->hide();
+
+    layout->addWidget(possibleCardsLabel);
+    layout->addWidget(cardListContainer);
+    layout->addWidget(alreadySelectedCardsLabel);
+    layout->addWidget(alreadySelectedCardListContainer);
+    setAttribute(Qt::WA_DeleteOnClose, false);
+}
+
+void SetEntryWidget::mousePressEvent(QMouseEvent *event)
+{
+    if (event->button() == Qt::LeftButton) {
+        QDrag *drag = new QDrag(this);
+        QMimeData *mimeData = new QMimeData;
+
+        mimeData->setData("application/x-setentrywidget", setName.toUtf8());
+        drag->setMimeData(mimeData);
+
+        // Create a drag preview (snapshot of the widget)
+        QPixmap pixmap(size());
+        pixmap.fill(Qt::transparent); // Ensure transparency
+
+        QPainter painter(&pixmap);
+        this->render(&painter);
+        painter.end();
+
+        drag->setPixmap(pixmap);
+        drag->setHotSpot(event->position().toPoint()); // Keeps the cursor aligned
+
+        drag->exec(Qt::MoveAction);
+    }
+}
+
+
+void SetEntryWidget::mouseMoveEvent(QMouseEvent *event) {
+    if (!(event->buttons() & Qt::LeftButton))
+        return;
+
+    // Start a drag operation
+    QDrag *drag = new QDrag(this);
+    QMimeData *mimeData = new QMimeData();
+    mimeData->setText("SetEntryWidget Data");  // Customize with relevant data
+    drag->setMimeData(mimeData);
+
+    // Create a drag preview of the widget
+    QPixmap pixmap(size());
+    pixmap.fill(Qt::transparent);
+
+    // Render the widget onto the pixmap
+    render(&pixmap);
+
+    // Optionally, apply transparency to make it look like a drag effect
+    QPixmap transparentPixmap = pixmap;
+    QPainter painter(&transparentPixmap);
+    painter.setCompositionMode(QPainter::CompositionMode_DestinationIn);
+    painter.fillRect(transparentPixmap.rect(), QColor(0, 0, 0, 128));  // Semi-transparent effect
+    painter.end();
+
+    // Set the drag pixmap
+    drag->setPixmap(transparentPixmap);
+    drag->setHotSpot(event->pos());  // Ensure the drag starts from where the user clicked
+
+    // Start the drag operation
+    drag->exec(Qt::MoveAction);
+}
+
+
+bool SetEntryWidget::isChecked() const
+{
+    return checkBox->isChecked();
+}
+
+void SetEntryWidget::toggleExpansion()
+{
+    expanded = !expanded;
+    possibleCardsLabel->setVisible(expanded);
+    cardListContainer->setVisible(expanded);
+    alreadySelectedCardsLabel->setVisible(expanded);
+    alreadySelectedCardListContainer->setVisible(expanded);
+    expandButton->setText(expanded ? "-" : "+");
+
+    parent->updateCardLists();
+}
+
+QStringList SetEntryWidget::getAllCardsForSet()
+{
+    QStringList list;
+    QMap<QString, QStringList> setCards = parent->getCardsForSets();
+    if (setCards.contains(setName)) {
+        for (const QString &cardName : setCards[setName]) {
+            list << cardName;
+        }
+    }
+    return list;
+}
+
+void SetEntryWidget::populateCardList()
+{
+    cardListContainer->clearLayout();
+    alreadySelectedCardListContainer->clearLayout();
+
+    QStringList possibleCards = getAllCardsForSet();
+    QList<SetEntryWidget*> entry_widgets;
+    for (int i = 0; i < parent->listLayout->count(); ++i) {
+        QWidget *widget = parent->listLayout->itemAt(i)->widget();
+        if (auto entry = qobject_cast<SetEntryWidget*>(widget)) {
+            entry_widgets.append(entry);
+        }
+    }
+
+    for (SetEntryWidget *entryWidget : entry_widgets) {
+        if (entryWidget == this) {
+            break;
+        }
+        if (entryWidget->isChecked()) {
+            QStringList alreadyDoneCards = entryWidget->getAllCardsForSet();
+            for (const QString &cardName : alreadyDoneCards) {
+                possibleCards.removeAll(cardName);
+            }
+        }
+    }
+
+    for (const QString &cardName : possibleCards) {
+        CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(cardListContainer);
+        picture_widget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
+            cardName,
+            CardDatabaseManager::getInstance()->getSpecificSetForCard(cardName, setName, nullptr).getProperty("uuid")));
+        cardListContainer->addWidget(picture_widget);
+    }
+
+    QStringList unusedCards = getAllCardsForSet();
+    for (const QString &cardName : possibleCards) {
+        unusedCards.removeAll(cardName);
+    }
+
+    for (const QString &cardName : unusedCards) {
+        CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(alreadySelectedCardListContainer);
+        picture_widget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
+            cardName,
+            CardDatabaseManager::getInstance()->getSpecificSetForCard(cardName, setName, nullptr).getProperty("uuid")));
+        alreadySelectedCardListContainer->addWidget(picture_widget);
+    }
+}
+
+QMap<QString, QStringList> DlgSelectSetForCards::getCardsForSets()
+{
+    QMap<QString, QStringList> setCards;
+    if (!model)
+        return setCards;
+
+    DeckList *decklist = model->getDeckList();
+    if (!decklist)
+        return setCards;
+
+    InnerDecklistNode *listRoot = decklist->getRoot();
+    if (!listRoot)
+        return setCards;
+
+    for (auto *i : *listRoot) {
+        auto *countCurrentZone = dynamic_cast<InnerDecklistNode *>(i);
+        if (!countCurrentZone)
+            continue;
+
+        for (auto *cardNode : *countCurrentZone) {
+            auto *currentCard = dynamic_cast<DecklistCardNode *>(cardNode);
+            if (!currentCard)
+                continue;
+
+            CardInfoPtr infoPtr = CardDatabaseManager::getInstance()->getCard(currentCard->getName());
+            if (!infoPtr)
+                continue;
+
+            CardInfoPerSetMap infoPerSetMap = infoPtr->getSets();
+            for (auto it = infoPerSetMap.begin(); it != infoPerSetMap.end(); ++it) {
+                setCards[it.key()].append(currentCard->getName());
+            }
+        }
+    }
+    return setCards;
+}

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -437,11 +437,7 @@ SetEntryWidget::SetEntryWidget(DlgSelectSetForCards *_parent, const QString &_se
     QHBoxLayout *headerLayout = new QHBoxLayout();
     CardSetPtr set = CardDatabaseManager::getInstance()->getSet(setName);
     checkBox = new QCheckBox("(" + set->getShortName() + ") - " + set->getLongName(), this);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    connect(checkBox, &QCheckBox::checkStateChanged, parent, &DlgSelectSetForCards::updateLayoutOrder);
-#else
     connect(checkBox, &QCheckBox::stateChanged, parent, &DlgSelectSetForCards::updateLayoutOrder);
-#endif
     expandButton = new QPushButton("+", this);
     countLabel = new QLabel(QString::number(count), this);
 

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -384,7 +384,8 @@ SetEntryWidget::SetEntryWidget(DlgSelectSetForCards *_parent, const QString &_se
     setLayout(layout);
 
     QHBoxLayout *headerLayout = new QHBoxLayout();
-    checkBox = new QCheckBox(setName, this);
+    CardSetPtr set = CardDatabaseManager::getInstance()->getSet(setName);
+    checkBox = new QCheckBox("(" + set->getShortName() + ") - " + set->getLongName(), this);
     connect(checkBox, &QCheckBox::checkStateChanged, parent, &DlgSelectSetForCards::updateCardLists);
     expandButton = new QPushButton("+", this);
     countLabel = new QLabel(QString::number(count), this);

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -25,12 +25,14 @@ DlgSelectSetForCards::DlgSelectSetForCards(QWidget *parent, DeckListModel *_mode
     setMinimumSize(500, 500);
     setAcceptDrops(true);
 
+    instructionLabel = new QLabel(this);
+    instructionLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
     setLayout(mainLayout);
 
     // Main vertical splitter
     QSplitter *splitter = new QSplitter(Qt::Vertical, this);
-    mainLayout->addWidget(splitter);
 
     // Top scroll area
     scrollArea = new QScrollArea(this);
@@ -100,7 +102,6 @@ DlgSelectSetForCards::DlgSelectSetForCards(QWidget *parent, DeckListModel *_mode
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOK()));
     connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
-    splitter->addWidget(buttonBox);
 
     // Set stretch factors
     splitter->setStretchFactor(0, 6); // Scroll area gets more space
@@ -112,6 +113,18 @@ DlgSelectSetForCards::DlgSelectSetForCards(QWidget *parent, DeckListModel *_mode
 
     connect(this, &DlgSelectSetForCards::orderChanged, this, &DlgSelectSetForCards::updateLayoutOrder);
     connect(this, &DlgSelectSetForCards::widgetOrderChanged, this, &DlgSelectSetForCards::updateCardLists);
+
+    mainLayout->addWidget(instructionLabel);
+    mainLayout->addWidget(splitter);
+    mainLayout->addWidget(buttonBox);
+
+    retranslateUi();
+}
+
+void DlgSelectSetForCards::retranslateUi()
+{
+    instructionLabel->setText(tr("Check Sets to enable them. Drag-and-Drop to reorder them and change their "
+                                 "priority. Cards will use the printing of the highest priority enabled set."));
 }
 
 void DlgSelectSetForCards::actOK()

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -437,7 +437,7 @@ SetEntryWidget::SetEntryWidget(DlgSelectSetForCards *_parent, const QString &_se
     QHBoxLayout *headerLayout = new QHBoxLayout();
     CardSetPtr set = CardDatabaseManager::getInstance()->getSet(setName);
     checkBox = new QCheckBox("(" + set->getShortName() + ") - " + set->getLongName(), this);
-    connect(checkBox, &QCheckBox::stateChanged, parent, &DlgSelectSetForCards::updateLayoutOrder);
+    connect(checkBox, &QCheckBox::toggled, parent, &DlgSelectSetForCards::updateLayoutOrder);
     expandButton = new QPushButton("+", this);
     countLabel = new QLabel(QString::number(count), this);
 

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -128,6 +128,8 @@ DlgSelectSetForCards::DlgSelectSetForCards(QWidget *parent, DeckListModel *_mode
     mainLayout->addWidget(buttonBox);
 
     retranslateUi();
+    setWindowFlags(Qt::Window);
+    showMaximized();
 }
 
 void DlgSelectSetForCards::retranslateUi()

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -103,6 +103,15 @@ DlgSelectSetForCards::DlgSelectSetForCards(QWidget *parent, DeckListModel *_mode
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(actOK()));
     connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
 
+    clearButton = new QPushButton(buttonBox);
+    connect(clearButton, &QPushButton::clicked, this, &DlgSelectSetForCards::actClear);
+
+    setAllToPreferredButton = new QPushButton(buttonBox);
+    connect(setAllToPreferredButton, &QPushButton::clicked, this, &DlgSelectSetForCards::actSetAllToPreferred);
+
+    buttonBox->addButton(clearButton, QDialogButtonBox::ActionRole);
+    buttonBox->addButton(setAllToPreferredButton, QDialogButtonBox::ActionRole);
+
     // Set stretch factors
     splitter->setStretchFactor(0, 6); // Scroll area gets more space
     splitter->setStretchFactor(1, 2); // Bottom part gets less space
@@ -125,6 +134,8 @@ void DlgSelectSetForCards::retranslateUi()
 {
     instructionLabel->setText(tr("Check Sets to enable them. Drag-and-Drop to reorder them and change their "
                                  "priority. Cards will use the printing of the highest priority enabled set."));
+    clearButton->setText(tr("Clear all set information"));
+    setAllToPreferredButton->setText(tr("Set all to preferred"));
 }
 
 void DlgSelectSetForCards::actOK()
@@ -141,6 +152,19 @@ void DlgSelectSetForCards::actOK()
                            DECK_ZONE_MAIN);
         }
     }
+    accept();
+}
+
+void DlgSelectSetForCards::actClear()
+{
+    model->getDeckList()->clearSetNamesAndNumbers();
+    accept();
+}
+
+void DlgSelectSetForCards::actSetAllToPreferred()
+{
+    model->getDeckList()->clearSetNamesAndNumbers();
+    model->getDeckList()->setProviderIdToPreferredPrinting();
     accept();
 }
 

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -321,7 +321,11 @@ void DlgSelectSetForCards::dropEvent(QDropEvent *event)
 {
     QByteArray itemData = event->mimeData()->data("application/x-setentrywidget");
     QString draggedSetName = QString::fromUtf8(itemData);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QPoint adjustedPos = event->position().toPoint() + QPoint(0, scrollArea->verticalScrollBar()->value());
+#else
+    QPoint adjustedPos = event->pos() + QPoint(0, scrollArea->verticalScrollBar()->value());
+#endif
     int dropIndex = -1;
     for (int i = 0; i < listLayout->count(); ++i) {
         QWidget *widget = listLayout->itemAt(i)->widget();
@@ -433,7 +437,11 @@ SetEntryWidget::SetEntryWidget(DlgSelectSetForCards *_parent, const QString &_se
     QHBoxLayout *headerLayout = new QHBoxLayout();
     CardSetPtr set = CardDatabaseManager::getInstance()->getSet(setName);
     checkBox = new QCheckBox("(" + set->getShortName() + ") - " + set->getLongName(), this);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     connect(checkBox, &QCheckBox::checkStateChanged, parent, &DlgSelectSetForCards::updateLayoutOrder);
+#else
+    connect(checkBox, &QCheckBox::stateChanged, parent, &DlgSelectSetForCards::updateLayoutOrder);
+#endif
     expandButton = new QPushButton("+", this);
     countLabel = new QLabel(QString::number(count), this);
 
@@ -503,7 +511,11 @@ void SetEntryWidget::mousePressEvent(QMouseEvent *event)
     }
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void SetEntryWidget::enterEvent(QEnterEvent *event)
+#else
+void SetEntryWidget::enterEvent(QEvent *event)
+#endif
 {
     QWidget::enterEvent(event); // Call the base class handler
     // Highlight the widget by changing the background color only for the widget itself

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -506,6 +506,8 @@ void SetEntryWidget::populateCardList()
         unusedCards.removeAll(cardName);
     }
     checkVisibility();
+    countLabel->setText(QString::number(possibleCards.size()) + " (" +
+                        QString::number(possibleCards.size() + unusedCards.size()) + ")");
 }
 
 void SetEntryWidget::updateCardDisplayWidgets()

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -13,6 +13,7 @@
 #include <QMimeData>
 #include <QPainter>
 #include <QPushButton>
+#include <QScrollBar>
 #include <QSplitter>
 #include <QVBoxLayout>
 #include <algorithm>
@@ -279,11 +280,11 @@ void DlgSelectSetForCards::dropEvent(QDropEvent *event)
 {
     QByteArray itemData = event->mimeData()->data("application/x-setentrywidget");
     QString draggedSetName = QString::fromUtf8(itemData);
-
+    QPoint adjustedPos = event->position().toPoint() + QPoint(0, scrollArea->verticalScrollBar()->value());
     int dropIndex = -1;
     for (int i = 0; i < listLayout->count(); ++i) {
         QWidget *widget = listLayout->itemAt(i)->widget();
-        if (widget && widget->geometry().contains(event->position().toPoint())) {
+        if (widget && widget->geometry().contains(adjustedPos)) {
             dropIndex = i;
             break;
         }

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -53,7 +53,7 @@ DlgSelectSetForCards::DlgSelectSetForCards(QWidget *parent, DeckListModel *_mode
     QVBoxLayout *leftLayout = new QVBoxLayout(leftContainer);
     leftLayout->setContentsMargins(0, 0, 0, 0);
 
-    uneditedCardsLabel = new QLabel("Unmodified Cards:", this);
+    uneditedCardsLabel = new QLabel(this);
     uneditedCardsArea = new QScrollArea(this);
     uneditedCardsArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     uneditedCardsArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
@@ -72,7 +72,7 @@ DlgSelectSetForCards::DlgSelectSetForCards(QWidget *parent, DeckListModel *_mode
     QVBoxLayout *rightLayout = new QVBoxLayout(rightContainer);
     rightLayout->setContentsMargins(0, 0, 0, 0);
 
-    modifiedCardsLabel = new QLabel("Modified Cards:", this);
+    modifiedCardsLabel = new QLabel(this);
     modifiedCardsArea = new QScrollArea(this);
     modifiedCardsArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     modifiedCardsArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
@@ -132,6 +132,8 @@ DlgSelectSetForCards::DlgSelectSetForCards(QWidget *parent, DeckListModel *_mode
 
 void DlgSelectSetForCards::retranslateUi()
 {
+    uneditedCardsLabel->setText(tr("Unmodified Cards:"));
+    modifiedCardsLabel->setText(tr("Modified Cards:"));
     instructionLabel->setText(tr("Check Sets to enable them. Drag-and-Drop to reorder them and change their "
                                  "priority. Cards will use the printing of the highest priority enabled set."));
     clearButton->setText(tr("Clear all set information"));

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.h
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.h
@@ -4,6 +4,7 @@
 #include "../client/ui/widgets/general/layout_containers/flow_widget.h"
 #include "../deck/deck_list_model.h"
 
+#include <QCheckBox>
 #include <QDialog>
 #include <QLabel>
 #include <QListWidget>
@@ -11,7 +12,6 @@
 #include <QScrollArea>
 #include <QVBoxLayout>
 
-class QCheckBox;
 class SetEntryWidget; // Forward declaration
 
 class DlgSelectSetForCards : public QDialog
@@ -20,16 +20,19 @@ class DlgSelectSetForCards : public QDialog
 
 public:
     explicit DlgSelectSetForCards(QWidget *parent, DeckListModel *_model);
+    void actOK();
     void sortSetsByCount();
     QMap<QString, QStringList> getCardsForSets();
     QMap<QString, QStringList> getModifiedCards();
+    void updateLayoutOrder();
     QVBoxLayout *listLayout;
+    QList<SetEntryWidget *> entry_widgets;
+    QMap<QString, QStringList> cardsForSets;
 
 public slots:
     void updateCardLists();
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;
-    void actOK();
 
 private:
     QVBoxLayout *layout;
@@ -52,16 +55,22 @@ class SetEntryWidget : public QWidget
 
 public:
     explicit SetEntryWidget(DlgSelectSetForCards *parent, const QString &setName, int count);
-    void mousePressEvent(QMouseEvent *event);
-    void mouseMoveEvent(QMouseEvent *event);
     void toggleExpansion();
+    void checkVisibility();
     QStringList getAllCardsForSet();
     void populateCardList();
+    void updateCardDisplayWidgets();
     void updateCardState(bool checked);
     bool isChecked() const;
     DlgSelectSetForCards *parent;
     QString setName;
     bool expanded;
+
+public slots:
+    void mousePressEvent(QMouseEvent *event) override;
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
+    void dragMoveEvent(QDragMoveEvent *event) override;
 
 private:
     QVBoxLayout *layout;
@@ -73,6 +82,8 @@ private:
     QLabel *alreadySelectedCardsLabel;
     FlowWidget *alreadySelectedCardListContainer;
     QVBoxLayout *cardListLayout;
+    QStringList possibleCards;
+    QStringList unusedCards;
 };
 
 #endif // DLG_SELECT_SET_FOR_CARDS_H

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.h
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.h
@@ -20,6 +20,7 @@ class DlgSelectSetForCards : public QDialog
 
 public:
     explicit DlgSelectSetForCards(QWidget *parent, DeckListModel *_model);
+    void retranslateUi();
     void sortSetsByCount();
     QMap<QString, QStringList> getCardsForSets();
     QMap<QString, QStringList> getModifiedCards();
@@ -40,6 +41,7 @@ public slots:
 
 private:
     QVBoxLayout *layout;
+    QLabel *instructionLabel;
     QScrollArea *scrollArea;
     QScrollArea *uneditedCardsArea;
     FlowWidget *uneditedCardsFlowWidget;

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.h
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.h
@@ -1,0 +1,76 @@
+#ifndef DLG_SELECT_SET_FOR_CARDS_H
+#define DLG_SELECT_SET_FOR_CARDS_H
+
+#include "../client/ui/widgets/general/layout_containers/flow_widget.h"
+#include "../deck/deck_list_model.h"
+
+#include <QDialog>
+#include <QLabel>
+#include <QListWidget>
+#include <QMap>
+#include <QScrollArea>
+#include <QVBoxLayout>
+
+class QCheckBox;
+class SetEntryWidget; // Forward declaration
+
+class DlgSelectSetForCards : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit DlgSelectSetForCards(QWidget *parent, DeckListModel *_model);
+    void sortSetsByCount();
+    QMap<QString, QStringList> getCardsForSets();
+    QVBoxLayout *listLayout;
+
+public slots:
+    void updateCardLists();
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
+
+private:
+    QVBoxLayout *layout;
+    QScrollArea *scrollArea;
+    QScrollArea *uneditedCardsArea;
+    FlowWidget *uneditedCardsFlowWidget;
+    QLabel *uneditedCardsLabel;
+    QWidget *listContainer;
+    QListWidget *listWidget;
+    DeckListModel *model;
+    QMap<QString, SetEntryWidget *> setEntries;
+
+    QMap<QString, int> getSetsForCards();
+    void updateCardAvailability();
+};
+
+class SetEntryWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit SetEntryWidget(DlgSelectSetForCards *parent, const QString &setName, int count);
+    void mousePressEvent(QMouseEvent *event);
+    void mouseMoveEvent(QMouseEvent *event);
+    void toggleExpansion();
+    QStringList getAllCardsForSet();
+    void populateCardList();
+    void updateCardState(bool checked);
+    bool isChecked() const;
+    DlgSelectSetForCards *parent;
+    QString setName;
+    bool expanded;
+
+private:
+    QVBoxLayout *layout;
+    QCheckBox *checkBox;
+    QPushButton *expandButton;
+    QLabel *countLabel;
+    QLabel *possibleCardsLabel;
+    FlowWidget *cardListContainer;
+    QLabel *alreadySelectedCardsLabel;
+    FlowWidget *alreadySelectedCardListContainer;
+    QVBoxLayout *cardListLayout;
+};
+
+#endif // DLG_SELECT_SET_FOR_CARDS_H

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.h
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.h
@@ -23,13 +23,17 @@ public:
     void sortSetsByCount();
     QMap<QString, QStringList> getCardsForSets();
     QMap<QString, QStringList> getModifiedCards();
-    void updateLayoutOrder();
     QVBoxLayout *listLayout;
     QList<SetEntryWidget *> entry_widgets;
     QMap<QString, QStringList> cardsForSets;
 
+signals:
+    void widgetOrderChanged();
+    void orderChanged();
+
 public slots:
     void actOK();
+    void updateLayoutOrder();
     void updateCardLists();
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.h
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.h
@@ -22,12 +22,14 @@ public:
     explicit DlgSelectSetForCards(QWidget *parent, DeckListModel *_model);
     void sortSetsByCount();
     QMap<QString, QStringList> getCardsForSets();
+    QMap<QString, QStringList> getModifiedCards();
     QVBoxLayout *listLayout;
 
 public slots:
     void updateCardLists();
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;
+    void actOK();
 
 private:
     QVBoxLayout *layout;

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.h
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.h
@@ -20,7 +20,6 @@ class DlgSelectSetForCards : public QDialog
 
 public:
     explicit DlgSelectSetForCards(QWidget *parent, DeckListModel *_model);
-    void actOK();
     void sortSetsByCount();
     QMap<QString, QStringList> getCardsForSets();
     QMap<QString, QStringList> getModifiedCards();
@@ -30,6 +29,7 @@ public:
     QMap<QString, QStringList> cardsForSets;
 
 public slots:
+    void actOK();
     void updateCardLists();
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;
@@ -40,6 +40,9 @@ private:
     QScrollArea *uneditedCardsArea;
     FlowWidget *uneditedCardsFlowWidget;
     QLabel *uneditedCardsLabel;
+    QScrollArea *modifiedCardsArea;
+    FlowWidget *modifiedCardsFlowWidget;
+    QLabel *modifiedCardsLabel;
     QWidget *listContainer;
     QListWidget *listWidget;
     DeckListModel *model;

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.h
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.h
@@ -34,6 +34,8 @@ signals:
 
 public slots:
     void actOK();
+    void actClear();
+    void actSetAllToPreferred();
     void updateLayoutOrder();
     void updateCardLists();
     void dragEnterEvent(QDragEnterEvent *event) override;
@@ -53,6 +55,8 @@ private:
     QListWidget *listWidget;
     DeckListModel *model;
     QMap<QString, SetEntryWidget *> setEntries;
+    QPushButton *clearButton;
+    QPushButton *setAllToPreferredButton;
 
     QMap<QString, int> getSetsForCards();
     void updateCardAvailability();

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.h
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.h
@@ -59,7 +59,6 @@ private:
     QPushButton *setAllToPreferredButton;
 
     QMap<QString, int> getSetsForCards();
-    void updateCardAvailability();
 };
 
 class SetEntryWidget : public QWidget
@@ -73,7 +72,6 @@ public:
     QStringList getAllCardsForSet();
     void populateCardList();
     void updateCardDisplayWidgets();
-    void updateCardState(bool checked);
     bool isChecked() const;
     DlgSelectSetForCards *parent;
     QString setName;

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.h
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.h
@@ -77,7 +77,11 @@ public:
 
 public slots:
     void mousePressEvent(QMouseEvent *event) override;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     void enterEvent(QEnterEvent *event) override;
+#else
+    void enterEvent(QEvent *event) override;
+#endif
     void leaveEvent(QEvent *event) override;
     void dragMoveEvent(QDragMoveEvent *event) override;
 

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -384,8 +384,13 @@ CardInfoPerSet CardDatabase::getSpecificSetForCard(const QString &cardName,
 
     for (const auto &cardInfoPerSetList : setMap) {
         for (auto &cardInfoForSet : cardInfoPerSetList) {
-            if (cardInfoForSet.getPtr()->getShortName() == setShortName) {
-                if (cardInfoForSet.getProperty("num") == collectorNumber || collectorNumber.isEmpty()) {
+            if (collectorNumber != nullptr) {
+                if (cardInfoForSet.getPtr()->getShortName() == setShortName &&
+                    cardInfoForSet.getProperty("num") == collectorNumber) {
+                    return cardInfoForSet;
+                }
+            } else {
+                if (cardInfoForSet.getPtr()->getShortName() == setShortName) {
                     return cardInfoForSet;
                 }
             }

--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -166,13 +166,16 @@ AbstractDecklistNode *InnerDecklistNode::findCardChildByNameProviderIdAndNumber(
                                                                                 const QString &_cardNumber)
 {
     for (const auto &i : *this) {
-        if (i != nullptr && i->getName() == _name) {
-            if (i->getCardCollectorNumber() == _cardNumber) {
-                if (i->getCardProviderId() == _providerId) {
-                    return i;
-                }
-            }
+        if (!i || i->getName() != _name) {
+            continue;
         }
+        if (_cardNumber != "" && i->getCardCollectorNumber() != _cardNumber) {
+            continue;
+        }
+        if (_providerId != "" && i->getCardProviderId() != _providerId) {
+            continue;
+        }
+        return i;
     }
     return nullptr;
 }

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -137,7 +137,7 @@ public:
     void clearTree();
     AbstractDecklistNode *findChild(const QString &_name);
     AbstractDecklistNode *findCardChildByNameProviderIdAndNumber(const QString &_name,
-                                                                 const QString &_providerId,
+                                                                 const QString &_providerId = "",
                                                                  const QString &_cardNumber = "");
     int height() const override;
     int recursiveCount(bool countTotalCards = false) const;


### PR DESCRIPTION
## Short roundup of the initial problem
Users are complaining that they can't easily update their decks to the new UUID system.
This adds a dialog that allows users to either:
- Clear all uuid information from every card in the deck
- Set the uuid for every card to the "preferred" printing according to the old set manager
- Set the uuid for every card that belongs to a certain set by "enabling" that set. Multiple sets may be enabled. If a card belongs to multiple sets, the highest in the list is used. Users may re-order the list through drag-and-drop to change priority. Unaffected and affected cards as well as the printings in the respective sets are visually shown.

## What will change with this Pull Request?
- New button in print selector
- New dialog from button

## Screenshots

New button position:
![image](https://github.com/user-attachments/assets/7fe84c02-81ee-45ec-adba-0eab0cc3d85f)

Utility buttons:
![image](https://github.com/user-attachments/assets/a77ea73d-f6e7-407d-a1cc-1f850631fff5)

Showcasing functionality with minimal cards:
![image](https://github.com/user-attachments/assets/ece6f21b-98ea-4b65-8ff5-a13ae8f3b97a)
![image](https://github.com/user-attachments/assets/eb6895e0-62ec-4138-9703-a46d6aecb1da)
![image](https://github.com/user-attachments/assets/681b9885-12d1-4274-936b-c4ee33435dc3)

Showcasing functionality with larger deck:

![image](https://github.com/user-attachments/assets/db8368e8-2814-428b-9571-07cda4378684)
