### PR TITLE
[Refactor] Move prev/next card logic out of PrintingSelector

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -548,6 +548,52 @@ void DeckEditorDeckDockWidget::cleanDeck()
     deckTagsDisplayWidget->setTags(deckModel->getDeckList()->getTags());
 }
 
+void DeckEditorDeckDockWidget::selectPrevCard()
+{
+    changeSelectedCard(-1);
+}
+
+void DeckEditorDeckDockWidget::selectNextCard()
+{
+    changeSelectedCard(1);
+}
+
+/**
+ * @brief Selects a card based on the change direction.
+ *
+ * @param changeBy The direction to change, -1 for previous, 1 for next.
+ */
+void DeckEditorDeckDockWidget::changeSelectedCard(int changeBy)
+{
+    if (changeBy == 0) {
+        return;
+    }
+
+    // Get the current index of the selected item
+    auto deckViewCurrentIndex = deckView->currentIndex();
+
+    auto nextIndex = deckViewCurrentIndex.siblingAtRow(deckViewCurrentIndex.row() + changeBy);
+    if (!nextIndex.isValid()) {
+        nextIndex = deckViewCurrentIndex;
+
+        // Increment to the next valid index, skipping header rows
+        AbstractDecklistNode *node;
+        do {
+            if (changeBy > 0) {
+                nextIndex = deckView->indexBelow(nextIndex);
+            } else {
+                nextIndex = deckView->indexAbove(nextIndex);
+            }
+            node = static_cast<AbstractDecklistNode *>(nextIndex.internalPointer());
+        } while (node && node->isDeckHeader());
+    }
+
+    if (nextIndex.isValid()) {
+        deckView->setCurrentIndex(nextIndex);
+        deckView->setFocus(Qt::FocusReason::MouseFocusReason);
+    }
+}
+
 /**
  * @brief Expands all parents of the given index.
  * @param sourceIndex The index to expand (model source index)

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.h
@@ -56,6 +56,8 @@ public:
 
 public slots:
     void cleanDeck();
+    void selectPrevCard();
+    void selectNextCard();
     void updateBannerCardComboBox();
     void setDeck(const LoadedDeck &_deck);
     void syncDisplayWidgetsToModel();
@@ -122,6 +124,7 @@ private slots:
     void updateShowBannerCardComboBox(bool visible);
     void updateShowTagsWidget(bool visible);
     void syncBannerCardComboBoxSelectionWithDeck();
+    void changeSelectedCard(int changeBy);
     void recursiveExpand(const QModelIndex &parent);
     void expandAll();
 };

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_printing_selector_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_printing_selector_dock_widget.cpp
@@ -33,6 +33,10 @@ void DeckEditorPrintingSelectorDockWidget::createPrintingSelectorDock()
 
     installEventFilter(deckEditor);
     connect(this, &QDockWidget::topLevelChanged, deckEditor, &AbstractTabDeckEditor::dockTopLevelChanged);
+    connect(printingSelector, &PrintingSelector::prevCardRequested, deckEditor->getDeckDockWidget(),
+            &DeckEditorDeckDockWidget::selectPrevCard);
+    connect(printingSelector, &PrintingSelector::nextCardRequested, deckEditor->getDeckDockWidget(),
+            &DeckEditorDeckDockWidget::selectNextCard);
 }
 
 void DeckEditorPrintingSelectorDockWidget::retranslateUi()

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector.cpp
@@ -139,58 +139,6 @@ void PrintingSelector::setCard(const CardInfoPtr &newCard, const QString &_curre
 }
 
 /**
- * @brief Selects the previous card in the list.
- */
-void PrintingSelector::selectPreviousCard()
-{
-    selectCard(-1);
-}
-
-/**
- * @brief Selects the next card in the list.
- */
-void PrintingSelector::selectNextCard()
-{
-    selectCard(1);
-}
-
-/**
- * @brief Selects a card based on the change direction.
- *
- * @param changeBy The direction to change, -1 for previous, 1 for next.
- */
-void PrintingSelector::selectCard(const int changeBy)
-{
-    if (changeBy == 0) {
-        return;
-    }
-
-    // Get the current index of the selected item
-    auto deckViewCurrentIndex = deckView->currentIndex();
-
-    auto nextIndex = deckViewCurrentIndex.siblingAtRow(deckViewCurrentIndex.row() + changeBy);
-    if (!nextIndex.isValid()) {
-        nextIndex = deckViewCurrentIndex;
-
-        // Increment to the next valid index, skipping header rows
-        AbstractDecklistNode *node;
-        do {
-            if (changeBy > 0) {
-                nextIndex = deckView->indexBelow(nextIndex);
-            } else {
-                nextIndex = deckView->indexAbove(nextIndex);
-            }
-            node = static_cast<AbstractDecklistNode *>(nextIndex.internalPointer());
-        } while (node && node->isDeckHeader());
-    }
-
-    if (nextIndex.isValid()) {
-        deckView->setCurrentIndex(nextIndex);
-        deckView->setFocus(Qt::FocusReason::MouseFocusReason);
-    }
-}
-
-/**
  * @brief Loads and displays all sets for the current selected card.
  */
 void PrintingSelector::getAllSetsForCurrentCard()

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector.h
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector.h
@@ -48,12 +48,20 @@ public:
 public slots:
     void retranslateUi();
     void updateDisplay();
-    void selectPreviousCard();
-    void selectNextCard();
     void toggleVisibilityNavigationButtons(bool _state);
 
 private slots:
     void printingsInDeckChanged();
+
+signals:
+    /**
+     * Requests the previous card in the list
+     */
+    void prevCardRequested();
+    /**
+     * Requests the next card in the list
+     */
+    void nextCardRequested();
 
 private:
     QVBoxLayout *layout;
@@ -73,7 +81,6 @@ private:
     QString currentZone;
     QTimer *widgetLoadingBufferTimer;
     int currentIndex = 0;
-    void selectCard(int changeBy);
 };
 
 #endif // PRINTING_SELECTOR_H

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_selection_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_selection_widget.cpp
@@ -42,8 +42,8 @@ PrintingSelectorCardSelectionWidget::PrintingSelectorCardSelectionWidget(Printin
  */
 void PrintingSelectorCardSelectionWidget::connectSignals()
 {
-    connect(previousCardButton, &QPushButton::clicked, parent, &PrintingSelector::selectPreviousCard);
-    connect(nextCardButton, &QPushButton::clicked, parent, &PrintingSelector::selectNextCard);
+    connect(previousCardButton, &QPushButton::clicked, parent, &PrintingSelector::prevCardRequested);
+    connect(nextCardButton, &QPushButton::clicked, parent, &PrintingSelector::nextCardRequested);
 }
 
 void PrintingSelectorCardSelectionWidget::selectSetForCards()


### PR DESCRIPTION
## Short roundup of the initial problem

`PrintingSelector` has logic for moving the selected card in the deck dock forward/back, which means it needs to take deckView as a dependency. This coupling is making it hard for my refactoring.

## What will change with this Pull Request?
- Moved the logic into the deck dock widget, and communicate with signals
  - `PrintingSelector` now emits signals when the prev/next card buttons are clicked
  - The signal eventually gets forwarded to deck dock widget, which then runs the existing logic
  - The existing logic already causes a signal to be emitted when the selected card changes, which causes PrintingSelector to update its card.

We can't remove deckView as a dependency from `PrintingSelector` yet because it gets passed down to another place really deep in the object tree. I am eventually planning to refactor out that dependency somehow