### PR TITLE
Retain arrows when phases change

### DIFF
--- a/common/server_game.cpp
+++ b/common/server_game.cpp
@@ -652,22 +652,7 @@ void Server_Game::setActivePlayer(int _activePlayer)
 void Server_Game::setActivePhase(int _activePhase)
 {
     QMutexLocker locker(&gameMutex);
-
-    for (Server_Player *player : players.values()) {
-        QList<Server_Arrow *> toDelete = player->getArrows().values();
-        for (int i = 0; i < toDelete.size(); ++i) {
-            Server_Arrow *a = toDelete[i];
-
-            Event_DeleteArrow event;
-            event.set_arrow_id(a->getId());
-            sendGameEventContainer(prepareGameEvent(event, player->getPlayerId()));
-
-            player->deleteArrow(a->getId());
-        }
-    }
-
     activePhase = _activePhase;
-
     Event_SetActivePhase event;
     event.set_phase(activePhase);
     sendGameEventContainer(prepareGameEvent(event, -1));


### PR DESCRIPTION
## Related Ticket(s)
- Implements [6035](https://github.com/Cockatrice/Cockatrice/issues/6035)

## Short roundup of the initial problem
Currently, arrows are destroyed when phases change. This often undesirable, especially during combat when complicated attack arrows have been drawn, only to be destroyed when going to blockers.


## What will change with this Pull Request?
- Arrows are not destroyed when phases change

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
