### PR TITLE
clean up freeDocksSize in tabs with dockWidgets

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_deck_editor.cpp
@@ -190,12 +190,9 @@ void TabDeckEditor::restartLayout()
 /** @brief Frees dock sizes to allow flexible resizing. */
 void TabDeckEditor::freeDocksSize()
 {
-    const QSize minSize(100, 100);
-    const QSize maxSize(5000, 5000);
-
     for (auto dockWidget : dockToActions.keys()) {
-        dockWidget->setMinimumSize(minSize);
-        dockWidget->setMaximumSize(maxSize);
+        dockWidget->setMinimumSize(100, 100);
+        dockWidget->setMaximumSize(5000, 5000);
     }
 }
 

--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -1113,18 +1113,9 @@ void TabGame::loadLayout()
 
 void TabGame::freeDocksSize()
 {
-    cardInfoDock->setMinimumSize(100, 100);
-    cardInfoDock->setMaximumSize(5000, 5000);
-
-    messageLayoutDock->setMinimumSize(100, 100);
-    messageLayoutDock->setMaximumSize(5000, 5000);
-
-    playerListDock->setMinimumSize(100, 100);
-    playerListDock->setMaximumSize(5000, 5000);
-
-    if (replayDock) {
-        replayDock->setMinimumSize(100, 100);
-        replayDock->setMaximumSize(5000, 5000);
+    for (auto dockWidget : dockToActions.keys()) {
+        dockWidget->setMinimumSize(100, 100);
+        dockWidget->setMaximumSize(5000, 5000);
     }
 }
 

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
@@ -249,17 +249,10 @@ void TabDeckEditorVisual::showPrintingSelector()
 /** @brief Set size restrictions for free floating dock widgets. */
 void TabDeckEditorVisual::freeDocksSize()
 {
-    deckDockWidget->setMinimumSize(100, 100);
-    deckDockWidget->setMaximumSize(5000, 5000);
-
-    cardInfoDockWidget->setMinimumSize(100, 100);
-    cardInfoDockWidget->setMaximumSize(5000, 5000);
-
-    filterDockWidget->setMinimumSize(100, 100);
-    filterDockWidget->setMaximumSize(5000, 5000);
-
-    printingSelectorDockWidget->setMinimumSize(100, 100);
-    printingSelectorDockWidget->setMaximumSize(5000, 5000);
+    for (auto dockWidget : dockToActions.keys()) {
+        dockWidget->setMinimumSize(100, 100);
+        dockWidget->setMaximumSize(5000, 5000);
+    }
 }
 
 /** @brief Refreshes keyboard shortcuts for this tab from settings. */


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6499
- Follow-up to #6529

## Short roundup of the initial problem

When we consolidated dockWidget management, we didn't consistently update the `freeDocksSize` method.

## What will change with this Pull Request?
- Clean up the `freeDocksSize` method in all 3 places it's replicated.