### PR TITLE
Refactor: remove second param from CardZone::getCard

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -1215,7 +1215,7 @@ CardItem *TabGame::getCard(int playerId, const QString &zoneName, int cardId) co
     if (!zone)
         return nullptr;
 
-    return zone->getCard(cardId, QString());
+    return zone->getCard(cardId);
 }
 
 QString TabGame::getTabText() const

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -2292,7 +2292,7 @@ void Player::eventSetCardAttr(const Event_SetCardAttr &event,
             emit logSetTapped(this, nullptr, event.attr_value() == "1");
         }
     } else {
-        CardItem *card = zone->getCard(event.card_id(), QString());
+        CardItem *card = zone->getCard(event.card_id());
         if (!card) {
             qWarning() << "Player::eventSetCardAttr: card id=" << event.card_id() << "not found";
             return;
@@ -2308,7 +2308,7 @@ void Player::eventSetCardCounter(const Event_SetCardCounter &event)
         return;
     }
 
-    CardItem *card = zone->getCard(event.card_id(), QString());
+    CardItem *card = zone->getCard(event.card_id());
     if (!card) {
         return;
     }
@@ -2467,10 +2467,17 @@ void Player::eventFlipCard(const Event_FlipCard &event)
     if (!zone) {
         return;
     }
-    CardItem *card = zone->getCard(event.card_id(), QString::fromStdString(event.card_name()));
+    CardItem *card = zone->getCard(event.card_id());
     if (!card) {
         return;
     }
+
+    QString cardName = QString::fromStdString(event.card_name());
+    if (!event.face_down()) {
+        // TODO: also set providerId
+        card->setCardRef({cardName});
+    }
+
     emit logFlipCard(this, card->getName(), event.face_down());
     card->setFaceDown(event.face_down());
     updateCardMenu(card);
@@ -2483,7 +2490,7 @@ void Player::eventDestroyCard(const Event_DestroyCard &event)
         return;
     }
 
-    CardItem *card = zone->getCard(event.card_id(), QString());
+    CardItem *card = zone->getCard(event.card_id());
     if (!card) {
         return;
     }
@@ -2510,7 +2517,7 @@ void Player::eventAttachCard(const Event_AttachCard &event)
         if (targetPlayer) {
             targetZone = targetPlayer->getZones().value(QString::fromStdString(event.target_zone()), 0);
             if (targetZone) {
-                targetCard = targetZone->getCard(event.target_card_id(), QString());
+                targetCard = targetZone->getCard(event.target_card_id());
             }
         }
     }
@@ -2520,7 +2527,7 @@ void Player::eventAttachCard(const Event_AttachCard &event)
         return;
     }
 
-    CardItem *startCard = startZone->getCard(event.card_id(), QString());
+    CardItem *startCard = startZone->getCard(event.card_id());
     if (!startCard) {
         return;
     }
@@ -2601,7 +2608,7 @@ void Player::eventRevealCards(const Event_RevealCards &event, EventProcessingOpt
         for (const auto &card : cardList) {
             QString cardName = QString::fromStdString(card->name());
             QString providerId = QString::fromStdString(card->provider_id());
-            CardItem *cardItem = zone->getCard(card->id(), QString());
+            CardItem *cardItem = zone->getCard(card->id());
             if (!cardItem) {
                 continue;
             }
@@ -2856,7 +2863,7 @@ void Player::processCardAttachment(const ServerInfo_Player &info)
         for (int j = 0; j < cardListSize; ++j) {
             const ServerInfo_Card &cardInfo = zoneInfo.card_list(j);
             if (cardInfo.has_attach_player_id()) {
-                CardItem *startCard = zone->getCard(cardInfo.id(), QString());
+                CardItem *startCard = zone->getCard(cardInfo.id());
                 CardItem *targetCard =
                     game->getCard(cardInfo.attach_player_id(), QString::fromStdString(cardInfo.attach_zone()),
                                   cardInfo.attach_card_id());
@@ -3045,10 +3052,10 @@ ArrowItem *Player::addArrow(const ServerInfo_Arrow &arrow)
         return nullptr;
     }
 
-    CardItem *startCard = startZone->getCard(arrow.start_card_id(), QString());
+    CardItem *startCard = startZone->getCard(arrow.start_card_id());
     CardItem *targetCard = nullptr;
     if (targetZone) {
-        targetCard = targetZone->getCard(arrow.target_card_id(), QString());
+        targetCard = targetZone->getCard(arrow.target_card_id());
     }
     if (!startCard || (!targetCard && arrow.has_target_card_id())) {
         return nullptr;

--- a/cockatrice/src/game/zones/card_zone.cpp
+++ b/cockatrice/src/game/zones/card_zone.cpp
@@ -154,7 +154,7 @@ void CardZone::addCard(CardItem *card, const bool reorganize, const int x, const
     emit cardCountChanged();
 }
 
-CardItem *CardZone::getCard(int cardId, const QString &cardName)
+CardItem *CardZone::getCard(int cardId)
 {
     CardItem *c = cards.findCard(cardId);
     if (!c) {
@@ -162,12 +162,10 @@ CardItem *CardZone::getCard(int cardId, const QString &cardName)
         return nullptr;
     }
     // If the card's id is -1, this zone is invisible,
-    // so we need to give the card an id and a name as it comes out.
+    // so we need to give the card an id as it comes out.
     // It can be assumed that in an invisible zone, all cards are equal.
-    if ((c->getId() == -1) || (c->getName().isEmpty())) {
+    if (c->getId() == -1) {
         c->setId(cardId);
-        // TODO: also set providerId
-        c->setCardRef({cardName});
     }
     return c;
 }

--- a/cockatrice/src/game/zones/card_zone.h
+++ b/cockatrice/src/game/zones/card_zone.h
@@ -103,7 +103,7 @@ public:
     }
     void addCard(CardItem *card, bool reorganize, int x, int y = -1);
     // getCard() finds a card by id.
-    CardItem *getCard(int cardId, const QString &cardName);
+    CardItem *getCard(int cardId);
     // takeCard() finds a card by position and removes it from the zone and from all of its views.
     virtual CardItem *takeCard(int position, int cardId, bool canResize = true);
     void removeCard(CardItem *card);


### PR DESCRIPTION
## Related Ticket(s)
- Preparation for #6038

## Short roundup of the initial problem

`CardZone::getCard(int cardId, const QString &cardName)` takes two params. However, every usage of the method except one always passes the empty string to the second param. The single exception is in `Player::eventFlipCard`. 

We need to add providerId support to the flip event. It's easier to move the cardName setting code out of `getCard` and into `eventFlipCard`, since that's the only place where we need to set it.

## What will change with this Pull Request?
- Removed the second parameter from `CardZone::getCard`
- Moved the name setting code out of `getCard` and into `eventFlipCard`
  - `eventFlipCard` will set the card's name if `event.face_down` is false (the card flips from face-down to face-up)
  - simplified a code a bit while I was at it
