### PR TITLE
[DeckListModel] Refactor api for offset count

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -831,11 +831,8 @@ void DeckEditorDeckDockWidget::offsetCountAtIndex(const QModelIndex &idx, bool i
 
     emit requestDeckHistorySave(reason);
 
-    if (isIncrement) {
-        deckModel->incrementAmountAtIndex(sourceIndex);
-    } else {
-        deckModel->decrementAmountAtIndex(sourceIndex);
-    }
+    int offset = isIncrement ? 1 : -1;
+    deckModel->offsetCountAtIndex(sourceIndex, offset);
 
     emit deckModified();
 }

--- a/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.cpp
@@ -257,7 +257,7 @@ void CardAmountWidget::decrementCardHelper(const QString &zone)
     QModelIndex idx = deckModel->findCard(rootCard.getName(), zone, rootCard.getPrinting().getUuid(),
                                           rootCard.getPrinting().getProperty("num"));
 
-    deckModel->decrementAmountAtIndex(idx);
+    deckModel->offsetCountAtIndex(idx, -1);
     deckEditor->setModified(true);
 }
 

--- a/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
+++ b/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
@@ -443,17 +443,7 @@ QModelIndex DeckListModel::addCard(const ExactCard &card, const QString &zoneNam
     return index;
 }
 
-bool DeckListModel::incrementAmountAtIndex(const QModelIndex &idx)
-{
-    return offsetAmountAtIndex(idx, 1);
-}
-
-bool DeckListModel::decrementAmountAtIndex(const QModelIndex &idx)
-{
-    return offsetAmountAtIndex(idx, -1);
-}
-
-bool DeckListModel::offsetAmountAtIndex(const QModelIndex &idx, int offset)
+bool DeckListModel::offsetCountAtIndex(const QModelIndex &idx, int offset)
 {
     if (!idx.isValid()) {
         return false;

--- a/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.h
+++ b/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.h
@@ -307,19 +307,13 @@ public:
     QModelIndex addCard(const ExactCard &card, const QString &zoneName);
 
     /**
-     * @brief Increments the `amount` field of the card node at the index by 1.
-     * @param idx The index of a card node. No-ops if the index is invalid or not a card node
+     * @brief Changes the `amount` field in the card node at the index by the amount.
+     * Removes the node if it causes the amount to fall to 0 or below.
+     * @param idx The index of a card node. No-ops if the index is invalid or not a card node.
+     * @param offset The amount to change the amount field by.
      * @return Whether the operation was successful
      */
-    bool incrementAmountAtIndex(const QModelIndex &idx);
-
-    /**
-     * @brief Decrements the `amount` field of the card node at the index by 1.
-     * Removes the node if it causes the amount to fall to 0.
-     * @param idx The index of a card node. No-ops if the index is invalid or not a card node
-     * @return Whether the operation was successful
-     */
-    bool decrementAmountAtIndex(const QModelIndex &idx);
+    bool offsetCountAtIndex(const QModelIndex &idx, int offset);
 
     /**
      * @brief Determines the sorted insertion row for a card.
@@ -394,8 +388,6 @@ private:
                                                       const QString &zoneName,
                                                       const QString &providerId = "",
                                                       const QString &cardNumber = "") const;
-
-    bool offsetAmountAtIndex(const QModelIndex &idx, int offset);
 
     void emitRecursiveUpdates(const QModelIndex &index);
     void sortHelper(InnerDecklistNode *node, Qt::SortOrder order);


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6446

## Short roundup of the initial problem

I made bad api decisions in the previous ticket. They're making the future code that I want to write messier than it should be.

## What will change with this Pull Request?
- `DeckListModel` directly exposes the `offsetCountAtIndex` method instead of just exposing the increment and decrement methods and forcing the caller to go through them.