### PR TITLE
[Replay] Implement option to skip empty sections

### DIFF
--- a/cockatrice/src/interface/widgets/replay/replay_manager.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_manager.cpp
@@ -3,9 +3,11 @@
 #include "../../../client/settings/cache_settings.h"
 
 #include <QTimer>
+#include <libcockatrice/protocol/get_pb_extension.h>
 #include <libcockatrice/settings/interface_settings.h>
 
 static constexpr int TIMER_INTERVAL_MS = 200;
+static constexpr int EMPTY_SECTION_MARGIN_MS = 500;
 
 static QList<int> createReplayTimeline(const GameReplay *replay)
 {
@@ -119,6 +121,10 @@ void ReplayManager::replayTimerTimeout()
     processNewEvents(NORMAL_PLAYBACK);
 
     timeChanged(currentVisualTime);
+
+    if (skipEmptySections) {
+        handleSkipEmptySection();
+    }
 }
 
 /** @brief Processes all unprocessed events up to the current time. */
@@ -149,11 +155,61 @@ void ReplayManager::processNewEvents(PlaybackMode playbackMode)
     }
 }
 
+static bool hasMeaningfulEvent(const GameEventContainer &cont)
+{
+    const int eventListSize = cont.event_list_size();
+    for (int i = 0; i < eventListSize; ++i) {
+        const GameEvent &event = cont.event_list(i);
+        const auto eventType = static_cast<GameEvent::GameEventType>(getPbExtension(event));
+
+        if (eventType != GameEvent::PLAYER_PROPERTIES_CHANGED) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void ReplayManager::handleSkipEmptySection()
+{
+    if (currentEvent == replayTimeline.size()) {
+        return;
+    }
+
+    // find most recent meaningful event
+    int prevEvent = currentEvent;
+    for (; prevEvent > 0 && !hasMeaningfulEvent(replay->event_list(prevEvent)); --prevEvent) {
+    }
+
+    int prevEventTime = replayTimeline.value(prevEvent);
+    if (currentVisualTime - prevEventTime <= EMPTY_SECTION_MARGIN_MS) {
+        return;
+    }
+
+    // find next earliest meaningful event
+    int nextEvent = currentEvent + 1;
+    for (; nextEvent < replayTimeline.size() - 1 && !hasMeaningfulEvent(replay->event_list(nextEvent)); ++nextEvent) {
+    }
+
+    int nextEventTime = replayTimeline.value(nextEvent);
+    if (nextEventTime - currentVisualTime <= EMPTY_SECTION_MARGIN_MS) {
+        return;
+    }
+
+    // skip forward if we're not within margin of either event
+    skipToTime(nextEventTime - EMPTY_SECTION_MARGIN_MS, false);
+}
+
 void ReplayManager::setTimeScaleFactor(qreal _timeScaleFactor)
 {
     timeScaleFactor = _timeScaleFactor;
     int interval = std::max(1, qRound(TIMER_INTERVAL_MS / timeScaleFactor));
     replayTimer->setInterval(interval);
+}
+
+void ReplayManager::setSkipEmptySections(bool value)
+{
+    skipEmptySections = value;
 }
 
 void ReplayManager::startReplay()

--- a/cockatrice/src/interface/widgets/replay/replay_manager.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_manager.cpp
@@ -177,7 +177,7 @@ void ReplayManager::handleSkipEmptySection()
     }
 
     // find most recent meaningful event
-    int prevEvent = currentEvent;
+    int prevEvent = std::max(0, currentEvent - 1);
     for (; prevEvent > 0 && !hasMeaningfulEvent(replay->event_list(prevEvent)); --prevEvent) {
     }
 
@@ -187,7 +187,7 @@ void ReplayManager::handleSkipEmptySection()
     }
 
     // find next earliest meaningful event
-    int nextEvent = currentEvent + 1;
+    int nextEvent = currentEvent;
     for (; nextEvent < replayTimeline.size() - 1 && !hasMeaningfulEvent(replay->event_list(nextEvent)); ++nextEvent) {
     }
 

--- a/cockatrice/src/interface/widgets/replay/replay_manager.h
+++ b/cockatrice/src/interface/widgets/replay/replay_manager.h
@@ -31,6 +31,7 @@ class ReplayManager : public QObject
     QTimer *rewindBufferingTimer;
 
     qreal timeScaleFactor = 1.0;
+    bool skipEmptySections = false;
 
     int currentVisualTime = 0;    ///< time currently displayed by the timeline
     int currentProcessedTime = 0; ///< time that events are currently processed up to. Could differ from visual time due
@@ -41,6 +42,7 @@ class ReplayManager : public QObject
     void handleBackwardsSkip(bool doRewindBuffering);
     void processRewind();
     void processNewEvents(PlaybackMode playbackMode);
+    void handleSkipEmptySection();
 
 private slots:
     void replayTimerTimeout();
@@ -63,6 +65,7 @@ public:
     }
 
     void setTimeScaleFactor(qreal _timeScaleFactor);
+    void setSkipEmptySections(bool value);
 
 public slots:
     void startReplay();

--- a/cockatrice/src/interface/widgets/replay/replay_quick_settings_widget.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_quick_settings_widget.cpp
@@ -18,12 +18,17 @@ ReplayQuickSettingsWidget::ReplayQuickSettingsWidget(QWidget *parent) : Settings
     connect(&fastForwardSpeedBox, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
             &ReplayQuickSettingsWidget::actUpdateFastForwardSpeed);
 
+    skipEmptyCheckBox.setChecked(SettingsCache::instance().interface().getSkipEmptySections());
+    connect(&skipEmptyCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+            &ReplayQuickSettingsWidget::actUpdateSkipEmptySections);
+
     // putting it all together
     auto *widget = new QWidget;
     auto *grid = new QGridLayout(widget);
     grid->setContentsMargins(0, 0, 0, 0);
     grid->addWidget(&fastForwardSpeedLabel, 0, 0, 1, 1);
     grid->addWidget(&fastForwardSpeedBox, 0, 1, 1, 1);
+    grid->addWidget(&skipEmptyCheckBox, 1, 0, 1, 2);
 
     this->addSettingsWidget(widget);
 
@@ -36,10 +41,18 @@ void ReplayQuickSettingsWidget::retranslateUi()
 {
     fastForwardSpeedLabel.setText(tr("Fast forward speed:"));
     fastForwardSpeedBox.setSuffix("x");
+
+    skipEmptyCheckBox.setText(tr("Skip empty sections"));
 }
 
 void ReplayQuickSettingsWidget::actUpdateFastForwardSpeed(qreal value)
 {
     SettingsCache::instance().userInterface().setFastForwardSpeed(value);
     emit fastForwardSpeedChanged(value);
+}
+
+void ReplayQuickSettingsWidget::actUpdateSkipEmptySections(QT_STATE_CHANGED_T value)
+{
+    SettingsCache::instance().interface().setSkipEmptySections(value);
+    emit skipEmptySectionsChanged(value);
 }

--- a/cockatrice/src/interface/widgets/replay/replay_quick_settings_widget.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_quick_settings_widget.cpp
@@ -18,7 +18,7 @@ ReplayQuickSettingsWidget::ReplayQuickSettingsWidget(QWidget *parent) : Settings
     connect(&fastForwardSpeedBox, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
             &ReplayQuickSettingsWidget::actUpdateFastForwardSpeed);
 
-    skipEmptyCheckBox.setChecked(SettingsCache::instance().interface().getSkipEmptySections());
+    skipEmptyCheckBox.setChecked(SettingsCache::instance().userInterface().getSkipEmptySections());
     connect(&skipEmptyCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
             &ReplayQuickSettingsWidget::actUpdateSkipEmptySections);
 
@@ -53,6 +53,6 @@ void ReplayQuickSettingsWidget::actUpdateFastForwardSpeed(qreal value)
 
 void ReplayQuickSettingsWidget::actUpdateSkipEmptySections(QT_STATE_CHANGED_T value)
 {
-    SettingsCache::instance().interface().setSkipEmptySections(value);
+    SettingsCache::instance().userInterface().setSkipEmptySections(value);
     emit skipEmptySectionsChanged(value);
 }

--- a/cockatrice/src/interface/widgets/replay/replay_quick_settings_widget.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_quick_settings_widget.cpp
@@ -18,12 +18,17 @@ ReplayQuickSettingsWidget::ReplayQuickSettingsWidget(QWidget *parent) : Settings
     connect(&fastForwardSpeedBox, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
             &ReplayQuickSettingsWidget::actUpdateFastForwardSpeed);
 
+    skipEmptyCheckBox.setChecked(SettingsCache::instance().interface().getSkipEmptySections());
+    connect(&skipEmptyCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+            &ReplayQuickSettingsWidget::actUpdateSkipEmptySections);
+
     // putting it all together
     auto *widget = new QWidget;
     auto *grid = new QGridLayout(widget);
     grid->setContentsMargins(0, 0, 0, 0);
     grid->addWidget(&fastForwardSpeedLabel, 0, 0, 1, 1);
     grid->addWidget(&fastForwardSpeedBox, 0, 1, 1, 1);
+    grid->addWidget(&skipEmptyCheckBox, 1, 0, 1, 2);
 
     this->addSettingsWidget(widget);
 
@@ -36,10 +41,18 @@ void ReplayQuickSettingsWidget::retranslateUi()
 {
     fastForwardSpeedLabel.setText(tr("Fast forward speed:"));
     fastForwardSpeedBox.setSuffix("x");
+
+    skipEmptyCheckBox.setText(tr("Skip empty sections"));
 }
 
 void ReplayQuickSettingsWidget::actUpdateFastForwardSpeed(qreal value)
 {
     SettingsCache::instance().interface().setFastForwardSpeed(value);
     emit fastForwardSpeedChanged(value);
+}
+
+void ReplayQuickSettingsWidget::actUpdateSkipEmptySections(QT_STATE_CHANGED_T value)
+{
+    SettingsCache::instance().interface().setSkipEmptySections(value);
+    emit skipEmptySectionsChanged(value);
 }

--- a/cockatrice/src/interface/widgets/replay/replay_quick_settings_widget.h
+++ b/cockatrice/src/interface/widgets/replay/replay_quick_settings_widget.h
@@ -3,7 +3,9 @@
 
 #include "../../interface/widgets/quick_settings/settings_button_widget.h"
 
+#include <QCheckBox>
 #include <QDoubleSpinBox>
+#include <libcockatrice/utility/macros.h>
 
 class ReplayQuickSettingsWidget : public SettingsButtonWidget
 {
@@ -16,13 +18,17 @@ public:
 
 signals:
     void fastForwardSpeedChanged(qreal speed);
+    void skipEmptySectionsChanged(bool skip);
 
 private:
     QLabel fastForwardSpeedLabel;
     QDoubleSpinBox fastForwardSpeedBox;
 
+    QCheckBox skipEmptyCheckBox;
+
 private slots:
     void actUpdateFastForwardSpeed(qreal value);
+    void actUpdateSkipEmptySections(QT_STATE_CHANGED_T value);
 };
 
 #endif // COCKATRICE_REPLAY_QUICK_SETTINGS_WIDGET_H

--- a/cockatrice/src/interface/widgets/replay/replay_widget.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_widget.cpp
@@ -66,6 +66,10 @@ ReplayWidget::ReplayWidget(QWidget *parent, GameReplay *replay)
     settingsWidget->setFixedSize(QSize(32, 32));
     connect(settingsWidget, &ReplayQuickSettingsWidget::fastForwardSpeedChanged, this,
             [this] { updateTimeScaleFactor(replayFastForwardButton->isChecked()); });
+    connect(settingsWidget, &ReplayQuickSettingsWidget::skipEmptySectionsChanged, replayManager,
+            &ReplayManager::setSkipEmptySections);
+
+    replayManager->setSkipEmptySections(SettingsCache::instance().interface().getSkipEmptySections());
 
     // putting everything together
     auto replayControlLayout = new QHBoxLayout;

--- a/cockatrice/src/interface/widgets/replay/replay_widget.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_widget.cpp
@@ -66,6 +66,10 @@ ReplayWidget::ReplayWidget(QWidget *parent, GameReplay *replay)
     settingsWidget->setFixedSize(QSize(32, 32));
     connect(settingsWidget, &ReplayQuickSettingsWidget::fastForwardSpeedChanged, this,
             [this] { updateTimeScaleFactor(replayFastForwardButton->isChecked()); });
+    connect(settingsWidget, &ReplayQuickSettingsWidget::skipEmptySectionsChanged, replayManager,
+            &ReplayManager::setSkipEmptySections);
+
+    replayManager->setSkipEmptySections(SettingsCache::instance().userInterface().getSkipEmptySections());
 
     // putting everything together
     auto replayControlLayout = new QHBoxLayout;

--- a/libcockatrice_interfaces/libcockatrice/interfaces/interface_interface_settings_provider.h
+++ b/libcockatrice_interfaces/libcockatrice/interfaces/interface_interface_settings_provider.h
@@ -32,6 +32,7 @@ public:
     [[nodiscard]] virtual bool getOpenDeckInNewTab() const = 0;
     [[nodiscard]] virtual int getRewindBufferingMs() const = 0;
     [[nodiscard]] virtual qreal getFastForwardSpeed() const = 0;
+    [[nodiscard]] virtual bool getSkipEmptySections() const = 0;
     [[nodiscard]] virtual bool getStyleUserList() const = 0;
     [[nodiscard]] virtual bool getLeftJustified() const = 0;
     [[nodiscard]] virtual int getZoneViewGroupByIndex() const = 0;

--- a/libcockatrice_interfaces/libcockatrice/interfaces/interface_interface_settings_provider.h
+++ b/libcockatrice_interfaces/libcockatrice/interfaces/interface_interface_settings_provider.h
@@ -31,6 +31,7 @@ public:
     [[nodiscard]] virtual int getMinPlayersForMultiColumnLayout() const = 0;
     [[nodiscard]] virtual int getRewindBufferingMs() const = 0;
     [[nodiscard]] virtual qreal getFastForwardSpeed() const = 0;
+    [[nodiscard]] virtual bool getSkipEmptySections() const = 0;
     [[nodiscard]] virtual bool getLeftJustified() const = 0;
     [[nodiscard]] virtual int getZoneViewGroupByIndex() const = 0;
     [[nodiscard]] virtual int getZoneViewSortByIndex() const = 0;

--- a/libcockatrice_settings/libcockatrice/settings/interface_settings.cpp
+++ b/libcockatrice_settings/libcockatrice/settings/interface_settings.cpp
@@ -120,6 +120,11 @@ qreal InterfaceSettings::getFastForwardSpeed() const
     return getValue("fastForwardSpeed", "replay", QString(), 10).toReal();
 }
 
+bool InterfaceSettings::getSkipEmptySections() const
+{
+    return getValue("skipEmptySections", "replay", QString(), false).toBool();
+}
+
 bool InterfaceSettings::getLeftJustified() const
 {
     return getValue("leftJustified", QString(), QString(), false).toBool();
@@ -277,6 +282,11 @@ void InterfaceSettings::setRewindBufferingMs(int _rewindBufferingMs)
 void InterfaceSettings::setFastForwardSpeed(qreal _value)
 {
     setValue(_value, "fastForwardSpeed", "replay");
+}
+
+void InterfaceSettings::setSkipEmptySections(bool _value)
+{
+    setValue(_value, "skipEmptySections", "replay");
 }
 
 void InterfaceSettings::setLeftJustified(bool _leftJustified)

--- a/libcockatrice_settings/libcockatrice/settings/interface_settings.cpp
+++ b/libcockatrice_settings/libcockatrice/settings/interface_settings.cpp
@@ -125,6 +125,11 @@ qreal InterfaceSettings::getFastForwardSpeed() const
     return getValue("fastForwardSpeed", "replay", QString(), 10).toReal();
 }
 
+bool InterfaceSettings::getSkipEmptySections() const
+{
+    return getValue("skipEmptySections", "replay", QString(), false).toBool();
+}
+
 bool InterfaceSettings::getStyleUserList() const
 {
     return getValue("styleUserList", "appearance", QString(), true).toBool();
@@ -282,6 +287,11 @@ void InterfaceSettings::setRewindBufferingMs(int _rewindBufferingMs)
 void InterfaceSettings::setFastForwardSpeed(qreal _value)
 {
     setValue(_value, "fastForwardSpeed", "replay");
+}
+
+void InterfaceSettings::setSkipEmptySections(bool _value)
+{
+    setValue(_value, "skipEmptySections", "replay");
 }
 
 void InterfaceSettings::setStyleUserList(bool _styleUserList)

--- a/libcockatrice_settings/libcockatrice/settings/interface_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/interface_settings.h
@@ -34,6 +34,7 @@ public:
     [[nodiscard]] int getMinPlayersForMultiColumnLayout() const override;
     [[nodiscard]] int getRewindBufferingMs() const override;
     [[nodiscard]] qreal getFastForwardSpeed() const override;
+    [[nodiscard]] bool getSkipEmptySections() const override;
     [[nodiscard]] bool getLeftJustified() const override;
     [[nodiscard]] int getZoneViewGroupByIndex() const override;
     [[nodiscard]] int getZoneViewSortByIndex() const override;
@@ -65,6 +66,7 @@ public:
     void setMinPlayersForMultiColumnLayout(int _minPlayersForMultiColumnLayout);
     void setRewindBufferingMs(int _rewindBufferingMs);
     void setFastForwardSpeed(qreal _value);
+    void setSkipEmptySections(bool _value);
     void setLeftJustified(bool _leftJustified);
     void setZoneViewGroupByIndex(int _zoneViewGroupByIndex);
     void setZoneViewSortByIndex(int _zoneViewSortByIndex);

--- a/libcockatrice_settings/libcockatrice/settings/interface_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/interface_settings.h
@@ -35,6 +35,7 @@ public:
     [[nodiscard]] bool getOpenDeckInNewTab() const override;
     [[nodiscard]] int getRewindBufferingMs() const override;
     [[nodiscard]] qreal getFastForwardSpeed() const override;
+    [[nodiscard]] bool getSkipEmptySections() const override;
     [[nodiscard]] bool getStyleUserList() const override;
     [[nodiscard]] bool getLeftJustified() const override;
     [[nodiscard]] int getZoneViewGroupByIndex() const override;
@@ -66,6 +67,7 @@ public:
     void setOpenDeckInNewTab(bool _openDeckInNewTab);
     void setRewindBufferingMs(int _rewindBufferingMs);
     void setFastForwardSpeed(qreal _value);
+    void setSkipEmptySections(bool _value);
     void setStyleUserList(bool _styleUserList);
     void setLeftJustified(bool _leftJustified);
     void setZoneViewGroupByIndex(int _zoneViewGroupByIndex);


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #7060

## Short roundup of the initial problem

Replays tend to have a lot of empty space, because players will often take time thinking.

It would be convenient if there was a way to automatically skip through the empty space.

## What will change with this Pull Request?

Added setting to skip empty sections. The setting checkbox is located in the quick settings widget, below the replay speed setting.

<img width="263" height="159" alt="Screenshot 2026-08-02 at 8 33 04 PM" src="https://github.com/user-attachments/assets/c91412cc-14e7-4a35-a34c-940849c08b23" />

An **empty section** is defined as a time in the replay where there is no **meaningful event** for 0.5 seconds on either side.

A **meaningful event** is any event other than a `PLAYER_PROPERTIES_CHANGED` event. That's because the replay spams these events like once a second, so we need to filter them out if we want the skipping to have any meaningful effect.

When the setting is enabled, the replay manager will check after each timer trigger if the current time is in the middle of an **empty section**, by checking the timestamps of the closest meaningful events on both sides. If the current time is inside an **empty section**, it will skip forward to 0.5 seconds before the next meaningful event, or to the end of the replay if none is found.  

https://github.com/user-attachments/assets/0baa5cd9-d38e-4d5f-aa18-c3b6765ed63d



