### PR TITLE
[PictureLoader] Dumb hack to fix segfault

### DIFF
--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
@@ -194,7 +194,10 @@ QImage PictureLoaderWorkerWork::tryLoadImageFromReply(QNetworkReply *reply)
 void PictureLoaderWorkerWork::concludeImageLoad(const QImage &image)
 {
     emit imageLoaded(cardToDownload.getCard(), image);
-    this->deleteLater();
+
+    // Delayed delete is a dumb hack to prevent segfaults due to calling methods on a deleted Work
+    // TODO: find a more proper way to structure this whole thing
+    QTimer::singleShot(2000, this, &QObject::deleteLater);
 }
 
 void PictureLoaderWorkerWork::picDownloadChanged()


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #6001

## Short roundup of the initial problem

Cockatrice was crashing because `PictureLoaderWorker::makeRequest` would sometimes be calling methods on the passed-in `PictureLoaderWorkerWork` object after that object has already been deleted.

`PictureLoaderWorkerWork` self-deletes as it emits `imageLoaded`.

In expected operations, `PictureLoaderWorker::makeRequest` should not be called with a Work once the Work has already finished loading the image, but there's probably some things that we didn't consider.

## What will change with this Pull Request?
- When `PictureLoaderWorkerWork` emits `imageLoaded`, wait 2 seconds before self-deleting

I spent like 2 days trying to figure out how to fix it the "proper way" but couldn't figure it out, so I'm just putting in this dumb hack for now.