### PR TITLE
CI: Use new attest action

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Attest binary provenance
         id: attestation
         if: steps.upload_release.outcome == 'success'
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@v4
         with:
           subject-name: ${{steps.build.outputs.name}}
           subject-path: ${{steps.build.outputs.path}}
@@ -530,7 +530,7 @@ jobs:
       - name: Attest binary provenance
         id: attestation
         if: steps.upload_release.outcome == 'success'
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@v4
         with:
           subject-name: ${{steps.build.outputs.name}}
           subject-path: ${{steps.build.outputs.path}}


### PR DESCRIPTION
## Short roundup of the initial problem
actions/attest-build-provenance is superseded by actions/attest

>As of version 4, actions/attest-build-provenance is simply a wrapper on top of [actions/attest](https://github.com/actions/attest).
>
>Existing applications may continue to use the attest-build-provenance action, but new implementations should use actions/attest instead. Please see the [actions/attest](https://github.com/actions/attest) repository for usage information.

## What will change with this Pull Request?
- No change in result