### PR TITLE
Refactor TabReplay creation

### DIFF
--- a/cockatrice/src/client/tabs/tab_replays.h
+++ b/cockatrice/src/client/tabs/tab_replays.h
@@ -23,13 +23,15 @@ private:
     AbstractClient *client;
     QTreeView *localDirView;
     QFileSystemModel *localDirModel;
-    QToolBar *leftToolBar, *rightToolBar;
     RemoteReplayList_TreeWidget *serverDirView;
     QGroupBox *leftGroupBox, *rightGroupBox;
 
     QAction *aOpenLocalReplay, *aRenameLocal, *aNewLocalFolder, *aDeleteLocalReplay;
     QAction *aOpenReplaysFolder;
     QAction *aOpenRemoteReplay, *aDownload, *aKeep, *aDeleteRemoteReplay;
+
+    QGroupBox *createLeftLayout();
+    QGroupBox *createRightLayout();
 
     void setRemoteEnabled(bool enabled);
 


### PR DESCRIPTION
## Short roundup of the initial problem

I'm adding a new rightmost button to the right side of the replay tab and it's really annoying to do.

## What will change with this Pull Request?
- Extract each side of the tab replay creation to its own method.
