### PR TITLE
CI: Print colored diff for lint check

### DIFF
--- a/.ci/lint_cpp.sh
+++ b/.ci/lint_cpp.sh
@@ -13,16 +13,8 @@ fi
 # Check formatting using format.sh
 echo "Checking your code using format.sh..."
 
-diff="$(./format.sh --diff --cmake --shell --print-version --branch origin/master)"
+./format.sh --color-diff --cmake --shell --print-version --branch origin/master
 err=$?
-
-sep="
-----------
-"
-used_version="${diff%%"$sep"*}"
-diff="${diff#*"$sep"}"
-changes_to_make="${diff%%"$sep"*}"
-files_to_edit="${diff#*"$sep"}"
 
 case $err in
   1)
@@ -36,18 +28,9 @@ case $err in
 ***  Then commit and push those changes to this branch. ***
 ***   Check our CONTRIBUTING.md file for more details.  ***
 ***                                                     ***
-***                    Thank you ❤️                      ***
+***                    Thank you ❤️                     ***
 ***                                                     ***
 ***********************************************************
-
-Used version:
-$used_version
-
-Affected files:
-$files_to_edit
-
-The following changes should be made:
-$changes_to_make
 
 Exiting...
 EOM
@@ -64,9 +47,6 @@ EOM
 ***                      Awesome 👍                     ***
 ***                                                     ***
 ***********************************************************
-
-Used version:
-$used_version
 
 Exiting...
 EOM

--- a/format.sh
+++ b/format.sh
@@ -107,7 +107,7 @@ OPTIONS:
 
     --shell
         Use shellcheck to lint shell files.
-		Not available in the default inline mode.
+        Not available in the default inline mode.
 
     -t, --test
         Do not edit files in place. Set exit code to 1 if changes are required.

--- a/format.sh
+++ b/format.sh
@@ -3,7 +3,7 @@
 # This script will run clang-format on all modified, non-3rd-party C++/Header files.
 # Optionally runs cmake-format on all modified cmake files.
 # Optionally runs shellcheck on all modified shell files.
-# Uses clang-format cmake-format git diff find shellcheck
+# Uses clang-format, cmake-format, git, diff, find and shellcheck
 # Never, ever, should this receive a path with a newline in it. Don't bother proofing it for that.
 
 set -o pipefail
@@ -103,11 +103,11 @@ OPTIONS:
         Do not check any source files for clang-format.
 
     --print-version
-        Print the version of clang-format being used before continuing.
+        Print the lint tool version being used before continuing.
 
     --shell
-        Use shellcheck to lint shell files. Not available in the default inline
-        mode.
+        Use shellcheck to lint shell files.
+		Not available in the default inline mode.
 
     -t, --test
         Do not edit files in place. Set exit code to 1 if changes are required.


### PR DESCRIPTION
## Short roundup of the initial problem
Diffs were not able to be colored in the CI logs because the script output was send into a variable.

## What will change with this Pull Request?
- Print output directly
  Output of format.sh script will be same than running locally, not the additionally processed version we used before, plus the "passed" or "failed" hints
- Use colored diff option