### PR TITLE
[TabGame] Don't create replay dock if not replay tab

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -255,7 +255,7 @@ void TabGame::emitUserEvent()
 
 TabGame::~TabGame()
 {
-    if (replayDock) {
+    if (replayManager) {
         delete replayManager->replay;
     }
 }

--- a/cockatrice/src/interface/widgets/tabs/tab_game.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.h
@@ -58,7 +58,7 @@ class TabGame : public Tab
 private:
     AbstractGame *game;
     const UserListProxy *userListProxy;
-    ReplayManager *replayManager;
+    ReplayManager *replayManager = nullptr;
     QStringList gameTypes;
     QCompleter *completer;
     QStringList autocompleteUserList;


### PR DESCRIPTION
## Short roundup of the initial problem

The replay timeline dock is still accessible in non-replay games through the view menu.
Making the timeline dock visible will reveal a glitched timeline widget.

https://github.com/user-attachments/assets/04d6b062-1a50-4353-ba9e-8cf00ec87862

## What will change with this Pull Request?
- Don't create replayDock at all if not replay tab (assign replayDock = nullptr)
  - This also means replayDock's dependencies don't get created
- Null check the `replayDock` to determine if game tab is a replay tab, instead of the previous method of checking the replayManager.  

https://github.com/user-attachments/assets/3ca1c46e-e517-4fa3-8555-90160906d562