### PR TITLE
[Game] Prevent spectator duplication when replaying joined events

### DIFF
--- a/cockatrice/src/game/game_event_handler.cpp
+++ b/cockatrice/src/game/game_event_handler.cpp
@@ -430,12 +430,13 @@ void GameEventHandler::eventJoin(const Event_Join &event, int /*eventPlayerId*/,
     QString playerName = QString::fromStdString(playerInfo.user_info().name());
     emit addPlayerToAutoCompleteList(playerName);
 
-    if (game->getPlayerManager()->getPlayers().contains(playerId)) {
+    PlayerManager *playerManager = game->getPlayerManager();
+    if (playerManager->getPlayers().contains(playerId) || playerManager->getSpectators().contains(playerId)) {
         return;
     }
 
     if (playerInfo.spectator()) {
-        game->getPlayerManager()->addSpectator(playerId, playerInfo);
+        playerManager->addSpectator(playerId, playerInfo);
         emit logJoinSpectator(playerName);
         emit spectatorJoined(playerInfo);
     } else {

--- a/cockatrice/src/game/player/player_manager.cpp
+++ b/cockatrice/src/game/player/player_manager.cpp
@@ -75,6 +75,14 @@ PlayerLogic *PlayerManager::getPlayer(int playerId) const
     return player;
 }
 
+void PlayerManager::clearSpectators()
+{
+    const QList<int> spectatorIds = spectators.keys();
+    for (int spectatorId : spectatorIds) {
+        removeSpectator(spectatorId);
+    }
+}
+
 void PlayerManager::onPlayerConceded(int playerId, bool conceded)
 {
     // Everything else cares about this

--- a/cockatrice/src/game/player/player_manager.h
+++ b/cockatrice/src/game/player/player_manager.h
@@ -100,6 +100,9 @@ public:
         emit spectatorRemoved(spectatorId, spectatorInfo);
     }
 
+    /** @brief Remove all spectators, emitting the removal signal for each. */
+    void clearSpectators();
+
     [[nodiscard]] AbstractGame *getGame() const
     {
         return game;

--- a/cockatrice/src/game_graphics/player/player_list_widget.cpp
+++ b/cockatrice/src/game_graphics/player/player_list_widget.cpp
@@ -92,6 +92,11 @@ void PlayerListWidget::retranslateUi()
 
 void PlayerListWidget::addPlayer(const ServerInfo_PlayerProperties &player)
 {
+    if (players.contains(player.player_id())) {
+        updatePlayerProperties(player);
+        return;
+    }
+
     QTreeWidgetItem *newPlayer = new PlayerListTWI;
     players.insert(player.player_id(), newPlayer);
     updatePlayerProperties(player);

--- a/cockatrice/src/game_graphics/player/player_list_widget.cpp
+++ b/cockatrice/src/game_graphics/player/player_list_widget.cpp
@@ -181,6 +181,17 @@ void PlayerListWidget::removePlayer(int playerId)
     delete takeTopLevelItem(indexOfTopLevelItem(player));
 }
 
+void PlayerListWidget::clearSpectators()
+{
+    const QList<int> playerIds = players.keys();
+    for (int playerId : playerIds) {
+        QTreeWidgetItem *player = players.value(playerId, 0);
+        if (player && !player->data(1, Qt::UserRole).toBool()) {
+            removePlayer(playerId);
+        }
+    }
+}
+
 void PlayerListWidget::setActivePlayer(int playerId)
 {
     QMapIterator<int, QTreeWidgetItem *> i(players);

--- a/cockatrice/src/game_graphics/player/player_list_widget.h
+++ b/cockatrice/src/game_graphics/player/player_list_widget.h
@@ -66,6 +66,7 @@ public slots:
     void addPlayer(const ServerInfo_PlayerProperties &player);
     void removePlayer(int playerId);
     void updatePlayerProperties(const ServerInfo_PlayerProperties &prop, int playerId = -1);
+    void clearSpectators();
 };
 
 #endif

--- a/cockatrice/src/interface/widgets/tabs/tab_game.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_game.cpp
@@ -266,6 +266,10 @@ void TabGame::resetChatAndPhase()
 
     // reset phase markers
     game->getGameState()->setCurrentPhase(-1);
+
+    // reset spectator state so the replay can rebuild it from the start
+    game->getPlayerManager()->clearSpectators();
+    playerListWidget->clearSpectators();
 }
 
 void TabGame::emitUserEvent()


### PR DESCRIPTION
## Short roundup of the initial problem
The spectator branch of eventJoin emitted spectatorJoined unconditionally even when the spectator was already present (e.g. replayed during a rewind). 

## What will change with this Pull Request?
- Guard it like the player branch and eventGameStateChanged, and make PlayerListWidget::addPlayer idempotent as defense in depth.
