### PR TITLE
Make TabHome a managed tab

### DIFF
--- a/cockatrice/src/client/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/client/tabs/tab_supervisor.cpp
@@ -255,6 +255,8 @@ void TabSupervisor::refreshShortcuts()
     ShortcutsSettings &shortcuts = SettingsCache::instance().shortcuts();
     aTabDeckEditor->setShortcuts(shortcuts.getShortcut("Tabs/aTabDeckEditor"));
     aTabVisualDeckEditor->setShortcuts(shortcuts.getShortcut("Tabs/aTabVisualDeckEditor"));
+
+    aTabHome->setShortcuts(shortcuts.getShortcut("Tabs/aTabHome"));
     aTabVisualDeckStorage->setShortcuts(shortcuts.getShortcut("Tabs/aTabVisualDeckStorage"));
     aTabServer->setShortcuts(shortcuts.getShortcut("Tabs/aTabServer"));
     aTabAccount->setShortcuts(shortcuts.getShortcut("Tabs/aTabAccount"));

--- a/cockatrice/src/client/tabs/tab_supervisor.h
+++ b/cockatrice/src/client/tabs/tab_supervisor.h
@@ -90,6 +90,7 @@ private:
     UserListManager *userListManager;
     QList<AbstractClient *> localClients;
     QMenu *tabsMenu;
+    TabHome *tabHome;
     TabDeckStorageVisual *tabVisualDeckStorage;
     TabServer *tabServer;
     TabAccount *tabAccount;
@@ -104,8 +105,8 @@ private:
     QList<AbstractTabDeckEditor *> deckEditorTabs;
     bool isLocalGame;
 
-    QAction *aTabDeckEditor, *aTabVisualDeckEditor, *aTabEdhRec, *aTabVisualDeckStorage, *aTabVisualDatabaseDisplay,
-        *aTabServer, *aTabAccount, *aTabDeckStorage, *aTabReplays, *aTabAdmin, *aTabLog;
+    QAction *aTabHome, *aTabDeckEditor, *aTabVisualDeckEditor, *aTabEdhRec, *aTabVisualDeckStorage,
+        *aTabVisualDatabaseDisplay, *aTabServer, *aTabAccount, *aTabDeckStorage, *aTabReplays, *aTabAdmin, *aTabLog;
 
     int myAddTab(Tab *tab, QAction *manager = nullptr);
     void addCloseButtonToTab(Tab *tab, int tabIndex, QAction *manager);
@@ -175,6 +176,7 @@ public slots:
 private slots:
     void refreshShortcuts();
 
+    void actTabHome(bool checked);
     void actTabServer(bool checked);
     void actTabAccount(bool checked);
     void actTabDeckStorage(bool checked);
@@ -182,6 +184,7 @@ private slots:
     void actTabLog(bool checked);
 
     void openTabVisualDeckStorage();
+    void openTabHome();
     void openTabServer();
     void openTabAccount();
     void openTabDeckStorage();
@@ -201,7 +204,6 @@ private slots:
     void processUserLeft(const QString &userName);
     void processUserJoined(const ServerInfo_User &userInfo);
     void talkLeft(TabMessage *tab);
-    TabHome *addHomeTab();
     void deckEditorClosed(AbstractTabDeckEditor *tab);
     void tabUserEvent(bool globalEvent);
     void updateTabText(Tab *tab, const QString &newTabText);

--- a/cockatrice/src/settings/shortcuts_settings.h
+++ b/cockatrice/src/settings/shortcuts_settings.h
@@ -707,6 +707,8 @@ private:
                                                   ShortcutGroup::Replays)},
         {"Tabs/aTabDeckEditor",
          ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Deck Editor"), parseSequenceString(""), ShortcutGroup::Tabs)},
+        {"Tabs/aTabHome",
+         ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Home"), parseSequenceString(""), ShortcutGroup::Tabs)},
         {"Tabs/aTabVisualDeckStorage", ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Visual Deck Storage"),
                                                    parseSequenceString(""),
                                                    ShortcutGroup::Tabs)},


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6114

## Short roundup of the initial problem

`TabHome` is a single instance tab, but it's not a managed tab. Once the Home tab is closed, it can't be re-opened.
For consistency, we should make it a managed tab.

## What will change with this Pull Request?
- Make the `Home` tab a managed tab, which means it has an entry in the tab menu.
  - Note that unlike the other managed tabs, we don't save the open status. We always open the home tab on startup.
- Add shortcut for home tab action.

https://github.com/user-attachments/assets/13b432a2-3502-408a-9039-0a3d57993a4b

## Screenshots

<img width="227" height="227" alt="Screenshot 2025-09-15 at 2 14 40 AM" src="https://github.com/user-attachments/assets/bf016843-f1c8-4604-9371-e47ae63ae7d1" />
