### PR TITLE
[VisualDeckEditor] Highlight searchEdit after add card

### DIFF
--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -99,6 +99,11 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
             &DeckEditorDatabaseDisplayWidget::copyDatabaseCellContents);
     connect(help, &QAction::triggered, this, [this] { createSearchSyntaxHelpWindow(searchEdit); });
 
+    connect(databaseDisplayWidget, &DeckEditorDatabaseDisplayWidget::addCardToMainDeck, this,
+            &VisualDatabaseDisplayWidget::highlightAllSearchEdit);
+    connect(databaseDisplayWidget, &DeckEditorDatabaseDisplayWidget::addCardToSideboard, this,
+            &VisualDatabaseDisplayWidget::highlightAllSearchEdit);
+
     databaseView = databaseDisplayWidget->getDatabaseView();
     databaseView->setFocusProxy(searchEdit);
     databaseView->setItemDelegate(nullptr);
@@ -179,6 +184,11 @@ void VisualDatabaseDisplayWidget::retranslateUi()
 {
     databaseLoadIndicator->setText(tr("Loading database ..."));
     clearFilterWidget->setToolTip(tr("Clear all filters"));
+}
+
+void VisualDatabaseDisplayWidget::highlightAllSearchEdit()
+{
+    searchEdit->setSelection(0, searchEdit->text().length());
 }
 
 void VisualDatabaseDisplayWidget::resizeEvent(QResizeEvent *event)

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
@@ -112,6 +112,8 @@ private:
     int currentPage = 0;    // Current page index
     int cardsPerPage = 100; // Number of cards per page
 
+    void highlightAllSearchEdit();
+
 protected:
     void resizeEvent(QResizeEvent *event) override;
 };


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6867

## Short roundup of the initial problem

When using the VDE's card database in table mode, the searchEdit doesn't automatically get highlighted after each add card, whereas it does in the classic deck editor

## What will change with this Pull Request?
- Add a `highlightAllSearchEdit` method to `VisualDatabaseDisplayWidget` and connect it to the underlying `DeckEditorDatabaseDisplayWidget`'s card added signals

Conveniently, that means the highlight on add will only happen if you're in the table display mode.

https://github.com/user-attachments/assets/22264ce3-7670-410e-b7f1-35a39c11f72b
