### PR TITLE
[Game][Counters] Split counters into AbstractCounter (graphics) and CounterState (logic)

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -66,6 +66,7 @@ set(cockatrice_SOURCES
     src/game/board/card_list.cpp
     src/game/board/card_state.cpp
     src/game/board/counter_general.cpp
+    src/game/board/counter_state.cpp
     src/game/board/translate_counter_name.cpp
     src/game/deckview/deck_view.cpp
     src/game/deckview/deck_view_container.cpp

--- a/cockatrice/src/game/board/abstract_counter.cpp
+++ b/cockatrice/src/game/board/abstract_counter.cpp
@@ -9,6 +9,7 @@
 #include <QAction>
 #include <QApplication>
 #include <QGraphicsSceneMouseEvent>
+#include <QGraphicsView>
 #include <QKeyEvent>
 #include <QMenu>
 #include <QString>
@@ -16,24 +17,20 @@
 #include <libcockatrice/protocol/pb/command_set_counter.pb.h>
 #include <libcockatrice/utility/expression.h>
 
-AbstractCounter::AbstractCounter(PlayerLogic *_player,
-                                 int _id,
-                                 const QString &_name,
+AbstractCounter::AbstractCounter(CounterState *_state,
+                                 PlayerLogic *_player,
                                  bool _shownInCounterArea,
-                                 int _value,
                                  bool _useNameForShortcut,
                                  QGraphicsItem *parent)
-    : QGraphicsItem(parent), player(_player), id(_id), name(_name), value(_value),
-      useNameForShortcut(_useNameForShortcut), hovered(false), aDec(nullptr), aInc(nullptr), dialogSemaphore(false),
-      deleteAfterDialog(false), shownInCounterArea(_shownInCounterArea)
+    : QGraphicsItem(parent), state(_state), player(_player), useNameForShortcut(_useNameForShortcut),
+      shownInCounterArea(_shownInCounterArea)
 {
     setAcceptHoverEvents(true);
 
-    shortcutActive = false;
+    connect(state, &CounterState::valueChanged, this, [this]() { update(); });
 
     if (player->getPlayerInfo()->getLocalOrJudge()) {
-        QString displayName = TranslateCounterName::getDisplayName(_name);
-        menu = new TearOffMenu(displayName);
+        menu = new TearOffMenu(TranslateCounterName::getDisplayName(state->getName()));
         aSet = new QAction(this);
         connect(aSet, &QAction::triggered, this, &AbstractCounter::setCounter);
         menu->addAction(aSet);
@@ -41,17 +38,18 @@ AbstractCounter::AbstractCounter(PlayerLogic *_player,
         for (int i = 10; i >= -10; --i) {
             if (i == 0) {
                 menu->addSeparator();
-            } else {
-                QAction *aIncrement = new QAction(QString(i < 0 ? "%1" : "+%1").arg(i), this);
-                if (i == -1) {
-                    aDec = aIncrement;
-                } else if (i == 1) {
-                    aInc = aIncrement;
-                }
-                aIncrement->setData(i);
-                connect(aIncrement, &QAction::triggered, this, &AbstractCounter::incrementCounter);
-                menu->addAction(aIncrement);
+                continue;
             }
+            auto *a = new QAction(QString(i < 0 ? "%1" : "+%1").arg(i), this);
+            if (i == -1) {
+                aDec = a;
+            }
+            if (i == 1) {
+                aInc = a;
+            }
+            a->setData(i);
+            connect(a, &QAction::triggered, this, &AbstractCounter::incrementCounter);
+            menu->addAction(a);
         }
     } else {
         menu = nullptr;
@@ -79,31 +77,26 @@ void AbstractCounter::delCounter()
 
 void AbstractCounter::retranslateUi()
 {
-    if (menu) {
+    if (aSet) {
         aSet->setText(tr("&Set counter..."));
     }
 }
 
 void AbstractCounter::setShortcutsActive()
 {
-    if (!menu) {
+    if (!menu || !player->getPlayerInfo()->getLocal()) {
         return;
     }
-    if (!player->getPlayerInfo()->getLocal()) {
-        return;
-    }
-
-    ShortcutsSettings &shortcuts = SettingsCache::instance().shortcuts();
-    if (name == "life") {
-        shortcutActive = true;
-        aSet->setShortcuts(shortcuts.getShortcut("Player/aSet"));
-        aDec->setShortcuts(shortcuts.getShortcut("Player/aDec"));
-        aInc->setShortcuts(shortcuts.getShortcut("Player/aInc"));
+    ShortcutsSettings &sc = SettingsCache::instance().shortcuts();
+    shortcutActive = true;
+    if (state->getName() == "life") {
+        aSet->setShortcuts(sc.getShortcut("Player/aSet"));
+        aDec->setShortcuts(sc.getShortcut("Player/aDec"));
+        aInc->setShortcuts(sc.getShortcut("Player/aInc"));
     } else if (useNameForShortcut) {
-        shortcutActive = true;
-        aSet->setShortcuts(shortcuts.getShortcut("Player/aSetCounter_" + name));
-        aDec->setShortcuts(shortcuts.getShortcut("Player/aDecCounter_" + name));
-        aInc->setShortcuts(shortcuts.getShortcut("Player/aIncCounter_" + name));
+        aSet->setShortcuts(sc.getShortcut("Player/aSetCounter_" + state->getName()));
+        aDec->setShortcuts(sc.getShortcut("Player/aDecCounter_" + state->getName()));
+        aInc->setShortcuts(sc.getShortcut("Player/aIncCounter_" + state->getName()));
     }
 }
 
@@ -114,7 +107,7 @@ void AbstractCounter::setShortcutsInactive()
     }
 
     shortcutActive = false;
-    if (name == "life" || useNameForShortcut) {
+    if (state->getName() == "life" || useNameForShortcut) {
         aSet->setShortcut(QKeySequence());
         aDec->setShortcut(QKeySequence());
         aInc->setShortcut(QKeySequence());
@@ -128,45 +121,32 @@ void AbstractCounter::refreshShortcuts()
     }
 }
 
-void AbstractCounter::setValue(int _value)
-{
-    value = _value;
-    update();
-}
-
 void AbstractCounter::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-    if (isUnderMouse() && player->getPlayerInfo()->getLocalOrJudge()) {
-        if (event->button() == Qt::MiddleButton || (QApplication::keyboardModifiers() & Qt::ShiftModifier)) {
-            if (menu) {
-                menu->exec(event->screenPos());
-            }
-            event->accept();
-        } else if (event->button() == Qt::LeftButton) {
-            Command_IncCounter cmd;
-            cmd.set_counter_id(id);
-            cmd.set_delta(1);
-            player->getPlayerActions()->sendGameCommand(cmd);
-            event->accept();
-        } else if (event->button() == Qt::RightButton) {
-            Command_IncCounter cmd;
-            cmd.set_counter_id(id);
-            cmd.set_delta(-1);
-            player->getPlayerActions()->sendGameCommand(cmd);
-            event->accept();
+    if (!isUnderMouse() || !player->getPlayerInfo()->getLocalOrJudge()) {
+        event->ignore();
+        return;
+    }
+
+    if (event->button() == Qt::MiddleButton || QApplication::keyboardModifiers() & Qt::ShiftModifier) {
+        if (menu) {
+            menu->exec(event->screenPos());
         }
     } else {
-        event->ignore();
+        Command_IncCounter cmd;
+        cmd.set_counter_id(state->getId());
+        cmd.set_delta(event->button() == Qt::LeftButton ? 1 : -1);
+        player->getPlayerActions()->sendGameCommand(cmd);
     }
+    event->accept();
 }
 
-void AbstractCounter::hoverEnterEvent(QGraphicsSceneHoverEvent * /*event*/)
+void AbstractCounter::hoverEnterEvent(QGraphicsSceneHoverEvent *)
 {
     hovered = true;
     update();
 }
-
-void AbstractCounter::hoverLeaveEvent(QGraphicsSceneHoverEvent * /*event*/)
+void AbstractCounter::hoverLeaveEvent(QGraphicsSceneHoverEvent *)
 {
     hovered = false;
     update();
@@ -174,35 +154,36 @@ void AbstractCounter::hoverLeaveEvent(QGraphicsSceneHoverEvent * /*event*/)
 
 void AbstractCounter::incrementCounter()
 {
-    const int delta = static_cast<QAction *>(sender())->data().toInt();
     Command_IncCounter cmd;
-    cmd.set_counter_id(id);
-    cmd.set_delta(delta);
+    cmd.set_counter_id(state->getId());
+    cmd.set_delta(static_cast<QAction *>(sender())->data().toInt());
     player->getPlayerActions()->sendGameCommand(cmd);
 }
 
 void AbstractCounter::setCounter()
 {
+    QWidget *parent = nullptr;
+    if (auto *view = scene() ? scene()->views().value(0) : nullptr) {
+        parent = view->window();
+    }
+
     dialogSemaphore = true;
-    AbstractCounterDialog dialog(name, QString::number(value), player->getGame()->getTab());
-    const int ok = dialog.exec();
+    AbstractCounterDialog dlg(state->getName(), QString::number(state->getValue()), parent);
+    const int ok = dlg.exec();
+    dialogSemaphore = false;
 
     if (deleteAfterDialog) {
         deleteLater();
         return;
     }
-    dialogSemaphore = false;
-
     if (!ok) {
         return;
     }
 
-    Expression exp(value);
-    int newValue = static_cast<int>(exp.parse(dialog.textValue()));
-
+    Expression exp(state->getValue());
     Command_SetCounter cmd;
-    cmd.set_counter_id(id);
-    cmd.set_value(newValue);
+    cmd.set_counter_id(state->getId());
+    cmd.set_value(static_cast<int>(exp.parse(dlg.textValue())));
     player->getPlayerActions()->sendGameCommand(cmd);
 }
 

--- a/cockatrice/src/game/board/abstract_counter.cpp
+++ b/cockatrice/src/game/board/abstract_counter.cpp
@@ -28,7 +28,10 @@ AbstractCounter::AbstractCounter(CounterState *state,
 {
     setAcceptHoverEvents(true);
 
-    connect(state, &CounterState::valueChanged, this, [this]() { update(); });
+    connect(state, &CounterState::valueChanged, this, [this](int, int newValue) {
+        value = newValue;
+        update();
+    });
 
     if (player->getPlayerInfo()->getLocalOrJudge()) {
         menu = new TearOffMenu(TranslateCounterName::getDisplayName(state->getName()));

--- a/cockatrice/src/game/board/abstract_counter.cpp
+++ b/cockatrice/src/game/board/abstract_counter.cpp
@@ -17,12 +17,13 @@
 #include <libcockatrice/protocol/pb/command_set_counter.pb.h>
 #include <libcockatrice/utility/expression.h>
 
-AbstractCounter::AbstractCounter(CounterState *_state,
+AbstractCounter::AbstractCounter(CounterState *state,
                                  PlayerLogic *_player,
                                  bool _shownInCounterArea,
                                  bool _useNameForShortcut,
                                  QGraphicsItem *parent)
-    : QGraphicsItem(parent), state(_state), player(_player), useNameForShortcut(_useNameForShortcut),
+    : QGraphicsItem(parent), player(_player), id(state->getId()), name(state->getName()), value(state->getValue()),
+      color(state->getColor()), radius(state->getRadius()), useNameForShortcut(_useNameForShortcut),
       shownInCounterArea(_shownInCounterArea)
 {
     setAcceptHoverEvents(true);
@@ -89,14 +90,14 @@ void AbstractCounter::setShortcutsActive()
     }
     ShortcutsSettings &sc = SettingsCache::instance().shortcuts();
     shortcutActive = true;
-    if (state->getName() == "life") {
+    if (name == "life") {
         aSet->setShortcuts(sc.getShortcut("Player/aSet"));
         aDec->setShortcuts(sc.getShortcut("Player/aDec"));
         aInc->setShortcuts(sc.getShortcut("Player/aInc"));
     } else if (useNameForShortcut) {
-        aSet->setShortcuts(sc.getShortcut("Player/aSetCounter_" + state->getName()));
-        aDec->setShortcuts(sc.getShortcut("Player/aDecCounter_" + state->getName()));
-        aInc->setShortcuts(sc.getShortcut("Player/aIncCounter_" + state->getName()));
+        aSet->setShortcuts(sc.getShortcut("Player/aSetCounter_" + name));
+        aDec->setShortcuts(sc.getShortcut("Player/aDecCounter_" + name));
+        aInc->setShortcuts(sc.getShortcut("Player/aIncCounter_" + name));
     }
 }
 
@@ -107,7 +108,7 @@ void AbstractCounter::setShortcutsInactive()
     }
 
     shortcutActive = false;
-    if (state->getName() == "life" || useNameForShortcut) {
+    if (name == "life" || useNameForShortcut) {
         aSet->setShortcut(QKeySequence());
         aDec->setShortcut(QKeySequence());
         aInc->setShortcut(QKeySequence());
@@ -134,7 +135,7 @@ void AbstractCounter::mousePressEvent(QGraphicsSceneMouseEvent *event)
         }
     } else {
         Command_IncCounter cmd;
-        cmd.set_counter_id(state->getId());
+        cmd.set_counter_id(id);
         cmd.set_delta(event->button() == Qt::LeftButton ? 1 : -1);
         player->getPlayerActions()->sendGameCommand(cmd);
     }
@@ -155,7 +156,7 @@ void AbstractCounter::hoverLeaveEvent(QGraphicsSceneHoverEvent *)
 void AbstractCounter::incrementCounter()
 {
     Command_IncCounter cmd;
-    cmd.set_counter_id(state->getId());
+    cmd.set_counter_id(id);
     cmd.set_delta(static_cast<QAction *>(sender())->data().toInt());
     player->getPlayerActions()->sendGameCommand(cmd);
 }
@@ -168,7 +169,7 @@ void AbstractCounter::setCounter()
     }
 
     dialogSemaphore = true;
-    AbstractCounterDialog dlg(state->getName(), QString::number(state->getValue()), parent);
+    AbstractCounterDialog dlg(name, QString::number(value), parent);
     const int ok = dlg.exec();
     dialogSemaphore = false;
 
@@ -180,9 +181,9 @@ void AbstractCounter::setCounter()
         return;
     }
 
-    Expression exp(state->getValue());
+    Expression exp(value);
     Command_SetCounter cmd;
-    cmd.set_counter_id(state->getId());
+    cmd.set_counter_id(id);
     cmd.set_value(static_cast<int>(exp.parse(dlg.textValue())));
     player->getPlayerActions()->sendGameCommand(cmd);
 }

--- a/cockatrice/src/game/board/abstract_counter.h
+++ b/cockatrice/src/game/board/abstract_counter.h
@@ -26,8 +26,12 @@ class AbstractCounter : public QObject, public QGraphicsItem, public AbstractPla
     Q_INTERFACES(QGraphicsItem)
 
 protected:
-    CounterState *state;
     PlayerLogic *player;
+    int id;
+    QString name;
+    int value;
+    QColor color;
+    int radius;
     bool hovered = false;
     bool useNameForShortcut;
 
@@ -61,25 +65,29 @@ public:
     void setShortcutsInactive() override;
     void delCounter();
 
-    CounterState *getState() const
-    {
-        return state;
-    }
     QMenu *getMenu() const
     {
         return menu;
     }
     int getId() const
     {
-        return state->getId();
+        return id;
     }
     QString getName() const
     {
-        return state->getName();
+        return name;
+    }
+    QColor getColor() const
+    {
+        return color;
+    }
+    int getRadius() const
+    {
+        return radius;
     }
     int getValue() const
     {
-        return state->getValue();
+        return value;
     }
     bool getShownInCounterArea() const
     {

--- a/cockatrice/src/game/board/abstract_counter.h
+++ b/cockatrice/src/game/board/abstract_counter.h
@@ -9,6 +9,7 @@
 
 #include "../../interface/widgets/menus/tearoff_menu.h"
 #include "../player/menu/abstract_player_component.h"
+#include "counter_state.h"
 
 #include <QGraphicsItem>
 #include <QInputDialog>
@@ -25,22 +26,22 @@ class AbstractCounter : public QObject, public QGraphicsItem, public AbstractPla
     Q_INTERFACES(QGraphicsItem)
 
 protected:
+    CounterState *state;
     PlayerLogic *player;
-    int id;
-    QString name;
-    int value;
-    bool useNameForShortcut, hovered;
+    bool hovered = false;
+    bool useNameForShortcut;
 
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
     void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
     void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
 
 private:
-    QAction *aSet, *aDec, *aInc;
-    TearOffMenu *menu;
-    bool dialogSemaphore, deleteAfterDialog;
+    QAction *aSet = nullptr, *aDec = nullptr, *aInc = nullptr;
+    TearOffMenu *menu = nullptr;
+    bool dialogSemaphore = false;
+    bool deleteAfterDialog = false;
     bool shownInCounterArea;
-    bool shortcutActive;
+    bool shortcutActive = false;
 
 private slots:
     void refreshShortcuts();
@@ -48,41 +49,41 @@ private slots:
     void setCounter();
 
 public:
-    AbstractCounter(PlayerLogic *_player,
-                    int _id,
-                    const QString &_name,
-                    bool _shownInCounterArea,
-                    int _value,
-                    bool _useNameForShortcut = false,
+    AbstractCounter(CounterState *state,
+                    PlayerLogic *player,
+                    bool shownInCounterArea,
+                    bool useNameForShortcut = false,
                     QGraphicsItem *parent = nullptr);
     ~AbstractCounter() override;
 
     void retranslateUi() override;
-    void setValue(int _value);
     void setShortcutsActive() override;
     void setShortcutsInactive() override;
     void delCounter();
 
+    CounterState *getState() const
+    {
+        return state;
+    }
     QMenu *getMenu() const
     {
         return menu;
     }
-
     int getId() const
     {
-        return id;
+        return state->getId();
     }
     QString getName() const
     {
-        return name;
+        return state->getName();
+    }
+    int getValue() const
+    {
+        return state->getValue();
     }
     bool getShownInCounterArea() const
     {
         return shownInCounterArea;
-    }
-    int getValue() const
-    {
-        return value;
     }
 };
 

--- a/cockatrice/src/game/board/counter_general.cpp
+++ b/cockatrice/src/game/board/counter_general.cpp
@@ -5,22 +5,15 @@
 
 #include <QPainter>
 
-GeneralCounter::GeneralCounter(PlayerLogic *_player,
-                               int _id,
-                               const QString &_name,
-                               const QColor &_color,
-                               int _radius,
-                               int _value,
-                               bool useNameForShortcut,
-                               QGraphicsItem *parent)
-    : AbstractCounter(_player, _id, _name, true, _value, useNameForShortcut, parent), color(_color), radius(_radius)
+GeneralCounter::GeneralCounter(CounterState *state, PlayerLogic *player, bool useNameForShortcut, QGraphicsItem *parent)
+    : AbstractCounter(state, player, true, useNameForShortcut, parent)
 {
     setCacheMode(DeviceCoordinateCache);
 }
 
 QRectF GeneralCounter::boundingRect() const
 {
-    return QRectF(0, 0, radius * 2, radius * 2);
+    return QRectF(0, 0, state->getRadius() * 2, state->getRadius() * 2);
 }
 
 void GeneralCounter::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
@@ -28,19 +21,19 @@ void GeneralCounter::paint(QPainter *painter, const QStyleOptionGraphicsItem * /
     QRectF mapRect = painter->combinedTransform().mapRect(boundingRect());
     int translatedHeight = mapRect.size().height();
     qreal scaleFactor = translatedHeight / boundingRect().height();
-    QPixmap pixmap = CounterPixmapGenerator::generatePixmap(translatedHeight, name, hovered);
+    QPixmap pixmap = CounterPixmapGenerator::generatePixmap(translatedHeight, state->getName(), hovered);
 
     painter->save();
     resetPainterTransform(painter);
     painter->drawPixmap(QPoint(0, 0), pixmap);
 
-    if (value) {
+    if (state->getValue()) {
         QFont f("Serif");
-        f.setPixelSize(qMax((int)(radius * scaleFactor), 10));
+        f.setPixelSize(qMax((int)(state->getRadius() * scaleFactor), 10));
         f.setWeight(QFont::Bold);
         painter->setPen(Qt::black);
         painter->setFont(f);
-        painter->drawText(mapRect, Qt::AlignCenter, QString::number(value));
+        painter->drawText(mapRect, Qt::AlignCenter, QString::number(state->getValue()));
     }
     painter->restore();
 }

--- a/cockatrice/src/game/board/counter_general.cpp
+++ b/cockatrice/src/game/board/counter_general.cpp
@@ -13,7 +13,7 @@ GeneralCounter::GeneralCounter(CounterState *state, PlayerLogic *player, bool us
 
 QRectF GeneralCounter::boundingRect() const
 {
-    return QRectF(0, 0, state->getRadius() * 2, state->getRadius() * 2);
+    return QRectF(0, 0, radius * 2, radius * 2);
 }
 
 void GeneralCounter::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
@@ -21,19 +21,19 @@ void GeneralCounter::paint(QPainter *painter, const QStyleOptionGraphicsItem * /
     QRectF mapRect = painter->combinedTransform().mapRect(boundingRect());
     int translatedHeight = mapRect.size().height();
     qreal scaleFactor = translatedHeight / boundingRect().height();
-    QPixmap pixmap = CounterPixmapGenerator::generatePixmap(translatedHeight, state->getName(), hovered);
+    QPixmap pixmap = CounterPixmapGenerator::generatePixmap(translatedHeight, name, hovered);
 
     painter->save();
     resetPainterTransform(painter);
     painter->drawPixmap(QPoint(0, 0), pixmap);
 
-    if (state->getValue()) {
+    if (value) {
         QFont f("Serif");
-        f.setPixelSize(qMax((int)(state->getRadius() * scaleFactor), 10));
+        f.setPixelSize(qMax((int)(radius * scaleFactor), 10));
         f.setWeight(QFont::Bold);
         painter->setPen(Qt::black);
         painter->setFont(f);
-        painter->drawText(mapRect, Qt::AlignCenter, QString::number(state->getValue()));
+        painter->drawText(mapRect, Qt::AlignCenter, QString::number(value));
     }
     painter->restore();
 }

--- a/cockatrice/src/game/board/counter_general.h
+++ b/cockatrice/src/game/board/counter_general.h
@@ -12,17 +12,10 @@
 class GeneralCounter : public AbstractCounter
 {
     Q_OBJECT
-private:
-    QColor color;
-    int radius;
 
 public:
-    GeneralCounter(PlayerLogic *_player,
-                   int _id,
-                   const QString &_name,
-                   const QColor &_color,
-                   int _radius,
-                   int _value,
+    GeneralCounter(CounterState *state,
+                   PlayerLogic *player,
                    bool useNameForShortcut = false,
                    QGraphicsItem *parent = nullptr);
     QRectF boundingRect() const override;

--- a/cockatrice/src/game/board/counter_state.cpp
+++ b/cockatrice/src/game/board/counter_state.cpp
@@ -1,0 +1,24 @@
+#include "counter_state.h"
+
+#include <libcockatrice/utility/color.h>
+
+CounterState::CounterState(int id, const QString &name, const QColor &color, int radius, int value, QObject *parent)
+    : QObject(parent), id(id), name(name), color(color), radius(radius), value(value)
+{
+}
+
+CounterState *CounterState::fromProto(const ServerInfo_Counter &counter, QObject *parent)
+{
+    return new CounterState(counter.id(), QString::fromStdString(counter.name()),
+                            convertColorToQColor(counter.counter_color()), counter.radius(), counter.count(), parent);
+}
+
+void CounterState::setValue(int newValue)
+{
+    if (newValue == value) {
+        return;
+    }
+    int old = value;
+    value = newValue;
+    emit valueChanged(old, newValue);
+}

--- a/cockatrice/src/game/board/counter_state.h
+++ b/cockatrice/src/game/board/counter_state.h
@@ -1,0 +1,51 @@
+#ifndef COCKATRICE_COUNTER_STATE_H
+#define COCKATRICE_COUNTER_STATE_H
+
+#include <QColor>
+#include <QObject>
+#include <QString>
+#include <libcockatrice/protocol/pb/serverinfo_counter.pb.h>
+
+class CounterState : public QObject
+{
+    Q_OBJECT
+public:
+    CounterState(int id, const QString &name, const QColor &color, int radius, int value, QObject *parent = nullptr);
+
+    static CounterState *fromProto(const ServerInfo_Counter &counter, QObject *parent = nullptr);
+
+    int getId() const
+    {
+        return id;
+    }
+    QString getName() const
+    {
+        return name;
+    }
+    QColor getColor() const
+    {
+        return color;
+    }
+    int getRadius() const
+    {
+        return radius;
+    }
+    int getValue() const
+    {
+        return value;
+    }
+
+    void setValue(int newValue);
+
+signals:
+    void valueChanged(int oldValue, int newValue);
+
+private:
+    int id;
+    QString name;
+    QColor color;
+    int radius;
+    int value;
+};
+
+#endif // COCKATRICE_COUNTER_STATE_H

--- a/cockatrice/src/game/player/menu/player_menu.cpp
+++ b/cockatrice/src/game/player/menu/player_menu.cpp
@@ -97,10 +97,7 @@ void PlayerMenu::retranslateUi()
         countersMenu->setTitle(tr("&Counters"));
     }
 
-    QMapIterator<int, AbstractCounter *> counterIterator(player->getCounters());
-    while (counterIterator.hasNext()) {
-        counterIterator.next().value()->retranslateUi();
-    }
+    emit retranslateRequested();
 }
 
 void PlayerMenu::refreshShortcuts()
@@ -120,30 +117,17 @@ void PlayerMenu::refreshShortcuts()
 void PlayerMenu::setShortcutsActive()
 {
     shortcutsActive = true;
-
-    for (auto *component : managedComponents) {
-        component->setShortcutsActive();
+    for (auto *c : managedComponents) {
+        c->setShortcutsActive();
     }
-
-    // Counters implement AbstractPlayerComponent but are iterated via Player::counters
-    // (the authoritative source) rather than managedComponents to avoid a redundant
-    // list that must stay in sync with the map.
-    QMapIterator<int, AbstractCounter *> counterIterator(player->getCounters());
-    while (counterIterator.hasNext()) {
-        counterIterator.next().value()->setShortcutsActive();
-    }
+    emit shortcutsActivated();
 }
 
 void PlayerMenu::setShortcutsInactive()
 {
     shortcutsActive = false;
-
-    for (auto *component : managedComponents) {
-        component->setShortcutsInactive();
+    for (auto *c : managedComponents) {
+        c->setShortcutsInactive();
     }
-
-    QMapIterator<int, AbstractCounter *> counterIterator(player->getCounters());
-    while (counterIterator.hasNext()) {
-        counterIterator.next().value()->setShortcutsInactive();
-    }
+    emit shortcutsDeactivated();
 }

--- a/cockatrice/src/game/player/menu/player_menu.h
+++ b/cockatrice/src/game/player/menu/player_menu.h
@@ -29,6 +29,9 @@ class PlayerMenu : public QObject
 
 signals:
     void cardMenuUpdated(QMenu *cardMenu);
+    void shortcutsActivated();
+    void shortcutsDeactivated();
+    void retranslateRequested();
 
 public slots:
     void setMenusForGraphicItems();

--- a/cockatrice/src/game/player/player_event_handler.cpp
+++ b/cockatrice/src/game/player/player_event_handler.cpp
@@ -246,7 +246,7 @@ void PlayerEventHandler::eventCreateCounter(const Event_CreateCounter &event)
 
 void PlayerEventHandler::eventSetCounter(const Event_SetCounter &event)
 {
-    AbstractCounter *ctr = player->getCounters().value(event.counter_id(), 0);
+    CounterState *ctr = player->getCounters().value(event.counter_id(), nullptr);
     if (!ctr) {
         return;
     }

--- a/cockatrice/src/game/player/player_graphics_item.cpp
+++ b/cockatrice/src/game/player/player_graphics_item.cpp
@@ -6,6 +6,7 @@
 #include "../../game_graphics/zones/table_zone.h"
 #include "../../interface/widgets/tabs/tab_game.h"
 #include "../board/abstract_card_item.h"
+#include "../board/counter_general.h"
 #include "../hand_counter.h"
 
 PlayerGraphicsItem::PlayerGraphicsItem(PlayerLogic *_player) : player(_player)
@@ -17,6 +18,25 @@ PlayerGraphicsItem::PlayerGraphicsItem(PlayerLogic *_player) : player(_player)
     connect(player, &PlayerLogic::rearrangeCounters, this, &PlayerGraphicsItem::rearrangeCounters);
     connect(player, &PlayerLogic::concededChanged, this, [this](int, bool c) { setVisible(!c); });
     connect(player, &PlayerLogic::zoneIdChanged, this, [this](int id) { playerArea->setPlayerZoneId(id); });
+
+    connect(player, &PlayerLogic::counterAdded, this, &PlayerGraphicsItem::onCounterAdded);
+    connect(player, &PlayerLogic::counterRemoved, this, &PlayerGraphicsItem::onCounterRemoved);
+
+    connect(player->getPlayerMenu(), &PlayerMenu::shortcutsActivated, this, [this]() {
+        for (auto *ctr : counterWidgets) {
+            ctr->setShortcutsActive();
+        }
+    });
+    connect(player->getPlayerMenu(), &PlayerMenu::shortcutsDeactivated, this, [this]() {
+        for (auto *ctr : counterWidgets) {
+            ctr->setShortcutsInactive();
+        }
+    });
+    connect(player->getPlayerMenu(), &PlayerMenu::retranslateRequested, this, [this]() {
+        for (auto *ctr : counterWidgets) {
+            ctr->retranslateUi();
+        }
+    });
 
     playerArea = new PlayerArea(this);
 
@@ -42,11 +62,6 @@ void PlayerGraphicsItem::retranslateUi()
     QMapIterator<QString, CardZoneLogic *> zoneIterator(player->getZones());
     while (zoneIterator.hasNext()) {
         emit zoneIterator.next().value()->retranslateUi();
-    }
-
-    QMapIterator<int, AbstractCounter *> counterIterator(player->getCounters());
-    while (counterIterator.hasNext()) {
-        counterIterator.next().value()->retranslateUi();
     }
 }
 
@@ -134,20 +149,48 @@ void PlayerGraphicsItem::setMirrored(bool _mirrored)
     }
 }
 
+void PlayerGraphicsItem::onCounterAdded(CounterState *state)
+{
+    AbstractCounter *widget;
+    if (state->getName() == "life") {
+        widget = playerTarget->addCounter(state);
+    } else {
+        widget = new GeneralCounter(state, player, true, this);
+    }
+    counterWidgets.insert(state->getId(), widget);
+
+    if (player->getPlayerMenu()->getCountersMenu() && widget->getMenu()) {
+        player->getPlayerMenu()->getCountersMenu()->addMenu(widget->getMenu());
+    }
+
+    if (player->getPlayerMenu()->getShortcutsActive()) {
+        widget->setShortcutsActive();
+    }
+
+    rearrangeCounters();
+}
+
+void PlayerGraphicsItem::onCounterRemoved(int counterId)
+{
+    auto *widget = counterWidgets.take(counterId);
+    if (!widget) {
+        return;
+    }
+    if (player->getPlayerMenu()->getCountersMenu() && widget->getMenu()) {
+        player->getPlayerMenu()->getCountersMenu()->removeAction(widget->getMenu()->menuAction());
+    }
+    widget->delCounter();
+    rearrangeCounters();
+}
+
 void PlayerGraphicsItem::rearrangeCounters()
 {
-    qreal marginTop = 80;
-    const qreal padding = 5;
-    qreal ySize = boundingRect().y() + marginTop;
-
-    // Place objects
-    for (const auto &counter : player->getCounters()) {
-        AbstractCounter *ctr = counter;
-
+    qreal ySize = boundingRect().y() + 80;
+    constexpr qreal padding = 5;
+    for (auto *ctr : counterWidgets.values()) {
         if (!ctr->getShownInCounterArea()) {
             continue;
         }
-
         QRectF br = ctr->boundingRect();
         ctr->setPos((counterAreaWidth - br.width()) / 2, ySize);
         ySize += br.height() + padding;

--- a/cockatrice/src/game/player/player_graphics_item.h
+++ b/cockatrice/src/game/player/player_graphics_item.h
@@ -6,6 +6,7 @@
 
 #ifndef COCKATRICE_PLAYER_GRAPHICS_ITEM_H
 #define COCKATRICE_PLAYER_GRAPHICS_ITEM_H
+#include "../board/abstract_counter.h"
 #include "../game_scene.h"
 #include "player_logic.h"
 
@@ -102,6 +103,9 @@ public:
 
 public slots:
     void onPlayerActiveChanged(bool _active);
+    void onCounterAdded(CounterState *state);
+    void onCounterRemoved(int counterId);
+    void rearrangeCounters();
     void retranslateUi();
 
 signals:
@@ -112,6 +116,7 @@ private:
     PlayerLogic *player;
     PlayerArea *playerArea;
     PlayerTarget *playerTarget;
+    QMap<int, AbstractCounter *> counterWidgets;
     PileZone *deckZoneGraphicsItem;
     PileZone *sideboardGraphicsItem;
     PileZone *graveyardZoneGraphicsItem;
@@ -126,7 +131,6 @@ private:
 private slots:
     void updateBoundingRect();
     void rearrangeZones();
-    void rearrangeCounters();
 };
 
 #endif // COCKATRICE_PLAYER_GRAPHICS_ITEM_H

--- a/cockatrice/src/game/player/player_logic.cpp
+++ b/cockatrice/src/game/player/player_logic.cpp
@@ -258,55 +258,50 @@ void PlayerLogic::setDeck(const DeckList &_deck)
     emit deckChanged();
 }
 
-AbstractCounter *PlayerLogic::addCounter(const ServerInfo_Counter &counter)
+CounterState *PlayerLogic::addCounter(const ServerInfo_Counter &counter)
 {
     return addCounter(counter.id(), QString::fromStdString(counter.name()),
                       convertColorToQColor(counter.counter_color()), counter.radius(), counter.count());
 }
 
-AbstractCounter *PlayerLogic::addCounter(int counterId, const QString &name, QColor color, int radius, int value)
+CounterState *PlayerLogic::addCounter(int id, const QString &name, const QColor &color, int radius, int value)
 {
-    if (counters.contains(counterId)) {
+    if (counters.contains(id)) {
         return nullptr;
     }
-
-    AbstractCounter *ctr;
-    if (name == "life") {
-        ctr = getGraphicsItem()->getPlayerTarget()->addCounter(counterId, name, value);
-    } else {
-        ctr = new GeneralCounter(this, counterId, name, color, radius, value, true, graphicsItem);
-    }
-    counters.insert(counterId, ctr);
-
-    if (playerMenu->getCountersMenu() && ctr->getMenu()) {
-        playerMenu->getCountersMenu()->addMenu(ctr->getMenu());
-    }
-    if (playerMenu->getShortcutsActive()) {
-        ctr->setShortcutsActive();
-    }
-    emit rearrangeCounters();
-    return ctr;
+    auto *state = new CounterState(id, name, color, radius, value, this);
+    counters.insert(id, state);
+    emit counterAdded(state);
+    return state;
 }
 
-void PlayerLogic::delCounter(int counterId)
+void PlayerLogic::delCounter(int id)
 {
-    AbstractCounter *ctr = counters.value(counterId, 0);
-    if (!ctr) {
+    auto *state = counters.take(id);
+    if (!state) {
         return;
     }
-
-    ctr->delCounter();
-    counters.remove(counterId);
-    emit rearrangeCounters();
+    emit counterRemoved(id);
+    state->deleteLater();
 }
 
 void PlayerLogic::clearCounters()
 {
-    QMapIterator<int, AbstractCounter *> counterIterator(counters);
-    while (counterIterator.hasNext()) {
-        counterIterator.next().value()->delCounter();
+    for (int id : counters.keys()) {
+        emit counterRemoved(id);
     }
+    qDeleteAll(counters);
     counters.clear();
+}
+
+CounterState *PlayerLogic::getLifeCounter() const
+{
+    for (auto *s : counters.values()) {
+        if (s->getName() == "life") {
+            return s;
+        }
+    }
+    return nullptr;
 }
 
 void PlayerLogic::incrementAllCardCounters()
@@ -343,16 +338,6 @@ void PlayerLogic::incrementAllCardCounters()
     if (!commandList.isEmpty()) {
         playerActions->sendGameCommand(playerActions->prepareGameCommand(commandList));
     }
-}
-
-AbstractCounter *PlayerLogic::getLifeCounter() const
-{
-    for (auto counter : counters.values()) {
-        if (counter->getName() == "life") {
-            return counter;
-        }
-    }
-    return nullptr;
 }
 
 ArrowItem *PlayerLogic::addArrow(const ServerInfo_Arrow &arrow)

--- a/cockatrice/src/game/player/player_logic.h
+++ b/cockatrice/src/game/player/player_logic.h
@@ -7,7 +7,6 @@
 #ifndef PLAYER_H
 #define PLAYER_H
 
-#include "../../game_graphics/board/abstract_graphics_item.h"
 #include "../../interface/widgets/menus/tearoff_menu.h"
 #include "../interface/deck_loader/loaded_deck.h"
 #include "../zones/hand_zone_logic.h"
@@ -39,7 +38,6 @@ class Message;
 }
 } // namespace google
 class AbstractCardItem;
-class AbstractCounter;
 class AbstractGame;
 class ArrowItem;
 class ArrowTarget;
@@ -70,6 +68,8 @@ signals:
     void openDeckEditor(const LoadedDeck &deck);
     void deckChanged();
     void newCardAdded(AbstractCardItem *card);
+    void counterAdded(CounterState *state);
+    void counterRemoved(int counterId);
     void rearrangeCounters();
     void activeChanged(bool active);
     void zoneIdChanged(int zoneId);
@@ -189,13 +189,13 @@ public:
         return qobject_cast<HandZoneLogic *>(zones.value(ZoneNames::HAND));
     }
 
-    AbstractCounter *addCounter(const ServerInfo_Counter &counter);
-    AbstractCounter *addCounter(int counterId, const QString &name, QColor color, int radius, int value);
+    CounterState *addCounter(const ServerInfo_Counter &counter);
+    CounterState *addCounter(int id, const QString &name, const QColor &color, int radius, int value);
     void delCounter(int counterId);
     void clearCounters();
     void incrementAllCardCounters();
 
-    QMap<int, AbstractCounter *> getCounters()
+    QMap<int, CounterState *> getCounters() const
     {
         return counters;
     }
@@ -203,7 +203,7 @@ public:
     /**
      * Gets the counter that represents the life total.
      */
-    AbstractCounter *getLifeCounter() const;
+    CounterState *getLifeCounter() const;
 
     ArrowItem *addArrow(const ServerInfo_Arrow &arrow);
     ArrowItem *addArrow(int arrowId, CardItem *startCard, ArrowTarget *targetItem, const QColor &color);
@@ -251,7 +251,7 @@ private:
 
     int zoneId;
     QMap<QString, CardZoneLogic *> zones;
-    QMap<int, AbstractCounter *> counters;
+    QMap<int, CounterState *> counters;
     QMap<int, ArrowItem *> arrows;
 
     bool dialogSemaphore;

--- a/cockatrice/src/game/player/player_target.cpp
+++ b/cockatrice/src/game/player/player_target.cpp
@@ -44,7 +44,7 @@ void PlayerCounter::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*
     font.setPixelSize(qMax(qRound(translatedSize.height() / 1.3), 9));
     painter->setFont(font);
     painter->setPen(Qt::white);
-    painter->drawText(translatedRect, Qt::AlignCenter, QString::number(state->getValue()));
+    painter->drawText(translatedRect, Qt::AlignCenter, QString::number(value));
 }
 
 PlayerTarget::PlayerTarget(PlayerLogic *_owner, QGraphicsItem *parentItem)

--- a/cockatrice/src/game/player/player_target.cpp
+++ b/cockatrice/src/game/player/player_target.cpp
@@ -9,8 +9,8 @@
 #include <QtMath>
 #include <libcockatrice/protocol/pb/serverinfo_user.pb.h>
 
-PlayerCounter::PlayerCounter(PlayerLogic *_player, int _id, const QString &_name, int _value, QGraphicsItem *parent)
-    : AbstractCounter(_player, _id, _name, false, _value, false, parent)
+PlayerCounter::PlayerCounter(CounterState *state, PlayerLogic *player, QGraphicsItem *parent)
+    : AbstractCounter(state, player, false, false, parent)
 {
 }
 
@@ -44,7 +44,7 @@ void PlayerCounter::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*
     font.setPixelSize(qMax(qRound(translatedSize.height() / 1.3), 9));
     painter->setFont(font);
     painter->setPen(Qt::white);
-    painter->drawText(translatedRect, Qt::AlignCenter, QString::number(value));
+    painter->drawText(translatedRect, Qt::AlignCenter, QString::number(state->getValue()));
 }
 
 PlayerTarget::PlayerTarget(PlayerLogic *_owner, QGraphicsItem *parentItem)
@@ -150,18 +150,16 @@ void PlayerTarget::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*o
     }
 }
 
-AbstractCounter *PlayerTarget::addCounter(int _counterId, const QString &_name, int _value)
+AbstractCounter *PlayerTarget::addCounter(CounterState *state)
 {
     if (playerCounter) {
         disconnect(playerCounter, nullptr, this, nullptr);
         playerCounter->delCounter();
     }
-
-    playerCounter = new PlayerCounter(owner, _counterId, _name, _value, this);
+    playerCounter = new PlayerCounter(state, owner, this);
     playerCounter->setPos(boundingRect().width() - playerCounter->boundingRect().width(),
                           boundingRect().height() - playerCounter->boundingRect().height());
     connect(playerCounter, &PlayerCounter::destroyed, this, &PlayerTarget::counterDeleted);
-
     return playerCounter;
 }
 

--- a/cockatrice/src/game/player/player_target.h
+++ b/cockatrice/src/game/player/player_target.h
@@ -19,7 +19,7 @@ class PlayerCounter : public AbstractCounter
 {
     Q_OBJECT
 public:
-    PlayerCounter(PlayerLogic *_player, int _id, const QString &_name, int _value, QGraphicsItem *parent = nullptr);
+    PlayerCounter(CounterState *state, PlayerLogic *player, QGraphicsItem *parent);
     QRectF boundingRect() const override;
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 };
@@ -48,7 +48,7 @@ public:
     QRectF boundingRect() const override;
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
-    AbstractCounter *addCounter(int _counterId, const QString &_name, int _value);
+    AbstractCounter *addCounter(CounterState *state);
 };
 
 #endif

--- a/libcockatrice_utility/libcockatrice/utility/color.h
+++ b/libcockatrice_utility/libcockatrice/utility/color.h
@@ -22,6 +22,7 @@ inline color convertQColorToColor(const QColor &c)
     return result;
 }
 
+#include <QMap>
 #include <QSet>
 
 namespace GameSpecificColors


### PR DESCRIPTION
## Short roundup of the initial problem
AbstractCounter was a QGraphicsItem that holds state. It's not possible for a graphics independent player_logic to exist because a player must know about counters associated with it, which it cannot do without instantiating a QGraphicsItem.

## What will change with this Pull Request?
- Added a new CounterState QObject that owns all logical counter data (id, name, color, radius, value)
- Refactored AbstractCounter and derived UI classes (PlayerCounter, GeneralCounter) to become purely graphical views/controllers associated with a CounterState
- Moved counter ownership and lifecycle management in PlayerLogic from AbstractCounter* to CounterState*
- Moved counter widget creation/removal responsibilities into PlayerGraphicsItem
- Introduced signals to synchronize logic and graphics (CounterState::valueChanged, PlayerLogic::counterAdded, PlayerLogic::counterRemoved, PlayerMenu:: shortcut and translation signals)
