### PR TITLE
CI: Avoid failing tx step if secret can not be accessed

### DIFF
--- a/.github/workflows/translations-pull.yml
+++ b/.github/workflows/translations-pull.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/checkout@v7
 
       - name: "Pull translated strings from Transifex"
+        # Do not run this step for PR's from forks, they don't have access to the secret
+        if: github.event_name != 'pull_request' || github.repository_owner == 'Cockatrice'
         uses: transifex/cli-action@v2
         with:
           # Used config file: https://github.com/Cockatrice/Cockatrice/blob/master/.tx/config

--- a/.github/workflows/translations-pull.yml
+++ b/.github/workflows/translations-pull.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: "Pull translated strings from Transifex"
         # Do not run this step for PR's from forks, they don't have access to the secret
-        if: github.event_name != 'pull_request' || github.repository_owner == 'Cockatrice'
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
         uses: transifex/cli-action@v2
         with:
           # Used config file: https://github.com/Cockatrice/Cockatrice/blob/master/.tx/config


### PR DESCRIPTION
## Short roundup of the initial problem
Job runs were failing because the needed secret is not available in PR's from untrusted sources / forks. (e.g. for Dependabot PR's which are opened from a fork, or external contributions)

## What will change with this Pull Request?
- Error message is not clear about the issue and reads only `Incorrect Usage. flag provided but not defined: -force`
- Skip step when secret is not available and only run in Cockatrice context
   --> CI checks stay green and are less misleading