### PR TITLE
[Build] Bump cmake_minimum_required from 3.10 to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@
 # This file sets all the variables shared between the projects
 # like the installation path, compilation flags etc..
 
-# cmake 3.16 is required if using qt6
-cmake_minimum_required(VERSION 3.10)
+# 3.16 required for Qt6 and target_precompile_headers()
+cmake_minimum_required(VERSION 3.16)
 
 # Use compiler cache (ccache)
 option(USE_CCACHE "Cache the build results with ccache" OFF)


### PR DESCRIPTION
## Short roundup of the initial problem

CMake 3.10 is over a decade old; the project already relies on Qt6 (which needs 3.16+) and the minimum blocks modern build features.

## What will change with this Pull Request?
- Bump `cmake_minimum_required` from 3.10 to 3.16
- Unblock `target_precompile_headers()` and `CMAKE_UNITY_BUILD` (CMake 3.16+)