### PR TITLE
build: target macos 13 for x86 binaries

### DIFF
--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -11,7 +11,7 @@
 # --debug or --release sets the build type ie CMAKE_BUILD_TYPE
 # --ccache [<size>] uses ccache and shows stats, optionally provide size
 # --dir <dir> sets the name of the build dir, default is "build"
-# --x86-macos
+# --x86-macos sets the min os version to 13.0 - only used for Intel builds
 # uses env: BUILDTYPE MAKE_INSTALL MAKE_PACKAGE PACKAGE_TYPE PACKAGE_SUFFIX MAKE_SERVER MAKE_TEST USE_CCACHE CCACHE_SIZE BUILD_DIR CMAKE_GENERATOR
 # (correspond to args: --debug/--release --install --package <package type> --suffix <suffix> --server --test --ccache <ccache_size> --dir <dir>)
 # exitcode: 1 for failure, 3 for invalid arguments
@@ -78,11 +78,7 @@ while [[ $# != 0 ]]; do
       ;;
     '--x86-macos')
       shift
-      if [[ $# == 0 ]]; then
-        echo "::error file=$0::--x86-macos expects an argument"
-        exit 3
-      fi
-      x86_MACOS="$1"
+      X86_MACOS=1
       shift
       ;;
     *)
@@ -126,7 +122,7 @@ fi
 if [[ $PACKAGE_TYPE ]]; then
   flags+=("-DCPACK_GENERATOR=$PACKAGE_TYPE")
 fi
-if [[ $x86_MACOS == true ]]; then
+if [[ $X86_MACOS ]]; then
   flags+=("-DCMAKE_OSX_DEPLOYMENT_TARGET=13.0")
   flags+=("-DVCPKG_TARGET_TRIPLET=x64-osx-13")
   flags+=("-DVCPKG_OVERLAY_TRIPLETS=../cmake/triplets")

--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -11,7 +11,7 @@
 # --debug or --release sets the build type ie CMAKE_BUILD_TYPE
 # --ccache [<size>] uses ccache and shows stats, optionally provide size
 # --dir <dir> sets the name of the build dir, default is "build"
-# --x86-macos sets the min os version to 13.0 - only used for Intel builds
+# --target-x86-macos sets the min os version to 13.0 - only used for Intel builds
 # uses env: BUILDTYPE MAKE_INSTALL MAKE_PACKAGE PACKAGE_TYPE PACKAGE_SUFFIX MAKE_SERVER MAKE_TEST USE_CCACHE CCACHE_SIZE BUILD_DIR CMAKE_GENERATOR
 # (correspond to args: --debug/--release --install --package <package type> --suffix <suffix> --server --test --ccache <ccache_size> --dir <dir>)
 # exitcode: 1 for failure, 3 for invalid arguments
@@ -76,9 +76,9 @@ while [[ $# != 0 ]]; do
       BUILD_DIR="$1"
       shift
       ;;
-    '--x86-macos')
+    '--target-x86-macos')
       shift
-      X86_MACOS=1
+      TARGET_X86_MACOS=1
       shift
       ;;
     *)
@@ -122,7 +122,7 @@ fi
 if [[ $PACKAGE_TYPE ]]; then
   flags+=("-DCPACK_GENERATOR=$PACKAGE_TYPE")
 fi
-if [[ $X86_MACOS ]]; then
+if [[ $TARGET_X86_MACOS ]]; then
   flags+=("-DCMAKE_OSX_DEPLOYMENT_TARGET=13.0")
   flags+=("-DVCPKG_TARGET_TRIPLET=x64-osx-13")
   flags+=("-DVCPKG_OVERLAY_TRIPLETS=../cmake/triplets")

--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -11,6 +11,7 @@
 # --debug or --release sets the build type ie CMAKE_BUILD_TYPE
 # --ccache [<size>] uses ccache and shows stats, optionally provide size
 # --dir <dir> sets the name of the build dir, default is "build"
+# --x86-macos
 # uses env: BUILDTYPE MAKE_INSTALL MAKE_PACKAGE PACKAGE_TYPE PACKAGE_SUFFIX MAKE_SERVER MAKE_TEST USE_CCACHE CCACHE_SIZE BUILD_DIR CMAKE_GENERATOR
 # (correspond to args: --debug/--release --install --package <package type> --suffix <suffix> --server --test --ccache <ccache_size> --dir <dir>)
 # exitcode: 1 for failure, 3 for invalid arguments
@@ -75,6 +76,15 @@ while [[ $# != 0 ]]; do
       BUILD_DIR="$1"
       shift
       ;;
+    '--x86-macos')
+      shift
+      if [[ $# == 0 ]]; then
+        echo "::error file=$0::--x86-macos expects an argument"
+        exit 3
+      fi
+      x86_MACOS="$1"
+      shift
+      ;;
     *)
       echo "::error file=$0::unrecognized option: $1"
       exit 3
@@ -115,6 +125,11 @@ if [[ $USE_CCACHE ]]; then
 fi
 if [[ $PACKAGE_TYPE ]]; then
   flags+=("-DCPACK_GENERATOR=$PACKAGE_TYPE")
+fi
+if [[ $x86_MACOS == true ]]; then
+  flags+=("-DCMAKE_OSX_DEPLOYMENT_TARGET=13.0")
+  flags+=("-DVCPKG_TARGET_TRIPLET=x64-osx-13")
+  flags+=("-DVCPKG_OVERLAY_TRIPLETS=../cmake/triplets")
 fi
 
 # Add cmake --build flags

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -319,7 +319,7 @@ jobs:
           VCPKG_DISABLE_METRICS: 1
           VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'
           VCPKG_OSX_DEPLOYMENT_TARGET: ${{ matrix.soc == 'Intel' && '13.0' || '' }}
-        run: .ci/compile.sh --server --test --ccache "$CCACHE_SIZE" --x86-macos ${{ matrix.soc == 'Intel' }}
+        run: .ci/compile.sh --server --test --ccache "$CCACHE_SIZE" ${{ matrix.soc == 'Intel' && '--x86-macos' || '' }}
 
       - name: Sign app bundle
         if: matrix.make_package && (github.ref == 'refs/heads/master' || needs.configure.outputs.tag != null)

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -232,8 +232,8 @@ jobs:
         include:
           - target: 13
             soc: Intel
-            os: macos-13
-            xcode: "14.3.1"
+            os: macos-15-intel
+            xcode: "16.4"
             type: Release
             make_package: 1
 
@@ -272,6 +272,15 @@ jobs:
       DEVELOPER_DIR:
         /Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer
       CMAKE_GENERATOR: 'Ninja'
+      BUILDTYPE: '${{matrix.type}}'
+      MAKE_PACKAGE: '${{matrix.make_package}}'
+      PACKAGE_SUFFIX: '-macOS${{matrix.target}}_${{matrix.soc}}'
+      MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
+      MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
+      MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
+      MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
+      VCPKG_DISABLE_METRICS: 1
+      VCPKG_BUILD_TYPE: 'release'
 
     steps:
       - name: Checkout
@@ -293,7 +302,7 @@ jobs:
       - name: Install Qt ${{env.QT_VERSION}}
         uses: jurplel/install-qt-action@v4
         with:
-          cache: false # qt caches take too much space for macOS (1.1Gi)
+          cache: true # qt caches take too much space for macOS (1.1Gi)
           version: ${{env.QT_VERSION}}
           arch: ${{env.QT_ARCH}}
           modules: ${{env.QT_MODULES}}
@@ -308,17 +317,9 @@ jobs:
         shell: bash
         id: build
         env:
-          BUILDTYPE: '${{matrix.type}}'
-          MAKE_PACKAGE: '${{matrix.make_package}}'
-          PACKAGE_SUFFIX: '-macOS${{matrix.target}}_${{matrix.soc}}'
-          MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
-          MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
-          MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
-          MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
-          CMAKE_GENERATOR: '${{env.CMAKE_GENERATOR}}'
-          VCPKG_DISABLE_METRICS: 1
           VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'
-        run: .ci/compile.sh --server --test --ccache "$CCACHE_SIZE"
+          VCPKG_OSX_DEPLOYMENT_TARGET: ${{ matrix.soc == 'Intel' && '13.0' || '' }}
+        run: .ci/compile.sh --server --test --ccache "$CCACHE_SIZE" --x86-macos ${{ matrix.soc == 'Intel' }}
 
       - name: Sign app bundle
         if: matrix.make_package && (github.ref == 'refs/heads/master' || needs.configure.outputs.tag != null)
@@ -455,6 +456,7 @@ jobs:
           CMAKE_GENERATOR_PLATFORM: 'x64'
           QTDIR: '${{github.workspace}}\Qt\${{matrix.qt_version}}\win64_${{matrix.qt_arch}}'
           VCPKG_DISABLE_METRICS: 1
+          VCPKG_BUILD_TYPE: 'release'
           VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'
         # No need for --parallel flag, MTT is added in the compile script to let cmake/msbuild manage core count,
         # project and process parallelism: https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -272,15 +272,6 @@ jobs:
       DEVELOPER_DIR:
         /Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer
       CMAKE_GENERATOR: 'Ninja'
-      BUILDTYPE: '${{matrix.type}}'
-      MAKE_PACKAGE: '${{matrix.make_package}}'
-      PACKAGE_SUFFIX: '-macOS${{matrix.target}}_${{matrix.soc}}'
-      MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
-      MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
-      MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
-      MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
-      VCPKG_DISABLE_METRICS: 1
-      VCPKG_BUILD_TYPE: 'release'
 
     steps:
       - name: Checkout
@@ -317,6 +308,15 @@ jobs:
         shell: bash
         id: build
         env:
+          BUILDTYPE: '${{matrix.type}}'
+          MAKE_PACKAGE: '${{matrix.make_package}}'
+          PACKAGE_SUFFIX: '-macOS${{matrix.target}}_${{matrix.soc}}'
+          MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
+          MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
+          MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
+          CMAKE_GENERATOR: '${{env.CMAKE_GENERATOR}}'
+          VCPKG_DISABLE_METRICS: 1
           VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'
           VCPKG_OSX_DEPLOYMENT_TARGET: ${{ matrix.soc == 'Intel' && '13.0' || '' }}
         run: .ci/compile.sh --server --test --ccache "$CCACHE_SIZE" --x86-macos ${{ matrix.soc == 'Intel' }}
@@ -456,7 +456,6 @@ jobs:
           CMAKE_GENERATOR_PLATFORM: 'x64'
           QTDIR: '${{github.workspace}}\Qt\${{matrix.qt_version}}\win64_${{matrix.qt_arch}}'
           VCPKG_DISABLE_METRICS: 1
-          VCPKG_BUILD_TYPE: 'release'
           VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'
         # No need for --parallel flag, MTT is added in the compile script to let cmake/msbuild manage core count,
         # project and process parallelism: https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -318,7 +318,6 @@ jobs:
           CMAKE_GENERATOR: '${{env.CMAKE_GENERATOR}}'
           VCPKG_DISABLE_METRICS: 1
           VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'
-          VCPKG_OSX_DEPLOYMENT_TARGET: ${{ matrix.soc == 'Intel' && '13.0' || '' }}
         run: .ci/compile.sh --server --test --ccache "$CCACHE_SIZE" ${{ matrix.soc == 'Intel' && '--x86-macos' || '' }}
 
       - name: Sign app bundle

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -247,14 +247,14 @@ jobs:
           - target: 15
             soc: Apple
             os: macos-15
-            xcode: "16.2"
+            xcode: "16.4"
             type: Release
             make_package: 1
 
           - target: 15
             soc: Apple
             os: macos-15
-            xcode: "16.2"
+            xcode: "16.4"
             type: Debug
 
     name: macOS ${{matrix.target}}${{ matrix.soc == 'Intel' && ' Intel' || '' }}${{ matrix.type == 'Debug' && ' Debug' || '' }}

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -293,7 +293,7 @@ jobs:
       - name: Install Qt ${{env.QT_VERSION}}
         uses: jurplel/install-qt-action@v4
         with:
-          cache: true # qt caches take too much space for macOS (1.1Gi)
+          cache: false # qt caches take too much space for macOS (1.1Gi)
           version: ${{env.QT_VERSION}}
           arch: ${{env.QT_ARCH}}
           modules: ${{env.QT_MODULES}}
@@ -318,7 +318,7 @@ jobs:
           CMAKE_GENERATOR: '${{env.CMAKE_GENERATOR}}'
           VCPKG_DISABLE_METRICS: 1
           VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'
-        run: .ci/compile.sh --server --test --ccache "$CCACHE_SIZE" ${{ matrix.soc == 'Intel' && '--x86-macos' || '' }}
+        run: .ci/compile.sh --server --test --ccache "$CCACHE_SIZE" ${{ matrix.soc == 'Intel' && '--target-x86-macos' || '' }}
 
       - name: Sign app bundle
         if: matrix.make_package && (github.ref == 'refs/heads/master' || needs.configure.outputs.tag != null)

--- a/cmake/triplets/x64-osx-13.cmake
+++ b/cmake/triplets/x64-osx-13.cmake
@@ -1,0 +1,12 @@
+# copied from vcpkg/triplets/x64-osx.cmake
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_ARCHITECTURES x86_64)
+# end of copied code
+
+# Set the minimum macOS version for all dependencies
+set(VCPKG_CMAKE_SYSTEM_VERSION 13.0)
+set(VCPKG_OSX_DEPLOYMENT_TARGET 13.0)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes cockatrice#6186

## Short roundup of the initial problem
GH's macos-13 runners, which are x86-based will be deprecated December 4th. The alternative offered is to use macos-15-intel runners. We want to keep supporting older Intel macs that are able to run macos 13. 


## What will change with this Pull Request?
- the macos 13 (intel/x86) build will now use the macos-15-intel runner using some flags to target macos 13
- introduce a vcpkg triplet file to build vcpkg dependencies targeting macos 13 
- update xcode of macos 15 builds to 16.4

## Output
```
/Applications/cockatrice.app/Contents/MacOS  vtool -show-build cockatrice
cockatrice:
Load command 11
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform MACOS
    minos 13.0
      sdk 15.5
   ntools 1
     tool LD
  version 1167.5
```

```
/Applications/cockatrice.app/Contents/MacOS  file cockatrice 
cockatrice: Mach-O 64-bit executable x86_64
```

## Todo
- [ ] Manual testing on x86 macos 13
- [x] Manual testing on arm macos 26
