### PR TITLE
[Server] Add match result strategy hook

### DIFF
--- a/libcockatrice_network/libcockatrice/network/server/remote/CMakeLists.txt
+++ b/libcockatrice_network/libcockatrice/network/server/remote/CMakeLists.txt
@@ -14,6 +14,7 @@ set(HEADERS
     game/server_deck_validation_strategy.h
     game/server_game.h
     game/server_game_lifecycle_strategy.h
+    game/server_match_result_strategy.h
     game/server_player.h
     game/server_spectator.h
     server.h

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
@@ -63,7 +63,8 @@ Server_Game::Server_Game(const GameConfig &config, Server_Room *_room)
       startingLifeTotal(config.startingLifeTotal), shareDecklistsOnLoad(config.shareDecklistsOnLoad),
       inactivityCounter(0), startTimeOfThisGame(0), secondsElapsed(0), firstGameStarted(false),
       turnOrderReversed(false), startTime(QDateTime::currentDateTime()), pingClock(nullptr),
-      lifecycleStrategy(new Server_DefaultLifecycleStrategy), gameMutex()
+      deckValidationStrategy(new Server_DefaultDeckValidationStrategy), lifecycleStrategy(new Server_DefaultLifecycleStrategy), matchResultStrategy(new Server_NullMatchResultStrategy),
+gameMutex()
 {
     currentReplay = new GameReplay;
     currentReplay->set_replay_id(room->getServer()->getDatabaseInterface()->getNextReplayId());
@@ -391,10 +392,12 @@ void Server_Game::stopGameIfFinished()
     QMutexLocker locker(&gameMutex);
 
     int playing = 0;
+    Server_AbstractPlayer *lastPlayer = nullptr;
     auto players = getPlayers();
     for (auto *player : players.values()) {
         if (!player->getConceded()) {
             ++playing;
+            lastPlayer = player;
         }
     }
     if (playing > 1) {
@@ -409,6 +412,16 @@ void Server_Game::stopGameIfFinished()
     }
 
     sendGameStateToPlayers();
+
+    bool matchDecided = matchResultStrategy->onGameFinished(this, playing, lastPlayer);
+    if (matchDecided) {
+        locker.unlock();
+
+        sendGameEventContainer(prepareGameEvent(Event_GameClosed(), -1));
+        gameClosed = true;
+        deleteLater();
+        return;
+    }
 
     locker.unlock();
 

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
@@ -63,8 +63,9 @@ Server_Game::Server_Game(const GameConfig &config, Server_Room *_room)
       startingLifeTotal(config.startingLifeTotal), shareDecklistsOnLoad(config.shareDecklistsOnLoad),
       inactivityCounter(0), startTimeOfThisGame(0), secondsElapsed(0), firstGameStarted(false),
       turnOrderReversed(false), startTime(QDateTime::currentDateTime()), pingClock(nullptr),
-      deckValidationStrategy(new Server_DefaultDeckValidationStrategy), lifecycleStrategy(new Server_DefaultLifecycleStrategy), matchResultStrategy(new Server_NullMatchResultStrategy),
-gameMutex()
+      deckValidationStrategy(new Server_DefaultDeckValidationStrategy),
+      lifecycleStrategy(new Server_DefaultLifecycleStrategy), matchResultStrategy(new Server_NullMatchResultStrategy),
+      gameMutex()
 {
     currentReplay = new GameReplay;
     currentReplay->set_replay_id(room->getServer()->getDatabaseInterface()->getNextReplayId());

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.h
@@ -22,6 +22,7 @@
 
 #include "../server_response_containers.h"
 #include "game_config.h"
+#include "server_match_result_strategy.h"
 #include "server_deck_validation_strategy.h"
 #include "server_game_lifecycle_strategy.h"
 
@@ -81,6 +82,8 @@ private:
     QTimer *pingClock;
     QList<GameReplay *> replayList;
     GameReplay *currentReplay;
+
+    QScopedPointer<Server_MatchResultStrategy> matchResultStrategy;
 
     QScopedPointer<Server_DeckValidationStrategy> deckValidationStrategy;
 

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.h
@@ -22,9 +22,9 @@
 
 #include "../server_response_containers.h"
 #include "game_config.h"
-#include "server_match_result_strategy.h"
 #include "server_deck_validation_strategy.h"
 #include "server_game_lifecycle_strategy.h"
+#include "server_match_result_strategy.h"
 
 #include <QDateTime>
 #include <QMap>
@@ -83,11 +83,11 @@ private:
     QList<GameReplay *> replayList;
     GameReplay *currentReplay;
 
-    QScopedPointer<Server_MatchResultStrategy> matchResultStrategy;
-
     QScopedPointer<Server_DeckValidationStrategy> deckValidationStrategy;
 
     QScopedPointer<Server_GameLifecycleStrategy> lifecycleStrategy;
+
+    QScopedPointer<Server_MatchResultStrategy> matchResultStrategy;
 
     void createGameStateChangedEvent(Event_GameStateChanged *event,
                                      Server_AbstractParticipant *recipient,

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_match_result_strategy.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_match_result_strategy.h
@@ -1,0 +1,38 @@
+#ifndef SERVER_MATCH_RESULT_STRATEGY_H
+#define SERVER_MATCH_RESULT_STRATEGY_H
+
+class Server_AbstractPlayer;
+class Server_Game;
+
+/**
+ * @brief Strategy hook invoked when a game has finished to decide the match result.
+ *
+ * Subclasses can report the match outcome (e.g. to a tournament backend) and decide
+ * whether the game should be closed permanently; the default implementation never
+ * closes the game, preserving the normal return-to-lobby behavior.
+ */
+class Server_MatchResultStrategy
+{
+public:
+    virtual ~Server_MatchResultStrategy() = default;
+
+    /**
+     * @brief Called when a game has finished.
+     * @return Whether the game has been decided and should be closed.
+     */
+    virtual bool onGameFinished(Server_Game *game, int playing, Server_AbstractPlayer *lastPlayer) = 0;
+};
+
+/**
+ * @brief Default match result strategy that never closes the game.
+ */
+class Server_NullMatchResultStrategy : public Server_MatchResultStrategy
+{
+public:
+    bool onGameFinished(Server_Game *, int, Server_AbstractPlayer *) override
+    {
+        return false;
+    }
+};
+
+#endif


### PR DESCRIPTION
## Short roundup of the initial problem
Purely additive. No behavior change yet. `stopGameIfFinished` has no hook for post-game actions such as tournament match reporting.

## What will change with this Pull Request?
- Add `Server_MatchResultStrategy` with `onGameFinished()`.
- Track the last non-conceded player in `stopGameIfFinished`.
- Call the strategy once a match is decided: a `true` result closes the game via `Event_GameClosed`.
- Null strategy returns `false`, so behavior is unchanged.