### PR TITLE
[Lobby][DeckView] Always at minimum create main and side deck zone containers

### DIFF
--- a/cockatrice/src/game_graphics/deckview/deck_view.cpp
+++ b/cockatrice/src/game_graphics/deckview/deck_view.cpp
@@ -360,6 +360,16 @@ void DeckViewScene::rebuildTree()
         return;
     }
 
+    QStringList requiredZones = {DECK_ZONE_MAIN, DECK_ZONE_SIDE};
+
+    for (const QString &zoneName : requiredZones) {
+        if (!cardContainers.contains(zoneName)) {
+            auto *container = new DeckViewCardContainer(zoneName);
+            cardContainers.insert(zoneName, container);
+            addItem(container);
+        }
+    }
+
     for (auto *currentZone : deck->getZoneNodes()) {
         DeckViewCardContainer *container = cardContainers.value(currentZone->getName(), 0);
         if (!container) {


### PR DESCRIPTION
## Related Tickets
- Fixes #6955

## Short roundup of the initial problem
Users are complaining that they can't sideboard in decks created without sideboards.

## What will change with this Pull Request?
- Always create the main and side deck zones so we can swap between them.