### PR TITLE
CI: Use default Qt arch values

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -271,7 +271,6 @@ jobs:
             override_target: 13
             package_suffix: "-macOS13_Intel"
             qt_version: 6.11.0
-            qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             soc: Intel
             type: Release
@@ -287,7 +286,6 @@ jobs:
             make_package: 1
             package_suffix: "-macOS14"
             qt_version: 6.11.0
-            qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             soc: Apple
             type: Release
@@ -303,7 +301,6 @@ jobs:
             make_package: 1
             package_suffix: "-macOS15"
             qt_version: 6.11.0
-            qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             soc: Apple
             type: Release
@@ -317,7 +314,6 @@ jobs:
             ccache_eviction_age: 7d
             cmake_generator: Ninja
             qt_version: 6.11.0
-            qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             soc: Apple
             type: Debug
@@ -333,7 +329,6 @@ jobs:
             make_package: 1
             package_suffix: "-Win10"
             qt_version: 6.11.0
-            qt_arch: win64_msvc2022_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             type: Release
 
@@ -398,7 +393,6 @@ jobs:
         if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'
         uses: jurplel/install-qt-action@v4
         with:
-          arch: ${{ matrix.qt_arch }}
           cache: false
           dir: ${{ github.workspace }}
           modules: ${{ matrix.qt_modules }}
@@ -421,7 +415,6 @@ jobs:
         with:
           # Qt 6.11.0 only works with aqtinstall directly from git until aqtinstall 3.4 is released
           aqtsource: git+https://github.com/miurahr/aqtinstall.git
-          arch: ${{ matrix.qt_arch }}
           cache: true
           modules: ${{ matrix.qt_modules }}
           version: ${{ steps.resolve_qt_version.outputs.version }}


### PR DESCRIPTION
## Short roundup of the initial problem
Default values of the tool were again defined during Qt installation

## What will change with this Pull Request?
- Do not specifically mention values that are used anyway. We had to do this at one point with older versions and when we had 32bit and 64bit builds. Now the defaults are correct for us and picked according to platform and Qt version.

  Simplifies the workflow file a little bit more. Removes something we do not need to worry about. 