### PR TITLE
Add 'facedown' as a valid attribute of related/reverse-related

### DIFF
--- a/doc/carddatabase_v4/cards.xsd
+++ b/doc/carddatabase_v4/cards.xsd
@@ -6,6 +6,7 @@
                 <xs:attribute type="xs:string" name="exclude" use="optional" />
                 <xs:attribute type="xs:string" name="attach" use="optional" />
                 <xs:attribute type="xs:string" name="persistent" use="optional" />
+                <xs:attribute type="xs:string" name="facedown" use="optional" />
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>


### PR DESCRIPTION
Related to https://github.com/Cockatrice/Cockatrice/pull/6997

Updates the v4 cards.xsd file (used by xml linters) to reflect that `facedown` is now a valid attribute of related/reverse-related.
