### PR TITLE
[ColorIdentityWidget] Refactor

### DIFF
--- a/cockatrice/src/interface/widgets/cards/additional_info/color_identity_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/additional_info/color_identity_widget.cpp
@@ -25,6 +25,11 @@ ColorIdentityWidget::ColorIdentityWidget(QWidget *parent, const QString &_colorI
             &ColorIdentityWidget::toggleUnusedVisibility);
 }
 
+ColorIdentityWidget::ColorIdentityWidget(QWidget *parent, const CardInfoPtr &card)
+    : ColorIdentityWidget(parent, card->getColors())
+{
+}
+
 void ColorIdentityWidget::populateManaSymbolWidgets()
 {
     // Define the full WUBRG set (White, Blue, Black, Red, Green)
@@ -74,12 +79,12 @@ void ColorIdentityWidget::resizeEvent(QResizeEvent *event)
     }
 }
 
-QStringList ColorIdentityWidget::parseColorIdentity(const QString &cmc)
+QStringList ColorIdentityWidget::parseColorIdentity(const QString &manaString)
 {
     QStringList symbols;
 
     // Handle split costs (e.g., "3U // 4UU")
-    QStringList splitCosts = cmc.split(" // ");
+    QStringList splitCosts = manaString.split(" // ");
     for (const QString &part : splitCosts) {
         QRegularExpression regex(R"(\{([^}]+)\}|(\d+)|([WUBRGCSPX]))");
         QRegularExpressionMatchIterator matches = regex.globalMatch(part);

--- a/cockatrice/src/interface/widgets/cards/additional_info/color_identity_widget.h
+++ b/cockatrice/src/interface/widgets/cards/additional_info/color_identity_widget.h
@@ -16,6 +16,8 @@ class ColorIdentityWidget : public QWidget
     Q_OBJECT
 public:
     explicit ColorIdentityWidget(QWidget *parent, const QString &_colorIdentity = "");
+    explicit ColorIdentityWidget(QWidget *parent, const CardInfoPtr &card);
+
     void populateManaSymbolWidgets();
 
     static QStringList parseColorIdentity(const QString &manaString);


### PR DESCRIPTION
## Short roundup of the initial problem

`ColorIdentityWidget` has an unused constructor. I don't see how that constructor would ever be used. Might as well clean it up at the same time.

## What will change with this Pull Request?
- Remove the constructor that takes a `CardInfoPtr`
- Rename field from `manaCost` to `colorIdentity`
- Some more cleanup