### PR TITLE
NSIS: Add app icon to installation exe on Windows

### DIFF
--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -26,6 +26,7 @@ Var PortableMode
 !define MUI_WELCOMEPAGE_TEXT "This wizard will guide you through the installation of Cockatrice.$\r$\n$\r$\nClick Next to continue."
 !define MUI_FINISHPAGE_RUN "$INSTDIR/cockatrice.exe"
 !define MUI_FINISHPAGE_RUN_TEXT "Run 'Cockatrice' now"
+!define MUI_ICON "${NSIS_SOURCE_PATH}\cockatrice\resources\appicon.ico"
 
 !insertmacro MUI_PAGE_WELCOME
 !insertmacro MUI_PAGE_LICENSE "${NSIS_SOURCE_PATH}\LICENSE"


### PR DESCRIPTION
## Short roundup of the initial problem
Only default NSIS installer icon displayed.

## What will change with this Pull Request?
- Display trice icon for installer on Windows

Our .ico file has several images/resolutions included, it takes a moment to load and display the (high res) icon.

Does the .dmg file on Mac, .deb on Ubuntu/Debian and .rpm on Fedora show our app icon already?

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
top: with this change
below: before
<img width="361" height="84" alt="image" src="https://github.com/user-attachments/assets/d35e635a-c0b9-44d0-b0f7-65f2e072f70b" />

<img width="203" height="149" alt="image" src="https://github.com/user-attachments/assets/d0e9ac5b-9c92-4297-8333-834b4bbae290" />
