### PR TITLE
Search by date.

### DIFF
--- a/cockatrice/src/interface/widgets/dialogs/dlg_manage_sets.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_manage_sets.cpp
@@ -62,7 +62,7 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     // search field
     searchField = new LineEditUnfocusable;
     searchField->setObjectName("searchEdit");
-    searchField->setPlaceholderText(tr("Search by set name, code, or type"));
+    searchField->setPlaceholderText(tr("Search by set name, code, type, or release date"));
     searchField->addAction(QPixmap("theme:icons/search"), LineEditUnfocusable::LeadingPosition);
     searchField->setClearButtonEnabled(true);
     setFocusProxy(searchField);

--- a/libcockatrice_models/libcockatrice/models/database/card_set/card_sets_model.cpp
+++ b/libcockatrice_models/libcockatrice/models/database/card_set/card_sets_model.cpp
@@ -303,12 +303,14 @@ bool SetsDisplayModel::filterAcceptsRow(int sourceRow, const QModelIndex &source
     auto typeIndex = sourceModel()->index(sourceRow, SetsModel::SetTypeCol, sourceParent);
     auto nameIndex = sourceModel()->index(sourceRow, SetsModel::LongNameCol, sourceParent);
     auto shortNameIndex = sourceModel()->index(sourceRow, SetsModel::ShortNameCol, sourceParent);
+    auto dateIndex = sourceModel()->index(sourceRow, SetsModel::ReleaseDateCol, sourceParent);
 
     const auto filter = filterRegularExpression();
 
     return (sourceModel()->data(typeIndex).toString().contains(filter) ||
             sourceModel()->data(nameIndex).toString().contains(filter) ||
-            sourceModel()->data(shortNameIndex).toString().contains(filter));
+            sourceModel()->data(shortNameIndex).toString().contains(filter) ||
+            sourceModel()->data(dateIndex).toString().contains(filter));
 }
 
 bool SetsDisplayModel::lessThan(const QModelIndex &left, const QModelIndex &right) const


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3683.

## Short roundup of the initial problem
Somebody wanted to be able to search for sets released during a certain year or on a certain day.

## What will change with this Pull Request?
- Users will be able to search by release date, year, and month of year.
- The text in the search bar will make sure users know this is an option.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<img width="676" height="39" alt="Screenshot 2026-06-29 165926" src="https://github.com/user-attachments/assets/7d6310ec-d2d7-4493-ac28-c80d14aae702" />
<img width="795" height="520" alt="Screenshot 2026-06-29 165938" src="https://github.com/user-attachments/assets/83cee171-5047-4af3-8889-c7c941127b50" />
<img width="795" height="526" alt="Screenshot 2026-06-29 165955" src="https://github.com/user-attachments/assets/518a0c41-cb6e-48fd-ae7c-936b7b9b32ef" />
