### PR TITLE
Change button colors to be palette aware.

### DIFF
--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_filter_button.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_filter_button.h
@@ -1,0 +1,21 @@
+#ifndef COCKATRICE_VISUAL_DATABASE_DISPLAY_FILTER_BUTTON_H
+#define COCKATRICE_VISUAL_DATABASE_DISPLAY_FILTER_BUTTON_H
+
+#include <QString>
+
+const QString visualDatabaseDisplayFilterButtonStyle = QString(R"(
+    QPushButton {
+        background-color: palette(button);
+        color: palette(button-text);
+        padding: 5px 10px;
+        border-radius: 4px;
+        border: 1px solid palette(dark);
+    }
+    QPushButton:checked {
+        background-color: palette(highlight);
+        color: palette(highlighted-text);
+        border: 1px solid palette(shadow);
+    }
+)");
+
+#endif // COCKATRICE_VISUAL_DATABASE_DISPLAY_FILTER_BUTTON_H

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_format_legality_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_format_legality_filter_widget.cpp
@@ -1,6 +1,7 @@
 #include "visual_database_display_format_legality_filter_widget.h"
 
 #include "../../../filters/filter_tree_model.h"
+#include "visual_database_display_filter_button.h"
 
 #include <QLabel>
 #include <QPushButton>
@@ -80,21 +81,7 @@ void VisualDatabaseDisplayFormatLegalityFilterWidget::createFormatButtons()
     for (auto it = allFormatsWithCount.begin(); it != allFormatsWithCount.end(); ++it) {
         auto *button = new QPushButton(it.key(), flowWidget);
         button->setCheckable(true);
-        QPalette pal = button->palette();
-        QString base = pal.button().color().name();
-        QString highlight = pal.highlight().color().name();
-
-        button->setStyleSheet(QString(R"(
-    QPushButton {
-        background-color: %1;
-        padding: 5px;
-    }
-    QPushButton:checked {
-        background-color: %2;
-        color: white;
-    }
-)")
-                                  .arg(base, highlight));
+        button->setStyleSheet(visualDatabaseDisplayFilterButtonStyle);
 
         flowWidget->addWidget(button);
         formatButtons[it.key()] = button;

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_format_legality_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_format_legality_filter_widget.cpp
@@ -80,8 +80,21 @@ void VisualDatabaseDisplayFormatLegalityFilterWidget::createFormatButtons()
     for (auto it = allFormatsWithCount.begin(); it != allFormatsWithCount.end(); ++it) {
         auto *button = new QPushButton(it.key(), flowWidget);
         button->setCheckable(true);
-        button->setStyleSheet("QPushButton { background-color: lightgray; border: 1px solid gray; padding: 5px; }"
-                              "QPushButton:checked { background-color: green; color: white; }");
+        QPalette pal = button->palette();
+        QString base = pal.button().color().name();
+        QString highlight = pal.highlight().color().name();
+
+        button->setStyleSheet(QString(R"(
+    QPushButton {
+        background-color: %1;
+        padding: 5px;
+    }
+    QPushButton:checked {
+        background-color: %2;
+        color: white;
+    }
+)")
+                                  .arg(base, highlight));
 
         flowWidget->addWidget(button);
         formatButtons[it.key()] = button;

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_main_type_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_main_type_filter_widget.cpp
@@ -1,6 +1,7 @@
 #include "visual_database_display_main_type_filter_widget.h"
 
 #include "../../../filters/filter_tree_model.h"
+#include "visual_database_display_filter_button.h"
 
 #include <QLabel>
 #include <QPushButton>
@@ -75,21 +76,8 @@ void VisualDatabaseDisplayMainTypeFilterWidget::createMainTypeButtons()
     for (auto it = allMainCardTypesWithCount.begin(); it != allMainCardTypesWithCount.end(); ++it) {
         auto *button = new QPushButton(it.key(), flowWidget);
         button->setCheckable(true);
-        QPalette pal = button->palette();
-        QString base = pal.button().color().name();
-        QString highlight = pal.highlight().color().name();
 
-        button->setStyleSheet(QString(R"(
-    QPushButton {
-        background-color: %1;
-        padding: 5px;
-    }
-    QPushButton:checked {
-        background-color: %2;
-        color: white;
-    }
-)")
-                                  .arg(base, highlight));
+        button->setStyleSheet(visualDatabaseDisplayFilterButtonStyle);
 
         flowWidget->addWidget(button);
         typeButtons[it.key()] = button;

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_main_type_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_main_type_filter_widget.cpp
@@ -75,8 +75,21 @@ void VisualDatabaseDisplayMainTypeFilterWidget::createMainTypeButtons()
     for (auto it = allMainCardTypesWithCount.begin(); it != allMainCardTypesWithCount.end(); ++it) {
         auto *button = new QPushButton(it.key(), flowWidget);
         button->setCheckable(true);
-        button->setStyleSheet("QPushButton { background-color: lightgray; border: 1px solid gray; padding: 5px; }"
-                              "QPushButton:checked { background-color: green; color: white; }");
+        QPalette pal = button->palette();
+        QString base = pal.button().color().name();
+        QString highlight = pal.highlight().color().name();
+
+        button->setStyleSheet(QString(R"(
+    QPushButton {
+        background-color: %1;
+        padding: 5px;
+    }
+    QPushButton:checked {
+        background-color: %2;
+        color: white;
+    }
+)")
+                                  .arg(base, highlight));
 
         flowWidget->addWidget(button);
         typeButtons[it.key()] = button;

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_name_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_name_filter_widget.cpp
@@ -95,8 +95,21 @@ void VisualDatabaseDisplayNameFilterWidget::createNameFilter(const QString &name
 
     // Create a button for the filter
     auto *button = new QPushButton(name, flowWidget);
-    button->setStyleSheet("QPushButton { background-color: lightgray; border: 1px solid gray; padding: 5px; }"
-                          "QPushButton:hover { background-color: red; color: white; }");
+    QPalette pal = button->palette();
+    QString base = pal.button().color().name();
+    QString highlight = pal.highlight().color().name();
+
+    button->setStyleSheet(QString(R"(
+    QPushButton {
+        background-color: %1;
+        padding: 5px;
+    }
+    QPushButton:checked {
+        background-color: %2;
+        color: white;
+    }
+)")
+                              .arg(base, highlight));
 
     connect(button, &QPushButton::clicked, this, [this, name]() {
         removeNameFilter(name);

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_name_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_name_filter_widget.cpp
@@ -3,6 +3,7 @@
 #include "../../../interface/widgets/dialogs/dlg_load_deck_from_clipboard.h"
 #include "../../../interface/widgets/tabs/abstract_tab_deck_editor.h"
 #include "../deck_editor/deck_state_manager.h"
+#include "visual_database_display_filter_button.h"
 
 #include <QHBoxLayout>
 
@@ -95,21 +96,8 @@ void VisualDatabaseDisplayNameFilterWidget::createNameFilter(const QString &name
 
     // Create a button for the filter
     auto *button = new QPushButton(name, flowWidget);
-    QPalette pal = button->palette();
-    QString base = pal.button().color().name();
-    QString highlight = pal.highlight().color().name();
 
-    button->setStyleSheet(QString(R"(
-    QPushButton {
-        background-color: %1;
-        padding: 5px;
-    }
-    QPushButton:checked {
-        background-color: %2;
-        color: white;
-    }
-)")
-                              .arg(base, highlight));
+    button->setStyleSheet(visualDatabaseDisplayFilterButtonStyle);
 
     connect(button, &QPushButton::clicked, this, [this, name]() {
         removeNameFilter(name);

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_set_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_set_filter_widget.cpp
@@ -2,6 +2,7 @@
 
 #include "../../../client/settings/cache_settings.h"
 #include "../../../filters/filter_tree_model.h"
+#include "visual_database_display_filter_button.h"
 
 #include <QLineEdit>
 #include <QPushButton>
@@ -101,21 +102,8 @@ void VisualDatabaseDisplaySetFilterWidget::createSetButtons()
 
         auto *button = new QPushButton(longName + " (" + shortName + ")", flowWidget);
         button->setCheckable(true);
-        QPalette pal = button->palette();
-        QString base = pal.button().color().name();
-        QString highlight = pal.highlight().color().name();
 
-        button->setStyleSheet(QString(R"(
-    QPushButton {
-        background-color: %1;
-        padding: 5px;
-    }
-    QPushButton:checked {
-        background-color: %2;
-        color: white;
-    }
-)")
-                                  .arg(base, highlight));
+        button->setStyleSheet(visualDatabaseDisplayFilterButtonStyle);
 
         flowWidget->addWidget(button);
         setButtons[shortName] = button;

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_set_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_set_filter_widget.cpp
@@ -101,8 +101,21 @@ void VisualDatabaseDisplaySetFilterWidget::createSetButtons()
 
         auto *button = new QPushButton(longName + " (" + shortName + ")", flowWidget);
         button->setCheckable(true);
-        button->setStyleSheet("QPushButton { background-color: lightgray; border: 1px solid gray; padding: 5px; }"
-                              "QPushButton:checked { background-color: green; color: white; }");
+        QPalette pal = button->palette();
+        QString base = pal.button().color().name();
+        QString highlight = pal.highlight().color().name();
+
+        button->setStyleSheet(QString(R"(
+    QPushButton {
+        background-color: %1;
+        padding: 5px;
+    }
+    QPushButton:checked {
+        background-color: %2;
+        color: white;
+    }
+)")
+                                  .arg(base, highlight));
 
         flowWidget->addWidget(button);
         setButtons[shortName] = button;

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_sub_type_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_sub_type_filter_widget.cpp
@@ -80,8 +80,21 @@ void VisualDatabaseDisplaySubTypeFilterWidget::createSubTypeButtons()
     for (auto it = allSubCardTypesWithCount.begin(); it != allSubCardTypesWithCount.end(); ++it) {
         auto *button = new QPushButton(it.key(), flowWidget);
         button->setCheckable(true);
-        button->setStyleSheet("QPushButton { background-color: lightgray; border: 1px solid gray; padding: 5px; }"
-                              "QPushButton:checked { background-color: green; color: white; }");
+        QPalette pal = button->palette();
+        QString base = pal.button().color().name();
+        QString highlight = pal.highlight().color().name();
+
+        button->setStyleSheet(QString(R"(
+    QPushButton {
+        background-color: %1;
+        padding: 5px;
+    }
+    QPushButton:checked {
+        background-color: %2;
+        color: white;
+    }
+)")
+                                  .arg(base, highlight));
 
         flowWidget->addWidget(button);
         typeButtons[it.key()] = button;

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_sub_type_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_sub_type_filter_widget.cpp
@@ -1,6 +1,7 @@
 #include "visual_database_display_sub_type_filter_widget.h"
 
 #include "../../../filters/filter_tree_model.h"
+#include "visual_database_display_filter_button.h"
 
 #include <QLabel>
 #include <QLineEdit>
@@ -80,21 +81,8 @@ void VisualDatabaseDisplaySubTypeFilterWidget::createSubTypeButtons()
     for (auto it = allSubCardTypesWithCount.begin(); it != allSubCardTypesWithCount.end(); ++it) {
         auto *button = new QPushButton(it.key(), flowWidget);
         button->setCheckable(true);
-        QPalette pal = button->palette();
-        QString base = pal.button().color().name();
-        QString highlight = pal.highlight().color().name();
 
-        button->setStyleSheet(QString(R"(
-    QPushButton {
-        background-color: %1;
-        padding: 5px;
-    }
-    QPushButton:checked {
-        background-color: %2;
-        color: white;
-    }
-)")
-                                  .arg(base, highlight));
+        button->setStyleSheet(visualDatabaseDisplayFilterButtonStyle);
 
         flowWidget->addWidget(button);
         typeButtons[it.key()] = button;


### PR DESCRIPTION
## Short roundup of the initial problem
Buttons are hard to read and oddly styled.
Originally, this was to accomodate the DarkMingo theme, which many people saw as a non-negotiable dark mode. With the advent of the fusion theme and user willingness to accept it as a default dark mode, we don't need to make such major concessions anymore.
Mostly: We don't *need* to enforce a border so that Mingo remains readable (it will be up to them to style these buttons properly for their theme) and we can just render the buttons as button, with palette aware text and custom highlighting (so the check state remains highly visible, as opposed to just a depressed button)

## What will change with this Pull Request?
- Change VDD filter button styling

## Screenshots

## Before:

Default:
<img width="853" height="467" alt="image" src="https://github.com/user-attachments/assets/936f5006-4d8f-4087-b942-85ecc61a95de" />

Fusion (Light):
<img width="866" height="493" alt="image" src="https://github.com/user-attachments/assets/aec8637d-f7ad-4e45-8e19-69b027288edc" />

Fusion (Dark)
<img width="866" height="476" alt="image" src="https://github.com/user-attachments/assets/892e2564-cb22-4f12-9ee5-fdefb5b48e94" />

DarkMingo (Custom Theme)
<img width="813" height="488" alt="image" src="https://github.com/user-attachments/assets/590794be-8946-43b9-9337-c8875fbb0db7" />

## After:

Default:
<img width="849" height="446" alt="image" src="https://github.com/user-attachments/assets/056f062d-b450-4ee7-8f3e-4e259c804b3a" />

Fusion (Light)
<img width="863" height="418" alt="image" src="https://github.com/user-attachments/assets/b1527e61-12ae-4cc2-8d6c-9252f7635f80" />

Fusion (Dark)
<img width="869" height="453" alt="image" src="https://github.com/user-attachments/assets/e8b9a97f-81c0-4a23-a55d-5e0099ae933b" />

DarkMingo (Custom Theme)
<img width="811" height="494" alt="image" src="https://github.com/user-attachments/assets/6d0ac83b-9010-4719-a44b-f3b2fb8c5c48" />
