### PR TITLE
[Game][Player] Pull out graphics_items out of player_logic

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -99,6 +99,7 @@ set(cockatrice_SOURCES
     src/game/player/menu/utility_menu.cpp
     src/game/player/player_actions.cpp
     src/game/player/player_area.cpp
+    src/game/player/player_dialogs.cpp
     src/game/player/player_event_handler.cpp
     src/game/player/player_graphics_item.cpp
     src/game/player/player_info.cpp

--- a/cockatrice/src/game/abstract_game.cpp
+++ b/cockatrice/src/game/abstract_game.cpp
@@ -3,7 +3,7 @@
 #include "../interface/widgets/tabs/tab_game.h"
 #include "player/player_logic.h"
 
-AbstractGame::AbstractGame(TabGame *_tab) : QObject(_tab), tab(_tab)
+AbstractGame::AbstractGame(QObject *_parent) : QObject(_parent)
 {
     gameMetaInfo = new GameMetaInfo(this);
     gameEventHandler = new GameEventHandler(this);

--- a/cockatrice/src/game/abstract_game.h
+++ b/cockatrice/src/game/abstract_game.h
@@ -16,25 +16,18 @@
 #include <libcockatrice/protocol/pb/game_replay.pb.h>
 
 class CardItem;
-class TabGame;
 class AbstractGame : public QObject
 {
     Q_OBJECT
 
 public:
-    explicit AbstractGame(TabGame *tab);
+    explicit AbstractGame(QObject *parent);
 
-    TabGame *tab;
     GameMetaInfo *gameMetaInfo;
     GameState *gameState;
     GameEventHandler *gameEventHandler;
     PlayerManager *playerManager;
     CardItem *activeCard;
-
-    TabGame *getTab() const
-    {
-        return tab;
-    }
 
     GameMetaInfo *getGameMetaInfo()
     {

--- a/cockatrice/src/game/board/abstract_card_item.h
+++ b/cockatrice/src/game/board/abstract_card_item.h
@@ -44,6 +44,11 @@ signals:
     void deleteCardInfoPopup(QString cardName);
     void sigPixmapUpdated();
     void cardShiftClicked(QString cardName);
+    void rightClicked(AbstractCardItem *card, QPoint screenPos);
+    void playSelected(AbstractCardItem *card);
+    void playSelectedFaceDown(AbstractCardItem *card);
+    void hideSelected(AbstractCardItem *card);
+    void selectionChanged(AbstractCardItem *card, bool selected);
 
 public:
     enum

--- a/cockatrice/src/game/board/card_item.cpp
+++ b/cockatrice/src/game/board/card_item.cpp
@@ -476,7 +476,6 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     if (event->button() == Qt::RightButton && owner != nullptr) {
         emit rightClicked(this, event->screenPos());
-        AbstractCardItem::mouseReleaseEvent(event);
         return;
     }
     if ((event->modifiers() != Qt::AltModifier) && (event->button() == Qt::LeftButton) &&

--- a/cockatrice/src/game/board/card_item.cpp
+++ b/cockatrice/src/game/board/card_item.cpp
@@ -40,7 +40,7 @@ void CardItem::prepareDelete()
 {
     if (owner != nullptr) {
         if (owner->getGame()->getActiveCard() == this) {
-            owner->getPlayerMenu()->updateCardMenu(nullptr);
+            emit owner->requestCardMenuUpdate(nullptr);
             owner->getGame()->setActiveCard(nullptr);
         }
         owner = nullptr;
@@ -399,8 +399,11 @@ void CardItem::playCard(bool faceDown)
         emit tz->toggleTapped();
     } else {
         if (SettingsCache::instance().getClickPlaysAllSelected()) {
-            faceDown ? state->getZone()->getPlayer()->getPlayerActions()->actPlayFacedown()
-                     : state->getZone()->getPlayer()->getPlayerActions()->actPlay();
+            if (faceDown) {
+                emit playSelectedFaceDown(this);
+            } else {
+                emit playSelected(this);
+            }
         } else {
             state->getZone()->getPlayer()->getPlayerActions()->playCard(this, faceDown);
         }
@@ -460,7 +463,7 @@ void CardItem::handleClickedToPlay(bool shiftHeld)
 {
     if (isUnwritableRevealZone(state->getZone())) {
         if (SettingsCache::instance().getClickPlaysAllSelected()) {
-            state->getZone()->getPlayer()->getPlayerActions()->actHide();
+            emit hideSelected(this);
         } else {
             state->getZone()->removeCard(this);
         }
@@ -471,21 +474,16 @@ void CardItem::handleClickedToPlay(bool shiftHeld)
 
 void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
-    if (event->button() == Qt::RightButton) {
-
-        if (owner != nullptr) {
-            owner->getGame()->setActiveCard(this);
-            if (QMenu *cardMenu = owner->getPlayerMenu()->updateCardMenu(this)) {
-                cardMenu->popup(event->screenPos());
-                return;
-            }
-        }
-    } else if ((event->modifiers() != Qt::AltModifier) && (event->button() == Qt::LeftButton) &&
-               (!SettingsCache::instance().getDoubleClickToPlay())) {
+    if (event->button() == Qt::RightButton && owner != nullptr) {
+        emit rightClicked(this, event->screenPos());
+        AbstractCardItem::mouseReleaseEvent(event);
+        return;
+    }
+    if ((event->modifiers() != Qt::AltModifier) && (event->button() == Qt::LeftButton) &&
+        (!SettingsCache::instance().getDoubleClickToPlay())) {
         handleClickedToPlay(event->modifiers().testFlag(Qt::ShiftModifier));
     }
-
-    if (owner != nullptr) { // cards without owner will be deleted
+    if (owner != nullptr) {
         setCursor(Qt::OpenHandCursor);
     }
     AbstractCardItem::mouseReleaseEvent(event);
@@ -531,14 +529,14 @@ bool CardItem::animationEvent()
 QVariant CardItem::itemChange(GraphicsItemChange change, const QVariant &value)
 {
     if ((change == ItemSelectedHasChanged) && owner != nullptr) {
-        if (value == true) {
-            owner->getGame()->setActiveCard(this);
-            owner->getPlayerMenu()->updateCardMenu(this);
-        } else if (owner->getGameScene()->selectedItems().isEmpty()) {
+        bool selected = value.toBool();
 
-            owner->getGame()->setActiveCard(nullptr);
-            owner->getPlayerMenu()->updateCardMenu(nullptr);
+        if (selected) {
+            owner->getGame()->setActiveCard(this);
         }
+
+        emit selectionChanged(this, selected);
     }
+
     return AbstractCardItem::itemChange(change, value);
 }

--- a/cockatrice/src/game/game.cpp
+++ b/cockatrice/src/game/game.cpp
@@ -4,16 +4,16 @@
 
 #include <libcockatrice/protocol/pb/event_game_joined.pb.h>
 
-Game::Game(TabGame *_tab,
+Game::Game(QObject *_parent,
+           bool isLocalGame,
            QList<AbstractClient *> &_clients,
            const Event_GameJoined &event,
            const QMap<int, QString> &_roomGameTypes)
-    : AbstractGame(_tab)
+    : AbstractGame(_parent)
 {
     gameMetaInfo->setFromProto(event.game_info());
     gameMetaInfo->setRoomGameTypes(_roomGameTypes);
-    gameState = new GameState(this, 0, event.host_id(), tab->getTabSupervisor()->getIsLocalGame(), _clients, false,
-                              event.resuming(), -1, false);
+    gameState = new GameState(this, 0, event.host_id(), isLocalGame, _clients, false, event.resuming(), -1, false);
     connect(gameMetaInfo, &GameMetaInfo::startedChanged, gameState, &GameState::onStartedChanged);
     playerManager = new PlayerManager(this, event.player_id(), event.judge(), event.spectator());
     gameMetaInfo->setStarted(false);

--- a/cockatrice/src/game/game.h
+++ b/cockatrice/src/game/game.h
@@ -16,7 +16,8 @@ class Game : public AbstractGame
     Q_OBJECT
 
 public:
-    Game(TabGame *tab,
+    Game(QObject *parent,
+         bool isLocalGame,
          QList<AbstractClient *> &_clients,
          const Event_GameJoined &event,
          const QMap<int, QString> &_roomGameTypes);

--- a/cockatrice/src/game/game_scene.cpp
+++ b/cockatrice/src/game/game_scene.cpp
@@ -4,8 +4,10 @@
 #include "../game_graphics/zones/select_zone.h"
 #include "../game_graphics/zones/view_zone.h"
 #include "../game_graphics/zones/view_zone_widget.h"
+#include "abstract_game.h"
 #include "board/card_item.h"
 #include "phases_toolbar.h"
+#include "player/player_actions.h"
 #include "player/player_graphics_item.h"
 #include "player/player_logic.h"
 
@@ -72,6 +74,62 @@ QList<CardItem *> GameScene::selectedCards() const
     return selectedCards;
 }
 
+void GameScene::onCardSelectionChanged(AbstractCardItem *abstractCard, bool selected)
+{
+    CardItem *card = qobject_cast<CardItem *>(abstractCard);
+    if (!card || !card->getOwner()) {
+        return;
+    }
+
+    auto *owner = card->getOwner();
+
+    if (selected) {
+        owner->requestCardMenuUpdate(card);
+        return;
+    }
+
+    if (selectedItems().isEmpty()) {
+        owner->getGame()->setActiveCard(nullptr);
+        owner->requestCardMenuUpdate(nullptr);
+    }
+}
+
+void GameScene::onCardRightClicked(AbstractCardItem *abstractCard, QPoint screenPos)
+{
+    auto *card = qobject_cast<CardItem *>(abstractCard);
+    if (!card) {
+        return;
+    }
+    if (!card->getOwner()) {
+        return;
+    }
+    auto *view = playerViews.value(card->getOwner()->getPlayerInfo()->getId());
+    if (!view) {
+        return;
+    }
+
+    card->getOwner()->getGame()->setActiveCard(card);
+
+    if (auto *menu = view->getPlayerMenu()->updateCardMenu(card)) {
+        menu->popup(screenPos);
+    }
+}
+
+void GameScene::playSelected(AbstractCardItem *card)
+{
+    card->getOwner()->getPlayerActions()->actPlay(selectedCards());
+}
+
+void GameScene::playSelectedFaceDown(AbstractCardItem *card)
+{
+    card->getOwner()->getPlayerActions()->actPlayFacedown(selectedCards());
+}
+
+void GameScene::hideSelected(AbstractCardItem *card)
+{
+    card->getOwner()->getPlayerActions()->actHide(selectedCards());
+}
+
 /**
  * @brief Adds a player to the scene and stores their graphics item.
  * @param player Player to add.
@@ -82,9 +140,11 @@ void GameScene::addPlayer(PlayerLogic *player)
 {
     qCInfo(GameScenePlayerAdditionRemovalLog) << "GameScene::addPlayer name=" << player->getPlayerInfo()->getName();
 
-    playerViews.insert(player->getPlayerInfo()->getId(), player->getGraphicsItem());
-    addItem(player->getGraphicsItem());
-    connect(player->getGraphicsItem(), &PlayerGraphicsItem::sizeChanged, this, &GameScene::rearrange);
+    auto *view = new PlayerGraphicsItem(player);
+
+    playerViews.insert(player->getPlayerInfo()->getId(), view);
+    addItem(view);
+    connect(view, &PlayerGraphicsItem::sizeChanged, this, &GameScene::rearrange);
 
     connect(player, &PlayerLogic::concededChanged, this, [this](int id, bool conceded) {
         if (conceded) {
@@ -93,6 +153,8 @@ void GameScene::addPlayer(PlayerLogic *player)
         rearrange();
     });
 
+    connect(player, &PlayerLogic::requestZoneViewToggle, this, &GameScene::toggleZoneView);
+    connect(player, &PlayerLogic::requestRevealedZoneView, this, &GameScene::addRevealedZoneView);
     connect(player, &PlayerLogic::arrowDeleted, this, &GameScene::onArrowDeleted);
     connect(player, &PlayerLogic::arrowCreateRequested, this, &GameScene::onArrowCreateRequested);
     connect(player, &PlayerLogic::arrowDeleteRequested, this, &GameScene::onArrowDeleteRequested);
@@ -204,7 +266,7 @@ QList<PlayerLogic *> GameScene::collectActivePlayers(int &firstPlayerIndex) cons
     bool firstPlayerFound = false;
 
     for (auto *pgItem : playerViews.values()) {
-        PlayerLogic *p = pgItem->getPlayer();
+        PlayerLogic *p = pgItem->getPlayerLogic();
         if (p && !p->getConceded()) {
             activePlayers.append(p);
             if (!firstPlayerFound && p->getPlayerInfo()->getLocal()) {
@@ -275,12 +337,12 @@ QSizeF GameScene::computeSceneSizeAndPlayerLayout(const QList<PlayerLogic *> &pl
         for (int j = 0; j < rowsInColumn; ++j) {
             PlayerLogic *player = playersIter.next();
             if (col == 0) {
-                playersByColumn[col].prepend(player->getGraphicsItem());
+                playersByColumn[col].prepend(playerViews.value(player->getPlayerInfo()->getId()));
             } else {
-                playersByColumn[col].append(player->getGraphicsItem());
+                playersByColumn[col].append(playerViews.value(player->getPlayerInfo()->getId()));
             }
 
-            auto *pgItem = player->getGraphicsItem();
+            auto *pgItem = playerViews.value(player->getPlayerInfo()->getId());
             thisColumnHeight += pgItem->boundingRect().height() + playerAreaSpacing;
             columnWidth[col] = std::max(columnWidth[col], (int)pgItem->boundingRect().width());
         }
@@ -375,7 +437,7 @@ void GameScene::onArrowCreateRequested(const ArrowData &data)
         return;
     }
 
-    PlayerLogic *startLogic = startView->getPlayer();
+    PlayerLogic *startLogic = startView->getPlayerLogic();
     auto *startZone = startLogic->getZones().value(data.startZone);
     if (!startZone) {
         return;
@@ -390,7 +452,7 @@ void GameScene::onArrowCreateRequested(const ArrowData &data)
     if (data.isPlayerTargeted()) {
         targetItem = targetView->getPlayerTarget();
     } else {
-        auto *zone = targetView->getPlayer()->getZones().value(data.targetZone);
+        auto *zone = targetView->getPlayerLogic()->getZones().value(data.targetZone);
         if (zone) {
             targetItem = zone->getCard(data.targetCardId);
         }
@@ -399,7 +461,7 @@ void GameScene::onArrowCreateRequested(const ArrowData &data)
         return;
     }
 
-    auto *arrow = new ArrowItem(startView->getPlayer(), data.id, startCard, targetItem, data.color);
+    auto *arrow = new ArrowItem(startView->getPlayerLogic(), data.id, startCard, targetItem, data.color);
     addItem(arrow);
     arrowRegistry.insert(data.id, arrow);
     connect(arrow, &ArrowItem::requestDeletion, this, &GameScene::onArrowDeleteRequested);

--- a/cockatrice/src/game/game_scene.cpp
+++ b/cockatrice/src/game/game_scene.cpp
@@ -117,16 +117,34 @@ void GameScene::onCardRightClicked(AbstractCardItem *abstractCard, QPoint screen
 
 void GameScene::playSelected(AbstractCardItem *card)
 {
+    if (!card) {
+        return;
+    }
+    if (!card->getOwner()) {
+        return;
+    }
     card->getOwner()->getPlayerActions()->actPlay(selectedCards());
 }
 
 void GameScene::playSelectedFaceDown(AbstractCardItem *card)
 {
+    if (!card) {
+        return;
+    }
+    if (!card->getOwner()) {
+        return;
+    }
     card->getOwner()->getPlayerActions()->actPlayFacedown(selectedCards());
 }
 
 void GameScene::hideSelected(AbstractCardItem *card)
 {
+    if (!card) {
+        return;
+    }
+    if (!card->getOwner()) {
+        return;
+    }
     card->getOwner()->getPlayerActions()->actHide(selectedCards());
 }
 

--- a/cockatrice/src/game/game_scene.cpp
+++ b/cockatrice/src/game/game_scene.cpp
@@ -266,7 +266,7 @@ QList<PlayerLogic *> GameScene::collectActivePlayers(int &firstPlayerIndex) cons
     bool firstPlayerFound = false;
 
     for (auto *pgItem : playerViews.values()) {
-        PlayerLogic *p = pgItem->getPlayerLogic();
+        PlayerLogic *p = pgItem->getLogic();
         if (p && !p->getConceded()) {
             activePlayers.append(p);
             if (!firstPlayerFound && p->getPlayerInfo()->getLocal()) {
@@ -437,7 +437,7 @@ void GameScene::onArrowCreateRequested(const ArrowData &data)
         return;
     }
 
-    PlayerLogic *startLogic = startView->getPlayerLogic();
+    PlayerLogic *startLogic = startView->getLogic();
     auto *startZone = startLogic->getZones().value(data.startZone);
     if (!startZone) {
         return;
@@ -452,7 +452,7 @@ void GameScene::onArrowCreateRequested(const ArrowData &data)
     if (data.isPlayerTargeted()) {
         targetItem = targetView->getPlayerTarget();
     } else {
-        auto *zone = targetView->getPlayerLogic()->getZones().value(data.targetZone);
+        auto *zone = targetView->getLogic()->getZones().value(data.targetZone);
         if (zone) {
             targetItem = zone->getCard(data.targetCardId);
         }
@@ -461,7 +461,7 @@ void GameScene::onArrowCreateRequested(const ArrowData &data)
         return;
     }
 
-    auto *arrow = new ArrowItem(startView->getPlayerLogic(), data.id, startCard, targetItem, data.color);
+    auto *arrow = new ArrowItem(startView->getLogic(), data.id, startCard, targetItem, data.color);
     addItem(arrow);
     arrowRegistry.insert(data.id, arrow);
     connect(arrow, &ArrowItem::requestDeletion, this, &GameScene::onArrowDeleteRequested);

--- a/cockatrice/src/game/game_scene.h
+++ b/cockatrice/src/game/game_scene.h
@@ -96,6 +96,16 @@ public:
      */
     void removePlayer(PlayerLogic *player);
 
+    QMap<int, PlayerGraphicsItem *> getPlayers() const
+    {
+        return playerViews;
+    }
+
+    PlayerGraphicsItem *viewForPlayer(int playerId)
+    {
+        return playerViews.value(playerId);
+    }
+
     /**
      * @brief Adjusts the global rotation offset for player layout.
      * @param rotationAdjustment Number of positions to rotate.
@@ -181,6 +191,11 @@ public:
     void stopRubberBand();
 
 public slots:
+    void onCardSelectionChanged(AbstractCardItem *card, bool selected);
+    void onCardRightClicked(AbstractCardItem *card, QPoint screenPos);
+    void playSelected(AbstractCardItem *card);
+    void playSelectedFaceDown(AbstractCardItem *card);
+    void hideSelected(AbstractCardItem *card);
     /** @brief Toggles a zone view for a player. */
     void toggleZoneView(PlayerLogic *player, const QString &zoneName, int numberCards, bool isReversed = false);
 

--- a/cockatrice/src/game/player/menu/card_menu.cpp
+++ b/cockatrice/src/game/player/menu/card_menu.cpp
@@ -30,17 +30,16 @@ static QAction *makeAction(QObject *parent, Slot &&slot, bool checkable = false,
 CardMenu::CardMenu(PlayerGraphicsItem *_player, const CardItem *_card, bool _shortcutsActive)
     : player(_player), card(_card), shortcutsActive(_shortcutsActive)
 {
-    const QList<PlayerLogic *> &players =
-        player->getPlayerLogic()->getGame()->getPlayerManager()->getPlayers().values();
+    const QList<PlayerLogic *> &players = player->getLogic()->getGame()->getPlayerManager()->getPlayers().values();
 
     for (auto playerToAdd : players) {
-        if (playerToAdd == player->getPlayerLogic()) {
+        if (playerToAdd == player->getLogic()) {
             continue;
         }
         playersInfo.append(qMakePair(playerToAdd->getPlayerInfo()->getName(), playerToAdd->getPlayerInfo()->getId()));
     }
 
-    auto *actions = player->getPlayerLogic()->getPlayerActions();
+    auto *actions = player->getLogic()->getPlayerActions();
     auto *gameScene = player->getGameScene();
 
     // Single selection resolver used by all lambdas — called at trigger time
@@ -100,7 +99,7 @@ CardMenu::CardMenu(PlayerGraphicsItem *_player, const CardItem *_card, bool _sho
     }
 
     bool revealedCard = false;
-    bool writeableCard = player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge();
+    bool writeableCard = player->getLogic()->getPlayerInfo()->getLocalOrJudge();
     if (auto *view = qobject_cast<ZoneViewZoneLogic *>(card->getZone())) {
         if (view->getRevealZone()) {
             if (view->getWriteableRevealZone()) {
@@ -285,7 +284,7 @@ void CardMenu::createHandOrCustomZoneMenu(bool canModifyCard)
     initContextualPlayersMenu(revealMenu, aRevealToAll);
 
     connect(revealMenu, &QMenu::triggered, this, [this](QAction *action) {
-        player->getPlayerLogic()->getPlayerActions()->actReveal(player->getGameScene()->selectedCards(), action);
+        player->getLogic()->getPlayerActions()->actReveal(player->getGameScene()->selectedCards(), action);
     });
 
     addSeparator();
@@ -433,7 +432,7 @@ void CardMenu::addRelatedCardActions()
 
         auto *createRelated = new QAction(text, this);
         createRelated->setData(QVariant(index++));
-        connect(createRelated, &QAction::triggered, player->getPlayerLogic()->getPlayerActions(),
+        connect(createRelated, &QAction::triggered, player->getLogic()->getPlayerActions(),
                 &PlayerActions::actCreateRelatedCard);
         addAction(createRelated);
     }
@@ -443,7 +442,7 @@ void CardMenu::addRelatedCardActions()
             createRelatedCards->setShortcuts(
                 SettingsCache::instance().shortcuts().getShortcut("Player/aCreateRelatedTokens"));
         }
-        connect(createRelatedCards, &QAction::triggered, player->getPlayerLogic()->getPlayerActions(),
+        connect(createRelatedCards, &QAction::triggered, player->getLogic()->getPlayerActions(),
                 &PlayerActions::actCreateAllRelatedCards);
         addAction(createRelatedCards);
     }

--- a/cockatrice/src/game/player/menu/card_menu.cpp
+++ b/cockatrice/src/game/player/menu/card_menu.cpp
@@ -39,6 +39,9 @@ CardMenu::CardMenu(PlayerGraphicsItem *_player, const CardItem *_card, bool _sho
         playersInfo.append(qMakePair(playerToAdd->getPlayerInfo()->getName(), playerToAdd->getPlayerInfo()->getId()));
     }
 
+    connect(player->getLogic()->getGame()->getPlayerManager(), &PlayerManager::playerRemoved, this,
+            &CardMenu::removePlayer);
+
     auto *actions = player->getLogic()->getPlayerActions();
     auto *gameScene = player->getGameScene();
 

--- a/cockatrice/src/game/player/menu/card_menu.cpp
+++ b/cockatrice/src/game/player/menu/card_menu.cpp
@@ -6,6 +6,7 @@
 #include "../../zones/view_zone_logic.h"
 #include "../card_menu_action_type.h"
 #include "../player_actions.h"
+#include "../player_graphics_item.h"
 #include "../player_logic.h"
 #include "move_menu.h"
 #include "pt_menu.h"
@@ -14,81 +15,80 @@
 #include <libcockatrice/card/relation/card_relation.h>
 #include <libcockatrice/utility/zone_names.h>
 
-CardMenu::CardMenu(PlayerLogic *_player, const CardItem *_card, bool _shortcutsActive)
+template <typename Slot>
+static QAction *makeAction(QObject *parent, Slot &&slot, bool checkable = false, bool checked = false)
+{
+    auto *a = new QAction(parent);
+    a->setCheckable(checkable);
+    if (checkable) {
+        a->setChecked(checked);
+    }
+    QObject::connect(a, &QAction::triggered, parent, std::forward<Slot>(slot));
+    return a;
+}
+
+CardMenu::CardMenu(PlayerGraphicsItem *_player, const CardItem *_card, bool _shortcutsActive)
     : player(_player), card(_card), shortcutsActive(_shortcutsActive)
 {
-    auto playerActions = player->getPlayerActions();
-
-    const QList<PlayerLogic *> &players = player->getGame()->getPlayerManager()->getPlayers().values();
+    const QList<PlayerLogic *> &players =
+        player->getPlayerLogic()->getGame()->getPlayerManager()->getPlayers().values();
 
     for (auto playerToAdd : players) {
-        if (playerToAdd == player) {
+        if (playerToAdd == player->getPlayerLogic()) {
             continue;
         }
         playersInfo.append(qMakePair(playerToAdd->getPlayerInfo()->getName(), playerToAdd->getPlayerInfo()->getId()));
     }
 
-    connect(player->getGame()->getPlayerManager(), &PlayerManager::playerRemoved, this, &CardMenu::removePlayer);
+    auto *actions = player->getPlayerLogic()->getPlayerActions();
+    auto *gameScene = player->getGameScene();
 
-    aTap = new QAction(this);
-    aTap->setData(cmTap);
-    connect(aTap, &QAction::triggered, playerActions, &PlayerActions::cardMenuAction);
-    aDoesntUntap = new QAction(this);
-    aDoesntUntap->setData(cmDoesntUntap);
-    aDoesntUntap->setCheckable(true);
-    aDoesntUntap->setChecked(card != nullptr && card->getDoesntUntap());
-    connect(aDoesntUntap, &QAction::triggered, playerActions, &PlayerActions::cardMenuAction);
+    // Single selection resolver used by all lambdas — called at trigger time
+    auto sel = [gameScene]() { return gameScene->selectedCards(); };
+
+    // Unified dispatcher for card menu actions
+    auto invoke = [actions, sel](CardMenuActionType type) {
+        return [actions, sel, type]() { actions->cardMenuAction(sel(), type); };
+    };
+
+    // Actions using invoke (type dispatch, need selection)
+    aTap = makeAction(this, invoke(cmTap));
+    aDoesntUntap = makeAction(this, invoke(cmDoesntUntap), /*checkable=*/true, card && card->getDoesntUntap());
+    aFlip = makeAction(this, invoke(cmFlip));
+    aPeek = makeAction(this, invoke(cmPeek));
+    aClone = makeAction(this, invoke(cmClone));
+
+    // Actions using selection directly
+    aUnattach = makeAction(this, [actions, sel]() { actions->actUnattach(sel()); });
+    aSetAnnotation = makeAction(this, [actions, sel]() { actions->actRequestSetAnnotationDialog(sel()); });
+    aPlay = makeAction(this, [actions, sel]() { actions->actPlay(sel()); });
+    aPlayFacedown = makeAction(this, [actions, sel]() { actions->actPlayFacedown(sel()); });
+    aHide = makeAction(this, [actions, sel]() { actions->actHide(sel()); });
+    aReduceLifeByPower = makeAction(this, [actions, sel]() { actions->actReduceLifeByPower(sel()); });
+
+    // Actions that use activeCard, not selection — direct connection
     aAttach = new QAction(this);
-    connect(aAttach, &QAction::triggered, playerActions, &PlayerActions::actAttach);
-    aUnattach = new QAction(this);
-    connect(aUnattach, &QAction::triggered, playerActions, &PlayerActions::actUnattach);
     aDrawArrow = new QAction(this);
-    connect(aDrawArrow, &QAction::triggered, playerActions, &PlayerActions::actDrawArrow);
-    aSetAnnotation = new QAction(this);
-    connect(aSetAnnotation, &QAction::triggered, playerActions, &PlayerActions::actSetAnnotation);
-    aFlip = new QAction(this);
-    aFlip->setData(cmFlip);
-    connect(aFlip, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
-    aPeek = new QAction(this);
-    aPeek->setData(cmPeek);
-    connect(aPeek, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
-    aClone = new QAction(this);
-    aClone->setData(cmClone);
-    connect(aClone, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
     aSelectAll = new QAction(this);
-    connect(aSelectAll, &QAction::triggered, playerActions, &PlayerActions::actSelectAll);
     aSelectRow = new QAction(this);
-    connect(aSelectRow, &QAction::triggered, playerActions, &PlayerActions::actSelectRow);
     aSelectColumn = new QAction(this);
-    connect(aSelectColumn, &QAction::triggered, playerActions, &PlayerActions::actSelectColumn);
 
-    aReduceLifeByPower = new QAction(this);
-    connect(aReduceLifeByPower, &QAction::triggered, playerActions, &PlayerActions::actReduceLifeByPower);
-
-    aPlay = new QAction(this);
-    connect(aPlay, &QAction::triggered, playerActions, &PlayerActions::actPlay);
-    aHide = new QAction(this);
-    connect(aHide, &QAction::triggered, playerActions, &PlayerActions::actHide);
-    aPlayFacedown = new QAction(this);
-    connect(aPlayFacedown, &QAction::triggered, playerActions, &PlayerActions::actPlayFacedown);
+    connect(aAttach, &QAction::triggered, actions, &PlayerActions::actAttach);
+    connect(aDrawArrow, &QAction::triggered, actions, &PlayerActions::actDrawArrow);
+    connect(aSelectAll, &QAction::triggered, actions, &PlayerActions::actSelectAll);
+    connect(aSelectRow, &QAction::triggered, actions, &PlayerActions::actSelectRow);
+    connect(aSelectColumn, &QAction::triggered, actions, &PlayerActions::actSelectColumn);
 
     aRevealToAll = new QAction(this);
 
     mCardCounters = new QMenu;
 
+    // Card counters
     for (int i = 0; i < 6; ++i) {
-        auto *tempAddCounter = new QAction(this);
-        auto *tempRemoveCounter = new QAction(this);
-        auto *tempSetCounter = new QAction(this);
-        aAddCounter.append(tempAddCounter);
-        aRemoveCounter.append(tempRemoveCounter);
-        aSetCounter.append(tempSetCounter);
-        connect(tempAddCounter, &QAction::triggered, playerActions,
-                [playerActions, i] { playerActions->actAddCardCounter(i); });
-        connect(tempRemoveCounter, &QAction::triggered, playerActions,
-                [playerActions, i] { playerActions->actRemoveCardCounter(i); });
-        connect(tempSetCounter, &QAction::triggered, playerActions,
-                [playerActions, i] { playerActions->actSetCardCounter(i); });
+        aAddCounter.append(makeAction(this, [actions, sel, i]() { actions->actAddCardCounter(sel(), i); }));
+        aRemoveCounter.append(makeAction(this, [actions, sel, i]() { actions->actRemoveCardCounter(sel(), i); }));
+        aSetCounter.append(
+            makeAction(this, [actions, sel, i]() { actions->actRequestSetCardCounterDialog(sel(), i); }));
     }
 
     setShortcutsActive();
@@ -100,7 +100,7 @@ CardMenu::CardMenu(PlayerLogic *_player, const CardItem *_card, bool _shortcutsA
     }
 
     bool revealedCard = false;
-    bool writeableCard = player->getPlayerInfo()->getLocalOrJudge();
+    bool writeableCard = player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge();
     if (auto *view = qobject_cast<ZoneViewZoneLogic *>(card->getZone())) {
         if (view->getRevealZone()) {
             if (view->getWriteableRevealZone()) {
@@ -284,7 +284,9 @@ void CardMenu::createHandOrCustomZoneMenu(bool canModifyCard)
 
     initContextualPlayersMenu(revealMenu, aRevealToAll);
 
-    connect(revealMenu, &QMenu::triggered, player->getPlayerActions(), &PlayerActions::actReveal);
+    connect(revealMenu, &QMenu::triggered, this, [this](QAction *action) {
+        player->getPlayerLogic()->getPlayerActions()->actReveal(player->getGameScene()->selectedCards(), action);
+    });
 
     addSeparator();
     addAction(aClone);
@@ -369,8 +371,7 @@ void CardMenu::addRelatedCardView()
         QAction *viewCard = viewRelatedCards->addAction(relatedCardName);
         Q_UNUSED(viewCard);
 
-        connect(viewCard, &QAction::triggered, player->getGame(),
-                [this, cardRef] { player->getGame()->getTab()->viewCardInfo(cardRef); });
+        connect(viewCard, &QAction::triggered, this, [this, cardRef] { emit cardInfoRequested(cardRef); });
     }
 }
 
@@ -432,7 +433,8 @@ void CardMenu::addRelatedCardActions()
 
         auto *createRelated = new QAction(text, this);
         createRelated->setData(QVariant(index++));
-        connect(createRelated, &QAction::triggered, player->getPlayerActions(), &PlayerActions::actCreateRelatedCard);
+        connect(createRelated, &QAction::triggered, player->getPlayerLogic()->getPlayerActions(),
+                &PlayerActions::actCreateRelatedCard);
         addAction(createRelated);
     }
 
@@ -441,7 +443,7 @@ void CardMenu::addRelatedCardActions()
             createRelatedCards->setShortcuts(
                 SettingsCache::instance().shortcuts().getShortcut("Player/aCreateRelatedTokens"));
         }
-        connect(createRelatedCards, &QAction::triggered, player->getPlayerActions(),
+        connect(createRelatedCards, &QAction::triggered, player->getPlayerLogic()->getPlayerActions(),
                 &PlayerActions::actCreateAllRelatedCards);
         addAction(createRelatedCards);
     }

--- a/cockatrice/src/game/player/menu/card_menu.h
+++ b/cockatrice/src/game/player/menu/card_menu.h
@@ -7,9 +7,8 @@
 #ifndef COCKATRICE_CARD_MENU_H
 #define COCKATRICE_CARD_MENU_H
 
-#include "libcockatrice/utility/card_ref.h"
-
 #include <QMenu>
+#include <libcockatrice/utility/card_ref.h>
 
 class CardItem;
 class PlayerGraphicsItem;

--- a/cockatrice/src/game/player/menu/card_menu.h
+++ b/cockatrice/src/game/player/menu/card_menu.h
@@ -7,16 +7,22 @@
 #ifndef COCKATRICE_CARD_MENU_H
 #define COCKATRICE_CARD_MENU_H
 
+#include "libcockatrice/utility/card_ref.h"
+
 #include <QMenu>
 
 class CardItem;
+class PlayerGraphicsItem;
 class PlayerLogic;
 class CardMenu : public QMenu
 {
     Q_OBJECT
 
+signals:
+    void cardInfoRequested(const CardRef &cardRef);
+
 public:
-    explicit CardMenu(PlayerLogic *player, const CardItem *card, bool shortcutsActive);
+    explicit CardMenu(PlayerGraphicsItem *player, const CardItem *card, bool shortcutsActive);
     void removePlayer(PlayerLogic *playerToRemove);
     void createTableMenu(bool canModifyCard);
     void createStackMenu(bool canModifyCard);
@@ -41,7 +47,7 @@ public:
     QList<QAction *> aAddCounter, aSetCounter, aRemoveCounter;
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
     const CardItem *card;
     QList<QPair<QString, int>> playersInfo;
     bool shortcutsActive;

--- a/cockatrice/src/game/player/menu/custom_zone_menu.cpp
+++ b/cockatrice/src/game/player/menu/custom_zone_menu.cpp
@@ -2,12 +2,12 @@
 
 #include "../player_logic.h"
 
-CustomZoneMenu::CustomZoneMenu(PlayerLogic *_player) : player(_player)
+CustomZoneMenu::CustomZoneMenu(PlayerGraphicsItem *_player) : player(_player)
 {
     menuAction()->setVisible(false);
 
-    connect(player, &PlayerLogic::clearCustomZonesMenu, this, &CustomZoneMenu::clearCustomZonesMenu);
-    connect(player, &PlayerLogic::addViewCustomZoneActionToCustomZoneMenu, this,
+    connect(player->getPlayerLogic(), &PlayerLogic::clearCustomZonesMenu, this, &CustomZoneMenu::clearCustomZonesMenu);
+    connect(player->getPlayerLogic(), &PlayerLogic::addViewCustomZoneActionToCustomZoneMenu, this,
             &CustomZoneMenu::addViewCustomZoneActionToCustomZoneMenu);
 
     retranslateUi();
@@ -17,7 +17,7 @@ void CustomZoneMenu::retranslateUi()
 {
     setTitle(tr("C&ustom Zones"));
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
 
         for (auto aViewZone : actions()) {
             aViewZone->setText(tr("View custom zone '%1'").arg(aViewZone->data().toString()));
@@ -37,5 +37,5 @@ void CustomZoneMenu::addViewCustomZoneActionToCustomZoneMenu(QString zoneName)
     QAction *aViewZone = addAction(tr("View custom zone '%1'").arg(zoneName));
     aViewZone->setData(zoneName);
     connect(aViewZone, &QAction::triggered, this,
-            [zoneName, this]() { player->getGameScene()->toggleZoneView(player, zoneName, -1); });
+            [zoneName, this]() { player->getGameScene()->toggleZoneView(player->getPlayerLogic(), zoneName, -1); });
 }

--- a/cockatrice/src/game/player/menu/custom_zone_menu.cpp
+++ b/cockatrice/src/game/player/menu/custom_zone_menu.cpp
@@ -6,8 +6,8 @@ CustomZoneMenu::CustomZoneMenu(PlayerGraphicsItem *_player) : player(_player)
 {
     menuAction()->setVisible(false);
 
-    connect(player->getPlayerLogic(), &PlayerLogic::clearCustomZonesMenu, this, &CustomZoneMenu::clearCustomZonesMenu);
-    connect(player->getPlayerLogic(), &PlayerLogic::addViewCustomZoneActionToCustomZoneMenu, this,
+    connect(player->getLogic(), &PlayerLogic::clearCustomZonesMenu, this, &CustomZoneMenu::clearCustomZonesMenu);
+    connect(player->getLogic(), &PlayerLogic::addViewCustomZoneActionToCustomZoneMenu, this,
             &CustomZoneMenu::addViewCustomZoneActionToCustomZoneMenu);
 
     retranslateUi();
@@ -17,7 +17,7 @@ void CustomZoneMenu::retranslateUi()
 {
     setTitle(tr("C&ustom Zones"));
 
-    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
 
         for (auto aViewZone : actions()) {
             aViewZone->setText(tr("View custom zone '%1'").arg(aViewZone->data().toString()));
@@ -37,5 +37,5 @@ void CustomZoneMenu::addViewCustomZoneActionToCustomZoneMenu(QString zoneName)
     QAction *aViewZone = addAction(tr("View custom zone '%1'").arg(zoneName));
     aViewZone->setData(zoneName);
     connect(aViewZone, &QAction::triggered, this,
-            [zoneName, this]() { player->getGameScene()->toggleZoneView(player->getPlayerLogic(), zoneName, -1); });
+            [zoneName, this]() { player->getGameScene()->toggleZoneView(player->getLogic(), zoneName, -1); });
 }

--- a/cockatrice/src/game/player/menu/custom_zone_menu.h
+++ b/cockatrice/src/game/player/menu/custom_zone_menu.h
@@ -11,12 +11,12 @@
 
 #include <QMenu>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class CustomZoneMenu : public QMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 public:
-    explicit CustomZoneMenu(PlayerLogic *player);
+    explicit CustomZoneMenu(PlayerGraphicsItem *player);
     void retranslateUi() override;
     void setShortcutsActive() override
     {
@@ -26,7 +26,7 @@ public:
     }
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
 private slots:
     void clearCustomZonesMenu();
     void addViewCustomZoneActionToCustomZoneMenu(QString zoneName);

--- a/cockatrice/src/game/player/menu/grave_menu.cpp
+++ b/cockatrice/src/game/player/menu/grave_menu.cpp
@@ -15,7 +15,7 @@ GraveyardMenu::GraveyardMenu(PlayerGraphicsItem *_player, QWidget *parent) : Tea
 
     addAction(aViewGraveyard);
 
-    if (player->getPlayerLogic()->getPlayerInfo()->local || player->getPlayerLogic()->getPlayerInfo()->judge) {
+    if (player->getLogic()->getPlayerInfo()->local || player->getLogic()->getPlayerInfo()->judge) {
         mRevealRandomGraveyardCard = addMenu(QString());
         connect(mRevealRandomGraveyardCard, &QMenu::aboutToShow, this,
                 &GraveyardMenu::populateRevealRandomMenuWithActivePlayers);
@@ -36,9 +36,9 @@ GraveyardMenu::GraveyardMenu(PlayerGraphicsItem *_player, QWidget *parent) : Tea
 
 void GraveyardMenu::createMoveActions()
 {
-    auto grave = player->getPlayerLogic()->getGraveZone();
+    auto grave = player->getLogic()->getGraveZone();
 
-    if (player->getPlayerLogic()->getPlayerInfo()->local || player->getPlayerLogic()->getPlayerInfo()->judge) {
+    if (player->getLogic()->getPlayerInfo()->local || player->getLogic()->getPlayerInfo()->judge) {
         aMoveGraveToTopLibrary = new QAction(this);
         aMoveGraveToTopLibrary->setData(QList<QVariant>() << ZoneNames::DECK << 0);
 
@@ -60,7 +60,7 @@ void GraveyardMenu::createMoveActions()
 
 void GraveyardMenu::createViewActions()
 {
-    PlayerActions *playerActions = player->getPlayerLogic()->getPlayerActions();
+    PlayerActions *playerActions = player->getLogic()->getPlayerActions();
 
     aViewGraveyard = new QAction(this);
     connect(aViewGraveyard, &QAction::triggered, playerActions, &PlayerActions::actViewGraveyard);
@@ -76,9 +76,9 @@ void GraveyardMenu::populateRevealRandomMenuWithActivePlayers()
 
     mRevealRandomGraveyardCard->addSeparator();
 
-    const auto &players = player->getPlayerLogic()->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player->getPlayerLogic()) {
+        if (other == player->getLogic()) {
             continue;
         }
         QAction *a = mRevealRandomGraveyardCard->addAction(other->getPlayerInfo()->getName());
@@ -90,7 +90,7 @@ void GraveyardMenu::populateRevealRandomMenuWithActivePlayers()
 void GraveyardMenu::onRevealRandomTriggered()
 {
     if (auto *a = qobject_cast<QAction *>(sender())) {
-        player->getPlayerLogic()->getPlayerActions()->actRevealRandomGraveyardCard(a->data().toInt());
+        player->getLogic()->getPlayerActions()->actRevealRandomGraveyardCard(a->data().toInt());
     }
 }
 
@@ -100,7 +100,7 @@ void GraveyardMenu::retranslateUi()
 
     aViewGraveyard->setText(tr("&View graveyard"));
 
-    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         moveGraveMenu->setTitle(tr("&Move graveyard to..."));
         aMoveGraveToTopLibrary->setText(tr("&Top of library"));
         aMoveGraveToBottomLibrary->setText(tr("&Bottom of library"));

--- a/cockatrice/src/game/player/menu/grave_menu.cpp
+++ b/cockatrice/src/game/player/menu/grave_menu.cpp
@@ -8,14 +8,14 @@
 #include <QMenu>
 #include <libcockatrice/utility/zone_names.h>
 
-GraveyardMenu::GraveyardMenu(PlayerLogic *_player, QWidget *parent) : TearOffMenu(parent), player(_player)
+GraveyardMenu::GraveyardMenu(PlayerGraphicsItem *_player, QWidget *parent) : TearOffMenu(parent), player(_player)
 {
     createMoveActions();
     createViewActions();
 
     addAction(aViewGraveyard);
 
-    if (player->getPlayerInfo()->local || player->getPlayerInfo()->judge) {
+    if (player->getPlayerLogic()->getPlayerInfo()->local || player->getPlayerLogic()->getPlayerInfo()->judge) {
         mRevealRandomGraveyardCard = addMenu(QString());
         connect(mRevealRandomGraveyardCard, &QMenu::aboutToShow, this,
                 &GraveyardMenu::populateRevealRandomMenuWithActivePlayers);
@@ -36,9 +36,9 @@ GraveyardMenu::GraveyardMenu(PlayerLogic *_player, QWidget *parent) : TearOffMen
 
 void GraveyardMenu::createMoveActions()
 {
-    auto grave = player->getGraveZone();
+    auto grave = player->getPlayerLogic()->getGraveZone();
 
-    if (player->getPlayerInfo()->local || player->getPlayerInfo()->judge) {
+    if (player->getPlayerLogic()->getPlayerInfo()->local || player->getPlayerLogic()->getPlayerInfo()->judge) {
         aMoveGraveToTopLibrary = new QAction(this);
         aMoveGraveToTopLibrary->setData(QList<QVariant>() << ZoneNames::DECK << 0);
 
@@ -60,7 +60,7 @@ void GraveyardMenu::createMoveActions()
 
 void GraveyardMenu::createViewActions()
 {
-    PlayerActions *playerActions = player->getPlayerActions();
+    PlayerActions *playerActions = player->getPlayerLogic()->getPlayerActions();
 
     aViewGraveyard = new QAction(this);
     connect(aViewGraveyard, &QAction::triggered, playerActions, &PlayerActions::actViewGraveyard);
@@ -76,9 +76,9 @@ void GraveyardMenu::populateRevealRandomMenuWithActivePlayers()
 
     mRevealRandomGraveyardCard->addSeparator();
 
-    const auto &players = player->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getPlayerLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player) {
+        if (other == player->getPlayerLogic()) {
             continue;
         }
         QAction *a = mRevealRandomGraveyardCard->addAction(other->getPlayerInfo()->getName());
@@ -90,7 +90,7 @@ void GraveyardMenu::populateRevealRandomMenuWithActivePlayers()
 void GraveyardMenu::onRevealRandomTriggered()
 {
     if (auto *a = qobject_cast<QAction *>(sender())) {
-        player->getPlayerActions()->actRevealRandomGraveyardCard(a->data().toInt());
+        player->getPlayerLogic()->getPlayerActions()->actRevealRandomGraveyardCard(a->data().toInt());
     }
 }
 
@@ -100,7 +100,7 @@ void GraveyardMenu::retranslateUi()
 
     aViewGraveyard->setText(tr("&View graveyard"));
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
         moveGraveMenu->setTitle(tr("&Move graveyard to..."));
         aMoveGraveToTopLibrary->setText(tr("&Top of library"));
         aMoveGraveToBottomLibrary->setText(tr("&Bottom of library"));

--- a/cockatrice/src/game/player/menu/grave_menu.h
+++ b/cockatrice/src/game/player/menu/grave_menu.h
@@ -13,7 +13,7 @@
 #include <QAction>
 #include <QMenu>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class GraveyardMenu : public TearOffMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
@@ -21,7 +21,7 @@ signals:
     void newPlayerActionCreated(QAction *action);
 
 public:
-    explicit GraveyardMenu(PlayerLogic *player, QWidget *parent = nullptr);
+    explicit GraveyardMenu(PlayerGraphicsItem *player, QWidget *parent = nullptr);
     void createMoveActions();
     void createViewActions();
     void populateRevealRandomMenuWithActivePlayers();
@@ -40,7 +40,7 @@ public:
     QAction *aMoveGraveToRfg = nullptr;
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
 };
 
 #endif // COCKATRICE_GRAVE_MENU_H

--- a/cockatrice/src/game/player/menu/hand_menu.cpp
+++ b/cockatrice/src/game/player/menu/hand_menu.cpp
@@ -14,9 +14,9 @@
 
 HandMenu::HandMenu(PlayerGraphicsItem *_player, QWidget *parent) : TearOffMenu(parent), player(_player)
 {
-    auto *actions = player->getPlayerLogic()->getPlayerActions();
+    auto *actions = player->getLogic()->getPlayerActions();
 
-    if (player->getPlayerLogic()->getPlayerInfo()->local || player->getPlayerLogic()->getPlayerInfo()->judge) {
+    if (player->getLogic()->getPlayerInfo()->local || player->getLogic()->getPlayerInfo()->judge) {
         aViewHand = new QAction(this);
 
         connect(aViewHand, &QAction::triggered, actions, &PlayerActions::actViewHand);
@@ -79,7 +79,7 @@ HandMenu::HandMenu(PlayerGraphicsItem *_player, QWidget *parent) : TearOffMenu(p
 
     mMoveHandMenu = addTearOffMenu(QString());
 
-    if (player->getPlayerLogic()->getPlayerInfo()->local || player->getPlayerLogic()->getPlayerInfo()->judge) {
+    if (player->getLogic()->getPlayerInfo()->local || player->getLogic()->getPlayerInfo()->judge) {
         aMoveHandToTopLibrary = new QAction(this);
         aMoveHandToTopLibrary->setData(QList<QVariant>() << ZoneNames::DECK << 0);
         aMoveHandToBottomLibrary = new QAction(this);
@@ -89,7 +89,7 @@ HandMenu::HandMenu(PlayerGraphicsItem *_player, QWidget *parent) : TearOffMenu(p
         aMoveHandToRfg = new QAction(this);
         aMoveHandToRfg->setData(QList<QVariant>() << ZoneNames::EXILE << 0);
 
-        auto hand = player->getPlayerLogic()->getHandZone();
+        auto hand = player->getLogic()->getHandZone();
 
         connect(aMoveHandToTopLibrary, &QAction::triggered, hand, &HandZoneLogic::moveAllToZone);
         connect(aMoveHandToBottomLibrary, &QAction::triggered, hand, &HandZoneLogic::moveAllToZone);
@@ -111,7 +111,7 @@ void HandMenu::retranslateUi()
 {
     setTitle(tr("&Hand"));
 
-    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aViewHand->setText(tr("&View hand"));
 
         mSortHand->setTitle(tr("Sort hand by..."));
@@ -170,9 +170,9 @@ void HandMenu::populateRevealHandMenuWithActivePlayers()
 
     mRevealHand->addSeparator();
 
-    const auto &players = player->getPlayerLogic()->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player->getPlayerLogic()) {
+        if (other == player->getLogic()) {
             continue;
         }
         QAction *a = mRevealHand->addAction(other->getPlayerInfo()->getName());
@@ -189,9 +189,9 @@ void HandMenu::populateRevealRandomHandCardMenuWithActivePlayers()
 
     mRevealRandomHandCard->addSeparator();
 
-    const auto &players = player->getPlayerLogic()->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player->getPlayerLogic()) {
+        if (other == player->getLogic()) {
             continue;
         }
         QAction *a = mRevealRandomHandCard->addAction(other->getPlayerInfo()->getName());
@@ -208,7 +208,7 @@ void HandMenu::onRevealHandTriggered()
     }
 
     const int targetId = action->data().toInt();
-    player->getPlayerLogic()->getPlayerActions()->actRevealHand(targetId);
+    player->getLogic()->getPlayerActions()->actRevealHand(targetId);
 }
 
 void HandMenu::onRevealRandomHandCardTriggered()
@@ -219,5 +219,5 @@ void HandMenu::onRevealRandomHandCardTriggered()
     }
 
     const int targetId = action->data().toInt();
-    player->getPlayerLogic()->getPlayerActions()->actRevealRandomHandCard(targetId);
+    player->getLogic()->getPlayerActions()->actRevealRandomHandCard(targetId);
 }

--- a/cockatrice/src/game/player/menu/hand_menu.cpp
+++ b/cockatrice/src/game/player/menu/hand_menu.cpp
@@ -5,16 +5,20 @@
 #include "../../../game_graphics/zones/hand_zone.h"
 #include "../../abstract_game.h"
 #include "../player_actions.h"
+#include "../player_graphics_item.h"
 #include "../player_logic.h"
 
 #include <QAction>
 #include <QMenu>
 #include <libcockatrice/utility/zone_names.h>
 
-HandMenu::HandMenu(PlayerLogic *_player, PlayerActions *actions, QWidget *parent) : TearOffMenu(parent), player(_player)
+HandMenu::HandMenu(PlayerGraphicsItem *_player, QWidget *parent) : TearOffMenu(parent), player(_player)
 {
-    if (player->getPlayerInfo()->local || player->getPlayerInfo()->judge) {
+    auto *actions = player->getPlayerLogic()->getPlayerActions();
+
+    if (player->getPlayerLogic()->getPlayerInfo()->local || player->getPlayerLogic()->getPlayerInfo()->judge) {
         aViewHand = new QAction(this);
+
         connect(aViewHand, &QAction::triggered, actions, &PlayerActions::actViewHand);
         addAction(aViewHand);
 
@@ -58,7 +62,7 @@ HandMenu::HandMenu(PlayerLogic *_player, PlayerActions *actions, QWidget *parent
     addSeparator();
 
     aMulligan = new QAction(this);
-    connect(aMulligan, &QAction::triggered, actions, &PlayerActions::actMulligan);
+    connect(aMulligan, &QAction::triggered, actions, &PlayerActions::actRequestMulliganDialog);
     addAction(aMulligan);
 
     // Mulligan same size
@@ -75,7 +79,7 @@ HandMenu::HandMenu(PlayerLogic *_player, PlayerActions *actions, QWidget *parent
 
     mMoveHandMenu = addTearOffMenu(QString());
 
-    if (player->getPlayerInfo()->local || player->getPlayerInfo()->judge) {
+    if (player->getPlayerLogic()->getPlayerInfo()->local || player->getPlayerLogic()->getPlayerInfo()->judge) {
         aMoveHandToTopLibrary = new QAction(this);
         aMoveHandToTopLibrary->setData(QList<QVariant>() << ZoneNames::DECK << 0);
         aMoveHandToBottomLibrary = new QAction(this);
@@ -85,7 +89,7 @@ HandMenu::HandMenu(PlayerLogic *_player, PlayerActions *actions, QWidget *parent
         aMoveHandToRfg = new QAction(this);
         aMoveHandToRfg->setData(QList<QVariant>() << ZoneNames::EXILE << 0);
 
-        auto hand = player->getHandZone();
+        auto hand = player->getPlayerLogic()->getHandZone();
 
         connect(aMoveHandToTopLibrary, &QAction::triggered, hand, &HandZoneLogic::moveAllToZone);
         connect(aMoveHandToBottomLibrary, &QAction::triggered, hand, &HandZoneLogic::moveAllToZone);
@@ -107,7 +111,7 @@ void HandMenu::retranslateUi()
 {
     setTitle(tr("&Hand"));
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aViewHand->setText(tr("&View hand"));
 
         mSortHand->setTitle(tr("Sort hand by..."));
@@ -166,9 +170,9 @@ void HandMenu::populateRevealHandMenuWithActivePlayers()
 
     mRevealHand->addSeparator();
 
-    const auto &players = player->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getPlayerLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player) {
+        if (other == player->getPlayerLogic()) {
             continue;
         }
         QAction *a = mRevealHand->addAction(other->getPlayerInfo()->getName());
@@ -185,9 +189,9 @@ void HandMenu::populateRevealRandomHandCardMenuWithActivePlayers()
 
     mRevealRandomHandCard->addSeparator();
 
-    const auto &players = player->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getPlayerLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player) {
+        if (other == player->getPlayerLogic()) {
             continue;
         }
         QAction *a = mRevealRandomHandCard->addAction(other->getPlayerInfo()->getName());
@@ -204,7 +208,7 @@ void HandMenu::onRevealHandTriggered()
     }
 
     const int targetId = action->data().toInt();
-    player->getPlayerActions()->actRevealHand(targetId);
+    player->getPlayerLogic()->getPlayerActions()->actRevealHand(targetId);
 }
 
 void HandMenu::onRevealRandomHandCardTriggered()
@@ -215,5 +219,5 @@ void HandMenu::onRevealRandomHandCardTriggered()
     }
 
     const int targetId = action->data().toInt();
-    player->getPlayerActions()->actRevealRandomHandCard(targetId);
+    player->getPlayerLogic()->getPlayerActions()->actRevealRandomHandCard(targetId);
 }

--- a/cockatrice/src/game/player/menu/hand_menu.h
+++ b/cockatrice/src/game/player/menu/hand_menu.h
@@ -13,7 +13,7 @@
 #include <QAction>
 #include <QMenu>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class PlayerActions;
 
 class HandMenu : public TearOffMenu, public AbstractPlayerComponent
@@ -21,7 +21,7 @@ class HandMenu : public TearOffMenu, public AbstractPlayerComponent
     Q_OBJECT
 
 public:
-    HandMenu(PlayerLogic *player, PlayerActions *actions, QWidget *parent = nullptr);
+    HandMenu(PlayerGraphicsItem *player, QWidget *parent = nullptr);
 
     QMenu *revealHandMenu() const
     {
@@ -43,7 +43,7 @@ private slots:
     void onRevealRandomHandCardTriggered();
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
 
     QAction *aViewHand = nullptr;
     QAction *aMulligan = nullptr;

--- a/cockatrice/src/game/player/menu/library_menu.cpp
+++ b/cockatrice/src/game/player/menu/library_menu.cpp
@@ -8,9 +8,10 @@
 #include "../player_logic.h"
 
 #include <QAction>
+#include <QGraphicsView>
 #include <QMenu>
 
-LibraryMenu::LibraryMenu(PlayerLogic *_player, QWidget *parent) : TearOffMenu(parent), player(_player)
+LibraryMenu::LibraryMenu(PlayerGraphicsItem *_player, QWidget *parent) : TearOffMenu(parent), player(_player)
 {
     createDrawActions();
     createShuffleActions();
@@ -75,8 +76,9 @@ LibraryMenu::LibraryMenu(PlayerLogic *_player, QWidget *parent) : TearOffMenu(pa
     bottomLibraryMenu->addSeparator();
     bottomLibraryMenu->addAction(aShuffleBottomCards);
 
-    connect(player, &PlayerLogic::resetTopCardMenuActions, this, &LibraryMenu::resetTopCardMenuActions);
-    connect(player, &PlayerLogic::deckChanged, this, &LibraryMenu::enableOpenInDeckEditorAction);
+    connect(player->getPlayerLogic(), &PlayerLogic::resetTopCardMenuActions, this,
+            &LibraryMenu::resetTopCardMenuActions);
+    connect(player->getPlayerLogic(), &PlayerLogic::deckChanged, this, &LibraryMenu::enableOpenInDeckEditorAction);
 
     retranslateUi();
 }
@@ -94,41 +96,41 @@ void LibraryMenu::resetTopCardMenuActions()
 
 void LibraryMenu::createDrawActions()
 {
-    PlayerActions *playerActions = player->getPlayerActions();
+    PlayerActions *playerActions = player->getPlayerLogic()->getPlayerActions();
 
-    if (player->getPlayerInfo()->local || player->getPlayerInfo()->judge) {
+    if (player->getPlayerLogic()->getPlayerInfo()->local || player->getPlayerLogic()->getPlayerInfo()->judge) {
         aDrawCard = new QAction(this);
         connect(aDrawCard, &QAction::triggered, playerActions, &PlayerActions::actDrawCard);
         aDrawCards = new QAction(this);
-        connect(aDrawCards, &QAction::triggered, playerActions, &PlayerActions::actDrawCards);
+        connect(aDrawCards, &QAction::triggered, playerActions, &PlayerActions::actRequestDrawCardsDialog);
         aUndoDraw = new QAction(this);
         connect(aUndoDraw, &QAction::triggered, playerActions, &PlayerActions::actUndoDraw);
         aDrawBottomCard = new QAction(this);
         connect(aDrawBottomCard, &QAction::triggered, playerActions, &PlayerActions::actDrawBottomCard);
         aDrawBottomCards = new QAction(this);
-        connect(aDrawBottomCards, &QAction::triggered, playerActions, &PlayerActions::actDrawBottomCards);
+        connect(aDrawBottomCards, &QAction::triggered, playerActions, &PlayerActions::actRequestDrawBottomCardsDialog);
     }
 }
 
 void LibraryMenu::createShuffleActions()
 {
-    PlayerActions *playerActions = player->getPlayerActions();
+    PlayerActions *playerActions = player->getPlayerLogic()->getPlayerActions();
 
-    if (player->getPlayerInfo()->local || player->getPlayerInfo()->judge) {
+    if (player->getPlayerLogic()->getPlayerInfo()->local || player->getPlayerLogic()->getPlayerInfo()->judge) {
         aShuffle = new QAction(this);
         connect(aShuffle, &QAction::triggered, playerActions, &PlayerActions::actShuffle);
         aShuffleTopCards = new QAction(this);
-        connect(aShuffleTopCards, &QAction::triggered, playerActions, &PlayerActions::actShuffleTop);
+        connect(aShuffleTopCards, &QAction::triggered, playerActions, &PlayerActions::actRequestShuffleTopDialog);
         aShuffleBottomCards = new QAction(this);
-        connect(aShuffleBottomCards, &QAction::triggered, playerActions, &PlayerActions::actShuffleBottom);
+        connect(aShuffleBottomCards, &QAction::triggered, playerActions, &PlayerActions::actRequestShuffleBottomDialog);
     }
 }
 
 void LibraryMenu::createMoveActions()
 {
-    PlayerActions *playerActions = player->getPlayerActions();
+    PlayerActions *playerActions = player->getPlayerLogic()->getPlayerActions();
 
-    if (player->getPlayerInfo()->local || player->getPlayerInfo()->judge) {
+    if (player->getPlayerLogic()->getPlayerInfo()->local || player->getPlayerLogic()->getPlayerInfo()->judge) {
         aMoveTopToPlay = new QAction(this);
         connect(aMoveTopToPlay, &QAction::triggered, playerActions, &PlayerActions::actMoveTopCardToPlay);
         aMoveTopToPlayFaceDown = new QAction(this);
@@ -149,7 +151,8 @@ void LibraryMenu::createMoveActions()
         connect(aMoveTopCardsToExileFaceDown, &QAction::triggered, playerActions,
                 &PlayerActions::actMoveTopCardsToExileFaceDown);
         aMoveTopCardsUntil = new QAction(this);
-        connect(aMoveTopCardsUntil, &QAction::triggered, playerActions, &PlayerActions::actMoveTopCardsUntil);
+        connect(aMoveTopCardsUntil, &QAction::triggered, playerActions,
+                &PlayerActions::actRequestMoveTopCardsUntilDialog);
         aMoveTopCardToBottom = new QAction(this);
         connect(aMoveTopCardToBottom, &QAction::triggered, playerActions, &PlayerActions::actMoveTopCardToBottom);
 
@@ -181,16 +184,16 @@ void LibraryMenu::createMoveActions()
 
 void LibraryMenu::createViewActions()
 {
-    PlayerActions *playerActions = player->getPlayerActions();
+    PlayerActions *playerActions = player->getPlayerLogic()->getPlayerActions();
 
-    if (player->getPlayerInfo()->local || player->getPlayerInfo()->judge) {
+    if (player->getPlayerLogic()->getPlayerInfo()->local || player->getPlayerLogic()->getPlayerInfo()->judge) {
         aViewLibrary = new QAction(this);
         connect(aViewLibrary, &QAction::triggered, playerActions, &PlayerActions::actViewLibrary);
 
         aViewTopCards = new QAction(this);
-        connect(aViewTopCards, &QAction::triggered, playerActions, &PlayerActions::actViewTopCards);
+        connect(aViewTopCards, &QAction::triggered, playerActions, &PlayerActions::actRequestViewTopCardsDialog);
         aViewBottomCards = new QAction(this);
-        connect(aViewBottomCards, &QAction::triggered, playerActions, &PlayerActions::actViewBottomCards);
+        connect(aViewBottomCards, &QAction::triggered, playerActions, &PlayerActions::actRequestViewBottomCardsDialog);
         aAlwaysRevealTopCard = new QAction(this);
         aAlwaysRevealTopCard->setCheckable(true);
         connect(aAlwaysRevealTopCard, &QAction::triggered, playerActions, &PlayerActions::actAlwaysRevealTopCard);
@@ -207,7 +210,7 @@ void LibraryMenu::retranslateUi()
 {
     setTitle(tr("&Library"));
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aViewLibrary->setText(tr("&View library"));
         aViewTopCards->setText(tr("View &top cards of library..."));
         aViewBottomCards->setText(tr("View bottom cards of library..."));
@@ -263,9 +266,9 @@ void LibraryMenu::populateRevealLibraryMenuWithActivePlayers()
 
     mRevealLibrary->addSeparator();
 
-    const auto &players = player->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getPlayerLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player) {
+        if (other == player->getPlayerLogic()) {
             continue;
         }
         QAction *a = mRevealLibrary->addAction(other->getPlayerInfo()->getName());
@@ -278,9 +281,9 @@ void LibraryMenu::populateLendLibraryMenuWithActivePlayers()
 {
     mLendLibrary->clear();
 
-    const auto &players = player->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getPlayerLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player) {
+        if (other == player->getPlayerLogic()) {
             continue;
         }
         QAction *a = mLendLibrary->addAction(other->getPlayerInfo()->getName());
@@ -299,9 +302,9 @@ void LibraryMenu::populateRevealTopCardMenuWithActivePlayers()
 
     mRevealTopCard->addSeparator();
 
-    const auto &players = player->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getPlayerLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player) {
+        if (other == player->getPlayerLogic()) {
             continue;
         }
         QAction *a = mRevealTopCard->addAction(other->getPlayerInfo()->getName());
@@ -313,27 +316,33 @@ void LibraryMenu::populateRevealTopCardMenuWithActivePlayers()
 void LibraryMenu::onRevealLibraryTriggered()
 {
     if (auto *a = qobject_cast<QAction *>(sender())) {
-        player->getPlayerActions()->actRevealLibrary(a->data().toInt());
+        player->getPlayerLogic()->getPlayerActions()->actRevealLibrary(a->data().toInt());
     }
 }
 
 void LibraryMenu::onLendLibraryTriggered()
 {
     if (auto *a = qobject_cast<QAction *>(sender())) {
-        player->getPlayerActions()->actLendLibrary(a->data().toInt());
+        player->getPlayerLogic()->getPlayerActions()->actLendLibrary(a->data().toInt());
     }
 }
 
 void LibraryMenu::onRevealTopCardTriggered()
 {
+    QWidget *parent = nullptr;
+    if (auto *view = player->scene() ? player->scene()->views().value(0) : nullptr) {
+        parent = view->window();
+    }
     if (auto *a = qobject_cast<QAction *>(sender())) {
-        int deckSize = player->getDeckZone()->getCards().size();
-        bool ok;
-        int number = QInputDialog::getInt(player->getGame()->getTab(), tr("Reveal top cards of library"),
+
+        int deckSize = player->getPlayerLogic()->getDeckZone()->getCards().size();
+        bool ok = true;
+        int number = QInputDialog::getInt(parent, tr("Reveal top cards of library"),
                                           tr("Number of cards: (max. %1)").arg(deckSize), defaultNumberTopCards, 1,
                                           deckSize, 1, &ok);
+
         if (ok) {
-            player->getPlayerActions()->actRevealTopCards(a->data().toInt(), number);
+            player->getPlayerLogic()->getPlayerActions()->actRevealTopCards(a->data().toInt(), number);
             defaultNumberTopCards = number;
         }
     }

--- a/cockatrice/src/game/player/menu/library_menu.cpp
+++ b/cockatrice/src/game/player/menu/library_menu.cpp
@@ -76,9 +76,8 @@ LibraryMenu::LibraryMenu(PlayerGraphicsItem *_player, QWidget *parent) : TearOff
     bottomLibraryMenu->addSeparator();
     bottomLibraryMenu->addAction(aShuffleBottomCards);
 
-    connect(player->getPlayerLogic(), &PlayerLogic::resetTopCardMenuActions, this,
-            &LibraryMenu::resetTopCardMenuActions);
-    connect(player->getPlayerLogic(), &PlayerLogic::deckChanged, this, &LibraryMenu::enableOpenInDeckEditorAction);
+    connect(player->getLogic(), &PlayerLogic::resetTopCardMenuActions, this, &LibraryMenu::resetTopCardMenuActions);
+    connect(player->getLogic(), &PlayerLogic::deckChanged, this, &LibraryMenu::enableOpenInDeckEditorAction);
 
     retranslateUi();
 }
@@ -96,9 +95,9 @@ void LibraryMenu::resetTopCardMenuActions()
 
 void LibraryMenu::createDrawActions()
 {
-    PlayerActions *playerActions = player->getPlayerLogic()->getPlayerActions();
+    PlayerActions *playerActions = player->getLogic()->getPlayerActions();
 
-    if (player->getPlayerLogic()->getPlayerInfo()->local || player->getPlayerLogic()->getPlayerInfo()->judge) {
+    if (player->getLogic()->getPlayerInfo()->local || player->getLogic()->getPlayerInfo()->judge) {
         aDrawCard = new QAction(this);
         connect(aDrawCard, &QAction::triggered, playerActions, &PlayerActions::actDrawCard);
         aDrawCards = new QAction(this);
@@ -114,9 +113,9 @@ void LibraryMenu::createDrawActions()
 
 void LibraryMenu::createShuffleActions()
 {
-    PlayerActions *playerActions = player->getPlayerLogic()->getPlayerActions();
+    PlayerActions *playerActions = player->getLogic()->getPlayerActions();
 
-    if (player->getPlayerLogic()->getPlayerInfo()->local || player->getPlayerLogic()->getPlayerInfo()->judge) {
+    if (player->getLogic()->getPlayerInfo()->local || player->getLogic()->getPlayerInfo()->judge) {
         aShuffle = new QAction(this);
         connect(aShuffle, &QAction::triggered, playerActions, &PlayerActions::actShuffle);
         aShuffleTopCards = new QAction(this);
@@ -128,9 +127,9 @@ void LibraryMenu::createShuffleActions()
 
 void LibraryMenu::createMoveActions()
 {
-    PlayerActions *playerActions = player->getPlayerLogic()->getPlayerActions();
+    PlayerActions *playerActions = player->getLogic()->getPlayerActions();
 
-    if (player->getPlayerLogic()->getPlayerInfo()->local || player->getPlayerLogic()->getPlayerInfo()->judge) {
+    if (player->getLogic()->getPlayerInfo()->local || player->getLogic()->getPlayerInfo()->judge) {
         aMoveTopToPlay = new QAction(this);
         connect(aMoveTopToPlay, &QAction::triggered, playerActions, &PlayerActions::actMoveTopCardToPlay);
         aMoveTopToPlayFaceDown = new QAction(this);
@@ -184,9 +183,9 @@ void LibraryMenu::createMoveActions()
 
 void LibraryMenu::createViewActions()
 {
-    PlayerActions *playerActions = player->getPlayerLogic()->getPlayerActions();
+    PlayerActions *playerActions = player->getLogic()->getPlayerActions();
 
-    if (player->getPlayerLogic()->getPlayerInfo()->local || player->getPlayerLogic()->getPlayerInfo()->judge) {
+    if (player->getLogic()->getPlayerInfo()->local || player->getLogic()->getPlayerInfo()->judge) {
         aViewLibrary = new QAction(this);
         connect(aViewLibrary, &QAction::triggered, playerActions, &PlayerActions::actViewLibrary);
 
@@ -210,7 +209,7 @@ void LibraryMenu::retranslateUi()
 {
     setTitle(tr("&Library"));
 
-    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aViewLibrary->setText(tr("&View library"));
         aViewTopCards->setText(tr("View &top cards of library..."));
         aViewBottomCards->setText(tr("View bottom cards of library..."));
@@ -266,9 +265,9 @@ void LibraryMenu::populateRevealLibraryMenuWithActivePlayers()
 
     mRevealLibrary->addSeparator();
 
-    const auto &players = player->getPlayerLogic()->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player->getPlayerLogic()) {
+        if (other == player->getLogic()) {
             continue;
         }
         QAction *a = mRevealLibrary->addAction(other->getPlayerInfo()->getName());
@@ -281,9 +280,9 @@ void LibraryMenu::populateLendLibraryMenuWithActivePlayers()
 {
     mLendLibrary->clear();
 
-    const auto &players = player->getPlayerLogic()->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player->getPlayerLogic()) {
+        if (other == player->getLogic()) {
             continue;
         }
         QAction *a = mLendLibrary->addAction(other->getPlayerInfo()->getName());
@@ -302,9 +301,9 @@ void LibraryMenu::populateRevealTopCardMenuWithActivePlayers()
 
     mRevealTopCard->addSeparator();
 
-    const auto &players = player->getPlayerLogic()->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player->getPlayerLogic()) {
+        if (other == player->getLogic()) {
             continue;
         }
         QAction *a = mRevealTopCard->addAction(other->getPlayerInfo()->getName());
@@ -316,14 +315,14 @@ void LibraryMenu::populateRevealTopCardMenuWithActivePlayers()
 void LibraryMenu::onRevealLibraryTriggered()
 {
     if (auto *a = qobject_cast<QAction *>(sender())) {
-        player->getPlayerLogic()->getPlayerActions()->actRevealLibrary(a->data().toInt());
+        player->getLogic()->getPlayerActions()->actRevealLibrary(a->data().toInt());
     }
 }
 
 void LibraryMenu::onLendLibraryTriggered()
 {
     if (auto *a = qobject_cast<QAction *>(sender())) {
-        player->getPlayerLogic()->getPlayerActions()->actLendLibrary(a->data().toInt());
+        player->getLogic()->getPlayerActions()->actLendLibrary(a->data().toInt());
     }
 }
 
@@ -335,14 +334,14 @@ void LibraryMenu::onRevealTopCardTriggered()
     }
     if (auto *a = qobject_cast<QAction *>(sender())) {
 
-        int deckSize = player->getPlayerLogic()->getDeckZone()->getCards().size();
+        int deckSize = player->getLogic()->getDeckZone()->getCards().size();
         bool ok = true;
         int number = QInputDialog::getInt(parent, tr("Reveal top cards of library"),
                                           tr("Number of cards: (max. %1)").arg(deckSize), defaultNumberTopCards, 1,
                                           deckSize, 1, &ok);
 
         if (ok) {
-            player->getPlayerLogic()->getPlayerActions()->actRevealTopCards(a->data().toInt(), number);
+            player->getLogic()->getPlayerActions()->actRevealTopCards(a->data().toInt(), number);
             defaultNumberTopCards = number;
         }
     }

--- a/cockatrice/src/game/player/menu/library_menu.h
+++ b/cockatrice/src/game/player/menu/library_menu.h
@@ -13,6 +13,7 @@
 #include <QAction>
 #include <QMenu>
 
+class PlayerGraphicsItem;
 class PlayerLogic;
 class PlayerActions;
 
@@ -24,7 +25,7 @@ public slots:
     void resetTopCardMenuActions();
 
 public:
-    LibraryMenu(PlayerLogic *player, QWidget *parent = nullptr);
+    LibraryMenu(PlayerGraphicsItem *player, QWidget *parent = nullptr);
     void createDrawActions();
     void createShuffleActions();
     void createMoveActions();
@@ -111,7 +112,7 @@ public:
     int defaultNumberTopCards = 1;
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
 };
 
 #endif // COCKATRICE_LIBRARY_MENU_H

--- a/cockatrice/src/game/player/menu/move_menu.cpp
+++ b/cockatrice/src/game/player/menu/move_menu.cpp
@@ -4,7 +4,7 @@
 #include "../player_actions.h"
 #include "../player_logic.h"
 
-MoveMenu::MoveMenu(PlayerLogic *player) : QMenu(tr("Move to"))
+MoveMenu::MoveMenu(PlayerGraphicsItem *player) : QMenu(tr("Move to"))
 {
     aMoveToTopLibrary = new QAction(this);
     aMoveToTopLibrary->setData(cmMoveToTopLibrary);
@@ -20,14 +20,22 @@ MoveMenu::MoveMenu(PlayerLogic *player) : QMenu(tr("Move to"))
     aMoveToExile = new QAction(this);
     aMoveToExile->setData(cmMoveToExile);
 
-    connect(aMoveToTopLibrary, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
-    connect(aMoveToBottomLibrary, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
-    connect(aMoveToXfromTopOfLibrary, &QAction::triggered, player->getPlayerActions(),
-            &PlayerActions::actMoveCardXCardsFromTop);
-    connect(aMoveToTable, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
-    connect(aMoveToHand, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
-    connect(aMoveToGraveyard, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
-    connect(aMoveToExile, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
+    auto *actions = player->getPlayerLogic()->getPlayerActions();
+
+    auto invoke = [player](CardMenuActionType type) {
+        return [type, player]() {
+            player->getPlayerLogic()->getPlayerActions()->cardMenuAction(player->getGameScene()->selectedCards(), type);
+        };
+    };
+
+    connect(aMoveToTopLibrary, &QAction::triggered, actions, invoke(cmMoveToTopLibrary));
+    connect(aMoveToBottomLibrary, &QAction::triggered, actions, invoke(cmMoveToBottomLibrary));
+    connect(aMoveToXfromTopOfLibrary, &QAction::triggered, actions,
+            &PlayerActions::actRequestMoveCardXCardsFromTopDialog);
+    connect(aMoveToTable, &QAction::triggered, actions, invoke(cmMoveToTable));
+    connect(aMoveToHand, &QAction::triggered, actions, invoke(cmMoveToHand));
+    connect(aMoveToGraveyard, &QAction::triggered, actions, invoke(cmMoveToGraveyard));
+    connect(aMoveToExile, &QAction::triggered, actions, invoke(cmMoveToExile));
 
     addAction(aMoveToTopLibrary);
     addAction(aMoveToXfromTopOfLibrary);

--- a/cockatrice/src/game/player/menu/move_menu.cpp
+++ b/cockatrice/src/game/player/menu/move_menu.cpp
@@ -20,11 +20,11 @@ MoveMenu::MoveMenu(PlayerGraphicsItem *player) : QMenu(tr("Move to"))
     aMoveToExile = new QAction(this);
     aMoveToExile->setData(cmMoveToExile);
 
-    auto *actions = player->getPlayerLogic()->getPlayerActions();
+    auto *actions = player->getLogic()->getPlayerActions();
 
     auto invoke = [player](CardMenuActionType type) {
         return [type, player]() {
-            player->getPlayerLogic()->getPlayerActions()->cardMenuAction(player->getGameScene()->selectedCards(), type);
+            player->getLogic()->getPlayerActions()->cardMenuAction(player->getGameScene()->selectedCards(), type);
         };
     };
 

--- a/cockatrice/src/game/player/menu/move_menu.h
+++ b/cockatrice/src/game/player/menu/move_menu.h
@@ -8,13 +8,13 @@
 #define COCKATRICE_MOVE_MENU_H
 #include <QMenu>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class MoveMenu : public QMenu
 {
     Q_OBJECT
 
 public:
-    explicit MoveMenu(PlayerLogic *player);
+    explicit MoveMenu(PlayerGraphicsItem *player);
     void setShortcutsActive();
     void retranslateUi();
 

--- a/cockatrice/src/game/player/menu/player_menu.cpp
+++ b/cockatrice/src/game/player/menu/player_menu.cpp
@@ -10,12 +10,15 @@
 
 #include <libcockatrice/protocol/pb/command_reveal_cards.pb.h>
 
-PlayerMenu::PlayerMenu(PlayerLogic *_player) : QObject(_player), player(_player)
+PlayerMenu::PlayerMenu(PlayerGraphicsItem *_player) : QObject(_player), player(_player)
 {
+    connect(player->getPlayerLogic(), &PlayerLogic::requestCardMenuUpdate, this, &PlayerMenu::updateCardMenu);
+    connect(this, &PlayerMenu::cardInfoRequested, player, &PlayerGraphicsItem::cardInfoRequested);
+
     playerMenu = new TearOffMenu();
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
-        handMenu = addManagedMenu<HandMenu>(player, player->getPlayerActions(), playerMenu);
+    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
+        handMenu = addManagedMenu<HandMenu>(player, playerMenu);
         libraryMenu = addManagedMenu<LibraryMenu>(player, playerMenu);
     } else {
         handMenu = nullptr;
@@ -25,7 +28,7 @@ PlayerMenu::PlayerMenu(PlayerLogic *_player) : QObject(_player), player(_player)
     graveMenu = addManagedMenu<GraveyardMenu>(player, playerMenu);
     rfgMenu = addManagedMenu<RfgMenu>(player, playerMenu);
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
         sideboardMenu = addManagedMenu<SideboardMenu>(player, playerMenu);
         customZonesMenu = addManagedMenu<CustomZoneMenu>(player);
         playerMenu->addSeparator();
@@ -40,7 +43,7 @@ PlayerMenu::PlayerMenu(PlayerLogic *_player) : QObject(_player), player(_player)
         utilityMenu = nullptr;
     }
 
-    if (player->getPlayerInfo()->getLocal()) {
+    if (player->getPlayerLogic()->getPlayerInfo()->getLocal()) {
         sayMenu = addManagedMenu<SayMenu>(player);
     } else {
         sayMenu = nullptr;
@@ -55,13 +58,13 @@ PlayerMenu::PlayerMenu(PlayerLogic *_player) : QObject(_player), player(_player)
 
 void PlayerMenu::setMenusForGraphicItems()
 {
-    player->getGraphicsItem()->getTableZoneGraphicsItem()->setMenu(playerMenu);
-    player->getGraphicsItem()->getGraveyardZoneGraphicsItem()->setMenu(graveMenu, graveMenu->aViewGraveyard);
-    player->getGraphicsItem()->getRfgZoneGraphicsItem()->setMenu(rfgMenu, rfgMenu->aViewRfg);
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
-        player->getGraphicsItem()->getHandZoneGraphicsItem()->setMenu(handMenu);
-        player->getGraphicsItem()->getDeckZoneGraphicsItem()->setMenu(libraryMenu, libraryMenu->aDrawCard);
-        player->getGraphicsItem()->getSideboardZoneGraphicsItem()->setMenu(sideboardMenu);
+    player->getTableZoneGraphicsItem()->setMenu(playerMenu);
+    player->getGraveyardZoneGraphicsItem()->setMenu(graveMenu, graveMenu->aViewGraveyard);
+    player->getRfgZoneGraphicsItem()->setMenu(rfgMenu, rfgMenu->aViewRfg);
+    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
+        player->getHandZoneGraphicsItem()->setMenu(handMenu);
+        player->getDeckZoneGraphicsItem()->setMenu(libraryMenu, libraryMenu->aDrawCard);
+        player->getSideboardZoneGraphicsItem()->setMenu(sideboardMenu);
     }
 }
 
@@ -74,12 +77,14 @@ QMenu *PlayerMenu::updateCardMenu(const CardItem *card)
 
     // If is spectator (as spectators don't need card menus), return
     // only update the menu if the card is actually selected
-    if ((player->getGame()->getPlayerManager()->isSpectator() && !player->getGame()->getPlayerManager()->isJudge()) ||
-        player->getGame()->getActiveCard() != card) {
+    if ((player->getPlayerLogic()->getGame()->getPlayerManager()->isSpectator() &&
+         !player->getPlayerLogic()->getGame()->getPlayerManager()->isJudge()) ||
+        player->getPlayerLogic()->getGame()->getActiveCard() != card) {
         return nullptr;
     }
 
-    QMenu *menu = new CardMenu(player, card, shortcutsActive);
+    CardMenu *menu = new CardMenu(player, card, shortcutsActive);
+    connect(menu, &CardMenu::cardInfoRequested, this, &PlayerMenu::cardInfoRequested);
     emit cardMenuUpdated(menu);
 
     return menu;
@@ -87,7 +92,7 @@ QMenu *PlayerMenu::updateCardMenu(const CardItem *card)
 
 void PlayerMenu::retranslateUi()
 {
-    playerMenu->setTitle(tr("Player \"%1\"").arg(player->getPlayerInfo()->getName()));
+    playerMenu->setTitle(tr("Player \"%1\"").arg(player->getPlayerLogic()->getPlayerInfo()->getName()));
 
     for (auto *component : managedComponents) {
         component->retranslateUi();
@@ -104,7 +109,8 @@ void PlayerMenu::refreshShortcuts()
 {
     if (shortcutsActive) {
         // Judges get access to every player's menus but only want shortcuts to be set for their own.
-        if (player->getPlayerInfo()->getLocalOrJudge() && !player->getPlayerInfo()->getLocal()) {
+        if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge() &&
+            !player->getPlayerLogic()->getPlayerInfo()->getLocal()) {
             setShortcutsInactive();
         } else {
             setShortcutsActive();

--- a/cockatrice/src/game/player/menu/player_menu.cpp
+++ b/cockatrice/src/game/player/menu/player_menu.cpp
@@ -12,12 +12,12 @@
 
 PlayerMenu::PlayerMenu(PlayerGraphicsItem *_player) : QObject(_player), player(_player)
 {
-    connect(player->getPlayerLogic(), &PlayerLogic::requestCardMenuUpdate, this, &PlayerMenu::updateCardMenu);
+    connect(player->getLogic(), &PlayerLogic::requestCardMenuUpdate, this, &PlayerMenu::updateCardMenu);
     connect(this, &PlayerMenu::cardInfoRequested, player, &PlayerGraphicsItem::cardInfoRequested);
 
     playerMenu = new TearOffMenu();
 
-    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         handMenu = addManagedMenu<HandMenu>(player, playerMenu);
         libraryMenu = addManagedMenu<LibraryMenu>(player, playerMenu);
     } else {
@@ -28,7 +28,7 @@ PlayerMenu::PlayerMenu(PlayerGraphicsItem *_player) : QObject(_player), player(_
     graveMenu = addManagedMenu<GraveyardMenu>(player, playerMenu);
     rfgMenu = addManagedMenu<RfgMenu>(player, playerMenu);
 
-    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         sideboardMenu = addManagedMenu<SideboardMenu>(player, playerMenu);
         customZonesMenu = addManagedMenu<CustomZoneMenu>(player);
         playerMenu->addSeparator();
@@ -43,7 +43,7 @@ PlayerMenu::PlayerMenu(PlayerGraphicsItem *_player) : QObject(_player), player(_
         utilityMenu = nullptr;
     }
 
-    if (player->getPlayerLogic()->getPlayerInfo()->getLocal()) {
+    if (player->getLogic()->getPlayerInfo()->getLocal()) {
         sayMenu = addManagedMenu<SayMenu>(player);
     } else {
         sayMenu = nullptr;
@@ -61,7 +61,7 @@ void PlayerMenu::setMenusForGraphicItems()
     player->getTableZoneGraphicsItem()->setMenu(playerMenu);
     player->getGraveyardZoneGraphicsItem()->setMenu(graveMenu, graveMenu->aViewGraveyard);
     player->getRfgZoneGraphicsItem()->setMenu(rfgMenu, rfgMenu->aViewRfg);
-    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         player->getHandZoneGraphicsItem()->setMenu(handMenu);
         player->getDeckZoneGraphicsItem()->setMenu(libraryMenu, libraryMenu->aDrawCard);
         player->getSideboardZoneGraphicsItem()->setMenu(sideboardMenu);
@@ -77,9 +77,9 @@ QMenu *PlayerMenu::updateCardMenu(const CardItem *card)
 
     // If is spectator (as spectators don't need card menus), return
     // only update the menu if the card is actually selected
-    if ((player->getPlayerLogic()->getGame()->getPlayerManager()->isSpectator() &&
-         !player->getPlayerLogic()->getGame()->getPlayerManager()->isJudge()) ||
-        player->getPlayerLogic()->getGame()->getActiveCard() != card) {
+    if ((player->getLogic()->getGame()->getPlayerManager()->isSpectator() &&
+         !player->getLogic()->getGame()->getPlayerManager()->isJudge()) ||
+        player->getLogic()->getGame()->getActiveCard() != card) {
         return nullptr;
     }
 
@@ -92,7 +92,7 @@ QMenu *PlayerMenu::updateCardMenu(const CardItem *card)
 
 void PlayerMenu::retranslateUi()
 {
-    playerMenu->setTitle(tr("Player \"%1\"").arg(player->getPlayerLogic()->getPlayerInfo()->getName()));
+    playerMenu->setTitle(tr("Player \"%1\"").arg(player->getLogic()->getPlayerInfo()->getName()));
 
     for (auto *component : managedComponents) {
         component->retranslateUi();
@@ -109,8 +109,8 @@ void PlayerMenu::refreshShortcuts()
 {
     if (shortcutsActive) {
         // Judges get access to every player's menus but only want shortcuts to be set for their own.
-        if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge() &&
-            !player->getPlayerLogic()->getPlayerInfo()->getLocal()) {
+        if (player->getLogic()->getPlayerInfo()->getLocalOrJudge() &&
+            !player->getLogic()->getPlayerInfo()->getLocal()) {
             setShortcutsInactive();
         } else {
             setShortcutsActive();

--- a/cockatrice/src/game/player/menu/player_menu.h
+++ b/cockatrice/src/game/player/menu/player_menu.h
@@ -8,7 +8,6 @@
 #define COCKATRICE_PLAYER_MENU_H
 
 #include "../../../interface/widgets/menus/tearoff_menu.h"
-#include "../player_logic.h"
 #include "custom_zone_menu.h"
 #include "grave_menu.h"
 #include "hand_menu.h"
@@ -23,28 +22,30 @@
 #include <QObject>
 
 class CardItem;
+class CardMenu;
+class PlayerGraphicsItem;
 class PlayerMenu : public QObject
 {
     Q_OBJECT
 
 signals:
-    void cardMenuUpdated(QMenu *cardMenu);
+    void cardMenuUpdated(CardMenu *cardMenu);
+    void cardInfoRequested(const CardRef &cardRef);
     void shortcutsActivated();
     void shortcutsDeactivated();
     void retranslateRequested();
 
 public slots:
     void setMenusForGraphicItems();
+    QMenu *updateCardMenu(const CardItem *card);
 
 private slots:
     void refreshShortcuts();
 
 public:
-    explicit PlayerMenu(PlayerLogic *player);
+    explicit PlayerMenu(PlayerGraphicsItem *player);
     /** @brief Retranslate all user-visible strings. Called on language change. */
     void retranslateUi();
-
-    QMenu *updateCardMenu(const CardItem *card);
 
     [[nodiscard]] QMenu *getPlayerMenu() const
     {
@@ -77,7 +78,7 @@ public:
     void setShortcutsInactive();
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
     TearOffMenu *playerMenu;
     QMenu *countersMenu;
     HandMenu *handMenu;

--- a/cockatrice/src/game/player/menu/pt_menu.cpp
+++ b/cockatrice/src/game/player/menu/pt_menu.cpp
@@ -5,7 +5,7 @@
 
 PtMenu::PtMenu(PlayerGraphicsItem *player) : QMenu(tr("Power / toughness"))
 {
-    PlayerActions *playerActions = player->getPlayerLogic()->getPlayerActions();
+    PlayerActions *playerActions = player->getLogic()->getPlayerActions();
 
     aIncP = new QAction(this);
     connect(aIncP, &QAction::triggered, playerActions,

--- a/cockatrice/src/game/player/menu/pt_menu.cpp
+++ b/cockatrice/src/game/player/menu/pt_menu.cpp
@@ -3,30 +3,40 @@
 #include "../player_actions.h"
 #include "../player_logic.h"
 
-PtMenu::PtMenu(PlayerLogic *player) : QMenu(tr("Power / toughness"))
+PtMenu::PtMenu(PlayerGraphicsItem *player) : QMenu(tr("Power / toughness"))
 {
-    PlayerActions *playerActions = player->getPlayerActions();
+    PlayerActions *playerActions = player->getPlayerLogic()->getPlayerActions();
 
     aIncP = new QAction(this);
-    connect(aIncP, &QAction::triggered, playerActions, &PlayerActions::actIncP);
+    connect(aIncP, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actIncP(player->getGameScene()->selectedCards()); });
     aDecP = new QAction(this);
-    connect(aDecP, &QAction::triggered, playerActions, &PlayerActions::actDecP);
+    connect(aDecP, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actDecP(player->getGameScene()->selectedCards()); });
     aIncT = new QAction(this);
-    connect(aIncT, &QAction::triggered, playerActions, &PlayerActions::actIncT);
+    connect(aIncT, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actIncT(player->getGameScene()->selectedCards()); });
     aDecT = new QAction(this);
-    connect(aDecT, &QAction::triggered, playerActions, &PlayerActions::actDecT);
+    connect(aDecT, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actDecT(player->getGameScene()->selectedCards()); });
     aIncPT = new QAction(this);
-    connect(aIncPT, &QAction::triggered, playerActions, [playerActions] { playerActions->actIncPT(); });
+    connect(aIncPT, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actIncPT(player->getGameScene()->selectedCards()); });
     aDecPT = new QAction(this);
-    connect(aDecPT, &QAction::triggered, playerActions, &PlayerActions::actDecPT);
+    connect(aDecPT, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actDecPT(player->getGameScene()->selectedCards()); });
     aFlowP = new QAction(this);
-    connect(aFlowP, &QAction::triggered, playerActions, &PlayerActions::actFlowP);
+    connect(aFlowP, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actFlowP(player->getGameScene()->selectedCards()); });
     aFlowT = new QAction(this);
-    connect(aFlowT, &QAction::triggered, playerActions, &PlayerActions::actFlowT);
+    connect(aFlowT, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actFlowT(player->getGameScene()->selectedCards()); });
     aSetPT = new QAction(this);
-    connect(aSetPT, &QAction::triggered, playerActions, &PlayerActions::actSetPT);
+    connect(aSetPT, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actRequestSetPTDialog(player->getGameScene()->selectedCards()); });
     aResetPT = new QAction(this);
-    connect(aResetPT, &QAction::triggered, playerActions, &PlayerActions::actResetPT);
+    connect(aResetPT, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actResetPT(player->getGameScene()->selectedCards()); });
 
     addAction(aIncP);
     addAction(aDecP);

--- a/cockatrice/src/game/player/menu/pt_menu.h
+++ b/cockatrice/src/game/player/menu/pt_menu.h
@@ -8,14 +8,14 @@
 #define COCKATRICE_PT_MENU_H
 #include <QMenu>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class PtMenu : public QMenu
 {
 
     Q_OBJECT
 
 public:
-    explicit PtMenu(PlayerLogic *player);
+    explicit PtMenu(PlayerGraphicsItem *player);
     void retranslateUi();
     void setShortcutsActive();
 

--- a/cockatrice/src/game/player/menu/rfg_menu.cpp
+++ b/cockatrice/src/game/player/menu/rfg_menu.cpp
@@ -5,14 +5,14 @@
 
 #include <libcockatrice/utility/zone_names.h>
 
-RfgMenu::RfgMenu(PlayerLogic *_player, QWidget *parent) : TearOffMenu(parent), player(_player)
+RfgMenu::RfgMenu(PlayerGraphicsItem *_player, QWidget *parent) : TearOffMenu(parent), player(_player)
 {
     createMoveActions();
     createViewActions();
 
     addAction(aViewRfg);
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
         addSeparator();
         moveRfgMenu = addTearOffMenu(QString());
         moveRfgMenu->addAction(aMoveRfgToTopLibrary);
@@ -28,8 +28,8 @@ RfgMenu::RfgMenu(PlayerLogic *_player, QWidget *parent) : TearOffMenu(parent), p
 
 void RfgMenu::createMoveActions()
 {
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
-        auto rfg = player->getRfgZone();
+    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
+        auto rfg = player->getPlayerLogic()->getRfgZone();
 
         aMoveRfgToTopLibrary = new QAction(this);
         aMoveRfgToTopLibrary->setData(QList<QVariant>() << ZoneNames::DECK << 0);
@@ -49,7 +49,7 @@ void RfgMenu::createMoveActions()
 
 void RfgMenu::createViewActions()
 {
-    PlayerActions *playerActions = player->getPlayerActions();
+    PlayerActions *playerActions = player->getPlayerLogic()->getPlayerActions();
 
     aViewRfg = new QAction(this);
     connect(aViewRfg, &QAction::triggered, playerActions, &PlayerActions::actViewRfg);
@@ -61,7 +61,7 @@ void RfgMenu::retranslateUi()
 
     aViewRfg->setText(tr("&View exile"));
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
         moveRfgMenu->setTitle(tr("&Move exile to..."));
         aMoveRfgToTopLibrary->setText(tr("&Top of library"));
         aMoveRfgToBottomLibrary->setText(tr("&Bottom of library"));

--- a/cockatrice/src/game/player/menu/rfg_menu.cpp
+++ b/cockatrice/src/game/player/menu/rfg_menu.cpp
@@ -12,7 +12,7 @@ RfgMenu::RfgMenu(PlayerGraphicsItem *_player, QWidget *parent) : TearOffMenu(par
 
     addAction(aViewRfg);
 
-    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         addSeparator();
         moveRfgMenu = addTearOffMenu(QString());
         moveRfgMenu->addAction(aMoveRfgToTopLibrary);
@@ -28,8 +28,8 @@ RfgMenu::RfgMenu(PlayerGraphicsItem *_player, QWidget *parent) : TearOffMenu(par
 
 void RfgMenu::createMoveActions()
 {
-    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
-        auto rfg = player->getPlayerLogic()->getRfgZone();
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
+        auto rfg = player->getLogic()->getRfgZone();
 
         aMoveRfgToTopLibrary = new QAction(this);
         aMoveRfgToTopLibrary->setData(QList<QVariant>() << ZoneNames::DECK << 0);
@@ -49,7 +49,7 @@ void RfgMenu::createMoveActions()
 
 void RfgMenu::createViewActions()
 {
-    PlayerActions *playerActions = player->getPlayerLogic()->getPlayerActions();
+    PlayerActions *playerActions = player->getLogic()->getPlayerActions();
 
     aViewRfg = new QAction(this);
     connect(aViewRfg, &QAction::triggered, playerActions, &PlayerActions::actViewRfg);
@@ -61,7 +61,7 @@ void RfgMenu::retranslateUi()
 
     aViewRfg->setText(tr("&View exile"));
 
-    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         moveRfgMenu->setTitle(tr("&Move exile to..."));
         aMoveRfgToTopLibrary->setText(tr("&Top of library"));
         aMoveRfgToBottomLibrary->setText(tr("&Bottom of library"));

--- a/cockatrice/src/game/player/menu/rfg_menu.h
+++ b/cockatrice/src/game/player/menu/rfg_menu.h
@@ -13,12 +13,12 @@
 #include <QAction>
 #include <QMenu>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class RfgMenu : public TearOffMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 public:
-    explicit RfgMenu(PlayerLogic *player, QWidget *parent = nullptr);
+    explicit RfgMenu(PlayerGraphicsItem *player, QWidget *parent = nullptr);
     void createMoveActions();
     void createViewActions();
     void retranslateUi() override;
@@ -38,7 +38,7 @@ public:
     QAction *aMoveRfgToGrave = nullptr;
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
 };
 
 #endif // COCKATRICE_RFG_MENU_H

--- a/cockatrice/src/game/player/menu/say_menu.cpp
+++ b/cockatrice/src/game/player/menu/say_menu.cpp
@@ -44,8 +44,7 @@ void SayMenu::initSayMenu()
 
     for (int i = 0; i < count; ++i) {
         auto *newAction = new QAction(SettingsCache::instance().messages().getMessageAt(i), this);
-        connect(newAction, &QAction::triggered, player->getPlayerLogic()->getPlayerActions(),
-                &PlayerActions::actSayMessage);
+        connect(newAction, &QAction::triggered, player->getLogic()->getPlayerActions(), &PlayerActions::actSayMessage);
         addAction(newAction);
     }
 

--- a/cockatrice/src/game/player/menu/say_menu.cpp
+++ b/cockatrice/src/game/player/menu/say_menu.cpp
@@ -4,7 +4,7 @@
 #include "../player_actions.h"
 #include "../player_logic.h"
 
-SayMenu::SayMenu(PlayerLogic *_player) : player(_player)
+SayMenu::SayMenu(PlayerGraphicsItem *_player) : player(_player)
 {
     connect(&SettingsCache::instance().messages(), &MessageSettings::messageMacrosChanged, this, &SayMenu::initSayMenu);
     initSayMenu();
@@ -44,7 +44,8 @@ void SayMenu::initSayMenu()
 
     for (int i = 0; i < count; ++i) {
         auto *newAction = new QAction(SettingsCache::instance().messages().getMessageAt(i), this);
-        connect(newAction, &QAction::triggered, player->getPlayerActions(), &PlayerActions::actSayMessage);
+        connect(newAction, &QAction::triggered, player->getPlayerLogic()->getPlayerActions(),
+                &PlayerActions::actSayMessage);
         addAction(newAction);
     }
 

--- a/cockatrice/src/game/player/menu/say_menu.h
+++ b/cockatrice/src/game/player/menu/say_menu.h
@@ -11,12 +11,12 @@
 
 #include <QMenu>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class SayMenu : public QMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 public:
-    explicit SayMenu(PlayerLogic *player);
+    explicit SayMenu(PlayerGraphicsItem *player);
 
     void retranslateUi() override;
     void setShortcutsActive() override;
@@ -26,7 +26,7 @@ private slots:
     void initSayMenu();
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
     bool shortcutsActive = false;
 };
 

--- a/cockatrice/src/game/player/menu/sideboard_menu.cpp
+++ b/cockatrice/src/game/player/menu/sideboard_menu.cpp
@@ -6,10 +6,10 @@
 SideboardMenu::SideboardMenu(PlayerGraphicsItem *player, QMenu *playerMenu) : QMenu(playerMenu)
 {
     aViewSideboard = new QAction(this);
-    connect(aViewSideboard, &QAction::triggered, player->getPlayerLogic()->getPlayerActions(),
+    connect(aViewSideboard, &QAction::triggered, player->getLogic()->getPlayerActions(),
             &PlayerActions::actViewSideboard);
 
-    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         addAction(aViewSideboard);
     }
 

--- a/cockatrice/src/game/player/menu/sideboard_menu.cpp
+++ b/cockatrice/src/game/player/menu/sideboard_menu.cpp
@@ -3,12 +3,13 @@
 #include "../player_actions.h"
 #include "../player_logic.h"
 
-SideboardMenu::SideboardMenu(PlayerLogic *player, QMenu *playerMenu) : QMenu(playerMenu)
+SideboardMenu::SideboardMenu(PlayerGraphicsItem *player, QMenu *playerMenu) : QMenu(playerMenu)
 {
     aViewSideboard = new QAction(this);
-    connect(aViewSideboard, &QAction::triggered, player->getPlayerActions(), &PlayerActions::actViewSideboard);
+    connect(aViewSideboard, &QAction::triggered, player->getPlayerLogic()->getPlayerActions(),
+            &PlayerActions::actViewSideboard);
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
         addAction(aViewSideboard);
     }
 

--- a/cockatrice/src/game/player/menu/sideboard_menu.h
+++ b/cockatrice/src/game/player/menu/sideboard_menu.h
@@ -11,19 +11,19 @@
 
 #include <QMenu>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class SideboardMenu : public QMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 
 public:
-    explicit SideboardMenu(PlayerLogic *player, QMenu *playerMenu);
+    explicit SideboardMenu(PlayerGraphicsItem *player, QMenu *playerMenu);
     void retranslateUi() override;
     void setShortcutsActive() override;
     void setShortcutsInactive() override;
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
 
     QAction *aViewSideboard;
 };

--- a/cockatrice/src/game/player/menu/utility_menu.cpp
+++ b/cockatrice/src/game/player/menu/utility_menu.cpp
@@ -10,12 +10,12 @@
 
 UtilityMenu::UtilityMenu(PlayerGraphicsItem *_player, QMenu *playerMenu) : QMenu(playerMenu), player(_player)
 {
-    PlayerActions *playerActions = player->getPlayerLogic()->getPlayerActions();
+    PlayerActions *playerActions = player->getLogic()->getPlayerActions();
     connect(playerActions, &PlayerActions::requestEnableAndSetCreateAnotherTokenAction, this,
             &UtilityMenu::setAndEnableCreateAnotherTokenAction);
     connect(playerActions, &PlayerActions::requestSetLastToken, this, &UtilityMenu::setLastToken);
 
-    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aUntapAll = new QAction(this);
         connect(aUntapAll, &QAction::triggered, playerActions, &PlayerActions::actUntapAll);
 
@@ -27,7 +27,7 @@ UtilityMenu::UtilityMenu(PlayerGraphicsItem *_player, QMenu *playerMenu) : QMenu
 
         aCreateToken = new QAction(this);
         connect(aCreateToken, &QAction::triggered, playerActions, [this]() {
-            player->getPlayerLogic()->getPlayerActions()->actRequestCreateTokenDialog(getPredefinedTokens());
+            player->getLogic()->getPlayerActions()->actRequestCreateTokenDialog(getPredefinedTokens());
         });
 
         aCreateAnotherToken = new QAction(this);
@@ -36,13 +36,13 @@ UtilityMenu::UtilityMenu(PlayerGraphicsItem *_player, QMenu *playerMenu) : QMenu
 
         aIncrementAllCardCounters = new QAction(this);
         connect(aIncrementAllCardCounters, &QAction::triggered, playerActions, [this]() {
-            player->getPlayerLogic()->getPlayerActions()->actIncrementAllCardCounters(
+            player->getLogic()->getPlayerActions()->actIncrementAllCardCounters(
                 player->getGameScene()->selectedCards());
         });
 
         createPredefinedTokenMenu = new QMenu(QString());
         createPredefinedTokenMenu->setEnabled(false);
-        connect(player->getPlayerLogic(), &PlayerLogic::deckChanged, this, &UtilityMenu::populatePredefinedTokensMenu);
+        connect(player->getLogic(), &PlayerLogic::deckChanged, this, &UtilityMenu::populatePredefinedTokensMenu);
 
         playerMenu->addAction(aIncrementAllCardCounters);
         playerMenu->addSeparator();
@@ -73,7 +73,7 @@ void UtilityMenu::populatePredefinedTokensMenu()
     clear();
     setEnabled(false);
     predefinedTokens.clear();
-    const DeckList &deckList = player->getPlayerLogic()->getDeck();
+    const DeckList &deckList = player->getLogic()->getDeck();
 
     if (deckList.isEmpty()) {
         return;
@@ -91,7 +91,7 @@ void UtilityMenu::populatePredefinedTokensMenu()
             if (i < 10) {
                 a->setShortcut(QKeySequence("Alt+" + QString::number((i + 1) % 10)));
             }
-            connect(a, &QAction::triggered, player->getPlayerLogic()->getPlayerActions(),
+            connect(a, &QAction::triggered, player->getLogic()->getPlayerActions(),
                     &PlayerActions::actCreatePredefinedToken);
         }
     }
@@ -103,12 +103,12 @@ void UtilityMenu::setLastToken(CardInfoPtr lastToken)
         return;
     }
 
-    player->getPlayerLogic()->getPlayerActions()->setLastTokenInfo(lastToken);
+    player->getLogic()->getPlayerActions()->setLastTokenInfo(lastToken);
 }
 
 void UtilityMenu::retranslateUi()
 {
-    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aIncrementAllCardCounters->setText(tr("Increment all card counters"));
         aUntapAll->setText(tr("&Untap all permanents"));
         aRollDie->setText(tr("R&oll die..."));
@@ -123,7 +123,7 @@ void UtilityMenu::setShortcutsActive()
 {
     ShortcutsSettings &shortcuts = SettingsCache::instance().shortcuts();
 
-    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aIncrementAllCardCounters->setShortcuts(shortcuts.getShortcut("Player/aIncrementAllCardCounters"));
         aUntapAll->setShortcuts(shortcuts.getShortcut("Player/aUntapAll"));
         aRollDie->setShortcuts(shortcuts.getShortcut("Player/aRollDie"));
@@ -135,7 +135,7 @@ void UtilityMenu::setShortcutsActive()
 
 void UtilityMenu::setShortcutsInactive()
 {
-    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aUntapAll->setShortcut(QKeySequence());
         aRollDie->setShortcut(QKeySequence());
         aFlipCoin->setShortcut(QKeySequence());

--- a/cockatrice/src/game/player/menu/utility_menu.cpp
+++ b/cockatrice/src/game/player/menu/utility_menu.cpp
@@ -8,22 +8,27 @@
 #include <libcockatrice/deck_list/tree/deck_list_card_node.h>
 #include <libcockatrice/deck_list/tree/inner_deck_list_node.h>
 
-UtilityMenu::UtilityMenu(PlayerLogic *_player, QMenu *playerMenu) : QMenu(playerMenu), player(_player)
+UtilityMenu::UtilityMenu(PlayerGraphicsItem *_player, QMenu *playerMenu) : QMenu(playerMenu), player(_player)
 {
-    PlayerActions *playerActions = player->getPlayerActions();
+    PlayerActions *playerActions = player->getPlayerLogic()->getPlayerActions();
+    connect(playerActions, &PlayerActions::requestEnableAndSetCreateAnotherTokenAction, this,
+            &UtilityMenu::setAndEnableCreateAnotherTokenAction);
+    connect(playerActions, &PlayerActions::requestSetLastToken, this, &UtilityMenu::setLastToken);
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aUntapAll = new QAction(this);
         connect(aUntapAll, &QAction::triggered, playerActions, &PlayerActions::actUntapAll);
 
         aRollDie = new QAction(this);
-        connect(aRollDie, &QAction::triggered, playerActions, &PlayerActions::actRollDie);
+        connect(aRollDie, &QAction::triggered, playerActions, &PlayerActions::actRequestRollDieDialog);
 
         aFlipCoin = new QAction(this);
         connect(aFlipCoin, &QAction::triggered, playerActions, &PlayerActions::actFlipCoin);
 
         aCreateToken = new QAction(this);
-        connect(aCreateToken, &QAction::triggered, playerActions, &PlayerActions::actCreateToken);
+        connect(aCreateToken, &QAction::triggered, playerActions, [this]() {
+            player->getPlayerLogic()->getPlayerActions()->actRequestCreateTokenDialog(getPredefinedTokens());
+        });
 
         aCreateAnotherToken = new QAction(this);
         connect(aCreateAnotherToken, &QAction::triggered, playerActions, &PlayerActions::actCreateAnotherToken);
@@ -35,7 +40,7 @@ UtilityMenu::UtilityMenu(PlayerLogic *_player, QMenu *playerMenu) : QMenu(player
 
         createPredefinedTokenMenu = new QMenu(QString());
         createPredefinedTokenMenu->setEnabled(false);
-        connect(player, &PlayerLogic::deckChanged, this, &UtilityMenu::populatePredefinedTokensMenu);
+        connect(player->getPlayerLogic(), &PlayerLogic::deckChanged, this, &UtilityMenu::populatePredefinedTokensMenu);
 
         playerMenu->addAction(aIncrementAllCardCounters);
         playerMenu->addSeparator();
@@ -66,7 +71,7 @@ void UtilityMenu::populatePredefinedTokensMenu()
     clear();
     setEnabled(false);
     predefinedTokens.clear();
-    const DeckList &deckList = player->getDeck();
+    const DeckList &deckList = player->getPlayerLogic()->getDeck();
 
     if (deckList.isEmpty()) {
         return;
@@ -84,14 +89,24 @@ void UtilityMenu::populatePredefinedTokensMenu()
             if (i < 10) {
                 a->setShortcut(QKeySequence("Alt+" + QString::number((i + 1) % 10)));
             }
-            connect(a, &QAction::triggered, player->getPlayerActions(), &PlayerActions::actCreatePredefinedToken);
+            connect(a, &QAction::triggered, player->getPlayerLogic()->getPlayerActions(),
+                    &PlayerActions::actCreatePredefinedToken);
         }
     }
 }
 
+void UtilityMenu::setLastToken(CardInfoPtr lastToken)
+{
+    if (createAnotherTokenActionExists()) {
+        return;
+    }
+
+    player->getPlayerLogic()->getPlayerActions()->setLastTokenInfo(lastToken);
+}
+
 void UtilityMenu::retranslateUi()
 {
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aIncrementAllCardCounters->setText(tr("Increment all card counters"));
         aUntapAll->setText(tr("&Untap all permanents"));
         aRollDie->setText(tr("R&oll die..."));
@@ -106,7 +121,7 @@ void UtilityMenu::setShortcutsActive()
 {
     ShortcutsSettings &shortcuts = SettingsCache::instance().shortcuts();
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aIncrementAllCardCounters->setShortcuts(shortcuts.getShortcut("Player/aIncrementAllCardCounters"));
         aUntapAll->setShortcuts(shortcuts.getShortcut("Player/aUntapAll"));
         aRollDie->setShortcuts(shortcuts.getShortcut("Player/aRollDie"));
@@ -118,7 +133,7 @@ void UtilityMenu::setShortcutsActive()
 
 void UtilityMenu::setShortcutsInactive()
 {
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getPlayerLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aUntapAll->setShortcut(QKeySequence());
         aRollDie->setShortcut(QKeySequence());
         aFlipCoin->setShortcut(QKeySequence());

--- a/cockatrice/src/game/player/menu/utility_menu.cpp
+++ b/cockatrice/src/game/player/menu/utility_menu.cpp
@@ -99,7 +99,7 @@ void UtilityMenu::populatePredefinedTokensMenu()
 
 void UtilityMenu::setLastToken(CardInfoPtr lastToken)
 {
-    if (createAnotherTokenActionExists()) {
+    if (!createAnotherTokenActionExists()) {
         return;
     }
 

--- a/cockatrice/src/game/player/menu/utility_menu.cpp
+++ b/cockatrice/src/game/player/menu/utility_menu.cpp
@@ -35,8 +35,10 @@ UtilityMenu::UtilityMenu(PlayerGraphicsItem *_player, QMenu *playerMenu) : QMenu
         aCreateAnotherToken->setEnabled(false);
 
         aIncrementAllCardCounters = new QAction(this);
-        connect(aIncrementAllCardCounters, &QAction::triggered, playerActions,
-                &PlayerActions::actIncrementAllCardCounters);
+        connect(aIncrementAllCardCounters, &QAction::triggered, playerActions, [this]() {
+            player->getPlayerLogic()->getPlayerActions()->actIncrementAllCardCounters(
+                player->getGameScene()->selectedCards());
+        });
 
         createPredefinedTokenMenu = new QMenu(QString());
         createPredefinedTokenMenu->setEnabled(false);

--- a/cockatrice/src/game/player/menu/utility_menu.h
+++ b/cockatrice/src/game/player/menu/utility_menu.h
@@ -8,9 +8,9 @@
 #define COCKATRICE_UTILITY_MENU_H
 
 #include "abstract_player_component.h"
-#include "libcockatrice/card/card_info.h"
 
 #include <QMenu>
+#include <libcockatrice/card/card_info.h>
 
 class PlayerGraphicsItem;
 class UtilityMenu : public QMenu, public AbstractPlayerComponent

--- a/cockatrice/src/game/player/menu/utility_menu.h
+++ b/cockatrice/src/game/player/menu/utility_menu.h
@@ -8,21 +8,23 @@
 #define COCKATRICE_UTILITY_MENU_H
 
 #include "abstract_player_component.h"
+#include "libcockatrice/card/card_info.h"
 
 #include <QMenu>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class UtilityMenu : public QMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 public slots:
     void populatePredefinedTokensMenu();
+    void setLastToken(CardInfoPtr lastToken);
     void retranslateUi() override;
     void setShortcutsActive() override;
     void setShortcutsInactive() override;
 
 public:
-    explicit UtilityMenu(PlayerLogic *player, QMenu *playerMenu);
+    explicit UtilityMenu(PlayerGraphicsItem *player, QMenu *playerMenu);
 
     [[nodiscard]] bool createAnotherTokenActionExists() const
     {
@@ -31,7 +33,7 @@ public:
 
     void setAndEnableCreateAnotherTokenAction(QString text)
     {
-        aCreateAnotherToken->setText(text);
+        aCreateAnotherToken->setText(tr("C&reate another %1 token").arg(text));
         aCreateAnotherToken->setEnabled(true);
     }
 
@@ -41,7 +43,7 @@ public:
     }
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
     QStringList predefinedTokens;
 
     QMenu *createPredefinedTokenMenu;

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -5,7 +5,6 @@
 #include "../../interface/widgets/tabs/tab_game.h"
 #include "../../interface/widgets/utility/get_text_with_max.h"
 #include "../board/card_item.h"
-#include "../client/settings/card_counter_settings.h"
 #include "../dialogs/dlg_move_top_cards_until.h"
 #include "../dialogs/dlg_roll_dice.h"
 #include "../zones/view_zone_logic.h"
@@ -39,6 +38,8 @@ static constexpr int MOVE_TOP_CARD_UNTIL_INTERVAL = 100;
 PlayerActions::PlayerActions(PlayerLogic *_player)
     : QObject(_player), player(_player), lastTokenTableRow(0), movingCardsUntil(false)
 {
+    connect(this, &PlayerActions::requestZoneViewToggle, player, &PlayerLogic::onRequestZoneViewToggle);
+
     moveTopCardTimer = new QTimer(this);
     moveTopCardTimer->setInterval(MOVE_TOP_CARD_UNTIL_INTERVAL);
     moveTopCardTimer->setSingleShot(true);
@@ -133,12 +134,12 @@ void PlayerActions::playCardToTable(const CardItem *card, bool faceDown)
 
 void PlayerActions::actViewLibrary()
 {
-    player->getGameScene()->toggleZoneView(player, ZoneNames::DECK, -1);
+    emit requestZoneViewToggle(ZoneNames::DECK, -1);
 }
 
 void PlayerActions::actViewHand()
 {
-    player->getGameScene()->toggleZoneView(player, ZoneNames::HAND, -1);
+    emit requestZoneViewToggle(ZoneNames::HAND, -1);
 }
 
 /**
@@ -170,49 +171,45 @@ void PlayerActions::actSortHand()
 
     static QList defaultOptions = {CardList::SortByName, CardList::SortByPrinting};
 
-    player->getGraphicsItem()->getHandZoneGraphicsItem()->sortHand(sortOptions + defaultOptions);
+    emit requestSortHand(sortOptions + defaultOptions);
 }
 
-void PlayerActions::actViewTopCards()
+void PlayerActions::actRequestViewTopCardsDialog()
 {
-    int deckSize = player->getDeckZone()->getCards().size();
-    bool ok;
-    int number = QInputDialog::getInt(player->getGame()->getTab(), tr("View top cards of library"),
-                                      tr("Number of cards: (max. %1)").arg(deckSize), defaultNumberTopCards, 1,
-                                      deckSize, 1, &ok);
-    if (ok) {
-        defaultNumberTopCards = number;
-        player->getGameScene()->toggleZoneView(player, ZoneNames::DECK, number);
-    }
+    emit requestViewTopCardsDialog(defaultNumberTopCards, player->getDeckZone()->getCards().size());
 }
 
-void PlayerActions::actViewBottomCards()
+void PlayerActions::actViewTopCards(int number)
 {
-    int deckSize = player->getDeckZone()->getCards().size();
-    bool ok;
-    int number = QInputDialog::getInt(player->getGame()->getTab(), tr("View bottom cards of library"),
-                                      tr("Number of cards: (max. %1)").arg(deckSize), defaultNumberBottomCards, 1,
-                                      deckSize, 1, &ok);
-    if (ok) {
-        defaultNumberBottomCards = number;
-        player->getGameScene()->toggleZoneView(player, ZoneNames::DECK, number, true);
-    }
+    defaultNumberTopCards = number;
+    emit requestZoneViewToggle(ZoneNames::DECK, number);
 }
 
-void PlayerActions::actAlwaysRevealTopCard()
+void PlayerActions::actRequestViewBottomCardsDialog()
+{
+    emit requestViewBottomCardsDialog(defaultNumberBottomCards, player->getDeckZone()->getCards().size());
+}
+
+void PlayerActions::actViewBottomCards(int number)
+{
+    defaultNumberBottomCards = number;
+    emit requestZoneViewToggle(ZoneNames::DECK, number, true);
+}
+
+void PlayerActions::actAlwaysRevealTopCard(bool alwaysRevealTopCard)
 {
     Command_ChangeZoneProperties cmd;
     cmd.set_zone_name(ZoneNames::DECK);
-    cmd.set_always_reveal_top_card(player->getPlayerMenu()->getLibraryMenu()->isAlwaysRevealTopCardChecked());
+    cmd.set_always_reveal_top_card(alwaysRevealTopCard);
 
     sendGameCommand(cmd);
 }
 
-void PlayerActions::actAlwaysLookAtTopCard()
+void PlayerActions::actAlwaysLookAtTopCard(bool alwaysRevealTopCard)
 {
     Command_ChangeZoneProperties cmd;
     cmd.set_zone_name(ZoneNames::DECK);
-    cmd.set_always_look_at_top_card(player->getPlayerMenu()->getLibraryMenu()->isAlwaysLookAtTopCardChecked());
+    cmd.set_always_look_at_top_card(alwaysRevealTopCard);
 
     sendGameCommand(cmd);
 }
@@ -224,17 +221,17 @@ void PlayerActions::actOpenDeckInDeckEditor()
 
 void PlayerActions::actViewGraveyard()
 {
-    player->getGameScene()->toggleZoneView(player, ZoneNames::GRAVE, -1);
+    emit requestZoneViewToggle(ZoneNames::GRAVE, -1);
 }
 
 void PlayerActions::actViewRfg()
 {
-    player->getGameScene()->toggleZoneView(player, ZoneNames::EXILE, -1);
+    emit requestZoneViewToggle(ZoneNames::EXILE, -1);
 }
 
 void PlayerActions::actViewSideboard()
 {
-    player->getGameScene()->toggleZoneView(player, ZoneNames::SIDEBOARD, -1);
+    emit requestZoneViewToggle(ZoneNames::SIDEBOARD, -1);
 }
 
 void PlayerActions::actShuffle()
@@ -242,18 +239,20 @@ void PlayerActions::actShuffle()
     sendGameCommand(Command_Shuffle());
 }
 
-void PlayerActions::actShuffleTop()
+void PlayerActions::actRequestShuffleTopDialog()
 {
     const int maxCards = player->getDeckZone()->getCards().size();
     if (maxCards == 0) {
         return;
     }
 
-    bool ok;
-    int number = QInputDialog::getInt(player->getGame()->getTab(), tr("Shuffle top cards of library"),
-                                      tr("Number of cards: (max. %1)").arg(maxCards), defaultNumberTopCards, 1,
-                                      maxCards, 1, &ok);
-    if (!ok) {
+    emit requestShuffleTopDialog(defaultNumberTopCards, maxCards);
+}
+
+void PlayerActions::actShuffleTop(int number)
+{
+    const int maxCards = player->getDeckZone()->getCards().size();
+    if (maxCards == 0) {
         return;
     }
 
@@ -271,18 +270,20 @@ void PlayerActions::actShuffleTop()
     sendGameCommand(cmd);
 }
 
-void PlayerActions::actShuffleBottom()
+void PlayerActions::actRequestShuffleBottomDialog()
 {
     const int maxCards = player->getDeckZone()->getCards().size();
     if (maxCards == 0) {
         return;
     }
 
-    bool ok;
-    int number = QInputDialog::getInt(player->getGame()->getTab(), tr("Shuffle bottom cards of library"),
-                                      tr("Number of cards: (max. %1)").arg(maxCards), defaultNumberBottomCards, 1,
-                                      maxCards, 1, &ok);
-    if (!ok) {
+    emit requestShuffleBottomDialog(defaultNumberBottomCards, maxCards);
+}
+
+void PlayerActions::actShuffleBottom(int number)
+{
+    const int maxCards = player->getDeckZone()->getCards().size();
+    if (maxCards == 0) {
         return;
     }
 
@@ -307,21 +308,18 @@ void PlayerActions::actDrawCard()
     sendGameCommand(cmd);
 }
 
-void PlayerActions::actMulligan()
+void PlayerActions::actRequestMulliganDialog()
 {
     int startSize = SettingsCache::instance().getStartingHandSize();
     int handSize = player->getHandZone()->getCards().size();
     int deckSize = player->getDeckZone()->getCards().size() + handSize;
 
-    bool ok;
-    int number = QInputDialog::getInt(player->getGame()->getTab(), tr("Draw hand"),
-                                      tr("Number of cards: (max. %1)").arg(deckSize) + '\n' +
-                                          tr("0 and lower are in comparison to current hand size"),
-                                      startSize, -handSize, deckSize, 1, &ok);
+    emit requestMulliganDialog(startSize, handSize, deckSize);
+}
 
-    if (!ok) {
-        return;
-    }
+void PlayerActions::actMulligan(int number)
+{
+    int handSize = player->getHandZone()->getCards().size();
 
     if (number < 1) {
         number = handSize + number;
@@ -355,19 +353,19 @@ void PlayerActions::doMulligan(int number)
     sendGameCommand(cmd);
 }
 
-void PlayerActions::actDrawCards()
+void PlayerActions::actRequestDrawCardsDialog()
 {
     int deckSize = player->getDeckZone()->getCards().size();
-    bool ok;
-    int number = QInputDialog::getInt(player->getGame()->getTab(), tr("Draw cards"),
-                                      tr("Number of cards: (max. %1)").arg(deckSize), defaultNumberTopCards, 1,
-                                      deckSize, 1, &ok);
-    if (ok) {
-        defaultNumberTopCards = number;
-        Command_DrawCards cmd;
-        cmd.set_number(static_cast<google::protobuf::uint32>(number));
-        sendGameCommand(cmd);
-    }
+
+    emit requestDrawCardsDialog(defaultNumberTopCards, deckSize);
+}
+
+void PlayerActions::actDrawCards(int number)
+{
+    defaultNumberTopCards = number;
+    Command_DrawCards cmd;
+    cmd.set_number(static_cast<google::protobuf::uint32>(number));
+    sendGameCommand(cmd);
 }
 
 void PlayerActions::actUndoDraw()
@@ -425,36 +423,40 @@ void PlayerActions::actMoveTopCardToExile()
 
 void PlayerActions::actMoveTopCardsToGrave()
 {
-    moveTopCardsTo(ZoneNames::GRAVE, tr("grave"), false);
+    actRequestMoveTopCardsToDialog(ZoneNames::GRAVE, tr("grave"), false);
 }
 
 void PlayerActions::actMoveTopCardsToGraveFaceDown()
 {
-    moveTopCardsTo(ZoneNames::GRAVE, tr("grave"), true);
+    actRequestMoveTopCardsToDialog(ZoneNames::GRAVE, tr("grave"), true);
 }
 
 void PlayerActions::actMoveTopCardsToExile()
 {
-    moveTopCardsTo(ZoneNames::EXILE, tr("exile"), false);
+    actRequestMoveTopCardsToDialog(ZoneNames::EXILE, tr("exile"), false);
 }
 
 void PlayerActions::actMoveTopCardsToExileFaceDown()
 {
-    moveTopCardsTo(ZoneNames::EXILE, tr("exile"), true);
+    actRequestMoveTopCardsToDialog(ZoneNames::EXILE, tr("exile"), true);
 }
 
-void PlayerActions::moveTopCardsTo(const QString &targetZone, const QString &zoneDisplayName, bool faceDown)
+void PlayerActions::actRequestMoveTopCardsToDialog(const QString &targetZone,
+                                                   const QString &zoneDisplayName,
+                                                   bool faceDown)
 {
     const int maxCards = player->getDeckZone()->getCards().size();
     if (maxCards == 0) {
         return;
     }
 
-    bool ok;
-    int number = QInputDialog::getInt(player->getGame()->getTab(), tr("Move top cards to %1").arg(zoneDisplayName),
-                                      tr("Number of cards: (max. %1)").arg(maxCards), defaultNumberTopCards, 1,
-                                      maxCards, 1, &ok);
-    if (!ok) {
+    emit requestMoveTopCardsToDialog(defaultNumberTopCards, maxCards, targetZone, zoneDisplayName, faceDown);
+}
+
+void PlayerActions::moveTopCardsTo(int number, const QString &targetZone, bool faceDown)
+{
+    const int maxCards = player->getDeckZone()->getCards().size();
+    if (maxCards == 0) {
         return;
     }
 
@@ -481,17 +483,16 @@ void PlayerActions::moveTopCardsTo(const QString &targetZone, const QString &zon
     sendGameCommand(cmd);
 }
 
-void PlayerActions::actMoveTopCardsUntil()
+void PlayerActions::actRequestMoveTopCardsUntilDialog()
 {
     stopMoveTopCardsUntil();
 
-    DlgMoveTopCardsUntil dlg(player->getGame()->getTab(), movingCardsUntilOptions);
-    if (!dlg.exec()) {
-        return;
-    }
+    emit requestMoveTopCardsUntilDialog(movingCardsUntilOptions);
+}
 
-    auto expr = dlg.getExpr();
-    movingCardsUntilOptions = dlg.getOptions();
+void PlayerActions::moveTopCardsUntil(const QString &expr, MoveTopCardsUntilOptions options)
+{
+    movingCardsUntilOptions = options;
 
     if (player->getDeckZone()->getCards().empty()) {
         stopMoveTopCardsUntil();
@@ -620,36 +621,40 @@ void PlayerActions::actMoveBottomCardToExile()
 
 void PlayerActions::actMoveBottomCardsToGrave()
 {
-    moveBottomCardsTo(ZoneNames::GRAVE, tr("grave"), false);
+    actRequestMoveBottomCardsToDialog(ZoneNames::GRAVE, tr("grave"), false);
 }
 
 void PlayerActions::actMoveBottomCardsToGraveFaceDown()
 {
-    moveBottomCardsTo(ZoneNames::GRAVE, tr("grave"), true);
+    actRequestMoveBottomCardsToDialog(ZoneNames::GRAVE, tr("grave"), true);
 }
 
 void PlayerActions::actMoveBottomCardsToExile()
 {
-    moveBottomCardsTo(ZoneNames::EXILE, tr("exile"), false);
+    actRequestMoveBottomCardsToDialog(ZoneNames::EXILE, tr("exile"), false);
 }
 
 void PlayerActions::actMoveBottomCardsToExileFaceDown()
 {
-    moveBottomCardsTo(ZoneNames::EXILE, tr("exile"), true);
+    actRequestMoveBottomCardsToDialog(ZoneNames::EXILE, tr("exile"), true);
 }
 
-void PlayerActions::moveBottomCardsTo(const QString &targetZone, const QString &zoneDisplayName, bool faceDown)
+void PlayerActions::actRequestMoveBottomCardsToDialog(const QString &targetZone,
+                                                      const QString &zoneDisplayName,
+                                                      bool faceDown)
 {
     const int maxCards = player->getDeckZone()->getCards().size();
     if (maxCards == 0) {
         return;
     }
 
-    bool ok;
-    int number = QInputDialog::getInt(player->getGame()->getTab(), tr("Move bottom cards to %1").arg(zoneDisplayName),
-                                      tr("Number of cards: (max. %1)").arg(maxCards), defaultNumberBottomCards, 1,
-                                      maxCards, 1, &ok);
-    if (!ok) {
+    emit requestMoveBottomCardsToDialog(defaultNumberBottomCards, maxCards, targetZone, zoneDisplayName, faceDown);
+}
+
+void PlayerActions::moveBottomCardsTo(int number, const QString &targetZone, bool faceDown)
+{
+    const int maxCards = player->getDeckZone()->getCards().size();
+    if (maxCards == 0) {
         return;
     }
 
@@ -761,20 +766,24 @@ void PlayerActions::actDrawBottomCard()
     sendGameCommand(cmd);
 }
 
-void PlayerActions::actDrawBottomCards()
+void PlayerActions::actRequestDrawBottomCardsDialog()
 {
     const int maxCards = player->getDeckZone()->getCards().size();
     if (maxCards == 0) {
         return;
     }
 
-    bool ok;
-    int number = QInputDialog::getInt(player->getGame()->getTab(), tr("Draw bottom cards"),
-                                      tr("Number of cards: (max. %1)").arg(maxCards), defaultNumberBottomCards, 1,
-                                      maxCards, 1, &ok);
-    if (!ok) {
+    emit requestDrawBottomCardsDialog(defaultNumberBottomCards, maxCards);
+}
+
+void PlayerActions::actDrawBottomCards(int number)
+{
+    const int maxCards = player->getDeckZone()->getCards().size();
+    if (maxCards == 0) {
         return;
-    } else if (number > maxCards) {
+    }
+
+    if (number > maxCards) {
         number = maxCards;
     }
     defaultNumberBottomCards = number;
@@ -841,16 +850,16 @@ void PlayerActions::actUntapAll()
     sendGameCommand(cmd);
 }
 
-void PlayerActions::actRollDie()
+void PlayerActions::actRequestRollDieDialog()
 {
-    DlgRollDice dlg(player->getGame()->getTab());
-    if (!dlg.exec()) {
-        return;
-    }
+    emit requestRollDieDialog();
+}
 
+void PlayerActions::actRollDie(int sides, int count)
+{
     Command_RollDie cmd;
-    cmd.set_sides(dlg.getDieSideCount());
-    cmd.set_count(dlg.getDiceToRollCount());
+    cmd.set_sides(sides);
+    cmd.set_count(count);
     sendGameCommand(cmd);
 }
 
@@ -862,14 +871,14 @@ void PlayerActions::actFlipCoin()
     sendGameCommand(cmd);
 }
 
-void PlayerActions::actCreateToken()
+void PlayerActions::actRequestCreateTokenDialog(const QStringList &predefinedTokens)
 {
-    DlgCreateToken dlg(player->getPlayerMenu()->getUtilityMenu()->getPredefinedTokens(), player->getGame()->getTab());
-    if (!dlg.exec()) {
-        return;
-    }
+    emit requestCreateTokenDialog(predefinedTokens);
+}
 
-    lastTokenInfo = dlg.getTokenInfo();
+void PlayerActions::actCreateToken(TokenInfo tokenToCreate)
+{
+    lastTokenInfo = tokenToCreate;
 
     ExactCard correctedCard = CardDatabaseManager::query()->guessCard({lastTokenInfo.name, lastTokenInfo.providerId});
     if (correctedCard) {
@@ -880,8 +889,7 @@ void PlayerActions::actCreateToken()
         }
     }
 
-    player->getPlayerMenu()->getUtilityMenu()->setAndEnableCreateAnotherTokenAction(
-        tr("C&reate another %1 token").arg(lastTokenInfo.name));
+    emit requestEnableAndSetCreateAnotherTokenAction(lastTokenInfo.name);
     actCreateAnotherToken();
 }
 
@@ -912,8 +920,12 @@ void PlayerActions::setLastToken(CardInfoPtr cardInfo)
         return;
     }
 
-    UtilityMenu *utilityMenu = player->getPlayerMenu()->getUtilityMenu();
-    if (utilityMenu == nullptr || !utilityMenu->createAnotherTokenActionExists()) {
+    emit requestSetLastToken(cardInfo);
+}
+
+void PlayerActions::setLastTokenInfo(CardInfoPtr cardInfo)
+{
+    if (cardInfo == nullptr) {
         return;
     }
 
@@ -927,7 +939,7 @@ void PlayerActions::setLastToken(CardInfoPtr cardInfo)
 
     lastTokenTableRow = TableZone::tableRowToGridY(cardInfo->getUiAttributes().tableRow);
 
-    utilityMenu->setAndEnableCreateAnotherTokenAction(tr("C&reate another %1 token").arg(lastTokenInfo.name));
+    emit requestEnableAndSetCreateAnotherTokenAction(lastTokenInfo.name);
 }
 
 void PlayerActions::actCreatePredefinedToken()
@@ -946,23 +958,17 @@ void PlayerActions::actCreatePredefinedToken()
 void PlayerActions::actCreateRelatedCard()
 {
     const CardItem *sourceCard = player->getGame()->getActiveCard();
+
     if (!sourceCard) {
         return;
     }
+
     auto *action = static_cast<QAction *>(sender());
     // If there is a better way of passing a CardRelation through a QAction, please add it here.
     auto relatedCards = sourceCard->getCardInfo().getAllRelatedCards();
-    CardRelation *cardRelation = relatedCards.at(action->data().toInt());
 
-    /*
-     * If we make a token via "Token: TokenName"
-     * then let's allow it to be created via "create another token"
-     */
-    if (createRelatedFromRelation(sourceCard, cardRelation) && cardRelation->getCanCreateAnother()) {
-        ExactCard relatedCard = CardDatabaseManager::query()->getCardFromSameSet(cardRelation->getName(),
-                                                                                 sourceCard->getCard().getPrinting());
-        setLastToken(relatedCard.getCardPtr());
-    }
+    CardRelation *cardRelation = relatedCards.at(action->data().toInt());
+    actRequestCreateRelatedFromRelationDialog(sourceCard, cardRelation);
 }
 
 void PlayerActions::actCreateAllRelatedCards()
@@ -982,9 +988,8 @@ void PlayerActions::actCreateAllRelatedCards()
 
     if (relatedCards.length() == 1) {
         cardRelation = relatedCards.at(0);
-        if (createRelatedFromRelation(sourceCard, cardRelation)) {
-            ++tokensTypesCreated;
-        }
+        actRequestCreateRelatedFromRelationDialog(sourceCard, cardRelation);
+        ++tokensTypesCreated;
     } else {
         QList<CardRelation *> nonExcludedRelatedCards;
         QString dbName;
@@ -996,9 +1001,9 @@ void PlayerActions::actCreateAllRelatedCards()
         switch (nonExcludedRelatedCards.length()) {
             case 1: // if nonExcludedRelatedCards == 1
                 cardRelation = nonExcludedRelatedCards.at(0);
-                if (createRelatedFromRelation(sourceCard, cardRelation)) {
-                    ++tokensTypesCreated;
-                }
+                actRequestCreateRelatedFromRelationDialog(sourceCard, cardRelation);
+                ++tokensTypesCreated;
+
                 break;
             // If all are marked "Exclude", then treat the situation as if none of them are.
             // We won't accept "garbage in, garbage out", here.
@@ -1045,48 +1050,74 @@ void PlayerActions::actCreateAllRelatedCards()
     }
 }
 
-bool PlayerActions::createRelatedFromRelation(const CardItem *sourceCard, const CardRelation *cardRelation)
+void PlayerActions::actRequestCreateRelatedFromRelationDialog(const CardItem *sourceCard,
+                                                              const CardRelation *cardRelation)
+{
+    emit requestCreateRelatedFromRelationDialog(sourceCard, cardRelation);
+}
+
+void PlayerActions::createRelatedFromRelation(const CardItem *sourceCard,
+                                              const CardRelation *cardRelation,
+                                              int variableCount)
 {
     if (sourceCard == nullptr || cardRelation == nullptr) {
-        return false;
+        return;
     }
-    QString dbName = cardRelation->getName();
-    bool persistent = cardRelation->getIsPersistent();
+
+    const QString dbName = cardRelation->getName();
+    const bool persistent = cardRelation->getIsPersistent();
+
+    int count = 1;
+
     if (cardRelation->getIsVariable()) {
-        bool ok;
-        player->setDialogSemaphore(true);
-        int count = QInputDialog::getInt(player->getGame()->getTab(), tr("Create tokens"), tr("Number:"),
-                                         cardRelation->getDefaultCount(), 1, MAX_TOKENS_PER_DIALOG, 1, &ok);
-        player->setDialogSemaphore(false);
-        if (!ok) {
-            return false;
+        count = variableCount;
+        if (count <= 0) {
+            return;
         }
+    } else {
+        count = cardRelation->getDefaultCount();
+    }
+
+    if (count > 1) {
         for (int i = 0; i < count; ++i) {
             createCard(sourceCard, dbName, CardRelationType::DoesNotAttach, persistent);
         }
-    } else if (cardRelation->getDefaultCount() > 1) {
-        for (int i = 0; i < cardRelation->getDefaultCount(); ++i) {
-            createCard(sourceCard, dbName, CardRelationType::DoesNotAttach, persistent);
-        }
-    } else {
-        CardRelationType attachType;
-        // do not attempt to attach to another player's cards, this causes the card to attempt to attach to the same
-        // cardid on the local player's field instead, which is an entirely different card!
-        if (player->getPlayerInfo()->getLocalOrJudge()) {
-            attachType = cardRelation->getAttachType();
-        } else {
-            attachType = CardRelationType::DoesNotAttach;
-        }
-
-        // move card onto table first if attaching from some other zone
-        // we only do this for AttachTo because cross-zone TransformInto is already handled server-side
-        if (attachType == CardRelationType::AttachTo && sourceCard->getZone()->getName() != ZoneNames::TABLE) {
-            playCardToTable(sourceCard, false);
-        }
-
-        createCard(sourceCard, dbName, attachType, persistent);
+        return;
     }
-    return true;
+
+    CardRelationType attachType;
+    // do not attempt to attach to another player's cards, this causes the card to attempt to attach to the same
+    // cardid on the local player's field instead, which is an entirely different card!
+    if (player->getPlayerInfo()->getLocalOrJudge()) {
+        attachType = cardRelation->getAttachType();
+    } else {
+        attachType = CardRelationType::DoesNotAttach;
+    }
+
+    // move card onto table first if attaching from some other zone
+    // we only do this for AttachTo because cross-zone TransformInto is already handled server-side
+    if (attachType == CardRelationType::AttachTo && sourceCard->getZone()->getName() != ZoneNames::TABLE) {
+        playCardToTable(sourceCard, false);
+    }
+
+    createCard(sourceCard, dbName, attachType, persistent);
+    return;
+}
+
+void PlayerActions::onRelatedCardCreated(const CardItem *sourceCard, const CardRelation *cardRelation)
+{
+    /*
+     * If we make a token via "Token: TokenName"
+     * then let's allow it to be created via "create another token"
+     */
+    if (!cardRelation->getCanCreateAnother()) {
+        return;
+    }
+
+    ExactCard relatedCard =
+        CardDatabaseManager::query()->getCardFromSameSet(cardRelation->getName(), sourceCard->getCard().getPrinting());
+
+    setLastToken(relatedCard.getCardPtr());
 }
 
 void PlayerActions::createCard(const CardItem *sourceCard,
@@ -1166,35 +1197,29 @@ void PlayerActions::actSayMessage()
     sendGameCommand(cmd);
 }
 
-void PlayerActions::actMoveCardXCardsFromTop()
+void PlayerActions::actRequestMoveCardXCardsFromTopDialog()
 {
     int deckSize = player->getDeckZone()->getCards().size() + 1; // add the card to move to the deck
-    bool ok;
-    int number =
-        QInputDialog::getInt(player->getGame()->getTab(), tr("Place card X cards from top of library"),
-                             tr("Which position should this card be placed:") + "\n" + tr("(max. %1)").arg(deckSize),
-                             defaultNumberTopCardsToPlaceBelow, 1, deckSize, 1, &ok);
-    number -= 1; // indexes start at 0
 
-    if (!ok) {
-        return;
-    }
+    emit requestMoveCardXCardsFromTopDialog(defaultNumberTopCardsToPlaceBelow, deckSize);
+}
 
+void PlayerActions::actMoveCardXCardsFromTop(QList<CardItem *> selectedCards, int number)
+{
     defaultNumberTopCardsToPlaceBelow = number;
 
-    QList<CardItem *> cardList = player->getGameScene()->selectedCards();
-    if (cardList.isEmpty()) {
+    if (selectedCards.isEmpty()) {
         return;
     }
 
     QList<const ::google::protobuf::Message *> commandList;
     ListOfCardsToMove idList;
-    for (const auto &i : cardList) {
+    for (const auto &i : selectedCards) {
         idList.add_card()->set_card_id(i->getId());
     }
 
-    int startPlayerId = cardList[0]->getZone()->getPlayer()->getPlayerInfo()->getId();
-    QString startZone = cardList[0]->getZone()->getName();
+    int startPlayerId = selectedCards[0]->getZone()->getPlayer()->getPlayerInfo()->getId();
+    QString startZone = selectedCards[0]->getZone()->getName();
 
     auto *cmd = new Command_MoveCard;
     cmd->set_start_player_id(startPlayerId);
@@ -1213,12 +1238,12 @@ void PlayerActions::actMoveCardXCardsFromTop()
     }
 }
 
-void PlayerActions::actIncPT(int deltaP, int deltaT)
+void PlayerActions::actIncPT(QList<CardItem *> selectedCards, int deltaP, int deltaT)
 {
     int playerid = player->getPlayerInfo()->getId();
 
     QList<const ::google::protobuf::Message *> commandList;
-    for (auto card : player->getGameScene()->selectedCards()) {
+    for (auto card : selectedCards) {
         QString pt = card->getPT();
         const auto ptList = CardItem::parsePT(pt);
         QString newpt;
@@ -1246,11 +1271,11 @@ void PlayerActions::actIncPT(int deltaP, int deltaT)
     player->getGame()->getGameEventHandler()->sendGameCommand(prepareGameCommand(commandList), playerid);
 }
 
-void PlayerActions::actResetPT()
+void PlayerActions::actResetPT(QList<CardItem *> selectedCards)
 {
     int playerid = player->getPlayerInfo()->getId();
     QList<const ::google::protobuf::Message *> commandList;
-    for (auto card : player->getGameScene()->selectedCards()) {
+    for (auto card : selectedCards) {
         QString ptString;
         if (!card->getFaceDown()) { // leave the pt empty if the card is face down
             ExactCard ec = card->getCard();
@@ -1279,31 +1304,28 @@ void PlayerActions::actResetPT()
     }
 }
 
-void PlayerActions::actSetPT()
+void PlayerActions::actRequestSetPTDialog(QList<CardItem *> selectedCards)
 {
     QString oldPT;
-    int playerid = player->getPlayerInfo()->getId();
 
-    auto cards = player->getGameScene()->selectedCards();
-    for (auto card : cards) {
+    for (auto card : selectedCards) {
         if (!card->getPT().isEmpty()) {
             oldPT = card->getPT();
         }
     }
-    bool ok;
-    player->setDialogSemaphore(true);
-    QString pt = getTextWithMax(player->getGame()->getTab(), tr("Change power/toughness"), tr("Change stats to:"),
-                                QLineEdit::Normal, oldPT, &ok);
-    player->setDialogSemaphore(false);
-    if (player->clearCardsToDelete() || !ok) {
-        return;
-    }
+
+    emit requestSetPTDialog(oldPT);
+}
+
+void PlayerActions::actSetPT(QList<CardItem *> selectedCards, const QString &pt)
+{
+    int playerid = player->getPlayerInfo()->getId();
 
     const auto ptList = CardItem::parsePT(pt);
     bool empty = ptList.isEmpty();
 
     QList<const ::google::protobuf::Message *> commandList;
-    for (auto card : cards) {
+    for (auto card : selectedCards) {
         auto *cmd = new Command_SetCardAttr;
         QString newpt = QString();
         if (!empty) {
@@ -1347,47 +1369,47 @@ void PlayerActions::actDrawArrow()
     }
 }
 
-void PlayerActions::actIncP()
+void PlayerActions::actIncP(QList<CardItem *> selectedCards)
 {
-    actIncPT(1, 0);
+    actIncPT(selectedCards, 1, 0);
 }
 
-void PlayerActions::actDecP()
+void PlayerActions::actDecP(QList<CardItem *> selectedCards)
 {
-    actIncPT(-1, 0);
+    actIncPT(selectedCards, -1, 0);
 }
 
-void PlayerActions::actIncT()
+void PlayerActions::actIncT(QList<CardItem *> selectedCards)
 {
-    actIncPT(0, 1);
+    actIncPT(selectedCards, 0, 1);
 }
 
-void PlayerActions::actDecT()
+void PlayerActions::actDecT(QList<CardItem *> selectedCards)
 {
-    actIncPT(0, -1);
+    actIncPT(selectedCards, 0, -1);
 }
 
-void PlayerActions::actIncPT()
+void PlayerActions::actIncPT(QList<CardItem *> selectedCards)
 {
-    actIncPT(1, 1);
+    actIncPT(selectedCards, 1, 1);
 }
 
-void PlayerActions::actDecPT()
+void PlayerActions::actDecPT(QList<CardItem *> selectedCards)
 {
-    actIncPT(-1, -1);
+    actIncPT(selectedCards, -1, -1);
 }
 
-void PlayerActions::actFlowP()
+void PlayerActions::actFlowP(QList<CardItem *> selectedCards)
 {
-    actIncPT(1, -1);
+    actIncPT(selectedCards, 1, -1);
 }
 
-void PlayerActions::actFlowT()
+void PlayerActions::actFlowT(QList<CardItem *> selectedCards)
 {
-    actIncPT(-1, 1);
+    actIncPT(selectedCards, -1, 1);
 }
 
-void PlayerActions::actReduceLifeByPower()
+void PlayerActions::actReduceLifeByPower(QList<CardItem *> selectedCards)
 {
     // find life counter
     auto lifeCounter = player->getLifeCounter();
@@ -1395,10 +1417,9 @@ void PlayerActions::actReduceLifeByPower()
         return;
     }
 
-    // calculate total power
-    auto cards = player->getGameScene()->selectedCards();
+    // calculate total power;
     int total = 0;
-    for (auto card : cards) {
+    for (auto card : selectedCards) {
         QVariantList parsed = CardItem::parsePT(card->getPT());
         if (!parsed.isEmpty()) {
             int power = parsed.first().toInt(); // toInt will default to 0 if it's not an int
@@ -1423,31 +1444,22 @@ void AnnotationDialog::keyPressEvent(QKeyEvent *event)
     QInputDialog::keyPressEvent(event);
 }
 
-void PlayerActions::actSetAnnotation()
+void PlayerActions::actRequestSetAnnotationDialog(QList<CardItem *> selectedCards)
 {
     QString oldAnnotation;
-    auto cards = player->getGameScene()->selectedCards();
-    for (auto card : cards) {
+    for (auto card : selectedCards) {
         if (!card->getAnnotation().isEmpty()) {
             oldAnnotation = card->getAnnotation();
         }
     }
 
-    player->setDialogSemaphore(true);
-    AnnotationDialog *dialog = new AnnotationDialog(player->getGame()->getTab());
-    dialog->setOptions(QInputDialog::UsePlainTextEditForTextInput);
-    dialog->setWindowTitle(tr("Set annotation"));
-    dialog->setLabelText(tr("Please enter the new annotation:"));
-    dialog->setTextValue(oldAnnotation);
-    bool ok = dialog->exec();
-    player->setDialogSemaphore(false);
-    if (player->clearCardsToDelete() || !ok) {
-        return;
-    }
-    QString annotation = dialog->textValue().left(MAX_NAME_LENGTH);
+    emit requestSetAnnotationDialog(oldAnnotation);
+}
 
+void PlayerActions::actSetAnnotation(QList<CardItem *> selectedCards, const QString &annotation)
+{
     QList<const ::google::protobuf::Message *> commandList;
-    for (auto card : cards) {
+    for (auto card : selectedCards) {
         auto *cmd = new Command_SetCardAttr;
         cmd->set_zone(card->getZone()->getName().toStdString());
         cmd->set_card_id(card->getId());
@@ -1468,10 +1480,10 @@ void PlayerActions::actAttach()
     card->drawAttachArrow();
 }
 
-void PlayerActions::actUnattach()
+void PlayerActions::actUnattach(QList<CardItem *> selectedCards)
 {
     QList<const ::google::protobuf::Message *> commandList;
-    for (auto card : player->getGameScene()->selectedCards()) {
+    for (auto card : selectedCards) {
         if (!card->getAttachedTo()) {
             continue;
         }
@@ -1484,20 +1496,20 @@ void PlayerActions::actUnattach()
     sendGameCommand(prepareGameCommand(commandList));
 }
 
-void PlayerActions::actAddCardCounter(int counterId)
+void PlayerActions::actAddCardCounter(QList<CardItem *> selectedCards, int counterId)
 {
-    offsetCardCounter(counterId, 1);
+    offsetCardCounter(selectedCards, counterId, 1);
 }
 
-void PlayerActions::actRemoveCardCounter(int counterId)
+void PlayerActions::actRemoveCardCounter(QList<CardItem *> selectedCards, int counterId)
 {
-    offsetCardCounter(counterId, -1);
+    offsetCardCounter(selectedCards, counterId, -1);
 }
 
-void PlayerActions::offsetCardCounter(int counterId, int offset)
+void PlayerActions::offsetCardCounter(QList<CardItem *> selectedCards, int counterId, int offset)
 {
     QList<const ::google::protobuf::Message *> commandList;
-    for (auto card : player->getGameScene()->selectedCards()) {
+    for (auto card : selectedCards) {
         int oldValue = card->getCounters().value(counterId, 0);
         int newValue = oldValue + offset;
 
@@ -1517,31 +1529,22 @@ void PlayerActions::offsetCardCounter(int counterId, int offset)
     sendGameCommand(prepareGameCommand(commandList));
 }
 
-void PlayerActions::actSetCardCounter(int counterId)
+void PlayerActions::actRequestSetCardCounterDialog(QList<CardItem *> selectedCards, int counterId)
 {
-    player->setDialogSemaphore(true);
-
     // If a single card is selected, we show the old value in the dialog. Otherwise, we show "x"
-    QList<CardItem *> sel = player->getGameScene()->selectedCards();
     QString oldValueForDlg = "x";
-    if (sel.size() == 1) {
-        auto *card = sel.first();
+    if (selectedCards.size() == 1) {
+        auto *card = selectedCards.first();
         oldValueForDlg = QString::number(card->getCounters().value(counterId, 0));
     }
 
-    auto &cardCounterSettings = SettingsCache::instance().cardCounters();
-    QString counterName = cardCounterSettings.displayName(counterId);
+    emit requestSetCardCounterDialog(counterId, oldValueForDlg);
+}
 
-    AbstractCounterDialog dialog(counterName, oldValueForDlg, player->getGame()->getTab());
-    int ok = dialog.exec();
-
-    player->setDialogSemaphore(false);
-    if (player->clearCardsToDelete() || !ok) {
-        return;
-    }
-
+void PlayerActions::actSetCardCounter(QList<CardItem *> selectedCards, int counterId, const QString &counterValue)
+{
     QList<const ::google::protobuf::Message *> commandList;
-    for (auto card : sel) {
+    for (auto card : selectedCards) {
         int oldValue = card->getCounters().value(counterId, 0);
         Expression exp(oldValue);
         double parsed = exp.parse(dialog.textValue());
@@ -1607,10 +1610,8 @@ static bool isUnwritableRevealZone(CardZoneLogic *zone)
     return false;
 }
 
-void PlayerActions::playSelectedCards(const bool faceDown)
+void PlayerActions::playSelectedCards(QList<CardItem *> selectedCards, const bool faceDown)
 {
-    QList<CardItem *> selectedCards = player->getGameScene()->selectedCards();
-
     // CardIds will get shuffled downwards when cards leave the deck.
     // We need to iterate through the cards in reverse order so cardIds don't get changed out from under us as we play
     // out the cards one-by-one.
@@ -1624,19 +1625,19 @@ void PlayerActions::playSelectedCards(const bool faceDown)
     }
 }
 
-void PlayerActions::actPlay()
+void PlayerActions::actPlay(QList<CardItem *> selectedCards)
 {
-    playSelectedCards(false);
+    playSelectedCards(selectedCards, false);
 }
 
-void PlayerActions::actPlayFacedown()
+void PlayerActions::actPlayFacedown(QList<CardItem *> selectedCards)
 {
-    playSelectedCards(true);
+    playSelectedCards(selectedCards, true);
 }
 
-void PlayerActions::actHide()
+void PlayerActions::actHide(QList<CardItem *> selectedCards)
 {
-    for (const auto &item : player->getGameScene()->selectedCards()) {
+    for (const auto &item : selectedCards) {
         auto *card = static_cast<CardItem *>(item);
         if (card && isUnwritableRevealZone(card->getZone())) {
             card->getZone()->removeCard(card);
@@ -1644,7 +1645,7 @@ void PlayerActions::actHide()
     }
 }
 
-void PlayerActions::actReveal(QAction *action)
+void PlayerActions::actReveal(QList<CardItem *> selectedCards, QAction *action)
 {
     const int otherPlayerId = action->data().toInt();
 
@@ -1653,7 +1654,7 @@ void PlayerActions::actReveal(QAction *action)
         cmd.set_player_id(otherPlayerId);
     }
 
-    for (auto card : player->getGameScene()->selectedCards()) {
+    for (auto card : selectedCards) {
         if (!cmd.has_zone_name()) {
             cmd.set_zone_name(card->getZone()->getName().toStdString());
         }
@@ -1735,15 +1736,14 @@ void PlayerActions::actRevealRandomGraveyardCard(int revealToPlayerId)
     sendGameCommand(cmd);
 }
 
-void PlayerActions::cardMenuAction()
+void PlayerActions::cardMenuAction(QList<CardItem *> selectedCards, CardMenuActionType type)
 {
-    auto *a = dynamic_cast<QAction *>(sender());
-    QList<CardItem *> cardList = player->getGameScene()->selectedCards();
+    QList<CardItem *> cardList = selectedCards;
 
     QList<const ::google::protobuf::Message *> commandList;
-    if (a->data().toInt() <= (int)cmClone) {
+    if (type <= cmClone) {
         for (const auto &card : cardList) {
-            switch (static_cast<CardMenuActionType>(a->data().toInt())) {
+            switch (type) {
                 // Leaving both for compatibility with server
                 case cmUntap:
                     // fallthrough
@@ -1824,7 +1824,7 @@ void PlayerActions::cardMenuAction()
             idList.add_card()->set_card_id(i->getId());
         }
 
-        switch (static_cast<CardMenuActionType>(a->data().toInt())) {
+        switch (type) {
             case cmMoveToTopLibrary: {
                 auto *cmd = new Command_MoveCard;
                 cmd->set_start_player_id(startPlayerId);

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -1547,7 +1547,7 @@ void PlayerActions::actSetCardCounter(QList<CardItem *> selectedCards, int count
     for (auto card : selectedCards) {
         int oldValue = card->getCounters().value(counterId, 0);
         Expression exp(oldValue);
-        double parsed = exp.parse(dialog.textValue());
+        double parsed = exp.parse(counterValue);
         // Clamp in double precision first to avoid UB, then cast
         int number = static_cast<int>(qBound(0.0, parsed, static_cast<double>(MAX_COUNTERS_ON_CARD)));
 
@@ -1562,9 +1562,8 @@ void PlayerActions::actSetCardCounter(QList<CardItem *> selectedCards, int count
     sendGameCommand(prepareGameCommand(commandList));
 }
 
-void PlayerActions::actIncrementAllCardCounters()
+void PlayerActions::actIncrementAllCardCounters(QList<CardItem *> cardsToUpdate)
 {
-    auto cardsToUpdate = player->getGameScene()->selectedCards();
     if (cardsToUpdate.isEmpty()) {
         // If no cards selected, update all cards on table
         cardsToUpdate = static_cast<QList<CardItem *>>(player->getTableZone()->getCards());

--- a/cockatrice/src/game/player/player_actions.h
+++ b/cockatrice/src/game/player/player_actions.h
@@ -9,6 +9,7 @@
 #define COCKATRICE_PLAYER_ACTIONS_H
 #include "../dialogs/dlg_create_token.h"
 #include "../dialogs/dlg_move_top_cards_until.h"
+#include "card_menu_action_type.h"
 #include "event_processing_options.h"
 #include "player_logic.h"
 
@@ -56,30 +57,71 @@ public:
         return movingCardsUntil;
     }
 
+signals:
+    void requestViewTopCardsDialog(int defaultNumberTopCards, int deckSize);
+    void requestViewBottomCardsDialog(int defaultNumberBottomCards, int deckSize);
+    void requestShuffleTopDialog(int defaultNumberTopCards, int maxCards);
+    void requestShuffleBottomDialog(int defaultNumberBottomCards, int maxCards);
+    void requestMulliganDialog(int startSize, int handSize, int deckSize);
+    void requestDrawCardsDialog(int defaultNumberTopCards, int deckSize);
+    void requestMoveTopCardsToDialog(int defaultNumberTopCards,
+                                     int maxCards,
+                                     const QString &targetZone,
+                                     const QString &zoneDisplayName,
+                                     bool faceDown);
+    void requestMoveTopCardsUntilDialog(MoveTopCardsUntilOptions options);
+    void requestMoveBottomCardsToDialog(int defaultNumberBottomCards,
+                                        int maxCards,
+                                        const QString &targetZone,
+                                        const QString &zoneDisplayName,
+                                        bool faceDown);
+    void requestDrawBottomCardsDialog(int defaultNumberBottomCards, int maxCards);
+    void requestRollDieDialog();
+    void requestCreateTokenDialog(const QStringList &predefinedTokens);
+    void requestCreateRelatedFromRelationDialog(const CardItem *sourceCard, const CardRelation *cardRelation);
+    void requestMoveCardXCardsFromTopDialog(int defaultNumberTopCardsToPlaceBelow, int deckSize);
+    void requestSetPTDialog(const QString &oldPT);
+    void requestSetAnnotationDialog(const QString &oldAnnotation);
+    void requestSetCardCounterDialog(int counterId, const QString &oldValueForDlg);
+    void requestZoneViewToggle(const QString &zoneName, int numberCards, bool isReversed = false);
+    void requestSortHand(const QList<CardList::SortOption> &options);
+    void requestEnableAndSetCreateAnotherTokenAction(const QString &lastTokenName);
+    void requestSetLastToken(CardInfoPtr lastToken);
+
 public slots:
     void setLastToken(CardInfoPtr cardInfo);
+    void setLastTokenInfo(CardInfoPtr cardInfo);
     void playCard(CardItem *c, bool faceDown);
     void playCardToTable(const CardItem *c, bool faceDown);
 
     void actUntapAll();
-    void actRollDie();
+    void actRequestRollDieDialog();
+    void actRollDie(int sides, int count);
     void actFlipCoin();
-    void actCreateToken();
+    void actRequestCreateTokenDialog(const QStringList &predefinedTokens);
+    void actCreateToken(TokenInfo tokenToCreate);
     void actCreateAnotherToken();
+    void actRequestCreateRelatedFromRelationDialog(const CardItem *sourceCard, const CardRelation *cardRelation);
+    void createRelatedFromRelation(const CardItem *sourceCard, const CardRelation *cardRelation, int variableCount);
+    void onRelatedCardCreated(const CardItem *sourceCard, const CardRelation *cardRelation);
     void actShuffle();
-    void actShuffleTop();
-    void actShuffleBottom();
+    void actRequestShuffleTopDialog();
+    void actShuffleTop(int number);
+    void actRequestShuffleBottomDialog();
+    void actShuffleBottom(int number);
     void actDrawCard();
-    void actDrawCards();
+    void actRequestDrawCardsDialog();
+    void actDrawCards(int number);
     void actUndoDraw();
-    void actMulligan();
+    void actRequestMulliganDialog();
+    void actMulligan(int number);
     void actMulliganSameSize();
     void actMulliganMinusOne();
     void doMulligan(int number);
 
-    void actPlay();
-    void actPlayFacedown();
-    void actHide();
+    void actPlay(QList<CardItem *> selectedCards);
+    void actPlayFacedown(QList<CardItem *> selectedCards);
+    void actHide(QList<CardItem *> selectedCards);
 
     void actMoveTopCardToPlay();
     void actMoveTopCardToPlayFaceDown();
@@ -89,10 +131,14 @@ public slots:
     void actMoveTopCardsToGraveFaceDown();
     void actMoveTopCardsToExile();
     void actMoveTopCardsToExileFaceDown();
-    void actMoveTopCardsUntil();
+    void actRequestMoveTopCardsUntilDialog();
+    void moveTopCardsUntil(const QString &expr, MoveTopCardsUntilOptions options);
     void actMoveTopCardToBottom();
+    void actRequestMoveTopCardsToDialog(const QString &targetZone, const QString &zoneDisplayName, bool faceDown);
+    void moveTopCardsTo(int number, const QString &targetZone, bool faceDown);
     void actDrawBottomCard();
-    void actDrawBottomCards();
+    void actRequestDrawBottomCardsDialog();
+    void actDrawBottomCards(int number);
     void actMoveBottomCardToPlay();
     void actMoveBottomCardToPlayFaceDown();
     void actMoveBottomCardToGrave();
@@ -102,6 +148,8 @@ public slots:
     void actMoveBottomCardsToExile();
     void actMoveBottomCardsToExileFaceDown();
     void actMoveBottomCardToTop();
+    void actRequestMoveBottomCardsToDialog(const QString &targetZone, const QString &zoneDisplayName, bool faceDown);
+    void moveBottomCardsTo(int number, const QString &targetZone, bool faceDown);
 
     void actSelectAll();
     void actSelectRow();
@@ -109,10 +157,12 @@ public slots:
 
     void actViewLibrary();
     void actViewHand();
-    void actViewTopCards();
-    void actViewBottomCards();
-    void actAlwaysRevealTopCard();
-    void actAlwaysLookAtTopCard();
+    void actRequestViewTopCardsDialog();
+    void actViewTopCards(int number);
+    void actRequestViewBottomCardsDialog();
+    void actViewBottomCards(int number);
+    void actAlwaysRevealTopCard(bool alwaysRevealTopCard);
+    void actAlwaysLookAtTopCard(bool alwaysRevealTopCard);
     void actViewGraveyard();
     void actLendLibrary(int lendToPlayerId);
     void actRevealTopCards(int revealToPlayerId, int amount);
@@ -127,37 +177,41 @@ public slots:
     void actCreateRelatedCard();
     void actCreateAllRelatedCards();
 
-    void actMoveCardXCardsFromTop();
-    void actRemoveCardCounter(int counterId);
-    void actAddCardCounter(int counterId);
-    void actSetCardCounter(int counterId);
+    void actRequestMoveCardXCardsFromTopDialog();
+    void actMoveCardXCardsFromTop(QList<CardItem *> selectedCards, int number);
+    void actRemoveCardCounter(QList<CardItem *> selectedCards, int counterId);
+    void actAddCardCounter(QList<CardItem *> selectedCards, int counterId);
+    void actRequestSetCardCounterDialog(QList<CardItem *> selectedCards, int counterId);
+    void actSetCardCounter(QList<CardItem *> selectedCards, int counterId, const QString &counterValue);
     void actIncrementAllCardCounters();
     void actAttach();
-    void actUnattach();
+    void actUnattach(QList<CardItem *> selectedCards);
     void actDrawArrow();
-    void actIncPT(int deltaP, int deltaT);
-    void actResetPT();
-    void actSetPT();
-    void actIncP();
-    void actDecP();
-    void actIncT();
-    void actDecT();
-    void actIncPT();
-    void actDecPT();
-    void actFlowP();
-    void actFlowT();
+    void actIncPT(QList<CardItem *> selectedCards, int deltaP, int deltaT);
+    void actResetPT(QList<CardItem *> selectedCards);
+    void actRequestSetPTDialog(QList<CardItem *> selectedCards);
+    void actSetPT(QList<CardItem *> selectedCards, const QString &pt);
+    void actIncP(QList<CardItem *> selectedCards);
+    void actDecP(QList<CardItem *> selectedCards);
+    void actIncT(QList<CardItem *> selectedCards);
+    void actDecT(QList<CardItem *> selectedCards);
+    void actIncPT(QList<CardItem *> selectedCards);
+    void actDecPT(QList<CardItem *> selectedCards);
+    void actFlowP(QList<CardItem *> selectedCards);
+    void actFlowT(QList<CardItem *> selectedCards);
 
-    void actReduceLifeByPower();
+    void actReduceLifeByPower(QList<CardItem *> selectedCards);
 
-    void actSetAnnotation();
-    void actReveal(QAction *action);
+    void actRequestSetAnnotationDialog(QList<CardItem *> selectedCards);
+    void actSetAnnotation(QList<CardItem *> selectedCards, const QString &annotation);
+    void actReveal(QList<CardItem *> selectedCards, QAction *action);
     void actRevealHand(int revealToPlayerId);
     void actRevealRandomHandCard(int revealToPlayerId);
     void actRevealLibrary(int revealToPlayerId);
 
     void actSortHand();
 
-    void cardMenuAction();
+    void cardMenuAction(QList<CardItem *> selectedCards, CardMenuActionType type);
 
 private:
     PlayerLogic *player;
@@ -176,21 +230,17 @@ private:
     int movingCardsUntilCounter = 0;
     MoveTopCardsUntilOptions movingCardsUntilOptions;
 
-    void moveTopCardsTo(const QString &targetZone, const QString &zoneDisplayName, bool faceDown);
-    void moveBottomCardsTo(const QString &targetZone, const QString &zoneDisplayName, bool faceDown);
-
     void createCard(const CardItem *sourceCard,
                     const QString &dbCardName,
                     CardRelationType attach = CardRelationType::DoesNotAttach,
                     bool persistent = false);
-    bool createRelatedFromRelation(const CardItem *sourceCard, const CardRelation *cardRelation);
 
-    void playSelectedCards(bool faceDown = false);
+    void playSelectedCards(QList<CardItem *> selectedCards, bool faceDown = false);
 
     void cmdSetTopCard(Command_MoveCard &cmd);
     void cmdSetBottomCard(Command_MoveCard &cmd);
 
-    void offsetCardCounter(int counterId, int offset);
+    void offsetCardCounter(QList<CardItem *> selectedCards, int counterId, int offset);
 };
 
 #endif // COCKATRICE_PLAYER_ACTIONS_H

--- a/cockatrice/src/game/player/player_actions.h
+++ b/cockatrice/src/game/player/player_actions.h
@@ -183,7 +183,7 @@ public slots:
     void actAddCardCounter(QList<CardItem *> selectedCards, int counterId);
     void actRequestSetCardCounterDialog(QList<CardItem *> selectedCards, int counterId);
     void actSetCardCounter(QList<CardItem *> selectedCards, int counterId, const QString &counterValue);
-    void actIncrementAllCardCounters();
+    void actIncrementAllCardCounters(QList<CardItem *> cardsToUpdate);
     void actAttach();
     void actUnattach(QList<CardItem *> selectedCards);
     void actDrawArrow();

--- a/cockatrice/src/game/player/player_dialogs.cpp
+++ b/cockatrice/src/game/player/player_dialogs.cpp
@@ -9,8 +9,8 @@
 #include <QInputDialog>
 #include <libcockatrice/card/relation/card_relation.h>
 
-PlayerDialogs::PlayerDialogs(PlayerGraphicsItem *_player, QWidget *_dialogParent, PlayerActions *_playerActions)
-    : QObject(_player), player(_player), dialogParent(_dialogParent), playerActions(_playerActions)
+PlayerDialogs::PlayerDialogs(PlayerGraphicsItem *_player, PlayerActions *_playerActions)
+    : QObject(_player), player(_player), playerActions(_playerActions)
 {
     connect(playerActions, &PlayerActions::requestViewTopCardsDialog, this,
             &PlayerDialogs::onViewTopCardsDialogRequested);
@@ -62,7 +62,7 @@ PlayerDialogs::PlayerDialogs(PlayerGraphicsItem *_player, QWidget *_dialogParent
 void PlayerDialogs::onViewTopCardsDialogRequested(int defaultNumberTopCards, int deckSize)
 {
     bool ok;
-    int number = QInputDialog::getInt(dialogParent, tr("View top cards of library"),
+    int number = QInputDialog::getInt(dialogParent(), tr("View top cards of library"),
                                       tr("Number of cards: (max. %1)").arg(deckSize), defaultNumberTopCards, 1,
                                       deckSize, 1, &ok);
     if (ok) {
@@ -73,7 +73,7 @@ void PlayerDialogs::onViewTopCardsDialogRequested(int defaultNumberTopCards, int
 void PlayerDialogs::onViewBottomCardsDialogRequested(int defaultNumberBottomCards, int deckSize)
 {
     bool ok;
-    int number = QInputDialog::getInt(dialogParent, tr("View bottom cards of library"),
+    int number = QInputDialog::getInt(dialogParent(), tr("View bottom cards of library"),
                                       tr("Number of cards: (max. %1)").arg(deckSize), defaultNumberBottomCards, 1,
                                       deckSize, 1, &ok);
     if (ok) {
@@ -84,7 +84,7 @@ void PlayerDialogs::onViewBottomCardsDialogRequested(int defaultNumberBottomCard
 void PlayerDialogs::onShuffleTopDialogRequested(int defaultNumberTopCards, int maxCards)
 {
     bool ok;
-    int number = QInputDialog::getInt(dialogParent, tr("Shuffle top cards of library"),
+    int number = QInputDialog::getInt(dialogParent(), tr("Shuffle top cards of library"),
                                       tr("Number of cards: (max. %1)").arg(maxCards), defaultNumberTopCards, 1,
                                       maxCards, 1, &ok);
     if (ok) {
@@ -95,7 +95,7 @@ void PlayerDialogs::onShuffleTopDialogRequested(int defaultNumberTopCards, int m
 void PlayerDialogs::onShuffleBottomDialogRequested(int defaultNumberBottomCards, int maxCards)
 {
     bool ok;
-    int number = QInputDialog::getInt(dialogParent, tr("Shuffle bottom cards of library"),
+    int number = QInputDialog::getInt(dialogParent(), tr("Shuffle bottom cards of library"),
                                       tr("Number of cards: (max. %1)").arg(maxCards), defaultNumberBottomCards, 1,
                                       maxCards, 1, &ok);
     if (ok) {
@@ -106,7 +106,7 @@ void PlayerDialogs::onShuffleBottomDialogRequested(int defaultNumberBottomCards,
 void PlayerDialogs::onMulliganDialogRequested(int startSize, int handSize, int deckSize)
 {
     bool ok;
-    int number = QInputDialog::getInt(dialogParent, tr("Draw hand"),
+    int number = QInputDialog::getInt(dialogParent(), tr("Draw hand"),
                                       tr("Number of cards: (max. %1)").arg(deckSize) + '\n' +
                                           tr("0 and lower are in comparison to current hand size"),
                                       startSize, -handSize, deckSize, 1, &ok);
@@ -119,7 +119,7 @@ void PlayerDialogs::onMulliganDialogRequested(int startSize, int handSize, int d
 void PlayerDialogs::onDrawCardsDialogRequested(int defaultNumberTopCards, int deckSize)
 {
     bool ok;
-    int number = QInputDialog::getInt(dialogParent, tr("Draw cards"), tr("Number of cards: (max. %1)").arg(deckSize),
+    int number = QInputDialog::getInt(dialogParent(), tr("Draw cards"), tr("Number of cards: (max. %1)").arg(deckSize),
                                       defaultNumberTopCards, 1, deckSize, 1, &ok);
 
     if (ok) {
@@ -134,7 +134,7 @@ void PlayerDialogs::onMoveTopCardsToDialogRequested(int defaultNumberTopCards,
                                                     bool faceDown)
 {
     bool ok;
-    int number = QInputDialog::getInt(dialogParent, tr("Move top cards to %1").arg(zoneDisplayName),
+    int number = QInputDialog::getInt(dialogParent(), tr("Move top cards to %1").arg(zoneDisplayName),
                                       tr("Number of cards: (max. %1)").arg(maxCards), defaultNumberTopCards, 1,
                                       maxCards, 1, &ok);
     if (ok) {
@@ -144,7 +144,7 @@ void PlayerDialogs::onMoveTopCardsToDialogRequested(int defaultNumberTopCards,
 
 void PlayerDialogs::onMoveTopCardsUntilDialogRequested(MoveTopCardsUntilOptions options)
 {
-    DlgMoveTopCardsUntil dlg(dialogParent, options);
+    DlgMoveTopCardsUntil dlg(dialogParent(), options);
     if (!dlg.exec()) {
         return;
     }
@@ -158,7 +158,7 @@ void PlayerDialogs::onMoveBottomCardsToDialogRequested(int defaultNumberBottomCa
                                                        bool faceDown)
 {
     bool ok;
-    int number = QInputDialog::getInt(dialogParent, tr("Move bottom cards to %1").arg(zoneDisplayName),
+    int number = QInputDialog::getInt(dialogParent(), tr("Move bottom cards to %1").arg(zoneDisplayName),
                                       tr("Number of cards: (max. %1)").arg(maxCards), defaultNumberBottomCards, 1,
                                       maxCards, 1, &ok);
     if (ok) {
@@ -170,7 +170,7 @@ void PlayerDialogs::onDrawBottomCardsDialogRequested(int defaultNumberBottomCard
 {
     bool ok;
     int number =
-        QInputDialog::getInt(dialogParent, tr("Draw bottom cards"), tr("Number of cards: (max. %1)").arg(maxCards),
+        QInputDialog::getInt(dialogParent(), tr("Draw bottom cards"), tr("Number of cards: (max. %1)").arg(maxCards),
                              defaultNumberBottomCards, 1, maxCards, 1, &ok);
     if (ok) {
         playerActions->actDrawBottomCards(number);
@@ -179,7 +179,7 @@ void PlayerDialogs::onDrawBottomCardsDialogRequested(int defaultNumberBottomCard
 
 void PlayerDialogs::onRollDieDialogRequested()
 {
-    DlgRollDice dlg(dialogParent);
+    DlgRollDice dlg(dialogParent());
     if (!dlg.exec()) {
         return;
     }
@@ -200,7 +200,7 @@ void PlayerDialogs::onCreateRelatedFromRelationDialogRequested(const CardItem *s
 
         emit requestDialogSemaphore(true);
 
-        variableCount = QInputDialog::getInt(dialogParent, tr("Create tokens"), tr("Number:"),
+        variableCount = QInputDialog::getInt(dialogParent(), tr("Create tokens"), tr("Number:"),
                                              cardRelation->getDefaultCount(), 1, MAX_TOKENS_PER_DIALOG, 1, &ok);
 
         emit requestDialogSemaphore(false);
@@ -217,7 +217,7 @@ void PlayerDialogs::onCreateRelatedFromRelationDialogRequested(const CardItem *s
 
 void PlayerDialogs::onCreateTokenDialogRequested(const QStringList &predefinedTokens)
 {
-    DlgCreateToken dlg(predefinedTokens, dialogParent);
+    DlgCreateToken dlg(predefinedTokens, dialogParent());
     if (!dlg.exec()) {
         return;
     }
@@ -229,7 +229,7 @@ void PlayerDialogs::onMoveCardXCardsFromTopDialogRequested(int defaultNumberTopC
 {
     bool ok;
     int number =
-        QInputDialog::getInt(dialogParent, tr("Place card X cards from top of library"),
+        QInputDialog::getInt(dialogParent(), tr("Place card X cards from top of library"),
                              tr("Which position should this card be placed:") + "\n" + tr("(max. %1)").arg(deckSize),
                              defaultNumberTopCardsToPlaceBelow, 1, deckSize, 1, &ok);
     number -= 1; // indexes start at 0
@@ -243,7 +243,7 @@ void PlayerDialogs::onSetPTDialogRequested(const QString &oldPT)
 {
     bool ok;
     emit requestDialogSemaphore(true);
-    QString pt = getTextWithMax(dialogParent, tr("Change power/toughness"), tr("Change stats to:"), QLineEdit::Normal,
+    QString pt = getTextWithMax(dialogParent(), tr("Change power/toughness"), tr("Change stats to:"), QLineEdit::Normal,
                                 oldPT, &ok);
     emit requestDialogSemaphore(false);
 
@@ -257,7 +257,7 @@ void PlayerDialogs::onSetPTDialogRequested(const QString &oldPT)
 void PlayerDialogs::onSetAnnotationDialogRequested(const QString &oldAnnotation)
 {
     emit requestDialogSemaphore(true);
-    AnnotationDialog *dialog = new AnnotationDialog(dialogParent);
+    AnnotationDialog *dialog = new AnnotationDialog(dialogParent());
     dialog->setOptions(QInputDialog::UsePlainTextEditForTextInput);
     dialog->setWindowTitle(tr("Set annotation"));
     dialog->setLabelText(tr("Please enter the new annotation:"));
@@ -278,7 +278,7 @@ void PlayerDialogs::onSetCardCounterDialogRequested(int counterId, const QString
     auto &cardCounterSettings = SettingsCache::instance().cardCounters();
     QString counterName = cardCounterSettings.displayName(counterId);
 
-    AbstractCounterDialog dialog(counterName, oldValueForDlg, dialogParent);
+    AbstractCounterDialog dialog(counterName, oldValueForDlg, dialogParent());
     int ok = dialog.exec();
 
     emit requestDialogSemaphore(false);

--- a/cockatrice/src/game/player/player_dialogs.cpp
+++ b/cockatrice/src/game/player/player_dialogs.cpp
@@ -147,7 +147,7 @@ void PlayerDialogs::onMoveTopCardsUntilDialogRequested(MoveTopCardsUntilOptions 
     if (!dlg.exec()) {
         return;
     }
-    playerActions->moveTopCardsUntil(dlg.getExpr(), options);
+    playerActions->moveTopCardsUntil(dlg.getExpr(), dlg.getOptions());
 }
 
 void PlayerDialogs::onMoveBottomCardsToDialogRequested(int defaultNumberBottomCards,

--- a/cockatrice/src/game/player/player_dialogs.cpp
+++ b/cockatrice/src/game/player/player_dialogs.cpp
@@ -4,6 +4,7 @@
 #include "../board/card_item.h"
 #include "../client/settings/card_counter_settings.h"
 #include "../dialogs/dlg_roll_dice.h"
+#include "../player/player_graphics_item.h"
 
 #include <QInputDialog>
 #include <libcockatrice/card/relation/card_relation.h>

--- a/cockatrice/src/game/player/player_dialogs.cpp
+++ b/cockatrice/src/game/player/player_dialogs.cpp
@@ -1,11 +1,12 @@
 #include "player_dialogs.h"
 
 #include "../../interface/widgets/utility/get_text_with_max.h"
+#include "../board/card_item.h"
 #include "../client/settings/card_counter_settings.h"
 #include "../dialogs/dlg_roll_dice.h"
-#include "libcockatrice/card/relation/card_relation.h"
 
 #include <QInputDialog>
+#include <libcockatrice/card/relation/card_relation.h>
 
 PlayerDialogs::PlayerDialogs(PlayerGraphicsItem *_player, QWidget *_dialogParent, PlayerActions *_playerActions)
     : QObject(_player), player(_player), dialogParent(_dialogParent), playerActions(_playerActions)

--- a/cockatrice/src/game/player/player_dialogs.cpp
+++ b/cockatrice/src/game/player/player_dialogs.cpp
@@ -1,0 +1,286 @@
+#include "player_dialogs.h"
+
+#include "../../interface/widgets/utility/get_text_with_max.h"
+#include "../client/settings/card_counter_settings.h"
+#include "../dialogs/dlg_roll_dice.h"
+#include "libcockatrice/card/relation/card_relation.h"
+
+#include <QInputDialog>
+
+PlayerDialogs::PlayerDialogs(PlayerGraphicsItem *_player, QWidget *_dialogParent, PlayerActions *_playerActions)
+    : QObject(_player), player(_player), dialogParent(_dialogParent), playerActions(_playerActions)
+{
+    connect(playerActions, &PlayerActions::requestViewTopCardsDialog, this,
+            &PlayerDialogs::onViewTopCardsDialogRequested);
+
+    connect(playerActions, &PlayerActions::requestViewBottomCardsDialog, this,
+            &PlayerDialogs::onViewBottomCardsDialogRequested);
+
+    connect(playerActions, &PlayerActions::requestShuffleTopDialog, this, &PlayerDialogs::onShuffleTopDialogRequested);
+
+    connect(playerActions, &PlayerActions::requestShuffleBottomDialog, this,
+            &PlayerDialogs::onShuffleBottomDialogRequested);
+
+    connect(playerActions, &PlayerActions::requestMulliganDialog, this, &PlayerDialogs::onMulliganDialogRequested);
+
+    connect(playerActions, &PlayerActions::requestDrawCardsDialog, this, &PlayerDialogs::onDrawCardsDialogRequested);
+
+    connect(playerActions, &PlayerActions::requestMoveTopCardsToDialog, this,
+            &PlayerDialogs::onMoveTopCardsToDialogRequested);
+
+    connect(playerActions, &PlayerActions::requestMoveTopCardsUntilDialog, this,
+            &PlayerDialogs::onMoveTopCardsUntilDialogRequested);
+
+    connect(playerActions, &PlayerActions::requestMoveBottomCardsToDialog, this,
+            &PlayerDialogs::onMoveBottomCardsToDialogRequested);
+
+    connect(playerActions, &PlayerActions::requestDrawBottomCardsDialog, this,
+            &PlayerDialogs::onDrawBottomCardsDialogRequested);
+
+    connect(playerActions, &PlayerActions::requestRollDieDialog, this, &PlayerDialogs::onRollDieDialogRequested);
+
+    connect(playerActions, &PlayerActions::requestCreateTokenDialog, this,
+            &PlayerDialogs::onCreateTokenDialogRequested);
+
+    connect(playerActions, &PlayerActions::requestCreateRelatedFromRelationDialog, this,
+            &PlayerDialogs::onCreateRelatedFromRelationDialogRequested);
+
+    connect(playerActions, &PlayerActions::requestMoveCardXCardsFromTopDialog, this,
+            &PlayerDialogs::onMoveCardXCardsFromTopDialogRequested);
+
+    connect(playerActions, &PlayerActions::requestSetPTDialog, this, &PlayerDialogs::onSetPTDialogRequested);
+
+    connect(playerActions, &PlayerActions::requestSetAnnotationDialog, this,
+            &PlayerDialogs::onSetAnnotationDialogRequested);
+
+    connect(playerActions, &PlayerActions::requestSetCardCounterDialog, this,
+            &PlayerDialogs::onSetCardCounterDialogRequested);
+}
+
+void PlayerDialogs::onViewTopCardsDialogRequested(int defaultNumberTopCards, int deckSize)
+{
+    bool ok;
+    int number = QInputDialog::getInt(dialogParent, tr("View top cards of library"),
+                                      tr("Number of cards: (max. %1)").arg(deckSize), defaultNumberTopCards, 1,
+                                      deckSize, 1, &ok);
+    if (ok) {
+        playerActions->actViewTopCards(number);
+    }
+}
+
+void PlayerDialogs::onViewBottomCardsDialogRequested(int defaultNumberBottomCards, int deckSize)
+{
+    bool ok;
+    int number = QInputDialog::getInt(dialogParent, tr("View bottom cards of library"),
+                                      tr("Number of cards: (max. %1)").arg(deckSize), defaultNumberBottomCards, 1,
+                                      deckSize, 1, &ok);
+    if (ok) {
+        playerActions->actViewBottomCards(number);
+    }
+}
+
+void PlayerDialogs::onShuffleTopDialogRequested(int defaultNumberTopCards, int maxCards)
+{
+    bool ok;
+    int number = QInputDialog::getInt(dialogParent, tr("Shuffle top cards of library"),
+                                      tr("Number of cards: (max. %1)").arg(maxCards), defaultNumberTopCards, 1,
+                                      maxCards, 1, &ok);
+    if (ok) {
+        playerActions->actShuffleTop(number);
+    }
+}
+
+void PlayerDialogs::onShuffleBottomDialogRequested(int defaultNumberBottomCards, int maxCards)
+{
+    bool ok;
+    int number = QInputDialog::getInt(dialogParent, tr("Shuffle bottom cards of library"),
+                                      tr("Number of cards: (max. %1)").arg(maxCards), defaultNumberBottomCards, 1,
+                                      maxCards, 1, &ok);
+    if (!ok) {
+        playerActions->actShuffleBottom(number);
+    }
+}
+
+void PlayerDialogs::onMulliganDialogRequested(int startSize, int handSize, int deckSize)
+{
+    bool ok;
+    int number = QInputDialog::getInt(dialogParent, tr("Draw hand"),
+                                      tr("Number of cards: (max. %1)").arg(deckSize) + '\n' +
+                                          tr("0 and lower are in comparison to current hand size"),
+                                      startSize, -handSize, deckSize, 1, &ok);
+
+    if (ok) {
+        playerActions->actMulligan(number);
+    }
+}
+
+void PlayerDialogs::onDrawCardsDialogRequested(int defaultNumberTopCards, int deckSize)
+{
+    bool ok;
+    int number = QInputDialog::getInt(dialogParent, tr("Draw cards"), tr("Number of cards: (max. %1)").arg(deckSize),
+                                      defaultNumberTopCards, 1, deckSize, 1, &ok);
+
+    if (ok) {
+        playerActions->actDrawCards(number);
+    }
+}
+
+void PlayerDialogs::onMoveTopCardsToDialogRequested(int defaultNumberTopCards,
+                                                    int maxCards,
+                                                    const QString &targetZone,
+                                                    const QString &zoneDisplayName,
+                                                    bool faceDown)
+{
+    bool ok;
+    int number = QInputDialog::getInt(dialogParent, tr("Move top cards to %1").arg(zoneDisplayName),
+                                      tr("Number of cards: (max. %1)").arg(maxCards), defaultNumberTopCards, 1,
+                                      maxCards, 1, &ok);
+    if (ok) {
+        playerActions->moveTopCardsTo(number, targetZone, faceDown);
+    }
+}
+
+void PlayerDialogs::onMoveTopCardsUntilDialogRequested(MoveTopCardsUntilOptions options)
+{
+    DlgMoveTopCardsUntil dlg(dialogParent, options);
+    if (!dlg.exec()) {
+        return;
+    }
+    playerActions->moveTopCardsUntil(dlg.getExpr(), options);
+}
+
+void PlayerDialogs::onMoveBottomCardsToDialogRequested(int defaultNumberBottomCards,
+                                                       int maxCards,
+                                                       const QString &targetZone,
+                                                       const QString &zoneDisplayName,
+                                                       bool faceDown)
+{
+    bool ok;
+    int number = QInputDialog::getInt(dialogParent, tr("Move bottom cards to %1").arg(zoneDisplayName),
+                                      tr("Number of cards: (max. %1)").arg(maxCards), defaultNumberBottomCards, 1,
+                                      maxCards, 1, &ok);
+    if (ok) {
+        playerActions->moveBottomCardsTo(number, targetZone, faceDown);
+    }
+}
+
+void PlayerDialogs::onDrawBottomCardsDialogRequested(int defaultNumberBottomCards, int maxCards)
+{
+    bool ok;
+    int number =
+        QInputDialog::getInt(dialogParent, tr("Draw bottom cards"), tr("Number of cards: (max. %1)").arg(maxCards),
+                             defaultNumberBottomCards, 1, maxCards, 1, &ok);
+    if (ok) {
+        playerActions->actDrawBottomCards(number);
+    }
+}
+
+void PlayerDialogs::onRollDieDialogRequested()
+{
+    DlgRollDice dlg(dialogParent);
+    if (!dlg.exec()) {
+        return;
+    }
+    playerActions->actRollDie(dlg.getDieSideCount(), dlg.getDiceToRollCount());
+}
+
+void PlayerDialogs::onCreateRelatedFromRelationDialogRequested(const CardItem *sourceCard,
+                                                               const CardRelation *cardRelation)
+{
+    if (sourceCard == nullptr || cardRelation == nullptr) {
+        return;
+    }
+
+    int variableCount = cardRelation->getDefaultCount();
+
+    if (cardRelation->getIsVariable()) {
+        bool ok;
+
+        emit requestDialogSemaphore(true);
+
+        variableCount = QInputDialog::getInt(dialogParent, tr("Create tokens"), tr("Number:"),
+                                             cardRelation->getDefaultCount(), 1, MAX_TOKENS_PER_DIALOG, 1, &ok);
+
+        emit requestDialogSemaphore(false);
+
+        if (!ok) {
+            return;
+        }
+    }
+
+    playerActions->createRelatedFromRelation(sourceCard, cardRelation, variableCount);
+
+    playerActions->onRelatedCardCreated(sourceCard, cardRelation);
+}
+
+void PlayerDialogs::onCreateTokenDialogRequested(const QStringList &predefinedTokens)
+{
+    DlgCreateToken dlg(predefinedTokens, dialogParent);
+    if (!dlg.exec()) {
+        return;
+    }
+
+    playerActions->actCreateToken(dlg.getTokenInfo());
+}
+
+void PlayerDialogs::onMoveCardXCardsFromTopDialogRequested(int defaultNumberTopCardsToPlaceBelow, int deckSize)
+{
+    bool ok;
+    int number =
+        QInputDialog::getInt(dialogParent, tr("Place card X cards from top of library"),
+                             tr("Which position should this card be placed:") + "\n" + tr("(max. %1)").arg(deckSize),
+                             defaultNumberTopCardsToPlaceBelow, 1, deckSize, 1, &ok);
+    number -= 1; // indexes start at 0
+
+    if (ok) {
+        playerActions->actMoveCardXCardsFromTop(player->getGameScene()->selectedCards(), number);
+    }
+}
+
+void PlayerDialogs::onSetPTDialogRequested(const QString &oldPT)
+{
+    bool ok;
+    emit requestDialogSemaphore(true);
+    QString pt = getTextWithMax(dialogParent, tr("Change power/toughness"), tr("Change stats to:"), QLineEdit::Normal,
+                                oldPT, &ok);
+    emit requestDialogSemaphore(false);
+
+    if (!ok) { // player->clearCardsToDelete() ||
+        return;
+    }
+
+    playerActions->actSetPT(player->getGameScene()->selectedCards(), pt);
+}
+
+void PlayerDialogs::onSetAnnotationDialogRequested(const QString &oldAnnotation)
+{
+    emit requestDialogSemaphore(true);
+    AnnotationDialog *dialog = new AnnotationDialog(dialogParent);
+    dialog->setOptions(QInputDialog::UsePlainTextEditForTextInput);
+    dialog->setWindowTitle(tr("Set annotation"));
+    dialog->setLabelText(tr("Please enter the new annotation:"));
+    dialog->setTextValue(oldAnnotation);
+    bool ok = dialog->exec();
+    emit requestDialogSemaphore(false);
+    if (!ok) { // player->clearCardsToDelete() ||
+        return;
+    }
+    QString annotation = dialog->textValue().left(MAX_NAME_LENGTH);
+}
+
+void PlayerDialogs::onSetCardCounterDialogRequested(int counterId, const QString &oldValueForDlg)
+{
+    emit requestDialogSemaphore(true);
+
+    auto &cardCounterSettings = SettingsCache::instance().cardCounters();
+    QString counterName = cardCounterSettings.displayName(counterId);
+
+    AbstractCounterDialog dialog(counterName, oldValueForDlg, dialogParent);
+    int ok = dialog.exec();
+
+    emit requestDialogSemaphore(false);
+    if (!ok) { // player->clearCardsToDelete() ||
+        return;
+    }
+    playerActions->actSetCardCounter(player->getGameScene()->selectedCards(), counterId, dialog.textValue());
+}

--- a/cockatrice/src/game/player/player_dialogs.cpp
+++ b/cockatrice/src/game/player/player_dialogs.cpp
@@ -97,7 +97,7 @@ void PlayerDialogs::onShuffleBottomDialogRequested(int defaultNumberBottomCards,
     int number = QInputDialog::getInt(dialogParent, tr("Shuffle bottom cards of library"),
                                       tr("Number of cards: (max. %1)").arg(maxCards), defaultNumberBottomCards, 1,
                                       maxCards, 1, &ok);
-    if (!ok) {
+    if (ok) {
         playerActions->actShuffleBottom(number);
     }
 }

--- a/cockatrice/src/game/player/player_dialogs.cpp
+++ b/cockatrice/src/game/player/player_dialogs.cpp
@@ -267,6 +267,7 @@ void PlayerDialogs::onSetAnnotationDialogRequested(const QString &oldAnnotation)
         return;
     }
     QString annotation = dialog->textValue().left(MAX_NAME_LENGTH);
+    playerActions->actSetAnnotation(player->getGameScene()->selectedCards(), annotation);
 }
 
 void PlayerDialogs::onSetCardCounterDialogRequested(int counterId, const QString &oldValueForDlg)

--- a/cockatrice/src/game/player/player_dialogs.h
+++ b/cockatrice/src/game/player/player_dialogs.h
@@ -1,0 +1,51 @@
+#ifndef COCKATRICE_PLAYER_DIALOGS_H
+#define COCKATRICE_PLAYER_DIALOGS_H
+#include "player_actions.h"
+
+#include <QObject>
+
+class PlayerDialogs : public QObject
+{
+
+    Q_OBJECT
+
+public:
+    explicit PlayerDialogs(PlayerGraphicsItem *player, QWidget *dialogParent, PlayerActions *playerActions);
+
+signals:
+    void requestDialogSemaphore(bool active);
+
+public slots:
+    void onViewTopCardsDialogRequested(int defaultNumberTopCards, int deckSize);
+    void onViewBottomCardsDialogRequested(int defaultNumberBottomCards, int deckSize);
+    void onShuffleTopDialogRequested(int defaultNumberTopCards, int maxCards);
+    void onShuffleBottomDialogRequested(int defaultNumberBottomCards, int maxCards);
+    void onMulliganDialogRequested(int startSize, int handSize, int deckSize);
+    void onDrawCardsDialogRequested(int defaultNumberTopCards, int deckSize);
+    void onMoveTopCardsToDialogRequested(int defaultNumberTopCards,
+                                         int maxCards,
+                                         const QString &targetZone,
+                                         const QString &zoneDisplayName,
+                                         bool faceDown);
+    void onMoveTopCardsUntilDialogRequested(MoveTopCardsUntilOptions options);
+    void onMoveBottomCardsToDialogRequested(int defaultNumberBottomCards,
+                                            int maxCards,
+                                            const QString &targetZone,
+                                            const QString &zoneDisplayName,
+                                            bool faceDown);
+    void onDrawBottomCardsDialogRequested(int defaultNumberBottomCards, int maxCards);
+    void onRollDieDialogRequested();
+    void onCreateRelatedFromRelationDialogRequested(const CardItem *sourceCard, const CardRelation *cardRelation);
+    void onCreateTokenDialogRequested(const QStringList &predefinedTokens);
+    void onMoveCardXCardsFromTopDialogRequested(int defaultNumberTopCardsToPlaceBelow, int deckSize);
+    void onSetPTDialogRequested(const QString &oldPT);
+    void onSetAnnotationDialogRequested(const QString &oldAnnotation);
+    void onSetCardCounterDialogRequested(int counterId, const QString &oldValueForDlg);
+
+private:
+    PlayerGraphicsItem *player;
+    QWidget *dialogParent;
+    PlayerActions *playerActions;
+};
+
+#endif // COCKATRICE_PLAYER_DIALOGS_H

--- a/cockatrice/src/game/player/player_dialogs.h
+++ b/cockatrice/src/game/player/player_dialogs.h
@@ -2,6 +2,7 @@
 #define COCKATRICE_PLAYER_DIALOGS_H
 #include "player_actions.h"
 
+#include <QGraphicsView>
 #include <QObject>
 
 class PlayerDialogs : public QObject
@@ -10,7 +11,7 @@ class PlayerDialogs : public QObject
     Q_OBJECT
 
 public:
-    explicit PlayerDialogs(PlayerGraphicsItem *player, QWidget *dialogParent, PlayerActions *playerActions);
+    explicit PlayerDialogs(PlayerGraphicsItem *player, PlayerActions *playerActions);
 
 signals:
     void requestDialogSemaphore(bool active);
@@ -44,8 +45,17 @@ public slots:
 
 private:
     PlayerGraphicsItem *player;
-    QWidget *dialogParent;
     PlayerActions *playerActions;
+
+    QWidget *dialogParent() const
+    {
+        if (auto *s = player->scene()) {
+            if (auto *v = s->views().value(0)) {
+                return v->window();
+            }
+        }
+        return nullptr;
+    }
 };
 
 #endif // COCKATRICE_PLAYER_DIALOGS_H

--- a/cockatrice/src/game/player/player_dialogs.h
+++ b/cockatrice/src/game/player/player_dialogs.h
@@ -5,6 +5,7 @@
 #include <QGraphicsView>
 #include <QObject>
 
+class PlayerGraphicsItem;
 class PlayerDialogs : public QObject
 {
 

--- a/cockatrice/src/game/player/player_event_handler.cpp
+++ b/cockatrice/src/game/player/player_event_handler.cpp
@@ -37,6 +37,7 @@
 
 PlayerEventHandler::PlayerEventHandler(PlayerLogic *_player) : QObject(_player), player(_player)
 {
+    connect(this, &PlayerEventHandler::requestCardMenuUpdate, player, &PlayerLogic::requestCardMenuUpdate);
 }
 
 void PlayerEventHandler::eventGameSay(const Event_GameSay &event)
@@ -255,7 +256,7 @@ void PlayerEventHandler::eventSetCardCounter(const Event_SetCardCounter &event)
 
     int oldValue = card->getCounters().value(event.counter_id(), 0);
     card->setCounter(event.counter_id(), event.counter_value());
-    player->getPlayerMenu()->updateCardMenu(card);
+    emit requestCardMenuUpdate(card);
     emit logSetCardCounter(player, card->getName(), event.counter_id(), event.counter_value(), oldValue);
 }
 
@@ -373,7 +374,7 @@ void PlayerEventHandler::eventMoveCard(const Event_MoveCard &event, const GameEv
     targetZone->addCard(card, true, x, y);
 
     emit cardZoneChanged(card, startZone == targetZone);
-    player->getPlayerMenu()->updateCardMenu(card);
+    emit requestCardMenuUpdate(card);
 
     if (player->getPlayerActions()->isMovingCardsUntil() && startZoneString == ZoneNames::DECK &&
         targetZone->getName() == ZoneNames::STACK) {
@@ -400,7 +401,7 @@ void PlayerEventHandler::eventFlipCard(const Event_FlipCard &event)
 
     emit logFlipCard(player, card->getName(), event.face_down());
     card->setFaceDown(event.face_down());
-    player->getPlayerMenu()->updateCardMenu(card);
+    emit requestCardMenuUpdate(card);
 }
 
 void PlayerEventHandler::eventDestroyCard(const Event_DestroyCard &event)
@@ -469,7 +470,7 @@ void PlayerEventHandler::eventAttachCard(const Event_AttachCard &event)
     } else {
         emit logUnattachCard(player, startCard->getName());
     }
-    player->getPlayerMenu()->updateCardMenu(startCard);
+    emit requestCardMenuUpdate(startCard);
 }
 
 void PlayerEventHandler::eventDrawCards(const Event_DrawCards &event)
@@ -555,7 +556,7 @@ void PlayerEventHandler::eventRevealCards(const Event_RevealCards &event, EventP
         }
 
         if (!options.testFlag(SKIP_REVEAL_WINDOW) && showZoneView && !cardList.isEmpty()) {
-            player->getGameScene()->addRevealedZoneView(player, zone, cardList, event.grant_write_access());
+            emit player->requestRevealedZoneView(player, zone, cardList, event.grant_write_access());
         }
 
         emit logRevealCards(player, zone, cardId, cardName, otherPlayer, false,

--- a/cockatrice/src/game/player/player_event_handler.cpp
+++ b/cockatrice/src/game/player/player_event_handler.cpp
@@ -6,7 +6,6 @@
 #include "../board/arrow_item.h"
 #include "../board/card_item.h"
 #include "../board/card_list.h"
-#include "libcockatrice/utility/color.h"
 #include "player_actions.h"
 #include "player_logic.h"
 
@@ -33,6 +32,7 @@
 #include <libcockatrice/protocol/pb/event_set_card_counter.pb.h>
 #include <libcockatrice/protocol/pb/event_set_counter.pb.h>
 #include <libcockatrice/protocol/pb/event_shuffle.pb.h>
+#include <libcockatrice/utility/color.h>
 #include <libcockatrice/utility/zone_names.h>
 
 PlayerEventHandler::PlayerEventHandler(PlayerLogic *_player) : QObject(_player), player(_player)

--- a/cockatrice/src/game/player/player_event_handler.h
+++ b/cockatrice/src/game/player/player_event_handler.h
@@ -83,6 +83,7 @@ signals:
     void logAlwaysRevealTopCard(PlayerLogic *player, CardZoneLogic *zone, bool reveal);
     void logAlwaysLookAtTopCard(PlayerLogic *player, CardZoneLogic *zone, bool reveal);
     void cardZoneChanged(CardItem *card, bool sameZone);
+    void requestCardMenuUpdate(const CardItem *card);
 
 public:
     PlayerEventHandler(PlayerLogic *player);

--- a/cockatrice/src/game/player/player_graphics_item.cpp
+++ b/cockatrice/src/game/player/player_graphics_item.cpp
@@ -8,6 +8,10 @@
 #include "../board/abstract_card_item.h"
 #include "../board/counter_general.h"
 #include "../hand_counter.h"
+#include "player_actions.h"
+#include "player_dialogs.h"
+
+#include <QGraphicsView>
 
 PlayerGraphicsItem::PlayerGraphicsItem(PlayerLogic *_player) : player(_player)
 {
@@ -16,27 +20,37 @@ PlayerGraphicsItem::PlayerGraphicsItem(PlayerLogic *_player) : player(_player)
     connect(&SettingsCache::instance(), &SettingsCache::handJustificationChanged, this,
             &PlayerGraphicsItem::rearrangeZones);
     connect(player, &PlayerLogic::rearrangeCounters, this, &PlayerGraphicsItem::rearrangeCounters);
+    connect(player, &PlayerLogic::activeChanged, this, &PlayerGraphicsItem::onPlayerActiveChanged);
     connect(player, &PlayerLogic::concededChanged, this, [this](int, bool c) { setVisible(!c); });
     connect(player, &PlayerLogic::zoneIdChanged, this, [this](int id) { playerArea->setPlayerZoneId(id); });
 
     connect(player, &PlayerLogic::counterAdded, this, &PlayerGraphicsItem::onCounterAdded);
     connect(player, &PlayerLogic::counterRemoved, this, &PlayerGraphicsItem::onCounterRemoved);
 
-    connect(player->getPlayerMenu(), &PlayerMenu::shortcutsActivated, this, [this]() {
+    playerMenu = new PlayerMenu(this);
+
+    connect(playerMenu, &PlayerMenu::shortcutsActivated, this, [this]() {
         for (auto *ctr : counterWidgets) {
             ctr->setShortcutsActive();
         }
     });
-    connect(player->getPlayerMenu(), &PlayerMenu::shortcutsDeactivated, this, [this]() {
+    connect(playerMenu, &PlayerMenu::shortcutsDeactivated, this, [this]() {
         for (auto *ctr : counterWidgets) {
             ctr->setShortcutsInactive();
         }
     });
-    connect(player->getPlayerMenu(), &PlayerMenu::retranslateRequested, this, [this]() {
+    connect(playerMenu, &PlayerMenu::retranslateRequested, this, [this]() {
         for (auto *ctr : counterWidgets) {
             ctr->retranslateUi();
         }
     });
+
+    QWidget *dialogParent = nullptr;
+    if (auto *view = scene() ? scene()->views().value(0) : nullptr) {
+        dialogParent = view->window();
+    }
+
+    playerDialogs = new PlayerDialogs(this, dialogParent, player->getPlayerActions());
 
     playerArea = new PlayerArea(this);
 
@@ -46,6 +60,8 @@ PlayerGraphicsItem::PlayerGraphicsItem(PlayerLogic *_player) : player(_player)
     playerTarget->setPos(QPointF(avatarMargin, avatarMargin));
 
     initializeZones();
+
+    playerMenu->setMenusForGraphicItems();
 
     connect(tableZoneGraphicsItem, &TableZone::sizeChanged, this, &PlayerGraphicsItem::updateBoundingRect);
 
@@ -57,7 +73,7 @@ PlayerGraphicsItem::PlayerGraphicsItem(PlayerLogic *_player) : player(_player)
 
 void PlayerGraphicsItem::retranslateUi()
 {
-    player->getPlayerMenu()->retranslateUi();
+    playerMenu->retranslateUi();
 
     QMapIterator<QString, CardZoneLogic *> zoneIterator(player->getZones());
     while (zoneIterator.hasNext()) {
@@ -93,14 +109,16 @@ void PlayerGraphicsItem::initializeZones()
     rfgZoneGraphicsItem = new PileZone(player->getRfgZone(), this);
     rfgZoneGraphicsItem->setPos(base + QPointF(0, 2 * h + h2 + 10));
 
-    tableZoneGraphicsItem = new TableZone(player->getTableZone(), this);
+    tableZoneGraphicsItem = new TableZone(player->getTableZone(), mirrored, this);
     connect(tableZoneGraphicsItem, &TableZone::sizeChanged, this, &PlayerGraphicsItem::updateBoundingRect);
+    connect(this, &PlayerGraphicsItem::mirroredChanged, tableZoneGraphicsItem, &TableZone::setMirrored);
 
     stackZoneGraphicsItem =
         new StackZone(player->getStackZone(), static_cast<int>(tableZoneGraphicsItem->boundingRect().height()), this);
 
     handZoneGraphicsItem =
         new HandZone(player->getHandZone(), static_cast<int>(tableZoneGraphicsItem->boundingRect().height()), this);
+    connect(player->getPlayerActions(), &PlayerActions::requestSortHand, handZoneGraphicsItem, &HandZone::sortHand);
 
     connect(handZoneGraphicsItem->getLogic(), &HandZoneLogic::cardCountChanged, handCounter,
             &HandCounter::updateNumber);
@@ -145,6 +163,7 @@ void PlayerGraphicsItem::setMirrored(bool _mirrored)
 {
     if (mirrored != _mirrored) {
         mirrored = _mirrored;
+        emit mirroredChanged(mirrored);
         rearrangeZones();
     }
 }
@@ -159,11 +178,11 @@ void PlayerGraphicsItem::onCounterAdded(CounterState *state)
     }
     counterWidgets.insert(state->getId(), widget);
 
-    if (player->getPlayerMenu()->getCountersMenu() && widget->getMenu()) {
-        player->getPlayerMenu()->getCountersMenu()->addMenu(widget->getMenu());
+    if (playerMenu->getCountersMenu() && widget->getMenu()) {
+        playerMenu->getCountersMenu()->addMenu(widget->getMenu());
     }
 
-    if (player->getPlayerMenu()->getShortcutsActive()) {
+    if (playerMenu->getShortcutsActive()) {
         widget->setShortcutsActive();
     }
 
@@ -176,8 +195,8 @@ void PlayerGraphicsItem::onCounterRemoved(int counterId)
     if (!widget) {
         return;
     }
-    if (player->getPlayerMenu()->getCountersMenu() && widget->getMenu()) {
-        player->getPlayerMenu()->getCountersMenu()->removeAction(widget->getMenu()->menuAction());
+    if (playerMenu->getCountersMenu() && widget->getMenu()) {
+        playerMenu->getCountersMenu()->removeAction(widget->getMenu()->menuAction());
     }
     widget->delCounter();
     rearrangeCounters();

--- a/cockatrice/src/game/player/player_graphics_item.cpp
+++ b/cockatrice/src/game/player/player_graphics_item.cpp
@@ -47,6 +47,8 @@ PlayerGraphicsItem::PlayerGraphicsItem(PlayerLogic *_player) : player(_player)
 
     playerDialogs = new PlayerDialogs(this, player->getPlayerActions());
 
+    connect(playerDialogs, &PlayerDialogs::requestDialogSemaphore, player, &PlayerLogic::setDialogSemaphore);
+
     playerArea = new PlayerArea(this);
 
     playerTarget = new PlayerTarget(player, playerArea);

--- a/cockatrice/src/game/player/player_graphics_item.cpp
+++ b/cockatrice/src/game/player/player_graphics_item.cpp
@@ -45,12 +45,7 @@ PlayerGraphicsItem::PlayerGraphicsItem(PlayerLogic *_player) : player(_player)
         }
     });
 
-    QWidget *dialogParent = nullptr;
-    if (auto *view = scene() ? scene()->views().value(0) : nullptr) {
-        dialogParent = view->window();
-    }
-
-    playerDialogs = new PlayerDialogs(this, dialogParent, player->getPlayerActions());
+    playerDialogs = new PlayerDialogs(this, player->getPlayerActions());
 
     playerArea = new PlayerArea(this);
 

--- a/cockatrice/src/game/player/player_graphics_item.h
+++ b/cockatrice/src/game/player/player_graphics_item.h
@@ -56,7 +56,7 @@ public:
         return static_cast<GameScene *>(scene());
     }
 
-    PlayerLogic *getPlayerLogic() const
+    PlayerLogic *getLogic() const
     {
         return player;
     }

--- a/cockatrice/src/game/player/player_graphics_item.h
+++ b/cockatrice/src/game/player/player_graphics_item.h
@@ -14,6 +14,7 @@
 
 class HandZone;
 class PileZone;
+class PlayerDialogs;
 class PlayerTarget;
 class StackZone;
 class TableZone;
@@ -55,9 +56,14 @@ public:
         return static_cast<GameScene *>(scene());
     }
 
-    PlayerLogic *getPlayer() const
+    PlayerLogic *getPlayerLogic() const
     {
         return player;
+    }
+
+    [[nodiscard]] PlayerMenu *getPlayerMenu() const
+    {
+        return playerMenu;
     }
 
     PlayerArea *getPlayerArea() const
@@ -111,9 +117,13 @@ public slots:
 signals:
     void sizeChanged();
     void playerCountChanged();
+    void mirroredChanged(bool isMirrored);
+    void cardInfoRequested(const CardRef &cardRef);
 
 private:
     PlayerLogic *player;
+    PlayerMenu *playerMenu;
+    PlayerDialogs *playerDialogs;
     PlayerArea *playerArea;
     PlayerTarget *playerTarget;
     QMap<int, AbstractCounter *> counterWidgets;

--- a/cockatrice/src/game/player/player_logic.cpp
+++ b/cockatrice/src/game/player/player_logic.cpp
@@ -35,14 +35,6 @@ PlayerLogic::PlayerLogic(const ServerInfo_User &info, int _id, bool _local, bool
       conceded(false), zoneId(0), dialogSemaphore(false)
 {
     initializeZones();
-
-    playerMenu = new PlayerMenu(this);
-    graphicsItem = new PlayerGraphicsItem(this);
-    playerMenu->setMenusForGraphicItems();
-
-    connect(this, &PlayerLogic::activeChanged, graphicsItem, &PlayerGraphicsItem::onPlayerActiveChanged);
-
-    connect(this, &PlayerLogic::openDeckEditor, game->getTab(), &TabGame::openDeckEditor);
 }
 
 void PlayerLogic::initializeZones()
@@ -68,7 +60,6 @@ PlayerLogic::~PlayerLogic()
     }
     zones.clear();
 
-    delete playerMenu;
     delete getPlayerInfo()->userInfo;
 }
 
@@ -325,20 +316,14 @@ void PlayerLogic::setActive(bool _active)
     active = _active;
     emit activeChanged(active);
 }
+void PlayerLogic::onRequestZoneViewToggle(const QString &zoneName, int numberCards, bool isReversed)
+{
+    emit requestZoneViewToggle(this, zoneName, numberCards, isReversed);
+}
 
 void PlayerLogic::updateZones()
 {
     getTableZone()->reorganizeCards();
-}
-
-PlayerGraphicsItem *PlayerLogic::getGraphicsItem()
-{
-    return graphicsItem;
-}
-
-GameScene *PlayerLogic::getGameScene()
-{
-    return getGraphicsItem()->getGameScene();
 }
 
 void PlayerLogic::setGameStarted()

--- a/cockatrice/src/game/player/player_logic.h
+++ b/cockatrice/src/game/player/player_logic.h
@@ -67,8 +67,14 @@ class PlayerLogic : public QObject
 
 signals:
     void openDeckEditor(const LoadedDeck &deck);
+    void requestZoneViewToggle(PlayerLogic *player, const QString &zoneName, int numberCards, bool isReversed);
+    void requestRevealedZoneView(PlayerLogic *player,
+                                 CardZoneLogic *zone,
+                                 const QList<const ServerInfo_Card *> &cardList,
+                                 bool withWritePermission);
     void deckChanged();
     void newCardAdded(AbstractCardItem *card);
+    void requestCardMenuUpdate(const CardItem *card);
     void counterAdded(CounterState *state);
     void counterRemoved(int counterId);
     void rearrangeCounters();
@@ -85,6 +91,7 @@ signals:
 
 public slots:
     void setActive(bool _active);
+    void onRequestZoneViewToggle(const QString &zoneName, int numberCards, bool isReversed);
 
 public:
     PlayerLogic(const ServerInfo_User &info, int _id, bool _local, bool _judge, AbstractGame *_parent);
@@ -112,10 +119,6 @@ public:
         return game;
     }
 
-    GameScene *getGameScene();
-
-    [[nodiscard]] PlayerGraphicsItem *getGraphicsItem();
-
     [[nodiscard]] PlayerActions *getPlayerActions() const
     {
         return playerActions;
@@ -129,11 +132,6 @@ public:
     [[nodiscard]] PlayerInfo *getPlayerInfo() const
     {
         return playerInfo;
-    }
-
-    [[nodiscard]] PlayerMenu *getPlayerMenu() const
-    {
-        return playerMenu;
     }
 
     void setDeck(const DeckList &_deck);
@@ -234,8 +232,6 @@ private:
     PlayerInfo *playerInfo;
     PlayerEventHandler *playerEventHandler;
     PlayerActions *playerActions;
-    PlayerMenu *playerMenu;
-    PlayerGraphicsItem *graphicsItem;
 
     bool active;
     bool conceded;

--- a/cockatrice/src/game/replay.cpp
+++ b/cockatrice/src/game/replay.cpp
@@ -2,9 +2,9 @@
 
 #include "../interface/widgets/tabs/tab_game.h"
 
-Replay::Replay(TabGame *_tab, GameReplay *_replay) : AbstractGame(_tab)
+Replay::Replay(QObject *_parent, GameReplay *_replay, bool isLocalGame) : AbstractGame(_parent)
 {
-    gameState = new GameState(this, 0, -1, tab->getTabSupervisor()->getIsLocalGame(), {}, false, false, -1, false);
+    gameState = new GameState(this, 0, -1, isLocalGame, {}, false, false, -1, false);
     connect(gameMetaInfo, &GameMetaInfo::startedChanged, gameState, &GameState::onStartedChanged);
     playerManager = new PlayerManager(this, -1, false, true);
     loadReplay(_replay);

--- a/cockatrice/src/game/replay.h
+++ b/cockatrice/src/game/replay.h
@@ -15,7 +15,7 @@ class Replay : public AbstractGame
     Q_OBJECT
 
 public:
-    explicit Replay(TabGame *_tab, GameReplay *_replay);
+    explicit Replay(QObject *_parent, GameReplay *_replay, bool isLocalGame);
 };
 
 #endif // COCKATRICE_REPLAY_H

--- a/cockatrice/src/game_graphics/zones/table_zone.cpp
+++ b/cockatrice/src/game_graphics/zones/table_zone.cpp
@@ -22,7 +22,8 @@ const QColor TableZone::FADE_MASK = QColor(0, 0, 0, 80);
 const QColor TableZone::GRADIENT_COLOR = QColor(255, 255, 255, 150);
 const QColor TableZone::GRADIENT_COLORLESS = QColor(255, 255, 255, 0);
 
-TableZone::TableZone(TableZoneLogic *_logic, QGraphicsItem *parent) : SelectZone(_logic, parent), active(false)
+TableZone::TableZone(TableZoneLogic *_logic, bool _mirrored, QGraphicsItem *parent)
+    : SelectZone(_logic, parent), active(false), mirrored(_mirrored)
 {
     connect(_logic, &TableZoneLogic::contentSizeChanged, this, &TableZone::resizeToContents);
     connect(_logic, &TableZoneLogic::toggleTapped, this, &TableZone::toggleTapped);
@@ -50,12 +51,16 @@ QRectF TableZone::boundingRect() const
     return QRectF(0, 0, width, height);
 }
 
+void TableZone::setMirrored(bool isMirrored)
+{
+    mirrored = isMirrored;
+    update();
+}
+
 bool TableZone::isInverted() const
 {
-    return ((getLogic()->getPlayer()->getGraphicsItem()->getMirrored() &&
-             !SettingsCache::instance().getInvertVerticalCoordinate()) ||
-            (!getLogic()->getPlayer()->getGraphicsItem()->getMirrored() &&
-             SettingsCache::instance().getInvertVerticalCoordinate()));
+    return ((mirrored && !SettingsCache::instance().getInvertVerticalCoordinate()) ||
+            (!mirrored && SettingsCache::instance().getInvertVerticalCoordinate()));
 }
 
 void TableZone::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)

--- a/cockatrice/src/game_graphics/zones/table_zone.h
+++ b/cockatrice/src/game_graphics/zones/table_zone.h
@@ -82,6 +82,7 @@ private:
        If this TableZone is currently active
      */
     bool active = false;
+    bool mirrored = false;
 
     [[nodiscard]] bool isInverted() const;
 
@@ -96,6 +97,7 @@ public slots:
        Reorganizes CardItems in the TableZone
      */
     void reorganizeCards() override;
+    void setMirrored(bool isMirrored);
 
 public:
     /**
@@ -104,7 +106,7 @@ public:
        @param _p the Player
        @param parent defaults to null
      */
-    explicit TableZone(TableZoneLogic *_logic, QGraphicsItem *parent = nullptr);
+    explicit TableZone(TableZoneLogic *_logic, bool mirrored, QGraphicsItem *parent = nullptr);
 
     /**
        @return a QRectF of the TableZone bounding box.

--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -1,6 +1,7 @@
 #include "tab_game.h"
 
 #include "../../../client/settings/cache_settings.h"
+#include "../../../game/player/menu/card_menu.h"
 #include "../game/board/arrow_item.h"
 #include "../game/board/card_item.h"
 #include "../game/deckview/deck_view_container.h"
@@ -47,7 +48,7 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor, GameReplay *_replay)
     : Tab(_tabSupervisor), sayLabel(nullptr), sayEdit(nullptr)
 {
     // THIS CTOR IS USED ON REPLAY
-    game = new Replay(this, _replay);
+    game = new Replay(this, _replay, tabSupervisor->getIsLocalGame());
 
     createCardInfoDock(true);
     createPlayerListDock(true);
@@ -91,7 +92,7 @@ TabGame::TabGame(TabSupervisor *_tabSupervisor,
     : Tab(_tabSupervisor), userListProxy(_tabSupervisor->getUserListManager())
 {
     // THIS CTOR IS USED ON GAMES
-    game = new Game(this, _clients, event, _roomGameTypes);
+    game = new Game(this, tabSupervisor->getIsLocalGame(), _clients, event, _roomGameTypes);
 
     createCardInfoDock();
     createPlayerListDock();
@@ -363,11 +364,10 @@ void TabGame::retranslateUi()
 
     cardInfoFrameWidget->retranslateUi();
 
-    QMapIterator<int, PlayerLogic *> i(game->getPlayerManager()->getPlayers());
-
-    while (i.hasNext()) {
-        i.next().value()->getGraphicsItem()->retranslateUi();
+    for (auto playerView : scene->getPlayers().values()) {
+        playerView->retranslateUi();
     }
+
     QMapIterator<int, TabbedDeckViewContainer *> j(deckViewContainers);
     while (j.hasNext()) {
         j.next().value()->playerDeckView->retranslateUi();
@@ -654,8 +654,12 @@ PlayerLogic *TabGame::addPlayer(PlayerLogic *newPlayer)
 
     scene->addPlayer(newPlayer);
 
+    auto *view = scene->viewForPlayer(newPlayer->getPlayerInfo()->getId());
+
     connect(newPlayer, &PlayerLogic::newCardAdded, this, &TabGame::newCardAdded);
-    connect(newPlayer->getPlayerMenu(), &PlayerMenu::cardMenuUpdated, this, &TabGame::setCardMenu);
+    connect(newPlayer, &PlayerLogic::openDeckEditor, this, &TabGame::openDeckEditor);
+    connect(view->getPlayerMenu(), &PlayerMenu::cardMenuUpdated, this, &TabGame::setCardMenu);
+    connect(view, &PlayerGraphicsItem::cardInfoRequested, this, &TabGame::viewCardInfo);
 
     messageLog->connectToPlayerEventHandler(newPlayer->getPlayerEventHandler());
 
@@ -668,7 +672,7 @@ PlayerLogic *TabGame::addPlayer(PlayerLogic *newPlayer)
         addLocalPlayer(newPlayer, newPlayer->getPlayerInfo()->getId());
     }
 
-    gameMenu->insertMenu(playersSeparator, newPlayer->getPlayerMenu()->getPlayerMenu());
+    gameMenu->insertMenu(playersSeparator, view->getPlayerMenu()->getPlayerMenu());
 
     createZoneForPlayer(newPlayer, newPlayer->getPlayerInfo()->getId());
 
@@ -678,7 +682,7 @@ PlayerLogic *TabGame::addPlayer(PlayerLogic *newPlayer)
 void TabGame::addLocalPlayer(PlayerLogic *newPlayer, int playerId)
 {
     if (game->getGameState()->getClients().size() == 1) {
-        newPlayer->getPlayerMenu()->setShortcutsActive();
+        scene->viewForPlayer(playerId)->getPlayerMenu()->setShortcutsActive();
     }
 
     auto *deckView = new TabbedDeckViewContainer(playerId, this);
@@ -698,27 +702,23 @@ void TabGame::addLocalPlayer(PlayerLogic *newPlayer, int playerId)
 
 void TabGame::processPlayerLeave(PlayerLogic *leavingPlayer)
 {
-    QString playerName = "@" + leavingPlayer->getPlayerInfo()->getName();
-    removePlayerFromAutoCompleteList(playerName);
-
-    scene->removePlayer(leavingPlayer);
+    removePlayerFromAutoCompleteList("@" + leavingPlayer->getPlayerInfo()->getName());
 
     // When we inserted the playerMenu into the gameMenu earlier, Qt wrapped the playerMenu into a QAction*, which lives
     // independently and does not get cleaned up when the source menu gets destroyed. We have to manually clean here.
-    if (leavingPlayer->getPlayerMenu()) {
-        QMenu *menu = leavingPlayer->getPlayerMenu()->getPlayerMenu();
-        if (menu) {
-            // Find and remove the QAction pointing to this menu
-            QList<QAction *> actions = gameMenu->actions();
-            for (QAction *act : actions) {
-                if (act->menu() == menu) {
-                    gameMenu->removeAction(act);
-                    delete act; // deletes the QAction wrapper around the submenu
-                    break;
-                }
+    auto *view = scene->viewForPlayer(leavingPlayer->getPlayerInfo()->getId());
+    if (view) {
+        QMenu *menu = view->getPlayerMenu()->getPlayerMenu();
+        for (QAction *act : gameMenu->actions()) {
+            if (act->menu() == menu) {
+                gameMenu->removeAction(act);
+                delete act;
+                break;
             }
         }
     }
+
+    scene->removePlayer(leavingPlayer);
 }
 
 void TabGame::processRemotePlayerDeckSelect(QString deckList, int playerId, QString playerName)
@@ -869,12 +869,12 @@ PlayerLogic *TabGame::setActivePlayer(int id)
         if (i.value() == player) {
             i.value()->setActive(true);
             if (game->getGameState()->getClients().size() > 1) {
-                i.value()->getPlayerMenu()->setShortcutsActive();
+                scene->viewForPlayer(i.value()->getPlayerInfo()->getId())->getPlayerMenu()->setShortcutsActive();
             }
         } else {
             i.value()->setActive(false);
             if (game->getGameState()->getClients().size() > 1) {
-                i.value()->getPlayerMenu()->setShortcutsInactive();
+                scene->viewForPlayer(i.value()->getPlayerInfo()->getId())->getPlayerMenu()->setShortcutsInactive();
             }
         }
     }
@@ -890,8 +890,13 @@ void TabGame::setActivePhase(int phase)
 
 void TabGame::newCardAdded(AbstractCardItem *card)
 {
+    connect(card, &AbstractCardItem::rightClicked, scene, &GameScene::onCardRightClicked);
+    connect(card, &AbstractCardItem::playSelected, scene, &GameScene::playSelected);
+    connect(card, &AbstractCardItem::playSelectedFaceDown, scene, &GameScene::playSelectedFaceDown);
+    connect(card, &AbstractCardItem::hideSelected, scene, &GameScene::hideSelected);
     connect(card, &AbstractCardItem::hovered, cardInfoFrameWidget,
             qOverload<AbstractCardItem *>(&CardInfoFrameWidget::setCard));
+    connect(card, &AbstractCardItem::selectionChanged, scene, &GameScene::onCardSelectionChanged);
     connect(card, &AbstractCardItem::showCardInfoPopup, this, &TabGame::showCardInfoPopup);
     connect(card, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));
     connect(card, &AbstractCardItem::cardShiftClicked, this, &TabGame::linkCardToChat);
@@ -940,7 +945,7 @@ QString TabGame::getTabText() const
 /**
  * @param menu The menu to set. Pass in nullptr to set the menu to empty.
  */
-void TabGame::setCardMenu(QMenu *menu)
+void TabGame::setCardMenu(CardMenu *menu)
 {
     if (!aCardMenu) {
         return;

--- a/cockatrice/src/interface/widgets/tabs/tab_game.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.h
@@ -141,7 +141,7 @@ signals:
 private slots:
     void adminLockChanged(bool lock);
     void newCardAdded(AbstractCardItem *card);
-    void setCardMenu(QMenu *menu);
+    void setCardMenu(CardMenu *menu);
 
     void actGameInfo();
     void actConcede();


### PR DESCRIPTION
## Short roundup of the initial problem
This PR is the first structural step in a larger refactor to decouple the game's UI layer from its logic layer, enabling a future pub/sub event system. The core problem was that Player (now PlayerLogic) directly owned and created PlayerGraphicsItem, PlayerMenu, and all associated graphics classes, making the logic layer tightly coupled to Qt's widget/graphics stack.

## What will change with this Pull Request?
- AbstractGame drops TabGame*. AbstractGame now takes a plain QObject *parent. Game and Replay extract the one bool they needed (isLocalGame) locally before calling the base constructor.
- PlayerLogic no longer owns graphics
- PlayerGraphicsItem and PlayerMenu are no longer constructed inside PlayerLogic. The constructor no longer creates graphics objects. Logic signals (_arrowCreateRequested, arrowDeleteRequested, arrowsCleared, counterAdded, counterRemoved, concededChanged, zoneIdChanged, requestZoneViewToggle, requestSortHand_) replace direct calls into the graphics layer.
- GameScene owns PlayerGraphicsItem
GameScene::addPlayer(PlayerLogic*) now creates PlayerGraphicsItem internally and registers it in a QMap<int, PlayerGraphicsItem*> playerViews for ID-based lookup. GameScene::viewForPlayer(int) is the new access point for anything that needs the view for a given player.
- All menu classes take PlayerGraphicsItem* instead of PlayerLogic*
- CardMenu, CustomZoneMenu, GraveyardMenu, HandMenu, LibraryMenu, MoveMenu, PtMenu, RfgMenu, SayMenu, SideboardMenu, UtilityMenu, and PlayerMenu all now hold PlayerGraphicsItem* and reach logic through player->getPlayerLogic(). These are view-layer classes and this reflects their actual nature.
- PlayerDialogs introduced
- Dialog handling is extracted out of PlayerActions into a new PlayerDialogs class owned by PlayerGraphicsItem. PlayerActions emits requestDialog signals; PlayerDialogs connects to them and owns the QWidget dialogParent needed to show dialogs.
- CardItem::mouseReleaseEvent wired via signal
- Right-click context menus are now triggered via AbstractCardItem::rightClicked signal connected to GameScene::onCardRightClicked, which resolves the PlayerGraphicsItem from playerViews and shows the menu.

## TODO:
Remove AbstractGame::activeCard (CardItem* on the logic layer)
Remove CardZoneLogic::updateGraphics() / setGraphicsVisibility() signals
Move files into game_graphics/

These are left as subsequent PRs to keep this one reviewable. The goal here is establishing the structural boundary so those cleanups can happen without the whole thing collapsing.

## Patterns

We essentially had two patterns in PlayerActions:

```
// Pattern 1 — pure command builder. Takes primitives, builds protobuf, sends.
void PlayerActions::actDrawCards(int number) {
    Command_DrawCards cmd;
    cmd.set_number(number);
    sendGameCommand(cmd);
}

// Pattern 2 — pulls UI state itself instead of receiving it.
void PlayerActions::actIncPT(int deltaP, int deltaT) {
    for (auto card : player->getGameScene()->selectedCards()) { // ← reaches into scene
        // ... builds command from card data
    }
}
```

Pattern 2 is what this PR fixes. Pattern 1 is the correct and intended usage. 

## What PlayerActions actually is
It's a command builder. Given a user's intention and the current game state, it constructs the correct protobuf message and sends it through GameEventHandler. That's it. Everything that isn't command building is either:

- UI translation: figuring out which cards the user means (selected cards, active card), which belongs in the caller
- Dialog orchestration: asking the user for parameters (how many cards?), which belongs in PlayerDialogs

## Screenshots
<img width="666" height="436" alt="image" src="https://github.com/user-attachments/assets/bf6c6dc8-c2b5-4302-a694-06f83a61f078" />
