### PR TITLE
[DeckListModel] Fix deck hash not updating on card node add/remove

### DIFF
--- a/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
+++ b/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
@@ -340,6 +340,9 @@ bool DeckListModel::removeRows(int row, int count, const QModelIndex &parent)
         emitRecursiveUpdates(parent);
     }
 
+    deckList->refreshDeckHash();
+    emit deckHashChanged();
+
     return true;
 }
 
@@ -448,8 +451,6 @@ QModelIndex DeckListModel::addCard(const ExactCard &card, const QString &zoneNam
         cardNode->setCardSetShortName(cardSetName);
         cardNode->setCardCollectorNumber(printingInfo.getProperty("num"));
         cardNode->setCardProviderId(printingInfo.getProperty("uuid"));
-        deckList->refreshDeckHash();
-        emit deckHashChanged();
         // Emit dataChanged for the amount column since we modified it
         QModelIndex cardIndex = nodeToIndex(cardNode);
         QModelIndex amountIndex = cardIndex.sibling(cardIndex.row(), DeckListModelColumns::CARD_AMOUNT);
@@ -458,6 +459,10 @@ QModelIndex DeckListModel::addCard(const ExactCard &card, const QString &zoneNam
     sort(lastKnownColumn, lastKnownOrder);
     refreshCardFormatLegalities();
     emitRecursiveUpdates(parentIndex);
+
+    deckList->refreshDeckHash();
+    emit deckHashChanged();
+
     auto index = nodeToIndex(cardNode);
 
     if (cardNodeAdded) {


### PR DESCRIPTION
## Short roundup of the initial problem

The displayed hash in the deck editor doesn't update when a card node is added or removed.

https://github.com/user-attachments/assets/935404a3-25b5-4cdb-a71c-0a4381180d1d

## What will change with this Pull Request?
- Emit deckHashChanged in `removeRows` and `addCard`

https://github.com/user-attachments/assets/2b771e2a-e537-49b1-9dc5-19f8ca1915d1