### PR TITLE
bump vcpkg to 2026.04.27 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     # Look for `.gitmodules` in the `root` directory
     directory: "/"
     ignore:
-      # Ignore updates for vcpkg (Bump to latest tag not working (no SemVer used) & macOS Intel triplet broken with newer releases)
+      # Ignore updates for vcpkg (Bump to latest tag not working (no SemVer used)
       - dependency-name: "vcpkg"
     # Check for updates once a month
     schedule:


### PR DESCRIPTION
With https://github.com/Cockatrice/Cockatrice/commit/63143f941643dc2f46f658cb51ea3b5727da3e56, this is now possible.

See comments in https://github.com/Cockatrice/Cockatrice/pull/6627

