### PR TITLE
[TabDeckEditor] Refactor: Remove cardDatabase field from analysis interfaces

### DIFF
--- a/cockatrice/src/client/network/interfaces/deck_stats_interface.cpp
+++ b/cockatrice/src/client/network/interfaces/deck_stats_interface.cpp
@@ -6,12 +6,12 @@
 #include <QNetworkRequest>
 #include <QRegularExpression>
 #include <QUrlQuery>
+#include <libcockatrice/card/database/card_database_manager.h>
 #include <libcockatrice/deck_list/deck_list.h>
 #include <libcockatrice/deck_list/tree/deck_list_card_node.h>
 #include <version_string.h>
 
-DeckStatsInterface::DeckStatsInterface(CardDatabase &_cardDatabase, QObject *parent)
-    : QObject(parent), cardDatabase(_cardDatabase)
+DeckStatsInterface::DeckStatsInterface(QObject *parent) : QObject(parent)
 {
     manager = new QNetworkAccessManager(this);
     connect(manager, &QNetworkAccessManager::finished, this, &DeckStatsInterface::queryFinished);
@@ -70,8 +70,8 @@ void DeckStatsInterface::analyzeDeck(const DeckList &deck)
 
 void DeckStatsInterface::copyDeckWithoutTokens(const DeckList &source, DeckList &destination)
 {
-    auto copyIfNotAToken = [this, &destination](const auto node, const auto card) {
-        CardInfoPtr dbCard = cardDatabase.query()->getCardInfo(card->getName());
+    auto copyIfNotAToken = [&destination](const auto node, const auto card) {
+        CardInfoPtr dbCard = CardDatabaseManager::query()->getCardInfo(card->getName());
         if (dbCard && !dbCard->getIsToken()) {
             DecklistCardNode *addedCard = destination.addCard(card->getName(), node->getName(), -1);
             addedCard->setNumber(card->getNumber());

--- a/cockatrice/src/client/network/interfaces/deck_stats_interface.h
+++ b/cockatrice/src/client/network/interfaces/deck_stats_interface.h
@@ -7,7 +7,6 @@
 #ifndef DECKSTATS_INTERFACE_H
 #define DECKSTATS_INTERFACE_H
 
-#include <libcockatrice/card/database/card_database.h>
 #include <libcockatrice/deck_list/deck_list.h>
 
 class QByteArray;

--- a/cockatrice/src/client/network/interfaces/deck_stats_interface.h
+++ b/cockatrice/src/client/network/interfaces/deck_stats_interface.h
@@ -21,8 +21,6 @@ class DeckStatsInterface : public QObject
 private:
     QNetworkAccessManager *manager;
 
-    CardDatabase &cardDatabase;
-
     /**
      * Deckstats doesn't recognize token cards, and instead tries to find the
      * closest non-token card instead. So we construct a new deck which has no
@@ -35,7 +33,7 @@ private slots:
     void getAnalyzeRequestData(const DeckList &deck, QByteArray &data);
 
 public:
-    explicit DeckStatsInterface(CardDatabase &_cardDatabase, QObject *parent = nullptr);
+    explicit DeckStatsInterface(QObject *parent = nullptr);
     void analyzeDeck(const DeckList &deck);
 };
 

--- a/cockatrice/src/client/network/interfaces/tapped_out_interface.cpp
+++ b/cockatrice/src/client/network/interfaces/tapped_out_interface.cpp
@@ -6,12 +6,12 @@
 #include <QNetworkRequest>
 #include <QRegularExpression>
 #include <QUrlQuery>
+#include <libcockatrice/card/database/card_database_manager.h>
 #include <libcockatrice/deck_list/deck_list.h>
 #include <libcockatrice/deck_list/tree/deck_list_card_node.h>
 #include <version_string.h>
 
-TappedOutInterface::TappedOutInterface(CardDatabase &_cardDatabase, QObject *parent)
-    : QObject(parent), cardDatabase(_cardDatabase)
+TappedOutInterface::TappedOutInterface(QObject *parent) : QObject(parent)
 {
     manager = new QNetworkAccessManager(this);
     connect(manager, &QNetworkAccessManager::finished, this, &TappedOutInterface::queryFinished);
@@ -97,8 +97,8 @@ void TappedOutInterface::analyzeDeck(const DeckList &deck)
 
 void TappedOutInterface::copyDeckSplitMainAndSide(const DeckList &source, DeckList &mainboard, DeckList &sideboard)
 {
-    auto copyMainOrSide = [this, &mainboard, &sideboard](const auto node, const auto card) {
-        CardInfoPtr dbCard = cardDatabase.query()->getCardInfo(card->getName());
+    auto copyMainOrSide = [&mainboard, &sideboard](const auto node, const auto card) {
+        CardInfoPtr dbCard = CardDatabaseManager::query()->getCardInfo(card->getName());
         if (!dbCard || dbCard->getIsToken()) {
             return;
         }

--- a/cockatrice/src/client/network/interfaces/tapped_out_interface.h
+++ b/cockatrice/src/client/network/interfaces/tapped_out_interface.h
@@ -29,14 +29,13 @@ class TappedOutInterface : public QObject
 private:
     QNetworkAccessManager *manager;
 
-    CardDatabase &cardDatabase;
     void copyDeckSplitMainAndSide(const DeckList &source, DeckList &mainboard, DeckList &sideboard);
 private slots:
     void queryFinished(QNetworkReply *reply);
     void getAnalyzeRequestData(const DeckList &deck, QByteArray &data);
 
 public:
-    explicit TappedOutInterface(CardDatabase &_cardDatabase, QObject *parent = nullptr);
+    explicit TappedOutInterface(QObject *parent = nullptr);
     void analyzeDeck(const DeckList &deck);
 };
 

--- a/cockatrice/src/client/network/interfaces/tapped_out_interface.h
+++ b/cockatrice/src/client/network/interfaces/tapped_out_interface.h
@@ -7,8 +7,8 @@
 #ifndef TAPPEDOUT_INTERFACE_H
 #define TAPPEDOUT_INTERFACE_H
 
-#include <libcockatrice/card/database/card_database.h>
-#include <libcockatrice/deck_list/deck_list.h>
+#include <QLoggingCategory>
+#include <QObject>
 
 inline Q_LOGGING_CATEGORY(TappedOutInterfaceLog, "tapped_out_interface");
 

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
@@ -538,14 +538,14 @@ void AbstractTabDeckEditor::actExportDeckDecklistXyz()
 /** @brief Analyzes the deck using DeckStats. */
 void AbstractTabDeckEditor::actAnalyzeDeckDeckstats()
 {
-    auto *interface = new DeckStatsInterface(*cardDatabaseDockWidget->getDatabase(), this);
+    auto *interface = new DeckStatsInterface(this);
     interface->analyzeDeck(deckStateManager->getDeckList());
 }
 
 /** @brief Analyzes the deck using TappedOut. */
 void AbstractTabDeckEditor::actAnalyzeDeckTappedout()
 {
-    auto *interface = new TappedOutInterface(*cardDatabaseDockWidget->getDatabase(), this);
+    auto *interface = new TappedOutInterface(this);
     interface->analyzeDeck(deckStateManager->getDeckList());
 }
 


### PR DESCRIPTION
## Short roundup of the initial problem

There's no reason for `DeckStatsInterface` and `TappedOutInterface` to hold the `CardDatabase` in a field, when we just directly query using the `CardDatabaseManager` everywhere else in the project.

## What will change with this Pull Request?
- Remove `cardDatabase` field from those classes and fix signatures
- Use `CardDatabaseManager::query()` in those classes instead 