### PR TITLE
Automatic Card Database Updates

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -172,6 +172,7 @@ set(cockatrice_SOURCES
     src/dialogs/dlg_roll_dice.cpp
     src/dialogs/dlg_select_set_for_cards.cpp
     src/dialogs/dlg_settings.cpp
+    src/dialogs/dlg_startup_card_check.cpp
     src/dialogs/dlg_tip_of_the_day.cpp
     src/dialogs/dlg_update.cpp
     src/dialogs/dlg_view_log.cpp

--- a/cockatrice/src/client/ui/window_main.cpp
+++ b/cockatrice/src/client/ui/window_main.cpp
@@ -53,6 +53,7 @@
 
 #include <QAction>
 #include <QApplication>
+#include <QButtonGroup>
 #include <QCloseEvent>
 #include <QDateTime>
 #include <QDesktopServices>
@@ -71,7 +72,6 @@
 #include <QWindow>
 #include <QtConcurrent>
 #include <QtNetwork>
-#include <qbuttongroup.h>
 
 #define GITHUB_PAGES_URL "https://cockatrice.github.io"
 #define GITHUB_CONTRIBUTORS_URL "https://github.com/Cockatrice/Cockatrice/graphs/contributors?type=c"

--- a/cockatrice/src/client/ui/window_main.h
+++ b/cockatrice/src/client/ui/window_main.h
@@ -56,6 +56,7 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 public slots:
     void actCheckCardUpdates();
+    void actCheckCardUpdatesBackground();
     void actCheckServerUpdates();
     void actCheckClientUpdates();
 private slots:
@@ -131,6 +132,7 @@ private:
     {
         return "oracle";
     };
+    void createCardUpdateProcess(bool background = false);
     void exitCardDatabaseUpdate();
 
     void startLocalGame(int numberPlayers);
@@ -141,7 +143,8 @@ private:
     QAction *aConnect, *aDisconnect, *aRegister, *aForgotPassword, *aSinglePlayer, *aWatchReplay, *aFullScreen;
     QAction *aManageSets, *aEditTokens, *aOpenCustomFolder, *aOpenCustomsetsFolder, *aAddCustomSet,
         *aReloadCardDatabase;
-    QAction *aTips, *aUpdate, *aCheckCardUpdates, *aStatusBar, *aViewLog, *aOpenSettingsFolder;
+    QAction *aTips, *aUpdate, *aCheckCardUpdates, *aCheckCardUpdatesBackground, *aStatusBar, *aViewLog,
+        *aOpenSettingsFolder;
 
     TabSupervisor *tabSupervisor;
     WndSets *wndSets;

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -353,7 +353,7 @@ void GeneralSettingsPage::retranslateUi()
     tokenDatabasePathLabel.setText(tr("Token database:"));
     updateReleaseChannelLabel.setText(tr("Update channel"));
     startupUpdateCheckCheckBox.setText(tr("Check for client updates on startup"));
-    startupCardUpdateCheckCheckBox.setText(tr("Automatically update card database in the background on startup."));
+    startupCardUpdateCheckCheckBox.setText(tr("Automatically update card database in the background on startup"));
     cardUpdateCheckIntervalLabel.setText(tr("Check for card database updates every"));
     cardUpdateCheckIntervalSpinBox.setSuffix(tr(" days"));
     updateNotificationCheckBox.setText(tr("Notify if a feature supported by the server is missing in my client"));

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -78,6 +78,7 @@ GeneralSettingsPage::GeneralSettingsPage()
     // updates
     SettingsCache &settings = SettingsCache::instance();
     startupUpdateCheckCheckBox.setChecked(settings.getCheckUpdatesOnStartup());
+
     startupCardUpdateCheckBehaviorSelector.addItem(""); // these will be set in retranslateUI
     startupCardUpdateCheckBehaviorSelector.addItem("");
     startupCardUpdateCheckBehaviorSelector.addItem("");
@@ -125,7 +126,8 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(&updateReleaseChannelLabel, 2, 0);
     personalGrid->addWidget(&updateReleaseChannelBox, 2, 1);
     personalGrid->addWidget(&startupUpdateCheckCheckBox, 4, 0, 1, 2);
-    personalGrid->addWidget(&startupCardUpdateCheckBehaviorSelector, 5, 0, 1, 2);
+    personalGrid->addWidget(&startupCardUpdateCheckBehaviorLabel, 5, 0);
+    personalGrid->addWidget(&startupCardUpdateCheckBehaviorSelector, 5, 1);
     personalGrid->addWidget(&cardUpdateCheckIntervalLabel, 6, 0);
     personalGrid->addWidget(&cardUpdateCheckIntervalSpinBox, 6, 1);
     personalGrid->addWidget(&lastCardUpdateCheckDateLabel, 7, 1);
@@ -375,6 +377,7 @@ void GeneralSettingsPage::retranslateUi()
     tokenDatabasePathLabel.setText(tr("Token database:"));
     updateReleaseChannelLabel.setText(tr("Update channel"));
     startupUpdateCheckCheckBox.setText(tr("Check for client updates on startup"));
+    startupCardUpdateCheckBehaviorLabel.setText(tr("Check for card database updates on startup"));
     startupCardUpdateCheckBehaviorSelector.setItemText(startupCardUpdateCheckBehaviorIndexNone, tr("Don't check"));
     startupCardUpdateCheckBehaviorSelector.setItemText(startupCardUpdateCheckBehaviorIndexPrompt,
                                                        tr("Prompt for update"));

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -89,7 +89,7 @@ GeneralSettingsPage::GeneralSettingsPage()
             &SettingsCache::setCheckUpdatesOnStartup);
     connect(&startupCardUpdateCheckCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings,
             &SettingsCache::setCheckCardUpdatesOnStartup);
-    connect(&cardUpdateCheckIntervalSpinBox, &QSpinBox::valueChanged, &settings,
+    connect(&cardUpdateCheckIntervalSpinBox, qOverload<int>(&QSpinBox::valueChanged), &settings,
             &SettingsCache::setCardUpdateCheckInterval);
     connect(&updateNotificationCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings, &SettingsCache::setNotifyAboutUpdate);
     connect(&newVersionOracleCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings,

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -71,6 +71,10 @@ GeneralSettingsPage::GeneralSettingsPage()
     // updates
     SettingsCache &settings = SettingsCache::instance();
     startupUpdateCheckCheckBox.setChecked(settings.getCheckUpdatesOnStartup());
+    startupCardUpdateCheckCheckBox.setChecked(settings.getCheckCardUpdatesOnStartup());
+    cardUpdateCheckIntervalSpinBox.setMinimum(1);
+    cardUpdateCheckIntervalSpinBox.setMaximum(30);
+    cardUpdateCheckIntervalSpinBox.setValue(settings.getCardUpdateCheckInterval());
     updateNotificationCheckBox.setChecked(settings.getNotifyAboutUpdates());
     newVersionOracleCheckBox.setChecked(settings.getNotifyAboutNewVersion());
 
@@ -83,6 +87,10 @@ GeneralSettingsPage::GeneralSettingsPage()
             &GeneralSettingsPage::languageBoxChanged);
     connect(&startupUpdateCheckCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings,
             &SettingsCache::setCheckUpdatesOnStartup);
+    connect(&startupCardUpdateCheckCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings,
+            &SettingsCache::setCheckCardUpdatesOnStartup);
+    connect(&cardUpdateCheckIntervalSpinBox, &QSpinBox::valueChanged, &settings,
+            &SettingsCache::setCardUpdateCheckInterval);
     connect(&updateNotificationCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings, &SettingsCache::setNotifyAboutUpdate);
     connect(&newVersionOracleCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings,
             &SettingsCache::setNotifyAboutNewVersion);
@@ -95,9 +103,13 @@ GeneralSettingsPage::GeneralSettingsPage()
     personalGrid->addWidget(&updateReleaseChannelLabel, 2, 0);
     personalGrid->addWidget(&updateReleaseChannelBox, 2, 1);
     personalGrid->addWidget(&startupUpdateCheckCheckBox, 4, 0, 1, 2);
-    personalGrid->addWidget(&updateNotificationCheckBox, 5, 0, 1, 2);
-    personalGrid->addWidget(&newVersionOracleCheckBox, 6, 0, 1, 2);
-    personalGrid->addWidget(&showTipsOnStartup, 7, 0, 1, 2);
+    personalGrid->addWidget(&startupCardUpdateCheckCheckBox, 5, 0, 1, 2);
+    personalGrid->addWidget(&cardUpdateCheckIntervalLabel, 6, 0);
+    personalGrid->addWidget(&cardUpdateCheckIntervalSpinBox, 6, 1);
+    personalGrid->addWidget(&lastCardUpdateCheckDateLabel, 7, 1);
+    personalGrid->addWidget(&updateNotificationCheckBox, 8, 0, 1, 2);
+    personalGrid->addWidget(&newVersionOracleCheckBox, 9, 0, 1, 2);
+    personalGrid->addWidget(&showTipsOnStartup, 10, 0, 1, 2);
 
     personalGroupBox = new QGroupBox;
     personalGroupBox->setLayout(personalGrid);
@@ -341,12 +353,21 @@ void GeneralSettingsPage::retranslateUi()
     tokenDatabasePathLabel.setText(tr("Token database:"));
     updateReleaseChannelLabel.setText(tr("Update channel"));
     startupUpdateCheckCheckBox.setText(tr("Check for client updates on startup"));
+    startupCardUpdateCheckCheckBox.setText(tr("Automatically update card database in the background on startup."));
+    cardUpdateCheckIntervalLabel.setText(tr("Check for card database updates every"));
+    cardUpdateCheckIntervalSpinBox.setSuffix(tr(" days"));
     updateNotificationCheckBox.setText(tr("Notify if a feature supported by the server is missing in my client"));
     newVersionOracleCheckBox.setText(tr("Automatically run Oracle when running a new version of Cockatrice"));
     showTipsOnStartup.setText(tr("Show tips on startup"));
     resetAllPathsButton->setText(tr("Reset all paths"));
 
     const auto &settings = SettingsCache::instance();
+
+    QDate lastCheckDate = settings.getLastCardUpdateCheck();
+    int daysAgo = lastCheckDate.daysTo(QDate::currentDate());
+
+    lastCardUpdateCheckDateLabel.setText(
+        tr("Last update check on %1 (%2 days ago)").arg(lastCheckDate.toString()).arg(daysAgo));
 
     // We can't change the strings after they're put into the QComboBox, so this is our workaround
     int oldIndex = updateReleaseChannelBox.currentIndex();

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -71,6 +71,10 @@ private:
     QGroupBox *pathsGroupBox;
     QComboBox languageBox;
     QCheckBox startupUpdateCheckCheckBox;
+    QCheckBox startupCardUpdateCheckCheckBox;
+    QLabel cardUpdateCheckIntervalLabel;
+    QSpinBox cardUpdateCheckIntervalSpinBox;
+    QLabel lastCardUpdateCheckDateLabel;
     QCheckBox updateNotificationCheckBox;
     QCheckBox newVersionOracleCheckBox;
     QComboBox updateReleaseChannelBox;

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -71,6 +71,7 @@ private:
     QGroupBox *pathsGroupBox;
     QComboBox languageBox;
     QCheckBox startupUpdateCheckCheckBox;
+    QLabel startupCardUpdateCheckBehaviorLabel;
     QComboBox startupCardUpdateCheckBehaviorSelector;
     QLabel cardUpdateCheckIntervalLabel;
     QSpinBox cardUpdateCheckIntervalSpinBox;

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -71,7 +71,7 @@ private:
     QGroupBox *pathsGroupBox;
     QComboBox languageBox;
     QCheckBox startupUpdateCheckCheckBox;
-    QCheckBox startupCardUpdateCheckCheckBox;
+    QComboBox startupCardUpdateCheckBehaviorSelector;
     QLabel cardUpdateCheckIntervalLabel;
     QSpinBox cardUpdateCheckIntervalSpinBox;
     QLabel lastCardUpdateCheckDateLabel;

--- a/cockatrice/src/dialogs/dlg_startup_card_check.cpp
+++ b/cockatrice/src/dialogs/dlg_startup_card_check.cpp
@@ -1,0 +1,50 @@
+#include "dlg_startup_card_check.h"
+
+#include "../settings/cache_settings.h"
+
+#include <QDate>
+
+DlgStartupCardCheck::DlgStartupCardCheck(QWidget *parent) : QDialog(parent)
+{
+    setWindowTitle(tr("Card Update Check"));
+
+    layout = new QVBoxLayout(this);
+
+    QDate lastCheckDate = SettingsCache::instance().getLastCardUpdateCheck();
+    int daysAgo = lastCheckDate.daysTo(QDate::currentDate());
+
+    instructionLabel = new QLabel(
+        tr("It has been more than %2 days since you last checked your card database for updates.\nChoose how you would "
+           "like to run the card database updater.\nYou can always change this behavior in the 'General' settings tab.")
+            .arg(daysAgo));
+
+    layout->addWidget(instructionLabel);
+
+    group = new QButtonGroup(this);
+
+    foregroundBtn = new QRadioButton(tr("Run in foreground"));
+    backgroundBtn = new QRadioButton(tr("Run in background"));
+    backgroundAlwaysBtn = new QRadioButton(tr("Run in background and always from now on"));
+    dontPromptBtn = new QRadioButton(tr("Don't prompt again and don't run"));
+    dontRunBtn = new QRadioButton(tr("Don't run this time"));
+
+    group->addButton(foregroundBtn, 0);
+    group->addButton(backgroundBtn, 1);
+    group->addButton(backgroundAlwaysBtn, 2);
+    group->addButton(dontPromptBtn, 3);
+    group->addButton(dontRunBtn, 4);
+
+    foregroundBtn->setChecked(true); // default
+
+    layout->addWidget(foregroundBtn);
+    layout->addWidget(backgroundBtn);
+    layout->addWidget(backgroundAlwaysBtn);
+    layout->addWidget(dontPromptBtn);
+    layout->addWidget(dontRunBtn);
+
+    buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    layout->addWidget(buttonBox);
+
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+}

--- a/cockatrice/src/dialogs/dlg_startup_card_check.h
+++ b/cockatrice/src/dialogs/dlg_startup_card_check.h
@@ -1,0 +1,24 @@
+#ifndef DLG_STARTUP_CARD_CHECK_H
+#define DLG_STARTUP_CARD_CHECK_H
+
+#include <QButtonGroup>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QRadioButton>
+#include <QVBoxLayout>
+
+class DlgStartupCardCheck : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit DlgStartupCardCheck(QWidget *parent);
+
+    QVBoxLayout *layout;
+    QLabel *instructionLabel;
+    QButtonGroup *group;
+    QRadioButton *foregroundBtn, *backgroundBtn, *backgroundAlwaysBtn, *dontPromptBtn, *dontRunBtn;
+    QDialogButtonBox *buttonBox;
+};
+
+#endif // DLG_STARTUP_CARD_CHECK_H

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -194,7 +194,9 @@ SettingsCache::SettingsCache()
     mbDownloadSpoilers = settings->value("personal/downloadspoilers", false).toBool();
 
     checkUpdatesOnStartup = settings->value("personal/startupUpdateCheck", true).toBool();
-    checkCardUpdatesOnStartup = settings->value("personal/startupCardUpdateCheck", true).toBool();
+    startupCardUpdateCheckPromptForUpdate =
+        settings->value("personal/startupCardUpdateCheckPromptForUpdate", true).toBool();
+    startupCardUpdateCheckAlwaysUpdate = settings->value("personal/startupCardUpdateCheckAlwaysUpdate", false).toBool();
     cardUpdateCheckInterval = settings->value("personal/cardUpdateCheckInterval", 7).toInt();
     lastCardUpdateCheck = settings->value("personal/lastCardUpdateCheck", QDateTime::currentDateTime().date()).toDate();
     notifyAboutUpdates = settings->value("personal/updatenotification", true).toBool();
@@ -1366,10 +1368,15 @@ void SettingsCache::setCheckUpdatesOnStartup(QT_STATE_CHANGED_T value)
     settings->setValue("personal/startupUpdateCheck", checkUpdatesOnStartup);
 }
 
-void SettingsCache::setCheckCardUpdatesOnStartup(QT_STATE_CHANGED_T value)
+void SettingsCache::setStartupCardUpdateCheckPromptForUpdate(bool value)
 {
-    checkCardUpdatesOnStartup = static_cast<bool>(value);
-    settings->setValue("personal/startupCardUpdateCheck", checkCardUpdatesOnStartup);
+    startupCardUpdateCheckPromptForUpdate = value;
+    settings->setValue("personal/startupCardUpdateCheckPromptForUpdate", startupCardUpdateCheckPromptForUpdate);
+}
+void SettingsCache::setStartupCardUpdateCheckAlwaysUpdate(bool value)
+{
+    startupCardUpdateCheckAlwaysUpdate = value;
+    settings->setValue("personal/startupCardUpdateCheckAlwaysUpdate", startupCardUpdateCheckAlwaysUpdate);
 }
 
 void SettingsCache::setCardUpdateCheckInterval(int value)

--- a/cockatrice/src/settings/cache_settings.cpp
+++ b/cockatrice/src/settings/cache_settings.cpp
@@ -194,6 +194,9 @@ SettingsCache::SettingsCache()
     mbDownloadSpoilers = settings->value("personal/downloadspoilers", false).toBool();
 
     checkUpdatesOnStartup = settings->value("personal/startupUpdateCheck", true).toBool();
+    checkCardUpdatesOnStartup = settings->value("personal/startupCardUpdateCheck", true).toBool();
+    cardUpdateCheckInterval = settings->value("personal/cardUpdateCheckInterval", 7).toInt();
+    lastCardUpdateCheck = settings->value("personal/lastCardUpdateCheck", QDateTime::currentDateTime().date()).toDate();
     notifyAboutUpdates = settings->value("personal/updatenotification", true).toBool();
     notifyAboutNewVersion = settings->value("personal/newversionnotification", true).toBool();
     updateReleaseChannel = settings->value("personal/updatereleasechannel", 0).toInt();
@@ -1361,6 +1364,24 @@ void SettingsCache::setCheckUpdatesOnStartup(QT_STATE_CHANGED_T value)
 {
     checkUpdatesOnStartup = static_cast<bool>(value);
     settings->setValue("personal/startupUpdateCheck", checkUpdatesOnStartup);
+}
+
+void SettingsCache::setCheckCardUpdatesOnStartup(QT_STATE_CHANGED_T value)
+{
+    checkCardUpdatesOnStartup = static_cast<bool>(value);
+    settings->setValue("personal/startupCardUpdateCheck", checkCardUpdatesOnStartup);
+}
+
+void SettingsCache::setCardUpdateCheckInterval(int value)
+{
+    cardUpdateCheckInterval = value;
+    settings->setValue("personal/cardUpdateCheckInterval", cardUpdateCheckInterval);
+}
+
+void SettingsCache::setLastCardUpdateCheck(QDate value)
+{
+    lastCardUpdateCheck = value;
+    settings->setValue("personal/lastCardUpdateCheck", lastCardUpdateCheck);
 }
 
 void SettingsCache::setRememberGameSettings(const bool _rememberGameSettings)

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -199,6 +199,8 @@ private:
     bool tabVisualDeckStorageOpen, tabServerOpen, tabAccountOpen, tabDeckStorageOpen, tabReplaysOpen, tabAdminOpen,
         tabLogOpen;
     bool checkUpdatesOnStartup;
+    bool startupCardUpdateCheckPromptForUpdate;
+    bool startupCardUpdateCheckAlwaysUpdate;
     bool checkCardUpdatesOnStartup;
     int cardUpdateCheckInterval;
     QDate lastCardUpdateCheck;
@@ -442,9 +444,13 @@ public:
     {
         return checkUpdatesOnStartup;
     }
-    bool getCheckCardUpdatesOnStartup() const
+    bool getStartupCardUpdateCheckPromptForUpdate()
     {
-        return checkCardUpdatesOnStartup;
+        return startupCardUpdateCheckPromptForUpdate;
+    }
+    bool getStartupCardUpdateCheckAlwaysUpdate()
+    {
+        return startupCardUpdateCheckAlwaysUpdate;
     }
     int getCardUpdateCheckInterval() const
     {
@@ -1028,7 +1034,8 @@ public slots:
     void setDefaultStartingLifeTotal(const int _defaultStartingLifeTotal);
     void setRememberGameSettings(const bool _rememberGameSettings);
     void setCheckUpdatesOnStartup(QT_STATE_CHANGED_T value);
-    void setCheckCardUpdatesOnStartup(QT_STATE_CHANGED_T value);
+    void setStartupCardUpdateCheckPromptForUpdate(bool value);
+    void setStartupCardUpdateCheckAlwaysUpdate(bool value);
     void setCardUpdateCheckInterval(int value);
     void setLastCardUpdateCheck(QDate value);
     void setNotifyAboutUpdate(QT_STATE_CHANGED_T _notifyaboutupdate);

--- a/cockatrice/src/settings/cache_settings.h
+++ b/cockatrice/src/settings/cache_settings.h
@@ -13,6 +13,7 @@
 #include "servers_settings.h"
 #include "shortcuts_settings.h"
 
+#include <QDate>
 #include <QLoggingCategory>
 #include <QObject>
 #include <QSize>
@@ -198,6 +199,9 @@ private:
     bool tabVisualDeckStorageOpen, tabServerOpen, tabAccountOpen, tabDeckStorageOpen, tabReplaysOpen, tabAdminOpen,
         tabLogOpen;
     bool checkUpdatesOnStartup;
+    bool checkCardUpdatesOnStartup;
+    int cardUpdateCheckInterval;
+    QDate lastCardUpdateCheck;
     bool notifyAboutUpdates;
     bool notifyAboutNewVersion;
     bool showTipsOnStartup;
@@ -437,6 +441,23 @@ public:
     bool getCheckUpdatesOnStartup() const
     {
         return checkUpdatesOnStartup;
+    }
+    bool getCheckCardUpdatesOnStartup() const
+    {
+        return checkCardUpdatesOnStartup;
+    }
+    int getCardUpdateCheckInterval() const
+    {
+        return cardUpdateCheckInterval;
+    }
+    QDate getLastCardUpdateCheck() const
+    {
+        return lastCardUpdateCheck;
+    }
+    bool getCardUpdateCheckRequired() const
+    {
+        return getLastCardUpdateCheck().daysTo(QDateTime::currentDateTime().date()) >= getCardUpdateCheckInterval() &&
+               getLastCardUpdateCheck() != QDateTime::currentDateTime().date();
     }
     bool getNotifyAboutUpdates() const
     {
@@ -1007,6 +1028,9 @@ public slots:
     void setDefaultStartingLifeTotal(const int _defaultStartingLifeTotal);
     void setRememberGameSettings(const bool _rememberGameSettings);
     void setCheckUpdatesOnStartup(QT_STATE_CHANGED_T value);
+    void setCheckCardUpdatesOnStartup(QT_STATE_CHANGED_T value);
+    void setCardUpdateCheckInterval(int value);
+    void setLastCardUpdateCheck(QDate value);
     void setNotifyAboutUpdate(QT_STATE_CHANGED_T _notifyaboutupdate);
     void setNotifyAboutNewVersion(QT_STATE_CHANGED_T _notifyaboutnewversion);
     void setUpdateReleaseChannelIndex(int value);

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -408,7 +408,10 @@ void SettingsCache::setRememberGameSettings(const bool /* _rememberGameSettings 
 void SettingsCache::setCheckUpdatesOnStartup(QT_STATE_CHANGED_T /* value */)
 {
 }
-void SettingsCache::setCheckCardUpdatesOnStartup(QT_STATE_CHANGED_T /* value */)
+void SettingsCache::setStartupCardUpdateCheckPromptForUpdate(bool /* value */)
+{
+}
+void SettingsCache::setStartupCardUpdateCheckAlwaysUpdate(bool /* value */)
 {
 }
 void SettingsCache::setCardUpdateCheckInterval(int /* value */)

--- a/dbconverter/src/mocks.cpp
+++ b/dbconverter/src/mocks.cpp
@@ -408,6 +408,15 @@ void SettingsCache::setRememberGameSettings(const bool /* _rememberGameSettings 
 void SettingsCache::setCheckUpdatesOnStartup(QT_STATE_CHANGED_T /* value */)
 {
 }
+void SettingsCache::setCheckCardUpdatesOnStartup(QT_STATE_CHANGED_T /* value */)
+{
+}
+void SettingsCache::setCardUpdateCheckInterval(int /* value */)
+{
+}
+void SettingsCache::setLastCardUpdateCheck(QDate /* value */)
+{
+}
 void SettingsCache::setNotifyAboutUpdate(QT_STATE_CHANGED_T /* _notifyaboutupdate */)
 {
 }

--- a/oracle/src/main.cpp
+++ b/oracle/src/main.cpp
@@ -8,6 +8,7 @@
 #include <QCommandLineParser>
 #include <QIcon>
 #include <QLibraryInfo>
+#include <QTimer>
 #include <QTranslator>
 
 QTranslator *translator, *qtTranslator;
@@ -16,6 +17,7 @@ ThemeManager *themeManager;
 const QString translationPrefix = "oracle";
 QString translationPath;
 bool isSpoilersOnly;
+bool isBackgrounded;
 
 void installNewTranslator()
 {
@@ -57,10 +59,13 @@ int main(int argc, char *argv[])
 
     // If the program is opened with the -s flag, it will only do spoilers. Otherwise it will do MTGJSON/Tokens
     QCommandLineParser parser;
-    QCommandLineOption showProgressOption("s", QCoreApplication::translate("main", "Only run in spoiler mode"));
-    parser.addOption(showProgressOption);
+    QCommandLineOption spoilersOnlyOption("s", QCoreApplication::translate("main", "Only run in spoiler mode"));
+    QCommandLineOption backgroundOption("b", QCoreApplication::translate("main", "Run in no-confirm background mode"));
+    parser.addOption(spoilersOnlyOption);
+    parser.addOption(backgroundOption);
     parser.process(app);
-    isSpoilersOnly = parser.isSet(showProgressOption);
+    isSpoilersOnly = parser.isSet(spoilersOnlyOption);
+    isBackgrounded = parser.isSet(backgroundOption);
 
 #ifdef Q_OS_MAC
     translationPath = qApp->applicationDirPath() + "/../Resources/translations";
@@ -84,6 +89,10 @@ int main(int argc, char *argv[])
     QGuiApplication::setDesktopFileName("oracle");
 
     wizard.show();
+
+    if (isBackgrounded) {
+        QTimer::singleShot(0, &wizard, [&wizard]() { wizard.runInBackground(); });
+    }
 
     return app.exec();
 }

--- a/oracle/src/oraclewizard.h
+++ b/oracle/src/oraclewizard.h
@@ -3,6 +3,7 @@
 
 #include <QFuture>
 #include <QFutureWatcher>
+#include <QTimer>
 #include <QWizard>
 #include <utility>
 
@@ -56,12 +57,20 @@ public:
     }
     bool saveTokensToFile(const QString &fileName);
 
+    void runInBackground()
+    {
+        backgroundMode = true;
+        hide();
+        currentPage()->initializePage();
+    }
+
 public:
     OracleImporter *importer;
     QSettings *settings;
     QNetworkAccessManager *nam;
     bool downloadedPlainXml = false;
     QByteArray xmlData;
+    bool backgroundMode = false;
 
 private slots:
     void updateLanguage();
@@ -92,6 +101,9 @@ private:
 
 private slots:
     void languageBoxChanged(int index);
+
+protected slots:
+    void initializePage() override;
 };
 
 class OutroPage : public OracleWizardPage
@@ -102,6 +114,8 @@ public:
     {
     }
     void retranslateUi() override;
+protected:
+    void initializePage() override;
 };
 
 class LoadSetsPage : public OracleWizardPage
@@ -167,7 +181,7 @@ class LoadSpoilersPage : public SimpleDownloadFilePage
 {
     Q_OBJECT
 public:
-    explicit LoadSpoilersPage(QWidget * = nullptr){};
+    explicit LoadSpoilersPage(QWidget * = nullptr) {};
     void retranslateUi() override;
 
 protected:
@@ -182,7 +196,7 @@ class LoadTokensPage : public SimpleDownloadFilePage
 {
     Q_OBJECT
 public:
-    explicit LoadTokensPage(QWidget * = nullptr){};
+    explicit LoadTokensPage(QWidget * = nullptr) {};
     void retranslateUi() override;
 
 protected:
@@ -191,6 +205,7 @@ protected:
     QString getDefaultSavePath() override;
     QString getWindowTitle() override;
     QString getFileType() override;
+    void initializePage() override;
 };
 
 #endif

--- a/oracle/src/oraclewizard.h
+++ b/oracle/src/oraclewizard.h
@@ -182,7 +182,7 @@ class LoadSpoilersPage : public SimpleDownloadFilePage
 {
     Q_OBJECT
 public:
-    explicit LoadSpoilersPage(QWidget * = nullptr) {};
+    explicit LoadSpoilersPage(QWidget * = nullptr){};
     void retranslateUi() override;
 
 protected:
@@ -197,7 +197,7 @@ class LoadTokensPage : public SimpleDownloadFilePage
 {
     Q_OBJECT
 public:
-    explicit LoadTokensPage(QWidget * = nullptr) {};
+    explicit LoadTokensPage(QWidget * = nullptr){};
     void retranslateUi() override;
 
 protected:

--- a/oracle/src/oraclewizard.h
+++ b/oracle/src/oraclewizard.h
@@ -114,6 +114,7 @@ public:
     {
     }
     void retranslateUi() override;
+
 protected:
     void initializePage() override;
 };

--- a/oracle/src/pagetemplates.cpp
+++ b/oracle/src/pagetemplates.cpp
@@ -70,7 +70,7 @@ bool SimpleDownloadFilePage::validatePage()
 
     QUrl url = QUrl::fromUserInput(urlLineEdit->text());
     if (!url.isValid()) {
-        QMessageBox::critical(this, tr("Error"), tr("The provided URL is not valid."));
+        QMessageBox::critical(this, tr("Error"), tr("The provided URL is not valid: ") + url.toString());
         return false;
     }
 

--- a/oracle/src/pagetemplates.h
+++ b/oracle/src/pagetemplates.h
@@ -13,7 +13,7 @@ class OracleWizardPage : public QWizardPage
 {
     Q_OBJECT
 public:
-    explicit OracleWizardPage(QWidget *parent = nullptr) : QWizardPage(parent) {};
+    explicit OracleWizardPage(QWidget *parent = nullptr) : QWizardPage(parent){};
     virtual void retranslateUi() = 0;
 
 signals:

--- a/oracle/src/pagetemplates.h
+++ b/oracle/src/pagetemplates.h
@@ -13,8 +13,11 @@ class OracleWizardPage : public QWizardPage
 {
     Q_OBJECT
 public:
-    explicit OracleWizardPage(QWidget *parent = nullptr) : QWizardPage(parent){};
+    explicit OracleWizardPage(QWidget *parent = nullptr) : QWizardPage(parent) {};
     virtual void retranslateUi() = 0;
+
+signals:
+    void readyToContinue();
 
 protected:
     inline OracleWizard *wizard()

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -412,7 +412,10 @@ void SettingsCache::setRememberGameSettings(const bool /* _rememberGameSettings 
 void SettingsCache::setCheckUpdatesOnStartup(QT_STATE_CHANGED_T /* value */)
 {
 }
-void SettingsCache::setCheckCardUpdatesOnStartup(QT_STATE_CHANGED_T /* value */)
+void SettingsCache::setStartupCardUpdateCheckPromptForUpdate(bool /* value */)
+{
+}
+void SettingsCache::setStartupCardUpdateCheckAlwaysUpdate(bool /* value */)
 {
 }
 void SettingsCache::setCardUpdateCheckInterval(int /* value */)

--- a/tests/carddatabase/mocks.cpp
+++ b/tests/carddatabase/mocks.cpp
@@ -412,6 +412,15 @@ void SettingsCache::setRememberGameSettings(const bool /* _rememberGameSettings 
 void SettingsCache::setCheckUpdatesOnStartup(QT_STATE_CHANGED_T /* value */)
 {
 }
+void SettingsCache::setCheckCardUpdatesOnStartup(QT_STATE_CHANGED_T /* value */)
+{
+}
+void SettingsCache::setCardUpdateCheckInterval(int /* value */)
+{
+}
+void SettingsCache::setLastCardUpdateCheck(QDate /* value */)
+{
+}
 void SettingsCache::setNotifyAboutUpdate(QT_STATE_CHANGED_T /* _notifyaboutupdate */)
 {
 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes people coming into the discord and asking "Why is set XYZ not available yet?"

## Short roundup of the initial problem
Users have to manually update the card database for every single new set which is cumbersome for experienced users and not intuitive for newer users.

## What will change with this Pull Request?
- Add the option to background the oracle wizard and have it run through its dialogs in a no-confirm all-default mode.
- Add an option to automatically launch oracle wizard in background every X days since last launch.

## Screenshots

![image](https://github.com/user-attachments/assets/6a5328a7-79c3-4b80-8c97-58267222f418)

![image](https://github.com/user-attachments/assets/14e342c4-7b3b-462d-b215-fad3839c0427)

![image](https://github.com/user-attachments/assets/7358bda4-4097-43a2-b134-d8554dbde6c3)

![image](https://github.com/user-attachments/assets/eef2c01e-ea25-4f9e-aa7d-6e2e57041352)
