### PR TITLE
[DeckList] Add optional restrictToZone param to getZoneNodes

### DIFF
--- a/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.cpp
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.cpp
@@ -464,9 +464,9 @@ QList<const DecklistCardNode *> DeckList::getCardNodes(const QSet<QString> &rest
     return tree.getCardNodes(restrictToZones);
 }
 
-QList<const InnerDecklistNode *> DeckList::getZoneNodes() const
+QList<const InnerDecklistNode *> DeckList::getZoneNodes(const QSet<QString> &restrictToZones) const
 {
-    return tree.getZoneNodes();
+    return tree.getZoneNodes(restrictToZones);
 }
 
 int DeckList::getSideboardSize() const

--- a/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.h
@@ -224,7 +224,7 @@ public:
     QStringList getCardList(const QSet<QString> &restrictToZones = {}) const;
     QList<CardRef> getCardRefList(const QSet<QString> &restrictToZones = {}) const;
     QList<const DecklistCardNode *> getCardNodes(const QSet<QString> &restrictToZones = {}) const;
-    QList<const InnerDecklistNode *> getZoneNodes() const;
+    QList<const InnerDecklistNode *> getZoneNodes(const QSet<QString> &restrictToZones = {}) const;
     int getSideboardSize() const;
 
     DecklistCardNode *addCard(const QString &cardName,

--- a/libcockatrice_deck_list/libcockatrice/deck_list/deck_list_node_tree.cpp
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/deck_list_node_tree.cpp
@@ -41,10 +41,7 @@ QList<const DecklistCardNode *> DecklistNodeTree::getCardNodes(const QSet<QStrin
 {
     QList<const DecklistCardNode *> result;
 
-    for (auto *zoneNode : getZoneNodes()) {
-        if (!restrictToZones.isEmpty() && !restrictToZones.contains(zoneNode->getName())) {
-            continue;
-        }
+    for (auto *zoneNode : getZoneNodes(restrictToZones)) {
         for (auto *cardNode : *zoneNode) {
             auto *cardCardNode = dynamic_cast<DecklistCardNode *>(cardNode);
             if (cardCardNode) {
@@ -56,13 +53,16 @@ QList<const DecklistCardNode *> DecklistNodeTree::getCardNodes(const QSet<QStrin
     return result;
 }
 
-QList<const InnerDecklistNode *> DecklistNodeTree::getZoneNodes() const
+QList<const InnerDecklistNode *> DecklistNodeTree::getZoneNodes(const QSet<QString> &restrictToZones) const
 {
     QList<const InnerDecklistNode *> zones;
     for (auto *node : *root) {
         InnerDecklistNode *currentZone = dynamic_cast<InnerDecklistNode *>(node);
         if (!currentZone)
             continue;
+        if (!restrictToZones.isEmpty() && !restrictToZones.contains(currentZone->getName())) {
+            continue;
+        }
         zones.append(currentZone);
     }
 

--- a/libcockatrice_deck_list/libcockatrice/deck_list/deck_list_node_tree.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/deck_list_node_tree.h
@@ -45,7 +45,12 @@ public:
      */
     QList<const DecklistCardNode *> getCardNodes(const QSet<QString> &restrictToZones = {}) const;
 
-    QList<const InnerDecklistNode *> getZoneNodes() const;
+    /**
+     * Gets all zone nodes in the tree
+     * @param restrictToZones If not empty, only get the zone nodes with these names.
+     * @return A QList containing all the zone nodes in the tree.
+     */
+    QList<const InnerDecklistNode *> getZoneNodes(const QSet<QString> &restrictToZones = {}) const;
 
     /**
      * @brief Computes the deck hash


### PR DESCRIPTION
## Related Ticket(s)
-  Needed for the fix to #6429

## Short roundup of the initial problem

I want to add the same zone filtering param to `getZoneNodes` to make implementation easier in a future PR.

## What will change with this Pull Request?
- Add `restrictToZones` param to `getZoneNodes` in `DeckList` and `DeckListNodeTree`