### PR TITLE
Contextual menus improvements

### DIFF
--- a/cockatrice/src/game/player/menu/card_menu.cpp
+++ b/cockatrice/src/game/player/menu/card_menu.cpp
@@ -108,6 +108,7 @@ CardMenu::CardMenu(Player *_player, const CardItem *_card, bool _shortcutsActive
 
     if (revealedCard) {
         addAction(aHide);
+        addSeparator();
         addAction(aClone);
         addSeparator();
         addAction(aSelectAll);
@@ -146,16 +147,14 @@ void CardMenu::createTableMenu(bool canModifyCard)
 {
     // Card is on the battlefield
     if (!canModifyCard) {
-        addRelatedCardView();
-        addRelatedCardActions();
-
-        addSeparator();
         addAction(aDrawArrow);
         addSeparator();
         addAction(aClone);
         addSeparator();
         addAction(aSelectAll);
         addAction(aSelectRow);
+        addRelatedCardView();
+        addRelatedCardActions();
         return;
     }
 
@@ -165,10 +164,9 @@ void CardMenu::createTableMenu(bool canModifyCard)
     if (card->getFaceDown()) {
         addAction(aPeek);
     }
-
-    addRelatedCardView();
-    addRelatedCardActions();
-
+    addSeparator();
+    addAction(aClone);
+    addMenu(new MoveMenu(player));
     addSeparator();
     addAction(aAttach);
     if (card->getAttachedTo()) {
@@ -178,9 +176,6 @@ void CardMenu::createTableMenu(bool canModifyCard)
     addSeparator();
     addMenu(new PtMenu(player));
     addAction(aSetAnnotation);
-    addSeparator();
-    addAction(aClone);
-    addMenu(new MoveMenu(player));
     addSeparator();
     addAction(aSelectAll);
     addAction(aSelectRow);
@@ -197,27 +192,34 @@ void CardMenu::createTableMenu(bool canModifyCard)
     }
     addSeparator();
     addMenu(mCardCounters);
+    addRelatedCardView();
+    addRelatedCardActions();
 }
 
 void CardMenu::createStackMenu(bool canModifyCard)
 {
     // Card is on the stack
-    if (canModifyCard) {
-        addAction(aAttach);
-        addAction(aDrawArrow);
-        addSeparator();
-        addAction(aClone);
-        addMenu(new MoveMenu(player));
-        addSeparator();
-        addAction(aSelectAll);
-    } else {
+    if (!canModifyCard) {
         addAction(aDrawArrow);
         addSeparator();
         addAction(aClone);
         addSeparator();
         addAction(aSelectAll);
+        addRelatedCardView();
+        addRelatedCardActions();
+        return;
     }
 
+    addAction(aPlay);
+    addAction(aPlayFacedown);
+    addSeparator();
+    addAction(aClone);
+    addMenu(new MoveMenu(player));
+    addSeparator();
+    addAction(aAttach);
+    addAction(aDrawArrow);
+    addSeparator();
+    addAction(aSelectAll);
     addRelatedCardView();
     addRelatedCardActions();
 }
@@ -225,29 +227,29 @@ void CardMenu::createStackMenu(bool canModifyCard)
 void CardMenu::createGraveyardOrExileMenu(bool canModifyCard)
 {
     // Card is in the graveyard or exile
-    if (canModifyCard) {
-        addAction(aPlay);
-        addAction(aPlayFacedown);
-
-        addSeparator();
-        addAction(aClone);
-        addMenu(new MoveMenu(player));
-        addSeparator();
-        addAction(aSelectAll);
-        addAction(aSelectColumn);
-
-        addSeparator();
-        addAction(aAttach);
+    if (!canModifyCard) {
         addAction(aDrawArrow);
-    } else {
+        addSeparator();
         addAction(aClone);
         addSeparator();
         addAction(aSelectAll);
         addAction(aSelectColumn);
-        addSeparator();
-        addAction(aDrawArrow);
+        addRelatedCardView();
+        addRelatedCardActions();
+        return;
     }
 
+    addAction(aPlay);
+    addAction(aPlayFacedown);
+    addSeparator();
+    addAction(aClone);
+    addMenu(new MoveMenu(player));
+    addSeparator();
+    addAction(aAttach);
+    addAction(aDrawArrow);
+    addSeparator();
+    addAction(aSelectAll);
+    addAction(aSelectColumn);
     addRelatedCardView();
     addRelatedCardActions();
 }
@@ -257,12 +259,11 @@ void CardMenu::createHandOrCustomZoneMenu(bool canModifyCard)
     if (!canModifyCard) {
         addAction(aDrawArrow);
         addSeparator();
-        addRelatedCardView();
-        addRelatedCardActions();
-        addSeparator();
         addAction(aClone);
         addSeparator();
         addAction(aSelectAll);
+        addRelatedCardView();
+        addRelatedCardActions();
         return;
     }
 

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -64,7 +64,7 @@ void PlayerActions::playCard(CardItem *card, bool faceDown)
     int tableRow = info.getUiAttributes().tableRow;
     bool playToStack = SettingsCache::instance().getPlayToStack();
     QString currentZone = card->getZone()->getName();
-    if (currentZone == ZoneNames::STACK && tableRow == 3) {
+    if (!faceDown && currentZone == ZoneNames::STACK && tableRow == 3) {
         cmd.set_target_zone(ZoneNames::GRAVE);
         cmd.set_x(0);
         cmd.set_y(0);


### PR DESCRIPTION
## Short roundup of the initial problem
Play and play face down options weren't implemented for the stack

## What will change with this Pull Request?

Reorganize card context menus across table, stack, and graveyard/exile zones for better consistency: promote Draw Arrow and Clone actions, move related card entries to the bottom, add Play/Play Face Down to the stack menu, and flatten if/else blocks with early returns. 
Also fix playCard() ignoring the faceDown flag when routing instants/sorceries from the stack, which sent them to the graveyard instead of the table.