### PR TITLE
Included an Exclude button (ironic) on the Visual Deck Storage.

### DIFF
--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_filter_widget.cpp
@@ -28,11 +28,10 @@ DeckPreviewColorIdentityFilterWidget::DeckPreviewColorIdentityFilterWidget(Visua
     }
 
     toggleButton = new QPushButton(this);
-    toggleButton->setCheckable(true);
     layout->addWidget(toggleButton);
 
-    // Connect the button's toggled signal
-    connect(toggleButton, &QPushButton::toggled, this, &DeckPreviewColorIdentityFilterWidget::updateFilterMode);
+    // Connect the button's clicked signal
+    connect(toggleButton, &QPushButton::clicked, this, &DeckPreviewColorIdentityFilterWidget::updateFilterMode);
     connect(this, &DeckPreviewColorIdentityFilterWidget::activeColorsChanged, parent,
             &VisualDeckStorageWidget::updateColorFilter);
     connect(this, &DeckPreviewColorIdentityFilterWidget::filterModeChanged, parent,
@@ -45,7 +44,17 @@ DeckPreviewColorIdentityFilterWidget::DeckPreviewColorIdentityFilterWidget(Visua
 void DeckPreviewColorIdentityFilterWidget::retranslateUi()
 {
     // Set the toggle button text based on the current mode
-    toggleButton->setText(exactMatchMode ? tr("Mode: Exact Match") : tr("Mode: Includes"));
+    switch (filterMode) {
+        case ExactMatch:
+            toggleButton->setText(tr("Mode: Exact Match"));
+            break;
+        case Includes:
+            toggleButton->setText(tr("Mode: Includes"));
+            break;
+        case Excludes:
+            toggleButton->setText(tr("Mode: Excludes"));
+            break;
+    }
     toggleButton->setToolTip(tr("Color identity filter mode (AND/OR/NOT conjunctions of filters)"));
 }
 
@@ -55,11 +64,23 @@ void DeckPreviewColorIdentityFilterWidget::handleColorToggled(QChar color, bool 
     emit activeColorsChanged();
 }
 
-void DeckPreviewColorIdentityFilterWidget::updateFilterMode(bool checked)
+void DeckPreviewColorIdentityFilterWidget::updateFilterMode()
 {
-    exactMatchMode = checked; // Toggle between modes
-    retranslateUi();          // Update the button text
-    emit filterModeChanged(exactMatchMode);
+    // Cycle through the modes
+    switch (filterMode) {
+        case ExactMatch:
+            filterMode = Includes;
+            break;
+        case Includes:
+            filterMode = Excludes;
+            break;
+        case Excludes:
+            filterMode = ExactMatch;
+            break;
+    }
+
+    retranslateUi(); // Update the button text
+    emit filterModeChanged(filterMode);
 }
 
 void DeckPreviewColorIdentityFilterWidget::filterWidgets(QList<DeckPreviewWidget *> widgets)
@@ -78,41 +99,55 @@ void DeckPreviewColorIdentityFilterWidget::filterWidgets(QList<DeckPreviewWidget
         for (DeckPreviewWidget *previewWidget : widgets) {
             previewWidget->filteredByColor = false;
         }
+        return;
     }
 
     for (const auto &widget : widgets) {
         QString colorIdentity = widget->getColorIdentity();
 
         bool matchesFilter = true;
-        if (exactMatchMode) {
-            // Exact match mode: active colors must exactly match colorIdentity
+        switch (filterMode) {
+            case ExactMatch: {
+                // Exact match mode: active colors must exactly match colorIdentity
 
-            // Create a set of active colors
-            QSet<QChar> activeColorSet;
-            for (auto it = activeColors.constBegin(); it != activeColors.constEnd(); ++it) {
-                if (it.value()) {
-                    activeColorSet.insert(it.key().toUpper()); // Use uppercase for uniformity
+                // Create a set of active colors
+                QSet<QChar> activeColorSet;
+                for (auto it = activeColors.constBegin(); it != activeColors.constEnd(); ++it) {
+                    if (it.value()) {
+                        activeColorSet.insert(it.key().toUpper()); // Use uppercase for uniformity
+                    }
                 }
-            }
 
-            // Create a set of colors from the color identity string
-            QSet<QChar> colorIdentitySet;
-            for (const QChar &color : colorIdentity) {
-                colorIdentitySet.insert(color.toUpper()); // Ensure case uniformity
-            }
+                // Create a set of colors from the color identity string
+                QSet<QChar> colorIdentitySet;
+                for (const QChar &color : colorIdentity) {
+                    colorIdentitySet.insert(color.toUpper()); // Ensure case uniformity
+                }
 
-            // Compare the sets: the sets must match exactly
-            if (activeColorSet != colorIdentitySet) {
-                matchesFilter = false;
-            }
-        } else {
-            // Includes mode: colorIdentity must contain all active colors
-            for (auto it = activeColors.constBegin(); it != activeColors.constEnd(); ++it) {
-                if (it.value() && !colorIdentity.contains(it.key())) {
+                // Compare the sets: the sets must match exactly
+                if (activeColorSet != colorIdentitySet) {
                     matchesFilter = false;
-                    break;
                 }
+                break;
             }
+            case Includes:
+                // Includes mode: colorIdentity must contain all active colors
+                for (auto it = activeColors.constBegin(); it != activeColors.constEnd(); ++it) {
+                    if (it.value() && !colorIdentity.contains(it.key())) {
+                        matchesFilter = false;
+                        break;
+                    }
+                }
+                break;
+            case Excludes:
+                // Excludes mode: colorIdentity must contain none of the active colors
+                for (auto it = activeColors.constBegin(); it != activeColors.constEnd(); ++it) {
+                    if (it.value() && colorIdentity.contains(it.key())) {
+                        matchesFilter = false;
+                        break;
+                    }
+                }
+                break;
         }
 
         widget->filteredByColor = !matchesFilter;

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_filter_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_filter_widget.h
@@ -21,23 +21,34 @@ class DeckPreviewColorIdentityFilterWidget : public QWidget
     Q_OBJECT
 
 public:
+    /**
+     * How the active colors are matched against a deck's color identity.
+     */
+    enum FilterMode
+    {
+        ExactMatch, ///< The color identity consists of exactly the active colors.
+        Includes,   ///< The color identity contains all of the active colors.
+        Excludes    ///< The color identity contains none of the active colors.
+    };
+    Q_ENUM(FilterMode)
+
     explicit DeckPreviewColorIdentityFilterWidget(VisualDeckStorageWidget *parent);
     void retranslateUi();
     void filterWidgets(QList<DeckPreviewWidget *> widgets);
 
 signals:
-    void filterModeChanged(bool exactMatchMode);
+    void filterModeChanged(FilterMode mode);
     void activeColorsChanged();
 
 private slots:
     void handleColorToggled(QChar color, bool active);
-    void updateFilterMode(bool checked);
+    void updateFilterMode();
 
 private:
     QHBoxLayout *layout;
     QPushButton *toggleButton;
     QMap<QChar, bool> activeColors;
-    bool exactMatchMode = false; // Default to "includes" mode
+    FilterMode filterMode = Includes; // Default to "includes" mode
 };
 
 #endif // DECK_PREVIEW_COLOR_IDENTITY_FILTER_WIDGET_H


### PR DESCRIPTION
## Related Ticket(s)
N/A
## Short roundup of the initial problem
Visual Deck Storage does not include an "Exclude" option for deck colors and what-not.

## What will change with this Pull Request?
- VDS now includes an "Exclude" mode cycle option. It will exclude anything that matches the color combinations (no color combination selected will exclude colorless decks.)

## Screenshots
<img width="2451" height="1220" alt="image" src="https://github.com/user-attachments/assets/1d9d49d1-85f5-419a-856a-134677dbcfd1" />

