### PR TITLE
[TabGame] Fix concede removing player without waiting for server

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -488,14 +488,12 @@ void TabGame::actConcede()
                                   QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes)
             return;
         emit game->getPlayerManager()->activeLocalPlayerConceded();
-        player->setConceded(true);
     } else {
         if (QMessageBox::question(this, tr("Unconcede"),
                                   tr("You have already conceded.  Do you want to return to this game?"),
                                   QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes)
             return;
         emit game->getPlayerManager()->activeLocalPlayerUnconceded();
-        player->setConceded(false);
     }
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #6112

## Short roundup of the initial problem

In a game, when the user concedes, the game code will remove the player from the playerManager as it sends the concede command to the server, before and independent of any responses from the server.

If this concede causes the game to end, it will cause the game to "flash" a board with only a single player, before being sent back to the deck view.

https://github.com/user-attachments/assets/fb68e88f-322f-4ac0-8873-81c640c2679f

## What will change with this Pull Request?

- Remove the code that removed the player from the playerManager on concede action
  - event handler for server response already properly removes the conceded player

https://github.com/user-attachments/assets/22126a63-32c5-4116-9e8e-95e125c54640

