### PR TITLE
[Home Tab] Only use normal layout cards as a background source

### DIFF
--- a/cockatrice/src/client/ui/widgets/general/home_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/home_widget.cpp
@@ -89,7 +89,8 @@ void HomeWidget::updateRandomCard()
         case BackgroundSources::RandomCardArt:
             do {
                 newCard = CardDatabaseManager::getInstance()->getRandomCard();
-            } while (newCard == backgroundSourceCard->getCard());
+            } while (newCard == backgroundSourceCard->getCard() &&
+                     newCard.getCardPtr()->getProperty("layout") != "normal");
             break;
         case BackgroundSources::DeckFileArt:
             QList<CardRef> cardRefs = backgroundSourceDeck->getCardRefList();


### PR DESCRIPTION
## Short roundup of the initial problem
The art crop doesn't work for non-normal layout cards.