### PR TITLE
[TabGame] Reconnect remote player deck selection signals to game event handler.

### DIFF
--- a/cockatrice/src/tabs/tab_game.cpp
+++ b/cockatrice/src/tabs/tab_game.cpp
@@ -165,6 +165,10 @@ void TabGame::connectToGameEventHandler()
             &TabGame::processLocalPlayerSideboardLocked);
     connect(game->getGameEventHandler(), &GameEventHandler::localPlayerDeckSelected, this,
             &TabGame::processLocalPlayerDeckSelect);
+    connect(game->getGameEventHandler(), &GameEventHandler::remotePlayerDeckSelected, this,
+            &TabGame::processRemotePlayerDeckSelect);
+    connect(game->getGameEventHandler(), &GameEventHandler::remotePlayersDecksSelected, this,
+            &TabGame::processMultipleRemotePlayerDeckSelect);
 }
 
 void TabGame::connectMessageLogToGameEventHandler()


### PR DESCRIPTION
## Short roundup of the initial problem
Open decklist lobbies are broken because while the game event handler correctly emits signals, they're never wired up.

## What will change with this Pull Request?
- Wire signals.