### PR TITLE
remove break statement when closing views

### DIFF
--- a/cockatrice/src/game/player/player_event_handler.cpp
+++ b/cockatrice/src/game/player/player_event_handler.cpp
@@ -60,7 +60,6 @@ void PlayerEventHandler::eventShuffle(const Event_Shuffle &event)
             // we want to close empty views as well
             if (length == 0 || length > absStart) { // note this assumes views always start at the top of the library
                 view->close();
-                break;
             }
         } else {
             qWarning() << zone->getName() << "of" << player->getPlayerInfo()->getName() << "holds empty zoneview!";


### PR DESCRIPTION
it's possible that multiple views need to be closed
this is an oversight of #4570
