### PR TITLE
[Refactor] Pass around LoadedDeck instead of DeckLoader

### DIFF
--- a/cockatrice/src/client/network/parsers/interface_json_deck_parser.h
+++ b/cockatrice/src/client/network/parsers/interface_json_deck_parser.h
@@ -18,21 +18,21 @@ class IJsonDeckParser
 public:
     virtual ~IJsonDeckParser() = default;
 
-    virtual DeckLoader *parse(const QJsonObject &obj) = 0;
+    virtual DeckList parse(const QJsonObject &obj) = 0;
 };
 
 class ArchidektJsonParser : public IJsonDeckParser
 {
 public:
-    DeckLoader *parse(const QJsonObject &obj) override
+    DeckList parse(const QJsonObject &obj) override
     {
-        DeckLoader *loader = new DeckLoader(nullptr);
+        DeckList deckList;
 
         QString deckName = obj.value("name").toString();
         QString deckDescription = obj.value("description").toString();
 
-        loader->getDeckList()->setName(deckName);
-        loader->getDeckList()->setComments(deckDescription);
+        deckList.setName(deckName);
+        deckList.setComments(deckDescription);
 
         QString outputText;
         QTextStream outStream(&outputText);
@@ -49,25 +49,25 @@ public:
             outStream << quantity << ' ' << cardName << " (" << setName << ") " << collectorNumber << '\n';
         }
 
-        loader->getDeckList()->loadFromStream_Plain(outStream, false);
-        loader->getDeckList()->forEachCard(CardNodeFunction::ResolveProviderId());
+        deckList.loadFromStream_Plain(outStream, false);
+        deckList.forEachCard(CardNodeFunction::ResolveProviderId());
 
-        return loader;
+        return deckList;
     }
 };
 
 class MoxfieldJsonParser : public IJsonDeckParser
 {
 public:
-    DeckLoader *parse(const QJsonObject &obj) override
+    DeckList parse(const QJsonObject &obj) override
     {
-        DeckLoader *loader = new DeckLoader(nullptr);
+        DeckList deckList;
 
         QString deckName = obj.value("name").toString();
         QString deckDescription = obj.value("description").toString();
 
-        loader->getDeckList()->setName(deckName);
-        loader->getDeckList()->setComments(deckDescription);
+        deckList.setName(deckName);
+        deckList.setComments(deckDescription);
 
         QString outputText;
         QTextStream outStream(&outputText);
@@ -96,8 +96,8 @@ public:
             outStream << quantity << ' ' << cardName << " (" << setName << ") " << collectorNumber << '\n';
         }
 
-        loader->getDeckList()->loadFromStream_Plain(outStream, false);
-        loader->getDeckList()->forEachCard(CardNodeFunction::ResolveProviderId());
+        deckList.loadFromStream_Plain(outStream, false);
+        deckList.forEachCard(CardNodeFunction::ResolveProviderId());
 
         QJsonObject commandersObj = obj.value("commanders").toObject();
         if (!commandersObj.isEmpty()) {
@@ -108,12 +108,12 @@ public:
                 QString collectorNumber = cardData.value("cn").toString();
                 QString providerId = cardData.value("scryfall_id").toString();
 
-                loader->getDeckList()->setBannerCard({commanderName, providerId});
-                loader->getDeckList()->addCard(commanderName, DECK_ZONE_MAIN, -1, setName, collectorNumber, providerId);
+                deckList.setBannerCard({commanderName, providerId});
+                deckList.addCard(commanderName, DECK_ZONE_MAIN, -1, setName, collectorNumber, providerId);
             }
         }
 
-        return loader;
+        return deckList;
     }
 };
 

--- a/cockatrice/src/filters/deck_filter_string.cpp
+++ b/cockatrice/src/filters/deck_filter_string.cpp
@@ -119,7 +119,7 @@ static void setupParserRules()
 
         return [=](const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &) -> bool {
             int count = 0;
-            auto cardNodes = deck->deckLoader->getDeckList()->getCardNodes();
+            auto cardNodes = deck->deckLoader->getDeck().deckList.getCardNodes();
             for (auto node : cardNodes) {
                 auto cardInfoPtr = CardDatabaseManager::query()->getCardInfo(node->getName());
                 if (!cardInfoPtr.isNull() && cardFilter.check(cardInfoPtr)) {
@@ -139,7 +139,7 @@ static void setupParserRules()
     search["DeckNameQuery"] = [](const peg::SemanticValues &sv) -> DeckFilter {
         auto name = std::any_cast<QString>(sv[0]);
         return [=](const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &) {
-            return deck->deckLoader->getDeckList()->getName().contains(name, Qt::CaseInsensitive);
+            return deck->deckLoader->getDeck().deckList.getName().contains(name, Qt::CaseInsensitive);
         };
     };
 
@@ -161,7 +161,7 @@ static void setupParserRules()
     search["FormatQuery"] = [](const peg::SemanticValues &sv) -> DeckFilter {
         auto format = std::any_cast<QString>(sv[0]);
         return [=](const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &) {
-            auto gameFormat = deck->deckLoader->getDeckList()->getGameFormat();
+            auto gameFormat = deck->deckLoader->getDeck().deckList.getGameFormat();
             return QString::compare(format, gameFormat, Qt::CaseInsensitive) == 0;
         };
     };

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -269,12 +269,12 @@ void DeckViewContainer::loadDeckFromFile(const QString &filePath)
         return;
     }
 
-    loadDeckFromDeckLoader(&deck);
+    loadDeckFromDeckList(deck.getDeck().deckList);
 }
 
-void DeckViewContainer::loadDeckFromDeckLoader(DeckLoader *deck)
+void DeckViewContainer::loadDeckFromDeckList(const DeckList &deck)
 {
-    QString deckString = deck->getDeckList()->writeToString_Native();
+    QString deckString = deck.writeToString_Native();
 
     if (deckString.length() > MAX_FILE_LENGTH) {
         QMessageBox::critical(this, tr("Error"), tr("Deck is greater than maximum file size."));
@@ -308,8 +308,8 @@ void DeckViewContainer::loadFromClipboard()
         return;
     }
 
-    DeckLoader *deck = dlg.getDeckList();
-    loadDeckFromDeckLoader(deck);
+    DeckList deck = dlg.getDeckList();
+    loadDeckFromDeckList(deck);
 }
 
 void DeckViewContainer::loadFromWebsite()
@@ -320,16 +320,15 @@ void DeckViewContainer::loadFromWebsite()
         return;
     }
 
-    DeckLoader *deck = dlg.getDeck();
-    loadDeckFromDeckLoader(deck);
+    DeckList deck = dlg.getDeck();
+    loadDeckFromDeckList(deck);
 }
 
 void DeckViewContainer::deckSelectFinished(const Response &r)
 {
     const Response_DeckDownload &resp = r.GetExtension(Response_DeckDownload::ext);
-    DeckLoader newDeck(this, new DeckList(QString::fromStdString(resp.deck())));
-    CardPictureLoader::cacheCardPixmaps(
-        CardDatabaseManager::query()->getCards(newDeck.getDeckList()->getCardRefList()));
+    DeckList newDeck = DeckList(QString::fromStdString(resp.deck()));
+    CardPictureLoader::cacheCardPixmaps(CardDatabaseManager::query()->getCards(newDeck.getCardRefList()));
     setDeck(newDeck);
     switchToDeckLoadedView();
 }
@@ -410,8 +409,8 @@ void DeckViewContainer::setSideboardLocked(bool locked)
         deckView->resetSideboardPlan();
 }
 
-void DeckViewContainer::setDeck(DeckLoader &deck)
+void DeckViewContainer::setDeck(const DeckList &deck)
 {
-    deckView->setDeck(*deck.getDeckList());
+    deckView->setDeck(deck);
     switchToDeckLoadedView();
 }

--- a/cockatrice/src/game/deckview/deck_view_container.h
+++ b/cockatrice/src/game/deckview/deck_view_container.h
@@ -85,12 +85,12 @@ public:
     void setReadyStart(bool ready);
     void readyAndUpdate();
     void setSideboardLocked(bool locked);
-    void setDeck(DeckLoader &deck);
+    void setDeck(const DeckList &deck);
     void setVisualDeckStorageExists(bool exists);
 
 public slots:
     void loadDeckFromFile(const QString &filePath);
-    void loadDeckFromDeckLoader(DeckLoader *deck);
+    void loadDeckFromDeckList(const DeckList &deck);
 };
 
 #endif // DECK_VIEW_CONTAINER_H

--- a/cockatrice/src/game/player/menu/utility_menu.cpp
+++ b/cockatrice/src/game/player/menu/utility_menu.cpp
@@ -60,13 +60,13 @@ void UtilityMenu::populatePredefinedTokensMenu()
     clear();
     setEnabled(false);
     predefinedTokens.clear();
-    DeckLoader *_deck = player->getDeck();
+    const DeckList &deckList = player->getDeck();
 
-    if (!_deck) {
+    if (deckList.isEmpty()) {
         return;
     }
 
-    auto tokenCardNodes = _deck->getDeckList()->getCardNodes({DECK_ZONE_TOKENS});
+    auto tokenCardNodes = deckList.getCardNodes({DECK_ZONE_TOKENS});
 
     if (!tokenCardNodes.isEmpty()) {
         setEnabled(true);

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -32,7 +32,7 @@
 Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, AbstractGame *_parent)
     : QObject(_parent), game(_parent), playerInfo(new PlayerInfo(info, _id, _local, _judge)),
       playerEventHandler(new PlayerEventHandler(this)), playerActions(new PlayerActions(this)), active(false),
-      conceded(false), deck(nullptr), zoneId(0), dialogSemaphore(false)
+      conceded(false), zoneId(0), dialogSemaphore(false)
 {
     initializeZones();
 
@@ -263,10 +263,9 @@ void Player::deleteCard(CardItem *card)
     }
 }
 
-//! \todo Does a player need a DeckLoader?
-void Player::setDeck(DeckLoader &_deck)
+void Player::setDeck(const DeckList &_deck)
 {
-    deck = new DeckLoader(this, _deck.getDeckList());
+    deck = _deck;
 
     emit deckChanged();
 }

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -9,6 +9,7 @@
 
 #include "../../game_graphics/board/abstract_graphics_item.h"
 #include "../../interface/widgets/menus/tearoff_menu.h"
+#include "../interface/deck_loader/loaded_deck.h"
 #include "../zones/logic/hand_zone_logic.h"
 #include "../zones/logic/pile_zone_logic.h"
 #include "../zones/logic/stack_zone_logic.h"
@@ -44,7 +45,6 @@ class ArrowTarget;
 class CardDatabase;
 class CardZone;
 class CommandContainer;
-class DeckLoader;
 class GameCommand;
 class GameEvent;
 class PlayerInfo;
@@ -66,7 +66,7 @@ class Player : public QObject
     Q_OBJECT
 
 signals:
-    void openDeckEditor(DeckLoader *deck);
+    void openDeckEditor(const LoadedDeck &deck);
     void deckChanged();
     void newCardAdded(AbstractCardItem *card);
     void rearrangeCounters();
@@ -130,9 +130,9 @@ public:
         return playerMenu;
     }
 
-    void setDeck(DeckLoader &_deck);
+    void setDeck(const DeckList &_deck);
 
-    [[nodiscard]] DeckLoader *getDeck() const
+    [[nodiscard]] const DeckList &getDeck() const
     {
         return deck;
     }
@@ -241,7 +241,7 @@ private:
     bool active;
     bool conceded;
 
-    DeckLoader *deck;
+    DeckList deck;
 
     int zoneId;
     QMap<QString, CardZoneLogic *> zones;

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -218,7 +218,7 @@ void PlayerActions::actAlwaysLookAtTopCard()
 
 void PlayerActions::actOpenDeckInDeckEditor()
 {
-    emit player->openDeckEditor(player->getDeck());
+    emit player->openDeckEditor({.deckList = player->getDeck()});
 }
 
 void PlayerActions::actViewGraveyard()

--- a/cockatrice/src/interface/deck_loader/deck_loader.h
+++ b/cockatrice/src/interface/deck_loader/deck_loader.h
@@ -41,28 +41,16 @@ public:
     };
 
 private:
-    DeckList *deckList;
-    LoadedDeck::LoadInfo lastLoadInfo;
+    LoadedDeck loadedDeck;
 
 public:
     DeckLoader(QObject *parent);
-    DeckLoader(QObject *parent, DeckList *_deckList);
     DeckLoader(const DeckLoader &) = delete;
     DeckLoader &operator=(const DeckLoader &) = delete;
 
-    const LoadedDeck::LoadInfo &getLastLoadInfo() const
-    {
-        return lastLoadInfo;
-    }
-
-    void setLastLoadInfo(const LoadedDeck::LoadInfo &info)
-    {
-        lastLoadInfo = info;
-    }
-
     [[nodiscard]] bool hasNotBeenLoaded() const
     {
-        return lastLoadInfo.isEmpty();
+        return loadedDeck.lastLoadInfo.isEmpty();
     }
 
     bool loadFromFile(const QString &fileName, DeckFileFormat::Format fmt, bool userRequest = false);
@@ -88,9 +76,17 @@ public:
 
     bool convertToCockatriceFormat(QString fileName);
 
-    DeckList *getDeckList()
+    LoadedDeck &getDeck()
     {
-        return deckList;
+        return loadedDeck;
+    }
+    const LoadedDeck &getDeck() const
+    {
+        return loadedDeck;
+    }
+    void setDeck(const LoadedDeck &deck)
+    {
+        loadedDeck = deck;
     }
 
 private:

--- a/cockatrice/src/interface/deck_loader/loaded_deck.h
+++ b/cockatrice/src/interface/deck_loader/loaded_deck.h
@@ -30,8 +30,8 @@ struct LoadedDeck
         bool isEmpty() const;
     };
 
-    DeckList deckList;     ///< The decklist itself
-    LoadInfo lastLoadInfo; ///< info about where the deck was loaded from
+    DeckList deckList;          ///< The decklist itself
+    LoadInfo lastLoadInfo = {}; ///< info about where the deck was loaded from
 
     bool isEmpty() const;
 };

--- a/cockatrice/src/interface/widgets/cards/deck_preview_card_picture_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/deck_preview_card_picture_widget.cpp
@@ -17,7 +17,6 @@
  * @param outlineColor The color of the outline around the text.
  * @param fontSize The font size of the overlay text.
  * @param alignment The alignment of the text within the overlay.
- * @param _deckLoader The Deck Loader holding the Deck associated with this preview.
  *
  * Sets the widget's size policy and default border style.
  */

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -56,7 +56,7 @@ void DeckEditorDeckDockWidget::createDeckDock()
     deckModel->setObjectName("deckModel");
     connect(deckModel, &DeckListModel::deckHashChanged, this, &DeckEditorDeckDockWidget::updateHash);
 
-    deckLoader = new DeckLoader(this, deckModel->getDeckList());
+    deckLoader = new DeckLoader(this);
 
     proxy = new DeckListStyleProxy(this);
     proxy->setSourceModel(deckModel);
@@ -347,7 +347,7 @@ void DeckEditorDeckDockWidget::updateCard(const QModelIndex /*&current*/, const 
 void DeckEditorDeckDockWidget::updateName(const QString &name)
 {
     emit requestDeckHistorySave(
-        QString(tr("Rename deck to \"%1\" from \"%2\"")).arg(name).arg(deckLoader->getDeckList()->getName()));
+        QString(tr("Rename deck to \"%1\" from \"%2\"")).arg(name).arg(deckLoader->getDeck().deckList.getName()));
     deckModel->getDeckList()->setName(name);
     deckEditor->setModified(name.isEmpty());
     emit nameChanged();
@@ -357,7 +357,7 @@ void DeckEditorDeckDockWidget::updateName(const QString &name)
 void DeckEditorDeckDockWidget::updateComments()
 {
     emit requestDeckHistorySave(tr("Updated comments (was %1 chars, now %2 chars)")
-                                    .arg(deckLoader->getDeckList()->getComments().size())
+                                    .arg(deckLoader->getDeck().deckList.getComments().size())
                                     .arg(commentsEdit->toPlainText().size()));
 
     deckModel->getDeckList()->setComments(commentsEdit->toPlainText());
@@ -474,13 +474,12 @@ void DeckEditorDeckDockWidget::syncBannerCardComboBoxSelectionWithDeck()
 
 /**
  * Sets the currently active deck for this tab
- * @param _deck The deck. Takes ownership of the object
+ * @param _deck The deck.
  */
-void DeckEditorDeckDockWidget::setDeck(DeckLoader *_deck)
+void DeckEditorDeckDockWidget::setDeck(const LoadedDeck &_deck)
 {
-    deckLoader = _deck;
-    deckLoader->setParent(this);
-    deckModel->setDeckList(deckLoader->getDeckList());
+    deckLoader->setDeck(_deck);
+    deckModel->setDeckList(&deckLoader->getDeck().deckList);
     connect(deckLoader, &DeckLoader::deckLoaded, deckModel, &DeckListModel::rebuildTree);
 
     emit requestDeckHistoryClear();

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.h
@@ -57,7 +57,7 @@ public:
 public slots:
     void cleanDeck();
     void updateBannerCardComboBox();
-    void setDeck(DeckLoader *_deck);
+    void setDeck(const LoadedDeck &_deck);
     void syncDisplayWidgetsToModel();
     void sortDeckModelToDeckView();
     DeckLoader *getDeckLoader();

--- a/cockatrice/src/interface/widgets/dialogs/dlg_load_deck_from_clipboard.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_load_deck_from_clipboard.cpp
@@ -66,26 +66,26 @@ void AbstractDlgDeckTextEdit::setText(const QString &text)
 }
 
 /**
- * Tries to load the current contents of the contentsEdit into the DeckLoader
+ * Tries to load the current contents of the contentsEdit into the deckList
  *
- * @param deckLoader The DeckLoader to load the deck into
+ * @param deckList The deckList to load the deck into
  * @return Whether the loading was successful
  */
-bool AbstractDlgDeckTextEdit::loadIntoDeck(DeckLoader *deckLoader) const
+bool AbstractDlgDeckTextEdit::loadIntoDeck(DeckList &deckList) const
 {
     QString buffer = contentsEdit->toPlainText();
 
     if (buffer.contains("<cockatrice_deck version=\"1\">")) {
-        return deckLoader->getDeckList()->loadFromString_Native(buffer);
+        return deckList.loadFromString_Native(buffer);
     }
 
     QTextStream stream(&buffer);
 
-    if (deckLoader->getDeckList()->loadFromStream_Plain(stream, true)) {
+    if (deckList.loadFromStream_Plain(stream, true)) {
         if (loadSetNameAndNumberCheckBox->isChecked()) {
-            deckLoader->getDeckList()->forEachCard(CardNodeFunction::ResolveProviderId());
+            deckList.forEachCard(CardNodeFunction::ResolveProviderId());
         } else {
-            deckLoader->getDeckList()->forEachCard(CardNodeFunction::ClearPrintingData());
+            deckList.forEachCard(CardNodeFunction::ClearPrintingData());
         }
         return true;
     }
@@ -108,7 +108,7 @@ void AbstractDlgDeckTextEdit::keyPressEvent(QKeyEvent *event)
  *
  * @param parent The parent widget
  */
-DlgLoadDeckFromClipboard::DlgLoadDeckFromClipboard(QWidget *parent) : AbstractDlgDeckTextEdit(parent), deckList(nullptr)
+DlgLoadDeckFromClipboard::DlgLoadDeckFromClipboard(QWidget *parent) : AbstractDlgDeckTextEdit(parent)
 {
     setWindowTitle(tr("Load deck from clipboard"));
 
@@ -122,8 +122,6 @@ void DlgLoadDeckFromClipboard::actRefresh()
 
 void DlgLoadDeckFromClipboard::actOK()
 {
-    deckList = new DeckLoader(this);
-
     if (loadIntoDeck(deckList)) {
         accept();
     } else {
@@ -134,17 +132,14 @@ void DlgLoadDeckFromClipboard::actOK()
 /**
  * Creates the dialog window for the "Edit deck in clipboard" action
  *
- * @param _deckLoader The existing deck in the deck editor. Copies the instance
+ * @param _deckList The existing deck in the deck editor.
  * @param _annotated Whether to add annotations to the text that is loaded from the deck
  * @param parent The parent widget
  */
-DlgEditDeckInClipboard::DlgEditDeckInClipboard(DeckLoader *_deckLoader, bool _annotated, QWidget *parent)
-    : AbstractDlgDeckTextEdit(parent), annotated(_annotated)
+DlgEditDeckInClipboard::DlgEditDeckInClipboard(const DeckList &_deckList, bool _annotated, QWidget *parent)
+    : AbstractDlgDeckTextEdit(parent), deckList(_deckList), annotated(_annotated)
 {
     setWindowTitle(tr("Edit deck in clipboard"));
-
-    deckLoader = new DeckLoader(this, _deckLoader->getDeckList());
-    deckLoader->setParent(this);
 
     DlgEditDeckInClipboard::actRefresh();
 }
@@ -165,12 +160,12 @@ static QString deckListToString(const DeckList *deckList, bool addComments)
 
 void DlgEditDeckInClipboard::actRefresh()
 {
-    setText(deckListToString(deckLoader->getDeckList(), annotated));
+    setText(deckListToString(&deckList, annotated));
 }
 
 void DlgEditDeckInClipboard::actOK()
 {
-    if (loadIntoDeck(deckLoader)) {
+    if (loadIntoDeck(deckList)) {
         accept();
     } else {
         QMessageBox::critical(this, tr("Error"), tr("Invalid deck list."));

--- a/cockatrice/src/interface/widgets/dialogs/dlg_load_deck_from_clipboard.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_load_deck_from_clipboard.h
@@ -8,10 +8,11 @@
 #ifndef DLG_LOAD_DECK_FROM_CLIPBOARD_H
 #define DLG_LOAD_DECK_FROM_CLIPBOARD_H
 
+#include "../../deck_loader/loaded_deck.h"
+
 #include <QCheckBox>
 #include <QDialog>
 
-class DeckLoader;
 class QPlainTextEdit;
 class QPushButton;
 
@@ -35,15 +36,13 @@ public:
     /**
      * Gets the loaded deck. Only call this method after this dialog window has been successfully exec'd.
      *
-     * The returned DeckLoader is parented to this object; make sure to take ownership of the DeckLoader if you intend
-     * to use it, since otherwise it will get destroyed once this dlg is destroyed
-     * @return The DeckLoader
+     * @return The loaded decklist
      */
-    [[nodiscard]] virtual DeckLoader *getDeckList() const = 0;
+    [[nodiscard]] virtual const DeckList &getDeckList() = 0;
 
 protected:
     void setText(const QString &text);
-    bool loadIntoDeck(DeckLoader *deckLoader) const;
+    bool loadIntoDeck(DeckList &deckList) const;
     void keyPressEvent(QKeyEvent *event) override;
 
 protected slots:
@@ -62,12 +61,12 @@ protected slots:
     void actRefresh() override;
 
 private:
-    DeckLoader *deckList;
+    DeckList deckList;
 
 public:
     explicit DlgLoadDeckFromClipboard(QWidget *parent = nullptr);
 
-    [[nodiscard]] DeckLoader *getDeckList() const override
+    [[nodiscard]] const DeckList &getDeckList() override
     {
         return deckList;
     }
@@ -84,15 +83,15 @@ protected slots:
     void actRefresh() override;
 
 private:
-    DeckLoader *deckLoader;
+    DeckList deckList;
     bool annotated;
 
 public:
-    explicit DlgEditDeckInClipboard(DeckLoader *_deckLoader, bool _annotated, QWidget *parent = nullptr);
+    explicit DlgEditDeckInClipboard(const DeckList &_deckList, bool _annotated, QWidget *parent = nullptr);
 
-    [[nodiscard]] DeckLoader *getDeckList() const override
+    [[nodiscard]] const DeckList &getDeckList() override
     {
-        return deckLoader;
+        return deckList;
     }
 };
 

--- a/cockatrice/src/interface/widgets/dialogs/dlg_load_deck_from_website.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_load_deck_from_website.cpp
@@ -97,11 +97,11 @@ void DlgLoadDeckFromWebsite::accept()
             }
 
             // Parse the plain text deck here
-            DeckLoader *loader = new DeckLoader(this);
+            DeckList deckList;
             QTextStream stream(&deckText);
-            loader->getDeckList()->loadFromStream_Plain(stream, false);
-            loader->getDeckList()->forEachCard(CardNodeFunction::ResolveProviderId());
-            deck = loader;
+            deckList.loadFromStream_Plain(stream, false);
+            deckList.forEachCard(CardNodeFunction::ResolveProviderId());
+            deck = deckList;
 
             QDialog::accept();
             return;

--- a/cockatrice/src/interface/widgets/dialogs/dlg_load_deck_from_website.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_load_deck_from_website.h
@@ -26,9 +26,9 @@ public:
     explicit DlgLoadDeckFromWebsite(QWidget *parent);
     void retranslateUi();
     bool testValidUrl();
-    DeckLoader *deck;
+    DeckList deck;
 
-    DeckLoader *getDeck()
+    const DeckList &getDeck() const
     {
         return deck;
     }

--- a/cockatrice/src/interface/widgets/general/home_widget.cpp
+++ b/cockatrice/src/interface/widgets/general/home_widget.cpp
@@ -20,10 +20,6 @@ HomeWidget::HomeWidget(QWidget *parent, TabSupervisor *_tabSupervisor)
     layout = new QGridLayout(this);
 
     backgroundSourceCard = new CardInfoPictureArtCropWidget(this);
-    backgroundSourceDeck = new DeckLoader(this);
-
-    backgroundSourceDeck->loadFromFile(SettingsCache::instance().getDeckPath() + "background.cod",
-                                       DeckFileFormat::Cockatrice, false);
 
     gradientColors = extractDominantColors(background);
 
@@ -72,11 +68,18 @@ void HomeWidget::initializeBackgroundFromSource()
             cardChangeTimer->start(SettingsCache::instance().getHomeTabBackgroundShuffleFrequency() * 1000);
             break;
         case BackgroundSources::DeckFileArt:
-            backgroundSourceDeck->loadFromFile(SettingsCache::instance().getDeckPath() + "background.cod",
-                                               DeckFileFormat::Cockatrice, false);
+            loadBackgroundSourceDeck();
             cardChangeTimer->start(SettingsCache::instance().getHomeTabBackgroundShuffleFrequency() * 1000);
             break;
     }
+}
+
+void HomeWidget::loadBackgroundSourceDeck()
+{
+    DeckLoader deckLoader = DeckLoader(this);
+    deckLoader.loadFromFile(SettingsCache::instance().getDeckPath() + "background.cod", DeckFileFormat::Cockatrice,
+                            false);
+    backgroundSourceDeck = deckLoader.getDeck().deckList;
 }
 
 void HomeWidget::updateRandomCard()
@@ -95,7 +98,7 @@ void HomeWidget::updateRandomCard()
                      newCard.getCardPtr()->getProperty("layout") != "normal");
             break;
         case BackgroundSources::DeckFileArt:
-            QList<CardRef> cardRefs = backgroundSourceDeck->getDeckList()->getCardRefList();
+            QList<CardRef> cardRefs = backgroundSourceDeck.getCardRefList();
             ExactCard oldCard = backgroundSourceCard->getCard();
 
             if (!cardRefs.empty()) {
@@ -183,7 +186,7 @@ QGroupBox *HomeWidget::createButtons()
 
     auto visualDeckEditorButton = new HomeStyledButton(tr("Create New Deck"), gradientColors);
     connect(visualDeckEditorButton, &QPushButton::clicked, tabSupervisor,
-            [this] { tabSupervisor->openDeckInNewTab(nullptr); });
+            [this] { tabSupervisor->openDeckInNewTab(LoadedDeck()); });
     boxLayout->addWidget(visualDeckEditorButton);
     auto visualDeckStorageButton = new HomeStyledButton(tr("Browse Decks"), gradientColors);
     connect(visualDeckStorageButton, &QPushButton::clicked, tabSupervisor,

--- a/cockatrice/src/interface/widgets/general/home_widget.h
+++ b/cockatrice/src/interface/widgets/general/home_widget.h
@@ -40,10 +40,12 @@ private:
     TabSupervisor *tabSupervisor;
     QPixmap background;
     CardInfoPictureArtCropWidget *backgroundSourceCard = nullptr;
-    DeckLoader *backgroundSourceDeck;
+    DeckList backgroundSourceDeck;
     QPixmap overlay;
     QPair<QColor, QColor> gradientColors;
     HomeStyledButton *connectButton;
+
+    void loadBackgroundSourceDeck();
 };
 
 #endif // HOME_WIDGET_H

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
@@ -114,9 +114,9 @@ public:
     virtual void retranslateUi() override = 0;
 
     /** @brief Opens a deck in this tab.
-     *  @param deck Pointer to a DeckLoader object.
+     *  @param deck The deck to open
      */
-    void openDeck(DeckLoader *deck);
+    void openDeck(const LoadedDeck &deck);
 
     /** @brief Returns the currently active deck loader. */
     DeckLoader *getDeckLoader() const;
@@ -198,7 +198,7 @@ public slots:
 
 signals:
     /** @brief Emitted when a deck should be opened in a new editor tab. */
-    void openDeckEditor(DeckLoader *deckLoader);
+    void openDeckEditor(const LoadedDeck &deck);
 
     /** @brief Emitted before the tab is closed. */
     void deckEditorClosing(AbstractTabDeckEditor *tab);
@@ -286,7 +286,7 @@ private:
     /** @brief Sets the deck for this tab.
      *  @param _deck The deck object.
      */
-    virtual void setDeck(DeckLoader *_deck);
+    virtual void setDeck(const LoadedDeck &_deck);
 
     /** @brief Helper for editing decks from the clipboard. */
     void editDeckInClipboard(bool annotated);

--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/display/archidekt_api_response_deck_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/display/archidekt_api_response_deck_display_widget.cpp
@@ -90,14 +90,14 @@ void ArchidektApiResponseDeckDisplayWidget::onGroupCriteriaChange(const QString 
 
 void ArchidektApiResponseDeckDisplayWidget::actOpenInDeckEditor()
 {
-    auto loader = new DeckLoader(this);
-    loader->getDeckList()->loadFromString_Native(model->getDeckList()->writeToString_Native());
-
-    loader->getDeckList()->setName(response.getDeckName());
-    loader->getDeckList()->setGameFormat(
+    DeckList deckList(*model->getDeckList());
+    deckList.setName(response.getDeckName());
+    deckList.setGameFormat(
         ArchidektFormats::formatToCockatriceName(ArchidektFormats::DeckFormat(response.getDeckFormat() - 1)));
 
-    emit openInDeckEditor(loader);
+    LoadedDeck loadedDeck = {deckList, {}};
+
+    emit openInDeckEditor(loadedDeck);
 }
 
 void ArchidektApiResponseDeckDisplayWidget::clearAllDisplayWidgets()

--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/display/archidekt_api_response_deck_display_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/display/archidekt_api_response_deck_display_widget.h
@@ -31,7 +31,7 @@
  *
  * ### Signals
  * - `requestNavigation(QString url)` — triggered when navigation to a deck URL is requested.
- * - `openInDeckEditor(DeckLoader *loader)` — emitted when the user chooses to open the deck
+ * - `openInDeckEditor(const LoadedDeck &deck)` — emitted when the user chooses to open the deck
  *   in the deck editor.
  *
  * ### Features
@@ -52,9 +52,9 @@ signals:
 
     /**
      * @brief Emitted when the deck should be opened in the deck editor.
-     * @param loader Initialized DeckLoader containing the deck data.
+     * @param deck LoadedDeck containing the deck data.
      */
-    void openInDeckEditor(DeckLoader *loader);
+    void openInDeckEditor(const LoadedDeck &deck);
 
 public:
     /**
@@ -75,7 +75,7 @@ public:
     void retranslateUi();
 
     /**
-     * @brief Opens the deck in the deck editor via DeckLoader.
+     * @brief Opens the deck in the deck editor.
      */
     void actOpenInDeckEditor();
 

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/average_deck/edhrec_deck_api_response.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/average_deck/edhrec_deck_api_response.cpp
@@ -14,10 +14,8 @@ void EdhrecDeckApiResponse::fromJson(const QJsonArray &json)
         deckList += cardlistValue.toString() + "\n";
     }
 
-    deckLoader = new DeckLoader(nullptr);
-
     QTextStream stream(&deckList);
-    deckLoader->getDeckList()->loadFromStream_Plain(stream, true);
+    deck.loadFromStream_Plain(stream, true);
 }
 
 void EdhrecDeckApiResponse::debugPrint() const

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/average_deck/edhrec_deck_api_response.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/average_deck/edhrec_deck_api_response.h
@@ -21,7 +21,7 @@ public:
     // Debug method for logging
     void debugPrint() const;
 
-    DeckLoader *deckLoader;
+    DeckList deck;
 };
 
 #endif // EDHREC_DECK_API_RESPONSE_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/tab_edhrec_main.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/tab_edhrec_main.cpp
@@ -363,7 +363,7 @@ void TabEdhRecMain::processAverageDeckResponse(QJsonObject reply)
 {
     EdhrecAverageDeckApiResponse deckData;
     deckData.fromJson(reply);
-    tabSupervisor->openDeckInNewTab(deckData.deck.deckLoader);
+    tabSupervisor->openDeckInNewTab({deckData.deck.deck, {}});
 }
 
 void TabEdhRecMain::prettyPrintJson(const QJsonValue &value, int indentLevel)

--- a/cockatrice/src/interface/widgets/tabs/tab_deck_editor.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_deck_editor.h
@@ -12,7 +12,6 @@ class CardDatabaseDisplayModel;
 class DeckListModel;
 
 class QLabel;
-class DeckLoader;
 
 /**
  * @class TabDeckEditor

--- a/cockatrice/src/interface/widgets/tabs/tab_deck_storage.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_deck_storage.h
@@ -13,6 +13,7 @@
 
 #include <libcockatrice/network/client/abstract/abstract_client.h>
 
+struct LoadedDeck;
 class ServerInfo_User;
 class AbstractClient;
 class QTreeView;
@@ -23,7 +24,6 @@ class QTreeWidgetItem;
 class QGroupBox;
 class CommandContainer;
 class Response;
-class DeckLoader;
 
 class TabDeckStorage : public Tab
 {
@@ -87,7 +87,7 @@ public:
         return tr("Deck Storage");
     }
 signals:
-    void openDeckEditor(DeckLoader *deckLoader);
+    void openDeckEditor(const LoadedDeck &deck);
 };
 
 #endif

--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -749,11 +749,10 @@ void TabGame::loadDeckForLocalPlayer(Player *localPlayer, int playerId, ServerIn
 {
     TabbedDeckViewContainer *deckViewContainer = deckViewContainers.value(playerId);
     if (playerInfo.has_deck_list()) {
-        DeckLoader newDeck(this, new DeckList(QString::fromStdString(playerInfo.deck_list())));
-        CardPictureLoader::cacheCardPixmaps(
-            CardDatabaseManager::query()->getCards(newDeck.getDeckList()->getCardRefList()));
-        deckViewContainer->playerDeckView->setDeck(newDeck);
-        localPlayer->setDeck(newDeck);
+        DeckList deckList = DeckList(QString::fromStdString(playerInfo.deck_list()));
+        CardPictureLoader::cacheCardPixmaps(CardDatabaseManager::query()->getCards(deckList.getCardRefList()));
+        deckViewContainer->playerDeckView->setDeck(deckList);
+        localPlayer->setDeck(deckList);
     }
 }
 

--- a/cockatrice/src/interface/widgets/tabs/tab_game.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.h
@@ -45,7 +45,6 @@ class ReplayTimelineWidget;
 class CardZone;
 class AbstractCardItem;
 class CardItem;
-class DeckLoader;
 class QVBoxLayout;
 class QHBoxLayout;
 class GameReplay;
@@ -119,7 +118,7 @@ signals:
     void containerProcessingStarted(const GameEventContext &context);
     void containerProcessingDone();
     void openMessageDialog(const QString &userName, bool focus);
-    void openDeckEditor(DeckLoader *deck);
+    void openDeckEditor(const LoadedDeck &deck);
     void notIdle();
 
     void phaseChanged(int phase);

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
@@ -133,10 +133,10 @@ TabSupervisor::TabSupervisor(AbstractClient *_client, QMenu *tabsMenu, QWidget *
 
     // create tabs menu actions
     aTabDeckEditor = new QAction(this);
-    connect(aTabDeckEditor, &QAction::triggered, this, [this] { addDeckEditorTab(nullptr); });
+    connect(aTabDeckEditor, &QAction::triggered, this, [this] { addDeckEditorTab(LoadedDeck()); });
 
     aTabVisualDeckEditor = new QAction(this);
-    connect(aTabVisualDeckEditor, &QAction::triggered, this, [this] { addVisualDeckEditorTab(nullptr); });
+    connect(aTabVisualDeckEditor, &QAction::triggered, this, [this] { addVisualDeckEditorTab(LoadedDeck()); });
 
     aTabEdhRec = new QAction(this);
     connect(aTabEdhRec, &QAction::triggered, this, [this] { addEdhrecMainTab(); });
@@ -846,9 +846,9 @@ void TabSupervisor::talkLeft(TabMessage *tab)
 /**
  * Creates a new deck editor tab and loads the deck into it.
  * Creates either a classic or visual deck editor tab depending on settings
- * @param deckToOpen The deck to open in the tab. Creates a copy of the DeckLoader instance.
+ * @param deckToOpen The deck to open in the tab.
  */
-void TabSupervisor::openDeckInNewTab(DeckLoader *deckToOpen)
+void TabSupervisor::openDeckInNewTab(const LoadedDeck &deckToOpen)
 {
     int type = SettingsCache::instance().getDefaultDeckEditorType();
     switch (type) {
@@ -868,13 +868,12 @@ void TabSupervisor::openDeckInNewTab(DeckLoader *deckToOpen)
 
 /**
  * Creates a new deck editor tab
- * @param deckToOpen The deck to open in the tab. Creates a copy of the DeckLoader instance.
+ * @param deckToOpen The deck to open in the tab.
  */
-TabDeckEditor *TabSupervisor::addDeckEditorTab(DeckLoader *deckToOpen)
+TabDeckEditor *TabSupervisor::addDeckEditorTab(const LoadedDeck &deckToOpen)
 {
     auto *tab = new TabDeckEditor(this);
-    if (deckToOpen)
-        tab->openDeck(deckToOpen);
+    tab->openDeck(deckToOpen);
     connect(tab, &AbstractTabDeckEditor::deckEditorClosing, this, &TabSupervisor::deckEditorClosed);
     connect(tab, &AbstractTabDeckEditor::openDeckEditor, this, &TabSupervisor::addDeckEditorTab);
     myAddTab(tab);
@@ -883,11 +882,10 @@ TabDeckEditor *TabSupervisor::addDeckEditorTab(DeckLoader *deckToOpen)
     return tab;
 }
 
-TabDeckEditorVisual *TabSupervisor::addVisualDeckEditorTab(DeckLoader *deckToOpen)
+TabDeckEditorVisual *TabSupervisor::addVisualDeckEditorTab(const LoadedDeck &deckToOpen)
 {
     auto *tab = new TabDeckEditorVisual(this);
-    if (deckToOpen)
-        tab->openDeck(deckToOpen);
+    tab->openDeck(deckToOpen);
     connect(tab, &AbstractTabDeckEditor::deckEditorClosing, this, &TabSupervisor::deckEditorClosed);
     connect(tab, &AbstractTabDeckEditor::openDeckEditor, this, &TabSupervisor::addVisualDeckEditorTab);
     myAddTab(tab);

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.h
@@ -168,9 +168,9 @@ signals:
     void showWindowIfHidden();
 
 public slots:
-    void openDeckInNewTab(DeckLoader *deckToOpen);
-    TabDeckEditor *addDeckEditorTab(DeckLoader *deckToOpen);
-    TabDeckEditorVisual *addVisualDeckEditorTab(DeckLoader *deckToOpen);
+    void openDeckInNewTab(const LoadedDeck &deckToOpen);
+    TabDeckEditor *addDeckEditorTab(const LoadedDeck &deckToOpen);
+    TabDeckEditorVisual *addVisualDeckEditorTab(const LoadedDeck &deckToOpen);
     TabVisualDatabaseDisplay *addVisualDatabaseDisplayTab();
     TabEdhRecMain *addEdhrecMainTab();
     TabArchidekt *addArchidektTab();

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_storage/tab_deck_storage_visual.cpp
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_storage/tab_deck_storage_visual.cpp
@@ -24,11 +24,11 @@ TabDeckStorageVisual::TabDeckStorageVisual(TabSupervisor *_tabSupervisor)
 
 void TabDeckStorageVisual::actOpenLocalDeck(const QString &filePath)
 {
-    auto deckLoader = new DeckLoader(this);
-    if (!deckLoader->loadFromFile(filePath, DeckFileFormat::getFormatFromName(filePath), true)) {
+    auto deckLoader = DeckLoader(this);
+    if (!deckLoader.loadFromFile(filePath, DeckFileFormat::getFormatFromName(filePath), true)) {
         QMessageBox::critical(this, tr("Error"), tr("Could not open deck at %1").arg(filePath));
         return;
     }
 
-    emit openDeckEditor(deckLoader);
+    emit openDeckEditor(deckLoader.getDeck());
 }

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_storage/tab_deck_storage_visual.h
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_storage/tab_deck_storage_visual.h
@@ -9,9 +9,9 @@
 
 #include "../tab.h"
 
+struct LoadedDeck;
 class AbstractClient;
 class CommandContainer;
-class DeckLoader;
 class DeckPreviewWidget;
 class QFileSystemModel;
 class QGroupBox;
@@ -39,7 +39,7 @@ public slots:
     void actOpenLocalDeck(const QString &filePath);
 
 signals:
-    void openDeckEditor(DeckLoader *deckLoader);
+    void openDeckEditor(const LoadedDeck &deck);
 
 private:
     VisualDeckStorageWidget *visualDeckStorageWidget;

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_name_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_name_filter_widget.cpp
@@ -83,7 +83,7 @@ void VisualDatabaseDisplayNameFilterWidget::actLoadFromClipboard()
     if (!dlg.exec())
         return;
 
-    QStringList cardsInClipboard = dlg.getDeckList()->getDeckList()->getCardList();
+    QStringList cardsInClipboard = dlg.getDeckList().getCardList();
     for (QString cardName : cardsInClipboard) {
         createNameFilter(cardName);
     }

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.cpp
@@ -80,7 +80,7 @@ static QStringList findAllKnownTags()
     auto loader = DeckLoader(nullptr);
     for (const QString &file : allFiles) {
         loader.loadFromFile(file, DeckFileFormat::getFormatFromName(file), false);
-        QStringList tags = loader.getDeckList()->getTags();
+        QStringList tags = loader.getDeck().deckList.getTags();
         knownTags.append(tags);
         knownTags.removeDuplicates();
     }
@@ -125,7 +125,7 @@ static bool confirmOverwriteIfExists(QWidget *parent, const QString &filePath)
 static void convertFileToCockatriceFormat(DeckPreviewWidget *deckPreviewWidget)
 {
     deckPreviewWidget->deckLoader->convertToCockatriceFormat(deckPreviewWidget->filePath);
-    deckPreviewWidget->filePath = deckPreviewWidget->deckLoader->getLastLoadInfo().fileName;
+    deckPreviewWidget->filePath = deckPreviewWidget->deckLoader->getDeck().lastLoadInfo.fileName;
     deckPreviewWidget->refreshBannerCardText();
 }
 

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -74,16 +74,16 @@ void DeckPreviewWidget::initializeUi(const bool deckLoadSuccess)
     if (!deckLoadSuccess) {
         return;
     }
-    auto bannerCard = deckLoader->getDeckList()->getBannerCard().name.isEmpty()
+    auto bannerCard = deckLoader->getDeck().deckList.getBannerCard().name.isEmpty()
                           ? ExactCard()
-                          : CardDatabaseManager::query()->getCard(deckLoader->getDeckList()->getBannerCard());
+                          : CardDatabaseManager::query()->getCard(deckLoader->getDeck().deckList.getBannerCard());
 
     bannerCardDisplayWidget->setCard(bannerCard);
     bannerCardDisplayWidget->setFontSize(24);
-    setFilePath(deckLoader->getLastLoadInfo().fileName);
+    setFilePath(deckLoader->getDeck().lastLoadInfo.fileName);
 
     colorIdentityWidget = new ColorIdentityWidget(this, getColorIdentity());
-    deckTagsDisplayWidget = new DeckPreviewDeckTagsDisplayWidget(this, deckLoader->getDeckList()->getTags());
+    deckTagsDisplayWidget = new DeckPreviewDeckTagsDisplayWidget(this, deckLoader->getDeck().deckList.getTags());
     connect(deckTagsDisplayWidget, &DeckPreviewDeckTagsDisplayWidget::tagsChanged, this, &DeckPreviewWidget::setTags);
 
     bannerCardLabel = new QLabel(this);
@@ -91,7 +91,7 @@ void DeckPreviewWidget::initializeUi(const bool deckLoadSuccess)
     bannerCardComboBox = new QComboBox(this);
     bannerCardComboBox->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
     bannerCardComboBox->setObjectName("bannerCardComboBox");
-    bannerCardComboBox->setCurrentText(deckLoader->getDeckList()->getBannerCard().name);
+    bannerCardComboBox->setCurrentText(deckLoader->getDeck().deckList.getBannerCard().name);
     bannerCardComboBox->installEventFilter(new NoScrollFilter());
     connect(bannerCardComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &DeckPreviewWidget::setBannerCard);
@@ -153,7 +153,7 @@ void DeckPreviewWidget::updateTagsVisibility(bool visible)
 
 QString DeckPreviewWidget::getColorIdentity()
 {
-    QStringList cardList = deckLoader->getDeckList()->getCardList();
+    QStringList cardList = deckLoader->getDeck().deckList.getCardList();
     if (cardList.isEmpty()) {
         return {};
     }
@@ -187,8 +187,8 @@ QString DeckPreviewWidget::getColorIdentity()
  */
 QString DeckPreviewWidget::getDisplayName() const
 {
-    return deckLoader->getDeckList()->getName().isEmpty() ? QFileInfo(deckLoader->getLastLoadInfo().fileName).fileName()
-                                                          : deckLoader->getDeckList()->getName();
+    QString deckName = deckLoader->getDeck().deckList.getName();
+    return !deckName.isEmpty() ? deckName : QFileInfo(deckLoader->getDeck().lastLoadInfo.fileName).fileName();
 }
 
 void DeckPreviewWidget::setFilePath(const QString &_filePath)
@@ -235,7 +235,7 @@ void DeckPreviewWidget::updateBannerCardComboBox()
     // Prepare the new items with deduplication
     QSet<QPair<QString, QString>> bannerCardSet;
 
-    QList<const DecklistCardNode *> cardsInDeck = deckLoader->getDeckList()->getCardNodes();
+    QList<const DecklistCardNode *> cardsInDeck = deckLoader->getDeck().deckList.getCardNodes();
 
     for (auto currentCard : cardsInDeck) {
         for (int k = 0; k < currentCard->getNumber(); ++k) {
@@ -269,7 +269,7 @@ void DeckPreviewWidget::updateBannerCardComboBox()
         bannerCardComboBox->setCurrentIndex(restoredIndex);
     } else {
         // Add a placeholder "-" and set it as the current selection
-        int bannerIndex = bannerCardComboBox->findText(deckLoader->getDeckList()->getBannerCard().name);
+        int bannerIndex = bannerCardComboBox->findText(deckLoader->getDeck().deckList.getBannerCard().name);
         if (bannerIndex != -1) {
             bannerCardComboBox->setCurrentIndex(bannerIndex);
         } else {
@@ -287,7 +287,7 @@ void DeckPreviewWidget::setBannerCard(int /* changedIndex */)
 {
     auto [name, id] = bannerCardComboBox->currentData().value<QPair<QString, QString>>();
     CardRef cardRef = {name, id};
-    deckLoader->getDeckList()->setBannerCard(cardRef);
+    deckLoader->getDeck().deckList.setBannerCard(cardRef);
     deckLoader->saveToFile(filePath, DeckFileFormat::getFormatFromName(filePath));
     bannerCardDisplayWidget->setCard(CardDatabaseManager::query()->getCard(cardRef));
 }
@@ -310,7 +310,7 @@ void DeckPreviewWidget::imageDoubleClickedEvent(QMouseEvent *event, DeckPreviewC
 
 void DeckPreviewWidget::setTags(const QStringList &tags)
 {
-    deckLoader->getDeckList()->setTags(tags);
+    deckLoader->getDeck().deckList.setTags(tags);
     deckLoader->saveToFile(filePath, DeckFileFormat::Cockatrice);
 }
 
@@ -320,7 +320,7 @@ QMenu *DeckPreviewWidget::createRightClickMenu()
     menu->setAttribute(Qt::WA_DeleteOnClose);
 
     connect(menu->addAction(tr("Open in deck editor")), &QAction::triggered, this,
-            [this] { emit openDeckEditor(deckLoader); });
+            [this] { emit openDeckEditor(deckLoader->getDeck()); });
 
     connect(menu->addAction(tr("Edit Tags")), &QAction::triggered, deckTagsDisplayWidget,
             &DeckPreviewDeckTagsDisplayWidget::openTagEditDlg);
@@ -334,13 +334,13 @@ QMenu *DeckPreviewWidget::createRightClickMenu()
     auto saveToClipboardMenu = menu->addMenu(tr("Save Deck to Clipboard"));
 
     connect(saveToClipboardMenu->addAction(tr("Annotated")), &QAction::triggered, this,
-            [this] { DeckLoader::saveToClipboard(deckLoader->getDeckList(), true, true); });
+            [this] { DeckLoader::saveToClipboard(&deckLoader->getDeck().deckList, true, true); });
     connect(saveToClipboardMenu->addAction(tr("Annotated (No set info)")), &QAction::triggered, this,
-            [this] { DeckLoader::saveToClipboard(deckLoader->getDeckList(), true, false); });
+            [this] { DeckLoader::saveToClipboard(&deckLoader->getDeck().deckList, true, false); });
     connect(saveToClipboardMenu->addAction(tr("Not Annotated")), &QAction::triggered, this,
-            [this] { DeckLoader::saveToClipboard(deckLoader->getDeckList(), false, true); });
+            [this] { DeckLoader::saveToClipboard(&deckLoader->getDeck().deckList, false, true); });
     connect(saveToClipboardMenu->addAction(tr("Not Annotated (No set info)")), &QAction::triggered, this,
-            [this] { DeckLoader::saveToClipboard(deckLoader->getDeckList(), false, false); });
+            [this] { DeckLoader::saveToClipboard(&deckLoader->getDeck().deckList, false, false); });
 
     menu->addSeparator();
 
@@ -376,7 +376,7 @@ void DeckPreviewWidget::addSetBannerCardMenu(QMenu *menu)
 void DeckPreviewWidget::actRenameDeck()
 {
     // read input
-    const QString oldName = deckLoader->getDeckList()->getName();
+    const QString oldName = deckLoader->getDeck().deckList.getName();
 
     bool ok;
     QString newName = QInputDialog::getText(this, "Rename deck", tr("New name:"), QLineEdit::Normal, oldName, &ok);
@@ -385,7 +385,7 @@ void DeckPreviewWidget::actRenameDeck()
     }
 
     // write change
-    deckLoader->getDeckList()->setName(newName);
+    deckLoader->getDeck().deckList.setName(newName);
     deckLoader->saveToFile(filePath, DeckFileFormat::getFormatFromName(filePath));
 
     // update VDS
@@ -416,9 +416,7 @@ void DeckPreviewWidget::actRenameFile()
         return;
     }
 
-    LoadedDeck::LoadInfo lastLoadInfo = deckLoader->getLastLoadInfo();
-    lastLoadInfo.fileName = newFilePath;
-    deckLoader->setLastLoadInfo(lastLoadInfo);
+    deckLoader->getDeck().lastLoadInfo.fileName = newFilePath;
 
     // update VDS
     setFilePath(newFilePath);

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
@@ -51,7 +51,7 @@ public:
 
 signals:
     void deckLoadRequested(const QString &filePath);
-    void openDeckEditor(DeckLoader *deck);
+    void openDeckEditor(const LoadedDeck &deck);
 
 public slots:
     void setFilePath(const QString &filePath);

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
@@ -211,7 +211,7 @@ QStringList VisualDeckStorageFolderDisplayWidget::gatherAllTagsFromFlowWidget() 
         // Iterate through all DeckPreviewWidgets
         for (DeckPreviewWidget *display : flowWidget->findChildren<DeckPreviewWidget *>()) {
             // Get tags from each DeckPreviewWidget
-            QStringList tags = display->deckLoader->getDeckList()->getTags();
+            QStringList tags = display->deckLoader->getDeck().deckList.getTags();
 
             // Add tags to the list while avoiding duplicates
             allTags.append(tags);

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
@@ -95,14 +95,17 @@ QList<DeckPreviewWidget *> VisualDeckStorageSortWidget::filterFiles(QList<DeckPr
 
         switch (sortOrder) {
             case ByName:
-                return widget1->deckLoader->getDeckList()->getName() < widget2->deckLoader->getDeckList()->getName();
+                return widget1->deckLoader->getDeck().deckList.getName() <
+                       widget2->deckLoader->getDeck().deckList.getName();
             case Alphabetical:
                 return QString::localeAwareCompare(info1.fileName(), info2.fileName()) <= 0;
             case ByLastModified:
                 return info1.lastModified() > info2.lastModified();
             case ByLastLoaded: {
-                QDateTime time1 = QDateTime::fromString(widget1->deckLoader->getDeckList()->getLastLoadedTimestamp());
-                QDateTime time2 = QDateTime::fromString(widget2->deckLoader->getDeckList()->getLastLoadedTimestamp());
+                QDateTime time1 =
+                    QDateTime::fromString(widget1->deckLoader->getDeck().deckList.getLastLoadedTimestamp());
+                QDateTime time2 =
+                    QDateTime::fromString(widget2->deckLoader->getDeck().deckList.getLastLoadedTimestamp());
                 return time1 > time2;
             }
         }

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
@@ -57,7 +57,7 @@ void VisualDeckStorageTagFilterWidget::filterDecksBySelectedTags(const QList<Dec
     }
 
     for (DeckPreviewWidget *deckPreview : deckPreviews) {
-        QStringList deckTags = deckPreview->deckLoader->getDeckList()->getTags();
+        QStringList deckTags = deckPreview->deckLoader->getDeck().deckList.getTags();
 
         bool hasAllSelected = std::all_of(selectedTags.begin(), selectedTags.end(),
                                           [&deckTags](const QString &tag) { return deckTags.contains(tag); });
@@ -153,7 +153,7 @@ QSet<QString> VisualDeckStorageTagFilterWidget::gatherAllTags() const
 
     for (DeckPreviewWidget *widget : deckWidgets) {
         if (widget->checkVisibility()) {
-            for (const QString &tag : widget->deckLoader->getDeckList()->getTags()) {
+            for (const QString &tag : widget->deckLoader->getDeck().deckList.getTags()) {
                 allTags.insert(tag);
             }
         }

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -53,7 +53,7 @@ public slots:
 signals:
     void bannerCardsRefreshed();
     void deckLoadRequested(const QString &filePath);
-    void openDeckEditor(DeckLoader *deck);
+    void openDeckEditor(const LoadedDeck &deck);
 
 private:
     QVBoxLayout *layout;


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to 
  - #6406
  - #6407
  - #6412

## Short roundup of the initial problem

`DeckLoader` is a QObject that holds the `DeckList` and `LoadInfo`. That means its subject to Qt's ownership rules, which makes it unsafe to copy, and annoying to pass around.

Currently, our code primarily passes around `DeckLoader` instances as a way to pass around deck info. We would like to instead pass around a pure data holder for the deck info, since that will simplify the code.

## What will change with this Pull Request?
- Changed `DeckLoader` to hold a `LoadedDeck` instead of the fields separately
  - Replace previous getters with a const and non-const getter for the `LoadedDeck`
  - Note that I haven't changed the `DeckLoader` methods that load and save decks to static.
    - I'm planning to do that in a future PR. 
    - For now, that means to load a deck, you still need to create a DeckLoader instance, load the deck, then get the `LoadedDeck` from the instance.
- Updated signatures and usages to use `DeckList` or `LoadedDeck` instead of `DeckLoader` whenever possible.
  - Used `LoadedDeck` if the usage location expects to have info about where the deck is loaded from
  - Used `DeckList` if the usage location doesn't care about `LoadInfo`
- Places where `DeckLoader` is still used:
  - VDS deck preview widget, since they're the only place that uses async loading.
    - Once the follow-up refactors are done, ideally, the only place where a `DeckLoader` instance would be used is for async loading.
  - Deck editor decklist dock widget, since changing it would require a even more refactoring. 
    - I'm planning on updating it in a future PR

 