### PR TITLE
[TabDeckEditor] Refactor check ctrl to be on click

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
@@ -79,7 +79,7 @@ DeckEditorDatabaseDisplayWidget::DeckEditorDatabaseDisplayWidget(QWidget *parent
             &DeckEditorDatabaseDisplayWidget::databaseCustomMenu);
     connect(databaseView->selectionModel(), &QItemSelectionModel::currentRowChanged, this,
             &DeckEditorDatabaseDisplayWidget::updateCard);
-    connect(databaseView, &QTreeView::doubleClicked, this, &DeckEditorDatabaseDisplayWidget::actAddCardToMainDeck);
+    connect(databaseView, &QTreeView::doubleClicked, this, &DeckEditorDatabaseDisplayWidget::actAddCard);
 
     QByteArray dbHeaderState = SettingsCache::instance().layouts().getDeckEditorDbHeaderState();
     if (dbHeaderState.isNull()) {
@@ -143,6 +143,15 @@ void DeckEditorDatabaseDisplayWidget::updateCard(const QModelIndex &current, con
 
     if (!current.model()->hasChildren(current.siblingAtColumn(CardDatabaseModel::NameColumn))) {
         emit cardChanged(CardDatabaseManager::query()->getPreferredCard(cardName));
+    }
+}
+
+void DeckEditorDatabaseDisplayWidget::actAddCard()
+{
+    if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
+        actAddCardToSideboard();
+    } else {
+        actAddCardToMainDeck();
     }
 }
 

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.h
@@ -39,6 +39,7 @@ public slots:
     void clearAllDatabaseFilters();
     void updateSearch(const QString &search);
     void updateCard(const QModelIndex &current, const QModelIndex &);
+    void actAddCard();
     void actAddCardToMainDeck();
     void actAddCardToSideboard();
     void actDecrementCardFromMainDeck();

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
@@ -144,11 +144,7 @@ void AbstractTabDeckEditor::decrementCard(const ExactCard &card, const QString &
  */
 void AbstractTabDeckEditor::actAddCard(const ExactCard &card)
 {
-    if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
-        actAddCardToSideboard(card);
-    } else {
-        addCard(card, DECK_ZONE_MAIN);
-    }
+    addCard(card, DECK_ZONE_MAIN);
 }
 
 /** @brief Adds a card to the sideboard explicitly. */

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
@@ -223,7 +223,11 @@ void TabDeckEditorVisual::processCardClickDatabaseDisplay(QMouseEvent *event,
                                                           CardInfoPictureWithTextOverlayWidget *instance)
 {
     if (event->button() == Qt::LeftButton) {
-        actAddCard(instance->getCard());
+        if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
+            actAddCardToSideboard(instance->getCard());
+        } else {
+            actAddCard(instance->getCard());
+        }
     } else if (event->button() == Qt::RightButton) {
         actDecrementCard(instance->getCard());
     } else if (event->button() == Qt::MiddleButton) {


### PR DESCRIPTION
## Related Ticket(s)
- #6939

## Short roundup of the initial problem

Having the ctrl check happen all the way at `AbstractTabDeckEditor::actAddCard` is both unintuitive, and is getting in the way of my planned refactors.

## What will change with this Pull Request?

- Do the ctrl check lower in the calls, and delegate to the correct signal.

This *does* change functionality, in that the green `add to mainboard` button will no longer add to sideboard while ctrl is held. I doubt anyone actually used or even knew about that, seeing as the blue `add to sideboard` button is right next to it.