### PR TITLE
Add reminder check list to release template

### DIFF
--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -1,8 +1,29 @@
 <!-- this template comes from .ci/release_template.md -->
 
-<!-- Don't forget to delete the previous betas after publishing this!
-git push -d origin --REPLACE-WITH-BETA-LIST--
- -->
+
+>[!CAUTION]
+> **Release Check List**
+>
+>**While DRAFTING** a new stable release:
+> - [ ] Pull in newest translations data from transifex: [Trigger workflow manually](https://github.com/Cockatrice/Cockatrice/actions/workflows/translations-pull.yml) & merge PR's
+> - [ ] [Create a Draft Release in GitHub UI](https://github.com/Cockatrice/Cockatrice/releases/new)
+>   - [ ] Add `title` in the form `Cockatrice X.Y.Z: <RELEASE_NAME>`
+>   - [ ] Create a new `tag` targeting master branch in the form `YYYY-MM-DD-Release-X.Y.Z` (Also see [CONTRIBUTING](https://github.com/Cockatrice/Cockatrice/blob/master/.github/CONTRIBUTING.md#release-management) file)
+> - [ ] Review & update automatically generated Release Notes
+>   - [ ] Review [current build pipeline](https://github.com/Cockatrice/Cockatrice/blob/master/.github/workflows/desktop-build.yml) and update list of release binaries
+>   - [ ] Add note for relevant deprecations of supported operating systems or achitectures
+>   - [ ] Note Highlights / New Features / Important Fixes
+> <br>
+>
+>**After PUBLISHING** the release:
+> - [ ] Delete previous betas (double check this command carefully before executing the remote deletion)
+>    ```
+>    gh release delete --no-delete-tag --REPLACE-WITH-BETA-LIST--
+>    ```
+> - [ ] Bump version in main [CMakeLists](https://github.com/Cockatrice/Cockatrice/blob/master/CMakeLists.txt) to next patch release, e.g. `project("Cockatrice" VERSION 3.0.1)`
+> - [ ] Remove this reminder check list
+<br>
+
 
 <!-- This list of binaries should be updated every time the CI is changed to include all targets -->
 <pre>


### PR DESCRIPTION
Add a check list as reminder before/during releases.
We currently have something in the contributing file, but it feels outdated and is probably often missed.
Probably more helpful to bring the information "closer to the release".
For recent v3 release, we missed to pull in most recent translations for example, and there were issues with deleting beta releases after.

View result: https://github.com/Cockatrice/Cockatrice/blob/tooomm-release_list/.ci/release_template.md
Did I miss something? Suggestions?

<br>

A comment in the template did mention `git push -d origin <TAG>` before which would actually delete the tag.
Instead `gh release delete --no-delete-tag <TAG>` is probably what we need **if related tags should not be deleted and be kept for reference**, but rather the GitHub Release associated with it.

<br>

Not too sure about the [.ci/prep_release.sh](https://github.com/Cockatrice/Cockatrice/blob/master/.ci/prep_release.sh) script, which is [run on tags](https://github.com/Cockatrice/Cockatrice/blob/master/.github/workflows/desktop-build.yml#L79).
Is creating releases in the GitHub UI conflicting?
Should beta and full releases always and only be created via the automation after creating a tag via git CLI? 🤔 
Has been a while that I created releases or drafted them.
The check list should then update as well.

Our release process could be better documented (and updated) in the CONTRIBUTING file.
Happy to do that - add your comments and thoughts here.



Add note on merging flatpak auto-pr (watch repo)


Add job which runs on pre-releases and auto-publishes the draft release at github after both (build-linux + build-vcpkg) main jobs completed successfully and published their assets (draft is creatd in "configure" job)
Not sure how it comes together for full releases, same? Or do we want a human gate here to coordinate the release better?