### PR TITLE
CI: Fetch logs on notarization error

### DIFF
--- a/.ci/sign_macos.sh
+++ b/.ci/sign_macos.sh
@@ -56,7 +56,22 @@ if [[ -n "$MACOS_NOTARIZATION_APPLE_ID" ]]; then
   # This typically takes a few seconds inside a CI environment, but it might take more depending on the App
   # characteristics. Visit the Notarization docs for more information and strategies on how to optimize it if
   # you're curious
-  xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
+  # Submit for notarization and capture output
+  NOTARY_OUTPUT=$(xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait --output-format json)
+  
+  # Parse the submission ID from the JSON output
+  SUBMISSION_ID=$(echo "$NOTARY_OUTPUT" | jq -r '.id')
+  
+  # Parse the status field in the JSON
+  STATUS=$(echo "$NOTARY_OUTPUT" | jq -r '.status')
+  
+  if [[ "$STATUS" != "Accepted" ]]; then
+    echo "Notarization failed (status: $STATUS). Fetching detailed log..."
+    # Fetch and print the notarization log
+    xcrun notarytool log "$SUBMISSION_ID" --keychain-profile "notarytool-profile"
+  exit 1
+  fi
+
 else
   echo "No Apple ID configured."
 fi


### PR DESCRIPTION
## Short roundup of the initial problem
I do not see an issue with the [sign script](https://github.com/Cockatrice/Cockatrice/blob/master/.ci/sign_macos.sh) or how we're calling it from the [workflow](https://github.com/Cockatrice/Cockatrice/blob/master/.github/workflows/desktop-build.yml#L316).

## What will change with this Pull Request?
- Get the logs on failure

<br>

Unfortunately, we can only test this on master branch and tagging a release again.