### PR TITLE
[Fix-Warnings] Suppress C4100: unreferenced parameter for protobuf files

### DIFF
--- a/libcockatrice_protocol/libcockatrice/protocol/pb/CMakeLists.txt
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/CMakeLists.txt
@@ -165,11 +165,11 @@ set(PROTO_FILES
     session_event.proto
 )
 
-if (MSVC)
+if(MSVC)
   set(unused_warning /wd4100)
-else ()
+else()
   set(unused_warning -Wno-unused-parameter)
-endif ()
+endif()
 
 if(${Protobuf_VERSION} VERSION_LESS "3.21.0.0")
   message(STATUS "Using Protobuf Legacy Mode")


### PR DESCRIPTION
## Short roundup of the initial problem
These warnings are generated during protobuf compilation:
```
libcockatrice_protocol\libcockatrice\protocol\pb\event_notify_user.pb.cc(169): warning C4100: 'from_msg': unreferenced parameter
```

They are erroneous and can be safely suppressed so they don't clutter up our output.

## What will change with this Pull Request?
- Suppress warning C4100 for libcockatrice_protocol_pb target

## Screenshots
<img width="1429" height="487" alt="image" src="https://github.com/user-attachments/assets/71b14b35-c1f4-401b-a033-f426d3361575" />
