### PR TITLE
Check if card has no PT set yet if dropped on table.

### DIFF
--- a/cockatrice/src/game/zones/logic/table_zone_logic.cpp
+++ b/cockatrice/src/game/zones/logic/table_zone_logic.cpp
@@ -15,7 +15,7 @@ TableZoneLogic::TableZoneLogic(Player *_player,
 void TableZoneLogic::addCardImpl(CardItem *card, int _x, int _y)
 {
     cards.append(card);
-    if (!card->getFaceDown()) {
+    if (!card->getFaceDown() && card->getPT() == "") {
         card->setPT(card->getCardInfo().getPowTough());
     }
     card->setGridPoint(QPoint(_x, _y));

--- a/cockatrice/src/game/zones/logic/table_zone_logic.cpp
+++ b/cockatrice/src/game/zones/logic/table_zone_logic.cpp
@@ -15,7 +15,7 @@ TableZoneLogic::TableZoneLogic(Player *_player,
 void TableZoneLogic::addCardImpl(CardItem *card, int _x, int _y)
 {
     cards.append(card);
-    if (!card->getFaceDown() && card->getPT() == "") {
+    if (!card->getFaceDown() && card->getPT().isEmpty()) {
         card->setPT(card->getCardInfo().getPowTough());
     }
     card->setGridPoint(QPoint(_x, _y));


### PR DESCRIPTION
## Related Ticket(s)
- Fixes regression introduced by #6129

## Short roundup of the initial problem
Moving a card within a table zone will reset PT because addCardImpl gets called. This is fine when moving TO a table zone since no other zones can have PT set but not fine when moving within a zone.

## What will change with this Pull Request?
- Check if a card's PT is empty before overwriting it.