### PR TITLE
[Lobby] Fix opponent deck views not updating card info widget

### DIFF
--- a/cockatrice/src/game/deckview/tabbed_deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/tabbed_deck_view_container.cpp
@@ -21,6 +21,8 @@ void TabbedDeckViewContainer::addOpponentDeckView(const DeckList &opponentDeck, 
         opponentDeckViews[opponentId]->setDeck(opponentDeck);
     } else {
         auto *opponentDeckView = new DeckView(this);
+        connect(opponentDeckView, &DeckView::newCardAdded, playerDeckView, &DeckViewContainer::newCardAdded);
+
         opponentDeckView->setDeck(opponentDeck);
 
         addTab(opponentDeckView, QString("%1's Deck").arg(opponentName));


### PR DESCRIPTION
## Short roundup of the initial problem
Hovering over an opponents card in an open decklist lobby does not update the card info widgets.

## What will change with this Pull Request?
- Forward opponent deck view signals to deck view container as well instead of just the player deck view signals.

## Screenshots
<img width="1261" height="934" alt="image" src="https://github.com/user-attachments/assets/9fe77337-f48a-4b43-92be-edfcdda045c4" />

