### PR TITLE
Fix unattach shortcut not working at all in remote games

### DIFF
--- a/cockatrice/src/game/player/menu/card_menu.cpp
+++ b/cockatrice/src/game/player/menu/card_menu.cpp
@@ -489,12 +489,4 @@ void CardMenu::setShortcutsActive()
         aRemoveCounter[i]->setShortcuts(shortcuts.getShortcut("Player/aRC" + colorWords[i]));
         aSetCounter[i]->setShortcuts(shortcuts.getShortcut("Player/aSC" + colorWords[i]));
     }
-
-    // Don't enable always-active shortcuts in local games, since it causes keyboard shortcuts to work inconsistently
-    // when there are more than 1 player.
-    if (!player->getGame()->getGameState()->getIsLocalGame()) {
-        // unattach action is only active in card menu if the active card is attached.
-        // make unattach shortcut always active so that it consistently works when multiple cards are selected.
-        player->getGame()->getTab()->addAction(aUnattach);
-    }
 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #6112 and #6121
- Undoes fix in #5278

## Short roundup of the initial problem

The unattach shortcut doesn't work at all in remote games. 

The refactor caused the hack in #5278 to no longer work, and in fact causes the shortcut to not work at all.

This is because the hack previously relied on the fact that there's only a single `aUnattach` instance. If the same `QAction` instance is added to a widget multiple times, it will no-op, so we were safe to try to add the `aUnattach` instance to the `TabGame` on every shortcut refresh, in order to make the action always present.

However, after the refactor, a new `QAction` instance is created every time the menu is updated, which means it will cause multiple unattach actions to be added to the `TabGame`. This then causes multiple actions with the same shortcut to be active, which then prevents the shortcut from working due to conflicts.

## What will change with this Pull Request?
- Remove the workaround introduced in #5278.

This does mean that the shortcut no longer works unless you exactly select attached cards. However, since the shortcut doesn't work at all right now, we should at least get the shortcut working occasionally. 

We can figure out a way to make the shortcut always active again later.
