### PR TITLE
CI: Fix artifact digest sha for attestation

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -220,7 +220,7 @@ jobs:
 
       - name: Upload to release
         id: upload_release
-        if: needs.configure.outputs.tag != null
+        if: needs.configure.outputs.tag != null && matrix.package != 'skip'
         shell: bash
         env:
           GH_TOKEN: ${{github.token}}


### PR DESCRIPTION
## Short roundup of the initial problem
Attestation was done with the artifact digest output from the uploading step that attaches assets to the workflow.
However, uploads there are always wrapped in a zip file.

The verification is run against the binary source file, the same that is uploaded to the release and the one that people would like to verify downloads against.

## What will change with this Pull Request?
- Calculate the hash of the actual binary itself, and do not reuse the digest output from the upload-artifact action step
  ```diff
  - subject-digest: sha256:${{ steps.upload_artifact.outputs.artifact-digest }}
  + subject-path: ${{steps.build.outputs.path}}
  ```
- Disable summary

<br>

Finally managed to look into this and fix it.