### PR TITLE
Pre-release script: Escape ampersand

### DIFF
--- a/.ci/prep_release.sh
+++ b/.ci/prep_release.sh
@@ -89,6 +89,8 @@ else
       echo "'$previous' to '$TAG' ($count commits)"
       # --> is the markdown comment escape sequence, emojis are way better
       generated_list="${generated_list//-->/→}"
+      # Escape & to preserve it from commit message into markdown output
+      generated_list="${generated_list//&/\\&}"
       body="${body//--REPLACE-WITH-GENERATED-LIST--/$generated_list}"
       body="${body//--REPLACE-WITH-COMMIT-COUNT--/$count}"
       body="${body//--REPLACE-WITH-PREVIOUS-RELEASE-TAG--/$previous}"


### PR DESCRIPTION
## Short roundup of the initial problem
Turns out `&` is not escaped in bash and is interpreted.
--> & is replaced in resulting markdown

## What will change with this Pull Request?
- Escape it to preserve commit messages with "&"

## Screenshots
Last Beta release
<img width="1097" height="652" alt="Image" src="https://github.com/user-attachments/assets/cac284ee-ffc6-4a5e-b241-2d8573534bab" />

Note the `--REPLACE-WITH-GENERATED-LIST--` in the title of one of the commits.

While the original commit looks different in history:
<img width="1391" height="137" alt="Image" src="https://github.com/user-attachments/assets/0356a4ad-ffa4-4f1b-8549-6df5ac7ac78f" />