### PR TITLE
fix cards attaching/transforming to the wrong card across players

### DIFF
--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -1070,9 +1070,9 @@ bool PlayerActions::createRelatedFromRelation(const CardItem *sourceCard, const 
         }
     } else {
         CardRelationType attachType;
+        // do not attempt to attach to another player's cards, this causes the card to attempt to attach to the same
+        // cardid on the local player's field instead, which is an entirely different card!
         if (player->getPlayerInfo()->getLocalOrJudge()) {
-            // do not attempt to attach to another player's cards, this causes the card to attempt to attach to the same
-            // cardid on the local player's field instead, which is an entirely different card!
             attachType = cardRelation->getAttachType();
         } else {
             attachType = CardRelationType::DoesNotAttach;

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -1069,7 +1069,14 @@ bool PlayerActions::createRelatedFromRelation(const CardItem *sourceCard, const 
             createCard(sourceCard, dbName, CardRelationType::DoesNotAttach, persistent);
         }
     } else {
-        auto attachType = cardRelation->getAttachType();
+        CardRelationType attachType;
+        if (player->getPlayerInfo()->getLocalOrJudge()) {
+            // do not attempt to attach to another player's cards, this causes the card to attempt to attach to the same
+            // cardid on the local player's field instead, which is an entirely different card!
+            attachType = cardRelation->getAttachType();
+        } else {
+            attachType = CardRelationType::DoesNotAttach;
+        }
 
         // move card onto table first if attaching from some other zone
         // we only do this for AttachTo because cross-zone TransformInto is already handled server-side


### PR DESCRIPTION
## Related Ticket(s)
- presumably introduced in #2773

## Short roundup of the initial problem
when a player transforms a card controlled by another player that has the same cardid as a card on that player's own field, it'll destroy and replace it, similarly if it is instructed to "attach" it will attach to the card with the same id on the player's own side of the board.

## What will change with this Pull Request?
- check for and do not allow attaching/transforming of tokens created by an opponent's card