### PR TITLE
[Client] Show latency in status bar and server tab indicator

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -15,6 +15,8 @@ set(cockatrice_SOURCES
     src/client/network/update/client/client_update_checker.cpp
     src/client/network/update/client/release_channel.cpp
     src/client/network/update/card_spoiler/spoiler_background_updater.cpp
+    src/client/latency_graph_widget.cpp
+    src/client/latency_status_widget.cpp
     src/client/lag_monitor.cpp
     src/client/sound_engine.cpp
     src/client/settings/cache_settings.cpp

--- a/cockatrice/src/client/latency_graph_widget.cpp
+++ b/cockatrice/src/client/latency_graph_widget.cpp
@@ -44,8 +44,7 @@ void LatencyGraphWidget::paintEvent(QPaintEvent * /* event */)
         QColor color;
         color.setHsv(qRound(120.0 * (1.0 - colorRatio)), 255, 255);
 
-        const QRectF bar(static_cast<qreal>(i) * widthPerBar + 1.0,
-                         static_cast<qreal>(height()) - barHeight,
+        const QRectF bar(static_cast<qreal>(i) * widthPerBar + 1.0, static_cast<qreal>(height()) - barHeight,
                          qMax(1.0, widthPerBar - 2.0), barHeight);
         painter.fillRect(bar, color);
     }

--- a/cockatrice/src/client/latency_graph_widget.cpp
+++ b/cockatrice/src/client/latency_graph_widget.cpp
@@ -1,0 +1,52 @@
+/**
+ * @file latency_graph_widget.cpp
+ * @ingroup Client
+ */
+
+#include "latency_graph_widget.h"
+
+#include <QPainter>
+
+LatencyGraphWidget::LatencyGraphWidget(QWidget *parent) : QWidget(parent)
+{
+}
+
+void LatencyGraphWidget::setSamples(const QList<int> &samplesMs)
+{
+    samples = samplesMs;
+    update();
+}
+
+void LatencyGraphWidget::paintEvent(QPaintEvent * /* event */)
+{
+    if (samples.isEmpty()) {
+        return;
+    }
+
+    QPainter painter(this);
+
+    // Heights are relative to the window's own worst sample (floored at
+    // MinScaleMs) so the shape of the variance stays readable even when every
+    // value is small.
+    qint64 heightScaleMs = MinScaleMs;
+    for (int sample : samples) {
+        heightScaleMs = qMax(heightScaleMs, static_cast<qint64>(sample));
+    }
+
+    const qreal widthPerBar = static_cast<qreal>(width()) / samples.size();
+    for (int i = 0; i < samples.size(); ++i) {
+        const qreal heightRatio = qBound(0.0, static_cast<double>(samples.at(i)) / heightScaleMs, 1.0);
+        const qreal barHeight = heightRatio * height();
+
+        // Colors follow an absolute quality ramp: a steady good ping stays
+        // green no matter how uniform the window is.
+        const qreal colorRatio = qBound(0.0, static_cast<double>(samples.at(i)) / ColorScaleMs, 1.0);
+        QColor color;
+        color.setHsv(qRound(120.0 * (1.0 - colorRatio)), 255, 255);
+
+        const QRectF bar(static_cast<qreal>(i) * widthPerBar + 1.0,
+                         static_cast<qreal>(height()) - barHeight,
+                         qMax(1.0, widthPerBar - 2.0), barHeight);
+        painter.fillRect(bar, color);
+    }
+}

--- a/cockatrice/src/client/latency_graph_widget.h
+++ b/cockatrice/src/client/latency_graph_widget.h
@@ -1,0 +1,43 @@
+/**
+ * @file latency_graph_widget.h
+ * @ingroup Client
+ */
+
+#ifndef LATENCY_GRAPH_WIDGET_H
+#define LATENCY_GRAPH_WIDGET_H
+
+#include <QList>
+#include <QWidget>
+
+/**
+ * @brief Bar graph of recent network round-trip samples.
+ *
+ * Draws one bar per sample, oldest on the left. Bar height is relative to the
+ * window's own scale so the shape of the variance stays readable, while bar
+ * color maps each sample onto an absolute quality ramp (green at rest through
+ * red at ColorScaleMs) so a steady good ping never looks alarming. Size
+ * agnostic: the status bar embeds a small instance while the latency detail
+ * popup shows a large one.
+ */
+class LatencyGraphWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit LatencyGraphWidget(QWidget *parent = nullptr);
+
+    /// Sample in milliseconds that maps to a fully red bar.
+    static constexpr qint64 ColorScaleMs = 500;
+
+    void setSamples(const QList<int> &samplesMs);
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+
+private:
+    /// Floor of the vertical scale in milliseconds. Keeps small windows readable.
+    static constexpr qint64 MinScaleMs = 100;
+
+    QList<int> samples;
+};
+
+#endif

--- a/cockatrice/src/client/latency_status_widget.cpp
+++ b/cockatrice/src/client/latency_status_widget.cpp
@@ -35,8 +35,14 @@ LatencyStatusWidget::LatencyStatusWidget(QWidget *parent) : QWidget(parent)
     hide();
 }
 
-void LatencyStatusWidget::updateStats(const LatencyTracker::Stats &stats)
+void LatencyStatusWidget::updateData(const LatencyTracker::Stats &stats, const QList<int> &samplesMs)
 {
+    latestSamples = samplesMs;
+    latencyGraph->setSamples(samplesMs);
+    if (popup && popup->isVisible() && detailGraph) {
+        detailGraph->setSamples(samplesMs);
+    }
+
     if (stats.sampleCount == 0) {
         hide();
         return;
@@ -51,15 +57,6 @@ void LatencyStatusWidget::updateStats(const LatencyTracker::Stats &stats)
         detailLabel->setText(statsStr);
     }
     show();
-}
-
-void LatencyStatusWidget::updateSamples(const QList<int> &samplesMs)
-{
-    latestSamples = samplesMs;
-    latencyGraph->setSamples(samplesMs);
-    if (popup && popup->isVisible() && detailGraph) {
-        detailGraph->setSamples(samplesMs);
-    }
 }
 
 bool LatencyStatusWidget::eventFilter(QObject *watched, QEvent *event)

--- a/cockatrice/src/client/latency_status_widget.cpp
+++ b/cockatrice/src/client/latency_status_widget.cpp
@@ -1,0 +1,50 @@
+/**
+ * @file latency_status_widget.cpp
+ * @ingroup Client
+ */
+
+#include "latency_status_widget.h"
+
+#include "latency_graph_widget.h"
+
+#include <QHBoxLayout>
+#include <QLabel>
+
+LatencyStatusWidget::LatencyStatusWidget(QWidget *parent) : QWidget(parent)
+{
+    pingLabel = new QLabel(this);
+    pingLabel->setAccessibleName(tr("Ping"));
+
+    latencyGraph = new LatencyGraphWidget(this);
+    latencyGraph->setFixedSize(90, 14);
+
+    auto *layout = new QHBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(4);
+    layout->addWidget(latencyGraph);
+    layout->addWidget(pingLabel);
+
+    hide();
+}
+
+void LatencyStatusWidget::updateStats(int lastMs, int medianMs, int p95Ms, int maxMs, int sampleCount)
+{
+    if (sampleCount == 0) {
+        hide();
+        return;
+    }
+
+    const QString stats = tr("Connection quality over the last %n sample(s):", "", sampleCount) + "\n" +
+                          tr("Last: %1 ms").arg(lastMs) + "\n" + tr("Median: %1 ms").arg(medianMs) + "\n" +
+                          tr("95th percentile: %1 ms").arg(p95Ms) + "\n" + tr("Maximum: %1 ms").arg(maxMs);
+
+    pingLabel->setText(tr("Ping: %1 ms").arg(lastMs));
+    pingLabel->setToolTip(stats);
+    pingLabel->setAccessibleDescription(stats);
+    show();
+}
+
+void LatencyStatusWidget::updateSamples(const QList<int> &samplesMs)
+{
+    latencyGraph->setSamples(samplesMs);
+}

--- a/cockatrice/src/client/latency_status_widget.cpp
+++ b/cockatrice/src/client/latency_status_widget.cpp
@@ -35,20 +35,20 @@ LatencyStatusWidget::LatencyStatusWidget(QWidget *parent) : QWidget(parent)
     hide();
 }
 
-void LatencyStatusWidget::updateStats(int lastMs, int medianMs, int p95Ms, int maxMs, int sampleCount)
+void LatencyStatusWidget::updateStats(const LatencyTracker::Stats &stats)
 {
-    if (sampleCount == 0) {
+    if (stats.sampleCount == 0) {
         hide();
         return;
     }
 
-    const QString stats = statsText(lastMs, medianMs, p95Ms, maxMs, sampleCount);
+    const QString statsStr = statsText(stats);
 
-    pingLabel->setText(tr("Ping: %1 ms").arg(lastMs));
-    pingLabel->setToolTip(stats);
-    pingLabel->setAccessibleDescription(stats);
+    pingLabel->setText(tr("Ping: %1 ms").arg(stats.lastMs));
+    pingLabel->setToolTip(statsStr);
+    pingLabel->setAccessibleDescription(statsStr);
     if (popup && popup->isVisible() && detailLabel) {
-        detailLabel->setText(stats);
+        detailLabel->setText(statsStr);
     }
     show();
 }
@@ -106,9 +106,9 @@ void LatencyStatusWidget::togglePopup()
     popup->show();
 }
 
-QString LatencyStatusWidget::statsText(int lastMs, int medianMs, int p95Ms, int maxMs, int sampleCount) const
+QString LatencyStatusWidget::statsText(const LatencyTracker::Stats &stats) const
 {
-    return tr("Connection quality over the last %n sample(s):", "", sampleCount) + "\n" +
-           tr("Last: %1 ms").arg(lastMs) + "\n" + tr("Median: %1 ms").arg(medianMs) + "\n" +
-           tr("95th percentile: %1 ms").arg(p95Ms) + "\n" + tr("Maximum: %1 ms").arg(maxMs);
+    return tr("Connection quality over the last %n sample(s):", "", stats.sampleCount) + "\n" +
+           tr("Last: %1 ms").arg(stats.lastMs) + "\n" + tr("Median: %1 ms").arg(stats.medianMs) + "\n" +
+           tr("95th percentile: %1 ms").arg(stats.p95Ms) + "\n" + tr("Maximum: %1 ms").arg(stats.maxMs);
 }

--- a/cockatrice/src/client/latency_status_widget.cpp
+++ b/cockatrice/src/client/latency_status_widget.cpp
@@ -7,8 +7,10 @@
 
 #include "latency_graph_widget.h"
 
+#include <QEvent>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QVBoxLayout>
 
 LatencyStatusWidget::LatencyStatusWidget(QWidget *parent) : QWidget(parent)
 {
@@ -24,6 +26,12 @@ LatencyStatusWidget::LatencyStatusWidget(QWidget *parent) : QWidget(parent)
     layout->addWidget(latencyGraph);
     layout->addWidget(pingLabel);
 
+    // Clicking anywhere in the area opens the detail view.
+    for (QObject *child : QList<QObject *>{pingLabel, latencyGraph}) {
+        child->installEventFilter(this);
+    }
+    setCursor(Qt::PointingHandCursor);
+
     hide();
 }
 
@@ -34,17 +42,73 @@ void LatencyStatusWidget::updateStats(int lastMs, int medianMs, int p95Ms, int m
         return;
     }
 
-    const QString stats = tr("Connection quality over the last %n sample(s):", "", sampleCount) + "\n" +
-                          tr("Last: %1 ms").arg(lastMs) + "\n" + tr("Median: %1 ms").arg(medianMs) + "\n" +
-                          tr("95th percentile: %1 ms").arg(p95Ms) + "\n" + tr("Maximum: %1 ms").arg(maxMs);
+    const QString stats = statsText(lastMs, medianMs, p95Ms, maxMs, sampleCount);
 
     pingLabel->setText(tr("Ping: %1 ms").arg(lastMs));
     pingLabel->setToolTip(stats);
     pingLabel->setAccessibleDescription(stats);
+    if (popup && popup->isVisible() && detailLabel) {
+        detailLabel->setText(stats);
+    }
     show();
 }
 
 void LatencyStatusWidget::updateSamples(const QList<int> &samplesMs)
 {
+    latestSamples = samplesMs;
     latencyGraph->setSamples(samplesMs);
+    if (popup && popup->isVisible() && detailGraph) {
+        detailGraph->setSamples(samplesMs);
+    }
+}
+
+bool LatencyStatusWidget::eventFilter(QObject *watched, QEvent *event)
+{
+    if ((watched == pingLabel || watched == latencyGraph) && event->type() == QEvent::MouseButtonPress) {
+        togglePopup();
+        return true;
+    }
+    return QWidget::eventFilter(watched, event);
+}
+
+void LatencyStatusWidget::togglePopup()
+{
+    if (!popup) {
+        popup = new QWidget(this, Qt::Popup | Qt::FramelessWindowHint);
+        auto *layout = new QVBoxLayout(popup);
+        layout->setContentsMargins(8, 8, 8, 8);
+
+        detailLabel = new QLabel(popup);
+        detailLabel->setAccessibleName(tr("Connection latency details"));
+        detailLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
+        detailGraph = new LatencyGraphWidget(popup);
+        detailGraph->setFixedSize(280, 80);
+
+        layout->addWidget(detailLabel, 0, Qt::AlignLeft);
+        layout->addWidget(detailGraph, 0, Qt::AlignHCenter);
+    }
+
+    if (popup->isVisible()) {
+        popup->hide();
+        return;
+    }
+
+    // Qt::Popup closes itself on any outside click, so just position and show.
+    if (latestSamples.isEmpty()) {
+        return;
+    }
+    detailGraph->setSamples(latestSamples);
+    detailLabel->setText(pingLabel->toolTip());
+    popup->adjustSize();
+    const QPoint anchor = mapToGlobal(QPoint(width() / 2, 0));
+    popup->move(anchor.x() - popup->width() / 2, anchor.y() - popup->height() - 6);
+    popup->show();
+}
+
+QString LatencyStatusWidget::statsText(int lastMs, int medianMs, int p95Ms, int maxMs, int sampleCount) const
+{
+    return tr("Connection quality over the last %n sample(s):", "", sampleCount) + "\n" +
+           tr("Last: %1 ms").arg(lastMs) + "\n" + tr("Median: %1 ms").arg(medianMs) + "\n" +
+           tr("95th percentile: %1 ms").arg(p95Ms) + "\n" + tr("Maximum: %1 ms").arg(maxMs);
 }

--- a/cockatrice/src/client/latency_status_widget.h
+++ b/cockatrice/src/client/latency_status_widget.h
@@ -16,9 +16,11 @@ class LatencyGraphWidget;
  * @brief Status bar presentation of server round-trip health.
  *
  * Combines the textual "Ping" readout with a small LatencyGraphWidget
- * sparkline of the rolling sample window. Stays hidden while disconnected or
- * before any samples exist. Owns all latency display state so MainWindow only
- * needs to forward two signals here.
+ * sparkline of the rolling sample window. Clicking anywhere in the area opens
+ * a popup with a larger graph and the numeric statistics. It closes on any
+ * outside click. Stays hidden while disconnected or before any samples exist.
+ * Owns all latency display state so MainWindow only needs to forward two
+ * signals here.
  */
 class LatencyStatusWidget : public QWidget
 {
@@ -30,9 +32,19 @@ public slots:
     void updateStats(int lastMs, int medianMs, int p95Ms, int maxMs, int sampleCount);
     void updateSamples(const QList<int> &samplesMs);
 
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
 private:
+    void togglePopup();
+    QString statsText(int lastMs, int medianMs, int p95Ms, int maxMs, int sampleCount) const;
+
     QLabel *pingLabel = nullptr;
     LatencyGraphWidget *latencyGraph = nullptr;
+    QWidget *popup = nullptr;
+    LatencyGraphWidget *detailGraph = nullptr;
+    QLabel *detailLabel = nullptr;
+    QList<int> latestSamples;
 };
 
 #endif

--- a/cockatrice/src/client/latency_status_widget.h
+++ b/cockatrice/src/client/latency_status_widget.h
@@ -20,8 +20,8 @@ class LatencyGraphWidget;
  * sparkline of the rolling sample window. Clicking anywhere in the area opens
  * a popup with a larger graph and the numeric statistics. It closes on any
  * outside click. Stays hidden while disconnected or before any samples exist.
- * Owns all latency display state so MainWindow only needs to forward two
- * signals here.
+ * Owns all latency display state so MainWindow only needs to forward one
+ * signal here.
  */
 class LatencyStatusWidget : public QWidget
 {
@@ -30,8 +30,7 @@ public:
     explicit LatencyStatusWidget(QWidget *parent = nullptr);
 
 public slots:
-    void updateStats(const LatencyTracker::Stats &stats);
-    void updateSamples(const QList<int> &samplesMs);
+    void updateData(const LatencyTracker::Stats &stats, const QList<int> &samplesMs);
 
 protected:
     bool eventFilter(QObject *watched, QEvent *event) override;

--- a/cockatrice/src/client/latency_status_widget.h
+++ b/cockatrice/src/client/latency_status_widget.h
@@ -1,0 +1,38 @@
+/**
+ * @file latency_status_widget.h
+ * @ingroup Client
+ */
+
+#ifndef LATENCY_STATUS_WIDGET_H
+#define LATENCY_STATUS_WIDGET_H
+
+#include <QList>
+#include <QWidget>
+
+class QLabel;
+class LatencyGraphWidget;
+
+/**
+ * @brief Status bar presentation of server round-trip health.
+ *
+ * Combines the textual "Ping" readout with a small LatencyGraphWidget
+ * sparkline of the rolling sample window. Stays hidden while disconnected or
+ * before any samples exist. Owns all latency display state so MainWindow only
+ * needs to forward two signals here.
+ */
+class LatencyStatusWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit LatencyStatusWidget(QWidget *parent = nullptr);
+
+public slots:
+    void updateStats(int lastMs, int medianMs, int p95Ms, int maxMs, int sampleCount);
+    void updateSamples(const QList<int> &samplesMs);
+
+private:
+    QLabel *pingLabel = nullptr;
+    LatencyGraphWidget *latencyGraph = nullptr;
+};
+
+#endif

--- a/cockatrice/src/client/latency_status_widget.h
+++ b/cockatrice/src/client/latency_status_widget.h
@@ -8,6 +8,7 @@
 
 #include <QList>
 #include <QWidget>
+#include <libcockatrice/network/client/abstract/latency_tracker.h>
 
 class QLabel;
 class LatencyGraphWidget;
@@ -29,7 +30,7 @@ public:
     explicit LatencyStatusWidget(QWidget *parent = nullptr);
 
 public slots:
-    void updateStats(int lastMs, int medianMs, int p95Ms, int maxMs, int sampleCount);
+    void updateStats(const LatencyTracker::Stats &stats);
     void updateSamples(const QList<int> &samplesMs);
 
 protected:
@@ -37,7 +38,7 @@ protected:
 
 private:
     void togglePopup();
-    QString statsText(int lastMs, int medianMs, int p95Ms, int maxMs, int sampleCount) const;
+    QString statsText(const LatencyTracker::Stats &stats) const;
 
     QLabel *pingLabel = nullptr;
     LatencyGraphWidget *latencyGraph = nullptr;

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
@@ -884,21 +884,21 @@ void TabSupervisor::updatePingTime(int value, int max)
     setTabIcon(indexOf(tabServer), QIcon(PingPixmapGenerator::generatePixmap(15, value, max)));
 }
 
-void TabSupervisor::updateLatencyTooltip(int lastMs, int medianMs, int p95Ms, int maxMs, int sampleCount)
+void TabSupervisor::updateLatencyTooltip(const LatencyTracker::Stats &stats)
 {
     if (!tabServer) {
         return;
     }
 
-    if (sampleCount == 0) {
+    if (stats.sampleCount == 0) {
         setTabToolTip(indexOf(tabServer), QString());
         return;
     }
 
-    setTabToolTip(indexOf(tabServer), tr("Connection quality over the last %n sample(s):", "", sampleCount) + "\n" +
-                                          tr("Last: %1 ms").arg(lastMs) + "\n" + tr("Median: %1 ms").arg(medianMs) +
-                                          "\n" + tr("95th percentile: %1 ms").arg(p95Ms) + "\n" +
-                                          tr("Maximum: %1 ms").arg(maxMs));
+    setTabToolTip(indexOf(tabServer),
+                  tr("Connection quality over the last %n sample(s):", "", stats.sampleCount) + "\n" +
+                      tr("Last: %1 ms").arg(stats.lastMs) + "\n" + tr("Median: %1 ms").arg(stats.medianMs) + "\n" +
+                      tr("95th percentile: %1 ms").arg(stats.p95Ms) + "\n" + tr("Maximum: %1 ms").arg(stats.maxMs));
 }
 
 void TabSupervisor::gameJoined(const Event_GameJoined &event)

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
@@ -141,6 +141,7 @@ TabSupervisor::TabSupervisor(AbstractClient *_client, QMenu *tabsMenu, QWidget *
     connect(client, &AbstractClient::gameJoinedEventReceived, this, &TabSupervisor::gameJoined);
     connect(client, &AbstractClient::userMessageEventReceived, this, &TabSupervisor::processUserMessageEvent);
     connect(client, &AbstractClient::maxPingTime, this, &TabSupervisor::updatePingTime);
+    connect(client, &AbstractClient::pingStatsUpdated, this, &TabSupervisor::updateLatencyTooltip);
     connect(client, &AbstractClient::notifyUserEventReceived, this, &TabSupervisor::processNotifyUserEvent);
 
     // create tabs menu actions
@@ -881,6 +882,23 @@ void TabSupervisor::updatePingTime(int value, int max)
     }
 
     setTabIcon(indexOf(tabServer), QIcon(PingPixmapGenerator::generatePixmap(15, value, max)));
+}
+
+void TabSupervisor::updateLatencyTooltip(int lastMs, int medianMs, int p95Ms, int maxMs, int sampleCount)
+{
+    if (!tabServer) {
+        return;
+    }
+
+    if (sampleCount == 0) {
+        setTabToolTip(indexOf(tabServer), QString());
+        return;
+    }
+
+    setTabToolTip(indexOf(tabServer), tr("Connection quality over the last %n sample(s):", "", sampleCount) + "\n" +
+                                          tr("Last: %1 ms").arg(lastMs) + "\n" + tr("Median: %1 ms").arg(medianMs) +
+                                          "\n" + tr("95th percentile: %1 ms").arg(p95Ms) + "\n" +
+                                          tr("Maximum: %1 ms").arg(maxMs));
 }
 
 void TabSupervisor::gameJoined(const Event_GameJoined &event)

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.h
@@ -24,6 +24,7 @@
 #include <QMap>
 #include <QProxyStyle>
 #include <QTabWidget>
+#include <libcockatrice/network/client/abstract/latency_tracker.h>
 
 class TabCardArtRules;
 inline Q_LOGGING_CATEGORY(TabSupervisorLog, "tab_supervisor");
@@ -220,7 +221,7 @@ private slots:
 
     void updateCurrent(int index);
     void updatePingTime(int value, int max);
-    void updateLatencyTooltip(int lastMs, int medianMs, int p95Ms, int maxMs, int sampleCount);
+    void updateLatencyTooltip(const LatencyTracker::Stats &stats);
     void gameJoined(const Event_GameJoined &event);
     void localGameJoined(const Event_GameJoined &event);
     void gameLeft(TabGame *tab);

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.h
@@ -220,6 +220,7 @@ private slots:
 
     void updateCurrent(int index);
     void updatePingTime(int value, int max);
+    void updateLatencyTooltip(int lastMs, int medianMs, int p95Ms, int maxMs, int sampleCount);
     void gameJoined(const Event_GameJoined &event);
     void localGameJoined(const Event_GameJoined &event);
     void gameLeft(TabGame *tab);

--- a/cockatrice/src/interface/window_main.cpp
+++ b/cockatrice/src/interface/window_main.cpp
@@ -541,10 +541,7 @@ MainWindow::MainWindow(QWidget *parent)
     statusBar()->addPermanentWidget(latencyStatus);
 
     connect(connectionController, &ConnectionController::pingStatsUpdated, latencyStatus,
-            [this](const LatencyTracker::Stats &stats, const QList<int> &samplesMs) {
-                latencyStatus->updateStats(stats);
-                latencyStatus->updateSamples(samplesMs);
-            });
+            &LatencyStatusWidget::updateData);
 
     connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
             &MainWindow::refreshShortcuts);

--- a/cockatrice/src/interface/window_main.cpp
+++ b/cockatrice/src/interface/window_main.cpp
@@ -56,6 +56,7 @@
 #include <QDesktopServices>
 #include <QFile>
 #include <QFileDialog>
+#include <QLabel>
 #include <QMenu>
 #include <QMenuBar>
 #include <QMessageBox>
@@ -142,6 +143,23 @@ void MainWindow::statusChanged(ClientStatus _status)
         default:
             break;
     }
+}
+
+void MainWindow::updatePingDisplay(int lastMs, int medianMs, int p95Ms, int maxMs, int sampleCount)
+{
+    if (!pingLabel || sampleCount == 0) {
+        if (pingLabel) {
+            pingLabel->hide();
+        }
+        return;
+    }
+
+    pingLabel->setText(tr("Ping: %1 ms").arg(lastMs));
+    pingLabel->setToolTip(tr("Connection quality over the last %n sample(s):", "", sampleCount) + "\n" +
+                          tr("Last: %1 ms").arg(lastMs) + "\n" + tr("Median: %1 ms").arg(medianMs) + "\n" +
+                          tr("95th percentile: %1 ms").arg(p95Ms) + "\n" + tr("Maximum: %1 ms").arg(maxMs));
+    pingLabel->setAccessibleDescription(pingLabel->toolTip());
+    pingLabel->show();
 }
 
 // Actions
@@ -534,6 +552,12 @@ MainWindow::MainWindow(QWidget *parent)
     connect(&SettingsCache::instance().userInterface(), &InterfaceSettings::showStatusBarChanged, this,
             [this](bool show) { statusBar()->setVisible(show); });
     statusBar()->setVisible(SettingsCache::instance().userInterface().getShowStatusBar());
+
+    pingLabel = new QLabel(this);
+    pingLabel->setAccessibleName(tr("Ping"));
+    pingLabel->hide();
+    statusBar()->addPermanentWidget(pingLabel);
+    connect(connectionController, &ConnectionController::pingStatsUpdated, this, &MainWindow::updatePingDisplay);
 
     connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
             &MainWindow::refreshShortcuts);

--- a/cockatrice/src/interface/window_main.cpp
+++ b/cockatrice/src/interface/window_main.cpp
@@ -19,6 +19,7 @@
  ***************************************************************************/
 #include "window_main.h"
 
+#include "../client/latency_status_widget.h"
 #include "../client/network/update/client/client_update_checker.h"
 #include "../client/network/update/client/release_channel.h"
 #include "../client/settings/cache_settings.h"
@@ -143,23 +144,6 @@ void MainWindow::statusChanged(ClientStatus _status)
         default:
             break;
     }
-}
-
-void MainWindow::updatePingDisplay(int lastMs, int medianMs, int p95Ms, int maxMs, int sampleCount)
-{
-    if (!pingLabel || sampleCount == 0) {
-        if (pingLabel) {
-            pingLabel->hide();
-        }
-        return;
-    }
-
-    pingLabel->setText(tr("Ping: %1 ms").arg(lastMs));
-    pingLabel->setToolTip(tr("Connection quality over the last %n sample(s):", "", sampleCount) + "\n" +
-                          tr("Last: %1 ms").arg(lastMs) + "\n" + tr("Median: %1 ms").arg(medianMs) + "\n" +
-                          tr("95th percentile: %1 ms").arg(p95Ms) + "\n" + tr("Maximum: %1 ms").arg(maxMs));
-    pingLabel->setAccessibleDescription(pingLabel->toolTip());
-    pingLabel->show();
 }
 
 // Actions
@@ -553,11 +537,13 @@ MainWindow::MainWindow(QWidget *parent)
             [this](bool show) { statusBar()->setVisible(show); });
     statusBar()->setVisible(SettingsCache::instance().userInterface().getShowStatusBar());
 
-    pingLabel = new QLabel(this);
-    pingLabel->setAccessibleName(tr("Ping"));
-    pingLabel->hide();
-    statusBar()->addPermanentWidget(pingLabel);
-    connect(connectionController, &ConnectionController::pingStatsUpdated, this, &MainWindow::updatePingDisplay);
+    latencyStatus = new LatencyStatusWidget(this);
+    statusBar()->addPermanentWidget(latencyStatus);
+
+    connect(connectionController, &ConnectionController::pingStatsUpdated, latencyStatus,
+            &LatencyStatusWidget::updateStats);
+    connect(connectionController, &ConnectionController::pingSamplesUpdated, latencyStatus,
+            &LatencyStatusWidget::updateSamples);
 
     connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
             &MainWindow::refreshShortcuts);

--- a/cockatrice/src/interface/window_main.cpp
+++ b/cockatrice/src/interface/window_main.cpp
@@ -541,9 +541,10 @@ MainWindow::MainWindow(QWidget *parent)
     statusBar()->addPermanentWidget(latencyStatus);
 
     connect(connectionController, &ConnectionController::pingStatsUpdated, latencyStatus,
-            &LatencyStatusWidget::updateStats);
-    connect(connectionController, &ConnectionController::pingSamplesUpdated, latencyStatus,
-            &LatencyStatusWidget::updateSamples);
+            [this](const LatencyTracker::Stats &stats, const QList<int> &samplesMs) {
+                latencyStatus->updateStats(stats);
+                latencyStatus->updateSamples(samplesMs);
+            });
 
     connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
             &MainWindow::refreshShortcuts);

--- a/cockatrice/src/interface/window_main.h
+++ b/cockatrice/src/interface/window_main.h
@@ -148,7 +148,7 @@ private:
     WndSets *wndSets;
     ConnectionController *connectionController;
     LocalServer *localServer;
-    LagMonitor lagMonitor; ///< watches the main thread for event loop stalls
+    LagMonitor lagMonitor;                        ///< watches the main thread for event loop stalls
     LatencyStatusWidget *latencyStatus = nullptr; ///< status bar widget with live round-trip stats and history graph
     bool bHasActivated, askedForDbUpdater;
     QProcess *cardUpdateProcess;

--- a/cockatrice/src/interface/window_main.h
+++ b/cockatrice/src/interface/window_main.h
@@ -51,6 +51,7 @@ class HandlePublicServers;
 class LocalClient;
 class LocalServer;
 class QLabel;
+class LatencyStatusWidget;
 class QThread;
 class RemoteClient;
 class ServerInfo_User;
@@ -73,7 +74,6 @@ public slots:
 private slots:
     void updateTabMenu(const QList<QMenu *> &newMenuList);
     void statusChanged(ClientStatus _status);
-    void updatePingDisplay(int lastMs, int medianMs, int p95Ms, int maxMs, int sampleCount);
     void localGameEnded();
     void pixmapCacheSizeChanged(int newSizeInMBs);
     void actDisconnect();
@@ -148,8 +148,8 @@ private:
     WndSets *wndSets;
     ConnectionController *connectionController;
     LocalServer *localServer;
-    QLabel *pingLabel = nullptr; ///< status bar label with live round-trip stats
     LagMonitor lagMonitor; ///< watches the main thread for event loop stalls
+    LatencyStatusWidget *latencyStatus = nullptr; ///< status bar widget with live round-trip stats and history graph
     bool bHasActivated, askedForDbUpdater;
     QProcess *cardUpdateProcess;
     DlgViewLog *logviewDialog;

--- a/cockatrice/src/interface/window_main.h
+++ b/cockatrice/src/interface/window_main.h
@@ -50,6 +50,7 @@ class GameReplay;
 class HandlePublicServers;
 class LocalClient;
 class LocalServer;
+class QLabel;
 class QThread;
 class RemoteClient;
 class ServerInfo_User;
@@ -72,6 +73,7 @@ public slots:
 private slots:
     void updateTabMenu(const QList<QMenu *> &newMenuList);
     void statusChanged(ClientStatus _status);
+    void updatePingDisplay(int lastMs, int medianMs, int p95Ms, int maxMs, int sampleCount);
     void localGameEnded();
     void pixmapCacheSizeChanged(int newSizeInMBs);
     void actDisconnect();
@@ -146,6 +148,7 @@ private:
     WndSets *wndSets;
     ConnectionController *connectionController;
     LocalServer *localServer;
+    QLabel *pingLabel = nullptr; ///< status bar label with live round-trip stats
     LagMonitor lagMonitor; ///< watches the main thread for event loop stalls
     bool bHasActivated, askedForDbUpdater;
     QProcess *cardUpdateProcess;


### PR DESCRIPTION
## Short roundup of the initial problem
No client UI for #7153 

## What will change with this Pull Request?
- Add a permanent status-bar label fed by ConnectionController's pingStatsUpdated which shows the latest round-trip time, hides while disconnected or without samples, and carries a tooltip with Last/Median/95th percentile/Maximum over the rolling sample window. 
- The server tab gets the same stats as its tooltip.
- Add LatencyGraphWidget, a size-agnostic bar sparkline over the rolling sample window: heights scale to the window's own range while colors map onto an absolute quality ramp, so a steady good ping stays green. 
- Embed it in the new LatencyStatusWidget together with the textual ping readout.
