### PR TITLE
[GameSelector] Don't conditionally initialize gamesListProxyModel

### DIFF
--- a/cockatrice/src/interface/widgets/server/game_selector.cpp
+++ b/cockatrice/src/interface/widgets/server/game_selector.cpp
@@ -37,8 +37,9 @@ GameSelector::GameSelector(AbstractClient *_client,
     connect(gameListView, &QTreeView::customContextMenuRequested, this, &GameSelector::customContextMenu);
 
     gameListModel = new GamesModel(_rooms, _gameTypes, this);
+    gameListProxyModel = new GamesProxyModel(this, tabSupervisor->getUserListManager());
+
     if (showFilters) {
-        gameListProxyModel = new GamesProxyModel(this, tabSupervisor->getUserListManager());
         gameListProxyModel->setSourceModel(gameListModel);
         gameListProxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
         gameListView->setModel(gameListProxyModel);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes crash case when inspecting user games sometimes

## Short roundup of the initial problem
There's no reason to conditionally initialize this if we depend on it in later code. There's no harm in initializing it.

## What will change with this Pull Request?
- No longer conditionally initialize gamesListProxyModel (only if showFilters was true before)
