### PR TITLE
[Game] Use in-game menu for tally setting

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -97,6 +97,7 @@ set(cockatrice_SOURCES
     src/game_graphics/player/menu/rfg_menu.cpp
     src/game_graphics/player/menu/say_menu.cpp
     src/game_graphics/player/menu/sideboard_menu.cpp
+    src/game_graphics/player/menu/tally_menu.cpp
     src/game_graphics/player/menu/utility_menu.cpp
     src/game_graphics/tally/subtype_tally.cpp
     src/game_graphics/tally/tally.cpp

--- a/cockatrice/src/client/settings/cache_settings.cpp
+++ b/cockatrice/src/client/settings/cache_settings.cpp
@@ -313,7 +313,7 @@ SettingsCache::SettingsCache()
 
     showDragSelectionCount = settings->value("interface/showlassoselectioncount", true).toBool();
     showTotalSelectionCount = settings->value("interface/showpersistentselectioncount", true).toBool();
-    showSubtypeSelectionTally = settings->value("interface/showsubtypeselectiontally", true).toBool();
+    tallyType = settings->value("interface/tallyType", 0).toInt();
 
     showShortcuts = settings->value("menu/showshortcuts", true).toBool();
     showGameSelectorFilterToolbar = settings->value("menu/showgameselectorfiltertoolbar", true).toBool();
@@ -1396,10 +1396,11 @@ void SettingsCache::setShowTotalSelectionCount(QT_STATE_CHANGED_T _showTotalSele
     settings->setValue("interface/showpersistentselectioncount", showTotalSelectionCount);
 }
 
-void SettingsCache::setShowSubtypeSelectionTally(QT_STATE_CHANGED_T _showSubtypeSelectionTally)
+void SettingsCache::setTallyType(TallyType value)
 {
-    showSubtypeSelectionTally = static_cast<bool>(_showSubtypeSelectionTally);
-    settings->setValue("interface/showsubtypeselectiontally", showSubtypeSelectionTally);
+    tallyType = static_cast<int>(value);
+    settings->setValue("interface/tallyType", tallyType);
+    emit tallyTypeChanged(value);
 }
 
 void SettingsCache::loadPaths()

--- a/cockatrice/src/client/settings/cache_settings.cpp
+++ b/cockatrice/src/client/settings/cache_settings.cpp
@@ -1396,10 +1396,14 @@ void SettingsCache::setShowTotalSelectionCount(QT_STATE_CHANGED_T _showTotalSele
     settings->setValue("interface/showpersistentselectioncount", showTotalSelectionCount);
 }
 
-void SettingsCache::setTallyType(TallyType value)
+void SettingsCache::setTallyType(int value)
 {
-    tallyType = static_cast<int>(value);
-    settings->setValue("interface/tallyType", tallyType);
+    if (tallyType == value) {
+        return;
+    }
+
+    tallyType = value;
+    settings->setValue("interface/tallyType", value);
     emit tallyTypeChanged(value);
 }
 

--- a/cockatrice/src/client/settings/cache_settings.h
+++ b/cockatrice/src/client/settings/cache_settings.h
@@ -7,7 +7,6 @@
 #ifndef SETTINGSCACHE_H
 #define SETTINGSCACHE_H
 
-#include "../../game_graphics/tally/tally.h"
 #include "../../interface/card_picture_loader/card_picture_loader_cache_method.h"
 #include "../../interface/card_picture_loader/card_picture_loader_local_schemes.h"
 #include "shortcuts_settings.h"
@@ -198,7 +197,7 @@ signals:
     void useTearOffMenusChanged(bool state);
     void roundCardCornersChanged(bool roundCardCorners);
     void keepGameChatFocusChanged(bool value);
-    void tallyTypeChanged(TallyType type);
+    void tallyTypeChanged(int type);
 
 private:
     QSettings *settings;
@@ -481,9 +480,9 @@ public:
     {
         return showTotalSelectionCount;
     }
-    [[nodiscard]] TallyType getTallyType() const
+    [[nodiscard]] int getTallyType() const
     {
-        return static_cast<TallyType>(tallyType);
+        return tallyType;
     }
     [[nodiscard]] bool getNotificationsEnabled() const
     {
@@ -1183,6 +1182,6 @@ public slots:
     void setRoundCardCorners(bool _roundCardCorners);
     void setShowDragSelectionCount(QT_STATE_CHANGED_T _showDragSelectionCount);
     void setShowTotalSelectionCount(QT_STATE_CHANGED_T _showTotalSelectionCount);
-    void setTallyType(TallyType value);
+    void setTallyType(int value);
 };
 #endif

--- a/cockatrice/src/client/settings/cache_settings.h
+++ b/cockatrice/src/client/settings/cache_settings.h
@@ -7,6 +7,7 @@
 #ifndef SETTINGSCACHE_H
 #define SETTINGSCACHE_H
 
+#include "../../game_graphics/tally/tally.h"
 #include "../../interface/card_picture_loader/card_picture_loader_cache_method.h"
 #include "../../interface/card_picture_loader/card_picture_loader_local_schemes.h"
 #include "shortcuts_settings.h"
@@ -197,6 +198,7 @@ signals:
     void useTearOffMenusChanged(bool state);
     void roundCardCornersChanged(bool roundCardCorners);
     void keepGameChatFocusChanged(bool value);
+    void tallyTypeChanged(TallyType type);
 
 private:
     QSettings *settings;
@@ -355,7 +357,7 @@ private:
     bool showStatusBar;
     bool showDragSelectionCount;
     bool showTotalSelectionCount;
-    bool showSubtypeSelectionTally;
+    int tallyType;
 
 public:
     SettingsCache();
@@ -479,9 +481,9 @@ public:
     {
         return showTotalSelectionCount;
     }
-    [[nodiscard]] bool getShowSubtypeSelectionTally() const
+    [[nodiscard]] TallyType getTallyType() const
     {
-        return showSubtypeSelectionTally;
+        return static_cast<TallyType>(tallyType);
     }
     [[nodiscard]] bool getNotificationsEnabled() const
     {
@@ -1181,6 +1183,6 @@ public slots:
     void setRoundCardCorners(bool _roundCardCorners);
     void setShowDragSelectionCount(QT_STATE_CHANGED_T _showDragSelectionCount);
     void setShowTotalSelectionCount(QT_STATE_CHANGED_T _showTotalSelectionCount);
-    void setShowSubtypeSelectionTally(QT_STATE_CHANGED_T _showSubtypeSelectionTally);
+    void setTallyType(TallyType value);
 };
 #endif

--- a/cockatrice/src/game_graphics/game_view.cpp
+++ b/cockatrice/src/game_graphics/game_view.cpp
@@ -45,6 +45,8 @@ GameView::GameView(GameScene *scene, QWidget *parent) : QGraphicsView(scene, par
     connect(scene, &GameScene::sigResizeRubberBand, this, &GameView::resizeRubberBand);
     connect(scene, &GameScene::sigStopRubberBand, this, &GameView::stopRubberBand);
     connect(scene, &QGraphicsScene::selectionChanged, this, [this]() { updateTotalSelectionCount(); });
+    connect(&SettingsCache::instance(), &SettingsCache::tallyTypeChanged, this,
+            [this] { updateTotalSelectionCount(); });
 
     setFocusDisabled(SettingsCache::instance().getKeepGameChatFocus());
     connect(&SettingsCache::instance(), &SettingsCache::keepGameChatFocusChanged, this, &GameView::setFocusDisabled);
@@ -246,8 +248,7 @@ void GameView::updateTotalSelectionCount(const QSize &viewSize)
         totalCountLabel->show();
     }
 
-    TallyType tallyType =
-        SettingsCache::instance().getShowSubtypeSelectionTally() ? TallyType::Subtypes : TallyType::None;
+    TallyType tallyType = SettingsCache::instance().getTallyType();
 
     GameScene *gameScene = static_cast<GameScene *>(scene());
     QList<TallyRow> entries = Tally::compute(gameScene->selectedCards(), tallyType);

--- a/cockatrice/src/game_graphics/game_view.cpp
+++ b/cockatrice/src/game_graphics/game_view.cpp
@@ -248,7 +248,7 @@ void GameView::updateTotalSelectionCount(const QSize &viewSize)
         totalCountLabel->show();
     }
 
-    TallyType tallyType = SettingsCache::instance().getTallyType();
+    TallyType tallyType = Tally::intToType(SettingsCache::instance().getTallyType());
 
     GameScene *gameScene = static_cast<GameScene *>(scene());
     QList<TallyRow> entries = Tally::compute(gameScene->selectedCards(), tallyType);

--- a/cockatrice/src/game_graphics/player/menu/player_menu.cpp
+++ b/cockatrice/src/game_graphics/player/menu/player_menu.cpp
@@ -44,6 +44,8 @@ PlayerMenu::PlayerMenu(PlayerGraphicsItem *_player) : QObject(_player), player(_
         utilityMenu = nullptr;
     }
 
+    tallyMenu = addManagedMenu<TallyMenu>();
+
     if (player->getLogic()->getPlayerInfo()->getLocal()) {
         sayMenu = addManagedMenu<SayMenu>(player);
     } else {

--- a/cockatrice/src/game_graphics/player/menu/player_menu.h
+++ b/cockatrice/src/game_graphics/player/menu/player_menu.h
@@ -15,6 +15,7 @@
 #include "rfg_menu.h"
 #include "say_menu.h"
 #include "sideboard_menu.h"
+#include "tally_menu.h"
 #include "utility_menu.h"
 
 #include <QList>
@@ -87,6 +88,7 @@ private:
     GraveyardMenu *graveMenu;
     RfgMenu *rfgMenu;
     UtilityMenu *utilityMenu;
+    TallyMenu *tallyMenu;
     SayMenu *sayMenu;
     CustomZoneMenu *customZonesMenu;
 

--- a/cockatrice/src/game_graphics/player/menu/tally_menu.cpp
+++ b/cockatrice/src/game_graphics/player/menu/tally_menu.cpp
@@ -21,14 +21,14 @@ TallyMenu::TallyMenu()
 
 QAction *TallyMenu::createTallyAction(TallyType tallyType)
 {
-    TallyType currentType = SettingsCache::instance().getTallyType();
+    TallyType currentType = Tally::intToType(SettingsCache::instance().getTallyType());
 
     QAction *action = new QAction(this);
     action->setCheckable(true);
     action->setChecked(tallyType == currentType);
 
     connect(action, &QAction::triggered, &SettingsCache::instance(),
-            [tallyType] { SettingsCache::instance().setTallyType(tallyType); });
+            [tallyType] { SettingsCache::instance().setTallyType(static_cast<int>(tallyType)); });
 
     actionGroup->addAction(action);
 

--- a/cockatrice/src/game_graphics/player/menu/tally_menu.cpp
+++ b/cockatrice/src/game_graphics/player/menu/tally_menu.cpp
@@ -1,6 +1,6 @@
 #include "tally_menu.h"
 
-#include "../../client/settings/cache_settings.h"
+#include "../../../client/settings/cache_settings.h"
 
 TallyMenu::TallyMenu()
 {

--- a/cockatrice/src/game_graphics/player/menu/tally_menu.cpp
+++ b/cockatrice/src/game_graphics/player/menu/tally_menu.cpp
@@ -5,11 +5,11 @@
 TallyMenu::TallyMenu()
 {
     aTallyNone = createTallyAction(TallyType::None);
-    aTallySubtype = createTallyAction(TallyType::Subtypes);
+    aTallySubtypes = createTallyAction(TallyType::Subtypes);
 
     addAction(aTallyNone);
     addSeparator();
-    addAction(aTallySubtype);
+    addAction(aTallySubtypes);
 
     retranslateUi();
 }
@@ -45,5 +45,5 @@ void TallyMenu::retranslateUi()
     setTitle(tr("Tally"));
 
     aTallyNone->setText(tr("None"));
-    aTallySubtype->setText(tr("Subtype"));
+    aTallySubtypes->setText(tr("Subtypes"));
 }

--- a/cockatrice/src/game_graphics/player/menu/tally_menu.cpp
+++ b/cockatrice/src/game_graphics/player/menu/tally_menu.cpp
@@ -2,8 +2,13 @@
 
 #include "../../../client/settings/cache_settings.h"
 
+#include <QActionGroup>
+
 TallyMenu::TallyMenu()
 {
+    actionGroup = new QActionGroup(this);
+    actionGroup->setExclusive(true);
+
     aTallyNone = createTallyAction(TallyType::None);
     aTallySubtypes = createTallyAction(TallyType::Subtypes);
 
@@ -24,8 +29,8 @@ QAction *TallyMenu::createTallyAction(TallyType tallyType)
 
     connect(action, &QAction::triggered, &SettingsCache::instance(),
             [tallyType] { SettingsCache::instance().setTallyType(tallyType); });
-    connect(&SettingsCache::instance(), &SettingsCache::tallyTypeChanged, action,
-            [action, tallyType](TallyType type) { action->setChecked(type == tallyType); });
+
+    actionGroup->addAction(action);
 
     return action;
 }

--- a/cockatrice/src/game_graphics/player/menu/tally_menu.cpp
+++ b/cockatrice/src/game_graphics/player/menu/tally_menu.cpp
@@ -1,0 +1,49 @@
+#include "tally_menu.h"
+
+#include "../../client/settings/cache_settings.h"
+
+TallyMenu::TallyMenu()
+{
+    aTallyNone = createTallyAction(TallyType::None);
+    aTallySubtype = createTallyAction(TallyType::Subtypes);
+
+    addAction(aTallyNone);
+    addSeparator();
+    addAction(aTallySubtype);
+
+    retranslateUi();
+}
+
+QAction *TallyMenu::createTallyAction(TallyType tallyType)
+{
+    TallyType currentType = SettingsCache::instance().getTallyType();
+
+    QAction *action = new QAction(this);
+    action->setCheckable(true);
+    action->setChecked(tallyType == currentType);
+
+    connect(action, &QAction::triggered, &SettingsCache::instance(),
+            [tallyType] { SettingsCache::instance().setTallyType(tallyType); });
+    connect(&SettingsCache::instance(), &SettingsCache::tallyTypeChanged, action,
+            [action, tallyType](TallyType type) { action->setChecked(type == tallyType); });
+
+    return action;
+}
+
+void TallyMenu::setShortcutsActive()
+{
+    // no-op because we haven't decided if we're adding shortcuts for tally types
+}
+
+void TallyMenu::setShortcutsInactive()
+{
+    // no-op because we haven't decided if we're adding shortcuts for tally types
+}
+
+void TallyMenu::retranslateUi()
+{
+    setTitle(tr("Tally"));
+
+    aTallyNone->setText(tr("None"));
+    aTallySubtype->setText(tr("Subtype"));
+}

--- a/cockatrice/src/game_graphics/player/menu/tally_menu.h
+++ b/cockatrice/src/game_graphics/player/menu/tally_menu.h
@@ -1,0 +1,28 @@
+#ifndef COCKATRICE_TALLY_MENU_H
+#define COCKATRICE_TALLY_MENU_H
+
+#include "../../../interface/widgets/menus/tearoff_menu.h"
+#include "../../tally/tally.h"
+#include "abstract_player_component.h"
+
+#include <QMenu>
+
+class TallyMenu : public TearOffMenu, public AbstractPlayerComponent
+{
+    Q_OBJECT
+
+public:
+    explicit TallyMenu();
+
+    void setShortcutsActive() override;
+    void setShortcutsInactive() override;
+    void retranslateUi() override;
+
+private:
+    QAction *aTallyNone = nullptr;
+    QAction *aTallySubtype = nullptr;
+
+    QAction *createTallyAction(TallyType tallyType);
+};
+
+#endif // COCKATRICE_TALLY_MENU_H

--- a/cockatrice/src/game_graphics/player/menu/tally_menu.h
+++ b/cockatrice/src/game_graphics/player/menu/tally_menu.h
@@ -12,13 +12,15 @@ class TallyMenu : public TearOffMenu, public AbstractPlayerComponent
     Q_OBJECT
 
 public:
-    explicit TallyMenu();
+    TallyMenu();
 
     void setShortcutsActive() override;
     void setShortcutsInactive() override;
     void retranslateUi() override;
 
 private:
+    QActionGroup *actionGroup = nullptr;
+
     QAction *aTallyNone = nullptr;
     QAction *aTallySubtypes = nullptr;
 

--- a/cockatrice/src/game_graphics/player/menu/tally_menu.h
+++ b/cockatrice/src/game_graphics/player/menu/tally_menu.h
@@ -20,7 +20,7 @@ public:
 
 private:
     QAction *aTallyNone = nullptr;
-    QAction *aTallySubtype = nullptr;
+    QAction *aTallySubtypes = nullptr;
 
     QAction *createTallyAction(TallyType tallyType);
 };

--- a/cockatrice/src/game_graphics/tally/tally.cpp
+++ b/cockatrice/src/game_graphics/tally/tally.cpp
@@ -4,8 +4,7 @@
 
 TallyType Tally::intToType(int value)
 {
-    // remember to change this whenever you add a new member
-    if (value < static_cast<int>(TallyType::None) || value >= static_cast<int>(TallyType::Subtypes)) {
+    if (value < static_cast<int>(TallyType::None) || value > static_cast<int>(TallyType::MaxValue)) {
         return TallyType::None;
     }
 

--- a/cockatrice/src/game_graphics/tally/tally.cpp
+++ b/cockatrice/src/game_graphics/tally/tally.cpp
@@ -2,6 +2,16 @@
 
 #include "subtype_tally.h"
 
+TallyType Tally::intToType(int value)
+{
+    // remember to change this whenever you add a new member
+    if (value < static_cast<int>(TallyType::None) || value >= static_cast<int>(TallyType::Subtypes)) {
+        return TallyType::None;
+    }
+
+    return static_cast<TallyType>(value);
+}
+
 QList<TallyRow> Tally::compute(const QList<CardItem *> &cards, const TallyType type)
 {
     switch (type) {

--- a/cockatrice/src/game_graphics/tally/tally.h
+++ b/cockatrice/src/game_graphics/tally/tally.h
@@ -20,6 +20,7 @@ enum class TallyType
 {
     None,
     Subtypes,
+    MaxValue = Subtypes // sentinel value
 };
 
 namespace Tally

--- a/cockatrice/src/game_graphics/tally/tally.h
+++ b/cockatrice/src/game_graphics/tally/tally.h
@@ -26,6 +26,14 @@ namespace Tally
 {
 
 /**
+ * Safely converts an int into the corresponding TallyType.
+ *
+ * @param value The int value
+ * @return The TallyType. Returns TallyType::None if the value is not within range
+ */
+TallyType intToType(int value);
+
+/**
  * @brief Analyzes the selected cards according to the tally type and builds the resulting tally rows.
  * This forwards the cards to the code for that tally type.
  *

--- a/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.cpp
+++ b/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.cpp
@@ -68,10 +68,6 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     connect(&showTotalSelectionCountCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             &SettingsCache::setShowTotalSelectionCount);
 
-    showSubtypeSelectionTallyCheckBox.setChecked(SettingsCache::instance().getShowSubtypeSelectionTally());
-    connect(&showSubtypeSelectionTallyCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
-            &SettingsCache::setShowSubtypeSelectionTally);
-
     useTearOffMenusCheckBox.setChecked(SettingsCache::instance().getUseTearOffMenus());
     connect(&useTearOffMenusCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance(),
             [](const QT_STATE_CHANGED_T state) { SettingsCache::instance().setUseTearOffMenus(state == Qt::Checked); });
@@ -90,9 +86,8 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     generalGrid->addWidget(&annotateTokensCheckBox, 6, 0);
     generalGrid->addWidget(&showDragSelectionCountCheckBox, 7, 0);
     generalGrid->addWidget(&showTotalSelectionCountCheckBox, 8, 0);
-    generalGrid->addWidget(&showSubtypeSelectionTallyCheckBox, 9, 0);
-    generalGrid->addWidget(&useTearOffMenusCheckBox, 10, 0);
-    generalGrid->addWidget(&keepGameChatFocusCheckBox, 11, 0);
+    generalGrid->addWidget(&useTearOffMenusCheckBox, 9, 0);
+    generalGrid->addWidget(&keepGameChatFocusCheckBox, 10, 0);
 
     generalGroupBox = new QGroupBox;
     generalGroupBox->setLayout(generalGrid);
@@ -216,7 +211,6 @@ void UserInterfaceSettingsPage::retranslateUi()
     annotateTokensCheckBox.setText(tr("Annotate card text on tokens"));
     showDragSelectionCountCheckBox.setText(tr("Show selection count during drag selection"));
     showTotalSelectionCountCheckBox.setText(tr("Show total selection count"));
-    showSubtypeSelectionTallyCheckBox.setText(tr("Show subtype breakdown in selection tally"));
     useTearOffMenusCheckBox.setText(tr("Use tear-off menus, allowing right click menus to persist on screen"));
     keepGameChatFocusCheckBox.setText(
         tr("Keep game chat focused when clicking in game (Note: disables card view search bar)"));

--- a/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.h
+++ b/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.h
@@ -29,7 +29,6 @@ private:
     QCheckBox annotateTokensCheckBox;
     QCheckBox showDragSelectionCountCheckBox;
     QCheckBox showTotalSelectionCountCheckBox;
-    QCheckBox showSubtypeSelectionTallyCheckBox;
     QCheckBox useTearOffMenusCheckBox;
     QCheckBox keepGameChatFocusCheckBox;
     QCheckBox tapAnimationCheckBox;


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #7021

## Short roundup of the initial problem

Use an in-game menu for selecting the tally type so that it's easier to change the tally type in-game and to allow for more tally types.

## What will change with this Pull Request?
- Create `TallyMenu`
  - Is another top-level managed `AbstractPlayerComponent` menu
  - Always appears regardless of whether game is replay or spectator
  - Is a tearoff menu
- Remove subtype tally setting from settings menu
- Change settings to store TallyType instead of a boolean.
  - Add signal to SettingsCache for TallyType change
  - Also connect tally update to the signal


https://github.com/user-attachments/assets/b8f695c9-aba3-4ec0-a11b-b606d186a008

## Screenshots

<img width="344" height="378" alt="Screenshot 2026-07-05 at 8 26 36 PM" src="https://github.com/user-attachments/assets/4f51afea-ae6b-4af1-9f9a-1b1ce1fb706e" />

<img width="231" height="129" alt="Screenshot 2026-07-05 at 8 27 07 PM" src="https://github.com/user-attachments/assets/341c45ae-974d-4c8c-95d1-f691cbff69f1" />

