### PR TITLE
add a limit to the size of deckfiles cockatrice can load

### DIFF
--- a/libcockatrice_deck_list/libcockatrice/deck_list/deck_list_node_tree.cpp
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/deck_list_node_tree.cpp
@@ -5,7 +5,7 @@
 #include <QCryptographicHash>
 #include <QSet>
 
-static constexpr int MAX_DECK_SIZE = 99999;
+static constexpr int MAX_DECK_SIZE = 1e5;
 
 DecklistNodeTree::DecklistNodeTree() : root(new InnerDecklistNode())
 {

--- a/libcockatrice_deck_list/libcockatrice/deck_list/deck_list_node_tree.cpp
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/deck_list_node_tree.cpp
@@ -5,6 +5,8 @@
 #include <QCryptographicHash>
 #include <QSet>
 
+static constexpr int MAX_DECK_SIZE = 99999;
+
 DecklistNodeTree::DecklistNodeTree() : root(new InnerDecklistNode())
 {
 }
@@ -107,7 +109,7 @@ void DecklistNodeTree::readZoneElement(QXmlStreamReader *xml)
 {
     QString zoneName = xml->attributes().value("name").toString();
     InnerDecklistNode *newZone = getZoneObjFromName(zoneName);
-    newZone->readElement(xml);
+    totalCards += newZone->readElement(xml, MAX_DECK_SIZE - totalCards);
 }
 
 DecklistCardNode *DecklistNodeTree::addCard(const QString &cardName,
@@ -119,6 +121,8 @@ DecklistCardNode *DecklistNodeTree::addCard(const QString &cardName,
                                             const QString &cardProviderId,
                                             const bool formatLegal)
 {
+    amount = qMin(amount, MAX_DECK_SIZE - totalCards);
+    totalCards += amount;
     auto *zoneNode = getZoneObjFromName(zoneName);
     auto *node = new DecklistCardNode(cardName, amount, zoneNode, position, cardSetName, cardSetCollectorNumber,
                                       cardProviderId, formatLegal);

--- a/libcockatrice_deck_list/libcockatrice/deck_list/deck_list_node_tree.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/deck_list_node_tree.h
@@ -10,6 +10,7 @@
 class DecklistNodeTree
 {
     InnerDecklistNode *root; ///< Root of the deck tree (zones + cards).
+    int totalCards = 0;
 
 public:
     /** @brief Constructs an empty DecklistNodeTree. */

--- a/libcockatrice_deck_list/libcockatrice/deck_list/tree/abstract_deck_list_card_node.cpp
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/tree/abstract_deck_list_card_node.cpp
@@ -34,15 +34,15 @@ bool AbstractDecklistCardNode::compareName(AbstractDecklistNode *other) const
     }
 }
 
-bool AbstractDecklistCardNode::readElement(QXmlStreamReader *xml)
+int AbstractDecklistCardNode::readElement(QXmlStreamReader *xml, int /* limit */)
 {
     while (!xml->atEnd()) {
         xml->readNext();
         if (xml->isEndElement() && xml->name().toString() == "card") {
-            return false;
+            return 0;
         }
     }
-    return true;
+    return 0;
 }
 
 void AbstractDecklistCardNode::writeElement(QXmlStreamWriter *xml)

--- a/libcockatrice_deck_list/libcockatrice/deck_list/tree/abstract_deck_list_card_node.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/tree/abstract_deck_list_card_node.h
@@ -141,7 +141,7 @@ public:
      *
      * This supports loading deck files from Cockatrice’s XML format.
      */
-    bool readElement(QXmlStreamReader *xml) override;
+    int readElement(QXmlStreamReader *xml, int limit) override;
 
     /**
      * @brief Serialize this node’s properties to XML.

--- a/libcockatrice_deck_list/libcockatrice/deck_list/tree/abstract_deck_list_node.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/tree/abstract_deck_list_node.h
@@ -177,7 +177,7 @@ public:
      * Cockatrice deck XML format.
      * @{
      */
-    virtual bool readElement(QXmlStreamReader *xml) = 0;
+    virtual int readElement(QXmlStreamReader *xml, int limit) = 0;
     virtual void writeElement(QXmlStreamWriter *xml) = 0;
     /// @}
 };

--- a/libcockatrice_deck_list/libcockatrice/deck_list/tree/inner_deck_list_node.cpp
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/tree/inner_deck_list_node.cpp
@@ -139,27 +139,31 @@ bool InnerDecklistNode::compareName(AbstractDecklistNode *other) const
     }
 }
 
-bool InnerDecklistNode::readElement(QXmlStreamReader *xml)
+int InnerDecklistNode::readElement(QXmlStreamReader *xml, int limit)
 {
+    int totalCards = 0;
     while (!xml->atEnd()) {
         xml->readNext();
         const QString childName = xml->name().toString();
         if (xml->isStartElement()) {
             if (childName == "zone") {
                 auto *newZone = new InnerDecklistNode(xml->attributes().value("name").toString(), this);
-                newZone->readElement(xml);
+                totalCards += newZone->readElement(xml, limit - totalCards);
             } else if (childName == "card") {
+              int amount = xml->attributes().value("number").toString().toInt();
+              amount = qMin(amount, limit - totalCards);
                 auto *newCard = new DecklistCardNode(
-                    xml->attributes().value("name").toString(), xml->attributes().value("number").toString().toInt(),
+                    xml->attributes().value("name").toString(), amount,
                     this, -1, xml->attributes().value("setShortName").toString(),
                     xml->attributes().value("collectorNumber").toString(), xml->attributes().value("uuid").toString());
-                newCard->readElement(xml);
+                totalCards += amount;
+                totalCards += newCard->readElement(xml, limit - totalCards);
             }
         } else if (xml->isEndElement() && (childName == "zone")) {
-            return false;
+            return totalCards;
         }
     }
-    return true;
+    return totalCards;
 }
 
 void InnerDecklistNode::writeElement(QXmlStreamWriter *xml)

--- a/libcockatrice_deck_list/libcockatrice/deck_list/tree/inner_deck_list_node.cpp
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/tree/inner_deck_list_node.cpp
@@ -150,12 +150,12 @@ int InnerDecklistNode::readElement(QXmlStreamReader *xml, int limit)
                 auto *newZone = new InnerDecklistNode(xml->attributes().value("name").toString(), this);
                 totalCards += newZone->readElement(xml, limit - totalCards);
             } else if (childName == "card") {
-              int amount = xml->attributes().value("number").toString().toInt();
-              amount = qMin(amount, limit - totalCards);
-                auto *newCard = new DecklistCardNode(
-                    xml->attributes().value("name").toString(), amount,
-                    this, -1, xml->attributes().value("setShortName").toString(),
-                    xml->attributes().value("collectorNumber").toString(), xml->attributes().value("uuid").toString());
+                int amount = xml->attributes().value("number").toString().toInt();
+                amount = qMin(amount, limit - totalCards);
+                auto *newCard = new DecklistCardNode(xml->attributes().value("name").toString(), amount, this, -1,
+                                                     xml->attributes().value("setShortName").toString(),
+                                                     xml->attributes().value("collectorNumber").toString(),
+                                                     xml->attributes().value("uuid").toString());
                 totalCards += amount;
                 totalCards += newCard->readElement(xml, limit - totalCards);
             }

--- a/libcockatrice_deck_list/libcockatrice/deck_list/tree/inner_deck_list_node.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/tree/inner_deck_list_node.h
@@ -214,9 +214,10 @@ public:
     /**
      * @brief Deserialize this node and its children from XML.
      * @param xml Reader positioned at this element.
-     * @return true if parsing succeeded.
+     * @param limit The maximum amount of cards to read
+     * @return the amount of cards found
      */
-    bool readElement(QXmlStreamReader *xml) override;
+    int readElement(QXmlStreamReader *xml, int limit) override;
 
     /**
      * @brief Serialize this node and its children to XML.


### PR DESCRIPTION


## Related Ticket(s)
related https://github.com/Cockatrice/Cockatrice/pull/5025
https://github.com/Cockatrice/Cockatrice/pull/5026

## Short roundup of the initial problem
cockatrice seems to allow to load millions of cards, leading to lag, this stops this at the deck loader stage

the limit or 100k right now, which is kind of the limit of what looks acceptable in the player

note that clients will still struggle heavily to display 100k cards, and these decks mess with the visual deck selector, this is why most users don't try to abuse this up till whtz was printed

## What will change with this Pull Request?
- add a constant in the deck loader
- use this limit when loading from xml and plaintext
- when the limit is reached, no cards are added to the deck
- this means those card names will also not be hashed, avoiding most performance issues