### PR TITLE
[Servatrice] Notify newly logged-in users of pending server shutdown

### DIFF
--- a/libcockatrice_network/libcockatrice/network/server/remote/server.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/server.h
@@ -90,6 +90,10 @@ public:
     {
         return QString();
     }
+    virtual SessionEvent *getLoginSessionEvent() const
+    {
+        return nullptr;
+    }
     virtual QString getRequiredFeatures() const
     {
         return QString();

--- a/libcockatrice_network/libcockatrice/network/server/remote/server_protocolhandler.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/server_protocolhandler.cpp
@@ -562,6 +562,11 @@ Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd
     event.set_message(server->getLoginMessage().toStdString());
     rc.enqueuePostResponseItem(ServerMessage::SESSION_EVENT, prepareSessionEvent(event));
 
+    SessionEvent *loginEvent = server->getLoginSessionEvent();
+    if (loginEvent) {
+        rc.enqueuePostResponseItem(ServerMessage::SESSION_EVENT, loginEvent);
+    }
+
     auto *re = new Response_Login;
     re->mutable_user_info()->CopyFrom(copyUserInfo(true));
 

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -673,8 +673,27 @@ void Servatrice::statusUpdate()
     }
 }
 
+SessionEvent *Servatrice::makeShutdownEvent() const
+{
+    Event_ServerShutdown event;
+    event.set_reason(shutdownReason.toStdString());
+    event.set_minutes(static_cast<google::protobuf::uint32>(shutdownMinutes));
+    return Server_ProtocolHandler::prepareSessionEvent(event);
+}
+
+SessionEvent *Servatrice::getLoginSessionEvent() const
+{
+    // Notify newly logged-in users of a pending server shutdown
+    QMutexLocker locker(&shutdownStateMutex);
+    if (shutdownTimer && shutdownMinutes > 0) {
+        return makeShutdownEvent();
+    }
+    return nullptr;
+}
+
 void Servatrice::scheduleShutdown(const QString &reason, int minutes)
 {
+    shutdownStateMutex.lock();
     shutdownReason = reason;
     shutdownMinutes = minutes;
     nextShutdownMessageMinutes = shutdownMinutes;
@@ -683,6 +702,7 @@ void Servatrice::scheduleShutdown(const QString &reason, int minutes)
         connect(shutdownTimer, SIGNAL(timeout()), this, SLOT(shutdownTimeout()));
         shutdownTimer->start(60000);
     }
+    shutdownStateMutex.unlock();
     shutdownTimeout();
 }
 
@@ -702,6 +722,7 @@ void Servatrice::incRxBytes(quint64 num)
 
 void Servatrice::shutdownTimeout()
 {
+    QMutexLocker locker(&shutdownStateMutex);
     // Show every time counter cut in half & every minute for last 5 minutes
     if (shutdownMinutes <= 5 || shutdownMinutes == nextShutdownMessageMinutes) {
         if (shutdownMinutes == nextShutdownMessageMinutes) {
@@ -710,10 +731,7 @@ void Servatrice::shutdownTimeout()
 
         SessionEvent *se;
         if (shutdownMinutes) {
-            Event_ServerShutdown event;
-            event.set_reason(shutdownReason.toStdString());
-            event.set_minutes(static_cast<google::protobuf::uint32>(shutdownMinutes));
-            se = Server_ProtocolHandler::prepareSessionEvent(event);
+            se = makeShutdownEvent();
         } else {
             Event_ConnectionClosed event;
             event.set_reason(Event_ConnectionClosed::SERVER_SHUTDOWN);

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -158,6 +158,7 @@ private:
     Servatrice_IslServer *islServer;
     mutable QMutex loginMessageMutex;
     QString loginMessage;
+    mutable QMutex shutdownStateMutex;
     QString dbPrefix;
     QMap<QString, bool> serverRequiredFeatureList;
     QString officialWarnings;
@@ -216,6 +217,8 @@ public:
         QMutexLocker locker(&loginMessageMutex);
         return loginMessage;
     }
+    SessionEvent *getLoginSessionEvent() const override;
+    SessionEvent *makeShutdownEvent() const;
     QString getRequiredFeatures() const override;
     QString getAuthenticationMethodString() const;
     QString getDBTypeString() const;


### PR DESCRIPTION
## Related Ticket(s)

- Fixes #6562

## Short roundup of the initial problem

When a server shutdown is scheduled, already connected users receive the shutdown notification via `shutdownTimeout()`. However, users who log in between two broadcast cycles do not receive the notification until the next scheduled broadcast, which can be up to 60 seconds later.

## What will change with this Pull Request?

- Added a `getLoginSessionEvent()` virtual hook to `Server` (similar to `getLoginMessage()`), allowing subclasses to provide session events to send after login
- `Servatrice` overrides this to return an `Event_ServerShutdown` when a shutdown is pending, so newly logged-in users are immediately notified
- `Server` base class returns `nullptr` by default, preserving existing behavior for other subclasses



## Screenshots

<img width="1910" height="1023" alt="6562-1" src="https://github.com/user-attachments/assets/50fac5e9-264f-4db6-aa3f-ffc76bd90137" />
<img width="1902" height="1025" alt="6562-2" src="https://github.com/user-attachments/assets/a2dbe237-6fff-4daa-a7f5-0af10c3b2380" />
