### PR TITLE
Use modelReset from new grouping in deck_list_model in VDE

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -179,6 +179,7 @@ VisualDeckEditorWidget::VisualDeckEditorWidget(QWidget *parent, DeckListModel *_
     mainLayout->addWidget(scrollArea);
     mainLayout->addWidget(cardSizeWidget);
 
+    connect(deckListModel, &DeckListModel::modelReset, this, &VisualDeckEditorWidget::decklistModelReset);
     connect(deckListModel, &DeckListModel::dataChanged, this, &VisualDeckEditorWidget::decklistDataChanged);
     connect(deckListModel, &QAbstractItemModel::rowsInserted, this, &VisualDeckEditorWidget::onCardAddition);
     connect(deckListModel, &QAbstractItemModel::rowsRemoved, this, &VisualDeckEditorWidget::onCardRemoval);
@@ -197,6 +198,16 @@ void VisualDeckEditorWidget::retranslateUi()
     displayTypeButton->setText(tr("Overlap Layout"));
     displayTypeButton->setToolTip(
         tr("Change how cards are displayed within zones (i.e. overlapped or fully visible.)"));
+}
+
+void VisualDeckEditorWidget::clearAllDisplayWidgets()
+{
+    for (auto idx : indexToWidgetMap.keys()) {
+        auto displayWidget = indexToWidgetMap.value(idx);
+        zoneContainerLayout->removeWidget(displayWidget);
+        indexToWidgetMap.remove(idx);
+        delete displayWidget;
+    }
 }
 
 void VisualDeckEditorWidget::cleanupInvalidZones(DeckCardZoneDisplayWidget *displayWidget)
@@ -330,6 +341,12 @@ void VisualDeckEditorWidget::actChangeActiveSortCriteria()
     activeSortCriteria = selectedCriteria;
 
     emit activeSortCriteriaChanged(selectedCriteria);
+}
+
+void VisualDeckEditorWidget::decklistModelReset()
+{
+    clearAllDisplayWidgets();
+    constructZoneWidgetsFromDeckListModel();
 }
 
 void VisualDeckEditorWidget::decklistDataChanged(QModelIndex topLeft, QModelIndex bottomRight)

--- a/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.h
@@ -31,6 +31,7 @@ class VisualDeckEditorWidget : public QWidget
 public:
     explicit VisualDeckEditorWidget(QWidget *parent, DeckListModel *deckListModel);
     void retranslateUi();
+    void clearAllDisplayWidgets();
     void resizeEvent(QResizeEvent *event) override;
 
     void setDeckList(const DeckList &_deckListModel);
@@ -60,6 +61,7 @@ protected slots:
     void onCardClick(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance, QString zoneName);
     void actChangeActiveGroupCriteria();
     void actChangeActiveSortCriteria();
+    void decklistModelReset();
 
 private:
     DeckListModel *deckListModel;


### PR DESCRIPTION
## Related Ticket(s)
- This entire refactor to make VDE more compliant introduced a regression because VDE is no longer responsible for deciding the grouping of the decklist, instead delegating that to deck_list_model and just responding to index changes. #5981
- #5931 introduced a grouping criteria to the deck_list_model that makes it possible to re-arrange the deck_list_model internally, which allows grouping both the existing QListView deck widget and the VDE deck display widget.

## What will change with this Pull Request?
- Nuke the index to widget map, delete everything (i.e. clear the VDE) and repopulate widgets on modelReset signal.
- Re-enables grouping
- Does not solve sorting so far

## Screenshots
<img width="1997" height="1259" alt="image" src="https://github.com/user-attachments/assets/74e58cd2-905c-4fb1-a648-331682a46805" />

