### PR TITLE
[View Zone Widget] Properly calculate titleBar close rect on Windows.

### DIFF
--- a/cockatrice/src/game/zones/view_zone_widget.h
+++ b/cockatrice/src/game/zones/view_zone_widget.h
@@ -54,7 +54,6 @@ private:
     ZoneViewZone *zone;
     QGraphicsWidget *zoneContainer;
 
-    QPushButton *closeButton;
     QScrollBar *scrollBar;
     ScrollableGraphicsProxyWidget *scrollBarProxy;
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes regression introduced in #6461

## Short roundup of the initial problem
The closeButtonRect() calculcation was off for Windows which means people couldn't close the windows anymore.

## What will change with this Pull Request?
- Proper coordinate space
