### PR TITLE
[VDE] Fix group by checkbox no longer working

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.h
@@ -41,6 +41,10 @@ public:
     {
         return nameEdit->text().simplified();
     }
+    QComboBox *getGroupByComboBox()
+    {
+        return activeGroupCriteriaComboBox;
+    }
 
 public slots:
     void cleanDeck();

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
@@ -60,6 +60,11 @@ public:
     DeckLoader *getDeckList() const;
     void setModified(bool _windowModified);
 
+    DeckEditorDeckDockWidget *getDeckDockWidget() const
+    {
+        return deckDockWidget;
+    }
+
     // UI Elements
     DeckEditorMenu *deckMenu;
     DeckEditorDatabaseDisplayWidget *databaseDisplayDockWidget;


### PR DESCRIPTION
## Short roundup of the initial problem
 #5931 introduced a proper way to group a deck_list_model internally and also a combobox for the deck editor dock widget that exposes this. #6100, in response to #5981, brought VDE somewhat in line with this, making VDE at least respond to the correct modelReset signal and also taking away VDE's right to group the model itself.

However, the old "group by" combo box in the VDE was never updated to properly use the granular deck list signals and group the way the deck editor dock widget combo box does.

## What will change with this Pull Request?
- Sync up Visual Deck Editor group by combo box to Deck Editor Dock Widget combo box.