### PR TITLE
[Settings] Capitalize option label

### DIFF
--- a/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.cpp
+++ b/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.cpp
@@ -241,11 +241,11 @@ void UserInterfaceSettingsPage::retranslateUi()
     visualDeckStoragePromptForConversionLabel.setText(
         tr("When adding a tag in the visual deck storage to a .txt deck:"));
     visualDeckStoragePromptForConversionSelector.setItemText(visualDeckStoragePromptForConversionIndexNone,
-                                                             tr("do nothing"));
+                                                             tr("Do nothing"));
     visualDeckStoragePromptForConversionSelector.setItemText(visualDeckStoragePromptForConversionIndexPrompt,
-                                                             tr("ask to convert to .cod"));
+                                                             tr("Ask to convert to .cod"));
     visualDeckStoragePromptForConversionSelector.setItemText(visualDeckStoragePromptForConversionIndexAlways,
-                                                             tr("always convert to .cod"));
+                                                             tr("Always convert to .cod"));
     defaultDeckEditorTypeLabel.setText(tr("Default deck editor type"));
     defaultDeckEditorTypeSelector.setItemText(TabSupervisor::ClassicDeckEditor, tr("Classic Deck Editor"));
     defaultDeckEditorTypeSelector.setItemText(TabSupervisor::VisualDeckEditor, tr("Visual Deck Editor"));


### PR DESCRIPTION
## Short roundup of the initial problem
Lower casing of dropdown elements

## What will change with this Pull Request?
- Capitalize options in dropdown

Edited this in the browser, not sure why file ending changed.

## Screenshots
Before:
<!-- simply drag & drop image files directly into this description! -->
<img width="697" height="171" alt="image" src="https://github.com/user-attachments/assets/c0e3e2b9-9723-4b99-ae18-1a2a1d2d75fe" />

Other example where we do it correctly:
<img width="697" height="112" alt="image" src="https://github.com/user-attachments/assets/9308ccd7-048b-455c-9b97-72f61da57dcd" />
