### PR TITLE
[PictureLoader] Add hash of new gatherer card back image to blacklist

### DIFF
--- a/cockatrice/src/interface/card_picture_loader/card_picture_loader_worker_work.cpp
+++ b/cockatrice/src/interface/card_picture_loader/card_picture_loader_worker_work.cpp
@@ -12,7 +12,10 @@
 #include <QThreadPool>
 
 // Card back returned by gatherer when card is not found
-static const QStringList MD5_BLACKLIST = {"db0c48db407a907c16ade38de048a441"};
+static const QStringList MD5_BLACKLIST = {
+    "db0c48db407a907c16ade38de048a441", // Old card back hash. Keep around just in case
+    "fbc7d763c08771c260b39e2115414eeb"  // Current card back hash
+};
 
 CardPictureLoaderWorkerWork::CardPictureLoaderWorkerWork(const CardPictureLoaderWorker *worker, const ExactCard &toLoad)
     : QObject(nullptr), cardToDownload(CardPictureToLoad(toLoad)),


### PR DESCRIPTION
## Short roundup of the initial problem

Wizards recently slightly changed the card back image used when a card is not found on gatherer such that it no longer matches the hash in the backlist.

This causes the card back image to be cached, poisoning the cache and requiring the cache to be cleared to try to download the image again.

## What will change with this Pull Request?
- Add hash of the new card back to the hash blacklist
  - Still keep around old hash just in case