### PR TITLE
chore: add GHA cache usage script and workflow

### DIFF
--- a/.ci/gha_cache_usage.sh
+++ b/.ci/gha_cache_usage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Reports GitHub Actions cache usage, grouped by key prefix (first segment before "-" or "/") or for one prefix.
 #
-# Usage: .ci/gh_buildkit_cache_usage.sh [-m|--markdown] [key-prefix]
+# Usage: .ci/gha_cache_usage.sh [-m|--markdown] [key-prefix]
 #   -m, --markdown  output as a markdown table
 #   No key-prefix:  all caches grouped by prefix.
 #   One arg:        caches with that key prefix (default buildkit-blob).

--- a/.github/workflows/cache-report.yml
+++ b/.github/workflows/cache-report.yml
@@ -1,5 +1,5 @@
 # Reports GitHub Actions cache usage grouped by key prefix (e.g. buildkit, ccache, vcpkg).
-# Run locally: .ci/gh_buildkit_cache_usage.sh
+# Run locally: .ci/gha_cache_usage.sh
 
 name: Cache usage report
 
@@ -27,5 +27,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          ./.ci/gh_buildkit_cache_usage.sh --markdown | tee report.txt
+          ./.ci/gha_cache_usage.sh --markdown | tee report.txt
           cat report.txt >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Related Ticket(s)
- Creation was inspired by comment in #6691

## Short roundup of the initial problem
We are hitting the 10GB limit of GHA caches.

## What will change with this Pull Request?
- Add a script that uses the `gh` client to get cache usage grouped by prefixes (e.g. ccache, vcpkg)
- The script can be run locally. e.g.: `.ci/gha_cache_usage.sh` (as long as `gh` is authenticated, for example via `gh auth login`)
- Add a workflow that displays formatted results in a table

## Screenshots
https://github.com/brunoalr/Cockatrice/actions/runs/23097226664
<img width="2400" height="1203" alt="image" src="https://github.com/user-attachments/assets/ed2c4e28-8d4c-4a47-8cdb-bd698086d010" />
Note: this is the usage from my fork, not this upstream repo.

## Disclaimer
I don't really know `jq` syntax. This is vibe coded.
<!-- simply drag & drop image files directly into this description! -->

