### PR TITLE
expand local game starting life total limits

### DIFF
--- a/cockatrice/src/interface/widgets/dialogs/dlg_local_game_options.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_local_game_options.cpp
@@ -28,8 +28,8 @@ DlgLocalGameOptions::DlgLocalGameOptions(QWidget *parent) : QDialog(parent)
 
     startingLifeTotalLabel = new QLabel(tr("Starting life total:"), this);
     startingLifeTotalEdit = new QSpinBox(this);
-    startingLifeTotalEdit->setMinimum(1);
-    startingLifeTotalEdit->setMaximum(99999);
+    startingLifeTotalEdit->setMinimum(-999999999);
+    startingLifeTotalEdit->setMaximum(999999999);
     startingLifeTotalEdit->setValue(20);
     startingLifeTotalLabel->setBuddy(startingLifeTotalEdit);
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6717

## Short roundup of the initial problem
the dialog enforced an arbitrary limit on what the starting life total can be, such limitation does not exist in cockatrice's protocol

## What will change with this Pull Request?
- I have expanded the limit to span from -999999999 to 999999999 which hopefully is enough for all usecases (640kb ought to be enough for everyone)