### PR TITLE
[Client] Show custom zones in the card display widgets

### DIFF
--- a/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
@@ -155,18 +155,6 @@ QWidget *CardGroupDisplayWidget::constructWidgetForIndex(QPersistentModelIndex i
 
 void CardGroupDisplayWidget::updateCardDisplays()
 {
-    // Custom zones are user-defined containers: they display their cards in the same
-    // order as the tree view, i.e. the model row order. Only criteria groups apply
-    // the visual sort criteria.
-    const bool isCustomZone = trackedIndex.data(DeckRoles::IsCustomZoneRole).toBool();
-
-    if (isCustomZone) {
-        for (int i = 0; i < deckListModel->rowCount(trackedIndex); ++i) {
-            addCardWidgets(QPersistentModelIndex(deckListModel->index(i, 0, trackedIndex)));
-        }
-        return;
-    }
-
     DeckListSortFilterProxyModel proxy;
     proxy.setSourceModel(deckListModel);
     proxy.setSortCriteria(activeSortCriteria);

--- a/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
@@ -155,6 +155,18 @@ QWidget *CardGroupDisplayWidget::constructWidgetForIndex(QPersistentModelIndex i
 
 void CardGroupDisplayWidget::updateCardDisplays()
 {
+    // Custom zones are user-defined containers: they display their cards in the same
+    // order as the tree view, i.e. the model row order. Only criteria groups apply
+    // the visual sort criteria.
+    const bool isCustomZone = trackedIndex.data(DeckRoles::IsCustomZoneRole).toBool();
+
+    if (isCustomZone) {
+        for (int i = 0; i < deckListModel->rowCount(trackedIndex); ++i) {
+            addCardWidgets(QPersistentModelIndex(deckListModel->index(i, 0, trackedIndex)));
+        }
+        return;
+    }
+
     DeckListSortFilterProxyModel proxy;
     proxy.setSourceModel(deckListModel);
     proxy.setSortCriteria(activeSortCriteria);
@@ -174,16 +186,18 @@ void CardGroupDisplayWidget::updateCardDisplays()
         QModelIndex sourceIndex = proxy.mapToSource(proxyIndex);
 
         // 4. persist the source index
-        QPersistentModelIndex persistent(sourceIndex);
+        addCardWidgets(QPersistentModelIndex(sourceIndex));
+    }
+}
 
-        // Get the card amount
-        int cardAmount =
-            sourceIndex.sibling(sourceIndex.row(), DeckListModelColumns::CARD_AMOUNT).data(Qt::EditRole).toInt();
+void CardGroupDisplayWidget::addCardWidgets(const QPersistentModelIndex &persistent)
+{
+    // Get the card amount
+    int cardAmount = persistent.sibling(persistent.row(), DeckListModelColumns::CARD_AMOUNT).data(Qt::EditRole).toInt();
 
-        // Create multiple widgets for the card count
-        for (int copy = 0; copy < cardAmount; ++copy) {
-            addToLayout(constructWidgetForIndex(persistent));
-        }
+    // Create multiple widgets for the card count
+    for (int copy = 0; copy < cardAmount; ++copy) {
+        addToLayout(constructWidgetForIndex(persistent));
     }
 }
 

--- a/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.h
+++ b/cockatrice/src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.h
@@ -35,6 +35,7 @@ public:
     void onSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
     void refreshSelectionForIndex(const QPersistentModelIndex &persistent);
     void clearAllDisplayWidgets();
+    void addCardWidgets(const QPersistentModelIndex &persistent);
 
     DeckListModel *deckListModel;
     QItemSelectionModel *selectionModel;

--- a/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.cpp
@@ -5,6 +5,7 @@
 #include "libcockatrice/card/database/card_database_manager.h"
 
 #include <QResizeEvent>
+#include <algorithm>
 #include <libcockatrice/models/deck_list/deck_list_model.h>
 
 DeckCardZoneDisplayWidget::DeckCardZoneDisplayWidget(QWidget *parent,
@@ -51,11 +52,6 @@ DeckCardZoneDisplayWidget::DeckCardZoneDisplayWidget(QWidget *parent,
 //                                                    User Interaction
 // =====================================================================================================================
 
-void DeckCardZoneDisplayWidget::onClick(QMouseEvent *event, const ExactCard &card)
-{
-    emit cardClicked(event, card, zoneName);
-}
-
 void DeckCardZoneDisplayWidget::onHover(const ExactCard &card)
 {
     emit cardHovered(card);
@@ -95,12 +91,18 @@ void DeckCardZoneDisplayWidget::constructAppropriateWidget(QPersistentModelIndex
     }
 
     auto categoryName = index.sibling(index.row(), DeckListModelColumns::CARD_NAME).data(Qt::EditRole).toString();
+    // Cards in a custom zone belong to that zone, not the board zone, so that
+    // increment/decrement/swap actions target the custom zone.
+    const bool isCustomZone = index.data(DeckRoles::IsCustomZoneRole).toBool();
+    const QString effectiveZoneName = isCustomZone ? categoryName : zoneName;
+    const auto routeCardClick = [this, effectiveZoneName](QMouseEvent *event, const ExactCard &card) {
+        emit cardClicked(event, card, effectiveZoneName);
+    };
     if (displayType == DisplayType::Overlap) {
         auto *displayWidget = new OverlappedCardGroupDisplayWidget(
-            cardGroupContainer, deckListModel, selectionModel, index, zoneName, categoryName, activeGroupCriteria,
-            activeSortCriteria, subBannerOpacity, cardSizeWidget);
-        connect(displayWidget, &OverlappedCardGroupDisplayWidget::cardClicked, this,
-                &DeckCardZoneDisplayWidget::onClick);
+            cardGroupContainer, deckListModel, selectionModel, index, effectiveZoneName, categoryName,
+            activeGroupCriteria, activeSortCriteria, subBannerOpacity, cardSizeWidget);
+        connect(displayWidget, &OverlappedCardGroupDisplayWidget::cardClicked, this, routeCardClick);
         connect(displayWidget, &OverlappedCardGroupDisplayWidget::cardHovered, this,
                 &DeckCardZoneDisplayWidget::onHover);
         connect(displayWidget, &CardGroupDisplayWidget::cleanupRequested, this,
@@ -111,9 +113,9 @@ void DeckCardZoneDisplayWidget::constructAppropriateWidget(QPersistentModelIndex
         indexToWidgetMap.insert(index, displayWidget);
     } else if (displayType == DisplayType::Flat) {
         auto *displayWidget = new FlatCardGroupDisplayWidget(cardGroupContainer, deckListModel, selectionModel, index,
-                                                             zoneName, categoryName, activeGroupCriteria,
+                                                             effectiveZoneName, categoryName, activeGroupCriteria,
                                                              activeSortCriteria, subBannerOpacity, cardSizeWidget);
-        connect(displayWidget, &FlatCardGroupDisplayWidget::cardClicked, this, &DeckCardZoneDisplayWidget::onClick);
+        connect(displayWidget, &FlatCardGroupDisplayWidget::cardClicked, this, routeCardClick);
         connect(displayWidget, &FlatCardGroupDisplayWidget::cardHovered, this, &DeckCardZoneDisplayWidget::onHover);
         connect(displayWidget, &CardGroupDisplayWidget::cleanupRequested, this,
                 &DeckCardZoneDisplayWidget::cleanupInvalidCardGroup);
@@ -126,24 +128,22 @@ void DeckCardZoneDisplayWidget::constructAppropriateWidget(QPersistentModelIndex
 
 void DeckCardZoneDisplayWidget::displayCards()
 {
-    QSortFilterProxyModel proxy;
-    proxy.setSourceModel(deckListModel);
-    proxy.setSortRole(Qt::EditRole);
-    proxy.sort(DeckListModelColumns::CARD_NAME, Qt::AscendingOrder);
+    if (!trackedIndex.isValid()) {
+        return;
+    }
 
-    // 1. trackedIndex is a source index → map it to proxy space
-    QModelIndex proxyParent = proxy.mapFromSource(trackedIndex);
+    // Iterate the direct children of the tracked zone, keeping the tree view's row
+    // order (criteria groups first, then custom zones in their creation order).
+    QList<QPersistentModelIndex> rows;
+    for (int i = 0; i < deckListModel->rowCount(trackedIndex); ++i) {
+        rows.append(QPersistentModelIndex(deckListModel->index(i, 0, trackedIndex)));
+    }
 
-    // 2. iterate children under the proxy parent
-    for (int i = 0; i < proxy.rowCount(proxyParent); ++i) {
-        QModelIndex proxyIndex = proxy.index(i, 0, proxyParent);
+    std::stable_partition(rows.begin(), rows.end(), [](const QPersistentModelIndex &row) {
+        return !row.data(DeckRoles::IsCustomZoneRole).toBool();
+    });
 
-        // 3. map back to source
-        QModelIndex sourceIndex = proxy.mapToSource(proxyIndex);
-
-        // 4. persist the source index
-        QPersistentModelIndex persistent(sourceIndex);
-
+    for (const QPersistentModelIndex &persistent : rows) {
         constructAppropriateWidget(persistent);
     }
 }

--- a/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.cpp
@@ -133,15 +133,11 @@ void DeckCardZoneDisplayWidget::displayCards()
     }
 
     // Iterate the direct children of the tracked zone, keeping the tree view's row
-    // order (criteria groups first, then custom zones in their creation order).
+    // order (criteria groups first, then custom zones, both in the model's sort order).
     QList<QPersistentModelIndex> rows;
     for (int i = 0; i < deckListModel->rowCount(trackedIndex); ++i) {
         rows.append(QPersistentModelIndex(deckListModel->index(i, 0, trackedIndex)));
     }
-
-    std::stable_partition(rows.begin(), rows.end(), [](const QPersistentModelIndex &row) {
-        return !row.data(DeckRoles::IsCustomZoneRole).toBool();
-    });
 
     for (const QPersistentModelIndex &persistent : rows) {
         constructAppropriateWidget(persistent);

--- a/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.h
+++ b/cockatrice/src/interface/widgets/cards/deck_card_zone_display_widget.h
@@ -42,7 +42,6 @@ public:
     void addCardsToOverlapWidget();
 
 public slots:
-    void onClick(QMouseEvent *event, const ExactCard &card);
     void onHover(const ExactCard &card);
     void cleanupInvalidCardGroup(CardGroupDisplayWidget *displayWidget);
     void constructAppropriateWidget(QPersistentModelIndex index);


### PR DESCRIPTION
## Related Ticket(s)
- Stacked on custom-zones/b2-editor-zone-menus (#7205)

## What will change with this Pull Request?
- Render custom zones next to the criteria groups in the deck display widgets (`CardGroupDisplayWidget`, `DeckCardZoneDisplayWidget`)
- Apply the visual sort criteria inside custom zones through the same `DeckListSortFilterProxyModel` path as criteria groups — no custom-zone special case
- Treat the model row order as the display order for the top-level zone children (criteria groups first, then custom zones)

## Why
- The visual deck editor should draw user-defined zones, and sorting should behave consistently everywhere instead of silently doing nothing inside a custom zone

## Verified
- Client builds; full ctest 25/25 passes; `format.sh` clean
