### PR TITLE
[Replay] Make fast forward speed configurable

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -228,8 +228,8 @@ set(cockatrice_SOURCES
     src/interface/widgets/printing_selector/set_name_and_collectors_number_display_widget.cpp
     src/interface/widgets/quick_settings/settings_button_widget.cpp
     src/interface/widgets/quick_settings/settings_popup_widget.cpp
-    src/interface/widgets/replay/replay_quick_settings_widget.cpp
     src/interface/widgets/replay/replay_manager.cpp
+    src/interface/widgets/replay/replay_quick_settings_widget.cpp
     src/interface/widgets/replay/replay_timeline_widget.cpp
     src/interface/widgets/server/chat_view/chat_view.cpp
     src/interface/widgets/server/game_filter_configs.cpp

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -228,6 +228,7 @@ set(cockatrice_SOURCES
     src/interface/widgets/printing_selector/set_name_and_collectors_number_display_widget.cpp
     src/interface/widgets/quick_settings/settings_button_widget.cpp
     src/interface/widgets/quick_settings/settings_popup_widget.cpp
+    src/interface/widgets/replay/replay_quick_settings_widget.cpp
     src/interface/widgets/replay/replay_manager.cpp
     src/interface/widgets/replay/replay_timeline_widget.cpp
     src/interface/widgets/server/chat_view/chat_view.cpp

--- a/cockatrice/src/client/settings/cache_settings.cpp
+++ b/cockatrice/src/client/settings/cache_settings.cpp
@@ -372,6 +372,7 @@ SettingsCache::SettingsCache()
 
     openDeckInNewTab = settings->value("editor/openDeckInNewTab", false).toBool();
     rewindBufferingMs = settings->value("replay/rewindBufferingMs", 200).toInt();
+    fastForwardSpeed = settings->value("replay/fastForwardSpeed", 10).toReal();
     styleUserList = settings->value("appearance/styleUserList", true).toBool();
     chatMention = settings->value("chat/mention", true).toBool();
     chatMentionCompleter = settings->value("chat/mentioncompleter", true).toBool();
@@ -1045,6 +1046,12 @@ void SettingsCache::setRewindBufferingMs(int _rewindBufferingMs)
 {
     rewindBufferingMs = _rewindBufferingMs;
     settings->setValue("replay/rewindBufferingMs", rewindBufferingMs);
+}
+
+void SettingsCache::setFastForwardSpeed(qreal _value)
+{
+    fastForwardSpeed = _value;
+    settings->setValue("replay/fastForwardSpeed", fastForwardSpeed);
 }
 
 void SettingsCache::setStyleUserList(QT_STATE_CHANGED_T _styleUserList)

--- a/cockatrice/src/client/settings/cache_settings.h
+++ b/cockatrice/src/client/settings/cache_settings.h
@@ -285,6 +285,7 @@ private:
     bool autoRotateSidewaysLayoutCards;
     bool openDeckInNewTab;
     int rewindBufferingMs;
+    qreal fastForwardSpeed;
     bool styleUserList;
     bool chatMention;
     bool chatMentionCompleter;
@@ -745,6 +746,10 @@ public:
     {
         return rewindBufferingMs;
     }
+    [[nodiscard]] qreal getFastForwardSpeed() const
+    {
+        return fastForwardSpeed;
+    }
     [[nodiscard]] bool getStyleUserList() const
     {
         return styleUserList;
@@ -1124,6 +1129,7 @@ public slots:
     void setAutoRotateSidewaysLayoutCards(QT_STATE_CHANGED_T _autoRotateSidewaysLayoutCards);
     void setOpenDeckInNewTab(QT_STATE_CHANGED_T _openDeckInNewTab);
     void setRewindBufferingMs(int _rewindBufferingMs);
+    void setFastForwardSpeed(qreal _value);
     void setStyleUserList(QT_STATE_CHANGED_T _styleUserList);
     void setChatMention(QT_STATE_CHANGED_T _chatMention);
     void setChatMentionCompleter(QT_STATE_CHANGED_T _chatMentionCompleter);

--- a/cockatrice/src/interface/widgets/replay/replay_manager.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_manager.cpp
@@ -1,6 +1,7 @@
 #include "replay_manager.h"
 
 #include "../interface/widgets/tabs/tab_game.h"
+#include "replay_quick_settings_widget.h"
 
 #include <QHBoxLayout>
 #include <QToolButton>
@@ -78,13 +79,19 @@ ReplayManager::ReplayManager(TabGame *parent, GameReplay *_replay)
     replayFastForwardButton->setIconSize(QSize(32, 32));
     replayFastForwardButton->setIcon(QPixmap("theme:replay/fastforward"));
     replayFastForwardButton->setCheckable(true);
-    connect(replayFastForwardButton, &QToolButton::toggled, this, &ReplayManager::replayFastForwardButtonToggled);
+    connect(replayFastForwardButton, &QToolButton::toggled, this, &ReplayManager::updateTimeScaleFactor);
+
+    settingsWidget = new ReplayQuickSettingsWidget(this);
+    settingsWidget->setFixedSize(QSize(32, 32));
+    connect(settingsWidget, &ReplayQuickSettingsWidget::fastForwardSpeedChanged, this,
+            [this] { updateTimeScaleFactor(replayFastForwardButton->isChecked()); });
 
     // putting everything together
     auto replayControlLayout = new QHBoxLayout;
     replayControlLayout->addWidget(timelineWidget, 10);
     replayControlLayout->addWidget(replayPlayButton);
     replayControlLayout->addWidget(replayFastForwardButton);
+    replayControlLayout->addWidget(settingsWidget);
 
     setObjectName("replayControlWidget");
     setLayout(replayControlLayout);
@@ -115,9 +122,10 @@ void ReplayManager::replayPlayButtonToggled(bool checked)
     }
 }
 
-void ReplayManager::replayFastForwardButtonToggled(bool checked)
+void ReplayManager::updateTimeScaleFactor(bool isFastForward)
 {
-    timelineWidget->setTimeScaleFactor(checked ? ReplayTimelineWidget::FAST_FORWARD_SCALE_FACTOR : 1.0);
+    qreal factor = isFastForward ? SettingsCache::instance().getFastForwardSpeed() : 1.0;
+    timelineWidget->setTimeScaleFactor(factor);
 }
 
 /**

--- a/cockatrice/src/interface/widgets/replay/replay_manager.h
+++ b/cockatrice/src/interface/widgets/replay/replay_manager.h
@@ -14,6 +14,7 @@
 #include <QWidget>
 #include <libcockatrice/protocol/pb/game_replay.pb.h>
 
+class ReplayQuickSettingsWidget;
 class TabGame;
 
 class ReplayManager : public QWidget
@@ -35,13 +36,14 @@ private:
     QList<int> replayTimeline;
     ReplayTimelineWidget *timelineWidget;
     QToolButton *replayPlayButton, *replayFastForwardButton;
+    ReplayQuickSettingsWidget *settingsWidget;
     QAction *aReplaySkipForward, *aReplaySkipBackward, *aReplaySkipForwardBig, *aReplaySkipBackwardBig;
 
 private slots:
     void replayNextEvent(EventProcessingOptions options);
     void replayFinished();
     void replayPlayButtonToggled(bool checked);
-    void replayFastForwardButtonToggled(bool checked);
+    void updateTimeScaleFactor(bool checked);
     void replayRewind();
     void refreshShortcuts();
 };

--- a/cockatrice/src/interface/widgets/replay/replay_quick_settings_widget.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_quick_settings_widget.cpp
@@ -1,0 +1,35 @@
+#include "replay_quick_settings_widget.h"
+
+#include "../../client/settings/cache_settings.h"
+
+ReplayQuickSettingsWidget::ReplayQuickSettingsWidget(QWidget *parent) : SettingsButtonWidget(parent)
+{
+    // fast forward speed
+    fastForwardSpeedBox.setMinimum(1);
+    fastForwardSpeedBox.setValue(SettingsCache::instance().getFastForwardSpeed());
+    connect(&fastForwardSpeedBox, &QDoubleSpinBox::valueChanged, this,
+            &ReplayQuickSettingsWidget::actUpdateFastForwardSpeed);
+
+    // putting it all together
+    auto *widget = new QWidget;
+    auto *grid = new QGridLayout(widget);
+    grid->setContentsMargins(0, 0, 0, 0);
+    grid->addWidget(&fastForwardSpeedLabel, 0, 0, 1, 1);
+    grid->addWidget(&fastForwardSpeedBox, 0, 1, 1, 1);
+
+    this->addSettingsWidget(widget);
+
+    retranslateUi();
+}
+
+void ReplayQuickSettingsWidget::retranslateUi()
+{
+    fastForwardSpeedLabel.setText(tr("Fast forward speed:"));
+    fastForwardSpeedBox.setSuffix("x");
+}
+
+void ReplayQuickSettingsWidget::actUpdateFastForwardSpeed(qreal value)
+{
+    SettingsCache::instance().setFastForwardSpeed(value);
+    emit fastForwardSpeedChanged(value);
+}

--- a/cockatrice/src/interface/widgets/replay/replay_quick_settings_widget.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_quick_settings_widget.cpp
@@ -1,13 +1,17 @@
 #include "replay_quick_settings_widget.h"
 
-#include "../../client/settings/cache_settings.h"
+#include "../../../client/settings/cache_settings.h"
+
+#include <QGridLayout>
+#include <QLabel>
+#include <QWidget>
 
 ReplayQuickSettingsWidget::ReplayQuickSettingsWidget(QWidget *parent) : SettingsButtonWidget(parent)
 {
     // fast forward speed
     fastForwardSpeedBox.setMinimum(1);
     fastForwardSpeedBox.setValue(SettingsCache::instance().getFastForwardSpeed());
-    connect(&fastForwardSpeedBox, &QDoubleSpinBox::valueChanged, this,
+    connect(&fastForwardSpeedBox, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
             &ReplayQuickSettingsWidget::actUpdateFastForwardSpeed);
 
     // putting it all together
@@ -19,6 +23,7 @@ ReplayQuickSettingsWidget::ReplayQuickSettingsWidget(QWidget *parent) : Settings
 
     this->addSettingsWidget(widget);
 
+    connect(&SettingsCache::instance(), &SettingsCache::langChanged, this, &ReplayQuickSettingsWidget::retranslateUi);
     retranslateUi();
 }
 

--- a/cockatrice/src/interface/widgets/replay/replay_quick_settings_widget.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_quick_settings_widget.cpp
@@ -10,6 +10,8 @@ ReplayQuickSettingsWidget::ReplayQuickSettingsWidget(QWidget *parent) : Settings
 {
     // fast forward speed
     fastForwardSpeedBox.setMinimum(1);
+    fastForwardSpeedBox.setMaximum(99.9);
+    fastForwardSpeedBox.setDecimals(1);
     fastForwardSpeedBox.setValue(SettingsCache::instance().getFastForwardSpeed());
     connect(&fastForwardSpeedBox, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
             &ReplayQuickSettingsWidget::actUpdateFastForwardSpeed);

--- a/cockatrice/src/interface/widgets/replay/replay_quick_settings_widget.h
+++ b/cockatrice/src/interface/widgets/replay/replay_quick_settings_widget.h
@@ -1,0 +1,28 @@
+#ifndef COCKATRICE_REPLAY_QUICK_SETTINGS_WIDGET_H
+#define COCKATRICE_REPLAY_QUICK_SETTINGS_WIDGET_H
+
+#include "../../interface/widgets/quick_settings/settings_button_widget.h"
+
+#include <QDoubleSpinBox>
+
+class ReplayQuickSettingsWidget : public SettingsButtonWidget
+{
+    Q_OBJECT
+
+public:
+    explicit ReplayQuickSettingsWidget(QWidget *parent);
+
+    void retranslateUi();
+
+signals:
+    void fastForwardSpeedChanged(qreal speed);
+
+private:
+    QLabel fastForwardSpeedLabel;
+    QDoubleSpinBox fastForwardSpeedBox;
+
+private slots:
+    void actUpdateFastForwardSpeed(qreal value);
+};
+
+#endif // COCKATRICE_REPLAY_QUICK_SETTINGS_WIDGET_H

--- a/cockatrice/src/interface/widgets/replay/replay_timeline_widget.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_timeline_widget.cpp
@@ -187,7 +187,7 @@ void ReplayTimelineWidget::processNewEvents(PlaybackMode playbackMode)
 void ReplayTimelineWidget::setTimeScaleFactor(qreal _timeScaleFactor)
 {
     timeScaleFactor = _timeScaleFactor;
-    int interval = qRound(TIMER_INTERVAL_MS / timeScaleFactor);
+    int interval = std::max(1, qRound(TIMER_INTERVAL_MS / timeScaleFactor));
     replayTimer->setInterval(interval);
 }
 

--- a/cockatrice/src/interface/widgets/replay/replay_timeline_widget.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_timeline_widget.cpp
@@ -11,6 +11,7 @@ ReplayTimelineWidget::ReplayTimelineWidget(QWidget *parent)
       currentEvent(0)
 {
     replayTimer = new QTimer(this);
+    replayTimer->setInterval(TIMER_INTERVAL_MS);
     connect(replayTimer, &QTimer::timeout, this, &ReplayTimelineWidget::replayTimerTimeout);
 
     rewindBufferingTimer = new QTimer(this);
@@ -186,12 +187,13 @@ void ReplayTimelineWidget::processNewEvents(PlaybackMode playbackMode)
 void ReplayTimelineWidget::setTimeScaleFactor(qreal _timeScaleFactor)
 {
     timeScaleFactor = _timeScaleFactor;
-    replayTimer->setInterval(static_cast<int>(TIMER_INTERVAL_MS / timeScaleFactor));
+    int interval = qRound(TIMER_INTERVAL_MS / timeScaleFactor);
+    replayTimer->setInterval(interval);
 }
 
 void ReplayTimelineWidget::startReplay()
 {
-    replayTimer->start(static_cast<int>(TIMER_INTERVAL_MS / timeScaleFactor));
+    replayTimer->start();
 }
 
 void ReplayTimelineWidget::stopReplay()

--- a/cockatrice/src/interface/widgets/replay/replay_timeline_widget.h
+++ b/cockatrice/src/interface/widgets/replay/replay_timeline_widget.h
@@ -55,7 +55,6 @@ private slots:
 public:
     static constexpr int SMALL_SKIP_MS = 1000;
     static constexpr int BIG_SKIP_MS = 10000;
-    static constexpr qreal FAST_FORWARD_SCALE_FACTOR = 10.0;
 
     explicit ReplayTimelineWidget(QWidget *parent = nullptr);
     void setTimeline(const QList<int> &_replayTimeline);


### PR DESCRIPTION
## Short roundup of the initial problem

I would like the replay fast forward speed to be configurable. 10x is too fast sometimes.

## What will change with this Pull Request?

- Add new setting for fast forward speed
  - Uses units of x times faster
- Refactor `ReplayTimelineWidget` to make the fastForwardScaleFactor configurable.
  - The replay speed is controlled by changing the timer interval, which is ultimately an integer. The fast forward speed setting allows decimals, so we ultimately round the result to an int.
- Create a `SettingsButtonWidget` for replays and put it in the replay dock

https://github.com/user-attachments/assets/83519e2f-b64b-48e7-a1da-d3ebbe5fdada

## Screenshots

<img width="495" height="317" alt="Screenshot 2026-07-05 at 10 33 00 PM" src="https://github.com/user-attachments/assets/4a07b9e7-422b-4b84-ba27-d0e39b3167ce" />
