### PR TITLE
Refactor: rename and consolidate getSpectator

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -411,11 +411,6 @@ void TabGame::adminLockChanged(bool lock)
     sayEdit->setVisible(v);
 }
 
-bool TabGame::isSpectator()
-{
-    return spectator;
-}
-
 void TabGame::actGameInfo()
 {
     DlgCreateGame dlg(gameInfo, roomGameTypes, this);

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -234,15 +234,14 @@ public:
         return gameInfo.game_id();
     }
     QString getTabText() const override;
-    bool getSpectator() const
+    bool isSpectator() const
     {
         return spectator;
     }
-    bool getSpectatorsSeeEverything() const
+    bool isSpectatorsOmniscient() const
     {
         return gameInfo.spectators_omniscient();
     }
-    bool isSpectator();
     Player *getActiveLocalPlayer() const;
     AbstractClient *getClientForPlayer(int playerId) const;
 

--- a/cockatrice/src/game/board/card_item.cpp
+++ b/cockatrice/src/game/board/card_item.cpp
@@ -274,7 +274,7 @@ void CardItem::deleteDragItem()
 
 void CardItem::drawArrow(const QColor &arrowColor)
 {
-    if (static_cast<TabGame *>(owner->parent())->getSpectator())
+    if (static_cast<TabGame *>(owner->parent())->isSpectator())
         return;
 
     Player *arrowOwner = static_cast<TabGame *>(owner->parent())->getActiveLocalPlayer();
@@ -297,7 +297,7 @@ void CardItem::drawArrow(const QColor &arrowColor)
 
 void CardItem::drawAttachArrow()
 {
-    if (static_cast<TabGame *>(owner->parent())->getSpectator())
+    if (static_cast<TabGame *>(owner->parent())->isSpectator())
         return;
 
     auto *arrow = new ArrowAttachItem(this);

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -150,8 +150,7 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
 
     stack = addZone(new StackZone(this, (int)table->boundingRect().height(), this));
 
-    hand = addZone(new HandZone(this,
-                                _local || _judge || (_parent->getSpectator() && _parent->getSpectatorsSeeEverything()),
+    hand = addZone(new HandZone(this, _local || _judge || (_parent->isSpectator() && _parent->isSpectatorsOmniscient()),
                                 (int)table->boundingRect().height(), this));
     connect(hand, &HandZone::cardCountChanged, handCounter, &HandCounter::updateNumber);
     connect(handCounter, &HandCounter::showContextMenu, hand, &HandZone::showContextMenu);
@@ -2782,7 +2781,7 @@ void Player::processPlayerInfo(const ServerInfo_Player &info)
 
                 switch (zoneInfo.type()) {
                     case ServerInfo_Zone::PrivateZone:
-                        contentsKnown = local || judge || (game->getSpectator() && game->getSpectatorsSeeEverything());
+                        contentsKnown = local || judge || (game->isSpectator() && game->isSpectatorsOmniscient());
                         break;
 
                     case ServerInfo_Zone::PublicZone:


### PR DESCRIPTION
## Short roundup of the initial problem

`Player::getSpectator` is completely redundant with `Player::isSpectator` (as in, the method bodies are the exact same).

## What will change with this Pull Request?
- Delete `getSpectator` and use `isSpectator` instead
- Rename `getSpectatorsSeeEverything` to `isSpectatorsOmniscient`