### PR TITLE
[GameEventHandler] Do not log joins on gameStateChanged (resume events)

### DIFF
--- a/cockatrice/src/game/game_event_handler.cpp
+++ b/cockatrice/src/game/game_event_handler.cpp
@@ -254,14 +254,12 @@ void GameEventHandler::eventGameStateChanged(const Event_GameStateChanged &event
             if (!game->getPlayerManager()->getSpectators().contains(playerId)) {
                 game->getPlayerManager()->addSpectator(playerId, prop);
                 emit spectatorJoined(prop);
-                emit logJoinSpectator(playerName);
             }
         } else {
             Player *player = game->getPlayerManager()->getPlayers().value(playerId, 0);
             if (!player) {
                 player = game->getPlayerManager()->addPlayer(playerId, prop.user_info());
                 emit playerJoined(prop);
-                emit logJoinPlayer(player);
             }
             player->processPlayerInfo(playerInfo);
             if (player->getPlayerInfo()->getLocal()) {


### PR DESCRIPTION
## Short roundup of the initial problem
Perceived inconsistencies in display

## What will change with this Pull Request?
- Don't emit log signals in eventGameStateChanged()