### PR TITLE
Correctly reset banner card if none was set but card appears in new deck

### DIFF
--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -346,6 +346,20 @@ void DeckEditorDeckDockWidget::updateShowTagsWidget(const bool visible)
     deckTagsDisplayWidget->setHidden(!visible);
 }
 
+void DeckEditorDeckDockWidget::syncBannerCardComboBoxSelectionWithDeck()
+{
+    if (deckModel->getDeckList()->getBannerCard().name == "") {
+        if (bannerCardComboBox->findText("-") != -1) {
+            bannerCardComboBox->setCurrentIndex(bannerCardComboBox->findText("-"));
+        } else {
+            bannerCardComboBox->insertItem(0, "-");
+            bannerCardComboBox->setCurrentIndex(0);
+        }
+    } else {
+        bannerCardComboBox->setCurrentText(deckModel->getDeckList()->getBannerCard().name);
+    }
+}
+
 /**
  * Sets the currently active deck for this tab
  * @param _deck The deck. Takes ownership of the object
@@ -356,7 +370,8 @@ void DeckEditorDeckDockWidget::setDeck(DeckLoader *_deck)
 
     nameEdit->setText(deckModel->getDeckList()->getName());
     commentsEdit->setText(deckModel->getDeckList()->getComments());
-    bannerCardComboBox->setCurrentText(deckModel->getDeckList()->getBannerCard().name);
+
+    syncBannerCardComboBoxSelectionWithDeck();
     updateBannerCardComboBox();
     updateHash();
     deckModel->sort(deckView->header()->sortIndicatorSection(), deckView->header()->sortIndicatorOrder());

--- a/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.h
+++ b/cockatrice/src/client/ui/widgets/deck_editor/deck_editor_deck_dock_widget.h
@@ -88,6 +88,7 @@ private slots:
     void refreshShortcuts();
     void updateShowBannerCardComboBox(bool visible);
     void updateShowTagsWidget(bool visible);
+    void syncBannerCardComboBoxSelectionWithDeck();
 };
 
 #endif // DECK_EDITOR_DECK_DOCK_WIDGET_H


### PR DESCRIPTION
Took 33 minutes

## Related Ticket(s)
- Fixes #6093

## Short roundup of the initial problem
You can't set arbitrary text on comboboxes it appears (or at least not empty text), so if a new deck doesn't have a banner card set BUT does contain the same card as the previous banner card, we'll set it back to that index.

## What will change with this Pull Request?
- Correctly check for an empty banner card now, insert and then set placeholder text if not found
