### PR TITLE
do not allow other players to know which cards are in a player's hand

### DIFF
--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_player.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_player.cpp
@@ -375,20 +375,17 @@ Response::ResponseCode Server_AbstractPlayer::moveCard(GameEventStorage &ges,
 
             eventPrivate.set_x(newX);
 
-            // Other players do not get to see the start and/or target position of the card if the respective
-            // part of the zone is being looked at. The information is not needed anyway because in hidden zones,
-            // all cards are equal.
-            if (((startzone->getType() == ServerInfo_Zone::HiddenZone) &&
-                 ((startzone->getCardsBeingLookedAt() > position) || (startzone->getCardsBeingLookedAt() == -1))) ||
-                (startzone->getType() == ServerInfo_Zone::PublicZone)) {
-                eventOthers.set_position(-1);
-            } else {
+            if (
+                // cards from public zones have their id known, their previous position is already known, the event does
+                // not accomodate for previous locations in zones with coordinates (which are always public)
+                (startzone->getType() != ServerInfo_Zone::PublicZone) &&
+                // other players are not allowed to be able to track which card is which in private zones like the hand
+                (startzone->getType() != ServerInfo_Zone::PrivateZone)) {
                 eventOthers.set_position(position);
             }
-            if ((targetzone->getType() == ServerInfo_Zone::HiddenZone) &&
-                ((targetzone->getCardsBeingLookedAt() > newX) || (targetzone->getCardsBeingLookedAt() == -1))) {
-                eventOthers.set_x(-1);
-            } else {
+            if (
+                // other players are not allowed to be able to track which card is which in private zones like the hand
+                (targetzone->getType() != ServerInfo_Zone::PrivateZone)) {
                 eventOthers.set_x(newX);
             }
 


### PR DESCRIPTION
## Related Ticket(s)
- similar to #6115

## Short roundup of the initial problem
the server never did any attempts to hide which card in a player's hand was which, allowing opponents to track which cards are being returned

## What will change with this Pull Request?
- cards being moved to and from the hand will have their position removed in the event being sent out to others
- the check for the since #5410 broken cards that are being looked at in the hidden zone (deck) is now removed, to be honest I did not fully understand the reasoning from 2012 for this to exist
- the event now removes the value instead of explicitly setting it to -1, -1 is the default value since the first ever release so this has no backwards compatibility concerns