### PR TITLE
[Security] Use a CSPRNG for salts, tokens, and RNG seeding

### DIFF
--- a/.ci/Arch/Dockerfile
+++ b/.ci/Arch/Dockerfile
@@ -8,6 +8,7 @@ RUN pacman --sync --refresh --sysupgrade --needed --noconfirm \
         gtest \
         mariadb-libs \
         ninja \
+        openssl \
         protobuf \
         qt6-base \
         qt6-declarative \

--- a/.ci/Debian12/Dockerfile
+++ b/.ci/Debian12/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
         libprotobuf-dev \
         libqt6multimedia6 \
         libqt6sql6-mysql \
+        libssl-dev \
         ninja-build \
         protobuf-compiler \
         qt6-image-formats-plugins \

--- a/.ci/Debian13/Dockerfile
+++ b/.ci/Debian13/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
         libprotobuf-dev \
         libqt6multimedia6 \
         libqt6sql6-mysql \
+        libssl-dev \
         ninja-build \
         protobuf-compiler \
         qt6-image-formats-plugins \

--- a/.ci/Fedora43/Dockerfile
+++ b/.ci/Fedora43/Dockerfile
@@ -7,6 +7,7 @@ RUN dnf install -y \
         git \
         mariadb-devel \
         ninja-build \
+        openssl-devel \
         protobuf-devel \
         qt6-{qtdeclarative,qtshadertools,qttools,qtsvg,qtmultimedia,qtwebsockets}-devel \
         qt6-qtimageformats \

--- a/.ci/Fedora44/Dockerfile
+++ b/.ci/Fedora44/Dockerfile
@@ -7,6 +7,7 @@ RUN dnf install -y \
         git \
         mariadb-devel \
         ninja-build \
+        openssl-devel \
         protobuf-devel \
         qt6-{qtdeclarative,qtshadertools,qttools,qtsvg,qtmultimedia,qtwebsockets}-devel \
         qt6-qtimageformats \

--- a/.ci/Servatrice_Debian12/Dockerfile
+++ b/.ci/Servatrice_Debian12/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
         libmariadb-dev-compat \
         libprotobuf-dev \
         libqt6sql6-mysql \
+        libssl-dev \
         ninja-build \
         protobuf-compiler \
         qt6-tools-dev \

--- a/.ci/Ubuntu24.04/Dockerfile
+++ b/.ci/Ubuntu24.04/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
         libprotobuf-dev \
         libqt6multimedia6 \
         libqt6sql6-mysql \
+        libssl-dev \
         ninja-build \
         protobuf-compiler \
         qt6-image-formats-plugins \

--- a/.ci/Ubuntu26.04/Dockerfile
+++ b/.ci/Ubuntu26.04/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
         libprotobuf-dev \
         libqt6multimedia6 \
         libqt6sql6-mysql \
+        libssl-dev \
         ninja-build \
         protobuf-compiler \
         qt6-image-formats-plugins \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,11 +239,6 @@ if(WIN32)
   find_package(OpenSSL REQUIRED)
   if(OPENSSL_FOUND)
     include_directories(${OPENSSL_INCLUDE_DIRS})
-  else()
-    message(
-      WARNING
-        "Could not find OpenSSL runtime libraries. They are not required for compiling, but needs to be available at runtime."
-    )
   endif()
 endif()
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
       libmariadb-dev-compat \
       libprotobuf-dev \
       libqt6sql6-mysql \
+      libssl-dev \
       qt6-websockets-dev \
       protobuf-compiler \
       qt6-tools-dev \
@@ -42,6 +43,7 @@ RUN apt-get update \
       libprotobuf32t64 \
       libqt6sql6-mysql \
       libqt6websockets6 \
+      libssl3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -53,6 +53,7 @@
 #include <libcockatrice/settings/interface_settings.h>
 #include <libcockatrice/settings/network_settings.h>
 #include <libcockatrice/settings/personal_settings.h>
+#include <libcockatrice/utility/cryptoutil.h>
 
 QTranslator *translator, *qtTranslator;
 RNG_Abstract *rng;
@@ -292,7 +293,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    rng = new RNG_SFMT;
+    rng = new RNG_SFMT(CryptoUtil::randomUInt64());
     themeManager = new ThemeManager;
     soundEngine = new SoundEngine;
 

--- a/libcockatrice_rng/libcockatrice/rng/rng_sfmt.cpp
+++ b/libcockatrice_rng/libcockatrice/rng/rng_sfmt.cpp
@@ -1,6 +1,5 @@
 #include "rng_sfmt.h"
 
-#include <QDateTime>
 #include <algorithm>
 #include <climits>
 #include <stdexcept>
@@ -11,10 +10,11 @@
 #define UINT64_MAX (~(uint64_t)0)
 #endif
 
-RNG_SFMT::RNG_SFMT(QObject *parent) : RNG_Abstract(parent)
+RNG_SFMT::RNG_SFMT(uint64_t seed, QObject *parent) : RNG_Abstract(parent)
 {
-    // initialize the random number generator with a 32bit integer seed (timestamp)
-    sfmt_init_gen_rand(&sfmt, QDateTime::currentDateTime().toSecsSinceEpoch());
+    // initialize the random number generator with a 64bit seed, e.g. from a CSPRNG
+    uint32_t seedArray[2] = {static_cast<uint32_t>(seed), static_cast<uint32_t>(seed >> 32)};
+    sfmt_init_by_array(&sfmt, seedArray, 2);
 }
 
 /**

--- a/libcockatrice_rng/libcockatrice/rng/rng_sfmt.h
+++ b/libcockatrice_rng/libcockatrice/rng/rng_sfmt.h
@@ -36,7 +36,7 @@ private:
     unsigned int cdf(unsigned int min, unsigned int max);
 
 public:
-    explicit RNG_SFMT(QObject *parent = nullptr);
+    explicit RNG_SFMT(uint64_t seed, QObject *parent = nullptr);
     unsigned int rand(int min, int max) override;
 };
 

--- a/libcockatrice_utility/CMakeLists.txt
+++ b/libcockatrice_utility/CMakeLists.txt
@@ -6,13 +6,14 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 
 set(UTILITY_SOURCES
-    libcockatrice/utility/expression.cpp libcockatrice/utility/levenshtein.cpp libcockatrice/utility/passwordhasher.cpp
-    libcockatrice/utility/server_rate_limiter.cpp libcockatrice/utility/warning_categories.cpp
+    libcockatrice/utility/cryptoutil.cpp libcockatrice/utility/expression.cpp libcockatrice/utility/levenshtein.cpp
+    libcockatrice/utility/passwordhasher.cpp libcockatrice/utility/server_rate_limiter.cpp libcockatrice/utility/warning_categories.cpp
 )
 
 set(UTILITY_HEADERS
     libcockatrice/utility/card_ref.h
     libcockatrice/utility/color.h
+    libcockatrice/utility/cryptoutil.h
     libcockatrice/utility/expression.h
     libcockatrice/utility/levenshtein.h
     libcockatrice/utility/macros.h
@@ -32,7 +33,9 @@ add_library(libcockatrice_utility STATIC ${UTILITY_SOURCES} ${UTILITY_HEADERS})
 
 target_include_directories(libcockatrice_utility PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(libcockatrice_utility PUBLIC libcockatrice_rng ${QT_CORE_MODULE})
+find_package(OpenSSL REQUIRED)
+
+target_link_libraries(libcockatrice_utility PUBLIC libcockatrice_rng OpenSSL::Crypto ${QT_CORE_MODULE})
 
 set(ORACLE_LIBS)
 

--- a/libcockatrice_utility/CMakeLists.txt
+++ b/libcockatrice_utility/CMakeLists.txt
@@ -7,7 +7,8 @@ set(CMAKE_AUTORCC ON)
 
 set(UTILITY_SOURCES
     libcockatrice/utility/cryptoutil.cpp libcockatrice/utility/expression.cpp libcockatrice/utility/levenshtein.cpp
-    libcockatrice/utility/passwordhasher.cpp libcockatrice/utility/server_rate_limiter.cpp libcockatrice/utility/warning_categories.cpp
+    libcockatrice/utility/passwordhasher.cpp libcockatrice/utility/server_rate_limiter.cpp
+    libcockatrice/utility/warning_categories.cpp
 )
 
 set(UTILITY_HEADERS

--- a/libcockatrice_utility/libcockatrice/utility/cryptoutil.cpp
+++ b/libcockatrice_utility/libcockatrice/utility/cryptoutil.cpp
@@ -1,0 +1,25 @@
+#include "cryptoutil.h"
+
+#include <openssl/rand.h>
+
+namespace CryptoUtil
+{
+QByteArray randomBytes(int count)
+{
+    QByteArray bytes(count, '\0');
+    if (RAND_bytes(reinterpret_cast<unsigned char *>(bytes.data()), count) != 1) {
+        // Randomness failure is fatal: never fall back to a predictable source.
+        qFatal("CryptoUtil::randomBytes: RAND_bytes failed");
+    }
+    return bytes;
+}
+
+quint64 randomUInt64()
+{
+    quint64 value;
+    if (RAND_bytes(reinterpret_cast<unsigned char *>(&value), sizeof(value)) != 1) {
+        qFatal("CryptoUtil::randomUInt64: RAND_bytes failed");
+    }
+    return value;
+}
+} // namespace CryptoUtil

--- a/libcockatrice_utility/libcockatrice/utility/cryptoutil.h
+++ b/libcockatrice_utility/libcockatrice/utility/cryptoutil.h
@@ -1,0 +1,13 @@
+#ifndef CRYPTOUTIL_H
+#define CRYPTOUTIL_H
+
+#include <QByteArray>
+#include <QtGlobal>
+
+namespace CryptoUtil
+{
+QByteArray randomBytes(int count);
+quint64 randomUInt64();
+} // namespace CryptoUtil
+
+#endif

--- a/libcockatrice_utility/libcockatrice/utility/passwordhasher.cpp
+++ b/libcockatrice_utility/libcockatrice/utility/passwordhasher.cpp
@@ -1,7 +1,7 @@
 #include "passwordhasher.h"
 
 #include <QCryptographicHash>
-#include <libcockatrice/rng/rng_sfmt.h>
+#include <libcockatrice/utility/cryptoutil.h>
 
 QString PasswordHasher::computeHash(const QString &password, const QString &salt)
 {
@@ -21,12 +21,28 @@ QString PasswordHasher::generateRandomSalt(const int len)
     static const char alphanum[] = "0123456789"
                                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                    "abcdefghijklmnopqrstuvwxyz";
+    const int size = sizeof(alphanum) - 1;
+
+    // Two bytes per character, corrected for modulo bias via rejection sampling.
+    const int bucketSize = 65536 / size;
+    const int limit = bucketSize * size;
 
     QString ret;
-    int size = sizeof(alphanum) - 1;
-
+    ret.reserve(len);
+    QByteArray random = CryptoUtil::randomBytes(len * 2);
+    int bytesUsed = 0;
     for (int i = 0; i < len; ++i) {
-        ret.append(alphanum[rng->rand(0, size)]);
+        unsigned int value;
+        do {
+            if (bytesUsed >= random.size()) {
+                random = CryptoUtil::randomBytes(len * 2);
+                bytesUsed = 0;
+            }
+            value = static_cast<unsigned int>(static_cast<unsigned char>(random.at(bytesUsed))) << 8 |
+                    static_cast<unsigned int>(static_cast<unsigned char>(random.at(bytesUsed + 1)));
+            bytesUsed += 2;
+        } while (value >= limit);
+        ret.append(alphanum[value / bucketSize]);
     }
 
     return ret;
@@ -34,5 +50,5 @@ QString PasswordHasher::generateRandomSalt(const int len)
 
 QString PasswordHasher::generateActivationToken()
 {
-    return QCryptographicHash::hash(generateRandomSalt().toUtf8(), QCryptographicHash::Md5).toBase64().left(16);
+    return QString(CryptoUtil::randomBytes(16).toBase64().left(16));
 }

--- a/servatrice/src/main.cpp
+++ b/servatrice/src/main.cpp
@@ -33,6 +33,7 @@
 #include <QtGlobal>
 #include <iostream>
 #include <libcockatrice/rng/rng_sfmt.h>
+#include <libcockatrice/utility/cryptoutil.h>
 #include <libcockatrice/utility/passwordhasher.h>
 
 RNG_Abstract *rng;
@@ -169,7 +170,7 @@ int main(int argc, char *argv[])
 
     signalhandler = new SignalHandler();
 
-    rng = new RNG_SFMT;
+    rng = new RNG_SFMT(CryptoUtil::randomUInt64());
 
     std::cerr << "Servatrice " << VERSION_STRING << " starting." << std::endl;
     std::cerr << "-------------------------" << std::endl;

--- a/tests/password_hash_test.cpp
+++ b/tests/password_hash_test.cpp
@@ -1,25 +1,9 @@
 #include "gtest/gtest.h"
-#include <libcockatrice/rng/rng_abstract.h>
-#include <libcockatrice/rng/rng_sfmt.h>
+#include <cstring>
 #include <libcockatrice/utility/passwordhasher.h>
-
-RNG_Abstract *rng;
 
 namespace
 {
-class PasswordHashTest : public ::testing::Test
-{
-protected:
-    void SetUp() override
-    {
-        rng = new RNG_SFMT;
-    }
-
-    void TearDown() override
-    {
-        delete rng;
-    }
-};
 
 TEST(PasswordHashTest, RegressionTest)
 {
@@ -28,6 +12,29 @@ TEST(PasswordHashTest, RegressionTest)
     QString expected = "vmKoWv975yf+WT2QCXhW48JNzZ2ghGxdgNvuKLBU0h7s6AQHSG72J6QO4ZswuSeqvBbAXbmgJSRBaSJrgc55WA==";
     QString hash = PasswordHasher::computeHash(password, salt);
     ASSERT_EQ(hash, salt + expected) << "The computed hash value remains the same";
+}
+
+TEST(PasswordHashTest, SaltUsesAlphanumericCharset)
+{
+    static const char alphanum[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    const QString salt = PasswordHasher::generateRandomSalt();
+    ASSERT_EQ(salt.size(), 16);
+    for (const QChar &c : salt) {
+        ASSERT_NE(strchr(alphanum, c.toLatin1()), nullptr);
+    }
+}
+
+TEST(PasswordHashTest, SaltsAreUnique)
+{
+    const QString salt1 = PasswordHasher::generateRandomSalt();
+    const QString salt2 = PasswordHasher::generateRandomSalt();
+    ASSERT_NE(salt1, salt2);
+}
+
+TEST(PasswordHashTest, TokenHasExpectedLength)
+{
+    const QString token = PasswordHasher::generateActivationToken();
+    ASSERT_EQ(token.size(), 16);
 }
 } // namespace
 


### PR DESCRIPTION
## Short roundup of the initial problem

Several places in the codebase produced "random" values from predictable sources. The game's RNG was seeded from the wall clock, login salts were built from a small alphabet using that same RNG, and activation tokens were an MD5 of
a not-very-random salt. An attacker who can predict a seed can predict the resulting salts and tokens. Critical because those protect password hashes and account activation.

## What will change with this Pull Request?

- Add `CryptoUtil`, backed by OpenSSL's `RAND_bytes`, a cryptographically secure PRNG (CSPRNG), as the single source of randomness for security.
- Seed the game's SFMT RNG from `CryptoUtil::randomUInt64()` instead of the current timestamp, so in-game randomness can no longer be predicted from the clock.
- Generate password salts from `CryptoUtil::randomBytes()`, and fix a modulo bias in salt character selection by adding rejection sampling.
- Generate account activation tokens directly from 16 secure random bytes instead of MD5-hashing a weak salt.
- Fail fast (`qFatal`) if the RNG ever fails, rather than silently falling back to a predictable source.
- Add regression tests for salt charset, uniqueness, and token length.

Supplies the secure randomness that the scrypt / challenge-response work in #7193 builds on.