### PR TITLE
[Game][Arrows] ArrowItem should not send deletion game commands by itself

### DIFF
--- a/cockatrice/src/game/board/arrow_item.cpp
+++ b/cockatrice/src/game/board/arrow_item.cpp
@@ -38,16 +38,21 @@ ArrowItem::ArrowItem(PlayerLogic *_player,
 
     if (startItem) {
         connect(startItem, &ArrowTarget::scenePositionChanged, this, doUpdate);
-        connect(startItem, &QObject::destroyed, this, &ArrowItem::delArrow);
+        connect(startItem, &QObject::destroyed, this, &ArrowItem::onTargetDestroyed);
     }
     if (targetItem) {
         connect(targetItem, &ArrowTarget::scenePositionChanged, this, doUpdate);
-        connect(targetItem, &QObject::destroyed, this, &ArrowItem::delArrow);
+        connect(targetItem, &QObject::destroyed, this, &ArrowItem::onTargetDestroyed);
     }
 
     if (startItem && targetItem) {
         updatePath();
     }
+}
+
+void ArrowItem::onTargetDestroyed()
+{
+    emit requestDeletion(id);
 }
 
 void ArrowItem::delArrow()
@@ -151,9 +156,7 @@ void ArrowItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 
     event->accept();
     if (event->button() == Qt::RightButton) {
-        Command_DeleteArrow cmd;
-        cmd.set_arrow_id(id);
-        player->getPlayerActions()->sendGameCommand(cmd);
+        emit requestDeletion(id);
     }
 }
 

--- a/cockatrice/src/game/board/arrow_item.h
+++ b/cockatrice/src/game/board/arrow_item.h
@@ -21,6 +21,9 @@ class ArrowItem : public QObject, public QGraphicsItem
 {
     Q_OBJECT
     Q_INTERFACES(QGraphicsItem)
+signals:
+    void requestDeletion(int id);
+
 private:
     QPainterPath path;
 
@@ -37,6 +40,7 @@ protected:
 
 public:
     ArrowItem(PlayerLogic *_player, int _id, ArrowTarget *_startItem, ArrowTarget *_targetItem, const QColor &_color);
+    void onTargetDestroyed();
 
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
     [[nodiscard]] QRectF boundingRect() const override

--- a/cockatrice/src/game/game_scene.cpp
+++ b/cockatrice/src/game/game_scene.cpp
@@ -402,7 +402,7 @@ void GameScene::onArrowCreateRequested(const ArrowData &data)
     auto *arrow = new ArrowItem(startView->getPlayer(), data.id, startCard, targetItem, data.color);
     addItem(arrow);
     arrowRegistry.insert(data.id, arrow);
-    connect(arrow, &QObject::destroyed, this, [this, id = data.id]() { arrowRegistry.remove(id); });
+    connect(arrow, &ArrowItem::requestDeletion, this, &GameScene::onArrowDeleteRequested);
 }
 
 void GameScene::onArrowDeleted(int arrowId)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes regression introduced in #6918 and not caught in #6927

## Short roundup of the initial problem
ArrowItems sent raw game commands by themselves, bypassing the arrow registry.

## What will change with this Pull Request?
- Have arrowItems emit the signal up to the GameScene
