### PR TITLE
[VDE] Reduce spacing in deck view toolbar

### DIFF
--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_display_options_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_display_options_widget.cpp
@@ -7,6 +7,8 @@
 VisualDeckDisplayOptionsWidget::VisualDeckDisplayOptionsWidget(QWidget *parent) : QWidget(parent)
 {
     groupAndSortLayout = new QHBoxLayout(this);
+    groupAndSortLayout->setContentsMargins(0, 0, 0, 0);
+    groupAndSortLayout->setSpacing(3);
     groupAndSortLayout->setAlignment(Qt::AlignLeft);
     this->setLayout(groupAndSortLayout);
 

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -161,6 +161,7 @@ void VisualDeckEditorWidget::initializeDisplayOptionsAndSearchWidget()
 
     displayOptionsAndSearch = new QWidget(this);
     displayOptionsAndSearchLayout = new QHBoxLayout(displayOptionsAndSearch);
+    displayOptionsAndSearchLayout->setContentsMargins(0, 0, 0, 0);
     displayOptionsAndSearchLayout->setAlignment(Qt::AlignLeft);
     displayOptionsAndSearch->setLayout(displayOptionsAndSearchLayout);
 


### PR DESCRIPTION
## Short roundup of the initial problem

There's empty space in the VDE toolbar

## What will change with this Pull Request?

Reduce spacing

## Screenshots

Before

<img width="1687" height="1075" alt="Screenshot 2026-02-06 at 7 23 47 PM" src="https://github.com/user-attachments/assets/ef8f28da-a553-475d-b5bc-d6c0d01d5850" />


After
<img width="1689" height="1075" alt="Screenshot 2026-02-06 at 7 23 29 PM" src="https://github.com/user-attachments/assets/7f9e1f7d-8dd5-4348-a8b1-c0970169c0c7" />
