### PR TITLE
CI: Add write permissions for `contents`

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,6 +1,7 @@
 name: Build Desktop
 
 permissions:
+  contents: write
   id-token: write
   attestations: write
 


### PR DESCRIPTION
## Short roundup of the initial problem
The workflow has no longer permissions to create or edit GitHub releases and the Configure step [fails on tagged release](https://github.com/Cockatrice/Cockatrice/actions/runs/15811164682/job/44562629476):
```
HTTP 403: Resource not accessible by integration (https://api.github.com/repos/Cockatrice/Cockatrice/releases)
```

Apparently this changed on GitHub side as it was never a problem before.
Or defining other permissions explicitly in #5987, require us now to define all of them.

## What will change with this Pull Request?
- Add `contents: write` permissions to allow to create or modify releases
