### PR TITLE
[GameSelector] Fix bug with hideNotBuddyCreatedGames checkbox

### DIFF
--- a/cockatrice/src/interface/widgets/server/game_selector_quick_filter_toolbar.cpp
+++ b/cockatrice/src/interface/widgets/server/game_selector_quick_filter_toolbar.cpp
@@ -29,19 +29,7 @@ GameSelectorQuickFilterToolBar::GameSelectorQuickFilterToolBar(QWidget *parent,
     hideGamesNotCreatedByBuddiesCheckBox = new QCheckBox(this);
     hideGamesNotCreatedByBuddiesCheckBox->setChecked(filters.hideNotBuddyCreatedGames);
     connect(hideGamesNotCreatedByBuddiesCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
-        applyFilters([&](GameFilterConfigs &configs) {
-            configs.hideNotBuddyCreatedGames = checked;
-
-            if (checked) {
-                QStringList buddyNames;
-                for (auto buddy : tabSupervisor->getUserListManager()->getBuddyList().values()) {
-                    buddyNames << QString::fromStdString(buddy.name());
-                }
-                configs.creatorNameFilters = buddyNames;
-            } else {
-                configs.creatorNameFilters.clear();
-            }
-        });
+        applyFilters([&](GameFilterConfigs &configs) { configs.hideNotBuddyCreatedGames = checked; });
     });
 
     hideFullGamesCheckBox = new QCheckBox(this);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6857
- Fixes bug introduced in #6822

## Short roundup of the initial problem

The code that triggered on the checkbox was changing the `creatorNameFilters` in addition to the `hideNotBuddyCreatedGames`. That is completely unnecessary because `hideNotBuddyCreatedGames` already handles hiding the relevant rows itself.

## What will change with this Pull Request?

- Don't modify `creatorNameFilters` in the code connected to the `hideNotBuddyCreatedGames` checkbox

https://github.com/user-attachments/assets/3bd7a36c-71c6-4d1b-9bd0-2d49a87edb53

