### PR TITLE
[Game] Fix opponent's cards not using zone-specific card menu

### DIFF
--- a/cockatrice/src/game/player/menu/card_menu.cpp
+++ b/cockatrice/src/game/player/menu/card_menu.cpp
@@ -113,32 +113,20 @@ CardMenu::CardMenu(Player *_player, const CardItem *_card, bool _shortcutsActive
         addAction(aSelectAll);
         addAction(aSelectColumn);
         addRelatedCardView();
-    } else if (writeableCard) {
-
+    } else {
         if (card->getZone()) {
             if (card->getZone()->getName() == ZoneNames::TABLE) {
-                createTableMenu();
+                createTableMenu(writeableCard);
             } else if (card->getZone()->getName() == ZoneNames::STACK) {
-                createStackMenu();
+                createStackMenu(writeableCard);
             } else if (card->getZone()->getName() == ZoneNames::EXILE ||
                        card->getZone()->getName() == ZoneNames::GRAVE) {
-                createGraveyardOrExileMenu();
+                createGraveyardOrExileMenu(writeableCard);
             } else {
-                createHandOrCustomZoneMenu();
+                createHandOrCustomZoneMenu(writeableCard);
             }
         } else {
-            addMenu(new MoveMenu(player));
-        }
-    } else {
-        if (card->getZone() && card->getZone()->getName() != ZoneNames::HAND) {
-            addAction(aDrawArrow);
-            addSeparator();
-            addRelatedCardView();
-            addRelatedCardActions();
-            addSeparator();
-            addAction(aClone);
-            addSeparator();
-            addAction(aSelectAll);
+            createZonelessMenu(writeableCard);
         }
     }
 }
@@ -154,11 +142,9 @@ void CardMenu::removePlayer(Player *playerToRemove)
     }
 }
 
-void CardMenu::createTableMenu()
+void CardMenu::createTableMenu(bool canModifyCard)
 {
     // Card is on the battlefield
-    bool canModifyCard = player->getPlayerInfo()->judge || card->getOwner() == player;
-
     if (!canModifyCard) {
         addRelatedCardView();
         addRelatedCardActions();
@@ -213,10 +199,8 @@ void CardMenu::createTableMenu()
     addMenu(mCardCounters);
 }
 
-void CardMenu::createStackMenu()
+void CardMenu::createStackMenu(bool canModifyCard)
 {
-    bool canModifyCard = player->getPlayerInfo()->judge || card->getOwner() == player;
-
     // Card is on the stack
     if (canModifyCard) {
         addAction(aAttach);
@@ -238,10 +222,8 @@ void CardMenu::createStackMenu()
     addRelatedCardActions();
 }
 
-void CardMenu::createGraveyardOrExileMenu()
+void CardMenu::createGraveyardOrExileMenu(bool canModifyCard)
 {
-    bool canModifyCard = player->getPlayerInfo()->judge || card->getOwner() == player;
-
     // Card is in the graveyard or exile
     if (canModifyCard) {
         addAction(aPlay);
@@ -270,8 +252,20 @@ void CardMenu::createGraveyardOrExileMenu()
     addRelatedCardActions();
 }
 
-void CardMenu::createHandOrCustomZoneMenu()
+void CardMenu::createHandOrCustomZoneMenu(bool canModifyCard)
 {
+    if (!canModifyCard) {
+        addAction(aDrawArrow);
+        addSeparator();
+        addRelatedCardView();
+        addRelatedCardActions();
+        addSeparator();
+        addAction(aClone);
+        addSeparator();
+        addAction(aSelectAll);
+        return;
+    }
+
     // Card is in hand or a custom zone specified by server
     addAction(aPlay);
     addAction(aPlayFacedown);
@@ -302,6 +296,13 @@ void CardMenu::createHandOrCustomZoneMenu()
     addRelatedCardView();
     if (card->getZone()->getName() == ZoneNames::HAND) {
         addRelatedCardActions();
+    }
+}
+
+void CardMenu::createZonelessMenu(bool canModifyCard)
+{
+    if (canModifyCard) {
+        addMenu(new MoveMenu(player));
     }
 }
 

--- a/cockatrice/src/game/player/menu/card_menu.h
+++ b/cockatrice/src/game/player/menu/card_menu.h
@@ -18,10 +18,11 @@ class CardMenu : public QMenu
 public:
     explicit CardMenu(Player *player, const CardItem *card, bool shortcutsActive);
     void removePlayer(Player *playerToRemove);
-    void createTableMenu();
-    void createStackMenu();
-    void createGraveyardOrExileMenu();
-    void createHandOrCustomZoneMenu();
+    void createTableMenu(bool canModifyCard);
+    void createStackMenu(bool canModifyCard);
+    void createGraveyardOrExileMenu(bool canModifyCard);
+    void createHandOrCustomZoneMenu(bool canModifyCard);
+    void createZonelessMenu(bool canModifyCard);
 
     QMenu *mCardCounters;
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug that was likely introduced in #6069

## Short roundup of the initial problem

The card menus for opponent's cards don't contain certain actions, even though they contained them back in `2.10.x`. For example, the card menu for enemy table zones don't contain the `Select row`, and card menus for opposing grave/exile don't contain `Select column`.

https://github.com/user-attachments/assets/4c029b0a-6b8b-4667-8140-99bcaef5b81e

This is caused by the `CardMenu` creation code skipping any zone-specific menu creation methods if the card is not in a modifiable zone. Many of the zone-specific menu creation methods will check if the zone is modifiable and create a different menu if not, but due to the first check, the code will just skip any zone-specific menu code and use the default unmodifiable zone card menu.

## What will change with this Pull Request?
- Changed `CardMenu` to not do the initial `canModifyCard` check
  - Refactored to instead pass `canModifyCard` into each zone creation method so that they can each handle their own `canModifyCard` logic.

https://github.com/user-attachments/assets/7d840617-fb29-4fc0-96ff-bb0c23320425

