### PR TITLE
Update vcpkg submodule to `2026.07.29` release (+ add baseline)

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
   "dependencies": [
     "gtest",
     "liblzma",


### PR DESCRIPTION
## Related Ticket(s)
- Enables #7032

## Short roundup of the initial problem
vcpkg-tool had a bug which prevented dependency graphs to be updated in GitHub

## What will change with this Pull Request?
- Update vcpkg submodule to [2026-07-29 Release](https://github.com/microsoft/vcpkg/releases/tag/2026.07.29)
- Fixed vcpkg-tool version is included
- Add `builtin-baseline` to vcpkg manifest with same commit hash than submodule for consistent and reproducible builds