### PR TITLE
[Game] Fix double concede in log

### DIFF
--- a/cockatrice/src/game/game_event_handler.cpp
+++ b/cockatrice/src/game/game_event_handler.cpp
@@ -340,6 +340,8 @@ void GameEventHandler::eventPlayerPropertiesChanged(const Event_PlayerProperties
             while (playerIterator.hasNext())
                 playerIterator.next().value()->updateZones();
 
+            emit logConcede(eventPlayerId);
+
             break;
         }
         case GameEventContext::UNCONCEDE: {
@@ -348,6 +350,8 @@ void GameEventHandler::eventPlayerPropertiesChanged(const Event_PlayerProperties
             QMapIterator<int, Player *> playerIterator(game->getPlayerManager()->getPlayers());
             while (playerIterator.hasNext())
                 playerIterator.next().value()->updateZones();
+
+            emit logUnconcede(eventPlayerId);
 
             break;
         }

--- a/cockatrice/src/game/game_event_handler.h
+++ b/cockatrice/src/game/game_event_handler.h
@@ -122,6 +122,8 @@ signals:
     void logGameClosed();
     void logActivePlayer(Player *activePlayer);
     void logActivePhaseChanged(int activePhase);
+    void logConcede(int playerId);
+    void logUnconcede(int playerId);
 };
 
 #endif // COCKATRICE_GAME_EVENT_HANDLER_H

--- a/cockatrice/src/tabs/tab_game.cpp
+++ b/cockatrice/src/tabs/tab_game.cpp
@@ -78,7 +78,6 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, GameReplay *_replay)
     connectToGameEventHandler();
     connectPlayerListToGameEventHandler();
     connectMessageLogToGameEventHandler();
-    connectMessageLogToPlayerHandler();
 
     retranslateUi();
     connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
@@ -124,7 +123,6 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor,
     connectToGameEventHandler();
     connectPlayerListToGameEventHandler();
     connectMessageLogToGameEventHandler();
-    connectMessageLogToPlayerHandler();
 
     retranslateUi();
     connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
@@ -206,14 +204,11 @@ void TabGame::connectMessageLogToGameEventHandler()
     connect(game->getGameEventHandler(), &GameEventHandler::logTurnReversed, messageLog,
             &MessageLogWidget::logReverseTurn);
 
+    connect(game->getGameEventHandler(), &GameEventHandler::logConcede, messageLog, &MessageLogWidget::logConcede);
+    connect(game->getGameEventHandler(), &GameEventHandler::logUnconcede, messageLog, &MessageLogWidget::logUnconcede);
+
     connect(game->getGameEventHandler(), &GameEventHandler::logGameClosed, messageLog,
             &MessageLogWidget::logGameClosed);
-}
-
-void TabGame::connectMessageLogToPlayerHandler()
-{
-    connect(game->getPlayerManager(), &PlayerManager::playerConceded, messageLog, &MessageLogWidget::logConcede);
-    connect(game->getPlayerManager(), &PlayerManager::playerUnconceded, messageLog, &MessageLogWidget::logUnconcede);
 }
 
 void TabGame::connectPlayerListToGameEventHandler()

--- a/cockatrice/src/tabs/tab_game.h
+++ b/cockatrice/src/tabs/tab_game.h
@@ -168,7 +168,6 @@ public:
     void connectToPlayerManager();
     void connectToGameEventHandler();
     void connectMessageLogToGameEventHandler();
-    void connectMessageLogToPlayerHandler();
     void connectPlayerListToGameEventHandler();
     TabGame(TabSupervisor *_tabSupervisor, GameReplay *replay);
     ~TabGame() override;


### PR DESCRIPTION
## Related Ticket(s)
- Related to #6127

## Short roundup of the initial problem

Whenever you concede, multiple concede and unconcede messages get logged in chat.

<img width="313" height="148" alt="Screenshot 2025-09-26 at 2 28 44 AM" src="https://github.com/user-attachments/assets/952e2ed4-6f5b-4a0f-b838-6ca73e9b4a07" />

This is caused by logging being triggered from signals emitted from the `PlayerManager`. The signals are emitted whenever the concession state of the player changes for any reason, including for internal client-side reasons.

## What will change with this Pull Request?

- emit the `logConcede`/`logUnconcede` signals from `GameEventHandler` instead of `PlayerManager`.
  - which means those logs only get emitted whenever an actual server-side change gets processed.

<img width="304" height="135" alt="Screenshot 2025-09-26 at 2 29 11 AM" src="https://github.com/user-attachments/assets/6581d92b-cbb5-4dd0-8f93-d9230ab5c792" />
