### PR TITLE
[Oracle] Add low-memory check (<=4GiB) and use mtgxml url instead.

### DIFF
--- a/libcockatrice_utility/CMakeLists.txt
+++ b/libcockatrice_utility/CMakeLists.txt
@@ -6,13 +6,17 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 
 set(UTILITY_SOURCES libcockatrice/utility/expression.cpp libcockatrice/utility/levenshtein.cpp
-        libcockatrice/utility/passwordhasher.cpp libcockatrice/utility/system_memory_querier.cpp
+                    libcockatrice/utility/passwordhasher.cpp libcockatrice/utility/system_memory_querier.cpp
 )
 
 set(UTILITY_HEADERS
-    libcockatrice/utility/color.h libcockatrice/utility/expression.h libcockatrice/utility/levenshtein.h
-        libcockatrice/utility/macros.h libcockatrice/utility/passwordhasher.h libcockatrice/utility/system_memory_querier.h
-        libcockatrice/utility/trice_limits.h
+    libcockatrice/utility/color.h
+    libcockatrice/utility/expression.h
+    libcockatrice/utility/levenshtein.h
+    libcockatrice/utility/macros.h
+    libcockatrice/utility/passwordhasher.h
+    libcockatrice/utility/system_memory_querier.h
+    libcockatrice/utility/trice_limits.h
 )
 
 add_library(libcockatrice_utility STATIC ${UTILITY_SOURCES} ${UTILITY_HEADERS})

--- a/libcockatrice_utility/CMakeLists.txt
+++ b/libcockatrice_utility/CMakeLists.txt
@@ -6,12 +6,13 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 
 set(UTILITY_SOURCES libcockatrice/utility/expression.cpp libcockatrice/utility/levenshtein.cpp
-                    libcockatrice/utility/passwordhasher.cpp
+        libcockatrice/utility/passwordhasher.cpp libcockatrice/utility/system_memory_querier.cpp
 )
 
 set(UTILITY_HEADERS
     libcockatrice/utility/color.h libcockatrice/utility/expression.h libcockatrice/utility/levenshtein.h
-    libcockatrice/utility/macros.h libcockatrice/utility/passwordhasher.h libcockatrice/utility/trice_limits.h
+        libcockatrice/utility/macros.h libcockatrice/utility/passwordhasher.h libcockatrice/utility/system_memory_querier.h
+        libcockatrice/utility/trice_limits.h
 )
 
 add_library(libcockatrice_utility STATIC ${UTILITY_SOURCES} ${UTILITY_HEADERS})

--- a/libcockatrice_utility/libcockatrice/utility/system_memory_querier.cpp
+++ b/libcockatrice_utility/libcockatrice/utility/system_memory_querier.cpp
@@ -1,0 +1,107 @@
+#include "system_memory_querier.h"
+
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
+
+#ifdef Q_OS_LINUX
+#include <QFile>
+#include <QTextStream>
+#endif
+
+#ifdef Q_OS_MACOS
+#include <mach/mach.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+qulonglong SystemMemoryQuerier::totalMemoryBytes()
+{
+#if defined(Q_OS_WIN)
+
+    MEMORYSTATUSEX statex;
+    statex.dwLength = sizeof(statex);
+    if (GlobalMemoryStatusEx(&statex))
+        return statex.ullTotalPhys;
+    return 0;
+
+#elif defined(Q_OS_LINUX)
+
+    QFile file("/proc/meminfo");
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+        return 0;
+
+    QTextStream in(&file);
+    while (!in.atEnd()) {
+        QString line = in.readLine();
+        if (line.startsWith("MemTotal:")) {
+            QStringList parts = line.split(QRegExp("\\s+"), Qt::SkipEmptyParts);
+            if (parts.size() >= 2)
+                return parts[1].toULongLong() * 1024; // kB → bytes
+        }
+    }
+    return 0;
+
+#elif defined(Q_OS_MACOS)
+
+    int mib[2] = {CTL_HW, HW_MEMSIZE};
+    qulonglong memsize = 0;
+    size_t len = sizeof(memsize);
+
+    if (sysctl(mib, 2, &memsize, &len, nullptr, 0) == 0)
+        return memsize;
+
+    return 0;
+
+#else
+    return 0;
+#endif
+}
+
+qulonglong SystemMemoryQuerier::availableMemoryBytes()
+{
+#if defined(Q_OS_WIN)
+
+    MEMORYSTATUSEX statex;
+    statex.dwLength = sizeof(statex);
+    if (GlobalMemoryStatusEx(&statex))
+        return statex.ullAvailPhys;
+    return 0;
+
+#elif defined(Q_OS_LINUX)
+
+    QFile file("/proc/meminfo");
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+        return 0;
+
+    QTextStream in(&file);
+    while (!in.atEnd()) {
+        QString line = in.readLine();
+        if (line.startsWith("MemAvailable:")) {
+            QStringList parts = line.split(QRegExp("\\s+"), Qt::SkipEmptyParts);
+            if (parts.size() >= 2)
+                return parts[1].toULongLong() * 1024;
+        }
+    }
+    return 0;
+
+#elif defined(Q_OS_MACOS)
+
+    vm_size_t pageSize;
+    host_page_size(mach_host_self(), &pageSize);
+
+    mach_msg_type_number_t count = HOST_VM_INFO_COUNT;
+    vm_statistics64_data_t vmstat;
+
+    if (host_statistics64(mach_host_self(), HOST_VM_INFO, (host_info64_t)&vmstat, &count) != KERN_SUCCESS)
+        return 0;
+
+    qulonglong freeBytes = (qulonglong)vmstat.free_count * (qulonglong)pageSize;
+
+    return freeBytes;
+
+#else
+    return 0;
+#endif
+}

--- a/libcockatrice_utility/libcockatrice/utility/system_memory_querier.cpp
+++ b/libcockatrice_utility/libcockatrice/utility/system_memory_querier.cpp
@@ -37,7 +37,11 @@ qulonglong SystemMemoryQuerier::totalMemoryBytes()
     while (!in.atEnd()) {
         QString line = in.readLine();
         if (line.startsWith("MemTotal:")) {
-            QStringList parts = line.split(QRegExp("\\s+"), Qt::SkipEmptyParts);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+            QStringList parts = line.split(QRegExp("\\s+"), QString::SkipEmptyParts);
+#else
+            QStringList parts = line.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
+#endif
             if (parts.size() >= 2)
                 return parts[1].toULongLong() * 1024; // kB → bytes
         }

--- a/libcockatrice_utility/libcockatrice/utility/system_memory_querier.cpp
+++ b/libcockatrice_utility/libcockatrice/utility/system_memory_querier.cpp
@@ -6,6 +6,7 @@
 
 #ifdef Q_OS_LINUX
 #include <QFile>
+#include <QRegularExpression>
 #include <QTextStream>
 #endif
 

--- a/libcockatrice_utility/libcockatrice/utility/system_memory_querier.h
+++ b/libcockatrice_utility/libcockatrice/utility/system_memory_querier.h
@@ -1,0 +1,19 @@
+#ifndef COCKATRICE_SYSTEM_MEMORY_QUERIER_H
+#define COCKATRICE_SYSTEM_MEMORY_QUERIER_H
+
+#include <QtGlobal>
+
+class SystemMemoryQuerier
+{
+public:
+    static qulonglong totalMemoryBytes();
+    static qulonglong availableMemoryBytes();
+
+    static bool hasAtLeastGiB(int gib)
+    {
+        const qulonglong GiB = 1024ull * 1024ull * 1024ull;
+        return totalMemoryBytes() >= (qulonglong)gib * GiB;
+    }
+};
+
+#endif // COCKATRICE_SYSTEM_MEMORY_QUERIER_H

--- a/oracle/src/pages.cpp
+++ b/oracle/src/pages.cpp
@@ -188,7 +188,7 @@ void LoadSetsPage::initializePage()
     urlLineEdit->setText(wizard()->settings->value("allsetsurl", ALLSETS_URL).toString());
 
     // Memory check because Oracle parsing fails on systems with less than 4GiB for MTGJsons allPrintings.json
-    if (!SystemMemoryQuerier::hasAtLeastGiB(33)) {
+    if (!SystemMemoryQuerier::hasAtLeastGiB(4) && urlLineEdit->text() == ALLSETS_URL) {
         // Ask user whether to switch URL
         QMessageBox msgBox(
             QMessageBox::Question, tr("Low Memory Detected"),


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4369
- Fixes #6091 (possibly)

## Short roundup of the initial problem
Oracle crashes when trying to parse MTGJsons AllPrintings.json because it uses too much memory.

## What will change with this Pull Request?
- Implement cross-platform utility to query available and total system memory and check for at least X GiB system memory (human readable)
- Check in oracle and add a prompt to change to direct download url if desired.

## Screenshots
<img width="502" height="359" alt="image" src="https://github.com/user-attachments/assets/cb18ebe6-5437-4545-8b6c-eb2dc2839d09" />
<img width="502" height="368" alt="image" src="https://github.com/user-attachments/assets/b2b65406-69d7-4a8a-8318-53193098ec22" />

