### PR TITLE
[Search] Fix OR usage in examples

### DIFF
--- a/cockatrice/resources/help/deck_search.md
+++ b/cockatrice/resources/help/deck_search.md
@@ -47,6 +47,6 @@ searches are case insensitive.
 <dd>[t:aggro OR o:control](#t:aggro OR o:control) <small>(Any deck filename that contains either aggro or control)</small></dd>
 
 <dt>Grouping:</dt>
-<dd><a href="#red -([[]]:100 or aggro)">red -([[]]:100 or aggro)</a> <small>(Any deck that has red in its filename but is not 100 cards or has aggro in its filename)</small></dd>
+<dd><a href="#red -([[]]:100 OR aggro)">red -([[]]:100 OR aggro)</a> <small>(Any deck that has red in its filename but is not 100 cards or has aggro in its filename)</small></dd>
 
 </dl>

--- a/cockatrice/resources/help/search.md
+++ b/cockatrice/resources/help/search.md
@@ -51,16 +51,16 @@ In this list of examples below, each entry has an explanation and can be clicked
 
 <dt><u>E</u>dition:</dt>
 <dd>[set:lea](#set:lea) <small>(Cards that appear in Alpha, which has the set code LEA)</small></dd>
-<dd>[e:lea or e:leb](#e:lea or e:leb) <small>(Cards that appear in Alpha or Beta)</small></dd>
+<dd>[e:lea OR e:leb](#e:lea OR e:leb) <small>(Cards that appear in Alpha or Beta)</small></dd>
 
 <dt>Negate:</dt>
 <dd>[c:wu -c:m](#c:wu -c:m) <small>(Any card that is white or blue, but not multicolored)</small></dd>
 
 <dt>Branching:</dt>
-<dd>[t:sliver or o:changeling](#t:sliver or o:changeling) <small>(Any card that is either a sliver or has changeling)</small></dd>
+<dd>[t:sliver OR o:changeling](#t:sliver OR o:changeling) <small>(Any card that is either a sliver or has changeling)</small></dd>
 
 <dt>Grouping:</dt>
-<dd><a href="#t:angel -(angel or c:w)">t:angel -(angel or c:w)</a> <small>(Any angel that doesn't have angel in its name and isn't white)</small></dd>
+<dd><a href="#t:angel -(angel OR c:w)">t:angel -(angel OR c:w)</a> <small>(Any angel that doesn't have angel in its name and isn't white)</small></dd>
 
 <dt>Regular Expression:</dt>
 <dd>[/^fell/](#/^fell/) <small>(Any card name that begins with "fell")</small></dd>


### PR DESCRIPTION
## Related Ticket(s)
- Fixes issue introduced in #5788
- Fixes issue introduced in #5943

## Short roundup of the initial problem

Some time ago, we changed the search expressions to only accept `OR` in all uppercase. However, we never updated the examples to match.

## What will change with this Pull Request?
- Update card search and deck search examples to correctly use uppercase `OR`

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<img width="491" height="206" alt="Screenshot 2026-02-23 at 1 18 25 AM" src="https://github.com/user-attachments/assets/3297247a-7e39-4b8f-8074-ecaf7461cfa1" />

<img width="488" height="136" alt="Screenshot 2026-02-23 at 1 18 41 AM" src="https://github.com/user-attachments/assets/639626dc-73d4-4a4a-b070-fcb3fc95fbd6" />
