### PR TITLE
Cleanup loop for arrowItems without targetItem on drawArrow

### DIFF
--- a/cockatrice/src/game/board/card_item.cpp
+++ b/cockatrice/src/game/board/card_item.cpp
@@ -285,6 +285,12 @@ void CardItem::drawArrow(const QColor &arrowColor)
         int currentPhase = game->getGameState()->getCurrentPhase();
         phase = Phases::getLastSubphase(currentPhase) + 1;
     }
+    for (ArrowItem *arrowItem : getArrowsFrom()) {
+        if (arrowItem->getTargetItem() == nullptr) {
+            arrowItem->ungrabMouse();
+            arrowItem->delArrow();
+        }
+    }
     ArrowDragItem *arrow = new ArrowDragItem(arrowOwner, this, arrowColor, phase);
     scene()->addItem(arrow);
     arrow->grabMouse();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4329

## Short roundup of the initial problem
drawArrow draws infnite arrows when spamming / holding the keyboard shortcut.

## What will change with this Pull Request?
- Add a cleanup loop in drawArrow to remove and release mouse from ArrowItems where the target is a nullptr.

## Screenshots
https://github.com/user-attachments/assets/1cf4dba7-7199-4545-a254-e411867dfc97

