### PR TITLE
[VDE] Add shortcut to increment cards [Alt + LMB]

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
@@ -163,23 +163,32 @@ void TabDeckEditorVisual::processMainboardCardClick(QMouseEvent *event,
     QItemSelectionModel *sel = deckDockWidget->getSelectionModel();
 
     // Double click = swap
-    if (event->type() == QEvent::MouseButtonDblClick && event->button() == Qt::LeftButton) {
+    if (event->type() == QEvent::MouseButtonDblClick && event->button() == Qt::LeftButton &&
+        !event->modifiers().testFlag(Qt::AltModifier)) {
         deckStateManager->swapCardAtIndex(idx);
         idx = deckStateManager->getModel()->findCard(card.getName(), zoneName);
         sel->setCurrentIndex(idx, QItemSelectionModel::ClearAndSelect);
         return;
     }
 
-    // Right-click = decrement
-    if (event->button() == Qt::RightButton) {
-        actDecrementCard(card);
+    // Alt + Right-click = decrement
+    if (event->button() == Qt::RightButton && event->modifiers().testFlag(Qt::AltModifier)) {
+        if (zoneName == DECK_ZONE_MAIN) {
+            actDecrementCard(card);
+        } else {
+            actDecrementCardFromSideboard(card);
+        }
         //  Keep selection intact.
         return;
     }
 
     // Alt + Left click = increment
     if (event->button() == Qt::LeftButton && event->modifiers().testFlag(Qt::AltModifier)) {
-        // actIncrementCard(card);
+        if (zoneName == DECK_ZONE_MAIN) {
+            actAddCard(card);
+        } else {
+            actAddCardToSideboard(card);
+        }
         //  Keep selection intact.
         return;
     }


### PR DESCRIPTION
## Related Ticket(s)
- Relates to one of the major/minor #6386

## Short roundup of the initial problem
There's currently no way to increment a card in the VDE itself. This means it's not really a fully fledged deck editor just yet.

## What will change with this Pull Request?
- Add Alt + LMB shortcut to increment selection
- Prevent mainboard<->sideboard swap when alt is held
- Properly increment and decrement from main/sideboard
