### PR TITLE
Refactor: rename CardInfoPerSet to PrintingInfo

### DIFF
--- a/cockatrice/src/client/ui/picture_loader/picture_to_load.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_to_load.cpp
@@ -28,9 +28,9 @@ PictureToLoad::PictureToLoad(CardInfoPtr _card)
 QList<CardSetPtr> PictureToLoad::extractSetsSorted(const CardInfoPtr &card)
 {
     QList<CardSetPtr> sortedSets;
-    for (const auto &cardInfoPerSetList : card->getSets()) {
-        for (const auto &set : cardInfoPerSetList) {
-            sortedSets << set.getSet();
+    for (const auto &printings : card->getSets()) {
+        for (const auto &printing : printings) {
+            sortedSets << printing.getSet();
         }
     }
     if (sortedSets.empty()) {
@@ -41,11 +41,11 @@ QList<CardSetPtr> PictureToLoad::extractSetsSorted(const CardInfoPtr &card)
     // If the user hasn't disabled arts other than their personal preference...
     if (!SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference()) {
         // If the pixmapCacheKey corresponds to a specific set, we have to try to load it first.
-        for (const auto &cardInfoPerSetList : card->getSets()) {
-            for (const auto &set : cardInfoPerSetList) {
-                if (QLatin1String("card_") + card->getName() + QString("_") + QString(set.getProperty("uuid")) ==
+        for (const auto &printings : card->getSets()) {
+            for (const auto &printing : printings) {
+                if (QLatin1String("card_") + card->getName() + QString("_") + QString(printing.getProperty("uuid")) ==
                     card->getPixmapCacheKey()) {
-                    long long setIndex = sortedSets.indexOf(set.getSet());
+                    long long setIndex = sortedSets.indexOf(printing.getSet());
                     CardSetPtr setForCardProviderID = sortedSets.takeAt(setIndex);
                     sortedSets.prepend(setForCardProviderID);
                 }

--- a/cockatrice/src/client/ui/picture_loader/picture_to_load.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_to_load.cpp
@@ -30,7 +30,7 @@ QList<CardSetPtr> PictureToLoad::extractSetsSorted(const CardInfoPtr &card)
     QList<CardSetPtr> sortedSets;
     for (const auto &cardInfoPerSetList : card->getSets()) {
         for (const auto &set : cardInfoPerSetList) {
-            sortedSets << set.getPtr();
+            sortedSets << set.getSet();
         }
     }
     if (sortedSets.empty()) {
@@ -45,7 +45,7 @@ QList<CardSetPtr> PictureToLoad::extractSetsSorted(const CardInfoPtr &card)
             for (const auto &set : cardInfoPerSetList) {
                 if (QLatin1String("card_") + card->getName() + QString("_") + QString(set.getProperty("uuid")) ==
                     card->getPixmapCacheKey()) {
-                    long long setIndex = sortedSets.indexOf(set.getPtr());
+                    long long setIndex = sortedSets.indexOf(set.getSet());
                     CardSetPtr setForCardProviderID = sortedSets.takeAt(setIndex);
                     sortedSets.prepend(setForCardProviderID);
                 }

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -477,7 +477,7 @@ bool DeckEditorDeckDockWidget::swapCard(const QModelIndex &currentIndex)
 
     // Third argument (true) says create the card no matter what, even if not in DB
     QModelIndex newCardIndex = deckModel->addCard(
-        cardName, CardDatabaseManager::getInstance()->getSpecificSetForCard(cardName, cardProviderID), otherZoneName,
+        cardName, CardDatabaseManager::getInstance()->getSpecificPrinting(cardName, cardProviderID), otherZoneName,
         true);
     recursiveExpand(newCardIndex);
 

--- a/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.cpp
@@ -24,7 +24,7 @@ AllZonesCardAmountWidget::AllZonesCardAmountWidget(QWidget *parent,
                                                    QTreeView *deckView,
                                                    QSlider *cardSizeSlider,
                                                    CardInfoPtr rootCard,
-                                                   CardInfoPerSet setInfoForCard)
+                                                   PrintingInfo setInfoForCard)
     : QWidget(parent), deckEditor(deckEditor), deckModel(deckModel), deckView(deckView), cardSizeSlider(cardSizeSlider),
       rootCard(rootCard), setInfoForCard(setInfoForCard)
 {

--- a/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.cpp
@@ -16,7 +16,7 @@
  * @param deckView Pointer to the QTreeView for the deck display.
  * @param cardSizeSlider Pointer to the QSlider used for dynamic font resizing.
  * @param rootCard The root card for the widget.
- * @param setInfoForCard The set information for the card.
+ * @param printingInfo The printing information for the card.
  */
 AllZonesCardAmountWidget::AllZonesCardAmountWidget(QWidget *parent,
                                                    AbstractTabDeckEditor *deckEditor,
@@ -24,9 +24,9 @@ AllZonesCardAmountWidget::AllZonesCardAmountWidget(QWidget *parent,
                                                    QTreeView *deckView,
                                                    QSlider *cardSizeSlider,
                                                    CardInfoPtr rootCard,
-                                                   PrintingInfo setInfoForCard)
+                                                   PrintingInfo printingInfo)
     : QWidget(parent), deckEditor(deckEditor), deckModel(deckModel), deckView(deckView), cardSizeSlider(cardSizeSlider),
-      rootCard(rootCard), setInfoForCard(setInfoForCard)
+      rootCard(rootCard), printingInfo(printingInfo)
 {
     layout = new QVBoxLayout(this);
     layout->setAlignment(Qt::AlignHCenter);
@@ -36,10 +36,10 @@ AllZonesCardAmountWidget::AllZonesCardAmountWidget(QWidget *parent,
 
     zoneLabelMainboard = new ShadowBackgroundLabel(this, tr("Mainboard"));
     buttonBoxMainboard = new CardAmountWidget(this, deckEditor, deckModel, deckView, cardSizeSlider, rootCard,
-                                              setInfoForCard, DECK_ZONE_MAIN);
+                                              printingInfo, DECK_ZONE_MAIN);
     zoneLabelSideboard = new ShadowBackgroundLabel(this, tr("Sideboard"));
     buttonBoxSideboard = new CardAmountWidget(this, deckEditor, deckModel, deckView, cardSizeSlider, rootCard,
-                                              setInfoForCard, DECK_ZONE_SIDE);
+                                              printingInfo, DECK_ZONE_SIDE);
 
     layout->addWidget(zoneLabelMainboard, 0, Qt::AlignHCenter | Qt::AlignBottom);
     layout->addWidget(buttonBoxMainboard, 0, Qt::AlignHCenter | Qt::AlignTop);

--- a/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.h
@@ -17,7 +17,7 @@ public:
                                       QTreeView *deckView,
                                       QSlider *cardSizeSlider,
                                       CardInfoPtr rootCard,
-                                      CardInfoPerSet setInfoForCard);
+                                      PrintingInfo setInfoForCard);
     int getMainboardAmount();
     int getSideboardAmount();
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
@@ -36,7 +36,7 @@ private:
     QTreeView *deckView;
     QSlider *cardSizeSlider;
     CardInfoPtr rootCard;
-    CardInfoPerSet setInfoForCard;
+    PrintingInfo setInfoForCard;
     QLabel *zoneLabelMainboard;
     CardAmountWidget *buttonBoxMainboard;
     QLabel *zoneLabelSideboard;

--- a/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.h
@@ -17,7 +17,7 @@ public:
                                       QTreeView *deckView,
                                       QSlider *cardSizeSlider,
                                       CardInfoPtr rootCard,
-                                      PrintingInfo setInfoForCard);
+                                      PrintingInfo printingInfo);
     int getMainboardAmount();
     int getSideboardAmount();
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
@@ -36,7 +36,7 @@ private:
     QTreeView *deckView;
     QSlider *cardSizeSlider;
     CardInfoPtr rootCard;
-    PrintingInfo setInfoForCard;
+    PrintingInfo printingInfo;
     QLabel *zoneLabelMainboard;
     CardAmountWidget *buttonBoxMainboard;
     QLabel *zoneLabelSideboard;

--- a/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.cpp
@@ -12,7 +12,7 @@
  * @param deckView Pointer to the QTreeView displaying the deck.
  * @param cardSizeSlider Pointer to the QSlider for adjusting font size.
  * @param rootCard The root card to manage within the widget.
- * @param setInfoForCard Card set information for the root card.
+ * @param printingInfo Printing info for the root card.
  * @param zoneName The zone name (e.g., DECK_ZONE_MAIN or DECK_ZONE_SIDE).
  */
 CardAmountWidget::CardAmountWidget(QWidget *parent,
@@ -21,10 +21,10 @@ CardAmountWidget::CardAmountWidget(QWidget *parent,
                                    QTreeView *deckView,
                                    QSlider *cardSizeSlider,
                                    CardInfoPtr &rootCard,
-                                   PrintingInfo &setInfoForCard,
+                                   PrintingInfo &printingInfo,
                                    const QString &zoneName)
     : QWidget(parent), deckEditor(deckEditor), deckModel(deckModel), deckView(deckView), cardSizeSlider(cardSizeSlider),
-      rootCard(rootCard), setInfoForCard(setInfoForCard), zoneName(zoneName), hovered(false)
+      rootCard(rootCard), printingInfo(printingInfo), zoneName(zoneName), hovered(false)
 {
     layout = new QHBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
@@ -142,18 +142,18 @@ void CardAmountWidget::updateCardCount()
  */
 void CardAmountWidget::addPrinting(const QString &zone)
 {
-    auto newCardIndex = deckModel->addCard(rootCard->getName(), setInfoForCard, zone);
+    auto newCardIndex = deckModel->addCard(rootCard->getName(), printingInfo, zone);
     recursiveExpand(newCardIndex);
     QModelIndex find_card = deckModel->findCard(rootCard->getName(), zone);
     if (find_card.isValid() && find_card != newCardIndex) {
         auto amount = deckModel->data(find_card, Qt::DisplayRole);
         for (int i = 0; i < amount.toInt() - 1; i++) {
-            deckModel->addCard(rootCard->getName(), setInfoForCard, zone);
+            deckModel->addCard(rootCard->getName(), printingInfo, zone);
         }
         deckModel->removeRow(find_card.row(), find_card.parent());
     }
-    newCardIndex = deckModel->findCard(rootCard->getName(), zone, setInfoForCard.getProperty("uuid"),
-                                       setInfoForCard.getProperty("num"));
+    newCardIndex = deckModel->findCard(rootCard->getName(), zone, printingInfo.getProperty("uuid"),
+                                       printingInfo.getProperty("num"));
     deckView->setCurrentIndex(newCardIndex);
     deckView->setFocus(Qt::FocusReason::MouseFocusReason);
     deckEditor->setModified(true);
@@ -235,8 +235,8 @@ void CardAmountWidget::offsetCountAtIndex(const QModelIndex &idx, int offset)
  */
 void CardAmountWidget::decrementCardHelper(const QString &zone)
 {
-    QModelIndex idx = deckModel->findCard(rootCard->getName(), zone, setInfoForCard.getProperty("uuid"),
-                                          setInfoForCard.getProperty("num"));
+    QModelIndex idx = deckModel->findCard(rootCard->getName(), zone, printingInfo.getProperty("uuid"),
+                                          printingInfo.getProperty("num"));
     offsetCountAtIndex(idx, -1);
     deckEditor->setModified(true);
 }
@@ -249,7 +249,7 @@ void CardAmountWidget::decrementCardHelper(const QString &zone)
  */
 int CardAmountWidget::countCardsInZone(const QString &deckZone)
 {
-    if (setInfoForCard.getProperty("uuid").isEmpty()) {
+    if (printingInfo.getProperty("uuid").isEmpty()) {
         return 0; // Cards without uuids/providerIds CANNOT match another card, they are undefined for us.
     }
 
@@ -286,7 +286,7 @@ int CardAmountWidget::countCardsInZone(const QString &deckZone)
             }
 
             for (int k = 0; k < currentCard->getNumber(); ++k) {
-                if (currentCard->getCardProviderId() == setInfoForCard.getProperty("uuid")) {
+                if (currentCard->getCardProviderId() == printingInfo.getProperty("uuid")) {
                     count++;
                 }
             }

--- a/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.cpp
@@ -21,7 +21,7 @@ CardAmountWidget::CardAmountWidget(QWidget *parent,
                                    QTreeView *deckView,
                                    QSlider *cardSizeSlider,
                                    CardInfoPtr &rootCard,
-                                   CardInfoPerSet &setInfoForCard,
+                                   PrintingInfo &setInfoForCard,
                                    const QString &zoneName)
     : QWidget(parent), deckEditor(deckEditor), deckModel(deckModel), deckView(deckView), cardSizeSlider(cardSizeSlider),
       rootCard(rootCard), setInfoForCard(setInfoForCard), zoneName(zoneName), hovered(false)

--- a/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.h
@@ -23,7 +23,7 @@ public:
                               QTreeView *deckView,
                               QSlider *cardSizeSlider,
                               CardInfoPtr &rootCard,
-                              PrintingInfo &setInfoForCard,
+                              PrintingInfo &printingInfo,
                               const QString &zoneName);
     int countCardsInZone(const QString &deckZone);
 
@@ -41,7 +41,7 @@ private:
     QTreeView *deckView;
     QSlider *cardSizeSlider;
     CardInfoPtr rootCard;
-    PrintingInfo setInfoForCard;
+    PrintingInfo printingInfo;
     QString zoneName;
     QHBoxLayout *layout;
     DynamicFontSizePushButton *incrementButton;

--- a/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.h
@@ -23,7 +23,7 @@ public:
                               QTreeView *deckView,
                               QSlider *cardSizeSlider,
                               CardInfoPtr &rootCard,
-                              CardInfoPerSet &setInfoForCard,
+                              PrintingInfo &setInfoForCard,
                               const QString &zoneName);
     int countCardsInZone(const QString &deckZone);
 
@@ -41,7 +41,7 @@ private:
     QTreeView *deckView;
     QSlider *cardSizeSlider;
     CardInfoPtr rootCard;
-    CardInfoPerSet setInfoForCard;
+    PrintingInfo setInfoForCard;
     QString zoneName;
     QHBoxLayout *layout;
     DynamicFontSizePushButton *incrementButton;

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
@@ -224,11 +224,11 @@ void PrintingSelector::getAllSetsForCurrentCard()
         return;
     }
 
-    CardInfoPerSetMap cardInfoPerSets = selectedCard->getSets();
-    const QList<CardInfoPerSet> sortedSets = sortToolBar->sortSets(cardInfoPerSets);
-    const QList<CardInfoPerSet> filteredSets =
+    PrintingInfoPerSetMap cardInfoPerSets = selectedCard->getSets();
+    const QList<PrintingInfo> sortedSets = sortToolBar->sortSets(cardInfoPerSets);
+    const QList<PrintingInfo> filteredSets =
         sortToolBar->filterSets(sortedSets, searchBar->getSearchText().trimmed().toLower());
-    QList<CardInfoPerSet> setsToUse;
+    QList<PrintingInfo> setsToUse;
 
     if (SettingsCache::instance().getBumpSetsWithCardsInDeckToTop()) {
         setsToUse = sortToolBar->prependPrintingsInDeck(filteredSets, selectedCard, deckModel);

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
@@ -224,27 +224,27 @@ void PrintingSelector::getAllSetsForCurrentCard()
         return;
     }
 
-    PrintingInfoPerSetMap cardInfoPerSets = selectedCard->getSets();
-    const QList<PrintingInfo> sortedSets = sortToolBar->sortSets(cardInfoPerSets);
-    const QList<PrintingInfo> filteredSets =
-        sortToolBar->filterSets(sortedSets, searchBar->getSearchText().trimmed().toLower());
-    QList<PrintingInfo> setsToUse;
+    PrintingInfoPerSetMap perSetMap = selectedCard->getSets();
+    const QList<PrintingInfo> sortedPrintings = sortToolBar->sortSets(perSetMap);
+    const QList<PrintingInfo> filteredPrintings =
+        sortToolBar->filterSets(sortedPrintings, searchBar->getSearchText().trimmed().toLower());
+    QList<PrintingInfo> printingsToUse;
 
     if (SettingsCache::instance().getBumpSetsWithCardsInDeckToTop()) {
-        setsToUse = sortToolBar->prependPrintingsInDeck(filteredSets, selectedCard, deckModel);
+        printingsToUse = sortToolBar->prependPrintingsInDeck(filteredPrintings, selectedCard, deckModel);
     } else {
-        setsToUse = filteredSets;
+        printingsToUse = filteredPrintings;
     }
-    setsToUse = sortToolBar->prependPinnedPrintings(setsToUse, selectedCard->getName());
+    printingsToUse = sortToolBar->prependPinnedPrintings(printingsToUse, selectedCard->getName());
 
     // Defer widget creation
     currentIndex = 0;
 
     connect(widgetLoadingBufferTimer, &QTimer::timeout, this, [=, this]() mutable {
-        for (int i = 0; i < BATCH_SIZE && currentIndex < setsToUse.size(); ++i, ++currentIndex) {
+        for (int i = 0; i < BATCH_SIZE && currentIndex < printingsToUse.size(); ++i, ++currentIndex) {
             auto *cardDisplayWidget = new PrintingSelectorCardDisplayWidget(this, deckEditor, deckModel, deckView,
                                                                             cardSizeWidget->getSlider(), selectedCard,
-                                                                            setsToUse[currentIndex], currentZone);
+                                                                            printingsToUse[currentIndex], currentZone);
             flowWidget->addWidget(cardDisplayWidget);
             cardDisplayWidget->clampSetNameToPicture();
             connect(cardDisplayWidget, &PrintingSelectorCardDisplayWidget::cardPreferenceChanged, this,
@@ -252,7 +252,7 @@ void PrintingSelector::getAllSetsForCurrentCard()
         }
 
         // Stop timer when done
-        if (currentIndex >= setsToUse.size()) {
+        if (currentIndex >= printingsToUse.size()) {
             widgetLoadingBufferTimer->stop();
         }
     });

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
@@ -224,8 +224,8 @@ void PrintingSelector::getAllSetsForCurrentCard()
         return;
     }
 
-    PrintingInfoPerSetMap perSetMap = selectedCard->getSets();
-    const QList<PrintingInfo> sortedPrintings = sortToolBar->sortSets(perSetMap);
+    SetToPrintingsMap setMap = selectedCard->getSets();
+    const QList<PrintingInfo> sortedPrintings = sortToolBar->sortSets(setMap);
     const QList<PrintingInfo> filteredPrintings =
         sortToolBar->filterSets(sortedPrintings, searchBar->getSearchText().trimmed().toLower());
     QList<PrintingInfo> printingsToUse;

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.cpp
@@ -24,7 +24,7 @@
  * @param _deckView The QTreeView instance displaying the deck.
  * @param _cardSizeSlider The slider controlling the size of the displayed card.
  * @param _rootCard The root card object, representing the card to be displayed.
- * @param _setInfoForCard The set-specific information for the card being displayed.
+ * @param _printingInfo The printing info for the card being displayed.
  * @param _currentZone The current zone in which the card is located.
  */
 PrintingSelectorCardDisplayWidget::PrintingSelectorCardDisplayWidget(QWidget *parent,
@@ -33,10 +33,10 @@ PrintingSelectorCardDisplayWidget::PrintingSelectorCardDisplayWidget(QWidget *pa
                                                                      QTreeView *_deckView,
                                                                      QSlider *_cardSizeSlider,
                                                                      CardInfoPtr _rootCard,
-                                                                     const PrintingInfo &_setInfoForCard,
+                                                                     const PrintingInfo &_printingInfo,
                                                                      QString &_currentZone)
     : QWidget(parent), deckEditor(_deckEditor), deckModel(_deckModel), deckView(_deckView),
-      cardSizeSlider(_cardSizeSlider), rootCard(std::move(_rootCard)), setInfoForCard(_setInfoForCard),
+      cardSizeSlider(_cardSizeSlider), rootCard(std::move(_rootCard)), printingInfo(_printingInfo),
       currentZone(_currentZone)
 {
     layout = new QVBoxLayout(this);
@@ -45,15 +45,15 @@ PrintingSelectorCardDisplayWidget::PrintingSelectorCardDisplayWidget(QWidget *pa
 
     // Create the overlay widget for the card display
     overlayWidget = new PrintingSelectorCardOverlayWidget(this, deckEditor, deckModel, deckView, cardSizeSlider,
-                                                          rootCard, setInfoForCard);
+                                                          rootCard, _printingInfo);
     connect(overlayWidget, &PrintingSelectorCardOverlayWidget::cardPreferenceChanged, this,
             [this]() { emit cardPreferenceChanged(); });
 
     // Create the widget to display the set name and collector's number
     const QString combinedSetName =
-        QString(setInfoForCard.getPtr()->getLongName() + " (" + setInfoForCard.getPtr()->getShortName() + ")");
+        QString(_printingInfo.getSet()->getLongName() + " (" + _printingInfo.getSet()->getShortName() + ")");
     setNameAndCollectorsNumberDisplayWidget = new SetNameAndCollectorsNumberDisplayWidget(
-        this, combinedSetName, setInfoForCard.getProperty("num"), cardSizeSlider);
+        this, combinedSetName, _printingInfo.getProperty("num"), cardSizeSlider);
 
     // Add the widgets to the layout
     layout->addWidget(overlayWidget, 0, Qt::AlignHCenter);

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.cpp
@@ -33,7 +33,7 @@ PrintingSelectorCardDisplayWidget::PrintingSelectorCardDisplayWidget(QWidget *pa
                                                                      QTreeView *_deckView,
                                                                      QSlider *_cardSizeSlider,
                                                                      CardInfoPtr _rootCard,
-                                                                     const CardInfoPerSet &_setInfoForCard,
+                                                                     const PrintingInfo &_setInfoForCard,
                                                                      QString &_currentZone)
     : QWidget(parent), deckEditor(_deckEditor), deckModel(_deckModel), deckView(_deckView),
       cardSizeSlider(_cardSizeSlider), rootCard(std::move(_rootCard)), setInfoForCard(_setInfoForCard),

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.h
@@ -21,7 +21,7 @@ public:
                                       QTreeView *_deckView,
                                       QSlider *_cardSizeSlider,
                                       CardInfoPtr _rootCard,
-                                      const CardInfoPerSet &_setInfoForCard,
+                                      const PrintingInfo &_setInfoForCard,
                                       QString &_currentZone);
 
 public slots:
@@ -39,7 +39,7 @@ private:
     QSlider *cardSizeSlider;
     CardInfoPtr rootCard;
     CardInfoPtr setCard;
-    CardInfoPerSet setInfoForCard;
+    PrintingInfo setInfoForCard;
     QString currentZone;
     PrintingSelectorCardOverlayWidget *overlayWidget;
 };

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.h
@@ -21,7 +21,7 @@ public:
                                       QTreeView *_deckView,
                                       QSlider *_cardSizeSlider,
                                       CardInfoPtr _rootCard,
-                                      const PrintingInfo &_setInfoForCard,
+                                      const PrintingInfo &_printingInfo,
                                       QString &_currentZone);
 
 public slots:
@@ -39,7 +39,7 @@ private:
     QSlider *cardSizeSlider;
     CardInfoPtr rootCard;
     CardInfoPtr setCard;
-    PrintingInfo setInfoForCard;
+    PrintingInfo printingInfo;
     QString currentZone;
     PrintingSelectorCardOverlayWidget *overlayWidget;
 };

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
@@ -30,7 +30,7 @@ PrintingSelectorCardOverlayWidget::PrintingSelectorCardOverlayWidget(QWidget *pa
                                                                      QTreeView *_deckView,
                                                                      QSlider *_cardSizeSlider,
                                                                      CardInfoPtr _rootCard,
-                                                                     const CardInfoPerSet &_setInfoForCard)
+                                                                     const PrintingInfo &_setInfoForCard)
     : QWidget(parent), deckEditor(_deckEditor), deckModel(_deckModel), deckView(_deckView),
       cardSizeSlider(_cardSizeSlider), rootCard(std::move(_rootCard)), setInfoForCard(_setInfoForCard)
 {

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
@@ -22,7 +22,7 @@
  * @param _deckView The QTreeView instance displaying the deck.
  * @param _cardSizeSlider The slider controlling the size of the card.
  * @param _rootCard The root card object that contains information about the card.
- * @param _setInfoForCard The set-specific information for the card being displayed.
+ * @param _printingInfo The printing-specific information for the card being displayed.
  */
 PrintingSelectorCardOverlayWidget::PrintingSelectorCardOverlayWidget(QWidget *parent,
                                                                      AbstractTabDeckEditor *_deckEditor,
@@ -30,9 +30,9 @@ PrintingSelectorCardOverlayWidget::PrintingSelectorCardOverlayWidget(QWidget *pa
                                                                      QTreeView *_deckView,
                                                                      QSlider *_cardSizeSlider,
                                                                      CardInfoPtr _rootCard,
-                                                                     const PrintingInfo &_setInfoForCard)
+                                                                     const PrintingInfo &_printingInfo)
     : QWidget(parent), deckEditor(_deckEditor), deckModel(_deckModel), deckView(_deckView),
-      cardSizeSlider(_cardSizeSlider), rootCard(std::move(_rootCard)), setInfoForCard(_setInfoForCard)
+      cardSizeSlider(_cardSizeSlider), rootCard(std::move(_rootCard)), printingInfo(_printingInfo)
 {
     // Set up the main layout
     auto *mainLayout = new QVBoxLayout(this);
@@ -45,13 +45,13 @@ PrintingSelectorCardOverlayWidget::PrintingSelectorCardOverlayWidget(QWidget *pa
     cardInfoPicture->setMinimumSize(0, 0);
     cardInfoPicture->setScaleFactor(cardSizeSlider->value());
     setCard = CardDatabaseManager::getInstance()->getCardByNameAndProviderId(rootCard->getName(),
-                                                                             setInfoForCard.getProperty("uuid"));
+                                                                             _printingInfo.getProperty("uuid"));
     cardInfoPicture->setCard(setCard);
     mainLayout->addWidget(cardInfoPicture);
 
     // Add AllZonesCardAmountWidget
     allZonesCardAmountWidget =
-        new AllZonesCardAmountWidget(this, deckEditor, deckModel, deckView, cardSizeSlider, setCard, setInfoForCard);
+        new AllZonesCardAmountWidget(this, deckEditor, deckModel, deckView, cardSizeSlider, setCard, _printingInfo);
 
     allZonesCardAmountWidget->raise(); // Ensure it's on top of the picture
     // Set initial visibility based on amounts
@@ -172,7 +172,7 @@ void PrintingSelectorCardOverlayWidget::customMenu(QPoint point)
 
     const auto &preferredProviderId =
         SettingsCache::instance().cardOverrides().getCardPreferenceOverride(rootCard->getName());
-    const auto &cardProviderId = setInfoForCard.getProperty("uuid");
+    const auto &cardProviderId = printingInfo.getProperty("uuid");
 
     if (preferredProviderId.isEmpty() || preferredProviderId != cardProviderId) {
         auto *pinAction = preferenceMenu->addAction(tr("Pin Printing"));

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.h
@@ -20,7 +20,7 @@ public:
                                                QTreeView *_deckView,
                                                QSlider *_cardSizeSlider,
                                                CardInfoPtr _rootCard,
-                                               const PrintingInfo &_setInfoForCard);
+                                               const PrintingInfo &_printingInfo);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -45,7 +45,7 @@ private:
     QSlider *cardSizeSlider;
     CardInfoPtr rootCard;
     CardInfoPtr setCard;
-    PrintingInfo setInfoForCard;
+    PrintingInfo printingInfo;
 };
 
 #endif // PRINTING_SELECTOR_CARD_OVERLAY_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.h
@@ -20,7 +20,7 @@ public:
                                                QTreeView *_deckView,
                                                QSlider *_cardSizeSlider,
                                                CardInfoPtr _rootCard,
-                                               const CardInfoPerSet &_setInfoForCard);
+                                               const PrintingInfo &_setInfoForCard);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -45,7 +45,7 @@ private:
     QSlider *cardSizeSlider;
     CardInfoPtr rootCard;
     CardInfoPtr setCard;
-    CardInfoPerSet setInfoForCard;
+    PrintingInfo setInfoForCard;
 };
 
 #endif // PRINTING_SELECTOR_CARD_OVERLAY_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.cpp
@@ -76,7 +76,7 @@ void PrintingSelectorCardSortingWidget::updateSortSetting()
  * @param cardInfoPerSets The list of card sets to be sorted.
  * @return A sorted list of card sets.
  */
-QList<CardInfoPerSet> PrintingSelectorCardSortingWidget::sortSets(const CardInfoPerSetMap &cardInfoPerSets)
+QList<PrintingInfo> PrintingSelectorCardSortingWidget::sortSets(const PrintingInfoPerSetMap &cardInfoPerSets)
 {
     QList<CardSetPtr> sortedSets;
 
@@ -98,7 +98,7 @@ QList<CardInfoPerSet> PrintingSelectorCardSortingWidget::sortSets(const CardInfo
         std::sort(sortedSets.begin(), sortedSets.end(), SetReleaseDateComparator());
     }
 
-    QList<CardInfoPerSet> sortedCardInfoPerSets;
+    QList<PrintingInfo> sortedCardInfoPerSets;
     // Reconstruct sorted list of CardInfoPerSet
     for (const auto &set : sortedSets) {
         for (auto it = cardInfoPerSets.begin(); it != cardInfoPerSets.end(); ++it) {
@@ -130,14 +130,14 @@ QList<CardInfoPerSet> PrintingSelectorCardSortingWidget::sortSets(const CardInfo
  * @param searchText The search text used to filter the card sets.
  * @return A filtered list of card sets.
  */
-QList<CardInfoPerSet> PrintingSelectorCardSortingWidget::filterSets(const QList<CardInfoPerSet> &sets,
+QList<PrintingInfo> PrintingSelectorCardSortingWidget::filterSets(const QList<PrintingInfo> &sets,
                                                                     const QString &searchText)
 {
     if (searchText.isEmpty()) {
         return sets;
     }
 
-    QList<CardInfoPerSet> filteredSets;
+    QList<PrintingInfo> filteredSets;
 
     for (const auto &set : sets) {
         const QString longName = set.getPtr()->getLongName().toLower();
@@ -151,7 +151,7 @@ QList<CardInfoPerSet> PrintingSelectorCardSortingWidget::filterSets(const QList<
     return filteredSets;
 }
 
-QList<CardInfoPerSet> PrintingSelectorCardSortingWidget::prependPinnedPrintings(const QList<CardInfoPerSet> &sets,
+QList<PrintingInfo> PrintingSelectorCardSortingWidget::prependPinnedPrintings(const QList<PrintingInfo> &sets,
                                                                                 const QString &cardName)
 {
     auto setsToUse = sets;
@@ -180,7 +180,7 @@ QList<CardInfoPerSet> PrintingSelectorCardSortingWidget::prependPinnedPrintings(
  * @param deckModel The model representing the deck.
  * @return A list of card sets with the printings contained in the deck prepended.
  */
-QList<CardInfoPerSet> PrintingSelectorCardSortingWidget::prependPrintingsInDeck(const QList<CardInfoPerSet> &sets,
+QList<PrintingInfo> PrintingSelectorCardSortingWidget::prependPrintingsInDeck(const QList<PrintingInfo> &sets,
                                                                                 const CardInfoPtr &selectedCard,
                                                                                 DeckListModel *deckModel)
 {
@@ -188,8 +188,8 @@ QList<CardInfoPerSet> PrintingSelectorCardSortingWidget::prependPrintingsInDeck(
         return {};
     }
 
-    CardInfoPerSetMap cardInfoPerSets = selectedCard->getSets();
-    QList<QPair<CardInfoPerSet, int>> countList;
+    PrintingInfoPerSetMap cardInfoPerSets = selectedCard->getSets();
+    QList<QPair<PrintingInfo, int>> countList;
 
     // Collect sets with their counts
     for (const auto &cardInfoPerSetList : cardInfoPerSets) {
@@ -209,16 +209,16 @@ QList<CardInfoPerSet> PrintingSelectorCardSortingWidget::prependPrintingsInDeck(
 
     // Sort sets by count in descending numerical order
     std::sort(countList.begin(), countList.end(),
-              [](const QPair<CardInfoPerSet, int> &a, const QPair<CardInfoPerSet, int> &b) {
+              [](const QPair<PrintingInfo, int> &a, const QPair<PrintingInfo, int> &b) {
                   return a.second > b.second; // Ensure numerical comparison
               });
 
     // Create a copy of the original list to modify
-    QList<CardInfoPerSet> result = sets;
+    QList<PrintingInfo> result = sets;
 
     // Prepend sorted sets and remove them from the original list
     for (const auto &pair : countList) {
-        auto it = std::find_if(result.begin(), result.end(), [&pair](const CardInfoPerSet &item) {
+        auto it = std::find_if(result.begin(), result.end(), [&pair](const PrintingInfo &item) {
             return item.getProperty("uuid") == pair.first.getProperty("uuid");
         });
         if (it != result.end()) {

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.cpp
@@ -99,13 +99,13 @@ QList<PrintingInfo> PrintingSelectorCardSortingWidget::sortSets(const SetToPrint
     }
 
     QList<PrintingInfo> sortedPrintings;
-    // Reconstruct sorted list of CardInfoPerSet
+    // Reconstruct sorted list of PrintingInfo
     for (const auto &set : sortedSets) {
         for (auto it = setMap.begin(); it != setMap.end(); ++it) {
-            for (const auto &cardInfoPerSet : it.value()) {
-                if (cardInfoPerSet.getSet() == set) {
-                    if (!sortedPrintings.contains(cardInfoPerSet)) {
-                        sortedPrintings << cardInfoPerSet;
+            for (const auto &printingInfo : it.value()) {
+                if (printingInfo.getSet() == set) {
+                    if (!sortedPrintings.contains(printingInfo)) {
+                        sortedPrintings << printingInfo;
                     }
                 }
             }

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.cpp
@@ -73,14 +73,14 @@ void PrintingSelectorCardSortingWidget::updateSortSetting()
  * - Contained in Deck
  * - Potential Cards in Deck
  *
- * @param perSetMap The list of card sets to be sorted.
+ * @param setMap The list of card sets to be sorted.
  * @return A sorted list of printings.
  */
-QList<PrintingInfo> PrintingSelectorCardSortingWidget::sortSets(const PrintingInfoPerSetMap &perSetMap)
+QList<PrintingInfo> PrintingSelectorCardSortingWidget::sortSets(const SetToPrintingsMap &setMap)
 {
     QList<CardSetPtr> sortedSets;
 
-    for (const auto &printingInfos : perSetMap) {
+    for (const auto &printingInfos : setMap) {
         for (const auto &set : printingInfos) {
             sortedSets << set.getSet();
             break;
@@ -101,7 +101,7 @@ QList<PrintingInfo> PrintingSelectorCardSortingWidget::sortSets(const PrintingIn
     QList<PrintingInfo> sortedPrintings;
     // Reconstruct sorted list of CardInfoPerSet
     for (const auto &set : sortedSets) {
-        for (auto it = perSetMap.begin(); it != perSetMap.end(); ++it) {
+        for (auto it = setMap.begin(); it != setMap.end(); ++it) {
             for (const auto &cardInfoPerSet : it.value()) {
                 if (cardInfoPerSet.getSet() == set) {
                     if (!sortedPrintings.contains(cardInfoPerSet)) {
@@ -188,11 +188,11 @@ QList<PrintingInfo> PrintingSelectorCardSortingWidget::prependPrintingsInDeck(co
         return {};
     }
 
-    PrintingInfoPerSetMap perSetMap = selectedCard->getSets();
+    SetToPrintingsMap setMap = selectedCard->getSets();
     QList<QPair<PrintingInfo, int>> countList;
 
     // Collect sets with their counts
-    for (const auto &printingList : perSetMap) {
+    for (const auto &printingList : setMap) {
         for (const auto &printing : printingList) {
             QModelIndex find_card =
                 deckModel->findCard(selectedCard->getName(), DECK_ZONE_MAIN, printing.getProperty("uuid"));

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.h
@@ -12,7 +12,7 @@ class PrintingSelectorCardSortingWidget : public QWidget
     Q_OBJECT
 public:
     explicit PrintingSelectorCardSortingWidget(PrintingSelector *parent);
-    QList<PrintingInfo> sortSets(const PrintingInfoPerSetMap &perSetMap);
+    QList<PrintingInfo> sortSets(const SetToPrintingsMap &setMap);
     QList<PrintingInfo> filterSets(const QList<PrintingInfo> &printings, const QString &searchText);
     QList<PrintingInfo> prependPinnedPrintings(const QList<PrintingInfo> &printings, const QString &cardName);
     QList<PrintingInfo> prependPrintingsInDeck(const QList<PrintingInfo> &printings,

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.h
@@ -12,10 +12,10 @@ class PrintingSelectorCardSortingWidget : public QWidget
     Q_OBJECT
 public:
     explicit PrintingSelectorCardSortingWidget(PrintingSelector *parent);
-    QList<CardInfoPerSet> sortSets(const CardInfoPerSetMap &cardInfoPerSets);
-    QList<CardInfoPerSet> filterSets(const QList<CardInfoPerSet> &sets, const QString &searchText);
-    QList<CardInfoPerSet> prependPinnedPrintings(const QList<CardInfoPerSet> &sets, const QString &cardName);
-    QList<CardInfoPerSet> prependPrintingsInDeck(const QList<CardInfoPerSet> &sets,
+    QList<PrintingInfo> sortSets(const PrintingInfoPerSetMap &cardInfoPerSets);
+    QList<PrintingInfo> filterSets(const QList<PrintingInfo> &sets, const QString &searchText);
+    QList<PrintingInfo> prependPinnedPrintings(const QList<PrintingInfo> &sets, const QString &cardName);
+    QList<PrintingInfo> prependPrintingsInDeck(const QList<PrintingInfo> &sets,
                                                  const CardInfoPtr &selectedCard,
                                                  DeckListModel *deckModel);
 

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.h
@@ -12,12 +12,12 @@ class PrintingSelectorCardSortingWidget : public QWidget
     Q_OBJECT
 public:
     explicit PrintingSelectorCardSortingWidget(PrintingSelector *parent);
-    QList<PrintingInfo> sortSets(const PrintingInfoPerSetMap &cardInfoPerSets);
-    QList<PrintingInfo> filterSets(const QList<PrintingInfo> &sets, const QString &searchText);
-    QList<PrintingInfo> prependPinnedPrintings(const QList<PrintingInfo> &sets, const QString &cardName);
-    QList<PrintingInfo> prependPrintingsInDeck(const QList<PrintingInfo> &sets,
-                                                 const CardInfoPtr &selectedCard,
-                                                 DeckListModel *deckModel);
+    QList<PrintingInfo> sortSets(const PrintingInfoPerSetMap &perSetMap);
+    QList<PrintingInfo> filterSets(const QList<PrintingInfo> &printings, const QString &searchText);
+    QList<PrintingInfo> prependPinnedPrintings(const QList<PrintingInfo> &printings, const QString &cardName);
+    QList<PrintingInfo> prependPrintingsInDeck(const QList<PrintingInfo> &printings,
+                                               const CardInfoPtr &selectedCard,
+                                               DeckListModel *deckModel);
 
 public slots:
     void updateSortOrder();

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -230,7 +230,7 @@ void VisualDatabaseDisplayWidget::populateCards()
 
         if (CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(name.toString())) {
             if (setFilter) {
-                PrintingInfoPerSetMap setMap = info->getSets();
+                SetToPrintingsMap setMap = info->getSets();
                 if (setMap.contains(setFilter->term())) {
                     for (PrintingInfo printing : setMap[setFilter->term()]) {
                         addCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
@@ -296,7 +296,7 @@ void VisualDatabaseDisplayWidget::loadNextPage()
         QVariant name = databaseDisplayModel->data(index, Qt::DisplayRole);
         if (CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(name.toString())) {
             if (setFilter) {
-                PrintingInfoPerSetMap setMap = info->getSets();
+                SetToPrintingsMap setMap = info->getSets();
                 if (setMap.contains(setFilter->term())) {
                     for (PrintingInfo printing : setMap[setFilter->term()]) {
                         addCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -230,9 +230,9 @@ void VisualDatabaseDisplayWidget::populateCards()
 
         if (CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(name.toString())) {
             if (setFilter) {
-                CardInfoPerSetMap setMap = info->getSets();
+                PrintingInfoPerSetMap setMap = info->getSets();
                 if (setMap.contains(setFilter->term())) {
-                    for (CardInfoPerSet cardSetInstance : setMap[setFilter->term()]) {
+                    for (PrintingInfo cardSetInstance : setMap[setFilter->term()]) {
                         addCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
                             name.toString(), cardSetInstance.getProperty("uuid")));
                     }
@@ -296,9 +296,9 @@ void VisualDatabaseDisplayWidget::loadNextPage()
         QVariant name = databaseDisplayModel->data(index, Qt::DisplayRole);
         if (CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(name.toString())) {
             if (setFilter) {
-                CardInfoPerSetMap setMap = info->getSets();
+                PrintingInfoPerSetMap setMap = info->getSets();
                 if (setMap.contains(setFilter->term())) {
-                    for (CardInfoPerSet cardSetInstance : setMap[setFilter->term()]) {
+                    for (PrintingInfo cardSetInstance : setMap[setFilter->term()]) {
                         addCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
                             name.toString(), cardSetInstance.getProperty("uuid")));
                     }

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -232,9 +232,9 @@ void VisualDatabaseDisplayWidget::populateCards()
             if (setFilter) {
                 PrintingInfoPerSetMap setMap = info->getSets();
                 if (setMap.contains(setFilter->term())) {
-                    for (PrintingInfo cardSetInstance : setMap[setFilter->term()]) {
+                    for (PrintingInfo printing : setMap[setFilter->term()]) {
                         addCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-                            name.toString(), cardSetInstance.getProperty("uuid")));
+                            name.toString(), printing.getProperty("uuid")));
                     }
                 }
             } else {
@@ -298,9 +298,9 @@ void VisualDatabaseDisplayWidget::loadNextPage()
             if (setFilter) {
                 PrintingInfoPerSetMap setMap = info->getSets();
                 if (setMap.contains(setFilter->term())) {
-                    for (PrintingInfo cardSetInstance : setMap[setFilter->term()]) {
+                    for (PrintingInfo printing : setMap[setFilter->term()]) {
                         addCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-                            name.toString(), cardSetInstance.getProperty("uuid")));
+                            name.toString(), printing.getProperty("uuid")));
                     }
                 }
             } else {

--- a/cockatrice/src/deck/deck_list_model.cpp
+++ b/cockatrice/src/deck/deck_list_model.cpp
@@ -367,17 +367,17 @@ QModelIndex DeckListModel::findCard(const QString &cardName,
 
 QModelIndex DeckListModel::addPreferredPrintingCard(const QString &cardName, const QString &zoneName, bool abAddAnyway)
 {
-    return addCard(cardName, CardDatabaseManager::getInstance()->getPreferredSetForCard(cardName), zoneName,
+    return addCard(cardName, CardDatabaseManager::getInstance()->getPreferredPrinting(cardName), zoneName,
                    abAddAnyway);
 }
 
 QModelIndex DeckListModel::addCard(const QString &cardName,
-                                   const PrintingInfo &cardInfoSet,
+                                   const PrintingInfo &printingInfo,
                                    const QString &zoneName,
                                    bool abAddAnyway)
 {
     CardInfoPtr cardInfo =
-        CardDatabaseManager::getInstance()->getCardByNameAndProviderId(cardName, cardInfoSet.getProperty("uuid"));
+        CardDatabaseManager::getInstance()->getCardByNameAndProviderId(cardName, printingInfo.getProperty("uuid"));
 
     if (cardInfo == nullptr) {
         if (abAddAnyway) {
@@ -398,15 +398,15 @@ QModelIndex DeckListModel::addCard(const QString &cardName,
 
     const QModelIndex parentIndex = nodeToIndex(groupNode);
     auto *cardNode = dynamic_cast<DecklistModelCardNode *>(groupNode->findCardChildByNameProviderIdAndNumber(
-        cardName, cardInfoSet.getProperty("uuid"), cardInfoSet.getProperty("num")));
-    const auto cardSetName = cardInfoSet.getPtr().isNull() ? "" : cardInfoSet.getPtr()->getCorrectedShortName();
+        cardName, printingInfo.getProperty("uuid"), printingInfo.getProperty("num")));
+    const auto cardSetName = printingInfo.getSet().isNull() ? "" : printingInfo.getSet()->getCorrectedShortName();
 
     if (!cardNode) {
         // Determine the correct index
         int insertRow = findSortedInsertRow(groupNode, cardInfo);
 
         auto *decklistCard = deckList->addCard(cardInfo->getName(), zoneName, insertRow, cardSetName,
-                                               cardInfoSet.getProperty("num"), cardInfoSet.getProperty("uuid"));
+                                               printingInfo.getProperty("num"), printingInfo.getProperty("uuid"));
 
         beginInsertRows(parentIndex, insertRow, insertRow);
         cardNode = new DecklistModelCardNode(decklistCard, groupNode, insertRow);
@@ -414,8 +414,8 @@ QModelIndex DeckListModel::addCard(const QString &cardName,
     } else {
         cardNode->setNumber(cardNode->getNumber() + 1);
         cardNode->setCardSetShortName(cardSetName);
-        cardNode->setCardCollectorNumber(cardInfoSet.getProperty("num"));
-        cardNode->setCardProviderId(cardInfoSet.getProperty("uuid"));
+        cardNode->setCardCollectorNumber(printingInfo.getProperty("num"));
+        cardNode->setCardProviderId(printingInfo.getProperty("uuid"));
         deckList->refreshDeckHash();
     }
     sort(lastKnownColumn, lastKnownOrder);

--- a/cockatrice/src/deck/deck_list_model.cpp
+++ b/cockatrice/src/deck/deck_list_model.cpp
@@ -372,7 +372,7 @@ QModelIndex DeckListModel::addPreferredPrintingCard(const QString &cardName, con
 }
 
 QModelIndex DeckListModel::addCard(const QString &cardName,
-                                   const CardInfoPerSet &cardInfoSet,
+                                   const PrintingInfo &cardInfoSet,
                                    const QString &zoneName,
                                    bool abAddAnyway)
 {

--- a/cockatrice/src/deck/deck_list_model.h
+++ b/cockatrice/src/deck/deck_list_model.h
@@ -112,7 +112,7 @@ public:
                          const QString &cardNumber = "") const;
     QModelIndex addPreferredPrintingCard(const QString &cardName, const QString &zoneName, bool abAddAnyway);
     QModelIndex addCard(const ::QString &cardName,
-                        const PrintingInfo &cardInfoSet,
+                        const PrintingInfo &printingInfo,
                         const QString &zoneName,
                         bool abAddAnyway = false);
     int findSortedInsertRow(InnerDecklistNode *parent, CardInfoPtr cardInfo) const;

--- a/cockatrice/src/deck/deck_list_model.h
+++ b/cockatrice/src/deck/deck_list_model.h
@@ -112,7 +112,7 @@ public:
                          const QString &cardNumber = "") const;
     QModelIndex addPreferredPrintingCard(const QString &cardName, const QString &zoneName, bool abAddAnyway);
     QModelIndex addCard(const ::QString &cardName,
-                        const CardInfoPerSet &cardInfoSet,
+                        const PrintingInfo &cardInfoSet,
                         const QString &zoneName,
                         bool abAddAnyway = false);
     int findSortedInsertRow(InnerDecklistNode *parent, CardInfoPtr cardInfo) const;

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -324,7 +324,7 @@ struct SetProviderIdToPreferred
     void operator()(const InnerDecklistNode *node, DecklistCardNode *card) const
     {
         Q_UNUSED(node);
-        CardInfoPerSet preferredSet = CardDatabaseManager::getInstance()->getSpecificSetForCard(
+        PrintingInfo preferredSet = CardDatabaseManager::getInstance()->getSpecificSetForCard(
             card->getName(),
             CardDatabaseManager::getInstance()->getPreferredPrintingProviderIdForCard(card->getName()));
         QString providerId = preferredSet.getProperty("uuid");

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -324,12 +324,12 @@ struct SetProviderIdToPreferred
     void operator()(const InnerDecklistNode *node, DecklistCardNode *card) const
     {
         Q_UNUSED(node);
-        PrintingInfo preferredSet = CardDatabaseManager::getInstance()->getSpecificSetForCard(
+        PrintingInfo preferredPrinting = CardDatabaseManager::getInstance()->getSpecificPrinting(
             card->getName(),
             CardDatabaseManager::getInstance()->getPreferredPrintingProviderIdForCard(card->getName()));
-        QString providerId = preferredSet.getProperty("uuid");
-        QString setShortName = preferredSet.getPtr()->getShortName();
-        QString collectorNumber = preferredSet.getProperty("num");
+        QString providerId = preferredPrinting.getProperty("uuid");
+        QString setShortName = preferredPrinting.getSet()->getShortName();
+        QString collectorNumber = preferredPrinting.getProperty("num");
 
         card->setCardProviderId(providerId);
         card->setCardCollectorNumber(collectorNumber);
@@ -360,7 +360,7 @@ void DeckLoader::resolveSetNameAndNumberToProviderID()
         // Retrieve the providerId based on setName and collectorNumber
         QString providerId =
             CardDatabaseManager::getInstance()
-                ->getSpecificSetForCard(card->getName(), card->getCardSetShortName(), card->getCardCollectorNumber())
+                ->getSpecificPrinting(card->getName(), card->getCardSetShortName(), card->getCardCollectorNumber())
                 .getProperty("uuid");
 
         // Set the providerId on the card

--- a/cockatrice/src/dialogs/dlg_edit_tokens.cpp
+++ b/cockatrice/src/dialogs/dlg_edit_tokens.cpp
@@ -162,8 +162,8 @@ void DlgEditTokens::actAddToken()
     }
 
     QString setName = CardSet::TOKENS_SETNAME;
-    CardInfoPerSetMap sets;
-    sets[setName].append(CardInfoPerSet(databaseModel->getDatabase()->getSet(setName)));
+    PrintingInfoPerSetMap sets;
+    sets[setName].append(PrintingInfo(databaseModel->getDatabase()->getSet(setName)));
     CardInfoPtr card = CardInfo::newInstance(name, "", true, QVariantHash(), QList<CardRelation *>(),
                                              QList<CardRelation *>(), sets, false, false, -1, false);
     card->setCardType("Token");

--- a/cockatrice/src/dialogs/dlg_edit_tokens.cpp
+++ b/cockatrice/src/dialogs/dlg_edit_tokens.cpp
@@ -162,7 +162,7 @@ void DlgEditTokens::actAddToken()
     }
 
     QString setName = CardSet::TOKENS_SETNAME;
-    PrintingInfoPerSetMap sets;
+    SetToPrintingsMap sets;
     sets[setName].append(PrintingInfo(databaseModel->getDatabase()->getSet(setName)));
     CardInfoPtr card = CardInfo::newInstance(name, "", true, QVariantHash(), QList<CardRelation *>(),
                                              QList<CardRelation *>(), sets, false, false, -1, false);

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -226,8 +226,8 @@ QMap<QString, int> DlgSelectSetForCards::getSetsForCards()
             if (!infoPtr)
                 continue;
 
-            PrintingInfoPerSetMap perSetMap = infoPtr->getSets();
-            for (auto it = perSetMap.begin(); it != perSetMap.end(); ++it) {
+            SetToPrintingsMap setMap = infoPtr->getSets();
+            for (auto it = setMap.begin(); it != setMap.end(); ++it) {
                 setCounts[it.key()]++;
             }
         }
@@ -380,8 +380,8 @@ QMap<QString, QStringList> DlgSelectSetForCards::getCardsForSets()
             if (!infoPtr)
                 continue;
 
-            PrintingInfoPerSetMap perSetMap = infoPtr->getSets();
-            for (auto it = perSetMap.begin(); it != perSetMap.end(); ++it) {
+            SetToPrintingsMap setMap = infoPtr->getSets();
+            for (auto it = setMap.begin(); it != setMap.end(); ++it) {
                 setCards[it.key()].append(currentCard->getName());
             }
         }

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -152,7 +152,7 @@ void DlgSelectSetForCards::actOK()
                 continue;
             }
             model->removeRow(find_card.row(), find_card.parent());
-            model->addCard(card, CardDatabaseManager::getInstance()->getSpecificSetForCard(card, modifiedSet, ""),
+            model->addCard(card, CardDatabaseManager::getInstance()->getSpecificPrinting(card, modifiedSet, ""),
                            DECK_ZONE_MAIN);
         }
     }
@@ -226,8 +226,8 @@ QMap<QString, int> DlgSelectSetForCards::getSetsForCards()
             if (!infoPtr)
                 continue;
 
-            PrintingInfoPerSetMap infoPerSetMap = infoPtr->getSets();
-            for (auto it = infoPerSetMap.begin(); it != infoPerSetMap.end(); ++it) {
+            PrintingInfoPerSetMap perSetMap = infoPtr->getSets();
+            for (auto it = perSetMap.begin(); it != perSetMap.end(); ++it) {
                 setCounts[it.key()]++;
             }
         }
@@ -297,7 +297,7 @@ void DlgSelectSetForCards::updateCardLists()
             } else {
                 CardInfoPtr infoPtr = CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
                     currentCard->getName(), CardDatabaseManager::getInstance()
-                                                ->getSpecificSetForCard(currentCard->getName(), foundSetName, "")
+                                                ->getSpecificPrinting(currentCard->getName(), foundSetName, "")
                                                 .getProperty("uuid"));
                 CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(modifiedCardsFlowWidget);
                 picture_widget->setCard(infoPtr);
@@ -380,8 +380,8 @@ QMap<QString, QStringList> DlgSelectSetForCards::getCardsForSets()
             if (!infoPtr)
                 continue;
 
-            PrintingInfoPerSetMap infoPerSetMap = infoPtr->getSets();
-            for (auto it = infoPerSetMap.begin(); it != infoPerSetMap.end(); ++it) {
+            PrintingInfoPerSetMap perSetMap = infoPtr->getSets();
+            for (auto it = perSetMap.begin(); it != perSetMap.end(); ++it) {
                 setCards[it.key()].append(currentCard->getName());
             }
         }
@@ -628,7 +628,7 @@ void SetEntryWidget::updateCardDisplayWidgets()
         CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(cardListContainer);
         picture_widget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
             cardName,
-            CardDatabaseManager::getInstance()->getSpecificSetForCard(cardName, setName, nullptr).getProperty("uuid")));
+            CardDatabaseManager::getInstance()->getSpecificPrinting(cardName, setName, nullptr).getProperty("uuid")));
         cardListContainer->addWidget(picture_widget);
     }
 
@@ -636,7 +636,7 @@ void SetEntryWidget::updateCardDisplayWidgets()
         CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(alreadySelectedCardListContainer);
         picture_widget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
             cardName,
-            CardDatabaseManager::getInstance()->getSpecificSetForCard(cardName, setName, nullptr).getProperty("uuid")));
+            CardDatabaseManager::getInstance()->getSpecificPrinting(cardName, setName, nullptr).getProperty("uuid")));
         alreadySelectedCardListContainer->addWidget(picture_widget);
     }
 }

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -226,7 +226,7 @@ QMap<QString, int> DlgSelectSetForCards::getSetsForCards()
             if (!infoPtr)
                 continue;
 
-            CardInfoPerSetMap infoPerSetMap = infoPtr->getSets();
+            PrintingInfoPerSetMap infoPerSetMap = infoPtr->getSets();
             for (auto it = infoPerSetMap.begin(); it != infoPerSetMap.end(); ++it) {
                 setCounts[it.key()]++;
             }
@@ -380,7 +380,7 @@ QMap<QString, QStringList> DlgSelectSetForCards::getCardsForSets()
             if (!infoPtr)
                 continue;
 
-            CardInfoPerSetMap infoPerSetMap = infoPtr->getSets();
+            PrintingInfoPerSetMap infoPerSetMap = infoPtr->getSets();
             for (auto it = infoPerSetMap.begin(); it != infoPerSetMap.end(); ++it) {
                 setCards[it.key()].append(currentCard->getName());
             }

--- a/cockatrice/src/game/board/abstract_card_item.cpp
+++ b/cockatrice/src/game/board/abstract_card_item.cpp
@@ -67,7 +67,7 @@ void AbstractCardItem::refreshCardInfo()
         QVariantHash properties = QVariantHash();
 
         info = CardInfo::newInstance(name, "", true, QVariantHash(), QList<CardRelation *>(), QList<CardRelation *>(),
-                                     PrintingInfoPerSetMap(), false, false, -1, false);
+                                     SetToPrintingsMap(), false, false, -1, false);
     }
     if (info.data()) {
         connect(info.data(), &CardInfo::pixmapUpdated, this, &AbstractCardItem::pixmapUpdated);

--- a/cockatrice/src/game/board/abstract_card_item.cpp
+++ b/cockatrice/src/game/board/abstract_card_item.cpp
@@ -67,7 +67,7 @@ void AbstractCardItem::refreshCardInfo()
         QVariantHash properties = QVariantHash();
 
         info = CardInfo::newInstance(name, "", true, QVariantHash(), QList<CardRelation *>(), QList<CardRelation *>(),
-                                     CardInfoPerSetMap(), false, false, -1, false);
+                                     PrintingInfoPerSetMap(), false, false, -1, false);
     }
     if (info.data()) {
         connect(info.data(), &CardInfo::pixmapUpdated, this, &AbstractCardItem::pixmapUpdated);

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -147,12 +147,12 @@ CardInfoPtr CardDatabase::getCardByNameAndProviderId(const QString &cardName, co
         return info;
     }
 
-    for (const auto &cardInfoPerSetList : info->getSets()) {
-        for (const auto &set : cardInfoPerSetList) {
-            if (set.getProperty("uuid") == providerId) {
+    for (const auto &printings : info->getSets()) {
+        for (const auto &printing : printings) {
+            if (printing.getProperty("uuid") == providerId) {
                 CardInfoPtr cardFromSpecificSet = info->clone();
                 cardFromSpecificSet->setPixmapCacheKey(QLatin1String("card_") + QString(info->getName()) +
-                                                       QString("_") + QString(set.getProperty("uuid")));
+                                                       QString("_") + QString(printing.getProperty("uuid")));
                 return cardFromSpecificSet;
             }
         }
@@ -354,8 +354,8 @@ PrintingInfo CardDatabase::getSpecificPrinting(const QString &cardName, const QS
         return PrintingInfo(nullptr);
     }
 
-    for (const auto &cardInfoPerSetList : setMap) {
-        for (auto &cardInfoForSet : cardInfoPerSetList) {
+    for (const auto &printings : setMap) {
+        for (auto &cardInfoForSet : printings) {
             if (cardInfoForSet.getProperty("uuid") == providerId) {
                 return cardInfoForSet;
             }
@@ -383,8 +383,8 @@ PrintingInfo CardDatabase::getSpecificPrinting(const QString &cardName,
         return PrintingInfo(nullptr);
     }
 
-    for (const auto &cardInfoPerSetList : setMap) {
-        for (auto &cardInfoForSet : cardInfoPerSetList) {
+    for (const auto &printings : setMap) {
+        for (auto &cardInfoForSet : printings) {
             if (collectorNumber != nullptr) {
                 if (cardInfoForSet.getSet()->getShortName() == setShortName &&
                     cardInfoForSet.getProperty("num") == collectorNumber) {
@@ -431,8 +431,8 @@ PrintingInfo CardDatabase::getSetInfoForCard(const CardInfoPtr &_card)
         return PrintingInfo(nullptr);
     }
 
-    for (const auto &cardInfoPerSetList : setMap) {
-        for (const auto &cardInfoForSet : cardInfoPerSetList) {
+    for (const auto &printings : setMap) {
+        for (const auto &cardInfoForSet : printings) {
             if (QLatin1String("card_") + _card->getName() + QString("_") + cardInfoForSet.getProperty("uuid") ==
                 _card->getPixmapCacheKey()) {
                 return cardInfoForSet;

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -73,9 +73,9 @@ void CardDatabase::addCard(CardInfoPtr card)
     // if card already exists just add the new set property
     if (cards.contains(card->getName())) {
         CardInfoPtr sameCard = cards[card->getName()];
-        for (const auto &cardInfoPerSetList : card->getSets()) {
-            for (const PrintingInfo &set : cardInfoPerSetList) {
-                sameCard->addToSet(set.getPtr(), set);
+        for (const auto &printings : card->getSets()) {
+            for (const PrintingInfo &printing : printings) {
+                sameCard->addToSet(printing.getSet(), printing);
             }
         }
         return;
@@ -309,7 +309,7 @@ void CardDatabase::refreshPreferredPrintings()
     }
 }
 
-PrintingInfo CardDatabase::getPreferredSetForCard(const QString &cardName) const
+PrintingInfo CardDatabase::getPreferredPrinting(const QString &cardName) const
 {
     CardInfoPtr cardInfo = getCard(cardName);
     if (!cardInfo) {
@@ -322,27 +322,27 @@ PrintingInfo CardDatabase::getPreferredSetForCard(const QString &cardName) const
     }
 
     CardSetPtr preferredSet = nullptr;
-    PrintingInfo preferredCard;
+    PrintingInfo preferredPrinting;
     SetPriorityComparator comparator;
 
-    for (const auto &cardInfoPerSetList : setMap) {
-        for (auto &cardInfoForSet : cardInfoPerSetList) {
-            CardSetPtr currentSet = cardInfoForSet.getPtr();
+    for (const auto &printings : setMap) {
+        for (auto &printing : printings) {
+            CardSetPtr currentSet = printing.getSet();
             if (!preferredSet || comparator(currentSet, preferredSet)) {
                 preferredSet = currentSet;
-                preferredCard = cardInfoForSet;
+                preferredPrinting = printing;
             }
         }
     }
 
     if (preferredSet) {
-        return preferredCard;
+        return preferredPrinting;
     }
 
     return PrintingInfo(nullptr);
 }
 
-PrintingInfo CardDatabase::getSpecificSetForCard(const QString &cardName, const QString &providerId) const
+PrintingInfo CardDatabase::getSpecificPrinting(const QString &cardName, const QString &providerId) const
 {
     CardInfoPtr cardInfo = getCard(cardName);
     if (!cardInfo) {
@@ -363,15 +363,15 @@ PrintingInfo CardDatabase::getSpecificSetForCard(const QString &cardName, const 
     }
 
     if (providerId.isNull()) {
-        return getPreferredSetForCard(cardName);
+        return getPreferredPrinting(cardName);
     }
 
     return PrintingInfo(nullptr);
 }
 
-PrintingInfo CardDatabase::getSpecificSetForCard(const QString &cardName,
-                                                 const QString &setShortName,
-                                                    const QString &collectorNumber) const
+PrintingInfo CardDatabase::getSpecificPrinting(const QString &cardName,
+                                               const QString &setShortName,
+                                               const QString &collectorNumber) const
 {
     CardInfoPtr cardInfo = getCard(cardName);
     if (!cardInfo) {
@@ -386,12 +386,12 @@ PrintingInfo CardDatabase::getSpecificSetForCard(const QString &cardName,
     for (const auto &cardInfoPerSetList : setMap) {
         for (auto &cardInfoForSet : cardInfoPerSetList) {
             if (collectorNumber != nullptr) {
-                if (cardInfoForSet.getPtr()->getShortName() == setShortName &&
+                if (cardInfoForSet.getSet()->getShortName() == setShortName &&
                     cardInfoForSet.getProperty("num") == collectorNumber) {
                     return cardInfoForSet;
                 }
             } else {
-                if (cardInfoForSet.getPtr()->getShortName() == setShortName) {
+                if (cardInfoForSet.getSet()->getShortName() == setShortName) {
                     return cardInfoForSet;
                 }
             }
@@ -403,8 +403,8 @@ PrintingInfo CardDatabase::getSpecificSetForCard(const QString &cardName,
 
 QString CardDatabase::getPreferredPrintingProviderIdForCard(const QString &cardName)
 {
-    PrintingInfo preferredSetCardInfo = getPreferredSetForCard(cardName);
-    QString preferredPrintingProviderId = preferredSetCardInfo.getProperty(QString("uuid"));
+    PrintingInfo preferredPrinting = getPreferredPrinting(cardName);
+    QString preferredPrintingProviderId = preferredPrinting.getProperty(QString("uuid"));
     if (preferredPrintingProviderId.isEmpty()) {
         CardInfoPtr defaultCardInfo = getCard(cardName);
         if (defaultCardInfo.isNull()) {

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -316,7 +316,7 @@ PrintingInfo CardDatabase::getPreferredPrinting(const QString &cardName) const
         return PrintingInfo(nullptr);
     }
 
-    PrintingInfoPerSetMap setMap = cardInfo->getSets();
+    SetToPrintingsMap setMap = cardInfo->getSets();
     if (setMap.empty()) {
         return PrintingInfo(nullptr);
     }
@@ -349,7 +349,7 @@ PrintingInfo CardDatabase::getSpecificPrinting(const QString &cardName, const QS
         return PrintingInfo(nullptr);
     }
 
-    PrintingInfoPerSetMap setMap = cardInfo->getSets();
+    SetToPrintingsMap setMap = cardInfo->getSets();
     if (setMap.empty()) {
         return PrintingInfo(nullptr);
     }
@@ -378,7 +378,7 @@ PrintingInfo CardDatabase::getSpecificPrinting(const QString &cardName,
         return PrintingInfo(nullptr);
     }
 
-    PrintingInfoPerSetMap setMap = cardInfo->getSets();
+    SetToPrintingsMap setMap = cardInfo->getSets();
     if (setMap.empty()) {
         return PrintingInfo(nullptr);
     }
@@ -426,7 +426,7 @@ bool CardDatabase::isProviderIdForPreferredPrinting(const QString &cardName, con
 
 PrintingInfo CardDatabase::getSetInfoForCard(const CardInfoPtr &_card)
 {
-    const PrintingInfoPerSetMap &setMap = _card->getSets();
+    const SetToPrintingsMap &setMap = _card->getSets();
     if (setMap.empty()) {
         return PrintingInfo(nullptr);
     }

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -74,7 +74,7 @@ void CardDatabase::addCard(CardInfoPtr card)
     if (cards.contains(card->getName())) {
         CardInfoPtr sameCard = cards[card->getName()];
         for (const auto &cardInfoPerSetList : card->getSets()) {
-            for (const CardInfoPerSet &set : cardInfoPerSetList) {
+            for (const PrintingInfo &set : cardInfoPerSetList) {
                 sameCard->addToSet(set.getPtr(), set);
             }
         }
@@ -309,20 +309,20 @@ void CardDatabase::refreshPreferredPrintings()
     }
 }
 
-CardInfoPerSet CardDatabase::getPreferredSetForCard(const QString &cardName) const
+PrintingInfo CardDatabase::getPreferredSetForCard(const QString &cardName) const
 {
     CardInfoPtr cardInfo = getCard(cardName);
     if (!cardInfo) {
-        return CardInfoPerSet(nullptr);
+        return PrintingInfo(nullptr);
     }
 
-    CardInfoPerSetMap setMap = cardInfo->getSets();
+    PrintingInfoPerSetMap setMap = cardInfo->getSets();
     if (setMap.empty()) {
-        return CardInfoPerSet(nullptr);
+        return PrintingInfo(nullptr);
     }
 
     CardSetPtr preferredSet = nullptr;
-    CardInfoPerSet preferredCard;
+    PrintingInfo preferredCard;
     SetPriorityComparator comparator;
 
     for (const auto &cardInfoPerSetList : setMap) {
@@ -339,19 +339,19 @@ CardInfoPerSet CardDatabase::getPreferredSetForCard(const QString &cardName) con
         return preferredCard;
     }
 
-    return CardInfoPerSet(nullptr);
+    return PrintingInfo(nullptr);
 }
 
-CardInfoPerSet CardDatabase::getSpecificSetForCard(const QString &cardName, const QString &providerId) const
+PrintingInfo CardDatabase::getSpecificSetForCard(const QString &cardName, const QString &providerId) const
 {
     CardInfoPtr cardInfo = getCard(cardName);
     if (!cardInfo) {
-        return CardInfoPerSet(nullptr);
+        return PrintingInfo(nullptr);
     }
 
-    CardInfoPerSetMap setMap = cardInfo->getSets();
+    PrintingInfoPerSetMap setMap = cardInfo->getSets();
     if (setMap.empty()) {
-        return CardInfoPerSet(nullptr);
+        return PrintingInfo(nullptr);
     }
 
     for (const auto &cardInfoPerSetList : setMap) {
@@ -366,21 +366,21 @@ CardInfoPerSet CardDatabase::getSpecificSetForCard(const QString &cardName, cons
         return getPreferredSetForCard(cardName);
     }
 
-    return CardInfoPerSet(nullptr);
+    return PrintingInfo(nullptr);
 }
 
-CardInfoPerSet CardDatabase::getSpecificSetForCard(const QString &cardName,
-                                                   const QString &setShortName,
-                                                   const QString &collectorNumber) const
+PrintingInfo CardDatabase::getSpecificSetForCard(const QString &cardName,
+                                                 const QString &setShortName,
+                                                    const QString &collectorNumber) const
 {
     CardInfoPtr cardInfo = getCard(cardName);
     if (!cardInfo) {
-        return CardInfoPerSet(nullptr);
+        return PrintingInfo(nullptr);
     }
 
-    CardInfoPerSetMap setMap = cardInfo->getSets();
+    PrintingInfoPerSetMap setMap = cardInfo->getSets();
     if (setMap.empty()) {
-        return CardInfoPerSet(nullptr);
+        return PrintingInfo(nullptr);
     }
 
     for (const auto &cardInfoPerSetList : setMap) {
@@ -398,12 +398,12 @@ CardInfoPerSet CardDatabase::getSpecificSetForCard(const QString &cardName,
         }
     }
 
-    return CardInfoPerSet(nullptr);
+    return PrintingInfo(nullptr);
 }
 
 QString CardDatabase::getPreferredPrintingProviderIdForCard(const QString &cardName)
 {
-    CardInfoPerSet preferredSetCardInfo = getPreferredSetForCard(cardName);
+    PrintingInfo preferredSetCardInfo = getPreferredSetForCard(cardName);
     QString preferredPrintingProviderId = preferredSetCardInfo.getProperty(QString("uuid"));
     if (preferredPrintingProviderId.isEmpty()) {
         CardInfoPtr defaultCardInfo = getCard(cardName);
@@ -424,11 +424,11 @@ bool CardDatabase::isProviderIdForPreferredPrinting(const QString &cardName, con
     return providerId == getPreferredPrintingProviderIdForCard(cardName);
 }
 
-CardInfoPerSet CardDatabase::getSetInfoForCard(const CardInfoPtr &_card)
+PrintingInfo CardDatabase::getSetInfoForCard(const CardInfoPtr &_card)
 {
-    const CardInfoPerSetMap &setMap = _card->getSets();
+    const PrintingInfoPerSetMap &setMap = _card->getSets();
     if (setMap.empty()) {
-        return CardInfoPerSet(nullptr);
+        return PrintingInfo(nullptr);
     }
 
     for (const auto &cardInfoPerSetList : setMap) {
@@ -440,7 +440,7 @@ CardInfoPerSet CardDatabase::getSetInfoForCard(const CardInfoPtr &_card)
         }
     }
 
-    return CardInfoPerSet(nullptr);
+    return PrintingInfo(nullptr);
 }
 
 void CardDatabase::refreshCachedReverseRelatedCards()

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -69,9 +69,9 @@ public:
     [[nodiscard]] QList<CardInfoPtr> getCards(const QStringList &cardNames) const;
     QList<CardInfoPtr> getCardsByNameAndProviderId(const QMap<QString, QString> &cardNames) const;
     [[nodiscard]] CardInfoPtr getCardByNameAndProviderId(const QString &cardName, const QString &providerId) const;
-    [[nodiscard]] CardInfoPerSet getPreferredSetForCard(const QString &cardName) const;
-    [[nodiscard]] CardInfoPerSet getSpecificSetForCard(const QString &cardName, const QString &providerId) const;
-    CardInfoPerSet
+    [[nodiscard]] PrintingInfo getPreferredSetForCard(const QString &cardName) const;
+    [[nodiscard]] PrintingInfo getSpecificSetForCard(const QString &cardName, const QString &providerId) const;
+    PrintingInfo
     getSpecificSetForCard(const QString &cardName, const QString &setShortName, const QString &collectorNumber) const;
     QString getPreferredPrintingProviderIdForCard(const QString &cardName);
     [[nodiscard]] CardInfoPtr guessCard(const QString &cardName, const QString &providerId = QString()) const;
@@ -84,7 +84,7 @@ public:
 
     CardSetPtr getSet(const QString &setName);
     bool isProviderIdForPreferredPrinting(const QString &cardName, const QString &providerId);
-    static CardInfoPerSet getSetInfoForCard(const CardInfoPtr &_card);
+    static PrintingInfo getSetInfoForCard(const CardInfoPtr &_card);
     const CardNameMap &getCardList() const
     {
         return cards;

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -69,10 +69,10 @@ public:
     [[nodiscard]] QList<CardInfoPtr> getCards(const QStringList &cardNames) const;
     QList<CardInfoPtr> getCardsByNameAndProviderId(const QMap<QString, QString> &cardNames) const;
     [[nodiscard]] CardInfoPtr getCardByNameAndProviderId(const QString &cardName, const QString &providerId) const;
-    [[nodiscard]] PrintingInfo getPreferredSetForCard(const QString &cardName) const;
-    [[nodiscard]] PrintingInfo getSpecificSetForCard(const QString &cardName, const QString &providerId) const;
+    [[nodiscard]] PrintingInfo getPreferredPrinting(const QString &cardName) const;
+    [[nodiscard]] PrintingInfo getSpecificPrinting(const QString &cardName, const QString &providerId) const;
     PrintingInfo
-    getSpecificSetForCard(const QString &cardName, const QString &setShortName, const QString &collectorNumber) const;
+    getSpecificPrinting(const QString &cardName, const QString &setShortName, const QString &collectorNumber) const;
     QString getPreferredPrintingProviderIdForCard(const QString &cardName);
     [[nodiscard]] CardInfoPtr guessCard(const QString &cardName, const QString &providerId = QString()) const;
 

--- a/cockatrice/src/game/cards/card_database_model.cpp
+++ b/cockatrice/src/game/cards/card_database_model.cpp
@@ -100,7 +100,7 @@ bool CardDatabaseModel::checkCardHasAtLeastOneEnabledSet(CardInfoPtr card)
 
     for (const auto &cardInfoPerSetList : card->getSets()) {
         for (const auto &set : cardInfoPerSetList) {
-            if (set.getPtr()->getEnabled())
+            if (set.getSet()->getEnabled())
                 return true;
         }
     }

--- a/cockatrice/src/game/cards/card_database_model.cpp
+++ b/cockatrice/src/game/cards/card_database_model.cpp
@@ -98,9 +98,9 @@ bool CardDatabaseModel::checkCardHasAtLeastOneEnabledSet(CardInfoPtr card)
     if (!showOnlyCardsFromEnabledSets)
         return true;
 
-    for (const auto &cardInfoPerSetList : card->getSets()) {
-        for (const auto &set : cardInfoPerSetList) {
-            if (set.getSet()->getEnabled())
+    for (const auto &printings : card->getSets()) {
+        for (const auto &printing : printings) {
+            if (printing.getSet()->getEnabled())
                 return true;
         }
     }

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
@@ -160,7 +160,7 @@ void CockatriceXml3Parser::loadCardsFromXml(QXmlStreamReader &xml)
             QVariantHash properties = QVariantHash();
             QString colors = QString("");
             QList<CardRelation *> relatedCards, reverseRelatedCards;
-            auto _sets = PrintingInfoPerSetMap();
+            auto _sets = SetToPrintingsMap();
             int tableRow = 0;
             bool cipt = false;
             bool landscapeOrientation = false;
@@ -343,8 +343,8 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfoPtr &in
     }
 
     // sets
-    const PrintingInfoPerSetMap perSetMap = info->getSets();
-    for (const auto &printings : perSetMap) {
+    const SetToPrintingsMap setMap = info->getSets();
+    for (const auto &printings : setMap) {
         for (const PrintingInfo &set : printings) {
             xml.writeStartElement("set");
             xml.writeAttribute("rarity", set.getProperty("rarity"));

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
@@ -343,9 +343,9 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfoPtr &in
     }
 
     // sets
-    const PrintingInfoPerSetMap sets = info->getSets();
-    for (const auto &cardInfoPerSetList : sets) {
-        for (const PrintingInfo &set : cardInfoPerSetList) {
+    const PrintingInfoPerSetMap perSetMap = info->getSets();
+    for (const auto &printings : perSetMap) {
+        for (const PrintingInfo &set : printings) {
             xml.writeStartElement("set");
             xml.writeAttribute("rarity", set.getProperty("rarity"));
             xml.writeAttribute("muId", set.getProperty("muid"));
@@ -361,7 +361,7 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfoPtr &in
                 xml.writeAttribute("picURL", tmpString);
             }
 
-            xml.writeCharacters(set.getPtr()->getShortName());
+            xml.writeCharacters(set.getSet()->getShortName());
             xml.writeEndElement();
         }
     }

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
@@ -160,7 +160,7 @@ void CockatriceXml3Parser::loadCardsFromXml(QXmlStreamReader &xml)
             QVariantHash properties = QVariantHash();
             QString colors = QString("");
             QList<CardRelation *> relatedCards, reverseRelatedCards;
-            auto _sets = CardInfoPerSetMap();
+            auto _sets = PrintingInfoPerSetMap();
             int tableRow = 0;
             bool cipt = false;
             bool landscapeOrientation = false;
@@ -209,7 +209,7 @@ void CockatriceXml3Parser::loadCardsFromXml(QXmlStreamReader &xml)
                     // NOTE: attributes must be read before readElementText()
                     QXmlStreamAttributes attrs = xml.attributes();
                     QString setName = xml.readElementText(QXmlStreamReader::IncludeChildElements);
-                    CardInfoPerSet setInfo(internalAddSet(setName));
+                    PrintingInfo setInfo(internalAddSet(setName));
                     if (attrs.hasAttribute("muId")) {
                         setInfo.setProperty("muid", attrs.value("muId").toString());
                     }
@@ -343,9 +343,9 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfoPtr &in
     }
 
     // sets
-    const CardInfoPerSetMap sets = info->getSets();
+    const PrintingInfoPerSetMap sets = info->getSets();
     for (const auto &cardInfoPerSetList : sets) {
-        for (const CardInfoPerSet &set : cardInfoPerSetList) {
+        for (const PrintingInfo &set : cardInfoPerSetList) {
             xml.writeStartElement("set");
             xml.writeAttribute("rarity", set.getProperty("rarity"));
             xml.writeAttribute("muId", set.getProperty("muid"));

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
@@ -144,7 +144,7 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
             QString text = QString("");
             QVariantHash properties = QVariantHash();
             QList<CardRelation *> relatedCards, reverseRelatedCards;
-            auto _sets = PrintingInfoPerSetMap();
+            auto _sets = SetToPrintingsMap();
             int tableRow = 0;
             bool cipt = false;
             bool landscapeOrientation = false;

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
@@ -184,12 +184,12 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
                     QString setName = xml.readElementText(QXmlStreamReader::IncludeChildElements);
                     auto set = internalAddSet(setName);
                     if (set->getEnabled()) {
-                        PrintingInfo setInfo(set);
+                        PrintingInfo printingInfo(set);
                         for (QXmlStreamAttribute attr : attrs) {
                             QString attrName = attr.name().toString();
                             if (attrName == "picURL")
                                 attrName = "picurl";
-                            setInfo.setProperty(attrName, attr.value().toString());
+                            printingInfo.setProperty(attrName, attr.value().toString());
                         }
 
                         // This is very much a hack and not the right place to
@@ -199,8 +199,8 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
                         // However, this is also true of the `set->getEnabled()`
                         // check above (which is currently bugged as well), so
                         // we'll fix both at the same time.
-                        if (includeRebalancedCards || setInfo.getProperty("isRebalanced") != "true") {
-                            _sets[setName].append(setInfo);
+                        if (includeRebalancedCards || printingInfo.getProperty("isRebalanced") != "true") {
+                            _sets[setName].append(printingInfo);
                         }
                     }
                     // related cards
@@ -309,14 +309,14 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfoPtr &in
     xml.writeEndElement();
 
     // sets
-    for (const auto &cardInfoPerSetList : info->getSets()) {
-        for (const PrintingInfo &set : cardInfoPerSetList) {
+    for (const auto &printings : info->getSets()) {
+        for (const PrintingInfo &set : printings) {
             xml.writeStartElement("set");
             for (const QString &propName : set.getProperties()) {
                 xml.writeAttribute(propName, set.getProperty(propName));
             }
 
-            xml.writeCharacters(set.getPtr()->getShortName());
+            xml.writeCharacters(set.getSet()->getShortName());
             xml.writeEndElement();
         }
     }

--- a/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
+++ b/cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
@@ -144,7 +144,7 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
             QString text = QString("");
             QVariantHash properties = QVariantHash();
             QList<CardRelation *> relatedCards, reverseRelatedCards;
-            auto _sets = CardInfoPerSetMap();
+            auto _sets = PrintingInfoPerSetMap();
             int tableRow = 0;
             bool cipt = false;
             bool landscapeOrientation = false;
@@ -184,7 +184,7 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
                     QString setName = xml.readElementText(QXmlStreamReader::IncludeChildElements);
                     auto set = internalAddSet(setName);
                     if (set->getEnabled()) {
-                        CardInfoPerSet setInfo(set);
+                        PrintingInfo setInfo(set);
                         for (QXmlStreamAttribute attr : attrs) {
                             QString attrName = attr.name().toString();
                             if (attrName == "picURL")
@@ -310,7 +310,7 @@ static QXmlStreamWriter &operator<<(QXmlStreamWriter &xml, const CardInfoPtr &in
 
     // sets
     for (const auto &cardInfoPerSetList : info->getSets()) {
-        for (const CardInfoPerSet &set : cardInfoPerSetList) {
+        for (const PrintingInfo &set : cardInfoPerSetList) {
             xml.writeStartElement("set");
             for (const QString &propName : set.getProperties()) {
                 xml.writeAttribute(propName, set.getProperty(propName));

--- a/cockatrice/src/game/cards/card_info.cpp
+++ b/cockatrice/src/game/cards/card_info.cpp
@@ -215,7 +215,7 @@ void SetList::defaultSort()
     });
 }
 
-CardInfoPerSet::CardInfoPerSet(const CardSetPtr &_set) : set(_set)
+PrintingInfo::PrintingInfo(const CardSetPtr &_set) : set(_set)
 {
 }
 
@@ -225,7 +225,7 @@ CardInfo::CardInfo(const QString &_name,
                    QVariantHash _properties,
                    const QList<CardRelation *> &_relatedCards,
                    const QList<CardRelation *> &_reverseRelatedCards,
-                   CardInfoPerSetMap _sets,
+                   PrintingInfoPerSetMap _sets,
                    bool _cipt,
                    bool _landscapeOrientation,
                    int _tableRow,
@@ -248,7 +248,7 @@ CardInfo::~CardInfo()
 CardInfoPtr CardInfo::newInstance(const QString &_name)
 {
     return newInstance(_name, QString(), false, QVariantHash(), QList<CardRelation *>(), QList<CardRelation *>(),
-                       CardInfoPerSetMap(), false, false, 0, false);
+                       PrintingInfoPerSetMap(), false, false, 0, false);
 }
 
 CardInfoPtr CardInfo::newInstance(const QString &_name,
@@ -257,7 +257,7 @@ CardInfoPtr CardInfo::newInstance(const QString &_name,
                                   QVariantHash _properties,
                                   const QList<CardRelation *> &_relatedCards,
                                   const QList<CardRelation *> &_reverseRelatedCards,
-                                  CardInfoPerSetMap _sets,
+                                  PrintingInfoPerSetMap _sets,
                                   bool _cipt,
                                   bool _landscapeOrientation,
                                   int _tableRow,
@@ -268,7 +268,7 @@ CardInfoPtr CardInfo::newInstance(const QString &_name,
     ptr->setSmartPointer(ptr);
 
     for (const auto &cardInfoPerSetList : _sets) {
-        for (const CardInfoPerSet &set : cardInfoPerSetList) {
+        for (const PrintingInfo &set : cardInfoPerSetList) {
             set.getPtr()->append(ptr);
             break;
         }
@@ -289,7 +289,7 @@ QString CardInfo::getCorrectedName() const
     return result.remove(rmrx).replace(spacerx, space);
 }
 
-void CardInfo::addToSet(const CardSetPtr &_set, const CardInfoPerSet _info)
+void CardInfo::addToSet(const CardSetPtr &_set, const PrintingInfo _info)
 {
     if (!_set->contains(smartThis)) {
         _set->append(smartThis);

--- a/cockatrice/src/game/cards/card_info.cpp
+++ b/cockatrice/src/game/cards/card_info.cpp
@@ -231,7 +231,7 @@ CardInfo::CardInfo(const QString &_name,
                    int _tableRow,
                    bool _upsideDownArt)
     : name(_name), text(_text), isToken(_isToken), properties(std::move(_properties)), relatedCards(_relatedCards),
-      reverseRelatedCards(_reverseRelatedCards), sets(std::move(_sets)), cipt(_cipt),
+      reverseRelatedCards(_reverseRelatedCards), setsToPrintings(std::move(_sets)), cipt(_cipt),
       landscapeOrientation(_landscapeOrientation), tableRow(_tableRow), upsideDownArt(_upsideDownArt)
 {
     pixmapCacheKey = QLatin1String("card_") + name;
@@ -294,8 +294,8 @@ void CardInfo::addToSet(const CardSetPtr &_set, const PrintingInfo _info)
     if (!_set->contains(smartThis)) {
         _set->append(smartThis);
     }
-    if (!sets[_set->getShortName()].contains(_info)) {
-        sets[_set->getShortName()].append(_info);
+    if (!setsToPrintings[_set->getShortName()].contains(_info)) {
+        setsToPrintings[_set->getShortName()].append(_info);
     }
 
     refreshCachedSetNames();
@@ -316,7 +316,7 @@ void CardInfo::refreshCachedSetNames()
 {
     QStringList setList;
     // update the cached list of set names
-    for (const auto &printings : sets) {
+    for (const auto &printings : setsToPrintings) {
         for (const auto &printing : printings) {
             if (printing.getSet()->getEnabled()) {
                 setList << printing.getSet()->getShortName();

--- a/cockatrice/src/game/cards/card_info.cpp
+++ b/cockatrice/src/game/cards/card_info.cpp
@@ -225,7 +225,7 @@ CardInfo::CardInfo(const QString &_name,
                    QVariantHash _properties,
                    const QList<CardRelation *> &_relatedCards,
                    const QList<CardRelation *> &_reverseRelatedCards,
-                   PrintingInfoPerSetMap _sets,
+                   SetToPrintingsMap _sets,
                    bool _cipt,
                    bool _landscapeOrientation,
                    int _tableRow,
@@ -248,7 +248,7 @@ CardInfo::~CardInfo()
 CardInfoPtr CardInfo::newInstance(const QString &_name)
 {
     return newInstance(_name, QString(), false, QVariantHash(), QList<CardRelation *>(), QList<CardRelation *>(),
-                       PrintingInfoPerSetMap(), false, false, 0, false);
+                       SetToPrintingsMap(), false, false, 0, false);
 }
 
 CardInfoPtr CardInfo::newInstance(const QString &_name,
@@ -257,7 +257,7 @@ CardInfoPtr CardInfo::newInstance(const QString &_name,
                                   QVariantHash _properties,
                                   const QList<CardRelation *> &_relatedCards,
                                   const QList<CardRelation *> &_reverseRelatedCards,
-                                  PrintingInfoPerSetMap _sets,
+                                  SetToPrintingsMap _sets,
                                   bool _cipt,
                                   bool _landscapeOrientation,
                                   int _tableRow,

--- a/cockatrice/src/game/cards/card_info.cpp
+++ b/cockatrice/src/game/cards/card_info.cpp
@@ -316,10 +316,10 @@ void CardInfo::refreshCachedSetNames()
 {
     QStringList setList;
     // update the cached list of set names
-    for (const auto &cardInfoPerSetList : sets) {
-        for (const auto &set : cardInfoPerSetList) {
-            if (set.getSet()->getEnabled()) {
-                setList << set.getSet()->getShortName();
+    for (const auto &printings : sets) {
+        for (const auto &printing : printings) {
+            if (printing.getSet()->getEnabled()) {
+                setList << printing.getSet()->getShortName();
             }
             break;
         }

--- a/cockatrice/src/game/cards/card_info.cpp
+++ b/cockatrice/src/game/cards/card_info.cpp
@@ -267,9 +267,9 @@ CardInfoPtr CardInfo::newInstance(const QString &_name,
                                  _sets, _cipt, _landscapeOrientation, _tableRow, _upsideDownArt));
     ptr->setSmartPointer(ptr);
 
-    for (const auto &cardInfoPerSetList : _sets) {
-        for (const PrintingInfo &set : cardInfoPerSetList) {
-            set.getPtr()->append(ptr);
+    for (const auto &printings : _sets) {
+        for (const PrintingInfo &printing : printings) {
+            printing.getSet()->append(ptr);
             break;
         }
     }
@@ -318,8 +318,8 @@ void CardInfo::refreshCachedSetNames()
     // update the cached list of set names
     for (const auto &cardInfoPerSetList : sets) {
         for (const auto &set : cardInfoPerSetList) {
-            if (set.getPtr()->getEnabled()) {
-                setList << set.getPtr()->getShortName();
+            if (set.getSet()->getEnabled()) {
+                setList << set.getSet()->getShortName();
             }
             break;
         }

--- a/cockatrice/src/game/cards/card_info.h
+++ b/cockatrice/src/game/cards/card_info.h
@@ -22,7 +22,7 @@ class ICardDatabaseParser;
 
 typedef QSharedPointer<CardInfo> CardInfoPtr;
 typedef QSharedPointer<CardSet> CardSetPtr;
-typedef QMap<QString, QList<PrintingInfo>> PrintingInfoPerSetMap;
+typedef QMap<QString, QList<PrintingInfo>> SetToPrintingsMap;
 
 typedef QHash<QString, CardInfoPtr> CardNameMap;
 typedef QHash<QString, CardSetPtr> SetNameMap;
@@ -204,7 +204,7 @@ private:
     // the cards thare are reverse-related to me
     QList<CardRelation *> reverseRelatedCardsToMe;
     // card sets
-    PrintingInfoPerSetMap sets;
+    SetToPrintingsMap sets;
     // cached set names
     QString setsNames;
     // positioning properties; used by UI
@@ -220,7 +220,7 @@ public:
                       QVariantHash _properties,
                       const QList<CardRelation *> &_relatedCards,
                       const QList<CardRelation *> &_reverseRelatedCards,
-                      PrintingInfoPerSetMap _sets,
+                      SetToPrintingsMap _sets,
                       bool _cipt,
                       bool _landscapeOrientation,
                       int _tableRow,
@@ -243,7 +243,7 @@ public:
                                    QVariantHash _properties,
                                    const QList<CardRelation *> &_relatedCards,
                                    const QList<CardRelation *> &_reverseRelatedCards,
-                                   PrintingInfoPerSetMap _sets,
+                                   SetToPrintingsMap _sets,
                                    bool _cipt,
                                    bool _landscapeOrientation,
                                    int _tableRow,
@@ -311,7 +311,7 @@ public:
     {
         return properties.contains(propertyName);
     }
-    const PrintingInfoPerSetMap &getSets() const
+    const SetToPrintingsMap &getSets() const
     {
         return sets;
     }

--- a/cockatrice/src/game/cards/card_info.h
+++ b/cockatrice/src/game/cards/card_info.h
@@ -204,7 +204,7 @@ private:
     // the cards thare are reverse-related to me
     QList<CardRelation *> reverseRelatedCardsToMe;
     // card sets
-    SetToPrintingsMap sets;
+    SetToPrintingsMap setsToPrintings;
     // cached set names
     QString setsNames;
     // positioning properties; used by UI
@@ -229,7 +229,7 @@ public:
         : QObject(other.parent()), name(other.name), simpleName(other.simpleName), pixmapCacheKey(other.pixmapCacheKey),
           text(other.text), isToken(other.isToken), properties(other.properties), relatedCards(other.relatedCards),
           reverseRelatedCards(other.reverseRelatedCards), reverseRelatedCardsToMe(other.reverseRelatedCardsToMe),
-          sets(other.sets), setsNames(other.setsNames), cipt(other.cipt),
+          setsToPrintings(other.setsToPrintings), setsNames(other.setsNames), cipt(other.cipt),
           landscapeOrientation(other.landscapeOrientation), tableRow(other.tableRow), upsideDownArt(other.upsideDownArt)
     {
     }
@@ -313,7 +313,7 @@ public:
     }
     const SetToPrintingsMap &getSets() const
     {
-        return sets;
+        return setsToPrintings;
     }
     const QString &getSetsNames() const
     {
@@ -321,17 +321,17 @@ public:
     }
     QString getSetProperty(const QString &setName, const QString &propertyName) const
     {
-        if (!sets.contains(setName))
+        if (!setsToPrintings.contains(setName))
             return "";
 
-        for (const auto &set : sets[setName]) {
+        for (const auto &set : setsToPrintings[setName]) {
             if (QLatin1String("card_") + this->getName() + QString("_") + QString(set.getProperty("uuid")) ==
                 this->getPixmapCacheKey()) {
                 return set.getProperty(propertyName);
             }
         }
 
-        return sets[setName][0].getProperty(propertyName);
+        return setsToPrintings[setName][0].getProperty(propertyName);
     }
 
     // related cards

--- a/cockatrice/src/game/cards/card_info.h
+++ b/cockatrice/src/game/cards/card_info.h
@@ -162,7 +162,7 @@ private:
     QVariantHash properties;
 
 public:
-    CardSetPtr getPtr() const
+    CardSetPtr getSet() const
     {
         return set;
     }

--- a/cockatrice/src/game/cards/card_info.h
+++ b/cockatrice/src/game/cards/card_info.h
@@ -160,15 +160,15 @@ private:
     QVariantHash properties;
 
 public:
-    const CardSetPtr getPtr() const
+    CardSetPtr getPtr() const
     {
         return set;
     }
-    const QStringList getProperties() const
+    QStringList getProperties() const
     {
         return properties.keys();
     }
-    const QString getProperty(const QString &propertyName) const
+    QString getProperty(const QString &propertyName) const
     {
         return properties.value(propertyName).toString();
     }
@@ -292,11 +292,11 @@ public:
     {
         return isToken;
     }
-    const QStringList getProperties() const
+    QStringList getProperties() const
     {
         return properties.keys();
     }
-    const QString getProperty(const QString &propertyName) const
+    QString getProperty(const QString &propertyName) const
     {
         return properties.value(propertyName).toString();
     }
@@ -317,7 +317,7 @@ public:
     {
         return setsNames;
     }
-    const QString getSetProperty(const QString &setName, const QString &propertyName) const
+    QString getSetProperty(const QString &setName, const QString &propertyName) const
     {
         if (!sets.contains(setName))
             return "";
@@ -345,7 +345,7 @@ public:
     {
         return reverseRelatedCardsToMe;
     }
-    const QList<CardRelation *> getAllRelatedCards() const
+    QList<CardRelation *> getAllRelatedCards() const
     {
         QList<CardRelation *> result;
         result.append(getRelatedCards());

--- a/cockatrice/src/game/cards/card_info.h
+++ b/cockatrice/src/game/cards/card_info.h
@@ -20,7 +20,6 @@ class CardSet;
 class CardRelation;
 class ICardDatabaseParser;
 
-typedef QMap<QString, QString> QStringMap;
 typedef QSharedPointer<CardInfo> CardInfoPtr;
 typedef QSharedPointer<CardSet> CardSetPtr;
 typedef QMap<QString, QList<CardInfoPerSet>> CardInfoPerSetMap;

--- a/cockatrice/src/game/cards/card_info.h
+++ b/cockatrice/src/game/cards/card_info.h
@@ -15,14 +15,14 @@
 inline Q_LOGGING_CATEGORY(CardInfoLog, "card_info");
 
 class CardInfo;
-class CardInfoPerSet;
+class PrintingInfo;
 class CardSet;
 class CardRelation;
 class ICardDatabaseParser;
 
 typedef QSharedPointer<CardInfo> CardInfoPtr;
 typedef QSharedPointer<CardSet> CardSetPtr;
-typedef QMap<QString, QList<CardInfoPerSet>> CardInfoPerSetMap;
+typedef QMap<QString, QList<PrintingInfo>> PrintingInfoPerSetMap;
 
 typedef QHash<QString, CardInfoPtr> CardNameMap;
 typedef QHash<QString, CardSetPtr> SetNameMap;
@@ -142,20 +142,23 @@ public:
     void defaultSort();
 };
 
-class CardInfoPerSet
+/**
+ * Info relating to a specific printing for a card.
+ */
+class PrintingInfo
 {
 public:
-    explicit CardInfoPerSet(const CardSetPtr &_set = QSharedPointer<CardSet>(nullptr));
-    ~CardInfoPerSet() = default;
+    explicit PrintingInfo(const CardSetPtr &_set = QSharedPointer<CardSet>(nullptr));
+    ~PrintingInfo() = default;
 
-    bool operator==(const CardInfoPerSet &other) const
+    bool operator==(const PrintingInfo &other) const
     {
         return this->set == other.set && this->properties == other.properties;
     }
 
 private:
     CardSetPtr set;
-    // per-set card properties;
+    // per-printing card properties;
     QVariantHash properties;
 
 public:
@@ -201,7 +204,7 @@ private:
     // the cards thare are reverse-related to me
     QList<CardRelation *> reverseRelatedCardsToMe;
     // card sets
-    CardInfoPerSetMap sets;
+    PrintingInfoPerSetMap sets;
     // cached set names
     QString setsNames;
     // positioning properties; used by UI
@@ -217,7 +220,7 @@ public:
                       QVariantHash _properties,
                       const QList<CardRelation *> &_relatedCards,
                       const QList<CardRelation *> &_reverseRelatedCards,
-                      CardInfoPerSetMap _sets,
+                      PrintingInfoPerSetMap _sets,
                       bool _cipt,
                       bool _landscapeOrientation,
                       int _tableRow,
@@ -240,7 +243,7 @@ public:
                                    QVariantHash _properties,
                                    const QList<CardRelation *> &_relatedCards,
                                    const QList<CardRelation *> &_reverseRelatedCards,
-                                   CardInfoPerSetMap _sets,
+                                   PrintingInfoPerSetMap _sets,
                                    bool _cipt,
                                    bool _landscapeOrientation,
                                    int _tableRow,
@@ -308,7 +311,7 @@ public:
     {
         return properties.contains(propertyName);
     }
-    const CardInfoPerSetMap &getSets() const
+    const PrintingInfoPerSetMap &getSets() const
     {
         return sets;
     }
@@ -398,7 +401,7 @@ public:
         return getSetProperty(set, "picurl");
     }
     QString getCorrectedName() const;
-    void addToSet(const CardSetPtr &_set, CardInfoPerSet _info = CardInfoPerSet());
+    void addToSet(const CardSetPtr &_set, PrintingInfo _info = PrintingInfo());
     void combineLegalities(const QVariantHash &props);
     void emitPixmapUpdated()
     {

--- a/cockatrice/src/game/filters/filter_string.cpp
+++ b/cockatrice/src/game/filters/filter_string.cpp
@@ -130,9 +130,9 @@ static void setupParserRules()
         const auto rarity = std::any_cast<QString>(sv[0]);
         return [=](const CardData &x) -> bool {
             QList<PrintingInfo> infos;
-            for (const auto &setsValue : x->getSets().values()) {
-                for (const auto &cardInfoPerSet : setsValue) {
-                    infos.append(cardInfoPerSet);
+            for (const auto &printings : x->getSets()) {
+                for (const auto &printing : printings) {
+                    infos.append(printing);
                 }
             }
 

--- a/cockatrice/src/game/filters/filter_string.cpp
+++ b/cockatrice/src/game/filters/filter_string.cpp
@@ -129,14 +129,14 @@ static void setupParserRules()
     search["RarityQuery"] = [](const peg::SemanticValues &sv) -> Filter {
         const auto rarity = std::any_cast<QString>(sv[0]);
         return [=](const CardData &x) -> bool {
-            QList<CardInfoPerSet> infos;
+            QList<PrintingInfo> infos;
             for (const auto &setsValue : x->getSets().values()) {
                 for (const auto &cardInfoPerSet : setsValue) {
                     infos.append(cardInfoPerSet);
                 }
             }
 
-            auto matchesRarity = [&rarity](const CardInfoPerSet &info) { return rarity == info.getProperty("rarity"); };
+            auto matchesRarity = [&rarity](const PrintingInfo &info) { return rarity == info.getProperty("rarity"); };
             return std::any_of(infos.begin(), infos.end(), matchesRarity);
         };
     };

--- a/cockatrice/src/game/filters/filter_tree.cpp
+++ b/cockatrice/src/game/filters/filter_tree.cpp
@@ -217,8 +217,8 @@ bool FilterItem::acceptSet(const CardInfoPtr info) const
     bool status = false;
     for (const auto &cardInfoPerSetList : info->getSets()) {
         for (const auto &set : cardInfoPerSetList) {
-            if (set.getPtr()->getShortName().compare(term, Qt::CaseInsensitive) == 0 ||
-                set.getPtr()->getLongName().compare(term, Qt::CaseInsensitive) == 0) {
+            if (set.getSet()->getShortName().compare(term, Qt::CaseInsensitive) == 0 ||
+                set.getSet()->getLongName().compare(term, Qt::CaseInsensitive) == 0) {
                 status = true;
                 break;
             }

--- a/cockatrice/src/game/filters/filter_tree.cpp
+++ b/cockatrice/src/game/filters/filter_tree.cpp
@@ -215,8 +215,8 @@ bool FilterItem::acceptText(const CardInfoPtr info) const
 bool FilterItem::acceptSet(const CardInfoPtr info) const
 {
     bool status = false;
-    for (const auto &cardInfoPerSetList : info->getSets()) {
-        for (const auto &set : cardInfoPerSetList) {
+    for (const auto &printings : info->getSets()) {
+        for (const auto &set : printings) {
             if (set.getSet()->getShortName().compare(term, Qt::CaseInsensitive) == 0 ||
                 set.getSet()->getLongName().compare(term, Qt::CaseInsensitive) == 0) {
                 status = true;
@@ -350,9 +350,9 @@ bool FilterItem::acceptRarity(const CardInfoPtr info) const
         }
     }
 
-    for (const auto &cardInfoPerSetList : info->getSets()) {
-        for (const auto &set : cardInfoPerSetList) {
-            if (set.getProperty("rarity").compare(converted_term, Qt::CaseInsensitive) == 0) {
+    for (const auto &printings : info->getSets()) {
+        for (const auto &printing : printings) {
+            if (printing.getProperty("rarity").compare(converted_term, Qt::CaseInsensitive) == 0) {
                 return true;
             }
         }

--- a/cockatrice/src/utility/card_set_comparator.h
+++ b/cockatrice/src/utility/card_set_comparator.h
@@ -47,7 +47,7 @@ public:
      * Enabled sets have priority over disabled sets
      * Both groups follow the user-defined order
      */
-    inline bool operator()(const CardInfoPerSet &a, const CardInfoPerSet &b) const
+    inline bool operator()(const PrintingInfo &a, const PrintingInfo &b) const
     {
         if (a.getPtr()->getEnabled()) {
             return !b.getPtr()->getEnabled() || a.getPtr()->getSortKey() < b.getPtr()->getSortKey();

--- a/cockatrice/src/utility/card_set_comparator.h
+++ b/cockatrice/src/utility/card_set_comparator.h
@@ -49,10 +49,10 @@ public:
      */
     inline bool operator()(const PrintingInfo &a, const PrintingInfo &b) const
     {
-        if (a.getPtr()->getEnabled()) {
-            return !b.getPtr()->getEnabled() || a.getPtr()->getSortKey() < b.getPtr()->getSortKey();
+        if (a.getSet()->getEnabled()) {
+            return !b.getSet()->getEnabled() || a.getSet()->getSortKey() < b.getSet()->getSortKey();
         } else {
-            return !b.getPtr()->getEnabled() && a.getPtr()->getSortKey() < b.getPtr()->getSortKey();
+            return !b.getSet()->getEnabled() && a.getSet()->getSortKey() < b.getSet()->getSortKey();
         }
     }
 };

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -200,7 +200,7 @@ CardInfoPtr OracleImporter::addCard(QString name,
 
     // insert the card and its properties
     QList<CardRelation *> reverseRelatedCards;
-    PrintingInfoPerSetMap setsInfo;
+    SetToPrintingsMap setsInfo;
     setsInfo[printingInfo.getSet()->getShortName()].append(printingInfo);
     CardInfoPtr newCard = CardInfo::newInstance(name, text, isToken, properties, relatedCards, reverseRelatedCards,
                                                 setsInfo, cipt, landscapeOrientation, tableRow, upsideDown);

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -12,8 +12,8 @@
 SplitCardPart::SplitCardPart(const QString &_name,
                              const QString &_text,
                              const QVariantHash &_properties,
-                             const PrintingInfo &_setInfo)
-    : name(_name), text(_text), properties(_properties), setInfo(_setInfo)
+                             const PrintingInfo &_printingInfo)
+    : name(_name), text(_text), properties(_properties), printingInfo(_printingInfo)
 {
 }
 
@@ -129,14 +129,14 @@ CardInfoPtr OracleImporter::addCard(QString name,
                                     bool isToken,
                                     QVariantHash properties,
                                     const QList<CardRelation *> &relatedCards,
-                                    const PrintingInfo &setInfo)
+                                    const PrintingInfo &printingInfo)
 {
     // Workaround for card name weirdness
     name = name.replace("Æ", "AE");
     name = name.replace("’", "'");
     if (cards.contains(name)) {
         CardInfoPtr card = cards.value(name);
-        card->addToSet(setInfo.getPtr(), setInfo);
+        card->addToSet(printingInfo.getSet(), printingInfo);
         if (card->getProperties().filter(formatRegex).empty()) {
             card->combineLegalities(properties);
         }
@@ -201,12 +201,12 @@ CardInfoPtr OracleImporter::addCard(QString name,
     // insert the card and its properties
     QList<CardRelation *> reverseRelatedCards;
     PrintingInfoPerSetMap setsInfo;
-    setsInfo[setInfo.getPtr()->getShortName()].append(setInfo);
+    setsInfo[printingInfo.getSet()->getShortName()].append(printingInfo);
     CardInfoPtr newCard = CardInfo::newInstance(name, text, isToken, properties, relatedCards, reverseRelatedCards,
                                                 setsInfo, cipt, landscapeOrientation, tableRow, upsideDown);
 
     if (name.isEmpty()) {
-        qDebug() << "warning: an empty card was added to set" << setInfo.getPtr()->getShortName();
+        qDebug() << "warning: an empty card was added to set" << printingInfo.getSet()->getShortName();
     }
     cards.insert(name, newCard);
 
@@ -242,7 +242,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
     static constexpr bool isToken = false;
     static const QList<QString> setsWithCardsWithSameNameButDifferentText = {"UST"};
     QVariantHash properties;
-    PrintingInfo setInfo;
+    PrintingInfo printingInfo;
     QList<CardRelation *> relatedCards;
     QList<QString> allNameProps;
 
@@ -281,7 +281,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
         }
 
         // per-set properties
-        setInfo = PrintingInfo(currentSet);
+        printingInfo = PrintingInfo(currentSet);
         QMapIterator it2(setInfoProperties);
         while (it2.hasNext()) {
             it2.next();
@@ -289,7 +289,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
             QString xmlPropertyName = it2.value();
             QString propertyValue = getStringPropertyFromMap(card, mtgjsonProperty);
             if (!propertyValue.isEmpty())
-                setInfo.setProperty(xmlPropertyName, propertyValue);
+                printingInfo.setProperty(xmlPropertyName, propertyValue);
         }
 
         // Identifiers
@@ -300,12 +300,12 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
             auto xmlPropertyName = it3.value();
             auto propertyValue = getStringPropertyFromMap(card.value("identifiers").toMap(), mtgjsonProperty);
             if (!propertyValue.isEmpty()) {
-                setInfo.setProperty(xmlPropertyName, propertyValue);
+                printingInfo.setProperty(xmlPropertyName, propertyValue);
             }
         }
 
         QString numComponent;
-        const QString numProperty = setInfo.getProperty("num");
+        const QString numProperty = printingInfo.getProperty("num");
         const QChar lastChar = numProperty.isEmpty() ? QChar() : numProperty.back();
 
         // Un-Sets do some wonky stuff. Split up these cards as individual entries.
@@ -353,7 +353,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
         // split cards are considered a single card, enqueue for later merging
         if (layout == "split" || layout == "aftermath" || layout == "adventure") {
             auto _faceName = getStringPropertyFromMap(card, "faceName");
-            SplitCardPart split(_faceName, text, properties, setInfo);
+            SplitCardPart split(_faceName, text, properties, printingInfo);
             auto found_iter = splitCards.find(name + numProperty);
             if (found_iter == splitCards.end()) {
                 splitCards.insert(name + numProperty, {{split}, name});
@@ -404,7 +404,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
                 }
             }
 
-            CardInfoPtr newCard = addCard(name + numComponent, text, isToken, properties, relatedCards, setInfo);
+            CardInfoPtr newCard = addCard(name + numComponent, text, isToken, properties, relatedCards, printingInfo);
             numCards++;
         }
     }
@@ -430,7 +430,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
 
             if (properties.isEmpty()) {
                 properties = tmp.getProperties();
-                setInfo = tmp.getSetInfo();
+                printingInfo = tmp.getPrintingInfo();
             } else {
                 const QVariantHash &tmpProps = tmp.getProperties();
                 for (const QString &prop : tmpProps.keys()) {
@@ -451,7 +451,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
                 }
             }
         }
-        CardInfoPtr newCard = addCard(name, text, isToken, properties, relatedCards, setInfo);
+        CardInfoPtr newCard = addCard(name, text, isToken, properties, relatedCards, printingInfo);
         numCards++;
     }
 

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -12,7 +12,7 @@
 SplitCardPart::SplitCardPart(const QString &_name,
                              const QString &_text,
                              const QVariantHash &_properties,
-                             const CardInfoPerSet &_setInfo)
+                             const PrintingInfo &_setInfo)
     : name(_name), text(_text), properties(_properties), setInfo(_setInfo)
 {
 }
@@ -129,7 +129,7 @@ CardInfoPtr OracleImporter::addCard(QString name,
                                     bool isToken,
                                     QVariantHash properties,
                                     const QList<CardRelation *> &relatedCards,
-                                    const CardInfoPerSet &setInfo)
+                                    const PrintingInfo &setInfo)
 {
     // Workaround for card name weirdness
     name = name.replace("Æ", "AE");
@@ -200,7 +200,7 @@ CardInfoPtr OracleImporter::addCard(QString name,
 
     // insert the card and its properties
     QList<CardRelation *> reverseRelatedCards;
-    CardInfoPerSetMap setsInfo;
+    PrintingInfoPerSetMap setsInfo;
     setsInfo[setInfo.getPtr()->getShortName()].append(setInfo);
     CardInfoPtr newCard = CardInfo::newInstance(name, text, isToken, properties, relatedCards, reverseRelatedCards,
                                                 setsInfo, cipt, landscapeOrientation, tableRow, upsideDown);
@@ -242,7 +242,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
     static constexpr bool isToken = false;
     static const QList<QString> setsWithCardsWithSameNameButDifferentText = {"UST"};
     QVariantHash properties;
-    CardInfoPerSet setInfo;
+    PrintingInfo setInfo;
     QList<CardRelation *> relatedCards;
     QList<QString> allNameProps;
 
@@ -281,7 +281,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
         }
 
         // per-set properties
-        setInfo = CardInfoPerSet(currentSet);
+        setInfo = PrintingInfo(currentSet);
         QMapIterator it2(setInfoProperties);
         while (it2.hasNext()) {
             it2.next();

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -95,7 +95,7 @@ public:
     SplitCardPart(const QString &_name,
                   const QString &_text,
                   const QVariantHash &_properties,
-                  const PrintingInfo &setInfo);
+                  const PrintingInfo &_printingInfo);
     inline const QString &getName() const
     {
         return name;
@@ -108,16 +108,16 @@ public:
     {
         return properties;
     }
-    inline const PrintingInfo &getSetInfo() const
+    inline const PrintingInfo &getPrintingInfo() const
     {
-        return setInfo;
+        return printingInfo;
     }
 
 private:
     QString name;
     QString text;
     QVariantHash properties;
-    PrintingInfo setInfo;
+    PrintingInfo printingInfo;
 };
 
 class OracleImporter : public QObject
@@ -143,7 +143,7 @@ private:
                         bool isToken,
                         QVariantHash properties,
                         const QList<CardRelation *> &relatedCards,
-                        const PrintingInfo &setInfo);
+                        const PrintingInfo &printingInfo);
 signals:
     void setIndexChanged(int cardsImported, int setIndex, const QString &setName);
     void dataReadProgress(int bytesRead, int totalBytes);

--- a/oracle/src/oracleimporter.h
+++ b/oracle/src/oracleimporter.h
@@ -95,7 +95,7 @@ public:
     SplitCardPart(const QString &_name,
                   const QString &_text,
                   const QVariantHash &_properties,
-                  const CardInfoPerSet &setInfo);
+                  const PrintingInfo &setInfo);
     inline const QString &getName() const
     {
         return name;
@@ -108,7 +108,7 @@ public:
     {
         return properties;
     }
-    inline const CardInfoPerSet &getSetInfo() const
+    inline const PrintingInfo &getSetInfo() const
     {
         return setInfo;
     }
@@ -117,7 +117,7 @@ private:
     QString name;
     QString text;
     QVariantHash properties;
-    CardInfoPerSet setInfo;
+    PrintingInfo setInfo;
 };
 
 class OracleImporter : public QObject
@@ -143,7 +143,7 @@ private:
                         bool isToken,
                         QVariantHash properties,
                         const QList<CardRelation *> &relatedCards,
-                        const CardInfoPerSet &setInfo);
+                        const PrintingInfo &setInfo);
 signals:
     void setIndexChanged(int cardsImported, int setIndex, const QString &setName);
     void dataReadProgress(int bytesRead, int totalBytes);


### PR DESCRIPTION
## Short roundup of the initial problem

`CardInfoPerSet` is not a very clear name. `PrintingInfo` better represents what the class represents.

## What will change with this Pull Request?
- Renamed class
  - also renamed `CardInfoPerSetMap` -> `SetToPrintingsMap`
- Renamed variables and methods where the classes were used, as appropriate
  - Also updated some docs