### PR TITLE
[ChatView] Fix extra blank line at beginning

### DIFF
--- a/cockatrice/src/interface/widgets/server/chat_view/chat_view.cpp
+++ b/cockatrice/src/interface/widgets/server/chat_view/chat_view.cpp
@@ -89,9 +89,9 @@ void ChatView::refreshBlockColors()
         QTextBlockFormat fmt = block.blockFormat();
 
         if (even)
-            fmt.setBackground(palette().window());
-        else
             fmt.setBackground(palette().base());
+        else
+            fmt.setBackground(palette().window());
 
         fmt.setForeground(palette().text());
 
@@ -113,20 +113,28 @@ QTextCursor ChatView::prepareBlock(bool same)
 {
     lastSender.clear();
 
-    QTextCursor cursor(document());
+    QTextDocument *doc = document();
+    QTextCursor cursor(doc);
+
     cursor.movePosition(QTextCursor::End);
     if (same) {
         cursor.insertHtml("<br>");
     } else {
         QTextBlockFormat blockFormat;
-        if ((evenNumber = !evenNumber))
-            blockFormat.setBackground(palette().window());
-        else
+        if (evenNumber)
             blockFormat.setBackground(palette().base());
+        else
+            blockFormat.setBackground(palette().window());
+
+        evenNumber = !evenNumber;
 
         blockFormat.setForeground(palette().text());
         blockFormat.setBottomMargin(4);
-        cursor.insertBlock(blockFormat);
+
+        // Empty QTextDocuments still have 1 block. Just write to that block instead of inserting a new one
+        if (!doc->isEmpty()) {
+            cursor.insertBlock(blockFormat);
+        }
     }
 
     return cursor;


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6612

## Short roundup of the initial problem

Currently, in all ChatViews, we log an extra blank line at the beginning

<img width="350" height="280" alt="Screenshot 2026-02-21 at 4 39 34 AM" src="https://github.com/user-attachments/assets/b94a647c-816a-4b93-bbc9-36f47e78ab81" />

<img width="350" height="193" alt="Screenshot 2026-02-21 at 4 38 56 AM" src="https://github.com/user-attachments/assets/ea572095-d435-4d3f-b50a-a4396fc194b5" />

<img width="350" height="146" alt="Screenshot 2026-02-21 at 4 39 52 AM" src="https://github.com/user-attachments/assets/28d861fc-5748-4b18-b45b-786bedac0eab" />

This is because an empty QTextDocument still has a single block containing the empty string.
Before appending the text, our code always inserts a new block for the text, including if the document is an empty document.

## What will change with this Pull Request?

- When the document is empty, don't insert a new block before writing the text.
- Fix background color parity calculations
  - The parity in `refreshBlockColors` and `prepareBlock` is actually opposite, probably due to us not realizing the empty document issue

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<img width="313" height="192" alt="Screenshot 2026-02-21 at 4 43 26 AM" src="https://github.com/user-attachments/assets/8b4b8777-b530-4ba2-b318-76ecb13e7cd3" />

<img width="366" height="176" alt="Screenshot 2026-02-21 at 4 43 53 AM" src="https://github.com/user-attachments/assets/9cdcccad-672a-4817-a249-f569d17fc023" />

<img width="388" height="143" alt="Screenshot 2026-02-21 at 4 44 09 AM" src="https://github.com/user-attachments/assets/e881edf0-fb36-4835-8354-a03352d62129" />
