### PR TITLE
[Server][Game][Arrows] Properly notify clients when deleting arrows on card move and transform into

### DIFF
--- a/cockatrice/src/game/game_event_handler.cpp
+++ b/cockatrice/src/game/game_event_handler.cpp
@@ -217,7 +217,20 @@ void GameEventHandler::handleArrowDeletion(int arrowId)
 {
     Command_DeleteArrow cmd;
     cmd.set_arrow_id(arrowId);
-    sendGameCommand(cmd);
+
+    auto preparedCommand = prepareGameCommand(cmd);
+
+    connect(preparedCommand, &PendingCommand::finished, this,
+            [arrowId, this](const Response &response) { handleArrowDeletionFinished(response, arrowId); });
+
+    sendGameCommand(preparedCommand);
+}
+
+void GameEventHandler::handleArrowDeletionFinished(const Response &response, int arrowId)
+{
+    if (response.response_code() == Response::RespNameNotFound) {
+        emit arrowDeleted(arrowId);
+    }
 }
 
 void GameEventHandler::eventSpectatorSay(const Event_GameSay &event,

--- a/cockatrice/src/game/game_event_handler.h
+++ b/cockatrice/src/game/game_event_handler.h
@@ -61,6 +61,7 @@ public:
     void handleGameLeft();
     void handleChatMessageSent(const QString &chatMessage);
     void handleArrowDeletion(int arrowId);
+    void handleArrowDeletionFinished(const Response &response, int arrowId);
 
     void eventSpectatorSay(const Event_GameSay &event, int eventPlayerId, const GameEventContext &context);
     void eventSpectatorLeave(const Event_Leave &event, int eventPlayerId, const GameEventContext &context);
@@ -112,6 +113,7 @@ signals:
     void containerProcessingStarted(GameEventContext context);
     void setContextJudgeName(QString judgeName);
     void containerProcessingDone();
+    void arrowDeleted(int arrowId);
     void logSpectatorSay(ServerInfo_User userInfo, QString message);
     void logSpectatorLeave(QString name, QString reason);
     void logGameStart();

--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -1147,6 +1147,7 @@ void TabGame::createPlayAreaWidget(bool bReplay)
     connect(game->getPlayerManager(), &PlayerManager::playerCountChanged, scene, &GameScene::rearrange);
     connect(scene, &GameScene::requestArrowDeletion, game->getGameEventHandler(),
             &GameEventHandler::handleArrowDeletion);
+    connect(game->getGameEventHandler(), &GameEventHandler::arrowDeleted, scene, &GameScene::onArrowDeleted);
     gameView = new GameView(scene);
 
     auto gamePlayAreaVBox = new QVBoxLayout;

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_player.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_player.cpp
@@ -397,6 +397,9 @@ void Server_AbstractPlayer::processMoveCard(GameEventStorage &ges,
                 }
             }
             for (int j : arrowsToDelete) {
+                Event_DeleteArrow event;
+                event.set_arrow_id(j);
+                ges.enqueueGameEvent(event, player->getPlayerId());
                 player->deleteArrow(j);
             }
         }
@@ -1132,12 +1135,18 @@ Server_AbstractPlayer::cmdCreateToken(const Command_CreateToken &cmd, ResponseCo
                         targetItem = card;
                     }
                     if (sendGameEvent) {
-                        Event_CreateArrow _event;
-                        ServerInfo_Arrow *arrowInfo = _event.mutable_arrow_info();
-                        changedArrowIds.append(arrow->getId());
-                        int id = player->newArrowId();
-                        arrow->setId(id);
-                        arrowInfo->set_id(id);
+                        const int oldId = arrow->getId();
+                        changedArrowIds.append(oldId);
+
+                        Event_DeleteArrow deleteEvent;
+                        deleteEvent.set_arrow_id(oldId);
+                        ges.enqueueGameEvent(deleteEvent, player->getPlayerId());
+
+                        Event_CreateArrow createEvent;
+                        ServerInfo_Arrow *arrowInfo = createEvent.mutable_arrow_info();
+                        const int newId = player->newArrowId();
+                        arrow->setId(newId);
+                        arrowInfo->set_id(newId);
                         arrowInfo->set_start_player_id(player->getPlayerId());
                         arrowInfo->set_start_zone(startCard->getZone()->getName().toStdString());
                         arrowInfo->set_start_card_id(startCard->getId());
@@ -1151,7 +1160,7 @@ Server_AbstractPlayer::cmdCreateToken(const Command_CreateToken &cmd, ResponseCo
                             arrowInfo->set_target_card_id(arrowTargetCard->getId());
                         }
                         arrowInfo->mutable_arrow_color()->CopyFrom(arrow->getColor());
-                        ges.enqueueGameEvent(_event, player->getPlayerId());
+                        ges.enqueueGameEvent(createEvent, player->getPlayerId());
                     }
                 }
                 for (int id : changedArrowIds) {


### PR DESCRIPTION
## Short roundup of the initial problem
When I refactored the local client arrow code, I reasoned that the client should not simply delete a local arrow when a card is moved -> It should instead issue a command for arrow deletion to the server and then separately acknowledge this deletion.
However, previously, the contract between client and server was such that, if a card was moved between zones, both silently deleted their own arrows without telling each other, meaning the client never gets a chance to delete the local arrow. If it then tries to by any other means (Cmd_DeleteArrow) or even just with the queued "please delete this arrow now" after the card moved event, the server can no longer find it in its own arrow registry and silently discard the request.

## What will change with this Pull Request?
- Have the server emit proper deletion events when it DOES remove arrows, in both CardMoved and CreateToken->TransformInto, where we delete and re-create arrows.
