### PR TITLE
remove all separate storing of widget sizes, rely on geometry

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
@@ -237,7 +237,6 @@ protected slots:
     // UI Layout Management
     virtual void loadLayout() = 0;
     virtual void restartLayout() = 0;
-    virtual void freeDocksSize() = 0;
     virtual void refreshShortcuts() = 0;
 
     /** @brief Handles dock close events. */

--- a/cockatrice/src/interface/widgets/tabs/tab_deck_editor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_deck_editor.cpp
@@ -143,17 +143,6 @@ void TabDeckEditor::loadLayout()
         restoreState(layoutState);
         restoreGeometry(layouts.getDeckEditorGeometry());
     }
-
-    for (auto it = dockToActions.constKeyValueBegin(); it != dockToActions.constKeyValueEnd(); ++it) {
-        auto dockWidget = it->first;
-        auto actions = it->second;
-
-        QSize size = layouts.getDeckEditorWidgetSize(dockWidget->objectName(), actions.defaultSize);
-        dockWidget->setMinimumSize(size);
-        dockWidget->setMaximumSize(size);
-    }
-
-    QTimer::singleShot(100, this, &TabDeckEditor::freeDocksSize);
 }
 
 /**
@@ -177,17 +166,6 @@ void TabDeckEditor::restartLayout()
     splitDockWidget(printingSelectorDockWidget, deckDockWidget, Qt::Horizontal);
     splitDockWidget(cardInfoDockWidget, printingSelectorDockWidget, Qt::Horizontal);
     splitDockWidget(cardInfoDockWidget, filterDockWidget, Qt::Vertical);
-
-    QTimer::singleShot(100, this, &TabDeckEditor::freeDocksSize);
-}
-
-/** @brief Frees dock sizes to allow flexible resizing. */
-void TabDeckEditor::freeDocksSize()
-{
-    for (auto dockWidget : dockToActions.keys()) {
-        dockWidget->setMinimumSize(100, 100);
-        dockWidget->setMaximumSize(5000, 5000);
-    }
 }
 
 /**
@@ -202,10 +180,6 @@ bool TabDeckEditor::eventFilter(QObject *o, QEvent *e)
         LayoutsSettings &layouts = SettingsCache::instance().layouts();
         layouts.setDeckEditorLayoutState(saveState());
         layouts.setDeckEditorGeometry(saveGeometry());
-
-        for (auto dockWidget : dockToActions.keys()) {
-            layouts.setDeckEditorWidgetSize(dockWidget->objectName(), dockWidget->size());
-        }
     }
     return false;
 }

--- a/cockatrice/src/interface/widgets/tabs/tab_deck_editor.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_deck_editor.h
@@ -62,9 +62,6 @@ protected slots:
     /** @brief Resets the layout to default positions and dock states. */
     void restartLayout() override;
 
-    /** @brief Frees the dock sizes for resizing flexibility. */
-    void freeDocksSize() override;
-
     /** @brief Refreshes shortcuts for this tab from settings. */
     void refreshShortcuts() override;
 

--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -1085,38 +1085,9 @@ void TabGame::loadLayout()
     if (replayDock) {
         restoreGeometry(layouts.getReplayPlayAreaGeometry());
         restoreState(layouts.getReplayPlayAreaLayoutState());
-
-        for (auto it = dockToActions.constKeyValueBegin(); it != dockToActions.constKeyValueEnd(); ++it) {
-            auto dockWidget = it->first;
-            auto actions = it->second;
-
-            QSize size = layouts.getReplayPlayAreaWidgetSize(dockWidget->objectName(), actions.defaultSize);
-            dockWidget->setMinimumSize(size);
-            dockWidget->setMaximumSize(size);
-        }
-
     } else {
         restoreGeometry(layouts.getGamePlayAreaGeometry());
         restoreState(layouts.getGamePlayAreaLayoutState());
-
-        for (auto it = dockToActions.constKeyValueBegin(); it != dockToActions.constKeyValueEnd(); ++it) {
-            auto dockWidget = it->first;
-            auto actions = it->second;
-
-            QSize size = layouts.getGamePlayAreaWidgetSize(dockWidget->objectName(), actions.defaultSize);
-            dockWidget->setMinimumSize(size);
-            dockWidget->setMaximumSize(size);
-        }
-    }
-
-    QTimer::singleShot(100, this, &TabGame::freeDocksSize);
-}
-
-void TabGame::freeDocksSize()
-{
-    for (auto dockWidget : dockToActions.keys()) {
-        dockWidget->setMinimumSize(100, 100);
-        dockWidget->setMaximumSize(5000, 5000);
     }
 }
 
@@ -1139,24 +1110,15 @@ void TabGame::actResetLayout()
         replayDock->setFloating(false);
         addDockWidget(Qt::BottomDockWidgetArea, replayDock);
 
-        cardInfoDock->setMinimumSize(250, 360);
-        cardInfoDock->setMaximumSize(250, 360);
-        messageLayoutDock->setMinimumSize(250, 200);
-        messageLayoutDock->setMaximumSize(250, 200);
-        playerListDock->setMinimumSize(250, 50);
-        playerListDock->setMaximumSize(250, 50);
-        replayDock->setMinimumSize(900, 100);
-        replayDock->setMaximumSize(900, 100);
+        cardInfoDock->resize(250, 360);
+        messageLayoutDock->resize(250, 200);
+        playerListDock->resize(250, 50);
+        replayDock->resize(900, 100);
     } else {
-        cardInfoDock->setMinimumSize(250, 360);
-        cardInfoDock->setMaximumSize(250, 360);
-        messageLayoutDock->setMinimumSize(250, 250);
-        messageLayoutDock->setMaximumSize(250, 250);
-        playerListDock->setMinimumSize(250, 50);
-        playerListDock->setMaximumSize(250, 50);
+        cardInfoDock->resize(250, 360);
+        messageLayoutDock->resize(250, 250);
+        playerListDock->resize(250, 50);
     }
-
-    QTimer::singleShot(100, this, &TabGame::freeDocksSize);
 }
 
 void TabGame::createPlayAreaWidget(bool bReplay)
@@ -1334,17 +1296,9 @@ void TabGame::hideEvent(QHideEvent *event)
     if (replayDock) {
         layouts.setReplayPlayAreaState(saveState());
         layouts.setReplayPlayAreaGeometry(saveGeometry());
-
-        for (auto dockWidget : dockToActions.keys()) {
-            layouts.setReplayPlayAreaWidgetSize(dockWidget->objectName(), dockWidget->size());
-        }
     } else {
         layouts.setGamePlayAreaState(saveState());
         layouts.setGamePlayAreaGeometry(saveGeometry());
-
-        for (auto dockWidget : dockToActions.keys()) {
-            layouts.setGamePlayAreaWidgetSize(dockWidget->objectName(), dockWidget->size());
-        }
     }
 
     Tab::hideEvent(event);

--- a/cockatrice/src/interface/widgets/tabs/tab_game.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.h
@@ -165,7 +165,6 @@ private slots:
     void notifyPlayerKicked();
     void processPlayerLeave(Player *leavingPlayer);
     void actResetLayout();
-    void freeDocksSize();
 
     void hideEvent(QHideEvent *event) override;
 

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
@@ -246,15 +246,6 @@ void TabDeckEditorVisual::showPrintingSelector()
     printingSelectorDockWidget->setVisible(true);
 }
 
-/** @brief Set size restrictions for free floating dock widgets. */
-void TabDeckEditorVisual::freeDocksSize()
-{
-    for (auto dockWidget : dockToActions.keys()) {
-        dockWidget->setMinimumSize(100, 100);
-        dockWidget->setMaximumSize(5000, 5000);
-    }
-}
-
 /** @brief Refreshes keyboard shortcuts for this tab from settings. */
 void TabDeckEditorVisual::refreshShortcuts()
 {
@@ -273,17 +264,6 @@ void TabDeckEditorVisual::loadLayout()
         restoreState(layoutState);
         restoreGeometry(layouts.getVisualDeckEditorGeometry());
     }
-
-    for (auto it = dockToActions.constKeyValueBegin(); it != dockToActions.constKeyValueEnd(); ++it) {
-        auto dockWidget = it->first;
-        auto actions = it->second;
-
-        QSize size = layouts.getVisualDeckEditorWidgetSize(dockWidget->objectName(), actions.defaultSize);
-        dockWidget->setMinimumSize(size);
-        dockWidget->setMaximumSize(size);
-    }
-
-    QTimer::singleShot(100, this, &TabDeckEditorVisual::freeDocksSize);
 }
 
 /** @brief Resets the layout to default positions and dock states. */
@@ -346,10 +326,6 @@ bool TabDeckEditorVisual::eventFilter(QObject *o, QEvent *e)
         LayoutsSettings &layouts = SettingsCache::instance().layouts();
         layouts.setVisualDeckEditorLayoutState(saveState());
         layouts.setVisualDeckEditorGeometry(saveGeometry());
-
-        for (auto dockWidget : dockToActions.keys()) {
-            layouts.setVisualDeckEditorWidgetSize(dockWidget->objectName(), dockWidget->size());
-        }
     }
     return false;
 }

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.h
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.h
@@ -67,11 +67,6 @@ protected slots:
     void restartLayout() override;
 
     /**
-     * @brief Set size restrictions for free floating dock widgets.
-     */
-    void freeDocksSize() override;
-
-    /**
      * @brief Refresh keyboard shortcuts for this tab.
      */
     void refreshShortcuts() override;

--- a/libcockatrice_settings/libcockatrice/settings/layouts_settings.cpp
+++ b/libcockatrice_settings/libcockatrice/settings/layouts_settings.cpp
@@ -48,17 +48,6 @@ void LayoutsSettings::setDeckEditorGeometry(const QByteArray &value)
     setValue(value, GEOMETRY_PROP, GROUP_DECK_EDITOR);
 }
 
-void LayoutsSettings::setDeckEditorWidgetSize(const QString &widgetName, const QSize &value)
-{
-    setValue(value, widgetName, GROUP_DECK_EDITOR, SIZE_PROP);
-}
-
-QSize LayoutsSettings::getDeckEditorWidgetSize(const QString &widgetName, const QSize &defaultValue)
-{
-    QVariant previous = getValue(widgetName, GROUP_DECK_EDITOR, SIZE_PROP);
-    return previous == QVariant() ? defaultValue : previous.toSize();
-}
-
 QByteArray LayoutsSettings::getVisualDeckEditorLayoutState()
 {
     return getValue(STATE_PROP, GROUP_VISUAL_DECK_EDITOR).toByteArray();
@@ -77,17 +66,6 @@ QByteArray LayoutsSettings::getVisualDeckEditorGeometry()
 void LayoutsSettings::setVisualDeckEditorGeometry(const QByteArray &value)
 {
     setValue(value, GEOMETRY_PROP, GROUP_VISUAL_DECK_EDITOR);
-}
-
-void LayoutsSettings::setVisualDeckEditorWidgetSize(const QString &widgetName, const QSize &value)
-{
-    setValue(value, widgetName, GROUP_VISUAL_DECK_EDITOR, SIZE_PROP);
-}
-
-QSize LayoutsSettings::getVisualDeckEditorWidgetSize(const QString &widgetName, const QSize &defaultValue)
-{
-    QVariant previous = getValue(widgetName, GROUP_VISUAL_DECK_EDITOR, SIZE_PROP);
-    return previous == QVariant() ? defaultValue : previous.toSize();
 }
 
 QByteArray LayoutsSettings::getDeckEditorDbHeaderState()
@@ -150,17 +128,6 @@ QByteArray LayoutsSettings::getGamePlayAreaGeometry()
     return getValue(GEOMETRY_PROP, GROUP_GAME_PLAY_AREA).toByteArray();
 }
 
-void LayoutsSettings::setGamePlayAreaWidgetSize(const QString &widgetName, const QSize &value)
-{
-    setValue(value, widgetName, GROUP_GAME_PLAY_AREA, SIZE_PROP);
-}
-
-QSize LayoutsSettings::getGamePlayAreaWidgetSize(const QString &widgetName, const QSize &defaultValue)
-{
-    QVariant previous = getValue(widgetName, GROUP_GAME_PLAY_AREA, SIZE_PROP);
-    return previous == QVariant() ? defaultValue : previous.toSize();
-}
-
 void LayoutsSettings::setReplayPlayAreaGeometry(const QByteArray &value)
 {
     setValue(value, GEOMETRY_PROP, GROUP_REPLAY_PLAY_AREA);
@@ -179,15 +146,4 @@ QByteArray LayoutsSettings::getReplayPlayAreaLayoutState()
 QByteArray LayoutsSettings::getReplayPlayAreaGeometry()
 {
     return getValue(GEOMETRY_PROP, GROUP_REPLAY_PLAY_AREA).toByteArray();
-}
-
-void LayoutsSettings::setReplayPlayAreaWidgetSize(const QString &widgetName, const QSize &value)
-{
-    setValue(value, widgetName, GROUP_REPLAY_PLAY_AREA, SIZE_PROP);
-}
-
-QSize LayoutsSettings::getReplayPlayAreaWidgetSize(const QString &widgetName, const QSize &defaultValue)
-{
-    QVariant previous = getValue(widgetName, GROUP_REPLAY_PLAY_AREA, SIZE_PROP);
-    return previous == QVariant() ? defaultValue : previous.toSize();
 }

--- a/libcockatrice_settings/libcockatrice/settings/layouts_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/layouts_settings.h
@@ -21,11 +21,9 @@ public:
 
     void setDeckEditorLayoutState(const QByteArray &value);
     void setDeckEditorGeometry(const QByteArray &value);
-    void setDeckEditorWidgetSize(const QString &widgetName, const QSize &value);
 
     void setVisualDeckEditorLayoutState(const QByteArray &value);
     void setVisualDeckEditorGeometry(const QByteArray &value);
-    void setVisualDeckEditorWidgetSize(const QString &widgetName, const QSize &value);
 
     void setDeckEditorDbHeaderState(const QByteArray &value);
     void setSetsDialogHeaderState(const QByteArray &value);
@@ -34,21 +32,17 @@ public:
 
     void setGamePlayAreaGeometry(const QByteArray &value);
     void setGamePlayAreaState(const QByteArray &value);
-    void setGamePlayAreaWidgetSize(const QString &widgetName, const QSize &value);
 
     void setReplayPlayAreaGeometry(const QByteArray &value);
     void setReplayPlayAreaState(const QByteArray &value);
-    void setReplayPlayAreaWidgetSize(const QString &widgetName, const QSize &value);
 
     QByteArray getMainWindowGeometry();
 
     QByteArray getDeckEditorLayoutState();
     QByteArray getDeckEditorGeometry();
-    QSize getDeckEditorWidgetSize(const QString &widgetName, const QSize &defaultValue = {});
 
     QByteArray getVisualDeckEditorLayoutState();
     QByteArray getVisualDeckEditorGeometry();
-    QSize getVisualDeckEditorWidgetSize(const QString &widgetName, const QSize &defaultValue = {});
 
     QByteArray getDeckEditorDbHeaderState();
     QByteArray getSetsDialogHeaderState();
@@ -57,11 +51,9 @@ public:
 
     QByteArray getGamePlayAreaLayoutState();
     QByteArray getGamePlayAreaGeometry();
-    QSize getGamePlayAreaWidgetSize(const QString &widgetName, const QSize &defaultValue = {});
 
     QByteArray getReplayPlayAreaLayoutState();
     QByteArray getReplayPlayAreaGeometry();
-    QSize getReplayPlayAreaWidgetSize(const QString &widgetName, const QSize &defaultValue = {});
 signals:
 
 public slots:


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4418
- fixes #4114


## Short roundup of the initial problem
when closing the app geometry is saved for each tab with docks, when reopening the app later on a different size will resize the app for some reason.

repro steps:
- open trice
- start local game
- close trice
- open trice
- resize the window
- start local game
- trice will "grow" a little bit in height if you have two or more docks stacked above each other anywhere (the default layout does)

058b91345 introduced the behavior of separately storing the sizes of docks outside of the geometry, now I don't know if this was different in 2016 but in the current version of qt all docks are properly restored in location when using the setGeometry function

## What will change with this Pull Request?
- remove all mentions of separately stored dock sizes, leaving just the restoreGeometry call
- note, this introduces a regression to the game tab that is already present on the deck editor: resetting the view on it will no longer reset the dock widths, only the heights, this affects all docks now, a separate fix for this needs to be found (preferably not one that was like the previous workaround with the timer, it blinks them in a kind of weird way)
