### PR TITLE
[VDS] Add option to hide color identity

### DIFF
--- a/cockatrice/src/client/settings/cache_settings.cpp
+++ b/cockatrice/src/client/settings/cache_settings.cpp
@@ -310,6 +310,7 @@ SettingsCache::SettingsCache()
     visualDeckStorageDefaultTagsList =
         settings->value("interface/visualdeckstoragedefaulttagslist", defaultTags).toStringList();
     visualDeckStorageSearchFolderNames = settings->value("interface/visualdeckstoragesearchfoldernames", true).toBool();
+    visualDeckStorageShowColorIdentity = settings->value("interface/visualdeckstorageshowcoloridentity", true).toBool();
     visualDeckStorageShowBannerCardComboBox =
         settings->value("interface/visualdeckstorageshowbannercardcombobox", true).toBool();
     visualDeckStorageShowTagsOnDeckPreviews =
@@ -827,6 +828,13 @@ void SettingsCache::setVisualDeckStorageSearchFolderNames(QT_STATE_CHANGED_T val
 {
     visualDeckStorageSearchFolderNames = value;
     settings->setValue("interface/visualdeckstoragesearchfoldernames", visualDeckStorageSearchFolderNames);
+}
+
+void SettingsCache::setVisualDeckStorageShowColorIdentity(QT_STATE_CHANGED_T value)
+{
+    visualDeckStorageShowColorIdentity = value;
+    settings->setValue("interface/visualdeckstorageshowcoloridentity", visualDeckStorageShowColorIdentity);
+    emit visualDeckStorageShowColorIdentityChanged(visualDeckStorageShowColorIdentity);
 }
 
 void SettingsCache::setVisualDeckStorageShowBannerCardComboBox(QT_STATE_CHANGED_T _showBannerCardComboBox)

--- a/cockatrice/src/client/settings/cache_settings.h
+++ b/cockatrice/src/client/settings/cache_settings.h
@@ -158,6 +158,7 @@ signals:
     void deckEditorTagsWidgetVisibleChanged(bool _visible);
     void visualDeckStorageShowTagFilterChanged(bool _visible);
     void visualDeckStorageDefaultTagsListChanged();
+    void visualDeckStorageShowColorIdentityChanged(bool _visible);
     void visualDeckStorageShowBannerCardComboBoxChanged(bool _visible);
     void visualDeckStorageShowTagsOnDeckPreviewsChanged(bool _visible);
     void visualDeckStorageCardSizeChanged();
@@ -251,6 +252,7 @@ private:
     bool deckEditorTagsWidgetVisible;
     int visualDeckStorageSortingOrder;
     bool visualDeckStorageShowFolders;
+    bool visualDeckStorageShowColorIdentity;
     bool visualDeckStorageShowBannerCardComboBox;
     bool visualDeckStorageShowTagsOnDeckPreviews;
     bool visualDeckStorageShowTagFilter;
@@ -620,6 +622,10 @@ public:
     [[nodiscard]] bool getVisualDeckStorageSearchFolderNames() const
     {
         return visualDeckStorageSearchFolderNames;
+    }
+    [[nodiscard]] bool getVisualDeckStorageShowColorIdentity() const
+    {
+        return visualDeckStorageShowColorIdentity;
     }
     [[nodiscard]] bool getVisualDeckStorageShowBannerCardComboBox() const
     {
@@ -1045,6 +1051,7 @@ public slots:
     void setVisualDeckStorageShowTagFilter(QT_STATE_CHANGED_T _showTags);
     void setVisualDeckStorageDefaultTagsList(QStringList _defaultTagsList);
     void setVisualDeckStorageSearchFolderNames(QT_STATE_CHANGED_T value);
+    void setVisualDeckStorageShowColorIdentity(QT_STATE_CHANGED_T value);
     void setVisualDeckStorageShowBannerCardComboBox(QT_STATE_CHANGED_T _showBannerCardComboBox);
     void setVisualDeckStorageShowTagsOnDeckPreviews(QT_STATE_CHANGED_T _showTags);
     void setVisualDeckStorageCardSize(int _visualDeckStorageCardSize);
@@ -1117,5 +1124,4 @@ public slots:
     void setMaxFontSize(int _max);
     void setRoundCardCorners(bool _roundCardCorners);
 };
-
 #endif

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -42,6 +42,8 @@ DeckPreviewWidget::DeckPreviewWidget(QWidget *_parent,
     connect(bannerCardDisplayWidget, &DeckPreviewCardPictureWidget::imageDoubleClicked, this,
             &DeckPreviewWidget::imageDoubleClickedEvent);
 
+    connect(&SettingsCache::instance(), &SettingsCache::visualDeckStorageShowColorIdentityChanged, this,
+            &DeckPreviewWidget::updateColorIdentityVisibility);
     connect(&SettingsCache::instance(), &SettingsCache::visualDeckStorageShowTagsOnDeckPreviewsChanged, this,
             &DeckPreviewWidget::updateTagsVisibility);
     connect(&SettingsCache::instance(), &SettingsCache::visualDeckStorageShowBannerCardComboBoxChanged, this,
@@ -96,6 +98,7 @@ void DeckPreviewWidget::initializeUi(const bool deckLoadSuccess)
     connect(bannerCardComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &DeckPreviewWidget::setBannerCard);
 
+    updateColorIdentityVisibility(SettingsCache::instance().getVisualDeckStorageShowColorIdentity());
     updateBannerCardComboBox();
     updateBannerCardComboBoxVisibility(SettingsCache::instance().getVisualDeckStorageShowBannerCardComboBox());
     updateTagsVisibility(SettingsCache::instance().getVisualDeckStorageShowTagsOnDeckPreviews());
@@ -121,6 +124,15 @@ bool DeckPreviewWidget::checkVisibility() const
         return false;
     }
     return true;
+}
+
+void DeckPreviewWidget::updateColorIdentityVisibility(bool visible)
+{
+    if (colorIdentityWidget == nullptr) {
+        return;
+    }
+
+    colorIdentityWidget->setVisible(visible);
 }
 
 void DeckPreviewWidget::updateBannerCardComboBoxVisibility(bool visible)

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
@@ -63,6 +63,7 @@ public slots:
     void imageDoubleClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance);
     void initializeUi(bool deckLoadSuccess);
     void updateVisibility();
+    void updateColorIdentityVisibility(bool visible);
     void updateBannerCardComboBoxVisibility(bool visible);
     void updateTagsVisibility(bool visible);
     void resizeEvent(QResizeEvent *event) override;

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.cpp
@@ -26,6 +26,14 @@ VisualDeckStorageQuickSettingsWidget::VisualDeckStorageQuickSettingsWidget(QWidg
     connect(showTagFilterCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setVisualDeckStorageShowTagFilter);
 
+    // show color identity on DeckPreviewWidget checkbox
+    showColorIdentityCheckBox = new QCheckBox(this);
+    showColorIdentityCheckBox->setChecked(SettingsCache::instance().getVisualDeckStorageShowColorIdentity());
+    connect(showColorIdentityCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+            &VisualDeckStorageQuickSettingsWidget::showColorIdentityChanged);
+    connect(showColorIdentityCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setVisualDeckStorageShowColorIdentity);
+
     // show tags on DeckPreviewWidget checkbox
     showTagsOnDeckPreviewsCheckBox = new QCheckBox(this);
     showTagsOnDeckPreviewsCheckBox->setChecked(SettingsCache::instance().getVisualDeckStorageShowTagsOnDeckPreviews());
@@ -103,6 +111,7 @@ VisualDeckStorageQuickSettingsWidget::VisualDeckStorageQuickSettingsWidget(QWidg
     // putting everything together
     this->addSettingsWidget(showFoldersCheckBox);
     this->addSettingsWidget(showTagFilterCheckBox);
+    this->addSettingsWidget(showColorIdentityCheckBox);
     this->addSettingsWidget(showTagsOnDeckPreviewsCheckBox);
     this->addSettingsWidget(showBannerCardComboBoxCheckBox);
     this->addSettingsWidget(drawUnusedColorIdentitiesCheckBox);
@@ -119,6 +128,7 @@ void VisualDeckStorageQuickSettingsWidget::retranslateUi()
 {
     showFoldersCheckBox->setText(tr("Show Folders"));
     showTagFilterCheckBox->setText(tr("Show Tag Filter"));
+    showColorIdentityCheckBox->setText(tr("Show Color Identity"));
     showTagsOnDeckPreviewsCheckBox->setText(tr("Show Tags On Deck Previews"));
     showBannerCardComboBoxCheckBox->setText(tr("Show Banner Card Selection Option"));
     drawUnusedColorIdentitiesCheckBox->setText(tr("Draw unused Color Identities"));
@@ -138,6 +148,11 @@ bool VisualDeckStorageQuickSettingsWidget::getShowFolders() const
 bool VisualDeckStorageQuickSettingsWidget::getDrawUnusedColorIdentities() const
 {
     return drawUnusedColorIdentitiesCheckBox->isChecked();
+}
+
+bool VisualDeckStorageQuickSettingsWidget::getShowColorIdentity() const
+{
+    return showColorIdentityCheckBox->isChecked();
 }
 
 bool VisualDeckStorageQuickSettingsWidget::getShowBannerCardComboBox() const

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.h
@@ -22,6 +22,7 @@ class VisualDeckStorageQuickSettingsWidget : public SettingsButtonWidget
     Q_OBJECT
 
     QCheckBox *showFoldersCheckBox;
+    QCheckBox *showColorIdentityCheckBox;
     QCheckBox *drawUnusedColorIdentitiesCheckBox;
     QCheckBox *showBannerCardComboBoxCheckBox;
     QCheckBox *showTagFilterCheckBox;
@@ -49,6 +50,7 @@ public:
 
     [[nodiscard]] bool getShowFolders() const;
     [[nodiscard]] bool getDrawUnusedColorIdentities() const;
+    [[nodiscard]] bool getShowColorIdentity() const;
     [[nodiscard]] bool getShowBannerCardComboBox() const;
     [[nodiscard]] bool getShowTagFilter() const;
     [[nodiscard]] bool getShowTagsOnDeckPreviews() const;
@@ -59,6 +61,7 @@ public:
 signals:
     void showFoldersChanged(bool enabled);
     void drawUnusedColorIdentitiesChanged(bool enabled);
+    void showColorIdentityChanged(bool enabled);
     void showBannerCardComboBoxChanged(bool enabled);
     void showTagFilterChanged(bool enabled);
     void showTagsOnDeckPreviewsChanged(bool enabled);


### PR DESCRIPTION
## Short roundup of the initial problem

Hiding the color identity widget can noticeably reduce the loading lag in the VDS when there are a lot of decks.

## What will change with this Pull Request?
- Add "Show Color Identity" option to VDS quick settings widget
- Update SettingsCache with the new setting
- Wire up the setting to hide the color identity widget when not enabled

https://github.com/user-attachments/assets/f9d844a4-78d7-4bcc-9854-f2428b5708ca


## Screenshots

<img width="343" height="304" alt="Screenshot 2026-01-18 at 8 50 23 PM" src="https://github.com/user-attachments/assets/a1960186-0e58-45c5-84ba-7372f532dd38" />

