### PR TITLE
Standardize Doxygen documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -211,11 +211,11 @@ into smaller parts, for example at spaces or after opening a brace.
 
 ### Documentation Comments ###
 
-Use [Doxygen](https://www.doxygen.nl/) for API documentation:
+Use [Doxygen](https://www.doxygen.nl/) for code documentation:
 
-- **Doc blocks**: Use `/** @brief Description */` (JavaDoc-style), not `///`
+- **Doc blocks**: Use `/** @brief Description */` (Javadoc-style), not `///`
 - **Member comments**: Use trailing `///<` for inline member documentation
-- **TODOs**: Use `//! \todo Description` (Qt-style) so Doxygen collects them into a Todo List
+- **TODOs**: Use `//! \todo Description` (Qt-style), Doxygen collects them into a Todo List
   (uses [Qt-style comments](https://www.doxygen.nl/manual/docblocks.html) with
   Doxygen's [\todo command](https://www.doxygen.nl/manual/commands.html#cmdtodo))
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -209,6 +209,16 @@ nowadays and clean it up for you.
 Lines should be 120 characters or less. Please break up lines that are too long
 into smaller parts, for example at spaces or after opening a brace.
 
+### Documentation Comments ###
+
+Use [Doxygen](https://www.doxygen.nl/) for API documentation:
+
+- **Doc blocks**: Use `/** @brief Description */` (JavaDoc-style), not `///`
+- **Member comments**: Use trailing `///<` for inline member documentation
+- **TODOs**: Use `//! \todo Description` (Qt-style) so Doxygen collects them into a Todo List
+  (uses [Qt-style comments](https://www.doxygen.nl/manual/docblocks.html) with
+  Doxygen's [\todo command](https://www.doxygen.nl/manual/commands.html#cmdtodo))
+
 ### Memory Management ###
 
 New code should be written using references over pointers and stack allocation

--- a/cockatrice/src/client/network/interfaces/deck_stats_interface.h
+++ b/cockatrice/src/client/network/interfaces/deck_stats_interface.h
@@ -1,8 +1,8 @@
 /**
  * @file deck_stats_interface.h
  * @ingroup ApiInterfaces
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DECKSTATS_INTERFACE_H
 #define DECKSTATS_INTERFACE_H

--- a/cockatrice/src/client/network/interfaces/tapped_out_interface.h
+++ b/cockatrice/src/client/network/interfaces/tapped_out_interface.h
@@ -1,8 +1,8 @@
 /**
  * @file tapped_out_interface.h
  * @ingroup ApiInterfaces
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TAPPEDOUT_INTERFACE_H
 #define TAPPEDOUT_INTERFACE_H

--- a/cockatrice/src/client/network/parsers/deck_link_to_api_transformer.h
+++ b/cockatrice/src/client/network/parsers/deck_link_to_api_transformer.h
@@ -1,8 +1,8 @@
 /**
  * @file deck_link_to_api_transformer.h
  * @ingroup ApiInterfaces
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DECK_LINK_TO_API_TRANSFORMER_H
 #define DECK_LINK_TO_API_TRANSFORMER_H

--- a/cockatrice/src/client/network/parsers/interface_json_deck_parser.h
+++ b/cockatrice/src/client/network/parsers/interface_json_deck_parser.h
@@ -1,8 +1,8 @@
 /**
  * @file interface_json_deck_parser.h
  * @ingroup ApiInterfaces
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef INTERFACE_JSON_DECK_PARSER_H
 #define INTERFACE_JSON_DECK_PARSER_H

--- a/cockatrice/src/client/network/update/card_spoiler/spoiler_background_updater.h
+++ b/cockatrice/src/client/network/update/card_spoiler/spoiler_background_updater.h
@@ -1,8 +1,8 @@
 /**
  * @file spoiler_background_updater.h
  * @ingroup Client
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_SPOILER_DOWNLOADER_H
 #define COCKATRICE_SPOILER_DOWNLOADER_H

--- a/cockatrice/src/client/network/update/client/client_update_checker.h
+++ b/cockatrice/src/client/network/update/client/client_update_checker.h
@@ -1,8 +1,8 @@
 /**
  * @file client_update_checker.h
  * @ingroup ClientUpdate
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CLIENT_UPDATE_CHECKER_H
 #define CLIENT_UPDATE_CHECKER_H

--- a/cockatrice/src/client/network/update/client/release_channel.h
+++ b/cockatrice/src/client/network/update/client/release_channel.h
@@ -1,8 +1,8 @@
 /**
  * @file release_channel.h
  * @ingroup ClientUpdate
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef RELEASECHANNEL_H
 #define RELEASECHANNEL_H

--- a/cockatrice/src/client/network/update/client/update_downloader.h
+++ b/cockatrice/src/client/network/update/client/update_downloader.h
@@ -1,8 +1,8 @@
 /**
  * @file update_downloader.h
  * @ingroup ClientUpdate
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_UPDATEDOWNLOADER_H
 #define COCKATRICE_UPDATEDOWNLOADER_H

--- a/cockatrice/src/client/settings/cache_settings.h
+++ b/cockatrice/src/client/settings/cache_settings.h
@@ -1,8 +1,8 @@
 /**
  * @file cache_settings.h
  * @ingroup Settings
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef SETTINGSCACHE_H
 #define SETTINGSCACHE_H

--- a/cockatrice/src/client/settings/card_counter_settings.h
+++ b/cockatrice/src/client/settings/card_counter_settings.h
@@ -1,8 +1,8 @@
 /**
  * @file card_counter_settings.h
  * @ingroup GameSettings
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARD_COUNTER_SETTINGS_H
 #define CARD_COUNTER_SETTINGS_H

--- a/cockatrice/src/client/settings/shortcut_treeview.h
+++ b/cockatrice/src/client/settings/shortcut_treeview.h
@@ -1,8 +1,8 @@
 /**
  * @file shortcut_treeview.h
  * @ingroup CoreSettings
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef SHORTCUT_TREEVIEW_H
 #define SHORTCUT_TREEVIEW_H

--- a/cockatrice/src/client/settings/shortcuts_settings.cpp
+++ b/cockatrice/src/client/settings/shortcuts_settings.cpp
@@ -64,8 +64,13 @@ ShortcutsSettings::ShortcutsSettings(const QString &settingsPath, QObject *paren
     }
 }
 
-/// PR 5079 changes Textbox/unfocusTextBox to Player/unfocusTextBox and tab_game/aFocusChat to Player/aFocusChat.
-/// A migration is necessary to let players keep their already configured shortcuts.
+/**
+ * @brief Migrates legacy shortcut key names to current naming scheme.
+ *
+ * PR 5079 changed Textbox/unfocusTextBox to Player/unfocusTextBox and
+ * tab_game/aFocusChat to Player/aFocusChat. This migration allows players
+ * to keep their already configured shortcuts.
+ */
 void ShortcutsSettings::migrateShortcuts()
 {
     if (QFile(settingsFilePath).exists()) {
@@ -236,9 +241,7 @@ bool ShortcutsSettings::isValid(const QString &name, const QString &sequences) c
     return findOverlaps(name, sequences).isEmpty();
 }
 
-/**
- * Checks if the shortcut is a shortcut that is active in all windows
- */
+/** @brief Checks if the shortcut is a shortcut that is active in all windows. */
 static bool isAlwaysActiveShortcut(const QString &shortcutName)
 {
     return shortcutName.startsWith("MainWindow") || shortcutName.startsWith("Tabs");

--- a/cockatrice/src/client/settings/shortcuts_settings.h
+++ b/cockatrice/src/client/settings/shortcuts_settings.h
@@ -1,8 +1,8 @@
 /**
  * @file shortcuts_settings.h
  * @ingroup CoreSettings
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef SHORTCUTSSETTINGS_H
 #define SHORTCUTSSETTINGS_H

--- a/cockatrice/src/client/sound_engine.h
+++ b/cockatrice/src/client/sound_engine.h
@@ -1,8 +1,8 @@
 /**
  * @file sound_engine.h
  * @ingroup Core
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef SOUNDENGINE_H
 #define SOUNDENGINE_H

--- a/cockatrice/src/filters/deck_filter_string.h
+++ b/cockatrice/src/filters/deck_filter_string.h
@@ -1,8 +1,8 @@
 /**
  * @file deck_filter_string.h
  * @ingroup DeckStorageWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DECK_FILTER_STRING_H
 #define DECK_FILTER_STRING_H

--- a/cockatrice/src/filters/filter_builder.h
+++ b/cockatrice/src/filters/filter_builder.h
@@ -1,8 +1,8 @@
 /**
  * @file filter_builder.h
  * @ingroup CardDatabaseModelFilters
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef FILTERBUILDER_H
 #define FILTERBUILDER_H

--- a/cockatrice/src/filters/filter_tree_model.h
+++ b/cockatrice/src/filters/filter_tree_model.h
@@ -1,8 +1,8 @@
 /**
  * @file filter_tree_model.h
  * @ingroup CardDatabaseModelFilters
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef FILTERTREEMODEL_H
 #define FILTERTREEMODEL_H

--- a/cockatrice/src/filters/syntax_help.h
+++ b/cockatrice/src/filters/syntax_help.h
@@ -2,8 +2,8 @@
  * @file syntax_help.h
  * @ingroup CardDatabaseModelFilters
  * @ingroup DeckStorageWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef SEARCH_SYNTAX_HELP_H
 #define SEARCH_SYNTAX_HELP_H

--- a/cockatrice/src/game/abstract_game.h
+++ b/cockatrice/src/game/abstract_game.h
@@ -1,8 +1,8 @@
 /**
  * @file abstract_game.h
  * @ingroup GameLogic
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_ABSTRACT_GAME_H
 #define COCKATRICE_ABSTRACT_GAME_H

--- a/cockatrice/src/game/board/abstract_card_drag_item.h
+++ b/cockatrice/src/game/board/abstract_card_drag_item.h
@@ -1,8 +1,8 @@
 /**
  * @file abstract_card_drag_item.h
  * @ingroup GameGraphicsCards
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef ABSTRACTCARDDRAGITEM_H
 #define ABSTRACTCARDDRAGITEM_H

--- a/cockatrice/src/game/board/abstract_counter.h
+++ b/cockatrice/src/game/board/abstract_counter.h
@@ -1,8 +1,8 @@
 /**
  * @file abstract_counter.h
  * @ingroup GameGraphicsPlayers
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COUNTER_H
 #define COUNTER_H

--- a/cockatrice/src/game/board/arrow_item.h
+++ b/cockatrice/src/game/board/arrow_item.h
@@ -1,8 +1,8 @@
 /**
  * @file arrow_item.h
  * @ingroup GameGraphics
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef ARROWITEM_H
 #define ARROWITEM_H

--- a/cockatrice/src/game/board/arrow_target.h
+++ b/cockatrice/src/game/board/arrow_target.h
@@ -1,8 +1,8 @@
 /**
  * @file arrow_target.h
  * @ingroup GameGraphics
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef ARROWTARGET_H
 #define ARROWTARGET_H

--- a/cockatrice/src/game/board/card_drag_item.h
+++ b/cockatrice/src/game/board/card_drag_item.h
@@ -1,8 +1,8 @@
 /**
  * @file card_drag_item.h
  * @ingroup GameGraphicsCards
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARDDRAGITEM_H
 #define CARDDRAGITEM_H

--- a/cockatrice/src/game/board/card_item.h
+++ b/cockatrice/src/game/board/card_item.h
@@ -1,8 +1,8 @@
 /**
  * @file card_item.h
  * @ingroup GameGraphicsCards
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARDITEM_H
 #define CARDITEM_H

--- a/cockatrice/src/game/board/card_list.h
+++ b/cockatrice/src/game/board/card_list.h
@@ -1,8 +1,8 @@
 /**
  * @file card_list.h
  * @ingroup GameLogicCards
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARDLIST_H
 #define CARDLIST_H

--- a/cockatrice/src/game/board/counter_general.h
+++ b/cockatrice/src/game/board/counter_general.h
@@ -1,8 +1,8 @@
 /**
  * @file counter_general.h
  * @ingroup GameGraphicsPlayers
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COUNTER_GENERAL_H
 #define COUNTER_GENERAL_H

--- a/cockatrice/src/game/board/translate_counter_name.h
+++ b/cockatrice/src/game/board/translate_counter_name.h
@@ -1,8 +1,8 @@
 /**
  * @file translate_counter_name.h
  * @ingroup GameGraphicsPlayers
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TRANSLATECOUNTERNAME_H
 #define TRANSLATECOUNTERNAME_H

--- a/cockatrice/src/game/card_dimensions.h
+++ b/cockatrice/src/game/card_dimensions.h
@@ -12,16 +12,16 @@
  */
 namespace CardDimensions
 {
-/// Card width in pixels
+/** @brief Card width in pixels. */
 constexpr int WIDTH = 72;
-/// Card height in pixels
+/** @brief Card height in pixels. */
 constexpr int HEIGHT = 102;
 
-/// Pre-converted for floating-point contexts (Z-value calculations)
+/** @brief Pre-converted for floating-point contexts (Z-value calculations). */
 constexpr qreal WIDTH_F = static_cast<qreal>(WIDTH);
 constexpr qreal HEIGHT_F = static_cast<qreal>(HEIGHT);
 
-/// Half-dimensions for centering and rotation transforms
+/** @brief Half-dimensions for centering and rotation transforms. */
 constexpr qreal WIDTH_HALF_F = WIDTH_F / 2;
 constexpr qreal HEIGHT_HALF_F = HEIGHT_F / 2;
 } // namespace CardDimensions

--- a/cockatrice/src/game/deckview/deck_view.h
+++ b/cockatrice/src/game/deckview/deck_view.h
@@ -1,8 +1,8 @@
 /**
  * @file deck_view.h
  * @ingroup Lobby
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DECKVIEW_H
 #define DECKVIEW_H

--- a/cockatrice/src/game/deckview/deck_view_container.h
+++ b/cockatrice/src/game/deckview/deck_view_container.h
@@ -1,8 +1,8 @@
 /**
  * @file deck_view_container.h
  * @ingroup Lobby
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DECK_VIEW_CONTAINER_H
 #define DECK_VIEW_CONTAINER_H

--- a/cockatrice/src/game/deckview/tabbed_deck_view_container.h
+++ b/cockatrice/src/game/deckview/tabbed_deck_view_container.h
@@ -1,8 +1,8 @@
 /**
  * @file tabbed_deck_view_container.h
  * @ingroup Lobby
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TABBED_DECK_VIEW_CONTAINER_H
 #define TABBED_DECK_VIEW_CONTAINER_H

--- a/cockatrice/src/game/dialogs/dlg_create_token.h
+++ b/cockatrice/src/game/dialogs/dlg_create_token.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_create_token.h
  * @ingroup GameDialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_CREATETOKEN_H
 #define DLG_CREATETOKEN_H

--- a/cockatrice/src/game/dialogs/dlg_move_top_cards_until.h
+++ b/cockatrice/src/game/dialogs/dlg_move_top_cards_until.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_move_top_cards_until.h
  * @ingroup GameDialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_MOVE_TOP_CARDS_UNTIL_H
 #define DLG_MOVE_TOP_CARDS_UNTIL_H

--- a/cockatrice/src/game/dialogs/dlg_roll_dice.h
+++ b/cockatrice/src/game/dialogs/dlg_roll_dice.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_roll_dice.h
  * @ingroup GameDialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_ROLL_DICE_H
 #define DLG_ROLL_DICE_H

--- a/cockatrice/src/game/game.h
+++ b/cockatrice/src/game/game.h
@@ -1,8 +1,8 @@
 /**
  * @file game.h
  * @ingroup GameLogic
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_GAME_H
 #define COCKATRICE_GAME_H

--- a/cockatrice/src/game/game_event_handler.h
+++ b/cockatrice/src/game/game_event_handler.h
@@ -1,8 +1,8 @@
 /**
  * @file game_event_handler.h
  * @ingroup GameLogic
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_GAME_EVENT_HANDLER_H
 #define COCKATRICE_GAME_EVENT_HANDLER_H

--- a/cockatrice/src/game/game_meta_info.h
+++ b/cockatrice/src/game/game_meta_info.h
@@ -1,8 +1,8 @@
 /**
  * @file game_meta_info.h
  * @ingroup GameLogic
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef GAME_META_INFO_H
 #define GAME_META_INFO_H

--- a/cockatrice/src/game/game_scene.h
+++ b/cockatrice/src/game/game_scene.h
@@ -56,10 +56,12 @@ private:
      */
     void updateHover(const QPointF &scenePos);
 
-    /// Activates hover state and escapes the card from its clip container so hover scaling is visible beyond zone
-    /// bounds.
+    /**
+     * @brief Activates hover state and escapes the card from its clip container
+     * so hover scaling is visible beyond zone bounds.
+     */
     void beginCardHover(CardItem *card);
-    /// Deactivates hover state and restores the card to its clip container.
+    /** @brief Deactivates hover state and restores the card to its clip container. */
     void endCardHover(CardItem *card);
 
 public:
@@ -70,13 +72,13 @@ public:
      */
     explicit GameScene(PhasesToolbar *_phasesToolbar, QObject *parent = nullptr);
 
-    /** Destructor, cleans up timer and zone views. */
+    /** @brief Destructor, cleans up timer and zone views. */
     ~GameScene() override;
 
-    /** Updates UI text for all zone views. */
+    /** @brief Updates UI text for all zone views. */
     void retranslateUi();
 
-    /** Gets all selected CardItems */
+    /** @brief Gets all selected CardItems. */
     QList<CardItem *> selectedCards() const;
 
     /**
@@ -97,7 +99,7 @@ public:
      */
     void adjustPlayerRotation(int rotationAdjustment);
 
-    /** Recomputes the layout of players and the scene size. */
+    /** @brief Recomputes the layout of players and the scene size. */
     void rearrange();
 
     /**
@@ -157,50 +159,50 @@ public:
      */
     void resizeColumnsAndPlayers(const QList<qreal> &minWidthByColumn, qreal newWidth);
 
-    /** Finds the topmost card zone under the cursor. */
+    /** @brief Finds the topmost card zone under the cursor. */
     static CardZone *findTopmostZone(const QList<QGraphicsItem *> &items);
 
-    /** Finds the topmost card in a given zone, considering attachments and Z-order. */
+    /** @brief Finds the topmost card in a given zone, considering attachments and Z-order. */
     static CardItem *findTopmostCardInZone(const QList<QGraphicsItem *> &items, CardZone *zone);
 
-    /** Updates hovered card highlighting. */
+    /** @brief Updates hovered card highlighting. */
     void updateHoveredCard(CardItem *newCard);
 
-    /** Registers a card for animation updates. */
+    /** @brief Registers a card for animation updates. */
     void registerAnimationItem(AbstractCardItem *card);
 
-    /** Unregisters a card from animation updates. */
+    /** @brief Unregisters a card from animation updates. */
     void unregisterAnimationItem(AbstractCardItem *card);
     void startRubberBand(const QPointF &selectionOrigin);
     void resizeRubberBand(const QPointF &cursorPoint, int selectedCount);
     void stopRubberBand();
 
 public slots:
-    /** Toggles a zone view for a player. */
+    /** @brief Toggles a zone view for a player. */
     void toggleZoneView(PlayerLogic *player, const QString &zoneName, int numberCards, bool isReversed = false);
 
-    /** Adds a revealed zone view (for shown cards). */
+    /** @brief Adds a revealed zone view (for shown cards). */
     void addRevealedZoneView(PlayerLogic *player,
                              CardZoneLogic *zone,
                              const QList<const ServerInfo_Card *> &cardList,
                              bool withWritePermission);
 
-    /** Removes a zone view widget from the scene. */
+    /** @brief Removes a zone view widget from the scene. */
     void removeZoneView(ZoneViewWidget *item);
 
-    /** Closes all zone views. */
+    /** @brief Closes all zone views. */
     void clearViews();
 
-    /** Closes the most recently added zone view. */
+    /** @brief Closes the most recently added zone view. */
     void closeMostRecentZoneView();
     QTransform getViewTransform() const;
     QTransform getViewportTransform() const;
 
 protected:
-    /** Handles hover updates. */
+    /** @brief Handles hover updates. */
     bool event(QEvent *event) override;
 
-    /** Handles animation timer updates. */
+    /** @brief Handles animation timer updates. */
     void timerEvent(QTimerEvent *event) override;
 
 signals:

--- a/cockatrice/src/game/game_state.h
+++ b/cockatrice/src/game/game_state.h
@@ -1,8 +1,8 @@
 /**
  * @file game_state.h
  * @ingroup GameLogic
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_GAME_STATE_H
 #define COCKATRICE_GAME_STATE_H

--- a/cockatrice/src/game/game_view.h
+++ b/cockatrice/src/game/game_view.h
@@ -1,8 +1,8 @@
 /**
  * @file game_view.h
  * @ingroup GameGraphics
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef GAMEVIEW_H
 #define GAMEVIEW_H

--- a/cockatrice/src/game/hand_counter.h
+++ b/cockatrice/src/game/hand_counter.h
@@ -1,8 +1,8 @@
 /**
  * @file hand_counter.h
  * @ingroup GameGraphicsPlayers
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef HANDCOUNTER_H
 #define HANDCOUNTER_H

--- a/cockatrice/src/game/log/message_log_widget.h
+++ b/cockatrice/src/game/log/message_log_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file message_log_widget.h
  * @ingroup GameWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef MESSAGELOGWIDGET_H
 #define MESSAGELOGWIDGET_H

--- a/cockatrice/src/game/phase.h
+++ b/cockatrice/src/game/phase.h
@@ -1,8 +1,8 @@
 /**
  * @file phase.h
  * @ingroup GameLogic
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef PHASE_H
 #define PHASE_H

--- a/cockatrice/src/game/phases_toolbar.h
+++ b/cockatrice/src/game/phases_toolbar.h
@@ -2,8 +2,8 @@
  * @file phases_toolbar.h
  * @ingroup GameGraphics
  * @ingroup GameWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef PHASESTOOLBAR_H
 #define PHASESTOOLBAR_H

--- a/cockatrice/src/game/player/card_menu_action_type.h
+++ b/cockatrice/src/game/player/card_menu_action_type.h
@@ -1,8 +1,8 @@
 /**
  * @file card_menu_action_type.h
  * @ingroup GameMenusPlayers
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_CARD_MENU_ACTION_TYPE_H
 #define COCKATRICE_CARD_MENU_ACTION_TYPE_H

--- a/cockatrice/src/game/player/event_processing_options.h
+++ b/cockatrice/src/game/player/event_processing_options.h
@@ -1,8 +1,8 @@
 /**
  * @file event_processing_options.h
  * @ingroup GameLogicPlayers
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_EVENT_PROCESSING_OPTIONS_H
 #define COCKATRICE_EVENT_PROCESSING_OPTIONS_H

--- a/cockatrice/src/game/player/menu/abstract_player_component.h
+++ b/cockatrice/src/game/player/menu/abstract_player_component.h
@@ -19,13 +19,13 @@ class AbstractPlayerComponent
 public:
     virtual ~AbstractPlayerComponent() = default;
 
-    /// Bind keyboard shortcuts. Called when this player gains focus.
+    /** @brief Bind keyboard shortcuts. Called when this player gains focus. */
     virtual void setShortcutsActive() = 0;
 
-    /// Unbind keyboard shortcuts. Called when this player loses focus.
+    /** @brief Unbind keyboard shortcuts. Called when this player loses focus. */
     virtual void setShortcutsInactive() = 0;
 
-    /// Retranslate all user-visible strings. Called on language change.
+    /** @brief Retranslate all user-visible strings. Called on language change. */
     virtual void retranslateUi() = 0;
 };
 

--- a/cockatrice/src/game/player/menu/card_menu.h
+++ b/cockatrice/src/game/player/menu/card_menu.h
@@ -1,8 +1,8 @@
 /**
  * @file card_menu.h
  * @ingroup GameMenusCards
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_CARD_MENU_H
 #define COCKATRICE_CARD_MENU_H

--- a/cockatrice/src/game/player/menu/custom_zone_menu.h
+++ b/cockatrice/src/game/player/menu/custom_zone_menu.h
@@ -1,8 +1,8 @@
 /**
  * @file custom_zone_menu.h
  * @ingroup GameMenusZones
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_CUSTOM_ZONE_MENU_H
 #define COCKATRICE_CUSTOM_ZONE_MENU_H

--- a/cockatrice/src/game/player/menu/grave_menu.h
+++ b/cockatrice/src/game/player/menu/grave_menu.h
@@ -1,8 +1,8 @@
 /**
  * @file grave_menu.h
  * @ingroup GameMenusZones
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_GRAVE_MENU_H
 #define COCKATRICE_GRAVE_MENU_H

--- a/cockatrice/src/game/player/menu/hand_menu.h
+++ b/cockatrice/src/game/player/menu/hand_menu.h
@@ -1,8 +1,8 @@
 /**
  * @file hand_menu.h
  * @ingroup GameMenusZones
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_HAND_MENU_H
 #define COCKATRICE_HAND_MENU_H

--- a/cockatrice/src/game/player/menu/library_menu.h
+++ b/cockatrice/src/game/player/menu/library_menu.h
@@ -1,8 +1,8 @@
 /**
  * @file library_menu.h
  * @ingroup GameMenusZones
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_LIBRARY_MENU_H
 #define COCKATRICE_LIBRARY_MENU_H

--- a/cockatrice/src/game/player/menu/move_menu.h
+++ b/cockatrice/src/game/player/menu/move_menu.h
@@ -1,8 +1,8 @@
 /**
  * @file move_menu.h
  * @ingroup GameMenusZones
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_MOVE_MENU_H
 #define COCKATRICE_MOVE_MENU_H

--- a/cockatrice/src/game/player/menu/player_menu.h
+++ b/cockatrice/src/game/player/menu/player_menu.h
@@ -87,7 +87,8 @@ private:
     CustomZoneMenu *customZonesMenu;
 
     /** @brief Drives AbstractPlayerComponent lifecycle delegation. Counters are iterated separately via
-     * player->getCounters(). */
+     * player->getCounters().
+     */
     QList<AbstractPlayerComponent *> managedComponents;
     bool shortcutsActive = false;
 

--- a/cockatrice/src/game/player/menu/player_menu.h
+++ b/cockatrice/src/game/player/menu/player_menu.h
@@ -38,7 +38,7 @@ private slots:
 
 public:
     explicit PlayerMenu(PlayerLogic *player);
-    /// Lifecycle methods: delegate to all managedComponents, plus counters separately via player->getCounters().
+    /** @brief Retranslate all user-visible strings. Called on language change. */
     void retranslateUi();
 
     QMenu *updateCardMenu(const CardItem *card);
@@ -68,9 +68,9 @@ public:
         return shortcutsActive;
     }
 
-    /// Delegates to all managedComponents, plus counters separately.
+    /** @brief Bind keyboard shortcuts. Called when this player gains focus. */
     void setShortcutsActive();
-    /// Delegates to all managedComponents, plus counters separately.
+    /** @brief Unbind keyboard shortcuts. Called when this player loses focus. */
     void setShortcutsInactive();
 
 private:
@@ -86,11 +86,12 @@ private:
     SayMenu *sayMenu;
     CustomZoneMenu *customZonesMenu;
 
-    /// Drives AbstractPlayerComponent lifecycle delegation. Counters are iterated separately via player->getCounters().
+    /** @brief Drives AbstractPlayerComponent lifecycle delegation. Counters are iterated separately via
+     * player->getCounters(). */
     QList<AbstractPlayerComponent *> managedComponents;
     bool shortcutsActive = false;
 
-    /// Creates component, adds it as a submenu of playerMenu, and registers in managedComponents.
+    /** @brief Creates component, adds it as a submenu of playerMenu, and registers in managedComponents. */
     template <typename MenuT, typename... Args> MenuT *addManagedMenu(Args &&...args)
     {
         auto *menu = new MenuT(std::forward<Args>(args)...);
@@ -99,7 +100,7 @@ private:
         return menu;
     }
 
-    /// Creates component and registers in managedComponents, but does NOT add it as a submenu.
+    /** @brief Creates component and registers in managedComponents, but does NOT add it as a submenu. */
     template <typename ComponentT, typename... Args> ComponentT *createManagedComponent(Args &&...args)
     {
         auto *component = new ComponentT(std::forward<Args>(args)...);

--- a/cockatrice/src/game/player/menu/pt_menu.h
+++ b/cockatrice/src/game/player/menu/pt_menu.h
@@ -1,8 +1,8 @@
 /**
  * @file pt_menu.h
  * @ingroup GameMenusCards
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_PT_MENU_H
 #define COCKATRICE_PT_MENU_H

--- a/cockatrice/src/game/player/menu/rfg_menu.h
+++ b/cockatrice/src/game/player/menu/rfg_menu.h
@@ -1,8 +1,8 @@
 /**
  * @file rfg_menu.h
  * @ingroup GameMenusZones
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_RFG_MENU_H
 #define COCKATRICE_RFG_MENU_H

--- a/cockatrice/src/game/player/menu/say_menu.h
+++ b/cockatrice/src/game/player/menu/say_menu.h
@@ -1,8 +1,8 @@
 /**
  * @file say_menu.h
  * @ingroup GameMenusPlayers
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_SAY_MENU_H
 #define COCKATRICE_SAY_MENU_H

--- a/cockatrice/src/game/player/menu/sideboard_menu.h
+++ b/cockatrice/src/game/player/menu/sideboard_menu.h
@@ -1,8 +1,8 @@
 /**
  * @file sideboard_menu.h
  * @ingroup GameMenusZones
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_SIDEBOARD_MENU_H
 #define COCKATRICE_SIDEBOARD_MENU_H

--- a/cockatrice/src/game/player/menu/utility_menu.h
+++ b/cockatrice/src/game/player/menu/utility_menu.h
@@ -1,8 +1,8 @@
 /**
  * @file utility_menu.h
  * @ingroup GameMenusPlayers
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_UTILITY_MENU_H
 #define COCKATRICE_UTILITY_MENU_H

--- a/cockatrice/src/game/player/player_actions.h
+++ b/cockatrice/src/game/player/player_actions.h
@@ -2,8 +2,8 @@
  * @file player_actions.h
  *  @ingroup GameLogicActions
  * @ingroup GameLogicPlayers
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_PLAYER_ACTIONS_H
 #define COCKATRICE_PLAYER_ACTIONS_H

--- a/cockatrice/src/game/player/player_area.h
+++ b/cockatrice/src/game/player/player_area.h
@@ -1,8 +1,8 @@
 /**
  * @file player_area.h
  * @ingroup GameGraphicsPlayers
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_PLAYER_AREA_H
 #define COCKATRICE_PLAYER_AREA_H

--- a/cockatrice/src/game/player/player_event_handler.h
+++ b/cockatrice/src/game/player/player_event_handler.h
@@ -1,8 +1,8 @@
 /**
  * @file player_event_handler.h
  * @ingroup GameLogicPlayers
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_PLAYER_EVENT_HANDLER_H
 #define COCKATRICE_PLAYER_EVENT_HANDLER_H

--- a/cockatrice/src/game/player/player_graphics_item.h
+++ b/cockatrice/src/game/player/player_graphics_item.h
@@ -1,8 +1,8 @@
 /**
  * @file player_graphics_item.h
  * @ingroup GameGraphicsPlayers
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_PLAYER_GRAPHICS_ITEM_H
 #define COCKATRICE_PLAYER_GRAPHICS_ITEM_H

--- a/cockatrice/src/game/player/player_info.h
+++ b/cockatrice/src/game/player/player_info.h
@@ -1,8 +1,8 @@
 /**
  * @file player_info.h
  * @ingroup GameLogicPlayers
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_PLAYER_INFO_H
 #define COCKATRICE_PLAYER_INFO_H

--- a/cockatrice/src/game/player/player_list_widget.h
+++ b/cockatrice/src/game/player/player_list_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file player_list_widget.h
  * @ingroup GameWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef PLAYERLISTWIDGET_H
 #define PLAYERLISTWIDGET_H

--- a/cockatrice/src/game/player/player_logic.h
+++ b/cockatrice/src/game/player/player_logic.h
@@ -1,8 +1,8 @@
 /**
  * @file player.h
  * @ingroup GameLogicPlayers
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef PLAYER_H
 #define PLAYER_H

--- a/cockatrice/src/game/player/player_manager.h
+++ b/cockatrice/src/game/player/player_manager.h
@@ -1,8 +1,8 @@
 /**
  * @file player_manager.h
  * @ingroup GameLogicPlayers
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_PLAYER_MANAGER_H
 #define COCKATRICE_PLAYER_MANAGER_H

--- a/cockatrice/src/game/player/player_target.h
+++ b/cockatrice/src/game/player/player_target.h
@@ -1,8 +1,8 @@
 /**
  * @file player_target.h
  * @ingroup GameGraphicsPlayers
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef PLAYERTARGET_H
 #define PLAYERTARGET_H

--- a/cockatrice/src/game/replay.h
+++ b/cockatrice/src/game/replay.h
@@ -2,8 +2,8 @@
  * @file replay.h
  * @ingroup GameLogic
  * @ingroup Replay
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_REPLAY_H
 #define COCKATRICE_REPLAY_H

--- a/cockatrice/src/game/z_value_layer_manager.h
+++ b/cockatrice/src/game/z_value_layer_manager.h
@@ -66,12 +66,9 @@ namespace ZValueLayerManager
  */
 enum class Layer
 {
-    /// Zone-level elements like backgrounds and containers
-    Zone,
-    /// Cards rendered in zones (uses sequential Z-values)
-    Card,
-    /// Temporary UI elements like hovered cards and drag items
-    Overlay
+    Zone,   ///< Zone-level elements like backgrounds and containers.
+    Card,   ///< Cards rendered in zones (uses sequential Z-values).
+    Overlay ///< Temporary UI elements like hovered cards and drag items.
 };
 
 /**

--- a/cockatrice/src/game/zones/card_zone_logic.h
+++ b/cockatrice/src/game/zones/card_zone_logic.h
@@ -1,8 +1,8 @@
 /**
  * @file card_zone_logic.h
  * @ingroup GameLogicZones
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_CARD_ZONE_LOGIC_H
 #define COCKATRICE_CARD_ZONE_LOGIC_H

--- a/cockatrice/src/game/zones/hand_zone_logic.h
+++ b/cockatrice/src/game/zones/hand_zone_logic.h
@@ -1,8 +1,8 @@
 /**
  * @file hand_zone_logic.h
  * @ingroup GameLogicZones
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_HAND_ZONE_LOGIC_H
 #define COCKATRICE_HAND_ZONE_LOGIC_H

--- a/cockatrice/src/game/zones/pile_zone_logic.h
+++ b/cockatrice/src/game/zones/pile_zone_logic.h
@@ -1,8 +1,8 @@
 /**
  * @file pile_zone_logic.h
  * @ingroup GameLogicZones
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_PILE_ZONE_LOGIC_H
 #define COCKATRICE_PILE_ZONE_LOGIC_H

--- a/cockatrice/src/game/zones/stack_zone_logic.h
+++ b/cockatrice/src/game/zones/stack_zone_logic.h
@@ -1,8 +1,8 @@
 /**
  * @file stack_zone_logic.h
  * @ingroup GameLogicZones
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_STACK_ZONE_LOGIC_H
 #define COCKATRICE_STACK_ZONE_LOGIC_H

--- a/cockatrice/src/game/zones/table_zone_logic.h
+++ b/cockatrice/src/game/zones/table_zone_logic.h
@@ -1,8 +1,8 @@
 /**
  * @file table_zone_logic.h
  * @ingroup GameLogicZones
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_TABLE_ZONE_LOGIC_H
 #define COCKATRICE_TABLE_ZONE_LOGIC_H

--- a/cockatrice/src/game/zones/view_zone_logic.h
+++ b/cockatrice/src/game/zones/view_zone_logic.h
@@ -1,8 +1,8 @@
 /**
  * @file view_zone_logic.h
  * @ingroup GameLogicZones
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_VIEW_ZONE_LOGIC_H
 #define COCKATRICE_VIEW_ZONE_LOGIC_H

--- a/cockatrice/src/game_graphics/board/abstract_graphics_item.h
+++ b/cockatrice/src/game_graphics/board/abstract_graphics_item.h
@@ -1,8 +1,8 @@
 /**
  * @file abstract_graphics_item.h
  * @ingroup GameGraphics
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef ABSTRACTGRAPHICSITEM_H
 #define ABSTRACTGRAPHICSITEM_H

--- a/cockatrice/src/game_graphics/board/graphics_item_type.h
+++ b/cockatrice/src/game_graphics/board/graphics_item_type.h
@@ -1,8 +1,8 @@
 /**
  * @file graphics_item_type.h
  * @ingroup GameGraphics
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_GRAPHICS_ITEM_TYPE_H
 #define COCKATRICE_GRAPHICS_ITEM_TYPE_H

--- a/cockatrice/src/game_graphics/zones/card_zone.h
+++ b/cockatrice/src/game_graphics/zones/card_zone.h
@@ -40,9 +40,12 @@ protected:
     }
 public slots:
     bool showContextMenu(const QPoint &screenPos);
-    /// @brief Called when a card is added to this zone. Default: reparents card to this item.
-    /// Virtual so subclasses (e.g. SelectZone) can override parenting behavior — the Qt signal
-    /// connection in CardZone's constructor dispatches through the vtable.
+    /**
+     * @brief Called when a card is added to this zone. Default: reparents card to this item.
+     *
+     * Virtual so subclasses (e.g. SelectZone) can override parenting behavior — the Qt signal
+     * connection in CardZone's constructor dispatches through the vtable.
+     */
     virtual void onCardAdded(CardItem *addedCard);
 
 public:

--- a/cockatrice/src/game_graphics/zones/pile_zone.h
+++ b/cockatrice/src/game_graphics/zones/pile_zone.h
@@ -1,8 +1,8 @@
 /**
  * @file pile_zone.h
  * @ingroup GameGraphicsZones
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef PILEZONE_H
 #define PILEZONE_H

--- a/cockatrice/src/game_graphics/zones/select_zone.h
+++ b/cockatrice/src/game_graphics/zones/select_zone.h
@@ -21,33 +21,41 @@ class SelectZone : public CardZone
 {
     Q_OBJECT
 public:
-    /// Finds the SelectZone that owns a card, regardless of whether the card is parented
-    /// to the zone directly or to its clip container. Returns nullptr if not in a SelectZone.
+    /**
+     * @brief Finds the SelectZone that owns a card, regardless of whether the card is parented
+     * to the zone directly or to its clip container. Returns nullptr if not in a SelectZone.
+     */
     static SelectZone *findOwningSelectZone(const QGraphicsItem *card);
 
     SelectZone(CardZoneLogic *logic, QGraphicsItem *parent = nullptr);
     ~SelectZone() override;
     void onCardAdded(CardItem *addedCard) override;
 
-    /// @brief Temporarily reparents a card from the clip container to this zone so hover scaling is visible beyond clip
-    /// bounds. Safe no-op if no clip container exists. Coordinates are preserved (clip container is at (0,0) with no
-    /// transform).
+    /**
+     * @brief Temporarily reparents a card from the clip container to this zone so hover scaling is visible beyond clip
+     * bounds. Safe no-op if no clip container exists. Coordinates are preserved (clip container is at (0,0) with no
+     * transform).
+     */
     void escapeClipForHover(QGraphicsItem *card);
-    /// @brief Restores a hover-escaped card back to the clip container. Guards against zone transitions that already
-    /// reparented the card.
+    /**
+     * @brief Restores a hover-escaped card back to the clip container. Guards against zone transitions that already
+     * reparented the card.
+     */
     void restoreClipAfterHover(QGraphicsItem *card);
 
 private:
     QPointF selectionOrigin;
     QSet<CardItem *> cardsInSelectionRect;
-    /// Invisible clipping parent for cards; owned by Qt parent-child tree (parented to this zone).
-    /// Created by setupClipContainer(); null when no clip container is active.
+    /**
+     * @brief Invisible clipping parent for cards; owned by Qt parent-child tree (parented to this zone).
+     * Created by setupClipContainer(); null when no clip container is active.
+     */
     QGraphicsRectItem *cardClipContainer = nullptr;
 
 protected:
     // -- Layout computation --
 
-    /// Parameters describing a vertical card stack's geometry.
+    /** @brief Parameters describing a vertical card stack's geometry. */
     struct StackLayoutParams
     {
         int cardCount;         ///< Number of cards in the stack
@@ -55,21 +63,23 @@ protected:
         qreal cardHeight;      ///< Height of a single card
         qreal desiredOffset;   ///< Preferred vertical offset between card tops
         qreal minOffset = 0.0; ///< Minimum offset to preserve (0 allows full compression)
-        /// When false (default), reserves full cardHeight for the bottom card, ensuring
-        /// all cards remain within zone bounds. When true, allows the bottom card to
-        /// partially overflow using sqrt-scaled allowance. Use with setupClipContainer()
-        /// for zones too short to fit a full card.
+        /**
+         * @brief When false (default), reserves full cardHeight for the bottom card, ensuring
+         * all cards remain within zone bounds. When true, allows the bottom card to
+         * partially overflow using sqrt-scaled allowance. Use with setupClipContainer()
+         * for zones too short to fit a full card.
+         */
         bool allowBottomOverflow = false;
     };
 
-    /// Result of computing a vertical stack layout.
+    /** @brief Result of computing a vertical stack layout. */
     struct ZoneLayout
     {
         qreal effectiveOffset; ///< Actual offset between card tops (may be compressed)
         qreal start;           ///< Y coordinate of the first card's top edge
     };
 
-    /// Minimum visible pixels of each card's top edge when stacking compresses offsets in tight zones.
+    /** @brief Minimum visible pixels of each card's top edge when stacking compresses offsets in tight zones. */
     static constexpr qreal MIN_CARD_VISIBLE = 10.0;
 
     /**
@@ -88,11 +98,13 @@ protected:
      */
     static ZoneLayout computeZoneLayout(const StackLayoutParams &params);
 
-    /// Builds StackLayoutParams from the current card list and zone geometry.
+    /** @brief Builds StackLayoutParams from the current card list and zone geometry. */
     StackLayoutParams buildStackParams(qreal minOffset = 0.0) const;
 
-    /// Computes the card index at a given y-coordinate within the zone's vertical layout.
-    /// Returns 0 if the zone has no cards or the offset is zero.
+    /**
+     * @brief Computes the card index at a given y-coordinate within the zone's vertical layout.
+     * Returns 0 if the zone has no cards or the offset is zero.
+     */
     int calcDropIndexFromY(qreal dropY, qreal minOffset = 0.0) const;
 
     /**
@@ -111,17 +123,21 @@ protected:
     // (e.g., zones too short to fit a full card). To enable: call setupClipContainer() in the
     // zone's constructor, and set allowBottomOverflow=true in layout params.
 
-    /// Restores any cards that were hover-escaped but whose hover state was not properly cleaned up.
-    /// Call at the start of reorganizeCards() in zones that use a clip container.
+    /**
+     * @brief Restores any cards that were hover-escaped but whose hover state was not properly cleaned up.
+     * Call at the start of reorganizeCards() in zones that use a clip container.
+     */
     void restoreStaleEscapedCards();
 
-    /// Creates a clip container child item that clips card overflow to zone bounds.
-    /// Cards entering this zone are reparented to this container by the onCardAdded override.
-    /// Disables zone-level child clipping; clipping is delegated to the container.
-    /// @param zValue Optional z-value for the clip container (e.g. ZValues::CARD_BASE)
+    /**
+     * @brief Creates a clip container child item that clips card overflow to zone bounds.
+     * Cards entering this zone are reparented to this container by the onCardAdded override.
+     * Disables zone-level child clipping; clipping is delegated to the container.
+     * @param zValue Optional z-value for the clip container (e.g. ZValues::CARD_BASE)
+     */
     void setupClipContainer(std::optional<qreal> zValue = std::nullopt);
 
-    /// Updates the clip container rect to match this zone's current boundingRect().
+    /** @brief Updates the clip container rect to match this zone's current boundingRect(). */
     void updateClipRect();
 
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;

--- a/cockatrice/src/game_graphics/zones/stack_zone.h
+++ b/cockatrice/src/game_graphics/zones/stack_zone.h
@@ -20,7 +20,7 @@ private slots:
 
 public:
     StackZone(StackZoneLogic *_logic, int _zoneHeight, QGraphicsItem *parent);
-    /// @brief Resizes the stack zone height, e.g. when sharing vertical space with the command zone.
+    /** @brief Resizes the stack zone height, e.g. when sharing vertical space with the command zone. */
     void setHeight(qreal newHeight);
     void
     handleDropEvent(const QList<CardDragItem *> &dragItems, CardZoneLogic *startZone, const QPoint &dropPoint) override;

--- a/cockatrice/src/game_graphics/zones/table_zone.h
+++ b/cockatrice/src/game_graphics/zones/table_zone.h
@@ -1,8 +1,8 @@
 /**
  * @file table_zone.h
  * @ingroup GameGraphicsZones
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TABLEZONE_H
 #define TABLEZONE_H
@@ -11,13 +11,12 @@
 #include "../../game/zones/table_zone_logic.h"
 #include "select_zone.h"
 
-/*
- * TableZone is the grid based rect where CardItems may be placed.
- * It is the main play zone and can be customized with background images.
+/**
+ * @brief TableZone is the grid based rect where CardItems may be placed.
  *
- * TODO: Refactor methods to make more readable, extract some logic to
- * private methods (Im looking at you TableZone::reorganizeCards())
+ * It is the main play zone and can be customized with background images.
  */
+//! \todo Refactor methods to make more readable, extract logic to private methods (especially reorganizeCards()).
 class TableZone : public SelectZone
 {
     Q_OBJECT

--- a/cockatrice/src/game_graphics/zones/view_zone.h
+++ b/cockatrice/src/game_graphics/zones/view_zone.h
@@ -1,8 +1,8 @@
 /**
  * @file view_zone.h
  * @ingroup GameGraphicsZones
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef ZONEVIEWERZONE_H
 #define ZONEVIEWERZONE_H

--- a/cockatrice/src/game_graphics/zones/view_zone_widget.h
+++ b/cockatrice/src/game_graphics/zones/view_zone_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file view_zone_widget.h
  * @ingroup GameGraphicsZones
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 #ifndef ZONEVIEWWIDGET_H
 #define ZONEVIEWWIDGET_H
 

--- a/cockatrice/src/interface/card_picture_loader/card_picture_to_load.cpp
+++ b/cockatrice/src/interface/card_picture_loader/card_picture_to_load.cpp
@@ -53,12 +53,12 @@ QList<CardSetPtr> CardPictureToLoad::extractSetsSorted(const ExactCard &card)
  * PrintingInfo for the set is returned.
  *
  * This method only exists to maintain existing behavior.
- * TODO: check if going through all sets is still necessary after the ExactCard refactor.
  *
  * @param card The card to look in
  * @param setName The set's short name
  * @return A PrintingInfo, or a default-constructed PrintingInfo if the set name is not in the CardInfo.
  */
+//! \todo Check if going through all sets is still necessary after the ExactCard refactor.
 static PrintingInfo findPrintingForSet(const ExactCard &card, const QString &setName)
 {
     SetToPrintingsMap setsToPrintings = card.getInfo().getSets();

--- a/cockatrice/src/interface/deck_loader/deck_loader.h
+++ b/cockatrice/src/interface/deck_loader/deck_loader.h
@@ -1,8 +1,8 @@
 /**
  * @file deck_loader.h
  * @ingroup ImportExport
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DECK_LOADER_H
 #define DECK_LOADER_H

--- a/cockatrice/src/interface/key_signals.h
+++ b/cockatrice/src/interface/key_signals.h
@@ -2,8 +2,8 @@
  * @file key_signals.h
  * @ingroup Core
  * @ingroup UI
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef KEYSIGNALS_H
 #define KEYSIGNALS_H

--- a/cockatrice/src/interface/layouts/flow_layout.h
+++ b/cockatrice/src/interface/layouts/flow_layout.h
@@ -4,6 +4,7 @@
  * @brief A QLayout subclass that arranges child widgets in wrapping rows (horizontal flow)
  *        or wrapping columns (vertical flow).
  */
+//! \todo Document this file.
 
 #ifndef FLOW_LAYOUT_H
 #define FLOW_LAYOUT_H

--- a/cockatrice/src/interface/layouts/overlap_layout.cpp
+++ b/cockatrice/src/interface/layouts/overlap_layout.cpp
@@ -223,7 +223,7 @@ void OverlapLayout::setGeometry(const QRect &rect)
         const int yPos = rect.top() + currentRow * (maxItemHeight - overlapOffsetHeight);
         item->setGeometry(QRect(xPos, yPos, maxItemWidth, maxItemHeight));
 
-        // TODO: Figure this out properly or maybe adjust size hint to account for this?
+        //! \todo Figure this out properly or maybe adjust size hint to account for this.
         // Update row and column indices based on the layout direction.
         if (overlapDirection == Qt::Horizontal) {
             currentColumn++;

--- a/cockatrice/src/interface/layouts/overlap_layout.h
+++ b/cockatrice/src/interface/layouts/overlap_layout.h
@@ -1,8 +1,8 @@
 /**
  * @file overlap_layout.h
  * @ingroup UI
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef OVERLAP_LAYOUT_H
 #define OVERLAP_LAYOUT_H

--- a/cockatrice/src/interface/logger.h
+++ b/cockatrice/src/interface/logger.h
@@ -1,8 +1,8 @@
 /**
  * @file logger.h
  * @ingroup Core
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef LOGGER_H
 #define LOGGER_H

--- a/cockatrice/src/interface/pixel_map_generator.h
+++ b/cockatrice/src/interface/pixel_map_generator.h
@@ -1,8 +1,8 @@
 /**
  * @file pixel_map_generator.h
  * @ingroup UI
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef PIXMAPGENERATOR_H
 #define PIXMAPGENERATOR_H

--- a/cockatrice/src/interface/theme_manager.cpp
+++ b/cockatrice/src/interface/theme_manager.cpp
@@ -92,7 +92,7 @@ struct PaletteColorInfo
 ThemeManager::ThemeManager(QObject *parent) : QObject(parent)
 {
     defaultStyleName = qApp->style()->objectName();
-    // FIXME workaround for windows11 style being broken
+    //! \todo Workaround for windows11 style being broken.
     if (defaultStyleName == "windows11") {
         defaultStyleName = "windowsvista";
     }

--- a/cockatrice/src/interface/theme_manager.h
+++ b/cockatrice/src/interface/theme_manager.h
@@ -1,8 +1,8 @@
 /**
  * @file theme_manager.h
  * @ingroup CoreSettings
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef THEMEMANAGER_H
 #define THEMEMANAGER_H

--- a/cockatrice/src/interface/widgets/cards/additional_info/color_identity_widget.h
+++ b/cockatrice/src/interface/widgets/cards/additional_info/color_identity_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file color_identity_widget.h
  * @ingroup CardExtraInfoWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COLOR_IDENTITY_WIDGET_H
 #define COLOR_IDENTITY_WIDGET_H

--- a/cockatrice/src/interface/widgets/cards/additional_info/mana_cost_widget.h
+++ b/cockatrice/src/interface/widgets/cards/additional_info/mana_cost_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file mana_cost_widget.h
  * @ingroup CardExtraInfoWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef MANA_COST_WIDGET_H
 #define MANA_COST_WIDGET_H

--- a/cockatrice/src/interface/widgets/cards/additional_info/mana_symbol_widget.h
+++ b/cockatrice/src/interface/widgets/cards/additional_info/mana_symbol_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file mana_symbol_widget.h
  * @ingroup CardExtraInfoWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef MANA_SYMBOL_WIDGET_H
 #define MANA_SYMBOL_WIDGET_H

--- a/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file card_group_display_widget.h
  * @ingroup DeckEditorCardGroupWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARD_GROUP_DISPLAY_WIDGET_H
 #define CARD_GROUP_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/cards/card_group_display_widgets/flat_card_group_display_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_group_display_widgets/flat_card_group_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file flat_card_group_display_widget.h
  * @ingroup DeckEditorCardGroupWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef FLAT_CARD_GROUP_DISPLAY_WIDGET_H
 #define FLAT_CARD_GROUP_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/cards/card_group_display_widgets/overlapped_card_group_display_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_group_display_widgets/overlapped_card_group_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file overlapped_card_group_display_widget.h
  * @ingroup DeckEditorCardGroupWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef OVERLAPPED_CARD_GROUP_DISPLAY_WIDGET_H
 #define OVERLAPPED_CARD_GROUP_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/cards/card_info_display_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_info_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file card_info_display_widget.h
  * @ingroup CardWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARDINFOWIDGET_H
 #define CARDINFOWIDGET_H

--- a/cockatrice/src/interface/widgets/cards/card_info_frame_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_info_frame_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file card_info_frame_widget.h
  * @ingroup CardWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARDFRAME_H
 #define CARDFRAME_H

--- a/cockatrice/src/interface/widgets/cards/card_info_picture_art_crop_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_art_crop_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file card_info_picture_art_crop_widget.h
  * @ingroup CardWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARD_INFO_PICTURE_ART_CROP_WIDGET_H
 #define CARD_INFO_PICTURE_ART_CROP_WIDGET_H

--- a/cockatrice/src/interface/widgets/cards/card_info_picture_enlarged_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_enlarged_widget.h
@@ -2,8 +2,8 @@
  * @file card_info_picture_enlarged_widget.h
  * @ingroup CardWigets
  * @ingroup DeckEditorWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARD_PICTURE_ENLARGED_WIDGET_H
 #define CARD_PICTURE_ENLARGED_WIDGET_H

--- a/cockatrice/src/interface/widgets/cards/card_info_picture_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file card_info_picture_widget.h
  * @ingroup CardWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARD_INFO_PICTURE_H
 #define CARD_INFO_PICTURE_H

--- a/cockatrice/src/interface/widgets/cards/card_info_picture_with_text_overlay_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_with_text_overlay_widget.h
@@ -2,8 +2,8 @@
  * @file card_info_picture_with_text_overlay_widget.h
  * @ingroup CardWidgets
  * @ingroup DeckStorageWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARD_PICTURE_WITH_TEXT_OVERLAY_H
 #define CARD_PICTURE_WITH_TEXT_OVERLAY_H

--- a/cockatrice/src/interface/widgets/cards/card_info_text_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_info_text_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file card_info_text_widget.h
  * @ingroup CardWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARDINFOTEXT_H
 #define CARDINFOTEXT_H

--- a/cockatrice/src/interface/widgets/cards/card_size_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_size_widget.h
@@ -3,8 +3,8 @@
  * @ingroup CardWidgets
  * @ingroup DeckEditorWidgets
  * @ingroup DeckStorageWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARD_SIZE_WIDGET_H
 #define CARD_SIZE_WIDGET_H

--- a/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.h
+++ b/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file deck_card_zone_display_widget.h
  * @ingroup DeckEditorWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DECK_CARD_ZONE_DISPLAY_WIDGET_H
 #define DECK_CARD_ZONE_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/cards/deck_preview_card_picture_widget.h
+++ b/cockatrice/src/interface/widgets/cards/deck_preview_card_picture_widget.h
@@ -2,8 +2,8 @@
  * @file deck_preview_card_picture_widget.h
  * @ingroup CardWidgets
  * @ingroup Lobby
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DECK_PREVIEW_CARD_PICTURE_WIDGET_H
 #define DECK_PREVIEW_CARD_PICTURE_WIDGET_H

--- a/cockatrice/src/interface/widgets/deck_analytics/analyzer_modules/mana_base/mana_base_widget.h
+++ b/cockatrice/src/interface/widgets/deck_analytics/analyzer_modules/mana_base/mana_base_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file mana_base_widget.h
  * @ingroup DeckEditorAnalyticsWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef MANA_BASE_WIDGET_H
 #define MANA_BASE_WIDGET_H

--- a/cockatrice/src/interface/widgets/deck_analytics/analyzer_modules/mana_curve/mana_curve_widget.h
+++ b/cockatrice/src/interface/widgets/deck_analytics/analyzer_modules/mana_curve/mana_curve_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file mana_curve_widget.h
  * @ingroup DeckEditorAnalyticsWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef MANA_CURVE_WIDGET_H
 #define MANA_CURVE_WIDGET_H

--- a/cockatrice/src/interface/widgets/deck_analytics/analyzer_modules/mana_curve/mana_curve_widget.h
+++ b/cockatrice/src/interface/widgets/deck_analytics/analyzer_modules/mana_curve/mana_curve_widget.h
@@ -37,7 +37,7 @@ public:
     {
         config = ManaCurveConfig::fromJson(o);
         updateDisplay();
-    };
+    }
 
     QJsonObject extractConfigFromDialog(QDialog *dlg) const override;
 

--- a/cockatrice/src/interface/widgets/deck_analytics/analyzer_modules/mana_devotion/mana_devotion_widget.h
+++ b/cockatrice/src/interface/widgets/deck_analytics/analyzer_modules/mana_devotion/mana_devotion_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file mana_devotion_widget.h
  * @ingroup DeckEditorAnalyticsWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef MANA_DEVOTION_WIDGET_H
 #define MANA_DEVOTION_WIDGET_H

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -531,7 +531,7 @@ void DeckEditorDeckDockWidget::changeSelectedCard(int changeBy)
     // currentIndex will return an index for the underlying deckModel instead of the proxy.
     // That index will return an invalid index when indexBelow/indexAbove crosses a header node,
     // causing the selection to fail to move down.
-    /** @todo Figure out why it's happening so we can do a proper fix instead of a hacky workaround. */
+    //! \todo Figure out why it's happening so we can do a proper fix instead of a hacky workaround.
     if (deckViewCurrentIndex.model() == proxy->sourceModel()) {
         deckViewCurrentIndex = proxy->mapFromSource(deckViewCurrentIndex);
     }
@@ -635,8 +635,8 @@ void DeckEditorDeckDockWidget::actSwapSelection()
 {
     auto selectedRows = getSelectedCardNodeSourceIndices();
 
-    // hack to maintain the old reselection behavior when currently selected row of a single-selection gets deleted
-    // TODO: remove the hack and also handle reselection when all rows of a multi-selection gets deleted
+    //! \todo Remove the hack and also handle reselection when all rows of a multi-selection gets deleted.
+    // Hack: maintains old reselection behavior when single-selection row is deleted.
     if (selectedRows.length() == 1) {
         deckView->setSelectionMode(QAbstractItemView::SingleSelection);
     }
@@ -666,8 +666,8 @@ void DeckEditorDeckDockWidget::actDecrementSelection()
 {
     auto selectedRows = getSelectedCardNodeSourceIndices();
 
-    // hack to maintain the old reselection behavior when currently selected row of a single-selection gets deleted
-    // TODO: remove the hack and also handle reselection when all rows of a multi-selection gets deleted
+    //! \todo Remove the hack and also handle reselection when all rows of a multi-selection gets deleted.
+    // Hack: maintains old reselection behavior when single-selection row is deleted.
     if (selectedRows.length() == 1) {
         deckView->setSelectionMode(QAbstractItemView::SingleSelection);
     }
@@ -683,8 +683,8 @@ void DeckEditorDeckDockWidget::actRemoveCard()
 {
     auto selectedRows = getSelectedCardNodeSourceIndices();
 
-    // hack to maintain the old reselection behavior when currently selected row of a single-selection gets deleted
-    // TODO: remove the hack and also handle reselection when all rows of a multi-selection gets deleted
+    //! \todo Remove the hack and also handle reselection when all rows of a multi-selection gets deleted.
+    // Hack: maintains old reselection behavior when single-selection row is deleted.
     if (selectedRows.length() == 1) {
         deckView->setSelectionMode(QAbstractItemView::SingleSelection);
     }

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -531,7 +531,7 @@ void DeckEditorDeckDockWidget::changeSelectedCard(int changeBy)
     // currentIndex will return an index for the underlying deckModel instead of the proxy.
     // That index will return an invalid index when indexBelow/indexAbove crosses a header node,
     // causing the selection to fail to move down.
-    /// \todo Figure out why it's happening so we can do a proper fix instead of a hacky workaround
+    /** @todo Figure out why it's happening so we can do a proper fix instead of a hacky workaround. */
     if (deckViewCurrentIndex.model() == proxy->sourceModel()) {
         deckViewCurrentIndex = proxy->mapFromSource(deckViewCurrentIndex);
     }

--- a/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.h
@@ -154,9 +154,11 @@ public:
      */
     QModelIndex modifyDeck(const QString &reason, const std::function<QModelIndex(DeckListModel *)> &operation);
 
-    /// @name Metadata setters
-    /// @brief These methods set the metadata. Will no-op if the new value is the same as the current value.
-    /// Saves the operation to history if successful.
+    /**
+     * @name Metadata setters
+     * @brief These methods set the metadata. Will no-op if the new value is the same as the current value.
+     * Saves the operation to history if successful.
+     */
     ///@{
     void setName(const QString &name);
     void setComments(const QString &comments);

--- a/cockatrice/src/interface/widgets/dialogs/dlg_connect.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_connect.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_connect.h
  * @ingroup ConnectionDialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_CONNECT_H
 #define DLG_CONNECT_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_convert_deck_to_cod_format.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_convert_deck_to_cod_format.h
@@ -2,8 +2,8 @@
  * @file dlg_convert_deck_to_cod_format.h
  * @ingroup LocalDeckStorageDialogs
  * @ingroup Lobby
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DIALOG_CONVERT_DECK_TO_COD_FORMAT_H
 #define DIALOG_CONVERT_DECK_TO_COD_FORMAT_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_create_game.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_create_game.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_create_game.h
  * @ingroup RoomDialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_CREATEGAME_H
 #define DLG_CREATEGAME_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_default_tags_editor.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_default_tags_editor.h
@@ -2,8 +2,8 @@
  * @file dlg_default_tags_editor.h
  * @ingroup Dialogs
  * @ingroup DeckStorageWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_DEFAULT_TAGS_EDITOR_H
 #define DLG_DEFAULT_TAGS_EDITOR_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_edit_avatar.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_edit_avatar.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_edit_avatar.h
  * @ingroup AccountDialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_EDITAVATAR_H
 #define DLG_EDITAVATAR_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_edit_password.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_edit_password.cpp
@@ -59,7 +59,7 @@ DlgEditPassword::DlgEditPassword(QWidget *parent) : QDialog(parent)
 
 void DlgEditPassword::actOk()
 {
-    //! \todo this stuff should be using qvalidators
+    //! \todo This stuff should be using QValidators.
     if (newPasswordEdit->text().length() < 8) {
         QMessageBox::critical(this, tr("Error"), tr("Your password is too short."));
         return;

--- a/cockatrice/src/interface/widgets/dialogs/dlg_edit_password.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_edit_password.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_edit_password.h
  * @ingroup AccountDialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_EDITPASSWORD_H
 #define DLG_EDITPASSWORD_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_edit_tokens.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_edit_tokens.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_edit_tokens.h
  * @ingroup GameDialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_EDIT_TOKENS_H
 #define DLG_EDIT_TOKENS_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_edit_user.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_edit_user.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_edit user.h
  * @ingroup NetworkDialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_EDITUSER_H
 #define DLG_EDITUSER_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_filter_games.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_filter_games.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_filter_games.h
  * @ingroup RoomDialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_FILTER_GAMES_H
 #define DLG_FILTER_GAMES_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_forgot_password_challenge.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_forgot_password_challenge.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_forgot_password_challenge.h
  * @ingroup AccountDialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_FORGOTPASSWORDCHALLENGE_H
 #define DLG_FORGOTPASSWORDCHALLENGE_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_forgot_password_request.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_forgot_password_request.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_forgot_password_request.h
  * @ingroup AccountDialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_FORGOTPASSWORDREQUEST_H
 #define DLG_FORGOTPASSWORDREQUEST_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_forgot_password_reset.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_forgot_password_reset.cpp
@@ -121,7 +121,7 @@ void DlgForgotPasswordReset::actOk()
         return;
     }
 
-    //! \todo this stuff should be using qvalidators
+    //! \todo This stuff should be using QValidators.
     if (newpasswordEdit->text().length() < 8) {
         QMessageBox::critical(this, tr("Error"), tr("Your password is too short."));
         return;

--- a/cockatrice/src/interface/widgets/dialogs/dlg_forgot_password_reset.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_forgot_password_reset.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_forgot_password_reset.h
  * @ingroup AccountDialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_FORGOTPASSWORDRESET_H
 #define DLG_FORGOTPASSWORDRESET_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_load_deck.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_load_deck.h
@@ -2,8 +2,8 @@
  * @file dlg_load_deck.h
  * @ingroup LocalDeckStorageDialogs
  * @ingroup Lobby
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_LOAD_DECK_H
 #define DLG_LOAD_DECK_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_load_deck_from_clipboard.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_load_deck_from_clipboard.h
@@ -2,8 +2,8 @@
  * @file dlg_load_deck_from_clipboard.h
  * @ingroup LocalDeckStorageDialogs
  * @ingroup Lobby
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_LOAD_DECK_FROM_CLIPBOARD_H
 #define DLG_LOAD_DECK_FROM_CLIPBOARD_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_load_deck_from_website.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_load_deck_from_website.h
@@ -2,8 +2,8 @@
  * @file dlg_load_deck_from_website.h
  * @ingroup RemoteDeckStorageDialogs
  * @ingroup Lobby
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_LOAD_DECK_FROM_WEBSITE_H
 #define DLG_LOAD_DECK_FROM_WEBSITE_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_load_remote_deck.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_load_remote_deck.h
@@ -2,8 +2,8 @@
  * @file dlg_load_remote_deck.h
  * @ingroup RemoteDeckStorageDialogs
  * @ingroup Lobby
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_STARTGAME_H
 #define DLG_STARTGAME_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_manage_sets.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_manage_sets.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_manage_sets.h
  * @ingroup Dialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_MANAGE_SETS_H
 #define DLG_MANAGE_SETS_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_register.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_register.cpp
@@ -357,7 +357,7 @@ DlgRegister::DlgRegister(QWidget *parent) : QDialog(parent)
 
 void DlgRegister::actOk()
 {
-    //! \todo this stuff should be using qvalidators
+    //! \todo This stuff should be using QValidators.
     if (passwordEdit->text().length() < 8) {
         QMessageBox::critical(this, tr("Registration Warning"), tr("Your password is too short."));
         return;

--- a/cockatrice/src/interface/widgets/dialogs/dlg_register.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_register.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_register.h
  * @ingroup AccountDialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_REGISTER_H
 #define DLG_REGISTER_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_select_set_for_cards.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_select_set_for_cards.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_select_set_for_cards.h
  * @ingroup Dialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_SELECT_SET_FOR_CARDS_H
 #define DLG_SELECT_SET_FOR_CARDS_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_settings.cpp
@@ -206,7 +206,7 @@ void DlgSettings::closeEvent(QCloseEvent *event)
     }
 
     if (!QDir(SettingsCache::instance().getDeckPath()).exists() || SettingsCache::instance().getDeckPath().isEmpty()) {
-        //! \todo Prompt to create it
+        //! \todo Prompt to create the deck directory.
         if (QMessageBox::critical(
                 this, tr("Error"),
                 tr("The path to your deck directory is invalid. Would you like to go back and set the correct path?"),
@@ -217,7 +217,7 @@ void DlgSettings::closeEvent(QCloseEvent *event)
     }
 
     if (!QDir(SettingsCache::instance().getPicsPath()).exists() || SettingsCache::instance().getPicsPath().isEmpty()) {
-        //! \todo Prompt to create it
+        //! \todo Prompt to create the pictures directory.
         if (QMessageBox::critical(this, tr("Error"),
                                   tr("The path to your card pictures directory is invalid. Would you like to go back "
                                      "and set the correct path?"),

--- a/cockatrice/src/interface/widgets/dialogs/dlg_settings.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_settings.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_settings.h
  * @ingroup Dialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_SETTINGS_H
 #define DLG_SETTINGS_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_startup_card_check.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_startup_card_check.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_startup_card_check.h
  * @ingroup CardDatabaseUpdateDialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_STARTUP_CARD_CHECK_H
 #define DLG_STARTUP_CARD_CHECK_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_tip_of_the_day.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_tip_of_the_day.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_tip_of_the_day.h
  * @ingroup Dialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_TIPOFDAY_H
 #define DLG_TIPOFDAY_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_update.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_update.cpp
@@ -40,7 +40,7 @@ DlgUpdate::DlgUpdate(QWidget *parent) : QDialog(parent)
     buttonBox->addButton(ok, QDialogButtonBox::AcceptRole);
 
     connect(gotoDownload, &QPushButton::clicked, this, &DlgUpdate::gotoDownloadPage);
-    // TODO: make reinstall button actually do something when clicked
+    //! \todo Make reinstall button actually do something when clicked.
     // connect(manualDownload, &QPushButton::clicked, this, &DlgUpdate::downloadUpdate);
     connect(stopDownload, &QPushButton::clicked, this, &DlgUpdate::cancelDownload);
     connect(ok, &QPushButton::clicked, this, &DlgUpdate::closeDialog);

--- a/cockatrice/src/interface/widgets/dialogs/dlg_update.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_update.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_update.h
  * @ingroup ClientUpdateDialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_UPDATE_H
 #define DLG_UPDATE_H

--- a/cockatrice/src/interface/widgets/dialogs/dlg_view_log.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_view_log.h
@@ -1,8 +1,8 @@
 /**
  * @file dlg_view_log.h
  * @ingroup ServerLogDialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DLG_VIEWLOG_H
 #define DLG_VIEWLOG_H

--- a/cockatrice/src/interface/widgets/dialogs/tip_of_the_day.h
+++ b/cockatrice/src/interface/widgets/dialogs/tip_of_the_day.h
@@ -1,8 +1,8 @@
 /**
  * @file tip_of_the_day.h
  * @ingroup Dialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TIP_OF_DAY_H
 #define TIP_OF_DAY_H

--- a/cockatrice/src/interface/widgets/general/background_sources.h
+++ b/cockatrice/src/interface/widgets/general/background_sources.h
@@ -1,8 +1,8 @@
 /**
  * @file background_sources.h
  * @ingroup UI
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_BACKGROUND_SOURCES_H
 #define COCKATRICE_BACKGROUND_SOURCES_H

--- a/cockatrice/src/interface/widgets/general/display/banner_widget.h
+++ b/cockatrice/src/interface/widgets/general/display/banner_widget.h
@@ -3,8 +3,8 @@
  * @ingroup Widgets
  * @ingroup DeckEditorCardGroupWidgets
  * @ingroup DeckStorageWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef BANNER_WIDGET_H
 #define BANNER_WIDGET_H

--- a/cockatrice/src/interface/widgets/general/display/charts/bars/bar_widget.h
+++ b/cockatrice/src/interface/widgets/general/display/charts/bars/bar_widget.h
@@ -2,8 +2,8 @@
  * @file bar_widget.h
  * @ingroup Widgets
  * @ingroup DeckEditorAnalyticsWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef BAR_WIDGET_H
 #define BAR_WIDGET_H

--- a/cockatrice/src/interface/widgets/general/display/charts/bars/color_bar.h
+++ b/cockatrice/src/interface/widgets/general/display/charts/bars/color_bar.h
@@ -99,13 +99,13 @@ protected:
     void mouseMoveEvent(QMouseEvent *event) override;
 
 private:
-    /// Map of color keys to counts used for rendering.
+    /** @brief Map of color keys to counts used for rendering. */
     QList<QPair<QString, int>> colors;
 
-    /// True if the mouse is currently inside the widget.
+    /** @brief True if the mouse is currently inside the widget. */
     bool isHovered = false;
 
-    /// Minimum ratio a segment must exceed to be drawn.
+    /** @brief Minimum ratio a segment must exceed to be drawn. */
     double minRatioThreshold = 0.0;
 
     /**

--- a/cockatrice/src/interface/widgets/general/display/charts/bars/percent_bar_widget.h
+++ b/cockatrice/src/interface/widgets/general/display/charts/bars/percent_bar_widget.h
@@ -2,8 +2,8 @@
  * @file percent_bar_widget.h
  * @ingroup Widgets
  * @ingroup DeckEditorAnalyticsWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef PERCENT_BAR_WIDGET_H
 #define PERCENT_BAR_WIDGET_H

--- a/cockatrice/src/interface/widgets/general/display/dynamic_font_size_label.h
+++ b/cockatrice/src/interface/widgets/general/display/dynamic_font_size_label.h
@@ -1,8 +1,8 @@
 /**
  * @file dynamic_font_size_label.h
  * @ingroup Widgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DYNAMICFONTSIZELABEL_H
 #define DYNAMICFONTSIZELABEL_H

--- a/cockatrice/src/interface/widgets/general/display/dynamic_font_size_push_button.h
+++ b/cockatrice/src/interface/widgets/general/display/dynamic_font_size_push_button.h
@@ -1,8 +1,8 @@
 /**
  * @file dynamic_font_size_push_button.h
  * @ingroup PrintingWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DYNAMICFONTSIZEPUSHBUTTON_H
 #define DYNAMICFONTSIZEPUSHBUTTON_H

--- a/cockatrice/src/interface/widgets/general/display/labeled_input.h
+++ b/cockatrice/src/interface/widgets/general/display/labeled_input.h
@@ -1,8 +1,8 @@
 /**
  * @file labeled_input.h
  * @ingroup DeckEditorCardGroupWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef LABELED_INPUT_H
 #define LABELED_INPUT_H

--- a/cockatrice/src/interface/widgets/general/display/shadow_background_label.h
+++ b/cockatrice/src/interface/widgets/general/display/shadow_background_label.h
@@ -1,8 +1,8 @@
 /**
  * @file shadow_background_label.h
  * @ingroup PrintingWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef STYLEDLABEL_H
 #define STYLEDLABEL_H

--- a/cockatrice/src/interface/widgets/general/home_styled_button.h
+++ b/cockatrice/src/interface/widgets/general/home_styled_button.h
@@ -1,8 +1,8 @@
 /**
  * @file home_styled_button.h
  * @ingroup Widgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef HOME_STYLED_BUTTON_H
 #define HOME_STYLED_BUTTON_H

--- a/cockatrice/src/interface/widgets/general/home_widget.h
+++ b/cockatrice/src/interface/widgets/general/home_widget.h
@@ -2,8 +2,8 @@
  * @file home_widget.h
  * @ingroup Core
  * @ingroup Widgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef HOME_WIDGET_H
 #define HOME_WIDGET_H

--- a/cockatrice/src/interface/widgets/general/layout_containers/flow_widget.h
+++ b/cockatrice/src/interface/widgets/general/layout_containers/flow_widget.h
@@ -3,6 +3,7 @@
  * @ingroup UI
  * @brief A QWidget that wraps a FlowLayout inside an optional QScrollArea.
  */
+//! \todo Document this file.
 
 #ifndef FLOW_WIDGET_H
 #define FLOW_WIDGET_H

--- a/cockatrice/src/interface/widgets/general/layout_containers/overlap_control_widget.cpp
+++ b/cockatrice/src/interface/widgets/general/layout_containers/overlap_control_widget.cpp
@@ -33,7 +33,7 @@ OverlapControlWidget::OverlapControlWidget(int overlapPercentage,
     layout->addWidget(overlap_percentage_input);
     layout->addWidget(overlap_direction);
 
-    // TODO probably connect this to the parent
+    //! \todo Probably connect this to the parent.
     // connect(card_size_slider, &QSlider::valueChanged, display, &CardPicture::setScaleFactor);
 }
 

--- a/cockatrice/src/interface/widgets/general/layout_containers/overlap_control_widget.h
+++ b/cockatrice/src/interface/widgets/general/layout_containers/overlap_control_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file overlap_control_widget.h
  * @ingroup UI
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef OVERLAP_CONTROL_WIDGET_H
 #define OVERLAP_CONTROL_WIDGET_H

--- a/cockatrice/src/interface/widgets/general/layout_containers/overlap_widget.h
+++ b/cockatrice/src/interface/widgets/general/layout_containers/overlap_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file overlap_widget.h
  * @ingroup UI
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef OVERLAP_WIDGET_H
 #define OVERLAP_WIDGET_H

--- a/cockatrice/src/interface/widgets/menus/deck_editor_menu.h
+++ b/cockatrice/src/interface/widgets/menus/deck_editor_menu.h
@@ -1,8 +1,8 @@
 /**
  * @file deck_editor_menu.h
  * @ingroup DeckEditors
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DECK_EDITOR_MENU_H
 #define DECK_EDITOR_MENU_H

--- a/cockatrice/src/interface/widgets/menus/tearoff_menu.h
+++ b/cockatrice/src/interface/widgets/menus/tearoff_menu.h
@@ -1,8 +1,8 @@
 /**
  * @file tearoff_menu.h
  * @ingroup GameMenus
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #pragma once
 

--- a/cockatrice/src/interface/widgets/printing_selector/all_zones_card_amount_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/all_zones_card_amount_widget.h
@@ -2,8 +2,8 @@
  * @file all_zones_card_amount_widget.h
  * @ingroup CardExtraInfoWidgets
  * @ingroup PrintingWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef ALL_ZONES_CARD_AMOUNT_WIDGET_H
 #define ALL_ZONES_CARD_AMOUNT_WIDGET_H

--- a/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.h
@@ -2,8 +2,8 @@
  * @file card_amount_widget.h
  * @ingroup CardExtraInfoWidgets
  * @ingroup PrintingWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARD_AMOUNT_WIDGET_H
 #define CARD_AMOUNT_WIDGET_H

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector.h
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector.h
@@ -1,8 +1,8 @@
 /**
  * @file printing_selector.h
  * @ingroup PrintingWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef PRINTING_SELECTOR_H
 #define PRINTING_SELECTOR_H

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file printing_selector_card_display_widget.h
  * @ingroup PrintingWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef PRINTING_SELECTOR_CARD_DISPLAY_WIDGET_H
 #define PRINTING_SELECTOR_CARD_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file printing_selector_card_overlay_widget.h
  * @ingroup PrintingWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef PRINTING_SELECTOR_CARD_OVERLAY_WIDGET_H
 #define PRINTING_SELECTOR_CARD_OVERLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_search_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_search_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file printing_selector_card_search_widget.h
  * @ingroup PrintingWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef PRINTING_SELECTOR_CARD_SEARCH_WIDGET_H
 #define PRINTING_SELECTOR_CARD_SEARCH_WIDGET_H

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_selection_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_selection_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file printing_selector_card_selection_widget.h
  * @ingroup PrintingWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef PRINTING_SELECTOR_CARD_SELECTION_WIDGET_H
 #define PRINTING_SELECTOR_CARD_SELECTION_WIDGET_H

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_sorting_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_sorting_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file printing_selector_card_sorting_widget.h
  * @ingroup PrintingWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef PRINTING_SELECTOR_CARD_SORTING_WIDGET_H
 #define PRINTING_SELECTOR_CARD_SORTING_WIDGET_H

--- a/cockatrice/src/interface/widgets/printing_selector/set_name_and_collectors_number_display_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/set_name_and_collectors_number_display_widget.h
@@ -2,8 +2,8 @@
  * @file set_name_and_collectors_number_display_widget.h
  * @ingroup CardExtraInfoWidgets
  * @ingroup PrintingWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef SET_NAME_AND_COLLECTORS_NUMBER_DISPLAY_WIDGET_H
 #define SET_NAME_AND_COLLECTORS_NUMBER_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/quick_settings/settings_button_widget.h
+++ b/cockatrice/src/interface/widgets/quick_settings/settings_button_widget.h
@@ -27,7 +27,7 @@ public:
     bool isCompact() const
     {
         return compact;
-    };
+    }
 
 protected:
     void mousePressEvent(QMouseEvent *event) override;

--- a/cockatrice/src/interface/widgets/quick_settings/settings_button_widget.h
+++ b/cockatrice/src/interface/widgets/quick_settings/settings_button_widget.h
@@ -2,8 +2,8 @@
  * @file settings_button_widget.h
  * @ingroup Widgets
  * @ingroup Settings
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef SETTINGS_BUTTON_WIDGET_H
 #define SETTINGS_BUTTON_WIDGET_H

--- a/cockatrice/src/interface/widgets/quick_settings/settings_popup_widget.h
+++ b/cockatrice/src/interface/widgets/quick_settings/settings_popup_widget.h
@@ -2,8 +2,8 @@
  * @file settings_popup_widget.h
  * @ingroup Widgets
  * @ingroup Settings
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef SETTINGS_POPUP_WIDGET_H
 #define SETTINGS_POPUP_WIDGET_H

--- a/cockatrice/src/interface/widgets/replay/replay_manager.h
+++ b/cockatrice/src/interface/widgets/replay/replay_manager.h
@@ -2,8 +2,8 @@
  * @file replay_manager.h
  * @ingroup Core
  * @ingroup Replay
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef REPLAY_MANAGER_H
 #define REPLAY_MANAGER_H

--- a/cockatrice/src/interface/widgets/replay/replay_timeline_widget.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_timeline_widget.cpp
@@ -103,8 +103,12 @@ void ReplayTimelineWidget::skipToTime(int newTime, bool doRewindBuffering)
     update();
 }
 
-/// @param doRewindBuffering When true, if multiple backward skips are made in quick succession, only a single rewind
-/// is processed at the end. When false, the backwards skip will always cause an immediate rewind
+/**
+ * @brief Handles a backwards skip in the replay timeline.
+ *
+ * @param doRewindBuffering When true, if multiple backward skips are made in quick succession, only a single rewind
+ * is processed at the end. When false, the backwards skip will always cause an immediate rewind.
+ */
 void ReplayTimelineWidget::handleBackwardsSkip(bool doRewindBuffering)
 {
     if (doRewindBuffering) {
@@ -151,7 +155,7 @@ void ReplayTimelineWidget::replayTimerTimeout()
     }
 }
 
-/// Processes all unprocessed events up to the current time.
+/** @brief Processes all unprocessed events up to the current time. */
 void ReplayTimelineWidget::processNewEvents(PlaybackMode playbackMode)
 {
     currentProcessedTime = currentVisualTime;

--- a/cockatrice/src/interface/widgets/replay/replay_timeline_widget.h
+++ b/cockatrice/src/interface/widgets/replay/replay_timeline_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file replay_timeline_widget.h
  * @ingroup Replay
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef REPLAY_TIMELINE_WIDGET
 #define REPLAY_TIMELINE_WIDGET

--- a/cockatrice/src/interface/widgets/server/chat_view/chat_view.cpp
+++ b/cockatrice/src/interface/widgets/server/chat_view/chat_view.cpp
@@ -261,7 +261,8 @@ void ChatView::appendMessage(QString message,
     defaultFormat = QTextCharFormat();
     if (!isUserMessage) {
         if (messageType == Event_RoomSay::ChatHistory) {
-            defaultFormat.setForeground(Qt::gray); //! \todo hardcoded color
+            //! \todo Remove hardcoded color.
+            defaultFormat.setForeground(Qt::gray);
             defaultFormat.setFontWeight(QFont::Light);
             defaultFormat.setFontItalic(true);
             static const QRegularExpression userNameRegex("^(\\[[^\\]]*\\]\\s)(\\S+):\\s");
@@ -284,7 +285,8 @@ void ChatView::appendMessage(QString message,
                 message.remove(0, pos.relativePosition - 2); // do not remove semicolon
             }
         } else {
-            defaultFormat.setForeground(Qt::darkGreen); //! \todo hardcoded color
+            //! \todo Remove hardcoded color.
+            defaultFormat.setForeground(Qt::darkGreen);
             defaultFormat.setFontWeight(QFont::Bold);
         }
     }

--- a/cockatrice/src/interface/widgets/server/chat_view/chat_view.h
+++ b/cockatrice/src/interface/widgets/server/chat_view/chat_view.h
@@ -2,8 +2,8 @@
  * @file chat_view.h
  * @ingroup NetworkingWidgets
  * @ingroup Lobby
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CHATVIEW_H
 #define CHATVIEW_H

--- a/cockatrice/src/interface/widgets/server/handle_public_servers.h
+++ b/cockatrice/src/interface/widgets/server/handle_public_servers.h
@@ -1,8 +1,8 @@
 /**
  * @file handle_public_servers.h
  * @ingroup Server
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_HANDLE_PUBLIC_SERVERS_H
 #define COCKATRICE_HANDLE_PUBLIC_SERVERS_H

--- a/cockatrice/src/interface/widgets/server/remote/remote_decklist_tree_widget.h
+++ b/cockatrice/src/interface/widgets/server/remote/remote_decklist_tree_widget.h
@@ -2,8 +2,8 @@
  * @file remote_decklist_tree_widget.h
  * @ingroup NetworkingWidgets
  * @ingroup DeckStorageWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef REMOTEDECKLIST_TREEWIDGET_H
 #define REMOTEDECKLIST_TREEWIDGET_H

--- a/cockatrice/src/interface/widgets/server/remote/remote_replay_list_tree_widget.h
+++ b/cockatrice/src/interface/widgets/server/remote/remote_replay_list_tree_widget.h
@@ -3,8 +3,8 @@
  * @ingroup DeckStorageWidgets
  * @ingroup Replays
  * @ingroup NetworkingWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef REMOTEREPLAYLIST_TREEWIDGET_H
 #define REMOTEREPLAYLIST_TREEWIDGET_H

--- a/cockatrice/src/interface/widgets/server/user/user_context_menu.h
+++ b/cockatrice/src/interface/widgets/server/user/user_context_menu.h
@@ -1,8 +1,8 @@
 /**
  * @file user_context_menu.h
  * @ingroup Lobby
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef USER_CONTEXT_MENU_H
 #define USER_CONTEXT_MENU_H

--- a/cockatrice/src/interface/widgets/server/user/user_info_box.h
+++ b/cockatrice/src/interface/widgets/server/user/user_info_box.h
@@ -1,8 +1,8 @@
 /**
  * @file user_info_box.h
  * @ingroup Lobby
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef USERINFOBOX_H
 #define USERINFOBOX_H

--- a/cockatrice/src/interface/widgets/server/user/user_info_connection.h
+++ b/cockatrice/src/interface/widgets/server/user/user_info_connection.h
@@ -1,8 +1,8 @@
 /**
  * @file user_info_connection.h
  * @ingroup Client
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef USERCONNECTION_INFORMATION_H
 #define USERCONNECTION_INFORMATION_H

--- a/cockatrice/src/interface/widgets/server/user/user_list_manager.h
+++ b/cockatrice/src/interface/widgets/server/user/user_list_manager.h
@@ -1,8 +1,8 @@
 /**
  * @file user_list_manager.h
  * @ingroup Lobby
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_USER_LIST_MANAGER_H
 #define COCKATRICE_USER_LIST_MANAGER_H

--- a/cockatrice/src/interface/widgets/server/user/user_list_proxy.h
+++ b/cockatrice/src/interface/widgets/server/user/user_list_proxy.h
@@ -2,8 +2,8 @@
  * @file user_list_proxy.h
  * @ingroup UI
  * @ingroup Lobby
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_USERLISTPROXY_H
 #define COCKATRICE_USERLISTPROXY_H

--- a/cockatrice/src/interface/widgets/server/user/user_list_widget.h
+++ b/cockatrice/src/interface/widgets/server/user/user_list_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file user_list_widget.h
  * @ingroup Lobby
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef USERLIST_H
 #define USERLIST_H

--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/api_response/card/archidekt_api_response_card.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/api_response/card/archidekt_api_response_card.cpp
@@ -22,6 +22,8 @@ void ArchidektApiResponseCard::fromJson(const QJsonObject &json)
 
     flavor = json.value("flavor").toString();
     //! \todo Parse games and options fields (not really important).
+    // games = {""};
+    // options = {""};
     scryfallImageHash = json.value("scryfallImageHash").toString();
     oracleCard = json.value("oracleCard").toObject();
     owned = json.value("owned").toInt();

--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/api_response/card/archidekt_api_response_card.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/api_response/card/archidekt_api_response_card.cpp
@@ -21,16 +21,13 @@ void ArchidektApiResponseCard::fromJson(const QJsonObject &json)
     edition.fromJson(json.value("edition").toObject());
 
     flavor = json.value("flavor").toString();
-    //! \todo but not really important
-    //! \todo games = {""};
-    //! \todo options = {""};
+    //! \todo Parse games and options fields (not really important).
     scryfallImageHash = json.value("scryfallImageHash").toString();
     oracleCard = json.value("oracleCard").toObject();
     owned = json.value("owned").toInt();
     pinnedStatus = json.value("pinnedStatus").toInt();
     rarity = json.value("rarity").toString();
-    //! \todo but not really important
-    //! \todo globalCategories = {""};
+    //! \todo Parse globalCategories field (not really important).
 }
 
 void ArchidektApiResponseCard::debugPrint() const

--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/api_response/card/archidekt_api_response_card.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/api_response/card/archidekt_api_response_card.cpp
@@ -28,6 +28,7 @@ void ArchidektApiResponseCard::fromJson(const QJsonObject &json)
     pinnedStatus = json.value("pinnedStatus").toInt();
     rarity = json.value("rarity").toString();
     //! \todo Parse globalCategories field (not really important).
+    // globalCategories = {""};
 }
 
 void ArchidektApiResponseCard::debugPrint() const

--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/api_response/deck/archidekt_api_response_deck.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/api_response/deck/archidekt_api_response_deck.cpp
@@ -44,7 +44,7 @@ void ArchidektApiResponseDeck::fromJson(const QJsonObject &json)
         cards.append(entry);
     }
 
-    // TODO but not really important
+    //! \todo Parse customCards field (not really important).
     // customCards = {""};
 }
 

--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/api_response/deck_listings/archidekt_api_response_deck_listing_container.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/api_response/deck_listings/archidekt_api_response_deck_listing_container.cpp
@@ -23,7 +23,7 @@ void ArchidektApiResponseDeckListingContainer::fromJson(const QJsonObject &json)
     theoryCrafted = json.value("theoryCrafted").toBool();
     game = json.value("game").toString();
     hasDescription = json.value("hasDescription").toBool();
-    // TODO
+    //! \todo Parse tags field.
     // tags = {""};
     parentFolderId = json.value("parentFolderId").toInt();
     owner.fromJson(json.value("owner").toObject());

--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/api_response/deck_listings/archidekt_api_response_deck_owner.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/api_response/deck_listings/archidekt_api_response_deck_owner.cpp
@@ -7,7 +7,7 @@ void ArchidektApiResponseDeckOwner::fromJson(const QJsonObject &json)
     avatar = QUrl(json.value("avatar").toString());
     moderator = json.value("moderator").toBool();
     pledgeLevel = json.value("pledgeLevel").toInt();
-    // TODO but not really important
+    //! \todo Parse roles field (not really important).
     // roles = {""};
 }
 

--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/display/archidekt_api_response_deck_listings_display_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/display/archidekt_api_response_deck_listings_display_widget.h
@@ -82,16 +82,16 @@ public:
     void resizeEvent(QResizeEvent *event) override;
 
 private:
-    /// Slider controlling the scale of card thumbnails in all deck entry widgets.
+    /** @brief Slider controlling the scale of card thumbnails in all deck entry widgets. */
     CardSizeWidget *cardSizeSlider;
 
-    /// Main horizontal layout containing the FlowWidget.
+    /** @brief Main horizontal layout containing the FlowWidget. */
     QHBoxLayout *layout;
 
-    /// Container providing scrollable multi-row flow layout of deck entries.
+    /** @brief Container providing scrollable multi-row flow layout of deck entries. */
     FlowWidget *flowWidget;
 
-    /// Shared network manager used to download card images for all child entry widgets.
+    /** @brief Shared network manager used to download card images for all child entry widgets. */
     QNetworkAccessManager *imageNetworkManager;
 };
 

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/average_deck/edhrec_deck_api_response.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/average_deck/edhrec_deck_api_response.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_deck_api_response.h
  * @ingroup ApiResponses
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef EDHREC_DECK_API_RESPONSE_H
 #define EDHREC_DECK_API_RESPONSE_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/card_prices/edhrec_api_response_card_prices.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/card_prices/edhrec_api_response_card_prices.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_api_response_card_prices.h
  * @ingroup ApiResponses
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef EDHREC_COMMANDER_API_RESPONSE_CARD_PRICES_H
 #define EDHREC_COMMANDER_API_RESPONSE_CARD_PRICES_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/cards/edhrec_api_response_card_container.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/cards/edhrec_api_response_card_container.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_api_response_card_container.h
  * @ingroup ApiResponses
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CONTAINER_ENTRY_H
 #define CONTAINER_ENTRY_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/cards/edhrec_api_response_card_details.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/cards/edhrec_api_response_card_details.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_api_response_card_details.h
  * @ingroup ApiResponses
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARD_VIEW_H
 #define CARD_VIEW_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/cards/edhrec_api_response_card_list.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/cards/edhrec_api_response_card_list.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_api_response_card_list.h
  * @ingroup ApiResponses
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARD_LIST_H
 #define CARD_LIST_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/cards/edhrec_commander_api_response_commander_details.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/cards/edhrec_commander_api_response_commander_details.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_commander_api_response_commander_details.h
  * @ingroup ApiResponses
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef EDHREC_COMMANDER_API_RESPONSE_COMMANDER_DETAILS_H
 #define EDHREC_COMMANDER_API_RESPONSE_COMMANDER_DETAILS_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/top_cards/edhrec_top_cards_api_response.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/top_cards/edhrec_top_cards_api_response.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_top_cards_api_response.h
  * @ingroup ApiResponses
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef EDHREC_TOP_CARDS_API_RESPONSE_H
 #define EDHREC_TOP_CARDS_API_RESPONSE_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/top_commanders/edhrec_top_commanders_api_response.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/top_commanders/edhrec_top_commanders_api_response.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_top_commanders_api_response.h
  * @ingroup ApiResponses
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef EDHREC_TOP_COMMANDERS_API_RESPONSE_H
 #define EDHREC_TOP_COMMANDERS_API_RESPONSE_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/top_tags/edhrec_top_tags_api_response.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/api_response/top_tags/edhrec_top_tags_api_response.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_top_tags_api_response.h
  * @ingroup ApiResponses
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef EDHREC_TOP_TAGS_API_RESPONSE_H
 #define EDHREC_TOP_TAGS_API_RESPONSE_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/display/card_prices/edhrec_api_response_card_prices_display_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/display/card_prices/edhrec_api_response_card_prices_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_api_response_card_prices_display_widget.h
  * @ingroup ApiResponseDisplayWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef EDHREC_API_RESPONSE_CARD_PRICES_DISPLAY_WIDGET_H
 #define EDHREC_API_RESPONSE_CARD_PRICES_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_api_response_card_details_display_widget.h
  * @ingroup ApiResponseDisplayWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef EDHREC_COMMANDER_API_RESPONSE_CARD_DETAILS_DISPLAY_WIDGET_H
 #define EDHREC_COMMANDER_API_RESPONSE_CARD_DETAILS_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_inclusion_display_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_inclusion_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_api_response_card_inclusion_display_widget.h
  * @ingroup ApiResponseDisplayWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef EDHREC_API_RESPONSE_CARD_INCLUSION_DISPLAY_WIDGET_H
 #define EDHREC_API_RESPONSE_CARD_INCLUSION_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_list_display_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_list_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_api_response_card_list_display_widget.h
  * @ingroup ApiResponseDisplayWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef EDHREC_COMMANDER_API_RESPONSE_CARD_LIST_DISPLAY_WIDGET_H
 #define EDHREC_COMMANDER_API_RESPONSE_CARD_LIST_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_synergy_display_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_synergy_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_api_response_card_synergy_display_widget.h
  * @ingroup ApiResponseDisplayWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef EDHREC_API_RESPONSE_CARD_SYNERGY_DISPLAY_WIDGET_H
 #define EDHREC_API_RESPONSE_CARD_SYNERGY_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/display/commander/edhrec_api_response_commander_details_display_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/display/commander/edhrec_api_response_commander_details_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_api_response_commander_details_display_widget.h
  * @ingroup ApiResponseDisplayWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef EDHREC_COMMANDER_API_RESPONSE_COMMANDER_DETAILS_DISPLAY_WIDGET_H
 #define EDHREC_COMMANDER_API_RESPONSE_COMMANDER_DETAILS_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/display/commander/edhrec_commander_api_response_display_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/display/commander/edhrec_commander_api_response_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_commander_api_response_display_widget.h
  * @ingroup ApiResponseDisplayWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef EDHREC_COMMANDER_API_RESPONSE_DISPLAY_WIDGET_H
 #define EDHREC_COMMANDER_API_RESPONSE_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/display/commander/edhrec_commander_api_response_navigation_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/display/commander/edhrec_commander_api_response_navigation_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_commander_api_response_navigation_widget.h
  * @ingroup ApiResponseDisplayWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef EDHREC_COMMANDER_API_RESPONSE_NAVIGATION_WIDGET_H
 #define EDHREC_COMMANDER_API_RESPONSE_NAVIGATION_WIDGET_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/display/top_cards/edhrec_top_cards_api_response_display_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/display/top_cards/edhrec_top_cards_api_response_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_top_cards_api_response_display_widget.h
  * @ingroup ApiResponseDisplayWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef EDHREC_TOP_CARDS_API_RESPONSE_DISPLAY_WIDGET_H
 #define EDHREC_TOP_CARDS_API_RESPONSE_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/display/top_commander/edhrec_top_commanders_api_response_display_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/display/top_commander/edhrec_top_commanders_api_response_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_top_commanders_api_response_display_widget.h
  * @ingroup ApiResponseDisplayWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef EDHREC_TOP_COMMANDERS_API_RESPONSE_DISPLAY_WIDGET_H
 #define EDHREC_TOP_COMMANDERS_API_RESPONSE_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/display/top_tags/edhrec_top_tags_api_response_display_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/display/top_tags/edhrec_top_tags_api_response_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file edhrec_top_tags_api_response_display_widget.h
  * @ingroup ApiResponseDisplayWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef EDHREC_TOP_TAGS_API_RESPONSE_DISPLAY_WIDGET_H
 #define EDHREC_TOP_TAGS_API_RESPONSE_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/tab_edhrec.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/tab_edhrec.h
@@ -1,8 +1,8 @@
 /**
  * @file tab_edhrec.h
  * @ingroup Tabs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TAB_EDHREC_H
 #define TAB_EDHREC_H

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/tab_edhrec_main.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/tab_edhrec_main.h
@@ -1,8 +1,8 @@
 /**
  * @file tab_edhrec_main.h
  * @ingroup Tabs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TAB_EDHREC_MAIN_H
 #define TAB_EDHREC_MAIN_H

--- a/cockatrice/src/interface/widgets/tabs/tab.h
+++ b/cockatrice/src/interface/widgets/tabs/tab.h
@@ -1,8 +1,8 @@
 /**
  * @file tab.h
  * @ingroup Tabs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TAB_H
 #define TAB_H

--- a/cockatrice/src/interface/widgets/tabs/tab_account.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_account.h
@@ -1,8 +1,8 @@
 /**
  * @file tab_account.h
  * @ingroup AccountTabs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TAB_ACCOUNT_H
 #define TAB_ACCOUNT_H

--- a/cockatrice/src/interface/widgets/tabs/tab_admin.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_admin.h
@@ -1,8 +1,8 @@
 /**
  * @file tab_admin.h
  * @ingroup ServerTabs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TAB_ADMIN_H
 #define TAB_ADMIN_H

--- a/cockatrice/src/interface/widgets/tabs/tab_deck_storage.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_deck_storage.h
@@ -2,8 +2,8 @@
  * @file tab_deck_storage.h
  * @ingroup DeckStorageWidgets
  * @ingroup Tabs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TAB_DECK_STORAGE_H
 #define TAB_DECK_STORAGE_H

--- a/cockatrice/src/interface/widgets/tabs/tab_game.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.h
@@ -3,8 +3,8 @@
  * @ingroup Tabs
  * @ingroup GameWidgets
  * @ingroup Lobby
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TAB_GAME_H
 #define TAB_GAME_H

--- a/cockatrice/src/interface/widgets/tabs/tab_home.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_home.h
@@ -1,8 +1,8 @@
 /**
  * @file tab_home.h
  * @ingroup Tabs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TAB_HOME_H
 #define TAB_HOME_H

--- a/cockatrice/src/interface/widgets/tabs/tab_logs.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_logs.h
@@ -1,8 +1,8 @@
 /**
  * @file tab_logs.h
  * @ingroup ServerTabs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TAB_LOG_H
 #define TAB_LOG_H

--- a/cockatrice/src/interface/widgets/tabs/tab_message.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_message.h
@@ -1,8 +1,8 @@
 /**
  * @file tab_message.h
  * @ingroup MessagingTabs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TAB_MESSAGE_H
 #define TAB_MESSAGE_H

--- a/cockatrice/src/interface/widgets/tabs/tab_replays.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_replays.h
@@ -2,8 +2,8 @@
  * @file tab_replays.h
  * @ingroup Replays
  * @ingroup Tabs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TAB_REPLAYS_H
 #define TAB_REPLAYS_H

--- a/cockatrice/src/interface/widgets/tabs/tab_room.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_room.h
@@ -2,8 +2,8 @@
  * @file tab_room.h
  * @ingroup RoomTabs
  * @ingroup Lobby
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TAB_ROOM_H
 #define TAB_ROOM_H

--- a/cockatrice/src/interface/widgets/tabs/tab_server.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_server.h
@@ -1,8 +1,8 @@
 /**
  * @file tab_server.h
  * @ingroup ServerTabs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TAB_SERVER_H
 #define TAB_SERVER_H

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.h
@@ -2,8 +2,8 @@
  * @file tab_supervisor.h
  * @ingroup Core
  * @ingroup Tabs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TAB_SUPERVISOR_H
 #define TAB_SUPERVISOR_H

--- a/cockatrice/src/interface/widgets/tabs/tab_visual_database_display.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_visual_database_display.h
@@ -1,8 +1,8 @@
 /**
  * @file tab_visual_database_display.h
  * @ingroup Tabs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TAB_VISUAL_DATABASE_DISPLAY_H
 #define TAB_VISUAL_DATABASE_DISPLAY_H

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.h
@@ -63,19 +63,19 @@ public:
                                           CardDatabaseModel *_cardDatabaseModel,
                                           CardDatabaseDisplayModel *_cardDatabaseDisplayModel);
 
-    /// Add a new tab with a widget and title.
+    /** @brief Add a new tab with a widget and title. */
     void addNewTab(QWidget *widget, const QString &title);
 
-    /// Remove the currently active tab.
+    /** @brief Remove the currently active tab. */
     void removeCurrentTab();
 
-    /// Set the title of a specific tab.
+    /** @brief Set the title of a specific tab. */
     void setTabTitle(int index, const QString &title);
 
-    /// Get the currently active tab widget.
+    /** @brief Get the currently active tab widget. */
     [[nodiscard]] QWidget *getCurrentTab() const;
 
-    /// Get the total number of tabs.
+    /** @brief Get the total number of tabs. */
     [[nodiscard]] int getTabCount() const;
 
     VisualDeckEditorWidget *visualDeckView; ///< Visual deck editor widget.

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_storage/tab_deck_storage_visual.h
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_storage/tab_deck_storage_visual.h
@@ -1,8 +1,8 @@
 /**
  * @file tab_deck_storage_visual.h
  * @ingroup Tabs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef TAB_DECK_STORAGE_VISUAL_H
 #define TAB_DECK_STORAGE_VISUAL_H

--- a/cockatrice/src/interface/widgets/utility/custom_line_edit.h
+++ b/cockatrice/src/interface/widgets/utility/custom_line_edit.h
@@ -1,8 +1,8 @@
 /**
  * @file custom_line_edit.h
  * @ingroup UI
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CUSTOMLINEEDIT_H
 #define CUSTOMLINEEDIT_H

--- a/cockatrice/src/interface/widgets/utility/line_edit_completer.h
+++ b/cockatrice/src/interface/widgets/utility/line_edit_completer.h
@@ -1,8 +1,8 @@
 /**
  * @file line_edit_completer.h
  * @ingroup UI
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef LINEEDITCOMPLETER_H
 #define LINEEDITCOMPLETER_H

--- a/cockatrice/src/interface/widgets/utility/sequence_edit.h
+++ b/cockatrice/src/interface/widgets/utility/sequence_edit.h
@@ -1,8 +1,8 @@
 /**
  * @file sequence_edit.h
  * @ingroup UI
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef SEQUENCEEDIT_H
 #define SEQUENCEEDIT_H

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_color_filter_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_color_filter_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file visual_database_display_color_filter_widget.h
  * @ingroup VisualCardDatabaseWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef VISUAL_DATABASE_DISPLAY_COLOR_FILTER_WIDGET_H
 #define VISUAL_DATABASE_DISPLAY_COLOR_FILTER_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_filter_save_load_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_filter_save_load_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file visual_database_display_filter_save_load_widget.h
  * @ingroup VisualCardDatabaseWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef VISUAL_DATABASE_DISPLAY_FILTER_SAVE_LOAD_WIDGET_H
 #define VISUAL_DATABASE_DISPLAY_FILTER_SAVE_LOAD_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_main_type_filter_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_main_type_filter_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file visual_database_display_main_type_filter_widget.h
  * @ingroup VisualCardDatabaseWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef VISUAL_DATABASE_DISPLAY_MAIN_TYPE_FILTER_WIDGET_H
 #define VISUAL_DATABASE_DISPLAY_MAIN_TYPE_FILTER_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_name_filter_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_name_filter_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file visual_database_display_name_filter_widget.h
  * @ingroup VisualCardDatabaseWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef VISUAL_DATABASE_DISPLAY_NAME_FILTER_WIDGET_H
 #define VISUAL_DATABASE_DISPLAY_NAME_FILTER_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_set_filter_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_set_filter_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file visual_database_display_set_filter_widget.h
  * @ingroup VisualCardDatabaseWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef VISUAL_DATABASE_DISPLAY_SET_FILTER_WIDGET_H
 #define VISUAL_DATABASE_DISPLAY_SET_FILTER_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_sub_type_filter_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_sub_type_filter_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file visual_database_display_sub_type_filter_widget.h
  * @ingroup VisualCardDatabaseWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef VISUAL_DATABASE_DISPLAY_SUB_TYPE_FILTER_WIDGET_H
 #define VISUAL_DATABASE_DISPLAY_SUB_TYPE_FILTER_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file visual_database_display_widget.h
  * @ingroup VisualCardDatabaseWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef VISUAL_DATABASE_DISPLAY_WIDGET_H
 #define VISUAL_DATABASE_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_filter_display_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_filter_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file visual_database_filter_display_widget.h
  * @ingroup VisualCardDatabaseWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef VISUAL_DATABASE_FILTER_DISPLAY_WIDGET_H
 #define VISUAL_DATABASE_FILTER_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_display_options_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_display_options_widget.h
@@ -104,37 +104,37 @@ private slots:
     void updateDisplayType();
 
 private:
-    /// Layout for grouping and sorting UI elements.
+    /** @brief Layout for grouping and sorting UI elements. */
     QHBoxLayout *groupAndSortLayout;
 
-    /// Current deck display type.
+    /** @brief Current deck display type. */
     DisplayType currentDisplayType = DisplayType::Overlap;
 
-    /// Button used to toggle the display layout.
+    /** @brief Button used to toggle the display layout. */
     CompactPushButton *displayTypeButton;
 
-    /// Label for the group-by selector.
+    /** @brief Label for the group-by selector. */
     QLabel *groupByLabel;
 
-    /// Combo box listing group-by criteria.
+    /** @brief Combo box listing group-by criteria. */
     QComboBox *groupByComboBox;
 
-    /// Currently active group-by criterion.
+    /** @brief Currently active group-by criterion. */
     QString activeGroupCriteria = "maintype";
 
-    /// Encapsulates the sort settings widgets (label + list).
+    /** @brief Encapsulates the sort settings widgets (label + list). */
     SettingsButtonWidget *sortCriteriaButton;
 
-    /// Label for “Sort by”.
+    /** @brief Label for "Sort by". */
     QLabel *sortByLabel;
 
-    /// Descriptive label inside the sort criteria button.
+    /** @brief Descriptive label inside the sort criteria button. */
     QLabel *sortLabel;
 
-    /// Draggable list of sort criteria.
+    /** @brief Draggable list of sort criteria. */
     QListWidget *sortByListWidget;
 
-    /// Ordered list of current sort criteria.
+    /** @brief Ordered list of current sort criteria. */
     QStringList activeSortCriteria = {"name", "cmc", "colors", "maintype"};
 };
 

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_sample_hand_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_sample_hand_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file visual_deck_editor_sample_hand_widget.h
  * @ingroup DeckEditorAnalyticsWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef VISUAL_DECK_EDITOR_SAMPLE_HAND_WIDGET_H
 #define VISUAL_DECK_EDITOR_SAMPLE_HAND_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -418,7 +418,7 @@ void VisualDeckEditorWidget::onHover(const ExactCard &hoveredCard)
     // If nothing is selected -> this is our "active/preview" card
     emit activeCardChanged(hoveredCard);
 
-    // TODO: highlight hovered card visually:
+    //! \todo Highlight hovered card visually.
     // highlightHoveredCard(hoveredCard);
 }
 
@@ -429,7 +429,7 @@ void VisualDeckEditorWidget::setSelectionModel(QItemSelectionModel *model)
     }
 
     if (selectionModel) {
-        // TODO: Possibly disconnect old ones?
+        //! \todo Possibly disconnect old signal connections.
     }
 
     selectionModel = model;

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file visual_deck_editor_widget.h
  * @ingroup DeckEditors
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef VISUAL_DECK_EDITOR_H
 #define VISUAL_DECK_EDITOR_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_filter_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_filter_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file deck_preview_color_identity_filter_widget.h
  * @ingroup VisualDeckPreviewWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DECK_PREVIEW_COLOR_IDENTITY_FILTER_WIDGET_H
 #define DECK_PREVIEW_COLOR_IDENTITY_FILTER_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file deck_preview_deck_tags_display_widget.h
  * @ingroup VisualDeckPreviewWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DECK_PREVIEW_DECK_TAGS_DISPLAY_WIDGET_H
 #define DECK_PREVIEW_DECK_TAGS_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_tag_addition_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_tag_addition_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file deck_preview_tag_addition_widget.h
  * @ingroup VisualDeckPreviewWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DECK_PREVIEW_TAG_ADDITION_WIDGET_H
 #define DECK_PREVIEW_TAG_ADDITION_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_tag_dialog.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_tag_dialog.h
@@ -2,8 +2,8 @@
  * @file deck_preview_tag_dialog.h
  * @ingroup VisualDeckPreviewWidgets
  * @ingroup Dialogs
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DECK_PREVIEW_TAG_DIALOG_H
 #define DECK_PREVIEW_TAG_DIALOG_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_tag_display_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_tag_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file deck_preview_tag_display_widget.h
  * @ingroup VisualDeckPreviewWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DECK_PREVIEW_TAG_DISPLAY_WIDGET_H
 #define DECK_PREVIEW_TAG_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_tag_item_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_tag_item_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file deck_preview_tag_item_widget.h
  * @ingroup VisualDeckPreviewWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DECK_PREVIEW_TAG_ITEM_WIDGET_H
 #define DECK_PREVIEW_TAG_ITEM_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -28,8 +28,8 @@ DeckPreviewWidget::DeckPreviewWidget(QWidget *_parent,
 
     deckLoader = new DeckLoader(this);
     connect(deckLoader, &DeckLoader::loadFinished, this, &DeckPreviewWidget::initializeUi);
-    /* TODO: We shouldn't update the tags on *every* deck load, since it's kinda expensive. We should instead count how
-     many deck loads have finished already and if we've loaded all decks and THEN load all the tags at once. */
+    //! \todo Batch tag refresh: count finished deck loads and refresh tags once all decks are loaded.
+    // Currently expensive: refreshes on each individual deck load instead of once at the end.
     connect(deckLoader, &DeckLoader::loadFinished, visualDeckStorageWidget->tagFilterWidget,
             &VisualDeckStorageTagFilterWidget::refreshTags);
     deckLoader->loadFromFileAsync(filePath, DeckFileFormat::getFormatFromName(filePath), false);

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file deck_preview_widget.h
  * @ingroup VisualDeckPreviewWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DECK_PREVIEW_WIDGET_H
 #define DECK_PREVIEW_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file visual_deck_storage_folder_display_widget.h
  * @ingroup VisualDeckStorageWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef VISUAL_DECK_STORAGE_FOLDER_DISPLAY_WIDGET_H
 #define VISUAL_DECK_STORAGE_FOLDER_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_search_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_search_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file visual_deck_storage_search_widget.h
  * @ingroup VisualDeckStorageWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef VISUAL_DECK_STORAGE_SEARCH_WIDGET_H
 #define VISUAL_DECK_STORAGE_SEARCH_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_sort_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_sort_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file visual_deck_storage_sort_widget.h
  * @ingroup VisualDeckStorageWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef VISUAL_DECK_STORAGE_SORT_WIDGET_H
 #define VISUAL_DECK_STORAGE_SORT_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file visual_deck_storage_tag_filter_widget.h
  * @ingroup VisualDeckStorageWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef VISUAL_DECK_STORAGE_TAG_FILTER_WIDGET_H
 #define VISUAL_DECK_STORAGE_TAG_FILTER_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -1,8 +1,8 @@
 /**
  * @file visual_deck_storage_widget.h
  * @ingroup VisualDeckStorageWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef VISUAL_DECK_STORAGE_WIDGET_H
 #define VISUAL_DECK_STORAGE_WIDGET_H

--- a/cockatrice/src/interface/window_main.h
+++ b/cockatrice/src/interface/window_main.h
@@ -20,8 +20,8 @@
 /**
  * @file window_main.h
  * @ingroup Core
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 #ifndef WINDOW_H
 #define WINDOW_H
 

--- a/cockatrice/src/main.h
+++ b/cockatrice/src/main.h
@@ -1,8 +1,8 @@
 /**
  * @file main.h
  * @ingroup Core
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef MAIN_H
 #define MAIN_H

--- a/libcockatrice_card/libcockatrice/card/card_info_comparator.h
+++ b/libcockatrice_card/libcockatrice/card/card_info_comparator.h
@@ -1,8 +1,8 @@
 /**
  * @file card_info_comparator.h
  * @ingroup Cards
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARD_INFO_COMPARATOR_H
 #define CARD_INFO_COMPARATOR_H

--- a/libcockatrice_card/libcockatrice/card/database/card_database.h
+++ b/libcockatrice_card/libcockatrice/card/database/card_database.h
@@ -30,27 +30,27 @@ class CardDatabase : public QObject
     Q_OBJECT
 
 protected:
-    /// Controller to determine set priority when choosing preferred printings.
+    /** @brief Controller to determine set priority when choosing preferred printings. */
     ICardSetPriorityController *setPriorityController;
 
-    /// Cards indexed by exact name
+    /** @brief Cards indexed by exact name. */
     CardNameMap cards;
 
-    /// Cards indexed by simplified name (normalized)
+    /** @brief Cards indexed by simplified name (normalized). */
     CardNameMap simpleNameCards;
 
-    /// Sets indexed by short name
+    /** @brief Sets indexed by short name. */
     SetNameMap sets;
 
     FormatRulesNameMap formats;
 
-    /// Loader responsible for file discovery and parsing
+    /** @brief Loader responsible for file discovery and parsing. */
     CardDatabaseLoader *loader;
 
-    /// Current load status of the database
+    /** @brief Current load status of the database. */
     LoadStatus loadStatus;
 
-    /// Querier for higher-level card lookups
+    /** @brief Querier for higher-level card lookups. */
     CardDatabaseQuerier *querier;
 
 private:
@@ -64,7 +64,7 @@ private:
      */
     void refreshCachedReverseRelatedCards();
 
-    /// Mutexes for thread safety
+    /** @brief Mutexes for thread safety. */
     QBasicMutex *clearDatabaseMutex = new QBasicMutex(), *addCardMutex = new QBasicMutex(),
                 *removeCardMutex = new QBasicMutex();
 

--- a/libcockatrice_card/libcockatrice/card/database/card_database.h
+++ b/libcockatrice_card/libcockatrice/card/database/card_database.h
@@ -133,7 +133,7 @@ public:
     ICardSetPriorityController *getPriorityController()
     {
         return setPriorityController;
-    };
+    }
 
 public slots:
     /**

--- a/libcockatrice_card/libcockatrice/card/database/card_database_manager.h
+++ b/libcockatrice_card/libcockatrice/card/database/card_database_manager.h
@@ -67,13 +67,13 @@ private:
     /** @brief Private destructor. */
     ~CardDatabaseManager() = default;
 
-    /// Static card preference provider pointer (default: Noop)
+    /** @brief Static card preference provider pointer (default: Noop). */
     static ICardPreferenceProvider *cardPreferenceProvider;
 
-    /// Static path provider pointer (default: Noop)
+    /** @brief Static path provider pointer (default: Noop). */
     static ICardDatabasePathProvider *pathProvider;
 
-    /// Static set priority controller pointer (default: Noop)
+    /** @brief Static set priority controller pointer (default: Noop). */
     static ICardSetPriorityController *setPriorityController;
 };
 

--- a/libcockatrice_card/libcockatrice/card/game_specific_terms.h
+++ b/libcockatrice_card/libcockatrice/card/game_specific_terms.h
@@ -1,8 +1,8 @@
 /**
  * @file game_specific_terms.h
  * @ingroup Cards
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef GAME_SPECIFIC_TERMS_H
 #define GAME_SPECIFIC_TERMS_H

--- a/libcockatrice_card/libcockatrice/card/set/card_set.h
+++ b/libcockatrice_card/libcockatrice/card/set/card_set.h
@@ -107,31 +107,31 @@ public:
      */
     [[nodiscard]] QString getCorrectedShortName() const;
 
-    /// @return Short identifier of the set.
+    /** @return Short identifier of the set. */
     [[nodiscard]] QString getShortName() const
     {
         return shortName;
     }
 
-    /// @return Descriptive name of the set.
+    /** @return Descriptive name of the set. */
     [[nodiscard]] QString getLongName() const
     {
         return longName;
     }
 
-    /// @return Type/category string of the set.
+    /** @return Type/category string of the set. */
     [[nodiscard]] QString getSetType() const
     {
         return setType;
     }
 
-    /// @return Release date of the set.
+    /** @return Release date of the set. */
     [[nodiscard]] QDate getReleaseDate() const
     {
         return releaseDate;
     }
 
-    /// @return Priority level of the set.
+    /** @return Priority level of the set. */
     [[nodiscard]] Priority getPriority() const
     {
         return priority;
@@ -190,7 +190,7 @@ public:
         enabled = _enabled;
     }
 
-    /// @return The sort key assigned to this set.
+    /** @return The sort key assigned to this set. */
     [[nodiscard]] int getSortKey() const
     {
         return sortKey;
@@ -202,7 +202,7 @@ public:
      */
     void setSortKey(unsigned int _sortKey);
 
-    /// @return True if the set is enabled.
+    /** @return True if the set is enabled. */
     [[nodiscard]] bool getEnabled() const
     {
         return enabled;
@@ -214,7 +214,7 @@ public:
      */
     void setEnabled(bool _enabled);
 
-    /// @return True if the set is considered known.
+    /** @return True if the set is considered known. */
     [[nodiscard]] bool getIsKnown() const
     {
         return isknown;

--- a/libcockatrice_card/libcockatrice/card/set/card_set_comparator.h
+++ b/libcockatrice_card/libcockatrice/card/set/card_set_comparator.h
@@ -1,8 +1,8 @@
 /**
  * @file card_set_comparator.h
  * @ingroup CardSets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef SET_PRIORITY_COMPARATOR_H
 #define SET_PRIORITY_COMPARATOR_H

--- a/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.h
@@ -89,7 +89,7 @@ private:
     mutable QString cachedDeckHash;
 
 public:
-    /// @name Metadata setters
+    /** @name Metadata setters */
     ///@{
     void setName(const QString &_name = QString())
     {
@@ -125,11 +125,11 @@ public:
     }
     ///@}
 
-    /// @brief Construct an empty deck.
+    /** @brief Construct an empty deck. */
     explicit DeckList();
-    /// @brief Construct from a serialized native-format string.
+    /** @brief Construct from a serialized native-format string. */
     explicit DeckList(const QString &nativeString);
-    /// @brief Construct from components
+    /** @brief Construct from components. */
     DeckList(const Metadata &metadata,
              const DecklistNodeTree &tree,
              const QMap<QString, SideboardPlan> &sideboardPlans = {});
@@ -144,8 +144,10 @@ public:
         return &tree;
     }
 
-    /// @name Metadata getters
-    /// The individual metadata getters still exist for backwards compatibility.
+    /**
+     * @name Metadata getters
+     * The individual metadata getters still exist for backwards compatibility.
+     */
     ///@{
     //! \todo Figure out when we can remove them.
     const Metadata &getMetadata() const
@@ -183,7 +185,7 @@ public:
         return metadata.isEmpty() && getCardList().isEmpty();
     }
 
-    /// @name Sideboard plans
+    /** @name Sideboard plans */
     ///@{
     QList<MoveCard_ToZone> getCurrentSideboardPlan() const;
     void setCurrentSideboardPlan(const QList<MoveCard_ToZone> &plan);
@@ -193,7 +195,7 @@ public:
     }
     ///@}
 
-    /// @name Serialization (XML)
+    /** @name Serialization (XML) */
     ///@{
     bool readElement(QXmlStreamReader *xml);
     void write(QXmlStreamWriter *xml) const;
@@ -204,7 +206,7 @@ public:
     bool saveToFile_Native(QIODevice *device) const;
     ///@}
 
-    /// @name Serialization (Plain text)
+    /** @name Serialization (Plain text) */
     ///@{
     bool loadFromStream_Plain(QTextStream &stream,
                               bool preserveMetadata,
@@ -216,7 +218,7 @@ public:
     QString writeToString_Plain(bool prefixSideboardCards = true, bool slashTappedOutSplitCards = false) const;
     ///@}
 
-    /// @name Deck manipulation
+    /** @name Deck manipulation */
     ///@{
     void cleanList(bool preserveMetadata = false);
     bool isEmpty() const
@@ -238,7 +240,7 @@ public:
                               const bool formatLegal = true);
     ///@}
 
-    /// @name Deck identity
+    /** @name Deck identity */
     ///@{
     QString getDeckHash() const;
     void refreshDeckHash();

--- a/libcockatrice_deck_list/libcockatrice/deck_list/deck_list_node_tree.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/deck_list_node_tree.h
@@ -12,11 +12,11 @@ class DecklistNodeTree
     InnerDecklistNode *root; ///< Root of the deck tree (zones + cards).
 
 public:
-    /// @brief Constructs an empty DecklistNodeTree
+    /** @brief Constructs an empty DecklistNodeTree. */
     explicit DecklistNodeTree();
-    /// @brief Copy constructor. Deep copies the tree
+    /** @brief Copy constructor. Deep copies the tree. */
     explicit DecklistNodeTree(const DecklistNodeTree &other);
-    /// @brief Copy-assignment operator. Deep copies the tree
+    /** @brief Copy-assignment operator. Deep copies the tree. */
     DecklistNodeTree &operator=(const DecklistNodeTree &other);
 
     virtual ~DecklistNodeTree();

--- a/libcockatrice_deck_list/libcockatrice/deck_list/sideboard_plan.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/sideboard_plan.h
@@ -51,19 +51,19 @@ public:
      */
     void write(QXmlStreamWriter *xml) const;
 
-    /// @return The plan name.
+    /** @return The plan name. */
     [[nodiscard]] QString getName() const
     {
         return name;
     }
 
-    /// @return Const reference to the move list.
+    /** @return Const reference to the move list. */
     [[nodiscard]] const QList<MoveCard_ToZone> &getMoveList() const
     {
         return moveList;
     }
 
-    /// @brief Replace the move list with a new one.
+    /** @brief Replace the move list with a new one. */
     void setMoveList(const QList<MoveCard_ToZone> &_moveList);
 };
 

--- a/libcockatrice_deck_list/libcockatrice/deck_list/tree/abstract_deck_list_card_node.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/tree/abstract_deck_list_card_node.h
@@ -58,40 +58,40 @@ public:
     {
     }
 
-    /// @return The number of copies of this card in the deck.
+    /** @return The number of copies of this card in the deck. */
     [[nodiscard]] virtual int getNumber() const = 0;
 
-    /// @param _number Set the number of copies of this card.
+    /** @param _number Set the number of copies of this card. */
     virtual void setNumber(int _number) = 0;
 
-    /// @return The display name of this card.
+    /** @return The display name of this card. */
     [[nodiscard]] QString getName() const override = 0;
 
-    /// @param _name Set the display name of this card.
+    /** @param _name Set the display name of this card. */
     virtual void setName(const QString &_name) = 0;
 
-    /// @return The provider identifier for this card (e.g., UUID).
+    /** @return The provider identifier for this card (e.g., UUID). */
     [[nodiscard]] virtual QString getCardProviderId() const override = 0;
 
-    /// @param _cardProviderId Set the provider identifier for this card.
+    /** @param _cardProviderId Set the provider identifier for this card. */
     virtual void setCardProviderId(const QString &_cardProviderId) = 0;
 
-    /// @return The abbreviated set code (e.g., "NEO").
+    /** @return The abbreviated set code (e.g., "NEO"). */
     [[nodiscard]] virtual QString getCardSetShortName() const override = 0;
 
-    /// @param _cardSetShortName Set the abbreviated set code.
+    /** @param _cardSetShortName Set the abbreviated set code. */
     virtual void setCardSetShortName(const QString &_cardSetShortName) = 0;
 
-    /// @return The collector number of the card within its set.
+    /** @return The collector number of the card within its set. */
     [[nodiscard]] virtual QString getCardCollectorNumber() const override = 0;
 
-    /// @param _cardSetNumber Set the collector number.
+    /** @param _cardSetNumber Set the collector number. */
     virtual void setCardCollectorNumber(const QString &_cardSetNumber) = 0;
 
-    /// @return The format legality of the card
+    /** @return The format legality of the card. */
     virtual bool getFormatLegality() const = 0;
 
-    /// @param _formatLegal If the card is considered legal
+    /** @param _formatLegal If the card is considered legal. */
     virtual void setFormatLegality(const bool _formatLegal) = 0;
 
     /**

--- a/libcockatrice_deck_list/libcockatrice/deck_list/tree/abstract_deck_list_node.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/tree/abstract_deck_list_node.h
@@ -101,7 +101,7 @@ public:
      */
     explicit AbstractDecklistNode(InnerDecklistNode *_parent = nullptr, int position = -1);
 
-    /// Virtual destructor. Child classes must clean up their resources.
+    /** @brief Virtual destructor. Child classes must clean up their resources. */
     virtual ~AbstractDecklistNode() = default;
 
     /**
@@ -136,7 +136,7 @@ public:
      */
     [[nodiscard]] virtual bool isDeckHeader() const = 0;
 
-    /// @return The parent node, or nullptr if this is the root.
+    /** @return The parent node, or nullptr if this is the root. */
     [[nodiscard]] InnerDecklistNode *getParent() const
     {
         return parent;

--- a/libcockatrice_deck_list/libcockatrice/deck_list/tree/deck_list_card_node.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/tree/deck_list_card_node.h
@@ -93,79 +93,79 @@ public:
      */
     explicit DecklistCardNode(DecklistCardNode *other, InnerDecklistNode *_parent);
 
-    /// @return The quantity of this card.
+    /** @return The quantity of this card. */
     [[nodiscard]] int getNumber() const override
     {
         return number;
     }
 
-    /// @param _number Set the quantity of this card.
+    /** @param _number Set the quantity of this card. */
     void setNumber(int _number) override
     {
         number = _number;
     }
 
-    /// @return The display name of this card.
+    /** @return The display name of this card. */
     [[nodiscard]] QString getName() const override
     {
         return name;
     }
 
-    /// @param _name Set the display name of this card.
+    /** @param _name Set the display name of this card. */
     void setName(const QString &_name) override
     {
         name = _name;
     }
 
-    /// @return The provider identifier for this card.
+    /** @return The provider identifier for this card. */
     [[nodiscard]] QString getCardProviderId() const override
     {
         return cardProviderId;
     }
 
-    /// @param _providerId Set the provider identifier for this card.
+    /** @param _providerId Set the provider identifier for this card. */
     void setCardProviderId(const QString &_providerId) override
     {
         cardProviderId = _providerId;
     }
 
-    /// @return The short set code (e.g., "NEO").
+    /** @return The short set code (e.g., "NEO"). */
     [[nodiscard]] QString getCardSetShortName() const override
     {
         return cardSetShortName;
     }
 
-    /// @param _cardSetShortName Set the short set code.
+    /** @param _cardSetShortName Set the short set code. */
     void setCardSetShortName(const QString &_cardSetShortName) override
     {
         cardSetShortName = _cardSetShortName;
     }
 
-    /// @return The collector number of this card within its set.
+    /** @return The collector number of this card within its set. */
     [[nodiscard]] QString getCardCollectorNumber() const override
     {
         return cardSetNumber;
     }
 
-    /// @param _cardSetNumber Set the collector number.
+    /** @param _cardSetNumber Set the collector number. */
     void setCardCollectorNumber(const QString &_cardSetNumber) override
     {
         cardSetNumber = _cardSetNumber;
     }
 
-    /// @return The format legality of the card
+    /** @return The format legality of the card. */
     [[nodiscard]] bool getFormatLegality() const override
     {
         return formatLegal;
     }
 
-    /// @param _formatLegal If the card is considered legal
+    /** @param _formatLegal If the card is considered legal. */
     void setFormatLegality(const bool _formatLegal) override
     {
         formatLegal = _formatLegal;
     }
 
-    /// @return Always false; card nodes are not deck headers.
+    /** @return Always false; card nodes are not deck headers. */
     [[nodiscard]] bool isDeckHeader() const override
     {
         return false;

--- a/libcockatrice_deck_list/libcockatrice/deck_list/tree/inner_deck_list_node.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/tree/inner_deck_list_node.h
@@ -18,11 +18,11 @@
 
 #include "abstract_deck_list_node.h"
 
-/// Constant for the "main" deck zone name.
+/** @brief Constant for the "main" deck zone name. */
 #define DECK_ZONE_MAIN "main"
-/// Constant for the "sideboard" zone name.
+/** @brief Constant for the "sideboard" zone name. */
 #define DECK_ZONE_SIDE "side"
-/// Constant for the "tokens" zone name.
+/** @brief Constant for the "tokens" zone name. */
 #define DECK_ZONE_TOKENS "tokens"
 
 /**
@@ -93,13 +93,13 @@ public:
      */
     void setSortMethod(DeckSortMethod method) override;
 
-    /// @return The internal name of this node.
+    /** @return The internal name of this node. */
     [[nodiscard]] QString getName() const override
     {
         return name;
     }
 
-    /// @param _name Set the internal name of this node.
+    /** @param _name Set the internal name of this node. */
     void setName(const QString &_name)
     {
         name = _name;
@@ -122,25 +122,25 @@ public:
      */
     [[nodiscard]] virtual QString getVisibleName() const;
 
-    /// @return Always empty for container nodes.
+    /** @return Always empty for container nodes. */
     [[nodiscard]] QString getCardProviderId() const override
     {
         return "";
     }
 
-    /// @return Always empty for container nodes.
+    /** @return Always empty for container nodes. */
     [[nodiscard]] QString getCardSetShortName() const override
     {
         return "";
     }
 
-    /// @return Always empty for container nodes.
+    /** @return Always empty for container nodes. */
     [[nodiscard]] QString getCardCollectorNumber() const override
     {
         return "";
     }
 
-    /// @return Always true; InnerDecklistNode represents deck structure.
+    /** @return Always true; InnerDecklistNode represents deck structure. */
     [[nodiscard]] bool isDeckHeader() const override
     {
         return true;
@@ -196,10 +196,10 @@ public:
      */
     bool compare(AbstractDecklistNode *other) const override;
 
-    /// @copydoc compare(AbstractDecklistNode*) const
+    /** @copydoc compare(AbstractDecklistNode*) const */
     bool compareNumber(AbstractDecklistNode *other) const;
 
-    /// @copydoc compare(AbstractDecklistNode*) const
+    /** @copydoc compare(AbstractDecklistNode*) const */
     bool compareName(AbstractDecklistNode *other) const;
 
     /**

--- a/libcockatrice_filters/libcockatrice/filters/filter_card.h
+++ b/libcockatrice_filters/libcockatrice/filters/filter_card.h
@@ -1,8 +1,8 @@
 /**
  * @file filter_card.h
  * @ingroup CardDatabaseModelFilters
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARDFILTER_H
 #define CARDFILTER_H

--- a/libcockatrice_filters/libcockatrice/filters/filter_string.h
+++ b/libcockatrice_filters/libcockatrice/filters/filter_string.h
@@ -1,8 +1,8 @@
 /**
  * @file filter_string.h
  * @ingroup CardDatabaseModelFilters
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef FILTER_STRING_H
 #define FILTER_STRING_H

--- a/libcockatrice_filters/libcockatrice/filters/filter_tree.h
+++ b/libcockatrice_filters/libcockatrice/filters/filter_tree.h
@@ -70,28 +70,33 @@ public:
     }
     virtual void nodeChanged() const
     {
-        if (parent() != nullptr)
+        if (parent() != nullptr) {
             parent()->nodeChanged();
+        }
     }
     virtual void preInsertChild(const FilterTreeNode *p, int i) const
     {
-        if (parent() != nullptr)
+        if (parent() != nullptr) {
             parent()->preInsertChild(p, i);
+        }
     }
     virtual void postInsertChild(const FilterTreeNode *p, int i) const
     {
-        if (parent() != nullptr)
+        if (parent() != nullptr) {
             parent()->postInsertChild(p, i);
+        }
     }
     virtual void preRemoveChild(const FilterTreeNode *p, int i) const
     {
-        if (parent() != nullptr)
+        if (parent() != nullptr) {
             parent()->preRemoveChild(p, i);
+        }
     }
     virtual void postRemoveChild(const FilterTreeNode *p, int i) const
     {
-        if (parent() != nullptr)
+        if (parent() != nullptr) {
             parent()->postRemoveChild(p, i);
+        }
     }
 };
 

--- a/libcockatrice_filters/libcockatrice/filters/filter_tree.h
+++ b/libcockatrice_filters/libcockatrice/filters/filter_tree.h
@@ -1,8 +1,8 @@
 /**
  * @file filter_tree.h
  * @ingroup CardDatabaseModelFilters
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef FILTERTREE_H
 #define FILTERTREE_H

--- a/libcockatrice_models/libcockatrice/models/database/card/card_completer_proxy_model.h
+++ b/libcockatrice_models/libcockatrice/models/database/card/card_completer_proxy_model.h
@@ -1,8 +1,8 @@
 /**
  * @file card_completer_proxy_model.h
  * @ingroup CardDatabaseModels
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARD_COMPLETER_PROXY_MODEL_H
 #define CARD_COMPLETER_PROXY_MODEL_H

--- a/libcockatrice_models/libcockatrice/models/database/card/card_search_model.h
+++ b/libcockatrice_models/libcockatrice/models/database/card/card_search_model.h
@@ -1,8 +1,8 @@
 /**
  * @file card_search_model.h
  * @ingroup CardDatabaseModels
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARD_SEARCH_MODEL_H
 #define CARD_SEARCH_MODEL_H

--- a/libcockatrice_models/libcockatrice/models/database/card_set/card_sets_model.h
+++ b/libcockatrice_models/libcockatrice/models/database/card_set/card_sets_model.h
@@ -1,8 +1,8 @@
 /**
  * @file sets_model.h
  * @ingroup CardDatabaseModels
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef SETSMODEL_H
 #define SETSMODEL_H

--- a/libcockatrice_models/libcockatrice/models/database/token/token_display_model.h
+++ b/libcockatrice_models/libcockatrice/models/database/token/token_display_model.h
@@ -1,8 +1,8 @@
 /**
  * @file token_display_model.h
  * @ingroup CardDatabaseModels
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_TOKEN_DISPLAY_MODEL_H
 #define COCKATRICE_TOKEN_DISPLAY_MODEL_H

--- a/libcockatrice_models/libcockatrice/models/database/token/token_edit_model.h
+++ b/libcockatrice_models/libcockatrice/models/database/token/token_edit_model.h
@@ -1,8 +1,8 @@
 /**
  * @file token_edit_model.h
  * @ingroup CardDatabaseModels
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_TOKEN_EDIT_MODEL_H
 #define COCKATRICE_TOKEN_EDIT_MODEL_H

--- a/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
+++ b/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
@@ -66,7 +66,7 @@ void DeckListModel::rebuildTree()
         for (int j = 0; j < currentZone->size(); j++) {
             auto *currentCard = dynamic_cast<DecklistCardNode *>(currentZone->at(j));
 
-            // TODO: better sanity checking
+            //! \todo Better sanity checking.
             if (currentCard == nullptr) {
                 continue;
             }

--- a/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
+++ b/libcockatrice_models/libcockatrice/models/deck_list/deck_list_model.cpp
@@ -257,8 +257,9 @@ Qt::ItemFlags DeckListModel::flags(const QModelIndex &index) const
 void DeckListModel::emitBackgroundUpdates(const QModelIndex &parent)
 {
     int rows = rowCount(parent);
-    if (rows == 0)
+    if (rows == 0) {
         return;
+    }
 
     QModelIndex topLeft = index(0, 0, parent);
     QModelIndex bottomRight = index(rows - 1, columnCount() - 1, parent);
@@ -539,8 +540,9 @@ int DeckListModel::findSortedInsertRow(const InnerDecklistNode *parent, const Ca
 
     for (int i = 0; i < parent->size(); ++i) {
         auto *existingCard = dynamic_cast<DecklistModelCardNode *>(parent->at(i));
-        if (!existingCard)
+        if (!existingCard) {
             continue;
+        }
 
         bool lessThan = false;
         switch (lastKnownColumn) {
@@ -557,8 +559,9 @@ int DeckListModel::findSortedInsertRow(const InnerDecklistNode *parent, const Ca
                 break;
         }
 
-        if (lessThan)
+        if (lessThan) {
             return i;
+        }
     }
 
     return parent->size(); // insert at end if no earlier match

--- a/libcockatrice_models/libcockatrice/models/deck_list/deck_list_sort_filter_proxy_model.h
+++ b/libcockatrice_models/libcockatrice/models/deck_list/deck_list_sort_filter_proxy_model.h
@@ -1,8 +1,8 @@
 /**
  * @file deck_list_sort_filter_proxy_model.h
  * @ingroup DeckEditorCardGroupWidgets
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_DECK_LIST_SORT_FILTER_PROXY_MODEL_H
 #define COCKATRICE_DECK_LIST_SORT_FILTER_PROXY_MODEL_H

--- a/libcockatrice_network/libcockatrice/network/client/abstract/abstract_client.h
+++ b/libcockatrice_network/libcockatrice/network/client/abstract/abstract_client.h
@@ -1,8 +1,8 @@
 /**
  * @file abstract_client.h
  * @ingroup Client
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef ABSTRACTCLIENT_H
 #define ABSTRACTCLIENT_H

--- a/libcockatrice_network/libcockatrice/network/client/local/local_client.h
+++ b/libcockatrice_network/libcockatrice/network/client/local/local_client.h
@@ -1,8 +1,8 @@
 /**
  * @file local_client.h
  * @ingroup Client
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef LOCALCLIENT_H
 #define LOCALCLIENT_H

--- a/libcockatrice_network/libcockatrice/network/client/remote/remote_client.cpp
+++ b/libcockatrice_network/libcockatrice/network/client/remote/remote_client.cpp
@@ -224,14 +224,14 @@ Command_Login RemoteClient::generateCommandLogin()
 void RemoteClient::doLogin()
 {
     if (!password.isEmpty() && serverSupportsPasswordHash) {
-        // TODO store and log in using stored hashed password
+        //! \todo Store and log in using stored hashed password.
         if (hashedPassword.isEmpty()) {
             doRequestPasswordSalt(); // ask salt to create hashedPassword, then log in
         } else {
             doHashedLogin(); // log in using hashed password instead
         }
     } else {
-        // TODO add setting for client to reject unhashed logins
+        //! \todo Add setting for client to reject unhashed logins.
         setStatus(StatusLoggingIn);
         Command_Login cmdLogin = generateCommandLogin();
         if (!password.isEmpty()) {

--- a/libcockatrice_network/libcockatrice/network/client/remote/remote_client.h
+++ b/libcockatrice_network/libcockatrice/network/client/remote/remote_client.h
@@ -1,8 +1,8 @@
 /**
  * @file remote_client.h
  * @ingroup Client
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef REMOTECLIENT_H
 #define REMOTECLIENT_H

--- a/libcockatrice_network/libcockatrice/network/server/local/local_server.h
+++ b/libcockatrice_network/libcockatrice/network/server/local/local_server.h
@@ -1,8 +1,8 @@
 /**
  * @file local_server.h
  * @ingroup Server
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef LOCALSERVER_H
 #define LOCALSERVER_H

--- a/libcockatrice_network/libcockatrice/network/server/local/local_server_interface.h
+++ b/libcockatrice_network/libcockatrice/network/server/local/local_server_interface.h
@@ -1,8 +1,8 @@
 /**
  * @file local_server_interface.h
  * @ingroup Server
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef LOCALSERVERINTERFACE_H
 #define LOCALSERVERINTERFACE_H

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
@@ -334,7 +334,7 @@ void Server_Game::doStartGameIfReady(bool forceStartGame)
         if (!player->getReadyStart()) {
             if (forceStartGame) {
                 // Player is not ready to start, so kick them
-                // TODO: Move them to Spectators instead
+                //! \todo Move them to Spectators instead.
                 kickParticipant(player->getPlayerId());
             } else {
                 return;
@@ -517,7 +517,7 @@ void Server_Game::addPlayer(Server_AbstractUserInterface *userInterface,
         allPlayersEver.insert(playerName);
 
         // if the original creator of the game joins, give them host status back
-        //! \todo transferring host to spectators has side effects
+        //! \todo Transferring host to spectators has side effects.
         if (newParticipant->getUserInfo()->name() == creatorInfo->name()) {
             hostId = newParticipant->getPlayerId();
             sendGameEventContainer(prepareGameEvent(Event_GameHostChanged(), hostId));

--- a/libcockatrice_network/libcockatrice/network/server/remote/server.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/server.cpp
@@ -286,7 +286,7 @@ QList<QString> Server::getOnlineModeratorList() const
     for (auto &client : clients) {
         ServerInfo_User *data = client->getUserInfo();
 
-        // TODO: this line should be updated in the event there is any type of new user level created
+        //! \todo This line should be updated in the event there is any type of new user level created.
         if (data &&
             (data->user_level() & ServerInfo_User::IsModerator || data->user_level() & ServerInfo_User::IsAdmin)) {
             results << QString::fromStdString(data->name()).simplified();

--- a/libcockatrice_protocol/libcockatrice/protocol/pending_command.h
+++ b/libcockatrice_protocol/libcockatrice/protocol/pending_command.h
@@ -1,8 +1,8 @@
 /**
  * @file pending_command.h
  * @ingroup Messages
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef PENDING_COMMAND_H
 #define PENDING_COMMAND_H

--- a/libcockatrice_settings/libcockatrice/settings/card_database_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/card_database_settings.h
@@ -2,8 +2,8 @@
  * @file card_database_settings.h
  * @ingroup CardDatabase
  * @ingroup CardSettings
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef CARDDATABASESETTINGS_H
 #define CARDDATABASESETTINGS_H

--- a/libcockatrice_settings/libcockatrice/settings/card_override_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/card_override_settings.h
@@ -1,8 +1,8 @@
 /**
  * @file card_override_settings.h
  * @ingroup CardSettings
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_CARD_OVERRIDE_SETTINGS_H
 #define COCKATRICE_CARD_OVERRIDE_SETTINGS_H

--- a/libcockatrice_settings/libcockatrice/settings/debug_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/debug_settings.h
@@ -1,8 +1,8 @@
 /**
  * @file debug_settings.h
  * @ingroup CoreSettings
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef DEBUG_SETTINGS_H
 #define DEBUG_SETTINGS_H

--- a/libcockatrice_settings/libcockatrice/settings/download_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/download_settings.h
@@ -1,8 +1,8 @@
 /**
  * @file download_settings.h
  * @ingroup NetworkSettings
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef COCKATRICE_DOWNLOADSETTINGS_H
 #define COCKATRICE_DOWNLOADSETTINGS_H

--- a/libcockatrice_settings/libcockatrice/settings/game_filters_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/game_filters_settings.h
@@ -2,8 +2,8 @@
  * @file game_filters_settings.h
  * @ingroup Lobby
  * @ingroup GameSettings
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef GAMEFILTERSSETTINGS_H
 #define GAMEFILTERSSETTINGS_H

--- a/libcockatrice_settings/libcockatrice/settings/layouts_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/layouts_settings.h
@@ -1,8 +1,8 @@
 /**
  * @file layouts_settings.h
  * @ingroup CoreSettings
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef LAYOUTSSETTINGS_H
 #define LAYOUTSSETTINGS_H

--- a/libcockatrice_settings/libcockatrice/settings/message_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/message_settings.h
@@ -1,8 +1,8 @@
 /**
  * @file message_settings.h
  * @ingroup NetworkSettings
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef MESSAGESETTINGS_H
 #define MESSAGESETTINGS_H

--- a/libcockatrice_settings/libcockatrice/settings/recents_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/recents_settings.h
@@ -1,8 +1,8 @@
 /**
  * @file recents_settings.h
  * @ingroup DeckSettings
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef RECENTS_SETTINGS_H
 #define RECENTS_SETTINGS_H

--- a/libcockatrice_settings/libcockatrice/settings/servers_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/servers_settings.h
@@ -1,8 +1,8 @@
 /**
  * @file servers_settings.h
  * @ingroup NetworkSettings
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef SERVERSSETTINGS_H
 #define SERVERSSETTINGS_H

--- a/libcockatrice_settings/libcockatrice/settings/settings_manager.h
+++ b/libcockatrice_settings/libcockatrice/settings/settings_manager.h
@@ -1,8 +1,8 @@
 /**
  * @file settings_manager.h
  * @ingroup Settings
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef SETTINGSMANAGER_H
 #define SETTINGSMANAGER_H

--- a/libcockatrice_utility/libcockatrice/utility/levenshtein.h
+++ b/libcockatrice_utility/libcockatrice/utility/levenshtein.h
@@ -1,8 +1,8 @@
 /**
  * @file levenshtein.h
  * @ingroup Core
- * @brief TODO: Document this.
  */
+//! \todo Document this file.
 
 #ifndef LEVENSHTEIN_H
 #define LEVENSHTEIN_H

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -1286,7 +1286,7 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
         return Response::RespEmailBlackListed;
     }
 
-    //! \todo Move this method outside of the db interface
+    //! \todo Move this method outside of the db interface.
     QString errorString;
     if (!sqlInterface->usernameIsValid(userName, errorString)) {
         if (servatrice->getEnableRegistrationAudit()) {
@@ -1421,7 +1421,7 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
 
 bool AbstractServerSocketInterface::tooManyRegistrationAttempts(const QString &ipAddress)
 {
-    //! \todo implement
+    //! \todo Implement registration attempt limiting.
     Q_UNUSED(ipAddress);
     return false;
 }


### PR DESCRIPTION
Standardize Doxygen documentation style to @brief format and TODO/FIXME comments to the Doxygen Qt-style //! \todo format. 

Convert leading triple-slash (///) comments to JavaDoc-style (/** @brief */) documentation for consistent API documentation generation. 
Convert informal TODO and FIXME comments to Doxygen-recognized \todo format
    
- Leading /// comments → /** @brief ... */
- Enum value comments → ///< ...
- Trailing ///< member comments are unchanged
- // TODO comments → //! \todo ...
- // FIXME comments → //! \todo ...
- /** @todo ... */ blocks → //! \todo ...
- @brief TODO: placeholders → //! \todo (moved outside doc blocks)

## Short roundup of the initial problem
Fix for inconsistent documentation style introduced by me or already present in the code.

## Related Issue
- Continues documentation standardization related to issue #6385. PR #6421 fixed the core of the issue while the current PR addresses consistency.