### PR TITLE
[CardInfoPictureEnlargedWidget] Fix DPR scaling.

### DIFF
--- a/cockatrice/src/interface/widgets/cards/card_info_picture_enlarged_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_enlarged_widget.cpp
@@ -33,10 +33,13 @@ CardInfoPictureEnlargedWidget::CardInfoPictureEnlargedWidget(QWidget *parent) : 
  */
 void CardInfoPictureEnlargedWidget::loadPixmap(const QSize &size)
 {
+    // Handle DPI scaling
+    qreal dpr = devicePixelRatio();   // Get the actual scaling factor
+    QSize availableSize = size * dpr; // Convert to physical pixel size
     if (card) {
-        CardPictureLoader::getPixmap(enlargedPixmap, card, size);
+        CardPictureLoader::getPixmap(enlargedPixmap, card, availableSize);
     } else {
-        CardPictureLoader::getCardBackPixmap(enlargedPixmap, size);
+        CardPictureLoader::getCardBackPixmap(enlargedPixmap, availableSize);
     }
     pixmapDirty = false;
 }
@@ -77,25 +80,35 @@ void CardInfoPictureEnlargedWidget::paintEvent(QPaintEvent *event)
         loadPixmap(size());
     }
 
-    // Scale the size of the pixmap to fit the widget while maintaining the aspect ratio
-    QSize scaledSize = enlargedPixmap.size().scaled(size().width(), size().height(), Qt::KeepAspectRatio);
+    qreal dpr = enlargedPixmap.devicePixelRatio();
 
-    // Calculate the position to center the scaled pixmap
-    QPoint topLeft{(width() - scaledSize.width()) / 2, (height() - scaledSize.height()) / 2};
+    QSize logicalPixmapSize(enlargedPixmap.width() / dpr, enlargedPixmap.height() / dpr);
 
-    // Define the radius for rounded corners
-    // Adjust the radius as needed for rounded corners
-    qreal radius = SettingsCache::instance().getRoundCardCorners() ? 0.05 * scaledSize.width() : 0.;
+    // Scale the pixmap to fit the widget (logical → logical)
+    QSize scaledLogicalSize = logicalPixmapSize.scaled(size(), Qt::KeepAspectRatio);
+
+    // Convert scaled logical size → physical size for scaled()
+    QSize scaledPhysicalSize = scaledLogicalSize * dpr;
+
+    // Pixmap scaled in PHYSICAL pixels
+    QPixmap finalPixmap = enlargedPixmap.scaled(scaledPhysicalSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+
+    finalPixmap.setDevicePixelRatio(dpr);
+
+    // Center inside widget
+    QPoint topLeft{(width() - scaledLogicalSize.width()) / 2, (height() - scaledLogicalSize.height()) / 2};
+
+    // Rounded corner radius based on logical width
+    qreal radius = SettingsCache::instance().getRoundCardCorners() ? 0.05 * scaledLogicalSize.width() : 0.0;
 
     QStylePainter painter(this);
     // Fill the background with transparent color to ensure rounded corners are rendered properly
     painter.fillRect(rect(), Qt::transparent); // Use the transparent background
 
     QPainterPath shape;
-    shape.addRoundedRect(QRect(topLeft, scaledSize), radius, radius);
+    shape.addRoundedRect(QRect(topLeft, scaledLogicalSize), radius, radius);
     painter.setClipPath(shape); // Set the clipping path
 
     // Draw the pixmap scaled to the calculated size
-    painter.drawItemPixmap(QRect(topLeft, scaledSize), Qt::AlignCenter,
-                           enlargedPixmap.scaled(scaledSize, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+    painter.drawPixmap(QRect(topLeft, scaledLogicalSize), finalPixmap);
 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6350

## Short roundup of the initial problem
Widget is resized by Qt so it respects DPR scaling. The loaded pixmap did not consider DPR as the CardInfoPictureWidget does. End result was an incorrectly sized pixmap with black borders.

## What will change with this Pull Request?
- Consider DPR

## Screenshots
Before:
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/e54b48c1-f3b3-47fb-a8d7-4b25790d6665" />

After:
<img width="2557" height="1383" alt="image" src="https://github.com/user-attachments/assets/ef932dd3-f2dc-4979-aa07-257467d96383" />

