### PR TITLE
[VDE] Add selection model

### DIFF
--- a/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.h
@@ -11,6 +11,7 @@
 #include "../card_info_picture_with_text_overlay_widget.h"
 #include "../card_size_widget.h"
 
+#include <QItemSelectionModel>
 #include <QLabel>
 #include <QVBoxLayout>
 #include <QWidget>
@@ -24,6 +25,7 @@ class CardGroupDisplayWidget : public QWidget
 public:
     CardGroupDisplayWidget(QWidget *parent,
                            DeckListModel *deckListModel,
+                           QItemSelectionModel *selectionModel,
                            QPersistentModelIndex trackedIndex,
                            QString zoneName,
                            QString cardGroupCategory,
@@ -31,9 +33,11 @@ public:
                            QStringList activeSortCriteria,
                            int bannerOpacity,
                            CardSizeWidget *cardSizeWidget);
+    void onSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
     void clearAllDisplayWidgets();
 
     DeckListModel *deckListModel;
+    QItemSelectionModel *selectionModel;
     QPersistentModelIndex trackedIndex;
     QHash<QPersistentModelIndex, QWidget *> indexToWidgetMap;
     QString zoneName;
@@ -43,6 +47,7 @@ public:
     CardSizeWidget *cardSizeWidget;
 
 public slots:
+    void mousePressEvent(QMouseEvent *event) override;
     void onClick(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *card);
     void onHover(const ExactCard &card);
     virtual QWidget *constructWidgetForIndex(QPersistentModelIndex index);

--- a/cockatrice/src/interface/widgets/cards/card_group_display_widgets/flat_card_group_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_group_display_widgets/flat_card_group_display_widget.cpp
@@ -10,6 +10,7 @@
 
 FlatCardGroupDisplayWidget::FlatCardGroupDisplayWidget(QWidget *parent,
                                                        DeckListModel *_deckListModel,
+                                                       QItemSelectionModel *_selectionModel,
                                                        QPersistentModelIndex _trackedIndex,
                                                        QString _zoneName,
                                                        QString _cardGroupCategory,
@@ -19,6 +20,7 @@ FlatCardGroupDisplayWidget::FlatCardGroupDisplayWidget(QWidget *parent,
                                                        CardSizeWidget *_cardSizeWidget)
     : CardGroupDisplayWidget(parent,
                              _deckListModel,
+                             _selectionModel,
                              std::move(_trackedIndex),
                              _zoneName,
                              _cardGroupCategory,

--- a/cockatrice/src/interface/widgets/cards/card_group_display_widgets/flat_card_group_display_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_group_display_widgets/flat_card_group_display_widget.h
@@ -17,6 +17,7 @@ class FlatCardGroupDisplayWidget : public CardGroupDisplayWidget
 public:
     FlatCardGroupDisplayWidget(QWidget *parent,
                                DeckListModel *deckListModel,
+                               QItemSelectionModel *selectionModel,
                                QPersistentModelIndex trackedIndex,
                                QString zoneName,
                                QString cardGroupCategory,

--- a/cockatrice/src/interface/widgets/cards/card_group_display_widgets/overlapped_card_group_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_group_display_widgets/overlapped_card_group_display_widget.cpp
@@ -1,14 +1,12 @@
 #include "overlapped_card_group_display_widget.h"
 
-#include "../card_info_picture_with_text_overlay_widget.h"
-
 #include <QResizeEvent>
-#include <libcockatrice/card/card_info_comparator.h>
 #include <libcockatrice/card/database/card_database_manager.h>
 #include <libcockatrice/models/deck_list/deck_list_model.h>
 
 OverlappedCardGroupDisplayWidget::OverlappedCardGroupDisplayWidget(QWidget *parent,
                                                                    DeckListModel *_deckListModel,
+                                                                   QItemSelectionModel *_selectionModel,
                                                                    QPersistentModelIndex _trackedIndex,
                                                                    QString _zoneName,
                                                                    QString _cardGroupCategory,
@@ -18,6 +16,7 @@ OverlappedCardGroupDisplayWidget::OverlappedCardGroupDisplayWidget(QWidget *pare
                                                                    CardSizeWidget *_cardSizeWidget)
     : CardGroupDisplayWidget(parent,
                              _deckListModel,
+                             _selectionModel,
                              _trackedIndex,
                              _zoneName,
                              _cardGroupCategory,

--- a/cockatrice/src/interface/widgets/cards/card_group_display_widgets/overlapped_card_group_display_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_group_display_widgets/overlapped_card_group_display_widget.h
@@ -17,6 +17,7 @@ class OverlappedCardGroupDisplayWidget : public CardGroupDisplayWidget
 public:
     OverlappedCardGroupDisplayWidget(QWidget *parent,
                                      DeckListModel *deckListModel,
+                                     QItemSelectionModel *selectionModel,
                                      QPersistentModelIndex trackedIndex,
                                      QString zoneName,
                                      QString cardGroupCategory,

--- a/cockatrice/src/interface/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
@@ -25,7 +25,7 @@ CardInfoPictureWithTextOverlayWidget::CardInfoPictureWithTextOverlayWidget(QWidg
                                                                            const int fontSize,
                                                                            const Qt::Alignment alignment)
     : CardInfoPictureWidget(parent, hoverToZoomEnabled, raiseOnEnter), textColor(textColor), outlineColor(outlineColor),
-      fontSize(fontSize), textAlignment(alignment)
+      fontSize(fontSize), textAlignment(alignment), highlighted(false)
 {
     this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 }
@@ -82,6 +82,16 @@ void CardInfoPictureWithTextOverlayWidget::setTextAlignment(const Qt::Alignment 
     update();
 }
 
+void CardInfoPictureWithTextOverlayWidget::setHighlighted(bool _highlighted)
+{
+    if (highlighted == _highlighted) {
+        return;
+    }
+
+    highlighted = _highlighted;
+    update();
+}
+
 void CardInfoPictureWithTextOverlayWidget::mousePressEvent(QMouseEvent *event)
 {
     emit imageClicked(event, this);
@@ -98,11 +108,6 @@ void CardInfoPictureWithTextOverlayWidget::paintEvent(QPaintEvent *event)
     // Call the base class's paintEvent to draw the card image
     CardInfoPictureWidget::paintEvent(event);
 
-    // If no overlay text, skip drawing the text
-    if (overlayText.isEmpty()) {
-        return;
-    }
-
     QStylePainter painter(this);
 
     // Get the pixmap from the base class using the getter
@@ -115,6 +120,36 @@ void CardInfoPictureWithTextOverlayWidget::paintEvent(QPaintEvent *event)
     const QSize scaledSize = pixmap.size().scaled(size(), Qt::KeepAspectRatio);
     const QPoint topLeft{(width() - scaledSize.width()) / 2, (height() - scaledSize.height()) / 2};
     const QRect pixmapRect(topLeft, scaledSize);
+
+    if (highlighted) {
+        painter.save();
+        painter.setRenderHint(QPainter::Antialiasing, true);
+
+        // Soft glow and border around the pixmap
+        const int padding = 4; // glow extends a little beyond image
+        QRect glowRect = pixmapRect.adjusted(-padding, -padding, padding, padding);
+
+        QPainterPath path;
+        int radius = 8; // rounded corners
+        path.addRoundedRect(glowRect, radius, radius);
+
+        // Soft outer glow
+        QColor glowColor(0, 150, 255, 80); // subtle blu
+        painter.setPen(QPen(glowColor, 6));
+        painter.drawPath(path);
+
+        // Thin inner border for crispness
+        QColor borderColor(0, 150, 255, 200);
+        painter.setPen(QPen(borderColor, 2));
+        painter.drawRoundedRect(pixmapRect, radius, radius);
+
+        painter.restore();
+    }
+
+    // If no overlay text, skip drawing the text
+    if (overlayText.isEmpty()) {
+        return;
+    }
 
     // Calculate the optimal font size
     QFont font = painter.font();

--- a/cockatrice/src/interface/widgets/cards/card_info_picture_with_text_overlay_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_with_text_overlay_widget.h
@@ -32,6 +32,7 @@ public:
     void setOutlineColor(const QColor &color);
     void setFontSize(int size);
     void setTextAlignment(Qt::Alignment alignment);
+    void setHighlighted(bool _highlighted);
 
     [[nodiscard]] QSize sizeHint() const override;
 signals:
@@ -53,6 +54,7 @@ private:
     QColor outlineColor;
     int fontSize;
     Qt::Alignment textAlignment;
+    bool highlighted;
 };
 
 #endif // CARD_PICTURE_WITH_TEXT_OVERLAY_H

--- a/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.cpp
@@ -9,6 +9,7 @@
 
 DeckCardZoneDisplayWidget::DeckCardZoneDisplayWidget(QWidget *parent,
                                                      DeckListModel *_deckListModel,
+                                                     QItemSelectionModel *_selectionModel,
                                                      QPersistentModelIndex _trackedIndex,
                                                      QString _zoneName,
                                                      QString _activeGroupCriteria,
@@ -17,9 +18,10 @@ DeckCardZoneDisplayWidget::DeckCardZoneDisplayWidget(QWidget *parent,
                                                      int bannerOpacity,
                                                      int subBannerOpacity,
                                                      CardSizeWidget *_cardSizeWidget)
-    : QWidget(parent), deckListModel(_deckListModel), trackedIndex(_trackedIndex), zoneName(_zoneName),
-      activeGroupCriteria(_activeGroupCriteria), activeSortCriteria(_activeSortCriteria), displayType(_displayType),
-      bannerOpacity(bannerOpacity), subBannerOpacity(subBannerOpacity), cardSizeWidget(_cardSizeWidget)
+    : QWidget(parent), deckListModel(_deckListModel), selectionModel(_selectionModel), trackedIndex(_trackedIndex),
+      zoneName(_zoneName), activeGroupCriteria(_activeGroupCriteria), activeSortCriteria(_activeSortCriteria),
+      displayType(_displayType), bannerOpacity(bannerOpacity), subBannerOpacity(subBannerOpacity),
+      cardSizeWidget(_cardSizeWidget)
 {
     layout = new QVBoxLayout(this);
     setLayout(layout);
@@ -37,7 +39,32 @@ DeckCardZoneDisplayWidget::DeckCardZoneDisplayWidget(QWidget *parent,
     displayCards();
 
     connect(deckListModel, &QAbstractItemModel::rowsInserted, this, &DeckCardZoneDisplayWidget::onCategoryAddition);
+    connect(selectionModel, &QItemSelectionModel::selectionChanged, this,
+            &DeckCardZoneDisplayWidget::onSelectionChanged);
     connect(deckListModel, &QAbstractItemModel::rowsRemoved, this, &DeckCardZoneDisplayWidget::onCategoryRemoval);
+}
+
+void DeckCardZoneDisplayWidget::onSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected)
+{
+    for (auto &range : selected) {
+        for (int row = range.top(); row <= range.bottom(); ++row) {
+            QModelIndex idx = range.model()->index(row, 0, range.parent());
+            auto it = indexToWidgetMap.find(QPersistentModelIndex(idx));
+            if (it != indexToWidgetMap.end()) {
+                // it.value()->setHighlighted(true);
+            }
+        }
+    }
+
+    for (auto &range : deselected) {
+        for (int row = range.top(); row <= range.bottom(); ++row) {
+            QModelIndex idx = range.model()->index(row, 0, range.parent());
+            auto it = indexToWidgetMap.find(QPersistentModelIndex(idx));
+            if (it != indexToWidgetMap.end()) {
+                // it.value()->setHighlighted(false);
+            }
+        }
+    }
 }
 
 void DeckCardZoneDisplayWidget::cleanupInvalidCardGroup(CardGroupDisplayWidget *displayWidget)
@@ -60,8 +87,8 @@ void DeckCardZoneDisplayWidget::constructAppropriateWidget(QPersistentModelIndex
     }
     if (displayType == DisplayType::Overlap) {
         auto *displayWidget = new OverlappedCardGroupDisplayWidget(
-            cardGroupContainer, deckListModel, index, zoneName, categoryName, activeGroupCriteria, activeSortCriteria,
-            subBannerOpacity, cardSizeWidget);
+            cardGroupContainer, deckListModel, selectionModel, index, zoneName, categoryName, activeGroupCriteria,
+            activeSortCriteria, subBannerOpacity, cardSizeWidget);
         connect(displayWidget, &OverlappedCardGroupDisplayWidget::cardClicked, this,
                 &DeckCardZoneDisplayWidget::onClick);
         connect(displayWidget, &OverlappedCardGroupDisplayWidget::cardHovered, this,
@@ -73,9 +100,9 @@ void DeckCardZoneDisplayWidget::constructAppropriateWidget(QPersistentModelIndex
         cardGroupLayout->addWidget(displayWidget);
         indexToWidgetMap.insert(index, displayWidget);
     } else if (displayType == DisplayType::Flat) {
-        auto *displayWidget =
-            new FlatCardGroupDisplayWidget(cardGroupContainer, deckListModel, index, zoneName, categoryName,
-                                           activeGroupCriteria, activeSortCriteria, subBannerOpacity, cardSizeWidget);
+        auto *displayWidget = new FlatCardGroupDisplayWidget(cardGroupContainer, deckListModel, selectionModel, index,
+                                                             zoneName, categoryName, activeGroupCriteria,
+                                                             activeSortCriteria, subBannerOpacity, cardSizeWidget);
         connect(displayWidget, &FlatCardGroupDisplayWidget::cardClicked, this, &DeckCardZoneDisplayWidget::onClick);
         connect(displayWidget, &FlatCardGroupDisplayWidget::cardHovered, this, &DeckCardZoneDisplayWidget::onHover);
         connect(displayWidget, &CardGroupDisplayWidget::cleanupRequested, this,

--- a/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.h
+++ b/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.h
@@ -26,6 +26,7 @@ class DeckCardZoneDisplayWidget : public QWidget
 public:
     DeckCardZoneDisplayWidget(QWidget *parent,
                               DeckListModel *deckListModel,
+                              QItemSelectionModel *selectionModel,
                               QPersistentModelIndex trackedIndex,
                               QString zoneName,
                               QString activeGroupCriteria,
@@ -34,7 +35,9 @@ public:
                               int bannerOpacity,
                               int subBannerOpacity,
                               CardSizeWidget *_cardSizeWidget);
+    void onSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
     DeckListModel *deckListModel;
+    QItemSelectionModel *selectionModel;
     QPersistentModelIndex trackedIndex;
     QString zoneName;
     void addCardsToOverlapWidget();

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.h
@@ -51,6 +51,11 @@ public:
         return activeGroupCriteriaComboBox;
     }
 
+    [[nodiscard]] QItemSelectionModel *getSelectionModel() const
+    {
+        return deckView->selectionModel();
+    }
+
 public slots:
     void cleanDeck();
     void updateBannerCardComboBox();

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.h
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.h
@@ -176,8 +176,9 @@ public slots:
      * @param instance Widget representing the clicked card.
      * @param zoneName Deck zone of the card.
      */
-    void
-    processMainboardCardClick(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance, QString zoneName);
+    void processMainboardCardClick(QMouseEvent *event,
+                                   CardInfoPictureWithTextOverlayWidget *instance,
+                                   const QString &zoneName);
 
     /**
      * @brief Handle card clicks in the database visual display.

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.cpp
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.cpp
@@ -28,7 +28,7 @@ TabDeckEditorVisualTabWidget::TabDeckEditorVisualTabWidget(QWidget *parent,
     layout = new QVBoxLayout(this);
     setLayout(layout);
 
-    visualDeckView = new VisualDeckEditorWidget(this, deckModel);
+    visualDeckView = new VisualDeckEditorWidget(this, deckModel, _deckEditor->deckDockWidget->getSelectionModel());
     visualDeckView->setObjectName("visualDeckView");
     connect(visualDeckView, &VisualDeckEditorWidget::activeCardChanged, this,
             &TabDeckEditorVisualTabWidget::onCardChanged);

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.h
@@ -36,12 +36,19 @@ class VisualDeckEditorWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit VisualDeckEditorWidget(QWidget *parent, DeckListModel *deckListModel);
+    explicit VisualDeckEditorWidget(QWidget *parent, DeckListModel *deckListModel, QItemSelectionModel *selectionModel);
     void retranslateUi();
     void clearAllDisplayWidgets();
     void resizeEvent(QResizeEvent *event) override;
 
     void setDeckList(const DeckList &_deckListModel);
+
+    void setSelectionModel(QItemSelectionModel *model);
+    void onSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
+    QItemSelectionModel *getSelectionModel() const
+    {
+        return selectionModel;
+    }
 
     QLineEdit *searchBar;
     CardSizeWidget *cardSizeWidget;
@@ -53,6 +60,7 @@ public slots:
     void cleanupInvalidZones(DeckCardZoneDisplayWidget *displayWidget);
     void onCardAddition(const QModelIndex &parent, int first, int last);
     void onCardRemoval(const QModelIndex &parent, int first, int last);
+    void constructZoneWidgetForIndex(QPersistentModelIndex persistent);
     void constructZoneWidgetsFromDeckListModel();
 
 signals:
@@ -72,6 +80,7 @@ protected slots:
 
 private:
     DeckListModel *deckListModel;
+    QItemSelectionModel *selectionModel;
     QVBoxLayout *mainLayout;
     QWidget *searchContainer;
     QHBoxLayout *searchLayout;


### PR DESCRIPTION
## Short roundup of the initial problem
Users are only able to interact with a card by hovering over it and clicking it. This is counter intuitive for certain operations (changing the printing of a card that is bordered by other cards, for example) since it's not possible to mouse away from the card without changing the active selection.

## What will change with this Pull Request?
- Introduce a selection model to the VDE and sync it to the deck dock widget tree view selection model.
- Update this selection model on simple click, ctrl click, shift click as well as a click on a non-card widget (Resets selection)
- Don't change active card if selection model is not empty

## Screenshots
<img width="673" height="1217" alt="image" src="https://github.com/user-attachments/assets/72a071fc-1139-4e44-8178-637ee4f354fa" />
<img width="640" height="1207" alt="image" src="https://github.com/user-attachments/assets/3a46b08c-8cc1-46fd-bf70-28bc0e2f6bf9" />
