### PR TITLE
[CardInfo] Refactor: remove properties setters

### DIFF
--- a/libcockatrice_card/libcockatrice/card/card_info.cpp
+++ b/libcockatrice_card/libcockatrice/card/card_info.cpp
@@ -64,14 +64,6 @@ void CardInfo::setProperty(const QString &_name, const QString &_value)
     emit cardInfoChanged(smartThis);
 }
 
-void CardInfo::setProperties(const QHash<QString, QString> &_props)
-{
-    ensurePropertiesLoaded();
-    propertiesCache = _props;
-    propertiesBlob = serializeProperties(propertiesCache);
-    emit cardInfoChanged(smartThis);
-}
-
 CardInfo::CardInfo(const QString &_name,
                    const QString &_text,
                    bool _isToken,

--- a/libcockatrice_card/libcockatrice/card/card_info.h
+++ b/libcockatrice_card/libcockatrice/card/card_info.h
@@ -290,25 +290,11 @@ public:
     }
     [[nodiscard]] const QHash<QString, QString> &getPropertiesHash() const;
 
-    /**
-     * @brief Stores the pre-serialized properties blob and invalidates the
-     *        materialized cache. Used by the binary cache reader so the
-     *        QHash<QString, QString> is not built at load time.
-     * @param _blob The serialized properties (as written by the cache writer).
-     */
-    void setPropertiesBlob(QByteArray _blob) const
-    {
-        QMutexLocker lock(&propertiesMutex);
-        propertiesBlob = std::move(_blob);
-        propertiesLoaded = false;
-        propertiesCache.clear();
-    }
     [[nodiscard]] QString getProperty(const QString &propertyName) const
     {
         return getPropertiesHash().value(propertyName);
     }
     void setProperty(const QString &_name, const QString &_value);
-    void setProperties(const QHash<QString, QString> &_props);
     [[nodiscard]] bool hasProperty(const QString &propertyName) const
     {
         return getPropertiesHash().contains(propertyName);

--- a/libcockatrice_card/libcockatrice/card/database/card_database_cache.cpp
+++ b/libcockatrice_card/libcockatrice/card/database/card_database_cache.cpp
@@ -117,12 +117,9 @@ PrintingInfo readPrinting(QDataStream &in, const SetNameMap &sets)
 {
     QString setName = readString(in);
     QByteArray propsBlob = readHashBlob(in);
-    PrintingInfo p;
-    if (auto set = sets.value(setName)) {
-        p = PrintingInfo(set);
-    }
-    p.setPropertiesBlob(propsBlob);
-    return p;
+    auto set = sets.value(setName);
+
+    return PrintingInfo(set, propsBlob);
 }
 
 // ---- CardSet ---------------------------------------------------------------

--- a/libcockatrice_card/libcockatrice/card/database/parser/cockatrice_xml_3.cpp
+++ b/libcockatrice_card/libcockatrice/card/database/parser/cockatrice_xml_3.cpp
@@ -228,7 +228,6 @@ void CockatriceXml3Parser::loadCardsFromXml(QXmlStreamReader &xml)
                     // Only load printings from sets the user has enabled, matching the v4 loader's
                     // behaviour. Without this check, disabling a set has no effect on v3 databases.
                     if (set->getEnabled()) {
-                        PrintingInfo setInfo(set);
                         QHash<QString, QString> printingProps;
                         if (attrs.hasAttribute("muId")) {
                             printingProps.insert("muid", attrs.value("muId").toString());
@@ -249,7 +248,7 @@ void CockatriceXml3Parser::loadCardsFromXml(QXmlStreamReader &xml)
                         if (attrs.hasAttribute("rarity")) {
                             printingProps.insert("rarity", attrs.value("rarity").toString());
                         }
-                        setInfo.setProperties(printingProps);
+                        PrintingInfo setInfo(set, printingProps);
                         _sets[setName].append(setInfo);
                     }
                     // related cards

--- a/libcockatrice_card/libcockatrice/card/database/parser/cockatrice_xml_4.cpp
+++ b/libcockatrice_card/libcockatrice/card/database/parser/cockatrice_xml_4.cpp
@@ -314,7 +314,6 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
                     QString setName = xml.readElementText(QXmlStreamReader::IncludeChildElements);
                     auto set = internalAddSet(setName);
                     if (set->getEnabled()) {
-                        PrintingInfo printingInfo(set);
                         QHash<QString, QString> printingProps;
                         for (QXmlStreamAttribute attr : attrs) {
                             QString attrName = attr.name().toString();
@@ -323,7 +322,7 @@ void CockatriceXml4Parser::loadCardsFromXml(QXmlStreamReader &xml)
                             }
                             printingProps.insert(attrName, attr.value().toString());
                         }
-                        printingInfo.setProperties(printingProps);
+                        PrintingInfo printingInfo(set, printingProps);
 
                         // This is very much a hack and not the right place to
                         // put this check, as it requires a reload of Cockatrice

--- a/libcockatrice_card/libcockatrice/card/printing/printing_info.cpp
+++ b/libcockatrice_card/libcockatrice/card/printing/printing_info.cpp
@@ -5,7 +5,12 @@
 #include <QDataStream>
 #include <QIODevice>
 
-PrintingInfo::PrintingInfo(const CardSetPtr &_set) : set(_set)
+PrintingInfo::PrintingInfo(const CardSetPtr &_set, const QHash<QString, QString> &_properties)
+    : set(_set), propertiesCache(_properties), propertiesLoaded(true)
+{
+}
+
+PrintingInfo::PrintingInfo(const CardSetPtr &_set, const QByteArray &_blob) : set(_set), propertiesBlob(_blob)
 {
 }
 
@@ -31,16 +36,6 @@ void PrintingInfo::setProperty(const QString &_name, const QString &_value)
         return;
     }
     propertiesCache.insert(_name, _value);
-    setProperties(propertiesCache);
-}
-
-void PrintingInfo::setProperties(const QHash<QString, QString> &_props)
-{
-    ensurePropertiesLoaded();
-    propertiesCache = _props;
-    QDataStream out(&propertiesBlob, QIODevice::WriteOnly);
-    out.setVersion(QDataStream::Qt_6_4);
-    out << propertiesCache;
 }
 
 /**

--- a/libcockatrice_card/libcockatrice/card/printing/printing_info.h
+++ b/libcockatrice_card/libcockatrice/card/printing/printing_info.h
@@ -32,8 +32,17 @@ public:
      * @brief Constructs a PrintingInfo associated with a specific set.
      *
      * @param _set The set this printing belongs to (defaults to null).
+     * @param _properties The printing properties (defaults to empty)
      */
-    explicit PrintingInfo(const CardSetPtr &_set = nullptr);
+    explicit PrintingInfo(const CardSetPtr &_set = nullptr, const QHash<QString, QString> &_properties = {});
+
+    /**
+     * @brief Constructs a PrintingInfo associated with a specific set.
+     *
+     * @param _set The set this printing belongs to (defaults to null).
+     * @param _blob The serialized properties (as written by the cache writer).
+     */
+    explicit PrintingInfo(const CardSetPtr &_set, const QByteArray &_blob);
 
     /**
      * @brief Destroys the PrintingInfo.
@@ -127,21 +136,6 @@ public:
      * @param _value The string value to assign.
      */
     void setProperty(const QString &_name, const QString &_value);
-    void setProperties(const QHash<QString, QString> &_props);
-
-    /**
-     * @brief Stores the pre-serialized properties blob and marks the materialized
-     *        cache as invalid. Used by the binary cache reader to avoid building a
-     *        QHash<QString, QString> at load time.
-     * @param _blob The serialized properties (as written by the cache writer).
-     */
-    void setPropertiesBlob(QByteArray _blob) const
-    {
-        QMutexLocker lock(propertiesMutex.data());
-        propertiesBlob = std::move(_blob);
-        propertiesLoaded = false;
-        propertiesCache.clear();
-    }
 
     /**
      * @brief Returns the providerID for this printing.

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -289,7 +289,6 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
         }
 
         // per-set properties
-        PrintingInfo printingInfo = PrintingInfo(currentSet);
         QHash<QString, QString> printingProps;
         for (auto i = setInfoProperties.cbegin(), end = setInfoProperties.cend(); i != end; ++i) {
             QString mtgjsonProperty = i.key();
@@ -317,7 +316,7 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
             }
         }
 
-        printingInfo.setProperties(printingProps);
+        PrintingInfo printingInfo(currentSet, printingProps);
 
         QString numComponent;
         const QString numProperty = printingInfo.getProperty("num");


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #7051

## Short roundup of the initial problem

`CardInfo` and `PrintingInfo` have setters that completely replace the properties. However, they are currently either unused or only used to initialize the values. 

Instead of doing two-phase initialization with the properties, it would be cleaner to just pass everything in the constructor. This is especially relevant when we have both the serialized and materialized views of the property that we need to manage together.

## What will change with this Pull Request?
- Remove `setProperties` and `setPropertiesBlob` on `CardInfo` and `PrintingInfo`
- Update `PrintingInfo` constructors to take the properties as a param
- Replace usages of the setters.
