### PR TITLE
Properly delete enlargedPixmapWidget

### DIFF
--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.cpp
@@ -40,8 +40,7 @@ CardInfoPictureWidget::CardInfoPictureWidget(QWidget *parent, const bool _hoverT
 
     enlargedPixmapWidget = new CardInfoPictureEnlargedWidget(this->window());
     enlargedPixmapWidget->hide();
-    connect(this, &CardInfoPictureWidget::deleteEnlargedPixmapWidget, enlargedPixmapWidget,
-            &CardInfoPictureEnlargedWidget::deleteLater);
+    connect(this, &QObject::destroyed, enlargedPixmapWidget, &CardInfoPictureEnlargedWidget::deleteLater);
 
     hoverTimer = new QTimer(this);
     hoverTimer->setSingleShot(true);
@@ -63,11 +62,6 @@ CardInfoPictureWidget::CardInfoPictureWidget(QWidget *parent, const bool _hoverT
 
         update();
     });
-}
-
-CardInfoPictureWidget::~CardInfoPictureWidget()
-{
-    emit deleteEnlargedPixmapWidget();
 }
 
 /**

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_widget.h
@@ -21,7 +21,6 @@ public:
     explicit CardInfoPictureWidget(QWidget *parent = nullptr,
                                    bool hoverToZoomEnabled = false,
                                    bool raiseOnEnter = false);
-    ~CardInfoPictureWidget();
     ExactCard getCard()
     {
         return exactCard;
@@ -40,7 +39,6 @@ signals:
     void cardScaleFactorChanged(int _scale);
     void cardChanged(const ExactCard &card);
     void cardClicked();
-    void deleteEnlargedPixmapWidget();
 
 protected:
     void resizeEvent(QResizeEvent *event) override;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes issue reported here https://github.com/Cockatrice/Cockatrice/pull/6114#issuecomment-3282281715

## Short roundup of the initial problem
If the VDS is hidden while the tab is closed, destructor stuff causes a crash because the enlargedPixmapWidget is owned by the parent window, not the tab.

## What will change with this Pull Request?
- emit a signal and forward to enlargedPixmapWidget's deleteLater