### PR TITLE
[PictureLoader] Remove manual multithreading

### DIFF
--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker.cpp
@@ -94,7 +94,7 @@ QNetworkReply *PictureLoaderWorker::makeRequest(const QUrl &url, PictureLoaderWo
     QNetworkReply *reply = networkManager->get(req);
 
     // Connect reply handling
-    connect(reply, &QNetworkReply::finished, worker, [reply, worker] { worker->acceptNetworkReply(reply); });
+    connect(reply, &QNetworkReply::finished, worker, [reply, worker] { worker->handleNetworkReply(reply); });
 
     return reply;
 }

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.cpp
@@ -71,15 +71,6 @@ void PictureLoaderWorkerWork::picDownloadFailed()
 }
 
 /**
- * Processes the reply in another thread.
- * @param reply The finished reply. Takes ownership of the object
- */
-void PictureLoaderWorkerWork::acceptNetworkReply(QNetworkReply *reply)
-{
-    QThreadPool::globalInstance()->start([this, reply] { handleNetworkReply(reply); });
-}
-
-/**
  *
  * @param reply The reply. Takes ownership of the object
  */

--- a/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.h
+++ b/cockatrice/src/client/ui/picture_loader/picture_loader_worker_work.h
@@ -30,14 +30,13 @@ public:
     PictureToLoad cardToDownload;
 
 public slots:
-    void acceptNetworkReply(QNetworkReply *reply);
+    void handleNetworkReply(QNetworkReply *reply);
 
 private:
     bool picDownload;
 
     void startNextPicDownload();
     void picDownloadFailed();
-    void handleNetworkReply(QNetworkReply *reply);
     void handleFailedReply(const QNetworkReply *reply);
     void handleSuccessfulReply(QNetworkReply *reply);
     QImage tryLoadImageFromReply(QNetworkReply *reply);


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6072

## Short roundup of the initial problem

I'm getting intermittent segfaults from the PictureLoader. Directly passing the reply into the threadpool seems to intermittently cause segfaults to happen.

Our current design is already async even without spinning up threads, and does everything through signals.
The only part being multithreaded right now is the reply processing, which might not be necessary, as that is not where the bottleneck is.

The cleanest thing to do might just remove the manual multithreading entirely.

## What will change with this Pull Request?
- Remove thread pool; don't manually multithread any part of the PictureLoaderWorker

I tested removing the multi threading, and the load times were indistinguishable from before. Everything else is so fast that the only bottleneck that matters is the rate limit. Qt's http client is async and already handles parallelizing requests internally, so the only thing being multithreading is the reply processing. The reply processing isn't intensive enough for multithreading to make enough of a noticeable difference.