### PR TITLE
Delete .codacy.yml

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,5 +1,0 @@
----
-exclude_paths:
-  - '**/translations/*.ts'
-
-# codacy config documentation: https://support.codacy.com/hc/en-us/articles/115002130625-Codacy-Configuration-File


### PR DESCRIPTION
It looks like our Codacy setup stopped working and is disabled since a long time:
https://www.codacy.com/app/Cockatrice/Cockatrice/issues

Two options:
1) Merge this PR and clean our repo up
2) There is actually [good support for C++](https://docs.codacy.com/getting-started/supported-languages-and-tools/) in [Codacy](https://www.codacy.com/).
  If the active devs think SAST and code scanning would be helpful and good for our repo, we should set it properly up instead on the Codacy page (@ZeldaZach).
I did also look into CodeQL and configured that as a similar alternative in #6958 (not quite the same and they work actually a bit different).