### PR TITLE
Refactor: add PrintingInfo::getUuid method

### DIFF
--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
@@ -130,7 +130,7 @@ void AbstractTabDeckEditor::actDecrementCardFromSideboard(CardInfoPtr info)
 
 void AbstractTabDeckEditor::actSwapCard(CardInfoPtr info, QString zoneName)
 {
-    QString providerId = CardDatabaseManager::getInstance()->getSetInfoForCard(info).getProperty("uuid");
+    QString providerId = CardDatabaseManager::getInstance()->getSetInfoForCard(info).getUuid();
     QString collectorNumber = CardDatabaseManager::getInstance()->getSetInfoForCard(info).getProperty("num");
 
     QModelIndex foundCard = deckDockWidget->deckModel->findCard(info->getName(), zoneName, providerId, collectorNumber);

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_local.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_local.cpp
@@ -66,7 +66,7 @@ QImage PictureLoaderLocal::tryLoad(const CardInfoPtr &toLoad) const
     if (setInstance.getSet()) {
         setName = setInstance.getSet()->getCorrectedShortName();
         collectorNumber = setInstance.getProperty("num");
-        providerId = setInstance.getProperty("uuid");
+        providerId = setInstance.getUuid();
     }
 
     qCDebug(PictureLoaderLocalLog).nospace()

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -488,7 +488,7 @@ void DeckEditorDeckDockWidget::actDecrementCard(CardInfoPtr info, QString zoneNa
     if (info->getIsToken())
         zoneName = DECK_ZONE_TOKENS;
 
-    QString providerId = CardDatabaseManager::getInstance()->getSetInfoForCard(info).getProperty("uuid");
+    QString providerId = CardDatabaseManager::getInstance()->getSetInfoForCard(info).getUuid();
     QString collectorNumber = CardDatabaseManager::getInstance()->getSetInfoForCard(info).getProperty("num");
 
     QModelIndex idx = deckModel->findCard(info->getName(), zoneName, providerId, collectorNumber);

--- a/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.cpp
@@ -152,8 +152,8 @@ void CardAmountWidget::addPrinting(const QString &zone)
         }
         deckModel->removeRow(find_card.row(), find_card.parent());
     }
-    newCardIndex = deckModel->findCard(rootCard->getName(), zone, printingInfo.getProperty("uuid"),
-                                       printingInfo.getProperty("num"));
+    newCardIndex =
+        deckModel->findCard(rootCard->getName(), zone, printingInfo.getUuid(), printingInfo.getProperty("num"));
     deckView->setCurrentIndex(newCardIndex);
     deckView->setFocus(Qt::FocusReason::MouseFocusReason);
     deckEditor->setModified(true);
@@ -235,8 +235,8 @@ void CardAmountWidget::offsetCountAtIndex(const QModelIndex &idx, int offset)
  */
 void CardAmountWidget::decrementCardHelper(const QString &zone)
 {
-    QModelIndex idx = deckModel->findCard(rootCard->getName(), zone, printingInfo.getProperty("uuid"),
-                                          printingInfo.getProperty("num"));
+    QModelIndex idx =
+        deckModel->findCard(rootCard->getName(), zone, printingInfo.getUuid(), printingInfo.getProperty("num"));
     offsetCountAtIndex(idx, -1);
     deckEditor->setModified(true);
 }
@@ -249,7 +249,7 @@ void CardAmountWidget::decrementCardHelper(const QString &zone)
  */
 int CardAmountWidget::countCardsInZone(const QString &deckZone)
 {
-    if (printingInfo.getProperty("uuid").isEmpty()) {
+    if (printingInfo.getUuid().isEmpty()) {
         return 0; // Cards without uuids/providerIds CANNOT match another card, they are undefined for us.
     }
 

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
@@ -44,7 +44,7 @@ PrintingSelectorCardOverlayWidget::PrintingSelectorCardOverlayWidget(QWidget *pa
     cardInfoPicture = new CardInfoPictureWidget(this);
     cardInfoPicture->setMinimumSize(0, 0);
     cardInfoPicture->setScaleFactor(cardSizeSlider->value());
-    setCard = CardDatabaseManager::getInstance()->getCard({rootCard->getName(), _printingInfo.getProperty("uuid")});
+    setCard = CardDatabaseManager::getInstance()->getCard({rootCard->getName(), _printingInfo.getUuid()});
     cardInfoPicture->setCard(setCard);
     mainLayout->addWidget(cardInfoPicture);
 
@@ -171,7 +171,7 @@ void PrintingSelectorCardOverlayWidget::customMenu(QPoint point)
 
     const auto &preferredProviderId =
         SettingsCache::instance().cardOverrides().getCardPreferenceOverride(rootCard->getName());
-    const auto &cardProviderId = printingInfo.getProperty("uuid");
+    const auto &cardProviderId = printingInfo.getUuid();
 
     if (preferredProviderId.isEmpty() || preferredProviderId != cardProviderId) {
         auto *pinAction = preferenceMenu->addAction(tr("Pin Printing"));

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_sorting_widget.cpp
@@ -159,7 +159,7 @@ QList<PrintingInfo> PrintingSelectorCardSortingWidget::prependPinnedPrintings(co
     if (!cardProviderId.isEmpty()) {
         for (int i = 0; i < printingsToUse.size(); ++i) {
             const auto &card = printingsToUse[i];
-            if (card.getProperty("uuid") == cardProviderId) {
+            if (card.getUuid() == cardProviderId) {
                 printingsToUse.move(i, 0);
                 break;
             }
@@ -218,9 +218,8 @@ QList<PrintingInfo> PrintingSelectorCardSortingWidget::prependPrintingsInDeck(co
 
     // Prepend sorted sets and remove them from the original list
     for (const auto &pair : countList) {
-        auto it = std::find_if(result.begin(), result.end(), [&pair](const PrintingInfo &item) {
-            return item.getProperty("uuid") == pair.first.getProperty("uuid");
-        });
+        auto it = std::find_if(result.begin(), result.end(),
+                               [&pair](const PrintingInfo &item) { return item.getUuid() == pair.first.getUuid(); });
         if (it != result.end()) {
             result.erase(it); // Remove the matching entry
         }

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -233,8 +233,7 @@ void VisualDatabaseDisplayWidget::populateCards()
                 SetToPrintingsMap setMap = info->getSets();
                 if (setMap.contains(setFilter->term())) {
                     for (PrintingInfo printing : setMap[setFilter->term()]) {
-                        addCard(CardDatabaseManager::getInstance()->getCard(
-                            {name.toString(), printing.getProperty("uuid")}));
+                        addCard(CardDatabaseManager::getInstance()->getCard({name.toString(), printing.getUuid()}));
                     }
                 }
             } else {
@@ -299,8 +298,7 @@ void VisualDatabaseDisplayWidget::loadNextPage()
                 SetToPrintingsMap setMap = info->getSets();
                 if (setMap.contains(setFilter->term())) {
                     for (PrintingInfo printing : setMap[setFilter->term()]) {
-                        addCard(CardDatabaseManager::getInstance()->getCard(
-                            {name.toString(), printing.getProperty("uuid")}));
+                        addCard(CardDatabaseManager::getInstance()->getCard({name.toString(), printing.getUuid()}));
                     }
                 }
             } else {

--- a/cockatrice/src/deck/deck_list_model.cpp
+++ b/cockatrice/src/deck/deck_list_model.cpp
@@ -375,7 +375,7 @@ QModelIndex DeckListModel::addCard(const QString &cardName,
                                    const QString &zoneName,
                                    bool abAddAnyway)
 {
-    CardInfoPtr cardInfo = CardDatabaseManager::getInstance()->getCard({cardName, printingInfo.getProperty("uuid")});
+    CardInfoPtr cardInfo = CardDatabaseManager::getInstance()->getCard({cardName, printingInfo.getUuid()});
 
     if (cardInfo == nullptr) {
         if (abAddAnyway) {
@@ -396,7 +396,7 @@ QModelIndex DeckListModel::addCard(const QString &cardName,
 
     const QModelIndex parentIndex = nodeToIndex(groupNode);
     auto *cardNode = dynamic_cast<DecklistModelCardNode *>(groupNode->findCardChildByNameProviderIdAndNumber(
-        cardName, printingInfo.getProperty("uuid"), printingInfo.getProperty("num")));
+        cardName, printingInfo.getUuid(), printingInfo.getProperty("num")));
     const auto cardSetName = printingInfo.getSet().isNull() ? "" : printingInfo.getSet()->getCorrectedShortName();
 
     if (!cardNode) {

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -325,7 +325,7 @@ struct SetProviderIdToPreferred
     {
         Q_UNUSED(node);
         PrintingInfo preferredPrinting = CardDatabaseManager::getInstance()->getPreferredPrinting(card->getName());
-        QString providerId = preferredPrinting.getProperty("uuid");
+        QString providerId = preferredPrinting.getUuid();
         QString setShortName = preferredPrinting.getSet()->getShortName();
         QString collectorNumber = preferredPrinting.getProperty("num");
 
@@ -359,7 +359,7 @@ void DeckLoader::resolveSetNameAndNumberToProviderID()
         QString providerId =
             CardDatabaseManager::getInstance()
                 ->getSpecificPrinting(card->getName(), card->getCardSetShortName(), card->getCardCollectorNumber())
-                .getProperty("uuid");
+                .getUuid();
 
         // Set the providerId on the card
         card->setCardProviderId(providerId);

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -298,7 +298,7 @@ void DlgSelectSetForCards::updateCardLists()
                 CardInfoPtr infoPtr = CardDatabaseManager::getInstance()->getCard(
                     {currentCard->getName(), CardDatabaseManager::getInstance()
                                                  ->getSpecificPrinting(currentCard->getName(), foundSetName, "")
-                                                 .getProperty("uuid")});
+                                                 .getUuid()});
                 CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(modifiedCardsFlowWidget);
                 picture_widget->setCard(infoPtr);
                 modifiedCardsFlowWidget->addWidget(picture_widget);
@@ -627,7 +627,7 @@ void SetEntryWidget::updateCardDisplayWidgets()
     for (const QString &cardName : possibleCards) {
         CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(cardListContainer);
         QString providerId =
-            CardDatabaseManager::getInstance()->getSpecificPrinting(cardName, setName, nullptr).getProperty("uuid");
+            CardDatabaseManager::getInstance()->getSpecificPrinting(cardName, setName, nullptr).getUuid();
         picture_widget->setCard(CardDatabaseManager::getInstance()->getCard({cardName, providerId}));
         cardListContainer->addWidget(picture_widget);
     }
@@ -635,7 +635,7 @@ void SetEntryWidget::updateCardDisplayWidgets()
     for (const QString &cardName : unusedCards) {
         CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(alreadySelectedCardListContainer);
         QString providerId =
-            CardDatabaseManager::getInstance()->getSpecificPrinting(cardName, setName, nullptr).getProperty("uuid");
+            CardDatabaseManager::getInstance()->getSpecificPrinting(cardName, setName, nullptr).getUuid();
         picture_widget->setCard(CardDatabaseManager::getInstance()->getCard({cardName, providerId}));
         alreadySelectedCardListContainer->addWidget(picture_widget);
     }

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -340,7 +340,7 @@ PrintingInfo CardDatabase::findPrintingWithId(const CardInfoPtr &cardInfo, const
 {
     for (const auto &printings : cardInfo->getSets()) {
         for (const auto &printing : printings) {
-            if (printing.getProperty("uuid") == providerId) {
+            if (printing.getUuid() == providerId) {
                 return printing;
             }
         }
@@ -432,7 +432,7 @@ PrintingInfo CardDatabase::getSpecificPrinting(const QString &cardName,
 QString CardDatabase::getPreferredPrintingProviderId(const QString &cardName) const
 {
     PrintingInfo preferredPrinting = getPreferredPrinting(cardName);
-    QString uuid = preferredPrinting.getProperty("uuid");
+    QString uuid = preferredPrinting.getUuid();
     if (!uuid.isEmpty()) {
         return uuid;
     }
@@ -462,7 +462,7 @@ PrintingInfo CardDatabase::getSetInfoForCard(const CardInfoPtr &_card)
 
     for (const auto &printings : setMap) {
         for (const auto &cardInfoForSet : printings) {
-            if (QLatin1String("card_") + _card->getName() + QString("_") + cardInfoForSet.getProperty("uuid") ==
+            if (QLatin1String("card_") + _card->getName() + QString("_") + cardInfoForSet.getUuid() ==
                 _card->getPixmapCacheKey()) {
                 return cardInfoForSet;
             }

--- a/cockatrice/src/game/cards/card_info.cpp
+++ b/cockatrice/src/game/cards/card_info.cpp
@@ -219,6 +219,14 @@ PrintingInfo::PrintingInfo(const CardSetPtr &_set) : set(_set)
 {
 }
 
+/**
+ * Gets the uuid property of the printing, or an empty string if the property isn't present
+ */
+QString PrintingInfo::getUuid() const
+{
+    return properties.value("uuid").toString();
+}
+
 CardInfo::CardInfo(const QString &_name,
                    const QString &_text,
                    bool _isToken,

--- a/cockatrice/src/game/cards/card_info.h
+++ b/cockatrice/src/game/cards/card_info.h
@@ -178,6 +178,8 @@ public:
     {
         properties.insert(_name, _value);
     }
+
+    QString getUuid() const;
 };
 
 class CardInfo : public QObject

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -4105,7 +4105,7 @@ void Player::addRelatedCardView(const CardItem *card, QMenu *cardMenu)
         QString relatedCardName = relatedCard->getName();
         QAction *viewCard = viewRelatedCards->addAction(relatedCardName);
         connect(viewCard, &QAction::triggered, game, [this, relatedCardName, currentCardSet] {
-            game->viewCardInfo({relatedCardName, currentCardSet.getProperty("uuid")});
+            game->viewCardInfo({relatedCardName, currentCardSet.getUuid()});
         });
     }
 }
@@ -4132,7 +4132,7 @@ void Player::addRelatedCardActions(const CardItem *card, QMenu *cardMenu)
     QAction *createRelatedCards = nullptr;
     for (const CardRelation *cardRelation : relatedCards) {
         CardInfoPtr relatedCard =
-            CardDatabaseManager::getInstance()->getCard({cardRelation->getName(), currentCardSet.getProperty("uuid")});
+            CardDatabaseManager::getInstance()->getCard({cardRelation->getName(), currentCardSet.getUuid()});
         if (relatedCard == nullptr) {
             relatedCard = CardDatabaseManager::getInstance()->getCardInfo(cardRelation->getName());
         }


### PR DESCRIPTION
## Short roundup of the initial problem

There are many places in the code where we get the `uuid` property from the PrintingInfo. Currently we just call `getProperty` with "uuid". I think it would be cleaner if we wrapped it in a method (and would make the autocomplete nicer)

## What will change with this Pull Request?
- Created `PrintingInfo::getUuid`
- Replaced all usages of `getProperty("uuid")`
