### PR TITLE
Add Debian 13 'Trixie' build

### DIFF
--- a/.ci/Debian13/Dockerfile
+++ b/.ci/Debian13/Dockerfile
@@ -1,0 +1,28 @@
+FROM debian:13
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        ccache \
+        clang-format \
+        cmake \
+        file \
+        g++ \
+        git \
+        libgl-dev \
+        liblzma-dev \
+        libmariadb-dev-compat \
+        libprotobuf-dev \
+        libqt6multimedia6 \
+        libqt6sql6-mysql \
+        ninja-build \
+        protobuf-compiler \
+        qt6-image-formats-plugins \
+        qt6-l10n-tools \
+        qt6-multimedia-dev \
+        qt6-svg-dev \
+        qt6-tools-dev \
+        qt6-tools-dev-tools \
+        qt6-websockets-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -20,6 +20,7 @@ Available pre-compiled binaries for installation:
   <b>Linux</b>
    • <kbd>Ubuntu 24.04 LTS</kbd> <sub><i>Noble Numbat</i></sub>
    • <kbd>Ubuntu 22.04 LTS</kbd> <sub><i>Jammy Jellyfish</i></sub>
+   • <kbd>Debian 13</kbd> <sub><i>Trixie</i></sub>
    • <kbd>Debian 12</kbd> <sub><i>Bookworm</i></sub>
    • <kbd>Debian 11</kbd> <sub><i>Bullseye</i></sub>
    • <kbd>Fedora 42</kbd>

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -105,6 +105,11 @@ jobs:
           - distro: Debian
             version: 12
             package: DEB
+            test: skip    # Running tests on all distros is superfluous
+
+          - distro: Debian
+            version: 13
+            package: DEB
 
           - distro: Fedora
             version: 41


### PR DESCRIPTION
## Short roundup of the initial problem

Debian 13 (Trixie) is scheduled for release on August 9, 2025 so it would be advantageous to build for it in our next release. 

## What will change with this Pull Request?
- Add Debian 13 dockerfile
- Update desktop-build and release template accordingly

As far as I can tell from compiling from source in a Debian 13 RC3 VM, there are no package changes relevant to our build requirements. Trixie has been in full freeze for about a week and half now so I don't expect that to change for the official release.

This PR is a draft until Docker adds the release candidate image (Debian:13 tag instead of Debian:Trixie). I will test the complied software in a Debian 13 VM at that time.
