### PR TITLE
Exclude spaces and punctuation marks from some tr() strings

### DIFF
--- a/cockatrice/src/game/player/menu/card_menu.cpp
+++ b/cockatrice/src/game/player/menu/card_menu.cpp
@@ -396,7 +396,7 @@ void CardMenu::addRelatedCardActions()
             relatedCardName = relatedCard.getName(); // "name"
         }
 
-        QString text = tr("Token: ");
+        QString text = tr("Token") + ": ";
         if (cardRelation->getDoesAttach()) {
             text +=
                 tr(cardRelation->getDoesTransform() ? "Transform into " : "Attach to ") + "\"" + relatedCardName + "\"";

--- a/cockatrice/src/interface/widgets/dialogs/dlg_forgot_password_reset.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_forgot_password_reset.cpp
@@ -49,7 +49,7 @@ DlgForgotPasswordReset::DlgForgotPasswordReset(QWidget *parent) : QDialog(parent
     playernameEdit->setMaxLength(MAX_NAME_LENGTH);
     playernameLabel->setBuddy(playernameEdit);
 
-    tokenLabel = new QLabel(tr("Token:"));
+    tokenLabel = new QLabel(tr("Token") + ":");
     tokenEdit = new QLineEdit();
     tokenEdit->setMaxLength(MAX_NAME_LENGTH);
     tokenLabel->setBuddy(tokenLabel);

--- a/cockatrice/src/interface/widgets/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_settings.cpp
@@ -441,7 +441,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     });
 
     homeTabBackgroundShuffleFrequencySpinBox.setRange(0, 3600);
-    homeTabBackgroundShuffleFrequencySpinBox.setSuffix(tr(" seconds"));
+    homeTabBackgroundShuffleFrequencySpinBox.setSuffix(QString(" ") + tr("seconds"));
     homeTabBackgroundShuffleFrequencySpinBox.setValue(SettingsCache::instance().getHomeTabBackgroundShuffleFrequency());
     connect(&homeTabBackgroundShuffleFrequencySpinBox, qOverload<int>(&QSpinBox::valueChanged),
             &SettingsCache::instance(), &SettingsCache::setHomeTabBackgroundShuffleFrequency);

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/tab_edhrec_main.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/tab_edhrec_main.h
@@ -29,7 +29,7 @@ public:
     [[nodiscard]] QString getTabText() const override
     {
         auto cardName = cardToQuery.isNull() ? QString() : cardToQuery->getName();
-        return tr("EDHRec: ") + cardName;
+        return tr("EDHRec") + ": ") + cardName;
     }
 
     CardSizeWidget *getCardSizeSlider() const

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/tab_edhrec_main.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/tab_edhrec_main.h
@@ -29,7 +29,7 @@ public:
     [[nodiscard]] QString getTabText() const override
     {
         auto cardName = cardToQuery.isNull() ? QString() : cardToQuery->getName();
-        return tr("EDHRec") + ": ") + cardName;
+        return tr("EDHRec") + ": " + cardName;
     }
 
     CardSizeWidget *getCardSizeSlider() const


### PR DESCRIPTION
## Related Ticket(s)
- Spotted when looking at #6480

## Short roundup of the initial problem
Spaces and colons are sometimes included in the translatable string, and are shown to translators out of context in the transifex webpage when doing translations.

This leads to easy, unintended mistakes that will mess with the interface:
<img width="552" height="84" alt="image" src="https://github.com/user-attachments/assets/8c508dc2-5156-46ee-9a93-48d407bb3198" />
<img width="521" height="90" alt="image" src="https://github.com/user-attachments/assets/dc5960c0-a7a1-4030-9999-663d029fe09c" />


## What will change with this Pull Request?
- Exclude spaces and punctuation marks from tr() strings