### PR TITLE
[VDE] Use splitter in sample hand widget

### DIFF
--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_sample_hand_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_sample_hand_widget.cpp
@@ -55,13 +55,6 @@ VisualDeckEditorSampleHandWidget::VisualDeckEditorSampleHandWidget(QWidget *pare
 
     drawProbabilityWidget = new DrawProbabilityWidget(this, statsAnalyzer);
 
-    for (const ExactCard &card : getRandomCards(handSizeSpinBox->value())) {
-        auto displayWidget = new CardInfoPictureWidget(this);
-        displayWidget->setCard(card);
-        displayWidget->setScaleFactor(cardSizeWidget->getSlider()->value());
-        flowWidget->addWidget(displayWidget);
-    }
-
     auto *splitter = new QSplitter(this);
     splitter->setObjectName("splitter");
     splitter->setOrientation(Qt::Vertical);


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6525

## Short roundup of the initial problem

I think the sample hand widget would look nicer with a splitter.

## What will change with this Pull Request?
- Use QSplitter widget to split the sample hand section from the probability widget section
- Remove the pointless calculation code in the constructor

https://github.com/user-attachments/assets/eab64a18-d10c-4a98-ae6c-2810550166c1

## Screenshots

<img width="900" height="1012" alt="Screenshot 2026-01-16 at 9 14 55 AM" src="https://github.com/user-attachments/assets/cfb11fe1-c092-403b-b971-455e2ae748e6" />
