### PR TITLE
CI: Own script for signing mac app bundles

### DIFF
--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -128,30 +128,13 @@ function ccachestatsverbose() {
 }
 
 # Compile
-if [[ $RUNNER_OS == macOS ]]; then
-  echo "::group::Signing Certificate"
-  if [[ -n "$MACOS_CERTIFICATE_NAME" ]]; then
-    echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
-    security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-    security default-keychain -s build.keychain
-    security set-keychain-settings -t 3600 -l build.keychain
-    security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-    security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
-    security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-    echo "macOS signing certificate successfully imported and keychain configured."
-  else
-    echo "No signing certificate configured. Skipping set up of keychain in macOS environment."
-  fi
-  echo "::endgroup::"
-fi
-
 if [[ $USE_CCACHE ]]; then
-  echo "::group::Show ccache stats"
+  echo "::group::Show ccache stats (before)"
   ccachestatsverbose
   echo "::endgroup::"
 fi
 
-echo "::group::Configure cmake"
+echo "::group::Configure CMake"
 cmake --version
 cmake .. "${flags[@]}"
 echo "::endgroup::"
@@ -167,7 +150,7 @@ fi
 echo "::endgroup::"
 
 if [[ $USE_CCACHE ]]; then
-  echo "::group::Show ccache stats again"
+  echo "::group::Show ccache stats (after)"
   ccachestatsverbose
   echo "::endgroup::"
 fi

--- a/.ci/sign_macos.sh
+++ b/.ci/sign_macos.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# Used by CI to sign, noratize and staple build artifacts under macOS
+
+set -e
+
+APP_PATH="$1"
+
+if [[ -z "$APP_PATH" ]]; then
+  echo "Error: No input path supplied. Usage: $0 <path-to-app-bundle>"
+  exit 1
+fi
+
+if [[ ! -e "$APP_PATH" ]]; then
+  echo "Error: Input path '$APP_PATH' does not exist."
+  exit 1
+fi
+
+echo "::group::Set up certificate"
+if [[ -n "$MACOS_CERTIFICATE_NAME" ]]; then
+  echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+  security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+  security default-keychain -s build.keychain
+  security set-keychain-settings -t 3600 -l build.keychain
+  security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+  security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+  security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+else
+  echo "No signing certificate configured."
+fi
+echo "::endgroup::"
+
+echo "::group::Sign app"
+if [[ -n "$MACOS_CERTIFICATE_NAME" ]]; then
+  security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+  /usr/bin/codesign --sign="$MACOS_CERTIFICATE_NAME" --entitlements=".ci/macos.entitlements" --options=runtime --force --deep --timestamp --verbose "$APP_PATH"
+else
+  echo "No signing certificate configured."
+fi
+echo "::endgroup::"
+
+echo "::group::Notarize app"
+if [[ -n "$MACOS_NOTARIZATION_APPLE_ID" ]]; then
+  # Store the notarization credentials so that we can prevent a UI password dialog from blocking the CI
+  xcrun notarytool store-credentials "notarytool-profile" --apple-id "$MACOS_NOTARIZATION_APPLE_ID" --team-id "$MACOS_NOTARIZATION_TEAM_ID" --password "$MACOS_NOTARIZATION_PWD"
+  echo ""
+
+  # We can't notarize an app bundle directly, but we need to compress it as an archive.
+  # Therefore, we create a zip file containing our app bundle, so that we can send it to the
+  # notarization service
+  echo "Creating temp notarization archive"
+  ditto -c -k --keepParent "$APP_PATH" "notarization.zip"
+  echo ""
+
+  # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
+  # This typically takes a few seconds inside a CI environment, but it might take more depending on the App
+  # characteristics. Visit the Notarization docs for more information and strategies on how to optimize it if
+  # you're curious
+  xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
+else
+  echo "No Apple ID configured."
+fi
+echo "::endgroup::"
+
+echo "::group::Staple app"
+if [[ -n "$MACOS_NOTARIZATION_APPLE_ID" ]]; then
+  # Finally, we need to "attach the staple" to our executable, which will allow our app to be
+  # validated by macOS even when an internet connection is not available.
+  xcrun stapler staple "$APP_PATH"
+else
+  echo "No Apple ID configured."
+fi
+echo "::endgroup::"
+
+echo "::group::Cleanup"
+# Cleanup keychain and files to avoid leaking credentials
+echo "Deleting keychain"
+security delete-keychain build.keychain
+rm -f certificate.p12 notarization.zip
+echo "::endgroup::"

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -292,10 +292,6 @@ jobs:
           BUILDTYPE: '${{matrix.type}}'
           MAKE_PACKAGE: '${{matrix.make_package}}'
           PACKAGE_SUFFIX: '-macOS${{matrix.target}}_${{matrix.soc}}'
-          MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
-          MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
-          MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
-          MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
           CMAKE_GENERATOR: '${{env.CMAKE_GENERATOR}}'
         run: .ci/compile.sh --server --test --ccache "$CCACHE_SIZE"
 
@@ -308,47 +304,16 @@ jobs:
 
       - name: Sign app bundle
         if: matrix.make_package && (github.ref == 'refs/heads/master' || needs.configure.outputs.tag != null)
+        shell: bash
         env:
           MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
+          MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
-        run: |
-          if [[ -n "$MACOS_CERTIFICATE_NAME" ]]
-          then
-            security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-            /usr/bin/codesign --sign="$MACOS_CERTIFICATE_NAME" --entitlements=".ci/macos.entitlements" --options=runtime --force --deep --timestamp --verbose ${{steps.build.outputs.path}}
-          fi
-
-      - name: Notarize app bundle
-        if: matrix.make_package && (github.ref == 'refs/heads/master' || needs.configure.outputs.tag != null)
-        env:
           MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
           MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
           MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
-        run: |
-          if [[ -n "$MACOS_NOTARIZATION_APPLE_ID" ]]
-          then
-            # Store the notarization credentials so that we can prevent a UI password dialog from blocking the CI
-            echo "Create keychain profile"
-            xcrun notarytool store-credentials "notarytool-profile" --apple-id "$MACOS_NOTARIZATION_APPLE_ID" --team-id "$MACOS_NOTARIZATION_TEAM_ID" --password "$MACOS_NOTARIZATION_PWD"
-  
-            # We can't notarize an app bundle directly, but we need to compress it as an archive.
-            # Therefore, we create a zip file containing our app bundle, so that we can send it to the
-            # notarization service
-            echo "Creating temp notarization archive"
-            ditto -c -k --keepParent ${{steps.build.outputs.path}} "notarization.zip"
-  
-            # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
-            # This typically takes a few seconds inside a CI environment, but it might take more depending on the App
-            # characteristics. Visit the Notarization docs for more information and strategies on how to optimize it if
-            # you're curious
-            echo "Notarize app"
-            xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
-  
-            # Finally, we need to "attach the staple" to our executable, which will allow our app to be
-            # validated by macOS even when an internet connection is not available.
-            echo "Attach staple"
-            xcrun stapler staple ${{steps.build.outputs.path}}
-          fi
+        run: .ci/sign_macos.sh ${{steps.build.outputs.path}}
 
       - name: Upload artifact
         id: upload_artifact


### PR DESCRIPTION
## Related Ticket(s)
- Follow up to https://github.com/Cockatrice/Cockatrice/pull/5996

## Short roundup of the initial problem
Workflow file is busy.
While the first change helped, this is now the complete solution, combining all relevant commands into a separate script and only call it with the needed parameter and right environment variables.

## What will change with this Pull Request?
- Script is mostly the same commands than before
  - Move all signing, notarizing and stapling commands into their own script
  - Move certificate configuration out of build step into the same script
  - Do validate if parameter is given and path exists at beginning
  - Cleanup keychain at the end
- Combine steps into one
- Call script with app path
- Cleaner workflow config, workflow runs and compile script