### PR TITLE
reset style to the default instead of the first key

### DIFF
--- a/cockatrice/src/interface/theme_manager.cpp
+++ b/cockatrice/src/interface/theme_manager.cpp
@@ -346,7 +346,7 @@ void ThemeManager::themeChangedSlot()
         qApp->setStyle(QStyleFactory::create("Fusion"));
         qApp->setPalette(createDarkGreenFusionPalette());
     } else {
-        qApp->setStyle(QStyleFactory::create(QStyleFactory::keys().first()));
+        qApp->setStyle("");
     }
 
     if (dirPath.isEmpty()) {


### PR DESCRIPTION
## Related Ticket(s)
- #6577

## Short roundup of the initial problem
ever since #6577 was merged linux installs default to the windows95 theme as they order the qstylefactory differently

this also meant that any custom theme used the windows95 theme as a background for any part that it did not style, which looks awful

## What will change with this Pull Request?
- instead create a style from the key "" (empty) this selects the default theme like it had before #6577 

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
before:
<img width="2817" height="1790" alt="image" src="https://github.com/user-attachments/assets/aee9774a-a142-41fb-9443-9205bee16571" />

after:
<img width="2810" height="1730" alt="image" src="https://github.com/user-attachments/assets/46a031dd-3ea5-4eb5-93d5-dddd10bbaa6e" />
note that the default style on linux is fusion, identical to the new fusion option, one might say that it's ok as linux users now have both options and some might like this theme, however in my opinion this is a terrible default and the way it interacts with custom themes as the default for unstyled components is awful.

as an alternative for these users they can simply set an environment variable:
using `QT_STYLE_OVERRIDE="windows"` will have the application use the style it did by default when #6577 was merged, other options are also available.