### PR TITLE
Skip cards with empty names when loading xml

### DIFF
--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
@@ -268,6 +268,11 @@ void CockatriceXml3Parser::loadCardsFromXml(QXmlStreamReader &xml)
                 }
             }
 
+            if (name.isEmpty()) {
+                qCWarning(CockatriceXml3Log) << "Encountered card with empty name; skipping";
+                continue;
+            }
+
             properties.insert("colors", colors);
             CardInfoPtr newCard =
                 CardInfo::newInstance(name, text, isToken, properties, relatedCards, reverseRelatedCards, _sets, cipt,

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
@@ -247,6 +247,11 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
                 }
             }
 
+            if (name.isEmpty()) {
+                qCWarning(CockatriceXml4Log) << "Encountered card with empty name; skipping";
+                continue;
+            }
+
             CardInfoPtr newCard =
                 CardInfo::newInstance(name, text, isToken, properties, relatedCards, reverseRelatedCards, _sets, cipt,
                                       landscapeOrientation, tableRow, upsideDown);


### PR DESCRIPTION
## Short roundup of the initial problem

Currently, Cockatrice does not validate that the card name is not empty when loading the card xml; it will happily put a card with an empty name into the card database. Seeing as Cockatrice uses the empty QString as a sentinel value all across the code, this causes Cockatrice to break in weird and wonderful ways.

One of the funnier consequences of this is that having an empty name will somehow cause the empty card to pick up every single reverse-relationship. When trying to view card info, Cockatrice will forcibly be stretched to ridiculous heights, causing it to become unusable.

![Screenshot 2025-06-24 at 8 50 24 PM](https://github.com/user-attachments/assets/8665d2d4-1db4-4408-98f2-068dfa0bdff4)

## What will change with this Pull Request?
- When loading from xml, If a card entry has an empty name, skip putting it into the card database.
