### PR TITLE
fix set sorting

### DIFF
--- a/cockatrice/src/interface/widgets/dialogs/dlg_manage_sets.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_manage_sets.cpp
@@ -20,8 +20,6 @@
 #include <libcockatrice/card/database/card_database_manager.h>
 #include <libcockatrice/models/database/card_set/card_sets_model.h>
 
-#define SORT_RESET -1
-
 WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
 {
     setOrderIsSorted = false;
@@ -97,7 +95,6 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     view->setDropIndicatorShown(true);
     view->setDragDropMode(QAbstractItemView::InternalMove);
 
-    view->sortByColumn(SetsModel::SortKeyCol, Qt::AscendingOrder);
     view->setColumnHidden(SetsModel::SortKeyCol, true);
     view->setColumnHidden(SetsModel::IsKnownCol, true);
     view->setColumnHidden(SetsModel::PriorityCol, true);
@@ -196,10 +193,10 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     auto headerState = SettingsCache::instance().layouts().getSetsDialogHeaderState();
     if (!headerState.isEmpty()) {
         view->header()->restoreState(headerState);
-        view->header()->setSortIndicator(SORT_RESET, Qt::DescendingOrder);
     } else {
         view->header()->resizeSections(QHeaderView::ResizeToContents);
     }
+    resetSort();
     connect(view->header(), &QHeaderView::geometriesChanged, this, &WndSets::saveHeaderState);
 }
 
@@ -239,6 +236,13 @@ void WndSets::rebuildMainLayout(int actionToTake)
     }
 }
 
+void WndSets::resetSort()
+{
+    view->sortByColumn(SetsModel::SortKeyCol, Qt::AscendingOrder);
+    sortIndex = -1;
+    sortWarning->setVisible(false);
+}
+
 void WndSets::includeRebalancedCardsChanged(bool _includeRebalancedCards)
 {
     includeRebalancedCards = _includeRebalancedCards;
@@ -260,9 +264,9 @@ void WndSets::actRestore()
 
 void WndSets::actRestoreOriginalOrder()
 {
-    view->header()->setSortIndicator(SORT_RESET, Qt::DescendingOrder);
     model->restoreOriginalOrder();
-    sortWarning->setVisible(false);
+    view->selectionModel()->reset();
+    resetSort();
 }
 
 void WndSets::actDisableResetButton(const QString &filterString)
@@ -288,10 +292,11 @@ void WndSets::actSort(int index)
             sortIndex = index;
             sortWarning->setVisible(true);
         } else {
-            view->header()->setSortIndicator(SORT_RESET, Qt::DescendingOrder);
-            sortIndex = -1;
-            sortWarning->setVisible(false);
+            resetSort();
         }
+    }
+    if (!view->selectionModel()->selection().empty()) {
+        view->scrollTo(view->selectionModel()->selectedRows().first());
     }
 }
 
@@ -301,22 +306,17 @@ void WndSets::actIgnoreWarning()
         return;
     }
     model->sort(sortIndex, sortOrder);
-    view->header()->setSortIndicator(SORT_RESET, Qt::DescendingOrder);
-    sortIndex = -1;
-    sortWarning->setVisible(false);
+    resetSort();
 }
 
 void WndSets::actDisableSortButtons(int index)
 {
-    if (index != SORT_RESET) {
+    if (index != SetsModel::SortKeyCol) {
         view->setDragEnabled(false);
         setOrderIsSorted = true;
     } else {
         setOrderIsSorted = false;
         view->setDragEnabled(true);
-    }
-    if (!view->selectionModel()->selection().empty()) {
-        view->scrollTo(view->selectionModel()->selectedRows().first());
     }
     actToggleButtons(view->selectionModel()->selection(), QItemSelection());
 }

--- a/cockatrice/src/interface/widgets/dialogs/dlg_manage_sets.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_manage_sets.h
@@ -45,9 +45,6 @@ private:
     QHBoxLayout *filterBox;
     int sortIndex;
     Qt::SortOrder sortOrder;
-    void closeEvent(QCloseEvent *ev) override;
-    void saveHeaderState();
-    void rebuildMainLayout(int actionToTake);
     bool setOrderIsSorted;
     bool includeRebalancedCards;
     enum
@@ -55,6 +52,11 @@ private:
         NO_SETS_SELECTED,
         SOME_SETS_SELECTED
     };
+
+    void closeEvent(QCloseEvent *ev) override;
+    void saveHeaderState();
+    void rebuildMainLayout(int actionToTake);
+    void resetSort();
 
 public:
     explicit WndSets(QWidget *parent = nullptr);

--- a/libcockatrice_models/libcockatrice/models/database/card_set/card_sets_model.cpp
+++ b/libcockatrice_models/libcockatrice/models/database/card_set/card_sets_model.cpp
@@ -45,7 +45,7 @@ QVariant SetsModel::data(const QModelIndex &index, int role) const
 
     switch (index.column()) {
         case SortKeyCol:
-            return QString("%1").arg(set->getSortKey(), 8, 10, QChar('0'));
+            return QString("%1").arg(index.row(), 8, 10, QChar('0'));
         case IsKnownCol:
             return set->getIsKnown();
         case SetTypeCol:


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6410

## Short roundup of the initial problem
the view for the set manager does not properly display the sorting

## What will change with this Pull Request?
- set the key to the current row instead of the row it was saved and sort by it by default always

I don't think this is how this was meant to work, but it works well and the hidden key now actually represents the value it will be set to when saved instead of the value it was when the view was opened, which makes sense to me.