### PR TITLE
[PictureLoader] Remove redundant startNextPicDownload calls; clean up

### DIFF
--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
@@ -16,7 +16,7 @@
 QStringList PictureLoaderWorkerWork::md5Blacklist = QStringList() << "db0c48db407a907c16ade38de048a441";
 
 PictureLoaderWorkerWork::PictureLoaderWorkerWork(const PictureLoaderWorker *worker, const CardInfoPtr &toLoad)
-    : QThread(nullptr), cardToDownload(toLoad)
+    : QThread(nullptr), cardToDownload(toLoad), picDownload(SettingsCache::instance().getPicDownload())
 {
     // Hook up signals to the orchestrator
     connect(this, &PictureLoaderWorkerWork::requestImageDownload, worker, &PictureLoaderWorker::queueRequest,
@@ -70,7 +70,7 @@ void PictureLoaderWorkerWork::picDownloadFailed()
     if (cardToDownload.nextUrl() || cardToDownload.nextSet()) {
         startNextPicDownload();
     } else {
-        qCDebug(PictureLoaderWorkerWorkLog).nospace()
+        qCWarning(PictureLoaderWorkerWorkLog).nospace()
             << "PictureLoader: [card: " << cardToDownload.getCard()->getCorrectedName()
             << " set: " << cardToDownload.getSetName() << "]: Picture NOT found, "
             << (picDownload ? "download failed" : "downloads disabled")

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
@@ -115,8 +115,8 @@ void PictureLoaderWorkerWork::picDownloadFinished(QNetworkReply *reply)
             << "PictureLoader: [card: " << cardToDownload.getCard()->getName()
             << " set: " << cardToDownload.getSetName() << "]: following "
             << (isFromCache ? "cached redirect" : "redirect") << " to " << redirectUrl.toDisplayString();
-        emit requestImageDownload(redirectUrl, this);
         reply->deleteLater();
+        emit requestImageDownload(redirectUrl, this);
         return;
     }
 
@@ -129,8 +129,8 @@ void PictureLoaderWorkerWork::picDownloadFinished(QNetworkReply *reply)
             << " set: " << cardToDownload.getSetName()
             << "]: Picture found, but blacklisted, will consider it as not found";
 
-        picDownloadFailed();
         reply->deleteLater();
+        picDownloadFailed();
         return;
     }
 

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
@@ -75,7 +75,7 @@ void PictureLoaderWorkerWork::picDownloadFailed()
             << " set: " << cardToDownload.getSetName() << "]: Picture NOT found, "
             << (picDownload ? "download failed" : "downloads disabled")
             << ", no more url combinations to try: BAILING OUT";
-        imageLoaded(cardToDownload.getCard(), QImage());
+        emit imageLoaded(cardToDownload.getCard(), QImage());
     }
 }
 
@@ -92,7 +92,7 @@ void PictureLoaderWorkerWork::picDownloadFinished(QNetworkReply *reply)
 
             networkManager->cache()->remove(reply->url());
 
-            requestImageDownload(reply->url(), this);
+            emit requestImageDownload(reply->url(), this);
         } else {
             qCDebug(PictureLoaderWorkerWorkLog).nospace()
                 << "PictureLoader: [card: " << cardToDownload.getCard()->getName()
@@ -115,7 +115,7 @@ void PictureLoaderWorkerWork::picDownloadFinished(QNetworkReply *reply)
             << "PictureLoader: [card: " << cardToDownload.getCard()->getName()
             << " set: " << cardToDownload.getSetName() << "]: following "
             << (isFromCache ? "cached redirect" : "redirect") << " to " << redirectUrl.toDisplayString();
-        requestImageDownload(redirectUrl, this);
+        emit requestImageDownload(redirectUrl, this);
         reply->deleteLater();
         return;
     }
@@ -153,10 +153,10 @@ void PictureLoaderWorkerWork::picDownloadFinished(QNetworkReply *reply)
         movie.start();
         movie.stop();
 
-        imageLoaded(cardToDownload.getCard(), movie.currentImage());
+        emit imageLoaded(cardToDownload.getCard(), movie.currentImage());
         logSuccessMessage = true;
     } else if (imgReader.read(&testImage)) {
-        imageLoaded(cardToDownload.getCard(), testImage);
+        emit imageLoaded(cardToDownload.getCard(), testImage);
         logSuccessMessage = true;
     } else {
         qCDebug(PictureLoaderWorkerWorkLog).nospace()

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
@@ -57,6 +57,10 @@ void PictureLoaderWorkerWork::startNextPicDownload()
     }
 }
 
+/**
+ * Starts another pic download using the next possible url combination for the card.
+ * If all possibilities are exhausted, then concludes the image loading with an empty QImage.
+ */
 void PictureLoaderWorkerWork::picDownloadFailed()
 {
     /* Take advantage of short-circuiting here to call the nextUrl until one
@@ -96,7 +100,6 @@ void PictureLoaderWorkerWork::picDownloadFinished(QNetworkReply *reply)
                 << " failed for url " << reply->url().toDisplayString() << " (" << reply->errorString() << ")";
 
             picDownloadFailed();
-            startNextPicDownload();
         }
 
         reply->deleteLater();
@@ -128,7 +131,6 @@ void PictureLoaderWorkerWork::picDownloadFinished(QNetworkReply *reply)
 
         picDownloadFailed();
         reply->deleteLater();
-        startNextPicDownload();
         return;
     }
 
@@ -170,8 +172,6 @@ void PictureLoaderWorkerWork::picDownloadFinished(QNetworkReply *reply)
             << "PictureLoader: [card: " << cardToDownload.getCard()->getName()
             << " set: " << cardToDownload.getSetName() << "]: Image successfully "
             << (isFromCache ? "loaded from cached" : "downloaded from") << " url " << reply->url().toDisplayString();
-    } else {
-        startNextPicDownload();
     }
 
     reply->deleteLater();

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
@@ -73,7 +73,6 @@ void PictureLoaderWorkerWork::picDownloadFailed()
             << ", no more url combinations to try: BAILING OUT";
         imageLoaded(cardToDownload.getCard(), QImage());
     }
-    emit startLoadQueue();
 }
 
 void PictureLoaderWorkerWork::picDownloadFinished(QNetworkReply *reply)

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.h
@@ -46,7 +46,6 @@ private slots:
     void picDownloadChanged();
 
 signals:
-    void startLoadQueue();
     void imageLoaded(CardInfoPtr card, const QImage &image);
     void requestImageDownload(const QUrl &url, PictureLoaderWorkerWork *instance);
 };

--- a/cockatrice/src/client/ui/picture_loader/picture_to_load.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_to_load.cpp
@@ -84,6 +84,11 @@ void PictureToLoad::populateSetUrls()
     (void)nextUrl();
 }
 
+/**
+ * Advances the currentSet to the next set in the list. Then repopulates the url list with the urls from that set.
+ * If we are already at the end of the list, then currentSet is set to empty.
+ * @return If we are already at the end of the list
+ */
 bool PictureToLoad::nextSet()
 {
     if (!sortedSets.isEmpty()) {
@@ -95,6 +100,11 @@ bool PictureToLoad::nextSet()
     return false;
 }
 
+/**
+ * Advances the currentUrl to the next url in the list.
+ * If we are already at the end of the list, then currentUrl is set to empty.
+ * @return If we are already at the end of the list
+ */
 bool PictureToLoad::nextUrl()
 {
     if (!currentSetUrls.isEmpty()) {


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #5977

## Short roundup of the initial problem

There's places in the code where we call `picDownloadFailed` and then call `startNextPicDownload` immediately afterwards. `picDownloadFailed` already calls `startNextPicDownload`. Those calls are redundant.

Also, there's some stuff that we can clean up or make more explicit.

## What will change with this Pull Request?
- Removed the redundant calls to `startNextPicDownload`
- Added docs to some methods.
- Removed the unused `startLoadQueue` signal
- In places where we call a method and then delete the reply and return, changed it so we delete the reply before calling the method.
- Log image loading failure at warning level
  - We used to log it at warning level before #5977 so I assume it was just a typo
  - Also correctly set `picDownload` in the constructor.
- explicitly `emit` any signals
