### PR TITLE
empty card info when switching back to theme background

### DIFF
--- a/cockatrice/src/interface/widgets/general/home_widget.cpp
+++ b/cockatrice/src/interface/widgets/general/home_widget.cpp
@@ -63,6 +63,7 @@ void HomeWidget::initializeBackgroundFromSource()
     switch (backgroundSourceType) {
         case BackgroundSources::Theme:
             background = QPixmap("theme:backgrounds/home");
+            backgroundSourceCard->setCard(ExactCard());
             updateButtonsToBackgroundColor();
             update();
             break;


### PR DESCRIPTION
## Related Ticket(s)
- #6646 
- #6639 

## Short roundup of the initial problem
when switching back from the "random art crop" setting for the home tab background the drawn title for the card source remains

## What will change with this Pull Request?
- reset it when changing the setting

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
