### PR TITLE
CI: Use last released aqtinstall again

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -419,8 +419,6 @@ jobs:
         if: matrix.os == 'Windows'
         uses: jurplel/install-qt-action@v4
         with:
-          # Qt 6.11.0 only works with aqtinstall directly from git until aqtinstall 3.4 is released
-          aqtsource: git+https://github.com/miurahr/aqtinstall.git
           arch: ${{ matrix.qt_arch }}
           cache: true
           modules: ${{ matrix.qt_modules }}


### PR DESCRIPTION
> [!CAUTION]
> - [ ] New [aqtinstall 3.4](https://github.com/miurahr/aqtinstall/releases) released upstream
> - [ ] Update this PR from master + fix conflicts
> - [ ] Windows check should turn green --> merge

## Short roundup of the initial problem
This workaround got added to support newer Qt versions on Windows in #6794.
[A fix is already available in the tool](https://github.com/miurahr/aqtinstall/pull/1000), but not yet included in a release.

The maintainer started to prepare a release some time back already, but it did not happen yet. 

## What will change with this Pull Request?
- Use latest released versions of the tool, rather than running bleeding edge master
