### PR TITLE
add scroll bar to properties in cardinfotextwidget

### DIFF
--- a/cockatrice/src/interface/widgets/cards/card_info_text_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_info_text_widget.cpp
@@ -39,9 +39,6 @@ CardInfoTextWidget::CardInfoTextWidget(QWidget *parent) : QFrame(parent), info(n
     grid->setRowStretch(1, 1);
 
     retranslateUi();
-
-    connect(this, &CardInfoTextWidget::resizeEvent, this,
-            [this]() { propsScroll->setMaximumHeight(propsLabel->sizeHint().height()); });
 }
 
 void CardInfoTextWidget::setTexts(const QString &propsText, const QString &textText)

--- a/cockatrice/src/interface/widgets/cards/card_info_text_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_info_text_widget.h
@@ -11,6 +11,7 @@
 
 #include <QFrame>
 class QLabel;
+class QScrollArea;
 class QTextEdit;
 
 class CardInfoTextWidget : public QFrame
@@ -18,9 +19,11 @@ class CardInfoTextWidget : public QFrame
     Q_OBJECT
 
 private:
-    QLabel *nameLabel;
+    QLabel *propsLabel;
+    QScrollArea *propsScroll;
     QTextEdit *textLabel;
     CardInfoPtr info;
+    void setTexts(const QString &propsText, const QString &textText);
 
 public:
     explicit CardInfoTextWidget(QWidget *parent = nullptr);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem
cards with long lists of properties will overflow the text part of the card info

## What will change with this Pull Request?
- add a scrollbar that appears only when the card has too many props to fit the list

## Current issues
- the scrollbar is inadvertently enabled when word wrapping happens in small widths, I haven't found a good solution to this

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
<img width="275" height="524" alt="image" src="https://github.com/user-attachments/assets/f31a4578-88b7-4e66-ad75-bbe98aeccf40" />
<img width="275" height="414" alt="image" src="https://github.com/user-attachments/assets/f2ed297c-fa1e-43b2-baa2-a023250ca5b0" />
<img width="373" height="417" alt="image" src="https://github.com/user-attachments/assets/b2c44889-8a76-4ac3-89a3-496ada9338e4" />

compare with release:
<img width="343" height="450" alt="image" src="https://github.com/user-attachments/assets/cc5b4457-a010-4ffc-866a-800c6ce34295" />
<img width="339" height="236" alt="image" src="https://github.com/user-attachments/assets/228e8002-f470-4515-b47d-15e02658a891" />(it's not possible to shrink it this far on release)
<img width="424" height="446" alt="image" src="https://github.com/user-attachments/assets/8b46ac77-aa7b-46be-aa83-008005f20c86" />(this is the furthest release is able to shrink this card)

issue introduced:
<img width="157" height="616" alt="image" src="https://github.com/user-attachments/assets/93199f5a-d297-47e2-835e-a6fd95a2900c" />
(the small width causes word wrap, the word wrap makes the scrollbar appear while the scrollarea is not resized as expected)