### PR TITLE
[Card] Respect disabled sets when loading v3 card databases (#6882)

### DIFF
--- a/libcockatrice_card/libcockatrice/card/database/parser/cockatrice_xml_3.cpp
+++ b/libcockatrice_card/libcockatrice/card/database/parser/cockatrice_xml_3.cpp
@@ -217,27 +217,32 @@ void CockatriceXml3Parser::loadCardsFromXml(QXmlStreamReader &xml)
                     // NOTE: attributes must be read before readElementText()
                     QXmlStreamAttributes attrs = xml.attributes();
                     QString setName = xml.readElementText(QXmlStreamReader::IncludeChildElements);
-                    PrintingInfo setInfo(internalAddSet(setName));
-                    if (attrs.hasAttribute("muId")) {
-                        setInfo.setProperty("muid", attrs.value("muId").toString());
-                    }
+                    auto set = internalAddSet(setName);
+                    // Only load printings from sets the user has enabled, matching the v4 loader's
+                    // behaviour. Without this check, disabling a set has no effect on v3 databases.
+                    if (set->getEnabled()) {
+                        PrintingInfo setInfo(set);
+                        if (attrs.hasAttribute("muId")) {
+                            setInfo.setProperty("muid", attrs.value("muId").toString());
+                        }
 
-                    if (attrs.hasAttribute("muId")) {
-                        setInfo.setProperty("uuid", attrs.value("uuId").toString());
-                    }
+                        if (attrs.hasAttribute("uuId")) {
+                            setInfo.setProperty("uuid", attrs.value("uuId").toString());
+                        }
 
-                    if (attrs.hasAttribute("picURL")) {
-                        setInfo.setProperty("picurl", attrs.value("picURL").toString());
-                    }
+                        if (attrs.hasAttribute("picURL")) {
+                            setInfo.setProperty("picurl", attrs.value("picURL").toString());
+                        }
 
-                    if (attrs.hasAttribute("num")) {
-                        setInfo.setProperty("num", attrs.value("num").toString());
-                    }
+                        if (attrs.hasAttribute("num")) {
+                            setInfo.setProperty("num", attrs.value("num").toString());
+                        }
 
-                    if (attrs.hasAttribute("rarity")) {
-                        setInfo.setProperty("rarity", attrs.value("rarity").toString());
+                        if (attrs.hasAttribute("rarity")) {
+                            setInfo.setProperty("rarity", attrs.value("rarity").toString());
+                        }
+                        _sets[setName].append(setInfo);
                     }
-                    _sets[setName].append(setInfo);
                     // related cards
                 } else if (xmlName == "related" || xmlName == "reverse-related") {
                     CardRelationType attach = CardRelationType::DoesNotAttach;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6882 

## Short roundup of the initial problem
  When a card database is stored in the older v3 XML format, disabling a set in
  the card database settings had no effect — cards from the disabled set were
  still loaded and shown. The v4 loader already skips printings from disabled
  sets, but the v3 loader (`CockatriceXml3Parser::loadCardsFromXml`) appended
  every printing unconditionally, so the two loaders behaved inconsistently.

## What will change with this Pull Request?
  - The v3 XML loader now only registers a printing if its set is enabled
    (`set->getEnabled()`), mirroring the existing behaviour in the v4 loader.
  - Disabling a set now correctly hides its cards regardless of whether the
    database is in v3 or v4 format.
