### PR TITLE
Move quick filters from right to left to be closer to the color filters.

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -126,11 +126,11 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
     quickFilterSubTypeWidget->addSettingsWidget(subTypeFilterWidget);
     quickFilterSetWidget->addSettingsWidget(setFilterWidget);
 
-    filterContainerLayout->addWidget(mainTypeFilterWidget);
     filterContainerLayout->addWidget(quickFilterSaveLoadWidget);
     filterContainerLayout->addWidget(quickFilterNameWidget);
     filterContainerLayout->addWidget(quickFilterSubTypeWidget);
     filterContainerLayout->addWidget(quickFilterSetWidget);
+    filterContainerLayout->addWidget(mainTypeFilterWidget);
 
     searchLayout->addWidget(colorFilterWidget);
     searchLayout->addWidget(clearFilterWidget);


### PR DESCRIPTION
## Short roundup of the initial problem
Aesthetics and usability. These sorta get overlooked.

## What will change with this Pull Request?
- Filters are moved from right to left

## Screenshots
Before:
<img width="2554" height="144" alt="image" src="https://github.com/user-attachments/assets/0358b761-017c-44f9-a27b-13e0b1eeab2f" />

After:
<img width="700" height="131" alt="image" src="https://github.com/user-attachments/assets/87b8cb68-aec8-4118-bec1-cf9c4f78856f" />

