### PR TITLE
Allow tokens to consider providerIds.

### DIFF
--- a/cockatrice/src/dialogs/dlg_create_token.cpp
+++ b/cockatrice/src/dialogs/dlg_create_token.cpp
@@ -198,7 +198,16 @@ void DlgCreateToken::tokenSelectionChanged(const QModelIndex &current, const QMo
         annotationEdit->setText("");
     }
 
-    pic->setCard(CardDatabaseManager::getInstance()->getPreferredCard(cardInfo));
+    const auto &cardProviderId =
+        SettingsCache::instance().cardOverrides().getCardPreferenceOverride(cardInfo->getName());
+    if (!cardProviderId.isEmpty()) {
+        CardRef ref;
+        ref.name = cardInfo->getName();
+        ref.providerId = cardProviderId;
+        pic->setCard(CardDatabaseManager::getInstance()->getCard(ref));
+    } else {
+        pic->setCard(CardDatabaseManager::getInstance()->getPreferredCard(cardInfo));
+    }
 }
 
 void DlgCreateToken::updateSearchFieldWithoutUpdatingFilter(const QString &newValue) const
@@ -250,5 +259,6 @@ TokenInfo DlgCreateToken::getTokenInfo() const
             .pt = ptEdit->text(),
             .annotation = annotationEdit->text(),
             .destroy = destroyCheckBox->isChecked(),
-            .faceDown = faceDownCheckBox->isChecked()};
+            .faceDown = faceDownCheckBox->isChecked(),
+            .providerId = SettingsCache::instance().cardOverrides().getCardPreferenceOverride(nameEdit->text())};
 }

--- a/cockatrice/src/dialogs/dlg_create_token.h
+++ b/cockatrice/src/dialogs/dlg_create_token.h
@@ -25,6 +25,7 @@ struct TokenInfo
     QString annotation;
     bool destroy = true;
     bool faceDown = false;
+    QString providerId;
 };
 
 class DlgCreateToken : public QDialog

--- a/cockatrice/src/game/cards/card_database.cpp
+++ b/cockatrice/src/game/cards/card_database.cpp
@@ -458,6 +458,12 @@ bool CardDatabase::isPreferredPrinting(const CardRef &cardRef) const
     return cardRef.providerId == getPreferredPrintingProviderId(cardRef.name);
 }
 
+ExactCard CardDatabase::getCardFromSameSet(const QString &cardName, const PrintingInfo &otherPrinting) const
+{
+    PrintingInfo relatedPrinting = getSpecificPrinting(cardName, otherPrinting.getSet()->getCorrectedShortName(), "");
+    return ExactCard(guessCard({cardName}).getCardPtr(), relatedPrinting);
+}
+
 void CardDatabase::refreshCachedReverseRelatedCards()
 {
     for (const CardInfoPtr &card : cards)

--- a/cockatrice/src/game/cards/card_database.h
+++ b/cockatrice/src/game/cards/card_database.h
@@ -82,6 +82,7 @@ public:
     getSpecificPrinting(const QString &cardName, const QString &setShortName, const QString &collectorNumber) const;
     QString getPreferredPrintingProviderId(const QString &cardName) const;
     bool isPreferredPrinting(const CardRef &cardRef) const;
+    ExactCard getCardFromSameSet(const QString &cardName, const PrintingInfo &otherPrinting) const;
 
     [[nodiscard]] ExactCard guessCard(const CardRef &cardRef) const;
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5961

## Short roundup of the initial problem
Because Tokens have to be created manually, we didn't implement providerIds for them. Turns out, it's easy enough to merge in providerIds with a small python script, which we can then use to have tokens respect providerIds.

## What will change with this Pull Request?
- Tokens created through Ctrl + T use the pinned printing, if available. 
- Tokens created through a related card menu use a token from the same set, if available.

## Screenshots

https://github.com/user-attachments/assets/482638f6-ed20-460c-aa27-cdd1dcad83a6


