### PR TITLE
[Client] Handle automatic card database update process in MainWindow destructor.

### DIFF
--- a/cockatrice/src/interface/window_main.cpp
+++ b/cockatrice/src/interface/window_main.cpp
@@ -1021,6 +1021,13 @@ MainWindow::~MainWindow()
         trayIcon->deleteLater();
     }
 
+    if (cardUpdateProcess) {
+        cardUpdateProcess->disconnect(this);
+        cardUpdateProcess->terminate();
+        cardUpdateProcess->waitForFinished(1000);
+        cardUpdateProcess = nullptr;
+    }
+
     client->deleteLater();
     clientThread->wait();
 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6200

## Short roundup of the initial problem
Trice crashes because the card database update process is emitting signals when MainWindow is already being torn down.

## What will change with this Pull Request?
- For the automatic card database update process, disconnect signals, terminate and wait for it to finish on window_main destruction.
