### PR TITLE
[Messages] Add option to ignore private messages from non-buddy users

### DIFF
--- a/cockatrice/src/client/settings/cache_settings.cpp
+++ b/cockatrice/src/client/settings/cache_settings.cpp
@@ -388,6 +388,7 @@ SettingsCache::SettingsCache()
 
     ignoreUnregisteredUsers = settings->value("chat/ignore_unregistered", false).toBool();
     ignoreUnregisteredUserMessages = settings->value("chat/ignore_unregistered_messages", false).toBool();
+    ignoreNonBuddyUserMessages = settings->value("chat/ignore_nonbuddy_messages", false).toBool();
 
     scaleCards = settings->value("cards/scaleCards", true).toBool();
     verticalCardOverlapPercent = settings->value("cards/verticalCardOverlapPercent", 33).toInt();
@@ -1115,6 +1116,12 @@ void SettingsCache::setIgnoreUnregisteredUserMessages(QT_STATE_CHANGED_T _ignore
 {
     ignoreUnregisteredUserMessages = static_cast<bool>(_ignoreUnregisteredUserMessages);
     settings->setValue("chat/ignore_unregistered_messages", ignoreUnregisteredUserMessages);
+}
+
+void SettingsCache::setIgnoreNonBuddyUserMessages(QT_STATE_CHANGED_T _ignoreNonBuddyUserMessages)
+{
+    ignoreNonBuddyUserMessages = static_cast<bool>(_ignoreNonBuddyUserMessages);
+    settings->setValue("chat/ignore_nonbuddy_messages", ignoreNonBuddyUserMessages);
 }
 
 void SettingsCache::setPixmapCacheSize(const int _pixmapCacheSize)

--- a/cockatrice/src/client/settings/cache_settings.h
+++ b/cockatrice/src/client/settings/cache_settings.h
@@ -183,6 +183,7 @@ signals:
     void soundThemeChanged();
     void ignoreUnregisteredUsersChanged();
     void ignoreUnregisteredUserMessagesChanged();
+    void ignoreNonBuddyUserMessagesChanged();
     void pixmapCacheSizeChanged(int newSizeInMBs);
     void networkCacheSizeChanged(int newSizeInMBs);
     void redirectCacheTtlChanged(int newTtl);
@@ -294,6 +295,7 @@ private:
     QString soundThemeName;
     bool ignoreUnregisteredUsers;
     bool ignoreUnregisteredUserMessages;
+    bool ignoreNonBuddyUserMessages;
     QString picUrl;
     QString picUrlFallback;
     QString clientID;
@@ -788,6 +790,10 @@ public:
     {
         return ignoreUnregisteredUserMessages;
     }
+    [[nodiscard]] bool getIgnoreNonBuddyUserMessages() const
+    {
+        return ignoreNonBuddyUserMessages;
+    }
     [[nodiscard]] int getPixmapCacheSize() const
     {
         return pixmapCacheSize;
@@ -1111,6 +1117,7 @@ public slots:
     void setSoundThemeName(const QString &_soundThemeName);
     void setIgnoreUnregisteredUsers(QT_STATE_CHANGED_T _ignoreUnregisteredUsers);
     void setIgnoreUnregisteredUserMessages(QT_STATE_CHANGED_T _ignoreUnregisteredUserMessages);
+    void setIgnoreNonBuddyUserMessages(QT_STATE_CHANGED_T _ignoreNonBuddyUserMessages);
     void setPixmapCacheSize(const int _pixmapCacheSize);
     void setCardImageCacheMethod(CardPictureLoaderCacheMethod::CacheMethod _cardImageCachingMethod);
     void setNetworkCacheSizeInMB(const int _networkCacheSize);

--- a/cockatrice/src/interface/widgets/settings_page/messages_settings_page.cpp
+++ b/cockatrice/src/interface/widgets/settings_page/messages_settings_page.cpp
@@ -22,10 +22,14 @@ MessagesSettingsPage::MessagesSettingsPage()
 
     ignoreUnregUsersMainChat.setChecked(SettingsCache::instance().getIgnoreUnregisteredUsers());
     ignoreUnregUserMessages.setChecked(SettingsCache::instance().getIgnoreUnregisteredUserMessages());
+    ignoreNonBuddyUserMessages.setChecked(SettingsCache::instance().getIgnoreNonBuddyUserMessages());
+
     connect(&ignoreUnregUsersMainChat, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setIgnoreUnregisteredUsers);
     connect(&ignoreUnregUserMessages, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setIgnoreUnregisteredUserMessages);
+    connect(&ignoreNonBuddyUserMessages, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setIgnoreNonBuddyUserMessages);
 
     invertMentionForeground.setChecked(SettingsCache::instance().getChatMentionForeground());
     connect(&invertMentionForeground, &QCheckBox::QT_STATE_CHANGED, this, &MessagesSettingsPage::updateTextColor);
@@ -62,9 +66,10 @@ MessagesSettingsPage::MessagesSettingsPage()
     chatGrid->addWidget(&ignoreUnregUsersMainChat, 2, 0);
     chatGrid->addWidget(&hexLabel, 1, 2);
     chatGrid->addWidget(&ignoreUnregUserMessages, 3, 0);
-    chatGrid->addWidget(&messagePopups, 4, 0);
-    chatGrid->addWidget(&mentionPopups, 5, 0);
-    chatGrid->addWidget(&roomHistory, 6, 0);
+    chatGrid->addWidget(&ignoreNonBuddyUserMessages, 4, 0);
+    chatGrid->addWidget(&messagePopups, 5, 0);
+    chatGrid->addWidget(&mentionPopups, 6, 0);
+    chatGrid->addWidget(&roomHistory, 7, 0);
     chatGroupBox = new QGroupBox;
     chatGroupBox->setLayout(chatGrid);
 
@@ -237,6 +242,7 @@ void MessagesSettingsPage::retranslateUi()
         QString("<a href='%1'>%2</a>").arg(WIKI_CUSTOM_SHORTCUTS).arg(tr("How to use in-game message macros")));
     ignoreUnregUsersMainChat.setText(tr("Ignore chat room messages sent by unregistered users"));
     ignoreUnregUserMessages.setText(tr("Ignore private messages sent by unregistered users"));
+    ignoreNonBuddyUserMessages.setText(tr("Ignore private messages sent by non-buddy users"));
     invertMentionForeground.setText(tr("Invert text color"));
     invertHighlightForeground.setText(tr("Invert text color"));
     messagePopups.setText(tr("Enable desktop notifications for private messages"));

--- a/cockatrice/src/interface/widgets/settings_page/messages_settings_page.h
+++ b/cockatrice/src/interface/widgets/settings_page/messages_settings_page.h
@@ -36,6 +36,7 @@ private:
     QCheckBox invertHighlightForeground;
     QCheckBox ignoreUnregUsersMainChat;
     QCheckBox ignoreUnregUserMessages;
+    QCheckBox ignoreNonBuddyUserMessages;
     QCheckBox messagePopups;
     QCheckBox mentionPopups;
     QCheckBox roomHistory;

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
@@ -1012,6 +1012,10 @@ void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)
         tab = messageTabs.value(QString::fromStdString(event.receiver_name()));
     }
     if (!tab) {
+        if (SettingsCache::instance().getIgnoreNonBuddyUserMessages() && !userListManager->isUserBuddy(senderName)) {
+            // When  he is not a buddy and the settings are set to block non friend messages
+            return;
+        }
         const ServerInfo_User *onlineUserInfo = userListManager->getOnlineUser(senderName);
         if (onlineUserInfo) {
             auto userLevel = UserLevelFlags(onlineUserInfo->user_level());

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
@@ -1012,16 +1012,18 @@ void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)
         tab = messageTabs.value(QString::fromStdString(event.receiver_name()));
     }
     if (!tab) {
-        if (SettingsCache::instance().getIgnoreNonBuddyUserMessages() && !userListManager->isUserBuddy(senderName)) {
-            // When  he is not a buddy and the settings are set to block non friend messages
-            return;
-        }
         const ServerInfo_User *onlineUserInfo = userListManager->getOnlineUser(senderName);
         if (onlineUserInfo) {
             auto userLevel = UserLevelFlags(onlineUserInfo->user_level());
             if (SettingsCache::instance().getIgnoreUnregisteredUserMessages() &&
                 !userLevel.testFlag(ServerInfo_User::IsRegistered)) {
                 // Flags are additive, so reg/mod/admin are all IsRegistered
+                return;
+            } else if (SettingsCache::instance().getIgnoreNonBuddyUserMessages() &&
+                       !userListManager->isUserBuddy(senderName) && !userLevel.testFlag(ServerInfo_User::IsModerator) &&
+                       !userLevel.testFlag(ServerInfo_User::IsAdmin)) {
+                // Ignore private messages from non-buddies
+                // Moderator/Admin messages are exempt to ensure warnings reach users
                 return;
             }
         }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6915

## Short roundup of the initial problem
Users currently have no way to block private messages from non-buddy users. There is an existing option to ignore messages from unregistered users, but no equivalent for non-buddies.

## What will change with this Pull Request?
- Add `ignoreNonBuddyUserMessages` setting following the existing `ignoreUnregisteredUserMessages` pattern
- Add a checkbox in Settings → Chat to toggle this option
- Filter non-buddy private messages in `TabSupervisor::processUserMessageEvent()`

## Files Changed
- `cockatrice/src/client/settings/cache_settings.h` — Add member variable, getter, setter, signal
- `cockatrice/src/client/settings/cache_settings.cpp` — Add setting initialization, persistence, setter implementation
- `cockatrice/src/interface/widgets/settings_page/messages_settings_page.h` — Add QCheckBox
- `cockatrice/src/interface/widgets/settings_page/messages_settings_page.cpp` — Add UI initialization, signal connection, layout, text
- `cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp` — Add filter logic in processUserMessageEvent

## Testing
- Compiled successfully with Qt 6.4.2
- GUI verified: checkbox appears correctly in Settings → Chat
- Functional test: with the option enabled, private messages from non-buddy users are ignored; with the option disabled, messages are received normally