### PR TITLE
Refactor: clean up CardDatabase pt2

### DIFF
--- a/cockatrice/src/client/tabs/api/edhrec/display/commander/edhrec_api_response_commander_details_display_widget.cpp
+++ b/cockatrice/src/client/tabs/api/edhrec/display/commander/edhrec_api_response_commander_details_display_widget.cpp
@@ -15,7 +15,7 @@ EdhrecCommanderResponseCommanderDetailsDisplayWidget::EdhrecCommanderResponseCom
     setLayout(layout);
 
     commanderPicture = new CardInfoPictureWidget(this);
-    commanderPicture->setCard(CardDatabaseManager::getInstance()->getCardInfo(commanderDetails.getName()));
+    commanderPicture->setCard(CardDatabaseManager::getInstance()->getCard({commanderDetails.getName()}));
 
     QWidget *currentParent = parentWidget();
     TabEdhRecMain *parentTab = nullptr;

--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.cpp
@@ -11,7 +11,7 @@
 #include <QVBoxLayout>
 #include <utility>
 
-CardInfoFrameWidget::CardInfoFrameWidget(const QString &cardName, QWidget *parent)
+CardInfoFrameWidget::CardInfoFrameWidget(QWidget *parent)
     : QTabWidget(parent), info(nullptr), viewTransformationButton(nullptr), cardTextOnly(false)
 {
     setContentsMargins(3, 3, 3, 3);
@@ -60,9 +60,6 @@ CardInfoFrameWidget::CardInfoFrameWidget(const QString &cardName, QWidget *paren
     tab3->setLayout(tab3Layout);
 
     setViewMode(SettingsCache::instance().getCardInfoViewMode());
-
-    // TODO: Change this to be by UUID
-    setCard(CardDatabaseManager::getInstance()->getCardInfo(cardName));
 }
 
 void CardInfoFrameWidget::retranslateUi()

--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.h
@@ -37,7 +37,7 @@ public:
         ImageAndTextView
     };
 
-    explicit CardInfoFrameWidget(const QString &cardName = QString(), QWidget *parent = nullptr);
+    explicit CardInfoFrameWidget(QWidget *parent = nullptr);
     CardInfoPtr getInfo()
     {
         return info;

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -227,8 +227,8 @@ QMap<QString, int> DlgSelectSetForCards::getSetsForCards()
                 continue;
 
             SetToPrintingsMap setMap = infoPtr->getSets();
-            for (auto it = setMap.begin(); it != setMap.end(); ++it) {
-                setCounts[it.key()]++;
+            for (auto &setName : setMap.keys()) {
+                setCounts[setName]++;
             }
         }
     }

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -72,6 +72,7 @@ public:
     QList<CardInfoPtr> getCards(const QList<CardRef> &cardRefs) const;
     [[nodiscard]] CardInfoPtr getCard(const CardRef &cardRef) const;
 
+    static PrintingInfo findPrintingWithId(const CardInfoPtr &cardInfo, const QString &providerId);
     [[nodiscard]] PrintingInfo getPreferredPrinting(const QString &cardName) const;
     [[nodiscard]] PrintingInfo getPreferredPrinting(const CardInfoPtr &cardInfo) const;
     [[nodiscard]] PrintingInfo getSpecificPrinting(const CardRef &cardRef) const;


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6034
- Follow-up to #6039

## Short roundup of the initial problem

Some more cleanup ahead of the big refactor

## What will change with this Pull Request?
- extract `findPrintingWithId` method
- correct wording in docs ("empty string" instead of "null string")
- Remove a redundant param from `CardInfoFrameWidget` constructor
- Use `getCard` instead of `getCardInfo` in one of the places