### PR TITLE
refactor: extract AbstractZoneMenu interface for polymorphic zone menu dispatch

### DIFF
--- a/cockatrice/src/game/board/abstract_counter.h
+++ b/cockatrice/src/game/board/abstract_counter.h
@@ -8,6 +8,7 @@
 #define COUNTER_H
 
 #include "../../interface/widgets/menus/tearoff_menu.h"
+#include "../player/menu/abstract_player_component.h"
 
 #include <QGraphicsItem>
 #include <QInputDialog>
@@ -18,7 +19,7 @@ class QKeyEvent;
 class QMenu;
 class QString;
 
-class AbstractCounter : public QObject, public QGraphicsItem
+class AbstractCounter : public QObject, public QGraphicsItem, public AbstractPlayerComponent
 {
     Q_OBJECT
     Q_INTERFACES(QGraphicsItem)
@@ -56,10 +57,10 @@ public:
                     QGraphicsItem *parent = nullptr);
     ~AbstractCounter() override;
 
-    void retranslateUi();
+    void retranslateUi() override;
     void setValue(int _value);
-    void setShortcutsActive();
-    void setShortcutsInactive();
+    void setShortcutsActive() override;
+    void setShortcutsInactive() override;
     void delCounter();
 
     QMenu *getMenu() const

--- a/cockatrice/src/game/player/menu/abstract_player_component.h
+++ b/cockatrice/src/game/player/menu/abstract_player_component.h
@@ -1,0 +1,32 @@
+/**
+ * @file abstract_player_component.h
+ * @ingroup GameMenusPlayers
+ * @brief Polymorphic interface for player-bound UI components managed by PlayerMenu.
+ */
+
+#ifndef COCKATRICE_ABSTRACT_PLAYER_COMPONENT_H
+#define COCKATRICE_ABSTRACT_PLAYER_COMPONENT_H
+
+/**
+ * @brief Interface for player-bound UI components that need shortcut and translation lifecycle management.
+ *
+ * Not a QObject — avoids diamond inheritance with Qt's MOC. Each concrete component
+ * inherits QObject through its Qt base class (QMenu, TearOffMenu, QGraphicsItem, etc.)
+ * and this interface through regular multiple inheritance.
+ */
+class AbstractPlayerComponent
+{
+public:
+    virtual ~AbstractPlayerComponent() = default;
+
+    /// Bind keyboard shortcuts. Called when this player gains focus.
+    virtual void setShortcutsActive() = 0;
+
+    /// Unbind keyboard shortcuts. Called when this player loses focus.
+    virtual void setShortcutsInactive() = 0;
+
+    /// Retranslate all user-visible strings. Called on language change.
+    virtual void retranslateUi() = 0;
+};
+
+#endif // COCKATRICE_ABSTRACT_PLAYER_COMPONENT_H

--- a/cockatrice/src/game/player/menu/custom_zone_menu.h
+++ b/cockatrice/src/game/player/menu/custom_zone_menu.h
@@ -7,15 +7,23 @@
 #ifndef COCKATRICE_CUSTOM_ZONE_MENU_H
 #define COCKATRICE_CUSTOM_ZONE_MENU_H
 
+#include "abstract_player_component.h"
+
 #include <QMenu>
 
 class Player;
-class CustomZoneMenu : public QMenu
+class CustomZoneMenu : public QMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 public:
     explicit CustomZoneMenu(Player *player);
-    void retranslateUi();
+    void retranslateUi() override;
+    void setShortcutsActive() override
+    {
+    }
+    void setShortcutsInactive() override
+    {
+    }
 
 private:
     Player *player;

--- a/cockatrice/src/game/player/menu/grave_menu.h
+++ b/cockatrice/src/game/player/menu/grave_menu.h
@@ -8,12 +8,13 @@
 #define COCKATRICE_GRAVE_MENU_H
 
 #include "../../../interface/widgets/menus/tearoff_menu.h"
+#include "abstract_player_component.h"
 
 #include <QAction>
 #include <QMenu>
 
 class Player;
-class GraveyardMenu : public TearOffMenu
+class GraveyardMenu : public TearOffMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 signals:
@@ -25,9 +26,9 @@ public:
     void createViewActions();
     void populateRevealRandomMenuWithActivePlayers();
     void onRevealRandomTriggered();
-    void retranslateUi();
-    void setShortcutsActive();
-    void setShortcutsInactive();
+    void retranslateUi() override;
+    void setShortcutsActive() override;
+    void setShortcutsInactive() override;
 
     QMenu *mRevealRandomGraveyardCard = nullptr;
     QMenu *moveGraveMenu = nullptr;

--- a/cockatrice/src/game/player/menu/hand_menu.h
+++ b/cockatrice/src/game/player/menu/hand_menu.h
@@ -8,6 +8,7 @@
 #define COCKATRICE_HAND_MENU_H
 
 #include "../../../interface/widgets/menus/tearoff_menu.h"
+#include "abstract_player_component.h"
 
 #include <QAction>
 #include <QMenu>
@@ -15,7 +16,7 @@
 class Player;
 class PlayerActions;
 
-class HandMenu : public TearOffMenu
+class HandMenu : public TearOffMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 
@@ -31,9 +32,9 @@ public:
         return mRevealRandomHandCard;
     }
 
-    void retranslateUi();
-    void setShortcutsActive();
-    void setShortcutsInactive();
+    void retranslateUi() override;
+    void setShortcutsActive() override;
+    void setShortcutsInactive() override;
 
 private slots:
     void populateRevealHandMenuWithActivePlayers();

--- a/cockatrice/src/game/player/menu/library_menu.h
+++ b/cockatrice/src/game/player/menu/library_menu.h
@@ -8,6 +8,7 @@
 #define COCKATRICE_LIBRARY_MENU_H
 
 #include "../../../interface/widgets/menus/tearoff_menu.h"
+#include "abstract_player_component.h"
 
 #include <QAction>
 #include <QMenu>
@@ -15,7 +16,7 @@
 class Player;
 class PlayerActions;
 
-class LibraryMenu : public TearOffMenu
+class LibraryMenu : public TearOffMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 public slots:
@@ -28,15 +29,15 @@ public:
     void createShuffleActions();
     void createMoveActions();
     void createViewActions();
-    void retranslateUi();
+    void retranslateUi() override;
     void populateRevealLibraryMenuWithActivePlayers();
     void populateLendLibraryMenuWithActivePlayers();
     void populateRevealTopCardMenuWithActivePlayers();
     void onRevealLibraryTriggered();
     void onLendLibraryTriggered();
     void onRevealTopCardTriggered();
-    void setShortcutsActive();
-    void setShortcutsInactive();
+    void setShortcutsActive() override;
+    void setShortcutsInactive() override;
 
     [[nodiscard]] bool isAlwaysRevealTopCardChecked() const
     {

--- a/cockatrice/src/game/player/menu/player_menu.cpp
+++ b/cockatrice/src/game/player/menu/player_menu.cpp
@@ -15,33 +15,24 @@ PlayerMenu::PlayerMenu(Player *_player) : player(_player)
     playerMenu = new TearOffMenu();
 
     if (player->getPlayerInfo()->getLocalOrJudge()) {
-        handMenu = new HandMenu(player, player->getPlayerActions(), playerMenu);
-        playerMenu->addMenu(handMenu);
-
-        libraryMenu = new LibraryMenu(player, playerMenu);
-        playerMenu->addMenu(libraryMenu);
+        handMenu = addManagedMenu<HandMenu>(player, player->getPlayerActions(), playerMenu);
+        libraryMenu = addManagedMenu<LibraryMenu>(player, playerMenu);
     } else {
         handMenu = nullptr;
         libraryMenu = nullptr;
     }
 
-    graveMenu = new GraveyardMenu(player, playerMenu);
-    playerMenu->addMenu(graveMenu);
-
-    rfgMenu = new RfgMenu(player, playerMenu);
-    playerMenu->addMenu(rfgMenu);
+    graveMenu = addManagedMenu<GraveyardMenu>(player, playerMenu);
+    rfgMenu = addManagedMenu<RfgMenu>(player, playerMenu);
 
     if (player->getPlayerInfo()->getLocalOrJudge()) {
-        sideboardMenu = new SideboardMenu(player, playerMenu);
-        playerMenu->addMenu(sideboardMenu);
-
-        customZonesMenu = new CustomZoneMenu(player);
-        playerMenu->addMenu(customZonesMenu);
+        sideboardMenu = addManagedMenu<SideboardMenu>(player, playerMenu);
+        customZonesMenu = addManagedMenu<CustomZoneMenu>(player);
         playerMenu->addSeparator();
 
         countersMenu = playerMenu->addMenu(QString());
 
-        utilityMenu = new UtilityMenu(player, playerMenu);
+        utilityMenu = createManagedComponent<UtilityMenu>(player, playerMenu);
     } else {
         sideboardMenu = nullptr;
         customZonesMenu = nullptr;
@@ -50,8 +41,7 @@ PlayerMenu::PlayerMenu(Player *_player) : player(_player)
     }
 
     if (player->getPlayerInfo()->getLocal()) {
-        sayMenu = new SayMenu(player);
-        playerMenu->addMenu(sayMenu);
+        sayMenu = addManagedMenu<SayMenu>(player);
     } else {
         sayMenu = nullptr;
     }
@@ -99,39 +89,17 @@ void PlayerMenu::retranslateUi()
 {
     playerMenu->setTitle(tr("Player \"%1\"").arg(player->getPlayerInfo()->getName()));
 
-    if (handMenu) {
-        handMenu->retranslateUi();
-    }
-    if (libraryMenu) {
-        libraryMenu->retranslateUi();
-    }
-
-    graveMenu->retranslateUi();
-    rfgMenu->retranslateUi();
-
-    if (sideboardMenu) {
-        sideboardMenu->retranslateUi();
+    for (auto *component : managedComponents) {
+        component->retranslateUi();
     }
 
     if (countersMenu) {
         countersMenu->setTitle(tr("&Counters"));
     }
 
-    if (customZonesMenu) {
-        customZonesMenu->retranslateUi();
-    }
-
     QMapIterator<int, AbstractCounter *> counterIterator(player->getCounters());
     while (counterIterator.hasNext()) {
         counterIterator.next().value()->retranslateUi();
-    }
-
-    if (utilityMenu) {
-        utilityMenu->retranslateUi();
-    }
-
-    if (sayMenu) {
-        sayMenu->setTitle(tr("S&ay"));
     }
 }
 
@@ -153,26 +121,16 @@ void PlayerMenu::setShortcutsActive()
 {
     shortcutsActive = true;
 
-    if (handMenu) {
-        handMenu->setShortcutsActive();
-    }
-    if (libraryMenu) {
-        libraryMenu->setShortcutsActive();
-    }
-    graveMenu->setShortcutsActive();
-    // No shortcuts for RfgMenu yet
-
-    if (sideboardMenu) {
-        sideboardMenu->setShortcutsActive();
+    for (auto *component : managedComponents) {
+        component->setShortcutsActive();
     }
 
+    // Counters implement AbstractPlayerComponent but are iterated via Player::counters
+    // (the authoritative source) rather than managedComponents to avoid a redundant
+    // list that must stay in sync with the map.
     QMapIterator<int, AbstractCounter *> counterIterator(player->getCounters());
     while (counterIterator.hasNext()) {
         counterIterator.next().value()->setShortcutsActive();
-    }
-
-    if (utilityMenu) {
-        utilityMenu->setShortcutsActive();
     }
 }
 
@@ -180,25 +138,12 @@ void PlayerMenu::setShortcutsInactive()
 {
     shortcutsActive = false;
 
-    if (handMenu) {
-        handMenu->setShortcutsInactive();
-    }
-    if (libraryMenu) {
-        libraryMenu->setShortcutsInactive();
-    }
-    graveMenu->setShortcutsInactive();
-    // No shortcuts for RfgMenu yet
-
-    if (sideboardMenu) {
-        sideboardMenu->setShortcutsInactive();
+    for (auto *component : managedComponents) {
+        component->setShortcutsInactive();
     }
 
     QMapIterator<int, AbstractCounter *> counterIterator(player->getCounters());
     while (counterIterator.hasNext()) {
         counterIterator.next().value()->setShortcutsInactive();
-    }
-
-    if (utilityMenu) {
-        utilityMenu->setShortcutsInactive();
     }
 }

--- a/cockatrice/src/game/player/menu/player_menu.h
+++ b/cockatrice/src/game/player/menu/player_menu.h
@@ -1,7 +1,7 @@
 /**
  * @file player_menu.h
  * @ingroup GameMenusPlayers
- * @brief TODO: Document this.
+ * @brief Orchestrates lifecycle management for all player-bound UI components.
  */
 
 #ifndef COCKATRICE_PLAYER_MENU_H
@@ -18,6 +18,7 @@
 #include "sideboard_menu.h"
 #include "utility_menu.h"
 
+#include <QList>
 #include <QMenu>
 #include <QObject>
 
@@ -37,6 +38,7 @@ private slots:
 
 public:
     PlayerMenu(Player *player);
+    /// Lifecycle methods: delegate to all managedComponents, plus counters separately via player->getCounters().
     void retranslateUi();
 
     QMenu *updateCardMenu(const CardItem *card);
@@ -66,7 +68,9 @@ public:
         return shortcutsActive;
     }
 
+    /// Delegates to all managedComponents, plus counters separately.
     void setShortcutsActive();
+    /// Delegates to all managedComponents, plus counters separately.
     void setShortcutsInactive();
 
 private:
@@ -82,9 +86,26 @@ private:
     SayMenu *sayMenu;
     CustomZoneMenu *customZonesMenu;
 
-    bool shortcutsActive;
+    /// Drives AbstractPlayerComponent lifecycle delegation. Counters are iterated separately via player->getCounters().
+    QList<AbstractPlayerComponent *> managedComponents;
+    bool shortcutsActive = false;
 
-    void initSayMenu();
+    /// Creates component, adds it as a submenu of playerMenu, and registers in managedComponents.
+    template <typename MenuT, typename... Args> MenuT *addManagedMenu(Args &&...args)
+    {
+        auto *menu = new MenuT(std::forward<Args>(args)...);
+        playerMenu->addMenu(menu);
+        managedComponents.append(menu);
+        return menu;
+    }
+
+    /// Creates component and registers in managedComponents, but does NOT add it as a submenu.
+    template <typename ComponentT, typename... Args> ComponentT *createManagedComponent(Args &&...args)
+    {
+        auto *component = new ComponentT(std::forward<Args>(args)...);
+        managedComponents.append(component);
+        return component;
+    }
 };
 
 #endif // COCKATRICE_PLAYER_MENU_H

--- a/cockatrice/src/game/player/menu/rfg_menu.h
+++ b/cockatrice/src/game/player/menu/rfg_menu.h
@@ -8,19 +8,26 @@
 #define COCKATRICE_RFG_MENU_H
 
 #include "../../../interface/widgets/menus/tearoff_menu.h"
+#include "abstract_player_component.h"
 
 #include <QAction>
 #include <QMenu>
 
 class Player;
-class RfgMenu : public TearOffMenu
+class RfgMenu : public TearOffMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 public:
     explicit RfgMenu(Player *player, QWidget *parent = nullptr);
     void createMoveActions();
     void createViewActions();
-    void retranslateUi();
+    void retranslateUi() override;
+    void setShortcutsActive() override
+    {
+    }
+    void setShortcutsInactive() override
+    {
+    }
 
     QMenu *moveRfgMenu = nullptr;
 

--- a/cockatrice/src/game/player/menu/say_menu.cpp
+++ b/cockatrice/src/game/player/menu/say_menu.cpp
@@ -8,6 +8,31 @@ SayMenu::SayMenu(Player *_player) : player(_player)
 {
     connect(&SettingsCache::instance().messages(), &MessageSettings::messageMacrosChanged, this, &SayMenu::initSayMenu);
     initSayMenu();
+    retranslateUi();
+}
+
+void SayMenu::retranslateUi()
+{
+    setTitle(tr("S&ay"));
+}
+
+void SayMenu::setShortcutsActive()
+{
+    shortcutsActive = true;
+
+    const auto menuActions = actions();
+    for (int i = 0; i < menuActions.size() && i < 10; ++i) {
+        menuActions[i]->setShortcut(QKeySequence("Ctrl+" + QString::number((i + 1) % 10)));
+    }
+}
+
+void SayMenu::setShortcutsInactive()
+{
+    shortcutsActive = false;
+
+    for (auto *action : actions()) {
+        action->setShortcut(QKeySequence());
+    }
 }
 
 void SayMenu::initSayMenu()
@@ -19,10 +44,11 @@ void SayMenu::initSayMenu()
 
     for (int i = 0; i < count; ++i) {
         auto *newAction = new QAction(SettingsCache::instance().messages().getMessageAt(i), this);
-        if (i < 10) {
-            newAction->setShortcut(QKeySequence("Ctrl+" + QString::number((i + 1) % 10)));
-        }
         connect(newAction, &QAction::triggered, player->getPlayerActions(), &PlayerActions::actSayMessage);
         addAction(newAction);
+    }
+
+    if (shortcutsActive) {
+        setShortcutsActive();
     }
 }

--- a/cockatrice/src/game/player/menu/say_menu.h
+++ b/cockatrice/src/game/player/menu/say_menu.h
@@ -7,18 +7,27 @@
 #ifndef COCKATRICE_SAY_MENU_H
 #define COCKATRICE_SAY_MENU_H
 
+#include "abstract_player_component.h"
+
 #include <QMenu>
 
 class Player;
-class SayMenu : public QMenu
+class SayMenu : public QMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 public:
     explicit SayMenu(Player *player);
+
+    void retranslateUi() override;
+    void setShortcutsActive() override;
+    void setShortcutsInactive() override;
+
+private slots:
     void initSayMenu();
 
 private:
     Player *player;
+    bool shortcutsActive = false;
 };
 
 #endif // COCKATRICE_SAY_MENU_H

--- a/cockatrice/src/game/player/menu/sideboard_menu.h
+++ b/cockatrice/src/game/player/menu/sideboard_menu.h
@@ -7,18 +7,20 @@
 #ifndef COCKATRICE_SIDEBOARD_MENU_H
 #define COCKATRICE_SIDEBOARD_MENU_H
 
+#include "abstract_player_component.h"
+
 #include <QMenu>
 
 class Player;
-class SideboardMenu : public QMenu
+class SideboardMenu : public QMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 
 public:
     explicit SideboardMenu(Player *player, QMenu *playerMenu);
-    void retranslateUi();
-    void setShortcutsActive();
-    void setShortcutsInactive();
+    void retranslateUi() override;
+    void setShortcutsActive() override;
+    void setShortcutsInactive() override;
 
 private:
     Player *player;

--- a/cockatrice/src/game/player/menu/utility_menu.h
+++ b/cockatrice/src/game/player/menu/utility_menu.h
@@ -7,17 +7,19 @@
 #ifndef COCKATRICE_UTILITY_MENU_H
 #define COCKATRICE_UTILITY_MENU_H
 
+#include "abstract_player_component.h"
+
 #include <QMenu>
 
 class Player;
-class UtilityMenu : public QMenu
+class UtilityMenu : public QMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 public slots:
     void populatePredefinedTokensMenu();
-    void retranslateUi();
-    void setShortcutsActive();
-    void setShortcutsInactive();
+    void retranslateUi() override;
+    void setShortcutsActive() override;
+    void setShortcutsInactive() override;
 
 public:
     explicit UtilityMenu(Player *player, QMenu *playerMenu);


### PR DESCRIPTION

Replaces scattered null-check-then-call patterns for retranslateUi() and shortcut activation in PlayerMenu with a single loop over a QVector<AbstractZoneMenu*>, populated at construction time. Uses non-QObject interface to avoid Qt MOC diamond inheritance.


## Short roundup of the initial problem
This became useful as I was implementing proper menus for my command zone project.

## What will change with this Pull Request?
- Hopefully nothing

