### PR TITLE
[ServerGame] null check participant in getPlayer

### DIFF
--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
@@ -232,7 +232,7 @@ QMap<int, Server_AbstractPlayer *> Server_Game::getPlayers() const // copies poi
 Server_AbstractPlayer *Server_Game::getPlayer(int id) const
 {
     auto *participant = participants.value(id);
-    if (!participant->isSpectator()) {
+    if (participant && !participant->isSpectator()) {
         return static_cast<Server_AbstractPlayer *>(participant);
     } else {
         return nullptr;


### PR DESCRIPTION
## Short roundup of the initial problem

The server has been crashing every-so-often recently. The crashes all happen in the same place.

```
#0  0x00005f7ab9835d2e in Server_AbstractParticipant::getSpectator (this=0x0)
    at /root/servatrice/cockatrice_github/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_participant.h:94
#1  0x00005f7ab9830adb in Server_Game::getPlayer (this=0x5f7b4dde4bc0, id=1)
    at /root/servatrice/cockatrice_github/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp:241
```

[crash-log.txt](https://github.com/user-attachments/files/24427762/message-11.txt)

`participants.value(id)` will return nullptr if `id` isn't in the map. `getPlayer` doesn't null check the return value before using it.

## What will change with this Pull Request?

- Add null check in `getPlayer`

I can't test if this fixes the crash, since it's so infrequent. We can make the change for now and see if anything improves.