### PR TITLE
[DeckDockWidget] Fix swap not auto-expanding tree

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -642,7 +642,7 @@ bool DeckEditorDeckDockWidget::swapCard(const QModelIndex &currentIndex)
     QModelIndex newCardIndex = card ? deckModel->addCard(card, otherZoneName)
                                     // Third argument (true) says create the card no matter what, even if not in DB
                                     : deckModel->addPreferredPrintingCard(cardName, otherZoneName, true);
-    recursiveExpand(proxy->mapToSource(newCardIndex));
+    recursiveExpand(proxy->mapFromSource(newCardIndex));
 
     return true;
 }


### PR DESCRIPTION
## Related Ticket(s)

- Fix bug from #6324

## Short roundup of the initial problem

When using the deck dock widget, swapping cards between mainboard and sideboard does not cause the parent to auto-expand.

https://github.com/user-attachments/assets/0d6614da-cbfc-4339-8999-b51bc300173b

## What will change with this Pull Request?
- Tree now auto-expands on swap

https://github.com/user-attachments/assets/b90fad99-d64d-4759-8037-edc4543e4bdf