### PR TITLE
[DeckDockWidget] Fix tree unexpanding when changing group by

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -157,7 +157,7 @@ void DeckEditorDeckDockWidget::createDeckDock()
         QTimer::singleShot(100, this, &DeckEditorDeckDockWidget::updateBannerCardComboBox);
     });
     connect(deckModel, &DeckListModel::cardAddedAt, this, &DeckEditorDeckDockWidget::recursiveExpand);
-    connect(deckModel, &DeckListModel::deckReplaced, this, &DeckEditorDeckDockWidget::expandAll);
+    connect(deckModel, &DeckListModel::modelReset, this, &DeckEditorDeckDockWidget::expandAll);
 
     connect(bannerCardComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &DeckEditorDeckDockWidget::setBannerCard);


### PR DESCRIPTION
## Short roundup of the initial problem

The tree unexpands when the `group by` changes.

https://github.com/user-attachments/assets/eb19bee3-cff5-4bc9-bd14-d4152ec7e374

## What will change with this Pull Request?
- connect the `expandAll` slot to the `modelReset` signal

https://github.com/user-attachments/assets/29ee86df-f65e-45d6-836b-ced925d671e2

