### PR TITLE
[DeckFilterString] Add search query for format

### DIFF
--- a/cockatrice/resources/help/deck_search.md
+++ b/cockatrice/resources/help/deck_search.md
@@ -24,6 +24,9 @@ searches are case insensitive.
 <dd>[p:aggro](#p:aggro) <small>(Any deck that has "aggro" somewhere in its relative path)</small></dd>
 <dd>[p:edh/](#p:edh/) <small>(Any deck with "edh/" in its relative path, A.K.A. decks in the "edh" folder)</small></dd>
 
+<dt><u>F</u>ormat:</dt>
+<dd>[f:standard](#f:standard) <small>(Any deck with format set to standard)</small></dd>
+
 <dt>Deck Contents (Uses [card search expressions](#cardSearchSyntaxHelp)):</dt>
 <dd><a href="#[[plains]]">[[plains]]</a> <small>(Any deck that contains at least one card with "plains" in its name)</small></dd>
 <dd><a href="#[[t:legendary]]">[[t:legendary]]</a> <small>(Any deck that contains at least one legendary)</small></dd>

--- a/cockatrice/src/filters/deck_filter_string.cpp
+++ b/cockatrice/src/filters/deck_filter_string.cpp
@@ -13,7 +13,7 @@ QueryPartList <- ComplexQueryPart ( ws ("AND" ws)? ComplexQueryPart)* ws*
 ComplexQueryPart <- SomewhatComplexQueryPart ws "OR" ws ComplexQueryPart / SomewhatComplexQueryPart
 SomewhatComplexQueryPart <- [(] QueryPartList [)] / QueryPart
 
-QueryPart <- NotQuery / DeckContentQuery / DeckNameQuery / FileNameQuery / PathQuery / GenericQuery
+QueryPart <- NotQuery / DeckContentQuery / DeckNameQuery / FileNameQuery / PathQuery / FormatQuery / GenericQuery
 
 NotQuery <- ('NOT' ws/'-') SomewhatComplexQueryPart
 
@@ -24,6 +24,7 @@ CardFilterString <- (!']]'.)*
 DeckNameQuery <- ([Dd] 'eck')? [Nn] 'ame'? [:] String
 FileNameQuery <- [Ff] ([Nn] / 'ile' ([Nn] 'ame')?) [:] String
 PathQuery <- [Pp] 'ath'? [:] String
+FormatQuery <- [Ff] 'ormat'? [:] String
 
 GenericQuery <- String
 
@@ -154,6 +155,14 @@ static void setupParserRules()
         auto name = std::any_cast<QString>(sv[0]);
         return [=](const DeckPreviewWidget *, const ExtraDeckSearchInfo &info) {
             return info.relativeFilePath.contains(name, Qt::CaseInsensitive);
+        };
+    };
+
+    search["FormatQuery"] = [](const peg::SemanticValues &sv) -> DeckFilter {
+        auto format = std::any_cast<QString>(sv[0]);
+        return [=](const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &) {
+            auto gameFormat = deck->deckLoader->getDeckList()->getGameFormat();
+            return QString::compare(format, gameFormat, Qt::CaseInsensitive) == 0;
         };
     };
 


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6166

## Short roundup of the initial problem

Now that decks have a format field, we can add a formats to the search query options.

## What will change with this Pull Request?
- `f:` or `format:` filters out all decks that have a format that doesn't **exactly** match (case-insensitive) the search string

Not sure whether we want exact match or partial match here.
Partial match might lead to too many false positives if a format name is nested inside another format's name, but exact match might too strict