### PR TITLE
do not save a const reference to the user data in the info dialog

### DIFF
--- a/cockatrice/src/interface/widgets/server/user/user_info_box.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_info_box.cpp
@@ -85,24 +85,15 @@ void UserInfoBox::retranslateUi()
     avatarButton.setText(tr("Change avatar"));
 }
 
-/**
- * Creates the default profile pic that is used when the user doesn't have a custom pic
- */
-static QPixmap createDefaultAvatar(int height, const ServerInfo_User &user)
-{
-    return UserLevelPixmapGenerator::generatePixmap(height, UserLevelFlags(user.user_level()), user.pawn_colors(),
-                                                    false, QString::fromStdString(user.privlevel()));
-}
-
 void UserInfoBox::updateInfo(const ServerInfo_User &user)
 {
-    currentUserInfo = &user;
-
-    const UserLevelFlags userLevel(user.user_level());
+    userLevel = UserLevelFlags(user.user_level());
+    pawnColors = user.pawn_colors();
+    privLevel = QString::fromStdString(user.privlevel());
 
     const std::string &bmp = user.avatar_bmp();
     if (!avatarPixmap.loadFromData((const uchar *)bmp.data(), static_cast<uint>(bmp.size()))) {
-        avatarPixmap = createDefaultAvatar(64, user);
+        avatarPixmap = UserLevelPixmapGenerator::generatePixmap(64, userLevel, pawnColors, false, privLevel);
         hasAvatar = false;
     } else {
         hasAvatar = true;
@@ -120,8 +111,7 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
         countryLabel3.setText("");
     }
 
-    userLevelIcon.setPixmap(UserLevelPixmapGenerator::generatePixmap(15, userLevel, user.pawn_colors(), false,
-                                                                     QString::fromStdString(user.privlevel())));
+    userLevelIcon.setPixmap(UserLevelPixmapGenerator::generatePixmap(15, userLevel, pawnColors, false, privLevel));
     QString userLevelText;
     if (userLevel.testFlag(ServerInfo_User::IsAdmin)) {
         userLevelText = tr("Administrator");
@@ -373,7 +363,7 @@ void UserInfoBox::processAvatarResponse(const Response &r)
             break;
         case Response::RespInternalError:
         default:
-            QMessageBox::critical(this, tr("Error"), tr("An error occured while trying to updater your avatar."));
+            QMessageBox::critical(this, tr("Error"), tr("An error occured while trying to update your avatar."));
             break;
     }
 }
@@ -385,7 +375,7 @@ void UserInfoBox::resizeEvent(QResizeEvent *event)
         resizedPixmap = avatarPixmap.scaled(avatarPic.size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
     } else {
         int height = qMin(avatarPic.size().width(), avatarPic.size().height());
-        resizedPixmap = createDefaultAvatar(height, *currentUserInfo);
+        resizedPixmap = UserLevelPixmapGenerator::generatePixmap(height, userLevel, pawnColors, false, privLevel);
     }
     avatarPic.setPixmap(resizedPixmap);
 

--- a/cockatrice/src/interface/widgets/server/user/user_info_box.h
+++ b/cockatrice/src/interface/widgets/server/user/user_info_box.h
@@ -11,8 +11,9 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QWidget>
+#include <libcockatrice/network/server/remote/user_level.h>
+#include <libcockatrice/utility/days_years_between.h>
 
-class ServerInfo_User;
 class AbstractClient;
 class Response;
 
@@ -27,20 +28,15 @@ private:
     QPushButton editButton, passwordButton, avatarButton;
     QPixmap avatarPixmap;
     bool hasAvatar;
-    const ServerInfo_User *currentUserInfo;
+    UserLevelFlags userLevel;
+    ServerInfo_User::PawnColorsOverride pawnColors;
+    QString privLevel;
 
     static QString getAgeString(int ageSeconds);
 
 public:
     UserInfoBox(AbstractClient *_client, bool editable, QWidget *parent = nullptr, Qt::WindowFlags flags = {});
     void retranslateUi();
-
-    inline static QPair<int, int> getDaysAndYearsBetween(const QDate &then, const QDate &now)
-    {
-        int years = now.addDays(1 - then.dayOfYear()).year() - then.year(); // there is no yearsTo
-        int days = then.addYears(years).daysTo(now);
-        return {days, years};
-    }
 private slots:
     void processResponse(const Response &r);
     void processEditResponse(const Response &r);

--- a/libcockatrice_utility/libcockatrice/utility/days_years_between.h
+++ b/libcockatrice_utility/libcockatrice/utility/days_years_between.h
@@ -1,0 +1,8 @@
+#include <QDateTime>
+
+inline static QPair<int, int> getDaysAndYearsBetween(const QDate &then, const QDate &now)
+{
+    int years = now.addDays(1 - then.dayOfYear()).year() - then.year(); // there is no yearsTo
+    int days = then.addYears(years).daysTo(now);
+    return {days, years};
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,7 +59,7 @@ endif()
 include_directories(${GTEST_INCLUDE_DIRS})
 target_link_libraries(dummy_test Threads::Threads ${GTEST_BOTH_LIBRARIES})
 target_link_libraries(expression_test libcockatrice_utility Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES})
-target_link_libraries(test_age_formatting Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES})
+target_link_libraries(test_age_formatting libcockatrice_utility Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES})
 target_link_libraries(
   password_hash_test libcockatrice_utility Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES}
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,7 +59,9 @@ endif()
 include_directories(${GTEST_INCLUDE_DIRS})
 target_link_libraries(dummy_test Threads::Threads ${GTEST_BOTH_LIBRARIES})
 target_link_libraries(expression_test libcockatrice_utility Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES})
-target_link_libraries(test_age_formatting libcockatrice_utility Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES})
+target_link_libraries(
+  test_age_formatting libcockatrice_utility Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES}
+)
 target_link_libraries(
   password_hash_test libcockatrice_utility Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES}
 )

--- a/tests/test_age_formatting.cpp
+++ b/tests/test_age_formatting.cpp
@@ -1,6 +1,5 @@
-#include "../cockatrice/src/interface/widgets/server/user/user_info_box.h"
-
 #include "gtest/gtest.h"
+#include <libcockatrice/utility/days_years_between.h>
 
 namespace
 {
@@ -8,31 +7,31 @@ using dayyear = QPair<int, int>;
 
 TEST(AgeFormatting, Zero)
 {
-    auto got = UserInfoBox::getDaysAndYearsBetween(QDate(2000, 1, 1), QDate(2000, 1, 1));
+    auto got = getDaysAndYearsBetween(QDate(2000, 1, 1), QDate(2000, 1, 1));
     ASSERT_EQ(got, dayyear(0, 0)) << "these are the same day";
 }
 
 TEST(AgeFormatting, LeapDay)
 {
-    auto got = UserInfoBox::getDaysAndYearsBetween(QDate(2000, 2, 28), QDate(2000, 3, 1));
+    auto got = getDaysAndYearsBetween(QDate(2000, 2, 28), QDate(2000, 3, 1));
     ASSERT_EQ(got, dayyear(2, 0)) << "there is a leap day in between these days";
 }
 
 TEST(AgeFormatting, LeapYear)
 {
-    auto got = UserInfoBox::getDaysAndYearsBetween(QDate(2000, 1, 1), QDate(2001, 1, 1));
+    auto got = getDaysAndYearsBetween(QDate(2000, 1, 1), QDate(2001, 1, 1));
     ASSERT_EQ(got, dayyear(0, 1)) << "there is a leap day in between these dates, but that's fine";
 }
 
 TEST(AgeFormatting, LeapDayWithYear)
 {
-    auto got = UserInfoBox::getDaysAndYearsBetween(QDate(2000, 2, 28), QDate(2001, 3, 1));
+    auto got = getDaysAndYearsBetween(QDate(2000, 2, 28), QDate(2001, 3, 1));
     ASSERT_EQ(got, dayyear(1, 1)) << "there is a leap day in between these days but not in the last year";
 }
 
 TEST(AgeFormatting, LeapDayThisYear)
 {
-    auto got = UserInfoBox::getDaysAndYearsBetween(QDate(2003, 2, 28), QDate(2004, 3, 1));
+    auto got = getDaysAndYearsBetween(QDate(2003, 2, 28), QDate(2004, 3, 1));
     ASSERT_EQ(got, dayyear(2, 1)) << "there is a leap day in between these days this year";
 }
 } // namespace


### PR DESCRIPTION
## Related Ticket(s)
- regression introduced in #5546

## Short roundup of the initial problem
when resizing the user info dialog of a user without profile picture, the client would crash

## What will change with this Pull Request?
- do not save the reference to the user data
- copy the fields needed to generate the pixmap instead, its a measly couple strings
- (notably don't copy the entire info which also includes the image, that'd be a bit wasteful)
- include the userlevel header
- fix the user age format test by moving the days and years between function to utils