### PR TITLE
[Home Tab] Disable random art crop shuffle if frequency is set to 0.

### DIFF
--- a/cockatrice/src/client/ui/widgets/general/home_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/home_widget.cpp
@@ -46,6 +46,8 @@ HomeWidget::HomeWidget(QWidget *parent, TabSupervisor *_tabSupervisor)
     connect(tabSupervisor->getClient(), &RemoteClient::statusChanged, this, &HomeWidget::updateConnectButton);
     connect(&SettingsCache::instance(), &SettingsCache::homeTabBackgroundSourceChanged, this,
             &HomeWidget::initializeBackgroundFromSource);
+    connect(&SettingsCache::instance(), &SettingsCache::homeTabBackgroundShuffleFrequencyChanged, this,
+            &HomeWidget::onBackgroundShuffleFrequencyChanged);
 }
 
 void HomeWidget::initializeBackgroundFromSource()
@@ -118,6 +120,19 @@ void HomeWidget::updateRandomCard()
     connect(newCard.getCardPtr().data(), &CardInfo::pixmapUpdated, this, &HomeWidget::updateBackgroundProperties);
     backgroundSourceCard->setCard(newCard);
     background = backgroundSourceCard->getProcessedBackground(size());
+
+    if (SettingsCache::instance().getHomeTabBackgroundShuffleFrequency() <= 0) {
+        cardChangeTimer->stop();
+    }
+}
+
+void HomeWidget::onBackgroundShuffleFrequencyChanged()
+{
+    cardChangeTimer->stop();
+    if (SettingsCache::instance().getHomeTabBackgroundShuffleFrequency() <= 0) {
+        return;
+    }
+    cardChangeTimer->start(SettingsCache::instance().getHomeTabBackgroundShuffleFrequency() * 1000);
 }
 
 void HomeWidget::updateBackgroundProperties()

--- a/cockatrice/src/client/ui/widgets/general/home_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/home_widget.h
@@ -22,6 +22,7 @@ public:
 public slots:
     void paintEvent(QPaintEvent *event) override;
     void initializeBackgroundFromSource();
+    void onBackgroundShuffleFrequencyChanged();
     void updateBackgroundProperties();
     void updateButtonsToBackgroundColor();
     QGroupBox *createButtons();

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -684,7 +684,7 @@ void AppearanceSettingsPage::retranslateUi()
     themeLabel.setText(tr("Current theme:"));
     openThemeButton.setText(tr("Open themes folder"));
     homeTabBackgroundSourceLabel.setText(tr("Home tab background source:"));
-    homeTabBackgroundShuffleFrequencyLabel.setText(tr("Home tab background shuffle frequency:"));
+    homeTabBackgroundShuffleFrequencyLabel.setText(tr("Home tab background shuffle frequency (0 to disable):"));
 
     menuGroupBox->setTitle(tr("Menu settings"));
     showShortcutsCheckBox.setText(tr("Show keyboard shortcuts in right-click menus"));


### PR DESCRIPTION
## Short roundup of the initial problem
Cards change way too fast if the timer is set to 0 seconds. It's meant to disable it, which this PR addresses.

## What will change with this Pull Request?
- Stop cardChange timer if home tab background shuffle frequency is set to 0.