### PR TITLE
add some output to the eviction step to measure effectiveness

### DIFF
--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -273,6 +273,11 @@ echo "::endgroup::"
 if [[ $USE_CCACHE ]]; then
   if [[ $CCACHE_EVICTION_AGE ]]; then
     echo "::group::evict ccache files older than $CCACHE_EVICTION_AGE"
+    ccache_dir=$(ccache --get-config cache_dir)
+    mapfile -t timestamps < <(find "$ccache_dir" -name CACHEDIR.TAG -prune -o -type f -printf '%T+\n' | sort)
+    filecount=${#timestamps[@]}
+    oldest_file=${timestamps[0]}
+    echo "the oldest file before deletion is from $oldest_file out of $filecount files in $ccache_dir"
     ccache --evict-older-than "$CCACHE_EVICTION_AGE"
     echo "::endgroup::"
   fi

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -187,10 +187,17 @@ jobs:
       - name: Build debug and test
         if: matrix.test != 'skip'
         shell: bash
+        env:
+          package: '${{matrix.package}}'
         run: |
           source .ci/docker.sh
-          RUN --server --debug --test --ccache "$CCACHE_SIZE" \
-                  --cmake-generator "$CMAKE_GENERATOR"
+          args=()
+          if [[ $GITHUB_REF == "refs/heads/master" && $package == "skip" ]]; then
+            args+=(--evict-ccache "$CCACHE_EVICTION_AGE")
+          fi
+          args+=(--ccache "$CCACHE_SIZE")
+          args+=(--cmake-generator "$CMAKE_GENERATOR")
+          RUN --server --debug --test "${args[@]}"
 
       - name: Build release package
         id: build

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -461,6 +461,7 @@ jobs:
           CMAKE_GENERATOR: ${{matrix.cmake_generator}}
           CMAKE_GENERATOR_PLATFORM: ${{matrix.cmake_generator_platform}}
           USE_CCACHE: ${{matrix.use_ccache}}
+          CCACHE_EVICTION_AGE: ${{github.ref == 'refs/heads/master' && matrix.ccache_eviction_age || ''}}
           VCPKG_DISABLE_METRICS: 1
           VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'
           # macOS-specific environment variables, will be ignored on Windows
@@ -470,7 +471,6 @@ jobs:
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
           DEVELOPER_DIR: '/Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer'
           TARGET_MACOS_VERSION: ${{ matrix.override_target }}
-          CCACHE_EVICTION_AGE: ${{ matrix.ccache_eviction_age }}
         run: .ci/compile.sh --server --test --vcpkg
 
       # Delete used cache to emulate a ccache update. See https://github.com/actions/cache/issues/342


### PR DESCRIPTION
## Related Ticket(s)
- followup to #6795

## Short roundup of the initial problem
the ccache eviction happens without any feedback

## What will change with this Pull Request?
- add a line that says what the oldest age of a file is and how many files there are, effectively doubling the amount of processing of this step