### PR TITLE
[Client] Confirm before joining a game opened from a game link

### DIFF
--- a/cockatrice/src/interface/intents/url_parser.cpp
+++ b/cockatrice/src/interface/intents/url_parser.cpp
@@ -1,5 +1,7 @@
 #include "url_parser.h"
 
+#include "../widgets/tabs/tab_room.h"
+#include "../widgets/tabs/tab_supervisor.h"
 #include "../window_main.h"
 #include "contexts/context_join_game.h"
 #include "intent_join_server_game.h"
@@ -9,6 +11,7 @@
 #include <QMessageBox>
 #include <QUrl>
 #include <QUrlQuery>
+#include <libcockatrice/network/client/abstract/abstract_client.h>
 #include <memory>
 
 IntentUrlParser::IntentUrlParser(QObject *parent, MainWindow *_mainWindow) : QObject(parent), mainWindow(_mainWindow)
@@ -68,6 +71,44 @@ void IntentUrlParser::handleJoinGame(const QUrlQuery &query)
 
     if (!ok) {
         showError(tr("Invalid or missing game id in the game link"));
+        return;
+    }
+
+    const QString hostname = ctx->roomContext.serverContext.hostname;
+    const QString port = ctx->roomContext.serverContext.port;
+    const int roomId = ctx->roomContext.roomId;
+    const int gameId = ctx->gameId;
+    const QString server = QStringLiteral("%1:%2").arg(hostname, port);
+
+    // Prefer the room name over the raw numeric id: it means something to the
+    // user. The name is only known when we are already connected to the same
+    // server and sitting in that room — otherwise fall back to a plain prompt.
+    AbstractClient *client = mainWindow->getTabSupervisor()->getClient();
+    const bool sameServer = client != nullptr && client->getStatus() == StatusLoggedIn &&
+                            hostname.compare(client->serverName(), Qt::CaseInsensitive) == 0 &&
+                            QString::number(client->serverPort()) == port;
+    TabRoom *roomTab = sameServer ? mainWindow->getTabSupervisor()->getRoomTabs().value(roomId) : nullptr;
+
+    // Links built by newer clients embed the game description ("game" item);
+    // restate it in the confirm so it matches what the chat anchor showed.
+    // Unknown query items are ignored, so old links without it keep working.
+    // The multi-arg .arg() overloads replace in a single pass, so a description
+    // containing "%…" cannot corrupt later placeholders.
+    // FullyDecoded undoes every %XX escape and must match the chat anchor's
+    // decode mode, so a description containing "%" reads identically in both.
+    const QString gameDescription = query.queryItemValue("game", QUrl::FullyDecoded);
+    const QString gameIdStr = QString::number(gameId);
+    const QString message =
+        gameDescription.isEmpty()
+            ? (roomTab ? tr("Join game #%1 in \"%2\" on %3?").arg(gameIdStr, roomTab->getRoomName(), server)
+                       : tr("Join game #%1 on %2?").arg(gameIdStr, server))
+            : (roomTab ? tr("Join game \"%1\" (#%2) in \"%3\" on %4?")
+                             .arg(gameDescription, gameIdStr, roomTab->getRoomName(), server)
+                       : tr("Join game \"%1\" (#%2) on %3?").arg(gameDescription, gameIdStr, server));
+
+    const QMessageBox::StandardButton answer = QMessageBox::question(
+        mainWindow, tr("Join game"), message, QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+    if (answer != QMessageBox::Yes) {
         return;
     }
 

--- a/cockatrice/src/interface/intents/url_parser.cpp
+++ b/cockatrice/src/interface/intents/url_parser.cpp
@@ -74,37 +74,8 @@ void IntentUrlParser::handleJoinGame(const QUrlQuery &query)
         return;
     }
 
-    const QString hostname = ctx->roomContext.serverContext.hostname;
-    const QString port = ctx->roomContext.serverContext.port;
-    const int roomId = ctx->roomContext.roomId;
-    const int gameId = ctx->gameId;
-    const QString server = QStringLiteral("%1:%2").arg(hostname, port);
-
-    // Prefer the room name over the raw numeric id: it means something to the
-    // user. The name is only known when we are already connected to the same
-    // server and sitting in that room — otherwise fall back to a plain prompt.
-    AbstractClient *client = mainWindow->getTabSupervisor()->getClient();
-    const bool sameServer = client != nullptr && client->getStatus() == StatusLoggedIn &&
-                            hostname.compare(client->serverName(), Qt::CaseInsensitive) == 0 &&
-                            QString::number(client->serverPort()) == port;
-    TabRoom *roomTab = sameServer ? mainWindow->getTabSupervisor()->getRoomTabs().value(roomId) : nullptr;
-
-    // Links built by newer clients embed the game description ("game" item);
-    // restate it in the confirm so it matches what the chat anchor showed.
-    // Unknown query items are ignored, so old links without it keep working.
-    // The multi-arg .arg() overloads replace in a single pass, so a description
-    // containing "%…" cannot corrupt later placeholders.
-    // FullyDecoded undoes every %XX escape and must match the chat anchor's
-    // decode mode, so a description containing "%" reads identically in both.
     const QString gameDescription = query.queryItemValue("game", QUrl::FullyDecoded);
-    const QString gameIdStr = QString::number(gameId);
-    const QString message =
-        gameDescription.isEmpty()
-            ? (roomTab ? tr("Join game #%1 in \"%2\" on %3?").arg(gameIdStr, roomTab->getRoomName(), server)
-                       : tr("Join game #%1 on %2?").arg(gameIdStr, server))
-            : (roomTab ? tr("Join game \"%1\" (#%2) in \"%3\" on %4?")
-                             .arg(gameDescription, gameIdStr, roomTab->getRoomName(), server)
-                       : tr("Join game \"%1\" (#%2) on %3?").arg(gameDescription, gameIdStr, server));
+    const QString message = generateJoinGameMessage(*ctx, gameDescription);
 
     const QMessageBox::StandardButton answer = QMessageBox::question(
         mainWindow, tr("Join game"), message, QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
@@ -127,4 +98,39 @@ void IntentUrlParser::handleJoinGame(const QUrlQuery &query)
     connect(joinGameIntent, &Intent::failed, this, [showError](const QString &reason) { showError(reason); });
 
     getLoginCredentialsIntent->execute();
+}
+
+QString IntentUrlParser::generateJoinGameMessage(const ContextJoinGame &context, const QString &gameDescription)
+{
+    const QString hostname = context.roomContext.serverContext.hostname;
+    const QString port = context.roomContext.serverContext.port;
+    const int roomId = context.roomContext.roomId;
+    const int gameId = context.gameId;
+    const QString server = QStringLiteral("%1:%2").arg(hostname, port);
+
+    // Prefer the room name over the raw numeric id: it means something to the
+    // user. The name is only known when we are already connected to the same
+    // server and sitting in that room — otherwise fall back to a plain prompt.
+    AbstractClient *client = mainWindow->getTabSupervisor()->getClient();
+    const bool sameServer = client != nullptr && client->getStatus() == StatusLoggedIn &&
+                            hostname.compare(client->serverName(), Qt::CaseInsensitive) == 0 &&
+                            QString::number(client->serverPort()) == port;
+    TabRoom *roomTab = sameServer ? mainWindow->getTabSupervisor()->getRoomTabs().value(roomId) : nullptr;
+
+    const QString gameIdStr = QString::number(gameId);
+    // Links built by newer clients embed the game description ("game" item);
+    // restate it in the confirm so it matches what the chat anchor showed.
+    // Unknown query items are ignored, so old links without it keep working.
+    // The multi-arg .arg() overloads replace in a single pass, so a description
+    // containing "%…" cannot corrupt later placeholders.
+    // FullyDecoded undoes every %XX escape and must match the chat anchor's
+    // decode mode, so a description containing "%" reads identically in both.
+    if (gameDescription.isEmpty()) {
+        return roomTab ? tr("Join game #%1 in \"%2\" on %3?").arg(gameIdStr, roomTab->getRoomName(), server)
+                       : tr("Join game #%1 on %2?").arg(gameIdStr, server);
+    }
+
+    return roomTab ? tr("Join game \"%1\" (#%2) in \"%3\" on %4?")
+                         .arg(gameDescription, gameIdStr, roomTab->getRoomName(), server)
+                   : tr("Join game \"%1\" (#%2) on %3?").arg(gameDescription, gameIdStr, server);
 }

--- a/cockatrice/src/interface/intents/url_parser.h
+++ b/cockatrice/src/interface/intents/url_parser.h
@@ -4,7 +4,7 @@
 #include <QUrlQuery>
 
 class MainWindow;
-class ContextJoinGame;
+struct ContextJoinGame;
 class IntentUrlParser : public QObject
 {
     Q_OBJECT

--- a/cockatrice/src/interface/intents/url_parser.h
+++ b/cockatrice/src/interface/intents/url_parser.h
@@ -4,6 +4,7 @@
 #include <QUrlQuery>
 
 class MainWindow;
+class ContextJoinGame;
 class IntentUrlParser : public QObject
 {
     Q_OBJECT
@@ -14,6 +15,8 @@ public:
     void handleJoinGame(const QUrlQuery &query);
 
 private:
+    QString generateJoinGameMessage(const ContextJoinGame &context, const QString &gameDescription);
+
     MainWindow *mainWindow;
 };
 


### PR DESCRIPTION
## Short roundup of the initial problem
Joining a game from a cockatrice://joingame link is a navigation decision, so restate what will be joined and ask before acting. 

## What will change with this Pull Request?
- The confirm names the game description when the link carries one (falling back to the room name and numeric id for older links), and reports the host:port so links that point at a different server are obvious. 
- The intent chain is only started after confirmation.

## Screenshots
<!-- simply drag & drop image files directly into this description! -->
