### PR TITLE
[Oracle] Don't report a cancelled card database update as successful

### DIFF
--- a/cockatrice/src/interface/window_main.cpp
+++ b/cockatrice/src/interface/window_main.cpp
@@ -920,7 +920,7 @@ void MainWindow::createCardUpdateProcess(bool background)
     if (updaterCmd.isEmpty()) {
         QMessageBox::warning(this, tr("Error"),
                              tr("Unable to run the card database updater: ") + dir.absoluteFilePath(binaryName));
-        exitCardDatabaseUpdate();
+        exitCardDatabaseUpdate(false);
         return;
     }
 
@@ -932,13 +932,15 @@ void MainWindow::createCardUpdateProcess(bool background)
     }
 }
 
-void MainWindow::exitCardDatabaseUpdate()
+void MainWindow::exitCardDatabaseUpdate(bool reload)
 {
     cardUpdateProcess->deleteLater();
     cardUpdateProcess = nullptr;
     statusBar()->clearMessage();
 
-    const auto reloadOk1 = QtConcurrent::run([] { CardDatabaseManager::getInstance()->loadCardDatabases(); });
+    if (reload) {
+        const auto reloadOk1 = QtConcurrent::run([] { CardDatabaseManager::getInstance()->loadCardDatabases(); });
+    }
 }
 
 void MainWindow::cardUpdateError(QProcess::ProcessError err)
@@ -969,16 +971,21 @@ void MainWindow::cardUpdateError(QProcess::ProcessError err)
             break;
     }
 
-    exitCardDatabaseUpdate();
+    exitCardDatabaseUpdate(false);
     QMessageBox::warning(this, tr("Error"), tr("The card database updater exited with an error:\n%1").arg(error));
 }
 
-void MainWindow::cardUpdateFinished(int, QProcess::ExitStatus exitStatus)
+void MainWindow::cardUpdateFinished(int exitCode, QProcess::ExitStatus exitStatus)
 {
-    if (exitStatus == QProcess::NormalExit) {
+    if (exitStatus == QProcess::NormalExit && exitCode == 0) {
         SettingsCache::instance().updates().setLastCardUpdateCheck(QDateTime::currentDateTime().date());
+        exitCardDatabaseUpdate(true);
+    } else {
+        exitCardDatabaseUpdate(false);
+        if (exitStatus == QProcess::NormalExit && exitCode != 0) {
+            statusBar()->showMessage(tr("Card database update cancelled."), 10000);
+        }
     }
-    exitCardDatabaseUpdate();
 }
 
 void MainWindow::actCheckServerUpdates()

--- a/cockatrice/src/interface/window_main.h
+++ b/cockatrice/src/interface/window_main.h
@@ -118,7 +118,7 @@ private:
         return "oracle";
     }
     void createCardUpdateProcess(bool background = false);
-    void exitCardDatabaseUpdate();
+    void exitCardDatabaseUpdate(bool reload);
 
     void startLocalGame(const LocalGameOptions &options);
 

--- a/oracle/src/main.cpp
+++ b/oracle/src/main.cpp
@@ -95,5 +95,6 @@ int main(int argc, char *argv[])
         QTimer::singleShot(0, &wizard, [&wizard]() { wizard.runInBackground(); });
     }
 
-    return app.exec();
+    const int execResult = app.exec();
+    return wizard.wasCancelled() ? 1 : execResult;
 }

--- a/oracle/src/oraclewizard.cpp
+++ b/oracle/src/oraclewizard.cpp
@@ -110,6 +110,18 @@ void OracleWizard::accept()
     QDialog::accept();
 }
 
+void OracleWizard::reject()
+{
+    cancelled = true;
+
+    const auto replies = nam->findChildren<QNetworkReply *>();
+    for (QNetworkReply *reply : replies) {
+        reply->abort();
+    }
+
+    QDialog::reject();
+}
+
 void OracleWizard::enableButtons()
 {
     button(QWizard::NextButton)->setDisabled(false);

--- a/oracle/src/oraclewizard.h
+++ b/oracle/src/oraclewizard.h
@@ -23,6 +23,11 @@ class OracleWizard : public QWizard
 public:
     explicit OracleWizard(QWidget *parent = nullptr);
     void accept() override;
+    void reject() override;
+    bool wasCancelled()
+    {
+        return cancelled;
+    }
     void enableButtons();
     void disableButtons();
     void retranslateUi();
@@ -74,6 +79,7 @@ private:
     QByteArray tokensData;
     QString cardSourceUrl;
     QString cardSourceVersion;
+    bool cancelled = false;
 
     void migrateOracleSettings();
 

--- a/oracle/src/pages.cpp
+++ b/oracle/src/pages.cpp
@@ -350,6 +350,10 @@ void LoadSetsPage::actDownloadFinishedSetsFile()
 {
     // check for a reply
     auto *reply = dynamic_cast<QNetworkReply *>(sender());
+    if (wizard()->wasCancelled()) {
+        reply->deleteLater();
+        return;
+    }
     auto errorCode = reply->error();
     if (errorCode != QNetworkReply::NoError) {
         QMessageBox::critical(this, tr("Error"), tr("Network error: %1.").arg(reply->errorString()));

--- a/oracle/src/pagetemplates.cpp
+++ b/oracle/src/pagetemplates.cpp
@@ -163,6 +163,10 @@ void SimpleDownloadFilePage::actDownloadFinished()
 {
     // check for a reply
     auto *reply = dynamic_cast<QNetworkReply *>(sender());
+    if (wizard()->wasCancelled()) {
+        reply->deleteLater();
+        return;
+    }
     QNetworkReply::NetworkError errorCode = reply->error();
     if (errorCode != QNetworkReply::NoError) {
         QMessageBox::critical(this, tr("Error"), tr("Network error: %1.").arg(reply->errorString()));


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1601
- Fixes #2145
- Fixes #3470

## Short roundup of the initial problem
Oracle doesn't report exit status

## What will change with this Pull Request?
- Report and respond to exit status
