### PR TITLE
Fix and rework client updater logic

### DIFF
--- a/cockatrice/src/client/network/update/client/release_channel.cpp
+++ b/cockatrice/src/client/network/update/client/release_channel.cpp
@@ -63,10 +63,6 @@ std::optional<int> ReleaseChannel::getTargetVersionForCurrentOS(const QString &f
     const QRegularExpression &regex = isIntel ? macIntelRegex : macArmRegex;
 
 #elif defined(Q_OS_WIN)
-#if Q_PROCESSOR_WORDSIZE != 8 // non 64-bit host
-    Q_UNUSED(fileName);
-    return std::nullopt;
-#endif
     static const QRegularExpression regex(R"(Win(?:dows)?(\d+)\.[^.]+$)", QRegularExpression::CaseInsensitiveOption);
 
 #else // if the OS doesn't fit one of the above #defines, then it will never match

--- a/cockatrice/src/client/network/update/client/release_channel.cpp
+++ b/cockatrice/src/client/network/update/client/release_channel.cpp
@@ -44,13 +44,28 @@ void ReleaseChannel::checkForUpdates()
     connect(response, &QNetworkReply::finished, this, &ReleaseChannel::releaseListFinished);
 }
 
-// Find compatible assets for host platform (Linux is not supported by in-client updater)
+// Find assets compatible with host platform (Linux is not supported by in-client updater)
 std::optional<int> ReleaseChannel::getTargetVersionForCurrentOS(const QString &fileName)
 {
     const QRegularExpression *regex = nullptr;
 
+    static const std::optional<int> systemVersion = [] {
+        bool ok = false;
+        const QString versionString = QSysInfo::productVersion();
+        const int version = versionString.split('.').first().toInt(&ok);
+        if (!ok) {
+            qCWarning(ReleaseChannelLog) << "Unable to determine OS version from" << versionString;
+            return std::optional<int>();
+        }
+        return std::optional<int>{version};
+    }();
+
+    if (!systemVersion) {
+        return std::nullopt;
+    }
+
 #if defined(Q_OS_MACOS)
-    const bool isIntel = [] {
+    static const bool isIntel = [] {
         // QSysInfo does not go through translation layers
         // We need to use sysctl to reliably detect the underlying architecture
         char arch[255];
@@ -60,12 +75,16 @@ std::optional<int> ReleaseChannel::getTargetVersionForCurrentOS(const QString &f
         }
         return false;
     }();
+
+    // Apple (ARM) --> Cockatrice-3.0.0-macOS15.dmg
+    // Apple (x86) --> Cockatrice-3.0.0-macOS15_Intel.dmg
     static const QRegularExpression macIntelRegex(R"(-macOS(\d+)_Intel\.[^.]+$)",
                                                   QRegularExpression::CaseInsensitiveOption);
-    static const QRegularExpression macArmRegex(R"(-macOS(\d+)\.[^.]+$)", QRegularExpression::CaseInsensitiveOption);
-    regex = isIntel ? &macIntelRegex : &macArmRegex;
+    static const QRegularExpression macRegex(R"(-macOS(\d+)\.[^.]+$)", QRegularExpression::CaseInsensitiveOption);
+    regex = isIntel ? &macIntelRegex : &macRegex;
 
 #elif defined(Q_OS_WIN)
+    // Windows (x86) --> Cockatrice-3.0.0-Windows10.exe
     static const QRegularExpression winRegex(R"(-(?:Win|Windows)(\d+)\.[^.]+$)",
                                              QRegularExpression::CaseInsensitiveOption);
     regex = &winRegex;
@@ -75,14 +94,13 @@ std::optional<int> ReleaseChannel::getTargetVersionForCurrentOS(const QString &f
     return std::nullopt;
 #endif
 
-    // Any asset targeting an OS version smaller or equal to the current host works
-    const int systemVersion = QSysInfo::productVersion().split('.').first().toInt();
+    // Any asset targeting an OS version up to the current host version works
     auto match = regex->match(fileName);
     if (!match.hasMatch()) {
         return std::nullopt;
     }
     const int targetVersion = match.captured(1).toInt();
-    if (targetVersion > systemVersion) {
+    if (targetVersion > *systemVersion) {
         return std::nullopt;
     }
     return targetVersion;

--- a/cockatrice/src/client/network/update/client/release_channel.cpp
+++ b/cockatrice/src/client/network/update/client/release_channel.cpp
@@ -2,7 +2,6 @@
 
 #include "version_string.h"
 
-#include <optional>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -11,6 +10,7 @@
 #include <QRegularExpression>
 #include <QSysInfo>
 #include <QtGlobal>
+#include <optional>
 
 #if defined(Q_OS_MACOS)
 #include <sys/sysctl.h>
@@ -47,6 +47,8 @@ void ReleaseChannel::checkForUpdates()
 // Different release channel checking functions for different operating systems
 std::optional<int> ReleaseChannel::getTargetVersionForCurrentOS(const QString &fileName)
 {
+    const QRegularExpression *regex = nullptr;
+
 #if defined(Q_OS_MACOS)
     const bool isIntel = [] {
         // QSysInfo does not go through translation layers
@@ -58,12 +60,14 @@ std::optional<int> ReleaseChannel::getTargetVersionForCurrentOS(const QString &f
         }
         return false;
     }();
-    static const QRegularExpression macIntelRegex(R"(macOS(\d+)_Intel\.[^.]+$)", QRegularExpression::CaseInsensitiveOption);
+    static const QRegularExpression macIntelRegex(R"(macOS(\d+)_Intel\.[^.]+$)",
+                                                  QRegularExpression::CaseInsensitiveOption);
     static const QRegularExpression macArmRegex(R"(macOS(\d+)\.[^.]+$)", QRegularExpression::CaseInsensitiveOption);
-    const QRegularExpression &regex = isIntel ? macIntelRegex : macArmRegex;
+    regex = isIntel ? &macIntelRegex : &macArmRegex;
 
 #elif defined(Q_OS_WIN)
-    static const QRegularExpression regex(R"(Win(?:dows)?(\d+)\.[^.]+$)", QRegularExpression::CaseInsensitiveOption);
+    static const QRegularExpression winRegex(R"(Win(?:dows)?(\d+)\.[^.]+$)", QRegularExpression::CaseInsensitiveOption);
+    regex = &winRegex;
 
 #else // if the OS doesn't fit one of the above #defines, then it will never match
     Q_UNUSED(fileName);
@@ -71,7 +75,7 @@ std::optional<int> ReleaseChannel::getTargetVersionForCurrentOS(const QString &f
 #endif
 
     const int systemVersion = QSysInfo::productVersion().split('.').first().toInt();
-    auto match = regex.match(fileName);
+    auto match = regex->match(fileName);
     if (!match.hasMatch()) {
         return std::nullopt;
     }
@@ -100,8 +104,7 @@ QString ReleaseChannel::findBestDownloadUrl(const QVariantList &assets)
         }
     }
     if (!bestUrl.isEmpty()) {
-        qCInfo(ReleaseChannelLog)
-            << "Best compatible asset=" << bestUrl;
+        qCInfo(ReleaseChannelLog) << "Best compatible asset=" << bestUrl;
     }
     return bestUrl;
 }
@@ -152,7 +155,7 @@ void StableReleaseChannel::releaseListFinished()
     if (resultMap.contains("assets")) {
         auto url = findBestDownloadUrl(resultMap["assets"].toList());
         if (!url.isEmpty()) {
-          lastRelease->setDownloadUrl(url);
+            lastRelease->setDownloadUrl(url);
         }
     }
 

--- a/cockatrice/src/client/network/update/client/release_channel.cpp
+++ b/cockatrice/src/client/network/update/client/release_channel.cpp
@@ -2,6 +2,7 @@
 
 #include "version_string.h"
 
+#include <optional>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -44,54 +45,84 @@ void ReleaseChannel::checkForUpdates()
 }
 
 // Different release channel checking functions for different operating systems
-bool ReleaseChannel::downloadMatchesCurrentOS(const QString &fileName)
+std::optional<int> ReleaseChannel::getTargetVersionForCurrentOS(const QString &fileName)
 {
 #if defined(Q_OS_MACOS)
-    static QRegularExpression version_regex("macOS(\\d+)");
-    auto match = version_regex.match(fileName);
-    if (!match.hasMatch()) {
-        return false;
-    }
-
-    auto getSystemVersion = [] {
-        // QSysInfo does not go through translation layers
-        // We need to use sysctl to reliably detect the underlying architecture
+    const bool isIntel = [] {
         char arch[255];
         size_t len = sizeof(arch);
         if (sysctlbyname("machdep.cpu.brand_string", arch, &len, nullptr, 0) == 0) {
-            // Intel mac is only supported on macOS 13 versions
-            if (QString::fromUtf8(arch).contains("Intel")) {
-                return 13;
-            }
+            return QString::fromUtf8(arch).contains("Intel");
         }
-
-        return QSysInfo::productVersion().split(".")[0].toInt();
-    };
-
-    // older(smaller) releases are compatible with a newer or the same system version
-    int sys_maj = getSystemVersion();
-    int rel_maj = match.captured(1).toInt();
-    return rel_maj == sys_maj;
+        return false;
+    }();
+    const int systemVersion = QSysInfo::productVersion().split(".")[0].toInt();
+    if (isIntel) {
+        static QRegularExpression regex(R"(macOS(\d+)_Intel)");
+        auto match = regex.match(fileName);
+        if (!match.hasMatch()) {
+            return std::nullopt;
+        }
+        int version = match.captured(1).toInt();
+        if (version <= systemVersion) {
+            return version;
+        }
+        return std::nullopt;
+    }
+    static QRegularExpression regex(R"(macOS(\d+)(?!_Intel))");
+    auto match = regex.match(fileName);
+    if (!match.hasMatch()) {
+        return std::nullopt;
+    }
+    int version = match.captured(1).toInt();
+    if (version <= systemVersion) {
+        return version;
+    }
+    return std::nullopt;
 
 #elif defined(Q_OS_WIN)
-#if Q_PROCESSOR_WORDSIZE == 4
-    return fileName.contains("32bit");
-#elif Q_PROCESSOR_WORDSIZE == 8
-    const QString &version = QSysInfo::productVersion();
-    if (version.startsWith("7") || version.startsWith("8")) {
-        return fileName.contains("Win7");
-    } else {
-        return fileName.contains("Win10");
+#if Q_PROCESSOR_WORDSIZE == 8
+    const int systemVersion = QSysInfo::productVersion().split(".")[0].toInt();
+    static QRegularExpression regex(R"(Windows(\d+))");
+    auto match = regex.match(fileName);
+    if (!match.hasMatch()) {
+        return std::nullopt;
     }
+    int version = match.captured(1).toInt();
+    if (version <= systemVersion) {
+        return version;
+    }
+#endif
+    return std::nullopt;
 #else
     Q_UNUSED(fileName);
-    return false;
+    return std::nullopt;
 #endif
+}
 
-#else // If the OS doesn't fit one of the above #defines, then it will never match
-    Q_UNUSED(fileName);
-    return false;
-#endif
+QString ReleaseChannel::findBestDownloadUrl(const QVariantList &assets)
+{
+    QString bestUrl;
+    int bestVersion = -1;
+    for (const auto &rawAsset : assets) {
+        QVariantMap asset = rawAsset.toMap();
+        QString name = asset["name"].toString();
+        QString url = asset["browser_download_url"].toString();
+        auto version = getTargetVersionForCurrentOS(name);
+        if (!version) {
+            continue;
+        }
+        if (*version > bestVersion) {
+            bestVersion = *version;
+            bestUrl = url;
+        }
+    }
+    if (!bestUrl.isEmpty()) {
+        qCInfo(ReleaseChannelLog)
+            << "Selected compatible asset version=" << bestVersion
+            << "url=" << bestUrl;
+    }
+    return bestUrl;
 }
 
 QString StableReleaseChannel::getManualDownloadUrl() const
@@ -138,16 +169,9 @@ void StableReleaseChannel::releaseListFinished()
     lastRelease->setPublishDate(resultMap["published_at"].toDate());
 
     if (resultMap.contains("assets")) {
-        auto rawAssets = resultMap["assets"].toList();
-        for (const auto &rawAsset : rawAssets) {
-            QVariantMap asset = rawAsset.toMap();
-            QString name = asset["name"].toString();
-            QString url = asset["browser_download_url"].toString();
-
-            if (downloadMatchesCurrentOS(name)) {
-                lastRelease->setDownloadUrl(url);
-                break;
-            }
+        auto url = findBestDownloadUrl(resultMap["assets"].toList());
+        if (!url.isEmpty()) {
+          lastRelease->setDownloadUrl(url);
         }
     }
 
@@ -289,21 +313,10 @@ void BetaReleaseChannel::fileListFinished()
     bool needToUpdate = (QString::compare(shortHash, myHash, Qt::CaseInsensitive) != 0);
     bool compatibleVersion = false;
 
-    QStringList resultUrlList{};
-    for (QVariant file : resultList) {
-        QVariantMap map = file.toMap();
-        resultUrlList << map["browser_download_url"].toString();
-    }
-
-    resultUrlList.sort();
-    // iterate in reverse so the first item is the latest os version
-    for (auto url = resultUrlList.rbegin(); url < resultUrlList.rend(); ++url) {
-        if (downloadMatchesCurrentOS(*url)) {
-            compatibleVersion = true;
-            lastRelease->setDownloadUrl(*url);
-            qCInfo(ReleaseChannelLog) << "Found compatible version url=" << *url;
-            break;
-        }
+    QString downloadUrl = findBestDownloadUrl(resultList);
+    if (!downloadUrl.isEmpty()) {
+        compatibleVersion = true;
+        lastRelease->setDownloadUrl(downloadUrl);
     }
 
     emit finishedCheck(needToUpdate, compatibleVersion, lastRelease);

--- a/cockatrice/src/client/network/update/client/release_channel.cpp
+++ b/cockatrice/src/client/network/update/client/release_channel.cpp
@@ -49,6 +49,8 @@ std::optional<int> ReleaseChannel::getTargetVersionForCurrentOS(const QString &f
 {
 #if defined(Q_OS_MACOS)
     const bool isIntel = [] {
+        // QSysInfo does not go through translation layers
+        // We need to use sysctl to reliably detect the underlying architecture
         char arch[255];
         size_t len = sizeof(arch);
         if (sysctlbyname("machdep.cpu.brand_string", arch, &len, nullptr, 0) == 0) {
@@ -56,48 +58,32 @@ std::optional<int> ReleaseChannel::getTargetVersionForCurrentOS(const QString &f
         }
         return false;
     }();
-    const int systemVersion = QSysInfo::productVersion().split(".")[0].toInt();
-    if (isIntel) {
-        static QRegularExpression regex(R"(macOS(\d+)_Intel)");
-        auto match = regex.match(fileName);
-        if (!match.hasMatch()) {
-            return std::nullopt;
-        }
-        int version = match.captured(1).toInt();
-        if (version <= systemVersion) {
-            return version;
-        }
-        return std::nullopt;
-    }
-    static QRegularExpression regex(R"(macOS(\d+)(?!_Intel))");
-    auto match = regex.match(fileName);
-    if (!match.hasMatch()) {
-        return std::nullopt;
-    }
-    int version = match.captured(1).toInt();
-    if (version <= systemVersion) {
-        return version;
-    }
-    return std::nullopt;
+    static const QRegularExpression macIntelRegex(R"(macOS(\d+)_Intel\.[^.]+$)", QRegularExpression::CaseInsensitiveOption);
+    static const QRegularExpression macArmRegex(R"(macOS(\d+)\.[^.]+$)", QRegularExpression::CaseInsensitiveOption);
+    const QRegularExpression &regex = isIntel ? macIntelRegex : macArmRegex;
 
 #elif defined(Q_OS_WIN)
-#if Q_PROCESSOR_WORDSIZE == 8
-    const int systemVersion = QSysInfo::productVersion().split(".")[0].toInt();
-    static QRegularExpression regex(R"(Windows(\d+))");
-    auto match = regex.match(fileName);
-    if (!match.hasMatch()) {
-        return std::nullopt;
-    }
-    int version = match.captured(1).toInt();
-    if (version <= systemVersion) {
-        return version;
-    }
-#endif
-    return std::nullopt;
-#else
+#if Q_PROCESSOR_WORDSIZE != 8 // non 64-bit host
     Q_UNUSED(fileName);
     return std::nullopt;
 #endif
+    static const QRegularExpression regex(R"(Win(?:dows)?(\d+)\.[^.]+$)", QRegularExpression::CaseInsensitiveOption);
+
+#else // if the OS doesn't fit one of the above #defines, then it will never match
+    Q_UNUSED(fileName);
+    return std::nullopt;
+#endif
+
+    const int systemVersion = QSysInfo::productVersion().split('.').first().toInt();
+    auto match = regex.match(fileName);
+    if (!match.hasMatch()) {
+        return std::nullopt;
+    }
+    const int targetVersion = match.captured(1).toInt();
+    if (targetVersion > systemVersion) {
+        return std::nullopt;
+    }
+    return targetVersion;
 }
 
 QString ReleaseChannel::findBestDownloadUrl(const QVariantList &assets)
@@ -119,8 +105,7 @@ QString ReleaseChannel::findBestDownloadUrl(const QVariantList &assets)
     }
     if (!bestUrl.isEmpty()) {
         qCInfo(ReleaseChannelLog)
-            << "Selected compatible asset version=" << bestVersion
-            << "url=" << bestUrl;
+            << "Best compatible asset=" << bestUrl;
     }
     return bestUrl;
 }

--- a/cockatrice/src/client/network/update/client/release_channel.cpp
+++ b/cockatrice/src/client/network/update/client/release_channel.cpp
@@ -44,7 +44,7 @@ void ReleaseChannel::checkForUpdates()
     connect(response, &QNetworkReply::finished, this, &ReleaseChannel::releaseListFinished);
 }
 
-// Different release channel checking functions for different operating systems
+// Find compatible assets for host platform (Linux is not supported by in-client updater)
 std::optional<int> ReleaseChannel::getTargetVersionForCurrentOS(const QString &fileName)
 {
     const QRegularExpression *regex = nullptr;
@@ -75,6 +75,7 @@ std::optional<int> ReleaseChannel::getTargetVersionForCurrentOS(const QString &f
     return std::nullopt;
 #endif
 
+    // Any asset targeting an OS version smaller or equal to the current host works
     const int systemVersion = QSysInfo::productVersion().split('.').first().toInt();
     auto match = regex->match(fileName);
     if (!match.hasMatch()) {
@@ -87,6 +88,7 @@ std::optional<int> ReleaseChannel::getTargetVersionForCurrentOS(const QString &f
     return targetVersion;
 }
 
+// Pick newest targeted version (highest number) amongst all compatible ones
 QString ReleaseChannel::findBestDownloadUrl(const QVariantList &assets)
 {
     QString bestUrl;

--- a/cockatrice/src/client/network/update/client/release_channel.cpp
+++ b/cockatrice/src/client/network/update/client/release_channel.cpp
@@ -60,13 +60,14 @@ std::optional<int> ReleaseChannel::getTargetVersionForCurrentOS(const QString &f
         }
         return false;
     }();
-    static const QRegularExpression macIntelRegex(R"(macOS(\d+)_Intel\.[^.]+$)",
+    static const QRegularExpression macIntelRegex(R"(-macOS(\d+)_Intel\.[^.]+$)",
                                                   QRegularExpression::CaseInsensitiveOption);
-    static const QRegularExpression macArmRegex(R"(macOS(\d+)\.[^.]+$)", QRegularExpression::CaseInsensitiveOption);
+    static const QRegularExpression macArmRegex(R"(-macOS(\d+)\.[^.]+$)", QRegularExpression::CaseInsensitiveOption);
     regex = isIntel ? &macIntelRegex : &macArmRegex;
 
 #elif defined(Q_OS_WIN)
-    static const QRegularExpression winRegex(R"(Win(?:dows)?(\d+)\.[^.]+$)", QRegularExpression::CaseInsensitiveOption);
+    static const QRegularExpression winRegex(R"(-(?:Win|Windows)(\d+)\.[^.]+$)",
+                                             QRegularExpression::CaseInsensitiveOption);
     regex = &winRegex;
 
 #else // if the OS doesn't fit one of the above #defines, then it will never match

--- a/cockatrice/src/client/network/update/client/release_channel.h
+++ b/cockatrice/src/client/network/update/client/release_channel.h
@@ -97,8 +97,8 @@ protected:
     Release *lastRelease;
 
 protected:
-    std::optional<int> getTargetVersionForCurrentOS(const QString &fileName);
-    QString findBestDownloadUrl(const QVariantList &assets);
+    static std::optional<int> getTargetVersionForCurrentOS(const QString &fileName);
+    static QString findBestDownloadUrl(const QVariantList &assets);
     [[nodiscard]] virtual QString getReleaseChannelUrl() const = 0;
 
 public:

--- a/cockatrice/src/client/network/update/client/release_channel.h
+++ b/cockatrice/src/client/network/update/client/release_channel.h
@@ -7,12 +7,12 @@
 #ifndef RELEASECHANNEL_H
 #define RELEASECHANNEL_H
 
-#include <optional>
 #include <QDate>
 #include <QLoggingCategory>
 #include <QObject>
 #include <QString>
 #include <QVariantMap>
+#include <optional>
 #include <utility>
 
 inline Q_LOGGING_CATEGORY(ReleaseChannelLog, "release_channel");

--- a/cockatrice/src/client/network/update/client/release_channel.h
+++ b/cockatrice/src/client/network/update/client/release_channel.h
@@ -7,6 +7,7 @@
 #ifndef RELEASECHANNEL_H
 #define RELEASECHANNEL_H
 
+#include <optional>
 #include <QDate>
 #include <QLoggingCategory>
 #include <QObject>
@@ -96,7 +97,8 @@ protected:
     Release *lastRelease;
 
 protected:
-    static bool downloadMatchesCurrentOS(const QString &fileName);
+    std::optional<int> getTargetVersionForCurrentOS(const QString &fileName);
+    QString findBestDownloadUrl(const QVariantList &assets);
     [[nodiscard]] virtual QString getReleaseChannelUrl() const = 0;
 
 public:


### PR DESCRIPTION
## Short roundup of the initial problem
- Some versions were hardcoded, e.g. "macOS 13" for Intel Macs, or outdated like "Windows 7" that we stopped supporting.
- Logic was looking for a matching target version in file name and major host OS version (`rel_maj == sys_maj`) on Mac. This was changed in https://github.com/Cockatrice/Cockatrice/pull/5589 some time back next to the regex (unintentionally?), it did then no longer match the comment nor the actual OS behavior.
That should also mean users running macOS 26 are not be able to use the in-client updater right now as we do not provide a binary targeting "macOS26" and newer --> no 26 == 26 match? 🤔 
- Order of returned assets from GitHub mattered
- Generic regex and no reliable separation between app bundles for Intel & ARM Macs

In general it was a bit static and outdated.

## What will change with this Pull Request?
Make the logic more flexible and future proof.

- **Properly implement concept of releases targeting former versions will run on newer OS versions without issues (applies on Win + macOS)**
  Old code comment claimed to do that already before
- **Dynamically select the best match (newest release amongst all available + compatible ones for the OS/Arch you're running on)**
- More explicit regex and proper separation for Intel binaries on Mac

Appreciate a throughout check from you guys. AI helped.

<br>

---

Tested and confirmed working on Windows 11 with our existing (pre)releases and file naming:
- Beta Channel:
  ```
  [2026-07-08 21:43:49.857 I] [unknown] - Searching for updates on the channel:  "https://api.github.com/repos/Cockatrice/Cockatrice/releases" [unknown:0]
  [2026-07-08 21:43:50.860 I] [unknown] - Got reply from release server, size= 20 name= "2026-06-27-Development-3.1.0-beta.3 (ad49225)" desc= "https://github.com/Cockatrice/Cockatrice/compare/6662d46...ad49225" commit= "ad4922537ddef6f1f06007b2978dae7e12a7af46" date= QDate("2026-06-27") [unknown:0]
  [2026-07-08 21:43:50.860 I] [unknown] - Searching for a corresponding file on the beta channel:  "https://api.github.com/repos/Cockatrice/Cockatrice/releases/345763947/assets" [unknown:0]
  [2026-07-08 21:43:51.056 I] [unknown] - Current hash= "6662d46" update hash= "ad49225" [unknown:0]
  [2026-07-08 21:43:51.056 I] [unknown] - Best compatible asset= "https://github.com/Cockatrice/Cockatrice/releases/download/2026-06-27-Development-3.1.0-beta.3/Cockatrice-3.1.0-beta.3-Win10.exe" [unknown:0]
  ```

- Stable Channel:
  ```
  [2026-07-08 21:46:56.416 I] [unknown] - Searching for updates on the channel:  "https://api.github.com/repos/Cockatrice/Cockatrice/releases/latest" [unknown:0]
  [2026-07-08 21:46:56.864 I] [unknown] - Best compatible asset= "https://github.com/Cockatrice/Cockatrice/releases/download/2026-06-26-Release-3.0.2/Cockatrice-Graduation-Day-3.0.2-Win10.exe" [unknown:0]
  [2026-07-08 21:46:56.864 I] [unknown] - Current hash= "6662d46" update hash= "" [unknown:0]
  [2026-07-08 21:46:56.864 I] [unknown] - Got reply from release server, name= "Cockatrice 3.0.2: Graduation Day" desc= "https://github.com/Cockatrice/Cockatrice/releases/tag/2026-06-26-Release-3.0.2" date= QDate("2026-06-26") url= "https://github.com/Cockatrice/Cockatrice/releases/download/2026-06-26-Release-3.0.2/Cockatrice-Graduation-Day-3.0.2-Win10.exe" [unknown:0]
  [2026-07-08 21:46:56.864 I] [unknown] - Searching for commit hash corresponding to stable channel tag:  "2026-06-26-Release-3.0.2" [unknown:0]
  [2026-07-08 21:46:57.058 I] [unknown] - Got reply from tag server, commit= "adfeb2234d14f040f2d73ba8ecab92e3dff4a5a8" [unknown:0]
  [2026-07-08 21:46:57.058 I] [unknown] - Current hash= "6662d46" update hash= "adfeb22" [unknown:0]
  ```