### PR TITLE
[Server/Client/Protocol] Add developer staff role

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -380,6 +380,7 @@ set(cockatrice_SOURCES
     src/interface/widgets/tabs/tab_card_art_rules.cpp
     src/interface/widgets/tabs/tab_deck_editor.cpp
     src/interface/widgets/tabs/tab_deck_storage.cpp
+    src/interface/widgets/tabs/tab_developer.cpp
     src/interface/widgets/tabs/tab_game.cpp
     src/interface/widgets/tabs/tab_home.cpp
     src/interface/widgets/tabs/tab_logs.cpp

--- a/cockatrice/src/interface/pixel_map_generator.cpp
+++ b/cockatrice/src/interface/pixel_map_generator.cpp
@@ -14,6 +14,7 @@
 #define DEFAULT_COLOR_MODERATOR_LEFT "#ffffff";
 #define DEFAULT_COLOR_MODERATOR_RIGHT "#000000";
 #define DEFAULT_COLOR_ADMIN "#ff2701";
+#define DEFAULT_COLOR_DEVELOPER "#800020"
 
 /**
  * Clamps an svg render size so that rendering does not exceed a multiple of the requested size.
@@ -359,6 +360,8 @@ QIcon UserLevelPixmapGenerator::generateIconDefault(int height,
 
     if (userLevel.testFlag(ServerInfo_User::IsAdmin)) {
         colorLeft = DEFAULT_COLOR_ADMIN;
+    } else if (userLevel.testFlag(ServerInfo_User::IsDeveloper)) {
+        colorLeft = DEFAULT_COLOR_DEVELOPER;
     } else if (userLevel.testFlag(ServerInfo_User::IsModerator)) {
         colorLeft = DEFAULT_COLOR_MODERATOR_LEFT;
         colorRight = DEFAULT_COLOR_MODERATOR_RIGHT;

--- a/cockatrice/src/interface/widgets/server/user/user_context_menu.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_context_menu.cpp
@@ -51,6 +51,8 @@ UserContextMenu::UserContextMenu(TabSupervisor *_tabSupervisor, QWidget *parent,
     aDemoteFromMod = new QAction(QString(), this);
     aPromoteToJudge = new QAction(QString(), this);
     aDemoteFromJudge = new QAction(QString(), this);
+    aPromoteToDeveloper = new QAction(QString(), this);
+    aDemoteFromDeveloper = new QAction(QString(), this);
     aGetAdminNotes = new QAction(QString(), this);
     aInvestigateUser = new QAction(QString(), this);
 
@@ -76,6 +78,8 @@ void UserContextMenu::retranslateUi()
     aDemoteFromMod->setText(tr("Dem&ote user from moderator"));
     aPromoteToJudge->setText(tr("Promote user to &judge"));
     aDemoteFromJudge->setText(tr("Demote user from judge"));
+    aPromoteToDeveloper->setText(tr("Promote user to &developer"));
+    aDemoteFromDeveloper->setText(tr("Demote user from de&veloper"));
     aGetAdminNotes->setText(tr("View admin notes"));
     aInvestigateUser->setText(tr("Investigate user"));
 }
@@ -268,7 +272,7 @@ void UserContextMenu::adjustMod_processUserResponse(const Response &resp, const 
     const Command_AdjustMod &cmd = commandContainer.admin_command(0).GetExtension(Command_AdjustMod::ext);
 
     if (resp.response_code() == Response::RespOk) {
-        if (cmd.should_be_mod() || cmd.should_be_judge()) {
+        if (cmd.should_be_mod() || cmd.should_be_judge() || cmd.should_be_developer()) {
             QMessageBox::information(static_cast<QWidget *>(parent()), tr("Success"),
                                      tr("Successfully promoted user."));
         } else {
@@ -276,7 +280,7 @@ void UserContextMenu::adjustMod_processUserResponse(const Response &resp, const 
         }
 
     } else {
-        if (cmd.should_be_mod() || cmd.should_be_judge()) {
+        if (cmd.should_be_mod() || cmd.should_be_judge() || cmd.should_be_developer()) {
             QMessageBox::information(static_cast<QWidget *>(parent()), tr("Failed"), tr("Failed to promote user."));
         } else {
             QMessageBox::information(static_cast<QWidget *>(parent()), tr("Failed"), tr("Failed to demote user."));
@@ -437,6 +441,15 @@ void UserContextMenu::showContextMenu(const QPoint &pos,
                    (tabSupervisor->getUserInfo()->user_level() & ServerInfo_User::IsAdmin)) {
             menu->addAction(aPromoteToJudge);
         }
+
+        if (userLevel.testFlag(ServerInfo_User::IsDeveloper) &&
+            (tabSupervisor->getUserInfo()->user_level() & ServerInfo_User::IsAdmin)) {
+            menu->addAction(aDemoteFromDeveloper);
+
+        } else if (userLevel.testFlag(ServerInfo_User::IsRegistered) &&
+                   (tabSupervisor->getUserInfo()->user_level() & ServerInfo_User::IsAdmin)) {
+            menu->addAction(aPromoteToDeveloper);
+        }
     }
     aDetails->setEnabled(true);
     aChat->setEnabled(anotherUser && online);
@@ -455,6 +468,10 @@ void UserContextMenu::showContextMenu(const QPoint &pos,
     aInvestigateUser->setEnabled(anotherUser);
     aPromoteToMod->setEnabled(anotherUser);
     aDemoteFromMod->setEnabled(anotherUser);
+    aPromoteToJudge->setEnabled(anotherUser);
+    aDemoteFromJudge->setEnabled(anotherUser);
+    aPromoteToDeveloper->setEnabled(anotherUser);
+    aDemoteFromDeveloper->setEnabled(anotherUser);
 
     QAction *actionClicked = menu->exec(pos);
     if (actionClicked == nullptr) {
@@ -489,6 +506,8 @@ void UserContextMenu::showContextMenu(const QPoint &pos,
         execAdjustMod(userName, actionClicked == aPromoteToMod);
     } else if (actionClicked == aPromoteToJudge || actionClicked == aDemoteFromJudge) {
         execAdjustJudge(userName, actionClicked == aPromoteToJudge);
+    } else if (actionClicked == aPromoteToDeveloper || actionClicked == aDemoteFromDeveloper) {
+        execAdjustDeveloper(userName, actionClicked == aPromoteToDeveloper);
     } else if (actionClicked == aBanHistory) {
         execBanHistory(userName);
     } else if (actionClicked == aWarnUser) {
@@ -695,6 +714,16 @@ void UserContextMenu::execAdjustJudge(const QString &userName, bool shouldBeJudg
     Command_AdjustMod cmd;
     cmd.set_user_name(userName.toStdString());
     cmd.set_should_be_judge(shouldBeJudge);
+    PendingCommand *pend = client->prepareAdminCommand(cmd);
+    connect(pend, &PendingCommand::finished, this, &UserContextMenu::adjustMod_processUserResponse);
+    client->sendCommand(pend);
+}
+
+void UserContextMenu::execAdjustDeveloper(const QString &userName, bool shouldBeDeveloper)
+{
+    Command_AdjustMod cmd;
+    cmd.set_user_name(userName.toStdString());
+    cmd.set_should_be_developer(shouldBeDeveloper);
     PendingCommand *pend = client->prepareAdminCommand(cmd);
     connect(pend, &PendingCommand::finished, this, &UserContextMenu::adjustMod_processUserResponse);
     client->sendCommand(pend);

--- a/cockatrice/src/interface/widgets/server/user/user_context_menu.h
+++ b/cockatrice/src/interface/widgets/server/user/user_context_menu.h
@@ -45,6 +45,7 @@ private:
     QAction *aBan, *aBanHistory;
     QAction *aPromoteToMod, *aDemoteFromMod;
     QAction *aPromoteToJudge, *aDemoteFromJudge;
+    QAction *aPromoteToDeveloper, *aDemoteFromDeveloper;
     QAction *aWarnUser, *aWarnHistory;
     QAction *aGetAdminNotes;
     std::function<QList<GameInviteOption>()> gameInviteLinkProvider;
@@ -123,6 +124,7 @@ public:
     void execInvestigateUser(const QString &userName);
     void execAdjustMod(const QString &userName, bool shouldBeMod);
     void execAdjustJudge(const QString &userName, bool shouldBeJudge);
+    void execAdjustDeveloper(const QString &userName, bool shouldBeDeveloper);
 
 private:
     void execInvite(const QString &userName, const GameInviteOption &option);

--- a/cockatrice/src/interface/widgets/server/user/user_info_box.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_info_box.cpp
@@ -122,6 +122,8 @@ void UserInfoBox::updateInfo(const ServerInfo_User &user)
     QString userLevelText;
     if (userLevel.testFlag(ServerInfo_User::IsAdmin)) {
         userLevelText = tr("Administrator");
+    } else if (userLevel.testFlag(ServerInfo_User::IsDeveloper)) {
+        userLevelText = tr("Developer");
     } else if (userLevel.testFlag(ServerInfo_User::IsModerator)) {
         userLevelText = tr("Moderator");
     } else if (userLevel.testFlag(ServerInfo_User::IsRegistered)) {

--- a/cockatrice/src/interface/widgets/server/user/user_info_popup.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_info_popup.cpp
@@ -245,6 +245,9 @@ void UserInfoHeaderWidget::paintEvent(QPaintEvent *)
         if (level.testFlag(ServerInfo_User::IsAdmin)) {
             return QColor(245, 158, 11);
         }
+        if (level.testFlag(ServerInfo_User::IsDeveloper)) {
+            return QColor(185, 28, 28);
+        }
         if (level.testFlag(ServerInfo_User::IsModerator)) {
             return QColor(59, 130, 246);
         }
@@ -300,6 +303,8 @@ void UserInfoHeaderWidget::paintEvent(QPaintEvent *)
     } badge;
     if (level.testFlag(ServerInfo_User::IsAdmin)) {
         badge = {"ADMIN", QColor(245, 158, 11)};
+    } else if (level.testFlag(ServerInfo_User::IsDeveloper)) {
+        badge = {"DEV", QColor(185, 28, 28)};
     } else if (level.testFlag(ServerInfo_User::IsModerator)) {
         badge = {"MOD", QColor(59, 130, 246)};
     } else if (level.testFlag(ServerInfo_User::IsJudge)) {

--- a/cockatrice/src/interface/widgets/server/user/user_list_painter.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_list_painter.cpp
@@ -49,6 +49,8 @@ QColor UserListPainter::getAccentColor(const UserLevelFlags &userLevel, bool onl
 
     if (userLevel.testFlag(ServerInfo_User::IsAdmin)) {
         accentColor = QColor(245, 158, 11);
+    } else if (userLevel.testFlag(ServerInfo_User::IsDeveloper)) {
+        accentColor = QColor(185, 28, 28);
     } else if (userLevel.testFlag(ServerInfo_User::IsModerator)) {
         accentColor = QColor(59, 130, 246);
     } else if (userLevel.testFlag(ServerInfo_User::IsJudge)) {
@@ -299,6 +301,8 @@ QList<UserListPainter::Badge> UserListPainter::buildBadges(const UserLevelFlags 
 
     if (userLevel.testFlag(ServerInfo_User::IsAdmin)) {
         badges << Badge{"ADMIN", QColor(245, 158, 11)};
+    } else if (userLevel.testFlag(ServerInfo_User::IsDeveloper)) {
+        badges << Badge{"DEV", QColor(185, 28, 28)};
     } else if (userLevel.testFlag(ServerInfo_User::IsModerator)) {
         badges << Badge{"MOD", QColor(59, 130, 246)};
     } else if (userLevel.testFlag(ServerInfo_User::IsJudge)) {
@@ -385,9 +389,9 @@ void UserListPainter::paint(QPainter *painter,
     const QString userName = QString::fromStdString(userInfo.name());
     const QString privLevel = QString::fromStdString(userInfo.privlevel());
     const QColor accentColor = getAccentColor(userLevel, online);
-    const bool hasRole = userLevel.testFlag(ServerInfo_User::IsAdmin) ||
-                         userLevel.testFlag(ServerInfo_User::IsModerator) ||
-                         userLevel.testFlag(ServerInfo_User::IsJudge);
+    const bool hasRole =
+        userLevel.testFlag(ServerInfo_User::IsAdmin) || userLevel.testFlag(ServerInfo_User::IsDeveloper) ||
+        userLevel.testFlag(ServerInfo_User::IsModerator) || userLevel.testFlag(ServerInfo_User::IsJudge);
     const QRectF cardRect = QRectF(rect).adjusted(3, 2, -3, -2);
     const int cardRight = getCardRight(option, rect);
 

--- a/cockatrice/src/interface/widgets/server/user/user_list_widget.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_list_widget.cpp
@@ -234,9 +234,11 @@ bool UserListTWI::operator<(const QTreeWidgetItem &other) const
     const auto &lhsUserLevelFlags = UserLevelFlags(data(0, Qt::UserRole).toInt());
     const auto &rhsUserLevelFlags = UserLevelFlags(other.data(0, Qt::UserRole).toInt());
 
-    // Admins & Mods need no additional comparison checks, just to see if they're an admin or a moderator
+    // Admins, Developers & Mods need no additional comparison checks, just to see if they're an admin, a developer
+    // or a moderator
     static const QList<ServerInfo_User_UserLevelFlag> userLevelWithNoOtherPrefOrder = {
-        ServerInfo_User_UserLevelFlag_IsAdmin, ServerInfo_User_UserLevelFlag_IsModerator};
+        ServerInfo_User_UserLevelFlag_IsAdmin, ServerInfo_User_UserLevelFlag_IsDeveloper,
+        ServerInfo_User_UserLevelFlag_IsModerator};
     for (const auto &userLevelEntry : userLevelWithNoOtherPrefOrder) {
         if (lhsUserLevelFlags.testFlag(userLevelEntry) &&
             lhsUserLevelFlags.testFlag(userLevelEntry) == rhsUserLevelFlags.testFlag(userLevelEntry)) {

--- a/cockatrice/src/interface/widgets/tabs/tab_developer.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_developer.cpp
@@ -1,0 +1,122 @@
+/**
+ * @file tab_developer.cpp
+ * @ingroup ServerTabs
+ */
+//! \todo Document this file.
+
+#include "tab_developer.h"
+
+#include <QDateTime>
+#include <QHeaderView>
+#include <QLabel>
+#include <QPushButton>
+#include <QTableWidget>
+#include <QVBoxLayout>
+#include <libcockatrice/network/client/abstract/abstract_client.h>
+#include <libcockatrice/protocol/pb/command_get_server_stats.pb.h>
+#include <libcockatrice/protocol/pb/response_get_server_stats.pb.h>
+#include <libcockatrice/protocol/pending_command.h>
+
+TabDeveloper::TabDeveloper(TabSupervisor *_tabSupervisor, AbstractClient *_client)
+    : Tab(_tabSupervisor), client(_client)
+{
+    statsTable = new QTableWidget(0, 2);
+    statsTable->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    statsTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    statsTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    statsTable->setSelectionMode(QAbstractItemView::SingleSelection);
+    statsTable->horizontalHeader()->setStretchLastSection(true);
+    statsTable->verticalHeader()->setVisible(false);
+
+    statusLabel = new QLabel;
+
+    refreshButton = new QPushButton;
+    refreshButton->setAutoDefault(true);
+    connect(refreshButton, &QPushButton::clicked, this, &TabDeveloper::refreshClicked);
+
+    auto *buttonLayout = new QHBoxLayout;
+    buttonLayout->addWidget(statusLabel, 1, Qt::AlignLeft);
+    buttonLayout->addWidget(refreshButton, 0, Qt::AlignRight);
+
+    auto *mainLayout = new QVBoxLayout;
+    mainLayout->addWidget(statsTable);
+    mainLayout->addLayout(buttonLayout);
+
+    auto *central = new QWidget;
+    central->setLayout(mainLayout);
+    setCentralWidget(central);
+
+    retranslateUi();
+}
+
+void TabDeveloper::retranslateUi()
+{
+    refreshButton->setText(tr("Refresh server stats"));
+    statsTable->setHorizontalHeaderLabels(QString(tr("Statistic;Value")).split(";"));
+    if (statsTable->rowCount() == 0) {
+        statusLabel->clear();
+    }
+}
+
+QString TabDeveloper::formatBytes(quint64 bytes)
+{
+    const quint64 kib = 1024;
+    const quint64 mib = 1024 * kib;
+    const quint64 gib = 1024 * mib;
+    if (bytes >= gib) {
+        return tr("%1 GiB").arg(QString::number(bytes / static_cast<double>(gib), 'f', 2));
+    }
+    if (bytes >= mib) {
+        return tr("%1 MiB").arg(QString::number(bytes / static_cast<double>(mib), 'f', 2));
+    }
+    if (bytes >= kib) {
+        return tr("%1 KiB").arg(QString::number(bytes / static_cast<double>(kib), 'f', 2));
+    }
+    return tr("%1 bytes").arg(bytes);
+}
+
+void TabDeveloper::appendStatRow(const QString &name, const QString &value)
+{
+    const int row = statsTable->rowCount();
+    statsTable->insertRow(row);
+    statsTable->setItem(row, 0, new QTableWidgetItem(name));
+    statsTable->setItem(row, 1, new QTableWidgetItem(value));
+}
+
+void TabDeveloper::refreshClicked()
+{
+    Command_GetServerStats cmd;
+    PendingCommand *pend = client->prepareDeveloperCommand(cmd);
+    connect(pend, &PendingCommand::finished, this, &TabDeveloper::serverStatsResponse);
+    client->sendCommand(pend);
+}
+
+void TabDeveloper::serverStatsResponse(const Response &resp)
+{
+    if (resp.response_code() != Response::RespOk) {
+        statusLabel->setText(tr("Failed to collect server statistics."));
+        return;
+    }
+
+    const Response_GetServerStats &response = resp.GetExtension(Response_GetServerStats::ext);
+
+    statsTable->setRowCount(0);
+    appendStatRow(tr("Registered users online"), QString::number(response.users_count()));
+    appendStatRow(tr("Moderators online"), QString::number(response.mods_count()));
+    appendStatRow(tr("Games running"), QString::number(response.games_count()));
+    appendStatRow(tr("Traffic sent (last tick)"), formatBytes(response.tx_bytes()));
+    appendStatRow(tr("Traffic received (last tick)"), formatBytes(response.rx_bytes()));
+
+    const qint64 uptime = static_cast<qint64>(response.uptime_secs());
+    const int days = static_cast<int>(uptime / 86400);
+    const int hours = static_cast<int>((uptime % 86400) / 3600);
+    const int minutes = static_cast<int>((uptime % 3600) / 60);
+    appendStatRow(tr("Server uptime"), days > 0 ? tr("%1d %2h %3m").arg(days).arg(hours).arg(minutes)
+                                                : tr("%1h %2m").arg(hours).arg(minutes));
+
+    const QDateTime snapshotTime = QDateTime::fromSecsSinceEpoch(static_cast<qint64>(response.timest()));
+    appendStatRow(tr("Snapshot taken"), snapshotTime.toLocalTime().toString("yyyy-MM-dd HH:mm"));
+
+    statsTable->resizeColumnsToContents();
+    statusLabel->setText(tr("Updated %1").arg(QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm")));
+}

--- a/cockatrice/src/interface/widgets/tabs/tab_developer.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_developer.h
@@ -1,0 +1,43 @@
+/**
+ * @file tab_developer.h
+ * @ingroup ServerTabs
+ */
+//! \todo Document this file.
+
+#ifndef TAB_DEVELOPER_H
+#define TAB_DEVELOPER_H
+
+#include "tab.h"
+
+class AbstractClient;
+class QLabel;
+class QPushButton;
+class QTableWidget;
+class Response;
+
+class TabDeveloper : public Tab
+{
+    Q_OBJECT
+private:
+    AbstractClient *client;
+    QTableWidget *statsTable;
+    QPushButton *refreshButton;
+    QLabel *statusLabel;
+
+    void appendStatRow(const QString &name, const QString &value);
+    static QString formatBytes(quint64 bytes);
+
+private slots:
+    void refreshClicked();
+    void serverStatsResponse(const Response &resp);
+
+public:
+    explicit TabDeveloper(TabSupervisor *_tabSupervisor, AbstractClient *_client);
+    void retranslateUi() override;
+    [[nodiscard]] QString getTabText() const override
+    {
+        return tr("Developer");
+    }
+};
+
+#endif

--- a/cockatrice/src/interface/widgets/tabs/tab_logs.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_logs.cpp
@@ -14,12 +14,14 @@
 #include <QTabWidget>
 #include <QTableWidget>
 #include <libcockatrice/network/client/abstract/abstract_client.h>
+#include <libcockatrice/protocol/pb/command_get_log_history.pb.h>
 #include <libcockatrice/protocol/pb/moderator_commands.pb.h>
 #include <libcockatrice/protocol/pb/response_viewlog_history.pb.h>
 #include <libcockatrice/protocol/pending_command.h>
 #include <libcockatrice/utility/string_limits.h>
 
-TabLog::TabLog(TabSupervisor *_tabSupervisor, AbstractClient *_client) : Tab(_tabSupervisor), client(_client)
+TabLog::TabLog(TabSupervisor *_tabSupervisor, AbstractClient *_client, bool _canUseDeveloperCommands)
+    : Tab(_tabSupervisor), client(_client), canUseDeveloperCommands(_canUseDeveloperCommands)
 {
     roomTable = new QTableWidget();
     roomTable->setColumnCount(6);
@@ -117,7 +119,26 @@ void TabLog::getClicked()
     };
     cmd.set_date_range(dateRange);
     cmd.set_maximum_results(maximumResults->value());
-    PendingCommand *pend = client->prepareModeratorCommand(cmd);
+
+    PendingCommand *pend;
+    if (canUseDeveloperCommands) {
+        // Developers query logs through the developer command family.
+        Command_GetLogHistory devCmd;
+        devCmd.set_user_name(cmd.user_name());
+        devCmd.set_ip_address(cmd.ip_address());
+        devCmd.set_game_name(cmd.game_name());
+        devCmd.set_game_id(cmd.game_id());
+        devCmd.set_message(cmd.message());
+        for (int i = 0; i < cmd.log_location_size(); ++i) {
+            devCmd.add_log_location(cmd.log_location(i));
+        }
+        devCmd.set_date_range(cmd.date_range());
+        devCmd.set_maximum_results(cmd.maximum_results());
+        pend = client->prepareDeveloperCommand(devCmd);
+    } else {
+        pend = client->prepareModeratorCommand(cmd);
+    }
+
     connect(pend, &PendingCommand::finished, this, &TabLog::viewLogHistory_processResponse);
     client->sendCommand(pend);
 }

--- a/cockatrice/src/interface/widgets/tabs/tab_logs.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_logs.h
@@ -33,6 +33,7 @@ class TabLog : public Tab
     Q_OBJECT
 private:
     AbstractClient *client;
+    bool canUseDeveloperCommands;
     QLabel *labelFindUserName, *labelFindIPAddress, *labelFindGameName, *labelFindGameID, *labelMessage, *labelMaximum,
         *labelDescription;
     LineEditUnfocusable *findUsername, *findIPAddress, *findGameName, *findGameID, *findMessage;
@@ -58,7 +59,7 @@ private slots:
     void restartLayout();
 
 public:
-    TabLog(TabSupervisor *_tabSupervisor, AbstractClient *_client);
+    TabLog(TabSupervisor *_tabSupervisor, AbstractClient *_client, bool _canUseDeveloperCommands = false);
     ~TabLog() override;
     void retranslateUi() override;
     [[nodiscard]] QString getTabText() const override

--- a/cockatrice/src/interface/widgets/tabs/tab_moderation.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_moderation.cpp
@@ -381,6 +381,9 @@ void TabModeration::moderatorLoginsResponse(const Response &response)
         if (login.user_level() & ServerInfo_User::IsAdmin) {
             levels << tr("Admin");
         }
+        if (login.user_level() & ServerInfo_User::IsDeveloper) {
+            levels << tr("Developer");
+        }
         if (login.user_level() & ServerInfo_User::IsModerator) {
             levels << tr("Moderator");
         }

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
@@ -15,6 +15,7 @@
 #include "tab_card_art_rules.h"
 #include "tab_deck_editor.h"
 #include "tab_deck_storage.h"
+#include "tab_developer.h"
 #include "tab_game.h"
 #include "tab_home.h"
 #include "tab_logs.h"
@@ -118,7 +119,7 @@ void CloseButton::paintEvent(QPaintEvent * /*event*/)
 TabSupervisor::TabSupervisor(AbstractClient *_client, QMenu *tabsMenu, QWidget *parent)
     : QTabWidget(parent), userInfo(nullptr), client(_client), tabsMenu(tabsMenu), tabVisualDeckStorage(nullptr),
       tabServer(nullptr), tabAccount(nullptr), tabDeckStorage(nullptr), tabReplays(nullptr), tabAdmin(nullptr),
-      tabLog(nullptr), tabReport(nullptr), tabModeration(nullptr), isLocalGame(false)
+      tabLog(nullptr), tabReport(nullptr), tabModeration(nullptr), tabDeveloper(nullptr), isLocalGame(false)
 {
     setElideMode(Qt::ElideRight);
     setMovable(true);
@@ -204,6 +205,10 @@ TabSupervisor::TabSupervisor(AbstractClient *_client, QMenu *tabsMenu, QWidget *
     aTabModeration->setCheckable(true);
     connect(aTabModeration, &QAction::triggered, this, &TabSupervisor::actTabModeration);
 
+    aTabDeveloper = new QAction(this);
+    aTabDeveloper->setCheckable(true);
+    connect(aTabDeveloper, &QAction::triggered, this, &TabSupervisor::actTabDeveloper);
+
     connect(&SettingsCache::instance().shortcuts(), &ShortcutsSettings::shortCutChanged, this,
             &TabSupervisor::refreshShortcuts);
     refreshShortcuts();
@@ -245,6 +250,7 @@ void TabSupervisor::retranslateUi()
     aTabLog->setText(tr("Logs"));
     aTabReport->setText(tr("Report Queue"));
     aTabModeration->setText(tr("Moderation"));
+    aTabDeveloper->setText(tr("Developer"));
 
     // tabs
     QList<Tab *> tabs;
@@ -256,6 +262,7 @@ void TabSupervisor::retranslateUi()
     tabs.append(tabLog);
     tabs.append(tabReport);
     tabs.append(tabModeration);
+    tabs.append(tabDeveloper);
     QMapIterator<int, TabRoom *> roomIterator(roomTabs);
     while (roomIterator.hasNext()) {
         tabs.append(roomIterator.next().value());
@@ -523,6 +530,19 @@ void TabSupervisor::start(const ServerInfo_User &_userInfo)
         openTabCardArtRules();
     }
 
+    if (userInfo->user_level() & ServerInfo_User::IsDeveloper) {
+        tabsMenu->addSeparator();
+        tabsMenu->addAction(aTabDeveloper);
+        // Developers without moderation rights get log access through their
+        // own role. Moderators already have the Logs entry from above.
+        if (!(userInfo->user_level() & ServerInfo_User::IsModerator)) {
+            tabsMenu->addAction(aTabLog);
+            if (SettingsCache::instance().tabs().getTabLogOpen()) {
+                openTabLog();
+            }
+        }
+    }
+
     retranslateUi();
 }
 
@@ -535,6 +555,7 @@ void TabSupervisor::startLocal(const QList<AbstractClient *> &_clients)
     tabLog = nullptr;
     tabReport = nullptr;
     tabModeration = nullptr;
+    tabDeveloper = nullptr;
     isLocalGame = true;
     userInfo = new ServerInfo_User;
     localClients = _clients;
@@ -581,6 +602,9 @@ void TabSupervisor::stop()
         }
         if (tabModeration) {
             tabModeration->close();
+        }
+        if (tabDeveloper) {
+            tabDeveloper->close();
         }
     }
 
@@ -810,7 +834,10 @@ void TabSupervisor::actTabLog(bool checked)
 
 void TabSupervisor::openTabLog()
 {
-    tabLog = new TabLog(this, client);
+    // Developers without moderation rights query logs through the developer
+    // command family, so tell the tab which family to use.
+    const bool isDeveloper = (userInfo->user_level() & ServerInfo_User::IsDeveloper) != 0;
+    tabLog = new TabLog(this, client, isDeveloper);
     myAddTab(tabLog, aTabLog);
     connect(tabLog, &QObject::destroyed, this, [this] {
         tabLog = nullptr;
@@ -870,6 +897,27 @@ void TabSupervisor::openTabModeration(const QString &userName)
         aTabModeration->setChecked(false);
     });
     aTabModeration->setChecked(true);
+}
+
+void TabSupervisor::actTabDeveloper(bool checked)
+{
+    if (checked && !tabDeveloper) {
+        openTabDeveloper();
+        setCurrentWidget(tabDeveloper);
+    } else if (!checked && tabDeveloper) {
+        tabDeveloper->closeRequest();
+    }
+}
+
+void TabSupervisor::openTabDeveloper()
+{
+    tabDeveloper = new TabDeveloper(this, client);
+    myAddTab(tabDeveloper, aTabDeveloper);
+    connect(tabDeveloper, &QObject::destroyed, this, [this] {
+        tabDeveloper = nullptr;
+        aTabDeveloper->setChecked(false);
+    });
+    aTabDeveloper->setChecked(true);
 }
 
 void TabSupervisor::updatePingTime(int value, int max)

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.h
@@ -45,6 +45,7 @@ class TabReport;
 class TabModeration;
 class TabAccount;
 class TabDeckEditor;
+class TabDeveloper;
 class TabLog;
 class RoomEvent;
 class GameEventContainer;
@@ -108,6 +109,7 @@ private:
     TabLog *tabLog;
     TabReport *tabReport;
     TabModeration *tabModeration;
+    TabDeveloper *tabDeveloper;
     QMap<int, TabRoom *> roomTabs;
     QMap<int, TabGame *> gameTabs;
     QList<TabGame *> replayTabs;
@@ -117,7 +119,7 @@ private:
 
     QAction *aTabHome, *aTabDeckEditor, *aTabVisualDeckEditor, *aTabEdhRec, *aTabArchidekt, *aTabVisualDeckStorage,
         *aTabVisualDatabaseDisplay, *aTabServer, *aTabAccount, *aTabDeckStorage, *aTabReplays, *aTabAdmin,
-        *aTabCardArtRules, *aTabLog, *aTabReport, *aTabModeration;
+        *aTabCardArtRules, *aTabLog, *aTabReport, *aTabModeration, *aTabDeveloper;
 
     int myAddTab(Tab *tab, QAction *manager = nullptr);
     void addCloseButtonToTab(Tab *tab, int tabIndex, QAction *manager);
@@ -207,6 +209,7 @@ private slots:
     void actTabLog(bool checked);
     void actTabReport(bool checked);
     void actTabModeration(bool checked);
+    void actTabDeveloper(bool checked);
 
     void openTabVisualDeckStorage();
     void openTabHome();
@@ -218,6 +221,7 @@ private slots:
     void openTabCardArtRules();
     void openTabLog();
     void openTabReport();
+    void openTabDeveloper();
 
     void updateCurrent(int index);
     void updatePingTime(int value, int max);

--- a/libcockatrice_network/libcockatrice/network/client/abstract/abstract_client.cpp
+++ b/libcockatrice_network/libcockatrice/network/client/abstract/abstract_client.cpp
@@ -253,3 +253,11 @@ PendingCommand *AbstractClient::prepareAdminCommand(const ::google::protobuf::Me
     c->GetReflection()->MutableMessage(c, cmd.GetDescriptor()->FindExtensionByName("ext"))->CopyFrom(cmd);
     return new PendingCommand(cont);
 }
+
+PendingCommand *AbstractClient::prepareDeveloperCommand(const ::google::protobuf::Message &cmd)
+{
+    CommandContainer cont;
+    DeveloperCommand *c = cont.add_developer_command();
+    c->GetReflection()->MutableMessage(c, cmd.GetDescriptor()->FindExtensionByName("ext"))->CopyFrom(cmd);
+    return new PendingCommand(cont);
+}

--- a/libcockatrice_network/libcockatrice/network/client/abstract/abstract_client.h
+++ b/libcockatrice_network/libcockatrice/network/client/abstract/abstract_client.h
@@ -173,6 +173,7 @@ public:
     static PendingCommand *prepareRoomCommand(const ::google::protobuf::Message &cmd, int roomId);
     static PendingCommand *prepareModeratorCommand(const ::google::protobuf::Message &cmd);
     static PendingCommand *prepareAdminCommand(const ::google::protobuf::Message &cmd);
+    static PendingCommand *prepareDeveloperCommand(const ::google::protobuf::Message &cmd);
 
     QMap<QString, bool> clientFeatures;
 };

--- a/libcockatrice_network/libcockatrice/network/server/remote/server_protocolhandler.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/server_protocolhandler.cpp
@@ -388,6 +388,33 @@ Response::ResponseCode Server_ProtocolHandler::processAdminCommandContainer(cons
     return finalResponseCode;
 }
 
+Response::ResponseCode Server_ProtocolHandler::processDeveloperCommandContainer(const CommandContainer &cont,
+                                                                                ResponseContainer &rc)
+{
+    if (!userInfo) {
+        return Response::RespLoginNeeded;
+    }
+    if (!(userInfo->user_level() & ServerInfo_User::IsDeveloper)) {
+        return Response::RespLoginNeeded;
+    }
+
+    resetIdleTimer();
+
+    Response::ResponseCode finalResponseCode = Response::RespOk;
+    for (int i = cont.developer_command_size() - 1; i >= 0; --i) {
+        Response::ResponseCode resp = Response::RespInvalidCommand;
+        const DeveloperCommand &sc = cont.developer_command(i);
+        const int num = getPbExtension(sc);
+        logDebugMessage(getSafeDebugString(sc));
+
+        resp = processExtendedDeveloperCommand(num, sc, rc);
+        if (resp != Response::RespOk) {
+            finalResponseCode = resp;
+        }
+    }
+    return finalResponseCode;
+}
+
 void Server_ProtocolHandler::processCommandContainer(const CommandContainer &cont)
 {
     // Command processing must be disabled after prepareDestroy() has been called.
@@ -410,6 +437,8 @@ void Server_ProtocolHandler::processCommandContainer(const CommandContainer &con
         finalResponseCode = processModeratorCommandContainer(cont, responseContainer);
     } else if (cont.admin_command_size()) {
         finalResponseCode = processAdminCommandContainer(cont, responseContainer);
+    } else if (cont.developer_command_size()) {
+        finalResponseCode = processDeveloperCommandContainer(cont, responseContainer);
     } else {
         finalResponseCode = Response::RespInvalidCommand;
     }
@@ -454,11 +483,12 @@ void Server_ProtocolHandler::pingClockTimeout()
         prepareDestroy();
     }
 
-    // PrivLevel users, Moderators, and Admins are not subject to the server idle timeout policy
+    // PrivLevel users, Moderators, Admins, and Developers are not subject to the server idle timeout policy
     const bool hasPrivLevel = userInfo && QString::fromStdString(userInfo->privlevel()).toLower() != "none";
-    const bool isModOrAdmin =
-        userInfo && (userInfo->user_level() & (ServerInfo_User::IsModerator | ServerInfo_User::IsAdmin));
-    if (!hasPrivLevel && !isModOrAdmin) {
+    const bool isStaff =
+        userInfo && (userInfo->user_level() &
+                     (ServerInfo_User::IsModerator | ServerInfo_User::IsAdmin | ServerInfo_User::IsDeveloper));
+    if (!hasPrivLevel && !isStaff) {
         if ((server->getIdleClientTimeout() > 0) && (idleClientWarningSent)) {
             if (timeRunning - lastActionReceived > server->getIdleClientTimeout()) {
                 prepareDestroy();

--- a/libcockatrice_network/libcockatrice/network/server/remote/server_protocolhandler.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/server_protocolhandler.h
@@ -27,6 +27,7 @@ class CommandContainer;
 class SessionCommand;
 class ModeratorCommand;
 class AdminCommand;
+class DeveloperCommand;
 
 class Command_Ping;
 class Command_Login;
@@ -95,6 +96,12 @@ private:
     Response::ResponseCode processAdminCommandContainer(const CommandContainer &cont, ResponseContainer &rc);
     virtual Response::ResponseCode
     processExtendedAdminCommand(int /* cmdType */, const AdminCommand & /* cmd */, ResponseContainer & /* rc */)
+    {
+        return Response::RespFunctionNotAllowed;
+    }
+    Response::ResponseCode processDeveloperCommandContainer(const CommandContainer &cont, ResponseContainer &rc);
+    virtual Response::ResponseCode
+    processExtendedDeveloperCommand(int /* cmdType */, const DeveloperCommand & /* cmd */, ResponseContainer & /* rc */)
     {
         return Response::RespFunctionNotAllowed;
     }

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/CMakeLists.txt
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/CMakeLists.txt
@@ -22,6 +22,8 @@ set(PROTO_FILES
     command_del_counter.proto
     command_delete_arrow.proto
     command_draw_cards.proto
+    command_get_log_history.proto
+    command_get_server_stats.proto
     command_dump_zone.proto
     command_flip_card.proto
     command_game_say.proto
@@ -71,6 +73,7 @@ set(PROTO_FILES
     context_ready_start.proto
     context_set_sideboard_lock.proto
     context_undo_draw.proto
+    developer_commands.proto
     event_add_to_list.proto
     event_attach_card.proto
     event_change_zone_properties.proto
@@ -141,6 +144,7 @@ set(PROTO_FILES
     response_forgotpasswordrequest.proto
     response_get_admin_notes.proto
     response_get_games_of_user.proto
+    response_get_server_stats.proto
     response_get_user_info.proto
     response_join_room.proto
     response_list_users.proto

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/admin_commands.proto
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/admin_commands.proto
@@ -37,6 +37,7 @@ message Command_AdjustMod {
     required string user_name = 1;
     optional bool should_be_mod = 2;
     optional bool should_be_judge = 3;
+    optional bool should_be_developer = 4;
 }
 
 message Command_ResetUserPassword {

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/command_get_log_history.proto
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/command_get_log_history.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+import "developer_commands.proto";
+
+// Developer counterpart of Command_ViewLogHistory: identical query fields, but
+// routed through the developer command family so developers never need the
+// moderator command container.
+message Command_GetLogHistory {
+    extend DeveloperCommand {
+        optional Command_GetLogHistory ext = 1001;
+    }
+    optional string user_name = 1;       // user that created message
+    optional string ip_address = 2;      // ip address of user that created message
+    optional string game_name = 3;       // client id of user that created the message
+    optional string game_id = 4;         // game number the message was sent to
+    optional string message = 5;         // raw message that was sent
+    repeated string log_location = 6;    // destination of message (ex: main room, game room, private chat)
+    required uint32 date_range = 7;      // the length of time (in minutes) to look back for
+    optional uint32 maximum_results = 8; // the maximum number of query results
+}

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/command_get_server_stats.proto
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/command_get_server_stats.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+import "developer_commands.proto";
+
+message Command_GetServerStats {
+    extend DeveloperCommand {
+        optional Command_GetServerStats ext = 1000;
+    }
+}

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/commands.proto
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/commands.proto
@@ -4,6 +4,7 @@ import "game_commands.proto";
 import "room_commands.proto";
 import "moderator_commands.proto";
 import "admin_commands.proto";
+import "developer_commands.proto";
 
 message CommandContainer {
     optional uint64 cmd_id = 1;
@@ -16,4 +17,5 @@ message CommandContainer {
     repeated RoomCommand room_command = 102;
     repeated ModeratorCommand moderator_command = 103;
     repeated AdminCommand admin_command = 104;
+    repeated DeveloperCommand developer_command = 105;
 }

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/developer_commands.proto
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/developer_commands.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+message DeveloperCommand {
+    enum DeveloperCommandType {
+        GET_SERVER_STATS = 1000;
+        VIEWLOG_HISTORY = 1001;
+    }
+    extensions 100 to max;
+}

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/response.proto
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/response.proto
@@ -77,6 +77,7 @@ message Response {
         FORGOT_PASSWORD_REQUEST = 1016; // Response to password reset request
         PASSWORD_SALT = 1017;           // Response containing password salt
         GET_ADMIN_NOTES = 1018;         // Response with admin notes
+        GET_SERVER_STATS = 1019;        // Response with server status statistics
         REPLAY_LIST = 1100;             // Response listing replays
         REPLAY_DOWNLOAD = 1101;         // Response for replay download
         REPLAY_GET_CODE = 1102;         // Response containing replay code

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/response_get_server_stats.proto
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/response_get_server_stats.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+import "response.proto";
+
+message Response_GetServerStats {
+    extend Response {
+        optional Response_GetServerStats ext = 1220;
+    }
+
+    optional uint64 users_count = 1;
+    optional uint64 mods_count = 2;
+    optional uint64 games_count = 3;
+
+    // Traffic recorded during the last status update tick
+    optional uint64 tx_bytes = 4;
+    optional uint64 rx_bytes = 5;
+
+    optional uint64 uptime_secs = 6;
+    optional uint64 timest = 7; // unix timestamp of the snapshot
+}

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/serverinfo_user.proto
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/serverinfo_user.proto
@@ -8,6 +8,7 @@ message ServerInfo_User {
         IsModerator = 4;
         IsAdmin = 8;
         IsJudge = 16;
+        IsDeveloper = 32;
     };
     message PawnColorsOverride {
         optional string left_side = 1;

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -641,6 +641,10 @@ ServerInfo_User Servatrice_DatabaseInterface::evalUserQueryResult(const QSqlQuer
         userLevel |= ServerInfo_User::IsJudge;
     }
 
+    if (is_admin & 8) {
+        userLevel |= ServerInfo_User::IsDeveloper;
+    }
+
     result.set_user_level(userLevel);
 
     const QString country = query->value(3).toString();
@@ -1448,7 +1452,7 @@ QList<ServerInfo_ModeratorLogin> Servatrice_DatabaseInterface::getModeratorLastL
     QSqlQuery *query = prepareQuery("SELECT u.name, u.admin, UNIX_TIMESTAMP(a.last_login) "
                                     "FROM {prefix}_users u "
                                     "LEFT JOIN {prefix}_user_analytics a ON a.id = u.id "
-                                    "WHERE (u.admin & 7) <> 0 ORDER BY u.name");
+                                    "WHERE (u.admin & 15) <> 0 ORDER BY u.name");
 
     if (!execSqlQuery(query)) {
         qCWarning(DatabaseInterfaceLog) << "Failed to collect moderator login information: SQL Error";
@@ -1468,6 +1472,9 @@ QList<ServerInfo_ModeratorLogin> Servatrice_DatabaseInterface::getModeratorLastL
         }
         if (isAdmin & 4) {
             userLevel |= ServerInfo_User::IsJudge;
+        }
+        if (isAdmin & 8) {
+            userLevel |= ServerInfo_User::IsDeveloper;
         }
         loginDetails.set_user_level(userLevel);
 

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -47,6 +47,8 @@
 #include <libcockatrice/protocol/pb/command_deck_list.pb.h>
 #include <libcockatrice/protocol/pb/command_deck_new_dir.pb.h>
 #include <libcockatrice/protocol/pb/command_deck_upload.pb.h>
+#include <libcockatrice/protocol/pb/command_get_log_history.pb.h>
+#include <libcockatrice/protocol/pb/command_get_server_stats.pb.h>
 #include <libcockatrice/protocol/pb/command_replay_delete_match.pb.h>
 #include <libcockatrice/protocol/pb/command_replay_download.pb.h>
 #include <libcockatrice/protocol/pb/command_replay_download_by_game_id.pb.h>
@@ -80,6 +82,7 @@
 #include <libcockatrice/protocol/pb/response_deck_upload.pb.h>
 #include <libcockatrice/protocol/pb/response_forgotpasswordrequest.pb.h>
 #include <libcockatrice/protocol/pb/response_get_admin_notes.pb.h>
+#include <libcockatrice/protocol/pb/response_get_server_stats.pb.h>
 #include <libcockatrice/protocol/pb/response_moderator_last_logins.pb.h>
 #include <libcockatrice/protocol/pb/response_password_salt.pb.h>
 #include <libcockatrice/protocol/pb/response_register.pb.h>
@@ -332,6 +335,38 @@ AbstractServerSocketInterface::processExtendedAdminCommand(int cmdType, const Ad
             return cmdAdjustMod(cmd.GetExtension(Command_AdjustMod::ext), rc);
         case AdminCommand::RESET_USER_PASSWORD:
             return cmdResetUserPassword(cmd.GetExtension(Command_ResetUserPassword::ext), rc);
+        default:
+            return Response::RespFunctionNotAllowed;
+    }
+}
+
+// DEVELOPER FUNCTIONS.
+// Permission is checked by processDeveloperCommandContainer. Only stats-style
+// queries live here, never community moderation or server administration.
+Response::ResponseCode AbstractServerSocketInterface::processExtendedDeveloperCommand(int cmdType,
+                                                                                      const DeveloperCommand &cmd,
+                                                                                      ResponseContainer &rc)
+{
+    switch ((DeveloperCommand::DeveloperCommandType)cmdType) {
+        case DeveloperCommand::GET_SERVER_STATS:
+            return cmdGetServerStats(cmd.GetExtension(Command_GetServerStats::ext), rc);
+        case DeveloperCommand::VIEWLOG_HISTORY: {
+            // Same query as the moderator log view, just carried by the
+            // developer command family.
+            const Command_GetLogHistory &devCmd = cmd.GetExtension(Command_GetLogHistory::ext);
+            Command_ViewLogHistory modCmd;
+            modCmd.set_user_name(devCmd.user_name());
+            modCmd.set_ip_address(devCmd.ip_address());
+            modCmd.set_game_name(devCmd.game_name());
+            modCmd.set_game_id(devCmd.game_id());
+            modCmd.set_message(devCmd.message());
+            for (int i = 0; i < devCmd.log_location_size(); ++i) {
+                modCmd.add_log_location(devCmd.log_location(i));
+            }
+            modCmd.set_date_range(devCmd.date_range());
+            modCmd.set_maximum_results(devCmd.maximum_results());
+            return cmdGetLogHistory(modCmd, rc);
+        }
         default:
             return Response::RespFunctionNotAllowed;
     }
@@ -1637,6 +1672,38 @@ Response::ResponseCode AbstractServerSocketInterface::cmdReportUserInfo(const Co
                 info->set_assigned_mod_name(recentQuery->value(9).toString().toStdString());
             }
         }
+    }
+
+    rc.setResponseExtension(re);
+    return Response::RespOk;
+}
+
+Response::ResponseCode AbstractServerSocketInterface::cmdGetServerStats(const Command_GetServerStats & /*cmd */,
+                                                                        ResponseContainer &rc)
+{
+    if (!sqlInterface->checkSql()) {
+        return Response::RespInternalError;
+    }
+
+    // Servatrice::statusUpdate() periodically snapshots server health into the
+    // uptime table. Serve the freshest snapshot for this server.
+    QSqlQuery *query = sqlInterface->prepareQuery(
+        "SELECT users_count, mods_count, games_count, tx_bytes, rx_bytes, uptime, UNIX_TIMESTAMP(timest) "
+        "FROM {prefix}_uptime WHERE id_server = :id_server ORDER BY timest DESC LIMIT 1");
+    query->bindValue(":id_server", servatrice->getServerID());
+    if (!sqlInterface->execSqlQuery(query)) {
+        return Response::RespInternalError;
+    }
+
+    auto *re = new Response_GetServerStats;
+    if (query->next()) {
+        re->set_users_count(query->value(0).toUInt());
+        re->set_mods_count(query->value(1).toUInt());
+        re->set_games_count(query->value(2).toUInt());
+        re->set_tx_bytes(query->value(3).toUInt());
+        re->set_rx_bytes(query->value(4).toUInt());
+        re->set_uptime_secs(query->value(5).toUInt());
+        re->set_timest(query->value(6).toUInt());
     }
 
     rc.setResponseExtension(re);
@@ -3215,7 +3282,7 @@ bool AbstractServerSocketInterface::removeAdminFlagFromUser(const QString &userN
     if (user) {
         Event_ConnectionClosed event;
         event.set_reason(Event_ConnectionClosed::DEMOTED);
-        event.set_reason_str("Your moderator and/or judge status has been revoked.");
+        event.set_reason_str("Your moderator, judge, and/or developer status has been revoked.");
         event.set_end_time(QDateTime::currentDateTime().toSecsSinceEpoch());
 
         SessionEvent *se = user->prepareSessionEvent(event);
@@ -3252,6 +3319,18 @@ Response::ResponseCode AbstractServerSocketInterface::cmdAdjustMod(const Command
             }
         } else {
             if (!removeAdminFlagFromUser(userName, 4)) {
+                return Response::RespInternalError;
+            }
+        }
+    }
+
+    if (cmd.has_should_be_developer()) {
+        if (cmd.should_be_developer()) {
+            if (!addAdminFlagToUser(userName, 8)) {
+                return Response::RespInternalError;
+            }
+        } else {
+            if (!removeAdminFlagFromUser(userName, 8)) {
                 return Response::RespInternalError;
             }
         }

--- a/servatrice/src/serversocketinterface.h
+++ b/servatrice/src/serversocketinterface.h
@@ -24,6 +24,8 @@
 #include <QMutex>
 #include <QTcpSocket>
 #include <QWebSocket>
+#include <libcockatrice/protocol/pb/command_get_log_history.pb.h>
+#include <libcockatrice/protocol/pb/command_get_server_stats.pb.h>
 #include <libcockatrice/protocol/pb/command_replay_download_by_game_id.pb.h>
 #include <libcockatrice/protocol/pb/command_report.pb.h>
 #include <libcockatrice/protocol/pb/command_report_add_comment.pb.h>
@@ -151,6 +153,8 @@ private:
     processExtendedModeratorCommand(int cmdType, const ModeratorCommand &cmd, ResponseContainer &rc) override;
     Response::ResponseCode
     processExtendedAdminCommand(int cmdType, const AdminCommand &cmd, ResponseContainer &rc) override;
+    Response::ResponseCode
+    processExtendedDeveloperCommand(int cmdType, const DeveloperCommand &cmd, ResponseContainer &rc) override;
 
     Response::ResponseCode cmdAccountEdit(const Command_AccountEdit &cmd, ResponseContainer &rc);
     Response::ResponseCode cmdAccountImage(const Command_AccountImage &cmd, ResponseContainer &rc);
@@ -171,6 +175,8 @@ private:
     Response::ResponseCode cmdGetModeratorLastLogins(const Command_GetModeratorLastLogins &cmd, ResponseContainer &rc);
     Response::ResponseCode cmdResetUserPassword(const Command_ResetUserPassword &cmd, ResponseContainer &rc);
     Response::ResponseCode cmdRemoveUserAvatar(const Command_RemoveUserAvatar &cmd, ResponseContainer &rc);
+
+    Response::ResponseCode cmdGetServerStats(const Command_GetServerStats &cmd, ResponseContainer &rc);
 
     bool addAdminFlagToUser(const QString &user, int flag);
     bool removeAdminFlagFromUser(const QString &user, int flag);


### PR DESCRIPTION
## Short roundup of the initial problem
We're currently more-or-less flying blind whenever there are issues with an update. In order to facilitate debugging and maintenance, it is necessary to install an additional looking glass into the server, which, ideally, we as developers have access to.
Promoting every developer to admin is not feasible.

## What will change with this Pull Request?
- Introduce a Developer staff level (proto flag 32, DB admin bit 8) that sits between admin and moderator: no kick/ban/warn/report/admin powers, but gets server log access via a new developer command container family (GET_SERVER_STATS, VIEWLOG_HISTORY) and an idle-timeout exemption. More features/stats to follow in another PR.

- Protocol: IsDeveloper flag, developer_commands.proto envelope, Command_GetServerStats/Command_GetLogHistory, Response_GetServerStats, Command_AdjustMod.should_be_developer
- Servatrice: fail-closed developer dispatcher, uptime snapshot handler, shared log history handler reuse, bit-8 DB mapping
- Client: burgundy pawn/badge/labels/sort order, prepareDeveloperCommand, minimal Developer stats tab, log tab access, promote/demote actions
