### PR TITLE
CI: Uniform caching strategy & improved GHA cache names

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -357,8 +357,8 @@ jobs:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         with:
           path: ${{env.CCACHE_DIR}}
-          key: ccache-${{matrix.runner}}-${{matrix.soc}}-${{matrix.type}}-${{env.BRANCH_NAME}}
-          restore-keys: ccache-${{matrix.runner}}-${{matrix.soc}}-${{matrix.type}}-
+          key: ccache-${{matrix.os}}${{matrix.target}}${{matrix.soc == 'Intel' && '_Intel' || ''}}-${{matrix.type}}-${{env.BRANCH_NAME}}
+          restore-keys: ccache-${{matrix.os}}${{matrix.target}}${{matrix.soc == 'Intel' && '_Intel' || ''}}-${{matrix.type}}-
 
       - name: Install aqtinstall
         run: pipx install aqtinstall

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -394,7 +394,7 @@ jobs:
         run: .ci/thin_macos_qtlib.sh
 
       - name: Cache thin Qt libraries (macOS${{matrix.soc == 'Intel' && ', Intel' || ''}})
-        if: matrix.os == 'macOS' && steps.qt_restore.outputs.cache-hit != 'true'
+        if: matrix.os == 'macOS' && steps.qt_restore.outputs.cache-hit != 'true' && github.ref == 'refs/heads/master'
         uses: actions/cache/save@v5
         with:
           path: ${{ github.workspace }}/Qt
@@ -407,7 +407,7 @@ jobs:
           version: ${{ steps.resolve_qt_version.outputs.version }}
           arch: ${{matrix.qt_arch}}
           modules: ${{matrix.qt_modules}}
-          cache: true
+          cache: ${{ github.ref == 'refs/heads/master' }}
           cache-key-prefix: qt
 
       - name: Install NSIS

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -375,10 +375,10 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/Qt
-          key: Qt-${{ steps.resolve_qt_version.outputs.version }}-thin-${{matrix.os}}${{matrix.soc == 'Intel' && '_Intel' || '_Apple'}}
+          key: qt-${{matrix.os}}${{matrix.soc == 'Intel' && '_Intel' || '_Apple'}}-${{ steps.resolve_qt_version.outputs.version }}-thin
 
       # Using jurplel/install-qt-action to install Qt without using brew
-      # qt build using vcpkg either just fails or takes too long to build
+      # Qt build using vcpkg either just fails or takes too long to build
       - name: Install fat Qt ${{ steps.resolve_qt_version.outputs.version }} (macOS${{matrix.soc == 'Intel' && ', Intel' || ''}})
         if: matrix.os == 'macOS' && steps.qt_restore.outputs.cache-hit != 'true'
         uses: jurplel/install-qt-action@v4
@@ -408,6 +408,7 @@ jobs:
           arch: ${{matrix.qt_arch}}
           modules: ${{matrix.qt_modules}}
           cache: true
+          cache-key-prefix: qt
 
       - name: Install NSIS
         if: matrix.os == 'Windows'

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -420,6 +420,7 @@ jobs:
         uses: TAServers/vcpkg-cache@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: vcpkg-
 
       # uses environment variables, see compile.sh for more details
       - name: Build Cockatrice

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -427,20 +427,21 @@ jobs:
         id: build
         shell: bash
         env:
-          BUILDTYPE: '${{matrix.type}}'
-          MAKE_PACKAGE: '${{matrix.make_package}}'
-          PACKAGE_SUFFIX: '${{matrix.package_suffix}}'
-          CMAKE_GENERATOR: ${{matrix.cmake_generator}}
-          CMAKE_GENERATOR_PLATFORM: ${{matrix.cmake_generator_platform}}
-          USE_CCACHE: ${{matrix.use_ccache}}
-          VCPKG_DISABLE_METRICS: 1
-          VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'
+          BUILDTYPE: ${{ matrix.type }}
+          MAKE_PACKAGE: ${{ matrix.make_package }}
+          PACKAGE_SUFFIX: ${{ matrix.package_suffix }}
+          CMAKE_GENERATOR: ${{ matrix.cmake_generator }}
+          CMAKE_GENERATOR_PLATFORM: ${{ matrix.cmake_generator_platform }}
+          USE_CCACHE: ${{ matrix.use_ccache }}
+          VCPKG_DISABLE_METRICS: true
+          VCPKG_FEATURE_FLAGS: "binarycaching"
+          VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},${{ github.ref == 'refs/heads/master' && 'readwrite' || 'read' }}"
           # macOS-specific environment variables, will be ignored on Windows
           MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
           MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
-          DEVELOPER_DIR: '/Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer'
+          DEVELOPER_DIR: "/Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer"
           TARGET_MACOS_VERSION: ${{ matrix.override_target }}
         run: .ci/compile.sh --server --test --vcpkg
 

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -369,18 +369,18 @@ jobs:
         shell: bash
         run: .ci/resolve_latest_aqt_qt_version.sh "${{matrix.qt_version}}"
 
-      - name: Restore thin Qt ${{ steps.resolve_qt_version.outputs.version }} libraries (${{ matrix.soc }} macOS)
+      - name: Restore thin Qt ${{ steps.resolve_qt_version.outputs.version }} libraries (macOS${{matrix.soc == 'Intel' && ', Intel' || ''}})
         if: matrix.os == 'macOS'
-        id: restore_qt
+        id: qt_restore
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/Qt
-          key: thin-qt-macos-${{ matrix.soc }}-${{ steps.resolve_qt_version.outputs.version }}
+          key: Qt-${{ steps.resolve_qt_version.outputs.version }}-thin-${{matrix.os}}${{matrix.soc == 'Intel' && '_Intel' || '_Apple'}}
 
       # Using jurplel/install-qt-action to install Qt without using brew
       # qt build using vcpkg either just fails or takes too long to build
-      - name: Install fat Qt ${{ steps.resolve_qt_version.outputs.version }} (${{ matrix.soc }} macOS)
-        if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'
+      - name: Install fat Qt ${{ steps.resolve_qt_version.outputs.version }} (macOS${{matrix.soc == 'Intel' && ', Intel' || ''}})
+        if: matrix.os == 'macOS' && steps.qt_restore.outputs.cache-hit != 'true'
         uses: jurplel/install-qt-action@v4
         with:
           version: ${{ steps.resolve_qt_version.outputs.version }}
@@ -389,16 +389,16 @@ jobs:
           cache: false
           dir: ${{github.workspace}}
 
-      - name: Thin Qt libraries (${{ matrix.soc }} macOS)
-        if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'
+      - name: Thin Qt libraries (macOS${{matrix.soc == 'Intel' && ', Intel' || ''}})
+        if: matrix.os == 'macOS' && steps.qt_restore.outputs.cache-hit != 'true'
         run: .ci/thin_macos_qtlib.sh
 
-      - name: Cache thin Qt libraries (${{ matrix.soc }} macOS)
-        if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'
+      - name: Cache thin Qt libraries (macOS${{matrix.soc == 'Intel' && ', Intel' || ''}})
+        if: matrix.os == 'macOS' && steps.qt_restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: ${{ github.workspace }}/Qt
-          key: thin-qt-macos-${{ matrix.soc }}-${{ steps.resolve_qt_version.outputs.version }}
+          key: ${{ steps.qt_restore.outputs.cache-primary-key }}
 
       - name: Install Qt ${{matrix.qt_version}} (Windows)
         if: matrix.os == 'Windows'

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -64,4 +64,4 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           annotations: ${{ steps.metadata.outputs.annotations }}
           cache-from: type=gha,scope=servatrice
-          cache-to: type=gha,mode=max,scope=servatrice
+          cache-to: ${{ github.ref == 'refs/heads/master' && 'type=gha,mode=max,scope=servatrice' || '' }}


### PR DESCRIPTION
## Short roundup of the initial problem
- ~~As `matrix.runner` already included "intel", we end up with double `intel-Intel`:~~
  <img width="375" height="145" alt="image" src="https://github.com/user-attachments/assets/2dcb1aee-e9a2-4f2c-b62c-ebdf8d85a215" />
  Solved in macos-26 runner PR (#7035)
- ~~We currently show the macOS version of the underlaying runner, not the target OS.
  In above example we are building for "macOS **13** Intel", not "macOS **15** Intel".~~
  Solved in macos-26 runner PR (#7035)
- Finding the right entries amongst the 500+ entries is tricky. The filter is also very limited in how it works and what can be searched for:
  <img width="1301" height="361" alt="image" src="https://github.com/user-attachments/assets/290d0394-ea6c-414b-8eed-cf973d89207a" />
- Names and cache separation are not very good designed or clear
- Compiler caches do save when run from PR's which pollutes core caches for example

## What will change with this Pull Request?
- Same naming as with our binaries:
  - No hint: default Apple Silicon for modern systems
  - `Intel` label: Native Intel version for compatibility on older x86_64 Mac hardware
- Apply same caching strategy as for compiler cache, also for Docker, Qt and vcpkg:
  Only save caches for runs from `master` branch
- Have clearer scope and uniform pattern when going through GHA caches (`Qt-*`, `ccache-*`, `vcpkg-*` ...)
(inspired by #6704)
  - Rename Qt cache for Mac
  - Rename Qt cache for Win
  - Rename vcpkg cache
  - The docker related ones (`buildkit`, `docker.io`, `index`) are tricky to rename and give a uniform prefix
- Cache filtering for `qt` now works: ["key:qt"](https://github.com/Cockatrice/Cockatrice/actions/caches?query=key%3Aqt)
- Cleaner names for steps without spaces when no "matrix.soc" is available for Win builds

<br>

Superseded by #7186, which introduces the uniform "save caches from master" strategy.
The other changes are mostly in place already, or no longer relevant.