### PR TITLE
[PrintingSelector] Sync PrintingSelector availability to OverrideAllCardArtWithPersonalPreference setting.

### DIFF
--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -681,9 +681,11 @@ void AppearanceSettingsPage::overrideAllCardArtWithPersonalPreferenceToggled(QT_
         PictureLoader::clearNetworkCache(); // PixmapCache is no longer valid.
     } else {
         // If user cancels, revert the checkbox/state back
-        overrideAllCardArtWithPersonalPreferenceCheckBox.blockSignals(true);
-        overrideAllCardArtWithPersonalPreferenceCheckBox.setChecked(!enable);
-        overrideAllCardArtWithPersonalPreferenceCheckBox.blockSignals(false);
+        QTimer::singleShot(0, this, [this, enable]() {
+            overrideAllCardArtWithPersonalPreferenceCheckBox.blockSignals(true);
+            overrideAllCardArtWithPersonalPreferenceCheckBox.setChecked(!enable);
+            overrideAllCardArtWithPersonalPreferenceCheckBox.blockSignals(false);
+        });
     }
 }
 

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -678,7 +678,9 @@ void AppearanceSettingsPage::overrideAllCardArtWithPersonalPreferenceToggled(QT_
 
     if (result == QMessageBox::Yes) {
         SettingsCache::instance().setOverrideAllCardArtWithPersonalPreference(value);
-        PictureLoader::clearNetworkCache(); // PixmapCache is no longer valid.
+        // Caches are now invalid.
+        PictureLoader::clearPixmapCache();
+        PictureLoader::clearNetworkCache();
     } else {
         // If user cancels, revert the checkbox/state back
         QTimer::singleShot(0, this, [this, enable]() {

--- a/cockatrice/src/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/dialogs/dlg_settings.cpp
@@ -731,8 +731,7 @@ void AppearanceSettingsPage::retranslateUi()
     displayCardNamesCheckBox.setText(tr("Display card names on cards having a picture"));
     autoRotateSidewaysLayoutCardsCheckBox.setText(tr("Auto-Rotate cards with sideways layout"));
     overrideAllCardArtWithPersonalPreferenceCheckBox.setText(
-        tr("Override all card art with personal set preference (Pre-ProviderID change behavior) [Requires Client "
-           "restart]"));
+        tr("Override all card art with personal set preference (Pre-ProviderID change behavior)"));
     bumpSetsWithCardsInDeckToTopCheckBox.setText(
         tr("Bump sets that the deck contains cards from to the top in the printing selector"));
     cardScalingCheckBox.setText(tr("Scale cards on mouse over"));

--- a/cockatrice/src/dialogs/dlg_settings.h
+++ b/cockatrice/src/dialogs/dlg_settings.h
@@ -105,6 +105,7 @@ private slots:
     void themeBoxChanged(int index);
     void openThemeLocation();
     void showShortcutsChanged(QT_STATE_CHANGED_T enabled);
+    void overrideAllCardArtWithPersonalPreferenceToggled(QT_STATE_CHANGED_T enabled);
 
     void cardViewInitialRowsMaxChanged(int value);
     void cardViewExpandedRowsMaxChanged(int value);

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
@@ -203,7 +203,10 @@ void DeckEditorDatabaseDisplayWidget::databaseCustomMenu(QPoint point)
         QAction *addToDeck, *addToSideboard, *selectPrinting, *edhRecCommander, *edhRecCard;
         addToDeck = menu.addAction(tr("Add to Deck"));
         addToSideboard = menu.addAction(tr("Add to Sideboard"));
-        selectPrinting = menu.addAction(tr("Select Printing"));
+        if (!SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference()) {
+            selectPrinting = menu.addAction(tr("Select Printing"));
+            connect(selectPrinting, &QAction::triggered, this, [this, card] { deckEditor->showPrintingSelector(); });
+        }
         if (canBeCommander(card.getInfo())) {
             edhRecCommander = menu.addAction(tr("Show on EDHRec (Commander)"));
             connect(edhRecCommander, &QAction::triggered, this,
@@ -213,7 +216,6 @@ void DeckEditorDatabaseDisplayWidget::databaseCustomMenu(QPoint point)
 
         connect(addToDeck, &QAction::triggered, this, &DeckEditorDatabaseDisplayWidget::actAddCardToMainDeck);
         connect(addToSideboard, &QAction::triggered, this, &DeckEditorDatabaseDisplayWidget::actAddCardToSideboard);
-        connect(selectPrinting, &QAction::triggered, this, [this, card] { deckEditor->showPrintingSelector(); });
         connect(edhRecCard, &QAction::triggered, this,
                 [this, card] { deckEditor->getTabSupervisor()->addEdhrecTab(card.getCardPtr()); });
 

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -37,12 +37,14 @@ void DeckEditorDeckDockWidget::createDeckDock()
     deckView->sortByColumn(1, Qt::AscendingOrder);
     deckView->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     deckView->installEventFilter(&deckViewKeySignals);
-    deckView->setContextMenuPolicy(Qt::CustomContextMenu);
     deckView->setSelectionMode(QAbstractItemView::ExtendedSelection);
     connect(deckView->selectionModel(), &QItemSelectionModel::currentRowChanged, this,
             &DeckEditorDeckDockWidget::updateCard);
     connect(deckView, &QTreeView::doubleClicked, this, &DeckEditorDeckDockWidget::actSwapCard);
-    connect(deckView, &QTreeView::customContextMenuRequested, this, &DeckEditorDeckDockWidget::decklistCustomMenu);
+    if (!SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference()) {
+        deckView->setContextMenuPolicy(Qt::CustomContextMenu);
+        connect(deckView, &QTreeView::customContextMenuRequested, this, &DeckEditorDeckDockWidget::decklistCustomMenu);
+    }
     connect(&deckViewKeySignals, &KeySignals::onShiftS, this, &DeckEditorDeckDockWidget::actSwapCard);
     connect(&deckViewKeySignals, &KeySignals::onEnter, this, &DeckEditorDeckDockWidget::actIncrement);
     connect(&deckViewKeySignals, &KeySignals::onCtrlAltEqual, this, &DeckEditorDeckDockWidget::actIncrement);
@@ -579,9 +581,10 @@ void DeckEditorDeckDockWidget::decklistCustomMenu(QPoint point)
 {
     QMenu menu;
 
-    QAction *selectPrinting = menu.addAction(tr("Select Printing"));
-
-    connect(selectPrinting, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::showPrintingSelector);
+    if (!SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference()) {
+        QAction *selectPrinting = menu.addAction(tr("Select Printing"));
+        connect(selectPrinting, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::showPrintingSelector);
+    }
 
     menu.exec(deckView->mapToGlobal(point));
 }

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -41,10 +41,8 @@ void DeckEditorDeckDockWidget::createDeckDock()
     connect(deckView->selectionModel(), &QItemSelectionModel::currentRowChanged, this,
             &DeckEditorDeckDockWidget::updateCard);
     connect(deckView, &QTreeView::doubleClicked, this, &DeckEditorDeckDockWidget::actSwapCard);
-    if (!SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference()) {
-        deckView->setContextMenuPolicy(Qt::CustomContextMenu);
-        connect(deckView, &QTreeView::customContextMenuRequested, this, &DeckEditorDeckDockWidget::decklistCustomMenu);
-    }
+    deckView->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(deckView, &QTreeView::customContextMenuRequested, this, &DeckEditorDeckDockWidget::decklistCustomMenu);
     connect(&deckViewKeySignals, &KeySignals::onShiftS, this, &DeckEditorDeckDockWidget::actSwapCard);
     connect(&deckViewKeySignals, &KeySignals::onEnter, this, &DeckEditorDeckDockWidget::actIncrement);
     connect(&deckViewKeySignals, &KeySignals::onCtrlAltEqual, this, &DeckEditorDeckDockWidget::actIncrement);
@@ -579,14 +577,14 @@ void DeckEditorDeckDockWidget::offsetCountAtIndex(const QModelIndex &idx, int of
 
 void DeckEditorDeckDockWidget::decklistCustomMenu(QPoint point)
 {
-    QMenu menu;
-
     if (!SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference()) {
+        QMenu menu;
+
         QAction *selectPrinting = menu.addAction(tr("Select Printing"));
         connect(selectPrinting, &QAction::triggered, deckEditor, &AbstractTabDeckEditor::showPrintingSelector);
-    }
 
-    menu.exec(deckView->mapToGlobal(point));
+        menu.exec(deckView->mapToGlobal(point));
+    }
 }
 
 void DeckEditorDeckDockWidget::refreshShortcuts()

--- a/cockatrice/src/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/tabs/abstract_tab_deck_editor.cpp
@@ -49,6 +49,9 @@ AbstractTabDeckEditor::AbstractTabDeckEditor(TabSupervisor *_tabSupervisor) : Ta
     cardInfoDockWidget = new DeckEditorCardInfoDockWidget(this);
     filterDockWidget = new DeckEditorFilterDockWidget(this);
     printingSelectorDockWidget = new DeckEditorPrintingSelectorDockWidget(this);
+    connect(&SettingsCache::instance(), &SettingsCache::overrideAllCardArtWithPersonalPreferenceChanged, this, [this] {
+        printingSelectorDockWidget->setHidden(SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference());
+    });
 
     connect(deckDockWidget, &DeckEditorDeckDockWidget::deckChanged, this, &AbstractTabDeckEditor::onDeckChanged);
     connect(deckDockWidget, &DeckEditorDeckDockWidget::deckModified, this, &AbstractTabDeckEditor::onDeckModified);

--- a/cockatrice/src/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/tabs/tab_deck_editor.cpp
@@ -244,7 +244,6 @@ void TabDeckEditor::restartLayout()
     filterDockWidget->setVisible(true);
     printingSelectorDockWidget->setVisible(!SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference());
 
-
     splitDockWidget(cardInfoDockWidget, printingSelectorDockWidget, Qt::Horizontal);
     splitDockWidget(printingSelectorDockWidget, deckDockWidget, Qt::Horizontal);
     splitDockWidget(cardInfoDockWidget, printingSelectorDockWidget, Qt::Horizontal);

--- a/cockatrice/src/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/tabs/tab_deck_editor.cpp
@@ -93,6 +93,13 @@ void TabDeckEditor::createMenus()
     aPrintingSelectorDockFloating->setCheckable(true);
     connect(aPrintingSelectorDockFloating, &QAction::triggered, this, &TabDeckEditor::dockFloatingTriggered);
 
+    if (SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference()) {
+        printingSelectorDockMenu->setEnabled(false);
+    }
+
+    connect(&SettingsCache::instance(), &SettingsCache::overrideAllCardArtWithPersonalPreferenceChanged, this,
+            [this](bool enabled) { printingSelectorDockMenu->setEnabled(!enabled); });
+
     viewMenu->addSeparator();
 
     aResetLayout = viewMenu->addAction(QString());
@@ -171,6 +178,13 @@ void TabDeckEditor::loadLayout()
         restoreGeometry(layouts.getDeckEditorGeometry());
     }
 
+    if (SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference()) {
+        if (!printingSelectorDockWidget->isHidden()) {
+            printingSelectorDockWidget->setHidden(true);
+            aPrintingSelectorDockVisible->setChecked(false);
+        }
+    }
+
     aCardInfoDockVisible->setChecked(!cardInfoDockWidget->isHidden());
     aFilterDockVisible->setChecked(!filterDockWidget->isHidden());
     aDeckDockVisible->setChecked(!deckDockWidget->isHidden());
@@ -203,10 +217,11 @@ void TabDeckEditor::loadLayout()
 
 void TabDeckEditor::restartLayout()
 {
+
     aCardInfoDockVisible->setChecked(true);
     aDeckDockVisible->setChecked(true);
     aFilterDockVisible->setChecked(true);
-    aPrintingSelectorDockVisible->setChecked(true);
+    aPrintingSelectorDockVisible->setChecked(!SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference());
 
     aCardInfoDockFloating->setChecked(false);
     aDeckDockFloating->setChecked(false);
@@ -227,7 +242,8 @@ void TabDeckEditor::restartLayout()
     deckDockWidget->setVisible(true);
     cardInfoDockWidget->setVisible(true);
     filterDockWidget->setVisible(true);
-    printingSelectorDockWidget->setVisible(true);
+    printingSelectorDockWidget->setVisible(!SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference());
+
 
     splitDockWidget(cardInfoDockWidget, printingSelectorDockWidget, Qt::Horizontal);
     splitDockWidget(printingSelectorDockWidget, deckDockWidget, Qt::Horizontal);

--- a/cockatrice/src/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
+++ b/cockatrice/src/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
@@ -126,6 +126,13 @@ void TabDeckEditorVisual::createMenus()
     aPrintingSelectorDockFloating->setCheckable(true);
     connect(aPrintingSelectorDockFloating, SIGNAL(triggered()), this, SLOT(dockFloatingTriggered()));
 
+    if (SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference()) {
+        printingSelectorDockMenu->setEnabled(false);
+    }
+
+    connect(&SettingsCache::instance(), &SettingsCache::overrideAllCardArtWithPersonalPreferenceChanged, this,
+            [this](bool enabled) { printingSelectorDockMenu->setEnabled(!enabled); });
+
     viewMenu->addSeparator();
 
     aResetLayout = viewMenu->addAction(QString());
@@ -236,6 +243,13 @@ void TabDeckEditorVisual::loadLayout()
         restoreGeometry(layouts.getDeckEditorGeometry());
     }
 
+    if (SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference()) {
+        if (!printingSelectorDockWidget->isHidden()) {
+            printingSelectorDockWidget->setHidden(true);
+            aPrintingSelectorDockVisible->setChecked(false);
+        }
+    }
+
     aCardInfoDockVisible->setChecked(!cardInfoDockWidget->isHidden());
     aFilterDockVisible->setChecked(!filterDockWidget->isHidden());
     aDeckDockVisible->setChecked(!deckDockWidget->isHidden());
@@ -271,7 +285,7 @@ void TabDeckEditorVisual::restartLayout()
     aCardInfoDockVisible->setChecked(true);
     aDeckDockVisible->setChecked(true);
     aFilterDockVisible->setChecked(false);
-    aPrintingSelectorDockVisible->setChecked(true);
+    aPrintingSelectorDockVisible->setChecked(!SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference());
 
     aCardInfoDockFloating->setChecked(false);
     aDeckDockFloating->setChecked(false);
@@ -279,21 +293,20 @@ void TabDeckEditorVisual::restartLayout()
     aPrintingSelectorDockFloating->setChecked(false);
 
     setCentralWidget(centralWidget);
-
     addDockWidget(Qt::RightDockWidgetArea, deckDockWidget);
     addDockWidget(Qt::RightDockWidgetArea, cardInfoDockWidget);
     addDockWidget(Qt::RightDockWidgetArea, filterDockWidget);
     addDockWidget(Qt::RightDockWidgetArea, printingSelectorDockWidget);
 
+    deckDockWidget->setVisible(true);
+    cardInfoDockWidget->setVisible(true);
+    filterDockWidget->setVisible(false);
+    printingSelectorDockWidget->setVisible(!SettingsCache::instance().getOverrideAllCardArtWithPersonalPreference());
+
     deckDockWidget->setFloating(false);
     cardInfoDockWidget->setFloating(false);
     filterDockWidget->setFloating(false);
     printingSelectorDockWidget->setFloating(false);
-
-    deckDockWidget->setVisible(true);
-    cardInfoDockWidget->setVisible(true);
-    filterDockWidget->setVisible(false);
-    printingSelectorDockWidget->setVisible(true);
 
     splitDockWidget(cardInfoDockWidget, printingSelectorDockWidget, Qt::Vertical);
     splitDockWidget(cardInfoDockWidget, deckDockWidget, Qt::Horizontal);


### PR DESCRIPTION
## Short roundup of the initial problem
If a user has OverrideAllCardArtWithPersonalPreference enabled, they can still use the PrintingSelector, which will then populate the individual set cache entries with: One and the same picture OR simply ignore the cached values and load the set preference, which results in one and the same: The user sees only one printing for every set variation.
It seems that sometimes these cache entries gets stuck.

## What will change with this Pull Request?
- Clearly warn users about disabling the providerId change and the consequences (and vice-versa)
-  Link PrintingSelector visibility and availability to the setting.
-  clear the networkCache when this setting is toggled to fix stuck images.

## Screenshots

Setting disabled, Printing Selector visible:
<img width="2559" height="1409" alt="image" src="https://github.com/user-attachments/assets/b8bbe702-5a89-4c1c-9a48-b9b24b7ea4b1" />

Toggle setting enabled:
<img width="701" height="718" alt="image" src="https://github.com/user-attachments/assets/e57e16cf-2d3b-49d3-a2c1-31732892b0da" />

Setting enabled, Printing Selector invisible:
<img width="2558" height="1409" alt="image" src="https://github.com/user-attachments/assets/db6e1a80-e076-4275-bedf-cba7ae86231d" />

Toggle setting disabled (goes back to screenshot 1):
<img width="703" height="716" alt="image" src="https://github.com/user-attachments/assets/ad2f3ae0-eb95-49d6-b931-2cf8aa092ad5" />
