### PR TITLE
[Game] Setting to restore old chat autofocus behavior

### DIFF
--- a/cockatrice/src/client/settings/cache_settings.cpp
+++ b/cockatrice/src/client/settings/cache_settings.cpp
@@ -309,6 +309,7 @@ SettingsCache::SettingsCache()
     cardViewExpandedRowsMax = settings->value("interface/cardViewExpandedRowsMax", 20).toInt();
     closeEmptyCardView = settings->value("interface/closeEmptyCardView", true).toBool();
     focusCardViewSearchBar = settings->value("interface/focusCardViewSearchBar", true).toBool();
+    keepGameChatFocus = settings->value("interface/keepGameChatFocus", false).toBool();
 
     showDragSelectionCount = settings->value("interface/showlassoselectioncount", true).toBool();
     showTotalSelectionCount = settings->value("interface/showpersistentselectioncount", true).toBool();
@@ -455,6 +456,13 @@ void SettingsCache::setFocusCardViewSearchBar(QT_STATE_CHANGED_T value)
 {
     focusCardViewSearchBar = value;
     settings->setValue("interface/focusCardViewSearchBar", focusCardViewSearchBar);
+}
+
+void SettingsCache::setKeepGameChatFocus(QT_STATE_CHANGED_T value)
+{
+    keepGameChatFocus = value;
+    settings->setValue("interface/keepGameChatFocus", keepGameChatFocus);
+    emit keepGameChatFocusChanged(keepGameChatFocus);
 }
 
 void SettingsCache::setKnownMissingFeatures(const QString &_knownMissingFeatures)

--- a/cockatrice/src/client/settings/cache_settings.h
+++ b/cockatrice/src/client/settings/cache_settings.h
@@ -195,6 +195,7 @@ signals:
     void downloadSpoilerStatusChanged();
     void useTearOffMenusChanged(bool state);
     void roundCardCornersChanged(bool roundCardCorners);
+    void keepGameChatFocusChanged(bool value);
 
 private:
     QSettings *settings;
@@ -306,6 +307,7 @@ private:
     int cardViewExpandedRowsMax;
     bool closeEmptyCardView;
     bool focusCardViewSearchBar;
+    bool keepGameChatFocus;
     int pixmapCacheSize;
     int networkCacheSize;
     int redirectCacheTtl;
@@ -935,6 +937,7 @@ public:
     void setCardViewExpandedRowsMax(int value);
     void setCloseEmptyCardView(QT_STATE_CHANGED_T value);
     void setFocusCardViewSearchBar(QT_STATE_CHANGED_T value);
+    void setKeepGameChatFocus(QT_STATE_CHANGED_T value);
     QString getClientID() override
     {
         return clientID;
@@ -966,6 +969,10 @@ public:
     [[nodiscard]] bool getFocusCardViewSearchBar() const
     {
         return focusCardViewSearchBar;
+    }
+    [[nodiscard]] bool getKeepGameChatFocus() const
+    {
+        return keepGameChatFocus;
     }
     [[nodiscard]] ShortcutsSettings &shortcuts() const
     {

--- a/cockatrice/src/game_graphics/game_view.cpp
+++ b/cockatrice/src/game_graphics/game_view.cpp
@@ -1,7 +1,6 @@
 #include "game_view.h"
 
 #include "../client/settings/cache_settings.h"
-#include "../game/game.h"
 #include "game_scene.h"
 
 #include <QAction>
@@ -196,9 +195,5 @@ void GameView::updateTotalSelectionCount(const QSize &viewSize)
  */
 void GameView::setFocusDisabled(bool disabled)
 {
-    if (disabled) {
-        setFocusPolicy(Qt::NoFocus);
-    } else {
-        setFocusPolicy(Qt::ClickFocus);
-    }
+    setFocusPolicy(disabled ? Qt::NoFocus : Qt::ClickFocus);
 }

--- a/cockatrice/src/game_graphics/game_view.cpp
+++ b/cockatrice/src/game_graphics/game_view.cpp
@@ -1,6 +1,7 @@
 #include "game_view.h"
 
 #include "../client/settings/cache_settings.h"
+#include "../game/game.h"
 #include "game_scene.h"
 
 #include <QAction>
@@ -34,7 +35,6 @@ GameView::GameView(GameScene *scene, QWidget *parent) : QGraphicsView(scene, par
 {
     setBackgroundBrush(QBrush(QColor(0, 0, 0)));
     setRenderHints(QPainter::TextAntialiasing | QPainter::Antialiasing);
-    setFocusPolicy(Qt::ClickFocus);
     setViewportUpdateMode(BoundingRectViewportUpdate);
 
     connect(scene, &GameScene::sceneRectChanged, this, &GameView::updateSceneRect);
@@ -43,6 +43,9 @@ GameView::GameView(GameScene *scene, QWidget *parent) : QGraphicsView(scene, par
     connect(scene, &GameScene::sigResizeRubberBand, this, &GameView::resizeRubberBand);
     connect(scene, &GameScene::sigStopRubberBand, this, &GameView::stopRubberBand);
     connect(scene, &QGraphicsScene::selectionChanged, this, [this]() { updateTotalSelectionCount(); });
+
+    setFocusDisabled(SettingsCache::instance().getKeepGameChatFocus());
+    connect(&SettingsCache::instance(), &SettingsCache::keepGameChatFocusChanged, this, &GameView::setFocusDisabled);
 
     aCloseMostRecentZoneView = new QAction(this);
 
@@ -184,5 +187,18 @@ void GameView::updateTotalSelectionCount(const QSize &viewSize)
         totalCountLabel->show();
     } else {
         totalCountLabel->hide();
+    }
+}
+
+/**
+ * Disabling focus on the game view will allow chat to maintain the autofocusing behavior of pre 2.10.3,
+ * at the cost of disabling the zone view search bar.
+ */
+void GameView::setFocusDisabled(bool disabled)
+{
+    if (disabled) {
+        setFocusPolicy(Qt::NoFocus);
+    } else {
+        setFocusPolicy(Qt::ClickFocus);
     }
 }

--- a/cockatrice/src/game_graphics/game_view.h
+++ b/cockatrice/src/game_graphics/game_view.h
@@ -31,7 +31,7 @@ private slots:
     void stopRubberBand();
     void refreshShortcuts();
     void updateTotalSelectionCount(const QSize &viewSize = QSize());
-    void setFocusDisabled(bool focusEnabled);
+    void setFocusDisabled(bool disabled);
 public slots:
     void updateSceneRect(const QRectF &rect);
 

--- a/cockatrice/src/game_graphics/game_view.h
+++ b/cockatrice/src/game_graphics/game_view.h
@@ -31,6 +31,7 @@ private slots:
     void stopRubberBand();
     void refreshShortcuts();
     void updateTotalSelectionCount(const QSize &viewSize = QSize());
+    void setFocusDisabled(bool focusEnabled);
 public slots:
     void updateSceneRect(const QRectF &rect);
 

--- a/cockatrice/src/game_graphics/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game_graphics/zones/view_zone_widget.cpp
@@ -75,6 +75,11 @@ ZoneViewWidget::ZoneViewWidget(PlayerLogic *_player,
         searchEditProxy->setZValue(ZValues::DRAG_ITEM);
         vbox->addItem(searchEditProxy);
 
+        // hide search bar if chat autofocus setting is enabled, since typing into it will no longer work anyway
+        searchEditProxy->setVisible(!SettingsCache::instance().getKeepGameChatFocus());
+        connect(&SettingsCache::instance(), &SettingsCache::keepGameChatFocusChanged, searchEditProxy,
+                [searchEditProxy](bool keepFocus) { searchEditProxy->setVisible(!keepFocus); });
+
         // top row
         QGraphicsLinearLayout *hTopRow = new QGraphicsLinearLayout(Qt::Horizontal);
 

--- a/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.cpp
+++ b/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.cpp
@@ -72,6 +72,10 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     connect(&useTearOffMenusCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             [](const QT_STATE_CHANGED_T state) { SettingsCache::instance().setUseTearOffMenus(state == Qt::Checked); });
 
+    keepGameChatFocusCheckBox.setChecked(SettingsCache::instance().getKeepGameChatFocus());
+    connect(&keepGameChatFocusCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
+            &SettingsCache::setKeepGameChatFocus);
+
     auto *generalGrid = new QGridLayout;
     generalGrid->addWidget(&doubleClickToPlayCheckBox, 0, 0);
     generalGrid->addWidget(&clickPlaysAllSelectedCheckBox, 1, 0);
@@ -83,6 +87,7 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     generalGrid->addWidget(&showDragSelectionCountCheckBox, 7, 0);
     generalGrid->addWidget(&showTotalSelectionCountCheckBox, 8, 0);
     generalGrid->addWidget(&useTearOffMenusCheckBox, 9, 0);
+    generalGrid->addWidget(&keepGameChatFocusCheckBox, 10, 0);
 
     generalGroupBox = new QGroupBox;
     generalGroupBox->setLayout(generalGrid);
@@ -207,6 +212,9 @@ void UserInterfaceSettingsPage::retranslateUi()
     showDragSelectionCountCheckBox.setText(tr("Show selection counter during drag selection"));
     showTotalSelectionCountCheckBox.setText(tr("Show total selection counter"));
     useTearOffMenusCheckBox.setText(tr("Use tear-off menus, allowing right click menus to persist on screen"));
+    keepGameChatFocusCheckBox.setText(
+        tr("Keep game chat focused when clicking in game (Note: disables card view search bar)"));
+
     notificationsGroupBox->setTitle(tr("Notifications settings"));
     notificationsEnabledCheckBox.setText(tr("Enable notifications in taskbar"));
     specNotificationsEnabledCheckBox.setText(tr("Notify in the taskbar for game events while you are spectating"));

--- a/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.h
+++ b/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.h
@@ -30,6 +30,7 @@ private:
     QCheckBox showDragSelectionCountCheckBox;
     QCheckBox showTotalSelectionCountCheckBox;
     QCheckBox useTearOffMenusCheckBox;
+    QCheckBox keepGameChatFocusCheckBox;
     QCheckBox tapAnimationCheckBox;
     QCheckBox openDeckInNewTabCheckBox;
     QLabel visualDeckStoragePromptForConversionLabel;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes regression introduced in #5791

## Short roundup of the initial problem

When we implemented the card view search bar, we had to remove the line that set the focusPolicy of the game view to `NoFocus` in order to allow the search to get focus. However, that also means we no longer have the behavior of the game chat remaining focused even when the game scene is clicked.

When we asked for feedback about the change, there weren't any complaints.

However, I recently ran across a contingent of players for whom the removal of the autofocusing is an absolute deal breaker and is making them refuse to upgrade.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/c7bc1974-5eba-4561-a4df-c3be787cf178

- Add the new setting under Interface -> general interface settings
- When setting is enabled, we set the focusPolicy on `GameView` to `NoFocus` again, which prevents the game chat from losing focus when you click on the game scene.
  - Also hides the search bar, so users don't get confused about why it doesn't work
- Emits signals on settings change, so the change can take effect midgame. 

## Screenshots

<img width="580" height="302" alt="Screenshot 2026-06-13 at 1 49 50 AM" src="https://github.com/user-attachments/assets/886426a2-c4a2-4462-a0d7-dbbbf9a8eb29" />

