### PR TITLE
[Client] Restore stored banner printing when the art dialog opens

### DIFF
--- a/cockatrice/src/interface/widgets/server/user/user_card_settings_dialog.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_card_settings_dialog.cpp
@@ -112,6 +112,19 @@ UserCardArtSettingsDialog::UserCardArtSettingsDialog(const CardArtParams &initia
     if (!initial.cardName.isEmpty()) {
         searchBar->setText(initial.cardName);
         onCardNameChanged(initial.cardName);
+
+        // onCardNameChanged leaves the printing combo on the first printing in
+        // the database, which would silently change the stored banner card on
+        // accept. Restore the stored printing when it resolves locally.
+        const int storedPrintingIndex = providerComboBox->findData(initial.cardProviderId);
+        if (storedPrintingIndex != -1) {
+            providerComboBox->setCurrentIndex(storedPrintingIndex);
+        } else {
+            // Stored printing not in the local database: keep it rather than
+            // silently substituting the first printing.
+            currentParams.cardProviderId = initial.cardProviderId;
+            reloadPreview();
+        }
     }
     marginLSpin->setValue(initial.marginPctL);
     marginRSpin->setValue(initial.marginPctR);

--- a/cockatrice/src/interface/widgets/server/user/user_info_box.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_info_box.cpp
@@ -319,6 +319,7 @@ void UserInfoBox::actBannerCard()
     if (hasUserInfo && currentUserInfo.has_card_art_params()) {
         const auto &cap = currentUserInfo.card_art_params();
         initial.cardName = QString::fromStdString(cap.card_name());
+        initial.cardProviderId = QString::fromStdString(cap.card_provider_id());
         initial.marginPctL = cap.margin_pct_l();
         initial.marginPctR = cap.margin_pct_r();
         initial.verticalOffset = cap.vertical_offset();


### PR DESCRIPTION
## Short roundup of the initial problem
Two problems made opening and confirming the banner dialog silently switch the banner to the default art of the first local printing. The caller dropped the card provider id when constructing the initial params, and the constructor left the printing combo wherever onCardNameChanged put it, which is always the first printing

## What will change with this Pull Request?
- Pass the provider id through, restore it in the combo when it resolves locally, and keep it verbatim when it does not