### PR TITLE
[App] Send diagnostics on server connection

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -42,6 +42,7 @@ set(cockatrice_SOURCES
     src/interface/widgets/dialogs/dlg_manage_sets.cpp
     src/interface/widgets/dialogs/dlg_register.cpp
     src/interface/widgets/dialogs/dlg_select_set_for_cards.cpp
+    src/interface/widgets/dialogs/dlg_prompt_send_diagnostics.cpp
     src/interface/widgets/dialogs/dlg_settings.cpp
     src/interface/widgets/dialogs/dlg_startup_card_check.cpp
     src/interface/widgets/dialogs/dlg_tip_of_the_day.cpp

--- a/cockatrice/src/client/settings/cache_settings.cpp
+++ b/cockatrice/src/client/settings/cache_settings.cpp
@@ -212,6 +212,7 @@ SettingsCache::SettingsCache()
     cardUpdateCheckInterval = settings->value("personal/cardUpdateCheckInterval", 7).toInt();
     lastCardUpdateCheck = settings->value("personal/lastCardUpdateCheck", QDateTime::currentDateTime().date()).toDate();
     notifyAboutUpdates = settings->value("personal/updatenotification", true).toBool();
+    sendDiagnostics = settings->value("personal/senddiagnostics", 0).toInt();
     notifyAboutNewVersion = settings->value("personal/newversionnotification", true).toBool();
 
     if (settings->contains("personal/updatereleasechannel")) {
@@ -1494,6 +1495,12 @@ void SettingsCache::setNotifyAboutUpdate(QT_STATE_CHANGED_T _notifyaboutupdate)
 {
     notifyAboutUpdates = static_cast<bool>(_notifyaboutupdate);
     settings->setValue("personal/updatenotification", notifyAboutUpdates);
+}
+
+void SettingsCache::setSendDiagnostics(int _sendDiagnostics)
+{
+    sendDiagnostics = _sendDiagnostics;
+    settings->setValue("personal/senddiagnostics", sendDiagnostics);
 }
 
 void SettingsCache::setNotifyAboutNewVersion(QT_STATE_CHANGED_T _notifyaboutnewversion)

--- a/cockatrice/src/client/settings/cache_settings.h
+++ b/cockatrice/src/client/settings/cache_settings.h
@@ -218,6 +218,7 @@ private:
     int cardUpdateCheckInterval;
     QDate lastCardUpdateCheck;
     bool notifyAboutUpdates;
+    int sendDiagnostics;
     bool notifyAboutNewVersion;
     bool showTipsOnStartup;
     QList<int> seenTips;
@@ -497,6 +498,10 @@ public:
     [[nodiscard]] bool getNotifyAboutUpdates() const override
     {
         return notifyAboutUpdates;
+    }
+    [[nodiscard]] int getSendDiagnostics() const override
+    {
+        return sendDiagnostics;
     }
     [[nodiscard]] bool getNotifyAboutNewVersion() const
     {
@@ -1105,6 +1110,7 @@ public slots:
     void setCardUpdateCheckInterval(int value);
     void setLastCardUpdateCheck(QDate value);
     void setNotifyAboutUpdate(QT_STATE_CHANGED_T _notifyaboutupdate);
+    void setSendDiagnostics(int _sendDiagnostics);
     void setNotifyAboutNewVersion(QT_STATE_CHANGED_T _notifyaboutnewversion);
     void setUpdateReleaseChannelIndex(int value);
     void setMaxFontSize(int _max);

--- a/cockatrice/src/interface/widgets/dialogs/dlg_prompt_send_diagnostics.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_prompt_send_diagnostics.cpp
@@ -1,0 +1,55 @@
+#include "dlg_prompt_send_diagnostics.h"
+
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+DlgPromptSendDiagnostics::DlgPromptSendDiagnostics(QWidget *parent) : QDialog(parent), choice(SendDiagnosticsDisabled)
+{
+    auto *layout = new QVBoxLayout(this);
+
+    messageLabel = new QLabel(this);
+    messageLabel->setWordWrap(true);
+    layout->addWidget(messageLabel);
+
+    auto *buttonLayout = new QHBoxLayout;
+
+    noButton = new QPushButton(this);
+    minimalButton = new QPushButton(this);
+    fullButton = new QPushButton(this);
+
+    buttonLayout->addWidget(noButton);
+    buttonLayout->addWidget(minimalButton);
+    buttonLayout->addWidget(fullButton);
+
+    layout->addLayout(buttonLayout);
+
+    // Connect buttons
+    connect(noButton, &QPushButton::clicked, this, [this]() {
+        choice = SendDiagnosticsDisabled;
+        accept();
+    });
+    connect(minimalButton, &QPushButton::clicked, this, [this]() {
+        choice = SendDiagnosticsBasic;
+        accept();
+    });
+    connect(fullButton, &QPushButton::clicked, this, [this]() {
+        choice = SendDiagnosticsFull;
+        accept();
+    });
+
+    retranslateUi();
+}
+
+void DlgPromptSendDiagnostics::retranslateUi()
+{
+    setWindowTitle(tr("Help us improve Cockatrice"));
+
+    messageLabel->setText(tr("Hi there! Cockatrice is made by a small team, and we want to make it better for you.\n\n"
+                             "We’d love to collect a tiny bit of anonymous technical data about how you use the app — "
+                             "nothing personal, just usage info so we know what works and what needs improvement."));
+
+    noButton->setText(tr("No, thank you"));
+    minimalButton->setText(tr("Minimal"));
+    fullButton->setText(tr("Full"));
+}

--- a/cockatrice/src/interface/widgets/dialogs/dlg_prompt_send_diagnostics.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_prompt_send_diagnostics.h
@@ -1,0 +1,34 @@
+#ifndef COCKATRICE_DLG_PROMPT_SEND_DIAGNOSTICS_H
+#define COCKATRICE_DLG_PROMPT_SEND_DIAGNOSTICS_H
+
+#include "dlg_settings.h"
+
+#include <QDialog>
+#include <QLabel>
+#include <libcockatrice/interfaces/interface_network_settings_provider.h>
+
+class QPushButton;
+
+class DlgPromptSendDiagnostics : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit DlgPromptSendDiagnostics(QWidget *parent = nullptr);
+
+    SendDiagnosticsMode selectedChoice() const
+    {
+        return choice;
+    }
+
+    void retranslateUi();
+
+private:
+    SendDiagnosticsMode choice;
+
+    QLabel *messageLabel;
+    QPushButton *noButton;
+    QPushButton *minimalButton;
+    QPushButton *fullButton;
+};
+
+#endif // COCKATRICE_DLG_PROMPT_SEND_DIAGNOSTICS_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_settings.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_settings.h
@@ -63,6 +63,7 @@ private slots:
 private:
     QStringList findQmFiles();
     QString languageName(const QString &lang);
+    void populateSendDiagnosticsCombo(int mode);
     QLineEdit *deckPathEdit;
     QLineEdit *filtersPathEdit;
     QLineEdit *replaysPathEdit;
@@ -84,6 +85,7 @@ private:
     QCheckBox updateNotificationCheckBox;
     QCheckBox newVersionOracleCheckBox;
     QComboBox updateReleaseChannelBox;
+    QComboBox sendDiagnosticsSelector;
     QLabel languageLabel;
     QLabel deckPathLabel;
     QLabel filtersPathLabel;
@@ -93,6 +95,7 @@ private:
     QLabel customCardDatabasePathLabel;
     QLabel tokenDatabasePathLabel;
     QLabel updateReleaseChannelLabel;
+    QLabel sendDiagnosticsLabel;
     QLabel advertiseTranslationPageLabel;
     QCheckBox showTipsOnStartup;
 };

--- a/cockatrice/src/interface/window_main.cpp
+++ b/cockatrice/src/interface/window_main.cpp
@@ -28,6 +28,7 @@
 #include "../interface/widgets/dialogs/dlg_forgot_password_request.h"
 #include "../interface/widgets/dialogs/dlg_forgot_password_reset.h"
 #include "../interface/widgets/dialogs/dlg_manage_sets.h"
+#include "../interface/widgets/dialogs/dlg_prompt_send_diagnostics.h"
 #include "../interface/widgets/dialogs/dlg_register.h"
 #include "../interface/widgets/dialogs/dlg_settings.h"
 #include "../interface/widgets/dialogs/dlg_startup_card_check.h"
@@ -851,6 +852,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(client, &RemoteClient::protocolVersionMismatch, this, &MainWindow::protocolVersionMismatch);
     connect(client, &RemoteClient::userInfoChanged, this, &MainWindow::userInfoReceived, Qt::BlockingQueuedConnection);
     connect(client, &RemoteClient::notifyUserAboutUpdate, this, &MainWindow::notifyUserAboutUpdate);
+    connect(client, &RemoteClient::notifyUserAboutDiagnostics, this, &MainWindow::notifyUserAboutDiagnostics);
     connect(client, &RemoteClient::registerAccepted, this, &MainWindow::registerAccepted);
     connect(client, &RemoteClient::registerAcceptedNeedsActivate, this, &MainWindow::registerAcceptedNeedsActivate);
     connect(client, &RemoteClient::registerError, this, &MainWindow::registerError);
@@ -1383,6 +1385,21 @@ void MainWindow::notifyUserAboutUpdate()
         tr("This server supports additional features that your client doesn't have.\nThis is most likely not a "
            "problem, but this message might mean there is a new version of Cockatrice available or this server is "
            "running a custom or pre-release version.\n\nTo update your client, go to Help -> Check for Updates."));
+}
+
+void MainWindow::notifyUserAboutDiagnostics()
+{
+    int mode = SendDiagnosticsDisabled;
+    DlgPromptSendDiagnostics dlg(this);
+    if (dlg.exec() == QDialog::Accepted) {
+        mode = dlg.selectedChoice();
+    }
+
+    SettingsCache::instance().setSendDiagnostics(mode);
+
+    if (mode == SendDiagnosticsBasic || mode == SendDiagnosticsFull) {
+        client->sendDiagnostics();
+    }
 }
 
 void MainWindow::actOpenCustomFolder()

--- a/cockatrice/src/interface/window_main.h
+++ b/cockatrice/src/interface/window_main.h
@@ -81,6 +81,7 @@ private slots:
     void localGameEnded();
     void pixmapCacheSizeChanged(int newSizeInMBs);
     void notifyUserAboutUpdate();
+    void notifyUserAboutDiagnostics();
     void actDisconnect();
     void actSinglePlayer();
     void actWatchReplay();

--- a/libcockatrice_interfaces/libcockatrice/interfaces/interface_network_settings_provider.h
+++ b/libcockatrice_interfaces/libcockatrice/interfaces/interface_network_settings_provider.h
@@ -2,6 +2,13 @@
 #define COCKATRICE_INETWORKSETTINGSPROVIDER_H
 #include <QString>
 
+enum SendDiagnosticsMode {
+    SendDiagnosticsUnprompted = 0, // never asked
+    SendDiagnosticsDisabled = 1,
+    SendDiagnosticsBasic = 2,
+    SendDiagnosticsFull = 3,
+};
+
 class INetworkSettingsProvider
 {
 public:
@@ -12,6 +19,7 @@ public:
     [[nodiscard]] virtual int getTimeOut() const = 0;
     [[nodiscard]] virtual int getKeepAlive() const = 0;
     [[nodiscard]] virtual bool getNotifyAboutUpdates() const = 0;
+    [[nodiscard]] virtual int getSendDiagnostics() const = 0;
 
     virtual void setKnownMissingFeatures(const QString &_knownMissingFeatures) = 0;
     virtual QString getKnownMissingFeatures() = 0;

--- a/libcockatrice_network/libcockatrice/network/client/remote/remote_client.h
+++ b/libcockatrice_network/libcockatrice/network/client/remote/remote_client.h
@@ -39,6 +39,7 @@ signals:
                              const QString &_realname);
     void sigActivateToServer(const QString &_token);
     void sigDisconnectFromServer();
+    void notifyUserAboutDiagnostics();
     void notifyUserAboutUpdate();
     void sigRequestForgotPasswordToServer(const QString &hostname, unsigned int port, const QString &_userName);
     void sigForgotPasswordSuccess();
@@ -80,6 +81,8 @@ private slots:
     void doLogin();
     void doHashedLogin();
     Command_Login generateCommandLogin();
+    Command_ClientDiagnostics generateClientDiagnostics();
+    void addDiagnosticsFeature(Command_ClientDiagnostics *diag, const QString &name, const QString &value);
     void doDisconnectFromServer();
     void doActivateToServer(const QString &_token);
     void doRequestForgotPasswordToServer(const QString &hostname, unsigned int port, const QString &_userName);
@@ -119,6 +122,9 @@ private:
 
 protected slots:
     void sendCommandContainer(const CommandContainer &cont) override;
+
+public slots:
+    void sendDiagnostics();
 
 public:
     explicit RemoteClient(QObject *parent = nullptr, INetworkSettingsProvider *networkSettingsProvider = nullptr);

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/session_commands.proto
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/session_commands.proto
@@ -55,6 +55,22 @@ message Command_Login {
     optional string hashed_password = 6;
 }
 
+message FeatureFlag {
+    optional string name = 1;
+    optional string value = 2;
+}
+
+message Command_ClientDiagnostics {
+    extend SessionCommand {
+        optional Command_ClientDiagnostics ext = 1051;
+    }
+
+    optional string clientver = 1;
+    repeated FeatureFlag feature_flags = 2;
+    optional string os = 3;
+    optional string arch = 4;
+}
+
 message Command_Message {
     extend SessionCommand {
         optional Command_Message ext = 1002;


### PR DESCRIPTION
## Short roundup of the initial problem
We're flying blind and relying on users actively posting feedback in the channel to reach us.

## What will change with this Pull Request?
- Introduce a new protocol command to send diagnostics
- Prompt the user about this after connection
- Send (non-PII) usage statistics if user agrees

## Screenshots
<img width="623" height="428" alt="image" src="https://github.com/user-attachments/assets/425a470e-6741-4706-9aa4-eaa4da25e82b" />
