### PR TITLE
[TabGame/GameEventHandler] Re-emit spectator addition signals in eventGameStateChanged

### DIFF
--- a/cockatrice/src/game/game_event_handler.cpp
+++ b/cockatrice/src/game/game_event_handler.cpp
@@ -251,7 +251,11 @@ void GameEventHandler::eventGameStateChanged(const Event_GameStateChanged &event
         QString playerName = "@" + QString::fromStdString(prop.user_info().name());
         emit addPlayerToAutoCompleteList(playerName);
         if (prop.spectator()) {
-            game->getPlayerManager()->addSpectator(playerId, prop);
+            if (game->getPlayerManager()->getSpectator(playerId).id() == -1) {
+                game->getPlayerManager()->addSpectator(playerId, prop);
+                emit spectatorJoined(prop);
+                emit logJoinSpectator(playerName);
+            }
         } else {
             Player *player = game->getPlayerManager()->getPlayers().value(playerId, 0);
             if (!player) {


### PR DESCRIPTION
## Short roundup of the initial problem
If you join a game, most of the setup is done in the initial gameStateChangedEvent, which currently does not emit addition signals for spectators. This makes them not display in the player list widget.

## What will change with this Pull Request?
- Re-emit signals.

## Screenshots
<img width="291" height="132" alt="image" src="https://github.com/user-attachments/assets/d7150758-ea6d-4491-a325-99c6ffbbfa7b" />
