### PR TITLE
Fix names in qtlogging.ini

### DIFF
--- a/cockatrice/resources/config/qtlogging.ini
+++ b/cockatrice/resources/config/qtlogging.ini
@@ -37,12 +37,14 @@
 #card_zone = true
 #view_zone = true
 
+#game_event_handler = true
+
 #user_info_connection = true
 
-#picture_loader = true
-#picture_loader.worker = true
-#picture_loader.card_back_cache_fail = true
-#picture_loader.picture_to_load = true
+#card_picture_loader = true
+#card_picture_loader.worker = true
+#card_picture_loader.card_back_cache_fail = true
+#card_picture_loader.picture_to_load = true
 #deck_loader = true
 #card_database = true
 #card_database.loading = true

--- a/cockatrice/src/game/game_event_handler.h
+++ b/cockatrice/src/game/game_event_handler.h
@@ -40,7 +40,7 @@ class AbstractGame;
 class PendingCommand;
 class Player;
 
-inline Q_LOGGING_CATEGORY(GameEventHandlerLog, "tab_game");
+inline Q_LOGGING_CATEGORY(GameEventHandlerLog, "game_event_handler");
 
 class GameEventHandler : public QObject
 {


### PR DESCRIPTION
## Related Ticket(s)
- Fixes issue introduced by #6212

## Short roundup of the initial problem

- The `picture_loader` log names got changed in the class but didn't get changed in `qtlogging.ini` 
- `GameEventHandler` has the wrong log name

## What will change with this Pull Request?

- Update the `picture_loader` log names in `qtlogging.ini`
- Fix `GameEventHandler` log name
