### PR TITLE
[VDE] Fix crash adding null check for card in PrintingSelector

### DIFF
--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector.cpp
@@ -122,6 +122,10 @@ static QMap<QString, QPair<int, int>> tallyUuidCounts(const DeckListModel *model
 
 void PrintingSelector::updateCardAmounts()
 {
+    if (selectedCard.isNull()) {
+        return;
+    }
+
     auto map = tallyUuidCounts(deckStateManager->getModel(), selectedCard->getName());
     emit cardAmountsChanged(map);
 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #6478

## Short roundup of the initial problem

Cockatrice will crash if you're in the visual deck editor and attempt to add a card through the quick search while no card is selected.

The cause is because I didn't null check the `selectedCard` in the `PrintingSelector` before using it. `selectedCard` is a `CardInfoPtr` so it's possible for it to be null.
The crash didn't happen in the classic deck editor because there it's physically impossible to add a card to the deck without selecting it somewhere first.

## What will change with this Pull Request?
- Add null check to `PrintingSelector::updateCardAmounts`
