### PR TITLE
[Game] Render custom deck zones in the deck view

### DIFF
--- a/cockatrice/src/game_graphics/deckview/deck_view.cpp
+++ b/cockatrice/src/game_graphics/deckview/deck_view.cpp
@@ -8,10 +8,8 @@
 #include <QMouseEvent>
 #include <QtMath>
 #include <algorithm>
-#include <functional>
 #include <libcockatrice/card/card_info.h>
 #include <libcockatrice/deck_list/deck_list.h>
-#include <libcockatrice/deck_list/tree/deck_list_card_node.h>
 #include <libcockatrice/settings/cards_display_settings.h>
 
 DeckViewCardDragItem::DeckViewCardDragItem(DeckViewCard *_item,
@@ -383,24 +381,15 @@ void DeckViewScene::rebuildTree()
         }
 
         // Cards in custom zones nested under a board are regular board cards in-game.
-        // They are collected recursively and reported with the top-level board zone
-        // as their origin, so that sideboard plans keep working.
-        std::function<void(const InnerDecklistNode *)> addZoneCards = [&addZoneCards, container, currentZone,
-                                                                       this](const InnerDecklistNode *zone) {
-            for (int j = 0; j < zone->size(); j++) {
-                auto *currentCard = dynamic_cast<DecklistCardNode *>(zone->at(j));
-                if (currentCard) {
-                    for (int k = 0; k < currentCard->getNumber(); ++k) {
-                        auto *newCard = new DeckViewCard(container, currentCard->toCardRef(), currentZone->getName());
-                        container->addCard(newCard);
-                        emit newCardAdded(newCard);
-                    }
-                } else if (auto *innerZone = dynamic_cast<InnerDecklistNode *>(zone->at(j))) {
-                    addZoneCards(innerZone);
-                }
+        // They are collected recursively (like every other consumer) and reported with
+        // the top-level board zone as their origin, so that sideboard plans keep working.
+        for (auto *currentCard : deck->getCardNodes({currentZone->getName()})) {
+            for (int k = 0; k < currentCard->getNumber(); ++k) {
+                auto *newCard = new DeckViewCard(container, currentCard->toCardRef(), currentZone->getName());
+                container->addCard(newCard);
+                emit newCardAdded(newCard);
             }
-        };
-        addZoneCards(currentZone);
+        }
     }
 }
 

--- a/cockatrice/src/game_graphics/deckview/deck_view.cpp
+++ b/cockatrice/src/game_graphics/deckview/deck_view.cpp
@@ -8,6 +8,7 @@
 #include <QMouseEvent>
 #include <QtMath>
 #include <algorithm>
+#include <functional>
 #include <libcockatrice/card/card_info.h>
 #include <libcockatrice/deck_list/deck_list.h>
 #include <libcockatrice/deck_list/tree/deck_list_card_node.h>
@@ -381,18 +382,25 @@ void DeckViewScene::rebuildTree()
             addItem(container);
         }
 
-        for (int j = 0; j < currentZone->size(); j++) {
-            auto *currentCard = dynamic_cast<DecklistCardNode *>(currentZone->at(j));
-            if (!currentCard) {
-                continue;
+        // Cards in custom zones nested under a board are regular board cards in-game.
+        // They are collected recursively and reported with the top-level board zone
+        // as their origin, so that sideboard plans keep working.
+        std::function<void(const InnerDecklistNode *)> addZoneCards = [&addZoneCards, container, currentZone,
+                                                                       this](const InnerDecklistNode *zone) {
+            for (int j = 0; j < zone->size(); j++) {
+                auto *currentCard = dynamic_cast<DecklistCardNode *>(zone->at(j));
+                if (currentCard) {
+                    for (int k = 0; k < currentCard->getNumber(); ++k) {
+                        auto *newCard = new DeckViewCard(container, currentCard->toCardRef(), currentZone->getName());
+                        container->addCard(newCard);
+                        emit newCardAdded(newCard);
+                    }
+                } else if (auto *innerZone = dynamic_cast<InnerDecklistNode *>(zone->at(j))) {
+                    addZoneCards(innerZone);
+                }
             }
-
-            for (int k = 0; k < currentCard->getNumber(); ++k) {
-                auto *newCard = new DeckViewCard(container, currentCard->toCardRef(), currentZone->getName());
-                container->addCard(newCard);
-                emit newCardAdded(newCard);
-            }
-        }
+        };
+        addZoneCards(currentZone);
     }
 }
 


### PR DESCRIPTION
## Related Ticket(s)
- Stacked on custom-zones/c1-display-widgets (#7206)

## What will change with this Pull Request?
- Render custom deck zones in the in-game deck view
- Collect the zone's cards through the canonical `DeckList::getCardNodes` traversal, so the deck view can't drift from how the server and other consumers resolve custom zones

## Why
- Lets players actually see and interact with custom zones in a live game, with cards recursively collected under their top-level zone so sideboard plans keep working

## Verified
- Client builds; full ctest 25/25 passes; `format.sh` clean
