### PR TITLE
Fix bug with next/prev buttons in PrintingSelector

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -575,6 +575,7 @@ void DeckEditorDeckDockWidget::changeSelectedCard(int changeBy)
     // currentIndex will return an index for the underlying deckModel instead of the proxy.
     // That index will return an invalid index when indexBelow/indexAbove crosses a header node,
     // causing the selection to fail to move down.
+    /// \todo Figure out why it's happening so we can do a proper fix instead of a hacky workaround
     if (deckViewCurrentIndex.model() == proxy->sourceModel()) {
         deckViewCurrentIndex = proxy->mapFromSource(deckViewCurrentIndex);
     }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #6294

## Short roundup of the initial problem

If you modify the deck through the printing selector, the next/prev buttons no longer cross header nodes until you use the mouse to reselect a node 

https://github.com/user-attachments/assets/ae8fd37f-57bf-4d28-9cd0-2de1447170f1

## What will change with this Pull Request?

