### PR TITLE
CI: Add CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
         dependency-caching: true
 
     - name: "[C++] Install dependencies"
-      if: matrix.build-mode == 'manual' && matrix.language == 'cpp'
+      if: matrix.language == 'cpp' && matrix.build-mode == 'manual'
       shell: bash
       env:
         DEBIAN_FRONTEND: noninteractive
@@ -79,12 +79,12 @@ jobs:
 # Add ccache usage for faster compilation, (install ccache dep, actions/cache step + append DUSE_CCACHE=1 in cmake config, CCACHE env values)
 
     - name: "[C++] Configure CMake"
-      if: matrix.build-mode == 'manual' && matrix.language == 'cpp'
+      if: matrix.language == 'cpp' && matrix.build-mode == 'manual'
       shell: bash
       run: cmake -S . -B build -G Ninja -DWITH_SERVER=1 -DCMAKE_BUILD_TYPE=Release
 
     - name: "[C++] Build application"
-      if: matrix.build-mode == 'manual' && matrix.language == 'cpp'
+      if: matrix.language == 'cpp' && matrix.build-mode == 'manual'
       shell: bash
       run: cmake --build build
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,12 +67,8 @@ jobs:
           liblzma-dev \
           libmariadb-dev-compat \
           libprotobuf-dev \
-          libqt6multimedia6 \
-          libqt6sql6-mysql \
           ninja-build \
           protobuf-compiler \
-          qt6-image-formats-plugins \
-          qt6-l10n-tools \
           qt6-multimedia-dev \
           qt6-svg-dev \
           qt6-tools-dev \
@@ -85,7 +81,7 @@ jobs:
     - name: "[C++] Configure CMake"
       if: matrix.build-mode == 'manual' && matrix.language == 'cpp'
       shell: bash
-      run: cmake -B build -S . -G Ninja -DWITH_SERVER=1 -DCMAKE_BUILD_TYPE=Release
+      run: cmake -S . -B build -G Ninja -DWITH_SERVER=1 -DCMAKE_BUILD_TYPE=Release
 
     - name: "[C++] Build application"
       if: matrix.build-mode == 'manual' && matrix.language == 'cpp'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,98 @@
+# GitHub Docs on Code Scanning:
+# https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning
+# https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/manage-your-configuration
+# https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options
+#
+# CodeQL Docs:
+# https://codeql.github.com/docs/
+
+name: CodeQL
+
+permissions:
+  security-events: write    # needed to post results
+  contents: read
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+      - 'doc/**'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+      - 'doc/**'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        # https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/
+        - language: cpp
+          build-mode: manual
+        - language: actions
+          build-mode: none
+
+    steps:
+    - name: "Checkout repository"
+      uses: actions/checkout@v6
+
+    - name: "Initialize CodeQL"
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        queries: security-and-quality
+        dependency-caching: true
+
+    - name: "[C++] Install dependencies"
+      if: matrix.build-mode == 'manual' && matrix.language == 'cpp'
+      shell: bash
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          cmake \
+          g++ \
+          libgl-dev \
+          liblzma-dev \
+          libmariadb-dev-compat \
+          libprotobuf-dev \
+          libqt6multimedia6 \
+          libqt6sql6-mysql \
+          ninja-build \
+          protobuf-compiler \
+          qt6-image-formats-plugins \
+          qt6-l10n-tools \
+          qt6-multimedia-dev \
+          qt6-svg-dev \
+          qt6-tools-dev \
+          qt6-tools-dev-tools \
+          qt6-websockets-dev
+
+# Minimize dependency install
+# Add ccache usage for faster compilation, (install ccache dep, actions/cache step + append DUSE_CCACHE=1 in cmake config, CCACHE env values)
+
+    - name: "[C++] Configure CMake"
+      if: matrix.build-mode == 'manual' && matrix.language == 'cpp'
+      shell: bash
+      run: cmake -B build -S . -G Ninja -DWITH_SERVER=1 -DCMAKE_BUILD_TYPE=Release
+
+    - name: "[C++] Build application"
+      if: matrix.build-mode == 'manual' && matrix.language == 'cpp'
+      shell: bash
+      run: cmake --build build
+
+    - name: "Perform CodeQL Analysis"
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,9 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        queries: security-and-quality
+        # https://docs.github.com/en/code-security/reference/code-scanning/codeql/codeql-queries/c-cpp-built-in-queries
+        # https://docs.github.com/en/code-security/reference/code-scanning/codeql/codeql-queries/actions-built-in-queries
+        queries: security-extended
         dependency-caching: true
 
     - name: "[C++] Install dependencies"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,11 @@ on:
       - '**/*.md'
       - 'doc/**'
 
+# Cancel earlier, unfinished runs of this workflow on the same branch
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref_name }}"
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,15 +16,7 @@ on:
   push:
     branches:
       - master
-    paths-ignore:
-      - '**/*.md'
-      - 'doc/**'
   pull_request:
-    branches:
-      - master
-    paths-ignore:
-      - '**/*.md'
-      - 'doc/**'
 
 # Cancel earlier, unfinished runs of this workflow on the same branch
 concurrency:

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -34,7 +34,7 @@ on:
       - 'vcpkg.json'
       - 'vcpkg'
 
-# Cancel earlier, unfinished runs of this workflow on the same branch (unless on release)
+# Cancel earlier, unfinished runs of this workflow on the same branch (unless on tag --> release)
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.ref_name }}"
   cancel-in-progress: ${{ github.ref_type != 'tag' }}

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -11,6 +11,11 @@ on:
       - 'Doxyfile'
   workflow_dispatch:
 
+# Cancel earlier, unfinished runs of this workflow on the same branch (unless on release)
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref_name }}"
+  cancel-in-progress: ${{ github.event_name != 'release' }}
+
 env:
   COCKATRICE_REF: ${{ github.ref_name }}    # Tag name if the commit is tagged, otherwise branch name
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #5105

## Short roundup of the initial problem
CodeQL was automatically enabled by GitHub, but the `autobuild` mode set by default was not working with our project.

## What will change with this Pull Request?
- Add manual steps for building the app to get best scan results rather than checking source files only
- Analyses `C++` code and `GitHub Actions` configurations for vulnerabilities and errors
- Comments will be posted to PR's
- Results will be uploaded to [GitHub Code Scanning in the Security tab](https://github.com/Cockatrice/Cockatrice/security/code-scanning) in the repo

Docs: https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities