### PR TITLE
[Game][Arrows] Don't request deletion on inbound arrow deletion signal again but react to it locally

### DIFF
--- a/cockatrice/src/game/game_scene.cpp
+++ b/cockatrice/src/game/game_scene.cpp
@@ -93,6 +93,7 @@ void GameScene::addPlayer(PlayerLogic *player)
         rearrange();
     });
 
+    connect(player, &PlayerLogic::arrowDeleted, this, &GameScene::onArrowDeleted);
     connect(player, &PlayerLogic::arrowCreateRequested, this, &GameScene::onArrowCreateRequested);
     connect(player, &PlayerLogic::arrowDeleteRequested, this, &GameScene::onArrowDeleteRequested);
     connect(player, &PlayerLogic::arrowsCleared, this,
@@ -404,11 +405,17 @@ void GameScene::onArrowCreateRequested(const ArrowData &data)
     connect(arrow, &QObject::destroyed, this, [this, id = data.id]() { arrowRegistry.remove(id); });
 }
 
+void GameScene::onArrowDeleted(int arrowId)
+{
+    if (arrowRegistry.contains(arrowId)) {
+        arrowRegistry.take(arrowId)->delArrow();
+    }
+}
+
 void GameScene::onArrowDeleteRequested(int arrowId)
 {
     if (arrowRegistry.contains(arrowId)) {
         emit requestArrowDeletion(arrowId);
-        arrowRegistry.take(arrowId)->delArrow();
     }
 }
 
@@ -426,7 +433,6 @@ void GameScene::onCardZoneChanged(CardItem *card, bool sameZone)
     }
     for (auto *arrow : toDelete) {
         emit requestArrowDeletion(arrow->getId());
-        arrowRegistry.take(arrow->getId())->delArrow();
     }
 }
 
@@ -435,7 +441,6 @@ void GameScene::clearArrowsForPlayer(int playerId)
     for (auto *arrow : arrowRegistry.values()) {
         if (arrow->getPlayer()->getPlayerInfo()->getId() == playerId) {
             emit requestArrowDeletion(arrow->getId());
-            arrowRegistry.take(arrow->getId())->delArrow();
         }
     }
 }

--- a/cockatrice/src/game/game_scene.cpp
+++ b/cockatrice/src/game/game_scene.cpp
@@ -408,6 +408,7 @@ void GameScene::onArrowDeleteRequested(int arrowId)
 {
     if (arrowRegistry.contains(arrowId)) {
         emit requestArrowDeletion(arrowId);
+        arrowRegistry.take(arrowId)->delArrow();
     }
 }
 
@@ -425,6 +426,7 @@ void GameScene::onCardZoneChanged(CardItem *card, bool sameZone)
     }
     for (auto *arrow : toDelete) {
         emit requestArrowDeletion(arrow->getId());
+        arrowRegistry.take(arrow->getId())->delArrow();
     }
 }
 
@@ -433,6 +435,7 @@ void GameScene::clearArrowsForPlayer(int playerId)
     for (auto *arrow : arrowRegistry.values()) {
         if (arrow->getPlayer()->getPlayerInfo()->getId() == playerId) {
             emit requestArrowDeletion(arrow->getId());
+            arrowRegistry.take(arrow->getId())->delArrow();
         }
     }
 }

--- a/cockatrice/src/game/game_scene.h
+++ b/cockatrice/src/game/game_scene.h
@@ -202,6 +202,7 @@ public slots:
     QTransform getViewportTransform() const;
 
     void onArrowCreateRequested(const ArrowData &data);
+    void onArrowDeleted(int arrowId);
     void onArrowDeleteRequested(int arrowId);
     void onCardZoneChanged(CardItem *card, bool sameZone);
     void clearArrowsForPlayer(int playerId);

--- a/cockatrice/src/game/player/player_event_handler.cpp
+++ b/cockatrice/src/game/player/player_event_handler.cpp
@@ -128,7 +128,7 @@ void PlayerEventHandler::eventCreateArrow(const Event_CreateArrow &event)
 
 void PlayerEventHandler::eventDeleteArrow(const Event_DeleteArrow &event)
 {
-    emit player->arrowDeleteRequested(event.arrow_id());
+    emit player->arrowDeleted(event.arrow_id());
 }
 
 void PlayerEventHandler::eventCreateToken(const Event_CreateToken &event)

--- a/cockatrice/src/game/player/player_logic.h
+++ b/cockatrice/src/game/player/player_logic.h
@@ -80,6 +80,7 @@ signals:
     void resetTopCardMenuActions();
     void arrowCreateRequested(ArrowData data);
     void arrowDeleteRequested(int arrowId);
+    void arrowDeleted(int arrowId);
     void arrowsCleared(); // fires on clear() and processPlayerInfo
 
 public slots:


### PR DESCRIPTION
## Short roundup of the initial problem
I hooked up the PlayerEventHandler (inbound events) to emit a "deleteArrowRequested" signal from the player logic. It should instead send a "arrowDeleted" signal, which the scene then reacts to by actually deleting the arrow from the view.

## What will change with this Pull Request?
- Implement new signal, hook up, react to it.