### PR TITLE
[CardInfo] Refactor: add getLegalityProp method

### DIFF
--- a/libcockatrice_card/libcockatrice/card/card_info.cpp
+++ b/libcockatrice_card/libcockatrice/card/card_info.cpp
@@ -75,13 +75,18 @@ QString CardInfo::getCorrectedName() const
     return result.remove(rmrx).replace(spacerx, space);
 }
 
+QString CardInfo::getLegalityProp(const QString &format) const
+{
+    return getProperty("format-" + format);
+}
+
 bool CardInfo::isLegalInFormat(const QString &format) const
 {
     if (format.isEmpty()) {
         return true;
     }
 
-    QString formatLegality = getProperty("format-" + format);
+    QString formatLegality = getLegalityProp(format);
     return formatLegality == "legal" || formatLegality == "restricted";
 }
 

--- a/libcockatrice_card/libcockatrice/card/card_info.h
+++ b/libcockatrice_card/libcockatrice/card/card_info.h
@@ -292,6 +292,14 @@ public:
     [[nodiscard]] QString getCorrectedName() const;
 
     /**
+     * @brief Gets the card's legality value for the given format.
+     * The legality prop for a format is stored in the property map under the key "format-<name>"
+     * @param format The format's name.
+     * @return The card's legality value for the format. Empty if not found.
+     */
+    [[nodiscard]] QString getLegalityProp(const QString &format) const;
+
+    /**
      * @brief Checks if the card is legal in the given format.
      * A card is considered legal in a format if its properties map contains an entry for "format-<name>", with value
      * "legal" or "restricted".

--- a/libcockatrice_filters/libcockatrice/filters/filter_string.cpp
+++ b/libcockatrice_filters/libcockatrice/filters/filter_string.cpp
@@ -143,13 +143,12 @@ static void setupParserRules()
     search["FormatQuery"] = [](const peg::SemanticValues &sv) -> Filter {
         if (sv.choice() == 0) {
             const auto format = std::any_cast<QString>(sv[0]);
-            return
-                [=](const CardData &x) -> bool { return x->getProperty(QString("format-%1").arg(format)) == "legal"; };
+            return [=](const CardData &x) -> bool { return x->getLegalityProp(format) == "legal"; };
         }
 
         const auto format = std::any_cast<QString>(sv[1]);
         const auto legality = std::any_cast<QString>(sv[0]);
-        return [=](const CardData &x) -> bool { return x->getProperty(QString("format-%1").arg(format)) == legality; };
+        return [=](const CardData &x) -> bool { return x->getLegalityProp(format) == legality; };
     };
     search["Legality"] = [](const peg::SemanticValues &sv) -> QString {
         switch (tolower(std::string(sv.sv())[0])) {

--- a/libcockatrice_filters/libcockatrice/filters/filter_tree.cpp
+++ b/libcockatrice_filters/libcockatrice/filters/filter_tree.cpp
@@ -275,7 +275,7 @@ bool FilterItem::acceptCmc(const CardInfoPtr info) const
 
 bool FilterItem::acceptFormat(const CardInfoPtr info) const
 {
-    return info->getProperty(QString("format-%1").arg(term.toLower())) == "legal";
+    return info->getLegalityProp(term.toLower()) == "legal";
 }
 
 bool FilterItem::acceptLoyalty(const CardInfoPtr info) const

--- a/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
+++ b/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
@@ -718,12 +718,11 @@ static bool isCardQuantityLegalForFormat(const QString &format, const CardInfo &
         return true;
     }
 
-    const QString legalityProp = "format-" + format;
-    if (!cardInfo.getProperties().contains(legalityProp)) {
+    // check legality prop
+    const QString legality = cardInfo.getLegalityProp(format);
+    if (legality.isEmpty()) {
         return false;
     }
-
-    const QString legality = cardInfo.getProperty(legalityProp);
 
     int maxAllowed = maxAllowedForLegality(*formatRules, legality);
 


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6460

## Short roundup of the initial problem

`DeckListModel` shouldn't need to know how legality props are stored.

## What will change with this Pull Request?
- Add a `getLegalityProp` method to `CardInfo`
- Update usages where outside code was looking up a "format-" property