### PR TITLE
[Game] Refactor: move parsePT to a static method

### DIFF
--- a/cockatrice/src/game/board/card_item.cpp
+++ b/cockatrice/src/game/board/card_item.cpp
@@ -396,6 +396,37 @@ void CardItem::playCard(bool faceDown)
     }
 }
 
+QVariantList CardItem::parsePT(const QString &pt)
+{
+    QVariantList ptList = QVariantList();
+    if (!pt.isEmpty()) {
+        int sep = pt.indexOf('/');
+        if (sep == 0) {
+            ptList.append(QVariant(pt.mid(1))); // cut off starting '/' and take full string
+        } else {
+            int start = 0;
+            for (;;) {
+                QString item = pt.mid(start, sep - start);
+                if (item.isEmpty()) {
+                    ptList.append(QVariant(QString()));
+                } else if (item[0] == '+') {
+                    ptList.append(QVariant(item.mid(1).toInt())); // add as int
+                } else if (item[0] == '-') {
+                    ptList.append(QVariant(item.toInt())); // add as int
+                } else {
+                    ptList.append(QVariant(item)); // add as qstring
+                }
+                if (sep == -1) {
+                    break;
+                }
+                start = sep + 1;
+                sep = pt.indexOf('/', start);
+            }
+        }
+    }
+    return ptList;
+}
+
 /**
  * @brief returns true if the zone is a unwritable reveal zone view (eg a card reveal window). Will return false if zone
  * is nullptr.

--- a/cockatrice/src/game/board/card_item.h
+++ b/cockatrice/src/game/board/card_item.h
@@ -146,6 +146,26 @@ public:
     void drawAttachArrow();
     void playCard(bool faceDown);
 
+    /**
+     * @brief Parses a string representing a p/t in order to extract the values from it.
+     *
+     * If the string contains '/', the string will be split at the '/' and each side will be parsed separately,
+     * which means the result list will have two elements.
+     *
+     * If '/' is not found, then the entire string is parsed together, which means the result list will
+     * have a single element.
+     *
+     * If either side of the split is empty, there will also only be a single element in the result list.
+     *
+     * This function will attempt to parse each substring as an int first, handling plus and minus prefixes.
+     * If successful, it will put the parsed value into the QVariant as an int.
+     * If failed, it will just put the substring into the QVariant as a QString.
+     *
+     * @param pt The p/t string
+     * @return A QVariantList that can contain one or two elements, where each QVariant can be either int or QString
+     */
+    static QVariantList parsePT(const QString &pt);
+
 protected:
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
     void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -1272,7 +1272,7 @@ void PlayerActions::actIncPT(int deltaP, int deltaT)
     for (const auto &item : player->getGameScene()->selectedItems()) {
         auto *card = static_cast<CardItem *>(item);
         QString pt = card->getPT();
-        const auto ptList = parsePT(pt);
+        const auto ptList = CardItem::parsePT(pt);
         QString newpt;
         if (ptList.isEmpty()) {
             newpt = QString::number(deltaP) + (deltaT ? "/" + QString::number(deltaT) : "");
@@ -1332,37 +1332,6 @@ void PlayerActions::actResetPT()
     }
 }
 
-QVariantList PlayerActions::parsePT(const QString &pt)
-{
-    QVariantList ptList = QVariantList();
-    if (!pt.isEmpty()) {
-        int sep = pt.indexOf('/');
-        if (sep == 0) {
-            ptList.append(QVariant(pt.mid(1))); // cut off starting '/' and take full string
-        } else {
-            int start = 0;
-            for (;;) {
-                QString item = pt.mid(start, sep - start);
-                if (item.isEmpty()) {
-                    ptList.append(QVariant(QString()));
-                } else if (item[0] == '+') {
-                    ptList.append(QVariant(item.mid(1).toInt())); // add as int
-                } else if (item[0] == '-') {
-                    ptList.append(QVariant(item.toInt())); // add as int
-                } else {
-                    ptList.append(QVariant(item)); // add as qstring
-                }
-                if (sep == -1) {
-                    break;
-                }
-                start = sep + 1;
-                sep = pt.indexOf('/', start);
-            }
-        }
-    }
-    return ptList;
-}
-
 void PlayerActions::actSetPT()
 {
     QString oldPT;
@@ -1384,7 +1353,7 @@ void PlayerActions::actSetPT()
         return;
     }
 
-    const auto ptList = parsePT(pt);
+    const auto ptList = CardItem::parsePT(pt);
     bool empty = ptList.isEmpty();
 
     QList<const ::google::protobuf::Message *> commandList;
@@ -1393,7 +1362,7 @@ void PlayerActions::actSetPT()
         auto *cmd = new Command_SetCardAttr;
         QString newpt = QString();
         if (!empty) {
-            const auto oldpt = parsePT(card->getPT());
+            const auto oldpt = CardItem::parsePT(card->getPT());
             int ptIter = 0;
             for (const auto &_item : ptList) {
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))

--- a/cockatrice/src/game/player/player_actions.h
+++ b/cockatrice/src/game/player/player_actions.h
@@ -197,8 +197,6 @@ private:
 
     void cmdSetTopCard(Command_MoveCard &cmd);
     void cmdSetBottomCard(Command_MoveCard &cmd);
-
-    QVariantList parsePT(const QString &pt);
 };
 
 #endif // COCKATRICE_PLAYER_ACTIONS_H


### PR DESCRIPTION
## Short roundup of the initial problem

I need to use the logic in `parsePT` in a class that isn't `PlayerActions`.

But also, `parsePT` isn't really logic that's specific to `PlayerActions`. If anything, p/t strings are something that's mainly used by `CardItem`.

## What will change with this Pull Request?
- Move `parsePT` to a static method on `CardItem`
- Add docs to `parsePT`