### PR TITLE
Fix Arch and Fedora 44 builds: suppress -Werror=sfinae-incomplete for GCC 16+

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -138,7 +138,6 @@ jobs:
           - distro: Fedora
             version: 44
             package: RPM
-            test: skip   # This is failing to build, currently. To be fixed.
 
           - distro: Ubuntu
             version: 22.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
       -Wno-error=delete-non-virtual-dtor
       -Wno-error=sign-compare
       -Wno-error=missing-declarations
+      -Wno-error=sfinae-incomplete  # GCC 16+: Qt MOC + protobuf forward decls trigger this
   )
 
   foreach(FLAG ${ADDITIONAL_DEBUG_FLAGS})


### PR DESCRIPTION
  Qt MOC and protobuf forward declarations trigger -Werror=sfinae-incomplete in GCC 16.
  Re-enable Fedora 44 CI build now that it compiles successfully.

## Related PR
- PR #6836 introduced a skip because builds were failing. 

## Related Issue
- #6841 

## Short roundup of the initial problem
- My other PRs were failing because of the same issue and this needs a separate PR.

## What will change with this Pull Request?
- suppress -Werror=sfinae-incomplete for GCC 16+
- Re-enable Fedora 44 CI build now that it compiles successfully.