### PR TITLE
[DeckEditor] Replace mainboard/sideboard with tokensboard for tokens (#6546)

### DIFF
--- a/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.cpp
@@ -255,10 +255,11 @@ bool DeckStateManager::swapCardAtIndex(const QModelIndex &idx)
     }
 
     QString zoneName = gparent.siblingAtColumn(DeckListModelColumns::CARD_NAME).data(Qt::EditRole).toString();
-    QString otherZoneName = zoneName == DECK_ZONE_TOKENS
-                                ? DECK_ZONE_TOKENS
-                                : (zoneName == DECK_ZONE_MAIN ? DECK_ZONE_SIDE : DECK_ZONE_MAIN);
-    // if card is Token,it should be swap to DECK_ZONE_TOKENS,not DECK_ZONE_MAIN or DECK_ZONE_SIDE.
+    // tokens have no swap target
+    if (zoneName == DECK_ZONE_TOKENS) {
+        return false;
+    }
+    QString otherZoneName = zoneName == DECK_ZONE_MAIN ? DECK_ZONE_SIDE : DECK_ZONE_MAIN;
 
     QString reason = tr("Moved to %1 1 × \"%2\" (%3)") //
                          .arg(otherZoneName)

--- a/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.cpp
@@ -255,7 +255,10 @@ bool DeckStateManager::swapCardAtIndex(const QModelIndex &idx)
     }
 
     QString zoneName = gparent.siblingAtColumn(DeckListModelColumns::CARD_NAME).data(Qt::EditRole).toString();
-    QString otherZoneName = zoneName == DECK_ZONE_MAIN ? DECK_ZONE_SIDE : DECK_ZONE_MAIN;
+    QString otherZoneName = zoneName == DECK_ZONE_TOKENS
+                                ? DECK_ZONE_TOKENS
+                                : (zoneName == DECK_ZONE_MAIN ? DECK_ZONE_SIDE : DECK_ZONE_MAIN);
+    // if card is Token,it should be swap to DECK_ZONE_TOKENS,not DECK_ZONE_MAIN or DECK_ZONE_SIDE.
 
     QString reason = tr("Moved to %1 1 × \"%2\" (%3)") //
                          .arg(otherZoneName)

--- a/cockatrice/src/interface/widgets/printing_selector/all_zones_card_amount_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/all_zones_card_amount_widget.cpp
@@ -31,15 +31,15 @@ AllZonesCardAmountWidget::AllZonesCardAmountWidget(QWidget *parent,
     buttonBoxMainboard = new CardAmountWidget(this, deckStateManager, cardSizeSlider, rootCard, DECK_ZONE_MAIN);
     zoneLabelSideboard = new ShadowBackgroundLabel(this, tr("Sideboard"));
     buttonBoxSideboard = new CardAmountWidget(this, deckStateManager, cardSizeSlider, rootCard, DECK_ZONE_SIDE);
-    zoneLabelTokensboard = new ShadowBackgroundLabel(this, tr("Tokensboard"));
+    zoneLabelTokensboard = new ShadowBackgroundLabel(this, tr("Tokens"));
     buttonBoxTokensboard = new CardAmountWidget(this, deckStateManager, cardSizeSlider, rootCard, DECK_ZONE_TOKENS);
 
     layout->addWidget(zoneLabelMainboard, 0, Qt::AlignHCenter | Qt::AlignBottom);
     layout->addWidget(buttonBoxMainboard, 0, Qt::AlignHCenter | Qt::AlignTop);
-    layout->addSpacing(12.5);
+    layout->addSpacing(12);
     layout->addWidget(zoneLabelTokensboard, 0, Qt::AlignHCenter | Qt::AlignBottom);
     layout->addWidget(buttonBoxTokensboard, 0, Qt::AlignHCenter | Qt::AlignTop);
-    layout->addSpacing(12.5);
+    layout->addSpacing(13);
     layout->addWidget(zoneLabelSideboard, 0, Qt::AlignHCenter | Qt::AlignBottom);
     layout->addWidget(buttonBoxSideboard, 0, Qt::AlignHCenter | Qt::AlignTop);
 

--- a/cockatrice/src/interface/widgets/printing_selector/all_zones_card_amount_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/all_zones_card_amount_widget.cpp
@@ -8,7 +8,7 @@
  * @brief Constructor for the AllZonesCardAmountWidget class.
  *
  * Initializes the widget with its layout and sets up the connections and necessary
- * UI elements for managing card counts in both the mainboard and sideboard zones.
+ * UI elements for managing card counts in all the mainboard, tokensboard and sideboard zones.
  *
  * @param parent The parent widget.
  * @param deckStateManager Pointer to the DeckStateManager
@@ -31,12 +31,27 @@ AllZonesCardAmountWidget::AllZonesCardAmountWidget(QWidget *parent,
     buttonBoxMainboard = new CardAmountWidget(this, deckStateManager, cardSizeSlider, rootCard, DECK_ZONE_MAIN);
     zoneLabelSideboard = new ShadowBackgroundLabel(this, tr("Sideboard"));
     buttonBoxSideboard = new CardAmountWidget(this, deckStateManager, cardSizeSlider, rootCard, DECK_ZONE_SIDE);
+    zoneLabelTokensboard = new ShadowBackgroundLabel(this, tr("Tokensboard"));
+    buttonBoxTokensboard = new CardAmountWidget(this, deckStateManager, cardSizeSlider, rootCard, DECK_ZONE_TOKENS);
 
     layout->addWidget(zoneLabelMainboard, 0, Qt::AlignHCenter | Qt::AlignBottom);
     layout->addWidget(buttonBoxMainboard, 0, Qt::AlignHCenter | Qt::AlignTop);
-    layout->addSpacing(25);
+    layout->addSpacing(12.5);
+    layout->addWidget(zoneLabelTokensboard, 0, Qt::AlignHCenter | Qt::AlignBottom);
+    layout->addWidget(buttonBoxTokensboard, 0, Qt::AlignHCenter | Qt::AlignTop);
+    layout->addSpacing(12.5);
     layout->addWidget(zoneLabelSideboard, 0, Qt::AlignHCenter | Qt::AlignBottom);
     layout->addWidget(buttonBoxSideboard, 0, Qt::AlignHCenter | Qt::AlignTop);
+
+    // Show Tokens buttons for token cards, Mainboard/Sideboard for non-token cards
+    bool isToken = rootCard.getInfo().getIsToken();
+
+    zoneLabelMainboard->setVisible(!isToken);
+    buttonBoxMainboard->setVisible(!isToken);
+    zoneLabelTokensboard->setVisible(isToken);
+    buttonBoxTokensboard->setVisible(isToken);
+    zoneLabelSideboard->setVisible(!isToken);
+    buttonBoxSideboard->setVisible(!isToken);
 
     connect(cardSizeSlider, &QSlider::valueChanged, this, &AllZonesCardAmountWidget::adjustFontSize);
 
@@ -67,15 +82,17 @@ void AllZonesCardAmountWidget::adjustFontSize(int scalePercentage)
     zoneLabelFont.setPointSize(newFontSize);
     zoneLabelMainboard->setFont(zoneLabelFont);
     zoneLabelSideboard->setFont(zoneLabelFont);
+    zoneLabelTokensboard->setFont(zoneLabelFont);
 
     // Repaint the widget (if necessary)
     repaint();
 }
 
-void AllZonesCardAmountWidget::setAmounts(int mainboardAmount, int sideboardAmount)
+void AllZonesCardAmountWidget::setAmounts(int mainboardAmount, int sideboardAmount, int tokensboardAmount)
 {
     buttonBoxMainboard->setAmount(mainboardAmount);
     buttonBoxSideboard->setAmount(sideboardAmount);
+    buttonBoxTokensboard->setAmount(tokensboardAmount);
 }
 
 /**
@@ -99,11 +116,21 @@ int AllZonesCardAmountWidget::getSideboardAmount()
 }
 
 /**
- * @brief Checks if the amount is at least one in either the mainboard or sideboard.
+ * @brief Gets the card count in the tokensboard zone.
+ *
+ * @return The number of cards in the tokensboard.
+ */
+int AllZonesCardAmountWidget::getTokensboardAmount()
+{
+    return buttonBoxTokensboard->getAmount();
+}
+
+/**
+ * @brief Checks if the amount is at least one in either the mainboard or sideboard or tokensboard.
  */
 bool AllZonesCardAmountWidget::isNonZero()
 {
-    return getMainboardAmount() > 0 || getSideboardAmount() > 0;
+    return getMainboardAmount() > 0 || getSideboardAmount() > 0 || getTokensboardAmount() > 0;
 }
 
 /**

--- a/cockatrice/src/interface/widgets/printing_selector/all_zones_card_amount_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/all_zones_card_amount_widget.h
@@ -23,6 +23,7 @@ public:
                                       const ExactCard &rootCard);
     int getMainboardAmount();
     int getSideboardAmount();
+    int getTokensboardAmount();
     bool isNonZero();
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
@@ -33,7 +34,7 @@ public:
 
 public slots:
     void adjustFontSize(int scalePercentage);
-    void setAmounts(int mainboardAmount, int sideboardAmount);
+    void setAmounts(int mainboardAmount, int sideboardAmount, int tokensboardAmount);
 
 private:
     QVBoxLayout *layout;
@@ -42,6 +43,8 @@ private:
     CardAmountWidget *buttonBoxMainboard;
     QLabel *zoneLabelSideboard;
     CardAmountWidget *buttonBoxSideboard;
+    QLabel *zoneLabelTokensboard;
+    CardAmountWidget *buttonBoxTokensboard;
 };
 
 #endif // ALL_ZONES_CARD_AMOUNT_WIDGET_H

--- a/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.cpp
@@ -11,7 +11,7 @@
  * @param parent The parent widget.
  * @param cardSizeSlider Pointer to the QSlider for adjusting font size.
  * @param rootCard The root card to manage within the widget.
- * @param zoneName The zone name (e.g., DECK_ZONE_MAIN or DECK_ZONE_SIDE).
+ * @param zoneName The zone name (e.g., DECK_ZONE_MAIN , DECK_ZONE_SIDE, or DECK_ZONE_TOKENS).
  */
 CardAmountWidget::CardAmountWidget(QWidget *parent,
                                    DeckStateManager *deckStateManager,
@@ -36,13 +36,16 @@ CardAmountWidget::CardAmountWidget(QWidget *parent,
     incrementButton->setFixedSize(parentWidget()->size().width() / 3, parentWidget()->size().height() / 9);
     decrementButton->setFixedSize(parentWidget()->size().width() / 3, parentWidget()->size().height() / 9);
 
-    // Set up connections based on the zone (Mainboard or Sideboard)
+    // Set up connections based on the zone (Mainboard, Sideboard, or Tokensboard)
     if (zoneName == DECK_ZONE_MAIN) {
         connect(incrementButton, &QPushButton::clicked, this, &CardAmountWidget::addPrintingMainboard);
         connect(decrementButton, &QPushButton::clicked, this, &CardAmountWidget::removePrintingMainboard);
     } else if (zoneName == DECK_ZONE_SIDE) {
         connect(incrementButton, &QPushButton::clicked, this, &CardAmountWidget::addPrintingSideboard);
         connect(decrementButton, &QPushButton::clicked, this, &CardAmountWidget::removePrintingSideboard);
+    } else if (zoneName == DECK_ZONE_TOKENS) {
+        connect(incrementButton, &QPushButton::clicked, this, &CardAmountWidget::addPrintingTokensboard);
+        connect(decrementButton, &QPushButton::clicked, this, &CardAmountWidget::removePrintingTokensboard);
     }
 
     cardCountInZone = new QLabel(QString::number(amount), this);
@@ -161,9 +164,9 @@ static QModelIndex addAndReplacePrintings(DeckListModel *model,
 }
 
 /**
- * @brief Adds a printing of the card to the specified zone (Mainboard or Sideboard).
+ * @brief Adds a printing of the card to the specified zone (Mainboard, Sideboard, or Tokensboard).
  *
- * @param zone The zone to add the card to (DECK_ZONE_MAIN or DECK_ZONE_SIDE).
+ * @param zone The zone to add the card to (DECK_ZONE_MAIN, DECK_ZONE_SIDE, or DECK_ZONE_TOKENS).
  */
 void CardAmountWidget::addPrinting(const QString &zone)
 {
@@ -183,14 +186,15 @@ void CardAmountWidget::addPrinting(const QString &zone)
         }
     }
 
-    QString reason = QString("Added %1 copies of '%2 (%3) %4' to %5 [ProviderID: %6]%7")
-                         .arg(1 + extraCopies)
-                         .arg(rootCard.getName())
-                         .arg(rootCard.getPrinting().getSet()->getShortName())
-                         .arg(rootCard.getPrinting().getProperty("num"))
-                         .arg(zone == DECK_ZONE_MAIN ? "mainboard" : "sideboard")
-                         .arg(rootCard.getPrinting().getUuid())
-                         .arg(replacingProviderless ? " (replaced providerless printings)" : "");
+    QString reason =
+        QString("Added %1 copies of '%2 (%3) %4' to %5 [ProviderID: %6]%7")
+            .arg(1 + extraCopies)
+            .arg(rootCard.getName())
+            .arg(rootCard.getPrinting().getSet()->getShortName())
+            .arg(rootCard.getPrinting().getProperty("num"))
+            .arg(zone == DECK_ZONE_MAIN ? "mainboard" : (zone == DECK_ZONE_SIDE ? "sideboard" : "tokensboard"))
+            .arg(rootCard.getPrinting().getUuid())
+            .arg(replacingProviderless ? " (replaced providerless printings)" : "");
 
     // Add the card and expand the list UI
     QModelIndex newCardIndex = deckStateManager->modifyDeck(reason, [&](auto model) {
@@ -219,6 +223,14 @@ void CardAmountWidget::addPrintingSideboard()
 }
 
 /**
+ * @brief Adds a printing to the tokens zone.
+ */
+void CardAmountWidget::addPrintingTokensboard()
+{
+    addPrinting(DECK_ZONE_TOKENS);
+}
+
+/**
  * @brief Removes a printing from the mainboard zone.
  */
 void CardAmountWidget::removePrintingMainboard()
@@ -235,18 +247,27 @@ void CardAmountWidget::removePrintingSideboard()
 }
 
 /**
+ * @brief Removes a printing from the tokens zone.
+ */
+void CardAmountWidget::removePrintingTokensboard()
+{
+    decrementCardHelper(DECK_ZONE_TOKENS);
+}
+
+/**
  * @brief Helper function to decrement the card count for a given zone.
  *
- * @param zone The zone from which to remove the card (DECK_ZONE_MAIN or DECK_ZONE_SIDE).
+ * @param zone The zone from which to remove the card (DECK_ZONE_MAIN, DECK_ZONE_SIDE, or DECK_ZONE_TOKENS).
  */
 void CardAmountWidget::decrementCardHelper(const QString &zone)
 {
-    QString reason = QString("Removed 1 copy of '%1 (%2) %3' from %4 [ProviderID: %5]")
-                         .arg(rootCard.getName())
-                         .arg(rootCard.getPrinting().getSet()->getShortName())
-                         .arg(rootCard.getPrinting().getProperty("num"))
-                         .arg(zone == DECK_ZONE_MAIN ? "mainboard" : "sideboard")
-                         .arg(rootCard.getPrinting().getUuid());
+    QString reason =
+        QString("Removed 1 copy of '%1 (%2) %3' from %4 [ProviderID: %5]")
+            .arg(rootCard.getName())
+            .arg(rootCard.getPrinting().getSet()->getShortName())
+            .arg(rootCard.getPrinting().getProperty("num"))
+            .arg(zone == DECK_ZONE_MAIN ? "mainboard" : (zone == DECK_ZONE_SIDE ? "sideboard" : "tokensboard"))
+            .arg(rootCard.getPrinting().getUuid());
 
     deckStateManager->modifyDeck(reason, [this, &zone](auto model) {
         QModelIndex idx = model->findCard(rootCard.getName(), zone, rootCard.getPrinting().getUuid(),

--- a/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.cpp
@@ -140,6 +140,19 @@ void CardAmountWidget::updateCardCount()
     layout->activate();
 }
 
+static QString zoneLogName(const QString &zone)
+{
+    if (zone == DECK_ZONE_MAIN) {
+        return "mainboard";
+    } else if (zone == DECK_ZONE_SIDE) {
+        return "sideboard";
+    } else if (zone == DECK_ZONE_TOKENS) {
+        return "tokens";
+    } else {
+        return "unknown";
+    }
+}
+
 static QModelIndex addAndReplacePrintings(DeckListModel *model,
                                           const QModelIndex &existing,
                                           const ExactCard &rootCard,
@@ -186,15 +199,15 @@ void CardAmountWidget::addPrinting(const QString &zone)
         }
     }
 
-    QString reason =
-        QString("Added %1 copies of '%2 (%3) %4' to %5 [ProviderID: %6]%7")
-            .arg(1 + extraCopies)
-            .arg(rootCard.getName())
-            .arg(rootCard.getPrinting().getSet()->getShortName())
-            .arg(rootCard.getPrinting().getProperty("num"))
-            .arg(zone == DECK_ZONE_MAIN ? "mainboard" : (zone == DECK_ZONE_SIDE ? "sideboard" : "tokensboard"))
-            .arg(rootCard.getPrinting().getUuid())
-            .arg(replacingProviderless ? " (replaced providerless printings)" : "");
+    QString zoneName = zoneLogName(zone);
+    QString reason = QString("Added %1 copies of '%2 (%3) %4' to %5 [ProviderID: %6]%7")
+                         .arg(1 + extraCopies)
+                         .arg(rootCard.getName())
+                         .arg(rootCard.getPrinting().getSet()->getShortName())
+                         .arg(rootCard.getPrinting().getProperty("num"))
+                         .arg(zoneName)
+                         .arg(rootCard.getPrinting().getUuid())
+                         .arg(replacingProviderless ? " (replaced providerless printings)" : "");
 
     // Add the card and expand the list UI
     QModelIndex newCardIndex = deckStateManager->modifyDeck(reason, [&](auto model) {
@@ -261,13 +274,13 @@ void CardAmountWidget::removePrintingTokensboard()
  */
 void CardAmountWidget::decrementCardHelper(const QString &zone)
 {
-    QString reason =
-        QString("Removed 1 copy of '%1 (%2) %3' from %4 [ProviderID: %5]")
-            .arg(rootCard.getName())
-            .arg(rootCard.getPrinting().getSet()->getShortName())
-            .arg(rootCard.getPrinting().getProperty("num"))
-            .arg(zone == DECK_ZONE_MAIN ? "mainboard" : (zone == DECK_ZONE_SIDE ? "sideboard" : "tokensboard"))
-            .arg(rootCard.getPrinting().getUuid());
+    QString zoneName = zoneLogName(zone);
+    QString reason = QString("Removed 1 copy of '%1 (%2) %3' from %4 [ProviderID: %5]")
+                         .arg(rootCard.getName())
+                         .arg(rootCard.getPrinting().getSet()->getShortName())
+                         .arg(rootCard.getPrinting().getProperty("num"))
+                         .arg(zoneName)
+                         .arg(rootCard.getPrinting().getUuid());
 
     deckStateManager->modifyDeck(reason, [this, &zone](auto model) {
         QModelIndex idx = model->findCard(rootCard.getName(), zone, rootCard.getPrinting().getUuid(),

--- a/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/card_amount_widget.h
@@ -60,8 +60,10 @@ private:
 private slots:
     void addPrintingMainboard();
     void addPrintingSideboard();
+    void addPrintingTokensboard();
     void removePrintingMainboard();
     void removePrintingSideboard();
+    void removePrintingTokensboard();
     void adjustFontSize(int scalePercentage);
 };
 

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector.cpp
@@ -105,23 +105,30 @@ void PrintingSelector::printingsInDeckChanged()
 }
 
 /**
- * @return A map of uuid to amounts (main, side).
+ * @return A map of uuid to amounts (main, side, tokens).
  */
-static QMap<QString, QPair<int, int>> tallyUuidCounts(const DeckListModel *model, const QString &cardName)
+static QMap<QString, std::tuple<int, int, int>> tallyUuidCounts(const DeckListModel *model, const QString &cardName)
 {
-    QMap<QString, QPair<int, int>> map;
+    QMap<QString, std::tuple<int, int, int>> map;
 
     auto mainNodes = model->getCardNodesForZone(DECK_ZONE_MAIN);
     for (auto &node : mainNodes) {
         if (node->getName() == cardName) {
-            map[node->getCardProviderId()].first += node->getNumber();
+            std::get<0>(map[node->getCardProviderId()]) += node->getNumber();
         }
     }
 
     auto sideNodes = model->getCardNodesForZone(DECK_ZONE_SIDE);
     for (auto &node : sideNodes) {
         if (node->getName() == cardName) {
-            map[node->getCardProviderId()].second += node->getNumber();
+            std::get<1>(map[node->getCardProviderId()]) += node->getNumber();
+        }
+    }
+
+    auto tokensNodes = model->getCardNodesForZone(DECK_ZONE_TOKENS);
+    for (auto &node : tokensNodes) {
+        if (node->getName() == cardName) {
+            std::get<2>(map[node->getCardProviderId()]) += node->getNumber();
         }
     }
 

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector.cpp
@@ -107,28 +107,28 @@ void PrintingSelector::printingsInDeckChanged()
 /**
  * @return A map of uuid to amounts (main, side, tokens).
  */
-static QMap<QString, std::tuple<int, int, int>> tallyUuidCounts(const DeckListModel *model, const QString &cardName)
+static QMap<QString, ZoneCounts> tallyUuidCounts(const DeckListModel *model, const QString &cardName)
 {
-    QMap<QString, std::tuple<int, int, int>> map;
+    QMap<QString, ZoneCounts> map;
 
     auto mainNodes = model->getCardNodesForZone(DECK_ZONE_MAIN);
     for (auto &node : mainNodes) {
         if (node->getName() == cardName) {
-            std::get<0>(map[node->getCardProviderId()]) += node->getNumber();
+            map[node->getCardProviderId()].mainboard += node->getNumber();
         }
     }
 
     auto sideNodes = model->getCardNodesForZone(DECK_ZONE_SIDE);
     for (auto &node : sideNodes) {
         if (node->getName() == cardName) {
-            std::get<1>(map[node->getCardProviderId()]) += node->getNumber();
+            map[node->getCardProviderId()].sideboard += node->getNumber();
         }
     }
 
     auto tokensNodes = model->getCardNodesForZone(DECK_ZONE_TOKENS);
     for (auto &node : tokensNodes) {
         if (node->getName() == cardName) {
-            std::get<2>(map[node->getCardProviderId()]) += node->getNumber();
+            map[node->getCardProviderId()].tokensboard += node->getNumber();
         }
     }
 

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector.h
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector.h
@@ -19,6 +19,7 @@
 #include <QWidget>
 #include <libcockatrice/card/card_info.h>
 #include <libcockatrice/models/deck_list/deck_list_model.h>
+#include <tuple>
 
 #define BATCH_SIZE 10
 
@@ -59,9 +60,9 @@ signals:
 
     /**
      * The amounts of the printings in the deck has changed
-     * @param uuidToAmounts Map of uuids to the amounts (maindeck, sideboard) in the deck
+     * @param uuidToAmounts Map of uuids to the amounts (maindeck, sideboard, tokensboard) in the deck
      */
-    void cardAmountsChanged(const QMap<QString, QPair<int, int>> &uuidToAmounts);
+    void cardAmountsChanged(const QMap<QString, std::tuple<int, int, int>> &uuidToAmounts);
 
 private:
     QVBoxLayout *layout;

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector.h
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector.h
@@ -19,9 +19,15 @@
 #include <QWidget>
 #include <libcockatrice/card/card_info.h>
 #include <libcockatrice/models/deck_list/deck_list_model.h>
-#include <tuple>
 
 #define BATCH_SIZE 10
+
+struct ZoneCounts
+{
+    int mainboard = 0;
+    int sideboard = 0;
+    int tokensboard = 0;
+};
 
 class DeckStateManager;
 class PrintingSelectorCardSearchWidget;
@@ -62,7 +68,7 @@ signals:
      * The amounts of the printings in the deck has changed
      * @param uuidToAmounts Map of uuids to the amounts (maindeck, sideboard, tokensboard) in the deck
      */
-    void cardAmountsChanged(const QMap<QString, std::tuple<int, int, int>> &uuidToAmounts);
+    void cardAmountsChanged(const QMap<QString, ZoneCounts> &uuidToAmounts);
 
 private:
     QVBoxLayout *layout;

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.cpp
@@ -67,10 +67,10 @@ void PrintingSelectorCardDisplayWidget::clampSetNameToPicture()
     update();
 }
 
-void PrintingSelectorCardDisplayWidget::updateCardAmounts(const QMap<QString, QPair<int, int>> &uuidToAmounts)
+void PrintingSelectorCardDisplayWidget::updateCardAmounts(const QMap<QString, std::tuple<int, int, int>> &uuidToAmounts)
 {
-    auto [main, side] = uuidToAmounts.value(rootCard.getPrinting().getUuid());
-    overlayWidget->updateCardAmounts(main, side);
+    auto [main, side, tokens] = uuidToAmounts.value(rootCard.getPrinting().getUuid());
+    overlayWidget->updateCardAmounts(main, side, tokens);
 }
 
 void PrintingSelectorCardDisplayWidget::resizeEvent(QResizeEvent *event)

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.cpp
@@ -67,10 +67,10 @@ void PrintingSelectorCardDisplayWidget::clampSetNameToPicture()
     update();
 }
 
-void PrintingSelectorCardDisplayWidget::updateCardAmounts(const QMap<QString, std::tuple<int, int, int>> &uuidToAmounts)
+void PrintingSelectorCardDisplayWidget::updateCardAmounts(const QMap<QString, ZoneCounts> &uuidToAmounts)
 {
-    auto [main, side, tokens] = uuidToAmounts.value(rootCard.getPrinting().getUuid());
-    overlayWidget->updateCardAmounts(main, side, tokens);
+    auto counts = uuidToAmounts.value(rootCard.getPrinting().getUuid());
+    overlayWidget->updateCardAmounts(counts.mainboard, counts.sideboard, counts.tokensboard);
 }
 
 void PrintingSelectorCardDisplayWidget::resizeEvent(QResizeEvent *event)

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.h
@@ -13,6 +13,7 @@
 
 #include <QWidget>
 #include <libcockatrice/models/deck_list/deck_list_model.h>
+#include <tuple>
 
 class PrintingSelectorCardDisplayWidget : public QWidget
 {
@@ -27,7 +28,7 @@ public:
 
 public slots:
     void clampSetNameToPicture();
-    void updateCardAmounts(const QMap<QString, QPair<int, int>> &uuidToAmounts);
+    void updateCardAmounts(const QMap<QString, std::tuple<int, int, int>> &uuidToAmounts);
 
     void resizeEvent(QResizeEvent *event) override;
 

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_display_widget.h
@@ -13,7 +13,6 @@
 
 #include <QWidget>
 #include <libcockatrice/models/deck_list/deck_list_model.h>
-#include <tuple>
 
 class PrintingSelectorCardDisplayWidget : public QWidget
 {
@@ -28,7 +27,7 @@ public:
 
 public slots:
     void clampSetNameToPicture();
-    void updateCardAmounts(const QMap<QString, std::tuple<int, int, int>> &uuidToAmounts);
+    void updateCardAmounts(const QMap<QString, ZoneCounts> &uuidToAmounts);
 
     void resizeEvent(QResizeEvent *event) override;
 

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
@@ -116,9 +116,11 @@ void PrintingSelectorCardOverlayWidget::enterEvent(QEvent *event)
     updateVisibility();
 }
 
-void PrintingSelectorCardOverlayWidget::updateCardAmounts(int mainboardAmount, int sideboardAmount)
+void PrintingSelectorCardOverlayWidget::updateCardAmounts(int mainboardAmount,
+                                                          int sideboardAmount,
+                                                          int tokensboardAmount)
 {
-    allZonesCardAmountWidget->setAmounts(mainboardAmount, sideboardAmount);
+    allZonesCardAmountWidget->setAmounts(mainboardAmount, sideboardAmount, tokensboardAmount);
     updateVisibility();
 }
 
@@ -173,8 +175,8 @@ void PrintingSelectorCardOverlayWidget::updatePinBadgeVisibility()
 /**
  * @brief Handles the mouse leave event when the cursor leaves the overlay widget area.
  *
- * When the cursor leaves the widget, the card amount widget is hidden if both the mainboard and sideboard
- * amounts are zero.
+ * When the cursor leaves the widget, the card amount widget is hidden if all of the mainboard, sideboard, and
+ * tokensboard amounts are zero.
  *
  * @param event The event triggered when the mouse leaves the widget.
  */

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.h
@@ -39,7 +39,7 @@ signals:
     void cardPreferenceChanged();
 
 public slots:
-    void updateCardAmounts(int mainboardAmount, int sideboardAmount);
+    void updateCardAmounts(int mainboardAmount, int sideboardAmount, int tokensboardAmount);
 
 private slots:
     void updateVisibility();


### PR DESCRIPTION
## Related Ticket(s)

- Fixes #6546

## Short roundup of the initial problem

Token cards in the printing selector show mainboard and sideboard +/- buttons, but tokens should only exist in the tokens zone per project design (see #6489, #6495). Additionally, tokens in the tokensboard zone would be incorrectly swapped to the mainboard on double-click in the visual deck editor.

## What will change with this Pull Request?

- Replace mainboard/sideboard +/- buttons with tokensboard +/- button for token cards in the printing selector
- Token cards show only a tokensboard label and +/- buttons; non-token cards show mainboard/sideboard as before
- `tallyUuidCounts` return type changed from `QMap<QString, QPair<int,int>>` to `QMap<QString, std::tuple<int,int,int>>` to include tokens zone counts
- Fix `swapCardAtIndex` to keep tokens in tokensboard instead of swapping them to mainboard on double-click
- Added `addPrintingTokensboard()` / `removePrintingTokensboard()` slots to `CardAmountWidget`

## Screenshots

Token printing selector

<img width="1904" height="1025" alt="6546-1" src="https://github.com/user-attachments/assets/89daa37e-6a53-422e-bd0a-32164f96362b" /> 

Non-token printing selector

<img width="1915" height="1023" alt="6546-2" src="https://github.com/user-attachments/assets/83db1ccf-9761-4e87-a623-8c4aab3308c5" />    

Classic editor tokens

<img width="1900" height="1014" alt="6546-3" src="https://github.com/user-attachments/assets/0caba67d-d5a6-44a9-831c-a38b25ed5b07" /> 
