### PR TITLE
[DeckLoader] remove unused private methods

### DIFF
--- a/cockatrice/src/interface/deck_loader/deck_loader.cpp
+++ b/cockatrice/src/interface/deck_loader/deck_loader.cpp
@@ -485,29 +485,6 @@ bool DeckLoader::convertToCockatriceFormat(QString fileName)
     return result;
 }
 
-QString DeckLoader::getCardZoneFromName(const QString &cardName, QString currentZoneName)
-{
-    CardInfoPtr card = CardDatabaseManager::query()->getCardInfo(cardName);
-
-    if (card && card->getIsToken()) {
-        return DECK_ZONE_TOKENS;
-    }
-
-    return currentZoneName;
-}
-
-QString DeckLoader::getCompleteCardName(const QString &cardName)
-{
-    if (CardDatabaseManager::getInstance()) {
-        ExactCard temp = CardDatabaseManager::query()->guessCard({cardName});
-        if (temp) {
-            return temp.getName();
-        }
-    }
-
-    return cardName;
-}
-
 void DeckLoader::printDeckListNode(QTextCursor *cursor, const InnerDecklistNode *node)
 {
     const int totalColumns = 2;

--- a/cockatrice/src/interface/deck_loader/deck_loader.h
+++ b/cockatrice/src/interface/deck_loader/deck_loader.h
@@ -106,9 +106,6 @@ private:
                                            QList<DecklistCardNode *> cards,
                                            bool addComments = true,
                                            bool addSetNameAndNumber = true);
-
-    [[nodiscard]] static QString getCardZoneFromName(const QString &cardName, QString currentZoneName);
-    [[nodiscard]] static QString getCompleteCardName(const QString &cardName);
 };
 
 #endif


### PR DESCRIPTION
## Short roundup of the initial problem

`DeckLoader` has two unused private methods

## What will change with this Pull Request?
- Remove the two unused private methods in `DeckLoader`