### PR TITLE
[GamesModel] Clear games types before merging

### DIFF
--- a/cockatrice/src/interface/widgets/server/games_model.cpp
+++ b/cockatrice/src/interface/widgets/server/games_model.cpp
@@ -285,6 +285,9 @@ void GamesModel::updateGameList(const ServerInfo_Game &game)
                 gameList.removeAt(i);
                 endRemoveRows();
             } else {
+                // MergeFrom concatenates repeated fields instead of replacing them,
+                // so clear game_types first to avoid duplicated entries.
+                gameList[i].clear_game_types();
                 gameList[i].MergeFrom(game);
                 emit dataChanged(index(i, 0), index(i, NUM_COLS - 1));
             }


### PR DESCRIPTION
## Short roundup of the initial problem
Protobuf appends to 'repeated' fields when merging, which leads to duplication in the games types category (the only repeated field)

## What will change with this Pull Request?
- Clear GamesTypes before merging