### PR TITLE
Fix server crash from out-of-bounds index when players is empty

### DIFF
--- a/common/server_game.cpp
+++ b/common/server_game.cpp
@@ -677,6 +677,11 @@ void Server_Game::nextTurn()
 {
     QMutexLocker locker(&gameMutex);
 
+    if (players.isEmpty()) {
+        qWarning() << "Server_Game::nextTurn was called while players is empty; gameId = " << gameId;
+        return;
+    }
+
     const QList<int> keys = players.keys();
     int listPos = -1;
     if (activePlayer != -1)


### PR DESCRIPTION
## Short roundup of the initial problem

If `Server_Game::nextTurn` gets called while the `players` map is empty, the server will crash from an out-of-bounds index at `keys[listPos]`. The logic inside the do block sets listPos to 0, then the code tries to access `keys[0]` while `keys` is empty.

I'm not sure how exact it would be possible for `nextTurn` to get called while `players` is empty, but the actual server has crashed a few times due to this before, so clearly there's some combination of conditions that could cause it to happen.

More pressingly, there's a one-line modification you can do to the client to cause this crash to happen on demand: Just go to [this line](https://github.com/Cockatrice/Cockatrice/blob/ae47ee802be8745d0e6768544c48b69aa143766f/cockatrice/src/game/deckview/deck_view_container.cpp#L356) and change `true` to `false`. Now the server will crash whenever you try to force start a game.

## What will change with this Pull Request?
- Check that `players` is not empty before proceeding.
- Add log in case we want to try to figure out the cause in the future