### PR TITLE
[DeckAnalytics] Add a checkbox to include/exclude sideboard for calculation

### DIFF
--- a/cockatrice/src/interface/widgets/deck_analytics/deck_analytics_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_analytics/deck_analytics_widget.cpp
@@ -29,10 +29,14 @@ DeckAnalyticsWidget::DeckAnalyticsWidget(QWidget *parent, DeckListStatisticsAnal
     removeButton = new QPushButton(this);
     saveButton = new QPushButton(this);
     loadButton = new QPushButton(this);
+    includeSideboardCheckBox = new QCheckBox(this);
+    includeSideboardCheckBox->setChecked(true);
+
     controlLayout->addWidget(addButton);
     controlLayout->addWidget(removeButton);
     controlLayout->addWidget(saveButton);
     controlLayout->addWidget(loadButton);
+    controlLayout->addWidget(includeSideboardCheckBox);
 
     layout->addWidget(controlContainer);
 
@@ -40,6 +44,7 @@ DeckAnalyticsWidget::DeckAnalyticsWidget(QWidget *parent, DeckListStatisticsAnal
     connect(removeButton, &QPushButton::clicked, this, &DeckAnalyticsWidget::onRemoveSelected);
     connect(saveButton, &QPushButton::clicked, this, &DeckAnalyticsWidget::saveLayout);
     connect(loadButton, &QPushButton::clicked, this, &DeckAnalyticsWidget::loadLayout);
+    connect(includeSideboardCheckBox, &QCheckBox::clicked, this, &DeckAnalyticsWidget::includeSideboardChanged);
 
     // Scroll area and container
     scrollArea = new QScrollArea(this);
@@ -66,6 +71,13 @@ void DeckAnalyticsWidget::retranslateUi()
     removeButton->setText(tr("Remove Panel"));
     saveButton->setText(tr("Save Layout"));
     loadButton->setText(tr("Load Layout"));
+    includeSideboardCheckBox->setText(tr("Include Sideboard"));
+}
+
+void DeckAnalyticsWidget::includeSideboardChanged(bool checked)
+{
+    statsAnalyzer->getConfig().includeSideboard = checked;
+    updateDisplays();
 }
 
 void DeckAnalyticsWidget::updateDisplays()

--- a/cockatrice/src/interface/widgets/deck_analytics/deck_analytics_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_analytics/deck_analytics_widget.cpp
@@ -30,7 +30,7 @@ DeckAnalyticsWidget::DeckAnalyticsWidget(QWidget *parent, DeckListStatisticsAnal
     saveButton = new QPushButton(this);
     loadButton = new QPushButton(this);
     includeSideboardCheckBox = new QCheckBox(this);
-    includeSideboardCheckBox->setChecked(true);
+    includeSideboardCheckBox->setChecked(false);
 
     controlLayout->addWidget(addButton);
     controlLayout->addWidget(removeButton);

--- a/cockatrice/src/interface/widgets/deck_analytics/deck_analytics_widget.h
+++ b/cockatrice/src/interface/widgets/deck_analytics/deck_analytics_widget.h
@@ -11,6 +11,7 @@
 #include "deck_list_statistics_analyzer.h"
 #include "resizable_panel.h"
 
+#include <QCheckBox>
 #include <QJsonObject>
 #include <QScrollArea>
 #include <QVBoxLayout>
@@ -29,6 +30,7 @@ public slots:
 public:
     explicit DeckAnalyticsWidget(QWidget *parent, DeckListStatisticsAnalyzer *analyzer);
     void retranslateUi();
+    void includeSideboardChanged(bool checked);
 
 private slots:
     void onAddPanel();
@@ -56,6 +58,8 @@ private:
     QPushButton *removeButton;
     QPushButton *saveButton;
     QPushButton *loadButton;
+
+    QCheckBox *includeSideboardCheckBox;
 
     QScrollArea *scrollArea;
     QWidget *panelContainer;

--- a/cockatrice/src/interface/widgets/deck_analytics/deck_list_statistics_analyzer.cpp
+++ b/cockatrice/src/interface/widgets/deck_analytics/deck_list_statistics_analyzer.cpp
@@ -19,7 +19,13 @@ void DeckListStatisticsAnalyzer::analyze()
 {
     clearData();
 
-    QList<const DecklistCardNode *> nodes = model->getCardNodes();
+    QList<const DecklistCardNode *> nodes;
+
+    if (config.includeSideboard) {
+        nodes = model->getCardNodes();
+    } else {
+        nodes = model->getCardNodesForZone(DECK_ZONE_MAIN);
+    }
 
     for (auto node : nodes) {
         CardInfoPtr info = CardDatabaseManager::query()->getCardInfo(node->getName());

--- a/cockatrice/src/interface/widgets/deck_analytics/deck_list_statistics_analyzer.h
+++ b/cockatrice/src/interface/widgets/deck_analytics/deck_list_statistics_analyzer.h
@@ -17,7 +17,7 @@ struct DeckListStatisticsAnalyzerConfig
     bool computeCategories = true;
     bool computeCurveBreakdowns = true;
     bool computeProbabilities = true;
-    bool includeSideboard = true;
+    bool includeSideboard = false;
 };
 
 class DeckListStatisticsAnalyzer : public QObject

--- a/cockatrice/src/interface/widgets/deck_analytics/deck_list_statistics_analyzer.h
+++ b/cockatrice/src/interface/widgets/deck_analytics/deck_list_statistics_analyzer.h
@@ -17,6 +17,7 @@ struct DeckListStatisticsAnalyzerConfig
     bool computeCategories = true;
     bool computeCurveBreakdowns = true;
     bool computeProbabilities = true;
+    bool includeSideboard = true;
 };
 
 class DeckListStatisticsAnalyzer : public QObject
@@ -131,6 +132,11 @@ public:
     DeckListModel *getModel() const
     {
         return model;
+    }
+
+    DeckListStatisticsAnalyzerConfig &getConfig()
+    {
+        return config;
     }
 
 signals:


### PR DESCRIPTION
## Short roundup of the initial problem
Currently, the deck list statistics are run for your entire deck but many people do not care about the sideboard when making evaluations, since you play with the mainboard.

## What will change with this Pull Request?
- Add a checkbox to toggle this behavior.
