### PR TITLE
Forward playerActions signals to playerEventHandler

### DIFF
--- a/cockatrice/src/game/game_event_handler.cpp
+++ b/cockatrice/src/game/game_event_handler.cpp
@@ -123,44 +123,34 @@ void GameEventHandler::processGameEventContainer(const GameEventContainer &cont,
 
             switch (eventType) {
                 case GameEvent::GAME_STATE_CHANGED:
-                    qInfo() << "Game state changed event";
                     eventGameStateChanged(event.GetExtension(Event_GameStateChanged::ext), playerId, context);
                     break;
                 case GameEvent::PLAYER_PROPERTIES_CHANGED:
-                    qInfo() << "player prop event";
                     eventPlayerPropertiesChanged(event.GetExtension(Event_PlayerPropertiesChanged::ext), playerId,
                                                  context);
                     break;
                 case GameEvent::JOIN:
-                    qInfo() << "join event";
                     eventJoin(event.GetExtension(Event_Join::ext), playerId, context);
                     break;
                 case GameEvent::LEAVE:
-                    qInfo() << "leave event";
                     eventLeave(event.GetExtension(Event_Leave::ext), playerId, context);
                     break;
                 case GameEvent::KICKED:
-                    qInfo() << "kicked event";
                     eventKicked(event.GetExtension(Event_Kicked::ext), playerId, context);
                     break;
                 case GameEvent::GAME_HOST_CHANGED:
-                    qInfo() << "host changed event";
                     eventGameHostChanged(event.GetExtension(Event_GameHostChanged::ext), playerId, context);
                     break;
                 case GameEvent::GAME_CLOSED:
-                    qInfo() << "game closed event";
                     eventGameClosed(event.GetExtension(Event_GameClosed::ext), playerId, context);
                     break;
                 case GameEvent::SET_ACTIVE_PLAYER:
-                    qInfo() << "set active player event";
                     eventSetActivePlayer(event.GetExtension(Event_SetActivePlayer::ext), playerId, context);
                     break;
                 case GameEvent::SET_ACTIVE_PHASE:
-                    qInfo() << "set active phase";
                     eventSetActivePhase(event.GetExtension(Event_SetActivePhase::ext), playerId, context);
                     break;
                 case GameEvent::REVERSE_TURN:
-                    qInfo() << "reverse turn event";
                     eventReverseTurn(event.GetExtension(Event_ReverseTurn::ext), playerId, context);
                     break;
 

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -43,6 +43,20 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, A
     connect(this, &Player::activeChanged, graphicsItem, &PlayerGraphicsItem::onPlayerActiveChanged);
 
     connect(this, &Player::openDeckEditor, game->getTab(), &TabGame::openDeckEditor);
+
+    forwardActionSignalsToEventHandler();
+}
+
+// Event Handler is the controller i.e. everything hooks up to this to know about player state
+// Player should forward (private) signals to the event handler
+
+void Player::forwardActionSignalsToEventHandler()
+{
+    connect(playerActions, &PlayerActions::logSetTapped, playerEventHandler, &PlayerEventHandler::logSetTapped);
+    connect(playerActions, &PlayerActions::logSetDoesntUntap, playerEventHandler,
+            &PlayerEventHandler::logSetDoesntUntap);
+    connect(playerActions, &PlayerActions::logSetAnnotation, playerEventHandler, &PlayerEventHandler::logSetAnnotation);
+    connect(playerActions, &PlayerActions::logSetPT, playerEventHandler, &PlayerEventHandler::logSetPT);
 }
 
 void Player::initializeZones()

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -75,6 +75,7 @@ public slots:
 
 public:
     Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, AbstractGame *_parent);
+    void forwardActionSignalsToEventHandler();
     ~Player() override;
 
     void initializeZones();


### PR DESCRIPTION
## Short roundup of the initial problem
We lost some logging signal connections related to a player manipulating card attributes because they were moved to playerActions.

## What will change with this Pull Request?
- Forward signals to playerEventHandler again so it, in turn, can properly signal them to the message log widget.
- Remove some debug prints