### PR TITLE
stop prepending the adventure side

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -366,8 +366,6 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
             auto found_iter = splitCards.find(name + numProperty);
             if (found_iter == splitCards.end()) {
                 splitCards.insert(name + numProperty, {{split}, name});
-            } else if (layout == "adventure" || layout == "prepare") {
-                found_iter->first.insert(0, split);
             } else {
                 found_iter->first.append(split);
             }


### PR DESCRIPTION


## Related Ticket(s)
- #6792
- #4244

## Short roundup of the initial problem
the adventure side of adventure cards used to be the first entry in mtgjson, at some point this changed to the second entry, better reflecting its secondary nature, however cockatrice has hardcoded the treatment of the card to assume the second part was the "main" part, when implementing the treatment of prepare layout cards (#6792) I copied the behavior over which was then already incorrect, this pr removes the special treatment of this card layout bringing the result back in line with expectation: the main part of the card provides the main type used in cockatrice for sorting and behavior

## What will change with this Pull Request?
- take main type of adventures and prepare cards from the first entry

## Screenshots
before
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/87bd68a0-c13a-45ba-869a-b1bf52535138" />
after<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/276a9098-50ae-4b89-841f-f26b7cb01bec" />
