### PR TITLE
[Game][Player] Split Player into PlayerLogic/PlayerGraphicsItem

### DIFF
--- a/cockatrice/src/game/board/abstract_card_item.h
+++ b/cockatrice/src/game/board/abstract_card_item.h
@@ -44,6 +44,11 @@ signals:
     void deleteCardInfoPopup(QString cardName);
     void sigPixmapUpdated();
     void cardShiftClicked(QString cardName);
+    void rightClicked(AbstractCardItem *card, QPoint screenPos);
+    void playSelected(AbstractCardItem *card);
+    void playSelectedFaceDown(AbstractCardItem *card);
+    void hideSelected(AbstractCardItem *card);
+    void selectionChanged(AbstractCardItem *card, bool selected);
 
 public:
     enum

--- a/cockatrice/src/game/board/card_item.cpp
+++ b/cockatrice/src/game/board/card_item.cpp
@@ -40,7 +40,7 @@ void CardItem::prepareDelete()
 {
     if (owner != nullptr) {
         if (owner->getGame()->getActiveCard() == this) {
-            owner->getPlayerMenu()->updateCardMenu(nullptr);
+            emit owner->requestCardMenuUpdate(nullptr);
             owner->getGame()->setActiveCard(nullptr);
         }
         owner = nullptr;
@@ -399,8 +399,11 @@ void CardItem::playCard(bool faceDown)
         emit tz->toggleTapped();
     } else {
         if (SettingsCache::instance().getClickPlaysAllSelected()) {
-            faceDown ? state->getZone()->getPlayer()->getPlayerActions()->actPlayFacedown()
-                     : state->getZone()->getPlayer()->getPlayerActions()->actPlay();
+            if (faceDown) {
+                emit playSelectedFaceDown(this);
+            } else {
+                emit playSelected(this);
+            }
         } else {
             state->getZone()->getPlayer()->getPlayerActions()->playCard(this, faceDown);
         }
@@ -460,7 +463,7 @@ void CardItem::handleClickedToPlay(bool shiftHeld)
 {
     if (isUnwritableRevealZone(state->getZone())) {
         if (SettingsCache::instance().getClickPlaysAllSelected()) {
-            state->getZone()->getPlayer()->getPlayerActions()->actHide();
+            emit hideSelected(this);
         } else {
             state->getZone()->removeCard(this);
         }
@@ -471,17 +474,12 @@ void CardItem::handleClickedToPlay(bool shiftHeld)
 
 void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
-    if (event->button() == Qt::RightButton) {
-
-        if (owner != nullptr) {
-            owner->getGame()->setActiveCard(this);
-            if (QMenu *cardMenu = owner->getPlayerMenu()->updateCardMenu(this)) {
-                cardMenu->popup(event->screenPos());
-                return;
-            }
-        }
-    } else if ((event->modifiers() != Qt::AltModifier) && (event->button() == Qt::LeftButton) &&
-               (!SettingsCache::instance().getDoubleClickToPlay())) {
+    if (event->button() == Qt::RightButton && owner != nullptr) {
+        emit rightClicked(this, event->screenPos());
+        return;
+    }
+    if ((event->modifiers() != Qt::AltModifier) && (event->button() == Qt::LeftButton) &&
+        (!SettingsCache::instance().getDoubleClickToPlay())) {
         handleClickedToPlay(event->modifiers().testFlag(Qt::ShiftModifier));
     }
 
@@ -531,14 +529,14 @@ bool CardItem::animationEvent()
 QVariant CardItem::itemChange(GraphicsItemChange change, const QVariant &value)
 {
     if ((change == ItemSelectedHasChanged) && owner != nullptr) {
-        if (value == true) {
-            owner->getGame()->setActiveCard(this);
-            owner->getPlayerMenu()->updateCardMenu(this);
-        } else if (owner->getGameScene()->selectedItems().isEmpty()) {
+        bool selected = value.toBool();
 
-            owner->getGame()->setActiveCard(nullptr);
-            owner->getPlayerMenu()->updateCardMenu(nullptr);
+        if (selected) {
+            owner->getGame()->setActiveCard(this);
         }
+
+        emit selectionChanged(this, selected);
     }
+
     return AbstractCardItem::itemChange(change, value);
 }

--- a/cockatrice/src/game/board/card_item.cpp
+++ b/cockatrice/src/game/board/card_item.cpp
@@ -476,7 +476,6 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     if (event->button() == Qt::RightButton && owner != nullptr) {
         emit rightClicked(this, event->screenPos());
-        return;
     }
     if ((event->modifiers() != Qt::AltModifier) && (event->button() == Qt::LeftButton) &&
         (!SettingsCache::instance().getDoubleClickToPlay())) {

--- a/cockatrice/src/game/game_scene.cpp
+++ b/cockatrice/src/game/game_scene.cpp
@@ -203,6 +203,7 @@ void GameScene::removePlayer(PlayerLogic *player)
     }
     auto *view = playerViews.take(player->getPlayerInfo()->getId());
     removeItem(view);
+    view->deleteLater();
     rearrange();
 }
 

--- a/cockatrice/src/game/game_scene.cpp
+++ b/cockatrice/src/game/game_scene.cpp
@@ -4,8 +4,10 @@
 #include "../game_graphics/zones/select_zone.h"
 #include "../game_graphics/zones/view_zone.h"
 #include "../game_graphics/zones/view_zone_widget.h"
+#include "abstract_game.h"
 #include "board/card_item.h"
 #include "phases_toolbar.h"
+#include "player/player_actions.h"
 #include "player/player_graphics_item.h"
 #include "player/player_logic.h"
 
@@ -72,6 +74,80 @@ QList<CardItem *> GameScene::selectedCards() const
     return selectedCards;
 }
 
+void GameScene::onCardSelectionChanged(AbstractCardItem *abstractCard, bool selected)
+{
+    CardItem *card = qobject_cast<CardItem *>(abstractCard);
+    if (!card || !card->getOwner()) {
+        return;
+    }
+
+    auto *owner = card->getOwner();
+
+    if (selected) {
+        owner->requestCardMenuUpdate(card);
+        return;
+    }
+
+    if (selectedItems().isEmpty()) {
+        owner->getGame()->setActiveCard(nullptr);
+        owner->requestCardMenuUpdate(nullptr);
+    }
+}
+
+void GameScene::onCardRightClicked(AbstractCardItem *abstractCard, QPoint screenPos)
+{
+    auto *card = qobject_cast<CardItem *>(abstractCard);
+    if (!card) {
+        return;
+    }
+    if (!card->getOwner()) {
+        return;
+    }
+    auto *view = playerViews.value(card->getOwner()->getPlayerInfo()->getId());
+    if (!view) {
+        return;
+    }
+
+    card->getOwner()->getGame()->setActiveCard(card);
+
+    if (auto *menu = view->getPlayerMenu()->updateCardMenu(card)) {
+        menu->popup(screenPos);
+    }
+}
+
+void GameScene::playSelected(AbstractCardItem *card)
+{
+    if (!card) {
+        return;
+    }
+    if (!card->getOwner()) {
+        return;
+    }
+    card->getOwner()->getPlayerActions()->actPlay(selectedCards());
+}
+
+void GameScene::playSelectedFaceDown(AbstractCardItem *card)
+{
+    if (!card) {
+        return;
+    }
+    if (!card->getOwner()) {
+        return;
+    }
+    card->getOwner()->getPlayerActions()->actPlayFacedown(selectedCards());
+}
+
+void GameScene::hideSelected(AbstractCardItem *card)
+{
+    if (!card) {
+        return;
+    }
+    if (!card->getOwner()) {
+        return;
+    }
+    card->getOwner()->getPlayerActions()->actHide(selectedCards());
+}
+
 /**
  * @brief Adds a player to the scene and stores their graphics item.
  * @param player Player to add.
@@ -82,9 +158,11 @@ void GameScene::addPlayer(PlayerLogic *player)
 {
     qCInfo(GameScenePlayerAdditionRemovalLog) << "GameScene::addPlayer name=" << player->getPlayerInfo()->getName();
 
-    playerViews.insert(player->getPlayerInfo()->getId(), player->getGraphicsItem());
-    addItem(player->getGraphicsItem());
-    connect(player->getGraphicsItem(), &PlayerGraphicsItem::sizeChanged, this, &GameScene::rearrange);
+    auto *view = new PlayerGraphicsItem(player);
+
+    playerViews.insert(player->getPlayerInfo()->getId(), view);
+    addItem(view);
+    connect(view, &PlayerGraphicsItem::sizeChanged, this, &GameScene::rearrange);
 
     connect(player, &PlayerLogic::concededChanged, this, [this](int id, bool conceded) {
         if (conceded) {
@@ -93,6 +171,8 @@ void GameScene::addPlayer(PlayerLogic *player)
         rearrange();
     });
 
+    connect(player, &PlayerLogic::requestZoneViewToggle, this, &GameScene::toggleZoneView);
+    connect(player, &PlayerLogic::requestRevealedZoneView, this, &GameScene::addRevealedZoneView);
     connect(player, &PlayerLogic::arrowDeleted, this, &GameScene::deleteArrow);
     connect(player, &PlayerLogic::arrowCreateRequested, this, &GameScene::addArrow);
     connect(player, &PlayerLogic::arrowDeleteRequested, this, &GameScene::requestArrowDeletion);
@@ -204,7 +284,7 @@ QList<PlayerLogic *> GameScene::collectActivePlayers(int &firstPlayerIndex) cons
     bool firstPlayerFound = false;
 
     for (auto *pgItem : playerViews.values()) {
-        PlayerLogic *p = pgItem->getPlayer();
+        PlayerLogic *p = pgItem->getLogic();
         if (p && !p->getConceded()) {
             activePlayers.append(p);
             if (!firstPlayerFound && p->getPlayerInfo()->getLocal()) {
@@ -275,12 +355,12 @@ QSizeF GameScene::computeSceneSizeAndPlayerLayout(const QList<PlayerLogic *> &pl
         for (int j = 0; j < rowsInColumn; ++j) {
             PlayerLogic *player = playersIter.next();
             if (col == 0) {
-                playersByColumn[col].prepend(player->getGraphicsItem());
+                playersByColumn[col].prepend(playerViews.value(player->getPlayerInfo()->getId()));
             } else {
-                playersByColumn[col].append(player->getGraphicsItem());
+                playersByColumn[col].append(playerViews.value(player->getPlayerInfo()->getId()));
             }
 
-            auto *pgItem = player->getGraphicsItem();
+            auto *pgItem = playerViews.value(player->getPlayerInfo()->getId());
             thisColumnHeight += pgItem->boundingRect().height() + playerAreaSpacing;
             columnWidth[col] = std::max(columnWidth[col], (int)pgItem->boundingRect().width());
         }
@@ -375,7 +455,8 @@ void GameScene::addArrow(QSharedPointer<ArrowData> data)
         return;
     }
 
-    auto *startZone = startView->getPlayer()->getZones().value(data->startZone);
+    PlayerLogic *startLogic = startView->getLogic();
+    auto *startZone = startLogic->getZones().value(data->startZone);
     if (!startZone) {
         return;
     }
@@ -389,7 +470,8 @@ void GameScene::addArrow(QSharedPointer<ArrowData> data)
     if (data->isPlayerTargeted()) {
         targetItem = targetView->getPlayerTarget();
     } else {
-        if (auto *zone = targetView->getPlayer()->getZones().value(data->targetZone)) {
+        auto *zone = targetView->getLogic()->getZones().value(data->targetZone);
+        if (zone) {
             targetItem = zone->getCard(data->targetCardId);
         }
     }

--- a/cockatrice/src/game/game_scene.h
+++ b/cockatrice/src/game/game_scene.h
@@ -97,6 +97,16 @@ public:
      */
     void removePlayer(PlayerLogic *player);
 
+    QMap<int, PlayerGraphicsItem *> getPlayers() const
+    {
+        return playerViews;
+    }
+
+    PlayerGraphicsItem *viewForPlayer(int playerId)
+    {
+        return playerViews.value(playerId);
+    }
+
     /**
      * @brief Adjusts the global rotation offset for player layout.
      * @param rotationAdjustment Number of positions to rotate.
@@ -182,6 +192,11 @@ public:
     void stopRubberBand();
 
 public slots:
+    void onCardSelectionChanged(AbstractCardItem *card, bool selected);
+    void onCardRightClicked(AbstractCardItem *card, QPoint screenPos);
+    void playSelected(AbstractCardItem *card);
+    void playSelectedFaceDown(AbstractCardItem *card);
+    void hideSelected(AbstractCardItem *card);
     /** @brief Toggles a zone view for a player. */
     void toggleZoneView(PlayerLogic *player, const QString &zoneName, int numberCards, bool isReversed = false);
 

--- a/cockatrice/src/game/player/menu/card_menu.cpp
+++ b/cockatrice/src/game/player/menu/card_menu.cpp
@@ -31,69 +31,84 @@ static QIcon createCircleIcon(const QColor &color)
     return QIcon(pixmap);
 }
 
-CardMenu::CardMenu(PlayerLogic *_player, const CardItem *_card, bool _shortcutsActive)
+template <typename Slot>
+static QAction *makeAction(QObject *parent, Slot &&slot, bool checkable = false, bool checked = false)
+{
+    auto *a = new QAction(parent);
+    a->setCheckable(checkable);
+    if (checkable) {
+        a->setChecked(checked);
+    }
+    QObject::connect(a, &QAction::triggered, parent, std::forward<Slot>(slot));
+    return a;
+}
+
+CardMenu::CardMenu(PlayerGraphicsItem *_player, const CardItem *_card, bool _shortcutsActive)
     : player(_player), card(_card), shortcutsActive(_shortcutsActive)
 {
-    auto playerActions = player->getPlayerActions();
-
-    const QList<PlayerLogic *> &players = player->getGame()->getPlayerManager()->getPlayers().values();
+    const QList<PlayerLogic *> &players = player->getLogic()->getGame()->getPlayerManager()->getPlayers().values();
 
     for (auto playerToAdd : players) {
-        if (playerToAdd == player) {
+        if (playerToAdd == player->getLogic()) {
             continue;
         }
         playersInfo.append(qMakePair(playerToAdd->getPlayerInfo()->getName(), playerToAdd->getPlayerInfo()->getId()));
     }
 
-    connect(player->getGame()->getPlayerManager(), &PlayerManager::playerRemoved, this, &CardMenu::removePlayer);
+    connect(player->getLogic()->getGame()->getPlayerManager(), &PlayerManager::playerRemoved, this,
+            &CardMenu::removePlayer);
 
-    aTap = new QAction(this);
-    aTap->setData(cmTap);
-    connect(aTap, &QAction::triggered, playerActions, &PlayerActions::cardMenuAction);
-    aDoesntUntap = new QAction(this);
-    aDoesntUntap->setData(cmDoesntUntap);
-    aDoesntUntap->setCheckable(true);
-    aDoesntUntap->setChecked(card != nullptr && card->getDoesntUntap());
-    connect(aDoesntUntap, &QAction::triggered, playerActions, &PlayerActions::cardMenuAction);
+    auto *actions = player->getLogic()->getPlayerActions();
+    auto *gameScene = player->getGameScene();
+
+    // Single selection resolver used by all lambdas — called at trigger time
+    auto sel = [gameScene]() { return gameScene->selectedCards(); };
+
+    // Unified dispatcher for card menu actions
+    auto invoke = [actions, sel](CardMenuActionType type) {
+        return [actions, sel, type]() { actions->cardMenuAction(sel(), type); };
+    };
+
+    // Actions using invoke (type dispatch, need selection)
+    aTap = makeAction(this, invoke(cmTap));
+    aDoesntUntap = makeAction(this, invoke(cmDoesntUntap), /*checkable=*/true, card && card->getDoesntUntap());
+    aFlip = makeAction(this, invoke(cmFlip));
+    aPeek = makeAction(this, invoke(cmPeek));
+    aClone = makeAction(this, invoke(cmClone));
+
+    // Actions using selection directly
+    aUnattach = makeAction(this, [actions, sel]() { actions->actUnattach(sel()); });
+    aSetAnnotation = makeAction(this, [actions, sel]() { actions->actSetAnnotation(sel()); });
+    aPlay = makeAction(this, [actions, sel]() { actions->actPlay(sel()); });
+    aPlayFacedown = makeAction(this, [actions, sel]() { actions->actPlayFacedown(sel()); });
+    aHide = makeAction(this, [actions, sel]() { actions->actHide(sel()); });
+    aReduceLifeByPower = makeAction(this, [actions, sel]() { actions->actReduceLifeByPower(sel()); });
+
+    // Actions that use activeCard, not selection — direct connection
     aAttach = new QAction(this);
-    connect(aAttach, &QAction::triggered, playerActions, &PlayerActions::actAttach);
-    aUnattach = new QAction(this);
-    connect(aUnattach, &QAction::triggered, playerActions, &PlayerActions::actUnattach);
     aDrawArrow = new QAction(this);
-    connect(aDrawArrow, &QAction::triggered, playerActions, &PlayerActions::actDrawArrow);
-    aSetAnnotation = new QAction(this);
-    connect(aSetAnnotation, &QAction::triggered, playerActions, &PlayerActions::actSetAnnotation);
-    aFlip = new QAction(this);
-    aFlip->setData(cmFlip);
-    connect(aFlip, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
-    aPeek = new QAction(this);
-    aPeek->setData(cmPeek);
-    connect(aPeek, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
-    aClone = new QAction(this);
-    aClone->setData(cmClone);
-    connect(aClone, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
     aSelectAll = new QAction(this);
-    connect(aSelectAll, &QAction::triggered, playerActions, &PlayerActions::actSelectAll);
     aSelectRow = new QAction(this);
-    connect(aSelectRow, &QAction::triggered, playerActions, &PlayerActions::actSelectRow);
     aSelectColumn = new QAction(this);
-    connect(aSelectColumn, &QAction::triggered, playerActions, &PlayerActions::actSelectColumn);
 
-    aReduceLifeByPower = new QAction(this);
-    connect(aReduceLifeByPower, &QAction::triggered, playerActions, &PlayerActions::actReduceLifeByPower);
-
-    aPlay = new QAction(this);
-    connect(aPlay, &QAction::triggered, playerActions, &PlayerActions::actPlay);
-    aHide = new QAction(this);
-    connect(aHide, &QAction::triggered, playerActions, &PlayerActions::actHide);
-    aPlayFacedown = new QAction(this);
-    connect(aPlayFacedown, &QAction::triggered, playerActions, &PlayerActions::actPlayFacedown);
+    connect(aAttach, &QAction::triggered, actions, &PlayerActions::actAttach);
+    connect(aDrawArrow, &QAction::triggered, actions, &PlayerActions::actDrawArrow);
+    connect(aSelectAll, &QAction::triggered, actions, &PlayerActions::actSelectAll);
+    connect(aSelectRow, &QAction::triggered, actions, &PlayerActions::actSelectRow);
+    connect(aSelectColumn, &QAction::triggered, actions, &PlayerActions::actSelectColumn);
 
     aRevealToAll = new QAction(this);
 
     mCardCounters = new QMenu;
 
+    // Card counters
     for (int i = 0; i < 6; ++i) {
+        aAddCounter.append(makeAction(this, [actions, sel, i]() { actions->actAddCardCounter(sel(), i); }));
+        aRemoveCounter.append(makeAction(this, [actions, sel, i]() { actions->actRemoveCardCounter(sel(), i); }));
+        aSetCounter.append(makeAction(this, [actions, sel, i]() { actions->actSetCardCounter(sel(), i); }));
+    }
+
+    /*for (int i = 0; i < 6; ++i) {
         QColor color = SettingsCache::instance().cardCounters().color(i);
         QIcon circleIcon = createCircleIcon(color);
 
@@ -118,7 +133,7 @@ CardMenu::CardMenu(PlayerLogic *_player, const CardItem *_card, bool _shortcutsA
                 [playerActions, i] { playerActions->actRemoveCardCounter(i); });
         connect(tempSetCounter, &QAction::triggered, playerActions,
                 [playerActions, i] { playerActions->actSetCardCounter(i); });
-    }
+    }*/
 
     setShortcutsActive();
 
@@ -129,7 +144,7 @@ CardMenu::CardMenu(PlayerLogic *_player, const CardItem *_card, bool _shortcutsA
     }
 
     bool revealedCard = false;
-    bool writeableCard = player->getPlayerInfo()->getLocalOrJudge();
+    bool writeableCard = player->getLogic()->getPlayerInfo()->getLocalOrJudge();
     if (auto *view = qobject_cast<ZoneViewZoneLogic *>(card->getZone())) {
         if (view->getRevealZone()) {
             if (view->getWriteableRevealZone()) {
@@ -313,7 +328,9 @@ void CardMenu::createHandOrCustomZoneMenu(bool canModifyCard)
 
     initContextualPlayersMenu(revealMenu, aRevealToAll);
 
-    connect(revealMenu, &QMenu::triggered, player->getPlayerActions(), &PlayerActions::actReveal);
+    connect(revealMenu, &QMenu::triggered, this, [this](QAction *action) {
+        player->getLogic()->getPlayerActions()->actReveal(player->getGameScene()->selectedCards(), action);
+    });
 
     addSeparator();
     addAction(aClone);
@@ -398,8 +415,7 @@ void CardMenu::addRelatedCardView()
         QAction *viewCard = viewRelatedCards->addAction(relatedCardName);
         Q_UNUSED(viewCard);
 
-        connect(viewCard, &QAction::triggered, player->getGame(),
-                [this, cardRef] { player->getGame()->getTab()->viewCardInfo(cardRef); });
+        connect(viewCard, &QAction::triggered, this, [this, cardRef] { emit cardInfoRequested(cardRef); });
     }
 }
 
@@ -461,7 +477,8 @@ void CardMenu::addRelatedCardActions()
 
         auto *createRelated = new QAction(text, this);
         createRelated->setData(QVariant(index++));
-        connect(createRelated, &QAction::triggered, player->getPlayerActions(), &PlayerActions::actCreateRelatedCard);
+        connect(createRelated, &QAction::triggered, player->getLogic()->getPlayerActions(),
+                &PlayerActions::actCreateRelatedCard);
         addAction(createRelated);
     }
 
@@ -470,7 +487,7 @@ void CardMenu::addRelatedCardActions()
             createRelatedCards->setShortcuts(
                 SettingsCache::instance().shortcuts().getShortcut("Player/aCreateRelatedTokens"));
         }
-        connect(createRelatedCards, &QAction::triggered, player->getPlayerActions(),
+        connect(createRelatedCards, &QAction::triggered, player->getLogic()->getPlayerActions(),
                 &PlayerActions::actCreateAllRelatedCards);
         addAction(createRelatedCards);
     }

--- a/cockatrice/src/game/player/menu/card_menu.cpp
+++ b/cockatrice/src/game/player/menu/card_menu.cpp
@@ -103,37 +103,21 @@ CardMenu::CardMenu(PlayerGraphicsItem *_player, const CardItem *_card, bool _sho
 
     // Card counters
     for (int i = 0; i < 6; ++i) {
-        aAddCounter.append(makeAction(this, [actions, sel, i]() { actions->actAddCardCounter(sel(), i); }));
-        aRemoveCounter.append(makeAction(this, [actions, sel, i]() { actions->actRemoveCardCounter(sel(), i); }));
-        aSetCounter.append(makeAction(this, [actions, sel, i]() { actions->actSetCardCounter(sel(), i); }));
-    }
-
-    /*for (int i = 0; i < 6; ++i) {
         QColor color = SettingsCache::instance().cardCounters().color(i);
         QIcon circleIcon = createCircleIcon(color);
 
-        auto *tempAddCounter = new QAction(this);
-        tempAddCounter->setIconVisibleInMenu(true);
-        tempAddCounter->setIcon(circleIcon);
+        auto *addAction = makeAction(this, [actions, sel, i]() { actions->actAddCardCounter(sel(), i); });
+        addAction->setIcon(circleIcon);
+        aAddCounter.append(addAction);
 
-        auto *tempRemoveCounter = new QAction(this);
-        tempRemoveCounter->setIconVisibleInMenu(true);
-        tempRemoveCounter->setIcon(circleIcon);
+        auto *removeAction = makeAction(this, [actions, sel, i]() { actions->actRemoveCardCounter(sel(), i); });
+        removeAction->setIcon(circleIcon);
+        aRemoveCounter.append(removeAction);
 
-        auto *tempSetCounter = new QAction(this);
-        tempSetCounter->setIconVisibleInMenu(true);
-        tempSetCounter->setIcon(circleIcon);
-
-        aAddCounter.append(tempAddCounter);
-        aRemoveCounter.append(tempRemoveCounter);
-        aSetCounter.append(tempSetCounter);
-        connect(tempAddCounter, &QAction::triggered, playerActions,
-                [playerActions, i] { playerActions->actAddCardCounter(i); });
-        connect(tempRemoveCounter, &QAction::triggered, playerActions,
-                [playerActions, i] { playerActions->actRemoveCardCounter(i); });
-        connect(tempSetCounter, &QAction::triggered, playerActions,
-                [playerActions, i] { playerActions->actSetCardCounter(i); });
-    }*/
+        auto *setAction = makeAction(this, [actions, sel, i]() { actions->actSetCardCounter(sel(), i); });
+        setAction->setIcon(circleIcon);
+        aSetCounter.append(setAction);
+    }
 
     setShortcutsActive();
 

--- a/cockatrice/src/game/player/menu/card_menu.h
+++ b/cockatrice/src/game/player/menu/card_menu.h
@@ -8,15 +8,20 @@
 #define COCKATRICE_CARD_MENU_H
 
 #include <QMenu>
+#include <libcockatrice/utility/card_ref.h>
 
 class CardItem;
+class PlayerGraphicsItem;
 class PlayerLogic;
 class CardMenu : public QMenu
 {
     Q_OBJECT
 
+signals:
+    void cardInfoRequested(const CardRef &cardRef);
+
 public:
-    explicit CardMenu(PlayerLogic *player, const CardItem *card, bool shortcutsActive);
+    explicit CardMenu(PlayerGraphicsItem *player, const CardItem *card, bool shortcutsActive);
     void removePlayer(PlayerLogic *playerToRemove);
     void createTableMenu(bool canModifyCard);
     void createStackMenu(bool canModifyCard);
@@ -41,7 +46,7 @@ public:
     QList<QAction *> aAddCounter, aSetCounter, aRemoveCounter;
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
     const CardItem *card;
     QList<QPair<QString, int>> playersInfo;
     bool shortcutsActive;

--- a/cockatrice/src/game/player/menu/custom_zone_menu.cpp
+++ b/cockatrice/src/game/player/menu/custom_zone_menu.cpp
@@ -2,12 +2,12 @@
 
 #include "../player_logic.h"
 
-CustomZoneMenu::CustomZoneMenu(PlayerLogic *_player) : player(_player)
+CustomZoneMenu::CustomZoneMenu(PlayerGraphicsItem *_player) : player(_player)
 {
     menuAction()->setVisible(false);
 
-    connect(player, &PlayerLogic::clearCustomZonesMenu, this, &CustomZoneMenu::clearCustomZonesMenu);
-    connect(player, &PlayerLogic::addViewCustomZoneActionToCustomZoneMenu, this,
+    connect(player->getLogic(), &PlayerLogic::clearCustomZonesMenu, this, &CustomZoneMenu::clearCustomZonesMenu);
+    connect(player->getLogic(), &PlayerLogic::addViewCustomZoneActionToCustomZoneMenu, this,
             &CustomZoneMenu::addViewCustomZoneActionToCustomZoneMenu);
 
     retranslateUi();
@@ -17,7 +17,7 @@ void CustomZoneMenu::retranslateUi()
 {
     setTitle(tr("C&ustom Zones"));
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
 
         for (auto aViewZone : actions()) {
             aViewZone->setText(tr("View custom zone '%1'").arg(aViewZone->data().toString()));
@@ -37,5 +37,5 @@ void CustomZoneMenu::addViewCustomZoneActionToCustomZoneMenu(QString zoneName)
     QAction *aViewZone = addAction(tr("View custom zone '%1'").arg(zoneName));
     aViewZone->setData(zoneName);
     connect(aViewZone, &QAction::triggered, this,
-            [zoneName, this]() { player->getGameScene()->toggleZoneView(player, zoneName, -1); });
+            [zoneName, this]() { player->getGameScene()->toggleZoneView(player->getLogic(), zoneName, -1); });
 }

--- a/cockatrice/src/game/player/menu/custom_zone_menu.h
+++ b/cockatrice/src/game/player/menu/custom_zone_menu.h
@@ -11,12 +11,12 @@
 
 #include <QMenu>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class CustomZoneMenu : public QMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 public:
-    explicit CustomZoneMenu(PlayerLogic *player);
+    explicit CustomZoneMenu(PlayerGraphicsItem *player);
     void retranslateUi() override;
     void setShortcutsActive() override
     {
@@ -26,7 +26,7 @@ public:
     }
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
 private slots:
     void clearCustomZonesMenu();
     void addViewCustomZoneActionToCustomZoneMenu(QString zoneName);

--- a/cockatrice/src/game/player/menu/move_menu.cpp
+++ b/cockatrice/src/game/player/menu/move_menu.cpp
@@ -4,7 +4,7 @@
 #include "../player_actions.h"
 #include "../player_logic.h"
 
-MoveMenu::MoveMenu(PlayerLogic *player) : QMenu(tr("Move to"))
+MoveMenu::MoveMenu(PlayerGraphicsItem *player) : QMenu(tr("Move to"))
 {
     aMoveToTopLibrary = new QAction(this);
     aMoveToTopLibrary->setData(cmMoveToTopLibrary);
@@ -20,14 +20,23 @@ MoveMenu::MoveMenu(PlayerLogic *player) : QMenu(tr("Move to"))
     aMoveToExile = new QAction(this);
     aMoveToExile->setData(cmMoveToExile);
 
-    connect(aMoveToTopLibrary, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
-    connect(aMoveToBottomLibrary, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
-    connect(aMoveToXfromTopOfLibrary, &QAction::triggered, player->getPlayerActions(),
-            &PlayerActions::actMoveCardXCardsFromTop);
-    connect(aMoveToTable, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
-    connect(aMoveToHand, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
-    connect(aMoveToGraveyard, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
-    connect(aMoveToExile, &QAction::triggered, player->getPlayerActions(), &PlayerActions::cardMenuAction);
+    auto *actions = player->getLogic()->getPlayerActions();
+
+    auto invoke = [player](CardMenuActionType type) {
+        return [type, player]() {
+            player->getLogic()->getPlayerActions()->cardMenuAction(player->getGameScene()->selectedCards(), type);
+        };
+    };
+
+    connect(aMoveToTopLibrary, &QAction::triggered, actions, invoke(cmMoveToTopLibrary));
+    connect(aMoveToBottomLibrary, &QAction::triggered, actions, invoke(cmMoveToBottomLibrary));
+    connect(aMoveToXfromTopOfLibrary, &QAction::triggered, actions, [player]() {
+        player->getLogic()->getPlayerActions()->actMoveCardXCardsFromTop(player->getGameScene()->selectedCards());
+    });
+    connect(aMoveToTable, &QAction::triggered, actions, invoke(cmMoveToTable));
+    connect(aMoveToHand, &QAction::triggered, actions, invoke(cmMoveToHand));
+    connect(aMoveToGraveyard, &QAction::triggered, actions, invoke(cmMoveToGraveyard));
+    connect(aMoveToExile, &QAction::triggered, actions, invoke(cmMoveToExile));
 
     addAction(aMoveToTopLibrary);
     addAction(aMoveToXfromTopOfLibrary);

--- a/cockatrice/src/game/player/menu/move_menu.h
+++ b/cockatrice/src/game/player/menu/move_menu.h
@@ -8,13 +8,13 @@
 #define COCKATRICE_MOVE_MENU_H
 #include <QMenu>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class MoveMenu : public QMenu
 {
     Q_OBJECT
 
 public:
-    explicit MoveMenu(PlayerLogic *player);
+    explicit MoveMenu(PlayerGraphicsItem *player);
     void setShortcutsActive();
     void retranslateUi();
 

--- a/cockatrice/src/game/player/menu/player_menu.cpp
+++ b/cockatrice/src/game/player/menu/player_menu.cpp
@@ -10,23 +10,26 @@
 
 #include <libcockatrice/protocol/pb/command_reveal_cards.pb.h>
 
-PlayerMenu::PlayerMenu(PlayerLogic *_player) : QObject(_player), player(_player)
+PlayerMenu::PlayerMenu(PlayerGraphicsItem *_player) : QObject(_player), player(_player)
 {
+    connect(player->getLogic(), &PlayerLogic::requestCardMenuUpdate, this, &PlayerMenu::updateCardMenu);
+    connect(this, &PlayerMenu::cardInfoRequested, player, &PlayerGraphicsItem::cardInfoRequested);
+
     playerMenu = new TearOffMenu();
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
-        handMenu = addManagedMenu<HandMenu>(player, player->getPlayerActions(), playerMenu);
-        libraryMenu = addManagedMenu<LibraryMenu>(player, playerMenu);
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
+        handMenu = addManagedMenu<HandMenu>(player->getLogic(), player->getLogic()->getPlayerActions(), playerMenu);
+        libraryMenu = addManagedMenu<LibraryMenu>(player->getLogic(), playerMenu);
     } else {
         handMenu = nullptr;
         libraryMenu = nullptr;
     }
 
-    graveMenu = addManagedMenu<GraveyardMenu>(player, playerMenu);
-    rfgMenu = addManagedMenu<RfgMenu>(player, playerMenu);
+    graveMenu = addManagedMenu<GraveyardMenu>(player->getLogic(), playerMenu);
+    rfgMenu = addManagedMenu<RfgMenu>(player->getLogic(), playerMenu);
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
-        sideboardMenu = addManagedMenu<SideboardMenu>(player, playerMenu);
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
+        sideboardMenu = addManagedMenu<SideboardMenu>(player->getLogic(), playerMenu);
         customZonesMenu = addManagedMenu<CustomZoneMenu>(player);
         playerMenu->addSeparator();
 
@@ -40,8 +43,8 @@ PlayerMenu::PlayerMenu(PlayerLogic *_player) : QObject(_player), player(_player)
         utilityMenu = nullptr;
     }
 
-    if (player->getPlayerInfo()->getLocal()) {
-        sayMenu = addManagedMenu<SayMenu>(player);
+    if (player->getLogic()->getPlayerInfo()->getLocal()) {
+        sayMenu = addManagedMenu<SayMenu>(player->getLogic());
     } else {
         sayMenu = nullptr;
     }
@@ -55,13 +58,13 @@ PlayerMenu::PlayerMenu(PlayerLogic *_player) : QObject(_player), player(_player)
 
 void PlayerMenu::setMenusForGraphicItems()
 {
-    player->getGraphicsItem()->getTableZoneGraphicsItem()->setMenu(playerMenu);
-    player->getGraphicsItem()->getGraveyardZoneGraphicsItem()->setMenu(graveMenu, graveMenu->aViewGraveyard);
-    player->getGraphicsItem()->getRfgZoneGraphicsItem()->setMenu(rfgMenu, rfgMenu->aViewRfg);
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
-        player->getGraphicsItem()->getHandZoneGraphicsItem()->setMenu(handMenu);
-        player->getGraphicsItem()->getDeckZoneGraphicsItem()->setMenu(libraryMenu, libraryMenu->aDrawCard);
-        player->getGraphicsItem()->getSideboardZoneGraphicsItem()->setMenu(sideboardMenu);
+    player->getTableZoneGraphicsItem()->setMenu(playerMenu);
+    player->getGraveyardZoneGraphicsItem()->setMenu(graveMenu, graveMenu->aViewGraveyard);
+    player->getRfgZoneGraphicsItem()->setMenu(rfgMenu, rfgMenu->aViewRfg);
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
+        player->getHandZoneGraphicsItem()->setMenu(handMenu);
+        player->getDeckZoneGraphicsItem()->setMenu(libraryMenu, libraryMenu->aDrawCard);
+        player->getSideboardZoneGraphicsItem()->setMenu(sideboardMenu);
     }
 }
 
@@ -74,12 +77,14 @@ QMenu *PlayerMenu::updateCardMenu(const CardItem *card)
 
     // If is spectator (as spectators don't need card menus), return
     // only update the menu if the card is actually selected
-    if ((player->getGame()->getPlayerManager()->isSpectator() && !player->getGame()->getPlayerManager()->isJudge()) ||
-        player->getGame()->getActiveCard() != card) {
+    if ((player->getLogic()->getGame()->getPlayerManager()->isSpectator() &&
+         !player->getLogic()->getGame()->getPlayerManager()->isJudge()) ||
+        player->getLogic()->getGame()->getActiveCard() != card) {
         return nullptr;
     }
 
-    QMenu *menu = new CardMenu(player, card, shortcutsActive);
+    CardMenu *menu = new CardMenu(player, card, shortcutsActive);
+    connect(menu, &CardMenu::cardInfoRequested, this, &PlayerMenu::cardInfoRequested);
     emit cardMenuUpdated(menu);
 
     return menu;
@@ -87,7 +92,7 @@ QMenu *PlayerMenu::updateCardMenu(const CardItem *card)
 
 void PlayerMenu::retranslateUi()
 {
-    playerMenu->setTitle(tr("Player \"%1\"").arg(player->getPlayerInfo()->getName()));
+    playerMenu->setTitle(tr("Player \"%1\"").arg(player->getLogic()->getPlayerInfo()->getName()));
 
     for (auto *component : managedComponents) {
         component->retranslateUi();
@@ -104,7 +109,8 @@ void PlayerMenu::refreshShortcuts()
 {
     if (shortcutsActive) {
         // Judges get access to every player's menus but only want shortcuts to be set for their own.
-        if (player->getPlayerInfo()->getLocalOrJudge() && !player->getPlayerInfo()->getLocal()) {
+        if (player->getLogic()->getPlayerInfo()->getLocalOrJudge() &&
+            !player->getLogic()->getPlayerInfo()->getLocal()) {
             setShortcutsInactive();
         } else {
             setShortcutsActive();

--- a/cockatrice/src/game/player/menu/player_menu.h
+++ b/cockatrice/src/game/player/menu/player_menu.h
@@ -8,7 +8,6 @@
 #define COCKATRICE_PLAYER_MENU_H
 
 #include "../../../interface/widgets/menus/tearoff_menu.h"
-#include "../player_logic.h"
 #include "custom_zone_menu.h"
 #include "grave_menu.h"
 #include "hand_menu.h"
@@ -23,28 +22,30 @@
 #include <QObject>
 
 class CardItem;
+class CardMenu;
+class PlayerGraphicsItem;
 class PlayerMenu : public QObject
 {
     Q_OBJECT
 
 signals:
-    void cardMenuUpdated(QMenu *cardMenu);
+    void cardMenuUpdated(CardMenu *cardMenu);
+    void cardInfoRequested(const CardRef &cardRef);
     void shortcutsActivated();
     void shortcutsDeactivated();
     void retranslateRequested();
 
 public slots:
     void setMenusForGraphicItems();
+    QMenu *updateCardMenu(const CardItem *card);
 
 private slots:
     void refreshShortcuts();
 
 public:
-    explicit PlayerMenu(PlayerLogic *player);
+    explicit PlayerMenu(PlayerGraphicsItem *player);
     /** @brief Retranslate all user-visible strings. Called on language change. */
     void retranslateUi();
-
-    QMenu *updateCardMenu(const CardItem *card);
 
     [[nodiscard]] QMenu *getPlayerMenu() const
     {
@@ -77,7 +78,7 @@ public:
     void setShortcutsInactive();
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
     TearOffMenu *playerMenu;
     QMenu *countersMenu;
     HandMenu *handMenu;

--- a/cockatrice/src/game/player/menu/pt_menu.cpp
+++ b/cockatrice/src/game/player/menu/pt_menu.cpp
@@ -3,30 +3,40 @@
 #include "../player_actions.h"
 #include "../player_logic.h"
 
-PtMenu::PtMenu(PlayerLogic *player) : QMenu(tr("Power / toughness"))
+PtMenu::PtMenu(PlayerGraphicsItem *player) : QMenu(tr("Power / toughness"))
 {
-    PlayerActions *playerActions = player->getPlayerActions();
+    PlayerActions *playerActions = player->getLogic()->getPlayerActions();
 
     aIncP = new QAction(this);
-    connect(aIncP, &QAction::triggered, playerActions, &PlayerActions::actIncP);
+    connect(aIncP, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actIncP(player->getGameScene()->selectedCards()); });
     aDecP = new QAction(this);
-    connect(aDecP, &QAction::triggered, playerActions, &PlayerActions::actDecP);
+    connect(aDecP, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actDecP(player->getGameScene()->selectedCards()); });
     aIncT = new QAction(this);
-    connect(aIncT, &QAction::triggered, playerActions, &PlayerActions::actIncT);
+    connect(aIncT, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actIncT(player->getGameScene()->selectedCards()); });
     aDecT = new QAction(this);
-    connect(aDecT, &QAction::triggered, playerActions, &PlayerActions::actDecT);
+    connect(aDecT, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actDecT(player->getGameScene()->selectedCards()); });
     aIncPT = new QAction(this);
-    connect(aIncPT, &QAction::triggered, playerActions, [playerActions] { playerActions->actIncPT(); });
+    connect(aIncPT, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actIncPT(player->getGameScene()->selectedCards()); });
     aDecPT = new QAction(this);
-    connect(aDecPT, &QAction::triggered, playerActions, &PlayerActions::actDecPT);
+    connect(aDecPT, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actDecPT(player->getGameScene()->selectedCards()); });
     aFlowP = new QAction(this);
-    connect(aFlowP, &QAction::triggered, playerActions, &PlayerActions::actFlowP);
+    connect(aFlowP, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actFlowP(player->getGameScene()->selectedCards()); });
     aFlowT = new QAction(this);
-    connect(aFlowT, &QAction::triggered, playerActions, &PlayerActions::actFlowT);
+    connect(aFlowT, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actFlowT(player->getGameScene()->selectedCards()); });
     aSetPT = new QAction(this);
-    connect(aSetPT, &QAction::triggered, playerActions, &PlayerActions::actSetPT);
+    connect(aSetPT, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actSetPT(player->getGameScene()->selectedCards()); });
     aResetPT = new QAction(this);
-    connect(aResetPT, &QAction::triggered, playerActions, &PlayerActions::actResetPT);
+    connect(aResetPT, &QAction::triggered, playerActions,
+            [player, playerActions] { playerActions->actResetPT(player->getGameScene()->selectedCards()); });
 
     addAction(aIncP);
     addAction(aDecP);

--- a/cockatrice/src/game/player/menu/pt_menu.h
+++ b/cockatrice/src/game/player/menu/pt_menu.h
@@ -8,14 +8,14 @@
 #define COCKATRICE_PT_MENU_H
 #include <QMenu>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class PtMenu : public QMenu
 {
 
     Q_OBJECT
 
 public:
-    explicit PtMenu(PlayerLogic *player);
+    explicit PtMenu(PlayerGraphicsItem *player);
     void retranslateUi();
     void setShortcutsActive();
 

--- a/cockatrice/src/game/player/menu/utility_menu.cpp
+++ b/cockatrice/src/game/player/menu/utility_menu.cpp
@@ -8,11 +8,14 @@
 #include <libcockatrice/deck_list/tree/deck_list_card_node.h>
 #include <libcockatrice/deck_list/tree/inner_deck_list_node.h>
 
-UtilityMenu::UtilityMenu(PlayerLogic *_player, QMenu *playerMenu) : QMenu(playerMenu), player(_player)
+UtilityMenu::UtilityMenu(PlayerGraphicsItem *_player, QMenu *playerMenu) : QMenu(playerMenu), player(_player)
 {
-    PlayerActions *playerActions = player->getPlayerActions();
+    PlayerActions *playerActions = player->getLogic()->getPlayerActions();
+    connect(playerActions, &PlayerActions::requestEnableAndSetCreateAnotherTokenAction, this,
+            &UtilityMenu::setAndEnableCreateAnotherTokenAction);
+    connect(playerActions, &PlayerActions::requestSetLastToken, this, &UtilityMenu::setLastToken);
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aUntapAll = new QAction(this);
         connect(aUntapAll, &QAction::triggered, playerActions, &PlayerActions::actUntapAll);
 
@@ -23,19 +26,22 @@ UtilityMenu::UtilityMenu(PlayerLogic *_player, QMenu *playerMenu) : QMenu(player
         connect(aFlipCoin, &QAction::triggered, playerActions, &PlayerActions::actFlipCoin);
 
         aCreateToken = new QAction(this);
-        connect(aCreateToken, &QAction::triggered, playerActions, &PlayerActions::actCreateToken);
+        connect(aCreateToken, &QAction::triggered, playerActions,
+                [this]() { player->getLogic()->getPlayerActions()->actCreateToken(getPredefinedTokens()); });
 
         aCreateAnotherToken = new QAction(this);
         connect(aCreateAnotherToken, &QAction::triggered, playerActions, &PlayerActions::actCreateAnotherToken);
         aCreateAnotherToken->setEnabled(false);
 
         aIncrementAllCardCounters = new QAction(this);
-        connect(aIncrementAllCardCounters, &QAction::triggered, playerActions,
-                &PlayerActions::actIncrementAllCardCounters);
+        connect(aIncrementAllCardCounters, &QAction::triggered, playerActions, [this]() {
+            player->getLogic()->getPlayerActions()->actIncrementAllCardCounters(
+                player->getGameScene()->selectedCards());
+        });
 
         createPredefinedTokenMenu = new QMenu(QString());
         createPredefinedTokenMenu->setEnabled(false);
-        connect(player, &PlayerLogic::deckChanged, this, &UtilityMenu::populatePredefinedTokensMenu);
+        connect(player->getLogic(), &PlayerLogic::deckChanged, this, &UtilityMenu::populatePredefinedTokensMenu);
 
         playerMenu->addAction(aIncrementAllCardCounters);
         playerMenu->addSeparator();
@@ -66,7 +72,7 @@ void UtilityMenu::populatePredefinedTokensMenu()
     clear();
     setEnabled(false);
     predefinedTokens.clear();
-    const DeckList &deckList = player->getDeck();
+    const DeckList &deckList = player->getLogic()->getDeck();
 
     if (deckList.isEmpty()) {
         return;
@@ -84,14 +90,24 @@ void UtilityMenu::populatePredefinedTokensMenu()
             if (i < 10) {
                 a->setShortcut(QKeySequence("Alt+" + QString::number((i + 1) % 10)));
             }
-            connect(a, &QAction::triggered, player->getPlayerActions(), &PlayerActions::actCreatePredefinedToken);
+            connect(a, &QAction::triggered, player->getLogic()->getPlayerActions(),
+                    &PlayerActions::actCreatePredefinedToken);
         }
     }
 }
 
+void UtilityMenu::setLastToken(CardInfoPtr lastToken)
+{
+    if (!createAnotherTokenActionExists()) {
+        return;
+    }
+
+    player->getLogic()->getPlayerActions()->setLastTokenInfo(lastToken);
+}
+
 void UtilityMenu::retranslateUi()
 {
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aIncrementAllCardCounters->setText(tr("Increment all card counters"));
         aUntapAll->setText(tr("&Untap all permanents"));
         aRollDie->setText(tr("R&oll die..."));
@@ -106,7 +122,7 @@ void UtilityMenu::setShortcutsActive()
 {
     ShortcutsSettings &shortcuts = SettingsCache::instance().shortcuts();
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aIncrementAllCardCounters->setShortcuts(shortcuts.getShortcut("Player/aIncrementAllCardCounters"));
         aUntapAll->setShortcuts(shortcuts.getShortcut("Player/aUntapAll"));
         aRollDie->setShortcuts(shortcuts.getShortcut("Player/aRollDie"));
@@ -118,7 +134,7 @@ void UtilityMenu::setShortcutsActive()
 
 void UtilityMenu::setShortcutsInactive()
 {
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aUntapAll->setShortcut(QKeySequence());
         aRollDie->setShortcut(QKeySequence());
         aFlipCoin->setShortcut(QKeySequence());

--- a/cockatrice/src/game/player/menu/utility_menu.h
+++ b/cockatrice/src/game/player/menu/utility_menu.h
@@ -10,19 +10,21 @@
 #include "abstract_player_component.h"
 
 #include <QMenu>
+#include <libcockatrice/card/card_info.h>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class UtilityMenu : public QMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 public slots:
     void populatePredefinedTokensMenu();
+    void setLastToken(CardInfoPtr lastToken);
     void retranslateUi() override;
     void setShortcutsActive() override;
     void setShortcutsInactive() override;
 
 public:
-    explicit UtilityMenu(PlayerLogic *player, QMenu *playerMenu);
+    explicit UtilityMenu(PlayerGraphicsItem *player, QMenu *playerMenu);
 
     [[nodiscard]] bool createAnotherTokenActionExists() const
     {
@@ -31,7 +33,7 @@ public:
 
     void setAndEnableCreateAnotherTokenAction(QString text)
     {
-        aCreateAnotherToken->setText(text);
+        aCreateAnotherToken->setText(tr("C&reate another %1 token").arg(text));
         aCreateAnotherToken->setEnabled(true);
     }
 
@@ -41,7 +43,7 @@ public:
     }
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
     QStringList predefinedTokens;
 
     QMenu *createPredefinedTokenMenu;

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -39,6 +39,8 @@ static constexpr int MOVE_TOP_CARD_UNTIL_INTERVAL = 100;
 PlayerActions::PlayerActions(PlayerLogic *_player)
     : QObject(_player), player(_player), lastTokenTableRow(0), movingCardsUntil(false)
 {
+    connect(this, &PlayerActions::requestZoneViewToggle, player, &PlayerLogic::onRequestZoneViewToggle);
+
     moveTopCardTimer = new QTimer(this);
     moveTopCardTimer->setInterval(MOVE_TOP_CARD_UNTIL_INTERVAL);
     moveTopCardTimer->setSingleShot(true);
@@ -133,12 +135,12 @@ void PlayerActions::playCardToTable(const CardItem *card, bool faceDown)
 
 void PlayerActions::actViewLibrary()
 {
-    player->getGameScene()->toggleZoneView(player, ZoneNames::DECK, -1);
+    emit requestZoneViewToggle(ZoneNames::DECK, -1);
 }
 
 void PlayerActions::actViewHand()
 {
-    player->getGameScene()->toggleZoneView(player, ZoneNames::HAND, -1);
+    emit requestZoneViewToggle(ZoneNames::HAND, -1);
 }
 
 /**
@@ -170,7 +172,7 @@ void PlayerActions::actSortHand()
 
     static QList defaultOptions = {CardList::SortByName, CardList::SortByPrinting};
 
-    player->getGraphicsItem()->getHandZoneGraphicsItem()->sortHand(sortOptions + defaultOptions);
+    emit requestSortHand(sortOptions + defaultOptions);
 }
 
 void PlayerActions::actViewTopCards()
@@ -182,7 +184,7 @@ void PlayerActions::actViewTopCards()
                                       deckSize, 1, &ok);
     if (ok) {
         defaultNumberTopCards = number;
-        player->getGameScene()->toggleZoneView(player, ZoneNames::DECK, number);
+        emit requestZoneViewToggle(ZoneNames::DECK, number);
     }
 }
 
@@ -195,24 +197,24 @@ void PlayerActions::actViewBottomCards()
                                       deckSize, 1, &ok);
     if (ok) {
         defaultNumberBottomCards = number;
-        player->getGameScene()->toggleZoneView(player, ZoneNames::DECK, number, true);
+        emit requestZoneViewToggle(ZoneNames::DECK, number, true);
     }
 }
 
-void PlayerActions::actAlwaysRevealTopCard()
+void PlayerActions::actAlwaysRevealTopCard(bool alwaysRevealTopCard)
 {
     Command_ChangeZoneProperties cmd;
     cmd.set_zone_name(ZoneNames::DECK);
-    cmd.set_always_reveal_top_card(player->getPlayerMenu()->getLibraryMenu()->isAlwaysRevealTopCardChecked());
+    cmd.set_always_reveal_top_card(alwaysRevealTopCard);
 
     sendGameCommand(cmd);
 }
 
-void PlayerActions::actAlwaysLookAtTopCard()
+void PlayerActions::actAlwaysLookAtTopCard(bool alwaysRevealTopCard)
 {
     Command_ChangeZoneProperties cmd;
     cmd.set_zone_name(ZoneNames::DECK);
-    cmd.set_always_look_at_top_card(player->getPlayerMenu()->getLibraryMenu()->isAlwaysLookAtTopCardChecked());
+    cmd.set_always_look_at_top_card(alwaysRevealTopCard);
 
     sendGameCommand(cmd);
 }
@@ -224,17 +226,17 @@ void PlayerActions::actOpenDeckInDeckEditor()
 
 void PlayerActions::actViewGraveyard()
 {
-    player->getGameScene()->toggleZoneView(player, ZoneNames::GRAVE, -1);
+    emit requestZoneViewToggle(ZoneNames::GRAVE, -1);
 }
 
 void PlayerActions::actViewRfg()
 {
-    player->getGameScene()->toggleZoneView(player, ZoneNames::EXILE, -1);
+    emit requestZoneViewToggle(ZoneNames::EXILE, -1);
 }
 
 void PlayerActions::actViewSideboard()
 {
-    player->getGameScene()->toggleZoneView(player, ZoneNames::SIDEBOARD, -1);
+    emit requestZoneViewToggle(ZoneNames::SIDEBOARD, -1);
 }
 
 void PlayerActions::actShuffle()
@@ -862,9 +864,9 @@ void PlayerActions::actFlipCoin()
     sendGameCommand(cmd);
 }
 
-void PlayerActions::actCreateToken()
+void PlayerActions::actCreateToken(const QStringList &predefinedTokens)
 {
-    DlgCreateToken dlg(player->getPlayerMenu()->getUtilityMenu()->getPredefinedTokens(), player->getGame()->getTab());
+    DlgCreateToken dlg(predefinedTokens, player->getGame()->getTab());
     if (!dlg.exec()) {
         return;
     }
@@ -880,8 +882,7 @@ void PlayerActions::actCreateToken()
         }
     }
 
-    player->getPlayerMenu()->getUtilityMenu()->setAndEnableCreateAnotherTokenAction(
-        tr("C&reate another %1 token").arg(lastTokenInfo.name));
+    emit requestEnableAndSetCreateAnotherTokenAction(lastTokenInfo.name);
     actCreateAnotherToken();
 }
 
@@ -912,8 +913,12 @@ void PlayerActions::setLastToken(CardInfoPtr cardInfo)
         return;
     }
 
-    UtilityMenu *utilityMenu = player->getPlayerMenu()->getUtilityMenu();
-    if (utilityMenu == nullptr || !utilityMenu->createAnotherTokenActionExists()) {
+    emit requestSetLastToken(cardInfo);
+}
+
+void PlayerActions::setLastTokenInfo(CardInfoPtr cardInfo)
+{
+    if (cardInfo == nullptr) {
         return;
     }
 
@@ -927,7 +932,7 @@ void PlayerActions::setLastToken(CardInfoPtr cardInfo)
 
     lastTokenTableRow = TableZone::tableRowToGridY(cardInfo->getUiAttributes().tableRow);
 
-    utilityMenu->setAndEnableCreateAnotherTokenAction(tr("C&reate another %1 token").arg(lastTokenInfo.name));
+    emit requestEnableAndSetCreateAnotherTokenAction(lastTokenInfo.name);
 }
 
 void PlayerActions::actCreatePredefinedToken()
@@ -1166,7 +1171,7 @@ void PlayerActions::actSayMessage()
     sendGameCommand(cmd);
 }
 
-void PlayerActions::actMoveCardXCardsFromTop()
+void PlayerActions::actMoveCardXCardsFromTop(QList<CardItem *> selectedCards)
 {
     int deckSize = player->getDeckZone()->getCards().size() + 1; // add the card to move to the deck
     bool ok;
@@ -1182,7 +1187,7 @@ void PlayerActions::actMoveCardXCardsFromTop()
 
     defaultNumberTopCardsToPlaceBelow = number;
 
-    QList<CardItem *> cardList = player->getGameScene()->selectedCards();
+    QList<CardItem *> cardList = selectedCards;
     if (cardList.isEmpty()) {
         return;
     }
@@ -1213,12 +1218,12 @@ void PlayerActions::actMoveCardXCardsFromTop()
     }
 }
 
-void PlayerActions::actIncPT(int deltaP, int deltaT)
+void PlayerActions::actIncPT(QList<CardItem *> selectedCards, int deltaP, int deltaT)
 {
     int playerid = player->getPlayerInfo()->getId();
 
     QList<const ::google::protobuf::Message *> commandList;
-    for (auto card : player->getGameScene()->selectedCards()) {
+    for (auto card : selectedCards) {
         QString pt = card->getPT();
         const auto ptList = CardItem::parsePT(pt);
         QString newpt;
@@ -1246,11 +1251,11 @@ void PlayerActions::actIncPT(int deltaP, int deltaT)
     player->getGame()->getGameEventHandler()->sendGameCommand(prepareGameCommand(commandList), playerid);
 }
 
-void PlayerActions::actResetPT()
+void PlayerActions::actResetPT(QList<CardItem *> selectedCards)
 {
     int playerid = player->getPlayerInfo()->getId();
     QList<const ::google::protobuf::Message *> commandList;
-    for (auto card : player->getGameScene()->selectedCards()) {
+    for (auto card : selectedCards) {
         QString ptString;
         if (!card->getFaceDown()) { // leave the pt empty if the card is face down
             ExactCard ec = card->getCard();
@@ -1279,13 +1284,12 @@ void PlayerActions::actResetPT()
     }
 }
 
-void PlayerActions::actSetPT()
+void PlayerActions::actSetPT(QList<CardItem *> selectedCards)
 {
     QString oldPT;
     int playerid = player->getPlayerInfo()->getId();
 
-    auto cards = player->getGameScene()->selectedCards();
-    for (auto card : cards) {
+    for (auto card : selectedCards) {
         if (!card->getPT().isEmpty()) {
             oldPT = card->getPT();
         }
@@ -1303,7 +1307,7 @@ void PlayerActions::actSetPT()
     bool empty = ptList.isEmpty();
 
     QList<const ::google::protobuf::Message *> commandList;
-    for (auto card : cards) {
+    for (auto card : selectedCards) {
         auto *cmd = new Command_SetCardAttr;
         QString newpt = QString();
         if (!empty) {
@@ -1347,47 +1351,47 @@ void PlayerActions::actDrawArrow()
     }
 }
 
-void PlayerActions::actIncP()
+void PlayerActions::actIncP(QList<CardItem *> selectedCards)
 {
-    actIncPT(1, 0);
+    actIncPT(selectedCards, 1, 0);
 }
 
-void PlayerActions::actDecP()
+void PlayerActions::actDecP(QList<CardItem *> selectedCards)
 {
-    actIncPT(-1, 0);
+    actIncPT(selectedCards, -1, 0);
 }
 
-void PlayerActions::actIncT()
+void PlayerActions::actIncT(QList<CardItem *> selectedCards)
 {
-    actIncPT(0, 1);
+    actIncPT(selectedCards, 0, 1);
 }
 
-void PlayerActions::actDecT()
+void PlayerActions::actDecT(QList<CardItem *> selectedCards)
 {
-    actIncPT(0, -1);
+    actIncPT(selectedCards, 0, -1);
 }
 
-void PlayerActions::actIncPT()
+void PlayerActions::actIncPT(QList<CardItem *> selectedCards)
 {
-    actIncPT(1, 1);
+    actIncPT(selectedCards, 1, 1);
 }
 
-void PlayerActions::actDecPT()
+void PlayerActions::actDecPT(QList<CardItem *> selectedCards)
 {
-    actIncPT(-1, -1);
+    actIncPT(selectedCards, -1, -1);
 }
 
-void PlayerActions::actFlowP()
+void PlayerActions::actFlowP(QList<CardItem *> selectedCards)
 {
-    actIncPT(1, -1);
+    actIncPT(selectedCards, 1, -1);
 }
 
-void PlayerActions::actFlowT()
+void PlayerActions::actFlowT(QList<CardItem *> selectedCards)
 {
-    actIncPT(-1, 1);
+    actIncPT(selectedCards, -1, 1);
 }
 
-void PlayerActions::actReduceLifeByPower()
+void PlayerActions::actReduceLifeByPower(QList<CardItem *> selectedCards)
 {
     // find life counter
     auto lifeCounter = player->getLifeCounter();
@@ -1395,10 +1399,9 @@ void PlayerActions::actReduceLifeByPower()
         return;
     }
 
-    // calculate total power
-    auto cards = player->getGameScene()->selectedCards();
+    // calculate total power;
     int total = 0;
-    for (auto card : cards) {
+    for (auto card : selectedCards) {
         QVariantList parsed = CardItem::parsePT(card->getPT());
         if (!parsed.isEmpty()) {
             int power = parsed.first().toInt(); // toInt will default to 0 if it's not an int
@@ -1423,11 +1426,10 @@ void AnnotationDialog::keyPressEvent(QKeyEvent *event)
     QInputDialog::keyPressEvent(event);
 }
 
-void PlayerActions::actSetAnnotation()
+void PlayerActions::actSetAnnotation(QList<CardItem *> selectedCards)
 {
     QString oldAnnotation;
-    auto cards = player->getGameScene()->selectedCards();
-    for (auto card : cards) {
+    for (auto card : selectedCards) {
         if (!card->getAnnotation().isEmpty()) {
             oldAnnotation = card->getAnnotation();
         }
@@ -1447,7 +1449,7 @@ void PlayerActions::actSetAnnotation()
     QString annotation = dialog->textValue().left(MAX_NAME_LENGTH);
 
     QList<const ::google::protobuf::Message *> commandList;
-    for (auto card : cards) {
+    for (auto card : selectedCards) {
         auto *cmd = new Command_SetCardAttr;
         cmd->set_zone(card->getZone()->getName().toStdString());
         cmd->set_card_id(card->getId());
@@ -1468,10 +1470,10 @@ void PlayerActions::actAttach()
     card->drawAttachArrow();
 }
 
-void PlayerActions::actUnattach()
+void PlayerActions::actUnattach(QList<CardItem *> selectedCards)
 {
     QList<const ::google::protobuf::Message *> commandList;
-    for (auto card : player->getGameScene()->selectedCards()) {
+    for (auto card : selectedCards) {
         if (!card->getAttachedTo()) {
             continue;
         }
@@ -1484,20 +1486,20 @@ void PlayerActions::actUnattach()
     sendGameCommand(prepareGameCommand(commandList));
 }
 
-void PlayerActions::actAddCardCounter(int counterId)
+void PlayerActions::actAddCardCounter(QList<CardItem *> selectedCards, int counterId)
 {
-    offsetCardCounter(counterId, 1);
+    offsetCardCounter(selectedCards, counterId, 1);
 }
 
-void PlayerActions::actRemoveCardCounter(int counterId)
+void PlayerActions::actRemoveCardCounter(QList<CardItem *> selectedCards, int counterId)
 {
-    offsetCardCounter(counterId, -1);
+    offsetCardCounter(selectedCards, counterId, -1);
 }
 
-void PlayerActions::offsetCardCounter(int counterId, int offset)
+void PlayerActions::offsetCardCounter(QList<CardItem *> selectedCards, int counterId, int offset)
 {
     QList<const ::google::protobuf::Message *> commandList;
-    for (auto card : player->getGameScene()->selectedCards()) {
+    for (auto card : selectedCards) {
         int oldValue = card->getCounters().value(counterId, 0);
         int newValue = oldValue + offset;
 
@@ -1517,15 +1519,14 @@ void PlayerActions::offsetCardCounter(int counterId, int offset)
     sendGameCommand(prepareGameCommand(commandList));
 }
 
-void PlayerActions::actSetCardCounter(int counterId)
+void PlayerActions::actSetCardCounter(QList<CardItem *> selectedCards, int counterId)
 {
     player->setDialogSemaphore(true);
 
     // If a single card is selected, we show the old value in the dialog. Otherwise, we show "x"
-    QList<CardItem *> sel = player->getGameScene()->selectedCards();
     QString oldValueForDlg = "x";
-    if (sel.size() == 1) {
-        auto *card = sel.first();
+    if (selectedCards.size() == 1) {
+        auto *card = selectedCards.first();
         oldValueForDlg = QString::number(card->getCounters().value(counterId, 0));
     }
 
@@ -1541,7 +1542,7 @@ void PlayerActions::actSetCardCounter(int counterId)
     }
 
     QList<const ::google::protobuf::Message *> commandList;
-    for (auto card : sel) {
+    for (auto card : selectedCards) {
         int oldValue = card->getCounters().value(counterId, 0);
         Expression exp(oldValue);
         double parsed = exp.parse(dialog.textValue());
@@ -1559,9 +1560,8 @@ void PlayerActions::actSetCardCounter(int counterId)
     sendGameCommand(prepareGameCommand(commandList));
 }
 
-void PlayerActions::actIncrementAllCardCounters()
+void PlayerActions::actIncrementAllCardCounters(QList<CardItem *> cardsToUpdate)
 {
-    auto cardsToUpdate = player->getGameScene()->selectedCards();
     if (cardsToUpdate.isEmpty()) {
         // If no cards selected, update all cards on table
         cardsToUpdate = static_cast<QList<CardItem *>>(player->getTableZone()->getCards());
@@ -1607,10 +1607,8 @@ static bool isUnwritableRevealZone(CardZoneLogic *zone)
     return false;
 }
 
-void PlayerActions::playSelectedCards(const bool faceDown)
+void PlayerActions::playSelectedCards(QList<CardItem *> selectedCards, const bool faceDown)
 {
-    QList<CardItem *> selectedCards = player->getGameScene()->selectedCards();
-
     // CardIds will get shuffled downwards when cards leave the deck.
     // We need to iterate through the cards in reverse order so cardIds don't get changed out from under us as we play
     // out the cards one-by-one.
@@ -1624,19 +1622,19 @@ void PlayerActions::playSelectedCards(const bool faceDown)
     }
 }
 
-void PlayerActions::actPlay()
+void PlayerActions::actPlay(QList<CardItem *> selectedCards)
 {
-    playSelectedCards(false);
+    playSelectedCards(selectedCards, false);
 }
 
-void PlayerActions::actPlayFacedown()
+void PlayerActions::actPlayFacedown(QList<CardItem *> selectedCards)
 {
-    playSelectedCards(true);
+    playSelectedCards(selectedCards, true);
 }
 
-void PlayerActions::actHide()
+void PlayerActions::actHide(QList<CardItem *> selectedCards)
 {
-    for (const auto &item : player->getGameScene()->selectedCards()) {
+    for (const auto &item : selectedCards) {
         auto *card = static_cast<CardItem *>(item);
         if (card && isUnwritableRevealZone(card->getZone())) {
             card->getZone()->removeCard(card);
@@ -1644,7 +1642,7 @@ void PlayerActions::actHide()
     }
 }
 
-void PlayerActions::actReveal(QAction *action)
+void PlayerActions::actReveal(QList<CardItem *> selectedCards, QAction *action)
 {
     const int otherPlayerId = action->data().toInt();
 
@@ -1653,7 +1651,7 @@ void PlayerActions::actReveal(QAction *action)
         cmd.set_player_id(otherPlayerId);
     }
 
-    for (auto card : player->getGameScene()->selectedCards()) {
+    for (auto card : selectedCards) {
         if (!cmd.has_zone_name()) {
             cmd.set_zone_name(card->getZone()->getName().toStdString());
         }
@@ -1735,15 +1733,14 @@ void PlayerActions::actRevealRandomGraveyardCard(int revealToPlayerId)
     sendGameCommand(cmd);
 }
 
-void PlayerActions::cardMenuAction()
+void PlayerActions::cardMenuAction(QList<CardItem *> selectedCards, CardMenuActionType type)
 {
-    auto *a = dynamic_cast<QAction *>(sender());
-    QList<CardItem *> cardList = player->getGameScene()->selectedCards();
+    QList<CardItem *> cardList = selectedCards;
 
     QList<const ::google::protobuf::Message *> commandList;
-    if (a->data().toInt() <= (int)cmClone) {
+    if (type <= cmClone) {
         for (const auto &card : cardList) {
-            switch (static_cast<CardMenuActionType>(a->data().toInt())) {
+            switch (type) {
                 // Leaving both for compatibility with server
                 case cmUntap:
                     // fallthrough
@@ -1824,7 +1821,7 @@ void PlayerActions::cardMenuAction()
             idList.add_card()->set_card_id(i->getId());
         }
 
-        switch (static_cast<CardMenuActionType>(a->data().toInt())) {
+        switch (type) {
             case cmMoveToTopLibrary: {
                 auto *cmd = new Command_MoveCard;
                 cmd->set_start_player_id(startPlayerId);

--- a/cockatrice/src/game/player/player_actions.h
+++ b/cockatrice/src/game/player/player_actions.h
@@ -9,6 +9,7 @@
 #define COCKATRICE_PLAYER_ACTIONS_H
 #include "../dialogs/dlg_create_token.h"
 #include "../dialogs/dlg_move_top_cards_until.h"
+#include "card_menu_action_type.h"
 #include "event_processing_options.h"
 #include "player_logic.h"
 
@@ -56,15 +57,22 @@ public:
         return movingCardsUntil;
     }
 
+signals:
+    void requestZoneViewToggle(const QString &zoneName, int numberCards, bool isReversed = false);
+    void requestSortHand(const QList<CardList::SortOption> &options);
+    void requestEnableAndSetCreateAnotherTokenAction(const QString &lastTokenName);
+    void requestSetLastToken(CardInfoPtr lastToken);
+
 public slots:
     void setLastToken(CardInfoPtr cardInfo);
+    void setLastTokenInfo(CardInfoPtr cardInfo);
     void playCard(CardItem *c, bool faceDown);
     void playCardToTable(const CardItem *c, bool faceDown);
 
     void actUntapAll();
     void actRollDie();
     void actFlipCoin();
-    void actCreateToken();
+    void actCreateToken(const QStringList &predefinedTokens);
     void actCreateAnotherToken();
     void actShuffle();
     void actShuffleTop();
@@ -77,9 +85,9 @@ public slots:
     void actMulliganMinusOne();
     void doMulligan(int number);
 
-    void actPlay();
-    void actPlayFacedown();
-    void actHide();
+    void actPlay(QList<CardItem *> selectedCards);
+    void actPlayFacedown(QList<CardItem *> selectedCards);
+    void actHide(QList<CardItem *> selectedCards);
 
     void actMoveTopCardToPlay();
     void actMoveTopCardToPlayFaceDown();
@@ -111,8 +119,8 @@ public slots:
     void actViewHand();
     void actViewTopCards();
     void actViewBottomCards();
-    void actAlwaysRevealTopCard();
-    void actAlwaysLookAtTopCard();
+    void actAlwaysRevealTopCard(bool alwaysRevealTopCard);
+    void actAlwaysLookAtTopCard(bool alwaysRevealTopCard);
     void actViewGraveyard();
     void actLendLibrary(int lendToPlayerId);
     void actRevealTopCards(int revealToPlayerId, int amount);
@@ -127,37 +135,37 @@ public slots:
     void actCreateRelatedCard();
     void actCreateAllRelatedCards();
 
-    void actMoveCardXCardsFromTop();
-    void actRemoveCardCounter(int counterId);
-    void actAddCardCounter(int counterId);
-    void actSetCardCounter(int counterId);
-    void actIncrementAllCardCounters();
+    void actMoveCardXCardsFromTop(QList<CardItem *> selectedCards);
+    void actRemoveCardCounter(QList<CardItem *> selectedCards, int counterId);
+    void actAddCardCounter(QList<CardItem *> selectedCards, int counterId);
+    void actSetCardCounter(QList<CardItem *> selectedCards, int counterId);
+    void actIncrementAllCardCounters(QList<CardItem *> cardsToUpdate);
     void actAttach();
-    void actUnattach();
+    void actUnattach(QList<CardItem *> selectedCards);
     void actDrawArrow();
-    void actIncPT(int deltaP, int deltaT);
-    void actResetPT();
-    void actSetPT();
-    void actIncP();
-    void actDecP();
-    void actIncT();
-    void actDecT();
-    void actIncPT();
-    void actDecPT();
-    void actFlowP();
-    void actFlowT();
+    void actIncPT(QList<CardItem *> selectedCards, int deltaP, int deltaT);
+    void actResetPT(QList<CardItem *> selectedCards);
+    void actSetPT(QList<CardItem *> selectedCards);
+    void actIncP(QList<CardItem *> selectedCards);
+    void actDecP(QList<CardItem *> selectedCards);
+    void actIncT(QList<CardItem *> selectedCards);
+    void actDecT(QList<CardItem *> selectedCards);
+    void actIncPT(QList<CardItem *> selectedCards);
+    void actDecPT(QList<CardItem *> selectedCards);
+    void actFlowP(QList<CardItem *> selectedCards);
+    void actFlowT(QList<CardItem *> selectedCards);
 
-    void actReduceLifeByPower();
+    void actReduceLifeByPower(QList<CardItem *> selectedCards);
 
-    void actSetAnnotation();
-    void actReveal(QAction *action);
+    void actSetAnnotation(QList<CardItem *> selectedCards);
+    void actReveal(QList<CardItem *> selectedCards, QAction *action);
     void actRevealHand(int revealToPlayerId);
     void actRevealRandomHandCard(int revealToPlayerId);
     void actRevealLibrary(int revealToPlayerId);
 
     void actSortHand();
 
-    void cardMenuAction();
+    void cardMenuAction(QList<CardItem *> selectedCards, CardMenuActionType type);
 
 private:
     PlayerLogic *player;
@@ -185,12 +193,12 @@ private:
                     bool persistent = false);
     bool createRelatedFromRelation(const CardItem *sourceCard, const CardRelation *cardRelation);
 
-    void playSelectedCards(bool faceDown = false);
+    void playSelectedCards(QList<CardItem *> selectedCards, bool faceDown = false);
 
     void cmdSetTopCard(Command_MoveCard &cmd);
     void cmdSetBottomCard(Command_MoveCard &cmd);
 
-    void offsetCardCounter(int counterId, int offset);
+    void offsetCardCounter(QList<CardItem *> selectedCards, int counterId, int offset);
 };
 
 #endif // COCKATRICE_PLAYER_ACTIONS_H

--- a/cockatrice/src/game/player/player_event_handler.cpp
+++ b/cockatrice/src/game/player/player_event_handler.cpp
@@ -6,7 +6,6 @@
 #include "../board/arrow_item.h"
 #include "../board/card_item.h"
 #include "../board/card_list.h"
-#include "libcockatrice/utility/color.h"
 #include "player_actions.h"
 #include "player_logic.h"
 
@@ -33,10 +32,12 @@
 #include <libcockatrice/protocol/pb/event_set_card_counter.pb.h>
 #include <libcockatrice/protocol/pb/event_set_counter.pb.h>
 #include <libcockatrice/protocol/pb/event_shuffle.pb.h>
+#include <libcockatrice/utility/color.h>
 #include <libcockatrice/utility/zone_names.h>
 
 PlayerEventHandler::PlayerEventHandler(PlayerLogic *_player) : QObject(_player), player(_player)
 {
+    connect(this, &PlayerEventHandler::requestCardMenuUpdate, player, &PlayerLogic::requestCardMenuUpdate);
 }
 
 void PlayerEventHandler::eventGameSay(const Event_GameSay &event)
@@ -252,7 +253,7 @@ void PlayerEventHandler::eventSetCardCounter(const Event_SetCardCounter &event)
 
     int oldValue = card->getCounters().value(event.counter_id(), 0);
     card->setCounter(event.counter_id(), event.counter_value());
-    player->getPlayerMenu()->updateCardMenu(card);
+    emit requestCardMenuUpdate(card);
     emit logSetCardCounter(player, card->getName(), event.counter_id(), event.counter_value(), oldValue);
 }
 
@@ -370,7 +371,7 @@ void PlayerEventHandler::eventMoveCard(const Event_MoveCard &event, const GameEv
     targetZone->addCard(card, true, x, y);
 
     emit cardZoneChanged(card, startZone == targetZone);
-    player->getPlayerMenu()->updateCardMenu(card);
+    emit requestCardMenuUpdate(card);
 
     if (player->getPlayerActions()->isMovingCardsUntil() && startZoneString == ZoneNames::DECK &&
         targetZone->getName() == ZoneNames::STACK) {
@@ -397,7 +398,7 @@ void PlayerEventHandler::eventFlipCard(const Event_FlipCard &event)
 
     emit logFlipCard(player, card->getName(), event.face_down());
     card->setFaceDown(event.face_down());
-    player->getPlayerMenu()->updateCardMenu(card);
+    emit requestCardMenuUpdate(card);
 }
 
 void PlayerEventHandler::eventDestroyCard(const Event_DestroyCard &event)
@@ -466,7 +467,7 @@ void PlayerEventHandler::eventAttachCard(const Event_AttachCard &event)
     } else {
         emit logUnattachCard(player, startCard->getName());
     }
-    player->getPlayerMenu()->updateCardMenu(startCard);
+    emit requestCardMenuUpdate(startCard);
 }
 
 void PlayerEventHandler::eventDrawCards(const Event_DrawCards &event)
@@ -552,7 +553,7 @@ void PlayerEventHandler::eventRevealCards(const Event_RevealCards &event, EventP
         }
 
         if (!options.testFlag(SKIP_REVEAL_WINDOW) && showZoneView && !cardList.isEmpty()) {
-            player->getGameScene()->addRevealedZoneView(player, zone, cardList, event.grant_write_access());
+            emit player->requestRevealedZoneView(player, zone, cardList, event.grant_write_access());
         }
 
         emit logRevealCards(player, zone, cardId, cardName, otherPlayer, false,

--- a/cockatrice/src/game/player/player_event_handler.h
+++ b/cockatrice/src/game/player/player_event_handler.h
@@ -83,6 +83,7 @@ signals:
     void logAlwaysRevealTopCard(PlayerLogic *player, CardZoneLogic *zone, bool reveal);
     void logAlwaysLookAtTopCard(PlayerLogic *player, CardZoneLogic *zone, bool reveal);
     void cardZoneChanged(CardItem *card, bool sameZone);
+    void requestCardMenuUpdate(const CardItem *card);
 
 public:
     PlayerEventHandler(PlayerLogic *player);

--- a/cockatrice/src/game/player/player_graphics_item.cpp
+++ b/cockatrice/src/game/player/player_graphics_item.cpp
@@ -8,6 +8,9 @@
 #include "../board/abstract_card_item.h"
 #include "../board/counter_general.h"
 #include "../hand_counter.h"
+#include "player_actions.h"
+
+#include <QGraphicsView>
 
 PlayerGraphicsItem::PlayerGraphicsItem(PlayerLogic *_player) : player(_player)
 {
@@ -16,23 +19,26 @@ PlayerGraphicsItem::PlayerGraphicsItem(PlayerLogic *_player) : player(_player)
     connect(&SettingsCache::instance(), &SettingsCache::handJustificationChanged, this,
             &PlayerGraphicsItem::rearrangeZones);
     connect(player, &PlayerLogic::rearrangeCounters, this, &PlayerGraphicsItem::rearrangeCounters);
+    connect(player, &PlayerLogic::activeChanged, this, &PlayerGraphicsItem::onPlayerActiveChanged);
     connect(player, &PlayerLogic::concededChanged, this, [this](int, bool c) { setVisible(!c); });
     connect(player, &PlayerLogic::zoneIdChanged, this, [this](int id) { playerArea->setPlayerZoneId(id); });
 
     connect(player, &PlayerLogic::counterAdded, this, &PlayerGraphicsItem::onCounterAdded);
     connect(player, &PlayerLogic::counterRemoved, this, &PlayerGraphicsItem::onCounterRemoved);
 
-    connect(player->getPlayerMenu(), &PlayerMenu::shortcutsActivated, this, [this]() {
+    playerMenu = new PlayerMenu(this);
+
+    connect(playerMenu, &PlayerMenu::shortcutsActivated, this, [this]() {
         for (auto *ctr : counterWidgets) {
             ctr->setShortcutsActive();
         }
     });
-    connect(player->getPlayerMenu(), &PlayerMenu::shortcutsDeactivated, this, [this]() {
+    connect(playerMenu, &PlayerMenu::shortcutsDeactivated, this, [this]() {
         for (auto *ctr : counterWidgets) {
             ctr->setShortcutsInactive();
         }
     });
-    connect(player->getPlayerMenu(), &PlayerMenu::retranslateRequested, this, [this]() {
+    connect(playerMenu, &PlayerMenu::retranslateRequested, this, [this]() {
         for (auto *ctr : counterWidgets) {
             ctr->retranslateUi();
         }
@@ -47,6 +53,8 @@ PlayerGraphicsItem::PlayerGraphicsItem(PlayerLogic *_player) : player(_player)
 
     initializeZones();
 
+    playerMenu->setMenusForGraphicItems();
+
     connect(tableZoneGraphicsItem, &TableZone::sizeChanged, this, &PlayerGraphicsItem::updateBoundingRect);
 
     updateBoundingRect();
@@ -57,7 +65,7 @@ PlayerGraphicsItem::PlayerGraphicsItem(PlayerLogic *_player) : player(_player)
 
 void PlayerGraphicsItem::retranslateUi()
 {
-    player->getPlayerMenu()->retranslateUi();
+    playerMenu->retranslateUi();
 
     QMapIterator<QString, CardZoneLogic *> zoneIterator(player->getZones());
     while (zoneIterator.hasNext()) {
@@ -93,14 +101,16 @@ void PlayerGraphicsItem::initializeZones()
     rfgZoneGraphicsItem = new PileZone(player->getRfgZone(), this);
     rfgZoneGraphicsItem->setPos(base + QPointF(0, 2 * h + h2 + 10));
 
-    tableZoneGraphicsItem = new TableZone(player->getTableZone(), this);
+    tableZoneGraphicsItem = new TableZone(player->getTableZone(), mirrored, this);
     connect(tableZoneGraphicsItem, &TableZone::sizeChanged, this, &PlayerGraphicsItem::updateBoundingRect);
+    connect(this, &PlayerGraphicsItem::mirroredChanged, tableZoneGraphicsItem, &TableZone::setMirrored);
 
     stackZoneGraphicsItem =
         new StackZone(player->getStackZone(), static_cast<int>(tableZoneGraphicsItem->boundingRect().height()), this);
 
     handZoneGraphicsItem =
         new HandZone(player->getHandZone(), static_cast<int>(tableZoneGraphicsItem->boundingRect().height()), this);
+    connect(player->getPlayerActions(), &PlayerActions::requestSortHand, handZoneGraphicsItem, &HandZone::sortHand);
 
     connect(handZoneGraphicsItem->getLogic(), &HandZoneLogic::cardCountChanged, handCounter,
             &HandCounter::updateNumber);
@@ -145,6 +155,7 @@ void PlayerGraphicsItem::setMirrored(bool _mirrored)
 {
     if (mirrored != _mirrored) {
         mirrored = _mirrored;
+        emit mirroredChanged(mirrored);
         rearrangeZones();
     }
 }
@@ -159,11 +170,11 @@ void PlayerGraphicsItem::onCounterAdded(CounterState *state)
     }
     counterWidgets.insert(state->getId(), widget);
 
-    if (player->getPlayerMenu()->getCountersMenu() && widget->getMenu()) {
-        player->getPlayerMenu()->getCountersMenu()->addMenu(widget->getMenu());
+    if (playerMenu->getCountersMenu() && widget->getMenu()) {
+        playerMenu->getCountersMenu()->addMenu(widget->getMenu());
     }
 
-    if (player->getPlayerMenu()->getShortcutsActive()) {
+    if (playerMenu->getShortcutsActive()) {
         widget->setShortcutsActive();
     }
 
@@ -176,8 +187,8 @@ void PlayerGraphicsItem::onCounterRemoved(int counterId)
     if (!widget) {
         return;
     }
-    if (player->getPlayerMenu()->getCountersMenu() && widget->getMenu()) {
-        player->getPlayerMenu()->getCountersMenu()->removeAction(widget->getMenu()->menuAction());
+    if (playerMenu->getCountersMenu() && widget->getMenu()) {
+        playerMenu->getCountersMenu()->removeAction(widget->getMenu()->menuAction());
     }
     widget->delCounter();
     rearrangeCounters();

--- a/cockatrice/src/game/player/player_graphics_item.h
+++ b/cockatrice/src/game/player/player_graphics_item.h
@@ -55,9 +55,14 @@ public:
         return static_cast<GameScene *>(scene());
     }
 
-    PlayerLogic *getPlayer() const
+    PlayerLogic *getLogic() const
     {
         return player;
+    }
+
+    [[nodiscard]] PlayerMenu *getPlayerMenu() const
+    {
+        return playerMenu;
     }
 
     PlayerArea *getPlayerArea() const
@@ -111,9 +116,12 @@ public slots:
 signals:
     void sizeChanged();
     void playerCountChanged();
+    void mirroredChanged(bool isMirrored);
+    void cardInfoRequested(const CardRef &cardRef);
 
 private:
     PlayerLogic *player;
+    PlayerMenu *playerMenu;
     PlayerArea *playerArea;
     PlayerTarget *playerTarget;
     QMap<int, AbstractCounter *> counterWidgets;

--- a/cockatrice/src/game/player/player_logic.cpp
+++ b/cockatrice/src/game/player/player_logic.cpp
@@ -35,14 +35,6 @@ PlayerLogic::PlayerLogic(const ServerInfo_User &info, int _id, bool _local, bool
       conceded(false), zoneId(0), dialogSemaphore(false)
 {
     initializeZones();
-
-    playerMenu = new PlayerMenu(this);
-    graphicsItem = new PlayerGraphicsItem(this);
-    playerMenu->setMenusForGraphicItems();
-
-    connect(this, &PlayerLogic::activeChanged, graphicsItem, &PlayerGraphicsItem::onPlayerActiveChanged);
-
-    connect(this, &PlayerLogic::openDeckEditor, game->getTab(), &TabGame::openDeckEditor);
 }
 
 void PlayerLogic::initializeZones()
@@ -68,7 +60,6 @@ PlayerLogic::~PlayerLogic()
     }
     zones.clear();
 
-    delete playerMenu;
     delete getPlayerInfo()->userInfo;
 }
 
@@ -326,20 +317,14 @@ void PlayerLogic::setActive(bool _active)
     active = _active;
     emit activeChanged(active);
 }
+void PlayerLogic::onRequestZoneViewToggle(const QString &zoneName, int numberCards, bool isReversed)
+{
+    emit requestZoneViewToggle(this, zoneName, numberCards, isReversed);
+}
 
 void PlayerLogic::updateZones()
 {
     getTableZone()->reorganizeCards();
-}
-
-PlayerGraphicsItem *PlayerLogic::getGraphicsItem()
-{
-    return graphicsItem;
-}
-
-GameScene *PlayerLogic::getGameScene()
-{
-    return getGraphicsItem()->getGameScene();
 }
 
 void PlayerLogic::setGameStarted()

--- a/cockatrice/src/game/player/player_logic.h
+++ b/cockatrice/src/game/player/player_logic.h
@@ -67,8 +67,14 @@ class PlayerLogic : public QObject
 
 signals:
     void openDeckEditor(const LoadedDeck &deck);
+    void requestZoneViewToggle(PlayerLogic *player, const QString &zoneName, int numberCards, bool isReversed);
+    void requestRevealedZoneView(PlayerLogic *player,
+                                 CardZoneLogic *zone,
+                                 const QList<const ServerInfo_Card *> &cardList,
+                                 bool withWritePermission);
     void deckChanged();
     void newCardAdded(AbstractCardItem *card);
+    void requestCardMenuUpdate(const CardItem *card);
     void counterAdded(CounterState *state);
     void counterRemoved(int counterId);
     void rearrangeCounters();
@@ -85,6 +91,7 @@ signals:
 
 public slots:
     void setActive(bool _active);
+    void onRequestZoneViewToggle(const QString &zoneName, int numberCards, bool isReversed);
 
 public:
     PlayerLogic(const ServerInfo_User &info, int _id, bool _local, bool _judge, AbstractGame *_parent);
@@ -112,10 +119,6 @@ public:
         return game;
     }
 
-    GameScene *getGameScene();
-
-    [[nodiscard]] PlayerGraphicsItem *getGraphicsItem();
-
     [[nodiscard]] PlayerActions *getPlayerActions() const
     {
         return playerActions;
@@ -129,11 +132,6 @@ public:
     [[nodiscard]] PlayerInfo *getPlayerInfo() const
     {
         return playerInfo;
-    }
-
-    [[nodiscard]] PlayerMenu *getPlayerMenu() const
-    {
-        return playerMenu;
     }
 
     void setDeck(const DeckList &_deck);
@@ -234,8 +232,6 @@ private:
     PlayerInfo *playerInfo;
     PlayerEventHandler *playerEventHandler;
     PlayerActions *playerActions;
-    PlayerMenu *playerMenu;
-    PlayerGraphicsItem *graphicsItem;
 
     bool active;
     bool conceded;

--- a/cockatrice/src/game_graphics/zones/table_zone.cpp
+++ b/cockatrice/src/game_graphics/zones/table_zone.cpp
@@ -22,7 +22,8 @@ const QColor TableZone::FADE_MASK = QColor(0, 0, 0, 80);
 const QColor TableZone::GRADIENT_COLOR = QColor(255, 255, 255, 150);
 const QColor TableZone::GRADIENT_COLORLESS = QColor(255, 255, 255, 0);
 
-TableZone::TableZone(TableZoneLogic *_logic, QGraphicsItem *parent) : SelectZone(_logic, parent), active(false)
+TableZone::TableZone(TableZoneLogic *_logic, bool _mirrored, QGraphicsItem *parent)
+    : SelectZone(_logic, parent), active(false), mirrored(_mirrored)
 {
     connect(_logic, &TableZoneLogic::contentSizeChanged, this, &TableZone::resizeToContents);
     connect(_logic, &TableZoneLogic::toggleTapped, this, &TableZone::toggleTapped);
@@ -50,12 +51,16 @@ QRectF TableZone::boundingRect() const
     return QRectF(0, 0, width, height);
 }
 
+void TableZone::setMirrored(bool isMirrored)
+{
+    mirrored = isMirrored;
+    update();
+}
+
 bool TableZone::isInverted() const
 {
-    return ((getLogic()->getPlayer()->getGraphicsItem()->getMirrored() &&
-             !SettingsCache::instance().getInvertVerticalCoordinate()) ||
-            (!getLogic()->getPlayer()->getGraphicsItem()->getMirrored() &&
-             SettingsCache::instance().getInvertVerticalCoordinate()));
+    return ((mirrored && !SettingsCache::instance().getInvertVerticalCoordinate()) ||
+            (!mirrored && SettingsCache::instance().getInvertVerticalCoordinate()));
 }
 
 void TableZone::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)

--- a/cockatrice/src/game_graphics/zones/table_zone.h
+++ b/cockatrice/src/game_graphics/zones/table_zone.h
@@ -82,6 +82,7 @@ private:
        If this TableZone is currently active
      */
     bool active = false;
+    bool mirrored = false;
 
     [[nodiscard]] bool isInverted() const;
 
@@ -96,6 +97,7 @@ public slots:
        Reorganizes CardItems in the TableZone
      */
     void reorganizeCards() override;
+    void setMirrored(bool isMirrored);
 
 public:
     /**
@@ -104,7 +106,7 @@ public:
        @param _p the Player
        @param parent defaults to null
      */
-    explicit TableZone(TableZoneLogic *_logic, QGraphicsItem *parent = nullptr);
+    explicit TableZone(TableZoneLogic *_logic, bool mirrored, QGraphicsItem *parent = nullptr);
 
     /**
        @return a QRectF of the TableZone bounding box.

--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -1,6 +1,7 @@
 #include "tab_game.h"
 
 #include "../../../client/settings/cache_settings.h"
+#include "../../../game/player/menu/card_menu.h"
 #include "../game/board/arrow_item.h"
 #include "../game/board/card_item.h"
 #include "../game/deckview/deck_view_container.h"
@@ -363,11 +364,10 @@ void TabGame::retranslateUi()
 
     cardInfoFrameWidget->retranslateUi();
 
-    QMapIterator<int, PlayerLogic *> i(game->getPlayerManager()->getPlayers());
-
-    while (i.hasNext()) {
-        i.next().value()->getGraphicsItem()->retranslateUi();
+    for (auto playerView : scene->getPlayers().values()) {
+        playerView->retranslateUi();
     }
+
     QMapIterator<int, TabbedDeckViewContainer *> j(deckViewContainers);
     while (j.hasNext()) {
         j.next().value()->playerDeckView->retranslateUi();
@@ -654,8 +654,12 @@ PlayerLogic *TabGame::addPlayer(PlayerLogic *newPlayer)
 
     scene->addPlayer(newPlayer);
 
+    auto *view = scene->viewForPlayer(newPlayer->getPlayerInfo()->getId());
+
     connect(newPlayer, &PlayerLogic::newCardAdded, this, &TabGame::newCardAdded);
-    connect(newPlayer->getPlayerMenu(), &PlayerMenu::cardMenuUpdated, this, &TabGame::setCardMenu);
+    connect(newPlayer, &PlayerLogic::openDeckEditor, this, &TabGame::openDeckEditor);
+    connect(view->getPlayerMenu(), &PlayerMenu::cardMenuUpdated, this, &TabGame::setCardMenu);
+    connect(view, &PlayerGraphicsItem::cardInfoRequested, this, &TabGame::viewCardInfo);
 
     messageLog->connectToPlayerEventHandler(newPlayer->getPlayerEventHandler());
 
@@ -668,7 +672,7 @@ PlayerLogic *TabGame::addPlayer(PlayerLogic *newPlayer)
         addLocalPlayer(newPlayer, newPlayer->getPlayerInfo()->getId());
     }
 
-    gameMenu->insertMenu(playersSeparator, newPlayer->getPlayerMenu()->getPlayerMenu());
+    gameMenu->insertMenu(playersSeparator, view->getPlayerMenu()->getPlayerMenu());
 
     createZoneForPlayer(newPlayer, newPlayer->getPlayerInfo()->getId());
 
@@ -678,7 +682,7 @@ PlayerLogic *TabGame::addPlayer(PlayerLogic *newPlayer)
 void TabGame::addLocalPlayer(PlayerLogic *newPlayer, int playerId)
 {
     if (game->getGameState()->getClients().size() == 1) {
-        newPlayer->getPlayerMenu()->setShortcutsActive();
+        scene->viewForPlayer(playerId)->getPlayerMenu()->setShortcutsActive();
     }
 
     auto *deckView = new TabbedDeckViewContainer(playerId, this);
@@ -698,27 +702,24 @@ void TabGame::addLocalPlayer(PlayerLogic *newPlayer, int playerId)
 
 void TabGame::processPlayerLeave(PlayerLogic *leavingPlayer)
 {
-    QString playerName = "@" + leavingPlayer->getPlayerInfo()->getName();
-    removePlayerFromAutoCompleteList(playerName);
-
-    scene->removePlayer(leavingPlayer);
+    removePlayerFromAutoCompleteList("@" + leavingPlayer->getPlayerInfo()->getName());
 
     // When we inserted the playerMenu into the gameMenu earlier, Qt wrapped the playerMenu into a QAction*, which lives
     // independently and does not get cleaned up when the source menu gets destroyed. We have to manually clean here.
-    if (leavingPlayer->getPlayerMenu()) {
-        QMenu *menu = leavingPlayer->getPlayerMenu()->getPlayerMenu();
-        if (menu) {
-            // Find and remove the QAction pointing to this menu
-            QList<QAction *> actions = gameMenu->actions();
-            for (QAction *act : actions) {
-                if (act->menu() == menu) {
-                    gameMenu->removeAction(act);
-                    delete act; // deletes the QAction wrapper around the submenu
-                    break;
-                }
+    auto *view = scene->viewForPlayer(leavingPlayer->getPlayerInfo()->getId());
+    if (view) {
+        // Find and remove the QAction pointing to this menu
+        QMenu *menu = view->getPlayerMenu()->getPlayerMenu();
+        for (QAction *act : gameMenu->actions()) {
+            if (act->menu() == menu) {
+                gameMenu->removeAction(act);
+                delete act;
+                break;
             }
         }
     }
+
+    scene->removePlayer(leavingPlayer);
 }
 
 void TabGame::processRemotePlayerDeckSelect(QString deckList, int playerId, QString playerName)
@@ -869,12 +870,12 @@ PlayerLogic *TabGame::setActivePlayer(int id)
         if (i.value() == player) {
             i.value()->setActive(true);
             if (game->getGameState()->getClients().size() > 1) {
-                i.value()->getPlayerMenu()->setShortcutsActive();
+                scene->viewForPlayer(i.value()->getPlayerInfo()->getId())->getPlayerMenu()->setShortcutsActive();
             }
         } else {
             i.value()->setActive(false);
             if (game->getGameState()->getClients().size() > 1) {
-                i.value()->getPlayerMenu()->setShortcutsInactive();
+                scene->viewForPlayer(i.value()->getPlayerInfo()->getId())->getPlayerMenu()->setShortcutsInactive();
             }
         }
     }
@@ -890,8 +891,13 @@ void TabGame::setActivePhase(int phase)
 
 void TabGame::newCardAdded(AbstractCardItem *card)
 {
+    connect(card, &AbstractCardItem::rightClicked, scene, &GameScene::onCardRightClicked);
+    connect(card, &AbstractCardItem::playSelected, scene, &GameScene::playSelected);
+    connect(card, &AbstractCardItem::playSelectedFaceDown, scene, &GameScene::playSelectedFaceDown);
+    connect(card, &AbstractCardItem::hideSelected, scene, &GameScene::hideSelected);
     connect(card, &AbstractCardItem::hovered, cardInfoFrameWidget,
             qOverload<AbstractCardItem *>(&CardInfoFrameWidget::setCard));
+    connect(card, &AbstractCardItem::selectionChanged, scene, &GameScene::onCardSelectionChanged);
     connect(card, &AbstractCardItem::showCardInfoPopup, this, &TabGame::showCardInfoPopup);
     connect(card, SIGNAL(deleteCardInfoPopup(QString)), this, SLOT(deleteCardInfoPopup(QString)));
     connect(card, &AbstractCardItem::cardShiftClicked, this, &TabGame::linkCardToChat);
@@ -935,7 +941,7 @@ QString TabGame::getTabText() const
 /**
  * @param menu The menu to set. Pass in nullptr to set the menu to empty.
  */
-void TabGame::setCardMenu(QMenu *menu)
+void TabGame::setCardMenu(CardMenu *menu)
 {
     if (!aCardMenu) {
         return;

--- a/cockatrice/src/interface/widgets/tabs/tab_game.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.h
@@ -141,7 +141,7 @@ signals:
 private slots:
     void adminLockChanged(bool lock);
     void newCardAdded(AbstractCardItem *card);
-    void setCardMenu(QMenu *menu);
+    void setCardMenu(CardMenu *menu);
 
     void actGameInfo();
     void actConcede();


### PR DESCRIPTION
## Related Ticket(s)
- Succeeds #6919

## Short roundup of the initial problem
This PR is the first structural step in a larger refactor to decouple the game's UI layer from its logic layer, enabling a future pub/sub event system. The core problem was that Player (now PlayerLogic) directly owned and created PlayerGraphicsItem, PlayerMenu, and all associated graphics classes, making the logic layer tightly coupled to Qt's widget/graphics stack.

## What will change with this Pull Request?
- PlayerLogic no longer owns graphics
- PlayerGraphicsItem and PlayerMenu are no longer constructed inside PlayerLogic. The constructor no longer creates graphics objects. Logic signals (arrowCreateRequested, arrowDeleteRequested, arrowsCleared, counterAdded, counterRemoved, concededChanged, zoneIdChanged, requestZoneViewToggle, requestSortHand) replace direct calls into the graphics layer.
- GameScene owns PlayerGraphicsItem
- GameScene::addPlayer(PlayerLogic*) now creates PlayerGraphicsItem internally and registers it in a QMap<int, PlayerGraphicsItem*> playerViews for ID-based lookup. GameScene::viewForPlayer(int) is the new access point for anything that needs the view for a given player.

