### PR TITLE
README: Add repo activity with top contributors acknowledgment

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,11 @@ We'll happily advice on how best to implement a feature, or we can show you wher
 
 Cockatrice tries to use the [Google Developer Documentation Style Guide](https://developers.google.com/style/) to ensure consistent documentation. We encourage you to improve the documentation by suggesting edits based on this guide.
 
+#### Repository Activity
+![Cockatrice Repo Analytics](https://repobeats.axiom.co/api/embed/c7cec938789a5bbaeb4182a028b4dbb96db8f181.svg "Cockatrice Repo Analytics by Repobeats")
+
 <details>
-<summary><b>Kudos to our amazing contributors ❤️</b></summary>
+<summary><b>Kudos to all our amazing contributors ❤️</b></summary>
 <br>
    <a href="https://github.com/Cockatrice/Cockatrice/graphs/contributors">
       <img src="https://contrib.rocks/image?repo=Cockatrice/Cockatrice" />


### PR DESCRIPTION
Adding `Repository Activity` section to `Contribute` in README.

See https://github.com/Cockatrice/Cockatrice/tree/tooomm-readme_activity?tab=readme-ov-file#repository-activity:

<img width="1193" height="584" alt="image" src="https://github.com/user-attachments/assets/34e8eefc-f141-4da1-b05c-a30d098b501c" />

<br><br>

This uses https://repobeats.axiom.co/