### PR TITLE
[Game][Graphics][Player] Add named zone lookup-map to player graphics.

### DIFF
--- a/cockatrice/src/game_graphics/player/player_graphics_item.cpp
+++ b/cockatrice/src/game_graphics/player/player_graphics_item.cpp
@@ -59,6 +59,9 @@ PlayerGraphicsItem::PlayerGraphicsItem(PlayerLogic *_player) : player(_player)
 
     initializeZones();
 
+    connect(player, &PlayerLogic::addViewCustomZoneActionToCustomZoneMenu, this,
+            &PlayerGraphicsItem::onCustomZoneAdded);
+
     playerMenu->setMenusForGraphicItems();
 
     connect(tableZoneGraphicsItem, &TableZone::sizeChanged, this, &PlayerGraphicsItem::updateBoundingRect);
@@ -121,6 +124,19 @@ void PlayerGraphicsItem::initializeZones()
     connect(handZoneGraphicsItem->getLogic(), &HandZoneLogic::cardCountChanged, handCounter,
             &HandCounter::updateNumber);
     connect(handCounter, &HandCounter::showContextMenu, handZoneGraphicsItem, &HandZone::showContextMenu);
+
+    zoneGraphicsItems.insert(player->getDeckZone()->getName(), deckZoneGraphicsItem);
+    zoneGraphicsItems.insert(player->getGraveZone()->getName(), graveyardZoneGraphicsItem);
+    zoneGraphicsItems.insert(player->getRfgZone()->getName(), rfgZoneGraphicsItem);
+    zoneGraphicsItems.insert(player->getSideboardZone()->getName(), sideboardGraphicsItem);
+    zoneGraphicsItems.insert(player->getTableZone()->getName(), tableZoneGraphicsItem);
+    zoneGraphicsItems.insert(player->getStackZone()->getName(), stackZoneGraphicsItem);
+    zoneGraphicsItems.insert(player->getHandZone()->getName(), handZoneGraphicsItem);
+}
+
+void PlayerGraphicsItem::onCustomZoneAdded(QString customZoneName)
+{
+    zoneGraphicsItems.insert(customZoneName, nullptr); // Custom zone view goes here, if we ever implement it.
 }
 
 QRectF PlayerGraphicsItem::boundingRect() const

--- a/cockatrice/src/game_graphics/player/player_graphics_item.h
+++ b/cockatrice/src/game_graphics/player/player_graphics_item.h
@@ -77,6 +77,11 @@ public:
         return playerTarget;
     }
 
+    CardZone *getZoneGraphicsItem(const QString &name) const
+    {
+        return zoneGraphicsItems.value(name, nullptr);
+    }
+
     [[nodiscard]] PileZone *getDeckZoneGraphicsItem() const
     {
         return deckZoneGraphicsItem;
@@ -110,6 +115,7 @@ public:
 
 public slots:
     void onPlayerActiveChanged(bool _active);
+    void onCustomZoneAdded(QString customZoneName);
     void onCounterAdded(CounterState *state);
     void onCounterRemoved(int counterId);
     void rearrangeCounters();
@@ -128,6 +134,7 @@ private:
     PlayerArea *playerArea;
     PlayerTarget *playerTarget;
     QMap<int, AbstractCounter *> counterWidgets;
+    QMap<QString, CardZone *> zoneGraphicsItems;
     PileZone *deckZoneGraphicsItem;
     PileZone *sideboardGraphicsItem;
     PileZone *graveyardZoneGraphicsItem;


### PR DESCRIPTION
## Short roundup of the initial problem
PlayerLogic stores all the zone data in a generic map `QMap<QString, CardZoneLogic *> zones;`, whereas PlayerGraphicsItem stores them all in named member variables. This introduces a slight discrepancy between the logic and the graphics API because we can fetch an arbitrary zone from the logic but we stall at converting that logic into a view, which means that while we can fetch logic items from graphics representations, we can't do the inverse.

## What will change with this Pull Request?
- Add an equivalent `QMap<QString, CardZone *> zoneGraphicsItems;` to PlayerGraphicsItem
- populate with named member variables in initializeZones()
- Existing named member variables remain untouched, no callsites updated
- Expose a getter for zones by name

This change pretty much just adds a map and registers all the existing zones in it. It's purely additive. We should, eventually, think about yeeting off the named member variables and just fetching from the map in all the callsites where required, but this change is small and effective for solving a problem I have in the ongoing refactor.
