### PR TITLE
[Game] Implement total power tally

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -99,6 +99,7 @@ set(cockatrice_SOURCES
     src/game_graphics/player/menu/sideboard_menu.cpp
     src/game_graphics/player/menu/tally_menu.cpp
     src/game_graphics/player/menu/utility_menu.cpp
+    src/game_graphics/tally/stats_tally.cpp
     src/game_graphics/tally/subtype_tally.cpp
     src/game_graphics/tally/tally.cpp
     src/game/player/player_actions.cpp

--- a/cockatrice/src/game_graphics/player/menu/tally_menu.cpp
+++ b/cockatrice/src/game_graphics/player/menu/tally_menu.cpp
@@ -11,10 +11,12 @@ TallyMenu::TallyMenu()
 
     aTallyNone = createTallyAction(TallyType::None);
     aTallySubtypes = createTallyAction(TallyType::Subtypes);
+    aTallyTotalPower = createTallyAction(TallyType::TotalPower);
 
     addAction(aTallyNone);
     addSeparator();
     addAction(aTallySubtypes);
+    addAction(aTallyTotalPower);
 
     retranslateUi();
 }
@@ -51,4 +53,5 @@ void TallyMenu::retranslateUi()
 
     aTallyNone->setText(tr("None"));
     aTallySubtypes->setText(tr("Subtypes"));
+    aTallyTotalPower->setText(tr("Total power"));
 }

--- a/cockatrice/src/game_graphics/player/menu/tally_menu.cpp
+++ b/cockatrice/src/game_graphics/player/menu/tally_menu.cpp
@@ -53,5 +53,5 @@ void TallyMenu::retranslateUi()
 
     aTallyNone->setText(tr("None"));
     aTallySubtypes->setText(tr("Subtypes"));
-    aTallyTotalPower->setText(tr("Total power"));
+    aTallyTotalPower->setText(tr("Total Power"));
 }

--- a/cockatrice/src/game_graphics/player/menu/tally_menu.h
+++ b/cockatrice/src/game_graphics/player/menu/tally_menu.h
@@ -23,6 +23,7 @@ private:
 
     QAction *aTallyNone = nullptr;
     QAction *aTallySubtypes = nullptr;
+    QAction *aTallyTotalPower = nullptr;
 
     QAction *createTallyAction(TallyType tallyType);
 };

--- a/cockatrice/src/game_graphics/tally/stats_tally.cpp
+++ b/cockatrice/src/game_graphics/tally/stats_tally.cpp
@@ -1,0 +1,35 @@
+#include "stats_tally.h"
+
+#include "../board/card_item.h"
+
+#include <QCoreApplication>
+#include <QList>
+
+static int sumPowers(const QList<CardItem *> &cards)
+{
+    // calculate total power;
+    int total = 0;
+    for (auto card : cards) {
+        QVariantList parsed = CardItem::parsePT(card->getPT());
+        if (!parsed.isEmpty()) {
+            int power = parsed.first().toInt(); // toInt will default to 0 if it's not an int
+            total += qMax(power, 0);
+        }
+    }
+    return total;
+}
+
+QList<TallyRow> StatsTally::computeTotalPower(const QList<CardItem *> &cards)
+{
+    // don't bother if none of the cards have pt
+    bool hasPT =
+        std::any_of(cards.cbegin(), cards.cend(), [](const CardItem *card) { return !card->getPT().isEmpty(); });
+    if (!hasPT) {
+        return {};
+    }
+
+    int total = sumPowers(cards);
+
+    QString name = QCoreApplication::translate("StatsTally", "Total Power");
+    return {TallyRow{name, QString::number(total)}};
+}

--- a/cockatrice/src/game_graphics/tally/stats_tally.cpp
+++ b/cockatrice/src/game_graphics/tally/stats_tally.cpp
@@ -4,6 +4,7 @@
 
 #include <QCoreApplication>
 #include <QList>
+#include <algorithm>
 
 static int sumPowers(const QList<CardItem *> &cards)
 {

--- a/cockatrice/src/game_graphics/tally/stats_tally.h
+++ b/cockatrice/src/game_graphics/tally/stats_tally.h
@@ -1,5 +1,5 @@
-#ifndef COCKATRICE_POWER_TALLY_H
-#define COCKATRICE_POWER_TALLY_H
+#ifndef COCKATRICE_STATS_TALLY_H
+#define COCKATRICE_STATS_TALLY_H
 #include "tally.h"
 
 /**
@@ -18,4 +18,4 @@ QList<TallyRow> computeTotalPower(const QList<CardItem *> &cards);
 
 } // namespace StatsTally
 
-#endif // COCKATRICE_POWER_TALLY_H
+#endif // COCKATRICE_STATS_TALLY_H

--- a/cockatrice/src/game_graphics/tally/stats_tally.h
+++ b/cockatrice/src/game_graphics/tally/stats_tally.h
@@ -1,0 +1,21 @@
+#ifndef COCKATRICE_POWER_TALLY_H
+#define COCKATRICE_POWER_TALLY_H
+#include "tally.h"
+
+/**
+ * @brief Extracts and tallies stats from selected cards.
+ */
+namespace StatsTally
+{
+
+/**
+ * @brief Sums the power of all selected cards
+ *
+ * @param cards The list of selected card items to analyze.
+ * @return A single row containing the total, or an empty list if none of the cards have pt
+ */
+QList<TallyRow> computeTotalPower(const QList<CardItem *> &cards);
+
+} // namespace StatsTally
+
+#endif // COCKATRICE_POWER_TALLY_H

--- a/cockatrice/src/game_graphics/tally/tally.cpp
+++ b/cockatrice/src/game_graphics/tally/tally.cpp
@@ -1,5 +1,6 @@
 #include "tally.h"
 
+#include "stats_tally.h"
 #include "subtype_tally.h"
 
 TallyType Tally::intToType(int value)
@@ -18,6 +19,8 @@ QList<TallyRow> Tally::compute(const QList<CardItem *> &cards, const TallyType t
             return {};
         case TallyType::Subtypes:
             return SubtypeTally::countSubtypes(cards);
+        case TallyType::TotalPower:
+            return StatsTally::computeTotalPower(cards);
     }
     return {};
 }

--- a/cockatrice/src/game_graphics/tally/tally.h
+++ b/cockatrice/src/game_graphics/tally/tally.h
@@ -20,7 +20,8 @@ enum class TallyType
 {
     None,
     Subtypes,
-    MaxValue = Subtypes // sentinel value
+    TotalPower,
+    MaxValue = TotalPower // sentinel value
 };
 
 namespace Tally


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #7036

## Short roundup of the initial problem

Being able to see the total power at a glance is very useful.

## What will change with this Pull Request?
- Add `Total Power` tally option
  - The tally will display a single row containing the total power of all selected cards
  - uses `CardItem::parsePT` to extract the powers
  - Will return empty if no cards with pt are selected, which will cause it to not display anything

Note that the tally will not automatically update if the p/t changes while the selection is already made. This can be something to fix in the future

https://github.com/user-attachments/assets/570d54ce-7a41-4ba1-8891-38d8870d7e50

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
