### PR TITLE
Docker: Build ARM image natively

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -14,7 +14,10 @@ on:
       - master
     paths:
       - '.github/workflows/docker-release.yml'
+      - '.dockerignore'
       - 'Dockerfile'
+      - 'docker-compose.yml'
+      - 'docker-compose.yml.windows'
   release:
     types:
       - released    # publishing of stable releases
@@ -25,26 +28,30 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'release' }}
 
 env:
-  IMAGE_NAME: ghcr.io/cockatrice/servatrice
+  GHCR_IMAGE: ghcr.io/cockatrice/servatrice
   OCI_DESCRIPTION: Server for Cockatrice, a cross-platform virtual tabletop for multiplayer card games
+  OCI_SOURCE: https://github.com/Cockatrice/Cockatrice
   OCI_TITLE: Servatrice
   OCI_URL: https://cockatrice.github.io/
+  OCI_VERSION: ${{ github.ref_name }}
 
 jobs:
   build:
+    name: "${{ matrix.label }}"
+    if: github.repository_owner == 'Cockatrice'
+    runs-on: ${{ matrix.runner }}
+
     strategy:
       fail-fast: false
       matrix:
         include:
-          - platform: linux/amd64
+          - label: x86
+            platform: linux/amd64
             runner: ubuntu-latest
 
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-
-    name: "Build (${{ matrix.platform }})"
-    if: github.repository_owner == 'Cockatrice'
-    runs-on: ${{ matrix.runner }}
+          - label: arm
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm    # to be replaced with "ubuntu-latest-arm" once available
 
     steps:
       - name: "Checkout"
@@ -58,36 +65,40 @@ jobs:
         id: login
         uses: docker/login-action@v4
         with:
-          password: ${{ github.token }}
           registry: ghcr.io
           username: ${{ github.actor }}
+          password: ${{ github.token }}
 
-      - name: "Build Docker image and push by digest"
-        if: steps.login.outcome == 'success'
-        id: build
-        uses: docker/build-push-action@v7
-        with:
-          cache-from: type=gha,scope=servatrice-${{ matrix.platform }}
-          cache-to: type=gha,mode=max,scope=servatrice-${{ matrix.platform }}
-          context: .
-          labels: |
-            org.opencontainers.image.description=${{ env.OCI_DESCRIPTION }}
-            org.opencontainers.image.title=${{ env.OCI_TITLE }}
-            org.opencontainers.image.url=${{ env.OCI_URL }}
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-          platforms: ${{ matrix.platform }}
-
-      - name: "Build Docker image"
+      - name: "Build image"
         if: steps.login.outcome != 'success'
         uses: docker/build-push-action@v7
         with:
-          cache-from: type=gha,scope=servatrice-${{ matrix.platform }}
-          cache-to: type=gha,mode=max,scope=servatrice-${{ matrix.platform }}
+          cache-from: type=gha,scope=servatrice-${{ matrix.label }}
+          cache-to: type=gha,mode=max,scope=servatrice-${{ matrix.label }}
           context: .
           platforms: ${{ matrix.platform }}
           push: false
 
-      - name: Export digest
+      - name: "Build image and push by digest"
+        if: steps.login.outcome == 'success'
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          cache-from: type=gha,scope=servatrice-${{ matrix.label }}
+          cache-to: type=gha,mode=max,scope=servatrice-${{ matrix.label }}
+          context: .
+          labels: |
+            org.opencontainers.image.description=${{ env.OCI_DESCRIPTION }}
+            org.opencontainers.image.source=${{ env.OCI_SOURCE }}
+            org.opencontainers.image.title=${{ env.OCI_TITLE }}
+            org.opencontainers.image.url=${{ env.OCI_URL }}
+            org.opencontainers.image.version=${{ env.OCI_VERSION }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          platforms: ${{ matrix.platform }}
+          provenance: mode=max
+          sbom: true
+
+      - name: "Export digest"
         if: steps.login.outcome == 'success'
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
@@ -95,22 +106,25 @@ jobs:
           mkdir -p $RUNNER_TEMP/digests
           touch "$RUNNER_TEMP/digests/${DIGEST#sha256:}"
 
-      - uses: actions/upload-artifact@v7
+      - name: "Upload digest"
         if: steps.login.outcome == 'success'
+        uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: digest-${{ matrix.platform }}
           path: $RUNNER_TEMP/digests/*
           retention-days: 1
 
 
   merge:
-    needs: build
-    name: "Publish manifest"
+    name: "Publish multi-arch manifest"
     if: github.repository_owner == 'Cockatrice' && github.event_name == 'release' && github.event.release.prerelease == false
+    needs: build
     runs-on: ubuntu-slim
 
     steps:
-      - uses: actions/download-artifact@v4
+      - name: "Download digests"
+        uses: actions/download-artifact@v4
         with:
           path: $RUNNER_TEMP/digests
           pattern: digest-*
@@ -122,15 +136,15 @@ jobs:
       - name: "Login to GitHub Container Registry (GHCR)"
         uses: docker/login-action@v4
         with:
-          password: ${{ github.token }}
           registry: ghcr.io
           username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: "Docker metadata"
         id: metadata
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ env.GHCR_IMAGE }}
           tags: |
             type=raw,value=latest
             type=ref,event=tag
@@ -147,10 +161,14 @@ jobs:
 
           docker buildx imagetools create \
             --annotation "index:org.opencontainers.image.description=$OCI_DESCRIPTION" \
+            --annotation "index:org.opencontainers.image.source=$OCI_SOURCE" \
             --annotation "index:org.opencontainers.image.title=$OCI_TITLE" \
             --annotation "index:org.opencontainers.image.url=$OCI_URL" \
+            --annotation "index:org.opencontainers.image.version=$OCI_VERSION" \
             $TAG_ARGS \
-            $(printf '%s@sha256:%s ' "$IMAGE_NAME" *)
+            $(printf '%s@sha256:%s ' "$GHCR_IMAGE" *)
 
-      - name: "Inspect image"
-        run: docker buildx imagetools inspect "$IMAGE_NAME:latest"
+      - name: "Inspect image via tags"
+        run: |
+          docker buildx imagetools inspect "$GHCR_IMAGE:latest"
+          docker buildx imagetools inspect "$GHCR_IMAGE:$OCI_VERSION"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -148,7 +148,7 @@ jobs:
           flavor: |
             latest=auto
           tags: |
-            type=match,pattern=^\d{4}-\d{2}-\d{2}-Release-(\d+\.\d+\.\d+)$,group=1    # if semver: type=ref,event=tag and type=semver,pattern={{version}} / {{major}}.{{minor}}
+            type=ref,event=tag    # if semver, also: type=semver,pattern={{version}} / {{major}}.{{minor}}
 
       # Add OCI annotations to image index and publish tags
       - name: "Create image index"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -46,11 +46,11 @@ jobs:
         include:
           - label: x86
             platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-latest    # https://github.com/actions/runner-images
 
           - label: arm
             platform: linux/arm64
-            runner: ubuntu-24.04-arm    # to be replaced with "ubuntu-latest-arm" once available
+            runner: ubuntu-24.04-arm    # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Arm64-Readme.md, replace with "ubuntu-latest-arm" once available
 
     env:
       CACHE_SCOPE: servatrice-${{ matrix.label }}
@@ -123,7 +123,7 @@ jobs:
     name: "Publish multi-platform Servatrice image"
     if: github.repository_owner == 'Cockatrice' && github.event_name == 'release' && github.event.release.prerelease == false
     needs: build
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-slim    # https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md
 
     steps:
       - name: "Download digests"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -95,7 +95,7 @@ jobs:
             org.opencontainers.image.description=${{ env.OCI_DESCRIPTION }}
             org.opencontainers.image.title=${{ env.OCI_TITLE }}
             org.opencontainers.image.url=${{ env.OCI_URL }}
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.GHCR_IMAGE }},name-canonical=true,push=true,push-by-digest=true
           platforms: ${{ matrix.platform }}
           provenance: mode=max    # Do not pass secrets as build arguments with this option
           sbom: true
@@ -113,7 +113,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           if-no-files-found: error
-          name: digest-${{ matrix.platform }}
+          name: digest-${{ matrix.label }}
           path: $RUNNER_TEMP/digests/*
           retention-days: 1
 
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: "Download digests"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: $RUNNER_TEMP/digests
           pattern: digest-*
@@ -152,11 +152,12 @@ jobs:
       # Add OCI annotations to image index and publish tags
       - name: "Create image index"
         env:
-          TAGS: ${{ steps.metadata.outputs.tags }}
+          DOCKER_TAGS: ${{ steps.metadata.outputs.tags }}
+          GITHUB_TAG: ${{ github.ref_name }}
         working-directory: ${{ runner.temp }}/digests
         run: |
           TAG_ARGS=""
-          for tag in $TAGS; do
+          for tag in $DOCKER_TAGS; do
             TAG_ARGS="$TAG_ARGS --tag $tag"
           done
 
@@ -171,4 +172,4 @@ jobs:
       - name: "Inspect images"
         run: |
           docker buildx imagetools inspect "$GHCR_IMAGE:latest"
-          docker buildx imagetools inspect "$GHCR_IMAGE:$OCI_VERSION"
+          docker buildx imagetools inspect "$GHCR_IMAGE:$GITHUB_TAG"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -167,7 +167,7 @@ jobs:
             --annotation "index:org.opencontainers.image.title=$OCI_TITLE" \
             --annotation "index:org.opencontainers.image.url=$OCI_URL" \
             $TAG_ARGS \
-            $(printf '%s@sha256:%s ' "$GHCR_IMAGE" *)
+            $(printf "$GHCR_IMAGE@sha256:%s " *)
 
       - name: "Inspect images"
         run: |

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -111,6 +111,7 @@ jobs:
         if: steps.login.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
+          archive: false
           if-no-files-found: error
           name: digest-${{ matrix.label }}
           path: ${{ runner.temp }}/digests/*
@@ -128,7 +129,6 @@ jobs:
       - name: "Download digests"
         uses: actions/download-artifact@v7
         with:
-          if_no_artifact_found: fail
           path: ${{ runner.temp }}/digests
           pattern: digest-*
           merge-multiple: true

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -145,9 +145,10 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.GHCR_IMAGE }}
+          flavor: |
+            latest=auto
           tags: |
-            type=raw,value=latest
-            type=ref,event=tag
+            type=match,pattern=^\d{4}-\d{2}-\d{2}-Release-(\d+\.\d+\.\d+)$,group=1    # if semver: type=ref,event=tag and type=semver,pattern={{version}} / {{major}}.{{minor}}
 
       # Add OCI annotations to image index and publish tags
       - name: "Create image index"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -2,7 +2,6 @@ name: Build Docker
 
 permissions:
   contents: read    # needed to checkout repo
-  id-token: write    # needed for signing attestations (SBOM & provenance) with GitHub OIDC
   packages: write    # needed for interacting with GHCR
 
 on:
@@ -105,7 +104,7 @@ jobs:
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          mkdir -p $RUNNER_TEMP/digests
+          mkdir -p "$RUNNER_TEMP/digests"
           touch "$RUNNER_TEMP/digests/${DIGEST#sha256:}"
 
       - name: "Upload digest"
@@ -129,6 +128,7 @@ jobs:
       - name: "Download digests"
         uses: actions/download-artifact@v7
         with:
+          if_no_artifact_found: fail
           path: ${{ runner.temp }}/digests
           pattern: digest-*
           merge-multiple: true
@@ -154,12 +154,16 @@ jobs:
       - name: "Create image index"
         env:
           DOCKER_TAGS: ${{ steps.metadata.outputs.tags }}
-          GITHUB_TAG: ${{ github.ref_name }}
         working-directory: ${{ runner.temp }}/digests
         run: |
-          TAG_ARGS=""
-          for tag in $DOCKER_TAGS; do
-            TAG_ARGS="$TAG_ARGS --tag $tag"
+          TAG_ARGS=()
+          while IFS= read -r tag; do
+            TAG_ARGS+=(--tag "$tag")
+          done <<< "$DOCKER_TAGS"
+
+          DIGEST_ARGS=()
+          for digest in *; do
+            DIGEST_ARGS+=("$GHCR_IMAGE@sha256:$digest")
           done
 
           docker buildx imagetools create \
@@ -167,10 +171,12 @@ jobs:
             --annotation "index:org.opencontainers.image.description=$OCI_DESCRIPTION" \
             --annotation "index:org.opencontainers.image.title=$OCI_TITLE" \
             --annotation "index:org.opencontainers.image.url=$OCI_URL" \
-            $TAG_ARGS \
-            $(printf "$GHCR_IMAGE@sha256:%s " *)
+            "${TAG_ARGS[@]}" \
+            "${DIGEST_ARGS[@]}"
 
       - name: "Inspect images"
+        env:
+          GITHUB_TAG: ${{ github.ref_name }}
         run: |
           docker buildx imagetools inspect "$GHCR_IMAGE:latest"
           docker buildx imagetools inspect "$GHCR_IMAGE:$GITHUB_TAG"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   # Create one platform-specific image and publish its OCI image manifest per matrix job
   build:
-    name: "${{ matrix.label }}"
+    name: "Servatrice (${{ matrix.label }})"
     if: github.repository_owner == 'Cockatrice'
     runs-on: ${{ matrix.runner }}
 
@@ -120,7 +120,7 @@ jobs:
 
   # Create an OCI image index from the platform-specific image manifests
   index:
-    name: "Publish multi-platform image"
+    name: "Publish multi-platform Servatrice image"
     if: github.repository_owner == 'Cockatrice' && github.event_name == 'release' && github.event.release.prerelease == false
     needs: build
     runs-on: ubuntu-slim

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,9 +1,9 @@
 name: Build Docker
 
 permissions:
-  actions: read
-  contents: read
-  packages: write
+  contents: read    # needed to checkout repo
+  id-token: write    # needed for signing attestations (SBOM & provenance) with GitHub OIDC
+  packages: write    # needed for interacting with GHCR
 
 on:
   push:
@@ -30,12 +30,11 @@ concurrency:
 env:
   GHCR_IMAGE: ghcr.io/cockatrice/servatrice
   OCI_DESCRIPTION: Server for Cockatrice, a cross-platform virtual tabletop for multiplayer card games
-  OCI_SOURCE: https://github.com/Cockatrice/Cockatrice
   OCI_TITLE: Servatrice
   OCI_URL: https://cockatrice.github.io/
-  OCI_VERSION: ${{ github.ref_name }}
 
 jobs:
+  # Create one platform-specific image and publish its OCI image manifest per matrix job
   build:
     name: "${{ matrix.label }}"
     if: github.repository_owner == 'Cockatrice'
@@ -53,6 +52,9 @@ jobs:
             platform: linux/arm64
             runner: ubuntu-24.04-arm    # to be replaced with "ubuntu-latest-arm" once available
 
+    env:
+      CACHE_SCOPE: servatrice-${{ matrix.label }}
+
     steps:
       - name: "Checkout"
         uses: actions/checkout@v7
@@ -69,33 +71,33 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      # Don't push for non-release triggers
       - name: "Build image"
         if: steps.login.outcome != 'success'
         uses: docker/build-push-action@v7
         with:
-          cache-from: type=gha,scope=servatrice-${{ matrix.label }}
-          cache-to: type=gha,mode=max,scope=servatrice-${{ matrix.label }}
+          cache-from: type=gha,scope=${{ env.CACHE_SCOPE }}
+          cache-to: type=gha,mode=max,scope=${{ env.CACHE_SCOPE }}
           context: .
           platforms: ${{ matrix.platform }}
           push: false
 
+      # Add OCI labels and push single-platform image by digest (without tags)
       - name: "Build image and push by digest"
         if: steps.login.outcome == 'success'
         id: build
         uses: docker/build-push-action@v7
         with:
-          cache-from: type=gha,scope=servatrice-${{ matrix.label }}
-          cache-to: type=gha,mode=max,scope=servatrice-${{ matrix.label }}
+          cache-from: type=gha,scope=${{ env.CACHE_SCOPE }}
+          cache-to: type=gha,mode=max,scope=${{ env.CACHE_SCOPE }}
           context: .
           labels: |
             org.opencontainers.image.description=${{ env.OCI_DESCRIPTION }}
-            org.opencontainers.image.source=${{ env.OCI_SOURCE }}
             org.opencontainers.image.title=${{ env.OCI_TITLE }}
             org.opencontainers.image.url=${{ env.OCI_URL }}
-            org.opencontainers.image.version=${{ env.OCI_VERSION }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           platforms: ${{ matrix.platform }}
-          provenance: mode=max
+          provenance: mode=max    # Do not pass secrets as build arguments with this option
           sbom: true
 
       - name: "Export digest"
@@ -116,8 +118,9 @@ jobs:
           retention-days: 1
 
 
-  merge:
-    name: "Publish multi-arch manifest"
+  # Create an OCI image index from the platform-specific image manifests
+  index:
+    name: "Publish multi-platform image"
     if: github.repository_owner == 'Cockatrice' && github.event_name == 'release' && github.event.release.prerelease == false
     needs: build
     runs-on: ubuntu-slim
@@ -129,9 +132,6 @@ jobs:
           path: $RUNNER_TEMP/digests
           pattern: digest-*
           merge-multiple: true
-
-      - name: "Set up Docker buildx"
-        uses: docker/setup-buildx-action@v4
 
       - name: "Login to GitHub Container Registry (GHCR)"
         uses: docker/login-action@v4
@@ -149,7 +149,8 @@ jobs:
             type=raw,value=latest
             type=ref,event=tag
 
-      - name: "Create manifest"
+      # Add OCI annotations to image index and publish tags
+      - name: "Create image index"
         env:
           TAGS: ${{ steps.metadata.outputs.tags }}
         working-directory: ${{ runner.temp }}/digests
@@ -160,15 +161,14 @@ jobs:
           done
 
           docker buildx imagetools create \
+            --prefer-index=true \
             --annotation "index:org.opencontainers.image.description=$OCI_DESCRIPTION" \
-            --annotation "index:org.opencontainers.image.source=$OCI_SOURCE" \
             --annotation "index:org.opencontainers.image.title=$OCI_TITLE" \
             --annotation "index:org.opencontainers.image.url=$OCI_URL" \
-            --annotation "index:org.opencontainers.image.version=$OCI_VERSION" \
             $TAG_ARGS \
             $(printf '%s@sha256:%s ' "$GHCR_IMAGE" *)
 
-      - name: "Inspect image via tags"
+      - name: "Inspect images"
         run: |
           docker buildx imagetools inspect "$GHCR_IMAGE:latest"
           docker buildx imagetools inspect "$GHCR_IMAGE:$OCI_VERSION"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           if-no-files-found: error
           name: digest-${{ matrix.label }}
-          path: $RUNNER_TEMP/digests/*
+          path: ${{ runner.temp }}/digests/*
           retention-days: 1
 
 
@@ -129,7 +129,7 @@ jobs:
       - name: "Download digests"
         uses: actions/download-artifact@v7
         with:
-          path: $RUNNER_TEMP/digests
+          path: ${{ runner.temp }}/digests
           pattern: digest-*
           merge-multiple: true
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           TAG_ARGS=""
           for tag in $TAGS; do
-            TAG_ARGS="$TAG_ARGS -t $tag"
+            TAG_ARGS="$TAG_ARGS --tag $tag"
           done
 
           docker buildx imagetools create \

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,6 +1,7 @@
-name: Build Docker Image
+name: Build Docker
 
 permissions:
+  actions: read
   contents: read
   packages: write
 
@@ -23,35 +24,31 @@ concurrency:
   group: "${{ github.workflow }} @ ${{ github.ref_name }}"
   cancel-in-progress: ${{ github.event_name != 'release' }}
 
+env:
+  IMAGE_NAME: ghcr.io/cockatrice/servatrice
+  OCI_DESCRIPTION: Server for Cockatrice, a cross-platform virtual tabletop for multiplayer card games
+  OCI_TITLE: Servatrice
+  OCI_URL: https://cockatrice.github.io/
+
 jobs:
-  docker:
-    name: amd64 & arm64
-    if: ${{ github.repository_owner == 'Cockatrice' }}
-    runs-on: ubuntu-latest
-  
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    name: "Build (${{ matrix.platform }})"
+    if: github.repository_owner == 'Cockatrice'
+    runs-on: ${{ matrix.runner }}
+
     steps:
       - name: "Checkout"
         uses: actions/checkout@v7
-
-      - name: "Docker metadata"
-        id: metadata
-        uses: docker/metadata-action@v6
-        env:
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: index    # needed for GHCR
-        with:
-          annotations: |
-            org.opencontainers.image.title=Servatrice
-            org.opencontainers.image.url=https://cockatrice.github.io/
-            org.opencontainers.image.description=Server for Cockatrice, a cross-platform virtual tabletop for multiplayer card games
-          images: |
-            ghcr.io/cockatrice/servatrice
-          labels: |
-            org.opencontainers.image.title=Servatrice
-            org.opencontainers.image.url=https://cockatrice.github.io/
-            org.opencontainers.image.description=Server for Cockatrice, a cross-platform virtual tabletop for multiplayer card games
-
-      - name: "Set up QEMU"
-        uses: docker/setup-qemu-action@v4
 
       - name: "Set up Docker buildx"
         uses: docker/setup-buildx-action@v4
@@ -65,14 +62,95 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
 
-      - name: "Build and push Docker image"
+      - name: "Build Docker image and push by digest"
+        if: steps.login.outcome == 'success'
+        id: build
         uses: docker/build-push-action@v7
         with:
-          annotations: ${{ steps.metadata.outputs.annotations }}
-          cache-from: type=gha,scope=servatrice
-          cache-to: type=gha,mode=max,scope=servatrice
+          cache-from: type=gha,scope=servatrice-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=servatrice-${{ matrix.platform }}
           context: .
-          labels: ${{ steps.metadata.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          push: ${{ steps.login.outcome == 'success' }}
-          tags: ${{ steps.metadata.outputs.tags }}
+          labels: |
+            org.opencontainers.image.description=${{ env.OCI_DESCRIPTION }}
+            org.opencontainers.image.title=${{ env.OCI_TITLE }}
+            org.opencontainers.image.url=${{ env.OCI_URL }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          platforms: ${{ matrix.platform }}
+
+      - name: "Build Docker image"
+        if: steps.login.outcome != 'success'
+        uses: docker/build-push-action@v7
+        with:
+          cache-from: type=gha,scope=servatrice-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=servatrice-${{ matrix.platform }}
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: false
+
+      - name: Export digest
+        if: steps.login.outcome == 'success'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p $RUNNER_TEMP/digests
+          touch "$RUNNER_TEMP/digests/${DIGEST#sha256:}"
+
+      - uses: actions/upload-artifact@v7
+        if: steps.login.outcome == 'success'
+        with:
+          name: digest-${{ matrix.platform }}
+          path: $RUNNER_TEMP/digests/*
+          retention-days: 1
+
+
+  merge:
+    needs: build
+    name: "Publish manifest"
+    if: github.repository_owner == 'Cockatrice' && github.event_name == 'release' && github.event.release.prerelease == false
+    runs-on: ubuntu-slim
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: $RUNNER_TEMP/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: "Set up Docker buildx"
+        uses: docker/setup-buildx-action@v4
+
+      - name: "Login to GitHub Container Registry (GHCR)"
+        uses: docker/login-action@v4
+        with:
+          password: ${{ github.token }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+
+      - name: "Docker metadata"
+        id: metadata
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=ref,event=tag
+
+      - name: "Create manifest"
+        env:
+          TAGS: ${{ steps.metadata.outputs.tags }}
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          TAG_ARGS=""
+          for tag in $TAGS; do
+            TAG_ARGS="$TAG_ARGS -t $tag"
+          done
+
+          docker buildx imagetools create \
+            --annotation "index:org.opencontainers.image.description=$OCI_DESCRIPTION" \
+            --annotation "index:org.opencontainers.image.title=$OCI_TITLE" \
+            --annotation "index:org.opencontainers.image.url=$OCI_URL" \
+            $TAG_ARGS \
+            $(printf '%s@sha256:%s ' "$IMAGE_NAME" *)
+
+      - name: "Inspect image"
+        run: docker buildx imagetools inspect "$IMAGE_NAME:latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,11 @@ WORKDIR /src
 COPY . .
 RUN cmake \
       -S . \
-	  -B build \
+      -B build \
       -G Ninja \
-      -DWITH_SERVER=1 \
       -DWITH_CLIENT=0 \
       -DWITH_ORACLE=0 \
+      -DWITH_SERVER=1 \
     && cmake --build build \
     && cmake --install build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
       build-essential \
-      ccache \
       cmake \
       ninja-build \
       file \
@@ -20,24 +19,17 @@ RUN apt-get update \
       qt6-tools-dev \
       qt6-tools-dev-tools
 
-ENV CCACHE_DIR=/root/.ccache
-ENV CCACHE_MAXSIZE=550M
 WORKDIR /src
 COPY . .
-RUN --mount=type=cache,id=ccache,target=/root/.ccache \
-    cmake \
-	  -S . \
+RUN cmake \
+      -S . \
 	  -B build \
       -G Ninja \
-      -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       -DWITH_SERVER=1 \
       -DWITH_CLIENT=0 \
       -DWITH_ORACLE=0 \
     && cmake --build build \
-    && cmake --install build \
-	&& ccache --show-config \
-    && ccache --show-stats
+    && cmake --install build
 
 
 # -------- Runtime Stage (clean) --------

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,47 +3,53 @@ FROM ubuntu:26.04 AS build
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  build-essential \
-  ccache \
-  cmake \
-  ninja-build \
-  file \
-  g++ \
-  git \
-  libmariadb-dev-compat \
-  libprotobuf-dev \
-  libqt6sql6-mysql \
-  qt6-websockets-dev \
-  protobuf-compiler \
-  qt6-tools-dev \
-  qt6-tools-dev-tools
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      build-essential \
+      ccache \
+      cmake \
+      ninja-build \
+      file \
+      g++ \
+      git \
+      libmariadb-dev-compat \
+      libprotobuf-dev \
+      libqt6sql6-mysql \
+      qt6-websockets-dev \
+      protobuf-compiler \
+      qt6-tools-dev \
+      qt6-tools-dev-tools
 
 ENV CCACHE_DIR=/root/.ccache
 ENV CCACHE_MAXSIZE=550M
 WORKDIR /src
 COPY . .
-RUN --mount=type=cache,target=/root/.ccache \
-  cmake -S . -B build \
-    -G Ninja \
-    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-    -DWITH_SERVER=1 \
-    -DWITH_CLIENT=0 \
-    -DWITH_ORACLE=0 \
-      && cmake --build build \
-      && cmake --install build
-
-RUN ccache --show-stats
+RUN --mount=type=cache,id=ccache,target=/root/.ccache \
+    cmake \
+	  -S . \
+	  -B build \
+      -G Ninja \
+      -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+      -DWITH_SERVER=1 \
+      -DWITH_CLIENT=0 \
+      -DWITH_ORACLE=0 \
+    && cmake --build build \
+    && cmake --install build \
+	&& ccache --show-config \
+    && ccache --show-stats
 
 
 # -------- Runtime Stage (clean) --------
 FROM ubuntu:26.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  libprotobuf32t64 \
-  libqt6sql6-mysql \
-  libqt6websockets6 \
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      libprotobuf32t64 \
+      libqt6sql6-mysql \
+      libqt6websockets6 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
+  ccache \
   cmake \
   ninja-build \
   file \
@@ -18,15 +19,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   qt6-tools-dev \
   qt6-tools-dev-tools
 
+ENV CCACHE_DIR=/root/.ccache
+ENV CCACHE_MAXSIZE=550M
 WORKDIR /src
 COPY . .
-RUN cmake -S . -B build \
-  -G Ninja \
-  -DWITH_SERVER=1 \
-  -DWITH_CLIENT=0 \
-  -DWITH_ORACLE=0 \
-    && cmake --build build \
-    && cmake --install build
+RUN --mount=type=cache,target=/root/.ccache \
+  cmake -S . -B build \
+    -G Ninja \
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DWITH_SERVER=1 \
+    -DWITH_CLIENT=0 \
+    -DWITH_ORACLE=0 \
+      && cmake --build build \
+      && cmake --install build
+
+RUN ccache --show-stats
 
 
 # -------- Runtime Stage (clean) --------

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
   cmake \
+  ninja-build \
   file \
   g++ \
   git \
@@ -19,10 +20,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /src
 COPY . .
-RUN mkdir build && cd build && \
-    cmake .. -DWITH_SERVER=1 -DWITH_CLIENT=0 -DWITH_ORACLE=0 && \
-    make -j$(nproc) && \
-    make install
+RUN cmake -S . -B build \
+  -G Ninja \
+  -DWITH_SERVER=1 \
+  -DWITH_CLIENT=0 \
+  -DWITH_ORACLE=0 \
+    && cmake --build build \
+    && cmake --install build
 
 
 # -------- Runtime Stage (clean) --------

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -46,6 +46,9 @@
 #include <libcockatrice/protocol/pb/event_server_shutdown.pb.h>
 #include <server_room.h>
 
+
+/* test */
+
 Servatrice_GameServer::Servatrice_GameServer(Servatrice *_server,
                                              int _numberPools,
                                              const QSqlDatabase &_sqlDatabase,

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -46,9 +46,6 @@
 #include <libcockatrice/protocol/pb/event_server_shutdown.pb.h>
 #include <server_room.h>
 
-
-/* test */
-
 Servatrice_GameServer::Servatrice_GameServer(Servatrice *_server,
                                              int _numberPools,
                                              const QSqlDatabase &_sqlDatabase,


### PR DESCRIPTION
## Short roundup of the initial problem
The multi-arch Docker build used QEMU emulation and was very slow for ARM.
Total build time was often 50min.

## What will change with this Pull Request?
- Build images on native architectures in parallel (GitHub has ARM runners as well)
  First build took 5min per arch (in parallel): https://github.com/Cockatrice/Cockatrice/actions/runs/29617876779
  - On releases: build + push images & digests
  - Other triggers: build only
- On completion, merge both into one multi-arch manifest and publish new tags (only for releases)

See e.g. https://obviy.us/blog/fastest-gha-multi-arch-docker
and https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners

<br>

Additional change:
- Use Ninja generator, same as in the main CI pipeline
- ~~Use ccache compiler cache, same as in the main CI pipeline~~
  According to the ["cache mount" docker docs](https://docs.docker.com/build/ci/github-actions/cache/#cache-mounts), BuildKit layer caching is not including cache mounts into GHA Cache. Setting "mode=max" and "type=gha" in `docker/build-push-action` is not changing that, confirmed this in this PR with a test run and checking "ccache --show-stats" as well.
The official documentation suggests to use another 3rd party action to manage and inject the compiler cache manually. As the performance is drastically increased by avoiding emulation alone, I think the extra complexity is not needed.
- Add SBOM

<br>

Performance impact: 10x quicker for uncached builds
- Old workflow
  - 1st run (QEMU emulation for ARM): **50 min** (uncached)
  - 2nd run (QEMU emulation for ARM): 30 s (layers cached)
- New workflow
  - ~~1st run (native ARM compilation + ninja + ccache): 6 min (uncached)~~
  - ~~2nd run (native ARM compilation + ninja + ccache): 30 s (layers cached)~~
  - ~~3rd run (native ARM compilation + ninja + ccache): 4 min (cpp change, dependency layer cached)~~
  - 4th run (native ARM compilation + ninja): **5 min** (uncached)
  - 5th run (native ARM compilation + ninja): 30 s (layers cached)

<br>

@maybeanerd Feel free to review & comment!

<br>

> [!NOTE]
> TODO after next release
> ```
> docker buildx imagetools inspect ghcr.io/cockatrice/servatrice:latest
> docker buildx imagetools inspect ghcr.io/cockatrice/servatrice:latest --raw
> ```
> - [ ] Verify attestations are present in single- and multi-platform images
> - [ ] Below labels and annotations are automatically added:
>   ```
>   "org.opencontainers.image.source": "https://github.com/Cockatrice/Cockatrice"
>   "org.opencontainers.image.licenses": "GPL-2.0"
>   "org.opencontainers.image.version": "<GITHUB_TAG>"
>   ```
> - [ ] Consider adding non-raw inspect output to GIHTUB_SUMMARY
