### PR TITLE
[Game] Fix CardZoneLogic::clearContents()

### DIFF
--- a/cockatrice/src/game/zones/logic/card_zone_logic.cpp
+++ b/cockatrice/src/game/zones/logic/card_zone_logic.cpp
@@ -148,17 +148,24 @@ void CardZoneLogic::moveAllToZone()
 
 void CardZoneLogic::clearContents()
 {
-    for (int i = 0; i < cards.size(); i++) {
+    // First gather the cards into a safe temporary list.
+    const CardList toClear = cards;
+
+    // Detach and notify attached cards and zones *before* deleting anything.
+    for (CardItem *card : toClear) {
         // If an incorrectly implemented server doesn't return attached cards to whom they belong before dropping a
         // player, we have to return them to avoid a crash.
-
-        const QList<CardItem *> &attachedCards = cards[i]->getAttachedCards();
-        for (auto attachedCard : attachedCards) {
+        const QList<CardItem *> &attachedCards = card->getAttachedCards();
+        for (CardItem *attachedCard : attachedCards) {
             emit attachedCard->getZone()->cardAdded(attachedCard);
         }
-
-        player->deleteCard(cards.at(i));
     }
+
+    // Now request deletions after all manipulations are done.
+    for (CardItem *card : toClear) {
+        player->deleteCard(card);
+    }
+
     cards.clear();
     emit cardCountChanged();
 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes concede crashes

## Short roundup of the initial problem
Manipulating lists while iterating them is problematic.

## What will change with this Pull Request?
- Unstack manipulation and deletion for loops