### PR TITLE
Log xml parse errors when loading card database

### DIFF
--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -245,8 +245,9 @@ LoadStatus CardDatabase::loadCardDatabase(const QString &path)
     }
 
     int msecs = startTime.msecsTo(QTime::currentTime());
-    qCInfo(CardDatabaseLoadingLog) << "Path =" << path << "Status =" << tempLoadStatus << "Cards =" << cards.size()
-                                   << "Sets =" << sets.size() << QString("%1ms").arg(msecs);
+    qCInfo(CardDatabaseLoadingLog) << "Loaded card database: Path =" << path << "Status =" << tempLoadStatus
+                                   << "Cards =" << cards.size() << "Sets =" << sets.size()
+                                   << QString("%1ms").arg(msecs);
 
     return tempLoadStatus;
 }

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
@@ -64,6 +64,11 @@ void CockatriceXml3Parser::parseFile(QIODevice &device)
             }
         }
     }
+
+    if (xml.hasError()) {
+        QString preamble = tr("Parse error at line %1 col %2:").arg(xml.lineNumber()).arg(xml.columnNumber());
+        qCWarning(CockatriceXml3Log).noquote() << preamble << xml.errorString();
+    }
 }
 
 void CockatriceXml3Parser::loadSetsFromXml(QXmlStreamReader &xml)

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
@@ -66,6 +66,11 @@ void CockatriceXml4Parser::parseFile(QIODevice &device)
             }
         }
     }
+
+    if (xml.hasError()) {
+        QString preamble = tr("Parse error at line %1 col %2:").arg(xml.lineNumber()).arg(xml.columnNumber());
+        qCWarning(CockatriceXml4Log).noquote() << preamble << xml.errorString();
+    }
 }
 
 void CockatriceXml4Parser::loadSetsFromXml(QXmlStreamReader &xml)


### PR DESCRIPTION
## Short roundup of the initial problem

When Cockatrice tries to load a cards.xml that contains invalid xml, Cockatrice will happily load in all cards up the the error, then silently fail, and not load any cards past the error.

This leads to a great deal of confusion as users scramble to figure out why only some of their custom cards loaded in.

## What will change with this Pull Request?

- Log out a warning message when xml parsing fails.
- Also slightly improved the "card database loaded" log message

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

![Screenshot_2025-06-24_at_8 06 06_PM](https://github.com/user-attachments/assets/134e2fff-853d-4310-b192-a18959fcf15e)
