### PR TITLE
replace windows11 with fusion for the view windows

### DIFF
--- a/cockatrice/src/game/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game/zones/view_zone_widget.cpp
@@ -19,6 +19,7 @@
 #include <QPainter>
 #include <QScrollBar>
 #include <QStyle>
+#include <QStyleFactory>
 #include <QStyleOption>
 #include <libcockatrice/protocol/pb/command_shuffle.pb.h>
 
@@ -46,6 +47,11 @@ ZoneViewWidget::ZoneViewWidget(Player *_player,
                                bool _isReversed)
     : QGraphicsWidget(0, Qt::Window), canBeShuffled(_origZone->getIsShufflable()), player(_player)
 {
+    // workaround for windows11 theme completely breaking on our zonewidgets
+    if (style()->name() == "windows11") {
+        setStyle(QStyleFactory::create("Fusion"));
+    }
+
     setAcceptHoverEvents(true);
     setAttribute(Qt::WA_DeleteOnClose);
     setZValue(ZValues::ZONE_VIEW_WIDGET);


### PR DESCRIPTION
## Related Ticket(s)
- #6734

## Short roundup of the initial problem
users on windows11 have been reporting the entire viewport breaking when a card view window appears in the player

## What will change with this Pull Request?
- replace the theme of just the view with fusion if it's found to use windows11