### PR TITLE
Guard against not-loaded database by delaying initialization.

### DIFF
--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -108,18 +108,51 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
     quickFilterSaveLoadWidget = new SettingsButtonWidget(this);
     quickFilterSaveLoadWidget->setButtonIcon(QPixmap("theme:icons/lock"));
 
-    saveLoadWidget = new VisualDatabaseDisplayFilterSaveLoadWidget(this, filterModel);
     quickFilterNameWidget = new SettingsButtonWidget(this);
     quickFilterNameWidget->setButtonIcon(QPixmap("theme:icons/rename"));
-    nameFilterWidget = new VisualDatabaseDisplayNameFilterWidget(this, deckEditor, filterModel);
-    mainTypeFilterWidget = new VisualDatabaseDisplayMainTypeFilterWidget(this, filterModel);
+
     quickFilterSubTypeWidget = new SettingsButtonWidget(this);
     quickFilterSubTypeWidget->setButtonIcon(QPixmap("theme:icons/player"));
-    subTypeFilterWidget = new VisualDatabaseDisplaySubTypeFilterWidget(this, filterModel);
+
     quickFilterSetWidget = new SettingsButtonWidget(this);
     quickFilterSetWidget->setButtonIcon(QPixmap("theme:icons/scales"));
-    setFilterWidget = new VisualDatabaseDisplaySetFilterWidget(this, filterModel);
+
     filterContainer->setMaximumHeight(80);
+
+    databaseLoadIndicator = new QLabel(this);
+    databaseLoadIndicator->setAlignment(Qt::AlignCenter);
+
+    mainLayout->addWidget(databaseLoadIndicator);
+
+    if (CardDatabaseManager::getInstance()->getLoadStatus() != LoadStatus::Ok) {
+        connect(CardDatabaseManager::getInstance(), &CardDatabase::cardDatabaseLoadingFinished, this,
+                &VisualDatabaseDisplayWidget::initialize);
+        quickFilterSaveLoadWidget->setVisible(false);
+        quickFilterNameWidget->setVisible(false);
+        quickFilterSubTypeWidget->setVisible(false);
+        quickFilterSetWidget->setVisible(false);
+    } else {
+        initialize();
+        databaseLoadIndicator->setVisible(false);
+    }
+
+    retranslateUi();
+}
+
+void VisualDatabaseDisplayWidget::initialize()
+{
+    databaseLoadIndicator->setVisible(false);
+
+    quickFilterSaveLoadWidget->setVisible(true);
+    quickFilterNameWidget->setVisible(true);
+    quickFilterSubTypeWidget->setVisible(true);
+    quickFilterSetWidget->setVisible(true);
+
+    saveLoadWidget = new VisualDatabaseDisplayFilterSaveLoadWidget(this, filterModel);
+    nameFilterWidget = new VisualDatabaseDisplayNameFilterWidget(this, deckEditor, filterModel);
+    mainTypeFilterWidget = new VisualDatabaseDisplayMainTypeFilterWidget(this, filterModel);
+    subTypeFilterWidget = new VisualDatabaseDisplaySubTypeFilterWidget(this, filterModel);
+    setFilterWidget = new VisualDatabaseDisplaySetFilterWidget(this, filterModel);
 
     quickFilterSaveLoadWidget->addSettingsWidget(saveLoadWidget);
     quickFilterNameWidget->addSettingsWidget(nameFilterWidget);
@@ -164,6 +197,8 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
 
 void VisualDatabaseDisplayWidget::retranslateUi()
 {
+    databaseLoadIndicator->setText(tr("Loading database ..."));
+
     clearFilterWidget->setToolTip(tr("Clear all filters"));
 
     quickFilterSaveLoadWidget->setToolTip(tr("Save and load filters"));

--- a/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.h
+++ b/cockatrice/src/client/ui/widgets/visual_database_display/visual_database_display_widget.h
@@ -62,6 +62,7 @@ signals:
     void cardHoveredDatabaseDisplay(const ExactCard &hoveredCard);
 
 protected slots:
+    void initialize();
     void onClick(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance);
     void onHover(const ExactCard &hoveredCard);
     void addCard(const ExactCard &cardToAdd);
@@ -71,6 +72,7 @@ protected slots:
     void updateSearch(const QString &search) const;
 
 private:
+    QLabel *databaseLoadIndicator;
     QToolButton *clearFilterWidget;
     QWidget *filterContainer;
     QHBoxLayout *filterContainerLayout;


### PR DESCRIPTION
## Short roundup of the initial problem
Cockatrice crashes when opening any tab with visual database display widget (VDS and VDE) if the database hasn't been loaded yet.

## What will change with this Pull Request?
- Delay initialization of some critical variables until db loading finishes.