### PR TITLE
Parent MoveMenu to CardMenu to fix memory leak on menu rebuild

### DIFF
--- a/cockatrice/src/game_graphics/player/menu/card_menu.cpp
+++ b/cockatrice/src/game_graphics/player/menu/card_menu.cpp
@@ -203,7 +203,7 @@ void CardMenu::createTableMenu(bool canModifyCard)
     }
     addSeparator();
     addAction(aClone);
-    addMenu(new MoveMenu(player));
+    addMenu(new MoveMenu(player, this));
     addSeparator();
     addAction(aAttach);
     if (card->getAttachedTo()) {
@@ -253,7 +253,7 @@ void CardMenu::createStackMenu(bool canModifyCard)
     addAction(aPlayFacedown);
     addSeparator();
     addAction(aClone);
-    addMenu(new MoveMenu(player));
+    addMenu(new MoveMenu(player, this));
     addSeparator();
     addAction(aAttach);
     addAction(aDrawArrow);
@@ -282,7 +282,7 @@ void CardMenu::createGraveyardOrExileMenu(bool canModifyCard)
     addAction(aPlayFacedown);
     addSeparator();
     addAction(aClone);
-    addMenu(new MoveMenu(player));
+    addMenu(new MoveMenu(player, this));
     addSeparator();
     addAction(aAttach);
     addAction(aDrawArrow);
@@ -320,7 +320,7 @@ void CardMenu::createHandOrCustomZoneMenu(bool canModifyCard)
 
     addSeparator();
     addAction(aClone);
-    addMenu(new MoveMenu(player));
+    addMenu(new MoveMenu(player, this));
 
     // actions that are really wonky when done from deck or sideboard
     if (card->getZone()->getName() == ZoneNames::HAND) {
@@ -344,7 +344,7 @@ void CardMenu::createHandOrCustomZoneMenu(bool canModifyCard)
 void CardMenu::createZonelessMenu(bool canModifyCard)
 {
     if (canModifyCard) {
-        addMenu(new MoveMenu(player));
+        addMenu(new MoveMenu(player, this));
     }
 }
 

--- a/cockatrice/src/game_graphics/player/menu/move_menu.cpp
+++ b/cockatrice/src/game_graphics/player/menu/move_menu.cpp
@@ -6,7 +6,7 @@
 #include "../card_menu_action_type.h"
 #include "../player_graphics_item.h"
 
-MoveMenu::MoveMenu(PlayerGraphicsItem *player) : QMenu(tr("Move to"))
+MoveMenu::MoveMenu(PlayerGraphicsItem *player, QWidget *parent) : QMenu(tr("Move to"), parent)
 {
     aMoveToTopLibrary = new QAction(this);
     aMoveToTopLibrary->setData(cmMoveToTopLibrary);

--- a/cockatrice/src/game_graphics/player/menu/move_menu.h
+++ b/cockatrice/src/game_graphics/player/menu/move_menu.h
@@ -14,7 +14,7 @@ class MoveMenu : public QMenu
     Q_OBJECT
 
 public:
-    explicit MoveMenu(PlayerGraphicsItem *player);
+    explicit MoveMenu(PlayerGraphicsItem *player, QWidget *parent);
     void setShortcutsActive();
     void retranslateUi();
 

--- a/cockatrice/src/game_graphics/player/menu/player_menu.cpp
+++ b/cockatrice/src/game_graphics/player/menu/player_menu.cpp
@@ -74,6 +74,11 @@ void PlayerMenu::setMenusForGraphicItems()
 
 QMenu *PlayerMenu::updateCardMenu(const CardItem *card)
 {
+    if (cardMenu) {
+        cardMenu->deleteLater();
+        cardMenu = nullptr;
+    }
+
     if (!card) {
         emit cardMenuUpdated(nullptr);
         return nullptr;
@@ -87,11 +92,11 @@ QMenu *PlayerMenu::updateCardMenu(const CardItem *card)
         return nullptr;
     }
 
-    CardMenu *menu = new CardMenu(player, card, shortcutsActive);
-    connect(menu, &CardMenu::cardInfoRequested, this, &PlayerMenu::cardInfoRequested);
-    emit cardMenuUpdated(menu);
+    cardMenu = new CardMenu(player, card, shortcutsActive);
+    connect(cardMenu, &CardMenu::cardInfoRequested, this, &PlayerMenu::cardInfoRequested);
+    emit cardMenuUpdated(cardMenu);
 
-    return menu;
+    return cardMenu;
 }
 
 void PlayerMenu::retranslateUi()

--- a/cockatrice/src/game_graphics/player/menu/player_menu.h
+++ b/cockatrice/src/game_graphics/player/menu/player_menu.h
@@ -97,6 +97,7 @@ private:
      * player->getCounters().
      */
     QList<AbstractPlayerComponent *> managedComponents;
+    CardMenu *cardMenu = nullptr;
     bool shortcutsActive = false;
 
     /** @brief Creates component, adds it as a submenu of playerMenu, and registers in managedComponents. */

--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -1026,8 +1026,8 @@ void TabGame::setCardMenu(CardMenu *menu)
 
     if (menu) {
         aCardMenu->setMenu(menu);
-    } else {
-        aCardMenu->setMenu(new QMenu);
+    } else if (aCardMenu->menu()) {
+        aCardMenu->menu()->clear();
     }
 }
 


### PR DESCRIPTION
## Short roundup of the initial problem
Found this leak while improving my command zone code, though it shouldn't be bundled in the same PR.
MoveMenu is created without a Qt parent, but QMenu::addMenu(QMenu*) does not take ownership. Since CardMenu is rebuilt on every right-click, each rebuild leaks one MoveMenu instance.

## What will change with this Pull Request?
- adds a parent parameter to MoveMenu and passes this (the CardMenu) at all call sites. Qt's parent-child mechanism now deletes MoveMenu when CardMenu is destroyed.
