### PR TITLE
[Mods] Align Card Art Rules Tab with other managed tabs and set UI strings

### DIFF
--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
@@ -245,6 +245,7 @@ void TabSupervisor::retranslateUi()
     aTabLog->setText(tr("Logs"));
     aTabReport->setText(tr("Report Queue"));
     aTabModeration->setText(tr("Moderation"));
+    aTabCardArtRules->setText(tr("Card Art Rules"));
 
     // tabs
     QList<Tab *> tabs;
@@ -256,6 +257,7 @@ void TabSupervisor::retranslateUi()
     tabs.append(tabLog);
     tabs.append(tabReport);
     tabs.append(tabModeration);
+    tabs.append(tabCardArtRules);
     QMapIterator<int, TabRoom *> roomIterator(roomTabs);
     while (roomIterator.hasNext()) {
         tabs.append(roomIterator.next().value());
@@ -520,7 +522,9 @@ void TabSupervisor::start(const ServerInfo_User &_userInfo)
         if (SettingsCache::instance().tabs().getTabModerationOpen()) {
             openTabModeration();
         }
-        openTabCardArtRules();
+        if (SettingsCache::instance().tabs().getTabCardArtRulesOpen()) {
+            openTabCardArtRules();
+        }
     }
 
     retranslateUi();
@@ -581,6 +585,9 @@ void TabSupervisor::stop()
         }
         if (tabModeration) {
             tabModeration->close();
+        }
+        if (tabCardArtRules) {
+            tabCardArtRules->close();
         }
     }
 
@@ -775,6 +782,7 @@ void TabSupervisor::openTabAdmin()
 
 void TabSupervisor::actTabCardArtRules(bool checked)
 {
+    SettingsCache::instance().tabs().setTabCardArtRulesOpen(checked);
     if (checked && !tabCardArtRules) {
         openTabCardArtRules();
         setCurrentWidget(tabCardArtRules);

--- a/libcockatrice_interfaces/libcockatrice/interfaces/interface_tabs_settings_provider.h
+++ b/libcockatrice_interfaces/libcockatrice/interfaces/interface_tabs_settings_provider.h
@@ -21,6 +21,7 @@ public:
     [[nodiscard]] virtual bool getTabLogOpen() const = 0;
     [[nodiscard]] virtual bool getTabReportOpen() const = 0;
     [[nodiscard]] virtual bool getTabModerationOpen() const = 0;
+    [[nodiscard]] virtual bool getTabCardArtRulesOpen() const = 0;
 };
 
 #endif // COCKATRICE_INTERFACE_TABS_SETTINGS_PROVIDER_H

--- a/libcockatrice_settings/libcockatrice/settings/tabs_settings.cpp
+++ b/libcockatrice_settings/libcockatrice/settings/tabs_settings.cpp
@@ -106,6 +106,11 @@ bool TabsSettings::getTabModerationOpen() const
     return getValue("moderation", QString(), QString(), false).toBool();
 }
 
+bool TabsSettings::getTabCardArtRulesOpen() const
+{
+    return getValue("cardArtRules", QString(), QString(), false).toBool();
+}
+
 void TabsSettings::setTabVisualDeckStorageOpen(bool value)
 {
     setValue(value, "visualDeckStorage");
@@ -149,4 +154,9 @@ void TabsSettings::setTabReportOpen(bool value)
 void TabsSettings::setTabModerationOpen(bool value)
 {
     setValue(value, "moderation");
+}
+
+void TabsSettings::setTabCardArtRulesOpen(bool value)
+{
+    setValue(value, "cardArtRules");
 }

--- a/libcockatrice_settings/libcockatrice/settings/tabs_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/tabs_settings.h
@@ -43,6 +43,7 @@ public:
     [[nodiscard]] bool getTabLogOpen() const override;
     [[nodiscard]] bool getTabReportOpen() const override;
     [[nodiscard]] bool getTabModerationOpen() const override;
+    [[nodiscard]] bool getTabCardArtRulesOpen() const override;
 
     void setStartupTabIndex(int value);
     void setStartupServerHost(const QString &host);
@@ -57,6 +58,7 @@ public:
     void setTabLogOpen(bool value);
     void setTabReportOpen(bool value);
     void setTabModerationOpen(bool value);
+    void setTabCardArtRulesOpen(bool value);
 
 signals:
     void startupTabIndexChanged(int index);

--- a/tests/settings/settings_defaults_test.cpp
+++ b/tests/settings/settings_defaults_test.cpp
@@ -238,6 +238,12 @@ TEST_F(SettingsDefaultsTest, Tabs_ModerationOpen_Default)
     ASSERT_EQ(s.getTabModerationOpen(), false);
 }
 
+TEST_F(SettingsDefaultsTest, Tabs_CardArtRulesOpen_Default)
+{
+    TabsSettings s(settingsPath, nullptr);
+    ASSERT_EQ(s.getTabCardArtRulesOpen(), false);
+}
+
 // --- ChatSettings ---
 
 TEST_F(SettingsDefaultsTest, Chat_Mention_Default)


### PR DESCRIPTION
## Short roundup of the initial problem
The card art rules tab doesn't close automatically on disconnect like the other moderation tabs and doesn't early return, which leads to duplicate and uncloseable tabs.

## What will change with this Pull Request?
- Close on disconnect
- Early return if tab already exists

