### PR TITLE
Fix crash on rejoining game when reconnecting.

### DIFF
--- a/cockatrice/src/interface/card_picture_loader/card_picture_to_load.cpp
+++ b/cockatrice/src/interface/card_picture_loader/card_picture_to_load.cpp
@@ -1,7 +1,6 @@
 #include "card_picture_to_load.h"
 
 #include "../../client/settings/cache_settings.h"
-#include "libcockatrice/interfaces/noop_card_set_priority_controller.h"
 
 #include <QCoreApplication>
 #include <QDate>
@@ -9,6 +8,7 @@
 #include <QUrl>
 #include <algorithm>
 #include <libcockatrice/card/set/card_set_comparator.h>
+#include <libcockatrice/interfaces/noop_card_set_priority_controller.h>
 
 CardPictureToLoad::CardPictureToLoad(const ExactCard &_card)
     : card(_card), urlTemplates(SettingsCache::instance().downloads().getAllURLs())


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem
SettingsCache isn't initialized yet, I guess. In any case, this dummy set can safely always have a NoopCardPriorityController, since it is just a dummy.

## What will change with this Pull Request?
- this
- and this

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
