### PR TITLE
CI: Bump version for Intel arch to macOS 14

### DIFF
--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -14,7 +14,7 @@ Available pre-compiled binaries for installation:
   <b>macOS</b>
    • <kbd>macOS 15+</kbd> <sub><i>Sequoia</i></sub> <sub>Apple M</sub>
    • <kbd>macOS 14+</kbd> <sub><i>Sonoma</i></sub> <sub>Apple M</sub>
-   • <kbd>macOS 13+</kbd> <sub><i>Ventura</i></sub> <sub>Intel</sub>
+   • <kbd>macOS 14+</kbd> <sub><i>Sonoma</i></sub> <sub>Intel</sub>
 
   <b>Linux</b>
    • <kbd>Ubuntu 24.04 LTS</kbd> <sub><i>Noble Numbat</i></sub>

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -251,15 +251,15 @@ jobs:
       matrix:
         include:
           - os: macOS
-            target: 13
+            target: 14
             runner: macos-15-intel
             soc: Intel
             xcode: "16.4"
             type: Release
-            override_target: 13
+            override_target: 14
             make_package: 1
-            package_suffix: "-macOS13_Intel"
-            artifact_name: macOS13_Intel-package
+            package_suffix: "-macOS14_Intel"
+            artifact_name: macOS14_Intel-package
             qt_version: 6.10.*
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets


### PR DESCRIPTION
## Short roundup of the initial problem
macOS 13 is out of support since half a year.

## What will change with this Pull Request?
- Bump native Intel version to macOS 14

<br>

Inspection looks good, but please somebody test the resulting binary on Mac (ideally a x64 one):
```
  Inspecting cockatrice...
  /Users/runner/work/Cockatrice/Cockatrice/build/cockatrice/cockatrice.app/Contents/MacOS/cockatrice:
  Load command 11
        cmd LC_BUILD_VERSION
    cmdsize 32
   platform MACOS
      minos 14.0
        sdk 15.5
     ntools 1
       tool LD
    version 1167.5

  /Users/runner/work/Cockatrice/Cockatrice/build/cockatrice/cockatrice.app/Contents/MacOS/cockatrice: Mach-O 64-bit executable x86_64
  Non-fat file: /Users/runner/work/Cockatrice/Cockatrice/build/cockatrice/cockatrice.app/Contents/MacOS/cockatrice is architecture: x86_64
```