### PR TITLE
CI: Add cleanup script for beta releases

### DIFF
--- a/.github/workflows/release-cleanup.yml
+++ b/.github/workflows/release-cleanup.yml
@@ -1,0 +1,136 @@
+name: Cleanup Beta Releases
+
+on:
+  release:
+    types: [released]    # triggers only on published stable releases
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/release-cleanup.yml'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run in dry mode"
+        required: true
+        type: choice
+        options:
+        - true
+        - false
+        default: 'true'
+
+jobs:
+  Deletion:
+    if: >
+      github.repository_owner == 'Cockatrice' &&
+      (
+        (github.event_name == 'release' && github.event.release.target_commitish == 'master') ||
+        (github.event_name == 'pull_request') ||
+        (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/'))
+      )
+    runs-on: ubuntu-slim
+    
+    permissions:
+      contents: write    # required to delete releases and tags
+    
+    concurrency:
+      group: cleanup-beta-releases @ ${{ github.ref_name }}
+      cancel-in-progress: false
+    
+    env:
+      DRY_RUN: ${{ inputs.dry_run || 'true' }}
+    
+    steps:
+      - name: Print release information
+        run: |
+          echo "Release Tag: ${{ github.event.release.tag_name }}"
+          echo "Release Name: ${{ github.event.release.name }}"
+          echo "Target Branch: ${{ github.event.release.target_commitish }}${{ github.base_ref }}"
+          echo ""
+          echo "Dry Run: ${{ env.DRY_RUN }}"
+
+      - name: Delete pre-releases
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const deleteReleasesTags = process.env.DRY_RUN === 'false';
+
+            core.startGroup('Fetching all releases...');
+            const releases = await github.paginate(
+              github.rest.repos.listReleases,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              }
+            );
+            
+            console.log(`Fetched ${releases.length} release(s):`);
+            releases.forEach(r => console.log(r.prerelease ? `${r.tag_name}` : `${r.tag_name} (${r.name})`));
+            core.endGroup();
+
+            core.startGroup('Filtering for published pre-releases...');
+            const prereleases = releases
+              .filter(r => r.published_at && r.prerelease && r.tag_name.includes('-beta'))
+              .sort((a, b) => new Date(b.published_at) - new Date(a.published_at));
+            
+            console.log(`Filtered ${prereleases.length} pre-release(s):`);
+            prereleases.forEach(r => console.log(`${r.published_at.split('T')[0]}: ${r.tag_name}`));
+            core.endGroup();
+
+            core.startGroup('Deleting pre-releases & related tags...');
+            console.log(`${prereleases.length} pre-release(s) marked for deletion:`);
+            
+            let deletedReleasesCount = 0;
+            let deletedTagsCount = 0;
+            
+            for (const rel of [...prereleases].reverse()) {
+              
+              // Delete release
+              console.log(`Processing release: ${rel.name}`);
+              if (deleteReleasesTags) {
+                try {
+                  await github.rest.repos.deleteRelease({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    release_id: rel.id,
+                  });
+                  console.log(`  Release deleted.`);
+                  deletedReleasesCount++;
+                } catch (err) {
+                  console.log(`  Release deletion failed: ${err.message}`);
+                  }
+              } else {
+                console.log(`  [DRY RUN] Release would be deleted.`);
+              }
+
+              // Delete tag
+              console.log(`  Processing related tag: ${rel.tag_name}`);
+              if (deleteReleasesTags) {
+                try {
+                  await github.rest.git.deleteRef({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref: `tags/${rel.tag_name}`,
+                  });
+                  console.log(`  Tag deleted.`);
+                  deletedTagsCount++;
+                } catch (err) {
+                  console.log(`  Tag deletion failed: ${err.message}`);
+                }
+              } else {
+                console.log(`  [DRY RUN] Tag would be deleted.`);
+              }
+            }
+
+            console.log();
+            console.log(`Total releases deleted: ${deletedReleasesCount}`);
+            console.log(`Total tags deleted: ${deletedTagsCount}`);
+            core.endGroup();
+
+            await core.summary
+              .addRaw (`${prereleases.length} pre-release(s) marked for deletion:`)
+              .addCodeBlock(
+                `Total releases deleted: ${deletedReleasesCount}\n` +
+                `Total tags deleted: ${deletedTagsCount}`
+              )
+              .write();

--- a/.github/workflows/release-cleanup.yml
+++ b/.github/workflows/release-cleanup.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-slim
     
     permissions:
-      contents: write    # required to delete releases and tags
+      contents: write    # required to delete releases
     
     concurrency:
       group: cleanup-beta-releases @ ${{ github.ref_name }}
@@ -53,7 +53,7 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const deleteReleasesTags = process.env.DRY_RUN === 'false';
+            const deleteReleases = process.env.DRY_RUN === 'false';
 
             core.startGroup('Fetching all releases...');
             const releases = await github.paginate(
@@ -77,17 +77,15 @@ jobs:
             prereleases.forEach(r => console.log(`${r.published_at.split('T')[0]}: ${r.tag_name}`));
             core.endGroup();
 
-            core.startGroup('Deleting pre-releases & related tags...');
+            core.startGroup('Deleting pre-releases...');
             console.log(`${prereleases.length} pre-release(s) marked for deletion:`);
             
             let deletedReleasesCount = 0;
-            let deletedTagsCount = 0;
             
             for (const rel of [...prereleases].reverse()) {
               
-              // Delete release
               console.log(`Processing release: ${rel.name}`);
-              if (deleteReleasesTags) {
+              if (deleteReleases) {
                 try {
                   await github.rest.repos.deleteRelease({
                     owner: context.repo.owner,
@@ -102,35 +100,13 @@ jobs:
               } else {
                 console.log(`  [DRY RUN] Release would be deleted.`);
               }
-
-              // Delete tag
-              console.log(`  Processing related tag: ${rel.tag_name}`);
-              if (deleteReleasesTags) {
-                try {
-                  await github.rest.git.deleteRef({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    ref: `tags/${rel.tag_name}`,
-                  });
-                  console.log(`  Tag deleted.`);
-                  deletedTagsCount++;
-                } catch (err) {
-                  console.log(`  Tag deletion failed: ${err.message}`);
-                }
-              } else {
-                console.log(`  [DRY RUN] Tag would be deleted.`);
-              }
             }
 
             console.log();
             console.log(`Total releases deleted: ${deletedReleasesCount}`);
-            console.log(`Total tags deleted: ${deletedTagsCount}`);
             core.endGroup();
 
             await core.summary
-              .addRaw (`${prereleases.length} pre-release(s) marked for deletion:`)
-              .addCodeBlock(
-                `Total releases deleted: ${deletedReleasesCount}\n` +
-                `Total tags deleted: ${deletedTagsCount}`
-              )
+              .addRaw(`${prereleases.length} pre-release(s) marked for deletion:`)
+              .addCodeBlock(`Total releases deleted: ${deletedReleasesCount}`)
               .write();


### PR DESCRIPTION
## Short roundup of the initial problem
Beta releases and related tags need to be manually cleaned up after stable releases and pile up. 
Currently we have 52 beta pre-releases for the upcoming release published. Deletion is annoying. 

## What will change with this Pull Request?
- Automation script which does
  - Delete all published **pre-releases**
  - Stable releases are not touched
  - Draft releases of both types are filtered out
  - Double check that the git tag contains a "beta" string before marking for deletion
  - ~~Delete the corresponding git tags~~
    Looking at https://github.com/Cockatrice/Cockatrice/tags?after=2024-12-19-Development-2.10.0-beta.5, it seems we keep the tags of old pre-releases
- Only runs when
  - A new release is published (not created)
  - This release is a stable release (not a pre-release), or a pre-release got elevated to a stable release
  - Targeting `master` branch
  - Repo is not a fork
  - Manually triggered against a tag from the UI
- Runs in dry run mode per default
  - Dry run flag (`DRY_RUN`) needs to be toggled to false to do actual deletion.
    We can switch to deletion by default once we are comfortable.
  - Triggering from the UI allows to switch dry run mode off.