### PR TITLE
CI: Use Visual Studio 2026

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -331,7 +331,7 @@ jobs:
             target: 10
             runner: windows-2025
             
-            cmake_generator: "Visual Studio 17 2022"
+            cmake_generator: "Visual Studio 18 2026"
             cmake_generator_platform: x64
             make_package: 1
             package_suffix: "-Win10"


### PR DESCRIPTION
## Short roundup of the initial problem
CI is failing for windows as VS can not be found. 
GH runner images did update and use newer version: https://github.com/actions/runner-images/issues/14017

## What will change with this Pull Request?
- use VS 18 2026
