### PR TITLE
CI: Adjust annotations level for Docker metadata

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Docker metadata
         id: metadata
         uses: docker/metadata-action@v6
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index    # needed for GHCR
         with:
           images: |
             ghcr.io/cockatrice/servatrice


### PR DESCRIPTION
## Short roundup of the initial problem
Annotations are added at `manifest` level per default:
<img width="1328" height="283" alt="image" src="https://github.com/user-attachments/assets/56408a40-490e-4b36-bcfc-848c1b43d754" />

For GHCR that seems not to be correct.
https://github.com/docker/metadata-action#annotations

## What will change with this Pull Request?
- Add on `index` level instead for our multi-arch image
  <img width="1319" height="272" alt="image" src="https://github.com/user-attachments/assets/19220d05-ac72-4324-aae5-85d108eca85c" />

The data should then be displayed for our package correctly, too 🤞
<img width="1044" height="806" alt="image" src="https://github.com/user-attachments/assets/e556dd0d-e9c2-44be-a0e5-07b1f4a3c899" />