### PR TITLE
[Server][Game] Make undo draw failure visible in chat

### DIFF
--- a/cockatrice/src/game/log/message_log_widget.cpp
+++ b/cockatrice/src/game/log/message_log_widget.cpp
@@ -806,6 +806,12 @@ void MessageLogWidget::logUndoDraw(PlayerLogic *player, QString cardName)
     }
 }
 
+void MessageLogWidget::logUndoDrawFailed(PlayerLogic *player)
+{
+    appendHtmlServerMessage(
+        tr("%1 failed to undo their last draw.").arg(sanitizeHtml(player->getPlayerInfo()->getName())));
+}
+
 void MessageLogWidget::setContextJudgeName(QString name)
 {
     messagePrefix = QString("<span style=\"color:black\">");
@@ -839,6 +845,7 @@ void MessageLogWidget::connectToPlayerEventHandler(PlayerEventHandler *playerEve
     connect(playerEventHandler, &PlayerEventHandler::logDumpZone, this, &MessageLogWidget::logDumpZone);
     connect(playerEventHandler, &PlayerEventHandler::logDrawCards, this, &MessageLogWidget::logDrawCards);
     connect(playerEventHandler, &PlayerEventHandler::logUndoDraw, this, &MessageLogWidget::logUndoDraw);
+    connect(playerEventHandler, &PlayerEventHandler::logUndoDrawFailed, this, &MessageLogWidget::logUndoDrawFailed);
     connect(playerEventHandler, &PlayerEventHandler::logRevealCards, this, &MessageLogWidget::logRevealCards);
     connect(playerEventHandler, &PlayerEventHandler::logAlwaysRevealTopCard, this,
             &MessageLogWidget::logAlwaysRevealTopCard);

--- a/cockatrice/src/game/log/message_log_widget.h
+++ b/cockatrice/src/game/log/message_log_widget.h
@@ -99,6 +99,7 @@ public slots:
     void logSpectatorSay(const ServerInfo_User &spectator, QString message);
     void logUnattachCard(PlayerLogic *player, QString cardName);
     void logUndoDraw(PlayerLogic *player, QString cardName);
+    void logUndoDrawFailed(PlayerLogic *player);
     void setContextJudgeName(QString player);
     void appendHtmlServerMessage(const QString &html,
                                  bool optionalIsBold = false,

--- a/cockatrice/src/game/player/player_event_handler.cpp
+++ b/cockatrice/src/game/player/player_event_handler.cpp
@@ -22,6 +22,7 @@
 #include <libcockatrice/protocol/pb/event_draw_cards.pb.h>
 #include <libcockatrice/protocol/pb/event_dump_zone.pb.h>
 #include <libcockatrice/protocol/pb/event_flip_card.pb.h>
+#include <libcockatrice/protocol/pb/event_game_log_notice.pb.h>
 #include <libcockatrice/protocol/pb/event_game_say.pb.h>
 #include <libcockatrice/protocol/pb/event_move_card.pb.h>
 #include <libcockatrice/protocol/pb/event_reveal_cards.pb.h>
@@ -30,7 +31,6 @@
 #include <libcockatrice/protocol/pb/event_set_card_counter.pb.h>
 #include <libcockatrice/protocol/pb/event_set_counter.pb.h>
 #include <libcockatrice/protocol/pb/event_shuffle.pb.h>
-#include <libcockatrice/protocol/pb/event_undo_draw_failed.pb.h>
 #include <libcockatrice/utility/zone_names.h>
 
 PlayerEventHandler::PlayerEventHandler(PlayerLogic *_player) : QObject(_player), player(_player)
@@ -582,9 +582,16 @@ void PlayerEventHandler::eventChangeZoneProperties(const Event_ChangeZonePropert
     }
 }
 
-void PlayerEventHandler::eventUndoDrawFailed(const Event_UndoDrawFailed &)
+void PlayerEventHandler::eventGameLogNotice(const Event_GameLogNotice &event)
 {
-    emit logUndoDrawFailed(player);
+    Event_GameLogNotice::NoticeType type = event.notice_type();
+    switch (type) {
+        case Event_GameLogNotice::UNDO_DRAW_FAILED:
+            emit logUndoDrawFailed(player);
+            break;
+        default:
+            qWarning() << "Received Event_GameLogNotice with unknown noticeType: " << type;
+    }
 }
 
 void PlayerEventHandler::processGameEvent(GameEvent::GameEventType type,
@@ -650,8 +657,8 @@ void PlayerEventHandler::processGameEvent(GameEvent::GameEventType type,
         case GameEvent::CHANGE_ZONE_PROPERTIES:
             eventChangeZoneProperties(event.GetExtension(Event_ChangeZoneProperties::ext));
             break;
-        case GameEvent::UNDO_DRAW_FAILED:
-            eventUndoDrawFailed(event.GetExtension(Event_UndoDrawFailed::ext));
+        case GameEvent::GAME_LOG_NOTICE:
+            eventGameLogNotice(event.GetExtension(Event_GameLogNotice::ext));
             break;
         default: {
             qWarning() << "unhandled game event" << type;

--- a/cockatrice/src/game/player/player_event_handler.cpp
+++ b/cockatrice/src/game/player/player_event_handler.cpp
@@ -30,6 +30,7 @@
 #include <libcockatrice/protocol/pb/event_set_card_counter.pb.h>
 #include <libcockatrice/protocol/pb/event_set_counter.pb.h>
 #include <libcockatrice/protocol/pb/event_shuffle.pb.h>
+#include <libcockatrice/protocol/pb/event_undo_draw_failed.pb.h>
 #include <libcockatrice/utility/zone_names.h>
 
 PlayerEventHandler::PlayerEventHandler(PlayerLogic *_player) : QObject(_player), player(_player)
@@ -581,6 +582,11 @@ void PlayerEventHandler::eventChangeZoneProperties(const Event_ChangeZonePropert
     }
 }
 
+void PlayerEventHandler::eventUndoDrawFailed(const Event_UndoDrawFailed &)
+{
+    emit logUndoDrawFailed(player);
+}
+
 void PlayerEventHandler::processGameEvent(GameEvent::GameEventType type,
                                           const GameEvent &event,
                                           const GameEventContext &context,
@@ -643,6 +649,9 @@ void PlayerEventHandler::processGameEvent(GameEvent::GameEventType type,
             break;
         case GameEvent::CHANGE_ZONE_PROPERTIES:
             eventChangeZoneProperties(event.GetExtension(Event_ChangeZoneProperties::ext));
+            break;
+        case GameEvent::UNDO_DRAW_FAILED:
+            eventUndoDrawFailed(event.GetExtension(Event_UndoDrawFailed::ext));
             break;
         default: {
             qWarning() << "unhandled game event" << type;

--- a/cockatrice/src/game/player/player_event_handler.h
+++ b/cockatrice/src/game/player/player_event_handler.h
@@ -35,6 +35,8 @@ class Event_SetCardAttr;
 class Event_SetCardCounter;
 class Event_SetCounter;
 class Event_Shuffle;
+class Event_UndoDrawFailed;
+
 class PlayerEventHandler : public QObject
 {
 
@@ -52,6 +54,7 @@ signals:
     void logCreateToken(PlayerLogic *player, QString cardName, QString pt, bool faceDown);
     void logDrawCards(PlayerLogic *player, int number, bool deckIsEmpty);
     void logUndoDraw(PlayerLogic *player, QString cardName);
+    void logUndoDrawFailed(PlayerLogic *player);
     void logMoveCard(PlayerLogic *player,
                      CardItem *card,
                      CardZoneLogic *startZone,
@@ -108,6 +111,7 @@ public:
     void eventDrawCards(const Event_DrawCards &event);
     void eventRevealCards(const Event_RevealCards &event, EventProcessingOptions options);
     void eventChangeZoneProperties(const Event_ChangeZoneProperties &event);
+    void eventUndoDrawFailed(const Event_UndoDrawFailed &event);
 
 private:
     PlayerLogic *player;

--- a/cockatrice/src/game/player/player_event_handler.h
+++ b/cockatrice/src/game/player/player_event_handler.h
@@ -35,7 +35,7 @@ class Event_SetCardAttr;
 class Event_SetCardCounter;
 class Event_SetCounter;
 class Event_Shuffle;
-class Event_UndoDrawFailed;
+class Event_GameLogNotice;
 
 class PlayerEventHandler : public QObject
 {
@@ -111,7 +111,7 @@ public:
     void eventDrawCards(const Event_DrawCards &event);
     void eventRevealCards(const Event_RevealCards &event, EventProcessingOptions options);
     void eventChangeZoneProperties(const Event_ChangeZoneProperties &event);
-    void eventUndoDrawFailed(const Event_UndoDrawFailed &event);
+    void eventGameLogNotice(const Event_GameLogNotice &event);
 
 private:
     PlayerLogic *player;

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_player.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_player.cpp
@@ -36,10 +36,10 @@
 #include <libcockatrice/protocol/pb/event_create_counter.pb.h>
 #include <libcockatrice/protocol/pb/event_del_counter.pb.h>
 #include <libcockatrice/protocol/pb/event_draw_cards.pb.h>
+#include <libcockatrice/protocol/pb/event_game_log_notice.pb.h>
 #include <libcockatrice/protocol/pb/event_player_properties_changed.pb.h>
 #include <libcockatrice/protocol/pb/event_set_counter.pb.h>
 #include <libcockatrice/protocol/pb/event_shuffle.pb.h>
-#include <libcockatrice/protocol/pb/event_undo_draw_failed.pb.h>
 #include <libcockatrice/protocol/pb/response.pb.h>
 #include <libcockatrice/protocol/pb/response_deck_download.pb.h>
 #include <libcockatrice/protocol/pb/response_dump_zone.pb.h>
@@ -410,7 +410,8 @@ Server_Player::cmdUndoDraw(const Command_UndoDraw & /*cmd*/, ResponseContainer &
     }
 
     if (lastDrawList.isEmpty()) {
-        Event_UndoDrawFailed event;
+        Event_GameLogNotice event;
+        event.set_notice_type(Event_GameLogNotice::UNDO_DRAW_FAILED);
         ges.enqueueGameEvent(event, playerId);
         return Response::RespContextError;
     }

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_player.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_player.cpp
@@ -39,6 +39,7 @@
 #include <libcockatrice/protocol/pb/event_player_properties_changed.pb.h>
 #include <libcockatrice/protocol/pb/event_set_counter.pb.h>
 #include <libcockatrice/protocol/pb/event_shuffle.pb.h>
+#include <libcockatrice/protocol/pb/event_undo_draw_failed.pb.h>
 #include <libcockatrice/protocol/pb/response.pb.h>
 #include <libcockatrice/protocol/pb/response_deck_download.pb.h>
 #include <libcockatrice/protocol/pb/response_dump_zone.pb.h>
@@ -409,6 +410,8 @@ Server_Player::cmdUndoDraw(const Command_UndoDraw & /*cmd*/, ResponseContainer &
     }
 
     if (lastDrawList.isEmpty()) {
+        Event_UndoDrawFailed event;
+        ges.enqueueGameEvent(event, playerId);
         return Response::RespContextError;
     }
 

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/CMakeLists.txt
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/CMakeLists.txt
@@ -106,6 +106,7 @@ set(PROTO_FILES
     event_set_card_counter.proto
     event_set_counter.proto
     event_shuffle.proto
+    event_undo_draw_failed.proto
     event_user_joined.proto
     event_user_left.proto
     event_user_message.proto

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/CMakeLists.txt
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/CMakeLists.txt
@@ -76,6 +76,7 @@ set(PROTO_FILES
     event_game_closed.proto
     event_game_host_changed.proto
     event_game_joined.proto
+    event_game_log_notice.proto
     event_game_say.proto
     event_game_state_changed.proto
     event_game_state_changed.proto
@@ -106,7 +107,6 @@ set(PROTO_FILES
     event_set_card_counter.proto
     event_set_counter.proto
     event_shuffle.proto
-    event_undo_draw_failed.proto
     event_user_joined.proto
     event_user_left.proto
     event_user_message.proto

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/event_game_log_notice.proto
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/event_game_log_notice.proto
@@ -1,0 +1,20 @@
+syntax = "proto2";
+import "game_event.proto";
+
+// Notifies clients of an event that happened, and which could safely be dropped without affect the game state.
+// This mostly just means events that should cause a message to be logged to chat.
+message Event_GameLogNotice {
+
+    // The type of the notice.
+    // Clients who do not recognize the type should drop the event.
+    enum NoticeType {
+        // Player's "undo draw" command failed due to losing track of recent draw
+        UNDO_DRAW_FAILED = 1;
+    }
+
+    extend GameEvent {
+        optional Event_GameLogNotice ext = 2022;
+    }
+
+    optional NoticeType notice_type = 1;
+}

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/event_undo_draw_failed.proto
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/event_undo_draw_failed.proto
@@ -1,9 +1,0 @@
-syntax = "proto2";
-import "game_event.proto";
-
-message Event_UndoDrawFailed {
-    extend GameEvent {
-        optional Event_UndoDrawFailed ext = 2022;
-    }
-    optional sint32 phase = 1;
-}

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/event_undo_draw_failed.proto
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/event_undo_draw_failed.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+import "game_event.proto";
+
+message Event_UndoDrawFailed {
+    extend GameEvent {
+        optional Event_UndoDrawFailed ext = 2022;
+    }
+    optional sint32 phase = 1;
+}

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/game_event.proto
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/game_event.proto
@@ -33,6 +33,7 @@ message GameEvent {
         // STOP_DUMP_ZONE = 2019; // obsolete
         CHANGE_ZONE_PROPERTIES = 2020;
         REVERSE_TURN = 2021;
+        UNDO_DRAW_FAILED = 2022;
     }
     optional sint32 player_id = 1 [default = -1];
     extensions 100 to max;

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/game_event.proto
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/game_event.proto
@@ -33,7 +33,7 @@ message GameEvent {
         // STOP_DUMP_ZONE = 2019; // obsolete
         CHANGE_ZONE_PROPERTIES = 2020;
         REVERSE_TURN = 2021;
-        UNDO_DRAW_FAILED = 2022;
+        GAME_LOG_NOTICE = 2022;
     }
     optional sint32 player_id = 1 [default = -1];
     extensions 100 to max;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6883

## Short roundup of the initial problem

Judges have no way to verify if an "undo draw" failed.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/8a63dfa6-7afa-43f9-b14e-2a2eca60ae41

- Added a new `Event_UndoDrawFailed` game event to the proto
  - Needs to be a new event since the successful undo draw is communicated through a EventContext
- Server sends the event when undo draw fails, right before returning the response code
- Client logs the failure to chat upon receiving the event 
  - Since this is a new event, older clients will safely completely ignore it

Still, having an entire single event for "undo draw failed" feels a bit weird.
For forwards-compatibility, perhaps we can instead make it a "generic status update that doesn't modify gamestate" event, containing a field holding an enum that signals what the status update in question is.
Then UNDO_DRAW_FAILED can be one of the enum values.
That means we can just add to the enum if we need more of this sort of thing in the future, instead of creating new events.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<img width="466" height="322" alt="Screenshot 2026-05-13 at 2 57 32 AM" src="https://github.com/user-attachments/assets/2a63bf8b-6a07-4c38-a4c7-097d2dce2da2" />
