### PR TITLE
CI: Move and clarify macOS signing certificate step

### DIFF
--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -128,6 +128,23 @@ function ccachestatsverbose() {
 }
 
 # Compile
+if [[ $RUNNER_OS == macOS ]]; then
+  echo "::group::Signing Certificate"
+  if [[ -n "$MACOS_CERTIFICATE_NAME" ]]; then
+    echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+    security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+    security default-keychain -s build.keychain
+    security set-keychain-settings -t 3600 -l build.keychain
+    security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+    security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+    security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+    echo "macOS signing certificate successfully imported and keychain configured."
+  else
+    echo "No signing certificate configured. Skipping set up of keychain in macOS environment."
+  fi
+  echo "::endgroup::"
+fi
+
 if [[ $USE_CCACHE ]]; then
   echo "::group::Show ccache stats"
   ccachestatsverbose

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -285,7 +285,7 @@ jobs:
           key: ccache-${{matrix.os}}-${{matrix.type}}-${{env.BRANCH_NAME}}
           restore-keys: ccache-${{matrix.os}}-${{matrix.type}}-
 
-      - name: Build & Sign on Xcode ${{matrix.xcode}}
+      - name: Build on Xcode ${{matrix.xcode}}
         shell: bash
         id: build
         env:
@@ -297,18 +297,7 @@ jobs:
           MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
           CMAKE_GENERATOR: '${{env.CMAKE_GENERATOR}}'
-        run: |
-          if [[ -n "$MACOS_CERTIFICATE_NAME" ]]
-          then
-            echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
-            security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-            security default-keychain -s build.keychain
-            security set-keychain-settings -t 3600 -l build.keychain
-            security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-            security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
-            security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-          fi
-          .ci/compile.sh --server --test --ccache "$CCACHE_SIZE"
+        run: .ci/compile.sh --server --test --ccache "$CCACHE_SIZE"
 
       - name: Save compiler cache (ccache)
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
## Short roundup of the initial problem
The workflow file to define builds gets a bit messy if many script are directly embedded.
There is already enough config stuff going on.

## What will change with this Pull Request?
- Move script for setting up the signing environment and importing the certificate into the existing script handling compilation in CI
- Gather output in a new group
- Print confirmation, or hint
- Rename build step, the signing does not happen there but in a later step

<br>

Let me know if there is better wording!