### PR TITLE
[TabServer] ensure "isOpen" settings value is always persisted/kept in sync

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
@@ -583,6 +583,7 @@ void TabSupervisor::actTabServer(bool checked)
 
 void TabSupervisor::openTabServer()
 {
+    SettingsCache::instance().tabs().setTabServerOpen(true);
     if (tabServer) {
         return;
     }


### PR DESCRIPTION
## Short roundup of the initial problem
If you close the server tab and then open it through the home widget "Play"  the setting for that causes the tab to automatically reopen when you launch trice is never persisted. Only the "Tabs -> Server" checkbox persists it

## What will change with this Pull Request?
- Persist whenever the tab is opened.