### PR TITLE
Properly allow resizing the printing selector

### DIFF
--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -198,9 +198,6 @@ void TabDeckEditor::loadLayout()
     printingSelectorDockWidget->setMinimumSize(layouts.getDeckEditorPrintingSelectorSize());
     printingSelectorDockWidget->setMaximumSize(layouts.getDeckEditorPrintingSelectorSize());
 
-    databaseDisplayDockWidget->setMinimumSize(100, 100);
-    databaseDisplayDockWidget->setMaximumSize(1400, 5000);
-
     QTimer::singleShot(100, this, &TabDeckEditor::freeDocksSize);
 }
 
@@ -253,9 +250,6 @@ void TabDeckEditor::freeDocksSize()
 
     printingSelectorDockWidget->setMinimumSize(100, 100);
     printingSelectorDockWidget->setMaximumSize(5000, 5000);
-
-    databaseDisplayDockWidget->setMinimumSize(100, 100);
-    databaseDisplayDockWidget->setMaximumSize(1400, 5000);
 }
 
 void TabDeckEditor::dockVisibleTriggered()

--- a/cockatrice/src/client/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/client/tabs/tab_deck_editor.cpp
@@ -251,7 +251,7 @@ void TabDeckEditor::freeDocksSize()
     filterDockWidget->setMinimumSize(100, 100);
     filterDockWidget->setMaximumSize(5000, 5000);
 
-    printingSelectorDockWidget->setMinimumSize(525, 100);
+    printingSelectorDockWidget->setMinimumSize(100, 100);
     printingSelectorDockWidget->setMaximumSize(5000, 5000);
 
     databaseDisplayDockWidget->setMinimumSize(100, 100);

--- a/cockatrice/src/client/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
+++ b/cockatrice/src/client/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
@@ -270,8 +270,8 @@ void TabDeckEditorVisual::restartLayout()
 {
     deckDockWidget->setVisible(true);
     cardInfoDockWidget->setVisible(true);
-    filterDockWidget->setVisible(true);
-    printingSelectorDockWidget->setVisible(false);
+    filterDockWidget->setVisible(false);
+    printingSelectorDockWidget->setVisible(true);
 
     deckDockWidget->setFloating(false);
     cardInfoDockWidget->setFloating(false);
@@ -280,22 +280,21 @@ void TabDeckEditorVisual::restartLayout()
 
     aCardInfoDockVisible->setChecked(true);
     aDeckDockVisible->setChecked(true);
-    aFilterDockVisible->setChecked(true);
-    aPrintingSelectorDockVisible->setChecked(false);
+    aFilterDockVisible->setChecked(false);
+    aPrintingSelectorDockVisible->setChecked(true);
 
     aCardInfoDockFloating->setChecked(false);
     aDeckDockFloating->setChecked(false);
     aFilterDockFloating->setChecked(false);
     aPrintingSelectorDockFloating->setChecked(false);
 
-    setCentralWidget(searchAndDatabaseDock);
+    setCentralWidget(centralWidget);
     addDockWidget(static_cast<Qt::DockWidgetArea>(2), deckDockWidget);
     addDockWidget(static_cast<Qt::DockWidgetArea>(2), cardInfoDockWidget);
-    addDockWidget(static_cast<Qt::DockWidgetArea>(2), filterDockWidget);
     addDockWidget(static_cast<Qt::DockWidgetArea>(2), printingSelectorDockWidget);
 
+    splitDockWidget(cardInfoDockWidget, printingSelectorDockWidget, Qt::Vertical);
     splitDockWidget(cardInfoDockWidget, deckDockWidget, Qt::Horizontal);
-    splitDockWidget(cardInfoDockWidget, filterDockWidget, Qt::Vertical);
 
     QTimer::singleShot(100, this, SLOT(freeDocksSize()));
 }

--- a/cockatrice/src/client/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
+++ b/cockatrice/src/client/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
@@ -217,9 +217,6 @@ void TabDeckEditorVisual::freeDocksSize()
 
     printingSelectorDockWidget->setMinimumSize(100, 100);
     printingSelectorDockWidget->setMaximumSize(5000, 5000);
-
-    databaseDisplayDockWidget->setMinimumSize(100, 100);
-    databaseDisplayDockWidget->setMaximumSize(1400, 5000);
 }
 
 void TabDeckEditorVisual::refreshShortcuts()
@@ -265,9 +262,6 @@ void TabDeckEditorVisual::loadLayout()
 
     printingSelectorDockWidget->setMinimumSize(layouts.getDeckEditorPrintingSelectorSize());
     printingSelectorDockWidget->setMaximumSize(layouts.getDeckEditorPrintingSelectorSize());
-
-    databaseDisplayDockWidget->setMinimumSize(100, 100);
-    databaseDisplayDockWidget->setMaximumSize(1400, 5000);
 
     QTimer::singleShot(100, this, &TabDeckEditorVisual::freeDocksSize);
 }

--- a/cockatrice/src/client/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
+++ b/cockatrice/src/client/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
@@ -95,7 +95,6 @@ void TabDeckEditorVisual::createMenus()
 
     cardInfoDockMenu = viewMenu->addMenu(QString());
     deckDockMenu = viewMenu->addMenu(QString());
-    deckAnalyticsMenu = viewMenu->addMenu(QString());
     filterDockMenu = viewMenu->addMenu(QString());
     printingSelectorDockMenu = viewMenu->addMenu(QString());
 
@@ -112,13 +111,6 @@ void TabDeckEditorVisual::createMenus()
     aDeckDockFloating = deckDockMenu->addAction(QString());
     aDeckDockFloating->setCheckable(true);
     connect(aDeckDockFloating, SIGNAL(triggered()), this, SLOT(dockFloatingTriggered()));
-
-    aDeckAnalyticsDockVisible = deckAnalyticsMenu->addAction(QString());
-    aDeckAnalyticsDockVisible->setCheckable(true);
-    connect(aDeckAnalyticsDockVisible, SIGNAL(triggered()), this, SLOT(dockVisibleTriggered()));
-    aDeckAnalyticsDockFloating = deckAnalyticsMenu->addAction(QString());
-    aDeckAnalyticsDockFloating->setCheckable(true);
-    connect(aDeckAnalyticsDockFloating, SIGNAL(triggered()), this, SLOT(dockFloatingTriggered()));
 
     aFilterDockVisible = filterDockMenu->addAction(QString());
     aFilterDockVisible->setCheckable(true);
@@ -212,41 +204,6 @@ void TabDeckEditorVisual::showPrintingSelector()
     printingSelectorDockWidget->setVisible(true);
 }
 
-void TabDeckEditorVisual::restartLayout()
-{
-    deckDockWidget->setVisible(true);
-    cardInfoDockWidget->setVisible(true);
-    filterDockWidget->setVisible(true);
-
-    deckDockWidget->setFloating(false);
-    cardInfoDockWidget->setFloating(false);
-    filterDockWidget->setFloating(false);
-
-    aCardInfoDockVisible->setChecked(true);
-    aDeckDockVisible->setChecked(true);
-    aFilterDockVisible->setChecked(true);
-
-    aCardInfoDockFloating->setChecked(false);
-    aDeckDockFloating->setChecked(false);
-    aFilterDockFloating->setChecked(false);
-
-    addDockWidget(static_cast<Qt::DockWidgetArea>(2), deckDockWidget);
-    addDockWidget(static_cast<Qt::DockWidgetArea>(2), cardInfoDockWidget);
-    addDockWidget(static_cast<Qt::DockWidgetArea>(1), deckAnalyticsDock);
-    addDockWidget(static_cast<Qt::DockWidgetArea>(2), filterDockWidget);
-
-    splitDockWidget(cardInfoDockWidget, deckDockWidget, Qt::Horizontal);
-    splitDockWidget(cardInfoDockWidget, filterDockWidget, Qt::Vertical);
-    splitDockWidget(searchAndDatabaseDock, deckAnalyticsDock, Qt::Vertical);
-
-    deckDockWidget->setMinimumWidth(360);
-    deckDockWidget->setMaximumWidth(360);
-
-    cardInfoDockWidget->setMinimumSize(250, 360);
-    cardInfoDockWidget->setMaximumSize(250, 360);
-    QTimer::singleShot(100, this, SLOT(freeDocksSize()));
-}
-
 void TabDeckEditorVisual::freeDocksSize()
 {
     deckDockWidget->setMinimumSize(100, 100);
@@ -257,6 +214,9 @@ void TabDeckEditorVisual::freeDocksSize()
 
     filterDockWidget->setMinimumSize(100, 100);
     filterDockWidget->setMaximumSize(5000, 5000);
+
+    printingSelectorDockWidget->setMinimumSize(100, 100);
+    printingSelectorDockWidget->setMaximumSize(5000, 5000);
 
     databaseDisplayDockWidget->setMinimumSize(100, 100);
     databaseDisplayDockWidget->setMaximumSize(1400, 5000);
@@ -312,6 +272,40 @@ void TabDeckEditorVisual::loadLayout()
     QTimer::singleShot(100, this, &TabDeckEditorVisual::freeDocksSize);
 }
 
+void TabDeckEditorVisual::restartLayout()
+{
+    deckDockWidget->setVisible(true);
+    cardInfoDockWidget->setVisible(true);
+    filterDockWidget->setVisible(true);
+    printingSelectorDockWidget->setVisible(false);
+
+    deckDockWidget->setFloating(false);
+    cardInfoDockWidget->setFloating(false);
+    filterDockWidget->setFloating(false);
+    printingSelectorDockWidget->setFloating(false);
+
+    aCardInfoDockVisible->setChecked(true);
+    aDeckDockVisible->setChecked(true);
+    aFilterDockVisible->setChecked(true);
+    aPrintingSelectorDockVisible->setChecked(false);
+
+    aCardInfoDockFloating->setChecked(false);
+    aDeckDockFloating->setChecked(false);
+    aFilterDockFloating->setChecked(false);
+    aPrintingSelectorDockFloating->setChecked(false);
+
+    setCentralWidget(searchAndDatabaseDock);
+    addDockWidget(static_cast<Qt::DockWidgetArea>(2), deckDockWidget);
+    addDockWidget(static_cast<Qt::DockWidgetArea>(2), cardInfoDockWidget);
+    addDockWidget(static_cast<Qt::DockWidgetArea>(2), filterDockWidget);
+    addDockWidget(static_cast<Qt::DockWidgetArea>(2), printingSelectorDockWidget);
+
+    splitDockWidget(cardInfoDockWidget, deckDockWidget, Qt::Horizontal);
+    splitDockWidget(cardInfoDockWidget, filterDockWidget, Qt::Vertical);
+
+    QTimer::singleShot(100, this, SLOT(freeDocksSize()));
+}
+
 void TabDeckEditorVisual::retranslateUi()
 {
     deckMenu->setTitle(tr("&Visual Deck Editor"));
@@ -323,7 +317,6 @@ void TabDeckEditorVisual::retranslateUi()
     viewMenu->setTitle(tr("&View"));
     cardInfoDockMenu->setTitle(tr("Card Info"));
     deckDockMenu->setTitle(tr("Deck"));
-    deckAnalyticsMenu->setTitle(tr("Deck Analytics"));
     filterDockMenu->setTitle(tr("Filters"));
     printingSelectorDockMenu->setTitle(tr("Printing"));
 
@@ -332,9 +325,6 @@ void TabDeckEditorVisual::retranslateUi()
 
     aDeckDockVisible->setText(tr("Visible"));
     aDeckDockFloating->setText(tr("Floating"));
-
-    aDeckAnalyticsDockVisible->setText(tr("Visible"));
-    aDeckAnalyticsDockFloating->setText(tr("Floating"));
 
     aFilterDockVisible->setText(tr("Visible"));
     aFilterDockFloating->setText(tr("Floating"));
@@ -355,9 +345,6 @@ bool TabDeckEditorVisual::eventFilter(QObject *o, QEvent *e)
         } else if (o == deckDockWidget) {
             aDeckDockVisible->setChecked(false);
             aDeckDockFloating->setEnabled(false);
-        } else if (o == deckAnalyticsDock) {
-            aDeckAnalyticsDockVisible->setChecked(false);
-            aDeckAnalyticsDockFloating->setEnabled(false);
         } else if (o == filterDockWidget) {
             aFilterDockVisible->setChecked(false);
             aFilterDockFloating->setEnabled(false);
@@ -393,12 +380,6 @@ void TabDeckEditorVisual::dockVisibleTriggered()
         return;
     }
 
-    if (o == aDeckAnalyticsDockVisible) {
-        deckAnalyticsDock->setHidden(!aDeckAnalyticsDockVisible->isChecked());
-        aDeckAnalyticsDockFloating->setEnabled(aDeckAnalyticsDockVisible->isChecked());
-        return;
-    }
-
     if (o == aFilterDockVisible) {
         filterDockWidget->setHidden(!aFilterDockVisible->isChecked());
         aFilterDockFloating->setEnabled(aFilterDockVisible->isChecked());
@@ -422,11 +403,6 @@ void TabDeckEditorVisual::dockFloatingTriggered()
 
     if (o == aDeckDockFloating) {
         deckDockWidget->setFloating(aDeckDockFloating->isChecked());
-        return;
-    }
-
-    if (o == aDeckAnalyticsDockFloating) {
-        deckAnalyticsDock->setFloating(aDeckAnalyticsDockFloating->isChecked());
         return;
     }
 
@@ -456,11 +432,6 @@ void TabDeckEditorVisual::dockTopLevelChanged(bool topLevel)
 
     if (o == filterDockWidget) {
         aFilterDockFloating->setChecked(topLevel);
-        return;
-    }
-
-    if (o == deckAnalyticsDock) {
-        aDeckAnalyticsDockFloating->setChecked(topLevel);
         return;
     }
 

--- a/cockatrice/src/client/tabs/visual_deck_editor/tab_deck_editor_visual.h
+++ b/cockatrice/src/client/tabs/visual_deck_editor/tab_deck_editor_visual.h
@@ -25,10 +25,7 @@ protected:
     QVBoxLayout *searchAndDatabaseFrame;
     QHBoxLayout *searchLayout;
     QDockWidget *searchAndDatabaseDock;
-    QDockWidget *deckAnalyticsDock;
     QWidget *centralWidget;
-    QMenu *deckAnalyticsMenu;
-    QAction *aDeckAnalyticsDockVisible, *aDeckAnalyticsDockFloating;
 
 public:
     explicit TabDeckEditorVisual(TabSupervisor *_tabSupervisor);

--- a/cockatrice/src/client/ui/widgets/cards/deck_card_zone_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/deck_card_zone_display_widget.cpp
@@ -64,7 +64,7 @@ void DeckCardZoneDisplayWidget::constructAppropriateWidget(QPersistentModelIndex
             subBannerOpacity, cardSizeWidget);
         connect(displayWidget, SIGNAL(cardClicked(QMouseEvent *, CardInfoPictureWithTextOverlayWidget *)), this,
                 SLOT(onClick(QMouseEvent *, CardInfoPictureWithTextOverlayWidget *)));
-        connect(displayWidget, SIGNAL(cardHovered(CardInfoPtr)), this, SLOT(onHover(CardInfoPtr)));
+        connect(displayWidget, SIGNAL(cardHovered(ExactCard)), this, SLOT(onHover(ExactCard)));
         connect(displayWidget, &CardGroupDisplayWidget::cleanupRequested, this,
                 &DeckCardZoneDisplayWidget::cleanupInvalidCardGroup);
         cardGroupLayout->addWidget(displayWidget);
@@ -75,7 +75,7 @@ void DeckCardZoneDisplayWidget::constructAppropriateWidget(QPersistentModelIndex
                                            activeGroupCriteria, activeSortCriteria, subBannerOpacity, cardSizeWidget);
         connect(displayWidget, SIGNAL(cardClicked(QMouseEvent *, CardInfoPictureWithTextOverlayWidget *)), this,
                 SLOT(onClick(QMouseEvent *, CardInfoPictureWithTextOverlayWidget *)));
-        connect(displayWidget, SIGNAL(cardHovered(CardInfoPtr)), this, SLOT(onHover(CardInfoPtr)));
+        connect(displayWidget, SIGNAL(cardHovered(ExactCard)), this, SLOT(onHover(ExactCard)));
         connect(displayWidget, &CardGroupDisplayWidget::cleanupRequested, this,
                 &DeckCardZoneDisplayWidget::cleanupInvalidCardGroup);
         cardGroupLayout->addWidget(displayWidget);


### PR DESCRIPTION
## Fixes
Crash when selecting reset layout in VDE
Unused variables in VDE

## Short roundup of the initial problem
Printing selector has some sizes set that can make it feel "locked" to the user, especially on devices with smaller screens. This sets the minimum size of the printing selector to be equal to the card info and the deck dock widget, which is a common use case for layouts I've observed. 

It's also never "set" as a free dock size for the visual printing selector which makes it unresizable (no min or max sizes set).

## What will change with this Pull Request?
- Change min width of printing selector to be in line with other dock widgets
- Set min and max sizes of printing selector in visual deck editor
- Remove unused deck analytics dock widget from visual deck editor
- Reset layout properly in visual deck editor
- Introduce a new default layout for visual deck editor [but not the regular deck editor] (see attached screenshot, filter is removed and the slot is moved centrally underneath a horizontally split card and deck info and filled with printing selector)

## Screenshots
<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/bc205f1f-6ec9-41f0-b3fd-04ef3baccb47" />
<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/4013db01-0417-420e-afed-52425390c0bf" />

