### PR TITLE
[Build] Use pipes for GCC/Clang compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,9 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
       set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${FLAG}")
     endif()
   endforeach()
+
+  # Reduce compiler I/O by using pipes between stages instead of temp files
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe")
 else()
   # other: osx/llvm, bsd/llvm
   set(CMAKE_CXX_FLAGS_RELEASE "-O2")
@@ -192,6 +195,9 @@ else()
   else()
     set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wextra")
   endif()
+
+  # Reduce compiler I/O by using pipes between stages instead of temp files
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe")
 endif()
 
 # GNU systems need to define the Mersenne exponent for the RNG to compile w/o warning


### PR DESCRIPTION
## Short roundup of the initial problem

GCC and Clang write preprocessed output to temporary files for every translation unit, adding disk I/O to an already heavy build.

## What will change with this Pull Request?
- Add `-pipe` to the GCC and Clang flag sets so compilers stream preprocessed output through pipes instead of temp files