### PR TITLE
Refactor: rework card menu handling

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -261,6 +261,10 @@ void TabGame::retranslateUi()
         sayLabel->setText(tr("&Say:"));
     }
 
+    if (aCardMenu) {
+        aCardMenu->setText(tr("Selected cards"));
+    }
+
     viewMenu->setTitle(tr("&View"));
     cardInfoDockMenu->setTitle(tr("Card Info"));
     messageLayoutDockMenu->setTitle(tr("Messages"));
@@ -576,6 +580,7 @@ Player *TabGame::addPlayer(int playerId, const ServerInfo_User &info)
     scene->addPlayer(newPlayer);
 
     connect(newPlayer, &Player::newCardAdded, this, &TabGame::newCardAdded);
+    connect(newPlayer, &Player::cardMenuUpdated, this, &TabGame::setCardMenu);
     messageLog->connectToPlayer(newPlayer);
 
     if (local && !spectator) {
@@ -1232,6 +1237,18 @@ void TabGame::updateCardMenu(AbstractCardItem *card)
     }
 }
 
+/**
+ * @param menu The menu to set. Pass in nullptr to set the menu to empty.
+ */
+void TabGame::setCardMenu(QMenu *menu)
+{
+    if (menu) {
+        aCardMenu->setMenu(menu);
+    } else {
+        aCardMenu->setMenu(new QMenu);
+    }
+}
+
 void TabGame::createMenuItems()
 {
     aNextPhase = new QAction(this);
@@ -1285,6 +1302,11 @@ void TabGame::createMenuItems()
     gameMenu->addAction(aConcede);
     gameMenu->addAction(aFocusChat);
     gameMenu->addAction(aLeaveGame);
+
+    gameMenu->addSeparator();
+
+    aCardMenu = gameMenu->addMenu(new QMenu(this));
+
     addTabMenu(gameMenu);
 }
 

--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -1218,23 +1218,6 @@ Player *TabGame::getActiveLocalPlayer() const
 void TabGame::setActiveCard(CardItem *card)
 {
     activeCard = card;
-    updateCardMenu(card);
-}
-
-void TabGame::updateCardMenu(AbstractCardItem *card)
-{
-    if (card == nullptr) {
-        return;
-    }
-    Player *player;
-    if ((clients.size() > 1) || !players.contains(localPlayerId)) {
-        player = card->getOwner();
-    } else {
-        player = players.value(localPlayerId);
-    }
-    if (player != nullptr) {
-        player->updateCardMenu(static_cast<CardItem *>(card));
-    }
 }
 
 /**

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -172,7 +172,6 @@ private slots:
     void incrementGameTime();
     void adminLockChanged(bool lock);
     void newCardAdded(AbstractCardItem *card);
-    void updateCardMenu(AbstractCardItem *card);
     void setCardMenu(QMenu *menu);
 
     void actGameInfo();

--- a/cockatrice/src/client/tabs/tab_game.h
+++ b/cockatrice/src/client/tabs/tab_game.h
@@ -118,6 +118,7 @@ private:
         *aPlayerListDockVisible, *aPlayerListDockFloating, *aReplayDockVisible, *aReplayDockFloating;
     QAction *aFocusChat;
     QList<QAction *> phaseActions;
+    QAction *aCardMenu;
 
     Player *addPlayer(int playerId, const ServerInfo_User &info);
 
@@ -172,6 +173,7 @@ private slots:
     void adminLockChanged(bool lock);
     void newCardAdded(AbstractCardItem *card);
     void updateCardMenu(AbstractCardItem *card);
+    void setCardMenu(QMenu *menu);
 
     void actGameInfo();
     void actConcede();

--- a/cockatrice/src/game/board/card_item.cpp
+++ b/cockatrice/src/game/board/card_item.cpp
@@ -468,6 +468,9 @@ QVariant CardItem::itemChange(GraphicsItemChange change, const QVariant &value)
         if (value == true) {
             owner->getGame()->setActiveCard(this);
             owner->updateCardMenu(this);
+        } else if (owner->scene()->selectedItems().isEmpty()) {
+            owner->getGame()->setActiveCard(nullptr);
+            owner->updateCardMenu(nullptr);
         }
     }
     return AbstractCardItem::itemChange(change, value);

--- a/cockatrice/src/game/board/card_item.cpp
+++ b/cockatrice/src/game/board/card_item.cpp
@@ -24,30 +24,17 @@ CardItem::CardItem(Player *_owner, QGraphicsItem *parent, const CardRef &cardRef
 {
     owner->addCard(this);
 
-    cardMenu = new QMenu;
-    ptMenu = new QMenu;
-    moveMenu = new QMenu;
-
     connect(&SettingsCache::instance().cardCounters(), &CardCounterSettings::colorChanged, this, [this](int counterId) {
         if (counters.contains(counterId))
             update();
     });
-
-    retranslateUi();
-}
-
-CardItem::~CardItem()
-{
-    delete cardMenu;
-    delete ptMenu;
-    delete moveMenu;
 }
 
 void CardItem::prepareDelete()
 {
     if (owner != nullptr) {
-        if (owner->getCardMenu() == cardMenu) {
-            owner->setCardMenu(nullptr);
+        if (owner->getGame()->getActiveCard() == this) {
+            owner->updateCardMenu(nullptr);
             owner->getGame()->setActiveCard(nullptr);
         }
         owner = nullptr;
@@ -79,8 +66,6 @@ void CardItem::setZone(CardZone *_zone)
 
 void CardItem::retranslateUi()
 {
-    moveMenu->setTitle(tr("&Move to"));
-    ptMenu->setTitle(tr("&Power / toughness"));
 }
 
 void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
@@ -422,9 +407,13 @@ void CardItem::handleClickedToPlay(bool shiftHeld)
 void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     if (event->button() == Qt::RightButton) {
-        if (cardMenu != nullptr && !cardMenu->isEmpty() && owner != nullptr) {
-            cardMenu->popup(event->screenPos());
-            return;
+
+        if (owner != nullptr) {
+            owner->getGame()->setActiveCard(this);
+            if (QMenu *cardMenu = owner->updateCardMenu(this)) {
+                cardMenu->popup(event->screenPos());
+                return;
+            }
         }
     } else if ((event->modifiers() != Qt::AltModifier) && (event->button() == Qt::LeftButton) &&
                (!SettingsCache::instance().getDoubleClickToPlay())) {
@@ -477,11 +466,8 @@ QVariant CardItem::itemChange(GraphicsItemChange change, const QVariant &value)
 {
     if ((change == ItemSelectedHasChanged) && owner != nullptr) {
         if (value == true) {
-            owner->setCardMenu(cardMenu);
+            owner->updateCardMenu(this);
             owner->getGame()->setActiveCard(this);
-        } else if (owner->getCardMenu() == cardMenu) {
-            owner->setCardMenu(nullptr);
-            owner->getGame()->setActiveCard(nullptr);
         }
     }
     return AbstractCardItem::itemChange(change, value);

--- a/cockatrice/src/game/board/card_item.cpp
+++ b/cockatrice/src/game/board/card_item.cpp
@@ -466,8 +466,8 @@ QVariant CardItem::itemChange(GraphicsItemChange change, const QVariant &value)
 {
     if ((change == ItemSelectedHasChanged) && owner != nullptr) {
         if (value == true) {
-            owner->updateCardMenu(this);
             owner->getGame()->setActiveCard(this);
+            owner->updateCardMenu(this);
         }
     }
     return AbstractCardItem::itemChange(change, value);

--- a/cockatrice/src/game/board/card_item.h
+++ b/cockatrice/src/game/board/card_item.h
@@ -33,8 +33,6 @@ private:
     CardItem *attachedTo;
     QList<CardItem *> attachedCards;
 
-    QMenu *cardMenu, *ptMenu, *moveMenu;
-
     void prepareDelete();
     void handleClickedToPlay(bool shiftHeld);
 public slots:
@@ -54,7 +52,7 @@ public:
                       const CardRef &cardRef = {},
                       int _cardid = -1,
                       CardZone *_zone = nullptr);
-    ~CardItem() override;
+
     void retranslateUi();
     CardZone *getZone() const
     {
@@ -134,19 +132,6 @@ public:
     }
     void resetState(bool keepAnnotations = false);
     void processCardInfo(const ServerInfo_Card &_info);
-
-    QMenu *getCardMenu() const
-    {
-        return cardMenu;
-    }
-    QMenu *getPTMenu() const
-    {
-        return ptMenu;
-    }
-    QMenu *getMoveMenu() const
-    {
-        return moveMenu;
-    }
 
     bool animationEvent();
     CardDragItem *createDragItem(int _id, const QPointF &_pos, const QPointF &_scenePos, bool faceDown);

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -449,11 +449,6 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, T
         initSayMenu();
     }
 
-    aCardMenu = new QAction(this);
-    aCardMenu->setEnabled(false);
-    playerMenu->addSeparator();
-    playerMenu->addAction(aCardMenu);
-
     if (local || judge) {
 
         for (auto &playerList : playerLists) {
@@ -869,8 +864,6 @@ void Player::retranslateUi()
             allPlayersAction->setText(tr("&All players"));
         }
     }
-
-    aCardMenu->setText(tr("Selec&ted cards"));
 
     if (local) {
         sayMenu->setTitle(tr("S&ay"));
@@ -4233,21 +4226,11 @@ QMenu *Player::updateCardMenu(const CardItem *card)
 {
     QMenu *menu = createCardMenu(card);
 
-    aCardMenu->setEnabled(menu != nullptr);
     if (menu) {
-        aCardMenu->setMenu(menu);
+        emit cardMenuUpdated(menu);
     }
 
     return menu;
-}
-
-QMenu *Player::getCardMenu() const
-{
-    if (aCardMenu != nullptr) {
-        return aCardMenu->menu();
-    } else {
-        return nullptr;
-    }
 }
 
 QString Player::getName() const

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3897,19 +3897,13 @@ void Player::refreshShortcuts()
     }
 }
 
-void Player::updateCardMenu(const CardItem *card)
+QMenu *Player::createCardMenu(const CardItem *card)
 {
     // If bad card OR is a spectator (as spectators don't need card menus), return
     // only update the menu if the card is actually selected
     if (card == nullptr || (game->isSpectator() && !judge) || game->getActiveCard() != card) {
-        return;
+        return nullptr;
     }
-
-    QMenu *cardMenu = card->getCardMenu();
-    QMenu *ptMenu = card->getPTMenu();
-    QMenu *moveMenu = card->getMoveMenu();
-
-    cardMenu->clear();
 
     bool revealedCard = false;
     bool writeableCard = getLocalOrJudge();
@@ -3923,6 +3917,8 @@ void Player::updateCardMenu(const CardItem *card)
         }
     }
 
+    QMenu *cardMenu = new QMenu;
+
     if (revealedCard) {
         cardMenu->addAction(aHide);
         cardMenu->addAction(aClone);
@@ -3932,18 +3928,6 @@ void Player::updateCardMenu(const CardItem *card)
         addRelatedCardView(card, cardMenu);
     } else if (writeableCard) {
         bool canModifyCard = judge || card->getOwner() == this;
-
-        if (moveMenu->isEmpty() && canModifyCard) {
-            moveMenu->addAction(aMoveToTopLibrary);
-            moveMenu->addAction(aMoveToXfromTopOfLibrary);
-            moveMenu->addAction(aMoveToBottomLibrary);
-            moveMenu->addSeparator();
-            moveMenu->addAction(aMoveToHand);
-            moveMenu->addSeparator();
-            moveMenu->addAction(aMoveToGraveyard);
-            moveMenu->addSeparator();
-            moveMenu->addAction(aMoveToExile);
-        }
 
         if (card->getZone()) {
             if (card->getZone()->getName() == "table") {
@@ -3960,23 +3944,7 @@ void Player::updateCardMenu(const CardItem *card)
                     cardMenu->addSeparator();
                     cardMenu->addAction(aSelectAll);
                     cardMenu->addAction(aSelectRow);
-                    return;
-                }
-
-                if (ptMenu->isEmpty()) {
-                    ptMenu->addAction(aIncP);
-                    ptMenu->addAction(aDecP);
-                    ptMenu->addAction(aFlowP);
-                    ptMenu->addSeparator();
-                    ptMenu->addAction(aIncT);
-                    ptMenu->addAction(aDecT);
-                    ptMenu->addAction(aFlowT);
-                    ptMenu->addSeparator();
-                    ptMenu->addAction(aIncPT);
-                    ptMenu->addAction(aDecPT);
-                    ptMenu->addSeparator();
-                    ptMenu->addAction(aSetPT);
-                    ptMenu->addAction(aResetPT);
+                    return cardMenu;
                 }
 
                 cardMenu->addAction(aTap);
@@ -3996,11 +3964,11 @@ void Player::updateCardMenu(const CardItem *card)
                 }
                 cardMenu->addAction(aDrawArrow);
                 cardMenu->addSeparator();
-                cardMenu->addMenu(ptMenu);
+                cardMenu->addMenu(createPtMenu());
                 cardMenu->addAction(aSetAnnotation);
                 cardMenu->addSeparator();
                 cardMenu->addAction(aClone);
-                cardMenu->addMenu(moveMenu);
+                cardMenu->addMenu(createMoveMenu());
                 cardMenu->addSeparator();
                 cardMenu->addAction(aSelectAll);
                 cardMenu->addAction(aSelectRow);
@@ -4024,7 +3992,7 @@ void Player::updateCardMenu(const CardItem *card)
                     cardMenu->addAction(aDrawArrow);
                     cardMenu->addSeparator();
                     cardMenu->addAction(aClone);
-                    cardMenu->addMenu(moveMenu);
+                    cardMenu->addMenu(createMoveMenu());
                     cardMenu->addSeparator();
                     cardMenu->addAction(aSelectAll);
                 } else {
@@ -4045,7 +4013,7 @@ void Player::updateCardMenu(const CardItem *card)
 
                     cardMenu->addSeparator();
                     cardMenu->addAction(aClone);
-                    cardMenu->addMenu(moveMenu);
+                    cardMenu->addMenu(createMoveMenu());
                     cardMenu->addSeparator();
                     cardMenu->addAction(aSelectAll);
                     cardMenu->addAction(aSelectColumn);
@@ -4075,7 +4043,7 @@ void Player::updateCardMenu(const CardItem *card)
 
                 cardMenu->addSeparator();
                 cardMenu->addAction(aClone);
-                cardMenu->addMenu(moveMenu);
+                cardMenu->addMenu(createMoveMenu());
 
                 // actions that are really wonky when done from deck or sideboard
                 if (card->getZone()->getName() == "hand") {
@@ -4096,7 +4064,7 @@ void Player::updateCardMenu(const CardItem *card)
                 }
             }
         } else {
-            cardMenu->addMenu(moveMenu);
+            cardMenu->addMenu(createMoveMenu());
         }
     } else {
         if (card->getZone() && card->getZone()->getName() != "hand") {
@@ -4110,6 +4078,42 @@ void Player::updateCardMenu(const CardItem *card)
             cardMenu->addAction(aSelectAll);
         }
     }
+
+    return cardMenu;
+}
+
+QMenu *Player::createMoveMenu() const
+{
+    QMenu *moveMenu = new QMenu("Move to");
+    moveMenu->addAction(aMoveToTopLibrary);
+    moveMenu->addAction(aMoveToXfromTopOfLibrary);
+    moveMenu->addAction(aMoveToBottomLibrary);
+    moveMenu->addSeparator();
+    moveMenu->addAction(aMoveToHand);
+    moveMenu->addSeparator();
+    moveMenu->addAction(aMoveToGraveyard);
+    moveMenu->addSeparator();
+    moveMenu->addAction(aMoveToExile);
+    return moveMenu;
+}
+
+QMenu *Player::createPtMenu() const
+{
+    QMenu *ptMenu = new QMenu("Power / toughness");
+    ptMenu->addAction(aIncP);
+    ptMenu->addAction(aDecP);
+    ptMenu->addAction(aFlowP);
+    ptMenu->addSeparator();
+    ptMenu->addAction(aIncT);
+    ptMenu->addAction(aDecT);
+    ptMenu->addAction(aFlowT);
+    ptMenu->addSeparator();
+    ptMenu->addAction(aIncPT);
+    ptMenu->addAction(aDecPT);
+    ptMenu->addSeparator();
+    ptMenu->addAction(aSetPT);
+    ptMenu->addAction(aResetPT);
+    return ptMenu;
 }
 
 void Player::addRelatedCardView(const CardItem *card, QMenu *cardMenu)
@@ -4219,14 +4223,22 @@ void Player::addRelatedCardActions(const CardItem *card, QMenu *cardMenu)
     }
 }
 
-void Player::setCardMenu(QMenu *menu)
+/**
+ * Creates a card menu from the given card and sets it as the currently active card menu.
+ *
+ * @param card The card to create the menu for. Pass nullptr to disable the card menu.
+ * @return The new card menu
+ */
+QMenu *Player::updateCardMenu(const CardItem *card)
 {
-    if (aCardMenu != nullptr) {
-        aCardMenu->setEnabled(menu != nullptr);
-        if (menu) {
-            aCardMenu->setMenu(menu);
-        }
+    QMenu *menu = createCardMenu(card);
+
+    aCardMenu->setEnabled(menu != nullptr);
+    if (menu) {
+        aCardMenu->setMenu(menu);
     }
+
+    return menu;
 }
 
 QMenu *Player::getCardMenu() const

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -3892,9 +3892,7 @@ void Player::refreshShortcuts()
 
 QMenu *Player::createCardMenu(const CardItem *card)
 {
-    // If bad card OR is a spectator (as spectators don't need card menus), return
-    // only update the menu if the card is actually selected
-    if (card == nullptr || (game->isSpectator() && !judge) || game->getActiveCard() != card) {
+    if (card == nullptr) {
         return nullptr;
     }
 
@@ -4218,17 +4216,26 @@ void Player::addRelatedCardActions(const CardItem *card, QMenu *cardMenu)
 
 /**
  * Creates a card menu from the given card and sets it as the currently active card menu.
+ * Will first check if the card should have a card menu, and no-ops if not.
  *
  * @param card The card to create the menu for. Pass nullptr to disable the card menu.
- * @return The new card menu
+ * @return The new card menu, or nullptr if failed.
  */
 QMenu *Player::updateCardMenu(const CardItem *card)
 {
-    QMenu *menu = createCardMenu(card);
-
-    if (menu) {
-        emit cardMenuUpdated(menu);
+    if (!card) {
+        emit cardMenuUpdated(nullptr);
+        return nullptr;
     }
+
+    // If is spectator (as spectators don't need card menus), return
+    // only update the menu if the card is actually selected
+    if ((game->isSpectator() && !judge) || game->getActiveCard() != card) {
+        return nullptr;
+    }
+
+    QMenu *menu = createCardMenu(card);
+    emit cardMenuUpdated(menu);
 
     return menu;
 }

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -326,6 +326,8 @@ private:
                            const QString &avalue,
                            bool allCards,
                            EventProcessingOptions options);
+    QMenu *createMoveMenu() const;
+    QMenu *createPtMenu() const;
     void addRelatedCardActions(const CardItem *card, QMenu *cardMenu);
     void addRelatedCardView(const CardItem *card, QMenu *cardMenu);
     void createCard(const CardItem *sourceCard,
@@ -484,9 +486,9 @@ public:
     {
         return arrows;
     }
-    void setCardMenu(QMenu *menu);
+    QMenu *updateCardMenu(const CardItem *card);
     QMenu *getCardMenu() const;
-    void updateCardMenu(const CardItem *card);
+    QMenu *createCardMenu(const CardItem *card);
     bool getActive() const
     {
         return active;

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -156,6 +156,7 @@ signals:
 
     void sizeChanged();
     void playerCountChanged();
+    void cardMenuUpdated(QMenu *cardMenu);
 public slots:
     void actUntapAll();
     void actRollDie();
@@ -271,7 +272,6 @@ private:
         *aMoveBottomToPlayFaceDown, *aMoveBottomCardToTop, *aMoveBottomCardToGraveyard, *aMoveBottomCardToExile,
         *aMoveBottomCardsToGraveyard, *aMoveBottomCardsToExile, *aDrawBottomCard, *aDrawBottomCards;
 
-    QAction *aCardMenu;
     QList<QAction *> aAddCounter, aSetCounter, aRemoveCounter;
     QAction *aPlay, *aPlayFacedown, *aHide, *aTap, *aDoesntUntap, *aAttach, *aUnattach, *aDrawArrow, *aSetPT, *aResetPT,
         *aIncP, *aDecP, *aIncT, *aDecT, *aIncPT, *aDecPT, *aFlowP, *aFlowT, *aSetAnnotation, *aFlip, *aPeek, *aClone,
@@ -487,7 +487,6 @@ public:
         return arrows;
     }
     QMenu *updateCardMenu(const CardItem *card);
-    QMenu *getCardMenu() const;
     QMenu *createCardMenu(const CardItem *card);
     bool getActive() const
     {


### PR DESCRIPTION
## Short roundup of the initial problem

The card menu handling logic is unintuitive, overcomplicated, and has led to subtle and hard-to-fix bugs in the past. ()

Main issues with the current code:
- Each `CardItem` object stores a QMenu inside of itself. When that card is selected, the `Player` code will pull out that menu, populate that menu with the appropriate card menu actions, then insert that menu into the player's action menu.
  - It's confusing for each `CardItem` to store its own menu
  - It's confusing for `Player::updateCardMenu` to update a specific `CardItem`'s menu, instead of updating a singular menu.
- Card menus are per-player. Without intervention, this leads to shortcuts not working in local multiplayer games, as multiple actions with the same shortcut are active at once.
  - We have to be very careful with managing how card menus are deactivated when cards are unselected
  - Even then, we still constantly get bugs related to shortcuts not working in local multiplayer, since menu micromanagement is tricky to get right.

## What will change with this Pull Request?
- `CardItem`s no longer each keep their own card menus.
- `Player::createCardMenu` now creates and returns a brand new card menu.
  - Also cleaned up the code there
- Card menus are now stored in `TabGame`'s menu instead of `Player`
  - This ensures we only have a single card menu active, even if there are multiple players.
- When the menu needs updating, `Player::updateCardMenu` is called, which will create a new menu for the card and then emit a new `cardMenuUpdated` signal
  - `TabGame` is connected to that signal and will update the its menu with the new card menu 
  - Rewrote some card menu update detection code in `CardItem` to account for this. 
    - Behavior might not be exactly the same after, but it should be close enough to the expected behavior.

## Note

This PR does not fix all that bugs related to card menu shortcuts not working. There are still some bugs that persist (For example, the `unattach` shortcut doesn't work if the last card selected doesn't have that action).