### PR TITLE
[TabDeckEditor] Refactor: pass ExactCard in signal instead of widget

### DIFF
--- a/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
@@ -58,16 +58,6 @@ void CardGroupDisplayWidget::mousePressEvent(QMouseEvent *event)
     }
 }
 
-void CardGroupDisplayWidget::onClick(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *card)
-{
-    emit cardClicked(event, card);
-}
-
-void CardGroupDisplayWidget::onHover(const ExactCard &card)
-{
-    emit cardHovered(card);
-}
-
 void CardGroupDisplayWidget::onSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected)
 {
     auto proxyModel = qobject_cast<QAbstractProxyModel *>(selectionModel->model());
@@ -154,8 +144,8 @@ QWidget *CardGroupDisplayWidget::constructWidgetForIndex(QPersistentModelIndex i
     widget->setScaleFactor(cardSizeWidget->getSlider()->value());
     widget->setCard(CardDatabaseManager::query()->getCard({cardName, cardProviderId}));
 
-    connect(widget, &CardInfoPictureWithTextOverlayWidget::imageClicked, this, &CardGroupDisplayWidget::onClick);
-    connect(widget, &CardInfoPictureWithTextOverlayWidget::hoveredOnCard, this, &CardGroupDisplayWidget::onHover);
+    connect(widget, &CardInfoPictureWithTextOverlayWidget::cardClicked, this, &CardGroupDisplayWidget::cardClicked);
+    connect(widget, &CardInfoPictureWithTextOverlayWidget::hoveredOnCard, this, &CardGroupDisplayWidget::cardHovered);
     connect(cardSizeWidget->getSlider(), &QSlider::valueChanged, widget, &CardInfoPictureWidget::setScaleFactor);
 
     indexToWidgetMap[index].append(widget);

--- a/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.h
@@ -48,8 +48,6 @@ public:
 
 public slots:
     void mousePressEvent(QMouseEvent *event) override;
-    void onClick(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *card);
-    void onHover(const ExactCard &card);
     virtual QWidget *constructWidgetForIndex(QPersistentModelIndex index);
     virtual void updateCardDisplays();
     virtual void onCardAddition(const QModelIndex &parent, int first, int last);
@@ -59,7 +57,7 @@ public slots:
     void resizeEvent(QResizeEvent *event) override;
 
 signals:
-    void cardClicked(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *card);
+    void cardClicked(QMouseEvent *event, const ExactCard &card);
     void cardHovered(const ExactCard &card);
     void cleanupRequested(CardGroupDisplayWidget *cardGroupDisplayWidget);
 

--- a/cockatrice/src/interface/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_widget.cpp
@@ -345,7 +345,7 @@ void CardInfoPictureWidget::mousePressEvent(QMouseEvent *event)
         createRightClickMenu()->popup(QCursor::pos());
     }
 
-    emit cardClicked(event);
+    emit cardClicked(event, exactCard);
 }
 
 void CardInfoPictureWidget::hideEvent(QHideEvent *event)

--- a/cockatrice/src/interface/widgets/cards/card_info_picture_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_widget.h
@@ -43,7 +43,7 @@ signals:
     void hoveredOnCard(const ExactCard &hoveredCard);
     void cardScaleFactorChanged(int _scale);
     void cardChanged(const ExactCard &card);
-    void cardClicked(QMouseEvent *event);
+    void cardClicked(QMouseEvent *event, const ExactCard &card);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;

--- a/cockatrice/src/interface/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
@@ -93,7 +93,7 @@ void CardInfoPictureWithTextOverlayWidget::setHighlighted(bool _highlighted)
 
 void CardInfoPictureWithTextOverlayWidget::mousePressEvent(QMouseEvent *event)
 {
-    emit imageClicked(event, this);
+    emit cardClicked(event, getCard());
 }
 
 /**

--- a/cockatrice/src/interface/widgets/cards/card_info_picture_with_text_overlay_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_with_text_overlay_widget.h
@@ -35,8 +35,6 @@ public:
     void setHighlighted(bool _highlighted);
 
     [[nodiscard]] QSize sizeHint() const override;
-signals:
-    void imageClicked(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance);
 
 protected:
     void paintEvent(QPaintEvent *event) override;

--- a/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.cpp
@@ -51,7 +51,7 @@ DeckCardZoneDisplayWidget::DeckCardZoneDisplayWidget(QWidget *parent,
 //                                                    User Interaction
 // =====================================================================================================================
 
-void DeckCardZoneDisplayWidget::onClick(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *card)
+void DeckCardZoneDisplayWidget::onClick(QMouseEvent *event, const ExactCard &card)
 {
     emit cardClicked(event, card, zoneName);
 }

--- a/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.h
+++ b/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.h
@@ -42,7 +42,7 @@ public:
     void addCardsToOverlapWidget();
 
 public slots:
-    void onClick(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *card);
+    void onClick(QMouseEvent *event, const ExactCard &card);
     void onHover(const ExactCard &card);
     void cleanupInvalidCardGroup(CardGroupDisplayWidget *displayWidget);
     void constructAppropriateWidget(QPersistentModelIndex index);
@@ -55,7 +55,7 @@ public slots:
     void onCategoryRemoval(const QModelIndex &parent, int first, int last);
 
 signals:
-    void cardClicked(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *card, QString zoneName);
+    void cardClicked(QMouseEvent *event, const ExactCard &card, const QString &zoneName);
     void cardHovered(const ExactCard &card);
     void activeSortCriteriaChanged(QStringList activeSortCriteria);
     void requestCleanup(DeckCardZoneDisplayWidget *displayWidget);

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
@@ -74,7 +74,7 @@ void TabDeckEditorVisual::createCentralFrame()
     connect(tabContainer, &TabDeckEditorVisualTabWidget::cardClicked, this,
             &TabDeckEditorVisual::processMainboardCardClick);
     connect(tabContainer, &TabDeckEditorVisualTabWidget::cardClickedDatabaseDisplay, this,
-            &TabDeckEditorVisual::processCardClickDatabaseDisplay);
+            &TabDeckEditorVisual::processDatabaseCardClick);
 
     centralFrame->addWidget(tabContainer);
     setCentralWidget(centralWidget);
@@ -143,12 +143,10 @@ void TabDeckEditorVisual::changeModelIndexToCard(const ExactCard &activeCard)
     }
 }
 
-void TabDeckEditorVisual::processMainboardCardClick(QMouseEvent *event,
-                                                    CardInfoPictureWithTextOverlayWidget *instance,
+void TabDeckEditorVisual::processMainboardCardClick(const QMouseEvent *event,
+                                                    const ExactCard &card,
                                                     const QString &zoneName)
 {
-    auto card = instance->getCard();
-
     // Get the model index for the card
     QModelIndex idx = deckStateManager->getModel()->findCard(card.getName(), zoneName);
     if (!idx.isValid()) {
@@ -211,17 +209,16 @@ void TabDeckEditorVisual::processMainboardCardClick(QMouseEvent *event,
 }
 
 /** @brief Handles clicks on cards in the database display. */
-void TabDeckEditorVisual::processCardClickDatabaseDisplay(QMouseEvent *event,
-                                                          CardInfoPictureWithTextOverlayWidget *instance)
+void TabDeckEditorVisual::processDatabaseCardClick(const QMouseEvent *event, const ExactCard &card)
 {
     if (event->button() == Qt::LeftButton) {
         if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
-            addCard(instance->getCard(), DECK_ZONE_SIDE);
+            addCard(card, DECK_ZONE_SIDE);
         } else {
-            addCard(instance->getCard(), DECK_ZONE_MAIN);
+            addCard(card, DECK_ZONE_MAIN);
         }
     } else if (event->button() == Qt::RightButton) {
-        decrementCard(instance->getCard(), DECK_ZONE_MAIN);
+        decrementCard(card, DECK_ZONE_MAIN);
     } else if (event->button() == Qt::MiddleButton) {
         deckDockWidget->actRemoveCard();
     }

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.h
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.h
@@ -41,7 +41,7 @@
  * - changeModelIndexAndCardInfo(const ExactCard &card) — Updates deck model selection and card info.
  * - changeModelIndexToCard(const ExactCard &card) — Selects the card in the deck view.
  * - processMainboardCardClick(QMouseEvent *event, ...) — Handles clicks on mainboard cards.
- * - processCardClickDatabaseDisplay(QMouseEvent *event, ...) — Handles clicks on database cards.
+ * - processDatabaseCardClick(QMouseEvent *event, ...) — Handles clicks on database cards.
  * - actSaveDeckAs() — Overrides save action with temporary UI adjustments.
  * - showPrintingSelector() — Opens the printing selector dock for the current card.
  * - freeDocksSize() — Frees constraints on dock widget sizes.

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.h
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.h
@@ -152,19 +152,17 @@ public slots:
     /**
      * @brief Handle card clicks in the mainboard visual deck.
      * @param event Mouse event triggering the action.
-     * @param instance Widget representing the clicked card.
+     * @param card The clicked card.
      * @param zoneName Deck zone of the card.
      */
-    void processMainboardCardClick(QMouseEvent *event,
-                                   CardInfoPictureWithTextOverlayWidget *instance,
-                                   const QString &zoneName);
+    void processMainboardCardClick(const QMouseEvent *event, const ExactCard &card, const QString &zoneName);
 
     /**
      * @brief Handle card clicks in the database visual display.
      * @param event Mouse event triggering the action.
-     * @param instance Widget representing the clicked card.
+     * @param card  The clicked card.
      */
-    void processCardClickDatabaseDisplay(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance);
+    void processDatabaseCardClick(const QMouseEvent *event, const ExactCard &card);
 
     /**
      * @brief Save the deck under a new name.

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.cpp
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.cpp
@@ -82,25 +82,24 @@ void TabDeckEditorVisualTabWidget::onCardChangedDatabaseDisplay(const ExactCard 
 /**
  * @brief Emits the cardClicked signal when a card is clicked in the visual deck view.
  * @param event The mouse event.
- * @param instance The widget instance of the clicked card.
+ * @param card The clicked card.
  * @param zoneName The zone of the deck where the card is located.
  */
 void TabDeckEditorVisualTabWidget::onCardClickedDeckEditor(QMouseEvent *event,
-                                                           CardInfoPictureWithTextOverlayWidget *instance,
-                                                           QString zoneName)
+                                                           const ExactCard &card,
+                                                           const QString &zoneName)
 {
-    emit cardClicked(event, instance, zoneName);
+    emit cardClicked(event, card, zoneName);
 }
 
 /**
  * @brief Emits the cardClickedDatabaseDisplay signal when a card is clicked in the database display.
  * @param event The mouse event.
- * @param instance The widget instance of the clicked card.
+ * @param card The clicked card.
  */
-void TabDeckEditorVisualTabWidget::onCardClickedDatabaseDisplay(QMouseEvent *event,
-                                                                CardInfoPictureWithTextOverlayWidget *instance)
+void TabDeckEditorVisualTabWidget::onCardClickedDatabaseDisplay(QMouseEvent *event, const ExactCard &card)
 {
-    emit cardClickedDatabaseDisplay(event, instance);
+    emit cardClickedDatabaseDisplay(event, card);
 }
 
 /**

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.h
@@ -101,23 +101,23 @@ public slots:
     /**
      * @brief Emitted when a card is clicked in the deck view.
      * @param event Mouse event.
-     * @param instance Widget representing the clicked card.
+     * @param card The clicked card.
      * @param zoneName Deck zone of the card.
      */
-    void onCardClickedDeckEditor(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance, QString zoneName);
+    void onCardClickedDeckEditor(QMouseEvent *event, const ExactCard &card, const QString &zoneName);
 
     /**
      * @brief Emitted when a card is clicked in the database display.
      * @param event Mouse event.
-     * @param instance Widget representing the clicked card.
+     * @param card The clicked card.
      */
-    void onCardClickedDatabaseDisplay(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance);
+    void onCardClickedDatabaseDisplay(QMouseEvent *event, const ExactCard &card);
 
 signals:
     void cardChanged(const ExactCard &activeCard);
     void cardChangedDatabaseDisplay(const ExactCard &activeCard);
-    void cardClicked(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance, QString zoneName);
-    void cardClickedDatabaseDisplay(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance);
+    void cardClicked(QMouseEvent *event, const ExactCard &card, const QString &zoneName);
+    void cardClickedDatabaseDisplay(QMouseEvent *event, const ExactCard &card);
 
 private:
     QVBoxLayout *layout;                                ///< Layout for tabs and controls.

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -214,9 +214,9 @@ void VisualDatabaseDisplayWidget::onDisplayModeChanged(bool checked)
     }
 }
 
-void VisualDatabaseDisplayWidget::onClick(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance)
+void VisualDatabaseDisplayWidget::onClick(QMouseEvent *event, const ExactCard &card)
 {
-    emit cardClickedDatabaseDisplay(event, instance);
+    emit cardClickedDatabaseDisplay(event, card);
 }
 
 void VisualDatabaseDisplayWidget::onHover(const ExactCard &hoveredCard)
@@ -231,7 +231,7 @@ void VisualDatabaseDisplayWidget::addCard(const ExactCard &cardToAdd)
     display->setScaleFactor(cardSizeWidget->getSlider()->value());
     display->setCard(cardToAdd);
     flowWidget->addWidget(display);
-    connect(display, &CardInfoPictureWithTextOverlayWidget::imageClicked, this, &VisualDatabaseDisplayWidget::onClick);
+    connect(display, &CardInfoPictureWithTextOverlayWidget::cardClicked, this, &VisualDatabaseDisplayWidget::onClick);
     connect(display, &CardInfoPictureWithTextOverlayWidget::hoveredOnCard, this, &VisualDatabaseDisplayWidget::onHover);
     connect(cardSizeWidget->getSlider(), &QSlider::valueChanged, display, &CardInfoPictureWidget::setScaleFactor);
 }

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
@@ -76,12 +76,12 @@ public slots:
     void onSearchModelChanged();
 
 signals:
-    void cardClickedDatabaseDisplay(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance);
+    void cardClickedDatabaseDisplay(QMouseEvent *event, const ExactCard &card);
     void cardHoveredDatabaseDisplay(const ExactCard &hoveredCard);
 
 protected slots:
     void initialize();
-    void onClick(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance);
+    void onClick(QMouseEvent *event, const ExactCard &card);
     void onHover(const ExactCard &hoveredCard);
     void addCard(const ExactCard &cardToAdd);
     void databaseDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -401,11 +401,6 @@ void VisualDeckEditorWidget::decklistDataChanged(QModelIndex topLeft, QModelInde
 //                                                 User Interaction
 // =====================================================================================================================
 
-void VisualDeckEditorWidget::onCardClick(QMouseEvent *event, const ExactCard &card, const QString &zoneName)
-{
-    emit cardClicked(event, card, zoneName);
-}
-
 void VisualDeckEditorWidget::onHover(const ExactCard &hoveredCard)
 {
     // If user has any card selected, ignore hover

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -281,7 +281,7 @@ void VisualDeckEditorWidget::constructZoneWidgetForIndex(QPersistentModelIndex p
         displayOptionsWidget->getActiveGroupCriteria(), displayOptionsWidget->getActiveSortCriteria(),
         displayOptionsWidget->getDisplayType(), 20, 10, cardSizeWidget);
     connect(zoneDisplayWidget, &DeckCardZoneDisplayWidget::cardHovered, this, &VisualDeckEditorWidget::onHover);
-    connect(zoneDisplayWidget, &DeckCardZoneDisplayWidget::cardClicked, this, &VisualDeckEditorWidget::onCardClick);
+    connect(zoneDisplayWidget, &DeckCardZoneDisplayWidget::cardClicked, this, &VisualDeckEditorWidget::cardClicked);
     connect(zoneDisplayWidget, &DeckCardZoneDisplayWidget::requestCleanup, this,
             &VisualDeckEditorWidget::cleanupInvalidZones);
     connect(this, &VisualDeckEditorWidget::activeSortCriteriaChanged, zoneDisplayWidget,
@@ -401,11 +401,9 @@ void VisualDeckEditorWidget::decklistDataChanged(QModelIndex topLeft, QModelInde
 //                                                 User Interaction
 // =====================================================================================================================
 
-void VisualDeckEditorWidget::onCardClick(QMouseEvent *event,
-                                         CardInfoPictureWithTextOverlayWidget *instance,
-                                         QString zoneName)
+void VisualDeckEditorWidget::onCardClick(QMouseEvent *event, const ExactCard &card, const QString &zoneName)
 {
-    emit cardClicked(event, instance, zoneName);
+    emit cardClicked(event, card, zoneName);
 }
 
 void VisualDeckEditorWidget::onHover(const ExactCard &hoveredCard)

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.h
@@ -82,7 +82,6 @@ protected:
 
 protected slots:
     void onHover(const ExactCard &hoveredCard);
-    void onCardClick(QMouseEvent *event, const ExactCard &card, const QString &zoneName);
     void decklistModelReset();
     void resizeEvent(QResizeEvent *event) override;
 

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.h
@@ -69,7 +69,7 @@ signals:
     void activeCardChanged(const ExactCard &activeCard);
     void activeGroupCriteriaChanged(QString activeGroupCriteria);
     void activeSortCriteriaChanged(QStringList activeSortCriteria);
-    void cardClicked(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance, QString zoneName);
+    void cardClicked(QMouseEvent *event, const ExactCard &card, const QString &zoneName);
     void cardAdditionRequested(const ExactCard &card);
     void displayTypeChanged(DisplayType displayType);
 
@@ -82,7 +82,7 @@ protected:
 
 protected slots:
     void onHover(const ExactCard &hoveredCard);
-    void onCardClick(QMouseEvent *event, CardInfoPictureWithTextOverlayWidget *instance, QString zoneName);
+    void onCardClick(QMouseEvent *event, const ExactCard &card, const QString &zoneName);
     void decklistModelReset();
     void resizeEvent(QResizeEvent *event) override;
 


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6961

## Short roundup of the initial problem

The code that relays the card click event from the card database to the vde passes the entire deck info widget in the signal, only extracting the ExactCard at the end. It would make more sense and be cleaner if we extracted the ExactCard from the start and just passed that in the signal.

## What will change with this Pull Request?
- Change the card click signal/slots along the entire chain to pass `ExactCard` instead of `CardInfoPictureWithTextOverlayWidget`
- Changed `CardInfoPictureWidget::cardClicked`'s signature to also have the `ExactCard`
  - Changed the subclass `CardInfoPictureWithTextOverlayWidget` to just use that signal instead of its own onClick signal.
- Some of the signatures weren't passing zoneNames as const ref, so fixed it while I was at it.