### PR TITLE
Fix segfault when drawing arrow

### DIFF
--- a/cockatrice/src/game/board/card_item.cpp
+++ b/cockatrice/src/game/board/card_item.cpp
@@ -260,14 +260,11 @@ void CardItem::deleteDragItem()
 
 void CardItem::drawArrow(const QColor &arrowColor)
 {
-    if (static_cast<TabGame *>(owner->parent())->getGame()->getPlayerManager()->isSpectator())
+    if (owner->getGame()->getPlayerManager()->isSpectator())
         return;
 
-    Player *arrowOwner = static_cast<TabGame *>(owner->parent())
-                             ->getGame()
-                             ->getPlayerManager()
-                             ->getActiveLocalPlayer(
-                                 static_cast<TabGame *>(owner->parent())->getGame()->getGameState()->getActivePlayer());
+    Player *arrowOwner =
+        owner->getGame()->getPlayerManager()->getActiveLocalPlayer(owner->getGame()->getGameState()->getActivePlayer());
     ArrowDragItem *arrow = new ArrowDragItem(arrowOwner, this, arrowColor);
     scene()->addItem(arrow);
     arrow->grabMouse();
@@ -287,7 +284,7 @@ void CardItem::drawArrow(const QColor &arrowColor)
 
 void CardItem::drawAttachArrow()
 {
-    if (static_cast<TabGame *>(owner->parent())->getGame()->getPlayerManager()->isSpectator())
+    if (owner->getGame()->getPlayerManager()->isSpectator())
         return;
 
     auto *arrow = new ArrowAttachItem(this);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes issue introduced in #6112

## Short roundup of the initial problem

Cockatrice segfaults whenever you try to draw an arrow in a game.

`CardItem`'s `owner`, (a `Player`) no longer has `TabGame` as a parent, so `static_cast<TabGame *>(owner->parent())` will just return a nullptr, eventually leading to a segfault.

## What will change with this Pull Request?

- Directly use `owner->getGame()` to get the game object.
