### PR TITLE
[PictureLoader] Fix freezes from local image search

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -67,6 +67,7 @@ set(cockatrice_SOURCES
     src/client/ui/line_edit_completer.cpp
     src/client/ui/phases_toolbar.cpp
     src/client/ui/picture_loader/picture_loader.cpp
+    src/client/ui/picture_loader/picture_loader_local.cpp
     src/client/ui/picture_loader/picture_loader_request_status_display_widget.cpp
     src/client/ui/picture_loader/picture_loader_status_bar.cpp
     src/client/ui/picture_loader/picture_loader_worker.cpp

--- a/cockatrice/src/client/ui/picture_loader/picture_loader.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader.cpp
@@ -148,6 +148,7 @@ void PictureLoader::getPixmap(QPixmap &pixmap, CardInfoPtr card, QSize size)
 void PictureLoader::imageLoaded(CardInfoPtr card, const QImage &image)
 {
     if (image.isNull()) {
+        qCDebug(PictureLoaderLog) << "Caching NULL pixmap for" << card->getName();
         QPixmapCache::insert(card->getPixmapCacheKey(), QPixmap());
     } else {
         if (card->getUpsideDownArt()) {

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_local.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_local.cpp
@@ -1,0 +1,146 @@
+#include "picture_loader_local.h"
+
+#include "../../../game/cards/card_database_manager.h"
+#include "../../../settings/cache_settings.h"
+#include "picture_to_load.h"
+
+#include <QDirIterator>
+#include <QMovie>
+
+PictureLoaderLocal::PictureLoaderLocal(QObject *parent)
+    : QObject(parent), picsPath(SettingsCache::instance().getPicsPath()),
+      customPicsPath(SettingsCache::instance().getCustomPicsPath()),
+      overrideAllCardArtWithPersonalPreference(SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference())
+{
+    // Hook up signals to settings
+    connect(&SettingsCache::instance(), &SettingsCache::picsPathChanged, this, &PictureLoaderLocal::picsPathChanged);
+    connect(&SettingsCache::instance(), &SettingsCache::overrideAllCardArtWithPersonalPreferenceChanged, this,
+            &PictureLoaderLocal::setOverrideAllCardArtWithPersonalPreference);
+
+    createIndex();
+}
+
+void PictureLoaderLocal::createIndex()
+{
+    QDirIterator it(customPicsPath, QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
+
+    // Recursively check all subdirectories of the CUSTOM folder
+    while (it.hasNext()) {
+        QString thisPath(it.next());
+        QFileInfo thisFileInfo(thisPath);
+
+        if (thisFileInfo.isFile()) {
+            // We don't know which name is the correctedName because there might be '.'s in the cardName.
+            // Just add all possibilities to be sure.
+            customFolderIndex.insert(thisFileInfo.baseName(), thisFileInfo.absoluteFilePath());
+            customFolderIndex.insert(thisFileInfo.completeBaseName(), thisFileInfo.absoluteFilePath());
+        }
+    }
+
+    qCInfo(PictureLoaderLocalLog) << "Finished indexing local image folder CUSTOM; map now has"
+                                  << customFolderIndex.size() << "entries.";
+}
+
+/**
+ * Tries to load the card image from the local images.
+ *
+ * @param toLoad The card to load
+ * @return The loaded image, or an empty QImage if loading failed.
+ */
+QImage PictureLoaderLocal::tryLoad(const CardInfoPtr &toLoad) const
+{
+    CardSetPtr set = PictureToLoad::extractSetsSorted(toLoad).first();
+
+    QString setName = set ? set->getCorrectedShortName() : QString();
+    QString cardName = toLoad->getName();
+    QString correctedCardName = toLoad->getCorrectedName();
+
+    // FIXME: This is a hack so that to keep old Cockatrice behavior
+    // (ignoring provider ID) when the "override all card art with personal
+    // preference" is set.
+    //
+    // Figure out a proper way to integrate the two systems at some point.
+    //
+    // Note: need to go through a member for
+    // overrideAllCardArtWithPersonalPreference as reading from the
+    // SettingsCache instance from the PictureLoaderWorker thread could
+    // cause race conditions.
+    //
+    // XXX: Reading from the CardDatabaseManager instance from the
+    // PictureLoaderWorker thread might not be safe either
+    bool searchCustomPics =
+        overrideAllCardArtWithPersonalPreference ||
+        CardDatabaseManager::getInstance()->isProviderIdForPreferredPrinting(cardName, toLoad->getPixmapCacheKey());
+    if (searchCustomPics) {
+        qCDebug(PictureLoaderLocalLog).nospace()
+            << "[card: " << cardName << " set: " << setName << "]: Attempting to load picture from local";
+        return tryLoadCardImageFromDisk(setName, correctedCardName, searchCustomPics);
+    }
+
+    qCDebug(PictureLoaderLocalLog).nospace()
+        << "[card: " << cardName << " set: " << setName << "]: Skipping load picture from local";
+
+    return QImage();
+}
+
+QImage PictureLoaderLocal::tryLoadCardImageFromDisk(const QString &setName,
+                                                    const QString &correctedCardName,
+                                                    const bool searchCustomPics) const
+{
+    QImage image;
+    QImageReader imgReader;
+    imgReader.setDecideFormatFromContent(true);
+    QList<QString> picsPaths = QList<QString>();
+
+    if (searchCustomPics) {
+        picsPaths << customFolderIndex.values(correctedCardName);
+    }
+
+    if (!setName.isEmpty()) {
+        picsPaths << picsPath + "/" + setName + "/" + correctedCardName
+                  // We no longer store downloaded images there, but don't just ignore
+                  // stuff that old versions have put there.
+                  << picsPath + "/downloadedPics/" + setName + "/" + correctedCardName;
+    }
+
+    // Iterates through the list of paths, searching for images with the desired
+    // name with any QImageReader-supported extension
+    for (const auto &_picsPath : picsPaths) {
+        if (!QFileInfo(_picsPath).isFile()) {
+            continue;
+        }
+
+        imgReader.setFileName(_picsPath);
+        if (imgReader.read(&image)) {
+            qCDebug(PictureLoaderLocalLog).nospace()
+                << "[card: " << correctedCardName << " set: " << setName << "]: Picture found on disk.";
+            return image;
+        }
+        imgReader.setFileName(_picsPath + ".full");
+        if (imgReader.read(&image)) {
+            qCDebug(PictureLoaderLocalLog).nospace()
+                << "[card: " << correctedCardName << " set: " << setName << "]: Picture.full found on disk.";
+            return image;
+        }
+        imgReader.setFileName(_picsPath + ".xlhq");
+        if (imgReader.read(&image)) {
+            qCDebug(PictureLoaderLocalLog).nospace()
+                << "[card: " << correctedCardName << " set: " << setName << "]: Picture.xlhq found on disk.";
+            return image;
+        }
+    }
+    qCDebug(PictureLoaderLocalLog).nospace()
+        << "[card: " << correctedCardName << " set: " << setName << "]: Picture NOT found on disk.";
+    return QImage();
+}
+
+void PictureLoaderLocal::picsPathChanged()
+{
+    picsPath = SettingsCache::instance().getPicsPath();
+    customPicsPath = SettingsCache::instance().getCustomPicsPath();
+}
+
+void PictureLoaderLocal::setOverrideAllCardArtWithPersonalPreference(bool _overrideAllCardArtWithPersonalPreference)
+{
+    overrideAllCardArtWithPersonalPreference = _overrideAllCardArtWithPersonalPreference;
+}

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_local.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_local.h
@@ -1,0 +1,40 @@
+#ifndef PICTURE_LOADER_LOCAL_H
+#define PICTURE_LOADER_LOCAL_H
+
+#include "../../../game/cards/card_info.h"
+
+#include <QLoggingCategory>
+#include <QObject>
+
+inline Q_LOGGING_CATEGORY(PictureLoaderLocalLog, "picture_loader.local");
+
+/**
+ * Handles searching for and loading card images from the local pics and custom image folders.
+ * This class maintains an index of the CUSTOM folder, to avoid repeatedly searching the entire directory.
+ */
+class PictureLoaderLocal : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit PictureLoaderLocal(QObject *parent);
+
+    QImage tryLoad(const CardInfoPtr &toLoad) const;
+
+private:
+    QString picsPath, customPicsPath;
+    bool overrideAllCardArtWithPersonalPreference;
+
+    QMultiHash<QString, QString> customFolderIndex; // multimap of cardName to picPaths
+
+    void createIndex();
+
+    QImage
+    tryLoadCardImageFromDisk(const QString &setName, const QString &correctedCardName, bool searchCustomPics) const;
+
+private slots:
+    void picsPathChanged();
+    void setOverrideAllCardArtWithPersonalPreference(bool _overrideAllCardArtWithPersonalPreference);
+};
+
+#endif // PICTURE_LOADER_LOCAL_H

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.h
@@ -24,10 +24,9 @@ class PictureLoaderWorkerWork : public QThread
 {
     Q_OBJECT
 public:
-    explicit PictureLoaderWorkerWork(PictureLoaderWorker *worker, const CardInfoPtr &toLoad);
+    explicit PictureLoaderWorkerWork(const PictureLoaderWorker *worker, const CardInfoPtr &toLoad);
     ~PictureLoaderWorkerWork() override;
-    void startWork();
-    PictureLoaderWorker *worker;
+
     PictureToLoad cardToDownload;
 
 public slots:
@@ -35,21 +34,16 @@ public slots:
     void picDownloadFailed();
 
 private:
-    QString picsPath, customPicsPath;
-    bool overrideAllCardArtWithPersonalPreference;
     static QStringList md5Blacklist;
     QThread *pictureLoaderThread;
     QNetworkAccessManager *networkManager;
     bool picDownload, downloadRunning, loadQueueRunning;
 
     void startNextPicDownload();
-    bool cardImageExistsOnDisk(const QString &setName, const QString &correctedCardName, bool searchCustomPics);
     bool imageIsBlackListed(const QByteArray &);
 
 private slots:
     void picDownloadChanged();
-    void picsPathChanged();
-    void setOverrideAllCardArtWithPersonalPreference(bool _overrideAllCardArtWithPersonalPreference);
 
 signals:
     void startLoadQueue();

--- a/cockatrice/src/client/ui/picture_loader/picture_to_load.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_to_load.h
@@ -41,6 +41,8 @@ public:
     bool nextSet();
     bool nextUrl();
     void populateSetUrls();
+
+    static QList<CardSetPtr> extractSetsSorted(const CardInfoPtr &card);
 };
 
 #endif // PICTURE_TO_LOAD_H

--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -21,6 +21,7 @@ set(oracle_SOURCES
     ../cockatrice/src/game/cards/card_database_manager.cpp
     ../cockatrice/src/game/cards/card_info.cpp
     ../cockatrice/src/client/ui/picture_loader/picture_loader.cpp
+    ../cockatrice/src/client/ui/picture_loader/picture_loader_local.cpp
     ../cockatrice/src/client/ui/picture_loader/picture_loader_request_status_display_widget.cpp
     ../cockatrice/src/client/ui/picture_loader/picture_loader_status_bar.cpp
     ../cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp


### PR DESCRIPTION
## Related Ticket(s)
- Fixes issue introduced in #5985

## Short roundup of the initial problem

Cockatrice freezes when there is lots of images in the CUSTOM folder and a lot of images need to be loaded at once. 
Cockatrice will also frequently crash on mac due to too many open file descriptors.

The picture loading code first traverses the local image folder to check if there's any local images with the cardName, and will only start sending remote requests once that fails.
After making picture loading parallel, that means we're trying to recursively traverse the CUSTOM directory at the same time, causing the slowdown and the crash.

## What will change with this Pull Request?
- Created a new `PictureLoaderLocal` class to handle the local picture loading
    - Moved the local image loading code from `PictureLoaderWorkerWork` to the new class
  - On startup, the class traverses the CUSTOM folder and creates a map of filenames to absolute paths 
- local file lookup will take place on the PictureLoader thread, after the image is enqued but *before* we create a `PictureLoaderWorkerWork` to spin up a separate thread.
- Added a way to deduplicate image loads.
- Added some more logging around picture loading

### Followup

Currently, we do not refresh the local image folder map. You would need to restart Cockatrice whenever you put in a new image. I'm planning on adding some way to have the index refresh itself in a future PR.