### PR TITLE
[(V)DE] Correctly add filterWidget as a dock widget for VDE, make printingSelector visible in the default layout for DE

### DIFF
--- a/cockatrice/src/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/tabs/tab_deck_editor.cpp
@@ -203,20 +203,10 @@ void TabDeckEditor::loadLayout()
 
 void TabDeckEditor::restartLayout()
 {
-    deckDockWidget->setVisible(true);
-    cardInfoDockWidget->setVisible(true);
-    filterDockWidget->setVisible(true);
-    printingSelectorDockWidget->setVisible(false);
-
-    deckDockWidget->setFloating(false);
-    cardInfoDockWidget->setFloating(false);
-    filterDockWidget->setFloating(false);
-    printingSelectorDockWidget->setFloating(false);
-
     aCardInfoDockVisible->setChecked(true);
     aDeckDockVisible->setChecked(true);
     aFilterDockVisible->setChecked(true);
-    aPrintingSelectorDockVisible->setChecked(false);
+    aPrintingSelectorDockVisible->setChecked(true);
 
     aCardInfoDockFloating->setChecked(false);
     aDeckDockFloating->setChecked(false);
@@ -224,10 +214,20 @@ void TabDeckEditor::restartLayout()
     aPrintingSelectorDockFloating->setChecked(false);
 
     setCentralWidget(databaseDisplayDockWidget);
-    addDockWidget(static_cast<Qt::DockWidgetArea>(2), deckDockWidget);
-    addDockWidget(static_cast<Qt::DockWidgetArea>(2), cardInfoDockWidget);
-    addDockWidget(static_cast<Qt::DockWidgetArea>(2), filterDockWidget);
-    addDockWidget(static_cast<Qt::DockWidgetArea>(2), printingSelectorDockWidget);
+    addDockWidget(Qt::RightDockWidgetArea, deckDockWidget);
+    addDockWidget(Qt::RightDockWidgetArea, cardInfoDockWidget);
+    addDockWidget(Qt::RightDockWidgetArea, filterDockWidget);
+    addDockWidget(Qt::RightDockWidgetArea, printingSelectorDockWidget);
+
+    deckDockWidget->setFloating(false);
+    cardInfoDockWidget->setFloating(false);
+    filterDockWidget->setFloating(false);
+    printingSelectorDockWidget->setFloating(false);
+
+    deckDockWidget->setVisible(true);
+    cardInfoDockWidget->setVisible(true);
+    filterDockWidget->setVisible(true);
+    printingSelectorDockWidget->setVisible(true);
 
     splitDockWidget(cardInfoDockWidget, printingSelectorDockWidget, Qt::Horizontal);
     splitDockWidget(printingSelectorDockWidget, deckDockWidget, Qt::Horizontal);

--- a/cockatrice/src/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
+++ b/cockatrice/src/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
@@ -268,16 +268,6 @@ void TabDeckEditorVisual::loadLayout()
 
 void TabDeckEditorVisual::restartLayout()
 {
-    deckDockWidget->setVisible(true);
-    cardInfoDockWidget->setVisible(true);
-    filterDockWidget->setVisible(false);
-    printingSelectorDockWidget->setVisible(true);
-
-    deckDockWidget->setFloating(false);
-    cardInfoDockWidget->setFloating(false);
-    filterDockWidget->setFloating(false);
-    printingSelectorDockWidget->setFloating(false);
-
     aCardInfoDockVisible->setChecked(true);
     aDeckDockVisible->setChecked(true);
     aFilterDockVisible->setChecked(false);
@@ -289,12 +279,25 @@ void TabDeckEditorVisual::restartLayout()
     aPrintingSelectorDockFloating->setChecked(false);
 
     setCentralWidget(centralWidget);
-    addDockWidget(static_cast<Qt::DockWidgetArea>(2), deckDockWidget);
-    addDockWidget(static_cast<Qt::DockWidgetArea>(2), cardInfoDockWidget);
-    addDockWidget(static_cast<Qt::DockWidgetArea>(2), printingSelectorDockWidget);
+
+    addDockWidget(Qt::RightDockWidgetArea, deckDockWidget);
+    addDockWidget(Qt::RightDockWidgetArea, cardInfoDockWidget);
+    addDockWidget(Qt::RightDockWidgetArea, filterDockWidget);
+    addDockWidget(Qt::RightDockWidgetArea, printingSelectorDockWidget);
+
+    deckDockWidget->setFloating(false);
+    cardInfoDockWidget->setFloating(false);
+    filterDockWidget->setFloating(false);
+    printingSelectorDockWidget->setFloating(false);
+
+    deckDockWidget->setVisible(true);
+    cardInfoDockWidget->setVisible(true);
+    filterDockWidget->setVisible(false);
+    printingSelectorDockWidget->setVisible(true);
 
     splitDockWidget(cardInfoDockWidget, printingSelectorDockWidget, Qt::Vertical);
     splitDockWidget(cardInfoDockWidget, deckDockWidget, Qt::Horizontal);
+    splitDockWidget(cardInfoDockWidget, filterDockWidget, Qt::Horizontal);
 
     QTimer::singleShot(100, this, SLOT(freeDocksSize()));
 }


### PR DESCRIPTION
## Related Ticket(s)
- (Hopefully) Fixes #6213

## Short roundup of the initial problem
FiltersWidget isn't technically a DockWidget for the VDE, which can leave it in an inconsistent state when it's saved, I think?

## What will change with this Pull Request?
- Add it to the VDE as a dock widget but do hide it.
- Also make the printingSelector visible in the DE default layout, which saves users from asking "how do I select printings?" (smth smth "Show, don't tell"
