### PR TITLE
Dependabot: Ignore `vcpkg` updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
   - package-ecosystem: "gitsubmodule"
     # Look for `.gitmodules` in the `root` directory
     directory: "/"
+    ignore:
+      # Ignore updates for vcpkg (Bump to latest tag not working (no SemVer used) & macOS Intel triplet broken with newer releases)
+      - dependency-name: "vcpkg"
     # Check for updates once a month
     schedule:
       interval: "monthly"


### PR DESCRIPTION
## Short roundup of the initial problem
Bump to latest tag currently not working for vcpkg (CalVer tags with two-digit values used, not SemVer).
macOS Intel triplet broken with newer releases).

## What will change with this Pull Request?
- Skip dependabot for vcpkg for now