### PR TITLE
[Icons] Fix cn and ss flags losing stars and clamp svg render sizes

### DIFF
--- a/cockatrice/resources/countries/cn.svg
+++ b/cockatrice/resources/countries/cn.svg
@@ -52,8 +52,7 @@
      id="defs8">
     <polygon
        id="s"
-       points="-301930,415571 0,-513674 301930,415571 -488533,-158734 488533,-158734 "
-       transform="scale(1.94676e-6,1.94676e-6)"
+       points="-0.587785,0.809017 0,-1 0.587785,0.809017 -0.951057,-0.309017 0.951057,-0.309017 "
        style="fill:#ffde00" />
     <clipPath
        clipPathUnits="userSpaceOnUse"

--- a/cockatrice/resources/countries/ss.svg
+++ b/cockatrice/resources/countries/ss.svg
@@ -16,6 +16,6 @@
   <rect id="rect10" height="2.88" width="12.8" y="4.278e-9" x="0"/>
   <rect id="rect12" height="2.88" width="12.8" y="3.36" x="0" fill="#da121a"/>
   <polygon id="polygon14" points="0 0 8.6603 5 0 10" fill="#0f47af" transform="scale(.96)"/>
-  <polygon id="polygon16" points="4.1557e5 -3.0193e5 -5.1367e5 0 4.1557e5 3.0193e5 -1.5873e5 -4.8853e5 -1.5873e5 4.8853e5" fill="#fcdd09" transform="matrix(.0000029902 0 0 .0000029902 2.7713 4.8)"/>
+  <polygon id="polygon16" points="4.01394 3.897169 1.23532 4.8 4.01394 5.702831 2.296666 3.3392 2.296666 6.2608" fill="#fcdd09"/>
  </g>
 </svg>

--- a/cockatrice/src/interface/pixel_map_generator.cpp
+++ b/cockatrice/src/interface/pixel_map_generator.cpp
@@ -15,6 +15,32 @@
 #define DEFAULT_COLOR_ADMIN "#ff2701";
 
 /**
+ * Clamps an svg render size so that rendering does not exceed a multiple of the requested size.
+ *
+ * Rendering at the full native size of an svg just to scale it down afterwards wastes memory,
+ * and canvases with extreme coordinates can exceed Qt's rasterizer coordinate limit which makes
+ * Qt silently drop shapes from the rendered image.
+ *
+ * @param renderSize The size the svg would be rendered at.
+ * @param requestedSize The size that was actually requested.
+ *
+ * @return A size with the aspect ratio of renderSize whose longest side is at most four times
+ * the longest side of requestedSize.
+ */
+static QSize capRenderSize(const QSize &renderSize, const QSize &requestedSize)
+{
+    const int longestRequestedSide = qMax(requestedSize.width(), requestedSize.height());
+    if (longestRequestedSide <= 0) {
+        return renderSize;
+    }
+
+    const int longestRenderSide = qMax(renderSize.width(), renderSize.height());
+    const qreal scale = qMin<qreal>(1.0, static_cast<qreal>(longestRequestedSide * 4) / longestRenderSide);
+    return QSize(qMax(1, static_cast<int>(renderSize.width() * scale)),
+                 qMax(1, static_cast<int>(renderSize.height() * scale)));
+}
+
+/**
  * Loads in an svg from file and scales it without affecting image quality.
  *
  * @param svgPath The path to the svg file, with file extension.
@@ -35,6 +61,9 @@ static QPixmap loadSvg(const QString &svgPath, const QSize &size, bool expandOnl
     // If expandOnly, make sure the pixmap is at least as large as the svg, so that we don't lose any detail.
     // QIcon.pixmap(size) will automatically scale down the image, but it won't scale it up.
     QSize pixmapSize = expandOnly ? svgRenderer.defaultSize().expandedTo(size) : size;
+    if (expandOnly) {
+        pixmapSize = capRenderSize(pixmapSize, size);
+    }
     QPixmap pix(pixmapSize);
     pix.fill(Qt::transparent);
 
@@ -247,7 +276,9 @@ static QIcon loadAndColorSvg(const QString &iconPath,
 
     QSvgRenderer svgRenderer(doc.toByteArray());
 
-    QPixmap pix(svgRenderer.defaultSize().expandedTo(QSize(minSize, minSize)));
+    const QSize pixmapSize =
+        capRenderSize(svgRenderer.defaultSize().expandedTo(QSize(minSize, minSize)), QSize(minSize, minSize));
+    QPixmap pix(pixmapSize);
     pix.fill(Qt::transparent);
 
     QPainter pixPainter(&pix);


### PR DESCRIPTION
## Short roundup of the initial problem
cn.svg and ss.svg defined their star polygons with coordinates around plus/minus 5e5 compensated by tiny scale transforms. Qt drops shapes whose device space bounds exceed its rasterizer coordinate limit, so both flags silently lost their stars when rendered wider than roughly 76px. That threshold was always exceeded because loadSvg with expandOnly renders at the declared 640x480 native size before scaling down to the icon size.

## What will change with this Pull Request?
- Fold the scale transforms into the polygon coordinates so the geometry is unchanged while bounds stay small at every render size.
- Also cap expandOnly and usericon render canvases at four times the requested size to bound memory use and keep pathological theme svgs away from the rasterizer limit.
