### PR TITLE
disallow users on your ignore list to get your current games

### DIFF
--- a/cockatrice/src/server/user/user_context_menu.cpp
+++ b/cockatrice/src/server/user/user_context_menu.cpp
@@ -79,8 +79,21 @@ void UserContextMenu::retranslateUi()
 
 void UserContextMenu::gamesOfUserReceived(const Response &resp, const CommandContainer &commandContainer)
 {
-    const Response_GetGamesOfUser &response = resp.GetExtension(Response_GetGamesOfUser::ext);
     const Command_GetGamesOfUser &cmd = commandContainer.session_command(0).GetExtension(Command_GetGamesOfUser::ext);
+    if (resp.response_code() == Response::RespNameNotFound) {
+        QMessageBox::critical(static_cast<QWidget *>(parent()), tr("Error"), tr("This user does not exist."));
+        return;
+    } else if (resp.response_code() == Response::RespInIgnoreList) {
+        QMessageBox::critical(
+            static_cast<QWidget *>(parent()), tr("Error"),
+            tr("You are being ignored by %1 and can't see their games.").arg(QString::fromStdString(cmd.user_name())));
+        return;
+    } else if (resp.response_code() != Response::RespOk) {
+        QMessageBox::critical(static_cast<QWidget *>(parent()), tr("Error"),
+                              tr("Could not get %1's games.").arg(QString::fromStdString(cmd.user_name())));
+        return;
+    }
+    const Response_GetGamesOfUser &response = resp.GetExtension(Response_GetGamesOfUser::ext);
 
     QMap<int, GameTypeMap> gameTypeMap;
     QMap<int, QString> roomMap;

--- a/common/server_protocolhandler.cpp
+++ b/common/server_protocolhandler.cpp
@@ -602,6 +602,17 @@ Response::ResponseCode Server_ProtocolHandler::cmdGetGamesOfUser(const Command_G
     if (authState == NotLoggedIn)
         return Response::RespLoginNeeded;
 
+    // Do not show games to someone on the ignore list of that user, except for mods
+    QString target_user = nameFromStdString(cmd.user_name());
+    Server_AbstractUserInterface *userInterface = server->findUser(target_user);
+    if (!userInterface) {
+        return Response::RespNameNotFound;
+    }
+    if (!(userInfo->user_level() & (ServerInfo_User::IsModerator | ServerInfo_User::IsAdmin)) &&
+        databaseInterface->isInIgnoreList(target_user, QString::fromStdString(userInfo->name()))) {
+        return Response::RespInIgnoreList;
+    }
+
     // We don't need to check whether the user is logged in; persistent games should also work.
     // The client needs to deal with an empty result list.
 


### PR DESCRIPTION
## Related Ticket(s)
- #5990

## Short roundup of the initial problem
users are not allowed to join games created by other users that have the user on their ignore list, however they can still "view" which games they are joining, this could potentially lead to users engaging in stalking behavior or intentionally joining games they are in but are not created by them

## What will change with this Pull Request?
- if a user requests to see the games of another user that they are on the ignore list of then they will receive a "RespInIgnoreList" similarly to when they try to join a game
- currently the client does not actually check the response status of Command_GetGamesOfUser it just blindly finds the extension, however as the default values of the empty extension are zero this just results in an empty list
- in order to properly display the error the client will now show an error in this case
- I could be convinced to instead remove all the error responses and just return RespOk with zero games, however this is inconsistent with how we currently treat ignore lists in joining games and sending dms

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
<img width="964" height="193" alt="image" src="https://github.com/user-attachments/assets/b7e16e2e-c7f1-446c-aad8-da81809ce2f2" />
