### PR TITLE
[DeckListModel] Refactor to use column num constants

### DIFF
--- a/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
@@ -91,8 +91,9 @@ QWidget *CardGroupDisplayWidget::constructWidgetForIndex(QPersistentModelIndex i
     if (indexToWidgetMap.contains(index)) {
         return indexToWidgetMap[index];
     }
-    auto cardName = deckListModel->data(index.sibling(index.row(), 1), Qt::EditRole).toString();
-    auto cardProviderId = deckListModel->data(index.sibling(index.row(), 4), Qt::EditRole).toString();
+    auto cardName = index.sibling(index.row(), DeckListModelColumns::CARD_NAME).data(Qt::EditRole).toString();
+    auto cardProviderId =
+        index.sibling(index.row(), DeckListModelColumns::CARD_PROVIDER_ID).data(Qt::EditRole).toString();
 
     auto widget = new CardInfoPictureWithTextOverlayWidget(getLayoutParent(), true);
     widget->setScaleFactor(cardSizeWidget->getSlider()->value());
@@ -114,7 +115,7 @@ void CardGroupDisplayWidget::updateCardDisplays()
 
     // This doesn't really matter since overwrite the whole lessThan function to just compare dynamically anyway.
     proxy.setSortRole(Qt::EditRole);
-    proxy.sort(1, Qt::AscendingOrder);
+    proxy.sort(DeckListModelColumns::CARD_NAME, Qt::AscendingOrder);
 
     // 1. trackedIndex is a source index → map it to proxy space
     QModelIndex proxyParent = proxy.mapFromSource(trackedIndex);

--- a/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.cpp
@@ -82,10 +82,11 @@ void DeckCardZoneDisplayWidget::cleanupInvalidCardGroup(CardGroupDisplayWidget *
 
 void DeckCardZoneDisplayWidget::constructAppropriateWidget(QPersistentModelIndex index)
 {
-    auto categoryName = deckListModel->data(index.sibling(index.row(), 1), Qt::EditRole).toString();
     if (indexToWidgetMap.contains(index)) {
         return;
     }
+
+    auto categoryName = index.sibling(index.row(), DeckListModelColumns::CARD_NAME).data(Qt::EditRole).toString();
     if (displayType == DisplayType::Overlap) {
         auto *displayWidget = new OverlappedCardGroupDisplayWidget(
             cardGroupContainer, deckListModel, selectionModel, index, zoneName, categoryName, activeGroupCriteria,
@@ -120,7 +121,7 @@ void DeckCardZoneDisplayWidget::displayCards()
     QSortFilterProxyModel proxy;
     proxy.setSourceModel(deckListModel);
     proxy.setSortRole(Qt::EditRole);
-    proxy.sort(1, Qt::AscendingOrder);
+    proxy.sort(DeckListModelColumns::CARD_NAME, Qt::AscendingOrder);
 
     // 1. trackedIndex is a source index → map it to proxy space
     QModelIndex proxyParent = proxy.mapFromSource(trackedIndex);

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
@@ -134,13 +134,13 @@ void DeckEditorDatabaseDisplayWidget::clearAllDatabaseFilters()
 
 void DeckEditorDatabaseDisplayWidget::updateCard(const QModelIndex &current, const QModelIndex & /*previous*/)
 {
-    const QString cardName = current.sibling(current.row(), 0).data().toString();
-
     if (!current.isValid()) {
         return;
     }
 
-    if (!current.model()->hasChildren(current.sibling(current.row(), 0))) {
+    const QString cardName = current.siblingAtColumn(CardDatabaseModel::NameColumn).data().toString();
+
+    if (!current.model()->hasChildren(current.siblingAtColumn(CardDatabaseModel::NameColumn))) {
         emit cardChanged(CardDatabaseManager::query()->getPreferredCard(cardName));
     }
 }
@@ -172,7 +172,7 @@ ExactCard DeckEditorDatabaseDisplayWidget::currentCard() const
         return {};
     }
 
-    const QString cardName = currentIndex.sibling(currentIndex.row(), 0).data().toString();
+    const QString cardName = currentIndex.siblingAtColumn(CardDatabaseModel::NameColumn).data().toString();
 
     return CardDatabaseManager::query()->getPreferredCard(cardName);
 }

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -319,17 +319,17 @@ ExactCard DeckEditorDeckDockWidget::getCurrentCard()
     QModelIndex current = deckView->selectionModel()->currentIndex();
     if (!current.isValid())
         return {};
-    const QString cardName = current.sibling(current.row(), 1).data().toString();
-    const QString cardProviderID = current.sibling(current.row(), 4).data().toString();
+    const QString cardName = current.siblingAtColumn(DeckListModelColumns::CARD_NAME).data().toString();
+    const QString cardProviderID = current.siblingAtColumn(DeckListModelColumns::CARD_PROVIDER_ID).data().toString();
     const QModelIndex gparent = current.parent().parent();
 
     if (!gparent.isValid()) {
         return {};
     }
 
-    const QString zoneName = gparent.sibling(gparent.row(), 1).data(Qt::EditRole).toString();
+    const QString zoneName = gparent.siblingAtColumn(DeckListModelColumns::CARD_NAME).data(Qt::EditRole).toString();
 
-    if (!current.model()->hasChildren(current.sibling(current.row(), 0))) {
+    if (!current.model()->hasChildren(current.siblingAtColumn(DeckListModelColumns::CARD_AMOUNT))) {
         if (ExactCard selectedCard = CardDatabaseManager::query()->getCard({cardName, cardProviderID})) {
             return selectedCard;
         }
@@ -627,14 +627,15 @@ bool DeckEditorDeckDockWidget::swapCard(const QModelIndex &currentIndex)
 {
     if (!currentIndex.isValid())
         return false;
-    const QString cardName = currentIndex.sibling(currentIndex.row(), 1).data().toString();
-    const QString cardProviderID = currentIndex.sibling(currentIndex.row(), 4).data().toString();
+    const QString cardName = currentIndex.siblingAtColumn(DeckListModelColumns::CARD_NAME).data().toString();
+    const QString cardProviderID =
+        currentIndex.siblingAtColumn(DeckListModelColumns::CARD_PROVIDER_ID).data().toString();
     const QModelIndex gparent = currentIndex.parent().parent();
 
     if (!gparent.isValid())
         return false;
 
-    const QString zoneName = gparent.sibling(gparent.row(), 1).data(Qt::EditRole).toString();
+    const QString zoneName = gparent.siblingAtColumn(DeckListModelColumns::CARD_NAME).data(Qt::EditRole).toString();
     offsetCountAtIndex(currentIndex, -1);
     const QString otherZoneName = zoneName == DECK_ZONE_MAIN ? DECK_ZONE_SIDE : DECK_ZONE_MAIN;
 
@@ -700,7 +701,7 @@ void DeckEditorDeckDockWidget::actRemoveCard()
             continue;
         }
         QModelIndex sourceIndex = proxy->mapToSource(index);
-        QString cardName = sourceIndex.sibling(sourceIndex.row(), 1).data().toString();
+        QString cardName = sourceIndex.siblingAtColumn(DeckListModelColumns::CARD_NAME).data().toString();
 
         emit requestDeckHistorySave(QString(tr("Removed \"%1\" (all copies)")).arg(cardName));
 
@@ -723,11 +724,11 @@ void DeckEditorDeckDockWidget::offsetCountAtIndex(const QModelIndex &idx, int of
 
     QModelIndex sourceIndex = proxy->mapToSource(idx);
 
-    const QModelIndex numberIndex = sourceIndex.sibling(sourceIndex.row(), 0);
-    const QModelIndex nameIndex = sourceIndex.sibling(sourceIndex.row(), 1);
+    const QModelIndex numberIndex = sourceIndex.siblingAtColumn(DeckListModelColumns::CARD_AMOUNT);
+    const QModelIndex nameIndex = sourceIndex.siblingAtColumn(DeckListModelColumns::CARD_NAME);
 
-    const QString cardName = deckModel->data(nameIndex, Qt::EditRole).toString();
-    const int count = deckModel->data(numberIndex, Qt::EditRole).toInt();
+    const QString cardName = nameIndex.data(Qt::EditRole).toString();
+    const int count = numberIndex.data(Qt::EditRole).toInt();
     const int new_count = count + offset;
 
     const auto reason =
@@ -735,7 +736,7 @@ void DeckEditorDeckDockWidget::offsetCountAtIndex(const QModelIndex &idx, int of
             .arg(offset > 0 ? tr("Added") : tr("Removed"))
             .arg(qAbs(offset))
             .arg(cardName)
-            .arg(deckModel->data(sourceIndex.sibling(sourceIndex.row(), 4), Qt::DisplayRole).toString());
+            .arg(sourceIndex.siblingAtColumn(DeckListModelColumns::CARD_PROVIDER_ID).data(Qt::DisplayRole).toString());
 
     emit requestDeckHistorySave(reason);
 

--- a/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.cpp
@@ -151,9 +151,10 @@ void CardAmountWidget::addPrinting(const QString &zone)
     bool replacingProviderless = false;
 
     if (existing.isValid()) {
-        QString providerId = deckModel->data(existing.sibling(existing.row(), 4), Qt::DisplayRole).toString();
+        QString providerId =
+            existing.siblingAtColumn(DeckListModelColumns::CARD_PROVIDER_ID).data(Qt::DisplayRole).toString();
         if (providerId.isEmpty()) {
-            int amount = deckModel->data(existing, Qt::DisplayRole).toInt();
+            int amount = existing.data(Qt::DisplayRole).toInt();
             extraCopies = amount - 1; // One less because we *always* add one
             replacingProviderless = true;
         }
@@ -177,9 +178,10 @@ void CardAmountWidget::addPrinting(const QString &zone)
     recursiveExpand(newCardIndex);
 
     // Check if a card without a providerId already exists in the deckModel and replace it, if so.
-    QString foundProviderId = deckModel->data(existing.sibling(existing.row(), 4), Qt::DisplayRole).toString();
+    QString foundProviderId =
+        existing.siblingAtColumn(DeckListModelColumns::CARD_PROVIDER_ID).data(Qt::DisplayRole).toString();
     if (existing.isValid() && existing != newCardIndex && foundProviderId == "") {
-        auto amount = deckModel->data(existing, Qt::DisplayRole);
+        auto amount = existing.data(Qt::DisplayRole);
         for (int i = 0; i < amount.toInt() - 1; i++) {
             deckModel->addCard(rootCard, zone);
         }
@@ -252,8 +254,8 @@ void CardAmountWidget::offsetCountAtIndex(const QModelIndex &idx, int offset)
         return;
     }
 
-    const QModelIndex numberIndex = idx.sibling(idx.row(), 0);
-    const int count = deckModel->data(numberIndex, Qt::EditRole).toInt();
+    const QModelIndex numberIndex = idx.siblingAtColumn(DeckListModelColumns::CARD_AMOUNT);
+    const int count = numberIndex.data(Qt::EditRole).toInt();
     const int new_count = count + offset;
 
     deckView->setCurrentIndex(numberIndex);

--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/display/archidekt_api_response_deck_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/display/archidekt_api_response_deck_display_widget.cpp
@@ -83,7 +83,7 @@ void ArchidektApiResponseDeckDisplayWidget::retranslateUi()
 void ArchidektApiResponseDeckDisplayWidget::onGroupCriteriaChange(const QString &activeGroupCriteria)
 {
     model->setActiveGroupCriteria(DeckListModelGroupCriteria::fromString(activeGroupCriteria));
-    model->sort(1, Qt::AscendingOrder);
+    model->sort(DeckListModelColumns::CARD_NAME, Qt::AscendingOrder);
 }
 
 void ArchidektApiResponseDeckDisplayWidget::actOpenInDeckEditor()
@@ -120,7 +120,7 @@ void ArchidektApiResponseDeckDisplayWidget::constructZoneWidgetsFromDeckListMode
     QSortFilterProxyModel proxy;
     proxy.setSourceModel(model);
     proxy.setSortRole(Qt::EditRole);
-    proxy.sort(1, Qt::AscendingOrder);
+    proxy.sort(DeckListModelColumns::CARD_NAME, Qt::AscendingOrder);
 
     for (int i = 0; i < proxy.rowCount(); ++i) {
         QModelIndex proxyIndex = proxy.index(i, 0);
@@ -133,10 +133,12 @@ void ArchidektApiResponseDeckDisplayWidget::constructZoneWidgetsFromDeckListMode
             continue;
         }
 
+        QString zoneName =
+            persistent.sibling(persistent.row(), DeckListModelColumns::CARD_NAME).data(Qt::EditRole).toString();
+
         DeckCardZoneDisplayWidget *zoneDisplayWidget =
-            new DeckCardZoneDisplayWidget(zoneContainer, model, nullptr, persistent,
-                                          model->data(persistent.sibling(persistent.row(), 1), Qt::EditRole).toString(),
-                                          "maintype", {"name"}, DisplayType::Overlap, 20, 10, cardSizeSlider);
+            new DeckCardZoneDisplayWidget(zoneContainer, model, nullptr, persistent, zoneName, "maintype", {"name"},
+                                          DisplayType::Overlap, 20, 10, cardSizeSlider);
 
         connect(displayOptionsWidget, &VisualDeckDisplayOptionsWidget::sortCriteriaChanged, zoneDisplayWidget,
                 &DeckCardZoneDisplayWidget::onActiveSortCriteriaChanged);

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -264,9 +264,10 @@ void VisualDeckEditorWidget::onCardRemoval(const QModelIndex &parent, int first,
 
 void VisualDeckEditorWidget::constructZoneWidgetForIndex(QPersistentModelIndex persistent)
 {
+    QString zoneName =
+        persistent.sibling(persistent.row(), DeckListModelColumns::CARD_NAME).data(Qt::EditRole).toString();
     DeckCardZoneDisplayWidget *zoneDisplayWidget = new DeckCardZoneDisplayWidget(
-        zoneContainer, deckListModel, selectionModel, persistent,
-        deckListModel->data(persistent.sibling(persistent.row(), 1), Qt::EditRole).toString(),
+        zoneContainer, deckListModel, selectionModel, persistent, zoneName,
         displayOptionsWidget->getActiveGroupCriteria(), displayOptionsWidget->getActiveSortCriteria(),
         displayOptionsWidget->getDisplayType(), 20, 10, cardSizeWidget);
     connect(zoneDisplayWidget, &DeckCardZoneDisplayWidget::cardHovered, this, &VisualDeckEditorWidget::onHover);
@@ -290,7 +291,7 @@ void VisualDeckEditorWidget::constructZoneWidgetsFromDeckListModel()
     QSortFilterProxyModel proxy;
     proxy.setSourceModel(deckListModel);
     proxy.setSortRole(Qt::EditRole);
-    proxy.sort(1, Qt::AscendingOrder);
+    proxy.sort(DeckListModelColumns::CARD_NAME, Qt::AscendingOrder);
 
     for (int i = 0; i < proxy.rowCount(); ++i) {
         QModelIndex proxyIndex = proxy.index(i, 0);

--- a/libcockatrice_models/libcockatrice/models/deck_list/deck_list_sort_filter_proxy_model.cpp
+++ b/libcockatrice_models/libcockatrice/models/deck_list/deck_list_sort_filter_proxy_model.cpp
@@ -11,8 +11,8 @@ bool DeckListSortFilterProxyModel::lessThan(const QModelIndex &left, const QMode
     bool rightIsCard = src->data(right, Qt::UserRole + 1).toBool();
 
     if (!leftIsCard || !rightIsCard) {
-        QString lName = src->data(left.siblingAtColumn(1), Qt::EditRole).toString();
-        QString rName = src->data(right.siblingAtColumn(1), Qt::EditRole).toString();
+        QString lName = src->data(left.siblingAtColumn(DeckListModelColumns::CARD_NAME), Qt::EditRole).toString();
+        QString rName = src->data(right.siblingAtColumn(DeckListModelColumns::CARD_NAME), Qt::EditRole).toString();
         return lName.localeAwareCompare(rName) < 0;
     }
 


### PR DESCRIPTION
## Short roundup of the initial problem

We added constants for DeckListModel column numbers a while back. However, we never updated our code to use those constants.

## What will change with this Pull Request?
- Update code to use `DeckListModelColumns` instead of hardcoded ints when referring to `DeckListModel` columns.
- Cleaned up some code
  - Use `siblingAtColumn` instead of `index.sibling(index.row()...` where applicable.
  - Directly access data with `index.data` instead of calling `model.data` with the index where applicable