### PR TITLE
CI: Improve vcpkg cache hits

### DIFF
--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -159,6 +159,7 @@ if [[ $PACKAGE_TYPE ]]; then
 fi
 if [[ $USE_VCPKG ]]; then
   flags+=("-DUSE_VCPKG=1")
+  flags+=("-DVCPKG_INSTALL_OPTIONS=--x-abi-tools-use-exact-versions")
 fi
 
 # Add cmake --build flags


### PR DESCRIPTION
## Short roundup of the initial problem
ABI hash comparison is also based on tool versions.

## What will change with this Pull Request?
- Use a specific flag (`--x-abi-tools-use-exact-version`) recommended by Microsoft when using vcpkg in CI with GitHub hosted runners.
  It leads to tool version changes being ruled out as source of ABI hash mismatches and vcpkg will manage downloading of uniform tool versions in CI runs to make cached binaries more likely to have the same ABI hash (e.g. changes in the underlaying GitHub hosted runner would still invalidate it).

See https://learn.microsoft.com/en-us/vcpkg/users/binarycaching-troubleshooting#abi-mismatch
