### PR TITLE
[Game] Show counter color icons in game log

### DIFF
--- a/cockatrice/src/game/log/message_log_widget.cpp
+++ b/cockatrice/src/game/log/message_log_widget.cpp
@@ -650,14 +650,16 @@ void MessageLogWidget::logSetCardCounter(PlayerLogic *player, QString cardName, 
     QString finalStr;
     int delta = abs(oldValue - value);
     if (value > oldValue) {
-        finalStr = tr("%1 places %2 \"%3\" counter(s) on %4 (now %5).", "", delta);
+        finalStr = tr("%1 places %2 %3%4 counter(s) on %5 (now %6).", "", delta);
     } else {
-        finalStr = tr("%1 removes %2 \"%3\" counter(s) from %4 (now %5).", "", delta);
+        finalStr = tr("%1 removes %2 %3%4 counter(s) from %5 (now %6).", "", delta);
     }
 
     auto &cardCounterSettings = SettingsCache::instance().cardCounters();
+    QString hex = cardCounterSettings.color(counterId).name();
     appendHtmlServerMessage(finalStr.arg(sanitizeHtml(player->getPlayerInfo()->getName()))
                                 .arg("<font class=\"blue\">" + QString::number(delta) + "</font>")
+                                .arg("<font color=\"" + hex + "\">●</font>")
                                 .arg(cardCounterSettings.displayName(counterId))
                                 .arg(cardLink(std::move(cardName)))
                                 .arg(value));


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6947

## Short roundup of the initial problem

It's sorta hard to parse the counters from the logs at a glance.

<img width="484" height="390" alt="Screenshot 2026-05-28 at 1 04 21 AM" src="https://github.com/user-attachments/assets/5f5410e8-e309-40f6-a2cf-cd844146578b" />

Since we're putting color icons in the counter menu, we might as well also do it in the game log

## What will change with this Pull Request?

- Change the counter log from surrounding the counter name in quotes to just having a colored dot before the name.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<img width="504" height="554" alt="Screenshot 2026-05-28 at 1 00 18 AM" src="https://github.com/user-attachments/assets/9b4f95dd-a724-4691-8ec9-505f084f5880" />

