### PR TITLE
[TabRoom] Re-layout game creation dialog.

### DIFF
--- a/cockatrice/src/dialogs/dlg_create_game.cpp
+++ b/cockatrice/src/dialogs/dlg_create_game.cpp
@@ -114,13 +114,24 @@ void DlgCreateGame::sharedCtor()
     gameSetupOptionsGroupBox = new QGroupBox(tr("Game setup options"));
     gameSetupOptionsGroupBox->setLayout(gameSetupOptionsLayout);
 
-    QGridLayout *grid = new QGridLayout;
+    auto *grid = new QGridLayout;
+
+    // Top row
     grid->addWidget(generalGroupBox, 0, 0);
     grid->addWidget(joinRestrictionsGroupBox, 0, 1);
+
+    // Middle row: left column
     grid->addWidget(gameTypeGroupBox, 1, 0);
-    grid->addWidget(spectatorsGroupBox, 1, 1, Qt::AlignTop);
-    grid->addWidget(gameSetupOptionsGroupBox, 1, 1, Qt::AlignBottom);
-    grid->addWidget(rememberGameSettings, 3, 0);
+
+    // Middle row: right column (game setup + spectators)
+    auto *rightLayout = new QVBoxLayout;
+    rightLayout->addWidget(spectatorsGroupBox, Qt::AlignTop); // top
+    rightLayout->addWidget(gameSetupOptionsGroupBox);         // bottom
+
+    grid->addLayout(rightLayout, 1, 1);
+
+    // Bottom row
+    grid->addWidget(rememberGameSettings, 3, 0, 1, 2); // span both columns if needed
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok);
     connect(buttonBox, &QDialogButtonBox::rejected, this, &DlgCreateGame::reject);

--- a/cockatrice/src/dialogs/dlg_create_game.cpp
+++ b/cockatrice/src/dialogs/dlg_create_game.cpp
@@ -119,7 +119,7 @@ void DlgCreateGame::sharedCtor()
     grid->addWidget(joinRestrictionsGroupBox, 0, 1);
     grid->addWidget(gameTypeGroupBox, 1, 0);
     grid->addWidget(spectatorsGroupBox, 1, 1, Qt::AlignTop);
-    grid->addWidget(gameSetupOptionsGroupBox, 2, 0);
+    grid->addWidget(gameSetupOptionsGroupBox, 1, 1, Qt::AlignBottom);
     grid->addWidget(rememberGameSettings, 3, 0);
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok);


### PR DESCRIPTION
## Short roundup of the initial problem
There's unused space in the create game dialog beneath the spectators.

## Screenshots
<img width="523" height="564" alt="image" src="https://github.com/user-attachments/assets/932e6901-f1a2-4e15-ba1c-03cd693605b7" />

<img width="513" height="467" alt="image" src="https://github.com/user-attachments/assets/c80e8dca-74a1-4fa7-a91c-8f87df6a7805" />

<img width="513" height="436" alt="image" src="https://github.com/user-attachments/assets/43628fe5-2401-4535-a939-e24cb4372233" />

