### PR TITLE
Don't use vcpkg on local macOS

### DIFF
--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -66,6 +66,10 @@ while [[ $# != 0 ]]; do
         shift
       fi
       ;;
+    '--vcpkg')
+      USE_VCPKG=1
+      shift
+      ;;
     '--dir')
       shift
       if [[ $# == 0 ]]; then
@@ -115,6 +119,9 @@ if [[ $USE_CCACHE ]]; then
 fi
 if [[ $PACKAGE_TYPE ]]; then
   flags+=("-DCPACK_GENERATOR=$PACKAGE_TYPE")
+fi
+if [[ $USE_VCPKG ]]; then
+  flags+=("-DUSE_VCPKG=1")
 fi
 
 # Add cmake --build flags

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -318,7 +318,7 @@ jobs:
           CMAKE_GENERATOR: '${{env.CMAKE_GENERATOR}}'
           VCPKG_DISABLE_METRICS: 1
           VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'
-        run: .ci/compile.sh --server --test --ccache "$CCACHE_SIZE" --use-vcpkg
+        run: .ci/compile.sh --server --test --ccache "$CCACHE_SIZE" --vcpkg
 
       - name: Sign app bundle
         if: matrix.make_package && (github.ref == 'refs/heads/master' || needs.configure.outputs.tag != null)

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -318,7 +318,7 @@ jobs:
           CMAKE_GENERATOR: '${{env.CMAKE_GENERATOR}}'
           VCPKG_DISABLE_METRICS: 1
           VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'
-        run: .ci/compile.sh --server --test --ccache "$CCACHE_SIZE"
+        run: .ci/compile.sh --server --test --ccache "$CCACHE_SIZE" --use-vcpkg
 
       - name: Sign app bundle
         if: matrix.make_package && (github.ref == 'refs/heads/master' || needs.configure.outputs.tag != null)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ option(WITH_ORACLE "build oracle" ON)
 option(WITH_DBCONVERTER "build dbconverter" ON)
 # Compile tests
 option(TEST "build tests" OFF)
+# Use vcpkg regardless of OS
+option(USE_VCPKG "Use vcpkg regardless of OS" OFF)
 
 # Default to "Release" build type
 # User-provided value for CMAKE_BUILD_TYPE must be checked before the PROJECT() call
@@ -48,8 +50,8 @@ if(USE_CCACHE)
   endif()
 endif()
 
-if(WIN32 OR APPLE)
-  # Use vcpkg toolchain on Windows and macOS
+if(WIN32 OR USE_VCPKG)
+  # Use vcpkg toolchain on Windows (and on macOS in CI)
   set(CMAKE_TOOLCHAIN_FILE
       ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake
       CACHE STRING "Vcpkg toolchain file"


### PR DESCRIPTION
## Related Ticket(s)
- Fixes issue introduced by #6170

## Short roundup of the initial problem

With the changes to use vcpkg for mac in CI, mac in local also uses vcpkg by default now.
We would prefer mac in local to still use homebrew by default.

## What will change with this Pull Request?

- Add `USE_VCPKG` option to cmake
- Use vcpkg only if OS is windows OR `USE_VCPKG` is enabled
  - That way mac still uses homebrew by default
- Update CI to run mac with `USE_VCPKG` enabled