### PR TITLE
[DeckEditor] Reuse the inherited CardDatabaseModel in the visual editor

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual.cpp
@@ -27,7 +27,6 @@
 #include <QTimer>
 #include <QTreeView>
 #include <QVBoxLayout>
-#include <libcockatrice/card/database/card_database_manager.h>
 #include <libcockatrice/models/deck_list/deck_list_model.h>
 #include <libcockatrice/protocol/pb/command_deck_upload.pb.h>
 #include <libcockatrice/protocol/pending_command.h>
@@ -66,9 +65,6 @@ void TabDeckEditorVisual::createCentralFrame()
 
     centralFrame = new QVBoxLayout;
     centralWidget->setLayout(centralFrame);
-
-    auto databaseModel = new CardDatabaseModel(CardDatabaseManager::getInstance(), true, this);
-    databaseModel->setObjectName("databaseModel");
 
     tabContainer = new TabDeckEditorVisualTabWidget(centralWidget, this, deckStateManager->getModel(), databaseModel);
 

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.cpp
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_editor/tab_deck_editor_visual_tab_widget.cpp
@@ -25,7 +25,8 @@ TabDeckEditorVisualTabWidget::TabDeckEditorVisualTabWidget(QWidget *parent,
     layout = new QVBoxLayout(this);
     setLayout(layout);
 
-    visualDeckView = new VisualDeckEditorWidget(this, deckModel, _deckEditor->deckDockWidget->getSelectionModel());
+    visualDeckView = new VisualDeckEditorWidget(this, deckModel, _deckEditor->deckDockWidget->getSelectionModel(),
+                                                _cardDatabaseModel);
     visualDeckView->setObjectName("visualDeckView");
     connect(visualDeckView, &VisualDeckEditorWidget::activeCardChanged, this,
             &TabDeckEditorVisualTabWidget::onCardChanged);

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -29,8 +29,10 @@
 
 VisualDeckEditorWidget::VisualDeckEditorWidget(QWidget *parent,
                                                DeckListModel *_deckListModel,
-                                               QItemSelectionModel *_selectionModel)
-    : QWidget(parent), deckListModel(_deckListModel), selectionModel(_selectionModel)
+                                               QItemSelectionModel *_selectionModel,
+                                               CardDatabaseModel *_cardDatabaseModel)
+    : QWidget(parent), deckListModel(_deckListModel), selectionModel(_selectionModel),
+      cardDatabaseModel(_cardDatabaseModel)
 {
     // The Main Widget and Main Layout, which contain a single Widget: The Scroll Area
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -94,7 +96,9 @@ void VisualDeckEditorWidget::initializeSearchBarAndCompleter()
     setFocusProxy(searchBar);
     setFocusPolicy(Qt::ClickFocus);
 
-    cardDatabaseModel = new CardDatabaseModel(CardDatabaseManager::getInstance(), false, this);
+    if (!cardDatabaseModel) {
+        cardDatabaseModel = new CardDatabaseModel(CardDatabaseManager::getInstance(), false, this);
+    }
     cardDatabaseDisplayModel = new CardDatabaseDisplayModel(this);
     cardDatabaseDisplayModel->setSourceModel(cardDatabaseModel);
 

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.h
@@ -38,7 +38,10 @@ class VisualDeckEditorWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit VisualDeckEditorWidget(QWidget *parent, DeckListModel *deckListModel, QItemSelectionModel *selectionModel);
+    explicit VisualDeckEditorWidget(QWidget *parent,
+                                    DeckListModel *deckListModel,
+                                    QItemSelectionModel *selectionModel,
+                                    CardDatabaseModel *_cardDatabaseModel = nullptr);
     void retranslateUi();
     void updateCompactMode();
     void clearAllDisplayWidgets();


### PR DESCRIPTION
## Short roundup of the initial problem
The visual deck editor built three full CardDatabaseModels per tab: 
the one inherited from AbstractTabDeckEditor, a duplicate local model for the tab container, and a third one for the search completer. Each construction iterates the whole database, which dominated tab creation.

## What will change with this Pull Request?

Reuse the inherited databaseModel everywhere instead:
- TabDeckEditorVisual passes the inherited model to the tab widget.
- VisualDeckEditorWidget takes the model as a constructor parameter and uses it as the completer source, falling back to creating its own if none is passed.

