### PR TITLE
Test Vcpkg without submodule

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -421,8 +421,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Install Qt ${{matrix.qt_version}}
         uses: jurplel/install-qt-action@v4

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -421,6 +421,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Install Qt ${{matrix.qt_version}}
         uses: jurplel/install-qt-action@v4

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "$docs": "https://learn.microsoft.com/en-us/vcpkg/reference/vcpkg-json",
   "dependencies": [
     "gtest",
     "liblzma",
@@ -7,5 +8,6 @@
     "protobuf",
     "pthreads",
     "zlib"
-  ]
+  ],
+  "builtin-baseline": "c63619856b89f0af4d77ba2049396039e4985418"
 }


### PR DESCRIPTION
Edit: I do not think this is bringing us anywhere and utilizing the new dependabot support for vcpkg in its current form would still require the existence (and manual updating) of the embedded submodule as only the builtin-baseline value would be updated for now.