### PR TITLE
manual drag override

### DIFF
--- a/cockatrice/src/game/zones/view_zone_widget.h
+++ b/cockatrice/src/game/zones/view_zone_widget.h
@@ -74,6 +74,8 @@ private:
     QPointer<QGraphicsView> dragView;
 
     void stopWindowDrag();
+    void startWindowDrag(QGraphicsSceneMouseEvent *event);
+    QRectF closeButtonRect(QWidget *styleWidget) const;
     /**
      * @brief Resolves the QGraphicsView to use for drag coordinate mapping
      *


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3386

## Short roundup of the initial problem
Zoneview window widgets (Library / Graveyard / Sideboard / etc) would  jitter while being dragged. At least on linux and possibly other os with high resolution.

## What will change with this Pull Request?
We are removing the drag jitter. Qt interfered with Cockatrice's constraints and the order of coord application. They would fight in the coord logic.
moveEvent fired after Qt moved the item so clamp or no clamp it would cause another move => another moveEvent.
This prevents that loop by intercepting the drag events and updates window position.

We now clamp before applying the position so it still can't be dragged offscreen.

## Screenshots
Video before: https://www.youtube.com/watch?v=mBqARUiaNho
Video after: https://www.youtube.com/watch?v=EEhh0tjJW0w

