### PR TITLE
[GDE] Fix add card always grouping by type

### DIFF
--- a/cockatrice/src/deck/deck_list_model.h
+++ b/cockatrice/src/deck/deck_list_model.h
@@ -96,7 +96,7 @@ public:
     {
         return nodeToIndex(root);
     };
-    QString getSortCriteriaForCard(CardInfoPtr info);
+    QString getGroupCriteriaForCard(CardInfoPtr info) const;
     int rowCount(const QModelIndex &parent) const override;
     int columnCount(const QModelIndex & /*parent*/ = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role) const override;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5931

## Short roundup of the initial problem

Adding card to deck will always add assuming it was grouping by type, even when the group criteria is different.

https://github.com/user-attachments/assets/8feaebc5-3c25-4762-a6ab-d0c4ebb67894


## What will change with this Pull Request?

- Adding cards to deck now considers the group criteria instead of being hardcoded to use the maintype for grouping
- Refactored/renamed some stuff in that class

https://github.com/user-attachments/assets/6cc67e5f-bf05-4a41-b78a-d891078b7839

