### PR TITLE
[TabGame/PlayerManager] Handle concession properly.

### DIFF
--- a/cockatrice/src/game/player/player_manager.cpp
+++ b/cockatrice/src/game/player/player_manager.cpp
@@ -72,14 +72,6 @@ Player *PlayerManager::getPlayer(int playerId) const
 
 void PlayerManager::onPlayerConceded(int playerId, bool conceded)
 {
-    // GameEventHandler cares about this for sending the concede/unconcede commands
-    if (isLocalPlayer(playerId)) {
-        if (conceded) {
-            emit activeLocalPlayerConceded();
-        } else {
-            emit activeLocalPlayerUnconceded();
-        }
-    }
     // Everything else cares about this
     if (conceded) {
         emit playerConceded(playerId);

--- a/cockatrice/src/tabs/tab_game.cpp
+++ b/cockatrice/src/tabs/tab_game.cpp
@@ -807,6 +807,9 @@ void TabGame::startGame(bool _resuming)
     playerListWidget->setGameStarted(true, game->getGameState()->isResuming());
     game->getGameMetaInfo()->setStarted(true);
     static_cast<GameScene *>(gameView->scene())->rearrange();
+
+    aConcede->setText(tr("&Concede"));
+    aConcede->setEnabled(true);
 }
 
 void TabGame::stopGame()
@@ -824,7 +827,8 @@ void TabGame::stopGame()
 
     scene->clearViews();
 
-    retranslateUi();
+    aConcede->setText(tr("&Concede"));
+    aConcede->setEnabled(false);
 }
 
 void TabGame::closeGame()
@@ -944,6 +948,9 @@ void TabGame::createMenuItems()
     connect(aGameInfo, &QAction::triggered, this, &TabGame::actGameInfo);
     aConcede = new QAction(this);
     connect(aConcede, &QAction::triggered, this, &TabGame::actConcede);
+    if (!game->getGameMetaInfo()->started()) {
+        aConcede->setEnabled(false);
+    }
     connect(game->getPlayerManager(), &PlayerManager::activeLocalPlayerConceded, game->getGameEventHandler(),
             &GameEventHandler::handleActiveLocalPlayerConceded);
     connect(game->getPlayerManager(), &PlayerManager::activeLocalPlayerUnconceded, game->getGameEventHandler(),

--- a/cockatrice/src/tabs/tab_game.cpp
+++ b/cockatrice/src/tabs/tab_game.cpp
@@ -152,6 +152,7 @@ void TabGame::connectToPlayerManager()
     connect(game->getPlayerManager(), &PlayerManager::playerRemoved, this, &TabGame::processPlayerLeave);
     // update menu text when player concedes so that "concede" gets updated to "unconcede"
     connect(game->getPlayerManager(), &PlayerManager::playerConceded, this, &TabGame::retranslateUi);
+    connect(game->getPlayerManager(), &PlayerManager::playerUnconceded, this, &TabGame::retranslateUi);
 }
 
 void TabGame::connectToGameEventHandler()
@@ -497,13 +498,14 @@ void TabGame::actConcede()
         if (QMessageBox::question(this, tr("Concede"), tr("Are you sure you want to concede this game?"),
                                   QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes)
             return;
+        emit game->getPlayerManager()->activeLocalPlayerConceded();
         player->setConceded(true);
     } else {
         if (QMessageBox::question(this, tr("Unconcede"),
                                   tr("You have already conceded.  Do you want to return to this game?"),
                                   QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes)
             return;
-
+        emit game->getPlayerManager()->activeLocalPlayerUnconceded();
         player->setConceded(false);
     }
 }
@@ -821,6 +823,8 @@ void TabGame::stopGame()
     playerListWidget->setGameStarted(false, false);
 
     scene->clearViews();
+
+    retranslateUi();
 }
 
 void TabGame::closeGame()


### PR DESCRIPTION
## Related Ticket(s)
- Fixes an issue in #6127

## Short roundup of the initial problem
Concession messages are duplicated because the client doesn't expect the order of the game servers concession handling and assumes that the duplicated state change of the player is the player actively asking for concession.

In the context of this, I would like a review/explanation of how the game server handles concession. The client seems to first receive a gameStateChangedEvent where the player is actually not conceded, followed up by an event where the player *is* conceded?

<img width="2163" height="147" alt="image" src="https://github.com/user-attachments/assets/9a57f9c0-d678-4876-b3fe-b22e6689763e" />

## What will change with this Pull Request?
- Do not check in the playerManager slot for player concession if the active local player has conceded. 
- The active local player can only ever actively concede from the tab_game action, which means this action can directly emit the activeLocalPlayerConceded signals of playerManager.

## Screenshots
Problematic concession:
<img width="331" height="94" alt="image" src="https://github.com/user-attachments/assets/43ffa10e-513c-44ab-a322-4fda6cf50f3c" />

Proper concession:
<img width="454" height="188" alt="image" src="https://github.com/user-attachments/assets/66f2f4c0-eb91-4266-b894-51676a3481e5" />

Resume after concession:
<img width="341" height="173" alt="image" src="https://github.com/user-attachments/assets/7dc566d6-08c0-424d-8092-3aec542beac4" />
