### PR TITLE
[VDE] Fix crash from alt-click when card has unknown set

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.cpp
@@ -175,9 +175,11 @@ QModelIndex DeckStateManager::addCard(const ExactCard &card, const QString &zone
 
     QString zone = card.getInfo().getIsToken() ? DECK_ZONE_TOKENS : zoneName;
 
-    QString reason = tr("Added (%1): %2 (%3) %4")
-                         .arg(zone, card.getName(), card.getPrinting().getSet()->getCorrectedShortName(),
-                              card.getPrinting().getProperty("num"));
+    CardSetPtr set = card.getPrinting().getSet();
+    QString setName = set ? set->getCorrectedShortName() : "";
+
+    QString reason =
+        tr("Added (%1): %2 (%3) %4").arg(zone, card.getName(), setName, card.getPrinting().getProperty("num"));
 
     QModelIndex idx = modifyDeck(reason, [&card, &zone](auto model) { return model->addCard(card, zone); });
 


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6549

## Short roundup of the initial problem

VDE alt-click crashes if you have a card with a set that doesn't exist in the card database

https://github.com/user-attachments/assets/03878c6c-dcac-43f1-ac93-134bb6da14ec

## What will change with this Pull Request?

- Null check the CardSetPtr before getting the name