### PR TITLE
Allow more naming schemes for custom pictures

### DIFF
--- a/cockatrice/src/client/ui/picture_loader/picture_loader_local.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_local.h
@@ -31,8 +31,10 @@ private:
 
     void refreshIndex();
 
-    QImage
-    tryLoadCardImageFromDisk(const QString &setName, const QString &correctedCardName, bool searchCustomPics) const;
+    QImage tryLoadCardImageFromDisk(const QString &setName,
+                                    const QString &correctedCardName,
+                                    const QString &collectorNumber,
+                                    const QString &providerId) const;
 
 private slots:
     void picsPathChanged();


### PR DESCRIPTION
Order is cardName_providerId, cardName_setName_collectorNumber, setName-collectorNumber-cardName and then just generically cardName, if the user has decided to override every printing. Most-to-least specific.

## Related Ticket(s)
- Closes #5763
- Probably closes #5682

## Short roundup of the initial problem
In order to play nice with the providerId change, we decided that only the preferred providerId would check for custom pictures. This is a bit jank however. 

## What will change with this Pull Request?
- If a user simply places a <cardName> file into the CUSTOM folder, it'll override everything, as before.
- If a user places a more granular naming scheme (cardName_providerId, cardName_setName_collectorNumber, setName-collectorNumber-cardName), we will attempt to load them in that order. [We could also include a cardName_setName option to just generically override a whole set where a card might have many printings {special sets come to mind}]

## Screenshots
![image](https://github.com/user-attachments/assets/b1e84254-7530-4442-ac22-47f17bd0e527)
![image](https://github.com/user-attachments/assets/30021e5a-922a-45b7-8064-4a8cf6a1be68)

![image](https://github.com/user-attachments/assets/e1f746c7-fb41-4572-bf89-856a5e1be51a)
