### PR TITLE
fix scaling for background images on home tab

### DIFF
--- a/cockatrice/src/interface/widgets/cards/card_info_picture_art_crop_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_art_crop_widget.cpp
@@ -8,7 +8,7 @@ CardInfoPictureArtCropWidget::CardInfoPictureArtCropWidget(QWidget *parent)
     hide();
 }
 
-QPixmap CardInfoPictureArtCropWidget::getProcessedBackground(const QSize &targetSize)
+QPixmap CardInfoPictureArtCropWidget::getBackground()
 {
     // Load the full-resolution card image, not a pre-scaled one
     QPixmap fullResPixmap;
@@ -17,10 +17,8 @@ QPixmap CardInfoPictureArtCropWidget::getProcessedBackground(const QSize &target
     } else {
         CardPictureLoader::getCardBackPixmap(fullResPixmap, QSize(745, 1040));
     }
-
-    // Fail-safe if loading failed
     if (fullResPixmap.isNull()) {
-        return QPixmap(targetSize);
+        return QPixmap(); // return null qpixmap
     }
 
     const QSize sz = fullResPixmap.size();
@@ -33,9 +31,7 @@ QPixmap CardInfoPictureArtCropWidget::getProcessedBackground(const QSize &target
 
     foilRect = foilRect.intersected(fullResPixmap.rect()); // always clamp to source bounds
 
-    // Crop first, then scale for best quality
+    // return full resolution image crop
     QPixmap cropped = fullResPixmap.copy(foilRect);
-    QPixmap scaled = cropped.scaled(targetSize, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
-
-    return scaled;
+    return cropped;
 }

--- a/cockatrice/src/interface/widgets/cards/card_info_picture_art_crop_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_art_crop_widget.h
@@ -16,8 +16,8 @@ class CardInfoPictureArtCropWidget : public CardInfoPictureWidget
 public:
     explicit CardInfoPictureArtCropWidget(QWidget *parent = nullptr);
 
-    // Returns a processed (cropped & scaled) version of the pixmap
-    QPixmap getProcessedBackground(const QSize &targetSize);
+    // Returns a cropped version of the pixmap
+    QPixmap getBackground();
 };
 
 #endif // CARD_INFO_PICTURE_ART_CROP_WIDGET_H

--- a/cockatrice/src/interface/widgets/general/home_widget.cpp
+++ b/cockatrice/src/interface/widgets/general/home_widget.cpp
@@ -124,7 +124,7 @@ void HomeWidget::updateRandomCard()
 
     connect(newCard.getCardPtr().data(), &CardInfo::pixmapUpdated, this, &HomeWidget::updateBackgroundProperties);
     backgroundSourceCard->setCard(newCard);
-    background = backgroundSourceCard->getProcessedBackground(size());
+    background = backgroundSourceCard->getBackground();
 
     if (SettingsCache::instance().getHomeTabBackgroundShuffleFrequency() <= 0) {
         cardChangeTimer->stop();
@@ -142,7 +142,7 @@ void HomeWidget::onBackgroundShuffleFrequencyChanged()
 
 void HomeWidget::updateBackgroundProperties()
 {
-    background = backgroundSourceCard->getProcessedBackground(size());
+    background = backgroundSourceCard->getBackground();
     updateButtonsToBackgroundColor();
     update(); // Triggers repaint
 }
@@ -300,14 +300,17 @@ void HomeWidget::paintEvent(QPaintEvent *event)
     QPainter painter(this);
     painter.setRenderHint(QPainter::Antialiasing);
 
-    background = background.scaled(size(), Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
+    if (!background.isNull()) {
+        QSize widgetSize = size() * devicePixelRatio();
+        QPixmap toDraw = background.scaled(widgetSize, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
 
-    // Draw already-scaled background centered
-    QSize widgetSize = size();
-    QSize bgSize = background.size();
-    QPoint topLeft((widgetSize.width() - bgSize.width()) / 2, (widgetSize.height() - bgSize.height()) / 2);
+        // Draw scaled background centered
+        QSize bgSize = toDraw.size();
+        QPoint topLeft((widgetSize.width() - bgSize.width()) / (devicePixelRatio() * 2), // undo scaling for painter
+                       (widgetSize.height() - bgSize.height()) / (devicePixelRatio() * 2));
 
-    painter.drawPixmap(topLeft, background);
+        painter.drawPixmap(topLeft, toDraw);
+    }
 
     // Draw translucent black overlay with rounded corners
     QRectF overlayRect(5, 5, width() - 10, height() - 10);


### PR DESCRIPTION
## Related Ticket(s)
- #6646 
- #6639

## Short roundup of the initial problem
background art crops in the home tab are broken when using scaling

## What will change with this Pull Request?
- fixes the scaling calculations

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
