### PR TITLE
CI: Update compiler cache on hit

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -202,11 +202,11 @@ jobs:
                   --ccache "$CCACHE_SIZE" $NO_CLIENT
           .ci/name_build.sh
 
-      # Delete the old cache on hit to emulate a cache update. See https://github.com/actions/cache/issues/342.
+      # Delete used cache to emulate a cache update. See https://github.com/actions/cache/issues/342.
       - name: Delete old compiler cache (ccache)
+        if: github.ref == 'refs/heads/master' && steps.ccache_restore.outputs.cache-hit && steps.build.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
-        if: github.ref == 'refs/heads/master' && steps.ccache_restore.outputs.cache-hit
         run: gh cache delete --repo ${{ github.repository }} ${{ steps.ccache_restore.outputs.cache-primary-key }}
 
       - name: Save compiler cache (ccache)
@@ -445,11 +445,11 @@ jobs:
           TARGET_MACOS_VERSION: ${{ matrix.override_target }}
         run: .ci/compile.sh --server --test --vcpkg
 
-      # Delete the old cache on hit to emulate a cache update. See https://github.com/actions/cache/issues/342.
+      # Delete used cache to emulate a cache update. See https://github.com/actions/cache/issues/342.
       - name: Delete old compiler cache (ccache)
+        if: github.ref == 'refs/heads/master' && matrix.use_ccache == 1 && steps.ccache_restore.outputs.cache-hit && steps.build.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
-        if: github.ref == 'refs/heads/master' && matrix.use_ccache == 1 && steps.ccache_restore.outputs.cache-hit
         run: gh cache delete --repo ${{ github.repository }} ${{ steps.ccache_restore.outputs.cache-primary-key }}
 
       - name: Save compiler cache (ccache)


### PR DESCRIPTION
## Related Issues
- Fixing #6690

## Short roundup of the initial problem
Updating/overwriting/replacing an existing cache is currently not supported (https://github.com/actions/cache/issues/342).

## What will change with this Pull Request?
- Delete existing cache on hit via CLI, ensure that only happens when run on master branch
- In that case only, upload new cache to keep a recent one on main branch as base