### PR TITLE
Fix card position when added to the stack

### DIFF
--- a/cockatrice/src/game_graphics/zones/stack_zone.cpp
+++ b/cockatrice/src/game_graphics/zones/stack_zone.cpp
@@ -43,12 +43,18 @@ void StackZone::handleDropEvent(const QList<CardDragItem *> &dragItems,
         return;
     }
 
-    int index = calcDropIndexFromY(dropPoint.y(), MIN_CARD_VISIBLE);
-
-    // Same-zone no-op: don't move a card onto itself
     const auto &cards = getLogic()->getCards();
-    if (!cards.isEmpty() && startZone == getLogic() && cards.at(index)->getId() == dragItems.at(0)->getId()) {
-        return;
+    int index;
+    if (startZone == getLogic()) {
+        // Reordering within the zone: use drop position
+        index = calcDropIndexFromY(dropPoint.y(), MIN_CARD_VISIBLE);
+        // Same-zone no-op: don't move a card onto itself
+        if (!cards.isEmpty() && cards.at(index)->getId() == dragItems.at(0)->getId()) {
+            return;
+        }
+    } else {
+        // Coming from another zone: append at end (top of stack, rendered on top)
+        index = static_cast<int>(cards.size());
     }
 
     Command_MoveCard cmd;


### PR DESCRIPTION
## Short roundup of the initial problem

I found a bug I introduced when refactoring/improving the vertical zones stacking behaviour. Cards added to the stack ended up being placed at the bottom of the stack instead of the top and couldn't be repositioned to the top even from within the zone.

## What will change with this Pull Request?
- The stack ordering behaviour should work as expected now: cards appended to the top of the stack when coming from another zone or reordered properly if already in the stack.

