### PR TITLE
CI: replaced dynamically injected variables with environment variables

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -211,9 +211,10 @@ jobs:
         if: github.ref == 'refs/heads/master' && steps.ccache_restore.outputs.cache-hit
         continue-on-error: true
         env:
+          CACHE_PRIMARY_KEY: ${{ steps.ccache_restore.outputs.cache-primary-key }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          if gh cache delete --repo ${{ github.repository }} ${{ steps.ccache_restore.outputs.cache-primary-key }}; then
+          if gh cache delete --repo "$GITHUB_REPOSITORY" "$CACHE_PRIMARY_KEY"; then
             echo "Cache deleted successfully"
           fi
 
@@ -256,8 +257,9 @@ jobs:
         if: steps.attestation.outcome == 'success'
         shell: bash
         env:
+          BUILD_PATH: ${{ steps.build.outputs.path }}
           GH_TOKEN: ${{ github.token }}
-        run: gh attestation verify "${{ steps.build.outputs.path }}" --repo Cockatrice/Cockatrice
+        run: gh attestation verify "$BUILD_PATH" --repo Cockatrice/Cockatrice
 
   build-vcpkg:
     strategy:
@@ -381,9 +383,11 @@ jobs:
 
       # Resolve given wildcard versions (e.g. Qt 6.6.*) to latest version via aqtinstall to avoid stale caches on new releases
       - name: "Resolve latest Qt patch version"
+        env:
+          QT_VERSION: ${{ matrix.qt_version }}
         id: resolve_qt_version
         shell: bash
-        run: .ci/resolve_latest_aqt_qt_version.sh "${{ matrix.qt_version }}"
+        run: .ci/resolve_latest_aqt_qt_version.sh "$QT_VERSION"
 
       - name: "[macOS] Restore thin Qt ${{ steps.resolve_qt_version.outputs.version }} libraries"
         if: matrix.os == 'macOS'
@@ -465,9 +469,10 @@ jobs:
         if: matrix.os == 'macOS' && matrix.use_ccache == 1 && github.ref == 'refs/heads/master' && steps.ccache_restore.outputs.cache-hit
         continue-on-error: true
         env:
+          CACHE_PRIMARY_KEY: ${{ steps.ccache_restore.outputs.cache-primary-key }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          if gh cache delete --repo ${{ github.repository }} ${{ steps.ccache_restore.outputs.cache-primary-key }}; then
+          if gh cache delete --repo "$GITHUB_REPOSITORY" "$CACHE_PRIMARY_KEY"; then
             echo "Cache deleted successfully"
           fi
 
@@ -482,18 +487,20 @@ jobs:
         if: matrix.os == 'macOS' && matrix.make_package && needs.configure.outputs.tag != null
         id: sign_macos
         env:
+          BUILD_PATH: ${{ steps.build.outputs.path }}
           MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
         run: |
           if [[ -n "$MACOS_CERTIFICATE_NAME" ]]
           then
             security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-            /usr/bin/codesign --sign="$MACOS_CERTIFICATE_NAME" --entitlements=".ci/macos.entitlements" --options=runtime --force --deep --timestamp --verbose "${{ steps.build.outputs.path }}"
+            /usr/bin/codesign --sign="$MACOS_CERTIFICATE_NAME" --entitlements=".ci/macos.entitlements" --options=runtime --force --deep --timestamp --verbose "$BUILD_PATH"
           fi
 
       - name: "[macOS] Notarize app bundle"
         if: matrix.os == 'macOS' && steps.sign_macos.outcome == 'success'
         env:
+          BUILD_PATH: ${{ steps.build.outputs.path }}
           MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
           MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
           MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
@@ -508,7 +515,7 @@ jobs:
             # Therefore, we create a zip file containing our app bundle, so that we can send it to the
             # notarization service
             echo "Creating temp notarization archive"
-            ditto -c -k --keepParent "${{ steps.build.outputs.path }}" "notarization.zip"
+            ditto -c -k --keepParent "$BUILD_PATH" "notarization.zip"
 
             # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
             # This typically takes a few seconds inside a CI environment, but it might take more depending on the App
@@ -520,7 +527,7 @@ jobs:
             # Finally, we need to "attach the staple" to our executable, which will allow our app to be
             # validated by macOS even when an internet connection is not available.
             echo "Attach staple"
-            xcrun stapler staple "${{ steps.build.outputs.path }}"
+            xcrun stapler staple "$BUILD_PATH"
           fi
 
       - name: "Upload artifact"
@@ -566,5 +573,6 @@ jobs:
         if: steps.attestation.outcome == 'success'
         shell: bash
         env:
+          BUILD_PATH: ${{ steps.build.outputs.path }}
           GH_TOKEN: ${{ github.token }}
-        run: gh attestation verify "${{ steps.build.outputs.path }}" --repo Cockatrice/Cockatrice
+        run: gh attestation verify "$BUILD_PATH" --repo Cockatrice/Cockatrice


### PR DESCRIPTION
This prevents some injection attacks and makes all the scripts valid Bash.

## Related Ticket(s)
- N/A

## Short roundup of the initial problem

Using dynamically injected values opens the door for script injection attacks. Those are not possible with environment variables.

* GitHub docs: [warning about their usage](https://docs.github.com/en/actions/concepts/security/script-injections)
* News story: [A GitHub Issue Title Compromised 4k Developer Machines](https://grith.ai/blog/clinejection-when-your-ai-tool-installs-another)

## What will change with this Pull Request?

* Replaced script injects with environment variables

> [!IMPORTANT]
>
> Some of these variable injections were left behind because they are addressed in another parallel ticket (#6995).

## Screenshots
N/A
