### PR TITLE
Fix providerId cards getting removed from deckList by convenience replacement function

### DIFF
--- a/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/printing_selector/card_amount_widget.cpp
@@ -140,16 +140,22 @@ void CardAmountWidget::updateCardCount()
  */
 void CardAmountWidget::addPrinting(const QString &zone)
 {
+    // Add the card and expand the list UI
     auto newCardIndex = deckModel->addCard(rootCard, zone);
     recursiveExpand(newCardIndex);
+
+    // Check if a card without a providerId already exists in the deckModel and replace it, if so.
     QModelIndex find_card = deckModel->findCard(rootCard.getName(), zone);
-    if (find_card.isValid() && find_card != newCardIndex) {
+    QString foundProviderId = deckModel->data(find_card.sibling(find_card.row(), 4), Qt::DisplayRole).toString();
+    if (find_card.isValid() && find_card != newCardIndex && foundProviderId == "") {
         auto amount = deckModel->data(find_card, Qt::DisplayRole);
         for (int i = 0; i < amount.toInt() - 1; i++) {
             deckModel->addCard(rootCard, zone);
         }
         deckModel->removeRow(find_card.row(), find_card.parent());
     }
+
+    // Set Index and Focus as if the user had just clicked the new card and modify the deckEditor saveState
     newCardIndex = deckModel->findCard(rootCard.getName(), zone, rootCard.getPrinting().getUuid(),
                                        rootCard.getPrinting().getProperty("num"));
     deckView->setCurrentIndex(newCardIndex);

--- a/cockatrice/src/deck/deck_loader.cpp
+++ b/cockatrice/src/deck/deck_loader.cpp
@@ -397,6 +397,7 @@ void DeckLoader::clearSetNamesAndNumbers()
         // Set the providerId on the card
         card->setCardSetShortName(nullptr);
         card->setCardCollectorNumber(nullptr);
+        card->setCardProviderId(nullptr);
     };
 
     forEachCard(clearSetNameAndNumber);


### PR DESCRIPTION
## Short roundup of the initial problem
We don't check the providerId of the card we're replacing so we just end up replacing every card if a user ever tries to add more than one providerId to the deck. 

## What will change with this Pull Request?
- This change only nukes cards from the deckList when adding new cards IF the old providerId was empty (thus replacing).
