### PR TITLE
[CardDatabase] Refactor: Don't store querier as pointer

### DIFF
--- a/cockatrice/src/client/network/interfaces/deck_stats_interface.cpp
+++ b/cockatrice/src/client/network/interfaces/deck_stats_interface.cpp
@@ -71,7 +71,7 @@ void DeckStatsInterface::analyzeDeck(const DeckList &deck)
 void DeckStatsInterface::copyDeckWithoutTokens(const DeckList &source, DeckList &destination)
 {
     auto copyIfNotAToken = [this, &destination](const auto node, const auto card) {
-        CardInfoPtr dbCard = cardDatabase.query()->getCardInfo(card->getName());
+        CardInfoPtr dbCard = cardDatabase.query().getCardInfo(card->getName());
         if (dbCard && !dbCard->getIsToken()) {
             DecklistCardNode *addedCard = destination.addCard(card->getName(), node->getName(), -1);
             addedCard->setNumber(card->getNumber());

--- a/cockatrice/src/client/network/interfaces/tapped_out_interface.cpp
+++ b/cockatrice/src/client/network/interfaces/tapped_out_interface.cpp
@@ -96,7 +96,7 @@ void TappedOutInterface::analyzeDeck(const DeckList &deck)
 void TappedOutInterface::copyDeckSplitMainAndSide(const DeckList &source, DeckList &mainboard, DeckList &sideboard)
 {
     auto copyMainOrSide = [this, &mainboard, &sideboard](const auto node, const auto card) {
-        CardInfoPtr dbCard = cardDatabase.query()->getCardInfo(card->getName());
+        CardInfoPtr dbCard = cardDatabase.query().getCardInfo(card->getName());
         if (!dbCard || dbCard->getIsToken())
             return;
 

--- a/cockatrice/src/filters/deck_filter_string.cpp
+++ b/cockatrice/src/filters/deck_filter_string.cpp
@@ -122,7 +122,7 @@ static void setupParserRules()
             int count = 0;
             auto cardNodes = deck->deckLoader->getDeck().deckList.getCardNodes();
             for (auto node : cardNodes) {
-                auto cardInfoPtr = CardDatabaseManager::query()->getCardInfo(node->getName());
+                auto cardInfoPtr = CardDatabaseManager::query().getCardInfo(node->getName());
                 if (!cardInfoPtr.isNull() && cardFilter.check(cardInfoPtr)) {
                     count += node->getNumber();
                 }

--- a/cockatrice/src/game/board/abstract_card_item.cpp
+++ b/cockatrice/src/game/board/abstract_card_item.cpp
@@ -58,7 +58,7 @@ void AbstractCardItem::pixmapUpdated()
 
 void AbstractCardItem::refreshCardInfo()
 {
-    exactCard = CardDatabaseManager::query()->getCard(cardRef);
+    exactCard = CardDatabaseManager::query().getCard(cardRef);
 
     if (!exactCard && !cardRef.name.isEmpty()) {
         CardInfo::UiAttributes attributes = {.tableRow = -1};

--- a/cockatrice/src/game/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game/deckview/deck_view_container.cpp
@@ -327,7 +327,7 @@ void DeckViewContainer::deckSelectFinished(const Response &r)
 {
     const Response_DeckDownload &resp = r.GetExtension(Response_DeckDownload::ext);
     DeckList newDeck = DeckList(QString::fromStdString(resp.deck()));
-    CardPictureLoader::cacheCardPixmaps(CardDatabaseManager::query()->getCards(newDeck.getCardRefList()));
+    CardPictureLoader::cacheCardPixmaps(CardDatabaseManager::query().getCards(newDeck.getCardRefList()));
     setDeck(newDeck);
     switchToDeckLoadedView();
 }

--- a/cockatrice/src/game/dialogs/dlg_create_token.cpp
+++ b/cockatrice/src/game/dialogs/dlg_create_token.cpp
@@ -194,7 +194,7 @@ void DlgCreateToken::tokenSelectionChanged(const QModelIndex &current, const QMo
         annotationEdit->setText("");
     }
 
-    pic->setCard(CardDatabaseManager::query()->getPreferredCard(cardInfo));
+    pic->setCard(CardDatabaseManager::query().getPreferredCard(cardInfo));
 }
 
 void DlgCreateToken::updateSearchFieldWithoutUpdatingFilter(const QString &newValue) const

--- a/cockatrice/src/game/player/menu/card_menu.cpp
+++ b/cockatrice/src/game/player/menu/card_menu.cpp
@@ -342,7 +342,7 @@ void CardMenu::addRelatedCardView()
     bool atLeastOneGoodRelationFound = false;
     QList<CardRelation *> relatedCards = exactCard.getInfo().getAllRelatedCards();
     for (const CardRelation *cardRelation : relatedCards) {
-        CardInfoPtr relatedCard = CardDatabaseManager::query()->getCardInfo(cardRelation->getName());
+        CardInfoPtr relatedCard = CardDatabaseManager::query().getCardInfo(cardRelation->getName());
         if (relatedCard != nullptr) {
             atLeastOneGoodRelationFound = true;
             break;
@@ -387,9 +387,9 @@ void CardMenu::addRelatedCardActions()
     QAction *createRelatedCards = nullptr;
     for (const CardRelation *cardRelation : relatedCards) {
         ExactCard relatedCard =
-            CardDatabaseManager::query()->getCardFromSameSet(cardRelation->getName(), card->getCard().getPrinting());
+            CardDatabaseManager::query().getCardFromSameSet(cardRelation->getName(), card->getCard().getPrinting());
         if (!relatedCard) {
-            relatedCard = CardDatabaseManager::query()->getCard({cardRelation->getName()});
+            relatedCard = CardDatabaseManager::query().getCard({cardRelation->getName()});
         }
         if (!relatedCard) {
             continue;

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -858,7 +858,7 @@ void PlayerActions::actCreateToken()
 
     lastTokenInfo = dlg.getTokenInfo();
 
-    ExactCard correctedCard = CardDatabaseManager::query()->guessCard({lastTokenInfo.name, lastTokenInfo.providerId});
+    ExactCard correctedCard = CardDatabaseManager::query().guessCard({lastTokenInfo.name, lastTokenInfo.providerId});
     if (correctedCard) {
         lastTokenInfo.name = correctedCard.getName();
         lastTokenTableRow = TableZone::tableRowToGridY(correctedCard.getInfo().getUiAttributes().tableRow);
@@ -920,7 +920,7 @@ void PlayerActions::setLastToken(CardInfoPtr cardInfo)
 void PlayerActions::actCreatePredefinedToken()
 {
     auto *action = static_cast<QAction *>(sender());
-    CardInfoPtr cardInfo = CardDatabaseManager::query()->getCardInfo(action->text());
+    CardInfoPtr cardInfo = CardDatabaseManager::query().getCardInfo(action->text());
     if (!cardInfo) {
         return;
     }
@@ -946,8 +946,8 @@ void PlayerActions::actCreateRelatedCard()
      * then let's allow it to be created via "create another token"
      */
     if (createRelatedFromRelation(sourceCard, cardRelation) && cardRelation->getCanCreateAnother()) {
-        ExactCard relatedCard = CardDatabaseManager::query()->getCardFromSameSet(cardRelation->getName(),
-                                                                                 sourceCard->getCard().getPrinting());
+        ExactCard relatedCard = CardDatabaseManager::query().getCardFromSameSet(cardRelation->getName(),
+                                                                                sourceCard->getCard().getPrinting());
         setLastToken(relatedCard.getCardPtr());
     }
 }
@@ -1027,7 +1027,7 @@ void PlayerActions::actCreateAllRelatedCards()
      * then assign the first to the "Create another" shortcut.
      */
     if (cardRelation != nullptr && cardRelation->getCanCreateAnother()) {
-        CardInfoPtr cardInfo = CardDatabaseManager::query()->getCardInfo(cardRelation->getName());
+        CardInfoPtr cardInfo = CardDatabaseManager::query().getCardInfo(cardRelation->getName());
         setLastToken(cardInfo);
     }
 }
@@ -1074,7 +1074,7 @@ void PlayerActions::createCard(const CardItem *sourceCard,
                                CardRelationType attachType,
                                bool persistent)
 {
-    CardInfoPtr cardInfo = CardDatabaseManager::query()->getCardInfo(dbCardName);
+    CardInfoPtr cardInfo = CardDatabaseManager::query().getCardInfo(dbCardName);
 
     if (cardInfo == nullptr || sourceCard == nullptr) {
         return;
@@ -1109,7 +1109,7 @@ void PlayerActions::createCard(const CardItem *sourceCard,
     cmd.set_y(gridPoint.y());
 
     ExactCard relatedCard =
-        CardDatabaseManager::query()->getCardFromSameSet(cardInfo->getName(), sourceCard->getCard().getPrinting());
+        CardDatabaseManager::query().getCardFromSameSet(cardInfo->getName(), sourceCard->getCard().getPrinting());
 
     switch (attachType) {
         case CardRelationType::DoesNotAttach:

--- a/cockatrice/src/interface/deck_loader/card_node_function.cpp
+++ b/cockatrice/src/interface/deck_loader/card_node_function.cpp
@@ -7,7 +7,7 @@
 void CardNodeFunction::SetProviderIdToPreferred::operator()(const InnerDecklistNode *node, DecklistCardNode *card) const
 {
     Q_UNUSED(node);
-    PrintingInfo preferredPrinting = CardDatabaseManager::query()->getPreferredPrinting(card->getName());
+    PrintingInfo preferredPrinting = CardDatabaseManager::query().getPreferredPrinting(card->getName());
     QString providerId = preferredPrinting.getUuid();
     QString setShortName = preferredPrinting.getSet()->getShortName();
     QString collectorNumber = preferredPrinting.getProperty("num");
@@ -30,9 +30,8 @@ void CardNodeFunction::ResolveProviderId::operator()(const InnerDecklistNode *no
     Q_UNUSED(node);
     // Retrieve the providerId based on setName and collectorNumber
     QString providerId =
-        CardDatabaseManager::getInstance()
-            ->query()
-            ->getSpecificPrinting(card->getName(), card->getCardSetShortName(), card->getCardCollectorNumber())
+        CardDatabaseManager::query()
+            .getSpecificPrinting(card->getName(), card->getCardSetShortName(), card->getCardCollectorNumber())
             .getUuid();
 
     // Set the providerId on the card

--- a/cockatrice/src/interface/deck_loader/deck_loader.cpp
+++ b/cockatrice/src/interface/deck_loader/deck_loader.cpp
@@ -373,7 +373,7 @@ void DeckLoader::saveToStream_DeckZone(QTextStream &out,
     for (int j = 0; j < zoneNode->size(); j++) {
         auto *card = dynamic_cast<DecklistCardNode *>(zoneNode->at(j));
 
-        CardInfoPtr info = CardDatabaseManager::query()->getCardInfo(card->getName());
+        CardInfoPtr info = CardDatabaseManager::query().getCardInfo(card->getName());
         QString cardType = info ? info->getMainCardType() : "unknown";
 
         cardsByType.insert(cardType, card);

--- a/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
@@ -151,7 +151,7 @@ QWidget *CardGroupDisplayWidget::constructWidgetForIndex(QPersistentModelIndex i
 
     auto widget = new CardInfoPictureWithTextOverlayWidget(getLayoutParent(), true);
     widget->setScaleFactor(cardSizeWidget->getSlider()->value());
-    widget->setCard(CardDatabaseManager::query()->getCard({cardName, cardProviderId}));
+    widget->setCard(CardDatabaseManager::query().getCard({cardName, cardProviderId}));
 
     connect(widget, &CardInfoPictureWithTextOverlayWidget::imageClicked, this, &CardGroupDisplayWidget::onClick);
     connect(widget, &CardInfoPictureWithTextOverlayWidget::hoveredOnCard, this, &CardGroupDisplayWidget::onHover);

--- a/cockatrice/src/interface/widgets/cards/card_info_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_info_display_widget.cpp
@@ -55,7 +55,7 @@ void CardInfoDisplayWidget::setCard(const ExactCard &card)
 
 void CardInfoDisplayWidget::setCard(const CardRef &cardRef)
 {
-    setCard(CardDatabaseManager::query()->guessCard(cardRef));
+    setCard(CardDatabaseManager::query().guessCard(cardRef));
     if (exactCard.isEmpty()) {
         text->setInvalidCardName(cardRef.name);
     }

--- a/cockatrice/src/interface/widgets/cards/card_info_frame_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_info_frame_widget.cpp
@@ -160,12 +160,12 @@ void CardInfoFrameWidget::setCard(const ExactCard &card)
 
 void CardInfoFrameWidget::setCard(const QString &cardName)
 {
-    setCard(CardDatabaseManager::query()->guessCard({cardName}));
+    setCard(CardDatabaseManager::query().guessCard({cardName}));
 }
 
 void CardInfoFrameWidget::setCard(const CardRef &cardRef)
 {
-    setCard(CardDatabaseManager::query()->getCard(cardRef));
+    setCard(CardDatabaseManager::query().getCard(cardRef));
 }
 
 void CardInfoFrameWidget::setCard(AbstractCardItem *card)

--- a/cockatrice/src/interface/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_widget.cpp
@@ -377,7 +377,7 @@ QMenu *CardInfoPictureWidget::createViewRelatedCardsMenu()
     QList<CardRelation *> relatedCards = exactCard.getInfo().getAllRelatedCards();
 
     auto relatedCardExists = [](const CardRelation *cardRelation) {
-        return CardDatabaseManager::query()->getCardInfo(cardRelation->getName()) != nullptr;
+        return CardDatabaseManager::query().getCardInfo(cardRelation->getName()) != nullptr;
     };
 
     bool atLeastOneGoodRelationFound = std::any_of(relatedCards.begin(), relatedCards.end(), relatedCardExists);
@@ -392,7 +392,7 @@ QMenu *CardInfoPictureWidget::createViewRelatedCardsMenu()
         QAction *viewCard = viewRelatedCards->addAction(relatedCardName);
         connect(viewCard, &QAction::triggered, this, [this, &relatedCardName] {
             emit cardChanged(
-                CardDatabaseManager::query()->getCard({relatedCardName, exactCard.getPrinting().getUuid()}));
+                CardDatabaseManager::query().getCard({relatedCardName, exactCard.getPrinting().getUuid()}));
         });
         viewRelatedCards->addAction(viewCard);
     }

--- a/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.cpp
@@ -238,7 +238,7 @@ QList<QString> DeckCardZoneDisplayWidget::getGroupCriteriaValueList()
     QList<const DecklistCardNode *> nodes = deckListModel->getCardNodesForZone(zoneName);
 
     for (auto node : nodes) {
-        CardInfoPtr info = CardDatabaseManager::query()->getCardInfo(node->getName());
+        CardInfoPtr info = CardDatabaseManager::query().getCardInfo(node->getName());
         if (info) {
             groupCriteriaValues.append(info->getProperty(activeGroupCriteria));
         }

--- a/cockatrice/src/interface/widgets/deck_analytics/analyzer_modules/draw_probability/draw_probability_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_analytics/analyzer_modules/draw_probability/draw_probability_widget.cpp
@@ -172,7 +172,7 @@ void DrawProbabilityWidget::updateFilterOptions()
 
     const auto nodes = analyzer->getModel()->getCardNodes();
     for (auto *node : nodes) {
-        CardInfoPtr info = CardDatabaseManager::query()->getCardInfo(node->getName());
+        CardInfoPtr info = CardDatabaseManager::query().getCardInfo(node->getName());
         if (!info) {
             continue;
         }

--- a/cockatrice/src/interface/widgets/deck_analytics/deck_list_statistics_analyzer.cpp
+++ b/cockatrice/src/interface/widgets/deck_analytics/deck_list_statistics_analyzer.cpp
@@ -22,7 +22,7 @@ void DeckListStatisticsAnalyzer::analyze()
     QList<const DecklistCardNode *> nodes = model->getCardNodes();
 
     for (auto node : nodes) {
-        CardInfoPtr info = CardDatabaseManager::query()->getCardInfo(node->getName());
+        CardInfoPtr info = CardDatabaseManager::query().getCardInfo(node->getName());
         if (!info) {
             continue;
         }

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
@@ -141,7 +141,7 @@ void DeckEditorDatabaseDisplayWidget::updateCard(const QModelIndex &current, con
     const QString cardName = current.siblingAtColumn(CardDatabaseModel::NameColumn).data().toString();
 
     if (!current.model()->hasChildren(current.siblingAtColumn(CardDatabaseModel::NameColumn))) {
-        emit cardChanged(CardDatabaseManager::query()->getPreferredCard(cardName));
+        emit cardChanged(CardDatabaseManager::query().getPreferredCard(cardName));
     }
 }
 
@@ -174,7 +174,7 @@ ExactCard DeckEditorDatabaseDisplayWidget::currentCard() const
 
     const QString cardName = currentIndex.siblingAtColumn(CardDatabaseModel::NameColumn).data().toString();
 
-    return CardDatabaseManager::query()->getPreferredCard(cardName);
+    return CardDatabaseManager::query().getPreferredCard(cardName);
 }
 
 void DeckEditorDatabaseDisplayWidget::databaseCustomMenu(QPoint point)

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -282,7 +282,7 @@ void DeckEditorDeckDockWidget::createDeckDock()
 
 void DeckEditorDeckDockWidget::initializeFormats()
 {
-    QStringList allFormats = CardDatabaseManager::query()->getAllFormatsWithCount().keys();
+    QStringList allFormats = CardDatabaseManager::query().getAllFormatsWithCount().keys();
 
     formatComboBox->clear(); // Remove "Loading Database..."
     formatComboBox->setEnabled(true);
@@ -327,7 +327,7 @@ ExactCard DeckEditorDeckDockWidget::getCurrentCard()
     const QString zoneName = gparent.siblingAtColumn(DeckListModelColumns::CARD_NAME).data(Qt::EditRole).toString();
 
     if (!current.model()->hasChildren(current.siblingAtColumn(DeckListModelColumns::CARD_AMOUNT))) {
-        if (ExactCard selectedCard = CardDatabaseManager::query()->getCard({cardName, cardProviderID})) {
+        if (ExactCard selectedCard = CardDatabaseManager::query().getCard({cardName, cardProviderID})) {
             return selectedCard;
         }
     }
@@ -380,7 +380,7 @@ void DeckEditorDeckDockWidget::updateBannerCardComboBox()
     QList<CardRef> cardsInDeck = getModel()->getCardRefs();
 
     for (auto cardRef : cardsInDeck) {
-        if (!CardDatabaseManager::query()->getCard(cardRef)) {
+        if (!CardDatabaseManager::query().getCard(cardRef)) {
             continue;
         }
 

--- a/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.cpp
@@ -229,7 +229,7 @@ static bool doSwapCard(DeckListModel *model,
         return false;
     }
 
-    if (ExactCard card = CardDatabaseManager::query()->getCard({cardName, providerId})) {
+    if (ExactCard card = CardDatabaseManager::query().getCard({cardName, providerId})) {
         model->addCard(card, otherZone);
     } else {
         // Third argument (true) says create the card no matter what, even if not in DB

--- a/cockatrice/src/interface/widgets/dialogs/dlg_edit_tokens.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_edit_tokens.cpp
@@ -151,7 +151,7 @@ void DlgEditTokens::actAddToken()
         name = getTextWithMax(this, tr("Add token"), tr("Please enter the name of the token:"));
         if (name.isEmpty())
             return;
-        if (databaseModel->getDatabase()->query()->getCardInfo(name)) {
+        if (databaseModel->getDatabase()->query().getCardInfo(name)) {
             QMessageBox::critical(this, tr("Error"),
                                   tr("The chosen name conflicts with an existing card or token.\nMake sure to enable "
                                      "the 'Token' set in the \"Manage sets\" dialog to display them correctly."));

--- a/cockatrice/src/interface/widgets/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_select_set_for_cards.cpp
@@ -153,8 +153,8 @@ static bool swapPrinting(DeckListModel *model, const QString &modifiedSet, const
     }
     int amount = model->data(idx.siblingAtColumn(DeckListModelColumns::CARD_AMOUNT), Qt::DisplayRole).toInt();
     model->removeCardAtIndex(idx);
-    CardInfoPtr cardInfo = CardDatabaseManager::query()->getCardInfo(cardName);
-    PrintingInfo printing = CardDatabaseManager::query()->getSpecificPrinting(cardName, modifiedSet, "");
+    CardInfoPtr cardInfo = CardDatabaseManager::query().getCardInfo(cardName);
+    PrintingInfo printing = CardDatabaseManager::query().getSpecificPrinting(cardName, modifiedSet, "");
     for (int i = 0; i < amount; i++) {
         model->addCard(ExactCard(cardInfo, printing), DECK_ZONE_MAIN);
     }
@@ -236,7 +236,7 @@ QMap<QString, int> DlgSelectSetForCards::getSetsForCards()
     QList<QString> cardNames = deckStateManager->getModel()->getCardNames();
 
     for (auto cardName : cardNames) {
-        CardInfoPtr infoPtr = CardDatabaseManager::query()->getCardInfo(cardName);
+        CardInfoPtr infoPtr = CardDatabaseManager::query().getCardInfo(cardName);
         if (!infoPtr)
             continue;
 
@@ -289,16 +289,13 @@ void DlgSelectSetForCards::updateCardLists()
 
         if (!found) {
             // The card was not in any selected set
-            ExactCard card = CardDatabaseManager::query()->getCard({cardName});
+            ExactCard card = CardDatabaseManager::query().getCard({cardName});
             CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(uneditedCardsFlowWidget);
             picture_widget->setCard(card);
             uneditedCardsFlowWidget->addWidget(picture_widget);
         } else {
-            ExactCard card =
-                CardDatabaseManager::query()->getCard({cardName, CardDatabaseManager::getInstance()
-                                                                     ->query()
-                                                                     ->getSpecificPrinting(cardName, foundSetName, "")
-                                                                     .getUuid()});
+            QString providerId = CardDatabaseManager::query().getSpecificPrinting(cardName, foundSetName, "").getUuid();
+            ExactCard card = CardDatabaseManager::query().getCard({cardName, providerId});
             CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(modifiedCardsFlowWidget);
             picture_widget->setCard(card);
             modifiedCardsFlowWidget->addWidget(picture_widget);
@@ -358,7 +355,7 @@ QMap<QString, QStringList> DlgSelectSetForCards::getCardsForSets()
     QList<QString> cardNames = deckStateManager->getModel()->getCardNames();
 
     for (auto cardName : cardNames) {
-        CardInfoPtr infoPtr = CardDatabaseManager::query()->getCardInfo(cardName);
+        CardInfoPtr infoPtr = CardDatabaseManager::query().getCardInfo(cardName);
         if (!infoPtr)
             continue;
 
@@ -608,15 +605,15 @@ void SetEntryWidget::updateCardDisplayWidgets()
 
     for (const QString &cardName : possibleCards) {
         CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(cardListContainer);
-        QString providerId = CardDatabaseManager::query()->getSpecificPrinting(cardName, setName, nullptr).getUuid();
-        picture_widget->setCard(CardDatabaseManager::query()->getCard({cardName, providerId}));
+        QString providerId = CardDatabaseManager::query().getSpecificPrinting(cardName, setName, nullptr).getUuid();
+        picture_widget->setCard(CardDatabaseManager::query().getCard({cardName, providerId}));
         cardListContainer->addWidget(picture_widget);
     }
 
     for (const QString &cardName : unusedCards) {
         CardInfoPictureWidget *picture_widget = new CardInfoPictureWidget(alreadySelectedCardListContainer);
-        QString providerId = CardDatabaseManager::query()->getSpecificPrinting(cardName, setName, nullptr).getUuid();
-        picture_widget->setCard(CardDatabaseManager::query()->getCard({cardName, providerId}));
+        QString providerId = CardDatabaseManager::query().getSpecificPrinting(cardName, setName, nullptr).getUuid();
+        picture_widget->setCard(CardDatabaseManager::query().getCard({cardName, providerId}));
         alreadySelectedCardListContainer->addWidget(picture_widget);
     }
 }

--- a/cockatrice/src/interface/widgets/general/home_widget.cpp
+++ b/cockatrice/src/interface/widgets/general/home_widget.cpp
@@ -93,7 +93,7 @@ void HomeWidget::setRandomCard(ExactCard &newCard)
 {
     static constexpr int ATTEMPTS = 10;
     for (int i = 0; i < ATTEMPTS; ++i) {
-        ExactCard tmpCard = CardDatabaseManager::query()->getRandomCard();
+        ExactCard tmpCard = CardDatabaseManager::query().getRandomCard();
         if (tmpCard != backgroundSourceCard->getCard() && tmpCard.getCardPtr()->getProperty("layout") == "normal" &&
             tmpCard.getPrinting().getSet() != nullptr) {
             newCard = tmpCard;
@@ -121,17 +121,17 @@ void HomeWidget::updateRandomCard()
 
             if (!cardRefs.empty()) {
                 if (cardRefs.size() == 1) {
-                    newCard = CardDatabaseManager::query()->getCard(cardRefs.first());
+                    newCard = CardDatabaseManager::query().getCard(cardRefs.first());
                 } else {
                     // Keep picking until different
                     do {
                         int idx = QRandomGenerator::global()->bounded(cardRefs.size());
-                        newCard = CardDatabaseManager::query()->getCard(cardRefs.at(idx));
+                        newCard = CardDatabaseManager::query().getCard(cardRefs.at(idx));
                     } while (newCard == oldCard);
                 }
             } else {
                 do {
-                    newCard = CardDatabaseManager::query()->getRandomCard();
+                    newCard = CardDatabaseManager::query().getRandomCard();
                 } while (newCard == oldCard);
             }
             break;

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
@@ -229,7 +229,7 @@ void PrintingSelectorCardOverlayWidget::customMenu(QPoint point)
             const QString &relatedCardName = rel->getName();
             QAction *relatedCard = relatedMenu->addAction(relatedCardName);
             connect(relatedCard, &QAction::triggered, deckEditor, [this, relatedCardName] {
-                deckEditor->updateCard(CardDatabaseManager::query()->getCard({relatedCardName}));
+                deckEditor->updateCard(CardDatabaseManager::query().getCard({relatedCardName}));
                 deckEditor->showPrintingSelector();
             });
         }

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
@@ -193,7 +193,7 @@ void AbstractTabDeckEditor::openDeck(const LoadedDeck &deck)
 void AbstractTabDeckEditor::setDeck(const LoadedDeck &_deck)
 {
     deckStateManager->replaceDeck(_deck);
-    CardPictureLoader::cacheCardPixmaps(CardDatabaseManager::query()->getCards(_deck.deckList.getCardRefList()));
+    CardPictureLoader::cacheCardPixmaps(CardDatabaseManager::query().getCards(_deck.deckList.getCardRefList()));
 
     dockToActions.value(deckDockWidget).aVisible->setChecked(true);
     deckDockWidget->setVisible(dockToActions.value(deckDockWidget).aVisible->isChecked());

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.cpp
@@ -14,7 +14,7 @@ EdhrecApiResponseCardDetailsDisplayWidget::EdhrecApiResponseCardDetailsDisplayWi
     setLayout(layout);
 
     cardPictureWidget = new CardInfoPictureWidget(this);
-    cardPictureWidget->setCard(CardDatabaseManager::query()->guessCard({toDisplay.sanitized}));
+    cardPictureWidget->setCard(CardDatabaseManager::query().guessCard({toDisplay.sanitized}));
 
     nameLabel = new QLabel(this);
     nameLabel->setText(toDisplay.name);

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/display/commander/edhrec_api_response_commander_details_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/display/commander/edhrec_api_response_commander_details_display_widget.cpp
@@ -22,7 +22,7 @@ EdhrecCommanderResponseCommanderDetailsDisplayWidget::EdhrecCommanderResponseCom
     navigationAndPricesLayout = new QVBoxLayout();
 
     commanderPicture = new CardInfoPictureWidget(this);
-    commanderPicture->setCard(CardDatabaseManager::query()->getCard({commanderDetails.getName()}));
+    commanderPicture->setCard(CardDatabaseManager::query().getCard({commanderDetails.getName()}));
 
     QWidget *currentParent = parentWidget();
     TabEdhRecMain *parentTab = nullptr;

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/tab_edhrec_main.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/tab_edhrec_main.cpp
@@ -136,7 +136,7 @@ void TabEdhRecMain::retranslateUi()
 
 void TabEdhRecMain::doSearch()
 {
-    CardInfoPtr searchedCard = CardDatabaseManager::query()->getCardInfo(searchBar->text());
+    CardInfoPtr searchedCard = CardDatabaseManager::query().getCardInfo(searchBar->text());
     if (!searchedCard) {
         return;
     }

--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -745,7 +745,7 @@ void TabGame::loadDeckForLocalPlayer(Player *localPlayer, int playerId, ServerIn
     TabbedDeckViewContainer *deckViewContainer = deckViewContainers.value(playerId);
     if (playerInfo.has_deck_list()) {
         DeckList deckList = DeckList(QString::fromStdString(playerInfo.deck_list()));
-        CardPictureLoader::cacheCardPixmaps(CardDatabaseManager::query()->getCards(deckList.getCardRefList()));
+        CardPictureLoader::cacheCardPixmaps(CardDatabaseManager::query().getCards(deckList.getCardRefList()));
         deckViewContainer->playerDeckView->setDeck(deckList);
         localPlayer->setDeck(deckList);
     }

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_format_legality_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_format_legality_filter_widget.cpp
@@ -14,7 +14,7 @@ VisualDatabaseDisplayFormatLegalityFilterWidget::VisualDatabaseDisplayFormatLega
     FilterTreeModel *_filterModel)
     : QWidget(parent), filterModel(_filterModel)
 {
-    allFormatsWithCount = CardDatabaseManager::query()->getAllFormatsWithCount();
+    allFormatsWithCount = CardDatabaseManager::query().getAllFormatsWithCount();
     int maxValue = std::numeric_limits<int>::min();
     for (int value : allFormatsWithCount) {
         maxValue = std::max(maxValue, value);

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_main_type_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_main_type_filter_widget.cpp
@@ -14,7 +14,7 @@ VisualDatabaseDisplayMainTypeFilterWidget::VisualDatabaseDisplayMainTypeFilterWi
     : QWidget(parent), filterModel(_filterModel)
 {
     // Get all main card types with their count
-    allMainCardTypesWithCount = CardDatabaseManager::query()->getAllMainCardTypesWithCount();
+    allMainCardTypesWithCount = CardDatabaseManager::query().getAllMainCardTypesWithCount();
     setMinimumWidth(300);
     setMaximumHeight(200);
 

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_sub_type_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_sub_type_filter_widget.cpp
@@ -14,7 +14,7 @@ VisualDatabaseDisplaySubTypeFilterWidget::VisualDatabaseDisplaySubTypeFilterWidg
                                                                                    FilterTreeModel *_filterModel)
     : QWidget(parent), filterModel(_filterModel)
 {
-    allSubCardTypesWithCount = CardDatabaseManager::query()->getAllSubCardTypesWithCount();
+    allSubCardTypesWithCount = CardDatabaseManager::query().getAllSubCardTypesWithCount();
 
     setMinimumWidth(300);
 

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -297,7 +297,7 @@ void VisualDatabaseDisplayWidget::loadPage(int start, int end)
         QVariant name = databaseDisplayModel->data(index, Qt::DisplayRole);
         qCDebug(VisualDatabaseDisplayLog) << name.toString();
 
-        if (CardInfoPtr info = CardDatabaseManager::query()->getCardInfo(name.toString())) {
+        if (CardInfoPtr info = CardDatabaseManager::query().getCardInfo(name.toString())) {
             if (!setFilters.empty()) {
                 SetToPrintingsMap setMap = info->getSets();
                 for (const CardFilter *setFilter : setFilters) {
@@ -308,7 +308,7 @@ void VisualDatabaseDisplayWidget::loadPage(int start, int end)
                     }
                 }
             } else {
-                addCard(CardDatabaseManager::query()->getPreferredCard(info));
+                addCard(CardDatabaseManager::query().getPreferredCard(info));
             }
         } else {
             qCDebug(VisualDatabaseDisplayLog) << "Card not found in database!";

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_sample_hand_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_sample_hand_widget.cpp
@@ -96,7 +96,7 @@ static QList<ExactCard> cardNodesToExactCards(QList<const DecklistCardNode *> no
 {
     QList<ExactCard> cards;
     for (auto node : nodes) {
-        ExactCard card = CardDatabaseManager::query()->getCard(node->toCardRef());
+        ExactCard card = CardDatabaseManager::query().getCard(node->toCardRef());
         if (card) {
             for (int k = 0; k < node->getNumber(); ++k) {
                 cards.append(card);

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -74,7 +74,7 @@ void VisualDeckEditorWidget::initializeSearchBarAndCompleter()
         if (!searchBar->hasFocus())
             return;
 
-        ExactCard card = CardDatabaseManager::query()->getCard({searchBar->text()});
+        ExactCard card = CardDatabaseManager::query().getCard({searchBar->text()});
         if (card) {
             emit cardAdditionRequested(card);
         }
@@ -135,7 +135,7 @@ void VisualDeckEditorWidget::initializeSearchBarAndCompleter()
     // Search button functionality
     searchPushButton = new QPushButton(this);
     connect(searchPushButton, &QPushButton::clicked, this, [=, this]() {
-        ExactCard card = CardDatabaseManager::query()->getCard({searchBar->text()});
+        ExactCard card = CardDatabaseManager::query().getCard({searchBar->text()});
         if (card) {
             emit cardAdditionRequested(card);
         }

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -147,7 +147,7 @@ void DeckPreviewWidget::initializeUi(const bool deckLoadSuccess)
 void DeckPreviewWidget::resyncWidgets()
 {
     auto bannerCardRef = deckLoader->getDeck().deckList.getBannerCard();
-    auto bannerCard = bannerCardRef.name.isEmpty() ? ExactCard() : CardDatabaseManager::query()->getCard(bannerCardRef);
+    auto bannerCard = bannerCardRef.name.isEmpty() ? ExactCard() : CardDatabaseManager::query().getCard(bannerCardRef);
 
     bannerCardDisplayWidget->setCard(bannerCard);
     refreshBannerCardText();
@@ -237,7 +237,7 @@ QString DeckPreviewWidget::getColorIdentity()
     QSet<QChar> colorSet; // A set to collect unique color symbols (e.g., W, U, B, R, G)
 
     for (const QString &cardName : cardList) {
-        CardInfoPtr currentCard = CardDatabaseManager::query()->getCardInfo(cardName);
+        CardInfoPtr currentCard = CardDatabaseManager::query().getCardInfo(cardName);
         if (currentCard) {
             QString colors = currentCard->getColors(); // Assuming this returns something like "WUB"
             for (const QChar &color : colors) {
@@ -362,7 +362,7 @@ void DeckPreviewWidget::setBannerCard(int /* changedIndex */)
     CardRef cardRef = {name, id};
     deckLoader->getDeck().deckList.setBannerCard(cardRef);
     writeDeckToFile();
-    bannerCardDisplayWidget->setCard(CardDatabaseManager::query()->getCard(cardRef));
+    bannerCardDisplayWidget->setCard(CardDatabaseManager::query().getCard(cardRef));
 }
 
 void DeckPreviewWidget::imageClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance)

--- a/libcockatrice_card/libcockatrice/card/database/card_database.cpp
+++ b/libcockatrice_card/libcockatrice/card/database/card_database.cpp
@@ -15,7 +15,8 @@ CardDatabase::CardDatabase(QObject *parent,
                            ICardPreferenceProvider *prefs,
                            ICardDatabasePathProvider *pathProvider,
                            ICardSetPriorityController *_setPriorityController)
-    : QObject(parent), setPriorityController(_setPriorityController), loadStatus(NotLoaded)
+    : QObject(parent), setPriorityController(_setPriorityController), loadStatus(NotLoaded),
+      querier(CardDatabaseQuerier(this, prefs))
 {
     qRegisterMetaType<CardInfoPtr>("CardInfoPtr");
     qRegisterMetaType<CardInfoPtr>("CardSetPtr");
@@ -27,8 +28,6 @@ CardDatabase::CardDatabase(QObject *parent,
     connect(loader, &CardDatabaseLoader::loadingFailed, this, &CardDatabase::cardDatabaseLoadingFailed);
     connect(loader, &CardDatabaseLoader::newSetsFound, this, &CardDatabase::cardDatabaseNewSetsFound);
     connect(loader, &CardDatabaseLoader::allNewSetsEnabled, this, &CardDatabase::cardDatabaseAllNewSetsEnabled);
-
-    querier = new CardDatabaseQuerier(this, this, prefs);
 }
 
 CardDatabase::~CardDatabase()

--- a/libcockatrice_card/libcockatrice/card/database/card_database.h
+++ b/libcockatrice_card/libcockatrice/card/database/card_database.h
@@ -29,7 +29,6 @@ class CardDatabase : public QObject
 {
     Q_OBJECT
 
-protected:
     /// Controller to determine set priority when choosing preferred printings.
     ICardSetPriorityController *setPriorityController;
 
@@ -51,9 +50,8 @@ protected:
     LoadStatus loadStatus;
 
     /// Querier for higher-level card lookups
-    CardDatabaseQuerier *querier;
+    CardDatabaseQuerier querier;
 
-private:
     /**
      * @brief Check for sets that are unknown and emit signals if needed.
      */
@@ -116,7 +114,7 @@ public:
     }
 
     /** @brief Returns the querier for performing card lookups. */
-    [[nodiscard]] CardDatabaseQuerier *query() const
+    [[nodiscard]] CardDatabaseQuerier const &query() const
     {
         return querier;
     }

--- a/libcockatrice_card/libcockatrice/card/database/card_database_manager.cpp
+++ b/libcockatrice_card/libcockatrice/card/database/card_database_manager.cpp
@@ -29,7 +29,7 @@ CardDatabase *CardDatabaseManager::getInstance()
     return &instance;
 }
 
-CardDatabaseQuerier *CardDatabaseManager::query()
+CardDatabaseQuerier const &CardDatabaseManager::query()
 {
     return getInstance()->query();
 }

--- a/libcockatrice_card/libcockatrice/card/database/card_database_manager.h
+++ b/libcockatrice_card/libcockatrice/card/database/card_database_manager.h
@@ -58,7 +58,7 @@ public:
      * @brief Returns the CardDatabaseQuerier of the singleton database.
      * @return Pointer to CardDatabaseQuerier.
      */
-    static CardDatabaseQuerier *query();
+    static CardDatabaseQuerier const &query();
 
 private:
     /** @brief Private default constructor to enforce singleton. */

--- a/libcockatrice_card/libcockatrice/card/database/card_database_querier.cpp
+++ b/libcockatrice_card/libcockatrice/card/database/card_database_querier.cpp
@@ -7,10 +7,8 @@
 
 #include <qrandom.h>
 
-CardDatabaseQuerier::CardDatabaseQuerier(QObject *_parent,
-                                         const CardDatabase *_db,
-                                         const ICardPreferenceProvider *prefs)
-    : QObject(_parent), db(_db), prefs(prefs)
+CardDatabaseQuerier::CardDatabaseQuerier(const CardDatabase *_db, const ICardPreferenceProvider *prefs)
+    : db(_db), prefs(prefs)
 {
 }
 

--- a/libcockatrice_card/libcockatrice/card/database/card_database_querier.h
+++ b/libcockatrice_card/libcockatrice/card/database/card_database_querier.h
@@ -19,19 +19,17 @@ class CardDatabase;
  * (e.g., CardInfoPtr, ExactCard, and PrintingInfo) from a CardDatabase. It also applies user
  * printing preferences via ICardPreferenceProvider when determining preferred printings.
  */
-class CardDatabaseQuerier : public QObject
+class CardDatabaseQuerier
 {
-    Q_OBJECT
 
 public:
     /**
      * @brief Constructs a CardDatabaseQuerier.
      *
-     * @param parent Parent QObject.
      * @param db Pointer to the CardDatabase used for lookups.
      * @param prefs Pointer to card preference provider which supplies user-preference for printings.
      */
-    explicit CardDatabaseQuerier(QObject *parent, const CardDatabase *db, const ICardPreferenceProvider *prefs);
+    explicit CardDatabaseQuerier(const CardDatabase *db, const ICardPreferenceProvider *prefs);
 
     /**
      * @brief Retrieves a card by its exact name.

--- a/libcockatrice_card/libcockatrice/card/import/card_name_normalizer.cpp
+++ b/libcockatrice_card/libcockatrice/card/import/card_name_normalizer.cpp
@@ -12,7 +12,7 @@
  */
 static QString getCompleteCardName(const QString &cardName)
 {
-    ExactCard temp = CardDatabaseManager::query()->guessCard({cardName});
+    ExactCard temp = CardDatabaseManager::query().guessCard({cardName});
     if (temp) {
         return temp.getName();
     }

--- a/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
+++ b/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
@@ -71,7 +71,7 @@ void DeckListModel::rebuildTree()
                 continue;
             }
 
-            CardInfoPtr info = CardDatabaseManager::query()->getCardInfo(currentCard->getName());
+            CardInfoPtr info = CardDatabaseManager::query().getCardInfo(currentCard->getName());
             QString groupCriteria = extractGroupCriteriaValue(info, activeGroupCriteria);
 
             auto *groupNode = dynamic_cast<InnerDecklistNode *>(node->findChild(groupCriteria));
@@ -369,7 +369,7 @@ DecklistModelCardNode *DeckListModel::findCardNode(const QString &cardName,
         return nullptr;
     }
 
-    CardInfoPtr info = CardDatabaseManager::query()->getCardInfo(cardName);
+    CardInfoPtr info = CardDatabaseManager::query().getCardInfo(cardName);
     if (!info) {
         return nullptr;
     }
@@ -399,7 +399,7 @@ QModelIndex DeckListModel::findCard(const QString &cardName,
 
 QModelIndex DeckListModel::addPreferredPrintingCard(const QString &cardName, const QString &zoneName, bool abAddAnyway)
 {
-    ExactCard card = CardDatabaseManager::query()->getCard({cardName});
+    ExactCard card = CardDatabaseManager::query().getCard({cardName});
 
     if (!card) {
         if (abAddAnyway) {
@@ -717,7 +717,7 @@ static bool isCardQuantityLegalForFormat(const QString &format, const CardInfo &
         return true;
     }
 
-    auto formatRules = CardDatabaseManager::query()->getFormat(format);
+    auto formatRules = CardDatabaseManager::query().getFormat(format);
 
     // if format has no custom rules, then just do the default check
     if (!formatRules) {
@@ -756,7 +756,7 @@ static bool isCardNodeLegalForFormat(const QString &format, const InnerDecklistN
     }
 
     // unknown cards are not legal
-    ExactCard exactCard = CardDatabaseManager::query()->getCard(card->toCardRef());
+    ExactCard exactCard = CardDatabaseManager::query().getCard(card->toCardRef());
     if (!exactCard) {
         return false;
     }

--- a/libcockatrice_models/libcockatrice/models/deck_list/deck_list_sort_filter_proxy_model.cpp
+++ b/libcockatrice_models/libcockatrice/models/deck_list/deck_list_sort_filter_proxy_model.cpp
@@ -20,8 +20,8 @@ bool DeckListSortFilterProxyModel::lessThan(const QModelIndex &left, const QMode
     auto *lNode = static_cast<DecklistModelCardNode *>(left.internalPointer());
     auto *rNode = static_cast<DecklistModelCardNode *>(right.internalPointer());
 
-    CardInfoPtr lInfo = CardDatabaseManager::query()->guessCard({lNode->getName()}).getCardPtr();
-    CardInfoPtr rInfo = CardDatabaseManager::query()->guessCard({rNode->getName()}).getCardPtr();
+    CardInfoPtr lInfo = CardDatabaseManager::query().guessCard({lNode->getName()}).getCardPtr();
+    CardInfoPtr rInfo = CardDatabaseManager::query().guessCard({rNode->getName()}).getCardPtr();
 
     // Example: multiple tie-break criteria (colors > cmc > name)
     for (const QString &crit : sortCriteria) {

--- a/tests/carddatabase/carddatabase_test.cpp
+++ b/tests/carddatabase/carddatabase_test.cpp
@@ -16,21 +16,21 @@ TEST(CardDatabaseTest, LoadXml)
     // ensure the card database is empty at start
     ASSERT_EQ(0, db->getCardList().size()) << "Cards not empty at start";
     ASSERT_EQ(0, db->getSetList().size()) << "Sets not empty at start";
-    ASSERT_EQ(0, db->query()->getAllMainCardTypes().size()) << "Types not empty at start";
+    ASSERT_EQ(0, db->query().getAllMainCardTypes().size()) << "Types not empty at start";
     ASSERT_EQ(NotLoaded, db->getLoadStatus()) << "Incorrect status at start";
 
     // load dummy cards and test result
     db->loadCardDatabases();
     ASSERT_EQ(9, db->getCardList().size()) << "Wrong card count after load";
     ASSERT_EQ(5, db->getSetList().size()) << "Wrong sets count after load";
-    ASSERT_EQ(3, db->query()->getAllMainCardTypes().size()) << "Wrong types count after load";
+    ASSERT_EQ(3, db->query().getAllMainCardTypes().size()) << "Wrong types count after load";
     ASSERT_EQ(Ok, db->getLoadStatus()) << "Wrong status after load";
 
     // ensure the card database is empty after clear()
     db->clear();
     ASSERT_EQ(0, db->getCardList().size()) << "Cards not empty after clear";
     ASSERT_EQ(0, db->getSetList().size()) << "Sets not empty after clear";
-    ASSERT_EQ(0, db->query()->getAllMainCardTypes().size()) << "Types not empty after clear";
+    ASSERT_EQ(0, db->query().getAllMainCardTypes().size()) << "Types not empty after clear";
     ASSERT_EQ(NotLoaded, db->getLoadStatus()) << "Incorrect status after clear";
 }
 } // namespace

--- a/tests/carddatabase/filter_string_test.cpp
+++ b/tests/carddatabase/filter_string_test.cpp
@@ -24,10 +24,10 @@ protected:
                                             new TestCardDatabasePathProvider(), new NoopCardSetPriorityController());
         db->loadCardDatabases();
 
-        cat = db->query()->getCardBySimpleName("Cat");
-        notDeadAfterAll = db->query()->getCardBySimpleName("Not Dead");
-        truth = db->query()->getCardBySimpleName("Truth");
-        doctor = db->query()->getCardBySimpleName("Doctor");
+        cat = db->query().getCardBySimpleName("Cat");
+        notDeadAfterAll = db->query().getCardBySimpleName("Not Dead");
+        truth = db->query().getCardBySimpleName("Truth");
+        doctor = db->query().getCardBySimpleName("Doctor");
     }
     // void TearDown() override {}
 


### PR DESCRIPTION
## Short roundup of the initial problem


## What will change with this Pull Request?
- Make `CardDatabaseQuerier` no longer extend `QObject`
- Store `CardDatabaseQuerier` in `CardDatabase` directly instead of as a pointer
- Change `CardDatabase::query` to return const ref instead of pointer.
  - Update usages