### PR TITLE
[VDS] Cache mana symbol renders and skip redundant resizes

### DIFF
--- a/cockatrice/src/interface/pixel_map_generator.cpp
+++ b/cockatrice/src/interface/pixel_map_generator.cpp
@@ -3,6 +3,7 @@
 #include <QApplication>
 #include <QDomDocument>
 #include <QFile>
+#include <QImageReader>
 #include <QPainter>
 #include <QPalette>
 #include <QSvgRenderer>
@@ -417,6 +418,57 @@ QPixmap DropdownIconPixmapGenerator::generatePixmap(int height, bool expanded)
 }
 
 QMap<QString, QPixmap> DropdownIconPixmapGenerator::pmCache;
+
+namespace
+{
+/// Longest side mana symbols are rendered at before being scaled to their final size.
+constexpr int MASTER_ICON_SIZE = 128;
+
+QString manaSymbolCacheKey(const QString &symbol, const QSize &size)
+{
+    return symbol + QLatin1Char('|') + QString::number(size.width()) + QLatin1Char('x') +
+           QString::number(size.height());
+}
+} // namespace
+
+const QPixmap &ManaSymbolPixmapGenerator::masterIcon(const QString &symbol)
+{
+    auto it = masterCache.constFind(symbol);
+    if (it != masterCache.constEnd()) {
+        return it.value();
+    }
+
+    QImageReader reader("theme:icons/mana/" + symbol);
+    QSize sourceSize = reader.size();
+    if (!sourceSize.isEmpty()) {
+        sourceSize.scale(QSize(MASTER_ICON_SIZE, MASTER_ICON_SIZE), Qt::KeepAspectRatio);
+        reader.setScaledSize(sourceSize);
+    }
+    const QPixmap rendered = QPixmap::fromImageReader(&reader);
+
+    return masterCache.insert(symbol, rendered).value();
+}
+
+QPixmap ManaSymbolPixmapGenerator::generatePixmap(const QString &symbol, const QSize &size)
+{
+    const QString key = manaSymbolCacheKey(symbol, size);
+    auto it = scaledCache.constFind(key);
+    if (it != scaledCache.constEnd()) {
+        return it.value();
+    }
+
+    const QPixmap &icon = masterIcon(symbol);
+    if (icon.isNull()) {
+        return {};
+    }
+
+    QPixmap scaled = icon.scaled(size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    scaledCache.insert(key, scaled);
+    return scaled;
+}
+
+QHash<QString, QPixmap> ManaSymbolPixmapGenerator::masterCache;
+QHash<QString, QPixmap> ManaSymbolPixmapGenerator::scaledCache;
 
 QPixmap loadColorAdjustedPixmap(const QString &name)
 {

--- a/cockatrice/src/interface/pixel_map_generator.h
+++ b/cockatrice/src/interface/pixel_map_generator.h
@@ -7,6 +7,7 @@
 #ifndef PIXMAPGENERATOR_H
 #define PIXMAPGENERATOR_H
 
+#include <QHash>
 #include <QIcon>
 #include <QLoggingCategory>
 #include <QMap>
@@ -122,6 +123,34 @@ public:
     static void clear()
     {
         pmCache.clear();
+    }
+};
+
+class ManaSymbolPixmapGenerator
+{
+private:
+    static QHash<QString, QPixmap> masterCache;
+    static QHash<QString, QPixmap> scaledCache;
+
+    /**
+     * @brief Renders \a symbol once at a fixed moderate size, so repeated scalings never
+     * re-rasterize the source file (SVG sources can be very expensive to rasterize).
+     */
+    static const QPixmap &masterIcon(const QString &symbol);
+
+public:
+    /**
+     * @brief Returns a smooth-scaled rendering of the given mana symbol icon.
+     *
+     * Results are shared between all callers via a process-wide cache keyed by symbol
+     * and size, so scaling work is done once per distinct combination instead of once
+     * per widget creation or resize.
+     */
+    static QPixmap generatePixmap(const QString &symbol, const QSize &size);
+    static void clear()
+    {
+        masterCache.clear();
+        scaledCache.clear();
     }
 };
 

--- a/cockatrice/src/interface/widgets/cards/additional_info/color_identity_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/additional_info/color_identity_widget.cpp
@@ -41,6 +41,11 @@ void ColorIdentityWidget::populateManaSymbolWidgets()
     // clear old layout
     QtUtils::clearLayoutRec(layout);
 
+    // The freshly created symbols haven't been sized yet, so force the next resize pass
+    // to apply the symbol size again.
+    lastIconSize = -1;
+    lastWidth = -1;
+
     // populate mana symbols
     if (SettingsCache::instance().visualDeckStorage().getVisualDeckStorageDrawUnusedColorIdentities()) {
         for (const QString symbol : fullColorIdentity) {
@@ -73,21 +78,35 @@ void ColorIdentityWidget::toggleUnusedVisibility()
 void ColorIdentityWidget::resizeEvent(QResizeEvent *event)
 {
     QWidget::resizeEvent(event);
+
+    // Layout passes resize this widget repeatedly with identical sizes, so bail out before
+    // touching the children when neither the width nor the resulting symbol size changed.
+    const int totalWidth = event->size().width();
+    if (totalWidth == lastWidth && lastIconSize != -1) {
+        return;
+    }
+    lastWidth = totalWidth;
+
+    const int totalHeight = totalWidth / 6; // Set height to 1/4 of the width
+    setFixedHeight(totalHeight);
+
     QList<ManaSymbolWidget *> manaSymbols = findChildren<ManaSymbolWidget *>();
+    if (manaSymbols.isEmpty()) {
+        return;
+    }
 
-    if (!manaSymbols.isEmpty()) {
-        int totalWidth = event->size().width();
-        int totalHeight = totalWidth / 6; // Set height to 1/4 of the width
-        setFixedHeight(totalHeight);
+    const int spacing = layout->spacing();
+    const int count = manaSymbols.size();
+    const int availableWidth = totalWidth - (spacing * (count - 1));
+    const int iconSize = qMin(availableWidth / count, totalHeight); // Ensure icons fit within the new height
 
-        int spacing = layout->spacing();
-        int count = manaSymbols.size();
-        int availableWidth = totalWidth - (spacing * (count - 1));
-        int iconSize = qMin(availableWidth / count, totalHeight); // Ensure icons fit within the new height
+    if (iconSize == lastIconSize) {
+        return;
+    }
+    lastIconSize = iconSize;
 
-        for (ManaSymbolWidget *manaSymbol : manaSymbols) {
-            manaSymbol->setFixedSize(iconSize, iconSize);
-        }
+    for (ManaSymbolWidget *manaSymbol : manaSymbols) {
+        manaSymbol->setFixedSize(iconSize, iconSize);
     }
 }
 

--- a/cockatrice/src/interface/widgets/cards/additional_info/color_identity_widget.h
+++ b/cockatrice/src/interface/widgets/cards/additional_info/color_identity_widget.h
@@ -30,6 +30,8 @@ public slots:
 private:
     QString colorIdentity;
     QHBoxLayout *layout;
+    int lastIconSize = -1; ///< The symbol size last applied, to skip redundant resize passes.
+    int lastWidth = -1;    ///< The width last processed, to skip redundant resize passes.
 };
 
 #endif // COLOR_IDENTITY_WIDGET_H

--- a/cockatrice/src/interface/widgets/cards/additional_info/mana_symbol_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/additional_info/mana_symbol_widget.cpp
@@ -1,57 +1,15 @@
 #include "mana_symbol_widget.h"
 
 #include "../../../../client/settings/cache_settings.h"
+#include "../../../pixel_map_generator.h"
 
-#include <QHash>
-#include <QImageReader>
 #include <QResizeEvent>
 #include <libcockatrice/settings/visual_deck_storage_settings.h>
-
-namespace
-{
-/// Longest side mana symbols are rendered at before being scaled to their final size.
-constexpr int MASTER_ICON_SIZE = 128;
-
-QHash<QString, QPixmap> &scaledIconCache()
-{
-    static QHash<QString, QPixmap> cache;
-    return cache;
-}
-
-/**
- * @brief Renders \a symbol once at a fixed moderate size, so repeated scalings never
- * re-rasterize the source file (SVG sources can be very expensive to rasterize).
- */
-const QPixmap &masterIcon(const QString &symbol)
-{
-    static QHash<QString, QPixmap> cache;
-    auto it = cache.constFind(symbol);
-    if (it != cache.constEnd()) {
-        return it.value();
-    }
-
-    QImageReader reader("theme:icons/mana/" + symbol);
-    QSize sourceSize = reader.size();
-    if (!sourceSize.isEmpty()) {
-        sourceSize.scale(QSize(MASTER_ICON_SIZE, MASTER_ICON_SIZE), Qt::KeepAspectRatio);
-        reader.setScaledSize(sourceSize);
-    }
-    const QPixmap rendered = QPixmap::fromImageReader(&reader);
-
-    return cache.insert(symbol, rendered).value();
-}
-
-QString cacheKey(const QString &symbol, const QSize &size)
-{
-    return symbol + QLatin1Char('|') + QString::number(size.width()) + QLatin1Char('x') +
-           QString::number(size.height());
-}
-} // namespace
 
 ManaSymbolWidget::ManaSymbolWidget(QWidget *parent, QString _symbol, bool _isActive, bool _mayBeToggled)
     : QLabel(parent), symbol(std::move(_symbol)), isActive(_isActive), mayBeToggled(_mayBeToggled)
 {
-    setPixmap(getCachedScaledIcon(symbol, QSize(50, 50)));
+    setPixmap(ManaSymbolPixmapGenerator::generatePixmap(symbol, QSize(50, 50)));
     setMaximumWidth(50);
 
     // Initialize opacity effect
@@ -62,24 +20,6 @@ ManaSymbolWidget::ManaSymbolWidget(QWidget *parent, QString _symbol, bool _isAct
     connect(&SettingsCache::instance().visualDeckStorage(),
             &VisualDeckStorageSettings::visualDeckStorageUnusedColorIdentitiesOpacityChanged, this,
             &ManaSymbolWidget::updateOpacity);
-}
-
-QPixmap ManaSymbolWidget::getCachedScaledIcon(const QString &symbol, const QSize &size)
-{
-    const QString key = cacheKey(symbol, size);
-    auto it = scaledIconCache().constFind(key);
-    if (it != scaledIconCache().constEnd()) {
-        return it.value();
-    }
-
-    const QPixmap &icon = masterIcon(symbol);
-    if (icon.isNull()) {
-        return {};
-    }
-
-    QPixmap scaled = icon.scaled(size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    scaledIconCache().insert(key, scaled);
-    return scaled;
 }
 
 void ManaSymbolWidget::toggleSymbol()
@@ -132,5 +72,5 @@ void ManaSymbolWidget::resizeEvent(QResizeEvent *event)
         return;
     }
 
-    setPixmap(getCachedScaledIcon(symbol, newSize));
+    setPixmap(ManaSymbolPixmapGenerator::generatePixmap(symbol, newSize));
 }

--- a/cockatrice/src/interface/widgets/cards/additional_info/mana_symbol_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/additional_info/mana_symbol_widget.cpp
@@ -2,14 +2,56 @@
 
 #include "../../../../client/settings/cache_settings.h"
 
+#include <QHash>
+#include <QImageReader>
 #include <QResizeEvent>
 #include <libcockatrice/settings/visual_deck_storage_settings.h>
 
-ManaSymbolWidget::ManaSymbolWidget(QWidget *parent, QString _symbol, bool _isActive, bool _mayBeToggled)
-    : QLabel(parent), symbol(_symbol), isActive(_isActive), mayBeToggled(_mayBeToggled)
+namespace
 {
-    loadManaIcon();
-    setPixmap(manaIcon.scaled(50, 50, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+/// Longest side mana symbols are rendered at before being scaled to their final size.
+constexpr int MASTER_ICON_SIZE = 128;
+
+QHash<QString, QPixmap> &scaledIconCache()
+{
+    static QHash<QString, QPixmap> cache;
+    return cache;
+}
+
+/**
+ * @brief Renders \a symbol once at a fixed moderate size, so repeated scalings never
+ * re-rasterize the source file (SVG sources can be very expensive to rasterize).
+ */
+const QPixmap &masterIcon(const QString &symbol)
+{
+    static QHash<QString, QPixmap> cache;
+    auto it = cache.constFind(symbol);
+    if (it != cache.constEnd()) {
+        return it.value();
+    }
+
+    QImageReader reader("theme:icons/mana/" + symbol);
+    QSize sourceSize = reader.size();
+    if (!sourceSize.isEmpty()) {
+        sourceSize.scale(QSize(MASTER_ICON_SIZE, MASTER_ICON_SIZE), Qt::KeepAspectRatio);
+        reader.setScaledSize(sourceSize);
+    }
+    const QPixmap rendered = QPixmap::fromImageReader(&reader);
+
+    return cache.insert(symbol, rendered).value();
+}
+
+QString cacheKey(const QString &symbol, const QSize &size)
+{
+    return symbol + QLatin1Char('|') + QString::number(size.width()) + QLatin1Char('x') +
+           QString::number(size.height());
+}
+} // namespace
+
+ManaSymbolWidget::ManaSymbolWidget(QWidget *parent, QString _symbol, bool _isActive, bool _mayBeToggled)
+    : QLabel(parent), symbol(std::move(_symbol)), isActive(_isActive), mayBeToggled(_mayBeToggled)
+{
+    setPixmap(getCachedScaledIcon(symbol, QSize(50, 50)));
     setMaximumWidth(50);
 
     // Initialize opacity effect
@@ -20,6 +62,24 @@ ManaSymbolWidget::ManaSymbolWidget(QWidget *parent, QString _symbol, bool _isAct
     connect(&SettingsCache::instance().visualDeckStorage(),
             &VisualDeckStorageSettings::visualDeckStorageUnusedColorIdentitiesOpacityChanged, this,
             &ManaSymbolWidget::updateOpacity);
+}
+
+QPixmap ManaSymbolWidget::getCachedScaledIcon(const QString &symbol, const QSize &size)
+{
+    const QString key = cacheKey(symbol, size);
+    auto it = scaledIconCache().constFind(key);
+    if (it != scaledIconCache().constEnd()) {
+        return it.value();
+    }
+
+    const QPixmap &icon = masterIcon(symbol);
+    if (icon.isNull()) {
+        return {};
+    }
+
+    QPixmap scaled = icon.scaled(size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    scaledIconCache().insert(key, scaled);
+    return scaled;
 }
 
 void ManaSymbolWidget::toggleSymbol()
@@ -64,16 +124,13 @@ void ManaSymbolWidget::mousePressEvent(QMouseEvent *event)
 void ManaSymbolWidget::resizeEvent(QResizeEvent *event)
 {
     QLabel::resizeEvent(event);
-    setPixmap(manaIcon.scaled(event->size(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
-}
+    const QSize newSize = event->size();
 
-void ManaSymbolWidget::loadManaIcon()
-{
-    QString filename = "theme:icons/mana/";
-
-    if (symbol == "W" || symbol == "U" || symbol == "B" || symbol == "R" || symbol == "G") {
-        filename += symbol;
+    // Skip the rescale when the size didn't actually change: layout passes resize these
+    // widgets repeatedly with identical sizes.
+    if (newSize.isEmpty() || pixmap().size() == newSize) {
+        return;
     }
 
-    manaIcon = QPixmap(filename);
+    setPixmap(getCachedScaledIcon(symbol, newSize));
 }

--- a/cockatrice/src/interface/widgets/cards/additional_info/mana_symbol_widget.h
+++ b/cockatrice/src/interface/widgets/cards/additional_info/mana_symbol_widget.h
@@ -33,15 +33,6 @@ public:
         return symbol[0];
     }
 
-    /**
-     * @brief Returns a smooth-scaled rendering of the given mana symbol icon.
-     *
-     * Results are shared between all instances via a process-wide cache keyed by symbol
-     * and size, so scaling work is done once per distinct combination instead of once per
-     * widget creation or resize.
-     */
-    static QPixmap getCachedScaledIcon(const QString &symbol, const QSize &size);
-
 public slots:
     void resizeEvent(QResizeEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;

--- a/cockatrice/src/interface/widgets/cards/additional_info/mana_symbol_widget.h
+++ b/cockatrice/src/interface/widgets/cards/additional_info/mana_symbol_widget.h
@@ -33,7 +33,14 @@ public:
         return symbol[0];
     }
 
-    void loadManaIcon();
+    /**
+     * @brief Returns a smooth-scaled rendering of the given mana symbol icon.
+     *
+     * Results are shared between all instances via a process-wide cache keyed by symbol
+     * and size, so scaling work is done once per distinct combination instead of once per
+     * widget creation or resize.
+     */
+    static QPixmap getCachedScaledIcon(const QString &symbol, const QSize &size);
 
 public slots:
     void resizeEvent(QResizeEvent *event) override;
@@ -44,7 +51,6 @@ signals:
 
 private:
     QString symbol;
-    QPixmap manaIcon;
     bool isActive;
     bool mayBeToggled;
     QGraphicsOpacityEffect *opacityEffect;

--- a/cockatrice/src/interface/widgets/utility/card_completer_delegate.cpp
+++ b/cockatrice/src/interface/widgets/utility/card_completer_delegate.cpp
@@ -1,5 +1,6 @@
 #include "card_completer_delegate.h"
 
+#include "../../pixel_map_generator.h"
 #include "../cards/additional_info/mana_cost_widget.h"
 
 #include <QFontMetrics>
@@ -84,7 +85,6 @@ QColor CardCompleterDelegate::accentForColors(const QString &colors)
 
 CardCompleterDelegate::CardCompleterDelegate(QObject *parent) : QStyledItemDelegate(parent)
 {
-    symbolCache.setMaxCost(64);
     setCodeCache.setMaxCost(64);
 }
 
@@ -108,36 +108,16 @@ QSize CardCompleterDelegate::sizeHint(const QStyleOptionViewItem &option, const 
 // Mana symbol painting
 // ---------------------------------------------------------------------------
 
-const QPixmap *CardCompleterDelegate::cachedSymbolPixmap(const QString &symbol, int size) const
-{
-    const QString key = symbol + QString::number(size);
-
-    if (symbolCache.contains(key)) {
-        return symbolCache[key];
-    }
-
-    QPixmap src(QString("theme:icons/mana/%1").arg(symbol));
-
-    if (!src.isNull()) {
-        auto *pm = new QPixmap(src.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation));
-
-        symbolCache.insert(key, pm);
-        return pm;
-    }
-
-    return nullptr;
-}
-
 // ---------------------------------------------------------------------------
 
 void CardCompleterDelegate::drawManaSymbol(QPainter *p, QPoint centre, const QString &symbol, int radius) const
 {
     const QRect pip(centre.x() - radius, centre.y() - radius, radius * 2, radius * 2);
 
-    const QPixmap *px = cachedSymbolPixmap(symbol, radius * 2);
+    const QPixmap px = ManaSymbolPixmapGenerator::generatePixmap(symbol, QSize(radius * 2, radius * 2));
 
-    if (px && !px->isNull()) {
-        p->drawPixmap(pip, *px);
+    if (!px.isNull()) {
+        p->drawPixmap(pip, px);
         return;
     }
 

--- a/cockatrice/src/interface/widgets/utility/card_completer_delegate.h
+++ b/cockatrice/src/interface/widgets/utility/card_completer_delegate.h
@@ -31,9 +31,6 @@ public:
     QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
 private:
-    // Mana symbol pixmaps, loaded once and cached
-    mutable QCache<QString, QPixmap> symbolCache;
-
     // Set short codes, resolved once per card name and cached
     mutable QCache<QString, QString> setCodeCache;
 
@@ -46,9 +43,6 @@ private:
     // Draw all mana pips for a cost string like "2RG" or "{2}{R}{G}"; split and
     // adventure costs ("1W // W") are drawn as separate groups. Returns the left-most x used
     int drawManaCost(QPainter *p, const QRect &row, const QString &manaCost, int radius) const;
-
-    // Load (or return cached) a mana icon pixmap; falls back to painted circle
-    const QPixmap *cachedSymbolPixmap(const QString &symbol, int size) const;
 
     // Resolve the preferred printing's set short code for a card
     QString setCodeForCard(const QSharedPointer<CardInfo> &card) const;

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -390,6 +390,7 @@ int main(int argc, char *argv[])
     PingPixmapGenerator::clear();
     CountryPixmapGenerator::clear();
     UserLevelPixmapGenerator::clear();
+    ManaSymbolPixmapGenerator::clear();
 
     return ret;
 }


### PR DESCRIPTION
## Short roundup of the initial problem
Lag because resize.

## What will change with this Pull Request?
- Render each mana symbol once at a bounded master size and derive every requested size from the cached master, avoiding repeated full-size SVG rasterization on the GUI thread
- Share scaled results through a process-wide cache keyed by symbol and size, so repeated widget creation and rescales don't redo the work
- Skip redundant resize work in ColorIdentityWidget and ManaSymbolWidget when sizes did not change