### PR TITLE
[Server/Client] Fix open_decklists not showing for already-loaded decks on join

### DIFF
--- a/cockatrice/src/game/game_event_handler.cpp
+++ b/cockatrice/src/game/game_event_handler.cpp
@@ -287,6 +287,9 @@ void GameEventHandler::eventGameStateChanged(const Event_GameStateChanged &event
                 if (!game->getGameMetaInfo()->proto().share_decklists_on_load()) {
                     continue;
                 }
+                if (!playerInfo.has_deck_list()) {
+                    continue;
+                }
 
                 opponentDecksToDisplay.append(
                     qMakePair(playerId, qMakePair(playerName, QString::fromStdString(playerInfo.deck_list()))));

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_player.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_player.cpp
@@ -1631,7 +1631,9 @@ void Server_AbstractPlayer::getInfo(ServerInfo_Player *info,
 {
     getProperties(*info->mutable_properties(), withUserInfo);
 
-    if (deck) {
+    // Deck lists are only shared with other players when the game is in Open Decklists mode,
+    // so a player joining an open lobby can see every deck that was loaded before they joined.
+    if (deck && (recipient == this || game->getShareDecklistsOnLoad())) {
         info->set_deck_list(deck->writeToString_Native().toStdString());
     }
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #7029 

## Short roundup of the initial problem
Wrong gate means the info the client needs is never populated

## What will change with this Pull Request?
- Populate info when open_decklists is enabled
- Don't create tabs for users with no loaded decks
