### PR TITLE
fix sending decks to tappedout

### DIFF
--- a/cockatrice/src/client/network/interfaces/tapped_out_interface.cpp
+++ b/cockatrice/src/client/network/interfaces/tapped_out_interface.cpp
@@ -89,6 +89,8 @@ void TappedOutInterface::analyzeDeck(const DeckList &deck)
     QNetworkRequest request(QUrl("https://tappedout.net/mtg-decks/paste/"));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
     request.setHeader(QNetworkRequest::UserAgentHeader, QString("Cockatrice %1").arg(VERSION_STRING));
+    // we interpret the redirect and open it in the browser instead, do not follow redirects
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::ManualRedirectPolicy);
 
     manager->post(request, data);
 }


### PR DESCRIPTION
## Related Ticket(s)
- #4068

## Short roundup of the initial problem
while investigating #4068 I noticed sending decks to tappedout does not work anymore, this is caused by a change in qt which now follows redirects by default, or we were using http instead of https and it didn't want to follow that or something like that, anyway it is solved by setting it to manually handle redirects.

## What will change with this Pull Request?
- set redirect policy to manual