### PR TITLE
[VDE, VDD, EDHRec] Remember more card sizes

### DIFF
--- a/cockatrice/src/client/settings/cache_settings.cpp
+++ b/cockatrice/src/client/settings/cache_settings.cpp
@@ -314,6 +314,11 @@ SettingsCache::SettingsCache()
     visualDatabaseDisplayFilterToMostRecentSetsAmount =
         settings->value("interface/visualdatabasedisplayfiltertomostrecentsetsamount", 10).toInt();
     visualDeckEditorSampleHandSize = settings->value("interface/visualdeckeditorsamplehandsize", 7).toInt();
+    visualDeckEditorCardSize = settings->value("interface/visualdeckeditorcardsize", 100).toInt();
+    visualDatabaseDisplayCardSize = settings->value("interface/visualdatabasedisplaycardsize", 100).toInt();
+    edhrecCardSize = settings->value("interface/edhreccardsize", 100).toInt();
+    archidektPreviewSize = settings->value("interface/archidektpreviewsize", 100).toInt();
+
     horizontalHand = settings->value("hand/horizontal", true).toBool();
     invertVerticalCoordinate = settings->value("table/invert_vertical", false).toBool();
     minPlayersForMultiColumnLayout = settings->value("interface/min_players_multicolumn", 4).toInt();
@@ -861,6 +866,34 @@ void SettingsCache::setVisualDeckStorageSelectionAnimation(QT_STATE_CHANGED_T va
     visualDeckStorageSelectionAnimation = value;
     settings->setValue("interface/visualdeckstorageselectionanimation", visualDeckStorageSelectionAnimation);
     emit visualDeckStorageSelectionAnimationChanged(visualDeckStorageSelectionAnimation);
+}
+
+void SettingsCache::setVisualDeckEditorCardSize(int _visualDeckEditorCardSize)
+{
+    visualDeckEditorCardSize = _visualDeckEditorCardSize;
+    settings->setValue("interface/visualdeckeditorcardsize", visualDeckEditorCardSize);
+    emit visualDeckEditorCardSizeChanged();
+}
+
+void SettingsCache::setVisualDatabaseDisplayCardSize(int _visualDatabaseDisplayCardSize)
+{
+    visualDatabaseDisplayCardSize = _visualDatabaseDisplayCardSize;
+    settings->setValue("interface/visualdatabasedisplaycardsize", visualDatabaseDisplayCardSize);
+    emit visualDatabaseDisplayCardSizeChanged();
+}
+
+void SettingsCache::setEDHRecCardSize(int _edhrecCardSize)
+{
+    edhrecCardSize = _edhrecCardSize;
+    settings->setValue("interface/edhreccardsize", edhrecCardSize);
+    emit edhRecCardSizeChanged();
+}
+
+void SettingsCache::setArchidektPreviewCardSize(int _archidektPreviewCardSize)
+{
+    archidektPreviewSize = _archidektPreviewCardSize;
+    settings->setValue("interface/archidektpreviewsize", archidektPreviewSize);
+    emit archidektPreviewSizeChanged();
 }
 
 void SettingsCache::setDefaultDeckEditorType(int value)

--- a/cockatrice/src/client/settings/cache_settings.h
+++ b/cockatrice/src/client/settings/cache_settings.h
@@ -167,6 +167,10 @@ signals:
     void visualDatabaseDisplayFilterToMostRecentSetsEnabledChanged(bool enabled);
     void visualDatabaseDisplayFilterToMostRecentSetsAmountChanged(int amount);
     void visualDeckEditorSampleHandSizeAmountChanged(int amount);
+    void visualDeckEditorCardSizeChanged();
+    void visualDatabaseDisplayCardSizeChanged();
+    void edhRecCardSizeChanged();
+    void archidektPreviewSizeChanged();
     void horizontalHandChanged();
     void handJustificationChanged();
     void invertVerticalCoordinateChanged();
@@ -250,6 +254,10 @@ private:
     QStringList visualDeckStorageDefaultTagsList;
     bool visualDeckStorageSearchFolderNames;
     int visualDeckStorageCardSize;
+    int visualDeckEditorCardSize;
+    int visualDatabaseDisplayCardSize;
+    int edhrecCardSize;
+    int archidektPreviewSize;
     bool visualDeckStorageDrawUnusedColorIdentities;
     int visualDeckStorageUnusedColorIdentitiesOpacity;
     int visualDeckStorageTooltipType;
@@ -642,6 +650,22 @@ public:
     {
         return visualDeckStorageSelectionAnimation;
     }
+    int getVisualDeckEditorCardSize() const
+    {
+        return visualDeckEditorCardSize;
+    }
+    int getVisualDatabaseDisplayCardSize() const
+    {
+        return visualDatabaseDisplayCardSize;
+    }
+    int getEDHRecCardSize() const
+    {
+        return edhrecCardSize;
+    }
+    int getArchidektPreviewSize() const
+    {
+        return archidektPreviewSize;
+    }
     int getDefaultDeckEditorType() const
     {
         return defaultDeckEditorType;
@@ -1018,6 +1042,10 @@ public slots:
     void setVisualDeckStorageAlwaysConvert(bool _visualDeckStorageAlwaysConvert);
     void setVisualDeckStorageInGame(QT_STATE_CHANGED_T value);
     void setVisualDeckStorageSelectionAnimation(QT_STATE_CHANGED_T value);
+    void setVisualDeckEditorCardSize(int _visualDeckEditorCardSize);
+    void setVisualDatabaseDisplayCardSize(int _visualDatabaseDisplayCardSize);
+    void setEDHRecCardSize(int _EDHRecCardSize);
+    void setArchidektPreviewCardSize(int _archidektPreviewCardSize);
     void setDefaultDeckEditorType(int value);
     void setVisualDatabaseDisplayFilterToMostRecentSetsEnabled(QT_STATE_CHANGED_T _enabled);
     void setVisualDatabaseDisplayFilterToMostRecentSetsAmount(int _amount);

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/tab_edhrec_main.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/tab_edhrec_main.cpp
@@ -1,5 +1,6 @@
 #include "tab_edhrec_main.h"
 
+#include "../../../../../client/settings/cache_settings.h"
 #include "../../tab_supervisor.h"
 #include "api_response/average_deck/edhrec_average_deck_api_response.h"
 #include "api_response/commander/edhrec_commander_api_response.h"
@@ -96,7 +97,9 @@ TabEdhRecMain::TabEdhRecMain(TabSupervisor *_tabSupervisor) : Tab(_tabSupervisor
 
     settingsButton = new SettingsButtonWidget(this);
 
-    cardSizeSlider = new CardSizeWidget(this);
+    cardSizeSlider = new CardSizeWidget(this, nullptr, SettingsCache::instance().getEDHRecCardSize());
+    connect(cardSizeSlider, &CardSizeWidget::cardSizeSettingUpdated, &SettingsCache::instance(),
+            &SettingsCache::setEDHRecCardSize);
 
     settingsButton->addSettingsWidget(cardSizeSlider);
 

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -43,7 +43,9 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
     mainLayout->setContentsMargins(0, 0, 0, 0);
 
     flowWidget = new FlowWidget(this, Qt::Horizontal, Qt::ScrollBarAlwaysOff, Qt::ScrollBarPolicy::ScrollBarAsNeeded);
-    cardSizeWidget = new CardSizeWidget(this, flowWidget);
+    cardSizeWidget = new CardSizeWidget(this, flowWidget, SettingsCache::instance().getVisualDatabaseDisplayCardSize());
+    connect(cardSizeWidget, &CardSizeWidget::cardSizeSettingUpdated, &SettingsCache::instance(),
+            &SettingsCache::setVisualDatabaseDisplayCardSize);
 
     searchContainer = new QWidget(this);
     searchLayout = new QHBoxLayout(searchContainer);

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -1,5 +1,6 @@
 #include "visual_deck_editor_widget.h"
 
+#include "../../../client/settings/cache_settings.h"
 #include "../../../main.h"
 #include "../../deck_loader/deck_loader.h"
 #include "../../layouts/overlap_layout.h"
@@ -194,7 +195,9 @@ VisualDeckEditorWidget::VisualDeckEditorWidget(QWidget *parent,
     scrollArea->addScrollBarWidget(zoneContainer, Qt::AlignHCenter);
     scrollArea->setWidget(zoneContainer);
 
-    cardSizeWidget = new CardSizeWidget(this);
+    cardSizeWidget = new CardSizeWidget(this, nullptr, SettingsCache::instance().getVisualDeckEditorCardSize());
+    connect(cardSizeWidget, &CardSizeWidget::cardSizeSettingUpdated, &SettingsCache::instance(),
+            &SettingsCache::setVisualDeckEditorCardSize);
 
     mainLayout->addWidget(groupAndSortContainer);
     mainLayout->addWidget(scrollArea);


### PR DESCRIPTION
## Short roundup of the initial problem
We have all the means to remember the sizes users set for these cards but we don't because I was lazy once upon a time.

## What will change with this Pull Request?
- Add settings for card sizes
- Initialize card size sliders with these settings
- hook up value changed signals on sliders to write settings