### PR TITLE
Doxygen: Enable internal comments

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -636,7 +636,7 @@ HIDE_IN_BODY_DOCS      = NO
 # will be excluded. Set it to YES to include the internal documentation.
 # The default value is: NO.
 
-INTERNAL_DOCS          = NO
+INTERNAL_DOCS          = YES
 
 # With the correct setting of option CASE_SENSE_NAMES Doxygen will better be
 # able to match the capabilities of the underlying filesystem. In case the


### PR DESCRIPTION
## Related Ticket(s)
- Closes #6385

<br>

>```
>The INTERNAL_DOCS tag determines if documentation that is typed after a
>\internal command is included. If the tag is set to NO then the documentation
>will be excluded. Set it to YES to include the internal documentation.
>The default value is: NO.
>```
>
>There are also several places in the code with comments marked as "internal", which are not included in the docs when doxygen builds:
https://github.com/search?q=repo%3ACockatrice%2FCockatrice%20%5Cinternal&type=code