### PR TITLE
Fix turning cards face-up not having correct printing

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -2472,10 +2472,10 @@ void Player::eventFlipCard(const Event_FlipCard &event)
         return;
     }
 
-    QString cardName = QString::fromStdString(event.card_name());
     if (!event.face_down()) {
-        // TODO: also set providerId
-        card->setCardRef({cardName});
+        QString cardName = QString::fromStdString(event.card_name());
+        QString providerId = QString::fromStdString(event.card_provider_id());
+        card->setCardRef({cardName, providerId});
     }
 
     emit logFlipCard(this, card->getName(), event.face_down());

--- a/common/pb/event_flip_card.proto
+++ b/common/pb/event_flip_card.proto
@@ -9,4 +9,5 @@ message Event_FlipCard {
     optional sint32 card_id = 2;
     optional string card_name = 3;
     optional bool face_down = 4;
+    optional string card_provider_id = 5;
 }

--- a/common/server_player.cpp
+++ b/common/server_player.cpp
@@ -1324,6 +1324,7 @@ Server_Player::cmdFlipCard(const Command_FlipCard &cmd, ResponseContainer & /*rc
     event.set_card_id(card->getId());
     if (!faceDown) {
         event.set_card_name(card->getName().toStdString());
+        event.set_card_provider_id(card->getProviderId().toStdString());
     }
     event.set_face_down(faceDown);
     ges.enqueueGameEvent(event, playerId);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6038

## Short roundup of the initial problem

Flipping a unknown face-down card face-up will cause it to have the default printing, regardless of the selected printing. This is because the flip card event does not carry providerId info.

## What will change with this Pull Request?
- Added `card_provider_id` field to `Event_FlipCard` proto
- Updated server and client to use the new field

https://github.com/user-attachments/assets/30342050-5e43-4013-b103-8f9d5e16bdc8
