### PR TITLE
[VDE] Make sample hand widget look nicer

### DIFF
--- a/cockatrice/src/interface/widgets/deck_analytics/analyzer_modules/draw_probability/draw_probability_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_analytics/analyzer_modules/draw_probability/draw_probability_widget.cpp
@@ -22,6 +22,7 @@ DrawProbabilityWidget::DrawProbabilityWidget(QWidget *parent, DeckListStatistics
 {
     controls = new QWidget(this);
     controlLayout = new QHBoxLayout(controls);
+    controlLayout->setContentsMargins(11, 0, 11, 0);
 
     labelPrefix = new QLabel(this);
     controlLayout->addWidget(labelPrefix);
@@ -65,6 +66,7 @@ DrawProbabilityWidget::DrawProbabilityWidget(QWidget *parent, DeckListStatistics
     resultTable = new QTableWidget(this);
     resultTable->setColumnCount(3);
     resultTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+    resultTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
     layout->addWidget(resultTable);
 
     // Connections

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_sample_hand_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_sample_hand_widget.cpp
@@ -15,10 +15,13 @@ VisualDeckEditorSampleHandWidget::VisualDeckEditorSampleHandWidget(QWidget *pare
     : QWidget(parent), deckListModel(_deckListModel), statsAnalyzer(_statsAnalyzer)
 {
     layout = new QVBoxLayout(this);
+    layout->setSpacing(0);
     setLayout(layout);
 
-    resetAndHandSizeContainerWidget = new QWidget(this);
     resetAndHandSizeLayout = new QHBoxLayout(resetAndHandSizeContainerWidget);
+    resetAndHandSizeLayout->setContentsMargins(11, 0, 11, 0);
+
+    resetAndHandSizeContainerWidget = new QWidget(this);
     resetAndHandSizeContainerWidget->setLayout(resetAndHandSizeLayout);
 
     resetButton = new QPushButton(this);
@@ -39,11 +42,11 @@ VisualDeckEditorSampleHandWidget::VisualDeckEditorSampleHandWidget(QWidget *pare
     flowWidget = new FlowWidget(this, Qt::Horizontal, Qt::ScrollBarAlwaysOff, Qt::ScrollBarAsNeeded);
     layout->addWidget(flowWidget);
 
-    drawProbabilityWidget = new DrawProbabilityWidget(this, statsAnalyzer);
-    layout->addWidget(drawProbabilityWidget);
-
     cardSizeWidget = new CardSizeWidget(this, flowWidget);
     layout->addWidget(cardSizeWidget);
+
+    drawProbabilityWidget = new DrawProbabilityWidget(this, statsAnalyzer);
+    layout->addWidget(drawProbabilityWidget);
 
     for (const ExactCard &card : getRandomCards(handSizeSpinBox->value())) {
         auto displayWidget = new CardInfoPictureWidget(this);


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6463

## Short roundup of the initial problem

The sample hand widget has too much empty space.
Also, the card size slider should be below the cards and not below the whole thing.

## What will change with this Pull Request?
- Move card size slider to below the cards
- Reduce empty vertical spacing
- Make the table uneditable

## Screenshots
Before

<img width="977" height="1011" alt="Screenshot 2026-01-15 at 7 53 53 PM" src="https://github.com/user-attachments/assets/28cccca7-6671-4e82-a472-17edf7d8d977" />

After

<img width="975" height="1021" alt="Screenshot 2026-01-15 at 7 53 27 PM" src="https://github.com/user-attachments/assets/452e375c-c58e-4e1e-8ece-971bc522993e" />

