### PR TITLE
Bump minimum required cmake to 3.10 in gtest

### DIFF
--- a/cmake/gtest-CMakeLists.txt.in
+++ b/cmake/gtest-CMakeLists.txt.in
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(gtest-download LANGUAGES NONE)
 
 include(ExternalProject)
 ExternalProject_Add(googletest
-  URL https://github.com/google/googletest/archive/release-1.11.0.zip
+  URL https://github.com/google/googletest/archive/release-1.12.0.zip
   URL_HASH SHA1=9ffb7b5923f4a8fcdabf2f42c6540cce299f44c0
   SOURCE_DIR "${CMAKE_BINARY_DIR}/gtest-src"
   BINARY_DIR "${CMAKE_BINARY_DIR}/gtest-build"

--- a/cmake/gtest-CMakeLists.txt.in
+++ b/cmake/gtest-CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(gtest-download LANGUAGES NONE)
 include(ExternalProject)
 ExternalProject_Add(
   googletest
-  URL https://github.com/google/googletest/archive/release-1.12.0.zip
+  URL https://github.com/google/googletest/archive/refs/tags/v1.17.0.zip
   URL_HASH SHA1=9ffb7b5923f4a8fcdabf2f42c6540cce299f44c0
   SOURCE_DIR "${CMAKE_BINARY_DIR}/gtest-src"
   BINARY_DIR "${CMAKE_BINARY_DIR}/gtest-build"

--- a/cmake/gtest-CMakeLists.txt.in
+++ b/cmake/gtest-CMakeLists.txt.in
@@ -3,13 +3,14 @@ cmake_minimum_required(VERSION 3.5)
 project(gtest-download LANGUAGES NONE)
 
 include(ExternalProject)
-ExternalProject_Add(googletest
+ExternalProject_Add(
+  googletest
   URL https://github.com/google/googletest/archive/release-1.12.0.zip
   URL_HASH SHA1=9ffb7b5923f4a8fcdabf2f42c6540cce299f44c0
   SOURCE_DIR "${CMAKE_BINARY_DIR}/gtest-src"
   BINARY_DIR "${CMAKE_BINARY_DIR}/gtest-build"
   CONFIGURE_COMMAND ""
-  BUILD_COMMAND     ""
-  INSTALL_COMMAND   ""
-  TEST_COMMAND      ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  TEST_COMMAND ""
 )

--- a/cmake/gtest-CMakeLists.txt.in
+++ b/cmake/gtest-CMakeLists.txt.in
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 project(gtest-download LANGUAGES NONE)
 
 include(ExternalProject)
-ExternalProject_Add(
+externalproject_add(
   googletest
   URL https://github.com/google/googletest/archive/refs/tags/v1.17.0.zip
   URL_HASH SHA1=f638fa0e724760e2ba07ff8cfba32cd644e1ce28

--- a/cmake/gtest-CMakeLists.txt.in
+++ b/cmake/gtest-CMakeLists.txt.in
@@ -6,7 +6,7 @@ include(ExternalProject)
 ExternalProject_Add(
   googletest
   URL https://github.com/google/googletest/archive/refs/tags/v1.17.0.zip
-  URL_HASH SHA1=9ffb7b5923f4a8fcdabf2f42c6540cce299f44c0
+  URL_HASH SHA1=f638fa0e724760e2ba07ff8cfba32cd644e1ce28
   SOURCE_DIR "${CMAKE_BINARY_DIR}/gtest-src"
   BINARY_DIR "${CMAKE_BINARY_DIR}/gtest-build"
   CONFIGURE_COMMAND ""

--- a/cmake/gtest-CMakeLists.txt.in
+++ b/cmake/gtest-CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(gtest-download LANGUAGES NONE)
 


### PR DESCRIPTION
## Related Ticket(s)
Fixes compile from source issue described in https://github.com/Cockatrice/Cockatrice/issues/6841#issuecomment-4355906889

## Short roundup of the initial problem
In CMake 4.0, [compatibility with cmake < 3.5 was removed](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required) and `cmake_minimum_required()` was changed to throw an error if set to a version < 3.5. 

Ubuntu 26.04, Fedora 44, and Arch all use CMake >= 4.0, causing compiling debug builds from source to fail as `cmake/gtest-CMakeLists.txt.in` sets the minimum to 3.2 and the version of GoogleTest that we download (1.11.0) sets the minimum to 2.8.x in its own CMakeLists files (anything that gets added to `build/gtest-src`).

(For whatever reason, this does not affect our Docker builds; I've only encountered it when compiling on my personal computer or in a VM)

## What will change with this Pull Request?
- Set `cmake_minimum_required()` to 3.10 in `cmake/gtest-CMakeLists.txt.in`
- Change downloaded GoogleTest to the latest version (1.17.0)

## Questions
~- Is there a particular reason we are using 1.11.0 that would make this a bad move?~
~- Are they any reasons for or against bumping GoogleTests up to the latest release (1.17.0) instead?~
