### PR TITLE
[DeckListModel] Fix exception precedence in legality check

### DIFF
--- a/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
+++ b/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
@@ -709,8 +709,9 @@ static bool isCardQuantityLegalForFormat(const QString &format, const CardInfo &
 
     auto formatRules = CardDatabaseManager::query()->getFormat(format);
 
+    // if format has no custom rules, then just do the default check
     if (!formatRules) {
-        return true;
+        return cardInfo.isLegalInFormat(format);
     }
 
     // Exceptions always win
@@ -758,11 +759,7 @@ void DeckListModel::refreshCardFormatLegalities()
             }
 
             QString format = deckList->getGameFormat();
-            bool legal = exactCard.getInfo().isLegalInFormat(format);
-
-            if (legal) {
-                legal = isCardQuantityLegalForFormat(format, exactCard.getInfo(), currentCard->getNumber());
-            }
+            bool legal = isCardQuantityLegalForFormat(format, exactCard.getInfo(), currentCard->getNumber());
 
             currentCard->setFormatLegality(legal);
         }


### PR DESCRIPTION
## Related Ticket(s)
- Fix bug introduced in #6166

## Short roundup of the initial problem

Currently, the legality check logic in `DeckListModel` does the default legality check (cardInfo has to contain a `format-<name>` property with value equal to "legal" or "restricted") first, and only when that passes does it look up the format rules.

That means the default legality check  takes precedence over any exceptions. I feel like that is the incorrect behavior. Exceptions should *always* take precedence, including over the default legality check.

## What will change with this Pull Request?
- If the format has any custom rules, do the exception check before doing the default legality check.

