### PR TITLE
Refactor: Remove unused fields in InnerDecklistNode

### DIFF
--- a/common/decklist.cpp
+++ b/common/decklist.cpp
@@ -93,8 +93,7 @@ int AbstractDecklistNode::depth() const
 }
 
 InnerDecklistNode::InnerDecklistNode(InnerDecklistNode *other, InnerDecklistNode *_parent)
-    : AbstractDecklistNode(_parent), name(other->getName()), cardSetShortName(other->getCardSetShortName()),
-      cardCollectorNumber(other->getCardCollectorNumber()), cardProviderId(other->getCardProviderId())
+    : AbstractDecklistNode(_parent), name(other->getName())
 {
     for (int i = 0; i < other->size(); ++i) {
         auto *inner = dynamic_cast<InnerDecklistNode *>(other->at(i));

--- a/common/decklist.h
+++ b/common/decklist.h
@@ -84,10 +84,6 @@ public:
 class InnerDecklistNode : public AbstractDecklistNode, public QList<AbstractDecklistNode *>
 {
     QString name;
-    QString cardSetShortName;
-    QString cardCollectorNumber;
-    QString cardProviderId;
-    class compareFunctor;
 
 public:
     explicit InnerDecklistNode(QString _name = QString(), InnerDecklistNode *_parent = nullptr, int position = -1)
@@ -109,27 +105,15 @@ public:
     [[nodiscard]] virtual QString getVisibleName() const;
     [[nodiscard]] QString getCardProviderId() const override
     {
-        return cardProviderId;
-    }
-    void setCardProviderId(const QString &_cardProviderId)
-    {
-        cardProviderId = _cardProviderId;
+        return "";
     }
     [[nodiscard]] QString getCardSetShortName() const override
     {
-        return cardSetShortName;
-    }
-    void setCardSetShortName(const QString &_cardSetShortName)
-    {
-        cardSetShortName = _cardSetShortName;
+        return "";
     }
     [[nodiscard]] QString getCardCollectorNumber() const override
     {
-        return cardCollectorNumber;
-    }
-    void setCardCollectorNumber(const QString &_cardCollectorNumber)
-    {
-        cardCollectorNumber = _cardCollectorNumber;
+        return "";
     }
     [[nodiscard]] bool isDeckHeader() const override
     {


### PR DESCRIPTION
## Short roundup of the initial problem

`InnerDecklistNode` contains fields for card info. However, only `DecklistCardNode` should actually have card info.

`AbstractDecklistNode` contains virtual getters for those fields. `InnerDecklistNode` inherits those getters. However, since `InnerDecklistNode` never sets those fields, the getters should always return an empty string.

## What will change with this Pull Request?
- Remove `cardSetShortName`, `cardCollectorNumber`, and `cardProviderId` field from `InnerDecklistNode`
- Remove the setters for those fields and make the getters always return an empty string.
- Removed the unused `compareFunctor`