### PR TITLE
nullcheck concede action

### DIFF
--- a/cockatrice/src/tabs/tab_game.cpp
+++ b/cockatrice/src/tabs/tab_game.cpp
@@ -807,8 +807,10 @@ void TabGame::startGame(bool _resuming)
     game->getGameMetaInfo()->setStarted(true);
     static_cast<GameScene *>(gameView->scene())->rearrange();
 
-    aConcede->setText(tr("&Concede"));
-    aConcede->setEnabled(true);
+    if (aConcede != nullptr) {
+        aConcede->setText(tr("&Concede"));
+        aConcede->setEnabled(true);
+    }
 }
 
 void TabGame::stopGame()
@@ -826,8 +828,10 @@ void TabGame::stopGame()
 
     scene->clearViews();
 
-    aConcede->setText(tr("&Concede"));
-    aConcede->setEnabled(false);
+    if (aConcede != nullptr) {
+        aConcede->setText(tr("&Concede"));
+        aConcede->setEnabled(false);
+    }
 }
 
 void TabGame::closeGame()


### PR DESCRIPTION
## Related Ticket(s)
- Fixes regression introduced in #6178

## Short roundup of the initial problem
when watching a replay the player tries to disable the concede action even though the action only exists when really playing

## What will change with this Pull Request?
- add nullcheck
