### PR TITLE
CI: Use `ubuntu-slim` for simple jobs

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -46,7 +46,7 @@ concurrency:
 jobs:
   configure:
     name: Configure
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       tag: ${{steps.configure.outputs.tag}}
       sha: ${{steps.configure.outputs.sha}}

--- a/.github/workflows/desktop-lint.yml
+++ b/.github/workflows/desktop-lint.yml
@@ -20,13 +20,13 @@ on:
 
 jobs:
   format:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
 
     steps:
     - name: Checkout
       uses: actions/checkout@v6
       with:
-        fetch-depth: 20 # should be enough to find merge base
+        fetch-depth: 20    # should be enough to find merge base
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/translations-pull.yml
+++ b/.github/workflows/translations-pull.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event_name != 'schedule' || github.repository_owner == 'Cockatrice'
 
     name: Pull languages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/translations-push.yml
+++ b/.github/workflows/translations-push.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Render template
         id: template
-        uses: chuhlomin/render-template@v1
+        uses: chuhlomin/render-template/binary@v1
         with:
           template: .ci/update_translation_source_strings_template.md
           vars: |

--- a/.github/workflows/translations-push.yml
+++ b/.github/workflows/translations-push.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event_name != 'schedule' || github.repository_owner == 'Cockatrice'
 
     name: Push strings
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/web-lint.yml
+++ b/.github/workflows/web-lint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   ESLint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     
     defaults:
       run:


### PR DESCRIPTION
## What will change with this Pull Request?
- Use new `ubuntu-slim` runner targeted for automation tasks
- Add to our simple workflows:
  - desktop-build (Config job only)
  - desktop-lint
  - translations-pull
  - translations-push
  - web-lint