### PR TITLE
add libqt6sql6-mysql to debian package recommends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,7 @@ if(UNIX)
       set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "http://github.com/Cockatrice/Cockatrice")
       if(Qt6_FOUND)
         set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt6multimedia6, libqt6svg6, qt6-qpa-plugins, qt6-image-formats-plugins")
+        set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "libqt6sql6-mysql") # for connecting servatrice to a mysql db
       elseif(Qt5_FOUND)
         set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5multimedia5-plugins, libqt5svg5")
       endif()


### PR DESCRIPTION
## Short roundup of the initial problem
when installing cockatrice from our provided debs this dependency is not installed, it is not required in order to run cockatrice however without it the included servatrice cannot connect to the db

## What will change with this Pull Request?
- adds it to CPACK_DEBIAN_PACKAGE_RECOMMENDS this means it will be installed by default unless the user opts out