### PR TITLE
[DeckEditor] Fix undo/redo clearing legality

### DIFF
--- a/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
+++ b/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
@@ -85,6 +85,8 @@ void DeckListModel::rebuildTree()
     }
 
     endResetModel();
+
+    refreshCardFormatLegalities();
 }
 
 int DeckListModel::rowCount(const QModelIndex &parent) const
@@ -649,7 +651,6 @@ void DeckListModel::setDeckList(const QSharedPointer<DeckList> &_deck)
         deckList = _deck;
     }
     rebuildTree();
-    refreshCardFormatLegalities();
     emit deckReplaced();
 }
 


### PR DESCRIPTION
## Short roundup of the initial problem

Undo/redo resets the red highlighting on illegal cards.

https://github.com/user-attachments/assets/74c2fc5e-fe10-4c96-87a7-00342a1cc2cc

This is caused because `refreshCardFormatLegalities` doesn't get called if the deck is replaced through a method other than `setDecklist`.

## What will change with this Pull Request?

- Refresh legality inside `rebuildTree`

https://github.com/user-attachments/assets/b74016d9-351a-406a-b53f-21b0e0f0b364