### PR TITLE
  Fix card stacking overflow when vertical zone has many cards

### DIFF
--- a/cockatrice/src/game_graphics/zones/select_zone.cpp
+++ b/cockatrice/src/game_graphics/zones/select_zone.cpp
@@ -42,7 +42,19 @@ SelectZone::ZoneLayout SelectZone::computeZoneLayout(const StackLayoutParams &pa
                 reservedForBottomCard = params.cardHeight;
             }
             fitOffset = (params.totalHeight - reservedForBottomCard) / (params.cardCount - 1);
-            effectiveOffset = qMax(params.minOffset, qMin(params.desiredOffset, fitOffset));
+
+            if (!params.allowBottomOverflow) {
+                // Constrain offset so all card tops remain within zone bounds.
+                // With start=0, last card top at (cardCount-1) * effectiveOffset must be < totalHeight.
+                qreal maxOffsetForTops = params.totalHeight / (params.cardCount - 1);
+                fitOffset = qMin(fitOffset, maxOffsetForTops);
+            }
+
+            // Apply minOffset only if it fits; otherwise compress further to keep all card tops visible.
+            effectiveOffset = qMin(params.desiredOffset, fitOffset);
+            if (fitOffset >= params.minOffset) {
+                effectiveOffset = qMax(params.minOffset, effectiveOffset);
+            }
         }
     }
     qreal stackHeight = (params.cardCount - 1) * effectiveOffset + params.cardHeight;


### PR DESCRIPTION

## Related Ticket(s)
- none that I could find

## Short roundup of the initial problem
- I saw this bug in the stacking behaviour: when adding too many cards they would clip out of bounds. 
- So my previous changes to it failed to handle that edge case.
- This should rectify the issue.

## What will change with this Pull Request?
  Previously, minOffset (10px) was enforced unconditionally, causing card
  tops to overflow zone bounds when many cards were stacked. For example,
  50 cards in a 200px zone would place the last card's top at y=490.

  Now offsets compress below minOffset when necessary to keep all card
  tops visible. The constraint is guarded by !allowBottomOverflow to
  preserve future clipping zone semantics.
