### PR TITLE
Update Linux Dockerfiles of build pipeline

### DIFF
--- a/.ci/Arch/Dockerfile
+++ b/.ci/Arch/Dockerfile
@@ -1,19 +1,17 @@
 from archlinux:latest
 
 RUN pacman --sync --refresh --sysupgrade --needed --noconfirm \
-        base-devel \
-        ccache \
-        cmake \
-        git \
-        gtest \
-        mariadb-libs \
-        ninja \
-        protobuf \
-        qt6-base \
-        qt6-imageformats \
-        qt6-multimedia \
-        qt6-svg \
-        qt6-tools \
-        qt6-translations \
-        qt6-websockets \
+      ccache \
+      cmake \
+	  gcc \
+	  git \
+      gtest \
+      ninja \
+      protobuf \
+	  qt6-imageformats \
+	  qt6-multimedia \
+	  qt6-svg \
+	  qt6-tools \
+	  qt6-translations \
+	  qt6-websockets \
     && pacman --sync --clean --clean --noconfirm

--- a/.ci/Arch/Dockerfile
+++ b/.ci/Arch/Dockerfile
@@ -4,7 +4,7 @@ RUN pacman --sync --refresh --sysupgrade --needed --noconfirm \
       ccache \
       cmake \
 	  gcc \
-    # gtest    Exclude gtest to confirm fallback of downloading source from google repo keeps working
+    # gtest    Exclude gtest to confirm fallback download and building from google repo keeps working
       ninja \
       protobuf \
 	  qt6-imageformats \

--- a/.ci/Arch/Dockerfile
+++ b/.ci/Arch/Dockerfile
@@ -4,7 +4,7 @@ RUN pacman --sync --refresh --sysupgrade --needed --noconfirm \
       ccache \
       cmake \
 	  gcc \
-      gtest \
+    # gtest    Exclude gtest to confirm fallback of downloading source from google repo keeps working
       ninja \
       protobuf \
 	  qt6-imageformats \

--- a/.ci/Arch/Dockerfile
+++ b/.ci/Arch/Dockerfile
@@ -4,7 +4,6 @@ RUN pacman --sync --refresh --sysupgrade --needed --noconfirm \
       ccache \
       cmake \
 	  gcc \
-	  git \
       gtest \
       ninja \
       protobuf \

--- a/.ci/Debian12/Dockerfile
+++ b/.ci/Debian12/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update \
       cmake \
 	  file \
       g++ \
-      git \
       libgl-dev \
 	  libgtest-dev \
       liblzma-dev \

--- a/.ci/Debian12/Dockerfile
+++ b/.ci/Debian12/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
       ccache \
       cmake \
+	  file \
       g++ \
       git \
       libgl-dev \

--- a/.ci/Debian12/Dockerfile
+++ b/.ci/Debian12/Dockerfile
@@ -1,28 +1,25 @@
 FROM debian:12
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        build-essential \
-        ccache \
-        clang-format \
-        cmake \
-        file \
-        g++ \
-        git \
-        libgl-dev \
-        liblzma-dev \
-        libmariadb-dev-compat \
-        libprotobuf-dev \
-        libqt6multimedia6 \
-        libqt6sql6-mysql \
-        ninja-build \
-        protobuf-compiler \
-        qt6-image-formats-plugins \
-        qt6-l10n-tools \
-        qt6-multimedia-dev \
-        qt6-svg-dev \
-        qt6-tools-dev \
-        qt6-tools-dev-tools \
-        qt6-websockets-dev \
-    && apt-get clean \
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      ccache \
+      cmake \
+      g++ \
+      git \
+      libgl-dev \
+      liblzma-dev \
+      libprotobuf-dev \
+      libqt6multimedia6 \
+      libqt6sql6-mysql \
+      ninja-build \
+      protobuf-compiler \
+      qt6-image-formats-plugins \
+      qt6-l10n-tools \
+      qt6-multimedia-dev \
+      qt6-svg-dev \
+      qt6-tools-dev \
+      qt6-tools-dev-tools \
+      qt6-websockets-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/.ci/Debian12/Dockerfile
+++ b/.ci/Debian12/Dockerfile
@@ -10,10 +10,10 @@ RUN apt-get update \
       g++ \
       git \
       libgl-dev \
+	  libgtest-dev \
       liblzma-dev \
       libprotobuf-dev \
       libqt6multimedia6 \
-      libqt6sql6-mysql \
       ninja-build \
       protobuf-compiler \
       qt6-image-formats-plugins \

--- a/.ci/Debian12/Dockerfile
+++ b/.ci/Debian12/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12
+FROM debian:12-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/.ci/Debian13/Dockerfile
+++ b/.ci/Debian13/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update \
       cmake \
 	  file \
       g++ \
-      git \
       libgl-dev \
 	  libgtest-dev \
       liblzma-dev \

--- a/.ci/Debian13/Dockerfile
+++ b/.ci/Debian13/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:13
+FROM debian:13-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/.ci/Debian13/Dockerfile
+++ b/.ci/Debian13/Dockerfile
@@ -1,29 +1,24 @@
 FROM debian:13
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        build-essential \
-        ca-certificates \
-        ccache \
-        clang-format \
-        cmake \
-        file \
-        g++ \
-        git \
-        libgl-dev \
-        liblzma-dev \
-        libmariadb-dev-compat \
-        libprotobuf-dev \
-        libqt6multimedia6 \
-        libqt6sql6-mysql \
-        ninja-build \
-        protobuf-compiler \
-        qt6-image-formats-plugins \
-        qt6-l10n-tools \
-        qt6-multimedia-dev \
-        qt6-svg-dev \
-        qt6-tools-dev \
-        qt6-tools-dev-tools \
-        qt6-websockets-dev \
-    && apt-get clean \
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      ccache \
+      cmake \
+      g++ \
+      git \
+      libgl-dev \
+      liblzma-dev \
+      libprotobuf-dev \
+      libqt6multimedia6 \
+      ninja-build \
+      protobuf-compiler \
+      qt6-image-formats-plugins \
+      qt6-l10n-tools \
+      qt6-multimedia-dev \
+      qt6-svg-dev \
+      qt6-tools-dev \
+      qt6-tools-dev-tools \
+      qt6-websockets-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/.ci/Debian13/Dockerfile
+++ b/.ci/Debian13/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
       ccache \
       cmake \
+	  file \
       g++ \
       git \
       libgl-dev \

--- a/.ci/Debian13/Dockerfile
+++ b/.ci/Debian13/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
       g++ \
       git \
       libgl-dev \
+	  libgtest-dev \
       liblzma-dev \
       libprotobuf-dev \
       libqt6multimedia6 \

--- a/.ci/Fedora43/Dockerfile
+++ b/.ci/Fedora43/Dockerfile
@@ -5,6 +5,7 @@ RUN dnf install -y --setopt=install_weak_deps=False \
       cmake \
       gcc-c++ \
       git \
+	  gtest-devel \
       ninja-build \
       protobuf-devel \
       qt6-qttools-devel \

--- a/.ci/Fedora43/Dockerfile
+++ b/.ci/Fedora43/Dockerfile
@@ -7,11 +7,11 @@ RUN dnf install -y --setopt=install_weak_deps=False \
 	  gtest-devel \
       ninja-build \
       protobuf-devel \
-      qt6-qttools-devel \
-      qt6-qtsvg-devel \
-      qt6-qtmultimedia-devel \
-      qt6-qtwebsockets-devel \
       qt6-qtimageformats \
+      qt6-qtmultimedia-devel \
+      qt6-qtsvg-devel \
+      qt6-qttools-devel \
+      qt6-qtwebsockets-devel \
       rpm-build \
       xz-devel \
       zlib-devel \

--- a/.ci/Fedora43/Dockerfile
+++ b/.ci/Fedora43/Dockerfile
@@ -1,16 +1,19 @@
 FROM fedora:43
 
-RUN dnf install -y \
-        ccache \
-        cmake \
-        gcc-c++ \
-        git \
-        mariadb-devel \
-        ninja-build \
-        protobuf-devel \
-        qt6-{qttools,qtsvg,qtmultimedia,qtwebsockets}-devel \
-        qt6-qtimageformats \
-        rpm-build \
-        xz-devel \
-        zlib-devel \
-    && dnf clean all
+RUN dnf install -y --setopt=install_weak_deps=False \
+      ccache \
+      cmake \
+      gcc-c++ \
+      git \
+      ninja-build \
+      protobuf-devel \
+      qt6-qttools-devel \
+      qt6-qtsvg-devel \
+      qt6-qtmultimedia-devel \
+      qt6-qtwebsockets-devel \
+      qt6-qtimageformats \
+      rpm-build \
+      xz-devel \
+      zlib-devel \
+    && dnf clean all \
+	&& rm -rf /var/cache/dnf

--- a/.ci/Fedora43/Dockerfile
+++ b/.ci/Fedora43/Dockerfile
@@ -4,7 +4,6 @@ RUN dnf install -y --setopt=install_weak_deps=False \
       ccache \
       cmake \
       gcc-c++ \
-      git \
 	  gtest-devel \
       ninja-build \
       protobuf-devel \

--- a/.ci/Fedora43/Dockerfile
+++ b/.ci/Fedora43/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:43
 
-RUN dnf install -y --setopt=install_weak_deps=False \
+RUN dnf install -y --nodocs --setopt=install_weak_deps=False \
       ccache \
       cmake \
       gcc-c++ \

--- a/.ci/Fedora44/Dockerfile
+++ b/.ci/Fedora44/Dockerfile
@@ -5,6 +5,7 @@ RUN dnf install -y --setopt=install_weak_deps=False \
       cmake \
       gcc-c++ \
       git \
+	  gtest-devel \
       ninja-build \
       protobuf-devel \
       qt6-qttools-devel \

--- a/.ci/Fedora44/Dockerfile
+++ b/.ci/Fedora44/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:44
 
-RUN dnf install -y --setopt=install_weak_deps=False \
+RUN dnf install -y --nodocs --setopt=install_weak_deps=False \
       ccache \
       cmake \
       gcc-c++ \

--- a/.ci/Fedora44/Dockerfile
+++ b/.ci/Fedora44/Dockerfile
@@ -1,16 +1,19 @@
 FROM fedora:44
 
-RUN dnf install -y \
-        ccache \
-        cmake \
-        gcc-c++ \
-        git \
-        mariadb-devel \
-        ninja-build \
-        protobuf-devel \
-        qt6-{qttools,qtsvg,qtmultimedia,qtwebsockets}-devel \
-        qt6-qtimageformats \
-        rpm-build \
-        xz-devel \
-        zlib-devel \
-    && dnf clean all
+RUN dnf install -y --setopt=install_weak_deps=False \
+      ccache \
+      cmake \
+      gcc-c++ \
+      git \
+      ninja-build \
+      protobuf-devel \
+      qt6-qttools-devel \
+	  qt6-qtsvg-devel \
+	  qt6-qtmultimedia-devel \
+	  qt6-qtwebsockets-devel \
+      qt6-qtimageformats \
+      rpm-build \
+      xz-devel \
+      zlib-devel \
+    && dnf clean all \
+	&& rm -rf /var/cache/dnf

--- a/.ci/Fedora44/Dockerfile
+++ b/.ci/Fedora44/Dockerfile
@@ -7,11 +7,11 @@ RUN dnf install -y --setopt=install_weak_deps=False \
 	  gtest-devel \
       ninja-build \
       protobuf-devel \
-      qt6-qttools-devel \
-	  qt6-qtsvg-devel \
-	  qt6-qtmultimedia-devel \
-	  qt6-qtwebsockets-devel \
       qt6-qtimageformats \
+      qt6-qtmultimedia-devel \
+      qt6-qtsvg-devel \
+      qt6-qttools-devel \
+      qt6-qtwebsockets-devel \
       rpm-build \
       xz-devel \
       zlib-devel \

--- a/.ci/Fedora44/Dockerfile
+++ b/.ci/Fedora44/Dockerfile
@@ -4,7 +4,6 @@ RUN dnf install -y --setopt=install_weak_deps=False \
       ccache \
       cmake \
       gcc-c++ \
-      git \
 	  gtest-devel \
       ninja-build \
       protobuf-devel \

--- a/.ci/Servatrice_Debian12/Dockerfile
+++ b/.ci/Servatrice_Debian12/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update \
       cmake \
 	  file \
       g++ \
-      git \
       libmariadb-dev-compat \
       libprotobuf-dev \
       libqt6sql6-mysql \

--- a/.ci/Servatrice_Debian12/Dockerfile
+++ b/.ci/Servatrice_Debian12/Dockerfile
@@ -1,21 +1,19 @@
 FROM debian:12
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        build-essential \
-        ccache \
-        clang-format \
-        cmake \
-        file \
-        g++ \
-        git \
-        libmariadb-dev-compat \
-        libprotobuf-dev \
-        libqt6sql6-mysql \
-        ninja-build \
-        protobuf-compiler \
-        qt6-tools-dev \
-        qt6-tools-dev-tools \
-        qt6-websockets-dev \
-    && apt-get clean \
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      ccache \
+      cmake \
+      g++ \
+      git \
+      libmariadb-dev-compat \
+      libprotobuf-dev \
+      libqt6sql6-mysql \
+      ninja-build \
+      protobuf-compiler \
+      qt6-tools-dev \
+      qt6-tools-dev-tools \
+      qt6-websockets-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/.ci/Servatrice_Debian12/Dockerfile
+++ b/.ci/Servatrice_Debian12/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
       ccache \
       cmake \
+	  file \
       g++ \
       git \
       libmariadb-dev-compat \

--- a/.ci/Servatrice_Debian12/Dockerfile
+++ b/.ci/Servatrice_Debian12/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12
+FROM debian:12-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/.ci/Ubuntu24.04/Dockerfile
+++ b/.ci/Ubuntu24.04/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update \
       cmake \
 	  file \
       g++ \
-      git \
       libgl-dev \
 	  libgtest-dev \
       liblzma-dev \

--- a/.ci/Ubuntu24.04/Dockerfile
+++ b/.ci/Ubuntu24.04/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
       ccache \
       cmake \
+	  file \
       g++ \
       git \
       libgl-dev \

--- a/.ci/Ubuntu24.04/Dockerfile
+++ b/.ci/Ubuntu24.04/Dockerfile
@@ -1,28 +1,24 @@
 FROM ubuntu:24.04
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        build-essential \
-        ccache \
-        clang-format \
-        cmake \
-        file \
-        g++ \
-        git \
-        libgl-dev \
-        liblzma-dev \
-        libmariadb-dev-compat \
-        libprotobuf-dev \
-        libqt6multimedia6 \
-        libqt6sql6-mysql \
-        ninja-build \
-        protobuf-compiler \
-        qt6-image-formats-plugins \
-        qt6-l10n-tools \
-        qt6-multimedia-dev \
-        qt6-svg-dev \
-        qt6-tools-dev \
-        qt6-tools-dev-tools \
-        qt6-websockets-dev \
-    && apt-get clean \
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      ccache \
+      cmake \
+      g++ \
+      git \
+      libgl-dev \
+      liblzma-dev \
+      libprotobuf-dev \
+      libqt6multimedia6 \
+      ninja-build \
+      protobuf-compiler \
+      qt6-image-formats-plugins \
+      qt6-l10n-tools \
+      qt6-multimedia-dev \
+      qt6-svg-dev \
+      qt6-tools-dev \
+      qt6-tools-dev-tools \
+      qt6-websockets-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/.ci/Ubuntu24.04/Dockerfile
+++ b/.ci/Ubuntu24.04/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
       g++ \
       git \
       libgl-dev \
+	  libgtest-dev \
       liblzma-dev \
       libprotobuf-dev \
       libqt6multimedia6 \

--- a/.ci/Ubuntu26.04/Dockerfile
+++ b/.ci/Ubuntu26.04/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update \
       cmake \
 	  file \
       g++ \
-      git \
       libgl-dev \
 	  libgtest-dev \
       liblzma-dev \

--- a/.ci/Ubuntu26.04/Dockerfile
+++ b/.ci/Ubuntu26.04/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
       ccache \
       cmake \
+	  file \
       g++ \
       git \
       libgl-dev \

--- a/.ci/Ubuntu26.04/Dockerfile
+++ b/.ci/Ubuntu26.04/Dockerfile
@@ -1,29 +1,24 @@
 FROM ubuntu:26.04
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        build-essential \
-        ca-certificates \
-        ccache \
-        clang-format \
-        cmake \
-        file \
-        g++ \
-        git \
-        libgl-dev \
-        liblzma-dev \
-        libmariadb-dev-compat \
-        libprotobuf-dev \
-        libqt6multimedia6 \
-        libqt6sql6-mysql \
-        ninja-build \
-        protobuf-compiler \
-        qt6-image-formats-plugins \
-        qt6-l10n-tools \
-        qt6-multimedia-dev \
-        qt6-svg-dev \
-        qt6-tools-dev \
-        qt6-tools-dev-tools \
-        qt6-websockets-dev \
-    && apt-get clean \
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      ccache \
+      cmake \
+      g++ \
+      git \
+      libgl-dev \
+      liblzma-dev \
+      libprotobuf-dev \
+      libqt6multimedia6 \
+      ninja-build \
+      protobuf-compiler \
+      qt6-image-formats-plugins \
+      qt6-l10n-tools \
+      qt6-multimedia-dev \
+      qt6-svg-dev \
+      qt6-tools-dev \
+      qt6-tools-dev-tools \
+      qt6-websockets-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/.ci/Ubuntu26.04/Dockerfile
+++ b/.ci/Ubuntu26.04/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
       g++ \
       git \
       libgl-dev \
+	  libgtest-dev \
       liblzma-dev \
       libprotobuf-dev \
       libqt6multimedia6 \


### PR DESCRIPTION
## Short roundup of the initial problem


## What will change with this Pull Request?
- Add gtest dev package to all images to avoid (hardcoded) fallback file download (no ca-certificate dependency)
  For Arch, gtest is commented out to test downloading and building from source repo
- Reformat for uniform style with Servatrice Dockerfile and better readability
- Remove not needed packages
  meta packages (base-devel, build-essential), git, qt6-base, clang-format, ca-certificates
- Cleanup Fedora images after package installation (similar to how it's done on Debian/Ubuntu images)