### PR TITLE
[UserContextMenu] Add confirmation dialog before kicking a player (#6689)

### DIFF
--- a/cockatrice/src/interface/widgets/server/user/user_context_menu.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_context_menu.cpp
@@ -476,10 +476,15 @@ void UserContextMenu::showContextMenu(const QPoint &pos,
 
         client->sendCommand(client->prepareSessionCommand(cmd));
     } else if (actionClicked == aKick) {
-        Command_KickFromGame cmd;
-        cmd.set_player_id(playerId);
+        auto result = QMessageBox::question(static_cast<QWidget *>(parent()), tr("Kick Player"),
+                                            tr("Are you sure you want to kick this player from the game?"),
+                                            QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+        if (result == QMessageBox::Yes) {
+            Command_KickFromGame cmd;
+            cmd.set_player_id(playerId);
 
-        game->getGameEventHandler()->sendGameCommand(cmd);
+            game->getGameEventHandler()->sendGameCommand(cmd);
+        }
     } else if (actionClicked == aBan) {
         Command_GetUserInfo cmd;
         cmd.set_user_name(userName.toStdString());


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6689

## Short roundup of the initial problem
Kicking a player from a game happens immediately without any confirmation. Since the "Kick" and "Add to ignore list" options are adjacent in the context menu, it's easy to accidentally kick a player. Kicking players is against the Cockatrice Discord's policy, so an accidental kick is problematic.

## What will change with this Pull Request?
- Added a confirmation dialog (QMessageBox::question) before kicking a player from a game
- The dialog asks "Are you sure you want to kick this player from the game?" with Yes/No buttons
- No is the default selection to prevent accidental kicks
- The kick command is only sent if the user confirms


