### PR TITLE
[Dialog] Reduce spacing in create local game dialog

### DIFF
--- a/cockatrice/src/interface/widgets/dialogs/dlg_local_game_options.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_local_game_options.cpp
@@ -20,6 +20,7 @@ DlgLocalGameOptions::DlgLocalGameOptions(QWidget *parent) : QDialog(parent)
     numberPlayersLabel->setBuddy(numberPlayersEdit);
 
     auto *generalGrid = new QGridLayout;
+    generalGrid->setContentsMargins(5, 5, 5, 5);
     generalGrid->addWidget(numberPlayersLabel, 0, 0);
     generalGrid->addWidget(numberPlayersEdit, 0, 1);
     generalGroupBox = new QGroupBox(tr("General"), this);
@@ -33,6 +34,7 @@ DlgLocalGameOptions::DlgLocalGameOptions(QWidget *parent) : QDialog(parent)
     startingLifeTotalLabel->setBuddy(startingLifeTotalEdit);
 
     auto *gameSetupGrid = new QGridLayout;
+    gameSetupGrid->setContentsMargins(5, 5, 5, 5);
     gameSetupGrid->addWidget(startingLifeTotalLabel, 0, 0);
     gameSetupGrid->addWidget(startingLifeTotalEdit, 0, 1);
     gameSetupOptionsGroupBox = new QGroupBox(tr("Game setup options"), this);


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6669

## Short roundup of the initial problem

The create local game dialog has too much empty space in the group boxes. It looks awkward when there's only a single entry in each box.

<img width="245" height="265" alt="Screenshot 2026-03-18 at 2 45 49 AM" src="https://github.com/user-attachments/assets/2d2411f2-d6e3-4d1f-aaff-b38e59ccd673" />

## What will change with this Pull Request?
- Reduce spacing in the group boxes

<img width="234" height="238" alt="Screenshot 2026-03-18 at 2 44 51 AM" src="https://github.com/user-attachments/assets/1011259a-7394-4596-8904-48e927230d12" />
