### PR TITLE
[Server] Add abstract match game factory for future tournament modes

### DIFF
--- a/libcockatrice_network/libcockatrice/network/server/remote/CMakeLists.txt
+++ b/libcockatrice_network/libcockatrice/network/server/remote/CMakeLists.txt
@@ -15,6 +15,7 @@ set(HEADERS
     game/server_game.h
     game/server_game_lifecycle_strategy.h
     game/server_match_result_strategy.h
+    game/server_match_game_factory.h
     game/server_player.h
     game/server_spectator.h
     server.h

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_match_game_factory.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_match_game_factory.h
@@ -1,0 +1,29 @@
+#ifndef SERVER_MATCH_GAME_FACTORY_H
+#define SERVER_MATCH_GAME_FACTORY_H
+
+#include <QString>
+
+class GameConfig;
+class Server_Game;
+class Server_AbstractUserInterface;
+
+/**
+ * @brief Abstract factory for creating match games, forward-looking for tournament modes.
+ *
+ * Implementations own the rules of how a match game is constructed, how player
+ * interfaces are resolved, and how games are registered with a room.
+ */
+class Server_MatchGameFactory
+{
+public:
+    virtual ~Server_MatchGameFactory() = default;
+
+    /** @brief Create a match game from @p config, storing the assigned game id in @p outGameId. */
+    virtual Server_Game *createMatchGame(const GameConfig &config, int &outGameId) = 0;
+    /** @brief Resolve the user interface for @p playerName. */
+    virtual Server_AbstractUserInterface *getUserInterface(const QString &playerName) = 0;
+    /** @brief Register @p game with the room that owns it. */
+    virtual void addGameToRoom(Server_Game *game) = 0;
+};
+
+#endif


### PR DESCRIPTION
## Short roundup of the initial problem
Purely additive. No behavior change yet. Tournament match creation needs an abstraction over room game creation that the server can inject later.

## What will change with this Pull Request?
- Add `Server_MatchGameFactory` interface: `createMatchGame()`, `getUserInterface()`, `addGameToRoom()`.

## Why?
The upcoming tournament mode implements this factory to create match games without reaching into the room's game-creation logic.