### PR TITLE
Respect default deck editor choice

### DIFF
--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -314,7 +314,6 @@ static void checkAndTrigger(QAction *checkableAction, bool checked)
 void TabSupervisor::initStartupTabs()
 {
     auto homeTab = addHomeTab();
-    addDeckEditorTab(nullptr);
     setCurrentWidget(homeTab);
 
     if (SettingsCache::instance().getTabVisualDeckStorageOpen()) {

--- a/cockatrice/src/client/ui/widgets/general/home_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/home_widget.cpp
@@ -167,7 +167,7 @@ QGroupBox *HomeWidget::createButtons()
 
     auto visualDeckEditorButton = new HomeStyledButton(tr("Create New Deck"), gradientColors);
     connect(visualDeckEditorButton, &QPushButton::clicked, tabSupervisor,
-            [this] { tabSupervisor->addVisualDeckEditorTab(nullptr); });
+            [this] { tabSupervisor->openDeckInNewTab(nullptr); });
     boxLayout->addWidget(visualDeckEditorButton);
     auto visualDeckStorageButton = new HomeStyledButton(tr("Browse Decks"), gradientColors);
     connect(visualDeckStorageButton, &QPushButton::clicked, tabSupervisor,


### PR DESCRIPTION
## Short roundup of the initial problem
"Create New Deck" in the home tab just opens the VDE. Some people might prefer the TDE.

## What will change with this Pull Request?
- Change openVisualDeckEditor() to openDeckInNewTab(), which respects default deck editor choice.
- Don't force open TDE on startup anymore.