### PR TITLE
[DeckEditor] Properly check if deck is blank.

### DIFF
--- a/cockatrice/src/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/tabs/abstract_tab_deck_editor.cpp
@@ -186,7 +186,7 @@ void AbstractTabDeckEditor::setModified(bool _modified)
 bool AbstractTabDeckEditor::isBlankNewDeck() const
 {
     DeckLoader *deck = getDeckList();
-    return !modified && deck->hasNotBeenLoaded();
+    return !modified && deck->isUnmodified() && deck->hasNotBeenLoaded();
 }
 
 void AbstractTabDeckEditor::actNewDeck()

--- a/common/deck_list.h
+++ b/common/deck_list.h
@@ -243,6 +243,11 @@ public:
     }
     ///@}
 
+    bool isUnmodified() const
+    {
+        return name.isEmpty() && comments.isEmpty() && getCardList().size() == 0;
+    }
+
     /// @name Sideboard plans
     ///@{
     QList<MoveCard_ToZone> getCurrentSideboardPlan();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6171

## Short roundup of the initial problem
DeckEditor modified flag isn't being set correctly.

## What will change with this Pull Request?
- Add isUnmodified method to decklist, which checks for an empty name, comment and decklist size == 0;
- Use this in the check

## Screenshots
<img width="803" height="210" alt="image" src="https://github.com/user-attachments/assets/05f9f20f-7777-4ef5-adca-b5c4f3fdfed3" />

<img width="812" height="250" alt="image" src="https://github.com/user-attachments/assets/a120768f-d722-41f0-af96-bb2571232dbe" />

<img width="808" height="211" alt="image" src="https://github.com/user-attachments/assets/9b275176-cfaf-4504-86e4-1382a45d11cc" />

<img width="768" height="208" alt="image" src="https://github.com/user-attachments/assets/592eb32e-af07-45a3-8e4b-9c8aa0a165d0" />

<img width="764" height="302" alt="image" src="https://github.com/user-attachments/assets/b62ab658-3ede-4143-aa59-c0062426115f" />

<img width="797" height="761" alt="image" src="https://github.com/user-attachments/assets/81634269-54bb-4193-ad9f-d2dce5f9dc0d" />

<img width="794" height="713" alt="image" src="https://github.com/user-attachments/assets/1b4b1d1f-bd87-4b66-a6ee-d41a19261a57" />

<img width="797" height="760" alt="image" src="https://github.com/user-attachments/assets/8248b4d6-877d-454b-8afb-f12ea5c391e7" />

