### PR TITLE
Fix #5774: Unused non-roll shortcuts in lobby

### DIFF
--- a/cockatrice/src/game/player/menu/player_menu.cpp
+++ b/cockatrice/src/game/player/menu/player_menu.cpp
@@ -2,6 +2,7 @@
 
 #include "../../../interface/widgets/tabs/tab_game.h"
 #include "../../board/card_item.h"
+#include "../../game_meta_info.h"
 #include "../../zones/hand_zone.h"
 #include "../../zones/pile_zone.h"
 #include "../../zones/table_zone.h"
@@ -48,6 +49,13 @@ PlayerMenu::PlayerMenu(Player *_player) : player(_player)
 
     connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
             &PlayerMenu::refreshShortcuts);
+    
+    // Monitor game state to re-evaluate shortcuts when game starts/stops
+    if (player->getGame() && player->getGame()->getGameMetaInfo()) {
+        connect(player->getGame()->getGameMetaInfo(), &GameMetaInfo::startedChanged, this,
+                &PlayerMenu::onGameStartedChanged);
+    }
+    
     refreshShortcuts();
 
     retranslateUi();
@@ -117,9 +125,39 @@ void PlayerMenu::refreshShortcuts()
     }
 }
 
+void PlayerMenu::onGameStartedChanged(bool started)
+{
+    Q_UNUSED(started);
+    // Re-evaluate shortcuts when game state transitions
+    if (shortcutsActive) {
+        setShortcutsActive();
+    }
+}
+
 void PlayerMenu::setShortcutsActive()
 {
     shortcutsActive = true;
+
+    // Null-safety checks
+    if (!player->getGame() || !player->getGame()->getGameMetaInfo()) {
+        return;
+    }
+
+    if (!player->getGame()->getGameMetaInfo()->started()) {
+        for (auto *component : managedComponents) {
+            component->setShortcutsInactive();
+        }
+
+        QMapIterator<int, AbstractCounter *> counterIterator(player->getCounters());
+        while (counterIterator.hasNext()) {
+            counterIterator.next().value()->setShortcutsInactive();
+        }
+
+        if (utilityMenu) {
+            utilityMenu->setLobbyShortcutsActive();
+        }
+        return;
+    }
 
     for (auto *component : managedComponents) {
         component->setShortcutsActive();

--- a/cockatrice/src/game/player/menu/player_menu.cpp
+++ b/cockatrice/src/game/player/menu/player_menu.cpp
@@ -49,13 +49,13 @@ PlayerMenu::PlayerMenu(Player *_player) : player(_player)
 
     connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
             &PlayerMenu::refreshShortcuts);
-    
+
     // Monitor game state to re-evaluate shortcuts when game starts/stops
     if (player->getGame() && player->getGame()->getGameMetaInfo()) {
         connect(player->getGame()->getGameMetaInfo(), &GameMetaInfo::startedChanged, this,
                 &PlayerMenu::onGameStartedChanged);
     }
-    
+
     refreshShortcuts();
 
     retranslateUi();

--- a/cockatrice/src/game/player/menu/player_menu.cpp
+++ b/cockatrice/src/game/player/menu/player_menu.cpp
@@ -144,9 +144,7 @@ void PlayerMenu::setShortcutsActive()
     }
 
     if (!player->getGame()->getGameMetaInfo()->started()) {
-        for (auto *component : managedComponents) {
-            component->setShortcutsInactive();
-        }
+        forManagedComponents([](auto *component) { component->setShortcutsInactive(); });
 
         QMapIterator<int, AbstractCounter *> counterIterator(player->getCounters());
         while (counterIterator.hasNext()) {
@@ -159,9 +157,7 @@ void PlayerMenu::setShortcutsActive()
         return;
     }
 
-    for (auto *component : managedComponents) {
-        component->setShortcutsActive();
-    }
+    forManagedComponents([](auto *component) { component->setShortcutsActive(); });
 
     // Counters implement AbstractPlayerComponent but are iterated via Player::counters
     // (the authoritative source) rather than managedComponents to avoid a redundant
@@ -176,9 +172,7 @@ void PlayerMenu::setShortcutsInactive()
 {
     shortcutsActive = false;
 
-    for (auto *component : managedComponents) {
-        component->setShortcutsInactive();
-    }
+    forManagedComponents([](auto *component) { component->setShortcutsInactive(); });
 
     QMapIterator<int, AbstractCounter *> counterIterator(player->getCounters());
     while (counterIterator.hasNext()) {

--- a/cockatrice/src/game/player/menu/player_menu.h
+++ b/cockatrice/src/game/player/menu/player_menu.h
@@ -69,7 +69,7 @@ public:
     }
 
     /// Delegates to all managedComponents, plus counters separately.
-    ///Stop full activation until game has started; only roll-die shortcut is active in lobby.
+    /// Stop full activation until game has started; only roll-die shortcut is active in lobby.
     void setShortcutsActive();
     /// Delegates to all managedComponents, plus counters separately.
     void setShortcutsInactive();

--- a/cockatrice/src/game/player/menu/player_menu.h
+++ b/cockatrice/src/game/player/menu/player_menu.h
@@ -69,9 +69,14 @@ public:
     }
 
     /// Delegates to all managedComponents, plus counters separately.
+    ///Stop full activation until game has started; only roll-die shortcut is active in lobby.
     void setShortcutsActive();
     /// Delegates to all managedComponents, plus counters separately.
     void setShortcutsInactive();
+
+private slots:
+    /// Re-evaluate shortcut state when game started/stopped state changes.
+    void onGameStartedChanged(bool started);
 
 private:
     Player *player;

--- a/cockatrice/src/game/player/menu/player_menu.h
+++ b/cockatrice/src/game/player/menu/player_menu.h
@@ -111,6 +111,14 @@ private:
         managedComponents.append(component);
         return component;
     }
+
+    /// Runs a normal for loop over all managedComponents, applying the provided function.
+    template <typename Func> void forManagedComponents(Func func)
+    {
+        for (auto *component : managedComponents) {
+            func(component);
+        }
+    }
 };
 
 #endif // COCKATRICE_PLAYER_MENU_H

--- a/cockatrice/src/game/player/menu/utility_menu.cpp
+++ b/cockatrice/src/game/player/menu/utility_menu.cpp
@@ -118,3 +118,13 @@ void UtilityMenu::setShortcutsInactive()
         aIncrementAllCardCounters->setShortcut(QKeySequence());
     }
 }
+
+void UtilityMenu::setLobbyShortcutsActive()
+{
+    if (!player->getPlayerInfo()->getLocalOrJudge()) {
+        return;
+    }
+
+    ShortcutsSettings &shortcuts = SettingsCache::instance().shortcuts();
+    aRollDie->setShortcuts(shortcuts.getShortcut("Player/aRollDie"));
+}

--- a/cockatrice/src/game/player/menu/utility_menu.h
+++ b/cockatrice/src/game/player/menu/utility_menu.h
@@ -23,6 +23,7 @@ public slots:
 
 public:
     explicit UtilityMenu(Player *player, QMenu *playerMenu);
+    void setLobbyShortcutsActive();
 
     [[nodiscard]] bool createAnotherTokenActionExists() const
     {


### PR DESCRIPTION


## Related Ticket(s)
- Fixes #5774 

## Short roundup of the initial problem
Player menu shortcuts are activated as soon as a local player is added, which happens in the deck selection lobby before the game starts.


## What will change with this Pull Request?
Disable full shortcut activation until the game has started.
Allow only the roll-die shortcut (Ctrl+I) while in the lobby.
