### PR TITLE
[TabDeckEditor] Refactor to use signal instead of calling tab

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_card_database_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_card_database_dock_widget.cpp
@@ -33,6 +33,12 @@ void DeckEditorCardDatabaseDockWidget::createDatabaseDisplayDock(AbstractTabDeck
             &AbstractTabDeckEditor::addCard);
     connect(databaseDisplayWidget, &DeckEditorDatabaseDisplayWidget::cardDecremented, deckEditor,
             &AbstractTabDeckEditor::decrementCard);
+    connect(databaseDisplayWidget, &DeckEditorDatabaseDisplayWidget::edhrecRequested, deckEditor,
+            &AbstractTabDeckEditor::openEdhrecTab);
+    connect(databaseDisplayWidget, &DeckEditorDatabaseDisplayWidget::printingSelectorRequested, deckEditor,
+            &AbstractTabDeckEditor::showPrintingSelector);
+    connect(databaseDisplayWidget, &DeckEditorDatabaseDisplayWidget::cardInfoRequested, deckEditor,
+            &AbstractTabDeckEditor::updateCardInfo);
 }
 
 CardDatabase *DeckEditorCardDatabaseDockWidget::getDatabase() const

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
@@ -222,10 +222,11 @@ void DeckEditorDatabaseDisplayWidget::databaseCustomMenu(QPoint point)
         } else {
             for (const CardRelation *rel : relatedCards) {
                 const QString &relatedCardName = rel->getName();
-                ExactCard exactCard = CardDatabaseManager::query()->getPreferredCard(relatedCardName);
                 QAction *relatedCard = relatedMenu->addAction(relatedCardName);
-                connect(relatedCard, &QAction::triggered, this,
-                        [this, exactCard] { emit cardInfoRequested(exactCard); });
+                connect(relatedCard, &QAction::triggered, this, [this, relatedCardName] {
+                    ExactCard card = CardDatabaseManager::query()->guessCard({relatedCardName});
+                    emit cardInfoRequested(card);
+                });
             }
         }
         menu.exec(databaseView->mapToGlobal(point));

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
@@ -200,18 +200,18 @@ void DeckEditorDatabaseDisplayWidget::databaseCustomMenu(QPoint point)
         addToDeck = menu.addAction(tr("Add to Deck"));
         addToSideboard = menu.addAction(tr("Add to Sideboard"));
         selectPrinting = menu.addAction(tr("Select Printing"));
-        connect(selectPrinting, &QAction::triggered, this, [this, card] { deckEditor->showPrintingSelector(); });
+        connect(selectPrinting, &QAction::triggered, this, &DeckEditorDatabaseDisplayWidget::printingSelectorRequested);
         if (canBeCommander(card.getInfo())) {
             edhRecCommander = menu.addAction(tr("Show on EDHRec (Commander)"));
             connect(edhRecCommander, &QAction::triggered, this,
-                    [this, card] { deckEditor->getTabSupervisor()->addEdhrecTab(card.getCardPtr(), true); });
+                    [this, card] { emit edhrecRequested(card.getCardPtr(), true); });
         }
         edhRecCard = menu.addAction(tr("Show on EDHRec (Card)"));
 
         connect(addToDeck, &QAction::triggered, this, &DeckEditorDatabaseDisplayWidget::actAddCardToMainDeck);
         connect(addToSideboard, &QAction::triggered, this, &DeckEditorDatabaseDisplayWidget::actAddCardToSideboard);
         connect(edhRecCard, &QAction::triggered, this,
-                [this, card] { deckEditor->getTabSupervisor()->addEdhrecTab(card.getCardPtr()); });
+                [this, card] { emit edhrecRequested(card.getCardPtr(), false); });
 
         // filling out the related cards submenu
         auto *relatedMenu = new QMenu(tr("Show Related cards"));
@@ -222,10 +222,10 @@ void DeckEditorDatabaseDisplayWidget::databaseCustomMenu(QPoint point)
         } else {
             for (const CardRelation *rel : relatedCards) {
                 const QString &relatedCardName = rel->getName();
+                ExactCard exactCard = CardDatabaseManager::query()->getPreferredCard(relatedCardName);
                 QAction *relatedCard = relatedMenu->addAction(relatedCardName);
-                connect(
-                    relatedCard, &QAction::triggered, deckEditor->cardInfoDockWidget->cardInfo,
-                    [this, relatedCardName] { deckEditor->cardInfoDockWidget->cardInfo->setCard(relatedCardName); });
+                connect(relatedCard, &QAction::triggered, this,
+                        [this, exactCard] { emit cardInfoRequested(exactCard); });
             }
         }
         menu.exec(databaseView->mapToGlobal(point));

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.h
@@ -52,6 +52,10 @@ signals:
     void cardDecremented(const ExactCard &card, const QString &zoneName);
     void cardChanged(const ExactCard &_card);
 
+    void edhrecRequested(const CardInfoPtr &cardInfo, bool isCommander);
+    void printingSelectorRequested();
+    void cardInfoRequested(const ExactCard &cardName);
+
 private:
     KeySignals searchKeySignals;
     QTreeView *databaseView;

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.h
@@ -54,7 +54,7 @@ signals:
 
     void edhrecRequested(const CardInfoPtr &cardInfo, bool isCommander);
     void printingSelectorRequested();
-    void cardInfoRequested(const ExactCard &cardName);
+    void cardInfoRequested(const ExactCard &card);
 
 private:
     KeySignals searchKeySignals;

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
@@ -105,14 +105,15 @@ void AbstractTabDeckEditor::registerDockWidget(QMenu *_viewMenu, QDockWidget *wi
     dockToActions.insert(widget, {menu, aVisible, aFloating, defaultSize});
 }
 
-/**
- * @brief Updates the card info dock and printing selector.
- * @param card The card to display.
- */
 void AbstractTabDeckEditor::updateCard(const ExactCard &card)
 {
     cardInfoDockWidget->updateCard(card);
     printingSelectorDockWidget->printingSelector->setCard(card.getCardPtr());
+}
+
+void AbstractTabDeckEditor::updateCardInfo(const ExactCard &card)
+{
+    cardInfoDockWidget->updateCard(card);
 }
 
 /** @brief Placeholder: called when the deck changes. */
@@ -594,4 +595,9 @@ void AbstractTabDeckEditor::showPrintingSelector()
     printingSelectorDockWidget->printingSelector->setCard(cardInfoDockWidget->cardInfo->getCard().getCardPtr());
     printingSelectorDockWidget->printingSelector->updateDisplay();
     printingSelectorDockWidget->setVisible(true);
+}
+
+void AbstractTabDeckEditor::openEdhrecTab(const CardInfoPtr &info, bool isCommander)
+{
+    getTabSupervisor()->addEdhrecTab(info, isCommander);
 }

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
@@ -140,10 +140,17 @@ public slots:
     /** @brief Called when the deck is modified. */
     virtual void onDeckModified();
 
-    /** @brief Updates the card info panel.
-     *  @param card The card to display.
+    /**
+     * @brief Updates the card info dock and printing selector.
+     * @param card The card to display.
      */
     void updateCard(const ExactCard &card);
+
+    /**
+     * @brief Updates just the card info dock
+     * @param card The card to display
+     */
+    void updateCardInfo(const ExactCard &card);
 
     /**
      * @brief Adds a card to the given zone
@@ -174,6 +181,9 @@ public slots:
 
     /** @brief Shows the printing selector dock and updates it with the current card. */
     void showPrintingSelector();
+
+    /** @brief Opens the edhrec tab with the following values */
+    void openEdhrecTab(const CardInfoPtr &info, bool isCommander);
 
 signals:
     /** @brief Emitted when a deck should be opened in a new editor tab. */

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
@@ -182,7 +182,11 @@ public slots:
     /** @brief Shows the printing selector dock and updates it with the current card. */
     void showPrintingSelector();
 
-    /** @brief Opens the edhrec tab with the following values */
+    /**
+     * @brief Opens an EDHRec tab for the given card
+     * @param info The card
+     * @param isCommander The type of search
+     */
     void openEdhrecTab(const CardInfoPtr &info, bool isCommander);
 
 signals:


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #6961
- Follow-up to #6962

## Short roundup of the initial problem

I need to make `DeckEditorDatabaseDisplayWidget` use signals instead of directly calling the deck editor tab, in order to set up for the main refactor I'm planning

## What will change with this Pull Request?

- Add two more slot methods to `AbstractTabDeckEditor`
- Add signals to `DeckEditorDatabaseDisplayWidget`
  - Use those signals instead of directly calling the deckEditor tab