### PR TITLE
add a nullcheck in the card item animation timer

### DIFF
--- a/cockatrice/src/game/board/card_item.cpp
+++ b/cockatrice/src/game/board/card_item.cpp
@@ -460,6 +460,9 @@ void CardItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
 
 bool CardItem::animationEvent()
 {
+    if (owner == nullptr) {
+        return false;
+    }
     int rotation = ROTATION_DEGREES_PER_FRAME;
     bool animationIncomplete = true;
     if (!tapped)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4440

## Short roundup of the initial problem
crash happening if a card was firing its animation timer while a player was destructed, this should not be possible but was happening anyway

## What will change with this Pull Request?
- nullcheck a card's owner (controller / container of its zone) before attempting to modify any of it.