### PR TITLE
[DeckFilterString] Rename filename search expression

### DIFF
--- a/cockatrice/resources/help/deck_search.md
+++ b/cockatrice/resources/help/deck_search.md
@@ -15,10 +15,10 @@ searches are case insensitive.
 <dd>[n:red n:deck n:wins](#n:red n:deck n:wins) <small>(Any deck with a name containing the words red, deck, and wins)</small></dd>
 <dd>[n:"red deck wins"](#n:%22red deck wins%22) <small>(Any deck with a name containing the exact phrase "red deck wins")</small></dd>
 
-<dt><u>F</u>ile Name:</dt>
-<dd>[f:aggro](#f:aggro) <small>(Any deck with a filename containing the word aggro)</small></dd>
-<dd>[f:red f:deck f:wins](#f:red f:deck f:wins) <small>(Any deck with a filename containing the words red, deck, and wins)</small></dd>
-<dd>[f:"red deck wins"](#f:%22red deck wins%22) <small>(Any deck with a filename containing the exact phrase "red deck wins")</small></dd>
+<dt><u>F</u>ile <u>N</u>ame:</dt>
+<dd>[fn:aggro](#fn:aggro) <small>(Any deck with a filename containing the word aggro)</small></dd>
+<dd>[fn:red fn:deck fn:wins](#fn:red fn:deck fn:wins) <small>(Any deck with a filename containing the words red, deck, and wins)</small></dd>
+<dd>[fn:"red deck wins"](#fn:%22red deck wins%22) <small>(Any deck with a filename containing the exact phrase "red deck wins")</small></dd>
 
 <dt>Relative <u>P</u>ath (starting from the deck folder):</dt>
 <dd>[p:aggro](#p:aggro) <small>(Any deck that has "aggro" somewhere in its relative path)</small></dd>

--- a/cockatrice/src/filters/deck_filter_string.cpp
+++ b/cockatrice/src/filters/deck_filter_string.cpp
@@ -22,7 +22,7 @@ CardSearch <- '[[' CardFilterString ']]'
 CardFilterString <- (!']]'.)*
 
 DeckNameQuery <- ([Dd] 'eck')? [Nn] 'ame'? [:] String
-FileNameQuery <- [Ff] ('ile' 'name'?)? [:] String
+FileNameQuery <- [Ff] ([Nn] / 'ile' ([Nn] 'ame')?) [:] String
 PathQuery <- [Pp] 'ath'? [:] String
 
 GenericQuery <- String


### PR DESCRIPTION
## Related Ticket(s)

## Short roundup of the initial problem

I want to add a search expression for format. However, `f:` is already taken by filename search. 
I think format search will be used more often than file search, so I think we should change the search expression for filename search.

## What will change with this Pull Request?
- Change filename pattern from `f:` to `fn:`
  - Also accepts `filename:`, `fname:`, or `fileName:`