### PR TITLE
[TabDeckEditor] Refactor: pass nullable deck model into filter widget

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.cpp
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.cpp
@@ -38,7 +38,7 @@ TabDeckEditorVisualTabWidget::TabDeckEditorVisualTabWidget(QWidget *parent,
             &TabDeckEditorVisualTabWidget::actAddCard);
 
     visualDatabaseDisplay =
-        new VisualDatabaseDisplayWidget(this, deckEditor, _cardDatabaseModel, _cardDatabaseDisplayModel);
+        new VisualDatabaseDisplayWidget(this, deckEditor, _cardDatabaseModel, _cardDatabaseDisplayModel, deckModel);
     visualDatabaseDisplay->setObjectName("visualDatabaseView");
     connect(visualDatabaseDisplay, &VisualDatabaseDisplayWidget::cardHoveredDatabaseDisplay, this,
             &TabDeckEditorVisualTabWidget::onCardChangedDatabaseDisplay);

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_filter_toolbar_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_filter_toolbar_widget.cpp
@@ -4,9 +4,10 @@
 
 #include <QGroupBox>
 
-VisualDatabaseDisplayFilterToolbarWidget::VisualDatabaseDisplayFilterToolbarWidget(VisualDatabaseDisplayWidget *_parent)
+VisualDatabaseDisplayFilterToolbarWidget::VisualDatabaseDisplayFilterToolbarWidget(VisualDatabaseDisplayWidget *_parent,
+                                                                                   DeckListModel *deckListModel)
     : FlowWidget(_parent, Qt::Horizontal, Qt::ScrollBarAlwaysOff, Qt::ScrollBarAlwaysOff),
-      visualDatabaseDisplay(_parent)
+      visualDatabaseDisplay(_parent), deckListModel(deckListModel)
 {
     connect(this, &VisualDatabaseDisplayFilterToolbarWidget::searchModelChanged, visualDatabaseDisplay,
             &VisualDatabaseDisplayWidget::onSearchModelChanged);
@@ -97,8 +98,7 @@ void VisualDatabaseDisplayFilterToolbarWidget::initialize()
     auto filterModel = visualDatabaseDisplay->getFilterModel();
 
     saveLoadWidget = new VisualDatabaseDisplayFilterSaveLoadWidget(this, filterModel);
-    nameFilterWidget =
-        new VisualDatabaseDisplayNameFilterWidget(this, visualDatabaseDisplay->getDeckEditor(), filterModel);
+    nameFilterWidget = new VisualDatabaseDisplayNameFilterWidget(this, filterModel, deckListModel);
     mainTypeFilterWidget = new VisualDatabaseDisplayMainTypeFilterWidget(this, filterModel);
     formatLegalityWidget = new VisualDatabaseDisplayFormatLegalityFilterWidget(this, filterModel);
     subTypeFilterWidget = new VisualDatabaseDisplaySubTypeFilterWidget(this, filterModel);

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_filter_toolbar_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_filter_toolbar_widget.h
@@ -18,12 +18,14 @@ signals:
     void searchModelChanged();
 
 public:
-    explicit VisualDatabaseDisplayFilterToolbarWidget(VisualDatabaseDisplayWidget *parent);
+    explicit VisualDatabaseDisplayFilterToolbarWidget(VisualDatabaseDisplayWidget *parent,
+                                                      DeckListModel *deckListModel = nullptr);
     void initialize();
     void retranslateUi();
 
 private:
     VisualDatabaseDisplayWidget *visualDatabaseDisplay;
+    DeckListModel *deckListModel;
 
     QGroupBox *sortGroupBox;
     QLabel *sortByLabel;

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_name_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_name_filter_widget.cpp
@@ -8,9 +8,9 @@
 #include <QHBoxLayout>
 
 VisualDatabaseDisplayNameFilterWidget::VisualDatabaseDisplayNameFilterWidget(QWidget *parent,
-                                                                             AbstractTabDeckEditor *_deckEditor,
-                                                                             FilterTreeModel *_filterModel)
-    : QWidget(parent), deckEditor(_deckEditor), filterModel(_filterModel)
+                                                                             FilterTreeModel *_filterModel,
+                                                                             DeckListModel *deckListModel)
+    : QWidget(parent), filterModel(_filterModel), deckListModel(deckListModel)
 {
     setMinimumWidth(300);
     setMaximumHeight(300);
@@ -62,8 +62,6 @@ void VisualDatabaseDisplayNameFilterWidget::retranslateUi()
 
 void VisualDatabaseDisplayNameFilterWidget::actLoadFromDeck()
 {
-    DeckListModel *deckListModel = deckEditor->deckStateManager->getModel();
-
     if (!deckListModel) {
         return;
     }

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_name_filter_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_name_filter_widget.h
@@ -21,8 +21,8 @@ class VisualDatabaseDisplayNameFilterWidget : public QWidget
     Q_OBJECT
 public:
     explicit VisualDatabaseDisplayNameFilterWidget(QWidget *parent,
-                                                   AbstractTabDeckEditor *deckEditor,
-                                                   FilterTreeModel *filterModel);
+                                                   FilterTreeModel *filterModel,
+                                                   DeckListModel *deckListModel = nullptr);
 
     void createNameFilter(const QString &name);
     void removeNameFilter(const QString &name);
@@ -34,8 +34,8 @@ public slots:
     void retranslateUi();
 
 private:
-    AbstractTabDeckEditor *deckEditor;
     FilterTreeModel *filterModel;
+    DeckListModel *deckListModel;
     QVBoxLayout *layout;
     QLineEdit *searchBox;
     FlowWidget *flowWidget;

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -25,7 +25,8 @@
 VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
                                                          AbstractTabDeckEditor *_deckEditor,
                                                          CardDatabaseModel *database_model,
-                                                         CardDatabaseDisplayModel *database_display_model)
+                                                         CardDatabaseDisplayModel *database_display_model,
+                                                         DeckListModel *deckListModel)
     : QWidget(parent), deckEditor(_deckEditor), databaseModel(database_model),
       databaseDisplayModel(database_display_model)
 {
@@ -109,7 +110,7 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
 
     colorFilterWidget = new VisualDatabaseDisplayColorFilterWidget(this, filterModel);
 
-    filterContainer = new VisualDatabaseDisplayFilterToolbarWidget(this);
+    filterContainer = new VisualDatabaseDisplayFilterToolbarWidget(this, deckListModel);
 
     clearFilterWidget = new QToolButton();
     clearFilterWidget->setFixedSize(32, 32);

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
@@ -36,7 +36,8 @@ public:
     explicit VisualDatabaseDisplayWidget(QWidget *parent,
                                          AbstractTabDeckEditor *deckEditor,
                                          CardDatabaseModel *database_model,
-                                         CardDatabaseDisplayModel *database_display_model);
+                                         CardDatabaseDisplayModel *database_display_model,
+                                         DeckListModel *deckListModel = nullptr);
     void retranslateUi();
 
     void adjustCardsPerPage();
@@ -46,11 +47,6 @@ public:
     void loadCurrentPage();
     void sortCardList(const QStringList &properties, Qt::SortOrder order) const;
     void setDeckList(const DeckList &new_deck_list_model);
-
-    AbstractTabDeckEditor *getDeckEditor()
-    {
-        return deckEditor;
-    }
 
     CardDatabaseDisplayModel *getDatabaseDisplayModel()
     {


### PR DESCRIPTION
## Related Ticket(s)
- Split from #6967

## Short roundup of the initial problem

`VisualDatabaseDisplayNameFilterWidget` directly holds a pointer to and calls `AbstractTabDeckEditor` because it wants to access the current deck for one of its actions. However, `VisualDatabaseDisplayNameFilterWidget` is used both in the visual deck editor tab and the visual database tab.

Currently we trick it by always creating a deck editor tab, but that won't work after the big refactor.

## What will change with this Pull Request?

- Eventually pass a `DeckListModel` into `VisualDatabaseDisplayNameFilterWidget`, instead of a `AbstractTabDeckEditor`
  - the `DeckListModel` can be null (we null check before using it)
- Remove `VisualDatabaseDisplayWidget:: getDeckEditor`, since it's no longer used