### PR TITLE
[PictureLoader] Fix double-queueing bug

### DIFF
--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
@@ -67,8 +67,7 @@ void PictureLoaderWorker::queueRequest(const QUrl &url, PictureLoaderWorkerWork 
     QUrl cachedRedirect = getCachedRedirect(url);
     if (!cachedRedirect.isEmpty()) {
         queueRequest(cachedRedirect, worker);
-    }
-    if (cache->metaData(url).isValid()) {
+    } else if (cache->metaData(url).isValid()) {
         makeRequest(url, worker);
     } else {
         requestLoadQueue.append(qMakePair(url, worker));

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
@@ -194,10 +194,7 @@ QImage PictureLoaderWorkerWork::tryLoadImageFromReply(QNetworkReply *reply)
 void PictureLoaderWorkerWork::concludeImageLoad(const QImage &image)
 {
     emit imageLoaded(cardToDownload.getCard(), image);
-
-    // Delayed delete is a dumb hack to prevent segfaults due to calling methods on a deleted Work
-    // TODO: find a more proper way to structure this whole thing
-    QTimer::singleShot(2000, this, &QObject::deleteLater);
+    deleteLater();
 }
 
 void PictureLoaderWorkerWork::picDownloadChanged()


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5977
- Fixes workaround in #6010

## Short roundup of the initial problem

Due to using an `if` instead of an `else if`, we were double-queueing any image load requests that were in the redirect cache.

The double-queued requests would be put consecutively into the request queue. If all requests had redirects, then that basically halved the image loading speed.

Additionally, the `PictureLoaderWorkerWork` pointer would be put multiple times in the queue. `PictureLoaderWorkerWork` deletes itself after the load finishes. The pointer being in multiple places made it possible for a Work to be called from a different place after it has already self-deleted, leading to the segfault.

## What will change with this Pull Request?

- Fix the bug
- Remove workaround for segfault