### PR TITLE
clear player before removing it from the scene

### DIFF
--- a/cockatrice/src/game/board/card_item.cpp
+++ b/cockatrice/src/game/board/card_item.cpp
@@ -460,9 +460,6 @@ void CardItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
 
 bool CardItem::animationEvent()
 {
-    if (owner == nullptr) {
-        return false;
-    }
     int rotation = ROTATION_DEGREES_PER_FRAME;
     bool animationIncomplete = true;
     if (!tapped)

--- a/cockatrice/src/game/game_event_handler.cpp
+++ b/cockatrice/src/game/game_event_handler.cpp
@@ -429,13 +429,13 @@ void GameEventHandler::eventLeave(const Event_Leave &event, int eventPlayerId, c
     if (!player)
         return;
 
+    player->clear();
     emit playerLeft(eventPlayerId);
 
     emit logLeave(player, getLeaveReason(event.reason()));
 
     game->getPlayerManager()->removePlayer(eventPlayerId);
 
-    player->clear();
     player->deleteLater();
 
     // Rearrange all remaining zones so that attachment relationship updates take place


### PR DESCRIPTION


## Related Ticket(s)
- revert #6740
- regression introduced in #6090

## Short roundup of the initial problem
when a player leaves it is important to first clear the player and its zones before removing it from the scene, clearing the player removes its cards which will then each remove their animation timers from the scene, if an animation timer were to fire while the player has been removed from the scene a problem occurs where the card attempts to perform a transformation while no longer existing, this is the entire reason why player->clear() is a separate step from deleteLater()

## What will change with this Pull Request?
- move player->clear() to before the signals are emitted to the scene
- remove the check introduced in 6740, as this fixes the root cause of why it was needed