### PR TITLE
[VDE] Separate layout settings for visual deck editor

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
@@ -266,19 +266,19 @@ void TabDeckEditorVisual::refreshShortcuts()
 void TabDeckEditorVisual::loadLayout()
 {
     LayoutsSettings &layouts = SettingsCache::instance().layouts();
-    auto layoutState = layouts.getDeckEditorLayoutState();
+    auto layoutState = layouts.getVisualDeckEditorLayoutState();
     if (layoutState.isNull()) {
         restartLayout();
     } else {
         restoreState(layoutState);
-        restoreGeometry(layouts.getDeckEditorGeometry());
+        restoreGeometry(layouts.getVisualDeckEditorGeometry());
     }
 
     for (auto it = dockToActions.constKeyValueBegin(); it != dockToActions.constKeyValueEnd(); ++it) {
         auto dockWidget = it->first;
         auto actions = it->second;
 
-        QSize size = layouts.getDeckEditorWidgetSize(dockWidget->objectName(), actions.defaultSize);
+        QSize size = layouts.getVisualDeckEditorWidgetSize(dockWidget->objectName(), actions.defaultSize);
         dockWidget->setMinimumSize(size);
         dockWidget->setMaximumSize(size);
     }
@@ -344,11 +344,11 @@ bool TabDeckEditorVisual::eventFilter(QObject *o, QEvent *e)
 {
     if (o == this && e->type() == QEvent::Hide) {
         LayoutsSettings &layouts = SettingsCache::instance().layouts();
-        layouts.setDeckEditorLayoutState(saveState());
-        layouts.setDeckEditorGeometry(saveGeometry());
+        layouts.setVisualDeckEditorLayoutState(saveState());
+        layouts.setVisualDeckEditorGeometry(saveGeometry());
 
         for (auto dockWidget : dockToActions.keys()) {
-            layouts.setDeckEditorWidgetSize(dockWidget->objectName(), dockWidget->size());
+            layouts.setVisualDeckEditorWidgetSize(dockWidget->objectName(), dockWidget->size());
         }
     }
     return false;

--- a/libcockatrice_settings/libcockatrice/settings/layouts_settings.cpp
+++ b/libcockatrice_settings/libcockatrice/settings/layouts_settings.cpp
@@ -6,6 +6,7 @@ const static QString SIZE_PROP = "widgetSize";
 
 const static QString GROUP_MAIN_WINDOW = "mainWindow";
 const static QString GROUP_DECK_EDITOR = "deckEditor";
+const static QString GROUP_VISUAL_DECK_EDITOR = "visualDeckEditor";
 const static QString GROUP_DECK_EDITOR_DB = "deckEditorDb";
 const static QString GROUP_SETS_DIALOG = "setsDialog";
 const static QString GROUP_TOKEN_DIALOG = "tokenDialog";
@@ -55,6 +56,37 @@ void LayoutsSettings::setDeckEditorWidgetSize(const QString &widgetName, const Q
 QSize LayoutsSettings::getDeckEditorWidgetSize(const QString &widgetName, const QSize &defaultValue)
 {
     QVariant previous = getValue(widgetName, GROUP_DECK_EDITOR, SIZE_PROP);
+    return previous == QVariant() ? defaultValue : previous.toSize();
+}
+
+QByteArray LayoutsSettings::getVisualDeckEditorLayoutState()
+{
+    return getValue(STATE_PROP, GROUP_VISUAL_DECK_EDITOR).toByteArray();
+}
+
+void LayoutsSettings::setVisualDeckEditorLayoutState(const QByteArray &value)
+{
+    setValue(value, STATE_PROP, GROUP_VISUAL_DECK_EDITOR);
+}
+
+QByteArray LayoutsSettings::getVisualDeckEditorGeometry()
+{
+    return getValue(GEOMETRY_PROP, GROUP_VISUAL_DECK_EDITOR).toByteArray();
+}
+
+void LayoutsSettings::setVisualDeckEditorGeometry(const QByteArray &value)
+{
+    setValue(value, GEOMETRY_PROP, GROUP_VISUAL_DECK_EDITOR);
+}
+
+void LayoutsSettings::setVisualDeckEditorWidgetSize(const QString &widgetName, const QSize &value)
+{
+    setValue(value, widgetName, GROUP_VISUAL_DECK_EDITOR, SIZE_PROP);
+}
+
+QSize LayoutsSettings::getVisualDeckEditorWidgetSize(const QString &widgetName, const QSize &defaultValue)
+{
+    QVariant previous = getValue(widgetName, GROUP_VISUAL_DECK_EDITOR, SIZE_PROP);
     return previous == QVariant() ? defaultValue : previous.toSize();
 }
 

--- a/libcockatrice_settings/libcockatrice/settings/layouts_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/layouts_settings.h
@@ -23,6 +23,10 @@ public:
     void setDeckEditorGeometry(const QByteArray &value);
     void setDeckEditorWidgetSize(const QString &widgetName, const QSize &value);
 
+    void setVisualDeckEditorLayoutState(const QByteArray &value);
+    void setVisualDeckEditorGeometry(const QByteArray &value);
+    void setVisualDeckEditorWidgetSize(const QString &widgetName, const QSize &value);
+
     void setDeckEditorDbHeaderState(const QByteArray &value);
     void setSetsDialogHeaderState(const QByteArray &value);
     void setSetsDialogGeometry(const QByteArray &value);
@@ -41,6 +45,10 @@ public:
     QByteArray getDeckEditorLayoutState();
     QByteArray getDeckEditorGeometry();
     QSize getDeckEditorWidgetSize(const QString &widgetName, const QSize &defaultValue = {});
+
+    QByteArray getVisualDeckEditorLayoutState();
+    QByteArray getVisualDeckEditorGeometry();
+    QSize getVisualDeckEditorWidgetSize(const QString &widgetName, const QSize &defaultValue = {});
 
     QByteArray getDeckEditorDbHeaderState();
     QByteArray getSetsDialogHeaderState();


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6594

## Short roundup of the initial problem

Currently, the classic deck editor and the visual deck editor tabs share the same layout settings, which leads to graphical bugs when one tab tries to load with the settings of another.

## What will change with this Pull Request?

- Create a separate set of settings for vde in `LayoutSettings`
- Update vde to use the new settings

<details><summary>new layouts.ini:</summary>

```ini
[deckEditor]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0\0\0\0\0\0\0\0\ay\0\0\x3\xe5\0\0\0\0\0\0\0\0\xff\xff\xff\xff\xff\xff\xff\xff\0\0\0\x1\0\0\0\0\a\x80\0\0\0\0\0\0\0\0\0\0\ay\0\0\x3\xe5)
state=@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\x2\0\0\0\0\0\0\x2\xeb\0\0\x3\xe6\xfc\x2\0\0\0\x1\xfb\0\0\0&\0\x64\0\x61\0t\0\x61\0\x62\0\x61\0s\0\x65\0\x44\0i\0s\0p\0l\0\x61\0y\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x3\xe6\0\0\0\xb4\0\0\x13\x88\0\0\0\x1\0\0\x4\x8e\0\0\x3\xe6\xfc\x2\0\0\0\x1\xfc\0\0\0\0\0\0\x3\xe6\0\0\x2\x1\0\0\x13\x88\xfc\x1\0\0\0\x3\xfc\0\0\x2\xec\0\0\x1\xe2\0\0\0\xb7\0\0\x13\x88\xfc\x2\0\0\0\x2\xfb\0\0\0\x18\0\x63\0\x61\0r\0\x64\0I\0n\0\x66\0o\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x3\xe6\0\0\x1\xf\0\0\x13\x88\xfb\0\0\0\x14\0\x66\0i\0l\0t\0\x65\0r\0\x44\0o\0\x63\0k\0\0\0\x1\xf0\0\0\x1\xf6\0\0\0\xed\0\0\x13\x88\xfb\0\0\0(\0p\0r\0i\0n\0t\0i\0n\0g\0S\0\x65\0l\0\x65\0\x63\0t\0o\0r\0\x44\0o\0\x63\0k\x2\0\0\x3\x9d\xff\xff\xfc\x17\0\0\x1\xfd\0\0\x3\xe6\xfb\0\0\0\x10\0\x64\0\x65\0\x63\0k\0\x44\0o\0\x63\0k\x1\0\0\x4\xcf\0\0\x2\xab\0\0\x1\x80\0\0\x13\x88\0\0\0\0\0\0\x3\xe6\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\0)
widgetSize\cardInfoDock=@Size(482 998)
widgetSize\databaseDisplayDock=@Size(747 998)
widgetSize\deckDock=@Size(683 998)
widgetSize\filterDock=@Size(482 502)
widgetSize\printingSelectorDock=@Size(509 998)

[deckEditorDb]
header\state=@ByteArray(\0\0\0\xff\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x2\xbc\0\0\0\x6\x1\x1\0\x1\0\0\0\0\0\0\0\0\0\0\0\0\x64\xff\xff\xff\xff\0\0\0\x81\0\0\0\0\0\0\0\x6\0\0\0\xc8\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\0\0\0\x3\xe8\0\0\0\0\x64\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x1)

[gamePlayArea]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0\0\0\0\0\0\0\0\ay\0\0\x3\xe5\0\0\0\0\0\0\0\0\xff\xff\xff\xff\xff\xff\xff\xff\0\0\0\x1\0\0\0\0\a\x80\0\0\0\0\0\0\0\0\0\0\ay\0\0\x3\xe5)
state=@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\x1\0\0\0\x1\0\0\x1\x9b\0\0\x3\xe6\xfc\x2\0\0\0\x3\xfb\0\0\0\x18\0\x63\0\x61\0r\0\x64\0I\0n\0\x66\0o\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x2\x64\0\0\0\xfd\0\0\x13\x88\xfb\0\0\0\x1c\0p\0l\0\x61\0y\0\x65\0r\0L\0i\0s\0t\0\x44\0o\0\x63\0k\0\0\0\x1U\0\0\0\x64\0\0\0\x64\0\0\x13\x88\xfb\0\0\0\"\0m\0\x65\0s\0s\0\x61\0g\0\x65\0L\0\x61\0y\0o\0u\0t\0\x44\0o\0\x63\0k\x1\0\0\x2\x65\0\0\x1\x81\0\0\0\x97\0\0\x13\x88\0\0\x5\xde\0\0\x3\xe6\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\0)
widgetSize\cardInfo=@Size(411 612)
widgetSize\cardInfoDock=@Size(250 340)
widgetSize\messageLayout=@Size(411 385)
widgetSize\messageLayoutDock=@Size(250 556)
widgetSize\playerList=@Size(250 100)
widgetSize\playerListDock=@Size(250 100)

[mainWindow]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\xff\xff\xff\x9e\xff\xff\xfb\xe1\0\0\a\x1d\xff\xff\xff\xff\0\0\0\0\xff\xff\xfb\xfd\0\0\x5\xd3\0\0\0\"\0\0\0\x1\x2\0\0\0\a\x80\xff\xff\xff\x9e\xff\xff\xfb\xfd\0\0\a\x1d\xff\xff\xff\xff)

[replayPlayArea]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0\0\0\0\0\0\0\0\ay\0\0\x3\xe5\0\0\0\0\0\0\0\0\xff\xff\xff\xff\xff\xff\xff\xff\0\0\0\x1\0\0\0\0\a\x80\0\0\0\0\0\0\0\0\0\0\ay\0\0\x3\xe5)
state=@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\x2\0\0\0\x1\0\0\0\xfa\0\0\x3\x81\xfc\x2\0\0\0\x3\xfb\0\0\0\x18\0\x63\0\x61\0r\0\x64\0I\0n\0\x66\0o\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\x1h\0\0\0\xfd\0\0\x13\x88\xfb\0\0\0\x1c\0p\0l\0\x61\0y\0\x65\0r\0L\0i\0s\0t\0\x44\0o\0\x63\0k\0\0\0\x1S\0\0\0\x64\0\0\0\x64\0\0\x13\x88\xfb\0\0\0\"\0m\0\x65\0s\0s\0\x61\0g\0\x65\0L\0\x61\0y\0o\0u\0t\0\x44\0o\0\x63\0k\x1\0\0\x1i\0\0\x2\x18\0\0\0\x64\0\0\x13\x88\0\0\0\x3\0\0\az\0\0\0\x64\xfc\x1\0\0\0\x1\xfb\0\0\0\x14\0r\0\x65\0p\0l\0\x61\0y\0\x44\0o\0\x63\0k\x1\0\0\0\0\0\0\az\0\0\x2\xe\0\0\x13\x88\0\0\x6\x7f\0\0\x3\x81\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\0)
widgetSize\cardInfoDock=@Size(250 360)
widgetSize\messageLayoutDock=@Size(250 536)
widgetSize\playerListDock=@Size(250 100)
widgetSize\replayDock=@Size(1914 100)

[setsDialog]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\x1\xc0\0\0\x1:\0\0\x4\xdf\0\0\x3|\0\0\x1\xc0\0\0\x1V\0\0\x4\xdf\0\0\x3|\0\0\0\0\0\0\0\0\x6\xc0\0\0\x1\xc0\0\0\x1V\0\0\x4\xdf\0\0\x3|)
header\state=@ByteArray(\0\0\0\xff\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\0\0\0\a\x3\0\0\0\x2\0\0\0\0\0\0\0\x64\0\0\0\x1\0\0\0\x64\0\0\x2\xce\0\0\0\a\x1\x1\0\x1\0\0\0\0\0\0\0\0\0\0\0\0\x64\xff\xff\xff\xff\0\0\0\x81\0\0\0\0\0\0\0\a\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0O\0\0\0\x1\0\0\0\0\0\0\x1\x4\0\0\0\x1\0\0\0\0\0\0\0X\0\0\0\x1\0\0\0\0\0\0\0Q\0\0\0\x1\0\0\0\0\0\0\0\xd2\0\0\0\x1\0\0\0\0\0\0\x3\xe8\0\0\0\0\x64\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x1)

[tokenDialog]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\x2\x1a\0\0\x1)\0\0\x4q\0\0\x3@\0\0\x2\x1a\0\0\x1\x45\0\0\x4q\0\0\x3@\0\0\0\0\0\0\0\0\x6\xc0\0\0\x2\x1a\0\0\x1\x45\0\0\x4q\0\0\x3@)

[visualDeckEditor]
geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0\0\0\0\0\0\0\0\ay\0\0\x3\xe5\0\0\0\0\0\0\0\0\xff\xff\xff\xff\xff\xff\xff\xff\0\0\0\x1\0\0\0\0\a\x80\0\0\0\0\0\0\0\0\0\0\ay\0\0\x3\xe5)
state=@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\x1\0\0\0\x1\0\0\x3~\0\0\x3\xe6\xfc\x2\0\0\0\x2\xfc\0\0\0\0\0\0\x3\xe6\0\0\x2\x1\0\0\x13\x88\xfc\x1\0\0\0\x3\xfb\0\0\0\x18\0\x63\0\x61\0r\0\x64\0I\0n\0\x66\0o\0\x44\0o\0\x63\0k\x1\0\0\x3\xfc\0\0\x1Z\0\0\0\xb7\0\0\x13\x88\xfb\0\0\0\x14\0\x66\0i\0l\0t\0\x65\0r\0\x44\0o\0\x63\0k\0\0\0\0\0\xff\xff\xff\xff\0\0\x1\xf\0\0\x13\x88\xfb\0\0\0\x10\0\x64\0\x65\0\x63\0k\0\x44\0o\0\x63\0k\x1\0\0\x5W\0\0\x2#\0\0\x1\x80\0\0\x13\x88\xfb\0\0\0(\0p\0r\0i\0n\0t\0i\0n\0g\0S\0\x65\0l\0\x65\0\x63\0t\0o\0r\0\x44\0o\0\x63\0k\x2\0\0\x5\x1e\xff\xff\xfd\xf2\0\0\x1\xfd\0\0\x2\v\0\0\x3\xfb\0\0\x3\xe6\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\0)
widgetSize\cardInfoDock=@Size(346 998)
widgetSize\deckDock=@Size(547 998)
widgetSize\filterDock=@Size(250 250)
widgetSize\printingSelectorDock=@Size(509 523)

```

</details>