### PR TITLE
fix resizing the visual card database loading more pages forever

### DIFF
--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -270,7 +270,7 @@ void VisualDatabaseDisplayWidget::onSearchModelChanged()
     }
 }
 
-bool VisualDatabaseDisplayWidget::nearEndOfPage()
+bool VisualDatabaseDisplayWidget::nearEndOfPage() const
 {
     if (!flowWidget->isVisible()) {
         return false;

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -142,6 +142,8 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
         databaseLoadIndicator->setVisible(false);
     }
 
+    QScrollBar *scrollBar = flowWidget->scrollArea->verticalScrollBar();
+    connect(scrollBar, &QScrollBar::valueChanged, [this](int /*value*/) { loadCurrentPage(); });
     retranslateUi();
 }
 
@@ -259,14 +261,27 @@ void VisualDatabaseDisplayWidget::onSearchModelChanged()
         flowWidget->clearLayout(); // Clear existing cards
         cards->clear();            // Clear the card list
         // Reset scrollbar position to the top after loading new cards
-        if (QScrollBar *scrollBar = flowWidget->scrollArea->verticalScrollBar()) {
-            scrollBar->setValue(0); // Reset scrollbar to top
-        }
+        QScrollBar *scrollBar = flowWidget->scrollArea->verticalScrollBar();
+        scrollBar->setValue(0); // Reset scrollbar to top
 
         currentPage = 0;
         loadCurrentPage();
         qCDebug(VisualDatabaseDisplayLog) << "Search model changed";
     }
+}
+
+bool VisualDatabaseDisplayWidget::nearEndOfPage()
+{
+    if (!flowWidget->isVisible()) {
+        return false;
+    }
+
+    QScrollBar *scrollBar = flowWidget->scrollArea->verticalScrollBar();
+    if (scrollBar->value() + scrollBar->pageStep() * 2 < scrollBar->maximum()) {
+        return false; // there is at least two pages of space to scroll remaining
+    }
+
+    return true;
 }
 
 void VisualDatabaseDisplayWidget::loadCurrentPage()
@@ -276,7 +291,7 @@ void VisualDatabaseDisplayWidget::loadCurrentPage()
         // Only load the first page initially
         qCDebug(VisualDatabaseDisplayLog) << "Loading the first page";
         populateCards();
-    } else {
+    } else if (nearEndOfPage()) {
         // If not the first page, just load the next page and append to the flow widget
         loadNextPage();
     }
@@ -354,24 +369,4 @@ void VisualDatabaseDisplayWidget::databaseDataChanged(const QModelIndex &topLeft
     (void)topLeft;
     (void)bottomRight;
     qCDebug(VisualDatabaseDisplayLog) << "Database Data changed";
-}
-
-void VisualDatabaseDisplayWidget::wheelEvent(QWheelEvent *event)
-{
-    int totalCards = databaseDisplayModel->rowCount(); // Total number of cards
-    int loadedCards = currentPage * cardsPerPage;
-
-    // Handle scrolling down
-    if (event->angleDelta().y() < 0) {
-        // Check if the next page has any cards to load
-        if (loadedCards < totalCards) {
-            loadCurrentPage(); // Load the next page
-            event->accept();   // Accept the event as valid
-            return;
-        }
-        qCDebug(VisualDatabaseDisplayLog) << loadedCards << ":" << totalCards;
-    }
-
-    // Prevent overscrolling when there's no more data to load
-    event->ignore();
 }

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
@@ -85,7 +85,6 @@ protected slots:
     void onHover(const ExactCard &hoveredCard);
     void addCard(const ExactCard &cardToAdd);
     void databaseDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
-    void wheelEvent(QWheelEvent *event) override;
     void modelDirty() const;
     void updateSearch(const QString &search) const;
     void onDisplayModeChanged(bool checked);
@@ -123,6 +122,7 @@ private:
     int cardsPerPage = 100; // Number of cards per page
 
     void highlightAllSearchEdit();
+    bool nearEndOfPage();
 
 protected:
     void resizeEvent(QResizeEvent *event) override;

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
@@ -122,7 +122,7 @@ private:
     int cardsPerPage = 100; // Number of cards per page
 
     void highlightAllSearchEdit();
-    bool nearEndOfPage();
+    bool nearEndOfPage() const;
 
 protected:
     void resizeEvent(QResizeEvent *event) override;


### PR DESCRIPTION
## Related Ticket(s)
- introduced in #5834

## Short roundup of the initial problem
when dragging the corner of the app while the vde is on the visual card database, the app will load a new page of cards every time the resize is processed, quickly grinding interface updates to a halt until you stop resizing it

fetching a new page of cards only happens when using the scroll wheel, not when dragging the bar or using pagedown or down arrow

## What will change with this Pull Request?
- a new page will only be loaded when the scrollbar is near the end (2 pages currently)
- all methods of scrolling will fetch new pages
- I checked, and when there are very few cards in the db it will work as expected (the scrollbar is always near the end)
