### PR TITLE
[Server] Add deck validation strategy interface

### DIFF
--- a/libcockatrice_network/libcockatrice/network/server/remote/CMakeLists.txt
+++ b/libcockatrice_network/libcockatrice/network/server/remote/CMakeLists.txt
@@ -11,6 +11,7 @@ set(HEADERS
     game/server_cardzone.h
     game/server_counter.h
     game/game_config.h
+    game/server_deck_validation_strategy.h
     game/server_game.h
     game/server_player.h
     game/server_spectator.h

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_deck_validation_strategy.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_deck_validation_strategy.h
@@ -1,0 +1,45 @@
+#ifndef SERVER_DECK_VALIDATION_STRATEGY_H
+#define SERVER_DECK_VALIDATION_STRATEGY_H
+
+#include <libcockatrice/protocol/pb/response.pb.h>
+
+class DeckList;
+class Server_Game;
+class Server_Player;
+class ResponseContainer;
+
+/**
+ * @brief Strategy for validating a player's deck before it is loaded into a game.
+ *
+ * Subclasses decide whether a deck may be accepted; the default implementation
+ * accepts every deck.
+ */
+class Server_DeckValidationStrategy
+{
+public:
+    virtual ~Server_DeckValidationStrategy() = default;
+
+    /**
+     * @brief Validate @p deck for @p player in @p game.
+     *
+     * @p rc is an out parameter used to attach the response details for a rejected
+     * deck (e.g. an error response extension via ResponseContainer::setResponseExtension).
+     * @return Response::RespOk when the deck is accepted, an error code otherwise.
+     */
+    virtual Response::ResponseCode
+    validate(Server_Game *game, Server_Player *player, DeckList *deck, ResponseContainer &rc) = 0;
+};
+
+/**
+ * @brief Default deck validation strategy that accepts every deck.
+ */
+class Server_DefaultDeckValidationStrategy : public Server_DeckValidationStrategy
+{
+public:
+    Response::ResponseCode validate(Server_Game *, Server_Player *, DeckList *, ResponseContainer &) override
+    {
+        return Response::RespOk;
+    }
+};
+
+#endif

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
@@ -62,7 +62,8 @@ Server_Game::Server_Game(const GameConfig &config, Server_Room *_room)
       spectatorsCanTalk(config.spectatorsCanTalk), spectatorsSeeEverything(config.spectatorsSeeEverything),
       startingLifeTotal(config.startingLifeTotal), shareDecklistsOnLoad(config.shareDecklistsOnLoad),
       inactivityCounter(0), startTimeOfThisGame(0), secondsElapsed(0), firstGameStarted(false),
-      turnOrderReversed(false), startTime(QDateTime::currentDateTime()), pingClock(nullptr), gameMutex()
+      turnOrderReversed(false), startTime(QDateTime::currentDateTime()), pingClock(nullptr),
+      deckValidationStrategy(new Server_DefaultDeckValidationStrategy), gameMutex()
 {
     currentReplay = new GameReplay;
     currentReplay->set_replay_id(room->getServer()->getDatabaseInterface()->getNextReplayId());
@@ -885,4 +886,9 @@ void Server_Game::returnCardsFromPlayer(GameEventStorage &ges, Server_AbstractPl
             break;
         }
     }
+}
+
+void Server_Game::setDeckValidationStrategy(Server_DeckValidationStrategy *strategy)
+{
+    deckValidationStrategy.reset(strategy);
 }

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.h
@@ -22,11 +22,13 @@
 
 #include "../server_response_containers.h"
 #include "game_config.h"
+#include "server_deck_validation_strategy.h"
 
 #include <QDateTime>
 #include <QMap>
 #include <QMutex>
 #include <QObject>
+#include <QScopedPointer>
 #include <QSet>
 #include <QStringList>
 #include <libcockatrice/protocol/pb/event_leave.pb.h>
@@ -78,6 +80,8 @@ private:
     QTimer *pingClock;
     QList<GameReplay *> replayList;
     GameReplay *currentReplay;
+
+    QScopedPointer<Server_DeckValidationStrategy> deckValidationStrategy;
 
     void createGameStateChangedEvent(Event_GameStateChanged *event,
                                      Server_AbstractParticipant *recipient,
@@ -208,6 +212,14 @@ public:
                                                                                    GameEventStorageItem::SendToOthers,
                                 int privatePlayerId = -1);
     void returnCardsFromPlayer(GameEventStorage &ges, Server_AbstractPlayer *player);
+
+    /** @brief Get the current deck validation strategy (non-owning). */
+    Server_DeckValidationStrategy *getDeckValidationStrategy() const
+    {
+        return deckValidationStrategy.data();
+    }
+    /** @brief Replace the deck validation strategy; takes ownership of @p strategy. */
+    void setDeckValidationStrategy(Server_DeckValidationStrategy *strategy);
 };
 
 #endif


### PR DESCRIPTION
## Short roundup of the initial problem
Purely additive. No behavior change yet. Deck validation rules (format checks, restricted lists) have no extension point. They are hardwired into game logic.

## What will change with this Pull Request?
- Add `Server_DeckValidationStrategy` interface and `Server_DefaultDeckValidationStrategy` no-op default.
- Wire a default instance into `Server_Game` with `getDeckValidationStrategy()` / `setDeckValidationStrategy()`.

## Why?
`validate()` has no call sites yet. A follow-up PR will wire the actual validation rules and consume them.
