### PR TITLE
[DeckEditor] Refactor: clean up addCardHelper

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
@@ -129,14 +129,15 @@ void AbstractTabDeckEditor::onDeckModified()
     emit tabTextChanged(this, getTabText());
 }
 
-/**
- * @brief Helper for adding a card to a deck zone.
- * @param card Card to add.
- * @param zoneName Zone to add the card to.
- */
-void AbstractTabDeckEditor::addCardHelper(const ExactCard &card, const QString &zoneName)
+void AbstractTabDeckEditor::addCard(const ExactCard &card, const QString &zoneName)
 {
     deckStateManager->addCard(card, zoneName);
+    deckMenu->setSaveStatus(true);
+}
+
+void AbstractTabDeckEditor::decrementCard(const ExactCard &card, const QString &zoneName)
+{
+    deckStateManager->decrementCard(card, zoneName);
 }
 
 /**
@@ -147,29 +148,26 @@ void AbstractTabDeckEditor::actAddCard(const ExactCard &card)
     if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
         actAddCardToSideboard(card);
     } else {
-        addCardHelper(card, DECK_ZONE_MAIN);
+        addCard(card, DECK_ZONE_MAIN);
     }
-
-    deckMenu->setSaveStatus(true);
 }
 
 /** @brief Adds a card to the sideboard explicitly. */
 void AbstractTabDeckEditor::actAddCardToSideboard(const ExactCard &card)
 {
-    addCardHelper(card, DECK_ZONE_SIDE);
-    deckMenu->setSaveStatus(true);
+    addCard(card, DECK_ZONE_SIDE);
 }
 
 /** @brief Decrements a card from the main deck. */
 void AbstractTabDeckEditor::actDecrementCard(const ExactCard &card)
 {
-    deckStateManager->decrementCard(card, DECK_ZONE_MAIN);
+    decrementCard(card, DECK_ZONE_MAIN);
 }
 
 /** @brief Decrements a card from the sideboard. */
 void AbstractTabDeckEditor::actDecrementCardFromSideboard(const ExactCard &card)
 {
-    deckStateManager->decrementCard(card, DECK_ZONE_SIDE);
+    decrementCard(card, DECK_ZONE_SIDE);
 }
 
 /**

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
@@ -132,7 +132,6 @@ void AbstractTabDeckEditor::onDeckModified()
 void AbstractTabDeckEditor::addCard(const ExactCard &card, const QString &zoneName)
 {
     deckStateManager->addCard(card, zoneName);
-    deckMenu->setSaveStatus(true);
 }
 
 void AbstractTabDeckEditor::decrementCard(const ExactCard &card, const QString &zoneName)

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
@@ -145,6 +145,24 @@ public slots:
      */
     void updateCard(const ExactCard &card);
 
+    /**
+     * @brief Adds a card to the given zone
+     * @param card Card to add.
+     * @param zoneName Zone to add the card to.
+     */
+    void addCard(const ExactCard &card, const QString &zoneName);
+
+    /**
+     * @brief Decrements a card from the given zone
+     *
+     * Use an ExactCard with empty PrintingInfo if you want to remove a card by name regardless of printing.
+     * Otherwise, it won't remove anything unless there's an exact printing match.
+     *
+     * @param card Card to decrement.
+     * @param zoneName Zone to decrement from.
+     */
+    void decrementCard(const ExactCard &card, const QString &zoneName);
+
     /** @brief Adds a card to the main deck or sideboard based on Ctrl key. */
     void actAddCard(const ExactCard &card);
 
@@ -292,9 +310,6 @@ protected:
      *  @return Pointer to a QMessageBox.
      */
     QMessageBox *createSaveConfirmationWindow();
-
-    /** @brief Helper function to add a card to a specific deck zone. */
-    void addCardHelper(const ExactCard &card, const QString &zoneName);
 
     /** @brief Opens a deck from a file. */
     virtual void openDeckFromFile(const QString &fileName, DeckOpenLocation deckOpenLocation);


### PR DESCRIPTION
## Short roundup of the initial problem

I'm planning on doing a big refactor of how the card database table view is managed in the deck editor and card database tabs. 

Right now, most code just directly reaches into the `DeckEditorDatabaseDisplayWidget` instance in the deck editor and hooks itself up to the database table view. (The visual database tab is an especially egregious case of this, where it [instantiates an entire deck editor tab](https://github.com/Cockatrice/Cockatrice/blob/b3c89167c53673ade34f376f60769dd5ff6355c8/cockatrice/src/interface/widgets/tabs/tab_visual_database_display.cpp#L7) just so that it can grab a database table view from it.)

I would like to extract out the database table view into its own class so that it can be more cleanly reused.

Anyways, this is the first step. This cleanup will help me later.

## What will change with this Pull Request?
- Replace `addCardHelper` with `addCard` and `decrementCard`
  - Made those methods public
  - Make all `actXXX` methods call through the new helpers.

I'm planning on consolidating the zones for the add/decrement signals/slots so that so that we have less wiring that we need to do.