### PR TITLE
[PictureLoader] Fix status bar not updating

### DIFF
--- a/cockatrice/src/client/ui/picture_loader/picture_loader.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader.cpp
@@ -36,8 +36,9 @@ PictureLoader::PictureLoader() : QObject(nullptr)
         mainWindow->statusBar()->addPermanentWidget(statusBar);
     }
 
-    connect(worker, &PictureLoaderWorker::imageLoadQueued, statusBar, &PictureLoaderStatusBar::addQueuedImageLoad);
-    connect(worker, &PictureLoaderWorker::requestSucceeded, statusBar, &PictureLoaderStatusBar::addSuccessfulImageLoad);
+    connect(worker, &PictureLoaderWorker::imageRequestQueued, statusBar, &PictureLoaderStatusBar::addQueuedImageLoad);
+    connect(worker, &PictureLoaderWorker::imageRequestSucceeded, statusBar,
+            &PictureLoaderStatusBar::addSuccessfulImageLoad);
 }
 
 PictureLoader::~PictureLoader()

--- a/cockatrice/src/client/ui/picture_loader/picture_loader.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader.cpp
@@ -37,8 +37,7 @@ PictureLoader::PictureLoader() : QObject(nullptr)
     }
 
     connect(worker, &PictureLoaderWorker::imageLoadQueued, statusBar, &PictureLoaderStatusBar::addQueuedImageLoad);
-    connect(worker, &PictureLoaderWorker::imageLoadSuccessful, statusBar,
-            &PictureLoaderStatusBar::addSuccessfulImageLoad);
+    connect(worker, &PictureLoaderWorker::requestSucceeded, statusBar, &PictureLoaderStatusBar::addSuccessfulImageLoad);
 }
 
 PictureLoader::~PictureLoader()

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
@@ -72,7 +72,7 @@ void PictureLoaderWorker::queueRequest(const QUrl &url, PictureLoaderWorkerWork 
         makeRequest(url, worker);
     } else {
         requestLoadQueue.append(qMakePair(url, worker));
-        emit imageLoadQueued(url, worker->cardToDownload.getCard(), worker->cardToDownload.getSetName());
+        emit imageRequestQueued(url, worker->cardToDownload.getCard(), worker->cardToDownload.getSetName());
         processQueuedRequests();
     }
 }
@@ -82,7 +82,7 @@ QNetworkReply *PictureLoaderWorker::makeRequest(const QUrl &url, PictureLoaderWo
     // Check for cached redirects
     QUrl cachedRedirect = getCachedRedirect(url);
     if (!cachedRedirect.isEmpty()) {
-        emit requestSucceeded(url);
+        emit imageRequestSucceeded(url);
         return makeRequest(cachedRedirect, worker);
     }
 

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
@@ -82,7 +82,7 @@ QNetworkReply *PictureLoaderWorker::makeRequest(const QUrl &url, PictureLoaderWo
     // Check for cached redirects
     QUrl cachedRedirect = getCachedRedirect(url);
     if (!cachedRedirect.isEmpty()) {
-        emit imageLoadSuccessful(url);
+        emit requestSucceeded(url);
         return makeRequest(cachedRedirect, worker);
     }
 

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.h
@@ -71,8 +71,8 @@ private slots:
 signals:
     void imageLoadEnqueued(const CardInfoPtr &card);
     void imageLoaded(CardInfoPtr card, const QImage &image);
-    void imageLoadQueued(const QUrl &url, const CardInfoPtr &card, const QString &setName);
-    void requestSucceeded(const QUrl &url);
+    void imageRequestQueued(const QUrl &url, const CardInfoPtr &card, const QString &setName);
+    void imageRequestSucceeded(const QUrl &url);
 };
 
 #endif // PICTURE_LOADER_WORKER_H

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.h
@@ -72,7 +72,7 @@ signals:
     void imageLoadEnqueued(const CardInfoPtr &card);
     void imageLoaded(CardInfoPtr card, const QImage &image);
     void imageLoadQueued(const QUrl &url, const CardInfoPtr &card, const QString &setName);
-    void imageLoadSuccessful(const QUrl &url);
+    void requestSucceeded(const QUrl &url);
 };
 
 #endif // PICTURE_LOADER_WORKER_H

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
@@ -23,7 +23,7 @@ PictureLoaderWorkerWork::PictureLoaderWorkerWork(const PictureLoaderWorker *work
     connect(this, &PictureLoaderWorkerWork::urlRedirected, worker, &PictureLoaderWorker::cacheRedirect);
     connect(this, &PictureLoaderWorkerWork::cachedUrlInvalidated, worker, &PictureLoaderWorker::removedCachedUrl);
     connect(this, &PictureLoaderWorkerWork::imageLoaded, worker, &PictureLoaderWorker::handleImageLoaded);
-    connect(this, &PictureLoaderWorkerWork::requestSucceeded, worker, &PictureLoaderWorker::requestSucceeded);
+    connect(this, &PictureLoaderWorkerWork::requestSucceeded, worker, &PictureLoaderWorker::imageRequestSucceeded);
 
     // Hook up signals to settings
     connect(&SettingsCache::instance(), SIGNAL(picDownloadChanged()), this, SLOT(picDownloadChanged()));

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
@@ -23,6 +23,7 @@ PictureLoaderWorkerWork::PictureLoaderWorkerWork(const PictureLoaderWorker *work
     connect(this, &PictureLoaderWorkerWork::urlRedirected, worker, &PictureLoaderWorker::cacheRedirect);
     connect(this, &PictureLoaderWorkerWork::cachedUrlInvalidated, worker, &PictureLoaderWorker::removedCachedUrl);
     connect(this, &PictureLoaderWorkerWork::imageLoaded, worker, &PictureLoaderWorker::handleImageLoaded);
+    connect(this, &PictureLoaderWorkerWork::requestSucceeded, worker, &PictureLoaderWorker::requestSucceeded);
 
     // Hook up signals to settings
     connect(&SettingsCache::instance(), SIGNAL(picDownloadChanged()), this, SLOT(picDownloadChanged()));
@@ -97,6 +98,7 @@ void PictureLoaderWorkerWork::handleNetworkReply(QNetworkReply *reply)
         handleFailedReply(reply);
     } else {
         handleSuccessfulReply(reply);
+        emit requestSucceeded(reply->url());
     }
 
     reply->deleteLater();

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.h
@@ -53,6 +53,11 @@ signals:
      * Note that this object will delete itself as this signal is emitted.
      */
     void imageLoaded(CardInfoPtr card, const QImage &image);
+
+    /**
+     * Emitted when a request did not return a 400 or 500 response
+     */
+    void requestSucceeded(const QUrl &url);
     void requestImageDownload(const QUrl &url, PictureLoaderWorkerWork *instance);
 
     void urlRedirected(const QUrl &originalUrl, const QUrl &redirectUrl);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #6016

## Short roundup of the initial problem

In #6016 we moved all the reply processing code into `PictureLoaderWorkerWork`. However, we forgot to preserve the behavior on [this line](https://github.com/Cockatrice/Cockatrice/commit/388db4e99563fe466048b9688870bab0ecd0b52f#diff-0a56bd9f513f8a7be4ad193618093bd1ed363ef399cb75d8cfa5a394d72ddec0L107) where we emit a `imageLoadSuccessful` on a successful reply.

## What will change with this Pull Request?
- Added `requestSucceeded` signal to Work object that gets emitted when a reply succeeds
  - Connected that signal to the old `imageLoadSuccessful` signal in the `PictureLoaderWorker`
- Renamed some signals
  - `imageLoadQueued` -> `imageRequestQueued`
  - `imageLoadSuccessful` -> `imageRequestSucceeded`
