### PR TITLE
remove hardcoded white in vde banner widget

### DIFF
--- a/cockatrice/src/interface/widgets/general/display/banner_widget.cpp
+++ b/cockatrice/src/interface/widgets/general/display/banner_widget.cpp
@@ -7,8 +7,8 @@
 #include <QPainter>
 #include <QVBoxLayout>
 
-BannerWidget::BannerWidget(QWidget *parent, const QString &text, Qt::Orientation orientation, int transparency)
-    : QWidget(parent), gradientOrientation(orientation), transparency(qBound(0, transparency, 100))
+BannerWidget::BannerWidget(QWidget *parent, const QString &text, Qt::Orientation orientation, int transparency_)
+    : QWidget(parent), gradientOrientation(orientation), transparency(qBound(0, transparency_, 100))
 {
     auto layout = new QHBoxLayout(this);
 
@@ -18,7 +18,12 @@ BannerWidget::BannerWidget(QWidget *parent, const QString &text, Qt::Orientation
     // Create the banner label and set properties
     bannerLabel = new QLabel(text, this);
     bannerLabel->setAlignment(Qt::AlignCenter);
-    bannerLabel->setStyleSheet("font-size: 24px; font-weight: bold;");
+
+    QString textColor;
+    if (transparency > 50) {
+        textColor = " color: white;";
+    }
+    bannerLabel->setStyleSheet("font-size: 24px; font-weight: bold;" + textColor);
 
     layout->addWidget(iconLabel);
     layout->addWidget(bannerLabel);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6597

## Short roundup of the initial problem
the text of the vde banner widget is hardcoded to white

## What will change with this Pull Request?
- simply remove that, it takes the color from the theme correctly already
- note that it does not adjust to live switches between light and dark, many parts of the app do not

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
<img width="2049" height="1129" alt="image" src="https://github.com/user-attachments/assets/f317f3cc-22c8-4cbe-b601-6f3e58a64a8c" />
