### PR TITLE
Don't set opaque paint event.

### DIFF
--- a/cockatrice/src/client/ui/widgets/general/home_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/home_widget.cpp
@@ -16,7 +16,6 @@
 HomeWidget::HomeWidget(QWidget *parent, TabSupervisor *_tabSupervisor)
     : QWidget(parent), tabSupervisor(_tabSupervisor), background("theme:backgrounds/home"), overlay("theme:cockatrice")
 {
-    setAttribute(Qt::WA_OpaquePaintEvent);
     layout = new QGridLayout(this);
 
     backgroundSourceCard = new CardInfoPictureArtCropWidget(this);


### PR DESCRIPTION
## Short roundup of the initial problem
Turns out we don't need it anymore and I forgot to remove it. Fixes flickering/weird display on 'Rotating random art crop' background setting (hopefully)