### PR TITLE
Enable `RemoveSemicolon` & update format.sh

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,9 @@ AccessModifierOffset: -4
 ColumnLimit: 120
 ---
 Language: Cpp
-BreakBeforeBraces: Custom
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortFunctionsOnASingleLine: None
+BinPackParameters: false
 BraceWrapping:
   AfterClass: true
   AfterControlStatement: false
@@ -18,18 +20,14 @@ BraceWrapping:
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
-AllowShortFunctionsOnASingleLine: None
-BinPackParameters: false
-AllowAllParametersOfDeclarationOnNextLine: false
-IndentCaseLabels: true
-PointerAlignment: Right
-SortIncludes: true
+BreakBeforeBraces: Custom
 IncludeBlocks: Regroup
-StatementAttributeLikeMacros: [emit]
-# requires clang-format 15
+IndentCaseLabels: true
 InsertBraces: true
-# requires clang-format 16
-# RemoveSemicolon: true
+PointerAlignment: Right
+RemoveSemicolon: true
+SortIncludes: true
+StatementAttributeLikeMacros: [emit]
 ---
 Language: Proto
 AllowShortFunctionsOnASingleLine: None

--- a/format.sh
+++ b/format.sh
@@ -14,16 +14,7 @@ cd "${BASH_SOURCE%/*}/" || exit 2 # could not find path, this could happen with 
 
 # defaults
 include=("cockatrice/src" \
-"libcockatrice_card" \
-"libcockatrice_deck_list" \
-"libcockatrice_filters" \
-"libcockatrice_interfaces" \
-"libcockatrice_models" \
-"libcockatrice_network" \
-"libcockatrice_protocol" \
-"libcockatrice_rng" \
-"libcockatrice_settings" \
-"libcockatrice_utility" \
+libcockatrice_* \
 "oracle/src" \
 "servatrice/src" \
 "tests")

--- a/format.sh
+++ b/format.sh
@@ -16,6 +16,9 @@ cd "${BASH_SOURCE%/*}/" || exit 2 # could not find path, this could happen with 
 include=("cockatrice/src" \
 "libcockatrice_card" \
 "libcockatrice_deck_list" \
+"libcockatrice_filters" \
+"libcockatrice_interfaces" \
+"libcockatrice_models" \
 "libcockatrice_network" \
 "libcockatrice_protocol" \
 "libcockatrice_rng" \


### PR DESCRIPTION
## Related Ticket(s)
- Related #6887

## Short roundup of the initial problem
Option was commented out, but we run on v18

## What will change with this Pull Request?
- Sort options alphabetically within languages
- Enable RemoveSemicolon option
- Remove comments on old clang-format versions
- Use libcockatrice_* to match all libs dynamically in format.sh