### PR TITLE
[HomeTab] Fix incorrect handling of invalid backgroundSource setting

### DIFF
--- a/cockatrice/src/interface/widgets/general/home_widget.cpp
+++ b/cockatrice/src/interface/widgets/general/home_widget.cpp
@@ -266,8 +266,8 @@ void HomeWidget::updateConnectButton(const ClientStatus status)
 
 QPair<QColor, QColor> HomeWidget::extractDominantColors(const QPixmap &pixmap)
 {
-    if (themeManager->isBuiltInTheme() && SettingsCache::instance().appearance().getHomeTabBackgroundSource() ==
-                                              BackgroundSources::toId(BackgroundSources::Theme)) {
+    QString sourceId = SettingsCache::instance().appearance().getHomeTabBackgroundSource();
+    if (themeManager->isBuiltInTheme() && BackgroundSources::fromId(sourceId) == BackgroundSources::Theme) {
         return QPair<QColor, QColor>(QColor::fromRgb(20, 140, 60), QColor::fromRgb(120, 200, 80));
     }
 

--- a/cockatrice/src/interface/widgets/settings_page/appearance_settings_page.cpp
+++ b/cockatrice/src/interface/widgets/settings_page/appearance_settings_page.cpp
@@ -420,8 +420,8 @@ void AppearanceSettingsPage::editPalette()
 
 void AppearanceSettingsPage::updateHomeTabSettingsVisibility()
 {
-    bool visible = SettingsCache::instance().appearance().getHomeTabBackgroundSource() !=
-                   BackgroundSources::toId(BackgroundSources::Theme);
+    QString sourceId = SettingsCache::instance().appearance().getHomeTabBackgroundSource();
+    bool visible = BackgroundSources::fromId(sourceId) != BackgroundSources::Theme;
 
     homeTabBackgroundShuffleFrequencyLabel.setVisible(visible);
     homeTabBackgroundShuffleFrequencySpinBox.setVisible(visible);


### PR DESCRIPTION
## Related Ticket(s)
- Relates to #7179

## Short roundup of the initial problem

Code was using

```
SettingsCache::instance().appearance().getHomeTabBackgroundSource() != BackgroundSources::toId(BackgroundSources::Theme)
```

to check if the backgroundSource setting is set to the default value. However, if the setting in the `ini` file is set to an unexpected value, `getHomeTabBackgroundSource` will return that value and then directly try to compare it against the id of `theme`, which will return false.

## What will change with this Pull Request?

- Instead use `BackgroundSources::fromId` (which handles invalid values) to map the value in the `ini` file to the enum, and then compare against the enum.