### PR TITLE
[Network] Don't allow Event_ListGames to leak info and bloat bandwith

### DIFF
--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
@@ -829,7 +829,7 @@ void Server_Game::getInfo(ServerInfo_Game &result) const
         result.mutable_creator_info()->CopyFrom(*getCreatorInfo());
         const Server_AbstractParticipant *host = participants.value(hostId, nullptr);
         if (host != nullptr) {
-            result.mutable_host_info()->CopyFrom(*host->getUserInfo());
+            host->copyUserInfo(*result.mutable_host_info(), false);
         } else {
             result.mutable_host_info()->CopyFrom(*getCreatorInfo());
         }


### PR DESCRIPTION
## Related Ticket(s)
- Follow up to #7077

## Short roundup of the initial problem
getUserInfo() returns the participant's raw stored ServerInfo_User, which was saved with copyUserInfo(true, true, true) at join time  i.e. everything: email, account id, session_id, address (IP), clientid, and up-to-2 MB avatar_bmp

## What will change with this Pull Request?
- Privacy: every user in a room receives the host's email + home IP + session/account ids on every game-list broadcast 
- Performance: every gameInfoChanged (join/leave/start) re-broadcasts full host_info to all room users uncompressed. Mid-game joins ship N players × avatars.
