### PR TITLE
CI: Adjustments to ccache usage

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -153,7 +153,7 @@ jobs:
     continue-on-error: ${{matrix.allow-failure == 'yes'}}
     env:
       NAME: ${{matrix.distro}}${{matrix.version}}
-      CACHE: ${{github.workspace}}/.cache/${{matrix.distro}}${{matrix.version}}   # directory for caching docker image and ccache
+      CACHE_DIR: ${{github.workspace}}/.cache/${{matrix.distro}}${{matrix.version}}   # directory for caching docker image and ccache
       # Cache size over the entire repo is 10Gi:
       # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
       CCACHE_SIZE: 550M
@@ -169,7 +169,7 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         with:
-          path: ${{env.CACHE}}
+          path: ${{env.CACHE_DIR}}
           key: ccache-${{matrix.distro}}${{matrix.version}}-${{env.BRANCH_NAME}}
           restore-keys: ccache-${{matrix.distro}}${{matrix.version}}-
 
@@ -213,7 +213,7 @@ jobs:
         if: github.ref == 'refs/heads/master'
         uses: actions/cache/save@v5
         with:
-          path: ${{env.CACHE}}
+          path: ${{env.CACHE_DIR}}
           key: ${{ steps.ccache_restore.outputs.cache-primary-key }}
 
       - name: Upload artifact
@@ -456,7 +456,7 @@ jobs:
         if: github.ref == 'refs/heads/master' && matrix.use_ccache == 1
         uses: actions/cache/save@v5
         with:
-          path: ${{env.CACHE}}
+          path: ${{env.CCACHE_DIR}}
           key: ${{ steps.ccache_restore.outputs.cache-primary-key }}
 
       - name: Sign app bundle


### PR DESCRIPTION
## Related Ticket(s)
- Follow up to #6691

## Short roundup of the initial problem
- Ubuntu 24.04 job was hitting the 500MB ccache size limit.
- Arch ccache was not updated correctly.

See https://github.com/Cockatrice/Cockatrice/pull/6691#issuecomment-4061280470 for some data.

## What will change with this Pull Request?
- Increase ccache size to 550MB
- Fix cache update for compiler cache on Arch
- Small cleanup and uniformization
