### PR TITLE
Fix crash when changing shortcut in game

### DIFF
--- a/cockatrice/src/game/board/abstract_counter.cpp
+++ b/cockatrice/src/game/board/abstract_counter.cpp
@@ -85,9 +85,13 @@ void AbstractCounter::retranslateUi()
 
 void AbstractCounter::setShortcutsActive()
 {
+    if (!menu) {
+        return;
+    }
     if (!player->getPlayerInfo()->getLocal()) {
         return;
     }
+
     ShortcutsSettings &shortcuts = SettingsCache::instance().shortcuts();
     if (name == "life") {
         shortcutActive = true;
@@ -104,6 +108,10 @@ void AbstractCounter::setShortcutsActive()
 
 void AbstractCounter::setShortcutsInactive()
 {
+    if (!menu) {
+        return;
+    }
+
     shortcutActive = false;
     if (name == "life" || useNameForShortcut) {
         aSet->setShortcut(QKeySequence());


### PR DESCRIPTION
## Related Ticket(s)
- Fixes issue introduced in #6112

## Short roundup of the initial problem

Cockatrice occasionally segfaults when you edit the shortcut settings while in a game.

The opponent's `AbstractCounter` have their QAction fields null. Changing the shortcuts will cause `setShortcutActive` or `setShortcutInactive` to get called on the opponent's `AbstractCounter`, which then segfaults due to trying to access the null QActions.

## What will change with this Pull Request?
- Null check in `setShortcutActive` and `setShortcutInactive`
