### PR TITLE
[DeckDockWidget] Fix VDE crash due to not mapping proxy index

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.h
@@ -90,7 +90,7 @@ private:
     QAction *aRemoveCard, *aIncrement, *aDecrement, *aSwapCard;
 
     DeckListModel *getModel() const;
-    [[nodiscard]] QModelIndexList getSelectedCardNodes() const;
+    [[nodiscard]] QModelIndexList getSelectedCardNodeSourceIndices() const;
     void offsetCountAtIndex(const QModelIndex &idx, bool isIncrement);
 
 private slots:


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #6459

## Short roundup of the initial problem

In the visual deck editor, once you used the "remove card" or "swap card" action, the next time a card node is added or removed, Cockatrice will crash.

## What will change with this Pull Request?
- Ensure indices from the view are mapped from proxy to source before passing into the DeckStateManager.
  - Refactored `getSelectedCardNodes` to return the source indices instead of proxy indices
  - Renamed some variables to make more apparent what model the index is for