### PR TITLE
[VDD] Refactor page loading so it's uniform

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.h
@@ -42,6 +42,7 @@ public:
 
     void adjustCardsPerPage();
     void populateCards();
+    void loadPage(int start, int end);
     void loadNextPage();
     void loadCurrentPage();
     void sortCardList(const QStringList &properties, Qt::SortOrder order) const;


### PR DESCRIPTION
display every printing from every filtered set instead of just one.

## Short roundup of the initial problem
When filtering to a single set, we display every card as every printing from that set in the VDD. Because the page loading code is duplicated, this doesn't happen after the first page.

## What will change with this Pull Request?
- Refactor page loading code so both instances call the same function
- Also display printings from additional set beyond the first one if set filters are enabled.

## Screenshots
Filtering to Final Fantasy + Extra sets still produces a coherent visual
<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/00a1bfc8-60de-4ff0-b8f9-7fcf16a08379" />

Dragonstorm + extras
<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/1ff80ada-233c-41c0-93d4-977eb9aff2a0" />

Sets up to Fallen Empires
<img width="2554" height="1230" alt="image" src="https://github.com/user-attachments/assets/7f6281fc-77e8-47ed-a1f7-d84b6147e383" />

