### PR TITLE
remove building docker images on code changes in prs

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -11,12 +11,6 @@ on:
       - master
     paths:
       - '.github/workflows/docker-release.yml'
-      - 'CMakeLists.txt'
-      - 'Dockerfile'
-      - 'servatrice/**'
-      - 'common/**'
-      - 'cmake/**'
-      - '!**.md'
 
 jobs:
   docker:


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem
building the docker images takes about an hour, it's our slowest pr job by far, running it on every code change is meaningless as we already do so with our other actions

## What will change with this Pull Request?
- remove code paths from the on pull request trigger from the action

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
