### PR TITLE
fix: manage ccache caches manually on macos

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -344,6 +344,9 @@ jobs:
     runs-on: ${{matrix.runner}}
     env:
       CCACHE_DIR: ${{github.workspace}}/.cache/
+      # Cache size over the entire repo is 10Gi:
+      # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
+      CCACHE_SIZE: 500M
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6369

## Short roundup of the initial problem
GHA cache entries for ccache on macos were not getting cleaned up.
Merry Christmas! 

## What will change with this Pull Request?
- manage ccache caches manually for macos the same way as it is done for linux
- install ccache via brew (the previously used action installed it from source)

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
