### PR TITLE
[Oracle] Support importing tokens and spoilers from local file

### DIFF
--- a/oracle/src/pages.cpp
+++ b/oracle/src/pages.cpp
@@ -672,13 +672,21 @@ QString LoadTokensPage::getFileType()
     return tr("XML; token database (*.xml)");
 }
 
+QString LoadTokensPage::getFilePromptName()
+{
+    return tr("tokens");
+}
+
 void LoadTokensPage::retranslateUi()
 {
     setTitle(tr("Tokens import"));
     setSubTitle(tr("Please specify a compatible source for token data."));
 
-    urlLabel->setText(tr("Download URL:"));
+    urlRadioButton->setText(tr("Download URL:"));
+    fileRadioButton->setText(tr("Local file:"));
     urlButton->setText(tr("Restore default URL"));
+    fileButton->setText(tr("Choose file..."));
+
     pathLabel->setText(tr("The token database will be saved at the following location:") + "<br>" +
                        SettingsCache::instance().getTokenDatabasePath());
     defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));
@@ -709,13 +717,21 @@ QString LoadSpoilersPage::getFileType()
     return tr("XML; spoiler database (*.xml)");
 }
 
+QString LoadSpoilersPage::getFilePromptName()
+{
+    return tr("spoiler");
+}
+
 void LoadSpoilersPage::retranslateUi()
 {
     setTitle(tr("Spoilers import"));
     setSubTitle(tr("Please specify a compatible source for spoiler data."));
 
-    urlLabel->setText(tr("Download URL:"));
+    urlRadioButton->setText(tr("Download URL:"));
+    fileRadioButton->setText(tr("Local file:"));
     urlButton->setText(tr("Restore default URL"));
+    fileButton->setText(tr("Choose file..."));
+
     pathLabel->setText(tr("The spoiler database will be saved at the following location:") + "<br>" +
                        SettingsCache::instance().getSpoilerCardDatabasePath());
     defaultPathCheckBox->setText(tr("Save to a custom path (not recommended)"));

--- a/oracle/src/pages.h
+++ b/oracle/src/pages.h
@@ -131,6 +131,7 @@ protected:
     QString getDefaultSavePath() override;
     QString getWindowTitle() override;
     QString getFileType() override;
+    QString getFilePromptName() override;
 };
 
 class LoadTokensPage : public SimpleDownloadFilePage
@@ -148,6 +149,7 @@ protected:
     QString getDefaultSavePath() override;
     QString getWindowTitle() override;
     QString getFileType() override;
+    QString getFilePromptName() override;
     void initializePage() override;
 };
 

--- a/oracle/src/pagetemplates.h
+++ b/oracle/src/pagetemplates.h
@@ -3,6 +3,8 @@
 
 #include <QWizardPage>
 
+class QFile;
+class QRadioButton;
 class OracleWizard;
 class QCheckBox;
 class QLabel;
@@ -43,15 +45,19 @@ protected:
     virtual QString getDefaultSavePath() = 0;
     virtual QString getWindowTitle() = 0;
     virtual QString getFileType() = 0;
+    virtual QString getFilePromptName() = 0;
     bool saveToFile();
     bool internalSaveToFile(const QString &fileName);
 
 protected:
     QByteArray downloadData;
-    QLabel *urlLabel;
-    QLabel *pathLabel;
+    QRadioButton *urlRadioButton;
+    QRadioButton *fileRadioButton;
     QLineEdit *urlLineEdit;
+    QLineEdit *fileLineEdit;
     QPushButton *urlButton;
+    QPushButton *fileButton;
+    QLabel *pathLabel;
     QLabel *progressLabel;
     QProgressBar *progressBar;
     QCheckBox *defaultPathCheckBox;
@@ -60,6 +66,7 @@ signals:
     void parsedDataReady();
 private slots:
     void actRestoreDefaultUrl();
+    void actLoadCardFile();
     void actDownloadProgress(qint64 received, qint64 total);
     void actDownloadFinished();
 };


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem

We still don't have support for loading local card files for tokens.

## What will change with this Pull Request?
- Add support for local files for tokens and spoilers

<img width="684" height="437" alt="Screenshot 2025-11-30 at 6 04 39 AM" src="https://github.com/user-attachments/assets/d44a3528-59ea-4635-a0f7-7cfb425685c0" />


I copied a lot of code from `LoadSetsPage`.
Maybe we can refactor so that there's less code duplication, but it's harder than normal because `LoadSetsPage` doesn't extend from the same class as the tokens and spoilers pages.