### PR TITLE
Make qtlogging.ini nicer to use

### DIFF
--- a/cockatrice/resources/config/qtlogging.ini
+++ b/cockatrice/resources/config/qtlogging.ini
@@ -2,64 +2,64 @@
 # The default log level is info
 *.debug = false
 
-# Uncomment a rule to disable logging for that category,
-# or set .debug = true for that category to see debug level logs
+# Uncomment a rule to see debug level logs for that category,
+# or set <category> = false to disable logging
 
-# main = false
-# qt_translator = false
-# window_main.* = false
-# release_channel = false
-# spoiler_background_updater = false
-# theme_manager = false
-# sound_engine = false
-# tapped_out_interface = false
+#main = true
+#qt_translator = true
+#window_main.* = true
+#release_channel = true
+#spoiler_background_updater = true
+#theme_manager = true
+#sound_engine = true
+#tapped_out_interface = true
 
-# tab_game = false
-# tab_message = false
-# tab_supervisor = false
+#tab_game = true
+#tab_message = true
+#tab_supervisor = true
 
-# dlg_edit_avatar = false
-# dlg_settings = false
-# dlg_tip_of_the_day = false
-# dlg_update = false
+#dlg_edit_avatar = true
+#dlg_settings = true
+#dlg_tip_of_the_day = true
+#dlg_update = true
 
-# settings_cache = false
-# servers_settings = false
-# shortcuts_settings = false
+#settings_cache = true
+#servers_settings = true
+#shortcuts_settings = true
 
-# local_client = false
-# remote_client = false
+#local_client = true
+#remote_client = true
 
-# player = false
-# game_scene = false
-# game_scene.player_addition_removal = false
-# card_zone = false
-# view_zone = false
+#player = true
+#game_scene = true
+#game_scene.player_addition_removal = true
+#card_zone = true
+#view_zone = true
 
-# user_info_connection = false
+#user_info_connection = true
 
-# picture_loader = false
-# picture_loader.worker = false
-# picture_loader.card_back_cache_fail = false
-# picture_loader.picture_to_load = false
-# deck_loader = false
-# card_database = false
-# card_database.loading = false
-# card_database.loading.success_or_failure = false
-# cockatrice_xml.* = false
-# cockatrice_xml.xml_3_parser = false
-# cockatrice_xml.xml_4_parser = false
-# card_info = false
-# card_list = false
+#picture_loader = true
+#picture_loader.worker = true
+#picture_loader.card_back_cache_fail = true
+#picture_loader.picture_to_load = true
+#deck_loader = true
+#card_database = true
+#card_database.loading = true
+#card_database.loading.success_or_failure = true
+#cockatrice_xml.* = true
+#cockatrice_xml.xml_3_parser = true
+#cockatrice_xml.xml_4_parser = true
+#card_info = true
+#card_list = true
 
-#flow_layout = false
-#flow_widget = false
-#flow_widget.size = false
+#flow_layout = true
+#flow_widget = true
+#flow_widget.size = true
 
-# card_info_picture_widget = false
+#card_info_picture_widget = true
 
-# pixel_map_generator = false
+#pixel_map_generator = true
 
-# deck_filter_string = false
-# filter_string = false
-# syntax_help = false
+#deck_filter_string = true
+#filter_string = true
+#syntax_help = true


### PR DESCRIPTION
## Short roundup of the initial problem

`qtlogging.ini` is annoying to use. 

We set the default debug level to `info` a while back, so nowadays the main reason to change the log configs is to enable debug logs for a class. It would be more convenient if that can be done by just uncommenting instead of uncommenting and also changing the boolean.

## What will change with this Pull Request?
- Changed the commented out category to be `= true`
- Removed the space after the `#` so it's easier to uncomment the line