### PR TITLE
[SettingsPage] Refactor: Clean up order of variables

### DIFF
--- a/cockatrice/src/interface/widgets/settings_page/appearance_settings_page.cpp
+++ b/cockatrice/src/interface/widgets/settings_page/appearance_settings_page.cpp
@@ -154,6 +154,48 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     homeTabGroupBox = new QGroupBox;
     homeTabGroupBox->setLayout(homeTabGrid);
 
+    // Playmat settings
+    playmatVisibilityCombo.addItem(tr("Show all playmats"), PlaymatVisibilityAll);
+    playmatVisibilityCombo.addItem(tr("Show own playmat only"), PlaymatVisibilityOwnOnly);
+    playmatVisibilityCombo.addItem(tr("Don't use playmats"), PlaymatVisibilityNone);
+    int visIdx = playmatVisibilityCombo.findData(settings.userInterface().getPlaymatVisibility());
+    if (visIdx >= 0) {
+        playmatVisibilityCombo.setCurrentIndex(visIdx);
+    }
+    connect(&playmatVisibilityCombo, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int index) {
+        SettingsCache::instance().userInterface().setPlaymatVisibility(playmatVisibilityCombo.itemData(index).toInt());
+    });
+    playmatVisibilityLabel.setBuddy(&playmatVisibilityCombo);
+
+    // Playmat mode: Override / Fallback / Deck-only
+    playmatModeCombo.addItem(tr("Override deck playmat"), PlaymatModeOverrideDeck);
+    playmatModeCombo.addItem(tr("Fallback if deck has none"), PlaymatModeFallback);
+    playmatModeCombo.addItem(tr("Deck only, ignore collection"), PlaymatModeDeckOnly);
+    int modeIdx = playmatModeCombo.findData(settings.userInterface().getPlaymatMode());
+    if (modeIdx >= 0) {
+        playmatModeCombo.setCurrentIndex(modeIdx);
+    }
+    connect(&playmatModeCombo, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int index) {
+        SettingsCache::instance().userInterface().setPlaymatMode(playmatModeCombo.itemData(index).toInt());
+    });
+    playmatModeLabel.setBuddy(&playmatModeCombo);
+
+    // User-level playmat settings: fallback collection.
+    connect(&playmatDefaultEditButton, &QPushButton::clicked, this,
+            &AppearanceSettingsPage::openPlaymatCollectionDialog);
+
+    auto *playmatGrid = new QGridLayout;
+    playmatGrid->addWidget(&playmatVisibilityLabel, 0, 0, 1, 1);
+    playmatGrid->addWidget(&playmatVisibilityCombo, 0, 1, 1, 1);
+    playmatGrid->addWidget(&playmatModeLabel, 1, 0, 1, 1);
+    playmatGrid->addWidget(&playmatModeCombo, 1, 1, 1, 1);
+    playmatGrid->addWidget(&playmatDefaultLabel, 2, 0, 1, 1);
+    playmatGrid->addWidget(&playmatDefaultEditButton, 2, 1, 1, 1);
+
+    playmatGroupBox = new QGroupBox;
+    playmatGroupBox->setLayout(playmatGrid);
+
+    // Styling settings
     styleUserListCheckBox.setChecked(settings.appearance().getStyleUserList());
     connect(&styleUserListCheckBox, &QCheckBox::QT_STATE_CHANGED, &settings.appearance(),
             &AppearanceSettings::setStyleUserList);
@@ -259,7 +301,6 @@ AppearanceSettingsPage::AppearanceSettingsPage()
     cardLayoutGroupBox->setLayout(cardLayoutGrid);
 
     // Card counter colors
-
     auto *cardCounterColorsLayout = new QGridLayout;
     cardCounterColorsLayout->setColumnStretch(1, 1);
     cardCounterColorsLayout->setColumnStretch(3, 1);
@@ -338,47 +379,6 @@ AppearanceSettingsPage::AppearanceSettingsPage()
 
     tableGroupBox = new QGroupBox;
     tableGroupBox->setLayout(tableGrid);
-
-    // Playmat settings
-    playmatVisibilityCombo.addItem(tr("Show all playmats"), PlaymatVisibilityAll);
-    playmatVisibilityCombo.addItem(tr("Show own playmat only"), PlaymatVisibilityOwnOnly);
-    playmatVisibilityCombo.addItem(tr("Don't use playmats"), PlaymatVisibilityNone);
-    int visIdx = playmatVisibilityCombo.findData(settings.userInterface().getPlaymatVisibility());
-    if (visIdx >= 0) {
-        playmatVisibilityCombo.setCurrentIndex(visIdx);
-    }
-    connect(&playmatVisibilityCombo, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int index) {
-        SettingsCache::instance().userInterface().setPlaymatVisibility(playmatVisibilityCombo.itemData(index).toInt());
-    });
-    playmatVisibilityLabel.setBuddy(&playmatVisibilityCombo);
-
-    // Playmat mode: Override / Fallback / Deck-only
-    playmatModeCombo.addItem(tr("Override deck playmat"), PlaymatModeOverrideDeck);
-    playmatModeCombo.addItem(tr("Fallback if deck has none"), PlaymatModeFallback);
-    playmatModeCombo.addItem(tr("Deck only, ignore collection"), PlaymatModeDeckOnly);
-    int modeIdx = playmatModeCombo.findData(settings.userInterface().getPlaymatMode());
-    if (modeIdx >= 0) {
-        playmatModeCombo.setCurrentIndex(modeIdx);
-    }
-    connect(&playmatModeCombo, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int index) {
-        SettingsCache::instance().userInterface().setPlaymatMode(playmatModeCombo.itemData(index).toInt());
-    });
-    playmatModeLabel.setBuddy(&playmatModeCombo);
-
-    // User-level playmat settings: fallback collection.
-    connect(&playmatDefaultEditButton, &QPushButton::clicked, this,
-            &AppearanceSettingsPage::openPlaymatCollectionDialog);
-
-    auto *playmatGrid = new QGridLayout;
-    playmatGrid->addWidget(&playmatVisibilityLabel, 0, 0, 1, 1);
-    playmatGrid->addWidget(&playmatVisibilityCombo, 0, 1, 1, 1);
-    playmatGrid->addWidget(&playmatModeLabel, 1, 0, 1, 1);
-    playmatGrid->addWidget(&playmatModeCombo, 1, 1, 1, 1);
-    playmatGrid->addWidget(&playmatDefaultLabel, 2, 0, 1, 1);
-    playmatGrid->addWidget(&playmatDefaultEditButton, 2, 1, 1, 1);
-
-    playmatGroupBox = new QGroupBox;
-    playmatGroupBox->setLayout(playmatGrid);
 
     // putting it all together
     auto *mainLayout = new QVBoxLayout;
@@ -512,6 +512,12 @@ void AppearanceSettingsPage::retranslateUi()
     homeTabButtonColorSourceBox.setToolTip(
         tr("Automatic: extract from background if present, otherwise use theme default"));
 
+    playmatGroupBox->setTitle(tr("Playmat settings"));
+    playmatVisibilityLabel.setText(tr("Playmat visibility:"));
+    playmatModeLabel.setText(tr("Default collection behavior:"));
+    playmatDefaultLabel.setText(tr("Default playmat collection:"));
+    playmatDefaultEditButton.setText(tr("Edit..."));
+
     stylingGroupBox->setTitle(tr("Styling settings"));
     styleUserListCheckBox.setText(tr("Style user list"));
 
@@ -554,9 +560,4 @@ void AppearanceSettingsPage::retranslateUi()
     tableGroupBox->setTitle(tr("Table grid layout"));
     invertVerticalCoordinateCheckBox.setText(tr("Invert vertical coordinate"));
     minPlayersForMultiColumnLayoutLabel.setText(tr("Minimum player count for multi-column layout:"));
-    playmatGroupBox->setTitle(tr("Playmat settings"));
-    playmatVisibilityLabel.setText(tr("Playmat visibility:"));
-    playmatModeLabel.setText(tr("Default collection behavior:"));
-    playmatDefaultLabel.setText(tr("Default playmat collection:"));
-    playmatDefaultEditButton.setText(tr("Edit..."));
 }

--- a/cockatrice/src/interface/widgets/settings_page/appearance_settings_page.h
+++ b/cockatrice/src/interface/widgets/settings_page/appearance_settings_page.h
@@ -84,15 +84,15 @@ private:
 
     QGroupBox *themeGroupBox;
     QGroupBox *homeTabGroupBox;
+    QGroupBox *playmatGroupBox;
     QGroupBox *stylingGroupBox;
     QGroupBox *menuGroupBox;
     QGroupBox *printingsGroupBox;
     QGroupBox *cardsGroupBox;
     QGroupBox *cardLayoutGroupBox;
-    QGroupBox *handGroupBox;
-    QGroupBox *playmatGroupBox;
-    QGroupBox *tableGroupBox;
     QGroupBox *cardCountersGroupBox;
+    QGroupBox *handGroupBox;
+    QGroupBox *tableGroupBox;
 
 public:
     AppearanceSettingsPage();

--- a/cockatrice/src/interface/widgets/settings_page/appearance_settings_page.h
+++ b/cockatrice/src/interface/widgets/settings_page/appearance_settings_page.h
@@ -44,32 +44,44 @@ private:
     QLabel homeTabButtonColorSourceLabel;
     QComboBox homeTabButtonColorSourceBox;
 
-    QCheckBox styleUserListCheckBox;
-    QCheckBox showShortcutsCheckBox;
-    QCheckBox showGameSelectorFilterToolbarCheckBox;
-    QLabel minPlayersForMultiColumnLayoutLabel;
-    QLabel maxFontSizeForCardsLabel;
-    QCheckBox overrideAllCardArtWithPersonalPreferenceCheckBox;
-    QCheckBox bumpSetsWithCardsInDeckToTopCheckBox;
-    QCheckBox displayCardNamesCheckBox;
-    QCheckBox autoRotateSidewaysLayoutCardsCheckBox;
-    QCheckBox cardScalingCheckBox;
-    QCheckBox roundCardCornersCheckBox;
-    QLabel verticalCardOverlapPercentLabel;
-    QSpinBox verticalCardOverlapPercentBox;
-    QLabel cardViewInitialRowsMaxLabel;
-    QSpinBox cardViewInitialRowsMaxBox;
-    QLabel cardViewExpandedRowsMaxLabel;
-    QSpinBox cardViewExpandedRowsMaxBox;
-    QCheckBox horizontalHandCheckBox;
-    QCheckBox leftJustifiedHandCheckBox;
-    QCheckBox invertVerticalCoordinateCheckBox;
     QLabel playmatVisibilityLabel;
     QComboBox playmatVisibilityCombo;
     QLabel playmatModeLabel;
     QComboBox playmatModeCombo;
     QLabel playmatDefaultLabel;
     QPushButton playmatDefaultEditButton;
+
+    QCheckBox styleUserListCheckBox;
+
+    QCheckBox showShortcutsCheckBox;
+    QCheckBox showGameSelectorFilterToolbarCheckBox;
+
+    QCheckBox overrideAllCardArtWithPersonalPreferenceCheckBox;
+    QCheckBox bumpSetsWithCardsInDeckToTopCheckBox;
+
+    QCheckBox displayCardNamesCheckBox;
+    QCheckBox autoRotateSidewaysLayoutCardsCheckBox;
+    QCheckBox cardScalingCheckBox;
+    QCheckBox roundCardCornersCheckBox;
+    QLabel maxFontSizeForCardsLabel;
+    QSpinBox maxFontSizeForCardsEdit;
+
+    QLabel verticalCardOverlapPercentLabel;
+    QSpinBox verticalCardOverlapPercentBox;
+    QLabel cardViewInitialRowsMaxLabel;
+    QSpinBox cardViewInitialRowsMaxBox;
+    QLabel cardViewExpandedRowsMaxLabel;
+    QSpinBox cardViewExpandedRowsMaxBox;
+
+    QList<QLabel *> cardCounterNames;
+
+    QCheckBox horizontalHandCheckBox;
+    QCheckBox leftJustifiedHandCheckBox;
+
+    QCheckBox invertVerticalCoordinateCheckBox;
+    QLabel minPlayersForMultiColumnLayoutLabel;
+    QSpinBox minPlayersForMultiColumnLayoutEdit;
+
     QGroupBox *themeGroupBox;
     QGroupBox *homeTabGroupBox;
     QGroupBox *stylingGroupBox;
@@ -81,9 +93,6 @@ private:
     QGroupBox *playmatGroupBox;
     QGroupBox *tableGroupBox;
     QGroupBox *cardCountersGroupBox;
-    QList<QLabel *> cardCounterNames;
-    QSpinBox minPlayersForMultiColumnLayoutEdit;
-    QSpinBox maxFontSizeForCardsEdit;
 
 public:
     AppearanceSettingsPage();

--- a/cockatrice/src/interface/widgets/settings_page/general_settings_page.cpp
+++ b/cockatrice/src/interface/widgets/settings_page/general_settings_page.cpp
@@ -425,29 +425,28 @@ void GeneralSettingsPage::updateStartupServerControlsVisibility()
 
 void GeneralSettingsPage::retranslateUi()
 {
+    const auto &settings = SettingsCache::instance();
+
     languageGroupBox->setTitle(tr("Language settings"));
     languageLabel.setText(tr("Language:"));
-
-    versionGroupBox->setTitle(tr("Version settings"));
-    cardDatabaseGroupBox->setTitle(tr("Card database"));
-    startupGroupBox->setTitle(tr("Startup settings"));
-
-    if (SettingsCache::instance().getIsPortableBuild()) {
-        pathsGroupBox->setTitle(tr("Paths (editing disabled in portable mode)"));
-    } else {
-        pathsGroupBox->setTitle(tr("Paths"));
-    }
     advertiseTranslationPageLabel.setText(
         QString("<a href='%1'>%2</a>").arg(WIKI_TRANSLATION_FAQ).arg(tr("How to help with translations")));
-    deckPathLabel.setText(tr("Decks directory:"));
-    filtersPathLabel.setText(tr("Filters directory:"));
-    replaysPathLabel.setText(tr("Replays directory:"));
-    picsPathLabel.setText(tr("Pictures directory:"));
-    cardDatabasePathLabel.setText(tr("Card database:"));
-    customCardDatabasePathLabel.setText(tr("Custom database directory:"));
-    tokenDatabasePathLabel.setText(tr("Token database:"));
+
+    versionGroupBox->setTitle(tr("Version settings"));
     updateReleaseChannelLabel.setText(tr("Update channel"));
     startupUpdateCheckCheckBox.setText(tr("Check for client updates on startup"));
+    updateNotificationCheckBox.setText(tr("Notify if a feature supported by the server is missing in my client"));
+    newVersionOracleCheckBox.setText(tr("Automatically run Oracle when running a new version of Cockatrice"));
+
+    // We can't change the strings after they're put into the QComboBox, so this is our workaround
+    int oldIndex = updateReleaseChannelBox.currentIndex();
+    updateReleaseChannelBox.clear();
+    for (ReleaseChannel *chan : settings.getUpdateReleaseChannels()) {
+        updateReleaseChannelBox.addItem(tr(chan->getName().toUtf8()));
+    }
+    updateReleaseChannelBox.setCurrentIndex(oldIndex);
+
+    cardDatabaseGroupBox->setTitle(tr("Card database"));
     startupCardUpdateCheckBehaviorLabel.setText(tr("Check for card database updates on startup"));
     startupCardUpdateCheckBehaviorSelector.setItemText(startupCardUpdateCheckBehaviorIndexNone, tr("Don't check"));
     startupCardUpdateCheckBehaviorSelector.setItemText(startupCardUpdateCheckBehaviorIndexPrompt,
@@ -456,8 +455,13 @@ void GeneralSettingsPage::retranslateUi()
                                                        tr("Always update in the background"));
     cardUpdateCheckIntervalLabel.setText(tr("Check for card database updates every"));
     cardUpdateCheckIntervalSpinBox.setSuffix(tr(" days"));
-    updateNotificationCheckBox.setText(tr("Notify if a feature supported by the server is missing in my client"));
-    newVersionOracleCheckBox.setText(tr("Automatically run Oracle when running a new version of Cockatrice"));
+
+    QDate lastCheckDate = settings.updates().getLastCardUpdateCheck();
+    int daysAgo = lastCheckDate.daysTo(QDate::currentDate());
+    lastCardUpdateCheckDateLabel.setText(
+        tr("Last update check on %1 (%2 days ago)").arg(lastCheckDate.toString()).arg(daysAgo));
+
+    startupGroupBox->setTitle(tr("Startup settings"));
     showTipsOnStartup.setText(tr("Show tips on startup"));
     startupTabLabel.setText(tr("Startup tab:"));
     startupTabSelector.setItemText(StartupTab::StartupTabHome, tr("Home"));
@@ -473,21 +477,18 @@ void GeneralSettingsPage::retranslateUi()
     startupServerLabel.setText(tr("Server:"));
     startupRoomLabel.setText(tr("Room:"));
     startupRoomNameEdit->setPlaceholderText(tr("Room name"));
-    resetAllPathsButton->setText(tr("Reset all paths"));
 
-    const auto &settings = SettingsCache::instance();
-
-    QDate lastCheckDate = settings.updates().getLastCardUpdateCheck();
-    int daysAgo = lastCheckDate.daysTo(QDate::currentDate());
-
-    lastCardUpdateCheckDateLabel.setText(
-        tr("Last update check on %1 (%2 days ago)").arg(lastCheckDate.toString()).arg(daysAgo));
-
-    // We can't change the strings after they're put into the QComboBox, so this is our workaround
-    int oldIndex = updateReleaseChannelBox.currentIndex();
-    updateReleaseChannelBox.clear();
-    for (ReleaseChannel *chan : settings.getUpdateReleaseChannels()) {
-        updateReleaseChannelBox.addItem(tr(chan->getName().toUtf8()));
+    if (SettingsCache::instance().getIsPortableBuild()) {
+        pathsGroupBox->setTitle(tr("Paths (editing disabled in portable mode)"));
+    } else {
+        pathsGroupBox->setTitle(tr("Paths"));
     }
-    updateReleaseChannelBox.setCurrentIndex(oldIndex);
+    deckPathLabel.setText(tr("Decks directory:"));
+    filtersPathLabel.setText(tr("Filters directory:"));
+    replaysPathLabel.setText(tr("Replays directory:"));
+    picsPathLabel.setText(tr("Pictures directory:"));
+    cardDatabasePathLabel.setText(tr("Card database:"));
+    customCardDatabasePathLabel.setText(tr("Custom database directory:"));
+    tokenDatabasePathLabel.setText(tr("Token database:"));
+    resetAllPathsButton->setText(tr("Reset all paths"));
 }

--- a/cockatrice/src/interface/widgets/settings_page/general_settings_page.cpp
+++ b/cockatrice/src/interface/widgets/settings_page/general_settings_page.cpp
@@ -478,7 +478,7 @@ void GeneralSettingsPage::retranslateUi()
     startupRoomLabel.setText(tr("Room:"));
     startupRoomNameEdit->setPlaceholderText(tr("Room name"));
 
-    if (SettingsCache::instance().getIsPortableBuild()) {
+    if (settings.getIsPortableBuild()) {
         pathsGroupBox->setTitle(tr("Paths (editing disabled in portable mode)"));
     } else {
         pathsGroupBox->setTitle(tr("Paths"));

--- a/cockatrice/src/interface/widgets/settings_page/general_settings_page.h
+++ b/cockatrice/src/interface/widgets/settings_page/general_settings_page.h
@@ -42,6 +42,38 @@ private:
     QGroupBox *startupGroupBox;
     QGroupBox *pathsGroupBox;
 
+    QLabel languageLabel;
+    QComboBox languageBox;
+    QLabel advertiseTranslationPageLabel;
+
+    QComboBox updateReleaseChannelBox;
+    QCheckBox startupUpdateCheckCheckBox;
+    QCheckBox updateNotificationCheckBox;
+    QCheckBox newVersionOracleCheckBox;
+
+    QLabel startupCardUpdateCheckBehaviorLabel;
+    QComboBox startupCardUpdateCheckBehaviorSelector;
+    QLabel cardUpdateCheckIntervalLabel;
+    QSpinBox cardUpdateCheckIntervalSpinBox;
+    QLabel lastCardUpdateCheckDateLabel;
+
+    QLabel updateReleaseChannelLabel;
+
+    QCheckBox showTipsOnStartup;
+    QLabel startupTabLabel;
+    QComboBox startupTabSelector;
+    QLabel startupServerLabel;
+    QComboBox startupServerSelector;
+    QLabel startupRoomLabel;
+    QLineEdit *startupRoomNameEdit;
+
+    QLabel deckPathLabel;
+    QLabel filtersPathLabel;
+    QLabel replaysPathLabel;
+    QLabel picsPathLabel;
+    QLabel cardDatabasePathLabel;
+    QLabel customCardDatabasePathLabel;
+    QLabel tokenDatabasePathLabel;
     QLineEdit *deckPathEdit;
     QLineEdit *filtersPathEdit;
     QLineEdit *replaysPathEdit;
@@ -51,33 +83,6 @@ private:
     QLineEdit *tokenDatabasePathEdit;
     QPushButton *resetAllPathsButton;
     QLabel *allPathsResetLabel;
-    QComboBox languageBox;
-    QCheckBox startupUpdateCheckCheckBox;
-    QLabel startupCardUpdateCheckBehaviorLabel;
-    QComboBox startupCardUpdateCheckBehaviorSelector;
-    QLabel cardUpdateCheckIntervalLabel;
-    QSpinBox cardUpdateCheckIntervalSpinBox;
-    QLabel lastCardUpdateCheckDateLabel;
-    QCheckBox updateNotificationCheckBox;
-    QCheckBox newVersionOracleCheckBox;
-    QComboBox updateReleaseChannelBox;
-    QLabel languageLabel;
-    QLabel deckPathLabel;
-    QLabel filtersPathLabel;
-    QLabel replaysPathLabel;
-    QLabel picsPathLabel;
-    QLabel cardDatabasePathLabel;
-    QLabel customCardDatabasePathLabel;
-    QLabel tokenDatabasePathLabel;
-    QLabel updateReleaseChannelLabel;
-    QLabel advertiseTranslationPageLabel;
-    QCheckBox showTipsOnStartup;
-    QLabel startupTabLabel;
-    QComboBox startupTabSelector;
-    QLabel startupServerLabel;
-    QComboBox startupServerSelector;
-    QLabel startupRoomLabel;
-    QLineEdit *startupRoomNameEdit;
 };
 
 #endif // COCKATRICE_GENERAL_SETTINGS_PAGE_H

--- a/cockatrice/src/interface/widgets/settings_page/general_settings_page.h
+++ b/cockatrice/src/interface/widgets/settings_page/general_settings_page.h
@@ -46,6 +46,7 @@ private:
     QComboBox languageBox;
     QLabel advertiseTranslationPageLabel;
 
+    QLabel updateReleaseChannelLabel;
     QComboBox updateReleaseChannelBox;
     QCheckBox startupUpdateCheckCheckBox;
     QCheckBox updateNotificationCheckBox;
@@ -56,8 +57,6 @@ private:
     QLabel cardUpdateCheckIntervalLabel;
     QSpinBox cardUpdateCheckIntervalSpinBox;
     QLabel lastCardUpdateCheckDateLabel;
-
-    QLabel updateReleaseChannelLabel;
 
     QCheckBox showTipsOnStartup;
     QLabel startupTabLabel;

--- a/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.cpp
+++ b/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.cpp
@@ -20,26 +20,7 @@ enum visualDeckStoragePromptForConversionIndex
 
 UserInterfaceSettingsPage::UserInterfaceSettingsPage()
 {
-    // general settings and notification settings
-    notificationsEnabledCheckBox.setChecked(SettingsCache::instance().userInterface().getNotificationsEnabled());
-    connect(&notificationsEnabledCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance().userInterface(),
-            &InterfaceSettings::setNotificationsEnabled);
-    connect(&notificationsEnabledCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
-            &UserInterfaceSettingsPage::setNotificationEnabled);
-
-    specNotificationsEnabledCheckBox.setChecked(
-        SettingsCache::instance().userInterface().getSpectatorNotificationsEnabled());
-    specNotificationsEnabledCheckBox.setEnabled(SettingsCache::instance().userInterface().getNotificationsEnabled());
-    connect(&specNotificationsEnabledCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance().userInterface(),
-            &InterfaceSettings::setSpectatorNotificationsEnabled);
-
-    buddyConnectNotificationsEnabledCheckBox.setChecked(
-        SettingsCache::instance().userInterface().getBuddyConnectNotificationsEnabled());
-    buddyConnectNotificationsEnabledCheckBox.setEnabled(
-        SettingsCache::instance().userInterface().getNotificationsEnabled());
-    connect(&buddyConnectNotificationsEnabledCheckBox, &QCheckBox::QT_STATE_CHANGED,
-            &SettingsCache::instance().userInterface(), &InterfaceSettings::setBuddyConnectNotificationsEnabled);
-
+    // general settings
     doubleClickToPlayCheckBox.setChecked(SettingsCache::instance().userInterface().getDoubleClickToPlay());
     connect(&doubleClickToPlayCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance().userInterface(),
             &InterfaceSettings::setDoubleClickToPlay);
@@ -102,6 +83,26 @@ UserInterfaceSettingsPage::UserInterfaceSettingsPage()
 
     generalGroupBox = new QGroupBox;
     generalGroupBox->setLayout(generalGrid);
+
+    // notification settings
+    notificationsEnabledCheckBox.setChecked(SettingsCache::instance().userInterface().getNotificationsEnabled());
+    connect(&notificationsEnabledCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance().userInterface(),
+            &InterfaceSettings::setNotificationsEnabled);
+    connect(&notificationsEnabledCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+            &UserInterfaceSettingsPage::setNotificationEnabled);
+
+    specNotificationsEnabledCheckBox.setChecked(
+        SettingsCache::instance().userInterface().getSpectatorNotificationsEnabled());
+    specNotificationsEnabledCheckBox.setEnabled(SettingsCache::instance().userInterface().getNotificationsEnabled());
+    connect(&specNotificationsEnabledCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance().userInterface(),
+            &InterfaceSettings::setSpectatorNotificationsEnabled);
+
+    buddyConnectNotificationsEnabledCheckBox.setChecked(
+        SettingsCache::instance().userInterface().getBuddyConnectNotificationsEnabled());
+    buddyConnectNotificationsEnabledCheckBox.setEnabled(
+        SettingsCache::instance().userInterface().getNotificationsEnabled());
+    connect(&buddyConnectNotificationsEnabledCheckBox, &QCheckBox::QT_STATE_CHANGED,
+            &SettingsCache::instance().userInterface(), &InterfaceSettings::setBuddyConnectNotificationsEnabled);
 
     auto *notificationsGrid = new QGridLayout;
     notificationsGrid->addWidget(&notificationsEnabledCheckBox, 0, 0);
@@ -355,6 +356,7 @@ void UserInterfaceSettingsPage::retranslateUi()
     notificationsEnabledCheckBox.setText(tr("Enable notifications in taskbar"));
     specNotificationsEnabledCheckBox.setText(tr("Notify in the taskbar for game events while you are spectating"));
     buddyConnectNotificationsEnabledCheckBox.setText(tr("Notify in the taskbar when users in your buddy list connect"));
+
     animationGroupBox->setTitle(tr("Animation settings"));
     enableAllAnimationsButton.setText(tr("&Enable all animations"));
     disableAllAnimationsButton.setText(tr("&Disable all animations"));
@@ -362,6 +364,7 @@ void UserInterfaceSettingsPage::retranslateUi()
     arrowDrawAnimationCheckBox.setText(tr("&Arrow draw animation"));
     lifeCounterAnimationsCheckBox.setText(tr("Life counter flash"));
     battlefieldFlashCheckBox.setText(tr("Battlefield flash on damage"));
+
     deckEditorGroupBox->setTitle(tr("Deck editor/storage settings"));
     openDeckInNewTabCheckBox.setText(tr("Open deck in new tab by default"));
     visualDeckStorageInGameCheckBox.setText(tr("Use visual deck storage in game lobby"));
@@ -397,8 +400,8 @@ void UserInterfaceSettingsPage::retranslateUi()
         0, CommanderBracketNames::CommanderSpellbookBracketNames);
     commanderSpellbookIntegrationBracketNamingSelector.setItemText(
         1, CommanderBracketNames::OfficialCommanderBracketNames);
-
     commanderSpellbookIntegrationUseOfficialBracketNamesExplainer.setToolTip(CommanderBracketNames::Explainer);
+
     replayGroupBox->setTitle(tr("Replay settings"));
     rewindBufferingMsLabel.setText(tr("Buffer time for backwards skip via shortcut:"));
     rewindBufferingMsBox.setSuffix(" ms");

--- a/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.h
+++ b/cockatrice/src/interface/widgets/settings_page/user_interface_settings_page.h
@@ -23,9 +23,6 @@ private slots:
     void updateCommanderSpellbookUiState();
 
 private:
-    QCheckBox notificationsEnabledCheckBox;
-    QCheckBox specNotificationsEnabledCheckBox;
-    QCheckBox buddyConnectNotificationsEnabledCheckBox;
     QCheckBox doubleClickToPlayCheckBox;
     QCheckBox clickPlaysAllSelectedCheckBox;
     QCheckBox playToStackCheckBox;
@@ -37,12 +34,18 @@ private:
     QCheckBox showTotalSelectionCountCheckBox;
     QCheckBox useTearOffMenusCheckBox;
     QCheckBox keepGameChatFocusCheckBox;
+
+    QCheckBox notificationsEnabledCheckBox;
+    QCheckBox specNotificationsEnabledCheckBox;
+    QCheckBox buddyConnectNotificationsEnabledCheckBox;
+
     QPushButton enableAllAnimationsButton;
     QPushButton disableAllAnimationsButton;
     QCheckBox tapAnimationCheckBox;
     QCheckBox arrowDrawAnimationCheckBox;
     QCheckBox lifeCounterAnimationsCheckBox;
     QCheckBox battlefieldFlashCheckBox;
+
     QCheckBox openDeckInNewTabCheckBox;
     QLabel visualDeckStoragePromptForConversionLabel;
     QComboBox visualDeckStoragePromptForConversionSelector;
@@ -57,8 +60,10 @@ private:
     QLabel commanderSpellbookIntegrationUseOfficialBracketNamesLabel;
     QToolButton commanderSpellbookIntegrationUseOfficialBracketNamesExplainer;
     QComboBox commanderSpellbookIntegrationBracketNamingSelector;
+
     QLabel rewindBufferingMsLabel;
     QSpinBox rewindBufferingMsBox;
+
     QGroupBox *generalGroupBox;
     QGroupBox *notificationsGroupBox;
     QGroupBox *animationGroupBox;


### PR DESCRIPTION
## Short roundup of the initial problem

The order of the variables in the `SettingsPage` classes can be cleaned up.

## What will change with this Pull Request?

- Group variable declarations by their sections, in the same order that they appear in the ui 
  - With an empty line between each section
- In constructor and `retranslateUi`, make the code follow the order that the section show up in the page, and put at least an empty line between each section.

I only touched `general`, `appearance`, and `user interface` settings in this PR, since those are the settings that have the most sections.