### PR TITLE
[HomeTab] Introduce button color source setting

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -230,6 +230,7 @@ set(cockatrice_SOURCES
     src/interface/widgets/general/display/charts/bars/segmented_bar_widget.cpp
     src/interface/widgets/general/display/charts/pies/color_pie.cpp
     src/interface/widgets/general/home_styled_button.cpp
+    src/interface/widgets/general/home_tab_button_color.h
     src/interface/widgets/general/home_widget.cpp
     src/interface/widgets/general/layout_containers/flow_widget.cpp
     src/interface/widgets/general/layout_containers/overlap_control_widget.cpp

--- a/cockatrice/src/interface/widgets/general/home_tab_button_color.h
+++ b/cockatrice/src/interface/widgets/general/home_tab_button_color.h
@@ -1,0 +1,49 @@
+#ifndef COCKATRICE_HOME_TAB_BUTTON_COLOR_H
+#define COCKATRICE_HOME_TAB_BUTTON_COLOR_H
+
+#include <QList>
+
+namespace HomeTabButtonColor
+{
+
+/**
+ * @brief Where to get the colors for the home tab buttons from
+ */
+enum Source
+{
+    Automatic,      ///< Extract color from background, or use theme color if no background
+    FromBackground, ///< Always extract color from background
+};
+
+struct Entry
+{
+    Source source;
+    const char *trKey; ///< key for translation
+};
+
+inline QList<Entry> all()
+{
+    static QList<Entry> entries = {{Automatic, QT_TR_NOOP("Automatic")},
+                                   {FromBackground, QT_TR_NOOP("Extract from background")}};
+
+    return entries;
+}
+
+/**
+ * Safely converts an int into the corresponding Source.
+ *
+ * @param value The int value
+ * @return The Source. Returns Source::Automatic if the value is not within range
+ */
+inline Source intToSource(int value)
+{
+    if (value > FromBackground) {
+        return Automatic; // default
+    }
+
+    return static_cast<Source>(value);
+}
+
+} // namespace HomeTabButtonColor
+
+#endif // COCKATRICE_HOME_TAB_BUTTON_COLOR_H

--- a/cockatrice/src/interface/widgets/general/home_widget.cpp
+++ b/cockatrice/src/interface/widgets/general/home_widget.cpp
@@ -7,6 +7,7 @@
 #include "../cards/art_crop_attribution.h"
 #include "background_sources.h"
 #include "home_styled_button.h"
+#include "home_tab_button_color.h"
 
 #include <QGroupBox>
 #include <QPainter>
@@ -25,7 +26,7 @@ HomeWidget::HomeWidget(QWidget *parent, TabSupervisor *_tabSupervisor)
 
     backgroundSourceCard = new CardInfoPictureArtCropWidget(this);
 
-    gradientColors = extractDominantColors(background);
+    gradientColors = determineButtonColor();
 
     layout->addWidget(createButtons(), 1, 1, Qt::AlignVCenter | Qt::AlignHCenter);
 
@@ -54,6 +55,8 @@ HomeWidget::HomeWidget(QWidget *parent, TabSupervisor *_tabSupervisor)
     connect(&SettingsCache::instance(), &SettingsCache::themeChanged, this,
             &HomeWidget::initializeBackgroundFromSource);
     connect(&SettingsCache::instance(), &SettingsCache::themeChanged, this,
+            &HomeWidget::updateButtonsToBackgroundColor);
+    connect(&SettingsCache::instance().appearance(), &AppearanceSettings::homeTabButtonColorChanged, this,
             &HomeWidget::updateButtonsToBackgroundColor);
 }
 
@@ -95,6 +98,34 @@ void HomeWidget::loadBackgroundSourceDeck()
     std::optional<LoadedDeck> deckOpt = DeckLoader::loadFromFile(
         SettingsCache::instance().paths().getDeckPath() + "background.cod", DeckFileFormat::Cockatrice, false);
     backgroundSourceDeck = deckOpt.has_value() ? deckOpt.value().deckList : DeckList();
+}
+
+static bool isDefaultBackgroundAndTheme()
+{
+    QString sourceId = SettingsCache::instance().appearance().getHomeTabBackgroundSource();
+    return themeManager->isBuiltInTheme() && BackgroundSources::fromId(sourceId) == BackgroundSources::Theme;
+}
+
+QPair<QColor, QColor> HomeWidget::determineButtonColor() const
+{
+    static QPair defaultColor = {QColor::fromRgb(20, 140, 60), QColor::fromRgb(120, 200, 80)};
+
+    auto colorSource =
+        HomeTabButtonColor::intToSource(SettingsCache::instance().appearance().getHomeTabButtonColorSourceIndex());
+
+    switch (colorSource) {
+        case HomeTabButtonColor::Automatic: {
+            if (isDefaultBackgroundAndTheme()) {
+                return defaultColor;
+            } else {
+                return extractDominantColors(background);
+            }
+        }
+        case HomeTabButtonColor::FromBackground:
+            return extractDominantColors(background);
+    }
+
+    return defaultColor;
 }
 
 void HomeWidget::setRandomCard(ExactCard &newCard)
@@ -171,7 +202,7 @@ void HomeWidget::updateBackgroundProperties()
 
 void HomeWidget::updateButtonsToBackgroundColor()
 {
-    gradientColors = extractDominantColors(background);
+    gradientColors = determineButtonColor();
     for (HomeStyledButton *button : findChildren<HomeStyledButton *>()) {
         button->updateStylesheet(gradientColors);
         button->update();
@@ -266,11 +297,6 @@ void HomeWidget::updateConnectButton(const ClientStatus status)
 
 QPair<QColor, QColor> HomeWidget::extractDominantColors(const QPixmap &pixmap)
 {
-    QString sourceId = SettingsCache::instance().appearance().getHomeTabBackgroundSource();
-    if (themeManager->isBuiltInTheme() && BackgroundSources::fromId(sourceId) == BackgroundSources::Theme) {
-        return QPair<QColor, QColor>(QColor::fromRgb(20, 140, 60), QColor::fromRgb(120, 200, 80));
-    }
-
     // Step 1: Downscale image for performance
     QImage image = pixmap.toImage()
                        .scaled(64, 64, Qt::KeepAspectRatio, Qt::SmoothTransformation)

--- a/cockatrice/src/interface/widgets/general/home_widget.h
+++ b/cockatrice/src/interface/widgets/general/home_widget.h
@@ -23,7 +23,7 @@ class HomeWidget : public QWidget
 public:
     HomeWidget(QWidget *parent, TabSupervisor *tabSupervisor);
     void updateRandomCard();
-    QPair<QColor, QColor> extractDominantColors(const QPixmap &pixmap);
+    static QPair<QColor, QColor> extractDominantColors(const QPixmap &pixmap);
 
 public slots:
     void paintEvent(QPaintEvent *event) override;
@@ -47,6 +47,7 @@ private:
 
     void setRandomCard(ExactCard &newCard);
     void loadBackgroundSourceDeck();
+    QPair<QColor, QColor> determineButtonColor() const;
 };
 
 #endif // HOME_WIDGET_H

--- a/cockatrice/src/interface/widgets/settings_page/appearance_settings_page.cpp
+++ b/cockatrice/src/interface/widgets/settings_page/appearance_settings_page.cpp
@@ -5,6 +5,7 @@
 #include "../../client/settings/card_counter_settings.h"
 #include "../../palette_editor/palette_editor_dialog.h"
 #include "../dialogs/override_printing_warning.h"
+#include "../general/home_tab_button_color.h"
 #include "../interface/theme_manager.h"
 #include "../interface/widgets/general/background_sources.h"
 #include "../playmat/playmat_collection_dialog.h"
@@ -131,6 +132,14 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     connect(&homeTabDisplayCardNameCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings.appearance(),
             &AppearanceSettings::setHomeTabDisplayCardName);
 
+    for (const auto &entry : HomeTabButtonColor::all()) {
+        homeTabButtonColorSourceBox.addItem(QObject::tr(entry.trKey));
+    }
+
+    homeTabButtonColorSourceBox.setCurrentIndex(settings.appearance().getHomeTabButtonColorSourceIndex());
+    connect(&homeTabButtonColorSourceBox, QOverload<int>::of(&QComboBox::currentIndexChanged), &settings.appearance(),
+            &AppearanceSettings::setHomeTabButtonColorSourceIndex);
+
     updateHomeTabSettingsVisibility();
 
     auto *homeTabGrid = new QGridLayout;
@@ -139,6 +148,8 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     homeTabGrid->addWidget(&homeTabBackgroundShuffleFrequencyLabel, 1, 0);
     homeTabGrid->addWidget(&homeTabBackgroundShuffleFrequencySpinBox, 1, 1);
     homeTabGrid->addWidget(&homeTabDisplayCardNameCheckBox, 2, 0, 1, 2);
+    homeTabGrid->addWidget(&homeTabButtonColorSourceLabel, 3, 0);
+    homeTabGrid->addWidget(&homeTabButtonColorSourceBox, 3, 1);
 
     homeTabGroupBox = new QGroupBox;
     homeTabGroupBox->setLayout(homeTabGrid);
@@ -497,6 +508,9 @@ void AppearanceSettingsPage::retranslateUi()
     homeTabBackgroundShuffleFrequencyLabel.setText(tr("Home tab background shuffle frequency:"));
     homeTabBackgroundShuffleFrequencySpinBox.setSpecialValueText(tr("Disabled"));
     homeTabDisplayCardNameCheckBox.setText(tr("Display card name of background in bottom right"));
+    homeTabButtonColorSourceLabel.setText(tr("Home tab button color:"));
+    homeTabButtonColorSourceBox.setToolTip(
+        tr("Automatic: extract from background if present, otherwise use theme default"));
 
     stylingGroupBox->setTitle(tr("Styling settings"));
     styleUserListCheckBox.setText(tr("Style user list"));

--- a/cockatrice/src/interface/widgets/settings_page/appearance_settings_page.h
+++ b/cockatrice/src/interface/widgets/settings_page/appearance_settings_page.h
@@ -35,11 +35,15 @@ private:
     QLabel styleComboLabel;
     QComboBox styleCombo;
     QPushButton editPaletteButton;
+
     QLabel homeTabBackgroundSourceLabel;
     QComboBox homeTabBackgroundSourceBox;
     QLabel homeTabBackgroundShuffleFrequencyLabel;
     QSpinBox homeTabBackgroundShuffleFrequencySpinBox;
     QCheckBox homeTabDisplayCardNameCheckBox;
+    QLabel homeTabButtonColorSourceLabel;
+    QComboBox homeTabButtonColorSourceBox;
+
     QCheckBox styleUserListCheckBox;
     QCheckBox showShortcutsCheckBox;
     QCheckBox showGameSelectorFilterToolbarCheckBox;

--- a/libcockatrice_settings/libcockatrice/settings/appearance_settings.cpp
+++ b/libcockatrice_settings/libcockatrice/settings/appearance_settings.cpp
@@ -69,3 +69,14 @@ void AppearanceSettings::setHomeTabDisplayCardName(bool _displayCardName)
     setValue(_displayCardName, "homeTabDisplayCardName");
     emit homeTabDisplayCardNameChanged();
 }
+
+int AppearanceSettings::getHomeTabButtonColorSourceIndex() const
+{
+    return getValue("homeTabButtonColorSource", "", "", 0).toInt();
+}
+
+void AppearanceSettings::setHomeTabButtonColorSourceIndex(int index)
+{
+    setValue(index, "homeTabButtonColorSource");
+    emit homeTabButtonColorChanged();
+}

--- a/libcockatrice_settings/libcockatrice/settings/appearance_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/appearance_settings.h
@@ -27,6 +27,8 @@ public:
     void setHomeTabBackgroundShuffleFrequency(int _frequency);
     [[nodiscard]] bool getHomeTabDisplayCardName() const;
     void setHomeTabDisplayCardName(bool _displayCardName);
+    [[nodiscard]] int getHomeTabButtonColorSourceIndex() const;
+    void setHomeTabButtonColorSourceIndex(int index);
 
 signals:
     void themeNameChanged();
@@ -34,6 +36,7 @@ signals:
     void homeTabBackgroundSourceChanged();
     void homeTabBackgroundShuffleFrequencyChanged();
     void homeTabDisplayCardNameChanged();
+    void homeTabButtonColorChanged();
 
 public:
     explicit AppearanceSettings(const QString &settingPath, QObject *parent = nullptr);


### PR DESCRIPTION
## Related Ticket(s)
- Relates to #7179
- Follow-up to #7180

## Short roundup of the initial problem

We fixed the bug that allowed me to have cockatrice extract button colors from background while not having a background, so it's time to make it a feature.

## What will change with this Pull Request?

- Create a `homeTabButtonColorSource` setting with two options:
  - `Automatic`: Existing behavior (use theme default if no background, otherwise extract from background)
  - `Extract from background`: always extract from background
- The setting is managed as an enum 
  - Created a header-only file namespaced under `HomeTabButtonColor` for the new enum
  - Used the displayname tech from `BackgroundSource` settings enum.
    - However, we just store the enum index in the `ini` file instead of an id string
- Update `AppearanceSettingsPage` and `HomeWidget` for the new setting. 

https://github.com/user-attachments/assets/4c7e2ad5-0e14-4158-82a7-ebf8a9fc99d7

## Screenshots

<img width="696" height="150" alt="Screenshot 2026-08-23 at 11 19 44 PM" src="https://github.com/user-attachments/assets/527dba48-7b08-484d-8485-45ca04ad9ab9" />

<img width="433" height="99" alt="Screenshot 2026-08-23 at 11 25 10 PM" src="https://github.com/user-attachments/assets/07e23957-84ef-43a5-84ef-b2572c81a7d2" />
