### PR TITLE
[App][Windows][NSIS] Use QProcess::setNativeArguments on Windows, properly order portable detection

### DIFF
--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -117,21 +117,22 @@ ${If} $InstDir == ""
     ; we need to set a default based on the install mode
     StrCpy $InstDir $0
 ${EndIf}
-Call SetModeDestinationFromInstdir
 
-; --- Detect portable install when using /R ---
+; --- Detect portable install when using /R (must come BEFORE SetModeDestinationFromInstdir) ---
 ${If} $ReinstallMode = 1
     IfFileExists "$InstDir\portable.dat" 0 not_portable
         StrCpy $PortableMode 1
         Goto portable_done
-
     not_portable:
         StrCpy $PortableMode 0
-
     portable_done:
 ${EndIf}
 
+; Now that $PortableMode reflects reality, commit InstDir into the correct slot
+Call SetModeDestinationFromInstdir
+
 ${If} $ReinstallMode = 1
+${AndIf} $PortableMode = 0
     Call AutoUninstallIfNeeded
 ${EndIf}
 

--- a/cockatrice/src/interface/widgets/dialogs/dlg_update.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_update.cpp
@@ -219,9 +219,25 @@ void DlgUpdate::downloadError(const QString &errorString)
 void DlgUpdate::downloadSuccessful(const QUrl &filepath)
 {
     setLabel(tr("Installing..."));
+
+    QString installerPath = filepath.toLocalFile();
+
+    QString appDir = QDir::toNativeSeparators(QCoreApplication::applicationDirPath());
+    QProcess process;
+    process.setProgram(installerPath);
+
+    // NSIS needs the /D= argument to be an UNQUOTED string, even if it contains spaces. Qt likes to quote arguments if
+    // they contain spaces, so we use the windows exclusive QProcess::setNativeArguments in the only case where this is
+    // relevant, which preserves the argument unquoted.
+#ifdef Q_OS_WIN
+    process.setNativeArguments(QString("/R /D=%1").arg(appDir));
+#else
+    // Linux/macOS: normal argument passing (not relevant since they update differently.)
+    process.setArguments({"/R", QString("/D=%1").arg(appDir)});
+#endif
+
     // Try to open the installer. If it opens, quit Cockatrice
-    if (QProcess::startDetached(
-            QString("\"%1\" /R /D=\"%2\"").arg(filepath.toLocalFile(), QCoreApplication::applicationDirPath()))) {
+    if (process.startDetached()) {
         QMetaObject::invokeMethod(static_cast<MainWindow *>(parent()), "close", Qt::QueuedConnection);
         qCInfo(DlgUpdateLog) << "Opened downloaded update file successfully - closing Cockatrice";
         close();


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6960
- Fixes #6943
- Fixes #6935
- Fixes #6934

## Short roundup of the initial problem
When we added the silent re-install option (/R), the concern for portable was that Cockatrice now needed to detect if the install was supposed to be portable or not by relying on the 'portable.dat' file detection in the destination folder.
To alleviate this, I passed /D along with the /R flag.
However, NSIS is a little difficult and requires the /D argument specifically to be handed to it on a silver platter with no quotes and nothing. Qt is... equally difficult.

## What will change with this Pull Request?
- Use the windows-exclusive QProcess:setNativeArguments to ensure our folder goes through unescaped.
- Also fix an ordering bug for portable detection.