### PR TITLE
[AnalyticsPanel] Use cogwheel icon for configure button

### DIFF
--- a/cockatrice/src/interface/widgets/deck_analytics/abstract_analytics_panel_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_analytics/abstract_analytics_panel_widget.cpp
@@ -19,7 +19,8 @@ AbstractAnalyticsPanelWidget::AbstractAnalyticsPanelWidget(QWidget *parent, Deck
     bannerAndSettingsLayout->addWidget(bannerWidget, 1);
 
     // config button
-    configureButton = new QPushButton(tr("Configure"), this);
+    configureButton = new QPushButton(this);
+    configureButton->setIcon(QPixmap("theme:icons/cogwheel"));
     configureButton->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
     connect(configureButton, &QPushButton::clicked, this, &AbstractAnalyticsPanelWidget::applyConfigFromDialog);
     bannerAndSettingsLayout->addWidget(configureButton, 0);


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6463

## Short roundup of the initial problem

I think the gear icon looks nicer than the "configure" text

## What will change with this Pull Request?

- Use gear icon instead of text

## Screenshots

### Before:
<img width="400" height="816" alt="Screenshot 2026-01-04 at 11 27 39 PM" src="https://github.com/user-attachments/assets/428d82dc-8755-40af-837d-66ad72594d0e" />

<img width="400" height="433" alt="Screenshot 2026-01-04 at 11 27 55 PM" src="https://github.com/user-attachments/assets/b8d6cbb4-7adf-45e5-8dba-bc2519e79093" />

### After:
<img width="400" height="837" alt="Screenshot 2026-01-04 at 11 15 14 PM" src="https://github.com/user-attachments/assets/b114416a-79bc-4a49-983a-0dd49cac71d1" />

<img width="400" height="425" alt="Screenshot 2026-01-04 at 11 22 31 PM" src="https://github.com/user-attachments/assets/62b746c2-48ec-46c9-8bb7-86ee909f47a1" />
