### PR TITLE
[Server] Add extension points for tournament game commands

### DIFF
--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_participant.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_participant.cpp
@@ -41,6 +41,7 @@
 #include <libcockatrice/protocol/pb/command_set_sideboard_lock.pb.h>
 #include <libcockatrice/protocol/pb/command_set_sideboard_plan.pb.h>
 #include <libcockatrice/protocol/pb/command_shuffle.pb.h>
+#include <libcockatrice/protocol/pb/command_tournament.pb.h>
 #include <libcockatrice/protocol/pb/command_undo_draw.pb.h>
 #include <libcockatrice/protocol/pb/context_connection_state_changed.pb.h>
 #include <libcockatrice/protocol/pb/event_game_say.pb.h>
@@ -536,6 +537,15 @@ Server_AbstractParticipant::processGameCommand(const GameCommand &command, Respo
         case GameCommand::SET_PLAYMAT:
             return cmdSetPlaymat(command.GetExtension(Command_SetPlaymat::ext), rc, ges);
             break;
+        case GameCommand::REPORT_MATCH_RESULT:
+            return cmdReportMatchResult(command.GetExtension(Command_ReportMatchResult::ext), rc, ges);
+            break;
+        case GameCommand::ADVANCE_TOURNAMENT:
+            return cmdAdvanceTournament(command.GetExtension(Command_AdvanceTournament::ext), rc, ges);
+            break;
+        case GameCommand::TOURNAMENT_SETTINGS_SELECT:
+            return cmdTournamentSettingsSelect(command.GetExtension(Command_TournamentSettingsSelect::ext), rc, ges);
+            break;
         default:
             return Response::RespInvalidCommand;
     }
@@ -583,4 +593,26 @@ void Server_AbstractParticipant::getInfo(ServerInfo_Player *info,
                                          bool withUserInfo)
 {
     getProperties(*info->mutable_properties(), withUserInfo);
+}
+
+Response::ResponseCode Server_AbstractParticipant::cmdReportMatchResult(const Command_ReportMatchResult & /*cmd*/,
+                                                                        ResponseContainer & /*rc*/,
+                                                                        GameEventStorage & /*ges*/)
+{
+    return Response::RespContextError;
+}
+
+Response::ResponseCode Server_AbstractParticipant::cmdAdvanceTournament(const Command_AdvanceTournament & /*cmd*/,
+                                                                        ResponseContainer & /*rc*/,
+                                                                        GameEventStorage & /*ges*/)
+{
+    return Response::RespContextError;
+}
+
+Response::ResponseCode
+Server_AbstractParticipant::cmdTournamentSettingsSelect(const Command_TournamentSettingsSelect & /*cmd*/,
+                                                        ResponseContainer & /*rc*/,
+                                                        GameEventStorage & /*ges*/)
+{
+    return Response::RespContextError;
 }

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_participant.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_participant.h
@@ -53,6 +53,9 @@ class Command_DeckSelect;
 class Command_SetSideboardLock;
 class Command_ChangeZoneProperties;
 class Command_SetPlaymat;
+class Command_ReportMatchResult;
+class Command_AdvanceTournament;
+class Command_TournamentSettingsSelect;
 
 class Server_AbstractParticipant : public Server_ArrowTarget, public ServerInfo_User_Container
 {
@@ -175,6 +178,13 @@ public:
     cmdReverseTurn(const Command_ReverseTurn & /*cmd*/, ResponseContainer & /*rc*/, GameEventStorage &ges);
     virtual Response::ResponseCode
     cmdChangeZoneProperties(const Command_ChangeZoneProperties &cmd, ResponseContainer &rc, GameEventStorage &ges);
+    virtual Response::ResponseCode
+    cmdReportMatchResult(const Command_ReportMatchResult &cmd, ResponseContainer &rc, GameEventStorage &ges);
+    virtual Response::ResponseCode
+    cmdAdvanceTournament(const Command_AdvanceTournament &cmd, ResponseContainer &rc, GameEventStorage &ges);
+    virtual Response::ResponseCode cmdTournamentSettingsSelect(const Command_TournamentSettingsSelect &cmd,
+                                                               ResponseContainer &rc,
+                                                               GameEventStorage &ges);
 
     Response::ResponseCode processGameCommand(const GameCommand &command, ResponseContainer &rc, GameEventStorage &ges);
     void sendGameEvent(const GameEventContainer &event);

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_player.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_player.cpp
@@ -1663,3 +1663,9 @@ void Server_AbstractPlayer::getPlayerProperties(ServerInfo_PlayerProperties &res
         playmatParams->set_zoom(playmat.params.zoom);
     }
 }
+
+void Server_AbstractPlayer::setDeck(DeckList *_deck)
+{
+    delete deck;
+    deck = _deck;
+}

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_player.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_player.h
@@ -47,6 +47,7 @@ public:
     {
         return deck;
     }
+    void setDeck(DeckList *_deck);
     bool getReadyStart() const
     {
         return readyStart;

--- a/libcockatrice_network/libcockatrice/network/server/remote/server_room.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/server_room.cpp
@@ -363,6 +363,18 @@ void Server_Room::broadcastGameListUpdate(const ServerInfo_Game &gameInfo, bool 
     sendRoomEvent(prepareRoomEvent(event), sendToIsl);
 }
 
+Server_AbstractUserInterface *Server_Room::getUserInterfaceByName(const QString &name) const
+{
+    usersLock.lockForRead();
+    auto it = users.constFind(name);
+    Server_AbstractUserInterface *result = nullptr;
+    if (it != users.constEnd()) {
+        result = it.value();
+    }
+    usersLock.unlock();
+    return result;
+}
+
 void Server_Room::addGame(Server_Game *game)
 {
     ServerInfo_Room roomInfo;

--- a/libcockatrice_network/libcockatrice/network/server/remote/server_room.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/server_room.h
@@ -135,6 +135,8 @@ public:
     void addGame(Server_Game *game);
     void removeGame(Server_Game *game);
 
+    Server_AbstractUserInterface *getUserInterfaceByName(const QString &name) const;
+
     void sendRoomEvent(RoomEvent *event, bool sendToIsl = true);
     RoomEvent *prepareRoomEvent(const ::google::protobuf::Message &roomEvent);
 };


### PR DESCRIPTION
## What will change with this Pull Request?
- Adds the server-side seams the tournament engine will plug into:

- Dispatch ReportMatchResult / AdvanceTournament / TournamentSettingsSelect in processGameCommand.
-  base implementations return RespContextError so regular games reject them safely

- Server_AbstractPlayer::setDeck lets a backend install a deck into a player slot directly
- Server_Room::getUserInterfaceByName resolves a room user by name for automated game setup

