### PR TITLE
[SettingsButtonWidget] Fix memory leak from unparented popup

### DIFF
--- a/cockatrice/src/interface/widgets/quick_settings/settings_button_widget.cpp
+++ b/cockatrice/src/interface/widgets/quick_settings/settings_button_widget.cpp
@@ -6,7 +6,7 @@
 #include <QScreen>
 
 SettingsButtonWidget::SettingsButtonWidget(QWidget *parent)
-    : QWidget(parent), button(new QToolButton(this)), popup(new SettingsPopupWidget(this))
+    : QWidget(parent), button(new QToolButton(this)), popup(new SettingsPopupWidget(nullptr))
 {
     button->setIcon(QPixmap("theme:icons/cogwheel"));
     button->setCheckable(true);
@@ -18,6 +18,13 @@ SettingsButtonWidget::SettingsButtonWidget(QWidget *parent)
     layout->addWidget(button);
     layout->setContentsMargins(0, 0, 0, 0);
     setLayout(layout);
+}
+
+SettingsButtonWidget::~SettingsButtonWidget()
+{
+    // We don't parent the popup because it might lead to better behavior on certain window managers.
+    // So we have to manually delete it
+    popup->deleteLater();
 }
 
 void SettingsButtonWidget::addSettingsWidget(QWidget *toAdd) const

--- a/cockatrice/src/interface/widgets/quick_settings/settings_button_widget.cpp
+++ b/cockatrice/src/interface/widgets/quick_settings/settings_button_widget.cpp
@@ -6,7 +6,7 @@
 #include <QScreen>
 
 SettingsButtonWidget::SettingsButtonWidget(QWidget *parent)
-    : QWidget(parent), button(new QToolButton(this)), popup(new SettingsPopupWidget(nullptr))
+    : QWidget(parent), button(new QToolButton(this)), popup(new SettingsPopupWidget(this))
 {
     button->setIcon(QPixmap("theme:icons/cogwheel"));
     button->setCheckable(true);

--- a/cockatrice/src/interface/widgets/quick_settings/settings_button_widget.h
+++ b/cockatrice/src/interface/widgets/quick_settings/settings_button_widget.h
@@ -19,6 +19,9 @@ class SettingsButtonWidget : public QWidget
 
 public:
     explicit SettingsButtonWidget(QWidget *parent = nullptr);
+
+    ~SettingsButtonWidget() override;
+
     void addSettingsWidget(QWidget *toAdd) const;
     void removeSettingsWidget(QWidget *toRemove) const;
     void setButtonIcon(QPixmap iconMap);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #5816

## Short roundup of the initial problem

As noted in [this comment](https://github.com/Cockatrice/Cockatrice/pull/7037#discussion_r3635007374), the `SettingsButtonWidget` currently has a memory leak. It doesn't parent the `SettingsPopupWidget` it creates, which causes it to get leaked once the `SettingsButtonWidget` is destroyed.

## What will change with this Pull Request?

- Delete the `SettingsPopupWidget` in the `SettingsButtonWidget` destructor.