### PR TITLE
[Game] Refactor: move proliferate action code to PlayerActions

### DIFF
--- a/cockatrice/src/game/player/menu/utility_menu.cpp
+++ b/cockatrice/src/game/player/menu/utility_menu.cpp
@@ -30,7 +30,8 @@ UtilityMenu::UtilityMenu(PlayerLogic *_player, QMenu *playerMenu) : QMenu(player
         aCreateAnotherToken->setEnabled(false);
 
         aIncrementAllCardCounters = new QAction(this);
-        connect(aIncrementAllCardCounters, &QAction::triggered, player, &PlayerLogic::incrementAllCardCounters);
+        connect(aIncrementAllCardCounters, &QAction::triggered, playerActions,
+                &PlayerActions::actIncrementAllCardCounters);
 
         createPredefinedTokenMenu = new QMenu(QString());
         createPredefinedTokenMenu->setEnabled(false);

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -1559,6 +1559,42 @@ void PlayerActions::actSetCardCounter(int counterId)
     sendGameCommand(prepareGameCommand(commandList));
 }
 
+void PlayerActions::actIncrementAllCardCounters()
+{
+    auto cardsToUpdate = player->getGameScene()->selectedCards();
+    if (cardsToUpdate.isEmpty()) {
+        // If no cards selected, update all cards on table
+        cardsToUpdate = static_cast<QList<CardItem *>>(player->getTableZone()->getCards());
+    }
+
+    QList<const ::google::protobuf::Message *> commandList;
+
+    for (const auto *card : cardsToUpdate) {
+        const auto &cardCounters = card->getCounters();
+
+        QMapIterator<int, int> counterIterator(cardCounters);
+        while (counterIterator.hasNext()) {
+            counterIterator.next();
+            int counterId = counterIterator.key();
+            int currentValue = counterIterator.value();
+            if (currentValue >= MAX_COUNTERS_ON_CARD) {
+                continue;
+            }
+
+            auto cmd = std::make_unique<Command_SetCardCounter>();
+            cmd->set_zone(card->getZone()->getName().toStdString());
+            cmd->set_card_id(card->getId());
+            cmd->set_counter_id(counterId);
+            cmd->set_counter_value(currentValue + 1);
+            commandList.append(cmd.release());
+        }
+    }
+
+    if (!commandList.isEmpty()) {
+        sendGameCommand(prepareGameCommand(commandList));
+    }
+}
+
 /**
  * @brief returns true if the zone is a unwritable reveal zone view (eg a card reveal window). Will return false if zone
  * is nullptr.

--- a/cockatrice/src/game/player/player_actions.h
+++ b/cockatrice/src/game/player/player_actions.h
@@ -131,6 +131,7 @@ public slots:
     void actRemoveCardCounter(int counterId);
     void actAddCardCounter(int counterId);
     void actSetCardCounter(int counterId);
+    void actIncrementAllCardCounters();
     void actAttach();
     void actUnattach();
     void actDrawArrow();

--- a/cockatrice/src/game/player/player_logic.cpp
+++ b/cockatrice/src/game/player/player_logic.cpp
@@ -304,42 +304,6 @@ CounterState *PlayerLogic::getLifeCounter() const
     return nullptr;
 }
 
-void PlayerLogic::incrementAllCardCounters()
-{
-    auto cardsToUpdate = getGameScene()->selectedCards();
-    if (cardsToUpdate.isEmpty()) {
-        // If no cards selected, update all cards on table
-        cardsToUpdate = static_cast<QList<CardItem *>>(getTableZone()->getCards());
-    }
-
-    QList<const ::google::protobuf::Message *> commandList;
-
-    for (const auto *card : cardsToUpdate) {
-        const auto &cardCounters = card->getCounters();
-
-        QMapIterator<int, int> counterIterator(cardCounters);
-        while (counterIterator.hasNext()) {
-            counterIterator.next();
-            int counterId = counterIterator.key();
-            int currentValue = counterIterator.value();
-            if (currentValue >= MAX_COUNTERS_ON_CARD) {
-                continue;
-            }
-
-            auto cmd = std::make_unique<Command_SetCardCounter>();
-            cmd->set_zone(card->getZone()->getName().toStdString());
-            cmd->set_card_id(card->getId());
-            cmd->set_counter_id(counterId);
-            cmd->set_counter_value(currentValue + 1);
-            commandList.append(cmd.release());
-        }
-    }
-
-    if (!commandList.isEmpty()) {
-        playerActions->sendGameCommand(playerActions->prepareGameCommand(commandList));
-    }
-}
-
 bool PlayerLogic::clearCardsToDelete()
 {
     if (cardsToDelete.isEmpty()) {

--- a/cockatrice/src/game/player/player_logic.h
+++ b/cockatrice/src/game/player/player_logic.h
@@ -197,7 +197,6 @@ public:
     CounterState *addCounter(int id, const QString &name, const QColor &color, int radius, int value);
     void delCounter(int counterId);
     void clearCounters();
-    void incrementAllCardCounters();
 
     QMap<int, CounterState *> getCounters() const
     {


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6055

## Short roundup of the initial problem

#6055 added a new action. However, that PR was done by an outside contributor while we were in the middle of our big Player refactor, so the code for handling the code didn't get moved to to `PlayerActions` with the rest of the actions in the refactor.

## What will change with this Pull Request?

- Move code for handling the `incrementAllCardCounters` action from `Player` to `PlayerActions`