### PR TITLE
[PictureLoader] Fix malformed MIME wildcards in Accept header

### DIFF
--- a/cockatrice/src/interface/card_picture_loader/card_picture_loader_worker.cpp
+++ b/cockatrice/src/interface/card_picture_loader/card_picture_loader_worker.cpp
@@ -86,7 +86,7 @@ QNetworkReply *CardPictureLoaderWorker::makeRequest(const QUrl &url, CardPicture
 
     QNetworkRequest req(url);
     req.setHeader(QNetworkRequest::UserAgentHeader, QString("Cockatrice %1").arg(VERSION_STRING));
-    req.setRawHeader("Accept", "image/avif,image/webp,image/apng,image/,/*;q=0.8");
+    req.setRawHeader("Accept", "image/avif,image/webp,image/apng,image/*,*/*;q=0.8");
     if (!picDownload) {
         req.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysCache);
     }


### PR DESCRIPTION
## Summary
- Fixes malformed MIME type wildcards in the Accept header introduced in #6607
- `image/` and `/*` were missing asterisks, should be `image/*` and `*/*`
- Servers may reject or mishandle requests with invalid MIME types, preventing card images from loading

## Changes
```diff
- req.setRawHeader("Accept", "image/avif,image/webp,image/apng,image/,/*;q=0.8");
+ req.setRawHeader("Accept", "image/avif,image/webp,image/apng,image/*,*/*;q=0.8");
```

## Test plan
- [ ] Verify card images load correctly from various sources (Scryfall, Gatherer, etc.)
- [ ] Confirm no CloudFlare 403 errors (the original issue #6607 addressed)