### PR TITLE
[Game][Menus] Make Menus accept PlayerGraphicsItem instead of PlayerLogic

### DIFF
--- a/cockatrice/src/game/board/card_item.cpp
+++ b/cockatrice/src/game/board/card_item.cpp
@@ -476,6 +476,7 @@ void CardItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     if (event->button() == Qt::RightButton && owner != nullptr) {
         emit rightClicked(this, event->screenPos());
+        return;
     }
     if ((event->modifiers() != Qt::AltModifier) && (event->button() == Qt::LeftButton) &&
         (!SettingsCache::instance().getDoubleClickToPlay())) {

--- a/cockatrice/src/game/player/menu/card_menu.cpp
+++ b/cockatrice/src/game/player/menu/card_menu.cpp
@@ -6,6 +6,7 @@
 #include "../../zones/view_zone_logic.h"
 #include "../card_menu_action_type.h"
 #include "../player_actions.h"
+#include "../player_graphics_item.h"
 #include "../player_logic.h"
 #include "move_menu.h"
 #include "pt_menu.h"

--- a/cockatrice/src/game/player/menu/grave_menu.cpp
+++ b/cockatrice/src/game/player/menu/grave_menu.cpp
@@ -8,14 +8,14 @@
 #include <QMenu>
 #include <libcockatrice/utility/zone_names.h>
 
-GraveyardMenu::GraveyardMenu(PlayerLogic *_player, QWidget *parent) : TearOffMenu(parent), player(_player)
+GraveyardMenu::GraveyardMenu(PlayerGraphicsItem *_player, QWidget *parent) : TearOffMenu(parent), player(_player)
 {
     createMoveActions();
     createViewActions();
 
     addAction(aViewGraveyard);
 
-    if (player->getPlayerInfo()->local || player->getPlayerInfo()->judge) {
+    if (player->getLogic()->getPlayerInfo()->local || player->getLogic()->getPlayerInfo()->judge) {
         mRevealRandomGraveyardCard = addMenu(QString());
         connect(mRevealRandomGraveyardCard, &QMenu::aboutToShow, this,
                 &GraveyardMenu::populateRevealRandomMenuWithActivePlayers);
@@ -36,9 +36,9 @@ GraveyardMenu::GraveyardMenu(PlayerLogic *_player, QWidget *parent) : TearOffMen
 
 void GraveyardMenu::createMoveActions()
 {
-    auto grave = player->getGraveZone();
+    auto grave = player->getLogic()->getGraveZone();
 
-    if (player->getPlayerInfo()->local || player->getPlayerInfo()->judge) {
+    if (player->getLogic()->getPlayerInfo()->local || player->getLogic()->getPlayerInfo()->judge) {
         aMoveGraveToTopLibrary = new QAction(this);
         aMoveGraveToTopLibrary->setData(QList<QVariant>() << ZoneNames::DECK << 0);
 
@@ -60,7 +60,7 @@ void GraveyardMenu::createMoveActions()
 
 void GraveyardMenu::createViewActions()
 {
-    PlayerActions *playerActions = player->getPlayerActions();
+    PlayerActions *playerActions = player->getLogic()->getPlayerActions();
 
     aViewGraveyard = new QAction(this);
     connect(aViewGraveyard, &QAction::triggered, playerActions, &PlayerActions::actViewGraveyard);
@@ -76,9 +76,9 @@ void GraveyardMenu::populateRevealRandomMenuWithActivePlayers()
 
     mRevealRandomGraveyardCard->addSeparator();
 
-    const auto &players = player->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player) {
+        if (other == player->getLogic()) {
             continue;
         }
         QAction *a = mRevealRandomGraveyardCard->addAction(other->getPlayerInfo()->getName());
@@ -90,7 +90,7 @@ void GraveyardMenu::populateRevealRandomMenuWithActivePlayers()
 void GraveyardMenu::onRevealRandomTriggered()
 {
     if (auto *a = qobject_cast<QAction *>(sender())) {
-        player->getPlayerActions()->actRevealRandomGraveyardCard(a->data().toInt());
+        player->getLogic()->getPlayerActions()->actRevealRandomGraveyardCard(a->data().toInt());
     }
 }
 
@@ -100,7 +100,7 @@ void GraveyardMenu::retranslateUi()
 
     aViewGraveyard->setText(tr("&View graveyard"));
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         moveGraveMenu->setTitle(tr("&Move graveyard to..."));
         aMoveGraveToTopLibrary->setText(tr("&Top of library"));
         aMoveGraveToBottomLibrary->setText(tr("&Bottom of library"));

--- a/cockatrice/src/game/player/menu/grave_menu.h
+++ b/cockatrice/src/game/player/menu/grave_menu.h
@@ -13,7 +13,7 @@
 #include <QAction>
 #include <QMenu>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class GraveyardMenu : public TearOffMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
@@ -21,7 +21,7 @@ signals:
     void newPlayerActionCreated(QAction *action);
 
 public:
-    explicit GraveyardMenu(PlayerLogic *player, QWidget *parent = nullptr);
+    explicit GraveyardMenu(PlayerGraphicsItem *player, QWidget *parent = nullptr);
     void createMoveActions();
     void createViewActions();
     void populateRevealRandomMenuWithActivePlayers();
@@ -40,7 +40,7 @@ public:
     QAction *aMoveGraveToRfg = nullptr;
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
 };
 
 #endif // COCKATRICE_GRAVE_MENU_H

--- a/cockatrice/src/game/player/menu/hand_menu.cpp
+++ b/cockatrice/src/game/player/menu/hand_menu.cpp
@@ -5,16 +5,20 @@
 #include "../../../game_graphics/zones/hand_zone.h"
 #include "../../abstract_game.h"
 #include "../player_actions.h"
+#include "../player_graphics_item.h"
 #include "../player_logic.h"
 
 #include <QAction>
 #include <QMenu>
 #include <libcockatrice/utility/zone_names.h>
 
-HandMenu::HandMenu(PlayerLogic *_player, PlayerActions *actions, QWidget *parent) : TearOffMenu(parent), player(_player)
+HandMenu::HandMenu(PlayerGraphicsItem *_player, QWidget *parent) : TearOffMenu(parent), player(_player)
 {
-    if (player->getPlayerInfo()->local || player->getPlayerInfo()->judge) {
+    auto *actions = player->getLogic()->getPlayerActions();
+
+    if (player->getLogic()->getPlayerInfo()->local || player->getLogic()->getPlayerInfo()->judge) {
         aViewHand = new QAction(this);
+
         connect(aViewHand, &QAction::triggered, actions, &PlayerActions::actViewHand);
         addAction(aViewHand);
 
@@ -75,7 +79,7 @@ HandMenu::HandMenu(PlayerLogic *_player, PlayerActions *actions, QWidget *parent
 
     mMoveHandMenu = addTearOffMenu(QString());
 
-    if (player->getPlayerInfo()->local || player->getPlayerInfo()->judge) {
+    if (player->getLogic()->getPlayerInfo()->local || player->getLogic()->getPlayerInfo()->judge) {
         aMoveHandToTopLibrary = new QAction(this);
         aMoveHandToTopLibrary->setData(QList<QVariant>() << ZoneNames::DECK << 0);
         aMoveHandToBottomLibrary = new QAction(this);
@@ -85,7 +89,7 @@ HandMenu::HandMenu(PlayerLogic *_player, PlayerActions *actions, QWidget *parent
         aMoveHandToRfg = new QAction(this);
         aMoveHandToRfg->setData(QList<QVariant>() << ZoneNames::EXILE << 0);
 
-        auto hand = player->getHandZone();
+        auto hand = player->getLogic()->getHandZone();
 
         connect(aMoveHandToTopLibrary, &QAction::triggered, hand, &HandZoneLogic::moveAllToZone);
         connect(aMoveHandToBottomLibrary, &QAction::triggered, hand, &HandZoneLogic::moveAllToZone);
@@ -107,7 +111,7 @@ void HandMenu::retranslateUi()
 {
     setTitle(tr("&Hand"));
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aViewHand->setText(tr("&View hand"));
 
         mSortHand->setTitle(tr("Sort hand by..."));
@@ -166,9 +170,9 @@ void HandMenu::populateRevealHandMenuWithActivePlayers()
 
     mRevealHand->addSeparator();
 
-    const auto &players = player->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player) {
+        if (other == player->getLogic()) {
             continue;
         }
         QAction *a = mRevealHand->addAction(other->getPlayerInfo()->getName());
@@ -185,9 +189,9 @@ void HandMenu::populateRevealRandomHandCardMenuWithActivePlayers()
 
     mRevealRandomHandCard->addSeparator();
 
-    const auto &players = player->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player) {
+        if (other == player->getLogic()) {
             continue;
         }
         QAction *a = mRevealRandomHandCard->addAction(other->getPlayerInfo()->getName());
@@ -204,7 +208,7 @@ void HandMenu::onRevealHandTriggered()
     }
 
     const int targetId = action->data().toInt();
-    player->getPlayerActions()->actRevealHand(targetId);
+    player->getLogic()->getPlayerActions()->actRevealHand(targetId);
 }
 
 void HandMenu::onRevealRandomHandCardTriggered()
@@ -215,5 +219,5 @@ void HandMenu::onRevealRandomHandCardTriggered()
     }
 
     const int targetId = action->data().toInt();
-    player->getPlayerActions()->actRevealRandomHandCard(targetId);
+    player->getLogic()->getPlayerActions()->actRevealRandomHandCard(targetId);
 }

--- a/cockatrice/src/game/player/menu/hand_menu.h
+++ b/cockatrice/src/game/player/menu/hand_menu.h
@@ -13,7 +13,7 @@
 #include <QAction>
 #include <QMenu>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class PlayerActions;
 
 class HandMenu : public TearOffMenu, public AbstractPlayerComponent
@@ -21,7 +21,7 @@ class HandMenu : public TearOffMenu, public AbstractPlayerComponent
     Q_OBJECT
 
 public:
-    HandMenu(PlayerLogic *player, PlayerActions *actions, QWidget *parent = nullptr);
+    HandMenu(PlayerGraphicsItem *player, QWidget *parent = nullptr);
 
     QMenu *revealHandMenu() const
     {
@@ -43,7 +43,7 @@ private slots:
     void onRevealRandomHandCardTriggered();
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
 
     QAction *aViewHand = nullptr;
     QAction *aMulligan = nullptr;

--- a/cockatrice/src/game/player/menu/library_menu.cpp
+++ b/cockatrice/src/game/player/menu/library_menu.cpp
@@ -8,9 +8,10 @@
 #include "../player_logic.h"
 
 #include <QAction>
+#include <QGraphicsView>
 #include <QMenu>
 
-LibraryMenu::LibraryMenu(PlayerLogic *_player, QWidget *parent) : TearOffMenu(parent), player(_player)
+LibraryMenu::LibraryMenu(PlayerGraphicsItem *_player, QWidget *parent) : TearOffMenu(parent), player(_player)
 {
     createDrawActions();
     createShuffleActions();
@@ -75,8 +76,8 @@ LibraryMenu::LibraryMenu(PlayerLogic *_player, QWidget *parent) : TearOffMenu(pa
     bottomLibraryMenu->addSeparator();
     bottomLibraryMenu->addAction(aShuffleBottomCards);
 
-    connect(player, &PlayerLogic::resetTopCardMenuActions, this, &LibraryMenu::resetTopCardMenuActions);
-    connect(player, &PlayerLogic::deckChanged, this, &LibraryMenu::enableOpenInDeckEditorAction);
+    connect(player->getLogic(), &PlayerLogic::resetTopCardMenuActions, this, &LibraryMenu::resetTopCardMenuActions);
+    connect(player->getLogic(), &PlayerLogic::deckChanged, this, &LibraryMenu::enableOpenInDeckEditorAction);
 
     retranslateUi();
 }
@@ -94,9 +95,9 @@ void LibraryMenu::resetTopCardMenuActions()
 
 void LibraryMenu::createDrawActions()
 {
-    PlayerActions *playerActions = player->getPlayerActions();
+    PlayerActions *playerActions = player->getLogic()->getPlayerActions();
 
-    if (player->getPlayerInfo()->local || player->getPlayerInfo()->judge) {
+    if (player->getLogic()->getPlayerInfo()->local || player->getLogic()->getPlayerInfo()->judge) {
         aDrawCard = new QAction(this);
         connect(aDrawCard, &QAction::triggered, playerActions, &PlayerActions::actDrawCard);
         aDrawCards = new QAction(this);
@@ -112,9 +113,9 @@ void LibraryMenu::createDrawActions()
 
 void LibraryMenu::createShuffleActions()
 {
-    PlayerActions *playerActions = player->getPlayerActions();
+    PlayerActions *playerActions = player->getLogic()->getPlayerActions();
 
-    if (player->getPlayerInfo()->local || player->getPlayerInfo()->judge) {
+    if (player->getLogic()->getPlayerInfo()->local || player->getLogic()->getPlayerInfo()->judge) {
         aShuffle = new QAction(this);
         connect(aShuffle, &QAction::triggered, playerActions, &PlayerActions::actShuffle);
         aShuffleTopCards = new QAction(this);
@@ -126,9 +127,9 @@ void LibraryMenu::createShuffleActions()
 
 void LibraryMenu::createMoveActions()
 {
-    PlayerActions *playerActions = player->getPlayerActions();
+    PlayerActions *playerActions = player->getLogic()->getPlayerActions();
 
-    if (player->getPlayerInfo()->local || player->getPlayerInfo()->judge) {
+    if (player->getLogic()->getPlayerInfo()->local || player->getLogic()->getPlayerInfo()->judge) {
         aMoveTopToPlay = new QAction(this);
         connect(aMoveTopToPlay, &QAction::triggered, playerActions, &PlayerActions::actMoveTopCardToPlay);
         aMoveTopToPlayFaceDown = new QAction(this);
@@ -181,9 +182,9 @@ void LibraryMenu::createMoveActions()
 
 void LibraryMenu::createViewActions()
 {
-    PlayerActions *playerActions = player->getPlayerActions();
+    PlayerActions *playerActions = player->getLogic()->getPlayerActions();
 
-    if (player->getPlayerInfo()->local || player->getPlayerInfo()->judge) {
+    if (player->getLogic()->getPlayerInfo()->local || player->getLogic()->getPlayerInfo()->judge) {
         aViewLibrary = new QAction(this);
         connect(aViewLibrary, &QAction::triggered, playerActions, &PlayerActions::actViewLibrary);
 
@@ -207,7 +208,7 @@ void LibraryMenu::retranslateUi()
 {
     setTitle(tr("&Library"));
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         aViewLibrary->setText(tr("&View library"));
         aViewTopCards->setText(tr("View &top cards of library..."));
         aViewBottomCards->setText(tr("View bottom cards of library..."));
@@ -263,9 +264,9 @@ void LibraryMenu::populateRevealLibraryMenuWithActivePlayers()
 
     mRevealLibrary->addSeparator();
 
-    const auto &players = player->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player) {
+        if (other == player->getLogic()) {
             continue;
         }
         QAction *a = mRevealLibrary->addAction(other->getPlayerInfo()->getName());
@@ -278,9 +279,9 @@ void LibraryMenu::populateLendLibraryMenuWithActivePlayers()
 {
     mLendLibrary->clear();
 
-    const auto &players = player->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player) {
+        if (other == player->getLogic()) {
             continue;
         }
         QAction *a = mLendLibrary->addAction(other->getPlayerInfo()->getName());
@@ -299,9 +300,9 @@ void LibraryMenu::populateRevealTopCardMenuWithActivePlayers()
 
     mRevealTopCard->addSeparator();
 
-    const auto &players = player->getGame()->getPlayerManager()->getPlayers().values();
+    const auto &players = player->getLogic()->getGame()->getPlayerManager()->getPlayers().values();
     for (auto *other : players) {
-        if (other == player) {
+        if (other == player->getLogic()) {
             continue;
         }
         QAction *a = mRevealTopCard->addAction(other->getPlayerInfo()->getName());
@@ -313,27 +314,33 @@ void LibraryMenu::populateRevealTopCardMenuWithActivePlayers()
 void LibraryMenu::onRevealLibraryTriggered()
 {
     if (auto *a = qobject_cast<QAction *>(sender())) {
-        player->getPlayerActions()->actRevealLibrary(a->data().toInt());
+        player->getLogic()->getPlayerActions()->actRevealLibrary(a->data().toInt());
     }
 }
 
 void LibraryMenu::onLendLibraryTriggered()
 {
     if (auto *a = qobject_cast<QAction *>(sender())) {
-        player->getPlayerActions()->actLendLibrary(a->data().toInt());
+        player->getLogic()->getPlayerActions()->actLendLibrary(a->data().toInt());
     }
 }
 
 void LibraryMenu::onRevealTopCardTriggered()
 {
+    QWidget *parent = nullptr;
+    if (auto *view = player->scene() ? player->scene()->views().value(0) : nullptr) {
+        parent = view->window();
+    }
     if (auto *a = qobject_cast<QAction *>(sender())) {
-        int deckSize = player->getDeckZone()->getCards().size();
-        bool ok;
-        int number = QInputDialog::getInt(player->getGame()->getTab(), tr("Reveal top cards of library"),
+
+        int deckSize = player->getLogic()->getDeckZone()->getCards().size();
+        bool ok = true;
+        int number = QInputDialog::getInt(parent, tr("Reveal top cards of library"),
                                           tr("Number of cards: (max. %1)").arg(deckSize), defaultNumberTopCards, 1,
                                           deckSize, 1, &ok);
+
         if (ok) {
-            player->getPlayerActions()->actRevealTopCards(a->data().toInt(), number);
+            player->getLogic()->getPlayerActions()->actRevealTopCards(a->data().toInt(), number);
             defaultNumberTopCards = number;
         }
     }

--- a/cockatrice/src/game/player/menu/library_menu.h
+++ b/cockatrice/src/game/player/menu/library_menu.h
@@ -13,6 +13,7 @@
 #include <QAction>
 #include <QMenu>
 
+class PlayerGraphicsItem;
 class PlayerLogic;
 class PlayerActions;
 
@@ -24,7 +25,7 @@ public slots:
     void resetTopCardMenuActions();
 
 public:
-    LibraryMenu(PlayerLogic *player, QWidget *parent = nullptr);
+    LibraryMenu(PlayerGraphicsItem *player, QWidget *parent = nullptr);
     void createDrawActions();
     void createShuffleActions();
     void createMoveActions();
@@ -111,7 +112,7 @@ public:
     int defaultNumberTopCards = 1;
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
 };
 
 #endif // COCKATRICE_LIBRARY_MENU_H

--- a/cockatrice/src/game/player/menu/player_menu.cpp
+++ b/cockatrice/src/game/player/menu/player_menu.cpp
@@ -18,18 +18,18 @@ PlayerMenu::PlayerMenu(PlayerGraphicsItem *_player) : QObject(_player), player(_
     playerMenu = new TearOffMenu();
 
     if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
-        handMenu = addManagedMenu<HandMenu>(player->getLogic(), player->getLogic()->getPlayerActions(), playerMenu);
-        libraryMenu = addManagedMenu<LibraryMenu>(player->getLogic(), playerMenu);
+        handMenu = addManagedMenu<HandMenu>(player, playerMenu);
+        libraryMenu = addManagedMenu<LibraryMenu>(player, playerMenu);
     } else {
         handMenu = nullptr;
         libraryMenu = nullptr;
     }
 
-    graveMenu = addManagedMenu<GraveyardMenu>(player->getLogic(), playerMenu);
-    rfgMenu = addManagedMenu<RfgMenu>(player->getLogic(), playerMenu);
+    graveMenu = addManagedMenu<GraveyardMenu>(player, playerMenu);
+    rfgMenu = addManagedMenu<RfgMenu>(player, playerMenu);
 
     if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
-        sideboardMenu = addManagedMenu<SideboardMenu>(player->getLogic(), playerMenu);
+        sideboardMenu = addManagedMenu<SideboardMenu>(player, playerMenu);
         customZonesMenu = addManagedMenu<CustomZoneMenu>(player);
         playerMenu->addSeparator();
 
@@ -44,7 +44,7 @@ PlayerMenu::PlayerMenu(PlayerGraphicsItem *_player) : QObject(_player), player(_
     }
 
     if (player->getLogic()->getPlayerInfo()->getLocal()) {
-        sayMenu = addManagedMenu<SayMenu>(player->getLogic());
+        sayMenu = addManagedMenu<SayMenu>(player);
     } else {
         sayMenu = nullptr;
     }

--- a/cockatrice/src/game/player/menu/rfg_menu.cpp
+++ b/cockatrice/src/game/player/menu/rfg_menu.cpp
@@ -5,14 +5,14 @@
 
 #include <libcockatrice/utility/zone_names.h>
 
-RfgMenu::RfgMenu(PlayerLogic *_player, QWidget *parent) : TearOffMenu(parent), player(_player)
+RfgMenu::RfgMenu(PlayerGraphicsItem *_player, QWidget *parent) : TearOffMenu(parent), player(_player)
 {
     createMoveActions();
     createViewActions();
 
     addAction(aViewRfg);
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         addSeparator();
         moveRfgMenu = addTearOffMenu(QString());
         moveRfgMenu->addAction(aMoveRfgToTopLibrary);
@@ -28,8 +28,8 @@ RfgMenu::RfgMenu(PlayerLogic *_player, QWidget *parent) : TearOffMenu(parent), p
 
 void RfgMenu::createMoveActions()
 {
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
-        auto rfg = player->getRfgZone();
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
+        auto rfg = player->getLogic()->getRfgZone();
 
         aMoveRfgToTopLibrary = new QAction(this);
         aMoveRfgToTopLibrary->setData(QList<QVariant>() << ZoneNames::DECK << 0);
@@ -49,7 +49,7 @@ void RfgMenu::createMoveActions()
 
 void RfgMenu::createViewActions()
 {
-    PlayerActions *playerActions = player->getPlayerActions();
+    PlayerActions *playerActions = player->getLogic()->getPlayerActions();
 
     aViewRfg = new QAction(this);
     connect(aViewRfg, &QAction::triggered, playerActions, &PlayerActions::actViewRfg);
@@ -61,7 +61,7 @@ void RfgMenu::retranslateUi()
 
     aViewRfg->setText(tr("&View exile"));
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         moveRfgMenu->setTitle(tr("&Move exile to..."));
         aMoveRfgToTopLibrary->setText(tr("&Top of library"));
         aMoveRfgToBottomLibrary->setText(tr("&Bottom of library"));

--- a/cockatrice/src/game/player/menu/rfg_menu.h
+++ b/cockatrice/src/game/player/menu/rfg_menu.h
@@ -13,12 +13,12 @@
 #include <QAction>
 #include <QMenu>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class RfgMenu : public TearOffMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 public:
-    explicit RfgMenu(PlayerLogic *player, QWidget *parent = nullptr);
+    explicit RfgMenu(PlayerGraphicsItem *player, QWidget *parent = nullptr);
     void createMoveActions();
     void createViewActions();
     void retranslateUi() override;
@@ -38,7 +38,7 @@ public:
     QAction *aMoveRfgToGrave = nullptr;
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
 };
 
 #endif // COCKATRICE_RFG_MENU_H

--- a/cockatrice/src/game/player/menu/say_menu.cpp
+++ b/cockatrice/src/game/player/menu/say_menu.cpp
@@ -4,7 +4,7 @@
 #include "../player_actions.h"
 #include "../player_logic.h"
 
-SayMenu::SayMenu(PlayerLogic *_player) : player(_player)
+SayMenu::SayMenu(PlayerGraphicsItem *_player) : player(_player)
 {
     connect(&SettingsCache::instance().messages(), &MessageSettings::messageMacrosChanged, this, &SayMenu::initSayMenu);
     initSayMenu();
@@ -44,7 +44,7 @@ void SayMenu::initSayMenu()
 
     for (int i = 0; i < count; ++i) {
         auto *newAction = new QAction(SettingsCache::instance().messages().getMessageAt(i), this);
-        connect(newAction, &QAction::triggered, player->getPlayerActions(), &PlayerActions::actSayMessage);
+        connect(newAction, &QAction::triggered, player->getLogic()->getPlayerActions(), &PlayerActions::actSayMessage);
         addAction(newAction);
     }
 

--- a/cockatrice/src/game/player/menu/say_menu.h
+++ b/cockatrice/src/game/player/menu/say_menu.h
@@ -11,12 +11,12 @@
 
 #include <QMenu>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class SayMenu : public QMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 public:
-    explicit SayMenu(PlayerLogic *player);
+    explicit SayMenu(PlayerGraphicsItem *player);
 
     void retranslateUi() override;
     void setShortcutsActive() override;
@@ -26,7 +26,7 @@ private slots:
     void initSayMenu();
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
     bool shortcutsActive = false;
 };
 

--- a/cockatrice/src/game/player/menu/sideboard_menu.cpp
+++ b/cockatrice/src/game/player/menu/sideboard_menu.cpp
@@ -3,12 +3,13 @@
 #include "../player_actions.h"
 #include "../player_logic.h"
 
-SideboardMenu::SideboardMenu(PlayerLogic *player, QMenu *playerMenu) : QMenu(playerMenu)
+SideboardMenu::SideboardMenu(PlayerGraphicsItem *player, QMenu *playerMenu) : QMenu(playerMenu)
 {
     aViewSideboard = new QAction(this);
-    connect(aViewSideboard, &QAction::triggered, player->getPlayerActions(), &PlayerActions::actViewSideboard);
+    connect(aViewSideboard, &QAction::triggered, player->getLogic()->getPlayerActions(),
+            &PlayerActions::actViewSideboard);
 
-    if (player->getPlayerInfo()->getLocalOrJudge()) {
+    if (player->getLogic()->getPlayerInfo()->getLocalOrJudge()) {
         addAction(aViewSideboard);
     }
 

--- a/cockatrice/src/game/player/menu/sideboard_menu.h
+++ b/cockatrice/src/game/player/menu/sideboard_menu.h
@@ -11,19 +11,19 @@
 
 #include <QMenu>
 
-class PlayerLogic;
+class PlayerGraphicsItem;
 class SideboardMenu : public QMenu, public AbstractPlayerComponent
 {
     Q_OBJECT
 
 public:
-    explicit SideboardMenu(PlayerLogic *player, QMenu *playerMenu);
+    explicit SideboardMenu(PlayerGraphicsItem *player, QMenu *playerMenu);
     void retranslateUi() override;
     void setShortcutsActive() override;
     void setShortcutsInactive() override;
 
 private:
-    PlayerLogic *player;
+    PlayerGraphicsItem *player;
 
     QAction *aViewSideboard;
 };


### PR DESCRIPTION
## Related Ticket(s)
- Succeeds #6919
- Dependent on #6944

## Short roundup of the initial problem
These are graphics classes and some of them need the player graphics. It's sensible to have them all take the graphic item, since it has access to the logic, especially for future refactors.

## What will change with this Pull Request?
- All menu classes take PlayerGraphicsItem* instead of PlayerLogic* (* This might not be entirely accurate in this PR but it will be)
CardMenu, CustomZoneMenu, GraveyardMenu, HandMenu, LibraryMenu, MoveMenu, PtMenu, RfgMenu, SayMenu, SideboardMenu, UtilityMenu, and PlayerMenu all now hold PlayerGraphicsItem* and reach logic through player->getPlayerLogic(). These are view-layer classes and this reflects their actual nature.

