### PR TITLE
[Security] Add per-address rate limiting for auth endpoints

### DIFF
--- a/libcockatrice_network/libcockatrice/network/server/remote/server.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/server.h
@@ -180,6 +180,16 @@ public:
     {
         return false;
     }
+    /**
+     * @brief True if the given address is already locked out of logging in.
+     *
+     * Consulted before any authentication work (database round trip, password
+     * verification) so a blocked address cannot burn server CPU per attempt.
+     */
+    virtual bool isLoginRateLimited(const QString & /*ipAddress*/)
+    {
+        return false;
+    }
     /** @brief Clear any failed-login lockout for the given address, e.g. after a successful login. */
     virtual void clearFailedLogins(const QString & /*ipAddress*/)
     {

--- a/libcockatrice_network/libcockatrice/network/server/remote/server.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/server.h
@@ -175,6 +175,15 @@ public:
     {
         return false;
     }
+    /** @brief Record a failed login attempt from the given address; returns true if the address is now locked out. */
+    virtual bool recordFailedLogin(const QString & /*ipAddress*/)
+    {
+        return false;
+    }
+    /** @brief Clear any failed-login lockout for the given address, e.g. after a successful login. */
+    virtual void clearFailedLogins(const QString & /*ipAddress*/)
+    {
+    }
 
     Server_DatabaseInterface *getDatabaseInterface() const;
     int getNextLocalGameId()

--- a/libcockatrice_network/libcockatrice/network/server/remote/server_protocolhandler.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/server_protocolhandler.cpp
@@ -527,10 +527,14 @@ Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd
             return Response::RespUserIsBanned;
         }
         case NotLoggedIn:
+            if (server->recordFailedLogin(getAddress())) {
+                return Response::RespTooManyRequests;
+            }
             return Response::RespWrongPassword;
         case WouldOverwriteOldSession:
             return Response::RespWouldOverwriteOldSession;
         case UsernameInvalid: {
+            server->recordFailedLogin(getAddress());
             auto *re = new Response_Login;
             re->set_denied_reason_str(reasonStr.toStdString());
             rc.setResponseExtension(re);
@@ -541,8 +545,10 @@ Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd
         case ClientIdRequired:
             return Response::RespClientIdRequired;
         case UserIsInactive:
+            server->recordFailedLogin(getAddress());
             return Response::RespAccountNotActivated;
         default:
+            server->clearFailedLogins(getAddress());
             authState = res;
             usingRealPassword = needsHash;
     }

--- a/libcockatrice_network/libcockatrice/network/server/remote/server_protocolhandler.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/server_protocolhandler.cpp
@@ -514,6 +514,11 @@ Response::ResponseCode Server_ProtocolHandler::cmdLogin(const Command_Login &cmd
     QString reasonStr;
     int banSecondsLeft = 0;
     QString connectionType = getConnectionType();
+    // Throttle before doing any work: a locked-out address must not get a full
+    // database round trip and password verification on every attempt.
+    if (server->isLoginRateLimited(getAddress())) {
+        return Response::RespTooManyRequests;
+    }
     AuthenticationResult res = server->loginUser(this, userName, password, needsHash, reasonStr, banSecondsLeft,
                                                  clientId, clientVersion, connectionType);
     switch (res) {

--- a/servatrice/CMakeLists.txt
+++ b/servatrice/CMakeLists.txt
@@ -7,6 +7,7 @@ project(Servatrice VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${
 set(servatrice_SOURCES
     src/email_parser.cpp
     src/main.cpp
+    src/ratelimiter.cpp
     src/servatrice.cpp
     src/servatrice_connection_pool.cpp
     src/servatrice_database_interface.cpp

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -348,6 +348,27 @@ max_users_websocket=500
 ; Maximum number of users that can connect from the same IP address; useful to avoid bots, default is 4
 max_users_per_address=4
 
+; Maximum number of failed login attempts from a single IP address before that
+; address is temporarily locked out.  Default is 5; set to 0 to disable.
+max_login_attempts_per_ip=5
+
+; Length in seconds of the sliding window used for the login lockout. Default is 900 (15 minutes).
+login_attempt_window_seconds=900
+
+; Maximum number of account registrations from a single IP address within the window below.
+; Default is 2; set to 0 to disable.
+max_registrations_per_ip=2
+
+; Length in seconds of the registration window. Default is 3600 (1 hour).
+registration_window_seconds=3600
+
+; Maximum number of forgot-password requests from a single IP address within the window below.
+; Default is 3; set to 0 to disable.
+max_forgot_password_requests_per_ip=3
+
+; Length in seconds of the forgot-password window. Default is 3600 (1 hour).
+forgot_password_window_seconds=3600
+
 ; You may want to allow an unlimited number of users from a trusted source. This setting can contain a
 ; comma-separed list of IP addresses which will allow an unlimited number of connections from each of the
 ; IP addresses listed (ignoring the max_users_per_address). Default is "127.0.0.1,::1"; example: "192.73.233.244,81.4.100.74"

--- a/servatrice/src/ratelimiter.cpp
+++ b/servatrice/src/ratelimiter.cpp
@@ -1,0 +1,42 @@
+#include "ratelimiter.h"
+
+#include <QDateTime>
+
+bool RateLimiter::recordAttempt(const QString &key, int maxAttempts, int windowSeconds)
+{
+    QMutexLocker locker(&mutex);
+    const qint64 now = QDateTime::currentSecsSinceEpoch();
+
+    QList<qint64> &timestamps = attempts[key];
+    timestamps.append(now);
+    while (!timestamps.isEmpty() && timestamps.first() <= now - windowSeconds) {
+        timestamps.removeFirst();
+    }
+
+    return timestamps.size() > maxAttempts;
+}
+
+bool RateLimiter::isBlocked(const QString &key, int maxAttempts, int windowSeconds) const
+{
+    QMutexLocker locker(&mutex);
+    const qint64 now = QDateTime::currentSecsSinceEpoch();
+
+    const auto it = attempts.constFind(key);
+    if (it == attempts.constEnd()) {
+        return false;
+    }
+
+    int count = 0;
+    for (const qint64 &timestamp : it.value()) {
+        if (timestamp > now - windowSeconds) {
+            ++count;
+        }
+    }
+    return count > maxAttempts;
+}
+
+void RateLimiter::clearAttempts(const QString &key)
+{
+    QMutexLocker locker(&mutex);
+    attempts.remove(key);
+}

--- a/servatrice/src/ratelimiter.cpp
+++ b/servatrice/src/ratelimiter.cpp
@@ -4,22 +4,47 @@
 
 bool RateLimiter::recordAttempt(const QString &key, int maxAttempts, int windowSeconds)
 {
-    QMutexLocker locker(&mutex);
-    const qint64 now = QDateTime::currentSecsSinceEpoch();
+    return recordAttemptAt(key, maxAttempts, windowSeconds, QDateTime::currentSecsSinceEpoch());
+}
 
-    QList<qint64> &timestamps = attempts[key];
-    timestamps.append(now);
+bool RateLimiter::recordAttemptAt(const QString &key, int maxAttempts, int windowSeconds, qint64 now)
+{
+    if (maxAttempts <= 0 || windowSeconds <= 0) {
+        return false; // rate limiting disabled for this endpoint
+    }
+
+    QMutexLocker locker(&mutex);
+    pruneLocked(now);
+
+    AttemptHistory &history = attempts[key];
+    history.windowSeconds = windowSeconds;
+    QList<qint64> &timestamps = history.timestamps;
     while (!timestamps.isEmpty() && timestamps.first() <= now - windowSeconds) {
         timestamps.removeFirst();
     }
+    if (timestamps.size() >= maxAttempts) {
+        // Already at the limit: reject without appending so repeated attempts
+        // at the attacker's own pace cannot keep sliding the window forward
+        // and hold the lockout open forever.
+        return true;
+    }
 
-    return timestamps.size() > maxAttempts;
+    timestamps.append(now);
+    return false;
 }
 
 bool RateLimiter::isBlocked(const QString &key, int maxAttempts, int windowSeconds) const
 {
+    return isBlockedAt(key, maxAttempts, windowSeconds, QDateTime::currentSecsSinceEpoch());
+}
+
+bool RateLimiter::isBlockedAt(const QString &key, int maxAttempts, int windowSeconds, qint64 now) const
+{
+    if (maxAttempts <= 0 || windowSeconds <= 0) {
+        return false;
+    }
+
     QMutexLocker locker(&mutex);
-    const qint64 now = QDateTime::currentSecsSinceEpoch();
 
     const auto it = attempts.constFind(key);
     if (it == attempts.constEnd()) {
@@ -27,16 +52,37 @@ bool RateLimiter::isBlocked(const QString &key, int maxAttempts, int windowSecon
     }
 
     int count = 0;
-    for (const qint64 &timestamp : it.value()) {
+    for (const qint64 &timestamp : it.value().timestamps) {
         if (timestamp > now - windowSeconds) {
             ++count;
         }
     }
-    return count > maxAttempts;
+    return count >= maxAttempts;
 }
 
 void RateLimiter::clearAttempts(const QString &key)
 {
     QMutexLocker locker(&mutex);
     attempts.remove(key);
+}
+
+void RateLimiter::pruneLocked(qint64 now)
+{
+    if (lastPruneSecs + PruneIntervalSeconds > now) {
+        return;
+    }
+    lastPruneSecs = now;
+
+    auto it = attempts.begin();
+    while (it != attempts.end()) {
+        QList<qint64> &timestamps = it.value().timestamps;
+        while (!timestamps.isEmpty() && timestamps.first() <= now - it.value().windowSeconds) {
+            timestamps.removeFirst();
+        }
+        if (timestamps.isEmpty()) {
+            it = attempts.erase(it);
+        } else {
+            ++it;
+        }
+    }
 }

--- a/servatrice/src/ratelimiter.h
+++ b/servatrice/src/ratelimiter.h
@@ -6,20 +6,69 @@
 #include <QMutex>
 #include <QString>
 
-/** @brief Thread-safe per-key attempt counter used to throttle abusive requests. */
+/** @brief Thread-safe per-key attempt limiter used to throttle abusive requests. */
 class RateLimiter
 {
 public:
-    /** @brief Record an attempt for the key and report whether the key is now over the limit. */
+    /**
+     * @brief Record an attempt for @p key and report whether the key is now blocked.
+     *
+     * A key that is already at its limit is not extended: the attempt is
+     * rejected without appending, so the lockout lifts once the recorded
+     * attempts age out of the window. Returns false immediately when
+     * @p maxAttempts <= 0 or @p windowSeconds <= 0 (rate limiting disabled),
+     * recording nothing.
+     *
+     * Delegates to recordAttemptAt() with the current wall-clock time.
+     */
     bool recordAttempt(const QString &key, int maxAttempts, int windowSeconds);
-    /** @brief True if the key already has more than maxAttempts attempts within windowSeconds. */
+
+    /**
+     * @brief Record an attempt as seen at epoch second @p now.
+     *
+     * Exposed for deterministic tests; production callers should use
+     * recordAttempt().
+     */
+    bool recordAttemptAt(const QString &key, int maxAttempts, int windowSeconds, qint64 now);
+
+    /**
+     * @brief True if @p key already has at least @p maxAttempts attempts within @p windowSeconds.
+     *
+     * Reads only; records nothing. Returns false when @p maxAttempts <= 0 or
+     * @p windowSeconds <= 0. Delegates to isBlockedAt().
+     */
     bool isBlocked(const QString &key, int maxAttempts, int windowSeconds) const;
+
+    /**
+     * @brief Whether @p key is blocked as measured at epoch second @p now.
+     *
+     * Exposed for deterministic tests; production callers should use
+     * isBlocked().
+     */
+    bool isBlockedAt(const QString &key, int maxAttempts, int windowSeconds, qint64 now) const;
+
     /** @brief Drop all recorded attempts for the key, e.g. after a successful login. */
     void clearAttempts(const QString &key);
 
 private:
+    struct AttemptHistory
+    {
+        QList<qint64> timestamps; // epoch seconds, oldest first
+        int windowSeconds;
+    };
+
+    /**
+     * @brief Drops keys whose last attempts have fully aged out of their window.
+     *
+     * Runs at most every PruneIntervalSeconds to stop the map from growing
+     * without bound when attackers rotate source addresses.
+     */
+    void pruneLocked(qint64 now);
+
     mutable QMutex mutex;
-    QMap<QString, QList<qint64>> attempts; // key -> attempt timestamps (epoch seconds)
+    QMap<QString, AttemptHistory> attempts; // key -> attempt history
+    qint64 lastPruneSecs = 0;
+    static constexpr int PruneIntervalSeconds = 60;
 };
 
 #endif

--- a/servatrice/src/ratelimiter.h
+++ b/servatrice/src/ratelimiter.h
@@ -1,0 +1,25 @@
+#ifndef RATELIMITER_H
+#define RATELIMITER_H
+
+#include <QList>
+#include <QMap>
+#include <QMutex>
+#include <QString>
+
+/** @brief Thread-safe per-key attempt counter used to throttle abusive requests. */
+class RateLimiter
+{
+public:
+    /** @brief Record an attempt for the key and report whether the key is now over the limit. */
+    bool recordAttempt(const QString &key, int maxAttempts, int windowSeconds);
+    /** @brief True if the key already has more than maxAttempts attempts within windowSeconds. */
+    bool isBlocked(const QString &key, int maxAttempts, int windowSeconds) const;
+    /** @brief Drop all recorded attempts for the key, e.g. after a successful login. */
+    void clearAttempts(const QString &key);
+
+private:
+    mutable QMutex mutex;
+    QMap<QString, QList<qint64>> attempts; // key -> attempt timestamps (epoch seconds)
+};
+
+#endif

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -1080,6 +1080,11 @@ bool Servatrice::recordFailedLogin(const QString &ipAddress)
     return rateLimiter.recordAttempt("login:" + ipAddress, getMaxLoginAttemptsPerIp(), getLoginAttemptWindowSeconds());
 }
 
+bool Servatrice::isLoginRateLimited(const QString &ipAddress)
+{
+    return rateLimiter.isBlocked("login:" + ipAddress, getMaxLoginAttemptsPerIp(), getLoginAttemptWindowSeconds());
+}
+
 void Servatrice::clearFailedLogins(const QString &ipAddress)
 {
     rateLimiter.clearAttempts("login:" + ipAddress);

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -1075,6 +1075,46 @@ int Servatrice::getForgotPasswordTokenLife() const
     return settingsCache->value("forgotpassword/tokenlife", 60).toInt();
 }
 
+bool Servatrice::recordFailedLogin(const QString &ipAddress)
+{
+    return rateLimiter.recordAttempt("login:" + ipAddress, getMaxLoginAttemptsPerIp(), getLoginAttemptWindowSeconds());
+}
+
+void Servatrice::clearFailedLogins(const QString &ipAddress)
+{
+    rateLimiter.clearAttempts("login:" + ipAddress);
+}
+
+int Servatrice::getMaxLoginAttemptsPerIp() const
+{
+    return settingsCache->value("security/max_login_attempts_per_ip", 5).toInt();
+}
+
+int Servatrice::getLoginAttemptWindowSeconds() const
+{
+    return settingsCache->value("security/login_attempt_window_seconds", 900).toInt();
+}
+
+int Servatrice::getMaxRegistrationsPerIp() const
+{
+    return settingsCache->value("security/max_registrations_per_ip", 2).toInt();
+}
+
+int Servatrice::getRegistrationWindowSeconds() const
+{
+    return settingsCache->value("security/registration_window_seconds", 3600).toInt();
+}
+
+int Servatrice::getMaxForgotPasswordRequestsPerIp() const
+{
+    return settingsCache->value("security/max_forgot_password_requests_per_ip", 3).toInt();
+}
+
+int Servatrice::getForgotPasswordWindowSeconds() const
+{
+    return settingsCache->value("security/forgot_password_window_seconds", 3600).toInt();
+}
+
 bool Servatrice::getEnableForgotPasswordChallenge() const
 {
     return settingsCache->value("forgotpassword/enablechallenge", false).toBool();

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -20,6 +20,8 @@
 #ifndef SERVATRICE_H
 #define SERVATRICE_H
 
+#include "ratelimiter.h"
+
 #include <QHostAddress>
 #include <QMetaType>
 #include <QMutex>
@@ -172,6 +174,8 @@ private:
     int nextShutdownMessageMinutes;
     QTimer *shutdownTimer;
 
+    RateLimiter rateLimiter;
+
     mutable QMutex serverListMutex;
     QList<ServerProperties> serverList;
     void updateServerList();
@@ -274,6 +278,19 @@ public:
     void incTxBytes(quint64 num);
     void incRxBytes(quint64 num);
     void addDatabaseInterface(QThread *thread, Servatrice_DatabaseInterface *databaseInterface);
+
+    RateLimiter *getRateLimiter()
+    {
+        return &rateLimiter;
+    }
+    bool recordFailedLogin(const QString &ipAddress) override;
+    void clearFailedLogins(const QString &ipAddress) override;
+    int getMaxLoginAttemptsPerIp() const;
+    int getLoginAttemptWindowSeconds() const;
+    int getMaxRegistrationsPerIp() const;
+    int getRegistrationWindowSeconds() const;
+    int getMaxForgotPasswordRequestsPerIp() const;
+    int getForgotPasswordWindowSeconds() const;
 
     bool islConnectionExists(int _serverId) const;
     void addIslInterface(int _serverId, IslInterface *interface);

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -284,6 +284,7 @@ public:
         return &rateLimiter;
     }
     bool recordFailedLogin(const QString &ipAddress) override;
+    bool isLoginRateLimited(const QString &ipAddress) override;
     void clearFailedLogins(const QString &ipAddress) override;
     int getMaxLoginAttemptsPerIp() const;
     int getLoginAttemptWindowSeconds() const;

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -1433,9 +1433,8 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
 
 bool AbstractServerSocketInterface::tooManyRegistrationAttempts(const QString &ipAddress)
 {
-    //! \todo Implement registration attempt limiting.
-    Q_UNUSED(ipAddress);
-    return false;
+    return servatrice->getRateLimiter()->recordAttempt("register:" + ipAddress, servatrice->getMaxRegistrationsPerIp(),
+                                                       servatrice->getRegistrationWindowSeconds());
 }
 
 Response::ResponseCode AbstractServerSocketInterface::cmdActivateAccount(const Command_Activate &cmd,
@@ -1788,6 +1787,17 @@ Response::ResponseCode AbstractServerSocketInterface::cmdForgotPasswordRequest(c
 
     qCDebug(AbstractServerSocketInterfaceLog) << "Received reset password request from user:" << userName;
 
+    if (servatrice->getRateLimiter()->recordAttempt("forgot:" + this->getAddress(),
+                                                    servatrice->getMaxForgotPasswordRequestsPerIp(),
+                                                    servatrice->getForgotPasswordWindowSeconds())) {
+        if (servatrice->getEnableForgotPasswordAudit()) {
+            sqlInterface->addAuditRecord(userName.simplified(), this->getAddress(), clientId.simplified(),
+                                         "PASSWORD_RESET_REQUEST", "Too many requests from this ip address", false);
+        }
+
+        return Response::RespTooManyRequests;
+    }
+
     if (!servatrice->getEnableForgotPassword()) {
         if (servatrice->getEnableForgotPasswordAudit()) {
             sqlInterface->addAuditRecord(userName.simplified(), this->getAddress(), clientId.simplified(),
@@ -1928,6 +1938,16 @@ AbstractServerSocketInterface::cmdForgotPasswordChallenge(const Command_ForgotPa
     const QString clientId = nameFromStdString(cmd.clientid());
 
     qCDebug(AbstractServerSocketInterfaceLog) << "Received reset password challenge from user:" << userName;
+
+    if (servatrice->getRateLimiter()->recordAttempt("forgot:" + this->getAddress(),
+                                                    servatrice->getMaxForgotPasswordRequestsPerIp(),
+                                                    servatrice->getForgotPasswordWindowSeconds())) {
+        if (servatrice->getEnableForgotPasswordAudit()) {
+            sqlInterface->addAuditRecord(userName.simplified(), this->getAddress(), clientId.simplified(),
+                                         "PASSWORD_RESET_CHALLENGE", "Too many requests from this ip address", false);
+        }
+        return Response::RespTooManyRequests;
+    }
 
     if (!servatrice->getEnableForgotPasswordChallenge()) {
         if (servatrice->getEnableForgotPasswordAudit()) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_test(NAME expression_test COMMAND expression_test)
 add_test(NAME clamped_arithmetic_test COMMAND clamped_arithmetic_test)
 add_test(NAME test_age_formatting COMMAND test_age_formatting)
 add_test(NAME password_hash_test COMMAND password_hash_test)
+add_test(NAME rate_limiter_test COMMAND rate_limiter_test)
 add_test(NAME server_card_counter_test COMMAND server_card_counter_test)
 add_test(NAME server_counter_test COMMAND server_counter_test)
 
@@ -20,6 +21,7 @@ add_executable(expression_test expression_test.cpp)
 add_executable(clamped_arithmetic_test clamped_arithmetic_test.cpp)
 add_executable(test_age_formatting test_age_formatting.cpp)
 add_executable(password_hash_test password_hash_test.cpp)
+add_executable(rate_limiter_test ../servatrice/src/ratelimiter.cpp rate_limiter_test.cpp)
 add_executable(deck_hash_performance_test deck_hash_performance_test.cpp)
 add_executable(server_card_counter_test server_card_counter_test.cpp)
 add_executable(server_counter_test server_counter_test.cpp)
@@ -54,6 +56,7 @@ if(NOT GTEST_FOUND)
   add_dependencies(clamped_arithmetic_test gtest)
   add_dependencies(test_age_formatting gtest)
   add_dependencies(password_hash_test gtest)
+  add_dependencies(rate_limiter_test gtest)
   add_dependencies(deck_hash_performance_test gtest)
   add_dependencies(server_card_counter_test gtest)
   add_dependencies(server_counter_test gtest)
@@ -71,6 +74,8 @@ target_link_libraries(
 target_link_libraries(
   password_hash_test libcockatrice_utility Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES}
 )
+target_include_directories(rate_limiter_test PRIVATE "${CMAKE_SOURCE_DIR}/servatrice/src")
+target_link_libraries(rate_limiter_test Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES})
 target_link_libraries(
   deck_hash_performance_test libcockatrice_deck_list libcockatrice_utility Threads::Threads ${GTEST_BOTH_LIBRARIES}
   ${TEST_QT_MODULES}

--- a/tests/rate_limiter_test.cpp
+++ b/tests/rate_limiter_test.cpp
@@ -8,36 +8,93 @@ namespace
 TEST(RateLimiterTest, AllowsAttemptsWithinLimit)
 {
     RateLimiter limiter;
-    ASSERT_FALSE(limiter.recordAttempt("ip", 3, 60));
-    ASSERT_FALSE(limiter.recordAttempt("ip", 3, 60));
-    ASSERT_FALSE(limiter.recordAttempt("ip", 3, 60));
-    ASSERT_FALSE(limiter.isBlocked("ip", 3, 60));
+    ASSERT_FALSE(limiter.recordAttemptAt("ip", 3, 60, 1000));
+    ASSERT_FALSE(limiter.recordAttemptAt("ip", 3, 60, 1001));
+    // Still under the limit after two attempts, so the key is not blocked...
+    ASSERT_FALSE(limiter.isBlockedAt("ip", 3, 60, 1002));
+    // ...and the third (the limit) is allowed through.
+    ASSERT_FALSE(limiter.recordAttemptAt("ip", 3, 60, 1002));
+    // The next attempt is blocked once three are on the books.
+    ASSERT_TRUE(limiter.isBlockedAt("ip", 3, 60, 1003));
+    ASSERT_TRUE(limiter.recordAttemptAt("ip", 3, 60, 1003));
 }
 
-TEST(RateLimiterTest, BlocksAttemptsOverLimit)
+TEST(RateLimiterTest, BlocksAttemptsAtTheLimit)
 {
     RateLimiter limiter;
-    ASSERT_FALSE(limiter.recordAttempt("ip", 2, 60));
-    ASSERT_FALSE(limiter.recordAttempt("ip", 2, 60));
-    ASSERT_TRUE(limiter.recordAttempt("ip", 2, 60));
-    ASSERT_TRUE(limiter.isBlocked("ip", 2, 60));
+    ASSERT_FALSE(limiter.recordAttemptAt("ip", 2, 60, 1000));
+    ASSERT_FALSE(limiter.recordAttemptAt("ip", 2, 60, 1001));
+    ASSERT_TRUE(limiter.recordAttemptAt("ip", 2, 60, 1002));
+    ASSERT_TRUE(limiter.isBlockedAt("ip", 2, 60, 1002));
+}
+
+TEST(RateLimiterTest, NonPositiveConfigDisablesLimiting)
+{
+    RateLimiter limiter;
+    // maxAttempts = 0 is the documented "set to 0 to disable"; negative or
+    // zero windows are config mistakes and must not lock everyone out either.
+    ASSERT_FALSE(limiter.recordAttempt("ip", 0, 60));
+    ASSERT_FALSE(limiter.isBlocked("ip", 0, 60));
+    ASSERT_FALSE(limiter.recordAttempt("ip", -1, 60));
+    ASSERT_FALSE(limiter.isBlocked("ip", -1, 60));
+    ASSERT_FALSE(limiter.recordAttempt("ip", 5, 0));
+    ASSERT_FALSE(limiter.isBlocked("ip", 5, 0));
 }
 
 TEST(RateLimiterTest, ClearAttempts)
 {
     RateLimiter limiter;
-    ASSERT_TRUE(limiter.recordAttempt("ip", 0, 60));
-    ASSERT_TRUE(limiter.isBlocked("ip", 0, 60));
+    ASSERT_FALSE(limiter.recordAttemptAt("ip", 1, 60, 1000));
+    ASSERT_TRUE(limiter.recordAttemptAt("ip", 1, 60, 1001));
+    ASSERT_TRUE(limiter.isBlockedAt("ip", 1, 60, 1001));
     limiter.clearAttempts("ip");
-    ASSERT_FALSE(limiter.isBlocked("ip", 0, 60));
+    ASSERT_FALSE(limiter.isBlockedAt("ip", 1, 60, 1002));
+    // The cleared key starts fresh and is allowed again.
+    ASSERT_FALSE(limiter.recordAttemptAt("ip", 1, 60, 1002));
 }
 
 TEST(RateLimiterTest, KeysAreIndependent)
 {
     RateLimiter limiter;
-    ASSERT_TRUE(limiter.recordAttempt("a", 0, 60));
-    ASSERT_FALSE(limiter.isBlocked("b", 0, 60));
-    ASSERT_TRUE(limiter.isBlocked("a", 0, 60));
+    ASSERT_FALSE(limiter.recordAttemptAt("a", 1, 60, 1000));
+    ASSERT_TRUE(limiter.recordAttemptAt("a", 1, 60, 1001));
+    ASSERT_FALSE(limiter.isBlockedAt("b", 1, 60, 1001));
+    ASSERT_TRUE(limiter.isBlockedAt("a", 1, 60, 1001));
+}
+
+TEST(RateLimiterTest, AttemptsAgeOutOfTheWindow)
+{
+    RateLimiter limiter;
+    const qint64 t = 1000;
+    const int window = 60;
+
+    ASSERT_FALSE(limiter.recordAttemptAt("ip", 2, window, t));
+    ASSERT_FALSE(limiter.recordAttemptAt("ip", 2, window, t + 1));
+    ASSERT_TRUE(limiter.recordAttemptAt("ip", 2, window, t + 2));
+    ASSERT_TRUE(limiter.isBlockedAt("ip", 2, window, t + 2));
+
+    // A blocked attempt is rejected without recording, so it cannot extend
+    // the lockout either.
+    ASSERT_TRUE(limiter.recordAttemptAt("ip", 2, window, t + 3));
+
+    // Once the recorded attempts fall outside the window the key clears by
+    // itself, with no manual unlock.
+    ASSERT_FALSE(limiter.isBlockedAt("ip", 2, window, t + 61));
+    ASSERT_FALSE(limiter.recordAttemptAt("ip", 2, window, t + 62));
+}
+
+TEST(RateLimiterTest, BlockedKeyIsUnlockedAfterSuccessfulClear)
+{
+    RateLimiter limiter;
+    const qint64 t = 5000;
+
+    ASSERT_FALSE(limiter.recordAttemptAt("ip", 2, 60, t));
+    ASSERT_FALSE(limiter.recordAttemptAt("ip", 2, 60, t + 1));
+    ASSERT_TRUE(limiter.recordAttemptAt("ip", 2, 60, t + 2));
+    ASSERT_TRUE(limiter.isBlockedAt("ip", 2, 60, t + 2));
+
+    limiter.clearAttempts("ip");
+    ASSERT_FALSE(limiter.recordAttemptAt("ip", 2, 60, t + 3));
 }
 
 } // namespace

--- a/tests/rate_limiter_test.cpp
+++ b/tests/rate_limiter_test.cpp
@@ -1,0 +1,49 @@
+#include "ratelimiter.h"
+
+#include "gtest/gtest.h"
+
+namespace
+{
+
+TEST(RateLimiterTest, AllowsAttemptsWithinLimit)
+{
+    RateLimiter limiter;
+    ASSERT_FALSE(limiter.recordAttempt("ip", 3, 60));
+    ASSERT_FALSE(limiter.recordAttempt("ip", 3, 60));
+    ASSERT_FALSE(limiter.recordAttempt("ip", 3, 60));
+    ASSERT_FALSE(limiter.isBlocked("ip", 3, 60));
+}
+
+TEST(RateLimiterTest, BlocksAttemptsOverLimit)
+{
+    RateLimiter limiter;
+    ASSERT_FALSE(limiter.recordAttempt("ip", 2, 60));
+    ASSERT_FALSE(limiter.recordAttempt("ip", 2, 60));
+    ASSERT_TRUE(limiter.recordAttempt("ip", 2, 60));
+    ASSERT_TRUE(limiter.isBlocked("ip", 2, 60));
+}
+
+TEST(RateLimiterTest, ClearAttempts)
+{
+    RateLimiter limiter;
+    ASSERT_TRUE(limiter.recordAttempt("ip", 0, 60));
+    ASSERT_TRUE(limiter.isBlocked("ip", 0, 60));
+    limiter.clearAttempts("ip");
+    ASSERT_FALSE(limiter.isBlocked("ip", 0, 60));
+}
+
+TEST(RateLimiterTest, KeysAreIndependent)
+{
+    RateLimiter limiter;
+    ASSERT_TRUE(limiter.recordAttempt("a", 0, 60));
+    ASSERT_FALSE(limiter.isBlocked("b", 0, 60));
+    ASSERT_TRUE(limiter.isBlocked("a", 0, 60));
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Short roundup of the initial problem
There's no rate limiting on certain endpoints, most crucially, auth ones.

## What will change with this Pull Request?
Introduce a thread-safe RateLimiter that tracks attempts per key (IP address) within a sliding time window, and wire it into the authentication endpoints:

- Login: failed login attempts from an address are counted; once the configured maximum is exceeded within the window, further logins from that address are rejected with RespTooManyRequests. A successful login clears the failed attempts for that address.
- Registration: implement the previously stubbed tooManyRegistrationAttempts, limiting how many accounts can be created per address per window.
- Forgot-password: throttle both the email-request and the email-challenge paths per address.

New [security] settings with defaults:
  max_login_attempts_per_ip=5 / login_attempt_window_seconds=900 max_registrations_per_ip=2 / registration_window_seconds=3600 max_forgot_password_requests_per_ip=3 / forgot_password_window_seconds=3600

Adds unit tests for the RateLimiter (window limit, over-limit blocking, clearing, per-key independence).

## Review fixes (6 threads)
- `maxAttempts=0` (or a non-positive window) now disables the limiter as documented, instead of rejecting every address
- Keys at their limit are rejected without recording, so the window isn't slid forward by repeated attempts — a lockout lifts after `windowSeconds` of quiet
- Bounded memory: an opportunistic 60s prune erases keys whose attempts have fully aged out
- Login is throttled before the work: a new `Server::isLoginRateLimited()` gate skips the DB round trip and password verification for locked-out addresses
- `recordAttemptAt()`/`isBlockedAt()` time seams make the sliding-window behavior deterministically testable; tests rewritten for the real semantics
