### PR TITLE
[Game/DB] Have landscape cards enter tapped and not untap normally when played to table

### DIFF
--- a/cockatrice/src/game/zones/logic/table_zone_logic.cpp
+++ b/cockatrice/src/game/zones/logic/table_zone_logic.cpp
@@ -18,6 +18,9 @@ void TableZoneLogic::addCardImpl(CardItem *card, int _x, int _y)
     if (!card->getFaceDown() && card->getPT().isEmpty()) {
         card->setPT(card->getCardInfo().getPowTough());
     }
+    if (card->getCardInfo().getCipt() && card->getCardInfo().getLandscapeOrientation()) {
+        card->setDoesntUntap(true);
+    }
     card->setGridPoint(QPoint(_x, _y));
     card->setVisible(true);
 }

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -173,12 +173,12 @@ CardInfoPtr OracleImporter::addCard(QString name,
 
     // DETECT CARD POSITIONING INFO
 
-    // cards that enter the field tapped
-    bool cipt = parseCipt(name, text);
-
     bool landscapeOrientation = properties.value("maintype").toString() == "Battle" ||
                                 properties.value("layout").toString() == "split" ||
                                 properties.value("layout").toString() == "planar";
+
+    // cards that enter the field tapped
+    bool cipt = parseCipt(name, text) || landscapeOrientation;
 
     // table row
     int tableRow = 1;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6040

## Short roundup of the initial problem
"Cards like sieges and rooms are going to always be oriented landscape, so they should be skipped when the untap key command is used."

## What will change with this Pull Request?
- Apply cipt parameter to all cards with landscape orientation
- Set doesntUntap when adding card with landscape and cipt to table_zone
