### PR TITLE
[VDE] Insert at correct index onDataChanged() instead of just appending.

### DIFF
--- a/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
@@ -325,11 +325,22 @@ void CardGroupDisplayWidget::onDataChanged(const QModelIndex &topLeft,
                 indexToWidgetMap.remove(persistent);
             }
         } else {
-            // Add new widgets
             int toAdd = newAmount - currentWidgetCount;
+            int insertBase = 0;
 
+            // Count widgets belonging to rows before this one
+            for (int r = 0; r < row; ++r) {
+                QModelIndex prevIdx = deckListModel->index(r, 0, trackedIndex);
+                QPersistentModelIndex prevPersistent(prevIdx);
+
+                if (indexToWidgetMap.contains(prevPersistent)) {
+                    insertBase += indexToWidgetMap.value(prevPersistent).size();
+                }
+            }
+
+            // Insert after existing copies of this card
             for (int i = 0; i < toAdd; ++i) {
-                addToLayout(constructWidgetForIndex(persistent));
+                insertIntoLayout(constructWidgetForIndex(persistent), insertBase + currentWidgetCount + i);
             }
         }
 


### PR DESCRIPTION
## Short roundup of the initial problem
Fixes a lil bug where new instances of a card where being added to the end of the display instead of inserted into their correct index positions.
