### PR TITLE
[TabDeckEditor] Refactor: Create shared CardDatabaseModel for tab

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_card_database_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_card_database_dock_widget.cpp
@@ -13,7 +13,7 @@ DeckEditorCardDatabaseDockWidget::DeckEditorCardDatabaseDockWidget(AbstractTabDe
 
 void DeckEditorCardDatabaseDockWidget::createDatabaseDisplayDock(AbstractTabDeckEditor *deckEditor)
 {
-    databaseDisplayWidget = new DeckEditorDatabaseDisplayWidget(this, deckEditor);
+    databaseDisplayWidget = new DeckEditorDatabaseDisplayWidget(this, deckEditor->databaseModel);
 
     auto *frame = new QVBoxLayout;
     frame->setObjectName("databaseDisplayFrame");

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
@@ -21,8 +21,8 @@ static bool canBeCommander(const CardInfo &cardInfo)
            cardInfo.getText().contains("can be your commander", Qt::CaseInsensitive);
 }
 
-DeckEditorDatabaseDisplayWidget::DeckEditorDatabaseDisplayWidget(QWidget *parent, AbstractTabDeckEditor *deckEditor)
-    : QWidget(parent), deckEditor(deckEditor)
+DeckEditorDatabaseDisplayWidget::DeckEditorDatabaseDisplayWidget(QWidget *parent, CardDatabaseModel *databaseModel)
+    : QWidget(parent), databaseModel(databaseModel)
 {
     setObjectName("databaseDisplayWidget");
 
@@ -58,8 +58,6 @@ DeckEditorDatabaseDisplayWidget::DeckEditorDatabaseDisplayWidget(QWidget *parent
     connect(&searchKeySignals, &KeySignals::onCtrlC, this, &DeckEditorDatabaseDisplayWidget::copyDatabaseCellContents);
     connect(help, &QAction::triggered, this, [this] { createSearchSyntaxHelpWindow(searchEdit); });
 
-    databaseModel = new CardDatabaseModel(CardDatabaseManager::getInstance(), true, this);
-    databaseModel->setObjectName("databaseModel");
     databaseDisplayModel = new CardDatabaseDisplayModel(this);
     databaseDisplayModel->setObjectName("databaseDisplayModel");
     databaseDisplayModel->setSourceModel(databaseModel);

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.h
@@ -23,8 +23,7 @@ class DeckEditorDatabaseDisplayWidget : public QWidget
 
     Q_OBJECT
 public:
-    explicit DeckEditorDatabaseDisplayWidget(QWidget *parent, AbstractTabDeckEditor *deckEditor);
-    AbstractTabDeckEditor *deckEditor;
+    explicit DeckEditorDatabaseDisplayWidget(QWidget *parent, CardDatabaseModel *databaseModel);
     CardDatabaseModel *databaseModel;
     CardDatabaseDisplayModel *databaseDisplayModel;
 

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
@@ -56,6 +56,9 @@ AbstractTabDeckEditor::AbstractTabDeckEditor(TabSupervisor *_tabSupervisor) : Ta
 
     deckStateManager = new DeckStateManager(this);
 
+    databaseModel = new CardDatabaseModel(CardDatabaseManager::getInstance(), true, this);
+    databaseModel->setObjectName("databaseModel");
+
     cardDatabaseDockWidget = new DeckEditorCardDatabaseDockWidget(this);
     deckDockWidget = new DeckEditorDeckDockWidget(this);
     cardInfoDockWidget = new DeckEditorCardInfoDockWidget(this);

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
@@ -126,6 +126,7 @@ public:
 
     // UI Elements
     DeckStateManager *deckStateManager;
+    CardDatabaseModel *databaseModel;                                 ///< Card database
     DeckEditorMenu *deckMenu;                                         ///< Menu for deck operations
     DeckEditorCardDatabaseDockWidget *cardDatabaseDockWidget;         ///< Database dock
     DeckEditorCardInfoDockWidget *cardInfoDockWidget;                 ///< Card info dock


### PR DESCRIPTION
## Related Ticket(s)
- Split off from #6967

## Short roundup of the initial problem

We can move the `CardDatabaseModel` creation to `AbstractTabDeckEditor` so that we can share a single model for the entire tab.

## What will change with this Pull Request?

- Add a field for `CardDatabaseModel` to `AbstractTabDeckEditor` and create it in the constructor
- Change `DeckEditorDatabaseDisplayWidget` to take a `CardDatabaseModel` instead of creating one itself