### PR TITLE
[CI] Remove Qt5

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -334,7 +334,7 @@ the tr() call, also you can add an extra string as a hint for translators:
 QString message = tr("Everyone draws %n cards", "english hint for translators", amount);
 ```
 See [Qt's wiki on translations](
-https://doc.qt.io/qt-5/i18n-source-translation.html#handling-plurals)
+https://doc.qt.io/qt-6/i18n-source-translation.html#handling-plurals)
 
 If you're about to propose a change that adds or modifies any translatable
 string in the code, you don't need to take care of adding the new strings to

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,10 +64,11 @@ if(WIN32 OR USE_VCPKG)
   else()
     set(QTDIR
         ""
-        CACHE PATH "Path to Qt (e.g. C:/Qt/5.7/msvc2015_64)"
+        CACHE PATH "Path to Qt (e.g. C:/Qt/6.4.2/msvc2019_64)"
     )
     message(
-      WARNING "QTDIR variable is missing.  Please set this variable to specify path to Qt (e.g. C:/Qt/5.7/msvc2015_64)"
+      WARNING
+        "QTDIR variable is missing.  Please set this variable to specify path to Qt (e.g. C:/Qt/6.4.2/msvc2019_64)"
     )
   endif()
 endif()
@@ -174,7 +175,7 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
       -Wno-error=delete-non-virtual-dtor
       -Wno-error=sign-compare
       -Wno-error=missing-declarations
-      -Wno-error=sfinae-incomplete  # GCC 16+: Qt MOC + protobuf forward decls trigger this
+      -Wno-error=sfinae-incomplete # GCC 16+: Qt MOC + protobuf forward decls trigger this
   )
 
   foreach(FLAG ${ADDITIONAL_DEBUG_FLAGS})
@@ -280,11 +281,7 @@ if(UNIX)
     if(CPACK_GENERATOR STREQUAL "RPM")
       set(CPACK_RPM_PACKAGE_LICENSE "GPLv2")
       set(CPACK_RPM_MAIN_COMPONENT "cockatrice")
-      if(Qt6_FOUND)
-        set(CPACK_RPM_PACKAGE_REQUIRES "protobuf, qt6-qttools, qt6-qtsvg, qt6-qtmultimedia, qt6-qtimageformats")
-      elseif(Qt5_FOUND)
-        set(CPACK_RPM_PACKAGE_REQUIRES "protobuf, qt5-qttools, qt5-qtsvg, qt5-qtmultimedia")
-      endif()
+      set(CPACK_RPM_PACKAGE_REQUIRES "protobuf, qt6-qttools, qt6-qtsvg, qt6-qtmultimedia, qt6-qtimageformats")
       set(CPACK_RPM_PACKAGE_GROUP "Amusements/Games")
       set(CPACK_RPM_PACKAGE_URL "http://github.com/Cockatrice/Cockatrice")
       # stop directories from making package conflicts
@@ -302,12 +299,8 @@ if(UNIX)
       set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
       set(CPACK_DEBIAN_PACKAGE_SECTION "games")
       set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "http://github.com/Cockatrice/Cockatrice")
-      if(Qt6_FOUND)
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt6multimedia6, libqt6svg6, qt6-qpa-plugins, qt6-image-formats-plugins")
-        set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "libqt6sql6-mysql") # for connecting servatrice to a mysql db
-      elseif(Qt5_FOUND)
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5multimedia5-plugins, libqt5svg5")
-      endif()
+      set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt6multimedia6, libqt6svg6, qt6-qpa-plugins, qt6-image-formats-plugins")
+      set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "libqt6sql6-mysql") # for connecting servatrice to a mysql db
     endif()
   endif()
 elseif(WIN32)

--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ The following flags (with their non-default values) can be passed to `cmake`:
 | `-DWARNING_AS_ERROR=0` | Don't treat compilation warnings as errors in debug mode |
 | `-DUPDATE_TRANSLATIONS=1` |  Configure `make` to update the translation .ts files for new strings in the source code<br> **Note:** `make clean` will remove the .ts files |
 | `-DTEST=1` | Enable regression tests<br> **Note:** `make test` to run tests, *googletest* will be downloaded if not available |
-| `-DFORCE_USE_QT5=1` | Skip looking for Qt6 before trying to find Qt5 |
 
 
 # Run

--- a/cmake/FindQtRuntime.cmake
+++ b/cmake/FindQtRuntime.cmake
@@ -1,8 +1,7 @@
 # Find a compatible Qt version
-# Inputs: WITH_SERVER, WITH_CLIENT, WITH_ORACLE, FORCE_USE_QT5
+# Inputs: WITH_SERVER, WITH_CLIENT, WITH_ORACLE
 # Optional Input: QT6_DIR -- Hint as to where Qt6 lives on the system
-# Optional Input: QT5_DIR -- Hint as to where Qt5 lives on the system
-# Output: COCKATRICE_QT_VERSION_NAME -- Example values: Qt5, Qt6
+# Output: COCKATRICE_QT_VERSION_NAME -- Example values: Qt6
 # Output: SERVATRICE_QT_MODULES
 # Output: COCKATRICE_QT_MODULES
 # Output: ORACLE_QT_MODULES
@@ -39,69 +38,37 @@ set(REQUIRED_QT_COMPONENTS ${REQUIRED_QT_COMPONENTS} ${_SERVATRICE_NEEDED} ${_CO
 )
 list(REMOVE_DUPLICATES REQUIRED_QT_COMPONENTS)
 
-if(NOT FORCE_USE_QT5)
-  # Linguist is now a component in Qt6 instead of an external package
-  find_package(
-    Qt6 6.4.2
-    COMPONENTS ${REQUIRED_QT_COMPONENTS} Linguist
-    QUIET HINTS ${Qt6_DIR}
-  )
+# Linguist is now a component in Qt6 instead of an external package
+find_package(
+  Qt6 6.4.2
+  COMPONENTS ${REQUIRED_QT_COMPONENTS} Linguist
+  QUIET HINTS ${Qt6_DIR}
+)
+if(NOT Qt6_FOUND)
+  message(FATAL_ERROR "No suitable version of Qt was found")
 endif()
-if(Qt6_FOUND)
-  set(COCKATRICE_QT_VERSION_NAME Qt6)
+set(COCKATRICE_QT_VERSION_NAME Qt6)
 
-  list(FIND Qt6LinguistTools_TARGETS Qt6::lrelease QT6_LRELEASE_INDEX)
-  if(QT6_LRELEASE_INDEX EQUAL -1)
-    message(WARNING "Qt6 lrelease not found.")
-  endif()
-
-  list(FIND Qt6LinguistTools_TARGETS Qt6::lupdate QT6_LUPDATE_INDEX)
-  if(QT6_LUPDATE_INDEX EQUAL -1)
-    message(WARNING "Qt6 lupdate not found.")
-  endif()
-else()
-  find_package(
-    Qt5 5.15.2
-    COMPONENTS ${REQUIRED_QT_COMPONENTS}
-    QUIET HINTS ${Qt5_DIR}
-  )
-  if(Qt5_FOUND)
-    set(COCKATRICE_QT_VERSION_NAME Qt5)
-  else()
-    message(FATAL_ERROR "No suitable version of Qt was found")
-  endif()
-
-  # Qt5 Linguist is in a separate package
-  find_package(Qt5LinguistTools QUIET)
-  if(Qt5LinguistTools_FOUND)
-    if(NOT Qt5_LRELEASE_EXECUTABLE)
-      message(WARNING "Qt5 lrelease not found.")
-    endif()
-    if(NOT Qt5_LUPDATE_EXECUTABLE)
-      message(WARNING "Qt5 lupdate not found.")
-    endif()
-  else()
-    message(WARNING "Linguist Tools not found, cannot handle translations")
-  endif()
+list(FIND Qt6LinguistTools_TARGETS Qt6::lrelease QT6_LRELEASE_INDEX)
+if(QT6_LRELEASE_INDEX EQUAL -1)
+  message(WARNING "Qt6 lrelease not found.")
 endif()
 
-if(Qt5_POSITION_INDEPENDENT_CODE OR Qt6_FOUND)
-  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+list(FIND Qt6LinguistTools_TARGETS Qt6::lupdate QT6_LUPDATE_INDEX)
+if(QT6_LUPDATE_INDEX EQUAL -1)
+  message(WARNING "Qt6 lupdate not found.")
 endif()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Establish Qt Plugins directory & Library directories
 get_target_property(QT_LIBRARY_DIR ${COCKATRICE_QT_VERSION_NAME}::Core LOCATION)
 get_filename_component(QT_LIBRARY_DIR ${QT_LIBRARY_DIR} DIRECTORY)
-if(Qt6_FOUND)
-  get_filename_component(QT_PLUGINS_DIR "${Qt6Core_DIR}/../../../${QT6_INSTALL_PLUGINS}" ABSOLUTE)
-  get_filename_component(QT_LIBRARY_DIR "${QT_LIBRARY_DIR}/../../.." ABSOLUTE)
-  if(UNIX AND APPLE)
-    # Mac needs a bit more help finding all necessary components
-    list(APPEND QT_LIBRARY_DIR "/usr/local/lib")
-  endif()
-elseif(Qt5_FOUND)
-  get_filename_component(QT_PLUGINS_DIR "${Qt5Core_DIR}/../../../plugins" ABSOLUTE)
-  get_filename_component(QT_LIBRARY_DIR "${QT_LIBRARY_DIR}/.." ABSOLUTE)
+get_filename_component(QT_PLUGINS_DIR "${Qt6Core_DIR}/../../../${QT6_INSTALL_PLUGINS}" ABSOLUTE)
+get_filename_component(QT_LIBRARY_DIR "${QT_LIBRARY_DIR}/../../.." ABSOLUTE)
+if(UNIX AND APPLE)
+  # Mac needs a bit more help finding all necessary components
+  list(APPEND QT_LIBRARY_DIR "/usr/local/lib")
 endif()
 message(DEBUG "QT_PLUGINS_DIR = ${QT_PLUGINS_DIR}")
 message(DEBUG "QT_LIBRARY_DIR = ${QT_LIBRARY_DIR}")

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -294,20 +294,6 @@ Section "Application" SecApplication
 SetShellVarContext all
 SetOutPath "$INSTDIR"
 
-${If} $PortableMode = 0
-
-    ; --- Register .cod file type ---
-    WriteRegStr HKCR ".cod" "" "Cockatrice"
-    WriteRegStr HKCR "Cockatrice" "" "Cockatrice Deck File"
-    WriteRegStr HKCR "Cockatrice\shell\open\command" "" '"$INSTDIR\cockatrice.exe" "%1"'
-
-    ; --- Register custom URI protocol ---
-    WriteRegStr HKCR "cockatrice" "" "URL: Cockatrice Protocol"
-    WriteRegStr HKCR "cockatrice" "URL Protocol" ""
-    WriteRegStr HKCR "cockatrice\shell\open\command" "" '"$INSTDIR\cockatrice.exe" "%1"'
-
-${EndIf}
-
 ${If} $PortableMode = 1
 ${AndIf} ${FileExists} "$INSTDIR\portable.dat"
 	; upgrade portable mode
@@ -416,18 +402,6 @@ Section "un.Application" UnSecApplication
 	RMDir "$SMPROGRAMS\Cockatrice"
 
 	DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Cockatrice"
-
-	; Only remove the file/protocol associations if we registered them (i.e. the
-	; install was not portable) and .cod is still owned by Cockatrice, so we don't
-	; clobber a .cod association installed by another application.
-	${If} Not ${FileExists} "$INSTDIR\portable.dat"
-		ReadRegStr $0 HKCR ".cod" ""
-		${If} $0 == "Cockatrice"
-			DeleteRegKey HKCR ".cod"
-			DeleteRegKey HKCR "Cockatrice"
-			DeleteRegKey HKCR "cockatrice"
-		${EndIf}
-	${EndIf}
 SectionEnd
 
 ; unselected because it is /o

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -403,11 +403,7 @@ if(APPLE)
   set(cockatrice_SOURCES ${cockatrice_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/resources/appicon.icns)
 endif(APPLE)
 
-if(Qt6_FOUND)
-  qt6_add_resources(cockatrice_RESOURCES_RCC ${cockatrice_RESOURCES})
-elseif(Qt5_FOUND)
-  qt5_add_resources(cockatrice_RESOURCES_RCC ${cockatrice_RESOURCES})
-endif()
+qt6_add_resources(cockatrice_RESOURCES_RCC ${cockatrice_RESOURCES})
 
 # Declare path variables
 set(ICONDIR
@@ -423,67 +419,28 @@ set(COCKATRICE_MAC_QM_INSTALL_DIR "cockatrice.app/Contents/Resources/translation
 set(COCKATRICE_UNIX_QM_INSTALL_DIR "share/cockatrice/translations")
 set(COCKATRICE_WIN32_QM_INSTALL_DIR "translations")
 
-if(Qt6_FOUND)
-  qt6_add_executable(
-    cockatrice
-    WIN32
-    MACOSX_BUNDLE
-    ${cockatrice_SOURCES}
-    ${cockatrice_RESOURCES_RCC}
-    ${cockatrice_MOC_SRCS}
-    MANUAL_FINALIZATION
-  )
-elseif(Qt5_FOUND)
-  # Qt5 Translations need to be linked at executable creation time
-  if(Qt5LinguistTools_FOUND)
-    if(UPDATE_TRANSLATIONS)
-      qt5_create_translation(cockatrice_QM ${translate_SRCS} ${cockatrice_TS})
-    else()
-      qt5_add_translation(cockatrice_QM ${cockatrice_TS})
-    endif()
-  endif()
-  add_executable(
-    cockatrice WIN32 MACOSX_BUNDLE ${cockatrice_MOC_SRCS} ${cockatrice_QM} ${cockatrice_RESOURCES_RCC}
-                                   ${cockatrice_SOURCES}
-  )
-  if(UNIX)
-    if(APPLE)
-      install(FILES ${cockatrice_QM} DESTINATION ${COCKATRICE_MAC_QM_INSTALL_DIR})
-    else()
-      install(FILES ${cockatrice_QM} DESTINATION ${COCKATRICE_UNIX_QM_INSTALL_DIR})
-    endif()
-  elseif(WIN32)
-    install(FILES ${cockatrice_QM} DESTINATION ${COCKATRICE_WIN32_QM_INSTALL_DIR})
-  endif()
-endif()
+qt6_add_executable(
+  cockatrice
+  WIN32
+  MACOSX_BUNDLE
+  ${cockatrice_SOURCES}
+  ${cockatrice_RESOURCES_RCC}
+  ${cockatrice_MOC_SRCS}
+  MANUAL_FINALIZATION
+)
 
-if(Qt5_FOUND)
-  target_link_libraries(
-    cockatrice
-    libcockatrice_card
-    libcockatrice_deck_list
-    libcockatrice_filters
-    libcockatrice_utility
-    libcockatrice_network
-    libcockatrice_models
-    libcockatrice_rng
-    libcockatrice_settings
-    ${COCKATRICE_QT_MODULES}
-  )
-else()
-  target_link_libraries(
-    cockatrice
-    PUBLIC libcockatrice_card
-           libcockatrice_deck_list
-           libcockatrice_filters
-           libcockatrice_utility
-           libcockatrice_network
-           libcockatrice_models
-           libcockatrice_rng
-           libcockatrice_settings
-           ${COCKATRICE_QT_MODULES}
-  )
-endif()
+target_link_libraries(
+  cockatrice
+  PUBLIC libcockatrice_card
+         libcockatrice_deck_list
+         libcockatrice_filters
+         libcockatrice_utility
+         libcockatrice_network
+         libcockatrice_models
+         libcockatrice_rng
+         libcockatrice_settings
+         ${COCKATRICE_QT_MODULES}
+)
 
 if(UNIX)
   if(APPLE)
@@ -513,7 +470,7 @@ if(APPLE)
   set(plugin_dest_dir cockatrice.app/Contents/Plugins)
   set(qtconf_dest_dir cockatrice.app/Contents/Resources)
 
-  # Qt plugins: audio (Qt5), iconengines, imageformats, multimedia (Qt6), platforms, printsupport (Qt5), styles, tls (Qt6)
+  # Qt plugins: audio, iconengines, imageformats, multimedia, platforms, printsupport, styles, tls
   install(
     DIRECTORY "${QT_PLUGINS_DIR}/"
     DESTINATION ${plugin_dest_dir}
@@ -580,7 +537,7 @@ if(WIN32)
     PATTERN "*.ini"
   )
 
-  # Qt plugins: audio (Qt5), iconengines, imageformats, multimedia (Qt6) platforms, printsupport (Qt5), styles, tls (Qt6)
+  # Qt plugins: audio, iconengines, imageformats, multimedia, platforms, printsupport, styles, tls
   install(
     DIRECTORY "${QT_PLUGINS_DIR}/"
     DESTINATION ${plugin_dest_dir}
@@ -636,7 +593,7 @@ Data = Resources\")
   endif()
 endif()
 
-if(Qt6_FOUND AND Qt6LinguistTools_FOUND)
+if(Qt6LinguistTools_FOUND)
   #Qt6 Translations happen after the executable is built up
   if(UPDATE_TRANSLATIONS)
     qt6_add_translations(
@@ -663,6 +620,4 @@ if(Qt6_FOUND AND Qt6LinguistTools_FOUND)
   endif()
 endif()
 
-if(Qt6_FOUND)
-  qt6_finalize_target(cockatrice)
-endif()
+qt6_finalize_target(cockatrice)

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -424,11 +424,7 @@ if(APPLE)
   set(cockatrice_SOURCES ${cockatrice_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/resources/appicon.icns)
 endif(APPLE)
 
-if(Qt6_FOUND)
-  qt6_add_resources(cockatrice_RESOURCES_RCC ${cockatrice_RESOURCES})
-elseif(Qt5_FOUND)
-  qt5_add_resources(cockatrice_RESOURCES_RCC ${cockatrice_RESOURCES})
-endif()
+qt6_add_resources(cockatrice_RESOURCES_RCC ${cockatrice_RESOURCES})
 
 # Declare path variables
 set(ICONDIR
@@ -449,67 +445,28 @@ set(COCKATRICE_MAC_QM_INSTALL_DIR "cockatrice.app/Contents/Resources/translation
 set(COCKATRICE_UNIX_QM_INSTALL_DIR "share/cockatrice/translations")
 set(COCKATRICE_WIN32_QM_INSTALL_DIR "translations")
 
-if(Qt6_FOUND)
-  qt6_add_executable(
-    cockatrice
-    WIN32
-    MACOSX_BUNDLE
-    ${cockatrice_SOURCES}
-    ${cockatrice_RESOURCES_RCC}
-    ${cockatrice_MOC_SRCS}
-    MANUAL_FINALIZATION
-  )
-elseif(Qt5_FOUND)
-  # Qt5 Translations need to be linked at executable creation time
-  if(Qt5LinguistTools_FOUND)
-    if(UPDATE_TRANSLATIONS)
-      qt5_create_translation(cockatrice_QM ${translate_SRCS} ${cockatrice_TS})
-    else()
-      qt5_add_translation(cockatrice_QM ${cockatrice_TS})
-    endif()
-  endif()
-  add_executable(
-    cockatrice WIN32 MACOSX_BUNDLE ${cockatrice_MOC_SRCS} ${cockatrice_QM} ${cockatrice_RESOURCES_RCC}
-                                   ${cockatrice_SOURCES}
-  )
-  if(UNIX)
-    if(APPLE)
-      install(FILES ${cockatrice_QM} DESTINATION ${COCKATRICE_MAC_QM_INSTALL_DIR})
-    else()
-      install(FILES ${cockatrice_QM} DESTINATION ${COCKATRICE_UNIX_QM_INSTALL_DIR})
-    endif()
-  elseif(WIN32)
-    install(FILES ${cockatrice_QM} DESTINATION ${COCKATRICE_WIN32_QM_INSTALL_DIR})
-  endif()
-endif()
+qt6_add_executable(
+  cockatrice
+  WIN32
+  MACOSX_BUNDLE
+  ${cockatrice_SOURCES}
+  ${cockatrice_RESOURCES_RCC}
+  ${cockatrice_MOC_SRCS}
+  MANUAL_FINALIZATION
+)
 
-if(Qt5_FOUND)
-  target_link_libraries(
-    cockatrice
-    libcockatrice_card
-    libcockatrice_deck_list
-    libcockatrice_filters
-    libcockatrice_utility
-    libcockatrice_network
-    libcockatrice_models
-    libcockatrice_rng
-    libcockatrice_settings
-    ${COCKATRICE_QT_MODULES}
-  )
-else()
-  target_link_libraries(
-    cockatrice
-    PUBLIC libcockatrice_card
-           libcockatrice_deck_list
-           libcockatrice_filters
-           libcockatrice_utility
-           libcockatrice_network
-           libcockatrice_models
-           libcockatrice_rng
-           libcockatrice_settings
-           ${COCKATRICE_QT_MODULES}
-  )
-endif()
+target_link_libraries(
+  cockatrice
+  PUBLIC libcockatrice_card
+         libcockatrice_deck_list
+         libcockatrice_filters
+         libcockatrice_utility
+         libcockatrice_network
+         libcockatrice_models
+         libcockatrice_rng
+         libcockatrice_settings
+         ${COCKATRICE_QT_MODULES}
+)
 
 if(UNIX)
   if(APPLE)
@@ -556,7 +513,7 @@ if(APPLE)
   set(plugin_dest_dir cockatrice.app/Contents/Plugins)
   set(qtconf_dest_dir cockatrice.app/Contents/Resources)
 
-  # Qt plugins: audio (Qt5), iconengines, imageformats, multimedia (Qt6), platforms, printsupport (Qt5), styles, tls (Qt6)
+  # Qt plugins: audio, iconengines, imageformats, multimedia, platforms, printsupport, styles, tls
   install(
     DIRECTORY "${QT_PLUGINS_DIR}/"
     DESTINATION ${plugin_dest_dir}
@@ -623,7 +580,7 @@ if(WIN32)
     PATTERN "*.ini"
   )
 
-  # Qt plugins: audio (Qt5), iconengines, imageformats, multimedia (Qt6) platforms, printsupport (Qt5), styles, tls (Qt6)
+  # Qt plugins: audio, iconengines, imageformats, multimedia, platforms, printsupport, styles, tls
   install(
     DIRECTORY "${QT_PLUGINS_DIR}/"
     DESTINATION ${plugin_dest_dir}
@@ -679,7 +636,7 @@ Data = Resources\")
   endif()
 endif()
 
-if(Qt6_FOUND AND Qt6LinguistTools_FOUND)
+if(Qt6LinguistTools_FOUND)
   #Qt6 Translations happen after the executable is built up
   if(UPDATE_TRANSLATIONS)
     qt6_add_translations(
@@ -706,6 +663,4 @@ if(Qt6_FOUND AND Qt6LinguistTools_FOUND)
   endif()
 endif()
 
-if(Qt6_FOUND)
-  qt6_finalize_target(cockatrice)
-endif()
+qt6_finalize_target(cockatrice)

--- a/cockatrice/src/client/sound_engine.cpp
+++ b/cockatrice/src/client/sound_engine.cpp
@@ -2,14 +2,11 @@
 
 #include "settings/cache_settings.h"
 
-#include <QDir>
-#include <QMediaPlayer>
-
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 #include <QApplication>
 #include <QAudioOutput>
+#include <QDir>
+#include <QMediaPlayer>
 #include <libcockatrice/settings/sound_settings.h>
-#endif
 
 #define DEFAULT_THEME_NAME "Default"
 #define TEST_SOUND_FILENAME "player_join"
@@ -44,10 +41,8 @@ void SoundEngine::soundEnabledChanged()
         qCInfo(SoundEngineLog) << "SoundEngine: enabling sound with" << audioData.size() << "sounds";
         if (!player) {
             player = new QMediaPlayer;
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
             audioOutput = new QAudioOutput(player);
             player->setAudioOutput(audioOutput);
-#endif
         }
     } else {
         qCInfo(SoundEngineLog) << "SoundEngine: disabling sound";
@@ -75,13 +70,8 @@ void SoundEngine::playSound(const QString &fileName)
 
     player->stop();
     int volumeSliderValue = SettingsCache::instance().sound().getMasterVolume();
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     player->audioOutput()->setVolume(qreal(volumeSliderValue) / 100);
     player->setSource(QUrl::fromLocalFile(audioData[fileName]));
-#else
-    player->setVolume(volumeSliderValue);
-    player->setMedia(QUrl::fromLocalFile(audioData[fileName]));
-#endif
     player->play();
 }
 

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -1354,11 +1354,7 @@ void PlayerActions::actSetPT(QList<CardItem *> selectedCards, const QString &pt)
             const auto oldpt = CardItem::parsePT(card->getPT());
             int ptIter = 0;
             for (const auto &_item : ptList) {
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
                 if (_item.typeId() == QMetaType::Type::Int) {
-#else
-                if (_item.type() == QVariant::Int) {
-#endif
                     int oldItem = ptIter < oldpt.size() ? oldpt.at(ptIter).toInt() : 0;
                     newpt += '/' + QString::number(oldItem + _item.toInt());
                 } else {

--- a/cockatrice/src/game_graphics/player/player_list_widget.cpp
+++ b/cockatrice/src/game_graphics/player/player_list_widget.cpp
@@ -25,11 +25,7 @@ bool PlayerListItemDelegate::editorEvent(QEvent *event,
     if ((event->type() == QEvent::MouseButtonPress) && index.isValid()) {
         auto *const mouseEvent = static_cast<QMouseEvent *>(event);
         if (mouseEvent->button() == Qt::RightButton) {
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
             static_cast<PlayerListWidget *>(parent())->showContextMenu(mouseEvent->globalPosition().toPoint(), index);
-#else
-            static_cast<PlayerListWidget *>(parent())->showContextMenu(mouseEvent->globalPos(), index);
-#endif
             return true;
         }
     }

--- a/cockatrice/src/game_graphics/tally/subtype_tally.cpp
+++ b/cockatrice/src/game_graphics/tally/subtype_tally.cpp
@@ -67,7 +67,7 @@ QList<TallyRow> countSubtypes(const QList<CardItem *> &cards)
 
     // convert entries into TallyRows
     QList<TallyRow> rows;
-    rows.reserve(entries.size()); // for backwards compatibility with Qt5
+    rows.reserve(entries.size());
     std::transform(entries.begin(), entries.end(), std::back_inserter(rows),
                    [](const SubtypeEntry &e) { return TallyRow{e.name, QString::number(e.count)}; });
 

--- a/cockatrice/src/interface/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_widget.cpp
@@ -250,11 +250,7 @@ QSize CardInfoPictureWidget::sizeHint() const
  * @brief Starts the hover timer to show the enlarged pixmap on hover.
  * @param event The enter event.
  */
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void CardInfoPictureWidget::enterEvent(QEnterEvent *event)
-#else
-void CardInfoPictureWidget::enterEvent(QEvent *event)
-#endif
 {
     QWidget::enterEvent(event); // Call the base class implementation
 

--- a/cockatrice/src/interface/widgets/cards/card_info_picture_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_widget.h
@@ -48,11 +48,7 @@ signals:
 protected:
     void resizeEvent(QResizeEvent *event) override;
     void paintEvent(QPaintEvent *) override;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    void enterEvent(QEnterEvent *event) override; // Qt6 signature
-#else
-    void enterEvent(QEvent *event) override; // Qt5 signature
-#endif
+    void enterEvent(QEnterEvent *event) override;
     void leaveEvent(QEvent *event) override;
     void moveEvent(QMoveEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;

--- a/cockatrice/src/interface/widgets/deck_analytics/resizable_panel.cpp
+++ b/cockatrice/src/interface/widgets/deck_analytics/resizable_panel.cpp
@@ -147,11 +147,7 @@ bool ResizablePanel::eventFilter(QObject *obj, QEvent *event)
         if (event->type() == QEvent::MouseButtonPress) {
             auto *mouseEvent = static_cast<QMouseEvent *>(event);
             if (mouseEvent->button() == Qt::LeftButton) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
                 dragStartPos = mouseEvent->globalPosition().toPoint();
-#else
-                dragStartPos = mouseEvent->globalPos();
-#endif
                 isDraggingPanel = false;
                 dragButton->setCursor(Qt::ClosedHandCursor);
             }
@@ -159,11 +155,7 @@ bool ResizablePanel::eventFilter(QObject *obj, QEvent *event)
         } else if (event->type() == QEvent::MouseMove) {
             auto *mouseEvent = static_cast<QMouseEvent *>(event);
             if (mouseEvent->buttons() & Qt::LeftButton) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
                 QPoint currentPos = mouseEvent->globalPosition().toPoint();
-#else
-                QPoint currentPos = mouseEvent->globalPos();
-#endif
                 int distance = (currentPos - dragStartPos).manhattanLength();
                 if (distance >= 5 && !isDraggingPanel) {
                     isDraggingPanel = true;
@@ -182,22 +174,14 @@ bool ResizablePanel::eventFilter(QObject *obj, QEvent *event)
     if (obj == resizeHandle) {
         if (event->type() == QEvent::MouseButtonPress) {
             auto *mouseEvent = static_cast<QMouseEvent *>(event);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
             resizeStartY = mouseEvent->globalPosition().y();
-#else
-            resizeStartY = mouseEvent->globalPos().y();
-#endif
             isResizing = true;
             resizeStartHeight = currentHeight;
             resizeHandle->grabMouse();
             return true;
         } else if (event->type() == QEvent::MouseMove && isResizing) {
             auto *mouseEvent = static_cast<QMouseEvent *>(event);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
             int deltaY = mouseEvent->globalPosition().y() - resizeStartY;
-#else
-            int deltaY = mouseEvent->globalPos().y() - resizeStartY;
-#endif
             int newHeight = resizeStartHeight + deltaY;
 
             int minAllowed = getMinimumAllowedHeight();
@@ -221,11 +205,7 @@ void ResizablePanel::dragEnterEvent(QDragEnterEvent *event)
 {
     if (event->mimeData()->hasFormat("application/x-resizablepanel")) {
         event->acceptProposedAction();
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         showDropIndicator(event->position().y());
-#else
-        showDropIndicator(event->pos().y());
-#endif
     }
 }
 
@@ -233,13 +213,8 @@ void ResizablePanel::dragMoveEvent(QDragMoveEvent *event)
 {
     if (event->mimeData()->hasFormat("application/x-resizablepanel")) {
         event->acceptProposedAction();
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         showDropIndicator(event->position().y());
         lastDragPos = mapToGlobal(event->position().toPoint());
-#else
-        showDropIndicator(event->pos().y());
-        lastDragPos = mapToGlobal(event->pos());
-#endif
 
         if (!autoScrollTimer->isActive()) {
             autoScrollTimer->start();
@@ -265,11 +240,7 @@ void ResizablePanel::dropEvent(QDropEvent *event)
         ResizablePanel *draggedPanel = reinterpret_cast<ResizablePanel *>(ptr);
 
         if (draggedPanel && draggedPanel != this) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
             bool insertBefore = (event->position().y() < height() / 2);
-#else
-            bool insertBefore = (event->pos().y() < height() / 2);
-#endif
             emit dropRequested(draggedPanel, this, insertBefore);
             event->acceptProposedAction();
         }

--- a/cockatrice/src/interface/widgets/dialogs/dlg_select_set_for_cards.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_select_set_for_cards.cpp
@@ -321,11 +321,7 @@ void DlgSelectSetForCards::dropEvent(QDropEvent *event)
 {
     QByteArray itemData = event->mimeData()->data("application/x-setentrywidget");
     QString draggedSetName = QString::fromUtf8(itemData);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QPoint adjustedPos = event->position().toPoint() + QPoint(0, scrollArea->verticalScrollBar()->value());
-#else
-    QPoint adjustedPos = event->pos() + QPoint(0, scrollArea->verticalScrollBar()->value());
-#endif
     int dropIndex = -1;
     for (int i = 0; i < listLayout->count(); ++i) {
         QWidget *widget = listLayout->itemAt(i)->widget();
@@ -491,11 +487,7 @@ void SetEntryWidget::mousePressEvent(QMouseEvent *event)
     }
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void SetEntryWidget::enterEvent(QEnterEvent *event)
-#else
-void SetEntryWidget::enterEvent(QEvent *event)
-#endif
 {
     QWidget::enterEvent(event); // Call the base class handler
     // Highlight the widget by changing the background color only for the widget itself

--- a/cockatrice/src/interface/widgets/dialogs/dlg_select_set_for_cards.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_select_set_for_cards.h
@@ -87,11 +87,7 @@ public:
 
 public slots:
     void mousePressEvent(QMouseEvent *event) override;
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     void enterEvent(QEnterEvent *event) override;
-#else
-    void enterEvent(QEvent *event) override;
-#endif
     void leaveEvent(QEvent *event) override;
     void dragMoveEvent(QDragMoveEvent *event) override;
 

--- a/cockatrice/src/interface/widgets/general/display/charts/bars/bar_chart_widget.cpp
+++ b/cockatrice/src/interface/widgets/general/display/charts/bars/bar_chart_widget.cpp
@@ -207,11 +207,7 @@ void BarChartWidget::mouseMoveEvent(QMouseEvent *e)
     if (hoveredSegment >= 0) {
         const auto &s = segments[hoveredSegment];
         QString text = QString("%1: %2 cards\n\n%3").arg(s.category).arg(s.value).arg(s.cards.join("\n"));
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         QToolTip::showText(e->globalPosition().toPoint(), text, this);
-#else
-        QToolTip::showText(e->globalPos(), text, this);
-#endif
     } else {
         QToolTip::hideText();
     }

--- a/cockatrice/src/interface/widgets/general/display/charts/bars/color_bar.cpp
+++ b/cockatrice/src/interface/widgets/general/display/charts/bars/color_bar.cpp
@@ -83,19 +83,11 @@ void ColorBar::paintEvent(QPaintEvent *)
     }
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void ColorBar::enterEvent(QEnterEvent *event)
 {
     Q_UNUSED(event);
     isHovered = true;
 }
-#else
-void ColorBar::enterEvent(QEvent *event)
-{
-    Q_UNUSED(event);
-    isHovered = true;
-}
-#endif
 
 void ColorBar::leaveEvent(QEvent *)
 {
@@ -108,13 +100,8 @@ void ColorBar::mouseMoveEvent(QMouseEvent *event)
         return;
     }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     int x = int(event->position().x());
     QPoint gp = event->globalPosition().toPoint();
-#else
-    int x = event->pos().x();
-    QPoint gp = event->globalPos();
-#endif
 
     QString text = tooltipForPosition(x);
     if (!text.isEmpty()) {

--- a/cockatrice/src/interface/widgets/general/display/charts/bars/color_bar.h
+++ b/cockatrice/src/interface/widgets/general/display/charts/bars/color_bar.h
@@ -76,17 +76,10 @@ protected:
      */
     void paintEvent(QPaintEvent *event) override;
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     /**
-     * @brief Handles mouse hover entering (Qt6 version).
+     * @brief Handles mouse hover entering.
      */
     void enterEvent(QEnterEvent *event) override;
-#else
-    /**
-     * @brief Handles mouse hover entering (Qt5 version).
-     */
-    void enterEvent(QEvent *event) override;
-#endif
 
     /**
      * @brief Handles mouse hover leaving.

--- a/cockatrice/src/interface/widgets/general/display/charts/bars/segmented_bar_widget.cpp
+++ b/cockatrice/src/interface/widgets/general/display/charts/bars/segmented_bar_widget.cpp
@@ -134,9 +134,5 @@ void SegmentedBarWidget::mouseMoveEvent(QMouseEvent *e)
     const Segment &s = segments[idx];
     QString text = QString("%1: %2 cards\n%3").arg(s.category).arg(s.value).arg(s.cards.join(", "));
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QToolTip::showText(e->globalPosition().toPoint(), text, this);
-#else
-    QToolTip::showText(e->globalPos(), text, this);
-#endif
 }

--- a/cockatrice/src/interface/widgets/general/display/charts/pies/color_pie.cpp
+++ b/cockatrice/src/interface/widgets/general/display/charts/pies/color_pie.cpp
@@ -82,11 +82,7 @@ void ColorPie::paintEvent(QPaintEvent *)
         QString label = QString("%1%").arg(int(ratio * 100 + 0.5));
 
         QFontMetrics fm(p.font());
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
         int labelWidth = fm.horizontalAdvance(label);
-#else
-        int labelWidth = fm.width(label);
-#endif
         QRectF textRect(labelPos.x() - labelWidth / 2.0, labelPos.y() - fm.height() / 2.0, labelWidth, fm.height());
 
         p.setPen(Qt::black);
@@ -96,19 +92,11 @@ void ColorPie::paintEvent(QPaintEvent *)
     }
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void ColorPie::enterEvent(QEnterEvent *event)
 {
     Q_UNUSED(event);
     isHovered = true;
 }
-#else
-void ColorPie::enterEvent(QEvent *event)
-{
-    Q_UNUSED(event);
-    isHovered = true;
-}
-#endif
 
 void ColorPie::leaveEvent(QEvent *)
 {
@@ -121,13 +109,8 @@ void ColorPie::mouseMoveEvent(QMouseEvent *event)
         return;
     }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QPoint p = event->position().toPoint();
     QPoint gp = event->globalPosition().toPoint();
-#else
-    QPoint p = event->pos();
-    QPoint gp = event->globalPos();
-#endif
 
     QString text = tooltipForPoint(p);
     if (!text.isEmpty()) {

--- a/cockatrice/src/interface/widgets/general/display/charts/pies/color_pie.h
+++ b/cockatrice/src/interface/widgets/general/display/charts/pies/color_pie.h
@@ -22,11 +22,7 @@ public:
 protected:
     void paintEvent(QPaintEvent *) override;
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     void enterEvent(QEnterEvent *event) override;
-#else
-    void enterEvent(QEvent *event) override;
-#endif
     void leaveEvent(QEvent *) override;
     void mouseMoveEvent(QMouseEvent *event) override;
 

--- a/cockatrice/src/interface/widgets/printing_selector/all_zones_card_amount_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/all_zones_card_amount_widget.cpp
@@ -141,11 +141,7 @@ bool AllZonesCardAmountWidget::isNonZero()
  *
  * @param event The event information for the mouse entry.
  */
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 void AllZonesCardAmountWidget::enterEvent(QEnterEvent *event)
-#else
-void AllZonesCardAmountWidget::enterEvent(QEvent *event)
-#endif
 {
     QWidget::enterEvent(event);
     update();

--- a/cockatrice/src/interface/widgets/printing_selector/all_zones_card_amount_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/all_zones_card_amount_widget.h
@@ -26,11 +26,7 @@ public:
     int getTokensboardAmount();
     bool isNonZero();
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     void enterEvent(QEnterEvent *event) override;
-#else
-    void enterEvent(QEvent *event) override;
-#endif
 
 public slots:
     void adjustFontSize(int scalePercentage);

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
@@ -106,11 +106,7 @@ void PrintingSelectorCardOverlayWidget::resizeEvent(QResizeEvent *event)
  *
  * @param event The event triggered when the mouse enters the widget.
  */
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void PrintingSelectorCardOverlayWidget::enterEvent(QEnterEvent *event)
-#else
-void PrintingSelectorCardOverlayWidget::enterEvent(QEvent *event)
-#endif
 {
     QWidget::enterEvent(event);
     deckEditor->updateCard(rootCard);

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.h
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.h
@@ -26,11 +26,7 @@ public:
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     void enterEvent(QEnterEvent *event) override;
-#else
-    void enterEvent(QEvent *event) override;
-#endif
     void leaveEvent(QEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
     void customMenu(QPoint point);

--- a/cockatrice/src/interface/widgets/quick_settings/settings_button_widget.cpp
+++ b/cockatrice/src/interface/widgets/quick_settings/settings_button_widget.cpp
@@ -110,11 +110,7 @@ void SettingsButtonWidget::onPopupClosed() const
 
 void SettingsButtonWidget::mousePressEvent(QMouseEvent *event)
 {
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     if (popup->isVisible() && !popup->geometry().contains(event->globalPosition().toPoint())) {
-#else
-    if (popup->isVisible() && !popup->geometry().contains(event->globalPos())) {
-#endif
         popup->close();
     }
     QWidget::mousePressEvent(event);

--- a/cockatrice/src/interface/widgets/replay/replay_timeline_widget.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_timeline_widget.cpp
@@ -65,11 +65,7 @@ void ReplayTimelineWidget::paintEvent(QPaintEvent * /* event */)
 
 void ReplayTimelineWidget::mousePressEvent(QMouseEvent *event)
 {
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     int newTime = static_cast<int>((qint64)maxTime * (qint64)event->position().x() / width());
-#else
-    int newTime = static_cast<int>((qint64)maxTime * (qint64)event->x() / width());
-#endif
     emit timeClicked(newTime);
 }
 

--- a/cockatrice/src/interface/widgets/server/chat_view/chat_view.cpp
+++ b/cockatrice/src/interface/widgets/server/chat_view/chat_view.cpp
@@ -580,11 +580,7 @@ void ChatView::redactMessages(const QString &userName, int amount)
     }
 }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 void ChatView::enterEvent(QEnterEvent * /*event*/)
-#else
-void ChatView::enterEvent(QEvent * /*event*/)
-#endif
 {
     setMouseTracking(true);
 }
@@ -641,12 +637,9 @@ void ChatView::mousePressEvent(QMouseEvent *event)
 {
     switch (hoveredItemType) {
         case HoveredCard: {
-            if ((event->button() == Qt::MiddleButton) || (event->button() == Qt::LeftButton))
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+            if ((event->button() == Qt::MiddleButton) || (event->button() == Qt::LeftButton)) {
                 emit showCardInfoPopup(event->globalPosition().toPoint(), {hoveredContent});
-#else
-                emit showCardInfoPopup(event->globalPos(), {hoveredContent});
-#endif
+            }
             break;
         }
         case HoveredUser: {
@@ -656,11 +649,7 @@ void ChatView::mousePressEvent(QMouseEvent *event)
                 switch (event->button()) {
                     case Qt::RightButton: {
                         UserLevelFlags userLevel(hoveredContent.left(delimiterIndex).toInt());
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
                         userContextMenu->showContextMenu(event->globalPosition().toPoint(), userName, userLevel, this);
-#else
-                        userContextMenu->showContextMenu(event->globalPos(), userName, userLevel, this);
-#endif
                         break;
                     }
                     case Qt::LeftButton: {

--- a/cockatrice/src/interface/widgets/server/chat_view/chat_view.h
+++ b/cockatrice/src/interface/widgets/server/chat_view/chat_view.h
@@ -103,11 +103,7 @@ public:
     void redactMessages(const QString &userName, int amount);
 
 protected:
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     void enterEvent(QEnterEvent *event) override;
-#else
-    void enterEvent(QEvent *event) override;
-#endif
     void leaveEvent(QEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;

--- a/cockatrice/src/interface/widgets/server/user/user_info_popup.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_info_popup.cpp
@@ -636,19 +636,11 @@ void UserInfoPopup::refreshGames()
 
 // ── Mouse events ──────────────────────────────────────────────────────────────
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void UserInfoPopup::enterEvent(QEnterEvent *e)
 {
     QFrame::enterEvent(e);
     emit mouseEnteredPopup();
 }
-#else
-void UserInfoPopup::enterEvent(QEvent *e)
-{
-    QFrame::enterEvent(e);
-    emit mouseEnteredPopup();
-}
-#endif
 void UserInfoPopup::leaveEvent(QEvent *e)
 {
     QFrame::leaveEvent(e);

--- a/cockatrice/src/interface/widgets/server/user/user_info_popup.h
+++ b/cockatrice/src/interface/widgets/server/user/user_info_popup.h
@@ -143,11 +143,7 @@ signals:
     void demoteFromJudgeRequested(const QString &userName);
 
 protected:
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     void enterEvent(QEnterEvent *e) override;
-#else
-    void enterEvent(QEvent *e) override;
-#endif
     void leaveEvent(QEvent *e) override;
 
 private slots:

--- a/cockatrice/src/interface/widgets/server/user/user_list_widget.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_list_widget.cpp
@@ -340,11 +340,7 @@ bool UserListItemDelegate::editorEvent(QEvent *event,
     if ((event->type() == QEvent::MouseButtonPress) && index.isValid()) {
         QMouseEvent *const mouseEvent = static_cast<QMouseEvent *>(event);
         if (mouseEvent->button() == Qt::RightButton) {
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
             static_cast<UserListWidget *>(parent())->showContextMenu(mouseEvent->globalPosition().toPoint(), index);
-#else
-            static_cast<UserListWidget *>(parent())->showContextMenu(mouseEvent->globalPos(), index);
-#endif
             return true;
         }
     }

--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/display/archidekt_api_response_deck_entry_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/display/archidekt_api_response_deck_entry_display_widget.cpp
@@ -137,11 +137,7 @@ void ArchidektApiResponseDeckEntryDisplayWidget::mousePressEvent(QMouseEvent *ev
     actRequestNavigationToDeck();
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void ArchidektApiResponseDeckEntryDisplayWidget::enterEvent(QEnterEvent *event)
-#else
-void ArchidektApiResponseDeckEntryDisplayWidget::enterEvent(QEvent *event)
-#endif
 {
     QWidget::enterEvent(event);
     backgroundPlateWidget->setFocused(true);

--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/display/archidekt_api_response_deck_entry_display_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/display/archidekt_api_response_deck_entry_display_widget.h
@@ -98,11 +98,7 @@ public slots:
 protected:
     void mousePressEvent(QMouseEvent *event) override;
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     void enterEvent(QEnterEvent *event) override; ///< Qt6 hover enter
-#else
-    void enterEvent(QEvent *event) override; ///< Qt5 hover enter
-#endif
     void leaveEvent(QEvent *event) override;
 
 private:

--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/display/archidekt_api_response_deck_entry_display_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/display/archidekt_api_response_deck_entry_display_widget.h
@@ -98,7 +98,7 @@ public slots:
 protected:
     void mousePressEvent(QMouseEvent *event) override;
 
-    void enterEvent(QEnterEvent *event) override; ///< Qt6 hover enter
+    void enterEvent(QEnterEvent *event) override; ///< Hover enter
     void leaveEvent(QEvent *event) override;
 
 private:

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.cpp
@@ -65,11 +65,7 @@ void EdhrecApiResponseCardDetailsDisplayWidget::mousePressEvent(QMouseEvent *eve
     }
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void EdhrecApiResponseCardDetailsDisplayWidget::enterEvent(QEnterEvent *event)
-#else
-void EdhrecApiResponseCardDetailsDisplayWidget::enterEvent(QEvent *event)
-#endif
 {
     QWidget::enterEvent(event);
     backgroundPlateWidget->setFocused(true);

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.h
@@ -39,11 +39,7 @@ private:
 protected slots:
     void mousePressEvent(QMouseEvent *event) override;
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     void enterEvent(QEnterEvent *event) override; ///< Qt6 hover enter
-#else
-    void enterEvent(QEvent *event) override; ///< Qt5 hover enter
-#endif
     void leaveEvent(QEvent *event) override;
 };
 

--- a/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/api/edhrec/display/cards/edhrec_api_response_card_details_display_widget.h
@@ -39,7 +39,7 @@ private:
 protected slots:
     void mousePressEvent(QMouseEvent *event) override;
 
-    void enterEvent(QEnterEvent *event) override; ///< Qt6 hover enter
+    void enterEvent(QEnterEvent *event) override; ///< Hover enter
     void leaveEvent(QEvent *event) override;
 };
 

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
@@ -50,7 +50,7 @@ QRect MacOSTabFixStyle::subElementRect(SubElement element, const QStyleOption *o
     }
 
     // Skip over QProxyStyle handling subElementRect,
-    // This fixes an issue with Qt 5.10 on OSX where the labels for tabs with a button and an icon
+    // This fixes an issue on OSX where the labels for tabs with a button and an icon
     // get cut-off too early
     return QCommonStyle::subElementRect(element, option, widget);
 }
@@ -70,11 +70,7 @@ QSize CloseButton::sizeHint() const
     return {width, height};
 }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 void CloseButton::enterEvent(QEnterEvent *event)
-#else
-void CloseButton::enterEvent(QEvent *event)
-#endif
 {
     update();
     QAbstractButton::enterEvent(event);
@@ -123,7 +119,7 @@ TabSupervisor::TabSupervisor(AbstractClient *_client, QMenu *tabsMenu, QWidget *
     setIconSize(QSize(15, 15));
 
 #if defined(Q_OS_MAC)
-    // This is necessary to fix an issue on macOS with qt5.10,
+    // This is necessary to fix an issue on macOS,
     // where tabs with icons and buttons get drawn incorrectly
     tabBar()->setStyle(new MacOSTabFixStyle);
 #endif

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.h
@@ -71,11 +71,7 @@ public:
     }
 
 protected:
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     void enterEvent(QEnterEvent *event) override;
-#else
-    void enterEvent(QEvent *event) override;
-#endif
     void leaveEvent(QEvent *event) override;
     void paintEvent(QPaintEvent *event) override;
 };

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -75,11 +75,7 @@ void DeckPreviewWidget::resizeEvent(QResizeEvent *event)
     }
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void DeckPreviewWidget::enterEvent(QEnterEvent *event)
-#else
-void DeckPreviewWidget::enterEvent(QEvent *event)
-#endif
 {
     QWidget::enterEvent(event);
 

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
@@ -72,11 +72,7 @@ public slots:
     void resizeEvent(QResizeEvent *event) override;
 
 protected:
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    void enterEvent(QEnterEvent *event) override; // Qt6 signature
-#else
-    void enterEvent(QEvent *event) override; // Qt5 signature
-#endif
+    void enterEvent(QEnterEvent *event) override;
 
 private:
     void updateLastModifiedTime();

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -137,11 +137,7 @@ void installNewTranslator()
     QString lang = SettingsCache::instance().personal().getLang();
 
     QString qtNameHint = "qt_" + lang;
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     QString qtTranslationPath = QLibraryInfo::path(QLibraryInfo::TranslationsPath);
-#else
-    QString qtTranslationPath = QLibraryInfo::location(QLibraryInfo::TranslationsPath);
-#endif
 
     bool qtTranslationLoaded = qtTranslator->load(qtNameHint, qtTranslationPath);
     if (!qtTranslationLoaded) {
@@ -365,10 +361,6 @@ int main(int argc, char *argv[])
     // force shortcuts to be shown/hidden in right-click menus, regardless of system defaults
     qApp->setAttribute(Qt::AA_DontShowShortcutsInContextMenus,
                        !SettingsCache::instance().cardsDisplay().getShowShortcuts());
-
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-    app.setAttribute(Qt::AA_UseHighDpiPixmaps);
-#endif
 
 #ifdef Q_OS_MAC
     for (const QString &url : pendingMacUrls) {

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -131,11 +131,7 @@ void installNewTranslator()
     QString lang = SettingsCache::instance().personal().getLang();
 
     QString qtNameHint = "qt_" + lang;
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     QString qtTranslationPath = QLibraryInfo::path(QLibraryInfo::TranslationsPath);
-#else
-    QString qtTranslationPath = QLibraryInfo::location(QLibraryInfo::TranslationsPath);
-#endif
 
     bool qtTranslationLoaded = qtTranslator->load(qtNameHint, qtTranslationPath);
     if (!qtTranslationLoaded) {
@@ -294,9 +290,6 @@ int main(int argc, char *argv[])
     qApp->setAttribute(Qt::AA_DontShowShortcutsInContextMenus,
                        !SettingsCache::instance().cardsDisplay().getShowShortcuts());
 
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-    app.setAttribute(Qt::AA_UseHighDpiPixmaps);
-#endif
     app.exec();
 
     qCInfo(MainLog) << "Event loop finished, terminating...";

--- a/libcockatrice_card/CMakeLists.txt
+++ b/libcockatrice_card/CMakeLists.txt
@@ -19,11 +19,7 @@ set(HEADERS
     libcockatrice/card/relation/card_relation.h
 )
 
-if(Qt6_FOUND)
-  qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
-elseif(Qt5_FOUND)
-  qt5_wrap_cpp(MOC_SOURCES ${HEADERS})
-endif()
+qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
 
 add_library(
   libcockatrice_card STATIC

--- a/libcockatrice_card/libcockatrice/card/card_info_comparator.cpp
+++ b/libcockatrice_card/libcockatrice/card/card_info_comparator.cpp
@@ -25,22 +25,13 @@ bool CardInfoComparator::operator()(const CardInfoPtr &a, const CardInfoPtr &b) 
 
 bool CardInfoComparator::compareVariants(const QVariant &a, const QVariant &b) const
 {
-    // Determine the type of QVariant based on Qt version
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     if (a.typeId() != b.typeId()) {
-#else
-    if (a.type() != b.type()) {
-#endif
         // If they are not the same type, compare as strings
         return a.toString() < b.toString();
     }
 
     // Perform type-specific comparison
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     switch (static_cast<int>(a.typeId())) {
-#else
-    switch (static_cast<int>(a.type())) {
-#endif
         case static_cast<int>(QMetaType::Int):
             return a.toInt() < b.toInt();
         case static_cast<int>(QMetaType::Double):

--- a/libcockatrice_deck_list/CMakeLists.txt
+++ b/libcockatrice_deck_list/CMakeLists.txt
@@ -14,11 +14,7 @@ set(HEADERS
     libcockatrice/deck_list/sideboard_plan.h
 )
 
-if(Qt6_FOUND)
-  qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
-elseif(Qt5_FOUND)
-  qt5_wrap_cpp(MOC_SOURCES ${HEADERS})
-endif()
+qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
 
 add_library(
   libcockatrice_deck_list STATIC

--- a/libcockatrice_filters/CMakeLists.txt
+++ b/libcockatrice_filters/CMakeLists.txt
@@ -6,11 +6,7 @@ set(HEADERS libcockatrice/filters/filter_card.h libcockatrice/filters/filter_str
             libcockatrice/filters/filter_tree.h
 )
 
-if(Qt6_FOUND)
-  qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
-elseif(Qt5_FOUND)
-  qt5_wrap_cpp(MOC_SOURCES ${HEADERS})
-endif()
+qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
 
 add_library(
   libcockatrice_filters STATIC ${MOC_SOURCES} libcockatrice/filters/filter_card.cpp

--- a/libcockatrice_interfaces/CMakeLists.txt
+++ b/libcockatrice_interfaces/CMakeLists.txt
@@ -23,11 +23,7 @@ set(HEADERS
     libcockatrice/interfaces/noop_card_set_priority_controller.h
 )
 
-if(Qt6_FOUND)
-  qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
-elseif(Qt5_FOUND)
-  qt5_wrap_cpp(MOC_SOURCES ${HEADERS})
-endif()
+qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
 
 add_library(libcockatrice_interfaces STATIC ${MOC_SOURCES})
 

--- a/libcockatrice_models/libcockatrice/models/database/CMakeLists.txt
+++ b/libcockatrice_models/libcockatrice/models/database/CMakeLists.txt
@@ -12,11 +12,7 @@ set(HEADERS
     token/token_edit_model.h
 )
 
-if(Qt6_FOUND)
-  qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
-elseif(Qt5_FOUND)
-  qt5_wrap_cpp(MOC_SOURCES ${HEADERS})
-endif()
+qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
 
 add_library(
   libcockatrice_models_database STATIC

--- a/libcockatrice_models/libcockatrice/models/deck_list/CMakeLists.txt
+++ b/libcockatrice_models/libcockatrice/models/deck_list/CMakeLists.txt
@@ -4,11 +4,7 @@ set(CMAKE_AUTORCC ON)
 
 set(HEADERS deck_list_model.h deck_list_sort_filter_proxy_model.h)
 
-if(Qt6_FOUND)
-  qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
-elseif(Qt5_FOUND)
-  qt5_wrap_cpp(MOC_SOURCES ${HEADERS})
-endif()
+qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
 
 add_library(
   libcockatrice_models_deck_list STATIC ${MOC_SOURCES} deck_list_model.cpp deck_list_sort_filter_proxy_model.cpp

--- a/libcockatrice_network/libcockatrice/network/client/abstract/CMakeLists.txt
+++ b/libcockatrice_network/libcockatrice/network/client/abstract/CMakeLists.txt
@@ -6,11 +6,7 @@ set(HEADERS abstract_client.h)
 
 set(SOURCES abstract_client.cpp)
 
-if(Qt6_FOUND)
-  qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
-elseif(Qt5_FOUND)
-  qt5_wrap_cpp(MOC_SOURCES ${HEADERS})
-endif()
+qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
 
 add_library(libcockatrice_network_client_abstract STATIC ${MOC_SOURCES} ${SOURCES})
 

--- a/libcockatrice_network/libcockatrice/network/client/local/CMakeLists.txt
+++ b/libcockatrice_network/libcockatrice/network/client/local/CMakeLists.txt
@@ -6,11 +6,7 @@ set(HEADERS local_client.h)
 
 set(SOURCES local_client.cpp)
 
-if(Qt6_FOUND)
-  qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
-elseif(Qt5_FOUND)
-  qt5_wrap_cpp(MOC_SOURCES ${HEADERS})
-endif()
+qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
 
 add_library(libcockatrice_network_client_local STATIC ${MOC_SOURCES} ${SOURCES})
 

--- a/libcockatrice_network/libcockatrice/network/client/remote/CMakeLists.txt
+++ b/libcockatrice_network/libcockatrice/network/client/remote/CMakeLists.txt
@@ -6,11 +6,7 @@ set(HEADERS remote_client.h)
 
 set(SOURCES remote_client.cpp)
 
-if(Qt6_FOUND)
-  qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
-elseif(Qt5_FOUND)
-  qt5_wrap_cpp(MOC_SOURCES ${HEADERS})
-endif()
+qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
 
 add_library(libcockatrice_network_client_remote STATIC ${MOC_SOURCES} ${SOURCES})
 

--- a/libcockatrice_network/libcockatrice/network/server/local/CMakeLists.txt
+++ b/libcockatrice_network/libcockatrice/network/server/local/CMakeLists.txt
@@ -6,11 +6,7 @@ set(HEADERS local_server.h local_server_interface.h)
 
 set(SOURCES local_server.cpp local_server_interface.cpp)
 
-if(Qt6_FOUND)
-  qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
-elseif(Qt5_FOUND)
-  qt5_wrap_cpp(MOC_SOURCES ${HEADERS})
-endif()
+qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
 
 add_library(libcockatrice_network_server_local STATIC ${MOC_SOURCES} ${SOURCES})
 

--- a/libcockatrice_network/libcockatrice/network/server/remote/CMakeLists.txt
+++ b/libcockatrice_network/libcockatrice/network/server/remote/CMakeLists.txt
@@ -23,11 +23,7 @@ set(HEADERS
     serverinfo_user_container.h
 )
 
-if(Qt6_FOUND)
-  qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
-elseif(Qt5_FOUND)
-  qt5_wrap_cpp(MOC_SOURCES ${HEADERS})
-endif()
+qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
 
 add_library(
   libcockatrice_network_server_remote STATIC

--- a/libcockatrice_rng/CMakeLists.txt
+++ b/libcockatrice_rng/CMakeLists.txt
@@ -4,11 +4,7 @@ set(CMAKE_AUTORCC ON)
 
 set(HEADERS libcockatrice/rng/rng_abstract.h libcockatrice/rng/rng_sfmt.h libcockatrice/rng/sfmt/SFMT.h)
 
-if(Qt6_FOUND)
-  qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
-elseif(Qt5_FOUND)
-  qt5_wrap_cpp(MOC_SOURCES ${HEADERS})
-endif()
+qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
 
 add_library(
   libcockatrice_rng STATIC ${MOC_SOURCES} libcockatrice/rng/rng_abstract.cpp libcockatrice/rng/rng_sfmt.cpp

--- a/libcockatrice_settings/CMakeLists.txt
+++ b/libcockatrice_settings/CMakeLists.txt
@@ -27,11 +27,7 @@ set(HEADERS
     libcockatrice/settings/visual_deck_storage_settings.h
 )
 
-if(Qt6_FOUND)
-  qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
-elseif(Qt5_FOUND)
-  qt5_wrap_cpp(MOC_SOURCES ${HEADERS})
-endif()
+qt6_wrap_cpp(MOC_SOURCES ${HEADERS})
 
 add_library(
   libcockatrice_settings STATIC

--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -64,11 +64,7 @@ set(oracle_RESOURCES oracle.qrc)
 # ------------------------
 # Qt resources
 # ------------------------
-if(Qt6_FOUND)
-  qt6_add_resources(oracle_RESOURCES_RCC ${oracle_RESOURCES})
-elseif(Qt5_FOUND)
-  qt5_add_resources(oracle_RESOURCES_RCC ${oracle_RESOURCES})
-endif()
+qt6_add_resources(oracle_RESOURCES_RCC ${oracle_RESOURCES})
 
 # ------------------------
 # Include directories
@@ -106,37 +102,16 @@ set(ORACLE_MAC_QM_INSTALL_DIR "oracle.app/Contents/Resources/translations")
 set(ORACLE_UNIX_QM_INSTALL_DIR "share/oracle/translations")
 set(ORACLE_WIN32_QM_INSTALL_DIR "translations")
 
-if(Qt6_FOUND)
-  # Qt6 Translations are linked after the executable is created in manual mode
-  qt6_add_executable(
-    oracle
-    WIN32
-    MACOSX_BUNDLE
-    ${oracle_SOURCES}
-    ${oracle_RESOURCES_RCC}
-    ${oracle_MOC_SRCS}
-    MANUAL_FINALIZATION
-  )
-elseif(Qt5_FOUND)
-  # Qt5 Translations need to be linked at executable creation time
-  if(Qt5LinguistTools_FOUND)
-    if(UPDATE_TRANSLATIONS)
-      qt5_create_translation(oracle_QM ${translate_SRCS} ${oracle_TS})
-    else()
-      qt5_add_translation(oracle_QM ${oracle_TS})
-    endif()
-  endif()
-  add_executable(oracle WIN32 MACOSX_BUNDLE ${oracle_MOC_SRCS} ${oracle_QM} ${oracle_RESOURCES_RCC} ${oracle_SOURCES})
-  if(UNIX)
-    if(APPLE)
-      install(FILES ${oracle_QM} DESTINATION ${ORACLE_MAC_QM_INSTALL_DIR})
-    else()
-      install(FILES ${oracle_QM} DESTINATION ${ORACLE_UNIX_QM_INSTALL_DIR})
-    endif()
-  elseif(WIN32)
-    install(FILES ${oracle_QM} DESTINATION ${ORACLE_WIN32_QM_INSTALL_DIR})
-  endif()
-endif()
+# Qt6 Translations are linked after the executable is created in manual mode
+qt6_add_executable(
+  oracle
+  WIN32
+  MACOSX_BUNDLE
+  ${oracle_SOURCES}
+  ${oracle_RESOURCES_RCC}
+  ${oracle_MOC_SRCS}
+  MANUAL_FINALIZATION
+)
 
 # ------------------------
 # Link libraries
@@ -285,7 +260,7 @@ endif()
 # ------------------------
 # Qt translations
 # ------------------------
-if(Qt6_FOUND AND Qt6LinguistTools_FOUND)
+if(Qt6LinguistTools_FOUND)
   #Qt6 Translations happen after the executable is built up
   if(UPDATE_TRANSLATIONS)
     qt6_add_translations(
@@ -312,6 +287,4 @@ if(Qt6_FOUND AND Qt6LinguistTools_FOUND)
   endif()
 endif()
 
-if(Qt6_FOUND)
-  qt6_finalize_target(oracle)
-endif()
+qt6_finalize_target(oracle)

--- a/oracle/src/main.cpp
+++ b/oracle/src/main.cpp
@@ -25,11 +25,7 @@ void installNewTranslator()
     QString lang = SettingsCache::instance().personal().getLang();
 
     QString qtNameHint = "qt_" + lang;
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     QString qtTranslationPath = QLibraryInfo::path(QLibraryInfo::TranslationsPath);
-#else
-    QString qtTranslationPath = QLibraryInfo::location(QLibraryInfo::TranslationsPath);
-#endif
 
     bool qtTranslationLoaded = qtTranslator->load(qtNameHint, qtTranslationPath);
     if (!qtTranslationLoaded) {

--- a/oracle/src/qt-json/json.cpp
+++ b/oracle/src/qt-json/json.cpp
@@ -109,12 +109,8 @@ QByteArray Json::serialize(const QVariant &data, bool &success)
     {
         str = "null";
     }
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     else if ((data.typeId() == QMetaType::Type::QVariantList) ||
              (data.typeId() == QMetaType::Type::QStringList)) // variant is a list?
-#else
-    else if ((data.type() == QVariant::List) || (data.type() == QVariant::StringList))  // variant is a list?
-#endif
     {
         QList<QByteArray> values;
         const QVariantList list = data.toList();
@@ -129,11 +125,7 @@ QByteArray Json::serialize(const QVariant &data, bool &success)
 
         str = "[ " + join(values, ", ") + " ]";
     }
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-    else if ((data.typeId() == QMetaType::Type::QVariantHash)) // variant is a list?
-#else
-    else if (data.type() == QVariant::Hash)                                             // variant is a hash?
-#endif
+    else if ((data.typeId() == QMetaType::Type::QVariantHash)) // variant is a hash?
     {
         const QVariantHash vhash = data.toHash();
         QHashIterator<QString, QVariant> it(vhash);
@@ -155,11 +147,7 @@ QByteArray Json::serialize(const QVariant &data, bool &success)
         str += join(pairs, ", ");
         str += " }";
     }
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-    else if ((data.typeId() == QMetaType::Type::QVariantMap)) // variant is a list?
-#else
-    else if (data.type() == QVariant::Map)                                              // variant is a map?
-#endif
+    else if ((data.typeId() == QMetaType::Type::QVariantMap)) // variant is a map?
     {
         const QVariantMap vmap = data.toMap();
         QMapIterator<QString, QVariant> it(vmap);
@@ -177,39 +165,23 @@ QByteArray Json::serialize(const QVariant &data, bool &success)
         str += join(pairs, ", ");
         str += " }";
     }
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     else if ((data.typeId() == QMetaType::Type::QString) ||
-             (data.typeId() == QMetaType::Type::QByteArray)) // variant is a list?
-#else
-    else if ((data.type() == QVariant::String) || (data.type() == QVariant::ByteArray)) // a string or a byte array?
-#endif
+             (data.typeId() == QMetaType::Type::QByteArray)) // a string or a byte array?
     {
         str = sanitizeString(data.toString()).toUtf8();
     }
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-    else if (data.typeId() == QMetaType::Type::Double)
-#else
-    else if (data.type() == QVariant::Double)                                           // double?
-#endif
+    else if (data.typeId() == QMetaType::Type::Double) // double?
     {
         str = QByteArray::number(data.toDouble(), 'g', 20);
         if (!str.contains(".") && !str.contains("e")) {
             str += ".0";
         }
     }
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-    else if (data.typeId() == QMetaType::Type::Bool)
-#else
-    else if (data.type() == QVariant::Bool)                                             // boolean value?
-#endif
+    else if (data.typeId() == QMetaType::Type::Bool) // boolean value?
     {
         str = data.toBool() ? "true" : "false";
     }
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-    else if (data.typeId() == QMetaType::Type::ULongLong)
-#else
-    else if (data.type() == QVariant::ULongLong)                                        // large unsigned number?
-#endif
+    else if (data.typeId() == QMetaType::Type::ULongLong) // large unsigned number?
     {
         str = QByteArray::number(data.value<qulonglong>());
     } else if (data.canConvert<qlonglong>()) // any signed number?

--- a/servatrice/CMakeLists.txt
+++ b/servatrice/CMakeLists.txt
@@ -43,11 +43,7 @@ if(APPLE)
   set(servatrice_SOURCES ${servatrice_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/resources/appicon.icns)
 endif(APPLE)
 
-if(Qt6_FOUND)
-  qt6_add_resources(servatrice_RESOURCES_RCC ${servatrice_RESOURCES})
-elseif(Qt5_FOUND)
-  qt5_add_resources(servatrice_RESOURCES_RCC ${servatrice_RESOURCES})
-endif()
+qt6_add_resources(servatrice_RESOURCES_RCC ${servatrice_RESOURCES})
 
 set(QT_DONT_USE_QTGUI TRUE)
 

--- a/servatrice/src/smtp/qxtsmtp.cpp
+++ b/servatrice/src/smtp/qxtsmtp.cpp
@@ -54,13 +54,8 @@ QxtSmtp::QxtSmtp(QObject *parent) : QObject(parent)
     // QObject::connect(socket(), SIGNAL(encrypted()), &qxt_d(), SLOT(ehlo()));
     QObject::connect(socket(), SIGNAL(connected()), this, SIGNAL(connected()));
     QObject::connect(socket(), SIGNAL(disconnected()), this, SIGNAL(disconnected()));
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     QObject::connect(socket(), SIGNAL(errorOccurred(QAbstractSocket::SocketError)), &qxt_d(),
                      SLOT(socketError(QAbstractSocket::SocketError)));
-#else
-    QObject::connect(socket(), SIGNAL(error(QAbstractSocket::SocketError)), &qxt_d(),
-                     SLOT(socketError(QAbstractSocket::SocketError)));
-#endif
     QObject::connect(this, SIGNAL(authenticated()), &qxt_d(), SLOT(sendNext()));
     QObject::connect(socket(), SIGNAL(readyRead()), &qxt_d(), SLOT(socketRead()));
 }


### PR DESCRIPTION
## Short roundup of the initial problem
We don't ship for Qt5 in CI anymore and it's largely deprecated everywhere nowadays.

## What will change with this Pull Request?
- Remove version guards in code
- Remove qt5 branches in cmakelists