### PR TITLE
[Chat] Render game link buttons

### DIFF
--- a/cockatrice/src/interface/widgets/server/chat_view/chat_view.cpp
+++ b/cockatrice/src/interface/widgets/server/chat_view/chat_view.cpp
@@ -226,7 +226,9 @@ void ChatView::appendGameLinkTag(QTextCursor &cursor, const QString &url)
     const QUrl gameUrl(url);
     const QUrlQuery query(gameUrl);
     const QString hostname = query.queryItemValue("hostname");
-    const QString description = query.queryItemValue("game");
+    // FullyDecoded undoes every %XX escape, so a description that itself
+    // contains "%" cannot end up displayed as "%25" in the label.
+    const QString description = query.queryItemValue("game", QUrl::FullyDecoded);
     const int gameId = query.queryItemValue("gameid").toInt();
 
     QString label;
@@ -544,9 +546,14 @@ void ChatView::checkWord(QTextCursor &cursor, QString &message)
     }
 
     if (fullWordUpToSpaceOrEnd.startsWith("cockatrice://", Qt::CaseInsensitive)) {
-        appendGameLinkTag(cursor, fullWordUpToSpaceOrEnd);
-        cursor.insertText(rest, defaultFormat);
-        return;
+        // Only links to a game (cockatrice://joingame) become invite buttons;
+        // any other cockatrice:// scheme falls through to plain text below.
+        const QUrl gameLink(fullWordUpToSpaceOrEnd);
+        if (gameLink.host().compare("joingame", Qt::CaseInsensitive) == 0) {
+            appendGameLinkTag(cursor, fullWordUpToSpaceOrEnd);
+            cursor.insertText(rest, defaultFormat);
+            return;
+        }
     }
 
     // check word mentions

--- a/cockatrice/src/interface/widgets/server/chat_view/chat_view.cpp
+++ b/cockatrice/src/interface/widgets/server/chat_view/chat_view.cpp
@@ -14,6 +14,8 @@
 #include <QMouseEvent>
 #include <QScrollBar>
 #include <QTimer>
+#include <QUrl>
+#include <QUrlQuery>
 #include <libcockatrice/card/database/card_database_manager.h>
 #include <libcockatrice/network/server/remote/user_level.h>
 #include <libcockatrice/settings/chat_settings.h>
@@ -49,7 +51,7 @@ ChatView::ChatView(TabSupervisor *_tabSupervisor, AbstractGame *_game, bool _sho
 
     viewport()->setCursor(Qt::IBeamCursor);
     setReadOnly(true);
-    setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::LinksAccessibleByMouse);
+    setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::LinksAccessibleByMouse | Qt::LinksAccessibleByKeyboard);
     setOpenLinks(false);
     connect(this, &ChatView::anchorClicked, this, &ChatView::openLink);
 
@@ -216,6 +218,44 @@ void ChatView::appendUrlTag(QTextCursor &cursor, QString url)
 
     cursor.setCharFormat(anchorFormat);
     cursor.insertText(url);
+    cursor.setCharFormat(oldFormat);
+}
+
+void ChatView::appendGameLinkTag(QTextCursor &cursor, const QString &url)
+{
+    const QUrl gameUrl(url);
+    const QUrlQuery query(gameUrl);
+    const QString hostname = query.queryItemValue("hostname");
+    const QString description = query.queryItemValue("game");
+    const int gameId = query.queryItemValue("gameid").toInt();
+
+    QString label;
+    if (gameId > 0 && !hostname.isEmpty()) {
+        // Links built before the description was embedded stay readable: the
+        // id + server fallback below is identical to the old anchor text.
+        if (!description.isEmpty()) {
+            // Multi-arg .arg() replaces all placeholders in a single pass, so a
+            // description containing "%…" cannot corrupt later placeholders.
+            label = tr("Join game \"%1\" (#%2) on %3").arg(description, QString::number(gameId), hostname);
+        } else {
+            label = tr("Join game #%1 on %2").arg(QString::number(gameId), hostname);
+        }
+    } else {
+        label = tr("Join game");
+    }
+
+    QTextCharFormat oldFormat = cursor.charFormat();
+    QTextCharFormat gameLinkFormat = oldFormat;
+    gameLinkFormat.setForeground(linkColor);
+    gameLinkFormat.setFontWeight(QFont::Bold);
+    gameLinkFormat.setAnchor(true);
+    gameLinkFormat.setAnchorHref(url);
+    QColor background = palette().highlight().color();
+    background.setAlpha(40);
+    gameLinkFormat.setBackground(background);
+
+    cursor.setCharFormat(gameLinkFormat);
+    cursor.insertText(label);
     cursor.setCharFormat(oldFormat);
 }
 
@@ -501,6 +541,12 @@ void ChatView::checkWord(QTextCursor &cursor, QString &message)
             cursor.insertText(rest, defaultFormat);
             return;
         }
+    }
+
+    if (fullWordUpToSpaceOrEnd.startsWith("cockatrice://", Qt::CaseInsensitive)) {
+        appendGameLinkTag(cursor, fullWordUpToSpaceOrEnd);
+        cursor.insertText(rest, defaultFormat);
+        return;
     }
 
     // check word mentions

--- a/cockatrice/src/interface/widgets/server/chat_view/chat_view.h
+++ b/cockatrice/src/interface/widgets/server/chat_view/chat_view.h
@@ -71,6 +71,7 @@ private:
     void scrollToBottom();
     void appendCardTag(QTextCursor &cursor, const QString &cardName);
     void appendUrlTag(QTextCursor &cursor, QString url);
+    void appendGameLinkTag(QTextCursor &cursor, const QString &url);
     static QColor getCustomMentionColor();
     static QColor getCustomHighlightColor();
     void showSystemPopup(const QString &userName);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem

## What will change with this Pull Request?
- Words starting with cockatrice:// become button-style anchors labelled with the game description, id and server (falling back to id + server for links built without a description). 
- The description is spliced via the multi-arg arg() overloads so a title containing "%…" cannot corrupt the label.

- Keyboard link access is enabled so the anchors are reachable without a mouse.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
