### PR TITLE
take default theme name from startup instead of using empty

### DIFF
--- a/cockatrice/src/interface/theme_manager.cpp
+++ b/cockatrice/src/interface/theme_manager.cpp
@@ -12,6 +12,7 @@
 #include <QPixmapCache>
 #include <QStandardPaths>
 #include <QString>
+#include <QStyle>
 #include <QStyleFactory>
 #include <QStyleHints>
 #include <Qt>
@@ -89,6 +90,7 @@ struct PaletteColorInfo
 
 ThemeManager::ThemeManager(QObject *parent) : QObject(parent)
 {
+    defaultStyleName = qApp->style()->objectName();
     ensureThemeDirectoryExists();
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
     connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this, &ThemeManager::themeChangedSlot);
@@ -346,7 +348,7 @@ void ThemeManager::themeChangedSlot()
         qApp->setStyle(QStyleFactory::create("Fusion"));
         qApp->setPalette(createDarkGreenFusionPalette());
     } else {
-        qApp->setStyle("");
+        qApp->setStyle(defaultStyleName); // setting the style also sets the palette
     }
 
     if (dirPath.isEmpty()) {

--- a/cockatrice/src/interface/theme_manager.h
+++ b/cockatrice/src/interface/theme_manager.h
@@ -40,6 +40,7 @@ public:
     };
 
 private:
+    QString defaultStyleName;
     std::array<QBrush, Role::MaxRole + 1> brushes;
     QStringMap availableThemes;
     /*

--- a/cockatrice/src/interface/widgets/general/home_widget.cpp
+++ b/cockatrice/src/interface/widgets/general/home_widget.cpp
@@ -46,6 +46,8 @@ HomeWidget::HomeWidget(QWidget *parent, TabSupervisor *_tabSupervisor)
             &HomeWidget::onBackgroundShuffleFrequencyChanged);
     // Lambda is cleaner to read than overloading this
     connect(&SettingsCache::instance(), &SettingsCache::homeTabDisplayCardNameChanged, this, [this] { repaint(); });
+    connect(&SettingsCache::instance(), &SettingsCache::themeChanged, this,
+            &HomeWidget::updateButtonsToBackgroundColor);
 }
 
 void HomeWidget::initializeBackgroundFromSource()


### PR DESCRIPTION
## Related Ticket(s)
- #6596 

## Short roundup of the initial problem
me fixing the issue on linux caused the exact same issue to appear on windows

## What will change with this Pull Request?
- read the default theme name on startup instead of using ""
- update the home screen button color when the theme is changed

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
