### PR TITLE
feat: support expressions when setting card counters

### DIFF
--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -1576,44 +1576,37 @@ void PlayerActions::actCardCounterTrigger()
         case 11: { // set counter with dialog
             player->setDialogSemaphore(true);
 
-            const auto &cardCounterSettings = SettingsCache::instance().cardCounters();
-            const auto &counterName = cardCounterSettings.displayName(counterId);
+            // If a single card is selected, we show the old value in the dialog. Otherwise, we show "x"
+            QList<QGraphicsItem *> sel = player->getGameScene()->selectedItems();
+            QString oldValueForDlg = "x";
+            if (sel.size() == 1) {
+                auto *card = dynamic_cast<CardItem *>(sel.first());
+                oldValueForDlg = QString::number(card->getCounters().value(counterId, 0));
+            }
 
-            const auto &selectedItems = player->getGameScene()->selectedItems();
-
-            const QString oldValueForDlg = [&selectedItems, &counterId] {
-                // If a single card is selected, we show the old value in the dialog. Otherwise, we show "x"
-                if (selectedItems.size() == 1) {
-                    const auto *card = dynamic_cast<CardItem *>(selectedItems.first());
-                    return QString::number(card->getCounters().value(counterId, 0));
-                }
-                return QString{"x"};
-            }();
+            auto &cardCounterSettings = SettingsCache::instance().cardCounters();
+            QString counterName = cardCounterSettings.displayName(counterId);
 
             AbstractCounterDialog dialog(counterName, oldValueForDlg, player->getGame()->getTab());
-            const int ok = dialog.exec();
-
-            if (!ok) {
-                return;
-            }
+            int ok = dialog.exec();
 
             player->setDialogSemaphore(false);
             if (player->clearCardsToDelete() || !ok) {
                 return;
             }
 
-            for (const auto &item : selectedItems) {
-                const auto *card = dynamic_cast<CardItem *>(item);
+            for (const auto &item : sel) {
+                auto *card = dynamic_cast<CardItem *>(item);
 
-                const auto oldValue = card->getCounters().value(counterId, 0);
+                int oldValue = card->getCounters().value(counterId, 0);
                 Expression exp(oldValue);
-                const auto newValue = static_cast<int>(exp.parse(dialog.textValue()));
+                int number = static_cast<int>(exp.parse(dialog.textValue()));
 
                 auto *cmd = new Command_SetCardCounter;
                 cmd->set_zone(card->getZone()->getName().toStdString());
                 cmd->set_card_id(card->getId());
                 cmd->set_counter_id(counterId);
-                cmd->set_counter_value(newValue);
+                cmd->set_counter_value(number);
                 commandList.append(cmd);
             }
             break;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem
Player counters support expressions when setting theirs values but card counters currently do not.

## What will change with this Pull Request?
- support expressions when setting card counters, including multiple selection
- when multiple cards are selected, the dialog shows "x" as the old value, which allows for expressions such as `x * 2`, making it easy to double all given counter for the selected cards
- reuse `AbstractCounterDialog` based on https://github.com/Cockatrice/Cockatrice/blob/c5fde071e79c162fa20a74d133b97c9488a4cb95/cockatrice/src/game/board/abstract_counter.cpp#L180

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

Single and multiple cards selected:

https://github.com/user-attachments/assets/abd214a2-ae57-49bb-b4d4-9a4364f5ad3b



