### PR TITLE
clear all players when closing game tab

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -259,6 +259,9 @@ TabGame::~TabGame()
     if (replayManager) {
         delete replayManager->replay;
     }
+    for (auto &player : game->getPlayerManager()->getPlayers()) {
+        player->clear();
+    }
 }
 
 void TabGame::updatePlayerListDockTitle()


### PR DESCRIPTION
this prevents issues caused by items in play when using the player destructor in the wrong order

this crash was reported by cheetah2003 on our discord