### PR TITLE
[TabDeckEditor] Move cardDatabase dock action to top of menu

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_deck_editor.cpp
@@ -54,8 +54,8 @@ void TabDeckEditor::createMenus()
 
     viewMenu = new QMenu(this);
 
-    registerDockWidget(viewMenu, cardInfoDockWidget);
     registerDockWidget(viewMenu, cardDatabaseDockWidget);
+    registerDockWidget(viewMenu, cardInfoDockWidget);
     registerDockWidget(viewMenu, deckDockWidget);
     registerDockWidget(viewMenu, filterDockWidget);
     registerDockWidget(viewMenu, printingSelectorDockWidget);
@@ -94,16 +94,16 @@ QString TabDeckEditor::getTabText() const
 void TabDeckEditor::retranslateUi()
 {
     deckMenu->retranslateUi();
-    cardInfoDockWidget->retranslateUi();
     cardDatabaseDockWidget->retranslateUi();
+    cardInfoDockWidget->retranslateUi();
     deckDockWidget->retranslateUi();
     filterDockWidget->retranslateUi();
     printingSelectorDockWidget->retranslateUi();
 
     viewMenu->setTitle(tr("&View"));
 
-    dockToActions[cardInfoDockWidget].menu->setTitle(tr("Card Info"));
     dockToActions[cardDatabaseDockWidget].menu->setTitle(tr("Card Database"));
+    dockToActions[cardInfoDockWidget].menu->setTitle(tr("Card Info"));
     dockToActions[deckDockWidget].menu->setTitle(tr("Deck"));
     dockToActions[filterDockWidget].menu->setTitle(tr("Filters"));
     dockToActions[printingSelectorDockWidget].menu->setTitle(tr("Printing"));


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6472

## Short roundup of the initial problem

I find it more intuitive to have the cardDatabase menu action before the cardInfo menu action

## What will change with this Pull Request?
- Move cardDatabase action to the top of the views menu
- Also change order of some stuff in the code to make the order clearer

## Screenshots

<img width="354" height="211" alt="Screenshot 2026-01-15 at 6 41 28 PM" src="https://github.com/user-attachments/assets/39e9006d-5511-487f-96dc-11fd4f77d93c" />

