### PR TITLE
Use a scoped disconnect for Home connect button

### DIFF
--- a/cockatrice/src/client/ui/widgets/general/home_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/home_widget.cpp
@@ -196,7 +196,7 @@ QGroupBox *HomeWidget::createButtons()
 
 void HomeWidget::updateConnectButton(const ClientStatus status)
 {
-    connectButton->disconnect();
+    disconnect(connectButton, &QPushButton::clicked, nullptr, nullptr);
     switch (status) {
         case StatusConnecting:
             connectButton->setText(tr("Connecting..."));


### PR DESCRIPTION
## Short roundup of the initial problem
We wildcard disconnect all signals/slots from the connect button, which issues a warning
QObject::disconnect: wildcard call disconnects from destroyed signal of HomeStyledButton::unnamed

## What will change with this Pull Request?
- Use a scoped disconnect to silence warning.