### PR TITLE
Also clear redirect cache when clearing network cache

### DIFF
--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
@@ -234,4 +234,5 @@ void PictureLoaderWorker::cleanStaleEntries()
 void PictureLoaderWorker::clearNetworkCache()
 {
     networkManager->cache()->clear();
+    redirectCache.clear();
 }


### PR DESCRIPTION
## Short roundup of the initial problem

The "Delete downloaded images" button clears the network cache, but doesn't clear the redirect cache.

Seeing as that button is used to forcibly reset all images, it should clear the redirect cache as well. Otherwise the wrong image might be loaded due to incorrect lingering redirects.

## What will change with this Pull Request?
- `PictureLoaderWorker::clearNetworkCache` now also clears the redirect cache
