### PR TITLE
CI: Ensure Docker runs + publishes images only on stable releases

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Docker metadata
+        if: ${{ github.repository_owner == 'Cockatrice' }}
         id: metadata
         uses: docker/metadata-action@v6
         with:
@@ -51,7 +52,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        if: contains(github.event.release.tag_name, 'Release')
+        if: contains(github.event.release.tag_name, 'Release') && github.event.release.target_commitish == 'master'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -3,17 +3,13 @@ name: Build Docker Image
 on:
   release:
     types:
-      - released 
+      - released    # publishing of stable releases
   pull_request:
     branches:
       - master
     paths:
       - '.github/workflows/docker-release.yml'
       - 'Dockerfile'
-
-permissions:
-  contents: read
-  packages: write
 
 # Cancel earlier, unfinished runs of this workflow on the same branch (unless on release)
 concurrency:
@@ -23,14 +19,18 @@ concurrency:
 jobs:
   docker:
     name: amd64 & arm64
+    if: ${{ github.repository_owner == 'Cockatrice' }}
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: write
+  
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Docker metadata
-        if: ${{ github.repository_owner == 'Cockatrice' }}
         id: metadata
         uses: docker/metadata-action@v6
         with:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,17 +1,19 @@
 name: Build Docker Image
 
 on:
-  push:
-    tags:
-      - '*Release*'
-    branches:
-      - master
+  release:
+    types:
+      - released 
   pull_request:
     branches:
       - master
     paths:
       - '.github/workflows/docker-release.yml'
       - 'Dockerfile'
+
+permissions:
+  contents: read
+  packages: write
 
 # Cancel earlier, unfinished runs of this workflow on the same branch (unless on release)
 concurrency:
@@ -22,9 +24,6 @@ jobs:
   docker:
     name: amd64 & arm64
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -18,7 +18,7 @@ permissions:
 # Cancel earlier, unfinished runs of this workflow on the same branch (unless on release)
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.ref_name }}"
-  cancel-in-progress: ${{ github.ref_type != 'tag' }}
+  cancel-in-progress: ${{ github.event_name != 'release' }}
 
 jobs:
   docker:
@@ -51,7 +51,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        if: github.ref_type == 'tag'
+        if: contains(github.event.release.tag_name, 'Release')
         uses: docker/login-action@v4
         with:
           registry: ghcr.io

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types:
       - released    # publishing of stable releases
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
## Short roundup of the initial problem
The docker workflow was run on all tags.
That lead to a v3 image being released two weeks back because such a tag for a stable release was already created (seems removed in the meantime again - image stayed), see https://github.com/Cockatrice/Cockatrice/pkgs/container/servatrice/806386408?tag=2026-04-19-Release-3.0.0

## What will change with this Pull Request?
- Trigger on stable release events instead all tags
- Adjust config to maintain similar behavior and checks than before