### PR TITLE
[Game] Refactor DlgMoveTopCardsUntil options into struct

### DIFF
--- a/cockatrice/src/game/dialogs/dlg_move_top_cards_until.cpp
+++ b/cockatrice/src/game/dialogs/dlg_move_top_cards_until.cpp
@@ -12,8 +12,7 @@
 #include <libcockatrice/card/database/card_database_manager.h>
 #include <libcockatrice/filters/filter_string.h>
 
-DlgMoveTopCardsUntil::DlgMoveTopCardsUntil(QWidget *parent, QStringList exprs, uint _numberOfHits, bool autoPlay)
-    : QDialog(parent)
+DlgMoveTopCardsUntil::DlgMoveTopCardsUntil(QWidget *parent, const MoveTopCardsUntilOptions &options) : QDialog(parent)
 {
     exprLabel = new QLabel(tr("Card name (or search expressions):"));
 
@@ -21,13 +20,13 @@ DlgMoveTopCardsUntil::DlgMoveTopCardsUntil(QWidget *parent, QStringList exprs, u
     exprComboBox->setFocus();
     exprComboBox->setEditable(true);
     exprComboBox->setInsertPolicy(QComboBox::InsertAtTop);
-    exprComboBox->insertItems(0, exprs);
+    exprComboBox->insertItems(0, options.exprs);
     exprLabel->setBuddy(exprComboBox);
 
     numberOfHitsLabel = new QLabel(tr("Number of hits:"));
     numberOfHitsEdit = new QSpinBox(this);
     numberOfHitsEdit->setRange(1, 99);
-    numberOfHitsEdit->setValue(_numberOfHits);
+    numberOfHitsEdit->setValue(options.numberOfHits);
     numberOfHitsLabel->setBuddy(numberOfHitsEdit);
 
     auto *grid = new QGridLayout;
@@ -35,7 +34,7 @@ DlgMoveTopCardsUntil::DlgMoveTopCardsUntil(QWidget *parent, QStringList exprs, u
     grid->addWidget(numberOfHitsEdit, 0, 1);
 
     autoPlayCheckBox = new QCheckBox(tr("Auto play hits"));
-    autoPlayCheckBox->setChecked(autoPlay);
+    autoPlayCheckBox->setChecked(options.autoPlay);
 
     buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgMoveTopCardsUntil::validateAndAccept);
@@ -118,6 +117,13 @@ QString DlgMoveTopCardsUntil::getExpr() const
     return exprComboBox->currentText();
 }
 
+MoveTopCardsUntilOptions DlgMoveTopCardsUntil::getOptions() const
+{
+    return {.exprs = getExprs(),
+            .numberOfHits = numberOfHitsEdit->text().toInt(),
+            .autoPlay = autoPlayCheckBox->isChecked()};
+}
+
 QStringList DlgMoveTopCardsUntil::getExprs() const
 {
     QStringList exprs;
@@ -125,14 +131,4 @@ QStringList DlgMoveTopCardsUntil::getExprs() const
         exprs.append(exprComboBox->itemText(i));
     }
     return exprs;
-}
-
-uint DlgMoveTopCardsUntil::getNumberOfHits() const
-{
-    return numberOfHitsEdit->text().toUInt();
-}
-
-bool DlgMoveTopCardsUntil::isAutoPlay() const
-{
-    return autoPlayCheckBox->isChecked();
 }

--- a/cockatrice/src/game/dialogs/dlg_move_top_cards_until.h
+++ b/cockatrice/src/game/dialogs/dlg_move_top_cards_until.h
@@ -16,6 +16,13 @@
 
 class FilterString;
 
+struct MoveTopCardsUntilOptions
+{
+    QStringList exprs = {};
+    int numberOfHits = 1;
+    bool autoPlay = false;
+};
+
 class DlgMoveTopCardsUntil : public QDialog
 {
     Q_OBJECT
@@ -29,15 +36,12 @@ class DlgMoveTopCardsUntil : public QDialog
     void validateAndAccept();
     bool validateMatchExists(const FilterString &filterString);
 
-public:
-    explicit DlgMoveTopCardsUntil(QWidget *parent = nullptr,
-                                  QStringList exprs = QStringList(),
-                                  uint numberOfHits = 1,
-                                  bool autoPlay = false);
-    [[nodiscard]] QString getExpr() const;
     [[nodiscard]] QStringList getExprs() const;
-    [[nodiscard]] uint getNumberOfHits() const;
-    [[nodiscard]] bool isAutoPlay() const;
+
+public:
+    explicit DlgMoveTopCardsUntil(QWidget *parent = nullptr, const MoveTopCardsUntilOptions &options = {});
+    [[nodiscard]] QString getExpr() const;
+    [[nodiscard]] MoveTopCardsUntilOptions getOptions() const;
 };
 
 #endif // DLG_MOVE_TOP_CARDS_UNTIL_H

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -485,22 +485,19 @@ void PlayerActions::actMoveTopCardsUntil()
 {
     stopMoveTopCardsUntil();
 
-    DlgMoveTopCardsUntil dlg(player->getGame()->getTab(), movingCardsUntilExprs, movingCardsUntilNumberOfHits,
-                             movingCardsUntilAutoPlay);
+    DlgMoveTopCardsUntil dlg(player->getGame()->getTab(), movingCardsUntilOptions);
     if (!dlg.exec()) {
         return;
     }
 
     auto expr = dlg.getExpr();
-    movingCardsUntilExprs = dlg.getExprs();
-    movingCardsUntilNumberOfHits = dlg.getNumberOfHits();
-    movingCardsUntilAutoPlay = dlg.isAutoPlay();
+    movingCardsUntilOptions = dlg.getOptions();
 
     if (player->getDeckZone()->getCards().empty()) {
         stopMoveTopCardsUntil();
     } else {
         movingCardsUntilFilter = FilterString(expr);
-        movingCardsUntilCounter = movingCardsUntilNumberOfHits;
+        movingCardsUntilCounter = movingCardsUntilOptions.numberOfHits;
         movingCardsUntil = true;
         actMoveTopCardToPlay();
     }
@@ -512,7 +509,7 @@ void PlayerActions::moveOneCardUntil(CardItem *card)
 
     const bool isMatch = card && movingCardsUntilFilter.check(card->getCard().getCardPtr());
 
-    if (isMatch && movingCardsUntilAutoPlay) {
+    if (isMatch && movingCardsUntilOptions.autoPlay) {
         // Directly calling playCard will deadlock, since we are already in the middle of processing an event.
         // Use QTimer::singleShot to queue up the playCard on the event loop.
         QTimer::singleShot(0, this, [card, this] { playCard(card, false); });

--- a/cockatrice/src/game/player/player_actions.h
+++ b/cockatrice/src/game/player/player_actions.h
@@ -8,6 +8,7 @@
 #ifndef COCKATRICE_PLAYER_ACTIONS_H
 #define COCKATRICE_PLAYER_ACTIONS_H
 #include "../dialogs/dlg_create_token.h"
+#include "../dialogs/dlg_move_top_cards_until.h"
 #include "event_processing_options.h"
 #include "player.h"
 
@@ -178,11 +179,9 @@ private:
 
     bool movingCardsUntil;
     QTimer *moveTopCardTimer;
-    QStringList movingCardsUntilExprs = {};
-    int movingCardsUntilNumberOfHits = 1;
-    bool movingCardsUntilAutoPlay = false;
     FilterString movingCardsUntilFilter;
     int movingCardsUntilCounter = 0;
+    MoveTopCardsUntilOptions movingCardsUntilOptions;
 
     void moveTopCardsTo(const QString &targetZone, const QString &zoneDisplayName, bool faceDown);
     void moveBottomCardsTo(const QString &targetZone, const QString &zoneDisplayName, bool faceDown);


### PR DESCRIPTION
## Short roundup of the initial problem

We should refactor the options in `DlgMoveTopCardsUntil` into a struct to make it closer to how we handle options in other in-game dialogs. (For example, the create token dialog)

## What will change with this Pull Request?

- Moved the options in `DlgMoveTopCardsUntil` into a struct
  - replace getters for fields with getter for that struct
  - pass that struct into constructor
- Save that struct in `PlayerActions` instead of each field individually