### PR TITLE
[Game] Fix facedown predefined tokens leaking tablerow

### DIFF
--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -882,7 +882,8 @@ void PlayerActions::actCreateToken(TokenInfo tokenToCreate)
     ExactCard correctedCard = CardDatabaseManager::query()->guessCard({lastTokenInfo.name, lastTokenInfo.providerId});
     if (correctedCard) {
         lastTokenInfo.name = correctedCard.getName();
-        lastTokenTableRow = TableZone::tableRowToGridY(correctedCard.getInfo().getUiAttributes().tableRow);
+        int tableRow = lastTokenInfo.faceDown ? 2 : correctedCard.getInfo().getUiAttributes().tableRow;
+        lastTokenTableRow = TableZone::tableRowToGridY(tableRow);
         if (lastTokenInfo.pt.isEmpty()) {
             lastTokenInfo.pt = correctedCard.getInfo().getPowTough();
         }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6999

## Short roundup of the initial problem

Client is always setting the the tablerow of the create token command to the value given by the CardInfo, regardless of whether the token is being created facedown

## What will change with this Pull Request?

- When the token is facedown, the tablerow will always be 2
  - Same behavior that we use for normal "play face down" 

https://github.com/user-attachments/assets/48cad458-c7ca-48f6-9227-033ffd4e2fa6

