### PR TITLE
CI: Add timeout to job matrixes

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -156,6 +156,7 @@ jobs:
     needs: configure
     runs-on: ubuntu-latest
     continue-on-error: ${{matrix.allow-failure == 'yes'}}
+    timeout-minutes: 70
     env:
       NAME: ${{matrix.distro}}${{matrix.version}}
       CACHE: ${{github.workspace}}/.cache/${{matrix.distro}}${{matrix.version}}   # directory for caching docker image and ccache
@@ -331,6 +332,7 @@ jobs:
     name: ${{matrix.os}} ${{matrix.target}}${{ matrix.soc == 'Intel' && ' Intel' || '' }}${{ matrix.type == 'Debug' && ' Debug' || '' }}
     needs: configure
     runs-on: ${{matrix.runner}}
+    timeout-minutes: 100
     env:
       CCACHE_DIR: ${{github.workspace}}/.cache/
       # Cache size over the entire repo is 10Gi:


### PR DESCRIPTION
## Short roundup of the initial problem
In rare cases some jobs are getting stuck and keep running for some hours:
https://github.com/Cockatrice/Cockatrice/actions/runs/23957724556/job/69926786339
https://github.com/Cockatrice/Cockatrice/actions/runs/23971364796/job/69921261517
https://github.com/Cockatrice/Cockatrice/actions/runs/23976334581/job/69940881542
https://github.com/Cockatrice/Cockatrice/actions/runs/24079358656/job/70235716695
https://github.com/Cockatrice/Cockatrice/actions/runs/24183035379/job/70584584513
https://github.com/Cockatrice/Cockatrice/actions/runs/24265301425/job/70858847782

The default job timeout is 6h.

## What will change with this Pull Request?
Introduce a timeout of roughly 1h plus the usual running time:
- Timeout of 70min for Linux builds
- Timeout of 100min for vcpkg builds (macOS + Win)
  <img width="644" height="42" alt="image" src="https://github.com/user-attachments/assets/32bbb841-7b2a-4f62-b10b-c889ab21b3a3" />


## Screenshot

Also in this PR itself, the vcpkg step is having the same issue. The timeout value is working as expected and cancelles after 1h 40min already:
<img width="1416" height="527" alt="image" src="https://github.com/user-attachments/assets/8ded75ad-9f83-4662-8d3d-dac64b41da03" />

Instead after 6h only:
<img width="1385" height="340" alt="image" src="https://github.com/user-attachments/assets/2f91f9d0-4983-4654-8074-aa8e940404a9" />
