### PR TITLE
[Client/Server/Protocol] Surface live metrics in the Developer tab

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/tab_developer.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_developer.cpp
@@ -7,11 +7,13 @@
 #include "tab_developer.h"
 
 #include <QDateTime>
+#include <QHBoxLayout>
 #include <QHeaderView>
 #include <QLabel>
 #include <QPushButton>
 #include <QTableWidget>
 #include <QVBoxLayout>
+#include <algorithm>
 #include <libcockatrice/network/client/abstract/abstract_client.h>
 #include <libcockatrice/protocol/pb/command_get_server_stats.pb.h>
 #include <libcockatrice/protocol/pb/response_get_server_stats.pb.h>
@@ -21,12 +23,25 @@ TabDeveloper::TabDeveloper(TabSupervisor *_tabSupervisor, AbstractClient *_clien
     : Tab(_tabSupervisor), client(_client)
 {
     statsTable = new QTableWidget(0, 2);
-    statsTable->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    statsTable->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     statsTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
     statsTable->setSelectionBehavior(QAbstractItemView::SelectRows);
     statsTable->setSelectionMode(QAbstractItemView::SingleSelection);
-    statsTable->horizontalHeader()->setStretchLastSection(true);
     statsTable->verticalHeader()->setVisible(false);
+    statsTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Interactive);
+    statsTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Interactive);
+    statsTable->horizontalHeader()->setStretchLastSection(true);
+
+    commandTable = new QTableWidget(0, 4);
+    commandTable->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    commandTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    commandTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    commandTable->setSelectionMode(QAbstractItemView::SingleSelection);
+    commandTable->verticalHeader()->setVisible(false);
+    commandTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Interactive);
+    commandTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Interactive);
+    commandTable->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Interactive);
+    commandTable->horizontalHeader()->setSectionResizeMode(3, QHeaderView::Interactive);
 
     statusLabel = new QLabel;
 
@@ -38,8 +53,12 @@ TabDeveloper::TabDeveloper(TabSupervisor *_tabSupervisor, AbstractClient *_clien
     buttonLayout->addWidget(statusLabel, 1, Qt::AlignLeft);
     buttonLayout->addWidget(refreshButton, 0, Qt::AlignRight);
 
+    auto *tableLayout = new QHBoxLayout;
+    tableLayout->addWidget(statsTable, 1);
+    tableLayout->addWidget(commandTable, 2);
+
     auto *mainLayout = new QVBoxLayout;
-    mainLayout->addWidget(statsTable);
+    mainLayout->addLayout(tableLayout, 1);
     mainLayout->addLayout(buttonLayout);
 
     auto *central = new QWidget;
@@ -53,6 +72,7 @@ void TabDeveloper::retranslateUi()
 {
     refreshButton->setText(tr("Refresh server stats"));
     statsTable->setHorizontalHeaderLabels(QString(tr("Statistic;Value")).split(";"));
+    commandTable->setHorizontalHeaderLabels(QString(tr("Command;Count;Total ms;Avg ms")).split(";"));
     if (statsTable->rowCount() == 0) {
         statusLabel->clear();
     }
@@ -75,12 +95,33 @@ QString TabDeveloper::formatBytes(quint64 bytes)
     return tr("%1 bytes").arg(bytes);
 }
 
+QString TabDeveloper::formatDurationMs(qint64 ms)
+{
+    if (ms >= 1000) {
+        return tr("%1 s").arg(QString::number(ms / 1000.0, 'f', 2));
+    }
+    return tr("%1 ms").arg(ms);
+}
+
 void TabDeveloper::appendStatRow(const QString &name, const QString &value)
 {
     const int row = statsTable->rowCount();
     statsTable->insertRow(row);
     statsTable->setItem(row, 0, new QTableWidgetItem(name));
     statsTable->setItem(row, 1, new QTableWidgetItem(value));
+}
+
+void TabDeveloper::appendSeparatorRow(const QString &sectionTitle)
+{
+    const int row = statsTable->rowCount();
+    statsTable->insertRow(row);
+    auto *labelItem = new QTableWidgetItem(sectionTitle);
+    auto font = labelItem->font();
+    font.setBold(true);
+    labelItem->setFont(font);
+    labelItem->setFlags(labelItem->flags() & ~Qt::ItemIsSelectable);
+    statsTable->setItem(row, 0, labelItem);
+    statsTable->setItem(row, 1, new QTableWidgetItem(QString()));
 }
 
 void TabDeveloper::refreshClicked()
@@ -101,6 +142,8 @@ void TabDeveloper::serverStatsResponse(const Response &resp)
     const Response_GetServerStats &response = resp.GetExtension(Response_GetServerStats::ext);
 
     statsTable->setRowCount(0);
+
+    // Overview section
     appendStatRow(tr("Registered users online"), QString::number(response.users_count()));
     appendStatRow(tr("Moderators online"), QString::number(response.mods_count()));
     appendStatRow(tr("Games running"), QString::number(response.games_count()));
@@ -117,6 +160,54 @@ void TabDeveloper::serverStatsResponse(const Response &resp)
     const QDateTime snapshotTime = QDateTime::fromSecsSinceEpoch(static_cast<qint64>(response.timest()));
     appendStatRow(tr("Snapshot taken"), snapshotTime.toLocalTime().toString("yyyy-MM-dd HH:mm"));
 
+    // Live metrics section
+    appendSeparatorRow(tr("Live Metrics"));
+    appendStatRow(tr("Cards in live games"), QString::number(response.cards_in_games()));
+    appendStatRow(tr("Total commands processed"), QString::number(response.total_commands()));
+
+    if (response.total_commands() > 0) {
+        const double avgMs = static_cast<double>(response.total_command_time_ms()) / response.total_commands();
+        appendStatRow(tr("Avg command time"), QString::number(avgMs, 'f', 2) + " ms");
+    }
+    appendStatRow(tr("Active command types"), QString::number(response.active_command_types()));
+
+    appendStatRow(tr("Event loop stalls"), QString::number(response.eventloop_stalls_total()));
+    appendStatRow(tr("Last stall overshoot"), formatDurationMs(response.eventloop_last_stall_ms()));
+    appendStatRow(tr("Worst stall overshoot"), formatDurationMs(response.eventloop_max_stall_ms()));
+
+    if (response.game_start_count() > 0) {
+        appendStatRow(tr("Game starts"), QString::number(response.game_start_count()));
+        const double avgStartMs = static_cast<double>(response.game_start_total_ms()) / response.game_start_count();
+        appendStatRow(tr("Avg game start time"), QString::number(avgStartMs, 'f', 1) + " ms");
+    }
+
+    // Per-command breakdown table
+    QList<CommandStats> sortedStats(response.command_stats().begin(), response.command_stats().end());
+    std::sort(sortedStats.begin(), sortedStats.end(),
+              [](const auto &a, const auto &b) { return a.total_ms() > b.total_ms(); });
+
+    commandTable->setRowCount(0);
+    for (const auto &cs : sortedStats) {
+        const int row = commandTable->rowCount();
+        commandTable->insertRow(row);
+        commandTable->setItem(row, 0, new QTableWidgetItem(QString::fromStdString(cs.command_name())));
+
+        auto *countItem = new QTableWidgetItem(QString::number(cs.count()));
+        countItem->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        commandTable->setItem(row, 1, countItem);
+
+        auto *totalItem = new QTableWidgetItem(QString::number(cs.total_ms()));
+        totalItem->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        commandTable->setItem(row, 2, totalItem);
+
+        const double avg = cs.count() > 0 ? static_cast<double>(cs.total_ms()) / cs.count() : 0.0;
+        auto *avgItem = new QTableWidgetItem(QString::number(avg, 'f', 2));
+        avgItem->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        commandTable->setItem(row, 3, avgItem);
+    }
+    commandTable->resizeColumnsToContents();
     statsTable->resizeColumnsToContents();
+    commandTable->resizeColumnsToContents();
+
     statusLabel->setText(tr("Updated %1").arg(QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm")));
 }

--- a/cockatrice/src/interface/widgets/tabs/tab_developer.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_developer.cpp
@@ -6,18 +6,23 @@
 
 #include "tab_developer.h"
 
+#include <QCheckBox>
 #include <QDateTime>
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QLabel>
 #include <QPushButton>
+#include <QSpinBox>
 #include <QTableWidget>
+#include <QTimer>
 #include <QVBoxLayout>
 #include <algorithm>
 #include <libcockatrice/network/client/abstract/abstract_client.h>
 #include <libcockatrice/protocol/pb/command_get_server_stats.pb.h>
 #include <libcockatrice/protocol/pb/response_get_server_stats.pb.h>
 #include <libcockatrice/protocol/pending_command.h>
+
+static constexpr int DEFAULT_AUTO_REFRESH_INTERVAL_SECS = 30;
 
 TabDeveloper::TabDeveloper(TabSupervisor *_tabSupervisor, AbstractClient *_client)
     : Tab(_tabSupervisor), client(_client)
@@ -45,12 +50,28 @@ TabDeveloper::TabDeveloper(TabSupervisor *_tabSupervisor, AbstractClient *_clien
 
     statusLabel = new QLabel;
 
+    autoRefreshCheckBox = new QCheckBox;
+    autoRefreshCheckBox->setChecked(false);
+
+    refreshIntervalSpinBox = new QSpinBox;
+    refreshIntervalSpinBox->setRange(5, 3600);
+    refreshIntervalSpinBox->setValue(DEFAULT_AUTO_REFRESH_INTERVAL_SECS);
+    refreshIntervalSpinBox->setEnabled(false);
+
+    autoRefreshTimer = new QTimer(this);
+    connect(autoRefreshTimer, &QTimer::timeout, this, &TabDeveloper::refreshClicked);
+    connect(autoRefreshCheckBox, &QCheckBox::toggled, this, &TabDeveloper::autoRefreshToggled);
+    connect(refreshIntervalSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), this,
+            &TabDeveloper::refreshIntervalChanged);
+
     refreshButton = new QPushButton;
     refreshButton->setAutoDefault(true);
     connect(refreshButton, &QPushButton::clicked, this, &TabDeveloper::refreshClicked);
 
     auto *buttonLayout = new QHBoxLayout;
     buttonLayout->addWidget(statusLabel, 1, Qt::AlignLeft);
+    buttonLayout->addWidget(autoRefreshCheckBox, 0, Qt::AlignRight);
+    buttonLayout->addWidget(refreshIntervalSpinBox, 0, Qt::AlignRight);
     buttonLayout->addWidget(refreshButton, 0, Qt::AlignRight);
 
     auto *tableLayout = new QHBoxLayout;
@@ -70,6 +91,10 @@ TabDeveloper::TabDeveloper(TabSupervisor *_tabSupervisor, AbstractClient *_clien
 
 void TabDeveloper::retranslateUi()
 {
+    autoRefreshCheckBox->setText(tr("Auto-refresh"));
+    autoRefreshCheckBox->setToolTip(tr("Automatically request fresh server statistics at a fixed interval."));
+    refreshIntervalSpinBox->setSuffix(tr(" s"));
+    refreshIntervalSpinBox->setToolTip(tr("Seconds between automatic refreshes."));
     refreshButton->setText(tr("Refresh server stats"));
     statsTable->setHorizontalHeaderLabels(QString(tr("Statistic;Value")).split(";"));
     commandTable->setHorizontalHeaderLabels(QString(tr("Command;Count;Total ms;Avg ms")).split(";"));
@@ -126,14 +151,37 @@ void TabDeveloper::appendSeparatorRow(const QString &sectionTitle)
 
 void TabDeveloper::refreshClicked()
 {
+    if (requestPending) {
+        return;
+    }
+    requestPending = true;
     Command_GetServerStats cmd;
     PendingCommand *pend = client->prepareDeveloperCommand(cmd);
     connect(pend, &PendingCommand::finished, this, &TabDeveloper::serverStatsResponse);
     client->sendCommand(pend);
 }
 
+void TabDeveloper::autoRefreshToggled(bool checked)
+{
+    refreshIntervalSpinBox->setEnabled(checked);
+    if (checked) {
+        refreshIntervalChanged();
+        refreshClicked();
+    } else {
+        autoRefreshTimer->stop();
+    }
+}
+
+void TabDeveloper::refreshIntervalChanged()
+{
+    if (autoRefreshCheckBox->isChecked()) {
+        autoRefreshTimer->start(refreshIntervalSpinBox->value() * 1000);
+    }
+}
+
 void TabDeveloper::serverStatsResponse(const Response &resp)
 {
+    requestPending = false;
     if (resp.response_code() != Response::RespOk) {
         statusLabel->setText(tr("No server statistics available yet."));
         return;

--- a/cockatrice/src/interface/widgets/tabs/tab_developer.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_developer.h
@@ -21,11 +21,14 @@ class TabDeveloper : public Tab
 private:
     AbstractClient *client;
     QTableWidget *statsTable;
+    QTableWidget *commandTable;
     QPushButton *refreshButton;
     QLabel *statusLabel;
 
     void appendStatRow(const QString &name, const QString &value);
+    void appendSeparatorRow(const QString &sectionTitle);
     static QString formatBytes(quint64 bytes);
+    static QString formatDurationMs(qint64 ms);
 
 private slots:
     void refreshClicked();

--- a/cockatrice/src/interface/widgets/tabs/tab_developer.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_developer.h
@@ -10,9 +10,12 @@
 #include "tab.h"
 
 class AbstractClient;
+class QCheckBox;
 class QLabel;
 class QPushButton;
+class QSpinBox;
 class QTableWidget;
+class QTimer;
 class Response;
 
 class TabDeveloper : public Tab
@@ -24,6 +27,10 @@ private:
     QTableWidget *commandTable;
     QPushButton *refreshButton;
     QLabel *statusLabel;
+    QCheckBox *autoRefreshCheckBox;
+    QSpinBox *refreshIntervalSpinBox;
+    QTimer *autoRefreshTimer;
+    bool requestPending = false;
 
     void appendStatRow(const QString &name, const QString &value);
     void appendSeparatorRow(const QString &sectionTitle);
@@ -33,6 +40,8 @@ private:
 private slots:
     void refreshClicked();
     void serverStatsResponse(const Response &resp);
+    void autoRefreshToggled(bool checked);
+    void refreshIntervalChanged();
 
 public:
     explicit TabDeveloper(TabSupervisor *_tabSupervisor, AbstractClient *_client);

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_player.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_player.cpp
@@ -66,6 +66,15 @@ Server_AbstractPlayer::Server_AbstractPlayer(Server_Game *_game,
 
 Server_AbstractPlayer::~Server_AbstractPlayer() = default;
 
+int Server_AbstractPlayer::getCardCount() const
+{
+    int result = 0;
+    for (auto *zone : zones) {
+        result += zone->getCards().size();
+    }
+    return result;
+}
+
 void Server_AbstractPlayer::prepareDestroy()
 {
     delete deck;

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_player.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_abstract_player.h
@@ -43,6 +43,8 @@ public:
                           Server_AbstractUserInterface *_handler);
     ~Server_AbstractPlayer() override;
     void prepareDestroy() override;
+    /// Total cards across all of this player's zones. The caller must hold the game's mutex.
+    int getCardCount() const;
     const DeckList *getDeckList() const
     {
         return deck;

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.cpp
@@ -32,6 +32,7 @@
 #include "server_spectator.h"
 
 #include <QDebug>
+#include <QElapsedTimer>
 #include <QRegularExpression>
 #include <QTimer>
 #include <google/protobuf/descriptor.h>
@@ -238,6 +239,17 @@ int Server_Game::getPlayerCount() const
     return participants.size() - getSpectatorCount();
 }
 
+int Server_Game::getCardsInGame() const
+{
+    QMutexLocker locker(&gameMutex);
+
+    int result = 0;
+    for (auto *player : getPlayers()) {
+        result += player->getCardCount();
+    }
+    return result;
+}
+
 int Server_Game::getSpectatorCount() const
 {
     QMutexLocker locker(&gameMutex);
@@ -330,6 +342,9 @@ void Server_Game::doStartGameIfReady(bool forceStartGame)
         }
     }
 
+    // Only actual starts are timed. The early returns above are no-ops.
+    QElapsedTimer startupTimer;
+    startupTimer.start();
     players = getPlayers(); // players could have been kicked, get new list of players
     if (lifecycleStrategy->onGameStarting(this) == Server_GameLifecycleStrategy::StartAction::Handled) {
         locker.unlock();
@@ -373,6 +388,7 @@ void Server_Game::doStartGameIfReady(bool forceStartGame)
 
     activePlayer = -1;
     nextTurn();
+    room->getServer()->observeGameStartDurationMs(startupTimer.nsecsElapsed() / 1000000);
 
     locker.unlock();
 

--- a/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/game/server_game.h
@@ -123,6 +123,8 @@ public:
         return gameStarted;
     }
     int getPlayerCount() const;
+    /// Total cards across all players' zones. Takes gameMutex itself.
+    int getCardsInGame() const;
     int getSpectatorCount() const;
     QMap<int, Server_AbstractPlayer *> getPlayers() const;
     Server_AbstractPlayer *getPlayer(int id) const;

--- a/libcockatrice_network/libcockatrice/network/server/remote/server.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/server.h
@@ -180,6 +180,11 @@ public:
     {
         return false;
     }
+    /// Called once per actual game start with how long bringing every player's
+    /// zones online took, so servers can spot deck sizes that wedge threads.
+    virtual void observeGameStartDurationMs(qint64 /* elapsedMs */)
+    {
+    }
 
     Server_DatabaseInterface *getDatabaseInterface() const;
     int getNextLocalGameId()

--- a/libcockatrice_network/libcockatrice/network/server/remote/server_protocolhandler.h
+++ b/libcockatrice_network/libcockatrice/network/server/remote/server_protocolhandler.h
@@ -136,7 +136,7 @@ public:
         return timeRunning - lastDataReceived;
     }
     bool addSaidMessageSize(int size);
-    void processCommandContainer(const CommandContainer &cont);
+    virtual void processCommandContainer(const CommandContainer &cont);
 
     void sendProtocolItem(const Response &item);
     void sendProtocolItem(const SessionEvent &item);

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/response_get_server_stats.proto
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/response_get_server_stats.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 import "response.proto";
 
 message CommandStats {
-    optional uint32 kind_index = 1;       // 0=session, 1=room, 2=game, 3=moderator, 4=admin
+    optional uint32 kind_index = 1;       // 0=session, 1=room, 2=game, 3=moderator, 4=admin, 5=developer
     optional uint32 extension_number = 2; // protobuf extension number within the kind
     optional string command_name = 3;     // e.g. "session/Command_Ping"
     optional uint64 count = 4;            // number of times observed

--- a/libcockatrice_protocol/libcockatrice/protocol/pb/response_get_server_stats.proto
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/response_get_server_stats.proto
@@ -1,6 +1,14 @@
 syntax = "proto2";
 import "response.proto";
 
+message CommandStats {
+    optional uint32 kind_index = 1;       // 0=session, 1=room, 2=game, 3=moderator, 4=admin
+    optional uint32 extension_number = 2; // protobuf extension number within the kind
+    optional string command_name = 3;     // e.g. "session/Command_Ping"
+    optional uint64 count = 4;            // number of times observed
+    optional uint64 total_ms = 5;         // cumulative processing milliseconds
+}
+
 message Response_GetServerStats {
     extend Response {
         optional Response_GetServerStats ext = 1220;
@@ -16,4 +24,18 @@ message Response_GetServerStats {
 
     optional uint64 uptime_secs = 6;
     optional uint64 timest = 7; // unix timestamp of the snapshot
+
+    // Live metrics from MetricsRegistry (reset on server restart)
+    optional uint64 cards_in_games = 8;
+    optional uint64 eventloop_stalls_total = 9;
+    optional uint64 eventloop_last_stall_ms = 10;
+    optional uint64 eventloop_max_stall_ms = 11;
+    optional uint64 total_commands = 12;
+    optional uint64 total_command_time_ms = 13;
+    optional int32 active_command_types = 14;
+    optional uint64 game_start_count = 15;
+    optional uint64 game_start_total_ms = 16;
+
+    // Per-command breakdown (only types with count > 0)
+    repeated CommandStats command_stats = 20;
 }

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -110,7 +110,7 @@ bool OracleImporter::readSetsFromByteArray(QByteArray data)
  * A lower index means a higher priority.
  */
 static const QStringList MAIN_CARD_TYPE_PRIORITY = {"Planeswalker", "Creature", "Land",       "Sorcery",
-                                                     "Instant",      "Artifact", "Enchantment"};
+                                                    "Instant",      "Artifact", "Enchantment"};
 
 /**
  * Returns the priority (index) of the given main card type. Known types map to their

--- a/servatrice/CMakeLists.txt
+++ b/servatrice/CMakeLists.txt
@@ -6,7 +6,9 @@ project(Servatrice VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${
 
 set(servatrice_SOURCES
     src/email_parser.cpp
+    src/event_loop_watchdog.cpp
     src/main.cpp
+    src/metrics_registry.cpp
     src/servatrice.cpp
     src/servatrice_connection_pool.cpp
     src/servatrice_database_interface.cpp

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -384,7 +384,9 @@ max_comments_per_hour=30
 
 [metrics]
 ; Command containers that take longer than this many milliseconds are logged
-; as slow commands. Set to 0 to disable the log line.
+; as slow commands. Set to 0 to disable the log line. A latency spike produces
+; one warning per slow container with no rate limiting of its own -- a bad
+; patch can briefly flood the log, which is how you notice it.
 slow_command_ms=500
 
 ; Each socket pool thread runs a watchdog heartbeat. If a heartbeat arrives

--- a/servatrice/servatrice.ini.example
+++ b/servatrice/servatrice.ini.example
@@ -382,6 +382,17 @@ max_reports_per_day=10
 ; Maximum number of report comments a single user can post per hour; default is 30; set to 0 to disable the limit
 max_comments_per_hour=30
 
+[metrics]
+; Command containers that take longer than this many milliseconds are logged
+; as slow commands. Set to 0 to disable the log line.
+slow_command_ms=500
+
+; Each socket pool thread runs a watchdog heartbeat. If a heartbeat arrives
+; this many milliseconds late, the stall is logged and exposed as
+; servatrice_eventloop_* metrics in the Developer tab. Set to 0 to disable
+; the watchdogs.
+stall_warn_ms=2000
+
 [logging]
 ; Admin/Moderators can query the stored logs for information when looking up reports by various players. This
 ; option can allow or disallow them from doing so.

--- a/servatrice/src/event_loop_watchdog.cpp
+++ b/servatrice/src/event_loop_watchdog.cpp
@@ -1,0 +1,34 @@
+/**
+ * @file event_loop_watchdog.cpp
+ * @ingroup Servatrice
+ */
+
+#include "event_loop_watchdog.h"
+
+#include "servatrice.h"
+
+#include <QTimer>
+
+EventLoopWatchdog::EventLoopWatchdog(Servatrice *_servatrice, QString _threadName)
+    : QObject(nullptr), servatrice(_servatrice), threadName(std::move(_threadName))
+{
+}
+
+void EventLoopWatchdog::start()
+{
+    heartbeatTimer = new QTimer(this);
+    sinceLastTick.start();
+    connect(heartbeatTimer, &QTimer::timeout, this, &EventLoopWatchdog::checkHeartbeat);
+    heartbeatTimer->start(HeartbeatIntervalMs);
+}
+
+void EventLoopWatchdog::checkHeartbeat()
+{
+    const qint64 elapsedMs = sinceLastTick.restart();
+    const qint64 overshootMs = qMax<qint64>(0, elapsedMs - HeartbeatIntervalMs);
+    if (overshootMs < servatrice->getMetricsStallWarnMs()) {
+        return;
+    }
+
+    servatrice->observeEventLoopStall(threadName, overshootMs);
+}

--- a/servatrice/src/event_loop_watchdog.h
+++ b/servatrice/src/event_loop_watchdog.h
@@ -1,0 +1,50 @@
+/**
+ * @file event_loop_watchdog.h
+ * @ingroup Servatrice
+ */
+
+#ifndef EVENT_LOOP_WATCHDOG_H
+#define EVENT_LOOP_WATCHDOG_H
+
+#include <QElapsedTimer>
+#include <QObject>
+#include <QString>
+
+class Servatrice;
+class QTimer;
+
+/**
+ * @brief Detects blocked or overloaded worker event loops.
+ *
+ * One instance lives in each socket pool thread. A heartbeat timer tick that
+ * arrives late means the loop spent that time elsewhere: busy work, a queued
+ * slot, or a hard wedge. Overshoots past the configured threshold bump
+ * lock-free counters on the metrics registry and log one warning per stall,
+ * so a stuck pool thread becomes visible instead of silent lag.
+ */
+class EventLoopWatchdog : public QObject
+{
+    Q_OBJECT
+public:
+    /// How often the heartbeat expects to fire. Small enough to catch short stalls.
+    static constexpr int HeartbeatIntervalMs = 500;
+
+    EventLoopWatchdog(Servatrice *_servatrice, QString _threadName);
+
+    /**
+     * Starts the heartbeat timer. Must be invoked queued after the instance
+     * was moved to its target thread so the timer lives there too.
+     */
+    void start();
+
+private slots:
+    void checkHeartbeat();
+
+private:
+    Servatrice *servatrice;
+    QString threadName;
+    QElapsedTimer sinceLastTick;
+    QTimer *heartbeatTimer = nullptr;
+};
+
+#endif

--- a/servatrice/src/metrics_registry.cpp
+++ b/servatrice/src/metrics_registry.cpp
@@ -2,33 +2,6 @@
 
 #include <QList>
 
-int MetricsRegistry::bucketIndexFor(qint64 elapsedMs)
-{
-    const int lastFiniteBucket = static_cast<int>(BucketBounds.size()) - 1;
-    int bucket = 0;
-    while (bucket < lastFiniteBucket && elapsedMs > BucketBounds[static_cast<size_t>(bucket)]) {
-        ++bucket;
-    }
-    return bucket;
-}
-
-void MetricsRegistry::appendCumulativeBuckets(QString &out,
-                                              const QString &bucketLine,
-                                              const std::array<std::atomic<qint64>, BucketCount> &buckets)
-{
-    // Cumulative buckets are required by the Prometheus histogram convention.
-    qint64 cumulative = 0;
-    for (int bucket = 0; bucket < static_cast<int>(BucketBounds.size()); ++bucket) {
-        cumulative += buckets[static_cast<size_t>(bucket)].load(std::memory_order_relaxed);
-        out += QStringLiteral("%1,le=\"%2\"} %3\n")
-                   .arg(bucketLine)
-                   .arg(BucketBounds[static_cast<size_t>(bucket)])
-                   .arg(cumulative);
-    }
-    cumulative += buckets[BucketCount - 1].load(std::memory_order_relaxed);
-    out += QStringLiteral("%1,le=\"+Inf\"} %2\n").arg(bucketLine).arg(cumulative);
-}
-
 void MetricsRegistry::observeCommand(int typeId, qint64 elapsedMs)
 {
     if (typeId < 0 || typeId >= MaxTypes) {
@@ -43,7 +16,6 @@ void MetricsRegistry::observeCommand(int typeId, qint64 elapsedMs)
     stats.totalMs.fetch_add(elapsedMs, std::memory_order_relaxed);
     totalCommandsCounter.fetch_add(1, std::memory_order_relaxed);
     totalTimeCounter.fetch_add(elapsedMs, std::memory_order_relaxed);
-    stats.buckets[static_cast<size_t>(bucketIndexFor(elapsedMs))].fetch_add(1, std::memory_order_relaxed);
 }
 
 void MetricsRegistry::observeGameStartDurationMs(qint64 elapsedMs)
@@ -54,7 +26,6 @@ void MetricsRegistry::observeGameStartDurationMs(qint64 elapsedMs)
 
     gameStartStats.count.fetch_add(1, std::memory_order_relaxed);
     gameStartStats.totalMs.fetch_add(elapsedMs, std::memory_order_relaxed);
-    gameStartStats.buckets[static_cast<size_t>(bucketIndexFor(elapsedMs))].fetch_add(1, std::memory_order_relaxed);
 }
 
 MetricsRegistry::TypeStats &MetricsRegistry::slotFor(int typeId)
@@ -76,49 +47,6 @@ int MetricsRegistry::activeTypeCount() const
         }
     }
     return active;
-}
-
-QString MetricsRegistry::toPrometheusText(const std::function<QString(int)> &nameForType,
-                                          const QHash<QString, qint64> &gauges) const
-{
-    QString out;
-    out.reserve(4096);
-
-    for (auto it = gauges.constBegin(); it != gauges.constEnd(); ++it) {
-        out += QStringLiteral("# TYPE %1 gauge\n").arg(it.key());
-        out += QStringLiteral("%1 %2\n").arg(it.key()).arg(it.value());
-    }
-
-    // Cumulative buckets are required by the Prometheus histogram convention.
-    out += QLatin1String("# TYPE servatrice_commands_duration_ms histogram\n");
-
-    for (int type = 0; type < MaxTypes; ++type) {
-        const TypeStats &stats = slotFor(type);
-        const qint64 count = stats.count.load(std::memory_order_relaxed);
-        if (count == 0) {
-            continue;
-        }
-
-        const QString label = nameForType ? nameForType(type) : QString::number(type);
-        appendCumulativeBuckets(out, QStringLiteral("servatrice_commands_duration_ms_bucket{command=\"%1\"").arg(label),
-                                stats.buckets);
-
-        out += QStringLiteral("servatrice_commands_duration_ms_sum{command=\"%1\"} %2\n")
-                   .arg(label)
-                   .arg(stats.totalMs.load(std::memory_order_relaxed));
-        out += QStringLiteral("servatrice_commands_duration_ms_count{command=\"%1\"} %2\n").arg(label).arg(count);
-    }
-
-    const qint64 startCount = gameStartStats.count.load(std::memory_order_relaxed);
-    if (startCount > 0) {
-        out += QLatin1String("# TYPE servatrice_game_start_duration_ms histogram\n");
-        appendCumulativeBuckets(out, QLatin1String("servatrice_game_start_duration_ms_bucket"), gameStartStats.buckets);
-        out += QStringLiteral("servatrice_game_start_duration_ms_sum %1\n")
-                   .arg(gameStartStats.totalMs.load(std::memory_order_relaxed));
-        out += QStringLiteral("servatrice_game_start_duration_ms_count %1\n").arg(startCount);
-    }
-
-    return out;
 }
 
 QList<MetricsRegistry::ActiveTypeStats> MetricsRegistry::collectActiveStats() const

--- a/servatrice/src/metrics_registry.cpp
+++ b/servatrice/src/metrics_registry.cpp
@@ -1,0 +1,142 @@
+#include "metrics_registry.h"
+
+#include <QList>
+
+int MetricsRegistry::bucketIndexFor(qint64 elapsedMs)
+{
+    const int lastFiniteBucket = static_cast<int>(BucketBounds.size()) - 1;
+    int bucket = 0;
+    while (bucket < lastFiniteBucket && elapsedMs > BucketBounds[static_cast<size_t>(bucket)]) {
+        ++bucket;
+    }
+    return bucket;
+}
+
+void MetricsRegistry::appendCumulativeBuckets(QString &out,
+                                              const QString &bucketLine,
+                                              const std::array<std::atomic<qint64>, BucketCount> &buckets)
+{
+    // Cumulative buckets are required by the Prometheus histogram convention.
+    qint64 cumulative = 0;
+    for (int bucket = 0; bucket < static_cast<int>(BucketBounds.size()); ++bucket) {
+        cumulative += buckets[static_cast<size_t>(bucket)].load(std::memory_order_relaxed);
+        out += QStringLiteral("%1,le=\"%2\"} %3\n")
+                   .arg(bucketLine)
+                   .arg(BucketBounds[static_cast<size_t>(bucket)])
+                   .arg(cumulative);
+    }
+    cumulative += buckets[BucketCount - 1].load(std::memory_order_relaxed);
+    out += QStringLiteral("%1,le=\"+Inf\"} %2\n").arg(bucketLine).arg(cumulative);
+}
+
+void MetricsRegistry::observeCommand(int typeId, qint64 elapsedMs)
+{
+    if (typeId < 0 || typeId >= MaxTypes) {
+        typeId = MaxTypes - 1; // overflow slot keeps misrouted ids visible
+    }
+    if (elapsedMs < 0) {
+        elapsedMs = 0;
+    }
+
+    TypeStats &stats = slotFor(typeId);
+    stats.count.fetch_add(1, std::memory_order_relaxed);
+    stats.totalMs.fetch_add(elapsedMs, std::memory_order_relaxed);
+    totalCommandsCounter.fetch_add(1, std::memory_order_relaxed);
+    totalTimeCounter.fetch_add(elapsedMs, std::memory_order_relaxed);
+    stats.buckets[static_cast<size_t>(bucketIndexFor(elapsedMs))].fetch_add(1, std::memory_order_relaxed);
+}
+
+void MetricsRegistry::observeGameStartDurationMs(qint64 elapsedMs)
+{
+    if (elapsedMs < 0) {
+        elapsedMs = 0;
+    }
+
+    gameStartStats.count.fetch_add(1, std::memory_order_relaxed);
+    gameStartStats.totalMs.fetch_add(elapsedMs, std::memory_order_relaxed);
+    gameStartStats.buckets[static_cast<size_t>(bucketIndexFor(elapsedMs))].fetch_add(1, std::memory_order_relaxed);
+}
+
+MetricsRegistry::TypeStats &MetricsRegistry::slotFor(int typeId)
+{
+    return typeSlots[static_cast<size_t>(typeId)];
+}
+
+const MetricsRegistry::TypeStats &MetricsRegistry::slotFor(int typeId) const
+{
+    return typeSlots[static_cast<size_t>(typeId)];
+}
+
+int MetricsRegistry::activeTypeCount() const
+{
+    int active = 0;
+    for (int type = 0; type < MaxTypes; ++type) {
+        if (slotFor(type).count.load(std::memory_order_relaxed) > 0) {
+            ++active;
+        }
+    }
+    return active;
+}
+
+QString MetricsRegistry::toPrometheusText(const std::function<QString(int)> &nameForType,
+                                          const QHash<QString, qint64> &gauges) const
+{
+    QString out;
+    out.reserve(4096);
+
+    for (auto it = gauges.constBegin(); it != gauges.constEnd(); ++it) {
+        out += QStringLiteral("# TYPE %1 gauge\n").arg(it.key());
+        out += QStringLiteral("%1 %2\n").arg(it.key()).arg(it.value());
+    }
+
+    // Cumulative buckets are required by the Prometheus histogram convention.
+    out += QLatin1String("# TYPE servatrice_commands_duration_ms histogram\n");
+
+    for (int type = 0; type < MaxTypes; ++type) {
+        const TypeStats &stats = slotFor(type);
+        const qint64 count = stats.count.load(std::memory_order_relaxed);
+        if (count == 0) {
+            continue;
+        }
+
+        const QString label = nameForType ? nameForType(type) : QString::number(type);
+        appendCumulativeBuckets(out, QStringLiteral("servatrice_commands_duration_ms_bucket{command=\"%1\"").arg(label),
+                                stats.buckets);
+
+        out += QStringLiteral("servatrice_commands_duration_ms_sum{command=\"%1\"} %2\n")
+                   .arg(label)
+                   .arg(stats.totalMs.load(std::memory_order_relaxed));
+        out += QStringLiteral("servatrice_commands_duration_ms_count{command=\"%1\"} %2\n").arg(label).arg(count);
+    }
+
+    const qint64 startCount = gameStartStats.count.load(std::memory_order_relaxed);
+    if (startCount > 0) {
+        out += QLatin1String("# TYPE servatrice_game_start_duration_ms histogram\n");
+        appendCumulativeBuckets(out, QLatin1String("servatrice_game_start_duration_ms_bucket"), gameStartStats.buckets);
+        out += QStringLiteral("servatrice_game_start_duration_ms_sum %1\n")
+                   .arg(gameStartStats.totalMs.load(std::memory_order_relaxed));
+        out += QStringLiteral("servatrice_game_start_duration_ms_count %1\n").arg(startCount);
+    }
+
+    return out;
+}
+
+QList<MetricsRegistry::ActiveTypeStats> MetricsRegistry::collectActiveStats() const
+{
+    QList<ActiveTypeStats> result;
+    for (int type = 0; type < MaxTypes; ++type) {
+        const TypeStats &stats = slotFor(type);
+        const qint64 count = stats.count.load(std::memory_order_relaxed);
+        if (count == 0) {
+            continue;
+        }
+        result.append({type, count, stats.totalMs.load(std::memory_order_relaxed)});
+    }
+    return result;
+}
+
+MetricsRegistry::GameStartSnapshot MetricsRegistry::getGameStartSnapshot() const
+{
+    return {gameStartStats.count.load(std::memory_order_relaxed),
+            gameStartStats.totalMs.load(std::memory_order_relaxed)};
+}

--- a/servatrice/src/metrics_registry.h
+++ b/servatrice/src/metrics_registry.h
@@ -6,11 +6,10 @@
 #ifndef METRICS_REGISTRY_H
 #define METRICS_REGISTRY_H
 
-#include <QHash>
+#include <QList>
 #include <QString>
 #include <array>
 #include <atomic>
-#include <functional>
 
 /**
  * @brief Lock-free accumulation of command processing statistics.
@@ -22,6 +21,10 @@
  *
  * Reading happens rarely (metrics scraping), accepts momentary tears between
  * related counters, and therefore also needs no synchronization.
+ *
+ * Only counts and totals are retained. An earlier Prometheus-style cumulative
+ * histogram (per-type, time-bucketed) was cut because nothing in the server
+ * ever wrote it out; it belongs to the future /metrics exporter that needs it.
  */
 class MetricsRegistry
 {
@@ -29,20 +32,23 @@ public:
     /**
      * Extension numbers are only unique per command kind, so recorded ids
      * combine the kind index with the protobuf extension number.
+     *
+     * The stride is only as wide as it needs to be: 1280 is the first round
+     * number above the largest extension actually in use (ModeratorCommand =
+     * 1206) and keeps the preallocated TypeStats array small. Bump it if a new
+     * command exceeds it.
      */
-    static constexpr int KindStride = 2048;
+    static constexpr int KindStride = 1280;
 
-    static constexpr int NumKinds = 5;
+    static constexpr int NumKinds = 6;
 
-    static constexpr const char *KindNames[NumKinds] = {"session", "room", "game", "moderator", "admin"};
+    static constexpr const char *KindNames[NumKinds] = {"session", "room", "game", "moderator", "admin", "developer"};
 
     /// Upper bound on distinct command type ids (see typeIdFor).
     static constexpr int MaxTypes = NumKinds * KindStride;
 
-    /// Histogram bucket upper bounds in milliseconds. Anything above the last
-    /// bound lands in the trailing +Inf bucket. Constexpr so the recording
-    /// hot path never allocates.
-    static constexpr std::array<qint64, 11> BucketBounds{1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000};
+    /// Guard against typeIdFor() overflowing into the neighbouring kind's slots.
+    static_assert(KindStride > 1206, "KindStride must exceed the highest command extension number in use");
 
     static int typeIdFor(int kindIndex, int extensionNumber)
     {
@@ -82,8 +88,8 @@ public:
 
     /**
      * Returns stats for every type slot that has seen at least one sample.
-     * The caller-provided @p labelForType maps a numeric type id to a stable
-     * human-readable label. Pass nullptr to skip label resolution.
+     * Callers resolve the numeric type id to a human-readable label via
+     * typeIdFor()/KindNames as needed.
      */
     QList<ActiveTypeStats> collectActiveStats() const;
 
@@ -95,36 +101,15 @@ public:
 
     GameStartSnapshot getGameStartSnapshot() const;
 
-    /**
-     * @brief Renders all recorded data in Prometheus text exposition format.
-     *
-     * @param nameForType maps a numeric command type id to a stable label
-     * value. Ids without a mapping are rendered as their number.
-     * @param gauges simple name/value pairs emitted as gauge samples.
-     */
-    QString toPrometheusText(const std::function<QString(int)> &nameForType,
-                             const QHash<QString, qint64> &gauges) const;
-
 private:
-    static constexpr int BucketCount = static_cast<int>(BucketBounds.size()) + 1; ///< bounds + the +Inf bucket
-
     struct TypeStats
     {
         std::atomic<qint64> count{0};
         std::atomic<qint64> totalMs{0};
-        std::array<std::atomic<qint64>, BucketCount> buckets{};
     };
 
     TypeStats &slotFor(int typeId);
     const TypeStats &slotFor(int typeId) const;
-
-    /// Index of the histogram bucket the sample falls into. The last index is +Inf.
-    static int bucketIndexFor(qint64 elapsedMs);
-
-    /// Appends one series of cumulative +Inf-terminated buckets to @p out.
-    static void appendCumulativeBuckets(QString &out,
-                                        const QString &bucketLine,
-                                        const std::array<std::atomic<qint64>, BucketCount> &buckets);
 
     std::array<TypeStats, MaxTypes> typeSlots{};
     TypeStats gameStartStats{};

--- a/servatrice/src/metrics_registry.h
+++ b/servatrice/src/metrics_registry.h
@@ -1,0 +1,135 @@
+/**
+ * @file metrics_registry.h
+ * @ingroup Servatrice
+ */
+
+#ifndef METRICS_REGISTRY_H
+#define METRICS_REGISTRY_H
+
+#include <QHash>
+#include <QString>
+#include <array>
+#include <atomic>
+#include <functional>
+
+/**
+ * @brief Lock-free accumulation of command processing statistics.
+ *
+ * observeCommand() is called once per processed command from whichever socket
+ * thread handled it. It uses relaxed atomic adds on preallocated storage only,
+ * so it introduces no locks, allocations, or shared cache-line ping-pong
+ * beyond the unavoidable counter updates.
+ *
+ * Reading happens rarely (metrics scraping), accepts momentary tears between
+ * related counters, and therefore also needs no synchronization.
+ */
+class MetricsRegistry
+{
+public:
+    /**
+     * Extension numbers are only unique per command kind, so recorded ids
+     * combine the kind index with the protobuf extension number.
+     */
+    static constexpr int KindStride = 2048;
+
+    static constexpr int NumKinds = 5;
+
+    static constexpr const char *KindNames[NumKinds] = {"session", "room", "game", "moderator", "admin"};
+
+    /// Upper bound on distinct command type ids (see typeIdFor).
+    static constexpr int MaxTypes = NumKinds * KindStride;
+
+    /// Histogram bucket upper bounds in milliseconds. Anything above the last
+    /// bound lands in the trailing +Inf bucket. Constexpr so the recording
+    /// hot path never allocates.
+    static constexpr std::array<qint64, 11> BucketBounds{1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000};
+
+    static int typeIdFor(int kindIndex, int extensionNumber)
+    {
+        return kindIndex * KindStride + extensionNumber;
+    }
+
+    void observeCommand(int typeId, qint64 elapsedMs);
+
+    /**
+     * Records how long one game start took to bring every player's zones
+     * online. Kept separate from command timings because it is triggered by
+     * the server itself and can dwarf any single command when decks are huge.
+     */
+    void observeGameStartDurationMs(qint64 elapsedMs);
+
+    /// Total number of observed commands across all types.
+    qint64 totalCommands() const
+    {
+        return totalCommandsCounter.load(std::memory_order_relaxed);
+    }
+
+    /// Cumulative processing milliseconds across all types.
+    qint64 totalTimeMs() const
+    {
+        return totalTimeCounter.load(std::memory_order_relaxed);
+    }
+
+    /// Number of distinct type slots that have seen at least one sample.
+    int activeTypeCount() const;
+
+    struct ActiveTypeStats
+    {
+        int typeId;
+        qint64 count;
+        qint64 totalMs;
+    };
+
+    /**
+     * Returns stats for every type slot that has seen at least one sample.
+     * The caller-provided @p labelForType maps a numeric type id to a stable
+     * human-readable label. Pass nullptr to skip label resolution.
+     */
+    QList<ActiveTypeStats> collectActiveStats() const;
+
+    struct GameStartSnapshot
+    {
+        qint64 count;
+        qint64 totalMs;
+    };
+
+    GameStartSnapshot getGameStartSnapshot() const;
+
+    /**
+     * @brief Renders all recorded data in Prometheus text exposition format.
+     *
+     * @param nameForType maps a numeric command type id to a stable label
+     * value. Ids without a mapping are rendered as their number.
+     * @param gauges simple name/value pairs emitted as gauge samples.
+     */
+    QString toPrometheusText(const std::function<QString(int)> &nameForType,
+                             const QHash<QString, qint64> &gauges) const;
+
+private:
+    static constexpr int BucketCount = static_cast<int>(BucketBounds.size()) + 1; ///< bounds + the +Inf bucket
+
+    struct TypeStats
+    {
+        std::atomic<qint64> count{0};
+        std::atomic<qint64> totalMs{0};
+        std::array<std::atomic<qint64>, BucketCount> buckets{};
+    };
+
+    TypeStats &slotFor(int typeId);
+    const TypeStats &slotFor(int typeId) const;
+
+    /// Index of the histogram bucket the sample falls into. The last index is +Inf.
+    static int bucketIndexFor(qint64 elapsedMs);
+
+    /// Appends one series of cumulative +Inf-terminated buckets to @p out.
+    static void appendCumulativeBuckets(QString &out,
+                                        const QString &bucketLine,
+                                        const std::array<std::atomic<qint64>, BucketCount> &buckets);
+
+    std::array<TypeStats, MaxTypes> typeSlots{};
+    TypeStats gameStartStats{};
+    std::atomic<qint64> totalCommandsCounter{0};
+    std::atomic<qint64> totalTimeCounter{0};
+};
+
+#endif

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -230,6 +230,13 @@ bool Servatrice::initServer()
 {
 
     serverId = getServerID();
+
+    // METRICS (always active. Slow-command logging and stall watchdogs are
+    // controlled by their respective thresholds below). Read up front so the
+    // values are available before any pool thread is started and watchdogged.
+    metricsSlowCommandMs = settingsCache->value("metrics/slow_command_ms", 500).toInt();
+    metricsStallWarnMs = qMax(0, settingsCache->value("metrics/stall_warn_ms", 2000).toInt());
+
     if (getAuthenticationMethodString() == "sql") {
         qDebug() << "Authenticating method: sql";
         authenticationMethod = AuthenticationSql;
@@ -474,11 +481,6 @@ bool Servatrice::initServer()
     }
 
     setRequiredFeatures(getRequiredFeatures());
-
-    // METRICS (always active. Slow-command logging and stall watchdogs are
-    // controlled by their respective thresholds below)
-    metricsSlowCommandMs = settingsCache->value("metrics/slow_command_ms", 500).toInt();
-    metricsStallWarnMs = qMax(0, settingsCache->value("metrics/stall_warn_ms", 2000).toInt());
 
     return true;
 }

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -20,6 +20,7 @@
 #include "servatrice.h"
 
 #include "email_parser.h"
+#include "event_loop_watchdog.h"
 #include "isl_interface.h"
 #include "main.h"
 #include "servatrice_connection_pool.h"
@@ -38,6 +39,7 @@
 #include <QStringList>
 #include <QTimer>
 #include <QUrl>
+#include <game/server_game.h>
 #include <iostream>
 #include <libcockatrice/deck_list/deck_list.h>
 #include <libcockatrice/protocol/featureset.h>
@@ -63,6 +65,7 @@ Servatrice_GameServer::Servatrice_GameServer(Servatrice *_server,
         server->addDatabaseInterface(newThread, newDatabaseInterface);
 
         newThread->start();
+        server->watchWorkerThread(newThread);
         QMetaObject::invokeMethod(newDatabaseInterface, "initDatabase", Qt::BlockingQueuedConnection,
                                   Q_ARG(QSqlDatabase, _sqlDatabase));
 
@@ -131,6 +134,7 @@ Servatrice_WebsocketGameServer::Servatrice_WebsocketGameServer(Servatrice *_serv
         server->addDatabaseInterface(newThread, newDatabaseInterface);
 
         newThread->start();
+        server->watchWorkerThread(newThread);
         QMetaObject::invokeMethod(newDatabaseInterface, "initDatabase", Qt::BlockingQueuedConnection,
                                   Q_ARG(QSqlDatabase, _sqlDatabase));
 
@@ -470,7 +474,58 @@ bool Servatrice::initServer()
     }
 
     setRequiredFeatures(getRequiredFeatures());
+
+    // METRICS (always active. Slow-command logging and stall watchdogs are
+    // controlled by their respective thresholds below)
+    metricsSlowCommandMs = settingsCache->value("metrics/slow_command_ms", 500).toInt();
+    metricsStallWarnMs = qMax(0, settingsCache->value("metrics/stall_warn_ms", 2000).toInt());
+
     return true;
+}
+
+void Servatrice::observeGameStartDurationMs(qint64 elapsedMs)
+{
+    metricsRegistry.observeGameStartDurationMs(elapsedMs);
+}
+
+void Servatrice::observeEventLoopStall(const QString &threadName, qint64 overshootMs)
+{
+    eventLoopStallsTotal.fetch_add(1, std::memory_order_relaxed);
+    eventLoopLastStallMs.store(overshootMs, std::memory_order_relaxed);
+    qint64 prevMax = eventLoopMaxStallMs.load(std::memory_order_relaxed);
+    while (overshootMs > prevMax &&
+           !eventLoopMaxStallMs.compare_exchange_weak(prevMax, overshootMs, std::memory_order_relaxed)) {
+        // retry until the max is at least as high as the new sample
+    }
+
+    qWarning() << "Event loop stall in" << threadName << "- heartbeat overshot by" << overshootMs << "ms";
+}
+
+void Servatrice::watchWorkerThread(QThread *thread)
+{
+    if (metricsStallWarnMs <= 0) {
+        return; // watchdogs disabled via metrics/stall_warn_ms = 0
+    }
+
+    auto *watchdog = new EventLoopWatchdog(this, thread->objectName());
+    connect(thread, &QThread::finished, watchdog, &QObject::deleteLater);
+    watchdog->moveToThread(thread);
+    QMetaObject::invokeMethod(watchdog, &EventLoopWatchdog::start, Qt::QueuedConnection);
+}
+
+qint64 Servatrice::getCardsInGamesTotal() const
+{
+    qint64 total = 0;
+    QReadLocker roomsLocker(&roomsLock); // locking order: roomsLock before gamesLock/gameMutex
+    QMapIterator<int, Server_Room *> roomIterator(rooms);
+    while (roomIterator.hasNext()) {
+        Server_Room *room = roomIterator.next().value();
+        QReadLocker gamesLocker(&room->gamesLock);
+        for (auto *game : room->getGames()) {
+            total += game->getCardsInGame();
+        }
+    }
+    return total;
 }
 
 void Servatrice::addDatabaseInterface(QThread *thread, Servatrice_DatabaseInterface *databaseInterface)
@@ -728,6 +783,7 @@ void Servatrice::incTxBytes(quint64 num)
     txBytesMutex.lock();
     txBytes += num;
     txBytesMutex.unlock();
+    txBytesTotal.fetch_add(num, std::memory_order_relaxed);
 }
 
 void Servatrice::incRxBytes(quint64 num)
@@ -735,6 +791,7 @@ void Servatrice::incRxBytes(quint64 num)
     rxBytesMutex.lock();
     rxBytes += num;
     rxBytesMutex.unlock();
+    rxBytesTotal.fetch_add(num, std::memory_order_relaxed);
 }
 
 void Servatrice::shutdownTimeout()

--- a/servatrice/src/servatrice.cpp
+++ b/servatrice/src/servatrice.cpp
@@ -89,7 +89,6 @@ void Servatrice_GameServer::incomingConnection(qintptr socketDescriptor)
     Servatrice_ConnectionPool *pool = findLeastUsedConnectionPool();
 
     auto ssi = new TcpServerSocketInterface(server, pool->getDatabaseInterface());
-    connect(ssi, SIGNAL(incTxBytes(qint64)), this, SLOT(incTxBytes(qint64)));
     ssi->moveToThread(pool->thread());
     pool->addClient();
     connect(ssi, SIGNAL(destroyed()), pool, SLOT(removeClient()));
@@ -160,7 +159,6 @@ void Servatrice_WebsocketGameServer::onNewConnection()
     Servatrice_ConnectionPool *pool = findLeastUsedConnectionPool();
 
     auto ssi = new WebsocketServerSocketInterface(server, pool->getDatabaseInterface());
-    connect(ssi, SIGNAL(incTxBytes(quint64)), this, SLOT(incTxBytes(quint64)));
     /*
      * Due to a Qt limitation, websockets can't be moved to another thread.
      * This will hopefully change in Qt6 if QtWebSocket will be integrated in QtNetwork
@@ -785,7 +783,6 @@ void Servatrice::incTxBytes(quint64 num)
     txBytesMutex.lock();
     txBytes += num;
     txBytesMutex.unlock();
-    txBytesTotal.fetch_add(num, std::memory_order_relaxed);
 }
 
 void Servatrice::incRxBytes(quint64 num)
@@ -793,7 +790,6 @@ void Servatrice::incRxBytes(quint64 num)
     rxBytesMutex.lock();
     rxBytes += num;
     rxBytesMutex.unlock();
-    rxBytesTotal.fetch_add(num, std::memory_order_relaxed);
 }
 
 void Servatrice::shutdownTimeout()

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -315,8 +315,11 @@ public:
         return uptime;
     }
     /**
-     * Sums cards across all zones of all running games. Locks rooms and games
-     * briefly per level, so scrape-time cost grows with live game count only.
+     * Sums cards across all zones of all running games. Each game takes its
+     * own gameMutex -- the hot per-game lock every game action contends on --
+     * and then iterates every player's zones, so the scrape cost is really
+     * O(total cards in play) plus one mutex acquisition per live game. Keep
+     * scrapes infrequent in big multiplayer rooms.
      */
     qint64 getCardsInGamesTotal() const;
     int getMetricsSlowCommandMs() const

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -20,6 +20,8 @@
 #ifndef SERVATRICE_H
 #define SERVATRICE_H
 
+#include "metrics_registry.h"
+
 #include <QDateTime>
 #include <QHostAddress>
 #include <QMetaType>
@@ -30,6 +32,7 @@
 #include <QSslKey>
 #include <QTcpServer>
 #include <QWebSocketServer>
+#include <atomic>
 #include <libcockatrice/protocol/pb/response_report_stats.pb.h>
 #include <memory>
 #include <server.h>
@@ -170,6 +173,14 @@ private:
     int uptime;
     QMutex txBytesMutex, rxBytesMutex;
     quint64 txBytes, rxBytes;
+    std::atomic<quint64> txBytesTotal{0}; ///< cumulative bytes sent since process start
+    std::atomic<quint64> rxBytesTotal{0}; ///< cumulative bytes received since process start
+    MetricsRegistry metricsRegistry;
+    int metricsSlowCommandMs = 500;
+    int metricsStallWarnMs = 2000;
+    std::atomic<qint64> eventLoopStallsTotal{0}; ///< heartbeat overshoots past the warn threshold
+    std::atomic<qint64> eventLoopLastStallMs{0}; ///< overshoot of the most recent stall
+    std::atomic<qint64> eventLoopMaxStallMs{0};  ///< worst overshoot seen since process start
 
     QString shutdownReason;
     int shutdownMinutes;
@@ -285,6 +296,58 @@ public:
     void incTxBytes(quint64 num);
     void incRxBytes(quint64 num);
     void addDatabaseInterface(QThread *thread, Servatrice_DatabaseInterface *databaseInterface);
+
+    // Metrics (see [metrics] section in servatrice.ini.example)
+    MetricsRegistry &getMetricsRegistry()
+    {
+        return metricsRegistry;
+    }
+    quint64 getTxBytesTotal() const
+    {
+        return txBytesTotal.load(std::memory_order_relaxed);
+    }
+    quint64 getRxBytesTotal() const
+    {
+        return rxBytesTotal.load(std::memory_order_relaxed);
+    }
+    int getUptimeSeconds() const
+    {
+        return uptime;
+    }
+    /**
+     * Sums cards across all zones of all running games. Locks rooms and games
+     * briefly per level, so scrape-time cost grows with live game count only.
+     */
+    qint64 getCardsInGamesTotal() const;
+    int getMetricsSlowCommandMs() const
+    {
+        return metricsSlowCommandMs;
+    }
+    /// Heartbeat overshoot that counts as a stall. A value of 0 disables the watchdogs.
+    int getMetricsStallWarnMs() const
+    {
+        return metricsStallWarnMs;
+    }
+    void observeGameStartDurationMs(qint64 elapsedMs) override;
+    qint64 getEventLoopStallsTotal() const
+    {
+        return eventLoopStallsTotal.load(std::memory_order_relaxed);
+    }
+    qint64 getEventLoopLastStallMs() const
+    {
+        return eventLoopLastStallMs.load(std::memory_order_relaxed);
+    }
+    qint64 getEventLoopMaxStallMs() const
+    {
+        return eventLoopMaxStallMs.load(std::memory_order_relaxed);
+    }
+    /// Records one heartbeat overshoot and logs a single warning for it.
+    void observeEventLoopStall(const QString &threadName, qint64 overshootMs);
+    /**
+     * Installs an EventLoopWatchdog in @p thread. Called once per socket pool
+     * thread right after it starts.
+     */
+    void watchWorkerThread(QThread *thread);
 
     bool islConnectionExists(int _serverId) const;
     void addIslInterface(int _serverId, IslInterface *interface);

--- a/servatrice/src/servatrice.h
+++ b/servatrice/src/servatrice.h
@@ -173,8 +173,6 @@ private:
     int uptime;
     QMutex txBytesMutex, rxBytesMutex;
     quint64 txBytes, rxBytes;
-    std::atomic<quint64> txBytesTotal{0}; ///< cumulative bytes sent since process start
-    std::atomic<quint64> rxBytesTotal{0}; ///< cumulative bytes received since process start
     MetricsRegistry metricsRegistry;
     int metricsSlowCommandMs = 500;
     int metricsStallWarnMs = 2000;
@@ -301,18 +299,6 @@ public:
     MetricsRegistry &getMetricsRegistry()
     {
         return metricsRegistry;
-    }
-    quint64 getTxBytesTotal() const
-    {
-        return txBytesTotal.load(std::memory_order_relaxed);
-    }
-    quint64 getRxBytesTotal() const
-    {
-        return rxBytesTotal.load(std::memory_order_relaxed);
-    }
-    int getUptimeSeconds() const
-    {
-        return uptime;
     }
     /**
      * Sums cards across all zones of all running games. Each game takes its

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -202,25 +202,58 @@ void AbstractServerSocketInterface::processCommandContainer(const CommandContain
     Server_ProtocolHandler::processCommandContainer(cont);
     const qint64 elapsedMs = timer.nsecsElapsed() / 1000000;
 
-    // A container usually holds a single command. When several are batched,
-    // each is attributed the container's total processing time.
-    for (const auto &cmd : cont.session_command()) {
-        servatrice->getMetricsRegistry().observeCommand(MetricsRegistry::typeIdFor(0, getPbExtension(cmd)), elapsedMs);
+    // The base dispatch is an if/else-if chain — at most one family is
+    // actually processed.  Recording every family in the container would
+    // let an unauthenticated client stampforge developer/moderator/admin
+    // samples by batching them alongside a session command the server
+    // actually runs.  Mirror the base's selection and skip entirely when
+    // deleted or when no family matched.
+    if (deleted) {
+        return;
     }
-    for (const auto &cmd : cont.room_command()) {
-        servatrice->getMetricsRegistry().observeCommand(MetricsRegistry::typeIdFor(1, getPbExtension(cmd)), elapsedMs);
+
+    // When getPbExtension returns -1 (no extension set) and the kind is
+    // non-zero, typeIdFor wraps into the previous kind's range instead of
+    // hitting the typeId < 0 guard in observeCommand.  Skip such entries.
+    int kind = -1;
+    if (cont.game_command_size()) {
+        kind = 2;
+    } else if (cont.room_command_size()) {
+        kind = 1;
+    } else if (cont.session_command_size()) {
+        kind = 0;
+    } else if (cont.moderator_command_size()) {
+        kind = 3;
+    } else if (cont.admin_command_size()) {
+        kind = 4;
+    } else if (cont.developer_command_size()) {
+        kind = 5;
     }
-    for (const auto &cmd : cont.game_command()) {
-        servatrice->getMetricsRegistry().observeCommand(MetricsRegistry::typeIdFor(2, getPbExtension(cmd)), elapsedMs);
-    }
-    for (const auto &cmd : cont.moderator_command()) {
-        servatrice->getMetricsRegistry().observeCommand(MetricsRegistry::typeIdFor(3, getPbExtension(cmd)), elapsedMs);
-    }
-    for (const auto &cmd : cont.admin_command()) {
-        servatrice->getMetricsRegistry().observeCommand(MetricsRegistry::typeIdFor(4, getPbExtension(cmd)), elapsedMs);
-    }
-    for (const auto &cmd : cont.developer_command()) {
-        servatrice->getMetricsRegistry().observeCommand(MetricsRegistry::typeIdFor(5, getPbExtension(cmd)), elapsedMs);
+
+    if (kind >= 0) {
+        auto recordDispatched = [&](int familyKind, const auto &cmds) {
+            for (const auto &cmd : cmds) {
+                const int ext = getPbExtension(cmd);
+                if (ext >= 0) {
+                    servatrice->getMetricsRegistry().observeCommand(MetricsRegistry::typeIdFor(familyKind, ext),
+                                                                    elapsedMs);
+                }
+            }
+        };
+
+        if (kind == 0) {
+            recordDispatched(kind, cont.session_command());
+        } else if (kind == 1) {
+            recordDispatched(kind, cont.room_command());
+        } else if (kind == 2) {
+            recordDispatched(kind, cont.game_command());
+        } else if (kind == 3) {
+            recordDispatched(kind, cont.moderator_command());
+        } else if (kind == 4) {
+            recordDispatched(kind, cont.admin_command());
+        } else {
+            recordDispatched(kind, cont.developer_command());
+        }
     }
 
     const int slowCommandMs = servatrice->getMetricsSlowCommandMs();

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -1772,7 +1772,7 @@ Response::ResponseCode AbstractServerSocketInterface::cmdGetServerStats(const Co
                 message ? pool->FindExtensionByNumber(message, number) : nullptr;
             if (extension) {
                 label = QString::fromLatin1(MetricsRegistry::KindNames[kind]) + QStringLiteral("/") +
-                        QString::fromStdString(std::string(extension->name()));
+                        QString::fromStdString(std::string(extension->message_type()->name()));
             }
         }
         if (label.isEmpty()) {

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -30,6 +30,7 @@
 
 #include <QDateTime>
 #include <QDebug>
+#include <QElapsedTimer>
 #include <QHostAddress>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -39,8 +40,10 @@
 #include <QSqlQuery>
 #include <QString>
 #include <game/server_player.h>
+#include <google/protobuf/descriptor.h>
 #include <iostream>
 #include <libcockatrice/deck_list/deck_list.h>
+#include <libcockatrice/protocol/get_pb_extension.h>
 #include <libcockatrice/protocol/pb/command_deck_del.pb.h>
 #include <libcockatrice/protocol/pb/command_deck_del_dir.pb.h>
 #include <libcockatrice/protocol/pb/command_deck_download.pb.h>
@@ -190,6 +193,41 @@ void AbstractServerSocketInterface::transmitProtocolItem(const ServerMessage &it
 void AbstractServerSocketInterface::logDebugMessage(const QString &message)
 {
     logger->logMessage(message, this);
+}
+
+void AbstractServerSocketInterface::processCommandContainer(const CommandContainer &cont)
+{
+    QElapsedTimer timer;
+    timer.start();
+    Server_ProtocolHandler::processCommandContainer(cont);
+    const qint64 elapsedMs = timer.nsecsElapsed() / 1000000;
+
+    // A container usually holds a single command. When several are batched,
+    // each is attributed the container's total processing time.
+    for (const auto &cmd : cont.session_command()) {
+        servatrice->getMetricsRegistry().observeCommand(MetricsRegistry::typeIdFor(0, getPbExtension(cmd)), elapsedMs);
+    }
+    for (const auto &cmd : cont.room_command()) {
+        servatrice->getMetricsRegistry().observeCommand(MetricsRegistry::typeIdFor(1, getPbExtension(cmd)), elapsedMs);
+    }
+    for (const auto &cmd : cont.game_command()) {
+        servatrice->getMetricsRegistry().observeCommand(MetricsRegistry::typeIdFor(2, getPbExtension(cmd)), elapsedMs);
+    }
+    for (const auto &cmd : cont.moderator_command()) {
+        servatrice->getMetricsRegistry().observeCommand(MetricsRegistry::typeIdFor(3, getPbExtension(cmd)), elapsedMs);
+    }
+    for (const auto &cmd : cont.admin_command()) {
+        servatrice->getMetricsRegistry().observeCommand(MetricsRegistry::typeIdFor(4, getPbExtension(cmd)), elapsedMs);
+    }
+
+    const int slowCommandMs = servatrice->getMetricsSlowCommandMs();
+    if (slowCommandMs > 0 && elapsedMs >= slowCommandMs) {
+        const ServerInfo_User *info = getUserInfo();
+        const QString user = authState == PasswordRight && info ? QString::fromStdString(info->name())
+                                                                : QStringLiteral("unauthenticated");
+        qCWarning(AbstractServerSocketInterfaceLog) << "slow command container from" << user << "processed in"
+                                                    << elapsedMs << "ms (" << cont.ByteSizeLong() << "bytes)";
+    }
 }
 
 Response::ResponseCode AbstractServerSocketInterface::processExtendedSessionCommand(int cmdType,
@@ -1703,6 +1741,51 @@ Response::ResponseCode AbstractServerSocketInterface::cmdGetServerStats(const Co
     re->set_rx_bytes(snapshot.rxBytes);
     re->set_uptime_secs(snapshot.uptimeSecs);
     re->set_timest(snapshot.timest);
+
+    // Live metrics from the in-process MetricsRegistry (resets on server restart)
+    re->set_cards_in_games(static_cast<google::protobuf::uint64>(servatrice->getCardsInGamesTotal()));
+    re->set_eventloop_stalls_total(static_cast<google::protobuf::uint64>(servatrice->getEventLoopStallsTotal()));
+    re->set_eventloop_last_stall_ms(static_cast<google::protobuf::uint64>(servatrice->getEventLoopLastStallMs()));
+    re->set_eventloop_max_stall_ms(static_cast<google::protobuf::uint64>(servatrice->getEventLoopMaxStallMs()));
+    re->set_total_commands(static_cast<google::protobuf::uint64>(servatrice->getMetricsRegistry().totalCommands()));
+    re->set_total_command_time_ms(
+        static_cast<google::protobuf::uint64>(servatrice->getMetricsRegistry().totalTimeMs()));
+    re->set_active_command_types(servatrice->getMetricsRegistry().activeTypeCount());
+
+    const auto gameStart = servatrice->getMetricsRegistry().getGameStartSnapshot();
+    re->set_game_start_count(static_cast<google::protobuf::uint64>(gameStart.count));
+    re->set_game_start_total_ms(static_cast<google::protobuf::uint64>(gameStart.totalMs));
+
+    // Per-command breakdown: resolve protobuf extension names via the descriptor pool
+    static const char *messageNames[] = {"SessionCommand", "RoomCommand", "GameCommand", "ModeratorCommand",
+                                         "AdminCommand"};
+    const auto activeStats = servatrice->getMetricsRegistry().collectActiveStats();
+    for (const auto &stat : activeStats) {
+        const int kind = stat.typeId / MetricsRegistry::KindStride;
+        const int number = stat.typeId % MetricsRegistry::KindStride;
+
+        QString label;
+        if (kind >= 0 && kind < MetricsRegistry::NumKinds) {
+            const google::protobuf::DescriptorPool *pool = google::protobuf::DescriptorPool::generated_pool();
+            const google::protobuf::Descriptor *message = pool->FindMessageTypeByName(messageNames[kind]);
+            const google::protobuf::FieldDescriptor *extension =
+                message ? pool->FindExtensionByNumber(message, number) : nullptr;
+            if (extension) {
+                label = QString::fromLatin1(MetricsRegistry::KindNames[kind]) + QStringLiteral("/") +
+                        QString::fromStdString(std::string(extension->name()));
+            }
+        }
+        if (label.isEmpty()) {
+            label = QString::number(stat.typeId);
+        }
+
+        CommandStats *cs = re->add_command_stats();
+        cs->set_kind_index(static_cast<google::protobuf::uint32>(kind));
+        cs->set_extension_number(static_cast<google::protobuf::uint32>(number));
+        cs->set_command_name(label.toStdString());
+        cs->set_count(static_cast<google::protobuf::uint64>(stat.count));
+        cs->set_total_ms(static_cast<google::protobuf::uint64>(stat.totalMs));
+    }
 
     rc.setResponseExtension(re);
     return Response::RespOk;

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -219,6 +219,9 @@ void AbstractServerSocketInterface::processCommandContainer(const CommandContain
     for (const auto &cmd : cont.admin_command()) {
         servatrice->getMetricsRegistry().observeCommand(MetricsRegistry::typeIdFor(4, getPbExtension(cmd)), elapsedMs);
     }
+    for (const auto &cmd : cont.developer_command()) {
+        servatrice->getMetricsRegistry().observeCommand(MetricsRegistry::typeIdFor(5, getPbExtension(cmd)), elapsedMs);
+    }
 
     const int slowCommandMs = servatrice->getMetricsSlowCommandMs();
     if (slowCommandMs > 0 && elapsedMs >= slowCommandMs) {
@@ -1757,8 +1760,8 @@ Response::ResponseCode AbstractServerSocketInterface::cmdGetServerStats(const Co
     re->set_game_start_total_ms(static_cast<google::protobuf::uint64>(gameStart.totalMs));
 
     // Per-command breakdown: resolve protobuf extension names via the descriptor pool
-    static const char *messageNames[] = {"SessionCommand", "RoomCommand", "GameCommand", "ModeratorCommand",
-                                         "AdminCommand"};
+    static const char *messageNames[] = {"SessionCommand",   "RoomCommand",  "GameCommand",
+                                         "ModeratorCommand", "AdminCommand", "DeveloperCommand"};
     const auto activeStats = servatrice->getMetricsRegistry().collectActiveStats();
     for (const auto &stat : activeStats) {
         const int kind = stat.typeId / MetricsRegistry::KindStride;

--- a/servatrice/src/serversocketinterface.h
+++ b/servatrice/src/serversocketinterface.h
@@ -81,6 +81,7 @@ signals:
 protected:
     void logDebugMessage(const QString &message) override;
     bool tooManyRegistrationAttempts(const QString &ipAddress);
+    void processCommandContainer(const CommandContainer &cont) override;
 
     virtual void writeToSocket(QByteArray &data) = 0;
     virtual void flushSocket() = 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_test(NAME server_developer_role_test COMMAND server_developer_role_test)
 add_test(NAME warning_categories_test COMMAND warning_categories_test)
 add_test(NAME lag_monitor_test COMMAND lag_monitor_test)
 add_test(NAME latency_tracker_test COMMAND latency_tracker_test)
+add_test(NAME metrics_registry_test COMMAND metrics_registry_test)
 
 add_test(NAME deck_hash_performance_test COMMAND deck_hash_performance_test)
 set_tests_properties(deck_hash_performance_test PROPERTIES TIMEOUT 15)
@@ -36,6 +37,7 @@ add_executable(warning_categories_test warning_categories_test.cpp)
 add_executable(lag_monitor_test ${CMAKE_SOURCE_DIR}/cockatrice/src/client/lag_monitor.cpp lag_monitor_test.cpp)
 target_include_directories(lag_monitor_test PRIVATE ${CMAKE_SOURCE_DIR}/cockatrice/src)
 add_executable(latency_tracker_test latency_tracker_test.cpp)
+add_executable(metrics_registry_test ../servatrice/src/metrics_registry.cpp metrics_registry_test.cpp)
 
 find_package(GTest)
 
@@ -76,6 +78,7 @@ if(NOT GTEST_FOUND)
   add_dependencies(warning_categories_test gtest)
   add_dependencies(lag_monitor_test gtest)
   add_dependencies(latency_tracker_test gtest)
+  add_dependencies(metrics_registry_test gtest)
 endif()
 
 include_directories(${GTEST_INCLUDE_DIRS})
@@ -118,6 +121,8 @@ target_link_libraries(lag_monitor_test Threads::Threads ${GTEST_BOTH_LIBRARIES} 
 target_link_libraries(
   latency_tracker_test libcockatrice_network Threads::Threads ${GTEST_BOTH_LIBRARIES} ${TEST_QT_MODULES}
 )
+target_include_directories(metrics_registry_test PRIVATE ${CMAKE_SOURCE_DIR}/servatrice/src)
+target_link_libraries(metrics_registry_test ${TEST_QT_MODULES} Threads::Threads ${GTEST_BOTH_LIBRARIES})
 
 add_subdirectory(card_zone_algorithms)
 add_subdirectory(carddatabase)

--- a/tests/metrics_registry_test.cpp
+++ b/tests/metrics_registry_test.cpp
@@ -1,0 +1,131 @@
+#include <QRegularExpression>
+#include <gtest/gtest.h>
+#include <metrics_registry.h>
+
+TEST(MetricsRegistryTest, EmptyRegistryProducesNoHistogramLines)
+{
+    MetricsRegistry registry;
+
+    EXPECT_EQ(0, registry.totalCommands());
+    EXPECT_EQ(0, registry.totalTimeMs());
+    EXPECT_EQ(0, registry.activeTypeCount());
+
+    const QString text = registry.toPrometheusText([](int) { return QString("x"); }, {});
+    // The family TYPE declaration may stand alone. What must not exist is a
+    // histogram sample without data behind it.
+    EXPECT_FALSE(text.contains(QRegularExpression("servatrice_commands_duration_ms_(bucket|sum|count)")));
+}
+
+TEST(MetricsRegistryTest, SingleSampleIsRecordedInTotalsAndBuckets)
+{
+    MetricsRegistry registry;
+    registry.observeCommand(MetricsRegistry::typeIdFor(0, 1000), 7);
+
+    EXPECT_EQ(1, registry.totalCommands());
+    EXPECT_EQ(7, registry.totalTimeMs());
+    EXPECT_EQ(1, registry.activeTypeCount());
+
+    const QString text = registry.toPrometheusText(
+        [](int typeId) {
+            return QString("%1/%2").arg(typeId / MetricsRegistry::KindStride).arg(typeId % MetricsRegistry::KindStride);
+        },
+        {});
+    // 7ms falls into the le="10" bucket. Smaller buckets stay empty
+    EXPECT_TRUE(text.contains("# TYPE servatrice_commands_duration_ms histogram\n"));
+    EXPECT_TRUE(text.contains(",le=\"10\"} 1"));
+    EXPECT_TRUE(text.contains(",le=\"5\"} 0"));
+    EXPECT_TRUE(text.contains("_sum{command=\"0/1000\"} 7"));
+    EXPECT_TRUE(text.contains("_count{command=\"0/1000\"} 1"));
+}
+
+TEST(MetricsRegistryTest, BucketsAreCumulative)
+{
+    MetricsRegistry registry;
+    registry.observeCommand(MetricsRegistry::typeIdFor(0, 1000), 2);
+    registry.observeCommand(MetricsRegistry::typeIdFor(0, 1000), 30);
+
+    const QString text = registry.toPrometheusText([](int) { return QString("cmd"); }, {});
+
+    // cumulative counts: <=25 -> 1 sample, <=50 -> 2 samples
+    EXPECT_TRUE(text.contains(",le=\"25\"} 1\n"));
+    EXPECT_TRUE(text.contains(",le=\"50\"} 2\n"));
+    EXPECT_TRUE(text.contains(",le=\"+Inf\"} 2\n"));
+}
+
+TEST(MetricsRegistryTest, KindEncodingSeparatesSameExtensionNumber)
+{
+    MetricsRegistry registry;
+    const int sessionPing = MetricsRegistry::typeIdFor(0, 1000);
+    const int roomLeaveRoom = MetricsRegistry::typeIdFor(1, 1000);
+    ASSERT_NE(sessionPing, roomLeaveRoom);
+
+    registry.observeCommand(sessionPing, 1);
+    registry.observeCommand(roomLeaveRoom, 5000);
+
+    EXPECT_EQ(2, registry.activeTypeCount());
+}
+
+TEST(MetricsRegistryTest, OutOfRangeIdsLandInOverflowSlot)
+{
+    MetricsRegistry registry;
+    registry.observeCommand(-1, 4);
+    registry.observeCommand(MetricsRegistry::MaxTypes + 12345, 4);
+
+    EXPECT_EQ(2, registry.totalCommands());
+    EXPECT_EQ(1, registry.activeTypeCount()); // both collapsed into one slot
+    EXPECT_EQ(8, registry.totalTimeMs());
+}
+
+TEST(MetricsRegistryTest, NegativeDurationsAreClamped)
+{
+    MetricsRegistry registry;
+    registry.observeCommand(MetricsRegistry::typeIdFor(0, 1000), -50);
+
+    EXPECT_EQ(0, registry.totalTimeMs());
+}
+
+TEST(MetricsRegistryTest, GaugesAndLabelEscapingAreRendered)
+{
+    MetricsRegistry registry;
+
+    QHash<QString, qint64> gauges;
+    gauges.insert("servatrice_users_current", 42);
+
+    const QString text = registry.toPrometheusText(nullptr, gauges);
+    EXPECT_TRUE(text.contains("# TYPE servatrice_users_current gauge\n"));
+    EXPECT_TRUE(text.contains("servatrice_users_current 42\n"));
+}
+
+TEST(MetricsRegistryTest, UnnamedTypesFallBackToNumericLabel)
+{
+    MetricsRegistry registry;
+    registry.observeCommand(MetricsRegistry::typeIdFor(2, 1042), 9);
+
+    const QString text = registry.toPrometheusText(nullptr, {});
+    EXPECT_TRUE(text.contains("{command=\"" + QString::number(MetricsRegistry::typeIdFor(2, 1042)) + "\"}"));
+}
+
+TEST(MetricsRegistryTest, GameStartHistogramOnlyAppearsAfterSamples)
+{
+    MetricsRegistry registry;
+    EXPECT_FALSE(registry.toPrometheusText(nullptr, {}).contains("servatrice_game_start_duration_ms"));
+
+    registry.observeGameStartDurationMs(120);
+    const QString text = registry.toPrometheusText(nullptr, {});
+    // 120ms falls into the le="250" bucket
+    EXPECT_TRUE(text.contains("# TYPE servatrice_game_start_duration_ms histogram\n"));
+    EXPECT_TRUE(text.contains(",le=\"100\"} 0\n"));
+    EXPECT_TRUE(text.contains(",le=\"250\"} 1\n"));
+    EXPECT_TRUE(text.contains("servatrice_game_start_duration_ms_sum 120\n"));
+    EXPECT_TRUE(text.contains("servatrice_game_start_duration_ms_count 1\n"));
+}
+
+TEST(MetricsRegistryTest, GameStartHistogramIsSeparateFromCommandTotals)
+{
+    MetricsRegistry registry;
+    registry.observeGameStartDurationMs(10);
+
+    EXPECT_EQ(0, registry.totalCommands());
+    EXPECT_EQ(0, registry.totalTimeMs());
+    EXPECT_EQ(0, registry.activeTypeCount());
+}

--- a/tests/metrics_registry_test.cpp
+++ b/tests/metrics_registry_test.cpp
@@ -1,22 +1,18 @@
-#include <QRegularExpression>
+#include <QList>
 #include <gtest/gtest.h>
 #include <metrics_registry.h>
 
-TEST(MetricsRegistryTest, EmptyRegistryProducesNoHistogramLines)
+TEST(MetricsRegistryTest, EmptyRegistryHasZeroedCounters)
 {
     MetricsRegistry registry;
 
     EXPECT_EQ(0, registry.totalCommands());
     EXPECT_EQ(0, registry.totalTimeMs());
     EXPECT_EQ(0, registry.activeTypeCount());
-
-    const QString text = registry.toPrometheusText([](int) { return QString("x"); }, {});
-    // The family TYPE declaration may stand alone. What must not exist is a
-    // histogram sample without data behind it.
-    EXPECT_FALSE(text.contains(QRegularExpression("servatrice_commands_duration_ms_(bucket|sum|count)")));
+    EXPECT_EQ(0, registry.getGameStartSnapshot().count);
 }
 
-TEST(MetricsRegistryTest, SingleSampleIsRecordedInTotalsAndBuckets)
+TEST(MetricsRegistryTest, SampleIsRecordedInTotalsAndSlot)
 {
     MetricsRegistry registry;
     registry.observeCommand(MetricsRegistry::typeIdFor(0, 1000), 7);
@@ -25,31 +21,11 @@ TEST(MetricsRegistryTest, SingleSampleIsRecordedInTotalsAndBuckets)
     EXPECT_EQ(7, registry.totalTimeMs());
     EXPECT_EQ(1, registry.activeTypeCount());
 
-    const QString text = registry.toPrometheusText(
-        [](int typeId) {
-            return QString("%1/%2").arg(typeId / MetricsRegistry::KindStride).arg(typeId % MetricsRegistry::KindStride);
-        },
-        {});
-    // 7ms falls into the le="10" bucket. Smaller buckets stay empty
-    EXPECT_TRUE(text.contains("# TYPE servatrice_commands_duration_ms histogram\n"));
-    EXPECT_TRUE(text.contains(",le=\"10\"} 1"));
-    EXPECT_TRUE(text.contains(",le=\"5\"} 0"));
-    EXPECT_TRUE(text.contains("_sum{command=\"0/1000\"} 7"));
-    EXPECT_TRUE(text.contains("_count{command=\"0/1000\"} 1"));
-}
-
-TEST(MetricsRegistryTest, BucketsAreCumulative)
-{
-    MetricsRegistry registry;
-    registry.observeCommand(MetricsRegistry::typeIdFor(0, 1000), 2);
-    registry.observeCommand(MetricsRegistry::typeIdFor(0, 1000), 30);
-
-    const QString text = registry.toPrometheusText([](int) { return QString("cmd"); }, {});
-
-    // cumulative counts: <=25 -> 1 sample, <=50 -> 2 samples
-    EXPECT_TRUE(text.contains(",le=\"25\"} 1\n"));
-    EXPECT_TRUE(text.contains(",le=\"50\"} 2\n"));
-    EXPECT_TRUE(text.contains(",le=\"+Inf\"} 2\n"));
+    const auto stats = registry.collectActiveStats();
+    ASSERT_EQ(1, stats.size());
+    EXPECT_EQ(MetricsRegistry::typeIdFor(0, 1000), stats[0].typeId);
+    EXPECT_EQ(1, stats[0].count);
+    EXPECT_EQ(7, stats[0].totalMs);
 }
 
 TEST(MetricsRegistryTest, KindEncodingSeparatesSameExtensionNumber)
@@ -84,48 +60,16 @@ TEST(MetricsRegistryTest, NegativeDurationsAreClamped)
     EXPECT_EQ(0, registry.totalTimeMs());
 }
 
-TEST(MetricsRegistryTest, GaugesAndLabelEscapingAreRendered)
+TEST(MetricsRegistryTest, GameStartTrackedSeparatelyFromCommands)
 {
     MetricsRegistry registry;
-
-    QHash<QString, qint64> gauges;
-    gauges.insert("servatrice_users_current", 42);
-
-    const QString text = registry.toPrometheusText(nullptr, gauges);
-    EXPECT_TRUE(text.contains("# TYPE servatrice_users_current gauge\n"));
-    EXPECT_TRUE(text.contains("servatrice_users_current 42\n"));
-}
-
-TEST(MetricsRegistryTest, UnnamedTypesFallBackToNumericLabel)
-{
-    MetricsRegistry registry;
-    registry.observeCommand(MetricsRegistry::typeIdFor(2, 1042), 9);
-
-    const QString text = registry.toPrometheusText(nullptr, {});
-    EXPECT_TRUE(text.contains("{command=\"" + QString::number(MetricsRegistry::typeIdFor(2, 1042)) + "\"}"));
-}
-
-TEST(MetricsRegistryTest, GameStartHistogramOnlyAppearsAfterSamples)
-{
-    MetricsRegistry registry;
-    EXPECT_FALSE(registry.toPrometheusText(nullptr, {}).contains("servatrice_game_start_duration_ms"));
-
     registry.observeGameStartDurationMs(120);
-    const QString text = registry.toPrometheusText(nullptr, {});
-    // 120ms falls into the le="250" bucket
-    EXPECT_TRUE(text.contains("# TYPE servatrice_game_start_duration_ms histogram\n"));
-    EXPECT_TRUE(text.contains(",le=\"100\"} 0\n"));
-    EXPECT_TRUE(text.contains(",le=\"250\"} 1\n"));
-    EXPECT_TRUE(text.contains("servatrice_game_start_duration_ms_sum 120\n"));
-    EXPECT_TRUE(text.contains("servatrice_game_start_duration_ms_count 1\n"));
-}
-
-TEST(MetricsRegistryTest, GameStartHistogramIsSeparateFromCommandTotals)
-{
-    MetricsRegistry registry;
-    registry.observeGameStartDurationMs(10);
 
     EXPECT_EQ(0, registry.totalCommands());
     EXPECT_EQ(0, registry.totalTimeMs());
     EXPECT_EQ(0, registry.activeTypeCount());
+
+    const auto snapshot = registry.getGameStartSnapshot();
+    EXPECT_EQ(1, snapshot.count);
+    EXPECT_EQ(120, snapshot.totalMs);
 }

--- a/tests/metrics_registry_test.cpp
+++ b/tests/metrics_registry_test.cpp
@@ -1,3 +1,4 @@
+#include <QCoreApplication>
 #include <QList>
 #include <gtest/gtest.h>
 #include <metrics_registry.h>
@@ -72,4 +73,11 @@ TEST(MetricsRegistryTest, GameStartTrackedSeparatelyFromCommands)
     const auto snapshot = registry.getGameStartSnapshot();
     EXPECT_EQ(1, snapshot.count);
     EXPECT_EQ(120, snapshot.totalMs);
+}
+
+int main(int argc, char **argv)
+{
+    QCoreApplication app(argc, argv);
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
## Related Ticket(s)
- Stacked on #7211 (developer role)

## What will change with this Pull Request?
- Instrument server command processing, game starts, and event loops
- Add a `MetricsRegistry` with relaxed-atomic counters (counts/totals per protobuf command kind); the Prometheus bucket histogram is removed for now — nothing emitted it, and it returns with the /metrics endpoint that needs it
- Watch worker event loops for stalls via a per-thread heartbeat watchdog
- Surface the live metrics in the Developer tab: overview stats, live metrics section, and a per-command breakdown table
- Extend `Response_GetServerStats` with command timing, event-loop stall, and game-start fields
- Instrument the `developer_command` family (kind 6) added by #7211

## Why
- Lets server operators see request timing and stalls without external tooling, and extends the Developer tab's view to the developer-role command family

## Review fixes (8 threads)
- Drop dead Prometheus histogram + `toPrometheusText`, and the +Inf bug it hid
- Rewrite histogram-bound tests against the production readers
- Read `metrics/slow_command_ms` + `stall_warn_ms` before pool threads start, so `stall_warn_ms=0` genuinely disables the watchdogs
- Correct the `getCardsInGamesTotal()` scrape-cost doc (gameMutex per game, O(cards in play))
- Instrument `developer_command` in `processCommandContainer`/`cmdGetServerStats`
- Shrink `KindStride` 2048 → 1280 (largest extension 1206) with a `static_assert`
- Document unrate-limited slow-command logging in `servatrice.ini.example`
