### PR TITLE
[Server] Consolidate Server_Game ctor params into a GameConfig struct

### DIFF
--- a/libcockatrice_network/libcockatrice/network/server/remote/CMakeLists.txt
+++ b/libcockatrice_network/libcockatrice/network/server/remote/CMakeLists.txt
@@ -10,6 +10,7 @@ set(HEADERS
     game/server_card.h
     game/server_cardzone.h
     game/server_counter.h
+    game/game_config.h
     game/server_game.h
     game/server_player.h
     game/server_spectator.h

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/game_config.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/game_config.h
@@ -1,0 +1,26 @@
+#ifndef GAME_CONFIG_H
+#define GAME_CONFIG_H
+
+#include <QList>
+#include <QString>
+#include <libcockatrice/protocol/pb/serverinfo_user.pb.h>
+
+struct GameConfig
+{
+    ServerInfo_User creatorInfo;
+    int gameId = -1;
+    QString description;
+    QString password;
+    int maxPlayers = 2;
+    QList<int> gameTypes;
+    bool onlyBuddies = false;
+    bool onlyRegistered = false;
+    bool spectatorsAllowed = false;
+    bool spectatorsNeedPassword = false;
+    bool spectatorsCanTalk = true;
+    bool spectatorsSeeEverything = true;
+    int startingLifeTotal = 20;
+    bool shareDecklistsOnLoad = true;
+};
+
+#endif

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
@@ -53,34 +53,19 @@
 #include <libcockatrice/protocol/pb/game_replay.pb.h>
 #include <libcockatrice/utility/zone_names.h>
 
-Server_Game::Server_Game(const ServerInfo_User &_creatorInfo,
-                         int _gameId,
-                         const QString &_description,
-                         const QString &_password,
-                         int _maxPlayers,
-                         const QList<int> &_gameTypes,
-                         bool _onlyBuddies,
-                         bool _onlyRegistered,
-                         bool _spectatorsAllowed,
-                         bool _spectatorsNeedPassword,
-                         bool _spectatorsCanTalk,
-                         bool _spectatorsSeeEverything,
-                         int _startingLifeTotal,
-                         bool _shareDecklistsOnLoad,
-                         Server_Room *_room)
-    : QObject(), room(_room), nextPlayerId(0), hostId(0), creatorInfo(new ServerInfo_User(_creatorInfo)),
-      gameStarted(false), gameClosed(false), gameId(_gameId), password(_password), maxPlayers(_maxPlayers),
-      gameTypes(_gameTypes), activePlayer(-1), activePhase(-1), onlyBuddies(_onlyBuddies),
-      onlyRegistered(_onlyRegistered), spectatorsAllowed(_spectatorsAllowed),
-      spectatorsNeedPassword(_spectatorsNeedPassword), spectatorsCanTalk(_spectatorsCanTalk),
-      spectatorsSeeEverything(_spectatorsSeeEverything), startingLifeTotal(_startingLifeTotal),
-      shareDecklistsOnLoad(_shareDecklistsOnLoad), inactivityCounter(0), startTimeOfThisGame(0), secondsElapsed(0),
-      firstGameStarted(false), turnOrderReversed(false), startTime(QDateTime::currentDateTime()), pingClock(nullptr),
-      gameMutex()
+Server_Game::Server_Game(const GameConfig &config, Server_Room *_room)
+    : QObject(), room(_room), nextPlayerId(0), hostId(0), creatorInfo(new ServerInfo_User(config.creatorInfo)),
+      gameStarted(false), gameClosed(false), gameId(config.gameId), description(config.description.simplified()),
+      password(config.password), maxPlayers(config.maxPlayers), gameTypes(config.gameTypes), activePlayer(-1),
+      activePhase(-1), onlyBuddies(config.onlyBuddies), onlyRegistered(config.onlyRegistered),
+      spectatorsAllowed(config.spectatorsAllowed), spectatorsNeedPassword(config.spectatorsNeedPassword),
+      spectatorsCanTalk(config.spectatorsCanTalk), spectatorsSeeEverything(config.spectatorsSeeEverything),
+      startingLifeTotal(config.startingLifeTotal), shareDecklistsOnLoad(config.shareDecklistsOnLoad),
+      inactivityCounter(0), startTimeOfThisGame(0), secondsElapsed(0), firstGameStarted(false),
+      turnOrderReversed(false), startTime(QDateTime::currentDateTime()), pingClock(nullptr), gameMutex()
 {
     currentReplay = new GameReplay;
     currentReplay->set_replay_id(room->getServer()->getDatabaseInterface()->getNextReplayId());
-    description = _description.simplified();
 
     connect(this, &Server_Game::sigStartGameIfReady, this, &Server_Game::doStartGameIfReady, Qt::QueuedConnection);
 

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.h
@@ -21,6 +21,7 @@
 #define SERVERGAME_H
 
 #include "../server_response_containers.h"
+#include "game_config.h"
 
 #include <QDateTime>
 #include <QMap>
@@ -92,21 +93,7 @@ private slots:
 
 public:
     mutable QRecursiveMutex gameMutex;
-    Server_Game(const ServerInfo_User &_creatorInfo,
-                int _gameId,
-                const QString &_description,
-                const QString &_password,
-                int _maxPlayers,
-                const QList<int> &_gameTypes,
-                bool _onlyBuddies,
-                bool _onlyRegistered,
-                bool _spectatorsAllowed,
-                bool _spectatorsNeedPassword,
-                bool _spectatorsCanTalk,
-                bool _spectatorsSeeEverything,
-                int _startingLifeTotal,
-                bool _shareDecklistsOnLoad,
-                Server_Room *parent);
+    Server_Game(const GameConfig &config, Server_Room *parent);
     ~Server_Game() override;
     Server_Room *getRoom() const
     {

--- a/libcockatrice_network/libcockatrice/network/server/remote/server_protocolhandler.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/server_protocolhandler.cpp
@@ -1,5 +1,6 @@
 #include "server_protocolhandler.h"
 
+#include "game/game_config.h"
 #include "game/server_game.h"
 #include "game/server_player.h"
 #include "server_database_interface.h"
@@ -920,10 +921,22 @@ Server_ProtocolHandler::cmdCreateGame(const Command_CreateGame &cmd, Server_Room
 
     // When server doesn't permit registered users to exist, do not honor only-reg setting
     bool onlyRegisteredUsers = cmd.only_registered() && (server->permitUnregisteredUsers());
-    auto *game = new Server_Game(copyUserInfo(false), gameId, description, QString::fromStdString(cmd.password()),
-                                 cmd.max_players(), gameTypes, cmd.only_buddies(), onlyRegisteredUsers,
-                                 cmd.spectators_allowed(), cmd.spectators_need_password(), cmd.spectators_can_talk(),
-                                 cmd.spectators_see_everything(), startingLifeTotal, shareDecklistsOnLoad, room);
+    GameConfig config{.creatorInfo = copyUserInfo(false),
+                      .gameId = gameId,
+                      .description = description,
+                      .password = QString::fromStdString(cmd.password()),
+                      .maxPlayers = static_cast<int>(cmd.max_players()),
+                      .gameTypes = gameTypes,
+                      .onlyBuddies = cmd.only_buddies(),
+                      .onlyRegistered = onlyRegisteredUsers,
+                      .spectatorsAllowed = cmd.spectators_allowed(),
+                      .spectatorsNeedPassword = cmd.spectators_need_password(),
+                      .spectatorsCanTalk = cmd.spectators_can_talk(),
+                      .spectatorsSeeEverything = cmd.spectators_see_everything(),
+                      .startingLifeTotal = startingLifeTotal,
+                      .shareDecklistsOnLoad = shareDecklistsOnLoad};
+
+    auto *game = new Server_Game(config, room);
 
     game->addPlayer(this, rc, asSpectator, asJudge, false);
     room->addGame(game);

--- a/tests/movecard_tests/reverse_card_move_test.cpp
+++ b/tests/movecard_tests/reverse_card_move_test.cpp
@@ -1,3 +1,4 @@
+#include "game/game_config.h"
 #include "game/server_abstract_player.h"
 #include "game/server_card.h"
 #include "game/server_cardzone.h"
@@ -22,7 +23,21 @@ TEST(ReverseCardMoveTest, MoveCardFromBottomTest)
     // instantiate a fake server instance
     FakeServer server;
     Server_Room room(0, 0, "", "", "", "", false, "", {}, &server);
-    Server_Game game(user, 1, "", "", 2, QList<int>(), false, false, false, false, false, false, 20, false, &room);
+    GameConfig config{.creatorInfo = user,
+                      .gameId = 1,
+                      .description = QString(),
+                      .password = QString(),
+                      .maxPlayers = 2,
+                      .gameTypes = QList<int>(),
+                      .onlyBuddies = false,
+                      .onlyRegistered = false,
+                      .spectatorsAllowed = false,
+                      .spectatorsNeedPassword = false,
+                      .spectatorsCanTalk = false,
+                      .spectatorsSeeEverything = false,
+                      .startingLifeTotal = 20,
+                      .shareDecklistsOnLoad = false};
+    Server_Game game(config, &room);
     Server_AbstractPlayer player(&game, 1, user, false, nullptr);
     Server_CardZone deckZone(&player, ZoneNames::DECK, true, ServerInfo_Zone::PublicZone);
     Server_CardZone exileZone(&player, ZoneNames::EXILE, true, ServerInfo_Zone::PublicZone);


### PR DESCRIPTION
## Short roundup of the initial problem
Pure refactor, no behavior change. `Server_Game` takes 15 positional constructor parameters. Every caller must repeat them, and any extension (draft/tournament) makes the signature explode.

## What will change with this Pull Request?
- Add a `GameConfig` struct consolidating the 14 construction parameters.
- Replace the 15-arg `Server_Game` constructor with `Server_Game(const GameConfig &, Server_Room *)`.
- Build `GameConfig` from `Command_CreateGame` in `cmdCreateGame` via a designated initializer list.