### PR TITLE
Add description for code docs link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,4 +9,4 @@ contact_links:
     about: For more information and guidance check our Translation FAQ on our wiki!
   - name: 📖 Code Documentation
     url: https://cockatrice.github.io/docs/
-    about: 
+    about: Helpful source focusing on developers, but there are also references for users!


### PR DESCRIPTION
## Related Ticket(s)
- Related https://github.com/Cockatrice/Cockatrice/pull/6649

## Short roundup of the initial problem
The above PR was merged without deciding on a description, see my open question [there](https://github.com/Cockatrice/Cockatrice/pull/6649#pullrequestreview-3872956557).
The new option does currently not show yet.

## What will change with this Pull Request?
- Add a description for the new link

## Screenshots
With a description it should show, see example from my fork:
<img width="899" height="417" alt="image" src="https://github.com/user-attachments/assets/fa74e5ac-44ad-41ff-9539-137a444fd509" />