### PR TITLE
[VDE] Fix right click to remove card not working

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.cpp
@@ -207,11 +207,13 @@ QModelIndex DeckStateManager::decrementCard(const ExactCard &card, const QString
         return {};
     }
 
-    if (idx.isValid()) {
-        emit focusIndexChanged(idx, true);
+    // old index is no longer safe since rows could have been removed
+    QModelIndex newIdx = deckListModel->findCard(card.getName(), zoneName, providerId, collectorNumber);
+    if (newIdx.isValid()) {
+        emit focusIndexChanged(newIdx, true);
     }
 
-    return idx;
+    return newIdx;
 }
 
 static bool doSwapCard(DeckListModel *model,


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6548

## Short roundup of the initial problem

`DeckStateManager::decrementCard` has a typo, which meant it wasn't removing cards.

Fixing the typo revealed that `decrementCard` removing the last card causes a crash, so also fixed that

## What will change with this Pull Request?
- Fix typo
- Fix crash

https://github.com/user-attachments/assets/c04bd4e0-8bc0-45ea-b0f6-46682388e0af

