### PR TITLE
[DeckListModel] Clean up recursive updates

### DIFF
--- a/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
+++ b/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
@@ -178,22 +178,6 @@ QVariant DeckListModel::data(const QModelIndex &index, int role) const
     }
 }
 
-void DeckListModel::emitBackgroundUpdates(const QModelIndex &parent)
-{
-    int rows = rowCount(parent);
-    if (rows == 0)
-        return;
-
-    QModelIndex topLeft = index(0, 0, parent);
-    QModelIndex bottomRight = index(rows - 1, columnCount() - 1, parent);
-    emit dataChanged(topLeft, bottomRight, {Qt::BackgroundRole});
-
-    for (int r = 0; r < rows; ++r) {
-        QModelIndex child = index(r, 0, parent);
-        emitBackgroundUpdates(child);
-    }
-}
-
 QVariant DeckListModel::headerData(const int section, const Qt::Orientation orientation, const int role) const
 {
     if ((role != Qt::DisplayRole) || (orientation != Qt::Horizontal)) {
@@ -252,6 +236,22 @@ Qt::ItemFlags DeckListModel::flags(const QModelIndex &index) const
     return result;
 }
 
+void DeckListModel::emitBackgroundUpdates(const QModelIndex &parent)
+{
+    int rows = rowCount(parent);
+    if (rows == 0)
+        return;
+
+    QModelIndex topLeft = index(0, 0, parent);
+    QModelIndex bottomRight = index(rows - 1, columnCount() - 1, parent);
+    emit dataChanged(topLeft, bottomRight, {Qt::BackgroundRole});
+
+    for (int r = 0; r < rows; ++r) {
+        QModelIndex child = index(r, 0, parent);
+        emitBackgroundUpdates(child);
+    }
+}
+
 void DeckListModel::emitRecursiveUpdates(const QModelIndex &index)
 {
     if (!index.isValid()) {
@@ -294,7 +294,6 @@ bool DeckListModel::setData(const QModelIndex &index, const QVariant &value, con
     deckList->refreshDeckHash();
     emit deckHashChanged();
 
-    emit dataChanged(index, index);
     return true;
 }
 

--- a/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.h
+++ b/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.h
@@ -270,12 +270,6 @@ public:
     bool removeRows(int row, int count, const QModelIndex &parent) override;
 
     /**
-     * Recursively emits the dataChanged signal for all child nodes.
-     * @param parent The parent node
-     */
-    void emitBackgroundUpdates(const QModelIndex &parent);
-
-    /**
      * @brief Finds a card by name, zone, and optional identifiers.
      * @param cardName The card's name.
      * @param zoneName The zone to search in (main/side/etc.).
@@ -389,7 +383,19 @@ private:
                                                       const QString &providerId = "",
                                                       const QString &cardNumber = "") const;
 
+    /**
+     * @brief Recursively emits the dataChanged signal with role as Qt::BackgroundRole for all indices that are children
+     * of the given node. This is used to update the background color when changing formats.
+     * @param parent The parent node
+     */
+    void emitBackgroundUpdates(const QModelIndex &parent);
+
+    /**
+     * @brief Recursively emits the dataChanged signal for the given node and all parent nodes.
+     * @param index The parent node
+     */
     void emitRecursiveUpdates(const QModelIndex &index);
+
     void sortHelper(InnerDecklistNode *node, Qt::SortOrder order);
 
     template <typename T> T getNode(const QModelIndex &index) const


### PR DESCRIPTION
## Short roundup of the initial problem

`DeckListModel::emitBackgroundUpdates` should be a private method.

Also, `setData` directly emit `dataChanged(idx)` while also calling `emitRecursiveUpdates(idx)`, which also emits `dataChanged` with that idx. That means the `dataChanged` signal for the root idx is emitted twice.

## What will change with this Pull Request?
- Make `DeckListModel::emitBackgroundUpdates`
- Fix the double `dataChanged` emit