### PR TITLE
CI: Allow failing of ccache deletion step

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -456,7 +456,7 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh cache delete --repo ${{ github.repository }} ${{ steps.ccache_restore.outputs.cache-primary-key }} || true
+        run: gh cache delete --repo ${{ github.repository }} ${{ steps.ccache_restore.outputs.cache-primary-key }}
 
       - name: Save updated compiler cache (ccache)
         if: github.ref == 'refs/heads/master' && matrix.use_ccache == 1

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -207,13 +207,13 @@ jobs:
                   --ccache "$CCACHE_SIZE" $NO_CLIENT
           .ci/name_build.sh
 
-      # Delete used cache to emulate a ccache update. See https://github.com/actions/cache/issues/342.
-      # If the deletion is failing we want to proceed nontheless and not error the job
+      # Delete used cache to emulate a ccache update. See https://github.com/actions/cache/issues/342
       - name: Delete remote compiler cache (ccache)
         if: github.ref == 'refs/heads/master' && steps.ccache_restore.outputs.cache-hit
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh cache delete --repo ${{ github.repository }} ${{ steps.ccache_restore.outputs.cache-primary-key }} || true
+        run: gh cache delete --repo ${{ github.repository }} ${{ steps.ccache_restore.outputs.cache-primary-key }}
 
       - name: Save updated compiler cache (ccache)
         if: github.ref == 'refs/heads/master'
@@ -450,10 +450,10 @@ jobs:
           TARGET_MACOS_VERSION: ${{ matrix.override_target }}
         run: .ci/compile.sh --server --test --vcpkg
 
-      # Delete used cache to emulate a ccache update. See https://github.com/actions/cache/issues/342.
-      # If the deletion is failing we want to proceed nontheless and not error the job
+      # Delete used cache to emulate a ccache update. See https://github.com/actions/cache/issues/342
       - name: Delete remote compiler cache (ccache)
         if: github.ref == 'refs/heads/master' && matrix.use_ccache == 1 && steps.ccache_restore.outputs.cache-hit
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh cache delete --repo ${{ github.repository }} ${{ steps.ccache_restore.outputs.cache-primary-key }} || true

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -208,11 +208,12 @@ jobs:
           .ci/name_build.sh
 
       # Delete used cache to emulate a ccache update. See https://github.com/actions/cache/issues/342.
+      # If the deletion is failing we want to proceed nontheless and not error the job
       - name: Delete remote compiler cache (ccache)
         if: github.ref == 'refs/heads/master' && steps.ccache_restore.outputs.cache-hit
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh cache delete --repo ${{ github.repository }} ${{ steps.ccache_restore.outputs.cache-primary-key }}
+        run: gh cache delete --repo ${{ github.repository }} ${{ steps.ccache_restore.outputs.cache-primary-key }} || true
 
       - name: Save updated compiler cache (ccache)
         if: github.ref == 'refs/heads/master'
@@ -450,11 +451,12 @@ jobs:
         run: .ci/compile.sh --server --test --vcpkg
 
       # Delete used cache to emulate a ccache update. See https://github.com/actions/cache/issues/342.
+      # If the deletion is failing we want to proceed nontheless and not error the job
       - name: Delete remote compiler cache (ccache)
         if: github.ref == 'refs/heads/master' && matrix.use_ccache == 1 && steps.ccache_restore.outputs.cache-hit
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh cache delete --repo ${{ github.repository }} ${{ steps.ccache_restore.outputs.cache-primary-key }}
+        run: gh cache delete --repo ${{ github.repository }} ${{ steps.ccache_restore.outputs.cache-primary-key }} || true
 
       - name: Save updated compiler cache (ccache)
         if: github.ref == 'refs/heads/master' && matrix.use_ccache == 1


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6791

## Short roundup of the initial problem
Deletion of the used cache in the job was failing because it could for some reason not be found.

## What will change with this Pull Request?
- Allow this step to fail and proceed with the rest of the steps in the job nonetheless
  - If the cache deletion is not possible, the next step will run but not be able to save the cache and print a warning
  - If the cache is not found for deletion, the next step will upload the cache and pass