### PR TITLE
allow oracle to run in background with direct xml downloads

### DIFF
--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -637,13 +637,13 @@ void SaveSetsPage::initializePage()
     retranslateUi();
     if (wizard()->downloadedPlainXml) {
         messageLog->hide();
-        return;
-    }
-    messageLog->show();
-    connect(wizard()->importer, &OracleImporter::setIndexChanged, this, &SaveSetsPage::updateTotalProgress);
+    } else {
+        messageLog->show();
+        connect(wizard()->importer, &OracleImporter::setIndexChanged, this, &SaveSetsPage::updateTotalProgress);
 
-    if (!wizard()->importer->startImport()) {
-        QMessageBox::critical(this, tr("Error"), tr("No set has been imported."));
+        if (!wizard()->importer->startImport()) {
+            QMessageBox::critical(this, tr("Error"), tr("No set has been imported."));
+        }
     }
 
     if (wizard()->backgroundMode) {


### PR DESCRIPTION
## Related Ticket(s)
- #6004

## Short roundup of the initial problem
when downloading an xml directly in oracle's background mode it'd stall indefinitely as the function would return early in the success page

## What will change with this Pull Request?
- no longer return early, put the other stuff in else statement