### PR TITLE
[DeckLoader] Disable copy constructor

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -265,7 +265,7 @@ void Player::deleteCard(CardItem *card)
 
 void Player::setDeck(const DeckLoader &_deck)
 {
-    deck = new DeckLoader(_deck);
+    deck = new DeckLoader(this, _deck.getDeckList());
 
     emit deckChanged();
 }

--- a/cockatrice/src/interface/deck_loader/deck_loader.cpp
+++ b/cockatrice/src/interface/deck_loader/deck_loader.cpp
@@ -36,12 +36,6 @@ DeckLoader::DeckLoader(QObject *parent, DeckList *_deckList)
     deckList->setParent(this);
 }
 
-DeckLoader::DeckLoader(const DeckLoader &other)
-    : QObject(), deckList(other.deckList), lastFileName(other.lastFileName), lastFileFormat(other.lastFileFormat),
-      lastRemoteDeckId(other.lastRemoteDeckId)
-{
-}
-
 void DeckLoader::setDeckList(DeckList *_deckList)
 {
     deckList = _deckList;

--- a/cockatrice/src/interface/deck_loader/deck_loader.h
+++ b/cockatrice/src/interface/deck_loader/deck_loader.h
@@ -53,8 +53,11 @@ private:
 public:
     DeckLoader(QObject *parent);
     DeckLoader(QObject *parent, DeckList *_deckList);
+    DeckLoader(const DeckLoader &) = delete;
+    DeckLoader &operator=(const DeckLoader &) = delete;
+
     void setDeckList(DeckList *_deckList);
-    DeckLoader(const DeckLoader &other);
+
     const QString &getLastFileName() const
     {
         return lastFileName;
@@ -106,7 +109,7 @@ public:
 
     bool convertToCockatriceFormat(QString fileName);
 
-    DeckList *getDeckList()
+    DeckList *getDeckList() const
     {
         return deckList;
     }

--- a/cockatrice/src/interface/widgets/dialogs/dlg_load_deck_from_clipboard.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_load_deck_from_clipboard.cpp
@@ -142,7 +142,7 @@ DlgEditDeckInClipboard::DlgEditDeckInClipboard(const DeckLoader &deckList, bool 
 {
     setWindowTitle(tr("Edit deck in clipboard"));
 
-    deckLoader = new DeckLoader(deckList);
+    deckLoader = new DeckLoader(this, deckList.getDeckList());
     deckLoader->setParent(this);
 
     DlgEditDeckInClipboard::actRefresh();


### PR DESCRIPTION
## Short roundup of the initial problem
Crash when opening deck editor from in-game

Probably related, it's early in the morning:

https://doc.qt.io/qt-6/qobject.html#no-copy-constructor-or-assignment-operator
https://doc.qt.io/qt-6/object.html#qt-objects-identity-vs-value

## What will change with this Pull Request?
- Disable DeckLoader copy constructor
