### PR TITLE
[DeckEditor] Don't change widget focus when adding card

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -459,12 +459,15 @@ void DeckEditorDeckDockWidget::syncBannerCardComboBoxSelectionWithDeck()
     }
 }
 
-void DeckEditorDeckDockWidget::setSelectedIndex(const QModelIndex &newCardIndex)
+void DeckEditorDeckDockWidget::setSelectedIndex(const QModelIndex &newCardIndex, bool preserveWidgetFocus)
 {
     deckView->clearSelection();
     deckView->setCurrentIndex(newCardIndex);
     recursiveExpand(newCardIndex);
-    deckView->setFocus(Qt::FocusReason::MouseFocusReason);
+
+    if (!preserveWidgetFocus) {
+        deckView->setFocus(Qt::FocusReason::MouseFocusReason);
+    }
 }
 
 void DeckEditorDeckDockWidget::syncDisplayWidgetsToModel()

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.h
@@ -100,7 +100,7 @@ private slots:
     void writeComments();
     void writeBannerCard(int);
     void applyActiveGroupCriteria();
-    void setSelectedIndex(const QModelIndex &newCardIndex);
+    void setSelectedIndex(const QModelIndex &newCardIndex, bool preserveWidgetFocus);
     void updateHash();
     void refreshShortcuts();
     void updateShowBannerCardComboBox(bool visible);

--- a/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.cpp
@@ -182,7 +182,7 @@ QModelIndex DeckStateManager::addCard(const ExactCard &card, const QString &zone
     QModelIndex idx = modifyDeck(reason, [&card, &zone](auto model) { return model->addCard(card, zone); });
 
     if (idx.isValid()) {
-        emit focusIndexChanged(idx);
+        emit focusIndexChanged(idx, true);
     }
 
     return idx;
@@ -208,7 +208,7 @@ QModelIndex DeckStateManager::decrementCard(const ExactCard &card, const QString
     }
 
     if (idx.isValid()) {
-        emit focusIndexChanged(idx);
+        emit focusIndexChanged(idx, true);
     }
 
     return idx;

--- a/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.h
@@ -290,8 +290,9 @@ signals:
     /**
      * The selected card on any views connected to this deck should be changed to this index.
      * @param index The model index
+     * @param preserveWidgetFocus Whether to keep the widget focus unchanged
      */
-    void focusIndexChanged(QModelIndex index);
+    void focusIndexChanged(QModelIndex index, bool preserveWidgetFocus);
 };
 
 #endif // COCKATRICE_DECK_STATE_MANAGER_H

--- a/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.cpp
@@ -198,7 +198,7 @@ void CardAmountWidget::addPrinting(const QString &zone)
     });
 
     if (newCardIndex.isValid()) {
-        emit deckStateManager->focusIndexChanged(newCardIndex);
+        emit deckStateManager->focusIndexChanged(newCardIndex, false);
     }
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #6459

## Short roundup of the initial problem

In the deck editor, the widget focus gets changed to the DeckDockWidget whenever a card is added. This is change from the previous behavior, and means you can't keep using the arrow buttons in the card database dock after a card.

https://github.com/user-attachments/assets/1683c1fa-3c23-4b28-9667-259ccee720ce

## What will change with this Pull Request?

- Add a bool param to the signal so that widget focus is only changed from the PrintingSelector

https://github.com/user-attachments/assets/a99b0794-7056-4d11-9d87-45db480f74a3


