### PR TITLE
move returning cards to server_game

### DIFF
--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.h
@@ -218,6 +218,7 @@ public:
                                 GameEventStorageItem::EventRecipients recipients = GameEventStorageItem::SendToPrivate |
                                                                                    GameEventStorageItem::SendToOthers,
                                 int privatePlayerId = -1);
+    void returnCardsFromPlayer(GameEventStorage &ges, Server_AbstractPlayer *player);
 };
 
 #endif


### PR DESCRIPTION
lock the game mutex instead of player mutex when returning cards

## Related Ticket(s)
- Fixes recurring crashes introduced in #5348
- first fix for this problem was in #5964

## Short roundup of the initial problem
returning cards to players does a lot of mutations to the general game state and the one of other players, it used to happen completely outside of the mutexes that are supposed to make this thread safe as every player has its own thread, this went wrong a lot, hopefully this will fix that

## What will change with this Pull Request?
- moving cards to their owner on concede is now a server_game function
- it locks the gameMutex

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
