### PR TITLE
[VisualDatabaseDisplayWidget] Refactor: Make all fields private

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/tab_visual_database_display.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_visual_database_display.h
@@ -23,8 +23,8 @@ public:
     void retranslateUi() override;
     [[nodiscard]] QString getTabText() const override
     {
-        return visualDatabaseDisplayWidget->displayModeButton->isChecked() ? tr("Database Display")
-                                                                           : tr("Visual Database Display");
+        return visualDatabaseDisplayWidget->isVisualDisplayMode() ? tr("Visual Database Display")
+                                                                  : tr("Database Display");
     }
 };
 

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_filter_toolbar_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_filter_toolbar_widget.cpp
@@ -101,7 +101,7 @@ void VisualDatabaseDisplayFilterToolbarWidget::initialize()
     filterLayout->setAlignment(Qt::AlignLeft);
 
     // create settings widgets
-    auto filterModel = visualDatabaseDisplay->filterModel;
+    auto filterModel = visualDatabaseDisplay->getFilterModel();
 
     saveLoadWidget = new VisualDatabaseDisplayFilterSaveLoadWidget(this, filterModel);
     nameFilterWidget =

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -237,6 +237,11 @@ void VisualDatabaseDisplayWidget::updateSearch(const QString &search) const
                                                         QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
 }
 
+bool VisualDatabaseDisplayWidget::isVisualDisplayMode() const
+{
+    return !displayModeButton->isChecked();
+}
+
 void VisualDatabaseDisplayWidget::onSearchModelChanged()
 {
     if (flowWidget->isVisible()) {

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
@@ -62,12 +62,15 @@ public:
         return databaseView;
     }
 
-    QWidget *searchContainer;
-    QHBoxLayout *searchLayout;
-    SearchLineEdit *searchEdit;
-    QPushButton *displayModeButton;
-    FilterTreeModel *filterModel;
-    VisualDatabaseDisplayColorFilterWidget *colorFilterWidget;
+    FilterTreeModel *getFilterModel()
+    {
+        return filterModel;
+    }
+
+    /**
+     * @return False if the widget is in database display mode and true if it's in visual display mode
+     */
+    bool isVisualDisplayMode() const;
 
 public slots:
     void onSearchModelChanged();
@@ -88,6 +91,13 @@ protected slots:
     void onDisplayModeChanged(bool checked);
 
 private:
+    QWidget *searchContainer;
+    QHBoxLayout *searchLayout;
+    SearchLineEdit *searchEdit;
+    QPushButton *displayModeButton;
+    FilterTreeModel *filterModel;
+    VisualDatabaseDisplayColorFilterWidget *colorFilterWidget;
+
     QLabel *databaseLoadIndicator;
 
     QToolButton *clearFilterWidget;


### PR DESCRIPTION
## Short roundup of the initial problem

No reason why the fields need to be public

## What will change with this Pull Request?
- Make all public fields in `VisualDatabaseDisplayWidget` private
- Create getters for the two fields that do get accessed elsewhere.
