### PR TITLE
set the minimum qt6 version to 6.4

### DIFF
--- a/.ci/Ubuntu22.04/Dockerfile
+++ b/.ci/Ubuntu22.04/Dockerfile
@@ -9,20 +9,18 @@ RUN apt-get update && \
         file \
         g++ \
         git \
-        libgl-dev \
         liblzma-dev \
         libmariadb-dev-compat \
         libprotobuf-dev \
-        libqt6multimedia6 \
-        libqt6sql6-mysql \
-        libqt6svg6-dev \
-        libqt6websockets6-dev \
+        libqt5multimedia5-plugins \
+        libqt5sql5-mysql \
+        libqt5svg5-dev \
+        libqt5websockets5-dev \
         ninja-build \
         protobuf-compiler \
-        qt6-image-formats-plugins \
-        qt6-l10n-tools \
-        qt6-multimedia-dev \
-        qt6-tools-dev \
-        qt6-tools-dev-tools \
+        qt5-image-formats-plugins \
+        qtmultimedia5-dev \
+        qttools5-dev \
+        qttools5-dev-tools \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/cmake/FindQtRuntime.cmake
+++ b/cmake/FindQtRuntime.cmake
@@ -42,7 +42,7 @@ list(REMOVE_DUPLICATES REQUIRED_QT_COMPONENTS)
 if(NOT FORCE_USE_QT5)
   # Linguist is now a component in Qt6 instead of an external package
   find_package(
-    Qt6 6.2.3
+    Qt6 6.4.2
     COMPONENTS ${REQUIRED_QT_COMPONENTS} Linguist
     QUIET HINTS ${Qt6_DIR}
   )

--- a/cockatrice/src/interface/deck_loader/deck_loader.h
+++ b/cockatrice/src/interface/deck_loader/deck_loader.h
@@ -13,6 +13,7 @@
 #include <QPrinter>
 #include <QTextCursor>
 #include <libcockatrice/deck_list/deck_list.h>
+#include <optional>
 
 inline Q_LOGGING_CATEGORY(DeckLoaderLog, "deck_loader");
 

--- a/cockatrice/src/interface/pixel_map_generator.h
+++ b/cockatrice/src/interface/pixel_map_generator.h
@@ -12,6 +12,7 @@
 #include <QMap>
 #include <QPixmap>
 #include <libcockatrice/network/server/remote/user_level.h>
+#include <optional>
 
 inline Q_LOGGING_CATEGORY(PixelMapGeneratorLog, "pixel_map_generator");
 


### PR DESCRIPTION


## Related Ticket(s)
- Fixes #6786


## Short roundup of the initial problem
qt 6.2 is broken, it used to be just debug builds that were but now it's also release builds, we have no reason to fix this as it's too old to bother, oses using qt6.2 will have to use qt5 instead

this will be separate from the qt5 removal which will happen after release

## What will change with this Pull Request?
- set minimum qt6 version to 6.4
- switch the packages of ubuntu 22.04 runner to qt5