### PR TITLE
Use Qt 6.11.0

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -281,7 +281,7 @@ jobs:
             override_target: 13
             make_package: 1
             package_suffix: "-macOS13_Intel"
-            qt_version: 6.11.*
+            qt_version: 6.10.*
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             cmake_generator: Ninja
@@ -296,7 +296,7 @@ jobs:
             type: Release
             make_package: 1
             package_suffix: "-macOS14"
-            qt_version: 6.11.*
+            qt_version: 6.10.*
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             cmake_generator: Ninja
@@ -311,7 +311,7 @@ jobs:
             type: Release
             make_package: 1
             package_suffix: "-macOS15"
-            qt_version: 6.11.*
+            qt_version: 6.10.*
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             cmake_generator: Ninja
@@ -324,7 +324,7 @@ jobs:
             soc: Apple
             xcode: "16.4"
             type: Debug
-            qt_version: 6.11.*
+            qt_version: 6.10.*
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             cmake_generator: Ninja
@@ -337,7 +337,7 @@ jobs:
             type: Release
             make_package: 1
             package_suffix: "-Win10"
-            qt_version: 6.11.*
+            qt_version: 6.10.*
             qt_arch: win64_msvc2022_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             cmake_generator: "Visual Studio 17 2022"

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -425,6 +425,8 @@ jobs:
         if: matrix.os == 'Windows'
         uses: jurplel/install-qt-action@v4
         with:
+          # qt 6.11.0 only works with aqtinstall directly from git until aqtinstall 3.4 is released
+          aqtsource: git+https://github.com/miurahr/aqtinstall.git
           version: ${{ steps.resolve_qt_version.outputs.version }}
           arch: ${{matrix.qt_arch}}
           modules: ${{matrix.qt_modules}}

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -281,7 +281,7 @@ jobs:
             override_target: 13
             make_package: 1
             package_suffix: "-macOS13_Intel"
-            qt_version: 6.10.*
+            qt_version: 6.11.0
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             cmake_generator: Ninja
@@ -296,7 +296,7 @@ jobs:
             type: Release
             make_package: 1
             package_suffix: "-macOS14"
-            qt_version: 6.10.*
+            qt_version: 6.11.0
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             cmake_generator: Ninja
@@ -311,7 +311,7 @@ jobs:
             type: Release
             make_package: 1
             package_suffix: "-macOS15"
-            qt_version: 6.10.*
+            qt_version: 6.11.0
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             cmake_generator: Ninja
@@ -324,7 +324,7 @@ jobs:
             soc: Apple
             xcode: "16.4"
             type: Debug
-            qt_version: 6.10.*
+            qt_version: 6.11.0
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             cmake_generator: Ninja
@@ -337,7 +337,7 @@ jobs:
             type: Release
             make_package: 1
             package_suffix: "-Win10"
-            qt_version: 6.10.*
+            qt_version: 6.11.0
             qt_arch: win64_msvc2022_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             cmake_generator: "Visual Studio 17 2022"

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -425,8 +425,6 @@ jobs:
         if: matrix.os == 'Windows'
         uses: jurplel/install-qt-action@v4
         with:
-          # qt 6.11.0 only works with aqtinstall directly from git until aqtinstall 3.4 is released
-          aqtsource: git+https://github.com/miurahr/aqtinstall.git
           version: ${{ steps.resolve_qt_version.outputs.version }}
           arch: ${{matrix.qt_arch}}
           modules: ${{matrix.qt_modules}}


### PR DESCRIPTION
## Short roundup of the initial problem
Upgrading Qt to 6.11.* in #6794 introduced some issues due to the recency of the Qt release, related to the aqtinstall tool not being able to verify the checksum. The proper fix would be to adjust the aqtinstall mirror sources or whatever to make the official mirrors more trustworthy or something but honestly, no one can be bothered to figure this out, we don't gain much from a .1 minor version bump and we wanna release.

## What will change with this Pull Request?
- Roll back runners to Qt 6.10.* instead of Qt 6.11.*
