### PR TITLE
[PictureLoader] Periodically refresh the local images index

### DIFF
--- a/cockatrice/src/client/ui/picture_loader/picture_loader_local.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_local.h
@@ -5,6 +5,7 @@
 
 #include <QLoggingCategory>
 #include <QObject>
+#include <QTimer>
 
 inline Q_LOGGING_CATEGORY(PictureLoaderLocalLog, "picture_loader.local");
 
@@ -26,8 +27,9 @@ private:
     bool overrideAllCardArtWithPersonalPreference;
 
     QMultiHash<QString, QString> customFolderIndex; // multimap of cardName to picPaths
+    QTimer *refreshTimer;
 
-    void createIndex();
+    void refreshIndex();
 
     QImage
     tryLoadCardImageFromDisk(const QString &setName, const QString &correctedCardName, bool searchCustomPics) const;


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5994

## Short roundup of the initial problem

In #5994 we create a map of file names to paths of the local image folder in order to reduce lookup time for local images. However, we never refresh that index, which means it would require a restart to detect new files.

## What will change with this Pull Request?
- Cockatrice now re-indexes the local image folder every 10 seconds.
  - Re-indexing is cheap enough that it should be reasonable to do every 10 seconds, even if the local image folder has lots of stuff.
