### PR TITLE
[PictureLoader] Use thread pool instead of creating new thread

### DIFF
--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
@@ -94,7 +94,7 @@ QNetworkReply *PictureLoaderWorker::makeRequest(const QUrl &url, PictureLoaderWo
     QNetworkReply *reply = networkManager->get(req);
 
     // Connect reply handling
-    connect(reply, &QNetworkReply::finished, worker, [reply, worker] { worker->handleNetworkReply(reply); });
+    connect(reply, &QNetworkReply::finished, worker, [reply, worker] { worker->acceptNetworkReply(reply); });
 
     return reply;
 }

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
@@ -11,6 +11,7 @@
 #include <QNetworkDiskCache>
 #include <QNetworkReply>
 #include <QThread>
+#include <QThreadPool>
 
 // Card back returned by gatherer when card is not found
 static const QStringList MD5_BLACKLIST = {"db0c48db407a907c16ade38de048a441"};
@@ -67,6 +68,15 @@ void PictureLoaderWorkerWork::picDownloadFailed()
             << ", no more url combinations to try: BAILING OUT";
         concludeImageLoad(QImage());
     }
+}
+
+/**
+ * Processes the reply in another thread.
+ * @param reply The finished reply. Takes ownership of the object
+ */
+void PictureLoaderWorkerWork::acceptNetworkReply(QNetworkReply *reply)
+{
+    QThreadPool::globalInstance()->start([this, reply] { handleNetworkReply(reply); });
 }
 
 /**

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.h
@@ -30,13 +30,14 @@ public:
     PictureToLoad cardToDownload;
 
 public slots:
-    void handleNetworkReply(QNetworkReply *reply);
+    void acceptNetworkReply(QNetworkReply *reply);
 
 private:
     bool picDownload;
 
     void startNextPicDownload();
     void picDownloadFailed();
+    void handleNetworkReply(QNetworkReply *reply);
     void handleFailedReply(const QNetworkReply *reply);
     void handleSuccessfulReply(QNetworkReply *reply);
     QImage tryLoadImageFromReply(QNetworkReply *reply);


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6016

## Short roundup of the initial problem

I'm on a mac and I'm still getting semi-regular crashes due to `QThreadPipe: Unable to create pipe: Too many open files`. Spinning up a new thread for every single image request is probably contributing to that. 

If you try to load many images while the image cache is empty and the network is slow, the queue gets backed up, which causes a lot of threads to get created and hang around waiting.

## What will change with this Pull Request?
- Removed the creation of a new thread inside each `PictureLoaderWorkerWork`
- Only run the reply processing part in a separate thread, instead of creating a new thread as soon as the `PictureLoaderWorkerWork` is initialized.
- Run the reply processing in the global thread pool, instead of creating a new thread each time.