### PR TITLE
[Dialogs] Focus login after selecting server, center update message box

### DIFF
--- a/cockatrice/src/interface/widgets/dialogs/dlg_connect.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_connect.cpp
@@ -271,6 +271,7 @@ void DlgConnect::updateDisplayInfo(const QString &saveName)
     hostEdit->setText(_data.at(1));
     portEdit->setText(_data.at(2));
     playernameEdit->setText(_data.at(3));
+    playernameEdit->setFocus();
     savePasswordCheckBox->setChecked(savePasswordStatus);
 
     if (savePasswordStatus) {

--- a/cockatrice/src/interface/widgets/dialogs/dlg_update.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_update.cpp
@@ -134,7 +134,7 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
         // If there's no need to update, tell them that. However we still allow them to run the
         // downloader themselves if there's a compatible build
         QMessageBox::information(
-            this, tr("No Update Available"),
+            window(), tr("No Update Available"),
             tr("Cockatrice is up to date!") + "<br><br>" +
                 tr("You are already running the latest version available in the chosen release channel.") + "<br>" +
                 "<b>" + tr("Current version") + QString(":</b> %1<br>").arg(VERSION_STRING) + "<b>" +
@@ -147,7 +147,7 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
     if (isCompatible) {
         int reply;
         reply = QMessageBox::question(
-            this, tr("Update Available"),
+            window(), tr("Update Available"),
             tr("A new version of Cockatrice is available!") + "<br><br>" + "<b>" + tr("New version") +
                 QString(":</b> %1<br>").arg(release->getName()) + "<b>" + tr("Released") +
                 QString(":</b> %1 (<a href=\"%2\">").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") +
@@ -159,7 +159,7 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
         }
     } else {
         QMessageBox::information(
-            this, tr("Update Available"),
+            window(), tr("Update Available"),
             tr("A new version of Cockatrice is available!") + "<br><br>" + "<b>" + tr("New version") +
                 QString(":</b> %1<br>").arg(release->getName()) + "<b>" + tr("Released") +
                 QString(":</b> %1 (<a href=\"%2\">").arg(publishDate, release->getDescriptionUrl()) + tr("Changelog") +


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #3346 
- Fixes #3538 

## Short roundup of the initial problem
Small UI stuff

## What will change with this Pull Request?
- Set focus
- Center message box
