### PR TITLE
[CardDatabaseModel] Pass CardInfoPtr by const ref

### DIFF
--- a/libcockatrice_models/libcockatrice/models/database/card_database_model.cpp
+++ b/libcockatrice_models/libcockatrice/models/database/card_database_model.cpp
@@ -81,7 +81,7 @@ QVariant CardDatabaseModel::headerData(int section, Qt::Orientation orientation,
     }
 }
 
-void CardDatabaseModel::cardInfoChanged(CardInfoPtr card)
+void CardDatabaseModel::cardInfoChanged(const CardInfoPtr &card)
 {
     const int row = cardList.indexOf(card);
     if (row == -1) {
@@ -91,7 +91,7 @@ void CardDatabaseModel::cardInfoChanged(CardInfoPtr card)
     emit dataChanged(index(row, 0), index(row, CARDDBMODEL_COLUMNS - 1));
 }
 
-bool CardDatabaseModel::checkCardHasAtLeastOneEnabledSet(CardInfoPtr card)
+bool CardDatabaseModel::checkCardHasAtLeastOneEnabledSet(const CardInfoPtr &card) const
 {
     if (!showOnlyCardsFromEnabledSets) {
         return true;
@@ -125,7 +125,7 @@ void CardDatabaseModel::cardDatabaseEnabledSetsChanged()
     }
 }
 
-void CardDatabaseModel::cardAdded(CardInfoPtr card)
+void CardDatabaseModel::cardAdded(const CardInfoPtr &card)
 {
     if (checkCardHasAtLeastOneEnabledSet(card)) {
         // add the card if it's present in at least one enabled set

--- a/libcockatrice_models/libcockatrice/models/database/card_database_model.h
+++ b/libcockatrice_models/libcockatrice/models/database/card_database_model.h
@@ -51,11 +51,11 @@ private:
     CardDatabase *db;
     bool showOnlyCardsFromEnabledSets;
 
-    inline bool checkCardHasAtLeastOneEnabledSet(CardInfoPtr card);
+    inline bool checkCardHasAtLeastOneEnabledSet(const CardInfoPtr &card) const;
 private slots:
-    void cardAdded(CardInfoPtr card);
+    void cardAdded(const CardInfoPtr &card);
     void cardRemoved(CardInfoPtr card);
-    void cardInfoChanged(CardInfoPtr card);
+    void cardInfoChanged(const CardInfoPtr &card);
     void cardDatabaseEnabledSetsChanged();
 };
 


### PR DESCRIPTION
## Short roundup of the initial problem

Some of the methods in `CardDatabaseModel` don't pass `CardInfoPtr` by const ref even though they could. `CardInfoPtr` are shared pointers, so this means it's doing an unnecessary reference count increment on every call.

Usually, this sort of micro-optimization wouldn't matter, but the aforementioned methods *are* being called inside a loop that iterates over the entire card database, so there might actually be some visible effects here as the size of the card database grows.

## What will change with this Pull Request?
- Make methods pass `CardInfoPtr` by const ref

Before
<img width="1541" height="483" alt="Screenshot 2026-05-26 at 12 57 24 AM" src="https://github.com/user-attachments/assets/42230114-35c4-4dbe-b7bd-193aac560f05" />

After
<img width="1543" height="486" alt="Screenshot 2026-05-26 at 12 57 35 AM" src="https://github.com/user-attachments/assets/6f06ec00-e8a1-40b8-83e8-73611e73ad41" />