### PR TITLE
[Game] Populate playerLists for menus in their aboutToShow …

### DIFF
--- a/cockatrice/src/game/player/menu/grave_menu.cpp
+++ b/cockatrice/src/game/player/menu/grave_menu.cpp
@@ -51,9 +51,9 @@ void GraveyardMenu::createMoveActions()
         aMoveGraveToRfg = new QAction(this);
         aMoveGraveToRfg->setData(QList<QVariant>() << "rfg" << 0);
 
-        connect(aMoveGraveToTopLibrary,    &QAction::triggered, grave, &PileZoneLogic::moveAllToZone);
+        connect(aMoveGraveToTopLibrary, &QAction::triggered, grave, &PileZoneLogic::moveAllToZone);
         connect(aMoveGraveToBottomLibrary, &QAction::triggered, grave, &PileZoneLogic::moveAllToZone);
-        connect(aMoveGraveToHand,          &QAction::triggered, grave, &PileZoneLogic::moveAllToZone);
+        connect(aMoveGraveToHand, &QAction::triggered, grave, &PileZoneLogic::moveAllToZone);
         connect(aMoveGraveToRfg, &QAction::triggered, grave, &PileZoneLogic::moveAllToZone);
     }
 }
@@ -63,8 +63,7 @@ void GraveyardMenu::createViewActions()
     PlayerActions *playerActions = player->getPlayerActions();
 
     aViewGraveyard = new QAction(this);
-    connect(aViewGraveyard, &QAction::triggered,
-            playerActions, &PlayerActions::actViewGraveyard);
+    connect(aViewGraveyard, &QAction::triggered, playerActions, &PlayerActions::actViewGraveyard);
 }
 
 void GraveyardMenu::populateRevealRandomMenuWithActivePlayers()

--- a/cockatrice/src/game/player/menu/grave_menu.h
+++ b/cockatrice/src/game/player/menu/grave_menu.h
@@ -23,6 +23,8 @@ public:
     explicit GraveyardMenu(Player *player, QWidget *parent = nullptr);
     void createMoveActions();
     void createViewActions();
+    void populateRevealRandomMenuWithActivePlayers();
+    void onRevealRandomTriggered();
     void retranslateUi();
     void setShortcutsActive();
     void setShortcutsInactive();

--- a/cockatrice/src/game/player/menu/hand_menu.cpp
+++ b/cockatrice/src/game/player/menu/hand_menu.cpp
@@ -102,10 +102,6 @@ void HandMenu::setShortcutsInactive()
     aMulligan->setShortcut(QKeySequence());
 }
 
-// -------------------------
-// Dynamic menu population
-// -------------------------
-
 void HandMenu::populateRevealHandMenuWithActivePlayers()
 {
     mRevealHand->clear();
@@ -145,10 +141,6 @@ void HandMenu::populateRevealRandomHandCardMenuWithActivePlayers()
         connect(a, &QAction::triggered, this, &HandMenu::onRevealRandomHandCardTriggered);
     }
 }
-
-// -------------------------
-// Action handlers
-// -------------------------
 
 void HandMenu::onRevealHandTriggered()
 {

--- a/cockatrice/src/game/player/menu/hand_menu.h
+++ b/cockatrice/src/game/player/menu/hand_menu.h
@@ -18,13 +18,10 @@ class PlayerActions;
 class HandMenu : public TearOffMenu
 {
     Q_OBJECT
-public:
-    explicit HandMenu(Player *player, PlayerActions *actions, QWidget *parent = nullptr);
-    void retranslateUi();
-    void setShortcutsActive();
-    void setShortcutsInactive();
 
-    // expose useful actions/menus if PlayerMenu needs them
+public:
+    HandMenu(Player *player, PlayerActions *actions, QWidget *parent = nullptr);
+
     QMenu *revealHandMenu() const
     {
         return mRevealHand;
@@ -33,10 +30,16 @@ public:
     {
         return mRevealRandomHandCard;
     }
-    QMenu *moveHandMenu() const
-    {
-        return mMoveHandMenu;
-    }
+
+    void retranslateUi();
+    void setShortcutsActive();
+    void setShortcutsInactive();
+
+private slots:
+    void populateRevealHandMenuWithActivePlayers();
+    void populateRevealRandomHandCardMenuWithActivePlayers();
+    void onRevealHandTriggered();
+    void onRevealRandomHandCardTriggered();
 
 private:
     Player *player;
@@ -47,8 +50,8 @@ private:
 
     QMenu *mRevealHand = nullptr;
     QMenu *mRevealRandomHandCard = nullptr;
-    QMenu *mMoveHandMenu = nullptr;
 
+    QMenu *mMoveHandMenu = nullptr;
     QAction *aMoveHandToTopLibrary = nullptr;
     QAction *aMoveHandToBottomLibrary = nullptr;
     QAction *aMoveHandToGrave = nullptr;

--- a/cockatrice/src/game/player/menu/library_menu.h
+++ b/cockatrice/src/game/player/menu/library_menu.h
@@ -29,6 +29,12 @@ public:
     void createMoveActions();
     void createViewActions();
     void retranslateUi();
+    void populateRevealLibraryMenuWithActivePlayers();
+    void populateLendLibraryMenuWithActivePlayers();
+    void populateRevealTopCardMenuWithActivePlayers();
+    void onRevealLibraryTriggered();
+    void onLendLibraryTriggered();
+    void onRevealTopCardTriggered();
     void setShortcutsActive();
     void setShortcutsInactive();
 
@@ -96,6 +102,8 @@ public:
     QAction *aMoveBottomCardsToGraveyard = nullptr;
     QAction *aMoveBottomCardsToExile = nullptr;
     QAction *aShuffleBottomCards = nullptr;
+
+    int defaultNumberTopCards = 1;
 
 private:
     Player *player;

--- a/cockatrice/src/game/player/menu/player_menu.cpp
+++ b/cockatrice/src/game/player/menu/player_menu.cpp
@@ -12,29 +12,13 @@
 
 PlayerMenu::PlayerMenu(Player *_player) : player(_player)
 {
-
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
-        connect(player->getGame()->getPlayerManager(), &PlayerManager::playerAdded, this, &PlayerMenu::addPlayer);
-        connect(player->getGame()->getPlayerManager(), &PlayerManager::playerRemoved, this, &PlayerMenu::removePlayer);
-    }
-
-    const QList<Player *> &players = player->getGame()->getPlayerManager()->getPlayers().values();
-    for (const auto playerToAdd : players) {
-        addPlayer(playerToAdd);
-    }
-
     playerMenu = new TearOffMenu();
 
     if (player->getPlayerInfo()->getLocalOrJudge()) {
         handMenu = new HandMenu(player, player->getPlayerActions(), playerMenu);
         playerMenu->addMenu(handMenu);
-        playerLists.append(handMenu->revealHandMenu());
-        playerLists.append(handMenu->revealRandomHandCardMenu());
 
         libraryMenu = new LibraryMenu(player, playerMenu);
-        playerLists.append(libraryMenu->revealLibrary());
-        playerLists.append(libraryMenu->lendLibraryMenu());
-        playerLists.append(libraryMenu->revealTopCardMenu());
         playerMenu->addMenu(libraryMenu);
     } else {
         handMenu = nullptr;
@@ -42,7 +26,6 @@ PlayerMenu::PlayerMenu(Player *_player) : player(_player)
     }
 
     graveMenu = new GraveyardMenu(player, playerMenu);
-    connect(graveMenu, &GraveyardMenu::newPlayerActionCreated, this, &PlayerMenu::onNewPlayerListActionCreated);
     playerMenu->addMenu(graveMenu);
 
     rfgMenu = new RfgMenu(player, playerMenu);
@@ -73,17 +56,6 @@ PlayerMenu::PlayerMenu(Player *_player) : player(_player)
         sayMenu = nullptr;
     }
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
-
-        for (auto &playerList : playerLists) {
-            QAction *newAction = playerList->addAction(QString());
-            newAction->setData(-1);
-            connect(newAction, &QAction::triggered, this, &PlayerMenu::playerListActionTriggered);
-            allPlayersActions.append(newAction);
-            playerList->addSeparator();
-        }
-    }
-
     connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
             &PlayerMenu::refreshShortcuts);
     refreshShortcuts();
@@ -101,89 +73,6 @@ void PlayerMenu::setMenusForGraphicItems()
         player->getGraphicsItem()->getDeckZoneGraphicsItem()->setMenu(libraryMenu, libraryMenu->aDrawCard);
         player->getGraphicsItem()->getSideboardZoneGraphicsItem()->setMenu(sideboardMenu);
     }
-}
-
-void PlayerMenu::addPlayer(Player *playerToAdd)
-{
-    if (playerToAdd == nullptr || playerToAdd == player) {
-        return;
-    }
-
-    for (auto &playerList : playerLists) {
-        addPlayerToList(playerList, playerToAdd);
-    }
-}
-
-void PlayerMenu::addPlayerToList(QMenu *playerList, Player *playerToAdd)
-{
-    QAction *newAction = playerList->addAction(playerToAdd->getPlayerInfo()->getName());
-    newAction->setData(playerToAdd->getPlayerInfo()->getId());
-    connect(newAction, &QAction::triggered, this, &PlayerMenu::playerListActionTriggered);
-}
-
-void PlayerMenu::removePlayer(Player *playerToRemove)
-{
-    if (playerToRemove == nullptr) {
-        return;
-    }
-
-    for (auto &playerList : playerLists) {
-        removePlayerFromList(playerList, playerToRemove);
-    }
-}
-
-void PlayerMenu::removePlayerFromList(QMenu *playerList, Player *player)
-{
-    QList<QAction *> actionList = playerList->actions();
-    for (auto &j : actionList)
-        if (j->data().toInt() == player->getPlayerInfo()->getId()) {
-            playerList->removeAction(j);
-            j->deleteLater();
-        }
-}
-
-void PlayerMenu::playerListActionTriggered()
-{
-    auto *action = static_cast<QAction *>(sender());
-    auto *menu = static_cast<QMenu *>(action->parent());
-
-    Command_RevealCards cmd;
-    const int otherPlayerId = action->data().toInt();
-    if (otherPlayerId != -1) {
-        cmd.set_player_id(otherPlayerId);
-    }
-
-    if (menu == libraryMenu->revealLibrary() || menu == libraryMenu->lendLibraryMenu()) {
-        cmd.set_zone_name("deck");
-        cmd.set_grant_write_access(menu == libraryMenu->lendLibraryMenu());
-    } else if (menu == libraryMenu->revealTopCardMenu()) {
-        int deckSize = player->getDeckZone()->getCards().size();
-        bool ok;
-        int number = QInputDialog::getInt(player->getGame()->getTab(), tr("Reveal top cards of library"),
-                                          tr("Number of cards: (max. %1)").arg(deckSize), /* defaultNumberTopCards */ 1,
-                                          1, deckSize, 1, &ok);
-        if (ok) {
-            cmd.set_zone_name("deck");
-            cmd.set_top_cards(number);
-            // backward compatibility: servers before #1051 only permits to reveal the first card
-            cmd.add_card_id(0);
-            // defaultNumberTopCards = number;
-        }
-    } else if (menu == handMenu->revealHandMenu()) {
-        cmd.set_zone_name("hand");
-    } else if (menu == handMenu->revealRandomHandCardMenu()) {
-        cmd.set_zone_name("hand");
-        cmd.add_card_id(PlayerActions::RANDOM_CARD_FROM_ZONE);
-    } else {
-        return;
-    }
-
-    player->getPlayerActions()->sendGameCommand(cmd);
-}
-
-void PlayerMenu::onNewPlayerListActionCreated(QAction *action)
-{
-    allPlayersActions.append(action);
 }
 
 QMenu *PlayerMenu::updateCardMenu(const CardItem *card)
@@ -239,10 +128,6 @@ void PlayerMenu::retranslateUi()
 
     if (utilityMenu) {
         utilityMenu->retranslateUi();
-    }
-
-    for (auto &allPlayersAction : allPlayersActions) {
-        allPlayersAction->setText(tr("&All players"));
     }
 
     if (sayMenu) {

--- a/cockatrice/src/game/player/menu/player_menu.h
+++ b/cockatrice/src/game/player/menu/player_menu.h
@@ -33,18 +33,11 @@ public slots:
     void setMenusForGraphicItems();
 
 private slots:
-    void addPlayer(Player *playerToAdd);
-    void removePlayer(Player *playerToRemove);
-    void playerListActionTriggered();
-    void onNewPlayerListActionCreated(QAction *action);
     void refreshShortcuts();
 
 public:
     PlayerMenu(Player *player);
     void retranslateUi();
-
-    void addPlayerToList(QMenu *playerList, Player *playerToAdd);
-    static void removePlayerFromList(QMenu *playerList, Player *player);
 
     QMenu *updateCardMenu(const CardItem *card);
 
@@ -88,8 +81,6 @@ private:
     UtilityMenu *utilityMenu;
     SayMenu *sayMenu;
     CustomZoneMenu *customZonesMenu;
-    QList<QMenu *> playerLists;
-    QList<QAction *> allPlayersActions;
 
     bool shortcutsActive;
 

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -197,19 +197,6 @@ void PlayerActions::actViewGraveyard()
     player->getGameScene()->toggleZoneView(player, "grave", -1);
 }
 
-void PlayerActions::actRevealRandomGraveyardCard()
-{
-    Command_RevealCards cmd;
-    auto *action = dynamic_cast<QAction *>(sender());
-    const int otherPlayerId = action->data().toInt();
-    if (otherPlayerId != -1) {
-        cmd.set_player_id(otherPlayerId);
-    }
-    cmd.set_zone_name("grave");
-    cmd.add_card_id(RANDOM_CARD_FROM_ZONE);
-    sendGameCommand(cmd);
-}
-
 void PlayerActions::actViewRfg()
 {
     player->getGameScene()->toggleZoneView(player, "rfg", -1);
@@ -1659,6 +1646,78 @@ void PlayerActions::actReveal(QAction *action)
         cmd.add_card_id(card->getId());
     }
 
+    sendGameCommand(cmd);
+}
+
+void PlayerActions::actRevealHand(int revealToPlayerId)
+{
+    Command_RevealCards cmd;
+    if (revealToPlayerId != -1) {
+        cmd.set_player_id(revealToPlayerId);
+    }
+    cmd.set_zone_name("hand");
+
+    sendGameCommand(cmd);
+}
+
+void PlayerActions::actRevealRandomHandCard(int revealToPlayerId)
+{
+    Command_RevealCards cmd;
+    if (revealToPlayerId != -1) {
+        cmd.set_player_id(revealToPlayerId);
+    }
+    cmd.set_zone_name("hand");
+    cmd.add_card_id(RANDOM_CARD_FROM_ZONE);
+
+    sendGameCommand(cmd);
+}
+
+void PlayerActions::actRevealLibrary(int revealToPlayerId)
+{
+    Command_RevealCards cmd;
+    if (revealToPlayerId != -1) {
+        cmd.set_player_id(revealToPlayerId);
+    }
+    cmd.set_zone_name("deck");
+
+    sendGameCommand(cmd);
+}
+
+void PlayerActions::actLendLibrary(int lendToPlayerId)
+{
+    Command_RevealCards cmd;
+    if (lendToPlayerId != -1) {
+        cmd.set_player_id(lendToPlayerId);
+    }
+    cmd.set_zone_name("deck");
+    cmd.set_grant_write_access(true);
+
+    sendGameCommand(cmd);
+}
+
+void PlayerActions::actRevealTopCards(int revealToPlayerId, int amount)
+{
+    Command_RevealCards cmd;
+    if (revealToPlayerId != -1) {
+        cmd.set_player_id(revealToPlayerId);
+    }
+
+    cmd.set_zone_name("deck");
+    cmd.set_top_cards(amount);
+    // backward compatibility: servers before #1051 only permits to reveal the first card
+    cmd.add_card_id(0);
+
+    sendGameCommand(cmd);
+}
+
+void PlayerActions::actRevealRandomGraveyardCard(int revealToPlayerId)
+{
+    Command_RevealCards cmd;
+    if (revealToPlayerId != -1) {
+        cmd.set_player_id(revealToPlayerId);
+    }
+    cmd.set_zone_name("grave");
+    cmd.add_card_id(RANDOM_CARD_FROM_ZONE);
     sendGameCommand(cmd);
 }
 

--- a/cockatrice/src/game/player/player_actions.h
+++ b/cockatrice/src/game/player/player_actions.h
@@ -116,7 +116,9 @@ public slots:
     void actAlwaysRevealTopCard();
     void actAlwaysLookAtTopCard();
     void actViewGraveyard();
-    void actRevealRandomGraveyardCard();
+    void actLendLibrary(int lendToPlayerId);
+    void actRevealTopCards(int revealToPlayerId, int amount);
+    void actRevealRandomGraveyardCard(int revealToPlayerId);
     void actViewRfg();
     void actViewSideboard();
 
@@ -145,6 +147,9 @@ public slots:
     void actFlowT();
     void actSetAnnotation();
     void actReveal(QAction *action);
+    void actRevealHand(int revealToPlayerId);
+    void actRevealRandomHandCard(int revealToPlayerId);
+    void actRevealLibrary(int revealToPlayerId);
 
     void actSortHand();
 


### PR DESCRIPTION
…so they are always current and do not rely on playerMenu manually tracking them. Also add playerActions for previous playerListActions.

Took 1 hour 35 minutes

## Related Ticket(s)
- Fixes players sometimes not showing up in the actions.

## Short roundup of the initial problem
I'm not sure why exactly the menus had such trouble keeping the playerLists accurate (the signal emission seemed to be correct.) but that's a terrible way to do these things anyway. Now that we have uncluttered the playerMenu into separate classes, we can simply hook the aboutToShow for the relevant classes up to methods that populate these values dynamically from the Game's PlayerManager. This is much more robust and also allows us to hook signals/slots/acts up declaratively instead of with a sort of opaque switch case.

## What will change with this Pull Request?
- Nuke the playerList handling from playerMenu
- Have each menu that cares about a playerList populate its own as a response to aboutToShow()
