### PR TITLE
[Game][Arrow] Refactor: Rename arrow methods in GameScene

### DIFF
--- a/cockatrice/src/game/game_scene.cpp
+++ b/cockatrice/src/game/game_scene.cpp
@@ -419,6 +419,15 @@ void GameScene::requestArrowDeletion(int arrowId)
     }
 }
 
+void GameScene::requestClearArrowsForPlayer(int playerId)
+{
+    for (auto *arrow : arrowRegistry.values()) {
+        if (arrow->getPlayer()->getPlayerInfo()->getId() == playerId) {
+            emit requestArrowDeletion(arrow->getId());
+        }
+    }
+}
+
 void GameScene::onCardZoneChanged(CardItem *card, bool sameZone)
 {
     QList<ArrowItem *> toDelete;
@@ -433,15 +442,6 @@ void GameScene::onCardZoneChanged(CardItem *card, bool sameZone)
     }
     for (auto *arrow : toDelete) {
         deleteArrow(arrow->getId());
-    }
-}
-
-void GameScene::requestClearArrowsForPlayer(int playerId)
-{
-    for (auto *arrow : arrowRegistry.values()) {
-        if (arrow->getPlayer()->getPlayerInfo()->getId() == playerId) {
-            emit requestArrowDeletion(arrow->getId());
-        }
     }
 }
 

--- a/cockatrice/src/game/game_scene.cpp
+++ b/cockatrice/src/game/game_scene.cpp
@@ -88,16 +88,16 @@ void GameScene::addPlayer(PlayerLogic *player)
 
     connect(player, &PlayerLogic::concededChanged, this, [this](int id, bool conceded) {
         if (conceded) {
-            clearArrowsForPlayer(id);
+            requestClearArrowsForPlayer(id);
         }
         rearrange();
     });
 
-    connect(player, &PlayerLogic::arrowDeleted, this, &GameScene::onArrowDeleted);
-    connect(player, &PlayerLogic::arrowCreateRequested, this, &GameScene::onArrowCreateRequested);
-    connect(player, &PlayerLogic::arrowDeleteRequested, this, &GameScene::onArrowDeleteRequested);
+    connect(player, &PlayerLogic::arrowDeleted, this, &GameScene::deleteArrow);
+    connect(player, &PlayerLogic::arrowCreateRequested, this, &GameScene::addArrow);
+    connect(player, &PlayerLogic::arrowDeleteRequested, this, &GameScene::requestArrowDeletion);
     connect(player, &PlayerLogic::arrowsCleared, this,
-            [this, id = player->getPlayerInfo()->getId()]() { clearArrowsForPlayer(id); });
+            [this, id = player->getPlayerInfo()->getId()]() { requestClearArrowsForPlayer(id); });
 
     connect(player->getPlayerEventHandler(), &PlayerEventHandler::cardZoneChanged, this, &GameScene::onCardZoneChanged);
 
@@ -114,7 +114,7 @@ void GameScene::removePlayer(PlayerLogic *player)
 {
     qCInfo(GameScenePlayerAdditionRemovalLog) << "GameScene::removePlayer name=" << player->getPlayerInfo()->getName();
 
-    clearArrowsForPlayer(player->getPlayerInfo()->getId());
+    requestClearArrowsForPlayer(player->getPlayerInfo()->getId());
 
     for (ZoneViewWidget *zone : zoneViews) {
         if (zone->getPlayer() == player) {
@@ -367,7 +367,7 @@ void GameScene::resizeColumnsAndPlayers(const QList<qreal> &minWidthByColumn, qr
     }
 }
 
-void GameScene::onArrowCreateRequested(const ArrowData &data)
+void GameScene::addArrow(const ArrowData &data)
 {
     auto *startView = playerViews.value(data.startPlayerId);
     auto *targetView = playerViews.value(data.targetPlayerId);
@@ -402,20 +402,20 @@ void GameScene::onArrowCreateRequested(const ArrowData &data)
     auto *arrow = new ArrowItem(startView->getPlayer(), data.id, startCard, targetItem, data.color);
     addItem(arrow);
     arrowRegistry.insert(data.id, arrow);
-    connect(arrow, &ArrowItem::requestDeletion, this, &GameScene::onArrowDeleteRequested);
+    connect(arrow, &ArrowItem::requestDeletion, this, &GameScene::requestArrowDeletion);
 }
 
-void GameScene::onArrowDeleted(int arrowId)
+void GameScene::deleteArrow(int arrowId)
 {
     if (arrowRegistry.contains(arrowId)) {
         arrowRegistry.take(arrowId)->delArrow();
     }
 }
 
-void GameScene::onArrowDeleteRequested(int arrowId)
+void GameScene::requestArrowDeletion(int arrowId)
 {
     if (arrowRegistry.contains(arrowId)) {
-        emit requestArrowDeletion(arrowId);
+        emit arrowDeletionRequested(arrowId);
     }
 }
 
@@ -432,11 +432,11 @@ void GameScene::onCardZoneChanged(CardItem *card, bool sameZone)
         }
     }
     for (auto *arrow : toDelete) {
-        onArrowDeleted(arrow->getId());
+        deleteArrow(arrow->getId());
     }
 }
 
-void GameScene::clearArrowsForPlayer(int playerId)
+void GameScene::requestClearArrowsForPlayer(int playerId)
 {
     for (auto *arrow : arrowRegistry.values()) {
         if (arrow->getPlayer()->getPlayerInfo()->getId() == playerId) {

--- a/cockatrice/src/game/game_scene.h
+++ b/cockatrice/src/game/game_scene.h
@@ -201,11 +201,11 @@ public slots:
     QTransform getViewTransform() const;
     QTransform getViewportTransform() const;
 
-    void onArrowCreateRequested(const ArrowData &data);
-    void onArrowDeleted(int arrowId);
-    void onArrowDeleteRequested(int arrowId);
+    void addArrow(const ArrowData &data);
+    void deleteArrow(int arrowId);
+    void requestArrowDeletion(int arrowId);
     void onCardZoneChanged(CardItem *card, bool sameZone);
-    void clearArrowsForPlayer(int playerId);
+    void requestClearArrowsForPlayer(int playerId);
 
 protected:
     /** @brief Handles hover updates. */
@@ -218,7 +218,7 @@ signals:
     void sigStartRubberBand(const QPointF &selectionOrigin);
     void sigResizeRubberBand(const QPointF &cursorPoint, int selectedCount);
     void sigStopRubberBand();
-    void requestArrowDeletion(int arrowId);
+    void arrowDeletionRequested(int arrowId);
 };
 
 #endif

--- a/cockatrice/src/game/game_scene.h
+++ b/cockatrice/src/game/game_scene.h
@@ -201,11 +201,15 @@ public slots:
     QTransform getViewTransform() const;
     QTransform getViewportTransform() const;
 
+    /// Directly modifies the scene
     void addArrow(const ArrowData &data);
     void deleteArrow(int arrowId);
+
+    /// Queues up arrow deletion but doesn't directly modify the scene
     void requestArrowDeletion(int arrowId);
-    void onCardZoneChanged(CardItem *card, bool sameZone);
     void requestClearArrowsForPlayer(int playerId);
+
+    void onCardZoneChanged(CardItem *card, bool sameZone);
 
 protected:
     /** @brief Handles hover updates. */

--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -608,7 +608,7 @@ void TabGame::actRemoveLocalArrows()
 {
     auto *local = game->getPlayerManager()->getActiveLocalPlayer(game->getGameState()->getActivePlayer());
     if (local) {
-        scene->clearArrowsForPlayer(local->getPlayerInfo()->getId());
+        scene->requestClearArrowsForPlayer(local->getPlayerInfo()->getId());
     }
 }
 
@@ -1150,9 +1150,9 @@ void TabGame::createPlayAreaWidget(bool bReplay)
     scene = new GameScene(phasesToolbar, this);
     connect(game->getPlayerManager(), &PlayerManager::playerConceded, scene, &GameScene::rearrange);
     connect(game->getPlayerManager(), &PlayerManager::playerCountChanged, scene, &GameScene::rearrange);
-    connect(scene, &GameScene::requestArrowDeletion, game->getGameEventHandler(),
+    connect(scene, &GameScene::arrowDeletionRequested, game->getGameEventHandler(),
             &GameEventHandler::handleArrowDeletion);
-    connect(game->getGameEventHandler(), &GameEventHandler::arrowDeleted, scene, &GameScene::onArrowDeleted);
+    connect(game->getGameEventHandler(), &GameEventHandler::arrowDeleted, scene, &GameScene::deleteArrow);
     gameView = new GameView(scene);
 
     auto gamePlayAreaVBox = new QVBoxLayout;


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6918

## Short roundup of the initial problem

I'm renaming the arrow-related methods in `GameScene` in order to make things easier to understand for myself, and also adding some documentation while at it.

## What will change with this Pull Request?
- Rename methods in `GameScene` to better describe which category they belong in
- Add some docs to the categories