### PR TITLE
[TagDisplayWidget] Refactor to just store tags and use signals

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -154,8 +154,10 @@ void DeckEditorDeckDockWidget::createDeckDock()
             &DeckEditorDeckDockWidget::setBannerCard);
     bannerCardComboBox->setHidden(!SettingsCache::instance().getDeckEditorBannerCardComboBoxVisible());
 
-    deckTagsDisplayWidget = new DeckPreviewDeckTagsDisplayWidget(this, deckModel->getDeckList());
+    deckTagsDisplayWidget = new DeckPreviewDeckTagsDisplayWidget(this, deckModel->getDeckList()->getTags());
     deckTagsDisplayWidget->setHidden(!SettingsCache::instance().getDeckEditorTagsWidgetVisible());
+    connect(deckTagsDisplayWidget, &DeckPreviewDeckTagsDisplayWidget::tagsChanged, this,
+            &DeckEditorDeckDockWidget::setTags);
 
     activeGroupCriteriaLabel = new QLabel(this);
 
@@ -383,6 +385,13 @@ void DeckEditorDeckDockWidget::setBannerCard(int /* changedIndex */)
     emit deckModified();
 }
 
+void DeckEditorDeckDockWidget::setTags(const QStringList &tags)
+{
+    deckModel->getDeckList()->setTags(tags);
+    deckEditor->setModified(true);
+    emit deckModified();
+}
+
 void DeckEditorDeckDockWidget::syncDeckListBannerCardWithComboBox()
 {
     auto [name, id] = bannerCardComboBox->currentData().value<QPair<QString, QString>>();
@@ -451,7 +460,7 @@ void DeckEditorDeckDockWidget::syncDisplayWidgetsToModel()
     sortDeckModelToDeckView();
     expandAll();
 
-    deckTagsDisplayWidget->setDeckList(deckModel->getDeckList());
+    deckTagsDisplayWidget->setTags(deckModel->getDeckList()->getTags());
 }
 
 void DeckEditorDeckDockWidget::sortDeckModelToDeckView()
@@ -484,7 +493,7 @@ void DeckEditorDeckDockWidget::cleanDeck()
     emit deckModified();
     emit deckChanged();
     updateBannerCardComboBox();
-    deckTagsDisplayWidget->setDeckList(deckModel->getDeckList());
+    deckTagsDisplayWidget->setTags(deckModel->getDeckList()->getTags());
 }
 
 void DeckEditorDeckDockWidget::recursiveExpand(const QModelIndex &index)

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.h
@@ -112,6 +112,7 @@ private slots:
     void updateName(const QString &name);
     void updateComments();
     void setBannerCard(int);
+    void setTags(const QStringList &tags);
     void syncDeckListBannerCardWithComboBox();
     void updateHash();
     void refreshShortcuts();

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.h
@@ -17,12 +17,12 @@ class DeckPreviewDeckTagsDisplayWidget : public QWidget
 {
     Q_OBJECT
 
-    DeckList *deckList;
+    QStringList currentTags;
     FlowWidget *flowWidget;
 
 public:
-    explicit DeckPreviewDeckTagsDisplayWidget(QWidget *_parent, DeckList *_deckList);
-    void setDeckList(DeckList *_deckList);
+    explicit DeckPreviewDeckTagsDisplayWidget(QWidget *_parent, const QStringList &_tags);
+    void setTags(const QStringList &_tags);
     void refreshTags();
 
 public slots:
@@ -30,5 +30,13 @@ public slots:
 
 private:
     bool promptFileConversionIfRequired(DeckPreviewWidget *deckPreviewWidget);
+    void execTagDialog(const QStringList &knownTags);
+
+signals:
+    /**
+     * Emitted when the tags have changed due to user interaction.
+     * @param tags The new list of tags.
+     */
+    void tagsChanged(const QStringList &tags);
 };
 #endif // DECK_PREVIEW_DECK_TAGS_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -83,7 +83,8 @@ void DeckPreviewWidget::initializeUi(const bool deckLoadSuccess)
     setFilePath(deckLoader->getLastLoadInfo().fileName);
 
     colorIdentityWidget = new ColorIdentityWidget(this, getColorIdentity());
-    deckTagsDisplayWidget = new DeckPreviewDeckTagsDisplayWidget(this, deckLoader->getDeckList());
+    deckTagsDisplayWidget = new DeckPreviewDeckTagsDisplayWidget(this, deckLoader->getDeckList()->getTags());
+    connect(deckTagsDisplayWidget, &DeckPreviewDeckTagsDisplayWidget::tagsChanged, this, &DeckPreviewWidget::setTags);
 
     bannerCardLabel = new QLabel(this);
     bannerCardLabel->setObjectName("bannerCardLabel");
@@ -305,6 +306,12 @@ void DeckPreviewWidget::imageDoubleClickedEvent(QMouseEvent *event, DeckPreviewC
     Q_UNUSED(event);
     Q_UNUSED(instance);
     emit deckLoadRequested(filePath);
+}
+
+void DeckPreviewWidget::setTags(const QStringList &tags)
+{
+    deckLoader->getDeckList()->setTags(tags);
+    deckLoader->saveToFile(filePath, DeckLoader::CockatriceFormat);
 }
 
 QMenu *DeckPreviewWidget::createRightClickMenu()

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
@@ -72,6 +72,8 @@ private:
     void addSetBannerCardMenu(QMenu *menu);
 
 private slots:
+    void setTags(const QStringList &tags);
+
     void actRenameDeck();
     void actRenameFile();
     void actDeleteFile();


### PR DESCRIPTION
## Short roundup of the initial problem

`DeckPreviewDeckTagsDisplayWidget` needing to hold a pointer to a DeckList and directly modifying the DeckList is an obstacle to the DeckList refactors I'm trying to do. 

It's probably better practice to have the widgets decoupled like this anyways.

## What will change with this Pull Request?
- `DeckPreviewDeckTagsDisplayWidget` now only stores a list of tags instead of a pointer to a `DeckList`.
- The class now emits `tagsChanged` when the user interaction changes the tags.
  - Other widgets are responsible for connecting to that signal to update their underlying DeckList