### PR TITLE
[DeckList] move SideboardPlan into separate file

### DIFF
--- a/libcockatrice_deck_list/CMakeLists.txt
+++ b/libcockatrice_deck_list/CMakeLists.txt
@@ -9,7 +9,9 @@ set(HEADERS
     libcockatrice/deck_list/tree/inner_deck_list_node.h
     libcockatrice/deck_list/deck_list.h
     libcockatrice/deck_list/deck_list_history_manager.h
+    libcockatrice/deck_list/deck_list_node_tree.h
     libcockatrice/deck_list/deck_list_memento.h
+    libcockatrice/deck_list/sideboard_plan.h
 )
 
 if(Qt6_FOUND)
@@ -28,7 +30,7 @@ add_library(
   libcockatrice/deck_list/deck_list.cpp
   libcockatrice/deck_list/deck_list_history_manager.cpp
   libcockatrice/deck_list/deck_list_node_tree.cpp
-  libcockatrice/deck_list/deck_list_node_tree.h
+  libcockatrice/deck_list/sideboard_plan.cpp
 )
 
 add_dependencies(libcockatrice_deck_list libcockatrice_protocol)

--- a/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.cpp
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.cpp
@@ -21,62 +21,6 @@ uint qHash(const QRegularExpression &key, uint seed) noexcept
 }
 #endif
 
-SideboardPlan::SideboardPlan(const QString &_name, const QList<MoveCard_ToZone> &_moveList)
-    : name(_name), moveList(_moveList)
-{
-}
-
-void SideboardPlan::setMoveList(const QList<MoveCard_ToZone> &_moveList)
-{
-    moveList = _moveList;
-}
-
-bool SideboardPlan::readElement(QXmlStreamReader *xml)
-{
-    while (!xml->atEnd()) {
-        xml->readNext();
-        const QString childName = xml->name().toString();
-        if (xml->isStartElement()) {
-            if (childName == "name")
-                name = xml->readElementText();
-            else if (childName == "move_card_to_zone") {
-                MoveCard_ToZone m;
-                while (!xml->atEnd()) {
-                    xml->readNext();
-                    const QString childName2 = xml->name().toString();
-                    if (xml->isStartElement()) {
-                        if (childName2 == "card_name")
-                            m.set_card_name(xml->readElementText().toStdString());
-                        else if (childName2 == "start_zone")
-                            m.set_start_zone(xml->readElementText().toStdString());
-                        else if (childName2 == "target_zone")
-                            m.set_target_zone(xml->readElementText().toStdString());
-                    } else if (xml->isEndElement() && (childName2 == "move_card_to_zone")) {
-                        moveList.append(m);
-                        break;
-                    }
-                }
-            }
-        } else if (xml->isEndElement() && (childName == "sideboard_plan"))
-            return true;
-    }
-    return false;
-}
-
-void SideboardPlan::write(QXmlStreamWriter *xml)
-{
-    xml->writeStartElement("sideboard_plan");
-    xml->writeTextElement("name", name);
-    for (auto &i : moveList) {
-        xml->writeStartElement("move_card_to_zone");
-        xml->writeTextElement("card_name", QString::fromStdString(i.card_name()));
-        xml->writeTextElement("start_zone", QString::fromStdString(i.start_zone()));
-        xml->writeTextElement("target_zone", QString::fromStdString(i.target_zone()));
-        xml->writeEndElement();
-    }
-    xml->writeEndElement();
-}
-
 bool DeckList::Metadata::isEmpty() const
 {
     return name.isEmpty() && comments.isEmpty() && bannerCard.isEmpty() && tags.isEmpty();

--- a/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.h
@@ -1,6 +1,6 @@
 /**
  * @file deck_list.h
- * @brief Defines the DeckList class and supporting types for managing a full
+ * @brief Defines the DeckList class, which manages a full
  *        deck structure including cards, zones, sideboard plans, and
  *        serialization to/from multiple formats. This is a logic class which
  *        does not care about Qt or user facing views.
@@ -12,12 +12,12 @@
 
 #include "deck_list_memento.h"
 #include "deck_list_node_tree.h"
+#include "sideboard_plan.h"
 #include "tree/inner_deck_list_node.h"
 
 #include <QMap>
 #include <QVector>
 #include <QtCore/QXmlStreamReader>
-#include <libcockatrice/protocol/pb/move_card_to_zone.pb.h>
 #include <libcockatrice/utility/card_ref.h>
 
 class AbstractDecklistNode;
@@ -26,67 +26,6 @@ class CardDatabase;
 class QIODevice;
 class QTextStream;
 class InnerDecklistNode;
-
-/**
- * @class SideboardPlan
- * @ingroup Decks
- * @brief Represents a predefined sideboarding strategy for a deck.
- *
- * Sideboard plans store a named list of card movements that should be applied
- * between the mainboard and sideboard for a specific matchup. Each movement
- * is expressed using a `MoveCard_ToZone` protobuf message.
- *
- * ### Responsibilities:
- * - Store the plan name and list of moves.
- * - Support XML serialization/deserialization.
- *
- * ### Typical usage:
- * A deck can contain multiple sideboard plans (e.g., "vs Aggro", "vs Control"),
- * each describing how to transform the main deck into its intended configuration.
- */
-class SideboardPlan
-{
-private:
-    QString name;                    ///< Human-readable name of this plan.
-    QList<MoveCard_ToZone> moveList; ///< List of move instructions for this plan.
-
-public:
-    /**
-     * @brief Construct a new SideboardPlan.
-     * @param _name The plan name.
-     * @param _moveList Initial list of card move instructions.
-     */
-    explicit SideboardPlan(const QString &_name = QString(),
-                           const QList<MoveCard_ToZone> &_moveList = QList<MoveCard_ToZone>());
-
-    /**
-     * @brief Read a SideboardPlan from an XML stream.
-     * @param xml XML reader positioned at the plan element.
-     * @return true if parsing succeeded.
-     */
-    bool readElement(QXmlStreamReader *xml);
-
-    /**
-     * @brief Write this SideboardPlan to XML.
-     * @param xml Stream to append the serialized element to.
-     */
-    void write(QXmlStreamWriter *xml);
-
-    /// @return The plan name.
-    [[nodiscard]] QString getName() const
-    {
-        return name;
-    }
-
-    /// @return Const reference to the move list.
-    [[nodiscard]] const QList<MoveCard_ToZone> &getMoveList() const
-    {
-        return moveList;
-    }
-
-    /// @brief Replace the move list with a new one.
-    void setMoveList(const QList<MoveCard_ToZone> &_moveList);
-};
 
 /**
  * @class DeckList

--- a/libcockatrice_deck_list/libcockatrice/deck_list/sideboard_plan.cpp
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/sideboard_plan.cpp
@@ -1,0 +1,59 @@
+#include "sideboard_plan.h"
+
+#include <QXmlStreamReader>
+
+SideboardPlan::SideboardPlan(const QString &_name, const QList<MoveCard_ToZone> &_moveList)
+    : name(_name), moveList(_moveList)
+{
+}
+
+void SideboardPlan::setMoveList(const QList<MoveCard_ToZone> &_moveList)
+{
+    moveList = _moveList;
+}
+
+bool SideboardPlan::readElement(QXmlStreamReader *xml)
+{
+    while (!xml->atEnd()) {
+        xml->readNext();
+        const QString childName = xml->name().toString();
+        if (xml->isStartElement()) {
+            if (childName == "name")
+                name = xml->readElementText();
+            else if (childName == "move_card_to_zone") {
+                MoveCard_ToZone m;
+                while (!xml->atEnd()) {
+                    xml->readNext();
+                    const QString childName2 = xml->name().toString();
+                    if (xml->isStartElement()) {
+                        if (childName2 == "card_name")
+                            m.set_card_name(xml->readElementText().toStdString());
+                        else if (childName2 == "start_zone")
+                            m.set_start_zone(xml->readElementText().toStdString());
+                        else if (childName2 == "target_zone")
+                            m.set_target_zone(xml->readElementText().toStdString());
+                    } else if (xml->isEndElement() && (childName2 == "move_card_to_zone")) {
+                        moveList.append(m);
+                        break;
+                    }
+                }
+            }
+        } else if (xml->isEndElement() && (childName == "sideboard_plan"))
+            return true;
+    }
+    return false;
+}
+
+void SideboardPlan::write(QXmlStreamWriter *xml)
+{
+    xml->writeStartElement("sideboard_plan");
+    xml->writeTextElement("name", name);
+    for (auto &i : moveList) {
+        xml->writeStartElement("move_card_to_zone");
+        xml->writeTextElement("card_name", QString::fromStdString(i.card_name()));
+        xml->writeTextElement("start_zone", QString::fromStdString(i.start_zone()));
+        xml->writeTextElement("target_zone", QString::fromStdString(i.target_zone()));
+        xml->writeEndElement();
+    }
+    xml->writeEndElement();
+}

--- a/libcockatrice_deck_list/libcockatrice/deck_list/sideboard_plan.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/sideboard_plan.h
@@ -1,0 +1,71 @@
+#ifndef COCKATRICE_SIDEBOARD_PLAN_H
+#define COCKATRICE_SIDEBOARD_PLAN_H
+
+#include <QList>
+#include <libcockatrice/protocol/pb/move_card_to_zone.pb.h>
+
+class QXmlStreamWriter;
+class QXmlStreamReader;
+
+/**
+ * @class SideboardPlan
+ * @ingroup Decks
+ * @brief Represents a predefined sideboarding strategy for a deck.
+ *
+ * Sideboard plans store a named list of card movements that should be applied
+ * between the mainboard and sideboard for a specific matchup. Each movement
+ * is expressed using a `MoveCard_ToZone` protobuf message.
+ *
+ * ### Responsibilities:
+ * - Store the plan name and list of moves.
+ * - Support XML serialization/deserialization.
+ *
+ * ### Typical usage:
+ * A deck can contain multiple sideboard plans (e.g., "vs Aggro", "vs Control"),
+ * each describing how to transform the main deck into its intended configuration.
+ */
+class SideboardPlan
+{
+private:
+    QString name;                    ///< Human-readable name of this plan.
+    QList<MoveCard_ToZone> moveList; ///< List of move instructions for this plan.
+
+public:
+    /**
+     * @brief Construct a new SideboardPlan.
+     * @param _name The plan name.
+     * @param _moveList Initial list of card move instructions.
+     */
+    explicit SideboardPlan(const QString &_name = QString(),
+                           const QList<MoveCard_ToZone> &_moveList = QList<MoveCard_ToZone>());
+
+    /**
+     * @brief Read a SideboardPlan from an XML stream.
+     * @param xml XML reader positioned at the plan element.
+     * @return true if parsing succeeded.
+     */
+    bool readElement(QXmlStreamReader *xml);
+
+    /**
+     * @brief Write this SideboardPlan to XML.
+     * @param xml Stream to append the serialized element to.
+     */
+    void write(QXmlStreamWriter *xml);
+
+    /// @return The plan name.
+    [[nodiscard]] QString getName() const
+    {
+        return name;
+    }
+
+    /// @return Const reference to the move list.
+    [[nodiscard]] const QList<MoveCard_ToZone> &getMoveList() const
+    {
+        return moveList;
+    }
+
+    /// @brief Replace the move list with a new one.
+    void setMoveList(const QList<MoveCard_ToZone> &_moveList);
+};
+
+#endif // COCKATRICE_SIDEBOARD_PLAN_H


### PR DESCRIPTION
## Short roundup of the initial problem

`SideboardPlan` has enough stuff in it that it can be in its own file.

## What will change with this Pull Request?
- Move `SideboardPlan` to separate file
- Fix the incorrect location for `deck_list_node_tree.h` in the cmake from before