### PR TITLE
[PictureLoader] Reduce downtime between load attempts

### DIFF
--- a/cockatrice/src/client/ui/picture_loader/picture_loader_request_status_display_widget.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_request_status_display_widget.cpp
@@ -2,23 +2,22 @@
 
 PictureLoaderRequestStatusDisplayWidget::PictureLoaderRequestStatusDisplayWidget(QWidget *parent,
                                                                                  const QUrl &_url,
-                                                                                 PictureLoaderWorkerWork *worker)
+                                                                                 const CardInfoPtr &card,
+                                                                                 const QString &setName)
     : QWidget(parent)
 {
     layout = new QHBoxLayout(this);
 
-    if (worker->cardToDownload.getCard()) {
-        name = new QLabel(this);
-        name->setText(worker->cardToDownload.getCard()->getName());
-        setShortname = new QLabel(this);
-        setShortname->setText(worker->cardToDownload.getSetName());
-        providerId = new QLabel(this);
-        providerId->setText(worker->cardToDownload.getCard()->getProperty("uuid"));
+    name = new QLabel(this);
+    name->setText(card->getName());
+    setShortname = new QLabel(this);
+    setShortname->setText(setName);
+    providerId = new QLabel(this);
+    providerId->setText(card->getProperty("uuid"));
 
-        layout->addWidget(name);
-        layout->addWidget(setShortname);
-        layout->addWidget(providerId);
-    }
+    layout->addWidget(name);
+    layout->addWidget(setShortname);
+    layout->addWidget(providerId);
 
     startTime = new QLabel(QDateTime::currentDateTime().toString(), this);
     elapsedTime = new QLabel("0", this);

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_request_status_display_widget.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_request_status_display_widget.h
@@ -10,8 +10,10 @@ class PictureLoaderRequestStatusDisplayWidget : public QWidget
 {
     Q_OBJECT
 public:
-    PictureLoaderRequestStatusDisplayWidget(QWidget *parent, const QUrl &url, PictureLoaderWorkerWork *worker);
-    PictureLoaderWorkerWork *worker;
+    PictureLoaderRequestStatusDisplayWidget(QWidget *parent,
+                                            const QUrl &url,
+                                            const CardInfoPtr &card,
+                                            const QString &setName);
 
     void setFinished()
     {

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_status_bar.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_status_bar.cpp
@@ -38,15 +38,14 @@ void PictureLoaderStatusBar::cleanOldEntries()
     }
 }
 
-void PictureLoaderStatusBar::addQueuedImageLoad(const QUrl &url, PictureLoaderWorkerWork *worker)
+void PictureLoaderStatusBar::addQueuedImageLoad(const QUrl &url, const CardInfoPtr &card, const QString &setName)
 {
-    loadLog->addSettingsWidget(new PictureLoaderRequestStatusDisplayWidget(loadLog, url, worker));
+    loadLog->addSettingsWidget(new PictureLoaderRequestStatusDisplayWidget(loadLog, url, card, setName));
     progressBar->setMaximum(progressBar->maximum() + 1);
 }
 
-void PictureLoaderStatusBar::addSuccessfulImageLoad(const QUrl &url, PictureLoaderWorkerWork *worker)
+void PictureLoaderStatusBar::addSuccessfulImageLoad(const QUrl &url)
 {
-    Q_UNUSED(worker)
     progressBar->setValue(progressBar->value() + 1);
     for (PictureLoaderRequestStatusDisplayWidget *statusDisplayWidget :
          loadLog->popup->findChildren<PictureLoaderRequestStatusDisplayWidget *>()) {

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_status_bar.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_status_bar.h
@@ -15,8 +15,8 @@ public:
     explicit PictureLoaderStatusBar(QWidget *parent);
 
 public slots:
-    void addQueuedImageLoad(const QUrl &url, PictureLoaderWorkerWork *worker);
-    void addSuccessfulImageLoad(const QUrl &url, PictureLoaderWorkerWork *worker);
+    void addQueuedImageLoad(const QUrl &url, const CardInfoPtr &card, const QString &setName);
+    void addSuccessfulImageLoad(const QUrl &url);
     void cleanOldEntries();
 
 private:

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
@@ -106,7 +106,7 @@ void PictureLoaderWorker::resetRequestQuota()
 }
 
 /**
- * Keeps processing requests from the queue until the quota runs out or the request queue runs out.
+ * Keeps processing requests from the queue until it is empty or until the quota runs out.
  */
 void PictureLoaderWorker::processQueuedRequests()
 {

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
@@ -148,7 +148,7 @@ void PictureLoaderWorker::handleImageLoadEnqueued(const CardInfoPtr &card)
     // try to load image from local first
     QImage image = localLoader->tryLoad(card);
     if (!image.isNull()) {
-        imageLoadedSuccessfully(card, image);
+        handleImageLoaded(card, image);
     } else {
         // queue up to load image from remote only after local loading failed
         new PictureLoaderWorkerWork(this, card);
@@ -156,10 +156,9 @@ void PictureLoaderWorker::handleImageLoadEnqueued(const CardInfoPtr &card)
 }
 
 /**
- * Called when image loading is done
- * Contrary to the name, this is called on both success and failure. Failures are indicated by an empty QImage.
+ * Called when image loading is done. Failures are indicated by an empty QImage.
  */
-void PictureLoaderWorker::imageLoadedSuccessfully(const CardInfoPtr &card, const QImage &image)
+void PictureLoaderWorker::handleImageLoaded(const CardInfoPtr &card, const QImage &image)
 {
     currentlyLoading.remove(card);
     emit imageLoaded(card, image);

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
@@ -72,7 +72,7 @@ void PictureLoaderWorker::queueRequest(const QUrl &url, PictureLoaderWorkerWork 
         makeRequest(url, worker);
     } else {
         requestLoadQueue.append(qMakePair(url, worker));
-        emit imageLoadQueued(url, worker);
+        emit imageLoadQueued(url, worker->cardToDownload.getCard(), worker->cardToDownload.getSetName());
         processQueuedRequests();
     }
 }
@@ -82,7 +82,7 @@ QNetworkReply *PictureLoaderWorker::makeRequest(const QUrl &url, PictureLoaderWo
     // Check for cached redirects
     QUrl cachedRedirect = getCachedRedirect(url);
     if (!cachedRedirect.isEmpty()) {
-        emit imageLoadSuccessful(url, worker);
+        emit imageLoadSuccessful(url);
         return makeRequest(cachedRedirect, worker);
     }
 

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.h
@@ -71,8 +71,8 @@ private slots:
 signals:
     void imageLoadEnqueued(const CardInfoPtr &card);
     void imageLoaded(CardInfoPtr card, const QImage &image);
-    void imageLoadQueued(const QUrl &url, PictureLoaderWorkerWork *worker);
-    void imageLoadSuccessful(const QUrl &url, PictureLoaderWorkerWork *worker);
+    void imageLoadQueued(const QUrl &url, const CardInfoPtr &card, const QString &setName);
+    void imageLoadSuccessful(const QUrl &url);
 };
 
 #endif // PICTURE_LOADER_WORKER_H

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.h
@@ -38,7 +38,7 @@ public:
 public slots:
     QNetworkReply *makeRequest(const QUrl &url, PictureLoaderWorkerWork *workThread);
     void processQueuedRequests();
-    void processSingleRequest();
+    bool processSingleRequest();
     void imageLoadedSuccessfully(const CardInfoPtr &card, const QImage &image);
     void cacheRedirect(const QUrl &originalUrl, const QUrl &redirectUrl);
     void removedCachedUrl(const QUrl &url);
@@ -52,7 +52,9 @@ private:
     static constexpr int CacheTTLInDays = 30;          // TODO: Make user configurable
     bool picDownload;
     QQueue<QPair<QUrl, PictureLoaderWorkerWork *>> requestLoadQueue;
-    QTimer requestTimer; // Timer for processing delayed requests
+
+    int requestCounter;
+    QTimer requestTimer; // Timer for refreshing request counter
 
     PictureLoaderLocal *localLoader;
     QSet<CardInfoPtr> currentlyLoading; // for deduplication purposes
@@ -63,6 +65,7 @@ private:
     void cleanStaleEntries();
 
 private slots:
+    void resetRequestCounter();
     void handleImageLoadEnqueued(const CardInfoPtr &card);
 
 signals:

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.h
@@ -39,7 +39,7 @@ public slots:
     QNetworkReply *makeRequest(const QUrl &url, PictureLoaderWorkerWork *workThread);
     void processQueuedRequests();
     bool processSingleRequest();
-    void imageLoadedSuccessfully(const CardInfoPtr &card, const QImage &image);
+    void handleImageLoaded(const CardInfoPtr &card, const QImage &image);
     void cacheRedirect(const QUrl &originalUrl, const QUrl &redirectUrl);
     void removedCachedUrl(const QUrl &url);
 

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.h
@@ -53,8 +53,8 @@ private:
     bool picDownload;
     QQueue<QPair<QUrl, PictureLoaderWorkerWork *>> requestLoadQueue;
 
-    int requestCounter;
-    QTimer requestTimer; // Timer for refreshing request counter
+    int requestQuota;
+    QTimer requestTimer; // Timer for refreshing request quota
 
     PictureLoaderLocal *localLoader;
     QSet<CardInfoPtr> currentlyLoading; // for deduplication purposes
@@ -65,7 +65,7 @@ private:
     void cleanStaleEntries();
 
 private slots:
-    void resetRequestCounter();
+    void resetRequestQuota();
     void handleImageLoadEnqueued(const CardInfoPtr &card);
 
 signals:

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
@@ -22,7 +22,7 @@ PictureLoaderWorkerWork::PictureLoaderWorkerWork(const PictureLoaderWorker *work
     connect(this, &PictureLoaderWorkerWork::requestImageDownload, worker, &PictureLoaderWorker::queueRequest);
     connect(this, &PictureLoaderWorkerWork::urlRedirected, worker, &PictureLoaderWorker::cacheRedirect);
     connect(this, &PictureLoaderWorkerWork::cachedUrlInvalidated, worker, &PictureLoaderWorker::removedCachedUrl);
-    connect(this, &PictureLoaderWorkerWork::imageLoaded, worker, &PictureLoaderWorker::imageLoadedSuccessfully);
+    connect(this, &PictureLoaderWorkerWork::imageLoaded, worker, &PictureLoaderWorker::handleImageLoaded);
 
     // Hook up signals to settings
     connect(&SettingsCache::instance(), SIGNAL(picDownloadChanged()), this, SLOT(picDownloadChanged()));


### PR DESCRIPTION
## Related Ticket(s)
- Fixes issue that was present since #5977

## Short roundup of the initial problem

Currently, we rate-limit our queued requests by using a timer that fires every second, and every time the timer fires, we process 10 requests from the queue.
However, that means that if a request gets enqueued while between the timer firing, even if not all 10 requests of the second were made, that request still has to wait for the timer to fire before it can be processed.

This is very apparent if the correct url is not the first url in the download url list. You have to wait an entire second between each attempt.

It takes at least one second to load a single image, with nothing else in the queue, if that image's correct url is not at the top of the list.

## What will change with this Pull Request?

Switched over to a different system for rate-limiting the queried requests
- `PictureLoaderWorker` now has a `requestQuota` field that represents the number of remaining requests it can make
- The `requestQuota` is reset to 10 every second.
- When `processQueuedRequests` is called, it will attempt to process requests from the queue until it is empty or until the quota runs out.
  - Each successful requests uses up one quota
- `processQueuedRequests` now gets called whenever a request is queued (in addition to when the timer fires)

Also fixed a segfault that was uncovered after switching to the new system
- Pass just the relevant data through the signals to the status bar, instead of the entire Work object
  - We were segfaulting because the status bar try to access the Work object after it already self-deleted. By passing just the data, we detach the data from the Work object and avoid all that.
