### PR TITLE
CI: More polish

### DIFF
--- a/.ci/docker.sh
+++ b/.ci/docker.sh
@@ -7,13 +7,13 @@
 # usage: source <script> <name> [--get] [--build] [--save] [--interactive] [--set-cache <location>]
 # <name> sets the name of the docker image, these correspond to directories in .ci
 # --get loads the image from a previously saved image cache, will build if no image is found
-# --build builds the image from the Dockerfile in .ci/$NAME
+# --build builds the image from the Dockerfile in .ci/$BUILD_REFERENCE
 # --save stores the image, if an image was loaded it will not be stored
 # --interactive immediately starts the image interactively for debugging
 # --set-cache <location> sets the location to cache the image or for ccache
 #
 # requires: docker
-# uses env: NAME CACHE BUILD GET SAVE INTERACTIVE
+# uses env: BUILD_REFERENCE CACHE BUILD GET SAVE INTERACTIVE
 # (correspond to args: <name> --set-cache <cache> --build --get --save --interactive)
 # sets env: RUN CCACHE_DIR IMAGE_NAME RUN_ARGS RUN_OPTS BUILD_SCRIPT
 # exitcode: 1 for failure, 2 for missing dockerfile, 3 for invalid arguments
@@ -69,21 +69,21 @@ while [[ $# != 0 ]]; do
         echo "unrecognized option: $1"
         return 3
       fi
-      NAME="$1"
+      BUILD_REFERENCE="$1"
       shift
       ;;
   esac
 done
 
 # Setup
-if ! [[ $NAME ]]; then
+if ! [[ $BUILD_REFERENCE ]]; then
   echo "no build name given" >&2
   return 3
 fi
 
-export IMAGE_NAME="${project_name,,}_${NAME,,}" # lower case
+export IMAGE_NAME="${project_name,,}_${BUILD_REFERENCE,,}" # lower case
 
-docker_dir=".ci/$NAME"
+docker_dir=".ci/$BUILD_REFERENCE"
 if ! [[ -r $docker_dir/Dockerfile ]]; then
   echo "could not find Dockerfile in $docker_dir" >&2
   return 2 # even if the image is cached, we do not want to run if there is no way to build this image

--- a/.ci/prep_release.sh
+++ b/.ci/prep_release.sh
@@ -7,7 +7,7 @@
 # adds output to GITHUB_OUTPUT
 template_path=".ci/release_template.md"
 body_path="/tmp/release.md"
-beta_regex='beta'
+beta_regex='-beta'
 name_regex='set\(GIT_TAG_RELEASENAME "([[:print:]]+)")'
 whitespace='^\s*$'
 
@@ -23,28 +23,29 @@ fi
 
 # create title
 if [[ $TAG =~ $beta_regex ]]; then
-  echo "is_beta=true" >>"$GITHUB_OUTPUT"
+  beta=true
+  echo "beta=$beta" >>"$GITHUB_OUTPUT"
   title="$TAG"
-  echo "creating beta release '$title'"
+  echo "Creating beta release '$title'"
 elif [[ ! $(cat CMakeLists.txt) =~ $name_regex ]]; then
-  echo "::error file=$0::could not find releasename in CMakeLists.txt"
+  echo "::error file=$0::Could not find releasename in CMakeLists.txt"
   exit 1
 else
-  echo "is_beta=false" >>"$GITHUB_OUTPUT"
+  beta=false
+  echo "beta=$beta" >>"$GITHUB_OUTPUT"
   name="${BASH_REMATCH[1]}"
   version="${TAG##*-}"
   title="Cockatrice $version: $name"
-  no_beta=true
   echo "friendly_name=$name" >>"$GITHUB_OUTPUT"
-  echo "creating full release '$title'"
+  echo "Creating full release '$title'"
 fi
 echo "title=$title" >>"$GITHUB_OUTPUT"
 
 # add release notes template
-if [[ $no_beta ]]; then
+if [[ $beta == "false" ]]; then
   body="$(cat "$template_path")"
   if [[ ! $body ]]; then
-    echo "::warning file=$0::could not find release template"
+    echo "::warning file=$0::Could not find release template"
   fi
   body="${body//--REPLACE-WITH-RELEASE-TITLE--/$title}"
 else
@@ -64,13 +65,13 @@ before="${all_tags%%
 "$TAG"*}" # strip line with current tag an all lines after it
 # note the extra newlines are needed to always have a last line
 if [[ $all_tags == "$before" ]]; then
-  echo "::warning file=$0::could not find current tag"
+  echo "::warning file=$0::Could not find current tag"
 else
   while
     previous="${before##*
 }" # get the last line
     # skip this tag if this is a full release and it's a beta or if empty
-    [[ $no_beta && $previous =~ $beta_regex || ! $previous ]]
+    [[ $beta == "false" && $previous =~ $beta_regex || ! $previous ]]
   do
     beta_list+=" $previous" # add to list of skipped betas
     next_before="${before%
@@ -85,7 +86,7 @@ else
     if generated_list="$(git log "$previous..$TAG" --pretty="- %s")"; then
       count="$(git rev-list --count "$previous..$TAG")"
       [[ $previous =~ $beta_regex ]] && previousreleasetype="beta release" || previousreleasetype="full release"
-      echo "adding list of commits to release notes:"
+      echo "Adding list of commits to release notes:"
       echo "'$previous' to '$TAG' ($count commits)"
       # --> is the markdown comment escape sequence, emojis are way better
       generated_list="${generated_list//-->/→}"
@@ -98,15 +99,15 @@ else
       if [[ $beta_list =~ $whitespace ]]; then
         beta_list="-n there are no betas to delete!"
       else
-        echo "the following betas should be deleted after publishing:"
+        echo "The following betas should be deleted after publishing:"
         echo "$beta_list"
       fi
       body="${body//--REPLACE-WITH-BETA-LIST--/$beta_list}"
     else
-      echo "::warning file=$0::failed to produce git log"
+      echo "::warning file=$0::Failed to produce git log"
     fi
   else
-    echo "::warning file=$0::could not find previous tag"
+    echo "::warning file=$0::Could not find previous tag"
   fi
 fi
 

--- a/.ci/prep_release.sh
+++ b/.ci/prep_release.sh
@@ -23,18 +23,18 @@ fi
 
 # create title
 if [[ $TAG =~ $beta_regex ]]; then
-  echo "is_beta=yes" >>"$GITHUB_OUTPUT"
+  echo "is_beta=true" >>"$GITHUB_OUTPUT"
   title="$TAG"
   echo "creating beta release '$title'"
 elif [[ ! $(cat CMakeLists.txt) =~ $name_regex ]]; then
   echo "::error file=$0::could not find releasename in CMakeLists.txt"
   exit 1
 else
-  echo "is_beta=no" >>"$GITHUB_OUTPUT"
+  echo "is_beta=false" >>"$GITHUB_OUTPUT"
   name="${BASH_REMATCH[1]}"
   version="${TAG##*-}"
   title="Cockatrice $version: $name"
-  no_beta=1
+  no_beta=true
   echo "friendly_name=$name" >>"$GITHUB_OUTPUT"
   echo "creating full release '$title'"
 fi

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -147,7 +147,7 @@ jobs:
     name: ${{ matrix.distro }} ${{ matrix.version }}
     needs: configure
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allow-failure == 'true' }}
+    continue-on-error: ${{ matrix.allow-failure == true }}
     timeout-minutes: 70
     env:
       CACHE: ${{ github.workspace }}/.cache/${{ matrix.distro }}${{ matrix.version }}    # directory for caching docker image and ccache
@@ -359,11 +359,11 @@ jobs:
           msbuild-architecture: x64
 
       - name: "[macOS] Setup ccache"
-        if: matrix.os == 'macOS' && matrix.use_ccache == 'true'
+        if: matrix.os == 'macOS' && matrix.use_ccache == true
         run: brew install ccache
 
       - name: "[macOS] Restore compiler cache (ccache)"
-        if: matrix.os == 'macOS' && matrix.use_ccache == 'true'
+        if: matrix.os == 'macOS' && matrix.use_ccache == true
         id: ccache_restore
         uses: actions/cache/restore@v5
         env:
@@ -461,7 +461,7 @@ jobs:
 
       # Delete used cache to emulate a ccache update. See https://github.com/actions/cache/issues/342
       - name: "[macOS] Delete remote compiler cache (ccache)"
-        if: matrix.os == 'macOS' && matrix.use_ccache == 'true' && github.ref == 'refs/heads/master' && steps.ccache_restore.outputs.cache-hit
+        if: matrix.os == 'macOS' && matrix.use_ccache == true && github.ref == 'refs/heads/master' && steps.ccache_restore.outputs.cache-hit
         continue-on-error: true
         env:
           CACHE_PRIMARY_KEY: ${{ steps.ccache_restore.outputs.cache-primary-key }}
@@ -472,7 +472,7 @@ jobs:
           fi
 
       - name: "[macOS] Save updated compiler cache (ccache)"
-        if: matrix.os == 'macOS' && matrix.use_ccache == 'true' && github.ref == 'refs/heads/master'
+        if: matrix.os == 'macOS' && matrix.use_ccache == true && github.ref == 'refs/heads/master'
         uses: actions/cache/save@v5
         with:
           key: ${{ steps.ccache_restore.outputs.cache-primary-key }}
@@ -546,7 +546,7 @@ jobs:
             build/servatrice/Release/*.pdb
 
       - name: "Upload to release"
-        if: needs.configure.outputs.tag != null && matrix.make_package == 'true'
+        if: needs.configure.outputs.tag != null && matrix.make_package == true
         id: upload_release
         shell: bash
         env:

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -7,6 +7,17 @@ permissions:
   id-token: write    # needed for signing certificate in attestation
 
 on:
+  pull_request:
+    paths:
+      - '*/**'    # matches all files not in root
+      - '!**.md'
+      - '!.github/**'
+      - '!.tx/**'
+      - '!doc/**'
+      - '.github/workflows/desktop-build.yml'
+      - 'CMakeLists.txt'
+      - 'vcpkg.json'
+      - 'vcpkg'    # needed to match submodule bumps (gitlink)
   push:
     branches:
       - master
@@ -22,17 +33,6 @@ on:
       - 'vcpkg'    # needed to match submodule bumps (gitlink)
     tags:
       - '*'
-  pull_request:
-    paths:
-      - '*/**'    # matches all files not in root
-      - '!**.md'
-      - '!.github/**'
-      - '!.tx/**'
-      - '!doc/**'
-      - '.github/workflows/desktop-build.yml'
-      - 'CMakeLists.txt'
-      - 'vcpkg.json'
-      - 'vcpkg'    # needed to match submodule bumps (gitlink)
 
 # Cancel earlier, unfinished runs of this workflow on the same branch (unless on release)
 concurrency:

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -337,7 +337,7 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             type: Release
 
-    name: ${{ matrix.os }} ${{ matrix.target }}${{ matrix.soc == 'Intel' && ' Intel' || '' }}${{ matrix.type == 'Debug' && ' Debug' || '' }}
+    name: ${{ matrix.os }} ${{ matrix.target }}${{ case(matrix.soc == 'Intel', ' Intel', '') }}${{ case(matrix.type == 'Debug', ' Debug', '') }}
     needs: configure
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 100

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -102,20 +102,20 @@ jobs:
           - distro: Arch
 
             allow-failure: true
-            package: skip    # We are packaged in Arch already
+            package: false    # We are packaged in Arch already
 
           - distro: Servatrice_Debian
             version: 12
 
             package: DEB
             server_only: true
-            test: skip
+            test: false
 
           - distro: Debian
             version: 12
 
             package: DEB
-            test: skip    # Running tests on all distros is superfluous
+            test: false    # Running tests on all distros is superfluous
 
           - distro: Debian
             version: 13
@@ -126,7 +126,7 @@ jobs:
             version: 43
 
             package: RPM
-            test: skip    # Running tests on all distros is superfluous
+            test: false    # Running tests on all distros is superfluous
 
           - distro: Fedora
             version: 44
@@ -137,7 +137,7 @@ jobs:
             version: 24.04
 
             package: DEB
-            test: skip    # Running tests on all distros is superfluous
+            test: false    # Running tests on all distros is superfluous
 
           - distro: Ubuntu
             version: 26.04
@@ -175,7 +175,7 @@ jobs:
         run: source .ci/docker.sh --build
 
       - name: "Build debug and test"
-        if: matrix.test != 'skip'
+        if: matrix.test != false
         shell: bash
         run: |
           source .ci/docker.sh
@@ -184,7 +184,7 @@ jobs:
 
       - name: "Build release package"
         id: build
-        if: matrix.package != 'skip'
+        if: matrix.package != false
         shell: bash
         env:
           SUFFIX: '-${{ matrix.distro }}${{ matrix.version }}'
@@ -222,7 +222,7 @@ jobs:
 
       - name: "Upload artifact"
         id: upload_artifact
-        if: matrix.package != 'skip'
+        if: matrix.package != false
         uses: actions/upload-artifact@v7
         with:
           archive: false
@@ -231,7 +231,7 @@ jobs:
 
       - name: "Upload to release"
         id: upload_release
-        if: matrix.package != 'skip' && needs.configure.outputs.tag != null
+        if: matrix.package != false && needs.configure.outputs.tag != null
         shell: bash
         env:
           ASSET_NAME: ${{ steps.build.outputs.fullname }}

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The files in ".ci/$distro$version" correspond to the values given here
+        # The files in ".ci/$distro$distro_version" correspond to the values given here
         include:
           - distro: Arch
 
@@ -105,55 +105,55 @@ jobs:
             test: true    # run debug build and tests
 
           - distro: Servatrice_Debian
-            version: 12
+            distro_version: 12
 
             package: DEB
             server_only: true
 
           - distro: Debian
-            version: 12
+            distro_version: 12
 
             package: DEB
 
           - distro: Debian
-            version: 13
+            distro_version: 13
 
             package: DEB
             test: true    # run debug build and tests on newest distro version
 
           - distro: Fedora
-            version: 43
+            distro_version: 43
 
             package: RPM
 
           - distro: Fedora
-            version: 44
+            distro_version: 44
 
             package: RPM
             test: true    # run debug build and tests on newest distro version
 
           - distro: Ubuntu
-            version: 24.04
+            distro_version: 24.04
 
             package: DEB
 
           - distro: Ubuntu
-            version: 26.04
+            distro_version: 26.04
 
             package: DEB
             test: true    # run debug build and tests on newest distro version
 
-    name: ${{ matrix.distro }} ${{ matrix.version }}
+    name: ${{ matrix.distro }} ${{ matrix.distro_version }}
     needs: configure
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.allow-failure == true }}
     timeout-minutes: 70
     env:
-      CACHE_DIR: ${{ github.workspace }}/.cache/${{ matrix.distro }}${{ matrix.version }}    # directory for caching docker image and ccache
+      CACHE_DIR: ${{ github.workspace }}/.cache/${{ matrix.distro }}${{ matrix.distro_version }}    # directory for caching docker image and ccache
       CCACHE_EVICTION_AGE: 7d
       CCACHE_SIZE: 550M    # space of all repo is 10Gi: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
       CMAKE_GENERATOR: 'Ninja'
-      NAME: ${{ matrix.distro }}${{ matrix.version }}
+      NAME: ${{ matrix.distro }}${{ matrix.distro_version }}
 
     steps:
       - name: "Checkout"
@@ -165,11 +165,11 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         with:
-          key: ccache-${{ matrix.distro }}${{ matrix.version }}-${{ env.BRANCH_NAME }}
+          key: ccache-${{ matrix.distro }}${{ matrix.distro_version }}-${{ env.BRANCH_NAME }}
           path: ${{ env.CACHE_DIR }}
-          restore-keys: ccache-${{ matrix.distro }}${{ matrix.version }}-
+          restore-keys: ccache-${{ matrix.distro }}${{ matrix.distro_version }}-
 
-      - name: "Build ${{ matrix.distro }} ${{ matrix.version }} Docker image"
+      - name: "Build ${{ matrix.distro }} ${{ matrix.distro_version }} Docker image"
         shell: bash
         run: source .ci/docker.sh --build
 
@@ -188,7 +188,7 @@ jobs:
         env:
           PACKAGE: '${{ matrix.package }}'
           SERVER_ONLY: '${{ matrix.server_only }}'
-          SUFFIX: '-${{ matrix.distro }}${{ matrix.version }}'
+          SUFFIX: '-${{ matrix.distro }}${{ matrix.distro_version }}'
         run: |
           source .ci/docker.sh
           args=()
@@ -261,7 +261,7 @@ jobs:
       matrix:
         include:
           - os: macOS
-            target: 13
+            os_target_version: 13
             runner: macos-15-intel
 
             cmake_generator: Ninja
@@ -277,7 +277,7 @@ jobs:
             xcode: "16.4"
 
           - os: macOS
-            target: 14
+            os_target_version: 14
             runner: macos-14
 
             cmake_generator: Ninja
@@ -292,7 +292,7 @@ jobs:
             xcode: "15.4"
 
           - os: macOS
-            target: 15
+            os_target_version: 15
             runner: macos-15
 
             cmake_generator: Ninja
@@ -307,7 +307,7 @@ jobs:
             xcode: "16.4"
 
           - os: macOS
-            target: 15
+            os_target_version: 15
             runner: macos-15
 
             cmake_generator: Ninja
@@ -320,7 +320,7 @@ jobs:
             xcode: "16.4"
 
           - os: Windows
-            target: 10
+            os_target_version: 10
             runner: windows-2025
 
             cmake_generator: "Visual Studio 18 2026"
@@ -332,7 +332,7 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             type: Release
 
-    name: ${{ matrix.os }} ${{ matrix.target }}${{ case(matrix.soc == 'Intel', ' Intel', '') }}${{ case(matrix.type == 'Debug', ' Debug', '') }}
+    name: ${{ matrix.os }} ${{ matrix.os_target_version }}${{ case(matrix.soc == 'Intel', ' Intel', '') }}${{ case(matrix.type == 'Debug', ' Debug', '') }}
     needs: configure
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 100
@@ -439,7 +439,6 @@ jobs:
         shell: bash
         env:
           BUILDTYPE: '${{ matrix.type }}'
-          CCACHE_EVICTION_AGE: ${{ matrix.ccache_eviction_age }}
           CMAKE_GENERATOR: ${{ matrix.cmake_generator }}
           CMAKE_GENERATOR_PLATFORM: ${{ matrix.cmake_generator_platform }}
           DEVELOPER_DIR: '/Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer'

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -79,19 +79,19 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          tag_name: ${{ steps.configure.outputs.tag }}
-          target: ${{ steps.configure.outputs.sha }}
-          release_name: ${{ steps.prepare.outputs.title }}
-          body_path: ${{ steps.prepare.outputs.body_path }}
-          prerelease: ${{ steps.prepare.outputs.is_beta }}
+          TAG_NAME: ${{ steps.configure.outputs.tag }}
+          TARGET: ${{ steps.configure.outputs.sha }}
+          RELEASE_NAME: ${{ steps.prepare.outputs.title }}
+          BODY_PATH: ${{ steps.prepare.outputs.body_path }}
+          PRERELEASE: ${{ steps.prepare.outputs.is_beta }}
         run: |
           args=()
-          [[ $prerelease == yes ]] && args+=(--prerelease)
+          [[ $PRERELEASE == yes ]] && args+=(--prerelease)
 
-          gh release create "$tag_name" --verify-tag --draft "${args[@]}" \
-            --target "$target" \
-            --title "$release_name" \
-            --notes-file "$body_path"
+          gh release create "$TAG_NAME" --verify-tag --draft "${args[@]}" \
+            --target "$TARGET" \
+            --title "$RELEASE_NAME" \
+            --notes-file "$BODY_PATH"
 
   build-linux:
     strategy:
@@ -188,18 +188,18 @@ jobs:
         shell: bash
         env:
           SUFFIX: '-${{ matrix.distro }}${{ matrix.version }}'
-          package: '${{ matrix.package }}'
-          server_only: '${{ matrix.server_only }}'
+          PACKAGE: '${{ matrix.package }}'
+          SERVER_ONLY: '${{ matrix.server_only }}'
         run: |
           source .ci/docker.sh
           args=()
-          [[ $server_only == yes ]] && args+=(--no-client)
+          [[ $SERVER_ONLY == yes ]] && args+=(--no-client)
           [[ $GITHUB_REF == "refs/heads/master" ]] && args+=(--evict-ccache "$CCACHE_EVICTION_AGE")
           args+=(--ccache "$CCACHE_SIZE")
           args+=(--cmake-generator "$CMAKE_GENERATOR")
           args+=(--suffix "$SUFFIX")
 
-          RUN --server --release --package "$package" "${args[@]}"
+          RUN --server --release --package "$PACKAGE" "${args[@]}"
 
       # Delete used cache to emulate a ccache update. See https://github.com/actions/cache/issues/342
       - name: "Delete remote compiler cache (ccache)"
@@ -234,11 +234,11 @@ jobs:
         if: matrix.package != 'skip' && needs.configure.outputs.tag != null
         shell: bash
         env:
-          asset_name: ${{ steps.build.outputs.fullname }}
-          asset_path: ${{ steps.build.outputs.path }}
+          ASSET_NAME: ${{ steps.build.outputs.fullname }}
+          ASSET_PATH: ${{ steps.build.outputs.path }}
           GH_TOKEN: ${{ github.token }}
-          tag_name: ${{ needs.configure.outputs.tag }}
-        run: gh release upload "$tag_name" "$asset_path#$asset_name"
+          TAG_NAME: ${{ needs.configure.outputs.tag }}
+        run: gh release upload "$TAG_NAME" "$ASSET_PATH#$ASSET_NAME"
 
       - name: "Attest binary provenance"
         id: attestation
@@ -550,11 +550,11 @@ jobs:
         id: upload_release
         shell: bash
         env:
-          asset_name: ${{ steps.build.outputs.fullname }}
-          asset_path: ${{ steps.build.outputs.path }}
+          ASSET_NAME: ${{ steps.build.outputs.fullname }}
+          ASSET_PATH: ${{ steps.build.outputs.path }}
           GH_TOKEN: ${{ github.token }}
-          tag_name: ${{ needs.configure.outputs.tag }}
-        run: gh release upload "$tag_name" "$asset_path#$asset_name"
+          TAG_NAME: ${{ needs.configure.outputs.tag }}
+        run: gh release upload "$TAG_NAME" "$ASSET_PATH#$ASSET_NAME"
 
       - name: "Attest binary provenance"
         if: steps.upload_release.outcome == 'success'

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -456,7 +456,7 @@ jobs:
           TARGET_MACOS_VERSION: ${{ matrix.override_target }}
           USE_CCACHE: ${{ matrix.use_ccache }}
           VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'
-          VCPKG_DISABLE_METRICS: 1
+          VCPKG_DISABLE_METRICS: true
         run: .ci/compile.sh --server --test --vcpkg
 
       # Delete used cache to emulate a ccache update. See https://github.com/actions/cache/issues/342

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -83,7 +83,7 @@ jobs:
           TARGET: ${{ steps.configure.outputs.sha }}
           RELEASE_NAME: ${{ steps.prepare.outputs.title }}
           BODY_PATH: ${{ steps.prepare.outputs.body_path }}
-          PRERELEASE: ${{ steps.prepare.outputs.is_beta }}
+          PRERELEASE: ${{ steps.prepare.outputs.beta }}
         run: |
           args=()
           [[ "$PRERELEASE" == "true" ]] && args+=(--prerelease)

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -86,7 +86,7 @@ jobs:
           PRERELEASE: ${{ steps.prepare.outputs.is_beta }}
         run: |
           args=()
-          [[ $PRERELEASE == yes ]] && args+=(--prerelease)
+          [[ "$PRERELEASE" == "true" ]] && args+=(--prerelease)
 
           gh release create "$TAG_NAME" --verify-tag --draft "${args[@]}" \
             --target "$TARGET" \
@@ -101,14 +101,14 @@ jobs:
         include:
           - distro: Arch
 
-            allow-failure: yes
+            allow-failure: true
             package: skip    # We are packaged in Arch already
 
           - distro: Servatrice_Debian
             version: 12
 
             package: DEB
-            server_only: yes
+            server_only: true
             test: skip
 
           - distro: Debian
@@ -147,7 +147,7 @@ jobs:
     name: ${{ matrix.distro }} ${{ matrix.version }}
     needs: configure
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allow-failure == 'yes' }}
+    continue-on-error: ${{ matrix.allow-failure == 'true' }}
     timeout-minutes: 70
     env:
       CACHE: ${{ github.workspace }}/.cache/${{ matrix.distro }}${{ matrix.version }}    # directory for caching docker image and ccache
@@ -193,8 +193,8 @@ jobs:
         run: |
           source .ci/docker.sh
           args=()
-          [[ $SERVER_ONLY == yes ]] && args+=(--no-client)
-          [[ $GITHUB_REF == "refs/heads/master" ]] && args+=(--evict-ccache "$CCACHE_EVICTION_AGE")
+          [[ "$SERVER_ONLY" == "true" ]] && args+=(--no-client)
+          [[ "$GITHUB_REF" == "refs/heads/master" ]] && args+=(--evict-ccache "$CCACHE_EVICTION_AGE")
           args+=(--ccache "$CCACHE_SIZE")
           args+=(--cmake-generator "$CMAKE_GENERATOR")
           args+=(--suffix "$SUFFIX")
@@ -267,7 +267,7 @@ jobs:
 
             ccache_eviction_age: 7d
             cmake_generator: Ninja
-            make_package: 1
+            make_package: true
             override_target: 13
             package_suffix: "-macOS13_Intel"
             qt_version: 6.11.0
@@ -275,7 +275,7 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             soc: Intel
             type: Release
-            use_ccache: 1
+            use_ccache: true
             xcode: "16.4"
 
           - os: macOS
@@ -284,14 +284,14 @@ jobs:
 
             ccache_eviction_age: 7d
             cmake_generator: Ninja
-            make_package: 1
+            make_package: true
             package_suffix: "-macOS14"
             qt_version: 6.11.0
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             soc: Apple
             type: Release
-            use_ccache: 1
+            use_ccache: true
             xcode: "15.4"
 
           - os: macOS
@@ -300,14 +300,14 @@ jobs:
 
             ccache_eviction_age: 7d
             cmake_generator: Ninja
-            make_package: 1
+            make_package: true
             package_suffix: "-macOS15"
             qt_version: 6.11.0
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             soc: Apple
             type: Release
-            use_ccache: 1
+            use_ccache: true
             xcode: "16.4"
 
           - os: macOS
@@ -321,7 +321,7 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             soc: Apple
             type: Debug
-            use_ccache: 1
+            use_ccache: true
             xcode: "16.4"
 
           - os: Windows
@@ -330,7 +330,7 @@ jobs:
 
             cmake_generator: "Visual Studio 18 2026"
             cmake_generator_platform: x64
-            make_package: 1
+            make_package: true
             package_suffix: "-Win10"
             qt_version: 6.11.0
             qt_arch: win64_msvc2022_64
@@ -359,11 +359,11 @@ jobs:
           msbuild-architecture: x64
 
       - name: "[macOS] Setup ccache"
-        if: matrix.os == 'macOS' && matrix.use_ccache == 1
+        if: matrix.os == 'macOS' && matrix.use_ccache == 'true'
         run: brew install ccache
 
       - name: "[macOS] Restore compiler cache (ccache)"
-        if: matrix.os == 'macOS' && matrix.use_ccache == 1
+        if: matrix.os == 'macOS' && matrix.use_ccache == 'true'
         id: ccache_restore
         uses: actions/cache/restore@v5
         env:
@@ -461,7 +461,7 @@ jobs:
 
       # Delete used cache to emulate a ccache update. See https://github.com/actions/cache/issues/342
       - name: "[macOS] Delete remote compiler cache (ccache)"
-        if: matrix.os == 'macOS' && matrix.use_ccache == 1 && github.ref == 'refs/heads/master' && steps.ccache_restore.outputs.cache-hit
+        if: matrix.os == 'macOS' && matrix.use_ccache == 'true' && github.ref == 'refs/heads/master' && steps.ccache_restore.outputs.cache-hit
         continue-on-error: true
         env:
           CACHE_PRIMARY_KEY: ${{ steps.ccache_restore.outputs.cache-primary-key }}
@@ -472,7 +472,7 @@ jobs:
           fi
 
       - name: "[macOS] Save updated compiler cache (ccache)"
-        if: matrix.os == 'macOS' && matrix.use_ccache == 1 && github.ref == 'refs/heads/master'
+        if: matrix.os == 'macOS' && matrix.use_ccache == 'true' && github.ref == 'refs/heads/master'
         uses: actions/cache/save@v5
         with:
           key: ${{ steps.ccache_restore.outputs.cache-primary-key }}
@@ -546,7 +546,7 @@ jobs:
             build/servatrice/Release/*.pdb
 
       - name: "Upload to release"
-        if: needs.configure.outputs.tag != null && matrix.make_package == '1'
+        if: needs.configure.outputs.tag != null && matrix.make_package == 'true'
         id: upload_release
         shell: bash
         env:

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -144,7 +144,7 @@ jobs:
             package: DEB
             test: true    # run debug build and tests on newest distro version
 
-    name: Linux / ${{ matrix.distro }} / ${{ matrix.distro_version }}
+    name: "Linux / ${{ matrix.distro }} / ${{ matrix.distro_version }}"
     needs: configure
     runs-on: ubuntu-latest    # https://github.com/actions/runner-images/tree/main#available-images
     continue-on-error: ${{ matrix.allow-failure == true }}
@@ -328,7 +328,7 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             type: Release
 
-    name: ${{ matrix.os }} / ${{ matrix.os_target_version }}${{ case(matrix.soc == 'Intel', ' Intel', '') }}${{ case(matrix.type == 'Debug', ' Debug', '') }}
+    name: "${{ matrix.os }} / ${{ matrix.os_target_version }}${{ case(matrix.soc == 'Intel', ' Intel', '') }}${{ case(matrix.type == 'Debug', ' Debug', '') }}"
     needs: configure
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 100

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -368,7 +368,7 @@ jobs:
       # Using jurplel/install-qt-action to install Qt without using brew
       # Qt build using vcpkg either just fails or takes too long to build
       - name: "[macOS] Install fat Qt ${{ steps.resolve_qt_version.outputs.version }}"
-        if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'
+        if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit == ''
         uses: jurplel/install-qt-action@v4
         with:
           arch: ${{ matrix.qt_arch }}
@@ -378,11 +378,11 @@ jobs:
           version: ${{ steps.resolve_qt_version.outputs.version }}
 
       - name: "[macOS] Create thin Qt libraries"
-        if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'
+        if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit == ''
         run: .ci/thin_macos_qtlib.sh
 
       - name: "[macOS] Cache thin Qt libraries"
-        if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'
+        if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit == ''
         uses: actions/cache/save@v6
         with:
           key: thin-qt-macos-${{ matrix.soc }}-${{ steps.resolve_qt_version.outputs.version }}

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -78,12 +78,12 @@ jobs:
         id: create_release
         shell: bash
         env:
+          BODY_PATH: ${{ steps.prepare.outputs.body_path }}
           GH_TOKEN: ${{ github.token }}
+          PRERELEASE: ${{ steps.prepare.outputs.beta }}
+          RELEASE_NAME: ${{ steps.prepare.outputs.title }}
           TAG_NAME: ${{ steps.configure.outputs.tag }}
           TARGET: ${{ steps.configure.outputs.sha }}
-          RELEASE_NAME: ${{ steps.prepare.outputs.title }}
-          BODY_PATH: ${{ steps.prepare.outputs.body_path }}
-          PRERELEASE: ${{ steps.prepare.outputs.beta }}
         run: |
           args=()
           [[ "$PRERELEASE" == "true" ]] && args+=(--prerelease)
@@ -102,47 +102,46 @@ jobs:
           - distro: Arch
 
             allow-failure: true
-            package: false    # We are packaged in Arch already
+            test: true    # run debug build and tests
 
           - distro: Servatrice_Debian
             version: 12
 
             package: DEB
             server_only: true
-            test: false
 
           - distro: Debian
             version: 12
 
             package: DEB
-            test: false    # Running tests on all distros is superfluous
 
           - distro: Debian
             version: 13
 
             package: DEB
+            test: true    # run debug build and tests on newest distro version
 
           - distro: Fedora
             version: 43
 
             package: RPM
-            test: false    # Running tests on all distros is superfluous
 
           - distro: Fedora
             version: 44
 
             package: RPM
+            test: true    # run debug build and tests on newest distro version
 
           - distro: Ubuntu
             version: 24.04
 
             package: DEB
-            test: false    # Running tests on all distros is superfluous
 
           - distro: Ubuntu
             version: 26.04
 
             package: DEB
+            test: true    # run debug build and tests on newest distro version
 
     name: ${{ matrix.distro }} ${{ matrix.version }}
     needs: configure
@@ -150,7 +149,7 @@ jobs:
     continue-on-error: ${{ matrix.allow-failure == true }}
     timeout-minutes: 70
     env:
-      CACHE: ${{ github.workspace }}/.cache/${{ matrix.distro }}${{ matrix.version }}    # directory for caching docker image and ccache
+      CACHE_DIR: ${{ github.workspace }}/.cache/${{ matrix.distro }}${{ matrix.version }}    # directory for caching docker image and ccache
       CCACHE_EVICTION_AGE: 7d
       CCACHE_SIZE: 550M    # space of all repo is 10Gi: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
       CMAKE_GENERATOR: 'Ninja'
@@ -167,7 +166,7 @@ jobs:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         with:
           key: ccache-${{ matrix.distro }}${{ matrix.version }}-${{ env.BRANCH_NAME }}
-          path: ${{ env.CACHE }}
+          path: ${{ env.CACHE_DIR }}
           restore-keys: ccache-${{ matrix.distro }}${{ matrix.version }}-
 
       - name: "Build ${{ matrix.distro }} ${{ matrix.version }} Docker image"
@@ -175,7 +174,7 @@ jobs:
         run: source .ci/docker.sh --build
 
       - name: "Build debug and test"
-        if: matrix.test != false
+        if: matrix.test == true
         shell: bash
         run: |
           source .ci/docker.sh
@@ -184,12 +183,12 @@ jobs:
 
       - name: "Build release package"
         id: build
-        if: matrix.package != false
+        if: matrix.package
         shell: bash
         env:
-          SUFFIX: '-${{ matrix.distro }}${{ matrix.version }}'
           PACKAGE: '${{ matrix.package }}'
           SERVER_ONLY: '${{ matrix.server_only }}'
+          SUFFIX: '-${{ matrix.distro }}${{ matrix.version }}'
         run: |
           source .ci/docker.sh
           args=()
@@ -218,11 +217,11 @@ jobs:
         uses: actions/cache/save@v6
         with:
           key: ${{ steps.ccache_restore.outputs.cache-primary-key }}
-          path: ${{ env.CACHE }}
+          path: ${{ env.CACHE_DIR }}
 
       - name: "Upload artifact"
         id: upload_artifact
-        if: matrix.package != false
+        if: matrix.package
         uses: actions/upload-artifact@v7
         with:
           archive: false
@@ -231,7 +230,7 @@ jobs:
 
       - name: "Upload to release"
         id: upload_release
-        if: matrix.package != false && needs.configure.outputs.tag != null
+        if: matrix.package && needs.configure.outputs.tag != null
         shell: bash
         env:
           ASSET_NAME: ${{ steps.build.outputs.fullname }}
@@ -265,7 +264,6 @@ jobs:
             target: 13
             runner: macos-15-intel
 
-            ccache_eviction_age: 7d
             cmake_generator: Ninja
             make_package: true
             override_target: 13
@@ -282,7 +280,6 @@ jobs:
             target: 14
             runner: macos-14
 
-            ccache_eviction_age: 7d
             cmake_generator: Ninja
             make_package: true
             package_suffix: "-macOS14"
@@ -298,7 +295,6 @@ jobs:
             target: 15
             runner: macos-15
 
-            ccache_eviction_age: 7d
             cmake_generator: Ninja
             make_package: true
             package_suffix: "-macOS15"
@@ -314,7 +310,6 @@ jobs:
             target: 15
             runner: macos-15
 
-            ccache_eviction_age: 7d
             cmake_generator: Ninja
             qt_version: 6.11.0
             qt_arch: clang_64
@@ -343,6 +338,7 @@ jobs:
     timeout-minutes: 100
     env:
       CCACHE_DIR: ${{ github.workspace }}/.cache/
+      CCACHE_EVICTION_AGE: 7d
       CCACHE_SIZE: 550M    # space of all repo is 10Gi: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
 
     steps:
@@ -479,7 +475,7 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
 
       - name: "[macOS] Sign app bundle"
-        if: matrix.os == 'macOS' && matrix.make_package && needs.configure.outputs.tag != null
+        if: matrix.os == 'macOS' && matrix.make_package == true && needs.configure.outputs.tag != null
         id: sign_macos
         env:
           BUILD_PATH: ${{ steps.build.outputs.path }}
@@ -526,7 +522,7 @@ jobs:
           fi
 
       - name: "Upload artifact"
-        if: matrix.make_package
+        if: matrix.make_package == true
         id: upload_artifact
         uses: actions/upload-artifact@v7
         with:
@@ -546,7 +542,7 @@ jobs:
             build/servatrice/Release/*.pdb
 
       - name: "Upload to release"
-        if: needs.configure.outputs.tag != null && matrix.make_package == true
+        if: matrix.make_package == true && needs.configure.outputs.tag != null
         id: upload_release
         shell: bash
         env:

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -42,7 +42,7 @@ concurrency:
 jobs:
   configure:
     name: Configure
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-slim    # https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md
     outputs:
       tag: ${{ steps.configure.outputs.tag }}
       sha: ${{ steps.configure.outputs.sha }}
@@ -146,7 +146,7 @@ jobs:
 
     name: ${{ matrix.distro }} ${{ matrix.distro_version }}
     needs: configure
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest    # https://github.com/actions/runner-images/tree/main#available-images
     continue-on-error: ${{ matrix.allow-failure == true }}
     timeout-minutes: 70
     env:
@@ -201,7 +201,7 @@ jobs:
 
           RUN --server --release --package "$PACKAGE" "${args[@]}"
 
-      # Delete used cache to emulate a ccache update. See https://github.com/actions/cache/issues/342
+      # Delete used cache on exact hit (true) to emulate a ccache update. See https://github.com/actions/cache/issues/342
       - name: "Delete remote compiler cache (ccache)"
         if: github.ref == 'refs/heads/master' && steps.ccache_restore.outputs.cache-hit == 'true'
         continue-on-error: true
@@ -263,7 +263,7 @@ jobs:
         include:
           - os: macOS
             os_target_version: 13
-            runner: macos-15-intel
+            runner: macos-15-intel    # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
 
             cmake_generator: Ninja
             make_package: true
@@ -273,11 +273,11 @@ jobs:
             soc: Intel
             type: Release
             use_ccache: true
-            xcode: 16.4
+            xcode: 26.3
 
           - os: macOS
             os_target_version: 14
-            runner: macos-14
+            runner: macos-14    # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
 
             cmake_generator: Ninja
             make_package: true
@@ -287,11 +287,11 @@ jobs:
             soc: Apple
             type: Release
             use_ccache: true
-            xcode: 15.4
+            xcode: 16.2
 
           - os: macOS
             os_target_version: 15
-            runner: macos-15
+            runner: macos-15    # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md
 
             cmake_generator: Ninja
             make_package: true
@@ -301,11 +301,11 @@ jobs:
             soc: Apple
             type: Release
             use_ccache: true
-            xcode: 16.4
+            xcode: 26.3
 
           - os: macOS
             os_target_version: 15
-            runner: macos-15
+            runner: macos-15    # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md
 
             cmake_generator: Ninja
             qt_version: 6.11.0
@@ -314,11 +314,11 @@ jobs:
             soc: Apple
             type: Debug
             use_ccache: true
-            xcode: 16.4
+            xcode: 26.3
 
           - os: Windows
             os_target_version: 10
-            runner: windows-2025
+            runner: windows-2025    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
 
             cmake_generator: Visual Studio 18 2026
             cmake_generator_platform: x64
@@ -363,7 +363,7 @@ jobs:
         id: restore_qt
         uses: actions/cache/restore@v6
         with:
-          key: thin-qt-macos-${{ matrix.soc }}-${{ steps.resolve_qt_version.outputs.version }}
+          key: Qt-${{ steps.resolve_qt_version.outputs.version }}-macOS${{ case(matrix.soc == 'Intel', '-Intel', '') }}-thin
           path: ${{ github.workspace }}/Qt
 
       # Using jurplel/install-qt-action to install Qt without using brew
@@ -386,7 +386,7 @@ jobs:
         if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit == ''
         uses: actions/cache/save@v6
         with:
-          key: thin-qt-macos-${{ matrix.soc }}-${{ steps.resolve_qt_version.outputs.version }}
+          key: Qt-${{ steps.resolve_qt_version.outputs.version }}-macOS${{ case(matrix.soc == 'Intel', '-Intel', '') }}-thin
           path: ${{ github.workspace }}/Qt
 
       - name: "[Windows] Install NSIS"
@@ -425,9 +425,9 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         with:
-          key: ccache-${{ matrix.runner }}-${{ matrix.soc }}-${{ matrix.type }}-${{ env.BRANCH_NAME }}
+          key: ccache-${{ matrix.os }}${{ matrix.os_target_version }}${{ case(matrix.soc == 'Intel', '-Intel', '') }}-${{ matrix.type }}-${{ env.BRANCH_NAME }}
           path: ${{ env.CCACHE_DIR }}
-          restore-keys: ccache-${{ matrix.runner }}-${{ matrix.soc }}-${{ matrix.type }}-
+          restore-keys: ccache-${{ matrix.os }}${{ matrix.os_target_version }}${{ case(matrix.soc == 'Intel', '-Intel', '') }}-${{ matrix.type }}-
 
       # Uses environment variables, see compile.sh for more details
       - name: "Build Cockatrice"

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -87,6 +87,7 @@ jobs:
         run: |
           args=()
           [[ "$PRERELEASE" == "true" ]] && args+=(--prerelease)
+          [[ "$PRERELEASE" == "false" ]] && args+=(--latest)
 
           gh release create "$TAG_NAME" --verify-tag --draft "${args[@]}" \
             --target "$TARGET" \

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -152,7 +152,7 @@ jobs:
       CACHE_DIR: ${{ github.workspace }}/.cache/${{ matrix.distro }}${{ matrix.distro_version }}    # directory for caching docker image and ccache
       CCACHE_EVICTION_AGE: 7d
       CCACHE_SIZE: 550M    # space of all repo is 10Gi: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
-      CMAKE_GENERATOR: 'Ninja'
+      CMAKE_GENERATOR: Ninja
       NAME: ${{ matrix.distro }}${{ matrix.distro_version }}
 
     steps:
@@ -186,17 +186,17 @@ jobs:
         if: matrix.package
         shell: bash
         env:
-          PACKAGE: '${{ matrix.package }}'
-          SERVER_ONLY: '${{ matrix.server_only }}'
-          SUFFIX: '-${{ matrix.distro }}${{ matrix.distro_version }}'
+          PACKAGE: ${{ matrix.package }}
+          PACKAGE_SUFFIX: -${{ matrix.distro }}${{ matrix.distro_version }}
+          SERVER_ONLY: ${{ matrix.server_only }}
         run: |
           source .ci/docker.sh
           args=()
-          [[ "$SERVER_ONLY" == "true" ]] && args+=(--no-client)
           [[ "$GITHUB_REF" == "refs/heads/master" ]] && args+=(--evict-ccache "$CCACHE_EVICTION_AGE")
+          [[ "$SERVER_ONLY" == "true" ]] && args+=(--no-client)
           args+=(--ccache "$CCACHE_SIZE")
           args+=(--cmake-generator "$CMAKE_GENERATOR")
-          args+=(--suffix "$SUFFIX")
+          args+=(--suffix "$PACKAGE_SUFFIX")
 
           RUN --server --release --package "$PACKAGE" "${args[@]}"
 
@@ -438,7 +438,7 @@ jobs:
         id: build
         shell: bash
         env:
-          BUILDTYPE: '${{ matrix.type }}'
+          BUILDTYPE: ${{ matrix.type }}
           CMAKE_GENERATOR: ${{ matrix.cmake_generator }}
           CMAKE_GENERATOR_PLATFORM: ${{ matrix.cmake_generator_platform }}
           DEVELOPER_DIR: '/Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer'
@@ -446,8 +446,8 @@ jobs:
           MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
-          MAKE_PACKAGE: '${{ matrix.make_package }}'
-          PACKAGE_SUFFIX: '${{ matrix.package_suffix }}'
+          MAKE_PACKAGE: ${{ matrix.make_package }}
+          PACKAGE_SUFFIX: ${{ matrix.package_suffix }}
           TARGET_MACOS_VERSION: ${{ matrix.override_target }}
           USE_CCACHE: ${{ matrix.use_ccache }}
           VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -149,11 +149,11 @@ jobs:
     continue-on-error: ${{ matrix.allow-failure == true }}
     timeout-minutes: 70
     env:
+      BUILD_REFERENCE: ${{ matrix.distro }}${{ matrix.distro_version }}
       CACHE_DIR: ${{ github.workspace }}/.cache/${{ matrix.distro }}${{ matrix.distro_version }}    # directory for caching docker image and ccache
       CCACHE_EVICTION_AGE: 7d
       CCACHE_SIZE: 550M    # space of all repo is 10Gi: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
       CMAKE_GENERATOR: Ninja
-      BUILD_REFERENCE: ${{ matrix.distro }}${{ matrix.distro_version }}
 
     steps:
       - name: "Checkout"
@@ -273,7 +273,7 @@ jobs:
             soc: Intel
             type: Release
             use_ccache: true
-            xcode: "16.4"
+            xcode: 16.4
 
           - os: macOS
             os_target_version: 14
@@ -287,7 +287,7 @@ jobs:
             soc: Apple
             type: Release
             use_ccache: true
-            xcode: "15.4"
+            xcode: 15.4
 
           - os: macOS
             os_target_version: 15
@@ -301,7 +301,7 @@ jobs:
             soc: Apple
             type: Release
             use_ccache: true
-            xcode: "16.4"
+            xcode: 16.4
 
           - os: macOS
             os_target_version: 15
@@ -314,13 +314,13 @@ jobs:
             soc: Apple
             type: Debug
             use_ccache: true
-            xcode: "16.4"
+            xcode: 16.4
 
           - os: Windows
             os_target_version: 10
             runner: windows-2025
 
-            cmake_generator: "Visual Studio 18 2026"
+            cmake_generator: Visual Studio 18 2026
             cmake_generator_platform: x64
             make_package: true
             qt_version: 6.11.0

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -416,7 +416,7 @@ jobs:
         id: vcpkg-cache
         uses: TAServers/vcpkg-cache@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
 
       - name: "[macOS] Restore compiler cache (ccache)"
         if: matrix.os == 'macOS' && matrix.use_ccache == true

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -187,7 +187,7 @@ jobs:
         shell: bash
         env:
           PACKAGE: ${{ matrix.package }}
-          PACKAGE_SUFFIX: -${{ matrix.distro }}${{ matrix.distro_version }}
+          PACKAGE_SUFFIX: "-${{ matrix.distro }}${{ matrix.distro_version }}"
           SERVER_ONLY: ${{ matrix.server_only }}
         run: |
           source .ci/docker.sh
@@ -437,16 +437,16 @@ jobs:
           BUILDTYPE: ${{ matrix.type }}
           CMAKE_GENERATOR: ${{ matrix.cmake_generator }}
           CMAKE_GENERATOR_PLATFORM: ${{ matrix.cmake_generator_platform }}
-          DEVELOPER_DIR: '/Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer'
+          DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer"
           MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
           MAKE_PACKAGE: ${{ matrix.make_package }}
-          PACKAGE_SUFFIX: '-${{ matrix.os }}${{ matrix.os_target_version }}${{ case(matrix.soc == 'Intel', '_Intel', '') }}'
+          PACKAGE_SUFFIX: "-${{ matrix.os }}${{ matrix.os_target_version }}${{ case(matrix.soc == 'Intel', '_Intel', '') }}"
           TARGET_MACOS_VERSION: ${{ matrix.override_target }}
           USE_CCACHE: ${{ matrix.use_ccache }}
-          VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'
+          VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
           VCPKG_DISABLE_METRICS: true
         run: .ci/compile.sh --server --test --vcpkg
 

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -266,7 +266,6 @@ jobs:
 
             cmake_generator: Ninja
             make_package: true
-            override_target: 13
             qt_version: 6.11.0
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
@@ -444,7 +443,7 @@ jobs:
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
           MAKE_PACKAGE: ${{ matrix.make_package }}
           PACKAGE_SUFFIX: "-${{ matrix.os }}${{ matrix.os_target_version }}${{ case(matrix.soc == 'Intel', '_Intel', '') }}"
-          TARGET_MACOS_VERSION: ${{ matrix.override_target }}
+          TARGET_MACOS_VERSION: ${{ matrix.os_target_version }}
           USE_CCACHE: ${{ matrix.use_ccache }}
           VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
           VCPKG_DISABLE_METRICS: true

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -60,21 +60,21 @@ jobs:
           echo "sha=$RESOLVED_SHA" >> "$GITHUB_OUTPUT"
 
       - name: "Checkout"
-        if: steps.configure.outputs.tag != null
+        if: steps.configure.outputs.tag
         uses: actions/checkout@v7
         with:
           fetch-depth: 0    # fetch all history for all branches and tags
 
       - name: "Prepare release parameters"
         id: prepare
-        if: steps.configure.outputs.tag != null
+        if: steps.configure.outputs.tag
         shell: bash
         env:
           TAG: ${{ steps.configure.outputs.tag }}
         run: .ci/prep_release.sh
 
       - name: "Create release"
-        if: steps.configure.outputs.tag != null
+        if: steps.configure.outputs.tag
         id: create_release
         shell: bash
         env:
@@ -202,7 +202,7 @@ jobs:
 
       # Delete used cache to emulate a ccache update. See https://github.com/actions/cache/issues/342
       - name: "Delete remote compiler cache (ccache)"
-        if: github.ref == 'refs/heads/master' && steps.ccache_restore.outputs.cache-hit
+        if: github.ref == 'refs/heads/master' && steps.ccache_restore.outputs.cache-hit == 'true'
         continue-on-error: true
         env:
           CACHE_PRIMARY_KEY: ${{ steps.ccache_restore.outputs.cache-primary-key }}
@@ -230,7 +230,7 @@ jobs:
 
       - name: "Upload to release"
         id: upload_release
-        if: matrix.package && needs.configure.outputs.tag != null
+        if: matrix.package && needs.configure.outputs.tag
         shell: bash
         env:
           ASSET_NAME: ${{ steps.build.outputs.fullname }}
@@ -452,7 +452,7 @@ jobs:
 
       # Delete used cache to emulate a ccache update. See https://github.com/actions/cache/issues/342
       - name: "[macOS] Delete remote compiler cache (ccache)"
-        if: matrix.os == 'macOS' && matrix.use_ccache == true && github.ref == 'refs/heads/master' && steps.ccache_restore.outputs.cache-hit
+        if: matrix.os == 'macOS' && matrix.use_ccache == true && github.ref == 'refs/heads/master' && steps.ccache_restore.outputs.cache-hit == 'true'
         continue-on-error: true
         env:
           CACHE_PRIMARY_KEY: ${{ steps.ccache_restore.outputs.cache-primary-key }}
@@ -470,7 +470,7 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
 
       - name: "[macOS] Sign app bundle"
-        if: matrix.os == 'macOS' && matrix.make_package == true && needs.configure.outputs.tag != null
+        if: matrix.os == 'macOS' && matrix.make_package == true && needs.configure.outputs.tag
         id: sign_macos
         env:
           BUILD_PATH: ${{ steps.build.outputs.path }}
@@ -537,7 +537,7 @@ jobs:
             build/servatrice/Release/*.pdb
 
       - name: "Upload to release"
-        if: matrix.make_package == true && needs.configure.outputs.tag != null
+        if: matrix.make_package == true && needs.configure.outputs.tag
         id: upload_release
         shell: bash
         env:

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -443,7 +443,7 @@ jobs:
           MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
           MAKE_PACKAGE: ${{ matrix.make_package }}
-          PACKAGE_SUFFIX: "-${{ matrix.os }}${{ matrix.os_target_version }}${{ case(matrix.soc == 'Intel', '_Intel', '') }}"
+          PACKAGE_SUFFIX: "-${{ matrix.os }}${{ matrix.os_target_version }}${{ case(matrix.soc == 'Intel', '_Intel', '') }}+"
           TARGET_MACOS_VERSION: ${{ matrix.os_target_version }}
           USE_CCACHE: ${{ matrix.use_ccache }}
           VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -144,7 +144,7 @@ jobs:
             package: DEB
             test: true    # run debug build and tests on newest distro version
 
-    name: ${{ matrix.distro }} ${{ matrix.distro_version }}
+    name: Linux / ${{ matrix.distro }} / ${{ matrix.distro_version }}
     needs: configure
     runs-on: ubuntu-latest    # https://github.com/actions/runner-images/tree/main#available-images
     continue-on-error: ${{ matrix.allow-failure == true }}
@@ -328,7 +328,7 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             type: Release
 
-    name: ${{ matrix.os }} ${{ matrix.os_target_version }}${{ case(matrix.soc == 'Intel', ' Intel', '') }}${{ case(matrix.type == 'Debug', ' Debug', '') }}
+    name: ${{ matrix.os }} / ${{ matrix.os_target_version }}${{ case(matrix.soc == 'Intel', ' Intel', '') }}${{ case(matrix.type == 'Debug', ' Debug', '') }}
     needs: configure
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 100

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The files in ".ci/$distro$distro_version" correspond to the values given here
+        # The files in ".ci/$BUILD_REFERENCE" correspond to the values given here
         include:
           - distro: Arch
 
@@ -153,7 +153,7 @@ jobs:
       CCACHE_EVICTION_AGE: 7d
       CCACHE_SIZE: 550M    # space of all repo is 10Gi: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
       CMAKE_GENERATOR: Ninja
-      NAME: ${{ matrix.distro }}${{ matrix.distro_version }}
+      BUILD_REFERENCE: ${{ matrix.distro }}${{ matrix.distro_version }}
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -267,7 +267,6 @@ jobs:
             cmake_generator: Ninja
             make_package: true
             override_target: 13
-            package_suffix: "-macOS13_Intel"
             qt_version: 6.11.0
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
@@ -282,7 +281,6 @@ jobs:
 
             cmake_generator: Ninja
             make_package: true
-            package_suffix: "-macOS14"
             qt_version: 6.11.0
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
@@ -297,7 +295,6 @@ jobs:
 
             cmake_generator: Ninja
             make_package: true
-            package_suffix: "-macOS15"
             qt_version: 6.11.0
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
@@ -326,7 +323,6 @@ jobs:
             cmake_generator: "Visual Studio 18 2026"
             cmake_generator_platform: x64
             make_package: true
-            package_suffix: "-Win10"
             qt_version: 6.11.0
             qt_arch: win64_msvc2022_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
@@ -447,7 +443,7 @@ jobs:
           MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
           MAKE_PACKAGE: ${{ matrix.make_package }}
-          PACKAGE_SUFFIX: ${{ matrix.package_suffix }}
+          PACKAGE_SUFFIX: '-${{ matrix.os }}${{ matrix.os_target_version }}${{ case(matrix.soc == 'Intel', '_Intel', '') }}'
           TARGET_MACOS_VERSION: ${{ matrix.override_target }}
           USE_CCACHE: ${{ matrix.use_ccache }}
           VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -347,27 +347,9 @@ jobs:
         with:
           submodules: recursive
 
-      - name: "[Windows] Add msbuild to PATH"
-        if: matrix.os == 'Windows'
-        id: add-msbuild
-        uses: microsoft/setup-msbuild@v3
-        with:
-          msbuild-architecture: x64
-
-      - name: "[macOS] Setup ccache"
+      - name: "[macOS] Install ccache"
         if: matrix.os == 'macOS' && matrix.use_ccache == true
         run: brew install ccache
-
-      - name: "[macOS] Restore compiler cache (ccache)"
-        if: matrix.os == 'macOS' && matrix.use_ccache == true
-        id: ccache_restore
-        uses: actions/cache/restore@v6
-        env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-        with:
-          key: ccache-${{ matrix.runner }}-${{ matrix.soc }}-${{ matrix.type }}-${{ env.BRANCH_NAME }}
-          path: ${{ env.CCACHE_DIR }}
-          restore-keys: ccache-${{ matrix.runner }}-${{ matrix.soc }}-${{ matrix.type }}-
 
       - name: "Install aqtinstall"
         run: pipx install aqtinstall
@@ -411,6 +393,11 @@ jobs:
           key: thin-qt-macos-${{ matrix.soc }}-${{ steps.resolve_qt_version.outputs.version }}
           path: ${{ github.workspace }}/Qt
 
+      - name: "[Windows] Install NSIS"
+        if: matrix.os == 'Windows'
+        shell: bash
+        run: choco install nsis
+
       - name: "[Windows] Install Qt ${{ matrix.qt_version }}"
         if: matrix.os == 'Windows'
         uses: jurplel/install-qt-action@v4
@@ -422,16 +409,29 @@ jobs:
           modules: ${{ matrix.qt_modules }}
           version: ${{ steps.resolve_qt_version.outputs.version }}
 
-      - name: "[Windows] Install NSIS"
+      - name: "[Windows] Setup MSBuild"
         if: matrix.os == 'Windows'
-        shell: bash
-        run: choco install nsis
+        id: add-msbuild
+        uses: microsoft/setup-msbuild@v3
+        with:
+          msbuild-architecture: x64
 
       - name: "Setup vcpkg cache"
         id: vcpkg-cache
         uses: TAServers/vcpkg-cache@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "[macOS] Restore compiler cache (ccache)"
+        if: matrix.os == 'macOS' && matrix.use_ccache == true
+        id: ccache_restore
+        uses: actions/cache/restore@v6
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        with:
+          key: ccache-${{ matrix.runner }}-${{ matrix.soc }}-${{ matrix.type }}-${{ env.BRANCH_NAME }}
+          path: ${{ env.CCACHE_DIR }}
+          restore-keys: ccache-${{ matrix.runner }}-${{ matrix.soc }}-${{ matrix.type }}-
 
       # Uses environment variables, see compile.sh for more details
       - name: "Build Cockatrice"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -5,15 +5,15 @@ permissions:
   packages: write
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
     paths:
       - '.github/workflows/docker-release.yml'
       - 'Dockerfile'
+  push:
+    branches:
+      - master
   release:
     types:
       - released    # publishing of stable releases

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,4 +1,4 @@
-name: Build Docker Image
+name: Build Docker
 
 permissions:
   contents: read
@@ -26,9 +26,9 @@ concurrency:
 jobs:
   docker:
     name: amd64 & arm64
-    if: ${{ github.repository_owner == 'Cockatrice' }}
+    if: github.repository_owner == 'Cockatrice'
     runs-on: ubuntu-latest
-  
+
     steps:
       - name: "Checkout"
         uses: actions/checkout@v7

--- a/cockatrice/src/client/network/update/client/release_channel.cpp
+++ b/cockatrice/src/client/network/update/client/release_channel.cpp
@@ -79,9 +79,9 @@ bool ReleaseChannel::downloadMatchesCurrentOS(const QString &fileName)
 #elif Q_PROCESSOR_WORDSIZE == 8
     const QString &version = QSysInfo::productVersion();
     if (version.startsWith("7") || version.startsWith("8")) {
-        return fileName.contains("Win7");
+        return fileName.contains("Win7") || fileName.contains("Windows7");
     } else {
-        return fileName.contains("Win10");
+        return fileName.contains("Win10") || fileName.contains("Windows10");
     }
 #else
     Q_UNUSED(fileName);


### PR DESCRIPTION
## Short roundup of the initial problem
- Mixed usage of yes/no, 1/0 and true/false
- Some environment variables were not UPPER_CASE styled in `env:` sections
- *prep_release* script used `is_beta` and `no_beta`

## What will change with this Pull Request?
**desktop-build.yml**
- Uniform use of true/false terms in workflow configs
  - Options for running tests & debug builds, as well as creating packages used to be "skip" etc.
  - compile.sh script is unchanged and still uses 1/0 instead true/false
- Change defined env vars to use all caps
- Use new case() expression consistently over GitHub's ternary evaluation
- More sorting and renames, e.g.
  - Use same `PACKAGE_SUFFIX` env var name across all OS and build jobs
  - Rename gerneric "version" and "target" values
  - Rename generic "NAME" env var
- More cleanup and simplifications, e.g.
  - Dedicated "override version" value on Mac was redundant (use existing "target os" to set min OS)
- Various updates, e.g.
  - Xcode versions (not Xcode SDK determines supported min OS version, but the defined variable)
- More uniform use of quotes ~
  - Double quotes when there are not only ${{ }}, or expressions with potential single quotes inside
  - Single quotes when conditions are matched against strings
  - No quotes for normal strings
  - Indicate that Windows and macOS binaries can be used on newer OS versions without issues
    (updater compatible with naming? page scripts?)

**prep_release.sh**
- Combine "is_beta" and "no_beta" into "beta=true/false", always assign it and check against its value
- The regex to identify beta releases checks now for "-beta" instead "beta" to avoid random matches a bit better
  Still not very explicit (could be `^[0-9]+\.[0-9]+\.[0-9]+-beta(\.[2-9][0-9]*)?$`)



**TODO**
change soc to arch or platform
remove "custom" term from pr builds
add runner images links to all workflows
remove soc entry for arm mac
add type to "release-pdb's" name
Check #6958 regarding yaml/strings/quotes conversation
add ccache to codeql run (impact on analysis and quality?), share with linux (ubuntu) build sharing/targeting same version? (check and slim dependencies there potentially, check other dockerfiles for e.g. servatrice and the linux pipeline/dockerfiles)
check workflow references in path with new codeql and doc ones
rename docs yml + its job name
add debug build for windows
Introduce debug symbols store (GitHub artifact storage?)
Readme mention main CMakelists file for version checks
add compiler to ccache key
harmonize running of tests: on linux only debug builds run tests, on macos all run them, only windows build (non-debug) runs them as well
"running image:" and "Set cache size limit to 550.0 MB" lines are printed between log groups for some builds - to fix
add verbose option to ccache stats to see special error and uncachable counters (only after compilation and not first step?): https://ccache.dev/manual/latest.html#_cache_statistics
remove custom from non-standard-release-builds (having the hash in the file name is already enough and makes the binary name a good chunk shorter), in particular in places where the pretty printed one with date is used it's very long:
<img width="350" height="55" alt="image" src="https://github.com/user-attachments/assets/95226cb3-e156-423c-9dd4-83fa9079b128" />
reword pdb step and put full name in brackets only (other way around)
fix servatrice naming in ci (related docker folder, job name...)
add comment that evict is needed next to deleting+reuploading cache, otherwise the pulled cache will grow still (and uploaded with the mix of old+new cache) unless build from scratch (not pulling cache at start, which would then not trigger delete step)
Rename workflow to "Build Docs" or "Build Documentation"
more checks on compiler args in workflow config for linux (e.g. suffix, ccache are not checked but always applied - unlike e.g. evict)
Check more narrow cache key using default variables for e.g. ImageVersion of the runner: `${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ runner.arch }}-${{ hashFiles('<lockfile(s)>') }}`
run less debug builds to reduce ccache usage only ubuntu-latest (actually do the same for macos-latest and win-latest to have early checks + failures with new tooling catched, but no need to run on every distro (debian, fedora, ubuntu, arch...) (arch is debug build only and on latest tools, could be our debug check on Linux? Label accordingly)
add generator to ccache key?
change readme and say "main CMakeLists file"
Some "CACHE STRING" value should be "CACHE FILEPATH" (compare vcpkg cmake file)
Remove min cmake req version in great cmake template .in file (seeqt5 cleanup comment) - inline it template configuration tests/cmakelists
"Force enabling CCache usage under macOS" - ccache naming
Use uniform "Found <tool>" and list their version (replace and check [code search](https://github.com/search?q=repo%3ACockatrice%2FCockatrice+%22+at%3A+%22+language%3ACMake&type=code&l=CMake))
Look into [CPACK_PACKAGE_* values](https://cmake.org/cmake/help/latest/module/CPack.html) in main cmakelists file again and check [docs](https://cmake.org/cmake/help/book/mastering-cmake/chapter/Packaging%20With%20CPack.html)
See https://github.com/Cockatrice/Cockatrice/tree/tooomm-ci_if
"install ccache" step name instead "setup ccache"
change "steps.configure.outputs.tag != null" in build desktop workflow to "steps.configure.outputs.tag != ''"?

Consider caching vcpkg manually with actions/cache into a single file than hundred of files via dedicated vcpkg actions
We regularly hit cache rate limits during runs - probably due to the huge amount of individual vcpkg files
Docker layer caches (+buildkit), adjust cache keys?
