### PR TITLE
[Game] Fix dragged card always placed on bottom of stack

### DIFF
--- a/cockatrice/src/game_graphics/zones/stack_zone.cpp
+++ b/cockatrice/src/game_graphics/zones/stack_zone.cpp
@@ -58,17 +58,12 @@ void StackZone::handleDropEvent(const QList<CardDragItem *> &dragItems,
     }
 
     const auto &cards = getLogic()->getCards();
-    int index;
+    int index = calcDropIndexFromY(dropPoint.y(), MIN_CARD_VISIBLE);
     if (startZone == getLogic()) {
-        // Reordering within the zone: use drop position
-        index = calcDropIndexFromY(dropPoint.y(), MIN_CARD_VISIBLE);
         // Same-zone no-op: don't move a card onto itself
         if (!cards.isEmpty() && cards.at(index)->getId() == dragItems.at(0)->getId()) {
             return;
         }
-    } else {
-        // Coming from another zone: append at end (top of stack, rendered on top)
-        index = static_cast<int>(cards.size());
     }
 
     Command_MoveCard cmd;


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #7146
- Reverts #7041

## Short roundup of the initial problem

#7041 changed the behavior of dragging cards from other zones to the stack zone to be different from what the users expected. It made the card always get added to the bottom of the stack. 

I'm reverting that change. The previous behavior still worked as expected.

## What will change with this Pull Request?
- Use drop position regardless of where the card came from

https://github.com/user-attachments/assets/052ba641-98c9-4183-9494-6cd917b6112f