### PR TITLE
[Player] Stop reaching into graphics_item and emit signals instead for conceded and zoneId

### DIFF
--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -89,7 +89,6 @@ void Player::setConceded(bool _conceded)
     if (conceded != _conceded) {
         conceded = _conceded;
 
-        getGraphicsItem()->setVisible(!conceded);
         if (conceded) {
             clear();
         }
@@ -100,7 +99,7 @@ void Player::setConceded(bool _conceded)
 void Player::setZoneId(int _zoneId)
 {
     zoneId = _zoneId;
-    graphicsItem->getPlayerArea()->setPlayerZoneId(zoneId);
+    emit zoneIdChanged(zoneId);
 }
 
 void Player::processPlayerInfo(const ServerInfo_Player &info)

--- a/cockatrice/src/game/player/player.cpp
+++ b/cockatrice/src/game/player/player.cpp
@@ -98,8 +98,10 @@ void Player::setConceded(bool _conceded)
 
 void Player::setZoneId(int _zoneId)
 {
-    zoneId = _zoneId;
-    emit zoneIdChanged(zoneId);
+    if (zoneId != _zoneId) {
+        zoneId = _zoneId;
+        emit zoneIdChanged(zoneId);
+    }
 }
 
 void Player::processPlayerInfo(const ServerInfo_Player &info)

--- a/cockatrice/src/game/player/player.h
+++ b/cockatrice/src/game/player/player.h
@@ -72,6 +72,7 @@ signals:
     void newCardAdded(AbstractCardItem *card);
     void rearrangeCounters();
     void activeChanged(bool active);
+    void zoneIdChanged(int zoneId);
     void concededChanged(int playerId, bool conceded);
     void clearCustomZonesMenu();
     void addViewCustomZoneActionToCustomZoneMenu(QString zoneName);

--- a/cockatrice/src/game/player/player_graphics_item.cpp
+++ b/cockatrice/src/game/player/player_graphics_item.cpp
@@ -15,6 +15,8 @@ PlayerGraphicsItem::PlayerGraphicsItem(Player *_player) : player(_player)
     connect(&SettingsCache::instance(), &SettingsCache::handJustificationChanged, this,
             &PlayerGraphicsItem::rearrangeZones);
     connect(player, &Player::rearrangeCounters, this, &PlayerGraphicsItem::rearrangeCounters);
+    connect(player, &Player::concededChanged, this, [this](int, bool c) { setVisible(!c); });
+    connect(player, &Player::zoneIdChanged, this, [this](int id) { playerArea->setPlayerZoneId(id); });
 
     playerArea = new PlayerArea(this);
 


### PR DESCRIPTION
## Short roundup of the initial problem
The player logic can be more agnostic to the graphics item by simply emitting signals that the graphics item hooks up to.

## What will change with this Pull Request?
- Stop reaching into graphicsItem for conceded and zoneIdChanged.