### PR TITLE
add workaround for windows11 theme

### DIFF
--- a/cockatrice/src/interface/theme_manager.cpp
+++ b/cockatrice/src/interface/theme_manager.cpp
@@ -91,6 +91,10 @@ struct PaletteColorInfo
 ThemeManager::ThemeManager(QObject *parent) : QObject(parent)
 {
     defaultStyleName = qApp->style()->objectName();
+    // FIXME workaround for windows11 style being broken
+    if (defaultStyleName == "windows11") {
+        defaultStyleName = "windowsvista";
+    }
     ensureThemeDirectoryExists();
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
     connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this, &ThemeManager::themeChangedSlot);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes https://github.com/Cockatrice/Cockatrice/issues/6807

## Short roundup of the initial problem
I tried to find if there is a way to keep the new windows11 theme, but it's too much effort, people are just stuck with the vista theme for now, the other option is to downgrade the used version in ci, but that does not fix compiled builds for example, I think it's a better idea to move forward in qt version as otherwise we'll just be stuck on 6.6 forever.

## What will change with this Pull Request?
- detect if windows11 theme is used and replace it with windowsvista