### PR TITLE
[ChatView] Fix game log first line incorrect background color

### DIFF
--- a/cockatrice/src/interface/widgets/server/chat_view/chat_view.cpp
+++ b/cockatrice/src/interface/widgets/server/chat_view/chat_view.cpp
@@ -75,8 +75,14 @@ void ChatView::adjustColorsToPalette()
 void ChatView::refreshBlockColors()
 {
     QTextDocument *doc = document();
-    QTextCursor cursor(doc);
 
+    // Empty QTextDocuments still have 1 block, so we need handle this edge case
+    if (doc->isEmpty()) {
+        evenNumber = true;
+        return;
+    }
+
+    QTextCursor cursor(doc);
     bool even = true; // start fresh
 
     for (QTextBlock block = doc->begin(); block.isValid(); block = block.next()) {


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #6581

## Short roundup of the initial problem

The first line of the game log uses darkened background color instead of the blank background color

https://github.com/user-attachments/assets/c4bc547e-eedf-4533-8b3d-a2705855d363

<img width="463" height="133" alt="Screenshot 2026-02-21 at 4 06 33 AM" src="https://github.com/user-attachments/assets/6a518e63-94e6-4381-af70-9056501c5594" />

This is because an empty QTextDocument still has a single block containing the empty string.
The logic in `refreshBlockColors` iterates over each block in the document to set the color, which means when the document is empty, it will still do one iteration.

## What will change with this Pull Request?

- Specifically add a check to `refreshBlockColors` to return early if the document is empty

https://github.com/user-attachments/assets/6ea900b9-c335-4ac4-85a9-678a8ed6f755