### PR TITLE
Consolidate closeReplay action into leaveGame

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -323,10 +323,11 @@ void TabGame::retranslateUi()
         }
     }
     if (aLeaveGame) {
-        aLeaveGame->setText(tr("&Leave game"));
-    }
-    if (aCloseReplay) {
-        aCloseReplay->setText(tr("C&lose replay"));
+        if (replayManager->replay) {
+            aLeaveGame->setText(tr("C&lose replay"));
+        } else {
+            aLeaveGame->setText(tr("&Leave game"));
+        }
     }
     if (aFocusChat) {
         aFocusChat->setText(tr("&Focus Chat"));
@@ -443,9 +444,6 @@ void TabGame::refreshShortcuts()
     }
     if (aLeaveGame) {
         aLeaveGame->setShortcuts(shortcuts.getShortcut("Player/aLeaveGame"));
-    }
-    if (aCloseReplay) {
-        aCloseReplay->setShortcuts(shortcuts.getShortcut("Player/aCloseReplay"));
     }
     if (aResetLayout) {
         aResetLayout->setShortcuts(shortcuts.getShortcut("Player/aResetLayout"));
@@ -979,7 +977,6 @@ void TabGame::createMenuItems()
     connect(aLeaveGame, &QAction::triggered, this, &TabGame::closeRequest);
     aFocusChat = new QAction(this);
     connect(aFocusChat, &QAction::triggered, sayEdit, qOverload<>(&LineEditCompleter::setFocus));
-    aCloseReplay = nullptr;
 
     phasesMenu = new TearOffMenu(this);
 
@@ -1029,13 +1026,12 @@ void TabGame::createReplayMenuItems()
     aGameInfo = nullptr;
     aConcede = nullptr;
     aFocusChat = nullptr;
-    aLeaveGame = nullptr;
-    aCloseReplay = new QAction(this);
-    connect(aCloseReplay, &QAction::triggered, this, &TabGame::closeRequest);
+    aLeaveGame = new QAction(this);
+    connect(aLeaveGame, &QAction::triggered, this, &TabGame::closeRequest);
 
     phasesMenu = nullptr;
     gameMenu = new QMenu(this);
-    gameMenu->addAction(aCloseReplay);
+    gameMenu->addAction(aLeaveGame);
 
     aCardMenu = nullptr;
 

--- a/cockatrice/src/interface/widgets/tabs/tab_game.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.h
@@ -83,8 +83,8 @@ private:
     QAction *playersSeparator;
     QMenu *gameMenu, *viewMenu, *cardInfoDockMenu, *messageLayoutDockMenu, *playerListDockMenu, *replayDockMenu;
     TearOffMenu *phasesMenu;
-    QAction *aGameInfo, *aConcede, *aLeaveGame, *aCloseReplay, *aNextPhase, *aNextPhaseAction, *aNextTurn,
-        *aReverseTurn, *aRemoveLocalArrows, *aRotateViewCW, *aRotateViewCCW, *aResetLayout, *aResetReplayLayout;
+    QAction *aGameInfo, *aConcede, *aLeaveGame, *aNextPhase, *aNextPhaseAction, *aNextTurn, *aReverseTurn,
+        *aRemoveLocalArrows, *aRotateViewCW, *aRotateViewCCW, *aResetLayout, *aResetReplayLayout;
     QAction *aCardInfoDockVisible, *aCardInfoDockFloating, *aMessageLayoutDockVisible, *aMessageLayoutDockFloating,
         *aPlayerListDockVisible, *aPlayerListDockFloating, *aReplayDockVisible, *aReplayDockFloating;
     QAction *aFocusChat;


### PR DESCRIPTION
## Short roundup of the initial problem

There is no shortcut for the "close replay" action.

Also, we have separate `aLeaveGame` and `aCloseReplay` actions, despite them sharing the exact same logic, and never appearing together.

## What will change with this Pull Request?
- Remove `aCloseReplay` and just use `aLeaveGame` for everything
  - Set the text to either "Close replay" or "Leave game" depending on presence of replay

As a side effect, this allows the "close replay" action to have the same shortcut as leave game.

## Screenshots

https://github.com/user-attachments/assets/ad56f436-3776-4442-8fd4-43ab0869c1d3

