### PR TITLE
[Game] Refactor: move setCardAttrHelper to PlayerEventHandler

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -43,20 +43,6 @@ Player::Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, A
     connect(this, &Player::activeChanged, graphicsItem, &PlayerGraphicsItem::onPlayerActiveChanged);
 
     connect(this, &Player::openDeckEditor, game->getTab(), &TabGame::openDeckEditor);
-
-    forwardActionSignalsToEventHandler();
-}
-
-// Event Handler is the controller i.e. everything hooks up to this to know about player state
-// Player should forward (private) signals to the event handler
-
-void Player::forwardActionSignalsToEventHandler()
-{
-    connect(playerActions, &PlayerActions::logSetTapped, playerEventHandler, &PlayerEventHandler::logSetTapped);
-    connect(playerActions, &PlayerActions::logSetDoesntUntap, playerEventHandler,
-            &PlayerEventHandler::logSetDoesntUntap);
-    connect(playerActions, &PlayerActions::logSetAnnotation, playerEventHandler, &PlayerEventHandler::logSetAnnotation);
-    connect(playerActions, &PlayerActions::logSetPT, playerEventHandler, &PlayerEventHandler::logSetPT);
 }
 
 void Player::initializeZones()

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -82,7 +82,6 @@ public slots:
 
 public:
     Player(const ServerInfo_User &info, int _id, bool _local, bool _judge, AbstractGame *_parent);
-    void forwardActionSignalsToEventHandler();
     ~Player() override;
 
     void initializeZones();

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -1146,61 +1146,6 @@ void PlayerActions::actSayMessage()
     sendGameCommand(cmd);
 }
 
-void PlayerActions::setCardAttrHelper(const GameEventContext &context,
-                                      CardItem *card,
-                                      CardAttribute attribute,
-                                      const QString &avalue,
-                                      bool allCards,
-                                      EventProcessingOptions options)
-{
-    if (card == nullptr) {
-        return;
-    }
-
-    bool moveCardContext = context.HasExtension(Context_MoveCard::ext);
-    switch (attribute) {
-        case AttrTapped: {
-            bool tapped = avalue == "1";
-            if (!(!tapped && card->getDoesntUntap() && allCards)) {
-                if (!allCards) {
-                    emit logSetTapped(player, card, tapped);
-                }
-                bool canAnimate = !options.testFlag(SKIP_TAP_ANIMATION) && !moveCardContext;
-                card->setTapped(tapped, canAnimate);
-            }
-            break;
-        }
-        case AttrAttacking: {
-            card->setAttacking(avalue == "1");
-            break;
-        }
-        case AttrFaceDown: {
-            card->setFaceDown(avalue == "1");
-            break;
-        }
-        case AttrColor: {
-            card->setColor(avalue);
-            break;
-        }
-        case AttrAnnotation: {
-            emit logSetAnnotation(player, card, avalue);
-            card->setAnnotation(avalue);
-            break;
-        }
-        case AttrDoesntUntap: {
-            bool value = (avalue == "1");
-            emit logSetDoesntUntap(player, card, value);
-            card->setDoesntUntap(value);
-            break;
-        }
-        case AttrPT: {
-            emit logSetPT(player, card, avalue);
-            card->setPT(avalue);
-            break;
-        }
-    }
-}
-
 void PlayerActions::actMoveCardXCardsFromTop()
 {
     int deckSize = player->getDeckZone()->getCards().size() + 1; // add the card to move to the deck

--- a/cockatrice/src/game/player/player_actions.h
+++ b/cockatrice/src/game/player/player_actions.h
@@ -16,7 +16,6 @@
 #include <QObject>
 #include <libcockatrice/card/relation/card_relation_type.h>
 #include <libcockatrice/filters/filter_string.h>
-#include <libcockatrice/protocol/pb/card_attributes.pb.h>
 
 namespace google
 {
@@ -35,12 +34,6 @@ class PlayerActions : public QObject
 {
     Q_OBJECT
 
-signals:
-    void logSetTapped(Player *player, CardItem *card, bool tapped);
-    void logSetAnnotation(Player *player, CardItem *card, QString newAnnotation);
-    void logSetDoesntUntap(Player *player, CardItem *card, bool doesntUntap);
-    void logSetPT(Player *player, CardItem *card, QString newPT);
-
 public:
     enum CardsToReveal
     {
@@ -54,13 +47,6 @@ public:
 
     PendingCommand *prepareGameCommand(const ::google::protobuf::Message &cmd);
     PendingCommand *prepareGameCommand(const QList<const ::google::protobuf::Message *> &cmdList);
-
-    void setCardAttrHelper(const GameEventContext &context,
-                           CardItem *card,
-                           CardAttribute attribute,
-                           const QString &avalue,
-                           bool allCards,
-                           EventProcessingOptions options);
 
     void moveOneCardUntil(CardItem *card);
     void stopMoveTopCardsUntil();

--- a/cockatrice/src/game/player/player_event_handler.cpp
+++ b/cockatrice/src/game/player/player_event_handler.cpp
@@ -150,8 +150,8 @@ void PlayerEventHandler::eventSetCardAttr(const Event_SetCardAttr &event,
     if (!event.has_card_id()) {
         const CardList &cards = zone->getCards();
         for (int i = 0; i < cards.size(); ++i) {
-            player->getPlayerActions()->setCardAttrHelper(context, cards.at(i), event.attribute(),
-                                                          QString::fromStdString(event.attr_value()), true, options);
+            setCardAttrHelper(context, cards.at(i), event.attribute(), QString::fromStdString(event.attr_value()), true,
+                              options);
         }
         if (event.attribute() == AttrTapped) {
             emit logSetTapped(player, nullptr, event.attr_value() == "1");
@@ -162,8 +162,62 @@ void PlayerEventHandler::eventSetCardAttr(const Event_SetCardAttr &event,
             qWarning() << "PlayerEventHandler::eventSetCardAttr: card id=" << event.card_id() << "not found";
             return;
         }
-        player->getPlayerActions()->setCardAttrHelper(context, card, event.attribute(),
-                                                      QString::fromStdString(event.attr_value()), false, options);
+        setCardAttrHelper(context, card, event.attribute(), QString::fromStdString(event.attr_value()), false, options);
+    }
+}
+
+void PlayerEventHandler::setCardAttrHelper(const GameEventContext &context,
+                                           CardItem *card,
+                                           CardAttribute attribute,
+                                           const QString &avalue,
+                                           bool allCards,
+                                           EventProcessingOptions options)
+{
+    if (card == nullptr) {
+        return;
+    }
+
+    bool moveCardContext = context.HasExtension(Context_MoveCard::ext);
+    switch (attribute) {
+        case AttrTapped: {
+            bool tapped = avalue == "1";
+            if (!(!tapped && card->getDoesntUntap() && allCards)) {
+                if (!allCards) {
+                    emit logSetTapped(player, card, tapped);
+                }
+                bool canAnimate = !options.testFlag(SKIP_TAP_ANIMATION) && !moveCardContext;
+                card->setTapped(tapped, canAnimate);
+            }
+            break;
+        }
+        case AttrAttacking: {
+            card->setAttacking(avalue == "1");
+            break;
+        }
+        case AttrFaceDown: {
+            card->setFaceDown(avalue == "1");
+            break;
+        }
+        case AttrColor: {
+            card->setColor(avalue);
+            break;
+        }
+        case AttrAnnotation: {
+            emit logSetAnnotation(player, card, avalue);
+            card->setAnnotation(avalue);
+            break;
+        }
+        case AttrDoesntUntap: {
+            bool value = (avalue == "1");
+            emit logSetDoesntUntap(player, card, value);
+            card->setDoesntUntap(value);
+            break;
+        }
+        case AttrPT: {
+            emit logSetPT(player, card, avalue);
+            card->setPT(avalue);
+            break;
+        }
     }
 }
 

--- a/cockatrice/src/game/player/player_event_handler.h
+++ b/cockatrice/src/game/player/player_event_handler.h
@@ -9,6 +9,7 @@
 #include "event_processing_options.h"
 
 #include <QObject>
+#include <libcockatrice/protocol/pb/card_attributes.pb.h>
 #include <libcockatrice/protocol/pb/game_event.pb.h>
 #include <libcockatrice/protocol/pb/game_event_context.pb.h>
 
@@ -110,6 +111,13 @@ public:
 
 private:
     Player *player;
+
+    void setCardAttrHelper(const GameEventContext &context,
+                           CardItem *card,
+                           CardAttribute attribute,
+                           const QString &avalue,
+                           bool allCards,
+                           EventProcessingOptions options);
 };
 
 #endif // COCKATRICE_PLAYER_EVENT_HANDLER_H


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to changes made in #6112 and #6126

## Short roundup of the initial problem

The `setCardAttrHelper` method is in `PlayerActions`, which is the wrong place for it. 

`setCardAttrHelper` directly modifies the client's cardItem. However, `PlayerActions` should only be responsible for sending commands to the server. It should not directly modify the client-side cards. `PlayerEventHandler` is the class that is actually suppose to modify the client-side cards.

In fact, `setCardAttrHelper` only ever gets called from `PlayerEventHandler`. `PlayerActions` even has a bunch of signals to forward the logging to `PlayerEventHandler`. It seems like we didn't move the method to the correct place when we did the big refactor back then.

## What will change with this Pull Request?
- Moved `setCardAttrHelper` from `PlayerActions` to `PlayerEventHandler`
- Remove the now-unecessary signals from `PlayerActions`