### PR TITLE
[SettingsManager] Properly handle multithreaded access

### DIFF
--- a/cockatrice/src/client/settings/card_counter_settings.cpp
+++ b/cockatrice/src/client/settings/card_counter_settings.cpp
@@ -11,6 +11,8 @@ CardCounterSettings::CardCounterSettings(const QString &settingsPath, QObject *p
 
 void CardCounterSettings::setColor(int counterId, const QColor &color)
 {
+    QSettings settings = getSettings();
+
     QString key = QString("cards/counters/%1/color").arg(counterId);
 
     if (settings.value(key).value<QColor>() == color)
@@ -36,7 +38,7 @@ QColor CardCounterSettings::color(int counterId) const
         defaultColor = QColor::fromHsv(h, s, v);
     }
 
-    return settings.value(QString("cards/counters/%1/color").arg(counterId), defaultColor).value<QColor>();
+    return getSettings().value(QString("cards/counters/%1/color").arg(counterId), defaultColor).value<QColor>();
 }
 
 QString CardCounterSettings::displayName(int counterId) const

--- a/libcockatrice_settings/libcockatrice/settings/settings_manager.cpp
+++ b/libcockatrice_settings/libcockatrice/settings/settings_manager.cpp
@@ -1,16 +1,22 @@
 #include "settings_manager.h"
 
-SettingsManager::SettingsManager(const QString &settingPath,
+SettingsManager::SettingsManager(const QString &_settingPath,
                                  const QString &_defaultGroup,
                                  const QString &_defaultSubGroup,
                                  QObject *parent)
-    : QObject(parent), settings(settingPath, QSettings::IniFormat), defaultGroup(_defaultGroup),
-      defaultSubGroup(_defaultSubGroup)
+    : QObject(parent), settingPath(_settingPath), defaultGroup(_defaultGroup), defaultSubGroup(_defaultSubGroup)
 {
+}
+
+QSettings SettingsManager::getSettings() const
+{
+    return QSettings(settingPath, QSettings::IniFormat);
 }
 
 void SettingsManager::setValue(const QVariant &value, const QString &name)
 {
+    auto settings = getSettings();
+
     if (!defaultGroup.isEmpty()) {
         settings.beginGroup(defaultGroup);
     }
@@ -35,6 +41,8 @@ void SettingsManager::setValue(const QVariant &value,
                                const QString &group,
                                const QString &subGroup)
 {
+    auto settings = getSettings();
+
     if (!group.isEmpty()) {
         settings.beginGroup(group);
     }
@@ -56,6 +64,8 @@ void SettingsManager::setValue(const QVariant &value,
 
 void SettingsManager::deleteValue(const QString &name)
 {
+    auto settings = getSettings();
+
     if (!defaultGroup.isEmpty()) {
         settings.beginGroup(defaultGroup);
     }
@@ -77,6 +87,8 @@ void SettingsManager::deleteValue(const QString &name)
 
 void SettingsManager::deleteValue(const QString &name, const QString &group, const QString &subGroup)
 {
+    auto settings = getSettings();
+
     if (!group.isEmpty()) {
         settings.beginGroup(group);
     }
@@ -98,6 +110,8 @@ void SettingsManager::deleteValue(const QString &name, const QString &group, con
 
 QVariant SettingsManager::getValue(const QString &name)
 {
+    auto settings = getSettings();
+
     if (!defaultGroup.isEmpty()) {
         settings.beginGroup(defaultGroup);
     }
@@ -121,6 +135,8 @@ QVariant SettingsManager::getValue(const QString &name)
 
 QVariant SettingsManager::getValue(const QString &name, const QString &group, const QString &subGroup)
 {
+    auto settings = getSettings();
+
     if (!group.isEmpty()) {
         settings.beginGroup(group);
     }
@@ -147,5 +163,7 @@ QVariant SettingsManager::getValue(const QString &name, const QString &group, co
  */
 void SettingsManager::sync()
 {
+    auto settings = getSettings();
+
     settings.sync();
 }

--- a/libcockatrice_settings/libcockatrice/settings/settings_manager.h
+++ b/libcockatrice_settings/libcockatrice/settings/settings_manager.h
@@ -24,9 +24,12 @@ public:
     void sync();
 
 protected:
-    QSettings settings;
+    QString settingPath;
     QString defaultGroup;
     QString defaultSubGroup;
+
+    QSettings getSettings() const;
+
     void setValue(const QVariant &value, const QString &name);
     void
     setValue(const QVariant &value, const QString &name, const QString &group, const QString &subGroup = QString());


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6744

## Short roundup of the initial problem

`SettingsManager` is not threadsafe. The class stores a `QSettings` instance, and calls `beginGroup` and `endGroup` on it in the getters (which mutates the instance!). Not to mention `QSettings` [isn't threadsafe anyways](https://doc.qt.io/qt-6/qsettings.html#accessing-settings-from-multiple-threads-or-processes-simultaneously)

This is leading to memory corruption in #6744 when the VDS tries to parse the decks on a background thread, which calls to `CardDatabase`, which then calls getters on `CardDatabaseSettings`.

## What will change with this Pull Request?

- Instead of storing a single `QSettings` instance, create a new `QSettings` instance locally on demand.

This is actually the [intended usage](https://doc.qt.io/qt-6/qsettings.html#basic-usage) of `QSettings`. `QSettings` is intentionally lightweight to create and destroy, so that you can create a new instance and use it on demand.