### PR TITLE
Sort VDE groups internally

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -256,6 +256,7 @@ set(cockatrice_SOURCES
     src/settings/shortcut_treeview.cpp
     src/settings/shortcuts_settings.cpp
     src/utility/card_info_comparator.cpp
+    src/utility/deck_list_sort_filter_proxy_model.h
     src/utility/key_signals.cpp
     src/utility/levenshtein.cpp
     src/utility/logger.cpp

--- a/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/card_group_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/card_group_display_widget.h
@@ -25,6 +25,7 @@ public:
                            QStringList activeSortCriteria,
                            int bannerOpacity,
                            CardSizeWidget *cardSizeWidget);
+    void clearAllDisplayWidgets();
 
     DeckListModel *deckListModel;
     QPersistentModelIndex trackedIndex;
@@ -38,10 +39,11 @@ public:
 public slots:
     void onClick(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *card);
     void onHover(const ExactCard &card);
-    virtual QWidget *constructWidgetForIndex(int rowIndex);
+    virtual QWidget *constructWidgetForIndex(QPersistentModelIndex index);
     virtual void updateCardDisplays();
     virtual void onCardAddition(const QModelIndex &parent, int first, int last);
     virtual void onCardRemoval(const QModelIndex &parent, int first, int last);
+    void onActiveSortCriteriaChanged(QStringList activeSortCriteria);
     void resizeEvent(QResizeEvent *event) override;
 
 signals:

--- a/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/flat_card_group_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/flat_card_group_display_widget.h
@@ -20,10 +20,7 @@ public:
                                CardSizeWidget *cardSizeWidget);
 
 public slots:
-    QWidget *constructWidgetForIndex(int row) override;
     void resizeEvent(QResizeEvent *event) override;
-    void onCardAddition(const QModelIndex &parent, int first, int last) override;
-    void onCardRemoval(const QModelIndex &parent, int first, int last) override;
 
 private:
     FlowWidget *flowWidget;

--- a/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/overlapped_card_group_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/overlapped_card_group_display_widget.cpp
@@ -49,37 +49,6 @@ OverlappedCardGroupDisplayWidget::OverlappedCardGroupDisplayWidget(QWidget *pare
     connect(deckListModel, &QAbstractItemModel::rowsRemoved, this, &OverlappedCardGroupDisplayWidget::onCardRemoval);
 }
 
-void OverlappedCardGroupDisplayWidget::onCardAddition(const QModelIndex &parent, int first, int last)
-{
-    if (!trackedIndex.isValid()) {
-        emit cleanupRequested(this);
-        return;
-    }
-    if (parent == trackedIndex) {
-        for (int i = first; i <= last; i++) {
-            insertIntoLayout(constructWidgetForIndex(i), i);
-        }
-    }
-}
-
-void OverlappedCardGroupDisplayWidget::onCardRemoval(const QModelIndex &parent, int first, int last)
-{
-    Q_UNUSED(first);
-    Q_UNUSED(last);
-    if (parent == trackedIndex) {
-        for (const QPersistentModelIndex &idx : indexToWidgetMap.keys()) {
-            if (!idx.isValid()) {
-                removeFromLayout(indexToWidgetMap.value(idx));
-                indexToWidgetMap.value(idx)->deleteLater();
-                indexToWidgetMap.remove(idx);
-            }
-        }
-        if (!trackedIndex.isValid()) {
-            emit cleanupRequested(this);
-        }
-    }
-}
-
 void OverlappedCardGroupDisplayWidget::resizeEvent(QResizeEvent *event)
 {
     QWidget::resizeEvent(event);

--- a/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/overlapped_card_group_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_group_display_widgets/overlapped_card_group_display_widget.h
@@ -20,8 +20,6 @@ public:
                                      CardSizeWidget *cardSizeWidget);
 
 public slots:
-    void onCardAddition(const QModelIndex &parent, int first, int last) override;
-    void onCardRemoval(const QModelIndex &parent, int first, int last) override;
     void resizeEvent(QResizeEvent *event) override;
 
 private:

--- a/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -270,16 +270,31 @@ void VisualDeckEditorWidget::onCardRemoval(const QModelIndex &parent, int first,
 
 void VisualDeckEditorWidget::constructZoneWidgetsFromDeckListModel()
 {
-    for (int i = 0; i < deckListModel->rowCount(deckListModel->parent(QModelIndex())); i++) {
-        QPersistentModelIndex index = QPersistentModelIndex(deckListModel->index(i, 0, deckListModel->getRoot()));
+    QSortFilterProxyModel proxy;
+    proxy.setSourceModel(deckListModel);
+    proxy.setSortRole(Qt::EditRole);
+    proxy.sort(1, Qt::AscendingOrder);
 
-        if (indexToWidgetMap.contains(index)) {
+    for (int i = 0; i < proxy.rowCount(); ++i) {
+        QModelIndex proxyIndex = proxy.index(i, 0);
+        QModelIndex sourceIndex = proxy.mapToSource(proxyIndex);
+
+        // Make a persistent index from the *source* model
+        QPersistentModelIndex persistent(sourceIndex);
+
+        if (indexToWidgetMap.contains(persistent))
+            continue;
+
+        // for (int i = 0; i < deckListModel->rowCount(deckListModel->parent(QModelIndex())); i++) {
+        //    QPersistentModelIndex index = QPersistentModelIndex(deckListModel->index(i, 0, deckListModel->getRoot()));
+
+        if (indexToWidgetMap.contains(persistent)) {
             continue;
         }
 
         DeckCardZoneDisplayWidget *zoneDisplayWidget = new DeckCardZoneDisplayWidget(
-            zoneContainer, deckListModel, index,
-            deckListModel->data(index.sibling(index.row(), 1), Qt::EditRole).toString(), activeGroupCriteria,
+            zoneContainer, deckListModel, persistent,
+            deckListModel->data(persistent.sibling(persistent.row(), 1), Qt::EditRole).toString(), activeGroupCriteria,
             activeSortCriteria, currentDisplayType, 20, 10, cardSizeWidget);
         connect(zoneDisplayWidget, &DeckCardZoneDisplayWidget::cardHovered, this, &VisualDeckEditorWidget::onHover);
         connect(zoneDisplayWidget, &DeckCardZoneDisplayWidget::cardClicked, this, &VisualDeckEditorWidget::onCardClick);
@@ -293,7 +308,7 @@ void VisualDeckEditorWidget::constructZoneWidgetsFromDeckListModel()
                 &DeckCardZoneDisplayWidget::refreshDisplayType);
         zoneContainerLayout->addWidget(zoneDisplayWidget);
 
-        indexToWidgetMap.insert(index, zoneDisplayWidget);
+        indexToWidgetMap.insert(persistent, zoneDisplayWidget);
     }
 }
 

--- a/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -282,12 +282,6 @@ void VisualDeckEditorWidget::constructZoneWidgetsFromDeckListModel()
         // Make a persistent index from the *source* model
         QPersistentModelIndex persistent(sourceIndex);
 
-        if (indexToWidgetMap.contains(persistent))
-            continue;
-
-        // for (int i = 0; i < deckListModel->rowCount(deckListModel->parent(QModelIndex())); i++) {
-        //    QPersistentModelIndex index = QPersistentModelIndex(deckListModel->index(i, 0, deckListModel->getRoot()));
-
         if (indexToWidgetMap.contains(persistent)) {
             continue;
         }

--- a/cockatrice/src/deck/deck_list_model.cpp
+++ b/cockatrice/src/deck/deck_list_model.cpp
@@ -142,6 +142,8 @@ QVariant DeckListModel::data(const QModelIndex &index, int role) const
                         return {};
                 }
             }
+            case Qt::UserRole + 1:
+                return false;
             case Qt::BackgroundRole: {
                 int color = 90 + 60 * node->depth();
                 return QBrush(QColor(color, 255, color));
@@ -171,6 +173,8 @@ QVariant DeckListModel::data(const QModelIndex &index, int role) const
                         return {};
                 }
             }
+            case Qt::UserRole + 1:
+                return true;
             case Qt::BackgroundRole: {
                 int color = 255 - (index.row() % 2) * 30;
                 return QBrush(QColor(color, color, color));

--- a/cockatrice/src/utility/deck_list_sort_filter_proxy_model.h
+++ b/cockatrice/src/utility/deck_list_sort_filter_proxy_model.h
@@ -41,7 +41,7 @@ protected:
         CardInfoPtr lInfo = CardDatabaseManager::getInstance()->guessCard({lNode->getName()}).getCardPtr();
         CardInfoPtr rInfo = CardDatabaseManager::getInstance()->guessCard({rNode->getName()}).getCardPtr();
 
-        // Example: multiple tie-break criteria (cmc > rarity > name)
+        // Example: multiple tie-break criteria (colors > cmc > name)
         for (const QString &crit : sortCriteria) {
             if (crit == "name") {
                 QString ln = lNode->getName();
@@ -74,26 +74,6 @@ protected:
 
 private:
     QStringList sortCriteria;
-
-    QVariant fetchCardProperty(const QAbstractItemModel *src, const QModelIndex &idx, const QString &criterion) const
-    {
-        // Map criterion strings to roles or columns in your model
-        if (criterion == "Name")
-            return src->data(idx.sibling(idx.row(), 1), Qt::DisplayRole);
-        else if (criterion == "CMC")
-            return src->data(idx, Qt::UserRole + 2); // e.g. custom role
-        else if (criterion == "Type")
-            return src->data(idx, Qt::UserRole + 3);
-        // etc…
-        return {};
-    }
-
-    static int compareVariants(const QVariant &a, const QVariant &b)
-    {
-        if (a.userType() == QMetaType::Int && b.userType() == QMetaType::Int)
-            return a.toInt() - b.toInt();
-        return QString::localeAwareCompare(a.toString(), b.toString());
-    }
 };
 
 #endif // COCKATRICE_DECK_LIST_SORT_FILTER_PROXY_MODEL_H

--- a/cockatrice/src/utility/deck_list_sort_filter_proxy_model.h
+++ b/cockatrice/src/utility/deck_list_sort_filter_proxy_model.h
@@ -1,0 +1,99 @@
+#ifndef COCKATRICE_DECK_LIST_SORT_FILTER_PROXY_MODEL_H
+#define COCKATRICE_DECK_LIST_SORT_FILTER_PROXY_MODEL_H
+
+#include "../game/cards/card_database_manager.h"
+
+#include <QSortFilterProxyModel>
+
+class DeckListSortFilterProxyModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+public:
+    explicit DeckListSortFilterProxyModel(QObject *parent = nullptr) : QSortFilterProxyModel(parent)
+    {
+    }
+
+    void setSortCriteria(const QStringList &criteria)
+    {
+        sortCriteria = criteria;
+        invalidate(); // re-sort
+    }
+
+protected:
+    bool lessThan(const QModelIndex &left, const QModelIndex &right) const override
+    {
+        auto *src = sourceModel();
+
+        // Inner nodes? -> sort alphabetically by column 1
+        bool leftIsCard = src->data(left, Qt::UserRole + 1).toBool();
+        bool rightIsCard = src->data(right, Qt::UserRole + 1).toBool();
+
+        if (!leftIsCard || !rightIsCard) {
+            QString lName = src->data(left.siblingAtColumn(1), Qt::EditRole).toString();
+            QString rName = src->data(right.siblingAtColumn(1), Qt::EditRole).toString();
+            return lName.localeAwareCompare(rName) < 0;
+        }
+
+        // Both are cards -> apply sort criteria
+        auto *lNode = static_cast<DecklistModelCardNode *>(left.internalPointer());
+        auto *rNode = static_cast<DecklistModelCardNode *>(right.internalPointer());
+
+        CardInfoPtr lInfo = CardDatabaseManager::getInstance()->guessCard({lNode->getName()}).getCardPtr();
+        CardInfoPtr rInfo = CardDatabaseManager::getInstance()->guessCard({rNode->getName()}).getCardPtr();
+
+        // Example: multiple tie-break criteria (cmc > rarity > name)
+        for (const QString &crit : sortCriteria) {
+            if (crit == "name") {
+                QString ln = lNode->getName();
+                QString rn = rNode->getName();
+                int cmp = ln.localeAwareCompare(rn);
+                if (cmp != 0)
+                    return cmp < 0;
+            } else if (crit == "cmc") {
+                int lc = lInfo ? lInfo->getCmc().toInt() : 0;
+                int rc = rInfo ? rInfo->getCmc().toInt() : 0;
+                if (lc != rc)
+                    return lc < rc;
+            } else if (crit == "colors") {
+                QString lr = lInfo ? lInfo->getColors() : QString();
+                QString rr = rInfo ? rInfo->getColors() : QString();
+                int cmp = lr.localeAwareCompare(rr);
+                if (cmp != 0)
+                    return cmp < 0;
+            } else if (crit == "maintype") {
+                QString lr = lInfo ? lInfo->getMainCardType() : QString();
+                QString rr = rInfo ? rInfo->getMainCardType() : QString();
+                int cmp = lr.localeAwareCompare(rr);
+                if (cmp != 0)
+                    return cmp < 0;
+            }
+        }
+
+        return false;
+    }
+
+private:
+    QStringList sortCriteria;
+
+    QVariant fetchCardProperty(const QAbstractItemModel *src, const QModelIndex &idx, const QString &criterion) const
+    {
+        // Map criterion strings to roles or columns in your model
+        if (criterion == "Name")
+            return src->data(idx.sibling(idx.row(), 1), Qt::DisplayRole);
+        else if (criterion == "CMC")
+            return src->data(idx, Qt::UserRole + 2); // e.g. custom role
+        else if (criterion == "Type")
+            return src->data(idx, Qt::UserRole + 3);
+        // etc…
+        return {};
+    }
+
+    static int compareVariants(const QVariant &a, const QVariant &b)
+    {
+        if (a.userType() == QMetaType::Int && b.userType() == QMetaType::Int)
+            return a.toInt() - b.toInt();
+        return QString::localeAwareCompare(a.toString(), b.toString());
+    }
+};
+
+#endif // COCKATRICE_DECK_LIST_SORT_FILTER_PROXY_MODEL_H


### PR DESCRIPTION
## Related Ticket(s)
- Fixes regression introduced in #5981

## Short roundup of the initial problem
There's no way to change the alphabetical sort order within groups displayed in the VDE. It does make more sense to change the sort order (since this indirectly influences how cards group together in case the sorting is *not* alphabetical, i.e. colors group together) and to be able to change the sort order.

## What will change with this Pull Request?
- Introduce QSortProxyModels for the relevant DeckListModel accesses in the relevant group widgets (i.e. groups are always sorted alphabetically)
- Introduce DeckListSortFilterProxyModel for sorting cards *within* the group widgets by a dynamic criteria list
- Cleanup some overriden methods from Flat and Overlapped CardGroupDisplayWidgets since the parent implementation is sufficient (the classes mainly differentiate themselves by which layout they return in their appropriate overriden method, not in how they internally manage layouts).

## Screenshots
Creature group sorted by Color > CMC > Name > Main Type
<img width="1278" height="432" alt="image" src="https://github.com/user-attachments/assets/c1cc59e2-4907-414e-a2c2-28e01ffe28db" />
