### PR TITLE
[GameSelector/Filters] Properly sync toolbar and dialog.

### DIFF
--- a/cockatrice/src/interface/widgets/server/game_selector.cpp
+++ b/cockatrice/src/interface/widgets/server/game_selector.cpp
@@ -91,6 +91,7 @@ GameSelector::GameSelector(AbstractClient *_client,
     bool filtersSetToDefault = showFilters && gameListProxyModel->areFilterParametersSetToDefaults();
     clearFilterButton->setEnabled(!filtersSetToDefault);
     connect(clearFilterButton, &QPushButton::clicked, this, &GameSelector::actClearFilter);
+    connect(gameListProxyModel, &GamesProxyModel::filtersChanged, this, &GameSelector::checkClearFilterButtonState);
 
     if (room) {
         createButton = new QPushButton;
@@ -188,15 +189,16 @@ void GameSelector::actSetFilter()
         dlg.getShowOnlyIfSpectatorsCanChat(), dlg.getShowOnlyIfSpectatorsCanSeeHands());
     gameListProxyModel->saveFilterParameters(gameTypeMap);
 
-    clearFilterButton->setEnabled(!gameListProxyModel->areFilterParametersSetToDefaults());
-
     updateTitle();
+}
+
+void GameSelector::checkClearFilterButtonState()
+{
+    clearFilterButton->setEnabled(!gameListProxyModel->areFilterParametersSetToDefaults());
 }
 
 void GameSelector::actClearFilter()
 {
-    clearFilterButton->setEnabled(false);
-
     gameListProxyModel->resetFilterParameters();
     gameListProxyModel->saveFilterParameters(gameTypeMap);
 

--- a/cockatrice/src/interface/widgets/server/game_selector.h
+++ b/cockatrice/src/interface/widgets/server/game_selector.h
@@ -40,6 +40,7 @@ private slots:
      * Updates the proxy model with selected filter parameters and refreshes the displayed game list.
      */
     void actSetFilter();
+    void checkClearFilterButtonState();
 
     /**
      * @brief Clears all filters applied to the game list.

--- a/cockatrice/src/interface/widgets/server/game_selector_quick_filter_toolbar.cpp
+++ b/cockatrice/src/interface/widgets/server/game_selector_quick_filter_toolbar.cpp
@@ -19,32 +19,46 @@ GameSelectorQuickFilterToolBar::GameSelectorQuickFilterToolBar(QWidget *parent,
     mainLayout->setSpacing(5);
 
     searchBar = new QLineEdit(this);
-    searchBar->setText(model->getCreatorNameFilters().join(", "));
-    connect(searchBar, &QLineEdit::textChanged, this, [this](const QString &text) { model->setGameNameFilter(text); });
+    searchBar->setText(model->getGameNameFilter());
+    connect(searchBar, &QLineEdit::textChanged, this, [this](const QString &text) {
+        applyFilters([&](auto &, auto &, auto &, auto &, auto &, auto &, auto &, QString &gameNameFilter, auto &,
+                         auto &, auto &, auto &, auto &, auto &, auto &, auto &, auto &) { gameNameFilter = text; });
+    });
 
     hideGamesNotCreatedByBuddiesCheckBox = new QCheckBox(this);
-    hideGamesNotCreatedByBuddiesCheckBox->setChecked(model->getHideBuddiesOnlyGames());
+    hideGamesNotCreatedByBuddiesCheckBox->setChecked(model->getHideNotBuddyCreatedGames());
     connect(hideGamesNotCreatedByBuddiesCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
-        if (checked) {
-            QStringList buddyNames;
-            for (auto buddy : tabSupervisor->getUserListManager()->getBuddyList().values()) {
-                buddyNames << QString::fromStdString(buddy.name());
+        applyFilters([&](auto &, auto &, auto &, auto &, auto &, bool &hideNotBuddyCreatedGames, auto &, auto &,
+                         QStringList &creatorNameFilters, auto &, auto &, auto &, auto &, auto &, auto &, auto &,
+                         auto &) {
+            hideNotBuddyCreatedGames = checked;
+
+            if (checked) {
+                QStringList buddyNames;
+                for (auto buddy : tabSupervisor->getUserListManager()->getBuddyList().values()) {
+                    buddyNames << QString::fromStdString(buddy.name());
+                }
+                creatorNameFilters = buddyNames;
+            } else {
+                creatorNameFilters.clear();
             }
-            model->setCreatorNameFilters(buddyNames);
-        } else {
-            model->setCreatorNameFilters({});
-        }
+        });
     });
 
     hideFullGamesCheckBox = new QCheckBox(this);
     hideFullGamesCheckBox->setChecked(model->getHideFullGames());
-    connect(hideFullGamesCheckBox, &QCheckBox::toggled, this,
-            [this](bool checked) { model->setHideFullGames(checked); });
+    connect(hideFullGamesCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
+        applyFilters([&](auto &, auto &, bool &hideFullGames, auto &, auto &, auto &, auto &, auto &, auto &, auto &,
+                         auto &, auto &, auto &, auto &, auto &, auto &, auto &) { hideFullGames = checked; });
+    });
 
     hideStartedGamesCheckBox = new QCheckBox(this);
     hideStartedGamesCheckBox->setChecked(model->getHideGamesThatStarted());
-    connect(hideStartedGamesCheckBox, &QCheckBox::toggled, this,
-            [this](bool checked) { model->setHideGamesThatStarted(checked); });
+    connect(hideStartedGamesCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
+        applyFilters([&](auto &, auto &, auto &, bool &hideGamesThatStarted, auto &, auto &, auto &, auto &, auto &,
+                         auto &, auto &, auto &, auto &, auto &, auto &, auto &,
+                         auto &) { hideGamesThatStarted = checked; });
+    });
 
     filterToFormatComboBox = new QComboBox(this);
 
@@ -69,13 +83,15 @@ GameSelectorQuickFilterToolBar::GameSelectorQuickFilterToolBar(QWidget *parent,
 
     // Update proxy model on selection change
     connect(filterToFormatComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int index) {
-        QVariant data = filterToFormatComboBox->itemData(index);
-        if (!data.isValid()) {
-            model->setGameTypeFilter({}); // empty = no filter
-        } else {
-            int typeId = data.toInt();
-            model->setGameTypeFilter({typeId});
-        }
+        applyFilters([&](auto &, auto &, auto &, auto &, auto &, auto &, auto &, auto &, auto &,
+                         QSet<int> &gameTypeFilter, auto &, auto &, auto &, auto &, auto &, auto &, auto &) {
+            QVariant data = filterToFormatComboBox->itemData(index);
+            if (!data.isValid()) {
+                gameTypeFilter.clear();
+            } else {
+                gameTypeFilter = {data.toInt()};
+            }
+        });
     });
 
     hideGamesNotCreatedByBuddiesCheckBox->setMinimumSize(20, 20);
@@ -96,7 +112,85 @@ GameSelectorQuickFilterToolBar::GameSelectorQuickFilterToolBar(QWidget *parent,
 
     setLayout(mainLayout);
 
+    syncFromModel();
+
+    connect(model, &GamesProxyModel::filtersChanged, this, &GameSelectorQuickFilterToolBar::syncFromModel);
+
     retranslateUi();
+}
+
+void GameSelectorQuickFilterToolBar::syncFromModel()
+{
+    QSignalBlocker b1(searchBar);
+    QSignalBlocker b2(filterToFormatComboBox);
+    QSignalBlocker b3(hideGamesNotCreatedByBuddiesCheckBox);
+    QSignalBlocker b4(hideFullGamesCheckBox);
+    QSignalBlocker b5(hideStartedGamesCheckBox);
+
+    searchBar->setText(model->getGameNameFilter());
+
+    hideGamesNotCreatedByBuddiesCheckBox->setChecked(model->getHideNotBuddyCreatedGames());
+    hideFullGamesCheckBox->setChecked(model->getHideFullGames());
+    hideStartedGamesCheckBox->setChecked(model->getHideGamesThatStarted());
+
+    QSet<int> types = model->getGameTypeFilter();
+    if (types.size() == 1) {
+        int idx = filterToFormatComboBox->findData(*types.begin());
+        filterToFormatComboBox->setCurrentIndex(idx >= 0 ? idx : 0);
+    } else {
+        filterToFormatComboBox->setCurrentIndex(0);
+    }
+}
+
+void GameSelectorQuickFilterToolBar::applyFilters(std::function<void(bool &,
+                                                                     bool &,
+                                                                     bool &,
+                                                                     bool &,
+                                                                     bool &,
+                                                                     bool &,
+                                                                     bool &,
+                                                                     QString &,
+                                                                     QStringList &,
+                                                                     QSet<int> &,
+                                                                     int &,
+                                                                     int &,
+                                                                     QTime &,
+                                                                     bool &,
+                                                                     bool &,
+                                                                     bool &,
+                                                                     bool &)> mutator)
+{
+    bool hideBuddiesOnlyGames = model->getHideBuddiesOnlyGames();
+    bool hideIgnoredUserGames = model->getHideIgnoredUserGames();
+    bool hideFullGames = model->getHideFullGames();
+    bool hideGamesThatStarted = model->getHideGamesThatStarted();
+    bool hidePasswordProtectedGames = model->getHidePasswordProtectedGames();
+    bool hideNotBuddyCreatedGames = model->getHideNotBuddyCreatedGames();
+    bool hideOpenDecklistGames = model->getHideOpenDecklistGames();
+
+    QString gameNameFilter = model->getGameNameFilter();
+    QStringList creatorNameFilters = model->getCreatorNameFilters();
+    QSet<int> gameTypeFilter = model->getGameTypeFilter();
+
+    int minPlayers = model->getMaxPlayersFilterMin();
+    int maxPlayers = model->getMaxPlayersFilterMax();
+    QTime maxGameAge = model->getMaxGameAge();
+
+    bool showOnlyIfSpectatorsCanWatch = model->getShowOnlyIfSpectatorsCanWatch();
+    bool showSpectatorPasswordProtected = model->getShowSpectatorPasswordProtected();
+    bool showOnlyIfSpectatorsCanChat = model->getShowOnlyIfSpectatorsCanChat();
+    bool showOnlyIfSpectatorsCanSeeHands = model->getShowOnlyIfSpectatorsCanSeeHands();
+
+    mutator(hideBuddiesOnlyGames, hideIgnoredUserGames, hideFullGames, hideGamesThatStarted, hidePasswordProtectedGames,
+            hideNotBuddyCreatedGames, hideOpenDecklistGames, gameNameFilter, creatorNameFilters, gameTypeFilter,
+            minPlayers, maxPlayers, maxGameAge, showOnlyIfSpectatorsCanWatch, showSpectatorPasswordProtected,
+            showOnlyIfSpectatorsCanChat, showOnlyIfSpectatorsCanSeeHands);
+
+    model->setGameFilters(hideBuddiesOnlyGames, hideIgnoredUserGames, hideFullGames, hideGamesThatStarted,
+                          hidePasswordProtectedGames, hideNotBuddyCreatedGames, hideOpenDecklistGames, gameNameFilter,
+                          creatorNameFilters, gameTypeFilter, minPlayers, maxPlayers, maxGameAge,
+                          showOnlyIfSpectatorsCanWatch, showSpectatorPasswordProtected, showOnlyIfSpectatorsCanChat,
+                          showOnlyIfSpectatorsCanSeeHands);
 }
 
 void GameSelectorQuickFilterToolBar::retranslateUi()

--- a/cockatrice/src/interface/widgets/server/game_selector_quick_filter_toolbar.h
+++ b/cockatrice/src/interface/widgets/server/game_selector_quick_filter_toolbar.h
@@ -18,6 +18,24 @@ public:
                                             TabSupervisor *tabSupervisor,
                                             GamesProxyModel *model,
                                             const QMap<int, QString> &allGameTypes);
+    void syncFromModel();
+    void applyFilters(std::function<void(bool &,
+                                         bool &,
+                                         bool &,
+                                         bool &,
+                                         bool &,
+                                         bool &,
+                                         bool &,
+                                         QString &,
+                                         QStringList &,
+                                         QSet<int> &,
+                                         int &,
+                                         int &,
+                                         QTime &,
+                                         bool &,
+                                         bool &,
+                                         bool &,
+                                         bool &)> mutator);
     void retranslateUi();
 
 private:

--- a/cockatrice/src/interface/widgets/server/games_model.cpp
+++ b/cockatrice/src/interface/widgets/server/games_model.cpp
@@ -326,6 +326,7 @@ void GamesProxyModel::setGameFilters(bool _hideBuddiesOnlyGames,
 #else
     invalidateFilter();
 #endif
+    emit filtersChanged();
 }
 
 int GamesProxyModel::getNumFilteredGames() const

--- a/cockatrice/src/interface/widgets/server/games_model.h
+++ b/cockatrice/src/interface/widgets/server/games_model.h
@@ -138,6 +138,9 @@ private:
     bool showOnlyIfSpectatorsCanChat;
     bool showOnlyIfSpectatorsCanSeeHands;
 
+signals:
+    void filtersChanged();
+
 public:
     /**
      * @brief Constructs a GamesProxyModel.


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6601

## Short roundup of the initial problem
Changing one doesn't necessarily change the other and the clear filter button does not affect the toolbar.

## What will change with this Pull Request?
- Add a filtersChanged() signal to the global setter
- Route all set() calls through that unified setter instead
- Hook up some other signals to filtersChanged()
- Fix some typos/mismatches