### PR TITLE
[LayoutSettings] Reorganize hierarchy in settings file

### DIFF
--- a/libcockatrice_settings/libcockatrice/settings/layouts_settings.cpp
+++ b/libcockatrice_settings/libcockatrice/settings/layouts_settings.cpp
@@ -5,8 +5,8 @@ const static QString GEOMETRY_PROP = "geometry";
 const static QString SIZE_PROP = "widgetSize";
 
 const static QString GROUP_DECK_EDITOR = "deckEditor";
-const static QString GROUP_DECK_EDITOR_DB_HEADER = "deckEditorDbHeader";
-const static QString GROUP_SETS_DIALOG_HEADER = "setsDialogHeader";
+const static QString GROUP_DECK_EDITOR_DB = "deckEditorDb";
+const static QString GROUP_SETS_DIALOG = "setsDialog";
 const static QString GROUP_GAME_PLAY_AREA = "gamePlayArea";
 const static QString GROUP_REPLAY_PLAY_AREA = "replayPlayArea";
 
@@ -92,22 +92,22 @@ void LayoutsSettings::setDeckEditorFilterSize(const QSize &value)
 
 const QByteArray LayoutsSettings::getDeckEditorDbHeaderState()
 {
-    return getValue(STATE_PROP, GROUP_DECK_EDITOR_DB_HEADER).toByteArray();
+    return getValue(STATE_PROP, GROUP_DECK_EDITOR_DB, "header").toByteArray();
 }
 
 void LayoutsSettings::setDeckEditorDbHeaderState(const QByteArray &value)
 {
-    setValue(value, STATE_PROP, GROUP_DECK_EDITOR_DB_HEADER);
+    setValue(value, STATE_PROP, GROUP_DECK_EDITOR_DB, "header");
 }
 
 const QByteArray LayoutsSettings::getSetsDialogHeaderState()
 {
-    return getValue(STATE_PROP, GROUP_SETS_DIALOG_HEADER).toByteArray();
+    return getValue(STATE_PROP, GROUP_SETS_DIALOG, "header").toByteArray();
 }
 
 void LayoutsSettings::setSetsDialogHeaderState(const QByteArray &value)
 {
-    setValue(value, STATE_PROP, GROUP_SETS_DIALOG_HEADER);
+    setValue(value, STATE_PROP, GROUP_SETS_DIALOG, "header");
 }
 
 void LayoutsSettings::setGamePlayAreaGeometry(const QByteArray &value)


### PR DESCRIPTION
## Short roundup of the initial problem

The settings in `layouts.ini` is organized is a confusing way. Every settings is a single string under the `layout` group.
We use underscores to separate parts of the hierarchy in the string.

<details><summary>current layouts.ini:</summary>

```ini
[layouts]
layouts\deckEditorDbHeader_state=@ByteArray(\0\0\0\xff\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x2\xbc\0\0\0\x6\x1\x1\0\x1\0\0\0\0\0\0\0\0\0\0\0\0\x64\xff\xff\xff\xff\0\0\0\x81\0\0\0\0\0\0\0\x6\0\0\0\xc8\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\x3\xe8\0\0\0\0\x64\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x1)
layouts\deckEditor_CardDatabaseSize=@Size(378 1033)
layouts\deckEditor_CardSize=@Size(298 511)
layouts\deckEditor_DeckSize=@Size(384 1033)
layouts\deckEditor_FilterSize=@Size(298 521)
layouts\deckEditor_PrintingSelectorSize=@Size(627 1033)
layouts\deckEditor_geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0\0\0\0\0\0\0\0\x6\x99\0\0\x4\b\0\0\0\0\0\0\0\0\xff\xff\xff\xff\xff\xff\xff\xff\0\0\0\0\0\0\0\0\x6\xc0\0\0\0\0\0\0\0\0\0\0\x6\x99\0\0\x4\b)
layouts\deckEditor_state=@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\x2\0\0\0\0\0\0\x1z\0\0\x4\t\xfc\x2\0\0\0\x1\xfb\0\0\0&\0\x64\0\x61\0t\0\x61\0\x62\0\x61\0s\0\x65\0\x44\0i\0s\0p\0l\0\x61\0y\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x4\t\0\0\0|\0\0\x13\x88\0\0\0\x1\0\0\x5\x1f\0\0\x4\t\xfc\x2\0\0\0\x1\xfc\0\0\0\0\0\0\x4\t\0\0\x2\v\0\0\x13\x88\xfc\x1\0\0\0\x3\xfc\0\0\x1{\0\0\x1*\0\0\x1\xf\0\0\x13\x88\xfc\x2\0\0\0\x2\xfb\0\0\0\x18\0\x63\0\x61\0r\0\x64\0I\0n\0\x66\0o\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x1\xff\0\0\x1\xf\0\0\x13\x88\xfb\0\0\0\x14\0\x66\0i\0l\0t\0\x65\0r\0\x44\0o\0\x63\0k\x1\0\0\x2\0\0\0\x2\t\0\0\0\xed\0\0\x13\x88\xfb\0\0\0(\0p\0r\0i\0n\0t\0i\0n\0g\0S\0\x65\0l\0\x65\0\x63\0t\0o\0r\0\x44\0o\0\x63\0k\x1\0\0\x2\xa6\0\0\x2s\0\0\x1\xfd\0\0\x13\x88\xfb\0\0\0\x10\0\x64\0\x65\0\x63\0k\0\x44\0o\0\x63\0k\x1\0\0\x5\x1a\0\0\x1\x80\0\0\x1\x80\0\0\x13\x88\0\0\0\0\0\0\x3\x1b\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\0)
layouts\gameplayarea_CardInfoSize=@Size(286 341)
layouts\gameplayarea_MessageLayoutSize=@Size(286 590)
layouts\gameplayarea_PlayerListSize=@Size(286 100)
layouts\gameplayarea_geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0\0\0\0\0\0\0\0\x6\x99\0\0\x4\b\0\0\0\0\0\0\0\0\xff\xff\xff\xff\xff\xff\xff\xff\0\0\0\0\0\0\0\0\x6\xc0\0\0\0\0\0\0\0\0\0\0\x6\x99\0\0\x4\b)
layouts\gameplayarea_state=@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\x1\0\0\0\x1\0\0\x1\x1e\0\0\x4\t\xfc\x2\0\0\0\x3\xfb\0\0\0\x18\0\x63\0\x61\0r\0\x64\0I\0n\0\x66\0o\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x1U\0\0\0\xfd\0\0\x13\x88\xfb\0\0\0\x1c\0p\0l\0\x61\0y\0\x65\0r\0L\0i\0s\0t\0\x44\0o\0\x63\0k\x1\0\0\x1V\0\0\0\x64\0\0\0\x64\0\0\x13\x88\xfb\0\0\0\"\0m\0\x65\0s\0s\0\x61\0g\0\x65\0L\0\x61\0y\0o\0u\0t\0\x44\0o\0\x63\0k\x1\0\0\x1\xbb\0\0\x2N\0\0\0\x97\0\0\x13\x88\0\0\x5{\0\0\x4\t\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\0)
layouts\replayplayarea_CardInfoSize=@Size(286 339)
layouts\replayplayarea_MessageLayoutSize=@Size(286 491)
layouts\replayplayarea_PlayerListSize=@Size(286 100)
layouts\replayplayarea_ReplaySize=@Size(1690 100)
layouts\replayplayarea_geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0\0\0\0\0\0\0\0\x6\x99\0\0\x4\b\0\0\0\0\0\0\0\0\xff\xff\xff\xff\xff\xff\xff\xff\0\0\0\0\0\0\0\0\x6\xc0\0\0\0\0\0\0\0\0\0\0\x6\x99\0\0\x4\b)
layouts\replayplayarea_state=@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\x2\0\0\0\x1\0\0\x1\x1e\0\0\x3\xa4\xfc\x2\0\0\0\x3\xfb\0\0\0\x18\0\x63\0\x61\0r\0\x64\0I\0n\0\x66\0o\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x1S\0\0\0\xfd\0\0\x13\x88\xfb\0\0\0\x1c\0p\0l\0\x61\0y\0\x65\0r\0L\0i\0s\0t\0\x44\0o\0\x63\0k\x1\0\0\x1T\0\0\0\x64\0\0\0\x64\0\0\x13\x88\xfb\0\0\0\"\0m\0\x65\0s\0s\0\x61\0g\0\x65\0L\0\x61\0y\0o\0u\0t\0\x44\0o\0\x63\0k\x1\0\0\x1\xb9\0\0\x1\xeb\0\0\0\x64\0\0\x13\x88\0\0\0\x3\0\0\x6\x9a\0\0\0\x64\xfc\x1\0\0\0\x1\xfb\0\0\0\x14\0r\0\x65\0p\0l\0\x61\0y\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x6\x9a\0\0\x2\xe\0\0\x13\x88\0\0\x5{\0\0\x3\xa4\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\0)
layouts\setsDialogHeader_state=@ByteArray(\0\0\0\xff\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\0\0\0\a\x3\0\0\0\x2\0\0\0\x1\0\0\0\x64\0\0\0\0\0\0\0\x64\0\0\x2\xce\0\0\0\a\x1\x1\0\x1\0\0\0\0\0\0\0\0\0\0\0\0\x64\xff\xff\xff\xff\0\0\0\x81\0\0\0\0\0\0\0\a\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0O\0\0\0\x1\0\0\0\0\0\0\x1\x4\0\0\0\x1\0\0\0\0\0\0\0X\0\0\0\x1\0\0\0\0\0\0\0Q\0\0\0\x1\0\0\0\0\0\0\0\xd2\0\0\0\x1\0\0\0\0\0\0\x3\xe8\0\0\0\0\x64\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x1)
```

</details>

## What will change with this Pull Request?

Changed the setting hierarchy so that the tab is the group.
Area and geometry is under the group, while all widget sizes are under the subgroup widgetSize.

<details><summary>new layouts.ini:</summary>

```ini
[deckEditor]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0\0\0\0\0\0\0\0\x6\x97\0\0\x4\b\0\0\0\0\0\0\0\0\xff\xff\xff\xff\xff\xff\xff\xff\0\0\0\0\0\0\0\0\x6\xc0\0\0\0\0\0\0\0\0\0\0\x6\x97\0\0\x4\b)
state=@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\x2\0\0\0\0\0\0\x1x\0\0\x4\t\xfc\x2\0\0\0\x1\xfb\0\0\0&\0\x64\0\x61\0t\0\x61\0\x62\0\x61\0s\0\x65\0\x44\0i\0s\0p\0l\0\x61\0y\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x4\t\0\0\0|\0\0\x13\x88\0\0\0\x1\0\0\x5\x1f\0\0\x4\t\xfc\x2\0\0\0\x1\xfc\0\0\0\0\0\0\x4\t\0\0\x2\v\0\0\x13\x88\xfc\x1\0\0\0\x3\xfc\0\0\x1y\0\0\x1*\0\0\x1\xf\0\0\x13\x88\xfc\x2\0\0\0\x2\xfb\0\0\0\x18\0\x63\0\x61\0r\0\x64\0I\0n\0\x66\0o\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x2\x1\0\0\x1\xf\0\0\x13\x88\xfb\0\0\0\x14\0\x66\0i\0l\0t\0\x65\0r\0\x44\0o\0\x63\0k\x1\0\0\x2\x2\0\0\x2\a\0\0\0\xed\0\0\x13\x88\xfb\0\0\0(\0p\0r\0i\0n\0t\0i\0n\0g\0S\0\x65\0l\0\x65\0\x63\0t\0o\0r\0\x44\0o\0\x63\0k\x1\0\0\x2\xa4\0\0\x2s\0\0\x1\xfd\0\0\x13\x88\xfb\0\0\0\x10\0\x64\0\x65\0\x63\0k\0\x44\0o\0\x63\0k\x1\0\0\x5\x18\0\0\x1\x80\0\0\x1\x80\0\0\x13\x88\0\0\0\0\0\0\x3\x1b\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\0)
widgetSize\card=@Size(298 513)
widgetSize\cardDatabase=@Size(376 1033)
widgetSize\deck=@Size(384 1033)
widgetSize\filter=@Size(298 519)
widgetSize\printingSelector=@Size(627 1033)

[deckEditorDb]
header\state=@ByteArray(\0\0\0\xff\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x2\xbc\0\0\0\x6\x1\x1\0\x1\0\0\0\0\0\0\0\0\0\0\0\0\x64\xff\xff\xff\xff\0\0\0\x81\0\0\0\0\0\0\0\x6\0\0\0\xc8\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\x3\xe8\0\0\0\0\x64\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x1)

[gamePlayArea]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0\0\0\0\0\0\0\0\x6\x97\0\0\x3\xfd\0\0\0\0\0\0\0\0\xff\xff\xff\xff\xff\xff\xff\xff\0\0\0\0\0\0\0\0\x6\xc0\0\0\0\0\0\0\0\0\0\0\x6\x97\0\0\x3\xfd)
state=@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\x1\0\0\0\x1\0\0\x1\x1e\0\0\x3\xfe\xfc\x2\0\0\0\x3\xfb\0\0\0\x18\0\x63\0\x61\0r\0\x64\0I\0n\0\x66\0o\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x1P\0\0\0\xfd\0\0\x13\x88\xfb\0\0\0\x1c\0p\0l\0\x61\0y\0\x65\0r\0L\0i\0s\0t\0\x44\0o\0\x63\0k\x1\0\0\x1Q\0\0\0\x64\0\0\0\x64\0\0\x13\x88\xfb\0\0\0\"\0m\0\x65\0s\0s\0\x61\0g\0\x65\0L\0\x61\0y\0o\0u\0t\0\x44\0o\0\x63\0k\x1\0\0\x1\xb6\0\0\x2H\0\0\0\x97\0\0\x13\x88\0\0\x5y\0\0\x3\xfe\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\0)
widgetSize\cardInfo=@Size(286 336)
widgetSize\messageLayout=@Size(286 584)
widgetSize\playerList=@Size(286 100)

[replayPlayArea]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0\0\0\0\0\0\0\0\x6\x97\0\0\x4\b\0\0\0\0\0\0\0\0\xff\xff\xff\xff\xff\xff\xff\xff\0\0\0\0\0\0\0\0\x6\xc0\0\0\0\0\0\0\0\0\0\0\x6\x97\0\0\x4\b)
state=@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\x2\0\0\0\x1\0\0\x1\x1e\0\0\x3\xa4\xfc\x2\0\0\0\x3\xfb\0\0\0\x18\0\x63\0\x61\0r\0\x64\0I\0n\0\x66\0o\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x1S\0\0\0\xfd\0\0\x13\x88\xfb\0\0\0\x1c\0p\0l\0\x61\0y\0\x65\0r\0L\0i\0s\0t\0\x44\0o\0\x63\0k\x1\0\0\x1T\0\0\0\x64\0\0\0\x64\0\0\x13\x88\xfb\0\0\0\"\0m\0\x65\0s\0s\0\x61\0g\0\x65\0L\0\x61\0y\0o\0u\0t\0\x44\0o\0\x63\0k\x1\0\0\x1\xb9\0\0\x1\xeb\0\0\0\x64\0\0\x13\x88\0\0\0\x3\0\0\x6\x98\0\0\0\x64\xfc\x1\0\0\0\x1\xfb\0\0\0\x14\0r\0\x65\0p\0l\0\x61\0y\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x6\x98\0\0\x2\xe\0\0\x13\x88\0\0\x5y\0\0\x3\xa4\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\0)
widgetSize\cardInfo=@Size(286 339)
widgetSize\messageLayout=@Size(286 491)
widgetSize\playerList=@Size(286 100)
widgetSize\replay=@Size(1688 100)

[setsDialog]
header\state=@ByteArray(\0\0\0\xff\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\0\0\0\a\x3\0\0\0\x2\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\x64\0\0\x2\xce\0\0\0\a\x1\x1\0\x1\0\0\0\0\0\0\0\0\0\0\0\0\x64\xff\xff\xff\xff\0\0\0\x81\0\0\0\0\0\0\0\a\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0O\0\0\0\x1\0\0\0\0\0\0\x1\x4\0\0\0\x1\0\0\0\0\0\0\0X\0\0\0\x1\0\0\0\0\0\0\0Q\0\0\0\x1\0\0\0\0\0\0\0\xd2\0\0\0\x1\0\0\0\0\0\0\x3\xe8\0\0\0\0\x64\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x1)
```

</details>

This will cause existing layout settings to be invalidated, but we already decided that it's fine to reset the layout settings for this update, since we're already adding new docks.
