### PR TITLE
[DeckEditor] Refactor searchEdit highlighting after add card

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_card_database_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_card_database_dock_widget.cpp
@@ -58,7 +58,3 @@ void DeckEditorCardDatabaseDockWidget::clearAllDatabaseFilters()
 {
     databaseDisplayWidget->clearAllDatabaseFilters();
 }
-void DeckEditorCardDatabaseDockWidget::highlightAllSearchEdit()
-{
-    databaseDisplayWidget->searchEdit->setSelection(0, databaseDisplayWidget->searchEdit->text().length());
-}

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_card_database_dock_widget.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_card_database_dock_widget.h
@@ -23,7 +23,6 @@ public:
 public slots:
     void retranslateUi();
     void clearAllDatabaseFilters();
-    void highlightAllSearchEdit();
 
 private:
     void createDatabaseDisplayDock(AbstractTabDeckEditor *deckEditor);

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
@@ -147,11 +147,13 @@ void DeckEditorDatabaseDisplayWidget::updateCard(const QModelIndex &current, con
 
 void DeckEditorDatabaseDisplayWidget::actAddCardToMainDeck()
 {
+    highlightAllSearchEdit();
     emit addCardToMainDeck(currentCard());
 }
 
 void DeckEditorDatabaseDisplayWidget::actAddCardToSideboard()
 {
+    highlightAllSearchEdit();
     emit addCardToSideboard(currentCard());
 }
 
@@ -240,4 +242,9 @@ void DeckEditorDatabaseDisplayWidget::retranslateUi()
 {
     aAddCard->setText(tr("Add card to &maindeck"));
     aAddCardToSideboard->setText(tr("Add card to &sideboard"));
+}
+
+void DeckEditorDatabaseDisplayWidget::highlightAllSearchEdit()
+{
+    searchEdit->setSelection(0, searchEdit->text().length());
 }

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.h
@@ -62,6 +62,8 @@ private:
     QVBoxLayout *centralFrame;
     QWidget *centralWidget;
 
+    void highlightAllSearchEdit();
+
 private slots:
     void retranslateUi();
     void saveDbHeaderState();

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.h
@@ -25,7 +25,6 @@ class DeckEditorDatabaseDisplayWidget : public QWidget
 public:
     explicit DeckEditorDatabaseDisplayWidget(QWidget *parent, AbstractTabDeckEditor *deckEditor);
     AbstractTabDeckEditor *deckEditor;
-    SearchLineEdit *searchEdit;
     CardDatabaseModel *databaseModel;
     CardDatabaseDisplayModel *databaseDisplayModel;
 
@@ -58,6 +57,7 @@ private:
     KeySignals searchKeySignals;
     QTreeView *databaseView;
     QHBoxLayout *searchLayout;
+    SearchLineEdit *searchEdit;
     QAction *aAddCard, *aAddCardToSideboard;
     QVBoxLayout *centralFrame;
     QWidget *centralWidget;

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
@@ -137,8 +137,6 @@ void AbstractTabDeckEditor::onDeckModified()
 void AbstractTabDeckEditor::addCardHelper(const ExactCard &card, const QString &zoneName)
 {
     deckStateManager->addCard(card, zoneName);
-
-    cardDatabaseDockWidget->highlightAllSearchEdit();
 }
 
 /**


### PR DESCRIPTION
## Related Ticket(s)
- Related to #6867

## Short roundup of the initial problem

The way that the "auto highlight searchEdit upon adding a card" is implemented in a really roundabout way, crossing two classes. 

#6867 pointed out that the visual deck database doesn't have the same feature, because it was never implemented for it. Since we don't want to the implementation for the visual deck database to also cross the same classes, that means the logic should be handled within the class. 

## What will change with this Pull Request?
- Make the auto-highlighting be handled entirely within the `DeckEditorDatabaseDisplayWidget` class
  - highlightAllSearchEdit whenever the add card actions are triggered, instead of waiting for it to bubble all the way up to the deck editor tab
    - This will have the exact same behavior as before, because if another widget causes a card to be added to the deck, the deck database would not be focused anyways

https://github.com/user-attachments/assets/3675e654-a598-43c8-aefb-91569e051a94
