### PR TITLE
[PictureLoader] Fix worker leak

### DIFF
--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.h
@@ -20,12 +20,12 @@
 inline Q_LOGGING_CATEGORY(PictureLoaderWorkerWorkLog, "picture_loader.worker");
 
 class PictureLoaderWorker;
-class PictureLoaderWorkerWork : public QThread
+
+class PictureLoaderWorkerWork : public QObject
 {
     Q_OBJECT
 public:
     explicit PictureLoaderWorkerWork(const PictureLoaderWorker *worker, const CardInfoPtr &toLoad);
-    ~PictureLoaderWorkerWork() override;
 
     PictureToLoad cardToDownload;
 
@@ -46,6 +46,11 @@ private slots:
     void picDownloadChanged();
 
 signals:
+    /**
+     * Emitted when this worker has successfully loaded the image or has exhausted all attempts at loading the image.
+     * Failures are represented by an empty QImage.
+     * Note that this object will delete itself as this signal is emitted.
+     */
     void imageLoaded(CardInfoPtr card, const QImage &image);
     void requestImageDownload(const QUrl &url, PictureLoaderWorkerWork *instance);
 };


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5977

## Short roundup of the initial problem

Cockatrice was not deleting the `PictureLoaderWorkerWork` objects after they are used. That meant that the image download threads were not being deleted.

## What will change with this Pull Request?
- `PictureLoaderWorkerWork` inherits `QObject` instead of `QThread`
  - We were not following the usage example for inheriting from QThread. Our usage closer resembles a worker QObject moving itself onto a thread
- connected the `imageLoaded` signal to `PictureLoaderWorkerWork`'s `deleteLater`
- use signals to clean up thread once `PictureLoaderWorkerWork` is destroyed
  - We can't clean up the thread inside `PictureLoaderWorkerWork`'s destructor because `PictureLoaderWorkerWork` is still running on that thread so it causes crashes to happen.