### PR TITLE
[DeckShare] Browse and open public decks with loading, error and accessibility states

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -323,6 +323,8 @@ set(cockatrice_SOURCES
     src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_tag_display_widget.cpp
     src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_tag_item_widget.cpp
     src/interface/widgets/visual_deck_storage/deck_preview/deck_preview_widget.cpp
+    src/interface/widgets/visual_deck_storage/deck_preview/public_deck_preview_widget.cpp
+    src/interface/widgets/visual_deck_storage/remote_public_decks_model.cpp
     src/interface/widgets/visual_deck_storage/visual_deck_storage_folder_display_widget.cpp
     src/interface/widgets/visual_deck_storage/visual_deck_storage_model.cpp
     src/interface/widgets/visual_deck_storage/visual_deck_storage_quick_settings_widget.cpp
@@ -382,6 +384,7 @@ set(cockatrice_SOURCES
     src/interface/widgets/tabs/api/edhrec/display/top_tags/edhrec_top_tags_api_response_display_widget.cpp
     src/interface/widgets/tabs/api/edhrec/tab_edhrec.cpp
     src/interface/widgets/tabs/api/edhrec/tab_edhrec_main.cpp
+    src/interface/widgets/tabs/public_decks_quick_settings_widget.cpp
     src/interface/widgets/tabs/tab.cpp
     src/interface/widgets/tabs/tab_account.cpp
     src/interface/widgets/tabs/tab_admin.cpp
@@ -393,6 +396,7 @@ set(cockatrice_SOURCES
     src/interface/widgets/tabs/tab_logs.cpp
     src/interface/widgets/tabs/tab_message.cpp
     src/interface/widgets/tabs/tab_moderation.cpp
+    src/interface/widgets/tabs/tab_public_decks.cpp
     src/interface/widgets/tabs/tab_report.cpp
     src/interface/widgets/tabs/tab_replays.cpp
     src/interface/widgets/tabs/tab_room.cpp

--- a/cockatrice/src/interface/widgets/server/remote/remote_decklist_tree_widget.cpp
+++ b/cockatrice/src/interface/widgets/server/remote/remote_decklist_tree_widget.cpp
@@ -113,7 +113,7 @@ int RemoteDeckList_TreeModel::rowCount(const QModelIndex &parent) const
 
 int RemoteDeckList_TreeModel::columnCount(const QModelIndex & /*parent*/) const
 {
-    return 3;
+    return 4;
 }
 
 QVariant RemoteDeckList_TreeModel::data(const QModelIndex &index, int role) const
@@ -121,7 +121,7 @@ QVariant RemoteDeckList_TreeModel::data(const QModelIndex &index, int role) cons
     if (!index.isValid()) {
         return QVariant();
     }
-    if (index.column() >= 3) {
+    if (index.column() >= 4) {
         return QVariant();
     }
 
@@ -134,12 +134,20 @@ QVariant RemoteDeckList_TreeModel::data(const QModelIndex &index, int role) cons
                 switch (index.column()) {
                     case 0:
                         return node->getName();
+                    case 3:
+                        return isEffectivelyPublic(node) ? tr("Public") : tr("Private");
                     default:
                         return QVariant();
                 }
             }
             case Qt::DecorationRole:
                 return index.column() == 0 ? dirIcon : QVariant();
+            case Qt::ToolTipRole:
+                if (index.column() == 3) {
+                    return isEffectivelyPublic(node) ? tr("This folder is visible to other users")
+                                                     : tr("This folder is only visible to you");
+                }
+                return QVariant();
             default:
                 return QVariant();
         }
@@ -153,6 +161,8 @@ QVariant RemoteDeckList_TreeModel::data(const QModelIndex &index, int role) cons
                         return file->getId();
                     case 2:
                         return file->getUploadTime();
+                    case 3:
+                        return isEffectivelyPublic(file) ? tr("Public") : tr("Private");
                     default:
                         return QVariant();
                 }
@@ -161,6 +171,12 @@ QVariant RemoteDeckList_TreeModel::data(const QModelIndex &index, int role) cons
                 return index.column() == 0 ? fileIcon : QVariant();
             case Qt::TextAlignmentRole:
                 return index.column() == 1 ? Qt::AlignRight : Qt::AlignLeft;
+            case Qt::ToolTipRole:
+                if (index.column() == 3) {
+                    return isEffectivelyPublic(file) ? tr("This deck is visible to other users")
+                                                     : tr("This deck is only visible to you");
+                }
+                return QVariant();
             default:
                 return QVariant();
         }
@@ -183,6 +199,8 @@ QVariant RemoteDeckList_TreeModel::headerData(int section, Qt::Orientation orien
                     return tr("ID");
                 case 2:
                     return tr("Upload time");
+                case 3:
+                    return tr("Visibility");
                 default:
                     return QVariant();
             }
@@ -239,13 +257,14 @@ void RemoteDeckList_TreeModel::addFileToTree(const ServerInfo_DeckStorage_TreeIt
     time.setSecsSinceEpoch(fileInfo.creation_time());
 
     beginInsertRows(nodeToIndex(parent), parent->size(), parent->size());
-    parent->append(new FileNode(QString::fromStdString(file.name()), file.id(), time, parent));
+    parent->append(new FileNode(QString::fromStdString(file.name()), file.id(), time, parent, fileInfo.is_public()));
     endInsertRows();
 }
 
 void RemoteDeckList_TreeModel::addFolderToTree(const ServerInfo_DeckStorage_TreeItem &folder, DirectoryNode *parent)
 {
     DirectoryNode *newItem = addNamedFolderToTree(QString::fromStdString(folder.name()), parent);
+    newItem->setIsPublic(folder.folder().is_public());
     const ServerInfo_DeckStorage_Folder &folderInfo = folder.folder();
     const int folderItemsSize = folderInfo.items_size();
     for (int i = 0; i < folderItemsSize; ++i) {
@@ -283,6 +302,21 @@ void RemoteDeckList_TreeModel::refreshTree()
     connect(pend, &PendingCommand::finished, this, &RemoteDeckList_TreeModel::deckListFinished);
 
     client->sendCommand(pend);
+}
+
+bool RemoteDeckList_TreeModel::isEffectivelyPublic(const Node *node) const
+{
+    if (node == nullptr || node == root) {
+        return false;
+    }
+    const Node *current = node;
+    while (current != nullptr) {
+        if (current->isPublic()) {
+            return true;
+        }
+        current = current->getParent();
+    }
+    return false;
 }
 
 void RemoteDeckList_TreeModel::clearTree()

--- a/cockatrice/src/interface/widgets/server/remote/remote_decklist_tree_widget.h
+++ b/cockatrice/src/interface/widgets/server/remote/remote_decklist_tree_widget.h
@@ -27,9 +27,11 @@ public:
     protected:
         DirectoryNode *parent;
         QString name;
+        bool publicFlag;
 
     public:
-        explicit Node(const QString &_name, DirectoryNode *_parent = nullptr) : parent(_parent), name(_name)
+        explicit Node(const QString &_name, DirectoryNode *_parent = nullptr)
+            : parent(_parent), name(_name), publicFlag(false)
         {
         }
         virtual ~Node() = default;
@@ -40,6 +42,14 @@ public:
         [[nodiscard]] QString getName() const
         {
             return name;
+        }
+        [[nodiscard]] bool isPublic() const
+        {
+            return publicFlag;
+        }
+        void setIsPublic(bool _public)
+        {
+            publicFlag = _public;
         }
     };
     class DirectoryNode : public Node, public QList<Node *>
@@ -59,9 +69,14 @@ public:
         QDateTime uploadTime;
 
     public:
-        FileNode(const QString &_name, int _id, const QDateTime &_uploadTime, DirectoryNode *_parent = nullptr)
+        FileNode(const QString &_name,
+                 int _id,
+                 const QDateTime &_uploadTime,
+                 DirectoryNode *_parent = nullptr,
+                 bool _isPublic = false)
             : Node(_name, _parent), id(_id), uploadTime(_uploadTime)
         {
+            setIsPublic(_isPublic);
         }
         [[nodiscard]] int getId() const
         {
@@ -109,6 +124,11 @@ public:
     {
         return root;
     }
+    /**
+     * @brief Whether a node is visible to other users (own flag or inherited
+     * from any ancestor folder).
+     */
+    [[nodiscard]] bool isEffectivelyPublic(const Node *node) const;
     void addFileToTree(const ServerInfo_DeckStorage_TreeItem &file, DirectoryNode *parent);
     void addFolderToTree(const ServerInfo_DeckStorage_TreeItem &folder, DirectoryNode *parent);
     DirectoryNode *addNamedFolderToTree(const QString &name, DirectoryNode *parent);
@@ -125,6 +145,10 @@ private:
 
 public:
     explicit RemoteDeckList_TreeWidget(AbstractClient *_client, QWidget *parent = nullptr);
+    [[nodiscard]] RemoteDeckList_TreeModel *getModel() const
+    {
+        return treeModel;
+    }
     [[nodiscard]] RemoteDeckList_TreeModel::Node *getNode(const QModelIndex &ind) const;
     [[nodiscard]] RemoteDeckList_TreeModel::Node *getCurrentItem() const;
     [[nodiscard]] QList<RemoteDeckList_TreeModel::Node *> getCurrentSelection() const;

--- a/cockatrice/src/interface/widgets/server/user/user_context_menu.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_context_menu.cpp
@@ -37,6 +37,7 @@ UserContextMenu::UserContextMenu(TabSupervisor *_tabSupervisor, QWidget *parent,
     aDetails = new QAction(QString(), this);
     aChat = new QAction(QString(), this);
     aShowGames = new QAction(QString(), this);
+    aViewPublicDecks = new QAction(QString(), this);
     aAddToBuddyList = new QAction(QString(), this);
     aRemoveFromBuddyList = new QAction(QString(), this);
     aAddToIgnoreList = new QAction(QString(), this);
@@ -62,6 +63,7 @@ void UserContextMenu::retranslateUi()
     aDetails->setText(tr("User &details"));
     aChat->setText(tr("Private &chat"));
     aShowGames->setText(tr("Show this user's &games"));
+    aViewPublicDecks->setText(tr("View this user's &public decks"));
     aAddToBuddyList->setText(tr("Add to &buddy list"));
     aRemoveFromBuddyList->setText(tr("Remove from &buddy list"));
     aAddToIgnoreList->setText(tr("Add to &ignore list"));
@@ -372,6 +374,9 @@ void UserContextMenu::showContextMenu(const QPoint &pos,
     }
     menu->addAction(aDetails);
     menu->addAction(aShowGames);
+    if (userLevel.testFlag(ServerInfo_User::IsRegistered)) {
+        menu->addAction(aViewPublicDecks);
+    }
     menu->addAction(aChat);
     const QList<GameInviteOption> inviteOptions = inviteOptionsForUser(userName);
     if (!inviteOptions.isEmpty()) {
@@ -442,6 +447,7 @@ void UserContextMenu::showContextMenu(const QPoint &pos,
     aChat->setEnabled(anotherUser && online);
     aShowGames->setEnabled(online);
     aReport->setEnabled(anotherUser);
+    aViewPublicDecks->setEnabled(anotherUser);
     aAddToBuddyList->setEnabled(anotherUser);
     aRemoveFromBuddyList->setEnabled(anotherUser);
     aAddToIgnoreList->setEnabled(anotherUser);
@@ -464,6 +470,8 @@ void UserContextMenu::showContextMenu(const QPoint &pos,
         execChat(userName);
     } else if (actionClicked == aShowGames) {
         execShowGames(userName);
+    } else if (actionClicked == aViewPublicDecks) {
+        execViewPublicDecks(userName);
     } else if (actionClicked == aAddToBuddyList) {
         execAddToBuddy(userName);
     } else if (actionClicked == aRemoveFromBuddyList) {
@@ -583,6 +591,11 @@ void UserContextMenu::execShowGames(const QString &userName)
     PendingCommand *pend = client->prepareSessionCommand(cmd);
     connect(pend, &PendingCommand::finished, this, &UserContextMenu::gamesOfUserReceived);
     client->sendCommand(pend);
+}
+
+void UserContextMenu::execViewPublicDecks(const QString &userName)
+{
+    tabSupervisor->openTabPublicDecks(userName);
 }
 
 void UserContextMenu::execAddToBuddy(const QString &userName)

--- a/cockatrice/src/interface/widgets/server/user/user_context_menu.h
+++ b/cockatrice/src/interface/widgets/server/user/user_context_menu.h
@@ -37,6 +37,7 @@ private:
     QAction *aUserName;
     QAction *aDetails;
     QAction *aShowGames;
+    QAction *aViewPublicDecks;
     QAction *aChat;
     QAction *aAddToBuddyList, *aRemoveFromBuddyList;
     QAction *aAddToIgnoreList, *aRemoveFromIgnoreList;
@@ -110,6 +111,7 @@ public:
     void execInvite(const QString &userName);
     void execDetails(const QString &userName);
     void execShowGames(const QString &userName);
+    void execViewPublicDecks(const QString &userName);
     void execAddToBuddy(const QString &userName);
     void execRemoveFromBuddy(const QString &userName);
     void execAddToIgnore(const QString &userName);

--- a/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/abstract_tab_deck_editor.cpp
@@ -324,6 +324,7 @@ bool AbstractTabDeckEditor::actSaveDeck()
         Command_DeckUpload cmd;
         cmd.set_deck_id(static_cast<google::protobuf::uint32>(loadedDeck.lastLoadInfo.remoteDeckId));
         cmd.set_deck_list(deckString.toStdString());
+        cmd.set_tags(loadedDeck.deckList.getTags().join(QStringLiteral(",")).toStdString());
 
         PendingCommand *pend = AbstractClient::prepareSessionCommand(cmd);
         connect(pend, &PendingCommand::finished, this, &AbstractTabDeckEditor::saveDeckRemoteFinished);

--- a/cockatrice/src/interface/widgets/tabs/public_decks_quick_settings_widget.cpp
+++ b/cockatrice/src/interface/widgets/tabs/public_decks_quick_settings_widget.cpp
@@ -1,0 +1,151 @@
+#include "public_decks_quick_settings_widget.h"
+
+#include "../../../client/settings/cache_settings.h"
+#include "../cards/card_size_widget.h"
+
+#include <QCheckBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QSpinBox>
+#include <libcockatrice/settings/cards_display_settings.h>
+#include <libcockatrice/settings/personal_settings.h>
+#include <libcockatrice/settings/visual_deck_storage_settings.h>
+
+PublicDecksQuickSettingsWidget::PublicDecksQuickSettingsWidget(QWidget *parent) : SettingsButtonWidget(parent)
+{
+    // show color identity on preview tiles checkbox
+    showColorIdentityCheckBox = new QCheckBox(this);
+    showColorIdentityCheckBox->setChecked(
+        SettingsCache::instance().visualDeckStorage().getVisualDeckStorageShowColorIdentity());
+    connect(showColorIdentityCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+            &PublicDecksQuickSettingsWidget::showColorIdentityChanged);
+    connect(showColorIdentityCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance().visualDeckStorage(),
+            &VisualDeckStorageSettings::setVisualDeckStorageShowColorIdentity);
+
+    // show tags on preview tiles checkbox
+    showTagsOnDeckPreviewsCheckBox = new QCheckBox(this);
+    showTagsOnDeckPreviewsCheckBox->setChecked(
+        SettingsCache::instance().visualDeckStorage().getVisualDeckStorageShowTagsOnDeckPreviews());
+    connect(showTagsOnDeckPreviewsCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+            &PublicDecksQuickSettingsWidget::showTagsOnDeckPreviewsChanged);
+    connect(showTagsOnDeckPreviewsCheckBox, &QCheckBox::QT_STATE_CHANGED,
+            &SettingsCache::instance().visualDeckStorage(),
+            &VisualDeckStorageSettings::setVisualDeckStorageShowTagsOnDeckPreviews);
+
+    // show the last modified / upload time on preview tiles checkbox
+    showUploadTimeCheckBox = new QCheckBox(this);
+    showUploadTimeCheckBox->setChecked(
+        SettingsCache::instance().visualDeckStorage().getVisualDeckStorageShowUploadTime());
+    connect(showUploadTimeCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+            &PublicDecksQuickSettingsWidget::showUploadTimeChanged);
+    connect(showUploadTimeCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance().visualDeckStorage(),
+            &VisualDeckStorageSettings::setVisualDeckStorageShowUploadTime);
+
+    // show tag filter box checkbox
+    showTagFilterCheckBox = new QCheckBox(this);
+    showTagFilterCheckBox->setChecked(
+        SettingsCache::instance().visualDeckStorage().getVisualDeckStorageShowTagFilter());
+    connect(showTagFilterCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+            &PublicDecksQuickSettingsWidget::showTagFilterChanged);
+    connect(showTagFilterCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance().visualDeckStorage(),
+            &VisualDeckStorageSettings::setVisualDeckStorageShowTagFilter);
+
+    // draw unused color identities checkbox
+    drawUnusedColorIdentitiesCheckBox = new QCheckBox(this);
+    drawUnusedColorIdentitiesCheckBox->setChecked(
+        SettingsCache::instance().visualDeckStorage().getVisualDeckStorageDrawUnusedColorIdentities());
+    connect(drawUnusedColorIdentitiesCheckBox, &QCheckBox::QT_STATE_CHANGED, this,
+            &PublicDecksQuickSettingsWidget::drawUnusedColorIdentitiesChanged);
+    connect(drawUnusedColorIdentitiesCheckBox, &QCheckBox::QT_STATE_CHANGED,
+            &SettingsCache::instance().visualDeckStorage(),
+            &VisualDeckStorageSettings::setVisualDeckStorageDrawUnusedColorIdentities);
+
+    // unused color identities opacity selector
+    auto unusedColorIdentityOpacityWidget = new QWidget(this);
+
+    unusedColorIdentitiesOpacityLabel = new QLabel(unusedColorIdentityOpacityWidget);
+    unusedColorIdentitiesOpacitySpinBox = new QSpinBox(unusedColorIdentityOpacityWidget);
+
+    unusedColorIdentitiesOpacitySpinBox->setMinimum(0);
+    unusedColorIdentitiesOpacitySpinBox->setMaximum(100);
+    unusedColorIdentitiesOpacitySpinBox->setValue(
+        SettingsCache::instance().visualDeckStorage().getVisualDeckStorageUnusedColorIdentitiesOpacity());
+    connect(unusedColorIdentitiesOpacitySpinBox, qOverload<int>(&QSpinBox::valueChanged), this,
+            &PublicDecksQuickSettingsWidget::unusedColorIdentitiesOpacityChanged);
+    connect(unusedColorIdentitiesOpacitySpinBox, qOverload<int>(&QSpinBox::valueChanged),
+            &SettingsCache::instance().visualDeckStorage(),
+            &VisualDeckStorageSettings::setVisualDeckStorageUnusedColorIdentitiesOpacity);
+
+    unusedColorIdentitiesOpacityLabel->setBuddy(unusedColorIdentitiesOpacitySpinBox);
+
+    auto unusedColorIdentityOpacityLayout = new QHBoxLayout(unusedColorIdentityOpacityWidget);
+    unusedColorIdentityOpacityLayout->setContentsMargins(11, 0, 11, 0);
+    unusedColorIdentityOpacityLayout->addWidget(unusedColorIdentitiesOpacityLabel);
+    unusedColorIdentityOpacityLayout->addWidget(unusedColorIdentitiesOpacitySpinBox);
+
+    // card size slider (kept at the bottom, like the Visual Deck Storage)
+    cardSizeWidget =
+        new CardSizeWidget(this, nullptr, SettingsCache::instance().cardsDisplay().getVisualDeckStorageCardSize());
+    connect(cardSizeWidget->getSlider(), &QSlider::valueChanged, this,
+            &PublicDecksQuickSettingsWidget::cardSizeChanged);
+    connect(cardSizeWidget, &CardSizeWidget::cardSizeSettingUpdated, &SettingsCache::instance().cardsDisplay(),
+            &CardsDisplaySettings::setVisualDeckStorageCardSize);
+
+    this->addSettingsWidget(showColorIdentityCheckBox);
+    this->addSettingsWidget(showTagsOnDeckPreviewsCheckBox);
+    this->addSettingsWidget(showUploadTimeCheckBox);
+    this->addSettingsWidget(showTagFilterCheckBox);
+    this->addSettingsWidget(drawUnusedColorIdentitiesCheckBox);
+    this->addSettingsWidget(unusedColorIdentityOpacityWidget);
+    this->addSettingsWidget(cardSizeWidget);
+
+    connect(&SettingsCache::instance().personal(), &PersonalSettings::langChanged, this,
+            &PublicDecksQuickSettingsWidget::retranslateUi);
+    retranslateUi();
+}
+
+void PublicDecksQuickSettingsWidget::retranslateUi()
+{
+    showColorIdentityCheckBox->setText(tr("Show Color Identity"));
+    showTagsOnDeckPreviewsCheckBox->setText(tr("Show Tags On Deck Previews"));
+    showUploadTimeCheckBox->setText(tr("Show Upload Time"));
+    showTagFilterCheckBox->setText(tr("Show Tag Filter"));
+    drawUnusedColorIdentitiesCheckBox->setText(tr("Draw unused Color Identities"));
+    unusedColorIdentitiesOpacityLabel->setText(tr("Unused Color Identities Opacity"));
+    unusedColorIdentitiesOpacitySpinBox->setSuffix("%");
+}
+
+bool PublicDecksQuickSettingsWidget::getDrawUnusedColorIdentities() const
+{
+    return drawUnusedColorIdentitiesCheckBox->isChecked();
+}
+
+bool PublicDecksQuickSettingsWidget::getShowColorIdentity() const
+{
+    return showColorIdentityCheckBox->isChecked();
+}
+
+bool PublicDecksQuickSettingsWidget::getShowTagFilter() const
+{
+    return showTagFilterCheckBox->isChecked();
+}
+
+bool PublicDecksQuickSettingsWidget::getShowTagsOnDeckPreviews() const
+{
+    return showTagsOnDeckPreviewsCheckBox->isChecked();
+}
+
+bool PublicDecksQuickSettingsWidget::getShowUploadTime() const
+{
+    return showUploadTimeCheckBox->isChecked();
+}
+
+int PublicDecksQuickSettingsWidget::getUnusedColorIdentitiesOpacity() const
+{
+    return unusedColorIdentitiesOpacitySpinBox->value();
+}
+
+CardSizeWidget *PublicDecksQuickSettingsWidget::getCardSizeWidget() const
+{
+    return cardSizeWidget;
+}

--- a/cockatrice/src/interface/widgets/tabs/public_decks_quick_settings_widget.h
+++ b/cockatrice/src/interface/widgets/tabs/public_decks_quick_settings_widget.h
@@ -1,0 +1,57 @@
+/**
+ * @file public_decks_quick_settings_widget.h
+ * @ingroup Tabs
+ * @brief The quick settings menu for the public decks tab.
+ * Manages the widgets in the quick settings menu dropdown of the public decks
+ * tab, and syncs their values with the same SettingsCache keys the Visual Deck
+ * Storage uses, so shared preview widgets (color identity, tags) behave the
+ * same way in both places.
+ */
+
+#ifndef PUBLIC_DECKS_QUICK_SETTINGS_WIDGET_H
+#define PUBLIC_DECKS_QUICK_SETTINGS_WIDGET_H
+
+#include "../quick_settings/settings_button_widget.h"
+
+class CardSizeWidget;
+class QCheckBox;
+class QLabel;
+class QSpinBox;
+
+class PublicDecksQuickSettingsWidget : public SettingsButtonWidget
+{
+    Q_OBJECT
+
+    QCheckBox *showColorIdentityCheckBox;
+    QCheckBox *drawUnusedColorIdentitiesCheckBox;
+    QCheckBox *showTagFilterCheckBox;
+    QCheckBox *showTagsOnDeckPreviewsCheckBox;
+    QCheckBox *showUploadTimeCheckBox;
+    QLabel *unusedColorIdentitiesOpacityLabel;
+    QSpinBox *unusedColorIdentitiesOpacitySpinBox;
+    CardSizeWidget *cardSizeWidget;
+
+public:
+    explicit PublicDecksQuickSettingsWidget(QWidget *parent = nullptr);
+
+    void retranslateUi();
+
+    [[nodiscard]] bool getDrawUnusedColorIdentities() const;
+    [[nodiscard]] bool getShowColorIdentity() const;
+    [[nodiscard]] bool getShowTagFilter() const;
+    [[nodiscard]] bool getShowTagsOnDeckPreviews() const;
+    [[nodiscard]] bool getShowUploadTime() const;
+    [[nodiscard]] int getUnusedColorIdentitiesOpacity() const;
+    [[nodiscard]] CardSizeWidget *getCardSizeWidget() const;
+
+signals:
+    void drawUnusedColorIdentitiesChanged(bool enabled);
+    void showColorIdentityChanged(bool enabled);
+    void showTagFilterChanged(bool enabled);
+    void showTagsOnDeckPreviewsChanged(bool enabled);
+    void showUploadTimeChanged(bool enabled);
+    void unusedColorIdentitiesOpacityChanged(int opacity);
+    void cardSizeChanged(int scale);
+};
+
+#endif // PUBLIC_DECKS_QUICK_SETTINGS_WIDGET_H

--- a/cockatrice/src/interface/widgets/tabs/tab_deck_storage.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_deck_storage.cpp
@@ -2,6 +2,7 @@
 
 #include "../../../client/settings/cache_settings.h"
 #include "../../deck_loader/deck_loader.h"
+#include "../cards/additional_info/deck_color_identity.h"
 #include "../deck_share/deck_share_utils.h"
 #include "../deck_share/share_bar_widget.h"
 #include "../interface/widgets/server/remote/remote_decklist_tree_widget.h"
@@ -24,11 +25,13 @@
 #include <QTreeView>
 #include <QUrl>
 #include <QVBoxLayout>
+#include <libcockatrice/card/database/card_database_manager.h>
 #include <libcockatrice/deck_list/deck_list.h>
 #include <libcockatrice/protocol/pb/command_deck_del.pb.h>
 #include <libcockatrice/protocol/pb/command_deck_del_dir.pb.h>
 #include <libcockatrice/protocol/pb/command_deck_download.pb.h>
 #include <libcockatrice/protocol/pb/command_deck_new_dir.pb.h>
+#include <libcockatrice/protocol/pb/command_deck_set_visibility.pb.h>
 #include <libcockatrice/protocol/pb/command_deck_share_create.pb.h>
 #include <libcockatrice/protocol/pb/command_deck_upload.pb.h>
 #include <libcockatrice/protocol/pb/response.pb.h>
@@ -159,6 +162,10 @@ TabDeckStorage::TabDeckStorage(TabSupervisor *_tabSupervisor,
     aShareDecks->setIcon(QPixmap("theme:icons/share"));
     connect(aShareDecks, &QAction::triggered, this, &TabDeckStorage::actShareDecks);
 
+    aPublishDeck = new QAction(this);
+    aPublishDeck->setIcon(QPixmap("theme:icons/lock"));
+    connect(aPublishDeck, &QAction::triggered, this, &TabDeckStorage::actPublishDeck);
+
     // Add actions to toolbars
     leftToolBar->addAction(aOpenLocalDeck);
     leftToolBar->addAction(aRenameLocal);
@@ -171,6 +178,7 @@ TabDeckStorage::TabDeckStorage(TabSupervisor *_tabSupervisor,
     rightToolBar->addAction(aOpenRemoteDeck);
     rightToolBar->addAction(aDownload);
     rightToolBar->addAction(aShareDecks);
+    rightToolBar->addAction(aPublishDeck);
     rightToolBar->addAction(aNewFolder);
     rightToolBar->addAction(aDeleteRemoteDeck);
 
@@ -200,6 +208,7 @@ void TabDeckStorage::retranslateUi()
     aDeleteLocalDeck->setText(tr("Delete"));
     aDeleteRemoteDeck->setText(tr("Delete"));
     aShareDecks->setText(tr("Share decks"));
+    aPublishDeck->setText(tr("Publish/unpublish deck"));
     aOpenDecksFolder->setText(tr("Open decks folder"));
     shareBar->retranslateUi();
 }
@@ -244,6 +253,7 @@ void TabDeckStorage::setRemoteEnabled(bool enabled)
     aOpenRemoteDeck->setEnabled(enabled);
     aDownload->setEnabled(enabled);
     aShareDecks->setEnabled(enabled);
+    aPublishDeck->setEnabled(enabled);
     aNewFolder->setEnabled(enabled);
     aDeleteRemoteDeck->setEnabled(enabled);
 
@@ -371,6 +381,12 @@ void TabDeckStorage::uploadDeck(const QString &filePath, const QString &targetPa
     Command_DeckUpload cmd;
     cmd.set_path(targetPath.toStdString());
     cmd.set_deck_list(deckString.toStdString());
+
+    const CardRef bannerCard = deck.getBannerCard();
+    cmd.set_banner_card_name(bannerCard.name.toStdString());
+    cmd.set_banner_card_provider(bannerCard.providerId.toStdString());
+    cmd.set_color_identity(getDeckColorIdentity(deck, CardDatabaseManager::query()).toStdString());
+    cmd.set_tags(deck.getTags().join(QStringLiteral(",")).toStdString());
 
     PendingCommand *pend = client->prepareSessionCommand(cmd);
     connect(pend, &PendingCommand::finished, this, &TabDeckStorage::uploadFinished);
@@ -795,7 +811,49 @@ void TabDeckStorage::shareFromTreeFinished(const Response &response, const Comma
 
 void TabDeckStorage::showShareNotice(const QString &message, bool warning)
 {
-    QMessageBox box(warning ? QMessageBox::Warning : QMessageBox::Information, tr("Deck share"), message,
+    QMessageBox box(warning ? QMessageBox::Warning : QMessageBox::Information, tr("Share link"), message,
                     QMessageBox::Ok, this);
     box.exec();
+}
+
+void TabDeckStorage::actPublishDeck()
+{
+    const auto selection = serverDirView->getCurrentSelection();
+    for (const auto *node : selection) {
+        Command_DeckSetVisibility cmd;
+        if (const auto *fileNode = dynamic_cast<const RemoteDeckList_TreeModel::FileNode *>(node)) {
+            cmd.set_deck_id(fileNode->getId());
+        } else if (const auto *dirNode = dynamic_cast<const RemoteDeckList_TreeModel::DirectoryNode *>(node)) {
+            const QString path = dirNode->getPath();
+            if (path.isEmpty()) {
+                continue; // the root folder cannot be published
+            }
+            cmd.set_folder_path(path.toStdString());
+        } else {
+            continue;
+        }
+        // Toggle the node's own visibility bit (what the server persists); the
+        // effective visibility shown by the column may additionally be inherited
+        // from a parent folder.
+        cmd.set_is_public(!node->isPublic());
+
+        PendingCommand *pend = client->prepareSessionCommand(cmd);
+        connect(pend, &PendingCommand::finished, this, &TabDeckStorage::setVisibilityFinished);
+        client->sendCommand(pend);
+        ++pendingVisibilityChanges;
+    }
+}
+
+void TabDeckStorage::setVisibilityFinished(const Response &r, const CommandContainer & /*commandContainer*/)
+{
+    if (r.response_code() != Response::RespOk) {
+        QMessageBox::critical(this, tr("Error"),
+                              tr("Failed to change deck visibility on server (response code %1).")
+                                  .arg(QString::number(static_cast<int>(r.response_code()))));
+    }
+    // Refresh once the last in-flight change has been acknowledged so the
+    // Public/Private column reflects every selected node.
+    if (--pendingVisibilityChanges == 0) {
+        serverDirView->refreshTree();
+    }
 }

--- a/cockatrice/src/interface/widgets/tabs/tab_deck_storage.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_deck_storage.h
@@ -40,7 +40,8 @@ private:
 
     QAction *aOpenLocalDeck, *aRenameLocal, *aUpload, *aNewLocalFolder, *aDeleteLocalDeck;
     QAction *aOpenDecksFolder;
-    QAction *aOpenRemoteDeck, *aDownload, *aShareDecks, *aNewFolder, *aDeleteRemoteDeck;
+    QAction *aOpenRemoteDeck, *aDownload, *aShareDecks, *aPublishDeck, *aNewFolder, *aDeleteRemoteDeck;
+    int pendingVisibilityChanges = 0;
     QString getTargetPath() const;
 
     void setRemoteEnabled(bool enabled);
@@ -86,6 +87,9 @@ private slots:
     void cancelShareDecks();
     void onServerSelectionChanged();
     void shareFromTreeFinished(const Response &r, const CommandContainer &commandContainer);
+
+    void actPublishDeck();
+    void setVisibilityFinished(const Response &r, const CommandContainer &commandContainer);
 
     void actDeleteRemoteDeck();
     void deleteFolderFinished(const Response &response, const CommandContainer &commandContainer);

--- a/cockatrice/src/interface/widgets/tabs/tab_public_decks.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_public_decks.cpp
@@ -1,0 +1,230 @@
+#include "tab_public_decks.h"
+
+#include "../../../client/settings/cache_settings.h"
+#include "../../deck_loader/deck_loader.h"
+#include "../general/layout_containers/flow_widget.h"
+#include "../visual_deck_storage/deck_preview/deck_preview_color_identity_filter_widget.h"
+#include "../visual_deck_storage/deck_preview/public_deck_preview_widget.h"
+#include "../visual_deck_storage/remote_public_decks_model.h"
+#include "../visual_deck_storage/visual_deck_storage_search_widget.h"
+#include "../visual_deck_storage/visual_deck_storage_tag_filter_widget.h"
+#include "public_decks_quick_settings_widget.h"
+#include "tab_supervisor.h"
+
+#include <QDateTime>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPixmap>
+#include <QStringList>
+#include <QToolButton>
+#include <QVBoxLayout>
+#include <libcockatrice/network/client/abstract/abstract_client.h>
+#include <libcockatrice/protocol/pb/command_deck_download_public.pb.h>
+#include <libcockatrice/protocol/pb/response.pb.h>
+#include <libcockatrice/protocol/pb/response_deck_download.pb.h>
+#include <libcockatrice/protocol/pending_command.h>
+#include <libcockatrice/settings/cards_display_settings.h>
+#include <optional>
+
+TabPublicDecks::TabPublicDecks(TabSupervisor *_tabSupervisor, AbstractClient *_client, const QString &_userName)
+    : Tab(_tabSupervisor), client(_client), userName(_userName)
+{
+    model = new RemotePublicDecksModel(client, this);
+    cardSize = SettingsCache::instance().cardsDisplay().getVisualDeckStorageCardSize();
+
+    titleLabel = new QLabel(tr("Public decks of %1").arg(userName), this);
+    QFont titleFont = titleLabel->font();
+    titleFont.setBold(true);
+    titleLabel->setFont(titleFont);
+
+    auto *headerLayout = new QHBoxLayout;
+    headerLayout->addWidget(titleLabel);
+    headerLayout->addStretch(1);
+
+    // Filter/toolbar row, matching the Visual Deck Storage: color identity filter
+    // first, the search bar stretching in the middle, and the quick settings
+    // cogwheel at the end. The card size slider lives inside the cogwheel popup.
+    emptyLabel = new QLabel(tr("This user has not published any decks."), this);
+    emptyLabel->setAlignment(Qt::AlignCenter);
+    emptyLabel->setVisible(false);
+
+    statusLabel = new QLabel(this);
+    statusLabel->setAlignment(Qt::AlignCenter);
+    statusLabel->setVisible(false);
+
+    flowWidget = new FlowWidget(this, Qt::Horizontal, Qt::ScrollBarAlwaysOff, Qt::ScrollBarAsNeeded);
+    flowWidget->setSpacing(8, 8);
+
+    colorIdentityFilter = new DeckPreviewColorIdentityFilterWidget(this);
+    searchWidget = new VisualDeckStorageSearchWidget(this);
+    searchWidget->setPlaceholderText(tr("Search by deck name"));
+    refreshButton = new QToolButton(this);
+    refreshButton->setIcon(QPixmap("theme:icons/reload"));
+    refreshButton->setFixedSize(32, 32);
+    quickSettingsWidget = new PublicDecksQuickSettingsWidget(this);
+
+    auto *filterLayout = new QHBoxLayout;
+    filterLayout->addWidget(colorIdentityFilter);
+    filterLayout->addWidget(searchWidget, 1);
+    filterLayout->addWidget(refreshButton);
+    filterLayout->addWidget(quickSettingsWidget);
+
+    tagFilterWidget = new VisualDeckStorageTagFilterWidget(this);
+    tagFilterWidget->setAllTagsProvider([this] { return model->allTags(); });
+    updateTagsVisibility(quickSettingsWidget->getShowTagFilter());
+
+    auto *layout = new QVBoxLayout;
+    layout->addLayout(headerLayout);
+    layout->addLayout(filterLayout);
+    layout->addWidget(tagFilterWidget);
+    layout->addWidget(statusLabel);
+    layout->addWidget(emptyLabel);
+    layout->addWidget(flowWidget, 1);
+
+    auto *mainWidget = new QWidget(this);
+    mainWidget->setLayout(layout);
+    setCentralWidget(mainWidget);
+
+    connect(refreshButton, &QToolButton::clicked, this, [this] { model->refresh(userName); });
+    connect(model, &QAbstractItemModel::modelReset, this, &TabPublicDecks::rebuildGrid);
+    connect(model, &RemotePublicDecksModel::loadingChanged, this, &TabPublicDecks::updateLoadingState);
+    connect(model, &RemotePublicDecksModel::loadFailed, this, [this](const QString &message) {
+        statusLabel->setText(message);
+        statusLabel->setVisible(true);
+        flowWidget->setVisible(false);
+        emptyLabel->setVisible(false);
+    });
+    connect(searchWidget, &VisualDeckStorageSearchWidget::searchTextChanged, this,
+            [this](const QString &text) { model->setSearchText(text); });
+    connect(colorIdentityFilter, &DeckPreviewColorIdentityFilterWidget::activeColorsChanged, this,
+            &TabPublicDecks::updateColorFilter);
+    connect(colorIdentityFilter, &DeckPreviewColorIdentityFilterWidget::filterModeChanged, this,
+            &TabPublicDecks::updateColorFilter);
+    connect(tagFilterWidget, &VisualDeckStorageTagFilterWidget::filterChanged, this, &TabPublicDecks::updateTagFilter);
+    connect(quickSettingsWidget, &PublicDecksQuickSettingsWidget::cardSizeChanged, this,
+            &TabPublicDecks::updateCardSize);
+    connect(quickSettingsWidget, &PublicDecksQuickSettingsWidget::showTagFilterChanged, this,
+            &TabPublicDecks::updateTagsVisibility);
+
+    model->refresh(userName);
+}
+
+QString TabPublicDecks::getTabText() const
+{
+    return tr("Public decks of %1").arg(userName);
+}
+
+void TabPublicDecks::retranslateUi()
+{
+    titleLabel->setText(tr("Public decks of %1").arg(userName));
+    searchWidget->setPlaceholderText(tr("Search by deck name"));
+    emptyLabel->setText(tr("This user has not published any decks."));
+    refreshButton->setToolTip(tr("Refresh"));
+    quickSettingsWidget->setToolTip(tr("Public Decks Settings"));
+    emit tabTextChanged(this, getTabText());
+}
+
+bool TabPublicDecks::closeRequest()
+{
+    emit closing(this);
+    return Tab::closeRequest();
+}
+
+void TabPublicDecks::rebuildGrid()
+{
+    flowWidget->clearLayout();
+
+    const int count = model->rowCount();
+    if (count == 0) {
+        emptyLabel->setText(model->totalCount() > 0 ? tr("No decks match your filters.")
+                                                    : tr("This user has not published any decks."));
+    }
+    emptyLabel->setVisible(count == 0);
+    for (int i = 0; i < count; ++i) {
+        auto *tile = new PublicDeckPreviewWidget(flowWidget, model->entryAt(i));
+        tile->setScaleFactor(cardSize);
+        connect(tile, &PublicDeckPreviewWidget::openDeckRequested, this, &TabPublicDecks::openDeck);
+        flowWidget->addWidget(tile);
+    }
+
+    // The deck set changed, so the tag filter chips are re-gathered from it.
+    tagFilterWidget->refreshTags();
+}
+
+void TabPublicDecks::updateColorFilter()
+{
+    model->setColorFilter(colorIdentityFilter->getFilterMode(), colorIdentityFilter->getActiveColors());
+}
+
+void TabPublicDecks::updateTagFilter()
+{
+    const QStringList selectedTags = tagFilterWidget->selectedTags();
+    const QStringList excludedTags = tagFilterWidget->excludedTags();
+    model->setTagFilter(QSet<QString>(selectedTags.cbegin(), selectedTags.cend()),
+                        QSet<QString>(excludedTags.cbegin(), excludedTags.cend()));
+    tagFilterWidget->refreshTags();
+}
+
+void TabPublicDecks::updateTagsVisibility(bool visible)
+{
+    tagFilterWidget->setVisible(visible);
+}
+
+void TabPublicDecks::updateLoadingState(bool loading)
+{
+    if (loading) {
+        statusLabel->setText(tr("Loading public decks…"));
+        statusLabel->setVisible(true);
+        flowWidget->setVisible(false);
+        emptyLabel->setVisible(false);
+    } else {
+        statusLabel->setVisible(false);
+        flowWidget->setVisible(true);
+    }
+}
+
+void TabPublicDecks::updateCardSize(int scale)
+{
+    cardSize = scale;
+    applyCardSize(scale);
+}
+
+void TabPublicDecks::applyCardSize(int scale)
+{
+    const auto tiles = flowWidget->findChildren<PublicDeckPreviewWidget *>();
+    for (PublicDeckPreviewWidget *tile : tiles) {
+        tile->setScaleFactor(scale);
+    }
+    flowWidget->setMinimumSizeToMaxSizeHint();
+}
+
+void TabPublicDecks::openDeck(int deckId)
+{
+    Command_DeckDownloadPublic cmd;
+    cmd.set_deck_id(deckId);
+
+    PendingCommand *pend = client->prepareSessionCommand(cmd);
+    connect(pend, &PendingCommand::finished, this, &TabPublicDecks::openDeckFinished);
+    client->sendCommand(pend);
+}
+
+void TabPublicDecks::openDeckFinished(const Response &response, const CommandContainer & /*commandContainer*/)
+{
+    if (response.response_code() != Response::RespOk) {
+        QMessageBox::warning(this, tr("Open public deck"),
+                             tr("Failed to open the public deck (server response code %1).")
+                                 .arg(QString::number(static_cast<int>(response.response_code()))));
+        return;
+    }
+
+    const Response_DeckDownload &resp = response.GetExtension(Response_DeckDownload::ext);
+    std::optional<LoadedDeck> deckOpt =
+        DeckLoader::loadFromRemote(QString::fromStdString(resp.deck()), LoadedDeck::LoadInfo::NON_REMOTE_ID);
+    if (!deckOpt) {
+        QMessageBox::warning(this, tr("Open public deck"), tr("The public deck could not be parsed."));
+        return;
+    }
+
+    tabSupervisor->openDeckInNewTab(deckOpt.value());
+}

--- a/cockatrice/src/interface/widgets/tabs/tab_public_decks.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_public_decks.h
@@ -1,0 +1,79 @@
+/**
+ * @file tab_public_decks.h
+ * @ingroup Tabs
+ */
+
+#ifndef TAB_PUBLIC_DECKS_H
+#define TAB_PUBLIC_DECKS_H
+
+#include "tab.h"
+
+class AbstractClient;
+class CommandContainer;
+class DeckPreviewColorIdentityFilterWidget;
+class FlowWidget;
+class PublicDeckPreviewWidget;
+class PublicDecksQuickSettingsWidget;
+class QLabel;
+class QToolButton;
+class RemotePublicDecksModel;
+class Response;
+class VisualDeckStorageSearchWidget;
+class VisualDeckStorageTagFilterWidget;
+
+/**
+ * @brief A visual grid of the public decks published by another user.
+ *
+ * The grid is rendered from the preview metadata the server stores for the
+ * decks, so browsing costs no downloads; the deck list is fetched via
+ * Command_DeckDownloadPublic only when the user opens a deck. Multiple users
+ * can be browsed simultaneously; each gets its own tab.
+ */
+class TabPublicDecks final : public Tab
+{
+    Q_OBJECT
+
+public:
+    TabPublicDecks(TabSupervisor *tabSupervisor, AbstractClient *client, const QString &userName);
+
+    [[nodiscard]] QString getTabText() const override;
+    void retranslateUi() override;
+    bool closeRequest() override;
+
+    [[nodiscard]] QString getUserName() const
+    {
+        return userName;
+    }
+
+signals:
+    void closing(TabPublicDecks *tab);
+
+private slots:
+    void openDeck(int deckId);
+    void openDeckFinished(const Response &response, const CommandContainer &commandContainer);
+    void updateColorFilter();
+    void updateTagFilter();
+    void updateCardSize(int scale);
+    void updateTagsVisibility(bool visible);
+    void updateLoadingState(bool loading);
+
+private:
+    void rebuildGrid();
+    void applyCardSize(int scale);
+
+    AbstractClient *client;
+    QString userName;
+    RemotePublicDecksModel *model;
+    FlowWidget *flowWidget;
+    VisualDeckStorageSearchWidget *searchWidget;
+    DeckPreviewColorIdentityFilterWidget *colorIdentityFilter;
+    VisualDeckStorageTagFilterWidget *tagFilterWidget;
+    QToolButton *refreshButton;
+    PublicDecksQuickSettingsWidget *quickSettingsWidget;
+    QLabel *titleLabel;
+    QLabel *statusLabel;
+    QLabel *emptyLabel;
+    int cardSize = 100;
+};
+
+#endif // TAB_PUBLIC_DECKS_H

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
@@ -20,6 +20,7 @@
 #include "tab_logs.h"
 #include "tab_message.h"
 #include "tab_moderation.h"
+#include "tab_public_decks.h"
 #include "tab_replays.h"
 #include "tab_report.h"
 #include "tab_room.h"
@@ -266,6 +267,10 @@ void TabSupervisor::retranslateUi()
     QMapIterator<int, TabGame *> gameIterator(gameTabs);
     while (gameIterator.hasNext()) {
         tabs.append(gameIterator.next().value());
+    }
+    QMapIterator<QString, TabPublicDecks *> publicDecksIterator(publicDecksTabs);
+    while (publicDecksIterator.hasNext()) {
+        tabs.append(publicDecksIterator.next().value());
     }
     QListIterator<TabGame *> replayIterator(replayTabs);
     while (replayIterator.hasNext()) {
@@ -983,6 +988,30 @@ void TabSupervisor::roomLeft(TabRoom *tab)
     }
 
     roomTabs.remove(tab->getRoomId());
+    removeTab(indexOf(tab));
+}
+
+void TabSupervisor::openTabPublicDecks(const QString &userName)
+{
+    if (auto *existing = publicDecksTabs.value(userName, nullptr)) {
+        setCurrentWidget(existing);
+        return;
+    }
+
+    auto *tab = new TabPublicDecks(this, client, userName);
+    connect(tab, &TabPublicDecks::closing, this, &TabSupervisor::publicDecksClosed);
+    myAddTab(tab);
+    publicDecksTabs.insert(userName, tab);
+    setCurrentWidget(tab);
+}
+
+void TabSupervisor::publicDecksClosed(TabPublicDecks *tab)
+{
+    if (tab == currentWidget()) {
+        emit setMenu();
+    }
+
+    publicDecksTabs.remove(tab->getUserName());
     removeTab(indexOf(tab));
 }
 

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.h
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.h
@@ -46,6 +46,7 @@ class TabModeration;
 class TabAccount;
 class TabDeckEditor;
 class TabLog;
+class TabPublicDecks;
 class RoomEvent;
 class GameEventContainer;
 class Event_GameJoined;
@@ -112,6 +113,7 @@ private:
     QMap<int, TabGame *> gameTabs;
     QList<TabGame *> replayTabs;
     QMap<QString, TabMessage *> messageTabs;
+    QMap<QString, TabPublicDecks *> publicDecksTabs;
     QList<AbstractTabDeckEditor *> deckEditorTabs;
     bool isLocalGame;
 
@@ -196,6 +198,7 @@ public slots:
     void actTabReplays(bool checked);
     void openTabServer();
     void addRoomTab(const ServerInfo_Room &info, bool setCurrent);
+    void openTabPublicDecks(const QString &userName);
 private slots:
     void refreshShortcuts();
 
@@ -226,6 +229,7 @@ private slots:
     void localGameJoined(const Event_GameJoined &event);
     void gameLeft(TabGame *tab);
     void roomLeft(TabRoom *tab);
+    void publicDecksClosed(TabPublicDecks *tab);
     TabMessage *addMessageTab(const QString &userName, bool focus);
     void replayLeft(TabGame *tab);
     void processUserLeft(const QString &userName);

--- a/cockatrice/src/interface/widgets/tabs/visual_deck_storage/tab_deck_storage_visual.cpp
+++ b/cockatrice/src/interface/widgets/tabs/visual_deck_storage/tab_deck_storage_visual.cpp
@@ -194,7 +194,7 @@ void TabDeckStorageVisual::handleConnectionChanged(ClientStatus status)
 
 void TabDeckStorageVisual::showShareNotice(const QString &message, bool warning)
 {
-    QMessageBox box(warning ? QMessageBox::Warning : QMessageBox::Information, tr("Deck share"), message,
+    QMessageBox box(warning ? QMessageBox::Warning : QMessageBox::Information, tr("Share link"), message,
                     QMessageBox::Ok, this);
     box.exec();
 }

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/public_deck_preview_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/public_deck_preview_widget.cpp
@@ -1,0 +1,164 @@
+#include "public_deck_preview_widget.h"
+
+#include "../../../../client/settings/cache_settings.h"
+#include "../../cards/additional_info/color_identity_widget.h"
+#include "../../cards/deck_preview_card_picture_widget.h"
+#include "../../general/layout_containers/flow_widget.h"
+#include "deck_preview_tag_display_widget.h"
+
+#include <QKeyEvent>
+#include <QLabel>
+#include <QMouseEvent>
+#include <QResizeEvent>
+#include <QVBoxLayout>
+#include <libcockatrice/card/database/card_database_manager.h>
+#include <libcockatrice/settings/visual_deck_storage_settings.h>
+
+PublicDeckPreviewWidget::PublicDeckPreviewWidget(QWidget *parent, const RemotePublicDecksModel::DeckEntry &entry)
+    : QWidget(parent)
+{
+    bannerCardDisplayWidget = new DeckPreviewCardPictureWidget(this);
+    bannerCardDisplayWidget->setFontSize(24);
+
+    // The whole tile is a single focusable, keyboard-operable control: Tab lands
+    // on it and Space/Enter opens the deck, mirroring the shared-deck preview tile.
+    setFocusPolicy(Qt::StrongFocus);
+
+    uploadTimeLabel = new QLabel(this);
+    uploadTimeLabel->setAlignment(Qt::AlignHCenter);
+
+    colorIdentityWidget = new ColorIdentityWidget(this);
+
+    tagsFlowWidget = new FlowWidget(this, Qt::Horizontal, Qt::ScrollBarAlwaysOff, Qt::ScrollBarAsNeeded);
+    tagsFlowWidget->setSpacing(3, 3);
+
+    auto *layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->addWidget(bannerCardDisplayWidget);
+    layout->addWidget(uploadTimeLabel);
+    layout->addWidget(colorIdentityWidget);
+    layout->addWidget(tagsFlowWidget);
+    setLayout(layout);
+
+    connect(&SettingsCache::instance().visualDeckStorage(),
+            &VisualDeckStorageSettings::visualDeckStorageShowColorIdentityChanged, this,
+            &PublicDeckPreviewWidget::updateColorIdentityVisibility);
+    connect(&SettingsCache::instance().visualDeckStorage(),
+            &VisualDeckStorageSettings::visualDeckStorageShowTagsOnDeckPreviewsChanged, this,
+            &PublicDeckPreviewWidget::updateTagsVisibility);
+    connect(&SettingsCache::instance().visualDeckStorage(),
+            &VisualDeckStorageSettings::visualDeckStorageShowUploadTimeChanged, this,
+            &PublicDeckPreviewWidget::updateUploadTimeVisibility);
+
+    setEntry(entry);
+
+    connect(bannerCardDisplayWidget, &DeckPreviewCardPictureWidget::imageClicked, this,
+            &PublicDeckPreviewWidget::imageClickedEvent);
+    connect(bannerCardDisplayWidget, &DeckPreviewCardPictureWidget::imageDoubleClicked, this,
+            &PublicDeckPreviewWidget::imageDoubleClickedEvent);
+
+    // resizeEvent clamps every child to the banner picture's width, so collect them
+    // once here to keep the resize handler from searching the widget tree on every pass.
+    fixedWidthChildren = {bannerCardDisplayWidget, uploadTimeLabel, colorIdentityWidget, tagsFlowWidget};
+}
+
+void PublicDeckPreviewWidget::resizeEvent(QResizeEvent *event)
+{
+    QWidget::resizeEvent(event);
+    if (bannerCardDisplayWidget == nullptr) {
+        return;
+    }
+
+    const int width = bannerCardDisplayWidget->width();
+    if (width == lastKnownBannerWidth) {
+        return;
+    }
+    lastKnownBannerWidth = width;
+
+    for (QWidget *widget : fixedWidthChildren) {
+        widget->setMaximumWidth(width);
+    }
+}
+
+void PublicDeckPreviewWidget::setEntry(const RemotePublicDecksModel::DeckEntry &entry)
+{
+    deckId = entry.id;
+
+    hasColorIdentity = !entry.colorIdentity.isEmpty();
+    colorIdentityWidget->setColorIdentity(entry.colorIdentity);
+    updateColorIdentityVisibility();
+
+    const ExactCard bannerCard =
+        entry.bannerCardName.isEmpty()
+            ? ExactCard()
+            : CardDatabaseManager::query()->getCard(CardRef{entry.bannerCardName, entry.bannerCardProvider});
+    bannerCardDisplayWidget->setCard(bannerCard);
+
+    // The deck name is the overlay text on the banner, like the local preview.
+    bannerCardDisplayWidget->setOverlayText(entry.name);
+    setToolTip(entry.name);
+    setBaseAccessibleName(entry.name);
+
+    tagsFlowWidget->clearLayout();
+    for (const QString &tag : entry.tags) {
+        auto *chip = new DeckPreviewTagDisplayWidget(tagsFlowWidget, tag);
+        chip->setAttribute(Qt::WA_TransparentForMouseEvents);
+        tagsFlowWidget->addWidget(chip);
+    }
+    hasTags = !entry.tags.isEmpty();
+    updateTagsVisibility();
+
+    uploadTimeLabel->setText(tr("Uploaded %1").arg(entry.uploadTime.toString(Qt::TextDate)));
+    hasUploadTime = !entry.uploadTime.isNull();
+    updateUploadTimeVisibility();
+}
+
+void PublicDeckPreviewWidget::updateColorIdentityVisibility()
+{
+    colorIdentityWidget->setVisible(
+        hasColorIdentity && SettingsCache::instance().visualDeckStorage().getVisualDeckStorageShowColorIdentity());
+}
+
+void PublicDeckPreviewWidget::updateTagsVisibility()
+{
+    tagsFlowWidget->setVisible(
+        hasTags && SettingsCache::instance().visualDeckStorage().getVisualDeckStorageShowTagsOnDeckPreviews());
+}
+
+void PublicDeckPreviewWidget::updateUploadTimeVisibility()
+{
+    uploadTimeLabel->setVisible(hasUploadTime &&
+                                SettingsCache::instance().visualDeckStorage().getVisualDeckStorageShowUploadTime());
+}
+
+void PublicDeckPreviewWidget::keyPressEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Space || event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return) {
+        event->accept();
+        emit openDeckRequested(deckId);
+        return;
+    }
+    QWidget::keyPressEvent(event);
+}
+
+void PublicDeckPreviewWidget::setBaseAccessibleName(const QString &name)
+{
+    baseAccessibleName = name;
+    setAccessibleName(name);
+}
+
+void PublicDeckPreviewWidget::setScaleFactor(int scale)
+{
+    bannerCardDisplayWidget->setScaleFactor(scale);
+}
+
+void PublicDeckPreviewWidget::imageClickedEvent(QMouseEvent * /*event*/, DeckPreviewCardPictureWidget * /*instance*/)
+{
+    // Reserved: clicking could show a card popup for the banner card.
+}
+
+void PublicDeckPreviewWidget::imageDoubleClickedEvent(QMouseEvent * /*event*/,
+                                                      DeckPreviewCardPictureWidget * /*instance*/)
+{
+    emit openDeckRequested(deckId);
+}

--- a/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/public_deck_preview_widget.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/deck_preview/public_deck_preview_widget.h
@@ -1,0 +1,75 @@
+/**
+ * @file public_deck_preview_widget.h
+ * @ingroup VisualDeckPreviewWidgets
+ */
+
+#ifndef PUBLIC_DECK_PREVIEW_WIDGET_H
+#define PUBLIC_DECK_PREVIEW_WIDGET_H
+
+#include "../remote_public_decks_model.h"
+
+#include <QList>
+#include <QString>
+#include <QWidget>
+
+class ColorIdentityWidget;
+class DeckPreviewCardPictureWidget;
+class FlowWidget;
+class QKeyEvent;
+class QLabel;
+class QMouseEvent;
+class QResizeEvent;
+
+/**
+ * @brief A preview tile for a public deck published by another user.
+ *
+ * Renders the banner card picture (looked up by name/provider in the card
+ * database) with the deck name overlaid, the color identity, the deck's tags
+ * (read-only) and its upload time, all from the metadata the server stores for
+ * the deck, so no deck list is downloaded until the user actually opens the
+ * deck. Double-clicking the banner requests opening it.
+ */
+class PublicDeckPreviewWidget final : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit PublicDeckPreviewWidget(QWidget *parent, const RemotePublicDecksModel::DeckEntry &entry);
+
+    void setEntry(const RemotePublicDecksModel::DeckEntry &entry);
+
+    /** @brief Sets the accessible name announced to assistive technologies. */
+    void setBaseAccessibleName(const QString &name);
+
+    /** @brief Scales the banner card picture, mirroring the Visual Deck Storage. */
+    void setScaleFactor(int scale);
+
+signals:
+    void openDeckRequested(int deckId);
+
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+    void keyPressEvent(QKeyEvent *event) override;
+
+private slots:
+    void imageClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance);
+    void imageDoubleClickedEvent(QMouseEvent *event, DeckPreviewCardPictureWidget *instance);
+    void updateColorIdentityVisibility();
+    void updateTagsVisibility();
+    void updateUploadTimeVisibility();
+
+private:
+    int deckId = 0;
+    QString baseAccessibleName;
+    bool hasColorIdentity = false;
+    bool hasTags = false;
+    bool hasUploadTime = false;
+    int lastKnownBannerWidth = 0;
+    QList<QWidget *> fixedWidthChildren;
+    DeckPreviewCardPictureWidget *bannerCardDisplayWidget;
+    ColorIdentityWidget *colorIdentityWidget;
+    FlowWidget *tagsFlowWidget;
+    QLabel *uploadTimeLabel;
+};
+
+#endif // PUBLIC_DECK_PREVIEW_WIDGET_H

--- a/cockatrice/src/interface/widgets/visual_deck_storage/remote_public_decks_model.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/remote_public_decks_model.cpp
@@ -1,0 +1,202 @@
+#include "remote_public_decks_model.h"
+
+#include <algorithm>
+#include <libcockatrice/network/client/abstract/abstract_client.h>
+#include <libcockatrice/protocol/pb/command_deck_list_other_user.pb.h>
+#include <libcockatrice/protocol/pb/response.pb.h>
+#include <libcockatrice/protocol/pb/response_deck_list.pb.h>
+#include <libcockatrice/protocol/pb/serverinfo_deckstorage.pb.h>
+#include <libcockatrice/protocol/pending_command.h>
+
+RemotePublicDecksModel::RemotePublicDecksModel(AbstractClient *_client, QObject *parent)
+    : QAbstractListModel(parent), client(_client)
+{
+}
+
+int RemotePublicDecksModel::rowCount(const QModelIndex &parent) const
+{
+    return parent.isValid() ? 0 : visibleIndices.size();
+}
+
+QVariant RemotePublicDecksModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || index.row() < 0 || index.row() >= visibleIndices.size()) {
+        return QVariant();
+    }
+    if (role == Qt::DisplayRole || role == Qt::ToolTipRole) {
+        return decks.at(visibleIndices.at(index.row())).name;
+    }
+    return QVariant();
+}
+
+RemotePublicDecksModel::DeckEntry RemotePublicDecksModel::entryAt(int row) const
+{
+    if (row < 0 || row >= visibleIndices.size()) {
+        return DeckEntry{};
+    }
+    return decks.at(visibleIndices.at(row));
+}
+
+void RemotePublicDecksModel::setSearchText(const QString &text)
+{
+    searchText = text.trimmed();
+    rebuildVisibleIndices();
+}
+
+void RemotePublicDecksModel::setColorFilter(VisualDeckStorageSortFilterProxyModel::FilterMode mode,
+                                            const QSet<QChar> &colors)
+{
+    colorFilterMode = mode;
+    activeColors = colors;
+    rebuildVisibleIndices();
+}
+
+void RemotePublicDecksModel::setTagFilter(const QSet<QString> &selected, const QSet<QString> &excluded)
+{
+    includedTags = selected;
+    excludedTags = excluded;
+    rebuildVisibleIndices();
+}
+
+QSet<QString> RemotePublicDecksModel::allTags() const
+{
+    QSet<QString> all;
+    for (const DeckEntry &entry : decks) {
+        all.unite(QSet<QString>(entry.tags.cbegin(), entry.tags.cend()));
+    }
+    return all;
+}
+
+void RemotePublicDecksModel::rebuildVisibleIndices()
+{
+    QList<int> newIndices;
+    newIndices.reserve(decks.size());
+    for (int row = 0; row < decks.size(); ++row) {
+        const DeckEntry &entry = decks.at(row);
+
+        if (!searchText.isEmpty() && !entry.name.contains(searchText, Qt::CaseInsensitive)) {
+            continue;
+        }
+
+        if (!activeColors.isEmpty()) {
+            const QString &identity = entry.colorIdentity;
+            bool colorMatch = true;
+            switch (colorFilterMode) {
+                case VisualDeckStorageSortFilterProxyModel::ExactMatch: {
+                    QSet<QChar> activeSet;
+                    for (const QChar &color : activeColors) {
+                        activeSet.insert(color.toUpper());
+                    }
+                    QSet<QChar> identitySet;
+                    for (const QChar &color : identity) {
+                        identitySet.insert(color.toUpper());
+                    }
+                    colorMatch = activeSet == identitySet;
+                    break;
+                }
+                case VisualDeckStorageSortFilterProxyModel::Includes:
+                    colorMatch = std::all_of(activeColors.begin(), activeColors.end(),
+                                             [&identity](const QChar &color) { return identity.contains(color); });
+                    break;
+                case VisualDeckStorageSortFilterProxyModel::Excludes:
+                    colorMatch = std::none_of(activeColors.begin(), activeColors.end(),
+                                              [&identity](const QChar &color) { return identity.contains(color); });
+                    break;
+            }
+            if (!colorMatch) {
+                continue;
+            }
+        }
+
+        if (!includedTags.isEmpty()) {
+            const QSet<QString> entryTags(entry.tags.cbegin(), entry.tags.cend());
+            bool hasAll = std::all_of(includedTags.begin(), includedTags.end(),
+                                      [&entryTags](const QString &tag) { return entryTags.contains(tag); });
+            if (!hasAll) {
+                continue;
+            }
+        }
+
+        if (!excludedTags.isEmpty() && std::any_of(excludedTags.begin(), excludedTags.end(),
+                                                   [&entry](const QString &tag) { return entry.tags.contains(tag); })) {
+            continue;
+        }
+
+        newIndices.append(row);
+    }
+
+    beginResetModel();
+    visibleIndices = newIndices;
+    endResetModel();
+}
+
+void RemotePublicDecksModel::refresh(const QString &userName)
+{
+    if (loading) {
+        return;
+    }
+    setLoading(true);
+    Command_DeckListOtherUser cmd;
+    cmd.set_user_name(userName.toStdString());
+    PendingCommand *pend = client->prepareSessionCommand(cmd);
+    connect(pend, &PendingCommand::finished, this, &RemotePublicDecksModel::decksReceived);
+    client->sendCommand(pend);
+}
+
+void RemotePublicDecksModel::clear()
+{
+    decks.clear();
+    rebuildVisibleIndices();
+}
+
+void RemotePublicDecksModel::setLoading(bool value)
+{
+    if (loading == value) {
+        return;
+    }
+    loading = value;
+    emit loadingChanged(loading);
+}
+
+void RemotePublicDecksModel::decksReceived(const Response &response, const CommandContainer & /*commandContainer*/)
+{
+    setLoading(false);
+    if (response.response_code() != Response::RespOk) {
+        emit loadFailed(tr("Failed to load the user's public decks (server response code %1).")
+                            .arg(QString::number(static_cast<int>(response.response_code()))));
+        return;
+    }
+
+    const Response_DeckList &resp = response.GetExtension(Response_DeckList::ext);
+    decks.clear();
+    addFolder(resp.root());
+    rebuildVisibleIndices();
+}
+
+void RemotePublicDecksModel::addFolder(const ServerInfo_DeckStorage_Folder &folder)
+{
+    const int itemCount = folder.items_size();
+    for (int i = 0; i < itemCount; ++i) {
+        addTreeItem(folder.items(i));
+    }
+}
+
+void RemotePublicDecksModel::addTreeItem(const ServerInfo_DeckStorage_TreeItem &item)
+{
+    if (item.has_folder()) {
+        addFolder(item.folder());
+        return;
+    }
+
+    const ServerInfo_DeckStorage_File &file = item.file();
+    DeckEntry entry;
+    entry.id = item.id();
+    entry.name = QString::fromStdString(item.name());
+    entry.uploadTime = QDateTime::fromSecsSinceEpoch(file.creation_time());
+    entry.bannerCardName = QString::fromStdString(file.banner_card_name());
+    entry.bannerCardProvider = QString::fromStdString(file.banner_card_provider());
+    entry.colorIdentity = QString::fromStdString(file.color_identity());
+    const QString tagsString = QString::fromStdString(file.tags());
+    entry.tags = tagsString.split(QLatin1Char(','), Qt::SkipEmptyParts);
+    decks.append(entry);
+}

--- a/cockatrice/src/interface/widgets/visual_deck_storage/remote_public_decks_model.h
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/remote_public_decks_model.h
@@ -1,0 +1,125 @@
+/**
+ * @file remote_public_decks_model.h
+ * @ingroup DeckStorageWidgets
+ */
+
+#ifndef REMOTE_PUBLIC_DECKS_MODEL_H
+#define REMOTE_PUBLIC_DECKS_MODEL_H
+
+#include "visual_deck_storage_sort_filter_proxy_model.h"
+
+#include <QAbstractListModel>
+#include <QDateTime>
+#include <QList>
+#include <QSet>
+#include <QStringList>
+
+class AbstractClient;
+class CommandContainer;
+class Response;
+class ServerInfo_DeckStorage_Folder;
+class ServerInfo_DeckStorage_TreeItem;
+
+/**
+ * @brief Flat, read-only list of the public decks published by another user.
+ *
+ * Fetches the target user's public decks via Command_DeckListOtherUser and
+ * flattens the response tree into entries carrying the preview metadata stored
+ * on the server (banner card name/provider and color identity). No deck list is
+ * downloaded until the user actually opens a deck.
+ *
+ * Name and color-identity filtering is applied against this metadata, mirroring
+ * the Visual Deck Storage's filter semantics, so the grid can be narrowed like
+ * the local deck storage.
+ */
+class RemotePublicDecksModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+public:
+    struct DeckEntry
+    {
+        int id = 0;
+        QString name;
+        QDateTime uploadTime;
+        QString bannerCardName;
+        QString bannerCardProvider;
+        QString colorIdentity;
+        QStringList tags;
+    };
+
+    /**
+     * @brief The color identity filter mode, shared with the Visual Deck Storage.
+     */
+    using FilterMode = VisualDeckStorageSortFilterProxyModel::FilterMode;
+
+    explicit RemotePublicDecksModel(AbstractClient *client, QObject *parent = nullptr);
+
+    [[nodiscard]] int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    [[nodiscard]] QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+
+    /** @brief Fetches the public decks of another user, replacing the current contents. */
+    void refresh(const QString &userName);
+    void clear();
+
+    /** @brief Sets a case-insensitive substring filter on the deck name. */
+    void setSearchText(const QString &text);
+
+    /** @brief Sets the active color identity filter and mode. */
+    void setColorFilter(FilterMode mode, const QSet<QChar> &colors);
+
+    /** @brief Filters decks by required (`selected`) and forbidden (`excluded`) tags. */
+    void setTagFilter(const QSet<QString> &selected, const QSet<QString> &excluded);
+
+    /** @brief All tags present across all loaded decks, for building filter chips. */
+    [[nodiscard]] QSet<QString> allTags() const;
+
+    /** @brief The number of decks after filtering. */
+    [[nodiscard]] int filteredCount() const
+    {
+        return visibleIndices.size();
+    }
+
+    /** @brief The number of decks before filtering. */
+    [[nodiscard]] int totalCount() const
+    {
+        return decks.size();
+    }
+
+    /** @brief True while a refresh request is in flight and the grid has no data yet. */
+    [[nodiscard]] bool isLoading() const
+    {
+        return loading;
+    }
+
+    [[nodiscard]] DeckEntry entryAt(int row) const;
+
+signals:
+    /** @brief Emitted when a refresh starts, completes, or fails (see loading()). */
+    void loadingChanged(bool loading);
+
+    /** @brief Emitted when the last refresh failed; contains a user-facing message. */
+    void loadFailed(const QString &message);
+
+private slots:
+    void decksReceived(const Response &response, const CommandContainer &commandContainer);
+
+private:
+    void addFolder(const ServerInfo_DeckStorage_Folder &folder);
+    void addTreeItem(const ServerInfo_DeckStorage_TreeItem &item);
+    void rebuildVisibleIndices();
+    void setLoading(bool value);
+
+    AbstractClient *client;
+    QList<DeckEntry> decks;
+    QList<int> visibleIndices; ///< Row indices into `decks` that pass the current filters.
+    bool loading = false;
+
+    QString searchText;
+    VisualDeckStorageSortFilterProxyModel::FilterMode colorFilterMode = VisualDeckStorageSortFilterProxyModel::Includes;
+    QSet<QChar> activeColors;
+    QSet<QString> includedTags;
+    QSet<QString> excludedTags;
+};
+
+#endif // REMOTE_PUBLIC_DECKS_MODEL_H

--- a/libcockatrice_settings/libcockatrice/settings/visual_deck_storage_settings.cpp
+++ b/libcockatrice_settings/libcockatrice/settings/visual_deck_storage_settings.cpp
@@ -130,6 +130,11 @@ bool VisualDeckStorageSettings::getVisualDeckStorageShowTagsOnDeckPreviews() con
     return getValue("showTagsOnDeckPreviews", "interface", "visualDeckStorage", true).toBool();
 }
 
+bool VisualDeckStorageSettings::getVisualDeckStorageShowUploadTime() const
+{
+    return getValue("showUploadTime", "interface", "visualDeckStorage", true).toBool();
+}
+
 bool VisualDeckStorageSettings::getVisualDeckStorageDrawUnusedColorIdentities() const
 {
     return getValue("drawUnusedColorIdentities", "interface", "visualDeckStorage", true).toBool();
@@ -218,6 +223,12 @@ void VisualDeckStorageSettings::setVisualDeckStorageShowTagsOnDeckPreviews(bool 
 {
     setValue(_showTags, "showTagsOnDeckPreviews", "interface", "visualDeckStorage");
     emit visualDeckStorageShowTagsOnDeckPreviewsChanged(_showTags);
+}
+
+void VisualDeckStorageSettings::setVisualDeckStorageShowUploadTime(bool value)
+{
+    setValue(value, "showUploadTime", "interface", "visualDeckStorage");
+    emit visualDeckStorageShowUploadTimeChanged(value);
 }
 
 void VisualDeckStorageSettings::setVisualDeckStorageDrawUnusedColorIdentities(bool _draw)

--- a/libcockatrice_settings/libcockatrice/settings/visual_deck_storage_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/visual_deck_storage_settings.h
@@ -20,6 +20,7 @@ public:
     [[nodiscard]] bool getVisualDeckStorageShowColorIdentity() const override;
     [[nodiscard]] bool getVisualDeckStorageShowBannerCardComboBox() const override;
     [[nodiscard]] bool getVisualDeckStorageShowTagsOnDeckPreviews() const override;
+    [[nodiscard]] bool getVisualDeckStorageShowUploadTime() const;
     [[nodiscard]] bool getVisualDeckStorageDrawUnusedColorIdentities() const override;
     [[nodiscard]] int getVisualDeckStorageUnusedColorIdentitiesOpacity() const override;
     [[nodiscard]] int getVisualDeckStorageTooltipType() const override;
@@ -38,6 +39,7 @@ public:
     void setVisualDeckStorageShowColorIdentity(bool value);
     void setVisualDeckStorageShowBannerCardComboBox(bool _showBannerCardComboBox);
     void setVisualDeckStorageShowTagsOnDeckPreviews(bool _showTags);
+    void setVisualDeckStorageShowUploadTime(bool value);
     void setVisualDeckStorageDrawUnusedColorIdentities(bool _draw);
     void setVisualDeckStorageUnusedColorIdentitiesOpacity(int _opacity);
     void setVisualDeckStorageTooltipType(int value);
@@ -54,6 +56,7 @@ signals:
     void visualDeckStorageShowColorIdentityChanged(bool _visible);
     void visualDeckStorageShowBannerCardComboBoxChanged(bool _visible);
     void visualDeckStorageShowTagsOnDeckPreviewsChanged(bool _visible);
+    void visualDeckStorageShowUploadTimeChanged(bool _visible);
     void visualDeckStorageDrawUnusedColorIdentitiesChanged(bool _visible);
     void visualDeckStorageUnusedColorIdentitiesOpacityChanged(bool value);
     void visualDeckStorageInGameChanged(bool enabled);

--- a/tests/settings/settings_defaults_test.cpp
+++ b/tests/settings/settings_defaults_test.cpp
@@ -571,6 +571,19 @@ TEST_F(SettingsDefaultsTest, VisualDeckStorage_DefaultTagsList_SetAndGet)
     ASSERT_EQ(s.getVisualDeckStorageDefaultTagsList(), custom);
 }
 
+TEST_F(SettingsDefaultsTest, VisualDeckStorage_ShowUploadTime_Default)
+{
+    VisualDeckStorageSettings s(settingsPath, nullptr);
+    ASSERT_EQ(s.getVisualDeckStorageShowUploadTime(), true);
+}
+
+TEST_F(SettingsDefaultsTest, VisualDeckStorage_ShowUploadTime_SetAndGet)
+{
+    VisualDeckStorageSettings s(settingsPath, nullptr);
+    s.setVisualDeckStorageShowUploadTime(false);
+    ASSERT_EQ(s.getVisualDeckStorageShowUploadTime(), false);
+}
+
 } // namespace
 
 int main(int argc, char **argv)


### PR DESCRIPTION
## Related tickets
- Fixes #7224

## Short roundup of the initial problem

Public decks have no browsing surface: a user could publish a deck, but nobody
had a place to see it, and opening another user's public deck failed silently
if the fetch errored. Deck uploads also carried no metadata, so a browser would
have to download every deck list just to render previews.

## What will change with this Pull Request?

- Add a `Public decks` tab that lists another user's public decks through
  `Command_DeckListOtherUser`, with a user-context menu entry that opens it and
  auto-selects that user
- Render each deck as a preview tile from the stored metadata (banner card,
  color identity, tags, upload time) without downloading the deck list, with the
  deck name as the tile's accessible name and Space/Enter or double-click
  opening the deck
- Add a `Show Upload Time` setting so the tile's upload stamp can be hidden like
  the other preview details, under the same settings group as the local storage
  previews
- Publish and unpublish decks from the storage toolbar and context menu, toggling
  the deck's own visibility bit (what the server persists) rather than the
  inherited effective state, and batching the visibility refresh until the last
  in-flight change is acknowledged
- Show a loading indicator and a server-error message instead of a blank tab when
  the deck list fetch fails or the connection drops, and a message box when
  opening a public deck fails or arrives corrupted
- Wire the new tab into the supervisor's `retranslateUi` loop and rename the
  share action tooltip from `Deck share` to `Share link`