### PR TITLE
Set OracleWizard style to "Modern" instead of "Aero"

### DIFF
--- a/cockatrice/src/interface/theme_manager.cpp
+++ b/cockatrice/src/interface/theme_manager.cpp
@@ -179,7 +179,7 @@ QBrush ThemeManager::loadExtraBrush(QString fileName, QBrush &fallbackBrush)
 
 static inline QPalette createDarkGreenFusionPalette()
 {
-    QPalette p;
+    QPalette p = QStyleFactory::create("Fusion")->standardPalette();
 
     // ---------- Core backgrounds ----------
     p.setColor(QPalette::Window, QColor(30, 30, 30));        // #ff1e1e1e
@@ -248,7 +248,7 @@ static inline QPalette createDarkGreenFusionPalette()
 
 static inline QPalette createLightGreenFusionPalette()
 {
-    QPalette p;
+    QPalette p = QStyleFactory::create("Fusion")->standardPalette();
 
     // ---------- Core backgrounds ----------
     p.setColor(QPalette::Window, QColor(240, 240, 240));        // #fff0f0f0
@@ -350,7 +350,7 @@ void ThemeManager::themeChangedSlot()
         qApp->setStyle(QStyleFactory::create("Fusion"));
         qApp->setPalette(createDarkGreenFusionPalette());
     } else {
-        qApp->setStyle(defaultStyleName); // setting the style also sets the palette
+        qApp->setStyle(QStyleFactory::create(defaultStyleName)); // setting the style also sets the palette
     }
 
     if (dirPath.isEmpty()) {

--- a/cockatrice/src/interface/theme_manager.cpp
+++ b/cockatrice/src/interface/theme_manager.cpp
@@ -332,13 +332,15 @@ void ThemeManager::themeChangedSlot()
     }
 
     if (themeName == FUSION_THEME_NAME) {
-        qApp->setStyle(QStyleFactory::create("Fusion"));
+        QStyle *fusionStyle = QStyleFactory::create("Fusion");
+        qApp->setStyle(fusionStyle);
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
-        QPalette palette;
+        // Start from Fusion's own palette so dark mode is handled correctly,
+        // then apply any tweaks on top of it.
+        QPalette palette = fusionStyle->standardPalette();
         if (QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark) {
             palette.setColor(QPalette::AlternateBase, QColor(53, 53, 53));
         }
-
         qApp->setPalette(palette);
 #endif
     } else if (themeName == FUSION_THEME_NAME_LIGHT) {

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -21,7 +21,9 @@ OracleWizard::OracleWizard(QWidget *parent) : QWizard(parent)
     // define a dummy context that will be used where needed
     QString dummy = QT_TRANSLATE_NOOP("i18n", "English");
 
+#ifdef Q_OS_WIN
     setWizardStyle(QWizard::ModernStyle);
+#endif
 
     QString oracleSettingsFile = SettingsCache::instance().getSettingsPath() + "oracle.ini";
     settings = new QSettings(oracleSettingsFile, QSettings::IniFormat, this);

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -21,6 +21,8 @@ OracleWizard::OracleWizard(QWidget *parent) : QWizard(parent)
     // define a dummy context that will be used where needed
     QString dummy = QT_TRANSLATE_NOOP("i18n", "English");
 
+    setWizardStyle(QWizard::ModernStyle);
+
     QString oracleSettingsFile = SettingsCache::instance().getSettingsPath() + "oracle.ini";
     settings = new QSettings(oracleSettingsFile, QSettings::IniFormat, this);
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6600

## Short roundup of the initial problem
On Windows, the QWizard Style is set to "Aero" which has hardcoded background colors and thus does not play nice with the dark mode.
No one on Windows actually uses Aero (instead they use Modern or Windows11), so the rendering isn't even done in Aero mode, we lose pretty much nothing by switching this to the "Modern" QWizard style imo.

## What will change with this Pull Request?
- Set the wizard style to modern on windows.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
