### PR TITLE
[Game] Allow dropping cards at bottom of stack zone

### DIFF
--- a/cockatrice/src/game_graphics/zones/hand_zone.cpp
+++ b/cockatrice/src/game_graphics/zones/hand_zone.cpp
@@ -41,7 +41,8 @@ void HandZone::handleDropEvent(const QList<CardDragItem *> &dragItems,
             }
         }
     } else {
-        x = calcDropIndexFromY(dropPoint.y());
+        bool sameZone = startZone == getLogic();
+        x = calcDropIndexFromY(dropPoint.y(), !sameZone);
     }
 
     Command_MoveCard cmd;

--- a/cockatrice/src/game_graphics/zones/select_zone.cpp
+++ b/cockatrice/src/game_graphics/zones/select_zone.cpp
@@ -83,7 +83,7 @@ SelectZone::StackLayoutParams SelectZone::buildStackParams(qreal minOffset) cons
     return {cardCount, boundingRect().height(), cardHeight, offset, minOffset};
 }
 
-int SelectZone::calcDropIndexFromY(qreal dropY, qreal minOffset) const
+int SelectZone::calcDropIndexFromY(qreal dropY, bool allowCountExpand, qreal minOffset) const
 {
     const auto &cards = getLogic()->getCards();
     if (cards.isEmpty()) {
@@ -94,7 +94,8 @@ int SelectZone::calcDropIndexFromY(qreal dropY, qreal minOffset) const
     if (effectiveOffset <= 0.0) {
         return 0;
     }
-    return qBound(0, qRound((dropY - start) / effectiveOffset), params.cardCount - 1);
+    int max = allowCountExpand ? params.cardCount : params.cardCount - 1;
+    return qBound(0, qRound((dropY - start) / effectiveOffset), max);
 }
 
 void SelectZone::restoreStaleEscapedCards()

--- a/cockatrice/src/game_graphics/zones/select_zone.h
+++ b/cockatrice/src/game_graphics/zones/select_zone.h
@@ -104,8 +104,12 @@ protected:
     /**
      * @brief Computes the card index at a given y-coordinate within the zone's vertical layout.
      * Returns 0 if the zone has no cards or the offset is zero.
+     *
+     * @param dropY The y-coordinate that the card was dropped at
+     * @param allowCountExpand If false, clamps the index at the number of cards minus 1
+     * @param minOffset Minimum offset to preserve
      */
-    int calcDropIndexFromY(qreal dropY, qreal minOffset = 0.0) const;
+    int calcDropIndexFromY(qreal dropY, bool allowCountExpand, qreal minOffset = 0.0) const;
 
     /**
      * @brief Positions cards vertically with alternating left/right x-offsets.

--- a/cockatrice/src/game_graphics/zones/stack_zone.cpp
+++ b/cockatrice/src/game_graphics/zones/stack_zone.cpp
@@ -57,10 +57,11 @@ void StackZone::handleDropEvent(const QList<CardDragItem *> &dragItems,
         return;
     }
 
-    const auto &cards = getLogic()->getCards();
-    int index = calcDropIndexFromY(dropPoint.y(), MIN_CARD_VISIBLE);
-    if (startZone == getLogic()) {
+    bool sameZone = startZone == getLogic();
+    int index = calcDropIndexFromY(dropPoint.y(), !sameZone, MIN_CARD_VISIBLE);
+    if (sameZone) {
         // Same-zone no-op: don't move a card onto itself
+        const auto &cards = getLogic()->getCards();
         if (!cards.isEmpty() && cards.at(index)->getId() == dragItems.at(0)->getId()) {
             return;
         }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes bug introduced in #6774 
- Follow-up to #7228

## Short roundup of the initial problem

It's impossible to drag a card from a different zone to the bottom of the stack zone. Cockatrice will always place the card in the second-to-last spot.

https://github.com/user-attachments/assets/7af23f12-be9f-4555-b435-cd92c3989ad6

This is because `calcDropIndexFromY` clamps the index to "current card count" - 1. This is correct for avoiding out-of-bounds if the movement is within the same zone. However, if the card is added from elsewhere into the zone, this causes the new card to take the previous last index, pushing the previous last card to the new last index, and leaving the new card as the second-to-last card.

## What will change with this Pull Request?

- Add a new `allowCountExpand` param to `calcDropIndexFromY`, which clamps the returned index at one beyond the last index of the current cards
  - This allows the card to be added at the new last index, instead of always taking the spot of the previous last index.
  - Only enabled when card is not from same zone, in order to prevent out-of-bounds array access when cards are in same zone.

Cards now properly get placed at the bottom of the stack when dragged in below all the existing cards.

https://github.com/user-attachments/assets/fe219521-08da-4b19-85e7-16bba8fd65dd

