### PR TITLE
Refactor: use ExactCard to represent specific printings

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -198,6 +198,7 @@ set(cockatrice_SOURCES
     src/game/cards/card_database_parser/cockatrice_xml_4.cpp
     src/game/cards/card_info.cpp
     src/game/cards/card_search_model.cpp
+    src/game/cards/exact_card.cpp
     src/game/deckview/deck_view.cpp
     src/game/deckview/deck_view_container.cpp
     src/game/filters/deck_filter_string.cpp

--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.cpp
@@ -72,10 +72,10 @@ AbstractTabDeckEditor::AbstractTabDeckEditor(TabSupervisor *_tabSupervisor) : Ta
             &AbstractTabDeckEditor::refreshShortcuts);
 }
 
-void AbstractTabDeckEditor::updateCard(CardInfoPtr _card)
+void AbstractTabDeckEditor::updateCard(const ExactCard &card)
 {
-    cardInfoDockWidget->updateCard(_card);
-    printingSelectorDockWidget->printingSelector->setCard(_card, DECK_ZONE_MAIN);
+    cardInfoDockWidget->updateCard(card);
+    printingSelectorDockWidget->printingSelector->setCard(card.getCardPtr(), DECK_ZONE_MAIN);
 }
 
 void AbstractTabDeckEditor::onDeckChanged()
@@ -88,14 +88,14 @@ void AbstractTabDeckEditor::onDeckModified()
     deckMenu->setSaveStatus(!isBlankNewDeck());
 }
 
-void AbstractTabDeckEditor::addCardHelper(const CardInfoPtr info, QString zoneName)
+void AbstractTabDeckEditor::addCardHelper(const ExactCard &card, QString zoneName)
 {
-    if (!info)
+    if (!card)
         return;
-    if (info->getIsToken())
+    if (card.getInfo().getIsToken())
         zoneName = DECK_ZONE_TOKENS;
 
-    QModelIndex newCardIndex = deckDockWidget->deckModel->addPreferredPrintingCard(info->getName(), zoneName, false);
+    QModelIndex newCardIndex = deckDockWidget->deckModel->addCard(card, zoneName);
     // recursiveExpand(newCardIndex);
     deckDockWidget->deckView->clearSelection();
     deckDockWidget->deckView->setCurrentIndex(newCardIndex);
@@ -103,39 +103,39 @@ void AbstractTabDeckEditor::addCardHelper(const CardInfoPtr info, QString zoneNa
     databaseDisplayDockWidget->searchEdit->setSelection(0, databaseDisplayDockWidget->searchEdit->text().length());
 }
 
-void AbstractTabDeckEditor::actAddCard(CardInfoPtr info)
+void AbstractTabDeckEditor::actAddCard(const ExactCard &card)
 {
     if (QApplication::keyboardModifiers() & Qt::ControlModifier)
-        actAddCardToSideboard(info);
+        actAddCardToSideboard(card);
     else
-        addCardHelper(info, DECK_ZONE_MAIN);
+        addCardHelper(card, DECK_ZONE_MAIN);
     deckMenu->setSaveStatus(true);
 }
 
-void AbstractTabDeckEditor::actAddCardToSideboard(CardInfoPtr info)
+void AbstractTabDeckEditor::actAddCardToSideboard(const ExactCard &card)
 {
-    addCardHelper(info, DECK_ZONE_SIDE);
+    addCardHelper(card, DECK_ZONE_SIDE);
     deckMenu->setSaveStatus(true);
 }
 
-void AbstractTabDeckEditor::actDecrementCard(CardInfoPtr info)
+void AbstractTabDeckEditor::actDecrementCard(const ExactCard &card)
 {
-    emit decrementCard(info, DECK_ZONE_MAIN);
+    emit decrementCard(card, DECK_ZONE_MAIN);
 }
 
-void AbstractTabDeckEditor::actDecrementCardFromSideboard(CardInfoPtr info)
+void AbstractTabDeckEditor::actDecrementCardFromSideboard(const ExactCard &card)
 {
-    emit decrementCard(info, DECK_ZONE_SIDE);
+    emit decrementCard(card, DECK_ZONE_SIDE);
 }
 
-void AbstractTabDeckEditor::actSwapCard(CardInfoPtr info, QString zoneName)
+void AbstractTabDeckEditor::actSwapCard(const ExactCard &card, const QString &zoneName)
 {
-    QString providerId = CardDatabaseManager::getInstance()->getSetInfoForCard(info).getUuid();
-    QString collectorNumber = CardDatabaseManager::getInstance()->getSetInfoForCard(info).getProperty("num");
+    QString providerId = card.getPrinting().getUuid();
+    QString collectorNumber = card.getPrinting().getProperty("num");
 
-    QModelIndex foundCard = deckDockWidget->deckModel->findCard(info->getName(), zoneName, providerId, collectorNumber);
+    QModelIndex foundCard = deckDockWidget->deckModel->findCard(card.getName(), zoneName, providerId, collectorNumber);
     if (!foundCard.isValid()) {
-        foundCard = deckDockWidget->deckModel->findCard(info->getName(), zoneName);
+        foundCard = deckDockWidget->deckModel->findCard(card.getName(), zoneName);
     }
 
     deckDockWidget->swapCard(foundCard);

--- a/cockatrice/src/client/tabs/abstract_tab_deck_editor.h
+++ b/cockatrice/src/client/tabs/abstract_tab_deck_editor.h
@@ -71,11 +71,11 @@ public:
 public slots:
     virtual void onDeckChanged();
     virtual void onDeckModified();
-    void updateCard(CardInfoPtr _card);
-    void actAddCard(CardInfoPtr info);
-    void actAddCardToSideboard(CardInfoPtr info);
-    void actDecrementCard(CardInfoPtr info);
-    void actDecrementCardFromSideboard(CardInfoPtr info);
+    void updateCard(const ExactCard &card);
+    void actAddCard(const ExactCard &card);
+    void actAddCardToSideboard(const ExactCard &card);
+    void actDecrementCard(const ExactCard &card);
+    void actDecrementCardFromSideboard(const ExactCard &card);
     void actOpenRecent(const QString &fileName);
     void filterTreeChanged(FilterTree *filterTree);
     void closeRequest(bool forced = false) override;
@@ -85,7 +85,7 @@ public slots:
 signals:
     void openDeckEditor(const DeckLoader *deckLoader);
     void deckEditorClosing(AbstractTabDeckEditor *tab);
-    void decrementCard(CardInfoPtr card, QString zoneName);
+    void decrementCard(const ExactCard &card, QString zoneName);
 
 protected slots:
     // Deck Operations
@@ -142,8 +142,8 @@ protected:
     bool isBlankNewDeck() const;
 
     // Helper functions for card actions
-    void addCardHelper(CardInfoPtr info, QString zoneName);
-    void actSwapCard(CardInfoPtr info, QString zoneName);
+    void addCardHelper(const ExactCard &card, QString zoneName);
+    void actSwapCard(const ExactCard &card, const QString &zoneName);
     virtual void openDeckFromFile(const QString &fileName, DeckOpenLocation deckOpenLocation);
 
     // UI Menu Elements

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -150,7 +150,8 @@ void TabDeckEditor::refreshShortcuts()
 
 void TabDeckEditor::showPrintingSelector()
 {
-    printingSelectorDockWidget->printingSelector->setCard(cardInfoDockWidget->cardInfo->getInfo(), DECK_ZONE_MAIN);
+    printingSelectorDockWidget->printingSelector->setCard(cardInfoDockWidget->cardInfo->getCard().getCardPtr(),
+                                                          DECK_ZONE_MAIN);
     printingSelectorDockWidget->printingSelector->updateDisplay();
     aPrintingSelectorDockVisible->setChecked(true);
     printingSelectorDockWidget->setVisible(true);

--- a/cockatrice/src/client/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
+++ b/cockatrice/src/client/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
@@ -153,15 +153,15 @@ QString TabDeckEditorVisual::getTabText() const
     return result;
 }
 
-void TabDeckEditorVisual::changeModelIndexAndCardInfo(const CardInfoPtr &activeCard)
+void TabDeckEditorVisual::changeModelIndexAndCardInfo(const ExactCard &activeCard)
 {
     updateCard(activeCard);
     changeModelIndexToCard(activeCard);
 }
 
-void TabDeckEditorVisual::changeModelIndexToCard(const CardInfoPtr &activeCard)
+void TabDeckEditorVisual::changeModelIndexToCard(const ExactCard &activeCard)
 {
-    QString cardName = activeCard->getName();
+    QString cardName = activeCard.getName();
     QModelIndex index = deckDockWidget->deckModel->findCard(cardName, DECK_ZONE_MAIN);
     if (!index.isValid()) {
         index = deckDockWidget->deckModel->findCard(cardName, DECK_ZONE_SIDE);
@@ -174,9 +174,9 @@ void TabDeckEditorVisual::processMainboardCardClick(QMouseEvent *event,
                                                     QString zoneName)
 {
     if (event->button() == Qt::LeftButton) {
-        actSwapCard(instance->getInfo(), zoneName);
+        actSwapCard(instance->getCard(), zoneName);
     } else if (event->button() == Qt::RightButton) {
-        actDecrementCard(instance->getInfo());
+        actDecrementCard(instance->getCard());
     } else if (event->button() == Qt::MiddleButton) {
         deckDockWidget->actRemoveCard();
     }
@@ -186,9 +186,9 @@ void TabDeckEditorVisual::processCardClickDatabaseDisplay(QMouseEvent *event,
                                                           CardInfoPictureWithTextOverlayWidget *instance)
 {
     if (event->button() == Qt::LeftButton) {
-        actAddCard(instance->getInfo());
+        actAddCard(instance->getCard());
     } else if (event->button() == Qt::RightButton) {
-        actDecrementCard(instance->getInfo());
+        actDecrementCard(instance->getCard());
     } else if (event->button() == Qt::MiddleButton) {
         deckDockWidget->actRemoveCard();
     }
@@ -205,7 +205,8 @@ bool TabDeckEditorVisual::actSaveDeckAs()
 
 void TabDeckEditorVisual::showPrintingSelector()
 {
-    printingSelectorDockWidget->printingSelector->setCard(cardInfoDockWidget->cardInfo->getInfo(), DECK_ZONE_MAIN);
+    printingSelectorDockWidget->printingSelector->setCard(cardInfoDockWidget->cardInfo->getCard().getCardPtr(),
+                                                          DECK_ZONE_MAIN);
     printingSelectorDockWidget->printingSelector->updateDisplay();
     aPrintingSelectorDockVisible->setChecked(true);
     printingSelectorDockWidget->setVisible(true);

--- a/cockatrice/src/client/tabs/visual_deck_editor/tab_deck_editor_visual.h
+++ b/cockatrice/src/client/tabs/visual_deck_editor/tab_deck_editor_visual.h
@@ -34,8 +34,8 @@ public:
     explicit TabDeckEditorVisual(TabSupervisor *_tabSupervisor);
     void retranslateUi() override;
     QString getTabText() const override;
-    void changeModelIndexAndCardInfo(const CardInfoPtr &activeCard);
-    void changeModelIndexToCard(const CardInfoPtr &activeCard);
+    void changeModelIndexAndCardInfo(const ExactCard &activeCard);
+    void changeModelIndexToCard(const ExactCard &activeCard);
     void createDeckAnalyticsDock();
     void createMenus() override;
     void createSearchAndDatabaseFrame();

--- a/cockatrice/src/client/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.cpp
+++ b/cockatrice/src/client/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.cpp
@@ -46,12 +46,12 @@ TabDeckEditorVisualTabWidget::TabDeckEditorVisualTabWidget(QWidget *parent,
     this->addNewTab(sampleHandWidget, tr("Sample Hand"));
 }
 
-void TabDeckEditorVisualTabWidget::onCardChanged(CardInfoPtr activeCard)
+void TabDeckEditorVisualTabWidget::onCardChanged(const ExactCard &activeCard)
 {
     emit cardChanged(activeCard);
 }
 
-void TabDeckEditorVisualTabWidget::onCardChangedDatabaseDisplay(CardInfoPtr activeCard)
+void TabDeckEditorVisualTabWidget::onCardChangedDatabaseDisplay(const ExactCard &activeCard)
 {
     emit cardChangedDatabaseDisplay(activeCard);
 }

--- a/cockatrice/src/client/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.h
+++ b/cockatrice/src/client/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.h
@@ -37,14 +37,14 @@ public:
     VisualDeckEditorSampleHandWidget *sampleHandWidget;
 
 public slots:
-    void onCardChanged(CardInfoPtr activeCard);
-    void onCardChangedDatabaseDisplay(CardInfoPtr activeCard);
+    void onCardChanged(const ExactCard &activeCard);
+    void onCardChangedDatabaseDisplay(const ExactCard &activeCard);
     void onCardClickedDeckEditor(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance, QString zoneName);
     void onCardClickedDatabaseDisplay(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance);
 
 signals:
-    void cardChanged(CardInfoPtr activeCard);
-    void cardChangedDatabaseDisplay(CardInfoPtr activeCard);
+    void cardChanged(const ExactCard &activeCard);
+    void cardChangedDatabaseDisplay(const ExactCard &activeCard);
     void cardClicked(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance, QString zoneName);
     void cardClickedDatabaseDisplay(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance);
 

--- a/cockatrice/src/client/ui/picture_loader/picture_loader.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader.h
@@ -31,13 +31,12 @@ private:
     PictureLoaderStatusBar *statusBar;
 
 public:
-    static void getPixmap(QPixmap &pixmap, CardInfoPtr card, QSize size);
+    static void getPixmap(QPixmap &pixmap, const ExactCard &card, QSize size);
     static void getCardBackPixmap(QPixmap &pixmap, QSize size);
     static void getCardBackLoadingInProgressPixmap(QPixmap &pixmap, QSize size);
     static void getCardBackLoadingFailedPixmap(QPixmap &pixmap, QSize size);
-    static void clearPixmapCache(CardInfoPtr card);
     static void clearPixmapCache();
-    static void cacheCardPixmaps(QList<CardInfoPtr> cards);
+    static void cacheCardPixmaps(const QList<ExactCard> &cards);
     static bool hasCustomArt();
 
 public slots:
@@ -48,6 +47,6 @@ private slots:
     void picsPathChanged();
 
 public slots:
-    void imageLoaded(CardInfoPtr card, const QImage &image);
+    void imageLoaded(const ExactCard &card, const QImage &image);
 };
 #endif

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_local.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_local.cpp
@@ -52,14 +52,12 @@ void PictureLoaderLocal::refreshIndex()
  * @param toLoad The card to load
  * @return The loaded image, or an empty QImage if loading failed.
  */
-QImage PictureLoaderLocal::tryLoad(const CardInfoPtr &toLoad) const
+QImage PictureLoaderLocal::tryLoad(const ExactCard &toLoad) const
 {
-    CardSetPtr set = PictureToLoad::extractSetsSorted(toLoad).first();
+    PrintingInfo setInstance = toLoad.getPrinting();
 
-    PrintingInfo setInstance = CardDatabaseManager::getInstance()->getSetInfoForCard(toLoad);
-
-    QString cardName = toLoad->getName();
-    QString correctedCardName = toLoad->getCorrectedName();
+    QString cardName = toLoad.getName();
+    QString correctedCardName = toLoad.getInfo().getCorrectedName();
 
     QString setName, collectorNumber, providerId;
 

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_local.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_local.h
@@ -1,7 +1,7 @@
 #ifndef PICTURE_LOADER_LOCAL_H
 #define PICTURE_LOADER_LOCAL_H
 
-#include "../../../game/cards/card_info.h"
+#include "../../../game/cards/exact_card.h"
 
 #include <QLoggingCategory>
 #include <QObject>
@@ -20,7 +20,7 @@ class PictureLoaderLocal : public QObject
 public:
     explicit PictureLoaderLocal(QObject *parent);
 
-    QImage tryLoad(const CardInfoPtr &toLoad) const;
+    QImage tryLoad(const ExactCard &toLoad) const;
 
 private:
     QString picsPath, customPicsPath;

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_request_status_display_widget.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_request_status_display_widget.cpp
@@ -2,18 +2,18 @@
 
 PictureLoaderRequestStatusDisplayWidget::PictureLoaderRequestStatusDisplayWidget(QWidget *parent,
                                                                                  const QUrl &_url,
-                                                                                 const CardInfoPtr &card,
+                                                                                 const ExactCard &card,
                                                                                  const QString &setName)
     : QWidget(parent)
 {
     layout = new QHBoxLayout(this);
 
     name = new QLabel(this);
-    name->setText(card->getName());
+    name->setText(card.getName());
     setShortname = new QLabel(this);
     setShortname->setText(setName);
     providerId = new QLabel(this);
-    providerId->setText(card->getProperty("uuid"));
+    providerId->setText(card.getPrinting().getUuid());
 
     layout->addWidget(name);
     layout->addWidget(setShortname);

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_request_status_display_widget.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_request_status_display_widget.h
@@ -12,7 +12,7 @@ class PictureLoaderRequestStatusDisplayWidget : public QWidget
 public:
     PictureLoaderRequestStatusDisplayWidget(QWidget *parent,
                                             const QUrl &url,
-                                            const CardInfoPtr &card,
+                                            const ExactCard &card,
                                             const QString &setName);
 
     void setFinished()

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_status_bar.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_status_bar.cpp
@@ -38,7 +38,7 @@ void PictureLoaderStatusBar::cleanOldEntries()
     }
 }
 
-void PictureLoaderStatusBar::addQueuedImageLoad(const QUrl &url, const CardInfoPtr &card, const QString &setName)
+void PictureLoaderStatusBar::addQueuedImageLoad(const QUrl &url, const ExactCard &card, const QString &setName)
 {
     loadLog->addSettingsWidget(new PictureLoaderRequestStatusDisplayWidget(loadLog, url, card, setName));
     progressBar->setMaximum(progressBar->maximum() + 1);

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_status_bar.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_status_bar.h
@@ -15,7 +15,7 @@ public:
     explicit PictureLoaderStatusBar(QWidget *parent);
 
 public slots:
-    void addQueuedImageLoad(const QUrl &url, const CardInfoPtr &card, const QString &setName);
+    void addQueuedImageLoad(const QUrl &url, const ExactCard &card, const QString &setName);
     void addSuccessfulImageLoad(const QUrl &url);
     void cleanOldEntries();
 

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
@@ -129,21 +129,21 @@ bool PictureLoaderWorker::processSingleRequest()
     return false;
 }
 
-void PictureLoaderWorker::enqueueImageLoad(const CardInfoPtr &card)
+void PictureLoaderWorker::enqueueImageLoad(const ExactCard &card)
 {
     // Send call through a connection to ensure the handling is run on the pictureLoader thread
     emit imageLoadEnqueued(card);
 }
 
-void PictureLoaderWorker::handleImageLoadEnqueued(const CardInfoPtr &card)
+void PictureLoaderWorker::handleImageLoadEnqueued(const ExactCard &card)
 {
     // deduplicate loads for the same card
-    if (currentlyLoading.contains(card)) {
+    if (currentlyLoading.contains(card.getPixmapCacheKey())) {
         qCDebug(PictureLoaderWorkerLog())
-            << "Skipping enqueued" << card->getName() << "because it's already being loaded";
+            << "Skipping enqueued" << card.getName() << "because it's already being loaded";
         return;
     }
-    currentlyLoading.insert(card);
+    currentlyLoading.insert(card.getPixmapCacheKey());
 
     // try to load image from local first
     QImage image = localLoader->tryLoad(card);
@@ -158,9 +158,9 @@ void PictureLoaderWorker::handleImageLoadEnqueued(const CardInfoPtr &card)
 /**
  * Called when image loading is done. Failures are indicated by an empty QImage.
  */
-void PictureLoaderWorker::handleImageLoaded(const CardInfoPtr &card, const QImage &image)
+void PictureLoaderWorker::handleImageLoaded(const ExactCard &card, const QImage &image)
 {
-    currentlyLoading.remove(card);
+    currentlyLoading.remove(card.getPixmapCacheKey());
     emit imageLoaded(card, image);
 }
 

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.h
@@ -31,7 +31,7 @@ public:
     explicit PictureLoaderWorker();
     ~PictureLoaderWorker() override;
 
-    void enqueueImageLoad(const CardInfoPtr &card);                      // Starts a thread for the image to be loaded
+    void enqueueImageLoad(const ExactCard &card);                        // Starts a thread for the image to be loaded
     void queueRequest(const QUrl &url, PictureLoaderWorkerWork *worker); // Queues network requests for load threads
     void clearNetworkCache();
 
@@ -39,7 +39,7 @@ public slots:
     QNetworkReply *makeRequest(const QUrl &url, PictureLoaderWorkerWork *workThread);
     void processQueuedRequests();
     bool processSingleRequest();
-    void handleImageLoaded(const CardInfoPtr &card, const QImage &image);
+    void handleImageLoaded(const ExactCard &card, const QImage &image);
     void cacheRedirect(const QUrl &originalUrl, const QUrl &redirectUrl);
     void removedCachedUrl(const QUrl &url);
 
@@ -57,7 +57,7 @@ private:
     QTimer requestTimer; // Timer for refreshing request quota
 
     PictureLoaderLocal *localLoader;
-    QSet<CardInfoPtr> currentlyLoading; // for deduplication purposes
+    QSet<QString> currentlyLoading; // for deduplication purposes. Contains pixmapCacheKey
 
     QUrl getCachedRedirect(const QUrl &originalUrl) const;
     void loadRedirectCache();
@@ -66,12 +66,12 @@ private:
 
 private slots:
     void resetRequestQuota();
-    void handleImageLoadEnqueued(const CardInfoPtr &card);
+    void handleImageLoadEnqueued(const ExactCard &card);
 
 signals:
-    void imageLoadEnqueued(const CardInfoPtr &card);
-    void imageLoaded(CardInfoPtr card, const QImage &image);
-    void imageRequestQueued(const QUrl &url, const CardInfoPtr &card, const QString &setName);
+    void imageLoadEnqueued(const ExactCard &card);
+    void imageLoaded(const ExactCard &card, const QImage &image);
+    void imageRequestQueued(const QUrl &url, const ExactCard &card, const QString &setName);
     void imageRequestSucceeded(const QUrl &url);
 };
 

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.h
@@ -25,7 +25,7 @@ class PictureLoaderWorkerWork : public QObject
 {
     Q_OBJECT
 public:
-    explicit PictureLoaderWorkerWork(const PictureLoaderWorker *worker, const CardInfoPtr &toLoad);
+    explicit PictureLoaderWorkerWork(const PictureLoaderWorker *worker, const ExactCard &toLoad);
 
     PictureToLoad cardToDownload;
 
@@ -52,7 +52,7 @@ signals:
      * Failures are represented by an empty QImage.
      * Note that this object will delete itself as this signal is emitted.
      */
-    void imageLoaded(CardInfoPtr card, const QImage &image);
+    void imageLoaded(const ExactCard &card, const QImage &image);
 
     /**
      * Emitted when a request did not return a 400 or 500 response

--- a/cockatrice/src/client/ui/picture_loader/picture_to_load.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_to_load.h
@@ -1,7 +1,7 @@
 #ifndef PICTURE_TO_LOAD_H
 #define PICTURE_TO_LOAD_H
 
-#include "../../../game/cards/card_info.h"
+#include "../../../game/cards/exact_card.h"
 
 #include <QLoggingCategory>
 
@@ -10,7 +10,7 @@ inline Q_LOGGING_CATEGORY(PictureToLoadLog, "picture_loader.picture_to_load");
 class PictureToLoad
 {
 private:
-    CardInfoPtr card;
+    ExactCard card;
     QList<CardSetPtr> sortedSets;
     QList<QString> urlTemplates;
     QList<QString> currentSetUrls;
@@ -18,15 +18,11 @@ private:
     CardSetPtr currentSet;
 
 public:
-    explicit PictureToLoad(CardInfoPtr _card = CardInfoPtr());
+    explicit PictureToLoad(const ExactCard &_card);
 
-    CardInfoPtr getCard() const
+    const ExactCard &getCard() const
     {
         return card;
-    }
-    void clear()
-    {
-        card.clear();
     }
     QString getCurrentUrl() const
     {
@@ -42,7 +38,7 @@ public:
     bool nextUrl();
     void populateSetUrls();
 
-    static QList<CardSetPtr> extractSetsSorted(const CardInfoPtr &card);
+    static QList<CardSetPtr> extractSetsSorted(const ExactCard &card);
 };
 
 #endif // PICTURE_TO_LOAD_H

--- a/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
@@ -99,7 +99,7 @@ void CardGroupDisplayWidget::onClick(QMouseEvent *event, CardInfoPictureWithText
     emit cardClicked(event, card);
 }
 
-void CardGroupDisplayWidget::onHover(CardInfoPtr card)
+void CardGroupDisplayWidget::onHover(const ExactCard &card)
 {
     emit cardHovered(card);
 }

--- a/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/card_group_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/card_group_display_widget.h
@@ -37,7 +37,7 @@ public:
 
 public slots:
     void onClick(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *card);
-    void onHover(CardInfoPtr card);
+    void onHover(const ExactCard &card);
     virtual QWidget *constructWidgetForIndex(int rowIndex);
     virtual void updateCardDisplays();
     virtual void onCardAddition(const QModelIndex &parent, int first, int last);
@@ -46,7 +46,7 @@ public slots:
 
 signals:
     void cardClicked(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *card);
-    void cardHovered(CardInfoPtr card);
+    void cardHovered(const ExactCard &card);
     void cleanupRequested(CardGroupDisplayWidget *cardGroupDisplayWidget);
 
 protected:

--- a/cockatrice/src/client/ui/widgets/cards/card_info_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_display_widget.cpp
@@ -12,7 +12,7 @@
 #include <utility>
 
 CardInfoDisplayWidget::CardInfoDisplayWidget(const CardRef &cardRef, QWidget *parent, Qt::WindowFlags flags)
-    : QFrame(parent, flags), aspectRatio((qreal)CARD_HEIGHT / (qreal)CARD_WIDTH), info(nullptr)
+    : QFrame(parent, flags), aspectRatio((qreal)CARD_HEIGHT / (qreal)CARD_WIDTH)
 {
     setContentsMargins(3, 3, 3, 3);
     pic = new CardInfoPictureWidget();
@@ -43,32 +43,32 @@ CardInfoDisplayWidget::CardInfoDisplayWidget(const CardRef &cardRef, QWidget *pa
     resize(width(), sizeHint().height());
 }
 
-void CardInfoDisplayWidget::setCard(CardInfoPtr card)
+void CardInfoDisplayWidget::setCard(const ExactCard &card)
 {
-    if (info)
-        disconnect(info.data(), nullptr, this, nullptr);
-    info = std::move(card);
-    if (info)
-        connect(info.data(), &QObject::destroyed, this, &CardInfoDisplayWidget::clear);
+    if (exactCard)
+        disconnect(exactCard.getCardPtr().data(), nullptr, this, nullptr);
+    exactCard = card;
+    if (exactCard)
+        connect(exactCard.getCardPtr().data(), &QObject::destroyed, this, &CardInfoDisplayWidget::clear);
 
-    text->setCard(info);
-    pic->setCard(info);
+    text->setCard(exactCard.getCardPtr());
+    pic->setCard(exactCard);
 }
 
 void CardInfoDisplayWidget::setCard(const CardRef &cardRef)
 {
     setCard(CardDatabaseManager::getInstance()->guessCard(cardRef));
-    if (info == nullptr) {
+    if (exactCard.isEmpty()) {
         text->setInvalidCardName(cardRef.name);
     }
 }
 
 void CardInfoDisplayWidget::setCard(AbstractCardItem *card)
 {
-    setCard(card->getInfo());
+    setCard(card->getCard());
 }
 
 void CardInfoDisplayWidget::clear()
 {
-    setCard((CardInfoPtr) nullptr);
+    setCard(ExactCard());
 }

--- a/cockatrice/src/client/ui/widgets/cards/card_info_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_display_widget.h
@@ -1,7 +1,7 @@
 #ifndef CARDINFOWIDGET_H
 #define CARDINFOWIDGET_H
 
-#include "../../../../game/cards/card_info.h"
+#include "../../../../game/cards/exact_card.h"
 #include "card_ref.h"
 
 #include <QComboBox>
@@ -18,7 +18,7 @@ class CardInfoDisplayWidget : public QFrame
 
 private:
     qreal aspectRatio;
-    CardInfoPtr info;
+    ExactCard exactCard;
     CardInfoPictureWidget *pic;
     CardInfoTextWidget *text;
 
@@ -26,7 +26,7 @@ public:
     explicit CardInfoDisplayWidget(const CardRef &cardRef, QWidget *parent = nullptr, Qt::WindowFlags f = {});
 
 public slots:
-    void setCard(CardInfoPtr card);
+    void setCard(const ExactCard &card);
     void setCard(const CardRef &cardRef);
     void setCard(AbstractCardItem *card);
 

--- a/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_frame_widget.h
@@ -1,7 +1,7 @@
 #ifndef CARDFRAME_H
 #define CARDFRAME_H
 
-#include "../../../../game/cards/card_info.h"
+#include "../../../../game/cards/exact_card.h"
 #include "card_ref.h"
 
 #include <QPushButton>
@@ -17,7 +17,7 @@ class CardInfoFrameWidget : public QTabWidget
 {
     Q_OBJECT
 private:
-    CardInfoPtr info;
+    ExactCard exactCard;
     CardInfoPictureWidget *pic;
     CardInfoTextWidget *text;
     QPushButton *viewTransformationButton;
@@ -38,14 +38,14 @@ public:
     };
 
     explicit CardInfoFrameWidget(QWidget *parent = nullptr);
-    CardInfoPtr getInfo()
+    ExactCard getCard()
     {
-        return info;
+        return exactCard;
     }
     void retranslateUi();
 
 public slots:
-    void setCard(CardInfoPtr card);
+    void setCard(const ExactCard &card);
     void setCard(const QString &cardName);
     void setCard(const CardRef &cardRef);
     void setCard(AbstractCardItem *card);

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_enlarged_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_enlarged_widget.cpp
@@ -13,8 +13,7 @@
  *
  * Sets the widget's window flags to keep it displayed as a tooltip overlay.
  */
-CardInfoPictureEnlargedWidget::CardInfoPictureEnlargedWidget(QWidget *parent)
-    : QWidget(parent), pixmapDirty(true), info(nullptr)
+CardInfoPictureEnlargedWidget::CardInfoPictureEnlargedWidget(QWidget *parent) : QWidget(parent), pixmapDirty(true)
 {
     setWindowFlags(Qt::ToolTip); // Keeps this widget on top of everything
     setAttribute(Qt::WA_TranslucentBackground);
@@ -35,8 +34,8 @@ CardInfoPictureEnlargedWidget::CardInfoPictureEnlargedWidget(QWidget *parent)
  */
 void CardInfoPictureEnlargedWidget::loadPixmap(const QSize &size)
 {
-    if (info) {
-        PictureLoader::getPixmap(enlargedPixmap, info, size);
+    if (card) {
+        PictureLoader::getPixmap(enlargedPixmap, card, size);
     } else {
         PictureLoader::getCardBackPixmap(enlargedPixmap, size);
     }
@@ -45,14 +44,14 @@ void CardInfoPictureEnlargedWidget::loadPixmap(const QSize &size)
 
 /**
  * @brief Sets the pixmap for the widget based on a provided card.
- * @param card The card information to load.
+ * @param _card The card information to load.
  * @param size The desired size for the pixmap.
  *
  * Sets the widget's pixmap to the card image and resizes the widget to match the specified size. Triggers a repaint.
  */
-void CardInfoPictureEnlargedWidget::setCardPixmap(CardInfoPtr card, const QSize size)
+void CardInfoPictureEnlargedWidget::setCardPixmap(const ExactCard &_card, const QSize size)
 {
-    info = std::move(card);
+    card = _card;
     loadPixmap(size);
 
     setFixedSize(size); // Set the widget size to the enlarged size

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_enlarged_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_enlarged_widget.h
@@ -1,7 +1,7 @@
 #ifndef CARD_PICTURE_ENLARGED_WIDGET_H
 #define CARD_PICTURE_ENLARGED_WIDGET_H
 
-#include "../../../../game/cards/card_info.h"
+#include "../../../../game/cards/exact_card.h"
 
 #include <QPixmap>
 #include <QWidget>
@@ -15,7 +15,7 @@ public:
     explicit CardInfoPictureEnlargedWidget(QWidget *parent = nullptr);
 
     // Sets the card pixmap to display
-    void setCardPixmap(CardInfoPtr card, QSize size);
+    void setCardPixmap(const ExactCard &_card, QSize size);
 
 protected:
     // Handles the painting event for the enlarged card
@@ -28,8 +28,8 @@ private:
     // Tracks if the pixmap needs to be refreshed/redrawn
     bool pixmapDirty;
 
-    // Card information (card data pointer)
-    CardInfoPtr info;
+    // Card information
+    ExactCard card;
 
     // Loads the enlarged card pixmap
     void loadPixmap(const QSize &size);

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
@@ -1,7 +1,7 @@
 #ifndef CARD_INFO_PICTURE_H
 #define CARD_INFO_PICTURE_H
 
-#include "../../../../game/cards/card_info.h"
+#include "../../../../game/cards/exact_card.h"
 #include "card_info_picture_enlarged_widget.h"
 
 #include <QPropertyAnimation>
@@ -22,23 +22,23 @@ public:
                                    bool hoverToZoomEnabled = false,
                                    bool raiseOnEnter = false);
     ~CardInfoPictureWidget();
-    CardInfoPtr getInfo()
+    ExactCard getCard()
     {
-        return info;
+        return exactCard;
     }
     [[nodiscard]] QSize sizeHint() const override;
 
 public slots:
-    void setCard(CardInfoPtr card);
+    void setCard(const ExactCard &card);
     void setScaleFactor(int scale); // New slot for scaling
     void setHoverToZoomEnabled(bool enabled);
     void setRaiseOnEnterEnabled(bool enabled);
     void updatePixmap();
 
 signals:
-    void hoveredOnCard(CardInfoPtr hoveredCard);
+    void hoveredOnCard(const ExactCard &hoveredCard);
     void cardScaleFactorChanged(int _scale);
-    void cardChanged(CardInfoPtr card);
+    void cardChanged(const ExactCard &card);
     void cardClicked();
 
 protected:
@@ -62,7 +62,7 @@ protected:
     void showEnlargedPixmap() const;
 
 private:
-    CardInfoPtr info;
+    ExactCard exactCard;
     qreal magicTheGatheringCardAspectRatio = 1.396;
     qreal yuGiOhCardAspectRatio = 1.457;
     qreal aspectRatio = magicTheGatheringCardAspectRatio;

--- a/cockatrice/src/client/ui/widgets/cards/deck_card_zone_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/deck_card_zone_display_widget.cpp
@@ -137,7 +137,7 @@ void DeckCardZoneDisplayWidget::onClick(QMouseEvent *event, CardInfoPictureWithT
 {
     emit cardClicked(event, card, zoneName);
 }
-void DeckCardZoneDisplayWidget::onHover(CardInfoPtr card)
+void DeckCardZoneDisplayWidget::onHover(const ExactCard &card)
 {
     emit cardHovered(card);
 }
@@ -181,10 +181,10 @@ QList<QString> DeckCardZoneDisplayWidget::getGroupCriteriaValueList()
 {
     QList<QString> groupCriteriaValues;
 
-    QList<CardInfoPtr> cardsInZone = deckListModel->getCardsAsCardInfoPtrsForZone(zoneName);
+    QList<ExactCard> cardsInZone = deckListModel->getCardsForZone(zoneName);
 
-    for (CardInfoPtr cardInZone : cardsInZone) {
-        groupCriteriaValues.append(cardInZone->getProperty(activeGroupCriteria));
+    for (const ExactCard &cardInZone : cardsInZone) {
+        groupCriteriaValues.append(cardInZone.getInfo().getProperty(activeGroupCriteria));
     }
 
     groupCriteriaValues.removeDuplicates();

--- a/cockatrice/src/client/ui/widgets/cards/deck_card_zone_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/deck_card_zone_display_widget.h
@@ -36,7 +36,7 @@ public:
 
 public slots:
     void onClick(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *card);
-    void onHover(CardInfoPtr card);
+    void onHover(const ExactCard &card);
     void cleanupInvalidCardGroup(CardGroupDisplayWidget *displayWidget);
     void constructAppropriateWidget(QPersistentModelIndex index);
     void displayCards();
@@ -49,7 +49,7 @@ public slots:
 
 signals:
     void cardClicked(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *card, QString zoneName);
-    void cardHovered(CardInfoPtr card);
+    void cardHovered(const ExactCard &card);
     void activeSortCriteriaChanged(QStringList activeSortCriteria);
     void requestCleanup(DeckCardZoneDisplayWidget *displayWidget);
 

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_card_info_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_card_info_dock_widget.cpp
@@ -34,7 +34,7 @@ void DeckEditorCardInfoDockWidget::createCardInfoDock()
     connect(this, &QDockWidget::topLevelChanged, deckEditor, &AbstractTabDeckEditor::dockTopLevelChanged);
 }
 
-void DeckEditorCardInfoDockWidget::updateCard(CardInfoPtr _card)
+void DeckEditorCardInfoDockWidget::updateCard(const ExactCard &_card)
 {
     cardInfo->setCard(_card);
 }

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_card_info_dock_widget.h
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_card_info_dock_widget.h
@@ -19,7 +19,7 @@ public:
     CardInfoFrameWidget *cardInfo;
 
 public slots:
-    void updateCard(CardInfoPtr _card);
+    void updateCard(const ExactCard &_card);
 };
 
 #endif // DECK_EDITOR_CARD_INFO_DOCK_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_database_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_database_display_widget.h
@@ -22,16 +22,16 @@ public:
     CardDatabaseDisplayModel *databaseDisplayModel;
 
 public slots:
-    CardInfoPtr currentCardInfo() const;
+    ExactCard currentCard() const;
     void setFilterTree(FilterTree *filterTree);
     void clearAllDatabaseFilters();
 
 signals:
-    void addCardToMainDeck(CardInfoPtr card);
-    void addCardToSideboard(CardInfoPtr card);
-    void decrementCardFromMainDeck(CardInfoPtr card);
-    void decrementCardFromSideboard(CardInfoPtr card);
-    void cardChanged(CardInfoPtr _card);
+    void addCardToMainDeck(const ExactCard &card);
+    void addCardToSideboard(const ExactCard &card);
+    void decrementCardFromMainDeck(const ExactCard &card);
+    void decrementCardFromSideboard(const ExactCard &card);
+    void cardChanged(const ExactCard &_card);
 
 private:
     KeySignals searchKeySignals;

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.h
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.h
@@ -24,7 +24,7 @@ public:
     QTreeView *deckView;
     QComboBox *bannerCardComboBox;
     void createDeckDock();
-    CardInfoPtr getCurrentCard();
+    ExactCard getCurrentCard();
     void retranslateUi();
     QString getDeckName()
     {
@@ -42,7 +42,7 @@ public slots:
     DeckLoader *getDeckList();
     void actIncrement();
     bool swapCard(const QModelIndex &idx);
-    void actDecrementCard(CardInfoPtr info, QString zoneName);
+    void actDecrementCard(const ExactCard &card, QString zoneName);
     void actDecrementSelection();
     void actSwapCard();
     void actRemoveCard();
@@ -54,7 +54,7 @@ signals:
     void hashChanged();
     void deckChanged();
     void deckModified();
-    void cardChanged(CardInfoPtr _card);
+    void cardChanged(const ExactCard &_card);
 
 private:
     AbstractTabDeckEditor *deckEditor;

--- a/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.cpp
@@ -16,17 +16,15 @@
  * @param deckView Pointer to the QTreeView for the deck display.
  * @param cardSizeSlider Pointer to the QSlider used for dynamic font resizing.
  * @param rootCard The root card for the widget.
- * @param printingInfo The printing information for the card.
  */
 AllZonesCardAmountWidget::AllZonesCardAmountWidget(QWidget *parent,
                                                    AbstractTabDeckEditor *deckEditor,
                                                    DeckListModel *deckModel,
                                                    QTreeView *deckView,
                                                    QSlider *cardSizeSlider,
-                                                   CardInfoPtr rootCard,
-                                                   PrintingInfo printingInfo)
+                                                   const ExactCard &rootCard)
     : QWidget(parent), deckEditor(deckEditor), deckModel(deckModel), deckView(deckView), cardSizeSlider(cardSizeSlider),
-      rootCard(rootCard), printingInfo(printingInfo)
+      rootCard(rootCard)
 {
     layout = new QVBoxLayout(this);
     layout->setAlignment(Qt::AlignHCenter);
@@ -35,11 +33,11 @@ AllZonesCardAmountWidget::AllZonesCardAmountWidget(QWidget *parent,
     setContentsMargins(5, 5, 5, 5); // Padding around the text
 
     zoneLabelMainboard = new ShadowBackgroundLabel(this, tr("Mainboard"));
-    buttonBoxMainboard = new CardAmountWidget(this, deckEditor, deckModel, deckView, cardSizeSlider, rootCard,
-                                              printingInfo, DECK_ZONE_MAIN);
+    buttonBoxMainboard =
+        new CardAmountWidget(this, deckEditor, deckModel, deckView, cardSizeSlider, rootCard, DECK_ZONE_MAIN);
     zoneLabelSideboard = new ShadowBackgroundLabel(this, tr("Sideboard"));
-    buttonBoxSideboard = new CardAmountWidget(this, deckEditor, deckModel, deckView, cardSizeSlider, rootCard,
-                                              printingInfo, DECK_ZONE_SIDE);
+    buttonBoxSideboard =
+        new CardAmountWidget(this, deckEditor, deckModel, deckView, cardSizeSlider, rootCard, DECK_ZONE_SIDE);
 
     layout->addWidget(zoneLabelMainboard, 0, Qt::AlignHCenter | Qt::AlignBottom);
     layout->addWidget(buttonBoxMainboard, 0, Qt::AlignHCenter | Qt::AlignTop);

--- a/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/all_zones_card_amount_widget.h
@@ -16,8 +16,7 @@ public:
                                       DeckListModel *deckModel,
                                       QTreeView *deckView,
                                       QSlider *cardSizeSlider,
-                                      CardInfoPtr rootCard,
-                                      PrintingInfo printingInfo);
+                                      const ExactCard &rootCard);
     int getMainboardAmount();
     int getSideboardAmount();
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
@@ -35,8 +34,7 @@ private:
     DeckListModel *deckModel;
     QTreeView *deckView;
     QSlider *cardSizeSlider;
-    CardInfoPtr rootCard;
-    PrintingInfo printingInfo;
+    ExactCard rootCard;
     QLabel *zoneLabelMainboard;
     CardAmountWidget *buttonBoxMainboard;
     QLabel *zoneLabelSideboard;

--- a/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.h
@@ -22,8 +22,7 @@ public:
                               DeckListModel *deckModel,
                               QTreeView *deckView,
                               QSlider *cardSizeSlider,
-                              CardInfoPtr &rootCard,
-                              PrintingInfo &printingInfo,
+                              const ExactCard &rootCard,
                               const QString &zoneName);
     int countCardsInZone(const QString &deckZone);
 
@@ -40,8 +39,7 @@ private:
     DeckListModel *deckModel;
     QTreeView *deckView;
     QSlider *cardSizeSlider;
-    CardInfoPtr rootCard;
-    PrintingInfo printingInfo;
+    ExactCard rootCard;
     QString zoneName;
     QHBoxLayout *layout;
     DynamicFontSizePushButton *incrementButton;

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector.cpp
@@ -218,9 +218,9 @@ void PrintingSelector::getAllSetsForCurrentCard()
 
     connect(widgetLoadingBufferTimer, &QTimer::timeout, this, [=, this]() mutable {
         for (int i = 0; i < BATCH_SIZE && currentIndex < printingsToUse.size(); ++i, ++currentIndex) {
-            auto *cardDisplayWidget = new PrintingSelectorCardDisplayWidget(this, deckEditor, deckModel, deckView,
-                                                                            cardSizeWidget->getSlider(), selectedCard,
-                                                                            printingsToUse[currentIndex], currentZone);
+            ExactCard card = ExactCard(selectedCard, printingsToUse[currentIndex]);
+            auto *cardDisplayWidget = new PrintingSelectorCardDisplayWidget(
+                this, deckEditor, deckModel, deckView, cardSizeWidget->getSlider(), card, currentZone);
             flowWidget->addWidget(cardDisplayWidget);
             cardDisplayWidget->clampSetNameToPicture();
             connect(cardDisplayWidget, &PrintingSelectorCardDisplayWidget::cardPreferenceChanged, this,

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.cpp
@@ -24,7 +24,6 @@
  * @param _deckView The QTreeView instance displaying the deck.
  * @param _cardSizeSlider The slider controlling the size of the displayed card.
  * @param _rootCard The root card object, representing the card to be displayed.
- * @param _printingInfo The printing info for the card being displayed.
  * @param _currentZone The current zone in which the card is located.
  */
 PrintingSelectorCardDisplayWidget::PrintingSelectorCardDisplayWidget(QWidget *parent,
@@ -32,28 +31,27 @@ PrintingSelectorCardDisplayWidget::PrintingSelectorCardDisplayWidget(QWidget *pa
                                                                      DeckListModel *_deckModel,
                                                                      QTreeView *_deckView,
                                                                      QSlider *_cardSizeSlider,
-                                                                     CardInfoPtr _rootCard,
-                                                                     const PrintingInfo &_printingInfo,
+                                                                     const ExactCard &_rootCard,
                                                                      QString &_currentZone)
     : QWidget(parent), deckEditor(_deckEditor), deckModel(_deckModel), deckView(_deckView),
-      cardSizeSlider(_cardSizeSlider), rootCard(std::move(_rootCard)), printingInfo(_printingInfo),
-      currentZone(_currentZone)
+      cardSizeSlider(_cardSizeSlider), rootCard(_rootCard), currentZone(_currentZone)
 {
     layout = new QVBoxLayout(this);
     setLayout(layout);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     // Create the overlay widget for the card display
-    overlayWidget = new PrintingSelectorCardOverlayWidget(this, deckEditor, deckModel, deckView, cardSizeSlider,
-                                                          rootCard, _printingInfo);
+    overlayWidget =
+        new PrintingSelectorCardOverlayWidget(this, deckEditor, deckModel, deckView, cardSizeSlider, rootCard);
     connect(overlayWidget, &PrintingSelectorCardOverlayWidget::cardPreferenceChanged, this,
             [this]() { emit cardPreferenceChanged(); });
 
+    CardSetPtr set = rootCard.getPrinting().getSet();
+
     // Create the widget to display the set name and collector's number
-    const QString combinedSetName =
-        QString(_printingInfo.getSet()->getLongName() + " (" + _printingInfo.getSet()->getShortName() + ")");
+    QString combinedSetName = QString(set->getLongName() + " (" + set->getShortName() + ")");
     setNameAndCollectorsNumberDisplayWidget = new SetNameAndCollectorsNumberDisplayWidget(
-        this, combinedSetName, _printingInfo.getProperty("num"), cardSizeSlider);
+        this, combinedSetName, rootCard.getPrinting().getProperty("num"), cardSizeSlider);
 
     // Add the widgets to the layout
     layout->addWidget(overlayWidget, 0, Qt::AlignHCenter);

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_display_widget.h
@@ -20,8 +20,7 @@ public:
                                       DeckListModel *_deckModel,
                                       QTreeView *_deckView,
                                       QSlider *_cardSizeSlider,
-                                      CardInfoPtr _rootCard,
-                                      const PrintingInfo &_printingInfo,
+                                      const ExactCard &_rootCard,
                                       QString &_currentZone);
 
 public slots:
@@ -37,9 +36,7 @@ private:
     DeckListModel *deckModel;
     QTreeView *deckView;
     QSlider *cardSizeSlider;
-    CardInfoPtr rootCard;
-    CardInfoPtr setCard;
-    PrintingInfo printingInfo;
+    ExactCard rootCard;
     QString currentZone;
     PrintingSelectorCardOverlayWidget *overlayWidget;
 };

--- a/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.h
+++ b/cockatrice/src/client/ui/widgets/printing_selector/printing_selector_card_overlay_widget.h
@@ -19,8 +19,7 @@ public:
                                                DeckListModel *_deckModel,
                                                QTreeView *_deckView,
                                                QSlider *_cardSizeSlider,
-                                               CardInfoPtr _rootCard,
-                                               const PrintingInfo &_printingInfo);
+                                               const ExactCard &_rootCard);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -43,9 +42,7 @@ private:
     DeckListModel *deckModel;
     QTreeView *deckView;
     QSlider *cardSizeSlider;
-    CardInfoPtr rootCard;
-    CardInfoPtr setCard;
-    PrintingInfo printingInfo;
+    ExactCard rootCard;
 };
 
 #endif // PRINTING_SELECTOR_CARD_OVERLAY_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.h
@@ -58,12 +58,12 @@ public slots:
 
 signals:
     void cardClickedDatabaseDisplay(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance);
-    void cardHoveredDatabaseDisplay(CardInfoPtr hoveredCard);
+    void cardHoveredDatabaseDisplay(const ExactCard &hoveredCard);
 
 protected slots:
     void onClick(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance);
-    void onHover(const CardInfoPtr &hoveredCard);
-    void addCard(const CardInfoPtr &cardToAdd);
+    void onHover(const ExactCard &hoveredCard);
+    void addCard(const ExactCard &cardToAdd);
     void databaseDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
     void wheelEvent(QWheelEvent *event) override;
     void modelDirty() const;
@@ -87,7 +87,7 @@ private:
     CardDatabaseModel *databaseModel;
     CardDatabaseDisplayModel *databaseDisplayModel;
     QTreeView *databaseView;
-    QList<CardInfoPtr> *cards;
+    QList<ExactCard> *cards;
     QVBoxLayout *mainLayout;
     QScrollArea *scrollArea;
     FlowWidget *flowWidget;

--- a/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_sample_hand_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_sample_hand_widget.cpp
@@ -38,7 +38,7 @@ VisualDeckEditorSampleHandWidget::VisualDeckEditorSampleHandWidget(QWidget *pare
     cardSizeWidget = new CardSizeWidget(this, flowWidget);
     layout->addWidget(cardSizeWidget);
 
-    for (CardInfoPtr card : getRandomCards(handSizeSpinBox->value())) {
+    for (const ExactCard &card : getRandomCards(handSizeSpinBox->value())) {
         auto displayWidget = new CardInfoPictureWidget(this);
         displayWidget->setCard(card);
         displayWidget->setScaleFactor(cardSizeWidget->getSlider()->value());
@@ -64,7 +64,7 @@ void VisualDeckEditorSampleHandWidget::setDeckModel(DeckListModel *deckModel)
 void VisualDeckEditorSampleHandWidget::updateDisplay()
 {
     flowWidget->clearLayout();
-    for (CardInfoPtr card : getRandomCards(handSizeSpinBox->value())) {
+    for (const ExactCard &card : getRandomCards(handSizeSpinBox->value())) {
         auto displayWidget = new CardInfoPictureWidget(this);
         displayWidget->setCard(card);
         displayWidget->setScaleFactor(cardSizeWidget->getSlider()->value());
@@ -74,10 +74,10 @@ void VisualDeckEditorSampleHandWidget::updateDisplay()
     }
 }
 
-QList<CardInfoPtr> VisualDeckEditorSampleHandWidget::getRandomCards(int amountToGet)
+QList<ExactCard> VisualDeckEditorSampleHandWidget::getRandomCards(int amountToGet)
 {
-    QList<CardInfoPtr> mainDeckCards;
-    QList<CardInfoPtr> randomCards;
+    QList<ExactCard> mainDeckCards;
+    QList<ExactCard> randomCards;
     if (!deckListModel)
         return randomCards;
     DeckList *decklist = deckListModel->getDeckList();
@@ -101,9 +101,9 @@ QList<CardInfoPtr> VisualDeckEditorSampleHandWidget::getRandomCards(int amountTo
                 continue;
 
             for (int k = 0; k < currentCard->getNumber(); ++k) {
-                CardInfoPtr info = CardDatabaseManager::getInstance()->getCard(currentCard->toCardRef());
-                if (info) {
-                    mainDeckCards.append(info);
+                ExactCard card = CardDatabaseManager::getInstance()->getCard(currentCard->toCardRef());
+                if (card) {
+                    mainDeckCards.append(card);
                 }
             }
         }
@@ -124,7 +124,7 @@ QList<CardInfoPtr> VisualDeckEditorSampleHandWidget::getRandomCards(int amountTo
     }
 
     std::sort(randomCards.begin(), randomCards.end(),
-              [](const CardInfoPtr &a, const CardInfoPtr &b) { return a->getCmc() < b->getCmc(); });
+              [](const ExactCard &a, const ExactCard &b) { return a.getInfo().getCmc() < b.getInfo().getCmc(); });
 
     return randomCards;
 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_sample_hand_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_sample_hand_widget.h
@@ -14,7 +14,7 @@ class VisualDeckEditorSampleHandWidget : public QWidget
     Q_OBJECT
 public:
     VisualDeckEditorSampleHandWidget(QWidget *parent, DeckListModel *deckListModel);
-    QList<CardInfoPtr> getRandomCards(int amountToGet);
+    QList<ExactCard> getRandomCards(int amountToGet);
 
 public slots:
     void updateDisplay();

--- a/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -42,7 +42,7 @@ VisualDeckEditorWidget::VisualDeckEditorWidget(QWidget *parent, DeckListModel *_
         if (!searchBar->hasFocus())
             return;
 
-        CardInfoPtr card = CardDatabaseManager::getInstance()->getCardInfo(searchBar->text());
+        ExactCard card = CardDatabaseManager::getInstance()->getCard({searchBar->text()});
         if (card) {
             emit cardAdditionRequested(card);
         }
@@ -103,7 +103,7 @@ VisualDeckEditorWidget::VisualDeckEditorWidget(QWidget *parent, DeckListModel *_
     // Search button functionality
     searchPushButton = new QPushButton(this);
     connect(searchPushButton, &QPushButton::clicked, this, [=, this]() {
-        CardInfoPtr card = CardDatabaseManager::getInstance()->getCardInfo(searchBar->text());
+        ExactCard card = CardDatabaseManager::getInstance()->getCard({searchBar->text()});
         if (card) {
             emit cardAdditionRequested(card);
         }
@@ -342,7 +342,7 @@ void VisualDeckEditorWidget::decklistDataChanged(QModelIndex topLeft, QModelInde
     updateZoneWidgets();
 }
 
-void VisualDeckEditorWidget::onHover(CardInfoPtr hoveredCard)
+void VisualDeckEditorWidget::onHover(const ExactCard &hoveredCard)
 {
     emit activeCardChanged(hoveredCard);
 }

--- a/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.h
@@ -48,15 +48,15 @@ public slots:
     void constructZoneWidgetsFromDeckListModel();
 
 signals:
-    void activeCardChanged(CardInfoPtr activeCard);
+    void activeCardChanged(const ExactCard &activeCard);
     void activeGroupCriteriaChanged(QString activeGroupCriteria);
     void activeSortCriteriaChanged(QStringList activeSortCriteria);
     void cardClicked(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance, QString zoneName);
-    void cardAdditionRequested(CardInfoPtr card);
+    void cardAdditionRequested(const ExactCard &card);
     void displayTypeChanged(DisplayType displayType);
 
 protected slots:
-    void onHover(CardInfoPtr hoveredCard);
+    void onHover(const ExactCard &hoveredCard);
     void onCardClick(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance, QString zoneName);
     void actChangeActiveGroupCriteria();
     void actChangeActiveSortCriteria();

--- a/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -75,7 +75,7 @@ void DeckPreviewWidget::initializeUi(const bool deckLoadSuccess)
         return;
     }
     auto bannerCard = deckLoader->getBannerCard().name.isEmpty()
-                          ? CardInfoPtr()
+                          ? ExactCard()
                           : CardDatabaseManager::getInstance()->getCard(deckLoader->getBannerCard());
 
     bannerCardDisplayWidget->setCard(bannerCard);

--- a/cockatrice/src/deck/deck_list_model.h
+++ b/cockatrice/src/deck/deck_list_model.h
@@ -1,7 +1,7 @@
 #ifndef DECKLISTMODEL_H
 #define DECKLISTMODEL_H
 
-#include "../game/cards/card_info.h"
+#include "../game/cards/exact_card.h"
 #include "decklist.h"
 
 #include <QAbstractItemModel>
@@ -111,10 +111,7 @@ public:
                          const QString &providerId = "",
                          const QString &cardNumber = "") const;
     QModelIndex addPreferredPrintingCard(const QString &cardName, const QString &zoneName, bool abAddAnyway);
-    QModelIndex addCard(const ::QString &cardName,
-                        const PrintingInfo &printingInfo,
-                        const QString &zoneName,
-                        bool abAddAnyway = false);
+    QModelIndex addCard(const ExactCard &card, const QString &zoneName);
     int findSortedInsertRow(InnerDecklistNode *parent, CardInfoPtr cardInfo) const;
     void sort(int column, Qt::SortOrder order) override;
     void cleanList();
@@ -123,8 +120,8 @@ public:
         return deckList;
     }
     void setDeckList(DeckLoader *_deck);
-    QList<CardInfoPtr> getCardsAsCardInfoPtrs() const;
-    QList<CardInfoPtr> getCardsAsCardInfoPtrsForZone(QString zoneName) const;
+    QList<ExactCard> getCards() const;
+    QList<ExactCard> getCardsForZone(const QString &zoneName) const;
     QList<QString> *getZones() const;
     void setActiveGroupCriteria(DeckListModelGroupCriteria newCriteria);
 

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -594,9 +594,9 @@ QString DeckLoader::getCardZoneFromName(QString cardName, QString currentZoneNam
 QString DeckLoader::getCompleteCardName(const QString &cardName) const
 {
     if (CardDatabaseManager::getInstance()) {
-        CardInfoPtr temp = CardDatabaseManager::getInstance()->guessCard({cardName});
+        ExactCard temp = CardDatabaseManager::getInstance()->guessCard({cardName});
         if (temp) {
-            return temp->getName();
+            return temp.getName();
         }
     }
 

--- a/cockatrice/src/dialogs/dlg_create_token.cpp
+++ b/cockatrice/src/dialogs/dlg_create_token.cpp
@@ -198,7 +198,7 @@ void DlgCreateToken::tokenSelectionChanged(const QModelIndex &current, const QMo
         annotationEdit->setText("");
     }
 
-    pic->setCard(cardInfo);
+    pic->setCard(CardDatabaseManager::getInstance()->getPreferredCard(cardInfo));
 }
 
 void DlgCreateToken::updateSearchFieldWithoutUpdatingFilter(const QString &newValue) const

--- a/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/dialogs/dlg_select_set_for_cards.cpp
@@ -152,8 +152,9 @@ void DlgSelectSetForCards::actOK()
                 continue;
             }
             model->removeRow(find_card.row(), find_card.parent());
-            model->addCard(card, CardDatabaseManager::getInstance()->getSpecificPrinting(card, modifiedSet, ""),
-                           DECK_ZONE_MAIN);
+            CardInfoPtr cardInfo = CardDatabaseManager::getInstance()->getCardInfo(card);
+            PrintingInfo printing = CardDatabaseManager::getInstance()->getSpecificPrinting(card, modifiedSet, "");
+            model->addCard(ExactCard(cardInfo, printing), DECK_ZONE_MAIN);
         }
     }
     accept();
@@ -290,17 +291,17 @@ void DlgSelectSetForCards::updateCardLists()
 
             if (!found) {
                 // The card was not in any selected set
-                CardInfoPtr infoPtr = CardDatabaseManager::getInstance()->getCardInfo(currentCard->getName());
+                ExactCard card = CardDatabaseManager::getInstance()->getCard({currentCard->getName()});
                 CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(uneditedCardsFlowWidget);
-                picture_widget->setCard(infoPtr);
+                picture_widget->setCard(card);
                 uneditedCardsFlowWidget->addWidget(picture_widget);
             } else {
-                CardInfoPtr infoPtr = CardDatabaseManager::getInstance()->getCard(
+                ExactCard card = CardDatabaseManager::getInstance()->getCard(
                     {currentCard->getName(), CardDatabaseManager::getInstance()
                                                  ->getSpecificPrinting(currentCard->getName(), foundSetName, "")
                                                  .getUuid()});
                 CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(modifiedCardsFlowWidget);
-                picture_widget->setCard(infoPtr);
+                picture_widget->setCard(card);
                 modifiedCardsFlowWidget->addWidget(picture_widget);
             }
         }

--- a/cockatrice/src/game/board/abstract_card_item.h
+++ b/cockatrice/src/game/board/abstract_card_item.h
@@ -1,7 +1,7 @@
 #ifndef ABSTRACTCARDITEM_H
 #define ABSTRACTCARDITEM_H
 
-#include "../cards/card_info.h"
+#include "../cards/exact_card.h"
 #include "arrow_target.h"
 #include "card_ref.h"
 
@@ -14,7 +14,7 @@ class AbstractCardItem : public ArrowTarget
 {
     Q_OBJECT
 protected:
-    CardInfoPtr info;
+    ExactCard exactCard;
     int id;
     CardRef cardRef;
     bool tapped;
@@ -58,10 +58,11 @@ public:
     QSizeF getTranslatedSize(QPainter *painter) const;
     void paintPicture(QPainter *painter, const QSizeF &translatedSize, int angle);
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
-    CardInfoPtr getInfo() const
+    ExactCard getCard() const
     {
-        return info;
+        return exactCard;
     }
+    const CardInfo &getCardInfo() const;
     int getId() const
     {
         return id;

--- a/cockatrice/src/game/board/arrow_item.cpp
+++ b/cockatrice/src/game/board/arrow_item.cpp
@@ -237,10 +237,10 @@ void ArrowDragItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
         }
         if (startZone->getName().compare("hand") == 0) {
             startCard->playCard(false);
-            CardInfoPtr ci = startCard->getInfo();
-            if (ci && (((!SettingsCache::instance().getPlayToStack() && ci->getTableRow() == 3) ||
-                        ((SettingsCache::instance().getPlayToStack() && ci->getTableRow() != 0) &&
-                         startCard->getZone()->getName().toStdString() != "stack"))))
+            CardInfoPtr ci = startCard->getCard().getCardPtr();
+            if (ci && ((!SettingsCache::instance().getPlayToStack() && ci->getTableRow() == 3) ||
+                       (SettingsCache::instance().getPlayToStack() && ci->getTableRow() != 0 &&
+                        startCard->getZone()->getName().toStdString() != "stack")))
                 cmd.set_start_zone("stack");
             else
                 cmd.set_start_zone(SettingsCache::instance().getPlayToStack() ? "stack" : "table");

--- a/cockatrice/src/game/board/card_item.cpp
+++ b/cockatrice/src/game/board/card_item.cpp
@@ -107,7 +107,7 @@ void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
         painter->save();
         transformPainter(painter, translatedSize, tapAngle);
 
-        if (!getFaceDown() && info && pt == info->getPowTough()) {
+        if (!getFaceDown() && pt == exactCard.getInfo().getPowTough()) {
             painter->setPen(Qt::white);
         } else {
             painter->setPen(QColor(255, 150, 0)); // dark orange

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -2,7 +2,7 @@
 #define CARDDATABASE_H
 
 #include "../common/card_ref.h"
-#include "card_info.h"
+#include "exact_card.h"
 
 #include <QBasicMutex>
 #include <QDate>
@@ -69,8 +69,10 @@ public:
     [[nodiscard]] CardInfoPtr getCardInfo(const QString &cardName) const;
     [[nodiscard]] QList<CardInfoPtr> getCardInfos(const QStringList &cardNames) const;
 
-    QList<CardInfoPtr> getCards(const QList<CardRef> &cardRefs) const;
-    [[nodiscard]] CardInfoPtr getCard(const CardRef &cardRef) const;
+    QList<ExactCard> getCards(const QList<CardRef> &cardRefs) const;
+    [[nodiscard]] ExactCard getCard(const CardRef &cardRef) const;
+
+    [[nodiscard]] ExactCard getPreferredCard(const CardInfoPtr &cardInfo) const;
 
     static PrintingInfo findPrintingWithId(const CardInfoPtr &cardInfo, const QString &providerId);
     [[nodiscard]] PrintingInfo getPreferredPrinting(const QString &cardName) const;
@@ -81,7 +83,7 @@ public:
     QString getPreferredPrintingProviderId(const QString &cardName) const;
     bool isPreferredPrinting(const CardRef &cardRef) const;
 
-    [[nodiscard]] CardInfoPtr guessCard(const CardRef &cardRef) const;
+    [[nodiscard]] ExactCard guessCard(const CardRef &cardRef) const;
 
     /*
      * Get a card by its simple name. The name will be simplified in this
@@ -90,7 +92,6 @@ public:
     [[nodiscard]] CardInfoPtr getCardBySimpleName(const QString &cardName) const;
 
     CardSetPtr getSet(const QString &setName);
-    static PrintingInfo getSetInfoForCard(const CardInfoPtr &_card);
     const CardNameMap &getCardList() const
     {
         return cards;
@@ -111,7 +112,6 @@ public:
 
 public slots:
     LoadStatus loadCardDatabases();
-    void refreshPreferredPrintings();
     void addCard(CardInfoPtr card);
     void addSet(CardSetPtr set);
 protected slots:

--- a/cockatrice/src/game/cards/card_info.cpp
+++ b/cockatrice/src/game/cards/card_info.cpp
@@ -242,15 +242,9 @@ CardInfo::CardInfo(const QString &_name,
       reverseRelatedCards(_reverseRelatedCards), setsToPrintings(std::move(_sets)), cipt(_cipt),
       landscapeOrientation(_landscapeOrientation), tableRow(_tableRow), upsideDownArt(_upsideDownArt)
 {
-    pixmapCacheKey = QLatin1String("card_") + name;
     simpleName = CardInfo::simplifyName(name);
 
     refreshCachedSetNames();
-}
-
-CardInfo::~CardInfo()
-{
-    PictureLoader::clearPixmapCache(smartThis);
 }
 
 CardInfoPtr CardInfo::newInstance(const QString &_name)

--- a/cockatrice/src/game/cards/exact_card.cpp
+++ b/cockatrice/src/game/cards/exact_card.cpp
@@ -1,0 +1,79 @@
+#include "exact_card.h"
+
+/**
+ * Default constructor.
+ * This will set the CardInfoPtr to null.
+ * The printing will be the default-constructed PrintingInfo.
+ */
+ExactCard::ExactCard()
+{
+}
+
+/**
+ * @param _card The card. Can be null.
+ * @param _printing The printing. Can be empty.
+ */
+ExactCard::ExactCard(const CardInfoPtr &_card, const PrintingInfo &_printing) : card(_card), printing(_printing)
+{
+}
+
+bool ExactCard::operator==(const ExactCard &other) const
+{
+    return this->card == other.card && this->printing == other.printing;
+}
+
+/**
+ * Convenience method to safely get the card's name.
+ * @return The name in the CardInfo, or an empty string if card is null
+ */
+QString ExactCard::getName() const
+{
+    return card.isNull() ? "" : card->getName();
+}
+
+/**
+ * Gets a view of the underlying cardInfoPtr.
+ * @return A const reference to the CardInfo, or an empty CardInfo if card is null
+ */
+const CardInfo &ExactCard::getInfo() const
+{
+    if (card.isNull()) {
+        static CardInfoPtr emptyCard = CardInfo::newInstance("");
+        return *emptyCard;
+    }
+    return *card;
+}
+
+/**
+ * The key used to identify this exact printing in the cache
+ */
+QString ExactCard::getPixmapCacheKey() const
+{
+    QString uuid = printing.getUuid();
+    QString suffix = uuid.isEmpty() ? "" : "_" + uuid;
+    return QLatin1String("card_") + card->getName() + suffix;
+}
+
+/**
+ * Checks if the card is null or empty.
+ */
+bool ExactCard::isEmpty() const
+{
+    return card.isNull() || card->getName().isEmpty();
+}
+
+/**
+ * Returns true if isEmpty() is false
+ */
+ExactCard::operator bool() const
+{
+    return !isEmpty();
+}
+
+/**
+ * Gets the CardInfo to emit the pixmapUpdated signal
+ */
+void ExactCard::emitPixmapUpdated() const
+{
+    emit card->pixmapUpdated(printing);
+}

--- a/cockatrice/src/game/cards/exact_card.h
+++ b/cockatrice/src/game/cards/exact_card.h
@@ -1,0 +1,46 @@
+#ifndef EXACT_CARD_H
+#define EXACT_CARD_H
+
+#include "card_info.h"
+
+/**
+ * Identifies the card along with its exact printing
+ */
+class ExactCard
+{
+    CardInfoPtr card;
+    PrintingInfo printing;
+
+public:
+    ExactCard();
+    explicit ExactCard(const CardInfoPtr &_card, const PrintingInfo &_printing = PrintingInfo());
+
+    /**
+     * Gets the CardInfoPtr. Can be null.
+     */
+    CardInfoPtr getCardPtr() const
+    {
+        return card;
+    }
+
+    /**
+     * Gets the PrintingInfo. Can be empty.
+     */
+    PrintingInfo getPrinting() const
+    {
+        return printing;
+    }
+
+    bool operator==(const ExactCard &other) const;
+
+    QString getName() const;
+    const CardInfo &getInfo() const;
+    QString getPixmapCacheKey() const;
+
+    bool isEmpty() const;
+    explicit operator bool() const;
+
+    void emitPixmapUpdated() const;
+};
+
+#endif // EXACT_CARD_H

--- a/cockatrice/src/game/deckview/deck_view.cpp
+++ b/cockatrice/src/game/deckview/deck_view.cpp
@@ -217,13 +217,13 @@ void DeckViewCardContainer::paint(QPainter *painter, const QStyleOptionGraphicsI
 void DeckViewCardContainer::addCard(DeckViewCard *card)
 {
     cards.append(card);
-    cardsByType.insert(card->getInfo() ? card->getInfo()->getMainCardType() : "", card);
+    cardsByType.insert(card->getCard().isEmpty() ? "" : card->getCardInfo().getMainCardType(), card);
 }
 
 void DeckViewCardContainer::removeCard(DeckViewCard *card)
 {
     cards.removeOne(card);
-    cardsByType.remove(card->getInfo() ? card->getInfo()->getMainCardType() : "", card);
+    cardsByType.remove(card->getCard().isEmpty() ? "" : card->getCardInfo().getMainCardType(), card);
 }
 
 QList<QPair<int, int>> DeckViewCardContainer::getRowsAndCols() const

--- a/cockatrice/src/game/zones/table_zone.cpp
+++ b/cockatrice/src/game/zones/table_zone.cpp
@@ -140,9 +140,9 @@ void TableZone::handleDropEventByGrid(const QList<CardDragItem *> &dragItems,
         ctm->set_card_id(item->getId());
         ctm->set_face_down(item->getFaceDown());
         if (startZone->getName() != name && !item->getFaceDown()) {
-            const auto &info = item->getItem()->getInfo();
-            if (info) {
-                ctm->set_pt(info->getPowTough().toStdString());
+            const auto &card = item->getItem()->getCard();
+            if (card) {
+                ctm->set_pt(card.getInfo().getPowTough().toStdString());
             }
         }
     }

--- a/cockatrice/src/game/zones/view_zone.cpp
+++ b/cockatrice/src/game/zones/view_zone.cpp
@@ -152,7 +152,7 @@ void ZoneViewZone::reorganizeCards()
     // filter cards
     CardList cardsToDisplay = CardList(cards.getContentsKnown());
     for (auto card : cards) {
-        if (filterString.check(card->getInfo())) {
+        if (filterString.check(card->getCard().getCardPtr())) {
             card->show();
             cardsToDisplay.append(card);
         } else {

--- a/dbconverter/CMakeLists.txt
+++ b/dbconverter/CMakeLists.txt
@@ -10,6 +10,7 @@ set(dbconverter_SOURCES
     ../cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
     ../cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
     ../cockatrice/src/game/cards/card_info.cpp
+    ../cockatrice/src/game/cards/exact_card.cpp
     ../cockatrice/src/settings/settings_manager.cpp
     ${VERSION_STRING_CPP}
 )

--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -17,16 +17,7 @@ set(oracle_SOURCES
     src/pagetemplates.cpp
     src/parsehelpers.cpp
     src/qt-json/json.cpp
-    ../cockatrice/src/game/cards/card_database.cpp
-    ../cockatrice/src/game/cards/card_database_manager.cpp
     ../cockatrice/src/game/cards/card_info.cpp
-    ../cockatrice/src/client/ui/picture_loader/picture_loader.cpp
-    ../cockatrice/src/client/ui/picture_loader/picture_loader_local.cpp
-    ../cockatrice/src/client/ui/picture_loader/picture_loader_request_status_display_widget.cpp
-    ../cockatrice/src/client/ui/picture_loader/picture_loader_status_bar.cpp
-    ../cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
-    ../cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
-    ../cockatrice/src/client/ui/picture_loader/picture_to_load.cpp
     ../cockatrice/src/client/ui/widgets/quick_settings/settings_button_widget.cpp
     ../cockatrice/src/client/ui/widgets/quick_settings/settings_popup_widget.cpp
     ../cockatrice/src/game/cards/card_database_parser/card_database_parser.cpp

--- a/tests/carddatabase/CMakeLists.txt
+++ b/tests/carddatabase/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(
   ../../cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
   ../../cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
   ../../cockatrice/src/game/cards/card_info.cpp
+  ../../cockatrice/src/game/cards/exact_card.cpp
   ../../cockatrice/src/settings/settings_manager.cpp
   carddatabase_test.cpp
   mocks.cpp
@@ -37,6 +38,7 @@ add_executable(
   ../../cockatrice/src/game/cards/card_database_parser/cockatrice_xml_3.cpp
   ../../cockatrice/src/game/cards/card_database_parser/cockatrice_xml_4.cpp
   ../../cockatrice/src/game/cards/card_info.cpp
+  ../../cockatrice/src/game/cards/exact_card.cpp
   ../../cockatrice/src/game/filters/filter_card.cpp
   ../../cockatrice/src/game/filters/filter_string.cpp
   ../../cockatrice/src/game/filters/filter_tree.cpp


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6039
- Follow-up to #6042

## Short roundup of the initial problem

When we added ability to select printings to Cockatrice, we implemented it by having each printing be represented by a clone of a `CardInfoPtr`, except with a different `pixmapCacheKey`. This implementation is unintuitive. Having the printing key off the `pixmapCacheKey` causes a lot of unintuitive code.

This refactor aims to replace the printing keying off the CardInfoPtr's pixmapCacheKey with a proper object that contains both the CardInfoPtr and the printing

## What will change with this Pull Request?
- Created `ExactCard` class
  - Contains a `CardInfoPtr` and a `PrintingInfo`
  - Intended to be passed around as a value object
  - Contains method to get `CardInfo` both as pointer or as const ref
- Updated `CardDatabase` to return `ExactCard`
- Replace usages of `CardInfoPtr` with `ExactCard` anywhere we care about the exact printing of the card and not just the raw card info.
- Getting the image to update when PictureLoader finishes is still done by connecting the `CardInfoPtr` inside the `ExactCard`.
  - This does mean that imageLoaded of other printings of the card will also trigger the signal, but refreshing the image is  idempotent so it should be fine.