### PR TITLE
[ShortcutsSettings] Fix duplicate aPlay shortcut; change play shortcut's group

### DIFF
--- a/cockatrice/src/client/settings/shortcuts_settings.h
+++ b/cockatrice/src/client/settings/shortcuts_settings.h
@@ -513,7 +513,7 @@ private:
         {"Player/aPlay", ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Play Card"),
                                      parseSequenceString(""),
                                      ShortcutGroup::Playing_Area)},
-        {"Player/aPlayFacedown", ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Battlefield, Face Down"),
+        {"Player/aPlayFacedown", ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Play Card, Face Down"),
                                              parseSequenceString(""),
                                              ShortcutGroup::Playing_Area)},
         {"Player/aAttach", ShortcutKey(QT_TRANSLATE_NOOP("shortcutsTab", "Attach Card..."),


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug that was introduced in #3987

## Short roundup of the initial problem

We accidentally put two entries with the key `"Player/aPlay"` into the shortcuts map (under two different groups) when initializing it. This causes the later entry to overwrite the earlier entry. Somehow we never noticed until now.

## What will change with this Pull Request?
- Remove the `aPlay` shortcut in the `Move_selected` group
- Move `aPlayFaceDown` to the `Playing_Area` group, since the `play face down` action isn't part of the move menu.
  - Update description

## Screenshots

<img width="663" height="347" alt="Screenshot 2026-03-16 at 9 06 27 PM" src="https://github.com/user-attachments/assets/6f8b2ae8-4021-4f1d-851d-a80dfe711f1c" />
