### PR TITLE
[VDS] Add search query option for comments

### DIFF
--- a/cockatrice/resources/help/deck_search.md
+++ b/cockatrice/resources/help/deck_search.md
@@ -27,6 +27,11 @@ searches are case insensitive.
 <dt><u>F</u>ormat:</dt>
 <dd>[f:standard](#f:standard) <small>(Any deck with format set to standard)</small></dd>
 
+<dt><u>C</u>omments:</dt>
+<dd>[c:good](#c:good) <small>(Any deck with comments containing the word good)</small></dd>
+<dd>[c:good c:deck](#c:good c:deck) <small>(Any deck with comments containing the words good and deck)</small></dd>
+<dd>[c:"good deck"](#c:%22good deck%22) <small>(Any deck with comments containing the exact phrase "good deck")</small></dd>
+
 <dt>Deck Contents (Uses [card search expressions](#cardSearchSyntaxHelp)):</dt>
 <dd><a href="#[[plains]]">[[plains]]</a> <small>(Any deck that contains at least one card with "plains" in its name)</small></dd>
 <dd><a href="#[[t:legendary]]">[[t:legendary]]</a> <small>(Any deck that contains at least one legendary)</small></dd>

--- a/cockatrice/src/filters/deck_filter_string.cpp
+++ b/cockatrice/src/filters/deck_filter_string.cpp
@@ -13,7 +13,7 @@ QueryPartList <- ComplexQueryPart ( ws ("AND" ws)? ComplexQueryPart)* ws*
 ComplexQueryPart <- SomewhatComplexQueryPart ws "OR" ws ComplexQueryPart / SomewhatComplexQueryPart
 SomewhatComplexQueryPart <- [(] QueryPartList [)] / QueryPart
 
-QueryPart <- NotQuery / DeckContentQuery / DeckNameQuery / FileNameQuery / PathQuery / FormatQuery / GenericQuery
+QueryPart <- NotQuery / DeckContentQuery / DeckNameQuery / FileNameQuery / PathQuery / FormatQuery / CommentQuery / GenericQuery
 
 NotQuery <- ('NOT' ws/'-') SomewhatComplexQueryPart
 
@@ -25,6 +25,7 @@ DeckNameQuery <- ([Dd] 'eck')? [Nn] 'ame'? [:] String
 FileNameQuery <- [Ff] ([Nn] / 'ile' ([Nn] 'ame')?) [:] String
 PathQuery <- [Pp] 'ath'? [:] String
 FormatQuery <- [Ff] 'ormat'? [:] String
+CommentQuery <- [Cc] ('omment' 's'?)? [:] String
 
 GenericQuery <- String
 
@@ -163,6 +164,14 @@ static void setupParserRules()
         return [=](const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &) {
             auto gameFormat = deck->deckLoader->getDeck().deckList.getGameFormat();
             return QString::compare(format, gameFormat, Qt::CaseInsensitive) == 0;
+        };
+    };
+
+    search["CommentQuery"] = [](const peg::SemanticValues &sv) -> DeckFilter {
+        auto value = std::any_cast<QString>(sv[0]);
+        return [=](const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &) {
+            auto comments = deck->deckLoader->getDeck().deckList.getComments();
+            return comments.contains(value, Qt::CaseInsensitive);
         };
     };
 


### PR DESCRIPTION
## Related Ticket(s)

- Follow-up to #6414

## Short roundup of the initial problem

Since we already have all these other search query options for metadata fields, might as well also add one for comments.

## What will change with this Pull Request?
- Add search query option for comments
  - Accepts `c:`, `comment:`, and `comments:`
  - Will match if the deck's comments contains the entire search string (case insensitive) 
- Update deck search help

https://github.com/user-attachments/assets/04cca9d4-7e80-4ba2-9f82-fa19c73a5965

## Screenshots

<img width="504" height="629" alt="Screenshot 2026-01-02 at 12 48 53 AM" src="https://github.com/user-attachments/assets/e3fac79f-048a-4fbd-8262-3a9c73a721a2" />
