### PR TITLE
Fix segfault when selecting card in replay

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -1267,6 +1267,10 @@ void TabGame::setActiveCard(CardItem *card)
  */
 void TabGame::setCardMenu(QMenu *menu)
 {
+    if (!aCardMenu) {
+        return;
+    }
+
     if (menu) {
         aCardMenu->setMenu(menu);
     } else {
@@ -1355,6 +1359,9 @@ void TabGame::createReplayMenuItems()
     phasesMenu = nullptr;
     gameMenu = new QMenu(this);
     gameMenu->addAction(aCloseReplay);
+
+    aCardMenu = nullptr;
+
     addTabMenu(gameMenu);
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #6069

## Short roundup of the initial problem

Cockatrice segfaults whenever you select a card while watching a replay.

https://github.com/user-attachments/assets/f55776cd-6a1c-4e5b-8d82-f12ed68346ba

Turns out `aCardMenu` isn't initialized if the game is a replay, causing Cockatrice to segfault when the card menu tries to update.

## What will change with this Pull Request?
- Set `aCardMenu` to null in replays
- Null check `aCardMenu` before updating the card menu

https://github.com/user-attachments/assets/6ad6105d-5d81-4381-b2f5-dcfb8915ba07
