### PR TITLE
[GameModel] Refactor game filters options into struct

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -216,6 +216,7 @@ set(cockatrice_SOURCES
     src/interface/widgets/replay/replay_manager.cpp
     src/interface/widgets/replay/replay_timeline_widget.cpp
     src/interface/widgets/server/chat_view/chat_view.cpp
+    src/interface/widgets/server/game_filter_configs.cpp
     src/interface/widgets/server/game_selector.cpp
     src/interface/widgets/server/game_selector_quick_filter_toolbar.cpp
     src/interface/widgets/server/games_model.cpp

--- a/cockatrice/src/interface/widgets/dialogs/dlg_filter_games.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_filter_games.cpp
@@ -22,41 +22,43 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
                   {QTime(1, 0), tr("1 hour")},
                   {QTime(2, 0), tr("2 hours")}})
 {
+    const GameFilterConfigs &filters = gamesProxyModel->getFilters();
+
     hideBuddiesOnlyGames = new QCheckBox(tr("Hide 'buddies only' games"));
-    hideBuddiesOnlyGames->setChecked(gamesProxyModel->getHideBuddiesOnlyGames());
+    hideBuddiesOnlyGames->setChecked(filters.hideBuddiesOnlyGames);
 
     hideFullGames = new QCheckBox(tr("Hide full games"));
-    hideFullGames->setChecked(gamesProxyModel->getHideFullGames());
+    hideFullGames->setChecked(filters.hideFullGames);
 
     hideGamesThatStarted = new QCheckBox(tr("Hide games that have started"));
-    hideGamesThatStarted->setChecked(gamesProxyModel->getHideGamesThatStarted());
+    hideGamesThatStarted->setChecked(filters.hideGamesThatStarted);
 
     hidePasswordProtectedGames = new QCheckBox(tr("Hide password protected games"));
-    hidePasswordProtectedGames->setChecked(gamesProxyModel->getHidePasswordProtectedGames());
+    hidePasswordProtectedGames->setChecked(filters.hidePasswordProtectedGames);
 
     hideIgnoredUserGames = new QCheckBox(tr("Hide 'ignored user' games"));
-    hideIgnoredUserGames->setChecked(gamesProxyModel->getHideIgnoredUserGames());
+    hideIgnoredUserGames->setChecked(filters.hideIgnoredUserGames);
 
     hideNotBuddyCreatedGames = new QCheckBox(tr("Hide games not created by buddies"));
-    hideNotBuddyCreatedGames->setChecked(gamesProxyModel->getHideNotBuddyCreatedGames());
+    hideNotBuddyCreatedGames->setChecked(filters.hideNotBuddyCreatedGames);
 
     hideOpenDecklistGames = new QCheckBox(tr("Hide games with forced open decklists"));
-    hideOpenDecklistGames->setChecked(gamesProxyModel->getHideOpenDecklistGames());
+    hideOpenDecklistGames->setChecked(filters.hideOpenDecklistGames);
 
     maxGameAgeComboBox = new QComboBox();
     maxGameAgeComboBox->setEditable(false);
     maxGameAgeComboBox->addItems(gameAgeMap.values());
-    QTime gameAge = gamesProxyModel->getMaxGameAge();
+    QTime gameAge = filters.maxGameAge;
     maxGameAgeComboBox->setCurrentIndex(gameAgeMap.keys().indexOf(gameAge)); // index is -1 if unknown
     auto *maxGameAgeLabel = new QLabel(tr("&Newer than:"));
     maxGameAgeLabel->setBuddy(maxGameAgeComboBox);
 
     gameNameFilterEdit = new QLineEdit;
-    gameNameFilterEdit->setText(gamesProxyModel->getGameNameFilter());
+    gameNameFilterEdit->setText(filters.gameNameFilter);
     auto *gameNameFilterLabel = new QLabel(tr("Game &description:"));
     gameNameFilterLabel->setBuddy(gameNameFilterEdit);
     creatorNameFilterEdit = new QLineEdit;
-    creatorNameFilterEdit->setText(gamesProxyModel->getCreatorNameFilters().join(", "));
+    creatorNameFilterEdit->setText(filters.creatorNameFilters.join(", "));
     auto *creatorNameFilterLabel = new QLabel(tr("&Creator name:"));
     creatorNameFilterLabel->setBuddy(creatorNameFilterEdit);
 
@@ -76,7 +78,7 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
         gameTypesIterator.next();
 
         auto *temp = new QCheckBox(gameTypesIterator.value());
-        temp->setChecked(gamesProxyModel->getGameTypeFilter().contains(gameTypesIterator.key()));
+        temp->setChecked(filters.gameTypeFilter.contains(gameTypesIterator.key()));
 
         gameTypeFilterCheckBoxes.insert(gameTypesIterator.key(), temp);
         gameTypeFilterLayout->addWidget(temp);
@@ -92,14 +94,14 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     maxPlayersFilterMinSpinBox = new QSpinBox;
     maxPlayersFilterMinSpinBox->setMinimum(0);
     maxPlayersFilterMinSpinBox->setMaximum(99);
-    maxPlayersFilterMinSpinBox->setValue(gamesProxyModel->getMaxPlayersFilterMin());
+    maxPlayersFilterMinSpinBox->setValue(filters.maxPlayersFilterMin);
     maxPlayersFilterMinLabel->setBuddy(maxPlayersFilterMinSpinBox);
 
     auto *maxPlayersFilterMaxLabel = new QLabel(tr("at &most:"));
     maxPlayersFilterMaxSpinBox = new QSpinBox;
     maxPlayersFilterMaxSpinBox->setMinimum(0);
     maxPlayersFilterMaxSpinBox->setMaximum(99);
-    maxPlayersFilterMaxSpinBox->setValue(gamesProxyModel->getMaxPlayersFilterMax());
+    maxPlayersFilterMaxSpinBox->setValue(filters.maxPlayersFilterMax);
     maxPlayersFilterMaxLabel->setBuddy(maxPlayersFilterMaxSpinBox);
 
     auto *maxPlayersFilterLayout = new QGridLayout;
@@ -124,17 +126,17 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     restrictionsGroupBox->setLayout(restrictionsLayout);
 
     showOnlyIfSpectatorsCanWatch = new QCheckBox(tr("Show games only if &spectators can watch"));
-    showOnlyIfSpectatorsCanWatch->setChecked(gamesProxyModel->getShowOnlyIfSpectatorsCanWatch());
+    showOnlyIfSpectatorsCanWatch->setChecked(filters.showOnlyIfSpectatorsCanWatch);
     connect(showOnlyIfSpectatorsCanWatch, &QCheckBox::toggled, this,
             &DlgFilterGames::toggleSpectatorCheckboxEnabledness);
 
     showSpectatorPasswordProtected = new QCheckBox(tr("Show spectator password p&rotected games"));
-    showSpectatorPasswordProtected->setChecked(gamesProxyModel->getShowSpectatorPasswordProtected());
+    showSpectatorPasswordProtected->setChecked(filters.showSpectatorPasswordProtected);
     showOnlyIfSpectatorsCanChat = new QCheckBox(tr("Show only if spectators can ch&at"));
-    showOnlyIfSpectatorsCanChat->setChecked(gamesProxyModel->getShowOnlyIfSpectatorsCanChat());
+    showOnlyIfSpectatorsCanChat->setChecked(filters.showOnlyIfSpectatorsCanChat);
     showOnlyIfSpectatorsCanSeeHands = new QCheckBox(tr("Show only if spectators can see &hands"));
-    showOnlyIfSpectatorsCanSeeHands->setChecked(gamesProxyModel->getShowOnlyIfSpectatorsCanSeeHands());
-    toggleSpectatorCheckboxEnabledness(getShowOnlyIfSpectatorsCanWatch());
+    showOnlyIfSpectatorsCanSeeHands->setChecked(filters.showOnlyIfSpectatorsCanSeeHands);
+    toggleSpectatorCheckboxEnabledness(filters.showOnlyIfSpectatorsCanWatch);
 
     auto *spectatorsLayout = new QGridLayout;
     spectatorsLayout->addWidget(showOnlyIfSpectatorsCanWatch, 0, 0);
@@ -180,6 +182,27 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     setFixedHeight(sizeHint().height());
 }
 
+GameFilterConfigs DlgFilterGames::getFilters() const
+{
+    return {hideBuddiesOnlyGames->isChecked(),
+            hideIgnoredUserGames->isChecked(),
+            hideFullGames->isChecked(),
+            hideGamesThatStarted->isChecked(),
+            hidePasswordProtectedGames->isChecked(),
+            hideNotBuddyCreatedGames->isChecked(),
+            hideOpenDecklistGames->isChecked(),
+            gameNameFilterEdit->text(),
+            getCreatorNameFilters(),
+            getGameTypeFilter(),
+            maxPlayersFilterMinSpinBox->value(),
+            maxPlayersFilterMaxSpinBox->value(),
+            getMaxGameAge(),
+            showOnlyIfSpectatorsCanWatch->isChecked(),
+            getShowSpectatorPasswordProtected(),
+            getShowOnlyIfSpectatorsCanChat(),
+            getShowOnlyIfSpectatorsCanSeeHands()};
+}
+
 void DlgFilterGames::actOk()
 {
     accept();
@@ -190,46 +213,6 @@ void DlgFilterGames::toggleSpectatorCheckboxEnabledness(bool spectatorsEnabled)
     showSpectatorPasswordProtected->setDisabled(!spectatorsEnabled);
     showOnlyIfSpectatorsCanChat->setDisabled(!spectatorsEnabled);
     showOnlyIfSpectatorsCanSeeHands->setDisabled(!spectatorsEnabled);
-}
-
-bool DlgFilterGames::getHideFullGames() const
-{
-    return hideFullGames->isChecked();
-}
-
-bool DlgFilterGames::getHideGamesThatStarted() const
-{
-    return hideGamesThatStarted->isChecked();
-}
-
-bool DlgFilterGames::getHideBuddiesOnlyGames() const
-{
-    return hideBuddiesOnlyGames->isChecked();
-}
-
-bool DlgFilterGames::getHidePasswordProtectedGames() const
-{
-    return hidePasswordProtectedGames->isChecked();
-}
-
-bool DlgFilterGames::getHideIgnoredUserGames() const
-{
-    return hideIgnoredUserGames->isChecked();
-}
-
-bool DlgFilterGames::getHideNotBuddyCreatedGames() const
-{
-    return hideNotBuddyCreatedGames->isChecked();
-}
-
-bool DlgFilterGames::getHideOpenDecklistGames() const
-{
-    return hideOpenDecklistGames->isChecked();
-}
-
-QString DlgFilterGames::getGameNameFilter() const
-{
-    return gameNameFilterEdit->text();
 }
 
 QStringList DlgFilterGames::getCreatorNameFilters() const
@@ -249,28 +232,13 @@ QSet<int> DlgFilterGames::getGameTypeFilter() const
     return result;
 }
 
-int DlgFilterGames::getMaxPlayersFilterMin() const
-{
-    return maxPlayersFilterMinSpinBox->value();
-}
-
-int DlgFilterGames::getMaxPlayersFilterMax() const
-{
-    return maxPlayersFilterMaxSpinBox->value();
-}
-
 QTime DlgFilterGames::getMaxGameAge() const
 {
     int index = maxGameAgeComboBox->currentIndex();
-    if (index < 0 || index >= gameAgeMap.size()) { // index is out of bounds
-        return gamesProxyModel->getMaxGameAge();   // leave the setting unchanged
+    if (index < 0 || index >= gameAgeMap.size()) {       // index is out of bounds
+        return gamesProxyModel->getFilters().maxGameAge; // leave the setting unchanged
     }
     return gameAgeMap.keys().at(index);
-}
-
-bool DlgFilterGames::getShowOnlyIfSpectatorsCanWatch() const
-{
-    return showOnlyIfSpectatorsCanWatch->isChecked();
 }
 
 bool DlgFilterGames::getShowSpectatorPasswordProtected() const

--- a/cockatrice/src/interface/widgets/dialogs/dlg_filter_games.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_filter_games.h
@@ -48,6 +48,14 @@ private:
 
     const QMap<int, QString> &allGameTypes;
     const GamesProxyModel *gamesProxyModel;
+    const QMap<QTime, QString> gameAgeMap;
+
+    [[nodiscard]] QStringList getCreatorNameFilters() const;
+    [[nodiscard]] QSet<int> getGameTypeFilter() const;
+    [[nodiscard]] QTime getMaxGameAge() const;
+    [[nodiscard]] bool getShowSpectatorPasswordProtected() const;
+    [[nodiscard]] bool getShowOnlyIfSpectatorsCanChat() const;
+    [[nodiscard]] bool getShowOnlyIfSpectatorsCanSeeHands() const;
 
 private slots:
     void actOk();
@@ -58,32 +66,7 @@ public:
                    const GamesProxyModel *_gamesProxyModel,
                    QWidget *parent = nullptr);
 
-    [[nodiscard]] bool getHideFullGames() const;
-    [[nodiscard]] bool getHideGamesThatStarted() const;
-    [[nodiscard]] bool getHidePasswordProtectedGames() const;
-    void setShowPasswordProtectedGames(bool _passwordProtectedGamesHidden);
-    [[nodiscard]] bool getHideBuddiesOnlyGames() const;
-    void setHideBuddiesOnlyGames(bool _hideBuddiesOnlyGames);
-    [[nodiscard]] bool getHideOpenDecklistGames() const;
-    void setHideOpenDecklistGames(bool _hideOpenDecklistGames);
-    [[nodiscard]] bool getHideIgnoredUserGames() const;
-    void setHideIgnoredUserGames(bool _hideIgnoredUserGames);
-    [[nodiscard]] bool getHideNotBuddyCreatedGames() const;
-    [[nodiscard]] QString getGameNameFilter() const;
-    void setGameNameFilter(const QString &_gameNameFilter);
-    [[nodiscard]] QStringList getCreatorNameFilters() const;
-    void setCreatorNameFilter(const QString &_creatorNameFilter);
-    [[nodiscard]] QSet<int> getGameTypeFilter() const;
-    void setGameTypeFilter(const QSet<int> &_gameTypeFilter);
-    [[nodiscard]] int getMaxPlayersFilterMin() const;
-    [[nodiscard]] int getMaxPlayersFilterMax() const;
-    void setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlayersFilterMax);
-    [[nodiscard]] QTime getMaxGameAge() const;
-    const QMap<QTime, QString> gameAgeMap;
-    [[nodiscard]] bool getShowOnlyIfSpectatorsCanWatch() const;
-    [[nodiscard]] bool getShowSpectatorPasswordProtected() const;
-    [[nodiscard]] bool getShowOnlyIfSpectatorsCanChat() const;
-    [[nodiscard]] bool getShowOnlyIfSpectatorsCanSeeHands() const;
+    [[nodiscard]] GameFilterConfigs getFilters() const;
 };
 
 #endif

--- a/cockatrice/src/interface/widgets/server/game_filter_configs.cpp
+++ b/cockatrice/src/interface/widgets/server/game_filter_configs.cpp
@@ -1,0 +1,7 @@
+#include "game_filter_configs.h"
+
+bool GameFilterConfigs::isDefault() const
+{
+    static const GameFilterConfigs DEFAULT = {};
+    return *this == DEFAULT;
+}

--- a/cockatrice/src/interface/widgets/server/game_filter_configs.h
+++ b/cockatrice/src/interface/widgets/server/game_filter_configs.h
@@ -1,0 +1,42 @@
+#ifndef COCKATRICE_GAME_FILTER_CONFIGS_H
+#define COCKATRICE_GAME_FILTER_CONFIGS_H
+
+#include <QTime>
+
+/**
+ * @brief The possible game filter configs.
+ */
+struct GameFilterConfigs
+{
+    static constexpr int DEFAULT_MAX_PLAYERS_MIN = 1;
+    static constexpr int DEFAULT_MAX_PLAYERS_MAX = 99;
+
+    bool hideBuddiesOnlyGames = false;
+    bool hideIgnoredUserGames = false;
+    bool hideFullGames = false;
+    bool hideGamesThatStarted = false;
+    bool hidePasswordProtectedGames = false;
+    bool hideNotBuddyCreatedGames = false;
+    bool hideOpenDecklistGames = false;
+    QString gameNameFilter = "";
+    QStringList creatorNameFilters = {};
+    QSet<int> gameTypeFilter = {};
+    int maxPlayersFilterMin = DEFAULT_MAX_PLAYERS_MIN;
+    int maxPlayersFilterMax = DEFAULT_MAX_PLAYERS_MAX;
+    QTime maxGameAge = {};
+    bool showOnlyIfSpectatorsCanWatch = false;
+    bool showSpectatorPasswordProtected = false;
+    bool showOnlyIfSpectatorsCanChat = false;
+    bool showOnlyIfSpectatorsCanSeeHands = false;
+
+    bool operator==(const GameFilterConfigs &) const = default;
+
+    /**
+     * @brief Checks if this config has exactly the default values.
+     *
+     * @return Whether this config has the default values
+     */
+    bool isDefault() const;
+};
+
+#endif // COCKATRICE_GAME_FILTER_CONFIGS_H

--- a/cockatrice/src/interface/widgets/server/game_selector.cpp
+++ b/cockatrice/src/interface/widgets/server/game_selector.cpp
@@ -180,13 +180,7 @@ void GameSelector::actSetFilter()
     if (!dlg.exec())
         return;
 
-    gameListProxyModel->setGameFilters(
-        dlg.getHideBuddiesOnlyGames(), dlg.getHideIgnoredUserGames(), dlg.getHideFullGames(),
-        dlg.getHideGamesThatStarted(), dlg.getHidePasswordProtectedGames(), dlg.getHideNotBuddyCreatedGames(),
-        dlg.getHideOpenDecklistGames(), dlg.getGameNameFilter(), dlg.getCreatorNameFilters(), dlg.getGameTypeFilter(),
-        dlg.getMaxPlayersFilterMin(), dlg.getMaxPlayersFilterMax(), dlg.getMaxGameAge(),
-        dlg.getShowOnlyIfSpectatorsCanWatch(), dlg.getShowSpectatorPasswordProtected(),
-        dlg.getShowOnlyIfSpectatorsCanChat(), dlg.getShowOnlyIfSpectatorsCanSeeHands());
+    gameListProxyModel->setGameFilters(dlg.getFilters());
     gameListProxyModel->saveFilterParameters(gameTypeMap);
 
     updateTitle();

--- a/cockatrice/src/interface/widgets/server/game_selector_quick_filter_toolbar.cpp
+++ b/cockatrice/src/interface/widgets/server/game_selector_quick_filter_toolbar.cpp
@@ -18,46 +18,42 @@ GameSelectorQuickFilterToolBar::GameSelectorQuickFilterToolBar(QWidget *parent,
     mainLayout->setContentsMargins(0, 0, 0, 0);
     mainLayout->setSpacing(5);
 
+    const GameFilterConfigs &filters = model->getFilters();
+
     searchBar = new QLineEdit(this);
-    searchBar->setText(model->getGameNameFilter());
+    searchBar->setText(filters.gameNameFilter);
     connect(searchBar, &QLineEdit::textChanged, this, [this](const QString &text) {
-        applyFilters([&](auto &, auto &, auto &, auto &, auto &, auto &, auto &, QString &gameNameFilter, auto &,
-                         auto &, auto &, auto &, auto &, auto &, auto &, auto &, auto &) { gameNameFilter = text; });
+        applyFilters([&](GameFilterConfigs &configs) { configs.gameNameFilter = text; });
     });
 
     hideGamesNotCreatedByBuddiesCheckBox = new QCheckBox(this);
-    hideGamesNotCreatedByBuddiesCheckBox->setChecked(model->getHideNotBuddyCreatedGames());
+    hideGamesNotCreatedByBuddiesCheckBox->setChecked(filters.hideNotBuddyCreatedGames);
     connect(hideGamesNotCreatedByBuddiesCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
-        applyFilters([&](auto &, auto &, auto &, auto &, auto &, bool &hideNotBuddyCreatedGames, auto &, auto &,
-                         QStringList &creatorNameFilters, auto &, auto &, auto &, auto &, auto &, auto &, auto &,
-                         auto &) {
-            hideNotBuddyCreatedGames = checked;
+        applyFilters([&](GameFilterConfigs &configs) {
+            configs.hideNotBuddyCreatedGames = checked;
 
             if (checked) {
                 QStringList buddyNames;
                 for (auto buddy : tabSupervisor->getUserListManager()->getBuddyList().values()) {
                     buddyNames << QString::fromStdString(buddy.name());
                 }
-                creatorNameFilters = buddyNames;
+                configs.creatorNameFilters = buddyNames;
             } else {
-                creatorNameFilters.clear();
+                configs.creatorNameFilters.clear();
             }
         });
     });
 
     hideFullGamesCheckBox = new QCheckBox(this);
-    hideFullGamesCheckBox->setChecked(model->getHideFullGames());
+    hideFullGamesCheckBox->setChecked(filters.hideFullGames);
     connect(hideFullGamesCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
-        applyFilters([&](auto &, auto &, bool &hideFullGames, auto &, auto &, auto &, auto &, auto &, auto &, auto &,
-                         auto &, auto &, auto &, auto &, auto &, auto &, auto &) { hideFullGames = checked; });
+        applyFilters([&](GameFilterConfigs &configs) { configs.hideFullGames = checked; });
     });
 
     hideStartedGamesCheckBox = new QCheckBox(this);
-    hideStartedGamesCheckBox->setChecked(model->getHideGamesThatStarted());
+    hideStartedGamesCheckBox->setChecked(filters.hideGamesThatStarted);
     connect(hideStartedGamesCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
-        applyFilters([&](auto &, auto &, auto &, bool &hideGamesThatStarted, auto &, auto &, auto &, auto &, auto &,
-                         auto &, auto &, auto &, auto &, auto &, auto &, auto &,
-                         auto &) { hideGamesThatStarted = checked; });
+        applyFilters([&](GameFilterConfigs &configs) { configs.hideGamesThatStarted = checked; });
     });
 
     filterToFormatComboBox = new QComboBox(this);
@@ -71,7 +67,7 @@ GameSelectorQuickFilterToolBar::GameSelectorQuickFilterToolBar(QWidget *parent,
         filterToFormatComboBox->addItem(i.value(), i.key()); // text = name, data = type ID
     }
 
-    QSet<int> currentTypes = model->getGameTypeFilter();
+    QSet<int> currentTypes = filters.gameTypeFilter;
     if (currentTypes.size() == 1) {
         int typeId = *currentTypes.begin();
         int index = filterToFormatComboBox->findData(typeId);
@@ -83,13 +79,12 @@ GameSelectorQuickFilterToolBar::GameSelectorQuickFilterToolBar(QWidget *parent,
 
     // Update proxy model on selection change
     connect(filterToFormatComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int index) {
-        applyFilters([&](auto &, auto &, auto &, auto &, auto &, auto &, auto &, auto &, auto &,
-                         QSet<int> &gameTypeFilter, auto &, auto &, auto &, auto &, auto &, auto &, auto &) {
+        applyFilters([&](GameFilterConfigs &configs) {
             QVariant data = filterToFormatComboBox->itemData(index);
             if (!data.isValid()) {
-                gameTypeFilter.clear();
+                configs.gameTypeFilter.clear();
             } else {
-                gameTypeFilter = {data.toInt()};
+                configs.gameTypeFilter = {data.toInt()};
             }
         });
     });
@@ -127,13 +122,15 @@ void GameSelectorQuickFilterToolBar::syncFromModel()
     QSignalBlocker b4(hideFullGamesCheckBox);
     QSignalBlocker b5(hideStartedGamesCheckBox);
 
-    searchBar->setText(model->getGameNameFilter());
+    const GameFilterConfigs filters = model->getFilters();
 
-    hideGamesNotCreatedByBuddiesCheckBox->setChecked(model->getHideNotBuddyCreatedGames());
-    hideFullGamesCheckBox->setChecked(model->getHideFullGames());
-    hideStartedGamesCheckBox->setChecked(model->getHideGamesThatStarted());
+    searchBar->setText(filters.gameNameFilter);
 
-    QSet<int> types = model->getGameTypeFilter();
+    hideGamesNotCreatedByBuddiesCheckBox->setChecked(filters.hideNotBuddyCreatedGames);
+    hideFullGamesCheckBox->setChecked(filters.hideFullGames);
+    hideStartedGamesCheckBox->setChecked(filters.hideGamesThatStarted);
+
+    QSet<int> types = filters.gameTypeFilter;
     if (types.size() == 1) {
         int idx = filterToFormatComboBox->findData(*types.begin());
         filterToFormatComboBox->setCurrentIndex(idx >= 0 ? idx : 0);
@@ -142,55 +139,13 @@ void GameSelectorQuickFilterToolBar::syncFromModel()
     }
 }
 
-void GameSelectorQuickFilterToolBar::applyFilters(std::function<void(bool &,
-                                                                     bool &,
-                                                                     bool &,
-                                                                     bool &,
-                                                                     bool &,
-                                                                     bool &,
-                                                                     bool &,
-                                                                     QString &,
-                                                                     QStringList &,
-                                                                     QSet<int> &,
-                                                                     int &,
-                                                                     int &,
-                                                                     QTime &,
-                                                                     bool &,
-                                                                     bool &,
-                                                                     bool &,
-                                                                     bool &)> mutator)
+void GameSelectorQuickFilterToolBar::applyFilters(std::function<void(GameFilterConfigs &)> mutator)
 {
-    bool hideBuddiesOnlyGames = model->getHideBuddiesOnlyGames();
-    bool hideIgnoredUserGames = model->getHideIgnoredUserGames();
-    bool hideFullGames = model->getHideFullGames();
-    bool hideGamesThatStarted = model->getHideGamesThatStarted();
-    bool hidePasswordProtectedGames = model->getHidePasswordProtectedGames();
-    bool hideNotBuddyCreatedGames = model->getHideNotBuddyCreatedGames();
-    bool hideOpenDecklistGames = model->getHideOpenDecklistGames();
+    GameFilterConfigs configs = model->getFilters();
 
-    QString gameNameFilter = model->getGameNameFilter();
-    QStringList creatorNameFilters = model->getCreatorNameFilters();
-    QSet<int> gameTypeFilter = model->getGameTypeFilter();
+    mutator(configs);
 
-    int minPlayers = model->getMaxPlayersFilterMin();
-    int maxPlayers = model->getMaxPlayersFilterMax();
-    QTime maxGameAge = model->getMaxGameAge();
-
-    bool showOnlyIfSpectatorsCanWatch = model->getShowOnlyIfSpectatorsCanWatch();
-    bool showSpectatorPasswordProtected = model->getShowSpectatorPasswordProtected();
-    bool showOnlyIfSpectatorsCanChat = model->getShowOnlyIfSpectatorsCanChat();
-    bool showOnlyIfSpectatorsCanSeeHands = model->getShowOnlyIfSpectatorsCanSeeHands();
-
-    mutator(hideBuddiesOnlyGames, hideIgnoredUserGames, hideFullGames, hideGamesThatStarted, hidePasswordProtectedGames,
-            hideNotBuddyCreatedGames, hideOpenDecklistGames, gameNameFilter, creatorNameFilters, gameTypeFilter,
-            minPlayers, maxPlayers, maxGameAge, showOnlyIfSpectatorsCanWatch, showSpectatorPasswordProtected,
-            showOnlyIfSpectatorsCanChat, showOnlyIfSpectatorsCanSeeHands);
-
-    model->setGameFilters(hideBuddiesOnlyGames, hideIgnoredUserGames, hideFullGames, hideGamesThatStarted,
-                          hidePasswordProtectedGames, hideNotBuddyCreatedGames, hideOpenDecklistGames, gameNameFilter,
-                          creatorNameFilters, gameTypeFilter, minPlayers, maxPlayers, maxGameAge,
-                          showOnlyIfSpectatorsCanWatch, showSpectatorPasswordProtected, showOnlyIfSpectatorsCanChat,
-                          showOnlyIfSpectatorsCanSeeHands);
+    model->setGameFilters(configs);
 }
 
 void GameSelectorQuickFilterToolBar::retranslateUi()

--- a/cockatrice/src/interface/widgets/server/game_selector_quick_filter_toolbar.h
+++ b/cockatrice/src/interface/widgets/server/game_selector_quick_filter_toolbar.h
@@ -19,23 +19,7 @@ public:
                                             GamesProxyModel *model,
                                             const QMap<int, QString> &allGameTypes);
     void syncFromModel();
-    void applyFilters(std::function<void(bool &,
-                                         bool &,
-                                         bool &,
-                                         bool &,
-                                         bool &,
-                                         bool &,
-                                         bool &,
-                                         QString &,
-                                         QStringList &,
-                                         QSet<int> &,
-                                         int &,
-                                         int &,
-                                         QTime &,
-                                         bool &,
-                                         bool &,
-                                         bool &,
-                                         bool &)> mutator);
+    void applyFilters(std::function<void(GameFilterConfigs &)> mutator);
     void retranslateUi();
 
 private:

--- a/cockatrice/src/interface/widgets/server/games_model.cpp
+++ b/cockatrice/src/interface/widgets/server/games_model.cpp
@@ -23,10 +23,6 @@ enum GameListColumn
     SPECTATORS
 };
 
-const int DEFAULT_MAX_PLAYERS_MIN = 1;
-const int DEFAULT_MAX_PLAYERS_MAX = 99;
-constexpr auto DEFAULT_MAX_GAME_AGE = QTime();
-
 const QString GamesModel::getGameCreatedString(const int secs)
 {
     static const QTime zeroTime{0, 0};
@@ -283,44 +279,12 @@ GamesProxyModel::GamesProxyModel(QObject *parent, const UserListProxy *_userList
     setDynamicSortFilter(true);
 }
 
-void GamesProxyModel::setGameFilters(bool _hideBuddiesOnlyGames,
-                                     bool _hideIgnoredUserGames,
-                                     bool _hideFullGames,
-                                     bool _hideGamesThatStarted,
-                                     bool _hidePasswordProtectedGames,
-                                     bool _hideNotBuddyCreatedGames,
-                                     bool _hideOpenDecklistGames,
-                                     const QString &_gameNameFilter,
-                                     const QStringList &_creatorNameFilters,
-                                     const QSet<int> &_gameTypeFilter,
-                                     int _maxPlayersFilterMin,
-                                     int _maxPlayersFilterMax,
-                                     const QTime &_maxGameAge,
-                                     bool _showOnlyIfSpectatorsCanWatch,
-                                     bool _showSpectatorPasswordProtected,
-                                     bool _showOnlyIfSpectatorsCanChat,
-                                     bool _showOnlyIfSpectatorsCanSeeHands)
+void GamesProxyModel::setGameFilters(const GameFilterConfigs &_filters)
 {
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 9, 0))
     beginFilterChange();
 #endif
-    hideBuddiesOnlyGames = _hideBuddiesOnlyGames;
-    hideIgnoredUserGames = _hideIgnoredUserGames;
-    hideFullGames = _hideFullGames;
-    hideGamesThatStarted = _hideGamesThatStarted;
-    hidePasswordProtectedGames = _hidePasswordProtectedGames;
-    hideNotBuddyCreatedGames = _hideNotBuddyCreatedGames;
-    hideOpenDecklistGames = _hideOpenDecklistGames;
-    gameNameFilter = _gameNameFilter;
-    creatorNameFilters = _creatorNameFilters;
-    gameTypeFilter = _gameTypeFilter;
-    maxPlayersFilterMin = _maxPlayersFilterMin;
-    maxPlayersFilterMax = _maxPlayersFilterMax;
-    maxGameAge = _maxGameAge;
-    showOnlyIfSpectatorsCanWatch = _showOnlyIfSpectatorsCanWatch;
-    showSpectatorPasswordProtected = _showSpectatorPasswordProtected;
-    showOnlyIfSpectatorsCanChat = _showOnlyIfSpectatorsCanChat;
-    showOnlyIfSpectatorsCanSeeHands = _showOnlyIfSpectatorsCanSeeHands;
+    filters = _filters;
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 10, 0))
     endFilterChange(QSortFilterProxyModel::Direction::Rows);
 #else
@@ -346,18 +310,12 @@ int GamesProxyModel::getNumFilteredGames() const
 
 void GamesProxyModel::resetFilterParameters()
 {
-    setGameFilters(false, false, false, false, false, false, false, QString(), QStringList(), {},
-                   DEFAULT_MAX_PLAYERS_MIN, DEFAULT_MAX_PLAYERS_MAX, DEFAULT_MAX_GAME_AGE, false, false, false, false);
+    setGameFilters({});
 }
 
 bool GamesProxyModel::areFilterParametersSetToDefaults() const
 {
-    return !hideFullGames && !hideGamesThatStarted && !hidePasswordProtectedGames && !hideBuddiesOnlyGames &&
-           !hideOpenDecklistGames && !hideIgnoredUserGames && !hideNotBuddyCreatedGames && gameNameFilter.isEmpty() &&
-           creatorNameFilters.isEmpty() && gameTypeFilter.isEmpty() && maxPlayersFilterMin == DEFAULT_MAX_PLAYERS_MIN &&
-           maxPlayersFilterMax == DEFAULT_MAX_PLAYERS_MAX && maxGameAge == DEFAULT_MAX_GAME_AGE &&
-           !showOnlyIfSpectatorsCanWatch && !showSpectatorPasswordProtected && !showOnlyIfSpectatorsCanChat &&
-           !showOnlyIfSpectatorsCanSeeHands;
+    return filters.isDefault();
 }
 
 void GamesProxyModel::loadFilterParameters(const QMap<int, QString> &allGameTypes)
@@ -373,44 +331,44 @@ void GamesProxyModel::loadFilterParameters(const QMap<int, QString> &allGameType
         }
     }
 
-    setGameFilters(gameFilters.isHideBuddiesOnlyGames(), gameFilters.isHideIgnoredUserGames(),
-                   gameFilters.isHideFullGames(), gameFilters.isHideGamesThatStarted(),
-                   gameFilters.isHidePasswordProtectedGames(), gameFilters.isHideNotBuddyCreatedGames(),
-                   gameFilters.isHideOpenDecklistGames(), gameFilters.getGameNameFilter(),
-                   gameFilters.getCreatorNameFilters(), newGameTypeFilter, gameFilters.getMinPlayers(),
-                   gameFilters.getMaxPlayers(), gameFilters.getMaxGameAge(),
-                   gameFilters.isShowOnlyIfSpectatorsCanWatch(), gameFilters.isShowSpectatorPasswordProtected(),
-                   gameFilters.isShowOnlyIfSpectatorsCanChat(), gameFilters.isShowOnlyIfSpectatorsCanSeeHands());
+    setGameFilters({gameFilters.isHideBuddiesOnlyGames(), gameFilters.isHideIgnoredUserGames(),
+                    gameFilters.isHideFullGames(), gameFilters.isHideGamesThatStarted(),
+                    gameFilters.isHidePasswordProtectedGames(), gameFilters.isHideNotBuddyCreatedGames(),
+                    gameFilters.isHideOpenDecklistGames(), gameFilters.getGameNameFilter(),
+                    gameFilters.getCreatorNameFilters(), newGameTypeFilter, gameFilters.getMinPlayers(),
+                    gameFilters.getMaxPlayers(), gameFilters.getMaxGameAge(),
+                    gameFilters.isShowOnlyIfSpectatorsCanWatch(), gameFilters.isShowSpectatorPasswordProtected(),
+                    gameFilters.isShowOnlyIfSpectatorsCanChat(), gameFilters.isShowOnlyIfSpectatorsCanSeeHands()});
 }
 
 void GamesProxyModel::saveFilterParameters(const QMap<int, QString> &allGameTypes)
 {
     GameFiltersSettings &gameFilters = SettingsCache::instance().gameFilters();
-    gameFilters.setHideBuddiesOnlyGames(hideBuddiesOnlyGames);
-    gameFilters.setHideFullGames(hideFullGames);
-    gameFilters.setHideGamesThatStarted(hideGamesThatStarted);
-    gameFilters.setHidePasswordProtectedGames(hidePasswordProtectedGames);
-    gameFilters.setHideIgnoredUserGames(hideIgnoredUserGames);
-    gameFilters.setHideNotBuddyCreatedGames(hideNotBuddyCreatedGames);
-    gameFilters.setHideOpenDecklistGames(hideOpenDecklistGames);
-    gameFilters.setGameNameFilter(gameNameFilter);
-    gameFilters.setCreatorNameFilters(creatorNameFilters);
+    gameFilters.setHideBuddiesOnlyGames(filters.hideBuddiesOnlyGames);
+    gameFilters.setHideFullGames(filters.hideFullGames);
+    gameFilters.setHideGamesThatStarted(filters.hideGamesThatStarted);
+    gameFilters.setHidePasswordProtectedGames(filters.hidePasswordProtectedGames);
+    gameFilters.setHideIgnoredUserGames(filters.hideIgnoredUserGames);
+    gameFilters.setHideNotBuddyCreatedGames(filters.hideNotBuddyCreatedGames);
+    gameFilters.setHideOpenDecklistGames(filters.hideOpenDecklistGames);
+    gameFilters.setGameNameFilter(filters.gameNameFilter);
+    gameFilters.setCreatorNameFilters(filters.creatorNameFilters);
 
     QMapIterator<int, QString> gameTypeIterator(allGameTypes);
     while (gameTypeIterator.hasNext()) {
         gameTypeIterator.next();
-        bool enabled = gameTypeFilter.contains(gameTypeIterator.key());
+        bool enabled = filters.gameTypeFilter.contains(gameTypeIterator.key());
         gameFilters.setGameTypeEnabled(gameTypeIterator.value(), enabled);
     }
 
-    gameFilters.setMinPlayers(maxPlayersFilterMin);
-    gameFilters.setMaxPlayers(maxPlayersFilterMax);
-    gameFilters.setMaxGameAge(maxGameAge);
+    gameFilters.setMinPlayers(filters.maxPlayersFilterMin);
+    gameFilters.setMaxPlayers(filters.maxPlayersFilterMax);
+    gameFilters.setMaxGameAge(filters.maxGameAge);
 
-    gameFilters.setShowOnlyIfSpectatorsCanWatch(showOnlyIfSpectatorsCanWatch);
-    gameFilters.setShowSpectatorPasswordProtected(showSpectatorPasswordProtected);
-    gameFilters.setShowOnlyIfSpectatorsCanChat(showOnlyIfSpectatorsCanChat);
-    gameFilters.setShowOnlyIfSpectatorsCanSeeHands(showOnlyIfSpectatorsCanSeeHands);
+    gameFilters.setShowOnlyIfSpectatorsCanWatch(filters.showOnlyIfSpectatorsCanWatch);
+    gameFilters.setShowSpectatorPasswordProtected(filters.showSpectatorPasswordProtected);
+    gameFilters.setShowOnlyIfSpectatorsCanChat(filters.showOnlyIfSpectatorsCanChat);
+    gameFilters.setShowOnlyIfSpectatorsCanSeeHands(filters.showOnlyIfSpectatorsCanSeeHands);
 }
 
 bool GamesProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex & /*sourceParent*/) const
@@ -431,33 +389,35 @@ bool GamesProxyModel::filterAcceptsRow(int sourceRow) const
 
     const ServerInfo_Game &game = model->getGame(sourceRow);
 
-    if (hideBuddiesOnlyGames && game.only_buddies()) {
+    if (filters.hideBuddiesOnlyGames && game.only_buddies()) {
         return false;
     }
-    if (hideOpenDecklistGames && game.share_decklists_on_load()) {
+    if (filters.hideOpenDecklistGames && game.share_decklists_on_load()) {
         return false;
     }
-    if (hideIgnoredUserGames && userListProxy->isUserIgnored(QString::fromStdString(game.creator_info().name()))) {
+    if (filters.hideIgnoredUserGames &&
+        userListProxy->isUserIgnored(QString::fromStdString(game.creator_info().name()))) {
         return false;
     }
-    if (hideNotBuddyCreatedGames && !userListProxy->isUserBuddy(QString::fromStdString(game.creator_info().name()))) {
+    if (filters.hideNotBuddyCreatedGames &&
+        !userListProxy->isUserBuddy(QString::fromStdString(game.creator_info().name()))) {
         return false;
     }
-    if (hideFullGames && game.player_count() == game.max_players())
+    if (filters.hideFullGames && game.player_count() == game.max_players())
         return false;
-    if (hideGamesThatStarted && game.started())
+    if (filters.hideGamesThatStarted && game.started())
         return false;
     if (!userListProxy->isOwnUserRegistered())
         if (game.only_registered())
             return false;
-    if (hidePasswordProtectedGames && game.with_password())
+    if (filters.hidePasswordProtectedGames && game.with_password())
         return false;
-    if (!gameNameFilter.isEmpty())
-        if (!QString::fromStdString(game.description()).contains(gameNameFilter, Qt::CaseInsensitive))
+    if (!filters.gameNameFilter.isEmpty())
+        if (!QString::fromStdString(game.description()).contains(filters.gameNameFilter, Qt::CaseInsensitive))
             return false;
-    if (!creatorNameFilters.isEmpty()) {
+    if (!filters.creatorNameFilters.isEmpty()) {
         bool found = false;
-        for (const auto &createNameFilter : creatorNameFilters) {
+        for (const auto &createNameFilter : filters.creatorNameFilters) {
             if (QString::fromStdString(game.creator_info().name()).contains(createNameFilter, Qt::CaseInsensitive)) {
                 found = true;
             }
@@ -470,33 +430,34 @@ bool GamesProxyModel::filterAcceptsRow(int sourceRow) const
     QSet<int> gameTypes;
     for (int i = 0; i < game.game_types_size(); ++i)
         gameTypes.insert(game.game_types(i));
-    if (!gameTypeFilter.isEmpty() && gameTypes.intersect(gameTypeFilter).isEmpty())
+    if (!filters.gameTypeFilter.isEmpty() && gameTypes.intersect(filters.gameTypeFilter).isEmpty())
         return false;
 
-    if (game.max_players() < maxPlayersFilterMin)
+    if (static_cast<int>(game.max_players()) < filters.maxPlayersFilterMin)
         return false;
-    if (game.max_players() > maxPlayersFilterMax)
+    if (static_cast<int>(game.max_players()) > filters.maxPlayersFilterMax)
         return false;
 
-    if (maxGameAge.isValid()) {
+    if (filters.maxGameAge.isValid()) {
         QDateTime now = QDateTime::currentDateTimeUtc();
         qint64 signed_start_time = game.start_time();      // cast to 64 bit value to allow signed value
         QDateTime total = now.addSecs(-signed_start_time); // a 32 bit value would wrap at 2038-1-19
         // games shouldn't have negative ages but we'll not filter them
         // because qtime wraps after a day we consider all games older than a day to be too old
-        if (total.isValid() && total.date() >= epochDate && (total.date() > epochDate || total.time() > maxGameAge)) {
+        if (total.isValid() && total.date() >= epochDate &&
+            (total.date() > epochDate || total.time() > filters.maxGameAge)) {
             return false;
         }
     }
 
-    if (showOnlyIfSpectatorsCanWatch) {
+    if (filters.showOnlyIfSpectatorsCanWatch) {
         if (!game.spectators_allowed())
             return false;
-        if (!showSpectatorPasswordProtected && game.spectators_need_password())
+        if (!filters.showSpectatorPasswordProtected && game.spectators_need_password())
             return false;
-        if (showOnlyIfSpectatorsCanChat && !game.spectators_can_chat())
+        if (filters.showOnlyIfSpectatorsCanChat && !game.spectators_can_chat())
             return false;
-        if (showOnlyIfSpectatorsCanSeeHands && !game.spectators_omniscient())
+        if (filters.showOnlyIfSpectatorsCanSeeHands && !game.spectators_omniscient())
             return false;
     }
     return true;

--- a/cockatrice/src/interface/widgets/server/games_model.h
+++ b/cockatrice/src/interface/widgets/server/games_model.h
@@ -1,6 +1,7 @@
 #ifndef GAMESMODEL_H
 #define GAMESMODEL_H
 
+#include "game_filter_configs.h"
 #include "game_type_map.h"
 
 #include <QList>
@@ -121,22 +122,7 @@ private:
     // - loadFilterParameters()
     // - saveFilterParameters()
     // - filterAcceptsRow()
-    bool hideBuddiesOnlyGames;
-    bool hideIgnoredUserGames;
-    bool hideFullGames;
-    bool hideGamesThatStarted;
-    bool hidePasswordProtectedGames;
-    bool hideNotBuddyCreatedGames;
-    bool hideOpenDecklistGames;
-    QString gameNameFilter;
-    QStringList creatorNameFilters;
-    QSet<int> gameTypeFilter;
-    quint32 maxPlayersFilterMin, maxPlayersFilterMax;
-    QTime maxGameAge;
-    bool showOnlyIfSpectatorsCanWatch;
-    bool showSpectatorPasswordProtected;
-    bool showOnlyIfSpectatorsCanChat;
-    bool showOnlyIfSpectatorsCanSeeHands;
+    GameFilterConfigs filters;
 
 signals:
     void filtersChanged();
@@ -150,182 +136,15 @@ public:
     explicit GamesProxyModel(QObject *parent = nullptr, const UserListProxy *_userListProxy = nullptr);
 
     // Getters for filter parameters
-    [[nodiscard]] bool getHideBuddiesOnlyGames() const
+    [[nodiscard]] const GameFilterConfigs &getFilters() const
     {
-        return hideBuddiesOnlyGames;
-    }
-    [[nodiscard]] bool getHideIgnoredUserGames() const
-    {
-        return hideIgnoredUserGames;
-    }
-    [[nodiscard]] bool getHideFullGames() const
-    {
-        return hideFullGames;
-    }
-    [[nodiscard]] bool getHideGamesThatStarted() const
-    {
-        return hideGamesThatStarted;
-    }
-    [[nodiscard]] bool getHidePasswordProtectedGames() const
-    {
-        return hidePasswordProtectedGames;
-    }
-    [[nodiscard]] bool getHideNotBuddyCreatedGames() const
-    {
-        return hideNotBuddyCreatedGames;
-    }
-    [[nodiscard]] bool getHideOpenDecklistGames() const
-    {
-        return hideOpenDecklistGames;
-    }
-    [[nodiscard]] QString getGameNameFilter() const
-    {
-        return gameNameFilter;
-    }
-    [[nodiscard]] QStringList getCreatorNameFilters() const
-    {
-        return creatorNameFilters;
-    }
-    [[nodiscard]] QSet<int> getGameTypeFilter() const
-    {
-        return gameTypeFilter;
-    }
-    [[nodiscard]] int getMaxPlayersFilterMin() const
-    {
-        return maxPlayersFilterMin;
-    }
-    [[nodiscard]] int getMaxPlayersFilterMax() const
-    {
-        return maxPlayersFilterMax;
-    }
-    [[nodiscard]] const QTime &getMaxGameAge() const
-    {
-        return maxGameAge;
-    }
-    [[nodiscard]] bool getShowOnlyIfSpectatorsCanWatch() const
-    {
-        return showOnlyIfSpectatorsCanWatch;
-    }
-    [[nodiscard]] bool getShowSpectatorPasswordProtected() const
-    {
-        return showSpectatorPasswordProtected;
-    }
-    [[nodiscard]] bool getShowOnlyIfSpectatorsCanChat() const
-    {
-        return showOnlyIfSpectatorsCanChat;
-    }
-    [[nodiscard]] bool getShowOnlyIfSpectatorsCanSeeHands() const
-    {
-        return showOnlyIfSpectatorsCanSeeHands;
+        return filters;
     }
 
     /**
      * @brief Sets all game filters at once.
      */
-    void setGameFilters(bool _hideBuddiesOnlyGames,
-                        bool _hideIgnoredUserGames,
-                        bool _hideFullGames,
-                        bool _hideGamesThatStarted,
-                        bool _hidePasswordProtectedGames,
-                        bool _hideNotBuddyCreatedGames,
-                        bool _hideOpenDecklistGames,
-                        const QString &_gameNameFilter,
-                        const QStringList &_creatorNameFilter,
-                        const QSet<int> &_gameTypeFilter,
-                        int _maxPlayersFilterMin,
-                        int _maxPlayersFilterMax,
-                        const QTime &_maxGameAge,
-                        bool _showOnlyIfSpectatorsCanWatch,
-                        bool _showSpectatorPasswordProtected,
-                        bool _showOnlyIfSpectatorsCanChat,
-                        bool _showOnlyIfSpectatorsCanSeeHands);
-
-    // Individual setters
-    void setHideBuddiesOnlyGames(bool value)
-    {
-        hideBuddiesOnlyGames = value;
-        refresh();
-    }
-    void setHideIgnoredUserGames(bool value)
-    {
-        hideIgnoredUserGames = value;
-        refresh();
-    }
-    void setHideFullGames(bool value)
-    {
-        hideFullGames = value;
-        refresh();
-    }
-    void setHideGamesThatStarted(bool value)
-    {
-        hideGamesThatStarted = value;
-        refresh();
-    }
-    void setHidePasswordProtectedGames(bool value)
-    {
-        hidePasswordProtectedGames = value;
-        refresh();
-    }
-    void setHideNotBuddyCreatedGames(bool value)
-    {
-        hideNotBuddyCreatedGames = value;
-        refresh();
-    }
-    void setHideOpenDecklistGames(bool value)
-    {
-        hideOpenDecklistGames = value;
-        refresh();
-    }
-    void setGameNameFilter(const QString &value)
-    {
-        gameNameFilter = value;
-        refresh();
-    }
-    void setCreatorNameFilters(const QStringList &values)
-    {
-        creatorNameFilters = values;
-        refresh();
-    }
-    void setGameTypeFilter(const QSet<int> &value)
-    {
-        gameTypeFilter = value;
-        refresh();
-    }
-    void setMaxPlayersFilterMin(int value)
-    {
-        maxPlayersFilterMin = value;
-        refresh();
-    }
-    void setMaxPlayersFilterMax(int value)
-    {
-        maxPlayersFilterMax = value;
-        refresh();
-    }
-    void setMaxGameAge(const QTime &value)
-    {
-        maxGameAge = value;
-        refresh();
-    }
-    void setShowOnlyIfSpectatorsCanWatch(bool value)
-    {
-        showOnlyIfSpectatorsCanWatch = value;
-        refresh();
-    }
-    void setShowSpectatorPasswordProtected(bool value)
-    {
-        showSpectatorPasswordProtected = value;
-        refresh();
-    }
-    void setShowOnlyIfSpectatorsCanChat(bool value)
-    {
-        showOnlyIfSpectatorsCanChat = value;
-        refresh();
-    }
-    void setShowOnlyIfSpectatorsCanSeeHands(bool value)
-    {
-        showOnlyIfSpectatorsCanSeeHands = value;
-        refresh();
-    }
+    void setGameFilters(const GameFilterConfigs &_filters);
 
     /**
      * @brief Returns the number of games filtered out by the current filter.


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6822

## Short roundup of the initial problem

We promised that we would refactor the mess in #6822 as soon as 3.0 is released

## What will change with this Pull Request?
- Store all game filter configs as a struct instead of as individual fields in the model.
- Update code to pass around the struct instead of passing around each field individually.