### PR TITLE
suggestion for drafting implementation

### DIFF
--- a/common/pb/CMakeLists.txt
+++ b/common/pb/CMakeLists.txt
@@ -21,6 +21,8 @@ set(PROTO_FILES
     command_deck_upload.proto
     command_del_counter.proto
     command_delete_arrow.proto
+    command_draft_options_select.proto
+    command_draft_pick_select.proto
     command_draw_cards.proto
     command_dump_zone.proto
     command_flip_card.proto
@@ -60,6 +62,7 @@ set(PROTO_FILES
     context_ready_start.proto
     context_set_sideboard_lock.proto
     context_undo_draw.proto
+    draft_options.proto
     event_add_to_list.proto
     event_attach_card.proto
     event_change_zone_properties.proto
@@ -70,6 +73,8 @@ set(PROTO_FILES
     event_del_counter.proto
     event_delete_arrow.proto
     event_destroy_card.proto
+    event_draft_pack.proto
+    event_draft_pick_select.proto
     event_draw_cards.proto
     event_dump_zone.proto
     event_flip_card.proto
@@ -124,6 +129,8 @@ set(PROTO_FILES
     response_deck_download.proto
     response_deck_list.proto
     response_deck_upload.proto
+    response_draft_deck_invalid.proto
+    response_draft_pick_selection_invalid.proto
     response_dump_zone.proto
     response_forgotpasswordrequest.proto
     response_get_admin_notes.proto

--- a/common/pb/command_draft_options_select.proto
+++ b/common/pb/command_draft_options_select.proto
@@ -1,0 +1,11 @@
+syntax = "proto2";
+import "game_commands.proto";
+import "draft_options.proto";
+
+// Sends the options to use to draft before the draft starts.
+message Command_DraftOptionsSelect {
+    extend GameCommand {
+        optional Command_DraftOptionsSelect ext = 1035;
+    }
+    optional Draft_Options options = 1;
+}

--- a/common/pb/command_draft_pick_select.proto
+++ b/common/pb/command_draft_pick_select.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+import "game_commands.proto";
+
+// Confirms the previously sent actions to the server and signals the next pack.
+message Command_DraftPickSelect {
+    extend GameCommand {
+        optional Command_DraftPickSelect ext = 1036;
+    }
+
+    // Index in the sequence of pick selections made, important to keep track of in case the pack is invalidated with a
+    // new one by the server during transit.
+    optional sint32 selection_index = 1 [default = -1];
+
+    // Confirms that the player desires to leave an unexpected amount of cards in the pack
+    optional bool is_overpicking = 2;
+
+    // Confirms that the player desires to place cards into the pack
+    optional bool is_returning = 3;
+}

--- a/common/pb/command_move_card.proto
+++ b/common/pb/command_move_card.proto
@@ -50,4 +50,7 @@ message Command_MoveCard {
 
     // Inverts the x coordinate to apply from the end of the target zone instead of the start
     optional bool is_reversed = 8 [default = false];
+
+    // During a draft this is the index of the pick selection
+    optional sint32 draft_selection_index = 9 [default = -1];
 }

--- a/common/pb/draft_options.proto
+++ b/common/pb/draft_options.proto
@@ -1,0 +1,66 @@
+syntax = "proto2";
+import "command_deck_select.proto";
+
+// Types of draft gamemodes available
+enum Draft_Type {
+    Booster_Draft = 1;
+    Sealed = 2;
+}
+
+// Container for options related to drafting shared in the game state
+message Draft_Options {
+    // The draft gamemode
+    optional Draft_Type type = 1;
+
+    // The cards to draft from as cockatrice decklist
+    optional string draft_list = 2;
+
+    // The cards to draft from as a decklist stored on the server
+    optional sint32 draft_list_id = 3 [default = -1];
+
+    // The cards that can be freely added to the deck before deck submission as cockatrice decklist
+    optional string addable_card_list = 4;
+
+    // The cards that can be freely added to the deck before deck submission as a decklist stored on the server
+    optional sint32 addable_card_list_id = 5 [default = -1];
+
+    // The amount of cards in each pack when using a cube, for example this is commonly 15 in boosterdrafts
+    optional uint32 cards_per_pack = 6;
+
+    // The amount of packs that will be drafted by each player when using a cube, for example this is commonly 3 in
+    // boosterdrafts
+    optional uint32 packs_per_player = 7;
+
+    // The minimum amount of cards in the mainboard of submitted decklists, often 40, -1 means any size
+    optional sint32 minimum_deck_size = 8 [default = -1];
+
+    // The amount of cards to pick every time a pack is passed, usually 1
+    optional uint32 picks_per_selection = 9 [default = 1];
+
+    // The amount of cards picked for removal every time a pack is passed, usually 0
+    optional uint32 burns_per_selection = 10;
+
+    // Amount of seconds before the server will decide picks automatically, -1 means no limit
+    optional sint32 selection_timer = 11 [default = -1];
+
+    // Amount of pick selections that can be made without having to wait on other players, this means that the slowest
+    // player can never have more than this amount of packs waiting for them and the fastest player can never be more
+    // than this amount of pick selections ahead of the slowest player, -1 means to never wait, 0 means to wait for all
+    // players to confirm their picks before showing the next pack
+    optional sint32 max_selections_ahead = 12 [default = -1];
+
+    // Amount of new packs that can be opened without having to wait on other players, only after all that player's pick
+    // selections in the current round of opened packs are finished can a new pack be opened, -1 means to never wait, 0
+    // means to wait for all players to finish their packs before showing the next pack when the player finished all
+    // picks
+    optional sint32 max_new_packs_ahead = 13 [default = -1];
+
+    // Allow players to interact using normal card actions on a table zone
+    optional bool enable_table = 32;
+
+    // Allow players to take more or less cards from packs with confirmation
+    optional bool enable_overpicking = 33;
+
+    // Allow players to return cards back into a pack with confirmation
+    optional bool enable_returning = 34;
+}

--- a/common/pb/event_draft_pack.proto
+++ b/common/pb/event_draft_pack.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+import "game_event.proto";
+import "serverinfo_card.proto";
+
+// Sent out by the server when a new pack is available, implicitly signals the start of the round timer
+message Event_DraftPack {
+    extend GameEvent {
+        optional Event_DraftPack ext = 2022;
+    }
+
+    // Index in the sequence of pick selections made
+    optional sint32 selection_index = 1 [default = -1];
+
+    // sequence of cards in the pack by index
+    repeated ServerInfo_Card cards = 2;
+}

--- a/common/pb/event_draft_pick_select.proto
+++ b/common/pb/event_draft_pick_select.proto
@@ -1,0 +1,27 @@
+syntax = "proto2";
+import "game_event.proto";
+
+// Sent by the server to confirm a player's picks that round
+message Event_DraftPickSelect {
+    extend GameEvent {
+        optional Event_DraftPickSelect ext = 2023;
+    }
+
+    // Index in the sequence of pick selections made
+    optional sint32 selection_index = 1 [default = -1];
+
+    // Amount of cards picked
+    optional sint32 picked_cards = 2 [default = -1];
+
+    // Amount of cards picked to destroy
+    optional sint32 burned_cards = 3 [default = -1];
+
+    // Amount of cards placed into the pack
+    optional sint32 returned_cards = 4 [default = -1];
+
+    // Amount of cards in the pack after picks
+    optional sint32 remaining_cards = 5 [default = -1];
+
+    // Next player receiving the pack
+    optional sint32 passed_to_user_id = 6 [default = -1];
+}

--- a/common/pb/event_game_state_changed.proto
+++ b/common/pb/event_game_state_changed.proto
@@ -1,6 +1,7 @@
 syntax = "proto2";
 import "game_event.proto";
 import "serverinfo_player.proto";
+import "draft_options.proto";
 
 // Signals that the game state has changed.
 // If a field is present in this message, it will overwrite the client's game state.
@@ -10,7 +11,7 @@ message Event_GameStateChanged {
         optional Event_GameStateChanged ext = 1005;
     }
 
-    // the list of players. Players contain their zones which contain all cards in the game
+    // The list of players. Players contain their zones which contain all cards in the game
     repeated ServerInfo_Player player_list = 1;
 
     // if the game has started
@@ -24,4 +25,7 @@ message Event_GameStateChanged {
 
     // the amount of seconds since the game started
     optional uint32 seconds_elapsed = 5;
+
+    // the options for the draft if this is a draft game
+    optional Draft_Options options = 6;
 }

--- a/common/pb/event_move_card.proto
+++ b/common/pb/event_move_card.proto
@@ -45,4 +45,7 @@ message Event_MoveCard {
     // The provider id of the card in case it was not known yet.
     // Extends the name to supply a specific printing of that type of card.
     optional string new_card_provider_id = 12;
+
+    // During a draft this is the index of the pick selection
+    optional sint32 draft_selection_index = 13 [default = -1];
 }

--- a/common/pb/game_commands.proto
+++ b/common/pb/game_commands.proto
@@ -38,6 +38,8 @@ message GameCommand {
         UNCONCEDE = 1032;
         JUDGE = 1033;
         REVERSE_TURN = 1034;
+        DRAFT_OPTIONS_SELECT = 1035;
+        DRAFT_PICK_SELECT = 1036;
     }
     extensions 100 to max;
 }

--- a/common/pb/game_event.proto
+++ b/common/pb/game_event.proto
@@ -33,6 +33,8 @@ message GameEvent {
         // STOP_DUMP_ZONE = 2019; // obsolete
         CHANGE_ZONE_PROPERTIES = 2020;
         REVERSE_TURN = 2021;
+        DRAFT_PACK = 2022;
+        DRAFT_PICK_SELECT = 2023;
     }
     optional sint32 player_id = 1 [default = -1];
     extensions 100 to max;

--- a/common/pb/response.proto
+++ b/common/pb/response.proto
@@ -68,6 +68,8 @@ message Response {
         REPLAY_LIST = 1100;
         REPLAY_DOWNLOAD = 1101;
         REPLAY_GET_CODE = 1102;
+        DRAFT_PICK_SELECTION_INVALID = 1200;
+        DRAFT_DECK_INVALID = 1201;
     }
     required uint64 cmd_id = 1;
     optional ResponseCode response_code = 2;

--- a/common/pb/response_draft_deck_invalid.proto
+++ b/common/pb/response_draft_deck_invalid.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+import "response.proto";
+
+// Sent in response to selecting a deck during a draft that does not meet the requirements. Clients are already aware of
+// what the requirements are but the fields in this serve as an extra validation.
+message Response_DraftDeckInvalid {
+    extend Response {
+        optional Response_DraftDeckInvalid ext = 1201;
+    }
+
+    // amount of cards that should be in the deck but aren't
+    optional uint32 missing_cards = 1;
+
+    // amount of cards that are in the deck but shouldn't
+    optional uint32 additional_cards = 2;
+}

--- a/common/pb/response_draft_pick_selection_invalid.proto
+++ b/common/pb/response_draft_pick_selection_invalid.proto
@@ -1,0 +1,20 @@
+syntax = "proto2";
+import "response.proto";
+
+// Response sent to a draft pick selection command when it isn't following the draft options or didn't confirm it's
+// actions. Clients are already aware of the options so the fields in this message just serve as an additional
+// validation.
+message Response_DraftPickSelectionInvalid {
+    extend Response {
+        optional Response_DraftPickSelectionInvalid ext = 1200;
+    }
+
+    // amount of picks performed that exceed the picks per selection, negative means too few picks were performed
+    optional sint32 too_many_picks = 1;
+
+    // amount of burns performed that exceed the burns per selection, negative means too few burns were performed
+    optional sint32 too_many_burns = 2;
+
+    // amount of cards that were returned to the pack
+    optional sint32 cards_returned_to_pack = 3;
+}

--- a/common/pb/room_commands.proto
+++ b/common/pb/room_commands.proto
@@ -69,6 +69,9 @@ message Command_CreateGame {
 
     // share decklists with all players when selected
     optional bool share_decklists_on_load = 14;
+
+    // if the game is a draft game
+    optional bool is_draft = 15;
 }
 
 message Command_JoinGame {

--- a/common/pb/serverinfo_card.proto
+++ b/common/pb/serverinfo_card.proto
@@ -53,4 +53,10 @@ message ServerInfo_Card {
 
     // unique id of this kind of card, extends the name to specify a specific printing of a card
     optional string provider_id = 17;
+
+    // index of the selection this card was picked in
+    optional sint32 draft_pick_selection_index = 64 [default = -1];
+
+    // user that picked this card
+    optional sint32 draft_pick_by_user_id = 65 [default = -1];
 }

--- a/common/pb/serverinfo_game.proto
+++ b/common/pb/serverinfo_game.proto
@@ -48,6 +48,9 @@ message ServerInfo_Game {
     // decklists are sent to all players when loaded
     optional bool share_decklists_on_load = 15;
 
+    // the game is a draft game
+    optional bool is_draft = 16;
+
     // the current player count
     optional uint32 player_count = 30;
 
@@ -60,6 +63,6 @@ message ServerInfo_Game {
     // time that the game started at
     optional uint32 start_time = 51;
 
-    // whether the game is closed. Closed games are finished and can't be interacted with
+    // Whether the game is closed. Closed games are finished and can't be interacted with
     optional bool closed = 52;
 }


### PR DESCRIPTION
## Related Ticket(s)
- related #3012

## Short roundup of the initial problem
while there are numerous websites that allow one to draft, it's much easier if it were possible to draft inside of cockatrice

## What will change with this Pull Request?
so far I've included the changes to the protocol that'd allow drafting, I plan to implement the server side after we agree on the protocol, the client side will be out of scope for now and I'd like to collaborate on it later.

## Proposed Implementation
<details>

<summary>(click to open initial version)</summary>

1. users create a game as normal with the added option of setting the lobby as a draft lobby, users without the draft feature will be unable to create draft games, but we have to be aware that users without the feature will still be able to join it.
2. the host will be able to send the new command Command_DraftOptionsSelect in a similar way to selecting a deck, other users will not be allowed to select a deck, not allowed actions will return an error and would not be available in the interface
3. the draft options in this command will be included in the game state and shared with all the players in a Event_GameStateChanged
4. the draft options include common options for playing cube drafts and an optional round timer
5. in the draft options will be the draft list, a simple decklist will represent a cube in this case, any decklist will be selectable for this
6. in order to support set drafts I propose to make an extension to the decklist format that will add more data like rarities and a pack formatting tag
7. the draft options will also have a simple list of accepted cards that can be freely added to decks after the draft
8. the currently proposed draft types are boosterdraft and sealed, more types can be added later
9. all players will be able to ready up without decks as long as the draft options are set by the host
10. games will fire as normal if all players are ready, when the game is started the host will no longer be allowed to use Command_DraftOptionsSelect and the draft options will not be changed as long as the game is running
11. if the type is sealed all players will immediately receive a pool of cards_per_pack * packs_per_player cards, normal settings for sealed will be 15 * 6, in their hand zone
12. if the type is boosterdraft players will receive packs using the Event_DraftPack event, these cards will exist in a new game zone called "Pack", this will be a private zone
13. players will not be allowed to move cards or perform any card actions, these will return an error, in a future version we might consider allowing these as an option in order to support conspiracy drafts (conspiracy drafts would require a tablezone and an option to allow players to pick deviating amounts of cards from packs, optionally to the public zone)
14. players will be able to use the Command_DraftPick command to send the cards they picked to the server using the index and round counter in the pack zone
15. the server will return a Event_DraftPick event that includes the picked cards to the player, these cards are then inside the hand zone, the event will include the current round the pick happened in, this is important in case of network delays, with this round parameter players could feasibly have multiple packs to pick from at the same time or pick asynchronously, this will not be part of this implementation but could happen in the future
16. other players will receive a draftpick event for each player but without the cards picked, spectators that can see hands will receive everything
17. the server will manage the rotation of packs, packzones will not be moved to players, a player's pack zone will be replaced entirely by the server for each pick each draftpack event, rotation will reverse as normal after one pack is finished
18. during the draft a player might lose connection, if registered they will be able to rejoin and use the gamestate event to restore their current pack and handzone as normal
19. during the draft a player's round timer might expire, if this is the case the server will use rng to determine their actions and generate the correct events
20. a player's pick and the round timer might intersect due to network delays, in this case the server will ignore their pick, the round property of the pick command is useful for this
21. the round timer is reset every time an Event_DraftPack happens for each player, players should display it with their server ping subtracted
22. during the draft players might leave/concede, they will be treated as if their round timer is one second even if round timers are not enabled
23. if all players have conceded the draft will immediately reset and return to the state before the draft started, like in normal games, this will allow the host to change the draft options and require everyone to ready up again
24. after all picks are done players will be able to export their handzone to the deck editor of their choice, the deck editor would only allow moving between main and sideboard and the adding of the cards specified by name in 
allowed_lands of Draft_Options in the game state
25. players will save their deck to disk and will be allowed to upload it to the deck storage if they wish
26. players will use the normal deck select command in order to set their deck after building
27. the server will check if their uploaded deck contains all the cards in the hand zone and ignore cards in allowed_lands
28. the server will post a normal deck loaded message if the check completes and provide everyone with the deck hash
29. players will create their own game lobbies and use the deck hash from the draft game in order to verify their opponent
30. during games the draft lobby will stay open for coordination using chat and displaying the deck hashes, players will be allowed to upload new decks that fulfill the deck check at any time
</details>

1. users create a game as normal with the added option of setting the lobby as a draft lobby, Command_CreateGame.is_draft
    1. users without the draft feature will be unable to create draft games but we have to be aware that users without the feature will still be able to join it
2. the host will be able to send the new Command_DraftOptionsSelect instead of selecting a deck at the start
    1. users will not be allowed to select a deck, this will return RespContextError
    2. players that are not the host will get RespContextError when sending Command_DraftOptionsSelect
3. the Draft_Options included in Command_DraftOptionsSelect will also be in the game state and shared with all the players in a Event_GameStateChanged
4. the Draft_Options include common options for playing cube drafts and other modes
    1. a selection_timer allows there to be a set limit to the amount of time a player has to make their selection of picks
    2. max_selections_ahead and max_new_packs_ahead allow players to not wait for other players to makes selections before viewing the next pack if available
    3. enable_table allows players to use the TableZone while drafting as in a normal game, eg to draft conspiracy cards that have to be drafted face up
    4. enable_overpicking and enable_returning enable actions required for certain conspiracy cards, these are not normally enabled for safety, players will additionally have to confirm their actions when using these actions
    5. picks_per_selection and burns_per_selection specify the amount of picks/burns per selection
5. the draft_list or draft_list_id will be a normal decklist to use as a cube list
    1. only the mainboard will be used
6. in order to support set drafts I propose to make an extension to the decklist format with metadata like rarities and pack format
    1. alternatively this can be a unique xml format that shares a lot of information with decklists
    2. a chaos draft set list might exceed some limitations we currently pose on deck list file size, there is no real way around this
7. the addable_card_list or addable_card_list_id will be a normal decklist of accepted cards that can be freely added to decks after the draft ( like lands )
    1. only the mainboard will be used, card counts will be ignored
    2. clients will always have to provide this list, the server does not know what lands are
8. the currently proposed Draft_Type values are boosterdraft and sealed
    1. in a cube draft cards_per_pack and packs_per_player will be used to create booster packs
9. all players will be able to Command_ReadyStart even though no deck was selected as long as Draft_Options is set
10. games will start as normal when all players are ready
    1. when the game is started Command_DraftOptionsSelect will respond RespContextError
    2. Draft_Options will not change during a game
11. if the Draft_Type is Sealed all players will immediately receive packs_per_player amount of packs
    1. if the draft_list is a cube a pack will be cards_per_pack cards, eg 6 packs_per_player and 15 cards_per_pack will result in a pool of 90 cards
    2. if the draft_list is a set the composition a pack will be defined in the set data
    3. the received cards will be placed in the normal HandZone, an outdated client will be able to receive them because of this
12. if the Draft_Type is BoosterDraft players will receive an Event_DraftPack event, the cards in this event will be located in the PackZone, a new private zone that will not be part of the game state
    1. the event will include a selection_index, this value will refer to this unique selection of picks the player will make over the entire draft, it starts from zero and is incremented by one for every Event_DraftPack
13. players will only be allowed most card actions if enable_table in Draft_Options is true
    1. otherwise it will return RespContextError
    2. modifying player properties or moving to the deck, gy, exile, or stack will also return RespContextError
14. to pick cards players will send Command_MoveCards targeting cards in the PackZone, the command will include the selection_index referring to the Event_DraftPack the card came in
    1. players will move cards to their HandZone to pick cards
    2. players will move cards to a nonexistant BurnZone to burn cards, cards will not enter the BurnZone, instead they get destroyed permanently
    3. moving cards from anywhere else to the BurnZone will return RespContextError
    4. after all selections are made the player will send Command_DraftPickSelect to finalise their card moves for the current selection, this will also include the selection_index
    5. if enable_table is true then cards can also be moved to the TableZone, this counts as a pick in picks_per_selection
    6. cards that started in the pack can be moved back into it to undo a pick, for this purpose their card_id will be the same as their card_id in the PackZone
    7. if enable_overpicking is true then players may choose to take more than one card from the pack, this requires additional confirmation by setting is_overpicking in the Command_DraftPickSelect
    8. if enable_returning is true then players can place cards from anywhere into the pack, this requires additional confirmation in the Command_DraftPickSelect, returned cards can be moved back by using the card_id from their original zone, this is confirmed by is_returning
    9. if enable_overpicking is false and enable_returning is true the resulting amount of cards left in the pack after their moves will be the same as if the player performed the required amount of picks, ie the player needs to remove the same amount of cards as they return
    10. if a client does not perform the right moves or did not set is overpicking or is_returning when needed the server will send RespInvalidData with the new extension Respons_DraftPickSelectionInvalid
    11. in Respons_DraftPickSelectionInvalid it will say how many cards were moved incorrectly of picks/burns/returns
    12. is_returning or is_overpicking while not enabled or not required will be ignored
15. the server will wait to send move events that include the PackZone until Command_DraftPickSelect is received
    1. the Event_MoveCard will include the selection_index the pick happened in
    2. move events will be personalised unless sent to the TableZone, spectators that see everything will see the full event
16. the server will send an Event_DraftPickSelect to all players that contains how many moves were signaled before it as picks/burns/returns for clarity
    1. the event also will say how many cards are left in the pack and which player will receive it next
17. the server will manage the rotation of packs
    1. the rotation will reverse when a pack is finished, the server keeps track of the rotation, it does not need to be in the pack event
18. during the draft a player might lose connection, if registered they will be able to rejoin and use the gamestate event to restore their hand and table
    1. if a disconnected player holds up the draft they can be kicked ( kicked players leave the game as normal, see point 22. )
    2. the selection_timer will reset when a player disconnects to allow them some time to rejoin, when this timer ends players will automatically concede as per point 22. (they can unconcede on rejoining)
    3. players abusing this leniency can be kicked
    4. If a player reconnects they will receive the packs they were looking at again and restart their timers, this means in total a player can get a lot of extra time for every disconnect, giving people these time extensions doesn't seem like a problem as it's very noticeable
    5. similarly they will have no awareness of their sent move commands before disconnecting, because of this their previously sent queued up moves will be cleared but only after they send a new move command and not immediately upon reconnecting
19. during the draft a player's selection_timer might expire, if this is the case the server will use rng to determine their actions and generate the correct events
    1. rng picked cards will never go to the tablezone and the player will be unable to use the option to "reveal this card as you draft it" as mentioned by conspiracy cards
    2. because clients could have already sent some move commands to the server they will be used instead of determining picks by rng, if multiple picks/burns are required per selection the remaining ones are determined with rng
    3. if too many move commands were sent when the timer expires they will be resolved in order and only the least recent results of the move commands will be used, later locations of the commands will be discarded
    4. note that 19.3. considers just the result of the move commands, if a player moves back a card this will be resolved first before considering what the least recent result is
20. if the server has sent an Event_DraftPickSelect either from command or timeout then subsequently received moves or selections with that selection_index will return RespContextError and discarded
21. the selection_timer is reset every time Event_DraftPack is sent, players should display it with their server ping subtracted
22. during the draft players might leave or concede, this will be treated as if their selection_timer is one second even if it is normally disabled (-1), this will trigger point 19.
    1. players can restore their position in the draft by rejoining or unconceding, this will restore their timer to normal, they will have to wait for the next pick selection before receiving their next pack as rng will have already picked for them
23. if all players have conceded the draft will immediately reset and return to the state before the draft started, like in normal games, this will allow the host to change the draft options and require everyone to ready up again
24. after all pick selections are done players will be able to export their picks to the deck editor of their choice
    1. the deck editor can update their card pool every selection event to help later choices
    2. cards included in the export are the HandZone and all faceup cards in the TableZone that are not attached
    3. the deck editor should not allow adding cards that are not in the addable_card_list, only moving between main and sideboard is allowed
25. players will save their deck to disk or upload it to the server
26. players will use the normal Command_SelectDeck command to choose a deck
27. the server will check if the deck includes only cards mentioned in 24. 2. and cards from the addable_card_list
    1. if the check fails then RespInvalidData is returned with the extension Response_DraftDeckInvalid, in the response the server will tell how many cards are missing from the submitted deck and how many cards have been added unintentionally
28. the server will send a normal Event_GameStateChanged to signal the deck was uploaded which includes the deck hash
29. players will create their own separate game lobbies and use the deck hash from the draft game to check if their opponent loaded the correct deck
30. during games the draft lobby will stay open for coordination using chat and displaying the deck hashes, players will be allowed to upload new decks that fulfill the deck check at any time
31. if enable_table is true players will be allowed to perform all normal card actions on the table including card counters, annotations, attachments, giving cards to other players, flipping cards and even moving cards to and from their hand to the board at any time
32. moving cards to other zones will never be allowed, they do not exist for the purposes of drafting ( 13. 2. )
33. revealing cards from your hand or pack to one or all players is also allowed
    1. the ServerInfo_Card will contain when and by who this card was picked, as required by some cards
34. players are allowed to keep using the tablezone even after all cards were picked, if they have any decks uploaded and 24. 2. would have a different result their deck will be removed with a game state event
35. some cards in conspiracy would require their own special commands and events and even additions to the game state, they are considered out of scope for this proposal as their gain will be very small, these cards interact with booster packs that are not in play at that time
