### PR TITLE
CI: Small docker build tweaks

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -62,5 +62,6 @@ jobs:
           push: ${{ github.ref_type == 'tag' }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          annotations: ${{ steps.metadata.outputs.annotations }}
+          cache-from: type=gha,scope=servatrice
+          cache-to: type=gha,mode=max,scope=servatrice


### PR DESCRIPTION
## Short roundup of the initial problem
 - Annotations not shown on GHCR.
  <img width="910" height="876" alt="image" src="https://github.com/user-attachments/assets/1f14eac0-4aae-41ca-b54a-97038d5f4aed" />

<br><br>

 - Caching not always working well, maybe scope helps. `cache-to` & `cache-from` can be fine tuned later.
   [Default was `buildkit`](https://docs.docker.com/build/cache/backends/gha/#scope), so the cache was not clearly labelled related to Docker/Servatrice.

## What will change with this Pull Request?
- Link annotations the same way as labels
- Add cache scope