### PR TITLE
[VDS] Fix search filter not being applied on refresh

### DIFF
--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
@@ -125,9 +125,7 @@ void VisualDeckStorageFolderDisplayWidget::continueDeckPass()
         }
 
         const bool matches = index.data(VisualDeckStorageRoles::FilterMatchRole).toBool();
-        if (matches == deckPreviewWidget->isHidden()) {
-            deckPreviewWidget->setVisible(matches);
-        }
+        deckPreviewWidget->setVisible(matches);
         if (matches) {
             ++visibleDeckCount;
         }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #7106

## Short roundup of the initial problem

Search filters are not applied upon VDS refresh

https://github.com/user-attachments/assets/d12e688d-9707-4d63-bbe0-c4f2f426c237

The cause seems to be because the filter code in the folder display widget checks if the widget is not hidden before hiding the widget, which doesn't work as expected when the VDS is refreshing.

## What will change with this Pull Request?

- Remove the `isHidden` check

https://github.com/user-attachments/assets/bb1ce358-d5a4-42ed-a98b-8a6ee163a586

When folder display is enabled, the filtered-out decks still flicker for a frame before being hidden, but that can be fixed in a separate PR.