### PR TITLE
[Game][Arrow] Correctly call clear all arrows for player

### DIFF
--- a/cockatrice/src/game/game_scene.cpp
+++ b/cockatrice/src/game/game_scene.cpp
@@ -88,7 +88,7 @@ void GameScene::addPlayer(PlayerLogic *player)
 
     connect(player, &PlayerLogic::concededChanged, this, [this](int id, bool conceded) {
         if (conceded) {
-            requestClearArrowsForPlayer(id);
+            clearArrowsForPlayer(id);
         }
         rearrange();
     });
@@ -97,7 +97,7 @@ void GameScene::addPlayer(PlayerLogic *player)
     connect(player, &PlayerLogic::arrowCreateRequested, this, &GameScene::addArrow);
     connect(player, &PlayerLogic::arrowDeleteRequested, this, &GameScene::requestArrowDeletion);
     connect(player, &PlayerLogic::arrowsCleared, this,
-            [this, id = player->getPlayerInfo()->getId()]() { requestClearArrowsForPlayer(id); });
+            [this, id = player->getPlayerInfo()->getId()]() { clearArrowsForPlayer(id); });
 
     connect(player->getPlayerEventHandler(), &PlayerEventHandler::cardZoneChanged, this, &GameScene::onCardZoneChanged);
 
@@ -114,7 +114,7 @@ void GameScene::removePlayer(PlayerLogic *player)
 {
     qCInfo(GameScenePlayerAdditionRemovalLog) << "GameScene::removePlayer name=" << player->getPlayerInfo()->getName();
 
-    requestClearArrowsForPlayer(player->getPlayerInfo()->getId());
+    clearArrowsForPlayer(player->getPlayerInfo()->getId());
 
     for (ZoneViewWidget *zone : zoneViews) {
         if (zone->getPlayer() == player) {
@@ -408,6 +408,21 @@ void GameScene::addArrow(const ArrowData &data)
 void GameScene::deleteArrow(int arrowId)
 {
     if (arrowRegistry.contains(arrowId)) {
+        arrowRegistry.take(arrowId)->delArrow();
+    }
+}
+
+void GameScene::clearArrowsForPlayer(int playerId)
+{
+    QList<int> toDelete;
+    for (auto i = arrowRegistry.cbegin(); i != arrowRegistry.cend(); ++i) {
+        auto *arrow = i.value();
+        if (arrow->getPlayer()->getPlayerInfo()->getId() == playerId) {
+            toDelete.append(i.key());
+        }
+    }
+
+    for (int arrowId : toDelete) {
         arrowRegistry.take(arrowId)->delArrow();
     }
 }

--- a/cockatrice/src/game/game_scene.h
+++ b/cockatrice/src/game/game_scene.h
@@ -204,6 +204,7 @@ public slots:
     /// Directly modifies the scene
     void addArrow(const ArrowData &data);
     void deleteArrow(int arrowId);
+    void clearArrowsForPlayer(int playerId);
 
     /// Queues up arrow deletion but doesn't directly modify the scene
     void requestArrowDeletion(int arrowId);


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6949
- Fixes bug introduced in #6918

## Short roundup of the initial problem

All code calls `requestClearArrowsForPlayer` to reset arrows. However, `requestClearArrowsForPlayer` only sends commands to the server, which makes no sense when you're trying to reset the local game scene.

Notably, that means arrows don't get deleted properly when rewinding a replay.

https://github.com/user-attachments/assets/bf5a39ee-b9ee-4b2a-896c-287597ba2a79

## What will change with this Pull Request?

- Create a method that *does* immediately clear all arrows
- Call that method when appropriate

This still doesn't fix all the arrow deletion problems, but it does fix one of them.

https://github.com/user-attachments/assets/f8ecd61f-5e04-4c07-8028-ce0ba9618186
