### PR TITLE
Scry fix

### DIFF
--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -145,7 +145,7 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
     zoneHBox->addItem(scrollBarProxy);
 
     vbox->addItem(zoneHBox);
-    
+
     if (_isReversed && showLibraryLabel(_origZone, numberCards)) {
         cardLocationLabel.setText(tr("Bottom of Library"));
         vbox->addItem(cardLocationLabelProxy);

--- a/cockatrice/src/game/zones/view_zone_widget.h
+++ b/cockatrice/src/game/zones/view_zone_widget.h
@@ -12,8 +12,8 @@
 #include <QComboBox>
 #include <QGraphicsProxyWidget>
 #include <QGraphicsWidget>
-#include <QLineEdit>
 #include <QLabel>
+#include <QLineEdit>
 #include <QPointer>
 #include <libcockatrice/utility/macros.h>
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3921 

## Short roundup of the initial problem
In the view top of library window, for some people, it can be ambiguous which card is on the top of the library. 

## What will change with this Pull Request?
Now, it will be more apparent. Above the card that represents the top of the library, it will say "Top of Library" 

Similarly, when viewing the bottom of the library, it will say "Bottom of Library" beneath the bottom card. 

It will only show this when viewing the library and only when viewing a specific number of cards. That is, if you just use F3, it will not show the label.

It will also not show when viewing any other zone (graveyard, exile, etc).

## Screenshots
<img width="222" height="271" alt="Screenshot From 2026-03-26 20-45-32" src="https://github.com/user-attachments/assets/9a8fd4ab-c3ed-4689-bca2-9ec013f7a556" />

