### PR TITLE
Correct ccache default setting

### DIFF
--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -124,10 +124,6 @@ set -e
 
 # Setup
 ./servatrice/check_schema_version.sh
-
-if [[ ! $USE_CCACHE ]]; then
-  USE_CCACHE=0
-fi
 if [[ ! $BUILDTYPE ]]; then
   BUILDTYPE=Release
 fi
@@ -140,7 +136,7 @@ cd "$BUILD_DIR"
 # Set minimum CMake Version
 export CMAKE_POLICY_VERSION_MINIMUM=3.10
 
-# Add CMake flags
+# Add cmake flags
 flags=("-DCMAKE_BUILD_TYPE=$BUILDTYPE")
 if [[ $MAKE_SERVER ]]; then
   flags+=("-DWITH_SERVER=1")
@@ -151,14 +147,12 @@ fi
 if [[ $MAKE_TEST ]]; then
   flags+=("-DTEST=1")
 fi
-if [[ $USE_CCACHE == "1" ]]; then
+if [[ $USE_CCACHE ]]; then
   flags+=("-DUSE_CCACHE=1")
   if [[ $CCACHE_SIZE ]]; then
-    # This setting persists after running the script
+    # note, this setting persists after running the script
     ccache --max-size "$CCACHE_SIZE"
   fi
-else
-  flags+=("-DUSE_CCACHE=0")
 fi
 if [[ $PACKAGE_TYPE ]]; then
   flags+=("-DCPACK_GENERATOR=$PACKAGE_TYPE")
@@ -168,7 +162,7 @@ if [[ $USE_VCPKG ]]; then
   flags+=("-DVCPKG_INSTALL_OPTIONS=--x-abi-tools-use-exact-versions")
 fi
 
-# Add CMake --build flags
+# Add cmake --build flags
 buildflags=(--config "$BUILDTYPE")
 
 function ccachestatsverbose() {
@@ -181,7 +175,7 @@ function ccachestatsverbose() {
   fi
 }
 
-# Prepare compilation
+# Compile
 if [[ $RUNNER_OS == macOS ]]; then
   # QTDIR is needed for macOS since we actually only use the cached thin Qt binaries instead of the install-qt-action,
   # which sets a few environment variables
@@ -264,26 +258,24 @@ elif [[ $RUNNER_OS == Windows ]]; then
   buildflags+=(-- -p:UseMultiToolTask=true -p:EnableClServerMode=true)
 fi
 
-if [[ $USE_CCACHE == "1" ]]; then
+if [[ $USE_CCACHE ]]; then
   echo "::group::Show ccache stats"
   ccachestatsverbose
   echo "::endgroup::"
 fi
 
-# Configure CMake
-echo "::group::Configure CMake"
+echo "::group::Configure cmake"
 cmake --version
-echo "Running CMake with these flags: ${flags[*]}"
+echo "Running cmake with flags: ${flags[*]}"
 cmake .. "${flags[@]}"
 echo "::endgroup::"
 
-# Build
 echo "::group::Build project"
-echo "Running CMake with these build flags: ${buildflags[*]}"
+echo "Running cmake --build with flags: ${buildflags[*]}"
 cmake --build . "${buildflags[@]}"
 echo "::endgroup::"
 
-if [[ $USE_CCACHE == "1" ]]; then
+if [[ $USE_CCACHE ]]; then
   if [[ $CCACHE_EVICTION_AGE ]]; then
     echo "::group::evict ccache files older than $CCACHE_EVICTION_AGE"
     ccache --evict-older-than "$CCACHE_EVICTION_AGE"
@@ -309,21 +301,18 @@ if [[ $RUNNER_OS == macOS ]]; then
   echo "::endgroup::"
 fi
 
-# Test
 if [[ $MAKE_TEST ]]; then
   echo "::group::Run tests"
   ctest -C "$BUILDTYPE" --output-on-failure
   echo "::endgroup::"
 fi
 
-# Install
 if [[ $MAKE_INSTALL ]]; then
   echo "::group::Install"
   cmake --build . --target install --config "$BUILDTYPE"
   echo "::endgroup::"
 fi
 
-# Package
 if [[ $MAKE_PACKAGE ]]; then
   echo "::group::Create package"
   cmake --build . --target package --config "$BUILDTYPE"

--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -124,6 +124,10 @@ set -e
 
 # Setup
 ./servatrice/check_schema_version.sh
+
+if [[ ! $USE_CCACHE ]]; then
+  USE_CCACHE=0
+fi
 if [[ ! $BUILDTYPE ]]; then
   BUILDTYPE=Release
 fi
@@ -136,7 +140,7 @@ cd "$BUILD_DIR"
 # Set minimum CMake Version
 export CMAKE_POLICY_VERSION_MINIMUM=3.10
 
-# Add cmake flags
+# Add CMake flags
 flags=("-DCMAKE_BUILD_TYPE=$BUILDTYPE")
 if [[ $MAKE_SERVER ]]; then
   flags+=("-DWITH_SERVER=1")
@@ -147,12 +151,14 @@ fi
 if [[ $MAKE_TEST ]]; then
   flags+=("-DTEST=1")
 fi
-if [[ $USE_CCACHE ]]; then
+if [[ $USE_CCACHE == "1" ]]; then
   flags+=("-DUSE_CCACHE=1")
   if [[ $CCACHE_SIZE ]]; then
-    # note, this setting persists after running the script
+    # This setting persists after running the script
     ccache --max-size "$CCACHE_SIZE"
   fi
+else
+  flags+=("-DUSE_CCACHE=0")
 fi
 if [[ $PACKAGE_TYPE ]]; then
   flags+=("-DCPACK_GENERATOR=$PACKAGE_TYPE")
@@ -162,7 +168,7 @@ if [[ $USE_VCPKG ]]; then
   flags+=("-DVCPKG_INSTALL_OPTIONS=--x-abi-tools-use-exact-versions")
 fi
 
-# Add cmake --build flags
+# Add CMake --build flags
 buildflags=(--config "$BUILDTYPE")
 
 function ccachestatsverbose() {
@@ -175,7 +181,7 @@ function ccachestatsverbose() {
   fi
 }
 
-# Compile
+# Prepare compilation
 if [[ $RUNNER_OS == macOS ]]; then
   # QTDIR is needed for macOS since we actually only use the cached thin Qt binaries instead of the install-qt-action,
   # which sets a few environment variables
@@ -258,24 +264,26 @@ elif [[ $RUNNER_OS == Windows ]]; then
   buildflags+=(-- -p:UseMultiToolTask=true -p:EnableClServerMode=true)
 fi
 
-if [[ $USE_CCACHE ]]; then
+if [[ $USE_CCACHE == "1" ]]; then
   echo "::group::Show ccache stats"
   ccachestatsverbose
   echo "::endgroup::"
 fi
 
-echo "::group::Configure cmake"
+# Configure CMake
+echo "::group::Configure CMake"
 cmake --version
-echo "Running cmake with flags: ${flags[*]}"
+echo "Running CMake with these flags: ${flags[*]}"
 cmake .. "${flags[@]}"
 echo "::endgroup::"
 
+# Build
 echo "::group::Build project"
-echo "Running cmake --build with flags: ${buildflags[*]}"
+echo "Running CMake with these build flags: ${buildflags[*]}"
 cmake --build . "${buildflags[@]}"
 echo "::endgroup::"
 
-if [[ $USE_CCACHE ]]; then
+if [[ $USE_CCACHE == "1" ]]; then
   if [[ $CCACHE_EVICTION_AGE ]]; then
     echo "::group::evict ccache files older than $CCACHE_EVICTION_AGE"
     ccache --evict-older-than "$CCACHE_EVICTION_AGE"
@@ -301,18 +309,21 @@ if [[ $RUNNER_OS == macOS ]]; then
   echo "::endgroup::"
 fi
 
+# Test
 if [[ $MAKE_TEST ]]; then
   echo "::group::Run tests"
   ctest -C "$BUILDTYPE" --output-on-failure
   echo "::endgroup::"
 fi
 
+# Install
 if [[ $MAKE_INSTALL ]]; then
   echo "::group::Install"
   cmake --build . --target install --config "$BUILDTYPE"
   echo "::endgroup::"
 fi
 
+# Package
 if [[ $MAKE_PACKAGE ]]; then
   echo "::group::Create package"
   cmake --build . --target package --config "$BUILDTYPE"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,20 +8,20 @@
 # cmake 3.16 is required if using qt6
 cmake_minimum_required(VERSION 3.10)
 
-# Early detect ccache
-option(USE_CCACHE "Cache the build results with ccache" ON)
+# Use compiler cache (ccache)
+option(USE_CCACHE "Cache the build results with ccache" OFF)
 # Treat warnings as errors (Debug builds only)
 option(WARNING_AS_ERROR "Treat warnings as errors in debug builds" ON)
 # Check for translation updates
 option(UPDATE_TRANSLATIONS "Update translations on compile" OFF)
-# Compile servatrice
-option(WITH_SERVER "build servatrice" OFF)
-# Compile cockatrice
-option(WITH_CLIENT "build cockatrice" ON)
-# Compile oracle
-option(WITH_ORACLE "build oracle" ON)
+# Compile Cockatrice
+option(WITH_CLIENT "Build Cockatrice client" ON)
+# Compile Oracle
+option(WITH_ORACLE "Build Cockatrice card database tool (Oracle)" ON)
+# Compile Servatrice
+option(WITH_SERVER "Build Cockatrice server (Servatrice)" OFF)
 # Compile tests
-option(TEST "build tests" OFF)
+option(TEST "Build tests" OFF)
 # Use vcpkg regardless of OS
 option(USE_VCPKG "Use vcpkg regardless of OS" OFF)
 


### PR DESCRIPTION
## Related Ticket(s)
- Related #7049

## Short roundup of the initial problem

On current `master`, we enable ccache by default:
https://github.com/Cockatrice/Cockatrice/blob/83833f468490935d7196e69f1c4cc772aeeb5a20/CMakeLists.txt#L12

That means, as long as we do not disable it in particular in CI, it was enabled.
While we do not install and use ccache on Windows, it was available due to some Perl tooling installing it in the GHA runner nonetheless.

That appeared to be the root case for a lot of headaches when trying to switch to Ninja and trying different approaches across various PRs before. The Visual Studio generator behaves different and did still orchestrate the compilation without trying to involve ccache.

This PR solves this config bug.

## What will change with this Pull Request?
- Config change, see 1) and 2)
- More comments polish in the area I came across

1) Set `USE_CCACHE=0` if no value configured to imitate "nothing set --> expectation is that it's disabled": https://github.com/Cockatrice/Cockatrice/pull/7190/commits/0af93629de040f5cdc3929e77576e7b563d71797

    - Before (Windows)
      ```
      env:
        USE_CCACHE: 
      ```
      ```
      Running cmake with flags: -DCMAKE_BUILD_TYPE=Release -DWITH_SERVER=1 -DTEST=1 -DUSE_VCPKG=1 -DVCPKG_INSTALL_OPTIONS=--x-abi-tools-use-exact-versions
      ...
       -- Found CCache C:/Strawberry/c/bin/ccache.exe
       ```

    - After (Windows), notice the `-DUSE_CCACHE=0` and missing `Found CCACHE`
      ```
      env:
        USE_CCACHE: 
      ```
      ```
       Running cmake with flags: -DCMAKE_BUILD_TYPE=Release -DWITH_SERVER=1 -DTEST=1 -DUSE_CCACHE=0 -DUSE_VCPKG=1 -DVCPKG_INSTALL_OPTIONS=--x-abi-tools-use-exact-versions
       ```

<br>

2) The alternative is to set the default to `OFF`: https://github.com/Cockatrice/Cockatrice/pull/7190/commits/a09d68a8df1e211371449bd1b6d815c534141f62
I think that's even cleaner and the correct approach. Enabling something that we do not list as required or dependency will likely lead to unexpected behavior during compilation.

    Doing so will omit the `DUSE_CCACHE` flag and still does not find or use the randomly available ccache on our Windows setup in CI:
    ```
    env:
      USE_CCACHE: 
    ```
    ```
    Running cmake with flags: -DCMAKE_BUILD_TYPE=Release -DWITH_SERVER=1 -DTEST=1 -DUSE_VCPKG=1 -DVCPKG_INSTALL_OPTIONS=--x-abi-tools-use-exact-versions
    ```

    For local compiling this means if you want to utilise ccache as compiler cache you have to enable it.

<br>

The other CI build (macOS and Linux) were never affected because they enable `USE_CCACHE` actively and use compiler caching. They're unchanged and behave the same with either of this changes.

