### PR TITLE
[DeckListModel] Consolidate methods and signals for card change

### DIFF
--- a/cockatrice/src/interface/widgets/deck_analytics/deck_list_statistics_analyzer.cpp
+++ b/cockatrice/src/interface/widgets/deck_analytics/deck_list_statistics_analyzer.cpp
@@ -12,7 +12,7 @@ DeckListStatisticsAnalyzer::DeckListStatisticsAnalyzer(QObject *parent,
                                                        DeckListStatisticsAnalyzerConfig _config)
     : QObject(parent), model(_model), config(_config)
 {
-    connect(model, &DeckListModel::dataChanged, this, &DeckListStatisticsAnalyzer::analyze);
+    connect(model, &DeckListModel::cardsChanged, this, &DeckListStatisticsAnalyzer::analyze);
 }
 
 void DeckListStatisticsAnalyzer::analyze()

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -152,7 +152,7 @@ void DeckEditorDeckDockWidget::createDeckDock()
     bannerCardLabel->setText(tr("Banner Card"));
     bannerCardLabel->setHidden(!SettingsCache::instance().getDeckEditorBannerCardComboBoxVisible());
     bannerCardComboBox = new QComboBox(this);
-    connect(getModel(), &DeckListModel::dataChanged, this, [this]() {
+    connect(getModel(), &DeckListModel::cardNodesChanged, this, [this]() {
         // Delay the update to avoid race conditions
         QTimer::singleShot(100, this, &DeckEditorDeckDockWidget::updateBannerCardComboBox);
     });

--- a/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.cpp
@@ -11,8 +11,7 @@ DeckStateManager::DeckStateManager(QObject *parent)
         setModified(true);
         emit historyChanged();
     });
-    connect(deckListModel, &DeckListModel::rowsInserted, this, &DeckStateManager::uniqueCardsChanged);
-    connect(deckListModel, &DeckListModel::rowsRemoved, this, &DeckStateManager::uniqueCardsChanged);
+    connect(deckListModel, &DeckListModel::cardNodesChanged, this, &DeckStateManager::uniqueCardsChanged);
 }
 
 const DeckList &DeckStateManager::getDeckList() const

--- a/cockatrice/src/interface/widgets/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_select_set_for_cards.cpp
@@ -152,7 +152,7 @@ static bool swapPrinting(DeckListModel *model, const QString &modifiedSet, const
         return false;
     }
     int amount = model->data(idx.siblingAtColumn(DeckListModelColumns::CARD_AMOUNT), Qt::DisplayRole).toInt();
-    model->removeRow(idx.row(), idx.parent());
+    model->removeCardAtIndex(idx);
     CardInfoPtr cardInfo = CardDatabaseManager::query()->getCardInfo(cardName);
     PrintingInfo printing = CardDatabaseManager::query()->getSpecificPrinting(cardName, modifiedSet, "");
     for (int i = 0; i < amount; i++) {

--- a/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.cpp
@@ -144,7 +144,7 @@ static QModelIndex addAndReplacePrintings(DeckListModel *model,
     // Check if a card without a providerId already exists in the deckModel and replace it, if so.
     if (existing.isValid() && existing != newCardIndex && replaceProviderless) {
         model->offsetCountAtIndex(newCardIndex, extraCopies);
-        model->removeRow(existing.row(), existing.parent());
+        model->removeCardAtIndex(existing);
     }
 
     // Set Index and Focus as if the user had just clicked the new card and modify the deckEditor saveState

--- a/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.h
+++ b/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.h
@@ -197,6 +197,12 @@ public:
  * InnerDecklistNode containers and supports grouping, sorting, adding/removing
  * cards, and printing decklists.
  *
+ * Outside code should refrain from modifying the model with methods inherited from QAbstractItemModel, such as with
+ * `setData` or `removeRow`.
+ * Instead, use the custom methods on this class to modify the model, such as `addCard`, `offsetCountAtIndex`, or
+ * `removeCardAtIndex`.
+ * This ensures the custom signals for this class are correctly emitted.
+ *
  * Signals:
  * - deckHashChanged(): emitted when the deck contents change in a way that
  *   affects its hash.
@@ -232,11 +238,38 @@ signals:
     void deckHashChanged();
 
     /**
+     * @brief Emitted whenever the cards in the deck changes. This includes when the deck is replaced.
+     */
+    void cardsChanged();
+
+    /**
      * @brief Emitted whenever a card is added to the deck, regardless of whether it's an entirely new card or an
      * existing card that got incremented.
      * @param index The index of the card that got added.
      */
     void cardAddedAt(const QModelIndex &index);
+
+    /**
+     * @brief Emitted whenever a card is removed from the deck, regardless of whether a card node was removed or an
+     * existing card got decremented.
+     */
+    void cardRemoved();
+
+    /**
+     * @brief Emitted whenever a card node is added or removed. This includes when the deck is replaced.
+     */
+    void cardNodesChanged();
+
+    /**
+     * @brief Emitted whenever a new card node is added.
+     * @param index The index of the card node that got added.
+     */
+    void cardNodeAddedAt(const QModelIndex &index);
+
+    /**
+     * @brief Emitted whenever a card node is removed.
+     */
+    void cardNodeRemoved();
 
     /**
      * @brief Emitted whenever the deck in the model has been replaced with a new one
@@ -310,6 +343,13 @@ public:
      * @return Whether the operation was successful
      */
     bool offsetCountAtIndex(const QModelIndex &idx, int offset);
+
+    /**
+     * @brief Removes the card node at the index
+     * @param idx The index of a card node. No-ops if the index is invalid or not a card node.
+     * @return Whether the node was removed.
+     */
+    bool removeCardAtIndex(const QModelIndex &idx);
 
     /**
      * @brief Removes all cards and resets the model.


### PR DESCRIPTION
## Short roundup of the initial problem

Currently, we connect to the `dataChanged` signal of the `DeckListModel` in order to react to card changes. However, `dataChanged` triggers on all node changes, included non-card nodes. Since we `emitRecursiveUpdates` whenever we modify a node, that means the `dataChanged` signal gets emitted multiple times on each change. 
Currently it's not a huge problem because the code can gracefully handle being triggered multiple times, but it *is* an inefficiency. 

## What will change with this Pull Request?
- Add `removeCardAtIndex` method 
- Add docs to class to instruct people to not modify the model directly
  - Replace outside usages of `removeRow`
- Add new signals to `DeckListModel` that are emitted on card change.
  - Update usages to use those signals instead of `dataChanged` when applicable.