### PR TITLE
Add generic colorless mana symbol

### DIFF
--- a/cockatrice/cockatrice.qrc
+++ b/cockatrice/cockatrice.qrc
@@ -55,6 +55,7 @@
         <file>resources/icons/view.svg</file>
 
         <file>resources/icons/mana/B.svg</file>
+        <file>resources/icons/mana/C.svg</file>
         <file>resources/icons/mana/G.svg</file>
         <file>resources/icons/mana/R.svg</file>
         <file>resources/icons/mana/U.svg</file>

--- a/cockatrice/resources/icons/mana/C.svg
+++ b/cockatrice/resources/icons/mana/C.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="169.33115mm"
+   height="169.59981mm"
+   viewBox="0 0 169.33115 169.59981"
+   version="1.1"
+   id="svg1"
+   inkscape:export-filename="C.svg"
+   inkscape:export-xdpi="96.000015"
+   inkscape:export-ydpi="96.000015"
+   inkscape:version="1.4.3 (0d15f75042, 2025-12-25)"
+   sodipodi:docname="colorless.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.71535494"
+     inkscape:cx="397.00572"
+     inkscape:cy="536.09751"
+     inkscape:window-width="1853"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:page
+       x="0"
+       y="0"
+       width="169.33115"
+       height="169.59981"
+       id="page2"
+       margin="0"
+       bleed="0" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-20.334425,-63.700102)">
+    <ellipse
+       style="fill:#cccccc;stroke:#000000;stroke-width:0.165333;stroke-linecap:round"
+       id="path1"
+       cx="-30.617094"
+       cy="179.22736"
+       transform="matrix(0.70654605,-0.70766707,0.70654608,0.70766704,0,0)"
+       rx="84.650612"
+       ry="84.65062" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:14.5003;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none"
+       id="rect1"
+       width="84.683701"
+       height="84.683769"
+       x="-221.60611"
+       y="-73.174698"
+       ry="0.084683768"
+       transform="matrix(-0.7073973,-0.70681615,0.7073973,-0.70681615,0,0)" />
+  </g>
+</svg>


### PR DESCRIPTION
## Related Ticket(s)
- Progress towards https://github.com/Cockatrice/Cockatrice/issues/6863

## Short roundup of the initial problem
We do not have a generic mana symbol for colorless mana and would like to use one in the client

## What will change with this Pull Request?
- Adds a colorless mana symbol that I made in Inkscape (source is I drew a diamond)

## Screenshots
<img width="100" height="100" alt="a grey circle with a black diamond in it" src="https://github.com/user-attachments/assets/4adfb4cf-85a8-48ac-8ab6-d4b0355e6f2f" />

