### PR TITLE
[UpdateDialog] Close dialog when declining an update

### DIFF
--- a/cockatrice/src/interface/widgets/dialogs/dlg_update.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_update.cpp
@@ -156,6 +156,8 @@ void DlgUpdate::finishedUpdateCheck(bool needToUpdate, bool isCompatible, Releas
 
         if (reply == QMessageBox::Yes) {
             downloadUpdate(release->getName());
+        } else {
+            closeDialog();
         }
     } else {
         QMessageBox::information(


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #2517

## Short roundup of the initial problem
Declining an update doesn't close the dialog

## What will change with this Pull Request?
- Close dialog
