### PR TITLE
[PrintingSelector] optimize amount calculation

### DIFF
--- a/cockatrice/src/interface/widgets/printing_selector/all_zones_card_amount_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/all_zones_card_amount_widget.cpp
@@ -72,6 +72,12 @@ void AllZonesCardAmountWidget::adjustFontSize(int scalePercentage)
     repaint();
 }
 
+void AllZonesCardAmountWidget::setAmounts(int mainboardAmount, int sideboardAmount)
+{
+    buttonBoxMainboard->setAmount(mainboardAmount);
+    buttonBoxSideboard->setAmount(sideboardAmount);
+}
+
 /**
  * @brief Gets the card count in the mainboard zone.
  *
@@ -79,7 +85,7 @@ void AllZonesCardAmountWidget::adjustFontSize(int scalePercentage)
  */
 int AllZonesCardAmountWidget::getMainboardAmount()
 {
-    return buttonBoxMainboard->countCardsInZone(DECK_ZONE_MAIN);
+    return buttonBoxMainboard->getAmount();
 }
 
 /**
@@ -89,7 +95,15 @@ int AllZonesCardAmountWidget::getMainboardAmount()
  */
 int AllZonesCardAmountWidget::getSideboardAmount()
 {
-    return buttonBoxSideboard->countCardsInZone(DECK_ZONE_SIDE);
+    return buttonBoxSideboard->getAmount();
+}
+
+/**
+ * @brief Checks if the amount is at least one in either the mainboard or sideboard.
+ */
+bool AllZonesCardAmountWidget::isNonZero()
+{
+    return getMainboardAmount() > 0 || getSideboardAmount() > 0;
 }
 
 /**

--- a/cockatrice/src/interface/widgets/printing_selector/all_zones_card_amount_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/all_zones_card_amount_widget.h
@@ -23,6 +23,8 @@ public:
                                       const ExactCard &rootCard);
     int getMainboardAmount();
     int getSideboardAmount();
+    bool isNonZero();
+
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     void enterEvent(QEnterEvent *event) override;
 #else
@@ -31,6 +33,7 @@ public:
 
 public slots:
     void adjustFontSize(int scalePercentage);
+    void setAmounts(int mainboardAmount, int sideboardAmount);
 
 private:
     QVBoxLayout *layout;

--- a/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.h
@@ -31,9 +31,10 @@ public:
                               QSlider *cardSizeSlider,
                               const ExactCard &rootCard,
                               const QString &zoneName);
-    int countCardsInZone(const QString &deckZone);
+    int getAmount();
 
 public slots:
+    void setAmount(int _amount);
     void updateCardCount();
     void addPrinting(const QString &zone);
 
@@ -52,6 +53,7 @@ private:
     QLabel *cardCountInZone;
 
     bool hovered;
+    int amount = 0;
 
     void decrementCardHelper(const QString &zoneName);
 

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector.h
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector.h
@@ -44,6 +44,7 @@ public slots:
 
 private slots:
     void printingsInDeckChanged();
+    void updateCardAmounts();
 
 signals:
     /**
@@ -54,6 +55,12 @@ signals:
      * Requests the next card in the list
      */
     void nextCardRequested();
+
+    /**
+     * The amounts of the printings in the deck has changed
+     * @param uuidToAmounts Map of uuids to the amounts (maindeck, sideboard) in the deck
+     */
+    void cardAmountsChanged(const QMap<QString, QPair<int, int>> &uuidToAmounts);
 
 private:
     QVBoxLayout *layout;

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.cpp
@@ -27,7 +27,7 @@ PrintingSelectorCardDisplayWidget::PrintingSelectorCardDisplayWidget(QWidget *pa
                                                                      DeckStateManager *deckStateManager,
                                                                      QSlider *cardSizeSlider,
                                                                      const ExactCard &rootCard)
-    : QWidget(parent)
+    : QWidget(parent), rootCard(rootCard)
 {
     layout = new QVBoxLayout(this);
     setLayout(layout);
@@ -63,4 +63,10 @@ void PrintingSelectorCardDisplayWidget::clampSetNameToPicture()
         setNameAndCollectorsNumberDisplayWidget->setMaximumWidth(overlayWidget->width());
     }
     update();
+}
+
+void PrintingSelectorCardDisplayWidget::updateCardAmounts(const QMap<QString, QPair<int, int>> &uuidToAmounts)
+{
+    auto [main, side] = uuidToAmounts.value(rootCard.getPrinting().getUuid());
+    overlayWidget->updateCardAmounts(main, side);
 }

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.h
@@ -27,11 +27,13 @@ public:
 
 public slots:
     void clampSetNameToPicture();
+    void updateCardAmounts(const QMap<QString, QPair<int, int>> &uuidToAmounts);
 
 signals:
     void cardPreferenceChanged();
 
 private:
+    ExactCard rootCard;
     QVBoxLayout *layout;
     SetNameAndCollectorsNumberDisplayWidget *setNameAndCollectorsNumberDisplayWidget;
     PrintingSelectorCardOverlayWidget *overlayWidget;

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
@@ -59,12 +59,6 @@ PrintingSelectorCardOverlayWidget::PrintingSelectorCardOverlayWidget(QWidget *pa
     allZonesCardAmountWidget = new AllZonesCardAmountWidget(this, deckStateManager, cardSizeSlider, _rootCard);
 
     allZonesCardAmountWidget->raise(); // Ensure it's on top of the picture
-    // Set initial visibility based on amounts
-    if (allZonesCardAmountWidget->getMainboardAmount() > 0 || allZonesCardAmountWidget->getSideboardAmount() > 0) {
-        allZonesCardAmountWidget->setVisible(true);
-    } else {
-        allZonesCardAmountWidget->setVisible(false);
-    }
 
     // Attempt to cast the parent to PrintingSelectorCardDisplayWidget
     if (const auto *parentWidget = qobject_cast<PrintingSelectorCardDisplayWidget *>(parent)) {
@@ -113,8 +107,7 @@ void PrintingSelectorCardOverlayWidget::resizeEvent(QResizeEvent *event)
 /**
  * @brief Handles the mouse enter event when the cursor enters the overlay widget area.
  *
- * When the cursor enters the widget, the card information is updated, and the card amount widget
- * is displayed if the amounts are zero for both the mainboard and sideboard.
+ * When the cursor enters the widget, the card amount widget becomes visible regardless of whether the amounts are zero.
  *
  * @param event The event triggered when the mouse enters the widget.
  */
@@ -126,16 +119,27 @@ void PrintingSelectorCardOverlayWidget::enterEvent(QEvent *event)
 {
     QWidget::enterEvent(event);
     deckEditor->updateCard(rootCard);
-
-    // Check if either mainboard or sideboard amount is greater than 0
-    if (allZonesCardAmountWidget->getMainboardAmount() > 0 || allZonesCardAmountWidget->getSideboardAmount() > 0) {
-        // Don't change visibility if amounts are greater than 0
-        return;
-    }
-
-    // Show the widget if amounts are 0
-    allZonesCardAmountWidget->setVisible(true);
+    updateVisibility();
 }
+
+void PrintingSelectorCardOverlayWidget::updateCardAmounts(int mainboardAmount, int sideboardAmount)
+{
+    allZonesCardAmountWidget->setAmounts(mainboardAmount, sideboardAmount);
+    updateVisibility();
+}
+
+/**
+ * @brief Sets the visibility of the widgets depending on the amounts and whether the mouse is hovering over.
+ */
+void PrintingSelectorCardOverlayWidget::updateVisibility()
+{
+    if (allZonesCardAmountWidget->isNonZero() || underMouse()) {
+        allZonesCardAmountWidget->setVisible(true);
+    } else {
+        allZonesCardAmountWidget->setVisible(false);
+    }
+}
+
 /**
  * @brief Updates the pin badge visibility and position based on the card's pinned state.
  *
@@ -182,15 +186,7 @@ void PrintingSelectorCardOverlayWidget::updatePinBadgeVisibility()
 void PrintingSelectorCardOverlayWidget::leaveEvent(QEvent *event)
 {
     QWidget::leaveEvent(event);
-
-    // Check if either mainboard or sideboard amount is greater than 0
-    if (allZonesCardAmountWidget->getMainboardAmount() > 0 || allZonesCardAmountWidget->getSideboardAmount() > 0) {
-        // Don't hide the widget if amounts are greater than 0
-        return;
-    }
-
-    // Hide the widget if amounts are 0
-    allZonesCardAmountWidget->setVisible(false);
+    updateVisibility();
 }
 
 /**

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.h
@@ -38,7 +38,11 @@ protected:
 signals:
     void cardPreferenceChanged();
 
+public slots:
+    void updateCardAmounts(int mainboardAmount, int sideboardAmount);
+
 private slots:
+    void updateVisibility();
     void updatePinBadgeVisibility();
 
 private:


### PR DESCRIPTION
## Short roundup of the initial problem

The amount calculation in the PrintingSelector is extremely inefficient. Each `CardAmountWidget` (which represents a single plus/minus pair) does their own amount calculation, by doing a full scan of the `DeckListModel` to count how many matching uuids it finds.

But also, the `CardAmountWidget`s don't actually store the amount after doing the calculation. Other classes are calling `CardAmountWidget::countCardsInZone` like it has the cost of a getter despite the fact that it has to do a full calculation every time.

We have two of these widgets per printing. For cards that have a lot of printings (such as basic lands), this leads to an insane amount of `DeckListModel` scans whenever the deck is modified. And also, the scans becomes more expensive the more cards you have in your deck.

<img width="800" height="800" alt="Screenshot 2025-12-31 at 6 39 16 PM" src="https://github.com/user-attachments/assets/d6fcc834-fea3-49a7-a4d7-fa68e47f5057" />

I lag noticeably when adding cards to the deck while there are a lot of cards in the deck already and the printingSelector is on a card with a lot of printings (such as a basic land).

## What will change with this Pull Request?
- The card amount calculation will be done a single time, in PrintingSelector, every time the deck changes.
  - Calculation returns a map of uuid to amounts that is passed down to the children widgets for them to use.
    - We now only need to do one full scan of the model on every change.
- `CardAmountWidget` stores the amount that is passed into it, instead of calculating it on the fly every time
  - Clean up some code in `PrintingSelectorCardOverlayWidget` related to widget visibility