### PR TITLE
CI: `windows-2025` runner

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -410,7 +410,7 @@ jobs:
           modules: ${{matrix.qt_modules}}
           cache: true
 
-      - name: Install NSIS (Windows)
+      - name: Install NSIS
         if: matrix.os == 'Windows'
         shell: bash
         run: choco install nsis


### PR DESCRIPTION
## What will change with this Pull Request?
- Use newer GitHub Actions runner for windows.
  `windows-2025` is the new default runner since half a year already.
- Install NSIS manually which is missing in the new base image
  

