### PR TITLE
[GameScene] Sever connections properly.

### DIFF
--- a/cockatrice/src/game_graphics/game_scene.cpp
+++ b/cockatrice/src/game_graphics/game_scene.cpp
@@ -44,11 +44,16 @@ GameScene::GameScene(PhasesToolbar *_phasesToolbar, QObject *parent)
 
 GameScene::~GameScene()
 {
-    // Sever all incoming connections (animated item destroy-tracking) before the
-    // members below are destroyed: the base QGraphicsScene destructor destroys the
-    // remaining items, and their destroyed() signals must not reach slots that
-    // reference members that no longer exist.
-    QObject::disconnect(nullptr, nullptr, this, nullptr);
+    // Sever the destroy-tracking connections before the members and base-class
+    // teardown destroy the items. The receiver (this) cannot be matched with a
+    // nullptr sender (QObject::disconnect forbids one) so disconnect each
+    // tracked sender explicitly. Otherwise, when the base QGraphicsScene destructor
+    // destroys the remaining items, their destroyed() signals would re-enter
+    // removeAnimatedItem() and touch members that no longer exist.
+    const auto animatedSenders = animatedItems.keys();
+    for (QObject *sender : animatedSenders) {
+        disconnect(sender, &QObject::destroyed, this, &GameScene::removeAnimatedItem);
+    }
 
     delete animationTimer;
     animationTimer = nullptr;

--- a/cockatrice/src/game_graphics/game_scene.cpp
+++ b/cockatrice/src/game_graphics/game_scene.cpp
@@ -44,16 +44,16 @@ GameScene::GameScene(PhasesToolbar *_phasesToolbar, QObject *parent)
 
 GameScene::~GameScene()
 {
-    // Sever the destroy-tracking connections before the members and base-class
-    // teardown destroy the items. The receiver (this) cannot be matched with a
-    // nullptr sender (QObject::disconnect forbids one) so disconnect each
-    // tracked sender explicitly. Otherwise, when the base QGraphicsScene destructor
-    // destroys the remaining items, their destroyed() signals would re-enter
-    // removeAnimatedItem() and touch members that no longer exist.
-    const auto animatedSenders = animatedItems.keys();
-    for (QObject *sender : animatedSenders) {
-        disconnect(sender, &QObject::destroyed, this, &GameScene::removeAnimatedItem);
+    // Sever all destroyed->removeAnimatedItem connections before the members below
+    // are destroyed: the base QGraphicsScene destructor destroys the remaining items,
+    // and their destroyed() signals must not reach slots that reference members that
+    // no longer exist. The connection handle overload is used because the string-based
+    // disconnect(nullptr, nullptr, this, nullptr) is invalid (the sender must never be
+    // nullptr) and would otherwise fail to sever these pointer-to-member connections.
+    for (auto it = animationItemConnections.constBegin(); it != animationItemConnections.constEnd(); ++it) {
+        QObject::disconnect(*it);
     }
+    animationItemConnections.clear();
 
     delete animationTimer;
     animationTimer = nullptr;
@@ -782,8 +782,15 @@ void GameScene::registerAnimationItem(IAnimatedItem *item)
     if (!object) {
         return;
     }
-    if (!animatedItems.contains(object)) {
-        connect(object, &QObject::destroyed, this, &GameScene::removeAnimatedItem);
+    // Guard against duplicate connections using the connection map, not
+    // animatedItems: the animation timer removes entries from animatedItems when an
+    // animation completes, but the destroyed->removeAnimatedItem connection must
+    // persist until the object is destroyed. Relying on animatedItems here would let
+    // a re-registered item (e.g. a life counter that flashes repeatedly) accumulate
+    // duplicate destroyed connections, the older ones of which would survive teardown.
+    if (!animationItemConnections.contains(object)) {
+        animationItemConnections.insert(object,
+                                        connect(object, &QObject::destroyed, this, &GameScene::removeAnimatedItem));
     }
     animatedItems.insert(object, item);
     if (animationTimer && !animationTimer->isActive()) {
@@ -802,6 +809,7 @@ void GameScene::unregisterAnimationItem(IAnimatedItem *item)
 void GameScene::removeAnimatedItem(QObject *item)
 {
     animatedItems.remove(item);
+    animationItemConnections.remove(item);
     if (animationTimer && animatedItems.isEmpty()) {
         animationTimer->stop();
     }

--- a/cockatrice/src/game_graphics/game_scene.h
+++ b/cockatrice/src/game_graphics/game_scene.h
@@ -54,9 +54,11 @@ private:
     QPointer<CardItem> hoveredCard;                     ///< Currently hovered card
     QBasicTimer *animationTimer;                        ///< Timer for scene animations
     QHash<QObject *, IAnimatedItem *> animatedItems;    ///< Items currently animating
-    int playerRotation;                                 ///< Rotation offset for player layout
-    bool rearranging = false;                           ///< Guard against re-entrant rearrange
-    bool needsReArrange = false;                        ///< Pending rearrange requested during a pass
+    QHash<QObject *, QMetaObject::Connection>
+        animationItemConnections; ///< destroyed->removeAnimatedItem handles per animated item
+    int playerRotation;           ///< Rotation offset for player layout
+    bool rearranging = false;     ///< Guard against re-entrant rearrange
+    bool needsReArrange = false;  ///< Pending rearrange requested during a pass
 
     /**
      * @brief Updates which card is currently hovered based on scene coordinates.


### PR DESCRIPTION
## Short roundup of the initial problem
Master's interim fix used QObject::disconnect(nullptr, nullptr, this, nullptr), which Qt rejects (nullptr sender → warning and unreliable).

## What will change with this Pull Request?
- This change severs the destroy-tracking connections per-sender instead, eliminating both the warning and the re-entrancy hazard.
