### PR TITLE
CI: Fix login+push for publishing Servatrice Docker images

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -57,7 +57,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: "Login to GitHub Container Registry"
-        if: contains(github.event.release.tag_name, 'Release') && github.event.release.target_commitish == 'master'
+        if: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
         uses: docker/login-action@v4
         with:
           password: ${{ github.token }}
@@ -73,5 +73,5 @@ jobs:
           context: .
           labels: ${{ steps.metadata.outputs.labels }}
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.ref_type == 'tag' }}
+          push: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
           tags: ${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: "Login to GitHub Container Registry"
         if: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
+        id: login
         uses: docker/login-action@v4
         with:
           password: ${{ github.token }}
@@ -73,5 +74,5 @@ jobs:
           context: .
           labels: ${{ steps.metadata.outputs.labels }}
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
+          push: ${{ steps.login.outcome == 'success' }}
           tags: ${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -56,8 +56,8 @@ jobs:
       - name: "Set up Docker buildx"
         uses: docker/setup-buildx-action@v4
 
-      - name: "Login to GitHub Container Registry"
-        if: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
+      - name: "Login to GitHub Container Registry (GHCR)"
+        if: github.event_name == 'release' && github.event.release.prerelease == false
         id: login
         uses: docker/login-action@v4
         with:


### PR DESCRIPTION
## Short roundup of the initial problem
Recent releases were not pushing Servatrice images to GHCR.
It turns out the `github.event.release.target_commitish == 'master'` condition is not reliable (maybe changing the workflow trigger from "tag" to "released" full versions did influence this?).
If we ever create releases against a non master branch, that is probably on purpose and we do not need/want to check for that anyway.

The login step was skipped for that reason for recently published full releases, resulting in the following step throwing a permission error when trying to push the image:
```
Error: buildx failed with: ERROR: failed to build: failed to solve: failed to fetch anonymous token: unexpected status from GET request to https://ghcr.io/token?scope=repository%3Acockatrice%2Fservatrice%3Apull%2Cpush&service=ghcr.io: 403 Forbidden
```

`v3.0.1` and `v3.0.2` did not publish a Docker image because of that.

<img width="991" height="770" alt="image" src="https://github.com/user-attachments/assets/09cf022f-248d-4e66-9fe0-101220a34f81" />

## What will change with this Pull Request?
- Double check that we're running on a release, and only a non-prereleases in particular.
  We assume releases will always be created against master.
  This is also a bit more general and does not require a specific wording in the tag.
- ~~Use same condition for login and pushing~~
   --> Evaluate `push` option to `true`, if login is successful
