### PR TITLE
[PrintingSelector] Properly initialize font size on each card load

### DIFF
--- a/cockatrice/src/interface/widgets/printing_selector/set_name_and_collectors_number_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/set_name_and_collectors_number_display_widget.cpp
@@ -36,6 +36,7 @@ SetNameAndCollectorsNumberDisplayWidget::SetNameAndCollectorsNumberDisplayWidget
 
     // Store the card size slider and connect its signal to the font size adjustment slot
     connect(cardSizeSlider, &QSlider::valueChanged, this, &SetNameAndCollectorsNumberDisplayWidget::adjustFontSize);
+    adjustFontSize(cardSizeSlider->value());
 
     // Add labels to the layout
     layout->addWidget(setName);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6567

## Short roundup of the initial problem

The `SetNameAndCollectorsNumberDisplayWidget` never called `adjustFontSize` inside its constructor. It only calls `adjustFontSize` when the card size slider changes. However, seeing as the widget is recreated on every card switch, it's unlikely for the user to see the adjusted font size. 

That means, for all this time, the printing selector was using the default unadjusted font size.

## What will change with this Pull Request?
- Call `adjustFontSize` in the constructor

## Sceenshots

Before
<img width="586" height="949" alt="Screenshot 2026-01-25 at 4 16 52 AM" src="https://github.com/user-attachments/assets/f8dbf680-1095-4392-a125-b9612d1b4938" />

After
<img width="576" height="951" alt="Screenshot 2026-01-25 at 4 16 28 AM" src="https://github.com/user-attachments/assets/31d63e08-e77c-4c6f-8fe4-b8d0f79ebfe9" />
