### PR TITLE
[CI] Fix a bug with a symlink dir not resolving correctly in format.sh

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -11,6 +11,7 @@ set -o pipefail
 # go to the project root directory, this file should be located in the project root directory
 olddir="$PWD"
 cd "${BASH_SOURCE%/*}/" || exit 2 # could not find path, this could happen with special links etc.
+phys_root="$(pwd -P)"
 
 # defaults
 include=("cockatrice/src" \
@@ -168,14 +169,14 @@ EOM
         echo "error in parsing arguments of $0: $1 is an unrecognized option" >&2
         exit 2 # input error
       fi
-      if [[ ! $1 ]] || next_dir=$(cd "$olddir" && cd -- "$1" && pwd); then
+      if [[ ! $1 ]] || next_dir=$(cd "$olddir" && cd -- "$1" && pwd -P); then
         if ! [[ $set_include ]]; then
           include=() # remove default includes
           set_include=1
         fi
         if [[ $1 ]]; then
-          if [[ $next_dir != $PWD/* ]]; then
-            echo "error in parsing arguments of $0: $next_dir is not in $PWD" >&2
+          if [[ "$next_dir" != "$phys_root" && "$next_dir" != "$phys_root"/* ]]; then
+            echo "error in parsing arguments of $0: $next_dir is not in $phys_root" >&2
             exit 2 # input error
           fi
           include+=("$next_dir")


### PR DESCRIPTION
## Short roundup of the initial problem
error in parsing arguments of ./format.sh: /home/ascor/Coding/CLionProjects/Cockatrice is not in /home/ascor/Coding/CLionProjects/Cockatrice

/home/ascor/Coding/CLionProjects/Cockatrice
/mnt/games-hdd/coding/CLionProjects/Cockatrice

- Line 177 checks [[ $next_dir != $PWD/* ]]. The glob $PWD/* requires at least one path component after $PWD/. When `.` is passed, next_dir resolves to $PWD itself, which doesn't match the pattern. So you get "X is not in X" error.
- Line 171 uses bare pwd (logical path) while cd through the /home/ascor/Coding symlink can resolve to the physical path /mnt/games-hdd/coding/... in some bash versions. If that happens, next_dir (physical) never matches $PWD (logical) for any argument.

## What will change with this Pull Request?
1. After line 13, capture the physical project root: phys_root="$(pwd -P)"
2. Line 171: pwd → pwd -P (so next_dir is always physical)
3. Line 177: compare against $phys_root with both equality and prefix match


