### PR TITLE
[Game] Give a graphics_item_type.h to arrow_item.h

### DIFF
--- a/cockatrice/src/game_graphics/board/arrow_item.h
+++ b/cockatrice/src/game_graphics/board/arrow_item.h
@@ -4,6 +4,7 @@
 #include "../../game/board/arrow_data.h"
 #include "../animated_item.h"
 #include "arrow_target.h"
+#include "graphics_item_type.h"
 
 #include <QElapsedTimer>
 #include <QGraphicsItem>
@@ -48,6 +49,14 @@ protected:
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
 
 public:
+    enum
+    {
+        Type = typeArrow
+    };
+    [[nodiscard]] int type() const override
+    {
+        return Type;
+    }
     ArrowItem(QSharedPointer<const ArrowData> _data, ArrowTarget *_startItem, ArrowTarget *_targetItem);
     ~ArrowItem() override;
 

--- a/cockatrice/src/game_graphics/board/graphics_item_type.h
+++ b/cockatrice/src/game_graphics/board/graphics_item_type.h
@@ -16,7 +16,8 @@ enum GraphicsItemType
     typeZone = QGraphicsItem::UserType + 3,
     typePlayerTarget = QGraphicsItem::UserType + 4,
     typeDeckViewCardContainer = QGraphicsItem::UserType + 5,
-    typeOther = QGraphicsItem::UserType + 6
+    typeOther = QGraphicsItem::UserType + 6,
+    typeArrow = QGraphicsItem::UserType + 7
 };
 
 #endif // COCKATRICE_GRAPHICS_ITEM_TYPE_H


### PR DESCRIPTION
## Short roundup of the initial problem
GameScene::~GameScene() has a teardown loop that deletes all arrows before the base scene destructor runs:

```
for (auto *item : items()) {
    if (auto *arrow = qgraphicsitem_cast<ArrowItem *>(item)) {
        delete arrow;
    }
}
```

But ArrowItem never declared its own Type enum / type() override whereas every other item class did. Qt's qgraphicsitem_cast detects that case and falls back to an unchecked blind cast, so every item in the scene matched as "ArrowItem". The loop deleted players, card zones, ZoneViewWidgets and then re-deleted their already-destroyed children from the stale items() snapshot.

## What will change with this Pull Request?
- Give a graphics item type to arrow items