### PR TITLE
fix crash when pressing Back to results

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/tab_archidekt.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/tab_archidekt.cpp
@@ -639,7 +639,7 @@ void TabArchidekt::processDeckResponse(QJsonObject reply)
 
     auto display = new ArchidektApiResponseDeckDisplayWidget(resultsContainer, deckData, cardSizeSlider);
     connect(display, &ArchidektApiResponseDeckDisplayWidget::requestNavigation, this, &TabArchidekt::actNavigatePage);
-    connect(display, &ArchidektApiResponseDeckDisplayWidget::requestSearch, this, &TabArchidekt::doSearchImmediate);
+    connect(display, &ArchidektApiResponseDeckDisplayWidget::requestSearch, this, &TabArchidekt::doSearch);
     connect(display, &ArchidektApiResponseDeckDisplayWidget::openInDeckEditor, tabSupervisor,
             &TabSupervisor::openDeckInNewTab);
     resultsLayout->addWidget(display);


### PR DESCRIPTION
returning to the search when viewing a deck in the archidekt browser while not viewing the first page, ie scroll down until it loads more, caused a crash, using doSearch now resets the page entirely, this however doesn't seem to be the best experience, however it never actually saved the scroll bar location or anything so it's just how it worked before but without the crash

reported on our discord by v0geekay0v