### PR TITLE
[TabDeckEditor] Refactor: consolidate add/decrement card signals

### DIFF
--- a/cockatrice/src/interface/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_widget.cpp
@@ -431,13 +431,13 @@ QMenu *CardInfoPictureWidget::createAddToOpenDeckMenu()
         QAction *addCard = addCardMenu->addAction(tr("Mainboard"));
         connect(addCard, &QAction::triggered, this, [this, deckEditorTab] {
             deckEditorTab->updateCard(exactCard);
-            deckEditorTab->actAddCard(exactCard);
+            deckEditorTab->addCard(exactCard, DECK_ZONE_MAIN);
         });
 
         QAction *addCardSideboard = addCardMenu->addAction(tr("Sideboard"));
         connect(addCardSideboard, &QAction::triggered, this, [this, deckEditorTab] {
             deckEditorTab->updateCard(exactCard);
-            deckEditorTab->actAddCardToSideboard(exactCard);
+            deckEditorTab->addCard(exactCard, DECK_ZONE_SIDE);
         });
     }
 

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_card_database_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_card_database_dock_widget.cpp
@@ -29,14 +29,10 @@ void DeckEditorCardDatabaseDockWidget::createDatabaseDisplayDock(AbstractTabDeck
     // connect signals
     connect(databaseDisplayWidget, &DeckEditorDatabaseDisplayWidget::cardChanged, deckEditor,
             &AbstractTabDeckEditor::updateCard);
-    connect(databaseDisplayWidget, &DeckEditorDatabaseDisplayWidget::addCardToMainDeck, deckEditor,
-            &AbstractTabDeckEditor::actAddCard);
-    connect(databaseDisplayWidget, &DeckEditorDatabaseDisplayWidget::addCardToSideboard, deckEditor,
-            &AbstractTabDeckEditor::actAddCardToSideboard);
-    connect(databaseDisplayWidget, &DeckEditorDatabaseDisplayWidget::decrementCardFromMainDeck, deckEditor,
-            &AbstractTabDeckEditor::actDecrementCard);
-    connect(databaseDisplayWidget, &DeckEditorDatabaseDisplayWidget::decrementCardFromSideboard, deckEditor,
-            &AbstractTabDeckEditor::actDecrementCardFromSideboard);
+    connect(databaseDisplayWidget, &DeckEditorDatabaseDisplayWidget::cardAdded, deckEditor,
+            &AbstractTabDeckEditor::addCard);
+    connect(databaseDisplayWidget, &DeckEditorDatabaseDisplayWidget::cardDecremented, deckEditor,
+            &AbstractTabDeckEditor::decrementCard);
 }
 
 CardDatabase *DeckEditorCardDatabaseDockWidget::getDatabase() const

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
@@ -158,23 +158,23 @@ void DeckEditorDatabaseDisplayWidget::actAddCard()
 void DeckEditorDatabaseDisplayWidget::actAddCardToMainDeck()
 {
     highlightAllSearchEdit();
-    emit addCardToMainDeck(currentCard());
+    emit cardAdded(currentCard(), DECK_ZONE_MAIN);
 }
 
 void DeckEditorDatabaseDisplayWidget::actAddCardToSideboard()
 {
     highlightAllSearchEdit();
-    emit addCardToSideboard(currentCard());
+    emit cardAdded(currentCard(), DECK_ZONE_SIDE);
 }
 
 void DeckEditorDatabaseDisplayWidget::actDecrementCardFromMainDeck()
 {
-    emit decrementCardFromMainDeck(currentCard());
+    emit cardDecremented(currentCard(), DECK_ZONE_MAIN);
 }
 
 void DeckEditorDatabaseDisplayWidget::actDecrementCardFromSideboard()
 {
-    emit decrementCardFromSideboard(currentCard());
+    emit cardDecremented(currentCard(), DECK_ZONE_SIDE);
 }
 
 ExactCard DeckEditorDatabaseDisplayWidget::currentCard() const

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.h
@@ -48,10 +48,8 @@ public slots:
     void copyDatabaseCellContents();
 
 signals:
-    void addCardToMainDeck(const ExactCard &card);
-    void addCardToSideboard(const ExactCard &card);
-    void decrementCardFromMainDeck(const ExactCard &card);
-    void decrementCardFromSideboard(const ExactCard &card);
+    void cardAdded(const ExactCard &card, const QString &zoneName);
+    void cardDecremented(const ExactCard &card, const QString &zoneName);
     void cardChanged(const ExactCard &_card);
 
 private:

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
@@ -140,32 +140,6 @@ void AbstractTabDeckEditor::decrementCard(const ExactCard &card, const QString &
 }
 
 /**
- * @brief Adds a card to the main deck or sideboard depending on Ctrl key.
- */
-void AbstractTabDeckEditor::actAddCard(const ExactCard &card)
-{
-    addCard(card, DECK_ZONE_MAIN);
-}
-
-/** @brief Adds a card to the sideboard explicitly. */
-void AbstractTabDeckEditor::actAddCardToSideboard(const ExactCard &card)
-{
-    addCard(card, DECK_ZONE_SIDE);
-}
-
-/** @brief Decrements a card from the main deck. */
-void AbstractTabDeckEditor::actDecrementCard(const ExactCard &card)
-{
-    decrementCard(card, DECK_ZONE_MAIN);
-}
-
-/** @brief Decrements a card from the sideboard. */
-void AbstractTabDeckEditor::actDecrementCardFromSideboard(const ExactCard &card)
-{
-    decrementCard(card, DECK_ZONE_SIDE);
-}
-
-/**
  * @brief Opens a deck in this tab.
  * @param deck The deck
  */

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
@@ -77,8 +77,8 @@ class QAction;
  *
  * **Key Methods:**
  *
- * - actAddCard(const ExactCard &card) — Adds a card to the deck.
- * - actDecrementCard(const ExactCard &card) — Removes a single instance of a card from the deck.
+ * - addCard(const ExactCard &card, const QString &zoneName) — Adds a card to the deck.
+ * - decrementCard(const ExactCard &card, const QString &zoneName) — Removes a single instance of a card from the deck.
  * - actRemoveCard() — Removes the currently selected card from the deck.
  * - actSaveDeckAs() — Performs a "Save As" action for the deck.
  * - updateCard(const ExactCard &card) — Updates the currently displayed card info in the dock.
@@ -162,18 +162,6 @@ public slots:
      * @param zoneName Zone to decrement from.
      */
     void decrementCard(const ExactCard &card, const QString &zoneName);
-
-    /** @brief Adds a card to the main deck or sideboard based on Ctrl key. */
-    void actAddCard(const ExactCard &card);
-
-    /** @brief Adds a card to the sideboard explicitly. */
-    void actAddCardToSideboard(const ExactCard &card);
-
-    /** @brief Decrements a card from the main deck. */
-    void actDecrementCard(const ExactCard &card);
-
-    /** @brief Decrements a card from the sideboard. */
-    void actDecrementCardFromSideboard(const ExactCard &card);
 
     /** @brief Opens a recently opened deck file. */
     void actOpenRecent(const QString &fileName);

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
@@ -168,22 +168,14 @@ void TabDeckEditorVisual::processMainboardCardClick(QMouseEvent *event,
 
     // Alt + Right-click = decrement
     if (event->button() == Qt::RightButton && event->modifiers().testFlag(Qt::AltModifier)) {
-        if (zoneName == DECK_ZONE_MAIN) {
-            actDecrementCard(card);
-        } else {
-            actDecrementCardFromSideboard(card);
-        }
+        decrementCard(card, zoneName);
         //  Keep selection intact.
         return;
     }
 
     // Alt + Left click = increment
     if (event->button() == Qt::LeftButton && event->modifiers().testFlag(Qt::AltModifier)) {
-        if (zoneName == DECK_ZONE_MAIN) {
-            actAddCard(card);
-        } else {
-            actAddCardToSideboard(card);
-        }
+        addCard(card, zoneName);
         //  Keep selection intact.
         return;
     }
@@ -224,12 +216,12 @@ void TabDeckEditorVisual::processCardClickDatabaseDisplay(QMouseEvent *event,
 {
     if (event->button() == Qt::LeftButton) {
         if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
-            actAddCardToSideboard(instance->getCard());
+            addCard(instance->getCard(), DECK_ZONE_SIDE);
         } else {
-            actAddCard(instance->getCard());
+            addCard(instance->getCard(), DECK_ZONE_MAIN);
         }
     } else if (event->button() == Qt::RightButton) {
-        actDecrementCard(instance->getCard());
+        decrementCard(instance->getCard(), DECK_ZONE_MAIN);
     } else if (event->button() == Qt::MiddleButton) {
         deckDockWidget->actRemoveCard();
     }

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.cpp
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.cpp
@@ -34,8 +34,8 @@ TabDeckEditorVisualTabWidget::TabDeckEditorVisualTabWidget(QWidget *parent,
             &TabDeckEditorVisualTabWidget::onCardChanged);
     connect(visualDeckView, &VisualDeckEditorWidget::cardClicked, this,
             &TabDeckEditorVisualTabWidget::onCardClickedDeckEditor);
-    connect(visualDeckView, &VisualDeckEditorWidget::cardAdditionRequested, deckEditor,
-            &AbstractTabDeckEditor::actAddCard);
+    connect(visualDeckView, &VisualDeckEditorWidget::cardAdditionRequested, this,
+            &TabDeckEditorVisualTabWidget::actAddCard);
 
     visualDatabaseDisplay =
         new VisualDatabaseDisplayWidget(this, deckEditor, _cardDatabaseModel, _cardDatabaseDisplayModel);
@@ -165,4 +165,16 @@ void TabDeckEditorVisualTabWidget::handleTabClose(int index)
     QWidget *tab = this->widget(index);
     this->removeTab(index);
     delete tab;
+}
+
+void TabDeckEditorVisualTabWidget::actAddCard(const ExactCard &card)
+{
+    QString zoneName;
+    if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
+        zoneName = DECK_ZONE_SIDE;
+    } else {
+        zoneName = DECK_ZONE_MAIN;
+    }
+
+    deckEditor->addCard(card, zoneName);
 }

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.h
@@ -132,6 +132,12 @@ private slots:
      * @param index Index of the tab to close.
      */
     void handleTabClose(int index);
+
+    /**
+     * @brief Adds card to maindeck or side depending on whether ctrl is held
+     * @param card
+     */
+    void actAddCard(const ExactCard &card);
 };
 
 #endif // TAB_DECK_EDITOR_VISUAL_TAB_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -97,9 +97,7 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
             &DeckEditorDatabaseDisplayWidget::copyDatabaseCellContents);
     connect(help, &QAction::triggered, this, [this] { createSearchSyntaxHelpWindow(searchEdit); });
 
-    connect(databaseDisplayWidget, &DeckEditorDatabaseDisplayWidget::addCardToMainDeck, this,
-            &VisualDatabaseDisplayWidget::highlightAllSearchEdit);
-    connect(databaseDisplayWidget, &DeckEditorDatabaseDisplayWidget::addCardToSideboard, this,
+    connect(databaseDisplayWidget, &DeckEditorDatabaseDisplayWidget::cardAdded, this,
             &VisualDatabaseDisplayWidget::highlightAllSearchEdit);
 
     databaseView = databaseDisplayWidget->getDatabaseView();


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6956
- Follow-up to #6939

## Short roundup of the initial problem

The signal/slot wiring becomes much nicer once we get rid of the individual methods for add/decremet card from main/side and just have everything take the zone as a param.

## What will change with this Pull Request?

- Remove the `actXXXCard` methods from `AbstractTabDeckEditor` entirely
  - Replace them with directly calling the `addCard` and `decrementCard` methods with the zoneName as a param.
- Clean up and consolidate signals of classes that connected to the removed slots.
- Fix regression introduced in #6956 that broke ctrl in the vde quick add widget