### PR TITLE
increase the timeout for the hashing performance test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ add_test(NAME server_card_counter_test COMMAND server_card_counter_test)
 add_test(NAME server_counter_test COMMAND server_counter_test)
 
 add_test(NAME deck_hash_performance_test COMMAND deck_hash_performance_test)
-set_tests_properties(deck_hash_performance_test PROPERTIES TIMEOUT 5)
+set_tests_properties(deck_hash_performance_test PROPERTIES TIMEOUT 15)
 
 # Find GTest
 


### PR DESCRIPTION
it seems like there is too much variance across platforms for how long this test takes probably fixes #7152