### PR TITLE
Fix opponent's hand zones being drawn when content isn't known

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -56,7 +56,9 @@ void Player::initializeZones()
     addZone(new PileZoneLogic(this, "sb", false, false, false, this));
     addZone(new TableZoneLogic(this, "table", true, false, true, this));
     addZone(new StackZoneLogic(this, "stack", true, false, true, this));
-    addZone(new HandZoneLogic(this, "hand", false, false, true, this));
+    bool visibleHand = playerInfo->getLocalOrJudge() ||
+                       (game->getPlayerManager()->isSpectator() && game->getGameMetaInfo()->spectatorsOmniscient());
+    addZone(new HandZoneLogic(this, "hand", false, false, visibleHand, this));
 }
 
 Player::~Player()


### PR DESCRIPTION
## Related Ticket(s)
- Fixes issue introduced in #6112

## Short roundup of the initial problem

The opponent's handzone is being drawn despite the user being in game as a player.

<img width="500" height="819" alt="Screenshot 2025-09-12 at 2 50 26 AM" src="https://github.com/user-attachments/assets/8cb6e4c8-b107-4380-be48-5445dc175311" />

## What will change with this Pull Request?
- Correctly set `HandZoneLogic`'s `contentKnown` field when constructing it.

## Screenshots

<img width="500" height="819" alt="Screenshot 2025-09-12 at 2 49 49 AM" src="https://github.com/user-attachments/assets/846c5120-8f4f-4124-a637-f05e7f21282c" />
