### PR TITLE
[DeckLoader] Fix missing lastFileName when opened from outside deck editor

### DIFF
--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -331,7 +331,7 @@ void DeckViewContainer::loadFromWebsite()
 void DeckViewContainer::deckSelectFinished(const Response &r)
 {
     const Response_DeckDownload &resp = r.GetExtension(Response_DeckDownload::ext);
-    DeckLoader newDeck(this, new DeckList(QString::fromStdString(resp.deck())));
+    DeckLoader newDeck(this, new DeckList(QString::fromStdString(resp.deck())), {});
     CardPictureLoader::cacheCardPixmaps(
         CardDatabaseManager::query()->getCards(newDeck.getDeckList()->getCardRefList()));
     setDeck(newDeck);

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -265,7 +265,7 @@ void Player::deleteCard(CardItem *card)
 
 void Player::setDeck(const DeckLoader &_deck)
 {
-    deck = new DeckLoader(this, _deck.getDeckList());
+    deck = new DeckLoader(this, _deck.getDeckList(), _deck.getLastLoadInfo());
 
     emit deckChanged();
 }

--- a/cockatrice/src/interface/deck_loader/deck_loader.h
+++ b/cockatrice/src/interface/deck_loader/deck_loader.h
@@ -44,40 +44,53 @@ public:
         DecklistXyz
     };
 
+    /**
+     * @brief Information about the file or source that the deck was loaded from
+     */
+    struct LoadInfo
+    {
+        QString fileName;
+        FileFormat fileFormat = CockatriceFormat;
+        int remoteDeckId = -1;
+    };
+
 private:
     DeckList *deckList;
-    QString lastFileName;
-    FileFormat lastFileFormat;
-    int lastRemoteDeckId;
+    LoadInfo lastLoadInfo;
 
 public:
     DeckLoader(QObject *parent);
-    DeckLoader(QObject *parent, DeckList *_deckList);
+    DeckLoader(QObject *parent, DeckList *_deckList, const LoadInfo &_lastLoadInfo);
     DeckLoader(const DeckLoader &) = delete;
     DeckLoader &operator=(const DeckLoader &) = delete;
 
     void setDeckList(DeckList *_deckList);
 
+    const LoadInfo &getLastLoadInfo() const
+    {
+        return lastLoadInfo;
+    }
+
     const QString &getLastFileName() const
     {
-        return lastFileName;
+        return lastLoadInfo.fileName;
     }
     void setLastFileName(const QString &_lastFileName)
     {
-        lastFileName = _lastFileName;
+        lastLoadInfo.fileName = _lastFileName;
     }
     FileFormat getLastFileFormat() const
     {
-        return lastFileFormat;
+        return lastLoadInfo.fileFormat;
     }
     int getLastRemoteDeckId() const
     {
-        return lastRemoteDeckId;
+        return lastLoadInfo.remoteDeckId;
     }
 
     bool hasNotBeenLoaded() const
     {
-        return getLastFileName().isEmpty() && getLastRemoteDeckId() == -1;
+        return lastLoadInfo.fileName.isEmpty() && lastLoadInfo.remoteDeckId == -1;
     }
 
     static void clearSetNamesAndNumbers(const DeckList *deckList);

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -32,7 +32,7 @@ void DeckEditorDeckDockWidget::createDeckDock()
     deckModel->setObjectName("deckModel");
     connect(deckModel, &DeckListModel::deckHashChanged, this, &DeckEditorDeckDockWidget::updateHash);
 
-    deckLoader = new DeckLoader(this, deckModel->getDeckList());
+    deckLoader = new DeckLoader(this, deckModel->getDeckList(), {});
 
     proxy = new DeckListStyleProxy(this);
     proxy->setSourceModel(deckModel);

--- a/cockatrice/src/interface/widgets/dialogs/dlg_load_deck_from_clipboard.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_load_deck_from_clipboard.cpp
@@ -142,7 +142,7 @@ DlgEditDeckInClipboard::DlgEditDeckInClipboard(const DeckLoader &deckList, bool 
 {
     setWindowTitle(tr("Edit deck in clipboard"));
 
-    deckLoader = new DeckLoader(this, deckList.getDeckList());
+    deckLoader = new DeckLoader(this, deckList.getDeckList(), deckList.getLastLoadInfo());
     deckLoader->setParent(this);
 
     DlgEditDeckInClipboard::actRefresh();

--- a/cockatrice/src/interface/widgets/tabs/tab_deck_storage.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_deck_storage.cpp
@@ -493,7 +493,7 @@ void TabDeckStorage::downloadFinished(const Response &r,
     const Response_DeckDownload &resp = r.GetExtension(Response_DeckDownload::ext);
     QString filePath = extraData.toString();
 
-    DeckLoader deck(this, new DeckList(QString::fromStdString(resp.deck())));
+    DeckLoader deck(this, new DeckList(QString::fromStdString(resp.deck())), {});
     deck.saveToFile(filePath, DeckLoader::CockatriceFormat);
 }
 

--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -754,7 +754,7 @@ void TabGame::loadDeckForLocalPlayer(Player *localPlayer, int playerId, ServerIn
 {
     TabbedDeckViewContainer *deckViewContainer = deckViewContainers.value(playerId);
     if (playerInfo.has_deck_list()) {
-        DeckLoader newDeck(this, new DeckList(QString::fromStdString(playerInfo.deck_list())));
+        DeckLoader newDeck(this, new DeckList(QString::fromStdString(playerInfo.deck_list())), {});
         CardPictureLoader::cacheCardPixmaps(
             CardDatabaseManager::query()->getCards(newDeck.getDeckList()->getCardRefList()));
         deckViewContainer->playerDeckView->setDeck(newDeck);

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
@@ -869,7 +869,7 @@ TabDeckEditor *TabSupervisor::addDeckEditorTab(DeckLoader *deckToOpen)
 {
     auto *tab = new TabDeckEditor(this);
     if (deckToOpen)
-        tab->openDeck(new DeckLoader(this, deckToOpen->getDeckList()));
+        tab->openDeck(new DeckLoader(this, deckToOpen->getDeckList(), deckToOpen->getLastLoadInfo()));
     connect(tab, &AbstractTabDeckEditor::deckEditorClosing, this, &TabSupervisor::deckEditorClosed);
     connect(tab, &AbstractTabDeckEditor::openDeckEditor, this, &TabSupervisor::addDeckEditorTab);
     myAddTab(tab);
@@ -882,7 +882,7 @@ TabDeckEditorVisual *TabSupervisor::addVisualDeckEditorTab(DeckLoader *deckToOpe
 {
     auto *tab = new TabDeckEditorVisual(this);
     if (deckToOpen)
-        tab->openDeck(new DeckLoader(this, deckToOpen->getDeckList()));
+        tab->openDeck(new DeckLoader(this, deckToOpen->getDeckList(), deckToOpen->getLastLoadInfo()));
     connect(tab, &AbstractTabDeckEditor::deckEditorClosing, this, &TabSupervisor::deckEditorClosed);
     connect(tab, &AbstractTabDeckEditor::openDeckEditor, this, &TabSupervisor::addVisualDeckEditorTab);
     myAddTab(tab);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #6306

## Short roundup of the initial problem

When another tab needs to open a deck, it calls TabSupervisor with a DeckLoader. However, we don't copy over the last load info when we create a copy of the `DeckLoader` to pass into the deck editor tab, meaning the deck editor will open the save location prompt when you try to save it.

https://github.com/user-attachments/assets/3657f15c-e36f-4f0f-8046-c23cb9261e81

## What will change with this Pull Request?
- Extract last load info fields into a `LoadInfo` struct.
  - Still leaving around old getters and setters since I didn't feel like updating the existing code right now. We're still in the middle of redesigning the whole deck structure, so there's a good chance it just gets cleaned up later.
- Make the copy constructor take a `LoadInfo`.
  - And update all usages to pass the loadInfo from the old DeckLoader

https://github.com/user-attachments/assets/6d143633-8b9a-4dc7-ab59-2cfeb57c4ea9
