### PR TITLE
Utility method to check if a theme is supposed to be in dark or light mode.

### DIFF
--- a/cockatrice/src/interface/theme_manager.cpp
+++ b/cockatrice/src/interface/theme_manager.cpp
@@ -108,6 +108,31 @@ void ThemeManager::ensureThemeDirectoryExists()
     }
 }
 
+bool ThemeManager::isDarkMode()
+{
+    auto themeName = SettingsCache::instance().getThemeName();
+    // Explicit Dark Mode
+    if (themeName == FUSION_THEME_NAME_LIGHT || themeName.endsWith("(Light)")) {
+        return false;
+    }
+    // Explicit Light Mode
+    if (themeName == FUSION_THEME_NAME_DARK || themeName.endsWith("(Dark)")) {
+        return true;
+    }
+
+    // Auto detection on compatible Qt versions
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+    if (QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark &&
+        (themeName == NONE_THEME_NAME || themeName == FUSION_THEME_NAME || themeName.endsWith("(System Default)"))) {
+        return true;
+    } else {
+        return false;
+    }
+#endif
+    // Default to light mode
+    return false;
+}
+
 QStringMap &ThemeManager::getAvailableThemes()
 {
     QDir dir;

--- a/cockatrice/src/interface/theme_manager.cpp
+++ b/cockatrice/src/interface/theme_manager.cpp
@@ -133,6 +133,14 @@ bool ThemeManager::isDarkMode()
     return false;
 }
 
+bool ThemeManager::isBuiltInTheme()
+{
+    const auto themeName = SettingsCache::instance().getThemeName();
+
+    return themeName == NONE_THEME_NAME || themeName == FUSION_THEME_NAME || themeName == FUSION_THEME_NAME_LIGHT ||
+           themeName == FUSION_THEME_NAME_DARK;
+}
+
 QStringMap &ThemeManager::getAvailableThemes()
 {
     QDir dir;

--- a/cockatrice/src/interface/theme_manager.cpp
+++ b/cockatrice/src/interface/theme_manager.cpp
@@ -414,7 +414,6 @@ void ThemeManager::themeChangedSlot()
         newStyle->polish(widget);
 
         widget->update();
-        widget->repaint();
     }
 
     if (dirPath.isEmpty()) {

--- a/cockatrice/src/interface/theme_manager.cpp
+++ b/cockatrice/src/interface/theme_manager.cpp
@@ -410,10 +410,12 @@ void ThemeManager::themeChangedSlot()
     // palette (WA_SetPalette not set). Calling it unconditionally would clobber
     // intentional per-widget palette customisations across the whole app.
     for (QWidget *widget : qApp->allWidgets()) {
-        newStyle->unpolish(widget);
-        newStyle->polish(widget);
+        if (widget->isVisible()) {
+            newStyle->unpolish(widget);
+            newStyle->polish(widget);
 
-        widget->update();
+            widget->update();
+        }
     }
 
     if (dirPath.isEmpty()) {

--- a/cockatrice/src/interface/theme_manager.cpp
+++ b/cockatrice/src/interface/theme_manager.cpp
@@ -413,9 +413,6 @@ void ThemeManager::themeChangedSlot()
         newStyle->unpolish(widget);
         newStyle->polish(widget);
 
-        widget->style()->unpolish(widget);
-        widget->style()->polish(widget);
-
         widget->update();
         widget->repaint();
     }

--- a/cockatrice/src/interface/theme_manager.cpp
+++ b/cockatrice/src/interface/theme_manager.cpp
@@ -15,6 +15,7 @@
 #include <QStyle>
 #include <QStyleFactory>
 #include <QStyleHints>
+#include <QWidget>
 #include <Qt>
 
 #define NONE_THEME_NAME "Default"
@@ -91,6 +92,10 @@ struct PaletteColorInfo
 ThemeManager::ThemeManager(QObject *parent) : QObject(parent)
 {
     defaultStyleName = qApp->style()->objectName();
+    // FIXME workaround for windows11 style being broken
+    if (defaultStyleName == "windows11") {
+        defaultStyleName = "windowsvista";
+    }
     ensureThemeDirectoryExists();
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
     connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this, &ThemeManager::themeChangedSlot);
@@ -364,26 +369,55 @@ void ThemeManager::themeChangedSlot()
         qApp->setStyleSheet("");
     }
 
+    QStyle *newStyle = nullptr;
+    QPalette newPalette;
+
     if (themeName == FUSION_THEME_NAME) {
-        QStyle *fusionStyle = QStyleFactory::create("Fusion");
-        qApp->setStyle(fusionStyle);
+        newStyle = QStyleFactory::create("Fusion");
+
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
         // Start from Fusion's own palette so dark mode is handled correctly,
         // then apply any tweaks on top of it.
-        QPalette palette = fusionStyle->standardPalette();
+        newPalette = newStyle->standardPalette();
         if (QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark) {
-            palette.setColor(QPalette::AlternateBase, QColor(53, 53, 53));
+            newPalette.setColor(QPalette::AlternateBase, QColor(53, 53, 53));
         }
-        qApp->setPalette(palette);
+#else
+        newPalette = qApp->palette();
 #endif
     } else if (themeName == FUSION_THEME_NAME_LIGHT) {
-        qApp->setStyle(QStyleFactory::create("Fusion"));
-        qApp->setPalette(createLightGreenFusionPalette());
+        newStyle = QStyleFactory::create("Fusion");
+        newPalette = createLightGreenFusionPalette();
     } else if (themeName == FUSION_THEME_NAME_DARK) {
-        qApp->setStyle(QStyleFactory::create("Fusion"));
-        qApp->setPalette(createDarkGreenFusionPalette());
+        newStyle = QStyleFactory::create("Fusion");
+        newPalette = createDarkGreenFusionPalette();
     } else {
-        qApp->setStyle(QStyleFactory::create(defaultStyleName)); // setting the style also sets the palette
+        newStyle = QStyleFactory::create(defaultStyleName);
+        // Use the style's default palette.
+        newPalette = newStyle->standardPalette();
+    }
+
+    // Apply palette FIRST.
+    qApp->setPalette(newPalette);
+    // Then apply style.
+    qApp->setStyle(newStyle);
+
+    // Force every widget to re-polish and repaint immediately rather than
+    // waiting for natural expose events, which produces a patchwork of old
+    // and new colours during a live preview.
+    // Note: we do NOT call widget->setPalette(base) here — qApp->setPalette()
+    // already propagates to all widgets that haven't explicitly overridden their
+    // palette (WA_SetPalette not set). Calling it unconditionally would clobber
+    // intentional per-widget palette customisations across the whole app.
+    for (QWidget *widget : qApp->allWidgets()) {
+        newStyle->unpolish(widget);
+        newStyle->polish(widget);
+
+        widget->style()->unpolish(widget);
+        widget->style()->polish(widget);
+
+        widget->update();
+        widget->repaint();
     }
 
     if (dirPath.isEmpty()) {

--- a/cockatrice/src/interface/theme_manager.h
+++ b/cockatrice/src/interface/theme_manager.h
@@ -54,6 +54,7 @@ protected:
     QBrush loadExtraBrush(QString fileName, QBrush &fallbackBrush);
 
 public:
+    bool isBuiltInTheme();
     bool isDarkMode();
     QStringMap &getAvailableThemes();
 

--- a/cockatrice/src/interface/theme_manager.h
+++ b/cockatrice/src/interface/theme_manager.h
@@ -50,11 +50,11 @@ private:
 
 protected:
     void ensureThemeDirectoryExists();
-    bool isDarkMode();
     QBrush loadBrush(QString fileName, QColor fallbackColor);
     QBrush loadExtraBrush(QString fileName, QBrush &fallbackBrush);
 
 public:
+    bool isDarkMode();
     QStringMap &getAvailableThemes();
 
     QBrush &getBgBrush(Role zone);

--- a/cockatrice/src/interface/theme_manager.h
+++ b/cockatrice/src/interface/theme_manager.h
@@ -50,6 +50,7 @@ private:
 
 protected:
     void ensureThemeDirectoryExists();
+    bool isDarkMode();
     QBrush loadBrush(QString fileName, QColor fallbackColor);
     QBrush loadExtraBrush(QString fileName, QBrush &fallbackBrush);
 

--- a/cockatrice/src/interface/widgets/general/home_widget.cpp
+++ b/cockatrice/src/interface/widgets/general/home_widget.cpp
@@ -2,6 +2,7 @@
 
 #include "../../../client/settings/cache_settings.h"
 #include "../../../interface/widgets/tabs/tab_supervisor.h"
+#include "../../theme_manager.h"
 #include "../../window_main.h"
 #include "background_sources.h"
 #include "home_styled_button.h"
@@ -256,7 +257,7 @@ void HomeWidget::updateConnectButton(const ClientStatus status)
 
 QPair<QColor, QColor> HomeWidget::extractDominantColors(const QPixmap &pixmap)
 {
-    if (SettingsCache::instance().getThemeName() == "Default" &&
+    if (themeManager->isBuiltInTheme() &&
         SettingsCache::instance().getHomeTabBackgroundSource() == BackgroundSources::toId(BackgroundSources::Theme)) {
         return QPair<QColor, QColor>(QColor::fromRgb(20, 140, 60), QColor::fromRgb(120, 200, 80));
     }

--- a/cockatrice/src/interface/widgets/general/home_widget.cpp
+++ b/cockatrice/src/interface/widgets/general/home_widget.cpp
@@ -48,6 +48,8 @@ HomeWidget::HomeWidget(QWidget *parent, TabSupervisor *_tabSupervisor)
     // Lambda is cleaner to read than overloading this
     connect(&SettingsCache::instance(), &SettingsCache::homeTabDisplayCardNameChanged, this, [this] { repaint(); });
     connect(&SettingsCache::instance(), &SettingsCache::themeChanged, this,
+            &HomeWidget::initializeBackgroundFromSource);
+    connect(&SettingsCache::instance(), &SettingsCache::themeChanged, this,
             &HomeWidget::updateButtonsToBackgroundColor);
 }
 


### PR DESCRIPTION
## Short roundup of the initial problem
We only perform light/dark logic in the themeChanged slot. With the introduction of light/dark mode, other UI components care about the current theme preference. Additionally, this allows custom themes to cue off of light/dark mode by adding magic strings to their names.

## What will change with this Pull Request?
- Add a utility method that checks for (Dark), (Light) or (System Default) at the end of theme names
- Fallthrough logic for detection, preferring hard coded dark/light and then falling through to system default on compatible themes (i.e. the ones we ship with, "Default" and "Fusion (System Default)"
- Repolish visible widgets on theme change, which fixes the issue of themes not applying to every visible widget on theme change

## Pictures
Partially applied theme before fix:
<img width="1267" height="1381" alt="image" src="https://github.com/user-attachments/assets/ab605deb-a83c-45d2-b9e1-ebeb59d0f98a" />
