### PR TITLE
[GameScene] Don't just sever self connections, sever them all.

### DIFF
--- a/cockatrice/src/game_graphics/game_scene.cpp
+++ b/cockatrice/src/game_graphics/game_scene.cpp
@@ -48,7 +48,7 @@ GameScene::~GameScene()
     // members below are destroyed: the base QGraphicsScene destructor destroys the
     // remaining items, and their destroyed() signals must not reach slots that
     // reference members that no longer exist.
-    disconnect(this);
+    QObject::disconnect(nullptr, nullptr, this, nullptr);
 
     delete animationTimer;
     animationTimer = nullptr;


### PR DESCRIPTION
## Short roundup of the initial problem
disconnect(this) only disconnects self-connections. This leads to a crash when an animation item is visible on teardown.

## What will change with this Pull Request?
- Disconnect *everything*, the scene is getting torn down.
