### PR TITLE
[Oracle] Move oracle settings to separate file

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -1,6 +1,5 @@
 #include "oracleimporter.h"
 
-#include "client/settings/cache_settings.h"
 #include "libcockatrice/interfaces/noop_card_preference_provider.h"
 #include "libcockatrice/interfaces/noop_card_set_priority_controller.h"
 #include "parsehelpers.h"

--- a/oracle/src/oraclewizard.h
+++ b/oracle/src/oraclewizard.h
@@ -75,6 +75,8 @@ private:
     QString cardSourceUrl;
     QString cardSourceVersion;
 
+    void migrateOracleSettings();
+
 protected:
     void changeEvent(QEvent *event) override;
 };


### PR DESCRIPTION
## Short roundup of the initial problem

Having the download urls in oracle saved in `global.ini` is actually really annoying for [cockswitch](https://github.com/RickyRister/cockswitch). 

I want cockswitch to set the oracle download urls on switch, since then it makes it easy to boot up oracle and update the cards. However, since those settings are in `global.ini`, I have to save and copy the entire `global.ini`, which forces cockswitch to store more settings than I want. If I change a setting that is saved in `global.ini`, I now have to update the files in all the backed-up formats for me to not lose that change when I cockswitch again. 

Since we're moving the settings around right now, might as well also make this change now.

## What will change with this Pull Request?
- Save the oracle-specific settings in `oracle.ini` instead of `global.ini`
  - This just includes the download urls right now
- Write settings migration
  - Migration triggers if `oracle.ini` doesn't exist, and will copy over the three download url settings from `global.ini`