### PR TITLE
Don't get local ID from playerInfo on concession

### DIFF
--- a/cockatrice/src/game/player/player_manager.cpp
+++ b/cockatrice/src/game/player/player_manager.cpp
@@ -68,7 +68,13 @@ Player *PlayerManager::getPlayer(int playerId) const
 void PlayerManager::onPlayerConceded(int playerId, bool conceded)
 {
     // GameEventHandler cares about this for sending the concede/unconcede commands
-    if (playerId == getActiveLocalPlayer(playerId)->getPlayerInfo()->getId()) {
+    if (game->getGameState()->getIsLocalGame()) {
+        if (conceded) {
+            emit activeLocalPlayerConceded();
+        } else {
+            emit activeLocalPlayerUnconceded();
+        }
+    } else if (playerId == localPlayerId) {
         if (conceded) {
             emit activeLocalPlayerConceded();
         } else {


### PR DESCRIPTION
## Short roundup of the initial problem
Active local player can be removed by the time this slot fires so we have to queue off of stored Ids. We were already doing this for the concession in general but not for the query if the conceding player was the active local player.
On online games, we can use the stored localPlayerId since we only have one, in local games, we can safely assume that it was always the active player that conceded because no other players have these actions/shortcuts available to them.

## What will change with this Pull Request?
- Query local game state on concession
- Query local player Id from PlayerManager attribute instead of dynamically getting the active local players PlayerInfo