### PR TITLE
Fix certain game actions only recognizing first shortcut

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -959,38 +959,11 @@ void Player::setShortcutsActive()
     aSelectRow->setShortcuts(shortcuts.getShortcut("Player/aSelectRow"));
     aSelectColumn->setShortcuts(shortcuts.getShortcut("Player/aSelectColumn"));
 
-    QList<QKeySequence> addCCShortCuts;
-    addCCShortCuts.append(shortcuts.getSingleShortcut("Player/aCCRed"));
-    addCCShortCuts.append(shortcuts.getSingleShortcut("Player/aCCYellow"));
-    addCCShortCuts.append(shortcuts.getSingleShortcut("Player/aCCGreen"));
-    addCCShortCuts.append(shortcuts.getSingleShortcut("Player/aCCCyan"));
-    addCCShortCuts.append(shortcuts.getSingleShortcut("Player/aCCPurple"));
-    addCCShortCuts.append(shortcuts.getSingleShortcut("Player/aCCMagenta"));
-
-    QList<QKeySequence> removeCCShortCuts;
-    removeCCShortCuts.append(shortcuts.getSingleShortcut("Player/aRCRed"));
-    removeCCShortCuts.append(shortcuts.getSingleShortcut("Player/aRCYellow"));
-    removeCCShortCuts.append(shortcuts.getSingleShortcut("Player/aRCGreen"));
-    removeCCShortCuts.append(shortcuts.getSingleShortcut("Player/aRCCyan"));
-    removeCCShortCuts.append(shortcuts.getSingleShortcut("Player/aRCPurple"));
-    removeCCShortCuts.append(shortcuts.getSingleShortcut("Player/aRCMagenta"));
-
-    QList<QKeySequence> setCCShortCuts;
-    setCCShortCuts.append(shortcuts.getSingleShortcut("Player/aSCRed"));
-    setCCShortCuts.append(shortcuts.getSingleShortcut("Player/aSCYellow"));
-    setCCShortCuts.append(shortcuts.getSingleShortcut("Player/aSCGreen"));
-    setCCShortCuts.append(shortcuts.getSingleShortcut("Player/aSCCyan"));
-    setCCShortCuts.append(shortcuts.getSingleShortcut("Player/aSCPurple"));
-    setCCShortCuts.append(shortcuts.getSingleShortcut("Player/aSCMagenta"));
-
-    for (int i = 0; i < addCCShortCuts.size(); ++i) {
-        aAddCounter[i]->setShortcut(addCCShortCuts.at(i));
-    }
-    for (int i = 0; i < removeCCShortCuts.size(); ++i) {
-        aRemoveCounter[i]->setShortcut(removeCCShortCuts.at(i));
-    }
-    for (int i = 0; i < setCCShortCuts.size(); ++i) {
-        aSetCounter[i]->setShortcut(setCCShortCuts.at(i));
+    static const QStringList colorWords = {"Red", "Yellow", "Green", "Cyan", "Purple", "Magenta"};
+    for (int i = 0; i < aAddCounter.size(); i++) {
+        aAddCounter[i]->setShortcuts(shortcuts.getShortcut("Player/aCC" + colorWords[i]));
+        aRemoveCounter[i]->setShortcuts(shortcuts.getShortcut("Player/aRC" + colorWords[i]));
+        aSetCounter[i]->setShortcuts(shortcuts.getShortcut("Player/aSC" + colorWords[i]));
     }
 
     QMapIterator<int, AbstractCounter *> counterIterator(counters);

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -998,44 +998,44 @@ void Player::setShortcutsActive()
         counterIterator.next().value()->setShortcutsActive();
     }
 
-    aViewSideboard->setShortcut(shortcuts.getSingleShortcut("Player/aViewSideboard"));
-    aViewLibrary->setShortcut(shortcuts.getSingleShortcut("Player/aViewLibrary"));
-    aViewHand->setShortcut(shortcuts.getSingleShortcut("Player/aViewHand"));
-    aViewTopCards->setShortcut(shortcuts.getSingleShortcut("Player/aViewTopCards"));
-    aViewBottomCards->setShortcut(shortcuts.getSingleShortcut("Player/aViewBottomCards"));
-    aViewGraveyard->setShortcut(shortcuts.getSingleShortcut("Player/aViewGraveyard"));
-    aDrawCard->setShortcut(shortcuts.getSingleShortcut("Player/aDrawCard"));
-    aDrawCards->setShortcut(shortcuts.getSingleShortcut("Player/aDrawCards"));
-    aUndoDraw->setShortcut(shortcuts.getSingleShortcut("Player/aUndoDraw"));
-    aMulligan->setShortcut(shortcuts.getSingleShortcut("Player/aMulligan"));
-    aShuffle->setShortcut(shortcuts.getSingleShortcut("Player/aShuffle"));
-    aShuffleTopCards->setShortcut(shortcuts.getSingleShortcut("Player/aShuffleTopCards"));
-    aShuffleBottomCards->setShortcut(shortcuts.getSingleShortcut("Player/aShuffleBottomCards"));
-    aUntapAll->setShortcut(shortcuts.getSingleShortcut("Player/aUntapAll"));
-    aRollDie->setShortcut(shortcuts.getSingleShortcut("Player/aRollDie"));
-    aCreateToken->setShortcut(shortcuts.getSingleShortcut("Player/aCreateToken"));
-    aCreateAnotherToken->setShortcut(shortcuts.getSingleShortcut("Player/aCreateAnotherToken"));
-    aAlwaysRevealTopCard->setShortcut(shortcuts.getSingleShortcut("Player/aAlwaysRevealTopCard"));
-    aAlwaysLookAtTopCard->setShortcut(shortcuts.getSingleShortcut("Player/aAlwaysLookAtTopCard"));
-    aMoveTopToPlay->setShortcut(shortcuts.getSingleShortcut("Player/aMoveTopToPlay"));
-    aMoveTopToPlayFaceDown->setShortcut(shortcuts.getSingleShortcut("Player/aMoveTopToPlayFaceDown"));
-    aMoveTopCardToGraveyard->setShortcut(shortcuts.getSingleShortcut("Player/aMoveTopCardToGraveyard"));
-    aMoveTopCardsToGraveyard->setShortcut(shortcuts.getSingleShortcut("Player/aMoveTopCardsToGraveyard"));
-    aMoveTopCardToExile->setShortcut(shortcuts.getSingleShortcut("Player/aMoveTopCardToExile"));
-    aMoveTopCardsToExile->setShortcut(shortcuts.getSingleShortcut("Player/aMoveTopCardsToExile"));
-    aMoveTopCardsUntil->setShortcut(shortcuts.getSingleShortcut("Player/aMoveTopCardsUntil"));
-    aMoveTopCardToBottom->setShortcut(shortcuts.getSingleShortcut("Player/aMoveTopCardToBottom"));
-    aDrawBottomCard->setShortcut(shortcuts.getSingleShortcut("Player/aDrawBottomCard"));
-    aDrawBottomCards->setShortcut(shortcuts.getSingleShortcut("Player/aDrawBottomCards"));
-    aMoveBottomToPlay->setShortcut(shortcuts.getSingleShortcut("Player/aMoveBottomToPlay"));
-    aMoveBottomToPlayFaceDown->setShortcut(shortcuts.getSingleShortcut("Player/aMoveBottomToPlayFaceDown"));
-    aMoveBottomCardToGraveyard->setShortcut(shortcuts.getSingleShortcut("Player/aMoveBottomCardToGrave"));
-    aMoveBottomCardsToGraveyard->setShortcut(shortcuts.getSingleShortcut("Player/aMoveBottomCardsToGrave"));
-    aMoveBottomCardToExile->setShortcut(shortcuts.getSingleShortcut("Player/aMoveBottomCardToExile"));
-    aMoveBottomCardsToExile->setShortcut(shortcuts.getSingleShortcut("Player/aMoveBottomCardsToExile"));
-    aMoveBottomCardToTop->setShortcut(shortcuts.getSingleShortcut("Player/aMoveBottomCardToTop"));
-    aPlayFacedown->setShortcut(shortcuts.getSingleShortcut("Player/aPlayFacedown"));
-    aPlay->setShortcut(shortcuts.getSingleShortcut("Player/aPlay"));
+    aViewSideboard->setShortcuts(shortcuts.getShortcut("Player/aViewSideboard"));
+    aViewLibrary->setShortcuts(shortcuts.getShortcut("Player/aViewLibrary"));
+    aViewHand->setShortcuts(shortcuts.getShortcut("Player/aViewHand"));
+    aViewTopCards->setShortcuts(shortcuts.getShortcut("Player/aViewTopCards"));
+    aViewBottomCards->setShortcuts(shortcuts.getShortcut("Player/aViewBottomCards"));
+    aViewGraveyard->setShortcuts(shortcuts.getShortcut("Player/aViewGraveyard"));
+    aDrawCard->setShortcuts(shortcuts.getShortcut("Player/aDrawCard"));
+    aDrawCards->setShortcuts(shortcuts.getShortcut("Player/aDrawCards"));
+    aUndoDraw->setShortcuts(shortcuts.getShortcut("Player/aUndoDraw"));
+    aMulligan->setShortcuts(shortcuts.getShortcut("Player/aMulligan"));
+    aShuffle->setShortcuts(shortcuts.getShortcut("Player/aShuffle"));
+    aShuffleTopCards->setShortcuts(shortcuts.getShortcut("Player/aShuffleTopCards"));
+    aShuffleBottomCards->setShortcuts(shortcuts.getShortcut("Player/aShuffleBottomCards"));
+    aUntapAll->setShortcuts(shortcuts.getShortcut("Player/aUntapAll"));
+    aRollDie->setShortcuts(shortcuts.getShortcut("Player/aRollDie"));
+    aCreateToken->setShortcuts(shortcuts.getShortcut("Player/aCreateToken"));
+    aCreateAnotherToken->setShortcuts(shortcuts.getShortcut("Player/aCreateAnotherToken"));
+    aAlwaysRevealTopCard->setShortcuts(shortcuts.getShortcut("Player/aAlwaysRevealTopCard"));
+    aAlwaysLookAtTopCard->setShortcuts(shortcuts.getShortcut("Player/aAlwaysLookAtTopCard"));
+    aMoveTopToPlay->setShortcuts(shortcuts.getShortcut("Player/aMoveTopToPlay"));
+    aMoveTopToPlayFaceDown->setShortcuts(shortcuts.getShortcut("Player/aMoveTopToPlayFaceDown"));
+    aMoveTopCardToGraveyard->setShortcuts(shortcuts.getShortcut("Player/aMoveTopCardToGraveyard"));
+    aMoveTopCardsToGraveyard->setShortcuts(shortcuts.getShortcut("Player/aMoveTopCardsToGraveyard"));
+    aMoveTopCardToExile->setShortcuts(shortcuts.getShortcut("Player/aMoveTopCardToExile"));
+    aMoveTopCardsToExile->setShortcuts(shortcuts.getShortcut("Player/aMoveTopCardsToExile"));
+    aMoveTopCardsUntil->setShortcuts(shortcuts.getShortcut("Player/aMoveTopCardsUntil"));
+    aMoveTopCardToBottom->setShortcuts(shortcuts.getShortcut("Player/aMoveTopCardToBottom"));
+    aDrawBottomCard->setShortcuts(shortcuts.getShortcut("Player/aDrawBottomCard"));
+    aDrawBottomCards->setShortcuts(shortcuts.getShortcut("Player/aDrawBottomCards"));
+    aMoveBottomToPlay->setShortcuts(shortcuts.getShortcut("Player/aMoveBottomToPlay"));
+    aMoveBottomToPlayFaceDown->setShortcuts(shortcuts.getShortcut("Player/aMoveBottomToPlayFaceDown"));
+    aMoveBottomCardToGraveyard->setShortcuts(shortcuts.getShortcut("Player/aMoveBottomCardToGrave"));
+    aMoveBottomCardsToGraveyard->setShortcuts(shortcuts.getShortcut("Player/aMoveBottomCardsToGrave"));
+    aMoveBottomCardToExile->setShortcuts(shortcuts.getShortcut("Player/aMoveBottomCardToExile"));
+    aMoveBottomCardsToExile->setShortcuts(shortcuts.getShortcut("Player/aMoveBottomCardsToExile"));
+    aMoveBottomCardToTop->setShortcuts(shortcuts.getShortcut("Player/aMoveBottomCardToTop"));
+    aPlayFacedown->setShortcuts(shortcuts.getShortcut("Player/aPlayFacedown"));
+    aPlay->setShortcuts(shortcuts.getShortcut("Player/aPlay"));
 
     // Don't enable always-active shortcuts in local games, since it causes keyboard shortcuts to work inconsistently
     // when there are more than 1 player.
@@ -4175,8 +4175,8 @@ void Player::addRelatedCardActions(const CardItem *card, QMenu *cardMenu)
 
     if (createRelatedCards) {
         if (shortcutsActive) {
-            createRelatedCards->setShortcut(
-                SettingsCache::instance().shortcuts().getSingleShortcut("Player/aCreateRelatedTokens"));
+            createRelatedCards->setShortcuts(
+                SettingsCache::instance().shortcuts().getShortcut("Player/aCreateRelatedTokens"));
         }
         connect(createRelatedCards, &QAction::triggered, this, &Player::actCreateAllRelatedCards);
         cardMenu->addAction(createRelatedCards);

--- a/cockatrice/src/settings/shortcuts_settings.cpp
+++ b/cockatrice/src/settings/shortcuts_settings.cpp
@@ -115,6 +115,13 @@ ShortcutKey ShortcutsSettings::getShortcut(const QString &name) const
     return getDefaultShortcut(name);
 }
 
+/**
+ * Gets the first shortcut for the given action.
+ *
+ * NOTE: In most cases you should be using ShortcutsSettings::getShortcut instead,
+ * as that will return all shortcuts if there are multiple shortcuts.
+ * The only reason to use this method is if an object does not accept multiple shortcuts, such as with QButtons.
+ */
 QKeySequence ShortcutsSettings::getSingleShortcut(const QString &name) const
 {
     return getShortcut(name).at(0);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6058

## Short roundup of the initial problem

Some of the actions in `Player` are using `ShortcutsSettings::getSingleShortcut` (which only gets the first shortcut) instead of `ShortcutsSettings::getShortcut`. This causes Cockatrice to not recognize shortcuts other than the first shortcut when multiple shortcuts are set for an action.

## What will change with this Pull Request?
- Use `getShortcut` instead of `getSingleShortcut` for all actions in `Player`
- Clean up card counter shortcut creation
- Add doc to `getSingleShortcut`