### PR TITLE
[Player] Pull handVisible out of player_info and let graphics_item just determine this on its own.

### DIFF
--- a/cockatrice/src/game/player/player_graphics_item.cpp
+++ b/cockatrice/src/game/player/player_graphics_item.cpp
@@ -158,11 +158,11 @@ void PlayerGraphicsItem::rearrangeZones()
     if (SettingsCache::instance().getHorizontalHand()) {
         if (mirrored) {
             if (player->getHandZone()->contentsKnown()) {
-                player->getPlayerInfo()->setHandVisible(true);
+                handVisible = true;
                 handZoneGraphicsItem->setPos(base);
                 base += QPointF(0, handZoneGraphicsItem->boundingRect().height());
             } else {
-                player->getPlayerInfo()->setHandVisible(false);
+                handVisible = false;
             }
 
             stackZoneGraphicsItem->setPos(base);
@@ -176,16 +176,16 @@ void PlayerGraphicsItem::rearrangeZones()
             base += QPointF(0, tableZoneGraphicsItem->boundingRect().height());
 
             if (player->getHandZone()->contentsKnown()) {
-                player->getPlayerInfo()->setHandVisible(true);
+                handVisible = true;
                 handZoneGraphicsItem->setPos(base);
             } else {
-                player->getPlayerInfo()->setHandVisible(false);
+                handVisible = false;
             }
         }
         handZoneGraphicsItem->setWidth(tableZoneGraphicsItem->getWidth() +
                                        stackZoneGraphicsItem->boundingRect().width());
     } else {
-        player->getPlayerInfo()->setHandVisible(true);
+        handVisible = true;
 
         handZoneGraphicsItem->setPos(base);
         base += QPointF(handZoneGraphicsItem->boundingRect().width(), 0);
@@ -195,7 +195,7 @@ void PlayerGraphicsItem::rearrangeZones()
 
         tableZoneGraphicsItem->setPos(base);
     }
-    handZoneGraphicsItem->setVisible(player->getPlayerInfo()->getHandVisible());
+    handZoneGraphicsItem->setVisible(handVisible);
     handZoneGraphicsItem->updateOrientation();
     tableZoneGraphicsItem->reorganizeCards();
     updateBoundingRect();
@@ -207,8 +207,7 @@ void PlayerGraphicsItem::updateBoundingRect()
     prepareGeometryChange();
     qreal width = CardDimensions::HEIGHT_F + 15 + counterAreaWidth + stackZoneGraphicsItem->boundingRect().width();
     if (SettingsCache::instance().getHorizontalHand()) {
-        qreal handHeight =
-            player->getPlayerInfo()->getHandVisible() ? handZoneGraphicsItem->boundingRect().height() : 0;
+        qreal handHeight = handVisible ? handZoneGraphicsItem->boundingRect().height() : 0;
         bRect = QRectF(0, 0, width + tableZoneGraphicsItem->boundingRect().width(),
                        tableZoneGraphicsItem->boundingRect().height() + handHeight);
     } else {

--- a/cockatrice/src/game/player/player_graphics_item.h
+++ b/cockatrice/src/game/player/player_graphics_item.h
@@ -121,6 +121,7 @@ private:
     HandZone *handZoneGraphicsItem;
     QRectF bRect;
     bool mirrored;
+    bool handVisible = false;
 
 private slots:
     void updateBoundingRect();

--- a/cockatrice/src/game/player/player_info.cpp
+++ b/cockatrice/src/game/player/player_info.cpp
@@ -1,7 +1,7 @@
 #include "player_info.h"
 
 PlayerInfo::PlayerInfo(const ServerInfo_User &info, int _id, bool _local, bool _judge)
-    : id(_id), local(_local), judge(_judge), handVisible(false)
+    : id(_id), local(_local), judge(_judge)
 {
     userInfo = new ServerInfo_User;
     userInfo->CopyFrom(info);

--- a/cockatrice/src/game/player/player_info.h
+++ b/cockatrice/src/game/player/player_info.h
@@ -22,7 +22,6 @@ public:
     int id;
     bool local;
     bool judge;
-    bool handVisible;
 
     int getId() const
     {
@@ -49,16 +48,6 @@ public:
     bool getJudge() const
     {
         return judge;
-    }
-
-    void setHandVisible(bool _handVisible)
-    {
-        handVisible = _handVisible;
-    }
-
-    bool getHandVisible() const
-    {
-        return handVisible;
     }
 
     QString getName() const


### PR DESCRIPTION
## Short roundup of the initial problem
There's no real reason for the graphics_item to pull the playerInfo into all of this. Nothing else reads the field and the graphics_item is perfectly capable of deducing the information it needs for rendering on its own.

## What will change with this Pull Request?
- Delete handVisible from playerInfo and related getters/setters
- Introduce handVisible field to graphics item, remove calls to playerInfo, adjust to use local field.