### PR TITLE
[LayoutSettings] Refactor how widgetSize settings are managed

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
@@ -75,7 +75,7 @@ AbstractTabDeckEditor::AbstractTabDeckEditor(TabSupervisor *_tabSupervisor) : Ta
             &AbstractTabDeckEditor::refreshShortcuts);
 }
 
-void AbstractTabDeckEditor::registerDockWidget(QMenu *_viewMenu, QDockWidget *widget)
+void AbstractTabDeckEditor::registerDockWidget(QMenu *_viewMenu, QDockWidget *widget, const QSize &defaultSize)
 {
     QMenu *menu = _viewMenu->addMenu(QString());
 
@@ -102,7 +102,7 @@ void AbstractTabDeckEditor::registerDockWidget(QMenu *_viewMenu, QDockWidget *wi
     connect(filter, &VisibilityChangeListener::visibilityChanged, aVisible,
             [aVisible](bool visible) { aVisible->setChecked(visible); });
 
-    dockToActions.insert(widget, {menu, aVisible, aFloating});
+    dockToActions.insert(widget, {menu, aVisible, aFloating, defaultSize});
 }
 
 /**

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
@@ -274,13 +274,14 @@ protected:
         QMenu *menu;        ///< The menu containing the actions
         QAction *aVisible;  ///< The menu action that toggles visibility
         QAction *aFloating; ///< The menu action that toggles floating
+        QSize defaultSize;  ///< The default size of the dock
     };
 
     /**
      * @brief registers a QDockWidget as a managed dock widget. Creates the associated actions and menu, adds them to
      * the viewMenu, and connects those actions to the tab's slots.
      */
-    void registerDockWidget(QMenu *_viewMenu, QDockWidget *widget);
+    void registerDockWidget(QMenu *_viewMenu, QDockWidget *widget, const QSize &defaultSize);
 
     /** @brief Confirms deck open action based on settings and modified state.
      *  @param openInSameTabIfBlank Whether to reuse same tab if blank.

--- a/cockatrice/src/interface/widgets/tabs/tab_game.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.h
@@ -94,6 +94,7 @@ private:
         QMenu *menu;
         QAction *aVisible;
         QAction *aFloating;
+        QSize defaultSize;
     };
 
     QMap<QDockWidget *, DockActions> dockToActions;
@@ -117,7 +118,7 @@ private:
     void createMenuItems();
     void createReplayMenuItems();
     void createViewMenuItems();
-    void registerDockWidget(QMenu *_viewMenu, QDockWidget *widget);
+    void registerDockWidget(QMenu *_viewMenu, QDockWidget *widget, const QSize &defaultSize);
     void createCardInfoDock(bool bReplay = false);
     void createPlayerListDock(bool bReplay = false);
     void createMessageDock(bool bReplay = false);

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
@@ -97,10 +97,10 @@ void TabDeckEditorVisual::createMenus()
 
     viewMenu = new QMenu(this);
 
-    registerDockWidget(viewMenu, cardInfoDockWidget);
-    registerDockWidget(viewMenu, deckDockWidget);
-    registerDockWidget(viewMenu, filterDockWidget);
-    registerDockWidget(viewMenu, printingSelectorDockWidget);
+    registerDockWidget(viewMenu, cardInfoDockWidget, {250, 500});
+    registerDockWidget(viewMenu, deckDockWidget, {250, 360});
+    registerDockWidget(viewMenu, filterDockWidget, {250, 250});
+    registerDockWidget(viewMenu, printingSelectorDockWidget, {525, 250});
 
     viewMenu->addSeparator();
 
@@ -281,17 +281,14 @@ void TabDeckEditorVisual::loadLayout()
         restoreGeometry(layouts.getDeckEditorGeometry());
     }
 
-    cardInfoDockWidget->setMinimumSize(layouts.getDeckEditorCardSize());
-    cardInfoDockWidget->setMaximumSize(layouts.getDeckEditorCardSize());
+    for (auto it = dockToActions.constKeyValueBegin(); it != dockToActions.constKeyValueEnd(); ++it) {
+        auto dockWidget = it->first;
+        auto actions = it->second;
 
-    filterDockWidget->setMinimumSize(layouts.getDeckEditorFilterSize());
-    filterDockWidget->setMaximumSize(layouts.getDeckEditorFilterSize());
-
-    deckDockWidget->setMinimumSize(layouts.getDeckEditorDeckSize());
-    deckDockWidget->setMaximumSize(layouts.getDeckEditorDeckSize());
-
-    printingSelectorDockWidget->setMinimumSize(layouts.getDeckEditorPrintingSelectorSize());
-    printingSelectorDockWidget->setMaximumSize(layouts.getDeckEditorPrintingSelectorSize());
+        QSize size = layouts.getDeckEditorWidgetSize(dockWidget->objectName(), actions.defaultSize);
+        dockWidget->setMinimumSize(size);
+        dockWidget->setMaximumSize(size);
+    }
 
     QTimer::singleShot(100, this, &TabDeckEditorVisual::freeDocksSize);
 }
@@ -356,10 +353,10 @@ bool TabDeckEditorVisual::eventFilter(QObject *o, QEvent *e)
         LayoutsSettings &layouts = SettingsCache::instance().layouts();
         layouts.setDeckEditorLayoutState(saveState());
         layouts.setDeckEditorGeometry(saveGeometry());
-        layouts.setDeckEditorCardSize(cardInfoDockWidget->size());
-        layouts.setDeckEditorFilterSize(filterDockWidget->size());
-        layouts.setDeckEditorDeckSize(deckDockWidget->size());
-        layouts.setDeckEditorPrintingSelectorSize(printingSelectorDockWidget->size());
+
+        for (auto dockWidget : dockToActions.keys()) {
+            layouts.setDeckEditorWidgetSize(dockWidget->objectName(), dockWidget->size());
+        }
     }
     return false;
 }

--- a/libcockatrice_settings/libcockatrice/settings/layouts_settings.cpp
+++ b/libcockatrice_settings/libcockatrice/settings/layouts_settings.cpp
@@ -47,59 +47,15 @@ void LayoutsSettings::setDeckEditorGeometry(const QByteArray &value)
     setValue(value, GEOMETRY_PROP, GROUP_DECK_EDITOR);
 }
 
-QSize LayoutsSettings::getDeckEditorCardDatabaseSize()
+void LayoutsSettings::setDeckEditorWidgetSize(const QString &widgetName, const QSize &value)
 {
-    QVariant previous = getValue("cardDatabase", GROUP_DECK_EDITOR, SIZE_PROP);
-    return previous == QVariant() ? QSize(500, 500) : previous.toSize();
+    setValue(value, widgetName, GROUP_DECK_EDITOR, SIZE_PROP);
 }
 
-void LayoutsSettings::setDeckEditorCardDatabaseSize(const QSize &value)
+QSize LayoutsSettings::getDeckEditorWidgetSize(const QString &widgetName, const QSize &defaultValue)
 {
-    setValue(value, "cardDatabase", GROUP_DECK_EDITOR, SIZE_PROP);
-}
-
-QSize LayoutsSettings::getDeckEditorCardSize()
-{
-    QVariant previous = getValue("card", GROUP_DECK_EDITOR, SIZE_PROP);
-    return previous == QVariant() ? QSize(250, 500) : previous.toSize();
-}
-
-void LayoutsSettings::setDeckEditorCardSize(const QSize &value)
-{
-    setValue(value, "card", GROUP_DECK_EDITOR, SIZE_PROP);
-}
-
-QSize LayoutsSettings::getDeckEditorDeckSize()
-{
-    QVariant previous = getValue("deck", GROUP_DECK_EDITOR, SIZE_PROP);
-    return previous == QVariant() ? QSize(250, 360) : previous.toSize();
-}
-
-void LayoutsSettings::setDeckEditorDeckSize(const QSize &value)
-{
-    setValue(value, "deck", GROUP_DECK_EDITOR, SIZE_PROP);
-}
-
-QSize LayoutsSettings::getDeckEditorPrintingSelectorSize()
-{
-    QVariant previous = getValue("printingSelector", GROUP_DECK_EDITOR, SIZE_PROP);
-    return previous == QVariant() ? QSize(525, 250) : previous.toSize();
-}
-
-void LayoutsSettings::setDeckEditorPrintingSelectorSize(const QSize &value)
-{
-    setValue(value, "printingSelector", GROUP_DECK_EDITOR, SIZE_PROP);
-}
-
-QSize LayoutsSettings::getDeckEditorFilterSize()
-{
-    QVariant previous = getValue("filter", GROUP_DECK_EDITOR, SIZE_PROP);
-    return previous == QVariant() ? QSize(250, 250) : previous.toSize();
-}
-
-void LayoutsSettings::setDeckEditorFilterSize(const QSize &value)
-{
-    setValue(value, "filter", GROUP_DECK_EDITOR, SIZE_PROP);
+    QVariant previous = getValue(widgetName, GROUP_DECK_EDITOR, SIZE_PROP);
+    return previous == QVariant() ? defaultValue : previous.toSize();
 }
 
 QByteArray LayoutsSettings::getDeckEditorDbHeaderState()
@@ -162,37 +118,15 @@ QByteArray LayoutsSettings::getGamePlayAreaGeometry()
     return getValue(GEOMETRY_PROP, GROUP_GAME_PLAY_AREA).toByteArray();
 }
 
-QSize LayoutsSettings::getGameCardInfoSize()
+void LayoutsSettings::setGamePlayAreaWidgetSize(const QString &widgetName, const QSize &value)
 {
-    QVariant previous = getValue("cardInfo", GROUP_GAME_PLAY_AREA, SIZE_PROP);
-    return previous == QVariant() ? QSize(250, 360) : previous.toSize();
+    setValue(value, widgetName, GROUP_GAME_PLAY_AREA, SIZE_PROP);
 }
 
-void LayoutsSettings::setGameCardInfoSize(const QSize &value)
+QSize LayoutsSettings::getGamePlayAreaWidgetSize(const QString &widgetName, const QSize &defaultValue)
 {
-    setValue(value, "cardInfo", GROUP_GAME_PLAY_AREA, SIZE_PROP);
-}
-
-QSize LayoutsSettings::getGameMessageLayoutSize()
-{
-    QVariant previous = getValue("messageLayout", GROUP_GAME_PLAY_AREA, SIZE_PROP);
-    return previous == QVariant() ? QSize(250, 250) : previous.toSize();
-}
-
-void LayoutsSettings::setGameMessageLayoutSize(const QSize &value)
-{
-    setValue(value, "messageLayout", GROUP_GAME_PLAY_AREA, SIZE_PROP);
-}
-
-QSize LayoutsSettings::getGamePlayerListSize()
-{
-    QVariant previous = getValue("playerList", GROUP_GAME_PLAY_AREA, SIZE_PROP);
-    return previous == QVariant() ? QSize(250, 50) : previous.toSize();
-}
-
-void LayoutsSettings::setGamePlayerListSize(const QSize &value)
-{
-    setValue(value, "playerList", GROUP_GAME_PLAY_AREA, SIZE_PROP);
+    QVariant previous = getValue(widgetName, GROUP_GAME_PLAY_AREA, SIZE_PROP);
+    return previous == QVariant() ? defaultValue : previous.toSize();
 }
 
 void LayoutsSettings::setReplayPlayAreaGeometry(const QByteArray &value)
@@ -215,46 +149,13 @@ QByteArray LayoutsSettings::getReplayPlayAreaGeometry()
     return getValue(GEOMETRY_PROP, GROUP_REPLAY_PLAY_AREA).toByteArray();
 }
 
-QSize LayoutsSettings::getReplayCardInfoSize()
+void LayoutsSettings::setReplayPlayAreaWidgetSize(const QString &widgetName, const QSize &value)
 {
-    QVariant previous = getValue("cardInfo", GROUP_REPLAY_PLAY_AREA, SIZE_PROP);
-    return previous == QVariant() ? QSize(250, 360) : previous.toSize();
+    setValue(value, widgetName, GROUP_REPLAY_PLAY_AREA, SIZE_PROP);
 }
 
-void LayoutsSettings::setReplayCardInfoSize(const QSize &value)
+QSize LayoutsSettings::getReplayPlayAreaWidgetSize(const QString &widgetName, const QSize &defaultValue)
 {
-    setValue(value, "cardInfo", GROUP_REPLAY_PLAY_AREA, SIZE_PROP);
-}
-
-QSize LayoutsSettings::getReplayMessageLayoutSize()
-{
-    QVariant previous = getValue("messageLayout", GROUP_REPLAY_PLAY_AREA, SIZE_PROP);
-    return previous == QVariant() ? QSize(250, 200) : previous.toSize();
-}
-
-void LayoutsSettings::setReplayMessageLayoutSize(const QSize &value)
-{
-    setValue(value, "messageLayout", GROUP_REPLAY_PLAY_AREA, SIZE_PROP);
-}
-
-QSize LayoutsSettings::getReplayPlayerListSize()
-{
-    QVariant previous = getValue("playerList", GROUP_REPLAY_PLAY_AREA, SIZE_PROP);
-    return previous == QVariant() ? QSize(250, 50) : previous.toSize();
-}
-
-void LayoutsSettings::setReplayPlayerListSize(const QSize &value)
-{
-    setValue(value, "playerList", GROUP_REPLAY_PLAY_AREA, SIZE_PROP);
-}
-
-QSize LayoutsSettings::getReplayReplaySize()
-{
-    QVariant previous = getValue("replay", GROUP_REPLAY_PLAY_AREA, SIZE_PROP);
-    return previous == QVariant() ? QSize(900, 100) : previous.toSize();
-}
-
-void LayoutsSettings::setReplayReplaySize(const QSize &value)
-{
-    setValue(value, "replay", GROUP_REPLAY_PLAY_AREA, SIZE_PROP);
+    QVariant previous = getValue(widgetName, GROUP_REPLAY_PLAY_AREA, SIZE_PROP);
+    return previous == QVariant() ? defaultValue : previous.toSize();
 }

--- a/libcockatrice_settings/libcockatrice/settings/layouts_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/layouts_settings.h
@@ -21,11 +21,8 @@ public:
 
     void setDeckEditorLayoutState(const QByteArray &value);
     void setDeckEditorGeometry(const QByteArray &value);
-    void setDeckEditorCardDatabaseSize(const QSize &value);
-    void setDeckEditorCardSize(const QSize &value);
-    void setDeckEditorDeckSize(const QSize &value);
-    void setDeckEditorPrintingSelectorSize(const QSize &value);
-    void setDeckEditorFilterSize(const QSize &value);
+    void setDeckEditorWidgetSize(const QString &widgetName, const QSize &value);
+
     void setDeckEditorDbHeaderState(const QByteArray &value);
     void setSetsDialogHeaderState(const QByteArray &value);
     void setSetsDialogGeometry(const QByteArray &value);
@@ -33,26 +30,18 @@ public:
 
     void setGamePlayAreaGeometry(const QByteArray &value);
     void setGamePlayAreaState(const QByteArray &value);
-    void setGameCardInfoSize(const QSize &value);
-    void setGameMessageLayoutSize(const QSize &value);
-    void setGamePlayerListSize(const QSize &value);
+    void setGamePlayAreaWidgetSize(const QString &widgetName, const QSize &value);
 
     void setReplayPlayAreaGeometry(const QByteArray &value);
     void setReplayPlayAreaState(const QByteArray &value);
-    void setReplayCardInfoSize(const QSize &value);
-    void setReplayMessageLayoutSize(const QSize &value);
-    void setReplayPlayerListSize(const QSize &value);
-    void setReplayReplaySize(const QSize &value);
+    void setReplayPlayAreaWidgetSize(const QString &widgetName, const QSize &value);
 
     QByteArray getMainWindowGeometry();
 
     QByteArray getDeckEditorLayoutState();
     QByteArray getDeckEditorGeometry();
-    QSize getDeckEditorCardDatabaseSize();
-    QSize getDeckEditorCardSize();
-    QSize getDeckEditorDeckSize();
-    QSize getDeckEditorPrintingSelectorSize();
-    QSize getDeckEditorFilterSize();
+    QSize getDeckEditorWidgetSize(const QString &widgetName, const QSize &defaultValue = {});
+
     QByteArray getDeckEditorDbHeaderState();
     QByteArray getSetsDialogHeaderState();
     QByteArray getSetsDialogGeometry();
@@ -60,16 +49,11 @@ public:
 
     QByteArray getGamePlayAreaLayoutState();
     QByteArray getGamePlayAreaGeometry();
-    QSize getGameCardInfoSize();
-    QSize getGameMessageLayoutSize();
-    QSize getGamePlayerListSize();
+    QSize getGamePlayAreaWidgetSize(const QString &widgetName, const QSize &defaultValue = {});
 
     QByteArray getReplayPlayAreaLayoutState();
     QByteArray getReplayPlayAreaGeometry();
-    QSize getReplayCardInfoSize();
-    QSize getReplayMessageLayoutSize();
-    QSize getReplayPlayerListSize();
-    QSize getReplayReplaySize();
+    QSize getReplayPlayAreaWidgetSize(const QString &widgetName, const QSize &defaultValue = {});
 signals:
 
 public slots:


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to 
  - #6586
  - #6587

## Short roundup of the initial problem

There's a nicer way to manage the widgetSize settings for each tab so that it reuses more code.

<details><summary>current layouts.ini:</summary>

```ini
[deckEditor]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0\0\0\0\0\0\0\0\x6\x97\0\0\x4\b\0\0\0\0\0\0\0\0\xff\xff\xff\xff\xff\xff\xff\xff\0\0\0\0\0\0\0\0\x6\xc0\0\0\0\0\0\0\0\0\0\0\x6\x97\0\0\x4\b)
state=@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\x2\0\0\0\0\0\0\x1x\0\0\x4\t\xfc\x2\0\0\0\x1\xfb\0\0\0&\0\x64\0\x61\0t\0\x61\0\x62\0\x61\0s\0\x65\0\x44\0i\0s\0p\0l\0\x61\0y\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x4\t\0\0\0|\0\0\x13\x88\0\0\0\x1\0\0\x5\x1f\0\0\x4\t\xfc\x2\0\0\0\x1\xfc\0\0\0\0\0\0\x4\t\0\0\x2\v\0\0\x13\x88\xfc\x1\0\0\0\x3\xfc\0\0\x1y\0\0\x1*\0\0\x1\xf\0\0\x13\x88\xfc\x2\0\0\0\x2\xfb\0\0\0\x18\0\x63\0\x61\0r\0\x64\0I\0n\0\x66\0o\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x2\x1\0\0\x1\xf\0\0\x13\x88\xfb\0\0\0\x14\0\x66\0i\0l\0t\0\x65\0r\0\x44\0o\0\x63\0k\x1\0\0\x2\x2\0\0\x2\a\0\0\0\xed\0\0\x13\x88\xfb\0\0\0(\0p\0r\0i\0n\0t\0i\0n\0g\0S\0\x65\0l\0\x65\0\x63\0t\0o\0r\0\x44\0o\0\x63\0k\x1\0\0\x2\xa4\0\0\x2s\0\0\x1\xfd\0\0\x13\x88\xfb\0\0\0\x10\0\x64\0\x65\0\x63\0k\0\x44\0o\0\x63\0k\x1\0\0\x5\x18\0\0\x1\x80\0\0\x1\x80\0\0\x13\x88\0\0\0\0\0\0\x3\x1b\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\0)
widgetSize\card=@Size(298 513)
widgetSize\cardDatabase=@Size(376 1033)
widgetSize\deck=@Size(384 1033)
widgetSize\filter=@Size(298 519)
widgetSize\printingSelector=@Size(627 1033)

[deckEditorDb]
header\state=@ByteArray(\0\0\0\xff\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x2\xbc\0\0\0\x6\x1\x1\0\x1\0\0\0\0\0\0\0\0\0\0\0\0\x64\xff\xff\xff\xff\0\0\0\x81\0\0\0\0\0\0\0\x6\0\0\0\xc8\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\x3\xe8\0\0\0\0\x64\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x1)

[gamePlayArea]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0\0\0\0\0\0\0\0\x6\x97\0\0\x3\xfd\0\0\0\0\0\0\0\0\xff\xff\xff\xff\xff\xff\xff\xff\0\0\0\0\0\0\0\0\x6\xc0\0\0\0\0\0\0\0\0\0\0\x6\x97\0\0\x3\xfd)
state=@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\x1\0\0\0\x1\0\0\x1\x1e\0\0\x3\xfe\xfc\x2\0\0\0\x3\xfb\0\0\0\x18\0\x63\0\x61\0r\0\x64\0I\0n\0\x66\0o\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x1P\0\0\0\xfd\0\0\x13\x88\xfb\0\0\0\x1c\0p\0l\0\x61\0y\0\x65\0r\0L\0i\0s\0t\0\x44\0o\0\x63\0k\x1\0\0\x1Q\0\0\0\x64\0\0\0\x64\0\0\x13\x88\xfb\0\0\0\"\0m\0\x65\0s\0s\0\x61\0g\0\x65\0L\0\x61\0y\0o\0u\0t\0\x44\0o\0\x63\0k\x1\0\0\x1\xb6\0\0\x2H\0\0\0\x97\0\0\x13\x88\0\0\x5y\0\0\x3\xfe\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\0)
widgetSize\cardInfo=@Size(286 336)
widgetSize\messageLayout=@Size(286 584)
widgetSize\playerList=@Size(286 100)

[replayPlayArea]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0\0\0\0\0\0\0\0\x6\x97\0\0\x4\b\0\0\0\0\0\0\0\0\xff\xff\xff\xff\xff\xff\xff\xff\0\0\0\0\0\0\0\0\x6\xc0\0\0\0\0\0\0\0\0\0\0\x6\x97\0\0\x4\b)
state=@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\x2\0\0\0\x1\0\0\x1\x1e\0\0\x3\xa4\xfc\x2\0\0\0\x3\xfb\0\0\0\x18\0\x63\0\x61\0r\0\x64\0I\0n\0\x66\0o\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x1S\0\0\0\xfd\0\0\x13\x88\xfb\0\0\0\x1c\0p\0l\0\x61\0y\0\x65\0r\0L\0i\0s\0t\0\x44\0o\0\x63\0k\x1\0\0\x1T\0\0\0\x64\0\0\0\x64\0\0\x13\x88\xfb\0\0\0\"\0m\0\x65\0s\0s\0\x61\0g\0\x65\0L\0\x61\0y\0o\0u\0t\0\x44\0o\0\x63\0k\x1\0\0\x1\xb9\0\0\x1\xeb\0\0\0\x64\0\0\x13\x88\0\0\0\x3\0\0\x6\x98\0\0\0\x64\xfc\x1\0\0\0\x1\xfb\0\0\0\x14\0r\0\x65\0p\0l\0\x61\0y\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x6\x98\0\0\x2\xe\0\0\x13\x88\0\0\x5y\0\0\x3\xa4\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\0)
widgetSize\cardInfo=@Size(286 339)
widgetSize\messageLayout=@Size(286 491)
widgetSize\playerList=@Size(286 100)
widgetSize\replay=@Size(1688 100)

[setsDialog]
header\state=@ByteArray(\0\0\0\xff\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\0\0\0\a\x3\0\0\0\x2\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\x64\0\0\x2\xce\0\0\0\a\x1\x1\0\x1\0\0\0\0\0\0\0\0\0\0\0\0\x64\xff\xff\xff\xff\0\0\0\x81\0\0\0\0\0\0\0\a\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0O\0\0\0\x1\0\0\0\0\0\0\x1\x4\0\0\0\x1\0\0\0\0\0\0\0X\0\0\0\x1\0\0\0\0\0\0\0Q\0\0\0\x1\0\0\0\0\0\0\0\xd2\0\0\0\x1\0\0\0\0\0\0\x3\xe8\0\0\0\0\x64\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x1)
```

</details>

## What will change with this Pull Request?

- `LayoutSettings` now only has a single `setXXXWidgetSize` method per tab, which takes the widgetName as a param
  - Updating settings now involves looping through the dockWidgets instead of calling each method manually.
- `getXXXWidgetSize` now takes a defaultSize param, so the default size is managed by the calling tab
  - Update `DockActions` to also store the default size for the dock

Note that this does change the settings names for the widgetSize settings. However, since we haven't released since that PR and now, it should be fine.

<details><summary>new layouts.ini:</summary>

```ini
[deckEditor]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0\0\0\0\0\0\0\0\ay\0\0\x3\xe5\0\0\0\0\0\0\0\0\xff\xff\xff\xff\xff\xff\xff\xff\0\0\0\x1\0\0\0\0\a\x80\0\0\0\0\0\0\0\0\0\0\ay\0\0\x3\xe5)
state=@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\x2\0\0\0\0\0\0\x2\xeb\0\0\x3\xe6\xfc\x2\0\0\0\x1\xfb\0\0\0&\0\x64\0\x61\0t\0\x61\0\x62\0\x61\0s\0\x65\0\x44\0i\0s\0p\0l\0\x61\0y\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x3\xe6\0\0\0|\0\0\x13\x88\0\0\0\x1\0\0\x4\x8e\0\0\x3\xe6\xfc\x2\0\0\0\x1\xfc\0\0\0\0\0\0\x3\xe6\0\0\x2\v\0\0\x13\x88\xfc\x1\0\0\0\x3\xfc\0\0\x2\xec\0\0\x1\xf\0\0\x1\xf\0\0\x13\x88\xfc\x2\0\0\0\x2\xfb\0\0\0\x18\0\x63\0\x61\0r\0\x64\0I\0n\0\x66\0o\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x1\xef\0\0\x1\xf\0\0\x13\x88\xfb\0\0\0\x14\0\x66\0i\0l\0t\0\x65\0r\0\x44\0o\0\x63\0k\x1\0\0\x1\xf0\0\0\x1\xf6\0\0\0\xed\0\0\x13\x88\xfb\0\0\0(\0p\0r\0i\0n\0t\0i\0n\0g\0S\0\x65\0l\0\x65\0\x63\0t\0o\0r\0\x44\0o\0\x63\0k\x1\0\0\x3\xfc\0\0\x1\xfd\0\0\x1\xfd\0\0\x13\x88\xfb\0\0\0\x10\0\x64\0\x65\0\x63\0k\0\x44\0o\0\x63\0k\x1\0\0\x5\xfa\0\0\x1\x80\0\0\x1\x80\0\0\x13\x88\0\0\0\0\0\0\x3\xe6\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\0)
widgetSize\cardInfoDock=@Size(271 495)
widgetSize\databaseDisplayDock=@Size(747 998)
widgetSize\deckDock=@Size(384 998)
widgetSize\filterDock=@Size(271 502)
widgetSize\printingSelectorDock=@Size(509 998)

[deckEditorDb]
header\state=@ByteArray(\0\0\0\xff\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x2\xbc\0\0\0\x6\x1\x1\0\x1\0\0\0\0\0\0\0\0\0\0\0\0\x64\xff\xff\xff\xff\0\0\0\x81\0\0\0\0\0\0\0\x6\0\0\0\xc8\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\x3\xe8\0\0\0\0\x64\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x1)

[gamePlayArea]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0\0\0\0\0\0\0\0\ay\0\0\x3\xe5\0\0\0\0\0\0\0\0\xff\xff\xff\xff\xff\xff\xff\xff\0\0\0\x1\0\0\0\0\a\x80\0\0\0\0\0\0\0\0\0\0\ay\0\0\x3\xe5)
state="@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\x1\0\0\0\x1\0\0\0\xfa\0\0\x3\xe6\xfc\x2\0\0\0\x3\xfb\0\0\0\x18\0\x63\0\x61\0r\0\x64\0I\0n\0\x66\0o\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x1T\0\0\0\xfd\0\0\x13\x88\xfb\0\0\0\x1c\0p\0l\0\x61\0y\0\x65\0r\0L\0i\0s\0t\0\x44\0o\0\x63\0k\x1\0\0\x1U\0\0\0\x64\0\0\0\x64\0\0\x13\x88\xfb\0\0\0\"\0m\0\x65\0s\0s\0\x61\0g\0\x65\0L\0\x61\0y\0o\0u\0t\0\x44\0o\0\x63\0k\x1\0\0\x1\xba\0\0\x2,\0\0\0\x97\0\0\x13\x88\0\0\x6\x7f\0\0\x3\xe6\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\0)"
widgetSize\cardInfoDock=@Size(250 340)
widgetSize\messageLayoutDock=@Size(250 556)
widgetSize\playerListDock=@Size(250 100)

[mainWindow]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\xff\xff\xff\x9e\xff\xff\xfb\xe1\0\0\a\x1d\xff\xff\xff\xff\0\0\0\0\xff\xff\xfb\xfe\0\0\x3\x44\xff\xff\xff\xfe\0\0\0\x1\x2\0\0\0\a\x80\xff\xff\xff\x9e\xff\xff\xfb\xfd\0\0\a\x1d\xff\xff\xff\xff)

[replayPlayArea]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0\0\0\0\0\0\0\0\ay\0\0\x3\xe5\0\0\0\0\0\0\0\0\xff\xff\xff\xff\xff\xff\xff\xff\0\0\0\x1\0\0\0\0\a\x80\0\0\0\0\0\0\0\0\0\0\ay\0\0\x3\xe5)
state=@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\x2\0\0\0\x1\0\0\0\xfa\0\0\x3\x81\xfc\x2\0\0\0\x3\xfb\0\0\0\x18\0\x63\0\x61\0r\0\x64\0I\0n\0\x66\0o\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x1h\0\0\0\xfd\0\0\x13\x88\xfb\0\0\0\x1c\0p\0l\0\x61\0y\0\x65\0r\0L\0i\0s\0t\0\x44\0o\0\x63\0k\0\0\0\x1S\0\0\0\x64\0\0\0\x64\0\0\x13\x88\xfb\0\0\0\"\0m\0\x65\0s\0s\0\x61\0g\0\x65\0L\0\x61\0y\0o\0u\0t\0\x44\0o\0\x63\0k\x1\0\0\x1i\0\0\x2\x18\0\0\0\x64\0\0\x13\x88\0\0\0\x3\0\0\az\0\0\0\x64\xfc\x1\0\0\0\x1\xfb\0\0\0\x14\0r\0\x65\0p\0l\0\x61\0y\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\az\0\0\x2\xe\0\0\x13\x88\0\0\x6\x7f\0\0\x3\x81\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\0)
widgetSize\cardInfoDock=@Size(250 360)
widgetSize\messageLayoutDock=@Size(250 536)
widgetSize\playerListDock=@Size(250 100)
widgetSize\replayDock=@Size(1914 100)

[setsDialog]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\x1\xc0\0\0\x1:\0\0\x4\xdf\0\0\x3|\0\0\x1\xc0\0\0\x1V\0\0\x4\xdf\0\0\x3|\0\0\0\0\0\0\0\0\x6\xc0\0\0\x1\xc0\0\0\x1V\0\0\x4\xdf\0\0\x3|)
header\state=@ByteArray(\0\0\0\xff\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\0\0\0\a\x3\0\0\0\x2\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\x64\0\0\x2\xce\0\0\0\a\x1\x1\0\x1\0\0\0\0\0\0\0\0\0\0\0\0\x64\xff\xff\xff\xff\0\0\0\x81\0\0\0\0\0\0\0\a\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0O\0\0\0\x1\0\0\0\0\0\0\x1\x4\0\0\0\x1\0\0\0\0\0\0\0X\0\0\0\x1\0\0\0\0\0\0\0Q\0\0\0\x1\0\0\0\0\0\0\0\xd2\0\0\0\x1\0\0\0\0\0\0\x3\xe8\0\0\0\0\x64\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x1)

[tokenDialog]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\x2\x1a\0\0\x1)\0\0\x4q\0\0\x3@\0\0\x2\x1a\0\0\x1\x45\0\0\x4q\0\0\x3@\0\0\0\0\0\0\0\0\x6\xc0\0\0\x2\x1a\0\0\x1\x45\0\0\x4q\0\0\x3@)
```

</details>

