### PR TITLE
Fix segfault when filtering card view that have blank cards

### DIFF
--- a/cockatrice/src/game/filters/filter_string.h
+++ b/cockatrice/src/game/filters/filter_string.h
@@ -31,6 +31,10 @@ public:
     explicit FilterString(const QString &exp);
     bool check(const CardData &card) const
     {
+        if (card.isNull()) {
+            static CardInfoPtr blankCard = CardInfo::newInstance("");
+            return result(blankCard);
+        }
         return result(card);
     }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5791

## Short roundup of the initial problem

When viewing the library, if there are any face-down cards (due to dragging a card from the view into itself), entering anything in the searchbar will cause a segfault

https://github.com/user-attachments/assets/c4b05d33-a789-432f-a20c-be1a95110dde

The cause is because the face-down cards have a null `CardInfoPtr`. 
Turns out `FilterString::check(const CardInfoPtr &card)` is not null-safe because it direct calls methods on the passed in cardInfoPtr

## What will change with this Pull Request?

- Added a null check in FilterString
  - If the CardInfoPtr is null, it will use a empty CardInfoPtr to put in the comparator

https://github.com/user-attachments/assets/040157e0-7115-421e-839c-3301181e9da1
