### PR TITLE
[Replay] Refactor: rename ReplayManager to ReplayWidget

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -229,9 +229,9 @@ set(cockatrice_SOURCES
     src/interface/widgets/printing_selector/set_name_and_collectors_number_display_widget.cpp
     src/interface/widgets/quick_settings/settings_button_widget.cpp
     src/interface/widgets/quick_settings/settings_popup_widget.cpp
-    src/interface/widgets/replay/replay_manager.cpp
     src/interface/widgets/replay/replay_quick_settings_widget.cpp
     src/interface/widgets/replay/replay_timeline_widget.cpp
+    src/interface/widgets/replay/replay_widget.cpp
     src/interface/widgets/server/chat_view/chat_view.cpp
     src/interface/widgets/server/game_filter_configs.cpp
     src/interface/widgets/server/game_selector.cpp

--- a/cockatrice/src/interface/widgets/replay/replay_widget.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_widget.cpp
@@ -1,4 +1,4 @@
-#include "replay_manager.h"
+#include "replay_widget.h"
 
 #include "../../../client/settings/shortcuts_settings.h"
 #include "../interface/widgets/tabs/tab_game.h"
@@ -7,7 +7,7 @@
 #include <QHBoxLayout>
 #include <QToolButton>
 
-ReplayManager::ReplayManager(TabGame *parent, GameReplay *_replay)
+ReplayWidget::ReplayWidget(TabGame *parent, GameReplay *_replay)
     : QWidget(parent), game(parent), replay(_replay), replayPlayButton(nullptr), replayFastForwardButton(nullptr),
       aReplaySkipForward(nullptr), aReplaySkipBackward(nullptr), aReplaySkipForwardBig(nullptr),
       aReplaySkipBackwardBig(nullptr)
@@ -41,9 +41,9 @@ ReplayManager::ReplayManager(TabGame *parent, GameReplay *_replay)
     // timeline widget
     timelineWidget = new ReplayTimelineWidget;
     timelineWidget->setTimeline(replayTimeline);
-    connect(timelineWidget, &ReplayTimelineWidget::processNextEvent, this, &ReplayManager::replayNextEvent);
-    connect(timelineWidget, &ReplayTimelineWidget::replayFinished, this, &ReplayManager::replayFinished);
-    connect(timelineWidget, &ReplayTimelineWidget::rewound, this, &ReplayManager::replayRewind);
+    connect(timelineWidget, &ReplayTimelineWidget::processNextEvent, this, &ReplayWidget::replayNextEvent);
+    connect(timelineWidget, &ReplayTimelineWidget::replayFinished, this, &ReplayWidget::replayFinished);
+    connect(timelineWidget, &ReplayTimelineWidget::rewound, this, &ReplayWidget::replayRewind);
 
     // timeline skip shortcuts
     aReplaySkipForward = new QAction(timelineWidget);
@@ -74,13 +74,13 @@ ReplayManager::ReplayManager(TabGame *parent, GameReplay *_replay)
     playButtonIcon.addPixmap(QPixmap("theme:replay/pause"), QIcon::Normal, QIcon::On);
     replayPlayButton->setIcon(playButtonIcon);
     replayPlayButton->setCheckable(true);
-    connect(replayPlayButton, &QToolButton::toggled, this, &ReplayManager::replayPlayButtonToggled);
+    connect(replayPlayButton, &QToolButton::toggled, this, &ReplayWidget::replayPlayButtonToggled);
 
     replayFastForwardButton = new QToolButton;
     replayFastForwardButton->setIconSize(QSize(32, 32));
     replayFastForwardButton->setIcon(QPixmap("theme:replay/fastforward"));
     replayFastForwardButton->setCheckable(true);
-    connect(replayFastForwardButton, &QToolButton::toggled, this, &ReplayManager::updateTimeScaleFactor);
+    connect(replayFastForwardButton, &QToolButton::toggled, this, &ReplayWidget::updateTimeScaleFactor);
 
     settingsWidget = new ReplayQuickSettingsWidget(this);
     settingsWidget->setFixedSize(QSize(32, 32));
@@ -97,24 +97,24 @@ ReplayManager::ReplayManager(TabGame *parent, GameReplay *_replay)
     setObjectName("replayControlWidget");
     setLayout(replayControlLayout);
 
-    connect(this, &ReplayManager::requestChatAndPhaseReset, game, &TabGame::resetChatAndPhase);
+    connect(this, &ReplayWidget::requestChatAndPhaseReset, game, &TabGame::resetChatAndPhase);
 
     connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
-            &ReplayManager::refreshShortcuts);
+            &ReplayWidget::refreshShortcuts);
     refreshShortcuts();
 }
 
-void ReplayManager::replayNextEvent(EventProcessingOptions options)
+void ReplayWidget::replayNextEvent(EventProcessingOptions options)
 {
     emit eventReplayed(replay->event_list(timelineWidget->getCurrentEvent()), options);
 }
 
-void ReplayManager::replayFinished()
+void ReplayWidget::replayFinished()
 {
     replayPlayButton->setChecked(false);
 }
 
-void ReplayManager::replayPlayButtonToggled(bool checked)
+void ReplayWidget::replayPlayButtonToggled(bool checked)
 {
     if (checked) { // start replay
         timelineWidget->startReplay();
@@ -123,7 +123,7 @@ void ReplayManager::replayPlayButtonToggled(bool checked)
     }
 }
 
-void ReplayManager::updateTimeScaleFactor(bool isFastForward)
+void ReplayWidget::updateTimeScaleFactor(bool isFastForward)
 {
     qreal factor = isFastForward ? SettingsCache::instance().interface().getFastForwardSpeed() : 1.0;
     timelineWidget->setTimeScaleFactor(factor);
@@ -132,12 +132,12 @@ void ReplayManager::updateTimeScaleFactor(bool isFastForward)
 /**
  * @brief Handles everything that needs to be reset when doing a replay rewind.
  */
-void ReplayManager::replayRewind()
+void ReplayWidget::replayRewind()
 {
     emit requestChatAndPhaseReset();
 }
 
-void ReplayManager::refreshShortcuts()
+void ReplayWidget::refreshShortcuts()
 {
     ShortcutsSettings &shortcuts = SettingsCache::instance().shortcuts();
     if (aReplaySkipForward) {

--- a/cockatrice/src/interface/widgets/replay/replay_widget.h
+++ b/cockatrice/src/interface/widgets/replay/replay_widget.h
@@ -1,12 +1,12 @@
 /**
- * @file replay_manager.h
+ * @file replay_widget.h
  * @ingroup Core
  * @ingroup Replay
  */
 //! \todo Document this file.
 
-#ifndef REPLAY_MANAGER_H
-#define REPLAY_MANAGER_H
+#ifndef REPLAY_WIDGET_H
+#define REPLAY_WIDGET_H
 
 #include "replay_timeline_widget.h"
 
@@ -17,12 +17,16 @@
 class ReplayQuickSettingsWidget;
 class TabGame;
 
-class ReplayManager : public QWidget
+/**
+ * @brief The top-level that is put in the replay dock widget.
+ * Contains the replay timeline as well as the buttons.
+ */
+class ReplayWidget : public QWidget
 {
     Q_OBJECT
 
 public:
-    ReplayManager(TabGame *parent, GameReplay *replay);
+    ReplayWidget(TabGame *parent, GameReplay *replay);
     TabGame *game;
     GameReplay *replay;
 
@@ -48,4 +52,4 @@ private slots:
     void refreshShortcuts();
 };
 
-#endif // REPLAY_MANAGER_H
+#endif // REPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -265,8 +265,8 @@ void TabGame::emitUserEvent()
 
 TabGame::~TabGame()
 {
-    if (replayManager) {
-        delete replayManager->replay;
+    if (replayWidget) {
+        delete replayWidget->replay;
     }
     for (auto &player : game->getPlayerManager()->getPlayers()) {
         player->clear();
@@ -1174,16 +1174,16 @@ void TabGame::createPlayAreaWidget(bool bReplay)
 
 void TabGame::createReplayDock(GameReplay *replay)
 {
-    replayManager = new ReplayManager(this, replay);
+    replayWidget = new ReplayWidget(this, replay);
 
     replayDock = new QDockWidget(this);
     replayDock->setObjectName("replayDock");
     replayDock->setFeatures(QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetFloatable |
                             QDockWidget::DockWidgetMovable);
-    replayDock->setWidget(replayManager);
+    replayDock->setWidget(replayWidget);
     replayDock->setFloating(false);
 
-    connect(replayManager, &ReplayManager::eventReplayed, game->getGameEventHandler(),
+    connect(replayWidget, &ReplayWidget::eventReplayed, game->getGameEventHandler(),
             [this](const auto &event, auto options) {
                 game->getGameEventHandler()->processGameEventContainer(event, nullptr, options);
             });

--- a/cockatrice/src/interface/widgets/tabs/tab_game.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.h
@@ -13,7 +13,7 @@
 #include "../game/player/player_logic.h"
 #include "../game_graphics/log/message_log_widget.h"
 #include "../interface/widgets/menus/tearoff_menu.h"
-#include "../interface/widgets/replay/replay_manager.h"
+#include "../interface/widgets/replay/replay_widget.h"
 #include "tab.h"
 
 #include <QCompleter>
@@ -31,7 +31,7 @@ class AbstractClient;
 class CardDatabase;
 class GameView;
 class GameScene;
-class ReplayManager;
+class ReplayWidget;
 class CardInfoFrameWidget;
 class QTimer;
 class QSplitter;
@@ -59,7 +59,7 @@ class TabGame : public Tab
 private:
     AbstractGame *game;
     const UserListProxy *userListProxy;
-    ReplayManager *replayManager = nullptr;
+    ReplayWidget *replayWidget = nullptr;
     QStringList gameTypes;
     QCompleter *completer;
     QStringList autocompleteUserList;


### PR DESCRIPTION
## Short roundup of the initial problem

The replay logic is scattered across two classes, which is making it hard for me to implement the feature I want. Namely, this current design means the `ReplayTimelineWidget` doesn't know anything about the contents of event while it's processing it.

The refactor will include moving the replay logic to a centralized class, so that the QWidget classes are only responsible for the ui. That class wants the name `ReplayManager`. `ReplayWidget` would be a better name for the current ReplayManager class. 

## What will change with this Pull Request?
- Rename `ReplayManager` to `ReplayWidget`