### PR TITLE
[Doxygen] Add troubleshooting for card pictures and logs

### DIFF
--- a/doc/doxygen/extra-pages/user_documentation/index.md
+++ b/doc/doxygen/extra-pages/user_documentation/index.md
@@ -11,6 +11,11 @@
 
 - @subpage beta_release
 
+## Troubleshooting
+
+- @subpage fixing_card_pictures
+- @subpage enabling_debug_logs
+
 ## Syntax Help
 
 - @subpage search_syntax_help

--- a/doc/doxygen/extra-pages/user_documentation/troubleshooting/enabling_debug_logs.md
+++ b/doc/doxygen/extra-pages/user_documentation/troubleshooting/enabling_debug_logs.md
@@ -56,10 +56,12 @@ altogether. Note that this copy may be replaced when you update the client.
 Open the Terminal app (it is in 'Applications → Utilities') and run the following two commands, replacing the path
 with the full location of your file:
 
-```text
+```shell
 launchctl setenv QT_LOGGING_CONF /path/to/qtlogging.ini
 open -a Cockatrice
 ```
+
+You can also use `export QT_LOGGING_CONF=/path/to/qtlogging.ini` to set the variable for the current terminal session.
 
 The setting stays active until you log out or restart your Mac. If you have multiple users on the same Mac, be aware
 that this setting only applies to your user account.
@@ -69,14 +71,14 @@ that this setting only applies to your user account.
 For a quick test, open a terminal and start Cockatrice with the file on the command line, replacing the path with the
 full location of your file:
 
-```text
+```shell
 QT_LOGGING_CONF=/path/to/qtlogging.ini cockatrice
 ```
 
 If this works and you want it to apply every time you start Cockatrice, add the following line to your `~/.profile`
 file and log in again:
 
-```text
+```shell
 export QT_LOGGING_CONF="/path/to/qtlogging.ini"
 ```
 
@@ -92,7 +94,7 @@ operating system.
 
 If you prefer to capture everything to a file instead, start Cockatrice with the `--debug-output` option:
 
-```text
+```shell
 cockatrice --debug-output
 ```
 

--- a/doc/doxygen/extra-pages/user_documentation/troubleshooting/enabling_debug_logs.md
+++ b/doc/doxygen/extra-pages/user_documentation/troubleshooting/enabling_debug_logs.md
@@ -104,18 +104,18 @@ Every message Cockatrice logs belongs to a category. The following table lists t
 grouped by area. Enable a category by adding a line like `category = true` to your `qtlogging.ini` file (or use a `.*`
 suffix, e.g. `card_picture_loader.*`, to include all sub categories).
 
-| What you want to see | Categories |
-|----------------------|------------|
-| Card picture loading (URLs, local file hits/misses, downloads, redirects) | `card_picture_loader.*` |
-| Card database loading and parsing | `card_database`, `card_database.loading`, `card_database.loading.success_or_failure`, `cockatrice_xml.*` |
-| Card, set, and deck information | `card_info`, `card_list`, `deck_loader` |
-| Startup sequence and update checks | `window_main.startup.*`, `release_channel`, `spoiler_background_updater` |
-| User interface and themes | `theme_manager`, `sound_engine`, `flow_layout`, `flow_widget.*`, `pixel_map_generator`, `card_info_picture_widget` |
-| Networking and servers | `local_client`, `remote_client`, `tapped_out_interface`, `servers_settings` |
-| In-game logic | `player`, `game_scene.*`, `card_zone.*`, `view_zone`, `game_event_handler` |
-| Dialogs and tabs | `dlg_settings`, `dlg_update`, `dlg_tip_of_the_day`, `tab_game`, `tab_message`, `tab_supervisor` |
-| Settings and shortcuts | `settings_cache`, `shortcuts_settings` |
-| Deck and card filtering | `filter_string`, `deck_filter_string`, `syntax_help` |
+| What you want to see                                                      | Categories                                                                                                         |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Card picture loading (URLs, local file hits/misses, downloads, redirects) | `card_picture_loader.*`                                                                                            |
+| Card database loading and parsing                                         | `card_database`, `card_database.loading`, `card_database.loading.success_or_failure`, `cockatrice_xml.*`           |
+| Card, set, and deck information                                           | `card_info`, `card_list`, `deck_loader`                                                                            |
+| Startup sequence and update checks                                        | `window_main.startup.*`, `release_channel`, `spoiler_background_updater`                                           |
+| User interface and themes                                                 | `theme_manager`, `sound_engine`, `flow_layout`, `flow_widget.*`, `pixel_map_generator`, `card_info_picture_widget` |
+| Networking and servers                                                    | `local_client`, `remote_client`, `tapped_out_interface`, `servers_settings`                                        |
+| In-game logic                                                             | `player`, `game_scene.*`, `card_zone.*`, `view_zone`, `game_event_handler`                                         |
+| Dialogs and tabs                                                          | `dlg_settings`, `dlg_update`, `dlg_tip_of_the_day`, `tab_game`, `tab_message`, `tab_supervisor`                    |
+| Settings and shortcuts                                                    | `settings_cache`, `shortcuts_settings`                                                                             |
+| Deck and card filtering                                                   | `filter_string`, `deck_filter_string`, `syntax_help`                                                               |
 
 For example, to investigate why a card database update seems to fail, enable the card database categories:
 

--- a/doc/doxygen/extra-pages/user_documentation/troubleshooting/enabling_debug_logs.md
+++ b/doc/doxygen/extra-pages/user_documentation/troubleshooting/enabling_debug_logs.md
@@ -1,0 +1,138 @@
+@page enabling_debug_logs Enabling Debug Logs
+
+Cockatrice ships with a "diagnostics mode" that prints detailed debug messages about what the client is doing. This is
+extremely useful when asking for help, because it shows exactly what happened: which URL the card picture loader tried,
+whether it found or missed a file on disk, whether a download succeeded or failed, which redirects were followed, and
+much more. Each of these messages belongs to a category, and you can enable or disable categories individually.
+
+Don't worry, this sounds more technical than it is. You only need to do two things: create one small text file, and tell
+Cockatrice where it is. There are no installation steps and you can undo everything later (see [When you are
+done](#when-you-are-done)).
+
+# Step 1: Create the file
+
+Open a plain text editor (Notepad on Windows, TextEdit on macOS, or any text editor on Linux) and paste the following
+content:
+
+```ini
+[Rules]
+# The default log level is info
+*.debug = false
+
+# Turn on debug level logs for the card picture loader and all its sub categories
+card_picture_loader.* = true
+```
+
+Save the file with the exact name `qtlogging.ini` in a place you can find again, for example your Documents folder.
+
+\attention The file name matters: it must be `qtlogging.ini`, not `qtlogging.ini.txt`. If your text editor adds a
+`.txt` extension automatically, you need to stop it from doing so (see below). On macOS, TextEdit must be switched to
+plain text mode first via 'Format → Make Plain Text'.
+
+The file contains one rule per line. The `*.debug = false` rule turns off debug messages everywhere by default, and the
+`card_picture_loader.* = true` line then re-enables them for the card picture loader. The `.*` at the end means "this
+category and all of its sub categories". To enable a different category instead, just replace that line with the
+category name of your choice, for example `card_database.loading = true` or `window_main.startup = true`.
+
+# Step 2: Tell Cockatrice where the file is
+
+Cockatrice does not know about the file yet. You have to point it there by setting an environment variable called
+`QT_LOGGING_CONF` to the full location of your file. How to do this depends on your operating system:
+
+**Windows**
+
+1. Press the Windows key, type "environment variables", and open "Edit the system environment variables".
+2. Click "Environment Variables...", then under "User variables" click "New...".
+3. Set "Variable name" to `QT_LOGGING_CONF` and "Variable value" to the full path of your file, for example
+   `C:\Users\YourName\Documents\qtlogging.ini`.
+4. Confirm all dialogs, then close and reopen Cockatrice.
+
+Alternatively, if Cockatrice is installed in a folder you can write to, you can simply place the `qtlogging.ini` file
+directly next to the Cockatrice executable (in the same folder as `cockatrice.exe`) and skip the environment variable
+altogether. Note that this copy may be replaced when you update the client.
+
+**macOS**
+
+Open the Terminal app (it is in 'Applications → Utilities') and run the following two commands, replacing the path
+with the full location of your file:
+
+```text
+launchctl setenv QT_LOGGING_CONF /path/to/qtlogging.ini
+open -a Cockatrice
+```
+
+The setting stays active until you log out or restart your Mac. If you have multiple users on the same Mac, be aware
+that this setting only applies to your user account.
+
+**Linux**
+
+For a quick test, open a terminal and start Cockatrice with the file on the command line, replacing the path with the
+full location of your file:
+
+```text
+QT_LOGGING_CONF=/path/to/qtlogging.ini cockatrice
+```
+
+If this works and you want it to apply every time you start Cockatrice, add the following line to your `~/.profile`
+file and log in again:
+
+```text
+export QT_LOGGING_CONF="/path/to/qtlogging.ini"
+```
+
+# Step 3: See the logs
+
+Now that debug logging is enabled, open Cockatrice and trigger the behavior you are investigating, for example by
+opening a deck, reloading the card database, or starting a game.
+
+The easiest way to see the logs is to use the built-in log viewer inside Cockatrice itself: open 'Help → View Debug
+Log'. A window appears that shows the log messages live and keeps the most recent entries. It even has a 'Copy to
+clipboard' button so you can paste the output into a bug report or a Discord message. This works the same on every
+operating system.
+
+If you prefer to capture everything to a file instead, start Cockatrice with the `--debug-output` option:
+
+```text
+cockatrice --debug-output
+```
+
+Cockatrice then writes the full log to a file called `qdebug.txt` in the folder it was started from.
+
+# Which categories are available?
+
+Every message Cockatrice logs belongs to a category. The following table lists the most useful ones for troubleshooting,
+grouped by area. Enable a category by adding a line like `category = true` to your `qtlogging.ini` file (or use a `.*`
+suffix, e.g. `card_picture_loader.*`, to include all sub categories).
+
+| What you want to see | Categories |
+|----------------------|------------|
+| Card picture loading (URLs, local file hits/misses, downloads, redirects) | `card_picture_loader.*` |
+| Card database loading and parsing | `card_database`, `card_database.loading`, `card_database.loading.success_or_failure`, `cockatrice_xml.*` |
+| Card, set, and deck information | `card_info`, `card_list`, `deck_loader` |
+| Startup sequence and update checks | `window_main.startup.*`, `release_channel`, `spoiler_background_updater` |
+| User interface and themes | `theme_manager`, `sound_engine`, `flow_layout`, `flow_widget.*`, `pixel_map_generator`, `card_info_picture_widget` |
+| Networking and servers | `local_client`, `remote_client`, `tapped_out_interface`, `servers_settings` |
+| In-game logic | `player`, `game_scene.*`, `card_zone.*`, `view_zone`, `game_event_handler` |
+| Dialogs and tabs | `dlg_settings`, `dlg_update`, `dlg_tip_of_the_day`, `tab_game`, `tab_message`, `tab_supervisor` |
+| Settings and shortcuts | `settings_cache`, `shortcuts_settings` |
+| Deck and card filtering | `filter_string`, `deck_filter_string`, `syntax_help` |
+
+For example, to investigate why a card database update seems to fail, enable the card database categories:
+
+```ini
+[Rules]
+*.debug = false
+
+card_database = true
+card_database.loading = true
+card_database.loading.success_or_failure = true
+cockatrice_xml.* = true
+```
+
+# When you are done
+
+To turn the diagnostics back off, just reverse what you did: remove the `QT_LOGGING_CONF` environment variable (or
+unset it again via `launchctl unsetenv QT_LOGGING_CONF` on macOS) and/or delete the `qtlogging.ini` file, then restart
+Cockatrice. Leaving it on is harmless, but the extra logging can make the client slightly slower.
+
+For the full details on how Cockatrice logging works, including the complete list of categories, see @ref logging.

--- a/doc/doxygen/extra-pages/user_documentation/troubleshooting/fixing_card_pictures.md
+++ b/doc/doxygen/extra-pages/user_documentation/troubleshooting/fixing_card_pictures.md
@@ -55,13 +55,13 @@ Cockatrice checks the following locations, in order:
 
 The following import naming schemes are recognized (using both `_` and `-` as separators):
 
-| Scheme                | Pattern                    |
-|-----------------------|----------------------------|
-| Card Name + Provider ID | `{name}_{providerId}`    |
+| Scheme                      | Pattern                    |
+| --------------------------- | -------------------------- |
+| Card Name + Provider ID     | `{name}_{providerId}`      |
 | Card Name + Set + Collector | `{name}_{set}_{collector}` |
 | Set + Collector + Card Name | `{set}_{collector}_{name}` |
-| Card Name + Set       | `{name}_{set}`             |
-| Card Name             | `{name}`                   |
+| Card Name + Set             | `{name}_{set}`             |
+| Card Name                   | `{name}`                   |
 
 If a picture you downloaded or placed manually is wrong, stale, or corrupted, delete the offending file. Pay special
 attention to the `downloadedPics` subfolder: this is where the filesystem caching method writes downloaded images, and

--- a/doc/doxygen/extra-pages/user_documentation/troubleshooting/fixing_card_pictures.md
+++ b/doc/doxygen/extra-pages/user_documentation/troubleshooting/fixing_card_pictures.md
@@ -1,0 +1,112 @@
+@page fixing_card_pictures Fixing Card Pictures
+
+This guide collects the common causes for card pictures not showing up, showing the wrong printing, or showing the
+card back instead of the artwork, and how to fix them.
+
+Work through the steps in order. In most cases the problem is caused by an outdated client, misconfigured download
+URLs, stale local images, or a corrupted cache.
+
+# Update Your Client
+
+Picture handling bugs are fixed on a regular basis, so the first thing to try is updating your client.
+
+Use the update check in 'Help → Check for Updates' (or look for the update prompt shown on startup).
+
+If a fix has not yet made it into the latest stable release, it may already be available in the beta release. The beta
+ships very frequently and usually receives a follow-up fix within a day or two if something breaks.
+
+See @subpage beta_release for instructions on how to switch to the beta channel.
+
+# Check Your Download URLs
+
+Card pictures are downloaded from a list of URL templates. Each template is tried in order until one produces a valid
+image, so the order matters: URLs at the top of the list are tried first.
+
+The list can be found in 'Cockatrice → Settings' (or Ctrl + Shift + P by default), on the 'Deck Editor' tab, in the
+'URL Download Priority' section. Make sure 'Download card pictures on the fly' is enabled and that the list contains
+valid URLs. If you suspect the list has been modified or corrupted, press 'Reset Download URLs' to restore the
+defaults:
+
+```text
+https://cards.scryfall.io/large/!prop:side!/!set:uuid_substr_0_1!/!set:uuid_substr_1_1!/!set:uuid!.jpg
+https://api.scryfall.com/cards/!set:uuid!?format=image&face=!prop:side!
+https://api.scryfall.com/cards/multiverse/!set:muid!?format=image
+https://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!set:muid!&type=card
+https://gatherer.wizards.com/Handlers/Image.ashx?name=!name!&type=card
+```
+
+For information on how to add your own custom URL templates, see the 'How to add a custom URL' link in the same
+settings section.
+
+\attention The Scryfall templates resolve the exact printing of a card, while the Gatherer templates do not. See
+[Provider Accuracy](#provider-accuracy) below.
+
+# Check Your Local Picture Folder
+
+Before any network request is made, Cockatrice looks for local image files. If a matching file is found on disk it is
+shown instead of anything downloaded, even if it is the wrong image.
+
+The pictures directory is configured on the 'General' settings tab, under 'Directories' → 'Pictures directory'.
+Cockatrice checks the following locations, in order:
+
+- The custom pictures folder (recursively indexed by file name).
+- `<pictures directory>/<set code>/<card file name>`
+- `<pictures directory>/downloadedPics/<set code>/<card file name>`
+
+The following import naming schemes are recognized (using both `_` and `-` as separators):
+
+| Scheme                | Pattern                    |
+|-----------------------|----------------------------|
+| Card Name + Provider ID | `{name}_{providerId}`    |
+| Card Name + Set + Collector | `{name}_{set}_{collector}` |
+| Set + Collector + Card Name | `{set}_{collector}_{name}` |
+| Card Name + Set       | `{name}_{set}`             |
+| Card Name             | `{name}`                   |
+
+If a picture you downloaded or placed manually is wrong, stale, or corrupted, delete the offending file. Pay special
+attention to the `downloadedPics` subfolder: this is where the filesystem caching method writes downloaded images, and
+after a provider outage it can permanently contain the wrong printing until you delete it manually.
+
+See @ref loading_card_pictures for details on how local images are loaded.
+
+# Clear Caches
+
+Cockatrice caches card pictures in three places. All of them can be managed on the 'Storage' settings tab:
+
+- **Network cache** — downloaded images stored on disk. Press 'Delete Cached Images' to clear it.
+- **Filesystem / image backup** — downloaded images written directly to `downloadedPics`. Press 'Delete Saved Images'
+  to clear it.
+- **In-memory (pixmap) cache** — images currently held in RAM. Press 'Clear In-Memory Images' to clear it.
+
+If a provider outage caused the wrong pictures to be downloaded and cached, clearing the network cache (and the
+'Delete Saved Images' button if you use the filesystem caching method) will force Cockatrice to download the correct
+images again. The redirect cache TTL (also on the Storage tab) controls how long previously seen redirects for
+download URLs are remembered; lowering it can help if a URL used to redirect somewhere else.
+
+# Restart the Client
+
+After updating the client, changing the download URLs, moving or deleting local image files, or clearing caches, it is
+recommended to restart Cockatrice so that all changes are fully picked up.
+
+# Enable Picture Loader Logs
+
+If the steps above did not solve the problem, you can turn on a "diagnostics mode" that prints what the picture loader
+is actually doing: which URL it is trying, whether it found or missed a file on disk, whether the download succeeded or
+failed, and which redirects it followed. This information is extremely useful when asking for help.
+
+See @subpage enabling_debug_logs for a step-by-step guide on how to enable the logs, including instructions
+for Windows, macOS, and Linux.
+
+# Provider Accuracy
+
+Cards in Cockatrice are identified by a provider ID, which is the Scryfall UUID of a specific printing. Decks store
+this ID, which is why the exact printing a card was added as can be looked up again.
+
+The Scryfall URL templates built into Cockatrice use this provider ID directly (`!set:uuid!`), so they always download
+the exact printing that was requested.
+
+The Gatherer URL templates, on the other hand, do **not** use the provider ID. They resolve pictures by multiverse ID
+(`!set:muid!`) or by card name (`!name!`) only. As a result they may return a different printing than the one the
+provider ID refers to, or no picture at all for cards Gatherer does not know. If you need pictures to match the exact
+printing of a card, make sure the Scryfall URLs are at the top of your download URL priority list and consider removing
+or demoting the Gatherer URLs.

--- a/doc/doxygen/extra-pages/user_documentation/troubleshooting/fixing_card_pictures.md
+++ b/doc/doxygen/extra-pages/user_documentation/troubleshooting/fixing_card_pictures.md
@@ -25,21 +25,10 @@ image, so the order matters: URLs at the top of the list are tried first.
 The list can be found in 'Cockatrice → Settings' (or Ctrl + Shift + P by default), on the 'Deck Editor' tab, in the
 'URL Download Priority' section. Make sure 'Download card pictures on the fly' is enabled and that the list contains
 valid URLs. If you suspect the list has been modified or corrupted, press 'Reset Download URLs' to restore the
-defaults:
-
-```text
-https://cards.scryfall.io/large/!prop:side!/!set:uuid_substr_0_1!/!set:uuid_substr_1_1!/!set:uuid!.jpg
-https://api.scryfall.com/cards/!set:uuid!?format=image&face=!prop:side!
-https://api.scryfall.com/cards/multiverse/!set:muid!?format=image
-https://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=!set:muid!&type=card
-https://gatherer.wizards.com/Handlers/Image.ashx?name=!name!&type=card
-```
+defaults.
 
 For information on how to add your own custom URL templates, see the 'How to add a custom URL' link in the same
 settings section.
-
-\attention The Scryfall templates resolve the exact printing of a card, while the Gatherer templates do not. See
-[Provider Accuracy](#provider-accuracy) below.
 
 # Check Your Local Picture Folder
 
@@ -88,7 +77,15 @@ download URLs are remembered; lowering it can help if a URL used to redirect som
 After updating the client, changing the download URLs, moving or deleting local image files, or clearing caches, it is
 recommended to restart Cockatrice so that all changes are fully picked up.
 
-# Enable Picture Loader Logs
+# Check Logs
+
+Before changing any settings, check the existing logs first. Rate limit errors and most download errors are already
+logged at warn level, so you may find the cause without enabling debug mode.
+
+Open 'Help → View Debug Log' and look for error or warning messages related to card picture loading. If you need more
+detail than the default log level provides, see below.
+
+# Enable Picture Loader Debug Logs
 
 If the steps above did not solve the problem, you can turn on a "diagnostics mode" that prints what the picture loader
 is actually doing: which URL it is trying, whether it found or missed a file on disk, whether the download succeeded or


### PR DESCRIPTION
## Short roundup of the initial problem
~~I'm tired of answering these questions.~~

The internal workings of the picture loader and Cockatrice are a mystery to the average user. While these explanations don't exactly demystify all the internals, they at least guide the user through all the steps, in order, that I would otherwise tell them to do in Discord.

## What will change with this Pull Request?
- Add documentation about how the picture loader works, how images are sourced, how caches can be reset
- Add documentation about how to enable logging now that we've nixed all the debug logging.
