### PR TITLE
[VDD] Defer heavy construction until after the tab paints

### DIFF
--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -163,7 +163,7 @@ void VisualDatabaseDisplayWidget::initialize()
 
 void VisualDatabaseDisplayWidget::initializeFilters()
 {
-    if (filtersInitialized || !isVisible()) {
+    if (filtersInitialized || !isVisible() || CardDatabaseManager::getInstance()->getLoadStatus() != LoadStatus::Ok) {
         return;
     }
 
@@ -172,7 +172,9 @@ void VisualDatabaseDisplayWidget::initializeFilters()
     // The filter toolbar builds its widgets by iterating the entire card database
     // (per-set, per-main-type, per-sub-type and per-format buttons). Building it
     // inside showEvent would block the tab switch, so keep it hidden and defer the
-    // build to the next event loop turn, letting the tab paint first.
+    // build to the next event loop turn, letting the tab paint first. The toolbar
+    // then appears one event loop turn later, shifting the grid down by the toolbar
+    // height -- the intended tradeoff of an responsive tab switch.
     filterContainer->setVisible(false);
 
     QTimer::singleShot(0, this, [this] {
@@ -181,11 +183,7 @@ void VisualDatabaseDisplayWidget::initializeFilters()
 
         databaseDisplayModel->setFilterTree(filterModel->filterTree());
 
-        loadCardsTimer = new QTimer(this);
-        loadCardsTimer->setSingleShot(true); // Ensure it only fires once after the timeout
-
-        connect(loadCardsTimer, &QTimer::timeout, this, [this]() { loadCurrentPage(); });
-        loadCardsTimer->start(5000);
+        QTimer::singleShot(5000, this, [this] { loadCurrentPage(); });
 
         retranslateUi();
     });
@@ -322,7 +320,8 @@ void VisualDatabaseDisplayWidget::loadCurrentPage()
             initialLoadScheduled = true;
             qCDebug(VisualDatabaseDisplayLog) << "Loading the first page";
             // Defer the first page so the tab switch stays responsive. The card
-            // grid builds one event loop turn later.
+            // grid builds one event loop turn later. This also applies to
+            // search-driven reloads, which reset currentPage back to 0.
             QTimer::singleShot(0, this, [this] {
                 initialLoadScheduled = false;
                 populateCards();

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -16,6 +16,7 @@
 
 #include <QHeaderView>
 #include <QScrollBar>
+#include <QShowEvent>
 #include <QStyledItemDelegate>
 #include <libcockatrice/card/card_info_comparator.h>
 #include <libcockatrice/card/database/card_database.h>
@@ -140,9 +141,6 @@ void VisualDatabaseDisplayWidget::initialize()
 {
     databaseLoadIndicator->setVisible(false);
 
-    filterContainer->initialize();
-    filterContainer->setVisible(true);
-
     searchContainer->addWidget(colorFilterWidget);
     searchContainer->addWidget(clearFilterWidget);
     searchContainer->addWidget(searchEdit);
@@ -158,17 +156,45 @@ void VisualDatabaseDisplayWidget::initialize()
 
     mainLayout->addWidget(cardSizeWidget);
 
-    databaseDisplayModel->setFilterTree(filterModel->filterTree());
-
     connect(filterModel, &FilterTreeModel::layoutChanged, this, &VisualDatabaseDisplayWidget::onSearchModelChanged);
 
-    loadCardsTimer = new QTimer(this);
-    loadCardsTimer->setSingleShot(true); // Ensure it only fires once after the timeout
+    initializeFilters();
+}
 
-    connect(loadCardsTimer, &QTimer::timeout, this, [this]() { loadCurrentPage(); });
-    loadCardsTimer->start(5000);
+void VisualDatabaseDisplayWidget::initializeFilters()
+{
+    if (filtersInitialized || !isVisible()) {
+        return;
+    }
 
-    retranslateUi();
+    filtersInitialized = true;
+
+    // The filter toolbar builds its widgets by iterating the entire card database
+    // (per-set, per-main-type, per-sub-type and per-format buttons). Building it
+    // inside showEvent would block the tab switch, so keep it hidden and defer the
+    // build to the next event loop turn, letting the tab paint first.
+    filterContainer->setVisible(false);
+
+    QTimer::singleShot(0, this, [this] {
+        filterContainer->initialize();
+        filterContainer->setVisible(true);
+
+        databaseDisplayModel->setFilterTree(filterModel->filterTree());
+
+        loadCardsTimer = new QTimer(this);
+        loadCardsTimer->setSingleShot(true); // Ensure it only fires once after the timeout
+
+        connect(loadCardsTimer, &QTimer::timeout, this, [this]() { loadCurrentPage(); });
+        loadCardsTimer->start(5000);
+
+        retranslateUi();
+    });
+}
+
+void VisualDatabaseDisplayWidget::showEvent(QShowEvent *event)
+{
+    QWidget::showEvent(event);
+    initializeFilters();
 }
 
 void VisualDatabaseDisplayWidget::retranslateUi()
@@ -292,9 +318,16 @@ void VisualDatabaseDisplayWidget::loadCurrentPage()
 {
     // Ensure only the initial page is loaded
     if (currentPage == 0) {
-        // Only load the first page initially
-        qCDebug(VisualDatabaseDisplayLog) << "Loading the first page";
-        populateCards();
+        if (!initialLoadScheduled) {
+            initialLoadScheduled = true;
+            qCDebug(VisualDatabaseDisplayLog) << "Loading the first page";
+            // Defer the first page so the tab switch stays responsive. The card
+            // grid builds one event loop turn later.
+            QTimer::singleShot(0, this, [this] {
+                initialLoadScheduled = false;
+                populateCards();
+            });
+        }
     } else if (nearEndOfPage()) {
         // If not the first page, just load the next page and append to the flow widget
         loadNextPage();

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
@@ -120,12 +120,16 @@ private:
     int debounceTime = 300; // in Ms
     int currentPage = 0;    // Current page index
     int cardsPerPage = 100; // Number of cards per page
+    bool filtersInitialized = false;
+    bool initialLoadScheduled = false;
 
+    void initializeFilters();
     void highlightAllSearchEdit();
     bool nearEndOfPage() const;
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
+    void showEvent(QShowEvent *event) override;
 };
 
 #endif // VISUAL_DATABASE_DISPLAY_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.h
@@ -115,7 +115,6 @@ private:
     OverlapControlWidget *overlapControlWidget;
     CardSizeWidget *cardSizeWidget;
     QTimer *debounceTimer;
-    QTimer *loadCardsTimer;
 
     int debounceTime = 300; // in Ms
     int currentPage = 0;    // Current page index


### PR DESCRIPTION
## Short roundup of the initial problem
Opening the Visual Database Display tab blocked synchronously on two full-database passes: building the filter toolbar (per-set, per-main-type, per-sub-type and per-format buttons) and creating the first 100-card page.

## What will change with this Pull Request?
Both now run via QTimer::singleShot(0, ...) after the tab is shown for the first time, so the tab switch paints immediately and the content settles one event loop turn later.

The filter toolbar build is gated on first show (hidden tabs such as the deck editor startup path never pay the cost) and the toolbar stays hidden until it is fully built so no layout shift occurs after paint. The initial card page load is gated by currentPage == 0. Scrolling and search-driven loads remain immediate.

