### PR TITLE
[PrintingSelector] Don't refresh display if "bump cards to top" is off

### DIFF
--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector.cpp
@@ -90,8 +90,10 @@ void PrintingSelector::retranslateUi()
 
 void PrintingSelector::printingsInDeckChanged()
 {
-    // Delay the update to avoid race conditions
-    QTimer::singleShot(100, this, &PrintingSelector::updateDisplay);
+    if (SettingsCache::instance().getBumpSetsWithCardsInDeckToTop()) {
+        // Delay the update to avoid race conditions
+        QTimer::singleShot(100, this, &PrintingSelector::updateDisplay);
+    }
 }
 
 /**


### PR DESCRIPTION
## Short roundup of the initial problem

Currently, the PrintingSelector will refresh the display whenever a unique printing is added/removed, in order to support the "bump cards to top" feature. However, it does that even if the setting for that feature is disabled.

It leads to a bad user experience, as it kicks you to the top of the layout whenever that happens, requiring you to scroll all the way down again.

## What will change with this Pull Request?
- In `printingsInDeckChanged`, check that the setting is enabled before calling `updateDisplay`

https://github.com/user-attachments/assets/48e13d80-6956-48ce-8caf-8f03f411b092