### PR TITLE
don't close dm tabs when disconnecting

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
@@ -491,10 +491,6 @@ void TabSupervisor::stop()
         tabsToDelete << i.value();
     }
 
-    for (auto i = messageTabs.cbegin(), end = messageTabs.cend(); i != end; ++i) {
-        tabsToDelete << i.value();
-    }
-
     for (const auto tab : tabsToDelete) {
         tab->close();
     }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6249
- #5447 and #5450

## Short roundup of the initial problem
when disconnecting no message history is preserved, keeping message tabs open allows users to more easily resume conversations between disconnects.

## What will change with this Pull Request?
- do not delete message tabs on disconnect