### PR TITLE
[DeckEditor] Fix undo/redo resetting deck sorting

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.cpp
@@ -320,6 +320,7 @@ void DeckStateManager::undo(int steps)
     deckListModel->rebuildTree();
 
     emit deckListModel->layoutChanged();
+    emit deckReplaced();
 }
 
 void DeckStateManager::redo(int steps)
@@ -338,6 +339,7 @@ void DeckStateManager::redo(int steps)
     deckListModel->rebuildTree();
 
     emit deckListModel->layoutChanged();
+    emit deckReplaced();
 }
 
 void DeckStateManager::requestHistorySave(const QString &reason)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6670

## Short roundup of the initial problem

Undo/redo essentially replaces the whole deck, but we weren't emitting the signal for that, which meant the DeckDockWidget wasn't [reapplying the group criteria](https://github.com/RickyRister/Cockatrice/blob/ce52de462769725b6942f3297ed7f881925fd47d/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp#L66-L67) after the replacement.

## What will change with this Pull Request?
- Emit `deckReplaced` signal on undo/redo

https://github.com/user-attachments/assets/58b82c90-de6f-4a2f-a224-c0b61c3f57ad