### PR TITLE
Connect concession signal correctly

### DIFF
--- a/cockatrice/src/client/tabs/tab_game.cpp
+++ b/cockatrice/src/client/tabs/tab_game.cpp
@@ -141,6 +141,7 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor,
 void TabGame::connectToGameState()
 {
     connect(game->getGameState(), &GameState::gameStarted, this, &TabGame::startGame);
+    connect(game->getGameState(), &GameState::gameStopped, this, &TabGame::stopGame);
     connect(game->getGameState(), &GameState::activePhaseChanged, this, &TabGame::setActivePhase);
     connect(game->getGameState(), &GameState::activePlayerChanged, this, &TabGame::setActivePlayer);
 }

--- a/cockatrice/src/game/player/player_manager.cpp
+++ b/cockatrice/src/game/player/player_manager.cpp
@@ -39,7 +39,7 @@ Player *PlayerManager::addPlayer(int playerId, const ServerInfo_User &info)
 {
     auto *newPlayer = new Player(info, playerId, isLocalPlayer(playerId) || game->getGameState()->getIsLocalGame(),
                                  isJudge(), getGame());
-    connect(newPlayer, &Player::concededChanged, this, &PlayerManager::playerConceded);
+    connect(newPlayer, &Player::concededChanged, this, &PlayerManager::onPlayerConceded);
     players.insert(playerId, newPlayer);
     emit playerAdded(newPlayer);
     emit playerCountChanged();


### PR DESCRIPTION
## Short roundup of the initial problem
I derped and didn't rename a signal, which led to concession commands never being sent (but the local player conceded state did change). Also, probably connect game state's stopped to TabGame::stopGame.

## What will change with this Pull Request?
- Connect signals appropriately.
