### PR TITLE
[Game] Life Animation

### DIFF
--- a/cockatrice/src/game_graphics/board/abstract_counter.cpp
+++ b/cockatrice/src/game_graphics/board/abstract_counter.cpp
@@ -29,8 +29,9 @@ AbstractCounter::AbstractCounter(CounterState *state,
 {
     setAcceptHoverEvents(true);
 
-    connect(state, &CounterState::valueChanged, this, [this](int, int newValue) {
+    connect(state, &CounterState::valueChanged, this, [this](int oldValue, int newValue) {
         value = newValue;
+        onValueChanged(oldValue, newValue);
         update();
     });
 
@@ -227,4 +228,10 @@ void AbstractCounterDialog::changeValue(int diff)
     }
     curValue += diff;
     setTextValue(QString::number(curValue));
+}
+
+void AbstractCounter::onValueChanged(int /*oldValue*/, int /*newValue*/)
+{
+    // Default: no feedback. Subclasses such as PlayerCounter override this to
+    // flash the counter on meaningful changes (life gain/loss).
 }

--- a/cockatrice/src/game_graphics/board/abstract_counter.h
+++ b/cockatrice/src/game_graphics/board/abstract_counter.h
@@ -35,6 +35,9 @@ protected:
     bool hovered = false;
     bool useNameForShortcut;
 
+    // Hook for subclasses that need per-value-change feedback (e.g. life-total flash).
+    virtual void onValueChanged(int oldValue, int newValue);
+
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
     void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
     void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;

--- a/cockatrice/src/game_graphics/player/player_graphics_item.cpp
+++ b/cockatrice/src/game_graphics/player/player_graphics_item.cpp
@@ -188,6 +188,12 @@ void PlayerGraphicsItem::onCounterAdded(CounterState *state)
     AbstractCounter *widget;
     if (state->getName() == "life") {
         widget = playerTarget->addCounter(state);
+        // design-game: taking damage shimmers the player's table zone crimson.
+        connect(state, &CounterState::valueChanged, this, [this](int oldValue, int newValue) {
+            if (newValue < oldValue) {
+                tableZoneGraphicsItem->triggerDamageShimmer();
+            }
+        });
     } else {
         widget = new GeneralCounter(state, player, true, this);
     }

--- a/cockatrice/src/game_graphics/player/player_target.cpp
+++ b/cockatrice/src/game_graphics/player/player_target.cpp
@@ -1,11 +1,15 @@
 #include "player_target.h"
 
+#include "../../client/settings/cache_settings.h"
 #include "../../game/player/player_logic.h"
 #include "../../interface/pixel_map_generator.h"
+#include "../../interface/theme_manager.h"
 
+#include <QApplication>
 #include <QDebug>
 #include <QPainter>
 #include <QPixmapCache>
+#include <QTimer>
 #include <QtMath>
 #include <libcockatrice/protocol/pb/serverinfo_user.pb.h>
 
@@ -21,8 +25,10 @@ QRectF PlayerCounter::boundingRect() const
 
 void PlayerCounter::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
 {
-    const int radius = 8;
-    const qreal border = 1;
+    // design-game: life totals live in a fully-rounded translucent HUD pill
+    // with an accent (Mana Green) border and mono numerals.
+    const int radius = 15;
+    const qreal border = 1.5;
     QPainterPath path(QPointF(50 - border / 2, border / 2));
     path.lineTo(radius, border / 2);
     path.arcTo(border / 2, border / 2, 2 * radius, 2 * radius, 90, 90);
@@ -30,21 +36,64 @@ void PlayerCounter::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*
     path.lineTo(50 - border / 2, 30 - border / 2);
     path.closeSubpath();
 
-    QPen pen(QColor(100, 100, 100));
-    pen.setWidth(border);
+    QPen pen(qApp->palette().highlight().color());
+    pen.setWidthF(border);
     painter->setPen(pen);
-    painter->setBrush(hovered ? QColor(50, 50, 50, 160) : QColor(0, 0, 0, 160));
+    painter->setBrush(hovered ? QColor(18, 24, 38, 200) : QColor(11, 14, 20, 184));
 
     painter->drawPath(path);
 
     QRectF translatedRect = path.controlPointRect();
     QSize translatedSize = translatedRect.size().toSize();
-    QFont font("Serif");
+    QFont font = themeManager->monoFont();
     font.setWeight(QFont::Bold);
     font.setPixelSize(qMax(qRound(translatedSize.height() / 1.3), 9));
     painter->setFont(font);
     painter->setPen(Qt::white);
     painter->drawText(translatedRect, Qt::AlignCenter, QString::number(value));
+
+    // Life-change flash: emerald on gain, red on loss, decaying over a few ticks.
+    if (flashAlpha > 0) {
+        painter->save();
+        QColor flashColor = flashDelta > 0 ? QColor(52, 224, 122) : QColor(239, 68, 68);
+        flashColor.setAlphaF(0.45 * flashAlpha);
+        painter->setPen(Qt::NoPen);
+        painter->setBrush(flashColor);
+        painter->setOpacity(0.85);
+        painter->drawPath(path);
+        painter->restore();
+    }
+}
+
+void PlayerCounter::onValueChanged(int oldValue, int newValue)
+{
+    flashDelta = newValue - oldValue;
+    if (flashDelta == 0) {
+        return;
+    }
+
+    if (!SettingsCache::instance().userInterface().getAnimationsEnabled() ||
+        !SettingsCache::instance().userInterface().getLifeCounterAnimationsEnabled()) {
+        flashAlpha = 0.0;
+        return;
+    }
+
+    flashAlpha = 1.0;
+    if (flashTimer == nullptr) {
+        flashTimer = new QTimer(this);
+        connect(flashTimer, &QTimer::timeout, this, &PlayerCounter::flashTick);
+    }
+    flashTimer->start(50);
+}
+
+void PlayerCounter::flashTick()
+{
+    flashAlpha -= 0.12;
+    if (flashAlpha <= 0.0) {
+        flashAlpha = 0.0;
+        flashTimer->stop();
+    }
+    update();
 }
 
 PlayerTarget::PlayerTarget(PlayerLogic *_owner, QGraphicsItem *parentItem)

--- a/cockatrice/src/game_graphics/player/player_target.h
+++ b/cockatrice/src/game_graphics/player/player_target.h
@@ -14,10 +14,22 @@
 #include <QPixmap>
 
 class PlayerLogic;
+class QTimer;
 
 class PlayerCounter : public AbstractCounter
 {
     Q_OBJECT
+protected:
+    void onValueChanged(int oldValue, int newValue) override;
+
+private:
+    QTimer *flashTimer = nullptr;
+    qreal flashAlpha = 0.0;
+    int flashDelta = 0;
+
+private slots:
+    void flashTick();
+
 public:
     PlayerCounter(CounterState *state, PlayerLogic *player, QGraphicsItem *parent);
     QRectF boundingRect() const override;

--- a/cockatrice/src/game_graphics/zones/table_zone.cpp
+++ b/cockatrice/src/game_graphics/zones/table_zone.cpp
@@ -12,6 +12,7 @@
 
 #include <QGraphicsScene>
 #include <QPainter>
+#include <QTimer>
 #include <libcockatrice/card/card_info.h>
 #include <libcockatrice/protocol/pb/command_move_card.pb.h>
 #include <libcockatrice/protocol/pb/command_set_card_attr.pb.h>
@@ -47,6 +48,31 @@ void TableZone::updateBg()
     update();
 }
 
+void TableZone::triggerDamageShimmer()
+{
+    // design-game: damage pulses the affected zone with a brief crimson
+    // shimmer so a hit reads as an event, not a dialog.
+    if (!SettingsCache::instance().userInterface().getAnimationsEnabled() ||
+        !SettingsCache::instance().userInterface().getBattlefieldFlashEnabled()) {
+        damageShimmerAlpha = 0.0;
+        return;
+    }
+
+    damageShimmerAlpha = 1.0;
+    if (damageShimmerTimer == nullptr) {
+        damageShimmerTimer = new QTimer(this);
+        connect(damageShimmerTimer, &QTimer::timeout, this, [this] {
+            damageShimmerAlpha -= 0.12;
+            if (damageShimmerAlpha <= 0.0) {
+                damageShimmerAlpha = 0.0;
+                damageShimmerTimer->stop();
+            }
+            update();
+        });
+    }
+    damageShimmerTimer->start(50);
+}
+
 QRectF TableZone::boundingRect() const
 {
     return QRectF(0, 0, width, height);
@@ -75,6 +101,13 @@ void TableZone::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*opti
         // inactive player gets a darker table zone with a semi transparent black mask
         // this means if the user provides a custom background it will fade
         painter->fillRect(boundingRect(), FADE_MASK);
+    }
+
+    // Decaying crimson wash from taking damage.
+    if (damageShimmerAlpha > 0.0) {
+        QColor shimmerColor(239, 68, 68);
+        shimmerColor.setAlphaF(0.22 * damageShimmerAlpha);
+        painter->fillRect(boundingRect(), shimmerColor);
     }
 
     paintLandDivider(painter);

--- a/cockatrice/src/game_graphics/zones/table_zone.h
+++ b/cockatrice/src/game_graphics/zones/table_zone.h
@@ -11,6 +11,8 @@
 #include "../board/abstract_card_item.h"
 #include "select_zone.h"
 
+class QTimer;
+
 /**
  * @brief TableZone is the grid based rect where CardItems may be placed.
  *
@@ -184,9 +186,20 @@ public:
         update();
     }
 
+    /**
+       Flashes the table surface after a player loses life.
+
+       Wired up through AbstractCounter so the life total on the battlefield
+       glows when it changes.
+     */
+    void triggerDamageShimmer();
+
 private:
     void paintZoneOutline(QPainter *painter);
     void paintLandDivider(QPainter *painter);
+
+    QTimer *damageShimmerTimer = nullptr;
+    qreal damageShimmerAlpha = 0.0;
 
     /*
     Calculates card stack widths so mapping functions work properly

--- a/cockatrice/src/interface/theme_config.cpp
+++ b/cockatrice/src/interface/theme_config.cpp
@@ -7,7 +7,8 @@
 
 bool ThemeConfig::isEmpty() const
 {
-    return colorScheme.isEmpty() && styleName.isEmpty();
+    return colorScheme.isEmpty() && styleName.isEmpty() && displayFont.isEmpty() && bodyFont.isEmpty() &&
+           cardTitleFont.isEmpty() && monoFont.isEmpty();
 }
 
 QString ThemeConfig::toIni() const
@@ -17,6 +18,21 @@ QString ThemeConfig::toIni() const
     out += QString("ColorScheme = %1\n").arg(colorScheme.isEmpty() ? "System" : colorScheme);
     out += "\n[Style]\n";
     out += QString("Name = %1\n").arg(styleName.isEmpty() ? "Default" : styleName);
+    if (!displayFont.isEmpty() || !bodyFont.isEmpty() || !cardTitleFont.isEmpty() || !monoFont.isEmpty()) {
+        out += "\n[Typography]\n";
+        if (!displayFont.isEmpty()) {
+            out += QString("DisplayFont = %1\n").arg(displayFont);
+        }
+        if (!bodyFont.isEmpty()) {
+            out += QString("BodyFont = %1\n").arg(bodyFont);
+        }
+        if (!cardTitleFont.isEmpty()) {
+            out += QString("CardTitleFont = %1\n").arg(cardTitleFont);
+        }
+        if (!monoFont.isEmpty()) {
+            out += QString("MonoFont = %1\n").arg(monoFont);
+        }
+    }
     return out;
 }
 
@@ -64,6 +80,16 @@ ThemeConfig ThemeConfig::fromThemeDir(const QString &themeDirPath)
         } else if (currentSection.compare("Style", Qt::CaseInsensitive) == 0) {
             if (key.compare("Name", Qt::CaseInsensitive) == 0) {
                 cfg.styleName = value;
+            }
+        } else if (currentSection.compare("Typography", Qt::CaseInsensitive) == 0) {
+            if (key.compare("DisplayFont", Qt::CaseInsensitive) == 0) {
+                cfg.displayFont = value;
+            } else if (key.compare("BodyFont", Qt::CaseInsensitive) == 0) {
+                cfg.bodyFont = value;
+            } else if (key.compare("CardTitleFont", Qt::CaseInsensitive) == 0) {
+                cfg.cardTitleFont = value;
+            } else if (key.compare("MonoFont", Qt::CaseInsensitive) == 0) {
+                cfg.monoFont = value;
             }
         }
     }

--- a/cockatrice/src/interface/theme_config.h
+++ b/cockatrice/src/interface/theme_config.h
@@ -11,6 +11,13 @@ struct ThemeConfig
     QString colorScheme;
     QString styleName;
 
+    // Optional per-theme font families (see design-game.md). Empty = use the
+    // application default / the classic "Serif" hint for card titles.
+    QString displayFont;
+    QString bodyFont;
+    QString cardTitleFont;
+    QString monoFont;
+
     bool isEmpty() const;
     QString toIni() const;
 

--- a/cockatrice/src/interface/theme_manager.cpp
+++ b/cockatrice/src/interface/theme_manager.cpp
@@ -99,6 +99,8 @@ ThemeManager::ThemeManager(QObject *parent) : QObject(parent)
     }
     // Capture the untouched application palette before any theme is applied.
     defaultPalette = qApp->palette();
+    // Capture the untouched application font before any theme is applied.
+    defaultFont = qApp->font();
     ensureThemeDirectoryExists();
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
     connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this, [this] {
@@ -352,6 +354,16 @@ void ThemeManager::applyStyleAndPalette(const QString &themeName,
     // widget gets polished against the stale colours, requiring a second apply
     // to fully resolve. Setting palette first means setStyle's repolish cascade
     // already sees the correct colours.
+    // The body font is applied on the same pass, before the repolish, so
+    // widgets are polished with the theme's typeface.
+    currentThemeConfig = themeCfg;
+    if (!themeCfg.bodyFont.isEmpty()) {
+        QFont bodyFont(themeCfg.bodyFont);
+        bodyFont.setStyleHint(QFont::SansSerif);
+        qApp->setFont(bodyFont);
+    } else {
+        qApp->setFont(defaultFont);
+    }
     qApp->setPalette(base);
     qApp->setStyle(style);
 
@@ -474,4 +486,51 @@ QBrush ThemeManager::getExtraBgBrush(Role role, int zoneId)
     }
 
     return brushCache.value(zoneId);
+}
+
+QFont ThemeManager::cardTitleFont() const
+{
+    QFont font;
+    if (currentThemeConfig.cardTitleFont.isEmpty()) {
+        // Classic behaviour: the platform serif, echoing printed cardstock.
+        font.setFamily(QStringLiteral("Serif"));
+        font.setStyleHint(QFont::Serif);
+    } else {
+        font.setFamily(currentThemeConfig.cardTitleFont);
+    }
+    return font;
+}
+
+QFont ThemeManager::monoFont() const
+{
+    QFont font;
+    if (currentThemeConfig.monoFont.isEmpty()) {
+        // Classic behaviour: serif numerals on counters and the card back.
+        font.setFamily(QStringLiteral("Serif"));
+        font.setStyleHint(QFont::Serif);
+    } else {
+        font.setFamily(currentThemeConfig.monoFont);
+        font.setStyleHint(QFont::Monospace);
+    }
+    return font;
+}
+
+QFont ThemeManager::displayFont() const
+{
+    QFont font;
+    if (currentThemeConfig.displayFont.isEmpty()) {
+        font.setFamily(QStringLiteral("sans-serif"));
+        font.setStyleHint(QFont::SansSerif);
+    } else {
+        font.setFamily(currentThemeConfig.displayFont);
+    }
+    return font;
+}
+
+QString ThemeManager::monoFontFamily() const
+{
+    if (!currentThemeConfig.monoFont.isEmpty()) {
+        return currentThemeConfig.monoFont;
+    }
+    return QStringLiteral("monospace");
 }

--- a/cockatrice/src/interface/theme_manager.h
+++ b/cockatrice/src/interface/theme_manager.h
@@ -11,6 +11,7 @@
 
 #include <QBrush>
 #include <QDir>
+#include <QFont>
 #include <QLoggingCategory>
 #include <QMap>
 #include <QObject>
@@ -47,6 +48,12 @@ private:
     // palette is applied. Used as the base when a theme supplies no palette, so
     // switching away from a custom palette restores the original colours.
     QPalette defaultPalette;
+    // Pristine application font captured at startup, restored when the active
+    // theme declares no body font of its own.
+    QFont defaultFont;
+    // ThemeConfig of the currently applied theme, used to resolve per-theme
+    // typography tokens.
+    ThemeConfig currentThemeConfig;
     QString currentThemePath;
     std::array<QBrush, Role::MaxRole + 1> brushes;
     QStringMap availableThemes;
@@ -92,6 +99,14 @@ public:
 
     QBrush &getBgBrush(Role zone);
     QBrush getExtraBgBrush(Role zone, int zoneId = 0);
+
+    // Per-theme typography helpers (see design-game.md). Falls back to the
+    // classic app defaults when the active theme declares no fonts, so
+    // non-CockatriceNG themes keep their current look.
+    QFont cardTitleFont() const;
+    QFont monoFont() const;
+    QFont displayFont() const;
+    QString monoFontFamily() const;
 protected slots:
     void themeChangedSlot();
 signals:

--- a/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.cpp
+++ b/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.cpp
@@ -116,8 +116,37 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
     connect(&tapAnimationCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance().cardsDisplay(),
             &CardsDisplaySettings::setTapAnimation);
 
+    animationsEnabledCheckBox.setChecked(SettingsCache::instance().userInterface().getAnimationsEnabled());
+    connect(&animationsEnabledCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance().userInterface(),
+            &InterfaceSettings::setAnimationsEnabled);
+
+    lifeCounterAnimationsCheckBox.setChecked(
+        SettingsCache::instance().userInterface().getLifeCounterAnimationsEnabled());
+    connect(&lifeCounterAnimationsCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance().userInterface(),
+            &InterfaceSettings::setLifeCounterAnimationsEnabled);
+
+    battlefieldFlashCheckBox.setChecked(SettingsCache::instance().userInterface().getBattlefieldFlashEnabled());
+    connect(&battlefieldFlashCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance().userInterface(),
+            &InterfaceSettings::setBattlefieldFlashEnabled);
+
     auto *animationGrid = new QGridLayout;
-    animationGrid->addWidget(&tapAnimationCheckBox, 0, 0);
+    animationGrid->addWidget(&animationsEnabledCheckBox, 0, 0);
+    animationGrid->addWidget(&tapAnimationCheckBox, 1, 0);
+
+    // Subgroup for per-effect toggles, active only while the blanket "enable all" is on.
+    auto *animationDetailGrid = new QGridLayout;
+    animationDetailGrid->addWidget(&lifeCounterAnimationsCheckBox, 0, 0);
+    animationDetailGrid->addWidget(&battlefieldFlashCheckBox, 1, 0);
+    animationDetailGroupBox = new QGroupBox;
+    animationDetailGroupBox->setLayout(animationDetailGrid);
+    animationGrid->addWidget(animationDetailGroupBox, 2, 0);
+
+    const auto syncAnimationDetailEnabled = [this] {
+        animationDetailGroupBox->setEnabled(SettingsCache::instance().userInterface().getAnimationsEnabled());
+    };
+    syncAnimationDetailEnabled();
+    connect(&SettingsCache::instance().userInterface(), &InterfaceSettings::animationsEnabledChanged, this,
+            syncAnimationDetailEnabled);
 
     animationGroupBox = new QGroupBox;
     animationGroupBox->setLayout(animationGrid);
@@ -310,7 +339,11 @@ void UserInterfaceSettingsPage::retranslateUi()
     specNotificationsEnabledCheckBox.setText(tr("Notify in the taskbar for game events while you are spectating"));
     buddyConnectNotificationsEnabledCheckBox.setText(tr("Notify in the taskbar when users in your buddy list connect"));
     animationGroupBox->setTitle(tr("Animation settings"));
+    animationsEnabledCheckBox.setText(tr("Enable game &animations"));
     tapAnimationCheckBox.setText(tr("&Tap/untap animation"));
+    animationDetailGroupBox->setTitle(tr("Individual animations"));
+    lifeCounterAnimationsCheckBox.setText(tr("Life counter flash"));
+    battlefieldFlashCheckBox.setText(tr("Battlefield flash on damage"));
     deckEditorGroupBox->setTitle(tr("Deck editor/storage settings"));
     openDeckInNewTabCheckBox.setText(tr("Open deck in new tab by default"));
     visualDeckStorageInGameCheckBox.setText(tr("Use visual deck storage in game lobby"));

--- a/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.h
+++ b/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.h
@@ -35,6 +35,9 @@ private:
     QCheckBox useTearOffMenusCheckBox;
     QCheckBox keepGameChatFocusCheckBox;
     QCheckBox tapAnimationCheckBox;
+    QCheckBox animationsEnabledCheckBox;
+    QCheckBox lifeCounterAnimationsCheckBox;
+    QCheckBox battlefieldFlashCheckBox;
     QCheckBox openDeckInNewTabCheckBox;
     QLabel visualDeckStoragePromptForConversionLabel;
     QComboBox visualDeckStoragePromptForConversionSelector;
@@ -52,6 +55,7 @@ private:
     QGroupBox *generalGroupBox;
     QGroupBox *notificationsGroupBox;
     QGroupBox *animationGroupBox;
+    QGroupBox *animationDetailGroupBox;
     QGroupBox *deckEditorGroupBox;
     QGroupBox *replayGroupBox;
 

--- a/libcockatrice_interfaces/libcockatrice/interfaces/interface_interface_settings_provider.h
+++ b/libcockatrice_interfaces/libcockatrice/interfaces/interface_interface_settings_provider.h
@@ -39,6 +39,9 @@ public:
     [[nodiscard]] virtual bool getShowStatusBar() const = 0;
     [[nodiscard]] virtual bool getShowShortcuts() const = 0;
     [[nodiscard]] virtual bool getShowGameSelectorFilterToolbar() const = 0;
+    [[nodiscard]] virtual bool getAnimationsEnabled() const = 0;
+    [[nodiscard]] virtual bool getLifeCounterAnimationsEnabled() const = 0;
+    [[nodiscard]] virtual bool getBattlefieldFlashEnabled() const = 0;
 };
 
 #endif // COCKATRICE_INTERFACE_INTERFACE_SETTINGS_PROVIDER_H

--- a/libcockatrice_settings/libcockatrice/settings/interface_settings.cpp
+++ b/libcockatrice_settings/libcockatrice/settings/interface_settings.cpp
@@ -160,6 +160,21 @@ bool InterfaceSettings::getShowGameSelectorFilterToolbar() const
     return getValue("showGameSelectorFilterToolbar", QString(), QString(), true).toBool();
 }
 
+bool InterfaceSettings::getAnimationsEnabled() const
+{
+    return getValue("animationsEnabled", QString(), QString(), true).toBool();
+}
+
+bool InterfaceSettings::getLifeCounterAnimationsEnabled() const
+{
+    return getValue("lifeCounterAnimationsEnabled", QString(), QString(), true).toBool();
+}
+
+bool InterfaceSettings::getBattlefieldFlashEnabled() const
+{
+    return getValue("battlefieldFlashEnabled", QString(), QString(), true).toBool();
+}
+
 void InterfaceSettings::setUseTearOffMenus(bool _useTearOffMenus)
 {
     setValue(_useTearOffMenus, "useTearOffMenus");
@@ -325,4 +340,22 @@ void InterfaceSettings::setShowGameSelectorFilterToolbar(bool _showGameSelectorF
 {
     setValue(_showGameSelectorFilterToolbar, "showGameSelectorFilterToolbar");
     emit showGameSelectorFilterToolbarChanged(_showGameSelectorFilterToolbar);
+}
+
+void InterfaceSettings::setAnimationsEnabled(bool _animationsEnabled)
+{
+    setValue(_animationsEnabled, "animationsEnabled");
+    emit animationsEnabledChanged(_animationsEnabled);
+}
+
+void InterfaceSettings::setLifeCounterAnimationsEnabled(bool _lifeCounterAnimationsEnabled)
+{
+    setValue(_lifeCounterAnimationsEnabled, "lifeCounterAnimationsEnabled");
+    emit lifeCounterAnimationsEnabledChanged(_lifeCounterAnimationsEnabled);
+}
+
+void InterfaceSettings::setBattlefieldFlashEnabled(bool _battlefieldFlashEnabled)
+{
+    setValue(_battlefieldFlashEnabled, "battlefieldFlashEnabled");
+    emit battlefieldFlashEnabledChanged(_battlefieldFlashEnabled);
 }

--- a/libcockatrice_settings/libcockatrice/settings/interface_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/interface_settings.h
@@ -42,6 +42,9 @@ public:
     [[nodiscard]] bool getShowStatusBar() const override;
     [[nodiscard]] bool getShowShortcuts() const override;
     [[nodiscard]] bool getShowGameSelectorFilterToolbar() const override;
+    [[nodiscard]] bool getAnimationsEnabled() const override;
+    [[nodiscard]] bool getLifeCounterAnimationsEnabled() const override;
+    [[nodiscard]] bool getBattlefieldFlashEnabled() const override;
 
     void setUseTearOffMenus(bool _useTearOffMenus);
     void setCardViewInitialRowsMax(int _cardViewInitialRowsMax);
@@ -74,6 +77,9 @@ public:
     void setShowStatusBar(bool _showStatusBar);
     void setShowShortcuts(bool _showShortcuts);
     void setShowGameSelectorFilterToolbar(bool _showGameSelectorFilterToolbar);
+    void setAnimationsEnabled(bool _animationsEnabled);
+    void setLifeCounterAnimationsEnabled(bool _lifeCounterAnimationsEnabled);
+    void setBattlefieldFlashEnabled(bool _battlefieldFlashEnabled);
 
 signals:
     void useTearOffMenusChanged(bool state);
@@ -85,6 +91,9 @@ signals:
     void tallyTypeChanged(int type);
     void showStatusBarChanged(bool state);
     void showGameSelectorFilterToolbarChanged(bool state);
+    void animationsEnabledChanged(bool state);
+    void lifeCounterAnimationsEnabledChanged(bool state);
+    void battlefieldFlashEnabledChanged(bool state);
 
 public:
     explicit InterfaceSettings(const QString &settingPath, QObject *parent = nullptr);


### PR DESCRIPTION
## Short roundup of the initial problem
It's not super obvious when another player manipulates their life total.

## What will change with this Pull Request?
- Make the life counter flash when manipulated
- Optionally make the battlefield flash red when a player decreases their life counter

## Screenshots

https://github.com/user-attachments/assets/e9335ca1-a274-431f-875b-fadfee01edd6


