### PR TITLE
[VDS] Fix crash when tab is opened before card database is loaded

### DIFF
--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -78,7 +78,11 @@ void DeckPreviewWidget::enterEvent(QEvent *event)
 #endif
 {
     QWidget::enterEvent(event);
-    reloadIfModified();
+
+    // don't do reloads until widgets have been created
+    if (bannerCardComboBox != nullptr) {
+        reloadIfModified();
+    }
 }
 
 /**


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #6507

## Short roundup of the initial problem

Cockatrice crashes if you mouse over the flow layout as the card database finishes loading.

This is because the enterEvent is causing a call to `syncWidgets` before the widgets have been properly initialized.

## What will change with this Pull Request?
- In the `enterEvent`, check that some widget exists before calling `reloadIfModified`