### PR TITLE
Set DeckList parent when ownership changes

### DIFF
--- a/cockatrice/src/interface/deck_loader/deck_loader.cpp
+++ b/cockatrice/src/interface/deck_loader/deck_loader.cpp
@@ -33,6 +33,7 @@ DeckLoader::DeckLoader(QObject *parent)
 DeckLoader::DeckLoader(QObject *parent, DeckList *_deckList)
     : QObject(parent), deckList(_deckList), lastFileFormat(CockatriceFormat), lastRemoteDeckId(-1)
 {
+    deckList->setParent(this);
 }
 
 DeckLoader::DeckLoader(const DeckLoader &other)
@@ -44,6 +45,7 @@ DeckLoader::DeckLoader(const DeckLoader &other)
 void DeckLoader::setDeckList(DeckList *_deckList)
 {
     deckList = _deckList;
+    deckList->setParent(this);
 }
 
 bool DeckLoader::loadFromFile(const QString &fileName, FileFormat fmt, bool userRequest)

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -375,6 +375,7 @@ void DeckEditorDeckDockWidget::syncBannerCardComboBoxSelectionWithDeck()
 void DeckEditorDeckDockWidget::setDeck(DeckLoader *_deck)
 {
     deckLoader = _deck;
+    deckLoader->setParent(this);
     deckModel->setDeckList(deckLoader->getDeckList());
     connect(deckLoader, &DeckLoader::deckLoaded, deckModel, &DeckListModel::rebuildTree);
     connect(deckLoader->getDeckList(), &DeckList::deckHashChanged, deckModel, &DeckListModel::deckHashChanged);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes crash when saving a deck loaded from clipboard

## Short roundup of the initial problem
Stuff isn't initialized and thus leads to an NPE on access.

## What will change with this Pull Request?
- this
- and this

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
