### PR TITLE
[HomeTab] Add setting to display card info in bottom right for non-theme backgrounds

### DIFF
--- a/cockatrice/src/client/settings/cache_settings.cpp
+++ b/cockatrice/src/client/settings/cache_settings.cpp
@@ -239,6 +239,7 @@ SettingsCache::SettingsCache()
 
     homeTabBackgroundSource = settings->value("home/background", "themed").toString();
     homeTabBackgroundShuffleFrequency = settings->value("home/background/shuffleTimer", 0).toInt();
+    homeTabDisplayCardName = settings->value("home/background/displayCardName", true).toBool();
 
     tabVisualDeckStorageOpen = settings->value("tabs/visualDeckStorage", true).toBool();
     tabServerOpen = settings->value("tabs/server", true).toBool();
@@ -592,6 +593,13 @@ void SettingsCache::setHomeTabBackgroundShuffleFrequency(int _frequency)
     homeTabBackgroundShuffleFrequency = _frequency;
     settings->setValue("home/background/shuffleTimer", homeTabBackgroundShuffleFrequency);
     emit homeTabBackgroundShuffleFrequencyChanged();
+}
+
+void SettingsCache::setHomeTabDisplayCardName(QT_STATE_CHANGED_T _displayCardName)
+{
+    homeTabDisplayCardName = static_cast<bool>(_displayCardName);
+    settings->setValue("home/background/displayCardName", homeTabDisplayCardName);
+    emit homeTabDisplayCardNameChanged();
 }
 
 void SettingsCache::setTabVisualDeckStorageOpen(bool value)

--- a/cockatrice/src/client/settings/cache_settings.h
+++ b/cockatrice/src/client/settings/cache_settings.h
@@ -143,6 +143,7 @@ signals:
     void themeChanged();
     void homeTabBackgroundSourceChanged();
     void homeTabBackgroundShuffleFrequencyChanged();
+    void homeTabDisplayCardNameChanged();
     void picDownloadChanged();
     void showStatusBarChanged(bool state);
     void showGameSelectorFilterToolbarChanged(bool state);
@@ -222,6 +223,7 @@ private:
     bool showTipsOnStartup;
     QList<int> seenTips;
     int homeTabBackgroundShuffleFrequency;
+    bool homeTabDisplayCardName;
     bool mbDownloadSpoilers;
     int updateReleaseChannel;
     int maxFontSize;
@@ -412,6 +414,10 @@ public:
     [[nodiscard]] int getHomeTabBackgroundShuffleFrequency() const
     {
         return homeTabBackgroundShuffleFrequency;
+    }
+    [[nodiscard]] bool getHomeTabDisplayCardName() const
+    {
+        return homeTabDisplayCardName;
     }
     [[nodiscard]] bool getTabVisualDeckStorageOpen() const
     {
@@ -1001,6 +1007,7 @@ public slots:
     void setThemeName(const QString &_themeName);
     void setHomeTabBackgroundSource(const QString &_backgroundSource);
     void setHomeTabBackgroundShuffleFrequency(int _frequency);
+    void setHomeTabDisplayCardName(QT_STATE_CHANGED_T _displayCardName);
     void setTabVisualDeckStorageOpen(bool value);
     void setTabServerOpen(bool value);
     void setTabAccountOpen(bool value);

--- a/cockatrice/src/interface/widgets/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_settings.cpp
@@ -438,6 +438,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     connect(&homeTabBackgroundSourceBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this]() {
         auto type = homeTabBackgroundSourceBox.currentData().value<BackgroundSources::Type>();
         SettingsCache::instance().setHomeTabBackgroundSource(BackgroundSources::toId(type));
+        updateHomeTabDisplayCardNameVisibility();
     });
 
     homeTabBackgroundShuffleFrequencySpinBox.setRange(0, 3600);
@@ -445,6 +446,12 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     homeTabBackgroundShuffleFrequencySpinBox.setValue(SettingsCache::instance().getHomeTabBackgroundShuffleFrequency());
     connect(&homeTabBackgroundShuffleFrequencySpinBox, qOverload<int>(&QSpinBox::valueChanged),
             &SettingsCache::instance(), &SettingsCache::setHomeTabBackgroundShuffleFrequency);
+
+    homeTabDisplayCardNameCheckBox.setChecked(settings.getHomeTabDisplayCardName());
+    connect(&homeTabDisplayCardNameCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings,
+            &SettingsCache::setHomeTabDisplayCardName);
+
+    updateHomeTabDisplayCardNameVisibility();
 
     auto *themeGrid = new QGridLayout;
     themeGrid->addWidget(&themeLabel, 0, 0);
@@ -454,6 +461,8 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     themeGrid->addWidget(&homeTabBackgroundSourceBox, 2, 1);
     themeGrid->addWidget(&homeTabBackgroundShuffleFrequencyLabel, 3, 0);
     themeGrid->addWidget(&homeTabBackgroundShuffleFrequencySpinBox, 3, 1);
+    themeGrid->addWidget(&homeTabDisplayCardNameLabel, 4, 0);
+    themeGrid->addWidget(&homeTabDisplayCardNameCheckBox, 4, 1);
 
     themeGroupBox = new QGroupBox;
     themeGroupBox->setLayout(themeGrid);
@@ -650,6 +659,17 @@ void AppearanceSettingsPage::openThemeLocation()
     }
 }
 
+void AppearanceSettingsPage::updateHomeTabDisplayCardNameVisibility()
+{
+    bool visible =
+        SettingsCache::instance().getHomeTabBackgroundSource() != BackgroundSources::toId(BackgroundSources::Theme);
+    qInfo() << BackgroundSources::toId(BackgroundSources::Theme);
+    qInfo() << SettingsCache::instance().getHomeTabBackgroundSource();
+    qInfo() << visible;
+    homeTabDisplayCardNameLabel.setVisible(visible);
+    homeTabDisplayCardNameCheckBox.setVisible(visible);
+}
+
 void AppearanceSettingsPage::showShortcutsChanged(QT_STATE_CHANGED_T value)
 {
     SettingsCache::instance().setShowShortcuts(value);
@@ -729,6 +749,7 @@ void AppearanceSettingsPage::retranslateUi()
     homeTabBackgroundSourceLabel.setText(tr("Home tab background source:"));
     homeTabBackgroundShuffleFrequencyLabel.setText(tr("Home tab background shuffle frequency:"));
     homeTabBackgroundShuffleFrequencySpinBox.setSpecialValueText(tr("Disabled"));
+    homeTabDisplayCardNameLabel.setText(tr("Display card name of background in bottom right:"));
 
     menuGroupBox->setTitle(tr("Menu settings"));
     showShortcutsCheckBox.setText(tr("Show keyboard shortcuts in right-click menus"));

--- a/cockatrice/src/interface/widgets/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_settings.cpp
@@ -438,7 +438,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     connect(&homeTabBackgroundSourceBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this]() {
         auto type = homeTabBackgroundSourceBox.currentData().value<BackgroundSources::Type>();
         SettingsCache::instance().setHomeTabBackgroundSource(BackgroundSources::toId(type));
-        updateHomeTabDisplayCardNameVisibility();
+        updateHomeTabSettingsVisibility();
     });
 
     homeTabBackgroundShuffleFrequencySpinBox.setRange(0, 3600);
@@ -451,7 +451,7 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     connect(&homeTabDisplayCardNameCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings,
             &SettingsCache::setHomeTabDisplayCardName);
 
-    updateHomeTabDisplayCardNameVisibility();
+    updateHomeTabSettingsVisibility();
 
     auto *themeGrid = new QGridLayout;
     themeGrid->addWidget(&themeLabel, 0, 0);
@@ -659,13 +659,13 @@ void AppearanceSettingsPage::openThemeLocation()
     }
 }
 
-void AppearanceSettingsPage::updateHomeTabDisplayCardNameVisibility()
+void AppearanceSettingsPage::updateHomeTabSettingsVisibility()
 {
     bool visible =
         SettingsCache::instance().getHomeTabBackgroundSource() != BackgroundSources::toId(BackgroundSources::Theme);
-    qInfo() << BackgroundSources::toId(BackgroundSources::Theme);
-    qInfo() << SettingsCache::instance().getHomeTabBackgroundSource();
-    qInfo() << visible;
+
+    homeTabBackgroundShuffleFrequencyLabel.setVisible(visible);
+    homeTabBackgroundShuffleFrequencySpinBox.setVisible(visible);
     homeTabDisplayCardNameLabel.setVisible(visible);
     homeTabDisplayCardNameCheckBox.setVisible(visible);
 }

--- a/cockatrice/src/interface/widgets/dialogs/dlg_settings.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_settings.h
@@ -103,6 +103,7 @@ class AppearanceSettingsPage : public AbstractSettingsPage
 private slots:
     void themeBoxChanged(int index);
     void openThemeLocation();
+    void updateHomeTabDisplayCardNameVisibility();
     void showShortcutsChanged(QT_STATE_CHANGED_T enabled);
     void overrideAllCardArtWithPersonalPreferenceToggled(QT_STATE_CHANGED_T enabled);
 
@@ -117,6 +118,8 @@ private:
     QComboBox homeTabBackgroundSourceBox;
     QLabel homeTabBackgroundShuffleFrequencyLabel;
     QSpinBox homeTabBackgroundShuffleFrequencySpinBox;
+    QLabel homeTabDisplayCardNameLabel;
+    QCheckBox homeTabDisplayCardNameCheckBox;
     QLabel minPlayersForMultiColumnLayoutLabel;
     QLabel maxFontSizeForCardsLabel;
     QCheckBox showShortcutsCheckBox;

--- a/cockatrice/src/interface/widgets/dialogs/dlg_settings.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_settings.h
@@ -103,7 +103,7 @@ class AppearanceSettingsPage : public AbstractSettingsPage
 private slots:
     void themeBoxChanged(int index);
     void openThemeLocation();
-    void updateHomeTabDisplayCardNameVisibility();
+    void updateHomeTabSettingsVisibility();
     void showShortcutsChanged(QT_STATE_CHANGED_T enabled);
     void overrideAllCardArtWithPersonalPreferenceToggled(QT_STATE_CHANGED_T enabled);
 


### PR DESCRIPTION
## Short roundup of the initial problem
Cool card art shuffles on but "where is that from?"

## What will change with this Pull Request?
- Add a setting to display the card name, set name, collector number in bottom right of home tab if background source is anything but "Theme"

## Screenshots
Theme (unchanged):
<img width="1277" height="1399" alt="image" src="https://github.com/user-attachments/assets/941316ad-c070-4765-a718-31bad1fe76ad" />
<img width="659" height="137" alt="image" src="https://github.com/user-attachments/assets/785e013e-6bc7-4e18-a87f-bd9206954882" />

<img width="1263" height="1391" alt="image" src="https://github.com/user-attachments/assets/198cbd04-0b73-4aa5-908c-f7d06b516759" />

<img width="1278" height="1406" alt="image" src="https://github.com/user-attachments/assets/99bdb58c-ac4e-4668-8c05-f3d3157c5e34" />
