### PR TITLE
update intel mac runner from 13 to 15, deprecate ventura

### DIFF
--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -15,7 +15,7 @@ Available pre-compiled binaries for installation:
   <b>macOS</b>
    • <kbd>macOS 15+</kbd> <sub><i>Sequoia</i></sub> <sub>Apple M</sub>
    • <kbd>macOS 14+</kbd> <sub><i>Sonoma</i></sub> <sub>Apple M</sub>
-   • <kbd>macOS 13+</kbd> <sub><i>Ventura</i></sub> <sub>Intel</sub>
+   • <kbd>macOS 15+</kbd> <sub><i>Sequoia</i></sub> <sub>Intel</sub>
 
   <b>Linux</b>
    • <kbd>Ubuntu 24.04 LTS</kbd> <sub><i>Noble Numbat</i></sub>

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -230,7 +230,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: 13
+          - target: 15
             soc: Intel
             os: macos-15-intel
             xcode: "16.2"

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -230,10 +230,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: 14
+          - target: 13
             soc: Intel
-            os: macos-14
-            xcode: "15.4"
+            os: macos-15-intel
+            xcode: "16.2"
             type: Release
             make_package: 1
 
@@ -267,6 +267,7 @@ jobs:
       DEVELOPER_DIR:
         /Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer
       CMAKE_GENERATOR: 'Ninja'
+      MACOSX_DEPLOYMENT_TARGET: ${{matrix.target}}.0
 
     steps:
       - name: Checkout

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -230,10 +230,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: 13
+          - target: 14
             soc: Intel
-            os: macos-13
-            xcode: "14.3.1"
+            os: macos-14
+            xcode: "15.4"
             type: Release
             make_package: 1
 


### PR DESCRIPTION
macos ventura will stop being supported officially tomorrow, however because homebrew is eager to stop supporting it builds already fail now, we have no choice but to move on to sequoia