### PR TITLE
Fix Logs tab close button not working

### DIFF
--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -651,9 +651,9 @@ void TabSupervisor::openTabLog()
     myAddTab(tabLog, aTabLog);
     connect(tabLog, &QObject::destroyed, this, [this] {
         tabLog = nullptr;
-        aTabAdmin->setChecked(false);
+        aTabLog->setChecked(false);
     });
-    aTabAdmin->setChecked(true);
+    aTabLog->setChecked(true);
 }
 
 void TabSupervisor::updatePingTime(int value, int max)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5651

## Short roundup of the initial problem

The close button on the Logs tab doesn't work.

https://github.com/user-attachments/assets/9c269227-5964-4730-bb10-e082f7a110f1

This is due to a typo in the code.

## What will change with this Pull Request?
- Fix typo

https://github.com/user-attachments/assets/9263e9d0-42ef-4b7c-a78a-4bfe28289477

