### PR TITLE
table_zone_logic now sets the PT of the cardItem to the cardInfos PT

### DIFF
--- a/cockatrice/src/game/zones/logic/table_zone_logic.cpp
+++ b/cockatrice/src/game/zones/logic/table_zone_logic.cpp
@@ -15,6 +15,9 @@ TableZoneLogic::TableZoneLogic(Player *_player,
 void TableZoneLogic::addCardImpl(CardItem *card, int _x, int _y)
 {
     cards.append(card);
+    if (!card->getFaceDown()) {
+        card->setPT(card->getCardInfo().getPowTough());
+    }
     card->setGridPoint(QPoint(_x, _y));
     card->setVisible(true);
 }


### PR DESCRIPTION
… which ensures consistency of this functionality when the card is added from a hidden zone.

## Related Ticket(s)
- Fixes #6128

## Short roundup of the initial problem
Power/Toughness not being set correctly when card enters from hidden zone

## What will change with this Pull Request?
- Resolve cardItem P/T from cardInfo when card enters table_zone (which is contentsKnown = true)