### PR TITLE
[CI] `macos-14` GHA runner is deprecated

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -278,8 +278,8 @@ jobs:
             xcode: "16.4"
 
           - os: macOS
-            target: 14
-            runner: macos-15
+            target: 14    # EOL Apple 2026-??
+            runner: macos-15    # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md
 
             ccache_eviction_age: 7d
             cmake_generator: Ninja
@@ -291,7 +291,7 @@ jobs:
             soc: Apple
             type: Release
             use_ccache: 1
-            xcode: "15.4"
+            xcode: "16.4"
 
           - os: macOS
             target: 15

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -42,7 +42,7 @@ concurrency:
 jobs:
   configure:
     name: Configure
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-slim    # https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md
     outputs:
       tag: ${{ steps.configure.outputs.tag }}
       sha: ${{ steps.configure.outputs.sha }}
@@ -146,7 +146,7 @@ jobs:
 
     name: ${{ matrix.distro }} ${{ matrix.version }}
     needs: configure
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest    # https://github.com/actions/runner-images
     continue-on-error: ${{ matrix.allow-failure == 'yes' }}
     timeout-minutes: 70
     env:
@@ -262,8 +262,8 @@ jobs:
       matrix:
         include:
           - os: macOS
-            target: 13
-            runner: macos-15-intel
+            target: 13    # EOL 2025-09-15
+            runner: macos-15-intel    # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
 
             ccache_eviction_age: 7d
             cmake_generator: Ninja
@@ -275,10 +275,10 @@ jobs:
             soc: Intel
             type: Release
             use_ccache: 1
-            xcode: "16.4"
+            xcode: "26.3"
 
           - os: macOS
-            target: 14    # EOL Apple 2026-??
+            target: 14    # EOL 2026-??
             runner: macos-15    # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md
 
             ccache_eviction_age: 7d
@@ -291,11 +291,11 @@ jobs:
             soc: Apple
             type: Release
             use_ccache: 1
-            xcode: "16.4"
+            xcode: "26.3"
 
           - os: macOS
             target: 15
-            runner: macos-15
+            runner: macos-15    # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md
 
             ccache_eviction_age: 7d
             cmake_generator: Ninja
@@ -306,11 +306,11 @@ jobs:
             soc: Apple
             type: Release
             use_ccache: 1
-            xcode: "16.4"
+            xcode: "26.3"
 
           - os: macOS
             target: 15
-            runner: macos-15
+            runner: macos-15    # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md
 
             ccache_eviction_age: 7d
             cmake_generator: Ninja
@@ -319,11 +319,11 @@ jobs:
             soc: Apple
             type: Debug
             use_ccache: 1
-            xcode: "16.4"
+            xcode: "26.3"
 
           - os: Windows
             target: 10
-            runner: windows-2025
+            runner: windows-2025    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-VS2026-Readme.md
 
             cmake_generator: "Visual Studio 18 2026"
             cmake_generator_platform: x64

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -279,11 +279,12 @@ jobs:
 
           - os: macOS
             target: 14
-            runner: macos-14
+            runner: macos-15
 
             ccache_eviction_age: 7d
             cmake_generator: Ninja
             make_package: 1
+            override_target: 14
             package_suffix: "-macOS14"
             qt_version: 6.11.0
             qt_modules: qtimageformats qtmultimedia qtwebsockets


### PR DESCRIPTION
## Related Ticket(s)
- See `https://github.com/actions/runner-images/issues/13518`

## Short roundup of the initial problem
>**Breaking changes**
>
>GitHub Actions announcing the **deprecation process for macOS 14 and macOS 14 arm64**. While the images are being deprecated, You may experience longer queue times during peak usage hours. **Deprecation will begin on July 6th, 2026 and the images will be fully unsupported by November 2nd, 2026 for GitHub Actions** and Azure DevOps.

## What will change with this Pull Request?
- Use `macos-15` image and target macOS 14, similar to how we are shipping macOS 13 (x86) still
- Bump used Xcode versions to 26.3
- Add EOL notes and links to used runner images
