### PR TITLE
[Game] Remove tally requiring two cards selected

### DIFF
--- a/cockatrice/src/game_graphics/game_view.cpp
+++ b/cockatrice/src/game_graphics/game_view.cpp
@@ -253,7 +253,7 @@ void GameView::updateTotalSelectionCount(const QSize &viewSize)
     GameScene *gameScene = static_cast<GameScene *>(scene());
     QList<TallyRow> entries = Tally::compute(gameScene->selectedCards(), tallyType);
 
-    if (entries.isEmpty() || count <= 1) {
+    if (entries.isEmpty()) {
         tallyContainer->hide();
         cachedTallyRows.clear();
         return;


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #7036
- Changes behavior from #6923

## Short roundup of the initial problem

The tally not working until at least two cards are selected is unintuitive.
Especially after adding the total power tally, it makes more sense for the tally to be visible as long as there is anything to display.

## What will change with this Pull Request?

- Tally will still show even if only one card is selected.

https://github.com/user-attachments/assets/d668a11e-7e9b-4c68-89a3-9ea4d2b9f92d