### PR TITLE
[DeckEditor] Allow .cod conversion prompt

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -299,8 +299,10 @@ set(cockatrice_SOURCES
     src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_tag_item_widget.cpp
     src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
     src/interface/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
+    src/interface/widgets/visual_deck_storage/visual_deck_storage_model.cpp
     src/interface/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.cpp
     src/interface/widgets/visual_deck_storage/visual_deck_storage_search_widget.cpp
+    src/interface/widgets/visual_deck_storage/visual_deck_storage_sort_filter_proxy_model.cpp
     src/interface/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
     src/interface/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
     src/interface/widgets/visual_deck_storage/visual_deck_storage_widget.cpp

--- a/cockatrice/src/filters/deck_filter_string.cpp
+++ b/cockatrice/src/filters/deck_filter_string.cpp
@@ -52,18 +52,14 @@ static void setupParserRules()
 
     search["Start"] = passthru;
     search["QueryPartList"] = [](const peg::SemanticValues &sv) -> DeckFilter {
-        return [=](const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &info) {
-            auto matchesFilter = [&deck, &info](const std::any &query) {
-                return std::any_cast<DeckFilter>(query)(deck, info);
-            };
+        return [=](const DeckSearchData &data) {
+            auto matchesFilter = [&data](const std::any &query) { return std::any_cast<DeckFilter>(query)(data); };
             return std::all_of(sv.begin(), sv.end(), matchesFilter);
         };
     };
     search["ComplexQueryPart"] = [](const peg::SemanticValues &sv) -> DeckFilter {
-        return [=](const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &info) {
-            auto matchesFilter = [&deck, &info](const std::any &query) {
-                return std::any_cast<DeckFilter>(query)(deck, info);
-            };
+        return [=](const DeckSearchData &data) {
+            auto matchesFilter = [&data](const std::any &query) { return std::any_cast<DeckFilter>(query)(data); };
             return std::any_of(sv.begin(), sv.end(), matchesFilter);
         };
     };
@@ -71,9 +67,7 @@ static void setupParserRules()
     search["QueryPart"] = passthru;
     search["NotQuery"] = [](const peg::SemanticValues &sv) -> DeckFilter {
         const auto dependent = std::any_cast<DeckFilter>(sv[0]);
-        return [=](const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &info) -> bool {
-            return !dependent(deck, info);
-        };
+        return [=](const DeckSearchData &data) -> bool { return !dependent(data); };
     };
 
     search["String"] = [](const peg::SemanticValues &sv) -> QString {
@@ -125,9 +119,9 @@ static void setupParserRules()
         auto cardFilter = FilterString(std::any_cast<QString>(sv[0]));
         auto numberMatcher = sv.size() > 1 ? std::any_cast<NumberMatcher>(sv[1]) : [](int count) { return count > 0; };
 
-        return [=](const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &) -> bool {
+        return [=](const DeckSearchData &data) -> bool {
             int count = 0;
-            auto cardNodes = deck->deckLoader->getDeck().deckList.getCardNodes();
+            auto cardNodes = data.deck->deckList.getCardNodes();
             for (auto node : cardNodes) {
                 auto cardInfoPtr = CardDatabaseManager::query()->getCardInfo(node->getName());
                 if (!cardInfoPtr.isNull() && cardFilter.check(cardInfoPtr)) {
@@ -146,53 +140,49 @@ static void setupParserRules()
 
     search["DeckNameQuery"] = [](const peg::SemanticValues &sv) -> DeckFilter {
         auto name = std::any_cast<QString>(sv[0]);
-        return [=](const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &) {
-            return deck->deckLoader->getDeck().deckList.getName().contains(name, Qt::CaseInsensitive);
+        return [=](const DeckSearchData &data) {
+            return data.deck->deckList.getName().contains(name, Qt::CaseInsensitive);
         };
     };
 
     search["FileNameQuery"] = [](const peg::SemanticValues &sv) -> DeckFilter {
         auto name = std::any_cast<QString>(sv[0]);
-        return [=](const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &) {
-            auto filename = QFileInfo(deck->filePath).fileName();
+        return [=](const DeckSearchData &data) {
+            auto filename = QFileInfo(data.filePath).fileName();
             return filename.contains(name, Qt::CaseInsensitive);
         };
     };
 
     search["PathQuery"] = [](const peg::SemanticValues &sv) -> DeckFilter {
         auto name = std::any_cast<QString>(sv[0]);
-        return [=](const DeckPreviewWidget *, const ExtraDeckSearchInfo &info) {
-            return info.relativeFilePath.contains(name, Qt::CaseInsensitive);
-        };
+        return [=](const DeckSearchData &data) { return data.relativeFilePath.contains(name, Qt::CaseInsensitive); };
     };
 
     search["FormatQuery"] = [](const peg::SemanticValues &sv) -> DeckFilter {
         auto format = std::any_cast<QString>(sv[0]);
-        return [=](const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &) {
-            auto gameFormat = deck->deckLoader->getDeck().deckList.getGameFormat();
+        return [=](const DeckSearchData &data) {
+            auto gameFormat = data.deck->deckList.getGameFormat();
             return QString::compare(format, gameFormat, Qt::CaseInsensitive) == 0;
         };
     };
 
     search["CommentQuery"] = [](const peg::SemanticValues &sv) -> DeckFilter {
         auto value = std::any_cast<QString>(sv[0]);
-        return [=](const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &) {
-            auto comments = deck->deckLoader->getDeck().deckList.getComments();
+        return [=](const DeckSearchData &data) {
+            auto comments = data.deck->deckList.getComments();
             return comments.contains(value, Qt::CaseInsensitive);
         };
     };
 
     search["GenericQuery"] = [](const peg::SemanticValues &sv) -> DeckFilter {
         auto name = std::any_cast<QString>(sv[0]);
-        return [=](const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &) {
-            return deck->getDisplayName().contains(name, Qt::CaseInsensitive);
-        };
+        return [=](const DeckSearchData &data) { return data.displayName.contains(name, Qt::CaseInsensitive); };
     };
 }
 
 DeckFilterString::DeckFilterString()
 {
-    filter = [](const DeckPreviewWidget *, const ExtraDeckSearchInfo &) { return false; };
+    filter = [](const DeckSearchData &) { return false; };
     _error = "Not initialized";
 }
 
@@ -205,7 +195,7 @@ DeckFilterString::DeckFilterString(const QString &expr)
     _error = QString();
 
     if (ba.isEmpty()) {
-        filter = [](const DeckPreviewWidget *, const ExtraDeckSearchInfo &) { return true; };
+        filter = [](const DeckSearchData &) { return true; };
         return;
     }
 
@@ -215,6 +205,6 @@ DeckFilterString::DeckFilterString(const QString &expr)
 
     if (!search.parse(ba.data(), filter)) {
         qCInfo(DeckFilterStringLog).nospace() << "DeckFilterString error for " << expr << "; " << qPrintable(_error);
-        filter = [](const DeckPreviewWidget *, const ExtraDeckSearchInfo &) { return false; };
+        filter = [](const DeckSearchData &) { return false; };
     }
 }

--- a/cockatrice/src/filters/deck_filter_string.h
+++ b/cockatrice/src/filters/deck_filter_string.h
@@ -7,7 +7,7 @@
 #ifndef DECK_FILTER_STRING_H
 #define DECK_FILTER_STRING_H
 
-#include "../interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h"
+#include "../interface/deck_loader/loaded_deck.h"
 
 #include <QLoggingCategory>
 #include <QString>
@@ -16,26 +16,29 @@
 inline Q_LOGGING_CATEGORY(DeckFilterStringLog, "deck_filter_string");
 
 /**
- * Extra info relevant to filtering that isn't present in the DeckPreviewWidget
+ * The data a deck search expression is evaluated against.
+ *
+ * This is a data view rather than a widget pointer, so the same filter
+ * expression can be evaluated against a model or a live widget.
  */
-struct ExtraDeckSearchInfo
+struct DeckSearchData
 {
-    /**
-     * The relative filepath starting from the deck folder
-     */
-    QString relativeFilePath;
+    const LoadedDeck *deck = nullptr; ///< The loaded deck. Must not be null.
+    QString filePath;                 ///< Absolute path of the deck file.
+    QString displayName;              ///< Deck name, or the file name if the deck has no name.
+    QString relativeFilePath;         ///< File path relative to the deck folder.
 };
 
-typedef std::function<bool(const DeckPreviewWidget *, const ExtraDeckSearchInfo &)> DeckFilter;
+typedef std::function<bool(const DeckSearchData &data)> DeckFilter;
 
 class DeckFilterString
 {
 public:
     DeckFilterString();
     explicit DeckFilterString(const QString &expr);
-    bool check(const DeckPreviewWidget *deck, const ExtraDeckSearchInfo &info) const
+    bool check(const DeckSearchData &data) const
     {
-        return filter(deck, info);
+        return filter(data);
     }
 
     [[nodiscard]] bool valid() const

--- a/cockatrice/src/game_graphics/deckview/deck_view_container.cpp
+++ b/cockatrice/src/game_graphics/deckview/deck_view_container.cpp
@@ -9,6 +9,7 @@
 #include "../../interface/widgets/dialogs/dlg_load_deck_from_website.h"
 #include "../../interface/widgets/dialogs/dlg_load_remote_deck.h"
 #include "../../interface/widgets/tabs/tab_game.h"
+#include "../../interface/widgets/visual_deck_storage/visual_deck_storage_widget.h"
 #include "deck_view.h"
 
 #include <QMessageBox>

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -2,6 +2,8 @@
 
 #include "../../../client/settings/cache_settings.h"
 #include "../../../client/settings/shortcuts_settings.h"
+#include "../../deck_loader/deck_loader.h"
+#include "../dialogs/dlg_convert_deck_to_cod_format.h"
 #include "../settings_page/user_interface_settings_page.h"
 #include "../tabs/api/commander_spellbook/commander_bracket_widget.h"
 #include "deck_list_style_proxy.h"
@@ -175,6 +177,23 @@ void DeckEditorDeckDockWidget::createDeckDock()
     deckTagsDisplayWidget->setHidden(!SettingsCache::instance().deckEditor().getTagsWidgetVisible());
     connect(deckTagsDisplayWidget, &DeckPreviewDeckTagsDisplayWidget::tagsChanged, deckStateManager,
             &DeckStateManager::setTags);
+
+    // Local deck files in non-Cockatrice formats (e.g. .txt) can't store tags.
+    // Offer to convert the file to .cod before the user opens the tag dialog.
+    deckTagsDisplayWidget->setConversionPromptHandler([this] {
+        const LoadedDeck::LoadInfo &loadInfo = deckStateManager->getLastLoadInfo();
+        if (loadInfo.fileName.isEmpty()) {
+            return true; // A new, unsaved deck can hold tags in memory.
+        }
+        return promptFileConversionIfRequired(this, loadInfo.fileName, [this] {
+            LoadedDeck deck = deckStateManager->toLoadedDeck();
+            if (!DeckLoader::convertToCockatriceFormat(deck)) {
+                return false;
+            }
+            deckStateManager->setLastLoadInfo(deck.lastLoadInfo);
+            return true;
+        });
+    });
 
     activeGroupCriteriaLabel = new QLabel(this);
 

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.h
@@ -15,6 +15,8 @@
 #include "deck_list_history_manager_widget.h"
 #include "deck_list_style_proxy.h"
 
+#include <QCheckBox>
+#include <QComboBox>
 #include <QDockWidget>
 #include <QLabel>
 #include <QTextEdit>

--- a/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.h
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_state_manager.h
@@ -117,6 +117,15 @@ public:
     void clearDeck();
 
     /**
+     * @brief Gets the lastLoadInfo.
+     * @return The lastLoadInfo
+     */
+    const LoadedDeck::LoadInfo &getLastLoadInfo() const
+    {
+        return lastLoadInfo;
+    }
+
+    /**
      * @brief Sets the lastLoadInfo.
      * @param loadInfo The lastLoadInfo
      */

--- a/cockatrice/src/interface/widgets/dialogs/dlg_convert_deck_to_cod_format.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_convert_deck_to_cod_format.cpp
@@ -1,9 +1,17 @@
 #include "dlg_convert_deck_to_cod_format.h"
 
+#include "../../../client/settings/cache_settings.h"
+#include "../../deck_loader/deck_loader.h"
+
 #include <QCheckBox>
 #include <QDialogButtonBox>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
 #include <QLabel>
+#include <QMessageBox>
 #include <QVBoxLayout>
+#include <libcockatrice/settings/visual_deck_storage_settings.h>
 
 DialogConvertDeckToCodFormat::DialogConvertDeckToCodFormat(QWidget *parent) : QDialog(parent)
 {
@@ -37,4 +45,65 @@ void DialogConvertDeckToCodFormat::retranslateUi()
 bool DialogConvertDeckToCodFormat::dontAskAgain() const
 {
     return dontAskAgainCheckbox->isChecked();
+}
+
+static bool confirmOverwriteIfExists(QWidget *parent, const QString &filePath)
+{
+    QFileInfo fileInfo(filePath);
+    QString newFileName = QDir::toNativeSeparators(fileInfo.path() + "/" + fileInfo.completeBaseName() + ".cod");
+
+    if (QFile::exists(newFileName)) {
+        QMessageBox::StandardButton reply =
+            QMessageBox::question(parent, QObject::tr("Overwrite Existing File?"),
+                                  QObject::tr("A .cod version of this deck already exists. Overwrite it?"),
+                                  QMessageBox::Yes | QMessageBox::No);
+        return reply == QMessageBox::Yes;
+    }
+    return true; // Safe to proceed
+}
+
+bool promptFileConversionIfRequired(QWidget *parent, const QString &filePath, const std::function<bool()> &convert)
+{
+    if (DeckFileFormat::getFormatFromName(filePath) == DeckFileFormat::Cockatrice) {
+        return true;
+    }
+
+    // Retrieve saved preference if the prompt is disabled
+    if (!SettingsCache::instance().visualDeckStorage().getVisualDeckStoragePromptForConversion()) {
+        if (!SettingsCache::instance().visualDeckStorage().getVisualDeckStorageAlwaysConvert()) {
+            return false;
+        }
+
+        if (!confirmOverwriteIfExists(parent, filePath)) {
+            return false;
+        }
+
+        return convert();
+    }
+
+    // Show the dialog to the user
+    DialogConvertDeckToCodFormat conversionDialog(parent);
+    if (conversionDialog.exec() != QDialog::Accepted) {
+        SettingsCache::instance().visualDeckStorage().setVisualDeckStoragePromptForConversion(
+            !conversionDialog.dontAskAgain());
+        SettingsCache::instance().visualDeckStorage().setVisualDeckStorageAlwaysConvert(false);
+
+        return false;
+    }
+
+    // Try to convert file
+    if (!confirmOverwriteIfExists(parent, filePath)) {
+        return false;
+    }
+
+    if (!convert()) {
+        return false;
+    }
+
+    if (conversionDialog.dontAskAgain()) {
+        SettingsCache::instance().visualDeckStorage().setVisualDeckStoragePromptForConversion(false);
+        SettingsCache::instance().visualDeckStorage().setVisualDeckStorageAlwaysConvert(true);
+    }
+
+    return true;
 }

--- a/cockatrice/src/interface/widgets/dialogs/dlg_convert_deck_to_cod_format.h
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_convert_deck_to_cod_format.h
@@ -13,6 +13,9 @@
 #include <QDialogButtonBox>
 #include <QLabel>
 #include <QVBoxLayout>
+#include <functional>
+
+class QWidget;
 
 class DialogConvertDeckToCodFormat : public QDialog
 {
@@ -32,5 +35,20 @@ private:
 
     Q_DISABLE_COPY(DialogConvertDeckToCodFormat)
 };
+
+/**
+ * @brief Checks whether the deck file at \a filePath can store tags.
+ *
+ * If the file is not a .cod deck, prompts the user for conversion to the
+ * Cockatrice format, honoring the saved "always convert / don't ask again"
+ * preference. On acceptance \a convert is called to perform the conversion.
+ *
+ * @param parent The widget to parent the prompt to.
+ * @param filePath The path of the deck file to check.
+ * @param convert Called to convert the deck once the user agrees.
+ * @return true if tags can be stored (no conversion needed, or the conversion
+ *         was performed), false if the user declined to convert.
+ */
+bool promptFileConversionIfRequired(QWidget *parent, const QString &filePath, const std::function<bool()> &convert);
 
 #endif // DIALOG_CONVERT_DECK_TO_COD_FORMAT_H

--- a/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
+++ b/cockatrice/src/interface/widgets/printing_selector/printing_selector_card_overlay_widget.cpp
@@ -1,6 +1,7 @@
 #include "printing_selector_card_overlay_widget.h"
 
 #include "../../../client/settings/cache_settings.h"
+#include "../cards/card_info_picture_widget.h"
 #include "printing_selector_card_display_widget.h"
 
 #include <QImageReader>

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.h
@@ -8,6 +8,7 @@
 #ifndef TAB_GENERIC_DECK_EDITOR_H
 #define TAB_GENERIC_DECK_EDITOR_H
 
+#include "../../deck_loader/deck_loader.h"
 #include "../interface/widgets/deck_editor/deck_editor_card_database_dock_widget.h"
 #include "../interface/widgets/deck_editor/deck_editor_card_info_dock_widget.h"
 #include "../interface/widgets/deck_editor/deck_editor_database_display_widget.h"

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_filter_widget.cpp
@@ -1,12 +1,12 @@
 #include "deck_preview_color_identity_filter_widget.h"
 
 #include "../../cards/additional_info/mana_symbol_widget.h"
-#include "deck_preview_widget.h"
+#include "../visual_deck_storage_widget.h"
 
-#include <QMouseEvent>
+#include <QSet>
 
 DeckPreviewColorIdentityFilterWidget::DeckPreviewColorIdentityFilterWidget(VisualDeckStorageWidget *parent)
-    : QWidget(parent), layout(new QHBoxLayout(this))
+    : QWidget(parent), layout(new QHBoxLayout(this)), visualDeckStorageWidget(parent)
 {
     setLayout(layout);
     layout->setSpacing(5);
@@ -32,10 +32,6 @@ DeckPreviewColorIdentityFilterWidget::DeckPreviewColorIdentityFilterWidget(Visua
 
     // Connect the button's clicked signal
     connect(toggleButton, &QPushButton::clicked, this, &DeckPreviewColorIdentityFilterWidget::updateFilterMode);
-    connect(this, &DeckPreviewColorIdentityFilterWidget::activeColorsChanged, parent,
-            &VisualDeckStorageWidget::updateColorFilter);
-    connect(this, &DeckPreviewColorIdentityFilterWidget::filterModeChanged, parent,
-            &VisualDeckStorageWidget::updateColorFilter);
 
     // Call retranslateUi to set the initial text
     retranslateUi();
@@ -45,111 +41,56 @@ void DeckPreviewColorIdentityFilterWidget::retranslateUi()
 {
     // Set the toggle button text based on the current mode
     switch (filterMode) {
-        case ExactMatch:
+        case VisualDeckStorageSortFilterProxyModel::FilterMode::ExactMatch:
             toggleButton->setText(tr("Mode: Exact Match"));
             break;
-        case Includes:
+        case VisualDeckStorageSortFilterProxyModel::FilterMode::Includes:
             toggleButton->setText(tr("Mode: Includes"));
             break;
-        case Excludes:
+        case VisualDeckStorageSortFilterProxyModel::FilterMode::Excludes:
             toggleButton->setText(tr("Mode: Excludes"));
             break;
     }
     toggleButton->setToolTip(tr("Color identity filter mode (AND/OR/NOT conjunctions of filters)"));
 }
 
+/**
+ * @brief Pushes the current filter state to the proxy model.
+ */
+void DeckPreviewColorIdentityFilterWidget::applyFilter()
+{
+    QSet<QChar> activeColorSet;
+    for (auto it = activeColors.constBegin(); it != activeColors.constEnd(); ++it) {
+        if (it.value()) {
+            activeColorSet.insert(it.key());
+        }
+    }
+
+    // The VDS owns the proxy model, which exists for the widget's whole lifetime.
+    visualDeckStorageWidget->proxyModel()->setColorFilter(filterMode, activeColorSet);
+}
+
 void DeckPreviewColorIdentityFilterWidget::handleColorToggled(QChar color, bool active)
 {
     activeColors[color] = active;
-    emit activeColorsChanged();
+    applyFilter();
 }
 
 void DeckPreviewColorIdentityFilterWidget::updateFilterMode()
 {
     // Cycle through the modes
     switch (filterMode) {
-        case ExactMatch:
-            filterMode = Includes;
+        case VisualDeckStorageSortFilterProxyModel::FilterMode::ExactMatch:
+            filterMode = VisualDeckStorageSortFilterProxyModel::FilterMode::Includes;
             break;
-        case Includes:
-            filterMode = Excludes;
+        case VisualDeckStorageSortFilterProxyModel::FilterMode::Includes:
+            filterMode = VisualDeckStorageSortFilterProxyModel::FilterMode::Excludes;
             break;
-        case Excludes:
-            filterMode = ExactMatch;
+        case VisualDeckStorageSortFilterProxyModel::FilterMode::Excludes:
+            filterMode = VisualDeckStorageSortFilterProxyModel::FilterMode::ExactMatch;
             break;
     }
 
     retranslateUi(); // Update the button text
-    emit filterModeChanged(filterMode);
-}
-
-void DeckPreviewColorIdentityFilterWidget::filterWidgets(QList<DeckPreviewWidget *> widgets)
-{
-    // Check if no colors are active
-    bool noColorsActive = true;
-    for (auto it = activeColors.constBegin(); it != activeColors.constEnd(); ++it) {
-        if (it.value()) {
-            noColorsActive = false;
-            break;
-        }
-    }
-
-    // If no colors are active, return the unfiltered list of widgets
-    if (noColorsActive) {
-        for (DeckPreviewWidget *previewWidget : widgets) {
-            previewWidget->filteredByColor = false;
-        }
-        return;
-    }
-
-    for (const auto &widget : widgets) {
-        QString colorIdentity = widget->getColorIdentity();
-
-        bool matchesFilter = true;
-        switch (filterMode) {
-            case ExactMatch: {
-                // Exact match mode: active colors must exactly match colorIdentity
-
-                // Create a set of active colors
-                QSet<QChar> activeColorSet;
-                for (auto it = activeColors.constBegin(); it != activeColors.constEnd(); ++it) {
-                    if (it.value()) {
-                        activeColorSet.insert(it.key().toUpper()); // Use uppercase for uniformity
-                    }
-                }
-
-                // Create a set of colors from the color identity string
-                QSet<QChar> colorIdentitySet;
-                for (const QChar &color : colorIdentity) {
-                    colorIdentitySet.insert(color.toUpper()); // Ensure case uniformity
-                }
-
-                // Compare the sets: the sets must match exactly
-                if (activeColorSet != colorIdentitySet) {
-                    matchesFilter = false;
-                }
-                break;
-            }
-            case Includes:
-                // Includes mode: colorIdentity must contain all active colors
-                for (auto it = activeColors.constBegin(); it != activeColors.constEnd(); ++it) {
-                    if (it.value() && !colorIdentity.contains(it.key())) {
-                        matchesFilter = false;
-                        break;
-                    }
-                }
-                break;
-            case Excludes:
-                // Excludes mode: colorIdentity must contain none of the active colors
-                for (auto it = activeColors.constBegin(); it != activeColors.constEnd(); ++it) {
-                    if (it.value() && colorIdentity.contains(it.key())) {
-                        matchesFilter = false;
-                        break;
-                    }
-                }
-                break;
-        }
-
-        widget->filteredByColor = !matchesFilter;
-    }
+    applyFilter();
 }

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_filter_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_color_identity_filter_widget.h
@@ -2,18 +2,17 @@
  * @file deck_preview_color_identity_filter_widget.h
  * @ingroup VisualDeckPreviewWidgets
  */
-//! \todo Document this file.
 
 #ifndef DECK_PREVIEW_COLOR_IDENTITY_FILTER_WIDGET_H
 #define DECK_PREVIEW_COLOR_IDENTITY_FILTER_WIDGET_H
 
-#include "../visual_deck_storage_widget.h"
+#include "../visual_deck_storage_sort_filter_proxy_model.h"
 
 #include <QHBoxLayout>
+#include <QMap>
 #include <QPushButton>
 #include <QWidget>
 
-class DeckPreviewWidget;
 class VisualDeckStorageWidget;
 
 class DeckPreviewColorIdentityFilterWidget : public QWidget
@@ -21,34 +20,21 @@ class DeckPreviewColorIdentityFilterWidget : public QWidget
     Q_OBJECT
 
 public:
-    /**
-     * How the active colors are matched against a deck's color identity.
-     */
-    enum FilterMode
-    {
-        ExactMatch, ///< The color identity consists of exactly the active colors.
-        Includes,   ///< The color identity contains all of the active colors.
-        Excludes    ///< The color identity contains none of the active colors.
-    };
-    Q_ENUM(FilterMode)
-
     explicit DeckPreviewColorIdentityFilterWidget(VisualDeckStorageWidget *parent);
     void retranslateUi();
-    void filterWidgets(QList<DeckPreviewWidget *> widgets);
-
-signals:
-    void filterModeChanged(FilterMode mode);
-    void activeColorsChanged();
 
 private slots:
     void handleColorToggled(QChar color, bool active);
     void updateFilterMode();
 
 private:
+    void applyFilter();
+
     QHBoxLayout *layout;
     QPushButton *toggleButton;
     QMap<QChar, bool> activeColors;
-    FilterMode filterMode = Includes; // Default to "includes" mode
+    VisualDeckStorageSortFilterProxyModel::FilterMode filterMode = VisualDeckStorageSortFilterProxyModel::Includes;
+    VisualDeckStorageWidget *visualDeckStorageWidget; ///< The VDS owning the proxy model.
 };
 
 #endif // DECK_PREVIEW_COLOR_IDENTITY_FILTER_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.cpp
@@ -1,19 +1,15 @@
 #include "deck_preview_deck_tags_display_widget.h"
 
 #include "../../../../client/settings/cache_settings.h"
-#include "../../../../interface/widgets/dialogs/dlg_convert_deck_to_cod_format.h"
-#include "../../../../interface/widgets/tabs/tab_deck_editor.h"
+#include "../../../deck_loader/deck_loader.h"
 #include "../../general/layout_containers/flow_widget.h"
 #include "deck_preview_tag_addition_widget.h"
 #include "deck_preview_tag_dialog.h"
 #include "deck_preview_tag_display_widget.h"
-#include "deck_preview_widget.h"
 
 #include <QDirIterator>
 #include <QHBoxLayout>
-#include <QMessageBox>
 #include <libcockatrice/settings/paths_settings.h>
-#include <libcockatrice/settings/visual_deck_storage_settings.h>
 
 DeckPreviewDeckTagsDisplayWidget::DeckPreviewDeckTagsDisplayWidget(QWidget *_parent, const QStringList &_tags)
     : QWidget(_parent), currentTags(_tags)
@@ -54,6 +50,16 @@ void DeckPreviewDeckTagsDisplayWidget::refreshTags()
     flowWidget->addWidget(tagAdditionWidget);
 }
 
+void DeckPreviewDeckTagsDisplayWidget::setKnownTagsProvider(const std::function<QStringList()> &provider)
+{
+    knownTagsProvider_ = provider;
+}
+
+void DeckPreviewDeckTagsDisplayWidget::setConversionPromptHandler(const std::function<bool()> &handler)
+{
+    conversionPromptHandler_ = handler;
+}
+
 /**
  * Gets the filepath of all files (no directories) in target directory and all subdirectories
  */
@@ -92,93 +98,13 @@ static QStringList findAllKnownTags()
 
 void DeckPreviewDeckTagsDisplayWidget::openTagEditDlg()
 {
-    if (qobject_cast<DeckPreviewWidget *>(parentWidget())) {
-        // If we're the child of a DeckPreviewWidget, then we need to handle conversion
-        auto *deckPreviewWidget = qobject_cast<DeckPreviewWidget *>(parentWidget());
-
-        bool canAddTags = promptFileConversionIfRequired(deckPreviewWidget);
-
-        if (canAddTags) {
-            QStringList knownTags = deckPreviewWidget->visualDeckStorageWidget->tagFilterWidget->getAllKnownTags();
-            execTagDialog(knownTags);
-        }
-    } else {
-        // If we're the child of an AbstractTabDeckEditor, then we don't bother with conversion
-        QStringList knownTags = findAllKnownTags();
-        execTagDialog(knownTags);
-    }
-}
-
-static bool confirmOverwriteIfExists(QWidget *parent, const QString &filePath)
-{
-    QFileInfo fileInfo(filePath);
-    QString newFileName = QDir::toNativeSeparators(fileInfo.path() + "/" + fileInfo.completeBaseName() + ".cod");
-
-    if (QFile::exists(newFileName)) {
-        QMessageBox::StandardButton reply =
-            QMessageBox::question(parent, QObject::tr("Overwrite Existing File?"),
-                                  QObject::tr("A .cod version of this deck already exists. Overwrite it?"),
-                                  QMessageBox::Yes | QMessageBox::No);
-        return reply == QMessageBox::Yes;
-    }
-    return true; // Safe to proceed
-}
-
-static void convertFileToCockatriceFormat(DeckPreviewWidget *deckPreviewWidget)
-{
-    DeckLoader::convertToCockatriceFormat(deckPreviewWidget->deckLoader->getDeck());
-    deckPreviewWidget->filePath = deckPreviewWidget->deckLoader->getDeck().lastLoadInfo.fileName;
-    deckPreviewWidget->refreshBannerCardText();
-}
-
-/**
- * Checks if the deck's file format supports tags.
- * If not, then prompt the user for file conversion.
- * @return whether the resulting file can support adding tags
- */
-bool DeckPreviewDeckTagsDisplayWidget::promptFileConversionIfRequired(DeckPreviewWidget *deckPreviewWidget)
-{
-    if (DeckFileFormat::getFormatFromName(deckPreviewWidget->filePath) == DeckFileFormat::Cockatrice) {
-        return true;
+    // The deck editor path has no conversion prompt; the VDS path registers one.
+    if (conversionPromptHandler_ && !conversionPromptHandler_()) {
+        return;
     }
 
-    // Retrieve saved preference if the prompt is disabled
-    if (!SettingsCache::instance().visualDeckStorage().getVisualDeckStoragePromptForConversion()) {
-        if (!SettingsCache::instance().visualDeckStorage().getVisualDeckStorageAlwaysConvert()) {
-            return false;
-        }
-
-        if (!confirmOverwriteIfExists(this, deckPreviewWidget->filePath)) {
-            return false;
-        }
-
-        convertFileToCockatriceFormat(deckPreviewWidget);
-        return true;
-    }
-
-    // Show the dialog to the user
-    DialogConvertDeckToCodFormat conversionDialog(parentWidget());
-    if (conversionDialog.exec() != QDialog::Accepted) {
-        SettingsCache::instance().visualDeckStorage().setVisualDeckStoragePromptForConversion(
-            !conversionDialog.dontAskAgain());
-        SettingsCache::instance().visualDeckStorage().setVisualDeckStorageAlwaysConvert(false);
-
-        return false;
-    }
-
-    // Try to convert file
-    if (!confirmOverwriteIfExists(this, deckPreviewWidget->filePath)) {
-        return false;
-    }
-
-    convertFileToCockatriceFormat(deckPreviewWidget);
-
-    if (conversionDialog.dontAskAgain()) {
-        SettingsCache::instance().visualDeckStorage().setVisualDeckStoragePromptForConversion(false);
-        SettingsCache::instance().visualDeckStorage().setVisualDeckStorageAlwaysConvert(true);
-    }
-
-    return true;
+    const QStringList knownTags = knownTagsProvider_ ? knownTagsProvider_() : findAllKnownTags();
+    execTagDialog(knownTags);
 }
 
 void DeckPreviewDeckTagsDisplayWidget::execTagDialog(const QStringList &knownTags)

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_deck_tags_display_widget.h
@@ -2,35 +2,44 @@
  * @file deck_preview_deck_tags_display_widget.h
  * @ingroup VisualDeckPreviewWidgets
  */
-//! \todo Document this file.
 
 #ifndef DECK_PREVIEW_DECK_TAGS_DISPLAY_WIDGET_H
 #define DECK_PREVIEW_DECK_TAGS_DISPLAY_WIDGET_H
 
-#include "../../../deck_loader/deck_loader.h"
-#include "deck_preview_widget.h"
-
+#include <QStringList>
 #include <QWidget>
+#include <functional>
 
-class DeckPreviewWidget;
+class FlowWidget;
+
 class DeckPreviewDeckTagsDisplayWidget : public QWidget
 {
     Q_OBJECT
 
     QStringList currentTags;
     FlowWidget *flowWidget;
+    std::function<QStringList()> knownTagsProvider_;
+    std::function<bool()> conversionPromptHandler_;
 
 public:
     explicit DeckPreviewDeckTagsDisplayWidget(QWidget *_parent, const QStringList &_tags = {});
     void setTags(const QStringList &_tags);
     void refreshTags();
 
+    /**
+     * @brief Sets a provider for the tags shown in the edit dialog.
+     * Defaults to scanning all deck files in the deck folder.
+     */
+    void setKnownTagsProvider(const std::function<QStringList()> &provider);
+
+    /**
+     * @brief Sets a handler run before opening the tag dialog. Returning false
+     * cancels the dialog. Defaults to no handler (the deck editor path).
+     */
+    void setConversionPromptHandler(const std::function<bool()> &handler);
+
 public slots:
     void openTagEditDlg();
-
-private:
-    bool promptFileConversionIfRequired(DeckPreviewWidget *deckPreviewWidget);
-    void execTagDialog(const QStringList &knownTags);
 
 signals:
     /**
@@ -38,5 +47,8 @@ signals:
      * @param tags The new list of tags.
      */
     void tagsChanged(const QStringList &tags);
+
+private:
+    void execTagDialog(const QStringList &knownTags);
 };
 #endif // DECK_PREVIEW_DECK_TAGS_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -11,7 +11,6 @@
 #include "deck_preview_deck_tags_display_widget.h"
 
 #include <QDir>
-#include <QFile>
 #include <QFileInfo>
 #include <QInputDialog>
 #include <QLabel>
@@ -479,21 +478,6 @@ void DeckPreviewWidget::actDeleteFile()
     // The folder widget removes this preview once the row is gone.
 }
 
-static bool confirmOverwriteIfExists(QWidget *parent, const QString &filePath)
-{
-    QFileInfo fileInfo(filePath);
-    QString newFileName = QDir::toNativeSeparators(fileInfo.path() + "/" + fileInfo.completeBaseName() + ".cod");
-
-    if (QFile::exists(newFileName)) {
-        QMessageBox::StandardButton reply =
-            QMessageBox::question(parent, QObject::tr("Overwrite Existing File?"),
-                                  QObject::tr("A .cod version of this deck already exists. Overwrite it?"),
-                                  QMessageBox::Yes | QMessageBox::No);
-        return reply == QMessageBox::Yes;
-    }
-    return true; // Safe to proceed
-}
-
 /**
  * Checks if the deck's file format supports tags.
  * If not, then prompt the user for file conversion.
@@ -501,45 +485,8 @@ static bool confirmOverwriteIfExists(QWidget *parent, const QString &filePath)
  */
 bool DeckPreviewWidget::promptFileConversionIfRequired()
 {
-    if (DeckFileFormat::getFormatFromName(filePath) == DeckFileFormat::Cockatrice) {
-        return true;
-    }
-
-    // Retrieve saved preference if the prompt is disabled
-    if (!SettingsCache::instance().visualDeckStorage().getVisualDeckStoragePromptForConversion()) {
-        if (!SettingsCache::instance().visualDeckStorage().getVisualDeckStorageAlwaysConvert()) {
-            return false;
-        }
-
-        if (!confirmOverwriteIfExists(this, filePath)) {
-            return false;
-        }
-
+    return ::promptFileConversionIfRequired(this, filePath, [this] {
         model_->convertToCockatriceFormat(row());
         return true;
-    }
-
-    // Show the dialog to the user
-    DialogConvertDeckToCodFormat conversionDialog(this);
-    if (conversionDialog.exec() != QDialog::Accepted) {
-        SettingsCache::instance().visualDeckStorage().setVisualDeckStoragePromptForConversion(
-            !conversionDialog.dontAskAgain());
-        SettingsCache::instance().visualDeckStorage().setVisualDeckStorageAlwaysConvert(false);
-
-        return false;
-    }
-
-    // Try to convert file
-    if (!confirmOverwriteIfExists(this, filePath)) {
-        return false;
-    }
-
-    model_->convertToCockatriceFormat(row());
-
-    if (conversionDialog.dontAskAgain()) {
-        SettingsCache::instance().visualDeckStorage().setVisualDeckStoragePromptForConversion(false);
-        SettingsCache::instance().visualDeckStorage().setVisualDeckStorageAlwaysConvert(true);
-    }
-
-    return true;
+    });
 }

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
@@ -1,47 +1,69 @@
 #include "deck_preview_widget.h"
 
 #include "../../../../client/settings/cache_settings.h"
+#include "../../../../interface/widgets/dialogs/dlg_convert_deck_to_cod_format.h"
+#include "../../../deck_loader/deck_loader.h"
 #include "../../cards/additional_info/color_identity_widget.h"
 #include "../../cards/deck_preview_card_picture_widget.h"
+#include "../visual_deck_storage_quick_settings_widget.h"
+#include "../visual_deck_storage_tag_filter_widget.h"
+#include "../visual_deck_storage_widget.h"
 #include "deck_preview_deck_tags_display_widget.h"
 
-#include <QClipboard>
 #include <QDir>
+#include <QFile>
 #include <QFileInfo>
 #include <QInputDialog>
+#include <QLabel>
 #include <QMenu>
 #include <QMessageBox>
 #include <QMouseEvent>
 #include <QSet>
 #include <QStandardItemModel>
 #include <QVBoxLayout>
+#include <algorithm>
 #include <libcockatrice/card/database/card_database_manager.h>
 #include <libcockatrice/settings/visual_deck_storage_settings.h>
 
 DeckPreviewWidget::DeckPreviewWidget(QWidget *_parent,
                                      VisualDeckStorageWidget *_visualDeckStorageWidget,
+                                     VisualDeckStorageModel *model,
                                      const QString &_filePath)
-    : QWidget(_parent), visualDeckStorageWidget(_visualDeckStorageWidget), filePath(_filePath),
-      colorIdentityWidget(nullptr), deckTagsDisplayWidget(nullptr)
+    : QWidget(_parent), visualDeckStorageWidget(_visualDeckStorageWidget), model_(model), filePath(_filePath)
 {
     layout = new QVBoxLayout(this);
     setLayout(layout);
 
-    deckLoader = new DeckLoader(this);
-    connect(deckLoader, &DeckLoader::loadFinished, this, &DeckPreviewWidget::initializeUi);
-    //! \todo Batch tag refresh: count finished deck loads and refresh tags once all decks are loaded.
-    // Currently expensive: refreshes on each individual deck load instead of once at the end.
-    connect(deckLoader, &DeckLoader::loadFinished, visualDeckStorageWidget->tagFilterWidget,
-            &VisualDeckStorageTagFilterWidget::refreshTags);
-    deckLoader->loadFromFileAsync(filePath, DeckFileFormat::getFormatFromName(filePath), false);
-
-    bannerCardDisplayWidget =
+    auto *pictureWidget =
         new DeckPreviewCardPictureWidget(this, false, visualDeckStorageWidget->deckPreviewSelectionAnimationEnabled);
-
-    connect(bannerCardDisplayWidget, &DeckPreviewCardPictureWidget::imageClicked, this,
-            &DeckPreviewWidget::imageClickedEvent);
-    connect(bannerCardDisplayWidget, &DeckPreviewCardPictureWidget::imageDoubleClicked, this,
+    pictureWidget->setFontSize(24);
+    connect(pictureWidget, &DeckPreviewCardPictureWidget::imageClicked, this, &DeckPreviewWidget::imageClickedEvent);
+    connect(pictureWidget, &DeckPreviewCardPictureWidget::imageDoubleClicked, this,
             &DeckPreviewWidget::imageDoubleClickedEvent);
+    bannerCardDisplayWidget = pictureWidget;
+
+    colorIdentityWidget = new ColorIdentityWidget(this);
+    deckTagsDisplayWidget = new DeckPreviewDeckTagsDisplayWidget(this);
+    connect(deckTagsDisplayWidget, &DeckPreviewDeckTagsDisplayWidget::tagsChanged, this, &DeckPreviewWidget::setTags);
+    deckTagsDisplayWidget->setKnownTagsProvider(
+        [this] { return visualDeckStorageWidget->tagFilterWidget->getAllKnownTags(); });
+    deckTagsDisplayWidget->setConversionPromptHandler([this] { return promptFileConversionIfRequired(); });
+
+    bannerCardLabel = new QLabel(this);
+    bannerCardLabel->setObjectName("bannerCardLabel");
+    bannerCardComboBox = new QComboBox(this);
+    bannerCardComboBox->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
+    bannerCardComboBox->setObjectName("bannerCardComboBox");
+    bannerCardComboBox->installEventFilter(new NoScrollFilter(bannerCardComboBox));
+    connect(bannerCardComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &DeckPreviewWidget::setBannerCard);
+
+    // Apply the initial visibility settings and keep them in sync while they change.
+    updateColorIdentityVisibility(
+        SettingsCache::instance().visualDeckStorage().getVisualDeckStorageShowColorIdentity());
+    updateBannerCardComboBoxVisibility(
+        SettingsCache::instance().visualDeckStorage().getVisualDeckStorageShowBannerCardComboBox());
+    updateTagsVisibility(SettingsCache::instance().visualDeckStorage().getVisualDeckStorageShowTagsOnDeckPreviews());
 
     connect(&SettingsCache::instance().visualDeckStorage(),
             &VisualDeckStorageSettings::visualDeckStorageShowColorIdentityChanged, this,
@@ -56,6 +78,15 @@ DeckPreviewWidget::DeckPreviewWidget(QWidget *_parent,
             &DeckPreviewWidget::refreshBannerCardToolTip);
 
     layout->addWidget(bannerCardDisplayWidget);
+    layout->addWidget(colorIdentityWidget);
+    layout->addWidget(deckTagsDisplayWidget);
+    layout->addWidget(bannerCardLabel);
+    layout->addWidget(bannerCardComboBox);
+
+    connect(model_, &QAbstractItemModel::dataChanged, this, &DeckPreviewWidget::syncFromModel);
+
+    retranslateUi();
+    syncFromModel();
 }
 
 void DeckPreviewWidget::retranslateUi()
@@ -79,83 +110,28 @@ void DeckPreviewWidget::enterEvent(QEnterEvent *event)
 {
     QWidget::enterEvent(event);
 
-    // don't do reloads until widgets have been created
-    if (bannerCardComboBox != nullptr) {
-        reloadIfModified();
+    // Don't do reloads until the deck has actually been loaded once.
+    reloadIfModified();
+}
+
+/**
+ * @brief The row of this deck in the source model, or -1 if it no longer exists.
+ */
+int DeckPreviewWidget::row() const
+{
+    return model_->rowForFilePath(filePath);
+}
+
+/**
+ * @brief The display name is given by the deck name, or the filename if the deck name is not set.
+ */
+QString DeckPreviewWidget::getDisplayName() const
+{
+    const int r = row();
+    if (r == -1) {
+        return {};
     }
-}
-
-/**
- * @brief Sets the lastModifiedTime to the value given by the file.
- */
-void DeckPreviewWidget::updateLastModifiedTime()
-{
-    QFileInfo fileInfo(filePath);
-    lastModifiedTime = fileInfo.lastModified();
-}
-
-/**
- * @brief Writes the current contents of the deck to file. Updates the lastModifiedTime afterward.
- */
-void DeckPreviewWidget::writeDeckToFile()
-{
-    DeckLoader::saveToFile(deckLoader->getDeck());
-    updateLastModifiedTime();
-}
-
-void DeckPreviewWidget::initializeUi(const bool deckLoadSuccess)
-{
-    if (!deckLoadSuccess) {
-        return;
-    }
-
-    QFileInfo fileInfo(filePath);
-    lastModifiedTime = fileInfo.lastModified();
-
-    bannerCardDisplayWidget->setFontSize(24);
-    setFilePath(deckLoader->getDeck().lastLoadInfo.fileName);
-
-    colorIdentityWidget = new ColorIdentityWidget(this);
-    deckTagsDisplayWidget = new DeckPreviewDeckTagsDisplayWidget(this);
-    connect(deckTagsDisplayWidget, &DeckPreviewDeckTagsDisplayWidget::tagsChanged, this, &DeckPreviewWidget::setTags);
-
-    bannerCardLabel = new QLabel(this);
-    bannerCardLabel->setObjectName("bannerCardLabel");
-    bannerCardComboBox = new QComboBox(this);
-    bannerCardComboBox->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
-    bannerCardComboBox->setObjectName("bannerCardComboBox");
-    bannerCardComboBox->installEventFilter(new NoScrollFilter(bannerCardComboBox));
-    connect(bannerCardComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
-            &DeckPreviewWidget::setBannerCard);
-
-    updateColorIdentityVisibility(
-        SettingsCache::instance().visualDeckStorage().getVisualDeckStorageShowColorIdentity());
-    updateBannerCardComboBoxVisibility(
-        SettingsCache::instance().visualDeckStorage().getVisualDeckStorageShowBannerCardComboBox());
-    updateTagsVisibility(SettingsCache::instance().visualDeckStorage().getVisualDeckStorageShowTagsOnDeckPreviews());
-
-    layout->addWidget(colorIdentityWidget);
-    layout->addWidget(deckTagsDisplayWidget);
-    layout->addWidget(bannerCardLabel);
-    layout->addWidget(bannerCardComboBox);
-
-    retranslateUi();
-    resyncWidgets();
-}
-
-/**
- * @brief Syncs the contents of the child widgets with the current deck.
- */
-void DeckPreviewWidget::resyncWidgets()
-{
-    auto bannerCardRef = deckLoader->getDeck().deckList.getBannerCard();
-    auto bannerCard = bannerCardRef.name.isEmpty() ? ExactCard() : CardDatabaseManager::query()->getCard(bannerCardRef);
-
-    bannerCardDisplayWidget->setCard(bannerCard);
-    refreshBannerCardText();
-    updateBannerCardComboBox(bannerCardRef.name);
-    colorIdentityWidget->setColorIdentity(getColorIdentity());
-    deckTagsDisplayWidget->setTags(deckLoader->getDeck().deckList.getTags());
+    return model_->dataForRow(r).displayName;
 }
 
 /**
@@ -163,33 +139,36 @@ void DeckPreviewWidget::resyncWidgets()
  */
 void DeckPreviewWidget::reloadIfModified()
 {
-    QFileInfo fileInfo(filePath);
-    QDateTime newLastModifiedTime = fileInfo.lastModified();
-
-    if (!newLastModifiedTime.isValid() || newLastModifiedTime <= lastModifiedTime) {
+    const int r = row();
+    if (r == -1 || !model_->dataForRow(r).loadSucceeded) {
         return;
     }
 
-    bool success = deckLoader->reload();
-
-    if (success) {
-        fileInfo.refresh();
-        lastModifiedTime = fileInfo.lastModified();
-        resyncWidgets();
-    }
+    model_->reloadIfModified(r);
 }
 
-void DeckPreviewWidget::updateVisibility()
+/**
+ * @brief Syncs the contents of the child widgets with the current row's data.
+ */
+void DeckPreviewWidget::syncFromModel()
 {
-    setHidden(!checkVisibility());
-}
-
-bool DeckPreviewWidget::checkVisibility() const
-{
-    if (filteredBySearch || filteredByColor || filteredByTags) {
-        return false;
+    const int r = row();
+    if (r == -1) {
+        return;
     }
-    return true;
+
+    const DeckPreviewData &data = model_->dataForRow(r);
+    filePath = data.filePath;
+
+    const CardRef bannerCardRef = data.deck.deckList.getBannerCard();
+    const ExactCard bannerCard =
+        bannerCardRef.name.isEmpty() ? ExactCard() : CardDatabaseManager::query()->getCard(bannerCardRef);
+
+    bannerCardDisplayWidget->setCard(bannerCard);
+    refreshBannerCardText();
+    updateBannerCardComboBox(bannerCardRef.name);
+    colorIdentityWidget->setColorIdentity(data.colorIdentity);
+    deckTagsDisplayWidget->setTags(data.tags);
 }
 
 void DeckPreviewWidget::updateColorIdentityVisibility(bool visible)
@@ -229,51 +208,6 @@ void DeckPreviewWidget::updateTagsVisibility(bool visible)
     }
 }
 
-QString DeckPreviewWidget::getColorIdentity()
-{
-    QStringList cardList = deckLoader->getDeck().deckList.getCardList({DECK_ZONE_MAIN, DECK_ZONE_SIDE});
-    if (cardList.isEmpty()) {
-        return {};
-    }
-
-    QSet<QChar> colorSet; // A set to collect unique color symbols (e.g., W, U, B, R, G)
-
-    for (const QString &cardName : cardList) {
-        CardInfoPtr currentCard = CardDatabaseManager::query()->getCardInfo(cardName);
-        if (currentCard) {
-            QString colors = currentCard->getColors(); // Assuming this returns something like "WUB"
-            for (const QChar &color : colors) {
-                colorSet.insert(color);
-            }
-        }
-    }
-
-    // Ensure the color identity is in WUBRG order
-    QString colorIdentity;
-    const QString wubrgOrder = "WUBRG";
-    for (const QChar &color : wubrgOrder) {
-        if (colorSet.contains(color)) {
-            colorIdentity.append(color);
-        }
-    }
-
-    return colorIdentity;
-}
-
-/**
- * The display name is given by the deck name, or the filename if the deck name is not set.
- */
-QString DeckPreviewWidget::getDisplayName() const
-{
-    QString deckName = deckLoader->getDeck().deckList.getName();
-    return !deckName.isEmpty() ? deckName : QFileInfo(deckLoader->getDeck().lastLoadInfo.fileName).fileName();
-}
-
-void DeckPreviewWidget::setFilePath(const QString &_filePath)
-{
-    filePath = _filePath;
-}
-
 /**
  * Refreshes the banner card text.
  * This also calls `refreshBannerCardToolTip`, since those two often need to be updated together.
@@ -310,11 +244,15 @@ void DeckPreviewWidget::updateBannerCardComboBox(const QString &currentText)
     // Prepare the new items with deduplication
     QSet<QPair<QString, QString>> bannerCardSet;
 
-    QList<const DecklistCardNode *> cardsInDeck = deckLoader->getDeck().deckList.getCardNodes();
+    const int r = row();
+    if (r != -1) {
+        const DeckList &deckList = model_->dataForRow(r).deck.deckList;
+        const QList<const DecklistCardNode *> cardsInDeck = deckList.getCardNodes();
 
-    for (auto currentCard : cardsInDeck) {
-        for (int k = 0; k < currentCard->getNumber(); ++k) {
-            bannerCardSet.insert(QPair<QString, QString>(currentCard->getName(), currentCard->getCardProviderId()));
+        for (auto currentCard : cardsInDeck) {
+            for (int k = 0; k < currentCard->getNumber(); ++k) {
+                bannerCardSet.insert(QPair<QString, QString>(currentCard->getName(), currentCard->getCardProviderId()));
+            }
         }
     }
 
@@ -344,7 +282,9 @@ void DeckPreviewWidget::updateBannerCardComboBox(const QString &currentText)
         bannerCardComboBox->setCurrentIndex(restoredIndex);
     } else {
         // Add a placeholder "-" and set it as the current selection
-        int bannerIndex = bannerCardComboBox->findText(deckLoader->getDeck().deckList.getBannerCard().name);
+        const QString currentBannerCardName =
+            r == -1 ? QString() : model_->dataForRow(r).deck.deckList.getBannerCard().name;
+        int bannerIndex = bannerCardComboBox->findText(currentBannerCardName);
         if (bannerIndex != -1) {
             bannerCardComboBox->setCurrentIndex(bannerIndex);
         } else {
@@ -362,8 +302,11 @@ void DeckPreviewWidget::setBannerCard(int /* changedIndex */)
 {
     auto [name, id] = bannerCardComboBox->currentData().value<QPair<QString, QString>>();
     CardRef cardRef = {name, id};
-    deckLoader->getDeck().deckList.setBannerCard(cardRef);
-    writeDeckToFile();
+    const int r = row();
+    if (r == -1) {
+        return;
+    }
+    model_->setBannerCard(r, cardRef);
     bannerCardDisplayWidget->setCard(CardDatabaseManager::query()->getCard(cardRef));
 }
 
@@ -385,17 +328,24 @@ void DeckPreviewWidget::imageDoubleClickedEvent(QMouseEvent *event, DeckPreviewC
 
 void DeckPreviewWidget::setTags(const QStringList &tags)
 {
-    deckLoader->getDeck().deckList.setTags(tags);
-    writeDeckToFile();
+    const int r = row();
+    if (r != -1) {
+        model_->setTags(r, tags);
+    }
 }
 
 QMenu *DeckPreviewWidget::createRightClickMenu()
 {
+    const int r = row();
+
     auto *menu = new QMenu(this);
     menu->setAttribute(Qt::WA_DeleteOnClose);
 
-    connect(menu->addAction(tr("Open in deck editor")), &QAction::triggered, this,
-            [this] { emit openDeckEditor(deckLoader->getDeck()); });
+    connect(menu->addAction(tr("Open in deck editor")), &QAction::triggered, this, [this, r] {
+        if (r != -1) {
+            emit openDeckEditor(model_->deckForRow(r));
+        }
+    });
 
     connect(menu->addAction(tr("Edit Tags")), &QAction::triggered, deckTagsDisplayWidget,
             &DeckPreviewDeckTagsDisplayWidget::openTagEditDlg);
@@ -408,14 +358,26 @@ QMenu *DeckPreviewWidget::createRightClickMenu()
 
     auto saveToClipboardMenu = menu->addMenu(tr("Save Deck to Clipboard"));
 
-    connect(saveToClipboardMenu->addAction(tr("Annotated")), &QAction::triggered, this,
-            [this] { DeckLoader::saveToClipboard(deckLoader->getDeck().deckList, true, true); });
-    connect(saveToClipboardMenu->addAction(tr("Annotated (No set info)")), &QAction::triggered, this,
-            [this] { DeckLoader::saveToClipboard(deckLoader->getDeck().deckList, true, false); });
-    connect(saveToClipboardMenu->addAction(tr("Not Annotated")), &QAction::triggered, this,
-            [this] { DeckLoader::saveToClipboard(deckLoader->getDeck().deckList, false, true); });
-    connect(saveToClipboardMenu->addAction(tr("Not Annotated (No set info)")), &QAction::triggered, this,
-            [this] { DeckLoader::saveToClipboard(deckLoader->getDeck().deckList, false, false); });
+    connect(saveToClipboardMenu->addAction(tr("Annotated")), &QAction::triggered, this, [this, r] {
+        if (r != -1) {
+            DeckLoader::saveToClipboard(model_->dataForRow(r).deck.deckList, true, true);
+        }
+    });
+    connect(saveToClipboardMenu->addAction(tr("Annotated (No set info)")), &QAction::triggered, this, [this, r] {
+        if (r != -1) {
+            DeckLoader::saveToClipboard(model_->dataForRow(r).deck.deckList, true, false);
+        }
+    });
+    connect(saveToClipboardMenu->addAction(tr("Not Annotated")), &QAction::triggered, this, [this, r] {
+        if (r != -1) {
+            DeckLoader::saveToClipboard(model_->dataForRow(r).deck.deckList, false, true);
+        }
+    });
+    connect(saveToClipboardMenu->addAction(tr("Not Annotated (No set info)")), &QAction::triggered, this, [this, r] {
+        if (r != -1) {
+            DeckLoader::saveToClipboard(model_->dataForRow(r).deck.deckList, false, false);
+        }
+    });
 
     menu->addSeparator();
 
@@ -450,57 +412,58 @@ void DeckPreviewWidget::addSetBannerCardMenu(QMenu *menu)
 
 void DeckPreviewWidget::actRenameDeck()
 {
+    const int r = row();
+    if (r == -1) {
+        return;
+    }
+
     // read input
-    const QString oldName = deckLoader->getDeck().deckList.getName();
+    const QString oldName = model_->dataForRow(r).deckName;
 
     bool ok;
-    QString newName = QInputDialog::getText(this, "Rename deck", tr("New name:"), QLineEdit::Normal, oldName, &ok);
+    QString newName = QInputDialog::getText(this, tr("Rename deck"), tr("New name:"), QLineEdit::Normal, oldName, &ok);
     if (!ok || oldName == newName) {
         return;
     }
 
     // write change
-    deckLoader->getDeck().deckList.setName(newName);
-    writeDeckToFile();
+    model_->renameDeck(r, newName);
 
-    // update VDS
-    refreshBannerCardText();
+    // The banner card text updates via the model's dataChanged signal.
 }
 
 void DeckPreviewWidget::actRenameFile()
 {
+    const int r = row();
+    if (r == -1) {
+        return;
+    }
+
     // read input
     const auto info = QFileInfo(filePath);
     const QString oldName = info.baseName();
 
     bool ok;
-    QString newName = QInputDialog::getText(this, "Rename file", tr("New name:"), QLineEdit::Normal, oldName, &ok);
+    QString newName = QInputDialog::getText(this, tr("Rename file"), tr("New name:"), QLineEdit::Normal, oldName, &ok);
     if (!ok || newName.isEmpty() || oldName == newName) {
         return;
     }
 
-    QString newFileName = newName;
-    if (!info.suffix().isEmpty()) {
-        newFileName += "." + info.suffix();
-    }
-
     // write change
-    const QString newFilePath = QFileInfo(info.dir(), newFileName).filePath();
-    if (!QFile::rename(info.filePath(), newFilePath)) {
+    if (!model_->renameFile(r, newName)) {
         QMessageBox::critical(this, tr("Error"), tr("Rename failed"));
-        return;
     }
 
-    deckLoader->getDeck().lastLoadInfo.fileName = newFilePath;
-    setFilePath(newFilePath);
-
-    // update VDS
-    updateLastModifiedTime();
-    refreshBannerCardText();
+    // The file path and banner card text update via the model's signals.
 }
 
 void DeckPreviewWidget::actDeleteFile()
 {
+    const int r = row();
+    if (r == -1) {
+        return;
+    }
+
     // read input
     auto res = QMessageBox::warning(this, tr("Delete file"), tr("Are you sure you want to delete the selected file?"),
                                     QMessageBox::Yes | QMessageBox::No);
@@ -509,11 +472,74 @@ void DeckPreviewWidget::actDeleteFile()
     }
 
     // write change
-    if (!QFile::remove(QFileInfo(filePath).filePath())) {
+    if (!model_->deleteFile(r)) {
         QMessageBox::critical(this, tr("Error"), tr("Delete failed"));
-        return;
     }
 
-    // update VDS
-    this->deleteLater();
+    // The folder widget removes this preview once the row is gone.
+}
+
+static bool confirmOverwriteIfExists(QWidget *parent, const QString &filePath)
+{
+    QFileInfo fileInfo(filePath);
+    QString newFileName = QDir::toNativeSeparators(fileInfo.path() + "/" + fileInfo.completeBaseName() + ".cod");
+
+    if (QFile::exists(newFileName)) {
+        QMessageBox::StandardButton reply =
+            QMessageBox::question(parent, QObject::tr("Overwrite Existing File?"),
+                                  QObject::tr("A .cod version of this deck already exists. Overwrite it?"),
+                                  QMessageBox::Yes | QMessageBox::No);
+        return reply == QMessageBox::Yes;
+    }
+    return true; // Safe to proceed
+}
+
+/**
+ * Checks if the deck's file format supports tags.
+ * If not, then prompt the user for file conversion.
+ * @return whether the resulting file can support adding tags
+ */
+bool DeckPreviewWidget::promptFileConversionIfRequired()
+{
+    if (DeckFileFormat::getFormatFromName(filePath) == DeckFileFormat::Cockatrice) {
+        return true;
+    }
+
+    // Retrieve saved preference if the prompt is disabled
+    if (!SettingsCache::instance().visualDeckStorage().getVisualDeckStoragePromptForConversion()) {
+        if (!SettingsCache::instance().visualDeckStorage().getVisualDeckStorageAlwaysConvert()) {
+            return false;
+        }
+
+        if (!confirmOverwriteIfExists(this, filePath)) {
+            return false;
+        }
+
+        model_->convertToCockatriceFormat(row());
+        return true;
+    }
+
+    // Show the dialog to the user
+    DialogConvertDeckToCodFormat conversionDialog(this);
+    if (conversionDialog.exec() != QDialog::Accepted) {
+        SettingsCache::instance().visualDeckStorage().setVisualDeckStoragePromptForConversion(
+            !conversionDialog.dontAskAgain());
+        SettingsCache::instance().visualDeckStorage().setVisualDeckStorageAlwaysConvert(false);
+
+        return false;
+    }
+
+    // Try to convert file
+    if (!confirmOverwriteIfExists(this, filePath)) {
+        return false;
+    }
+
+    model_->convertToCockatriceFormat(row());
+
+    if (conversionDialog.dontAskAgain()) {
+        SettingsCache::instance().visualDeckStorage().setVisualDeckStoragePromptForConversion(false);
+        SettingsCache::instance().visualDeckStorage().setVisualDeckStorageAlwaysConvert(true);
+    }
+
+    return true;
 }

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.h
@@ -2,16 +2,12 @@
  * @file deck_preview_widget.h
  * @ingroup VisualDeckPreviewWidgets
  */
-//! \todo Document this file.
 
 #ifndef DECK_PREVIEW_WIDGET_H
 #define DECK_PREVIEW_WIDGET_H
 
-#include "../../../deck_loader/deck_loader.h"
-#include "../../cards/additional_info/color_identity_widget.h"
 #include "../../cards/deck_preview_card_picture_widget.h"
-#include "../visual_deck_storage_widget.h"
-#include "deck_preview_deck_tags_display_widget.h"
+#include "../visual_deck_storage_model.h"
 
 #include <QAbstractItemView>
 #include <QApplication>
@@ -20,72 +16,80 @@
 #include <QVBoxLayout>
 #include <QWidget>
 
+class QEnterEvent;
+class QLabel;
 class QMenu;
-class VisualDeckStorageWidget;
+class QMouseEvent;
+class ColorIdentityWidget;
+class DeckPreviewCardPictureWidget;
 class DeckPreviewDeckTagsDisplayWidget;
+class VisualDeckStorageModel;
+class VisualDeckStorageWidget;
 
 class DeckPreviewWidget final : public QWidget
 {
     Q_OBJECT
 public:
-    explicit DeckPreviewWidget(QWidget *_parent,
+    explicit DeckPreviewWidget(QWidget *parent,
                                VisualDeckStorageWidget *_visualDeckStorageWidget,
+                               VisualDeckStorageModel *model,
                                const QString &_filePath);
     void retranslateUi();
-    QString getColorIdentity();
-    [[nodiscard]] QString getDisplayName() const;
 
-    VisualDeckStorageWidget *visualDeckStorageWidget;
-    QVBoxLayout *layout;
-    QString filePath;
-    QDateTime lastModifiedTime;
-    DeckLoader *deckLoader;
-    DeckPreviewCardPictureWidget *bannerCardDisplayWidget = nullptr;
-    ColorIdentityWidget *colorIdentityWidget = nullptr;
-    DeckPreviewDeckTagsDisplayWidget *deckTagsDisplayWidget = nullptr;
-    QLabel *bannerCardLabel = nullptr;
-    QComboBox *bannerCardComboBox = nullptr;
-    bool filteredBySearch = false;
-    bool filteredByColor = false;
-    bool filteredByTags = false;
-    [[nodiscard]] bool checkVisibility() const;
+    /**
+     * @brief The banner card picture; the parent widget wires its size to the card size setting.
+     */
+    DeckPreviewCardPictureWidget *bannerCardDisplayWidget;
 
 signals:
     void deckLoadRequested(const QString &filePath);
     void openDeckEditor(const LoadedDeck &deck);
 
 public slots:
-    void setFilePath(const QString &filePath);
-    void refreshBannerCardText();
-    void refreshBannerCardToolTip();
-    void updateBannerCardComboBox(const QString &currentText);
-    void setBannerCard(int);
-    void imageClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance);
-    void imageDoubleClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance);
-    void initializeUi(bool deckLoadSuccess);
-    void resyncWidgets();
+    /**
+     * @brief Re-reads the row's data from the model and syncs every child widget.
+     * Connected to the model's dataChanged signal.
+     */
+    void syncFromModel();
+
+    /**
+     * @brief Reloads the deck file if its modification time is newer than the stored one.
+     */
     void reloadIfModified();
-    void updateVisibility();
+    void refreshBannerCardToolTip();
     void updateColorIdentityVisibility(bool visible);
     void updateBannerCardComboBoxVisibility(bool visible);
     void updateTagsVisibility(bool visible);
-    void resizeEvent(QResizeEvent *event) override;
+    void setBannerCard(int);
+    void setTags(const QStringList &tags);
 
 protected:
     void enterEvent(QEnterEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
 
 private:
-    void updateLastModifiedTime();
-    void writeDeckToFile();
+    [[nodiscard]] int row() const;
+    [[nodiscard]] QString getDisplayName() const;
+    void refreshBannerCardText();
+    void updateBannerCardComboBox(const QString &currentText);
+    bool promptFileConversionIfRequired();
     QMenu *createRightClickMenu();
     void addSetBannerCardMenu(QMenu *menu);
-
-private slots:
-    void setTags(const QStringList &tags);
+    void imageClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance);
+    void imageDoubleClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance);
 
     void actRenameDeck();
     void actRenameFile();
     void actDeleteFile();
+
+    VisualDeckStorageWidget *visualDeckStorageWidget;
+    VisualDeckStorageModel *model_;
+    QString filePath;
+    QVBoxLayout *layout;
+    ColorIdentityWidget *colorIdentityWidget;
+    DeckPreviewDeckTagsDisplayWidget *deckTagsDisplayWidget;
+    QLabel *bannerCardLabel;
+    QComboBox *bannerCardComboBox;
 };
 
 class NoScrollFilter : public QObject

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
@@ -1,20 +1,26 @@
 #include "visual_deck_storage_folder_display_widget.h"
 
-#include "../../../client/settings/cache_settings.h"
+#include "../cards/card_info_picture_widget.h"
+#include "../general/display/banner_widget.h"
+#include "../general/layout_containers/flow_widget.h"
 #include "deck_preview/deck_preview_widget.h"
+#include "visual_deck_storage_model.h"
+#include "visual_deck_storage_quick_settings_widget.h"
+#include "visual_deck_storage_sort_filter_proxy_model.h"
 #include "visual_deck_storage_widget.h"
 
-#include <QDirIterator>
-#include <QMouseEvent>
-#include <libcockatrice/settings/paths_settings.h>
+#include <QSet>
+#include <QTimer>
+#include <QVBoxLayout>
 
 VisualDeckStorageFolderDisplayWidget::VisualDeckStorageFolderDisplayWidget(
     QWidget *parent,
     VisualDeckStorageWidget *_visualDeckStorageWidget,
-    QString _filePath,
+    const QString &_folderPath,
     bool canBeHidden,
     bool _showFolders)
-    : QWidget(parent), showFolders(_showFolders), visualDeckStorageWidget(_visualDeckStorageWidget), filePath(_filePath)
+    : QWidget(parent), showFolders(_showFolders), folderPath(_folderPath),
+      visualDeckStorageWidget(_visualDeckStorageWidget)
 {
     layout = new QVBoxLayout(this);
     setLayout(layout);
@@ -22,6 +28,9 @@ VisualDeckStorageFolderDisplayWidget::VisualDeckStorageFolderDisplayWidget(
     header = new BannerWidget(this, "");
     header->setClickable(canBeHidden);
     header->setHidden(!showFolders);
+
+    const QString bannerText = folderPath.isEmpty() ? tr("Deck Storage") : folderPath;
+    header->setText(bannerText);
     layout->addWidget(header);
 
     container = new QWidget(this);
@@ -35,192 +44,214 @@ VisualDeckStorageFolderDisplayWidget::VisualDeckStorageFolderDisplayWidget(
     flowWidget = new FlowWidget(this, Qt::Horizontal, Qt::ScrollBarAlwaysOff, Qt::ScrollBarAlwaysOff);
     containerLayout->addWidget(flowWidget);
 
-    createWidgetsForFiles();
-    createWidgetsForFolders();
+    auto *proxy = visualDeckStorageWidget->proxyModel();
+    // A burst of proxy changes (one dataChanged per finished deck load, plus the filter
+    // invalidations) coalesces into a single reconcile, so a scan of many decks doesn't
+    // rebuild the flow layout once per deck.
+    connect(proxy, &QAbstractItemModel::modelReset, this, &VisualDeckStorageFolderDisplayWidget::scheduleReconcile);
+    connect(proxy, &QAbstractItemModel::rowsInserted, this, &VisualDeckStorageFolderDisplayWidget::scheduleReconcile);
+    connect(proxy, &QAbstractItemModel::rowsRemoved, this, &VisualDeckStorageFolderDisplayWidget::scheduleReconcile);
+    connect(proxy, &QAbstractItemModel::dataChanged, this, &VisualDeckStorageFolderDisplayWidget::scheduleReconcile);
+    connect(proxy, &QAbstractItemModel::layoutChanged, this, &VisualDeckStorageFolderDisplayWidget::scheduleReconcile);
 
-    refreshUi();
+    reconcileTimer = new QTimer(this);
+    reconcileTimer->setSingleShot(true);
+    reconcileTimer->setInterval(150);
+    connect(reconcileTimer, &QTimer::timeout, this, &VisualDeckStorageFolderDisplayWidget::reconcile);
+
+    reconcile();
 }
 
-void VisualDeckStorageFolderDisplayWidget::refreshUi()
+void VisualDeckStorageFolderDisplayWidget::scheduleReconcile()
 {
-    QString bannerText = tr("Deck Storage");
-    QString deckPath = SettingsCache::instance().paths().getDeckPath();
-    if (filePath != deckPath) {
-        QString relativePath = filePath;
-
-        if (filePath.startsWith(deckPath)) {
-            relativePath = filePath.mid(deckPath.length()); // Remove the deckPath prefix
-            if (relativePath.startsWith('/')) {
-                relativePath.remove(0, 1); // Remove leading '/' if it exists
-            }
-        }
-
-        bannerText = relativePath;
-    }
-    header->setText(bannerText);
+    reconcileTimer->start();
 }
 
 /**
- * Gets all files in the directory that have an accepted decklist file extension
- *
- * @param filePath The directory to search through
- * @param recursive Whether to search through subdirectories
+ * @brief Re-reads the proxy and rebuilds the deck previews and subfolder widgets to match.
  */
-static QStringList getAllFiles(const QString &filePath, bool recursive)
+void VisualDeckStorageFolderDisplayWidget::reconcile()
 {
-    QStringList allFiles;
-
-    // QDirIterator with QDir::Files ensures only files are listed (no directories)
-    auto flags =
-        recursive ? QDirIterator::Subdirectories | QDirIterator::FollowSymlinks : QDirIterator::NoIteratorFlags;
-    QDirIterator it(filePath, DeckLoader::ACCEPTED_FILE_EXTENSIONS, QDir::Files, flags);
-
-    while (it.hasNext()) {
-        allFiles << it.next(); // Add each file path to the list
-    }
-
-    return allFiles;
+    reconcileDecks();
+    createSubFolderWidgets();
+    refreshVisibility();
 }
 
-void VisualDeckStorageFolderDisplayWidget::createWidgetsForFiles()
+/**
+ * @brief Reconciles the deck preview widgets in the flow layout with the accepted proxy rows.
+ *
+ * Decks are keyed by file path so that already-created preview widgets are reused
+ * (their banner combo box, tag editor state, etc. is preserved) whenever possible.
+ */
+void VisualDeckStorageFolderDisplayWidget::reconcileDecks()
 {
-    QList<DeckPreviewWidget *> allDecks;
-    for (const QString &file : getAllFiles(filePath, !showFolders)) {
-        auto *display = new DeckPreviewWidget(flowWidget, visualDeckStorageWidget, file);
+    auto *proxy = visualDeckStorageWidget->proxyModel();
+    auto *model = visualDeckStorageWidget->model();
 
-        connect(display, &DeckPreviewWidget::deckLoadRequested, visualDeckStorageWidget,
-                &VisualDeckStorageWidget::deckLoadRequested);
-        connect(display, &DeckPreviewWidget::openDeckEditor, visualDeckStorageWidget,
-                &VisualDeckStorageWidget::openDeckEditor);
-        connect(visualDeckStorageWidget->settings(), &VisualDeckStorageQuickSettingsWidget::cardSizeChanged,
-                display->bannerCardDisplayWidget, &CardInfoPictureWidget::setScaleFactor);
-        display->bannerCardDisplayWidget->setScaleFactor(visualDeckStorageWidget->settings()->getCardSize());
-        allDecks.append(display);
+    // Collect the file paths this folder should display, in proxy (sorted) order.
+    QStringList desiredOrder;
+    for (int proxyRow = 0; proxyRow < proxy->rowCount(); ++proxyRow) {
+        const QModelIndex sourceIndex = proxy->mapToSource(proxy->index(proxyRow, 0));
+        if (!sourceIndex.isValid()) {
+            continue;
+        }
+
+        const DeckPreviewData &data = model->dataForRow(sourceIndex.row());
+        if (showFolders && data.folderPath != folderPath) {
+            continue;
+        }
+        desiredOrder.append(data.filePath);
     }
 
-    flowWidget->clearLayout(); // Clear existing widgets in the flow layout
+    const QSet<QString> desiredSet(desiredOrder.cbegin(), desiredOrder.cend());
 
-    for (DeckPreviewWidget *deck : allDecks) {
-        flowWidget->addWidget(deck);
+    // Drop previews of decks that no longer match.
+    for (auto it = deckWidgets.begin(); it != deckWidgets.end();) {
+        if (!desiredSet.contains(it.key())) {
+            flowWidget->removeWidget(it.value());
+            it.value()->deleteLater();
+            it = deckWidgets.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    // Create or reuse the preview widgets in the desired order.
+    QList<DeckPreviewWidget *> orderedWidgets;
+    orderedWidgets.reserve(desiredOrder.size());
+    for (const QString &filePath : desiredOrder) {
+        DeckPreviewWidget *deckPreviewWidget = deckWidgets.value(filePath, nullptr);
+        if (!deckPreviewWidget) {
+            deckPreviewWidget = new DeckPreviewWidget(flowWidget, visualDeckStorageWidget, model, filePath);
+            connect(deckPreviewWidget, &DeckPreviewWidget::deckLoadRequested, visualDeckStorageWidget,
+                    &VisualDeckStorageWidget::deckLoadRequested);
+            connect(deckPreviewWidget, &DeckPreviewWidget::openDeckEditor, visualDeckStorageWidget,
+                    &VisualDeckStorageWidget::openDeckEditor);
+            connect(visualDeckStorageWidget->settings(), &VisualDeckStorageQuickSettingsWidget::cardSizeChanged,
+                    deckPreviewWidget->bannerCardDisplayWidget, &CardInfoPictureWidget::setScaleFactor);
+            deckPreviewWidget->bannerCardDisplayWidget->setScaleFactor(
+                visualDeckStorageWidget->settings()->getCardSize());
+            deckWidgets.insert(filePath, deckPreviewWidget);
+        }
+        orderedWidgets.append(deckPreviewWidget);
+    }
+
+    // Re-add all widgets so the flow layout order matches the proxy order. Skipped when the
+    // order is unchanged so that data-only updates don't invalidate the flow layout.
+    if (desiredOrder != lastOrderedFilePaths) {
+        for (DeckPreviewWidget *deckPreviewWidget : orderedWidgets) {
+            flowWidget->removeWidget(deckPreviewWidget);
+        }
+        for (DeckPreviewWidget *deckPreviewWidget : orderedWidgets) {
+            flowWidget->addWidget(deckPreviewWidget);
+        }
+        lastOrderedFilePaths = desiredOrder;
     }
 }
 
 /**
- * Updates the visibility of this folder and all its DeckPreviewWidgets
+ * @brief Creates, removes and keeps in sync the subfolder widgets of this folder.
  *
- * @param recursive Also update the visibility of all subfolders and their DeckPreviewWidgets.
+ * Only direct child folders are created here; each child manages its own
+ * children, mirroring the folder tree on disk.
  */
-void VisualDeckStorageFolderDisplayWidget::updateVisibility(bool recursive)
-{
-    bool atLeastOneWidgetVisible = checkVisibility();
-    if (atLeastOneWidgetVisible) {
-        setVisible(true);
-        for (DeckPreviewWidget *display : flowWidget->findChildren<DeckPreviewWidget *>()) {
-            display->updateVisibility();
-        }
-        if (recursive) {
-            for (auto *subFolder : findChildren<VisualDeckStorageFolderDisplayWidget *>()) {
-                subFolder->updateVisibility(false);
-            }
-        }
-    } else {
-        setVisible(false);
-    }
-}
-
-bool VisualDeckStorageFolderDisplayWidget::checkVisibility()
-{
-    bool atLeastOneWidgetVisible = false;
-    if (flowWidget) {
-        // Iterate through all DeckPreviewWidgets
-        for (DeckPreviewWidget *display : flowWidget->findChildren<DeckPreviewWidget *>()) {
-            if (display->checkVisibility()) {
-                atLeastOneWidgetVisible = true;
-            }
-        }
-    }
-    for (VisualDeckStorageFolderDisplayWidget *subFolder : findChildren<VisualDeckStorageFolderDisplayWidget *>()) {
-        if (subFolder->checkVisibility()) {
-            atLeastOneWidgetVisible = true;
-        }
-    }
-    return atLeastOneWidgetVisible;
-}
-
-static QStringList getAllSubFolders(const QString &filePath)
-{
-    QStringList allFolders;
-
-    // QDirIterator with QDir::Files ensures only files are listed (no directories)
-    QDirIterator it(filePath, QDir::Dirs | QDir::NoDotAndDotDot);
-
-    while (it.hasNext()) {
-        allFolders << it.next(); // Add each file path to the list
-    }
-
-    return allFolders;
-}
-
-void VisualDeckStorageFolderDisplayWidget::createWidgetsForFolders()
+void VisualDeckStorageFolderDisplayWidget::createSubFolderWidgets()
 {
     if (!showFolders) {
         return;
     }
 
-    for (const QString &dir : getAllSubFolders(filePath)) {
-        auto *display = new VisualDeckStorageFolderDisplayWidget(this, visualDeckStorageWidget, dir, true, showFolders);
-        containerLayout->addWidget(display);
+    const QStringList children = childFolderPaths();
+
+    for (auto it = subFolderWidgets.begin(); it != subFolderWidgets.end();) {
+        if (!children.contains(it.key())) {
+            containerLayout->removeWidget(it.value());
+            it.value()->deleteLater();
+            it = subFolderWidgets.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    for (const QString &child : children) {
+        if (subFolderWidgets.contains(child)) {
+            continue;
+        }
+
+        auto *subFolderWidget =
+            new VisualDeckStorageFolderDisplayWidget(this, visualDeckStorageWidget, child, true, showFolders);
+        connect(subFolderWidget, &VisualDeckStorageFolderDisplayWidget::contentVisibilityChanged, this,
+                &VisualDeckStorageFolderDisplayWidget::refreshVisibility);
+        containerLayout->addWidget(subFolderWidget);
+        subFolderWidgets.insert(child, subFolderWidget);
     }
 }
 
 void VisualDeckStorageFolderDisplayWidget::updateShowFolders(bool enabled)
 {
     showFolders = enabled;
+    header->setHidden(!showFolders);
 
     if (!showFolders) {
-        flattenFolderStructure();
-    } else {
-        // if setting was switched from disabled to enabled, we assume that there aren't any existing subfolders
-        createWidgetsForFiles();
-        createWidgetsForFolders();
+        for (auto it = subFolderWidgets.begin(); it != subFolderWidgets.end(); ++it) {
+            containerLayout->removeWidget(it.value());
+            it.value()->deleteLater();
+        }
+        subFolderWidgets.clear();
     }
 
-    header->setHidden(!showFolders);
+    reconcile();
 }
 
 /**
- * Steals all DeckPreviewWidgets from this widget's nested subfolders, and deletes those subfolders
+ * @brief Hides the folder when it contains nothing visible, and reports the change upward.
  */
-void VisualDeckStorageFolderDisplayWidget::flattenFolderStructure()
+void VisualDeckStorageFolderDisplayWidget::refreshVisibility()
 {
-    for (auto *subFolder : findChildren<VisualDeckStorageFolderDisplayWidget *>()) {
-        // steal all DeckPreviewWidgets from the subfolder
-        for (auto *deck : subFolder->getFlowWidget()->findChildren<DeckPreviewWidget *>()) {
-            flowWidget->addWidget(deck);
-        }
-
-        // delete the subfolder
-        subFolder->deleteLater();
+    const bool shouldBeVisible = hasContent();
+    if (isHidden() == !shouldBeVisible) {
+        return;
     }
+    setHidden(!shouldBeVisible);
+    emit contentVisibilityChanged();
 }
 
-QStringList VisualDeckStorageFolderDisplayWidget::gatherAllTagsFromFlowWidget() const
+/**
+ * @brief Whether this folder shows any deck previews or has any visible subfolder.
+ */
+bool VisualDeckStorageFolderDisplayWidget::hasContent() const
 {
-    QStringList allTags;
+    if (!deckWidgets.isEmpty()) {
+        return true;
+    }
 
-    if (flowWidget) {
-        // Iterate through all DeckPreviewWidgets
-        for (DeckPreviewWidget *display : flowWidget->findChildren<DeckPreviewWidget *>()) {
-            // Get tags from each DeckPreviewWidget
-            QStringList tags = display->deckLoader->getDeck().deckList.getTags();
-
-            // Add tags to the list while avoiding duplicates
-            allTags.append(tags);
+    for (VisualDeckStorageFolderDisplayWidget *subFolderWidget : subFolderWidgets) {
+        if (subFolderWidget->hasContent()) {
+            return true;
         }
     }
 
-    // Remove duplicates by calling 'removeDuplicates'
-    allTags.removeDuplicates();
+    return false;
+}
 
-    return allTags;
+/**
+ * @brief The direct child folder paths of this folder, sorted by name.
+ */
+QStringList VisualDeckStorageFolderDisplayWidget::childFolderPaths() const
+{
+    QStringList children;
+    const QString prefix = folderPath.isEmpty() ? QString() : folderPath + "/";
+
+    for (const QString &candidate : visualDeckStorageWidget->model()->folderPaths()) {
+        if (!candidate.startsWith(prefix)) {
+            continue;
+        }
+        const QString rest = candidate.mid(prefix.length());
+        if (rest.isEmpty() || rest.contains('/')) {
+            continue;
+        }
+        children.append(candidate);
+    }
+
+    return children;
 }

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.h
@@ -1,49 +1,79 @@
 /**
  * @file visual_deck_storage_folder_display_widget.h
  * @ingroup VisualDeckStorageWidgets
+ * @brief Renders the decks of one folder of the Visual Deck Storage.
+ *
+ * This is a pure view: it reads the accepted rows of the
+ * VisualDeckStorageSortFilterProxyModel whose folder matches this widget's
+ * folder path, and keeps a set of child DeckPreviewWidgets in sync with those
+ * rows. Subfolders are shown as nested VisualDeckStorageFolderDisplayWidgets
+ * when the "show folders" setting is enabled.
  */
-//! \todo Document this file.
 
 #ifndef VISUAL_DECK_STORAGE_FOLDER_DISPLAY_WIDGET_H
 #define VISUAL_DECK_STORAGE_FOLDER_DISPLAY_WIDGET_H
 
-#include "../general/display/banner_widget.h"
-#include "../general/layout_containers/flow_widget.h"
+#include <QHash>
+#include <QString>
+#include <QWidget>
 
+class BannerWidget;
+class DeckPreviewWidget;
+class FlowWidget;
+class QTimer;
+class QVBoxLayout;
 class VisualDeckStorageWidget;
+
 class VisualDeckStorageFolderDisplayWidget : public QWidget
 {
     Q_OBJECT
 public:
     VisualDeckStorageFolderDisplayWidget(QWidget *parent,
-                                         VisualDeckStorageWidget *_visualDeckStorageWidget,
-                                         QString _filePath,
+                                         VisualDeckStorageWidget *visualDeckStorageWidget,
+                                         const QString &folderPath,
                                          bool canBeHidden,
-                                         bool _showFolders);
-    void refreshUi();
-    void createWidgetsForFiles();
-    void createWidgetsForFolders();
-    void flattenFolderStructure();
-    [[nodiscard]] QStringList gatherAllTagsFromFlowWidget() const;
-    [[nodiscard]] FlowWidget *getFlowWidget() const
-    {
-        return flowWidget;
-    }
+                                         bool showFolders);
 
 public slots:
-    void updateVisibility(bool recursive = true);
-    bool checkVisibility();
+    /**
+     * @brief Re-reads the proxy and rebuilds the deck previews and subfolder
+     * widgets to match.
+     */
+    void reconcile();
+
+    /**
+     * @brief Coalesces proxy change signals (a burst of deck loads or filter
+     * invalidations) into a single reconcile on the next event loop turn.
+     */
+    void scheduleReconcile();
     void updateShowFolders(bool enabled);
 
+signals:
+    /**
+     * @brief Emitted whenever this folder's visible content changes, so parent
+     * folders can re-evaluate their own visibility.
+     */
+    void contentVisibilityChanged();
+
 private:
+    void reconcileDecks();
+    void createSubFolderWidgets();
+    void refreshVisibility();
+    [[nodiscard]] bool hasContent() const;
+    [[nodiscard]] QStringList childFolderPaths() const;
+
     bool showFolders;
+    QString folderPath; ///< Path relative to the deck folder; empty for the root folder.
     QVBoxLayout *layout;
-    VisualDeckStorageWidget *visualDeckStorageWidget;
-    QString filePath;
-    BannerWidget *header;
     QWidget *container;
     QVBoxLayout *containerLayout;
     FlowWidget *flowWidget;
+    BannerWidget *header;
+    VisualDeckStorageWidget *visualDeckStorageWidget;
+    QHash<QString, DeckPreviewWidget *> deckWidgets;                         ///< Deck file path -> preview widget.
+    QHash<QString, VisualDeckStorageFolderDisplayWidget *> subFolderWidgets; ///< Folder path -> subfolder widget.
+    QTimer *reconcileTimer = nullptr;                                        ///< Coalesces proxy change bursts.
+    QStringList lastOrderedFilePaths; ///< The deck order last applied to the flow layout.
 };
 
 #endif // VISUAL_DECK_STORAGE_FOLDER_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_model.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_model.cpp
@@ -1,0 +1,490 @@
+#include "visual_deck_storage_model.h"
+
+#include "../../deck_loader/deck_loader.h"
+
+#include <QDir>
+#include <QDirIterator>
+#include <QFile>
+#include <QFileInfo>
+#include <QFutureWatcher>
+#include <QSet>
+#include <QtConcurrentRun>
+#include <libcockatrice/card/database/card_database_manager.h>
+#include <utility>
+
+namespace
+{
+/**
+ * @brief The result of a background directory scan: the deck rows in scan order
+ * plus the sorted list of subfolder paths.
+ */
+struct DeckScanResult
+{
+    QList<DeckPreviewData> decks;
+    QStringList folderPaths;
+};
+
+/**
+ * @brief The result of a background deck file load: the parsed deck plus the
+ * file's modification time, so the disk stat happens off the UI thread.
+ */
+struct DeckLoadResult
+{
+    LoadedDeck deck;
+    QDateTime lastModified;
+};
+
+/**
+ * @brief The path of \a path relative to the deck root, or empty if \a path
+ * is not below it.
+ */
+QString relativePathFromDeckRoot(const QString &path, const QString &deckPath)
+{
+    if (!path.startsWith(deckPath)) {
+        return {};
+    }
+    QString relativePath = path.mid(deckPath.length());
+    if (relativePath.startsWith('/')) {
+        relativePath.remove(0, 1);
+    }
+    return relativePath;
+}
+} // namespace
+
+VisualDeckStorageModel::VisualDeckStorageModel(QObject *parent) : QAbstractListModel(parent)
+{
+}
+
+int VisualDeckStorageModel::rowCount(const QModelIndex &parent) const
+{
+    return parent.isValid() ? 0 : decks_.size();
+}
+
+QVariant VisualDeckStorageModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || index.row() < 0 || index.row() >= decks_.size()) {
+        return {};
+    }
+
+    const DeckPreviewData &data = decks_.at(index.row());
+    switch (role) {
+        case Qt::DisplayRole:
+        case VisualDeckStorageRoles::DisplayNameRole:
+            return data.displayName;
+        case VisualDeckStorageRoles::FilePathRole:
+            return data.filePath;
+        case VisualDeckStorageRoles::RelativeFilePathRole:
+            return data.relativeFilePath;
+        case VisualDeckStorageRoles::FolderPathRole:
+            return data.folderPath;
+        case VisualDeckStorageRoles::TagsRole:
+            return data.tags;
+        case VisualDeckStorageRoles::ColorIdentityRole:
+            return data.colorIdentity;
+        case VisualDeckStorageRoles::LastModifiedRole:
+            return data.lastModified;
+        case VisualDeckStorageRoles::LastLoadedRole:
+            return data.lastLoaded;
+        case VisualDeckStorageRoles::BannerCardNameRole:
+            return data.bannerCardName;
+        case VisualDeckStorageRoles::BannerCardProviderIdRole:
+            return data.bannerCardProviderId;
+        default:
+            return {};
+    }
+}
+
+void VisualDeckStorageModel::setDeckPath(const QString &deckPath)
+{
+    QString cleanedPath = QDir::cleanPath(deckPath);
+    if (cleanedPath == ".") {
+        cleanedPath.clear();
+    }
+    deckPath_ = cleanedPath;
+    startScan();
+}
+
+void VisualDeckStorageModel::refresh()
+{
+    startScan();
+}
+
+const DeckPreviewData &VisualDeckStorageModel::dataForRow(int row) const
+{
+    static const DeckPreviewData emptyData;
+    if (row < 0 || row >= decks_.size()) {
+        return emptyData;
+    }
+    return decks_.at(row);
+}
+
+const LoadedDeck &VisualDeckStorageModel::deckForRow(int row) const
+{
+    return dataForRow(row).deck;
+}
+
+int VisualDeckStorageModel::rowForFilePath(const QString &filePath) const
+{
+    for (int i = 0; i < decks_.size(); ++i) {
+        if (decks_.at(i).filePath == filePath) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+void VisualDeckStorageModel::startScan()
+{
+    ++scanGeneration_;
+    beginResetModel();
+    decks_.clear();
+    folderPaths_.clear();
+    endResetModel();
+
+    if (deckPath_.isEmpty()) {
+        return;
+    }
+
+    const QString deckPath = deckPath_;
+    const int generation = scanGeneration_;
+
+    // The scan (directory walk + one stat per file) runs on a worker thread so that
+    // constructing the widget never stalls the UI thread on a large deck folder.
+    auto *watcher = new QFutureWatcher<DeckScanResult>(this);
+    connect(watcher, &QFutureWatcher<DeckScanResult>::finished, this, [this, watcher, generation] {
+        watcher->deleteLater();
+
+        if (generation != scanGeneration_) {
+            return; // A newer scan started while this one was running; drop the stale result.
+        }
+
+        const DeckScanResult result = watcher->result();
+        folderPaths_ = result.folderPaths;
+
+        if (result.decks.isEmpty()) {
+            return;
+        }
+
+        beginInsertRows(QModelIndex(), 0, result.decks.size() - 1);
+        decks_ = result.decks;
+        endInsertRows();
+
+        for (int row = 0; row < decks_.size(); ++row) {
+            beginLoad(row);
+        }
+    });
+
+    watcher->setFuture(QtConcurrent::run([deckPath]() -> DeckScanResult {
+        DeckScanResult result;
+
+        QDirIterator fileIt(deckPath, DeckLoader::ACCEPTED_FILE_EXTENSIONS, QDir::Files,
+                            QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
+        while (fileIt.hasNext()) {
+            const QString filePath = fileIt.next();
+            DeckPreviewData data;
+            data.filePath = filePath;
+            data.relativeFilePath = VisualDeckStorageModel::relativeFilePathFor(filePath, deckPath);
+            data.folderPath = VisualDeckStorageModel::folderPathFor(filePath, deckPath);
+            data.lastModified = QFileInfo(filePath).lastModified();
+            result.decks.append(std::move(data));
+        }
+
+        QDirIterator folderIt(deckPath, QDir::Dirs | QDir::NoDotAndDotDot,
+                              QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
+        while (folderIt.hasNext()) {
+            const QString folderPath = relativePathFromDeckRoot(folderIt.next(), deckPath);
+            if (!folderPath.isEmpty() && !result.folderPaths.contains(folderPath)) {
+                result.folderPaths.append(folderPath);
+            }
+        }
+        result.folderPaths.sort();
+
+        return result;
+    }));
+}
+
+void VisualDeckStorageModel::beginLoad(int row)
+{
+    if (row < 0 || row >= decks_.size() || decks_.at(row).loadInProgress) {
+        return;
+    }
+
+    DeckPreviewData &data = decks_[row];
+    data.loadInProgress = true;
+
+    const QString filePath = data.filePath;
+    const DeckFileFormat::Format fmt = DeckFileFormat::getFormatFromName(filePath);
+    const int generation = scanGeneration_;
+
+    auto *watcher = new QFutureWatcher<std::optional<DeckLoadResult>>(this);
+    connect(watcher, &QFutureWatcher<std::optional<DeckLoadResult>>::finished, this,
+            [this, watcher, filePath, generation] {
+                watcher->deleteLater();
+
+                if (generation != scanGeneration_) {
+                    return; // The deck list was re-scanned while this load was running; drop the stale result.
+                }
+
+                const int row = rowForFilePath(filePath);
+                if (row == -1) {
+                    return;
+                }
+
+                DeckPreviewData &data = decks_[row];
+                data.loadInProgress = false;
+
+                std::optional<DeckLoadResult> result = watcher->result();
+                if (!result) {
+                    return; // Leave the row unloaded; it stays visible but without deck data.
+                }
+
+                data.deck = std::move(result->deck);
+                data.loadSucceeded = true;
+                data.lastModified = result->lastModified;
+                computeDeckMetadata(data);
+
+                emit dataChanged(index(row), index(row));
+                emit deckLoaded(row);
+            });
+
+    watcher->setFuture(QtConcurrent::run([filePath, fmt]() -> std::optional<DeckLoadResult> {
+        std::optional<LoadedDeck> deck = DeckLoader::loadFromFile(filePath, fmt, false);
+        if (!deck) {
+            return std::nullopt;
+        }
+        return DeckLoadResult{*deck, QFileInfo(filePath).lastModified()};
+    }));
+}
+
+/**
+ * @brief Computes the color identity of a deck in WUBRG order.
+ */
+static QString computeColorIdentity(const LoadedDeck &deck)
+{
+    QStringList cardList = deck.deckList.getCardList({DECK_ZONE_MAIN, DECK_ZONE_SIDE});
+    if (cardList.isEmpty()) {
+        return {};
+    }
+
+    QSet<QChar> colorSet; // A set to collect unique color symbols (e.g., W, U, B, R, G)
+
+    for (const QString &cardName : cardList) {
+        CardInfoPtr currentCard = CardDatabaseManager::query()->getCardInfo(cardName);
+        if (currentCard) {
+            const QString colors = currentCard->getColors(); // Something like "WUB"
+            for (const QChar &color : colors) {
+                colorSet.insert(color);
+            }
+        }
+    }
+
+    // Ensure the color identity is in WUBRG order
+    QString colorIdentity;
+    const QString wubrgOrder = "WUBRG";
+    for (const QChar &color : wubrgOrder) {
+        if (colorSet.contains(color)) {
+            colorIdentity.append(color);
+        }
+    }
+
+    return colorIdentity;
+}
+
+/**
+ * @brief Recomputes all derived metadata of a row from its loaded deck.
+ */
+void VisualDeckStorageModel::computeDeckMetadata(DeckPreviewData &data) const
+{
+    const DeckList &deckList = data.deck.deckList;
+
+    data.deckName = deckList.getName();
+    data.displayName = !data.deckName.isEmpty() ? data.deckName : QFileInfo(data.deck.lastLoadInfo.fileName).fileName();
+    data.tags = deckList.getTags();
+    data.lastLoaded = QDateTime::fromString(deckList.getLastLoadedTimestamp());
+
+    const CardRef bannerCard = deckList.getBannerCard();
+    data.bannerCardName = bannerCard.name;
+    data.bannerCardProviderId = bannerCard.providerId;
+
+    data.colorIdentity = computeColorIdentity(data.deck);
+}
+
+void VisualDeckStorageModel::setFilePathForRow(int row, const QString &newFilePath)
+{
+    if (row < 0 || row >= decks_.size()) {
+        return;
+    }
+
+    DeckPreviewData &data = decks_[row];
+    data.filePath = newFilePath;
+    data.relativeFilePath = relativeFilePathFor(newFilePath, deckPath_);
+    data.folderPath = folderPathFor(newFilePath, deckPath_);
+}
+
+QString VisualDeckStorageModel::relativeFilePathFor(const QString &filePath, const QString &deckPath)
+{
+    if (filePath.startsWith(deckPath)) {
+        return filePath.mid(deckPath.length());
+    }
+
+    return QFileInfo(filePath).fileName();
+}
+
+QString VisualDeckStorageModel::folderPathFor(const QString &filePath, const QString &deckPath)
+{
+    return relativePathFromDeckRoot(QFileInfo(filePath).absolutePath(), deckPath);
+}
+
+bool VisualDeckStorageModel::renameDeck(int row, const QString &newName)
+{
+    if (row < 0 || row >= decks_.size() || decks_.at(row).deck.isEmpty()) {
+        return false;
+    }
+
+    DeckPreviewData &data = decks_[row];
+    data.deck.deckList.setName(newName);
+    if (!DeckLoader::saveToFile(data.deck)) {
+        return false;
+    }
+
+    computeDeckMetadata(data);
+    emit dataChanged(index(row), index(row), {VisualDeckStorageRoles::DisplayNameRole});
+    return true;
+}
+
+bool VisualDeckStorageModel::renameFile(int row, const QString &newBaseName)
+{
+    if (row < 0 || row >= decks_.size() || newBaseName.isEmpty()) {
+        return false;
+    }
+
+    DeckPreviewData &data = decks_[row];
+    const QFileInfo info(data.filePath);
+    if (newBaseName == info.baseName()) {
+        return false;
+    }
+
+    QString newFileName = newBaseName;
+    if (!info.suffix().isEmpty()) {
+        newFileName += "." + info.suffix();
+    }
+
+    const QString newFilePath = QFileInfo(info.dir(), newFileName).filePath();
+    if (!QFile::rename(info.filePath(), newFilePath)) {
+        return false;
+    }
+
+    const QString oldFilePath = data.filePath;
+    data.deck.lastLoadInfo.fileName = newFilePath;
+    setFilePathForRow(row, newFilePath);
+    data.lastModified = QFileInfo(newFilePath).lastModified();
+
+    emit dataChanged(index(row), index(row));
+    emit deckFilePathChanged(oldFilePath, newFilePath);
+    return true;
+}
+
+bool VisualDeckStorageModel::deleteFile(int row)
+{
+    if (row < 0 || row >= decks_.size()) {
+        return false;
+    }
+
+    const QString filePath = decks_.at(row).filePath;
+    if (!QFile::remove(QFileInfo(filePath).filePath())) {
+        return false;
+    }
+
+    beginRemoveRows(QModelIndex(), row, row);
+    decks_.removeAt(row);
+    endRemoveRows();
+    return true;
+}
+
+bool VisualDeckStorageModel::setTags(int row, const QStringList &tags)
+{
+    if (row < 0 || row >= decks_.size() || decks_.at(row).deck.isEmpty()) {
+        return false;
+    }
+
+    DeckPreviewData &data = decks_[row];
+    data.deck.deckList.setTags(tags);
+    if (!DeckLoader::saveToFile(data.deck)) {
+        return false;
+    }
+
+    data.tags = tags;
+    emit dataChanged(index(row), index(row), {VisualDeckStorageRoles::TagsRole});
+    return true;
+}
+
+bool VisualDeckStorageModel::setBannerCard(int row, const CardRef &cardRef)
+{
+    if (row < 0 || row >= decks_.size() || decks_.at(row).deck.isEmpty()) {
+        return false;
+    }
+
+    DeckPreviewData &data = decks_[row];
+    data.deck.deckList.setBannerCard(cardRef);
+    if (!DeckLoader::saveToFile(data.deck)) {
+        return false;
+    }
+
+    data.bannerCardName = cardRef.name;
+    data.bannerCardProviderId = cardRef.providerId;
+    emit dataChanged(index(row), index(row),
+                     {VisualDeckStorageRoles::BannerCardNameRole, VisualDeckStorageRoles::BannerCardProviderIdRole});
+    return true;
+}
+
+bool VisualDeckStorageModel::convertToCockatriceFormat(int row)
+{
+    if (row < 0 || row >= decks_.size() || decks_.at(row).deck.isEmpty()) {
+        return false;
+    }
+
+    DeckPreviewData &data = decks_[row];
+    const QString oldFilePath = data.filePath;
+    if (!DeckLoader::convertToCockatriceFormat(data.deck)) {
+        return false;
+    }
+
+    setFilePathForRow(row, data.deck.lastLoadInfo.fileName);
+    data.lastModified = QFileInfo(data.filePath).lastModified();
+    computeDeckMetadata(data);
+
+    emit dataChanged(index(row), index(row));
+    if (oldFilePath != data.filePath) {
+        emit deckFilePathChanged(oldFilePath, data.filePath);
+    }
+    return true;
+}
+
+bool VisualDeckStorageModel::reloadIfModified(int row)
+{
+    if (row < 0 || row >= decks_.size()) {
+        return false;
+    }
+
+    DeckPreviewData &data = decks_[row];
+    QFileInfo fileInfo(data.filePath);
+    const QDateTime newLastModified = fileInfo.lastModified();
+    if (!newLastModified.isValid() || newLastModified <= data.lastModified) {
+        return false;
+    }
+
+    std::optional<LoadedDeck> result =
+        DeckLoader::loadFromFile(data.filePath, DeckFileFormat::getFormatFromName(data.filePath), false);
+    if (!result) {
+        return false;
+    }
+
+    data.deck = *result;
+    data.loadSucceeded = true;
+    data.lastModified = fileInfo.lastModified();
+    computeDeckMetadata(data);
+
+    emit dataChanged(index(row), index(row));
+    emit deckLoaded(row);
+    return true;
+}

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_model.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_model.h
@@ -1,0 +1,158 @@
+/**
+ * @file visual_deck_storage_model.h
+ * @ingroup VisualDeckStorageWidgets
+ * @brief Source model for the Visual Deck Storage: the deck files on disk.
+ *
+ * The model owns the deck metadata (name, tags, color identity, banner card,
+ * modification times) and the parsed deck list, loading each deck file in the
+ * background. Views read through the roles or the direct accessors, and all
+ * mutations (rename, tags, banner card, delete, conversion) go through this
+ * class so the view layer never touches the filesystem directly.
+ */
+
+#ifndef VISUAL_DECK_STORAGE_MODEL_H
+#define VISUAL_DECK_STORAGE_MODEL_H
+
+#include "../../deck_loader/loaded_deck.h"
+
+#include <QAbstractListModel>
+#include <QDateTime>
+#include <QList>
+#include <QStringList>
+#include <libcockatrice/deck_list/deck_list.h>
+#include <optional>
+
+namespace VisualDeckStorageRoles
+{
+/**
+ * @brief Custom roles exposed by the VisualDeckStorageModel.
+ */
+enum
+{
+    FilePathRole = Qt::UserRole + 1, /**< Absolute file path of the deck. */
+    RelativeFilePathRole,            /**< File path relative to the deck folder. */
+    FolderPathRole,                  /**< Directory of the deck relative to the deck folder ("" for root). */
+    DisplayNameRole,                 /**< Deck name, or the file name if the deck has no name. */
+    TagsRole,                        /**< The deck's tags. */
+    ColorIdentityRole,               /**< The deck's color identity (WUBRG order). */
+    LastModifiedRole,                /**< QDateTime of the deck file's last modification. */
+    LastLoadedRole,                  /**< QDateTime when the deck was last loaded from the file. */
+    BannerCardNameRole,              /**< Name of the deck's banner card. */
+    BannerCardProviderIdRole         /**< Provider id of the deck's banner card. */
+};
+} // namespace VisualDeckStorageRoles
+
+/**
+ * @brief One deck file as seen by the Visual Deck Storage.
+ *
+ * The metadata is computed once when the deck loads and refreshed on reloads
+ * and mutations, so filters and sorts never re-read the file from disk.
+ */
+struct DeckPreviewData
+{
+    QString filePath;             ///< Absolute file path.
+    QString relativeFilePath;     ///< File path relative to the deck folder.
+    QString folderPath;           ///< Directory relative to the deck folder ("" for the deck folder itself).
+    QString deckName;             ///< The deck name as stored in the file (may be empty).
+    QString displayName;          ///< Deck name, or the file name if the deck has no name.
+    QStringList tags;             ///< The deck's tags.
+    QString colorIdentity;        ///< The deck's color identity in WUBRG order.
+    QDateTime lastModified;       ///< File modification time at last check.
+    QDateTime lastLoaded;         ///< When the deck was last loaded from the file.
+    QString bannerCardName;       ///< Name of the deck's banner card.
+    QString bannerCardProviderId; ///< Provider id of the deck's banner card.
+    LoadedDeck deck;              ///< The parsed deck; empty until the file has been loaded.
+    bool loadSucceeded = false;   ///< Whether the deck file finished loading successfully.
+    bool loadInProgress = false;  ///< Whether the deck file is currently being loaded.
+};
+
+/**
+ * @brief The list model backing the Visual Deck Storage widget tree.
+ *
+ * Rows are in filesystem scan order; ordering and filtering are handled by
+ * VisualDeckStorageSortFilterProxyModel on top of this model.
+ */
+class VisualDeckStorageModel : public QAbstractListModel
+{
+    Q_OBJECT
+public:
+    explicit VisualDeckStorageModel(QObject *parent = nullptr);
+
+    /// @name Qt model overrides
+    ///@{
+    [[nodiscard]] int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    [[nodiscard]] QVariant data(const QModelIndex &index, int role) const override;
+    ///@}
+
+    /**
+     * @brief Sets the folder to scan for deck files and starts (re)loading.
+     * Emits modelReset once the scan finishes and deck loads begin.
+     */
+    void setDeckPath(const QString &deckPath);
+
+    /**
+     * @brief Re-scans the current deck folder, reloading every deck file.
+     */
+    void refresh();
+
+    [[nodiscard]] QString deckPath() const
+    {
+        return deckPath_;
+    }
+
+    /**
+     * @brief The relative paths of all subdirectories of the deck folder, one level at a time.
+     * Used by the view to build the folder tree. Sorted for deterministic order.
+     */
+    [[nodiscard]] QStringList folderPaths() const
+    {
+        return folderPaths_;
+    }
+
+    /// @name Data accessors
+    ///@{
+    [[nodiscard]] const DeckPreviewData &dataForRow(int row) const;
+    [[nodiscard]] const LoadedDeck &deckForRow(int row) const;
+    [[nodiscard]] int rowForFilePath(const QString &filePath) const;
+    ///@}
+
+    /// @name Mutations (persist to disk and update the row)
+    ///@{
+    bool renameDeck(int row, const QString &newName);
+    bool renameFile(int row, const QString &newBaseName);
+    bool deleteFile(int row);
+    bool setTags(int row, const QStringList &tags);
+    bool setBannerCard(int row, const CardRef &cardRef);
+    bool convertToCockatriceFormat(int row);
+    bool reloadIfModified(int row);
+    ///@}
+
+signals:
+    /**
+     * @brief Emitted when a deck file finishes loading.
+     * @param row The row of the deck that finished loading.
+     */
+    void deckLoaded(int row);
+
+    /**
+     * @brief Emitted when a deck's file path changes (rename file, conversion).
+     * @param oldFilePath The previous file path.
+     * @param newFilePath The new file path.
+     */
+    void deckFilePathChanged(const QString &oldFilePath, const QString &newFilePath);
+
+private:
+    void startScan();
+    void beginLoad(int row);
+    void computeDeckMetadata(DeckPreviewData &data) const;
+    void setFilePathForRow(int row, const QString &newFilePath);
+    [[nodiscard]] static QString relativeFilePathFor(const QString &filePath, const QString &deckPath);
+    [[nodiscard]] static QString folderPathFor(const QString &filePath, const QString &deckPath);
+
+    QString deckPath_;
+    QList<DeckPreviewData> decks_;
+    QStringList folderPaths_; ///< All subdirectories of the deck folder, sorted.
+    int scanGeneration_ = 0;  ///< Bumped on every scan so stale results are ignored.
+};
+
+#endif // VISUAL_DECK_STORAGE_MODEL_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.cpp
@@ -1,6 +1,7 @@
 #include "visual_deck_storage_quick_settings_widget.h"
 
 #include "../../../client/settings/cache_settings.h"
+#include "../cards/card_size_widget.h"
 #include "visual_deck_storage_widget.h"
 
 #include <QCheckBox>

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_search_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_search_widget.cpp
@@ -76,7 +76,11 @@ void VisualDeckStorageSearchWidget::filterWidgets(QList<DeckPreviewWidget *> wid
     auto filterString = DeckFilterString(searchText);
 
     for (auto widget : widgets) {
-        QString relativeFilePath = toRelativeFilepath(widget->filePath);
-        widget->filteredBySearch = !filterString.check(widget, {relativeFilePath});
+        DeckSearchData searchData;
+        searchData.deck = &widget->deckLoader->getDeck();
+        searchData.filePath = widget->filePath;
+        searchData.displayName = widget->getDisplayName();
+        searchData.relativeFilePath = toRelativeFilepath(widget->filePath);
+        widget->filteredBySearch = !filterString.check(searchData);
     }
 }

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_search_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_search_widget.cpp
@@ -1,21 +1,19 @@
 #include "visual_deck_storage_search_widget.h"
 
-#include "../../../client/settings/cache_settings.h"
-#include "../../../filters/deck_filter_string.h"
 #include "../../../filters/syntax_help.h"
 #include "../../pixel_map_generator.h"
+#include "visual_deck_storage_widget.h"
 
 #include <QAction>
-#include <QFileInfo>
-#include <libcockatrice/settings/paths_settings.h>
+#include <QTimer>
 
 /**
- * @brief Constructs a PrintingSelectorCardSearchWidget for searching cards by set name or set code.
+ * @brief Constructs a search bar for filtering decks in the Visual Deck Storage.
  *
- * This widget provides a search bar that allows users to search for cards by either their set name
- * or set code. It uses a debounced timer to trigger the search action after the user stops typing.
+ * Provides a search bar that allows users to search decks by filename or search
+ * expression, with a debounced timer to trigger the search after the user stops typing.
  *
- * @param parent The parent PrintingSelector widget that will handle the search results.
+ * @param parent The VisualDeckStorageWidget owning the search.
  */
 VisualDeckStorageSearchWidget::VisualDeckStorageSearchWidget(VisualDeckStorageWidget *parent) : parent(parent)
 {
@@ -40,47 +38,6 @@ VisualDeckStorageSearchWidget::VisualDeckStorageSearchWidget(VisualDeckStorageWi
         searchDebounceTimer->start(300); // 300ms debounce
     });
 
-    connect(searchDebounceTimer, &QTimer::timeout, parent, &VisualDeckStorageWidget::updateSearchFilter);
-}
-
-/**
- * @brief Retrieves the current text in the search bar.
- *
- * @return The text entered by the user in the search bar.
- */
-QString VisualDeckStorageSearchWidget::getSearchText()
-{
-    return searchBar->text();
-}
-
-/**
- * Converts the filepath into a relative filepath starting from the deck folder.
- * If the file isn't in the deck folder, then this will just return the filename.
- *
- * @param filePath The filepath to convert into a relative filepath
- */
-static QString toRelativeFilepath(const QString &filePath)
-{
-    QString deckPath = SettingsCache::instance().paths().getDeckPath();
-    if (filePath.startsWith(deckPath)) {
-        return filePath.mid(deckPath.length());
-    }
-
-    QFileInfo fileInfo(filePath);
-    QString fileName = fileInfo.fileName();
-    return fileName;
-}
-
-void VisualDeckStorageSearchWidget::filterWidgets(QList<DeckPreviewWidget *> widgets, const QString &searchText)
-{
-    auto filterString = DeckFilterString(searchText);
-
-    for (auto widget : widgets) {
-        DeckSearchData searchData;
-        searchData.deck = &widget->deckLoader->getDeck();
-        searchData.filePath = widget->filePath;
-        searchData.displayName = widget->getDisplayName();
-        searchData.relativeFilePath = toRelativeFilepath(widget->filePath);
-        widget->filteredBySearch = !filterString.check(searchData);
-    }
+    connect(searchDebounceTimer, &QTimer::timeout, this,
+            [this] { this->parent->proxyModel()->setSearchText(searchBar->text()); });
 }

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_search_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_search_widget.h
@@ -2,17 +2,15 @@
  * @file visual_deck_storage_search_widget.h
  * @ingroup VisualDeckStorageWidgets
  */
-//! \todo Document this file.
 
 #ifndef VISUAL_DECK_STORAGE_SEARCH_WIDGET_H
 #define VISUAL_DECK_STORAGE_SEARCH_WIDGET_H
-
-#include "deck_preview/deck_preview_widget.h"
 
 #include <QHBoxLayout>
 #include <QLineEdit>
 #include <QWidget>
 
+class QTimer;
 class VisualDeckStorageWidget;
 class VisualDeckStorageSearchWidget : public QWidget
 {
@@ -20,8 +18,6 @@ class VisualDeckStorageSearchWidget : public QWidget
 
 public:
     explicit VisualDeckStorageSearchWidget(VisualDeckStorageWidget *parent);
-    QString getSearchText();
-    void filterWidgets(QList<DeckPreviewWidget *> widgets, const QString &searchText);
 
 private:
     QHBoxLayout *layout;

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_sort_filter_proxy_model.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_sort_filter_proxy_model.cpp
@@ -1,0 +1,288 @@
+#include "visual_deck_storage_sort_filter_proxy_model.h"
+
+#include "../../filters/deck_filter_string.h"
+
+#include <QFileInfo>
+
+VisualDeckStorageSortFilterProxyModel::VisualDeckStorageSortFilterProxyModel(QObject *parent)
+    : QSortFilterProxyModel(parent)
+{
+    setDynamicSortFilter(false);
+}
+
+void VisualDeckStorageSortFilterProxyModel::setSourceModel(QAbstractItemModel *model)
+{
+    if (QAbstractItemModel *oldModel = sourceModel()) {
+        disconnect(oldModel, &QAbstractItemModel::modelReset, this,
+                   &VisualDeckStorageSortFilterProxyModel::resizeMatchLists);
+        disconnect(oldModel, &QAbstractItemModel::rowsInserted, this,
+                   &VisualDeckStorageSortFilterProxyModel::resizeMatchLists);
+        disconnect(oldModel, &QAbstractItemModel::rowsRemoved, this,
+                   &VisualDeckStorageSortFilterProxyModel::resizeMatchLists);
+    }
+
+    QSortFilterProxyModel::setSourceModel(model);
+
+    if (model) {
+        connect(model, &QAbstractItemModel::modelReset, this, &VisualDeckStorageSortFilterProxyModel::resizeMatchLists);
+        connect(model, &QAbstractItemModel::rowsInserted, this,
+                &VisualDeckStorageSortFilterProxyModel::resizeMatchLists);
+        connect(model, &QAbstractItemModel::rowsRemoved, this,
+                &VisualDeckStorageSortFilterProxyModel::resizeMatchLists);
+    }
+
+    resizeMatchLists();
+}
+
+void VisualDeckStorageSortFilterProxyModel::setSearchText(const QString &text)
+{
+    if (searchText_ == text) {
+        return;
+    }
+
+    searchText_ = text;
+    updateSearchMatches();
+    invalidate();
+}
+
+void VisualDeckStorageSortFilterProxyModel::setTagFilter(const QSet<QString> &selectedTags,
+                                                         const QSet<QString> &excludedTags)
+{
+    if (selectedTags_ == selectedTags && excludedTags_ == excludedTags) {
+        return;
+    }
+
+    selectedTags_ = selectedTags;
+    excludedTags_ = excludedTags;
+    updateTagMatches();
+    invalidate();
+}
+
+void VisualDeckStorageSortFilterProxyModel::setColorFilter(FilterMode mode, const QSet<QChar> &activeColors)
+{
+    if (colorFilterMode_ == mode && activeColors_ == activeColors) {
+        return;
+    }
+
+    colorFilterMode_ = mode;
+    activeColors_ = activeColors;
+    updateColorMatches();
+    invalidate();
+}
+
+void VisualDeckStorageSortFilterProxyModel::setSortOrder(SortOrder order)
+{
+    // No equality guard: the initial reapply (with the default order) must still
+    // trigger sort(0), since without a sort the proxy would show scan order.
+    sortOrder_ = order;
+    sort(0);
+}
+
+void VisualDeckStorageSortFilterProxyModel::reapplyFilters()
+{
+    const QList<bool> oldSearchMatches = searchMatches_;
+    const QList<bool> oldTagMatches = tagMatches_;
+    const QList<bool> oldColorMatches = colorMatches_;
+
+    updateSearchMatches();
+    updateTagMatches();
+    updateColorMatches();
+
+    if (searchMatches_ != oldSearchMatches || tagMatches_ != oldTagMatches || colorMatches_ != oldColorMatches) {
+        invalidate();
+    }
+
+    if (sortOrder_ == ByName || sortOrder_ == ByLastLoaded) {
+        // These orders depend on data that only becomes available when a deck finishes loading.
+        sort(0);
+    }
+}
+
+void VisualDeckStorageSortFilterProxyModel::resort()
+{
+    sort(0);
+}
+
+bool VisualDeckStorageSortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
+{
+    if (sourceParent.isValid()) {
+        return true;
+    }
+
+    // If the match lists aren't sized to the current model yet, don't hide anything.
+    if (sourceRow < 0 || sourceRow >= searchMatches_.size() || sourceRow >= tagMatches_.size() ||
+        sourceRow >= colorMatches_.size()) {
+        return true;
+    }
+
+    return searchMatches_.at(sourceRow) && tagMatches_.at(sourceRow) && colorMatches_.at(sourceRow);
+}
+
+bool VisualDeckStorageSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const
+{
+    const auto *source = deckSourceModel();
+    if (!source) {
+        return false;
+    }
+
+    const DeckPreviewData &leftData = source->dataForRow(left.row());
+    const DeckPreviewData &rightData = source->dataForRow(right.row());
+
+    switch (sortOrder_) {
+        case ByName:
+            return leftData.deckName < rightData.deckName;
+        case Alphabetical:
+            return QString::localeAwareCompare(QFileInfo(leftData.filePath).fileName(),
+                                               QFileInfo(rightData.filePath).fileName()) < 0;
+        case ByLastModified:
+            return leftData.lastModified > rightData.lastModified;
+        case ByLastLoaded:
+            return leftData.lastLoaded > rightData.lastLoaded;
+    }
+
+    return false;
+}
+
+void VisualDeckStorageSortFilterProxyModel::resizeMatchLists()
+{
+    const int count = sourceModel() ? sourceModel()->rowCount() : 0;
+    searchMatches_ = QList<bool>(count, true);
+    tagMatches_ = QList<bool>(count, true);
+    colorMatches_ = QList<bool>(count, true);
+}
+
+void VisualDeckStorageSortFilterProxyModel::updateSearchMatches()
+{
+    const auto *source = deckSourceModel();
+    if (!source) {
+        searchMatches_.clear();
+        return;
+    }
+
+    const int count = source->rowCount();
+    if (searchText_.isEmpty()) {
+        searchMatches_ = QList<bool>(count, true);
+        return;
+    }
+
+    searchMatches_.resize(count);
+    DeckFilterString filterString(searchText_);
+    for (int row = 0; row < count; ++row) {
+        const DeckPreviewData &data = source->dataForRow(row);
+
+        // Decks that haven't finished loading yet can't be evaluated; show them and
+        // re-evaluate once the load finishes (reapplyFilters is triggered by deckLoaded).
+        if (data.deck.isEmpty()) {
+            searchMatches_[row] = true;
+            continue;
+        }
+
+        DeckSearchData searchData;
+        searchData.deck = &data.deck;
+        searchData.filePath = data.filePath;
+        searchData.displayName = data.displayName;
+        searchData.relativeFilePath = data.relativeFilePath;
+        searchMatches_[row] = filterString.check(searchData);
+    }
+}
+
+void VisualDeckStorageSortFilterProxyModel::updateTagMatches()
+{
+    const auto *source = deckSourceModel();
+    if (!source) {
+        tagMatches_.clear();
+        return;
+    }
+
+    const int count = source->rowCount();
+    tagMatches_.resize(count);
+
+    if (selectedTags_.isEmpty() && excludedTags_.isEmpty()) {
+        tagMatches_.fill(true);
+        return;
+    }
+
+    for (int row = 0; row < count; ++row) {
+        const QStringList deckTags = source->dataForRow(row).tags;
+
+        bool hasAllSelected = true;
+        for (const QString &tag : selectedTags_) {
+            if (!deckTags.contains(tag)) {
+                hasAllSelected = false;
+                break;
+            }
+        }
+
+        bool hasAnyExcluded = false;
+        for (const QString &tag : excludedTags_) {
+            if (deckTags.contains(tag)) {
+                hasAnyExcluded = true;
+                break;
+            }
+        }
+
+        tagMatches_[row] = hasAllSelected && !hasAnyExcluded;
+    }
+}
+
+void VisualDeckStorageSortFilterProxyModel::updateColorMatches()
+{
+    const auto *source = deckSourceModel();
+    if (!source) {
+        colorMatches_.clear();
+        return;
+    }
+
+    const int count = source->rowCount();
+    colorMatches_.resize(count);
+
+    if (activeColors_.isEmpty()) {
+        colorMatches_.fill(true);
+        return;
+    }
+
+    for (int row = 0; row < count; ++row) {
+        const QString colorIdentity = source->dataForRow(row).colorIdentity;
+
+        bool matches = true;
+        switch (colorFilterMode_) {
+            case ExactMatch: {
+                QSet<QChar> activeColorSet;
+                for (const QChar &color : activeColors_) {
+                    activeColorSet.insert(color.toUpper());
+                }
+
+                QSet<QChar> colorIdentitySet;
+                for (const QChar &color : colorIdentity) {
+                    colorIdentitySet.insert(color.toUpper());
+                }
+
+                matches = activeColorSet == colorIdentitySet;
+                break;
+            }
+            case Includes:
+                for (const QChar &color : activeColors_) {
+                    if (!colorIdentity.contains(color)) {
+                        matches = false;
+                        break;
+                    }
+                }
+                break;
+            case Excludes:
+                for (const QChar &color : activeColors_) {
+                    if (colorIdentity.contains(color)) {
+                        matches = false;
+                        break;
+                    }
+                }
+                break;
+        }
+
+        colorMatches_[row] = matches;
+    }
+}
+
+const VisualDeckStorageModel *VisualDeckStorageSortFilterProxyModel::deckSourceModel() const
+{
+    return qobject_cast<const VisualDeckStorageModel *>(sourceModel());
+}

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_sort_filter_proxy_model.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_sort_filter_proxy_model.h
@@ -1,0 +1,98 @@
+/**
+ * @file visual_deck_storage_sort_filter_proxy_model.h
+ * @ingroup VisualDeckStorageWidgets
+ * @brief Sorting and filtering proxy on top of VisualDeckStorageModel.
+ *
+ * Owns all search / tag / color filter state and the sort order. Filtering is
+ * evaluated against the model's data (never against widgets), so it can run
+ * before any view exists and re-evaluate whenever deck data finishes loading.
+ */
+
+#ifndef VISUAL_DECK_STORAGE_SORT_FILTER_PROXY_MODEL_H
+#define VISUAL_DECK_STORAGE_SORT_FILTER_PROXY_MODEL_H
+
+#include "visual_deck_storage_model.h"
+
+#include <QSet>
+#include <QSortFilterProxyModel>
+#include <QString>
+
+class VisualDeckStorageSortFilterProxyModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+public:
+    /**
+     * @brief The order in which decks are sorted. Values must match the
+     * entries of the sort widget's combo box and the stored settings value.
+     */
+    enum SortOrder
+    {
+        ByName,
+        Alphabetical,
+        ByLastModified,
+        ByLastLoaded,
+    };
+    Q_ENUM(SortOrder)
+
+    /**
+     * @brief How the color identity filter is applied.
+     */
+    enum FilterMode
+    {
+        ExactMatch,
+        Includes,
+        Excludes
+    };
+    Q_ENUM(FilterMode)
+
+    explicit VisualDeckStorageSortFilterProxyModel(QObject *parent = nullptr);
+
+    void setSourceModel(QAbstractItemModel *model) override;
+
+    /// @name Filter input setters (each re-evaluates the affected matches)
+    ///@{
+    void setSearchText(const QString &text);
+    void setTagFilter(const QSet<QString> &selectedTags, const QSet<QString> &excludedTags);
+    void setColorFilter(FilterMode mode, const QSet<QChar> &activeColors);
+    ///@}
+
+    /**
+     * @brief Sets the sort order and applies it immediately.
+     */
+    void setSortOrder(SortOrder order);
+
+    /**
+     * @brief Re-evaluates all matches against the current model data and
+     * re-applies filtering and sorting. Called after deck data changes.
+     */
+    void reapplyFilters();
+
+    /**
+     * @brief Re-applies the current sort order without touching the filters.
+     */
+    void resort();
+
+protected:
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
+    bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;
+
+private:
+    void resizeMatchLists();
+    void updateSearchMatches();
+    void updateTagMatches();
+    void updateColorMatches();
+    [[nodiscard]] const VisualDeckStorageModel *deckSourceModel() const;
+
+    QString searchText_;
+    QSet<QString> selectedTags_;
+    QSet<QString> excludedTags_;
+    FilterMode colorFilterMode_ = ExactMatch;
+    QSet<QChar> activeColors_;
+    SortOrder sortOrder_ = Alphabetical;
+
+    QList<bool> searchMatches_; ///< Per-row search match, sized like the source model.
+    QList<bool> tagMatches_;    ///< Per-row tag match.
+    QList<bool> colorMatches_;  ///< Per-row color identity match.
+};
+
+#endif // VISUAL_DECK_STORAGE_SORT_FILTER_PROXY_MODEL_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_sort_widget.cpp
@@ -1,20 +1,11 @@
 #include "visual_deck_storage_sort_widget.h"
 
 #include "../../../client/settings/cache_settings.h"
+#include "visual_deck_storage_widget.h"
 
-#include <QFileInfo>
 #include <libcockatrice/settings/visual_deck_storage_settings.h>
 
-/**
- * @brief Constructs a PrintingSelectorCardSortWidget for searching cards by set name or set code.
- *
- * This widget provides a search bar that allows users to search for cards by either their set name
- * or set code. It uses a debounced timer to trigger the search action after the user stops typing.
- *
- * @param parent The parent PrintingSelector widget that will handle the search results.
- */
-VisualDeckStorageSortWidget::VisualDeckStorageSortWidget(VisualDeckStorageWidget *parent)
-    : parent(parent), sortOrder(Alphabetical)
+VisualDeckStorageSortWidget::VisualDeckStorageSortWidget(VisualDeckStorageWidget *parent) : QWidget(parent)
 {
     layout = new QHBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
@@ -30,12 +21,10 @@ VisualDeckStorageSortWidget::VisualDeckStorageSortWidget(VisualDeckStorageWidget
 
     // Set the current sort order
     sortComboBox->setCurrentIndex(SettingsCache::instance().visualDeckStorage().getVisualDeckStorageSortingOrder());
-    sortOrder = static_cast<SortOrder>(sortComboBox->currentIndex());
 
-    // Connect sorting change signal to refresh the file list
+    // Connect sorting change signal to persist the order and refresh the file list
     connect(sortComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &VisualDeckStorageSortWidget::updateSortOrder);
-    connect(this, &VisualDeckStorageSortWidget::sortOrderChanged, parent, &VisualDeckStorageWidget::updateSortOrder);
 }
 
 void VisualDeckStorageSortWidget::retranslateUi()
@@ -47,10 +36,13 @@ void VisualDeckStorageSortWidget::retranslateUi()
 
     // Clear and repopulate the ComboBox with translated items
     sortComboBox->clear();
-    sortComboBox->addItem(tr("Sort Alphabetically (Deck Name)"), ByName);
-    sortComboBox->addItem(tr("Sort Alphabetically (Filename)"), Alphabetical);
-    sortComboBox->addItem(tr("Sort by Last Modified"), ByLastModified);
-    sortComboBox->addItem(tr("Sort by Last Loaded"), ByLastLoaded);
+    sortComboBox->addItem(tr("Sort Alphabetically (Deck Name)"),
+                          VisualDeckStorageSortFilterProxyModel::SortOrder::ByName);
+    sortComboBox->addItem(tr("Sort Alphabetically (Filename)"),
+                          VisualDeckStorageSortFilterProxyModel::SortOrder::Alphabetical);
+    sortComboBox->addItem(tr("Sort by Last Modified"),
+                          VisualDeckStorageSortFilterProxyModel::SortOrder::ByLastModified);
+    sortComboBox->addItem(tr("Sort by Last Loaded"), VisualDeckStorageSortFilterProxyModel::SortOrder::ByLastLoaded);
 
     // Restore the current index
     sortComboBox->setCurrentIndex(oldIndex);
@@ -59,60 +51,13 @@ void VisualDeckStorageSortWidget::retranslateUi()
     sortComboBox->blockSignals(false);
 }
 
+VisualDeckStorageSortFilterProxyModel::SortOrder VisualDeckStorageSortWidget::currentSortOrder() const
+{
+    return static_cast<VisualDeckStorageSortFilterProxyModel::SortOrder>(sortComboBox->currentIndex());
+}
+
 void VisualDeckStorageSortWidget::updateSortOrder()
 {
-    sortOrder = static_cast<SortOrder>(sortComboBox->currentIndex());
     SettingsCache::instance().visualDeckStorage().setVisualDeckStorageSortingOrder(sortComboBox->currentIndex());
     emit sortOrderChanged();
-}
-
-void VisualDeckStorageSortWidget::sortFolder(VisualDeckStorageFolderDisplayWidget *folderWidget)
-{
-    auto children =
-        folderWidget->getFlowWidget()->findChildren<QWidget *>(QString(), Qt::FindChildOption::FindDirectChildrenOnly);
-    for (auto widget : children) {
-        auto deckPreviewWidgets =
-            widget->findChildren<DeckPreviewWidget *>(QString(), Qt::FindChildOption::FindDirectChildrenOnly);
-        auto newOrder = filterFiles(deckPreviewWidgets);
-        for (DeckPreviewWidget *previewWidget : newOrder) {
-            folderWidget->getFlowWidget()->removeWidget(previewWidget);
-        }
-        for (DeckPreviewWidget *previewWidget : newOrder) {
-            folderWidget->getFlowWidget()->addWidget(previewWidget);
-        }
-    }
-}
-
-QList<DeckPreviewWidget *> VisualDeckStorageSortWidget::filterFiles(QList<DeckPreviewWidget *> widgets)
-{
-    // Sort the widgets list based on the current sort order
-    std::sort(widgets.begin(), widgets.end(), [this](DeckPreviewWidget *widget1, DeckPreviewWidget *widget2) {
-        if (!widget1 || !widget2) {
-            return false; // Handle null pointers gracefully
-        }
-
-        QFileInfo info1(widget1->filePath);
-        QFileInfo info2(widget2->filePath);
-
-        switch (sortOrder) {
-            case ByName:
-                return widget1->deckLoader->getDeck().deckList.getName() <
-                       widget2->deckLoader->getDeck().deckList.getName();
-            case Alphabetical:
-                return QString::localeAwareCompare(info1.fileName(), info2.fileName()) <= 0;
-            case ByLastModified:
-                return info1.lastModified() > info2.lastModified();
-            case ByLastLoaded: {
-                QDateTime time1 =
-                    QDateTime::fromString(widget1->deckLoader->getDeck().deckList.getLastLoadedTimestamp());
-                QDateTime time2 =
-                    QDateTime::fromString(widget2->deckLoader->getDeck().deckList.getLastLoadedTimestamp());
-                return time1 > time2;
-            }
-        }
-
-        return false; // Default case, no sorting applied
-    });
-
-    return widgets;
 }

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_sort_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_sort_widget.h
@@ -2,19 +2,17 @@
  * @file visual_deck_storage_sort_widget.h
  * @ingroup VisualDeckStorageWidgets
  */
-//! \todo Document this file.
 
 #ifndef VISUAL_DECK_STORAGE_SORT_WIDGET_H
 #define VISUAL_DECK_STORAGE_SORT_WIDGET_H
 
-#include "visual_deck_storage_widget.h"
+#include "visual_deck_storage_sort_filter_proxy_model.h"
 
 #include <QComboBox>
 #include <QHBoxLayout>
 #include <QWidget>
 
 class VisualDeckStorageWidget;
-class VisualDeckStorageFolderDisplayWidget;
 class VisualDeckStorageSortWidget : public QWidget
 {
     Q_OBJECT
@@ -22,25 +20,23 @@ class VisualDeckStorageSortWidget : public QWidget
 public:
     explicit VisualDeckStorageSortWidget(VisualDeckStorageWidget *parent);
     void retranslateUi();
-    void updateSortOrder();
-    void sortFolder(VisualDeckStorageFolderDisplayWidget *folderWidget);
-    QString getSearchText();
-    QList<DeckPreviewWidget *> filterFiles(QList<DeckPreviewWidget *> widgets);
+
+    /**
+     * @brief The currently selected sort order.
+     */
+    [[nodiscard]] VisualDeckStorageSortFilterProxyModel::SortOrder currentSortOrder() const;
 
 signals:
+    /**
+     * @brief Emitted when the user picks a different sort order.
+     */
     void sortOrderChanged();
 
+private slots:
+    void updateSortOrder();
+
 private:
-    enum SortOrder
-    {
-        ByName,
-        Alphabetical,
-        ByLastModified,
-        ByLastLoaded,
-    };
     QHBoxLayout *layout;
-    VisualDeckStorageWidget *parent;
-    SortOrder sortOrder; // Current sorting option
     QComboBox *sortComboBox;
 };
 

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.cpp
@@ -18,7 +18,7 @@ VisualDeckStorageTagFilterWidget::VisualDeckStorageTagFilterWidget(VisualDeckSto
 
     setFixedHeight(100);
 
-    auto *flowWidget = new FlowWidget(this, Qt::Horizontal, Qt::ScrollBarAlwaysOff, Qt::ScrollBarAsNeeded);
+    flowWidget = new FlowWidget(this, Qt::Horizontal, Qt::ScrollBarAlwaysOff, Qt::ScrollBarAsNeeded);
 
     layout->addWidget(flowWidget);
 }
@@ -29,45 +29,26 @@ void VisualDeckStorageTagFilterWidget::showEvent(QShowEvent *event)
     refreshTags();
 }
 
-void VisualDeckStorageTagFilterWidget::filterDecksBySelectedTags(const QList<DeckPreviewWidget *> &deckPreviews) const
+/**
+ * @brief The tags of all decks currently accepted by the proxy model.
+ */
+QSet<QString> VisualDeckStorageTagFilterWidget::gatherAllTags() const
 {
-    QStringList selectedTags;
-    QStringList excludedTags;
+    QSet<QString> allTags;
+    auto *proxy = parent->proxyModel();
+    auto *model = parent->model();
 
-    // Collect selected and excluded tags
-    for (DeckPreviewTagDisplayWidget *tagWidget : findChildren<DeckPreviewTagDisplayWidget *>()) {
-        switch (tagWidget->getState()) {
-            case TagState::Selected:
-                selectedTags.append(tagWidget->getTagName());
-                break;
-            case TagState::Excluded:
-                excludedTags.append(tagWidget->getTagName());
-                break;
-            default:
-                break;
+    for (int proxyRow = 0; proxyRow < proxy->rowCount(); ++proxyRow) {
+        const QModelIndex sourceIndex = proxy->mapToSource(proxy->index(proxyRow, 0));
+        if (!sourceIndex.isValid()) {
+            continue;
+        }
+        for (const QString &tag : model->dataForRow(sourceIndex.row()).tags) {
+            allTags.insert(tag);
         }
     }
 
-    // If no tags are selected or excluded, show all
-    if (selectedTags.isEmpty() && excludedTags.isEmpty()) {
-        for (DeckPreviewWidget *deckPreview : deckPreviews) {
-            deckPreview->filteredByTags = false;
-        }
-        return;
-    }
-
-    for (DeckPreviewWidget *deckPreview : deckPreviews) {
-        QStringList deckTags = deckPreview->deckLoader->getDeck().deckList.getTags();
-
-        bool hasAllSelected = std::all_of(selectedTags.begin(), selectedTags.end(),
-                                          [&deckTags](const QString &tag) { return deckTags.contains(tag); });
-
-        bool hasAnyExcluded = std::any_of(excludedTags.begin(), excludedTags.end(),
-                                          [&deckTags](const QString &tag) { return deckTags.contains(tag); });
-
-        // Filter out if any excluded tag is present or if any selected tag is missing
-        deckPreview->filteredByTags = !(hasAllSelected && !hasAnyExcluded);
-    }
+    return allTags;
 }
 
 void VisualDeckStorageTagFilterWidget::refreshTags()
@@ -80,8 +61,6 @@ void VisualDeckStorageTagFilterWidget::refreshTags()
 
 void VisualDeckStorageTagFilterWidget::removeTagsNotInList(const QSet<QString> &tags)
 {
-    auto *flowWidget = findChild<FlowWidget *>();
-
     for (DeckPreviewTagDisplayWidget *tagWidget : findChildren<DeckPreviewTagDisplayWidget *>()) {
         const QString &tagName = tagWidget->getTagName();
 
@@ -116,20 +95,12 @@ void VisualDeckStorageTagFilterWidget::addTagIfNotPresent(const QString &tag)
         auto *newTagWidget = new DeckPreviewTagDisplayWidget(this, tag);
         connect(newTagWidget, &DeckPreviewTagDisplayWidget::tagClicked, parent,
                 &VisualDeckStorageWidget::updateTagFilter);
-        connect(newTagWidget, &DeckPreviewTagDisplayWidget::tagClicked, this,
-                &VisualDeckStorageTagFilterWidget::refreshTags);
-        auto *flowWidget = findChild<FlowWidget *>();
         flowWidget->addWidget(newTagWidget);
     }
 }
 
 void VisualDeckStorageTagFilterWidget::sortTags()
 {
-    auto *flowWidget = findChild<FlowWidget *>();
-    if (!flowWidget) {
-        return;
-    }
-
     // Get all tag widgets
     QList<DeckPreviewTagDisplayWidget *> tagWidgets = findChildren<DeckPreviewTagDisplayWidget *>();
 
@@ -147,19 +118,26 @@ void VisualDeckStorageTagFilterWidget::sortTags()
     }
 }
 
-QSet<QString> VisualDeckStorageTagFilterWidget::gatherAllTags() const
+QStringList VisualDeckStorageTagFilterWidget::selectedTags() const
 {
-    QSet<QString> allTags;
-    QList<DeckPreviewWidget *> deckWidgets = parent->findChildren<DeckPreviewWidget *>();
-
-    for (DeckPreviewWidget *widget : deckWidgets) {
-        if (widget->checkVisibility()) {
-            for (const QString &tag : widget->deckLoader->getDeck().deckList.getTags()) {
-                allTags.insert(tag);
-            }
+    QStringList selected;
+    for (DeckPreviewTagDisplayWidget *tagWidget : findChildren<DeckPreviewTagDisplayWidget *>()) {
+        if (tagWidget->getState() == TagState::Selected) {
+            selected.append(tagWidget->getTagName());
         }
     }
-    return allTags;
+    return selected;
+}
+
+QStringList VisualDeckStorageTagFilterWidget::excludedTags() const
+{
+    QStringList excluded;
+    for (DeckPreviewTagDisplayWidget *tagWidget : findChildren<DeckPreviewTagDisplayWidget *>()) {
+        if (tagWidget->getState() == TagState::Excluded) {
+            excluded.append(tagWidget->getTagName());
+        }
+    }
+    return excluded;
 }
 
 QStringList VisualDeckStorageTagFilterWidget::getAllKnownTags() const

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_tag_filter_widget.h
@@ -2,21 +2,22 @@
  * @file visual_deck_storage_tag_filter_widget.h
  * @ingroup VisualDeckStorageWidgets
  */
-//! \todo Document this file.
 
 #ifndef VISUAL_DECK_STORAGE_TAG_FILTER_WIDGET_H
 #define VISUAL_DECK_STORAGE_TAG_FILTER_WIDGET_H
 
-#include "deck_preview/deck_preview_widget.h"
-
+#include <QSet>
+#include <QStringList>
 #include <QWidget>
 
+class FlowWidget;
 class VisualDeckStorageWidget;
 class VisualDeckStorageTagFilterWidget : public QWidget
 {
     Q_OBJECT
 
     VisualDeckStorageWidget *parent;
+    FlowWidget *flowWidget;
 
     [[nodiscard]] QSet<QString> gatherAllTags() const;
     void removeTagsNotInList(const QSet<QString> &tags);
@@ -27,9 +28,21 @@ class VisualDeckStorageTagFilterWidget : public QWidget
 public:
     explicit VisualDeckStorageTagFilterWidget(VisualDeckStorageWidget *_parent);
     [[nodiscard]] QStringList getAllKnownTags() const;
-    void filterDecksBySelectedTags(const QList<DeckPreviewWidget *> &deckPreviews) const;
+
+    /**
+     * @brief The tags currently in "selected" state.
+     */
+    [[nodiscard]] QStringList selectedTags() const;
+
+    /**
+     * @brief The tags currently in "excluded" state.
+     */
+    [[nodiscard]] QStringList excludedTags() const;
 
 public slots:
+    /**
+     * @brief Rebuilds the tag chips from the tags of the currently visible decks.
+     */
     void refreshTags();
     void showEvent(QShowEvent *event) override;
 };

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -2,24 +2,28 @@
 
 #include "../../../client/settings/cache_settings.h"
 #include "../quick_settings/settings_button_widget.h"
+#include "deck_preview/deck_preview_color_identity_filter_widget.h"
 #include "deck_preview/deck_preview_widget.h"
 #include "visual_deck_storage_folder_display_widget.h"
+#include "visual_deck_storage_quick_settings_widget.h"
 #include "visual_deck_storage_search_widget.h"
 #include "visual_deck_storage_sort_widget.h"
 #include "visual_deck_storage_tag_filter_widget.h"
 
-#include <QComboBox>
-#include <QDirIterator>
-#include <QMouseEvent>
+#include <QLabel>
+#include <QTimer>
 #include <QVBoxLayout>
 #include <libcockatrice/card/database/card_database_manager.h>
 #include <libcockatrice/settings/paths_settings.h>
 #include <libcockatrice/settings/visual_deck_storage_settings.h>
 
-VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(parent), folderWidget(nullptr)
+VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(parent)
 {
-    deckListModel = new DeckListModel(this);
-    deckListModel->setObjectName("visualDeckModel");
+    // The model and proxy own all deck data, sorting and filtering. The view widgets below only
+    // display the proxy's accepted rows, so nothing touches the filesystem outside the model.
+    model_ = new VisualDeckStorageModel(this);
+    proxyModel_ = new VisualDeckStorageSortFilterProxyModel(this);
+    proxyModel_->setSourceModel(model_);
 
     layout = new QVBoxLayout(this);
     layout->setSpacing(0);
@@ -75,6 +79,25 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     layout->addWidget(tagFilterWidget);
     layout->addWidget(scrollArea);
 
+    // The deck data changed (a load finished, or a mutation happened): re-evaluate the filters,
+    // since search/tag/color matches are computed against the data. Debounced so that a burst of
+    // load completions triggers a single re-application instead of one O(n) pass per deck.
+    refreshTimer = new QTimer(this);
+    refreshTimer->setSingleShot(true);
+    refreshTimer->setInterval(150);
+    connect(refreshTimer, &QTimer::timeout, this, [this] {
+        proxyModel_->reapplyFilters();
+        // A batch of decks finished loading: re-gather the tag chips from the visible decks once
+        // the burst settles instead of on every individual load.
+        tagFilterWidget->refreshTags();
+    });
+    connect(model_, &QAbstractItemModel::dataChanged, this, [this] { refreshTimer->start(); });
+    connect(model_, &VisualDeckStorageModel::deckLoaded, this, [this] { refreshTimer->start(); });
+    // A deck's file path changed: re-apply the sort, since orders like "filename" depend on it.
+    connect(model_, &VisualDeckStorageModel::deckFilePathChanged, this, [this] { proxyModel_->resort(); });
+    connect(sortWidget, &VisualDeckStorageSortWidget::sortOrderChanged, this,
+            &VisualDeckStorageWidget::updateSortOrder);
+
     connect(CardDatabaseManager::getInstance(), &CardDatabase::cardDatabaseLoadingFinished, this,
             &VisualDeckStorageWidget::createRootFolderWidget);
 
@@ -123,6 +146,8 @@ void VisualDeckStorageWidget::retranslateUi()
 
     refreshButton->setToolTip(tr("Refresh loaded files"));
     quickSettingsWidget->setToolTip(tr("Visual Deck Storage Settings"));
+
+    sortWidget->retranslateUi();
 }
 
 /**
@@ -134,72 +159,52 @@ const VisualDeckStorageQuickSettingsWidget *VisualDeckStorageWidget::settings() 
 }
 
 /**
- * Reapplies all sort and filter options by calling the appropriate update methods.
+ * Reapplies all sort and filter options by updating the proxy model.
  */
 void VisualDeckStorageWidget::reapplySortAndFilters()
 {
-    updateSortOrder();
-    updateTagFilter();
-    updateColorFilter();
-    updateSearchFilter();
+    proxyModel_->setSortOrder(sortWidget->currentSortOrder());
+    proxyModel_->reapplyFilters();
 }
 
+/**
+ * @brief Scans the deck folder and rebuilds the folder tree of deck previews.
+ */
 void VisualDeckStorageWidget::createRootFolderWidget()
 {
-    folderWidget = new VisualDeckStorageFolderDisplayWidget(this, this, SettingsCache::instance().paths().getDeckPath(),
-                                                            false, quickSettingsWidget->getShowFolders());
+    model_->setDeckPath(SettingsCache::instance().paths().getDeckPath());
+
+    folderWidget =
+        new VisualDeckStorageFolderDisplayWidget(this, this, QString(), false, quickSettingsWidget->getShowFolders());
 
     scrollArea->setWidget(folderWidget); // this automatically destroys the old folderWidget
     scrollArea->widget()->setMaximumWidth(scrollArea->viewport()->width());
     scrollArea->widget()->adjustSize();
 
-    /* We have to schedule a QTimer here so that the sorting logic doesn't try to access widgets that haven't been
-     * processed by the event loop yet. Otherwise, deck sorting will intermittently segfault on some systems.
-     */
-    QTimer::singleShot(0, this, &VisualDeckStorageWidget::reapplySortAndFilters);
+    // Sort and filter runs against the model data, so it is safe to apply immediately.
+    reapplySortAndFilters();
 }
 
 void VisualDeckStorageWidget::updateShowFolders(bool enabled)
 {
     if (folderWidget) {
         folderWidget->updateShowFolders(enabled);
-        QTimer::singleShot(0, this, &VisualDeckStorageWidget::reapplySortAndFilters);
     }
 }
 
 void VisualDeckStorageWidget::updateSortOrder()
 {
-    if (folderWidget) {
-        sortWidget->sortFolder(folderWidget);
-        for (VisualDeckStorageFolderDisplayWidget *subFolderWidget :
-             folderWidget->findChildren<VisualDeckStorageFolderDisplayWidget *>()) {
-            sortWidget->sortFolder(subFolderWidget);
-        }
-    }
+    proxyModel_->setSortOrder(sortWidget->currentSortOrder());
 }
 
 void VisualDeckStorageWidget::updateTagFilter()
 {
-    if (folderWidget) {
-        tagFilterWidget->filterDecksBySelectedTags(folderWidget->findChildren<DeckPreviewWidget *>());
-        folderWidget->updateVisibility();
-    }
-}
-
-void VisualDeckStorageWidget::updateColorFilter()
-{
-    if (folderWidget) {
-        deckPreviewColorIdentityFilterWidget->filterWidgets(folderWidget->findChildren<DeckPreviewWidget *>());
-        folderWidget->updateVisibility();
-    }
-}
-
-void VisualDeckStorageWidget::updateSearchFilter()
-{
-    if (folderWidget) {
-        searchWidget->filterWidgets(folderWidget->findChildren<DeckPreviewWidget *>(), searchWidget->getSearchText());
-        folderWidget->updateVisibility();
-    }
+    const QStringList selected = tagFilterWidget->selectedTags();
+    const QStringList excluded = tagFilterWidget->excludedTags();
+    proxyModel_->setTagFilter(QSet<QString>(selected.cbegin(), selected.cend()),
+                              QSet<QString>(excluded.cbegin(), excluded.cend()));
+    // The visible deck set changed, so the chips are re-gathered from it.
+    tagFilterWidget->refreshTags();
 }
 
 void VisualDeckStorageWidget::updateTagsVisibility(const bool visible)

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_widget.h
@@ -2,29 +2,30 @@
  * @file visual_deck_storage_widget.h
  * @ingroup VisualDeckStorageWidgets
  */
-//! \todo Document this file.
 
 #ifndef VISUAL_DECK_STORAGE_WIDGET_H
 #define VISUAL_DECK_STORAGE_WIDGET_H
 
-#include "../../deck_loader/deck_loader.h"
-#include "../cards/card_size_widget.h"
-#include "../quick_settings/settings_button_widget.h"
-#include "deck_preview/deck_preview_color_identity_filter_widget.h"
-#include "visual_deck_storage_folder_display_widget.h"
-#include "visual_deck_storage_quick_settings_widget.h"
-#include "visual_deck_storage_search_widget.h"
-#include "visual_deck_storage_sort_widget.h"
-#include "visual_deck_storage_tag_filter_widget.h"
+#include "visual_deck_storage_model.h"
+#include "visual_deck_storage_sort_filter_proxy_model.h"
 
-#include <libcockatrice/models/deck_list/deck_list_model.h>
+#include <QHBoxLayout>
+#include <QScrollArea>
+#include <QToolButton>
+#include <QVBoxLayout>
+#include <QWidget>
 
-class QSpinBox;
+class QLabel;
+class QResizeEvent;
+class QShowEvent;
+class QTimer;
+class DeckPreviewColorIdentityFilterWidget;
+class VisualDeckStorageFolderDisplayWidget;
+class VisualDeckStorageQuickSettingsWidget;
 class VisualDeckStorageSearchWidget;
 class VisualDeckStorageSortWidget;
 class VisualDeckStorageTagFilterWidget;
-class VisualDeckStorageFolderDisplayWidget;
-class DeckPreviewColorIdentityFilterWidget;
+
 class VisualDeckStorageWidget final : public QWidget
 {
     Q_OBJECT
@@ -37,29 +38,41 @@ public:
     bool deckPreviewSelectionAnimationEnabled;
 
     [[nodiscard]] const VisualDeckStorageQuickSettingsWidget *settings() const;
+    [[nodiscard]] VisualDeckStorageModel *model() const
+    {
+        return model_;
+    }
+    [[nodiscard]] VisualDeckStorageSortFilterProxyModel *proxyModel() const
+    {
+        return proxyModel_;
+    }
 
 public slots:
-    void createRootFolderWidget(); // Refresh the display of cards based on the current sorting option
+    /**
+     * @brief Starts scanning the deck folder and rebuilds the folder tree and previews.
+     */
+    void createRootFolderWidget();
     void updateShowFolders(bool enabled);
-    void updateTagFilter();
-    void updateColorFilter();
-    void updateSearchFilter();
     void updateTagsVisibility(bool visible);
     void updateSelectionAnimationEnabled(bool enabled);
     void updateSortOrder();
+    void updateTagFilter();
+
+signals:
+    void deckLoadRequested(const QString &filePath);
+    void openDeckEditor(const LoadedDeck &deck);
+
+protected:
     void resizeEvent(QResizeEvent *event) override;
     void showEvent(QShowEvent *event) override;
 
-signals:
-    void bannerCardsRefreshed();
-    void deckLoadRequested(const QString &filePath);
-    void openDeckEditor(const LoadedDeck &deck);
+private:
+    void reapplySortAndFilters();
 
 private:
     QVBoxLayout *layout;
     QWidget *searchAndSortContainer;
     QHBoxLayout *searchAndSortLayout;
-    DeckListModel *deckListModel;
     QLabel *databaseLoadIndicator;
     VisualDeckStorageSortWidget *sortWidget;
     VisualDeckStorageSearchWidget *searchWidget;
@@ -67,9 +80,10 @@ private:
     QToolButton *refreshButton;
     VisualDeckStorageQuickSettingsWidget *quickSettingsWidget;
     QScrollArea *scrollArea;
-    VisualDeckStorageFolderDisplayWidget *folderWidget;
-
-    void reapplySortAndFilters();
+    VisualDeckStorageFolderDisplayWidget *folderWidget = nullptr;
+    VisualDeckStorageModel *model_ = nullptr;
+    VisualDeckStorageSortFilterProxyModel *proxyModel_ = nullptr;
+    QTimer *refreshTimer = nullptr; ///< Coalesces the re-apply/refresh burst following a batch of deck loads.
 };
 
 #endif // VISUAL_DECK_STORAGE_WIDGET_H


### PR DESCRIPTION
## Related tickets

Based on:

- #7107 
- #7106 
- #7105 
- #7104

## Short roundup of the initial problem
Tags can only be stored in Cockatrice-format (.cod) files, but the deck editor never prompted for conversion, only the deck preview did.

## What will change with this Pull Request?
- The tag widget now registers a conversion handler: for a deck loaded from a .txt (or other) file it runs the same conversion prompt and converts the deck in place via DeckLoader::convertToCockatriceFormat, updating lastLoadInfo so the deck saves as .cod from then on.
