### PR TITLE
[DeckPreview/DeckEditor] Extract conversion prompt from DeckPreviewWidget

### DIFF
--- a/cockatrice/src/interface/widgets/dialogs/dlg_convert_deck_to_cod_format.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_convert_deck_to_cod_format.cpp
@@ -1,9 +1,17 @@
 #include "dlg_convert_deck_to_cod_format.h"
 
+#include "../../../client/settings/cache_settings.h"
+#include "../../deck_loader/deck_loader.h"
+
 #include <QCheckBox>
 #include <QDialogButtonBox>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
 #include <QLabel>
+#include <QMessageBox>
 #include <QVBoxLayout>
+#include <libcockatrice/settings/visual_deck_storage_settings.h>
 
 DialogConvertDeckToCodFormat::DialogConvertDeckToCodFormat(QWidget *parent) : QDialog(parent)
 {
@@ -37,4 +45,72 @@ void DialogConvertDeckToCodFormat::retranslateUi()
 bool DialogConvertDeckToCodFormat::dontAskAgain() const
 {
     return dontAskAgainCheckbox->isChecked();
+}
+
+namespace
+{
+
+bool confirmOverwriteIfExists(QWidget *parent, const QString &filePath)
+{
+    QFileInfo fileInfo(filePath);
+    QString newFileName = QDir::toNativeSeparators(fileInfo.path() + "/" + fileInfo.completeBaseName() + ".cod");
+
+    if (QFile::exists(newFileName)) {
+        QMessageBox::StandardButton reply =
+            QMessageBox::question(parent, QObject::tr("Overwrite Existing File?"),
+                                  QObject::tr("A .cod version of this deck already exists. Overwrite it?"),
+                                  QMessageBox::Yes | QMessageBox::No);
+        return reply == QMessageBox::Yes;
+    }
+    return true; // Safe to proceed
+}
+
+} // namespace
+
+bool DialogConvertDeckToCodFormat::promptIfRequired(QWidget *parent,
+                                                    const QString &filePath,
+                                                    const std::function<bool()> &convert)
+{
+    if (DeckFileFormat::getFormatFromName(filePath) == DeckFileFormat::Cockatrice) {
+        return true;
+    }
+
+    // Retrieve saved preference if the prompt is disabled
+    if (!SettingsCache::instance().visualDeckStorage().getVisualDeckStoragePromptForConversion()) {
+        if (!SettingsCache::instance().visualDeckStorage().getVisualDeckStorageAlwaysConvert()) {
+            return false;
+        }
+
+        if (!confirmOverwriteIfExists(parent, filePath)) {
+            return false;
+        }
+
+        return convert();
+    }
+
+    // Show the dialog to the user
+    DialogConvertDeckToCodFormat conversionDialog(parent);
+    if (conversionDialog.exec() != QDialog::Accepted) {
+        SettingsCache::instance().visualDeckStorage().setVisualDeckStoragePromptForConversion(
+            !conversionDialog.dontAskAgain());
+        SettingsCache::instance().visualDeckStorage().setVisualDeckStorageAlwaysConvert(false);
+
+        return false;
+    }
+
+    // Try to convert file
+    if (!confirmOverwriteIfExists(parent, filePath)) {
+        return false;
+    }
+
+    if (!convert()) {
+        return false;
+    }
+
+    if (conversionDialog.dontAskAgain()) {
+        SettingsCache::instance().visualDeckStorage().setVisualDeckStoragePromptForConversion(false);
+        SettingsCache::instance().visualDeckStorage().setVisualDeckStorageAlwaysConvert(true);
+    }
+
+    return true;
 }

--- a/cockatrice/src/interface/widgets/dialogs/dlg_convert_deck_to_cod_format.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_convert_deck_to_cod_format.h
@@ -13,6 +13,9 @@
 #include <QDialogButtonBox>
 #include <QLabel>
 #include <QVBoxLayout>
+#include <functional>
+
+class QWidget;
 
 class DialogConvertDeckToCodFormat : public QDialog
 {
@@ -23,6 +26,21 @@ public:
     void retranslateUi();
 
     [[nodiscard]] bool dontAskAgain() const;
+
+    /**
+     * @brief Checks whether the deck file at \a filePath can store tags.
+     *
+     * If the file is not a .cod deck, prompts the user for conversion to the
+     * Cockatrice format, honoring the saved "always convert / don't ask again"
+     * preference. On acceptance \a convert is called to perform the conversion.
+     *
+     * @param parent The widget to parent the prompt to.
+     * @param filePath The path of the deck file to check.
+     * @param convert Called to convert the deck once the user agrees.
+     * @return true if tags can be stored (no conversion needed, or the conversion
+     *         was performed), false if the user declined to convert.
+     */
+    static bool promptIfRequired(QWidget *parent, const QString &filePath, const std::function<bool()> &convert);
 
 private:
     QVBoxLayout *layout;

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -10,8 +10,6 @@
 #include "../visual_deck_storage_widget.h"
 #include "deck_preview_deck_tags_display_widget.h"
 
-#include <QDir>
-#include <QFile>
 #include <QFileInfo>
 #include <QInputDialog>
 #include <QLabel>
@@ -499,21 +497,6 @@ void DeckPreviewWidget::actDeleteFile()
     // The folder widget removes this preview once the row is gone.
 }
 
-static bool confirmOverwriteIfExists(QWidget *parent, const QString &filePath)
-{
-    QFileInfo fileInfo(filePath);
-    QString newFileName = QDir::toNativeSeparators(fileInfo.path() + "/" + fileInfo.completeBaseName() + ".cod");
-
-    if (QFile::exists(newFileName)) {
-        QMessageBox::StandardButton reply =
-            QMessageBox::question(parent, QObject::tr("Overwrite Existing File?"),
-                                  QObject::tr("A .cod version of this deck already exists. Overwrite it?"),
-                                  QMessageBox::Yes | QMessageBox::No);
-        return reply == QMessageBox::Yes;
-    }
-    return true; // Safe to proceed
-}
-
 /**
  * Checks if the deck's file format supports tags.
  * If not, then prompt the user for file conversion.
@@ -521,45 +504,8 @@ static bool confirmOverwriteIfExists(QWidget *parent, const QString &filePath)
  */
 bool DeckPreviewWidget::promptFileConversionIfRequired()
 {
-    if (DeckFileFormat::getFormatFromName(filePath) == DeckFileFormat::Cockatrice) {
-        return true;
-    }
-
-    // Retrieve saved preference if the prompt is disabled
-    if (!SettingsCache::instance().visualDeckStorage().getVisualDeckStoragePromptForConversion()) {
-        if (!SettingsCache::instance().visualDeckStorage().getVisualDeckStorageAlwaysConvert()) {
-            return false;
-        }
-
-        if (!confirmOverwriteIfExists(this, filePath)) {
-            return false;
-        }
-
+    return DialogConvertDeckToCodFormat::promptIfRequired(this, filePath, [this] {
         model->convertToCockatriceFormat(row());
         return true;
-    }
-
-    // Show the dialog to the user
-    DialogConvertDeckToCodFormat conversionDialog(this);
-    if (conversionDialog.exec() != QDialog::Accepted) {
-        SettingsCache::instance().visualDeckStorage().setVisualDeckStoragePromptForConversion(
-            !conversionDialog.dontAskAgain());
-        SettingsCache::instance().visualDeckStorage().setVisualDeckStorageAlwaysConvert(false);
-
-        return false;
-    }
-
-    // Try to convert file
-    if (!confirmOverwriteIfExists(this, filePath)) {
-        return false;
-    }
-
-    model->convertToCockatriceFormat(row());
-
-    if (conversionDialog.dontAskAgain()) {
-        SettingsCache::instance().visualDeckStorage().setVisualDeckStoragePromptForConversion(false);
-        SettingsCache::instance().visualDeckStorage().setVisualDeckStorageAlwaysConvert(true);
-    }
-
-    return true;
+    });
 }


### PR DESCRIPTION
## Related tickets

Based on:

- #7106 
- #7105 
- #7104


## Short roundup of the initial problem
Pure refactor, no behavior change. Moves the deck-format conversion prompt (format check, saved "always convert / don't ask again" preferences, overwrite confirmation, dialog) out of DeckPreviewWidget into the dialog as a reusable promptFileConversionIfRequired free function. 

## What will change with this Pull Request?
- DeckPreviewWidget now delegates with identical semantics
- This lets the deck editor reuse the prompt in the next PR
