### PR TITLE
[TabArchidekt] Place sideboard categories into the sideboard.

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/api_response/card/archidekt_api_response_card_entry.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/api_response/card/archidekt_api_response_card_entry.cpp
@@ -4,10 +4,29 @@ void ArchidektApiResponseCardEntry::fromJson(const QJsonObject &json)
 {
     id = json.value("id").toInt();
 
+    categories.clear();
+
     auto categoriesJson = json.value("categories").toArray();
 
-    for (auto category : categoriesJson) {
-        categories.append(category.toString());
+    for (const auto &categoryValue : categoriesJson) {
+        Category cat;
+
+        if (categoryValue.isObject()) {
+            QJsonObject obj = categoryValue.toObject();
+
+            cat.id = obj.value("id").toInt();
+            cat.name = obj.value("name").toString();
+            cat.isPremier = obj.value("isPremier").toBool();
+            cat.includedInDeck = obj.value("includedInDeck").toBool();
+            cat.includedInPrice = obj.value("includedInPrice").toBool();
+        } else if (categoryValue.isString()) {
+            cat.name = categoryValue.toString();
+
+            // assume mainboard unless known otherwise
+            cat.includedInDeck = true;
+        }
+
+        categories.append(cat);
     }
 
     companion = json.value("companion").toBool();
@@ -27,7 +46,13 @@ void ArchidektApiResponseCardEntry::fromJson(const QJsonObject &json)
 void ArchidektApiResponseCardEntry::debugPrint() const
 {
     qDebug() << "Id:" << id;
-    qDebug() << "Categories:" << categories;
+    for (auto category : categories) {
+        qDebug() << "Category ID:" << category.id;
+        qDebug() << "Category Name:" << category.name;
+        qDebug() << "Category Premier:" << category.isPremier;
+        qDebug() << "Category Included in Deck:" << category.includedInDeck;
+        qDebug() << "Category Included in Price:" << category.includedInPrice;
+    }
     qDebug() << "Companion:" << companion;
     qDebug() << "FlippedDefault:" << flippedDefault;
     qDebug() << "Label:" << label;

--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/api_response/card/archidekt_api_response_card_entry.h
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/api_response/card/archidekt_api_response_card_entry.h
@@ -9,6 +9,15 @@
 #include <QString>
 #include <QVector>
 
+struct Category
+{
+    int id;
+    QString name;
+    bool isPremier;
+    bool includedInDeck;
+    bool includedInPrice;
+};
+
 class ArchidektApiResponseCardEntry
 {
 public:
@@ -26,7 +35,7 @@ public:
         return card;
     };
 
-    QStringList getCategories() const
+    QList<Category> getCategories() const
     {
         return categories;
     }
@@ -38,7 +47,7 @@ public:
 
 private:
     int id;
-    QStringList categories;
+    QList<Category> categories;
     bool companion;
     bool flippedDefault;
     QString label;

--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/display/archidekt_api_response_deck_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/display/archidekt_api_response_deck_display_widget.cpp
@@ -63,16 +63,60 @@ ArchidektApiResponseDeckDisplayWidget::ArchidektApiResponseDeckDisplayWidget(QWi
     QString tempDeck;
     QTextStream deckStream(&tempDeck);
 
-    for (auto card : response.getCards()) {
+    QString mainboardText;
+    QString sideboardText;
+
+    QTextStream mainStream(&mainboardText);
+    QTextStream sideStream(&sideboardText);
+
+    for (const auto &card : response.getCards()) {
         QString fullName = card.getCard().getOracleCard().value("name").toString();
         // We don't really care about the second card, the card database already has it as a relation
         QString cleanName = fullName.split("//").first().trimmed();
 
-        tempDeck += QString("%1 %2 (%3) %4\n")
-                        .arg(card.getQuantity())
-                        .arg(cleanName)
-                        .arg(card.getCard().getEdition().getEditionCode().toUpper())
-                        .arg(card.getCard().getCollectorNumber());
+        QString line = QString("%1 %2 (%3) %4\n")
+                           .arg(card.getQuantity())
+                           .arg(cleanName)
+                           .arg(card.getCard().getEdition().getEditionCode().toUpper())
+                           .arg(card.getCard().getCollectorNumber());
+
+        bool isCommander = false;
+        bool isSideboardCategory = false;
+        bool includedInDeck = false;
+
+        for (const auto &cat : card.getCategories()) {
+
+            if (cat.name.compare("Commander", Qt::CaseInsensitive) == 0) {
+                isCommander = true;
+            }
+
+            if (cat.name.compare("Sideboard", Qt::CaseInsensitive) == 0 ||
+                cat.name.compare("Maybeboard", Qt::CaseInsensitive) == 0) {
+                isSideboardCategory = true;
+            }
+
+            if (cat.includedInDeck) {
+                includedInDeck = true;
+            }
+        }
+
+        QString target;
+
+        if (isCommander || isSideboardCategory) {
+            sideStream << line;
+        } else if (includedInDeck) {
+            mainStream << line;
+        } else {
+            sideStream << line;
+        }
+    }
+
+    // Combine with blank line separator
+    tempDeck = mainboardText;
+
+    if (!sideboardText.isEmpty()) {
+        tempDeck += "\n";
+        tempDeck += sideboardText;
     }
 
     model = new DeckListModel(this);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6648

## Short roundup of the initial problem
We just jam everything into the mainboard right now.

## What will change with this Pull Request?
- Differentiate a little better -> 
- Sideboard and Maybeboard always go into the sideboard
- Same with Commander
- Anything else checks the "includedInDeck" flag
