### PR TITLE
[ReplayManager] Refactor to send replayed events through signal

### DIFF
--- a/cockatrice/src/interface/widgets/replay/replay_manager.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_manager.cpp
@@ -98,8 +98,7 @@ ReplayManager::ReplayManager(TabGame *parent, GameReplay *_replay)
 
 void ReplayManager::replayNextEvent(EventProcessingOptions options)
 {
-    game->getGame()->getGameEventHandler()->processGameEventContainer(
-        replay->event_list(timelineWidget->getCurrentEvent()), nullptr, options);
+    emit eventReplayed(replay->event_list(timelineWidget->getCurrentEvent()), options);
 }
 
 void ReplayManager::replayFinished()

--- a/cockatrice/src/interface/widgets/replay/replay_manager.h
+++ b/cockatrice/src/interface/widgets/replay/replay_manager.h
@@ -27,6 +27,7 @@ public:
 
 signals:
     void requestChatAndPhaseReset();
+    void eventReplayed(const GameEventContainer &cont, EventProcessingOptions options);
 
 private:
     // Replay related members

--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -1169,6 +1169,11 @@ void TabGame::createReplayDock(GameReplay *replay)
                             QDockWidget::DockWidgetMovable);
     replayDock->setWidget(replayManager);
     replayDock->setFloating(false);
+
+    connect(replayManager, &ReplayManager::eventReplayed, game->getGameEventHandler(),
+            [this](auto event, auto options) {
+                game->getGameEventHandler()->processGameEventContainer(event, nullptr, options);
+            });
 }
 
 void TabGame::createDeckViewContainerWidget(bool bReplay)

--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -1171,7 +1171,7 @@ void TabGame::createReplayDock(GameReplay *replay)
     replayDock->setFloating(false);
 
     connect(replayManager, &ReplayManager::eventReplayed, game->getGameEventHandler(),
-            [this](auto event, auto options) {
+            [this](const auto &event, auto options) {
                 game->getGameEventHandler()->processGameEventContainer(event, nullptr, options);
             });
 }

--- a/cockatrice/src/interface/widgets/tabs/tab_game.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.h
@@ -180,7 +180,6 @@ public:
     void connectToGameEventHandler();
     void connectMessageLogToGameEventHandler();
     void connectPlayerListToGameEventHandler();
-
     TabGame(TabSupervisor *_tabSupervisor, GameReplay *replay);
     ~TabGame() override;
     void retranslateUi() override;

--- a/cockatrice/src/interface/widgets/tabs/tab_game.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.h
@@ -180,6 +180,7 @@ public:
     void connectToGameEventHandler();
     void connectMessageLogToGameEventHandler();
     void connectPlayerListToGameEventHandler();
+
     TabGame(TabSupervisor *_tabSupervisor, GameReplay *replay);
     ~TabGame() override;
     void retranslateUi() override;


### PR DESCRIPTION
## Short roundup of the initial problem

Right now the `ReplayManager` directly calls the `GameEventHander` to process the events.

It would be nicer to use signals for this.

## What will change with this Pull Request?

- Make `ReplayManager` emit `eventReplayed` signal
- connect that signal to the `GameEventHandler` inside of `TabGame`