### PR TITLE
[CI] Add ccache eviction to all builds

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -176,8 +176,12 @@ jobs:
         shell: bash
         run: |
           source .ci/docker.sh
-          RUN --server --debug --test --ccache "$CCACHE_SIZE" \
-            --cmake-generator "$CMAKE_GENERATOR"
+          args=()
+          [[ $GITHUB_REF == "refs/heads/master" ]] && args+=(--evict-ccache "$CCACHE_EVICTION_AGE")
+          args+=(--ccache "$CCACHE_SIZE")
+          args+=(--cmake-generator "$CMAKE_GENERATOR")
+
+          RUN --server --debug --test "${args[@]}"
 
       - name: "Build release package"
         id: build


### PR DESCRIPTION
## Related Ticket(s)
- Related #6795

## Short roundup of the initial problem
Debug builds were using ccache, but did not evict the cache after compilation unlike all other builds.

## What will change with this Pull Request?
- Use similar command structure than for building release types on Linux
- While the compiler cache is shared and often both types are run after each other (see screenshot, the release run following the debug one would clean the shared cache in that case), it means the order of steps matters and e.g. our Arch build which does not have a release stream is not cleaned up at all.

  Without this change, the Arch cache will grow without limits over time. It will only be stopped by unintentional cache purging and rotation by chance because our caching is not well designed yet and it happens regularly that ccache entries are removed by GitHub because we constantly overrun the provided 10 GB limit.

  Existing cache is pulled --> new caches are added --> uploaded --> next build pulls it and adds more --> uploaded --> ...

  With this change, outdated cache content will be purged following a controlled approach before uploading and size stays in check because only recent data is kept.

## Screenshots
See missing `evict ccache` log group in the "Build debug and test" step:

Debian 13:
<img width="291" height="565" alt="image" src="https://github.com/user-attachments/assets/6f2b0e4d-587d-4268-b3c1-294efa7a4866" />

Arch (only "Build debug and test" step, no "Build release package" one):
<img width="283" height="371" alt="image" src="https://github.com/user-attachments/assets/50243414-c49d-45de-8e04-b501ca420a6f" />


<br><br>

Config happens in our CI build script:
https://github.com/Cockatrice/Cockatrice/blob/61e6a9913e4096303b8be61be727fbd7015b6a24/.ci/compile.sh#L76-L84
https://github.com/Cockatrice/Cockatrice/blob/61e6a9913e4096303b8be61be727fbd7015b6a24/.ci/compile.sh#L279-L282