### PR TITLE
[Protocol] Remove duplicate event_game_state_changed.proto entry

### DIFF
--- a/libcockatrice_protocol/libcockatrice/protocol/pb/CMakeLists.txt
+++ b/libcockatrice_protocol/libcockatrice/protocol/pb/CMakeLists.txt
@@ -90,7 +90,6 @@ set(PROTO_FILES
     event_game_log_notice.proto
     event_game_say.proto
     event_game_state_changed.proto
-    event_game_state_changed.proto
     event_join.proto
     event_join_room.proto
     event_kicked.proto


### PR DESCRIPTION
## Short roundup of the initial problem

`event_game_state_changed.proto` is listed twice in the protocol source list, so protoc compiles it twice on every build.

## What will change with this Pull Request?
- Remove the duplicate `event_game_state_changed.proto` entry