### PR TITLE
CI: Fix Linux compiler cache

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -153,7 +153,7 @@ jobs:
     continue-on-error: ${{matrix.allow-failure == 'yes'}}
     env:
       NAME: ${{matrix.distro}}${{matrix.version}}
-      CACHE_DIR: ${{github.workspace}}/.cache/${{matrix.distro}}${{matrix.version}}   # directory for caching docker image and ccache
+      CACHE: ${{github.workspace}}/.cache/${{matrix.distro}}${{matrix.version}}   # directory for caching docker image and ccache
       # Cache size over the entire repo is 10Gi:
       # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
       CCACHE_SIZE: 550M
@@ -169,7 +169,7 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         with:
-          path: ${{env.CACHE_DIR}}
+          path: ${{env.CACHE}}
           key: ccache-${{matrix.distro}}${{matrix.version}}-${{env.BRANCH_NAME}}
           restore-keys: ccache-${{matrix.distro}}${{matrix.version}}-
 
@@ -213,7 +213,7 @@ jobs:
         if: github.ref == 'refs/heads/master'
         uses: actions/cache/save@v5
         with:
-          path: ${{env.CACHE_DIR}}
+          path: ${{env.CACHE}}
           key: ${{ steps.ccache_restore.outputs.cache-primary-key }}
 
       - name: Upload artifact


### PR DESCRIPTION
## Related Ticket(s)
- Follow up to #6703

## What will change with this Pull Request?
- Revert env name change (`CACHE_DIR` back to `CACHE`)

## Screenshots

- `master` branch with `CACHE_DIR` and "cache dir is not set!" warning:
  <img width="823" height="709" alt="image" src="https://github.com/user-attachments/assets/98b0bd19-799e-46f6-9316-2b46a402daa2" />

- This PR with `CACHE`:
  <img width="756" height="643" alt="image" src="https://github.com/user-attachments/assets/a766e696-c147-4c05-9ff3-a86b82bd6ce8" />
