### PR TITLE
[PrintingSelector] Properly clamp text size to picture on load

### DIFF
--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector.cpp
@@ -223,7 +223,6 @@ void PrintingSelector::getAllSetsForCurrentCard()
             auto *cardDisplayWidget = new PrintingSelectorCardDisplayWidget(this, deckEditor, deckStateManager,
                                                                             cardSizeWidget->getSlider(), card);
             flowWidget->addWidget(cardDisplayWidget);
-            cardDisplayWidget->clampSetNameToPicture();
             cardDisplayWidget->updateCardAmounts(uuidToAmounts);
             connect(cardDisplayWidget, &PrintingSelectorCardDisplayWidget::cardPreferenceChanged, this,
                     &PrintingSelector::updateDisplay);

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.cpp
@@ -70,3 +70,9 @@ void PrintingSelectorCardDisplayWidget::updateCardAmounts(const QMap<QString, QP
     auto [main, side] = uuidToAmounts.value(rootCard.getPrinting().getUuid());
     overlayWidget->updateCardAmounts(main, side);
 }
+
+void PrintingSelectorCardDisplayWidget::resizeEvent(QResizeEvent *event)
+{
+    QWidget::resizeEvent(event);
+    clampSetNameToPicture();
+}

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.h
@@ -29,6 +29,8 @@ public slots:
     void clampSetNameToPicture();
     void updateCardAmounts(const QMap<QString, QPair<int, int>> &uuidToAmounts);
 
+    void resizeEvent(QResizeEvent *event) override;
+
 signals:
     void cardPreferenceChanged();
 

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
@@ -60,12 +60,6 @@ PrintingSelectorCardOverlayWidget::PrintingSelectorCardOverlayWidget(QWidget *pa
 
     allZonesCardAmountWidget->raise(); // Ensure it's on top of the picture
 
-    // Attempt to cast the parent to PrintingSelectorCardDisplayWidget
-    if (const auto *parentWidget = qobject_cast<PrintingSelectorCardDisplayWidget *>(parent)) {
-        connect(cardInfoPicture, &CardInfoPictureWidget::cardScaleFactorChanged, parentWidget,
-                &PrintingSelectorCardDisplayWidget::clampSetNameToPicture);
-    }
-
     connect(cardSizeSlider, &QSlider::valueChanged, cardInfoPicture, &CardInfoPictureWidget::setScaleFactor);
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6573 (requires that to be merged first)

## Short roundup of the initial problem

The printing selector card display widgets don't call `PrintingSelectorCardDisplayWidget::clampSetNameToPicture` on load; it only calls it when it receives a change signal from the slider. That means the set/num text is using the incorrect size when calculating the text wrapping, causing the text to take up more lines than necessary. The text size only gets corrected upon touching the card size slider.

## What will change with this Pull Request?
- call `clampSetNameToPicture` in `PrintingSelectorCardDisplayWidget`'s `resizeEvent`, instead of manually calling it in reaction to stuff
  - This also better ensures the size is always synced

## Screenshots

Before

<img width="482" height="706" alt="Screenshot 2026-01-26 at 4 36 31 AM" src="https://github.com/user-attachments/assets/fbdb44fc-34dc-409e-8fa6-d3d0913ba2d2" />

After

<img width="479" height="629" alt="Screenshot 2026-01-26 at 4 35 44 AM" src="https://github.com/user-attachments/assets/a774697e-184d-40ae-af12-b80d35eb88fb" />
