### PR TITLE
ensure judges are omniscient even when not spectating

### DIFF
--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_player.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_player.cpp
@@ -1502,7 +1502,7 @@ Server_AbstractPlayer::cmdRevealCards(const Command_RevealCards &cmd, ResponseCo
             zone->addWritePermission(cmd.player_id());
         }
 
-        if (isJudge()) {
+        if (judge) {
             ges.setOverwriteOwnership(true);
         }
 

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
@@ -306,7 +306,7 @@ void Server_Game::sendGameStateToPlayers()
             }
         } else {
             Event_GameStateChanged event;
-            createGameStateChangedEvent(&event, participant, false, false);
+            createGameStateChangedEvent(&event, participant, participant->isJudge(), false);
 
             gec = prepareGameEvent(event, -1);
         }
@@ -750,7 +750,7 @@ void Server_Game::createGameJoinedEvent(Server_AbstractParticipant *joiningParti
     event2.set_active_player_id(activePlayer);
     event2.set_active_phase(activePhase);
 
-    bool omniscient = joiningParticipant->isSpectator() && (spectatorsSeeEverything || joiningParticipant->isJudge());
+    bool omniscient = (joiningParticipant->isSpectator() && spectatorsSeeEverything) || joiningParticipant->isJudge();
     for (auto *participant : participants.values()) {
         participant->getInfo(event2.add_player_list(), joiningParticipant, omniscient, true);
     }
@@ -766,8 +766,8 @@ void Server_Game::sendGameEventContainer(GameEventContainer *cont,
 
     cont->set_game_id(gameId);
     for (auto *participant : participants.values()) {
-        const bool playerPrivate = (participant->getPlayerId() == privatePlayerId) ||
-                                   (participant->isSpectator() && (spectatorsSeeEverything || participant->isJudge()));
+        const bool playerPrivate = (participant->getPlayerId() == privatePlayerId) || participant->isJudge() ||
+                                   (participant->isSpectator() && spectatorsSeeEverything);
         if ((recipients.testFlag(GameEventStorageItem::SendToPrivate) && playerPrivate) ||
             (recipients.testFlag(GameEventStorageItem::SendToOthers) && !playerPrivate))
             participant->sendGameEvent(*cont);


### PR DESCRIPTION
## Related Ticket(s)
- #3531
- #5053

## Short roundup of the initial problem
judge users are able to use judge mode to join a game as a player as well, judge players are able to take all actions a judge spectator can but do not receive the same events because they check for that on the server side

this leads to strange behavior where clients while judge players behave as if they see all information while they actually don't, eg when a card is moved to a hand they will think the id of that card is correct, even though it actually isn't (#6125)

## What will change with this Pull Request?
- the server will send omniscient events to all judges