### PR TITLE
[Cards] Artist attribution

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -160,6 +160,7 @@ set(cockatrice_SOURCES
     src/interface/widgets/cards/additional_info/color_identity_widget.cpp
     src/interface/widgets/cards/additional_info/mana_cost_widget.cpp
     src/interface/widgets/cards/additional_info/mana_symbol_widget.cpp
+    src/interface/widgets/cards/art_crop_attribution.cpp
     src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
     src/interface/widgets/cards/card_group_display_widgets/flat_card_group_display_widget.cpp
     src/interface/widgets/cards/card_group_display_widgets/overlapped_card_group_display_widget.cpp

--- a/cockatrice/src/interface/widgets/cards/art_crop_attribution.cpp
+++ b/cockatrice/src/interface/widgets/cards/art_crop_attribution.cpp
@@ -1,0 +1,61 @@
+#include "art_crop_attribution.h"
+
+#include <QFontMetrics>
+#include <QObject>
+#include <QPainter>
+#include <libcockatrice/card/printing/exact_card.h>
+
+QString buildArtAttribution(const ExactCard &card)
+{
+    const QString artist = card.getPrinting().getArtist();
+    if (artist.isEmpty()) {
+        return QString();
+    }
+    return QObject::tr("Art: %1").arg(artist);
+}
+
+QRectF paintArtAttribution(QPainter &painter,
+                           const QRectF &rect,
+                           const QString &attribution,
+                           Qt::Alignment anchor,
+                           qreal scale)
+{
+    if (attribution.isEmpty()) {
+        return QRectF();
+    }
+
+    painter.save();
+
+    QFont font = painter.font();
+    font.setPointSizeF(qMax(6.0, font.pointSizeF() * scale));
+    painter.setFont(font);
+
+    const QFontMetrics fm(font);
+    const qreal maxTextWidth = rect.width() * 0.45;
+    const QString elided = fm.elidedText(attribution, Qt::ElideRight, qMax(qreal(80.0) * scale, maxTextWidth));
+
+    const qreal pad = 6.0 * scale;
+    QRectF captionRect(QPointF(0, 0), QSizeF(fm.horizontalAdvance(elided) + pad * 2.0, fm.height() + pad * 2.0));
+    const qreal margin = 4.0 * scale;
+    if (anchor.testFlag(Qt::AlignLeft)) {
+        captionRect.moveLeft(rect.left() + margin);
+    } else {
+        captionRect.moveRight(rect.right() - margin);
+    }
+    if (anchor.testFlag(Qt::AlignTop)) {
+        captionRect.moveTop(rect.top() + margin);
+    } else {
+        captionRect.moveBottom(rect.bottom() - margin);
+    }
+
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(QColor(0, 0, 0, 120));
+    painter.drawRoundedRect(captionRect, 4, 4);
+
+    painter.setPen(QColor(255, 255, 255, 220));
+    painter.drawText(captionRect, Qt::AlignCenter, elided);
+
+    painter.restore();
+
+    return captionRect;
+}

--- a/cockatrice/src/interface/widgets/cards/art_crop_attribution.h
+++ b/cockatrice/src/interface/widgets/cards/art_crop_attribution.h
@@ -1,0 +1,41 @@
+#ifndef COCKATRICE_ART_CROP_ATTRIBUTION_H
+#define COCKATRICE_ART_CROP_ATTRIBUTION_H
+
+#include <QStringView>
+
+class ExactCard;
+class QPainter;
+class QRectF;
+class QString;
+
+/**
+ * @brief Builds an attribution caption for a cropped card art display.
+ *
+ * When a card image's art region is shown cropped (an "art crop"), the artist
+ * should be credited in the same interface. Returns an empty string when the
+ * database has no artist data for the card.
+ *
+ * @param card The card whose art is being displayed.
+ * @return Caption such as "Art: John Avon", or empty.
+ */
+QString buildArtAttribution(const ExactCard &card);
+
+/**
+ * @brief Paints an attribution caption in a corner of a rect.
+ *
+ * Draws a subtle semi-transparent pill containing the caption, elided to fit.
+ *
+ * @param painter Painter to draw with.
+ * @param rect The area (e.g. the cropped art region) the caption belongs to.
+ * @param attribution Caption text (see buildArtAttribution()).
+ * @param anchor Corner of @p rect to pin the pill to (default bottom-right).
+ * @param scale Size multiplier for the pill (e.g. 0.8 for a smaller pill).
+ * @return The rect the pill was drawn in, or an empty rect if @p attribution is empty.
+ */
+QRectF paintArtAttribution(QPainter &painter,
+                           const QRectF &rect,
+                           const QString &attribution,
+                           Qt::Alignment anchor = Qt::AlignRight | Qt::AlignBottom,
+                           qreal scale = 1.0);
+
+#endif // COCKATRICE_ART_CROP_ATTRIBUTION_H

--- a/cockatrice/src/interface/widgets/general/home_widget.cpp
+++ b/cockatrice/src/interface/widgets/general/home_widget.cpp
@@ -356,12 +356,21 @@ void HomeWidget::paintEvent(QPaintEvent *event)
     }
 
     // Scryfall requires artist attribution wherever card art is shown cropped.
-    // Pin it to the bottom-right corner, using the same font as the card name pill.
+    // Pin it to the bottom-right corner, using the same font as the card name pill,
+    // and align its right edge with the card name pill's right edge.
+    constexpr int margin = 15;
+    constexpr qreal attributionMargin = 4.0;
+
     QFont attributionFont = painter.font();
     attributionFont.setPointSize(14);
     attributionFont.setBold(true);
     painter.setFont(attributionFont);
-    const QRectF attributionRect = paintArtAttribution(painter, rect(), attribution);
+
+    // paintArtAttribution insets the pill 4px from the given rect's right edge,
+    // so nudge the rect's right edge to land exactly on the pill's right edge.
+    QRectF attributionArea = rect();
+    attributionArea.setRight(width() - margin + attributionMargin);
+    const QRectF attributionRect = paintArtAttribution(painter, attributionArea, attribution);
 
     // Card name bubble above the attribution (when enabled).
     if (!cardName.isEmpty() && SettingsCache::instance().appearance().getHomeTabDisplayCardName()) {
@@ -372,7 +381,6 @@ void HomeWidget::paintEvent(QPaintEvent *event)
 
         QFontMetrics fm(font);
         constexpr int padding = 10;
-        constexpr int margin = 15;
 
         QRect textRect = fm.boundingRect(cardName);
 

--- a/cockatrice/src/interface/widgets/general/home_widget.cpp
+++ b/cockatrice/src/interface/widgets/general/home_widget.cpp
@@ -4,6 +4,7 @@
 #include "../../../interface/widgets/tabs/tab_supervisor.h"
 #include "../../theme_manager.h"
 #include "../../window_main.h"
+#include "../cards/art_crop_attribution.h"
 #include "background_sources.h"
 #include "home_styled_button.h"
 
@@ -341,8 +342,9 @@ void HomeWidget::paintEvent(QPaintEvent *event)
     QColor semiTransparentBlack(0, 0, 0, static_cast<int>(255 * 0.33));
     painter.fillPath(roundedRectPath, semiTransparentBlack);
 
-    // Card name overlay (bottom-right)
+    // Card name overlay (above the attribution, bottom-right)
     QString cardName;
+    QString attribution;
     ExactCard card = backgroundSourceCard->getCard();
     if (card) {
         cardName = card.getCardPtr()->getName();
@@ -350,8 +352,18 @@ void HomeWidget::paintEvent(QPaintEvent *event)
             cardName += " (" + card.getPrinting().getSet()->getCorrectedShortName() + ") " +
                         card.getPrinting().getProperty("num");
         }
+        attribution = buildArtAttribution(card);
     }
 
+    // Scryfall requires artist attribution wherever card art is shown cropped.
+    // Pin it to the bottom-right corner, using the same font as the card name pill.
+    QFont attributionFont = painter.font();
+    attributionFont.setPointSize(14);
+    attributionFont.setBold(true);
+    painter.setFont(attributionFont);
+    const QRectF attributionRect = paintArtAttribution(painter, rect(), attribution);
+
+    // Card name bubble above the attribution (when enabled).
     if (!cardName.isEmpty() && SettingsCache::instance().appearance().getHomeTabDisplayCardName()) {
         QFont font = painter.font();
         font.setPointSize(14);
@@ -364,19 +376,23 @@ void HomeWidget::paintEvent(QPaintEvent *event)
 
         QRect textRect = fm.boundingRect(cardName);
 
-        QRect bgRect(width() - textRect.width() - padding * 2 - margin,
-                     height() - textRect.height() - padding * 2 - margin, textRect.width() + padding * 2,
-                     textRect.height() + padding * 2);
+        int bubbleBottom = height() - margin;
+        if (!attributionRect.isEmpty()) {
+            bubbleBottom = attributionRect.top() - 6;
+        }
+        const QRect nameBubbleRect(width() - textRect.width() - padding * 2 - margin,
+                                   bubbleBottom - textRect.height() - padding * 2, textRect.width() + padding * 2,
+                                   textRect.height() + padding * 2);
 
         // Background bubble
         painter.setPen(Qt::NoPen);
         painter.setBrush(QColor(0, 0, 0, 160));
-        painter.drawRoundedRect(bgRect, 8, 8);
+        painter.drawRoundedRect(nameBubbleRect, 8, 8);
 
         // Text
         painter.setPen(Qt::white);
-        painter.drawText(bgRect.adjusted(padding, padding, -padding, -padding), Qt::AlignRight | Qt::AlignVCenter,
-                         cardName);
+        painter.drawText(nameBubbleRect.adjusted(padding, padding, -padding, -padding),
+                         Qt::AlignRight | Qt::AlignVCenter, cardName);
     }
 
     QWidget::paintEvent(event);

--- a/cockatrice/src/interface/widgets/server/user/user_card_settings_dialog.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_card_settings_dialog.cpp
@@ -2,6 +2,8 @@
 
 #include "../../../card_picture_loader/card_picture_loader.h"
 #include "../../utility/completer_utils.h"
+#include "../../cards/art_crop_attribution.h"
+#include "card/card_search_model.h"
 #include "card_database_display_model.h"
 #include "card_database_model.h"
 #include "user_card_art_provider.h"
@@ -18,6 +20,7 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QPushButton>
+#include <QRegularExpression>
 #include <QVBoxLayout>
 #include <libcockatrice/card/database/card_database_manager.h>
 
@@ -36,6 +39,12 @@ void CardArtPreviewWidget::setPixmap(const QPixmap &pixmap)
 void CardArtPreviewWidget::setParams(const CardArtParams &p)
 {
     params = p;
+    update();
+}
+
+void CardArtPreviewWidget::setAttribution(const QString &attribution)
+{
+    attributionText = attribution;
     update();
 }
 
@@ -88,6 +97,8 @@ void CardArtPreviewWidget::paintEvent(QPaintEvent *)
     painter.setPen(QPen(QColor(70, 80, 95), 2));
     painter.setBrush(Qt::NoBrush);
     painter.drawEllipse(avatarRect.adjusted(-1, -1, 1, 1));
+
+    paintArtAttribution(painter, cardRect, attributionText);
 }
 
 UserCardArtSettingsDialog::UserCardArtSettingsDialog(const CardArtParams &initial, QWidget *parent)
@@ -310,6 +321,11 @@ void UserCardArtSettingsDialog::reloadPreview()
     currentPixmap = UserCardArtProvider::cropCardArt(fullRes);
     preview->setPixmap(currentPixmap);
     preview->setParams(currentParams);
+
+    // Only attribute the art once the new pixmap is actually displayed, so a
+    // cache miss (which keeps the previous pixmap on screen) doesn't pair the
+    // new card's attribution with the old card's art.
+    preview->setAttribution(buildArtAttribution(card));
 }
 
 void UserCardArtSettingsDialog::onParamChanged()

--- a/cockatrice/src/interface/widgets/server/user/user_card_settings_dialog.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_card_settings_dialog.cpp
@@ -1,8 +1,8 @@
 #include "user_card_settings_dialog.h"
 
 #include "../../../card_picture_loader/card_picture_loader.h"
-#include "../../utility/completer_utils.h"
 #include "../../cards/art_crop_attribution.h"
+#include "../../utility/completer_utils.h"
 #include "card/card_search_model.h"
 #include "card_database_display_model.h"
 #include "card_database_model.h"

--- a/cockatrice/src/interface/widgets/server/user/user_card_settings_dialog.h
+++ b/cockatrice/src/interface/widgets/server/user/user_card_settings_dialog.h
@@ -24,6 +24,7 @@ public:
 
     void setPixmap(const QPixmap &pixmap);
     void setParams(const CardArtParams &params);
+    void setAttribution(const QString &attribution);
 
 protected:
     void paintEvent(QPaintEvent *event) override;
@@ -31,6 +32,7 @@ protected:
 private:
     QPixmap sourcePixmap;
     CardArtParams params;
+    QString attributionText;
 };
 
 class UserCardArtSettingsDialog : public QDialog

--- a/cockatrice/src/interface/widgets/server/user/user_info_popup.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_info_popup.cpp
@@ -322,10 +322,10 @@ void UserInfoHeaderWidget::paintEvent(QPaintEvent *)
     p.setFont(font());
 
     // Only show the attribution when there is actually art on screen: on a
-    // cache miss m_cardArt is null and the pill would float over the plain
+    // cache miss cardArt is null and the pill would float over the plain
     // header with no art behind it.
-    if (!m_cardArt.isNull()) {
-        paintArtAttribution(p, rect, m_attribution, Qt::AlignRight | Qt::AlignBottom, 0.8);
+    if (!cardArt.isNull()) {
+        paintArtAttribution(p, rect, attribution, Qt::AlignRight | Qt::AlignBottom, 0.8);
     }
 }
 

--- a/cockatrice/src/interface/widgets/server/user/user_info_popup.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_info_popup.cpp
@@ -156,9 +156,9 @@ void UserInfoHeaderWidget::setUserData(const ServerInfo_User &_user,
 
     attribution.clear();
     if (user.has_card_art_params()) {
-        const ExactCard card = CardDatabaseManager::query()->getCard(
-            {QString::fromStdString(user.card_art_params().card_name()),
-             QString::fromStdString(user.card_art_params().card_provider_id())});
+        const ExactCard card =
+            CardDatabaseManager::query()->getCard({QString::fromStdString(user.card_art_params().card_name()),
+                                                   QString::fromStdString(user.card_art_params().card_provider_id())});
         if (card) {
             attribution = buildArtAttribution(card);
         }

--- a/cockatrice/src/interface/widgets/server/user/user_info_popup.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_info_popup.cpp
@@ -1,5 +1,6 @@
 #include "user_info_popup.h"
 
+#include "../../cards/art_crop_attribution.h"
 #include "../../interface/pixel_map_generator.h"
 #include "../../interface/theme_manager.h"
 #include "../../interface/widgets/tabs/tab_supervisor.h"
@@ -18,6 +19,7 @@
 #include <QStandardItem>
 #include <QStyledItemDelegate>
 #include <QVBoxLayout>
+#include <libcockatrice/card/database/card_database_manager.h>
 #include <libcockatrice/network/client/abstract/abstract_client.h>
 #include <libcockatrice/protocol/pb/commands.pb.h>
 #include <libcockatrice/protocol/pb/response_get_games_of_user.pb.h>
@@ -151,6 +153,16 @@ void UserInfoHeaderWidget::setUserData(const ServerInfo_User &_user,
     avatar = _avatar;
     cardArt = _cardArt;
     params = _params;
+
+    attribution.clear();
+    if (user.has_card_art_params()) {
+        const ExactCard card = CardDatabaseManager::query()->getCard(
+            {QString::fromStdString(user.card_art_params().card_name()),
+             QString::fromStdString(user.card_art_params().card_provider_id())});
+        if (card) {
+            attribution = buildArtAttribution(card);
+        }
+    }
     update();
 }
 
@@ -303,6 +315,17 @@ void UserInfoHeaderWidget::paintEvent(QPaintEvent *)
         p.setPen(dark ? UserListPainter::blend(badge.color, Qt::white, 0.5)
                       : UserListPainter::blend(badge.color, Qt::black, 0.35));
         p.drawText(br, Qt::AlignCenter, badge.text);
+    }
+
+    // The painter font at this point depends on whether a badge was drawn
+    // (badge font vs username font), so pin an explicit font for the pill.
+    p.setFont(font());
+
+    // Only show the attribution when there is actually art on screen: on a
+    // cache miss m_cardArt is null and the pill would float over the plain
+    // header with no art behind it.
+    if (!m_cardArt.isNull()) {
+        paintArtAttribution(p, rect, m_attribution, Qt::AlignRight | Qt::AlignBottom, 0.8);
     }
 }
 

--- a/cockatrice/src/interface/widgets/server/user/user_info_popup.h
+++ b/cockatrice/src/interface/widgets/server/user/user_info_popup.h
@@ -95,6 +95,7 @@ private:
     QPixmap avatar;
     QPixmap cardArt;
     CardArtParams params;
+    QString attribution;
 };
 
 // ── Main popup ────────────────────────────────────────────────────────────────

--- a/cockatrice/src/interface/widgets/server/user/user_list_widget.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_list_widget.cpp
@@ -2,6 +2,7 @@
 
 #include "../../../../client/settings/cache_settings.h"
 #include "../../../card_picture_loader/card_picture_loader.h"
+#include "../../cards/art_crop_attribution.h"
 #include "../../interface/pixel_map_generator.h"
 #include "../../interface/theme_manager.h"
 #include "../../interface/widgets/tabs/tab_account.h"

--- a/libcockatrice_card/libcockatrice/card/printing/printing_info.h
+++ b/libcockatrice_card/libcockatrice/card/printing/printing_info.h
@@ -130,6 +130,18 @@ public:
      * @return The flavorName, or empty if it isn't present.
      */
     [[nodiscard]] QString getFlavorName() const;
+
+    /**
+     * @brief Returns the artist name credited for this printing's artwork.
+     *
+     * Requires a card database generated with artist data.
+     *
+     * @return The artist name, or empty if it isn't present.
+     */
+    [[nodiscard]] QString getArtist() const
+    {
+        return getProperty("artist");
+    }
 };
 
 #endif // COCKATRICE_PRINTING_INFO_H

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -237,8 +237,11 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QList
     };
 
     // mtgjson name => xml name
-    static const QMap<QString, QString> setInfoProperties{
-        {"number", "num"}, {"rarity", "rarity"}, {"isOnlineOnly", "isOnlineOnly"}, {"isRebalanced", "isRebalanced"}};
+    static const QMap<QString, QString> setInfoProperties{{"number", "num"},
+                                                          {"rarity", "rarity"},
+                                                          {"isOnlineOnly", "isOnlineOnly"},
+                                                          {"isRebalanced", "isRebalanced"},
+                                                          {"artist", "artist"}};
 
     // mtgjson name => xml name
     static const QMap<QString, QString> identifierProperties{{"multiverseId", "muid"}, {"scryfallId", "uuid"}};


### PR DESCRIPTION
## Short roundup of the initial problem
Scryfall asks that the artist attribution is visible or visible in the same interface whenever a card art crop is used.

## What will change with this Pull Request?
- Parse artist from MTGJson
- Draw artist in a little pill wherever art crops are used

Copyright attribution deferred until MTGJson provides a value for it.

## Screenshots
<img width="1258" height="1329" alt="image" src="https://github.com/user-attachments/assets/fa7b42df-0eeb-4670-9c33-1c45704f537d" />
<img width="595" height="245" alt="image" src="https://github.com/user-attachments/assets/99c20ba6-d504-40fa-bda0-bdc342fd0622" />

