### PR TITLE
[CardInfo] clean up signatures

### DIFF
--- a/libcockatrice_card/libcockatrice/card/card_info.cpp
+++ b/libcockatrice_card/libcockatrice/card/card_info.cpp
@@ -85,7 +85,7 @@ bool CardInfo::isLegalInFormat(const QString &format) const
     return formatLegality == "legal" || formatLegality == "restricted";
 }
 
-void CardInfo::addToSet(const CardSetPtr &_set, const PrintingInfo _info)
+void CardInfo::addToSet(const CardSetPtr &_set, const PrintingInfo &_info)
 {
     if (!_set->contains(smartThis)) {
         _set->append(smartThis);
@@ -166,7 +166,7 @@ QString CardInfo::simplifyName(const QString &name)
     return simpleName;
 }
 
-const QChar CardInfo::getColorChar() const
+QChar CardInfo::getColorChar() const
 {
     QString colors = getColors();
     switch (colors.size()) {
@@ -188,7 +188,7 @@ void CardInfo::resetReverseRelatedCards2Me()
 }
 
 // Back-compatibility methods. Remove ASAP
-const QString CardInfo::getCardType() const
+QString CardInfo::getCardType() const
 {
     return getProperty(Mtg::CardType);
 }
@@ -196,11 +196,11 @@ void CardInfo::setCardType(const QString &value)
 {
     setProperty(Mtg::CardType, value);
 }
-const QString CardInfo::getCmc() const
+QString CardInfo::getCmc() const
 {
     return getProperty(Mtg::ConvertedManaCost);
 }
-const QString CardInfo::getColors() const
+QString CardInfo::getColors() const
 {
     return getProperty(Mtg::Colors);
 }
@@ -208,19 +208,19 @@ void CardInfo::setColors(const QString &value)
 {
     setProperty(Mtg::Colors, value);
 }
-const QString CardInfo::getLoyalty() const
+QString CardInfo::getLoyalty() const
 {
     return getProperty(Mtg::Loyalty);
 }
-const QString CardInfo::getMainCardType() const
+QString CardInfo::getMainCardType() const
 {
     return getProperty(Mtg::MainCardType);
 }
-const QString CardInfo::getManaCost() const
+QString CardInfo::getManaCost() const
 {
     return getProperty(Mtg::ManaCost);
 }
-const QString CardInfo::getPowTough() const
+QString CardInfo::getPowTough() const
 {
     return getProperty(Mtg::PowTough);
 }

--- a/libcockatrice_card/libcockatrice/card/card_info.h
+++ b/libcockatrice_card/libcockatrice/card/card_info.h
@@ -267,18 +267,18 @@ public:
     }
     //@}
 
-    [[nodiscard]] const QChar getColorChar() const;
+    [[nodiscard]] QChar getColorChar() const;
 
     /** @name Legacy/Convenience Property Accessors */ //@{
-    [[nodiscard]] const QString getCardType() const;
+    [[nodiscard]] QString getCardType() const;
     void setCardType(const QString &value);
-    [[nodiscard]] const QString getCmc() const;
-    [[nodiscard]] const QString getColors() const;
+    [[nodiscard]] QString getCmc() const;
+    [[nodiscard]] QString getColors() const;
     void setColors(const QString &value);
-    [[nodiscard]] const QString getLoyalty() const;
-    [[nodiscard]] const QString getMainCardType() const;
-    [[nodiscard]] const QString getManaCost() const;
-    [[nodiscard]] const QString getPowTough() const;
+    [[nodiscard]] QString getLoyalty() const;
+    [[nodiscard]] QString getMainCardType() const;
+    [[nodiscard]] QString getManaCost() const;
+    [[nodiscard]] QString getPowTough() const;
     void setPowTough(const QString &value);
     //@}
 
@@ -308,7 +308,7 @@ public:
      * @param _set The set to which the card should be added.
      * @param _info Optional printing information.
      */
-    void addToSet(const CardSetPtr &_set, PrintingInfo _info = PrintingInfo());
+    void addToSet(const CardSetPtr &_set, const PrintingInfo &_info = PrintingInfo());
 
     /**
      * @brief Combines legality properties from a provided map.


### PR DESCRIPTION
## Short roundup of the initial problem

`CardInfo`'s getters return const QStrings. There's no reason to return const value types from methods. Const should only be used when returning a reference or pointer.

## What will change with this Pull Request?
- Remove the const
- Also update signature of `addToSet` to pass by const ref