### PR TITLE
[Home Tab] Don't add connect button with stretch

### DIFF
--- a/cockatrice/src/interface/widgets/general/home_widget.cpp
+++ b/cockatrice/src/interface/widgets/general/home_widget.cpp
@@ -178,7 +178,7 @@ QGroupBox *HomeWidget::createButtons()
     boxLayout->addSpacing(25);
 
     connectButton = new HomeStyledButton("Connect/Play", gradientColors);
-    boxLayout->addWidget(connectButton, 1);
+    boxLayout->addWidget(connectButton);
 
     auto visualDeckEditorButton = new HomeStyledButton(tr("Create New Deck"), gradientColors);
     connect(visualDeckEditorButton, &QPushButton::clicked, tabSupervisor,


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6233

## Short roundup of the initial problem
Connect button is added with stretch, which causes only it to be resized.

## What will change with this Pull Request?
- Don't add with stretch

## Screenshots
<img width="1919" height="1029" alt="image" src="https://github.com/user-attachments/assets/30520d02-aa7b-4eea-a9d7-a9becb013d02" />

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/7d9b13ca-85c6-41d3-8bf7-559c5a5f5b97" />

