### PR TITLE
[TabDeckEditor] Fix printingSelector dock close button not working

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_printing_selector_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_printing_selector_dock_widget.cpp
@@ -57,4 +57,7 @@ void DeckEditorPrintingSelectorDockWidget::setVisibleWidget(bool overridePrintin
         setWidget(printingSelectorDockContents);
         printingSelector->updateDisplay();
     }
+
+    printingDisabledInfoWidget->setVisible(overridePrintings);
+    printingSelectorDockContents->setVisible(!overridePrintings);
 }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #6554

## Short roundup of the initial problem

The close and float buttons on the printing selector dock widget don't work.

https://github.com/user-attachments/assets/5d7d2aa6-732a-4fad-bfb7-c2bccd3341ab

## What will change with this Pull Request?

The `PrintingSelectorDockWidget` creates both the widget for when printings are enabled and when printings are disabled. Then it uses `setWidget` to set the active widget. The other widget is still being parented to the dock widget and still considered visible, despite not being `setWidget`. For some reason that causes the dock buttons to not work.

The fix is to make the unused widget also not visible.

https://github.com/user-attachments/assets/0592e27e-ac3d-4405-bffd-a05e3921a2fb

