### PR TITLE
Switch to replay tab if already open.

### DIFF
--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -601,6 +601,8 @@ void TabSupervisor::actTabReplays(bool checked)
         setCurrentWidget(tabReplays);
     } else if (!checked && tabReplays) {
         tabReplays->closeRequest();
+    } else if (checked && tabReplays) {
+        setCurrentWidget(tabReplays);
     }
 }
 


### PR DESCRIPTION
## Short roundup of the initial problem
"View Replays" button in the home tab doesn't switch to the replay tab if it's already open based on how actTabReplays in the TabSupervisor works.

## What will change with this Pull Request?
- Add another check for if a switch is desired and the tab already exists (previously sort of impossible because the checked state was synchronized and there was no way to actTabReplays without checking)