### PR TITLE
[UI] Remove @ from playerName since only the auto complete list cares about it.

### DIFF
--- a/cockatrice/src/game/game_event_handler.cpp
+++ b/cockatrice/src/game/game_event_handler.cpp
@@ -248,8 +248,8 @@ void GameEventHandler::eventGameStateChanged(const Event_GameStateChanged &event
         const ServerInfo_Player &playerInfo = event.player_list(i);
         const ServerInfo_PlayerProperties &prop = playerInfo.properties();
         const int playerId = prop.player_id();
-        QString playerName = "@" + QString::fromStdString(prop.user_info().name());
-        emit addPlayerToAutoCompleteList(playerName);
+        QString playerName = QString::fromStdString(prop.user_info().name());
+        emit addPlayerToAutoCompleteList("@" + playerName);
         if (prop.spectator()) {
             if (!game->getPlayerManager()->getSpectators().contains(playerId)) {
                 game->getPlayerManager()->addSpectator(playerId, prop);


### PR DESCRIPTION
## Short roundup of the initial problem
playerName has an @ added to it when most things that care about using this variable are not intended to have this (as a matter of fact, only the auto complete list cares about this)

## What will change with this Pull Request?
- Move @ concatenation from variable declaration to function invocation parameter.