### PR TITLE
[Build] Enable ccache by default when it is installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 # Use compiler cache (ccache)
-option(USE_CCACHE "Cache the build results with ccache" OFF)
+option(USE_CCACHE "Cache the build results with ccache" ON)
 # Treat warnings as errors (Debug builds only)
 option(WARNING_AS_ERROR "Treat warnings as errors in debug builds" ON)
 # Check for translation updates

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,9 @@ else()
   )
 endif()
 
-if(USE_CCACHE)
+# ccache does not support MSVC and must not auto-engage on Windows
+# (it is installed unintentionally on the Windows CI runner)
+if(USE_CCACHE AND NOT WIN32)
   find_program(CCACHE_PROGRAM ccache)
   if(CCACHE_PROGRAM)
     # Support Unix Makefiles and Ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,9 @@ else()
 endif()
 
 # ccache does not support MSVC and must not auto-engage on Windows
-# (it is installed unintentionally on the Windows CI runner)
+# (it is installed unintentionally on the Windows CI runner).
+# NOTE: this keys off the target OS, so a mingw/Ninja configuration on Windows
+# also opts out of ccache even though the GNUCXX branch below supports it.
 if(USE_CCACHE AND NOT WIN32)
   find_program(CCACHE_PROGRAM ccache)
   if(CCACHE_PROGRAM)
@@ -52,6 +54,9 @@ if(USE_CCACHE AND NOT WIN32)
     execute_process(COMMAND ${CCACHE_PROGRAM} --set-config sloppiness=pch_defines,time_macros)
     message(STATUS "Found CCache ${CCACHE_PROGRAM}")
   endif()
+elseif(USE_CCACHE AND WIN32)
+  # An explicit opt-in must not disappear silently on Windows.
+  message(STATUS "ccache disabled: not supported for the MSVC toolchain on Windows")
 endif()
 
 if(WIN32 OR USE_VCPKG)


### PR DESCRIPTION
## Short roundup of the initial problem

ccache is installed by default on most dev machines but must be opted in with `-DUSE_CCACHE=ON`, so most contributors rebuild from scratch every time.

This was previously the default, but was changed to `OFF` in #7190 because ccache is not a supported cache for MSVC and is installed unintentionally on the Windows CI runner (see #7049).

## What will change with this Pull Request?
- Default `USE_CCACHE` to ON; `find_program` leaves the build untouched where ccache is not installed
- Auto-engage ccache only on non-Windows platforms (`NOT WIN32`) so it never affects MSVC builds on Windows, keeping the #7190 fix in place regardless of `USE_CCACHE`
- Users can still opt out with `-DUSE_CCACHE=OFF`
