### PR TITLE
[VDS] Ignore tokens when calculating color identity

### DIFF
--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -153,7 +153,7 @@ void DeckPreviewWidget::updateTagsVisibility(bool visible)
 
 QString DeckPreviewWidget::getColorIdentity()
 {
-    QStringList cardList = deckLoader->getDeck().deckList.getCardList();
+    QStringList cardList = deckLoader->getDeck().deckList.getCardList({DECK_ZONE_MAIN, DECK_ZONE_SIDE});
     if (cardList.isEmpty()) {
         return {};
     }

--- a/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.cpp
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.cpp
@@ -438,9 +438,9 @@ void DeckList::cleanList(bool preserveMetadata)
     refreshDeckHash();
 }
 
-QStringList DeckList::getCardList() const
+QStringList DeckList::getCardList(const QSet<QString> &restrictToZones) const
 {
-    auto nodes = tree.getCardNodes();
+    auto nodes = tree.getCardNodes(restrictToZones);
 
     QStringList result;
     std::transform(nodes.cbegin(), nodes.cend(), std::back_inserter(result), [](auto node) { return node->getName(); });
@@ -448,9 +448,9 @@ QStringList DeckList::getCardList() const
     return result;
 }
 
-QList<CardRef> DeckList::getCardRefList() const
+QList<CardRef> DeckList::getCardRefList(const QSet<QString> &restrictToZones) const
 {
-    auto nodes = tree.getCardNodes();
+    auto nodes = tree.getCardNodes(restrictToZones);
 
     QList<CardRef> result;
     std::transform(nodes.cbegin(), nodes.cend(), std::back_inserter(result),

--- a/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.h
@@ -221,8 +221,8 @@ public:
     {
         return tree.isEmpty() && metadata.isEmpty() && sideboardPlans.isEmpty();
     }
-    QStringList getCardList() const;
-    QList<CardRef> getCardRefList() const;
+    QStringList getCardList(const QSet<QString> &restrictToZones = {}) const;
+    QList<CardRef> getCardRefList(const QSet<QString> &restrictToZones = {}) const;
     QList<const DecklistCardNode *> getCardNodes(const QSet<QString> &restrictToZones = {}) const;
     QList<const InnerDecklistNode *> getZoneNodes() const;
     int getSideboardSize() const;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6473

## Short roundup of the initial problem


## What will change with this Pull Request?
- Also add the `restrictToZones` param that is on `DeckList::getCardNodes` to `DeckList:: getCardList`
- restrict zone to maindeck and sideboard when calculating color identity