### PR TITLE
[TabDeckEditor] Save cardDatabase dock size in settings

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_deck_editor.cpp
@@ -154,6 +154,9 @@ void TabDeckEditor::loadLayout()
         }
     }
 
+    cardDatabaseDockWidget->setMinimumSize(layouts.getDeckEditorCardDatabaseSize());
+    cardDatabaseDockWidget->setMaximumSize(layouts.getDeckEditorCardDatabaseSize());
+
     cardInfoDockWidget->setMinimumSize(layouts.getDeckEditorCardSize());
     cardInfoDockWidget->setMaximumSize(layouts.getDeckEditorCardSize());
 
@@ -221,6 +224,7 @@ bool TabDeckEditor::eventFilter(QObject *o, QEvent *e)
         LayoutsSettings &layouts = SettingsCache::instance().layouts();
         layouts.setDeckEditorLayoutState(saveState());
         layouts.setDeckEditorGeometry(saveGeometry());
+        layouts.setDeckEditorCardDatabaseSize(cardDatabaseDockWidget->size());
         layouts.setDeckEditorCardSize(cardInfoDockWidget->size());
         layouts.setDeckEditorFilterSize(filterDockWidget->size());
         layouts.setDeckEditorDeckSize(deckDockWidget->size());

--- a/libcockatrice_settings/libcockatrice/settings/layouts_settings.cpp
+++ b/libcockatrice_settings/libcockatrice/settings/layouts_settings.cpp
@@ -25,6 +25,17 @@ void LayoutsSettings::setDeckEditorGeometry(const QByteArray &value)
     setValue(value, "layouts/deckEditor_geometry");
 }
 
+QSize LayoutsSettings::getDeckEditorCardDatabaseSize()
+{
+    QVariant previous = getValue("layouts/deckEditor_CardDatabaseSize");
+    return previous == QVariant() ? QSize(500, 500) : previous.toSize();
+}
+
+void LayoutsSettings::setDeckEditorCardDatabaseSize(const QSize &value)
+{
+    setValue(value, "layouts/deckEditor_CardDatabaseSize");
+}
+
 QSize LayoutsSettings::getDeckEditorCardSize()
 {
     QVariant previous = getValue("layouts/deckEditor_CardSize");

--- a/libcockatrice_settings/libcockatrice/settings/layouts_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/layouts_settings.h
@@ -19,6 +19,7 @@ class LayoutsSettings : public SettingsManager
 public:
     void setDeckEditorLayoutState(const QByteArray &value);
     void setDeckEditorGeometry(const QByteArray &value);
+    void setDeckEditorCardDatabaseSize(const QSize &value);
     void setDeckEditorCardSize(const QSize &value);
     void setDeckEditorDeckSize(const QSize &value);
     void setDeckEditorPrintingSelectorSize(const QSize &value);
@@ -41,6 +42,7 @@ public:
 
     const QByteArray getDeckEditorLayoutState();
     const QByteArray getDeckEditorGeometry();
+    QSize getDeckEditorCardDatabaseSize();
     QSize getDeckEditorCardSize();
     QSize getDeckEditorDeckSize();
     QSize getDeckEditorPrintingSelectorSize();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #6472

## Short roundup of the initial problem

When we made cardDatabase a dockWidget, we forgot to save the cardDatabase dock size in the settings.

## What will change with this Pull Request?
- Add cardDatabase dock size to LayoutSettings
- read and write to settings in the same places as the other dockWidgets.