### PR TITLE
make general settings scrollable

### DIFF
--- a/cockatrice/src/interface/widgets/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_settings.cpp
@@ -1785,7 +1785,7 @@ DlgSettings::DlgSettings(QWidget *parent) : QDialog(parent)
     contentsWidget->setSpacing(5);
 
     pagesWidget = new QStackedWidget;
-    pagesWidget->addWidget(new GeneralSettingsPage);
+    pagesWidget->addWidget(makeScrollable(new GeneralSettingsPage));
     pagesWidget->addWidget(makeScrollable(new AppearanceSettingsPage));
     pagesWidget->addWidget(makeScrollable(new UserInterfaceSettingsPage));
     pagesWidget->addWidget(new DeckEditorSettingsPage);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem
the general settings page has become too tall to not squish the items on it on most screens

## What will change with this Pull Request?
- use existing convenience method to add a scrollarea to the general tab of the settings