### PR TITLE
[DeckList] Store sideboardPlans by value to fix crash

### DIFF
--- a/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.h
@@ -78,9 +78,9 @@ public:
     };
 
 private:
-    Metadata metadata;                             ///< Deck metadata that is stored in the deck file
-    QMap<QString, SideboardPlan *> sideboardPlans; ///< Named sideboard plans.
-    DecklistNodeTree tree;                         ///< The deck tree (zones + cards).
+    Metadata metadata;                           ///< Deck metadata that is stored in the deck file
+    QMap<QString, SideboardPlan> sideboardPlans; ///< Named sideboard plans.
+    DecklistNodeTree tree;                       ///< The deck tree (zones + cards).
 
     /**
      * @brief Cached deck hash, recalculated lazily.
@@ -132,8 +132,7 @@ public:
     /// @brief Construct from components
     DeckList(const Metadata &metadata,
              const DecklistNodeTree &tree,
-             const QMap<QString, SideboardPlan *> &sideboardPlans = {});
-    virtual ~DeckList();
+             const QMap<QString, SideboardPlan> &sideboardPlans = {});
 
     /**
      * @brief Gets a pointer to the underlying node tree.
@@ -186,9 +185,9 @@ public:
 
     /// @name Sideboard plans
     ///@{
-    QList<MoveCard_ToZone> getCurrentSideboardPlan();
+    QList<MoveCard_ToZone> getCurrentSideboardPlan() const;
     void setCurrentSideboardPlan(const QList<MoveCard_ToZone> &plan);
-    const QMap<QString, SideboardPlan *> &getSideboardPlans() const
+    const QMap<QString, SideboardPlan> &getSideboardPlans() const
     {
         return sideboardPlans;
     }

--- a/libcockatrice_deck_list/libcockatrice/deck_list/sideboard_plan.cpp
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/sideboard_plan.cpp
@@ -44,7 +44,7 @@ bool SideboardPlan::readElement(QXmlStreamReader *xml)
     return false;
 }
 
-void SideboardPlan::write(QXmlStreamWriter *xml)
+void SideboardPlan::write(QXmlStreamWriter *xml) const
 {
     xml->writeStartElement("sideboard_plan");
     xml->writeTextElement("name", name);

--- a/libcockatrice_deck_list/libcockatrice/deck_list/sideboard_plan.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/sideboard_plan.h
@@ -36,8 +36,7 @@ public:
      * @param _name The plan name.
      * @param _moveList Initial list of card move instructions.
      */
-    explicit SideboardPlan(const QString &_name = QString(),
-                           const QList<MoveCard_ToZone> &_moveList = QList<MoveCard_ToZone>());
+    explicit SideboardPlan(const QString &_name = "", const QList<MoveCard_ToZone> &_moveList = {});
 
     /**
      * @brief Read a SideboardPlan from an XML stream.
@@ -50,7 +49,7 @@ public:
      * @brief Write this SideboardPlan to XML.
      * @param xml Stream to append the serialized element to.
      */
-    void write(QXmlStreamWriter *xml);
+    void write(QXmlStreamWriter *xml) const;
 
     /// @return The plan name.
     [[nodiscard]] QString getName() const


### PR DESCRIPTION
## Related Ticket(s)

- Fixes bug introduced in #6412

## Short roundup of the initial problem

Cockatrice crashes whenever you try to open a deck that has a sideboard plan.

The reason is because `DeckList` stores the `SideboardPlan` objects by pointer in its map. `DeckList` uses the default copy-constructor, which shallow copies the map. The destructor, however, deletes all pointers in the map, causing a double free after the copy.

## What will change with this Pull Request?
- Store the `SideboardPlan` by value instead of by pointer in the map.
- Clean up some code related to `SideboardPlan`