### PR TITLE
[DeckList] Add maybeboard zone constant and skip it in exports

### DIFF
--- a/cockatrice/src/client/network/interfaces/deck_stats_interface.cpp
+++ b/cockatrice/src/client/network/interfaces/deck_stats_interface.cpp
@@ -72,7 +72,7 @@ void DeckStatsInterface::copyDeckWithoutTokens(const DeckList &source, DeckList 
 {
     auto copyIfNotAToken = [&destination](const auto node, const auto card) {
         CardInfoPtr dbCard = CardDatabaseManager::query()->getCardInfo(card->getName());
-        if (dbCard && !dbCard->getIsToken()) {
+        if (dbCard && !dbCard->getIsToken() && node->getName() != DECK_ZONE_MAYBEBOARD) {
             DecklistCardNode *addedCard = destination.addCard(card->getName(), node->getName(), -1);
             addedCard->setNumber(card->getNumber());
         }

--- a/cockatrice/src/client/network/interfaces/tapped_out_interface.cpp
+++ b/cockatrice/src/client/network/interfaces/tapped_out_interface.cpp
@@ -99,7 +99,7 @@ void TappedOutInterface::copyDeckSplitMainAndSide(const DeckList &source, DeckLi
 {
     auto copyMainOrSide = [&mainboard, &sideboard](const auto node, const auto card) {
         CardInfoPtr dbCard = CardDatabaseManager::query()->getCardInfo(card->getName());
-        if (!dbCard || dbCard->getIsToken()) {
+        if (!dbCard || dbCard->getIsToken() || node->getName() == DECK_ZONE_MAYBEBOARD) {
             return;
         }
 

--- a/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.cpp
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/deck_list.cpp
@@ -413,6 +413,10 @@ bool DeckList::loadFromFile_Plain(QIODevice *device, const std::function<QString
 bool DeckList::saveToStream_Plain(QTextStream &stream, bool prefixSideboardCards, bool slashTappedOutSplitCards) const
 {
     auto writeToStream = [&stream, prefixSideboardCards, slashTappedOutSplitCards](const auto node, const auto card) {
+        // The maybeboard is scratch space and never exported.
+        if (node->getName() == DECK_ZONE_MAYBEBOARD) {
+            return;
+        }
         if (prefixSideboardCards && node->getName() == DECK_ZONE_SIDE) {
             stream << "SB: ";
         }

--- a/libcockatrice_deck_list/libcockatrice/deck_list/tree/inner_deck_list_node.cpp
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/tree/inner_deck_list_node.cpp
@@ -28,6 +28,8 @@ QString InnerDecklistNode::visibleNameFromName(const QString &_name)
         return QObject::tr("Sideboard");
     } else if (_name == DECK_ZONE_TOKENS) {
         return QObject::tr("Tokens");
+    } else if (_name == DECK_ZONE_MAYBEBOARD) {
+        return QObject::tr("Maybeboard");
     } else {
         return _name;
     }

--- a/libcockatrice_deck_list/libcockatrice/deck_list/tree/inner_deck_list_node.h
+++ b/libcockatrice_deck_list/libcockatrice/deck_list/tree/inner_deck_list_node.h
@@ -24,6 +24,8 @@
 #define DECK_ZONE_SIDE "side"
 /** @brief Constant for the "tokens" zone name. */
 #define DECK_ZONE_TOKENS "tokens"
+/** @brief Constant for the "maybeboard" zone name. */
+#define DECK_ZONE_MAYBEBOARD "maybeboard"
 
 /**
  * @class InnerDecklistNode


### PR DESCRIPTION
## What will change with this Pull Request?
- Introduce DECK_ZONE_MAYBEBOARD and its visible name, and treat the maybeboard as editor-only scratch space: plain-text export, DeckStats and TappedOut uploads now skip cards living there.
- Zones of this name are created by later custom-zones units until then the skips are inert.
