### PR TITLE
CI: Run debug builds only for PR's

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -178,7 +178,7 @@ jobs:
         run: source .ci/docker.sh --build
 
       - name: Build debug and test
-        if: matrix.test != 'skip'
+        if: matrix.test != 'skip' && github.event_name == 'pull_request'
         shell: bash
         env:
           CMAKE_GENERATOR: '${{env.CMAKE_GENERATOR}}'
@@ -423,6 +423,7 @@ jobs:
 
       # uses environment variables, see compile.sh for more details
       - name: Build Cockatrice
+        if: matrix.type == 'Release' || (matrix.type == 'Debug' && github.event_name == 'pull_request')
         id: build
         shell: bash
         env:


### PR DESCRIPTION
## Short roundup of the initial problem
Long build times and additional dev builds triggered on master.
For each tagged version that is released, the dedicated `Debug` macOS build on master is always failing for example: https://github.com/Cockatrice/Cockatrice/actions/runs/22741286102

## What will change with this Pull Request?
- Only run `Debug` builds on PR's