### PR TITLE
Add a style for disabled buttons

### DIFF
--- a/cockatrice/src/client/ui/widgets/general/home_styled_button.cpp
+++ b/cockatrice/src/client/ui/widgets/general/home_styled_button.cpp
@@ -20,20 +20,22 @@ void HomeStyledButton::updateStylesheet(const QPair<QColor, QColor> &colors)
 
 QString HomeStyledButton::generateButtonStylesheet(const QPair<QColor, QColor> &colors)
 {
-    QColor base1 = colors.first;
-    QColor base2 = colors.second;
+    QColor baseGradientStart = colors.first;
+    QColor baseGradientEnd = colors.second;
 
-    QColor hover1 = base1.lighter(120); // 20% lighter
-    QColor hover2 = base2.lighter(120);
+    QColor hoverGradientStart = baseGradientStart.lighter(120); // 20% lighter
+    QColor hoverGradientEnd = baseGradientEnd.lighter(120);
 
-    QColor pressed1 = base1.darker(130); // 30% darker
-    QColor pressed2 = base2.darker(130);
+    QColor pressedGradientStart = baseGradientStart.darker(130); // 30% darker
+    QColor pressedGradientEnd = baseGradientEnd.darker(130);
 
     // Disabled: more gray, less saturated
-    QColor disabled1 = base1.toHsv();
-    disabled1.setHsv(disabled1.hue(), disabled1.saturation() * 0.2, disabled1.value() * 0.6);
-    QColor disabled2 = base2.toHsv();
-    disabled2.setHsv(disabled2.hue(), disabled2.saturation() * 0.2, disabled2.value() * 0.6);
+    QColor disabledGradientStart = baseGradientStart.toHsv();
+    disabledGradientStart.setHsv(disabledGradientStart.hue(), disabledGradientStart.saturation() * 0.2,
+                                 disabledGradientStart.value() * 0.6);
+    QColor disabledGradientEnd = baseGradientEnd.toHsv();
+    disabledGradientEnd.setHsv(disabledGradientEnd.hue(), disabledGradientEnd.saturation() * 0.2,
+                               disabledGradientEnd.value() * 0.6);
 
     return QString(R"(
         QPushButton {
@@ -60,15 +62,15 @@ QString HomeStyledButton::generateButtonStylesheet(const QPair<QColor, QColor> &
                                         stop:0 %8, stop:1 %9);
         }
     )")
-        .arg(base1.name())      // border color
-        .arg(base1.name())      // normal gradient start
-        .arg(base2.name())      // normal gradient end
-        .arg(hover1.name())     // hover start
-        .arg(hover2.name())     // hover end
-        .arg(pressed1.name())   // pressed start
-        .arg(pressed2.name())   // pressed end
-        .arg(disabled1.name())  // disabled start
-        .arg(disabled2.name()); // disabled end
+        .arg(baseGradientStart.name())
+        .arg(baseGradientStart.name())
+        .arg(baseGradientEnd.name())
+        .arg(hoverGradientStart.name())
+        .arg(hoverGradientEnd.name())
+        .arg(pressedGradientStart.name())
+        .arg(pressedGradientEnd.name())
+        .arg(disabledGradientStart.name())
+        .arg(disabledGradientEnd.name());
 }
 
 void HomeStyledButton::paintEvent(QPaintEvent *event)

--- a/cockatrice/src/client/ui/widgets/general/home_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/home_widget.cpp
@@ -176,12 +176,6 @@ QGroupBox *HomeWidget::createButtons()
     auto visualDatabaseDisplayButton = new HomeStyledButton(tr("Browse Card Database"), gradientColors);
     connect(visualDatabaseDisplayButton, &QPushButton::clicked, tabSupervisor,
             &TabSupervisor::addVisualDatabaseDisplayTab);
-    if (CardDatabaseManager::getInstance()->getLoadStatus() != LoadStatus::Ok) {
-        connect(CardDatabaseManager::getInstance(), &CardDatabase::cardDatabaseLoadingFinished,
-                visualDatabaseDisplayButton,
-                [visualDatabaseDisplayButton]() { visualDatabaseDisplayButton->setEnabled(true); });
-        visualDatabaseDisplayButton->setEnabled(false);
-    }
     boxLayout->addWidget(visualDatabaseDisplayButton);
     auto edhrecButton = new HomeStyledButton(tr("Browse EDHRec"), gradientColors);
     connect(edhrecButton, &QPushButton::clicked, tabSupervisor, &TabSupervisor::addEdhrecMainTab);


### PR DESCRIPTION
## Short roundup of the initial problem
HomeStyledButtons don't have a stylesheet for being disabled.

## What will change with this Pull Request?
- Add a disabled/desaturated stylesheet

## Screenshots
<img width="1267" height="1333" alt="image" src="https://github.com/user-attachments/assets/227ac056-f971-4646-9627-37fe7832f79b" />
