### PR TITLE
Fix segfault when creating token of opponent's card

### DIFF
--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -878,7 +878,8 @@ void PlayerActions::actCreateAnotherToken()
 
 void PlayerActions::setLastToken(CardInfoPtr cardInfo)
 {
-    if (cardInfo == nullptr || !player->getPlayerMenu()->getUtilityMenu()->createAnotherTokenActionExists()) {
+    if (cardInfo == nullptr || !player->getPlayerMenu()->getUtilityMenu() ||
+        player->getPlayerMenu()->getUtilityMenu()->createAnotherTokenActionExists()) {
         return;
     }
 


### PR DESCRIPTION
## Related Ticket(s)
- #6127

## Short roundup of the initial problem

Cockatrice segfaults when you try to create a token of an opponent's card.

## What will change with this Pull Request?
- Null check the `UtilityMenu` before calling `createAnotherTokenActionExists`
