### PR TITLE
CI: Include submodules in repo checkout (Docs deployment)

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          submodules: true
+          submodules: recursive
 
       - name: Install Graphviz
         run: |


### PR DESCRIPTION
## Related Ticket(s)
- Related #6512

## Short roundup of the initial problem
The new theme is included as submodule in the repo.
The deployment action does not include submodules when checking it out.

## What will change with this Pull Request?
- Include `submodules` in checkout for the doc generating CI workflow