### PR TITLE
[DeckListModel] Correctly refresh legality on add card

### DIFF
--- a/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
+++ b/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
@@ -435,9 +435,8 @@ QModelIndex DeckListModel::addCard(const ExactCard &card, const QString &zoneNam
         // Determine the correct index
         int insertRow = findSortedInsertRow(groupNode, cardInfo);
 
-        auto *decklistCard =
-            deckList->addCard(cardInfo->getName(), zoneName, insertRow, cardSetName, printingInfo.getProperty("num"),
-                              printingInfo.getProperty("uuid"), cardInfo->isLegalInFormat(deckList->getGameFormat()));
+        auto *decklistCard = deckList->addCard(cardInfo->getName(), zoneName, insertRow, cardSetName,
+                                               printingInfo.getProperty("num"), printingInfo.getProperty("uuid"));
 
         beginInsertRows(parentIndex, insertRow, insertRow);
         cardNode = new DecklistModelCardNode(decklistCard, groupNode, insertRow);
@@ -453,6 +452,7 @@ QModelIndex DeckListModel::addCard(const ExactCard &card, const QString &zoneNam
         emit deckHashChanged();
     }
     sort(lastKnownColumn, lastKnownOrder);
+    refreshCardFormatLegalities();
     emitRecursiveUpdates(parentIndex);
     auto index = nodeToIndex(cardNode);
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #6166

## Short roundup of the initial problem

The `DeckListModel::addCard` method does not run `refreshCardFormatLegalities` after adding the card; it instead does a legality check and directly passes the result into the cardNode constructor. The problem is that it only does the default legality check (cardInfo has to contain a `format-<name>` property with value equal to "legal" or "restricted") and not the full legality check that looks up the format.

Also `addCard` has an else branch that runs if copies of the card already exists in the deck, and I'm not sure if that branch triggers `refreshCardFormatLegalities`.

## What will change with this Pull Request?
- In `addCard`, call `refreshCardFormatLegalities` after the branch, right before `emitRecursiveUpdates`
- Don't bother passing the legality into the card node constructor