### PR TITLE
Do not allow users to remove VDE functionality by closing tabs

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.cpp
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.cpp
@@ -57,6 +57,8 @@ TabDeckEditorVisualTabWidget::TabDeckEditorVisualTabWidget(QWidget *parent,
     this->addNewTab(visualDatabaseDisplay, tr("Visual Database Display"));
     this->addNewTab(deckAnalytics, tr("Deck Analytics"));
     this->addNewTab(sampleHandWidget, tr("Sample Hand"));
+
+    setTabsClosable(false);
 }
 
 /**

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -140,6 +140,7 @@ void VisualDatabaseDisplayWidget::initialize()
     databaseLoadIndicator->setVisible(false);
 
     filterContainer->initialize();
+    filterContainer->setVisible(true);
 
     searchLayout->addWidget(colorFilterWidget);
     searchLayout->addWidget(clearFilterWidget);


### PR DESCRIPTION
## Short roundup of the initial problem
They shouldn't be closable in the first place.

## What will change with this Pull Request?
- setTabsClosable(false)
- also set filterToolbar visible on delayed visual database initialization due to card db not being loaded yet