### PR TITLE
[DeckEditor] Alternate row colors in history list

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_list_history_manager_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_list_history_manager_widget.cpp
@@ -36,6 +36,7 @@ DeckListHistoryManagerWidget::DeckListHistoryManagerWidget(DeckStateManager *_de
     historyLabel = new QLabel(this);
 
     historyList = new QListWidget(this);
+    historyList->setAlternatingRowColors(true);
 
     historyButton->addSettingsWidget(historyLabel);
     historyButton->addSettingsWidget(historyList);


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6340

## Short roundup of the initial problem

<img width="355" height="250" alt="Screenshot 2026-02-22 at 1 04 57 PM" src="https://github.com/user-attachments/assets/c441f56a-5af1-4960-8f22-75380271d472" />

## What will change with this Pull Request?

- Set historyList `alternateRowColors` true.

## Screenshots

<img width="363" height="278" alt="Screenshot 2026-02-22 at 1 03 18 PM" src="https://github.com/user-attachments/assets/c7b7ff71-32c3-4ef6-af79-5877d0319252" />

