### PR TITLE
Refactor: Represent cardName + providerId with CardRef struct

### DIFF
--- a/cockatrice/src/client/network/parsers/interface_json_deck_parser.h
+++ b/cockatrice/src/client/network/parsers/interface_json_deck_parser.h
@@ -100,7 +100,7 @@ public:
                 QString collectorNumber = cardData.value("cn").toString();
                 QString providerId = cardData.value("scryfall_id").toString();
 
-                list->setBannerCard(QPair<QString, QString>(commanderName, providerId));
+                list->setBannerCard({commanderName, providerId});
                 list->addCard(commanderName, DECK_ZONE_MAIN, -1, setName, collectorNumber, providerId);
             }
         }

--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
@@ -162,7 +162,7 @@ void AbstractTabDeckEditor::setDeck(DeckLoader *_deck)
 {
     deckDockWidget->setDeck(_deck);
     PictureLoader::cacheCardPixmaps(
-        CardDatabaseManager::getInstance()->getCardsByNameAndProviderId(getDeckList()->getCardListWithProviderId()));
+        CardDatabaseManager::getInstance()->getCardsByNameAndProviderId(getDeckList()->getCardRefList()));
     setModified(false);
 
     // If they load a deck, make the deck list appear

--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
@@ -161,8 +161,7 @@ void AbstractTabDeckEditor::openDeck(DeckLoader *deck)
 void AbstractTabDeckEditor::setDeck(DeckLoader *_deck)
 {
     deckDockWidget->setDeck(_deck);
-    PictureLoader::cacheCardPixmaps(
-        CardDatabaseManager::getInstance()->getCardsByNameAndProviderId(getDeckList()->getCardRefList()));
+    PictureLoader::cacheCardPixmaps(CardDatabaseManager::getInstance()->getCards(getDeckList()->getCardRefList()));
     setModified(false);
 
     // If they load a deck, make the deck list appear

--- a/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.cpp
+++ b/cockatrice/src/client/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.cpp
@@ -12,7 +12,7 @@ EdhrecApiResponseCardDetailsDisplayWidget::EdhrecApiResponseCardDetailsDisplayWi
     setLayout(layout);
 
     cardPictureWidget = new CardInfoPictureWidget(this);
-    cardPictureWidget->setCard(CardDatabaseManager::getInstance()->guessCard(toDisplay.sanitized));
+    cardPictureWidget->setCard(CardDatabaseManager::getInstance()->guessCard({toDisplay.sanitized}));
 
     nameLabel = new QLabel(this);
     nameLabel->setText(toDisplay.name);

--- a/cockatrice/src/client/tabs/api/edhrec/display/commander/edhrec_api_response_commander_details_display_widget.cpp
+++ b/cockatrice/src/client/tabs/api/edhrec/display/commander/edhrec_api_response_commander_details_display_widget.cpp
@@ -15,7 +15,7 @@ EdhrecCommanderResponseCommanderDetailsDisplayWidget::EdhrecCommanderResponseCom
     setLayout(layout);
 
     commanderPicture = new CardInfoPictureWidget(this);
-    commanderPicture->setCard(CardDatabaseManager::getInstance()->getCard(commanderDetails.getName()));
+    commanderPicture->setCard(CardDatabaseManager::getInstance()->getCardInfo(commanderDetails.getName()));
 
     QWidget *currentParent = parentWidget();
     TabEdhRecMain *parentTab = nullptr;

--- a/cockatrice/src/client/tabs/api/edhrec/tab_edhrec_main.cpp
+++ b/cockatrice/src/client/tabs/api/edhrec/tab_edhrec_main.cpp
@@ -136,7 +136,7 @@ void TabEdhRecMain::retranslateUi()
 
 void TabEdhRecMain::doSearch()
 {
-    CardInfoPtr searchedCard = CardDatabaseManager::getInstance()->getCard(searchBar->text());
+    CardInfoPtr searchedCard = CardDatabaseManager::getInstance()->getCardInfo(searchBar->text());
     if (!searchedCard) {
         return;
     }

--- a/cockatrice/src/client/tabs/tab.cpp
+++ b/cockatrice/src/client/tabs/tab.cpp
@@ -14,14 +14,13 @@ Tab::Tab(TabSupervisor *_tabSupervisor)
     setAttribute(Qt::WA_DeleteOnClose);
 }
 
-void Tab::showCardInfoPopup(const QPoint &pos, const QString &cardName, const QString &providerId)
+void Tab::showCardInfoPopup(const QPoint &pos, const CardRef &cardRef)
 {
     if (infoPopup) {
         infoPopup->deleteLater();
     }
-    currentCardName = cardName;
-    currentProviderId = providerId;
-    infoPopup = new CardInfoDisplayWidget(cardName, providerId, nullptr,
+    currentCard = cardRef;
+    infoPopup = new CardInfoDisplayWidget(currentCard, nullptr,
                                           Qt::Widget | Qt::FramelessWindowHint | Qt::X11BypassWindowManagerHint |
                                               Qt::WindowStaysOnTopHint);
     infoPopup->setAttribute(Qt::WA_TransparentForMouseEvents);
@@ -37,7 +36,7 @@ void Tab::showCardInfoPopup(const QPoint &pos, const QString &cardName, const QS
 void Tab::deleteCardInfoPopup(const QString &cardName)
 {
     if (infoPopup) {
-        if ((currentCardName == cardName) || (cardName == "_")) {
+        if (currentCard.name == cardName || cardName == "_") {
             infoPopup->deleteLater();
             infoPopup = 0;
         }

--- a/cockatrice/src/client/tabs/tab.h
+++ b/cockatrice/src/client/tabs/tab.h
@@ -1,6 +1,8 @@
 #ifndef TAB_H
 #define TAB_H
 
+#include "card_ref.h"
+
 #include <QMainWindow>
 
 class QMenu;
@@ -27,12 +29,12 @@ protected:
         tabMenus.append(menu);
     }
 protected slots:
-    void showCardInfoPopup(const QPoint &pos, const QString &cardName, const QString &providerId);
+    void showCardInfoPopup(const QPoint &pos, const CardRef &cardRef);
     void deleteCardInfoPopup(const QString &cardName);
     void closeEvent(QCloseEvent *event) override;
 
 private:
-    QString currentCardName, currentProviderId;
+    CardRef currentCard;
     bool contentsChanged;
     CardInfoDisplayWidget *infoPopup;
     QList<QMenu *> tabMenus;

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -929,8 +929,8 @@ void TabGame::eventGameStateChanged(const Event_GameStateChanged &event,
                 DeckViewContainer *deckViewContainer = deckViewContainers.value(playerId);
                 if (playerInfo.has_deck_list()) {
                     DeckLoader newDeck(QString::fromStdString(playerInfo.deck_list()));
-                    PictureLoader::cacheCardPixmaps(CardDatabaseManager::getInstance()->getCardsByNameAndProviderId(
-                        newDeck.getCardRefList()));
+                    PictureLoader::cacheCardPixmaps(
+                        CardDatabaseManager::getInstance()->getCards(newDeck.getCardRefList()));
                     deckViewContainer->setDeck(newDeck);
                     player->setDeck(newDeck);
                 }

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -1625,9 +1625,9 @@ void TabGame::createDeckViewContainerWidget(bool bReplay)
     deckViewContainerWidget->setLayout(deckViewContainerLayout);
 }
 
-void TabGame::viewCardInfo(const QString &cardName, const QString &providerId) const
+void TabGame::viewCardInfo(const CardRef &cardRef) const
 {
-    cardInfoFrameWidget->setCard(cardName, providerId);
+    cardInfoFrameWidget->setCard(cardRef);
 }
 
 void TabGame::createCardInfoDock(bool bReplay)

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -930,7 +930,7 @@ void TabGame::eventGameStateChanged(const Event_GameStateChanged &event,
                 if (playerInfo.has_deck_list()) {
                     DeckLoader newDeck(QString::fromStdString(playerInfo.deck_list()));
                     PictureLoader::cacheCardPixmaps(CardDatabaseManager::getInstance()->getCardsByNameAndProviderId(
-                        newDeck.getCardListWithProviderId()));
+                        newDeck.getCardRefList()));
                     deckViewContainer->setDeck(newDeck);
                     player->setDeck(newDeck);
                 }

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -266,7 +266,7 @@ public:
 public slots:
     void sendGameCommand(PendingCommand *pend, int playerId = -1);
     void sendGameCommand(const ::google::protobuf::Message &command, int playerId = -1);
-    void viewCardInfo(const QString &cardName, const QString &providerId = "") const;
+    void viewCardInfo(const CardRef &cardRef = {}) const;
 };
 
 #endif

--- a/cockatrice/src/client/tapped_out_interface.cpp
+++ b/cockatrice/src/client/tapped_out_interface.cpp
@@ -95,7 +95,7 @@ void TappedOutInterface::analyzeDeck(DeckList *deck)
 void TappedOutInterface::copyDeckSplitMainAndSide(DeckList &source, DeckList &mainboard, DeckList &sideboard)
 {
     auto copyMainOrSide = [this, &mainboard, &sideboard](const auto node, const auto card) {
-        CardInfoPtr dbCard = cardDatabase.getCard(card->getName());
+        CardInfoPtr dbCard = cardDatabase.getCardInfo(card->getName());
         if (!dbCard || dbCard->getIsToken())
             return;
 

--- a/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
@@ -46,7 +46,7 @@ QWidget *CardGroupDisplayWidget::constructWidgetForIndex(int rowIndex)
 
     auto widget = new CardInfoPictureWithTextOverlayWidget(getLayoutParent(), true);
     widget->setScaleFactor(cardSizeWidget->getSlider()->value());
-    widget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(cardName, cardProviderId));
+    widget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId({cardName, cardProviderId}));
 
     connect(widget, &CardInfoPictureWithTextOverlayWidget::imageClicked, this, &CardGroupDisplayWidget::onClick);
     connect(widget, &CardInfoPictureWithTextOverlayWidget::hoveredOnCard, this, &CardGroupDisplayWidget::onHover);

--- a/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
@@ -46,7 +46,7 @@ QWidget *CardGroupDisplayWidget::constructWidgetForIndex(int rowIndex)
 
     auto widget = new CardInfoPictureWithTextOverlayWidget(getLayoutParent(), true);
     widget->setScaleFactor(cardSizeWidget->getSlider()->value());
-    widget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId({cardName, cardProviderId}));
+    widget->setCard(CardDatabaseManager::getInstance()->getCard({cardName, cardProviderId}));
 
     connect(widget, &CardInfoPictureWithTextOverlayWidget::imageClicked, this, &CardGroupDisplayWidget::onClick);
     connect(widget, &CardInfoPictureWithTextOverlayWidget::hoveredOnCard, this, &CardGroupDisplayWidget::onHover);

--- a/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/flat_card_group_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/flat_card_group_display_widget.cpp
@@ -89,7 +89,7 @@ QWidget *FlatCardGroupDisplayWidget::constructWidgetForIndex(int row)
 
     auto widget = new CardInfoPictureWithTextOverlayWidget(flowWidget, true);
     widget->setScaleFactor(cardSizeWidget->getSlider()->value());
-    widget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId({cardName, cardProviderId}));
+    widget->setCard(CardDatabaseManager::getInstance()->getCard({cardName, cardProviderId}));
 
     connect(widget, &CardInfoPictureWithTextOverlayWidget::imageClicked, this, &FlatCardGroupDisplayWidget::onClick);
     connect(widget, &CardInfoPictureWithTextOverlayWidget::hoveredOnCard, this, &FlatCardGroupDisplayWidget::onHover);

--- a/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/flat_card_group_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/flat_card_group_display_widget.cpp
@@ -89,7 +89,7 @@ QWidget *FlatCardGroupDisplayWidget::constructWidgetForIndex(int row)
 
     auto widget = new CardInfoPictureWithTextOverlayWidget(flowWidget, true);
     widget->setScaleFactor(cardSizeWidget->getSlider()->value());
-    widget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(cardName, cardProviderId));
+    widget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId({cardName, cardProviderId}));
 
     connect(widget, &CardInfoPictureWithTextOverlayWidget::imageClicked, this, &FlatCardGroupDisplayWidget::onClick);
     connect(widget, &CardInfoPictureWithTextOverlayWidget::hoveredOnCard, this, &FlatCardGroupDisplayWidget::onHover);

--- a/cockatrice/src/client/ui/widgets/cards/card_info_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_display_widget.cpp
@@ -11,10 +11,7 @@
 #include <QVBoxLayout>
 #include <utility>
 
-CardInfoDisplayWidget::CardInfoDisplayWidget(const QString &cardName,
-                                             const QString &providerId,
-                                             QWidget *parent,
-                                             Qt::WindowFlags flags)
+CardInfoDisplayWidget::CardInfoDisplayWidget(const CardRef &cardRef, QWidget *parent, Qt::WindowFlags flags)
     : QFrame(parent, flags), aspectRatio((qreal)CARD_HEIGHT / (qreal)CARD_WIDTH), info(nullptr)
 {
     setContentsMargins(3, 3, 3, 3);
@@ -22,7 +19,7 @@ CardInfoDisplayWidget::CardInfoDisplayWidget(const QString &cardName,
     pic->setObjectName("pic");
     text = new CardInfoTextWidget();
     text->setObjectName("text");
-    connect(text, &CardInfoTextWidget::linkActivated, this, [this](const QString &card) { setCard(card); });
+    connect(text, &CardInfoTextWidget::linkActivated, this, [this](const QString &card) { setCard({card}); });
 
     auto *layout = new QVBoxLayout();
     layout->setObjectName("layout");
@@ -40,7 +37,7 @@ CardInfoDisplayWidget::CardInfoDisplayWidget(const QString &cardName,
     pic->setFixedHeight(pixmapHeight);
     setFixedWidth(pixmapWidth + 150);
 
-    setCard(cardName, providerId);
+    setCard(cardRef);
 
     // ensure our parent gets a valid size to position us correctly
     resize(width(), sizeHint().height());
@@ -58,11 +55,11 @@ void CardInfoDisplayWidget::setCard(CardInfoPtr card)
     pic->setCard(info);
 }
 
-void CardInfoDisplayWidget::setCard(const QString &cardName, const QString &providerId)
+void CardInfoDisplayWidget::setCard(const CardRef &cardRef)
 {
-    setCard(CardDatabaseManager::getInstance()->guessCard(cardName, providerId));
+    setCard(CardDatabaseManager::getInstance()->guessCard(cardRef));
     if (info == nullptr) {
-        text->setInvalidCardName(cardName);
+        text->setInvalidCardName(cardRef.name);
     }
 }
 

--- a/cockatrice/src/client/ui/widgets/cards/card_info_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_display_widget.h
@@ -2,6 +2,7 @@
 #define CARDINFOWIDGET_H
 
 #include "../../../../game/cards/card_info.h"
+#include "card_ref.h"
 
 #include <QComboBox>
 #include <QFrame>
@@ -22,14 +23,11 @@ private:
     CardInfoTextWidget *text;
 
 public:
-    explicit CardInfoDisplayWidget(const QString &cardName,
-                                   const QString &providerId,
-                                   QWidget *parent = nullptr,
-                                   Qt::WindowFlags f = {});
+    explicit CardInfoDisplayWidget(const CardRef &cardRef, QWidget *parent = nullptr, Qt::WindowFlags f = {});
 
 public slots:
     void setCard(CardInfoPtr card);
-    void setCard(const QString &cardName, const QString &providerId = QString());
+    void setCard(const CardRef &cardRef);
     void setCard(AbstractCardItem *card);
 
 private slots:

--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
@@ -166,12 +166,12 @@ void CardInfoFrameWidget::setCard(CardInfoPtr card)
 
 void CardInfoFrameWidget::setCard(const QString &cardName)
 {
-    setCard(CardDatabaseManager::getInstance()->guessCard(cardName));
+    setCard(CardDatabaseManager::getInstance()->guessCard({cardName}));
 }
 
-void CardInfoFrameWidget::setCard(const QString &cardName, const QString &providerId)
+void CardInfoFrameWidget::setCard(const CardRef &cardRef)
 {
-    setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(cardName, providerId));
+    setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(cardRef));
 }
 
 void CardInfoFrameWidget::setCard(AbstractCardItem *card)

--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
@@ -62,7 +62,7 @@ CardInfoFrameWidget::CardInfoFrameWidget(const QString &cardName, QWidget *paren
     setViewMode(SettingsCache::instance().getCardInfoViewMode());
 
     // TODO: Change this to be by UUID
-    setCard(CardDatabaseManager::getInstance()->getCard(cardName));
+    setCard(CardDatabaseManager::getInstance()->getCardInfo(cardName));
 }
 
 void CardInfoFrameWidget::retranslateUi()
@@ -171,7 +171,7 @@ void CardInfoFrameWidget::setCard(const QString &cardName)
 
 void CardInfoFrameWidget::setCard(const CardRef &cardRef)
 {
-    setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(cardRef));
+    setCard(CardDatabaseManager::getInstance()->getCard(cardRef));
 }
 
 void CardInfoFrameWidget::setCard(AbstractCardItem *card)

--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.h
@@ -2,6 +2,7 @@
 #define CARDFRAME_H
 
 #include "../../../../game/cards/card_info.h"
+#include "card_ref.h"
 
 #include <QPushButton>
 #include <QTabWidget>
@@ -46,7 +47,7 @@ public:
 public slots:
     void setCard(CardInfoPtr card);
     void setCard(const QString &cardName);
-    void setCard(const QString &cardName, const QString &providerId);
+    void setCard(const CardRef &cardRef);
     void setCard(AbstractCardItem *card);
     void viewTransformation();
     void clearCard();

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
@@ -374,7 +374,7 @@ QMenu *CardInfoPictureWidget::createViewRelatedCardsMenu()
     QList<CardRelation *> relatedCards = info->getAllRelatedCards();
 
     auto relatedCardExists = [](const CardRelation *cardRelation) {
-        return CardDatabaseManager::getInstance()->getCard(cardRelation->getName()) != nullptr;
+        return CardDatabaseManager::getInstance()->getCardInfo(cardRelation->getName()) != nullptr;
     };
 
     bool atLeastOneGoodRelationFound = std::any_of(relatedCards.begin(), relatedCards.end(), relatedCardExists);
@@ -388,7 +388,7 @@ QMenu *CardInfoPictureWidget::createViewRelatedCardsMenu()
         const auto &relatedCardName = relatedCard->getName();
         QAction *viewCard = viewRelatedCards->addAction(relatedCardName);
         connect(viewCard, &QAction::triggered, this, [this, &relatedCardName] {
-            emit cardChanged(CardDatabaseManager::getInstance()->getCard(relatedCardName));
+            emit cardChanged(CardDatabaseManager::getInstance()->getCardInfo(relatedCardName));
         });
         viewRelatedCards->addAction(viewCard);
     }

--- a/cockatrice/src/client/ui/widgets/deck_analytics/mana_base_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_analytics/mana_base_widget.cpp
@@ -87,7 +87,7 @@ QHash<QString, int> ManaBaseWidget::analyzeManaBase()
                 continue;
 
             for (int k = 0; k < currentCard->getNumber(); ++k) {
-                CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(currentCard->getName());
+                CardInfoPtr info = CardDatabaseManager::getInstance()->getCardInfo(currentCard->getName());
                 if (info) {
                     auto devotion = determineManaProduction(info->getText());
                     mergeManaCounts(manaBaseMap, devotion);

--- a/cockatrice/src/client/ui/widgets/deck_analytics/mana_curve_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_analytics/mana_curve_widget.cpp
@@ -53,7 +53,7 @@ std::unordered_map<int, int> ManaCurveWidget::analyzeManaCurve()
                 continue;
 
             for (int k = 0; k < currentCard->getNumber(); ++k) {
-                CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(currentCard->getName());
+                CardInfoPtr info = CardDatabaseManager::getInstance()->getCardInfo(currentCard->getName());
                 if (info) {
                     int cmc = info->getCmc().toInt();
                     manaCurveMap[cmc]++;

--- a/cockatrice/src/client/ui/widgets/deck_analytics/mana_devotion_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_analytics/mana_devotion_widget.cpp
@@ -55,7 +55,7 @@ std::unordered_map<char, int> ManaDevotionWidget::analyzeManaDevotion()
                 continue;
 
             for (int k = 0; k < currentCard->getNumber(); ++k) {
-                CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(currentCard->getName());
+                CardInfoPtr info = CardDatabaseManager::getInstance()->getCardInfo(currentCard->getName());
                 if (info) {
                     auto devotion = countManaSymbols(info->getManaCost());
                     mergeManaCounts(manaDevotionMap, devotion);

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_database_display_widget.cpp
@@ -136,16 +136,16 @@ void DeckEditorDatabaseDisplayWidget::clearAllDatabaseFilters()
 void DeckEditorDatabaseDisplayWidget::updateCard(const QModelIndex &current, const QModelIndex & /*previous*/)
 {
     const QString cardName = current.sibling(current.row(), 0).data().toString();
-    const QString cardProviderID = CardDatabaseManager::getInstance()->getPreferredPrintingProviderIdForCard(cardName);
+    const QString cardProviderID = CardDatabaseManager::getInstance()->getPreferredPrintingProviderId(cardName);
 
     if (!current.isValid()) {
         return;
     }
 
     if (!current.model()->hasChildren(current.sibling(current.row(), 0))) {
-        CardInfoPtr card = CardDatabaseManager::getInstance()->getCardByNameAndProviderId({cardName, cardProviderID});
+        CardInfoPtr card = CardDatabaseManager::getInstance()->getCard({cardName, cardProviderID});
         if (!card) {
-            card = CardDatabaseManager::getInstance()->getCard(cardName);
+            card = CardDatabaseManager::getInstance()->getCardInfo(cardName);
         }
         emit cardChanged(card);
     }
@@ -180,7 +180,7 @@ CardInfoPtr DeckEditorDatabaseDisplayWidget::currentCardInfo() const
 
     const QString cardName = currentIndex.sibling(currentIndex.row(), 0).data().toString();
 
-    return CardDatabaseManager::getInstance()->getCard(cardName);
+    return CardDatabaseManager::getInstance()->getCardInfo(cardName);
 }
 
 void DeckEditorDatabaseDisplayWidget::databaseCustomMenu(QPoint point)

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_database_display_widget.cpp
@@ -143,7 +143,7 @@ void DeckEditorDatabaseDisplayWidget::updateCard(const QModelIndex &current, con
     }
 
     if (!current.model()->hasChildren(current.sibling(current.row(), 0))) {
-        CardInfoPtr card = CardDatabaseManager::getInstance()->getCardByNameAndProviderId(cardName, cardProviderID);
+        CardInfoPtr card = CardDatabaseManager::getInstance()->getCardByNameAndProviderId({cardName, cardProviderID});
         if (!card) {
             card = CardDatabaseManager::getInstance()->getCard(cardName);
         }

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -227,8 +227,7 @@ CardInfoPtr DeckEditorDeckDockWidget::getCurrentCard()
     if (!current.model()->hasChildren(current.sibling(current.row(), 0))) {
         QString cardName = current.sibling(current.row(), 1).data().toString();
         QString providerId = current.sibling(current.row(), 4).data().toString();
-        if (CardInfoPtr selectedCard =
-                CardDatabaseManager::getInstance()->getCardByNameAndProviderId({cardName, providerId})) {
+        if (CardInfoPtr selectedCard = CardDatabaseManager::getInstance()->getCard({cardName, providerId})) {
             return selectedCard;
         }
     }
@@ -287,8 +286,7 @@ void DeckEditorDeckDockWidget::updateBannerCardComboBox()
                 continue;
 
             for (int k = 0; k < currentCard->getNumber(); ++k) {
-                CardInfoPtr info =
-                    CardDatabaseManager::getInstance()->getCardByNameAndProviderId(currentCard->toCardRef());
+                CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(currentCard->toCardRef());
                 if (info) {
                     bannerCardSet.insert({currentCard->getName(), currentCard->getCardProviderId()});
                 }

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
@@ -44,8 +44,7 @@ PrintingSelectorCardOverlayWidget::PrintingSelectorCardOverlayWidget(QWidget *pa
     cardInfoPicture = new CardInfoPictureWidget(this);
     cardInfoPicture->setMinimumSize(0, 0);
     cardInfoPicture->setScaleFactor(cardSizeSlider->value());
-    setCard = CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-        {rootCard->getName(), _printingInfo.getProperty("uuid")});
+    setCard = CardDatabaseManager::getInstance()->getCard({rootCard->getName(), _printingInfo.getProperty("uuid")});
     cardInfoPicture->setCard(setCard);
     mainLayout->addWidget(cardInfoPicture);
 
@@ -199,7 +198,7 @@ void PrintingSelectorCardOverlayWidget::customMenu(QPoint point)
             const QString &relatedCardName = rel->getName();
             QAction *relatedCard = relatedMenu->addAction(relatedCardName);
             connect(relatedCard, &QAction::triggered, deckEditor, [this, relatedCardName] {
-                deckEditor->updateCard(CardDatabaseManager::getInstance()->getCard(relatedCardName));
+                deckEditor->updateCard(CardDatabaseManager::getInstance()->getCardInfo(relatedCardName));
                 deckEditor->showPrintingSelector();
             });
         }

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
@@ -44,8 +44,8 @@ PrintingSelectorCardOverlayWidget::PrintingSelectorCardOverlayWidget(QWidget *pa
     cardInfoPicture = new CardInfoPictureWidget(this);
     cardInfoPicture->setMinimumSize(0, 0);
     cardInfoPicture->setScaleFactor(cardSizeSlider->value());
-    setCard = CardDatabaseManager::getInstance()->getCardByNameAndProviderId(rootCard->getName(),
-                                                                             _printingInfo.getProperty("uuid"));
+    setCard = CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
+        {rootCard->getName(), _printingInfo.getProperty("uuid")});
     cardInfoPicture->setCard(setCard);
     mainLayout->addWidget(cardInfoPicture);
 
@@ -177,7 +177,7 @@ void PrintingSelectorCardOverlayWidget::customMenu(QPoint point)
     if (preferredProviderId.isEmpty() || preferredProviderId != cardProviderId) {
         auto *pinAction = preferenceMenu->addAction(tr("Pin Printing"));
         connect(pinAction, &QAction::triggered, this, [this, cardProviderId]() {
-            SettingsCache::instance().cardOverrides().setCardPreferenceOverride(rootCard->getName(), cardProviderId);
+            SettingsCache::instance().cardOverrides().setCardPreferenceOverride({rootCard->getName(), cardProviderId});
             emit cardPreferenceChanged();
         });
     } else {

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -234,7 +234,7 @@ void VisualDatabaseDisplayWidget::populateCards()
                 if (setMap.contains(setFilter->term())) {
                     for (PrintingInfo printing : setMap[setFilter->term()]) {
                         addCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-                            name.toString(), printing.getProperty("uuid")));
+                            {name.toString(), printing.getProperty("uuid")}));
                     }
                 }
             } else {
@@ -300,7 +300,7 @@ void VisualDatabaseDisplayWidget::loadNextPage()
                 if (setMap.contains(setFilter->term())) {
                     for (PrintingInfo printing : setMap[setFilter->term()]) {
                         addCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-                            name.toString(), printing.getProperty("uuid")));
+                            {name.toString(), printing.getProperty("uuid")}));
                     }
                 }
             } else {

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -228,12 +228,12 @@ void VisualDatabaseDisplayWidget::populateCards()
         QVariant name = databaseDisplayModel->data(index, Qt::DisplayRole);
         qCDebug(VisualDatabaseDisplayLog) << name.toString();
 
-        if (CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(name.toString())) {
+        if (CardInfoPtr info = CardDatabaseManager::getInstance()->getCardInfo(name.toString())) {
             if (setFilter) {
                 SetToPrintingsMap setMap = info->getSets();
                 if (setMap.contains(setFilter->term())) {
                     for (PrintingInfo printing : setMap[setFilter->term()]) {
-                        addCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
+                        addCard(CardDatabaseManager::getInstance()->getCard(
                             {name.toString(), printing.getProperty("uuid")}));
                     }
                 }
@@ -294,12 +294,12 @@ void VisualDatabaseDisplayWidget::loadNextPage()
     for (int row = start; row < end; ++row) {
         QModelIndex index = databaseDisplayModel->index(row, CardDatabaseModel::NameColumn);
         QVariant name = databaseDisplayModel->data(index, Qt::DisplayRole);
-        if (CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(name.toString())) {
+        if (CardInfoPtr info = CardDatabaseManager::getInstance()->getCardInfo(name.toString())) {
             if (setFilter) {
                 SetToPrintingsMap setMap = info->getSets();
                 if (setMap.contains(setFilter->term())) {
                     for (PrintingInfo printing : setMap[setFilter->term()]) {
-                        addCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
+                        addCard(CardDatabaseManager::getInstance()->getCard(
                             {name.toString(), printing.getProperty("uuid")}));
                     }
                 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_sample_hand_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_sample_hand_widget.cpp
@@ -101,8 +101,8 @@ QList<CardInfoPtr> VisualDeckEditorSampleHandWidget::getRandomCards(int amountTo
                 continue;
 
             for (int k = 0; k < currentCard->getNumber(); ++k) {
-                CardInfoPtr info = CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-                    currentCard->getName(), currentCard->getCardProviderId());
+                CardInfoPtr info =
+                    CardDatabaseManager::getInstance()->getCardByNameAndProviderId(currentCard->toCardRef());
                 if (info) {
                     mainDeckCards.append(info);
                 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_sample_hand_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_sample_hand_widget.cpp
@@ -101,8 +101,7 @@ QList<CardInfoPtr> VisualDeckEditorSampleHandWidget::getRandomCards(int amountTo
                 continue;
 
             for (int k = 0; k < currentCard->getNumber(); ++k) {
-                CardInfoPtr info =
-                    CardDatabaseManager::getInstance()->getCardByNameAndProviderId(currentCard->toCardRef());
+                CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(currentCard->toCardRef());
                 if (info) {
                     mainDeckCards.append(info);
                 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -42,7 +42,7 @@ VisualDeckEditorWidget::VisualDeckEditorWidget(QWidget *parent, DeckListModel *_
         if (!searchBar->hasFocus())
             return;
 
-        CardInfoPtr card = CardDatabaseManager::getInstance()->getCard(searchBar->text());
+        CardInfoPtr card = CardDatabaseManager::getInstance()->getCardInfo(searchBar->text());
         if (card) {
             emit cardAdditionRequested(card);
         }
@@ -103,7 +103,7 @@ VisualDeckEditorWidget::VisualDeckEditorWidget(QWidget *parent, DeckListModel *_
     // Search button functionality
     searchPushButton = new QPushButton(this);
     connect(searchPushButton, &QPushButton::clicked, this, [=, this]() {
-        CardInfoPtr card = CardDatabaseManager::getInstance()->getCard(searchBar->text());
+        CardInfoPtr card = CardDatabaseManager::getInstance()->getCardInfo(searchBar->text());
         if (card) {
             emit cardAdditionRequested(card);
         }

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -76,7 +76,7 @@ void DeckPreviewWidget::initializeUi(const bool deckLoadSuccess)
     }
     auto bannerCard = deckLoader->getBannerCard().name.isEmpty()
                           ? CardInfoPtr()
-                          : CardDatabaseManager::getInstance()->getCardByNameAndProviderId(deckLoader->getBannerCard());
+                          : CardDatabaseManager::getInstance()->getCard(deckLoader->getBannerCard());
 
     bannerCardDisplayWidget->setCard(bannerCard);
     bannerCardDisplayWidget->setFontSize(24);
@@ -160,7 +160,7 @@ QString DeckPreviewWidget::getColorIdentity()
     QSet<QChar> colorSet; // A set to collect unique color symbols (e.g., W, U, B, R, G)
 
     for (const QString &cardName : cardList) {
-        CardInfoPtr currentCard = CardDatabaseManager::getInstance()->getCard(cardName);
+        CardInfoPtr currentCard = CardDatabaseManager::getInstance()->getCardInfo(cardName);
         if (currentCard) {
             QString colors = currentCard->getColors(); // Assuming this returns something like "WUB"
             for (const QChar &color : colors) {
@@ -293,7 +293,7 @@ void DeckPreviewWidget::setBannerCard(int /* changedIndex */)
     CardRef cardRef = {name, id};
     deckLoader->setBannerCard(cardRef);
     deckLoader->saveToFile(filePath, DeckLoader::getFormatFromName(filePath));
-    bannerCardDisplayWidget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(cardRef));
+    bannerCardDisplayWidget->setCard(CardDatabaseManager::getInstance()->getCard(cardRef));
 }
 
 void DeckPreviewWidget::imageClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance)

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -74,10 +74,9 @@ void DeckPreviewWidget::initializeUi(const bool deckLoadSuccess)
     if (!deckLoadSuccess) {
         return;
     }
-    auto bannerCard = deckLoader->getBannerCard().first.isEmpty()
+    auto bannerCard = deckLoader->getBannerCard().name.isEmpty()
                           ? CardInfoPtr()
-                          : CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-                                deckLoader->getBannerCard().first, deckLoader->getBannerCard().second);
+                          : CardDatabaseManager::getInstance()->getCardByNameAndProviderId(deckLoader->getBannerCard());
 
     bannerCardDisplayWidget->setCard(bannerCard);
     bannerCardDisplayWidget->setFontSize(24);
@@ -91,7 +90,7 @@ void DeckPreviewWidget::initializeUi(const bool deckLoadSuccess)
     bannerCardComboBox = new QComboBox(this);
     bannerCardComboBox->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
     bannerCardComboBox->setObjectName("bannerCardComboBox");
-    bannerCardComboBox->setCurrentText(deckLoader->getBannerCard().first);
+    bannerCardComboBox->setCurrentText(deckLoader->getBannerCard().name);
     bannerCardComboBox->installEventFilter(new NoScrollFilter());
     connect(bannerCardComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &DeckPreviewWidget::setBannerCard);
@@ -274,7 +273,7 @@ void DeckPreviewWidget::updateBannerCardComboBox()
         bannerCardComboBox->setCurrentIndex(restoredIndex);
     } else {
         // Add a placeholder "-" and set it as the current selection
-        int bannerIndex = bannerCardComboBox->findText(deckLoader->getBannerCard().first);
+        int bannerIndex = bannerCardComboBox->findText(deckLoader->getBannerCard().name);
         if (bannerIndex != -1) {
             bannerCardComboBox->setCurrentIndex(bannerIndex);
         } else {
@@ -290,11 +289,11 @@ void DeckPreviewWidget::updateBannerCardComboBox()
 
 void DeckPreviewWidget::setBannerCard(int /* changedIndex */)
 {
-    auto nameAndId = bannerCardComboBox->currentData().value<QPair<QString, QString>>();
-    deckLoader->setBannerCard(nameAndId);
+    auto [name, id] = bannerCardComboBox->currentData().value<QPair<QString, QString>>();
+    CardRef cardRef = {name, id};
+    deckLoader->setBannerCard(cardRef);
     deckLoader->saveToFile(filePath, DeckLoader::getFormatFromName(filePath));
-    bannerCardDisplayWidget->setCard(
-        CardDatabaseManager::getInstance()->getCardByNameAndProviderId(nameAndId.first, nameAndId.second));
+    bannerCardDisplayWidget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(cardRef));
 }
 
 void DeckPreviewWidget::imageClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance)

--- a/cockatrice/src/deck/deck_list_model.cpp
+++ b/cockatrice/src/deck/deck_list_model.cpp
@@ -66,7 +66,7 @@ void DeckListModel::rebuildTree()
                 continue;
             }
 
-            CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(currentCard->getName());
+            CardInfoPtr info = CardDatabaseManager::getInstance()->getCardInfo(currentCard->getName());
             QString groupCriteria = getGroupCriteriaForCard(info);
 
             auto *groupNode = dynamic_cast<InnerDecklistNode *>(node->findChild(groupCriteria));
@@ -337,7 +337,7 @@ DecklistModelCardNode *DeckListModel::findCardNode(const QString &cardName,
         return nullptr;
     }
 
-    CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(cardName);
+    CardInfoPtr info = CardDatabaseManager::getInstance()->getCardInfo(cardName);
     if (!info) {
         return nullptr;
     }
@@ -375,8 +375,7 @@ QModelIndex DeckListModel::addCard(const QString &cardName,
                                    const QString &zoneName,
                                    bool abAddAnyway)
 {
-    CardInfoPtr cardInfo =
-        CardDatabaseManager::getInstance()->getCardByNameAndProviderId({cardName, printingInfo.getProperty("uuid")});
+    CardInfoPtr cardInfo = CardDatabaseManager::getInstance()->getCard({cardName, printingInfo.getProperty("uuid")});
 
     if (cardInfo == nullptr) {
         if (abAddAnyway) {
@@ -559,8 +558,7 @@ QList<CardInfoPtr> DeckListModel::getCardsAsCardInfoPtrs() const
             if (!currentCard)
                 continue;
             for (int k = 0; k < currentCard->getNumber(); ++k) {
-                CardInfoPtr info =
-                    CardDatabaseManager::getInstance()->getCardByNameAndProviderId(currentCard->toCardRef());
+                CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(currentCard->toCardRef());
                 if (info) {
                     cards.append(info);
                 } else {
@@ -593,8 +591,7 @@ QList<CardInfoPtr> DeckListModel::getCardsAsCardInfoPtrsForZone(QString zoneName
                 if (!currentCard)
                     continue;
                 for (int k = 0; k < currentCard->getNumber(); ++k) {
-                    CardInfoPtr info =
-                        CardDatabaseManager::getInstance()->getCardByNameAndProviderId(currentCard->toCardRef());
+                    CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(currentCard->toCardRef());
                     if (info) {
                         cards.append(info);
                     } else {

--- a/cockatrice/src/deck/deck_list_model.cpp
+++ b/cockatrice/src/deck/deck_list_model.cpp
@@ -376,7 +376,7 @@ QModelIndex DeckListModel::addCard(const QString &cardName,
                                    bool abAddAnyway)
 {
     CardInfoPtr cardInfo =
-        CardDatabaseManager::getInstance()->getCardByNameAndProviderId(cardName, printingInfo.getProperty("uuid"));
+        CardDatabaseManager::getInstance()->getCardByNameAndProviderId({cardName, printingInfo.getProperty("uuid")});
 
     if (cardInfo == nullptr) {
         if (abAddAnyway) {
@@ -559,8 +559,8 @@ QList<CardInfoPtr> DeckListModel::getCardsAsCardInfoPtrs() const
             if (!currentCard)
                 continue;
             for (int k = 0; k < currentCard->getNumber(); ++k) {
-                CardInfoPtr info = CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-                    currentCard->getName(), currentCard->getCardProviderId());
+                CardInfoPtr info =
+                    CardDatabaseManager::getInstance()->getCardByNameAndProviderId(currentCard->toCardRef());
                 if (info) {
                     cards.append(info);
                 } else {
@@ -593,8 +593,8 @@ QList<CardInfoPtr> DeckListModel::getCardsAsCardInfoPtrsForZone(QString zoneName
                 if (!currentCard)
                     continue;
                 for (int k = 0; k < currentCard->getNumber(); ++k) {
-                    CardInfoPtr info = CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-                        currentCard->getName(), currentCard->getCardProviderId());
+                    CardInfoPtr info =
+                        CardDatabaseManager::getInstance()->getCardByNameAndProviderId(currentCard->toCardRef());
                     if (info) {
                         cards.append(info);
                     } else {

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -281,7 +281,7 @@ QString DeckLoader::exportDeckToDecklist(DecklistWebsite website)
     // Set up the function to call
     auto formatDeckListForExport = [&mainBoardCards, &sideBoardCards](const auto *node, const auto *card) {
         // Get the card name
-        CardInfoPtr dbCard = CardDatabaseManager::getInstance()->getCard(card->getName());
+        CardInfoPtr dbCard = CardDatabaseManager::getInstance()->getCardInfo(card->getName());
         if (!dbCard || dbCard->getIsToken()) {
             // If it's a token, we don't care about the card.
             return;
@@ -466,7 +466,7 @@ void DeckLoader::saveToStream_DeckZone(QTextStream &out,
     for (int j = 0; j < zoneNode->size(); j++) {
         auto *card = dynamic_cast<DecklistCardNode *>(zoneNode->at(j));
 
-        CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(card->getName());
+        CardInfoPtr info = CardDatabaseManager::getInstance()->getCardInfo(card->getName());
         QString cardType = info ? info->getMainCardType() : "unknown";
 
         cardsByType.insert(cardType, card);
@@ -582,7 +582,7 @@ bool DeckLoader::convertToCockatriceFormat(QString fileName)
 
 QString DeckLoader::getCardZoneFromName(QString cardName, QString currentZoneName)
 {
-    CardInfoPtr card = CardDatabaseManager::getInstance()->getCard(cardName);
+    CardInfoPtr card = CardDatabaseManager::getInstance()->getCardInfo(cardName);
 
     if (card && card->getIsToken()) {
         return DECK_ZONE_TOKENS;

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -594,7 +594,7 @@ QString DeckLoader::getCardZoneFromName(QString cardName, QString currentZoneNam
 QString DeckLoader::getCompleteCardName(const QString &cardName) const
 {
     if (CardDatabaseManager::getInstance()) {
-        CardInfoPtr temp = CardDatabaseManager::getInstance()->guessCard(cardName);
+        CardInfoPtr temp = CardDatabaseManager::getInstance()->guessCard({cardName});
         if (temp) {
             return temp->getName();
         }

--- a/cockatrice/src/deck/deck_stats_interface.cpp
+++ b/cockatrice/src/deck/deck_stats_interface.cpp
@@ -70,7 +70,7 @@ void DeckStatsInterface::analyzeDeck(DeckList *deck)
 void DeckStatsInterface::copyDeckWithoutTokens(DeckList &source, DeckList &destination)
 {
     auto copyIfNotAToken = [this, &destination](const auto node, const auto card) {
-        CardInfoPtr dbCard = cardDatabase.getCard(card->getName());
+        CardInfoPtr dbCard = cardDatabase.getCardInfo(card->getName());
         if (dbCard && !dbCard->getIsToken()) {
             DecklistCardNode *addedCard = destination.addCard(card->getName(), node->getName(), -1);
             addedCard->setNumber(card->getNumber());

--- a/cockatrice/src/dialogs/dlg_edit_tokens.cpp
+++ b/cockatrice/src/dialogs/dlg_edit_tokens.cpp
@@ -152,7 +152,7 @@ void DlgEditTokens::actAddToken()
         name = getTextWithMax(this, tr("Add token"), tr("Please enter the name of the token:"));
         if (name.isEmpty())
             return;
-        if (databaseModel->getDatabase()->getCard(name)) {
+        if (databaseModel->getDatabase()->getCardInfo(name)) {
             QMessageBox::critical(this, tr("Error"),
                                   tr("The chosen name conflicts with an existing card or token.\nMake sure to enable "
                                      "the 'Token' set in the \"Manage sets\" dialog to display them correctly."));

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -222,7 +222,7 @@ QMap<QString, int> DlgSelectSetForCards::getSetsForCards()
             if (!currentCard)
                 continue;
 
-            CardInfoPtr infoPtr = CardDatabaseManager::getInstance()->getCard(currentCard->getName());
+            CardInfoPtr infoPtr = CardDatabaseManager::getInstance()->getCardInfo(currentCard->getName());
             if (!infoPtr)
                 continue;
 
@@ -290,12 +290,12 @@ void DlgSelectSetForCards::updateCardLists()
 
             if (!found) {
                 // The card was not in any selected set
-                CardInfoPtr infoPtr = CardDatabaseManager::getInstance()->getCard(currentCard->getName());
+                CardInfoPtr infoPtr = CardDatabaseManager::getInstance()->getCardInfo(currentCard->getName());
                 CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(uneditedCardsFlowWidget);
                 picture_widget->setCard(infoPtr);
                 uneditedCardsFlowWidget->addWidget(picture_widget);
             } else {
-                CardInfoPtr infoPtr = CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
+                CardInfoPtr infoPtr = CardDatabaseManager::getInstance()->getCard(
                     {currentCard->getName(), CardDatabaseManager::getInstance()
                                                  ->getSpecificPrinting(currentCard->getName(), foundSetName, "")
                                                  .getProperty("uuid")});
@@ -376,7 +376,7 @@ QMap<QString, QStringList> DlgSelectSetForCards::getCardsForSets()
             if (!currentCard)
                 continue;
 
-            CardInfoPtr infoPtr = CardDatabaseManager::getInstance()->getCard(currentCard->getName());
+            CardInfoPtr infoPtr = CardDatabaseManager::getInstance()->getCardInfo(currentCard->getName());
             if (!infoPtr)
                 continue;
 
@@ -628,7 +628,7 @@ void SetEntryWidget::updateCardDisplayWidgets()
         CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(cardListContainer);
         QString providerId =
             CardDatabaseManager::getInstance()->getSpecificPrinting(cardName, setName, nullptr).getProperty("uuid");
-        picture_widget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId({cardName, providerId}));
+        picture_widget->setCard(CardDatabaseManager::getInstance()->getCard({cardName, providerId}));
         cardListContainer->addWidget(picture_widget);
     }
 
@@ -636,7 +636,7 @@ void SetEntryWidget::updateCardDisplayWidgets()
         CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(alreadySelectedCardListContainer);
         QString providerId =
             CardDatabaseManager::getInstance()->getSpecificPrinting(cardName, setName, nullptr).getProperty("uuid");
-        picture_widget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId({cardName, providerId}));
+        picture_widget->setCard(CardDatabaseManager::getInstance()->getCard({cardName, providerId}));
         alreadySelectedCardListContainer->addWidget(picture_widget);
     }
 }

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -296,9 +296,9 @@ void DlgSelectSetForCards::updateCardLists()
                 uneditedCardsFlowWidget->addWidget(picture_widget);
             } else {
                 CardInfoPtr infoPtr = CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-                    currentCard->getName(), CardDatabaseManager::getInstance()
-                                                ->getSpecificPrinting(currentCard->getName(), foundSetName, "")
-                                                .getProperty("uuid"));
+                    {currentCard->getName(), CardDatabaseManager::getInstance()
+                                                 ->getSpecificPrinting(currentCard->getName(), foundSetName, "")
+                                                 .getProperty("uuid")});
                 CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(modifiedCardsFlowWidget);
                 picture_widget->setCard(infoPtr);
                 modifiedCardsFlowWidget->addWidget(picture_widget);
@@ -626,17 +626,17 @@ void SetEntryWidget::updateCardDisplayWidgets()
 
     for (const QString &cardName : possibleCards) {
         CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(cardListContainer);
-        picture_widget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-            cardName,
-            CardDatabaseManager::getInstance()->getSpecificPrinting(cardName, setName, nullptr).getProperty("uuid")));
+        QString providerId =
+            CardDatabaseManager::getInstance()->getSpecificPrinting(cardName, setName, nullptr).getProperty("uuid");
+        picture_widget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId({cardName, providerId}));
         cardListContainer->addWidget(picture_widget);
     }
 
     for (const QString &cardName : unusedCards) {
         CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(alreadySelectedCardListContainer);
-        picture_widget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-            cardName,
-            CardDatabaseManager::getInstance()->getSpecificPrinting(cardName, setName, nullptr).getProperty("uuid")));
+        QString providerId =
+            CardDatabaseManager::getInstance()->getSpecificPrinting(cardName, setName, nullptr).getProperty("uuid");
+        picture_widget->setCard(CardDatabaseManager::getInstance()->getCardByNameAndProviderId({cardName, providerId}));
         alreadySelectedCardListContainer->addWidget(picture_widget);
     }
 }

--- a/cockatrice/src/game/board/abstract_card_item.cpp
+++ b/cockatrice/src/game/board/abstract_card_item.cpp
@@ -57,7 +57,7 @@ void AbstractCardItem::pixmapUpdated()
 
 void AbstractCardItem::refreshCardInfo()
 {
-    info = CardDatabaseManager::getInstance()->getCardByNameAndProviderId(cardRef);
+    info = CardDatabaseManager::getInstance()->getCard(cardRef);
 
     if (!info && !cardRef.name.isEmpty()) {
         QVariantHash properties = QVariantHash();

--- a/cockatrice/src/game/board/abstract_card_item.cpp
+++ b/cockatrice/src/game/board/abstract_card_item.cpp
@@ -184,22 +184,9 @@ void AbstractCardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *
     painter->restore();
 }
 
-void AbstractCardItem::setName(const QString &_name)
+void AbstractCardItem::setCardRef(const CardRef &_cardRef)
 {
-    if (cardRef.name == _name)
-        return;
-
-    emit deleteCardInfoPopup(cardRef.name);
-    if (info)
-        disconnect(info.data(), nullptr, this, nullptr);
-    cardRef.name = _name;
-
-    refreshCardInfo();
-}
-
-void AbstractCardItem::setProviderId(const QString &_providerId)
-{
-    if (cardRef.providerId == _providerId) {
+    if (cardRef == _cardRef) {
         return;
     }
 
@@ -207,7 +194,7 @@ void AbstractCardItem::setProviderId(const QString &_providerId)
     if (info) {
         disconnect(info.data(), nullptr, this, nullptr);
     }
-    cardRef.providerId = _providerId;
+    cardRef = _cardRef;
 
     refreshCardInfo();
 }

--- a/cockatrice/src/game/board/abstract_card_item.h
+++ b/cockatrice/src/game/board/abstract_card_item.h
@@ -74,12 +74,11 @@ public:
     {
         return cardRef.name;
     }
-    void setName(const QString &_name = QString());
     QString getProviderId() const
     {
         return cardRef.providerId;
     }
-    void setProviderId(const QString &_providerId = QString());
+    void setCardRef(const CardRef &_cardRef);
     CardRef getCardRef() const
     {
         return cardRef;

--- a/cockatrice/src/game/board/abstract_card_item.h
+++ b/cockatrice/src/game/board/abstract_card_item.h
@@ -3,6 +3,7 @@
 
 #include "../cards/card_info.h"
 #include "arrow_target.h"
+#include "card_ref.h"
 
 class Player;
 
@@ -15,8 +16,7 @@ class AbstractCardItem : public ArrowTarget
 protected:
     CardInfoPtr info;
     int id;
-    QString name;
-    QString providerId;
+    CardRef cardRef;
     bool tapped;
     bool facedown;
     int tapAngle;
@@ -34,7 +34,7 @@ public slots:
 
 signals:
     void hovered(AbstractCardItem *card);
-    void showCardInfoPopup(const QPoint &pos, const QString &cardName, const QString &providerId);
+    void showCardInfoPopup(const QPoint &pos, const CardRef &cardRef);
     void deleteCardInfoPopup(QString cardName);
     void sigPixmapUpdated();
     void cardShiftClicked(QString cardName);
@@ -49,8 +49,7 @@ public:
         return Type;
     }
     explicit AbstractCardItem(QGraphicsItem *parent = nullptr,
-                              const QString &_name = QString(),
-                              const QString &_providerId = QString(),
+                              const CardRef &cardRef = {},
                               Player *_owner = nullptr,
                               int _id = -1);
     ~AbstractCardItem() override;
@@ -73,14 +72,18 @@ public:
     }
     QString getName() const
     {
-        return name;
+        return cardRef.name;
     }
     void setName(const QString &_name = QString());
     QString getProviderId() const
     {
-        return providerId;
+        return cardRef.providerId;
     }
     void setProviderId(const QString &_providerId = QString());
+    CardRef getCardRef() const
+    {
+        return cardRef;
+    }
     qreal getRealZValue() const
     {
         return realZValue;
@@ -105,7 +108,7 @@ public:
     void processHoverEvent();
     void deleteCardInfoPopup()
     {
-        emit deleteCardInfoPopup(name);
+        emit deleteCardInfoPopup(cardRef.name);
     }
 
 protected:

--- a/cockatrice/src/game/board/card_item.cpp
+++ b/cockatrice/src/game/board/card_item.cpp
@@ -241,8 +241,7 @@ void CardItem::processCardInfo(const ServerInfo_Card &_info)
     }
 
     setId(_info.id());
-    setProviderId(QString::fromStdString(_info.provider_id()));
-    setName(QString::fromStdString(_info.name()));
+    setCardRef({QString::fromStdString(_info.name()), QString::fromStdString(_info.provider_id())});
     setAttacking(_info.attacking());
     setFaceDown(_info.face_down());
     setPT(QString::fromStdString(_info.pt()));

--- a/cockatrice/src/game/board/card_item.cpp
+++ b/cockatrice/src/game/board/card_item.cpp
@@ -18,14 +18,9 @@
 #include <QMenu>
 #include <QPainter>
 
-CardItem::CardItem(Player *_owner,
-                   QGraphicsItem *parent,
-                   const QString &_name,
-                   const QString &_providerId,
-                   int _cardid,
-                   CardZone *_zone)
-    : AbstractCardItem(parent, _name, _providerId, _owner, _cardid), zone(_zone), attacking(false),
-      destroyOnZoneChange(false), doesntUntap(false), dragItem(nullptr), attachedTo(nullptr)
+CardItem::CardItem(Player *_owner, QGraphicsItem *parent, const CardRef &cardRef, int _cardid, CardZone *_zone)
+    : AbstractCardItem(parent, cardRef, _owner, _cardid), zone(_zone), attacking(false), destroyOnZoneChange(false),
+      doesntUntap(false), dragItem(nullptr), attachedTo(nullptr)
 {
     owner->addCard(this);
 

--- a/cockatrice/src/game/board/card_item.h
+++ b/cockatrice/src/game/board/card_item.h
@@ -51,8 +51,7 @@ public:
     }
     explicit CardItem(Player *_owner,
                       QGraphicsItem *parent = nullptr,
-                      const QString &_name = QString(),
-                      const QString &_providerId = QString(),
+                      const CardRef &cardRef = {},
                       int _cardid = -1,
                       CardZone *_zone = nullptr);
     ~CardItem() override;

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -198,7 +198,7 @@ CardInfoPtr CardDatabase::getCardBySimpleName(const QString &cardName) const
  */
 CardInfoPtr CardDatabase::guessCard(const CardRef &cardRef) const
 {
-    CardInfoPtr temp = cardRef.providerId.isEmpty() ? getCardInfo(cardRef.name) : getCard(cardRef);
+    CardInfoPtr temp = getCard(cardRef);
 
     if (temp == nullptr) { // get card by simple name instead
         temp = getCardBySimpleName(cardRef.name);

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -427,7 +427,7 @@ PrintingInfo CardDatabase::getSpecificPrinting(const QString &cardName,
     return PrintingInfo(nullptr);
 }
 
-QString CardDatabase::getPreferredPrintingProviderId(const QString &cardName)
+QString CardDatabase::getPreferredPrintingProviderId(const QString &cardName) const
 {
     PrintingInfo preferredPrinting = getPreferredPrinting(cardName);
     QString uuid = preferredPrinting.getProperty("uuid");
@@ -442,7 +442,7 @@ QString CardDatabase::getPreferredPrintingProviderId(const QString &cardName)
     return defaultCardInfo->getName();
 }
 
-bool CardDatabase::isPreferredPrinting(const CardRef &cardRef)
+bool CardDatabase::isPreferredPrinting(const CardRef &cardRef) const
 {
     if (cardRef.providerId.startsWith("card_")) {
         return cardRef.providerId ==

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -109,11 +109,24 @@ void CardDatabase::removeCard(CardInfoPtr card)
     emit cardRemoved(card);
 }
 
+/**
+ * Looks up the generic cardInfo (the CardInfoPtr that does not refer to a specific printing) corresponding to the
+ * cardName.
+ *
+ * @param cardName The card name to look up
+ * @return A generic CardInfoPtr, or null if not corresponding CardInfo is found.
+ */
 CardInfoPtr CardDatabase::getCardInfo(const QString &cardName) const
 {
     return cards.value(cardName);
 }
 
+/**
+ * Looks up the generic cardInfos (the CardInfoPtr that does not refer to a specific printing) for a list of card names.
+ *
+ * @param cardNames The card names to look up
+ * @return A List of generic CardInfoPtr. Any failed lookups will be ignored and dropped from the resulting list
+ */
 QList<CardInfoPtr> CardDatabase::getCardInfos(const QStringList &cardNames) const
 {
     QList<CardInfoPtr> cardInfos;
@@ -126,6 +139,14 @@ QList<CardInfoPtr> CardDatabase::getCardInfos(const QStringList &cardNames) cons
     return cardInfos;
 }
 
+/**
+ * Looks up the CardInfoPtrs corresponding to the CardRefs
+ *
+ * @param cardRefs The cards to look up. If providerId is null for an entry, will look up the generic CardInfo for that
+ * entry's cardName.
+ * @return A list of specific printings of cards. Any failed lookups will be ignored and dropped from the resulting
+ * list.
+ */
 QList<CardInfoPtr> CardDatabase::getCards(const QList<CardRef> &cardRefs) const
 {
     QList<CardInfoPtr> cardInfos;
@@ -138,6 +159,12 @@ QList<CardInfoPtr> CardDatabase::getCards(const QList<CardRef> &cardRefs) const
     return cardInfos;
 }
 
+/**
+ * Looks up the CardInfoPtr corresponding to the CardRef
+ *
+ * @param cardRef The card to look up. If providerId is null, will look up the generic CardInfo for the cardName.
+ * @return A specific printing of a card, or null if not found.
+ */
 CardInfoPtr CardDatabase::getCard(const CardRef &cardRef) const
 {
     auto info = getCardInfo(cardRef.name);
@@ -163,6 +190,12 @@ CardInfoPtr CardDatabase::getCardBySimpleName(const QString &cardName) const
     return simpleNameCards.value(CardInfo::simplifyName(cardName));
 }
 
+/**
+ * Looks up the CardInfoPtr by CardRef, simplifying the name if required.
+ *
+ * @param cardRef The card to look up. If providerId is null, will look up the generic CardInfo for the cardName.
+ * @return A specific printing of a card, or null if not found.
+ */
 CardInfoPtr CardDatabase::guessCard(const CardRef &cardRef) const
 {
     CardInfoPtr temp = cardRef.providerId.isEmpty() ? getCardInfo(cardRef.name) : getCard(cardRef);

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -1,8 +1,8 @@
 #ifndef CARDDATABASE_H
 #define CARDDATABASE_H
 
+#include "../common/card_ref.h"
 #include "card_info.h"
-#include "card_ref.h"
 
 #include <QBasicMutex>
 #include <QDate>

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -66,18 +66,19 @@ public:
     void clear();
     void removeCard(CardInfoPtr card);
 
-    [[nodiscard]] CardInfoPtr getCard(const QString &cardName) const;
-    [[nodiscard]] QList<CardInfoPtr> getCards(const QStringList &cardNames) const;
-    QList<CardInfoPtr> getCardsByNameAndProviderId(const QList<CardRef> &cardRefs) const;
-    [[nodiscard]] CardInfoPtr getCardByNameAndProviderId(const CardRef &cardRef) const;
+    [[nodiscard]] CardInfoPtr getCardInfo(const QString &cardName) const;
+    [[nodiscard]] QList<CardInfoPtr> getCardInfos(const QStringList &cardNames) const;
+
+    QList<CardInfoPtr> getCards(const QList<CardRef> &cardRefs) const;
+    [[nodiscard]] CardInfoPtr getCard(const CardRef &cardRef) const;
 
     [[nodiscard]] PrintingInfo getPreferredPrinting(const QString &cardName) const;
     [[nodiscard]] PrintingInfo getPreferredPrinting(const CardInfoPtr &cardInfo) const;
     [[nodiscard]] PrintingInfo getSpecificPrinting(const CardRef &cardRef) const;
     PrintingInfo
     getSpecificPrinting(const QString &cardName, const QString &setShortName, const QString &collectorNumber) const;
-    QString getPreferredPrintingProviderIdForCard(const QString &cardName);
-    bool isProviderIdForPreferredPrinting(const CardRef &cardRef);
+    QString getPreferredPrintingProviderId(const QString &cardName);
+    bool isPreferredPrinting(const CardRef &cardRef);
 
     [[nodiscard]] CardInfoPtr guessCard(const CardRef &cardRef) const;
 

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -2,6 +2,7 @@
 #define CARDDATABASE_H
 
 #include "card_info.h"
+#include "card_ref.h"
 
 #include <QBasicMutex>
 #include <QDate>
@@ -67,18 +68,18 @@ public:
 
     [[nodiscard]] CardInfoPtr getCard(const QString &cardName) const;
     [[nodiscard]] QList<CardInfoPtr> getCards(const QStringList &cardNames) const;
-    QList<CardInfoPtr> getCardsByNameAndProviderId(const QMap<QString, QString> &cardNames) const;
-    [[nodiscard]] CardInfoPtr getCardByNameAndProviderId(const QString &cardName, const QString &providerId) const;
+    QList<CardInfoPtr> getCardsByNameAndProviderId(const QList<CardRef> &cardRefs) const;
+    [[nodiscard]] CardInfoPtr getCardByNameAndProviderId(const CardRef &cardRef) const;
 
     [[nodiscard]] PrintingInfo getPreferredPrinting(const QString &cardName) const;
     [[nodiscard]] PrintingInfo getPreferredPrinting(const CardInfoPtr &cardInfo) const;
-    [[nodiscard]] PrintingInfo getSpecificPrinting(const QString &cardName, const QString &providerId) const;
+    [[nodiscard]] PrintingInfo getSpecificPrinting(const CardRef &cardRef) const;
     PrintingInfo
     getSpecificPrinting(const QString &cardName, const QString &setShortName, const QString &collectorNumber) const;
     QString getPreferredPrintingProviderIdForCard(const QString &cardName);
-    bool isProviderIdForPreferredPrinting(const QString &cardName, const QString &providerId);
+    bool isProviderIdForPreferredPrinting(const CardRef &cardRef);
 
-    [[nodiscard]] CardInfoPtr guessCard(const QString &cardName, const QString &providerId = QString()) const;
+    [[nodiscard]] CardInfoPtr guessCard(const CardRef &cardRef) const;
 
     /*
      * Get a card by its simple name. The name will be simplified in this

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -77,8 +77,8 @@ public:
     [[nodiscard]] PrintingInfo getSpecificPrinting(const CardRef &cardRef) const;
     PrintingInfo
     getSpecificPrinting(const QString &cardName, const QString &setShortName, const QString &collectorNumber) const;
-    QString getPreferredPrintingProviderId(const QString &cardName);
-    bool isPreferredPrinting(const CardRef &cardRef);
+    QString getPreferredPrintingProviderId(const QString &cardName) const;
+    bool isPreferredPrinting(const CardRef &cardRef) const;
 
     [[nodiscard]] CardInfoPtr guessCard(const CardRef &cardRef) const;
 

--- a/cockatrice/src/game/deckview/deck_view.cpp
+++ b/cockatrice/src/game/deckview/deck_view.cpp
@@ -67,11 +67,8 @@ void DeckViewCardDragItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
     event->accept();
 }
 
-DeckViewCard::DeckViewCard(QGraphicsItem *parent,
-                           const QString &_name,
-                           const QString &_providerId,
-                           const QString &_originZone)
-    : AbstractCardItem(parent, _name, _providerId, 0, -1), originZone(_originZone), dragItem(0)
+DeckViewCard::DeckViewCard(QGraphicsItem *parent, const CardRef &cardRef, const QString &_originZone)
+    : AbstractCardItem(parent, cardRef, 0, -1), originZone(_originZone), dragItem(0)
 {
     setAcceptHoverEvents(true);
 
@@ -362,8 +359,7 @@ void DeckViewScene::rebuildTree()
                 continue;
 
             for (int k = 0; k < currentCard->getNumber(); ++k) {
-                DeckViewCard *newCard = new DeckViewCard(container, currentCard->getName(),
-                                                         currentCard->getCardProviderId(), currentZone->getName());
+                DeckViewCard *newCard = new DeckViewCard(container, currentCard->toCardRef(), currentZone->getName());
                 container->addCard(newCard);
                 emit newCardAdded(newCard);
             }

--- a/cockatrice/src/game/deckview/deck_view.h
+++ b/cockatrice/src/game/deckview/deck_view.h
@@ -25,8 +25,7 @@ private:
 
 public:
     explicit DeckViewCard(QGraphicsItem *parent = nullptr,
-                          const QString &_name = QString(),
-                          const QString &_providerId = QString(),
+                          const CardRef &cardRef = {},
                           const QString &_originZone = QString());
     ~DeckViewCard() override;
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -332,8 +332,7 @@ void DeckViewContainer::deckSelectFinished(const Response &r)
 {
     const Response_DeckDownload &resp = r.GetExtension(Response_DeckDownload::ext);
     DeckLoader newDeck(QString::fromStdString(resp.deck()));
-    PictureLoader::cacheCardPixmaps(
-        CardDatabaseManager::getInstance()->getCardsByNameAndProviderId(newDeck.getCardRefList()));
+    PictureLoader::cacheCardPixmaps(CardDatabaseManager::getInstance()->getCards(newDeck.getCardRefList()));
     setDeck(newDeck);
     switchToDeckLoadedView();
 }

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -333,7 +333,7 @@ void DeckViewContainer::deckSelectFinished(const Response &r)
     const Response_DeckDownload &resp = r.GetExtension(Response_DeckDownload::ext);
     DeckLoader newDeck(QString::fromStdString(resp.deck()));
     PictureLoader::cacheCardPixmaps(
-        CardDatabaseManager::getInstance()->getCardsByNameAndProviderId(newDeck.getCardListWithProviderId()));
+        CardDatabaseManager::getInstance()->getCardsByNameAndProviderId(newDeck.getCardRefList()));
     setDeck(newDeck);
     switchToDeckLoadedView();
 }

--- a/cockatrice/src/game/filters/deck_filter_string.cpp
+++ b/cockatrice/src/game/filters/deck_filter_string.cpp
@@ -118,7 +118,7 @@ static void setupParserRules()
         return [=](const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &) -> bool {
             int count = 0;
             deck->deckLoader->forEachCard([&](InnerDecklistNode *, const DecklistCardNode *node) {
-                auto cardInfoPtr = CardDatabaseManager::getInstance()->getCard(node->getName());
+                auto cardInfoPtr = CardDatabaseManager::getInstance()->getCardInfo(node->getName());
                 if (!cardInfoPtr.isNull() && cardFilter.check(cardInfoPtr)) {
                     count += node->getNumber();
                 }

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -1886,7 +1886,7 @@ void Player::actCreateAnotherToken()
 void Player::actCreatePredefinedToken()
 {
     auto *action = static_cast<QAction *>(sender());
-    CardInfoPtr cardInfo = CardDatabaseManager::getInstance()->getCard(action->text());
+    CardInfoPtr cardInfo = CardDatabaseManager::getInstance()->getCardInfo(action->text());
     if (!cardInfo) {
         return;
     }
@@ -1912,8 +1912,8 @@ void Player::actCreateRelatedCard()
      * then let's allow it to be created via "create another token"
      */
     if (createRelatedFromRelation(sourceCard, cardRelation) && cardRelation->getCanCreateAnother()) {
-        CardInfoPtr cardInfo = CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-            {cardRelation->getName(), sourceCard->getProviderId()});
+        CardInfoPtr cardInfo =
+            CardDatabaseManager::getInstance()->getCard({cardRelation->getName(), sourceCard->getProviderId()});
         setLastToken(cardInfo);
     }
 }
@@ -1993,7 +1993,7 @@ void Player::actCreateAllRelatedCards()
      * then assign the first to the "Create another" shortcut.
      */
     if (cardRelation != nullptr && cardRelation->getCanCreateAnother()) {
-        CardInfoPtr cardInfo = CardDatabaseManager::getInstance()->getCard(cardRelation->getName());
+        CardInfoPtr cardInfo = CardDatabaseManager::getInstance()->getCardInfo(cardRelation->getName());
         setLastToken(cardInfo);
     }
 }
@@ -2040,7 +2040,7 @@ void Player::createCard(const CardItem *sourceCard,
                         CardRelation::AttachType attachType,
                         bool persistent)
 {
-    CardInfoPtr cardInfo = CardDatabaseManager::getInstance()->getCard(dbCardName);
+    CardInfoPtr cardInfo = CardDatabaseManager::getInstance()->getCardInfo(dbCardName);
 
     if (cardInfo == nullptr || sourceCard == nullptr) {
         return;
@@ -4076,7 +4076,7 @@ void Player::addRelatedCardView(const CardItem *card, QMenu *cardMenu)
     bool atLeastOneGoodRelationFound = false;
     QList<CardRelation *> relatedCards = cardInfo->getAllRelatedCards();
     for (const CardRelation *cardRelation : relatedCards) {
-        CardInfoPtr relatedCard = CardDatabaseManager::getInstance()->getCard(cardRelation->getName());
+        CardInfoPtr relatedCard = CardDatabaseManager::getInstance()->getCardInfo(cardRelation->getName());
         if (relatedCard != nullptr) {
             atLeastOneGoodRelationFound = true;
             break;
@@ -4122,10 +4122,10 @@ void Player::addRelatedCardActions(const CardItem *card, QMenu *cardMenu)
     int index = 0;
     QAction *createRelatedCards = nullptr;
     for (const CardRelation *cardRelation : relatedCards) {
-        CardInfoPtr relatedCard = CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-            {cardRelation->getName(), currentCardSet.getProperty("uuid")});
+        CardInfoPtr relatedCard =
+            CardDatabaseManager::getInstance()->getCard({cardRelation->getName(), currentCardSet.getProperty("uuid")});
         if (relatedCard == nullptr) {
-            relatedCard = CardDatabaseManager::getInstance()->getCard(cardRelation->getName());
+            relatedCard = CardDatabaseManager::getInstance()->getCardInfo(cardRelation->getName());
         }
         if (relatedCard == nullptr) {
             continue;

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -1849,7 +1849,7 @@ void Player::actCreateToken()
 
     lastTokenInfo = dlg.getTokenInfo();
 
-    CardInfoPtr correctedCard = CardDatabaseManager::getInstance()->guessCard(lastTokenInfo.name);
+    CardInfoPtr correctedCard = CardDatabaseManager::getInstance()->guessCard({lastTokenInfo.name});
     if (correctedCard) {
         lastTokenInfo.name = correctedCard->getName();
         lastTokenTableRow = TableZone::clampValidTableRow(2 - correctedCard->getTableRow());
@@ -1913,7 +1913,7 @@ void Player::actCreateRelatedCard()
      */
     if (createRelatedFromRelation(sourceCard, cardRelation) && cardRelation->getCanCreateAnother()) {
         CardInfoPtr cardInfo = CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-            cardRelation->getName(), sourceCard->getProviderId());
+            {cardRelation->getName(), sourceCard->getProviderId()});
         setLastToken(cardInfo);
     }
 }
@@ -2253,8 +2253,8 @@ void Player::eventCreateToken(const Event_CreateToken &event)
         return;
     }
 
-    CardItem *card = new CardItem(this, nullptr, QString::fromStdString(event.card_name()),
-                                  QString::fromStdString(event.card_provider_id()), event.card_id());
+    CardRef cardRef = {QString::fromStdString(event.card_name()), QString::fromStdString(event.card_provider_id())};
+    CardItem *card = new CardItem(this, nullptr, cardRef, event.card_id());
     // use db PT if not provided in event and not face-down
     if (!QString::fromStdString(event.pt()).isEmpty()) {
         card->setPT(QString::fromStdString(event.pt()));
@@ -4096,7 +4096,7 @@ void Player::addRelatedCardView(const CardItem *card, QMenu *cardMenu)
         QString relatedCardName = relatedCard->getName();
         QAction *viewCard = viewRelatedCards->addAction(relatedCardName);
         connect(viewCard, &QAction::triggered, game, [this, relatedCardName, currentCardSet] {
-            game->viewCardInfo(relatedCardName, currentCardSet.getProperty("uuid"));
+            game->viewCardInfo({relatedCardName, currentCardSet.getProperty("uuid")});
         });
     }
 }
@@ -4123,7 +4123,7 @@ void Player::addRelatedCardActions(const CardItem *card, QMenu *cardMenu)
     QAction *createRelatedCards = nullptr;
     for (const CardRelation *cardRelation : relatedCards) {
         CardInfoPtr relatedCard = CardDatabaseManager::getInstance()->getCardByNameAndProviderId(
-            cardRelation->getName(), currentCardSet.getProperty("uuid"));
+            {cardRelation->getName(), currentCardSet.getProperty("uuid")});
         if (relatedCard == nullptr) {
             relatedCard = CardDatabaseManager::getInstance()->getCard(cardRelation->getName());
         }

--- a/cockatrice/src/game/zones/card_zone.cpp
+++ b/cockatrice/src/game/zones/card_zone.cpp
@@ -166,7 +166,8 @@ CardItem *CardZone::getCard(int cardId, const QString &cardName)
     // It can be assumed that in an invisible zone, all cards are equal.
     if ((c->getId() == -1) || (c->getName().isEmpty())) {
         c->setId(cardId);
-        c->setName(cardName);
+        // TODO: also set providerId
+        c->setCardRef({cardName});
     }
     return c;
 }

--- a/cockatrice/src/game/zones/card_zone.cpp
+++ b/cockatrice/src/game/zones/card_zone.cpp
@@ -141,8 +141,7 @@ void CardZone::addCard(CardItem *card, const bool reorganize, const int x, const
 
     for (auto *view : views) {
         if (view->prepareAddCard(x)) {
-            view->addCard(new CardItem(player, nullptr, card->getName(), card->getProviderId(), card->getId()),
-                          reorganize, x, y);
+            view->addCard(new CardItem(player, nullptr, card->getCardRef(), card->getId()), reorganize, x, y);
         }
     }
 

--- a/cockatrice/src/game/zones/hand_zone.cpp
+++ b/cockatrice/src/game/zones/hand_zone.cpp
@@ -32,7 +32,7 @@ void HandZone::addCardImpl(CardItem *card, int x, int /*y*/)
 
     if (!cards.getContentsKnown()) {
         card->setId(-1);
-        card->setName();
+        card->setCardRef({});
     }
     card->setParentItem(this);
     card->resetState();

--- a/cockatrice/src/game/zones/pile_zone.cpp
+++ b/cockatrice/src/game/zones/pile_zone.cpp
@@ -66,11 +66,11 @@ void PileZone::addCardImpl(CardItem *card, int x, int /*y*/)
     cards.insert(x, card);
     card->setPos(0, 0);
     if (!contentsKnown()) {
-        card->setName(QString());
+        card->setCardRef({});
         card->setId(-1);
         // If we obscure a previously revealed card, its name has to be forgotten
         if (cards.size() > x + 1)
-            cards.at(x + 1)->setName(QString());
+            cards.at(x + 1)->setCardRef({});
     }
     card->setVisible(false);
     card->resetState();

--- a/cockatrice/src/game/zones/stack_zone.cpp
+++ b/cockatrice/src/game/zones/stack_zone.cpp
@@ -34,7 +34,7 @@ void StackZone::addCardImpl(CardItem *card, int x, int /*y*/)
 
     if (!cards.getContentsKnown()) {
         card->setId(-1);
-        card->setName();
+        card->setCardRef({});
     }
     card->setParentItem(this);
     card->resetState(true);

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -68,10 +68,11 @@ void ZoneViewZone::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*o
 void ZoneViewZone::initializeCards(const QList<const ServerInfo_Card *> &cardList)
 {
     if (!cardList.isEmpty()) {
-        for (int i = 0; i < cardList.size(); ++i)
-            addCard(new CardItem(player, this, QString::fromStdString(cardList[i]->name()),
-                                 QString::fromStdString(cardList[i]->provider_id()), cardList[i]->id()),
-                    false, i);
+        for (int i = 0; i < cardList.size(); ++i) {
+            auto card = cardList[i];
+            CardRef cardRef = {QString::fromStdString(card->name()), QString::fromStdString(card->provider_id())};
+            addCard(new CardItem(player, this, cardRef, card->id()), false, i);
+        }
         reorganizeCards();
     } else if (!origZone->contentsKnown()) {
         Command_DumpZone cmd;
@@ -88,7 +89,7 @@ void ZoneViewZone::initializeCards(const QList<const ServerInfo_Card *> &cardLis
         int number = numberCards == -1 ? c.size() : (numberCards < c.size() ? numberCards : c.size());
         for (int i = 0; i < number; i++) {
             CardItem *card = c.at(i);
-            addCard(new CardItem(player, this, card->getName(), card->getProviderId(), card->getId()), false, i);
+            addCard(new CardItem(player, this, card->getCardRef(), card->getId()), false, i);
         }
         reorganizeCards();
     }
@@ -102,7 +103,7 @@ void ZoneViewZone::zoneDumpReceived(const Response &r)
         const ServerInfo_Card &cardInfo = resp.zone_info().card_list(i);
         auto cardName = QString::fromStdString(cardInfo.name());
         auto cardProviderId = QString::fromStdString(cardInfo.provider_id());
-        auto *card = new CardItem(player, this, cardName, cardProviderId, cardInfo.id(), this);
+        auto *card = new CardItem(player, this, {cardName, cardProviderId}, cardInfo.id(), this);
         cards.insert(i, card);
     }
 

--- a/cockatrice/src/server/chat_view/chat_view.cpp
+++ b/cockatrice/src/server/chat_view/chat_view.cpp
@@ -582,9 +582,9 @@ void ChatView::mousePressEvent(QMouseEvent *event)
         case HoveredCard: {
             if ((event->button() == Qt::MiddleButton) || (event->button() == Qt::LeftButton))
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-                emit showCardInfoPopup(event->globalPosition().toPoint(), hoveredContent, QString());
+                emit showCardInfoPopup(event->globalPosition().toPoint(), {hoveredContent});
 #else
-                emit showCardInfoPopup(event->globalPos(), hoveredContent, QString());
+                emit showCardInfoPopup(event->globalPos(), {hoveredContent});
 #endif
             break;
         }

--- a/cockatrice/src/server/chat_view/chat_view.h
+++ b/cockatrice/src/server/chat_view/chat_view.h
@@ -109,7 +109,7 @@ protected:
 signals:
     void openMessageDialog(const QString &userName, bool focus);
     void cardNameHovered(QString cardName);
-    void showCardInfoPopup(const QPoint &pos, const QString &cardName, const QString &providerId);
+    void showCardInfoPopup(const QPoint &pos, const CardRef &cardRef);
     void deleteCardInfoPopup(QString cardName);
     void addMentionTag(QString mentionTag);
     void messageClickedSignal();

--- a/cockatrice/src/settings/card_override_settings.cpp
+++ b/cockatrice/src/settings/card_override_settings.cpp
@@ -5,9 +5,9 @@ CardOverrideSettings::CardOverrideSettings(const QString &settingPath, QObject *
 {
 }
 
-void CardOverrideSettings::setCardPreferenceOverride(const QString &cardName, const QString &providerId)
+void CardOverrideSettings::setCardPreferenceOverride(const CardRef &cardRef)
 {
-    setValue(providerId, cardName, "cards");
+    setValue(cardRef.providerId, cardRef.name, "cards");
 }
 
 void CardOverrideSettings::deleteCardPreferenceOverride(const QString &cardName)

--- a/cockatrice/src/settings/card_override_settings.h
+++ b/cockatrice/src/settings/card_override_settings.h
@@ -1,7 +1,7 @@
 #ifndef COCKATRICE_CARD_OVERRIDE_SETTINGS_H
 #define COCKATRICE_CARD_OVERRIDE_SETTINGS_H
 
-#include "card_ref.h"
+#include "../common/card_ref.h"
 #include "settings_manager.h"
 
 #include <QObject>

--- a/cockatrice/src/settings/card_override_settings.h
+++ b/cockatrice/src/settings/card_override_settings.h
@@ -1,6 +1,7 @@
 #ifndef COCKATRICE_CARD_OVERRIDE_SETTINGS_H
 #define COCKATRICE_CARD_OVERRIDE_SETTINGS_H
 
+#include "card_ref.h"
 #include "settings_manager.h"
 
 #include <QObject>
@@ -11,7 +12,7 @@ class CardOverrideSettings : public SettingsManager
     friend class SettingsCache;
 
 public:
-    void setCardPreferenceOverride(const QString &cardName, const QString &providerId);
+    void setCardPreferenceOverride(const CardRef &cardRef);
 
     void deleteCardPreferenceOverride(const QString &cardName);
 

--- a/common/card_ref.h
+++ b/common/card_ref.h
@@ -1,0 +1,24 @@
+#ifndef CARD_REF_H
+#define CARD_REF_H
+
+#include <QString>
+
+/**
+ * The information passed over the server that is required to identify the exact card to display.
+ *
+ * @param name The name of the card. Should not be empty, unless to indicate the lack of a card.
+ * @param providerId Determines which printing of the card to use. Can be empty, in which case Cockatrice should default
+ * to using the preferred set.
+ */
+struct CardRef
+{
+    QString name;
+    QString providerId = QString();
+
+    bool operator==(const CardRef &other) const
+    {
+        return name == other.name && providerId == other.providerId;
+    }
+};
+
+#endif // CARD_REF_H

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -1,6 +1,8 @@
 #ifndef DECKLIST_H
 #define DECKLIST_H
 
+#include "card_ref.h"
+
 #include <QMap>
 #include <QVector>
 
@@ -246,6 +248,10 @@ public:
     {
         return false;
     }
+    CardRef toCardRef() const
+    {
+        return {name, cardProviderId};
+    }
 };
 
 class DeckList : public QObject
@@ -253,13 +259,13 @@ class DeckList : public QObject
     Q_OBJECT
 private:
     QString name, comments;
-    QPair<QString, QString> bannerCard;
+    CardRef bannerCard;
     QString lastLoadedTimestamp;
     QStringList tags;
     QMap<QString, SideboardPlan *> sideboardPlans;
     InnerDecklistNode *root;
-    void getCardListHelper(InnerDecklistNode *node, QSet<QString> &result) const;
-    void getCardListWithProviderIdHelper(InnerDecklistNode *item, QMap<QString, QString> &result) const;
+    static void getCardListHelper(InnerDecklistNode *node, QSet<QString> &result);
+    static void getCardRefListHelper(InnerDecklistNode *item, QList<CardRef> &result);
     InnerDecklistNode *getZoneObjFromName(const QString &zoneName);
 
     /**
@@ -305,7 +311,7 @@ public slots:
         tags.clear();
         emit deckTagsChanged();
     }
-    void setBannerCard(const QPair<QString, QString> &_bannerCard = QPair<QString, QString>())
+    void setBannerCard(const CardRef &_bannerCard = {})
     {
         bannerCard = _bannerCard;
     }
@@ -331,7 +337,7 @@ public:
     {
         return tags;
     }
-    QPair<QString, QString> getBannerCard() const
+    CardRef getBannerCard() const
     {
         return bannerCard;
     }
@@ -365,7 +371,7 @@ public:
         return root->isEmpty() && name.isEmpty() && comments.isEmpty() && sideboardPlans.isEmpty();
     }
     QStringList getCardList() const;
-    QMap<QString, QString> getCardListWithProviderId() const;
+    QList<CardRef> getCardRefList() const;
 
     int getSideboardSize() const;
 

--- a/common/server_card.cpp
+++ b/common/server_card.cpp
@@ -27,15 +27,9 @@
 
 #include <QVariant>
 
-Server_Card::Server_Card(QString _name,
-                         QString _provider_id,
-                         int _id,
-                         int _coord_x,
-                         int _coord_y,
-                         Server_CardZone *_zone)
-    : zone(_zone), id(_id), coord_x(_coord_x), coord_y(_coord_y), name(_name), provider_id(_provider_id), tapped(false),
-      attacking(false), facedown(false), color(), ptString(), annotation(), destroyOnZoneChange(false),
-      doesntUntap(false), parentCard(0), stashedCard(nullptr)
+Server_Card::Server_Card(const CardRef &cardRef, int _id, int _coord_x, int _coord_y, Server_CardZone *_zone)
+    : zone(_zone), id(_id), coord_x(_coord_x), coord_y(_coord_y), cardRef(cardRef), tapped(false), attacking(false),
+      facedown(false), destroyOnZoneChange(false), doesntUntap(false), parentCard(0), stashedCard(nullptr)
 {
 }
 
@@ -134,10 +128,10 @@ void Server_Card::setParentCard(Server_Card *_parentCard)
 
 void Server_Card::getInfo(ServerInfo_Card *info)
 {
-    QString displayedName = facedown ? QString() : name;
+    QString displayedName = facedown ? QString() : cardRef.name;
 
     info->set_id(id);
-    info->set_provider_id(provider_id.toStdString());
+    info->set_provider_id(cardRef.providerId.toStdString());
     info->set_name(displayedName.toStdString());
     info->set_x(coord_x);
     info->set_y(coord_y);

--- a/common/server_card.h
+++ b/common/server_card.h
@@ -149,9 +149,9 @@ public:
         coord_x = x;
         coord_y = y;
     }
-    void setName(const QString &_name)
+    void setCardRef(const CardRef &_cardRef)
     {
-        cardRef.name = _name;
+        cardRef = _cardRef;
     }
     void setCounter(int _id, int value, Event_SetCardCounter *event = nullptr);
     void setTapped(bool _tapped)

--- a/common/server_card.h
+++ b/common/server_card.h
@@ -20,6 +20,7 @@
 #ifndef SERVER_CARD_H
 #define SERVER_CARD_H
 
+#include "card_ref.h"
 #include "pb/card_attributes.pb.h"
 #include "pb/serverinfo_card.pb.h"
 #include "server_arrowtarget.h"
@@ -38,8 +39,7 @@ private:
     Server_CardZone *zone;
     int id;
     int coord_x, coord_y;
-    QString name;
-    QString provider_id;
+    CardRef cardRef;
     QMap<int, int> counters;
     bool tapped;
     bool attacking;
@@ -55,12 +55,7 @@ private:
     Server_Card *stashedCard;
 
 public:
-    Server_Card(QString _name,
-                QString _provider_id,
-                int _id,
-                int _coord_x,
-                int _coord_y,
-                Server_CardZone *_zone = nullptr);
+    Server_Card(const CardRef &cardRef, int _id, int _coord_x, int _coord_y, Server_CardZone *_zone = nullptr);
     ~Server_Card() override;
 
     Server_CardZone *getZone() const
@@ -76,9 +71,13 @@ public:
     {
         return id;
     }
+    CardRef getCardRef() const
+    {
+        return cardRef;
+    }
     QString getProviderId() const
     {
-        return provider_id;
+        return cardRef.providerId;
     }
     int getX() const
     {
@@ -90,7 +89,7 @@ public:
     }
     QString getName() const
     {
-        return name;
+        return cardRef.name;
     }
     const QMap<int, int> &getCounters() const
     {
@@ -152,7 +151,7 @@ public:
     }
     void setName(const QString &_name)
     {
-        name = _name;
+        cardRef.name = _name;
     }
     void setCounter(int _id, int value, Event_SetCardCounter *event = nullptr);
     void setTapped(bool _tapped)

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -210,9 +210,7 @@ void Server_Player::setupZones()
                 continue;
             }
             for (int k = 0; k < currentCard->getNumber(); ++k) {
-                z->insertCard(
-                    new Server_Card(currentCard->getName(), currentCard->getCardProviderId(), nextCardId++, 0, 0, z),
-                    -1, 0);
+                z->insertCard(new Server_Card(currentCard->toCardRef(), nextCardId++, 0, 0, z), -1, 0);
             }
         }
     }
@@ -1517,7 +1515,7 @@ Server_Player::cmdCreateToken(const Command_CreateToken &cmd, ResponseContainer 
         yCoord = 0;
     }
 
-    auto *card = new Server_Card(cardName, cardProviderId, newCardId(), xCoord, yCoord);
+    auto *card = new Server_Card({cardName, cardProviderId}, newCardId(), xCoord, yCoord);
     card->moveToThread(thread());
     // Client should already prevent face-down tokens from having attributes; this just an extra server-side check
     if (!cmd.face_down()) {

--- a/dbconverter/CMakeLists.txt
+++ b/dbconverter/CMakeLists.txt
@@ -26,6 +26,9 @@ elseif(Qt5_FOUND)
   )
 endif()
 
+# Include directories
+include_directories(../common) # Required due to card_ref.h
+
 # Build servatrice binary and link it
 add_executable(dbconverter MACOSX_BUNDLE ${dbconverter_MOC_SRCS} ${dbconverter_SOURCES})
 

--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -79,6 +79,7 @@ elseif(Qt5_FOUND)
 endif()
 
 include_directories(../cockatrice/src)
+include_directories(../common)
 
 # Libz is required to support zipped files
 find_package(ZLIB)

--- a/tests/carddatabase/CMakeLists.txt
+++ b/tests/carddatabase/CMakeLists.txt
@@ -49,8 +49,8 @@ if(NOT GTEST_FOUND)
   add_dependencies(filter_string_test gtest)
 endif()
 
-target_link_libraries(carddatabase_test Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES})
-target_link_libraries(filter_string_test Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES})
+target_link_libraries(carddatabase_test cockatrice_common Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES})
+target_link_libraries(filter_string_test cockatrice_common Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES})
 
 add_test(NAME carddatabase_test COMMAND carddatabase_test)
 add_test(NAME filter_string_test COMMAND filter_string_test)


### PR DESCRIPTION
## Short roundup of the initial problem

Ever since we added `providerId` to Cockatrice, we've been haphazardly back-adding it to places that used to only expect a `cardName`.

I think code clarity would be improved if we encapsulated the `cardName` + `providerId` combination in a struct.

This is part of the refactor to replace the printing keying off the CardInfoPtr's pixmapCacheKey with a proper object that contains both the CardInfoPtr and the printing

## What will change with this Pull Request?
- Created a `CardRef` struct with two fields: `name` and `providerId` 
- Replaced places in the code where we pass `cardName` + `providerId` together with a single `CardRef` instead.
  - This includes places where we pass the string as parameters, as well as places where an object stores the two strings together.
- Renamed the cardInfo lookup methods in `CardDatabase`
  - Added docs to those methods