### PR TITLE
[EDHRec] Fix unintentional navigation on card right click

### DIFF
--- a/cockatrice/src/interface/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_widget.cpp
@@ -343,11 +343,9 @@ void CardInfoPictureWidget::mousePressEvent(QMouseEvent *event)
     QWidget::mousePressEvent(event);
     if (event->button() == Qt::RightButton) {
         createRightClickMenu()->popup(QCursor::pos());
-    } else {
-        emit cardClicked();
     }
 
-    emit cardClicked();
+    emit cardClicked(event);
 }
 
 void CardInfoPictureWidget::hideEvent(QHideEvent *event)

--- a/cockatrice/src/interface/widgets/cards/card_info_picture_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_widget.h
@@ -43,7 +43,7 @@ signals:
     void hoveredOnCard(const ExactCard &hoveredCard);
     void cardScaleFactorChanged(int _scale);
     void cardChanged(const ExactCard &card);
-    void cardClicked();
+    void cardClicked(QMouseEvent *event);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.cpp
@@ -3,6 +3,7 @@
 #include "../../../../../general/display/background_plate_widget.h"
 #include "../../tab_edhrec_main.h"
 
+#include <QMouseEvent>
 #include <libcockatrice/card/database/card_database_manager.h>
 
 EdhrecApiResponseCardDetailsDisplayWidget::EdhrecApiResponseCardDetailsDisplayWidget(
@@ -48,7 +49,7 @@ EdhrecApiResponseCardDetailsDisplayWidget::EdhrecApiResponseCardDetailsDisplayWi
     if (parentTab) {
         cardPictureWidget->setScaleFactor(parentTab->getCardSizeSlider()->getSlider()->value());
         connect(cardPictureWidget, &CardInfoPictureWidget::cardClicked, this,
-                &EdhrecApiResponseCardDetailsDisplayWidget::actRequestPageNavigation);
+                &EdhrecApiResponseCardDetailsDisplayWidget::mousePressEvent);
         connect(parentTab->getCardSizeSlider()->getSlider(), &QSlider::valueChanged, cardPictureWidget,
                 &CardInfoPictureWidget::setScaleFactor);
         connect(this, &EdhrecApiResponseCardDetailsDisplayWidget::requestUrl, parentTab,
@@ -59,7 +60,9 @@ EdhrecApiResponseCardDetailsDisplayWidget::EdhrecApiResponseCardDetailsDisplayWi
 void EdhrecApiResponseCardDetailsDisplayWidget::mousePressEvent(QMouseEvent *event)
 {
     QWidget::mousePressEvent(event);
-    actRequestPageNavigation();
+    if (event->button() == Qt::LeftButton) {
+        actRequestPageNavigation();
+    }
 }
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)


### PR DESCRIPTION
## Short roundup of the initial problem
Left clicking is supposed to navigate to the card whereas right clicking opens the card menu so you can add the card to your deck.
We hook up to cardClicked for the navigation, which we always emit, whether it's a right or left click. This makes the right-click menu inaccessible.

## What will change with this Pull Request?
- Don't double emit cardClicked
- pass along the mouseEvent so we can check if it's a left or right click.
