### PR TITLE
Add the option to load decklists from Archidekt, Deckstats, Moxfield, TappedOut in deck editor and lobby

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -16,6 +16,7 @@ set(cockatrice_SOURCES
     src/client/network/replay_timeline_widget.cpp
     src/client/network/sets_model.cpp
     src/client/network/spoiler_background_updater.cpp
+    src/client/network/parsers/deck_link_to_api_transformer.cpp
     src/client/sound_engine.cpp
     src/client/tabs/abstract_tab_deck_editor.cpp
     src/client/tabs/api/edhrec/tab_edhrec.cpp
@@ -165,6 +166,7 @@ set(cockatrice_SOURCES
     src/dialogs/dlg_forgot_password_reset.cpp
     src/dialogs/dlg_load_deck.cpp
     src/dialogs/dlg_load_deck_from_clipboard.cpp
+    src/dialogs/dlg_load_deck_from_website.cpp
     src/dialogs/dlg_load_remote_deck.cpp
     src/dialogs/dlg_manage_sets.cpp
     src/dialogs/dlg_move_top_cards_until.cpp

--- a/cockatrice/src/client/menus/deck_editor/deck_editor_menu.cpp
+++ b/cockatrice/src/client/menus/deck_editor/deck_editor_menu.cpp
@@ -54,6 +54,9 @@ DeckEditorMenu::DeckEditorMenu(AbstractTabDeckEditor *parent) : QMenu(parent), d
     aPrintDeck = new QAction(QString(), this);
     connect(aPrintDeck, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::actPrintDeck);
 
+    aLoadDeckFromWebsite = new QAction(QString(), this);
+    connect(aLoadDeckFromWebsite, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::actLoadDeckFromWebsite);
+
     aExportDeckDecklist = new QAction(QString(), this);
     connect(aExportDeckDecklist, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::actExportDeckDecklist);
 
@@ -97,6 +100,7 @@ DeckEditorMenu::DeckEditorMenu(AbstractTabDeckEditor *parent) : QMenu(parent), d
     addMenu(saveDeckToClipboardMenu);
     addSeparator();
     addAction(aPrintDeck);
+    addAction(aLoadDeckFromWebsite);
     addMenu(analyzeDeckMenu);
     addSeparator();
     addAction(deckEditor->filterDockWidget->aClearFilterOne);
@@ -166,6 +170,7 @@ void DeckEditorMenu::retranslateUi()
 
     aPrintDeck->setText(tr("&Print deck..."));
 
+    aLoadDeckFromWebsite->setText(tr("Load deck from online service..."));
     analyzeDeckMenu->setTitle(tr("&Send deck to online service"));
     aExportDeckDecklist->setText(tr("Create decklist (decklist.org)"));
     aExportDeckDecklistXyz->setText(tr("Create decklist (decklist.xyz)"));

--- a/cockatrice/src/client/menus/deck_editor/deck_editor_menu.h
+++ b/cockatrice/src/client/menus/deck_editor/deck_editor_menu.h
@@ -16,8 +16,8 @@ public:
 
     QAction *aNewDeck, *aLoadDeck, *aClearRecents, *aSaveDeck, *aSaveDeckAs, *aLoadDeckFromClipboard,
         *aEditDeckInClipboard, *aEditDeckInClipboardRaw, *aSaveDeckToClipboard, *aSaveDeckToClipboardNoSetInfo,
-        *aSaveDeckToClipboardRaw, *aSaveDeckToClipboardRawNoSetInfo, *aPrintDeck, *aExportDeckDecklist,
-        *aExportDeckDecklistXyz, *aAnalyzeDeckDeckstats, *aAnalyzeDeckTappedout, *aClose;
+        *aSaveDeckToClipboardRaw, *aSaveDeckToClipboardRawNoSetInfo, *aPrintDeck, *aLoadDeckFromWebsite,
+        *aExportDeckDecklist, *aExportDeckDecklistXyz, *aAnalyzeDeckDeckstats, *aAnalyzeDeckTappedout, *aClose;
     QMenu *loadRecentDeckMenu, *analyzeDeckMenu, *editDeckInClipboardMenu, *saveDeckToClipboardMenu;
 
     void setSaveStatus(bool newStatus);

--- a/cockatrice/src/client/network/parsers/deck_link_to_api_transformer.cpp
+++ b/cockatrice/src/client/network/parsers/deck_link_to_api_transformer.cpp
@@ -1,0 +1,61 @@
+#include "deck_link_to_api_transformer.h"
+
+#include <QRegularExpression>
+
+namespace DeckLinkToApiTransformer
+{
+
+static const QString TAPPEDOUT_BASE = "https://tappedout.net/mtg-decks/";
+static const QString TAPPEDOUT_SUFFIX = "/?fmt=txt";
+
+static const QString ARCHIDEKT_BASE = "https://archidekt.com/api/decks/";
+static const QString ARCHIDEKT_SUFFIX = "/?format=json";
+
+static const QString MOXFIELD_BASE = "https://api.moxfield.com/v2/decks/all/";
+static const QString MOXFIELD_SUFFIX = "/";
+
+static const QString DECKSTATS_SUFFIX = "?include_comments=1&export_mtgarena=1";
+
+bool parseDeckUrl(const QString &url, ParsedDeckInfo &outInfo)
+{
+    QRegularExpression rxTappedOut("tappedout\\.net/(?:mtg-decks/)?([^/?#]+)");
+    QRegularExpression rxArchidekt("archidekt\\.com/decks/(\\d+)");
+    QRegularExpression rxMoxfield("moxfield\\.com/decks/([a-zA-Z0-9_-]+)");
+    QRegularExpression rxDeckstats("deckstats\\.net/decks/(\\d+/[a-zA-Z0-9_-]+)");
+
+    QRegularExpressionMatch match;
+
+    if ((match = rxTappedOut.match(url)).hasMatch()) {
+        QString slug = match.captured(1);
+        outInfo = ParsedDeckInfo{.baseUrl = TAPPEDOUT_BASE,
+                                 .deckID = slug,
+                                 .fullUrl = TAPPEDOUT_BASE + slug + TAPPEDOUT_SUFFIX,
+                                 .provider = DeckProvider::TappedOut};
+        return true;
+    } else if ((match = rxArchidekt.match(url)).hasMatch()) {
+        QString deckID = match.captured(1);
+        outInfo = ParsedDeckInfo{.baseUrl = ARCHIDEKT_BASE,
+                                 .deckID = deckID,
+                                 .fullUrl = ARCHIDEKT_BASE + deckID + ARCHIDEKT_SUFFIX,
+                                 .provider = DeckProvider::Archidekt};
+        return true;
+    } else if ((match = rxMoxfield.match(url)).hasMatch()) {
+        QString deckID = match.captured(1);
+        outInfo = ParsedDeckInfo{.baseUrl = MOXFIELD_BASE,
+                                 .deckID = deckID,
+                                 .fullUrl = MOXFIELD_BASE + deckID + MOXFIELD_SUFFIX,
+                                 .provider = DeckProvider::Moxfield};
+        return true;
+    } else if ((match = rxDeckstats.match(url)).hasMatch()) {
+        QString deckPath = match.captured(1);
+        outInfo = ParsedDeckInfo{.baseUrl = "https://deckstats.net/decks/",
+                                 .deckID = deckPath,
+                                 .fullUrl = "https://deckstats.net/decks/" + deckPath + DECKSTATS_SUFFIX,
+                                 .provider = DeckProvider::Deckstats};
+        return true;
+    }
+
+    return false;
+}
+
+} // namespace DeckLinkToApiTransformer

--- a/cockatrice/src/client/network/parsers/deck_link_to_api_transformer.h
+++ b/cockatrice/src/client/network/parsers/deck_link_to_api_transformer.h
@@ -1,0 +1,31 @@
+#ifndef DECK_LINK_TO_API_TRANSFORMER_H
+#define DECK_LINK_TO_API_TRANSFORMER_H
+
+#include <QString>
+
+enum class DeckProvider
+{
+    TappedOut,
+    Archidekt,
+    Moxfield,
+    Deckstats,
+    Unknown
+};
+
+struct ParsedDeckInfo
+{
+    QString baseUrl;
+    QString deckID;
+    QString fullUrl;
+    DeckProvider provider;
+};
+
+namespace DeckLinkToApiTransformer
+{
+
+// Returns true if the input URL is recognized and fills outInfo.
+bool parseDeckUrl(const QString &url, ParsedDeckInfo &outInfo);
+
+} // namespace DeckLinkToApiTransformer
+
+#endif // DECK_LINK_TO_API_TRANSFORMER_H

--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
@@ -6,6 +6,7 @@
 #include "../../deck/deck_stats_interface.h"
 #include "../../dialogs/dlg_load_deck.h"
 #include "../../dialogs/dlg_load_deck_from_clipboard.h"
+#include "../../dialogs/dlg_load_deck_from_website.h"
 #include "../../game/cards/card_database_manager.h"
 #include "../../game/cards/card_database_model.h"
 #include "../../server/pending_command.h"
@@ -465,6 +466,28 @@ void AbstractTabDeckEditor::actPrintDeck()
     auto *dlg = new QPrintPreviewDialog(this);
     connect(dlg, &QPrintPreviewDialog::paintRequested, deckDockWidget->deckModel, &DeckListModel::printDeckList);
     dlg->exec();
+}
+
+void AbstractTabDeckEditor::actLoadDeckFromWebsite()
+{
+    auto deckOpenLocation = confirmOpen();
+
+    if (deckOpenLocation == CANCELLED) {
+        return;
+    }
+
+    DlgLoadDeckFromWebsite dlg(this);
+    if (!dlg.exec())
+        return;
+
+    if (deckOpenLocation == NEW_TAB) {
+        emit openDeckEditor(dlg.getDeck());
+    } else {
+        setDeck(dlg.getDeck());
+        setModified(true);
+    }
+
+    deckMenu->setSaveStatus(true);
 }
 
 void AbstractTabDeckEditor::exportToDecklistWebsite(DeckLoader::DecklistWebsite website)

--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.h
@@ -102,6 +102,7 @@ protected slots:
     void actSaveDeckToClipboardRaw();
     void actSaveDeckToClipboardRawNoSetInfo();
     void actPrintDeck();
+    void actLoadDeckFromWebsite();
     void actExportDeckDecklist();
     void actExportDeckDecklistXyz();
     void actAnalyzeDeckDeckstats();

--- a/cockatrice/src/dialogs/dlg_load_deck_from_website.cpp
+++ b/cockatrice/src/dialogs/dlg_load_deck_from_website.cpp
@@ -1,0 +1,130 @@
+#include "dlg_load_deck_from_website.h"
+
+#include <QApplication>
+#include <QClipboard>
+#include <QDialogButtonBox>
+#include <QEventLoop>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkReply>
+
+DlgLoadDeckFromWebsite::DlgLoadDeckFromWebsite(QWidget *parent) : QDialog(parent)
+{
+    nam = new QNetworkAccessManager(this);
+
+    layout = new QVBoxLayout(this);
+    setLayout(layout);
+
+    instructionLabel = new QLabel(this);
+    layout->addWidget(instructionLabel);
+
+    urlEdit = new QLineEdit(this);
+    urlEdit->setText(QApplication::clipboard()->text());
+
+    layout->addWidget(urlEdit);
+
+    QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+    layout->addWidget(buttonBox);
+
+    if (testValidUrl()) {
+        QMetaObject::invokeMethod(this, "accept", Qt::QueuedConnection);
+        hide();
+    }
+
+    retranslateUi();
+}
+
+void DlgLoadDeckFromWebsite::retranslateUi()
+{
+    instructionLabel->setText(tr("Paste a link to a decklist site here to import it.\n(Archidekt, Deckstats, Moxfield, "
+                                 "and TappedOut are supported.)"));
+}
+
+bool DlgLoadDeckFromWebsite::testValidUrl()
+{
+    ParsedDeckInfo info;
+    return DeckLinkToApiTransformer::parseDeckUrl(urlEdit->text(), info);
+}
+
+void DlgLoadDeckFromWebsite::accept()
+{
+    ParsedDeckInfo info;
+    if (DeckLinkToApiTransformer::parseDeckUrl(urlEdit->text(), info)) {
+        qInfo() << info.baseUrl << info.deckID << info.fullUrl;
+
+        auto jsonParser = createParserForProvider(info.provider);
+        if (!jsonParser && info.provider != DeckProvider::Deckstats && info.provider != DeckProvider::TappedOut) {
+            qWarning() << "No parser found for provider";
+            QDialog::reject();
+            return;
+        }
+
+        QNetworkRequest request(QUrl(info.fullUrl));
+        QNetworkReply *reply = nam->get(request);
+
+        QEventLoop loop;
+        connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+        loop.exec();
+
+        if (reply->error() != QNetworkReply::NoError) {
+            qWarning() << "Network error:" << reply->errorString();
+            reply->deleteLater();
+            QDialog::reject();
+            return;
+        }
+
+        QByteArray responseData = reply->readAll();
+        reply->deleteLater();
+
+        // Special handling for Deckstats and TappedOut .txt
+        if (info.provider == DeckProvider::Deckstats || info.provider == DeckProvider::TappedOut) {
+            QString deckText = QString::fromUtf8(responseData);
+            if (deckText.isEmpty()) {
+                qWarning() << "Response is empty";
+                QDialog::reject();
+                return;
+            }
+
+            // Parse the plain text deck here
+            DeckLoader *loader = new DeckLoader();
+            QTextStream stream(&deckText);
+            loader->loadFromStream_Plain(stream, false);
+            loader->resolveSetNameAndNumberToProviderID();
+            deck = loader;
+
+            QDialog::accept();
+            return;
+        }
+
+        // Normal JSON parsing for other providers
+        QJsonParseError parseError;
+        QJsonDocument doc = QJsonDocument::fromJson(responseData, &parseError);
+        if (parseError.error != QJsonParseError::NoError) {
+            qWarning() << "JSON parse error:" << parseError.errorString();
+            QDialog::reject();
+            return;
+        }
+
+        deck = jsonParser->parse(doc.object());
+        QDialog::accept();
+
+    } else {
+        qInfo() << "URL not recognized";
+        QDialog::reject();
+    }
+}
+
+QSharedPointer<IJsonDeckParser> DlgLoadDeckFromWebsite::createParserForProvider(DeckProvider provider)
+{
+    switch (provider) {
+        case DeckProvider::Archidekt:
+            return QSharedPointer<IJsonDeckParser>(new ArchidektJsonParser());
+        case DeckProvider::Moxfield:
+            return QSharedPointer<IJsonDeckParser>(new MoxfieldJsonParser());
+        default:
+            return QSharedPointer<IJsonDeckParser>(nullptr);
+    }
+}

--- a/cockatrice/src/dialogs/dlg_load_deck_from_website.h
+++ b/cockatrice/src/dialogs/dlg_load_deck_from_website.h
@@ -1,0 +1,38 @@
+#ifndef DLG_LOAD_DECK_FROM_WEBSITE_H
+#define DLG_LOAD_DECK_FROM_WEBSITE_H
+
+#include "../client/network/parsers/deck_link_to_api_transformer.h"
+#include "../client/network/parsers/interface_json_deck_parser.h"
+
+#include <QDialog>
+#include <QLabel>
+#include <QLineEdit>
+#include <QNetworkAccessManager>
+#include <QVBoxLayout>
+
+class DlgLoadDeckFromWebsite : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit DlgLoadDeckFromWebsite(QWidget *parent);
+    void retranslateUi();
+    bool testValidUrl();
+    DeckLoader *deck;
+
+    DeckLoader *getDeck()
+    {
+        return deck;
+    }
+
+private:
+    QNetworkAccessManager *nam;
+    QVBoxLayout *layout;
+    QLabel *instructionLabel;
+    QLineEdit *urlEdit;
+
+public slots:
+    void accept() override;
+    QSharedPointer<IJsonDeckParser> createParserForProvider(DeckProvider provider);
+};
+
+#endif // DLG_LOAD_DECK_FROM_WEBSITE_H

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -5,6 +5,7 @@
 #include "../../deck/deck_loader.h"
 #include "../../dialogs/dlg_load_deck.h"
 #include "../../dialogs/dlg_load_deck_from_clipboard.h"
+#include "../../dialogs/dlg_load_deck_from_website.h"
 #include "../../dialogs/dlg_load_remote_deck.h"
 #include "../../server/pending_command.h"
 #include "../../settings/cache_settings.h"
@@ -54,6 +55,7 @@ DeckViewContainer::DeckViewContainer(int _playerId, TabGame *parent)
     loadLocalButton = new QPushButton;
     loadRemoteButton = new QPushButton;
     loadFromClipboardButton = new QPushButton;
+    loadFromWebsiteButton = new QPushButton;
     unloadDeckButton = new QPushButton;
     readyStartButton = new ToggleButton;
     forceStartGameButton = new QPushButton;
@@ -62,6 +64,7 @@ DeckViewContainer::DeckViewContainer(int _playerId, TabGame *parent)
     connect(loadLocalButton, &QPushButton::clicked, this, &DeckViewContainer::loadLocalDeck);
     connect(loadRemoteButton, &QPushButton::clicked, this, &DeckViewContainer::loadRemoteDeck);
     connect(loadFromClipboardButton, &QPushButton::clicked, this, &DeckViewContainer::loadFromClipboard);
+    connect(loadFromWebsiteButton, &QPushButton::clicked, this, &DeckViewContainer::loadFromWebsite);
     connect(readyStartButton, &QPushButton::clicked, this, &DeckViewContainer::readyStart);
     connect(unloadDeckButton, &QPushButton::clicked, this, &DeckViewContainer::unloadDeck);
     connect(forceStartGameButton, &QPushButton::clicked, this, &DeckViewContainer::forceStart);
@@ -72,6 +75,7 @@ DeckViewContainer::DeckViewContainer(int _playerId, TabGame *parent)
     buttonHBox->addWidget(loadLocalButton);
     buttonHBox->addWidget(loadRemoteButton);
     buttonHBox->addWidget(loadFromClipboardButton);
+    buttonHBox->addWidget(loadFromWebsiteButton);
     buttonHBox->addWidget(unloadDeckButton);
     buttonHBox->addWidget(readyStartButton);
     buttonHBox->addWidget(sideboardLockButton);
@@ -123,6 +127,7 @@ void DeckViewContainer::retranslateUi()
     loadLocalButton->setText(tr("Load deck..."));
     loadRemoteButton->setText(tr("Load remote deck..."));
     loadFromClipboardButton->setText(tr("Load from clipboard..."));
+    loadFromWebsiteButton->setText(tr("Load from website..."));
     unloadDeckButton->setText(tr("Unload deck"));
     readyStartButton->setText(tr("Ready to start"));
     forceStartGameButton->setText(tr("Force start"));
@@ -154,6 +159,7 @@ void DeckViewContainer::switchToDeckSelectView()
     setVisibility(loadLocalButton, true);
     setVisibility(loadRemoteButton, !parentGame->getIsLocalGame());
     setVisibility(loadFromClipboardButton, true);
+    setVisibility(loadFromWebsiteButton, true);
     setVisibility(unloadDeckButton, false);
     setVisibility(readyStartButton, false);
     setVisibility(sideboardLockButton, false);
@@ -179,6 +185,7 @@ void DeckViewContainer::switchToDeckLoadedView()
     setVisibility(loadLocalButton, false);
     setVisibility(loadRemoteButton, false);
     setVisibility(loadFromClipboardButton, false);
+    setVisibility(loadFromWebsiteButton, false);
     setVisibility(unloadDeckButton, true);
     setVisibility(readyStartButton, true);
     setVisibility(sideboardLockButton, true);
@@ -306,6 +313,18 @@ void DeckViewContainer::loadFromClipboard()
     }
 
     DeckLoader *deck = dlg.getDeckList();
+    loadDeckFromDeckLoader(deck);
+}
+
+void DeckViewContainer::loadFromWebsite()
+{
+    auto dlg = DlgLoadDeckFromWebsite(this);
+
+    if (!dlg.exec()) {
+        return;
+    }
+
+    DeckLoader *deck = dlg.getDeck();
     loadDeckFromDeckLoader(deck);
 }
 

--- a/cockatrice/src/game/deckview/deck_view_container.h
+++ b/cockatrice/src/game/deckview/deck_view_container.h
@@ -44,7 +44,7 @@ class DeckViewContainer : public QWidget
     Q_OBJECT
 private:
     QVBoxLayout *deckViewLayout;
-    QPushButton *loadLocalButton, *loadRemoteButton, *loadFromClipboardButton;
+    QPushButton *loadLocalButton, *loadRemoteButton, *loadFromClipboardButton, *loadFromWebsiteButton;
     QPushButton *unloadDeckButton, *forceStartGameButton;
     ToggleButton *readyStartButton, *sideboardLockButton;
     DeckView *deckView;
@@ -60,6 +60,7 @@ private slots:
     void loadLocalDeck();
     void loadRemoteDeck();
     void loadFromClipboard();
+    void loadFromWebsite();
     void unloadDeck();
     void readyStart();
     void forceStart();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4032
- Sort of #4389

## Short roundup of the initial problem
Importing a deck from an external website usually requires the user to navigate through some sort of export dialog on the website to get the decklist into their clipboard in a format that trice likes. Then, the user has to go through our import from clipboard dialog to actually get it imported. All in all, a lot of button presses, which is why someone came up with the idea of APIs.

## What will change with this Pull Request?
- Implement a new parser for various URL combos that parses out the deckID from a consumer URL and then constructs an API URL with that deckID
- Leverage Archidekt, Deckstats, Moxfield, and TappedOut APIs to get decklist exports for supplied urls
- Parse those decklists and load them in either the lobby or the deck editor.
- (Bonus) If the clipboard contains a valid URL that we can parse, the dialog auto confirms.

## Screenshots
<img width="405" height="105" alt="image" src="https://github.com/user-attachments/assets/6a9b3559-1343-4d53-840e-8d02b4f15628" />

https://github.com/user-attachments/assets/41b93d27-2786-430e-9d08-7528aa809c5e


